### PR TITLE
[#12] cli/bridge: integrate elevenlabs bridge command and connection auto-discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ bin/
 dist/
 /dir2mcp
 /dirstral
+/elevenlabs-bridge
 .gocache/
 .gomodcache/
 .golangci-lint-cache/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ dir2mcp is a single-binary Go service that indexes local directory content and s
 - Pull latest `main` before starting implementation work.
 - Create an issue branch if one does not already exist (e.g. `issue-<number>-<short-slug>`).
 - Keep commits scoped and atomic; use separate commit messages per logical change.
+- Use Conventional Commits for all commit messages: <https://www.conventionalcommits.org/>.
 - Do not mention yourself in commit messages.
 - Include the issue number in the pull request title.
 - Do not push directly to `main`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,5 +121,6 @@ codex mcp add context7 -- npx -y @upstash/context7-mcp
   - `off` = disabled
   - `on` = fail-open on incomplete payment config
   - `required` = strict gating/validation
-- `internal/retrieval/engine.go` `Ask()` is a stub — tracked in #70. Use `retrieval.Service` for retrieval work.
-- `retrieval.Service.Stats()` returns `ErrNotImplemented` — tracked in #71.
+- Retrieval status:
+  - `internal/retrieval/engine.go` `Ask()` is implemented (issue #70 closed).
+  - `retrieval.Service.Stats()` is implemented (issue #71 closed).

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Build binaries. Requires Go 1.24+.
 .PHONY: build build-dir2mcp build-elevenlabs-bridge
-build: build-dir2mcp build-elevenlabs-bridge
+build: build-dir2mcp
 
 DIR2MCP_VERSION ?= 0.0.0-dev
 DIR2MCP_LDFLAGS ?= -X dir2mcp/internal/buildinfo.Version=$(DIR2MCP_VERSION)
@@ -36,6 +36,7 @@ help:
 	@echo "  test   - run go test"
 	@echo "  check  - fmt + vet + lint + cyclo + test + build"
 	@echo "  ci     - vet + cyclo + test (CI-safe default)"
+	@echo "  build-elevenlabs-bridge - build the ElevenLabs webhook bridge binary"
 	@echo "  conformance      - run black-box conformance tests (tests/conformance/)"
 	@echo "  benchmark        - run the large-corpus retrieval benchmark"
 	@echo "  inspector-smoke  - build and run MCP inspector headless smoke test"

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ current environment and falls back to sensible defaults:
 | Variable | Required | Description |
 |---|---|---|
 | `MCP_URL` | No | `dir2mcp` MCP endpoint URL. When unset, the bridge first tries `$STATE_DIR/connection.json`, then falls back to `http://127.0.0.1:8087/mcp` |
-| `MCP_TOKEN` | No | Explicit bearer token for `dir2mcp`. When unset, the bridge tries `$STATE_DIR/secret.token` and otherwise connects without auth |
+| `MCP_TOKEN` | No | Explicit bearer token for `dir2mcp`. When set, overrides all other token sources. When unset, the bridge resolves credentials in order: first checks `connection.json.token_file` (inside `$STATE_DIR/connection.json` written by `dir2mcp` when using `--auth file:<path>`), then `$STATE_DIR/secret.token`, and finally falls back to no-auth if none exist |
 | `STATE_DIR` | No | `dir2mcp` state directory used to locate `connection.json` and token files. Default: `.dir2mcp` in the bridge working directory |
 | `PORT` | No | Bridge listen port. Default: `8088` |
 

--- a/README.md
+++ b/README.md
@@ -230,22 +230,25 @@ current environment and falls back to sensible defaults:
 
 | Variable | Required | Description |
 |---|---|---|
-| `MCP_URL` | No | `dir2mcp` MCP endpoint URL. Default: `http://127.0.0.1:8087/mcp` |
+| `MCP_URL` | No | `dir2mcp` MCP endpoint URL. When unset, the bridge first tries `$STATE_DIR/connection.json`, then falls back to `http://127.0.0.1:8087/mcp` |
 | `MCP_TOKEN` | No | Explicit bearer token for `dir2mcp`. When unset, the bridge tries `$STATE_DIR/secret.token` and otherwise connects without auth |
-| `STATE_DIR` | No | `dir2mcp` state directory used to locate `secret.token` when `MCP_TOKEN` is unset. Default: `.dir2mcp` in the bridge working directory |
+| `STATE_DIR` | No | `dir2mcp` state directory used to locate `connection.json` and token files. Default: `.dir2mcp` in the bridge working directory |
 | `PORT` | No | Bridge listen port. Default: `8088` |
 
 Usage:
 
 ```bash
-go build -o elevenlabs-bridge ./cmd/elevenlabs-bridge/
+dir2mcp bridge elevenlabs
 
-# If the bridge runs in the same corpus checkout as dir2mcp, the default
-# STATE_DIR (.dir2mcp relative to the current working directory) usually works.
-MCP_URL="http://127.0.0.1:8087/mcp" \
+# Override defaults when needed.
+MCP_URL="http://127.0.0.1:8092/mcp" \
 STATE_DIR="/path/to/corpus/.dir2mcp" \
 PORT=8088 \
-./elevenlabs-bridge
+dir2mcp bridge elevenlabs
+
+# Legacy wrapper binary still works and forwards to the same integrated command.
+make build-elevenlabs-bridge
+./elevenlabs-bridge --state-dir /path/to/corpus/.dir2mcp
 ```
 
 If your `dir2mcp` server already uses `--auth none`, you can omit `MCP_TOKEN`
@@ -315,7 +318,8 @@ Core server, ingestion pipeline, retrieval, citations, and x402 gating are imple
 ```bash
 make check        # fmt + vet + lint + cyclo + test + build
 make cyclo        # gocyclo -over 15 ./internal/ (install: go install github.com/fzipp/gocyclo/cmd/gocyclo@v0.6.0)
-make build        # build binary
+make build        # build dir2mcp binary
+make build-elevenlabs-bridge  # build ElevenLabs bridge wrapper binary
 make benchmark    # run retrieval benchmarks
 ```
 

--- a/cmd/elevenlabs-bridge/main.go
+++ b/cmd/elevenlabs-bridge/main.go
@@ -1,79 +1,13 @@
 package main
 
 import (
-	"context"
-	"flag"
-	"fmt"
 	"os"
-	"os/signal"
-	"strings"
-	"syscall"
 
-	"dir2mcp/internal/elevenlabsbridge"
+	"dir2mcp/internal/cli"
 )
 
 func main() {
-	os.Exit(run(os.Args[1:]))
-}
-
-func run(args []string) int {
-	defaultCfg, err := elevenlabsbridge.LoadConfigFromOSEnv()
-	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
-		return 2
-	}
-
-	listenFlag := flag.NewFlagSet("elevenlabs-bridge", flag.ContinueOnError)
-	listenFlag.SetOutput(os.Stderr)
-	mcpURL := listenFlag.String("mcp-url", defaultCfg.MCPURL, "dir2mcp MCP endpoint URL")
-	mcpToken := listenFlag.String("mcp-token", defaultCfg.MCPToken, "dir2mcp bearer token")
-	stateDir := listenFlag.String("state-dir", defaultCfg.StateDir, "dir2mcp state directory")
-	port := listenFlag.Int("port", defaultCfg.Port, "bridge listen port")
-	listenAddr := listenFlag.String("listen", "", "override listen address (host:port)")
-	if err := listenFlag.Parse(args); err != nil {
-		return 2
-	}
-
-	cfg := defaultCfg
-	if strings.TrimSpace(*mcpURL) != "" {
-		cfg.MCPURL = strings.TrimSpace(*mcpURL)
-	}
-	if strings.TrimSpace(*mcpToken) != "" {
-		cfg.MCPToken = strings.TrimSpace(*mcpToken)
-	}
-	if strings.TrimSpace(*stateDir) != "" {
-		cfg.StateDir = strings.TrimSpace(*stateDir)
-	}
-	if *port > 0 {
-		cfg.Port = *port
-	}
-	if cfg.Port < 1 || cfg.Port > 65535 {
-		_, _ = fmt.Fprintf(os.Stderr, "ERROR: invalid port %d\n", cfg.Port)
-		return 2
-	}
-
-	listen := strings.TrimSpace(*listenAddr)
-	if listen == "" {
-		listen = cfg.EffectiveListenAddr()
-	}
-
-	bridge, err := elevenlabsbridge.New(cfg)
-	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
-		return 1
-	}
-
-	_, _ = fmt.Fprintf(os.Stdout, "elevenlabs-bridge: listening on %s\n", listen)
-	_, _ = fmt.Fprintf(os.Stdout, "MCP_URL=%s\n", cfg.MCPURL)
-	_, _ = fmt.Fprintf(os.Stdout, "STATE_DIR=%s\n", cfg.StateDir)
-	_, _ = fmt.Fprintf(os.Stdout, "MCP token source=%s\n", bridge.TokenSource())
-
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
-
-	if err := elevenlabsbridge.Run(ctx, cfg, listen); err != nil && ctx.Err() == nil {
-		_, _ = fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
-		return 1
-	}
-	return 0
+	app := cli.NewApp()
+	// Keep the legacy binary as a thin wrapper over the integrated CLI command.
+	os.Exit(app.Run(append([]string{"bridge", "elevenlabs"}, os.Args[1:]...)))
 }

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -42,7 +42,7 @@ When `x402` mode is enabled, implementations SHOULD align with these references:
 - Network and facilitator support (CAIP-2 identifiers): <https://docs.cdp.coinbase.com/x402/network-support>
 - Bazaar discovery extension model: <https://docs.cdp.coinbase.com/x402/bazaar>
 
-### 0.2 Implementation status notes (March 2026)
+### 0.2 Implementation status notes (April 2026)
 
 Status tags used in this spec:
 
@@ -55,8 +55,8 @@ Current high-level status:
 
 - CLI + MCP server lifecycle, indexing pipeline, and core tool surface: **Implemented**
 - Multimodal ingestion (OCR/transcription/annotation) and retrieval workflows: **Implemented** (with ongoing quality/perf hardening)
-- Retrieval `Stats()` service contract: **Planned** (see issue #71)
-- Advanced retrieval answer quality/completion work: **In progress** (see issue #70)
+- Retrieval `Stats()` service contract: **Implemented** (issue #71 closed)
+- Retrieval answer generation path (`Engine.Ask()` / `AskWithContext`): **Implemented** (issue #70 closed)
 - Native x402 tools/call gating path: **Implemented** (optional and facilitator-backed)
 - Hosted smoke/runbook guidance: **Implemented** (see issue #19)
 - Release-completion checklist hardening: **In progress** (see issue #12)

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -62,6 +62,7 @@ var commands = map[string]struct{}{
 	"status":  {},
 	"ask":     {},
 	"reindex": {},
+	"bridge":  {},
 	"config":  {},
 	"version": {},
 }
@@ -362,6 +363,10 @@ func (a *App) RunWithContext(ctx context.Context, args []string) int {
 		return exitSuccess
 	}
 
+	return a.runCommand(ctx, globalOpts, remaining, jsonRequested)
+}
+
+func (a *App) runCommand(ctx context.Context, globalOpts globalOptions, remaining []string, jsonRequested bool) int {
 	switch remaining[0] {
 	case "up":
 		upOpts, parseErr := parseUpOptions(globalOpts, remaining[1:])
@@ -378,6 +383,8 @@ func (a *App) RunWithContext(ctx context.Context, args []string) int {
 		return a.runReindex(ctx, globalOpts, remaining[1:])
 	case "config":
 		return a.runConfig(ctx, globalOpts, remaining[1:])
+	case "bridge":
+		return a.runBridge(ctx, globalOpts, remaining[1:])
 	case "version":
 		if !globalOpts.quiet {
 			writeln(a.stdout, "dir2mcp v"+strings.TrimPrefix(buildinfo.Version, "v"))
@@ -410,6 +417,7 @@ func (a *App) printUsage() {
 		{"status", "show server health and corpus stats"},
 		{"ask", "query the knowledge base from the CLI"},
 		{"reindex", "force a full re-index of all documents"},
+		{"bridge", "run helper adapters (for example ElevenLabs webhooks)"},
 		{"config", "view or edit configuration"},
 		{"version", "print build version"},
 	}

--- a/internal/cli/bridge.go
+++ b/internal/cli/bridge.go
@@ -60,7 +60,7 @@ func (a *App) runBridgeElevenLabs(ctx context.Context, global globalOptions, arg
 		_, _ = fmt.Fprintf(a.stdout, "MCP token source=%s\n", bridge.TokenSource())
 	}
 
-	if err := elevenlabsbridge.Run(ctx, cfg, listen); err != nil && ctx.Err() == nil {
+	if err := elevenlabsbridge.RunWithBridge(ctx, bridge, listen); err != nil && ctx.Err() == nil {
 		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, err.Error())
 		return exitGeneric
 	}

--- a/internal/cli/bridge.go
+++ b/internal/cli/bridge.go
@@ -1,0 +1,119 @@
+package cli
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"dir2mcp/internal/elevenlabsbridge"
+)
+
+func (a *App) runBridge(ctx context.Context, global globalOptions, args []string) int {
+	if len(args) == 0 {
+		writeln(a.stdout, "bridge command: supported subcommands are elevenlabs")
+		return exitSuccess
+	}
+	switch args[0] {
+	case "elevenlabs":
+		return a.runBridgeElevenLabs(ctx, global, args[1:])
+	default:
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("unknown bridge subcommand: %s", args[0]))
+		return exitConfigInvalid
+	}
+}
+
+func (a *App) runBridgeElevenLabs(ctx context.Context, global globalOptions, args []string) int {
+	defaultCfg, err := loadBridgeDefaultConfig(global)
+	if err != nil {
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, err.Error())
+		return exitConfigInvalid
+	}
+
+	cfg, listen, parseCode := a.parseBridgeElevenLabsFlags(global, defaultCfg, args)
+	if parseCode != exitSuccess {
+		return parseCode
+	}
+
+	bridge, err := elevenlabsbridge.New(cfg)
+	if err != nil {
+		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, err.Error())
+		return exitGeneric
+	}
+
+	if global.jsonOutput {
+		if err := emitJSON(a.stdout, map[string]interface{}{
+			"mode":         "bridge.elevenlabs",
+			"listen":       listen,
+			"mcp_url":      cfg.MCPURL,
+			"state_dir":    cfg.StateDir,
+			"token_source": bridge.TokenSource(),
+		}); err != nil {
+			writeCLIError(a.stderr, true, exitGeneric, fmt.Sprintf("encode bridge json: %v", err))
+			return exitGeneric
+		}
+	} else if !global.quiet {
+		_, _ = fmt.Fprintf(a.stdout, "elevenlabs-bridge: listening on %s\n", listen)
+		_, _ = fmt.Fprintf(a.stdout, "MCP_URL=%s\n", cfg.MCPURL)
+		_, _ = fmt.Fprintf(a.stdout, "STATE_DIR=%s\n", cfg.StateDir)
+		_, _ = fmt.Fprintf(a.stdout, "MCP token source=%s\n", bridge.TokenSource())
+	}
+
+	if err := elevenlabsbridge.Run(ctx, cfg, listen); err != nil && ctx.Err() == nil {
+		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, err.Error())
+		return exitGeneric
+	}
+	return exitSuccess
+}
+
+func loadBridgeDefaultConfig(global globalOptions) (elevenlabsbridge.Config, error) {
+	env := map[string]string{
+		"MCP_URL":   os.Getenv("MCP_URL"),
+		"MCP_TOKEN": os.Getenv("MCP_TOKEN"),
+		"STATE_DIR": os.Getenv("STATE_DIR"),
+		"PORT":      os.Getenv("PORT"),
+	}
+	if v := strings.TrimSpace(global.stateDir); v != "" {
+		env["STATE_DIR"] = v
+	}
+	return elevenlabsbridge.LoadConfigFromEnv(env)
+}
+
+func (a *App) parseBridgeElevenLabsFlags(global globalOptions, defaultCfg elevenlabsbridge.Config, args []string) (cfg elevenlabsbridge.Config, listen string, code int) {
+	fs := flag.NewFlagSet("bridge elevenlabs", flag.ContinueOnError)
+	fs.SetOutput(a.stderr)
+	mcpURL := fs.String("mcp-url", defaultCfg.MCPURL, "dir2mcp MCP endpoint URL")
+	mcpToken := fs.String("mcp-token", defaultCfg.MCPToken, "dir2mcp bearer token")
+	stateDir := fs.String("state-dir", defaultCfg.StateDir, "dir2mcp state directory")
+	port := fs.Int("port", defaultCfg.Port, "bridge listen port")
+	listenAddr := fs.String("listen", "", "override listen address (host:port)")
+	if err := fs.Parse(args); err != nil {
+		return elevenlabsbridge.Config{}, "", exitConfigInvalid
+	}
+	if fs.NArg() > 0 {
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("bridge elevenlabs does not accept positional arguments: %s", strings.Join(fs.Args(), " ")))
+		return elevenlabsbridge.Config{}, "", exitConfigInvalid
+	}
+
+	cfg = defaultCfg
+	cfg.MCPURL = strings.TrimSpace(*mcpURL)
+	cfg.MCPToken = strings.TrimSpace(*mcpToken)
+	cfg.StateDir = strings.TrimSpace(*stateDir)
+	if *port > 0 {
+		cfg.Port = *port
+	}
+	if cfg.Port < 1 || cfg.Port > 65535 {
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("invalid port %d", cfg.Port))
+		return elevenlabsbridge.Config{}, "", exitConfigInvalid
+	}
+	if cfg.StateDir == "" {
+		cfg.StateDir = elevenlabsbridge.DefaultStateDirName
+	}
+
+	listen = strings.TrimSpace(*listenAddr)
+	if listen == "" {
+		listen = cfg.EffectiveListenAddr()
+	}
+	return cfg, listen, exitSuccess
+}

--- a/internal/elevenlabsbridge/config.go
+++ b/internal/elevenlabsbridge/config.go
@@ -1,6 +1,8 @@
 package elevenlabsbridge
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,7 +15,13 @@ const (
 	DefaultPort         = 8088
 	DefaultStateDirName = ".dir2mcp"
 	secretTokenName     = "secret.token"
+	connectionFileName  = "connection.json"
 )
+
+type connectionPayload struct {
+	URL       string `json:"url"`
+	TokenFile string `json:"token_file,omitempty"`
+}
 
 // Config captures the bridge runtime configuration.
 type Config struct {
@@ -39,9 +47,6 @@ func DefaultConfig() Config {
 func LoadConfigFromEnv(env map[string]string) (Config, error) {
 	cfg := DefaultConfig()
 
-	if v := strings.TrimSpace(env["MCP_URL"]); v != "" {
-		cfg.MCPURL = v
-	}
 	if v := strings.TrimSpace(env["MCP_TOKEN"]); v != "" {
 		cfg.MCPToken = v
 	}
@@ -64,6 +69,21 @@ func LoadConfigFromEnv(env map[string]string) (Config, error) {
 	}
 	if cfg.Port == 0 {
 		cfg.Port = DefaultPort
+	}
+
+	if v := strings.TrimSpace(env["MCP_URL"]); v != "" {
+		cfg.MCPURL = v
+		return cfg, nil
+	}
+
+	// Prefer the current dir2mcp connection metadata when available, then
+	// fall back to the static default URL.
+	conn, err := readConnectionPayload(cfg.StateDir)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return Config{}, err
+	}
+	if strings.TrimSpace(conn.URL) != "" {
+		cfg.MCPURL = strings.TrimSpace(conn.URL)
 	}
 
 	return cfg, nil
@@ -90,16 +110,32 @@ func ResolveToken(cfg Config) (token, source, tokenPath string, err error) {
 	if stateDir == "" {
 		stateDir = DefaultStateDirName
 	}
-	tokenPath = filepath.Join(stateDir, secretTokenName)
 
-	content, readErr := os.ReadFile(tokenPath)
-	if readErr != nil {
-		if os.IsNotExist(readErr) {
-			return "", "none", "", nil
-		}
-		return "", "", "", fmt.Errorf("read MCP token file %q: %w", tokenPath, readErr)
+	// If dir2mcp uses --auth file:<path>, connection.json includes token_file.
+	conn, connErr := readConnectionPayload(stateDir)
+	if connErr != nil && !errors.Is(connErr, os.ErrNotExist) {
+		return "", "", "", connErr
+	}
+	if tokenFromConn := strings.TrimSpace(conn.TokenFile); tokenFromConn != "" {
+		return readTokenFromFile(tokenFromConn)
 	}
 
+	tokenPath = filepath.Join(stateDir, secretTokenName)
+	token, source, tokenPath, err = readTokenFromFile(tokenPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", "none", "", nil
+		}
+		return "", "", "", err
+	}
+	return token, source, tokenPath, nil
+}
+
+func readTokenFromFile(tokenPath string) (token, source, absPath string, err error) {
+	content, readErr := os.ReadFile(tokenPath)
+	if readErr != nil {
+		return "", "", "", readErr
+	}
 	token = strings.TrimSpace(string(content))
 	if token == "" {
 		return "", "", "", fmt.Errorf("MCP token file %q is empty", tokenPath)
@@ -115,4 +151,17 @@ func ResolveToken(cfg Config) (token, source, tokenPath string, err error) {
 // port. The bridge intentionally binds to loopback by default.
 func (cfg Config) EffectiveListenAddr() string {
 	return fmt.Sprintf("127.0.0.1:%d", cfg.Port)
+}
+
+func readConnectionPayload(stateDir string) (connectionPayload, error) {
+	path := filepath.Join(stateDir, connectionFileName)
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return connectionPayload{}, err
+	}
+	var payload connectionPayload
+	if err := json.Unmarshal(content, &payload); err != nil {
+		return connectionPayload{}, fmt.Errorf("parse connection file %q: %w", path, err)
+	}
+	return payload, nil
 }

--- a/internal/elevenlabsbridge/config.go
+++ b/internal/elevenlabsbridge/config.go
@@ -41,9 +41,10 @@ func DefaultConfig() Config {
 	}
 }
 
-// LoadConfigFromEnv resolves the bridge config from environment variables.
-// Explicit MCP_TOKEN takes precedence; STATE_DIR is used to discover
-// <state-dir>/secret.token when MCP_TOKEN is not set.
+// LoadConfigFromEnv resolves bridge config from environment variables and
+// state metadata. MCP_URL from env takes precedence; when unset, the bridge
+// falls back to <state-dir>/connection.json URL discovery and then defaults.
+// Token resolution precedence is handled by ResolveToken.
 func LoadConfigFromEnv(env map[string]string) (Config, error) {
 	cfg := DefaultConfig()
 

--- a/internal/elevenlabsbridge/server.go
+++ b/internal/elevenlabsbridge/server.go
@@ -260,6 +260,12 @@ func Run(ctx context.Context, cfg Config, listenAddr string) error {
 	if err != nil {
 		return err
 	}
+	return RunWithBridge(ctx, b, listenAddr)
+}
+
+// RunWithBridge starts the bridge HTTP server with a pre-constructed bridge and
+// blocks until the context is canceled or the server fails to start.
+func RunWithBridge(ctx context.Context, b *bridge, listenAddr string) error {
 	server := &http.Server{
 		Addr:              strings.TrimSpace(listenAddr),
 		Handler:           b.Handler(),

--- a/tests/elevenlabsbridge/bridge_test.go
+++ b/tests/elevenlabsbridge/bridge_test.go
@@ -157,6 +157,30 @@ func TestLoadConfigFromEnvAndTokenResolution(t *testing.T) {
 			t.Fatalf("tokenPath=%q want=%q", tokenPath, customTokenFile)
 		}
 	})
+
+	t.Run("token_file in connection.json errors when file missing", func(t *testing.T) {
+		tmp := t.TempDir()
+		stateDir := filepath.Join(tmp, ".dir2mcp")
+		if err := os.MkdirAll(stateDir, 0o755); err != nil {
+			t.Fatalf("mkdir state dir: %v", err)
+		}
+
+		nonExistentTokenFile := filepath.Join(tmp, "does-not-exist.token")
+		payload := fmt.Sprintf(`{"transport":"mcp_streamable_http","url":"http://127.0.0.1:9099/mcp","token_file":%q}`, nonExistentTokenFile)
+		if err := os.WriteFile(filepath.Join(stateDir, "connection.json"), []byte(payload), 0o644); err != nil {
+			t.Fatalf("write connection.json: %v", err)
+		}
+
+		cfg := elevenlabsbridge.DefaultConfig()
+		cfg.StateDir = stateDir
+		_, _, _, err := elevenlabsbridge.ResolveToken(cfg)
+		if err == nil {
+			t.Fatalf("expected error when token_file references non-existent file, got nil")
+		}
+		if !os.IsNotExist(err) {
+			t.Fatalf("expected IsNotExist error, got %v", err)
+		}
+	})
 }
 
 func TestAskEndpointCallsDir2McpAsk(t *testing.T) {

--- a/tests/elevenlabsbridge/bridge_test.go
+++ b/tests/elevenlabsbridge/bridge_test.go
@@ -101,6 +101,62 @@ func TestLoadConfigFromEnvAndTokenResolution(t *testing.T) {
 			}
 		})
 	})
+
+	t.Run("MCP_URL auto-discovers from connection.json", func(t *testing.T) {
+		tmp := t.TempDir()
+		stateDir := filepath.Join(tmp, ".dir2mcp")
+		if err := os.MkdirAll(stateDir, 0o755); err != nil {
+			t.Fatalf("mkdir state dir: %v", err)
+		}
+		payload := `{"transport":"mcp_streamable_http","url":"http://127.0.0.1:9099/mcp"}`
+		if err := os.WriteFile(filepath.Join(stateDir, "connection.json"), []byte(payload), 0o644); err != nil {
+			t.Fatalf("write connection.json: %v", err)
+		}
+
+		cfg, err := elevenlabsbridge.LoadConfigFromEnv(map[string]string{
+			"STATE_DIR": stateDir,
+		})
+		if err != nil {
+			t.Fatalf("load config: %v", err)
+		}
+		if cfg.MCPURL != "http://127.0.0.1:9099/mcp" {
+			t.Fatalf("MCPURL=%q", cfg.MCPURL)
+		}
+	})
+
+	t.Run("token_file in connection.json takes precedence", func(t *testing.T) {
+		tmp := t.TempDir()
+		stateDir := filepath.Join(tmp, ".dir2mcp")
+		if err := os.MkdirAll(stateDir, 0o755); err != nil {
+			t.Fatalf("mkdir state dir: %v", err)
+		}
+
+		customTokenFile := filepath.Join(tmp, "custom.token")
+		if err := os.WriteFile(customTokenFile, []byte("custom-token\n"), 0o600); err != nil {
+			t.Fatalf("write custom token: %v", err)
+		}
+		// Also create secret.token to verify connection token_file wins.
+		if err := os.WriteFile(filepath.Join(stateDir, "secret.token"), []byte("state-token\n"), 0o600); err != nil {
+			t.Fatalf("write secret token: %v", err)
+		}
+		payload := fmt.Sprintf(`{"transport":"mcp_streamable_http","url":"http://127.0.0.1:9099/mcp","token_file":%q}`, customTokenFile)
+		if err := os.WriteFile(filepath.Join(stateDir, "connection.json"), []byte(payload), 0o644); err != nil {
+			t.Fatalf("write connection.json: %v", err)
+		}
+
+		cfg := elevenlabsbridge.DefaultConfig()
+		cfg.StateDir = stateDir
+		token, source, tokenPath, err := elevenlabsbridge.ResolveToken(cfg)
+		if err != nil {
+			t.Fatalf("resolve token: %v", err)
+		}
+		if token != "custom-token" || source != "file" {
+			t.Fatalf("unexpected token resolution: token=%q source=%q", token, source)
+		}
+		if tokenPath != customTokenFile {
+			t.Fatalf("tokenPath=%q want=%q", tokenPath, customTokenFile)
+		}
+	})
 }
 
 func TestAskEndpointCallsDir2McpAsk(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add integrated bridge command: `dir2mcp bridge elevenlabs`
- Route legacy `elevenlabs-bridge` binary through the integrated CLI path
- Auto-discover bridge MCP target from `.dir2mcp/connection.json` when `MCP_URL` is unset
- Reuse `token_file` from `connection.json` when present, with `secret.token` fallback
- Change `make build` default to build `dir2mcp` only; keep `build-elevenlabs-bridge` explicit
- Update bridge tests and README usage/docs
- Refresh stale AGENTS/SPEC notes for retrieval status (`#70`, `#71`) and ignore local `elevenlabs-bridge` artifact

## Scope
- In scope: CLI bridge integration, bridge config/token discovery behavior, build target behavior, docs/test updates
- Out of scope: MCP tool contract changes, x402 behavior changes, retrieval logic changes

## Validation
- `go test ./internal/cli -count=1`
- `go test ./tests/elevenlabsbridge -count=1`
- `make check`

## Checklist
- [x] Issue number included in PR title (`#12`)
- [x] No direct push to `main`
- [x] Tests/checks pass locally
- [x] README/docs aligned with behavior changes

## Notes
- Untracked local `.claude/` directory remains outside PR scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated the ElevenLabs bridge as a CLI subcommand; legacy invocation still supported.
  * Enhanced credential resolution to check additional state files for MCP URL and token.

* **Documentation**
  * Updated usage examples, README, and implementation status to reflect completed retrieval features.
  * Clarified bridge build/run instructions.

* **Tests**
  * Added tests covering connection.json-driven URL/token resolution.

* **Chores**
  * Bridge binary no longer built by default; added help text for optional build.
* **Ignore**
  * Added bridge path to .gitignore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->