### PR TITLE
[P1] x402: replace facilitator HTTP plumbing with Coinbase x402 SDK

### DIFF
--- a/docs/x402-payment-adapter-spec.md
+++ b/docs/x402-payment-adapter-spec.md
@@ -15,6 +15,8 @@ Provide a clear, versioned contract so that:
 ## Usage in dir2mcp
 
 When x402 gating is enabled (`--x402` flag in the CLI or `x402.mode` in config), dir2mcp invokes the adapter at the MCP request boundary (typically `POST /mcp` for `tools/call`, or selected tool names). Depending on the facilitator's response, the server either allows the request to proceed or returns `402 Payment Required` with `PAYMENT-REQUIRED` header data. Clients must then obtain and attach `PAYMENT-SIGNATURE` before retrying.
+
+The facilitator client implementation is selected at startup via `X402_CLIENT=legacy|sdk`; the default remains `legacy` for rollback safety. `legacy` keeps the current hand-rolled HTTP compatibility path, while `sdk` routes facilitator calls through the Coinbase x402 Go SDK.
 ### Example configuration snippet
 
 ```yaml
@@ -24,6 +26,9 @@ x402:
   adapter: "coinbase"      # named adapter from internal/x402
   facilitator:
     api_key: "..."         # credentials for the external service
+
+# Environment:
+# X402_CLIENT=legacy|sdk
 ```
 
 > **Security note:** never commit API keys or sensitive credentials (such as

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/clipperhouse/displaywidth v0.9.0 // indirect
 	github.com/clipperhouse/stringish v0.1.1 // indirect
 	github.com/clipperhouse/uax29/v2 v2.5.0 // indirect
+	github.com/coinbase/x402/go v0.0.0-20260331075907-bff876de232a // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/clipperhouse/stringish v0.1.1 h1:+NSqMOr3GR6k1FdRhhnXrLfztGzuG+VuFDfa
 github.com/clipperhouse/stringish v0.1.1/go.mod h1:v/WhFtE1q0ovMta2+m+UbpZ+2/HEXNWYXQgCt4hdOzA=
 github.com/clipperhouse/uax29/v2 v2.5.0 h1:x7T0T4eTHDONxFJsL94uKNKPHrclyFI0lm7+w94cO8U=
 github.com/clipperhouse/uax29/v2 v2.5.0/go.mod h1:Wn1g7MK6OoeDT0vL+Q0SQLDz/KpfsVRgg6W7ihQeh4g=
+github.com/coinbase/x402/go v0.0.0-20260331075907-bff876de232a h1:L8ZxbOqBxB7LYXdypWYA7Qq0iQtFaS6PCwjnhij4Oks=
+github.com/coinbase/x402/go v0.0.0-20260331075907-bff876de232a/go.mod h1:8xt63HO8mECoUwoI8E9xOjPiOzgFUvUx+Svrok+Wkss=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/google/pprof v0.0.0-20240409012703-83162a5b38cd h1:gbpYu9NMq8jhDVbvlGkMFWCjLFlqqEZjEmObmhUy6Vo=
@@ -46,6 +48,7 @@ golang.org/x/exp v0.0.0-20231108232855-2478ac86f678 h1:mchzmB1XO2pMaKFRqk/+MV3mg
 golang.org/x/exp v0.0.0-20231108232855-2478ac86f678/go.mod h1:zk2irFbV9DP96SEBUUAy67IdHUaZuSnrz1n472HUCLE=
 golang.org/x/mod v0.16.0 h1:QX4fJ0Rr5cPQCF7O9lh9Se4pmwfwskqZfq5moyldzic=
 golang.org/x/mod v0.16.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+golang.org/x/mod v0.30.0 h1:fDEXFVZ/fmCKProc/yAXXUijritrDzahmwwefnjoPFk=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
 golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
@@ -53,6 +56,7 @@ golang.org/x/term v0.40.0 h1:36e4zGLqU4yhjlmxEaagx2KuYbJq3EwY8K943ZsHcvg=
 golang.org/x/term v0.40.0/go.mod h1:w2P8uVp06p2iyKKuvXIm7N/y0UCRt3UfJTfZ7oOpglM=
 golang.org/x/tools v0.19.0 h1:tfGCXNR1OsFG+sVdLAitlpjAvD/I6dHDKnYrpEZUHkw=
 golang.org/x/tools v0.19.0/go.mod h1:qoJWxmGSIBmAeriMx19ogtrEPrGtDbPK634QFIcLAhc=
+golang.org/x/tools v0.39.0 h1:ik4ho21kwuQln40uelmciQPp9SipgNDdrafrYA4TmQQ=
 modernc.org/cc/v4 v4.21.4 h1:3Be/Rdo1fpr8GrQ7IVw9OHtplU4gWbb+wNgeoBMmGLQ=
 modernc.org/cc/v4 v4.21.4/go.mod h1:HM7VJTZbUCR3rV8EYBi9wxnJ0ZBRiGE5OeGXNA0IsLQ=
 modernc.org/ccgo/v4 v4.19.2 h1:lwQZgvboKD0jBwdaeVCTouxhxAyN6iawF3STraAal8Y=

--- a/internal/x402/sdk_adapter.go
+++ b/internal/x402/sdk_adapter.go
@@ -1,138 +1,323 @@
 package x402
 
-// sdk_adapter.go — adapter layer for the Coinbase x402 Go SDK.
-//
-// # SDK research findings (issue #110)
-//
-// The Coinbase x402 Go SDK lives at github.com/coinbase/x402/go (module path
-// github.com/coinbase/x402/go).  Its HTTP facilitator client is in the
-// sub-package github.com/coinbase/x402/go/http (HTTPFacilitatorClient).
-//
-// The SDK is real and well-maintained, but is NOT a drop-in replacement for
-// dir2mcp's legacy client for several reasons:
-//
-//  1. Wire-format mismatch.  The legacy client posts to
-//     /v2/x402/verify and /v2/x402/settle with body shape
-//     {"paymentPayload":…,"paymentRequirements":[…]}.
-//     The SDK's HTTPFacilitatorClient posts to /verify and /settle with body
-//     {"x402Version":…,"paymentPayload":{…},"paymentRequirements":{…}}.
-//     These are incompatible: a facilitator expecting the SDK format will reject
-//     legacy requests and vice-versa.
-//
-//  2. Heavy transitive dependencies.  The SDK module requires
-//     github.com/ethereum/go-ethereum, github.com/gagliardetto/solana-go, and
-//     gin — totaling many megabytes of chain-library code.  dir2mcp is a lean
-//     binary and importing the full SDK solely for its HTTP plumbing is
-//     disproportionate.
-//
-//  3. API shape mismatch.  The SDK's Verify/Settle methods accept raw
-//     []byte payloads that represent serialized SDK-specific structs
-//     (types.PaymentPayload, types.PaymentRequirements), whereas dir2mcp's
-//     FacilitatorClient accepts a plain string signature and a Requirement
-//     struct.  A non-trivial translation layer would be required.
-//
-//  4. Response schema mismatch.  The SDK returns typed *VerifyResponse /
-//     *SettleResponse structs; dir2mcp's FacilitatorClient returns
-//     json.RawMessage (the raw facilitator body) so that payment.go can log
-//     and forward it unchanged.
-//
-// # Design decision
-//
-// Rather than adding the SDK as a direct dependency now, this file establishes
-// the adapter skeleton that makes the eventual migration a contained,
-// low-risk change:
-//
-//   - The FacilitatorClient interface (see facilitator.go) is the sole
-//     contract consumed by payment.go.
-//   - NewFacilitatorClient is the single construction point, selected by the
-//     X402_CLIENT environment variable (values: "legacy" or "sdk").
-//   - sdkAdapterClient is a typed stub that makes the SDK code-path visible
-//     at compile time and returns a clear error if activated before the SDK
-//     adapter is fully implemented.
-//
-// When the SDK integration is ready, the body of sdkAdapterClient.Verify and
-// sdkAdapterClient.Settle should be replaced with calls to the SDK's
-// HTTPFacilitatorClient.  The feature flag wiring and interface boundary are
-// already in place — the swap should require no changes outside this file.
-//
-// # Feature flag
-//
-// Set X402_CLIENT=sdk to activate the SDK path (currently returns
-// CodePaymentConfigInvalid to prevent accidental use in production).
-// The default (X402_CLIENT unset or "legacy") uses the battle-tested
-// HTTPClient.
-
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
+
+	sdkhttp "github.com/coinbase/x402/go/http"
 )
 
 const (
-	// X402ClientEnvVar is the environment variable that selects the
-	// facilitator client implementation.  Accepted values are "legacy"
-	// (default) and "sdk".
+	// X402ClientEnvVar selects the facilitator client implementation.
+	// Accepted values are "legacy" (default) and "sdk".
 	X402ClientEnvVar = "X402_CLIENT"
 
 	// X402ClientLegacy selects the hand-rolled HTTPClient (default).
 	X402ClientLegacy = "legacy"
 
-	// X402ClientSDK selects the Coinbase x402 SDK adapter.  This value is
-	// reserved for future use; activating it currently returns an explicit
-	// error explaining that the adapter is pending SDK integration.
+	// X402ClientSDK selects the Coinbase x402 SDK-backed facilitator client.
 	X402ClientSDK = "sdk"
 )
 
 // NewFacilitatorClient constructs a FacilitatorClient according to the
 // X402_CLIENT environment variable.
 //
-//   - "legacy" or unset → &HTTPClient (existing hand-rolled client)
-//   - "sdk"             → &sdkAdapterClient (SDK adapter stub)
-//   - any other value   → &HTTPClient (falls back to legacy with no error)
+//   - "legacy" or unset -> HTTPClient (existing hand-rolled client)
+//   - "sdk"             -> SDK-backed facilitator client
+//   - any other value    -> HTTPClient (falls back to legacy with no error)
 //
-// The httpClient argument is forwarded to the legacy implementation; pass nil
+// The httpClient argument is forwarded to the selected implementation; pass nil
 // to use the package default timeout.
 func NewFacilitatorClient(baseURL, bearerToken string, httpClient *http.Client) FacilitatorClient {
 	raw := strings.ToLower(strings.TrimSpace(os.Getenv(X402ClientEnvVar)))
 	if raw == X402ClientSDK {
-		return &sdkAdapterClient{
-			baseURL:     baseURL,
-			bearerToken: bearerToken,
-		}
+		return newSDKFacilitatorClient(baseURL, bearerToken, httpClient)
 	}
-	// "legacy", "", or any unrecognised value → use the existing HTTP client.
 	return NewHTTPClient(baseURL, bearerToken, httpClient)
 }
 
-// sdkAdapterClient is a placeholder that satisfies FacilitatorClient.
-// It is instantiated when X402_CLIENT=sdk and communicates to the operator
-// (via a structured FacilitatorError) that the SDK integration is pending.
-//
-// To complete the SDK migration, replace the bodies of Verify and Settle with
-// calls to github.com/coinbase/x402/go/http.HTTPFacilitatorClient after
-// resolving the wire-format and dependency concerns documented at the top of
-// this file.
 type sdkAdapterClient struct {
 	baseURL     string
-	bearerToken string
+	facilitator *sdkhttp.HTTPFacilitatorClient
+}
+
+type sdkBearerAuthProvider struct {
+	token string
+}
+
+func (p sdkBearerAuthProvider) GetAuthHeaders(context.Context) (sdkhttp.AuthHeaders, error) {
+	headers := map[string]string{"Authorization": "Bearer " + p.token}
+	return sdkhttp.AuthHeaders{
+		Verify:    headers,
+		Settle:    headers,
+		Supported: headers,
+		Discovery: headers,
+	}, nil
+}
+
+func newSDKFacilitatorClient(baseURL, bearerToken string, httpClient *http.Client) FacilitatorClient {
+	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: defaultHTTPTimeout}
+	}
+	if baseURL == "" {
+		return &sdkAdapterClient{
+			baseURL: baseURL,
+		}
+	}
+
+	cfg := &sdkhttp.FacilitatorConfig{
+		URL:        baseURL,
+		HTTPClient: httpClient,
+		Timeout:    defaultHTTPTimeout,
+	}
+	if token := strings.TrimSpace(bearerToken); token != "" {
+		cfg.AuthProvider = sdkBearerAuthProvider{token: token}
+	}
+
+	return &sdkAdapterClient{
+		baseURL:     baseURL,
+		facilitator: sdkhttp.NewFacilitatorClient(cfg),
+	}
 }
 
 func (c *sdkAdapterClient) Verify(ctx context.Context, paymentSignature string, req Requirement) (json.RawMessage, error) {
-	return nil, &FacilitatorError{
-		Operation: "verify",
-		Code:      CodePaymentConfigInvalid,
-		Message:   "X402_CLIENT=sdk is not yet fully implemented; set X402_CLIENT=legacy or unset to use the default client",
-		Retryable: false,
-	}
+	return c.do(ctx, "verify", paymentSignature, req)
 }
 
 func (c *sdkAdapterClient) Settle(ctx context.Context, paymentSignature string, req Requirement) (json.RawMessage, error) {
-	return nil, &FacilitatorError{
-		Operation: "settle",
-		Code:      CodePaymentConfigInvalid,
-		Message:   "X402_CLIENT=sdk is not yet fully implemented; set X402_CLIENT=legacy or unset to use the default client",
-		Retryable: false,
+	return c.do(ctx, "settle", paymentSignature, req)
+}
+
+func (c *sdkAdapterClient) do(ctx context.Context, operation, paymentSignature string, req Requirement) (json.RawMessage, error) {
+	if c == nil || strings.TrimSpace(c.baseURL) == "" || c.facilitator == nil {
+		return nil, &FacilitatorError{
+			Operation: operation,
+			Code:      CodePaymentConfigInvalid,
+			Message:   "x402 facilitator URL is required",
+			Retryable: false,
+		}
 	}
+	if err := req.Validate(); err != nil {
+		return nil, &FacilitatorError{
+			Operation: operation,
+			Code:      CodePaymentConfigInvalid,
+			Message:   err.Error(),
+			Retryable: false,
+			Cause:     err,
+		}
+	}
+
+	paymentSignature = strings.TrimSpace(paymentSignature)
+	if paymentSignature == "" {
+		return nil, &FacilitatorError{
+			Operation: operation,
+			Code:      CodePaymentRequired,
+			Message:   "missing payment signature",
+			Retryable: false,
+		}
+	}
+
+	payloadBytes, err := buildSDKPaymentPayloadBytes(paymentSignature, req)
+	if err != nil {
+		return nil, &FacilitatorError{
+			Operation: operation,
+			Code:      CodePaymentConfigInvalid,
+			Message:   "failed to serialize x402 payment payload",
+			Retryable: false,
+			Cause:     err,
+		}
+	}
+	requirementsBytes, err := buildSDKPaymentRequirementsBytes(req)
+	if err != nil {
+		return nil, &FacilitatorError{
+			Operation: operation,
+			Code:      CodePaymentConfigInvalid,
+			Message:   "failed to serialize x402 payment requirements",
+			Retryable: false,
+			Cause:     err,
+		}
+	}
+
+	var rawResponse any
+	switch operation {
+	case "verify":
+		rawResponse, err = c.facilitator.Verify(ctx, payloadBytes, requirementsBytes)
+	case "settle":
+		rawResponse, err = c.facilitator.Settle(ctx, payloadBytes, requirementsBytes)
+	default:
+		err = fmt.Errorf("unsupported facilitator operation: %s", operation)
+	}
+	if err != nil {
+		return nil, mapSDKFacilitatorError(operation, err)
+	}
+
+	raw, err := json.Marshal(rawResponse)
+	if err != nil {
+		return nil, &FacilitatorError{
+			Operation: operation,
+			Code:      facilitatorUnavailableCode(operation),
+			Message:   "failed to serialize facilitator response",
+			Retryable: true,
+			Cause:     err,
+		}
+	}
+	return json.RawMessage(raw), nil
+}
+
+type sdkPaymentPayload struct {
+	X402Version int                    `json:"x402Version"`
+	Scheme      string                 `json:"scheme"`
+	Network     string                 `json:"network"`
+	Payload     map[string]interface{} `json:"payload"`
+}
+
+type sdkPaymentRequirements struct {
+	Scheme  string                 `json:"scheme"`
+	Network string                 `json:"network"`
+	Amount  string                 `json:"amount"`
+	Asset   string                 `json:"asset"`
+	PayTo   string                 `json:"payTo"`
+	Extra   map[string]interface{} `json:"extra,omitempty"`
+}
+
+func buildSDKPaymentPayloadBytes(paymentSignature string, req Requirement) ([]byte, error) {
+	trimmed := strings.TrimSpace(paymentSignature)
+	if trimmed == "" {
+		return nil, errors.New("empty payment signature")
+	}
+	if json.Valid([]byte(trimmed)) {
+		return []byte(trimmed), nil
+	}
+	if decoded, err := base64.StdEncoding.DecodeString(trimmed); err == nil && json.Valid(decoded) {
+		return decoded, nil
+	}
+
+	payload := sdkPaymentPayload{
+		X402Version: X402Version,
+		Scheme:      strings.ToLower(strings.TrimSpace(req.Scheme)),
+		Network:     strings.TrimSpace(req.Network),
+		Payload: map[string]interface{}{
+			"paymentSignature": trimmed,
+		},
+	}
+	return json.Marshal(payload)
+}
+
+func buildSDKPaymentRequirementsBytes(req Requirement) ([]byte, error) {
+	extra := make(map[string]interface{})
+	if trimmed := strings.TrimSpace(req.Resource); trimmed != "" {
+		extra["resource"] = trimmed
+	}
+	if trimmed := strings.TrimSpace(req.MaxAmountRequired); trimmed != "" {
+		extra["maxAmountRequired"] = trimmed
+	}
+	if len(extra) == 0 {
+		extra = nil
+	}
+
+	payload := sdkPaymentRequirements{
+		Scheme:  strings.ToLower(strings.TrimSpace(req.Scheme)),
+		Network: strings.TrimSpace(req.Network),
+		Amount:  strings.TrimSpace(req.Amount),
+		Asset:   strings.TrimSpace(req.Asset),
+		PayTo:   strings.TrimSpace(req.PayTo),
+		Extra:   extra,
+	}
+	return json.Marshal(payload)
+}
+
+func mapSDKFacilitatorError(operation string, err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return &FacilitatorError{
+			Operation: operation,
+			Code:      facilitatorUnavailableCode(operation),
+			Message:   "facilitator request failed",
+			Retryable: false,
+			Cause:     err,
+		}
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) || isURLTransportError(err) {
+		return &FacilitatorError{
+			Operation: operation,
+			Code:      facilitatorUnavailableCode(operation),
+			Message:   "facilitator request failed",
+			Retryable: true,
+			Cause:     err,
+		}
+	}
+
+	lower := strings.ToLower(err.Error())
+	if isSDKInvalidFailure(lower) {
+		code := CodePaymentInvalid
+		if operation == "settle" {
+			code = CodePaymentSettlementFailed
+		}
+		return &FacilitatorError{
+			Operation: operation,
+			Code:      code,
+			Message:   err.Error(),
+			Retryable: false,
+			Cause:     err,
+		}
+	}
+
+	return &FacilitatorError{
+		Operation: operation,
+		Code:      facilitatorUnavailableCode(operation),
+		Message:   "facilitator request failed",
+		Retryable: true,
+		Cause:     err,
+	}
+}
+
+func facilitatorUnavailableCode(operation string) string {
+	if operation == "settle" {
+		return CodePaymentSettlementUnavailable
+	}
+	return CodePaymentFacilitatorUnavailable
+}
+
+func isURLTransportError(err error) bool {
+	var urlErr *url.Error
+	return errors.As(err, &urlErr)
+}
+
+func isSDKInvalidFailure(lowerErr string) bool {
+	invalidSignals := []string{
+		"invalid",
+		"rejected",
+		"reject",
+		"insufficient",
+		"expired",
+		"unauthorized",
+		"forbidden",
+		"unprocessable",
+		"bad request",
+		"status 4",
+		" status 4",
+		"400",
+		"401",
+		"403",
+		"404",
+		"422",
+	}
+	for _, sig := range invalidSignals {
+		if strings.Contains(lowerErr, sig) {
+			return true
+		}
+	}
+	return false
 }

--- a/tests/mcp/x402_test.go
+++ b/tests/mcp/x402_test.go
@@ -71,8 +71,8 @@ func TestX402ToolsCall_PaidRetrySucceedsAndReturnsPaymentResponse(t *testing.T) 
 	fac := newFacilitatorStub(t)
 	fac.verifyStatus = http.StatusOK
 	fac.settleStatus = http.StatusOK
-	fac.verifyBody = `{"ok":true,"kind":"verify"}`
-	fac.settleBody = `{"ok":true,"kind":"settle","txHash":"abc123"}`
+	fac.verifyBody = `{"ok":true,"isValid":true,"payer":"payer-1"}`
+	fac.settleBody = `{"ok":true,"success":true,"transaction":"abc123","txHash":"abc123","network":"eip155:8453"}`
 	facServer := httptest.NewServer(fac)
 	defer facServer.Close()
 
@@ -278,7 +278,7 @@ func TestX402ToolsCall_SettleRetryReplaysCachedOutcomeWithoutReexecution(t *test
 	fac.settleStatuses = []int{http.StatusServiceUnavailable, http.StatusOK}
 	fac.settleBodies = []string{
 		`{"message":"settlement unavailable"}`,
-		`{"ok":true,"txHash":"abc123"}`,
+		`{"ok":true,"success":true,"transaction":"abc123","txHash":"abc123","network":"eip155:8453"}`,
 	}
 	facServer := httptest.NewServer(fac)
 	defer facServer.Close()
@@ -413,8 +413,8 @@ func newFacilitatorStub(t *testing.T) *facilitatorStub {
 		t:            t,
 		verifyStatus: http.StatusOK,
 		settleStatus: http.StatusOK,
-		verifyBody:   `{"ok":true}`,
-		settleBody:   `{"ok":true}`,
+		verifyBody:   `{"ok":true,"isValid":true,"payer":"payer-1"}`,
+		settleBody:   `{"ok":true,"success":true,"transaction":"tx-1","txHash":"tx-1","network":"eip155:8453"}`,
 	}
 	// initialize atomic values
 	f.lastAuthorization.Store("")
@@ -448,7 +448,28 @@ func (f *facilitatorStub) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(f.verifyStatus)
 		_, _ = w.Write([]byte(f.verifyBody))
+	case "/verify":
+		f.verifyCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(f.verifyStatus)
+		_, _ = w.Write([]byte(f.verifyBody))
 	case "/v2/x402/settle":
+		status := f.settleStatus
+		body := f.settleBody
+		// compute an index atomically (get-and-increment) so concurrent
+		// requests don't race against each other. the returned value is the
+		// previous counter, so subtract one to use it as an index.
+		idx := int(f.settleCalls.Add(1) - 1)
+		if len(f.settleStatuses) > 0 {
+			status = f.settleStatuses[clampIndex(idx, len(f.settleStatuses))]
+		}
+		if len(f.settleBodies) > 0 {
+			body = f.settleBodies[clampIndex(idx, len(f.settleBodies))]
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	case "/settle":
 		status := f.settleStatus
 		body := f.settleBody
 		// compute an index atomically (get-and-increment) so concurrent

--- a/tests/x402/facilitator_factory_test.go
+++ b/tests/x402/facilitator_factory_test.go
@@ -2,7 +2,10 @@ package x402_test
 
 import (
 	"context"
-	"errors"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"dir2mcp/internal/x402"
@@ -36,22 +39,81 @@ func TestNewFacilitatorClient_UnknownFallsBackToLegacy(t *testing.T) {
 	}
 }
 
-func TestNewFacilitatorClient_SDKReturnsConfigInvalidError(t *testing.T) {
+func TestNewFacilitatorClient_SDKUsesSDKFacilitatorClient(t *testing.T) {
 	t.Setenv(x402.X402ClientEnvVar, x402.X402ClientSDK)
-	client := x402.NewFacilitatorClient("https://facilitator.test", "token", nil)
 
-	_, err := client.Verify(context.Background(), "sig", validRequirement())
-	if err == nil {
-		t.Fatal("expected sdk adapter verify error")
+	var verifyCalls, settleCalls int
+	var verifyAuthorization, settleAuthorization string
+	facServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/verify":
+			verifyCalls++
+			verifyAuthorization = r.Header.Get("Authorization")
+			_, _ = io.Copy(io.Discard, r.Body)
+			_ = r.Body.Close()
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"isValid": true,
+				"payer":   "payer-1",
+			})
+		case "/settle":
+			settleCalls++
+			settleAuthorization = r.Header.Get("Authorization")
+			_, _ = io.Copy(io.Discard, r.Body)
+			_ = r.Body.Close()
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"success":     true,
+				"transaction": "tx-1",
+				"network":     "eip155:8453",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer facServer.Close()
+
+	client := x402.NewFacilitatorClient(facServer.URL, "token", nil)
+	if _, ok := client.(*x402.HTTPClient); ok {
+		t.Fatalf("expected sdk-backed client, got legacy %T", client)
 	}
-	var facErr *x402.FacilitatorError
-	if !errors.As(err, &facErr) {
-		t.Fatalf("expected FacilitatorError, got %T", err)
+
+	paymentPayload := `{"x402Version":2,"payload":{"paymentSignature":"sig"}}`
+
+	verifyRaw, err := client.Verify(context.Background(), paymentPayload, validRequirement())
+	if err != nil {
+		t.Fatalf("verify: %v", err)
 	}
-	if facErr.Code != x402.CodePaymentConfigInvalid {
-		t.Fatalf("code=%q want=%q", facErr.Code, x402.CodePaymentConfigInvalid)
+	if verifyCalls != 1 {
+		t.Fatalf("verify calls=%d want=1", verifyCalls)
 	}
-	if facErr.Retryable {
-		t.Fatalf("expected non-retryable error for sdk stub")
+
+	settleRaw, err := client.Settle(context.Background(), paymentPayload, validRequirement())
+	if err != nil {
+		t.Fatalf("settle: %v", err)
+	}
+	if settleCalls != 1 {
+		t.Fatalf("settle calls=%d want=1", settleCalls)
+	}
+	if verifyAuthorization != "Bearer token" {
+		t.Fatalf("verify authorization header=%q want=%q", verifyAuthorization, "Bearer token")
+	}
+	if settleAuthorization != "Bearer token" {
+		t.Fatalf("settle authorization header=%q want=%q", settleAuthorization, "Bearer token")
+	}
+
+	var verifyResp map[string]any
+	if err := json.Unmarshal(verifyRaw, &verifyResp); err != nil {
+		t.Fatalf("decode verify response: %v body=%s", err, string(verifyRaw))
+	}
+	if got := verifyResp["payer"]; got != "payer-1" {
+		t.Fatalf("verify payer=%v want=%q", got, "payer-1")
+	}
+
+	var settleResp map[string]any
+	if err := json.Unmarshal(settleRaw, &settleResp); err != nil {
+		t.Fatalf("decode settle response: %v body=%s", err, string(settleRaw))
+	}
+	if got := settleResp["transaction"]; got != "tx-1" {
+		t.Fatalf("settle transaction=%v want=%q", got, "tx-1")
 	}
 }

--- a/tests/x402/parity_test.go
+++ b/tests/x402/parity_test.go
@@ -45,8 +45,8 @@ func newParityFacilitator() *parityMockFacilitator {
 	return &parityMockFacilitator{
 		verifyStatus: http.StatusOK,
 		settleStatus: http.StatusOK,
-		verifyBody:   `{"ok":true}`,
-		settleBody:   `{"ok":true}`,
+		verifyBody:   `{"ok":true,"isValid":true,"payer":"payer-1"}`,
+		settleBody:   `{"ok":true,"success":true,"transaction":"tx-1","txHash":"tx-1","network":"eip155:8453"}`,
 	}
 }
 
@@ -57,7 +57,15 @@ func (f *parityMockFacilitator) ServeHTTP(w http.ResponseWriter, r *http.Request
 		f.verifyCalls.Add(1)
 		w.WriteHeader(f.verifyStatus)
 		_, _ = w.Write([]byte(f.verifyBody))
+	case "/verify":
+		f.verifyCalls.Add(1)
+		w.WriteHeader(f.verifyStatus)
+		_, _ = w.Write([]byte(f.verifyBody))
 	case "/v2/x402/settle":
+		f.settleCalls.Add(1)
+		w.WriteHeader(f.settleStatus)
+		_, _ = w.Write([]byte(f.settleBody))
+	case "/settle":
 		f.settleCalls.Add(1)
 		w.WriteHeader(f.settleStatus)
 		_, _ = w.Write([]byte(f.settleBody))
@@ -327,8 +335,8 @@ func TestParityModeOn_NoPaymentHeaderReturns402(t *testing.T) {
 func TestParityModeOn_ValidPaymentAccepted(t *testing.T) {
 	t.Parallel()
 	fac := newParityFacilitator()
-	fac.verifyBody = `{"ok":true,"kind":"verify"}`
-	fac.settleBody = `{"ok":true,"kind":"settle","txHash":"abc"}`
+	fac.verifyBody = `{"ok":true,"isValid":true,"payer":"payer-1"}`
+	fac.settleBody = `{"ok":true,"success":true,"transaction":"abc","txHash":"abc","network":"eip155:8453"}`
 	facSrv := httptest.NewServer(fac)
 	defer facSrv.Close()
 
@@ -480,8 +488,8 @@ func TestParityModeRequired_NoPaymentHeaderReturns402(t *testing.T) {
 func TestParityModeRequired_ValidPaymentAccepted(t *testing.T) {
 	t.Parallel()
 	fac := newParityFacilitator()
-	fac.verifyBody = `{"ok":true}`
-	fac.settleBody = `{"ok":true,"txHash":"xyz"}`
+	fac.verifyBody = `{"ok":true,"isValid":true,"payer":"payer-1"}`
+	fac.settleBody = `{"ok":true,"success":true,"transaction":"xyz","txHash":"xyz","network":"eip155:8453"}`
 	facSrv := httptest.NewServer(fac)
 	defer facSrv.Close()
 


### PR DESCRIPTION
Implements the SDK-backed x402 facilitator client behind `X402_CLIENT=legacy|sdk`.

Includes:
- Coinbase x402 SDK-backed facilitator client
- legacy default preserved
- parity fixtures updated for both legacy and SDK facilitator routes
- docs note for `X402_CLIENT`
- Coinbase x402 SDK dependency

Validation:
- `go test ./tests/x402/...`
- `X402_CLIENT=legacy go test ./tests/x402/...`
- `X402_CLIENT=sdk go test ./tests/x402/...`
- `go test ./tests/mcp/...`
- `X402_CLIENT=sdk go test ./tests/mcp/...`
- `make check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SDK-backed payment verification and settlement implementation.
  * Introduced bearer token authentication support for facilitator requests.

* **Documentation**
  * Documented facilitator client selection at startup (legacy or SDK mode), with legacy as the safe default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->