### PR TITLE
[#122] cli: unify --json stderr errors and NDJSON output

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -365,7 +365,7 @@ func (a *App) RunWithContext(ctx context.Context, args []string) int {
 	case "up":
 		upOpts, parseErr := parseUpOptions(globalOpts, remaining[1:])
 		if parseErr != nil {
-			writeCLIError(a.stderr, globalOpts.jsonOutput, exitConfigInvalid, fmt.Sprintf("invalid up flags: %v", parseErr))
+			writeCLIError(a.stderr, globalOpts.jsonOutput || argsContainJSONFlag(remaining[1:]), exitConfigInvalid, fmt.Sprintf("invalid up flags: %v", parseErr))
 			return exitConfigInvalid
 		}
 		return a.runUp(ctx, upOpts)

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -625,25 +625,22 @@ func emitJSON(out io.Writer, payload interface{}) error {
 }
 
 func isJSONFlagEnabled(arg string) bool {
-	if arg == "-json" || arg == "--json" {
+	if arg == "--json" || arg == "-json" {
 		return true
 	}
 
-	var value string
+	var raw string
 	switch {
-	case strings.HasPrefix(arg, "-json="):
-		value = strings.TrimPrefix(arg, "-json=")
 	case strings.HasPrefix(arg, "--json="):
-		value = strings.TrimPrefix(arg, "--json=")
+		raw = strings.TrimPrefix(arg, "--json=")
+	case strings.HasPrefix(arg, "-json="):
+		raw = strings.TrimPrefix(arg, "-json=")
 	default:
 		return false
 	}
 
-	enabled, err := strconv.ParseBool(value)
-	if err != nil {
-		return false
-	}
-	return enabled
+	enabled, err := strconv.ParseBool(strings.TrimSpace(raw))
+	return err == nil && enabled
 }
 
 func argsContainJSONFlag(args []string) bool {
@@ -690,13 +687,13 @@ func writeCLIError(stderr io.Writer, jsonOutput bool, exitCode int, message stri
 			ExitCode: exitCode,
 		}
 		if err := emitJSON(stderr, payload); err != nil {
-			fallbackMessage := strings.TrimSpace(message)
-			if fallbackMessage == "" {
-				fallbackMessage = "failed to encode error payload"
+			fallback := strings.TrimSpace(message)
+			if fallback == "" {
+				fallback = "failed to encode error payload"
 			} else {
-				fallbackMessage = fmt.Sprintf("%s (failed to encode error payload: %v)", fallbackMessage, err)
+				fallback = fmt.Sprintf("%s (failed to encode error payload: %v)", fallback, err)
 			}
-			escapedMessage, marshalErr := json.Marshal(fallbackMessage)
+			escapedMessage, marshalErr := json.Marshal(fallback)
 			if marshalErr != nil {
 				escapedMessage = []byte("\"failed to encode error payload\"")
 			}
@@ -826,9 +823,15 @@ func parseGlobalOptions(args []string) (globalOptions, []string, error) {
 			remaining = newRem
 			continue
 		}
+		if enabled, matched, err := parseJSONFlagValue(arg); matched {
+			if err != nil {
+				return globalOptions{}, nil, err
+			}
+			opts.jsonOutput = enabled
+			remaining = remaining[1:]
+			continue
+		}
 		switch arg {
-		case "--json":
-			opts.jsonOutput = true
 		case "--non-interactive":
 			opts.nonInteractive = true
 		case "--quiet":
@@ -843,6 +846,29 @@ func parseGlobalOptions(args []string) (globalOptions, []string, error) {
 	}
 
 	return opts, remaining, nil
+}
+
+func parseJSONFlagValue(arg string) (enabled bool, matched bool, err error) {
+	if arg == "--json" || arg == "-json" {
+		return true, true, nil
+	}
+	if strings.HasPrefix(arg, "--json=") {
+		raw := strings.TrimSpace(strings.TrimPrefix(arg, "--json="))
+		parsed, parseErr := strconv.ParseBool(raw)
+		if parseErr != nil {
+			return false, true, fmt.Errorf("invalid value for --json: %q", raw)
+		}
+		return parsed, true, nil
+	}
+	if strings.HasPrefix(arg, "-json=") {
+		raw := strings.TrimSpace(strings.TrimPrefix(arg, "-json="))
+		parsed, parseErr := strconv.ParseBool(raw)
+		if parseErr != nil {
+			return false, true, fmt.Errorf("invalid value for -json: %q", raw)
+		}
+		return parsed, true, nil
+	}
+	return false, false, nil
 }
 
 func consumeGlobalFlagValue(flagName string, args []string) (string, int, error) {

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -350,10 +350,11 @@ func (a *App) RunWithContext(ctx context.Context, args []string) int {
 		a.printUsage()
 		return exitSuccess
 	}
+	jsonRequested := argsContainJSONFlag(args)
 
 	globalOpts, remaining, err := parseGlobalOptions(args)
 	if err != nil {
-		writeCLIError(a.stderr, argsContainJSONFlag(args), exitConfigInvalid, err.Error())
+		writeCLIError(a.stderr, jsonRequested, exitConfigInvalid, err.Error())
 		return exitConfigInvalid
 	}
 	if len(remaining) == 0 {
@@ -383,8 +384,9 @@ func (a *App) RunWithContext(ctx context.Context, args []string) int {
 		}
 		return exitSuccess
 	default:
-		writeCLIError(a.stderr, globalOpts.jsonOutput, exitGeneric, fmt.Sprintf("unknown command: %s", remaining[0]))
-		if !globalOpts.jsonOutput {
+		effectiveJSON := globalOpts.jsonOutput || jsonRequested
+		writeCLIError(a.stderr, effectiveJSON, exitGeneric, fmt.Sprintf("unknown command: %s", remaining[0]))
+		if !effectiveJSON {
 			a.printUsage()
 		}
 		return exitGeneric

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -222,6 +222,17 @@ type ndjsonEmitter struct {
 	out     io.Writer
 }
 
+type cliErrorPayload struct {
+	Error    cliError `json:"error"`
+	ExitCode int      `json:"exit_code"`
+}
+
+type cliError struct {
+	Code    string   `json:"code"`
+	Message string   `json:"message"`
+	Hints   []string `json:"hints,omitempty"`
+}
+
 // corpusSnapshot is a point-in-time summary of the indexed corpus written to
 // corpus.json in the state directory. See corpusIndexing for field semantics,
 // including the sentinel value used for unavailable counters.
@@ -342,7 +353,7 @@ func (a *App) RunWithContext(ctx context.Context, args []string) int {
 
 	globalOpts, remaining, err := parseGlobalOptions(args)
 	if err != nil {
-		writef(a.stderr, "%v\n", err)
+		writeCLIError(a.stderr, argsContainJSONFlag(args), exitConfigInvalid, err.Error())
 		return exitConfigInvalid
 	}
 	if len(remaining) == 0 {
@@ -354,7 +365,7 @@ func (a *App) RunWithContext(ctx context.Context, args []string) int {
 	case "up":
 		upOpts, parseErr := parseUpOptions(globalOpts, remaining[1:])
 		if parseErr != nil {
-			writef(a.stderr, "invalid up flags: %v\n", parseErr)
+			writeCLIError(a.stderr, globalOpts.jsonOutput, exitConfigInvalid, fmt.Sprintf("invalid up flags: %v", parseErr))
 			return exitConfigInvalid
 		}
 		return a.runUp(ctx, upOpts)
@@ -372,8 +383,10 @@ func (a *App) RunWithContext(ctx context.Context, args []string) int {
 		}
 		return exitSuccess
 	default:
-		writef(a.stderr, "unknown command: %s\n", remaining[0])
-		a.printUsage()
+		writeCLIError(a.stderr, globalOpts.jsonOutput, exitGeneric, fmt.Sprintf("unknown command: %s", remaining[0]))
+		if !globalOpts.jsonOutput {
+			a.printUsage()
+		}
 		return exitGeneric
 	}
 }
@@ -607,8 +620,68 @@ func readCorpusSnapshot(path string) (corpusSnapshot, error) {
 
 func emitJSON(out io.Writer, payload interface{}) error {
 	enc := json.NewEncoder(out)
-	enc.SetIndent("", "  ")
+	enc.SetEscapeHTML(false)
 	return enc.Encode(payload)
+}
+
+func argsContainJSONFlag(args []string) bool {
+	for _, arg := range args {
+		if arg == "--json" {
+			return true
+		}
+		if arg == "--json=true" {
+			return true
+		}
+	}
+	return false
+}
+
+func exitCodeLabel(exitCode int) string {
+	switch exitCode {
+	case exitConfigInvalid:
+		return "CONFIG_INVALID"
+	case exitIngestionFatal:
+		return "INGESTION_FATAL"
+	case exitServerBindFailure:
+		return "SERVER_BIND_FAILURE"
+	case exitAuthOrPayment:
+		return "AUTH_OR_PAYMENT"
+	case exitSignalInterrupt:
+		return "INTERRUPTED"
+	default:
+		return "GENERIC_ERROR"
+	}
+}
+
+func writeCLIError(stderr io.Writer, jsonOutput bool, exitCode int, message string, hints ...string) {
+	if jsonOutput {
+		filteredHints := make([]string, 0, len(hints))
+		for _, hint := range hints {
+			trimmed := strings.TrimSpace(hint)
+			if trimmed != "" {
+				filteredHints = append(filteredHints, trimmed)
+			}
+		}
+		payload := cliErrorPayload{
+			Error: cliError{
+				Code:    exitCodeLabel(exitCode),
+				Message: strings.TrimSpace(message),
+				Hints:   filteredHints,
+			},
+			ExitCode: exitCode,
+		}
+		if err := emitJSON(stderr, payload); err != nil {
+			writef(stderr, "{\"error\":{\"code\":\"GENERIC_ERROR\",\"message\":\"failed to encode error payload\"},\"exit_code\":1}\n")
+		}
+		return
+	}
+	writef(stderr, "%s\n", strings.TrimSpace(message))
+	for _, hint := range hints {
+		trimmed := strings.TrimSpace(hint)
+		if trimmed != "" {
+			writef(stderr, "%s\n", trimmed)
+		}
+	}
 }
 
 func serializeHits(hits []model.SearchHit) []map[string]interface{} {
@@ -906,13 +979,13 @@ func (a *App) closeStoreWithLog(st model.Store) {
 	}
 }
 
-func clearContentHashesIfSupported(ctx context.Context, st model.Store, stderr io.Writer) int {
+func clearContentHashesIfSupported(ctx context.Context, st model.Store, stderr io.Writer, jsonOutput bool) int {
 	resetter, ok := interface{}(st).(contentHashResetter)
 	if !ok {
 		return exitSuccess
 	}
 	if err := resetter.ClearDocumentContentHashes(ctx); err != nil {
-		writef(stderr, "clear content hashes: %v\n", err)
+		writeCLIError(stderr, jsonOutput, exitGeneric, fmt.Sprintf("clear content hashes: %v", err))
 		return exitGeneric
 	}
 	return exitSuccess

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -624,12 +624,31 @@ func emitJSON(out io.Writer, payload interface{}) error {
 	return enc.Encode(payload)
 }
 
+func isJSONFlagEnabled(arg string) bool {
+	if arg == "-json" || arg == "--json" {
+		return true
+	}
+
+	var value string
+	switch {
+	case strings.HasPrefix(arg, "-json="):
+		value = strings.TrimPrefix(arg, "-json=")
+	case strings.HasPrefix(arg, "--json="):
+		value = strings.TrimPrefix(arg, "--json=")
+	default:
+		return false
+	}
+
+	enabled, err := strconv.ParseBool(value)
+	if err != nil {
+		return false
+	}
+	return enabled
+}
+
 func argsContainJSONFlag(args []string) bool {
 	for _, arg := range args {
-		if arg == "--json" {
-			return true
-		}
-		if arg == "--json=true" {
+		if isJSONFlagEnabled(arg) {
 			return true
 		}
 	}

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -671,7 +671,23 @@ func writeCLIError(stderr io.Writer, jsonOutput bool, exitCode int, message stri
 			ExitCode: exitCode,
 		}
 		if err := emitJSON(stderr, payload); err != nil {
-			writef(stderr, "{\"error\":{\"code\":\"GENERIC_ERROR\",\"message\":\"failed to encode error payload\"},\"exit_code\":1}\n")
+			fallbackMessage := strings.TrimSpace(message)
+			if fallbackMessage == "" {
+				fallbackMessage = "failed to encode error payload"
+			} else {
+				fallbackMessage = fmt.Sprintf("%s (failed to encode error payload: %v)", fallbackMessage, err)
+			}
+			escapedMessage, marshalErr := json.Marshal(fallbackMessage)
+			if marshalErr != nil {
+				escapedMessage = []byte("\"failed to encode error payload\"")
+			}
+			writef(
+				stderr,
+				"{\"error\":{\"code\":%q,\"message\":%s},\"exit_code\":%d}\n",
+				exitCodeLabel(exitCode),
+				escapedMessage,
+				exitCode,
+			)
 		}
 		return
 	}

--- a/internal/cli/ask.go
+++ b/internal/cli/ask.go
@@ -14,13 +14,13 @@ import (
 func (a *App) runAsk(ctx context.Context, global globalOptions, args []string) int {
 	opts, err := parseAskOptions(args)
 	if err != nil {
-		writef(a.stderr, "invalid ask flags: %v\n", err)
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("invalid ask flags: %v", err))
 		return exitConfigInvalid
 	}
 
 	cfg, err := loadConfigWithGlobalOptions(global)
 	if err != nil {
-		writef(a.stderr, "load config: %v\n", err)
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("load config: %v", err))
 		return exitConfigInvalid
 	}
 	if strings.TrimSpace(cfg.StateDir) == "" {
@@ -28,6 +28,17 @@ func (a *App) runAsk(ctx context.Context, global globalOptions, args []string) i
 	}
 
 	if strings.TrimSpace(cfg.MistralAPIKey) == "" {
+		if global.jsonOutput {
+			writeCLIError(
+				a.stderr,
+				true,
+				exitConfigInvalid,
+				"CONFIG_INVALID: Missing MISTRAL_API_KEY",
+				"Set env: MISTRAL_API_KEY=...",
+				"Or run: dir2mcp config init",
+			)
+			return exitConfigInvalid
+		}
 		se := a.sty(global.jsonOutput)
 		nonInteractiveMode := global.nonInteractive || !isTerminal(os.Stdin) || !isTerminal(os.Stdout)
 		if nonInteractiveMode {
@@ -44,13 +55,13 @@ func (a *App) runAsk(ctx context.Context, global globalOptions, args []string) i
 	st := a.storeForConfig(cfg)
 	defer func() { _ = st.Close() }()
 	if err := st.Init(ctx); err != nil && !errors.Is(err, model.ErrNotImplemented) {
-		writef(a.stderr, "initialize metadata store: %v\n", err)
+		writeCLIError(a.stderr, global.jsonOutput, exitIndexLoadFailure, fmt.Sprintf("initialize metadata store: %v", err))
 		return exitIndexLoadFailure
 	}
 
 	retriever, cleanup, err := a.buildRetrieverForAsk(ctx, cfg, st)
 	if err != nil {
-		writef(a.stderr, "initialize retriever: %v\n", err)
+		writeCLIError(a.stderr, global.jsonOutput, exitIndexLoadFailure, fmt.Sprintf("initialize retriever: %v", err))
 		return exitIndexLoadFailure
 	}
 	if cleanup != nil {
@@ -72,7 +83,7 @@ func (a *App) runAsk(ctx context.Context, global globalOptions, args []string) i
 
 	askResult, askErr := retriever.Ask(ctx, opts.question, query)
 	if askErr != nil {
-		writef(a.stderr, "ask failed: %v\n", askErr)
+		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("ask failed: %v", askErr))
 		return exitGeneric
 	}
 	return a.renderAskResult(global, askResult)
@@ -81,7 +92,7 @@ func (a *App) runAsk(ctx context.Context, global globalOptions, args []string) i
 func (a *App) runAskSearchOnly(ctx context.Context, global globalOptions, question string, retriever model.Retriever, query model.SearchQuery) int {
 	hits, searchErr := retriever.Search(ctx, query)
 	if searchErr != nil {
-		writef(a.stderr, "ask failed: %v\n", searchErr)
+		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("search failed: %v", searchErr))
 		return exitGeneric
 	}
 	if global.jsonOutput {
@@ -97,7 +108,7 @@ func (a *App) runAskSearchOnly(ctx context.Context, global globalOptions, questi
 			"indexing_complete": indexingComplete,
 		}
 		if err := emitJSON(a.stdout, payload); err != nil {
-			writef(a.stderr, "encode ask json: %v\n", err)
+			writeCLIError(a.stderr, true, exitGeneric, fmt.Sprintf("encode ask json: %v", err))
 			return exitGeneric
 		}
 		return exitSuccess
@@ -130,7 +141,7 @@ func (a *App) renderAskResult(global globalOptions, askResult model.AskResult) i
 			"indexing_complete": askResult.IndexingComplete,
 		}
 		if err := emitJSON(a.stdout, payload); err != nil {
-			writef(a.stderr, "encode ask json: %v\n", err)
+			writeCLIError(a.stderr, true, exitGeneric, fmt.Sprintf("encode ask json: %v", err))
 			return exitGeneric
 		}
 		return exitSuccess

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -40,7 +41,7 @@ func (a *App) promptAndSaveMistralAPIKey(global globalOptions, configPath string
 	}
 	envPath := filepath.Join(filepath.Dir(configPath), ".env.local")
 	if err := saveEnvLocalKey(envPath, "MISTRAL_API_KEY", key); err != nil {
-		writef(a.stderr, "save .env.local: %v\n", err)
+		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("save .env.local: %v", err))
 		return false
 	}
 	if !global.quiet {
@@ -60,7 +61,7 @@ func (a *App) runConfig(ctx context.Context, global globalOptions, args []string
 	case "print":
 		cfg, err := loadConfigWithGlobalOptions(global)
 		if err != nil {
-			writef(a.stderr, "load config: %v\n", err)
+			writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("load config: %v", err))
 			return exitConfigInvalid
 		}
 		if global.quiet {
@@ -77,7 +78,7 @@ func (a *App) runConfig(ctx context.Context, global globalOptions, args []string
 			cfg.MistralAPIKey != "",
 		)
 	default:
-		writef(a.stderr, "unknown config subcommand: %s\n", args[0])
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("unknown config subcommand: %s", args[0]))
 		return exitConfigInvalid
 	}
 	return exitSuccess
@@ -85,7 +86,7 @@ func (a *App) runConfig(ctx context.Context, global globalOptions, args []string
 
 func (a *App) runConfigInit(global globalOptions, args []string) int {
 	if len(args) > 0 {
-		writef(a.stderr, "config init does not accept arguments: %s\n", strings.Join(args, " "))
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("config init does not accept arguments: %s", strings.Join(args, " ")))
 		return exitConfigInvalid
 	}
 
@@ -96,14 +97,14 @@ func (a *App) runConfigInit(global globalOptions, args []string) int {
 
 	if _, err := os.Stat(configPath); err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
-			writef(a.stderr, "stat config: %v\n", err)
+			writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("stat config: %v", err))
 			return exitGeneric
 		}
 		created = true
 	} else {
 		existing, err := config.LoadFile(configPath)
 		if err != nil {
-			writef(a.stderr, "load config file: %v\n", err)
+			writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("load config file: %v", err))
 			return exitConfigInvalid
 		}
 		cfg = existing
@@ -111,7 +112,7 @@ func (a *App) runConfigInit(global globalOptions, args []string) int {
 	cfg = applyGlobalPathOverrides(cfg, global)
 
 	if err := config.SaveFile(configPath, cfg); err != nil {
-		writef(a.stderr, "save config file: %v\n", err)
+		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("save config file: %v", err))
 		return exitGeneric
 	}
 
@@ -139,7 +140,7 @@ func (a *App) runConfigInit(global globalOptions, args []string) int {
 			"next_steps":    nextSteps,
 		}
 		if err := emitJSON(a.stdout, payload); err != nil {
-			writef(a.stderr, "encode config init json: %v\n", err)
+			writeCLIError(a.stderr, true, exitGeneric, fmt.Sprintf("encode config init json: %v", err))
 			return exitGeneric
 		}
 		return exitSuccess

--- a/internal/cli/reindex.go
+++ b/internal/cli/reindex.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,7 +13,7 @@ import (
 
 func (a *App) runReindex(ctx context.Context, global globalOptions, args []string) int {
 	if len(args) > 0 {
-		writef(a.stderr, "reindex command does not accept arguments: %s\n", strings.Join(args, " "))
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("reindex command does not accept arguments: %s", strings.Join(args, " ")))
 		return exitConfigInvalid
 	}
 
@@ -22,7 +23,7 @@ func (a *App) runReindex(ctx context.Context, global globalOptions, args []strin
 	// proceeding with defaults as was previously the case.
 	cfg, err := loadConfigWithGlobalOptions(global)
 	if err != nil {
-		writef(a.stderr, "load config: %v\n", err)
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("load config: %v", err))
 		return exitConfigInvalid
 	}
 
@@ -35,7 +36,7 @@ func (a *App) runReindex(ctx context.Context, global globalOptions, args []strin
 	textIndexPath := filepath.Join(baseDir, "vectors_text.hnsw")
 	codeIndexPath := filepath.Join(baseDir, "vectors_code.hnsw")
 	if err := os.MkdirAll(baseDir, 0o755); err != nil {
-		writef(a.stderr, "create state dir: %v\n", err)
+		writeCLIError(a.stderr, global.jsonOutput, exitRootInaccessible, fmt.Sprintf("create state dir: %v", err))
 		return exitRootInaccessible
 	}
 	// update cfg so that the store factory uses the same baseDir
@@ -43,15 +44,15 @@ func (a *App) runReindex(ctx context.Context, global globalOptions, args []strin
 	st := a.storeForConfig(cfg)
 	defer a.closeStoreWithLog(st)
 	if err := st.Init(ctx); err != nil && !errors.Is(err, model.ErrNotImplemented) {
-		writef(a.stderr, "initialize metadata store: %v\n", err)
+		writeCLIError(a.stderr, global.jsonOutput, exitIndexLoadFailure, fmt.Sprintf("initialize metadata store: %v", err))
 		return exitIndexLoadFailure
 	}
-	if exitCode := clearContentHashesIfSupported(ctx, st, a.stderr); exitCode != exitSuccess {
+	if exitCode := clearContentHashesIfSupported(ctx, st, a.stderr, global.jsonOutput); exitCode != exitSuccess {
 		return exitCode
 	}
 	for _, indexPath := range []string{textIndexPath, codeIndexPath} {
 		if err := os.Remove(indexPath); err != nil && !errors.Is(err, os.ErrNotExist) {
-			writef(a.stderr, "remove stale index file %s: %v\n", indexPath, err)
+			writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("remove stale index file %s: %v", indexPath, err))
 			return exitGeneric
 		}
 	}
@@ -59,7 +60,7 @@ func (a *App) runReindex(ctx context.Context, global globalOptions, args []strin
 	// use the factory hook (same as runUp) to allow tests to intercept
 	ing, err := a.newIngestor(cfg, st)
 	if err != nil {
-		writef(a.stderr, "initialize ingestor: %v\n", err)
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("initialize ingestor: %v", err))
 		return exitConfigInvalid
 	}
 
@@ -71,7 +72,7 @@ func (a *App) runReindex(ctx context.Context, global globalOptions, args []strin
 		return exitSuccess
 	}
 	if err != nil {
-		writef(a.stderr, "reindex failed: %v\n", err)
+		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("reindex failed: %v", err))
 		return exitGeneric
 	}
 	return exitSuccess

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -47,7 +47,9 @@ func (a *App) runStatus(ctx context.Context, global globalOptions, args []string
 			writeCLIError(a.stderr, global.jsonOutput, exitIndexLoadFailure, fmt.Sprintf("initialize metadata store: %v", initErr))
 			return exitIndexLoadFailure
 		}
-		emitter := newNDJSONEmitter(a.stdout, global.jsonOutput)
+		// status --json must emit a single JSON object, not an NDJSON stream.
+		// Keep the emitter disabled so computed-snapshot warnings go to stderr.
+		emitter := newNDJSONEmitter(a.stdout, false)
 		snapshot, err = buildCorpusSnapshot(ctx, st, nil, a.stderr, emitter)
 		if err != nil {
 			writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("build status snapshot: %v", err))

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -14,13 +14,13 @@ import (
 
 func (a *App) runStatus(ctx context.Context, global globalOptions, args []string) int {
 	if len(args) > 0 {
-		writef(a.stderr, "status command does not accept arguments: %s\n", strings.Join(args, " "))
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("status command does not accept arguments: %s", strings.Join(args, " ")))
 		return exitConfigInvalid
 	}
 
 	cfg, err := loadConfigWithGlobalOptions(global)
 	if err != nil {
-		writef(a.stderr, "load config: %v\n", err)
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("load config: %v", err))
 		return exitConfigInvalid
 	}
 	if strings.TrimSpace(cfg.StateDir) == "" {
@@ -34,23 +34,23 @@ func (a *App) runStatus(ctx context.Context, global globalOptions, args []string
 		metaPath := filepath.Join(cfg.StateDir, "meta.sqlite")
 		if _, statErr := os.Stat(metaPath); statErr != nil {
 			if errors.Is(statErr, os.ErrNotExist) {
-				writef(a.stderr, "no state found in %s; run: dir2mcp up\n", cfg.StateDir)
+				writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("no state found in %s; run: dir2mcp up", cfg.StateDir))
 				return exitGeneric
 			}
-			writef(a.stderr, "read state: %v\n", statErr)
+			writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("read state: %v", statErr))
 			return exitGeneric
 		}
 
 		st := a.storeForConfig(cfg)
 		defer func() { _ = st.Close() }()
 		if initErr := st.Init(ctx); initErr != nil && !errors.Is(initErr, model.ErrNotImplemented) {
-			writef(a.stderr, "initialize metadata store: %v\n", initErr)
+			writeCLIError(a.stderr, global.jsonOutput, exitIndexLoadFailure, fmt.Sprintf("initialize metadata store: %v", initErr))
 			return exitIndexLoadFailure
 		}
 		emitter := newNDJSONEmitter(a.stdout, global.jsonOutput)
 		snapshot, err = buildCorpusSnapshot(ctx, st, nil, a.stderr, emitter)
 		if err != nil {
-			writef(a.stderr, "build status snapshot: %v\n", err)
+			writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("build status snapshot: %v", err))
 			return exitGeneric
 		}
 		source = "computed"
@@ -67,7 +67,7 @@ func (a *App) renderStatusOutput(global globalOptions, stateDir string, snapshot
 			"snapshot":  snapshot,
 		}
 		if err := emitJSON(a.stdout, payload); err != nil {
-			writef(a.stderr, "encode status json: %v\n", err)
+			writeCLIError(a.stderr, true, exitGeneric, fmt.Sprintf("encode status json: %v", err))
 			return exitGeneric
 		}
 		return exitSuccess

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -27,7 +27,7 @@ import (
 func (a *App) runUp(ctx context.Context, opts upOptions) int {
 	cfg, err := loadConfigWithGlobalOptions(opts.globalOptions)
 	if err != nil {
-		writef(a.stderr, "load config: %v\n", err)
+		writeCLIError(a.stderr, opts.jsonOutput, exitConfigInvalid, fmt.Sprintf("load config: %v", err))
 		return exitConfigInvalid
 	}
 
@@ -52,14 +52,14 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 
 	auth, err := prepareAuthMaterial(cfg)
 	if err != nil {
-		writef(a.stderr, "auth setup: %v\n", err)
+		writeCLIError(a.stderr, opts.jsonOutput, exitAuthOrPayment, fmt.Sprintf("auth setup: %v", err))
 		return exitAuthOrPayment
 	}
 	cfg.AuthMode = auth.mode
 	cfg.ResolvedAuthToken = auth.token
 	warnConfigSnapshotErr(a.stderr, opts.quiet, saveEffectiveConfigSnapshot(cfg, auth, x402TokenSource))
 
-	st, textIx, codeIx, code := a.initStoreAndIndices(ctx, &cfg)
+	st, textIx, codeIx, code := a.initStoreAndIndices(ctx, &cfg, opts.jsonOutput)
 	if code != exitSuccess {
 		return code
 	}
@@ -96,7 +96,7 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 	mcpServer := mcp.NewServer(cfg, ret, serverOptions...)
 	ing, err := a.newIngestor(cfg, st)
 	if err != nil {
-		writef(a.stderr, "initialize ingestor: %v\n", err)
+		writeCLIError(a.stderr, opts.jsonOutput, exitConfigInvalid, fmt.Sprintf("initialize ingestor: %v", err))
 		return exitConfigInvalid
 	}
 	wireIngestorHooks(ing, indexingState, ret.EvictDocuments)
@@ -107,7 +107,7 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 
 	ln, err := net.Listen("tcp", cfg.ListenAddr)
 	if err != nil {
-		writef(a.stderr, "bind server: %v\n", err)
+		writeCLIError(a.stderr, opts.jsonOutput, exitServerBindFailure, fmt.Sprintf("bind server: %v", err))
 		return exitServerBindFailure
 	}
 	runCtx, cancel := context.WithCancel(ctx)
@@ -137,7 +137,7 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 	mcpTransportMode := strings.TrimSpace(os.Getenv("MCP_TRANSPORT"))
 	transport, err := mcp.NewTransport(mcpTransportMode, mcpServer, ln, tlsCertFile, tlsKeyFile)
 	if err != nil {
-		writef(a.stderr, "transport init: %v\n", err)
+		writeCLIError(a.stderr, opts.jsonOutput, exitConfigInvalid, fmt.Sprintf("transport init: %v", err))
 		return exitConfigInvalid
 	}
 
@@ -154,7 +154,7 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 
 	connection := buildConnectionPayload(cfg, mcpURL, auth)
 	if err := writeConnectionFile(filepath.Join(cfg.StateDir, connectionFileName), connection); err != nil {
-		writef(a.stderr, "write %s: %v\n", connectionFileName, err)
+		writeCLIError(a.stderr, opts.jsonOutput, exitGeneric, fmt.Sprintf("write %s: %v", connectionFileName, err))
 		return exitGeneric
 	}
 
@@ -197,7 +197,7 @@ func (a *App) applyTLSConfig(cfg *config.Config, opts upOptions) (tlsCertFile, t
 		tlsKeyFile = strings.TrimSpace(cfg.ServerTLSKeyFile)
 	}
 	if err := validateTLSFlags(tlsCertFile, tlsKeyFile); err != nil {
-		writef(a.stderr, "CONFIG_INVALID: %v\n", err)
+		writeCLIError(a.stderr, opts.jsonOutput, exitConfigInvalid, fmt.Sprintf("CONFIG_INVALID: %v", err))
 		return "", "", exitConfigInvalid
 	}
 	cfg.ServerTLSCertFile = tlsCertFile
@@ -293,12 +293,12 @@ func (a *App) resolveX402Token(cfg *config.Config, opts upOptions) (source strin
 	if opts.x402FacilitatorTokenFile != "" {
 		data, err := os.ReadFile(filepath.Clean(opts.x402FacilitatorTokenFile))
 		if err != nil {
-			writef(a.stderr, "failed to read x402 facilitator token file: %v\n", err)
+			writeCLIError(a.stderr, opts.jsonOutput, exitAuthOrPayment, fmt.Sprintf("failed to read x402 facilitator token file: %v", err))
 			return "", exitAuthOrPayment
 		}
 		token := strings.TrimSpace(string(data))
 		if token == "" {
-			writef(a.stderr, "x402 facilitator token file is empty\n")
+			writeCLIError(a.stderr, opts.jsonOutput, exitAuthOrPayment, "x402 facilitator token file is empty")
 			return "", exitAuthOrPayment
 		}
 		cfg.X402.FacilitatorToken = token
@@ -327,20 +327,20 @@ func (a *App) validateUpConfig(cfg *config.Config, opts upOptions) int {
 		}
 	}
 	if !strings.HasPrefix(cfg.MCPPath, "/") {
-		writeln(a.stderr, "CONFIG_INVALID: --mcp-path must start with '/'")
+		writeCLIError(a.stderr, opts.jsonOutput, exitConfigInvalid, "CONFIG_INVALID: --mcp-path must start with '/'")
 		return exitConfigInvalid
 	}
 	strictX402 := strings.EqualFold(strings.TrimSpace(cfg.X402.Mode), "required")
 	if err := cfg.ValidateX402(strictX402); err != nil {
-		writef(a.stderr, "CONFIG_INVALID: %v\n", err)
+		writeCLIError(a.stderr, opts.jsonOutput, exitAuthOrPayment, fmt.Sprintf("x402 configuration invalid: %v", err))
 		return exitAuthOrPayment
 	}
 	if err := ensureRootAccessible(cfg.RootDir); err != nil {
-		writef(a.stderr, "root inaccessible: %v\n", err)
+		writeCLIError(a.stderr, opts.jsonOutput, exitRootInaccessible, fmt.Sprintf("root inaccessible: %v", err))
 		return exitRootInaccessible
 	}
 	if err := os.MkdirAll(cfg.StateDir, 0o755); err != nil {
-		writef(a.stderr, "create state dir: %v\n", err)
+		writeCLIError(a.stderr, opts.jsonOutput, exitRootInaccessible, fmt.Sprintf("create state dir: %v", err))
 		return exitRootInaccessible
 	}
 	// create payments subdirectory while x402 configuration has been
@@ -350,7 +350,7 @@ func (a *App) validateUpConfig(cfg *config.Config, opts upOptions) int {
 	// because it's done after x402 validation, a valid config (including
 	// mode="off") won't leave an inconsistent state.
 	if err := os.MkdirAll(filepath.Join(cfg.StateDir, "payments"), 0o755); err != nil {
-		writef(a.stderr, "create payments dir: %v\n", err)
+		writeCLIError(a.stderr, opts.jsonOutput, exitRootInaccessible, fmt.Sprintf("create payments dir: %v", err))
 		return exitRootInaccessible
 	}
 	return exitSuccess
@@ -369,8 +369,12 @@ func (a *App) applyPublicMode(cfg *config.Config, opts upOptions) int {
 	}
 	authMode := strings.TrimSpace(cfg.AuthMode)
 	if strings.EqualFold(authMode, "none") && !opts.forceInsecure {
-		se := a.sty(opts.jsonOutput)
-		writef(a.stderr, "%s --public requires auth. Use --auth auto or --force-insecure to override (unsafe).\n", se.errPrefix())
+		writeCLIError(
+			a.stderr,
+			opts.jsonOutput,
+			exitConfigInvalid,
+			"--public requires auth. Use --auth auto or --force-insecure to override (unsafe).",
+		)
 		return exitConfigInvalid
 	}
 	return exitSuccess
@@ -380,6 +384,17 @@ func (a *App) applyPublicMode(cfg *config.Config, opts upOptions) int {
 func (a *App) checkMistralAPIKey(cfg *config.Config, opts upOptions, nonInteractiveMode bool) int {
 	if strings.TrimSpace(cfg.MistralAPIKey) != "" {
 		return exitSuccess
+	}
+	if opts.jsonOutput {
+		writeCLIError(
+			a.stderr,
+			true,
+			exitConfigInvalid,
+			"CONFIG_INVALID: Missing MISTRAL_API_KEY",
+			"Set env: MISTRAL_API_KEY=...",
+			"Or run: dir2mcp config init",
+		)
+		return exitConfigInvalid
 	}
 	se := a.sty(opts.jsonOutput)
 	if nonInteractiveMode {
@@ -395,10 +410,10 @@ func (a *App) checkMistralAPIKey(cfg *config.Config, opts upOptions, nonInteract
 
 // initStoreAndIndices initialises the metadata store and both HNSW indices.
 // On success the caller is responsible for closing all three.
-func (a *App) initStoreAndIndices(ctx context.Context, cfg *config.Config) (model.Store, model.Index, model.Index, int) {
+func (a *App) initStoreAndIndices(ctx context.Context, cfg *config.Config, jsonOutput bool) (model.Store, model.Index, model.Index, int) {
 	st := a.storeForConfig(*cfg)
 	if err := st.Init(ctx); err != nil && !errors.Is(err, model.ErrNotImplemented) {
-		writef(a.stderr, "initialize metadata store: %v\n", err)
+		writeCLIError(a.stderr, jsonOutput, exitIndexLoadFailure, fmt.Sprintf("initialize metadata store: %v", err))
 		return nil, nil, nil, exitIndexLoadFailure
 	}
 
@@ -407,7 +422,7 @@ func (a *App) initStoreAndIndices(ctx context.Context, cfg *config.Config) (mode
 	if err := textIx.Load(textIndexPath); err != nil &&
 		!errors.Is(err, model.ErrNotImplemented) &&
 		!errors.Is(err, os.ErrNotExist) {
-		writef(a.stderr, "load text index: %v\n", err)
+		writeCLIError(a.stderr, jsonOutput, exitIndexLoadFailure, fmt.Sprintf("load text index: %v", err))
 		_ = st.Close()
 		_ = textIx.Close()
 		return nil, nil, nil, exitIndexLoadFailure
@@ -418,7 +433,7 @@ func (a *App) initStoreAndIndices(ctx context.Context, cfg *config.Config) (mode
 	if err := codeIx.Load(codeIndexPath); err != nil &&
 		!errors.Is(err, model.ErrNotImplemented) &&
 		!errors.Is(err, os.ErrNotExist) {
-		writef(a.stderr, "load code index: %v\n", err)
+		writeCLIError(a.stderr, jsonOutput, exitIndexLoadFailure, fmt.Sprintf("load code index: %v", err))
 		_ = st.Close()
 		_ = textIx.Close()
 		_ = codeIx.Close()
@@ -522,7 +537,7 @@ func (a *App) runEventLoop(
 			return exitSuccess
 		case serverErr := <-serverErrCh:
 			if serverErr != nil {
-				writef(a.stderr, "server failed: %v\n", serverErr)
+				writeCLIError(a.stderr, emitter.enabled, exitGeneric, fmt.Sprintf("server failed: %v", serverErr))
 				emitter.Emit("error", "fatal", map[string]interface{}{
 					"code":    "SERVER_FAILURE",
 					"message": serverErr.Error(),
@@ -540,7 +555,7 @@ func (a *App) runEventLoop(
 				_ = writeCorpusSnapshot(runCtx, cfg.StateDir, st, indexingState, a.stderr, emitter)
 				continue
 			}
-			writef(a.stderr, "ingestion failed: %v\n", ingestErr)
+			writeCLIError(a.stderr, emitter.enabled, exitIngestionFatal, fmt.Sprintf("ingestion failed: %v", ingestErr))
 			emitter.Emit("error", "file_error", map[string]interface{}{
 				"message": ingestErr.Error(),
 			})
@@ -553,7 +568,7 @@ func (a *App) runEventLoop(
 			if embedErr == nil {
 				continue
 			}
-			writef(a.stderr, "embedding worker warning: %v\n", embedErr)
+			writeCLIError(a.stderr, emitter.enabled, exitGeneric, fmt.Sprintf("embedding worker warning: %v", embedErr))
 			emitter.Emit("error", "embed_error", map[string]interface{}{
 				"message": embedErr.Error(),
 			})

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -332,8 +332,8 @@ func (a *App) validateUpConfig(cfg *config.Config, opts upOptions) int {
 	}
 	strictX402 := strings.EqualFold(strings.TrimSpace(cfg.X402.Mode), "required")
 	if err := cfg.ValidateX402(strictX402); err != nil {
-		writeCLIError(a.stderr, opts.jsonOutput, exitAuthOrPayment, fmt.Sprintf("x402 configuration invalid: %v", err))
-		return exitAuthOrPayment
+		writeCLIError(a.stderr, opts.jsonOutput, exitConfigInvalid, fmt.Sprintf("x402 configuration invalid: %v", err))
+		return exitConfigInvalid
 	}
 	if err := ensureRootAccessible(cfg.RootDir); err != nil {
 		writeCLIError(a.stderr, opts.jsonOutput, exitRootInaccessible, fmt.Sprintf("root inaccessible: %v", err))

--- a/tests/cli/command_behavior_test.go
+++ b/tests/cli/command_behavior_test.go
@@ -270,6 +270,52 @@ func TestStatusFallsBackToComputedSnapshot(t *testing.T) {
 	}
 }
 
+func TestStatusJSONComputedSnapshotDoesNotEmitExtraNDJSONEvents(t *testing.T) {
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, ".dir2mcp")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+
+	st := store.NewSQLiteStore(filepath.Join(stateDir, "meta.sqlite"))
+	if err := st.Init(context.Background()); err != nil {
+		t.Fatalf("init sqlite store: %v", err)
+	}
+	if err := st.UpsertDocument(context.Background(), model.Document{
+		RelPath:     "docs/weird.md",
+		DocType:     "md",
+		SourceType:  "file",
+		SizeBytes:   10,
+		MTimeUnix:   1,
+		ContentHash: "h1",
+		Status:      "mystery",
+	}); err != nil {
+		t.Fatalf("upsert document: %v", err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("close sqlite store: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	withWorkingDir(t, tmp, func() {
+		code := app.RunWithContext(context.Background(), []string{"--json", "status"})
+		if code != 0 {
+			t.Fatalf("unexpected exit code: %d stderr=%s", code, stderr.String())
+		}
+	})
+
+	var payload struct {
+		Source string `json:"source"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("expected single JSON payload on stdout: %v raw=%s", err, stdout.String())
+	}
+	if payload.Source != "computed" {
+		t.Fatalf("Source=%q want=%q", payload.Source, "computed")
+	}
+}
+
 func TestStatusNoStateReturnsExitCode1(t *testing.T) {
 	tmp := t.TempDir()
 	var stdout, stderr bytes.Buffer

--- a/tests/cli/command_behavior_test.go
+++ b/tests/cli/command_behavior_test.go
@@ -674,6 +674,126 @@ func TestAskMissingQuestionFails(t *testing.T) {
 	}
 }
 
+func TestStatusJSONErrorOutputWhenStateMissing(t *testing.T) {
+	tmp := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+
+	withWorkingDir(t, tmp, func() {
+		code := app.RunWithContext(context.Background(), []string{"--json", "status"})
+		if code != 1 {
+			t.Fatalf("unexpected exit code: got=%d want=1 stderr=%s", code, stderr.String())
+		}
+	})
+
+	var payload struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+		ExitCode int `json:"exit_code"`
+	}
+	if err := json.Unmarshal(stderr.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal status error payload: %v raw=%s", err, stderr.String())
+	}
+	if payload.Error.Code != "GENERIC_ERROR" || payload.ExitCode != 1 {
+		t.Fatalf("unexpected payload: %+v", payload)
+	}
+	if !strings.Contains(payload.Error.Message, "no state found") {
+		t.Fatalf("unexpected message: %q", payload.Error.Message)
+	}
+}
+
+func TestAskMissingQuestionJSONErrorOutput(t *testing.T) {
+	tmp := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+
+	withWorkingDir(t, tmp, func() {
+		code := app.RunWithContext(context.Background(), []string{"--json", "ask", "--k", "2"})
+		if code != 2 {
+			t.Fatalf("unexpected exit code: got=%d want=2 stderr=%s", code, stderr.String())
+		}
+	})
+
+	var payload struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+		ExitCode int `json:"exit_code"`
+	}
+	if err := json.Unmarshal(stderr.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal ask error payload: %v raw=%s", err, stderr.String())
+	}
+	if payload.Error.Code != "CONFIG_INVALID" || payload.ExitCode != 2 {
+		t.Fatalf("unexpected payload: %+v", payload)
+	}
+	if !strings.Contains(payload.Error.Message, "requires a question argument") {
+		t.Fatalf("unexpected message: %q", payload.Error.Message)
+	}
+}
+
+func TestReindexJSONErrorOutputForUnexpectedArgs(t *testing.T) {
+	tmp := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+
+	withWorkingDir(t, tmp, func() {
+		code := app.RunWithContext(context.Background(), []string{"--json", "reindex", "extra"})
+		if code != 2 {
+			t.Fatalf("unexpected exit code: got=%d want=2 stderr=%s", code, stderr.String())
+		}
+	})
+
+	var payload struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+		ExitCode int `json:"exit_code"`
+	}
+	if err := json.Unmarshal(stderr.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal reindex error payload: %v raw=%s", err, stderr.String())
+	}
+	if payload.Error.Code != "CONFIG_INVALID" || payload.ExitCode != 2 {
+		t.Fatalf("unexpected payload: %+v", payload)
+	}
+	if !strings.Contains(payload.Error.Message, "reindex command does not accept arguments") {
+		t.Fatalf("unexpected message: %q", payload.Error.Message)
+	}
+}
+
+func TestConfigUnknownSubcommandJSONErrorOutput(t *testing.T) {
+	tmp := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+
+	withWorkingDir(t, tmp, func() {
+		code := app.RunWithContext(context.Background(), []string{"--json", "config", "unknown"})
+		if code != 2 {
+			t.Fatalf("unexpected exit code: got=%d want=2 stderr=%s", code, stderr.String())
+		}
+	})
+
+	var payload struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+		ExitCode int `json:"exit_code"`
+	}
+	if err := json.Unmarshal(stderr.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal config error payload: %v raw=%s", err, stderr.String())
+	}
+	if payload.Error.Code != "CONFIG_INVALID" || payload.ExitCode != 2 {
+		t.Fatalf("unexpected payload: %+v", payload)
+	}
+	if !strings.Contains(payload.Error.Message, "unknown config subcommand") {
+		t.Fatalf("unexpected message: %q", payload.Error.Message)
+	}
+}
+
 func TestVersionUsesBuildInfo(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	app := cli.NewAppWithIO(&stdout, &stderr)

--- a/tests/cli/command_behavior_test.go
+++ b/tests/cli/command_behavior_test.go
@@ -866,6 +866,36 @@ func TestStatusJSONTrueGlobalFlagUsesJSONEnvelope(t *testing.T) {
 	}
 }
 
+func TestUnknownCommandTrailingJSONFlagUsesJSONEnvelope(t *testing.T) {
+	tmp := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+
+	withWorkingDir(t, tmp, func() {
+		code := app.RunWithContext(context.Background(), []string{"bogus", "--json"})
+		if code != 1 {
+			t.Fatalf("unexpected exit code: got=%d want=1 stderr=%s", code, stderr.String())
+		}
+	})
+
+	var payload struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+		ExitCode int `json:"exit_code"`
+	}
+	if err := json.Unmarshal(stderr.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal unknown-command error payload: %v raw=%s", err, stderr.String())
+	}
+	if payload.Error.Code != "GENERIC_ERROR" || payload.ExitCode != 1 {
+		t.Fatalf("unexpected payload: %+v", payload)
+	}
+	if !strings.Contains(payload.Error.Message, "unknown command: bogus") {
+		t.Fatalf("unexpected message: %q", payload.Error.Message)
+	}
+}
+
 func TestVersionUsesBuildInfo(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	app := cli.NewAppWithIO(&stdout, &stderr)

--- a/tests/cli/command_behavior_test.go
+++ b/tests/cli/command_behavior_test.go
@@ -794,6 +794,32 @@ func TestConfigUnknownSubcommandJSONErrorOutput(t *testing.T) {
 	}
 }
 
+func TestStatusJSONTrueGlobalFlagUsesJSONEnvelope(t *testing.T) {
+	tmp := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+
+	withWorkingDir(t, tmp, func() {
+		code := app.RunWithContext(context.Background(), []string{"--json=true", "status"})
+		if code != 1 {
+			t.Fatalf("unexpected exit code: got=%d want=1 stderr=%s", code, stderr.String())
+		}
+	})
+
+	var payload struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+		ExitCode int `json:"exit_code"`
+	}
+	if err := json.Unmarshal(stderr.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal status error payload: %v raw=%s", err, stderr.String())
+	}
+	if payload.Error.Code != "GENERIC_ERROR" || payload.ExitCode != 1 {
+		t.Fatalf("unexpected payload: %+v", payload)
+	}
+}
+
 func TestVersionUsesBuildInfo(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	app := cli.NewAppWithIO(&stdout, &stderr)

--- a/tests/cli/up_command_test.go
+++ b/tests/cli/up_command_test.go
@@ -645,8 +645,21 @@ func TestUpReturnsExitCode3OnIngestionFatal(t *testing.T) {
 	if code != 3 {
 		t.Fatalf("unexpected exit code: got=%d want=3 stderr=%s", code, stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "ingestion failed") {
-		t.Fatalf("expected ingestion error in stderr, got: %s", stderr.String())
+	var payload struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+		ExitCode int `json:"exit_code"`
+	}
+	if err := json.Unmarshal(stderr.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal ingestion stderr payload: %v raw=%s", err, stderr.String())
+	}
+	if payload.Error.Code != "INGESTION_FATAL" || payload.ExitCode != 3 {
+		t.Fatalf("unexpected payload: %+v", payload)
+	}
+	if !strings.Contains(payload.Error.Message, "ingestion failed") {
+		t.Fatalf("expected ingestion error message in payload, got: %q", payload.Error.Message)
 	}
 }
 

--- a/tests/cli/up_command_test.go
+++ b/tests/cli/up_command_test.go
@@ -203,6 +203,36 @@ func TestUpTLSRequiresCertAndKeyTogether(t *testing.T) {
 	}
 }
 
+func TestUpInvalidFlagWithJSONEmitsJSONError(t *testing.T) {
+	tmp := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+
+	withWorkingDir(t, tmp, func() {
+		code := app.RunWithContext(context.Background(), []string{"up", "--json", "--badflag"})
+		if code != 2 {
+			t.Fatalf("unexpected exit code: got=%d want=2 stderr=%s", code, stderr.String())
+		}
+	})
+
+	var payload struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+		ExitCode int `json:"exit_code"`
+	}
+	if err := json.Unmarshal(stderr.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal up parse error payload: %v raw=%s", err, stderr.String())
+	}
+	if payload.Error.Code != "CONFIG_INVALID" || payload.ExitCode != 2 {
+		t.Fatalf("unexpected payload: %+v", payload)
+	}
+	if !strings.Contains(payload.Error.Message, "invalid up flags") {
+		t.Fatalf("unexpected message: %q", payload.Error.Message)
+	}
+}
+
 func TestUpTLSConnectionURLUsesHTTPS(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("MISTRAL_API_KEY", "test-key")

--- a/tests/cli/up_command_test.go
+++ b/tests/cli/up_command_test.go
@@ -835,8 +835,8 @@ func TestUpX402RequiredMissingFieldsFailsFast(t *testing.T) {
 		})
 	})
 
-	if code != 5 {
-		t.Fatalf("unexpected exit code: got=%d want=5 stderr=%s", code, stderr.String())
+	if code != 2 {
+		t.Fatalf("unexpected exit code: got=%d want=2 stderr=%s", code, stderr.String())
 	}
 	if !strings.Contains(stderr.String(), "x402 facilitator URL is required") {
 		t.Fatalf("expected x402 validation error, got: %s", stderr.String())


### PR DESCRIPTION
## Summary
- switch CLI JSON output to single-line JSON so command JSON output is NDJSON-compatible
- add shared `writeCLIError` envelope for machine-readable stderr in `--json` mode across `up`, `ask`, `status`, `reindex`, and `config`
- normalize `RunWithContext` global/dispatch errors for JSON mode and suppress usage text on unknown command when `--json` is active
- add coverage for JSON stderr error envelopes and update `up` ingestion-fatal JSON assertions

## Validation
- `go test ./tests/cli ./internal/cli`
- `make check`
- `coderabbit review` (final rerun currently rate-limited; earlier findings were addressed)

Closes #122

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now emits structured JSON error payloads (error.code, error.message, exit_code) when using --json; human-readable stderr remains for non-JSON runs.

* **Improvements**
  * Unified and standardized error reporting across commands with clearer exit codes and consistent messages.
  * JSON output tuned to avoid HTML-escaping so messages preserve original characters.

* **Tests**
  * Added and updated tests to validate JSON-formatted error output and exit codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->