### PR TITLE
[#133] ci: add gocyclo gate and local cyclo target

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Install golangci-lint
         run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1
 
+      - name: Install gocyclo
+        run: go install github.com/fzipp/gocyclo/cmd/gocyclo@v0.6.0
+
       - name: Add Go bin to PATH
         run: echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
@@ -62,4 +65,3 @@ jobs:
 
       - name: Run inspector smoke test
         run: make inspector-smoke
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,12 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Install gocyclo
+        run: go install github.com/fzipp/gocyclo/cmd/gocyclo@v0.6.0
+
+      - name: Add Go bin to PATH
+        run: echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
       - name: Run checks
         run: make ci
 

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ build: build-dir2mcp
 
 DIR2MCP_VERSION ?= 0.0.0-dev
 DIR2MCP_LDFLAGS ?= -X dir2mcp/internal/buildinfo.Version=$(DIR2MCP_VERSION)
+GOCYCLO_BIN ?= $(shell command -v gocyclo 2>/dev/null || echo "$$(go env GOPATH)/bin/gocyclo")
 
 build-dir2mcp:
 	go build -ldflags "$(DIR2MCP_LDFLAGS)" -o dir2mcp ./cmd/dir2mcp/
@@ -13,7 +14,7 @@ build-dir2mcp:
 up: build
 	./dir2mcp up
 
-.PHONY: all clean clean-all help fmt vet lint test check ci benchmark inspector-smoke conformance
+.PHONY: all clean clean-all help fmt vet lint cyclo test check ci benchmark inspector-smoke conformance
 
 all: check
 
@@ -25,9 +26,10 @@ help:
 	@echo "  fmt       - format Go code"
 	@echo "  vet    - run go vet"
 	@echo "  lint   - run golangci-lint"
+	@echo "  cyclo  - run gocyclo -over 15 ./internal/"
 	@echo "  test   - run go test"
-	@echo "  check  - fmt + vet + lint + test + build"
-	@echo "  ci     - vet + test (CI-safe default)"
+	@echo "  check  - fmt + vet + lint + cyclo + test + build"
+	@echo "  ci     - vet + cyclo + test (CI-safe default)"
 	@echo "  conformance      - run black-box conformance tests (tests/conformance/)"
 	@echo "  benchmark        - run the large-corpus retrieval benchmark"
 	@echo "  inspector-smoke  - build and run MCP inspector headless smoke test"
@@ -42,15 +44,19 @@ lint:
 	@command -v golangci-lint >/dev/null 2>&1 || (echo "golangci-lint is required. Install: https://golangci-lint.run/welcome/install/" && exit 1)
 	golangci-lint run
 
+cyclo:
+	@test -x "$(GOCYCLO_BIN)" || (echo "gocyclo is required. Install: go install github.com/fzipp/gocyclo/cmd/gocyclo@v0.6.0" && exit 1)
+	"$(GOCYCLO_BIN)" -over 15 ./internal/
+
 test:
 	go test ./...
 
 conformance:
 	go test ./tests/conformance/...
 
-check: fmt vet lint test build
+check: fmt vet lint cyclo test build
 
-ci: vet test
+ci: vet cyclo test
 
 benchmark:
 	# run the large-corpus retrieval benchmark only

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,9 @@ build: build-dir2mcp
 
 DIR2MCP_VERSION ?= 0.0.0-dev
 DIR2MCP_LDFLAGS ?= -X dir2mcp/internal/buildinfo.Version=$(DIR2MCP_VERSION)
+GOCYCLO_FALLBACK_BIN := $(shell sh -c 'gobin=$$(go env GOBIN); if [ -n "$$gobin" ]; then echo "$$gobin/gocyclo"; else gopath=$$(go env GOPATH | cut -d: -f1); echo "$$gopath/bin/gocyclo"; fi')
 ifndef GOCYCLO_BIN
-GOCYCLO_BIN := $(shell command -v gocyclo 2>/dev/null || echo "$$(go env GOPATH)/bin/gocyclo")
+GOCYCLO_BIN := $(shell command -v gocyclo 2>/dev/null || echo "$(GOCYCLO_FALLBACK_BIN)")
 endif
 
 build-dir2mcp:

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,9 @@ build: build-dir2mcp
 
 DIR2MCP_VERSION ?= 0.0.0-dev
 DIR2MCP_LDFLAGS ?= -X dir2mcp/internal/buildinfo.Version=$(DIR2MCP_VERSION)
-GOCYCLO_BIN ?= $(shell command -v gocyclo 2>/dev/null || echo "$$(go env GOPATH)/bin/gocyclo")
+ifndef GOCYCLO_BIN
+GOCYCLO_BIN := $(shell command -v gocyclo 2>/dev/null || echo "$$(go env GOPATH)/bin/gocyclo")
+endif
 
 build-dir2mcp:
 	go build -ldflags "$(DIR2MCP_LDFLAGS)" -o dir2mcp ./cmd/dir2mcp/

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Core server, ingestion pipeline, retrieval, citations, and x402 gating are imple
 ## Development
 
 ```bash
-make check        # fmt + vet + lint + cyclo + test
+make check        # fmt + vet + lint + cyclo + test + build
 make cyclo        # gocyclo -over 15 ./internal/ (install: go install github.com/fzipp/gocyclo/cmd/gocyclo@v0.6.0)
 make build        # build binary
 make benchmark    # run retrieval benchmarks

--- a/README.md
+++ b/README.md
@@ -282,7 +282,8 @@ Core server, ingestion pipeline, retrieval, citations, and x402 gating are imple
 ## Development
 
 ```bash
-make check        # fmt + vet + lint + test
+make check        # fmt + vet + lint + cyclo + test
+make cyclo        # gocyclo -over 15 ./internal/ (install: go install github.com/fzipp/gocyclo/cmd/gocyclo@v0.6.0)
 make build        # build binary
 make benchmark    # run retrieval benchmarks
 ```
@@ -298,6 +299,7 @@ API notes:
   original `Ask` continues to exist as a thin wrapper for compatibility.
 
 `make check` includes `make lint`, which requires [`golangci-lint`](https://golangci-lint.run/welcome/install/) installed locally.
+`make cyclo` runs the cyclomatic-complexity gate used by CI. Go Report Card updates externally after the CI run; if the badge lags, refresh it from the goreportcard.com report page for this repository.
 
 Contributor and agent guides: [AGENTS.md](AGENTS.md) · [CLAUDE.md](CLAUDE.md)
 

--- a/internal/mcp/transport_sdk.go
+++ b/internal/mcp/transport_sdk.go
@@ -198,64 +198,92 @@ func (t *SDKTransport) parseSDKRequestAndID(w http.ResponseWriter, body []byte) 
 }
 
 func (t *SDKTransport) dispatchSDKRequest(w http.ResponseWriter, req *http.Request, parsedReq rpcRequest, id interface{}, hasID bool, sdkHandler http.Handler) {
-	// Validate session immediately before dispatch to eliminate the TOCTOU
-	// window between a prior check and handler invocation. initialize does not
-	// require a pre-existing session — it creates one.
-	if parsedReq.Method != protocol.RPCMethodInitialize {
-		sessionID := strings.TrimSpace(req.Header.Get(protocol.MCPSessionHeader))
-		if sessionID == "" {
-			writeError(w, http.StatusNotFound, id, -32001, "session not found", protocol.ErrorCodeSessionNotFound, false)
-			return
-		}
-		if ok, reason := t.server.hasActiveSession(sessionID, time.Now()); !ok {
-			if reason != "" {
-				w.Header().Set(protocol.MCPSessionExpiredHeader, reason)
-			}
-			writeError(w, http.StatusNotFound, id, -32001, "session not found", protocol.ErrorCodeSessionNotFound, false)
-			return
-		}
+	if !t.validateSDKSession(w, req, parsedReq.Method, id) {
+		return
 	}
 	switch parsedReq.Method {
 	case protocol.RPCMethodInitialize:
-		if !hasID {
-			writeError(w, http.StatusBadRequest, nil, -32600, "initialize requires id", "MISSING_FIELD", false)
-			return
-		}
-		rec := newBufferedResponseWriter()
-		sdkHandler.ServeHTTP(rec, req)
-		if sessionID := strings.TrimSpace(rec.header.Get(protocol.MCPSessionHeader)); sessionID != "" {
-			t.server.storeSession(sessionID)
-		}
-		copyBufferedResponse(w, rec)
+		t.handleSDKInitialize(w, req, id, hasID, sdkHandler)
 	case protocol.RPCMethodNotificationsInitialized:
-		if !hasID {
-			w.WriteHeader(http.StatusAccepted)
-			return
-		}
-		writeResult(w, http.StatusOK, id, map[string]interface{}{})
+		t.handleSDKNotificationsInitialized(w, id, hasID)
 	case protocol.RPCMethodToolsList:
-		if !hasID {
-			w.WriteHeader(http.StatusAccepted)
-			return
-		}
-		sdkHandler.ServeHTTP(w, req)
+		t.handleSDKToolsList(w, req, hasID, sdkHandler)
 	case protocol.RPCMethodToolsCall:
-		if !hasID {
-			w.WriteHeader(http.StatusAccepted)
-			return
-		}
-		if t.server.x402Enabled {
-			t.server.handleToolsCallRequest(req.Context(), w, req, parsedReq.Params, id)
-			return
-		}
-		sdkHandler.ServeHTTP(w, req)
+		t.handleSDKToolsCall(w, req, parsedReq.Params, id, hasID, sdkHandler)
 	default:
-		if !hasID {
-			w.WriteHeader(http.StatusAccepted)
-			return
-		}
-		writeError(w, http.StatusOK, id, -32601, "method not found", "METHOD_NOT_FOUND", false)
+		t.handleSDKUnknownMethod(w, id, hasID)
 	}
+}
+
+func (t *SDKTransport) validateSDKSession(w http.ResponseWriter, req *http.Request, method string, id interface{}) bool {
+	// Validate session immediately before dispatch to eliminate the TOCTOU
+	// window between a prior check and handler invocation. initialize does not
+	// require a pre-existing session — it creates one.
+	if method == protocol.RPCMethodInitialize {
+		return true
+	}
+	sessionID := strings.TrimSpace(req.Header.Get(protocol.MCPSessionHeader))
+	if sessionID == "" {
+		writeError(w, http.StatusNotFound, id, -32001, "session not found", protocol.ErrorCodeSessionNotFound, false)
+		return false
+	}
+	if ok, reason := t.server.hasActiveSession(sessionID, time.Now()); !ok {
+		if reason != "" {
+			w.Header().Set(protocol.MCPSessionExpiredHeader, reason)
+		}
+		writeError(w, http.StatusNotFound, id, -32001, "session not found", protocol.ErrorCodeSessionNotFound, false)
+		return false
+	}
+	return true
+}
+
+func (t *SDKTransport) handleSDKInitialize(w http.ResponseWriter, req *http.Request, id interface{}, hasID bool, sdkHandler http.Handler) {
+	if !hasID {
+		writeError(w, http.StatusBadRequest, nil, -32600, "initialize requires id", "MISSING_FIELD", false)
+		return
+	}
+	rec := newBufferedResponseWriter()
+	sdkHandler.ServeHTTP(rec, req)
+	if sessionID := strings.TrimSpace(rec.header.Get(protocol.MCPSessionHeader)); sessionID != "" {
+		t.server.storeSession(sessionID)
+	}
+	copyBufferedResponse(w, rec)
+}
+
+func (t *SDKTransport) handleSDKNotificationsInitialized(w http.ResponseWriter, id interface{}, hasID bool) {
+	if !hasID {
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+	writeResult(w, http.StatusOK, id, map[string]interface{}{})
+}
+
+func (t *SDKTransport) handleSDKToolsList(w http.ResponseWriter, req *http.Request, hasID bool, sdkHandler http.Handler) {
+	if !hasID {
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+	sdkHandler.ServeHTTP(w, req)
+}
+
+func (t *SDKTransport) handleSDKToolsCall(w http.ResponseWriter, req *http.Request, rawParams json.RawMessage, id interface{}, hasID bool, sdkHandler http.Handler) {
+	if !hasID {
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+	if t.server.x402Enabled {
+		t.server.handleToolsCallRequest(req.Context(), w, req, rawParams, id)
+		return
+	}
+	sdkHandler.ServeHTTP(w, req)
+}
+
+func (t *SDKTransport) handleSDKUnknownMethod(w http.ResponseWriter, id interface{}, hasID bool) {
+	if !hasID {
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+	writeError(w, http.StatusOK, id, -32601, "method not found", "METHOD_NOT_FOUND", false)
 }
 
 type bufferedResponseWriter struct {

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -612,7 +612,9 @@ func (s *Service) openFileFromMetadata(normalizedRel string, span model.Span, ma
 	if !isMetaSpanKind(kind) || (kind == "time" && span.EndMS <= 0) {
 		return "", false, false, nil
 	}
-	fromMeta, ok := s.sliceFromMetadata(normalizedRel, span)
+	normalizedSpan := span
+	normalizedSpan.Kind = kind
+	fromMeta, ok := s.sliceFromMetadata(normalizedRel, normalizedSpan)
 	if !ok {
 		return "", false, false, nil
 	}

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -596,14 +596,8 @@ func (s *Service) openFile(ctx context.Context, relPath string, span model.Span,
 	}
 
 	kind := strings.ToLower(strings.TrimSpace(span.Kind))
-	if isMetaSpanKind(kind) && (kind != "time" || span.EndMS > 0) {
-		if fromMeta, ok := s.sliceFromMetadata(normalizedRel, span); ok {
-			if hasSecretMatch(secretPatterns, fromMeta) {
-				return "", false, model.ErrForbidden
-			}
-			out, truncated := truncateRunesWithFlag(fromMeta, maxChars)
-			return out, truncated, nil
-		}
+	if content, truncated, handled, err := s.openFileFromMetadata(normalizedRel, span, maxChars, secretPatterns, kind); handled {
+		return content, truncated, err
 	}
 
 	resolvedAbs, err := resolveSymlinkInRoot(targetAbs, realRoot, pathExcludes, s)
@@ -611,6 +605,25 @@ func (s *Service) openFile(ctx context.Context, relPath string, span model.Span,
 		return "", false, err
 	}
 
+	return s.openFileFromResolvedPath(resolvedAbs, secretPatterns, kind, span, maxChars)
+}
+
+func (s *Service) openFileFromMetadata(normalizedRel string, span model.Span, maxChars int, secretPatterns []*regexp.Regexp, kind string) (content string, truncated bool, handled bool, err error) {
+	if !isMetaSpanKind(kind) || (kind == "time" && span.EndMS <= 0) {
+		return "", false, false, nil
+	}
+	fromMeta, ok := s.sliceFromMetadata(normalizedRel, span)
+	if !ok {
+		return "", false, false, nil
+	}
+	if hasSecretMatch(secretPatterns, fromMeta) {
+		return "", false, true, model.ErrForbidden
+	}
+	out, truncated := truncateRunesWithFlag(fromMeta, maxChars)
+	return out, truncated, true, nil
+}
+
+func (s *Service) openFileFromResolvedPath(resolvedAbs string, secretPatterns []*regexp.Regexp, kind string, span model.Span, maxChars int) (string, bool, error) {
 	info, err := os.Stat(resolvedAbs)
 	if err != nil {
 		return "", false, err


### PR DESCRIPTION
## Summary
- add `make cyclo` target (`gocyclo -over 15 ./internal/`)
- wire cyclo gate into `make check` and `make ci`
- install `gocyclo` in CI workflows before checks
- refactor remaining over-threshold functions in `internal/retrieval/service.go` and `internal/mcp/transport_sdk.go`
- document local cyclo check usage in README and note goreportcard refresh is external

## Validation
- `make check`

Closes #133

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added cyclomatic complexity checks to CI/CD pipeline and local development workflow.
  * Updated documentation to reflect new code quality gates and verification commands.

* **Refactor**
  * Improved internal code organization and maintainability across SDK request handling and file operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->