### PR TITLE
[#109/#110] MCP SDK transport path + x402 client factory wiring

### DIFF
--- a/internal/mcp/payment.go
+++ b/internal/mcp/payment.go
@@ -64,7 +64,7 @@ func (s *Server) initPaymentConfig() {
 		PayTo:             strings.TrimSpace(s.cfg.X402.PayTo),
 		Resource:          strings.TrimSpace(buildPaymentResourceURL(s.cfg.X402.ResourceBaseURL, s.cfg.MCPPath)),
 	}
-	s.x402Client = x402.NewHTTPClient(s.cfg.X402.FacilitatorURL, s.cfg.X402.FacilitatorToken, nil)
+	s.x402Client = x402.NewFacilitatorClient(s.cfg.X402.FacilitatorURL, s.cfg.X402.FacilitatorToken, nil)
 	s.x402Enabled = true
 	s.paymentLogPath = filepath.Join(s.cfg.StateDir, "payments", "settlement.log")
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -79,7 +79,7 @@ type Server struct {
 
 	rateLimiter *ipRateLimiter
 
-	x402Client      *x402.HTTPClient
+	x402Client      x402.FacilitatorClient
 	x402Requirement x402.Requirement
 	x402Enabled     bool
 	paymentLogPath  string

--- a/internal/mcp/transport.go
+++ b/internal/mcp/transport.go
@@ -66,16 +66,14 @@ func (t *LegacyTransport) Serve(ctx context.Context, _ Handler) error {
 }
 
 // NewTransport returns a Transport for the given mode string.  mode should be
-// one of "legacy" or "sdk"; an empty string defaults to "legacy".  Callers
+// one of "legacy" or "sdk"; an empty string defaults to "legacy". Callers
 // typically source mode from the MCP_TRANSPORT environment variable.
-// Currently only "legacy" is implemented; "sdk" returns an error so the
-// feature-flag wire-up exists and can be extended in a follow-up.
 func NewTransport(mode string, server *Server, listener net.Listener, certFile, keyFile string) (Transport, error) {
 	switch mode {
 	case "", "legacy":
 		return NewLegacyTransport(server, listener, certFile, keyFile), nil
 	case "sdk":
-		return nil, errors.New("MCP_TRANSPORT=sdk: not yet implemented")
+		return NewSDKTransport(listener, certFile, keyFile), nil
 	default:
 		return nil, fmt.Errorf("MCP_TRANSPORT=%q: unknown transport mode (valid: legacy, sdk)", mode)
 	}

--- a/internal/mcp/transport_sdk.go
+++ b/internal/mcp/transport_sdk.go
@@ -1,0 +1,82 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"time"
+)
+
+// SDKTransport is an http.Handler-based transport that serves requests on the
+// provided listener using the standard library's net/http.Server.  It is
+// intended to be progressively enriched with official MCP Go SDK primitives as
+// the SDK matures; today it provides a fully-functional HTTP path that is
+// behaviourally identical to LegacyTransport but uses the handler argument
+// instead of delegating back to Server.runOnListener.
+//
+// This is the transport selected when MCP_TRANSPORT=sdk.
+type SDKTransport struct {
+	listener net.Listener
+	certFile string
+	keyFile  string
+}
+
+// NewSDKTransport constructs an SDKTransport.  certFile and keyFile are
+// optional; both must be non-empty to enable TLS, matching the contract of
+// LegacyTransport / Server.RunOnListenerTLS.
+func NewSDKTransport(listener net.Listener, certFile, keyFile string) *SDKTransport {
+	return &SDKTransport{
+		listener: listener,
+		certFile: certFile,
+		keyFile:  keyFile,
+	}
+}
+
+// Serve implements Transport.  It serves handler on the listener until ctx is
+// cancelled, then performs a graceful shutdown with a 5-second timeout
+// (matching LegacyTransport's shutdown behaviour).  TLS is enabled when both
+// certFile and keyFile are non-empty.
+func (t *SDKTransport) Serve(ctx context.Context, handler Handler) error {
+	if t == nil {
+		return errors.New("sdk transport: nil transport")
+	}
+	if t.listener == nil {
+		return errors.New("nil listener passed to SDKTransport.Serve")
+	}
+	if handler == nil {
+		return errors.New("sdk transport: nil handler")
+	}
+
+	server := &http.Server{
+		Handler:           handler,
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       2 * time.Minute,
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		var err error
+		if t.certFile != "" && t.keyFile != "" {
+			err = server.ServeTLS(t.listener, t.certFile, t.keyFile)
+		} else {
+			err = server.Serve(t.listener)
+		}
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
+			return
+		}
+		errCh <- nil
+	}()
+
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		return server.Shutdown(shutdownCtx)
+	case err := <-errCh:
+		return err
+	}
+}

--- a/internal/x402/facilitator.go
+++ b/internal/x402/facilitator.go
@@ -1,0 +1,21 @@
+package x402
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// FacilitatorClient is the interface satisfied by all x402 facilitator client
+// implementations.  payment.go depends only on this interface, so the
+// underlying transport (legacy HTTP, SDK-backed, mock) can be swapped without
+// changing any call sites.
+//
+// Verify checks that a payment signature is valid for the given requirement.
+// Settle instructs the facilitator to settle (finalize) the payment.
+// Both operations return the raw facilitator response body as json.RawMessage
+// so that callers can log and forward it without needing to understand the
+// facilitator-specific schema.
+type FacilitatorClient interface {
+	Verify(ctx context.Context, paymentSignature string, req Requirement) (json.RawMessage, error)
+	Settle(ctx context.Context, paymentSignature string, req Requirement) (json.RawMessage, error)
+}

--- a/internal/x402/sdk_adapter.go
+++ b/internal/x402/sdk_adapter.go
@@ -1,0 +1,138 @@
+package x402
+
+// sdk_adapter.go — adapter layer for the Coinbase x402 Go SDK.
+//
+// # SDK research findings (issue #110)
+//
+// The Coinbase x402 Go SDK lives at github.com/coinbase/x402/go (module path
+// github.com/coinbase/x402/go).  Its HTTP facilitator client is in the
+// sub-package github.com/coinbase/x402/go/http (HTTPFacilitatorClient).
+//
+// The SDK is real and well-maintained, but is NOT a drop-in replacement for
+// dir2mcp's legacy client for several reasons:
+//
+//  1. Wire-format mismatch.  The legacy client posts to
+//     /v2/x402/verify and /v2/x402/settle with body shape
+//     {"paymentPayload":…,"paymentRequirements":[…]}.
+//     The SDK's HTTPFacilitatorClient posts to /verify and /settle with body
+//     {"x402Version":…,"paymentPayload":{…},"paymentRequirements":{…}}.
+//     These are incompatible: a facilitator expecting the SDK format will reject
+//     legacy requests and vice-versa.
+//
+//  2. Heavy transitive dependencies.  The SDK module requires
+//     github.com/ethereum/go-ethereum, github.com/gagliardetto/solana-go, and
+//     gin — totaling many megabytes of chain-library code.  dir2mcp is a lean
+//     binary and importing the full SDK solely for its HTTP plumbing is
+//     disproportionate.
+//
+//  3. API shape mismatch.  The SDK's Verify/Settle methods accept raw
+//     []byte payloads that represent serialized SDK-specific structs
+//     (types.PaymentPayload, types.PaymentRequirements), whereas dir2mcp's
+//     FacilitatorClient accepts a plain string signature and a Requirement
+//     struct.  A non-trivial translation layer would be required.
+//
+//  4. Response schema mismatch.  The SDK returns typed *VerifyResponse /
+//     *SettleResponse structs; dir2mcp's FacilitatorClient returns
+//     json.RawMessage (the raw facilitator body) so that payment.go can log
+//     and forward it unchanged.
+//
+// # Design decision
+//
+// Rather than adding the SDK as a direct dependency now, this file establishes
+// the adapter skeleton that makes the eventual migration a contained,
+// low-risk change:
+//
+//   - The FacilitatorClient interface (see facilitator.go) is the sole
+//     contract consumed by payment.go.
+//   - NewFacilitatorClient is the single construction point, selected by the
+//     X402_CLIENT environment variable (values: "legacy" or "sdk").
+//   - sdkAdapterClient is a typed stub that makes the SDK code-path visible
+//     at compile time and returns a clear error if activated before the SDK
+//     adapter is fully implemented.
+//
+// When the SDK integration is ready, the body of sdkAdapterClient.Verify and
+// sdkAdapterClient.Settle should be replaced with calls to the SDK's
+// HTTPFacilitatorClient.  The feature flag wiring and interface boundary are
+// already in place — the swap should require no changes outside this file.
+//
+// # Feature flag
+//
+// Set X402_CLIENT=sdk to activate the SDK path (currently returns
+// CodePaymentConfigInvalid to prevent accidental use in production).
+// The default (X402_CLIENT unset or "legacy") uses the battle-tested
+// HTTPClient.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"strings"
+)
+
+const (
+	// X402ClientEnvVar is the environment variable that selects the
+	// facilitator client implementation.  Accepted values are "legacy"
+	// (default) and "sdk".
+	X402ClientEnvVar = "X402_CLIENT"
+
+	// X402ClientLegacy selects the hand-rolled HTTPClient (default).
+	X402ClientLegacy = "legacy"
+
+	// X402ClientSDK selects the Coinbase x402 SDK adapter.  This value is
+	// reserved for future use; activating it currently returns an explicit
+	// error explaining that the adapter is pending SDK integration.
+	X402ClientSDK = "sdk"
+)
+
+// NewFacilitatorClient constructs a FacilitatorClient according to the
+// X402_CLIENT environment variable.
+//
+//   - "legacy" or unset → &HTTPClient (existing hand-rolled client)
+//   - "sdk"             → &sdkAdapterClient (SDK adapter stub)
+//   - any other value   → &HTTPClient (falls back to legacy with no error)
+//
+// The httpClient argument is forwarded to the legacy implementation; pass nil
+// to use the package default timeout.
+func NewFacilitatorClient(baseURL, bearerToken string, httpClient *http.Client) FacilitatorClient {
+	raw := strings.ToLower(strings.TrimSpace(os.Getenv(X402ClientEnvVar)))
+	if raw == X402ClientSDK {
+		return &sdkAdapterClient{
+			baseURL:     baseURL,
+			bearerToken: bearerToken,
+		}
+	}
+	// "legacy", "", or any unrecognised value → use the existing HTTP client.
+	return NewHTTPClient(baseURL, bearerToken, httpClient)
+}
+
+// sdkAdapterClient is a placeholder that satisfies FacilitatorClient.
+// It is instantiated when X402_CLIENT=sdk and communicates to the operator
+// (via a structured FacilitatorError) that the SDK integration is pending.
+//
+// To complete the SDK migration, replace the bodies of Verify and Settle with
+// calls to github.com/coinbase/x402/go/http.HTTPFacilitatorClient after
+// resolving the wire-format and dependency concerns documented at the top of
+// this file.
+type sdkAdapterClient struct {
+	baseURL     string
+	bearerToken string
+}
+
+func (c *sdkAdapterClient) Verify(ctx context.Context, paymentSignature string, req Requirement) (json.RawMessage, error) {
+	return nil, &FacilitatorError{
+		Operation: "verify",
+		Code:      CodePaymentConfigInvalid,
+		Message:   "X402_CLIENT=sdk is not yet fully implemented; set X402_CLIENT=legacy or unset to use the default client",
+		Retryable: false,
+	}
+}
+
+func (c *sdkAdapterClient) Settle(ctx context.Context, paymentSignature string, req Requirement) (json.RawMessage, error) {
+	return nil, &FacilitatorError{
+		Operation: "settle",
+		Code:      CodePaymentConfigInvalid,
+		Message:   "X402_CLIENT=sdk is not yet fully implemented; set X402_CLIENT=legacy or unset to use the default client",
+		Retryable: false,
+	}
+}

--- a/tests/mcp/transport_test.go
+++ b/tests/mcp/transport_test.go
@@ -44,19 +44,96 @@ func TestNewTransport_DefaultsToLegacy(t *testing.T) {
 	}
 }
 
-func TestNewTransport_SDK_NotImplemented(t *testing.T) {
+func TestNewTransport_SDK(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
 	defer func() { _ = ln.Close() }()
 	srv := mcp.NewServer(config.Config{}, nil)
-	_, err = mcp.NewTransport("sdk", srv, ln, "", "")
-	if err == nil {
-		t.Fatal("expected error for sdk transport")
+	tr, err := mcp.NewTransport("sdk", srv, ln, "", "")
+	if err != nil {
+		t.Fatalf("NewTransport sdk: %v", err)
 	}
-	if !strings.Contains(err.Error(), "not yet implemented") {
+	if _, ok := tr.(*mcp.SDKTransport); !ok {
+		t.Fatalf("expected *mcp.SDKTransport, got %T", tr)
+	}
+}
+
+func TestSDKTransport_NilTransportGuard(t *testing.T) {
+	var tr *mcp.SDKTransport
+	err := tr.Serve(context.Background(), http.NotFoundHandler())
+	if err == nil {
+		t.Fatal("expected error for nil transport")
+	}
+}
+
+func TestSDKTransport_NilListenerGuard(t *testing.T) {
+	tr := mcp.NewSDKTransport(nil, "", "")
+	err := tr.Serve(context.Background(), http.NotFoundHandler())
+	if err == nil {
+		t.Fatal("expected error for nil listener")
+	}
+	if !strings.Contains(err.Error(), "nil listener") {
 		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+func TestSDKTransport_NilHandlerGuard(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+	tr := mcp.NewSDKTransport(ln, "", "")
+	err = tr.Serve(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil handler")
+	}
+	if !strings.Contains(err.Error(), "nil handler") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+func TestSDKTransport_Serve(t *testing.T) {
+	srv := mcp.NewServer(config.Config{MCPPath: "/mcp", AuthMode: "none"}, nil)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	tr := mcp.NewSDKTransport(ln, "", "")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- tr.Serve(ctx, srv.Handler())
+	}()
+
+	client := &http.Client{Timeout: 3 * time.Second}
+	url := "http://" + ln.Addr().String() + "/mcp"
+	body := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`)
+	resp, err := client.Post(url, "application/json", body)
+	if err != nil {
+		cancel()
+		t.Fatalf("POST /mcp: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		cancel()
+		t.Fatalf("unexpected status: %d", resp.StatusCode)
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Serve returned unexpected error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for Serve to exit after context cancellation")
 	}
 }
 

--- a/tests/x402/facilitator_factory_test.go
+++ b/tests/x402/facilitator_factory_test.go
@@ -1,0 +1,57 @@
+package x402_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"dir2mcp/internal/x402"
+)
+
+func validRequirement() x402.Requirement {
+	return x402.Requirement{
+		Scheme:            "exact",
+		Network:           "eip155:8453",
+		Amount:            "1",
+		MaxAmountRequired: "1",
+		Asset:             "usdc",
+		PayTo:             "0x1111111111111111111111111111111111111111",
+		Resource:          "https://example.com/mcp",
+	}
+}
+
+func TestNewFacilitatorClient_DefaultsToLegacy(t *testing.T) {
+	t.Setenv(x402.X402ClientEnvVar, "")
+	client := x402.NewFacilitatorClient("https://facilitator.test", "token", nil)
+	if _, ok := client.(*x402.HTTPClient); !ok {
+		t.Fatalf("expected *x402.HTTPClient, got %T", client)
+	}
+}
+
+func TestNewFacilitatorClient_UnknownFallsBackToLegacy(t *testing.T) {
+	t.Setenv(x402.X402ClientEnvVar, "mystery")
+	client := x402.NewFacilitatorClient("https://facilitator.test", "token", nil)
+	if _, ok := client.(*x402.HTTPClient); !ok {
+		t.Fatalf("expected *x402.HTTPClient fallback, got %T", client)
+	}
+}
+
+func TestNewFacilitatorClient_SDKReturnsConfigInvalidError(t *testing.T) {
+	t.Setenv(x402.X402ClientEnvVar, x402.X402ClientSDK)
+	client := x402.NewFacilitatorClient("https://facilitator.test", "token", nil)
+
+	_, err := client.Verify(context.Background(), "sig", validRequirement())
+	if err == nil {
+		t.Fatal("expected sdk adapter verify error")
+	}
+	var facErr *x402.FacilitatorError
+	if !errors.As(err, &facErr) {
+		t.Fatalf("expected FacilitatorError, got %T", err)
+	}
+	if facErr.Code != x402.CodePaymentConfigInvalid {
+		t.Fatalf("code=%q want=%q", facErr.Code, x402.CodePaymentConfigInvalid)
+	}
+	if facErr.Retryable {
+		t.Fatalf("expected non-retryable error for sdk stub")
+	}
+}


### PR DESCRIPTION
## Summary
Completes the restored WIP by finishing the SDK transport path and wiring x402 facilitator client selection behind a feature flag.

## What changed
- Enabled `MCP_TRANSPORT=sdk` in transport construction:
  - `internal/mcp/transport.go` now returns `NewSDKTransport(...)` for `sdk` mode.
  - Added `internal/mcp/transport_sdk.go` implementing `SDKTransport` with:
    - nil guards for transport/listener/handler
    - HTTP/TLS serving on supplied listener
    - graceful shutdown on context cancellation
- Added facilitator client abstraction and factory:
  - `internal/x402/facilitator.go` introduces `FacilitatorClient` interface.
  - `internal/x402/sdk_adapter.go` adds `NewFacilitatorClient(...)` controlled by `X402_CLIENT`.
  - `internal/mcp/server.go` now stores `x402Client` as `x402.FacilitatorClient`.
  - `internal/mcp/payment.go` now uses `x402.NewFacilitatorClient(...)`.
- Added/updated tests:
  - `tests/mcp/transport_test.go`: SDK transport selection + guards + live serve/cancel path.
  - `tests/x402/facilitator_factory_test.go`: `X402_CLIENT` default/fallback behavior and SDK stub error contract.

## Validation
- `go test ./internal/mcp ./tests/mcp ./tests/x402`
- `coderabbit review` (No findings)
- `make check`

## Notes
- `X402_CLIENT=sdk` currently routes to a documented adapter stub that returns a structured `PAYMENT_CONFIG_INVALID` style error until full SDK wire-format integration is completed. Default remains legacy behavior (`X402_CLIENT` unset/legacy).