### PR TITLE
[#99] bug: replace Python ElevenLabs bridge with Go bridge

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,12 @@ DIR2MCP_ALLOWED_ORIGINS=
 # docs/x402-payment-adapter-spec.md for details on x402 modes and
 # configuration.
 DIR2MCP_X402_FACILITATOR_TOKEN=
+
+# ElevenLabs bridge (optional helper binary)
+# The bridge forwards ElevenLabs webhook calls to a running dir2mcp MCP
+# endpoint.  It can read the dir2mcp bearer token explicitly or from the
+# state directory token file when MCP_TOKEN is unset.
+MCP_URL=http://127.0.0.1:8087/mcp
+MCP_TOKEN=
+STATE_DIR=.dir2mcp
+PORT=8088

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,15 @@
 # Build binaries. Requires Go 1.24+.
-.PHONY: build build-dir2mcp
-build: build-dir2mcp
+.PHONY: build build-dir2mcp build-elevenlabs-bridge
+build: build-dir2mcp build-elevenlabs-bridge
 
 DIR2MCP_VERSION ?= 0.0.0-dev
 DIR2MCP_LDFLAGS ?= -X dir2mcp/internal/buildinfo.Version=$(DIR2MCP_VERSION)
 
 build-dir2mcp:
 	go build -ldflags "$(DIR2MCP_LDFLAGS)" -o dir2mcp ./cmd/dir2mcp/
+
+build-elevenlabs-bridge:
+	go build -o elevenlabs-bridge ./cmd/elevenlabs-bridge/
 
 # Run dir2mcp up (set MISTRAL_API_KEY first)
 .PHONY: up

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 # dir2mcp
 
-Deploy any local directory as an MCP knowledge server with indexing, retrieval, and citations, built to maximize use of Mistral models across embedding, OCR, transcription, and generation. Optional layers include ElevenLabs voice output and x402 request gating (payment/request‑gating protocol).
+Deploy any local directory as an MCP knowledge server with indexing, retrieval, and citations, built to maximize use of Mistral models across embedding, OCR, transcription, and generation. Optional layers include ElevenLabs voice output via a dedicated bridge binary and x402 request gating (payment/request-gating protocol).
 
 ## Why dir2mcp
 
@@ -21,13 +21,15 @@ Deploy any local directory as an MCP knowledge server with indexing, retrieval, 
   - STT default: `voxtral-mini-latest`
   - RAG generation: Mistral chat models
 - Single Go binary (`dir2mcp`) with local-first state in `.dir2mcp/`
+- Companion bridge binary (`elevenlabs-bridge`) for ElevenLabs webhook tools
 - MCP Streamable HTTP server with a stable tool surface
 - Multimodal ingestion: text/code, OCR, transcripts, structured annotations
 - Citation-aware retrieval and RAG-style answering
 - Optional facilitator-backed x402 payment gating for `tools/call`
-- Monorepo layout with two binaries:
+- Monorepo layout with three binaries:
   - `dir2mcp`: MCP server and indexing/runtime host
   - `dirstral`: terminal client (Chat/Voice/Start/Stop MCP Server/Settings)
+  - `elevenlabs-bridge`: HTTP helper for ElevenLabs webhook tools
 
 ## Installation
 
@@ -90,6 +92,7 @@ Or build each binary directly:
 
 - `go build -o dir2mcp ./cmd/dir2mcp/`
 - `go build -o dirstral ./cmd/dirstral/`
+- `go build -o elevenlabs-bridge ./cmd/elevenlabs-bridge/`
 
 The server prints its MCP endpoint URL on startup. Point your MCP client at that URL.
 Precedence (highest to lowest): shell environment variables > `.env.local` > `.env`.
@@ -218,7 +221,35 @@ vary by deployment. The commonly used variables are:
 Operational guidance:
 - Do not pass bearer tokens directly on command lines in shared environments.
 - Prefer token files (`--auth file:<path>`) or environment variables.
-- In public mode, do not run `--auth none` unless you intentionally set `--force-insecure`.
+
+### ElevenLabs bridge
+
+`elevenlabs-bridge` is a separate Go helper that forwards ElevenLabs webhook
+calls to a running `dir2mcp` MCP endpoint. It reads its configuration from the
+current environment and falls back to sensible defaults:
+
+| Variable | Required | Description |
+|---|---|---|
+| `MCP_URL` | No | `dir2mcp` MCP endpoint URL. Default: `http://127.0.0.1:8087/mcp` |
+| `MCP_TOKEN` | No | Explicit bearer token for `dir2mcp`. When unset, the bridge tries `$STATE_DIR/secret.token` and otherwise connects without auth |
+| `STATE_DIR` | No | `dir2mcp` state directory used to locate `secret.token` when `MCP_TOKEN` is unset. Default: `.dir2mcp` in the bridge working directory |
+| `PORT` | No | Bridge listen port. Default: `8088` |
+
+Usage:
+
+```bash
+go build -o elevenlabs-bridge ./cmd/elevenlabs-bridge/
+
+# If the bridge runs in the same corpus checkout as dir2mcp, the default
+# STATE_DIR (.dir2mcp relative to the current working directory) usually works.
+MCP_URL="http://127.0.0.1:8087/mcp" \
+STATE_DIR="/path/to/corpus/.dir2mcp" \
+PORT=8088 \
+./elevenlabs-bridge
+```
+
+If your `dir2mcp` server already uses `--auth none`, you can omit `MCP_TOKEN`
+and `STATE_DIR`.
 
 ## Security Defaults
 

--- a/cmd/elevenlabs-bridge/main.go
+++ b/cmd/elevenlabs-bridge/main.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"dir2mcp/internal/elevenlabsbridge"
+)
+
+func main() {
+	os.Exit(run(os.Args[1:]))
+}
+
+func run(args []string) int {
+	defaultCfg, err := elevenlabsbridge.LoadConfigFromOSEnv()
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
+		return 2
+	}
+
+	listenFlag := flag.NewFlagSet("elevenlabs-bridge", flag.ContinueOnError)
+	listenFlag.SetOutput(os.Stderr)
+	mcpURL := listenFlag.String("mcp-url", defaultCfg.MCPURL, "dir2mcp MCP endpoint URL")
+	mcpToken := listenFlag.String("mcp-token", defaultCfg.MCPToken, "dir2mcp bearer token")
+	stateDir := listenFlag.String("state-dir", defaultCfg.StateDir, "dir2mcp state directory")
+	port := listenFlag.Int("port", defaultCfg.Port, "bridge listen port")
+	listenAddr := listenFlag.String("listen", "", "override listen address (host:port)")
+	if err := listenFlag.Parse(args); err != nil {
+		return 2
+	}
+
+	cfg := defaultCfg
+	if strings.TrimSpace(*mcpURL) != "" {
+		cfg.MCPURL = strings.TrimSpace(*mcpURL)
+	}
+	if strings.TrimSpace(*mcpToken) != "" {
+		cfg.MCPToken = strings.TrimSpace(*mcpToken)
+	}
+	if strings.TrimSpace(*stateDir) != "" {
+		cfg.StateDir = strings.TrimSpace(*stateDir)
+	}
+	if *port > 0 {
+		cfg.Port = *port
+	}
+	if cfg.Port < 1 || cfg.Port > 65535 {
+		_, _ = fmt.Fprintf(os.Stderr, "ERROR: invalid port %d\n", cfg.Port)
+		return 2
+	}
+
+	listen := strings.TrimSpace(*listenAddr)
+	if listen == "" {
+		listen = cfg.EffectiveListenAddr()
+	}
+
+	bridge, err := elevenlabsbridge.New(cfg)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
+		return 1
+	}
+
+	_, _ = fmt.Fprintf(os.Stdout, "elevenlabs-bridge: listening on %s\n", listen)
+	_, _ = fmt.Fprintf(os.Stdout, "MCP_URL=%s\n", cfg.MCPURL)
+	_, _ = fmt.Fprintf(os.Stdout, "STATE_DIR=%s\n", cfg.StateDir)
+	_, _ = fmt.Fprintf(os.Stdout, "MCP token source=%s\n", bridge.TokenSource())
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if err := elevenlabsbridge.Run(ctx, cfg, listen); err != nil && ctx.Err() == nil {
+		_, _ = fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
+		return 1
+	}
+	return 0
+}

--- a/internal/elevenlabsbridge/client.go
+++ b/internal/elevenlabsbridge/client.go
@@ -1,0 +1,269 @@
+package elevenlabsbridge
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"dir2mcp/internal/protocol"
+)
+
+const (
+	bridgeProtocolVersion = "2025-11-25"
+	bridgeClientName      = "elevenlabs-bridge"
+	bridgeClientVersion   = "1.0.0"
+)
+
+type rpcRequest struct {
+	JSONRPC string      `json:"jsonrpc"`
+	ID      int64       `json:"id"`
+	Method  string      `json:"method"`
+	Params  interface{} `json:"params,omitempty"`
+}
+
+type rpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      int64           `json:"id"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+}
+
+type rpcError struct {
+	Code    int             `json:"code"`
+	Message string          `json:"message"`
+	Data    json.RawMessage `json:"data,omitempty"`
+}
+
+// HTTPError preserves HTTP status codes returned by the upstream MCP server.
+type HTTPError struct {
+	StatusCode int
+	Body       []byte
+}
+
+func (e *HTTPError) Error() string {
+	if e == nil {
+		return "mcp request failed"
+	}
+	if len(e.Body) == 0 {
+		return fmt.Sprintf("mcp request failed with HTTP %d", e.StatusCode)
+	}
+	return fmt.Sprintf("mcp request failed with HTTP %d: %s", e.StatusCode, strings.TrimSpace(string(e.Body)))
+}
+
+// ToolContentItem mirrors MCP tool call content items.
+type ToolContentItem struct {
+	Type     string `json:"type"`
+	Text     string `json:"text,omitempty"`
+	MIMEType string `json:"mime_type,omitempty"`
+	Data     string `json:"data,omitempty"`
+}
+
+// ToolResult captures the result payload from an MCP tools/call response.
+type ToolResult struct {
+	IsError           bool                   `json:"isError"`
+	Content           []ToolContentItem      `json:"content"`
+	StructuredContent map[string]interface{} `json:"structuredContent"`
+}
+
+// Text returns the first text content item, falling back to structured answer
+// fields when the tool result only exposes structured data.
+func (r ToolResult) Text() string {
+	for _, item := range r.Content {
+		if strings.EqualFold(strings.TrimSpace(item.Type), "text") && strings.TrimSpace(item.Text) != "" {
+			return strings.TrimSpace(item.Text)
+		}
+	}
+	if r.StructuredContent != nil {
+		if answer, ok := r.StructuredContent["answer"].(string); ok && strings.TrimSpace(answer) != "" {
+			return strings.TrimSpace(answer)
+		}
+	}
+	return ""
+}
+
+// Client speaks MCP over HTTP to the dir2mcp server.
+type Client struct {
+	endpoint   string
+	token      string
+	httpClient *http.Client
+
+	mu        sync.Mutex
+	sessionID string
+	nextID    atomic.Int64
+}
+
+// NewClient constructs a bridge client for the supplied MCP endpoint.
+func NewClient(endpoint, token string) *Client {
+	return &Client{
+		endpoint: strings.TrimSpace(endpoint),
+		token:    strings.TrimSpace(token),
+		httpClient: &http.Client{
+			Timeout: 45 * time.Second,
+		},
+	}
+}
+
+func (c *Client) nextRequestID() int64 {
+	return c.nextID.Add(1)
+}
+
+func (c *Client) authHeader() string {
+	if c == nil || strings.TrimSpace(c.token) == "" {
+		return ""
+	}
+	return "Bearer " + c.token
+}
+
+func (c *Client) sessionHeader() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.sessionID
+}
+
+func (c *Client) setSessionHeader(sessionID string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.sessionID = strings.TrimSpace(sessionID)
+}
+
+func (c *Client) clearSession() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.sessionID = ""
+}
+
+func (c *Client) doRPC(ctx context.Context, payload rpcRequest, includeSession bool) (*http.Response, []byte, error) {
+	if strings.TrimSpace(c.endpoint) == "" {
+		return nil, nil, fmt.Errorf("MCP_URL is required")
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal rpc request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, nil, fmt.Errorf("create rpc request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(protocol.MCPProtocolVersionHeader, bridgeProtocolVersion)
+	if auth := c.authHeader(); auth != "" {
+		req.Header.Set("Authorization", auth)
+	}
+	if includeSession {
+		if sessionID := c.sessionHeader(); sessionID != "" {
+			req.Header.Set(protocol.MCPSessionHeader, sessionID)
+		}
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("do rpc request: %w", err)
+	}
+	defer func() {
+		if resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+	}()
+
+	raw, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return resp, nil, fmt.Errorf("read rpc response: %w", readErr)
+	}
+	return resp, raw, nil
+}
+
+func (c *Client) ensureSession(ctx context.Context) error {
+	if strings.TrimSpace(c.sessionHeader()) != "" {
+		return nil
+	}
+
+	resp, body, err := c.doRPC(ctx, rpcRequest{
+		JSONRPC: "2.0",
+		ID:      c.nextRequestID(),
+		Method:  "initialize",
+		Params: map[string]interface{}{
+			"protocolVersion": bridgeProtocolVersion,
+			"capabilities":    map[string]interface{}{},
+			"clientInfo": map[string]interface{}{
+				"name":    bridgeClientName,
+				"version": bridgeClientVersion,
+			},
+		},
+	}, false)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return &HTTPError{StatusCode: resp.StatusCode, Body: body}
+	}
+
+	var envelope rpcResponse
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return fmt.Errorf("decode initialize response: %w", err)
+	}
+	if envelope.Error != nil {
+		return fmt.Errorf("initialize failed: %s", strings.TrimSpace(envelope.Error.Message))
+	}
+
+	sessionID := strings.TrimSpace(resp.Header.Get(protocol.MCPSessionHeader))
+	if sessionID == "" {
+		return fmt.Errorf("initialize response missing %s", protocol.MCPSessionHeader)
+	}
+	c.setSessionHeader(sessionID)
+	return nil
+}
+
+// CallTool invokes an MCP tool and decodes the tool result payload.
+func (c *Client) CallTool(ctx context.Context, name string, arguments map[string]interface{}) (ToolResult, error) {
+	if err := c.ensureSession(ctx); err != nil {
+		return ToolResult{}, err
+	}
+
+	call := rpcRequest{
+		JSONRPC: "2.0",
+		ID:      c.nextRequestID(),
+		Method:  "tools/call",
+		Params: map[string]interface{}{
+			"name":      name,
+			"arguments": arguments,
+		},
+	}
+
+	resp, body, err := c.doRPC(ctx, call, true)
+	if err != nil {
+		return ToolResult{}, err
+	}
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		c.clearSession()
+		return ToolResult{}, &HTTPError{StatusCode: resp.StatusCode, Body: body}
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return ToolResult{}, &HTTPError{StatusCode: resp.StatusCode, Body: body}
+	}
+
+	var envelope rpcResponse
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return ToolResult{}, fmt.Errorf("decode tools/call response: %w", err)
+	}
+	if envelope.Error != nil {
+		return ToolResult{}, fmt.Errorf("tools/call failed: %s", strings.TrimSpace(envelope.Error.Message))
+	}
+	if len(envelope.Result) == 0 {
+		return ToolResult{}, fmt.Errorf("tools/call response missing result")
+	}
+
+	var result ToolResult
+	if err := json.Unmarshal(envelope.Result, &result); err != nil {
+		return ToolResult{}, fmt.Errorf("decode tool result: %w", err)
+	}
+	return result, nil
+}

--- a/internal/elevenlabsbridge/client.go
+++ b/internal/elevenlabsbridge/client.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	bridgeProtocolVersion = "2025-11-25"
+	bridgeProtocolVersion = protocol.ProtocolDefaultVersion
 	bridgeClientName      = "elevenlabs-bridge"
 	bridgeClientVersion   = "1.0.0"
 )

--- a/internal/elevenlabsbridge/client.go
+++ b/internal/elevenlabsbridge/client.go
@@ -95,6 +95,7 @@ type Client struct {
 	httpClient *http.Client
 
 	mu        sync.Mutex
+	initMu    sync.Mutex
 	sessionID string
 	nextID    atomic.Int64
 }
@@ -185,11 +186,17 @@ func (c *Client) ensureSession(ctx context.Context) error {
 	if strings.TrimSpace(c.sessionHeader()) != "" {
 		return nil
 	}
+	// Serialize initialize so concurrent calls don't race on session creation.
+	c.initMu.Lock()
+	defer c.initMu.Unlock()
+	if strings.TrimSpace(c.sessionHeader()) != "" {
+		return nil
+	}
 
 	resp, body, err := c.doRPC(ctx, rpcRequest{
 		JSONRPC: "2.0",
 		ID:      c.nextRequestID(),
-		Method:  "initialize",
+		Method:  protocol.RPCMethodInitialize,
 		Params: map[string]interface{}{
 			"protocolVersion": bridgeProtocolVersion,
 			"capabilities":    map[string]interface{}{},
@@ -231,7 +238,7 @@ func (c *Client) CallTool(ctx context.Context, name string, arguments map[string
 	call := rpcRequest{
 		JSONRPC: "2.0",
 		ID:      c.nextRequestID(),
-		Method:  "tools/call",
+		Method:  protocol.RPCMethodToolsCall,
 		Params: map[string]interface{}{
 			"name":      name,
 			"arguments": arguments,
@@ -242,7 +249,7 @@ func (c *Client) CallTool(ctx context.Context, name string, arguments map[string
 	if err != nil {
 		return ToolResult{}, err
 	}
-	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden || isSessionExpired(resp, body) {
 		c.clearSession()
 		return ToolResult{}, &HTTPError{StatusCode: resp.StatusCode, Body: body}
 	}
@@ -266,4 +273,19 @@ func (c *Client) CallTool(ctx context.Context, name string, arguments map[string
 		return ToolResult{}, fmt.Errorf("decode tool result: %w", err)
 	}
 	return result, nil
+}
+
+func isSessionExpired(resp *http.Response, body []byte) bool {
+	if resp == nil {
+		return false
+	}
+	if strings.EqualFold(strings.TrimSpace(resp.Header.Get(protocol.MCPSessionExpiredHeader)), "true") {
+		return true
+	}
+	if resp.StatusCode != http.StatusNotFound {
+		return false
+	}
+	lower := strings.ToLower(string(body))
+	return strings.Contains(lower, "session not found") ||
+		strings.Contains(lower, strings.ToLower(protocol.ErrorCodeSessionNotFound))
 }

--- a/internal/elevenlabsbridge/config.go
+++ b/internal/elevenlabsbridge/config.go
@@ -1,0 +1,118 @@
+package elevenlabsbridge
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const (
+	DefaultMCPURL       = "http://127.0.0.1:8087/mcp"
+	DefaultPort         = 8088
+	DefaultStateDirName = ".dir2mcp"
+	secretTokenName     = "secret.token"
+)
+
+// Config captures the bridge runtime configuration.
+type Config struct {
+	MCPURL   string
+	MCPToken string
+	StateDir string
+	Port     int
+}
+
+// DefaultConfig returns the bridge defaults used when env vars and flags are
+// unset.
+func DefaultConfig() Config {
+	return Config{
+		MCPURL:   DefaultMCPURL,
+		StateDir: DefaultStateDirName,
+		Port:     DefaultPort,
+	}
+}
+
+// LoadConfigFromEnv resolves the bridge config from environment variables.
+// Explicit MCP_TOKEN takes precedence; STATE_DIR is used to discover
+// <state-dir>/secret.token when MCP_TOKEN is not set.
+func LoadConfigFromEnv(env map[string]string) (Config, error) {
+	cfg := DefaultConfig()
+
+	if v := strings.TrimSpace(env["MCP_URL"]); v != "" {
+		cfg.MCPURL = v
+	}
+	if v := strings.TrimSpace(env["MCP_TOKEN"]); v != "" {
+		cfg.MCPToken = v
+	}
+	if v := strings.TrimSpace(env["STATE_DIR"]); v != "" {
+		cfg.StateDir = v
+	}
+	if v := strings.TrimSpace(env["PORT"]); v != "" {
+		port, err := strconv.Atoi(v)
+		if err != nil || port < 1 || port > 65535 {
+			return Config{}, fmt.Errorf("invalid PORT value %q", v)
+		}
+		cfg.Port = port
+	}
+
+	if cfg.MCPURL == "" {
+		cfg.MCPURL = DefaultMCPURL
+	}
+	if cfg.StateDir == "" {
+		cfg.StateDir = DefaultStateDirName
+	}
+	if cfg.Port == 0 {
+		cfg.Port = DefaultPort
+	}
+
+	return cfg, nil
+}
+
+// LoadConfigFromOSEnv resolves the bridge config from the current process env.
+func LoadConfigFromOSEnv() (Config, error) {
+	return LoadConfigFromEnv(map[string]string{
+		"MCP_URL":   os.Getenv("MCP_URL"),
+		"MCP_TOKEN": os.Getenv("MCP_TOKEN"),
+		"STATE_DIR": os.Getenv("STATE_DIR"),
+		"PORT":      os.Getenv("PORT"),
+	})
+}
+
+// ResolveToken returns the MCP token and its source. When no explicit token or
+// token file is available, the bridge runs without Authorization headers.
+func ResolveToken(cfg Config) (token, source, tokenPath string, err error) {
+	if v := strings.TrimSpace(cfg.MCPToken); v != "" {
+		return v, "env", "", nil
+	}
+
+	stateDir := strings.TrimSpace(cfg.StateDir)
+	if stateDir == "" {
+		stateDir = DefaultStateDirName
+	}
+	tokenPath = filepath.Join(stateDir, secretTokenName)
+
+	content, readErr := os.ReadFile(tokenPath)
+	if readErr != nil {
+		if os.IsNotExist(readErr) {
+			return "", "none", "", nil
+		}
+		return "", "", "", fmt.Errorf("read MCP token file %q: %w", tokenPath, readErr)
+	}
+
+	token = strings.TrimSpace(string(content))
+	if token == "" {
+		return "", "", "", fmt.Errorf("MCP token file %q is empty", tokenPath)
+	}
+
+	if abs, absErr := filepath.Abs(tokenPath); absErr == nil {
+		tokenPath = abs
+	}
+	return token, "file", tokenPath, nil
+}
+
+// EffectiveListenAddr computes the HTTP listen address from the configured
+// port. The bridge intentionally binds to loopback by default.
+func (cfg Config) EffectiveListenAddr() string {
+	return fmt.Sprintf("127.0.0.1:%d", cfg.Port)
+}

--- a/internal/elevenlabsbridge/server.go
+++ b/internal/elevenlabsbridge/server.go
@@ -1,0 +1,263 @@
+package elevenlabsbridge
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const defaultAskK = 3
+
+type bridge struct {
+	cfg         Config
+	client      *Client
+	token       string
+	tokenSource string
+	tokenPath   string
+	mux         *http.ServeMux
+}
+
+// New constructs a bridge with resolved token configuration and HTTP routes.
+func New(cfg Config) (*bridge, error) {
+	token, source, tokenPath, err := ResolveToken(cfg)
+	if err != nil {
+		return nil, err
+	}
+	b := &bridge{
+		cfg:         cfg,
+		client:      NewClient(cfg.MCPURL, token),
+		token:       token,
+		tokenSource: source,
+		tokenPath:   tokenPath,
+		mux:         http.NewServeMux(),
+	}
+	b.routes()
+	return b, nil
+}
+
+// Handler returns the HTTP handler tree for the bridge.
+func (b *bridge) Handler() http.Handler {
+	return b.mux
+}
+
+// TokenSource reports whether the bridge token came from MCP_TOKEN, the state
+// directory token file, or was omitted entirely.
+func (b *bridge) TokenSource() string {
+	if b == nil {
+		return ""
+	}
+	return b.tokenSource
+}
+
+// TokenPath returns the absolute token file path when token file discovery was
+// successful.
+func (b *bridge) TokenPath() string {
+	if b == nil {
+		return ""
+	}
+	return b.tokenPath
+}
+
+// MCPURL returns the configured backend MCP endpoint.
+func (b *bridge) MCPURL() string {
+	if b == nil {
+		return ""
+	}
+	return b.cfg.MCPURL
+}
+
+func (b *bridge) routes() {
+	b.mux.HandleFunc("/health", b.handleHealth)
+	b.mux.HandleFunc("/ask", b.methodGuard(http.MethodPost, b.handleAsk))
+	b.mux.HandleFunc("/search", b.methodGuard(http.MethodPost, b.handleSearch))
+	b.mux.HandleFunc("/list_files", b.methodGuard(http.MethodGet, b.handleListFiles, http.MethodPost))
+	b.mux.HandleFunc("/stats", b.methodGuard(http.MethodGet, b.handleStats, http.MethodPost))
+}
+
+func (b *bridge) methodGuard(allowed string, fn http.HandlerFunc, extra ...string) http.HandlerFunc {
+	allowedMethods := map[string]struct{}{allowed: struct{}{}}
+	for _, method := range extra {
+		allowedMethods[method] = struct{}{}
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		if _, ok := allowedMethods[r.Method]; !ok {
+			writeJSONError(w, http.StatusMethodNotAllowed, fmt.Sprintf("%s not allowed", r.Method))
+			return
+		}
+		fn(w, r)
+	}
+}
+
+func (b *bridge) handleHealth(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+func (b *bridge) handleAsk(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Question string `json:"question"`
+		Query    string `json:"query"`
+		K        int    `json:"k"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	question := strings.TrimSpace(req.Question)
+	if question == "" {
+		question = strings.TrimSpace(req.Query)
+	}
+	if question == "" {
+		writeJSONError(w, http.StatusBadRequest, "question is required")
+		return
+	}
+	k := req.K
+	if k <= 0 {
+		k = defaultAskK
+	}
+
+	result, err := b.client.CallTool(r.Context(), "dir2mcp.ask", map[string]interface{}{
+		"question": question,
+		"k":        k,
+	})
+	if err != nil {
+		b.writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"result":     result.Text(),
+		"structured": result.StructuredContent,
+	})
+}
+
+func (b *bridge) handleSearch(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Query    string `json:"query"`
+		Question string `json:"question"`
+		K        int    `json:"k"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	query := strings.TrimSpace(req.Query)
+	if query == "" {
+		query = strings.TrimSpace(req.Question)
+	}
+	if query == "" {
+		writeJSONError(w, http.StatusBadRequest, "query is required")
+		return
+	}
+	k := req.K
+	if k <= 0 {
+		k = defaultAskK
+	}
+
+	result, err := b.client.CallTool(r.Context(), "dir2mcp.search", map[string]interface{}{
+		"query": query,
+		"k":     k,
+	})
+	if err != nil {
+		b.writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"result":     result.Text(),
+		"structured": result.StructuredContent,
+	})
+}
+
+func (b *bridge) handleListFiles(w http.ResponseWriter, r *http.Request) {
+	result, err := b.client.CallTool(r.Context(), "dir2mcp.list_files", map[string]interface{}{})
+	if err != nil {
+		b.writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"result":     result.Text(),
+		"structured": result.StructuredContent,
+	})
+}
+
+func (b *bridge) handleStats(w http.ResponseWriter, r *http.Request) {
+	result, err := b.client.CallTool(r.Context(), "dir2mcp.stats", map[string]interface{}{})
+	if err != nil {
+		b.writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"result":     result.Text(),
+		"structured": result.StructuredContent,
+	})
+}
+
+func (b *bridge) writeError(w http.ResponseWriter, err error) {
+	var httpErr *HTTPError
+	if errors.As(err, &httpErr) {
+		writeRawHTTPError(w, httpErr)
+		return
+	}
+	writeJSONError(w, http.StatusBadGateway, err.Error())
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func writeJSONError(w http.ResponseWriter, status int, message string) {
+	writeJSON(w, status, map[string]interface{}{
+		"error": map[string]string{
+			"message": message,
+		},
+	})
+}
+
+func writeRawHTTPError(w http.ResponseWriter, err *HTTPError) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(err.StatusCode)
+	if len(err.Body) == 0 {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"error": map[string]interface{}{
+				"message": fmt.Sprintf("upstream MCP returned HTTP %d", err.StatusCode),
+			},
+		})
+		return
+	}
+	_, _ = w.Write(err.Body)
+}
+
+// Run starts the bridge HTTP server and blocks until the context is canceled
+// or the server fails to start.
+func Run(ctx context.Context, cfg Config, listenAddr string) error {
+	b, err := New(cfg)
+	if err != nil {
+		return err
+	}
+	server := &http.Server{
+		Addr:    strings.TrimSpace(listenAddr),
+		Handler: b.Handler(),
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- server.ListenAndServe()
+	}()
+
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = server.Shutdown(shutdownCtx)
+		return ctx.Err()
+	case err := <-errCh:
+		if errors.Is(err, http.ErrServerClosed) {
+			return nil
+		}
+		return err
+	}
+}

--- a/internal/elevenlabsbridge/server.go
+++ b/internal/elevenlabsbridge/server.go
@@ -6,11 +6,15 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
+
+	"dir2mcp/internal/protocol"
 )
 
 const defaultAskK = 3
+const maxBridgeRequestBodyBytes int64 = 1 << 20
 
 type bridge struct {
 	cfg         Config
@@ -83,8 +87,10 @@ func (b *bridge) methodGuard(allowed string, fn http.HandlerFunc, extra ...strin
 	for _, method := range extra {
 		allowedMethods[method] = struct{}{}
 	}
+	allowHeader := buildAllowHeader(allowedMethods)
 	return func(w http.ResponseWriter, r *http.Request) {
 		if _, ok := allowedMethods[r.Method]; !ok {
+			w.Header().Set("Allow", allowHeader)
 			writeJSONError(w, http.StatusMethodNotAllowed, fmt.Sprintf("%s not allowed", r.Method))
 			return
 		}
@@ -97,12 +103,20 @@ func (b *bridge) handleHealth(w http.ResponseWriter, _ *http.Request) {
 }
 
 func (b *bridge) handleAsk(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBridgeRequestBodyBytes)
 	var req struct {
 		Question string `json:"question"`
 		Query    string `json:"query"`
 		K        int    `json:"k"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&req); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			writeJSONError(w, http.StatusRequestEntityTooLarge, "request body too large")
+			return
+		}
 		writeJSONError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
@@ -119,7 +133,7 @@ func (b *bridge) handleAsk(w http.ResponseWriter, r *http.Request) {
 		k = defaultAskK
 	}
 
-	result, err := b.client.CallTool(r.Context(), "dir2mcp.ask", map[string]interface{}{
+	result, err := b.client.CallTool(r.Context(), protocol.ToolNameAsk, map[string]interface{}{
 		"question": question,
 		"k":        k,
 	})
@@ -134,12 +148,20 @@ func (b *bridge) handleAsk(w http.ResponseWriter, r *http.Request) {
 }
 
 func (b *bridge) handleSearch(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBridgeRequestBodyBytes)
 	var req struct {
 		Query    string `json:"query"`
 		Question string `json:"question"`
 		K        int    `json:"k"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&req); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			writeJSONError(w, http.StatusRequestEntityTooLarge, "request body too large")
+			return
+		}
 		writeJSONError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
@@ -156,7 +178,7 @@ func (b *bridge) handleSearch(w http.ResponseWriter, r *http.Request) {
 		k = defaultAskK
 	}
 
-	result, err := b.client.CallTool(r.Context(), "dir2mcp.search", map[string]interface{}{
+	result, err := b.client.CallTool(r.Context(), protocol.ToolNameSearch, map[string]interface{}{
 		"query": query,
 		"k":     k,
 	})
@@ -171,7 +193,7 @@ func (b *bridge) handleSearch(w http.ResponseWriter, r *http.Request) {
 }
 
 func (b *bridge) handleListFiles(w http.ResponseWriter, r *http.Request) {
-	result, err := b.client.CallTool(r.Context(), "dir2mcp.list_files", map[string]interface{}{})
+	result, err := b.client.CallTool(r.Context(), protocol.ToolNameListFiles, map[string]interface{}{})
 	if err != nil {
 		b.writeError(w, err)
 		return
@@ -183,7 +205,7 @@ func (b *bridge) handleListFiles(w http.ResponseWriter, r *http.Request) {
 }
 
 func (b *bridge) handleStats(w http.ResponseWriter, r *http.Request) {
-	result, err := b.client.CallTool(r.Context(), "dir2mcp.stats", map[string]interface{}{})
+	result, err := b.client.CallTool(r.Context(), protocol.ToolNameStats, map[string]interface{}{})
 	if err != nil {
 		b.writeError(w, err)
 		return
@@ -239,8 +261,12 @@ func Run(ctx context.Context, cfg Config, listenAddr string) error {
 		return err
 	}
 	server := &http.Server{
-		Addr:    strings.TrimSpace(listenAddr),
-		Handler: b.Handler(),
+		Addr:              strings.TrimSpace(listenAddr),
+		Handler:           b.Handler(),
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       60 * time.Second,
 	}
 
 	errCh := make(chan error, 1)
@@ -260,4 +286,13 @@ func Run(ctx context.Context, cfg Config, listenAddr string) error {
 		}
 		return err
 	}
+}
+
+func buildAllowHeader(allowedMethods map[string]struct{}) string {
+	methods := make([]string, 0, len(allowedMethods))
+	for method := range allowedMethods {
+		methods = append(methods, method)
+	}
+	sort.Strings(methods)
+	return strings.Join(methods, ", ")
 }

--- a/tests/elevenlabsbridge/bridge_test.go
+++ b/tests/elevenlabsbridge/bridge_test.go
@@ -3,6 +3,7 @@ package elevenlabsbridge_test
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -107,6 +108,7 @@ func TestAskEndpointCallsDir2McpAsk(t *testing.T) {
 		mu       sync.Mutex
 		requests []recordedMCPRequest
 	)
+	handlerErrCh := make(chan error, 4)
 
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var payload struct {
@@ -116,7 +118,9 @@ func TestAskEndpointCallsDir2McpAsk(t *testing.T) {
 			Params  map[string]interface{} `json:"params"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
-			t.Fatalf("decode request: %v", err)
+			handlerErrCh <- fmt.Errorf("decode request: %w", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
 		}
 		rec := recordedMCPRequest{
 			Method:        payload.Method,
@@ -140,12 +144,16 @@ func TestAskEndpointCallsDir2McpAsk(t *testing.T) {
 				rec.K = int(k)
 			}
 			if rec.ToolName != "dir2mcp.ask" {
-				t.Fatalf("tool=%q want dir2mcp.ask", rec.ToolName)
+				handlerErrCh <- fmt.Errorf("tool=%q want dir2mcp.ask", rec.ToolName)
+				w.WriteHeader(http.StatusBadRequest)
+				return
 			}
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":2,"result":{"isError":false,"content":[{"type":"text","text":"bridge answer"}],"structuredContent":{"question":"what is alpha?","answer":"bridge answer","citations":[{"chunk_id":1,"rel_path":"docs/a.md","span":{"kind":"lines","start_line":1,"end_line":2}}],"hits":[],"indexing_complete":true}}}`))
 		default:
-			t.Fatalf("unexpected MCP method %q", payload.Method)
+			handlerErrCh <- fmt.Errorf("unexpected MCP method %q", payload.Method)
+			w.WriteHeader(http.StatusBadRequest)
+			return
 		}
 
 		mu.Lock()
@@ -214,5 +222,68 @@ func TestAskEndpointCallsDir2McpAsk(t *testing.T) {
 	}
 	if requests[1].K != 7 {
 		t.Fatalf("k=%d", requests[1].K)
+	}
+	close(handlerErrCh)
+	for err := range handlerErrCh {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestMethodGuardSetsAllowHeader(t *testing.T) {
+	cfg := elevenlabsbridge.DefaultConfig()
+	cfg.MCPURL = "http://127.0.0.1:1/mcp"
+	cfg.MCPToken = "token"
+
+	bridge, err := elevenlabsbridge.New(cfg)
+	if err != nil {
+		t.Fatalf("new bridge: %v", err)
+	}
+	srv := httptest.NewServer(bridge.Handler())
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodDelete, srv.URL+"/ask", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("status=%d want=%d", resp.StatusCode, http.StatusMethodNotAllowed)
+	}
+	if allow := resp.Header.Get("Allow"); allow != http.MethodPost {
+		t.Fatalf("Allow=%q want=%q", allow, http.MethodPost)
+	}
+}
+
+func TestAskRejectsOversizedBody(t *testing.T) {
+	cfg := elevenlabsbridge.DefaultConfig()
+	cfg.MCPURL = "http://127.0.0.1:1/mcp"
+	cfg.MCPToken = "token"
+
+	bridge, err := elevenlabsbridge.New(cfg)
+	if err != nil {
+		t.Fatalf("new bridge: %v", err)
+	}
+	srv := httptest.NewServer(bridge.Handler())
+	defer srv.Close()
+
+	// 1 MiB max; this body exceeds that limit.
+	oversized := strings.Repeat("a", (1<<20)+64)
+	body := fmt.Sprintf("{\"question\":\"%s\"}", oversized)
+	resp, err := http.Post(srv.URL+"/ask", "application/json", bytes.NewBufferString(body))
+	if err != nil {
+		t.Fatalf("post ask: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d want=%d body=%s", resp.StatusCode, http.StatusRequestEntityTooLarge, raw)
 	}
 }

--- a/tests/elevenlabsbridge/bridge_test.go
+++ b/tests/elevenlabsbridge/bridge_test.go
@@ -1,0 +1,218 @@
+package elevenlabsbridge_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"dir2mcp/internal/elevenlabsbridge"
+	"dir2mcp/tests/testutil"
+)
+
+type recordedMCPRequest struct {
+	Method        string
+	ToolName      string
+	Authorization string
+	SessionID     string
+	Protocol      string
+	K             int
+	Question      string
+}
+
+func TestLoadConfigFromEnvAndTokenResolution(t *testing.T) {
+	t.Run("explicit env token wins", func(t *testing.T) {
+		cfg, err := elevenlabsbridge.LoadConfigFromEnv(map[string]string{
+			"MCP_URL":   "https://example.test/mcp",
+			"MCP_TOKEN": "env-token",
+			"STATE_DIR": "/tmp/ignored",
+			"PORT":      "9090",
+		})
+		if err != nil {
+			t.Fatalf("load config: %v", err)
+		}
+		if cfg.MCPURL != "https://example.test/mcp" {
+			t.Fatalf("MCPURL=%q", cfg.MCPURL)
+		}
+		if cfg.Port != 9090 {
+			t.Fatalf("Port=%d", cfg.Port)
+		}
+
+		token, source, tokenPath, err := elevenlabsbridge.ResolveToken(cfg)
+		if err != nil {
+			t.Fatalf("resolve token: %v", err)
+		}
+		if token != "env-token" || source != "env" || tokenPath != "" {
+			t.Fatalf("unexpected token resolution: token=%q source=%q path=%q", token, source, tokenPath)
+		}
+	})
+
+	t.Run("state dir fallback uses cwd not script path", func(t *testing.T) {
+		tmp := t.TempDir()
+		stateDir := filepath.Join(tmp, ".dir2mcp")
+		if err := os.MkdirAll(stateDir, 0o755); err != nil {
+			t.Fatalf("mkdir state dir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(stateDir, "secret.token"), []byte("file-token\n"), 0o600); err != nil {
+			t.Fatalf("write token: %v", err)
+		}
+
+		testutil.WithWorkingDir(t, tmp, func() {
+			cfg, err := elevenlabsbridge.LoadConfigFromEnv(map[string]string{})
+			if err != nil {
+				t.Fatalf("load config: %v", err)
+			}
+			token, source, tokenPath, err := elevenlabsbridge.ResolveToken(cfg)
+			if err != nil {
+				t.Fatalf("resolve token: %v", err)
+			}
+			if token != "file-token" {
+				t.Fatalf("token=%q", token)
+			}
+			if source != "file" {
+				t.Fatalf("source=%q", source)
+			}
+			if !filepath.IsAbs(tokenPath) {
+				t.Fatalf("expected absolute token path, got %q", tokenPath)
+			}
+		})
+	})
+
+	t.Run("missing token falls back to none", func(t *testing.T) {
+		tmp := t.TempDir()
+		testutil.WithWorkingDir(t, tmp, func() {
+			cfg, err := elevenlabsbridge.LoadConfigFromEnv(map[string]string{})
+			if err != nil {
+				t.Fatalf("load config: %v", err)
+			}
+			token, source, tokenPath, err := elevenlabsbridge.ResolveToken(cfg)
+			if err != nil {
+				t.Fatalf("resolve token: %v", err)
+			}
+			if token != "" || source != "none" || tokenPath != "" {
+				t.Fatalf("unexpected resolution: token=%q source=%q path=%q", token, source, tokenPath)
+			}
+		})
+	})
+}
+
+func TestAskEndpointCallsDir2McpAsk(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		requests []recordedMCPRequest
+	)
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload struct {
+			JSONRPC string                 `json:"jsonrpc"`
+			ID      int64                  `json:"id"`
+			Method  string                 `json:"method"`
+			Params  map[string]interface{} `json:"params"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		rec := recordedMCPRequest{
+			Method:        payload.Method,
+			Authorization: strings.TrimSpace(r.Header.Get("Authorization")),
+			SessionID:     strings.TrimSpace(r.Header.Get("MCP-Session-Id")),
+			Protocol:      strings.TrimSpace(r.Header.Get("MCP-Protocol-Version")),
+		}
+
+		switch payload.Method {
+		case "initialize":
+			w.Header().Set("MCP-Session-Id", "session-123")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"capabilities":{},"serverInfo":{"name":"dir2mcp","version":"test"}}}`))
+		case "tools/call":
+			rec.ToolName, _ = payload.Params["name"].(string)
+			args, _ := payload.Params["arguments"].(map[string]interface{})
+			if q, _ := args["question"].(string); q != "" {
+				rec.Question = q
+			}
+			if k, ok := args["k"].(float64); ok {
+				rec.K = int(k)
+			}
+			if rec.ToolName != "dir2mcp.ask" {
+				t.Fatalf("tool=%q want dir2mcp.ask", rec.ToolName)
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":2,"result":{"isError":false,"content":[{"type":"text","text":"bridge answer"}],"structuredContent":{"question":"what is alpha?","answer":"bridge answer","citations":[{"chunk_id":1,"rel_path":"docs/a.md","span":{"kind":"lines","start_line":1,"end_line":2}}],"hits":[],"indexing_complete":true}}}`))
+		default:
+			t.Fatalf("unexpected MCP method %q", payload.Method)
+		}
+
+		mu.Lock()
+		requests = append(requests, rec)
+		mu.Unlock()
+	}))
+	defer backend.Close()
+
+	cfg := elevenlabsbridge.DefaultConfig()
+	cfg.MCPURL = backend.URL
+	cfg.MCPToken = "bridge-token"
+	cfg.StateDir = t.TempDir()
+
+	bridge, err := elevenlabsbridge.New(cfg)
+	if err != nil {
+		t.Fatalf("new bridge: %v", err)
+	}
+
+	srv := httptest.NewServer(bridge.Handler())
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/ask", "application/json", bytes.NewBufferString(`{"question":"what is alpha?","k":7}`))
+	if err != nil {
+		t.Fatalf("post ask: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+
+	var payload struct {
+		Result     string                 `json:"result"`
+		Structured map[string]interface{} `json:"structured"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode bridge response: %v", err)
+	}
+	if payload.Result != "bridge answer" {
+		t.Fatalf("result=%q", payload.Result)
+	}
+	if payload.Structured["answer"] != "bridge answer" {
+		t.Fatalf("structured answer=%#v", payload.Structured["answer"])
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requests) != 2 {
+		t.Fatalf("unexpected request count: %#v", requests)
+	}
+	if requests[0].Method != "initialize" || requests[1].Method != "tools/call" {
+		t.Fatalf("unexpected method sequence: %#v", requests)
+	}
+	if requests[0].Authorization != "Bearer bridge-token" || requests[1].Authorization != "Bearer bridge-token" {
+		t.Fatalf("expected authorization header to be forwarded: %#v", requests)
+	}
+	if requests[1].SessionID != "session-123" {
+		t.Fatalf("expected session id to be forwarded, got %#v", requests[1].SessionID)
+	}
+	if requests[1].ToolName != "dir2mcp.ask" {
+		t.Fatalf("tool=%q", requests[1].ToolName)
+	}
+	if requests[1].Question != "what is alpha?" {
+		t.Fatalf("question=%q", requests[1].Question)
+	}
+	if requests[1].K != 7 {
+		t.Fatalf("k=%d", requests[1].K)
+	}
+}


### PR DESCRIPTION
## Summary
- add new Go bridge binary at `cmd/elevenlabs-bridge` (net/http)
- route `/ask` through `dir2mcp.ask` via MCP JSON-RPC client code
- add robust bridge config resolution with explicit `MCP_TOKEN` and `STATE_DIR` fallback behavior
- add tests for bridge config and ask-flow behavior
- document bridge env vars/usage in README and `.env.example`
- wire build to include the bridge binary

## Notes
- In this checkout, `demo-corpus/bridge.py` and `rezeptbuch/bridge.py` were not present, so there were no corpus bridge files to remove in this PR.

## Validation
- `go test ./tests/elevenlabsbridge -count=1`
- `go build ./cmd/elevenlabs-bridge`
- `GOCACHE=/tmp/dir2mcp-gocache make check`

Closes #99