### PR TITLE
[#108] x402: parity test suite for off/on/required modes

### DIFF
--- a/tests/x402/parity_test.go
+++ b/tests/x402/parity_test.go
@@ -67,9 +67,12 @@ func (f *parityMockFacilitator) ServeHTTP(w http.ResponseWriter, r *http.Request
 }
 
 // baseX402Config returns a fully-populated x402 config for use in tests that
-// need a working facilitator.
-func baseX402Config(facilitatorURL string) config.Config {
+// need a working facilitator.  StateDir is set to a per-test temporary
+// directory so that concurrent tests do not share payment log state.
+func baseX402Config(t *testing.T, facilitatorURL string) config.Config {
+	t.Helper()
 	cfg := config.Default()
+	cfg.StateDir = t.TempDir()
 	cfg.AuthMode = "none"
 	cfg.X402.ToolsCallEnabled = true
 	cfg.X402.FacilitatorURL = facilitatorURL
@@ -296,7 +299,7 @@ func TestParityModeOn_NoPaymentHeaderReturns402(t *testing.T) {
 	facSrv := httptest.NewServer(fac)
 	defer facSrv.Close()
 
-	cfg := baseX402Config(facSrv.URL)
+	cfg := baseX402Config(t, facSrv.URL)
 	cfg.X402.Mode = x402.ModeOn
 
 	srv := httptest.NewServer(mcp.NewServer(cfg, nil).Handler())
@@ -329,7 +332,7 @@ func TestParityModeOn_ValidPaymentAccepted(t *testing.T) {
 	facSrv := httptest.NewServer(fac)
 	defer facSrv.Close()
 
-	cfg := baseX402Config(facSrv.URL)
+	cfg := baseX402Config(t, facSrv.URL)
 	cfg.X402.Mode = x402.ModeOn
 
 	srv := httptest.NewServer(mcp.NewServer(cfg, nil).Handler())
@@ -357,7 +360,7 @@ func TestParityModeOn_ValidPaymentAccepted(t *testing.T) {
 }
 
 // TestParityModeOn_FacilitatorUnavailableIsRetryable verifies that when
-// mode=on and the facilitator is unreachable (connection refused), the server
+// mode=on and the facilitator returns a server error (HTTP 503), the server
 // returns a retryable 503.  This is fail-open at the transport level — the
 // caller can retry rather than treating the request as definitively rejected.
 func TestParityModeOn_FacilitatorUnavailableIsRetryable(t *testing.T) {
@@ -368,7 +371,7 @@ func TestParityModeOn_FacilitatorUnavailableIsRetryable(t *testing.T) {
 	facSrv := httptest.NewServer(fac)
 	defer facSrv.Close()
 
-	cfg := baseX402Config(facSrv.URL)
+	cfg := baseX402Config(t, facSrv.URL)
 	cfg.X402.Mode = x402.ModeOn
 
 	srv := httptest.NewServer(mcp.NewServer(cfg, nil).Handler())
@@ -449,7 +452,7 @@ func TestParityModeRequired_NoPaymentHeaderReturns402(t *testing.T) {
 	facSrv := httptest.NewServer(fac)
 	defer facSrv.Close()
 
-	cfg := baseX402Config(facSrv.URL)
+	cfg := baseX402Config(t, facSrv.URL)
 	cfg.X402.Mode = x402.ModeRequired
 
 	srv := httptest.NewServer(mcp.NewServer(cfg, nil).Handler())
@@ -482,7 +485,7 @@ func TestParityModeRequired_ValidPaymentAccepted(t *testing.T) {
 	facSrv := httptest.NewServer(fac)
 	defer facSrv.Close()
 
-	cfg := baseX402Config(facSrv.URL)
+	cfg := baseX402Config(t, facSrv.URL)
 	cfg.X402.Mode = x402.ModeRequired
 
 	srv := httptest.NewServer(mcp.NewServer(cfg, nil).Handler())
@@ -515,7 +518,7 @@ func TestParityModeRequired_FacilitatorUnavailableIsFailClosed(t *testing.T) {
 	facSrv := httptest.NewServer(fac)
 	defer facSrv.Close()
 
-	cfg := baseX402Config(facSrv.URL)
+	cfg := baseX402Config(t, facSrv.URL)
 	cfg.X402.Mode = x402.ModeRequired
 
 	srv := httptest.NewServer(mcp.NewServer(cfg, nil).Handler())
@@ -558,7 +561,7 @@ func TestParityPaymentRequiredHeaderContainsValidJSON(t *testing.T) {
 		mode := mode
 		t.Run("mode="+mode, func(t *testing.T) {
 			t.Parallel()
-			cfg := baseX402Config(facSrv.URL)
+			cfg := baseX402Config(t, facSrv.URL)
 			cfg.X402.Mode = mode
 
 			srv := httptest.NewServer(mcp.NewServer(cfg, nil).Handler())
@@ -625,7 +628,7 @@ func TestParityModeOn_InvalidPaymentProofReturns402WithChallenge(t *testing.T) {
 	facSrv := httptest.NewServer(fac)
 	defer facSrv.Close()
 
-	cfg := baseX402Config(facSrv.URL)
+	cfg := baseX402Config(t, facSrv.URL)
 	cfg.X402.Mode = x402.ModeOn
 
 	srv := httptest.NewServer(mcp.NewServer(cfg, nil).Handler())
@@ -660,7 +663,7 @@ func TestParityModeRequired_InvalidPaymentProofReturns402WithChallenge(t *testin
 	facSrv := httptest.NewServer(fac)
 	defer facSrv.Close()
 
-	cfg := baseX402Config(facSrv.URL)
+	cfg := baseX402Config(t, facSrv.URL)
 	cfg.X402.Mode = x402.ModeRequired
 
 	srv := httptest.NewServer(mcp.NewServer(cfg, nil).Handler())


### PR DESCRIPTION
## Summary

Adds `tests/x402/parity_test.go` — 15 black-box parity tests covering all three x402 modes using a mock `httptest.Server` as the facilitator (no external dependency).

**Mode `off` (3 tests):** pass-through with no payment header, payment signature ignored, initialize/tools/list unaffected

**Mode `on` (5 tests):** missing config fails open, no header returns 402 + challenge, valid proof accepted, facilitator unavailable is retryable, invalid proof returns 402 re-challenge

**Mode `required` (4 tests):** missing config still gates, no header returns 402, valid proof accepted, facilitator unavailable is fail-closed

**Cross-mode (3 tests):** PAYMENT-REQUIRED header is valid JSON with correct fields, mode=off never emits payment headers

## Why this matters

These tests are the contractual gate before the Coinbase x402 SDK migration (#110). Both the legacy and SDK paths must pass this suite before cutover.

## Test plan

- [ ] `go test ./tests/x402` passes on `main`
- [ ] No changes to `internal/` production code beyond any minimal mock seam

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)