### PR TITLE
feat(cli,mcp,store): add remote CLI tool commands and persist MCP runtime state

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -58,13 +58,16 @@ const (
 )
 
 var commands = map[string]struct{}{
-	"up":      {},
-	"status":  {},
-	"ask":     {},
-	"reindex": {},
-	"bridge":  {},
-	"config":  {},
-	"version": {},
+	"up":         {},
+	"status":     {},
+	"ask":        {},
+	"search":     {},
+	"open-file":  {},
+	"list-files": {},
+	"reindex":    {},
+	"bridge":     {},
+	"config":     {},
+	"version":    {},
 }
 
 type App struct {
@@ -383,6 +386,12 @@ func (a *App) runCommand(ctx context.Context, globalOpts globalOptions, remainin
 		return a.runStatus(ctx, globalOpts, remaining[1:])
 	case "ask":
 		return a.runAsk(ctx, globalOpts, remaining[1:])
+	case "search":
+		return a.runSearchRemote(ctx, globalOpts, remaining[1:])
+	case "open-file":
+		return a.runOpenFileRemote(ctx, globalOpts, remaining[1:])
+	case "list-files":
+		return a.runListFilesRemote(ctx, globalOpts, remaining[1:])
 	case "reindex":
 		return a.runReindex(ctx, globalOpts, remaining[1:])
 	case "config":
@@ -420,6 +429,9 @@ func (a *App) printUsage() {
 		{"up", "start the MCP server and begin indexing"},
 		{"status", "show server health and corpus stats"},
 		{"ask", "query the knowledge base from the CLI"},
+		{"search", "query a running server and emit NDJSON"},
+		{"open-file", "open file content from a running server"},
+		{"list-files", "stream indexed files from a running server"},
 		{"reindex", "force a full re-index of all documents"},
 		{"bridge", "run helper adapters (for example ElevenLabs webhooks)"},
 		{"config", "view or edit configuration"},

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -374,7 +374,12 @@ func (a *App) RunWithContext(ctx context.Context, args []string) int {
 }
 
 func (a *App) runCommand(ctx context.Context, globalOpts globalOptions, remaining []string, jsonRequested bool) int {
-	switch remaining[0] {
+	command := remaining[0]
+	if code, handled := a.runSimpleCommand(ctx, globalOpts, command, remaining[1:]); handled {
+		return code
+	}
+
+	switch command {
 	case "up":
 		upOpts, parseErr := parseUpOptions(globalOpts, remaining[1:])
 		if parseErr != nil {
@@ -382,22 +387,6 @@ func (a *App) runCommand(ctx context.Context, globalOpts globalOptions, remainin
 			return exitConfigInvalid
 		}
 		return a.runUp(ctx, upOpts)
-	case "status":
-		return a.runStatus(ctx, globalOpts, remaining[1:])
-	case "ask":
-		return a.runAsk(ctx, globalOpts, remaining[1:])
-	case "search":
-		return a.runSearchRemote(ctx, globalOpts, remaining[1:])
-	case "open-file":
-		return a.runOpenFileRemote(ctx, globalOpts, remaining[1:])
-	case "list-files":
-		return a.runListFilesRemote(ctx, globalOpts, remaining[1:])
-	case "reindex":
-		return a.runReindex(ctx, globalOpts, remaining[1:])
-	case "config":
-		return a.runConfig(ctx, globalOpts, remaining[1:])
-	case "bridge":
-		return a.runBridge(ctx, globalOpts, remaining[1:])
 	case "version":
 		if !globalOpts.quiet {
 			writeln(a.stdout, "dir2mcp v"+strings.TrimPrefix(buildinfo.Version, "v"))
@@ -410,6 +399,29 @@ func (a *App) runCommand(ctx context.Context, globalOpts globalOptions, remainin
 			a.printUsage()
 		}
 		return exitGeneric
+	}
+}
+
+func (a *App) runSimpleCommand(ctx context.Context, globalOpts globalOptions, command string, args []string) (int, bool) {
+	switch command {
+	case "status":
+		return a.runStatus(ctx, globalOpts, args), true
+	case "ask":
+		return a.runAsk(ctx, globalOpts, args), true
+	case "search":
+		return a.runSearchRemote(ctx, globalOpts, args), true
+	case "open-file":
+		return a.runOpenFileRemote(ctx, globalOpts, args), true
+	case "list-files":
+		return a.runListFilesRemote(ctx, globalOpts, args), true
+	case "reindex":
+		return a.runReindex(ctx, globalOpts, args), true
+	case "config":
+		return a.runConfig(ctx, globalOpts, args), true
+	case "bridge":
+		return a.runBridge(ctx, globalOpts, args), true
+	default:
+		return 0, false
 	}
 }
 

--- a/internal/cli/ask.go
+++ b/internal/cli/ask.go
@@ -22,7 +22,12 @@ func (a *App) runAsk(ctx context.Context, global globalOptions, args []string) i
 	if remoteErr == nil {
 		return a.runAskRemote(ctx, global, opts, remoteClient)
 	}
-	if remoteErr != nil && !errors.Is(remoteErr, os.ErrNotExist) {
+	// Only fall back to local if the connection.json file specifically is missing
+	if remoteErr != nil {
+		var pathErr *os.PathError
+		if errors.As(remoteErr, &pathErr) && errors.Is(pathErr.Err, os.ErrNotExist) && filepath.Base(pathErr.Path) == connectionFileName {
+			return a.runAskLocal(ctx, global, opts)
+		}
 		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("resolve server connection: %v", remoteErr))
 		return exitGeneric
 	}

--- a/internal/cli/ask.go
+++ b/internal/cli/ask.go
@@ -18,6 +18,15 @@ func (a *App) runAsk(ctx context.Context, global globalOptions, args []string) i
 		return exitConfigInvalid
 	}
 
+	remoteClient, remoteErr := a.remoteToolClient(global)
+	if remoteErr == nil {
+		return a.runAskRemote(ctx, global, opts, remoteClient)
+	}
+	if remoteErr != nil && !errors.Is(remoteErr, os.ErrNotExist) {
+		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("resolve server connection: %v", remoteErr))
+		return exitGeneric
+	}
+
 	cfg, err := loadConfigWithGlobalOptions(global)
 	if err != nil {
 		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("load config: %v", err))

--- a/internal/cli/ask.go
+++ b/internal/cli/ask.go
@@ -26,7 +26,10 @@ func (a *App) runAsk(ctx context.Context, global globalOptions, args []string) i
 		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("resolve server connection: %v", remoteErr))
 		return exitGeneric
 	}
+	return a.runAskLocal(ctx, global, opts)
+}
 
+func (a *App) runAskLocal(ctx context.Context, global globalOptions, opts askOptions) int {
 	cfg, err := loadConfigWithGlobalOptions(global)
 	if err != nil {
 		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("load config: %v", err))
@@ -60,7 +63,6 @@ func (a *App) runAsk(ctx context.Context, global globalOptions, args []string) i
 		}
 		return exitConfigInvalid
 	}
-
 	st := a.storeForConfig(cfg)
 	defer func() { _ = st.Close() }()
 	if err := st.Init(ctx); err != nil && !errors.Is(err, model.ErrNotImplemented) {

--- a/internal/cli/remote_commands.go
+++ b/internal/cli/remote_commands.go
@@ -1,0 +1,467 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"dir2mcp/internal/protocol"
+)
+
+type remoteConnection struct {
+	URL       string            `json:"url"`
+	Headers   map[string]string `json:"headers"`
+	TokenFile string            `json:"token_file,omitempty"`
+}
+
+type rpcRequest struct {
+	JSONRPC string      `json:"jsonrpc"`
+	ID      int64       `json:"id"`
+	Method  string      `json:"method"`
+	Params  interface{} `json:"params,omitempty"`
+}
+
+type rpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      int64           `json:"id"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type mcpToolCallResult struct {
+	IsError           bool                   `json:"isError"`
+	StructuredContent map[string]interface{} `json:"structuredContent"`
+}
+
+type remoteMCPClient struct {
+	endpoint   string
+	authHeader string
+	httpClient *http.Client
+
+	mu        sync.Mutex
+	initMu    sync.Mutex
+	sessionID string
+	nextID    atomic.Int64
+}
+
+func newRemoteMCPClient(endpoint, authHeader string) *remoteMCPClient {
+	return &remoteMCPClient{
+		endpoint:   strings.TrimSpace(endpoint),
+		authHeader: strings.TrimSpace(authHeader),
+		httpClient: &http.Client{Timeout: 45 * time.Second},
+	}
+}
+
+func (c *remoteMCPClient) nextRequestID() int64 { return c.nextID.Add(1) }
+
+func (c *remoteMCPClient) getSessionID() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.sessionID
+}
+
+func (c *remoteMCPClient) setSessionID(sessionID string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.sessionID = strings.TrimSpace(sessionID)
+}
+
+func (c *remoteMCPClient) doRPC(ctx context.Context, reqBody rpcRequest, includeSession bool) (*http.Response, []byte, error) {
+	if strings.TrimSpace(c.endpoint) == "" {
+		return nil, nil, errors.New("connection url is empty")
+	}
+
+	raw, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal rpc request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, bytes.NewReader(raw))
+	if err != nil {
+		return nil, nil, fmt.Errorf("create rpc request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(protocol.MCPProtocolVersionHeader, protocol.ProtocolDefaultVersion)
+	if c.authHeader != "" {
+		req.Header.Set("Authorization", c.authHeader)
+	}
+	if includeSession {
+		if sid := c.getSessionID(); sid != "" {
+			req.Header.Set(protocol.MCPSessionHeader, sid)
+		}
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return resp, nil, fmt.Errorf("read response: %w", err)
+	}
+	return resp, body, nil
+}
+
+func (c *remoteMCPClient) ensureSession(ctx context.Context) error {
+	if c.getSessionID() != "" {
+		return nil
+	}
+	c.initMu.Lock()
+	defer c.initMu.Unlock()
+	if c.getSessionID() != "" {
+		return nil
+	}
+
+	resp, body, err := c.doRPC(ctx, rpcRequest{
+		JSONRPC: "2.0",
+		ID:      c.nextRequestID(),
+		Method:  protocol.RPCMethodInitialize,
+		Params: map[string]interface{}{
+			"protocolVersion": protocol.ProtocolDefaultVersion,
+			"capabilities":    map[string]interface{}{},
+			"clientInfo": map[string]interface{}{
+				"name":    "dir2mcp-cli",
+				"version": "1.0.0",
+			},
+		},
+	}, false)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("initialize failed with HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var envelope rpcResponse
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return fmt.Errorf("decode initialize response: %w", err)
+	}
+	if envelope.Error != nil {
+		return fmt.Errorf("initialize failed: %s", strings.TrimSpace(envelope.Error.Message))
+	}
+
+	sid := strings.TrimSpace(resp.Header.Get(protocol.MCPSessionHeader))
+	if sid == "" {
+		return fmt.Errorf("initialize response missing %s", protocol.MCPSessionHeader)
+	}
+	c.setSessionID(sid)
+	return nil
+}
+
+func (c *remoteMCPClient) CallTool(ctx context.Context, name string, arguments map[string]interface{}) (map[string]interface{}, error) {
+	if err := c.ensureSession(ctx); err != nil {
+		return nil, err
+	}
+
+	resp, body, err := c.doRPC(ctx, rpcRequest{
+		JSONRPC: "2.0",
+		ID:      c.nextRequestID(),
+		Method:  protocol.RPCMethodToolsCall,
+		Params: map[string]interface{}{
+			"name":      name,
+			"arguments": arguments,
+		},
+	}, true)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("tools/call failed with HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var envelope rpcResponse
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return nil, fmt.Errorf("decode tools/call response: %w", err)
+	}
+	if envelope.Error != nil {
+		return nil, fmt.Errorf("tools/call failed: %s", strings.TrimSpace(envelope.Error.Message))
+	}
+	if len(envelope.Result) == 0 {
+		return nil, errors.New("tools/call response missing result")
+	}
+
+	var result mcpToolCallResult
+	if err := json.Unmarshal(envelope.Result, &result); err != nil {
+		return nil, fmt.Errorf("decode tool result: %w", err)
+	}
+	if result.IsError {
+		errBody := "tool returned error"
+		if result.StructuredContent != nil {
+			if errorNode, ok := result.StructuredContent["error"].(map[string]interface{}); ok {
+				if msg, ok := errorNode["message"].(string); ok && strings.TrimSpace(msg) != "" {
+					errBody = strings.TrimSpace(msg)
+				}
+				if code, ok := errorNode["code"].(string); ok && strings.TrimSpace(code) != "" {
+					errBody = strings.TrimSpace(code) + ": " + errBody
+				}
+			}
+		}
+		return nil, errors.New(errBody)
+	}
+	if result.StructuredContent == nil {
+		return nil, errors.New("tool response missing structuredContent")
+	}
+	return result.StructuredContent, nil
+}
+
+func resolveRemoteConnection(global globalOptions) (remoteConnection, error) {
+	cfg, err := loadConfigWithGlobalOptions(global)
+	if err != nil {
+		return remoteConnection{}, fmt.Errorf("load config: %w", err)
+	}
+	path := filepath.Join(cfg.StateDir, connectionFileName)
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return remoteConnection{}, fmt.Errorf("read %s: %w", path, err)
+	}
+	var conn remoteConnection
+	if err := json.Unmarshal(raw, &conn); err != nil {
+		return remoteConnection{}, fmt.Errorf("parse %s: %w", path, err)
+	}
+	conn.URL = strings.TrimSpace(conn.URL)
+	if conn.URL == "" {
+		return remoteConnection{}, fmt.Errorf("%s is missing url", path)
+	}
+	if conn.Headers == nil {
+		conn.Headers = map[string]string{}
+	}
+	if conn.TokenFile != "" {
+		conn.TokenFile = strings.TrimSpace(conn.TokenFile)
+	}
+	return conn, nil
+}
+
+func authHeaderFromConnection(conn remoteConnection) (string, error) {
+	auth := strings.TrimSpace(conn.Headers["Authorization"])
+	if auth != "" && !strings.Contains(auth, "<") {
+		return auth, nil
+	}
+	if conn.TokenFile == "" {
+		return "", nil
+	}
+	tokenRaw, err := os.ReadFile(conn.TokenFile)
+	if err != nil {
+		return "", fmt.Errorf("read token file %s: %w", conn.TokenFile, err)
+	}
+	token := strings.TrimSpace(string(tokenRaw))
+	if token == "" {
+		return "", fmt.Errorf("token file %s is empty", conn.TokenFile)
+	}
+	return "Bearer " + token, nil
+}
+
+func (a *App) remoteToolClient(global globalOptions) (*remoteMCPClient, error) {
+	conn, err := resolveRemoteConnection(global)
+	if err != nil {
+		return nil, err
+	}
+	authHeader, err := authHeaderFromConnection(conn)
+	if err != nil {
+		return nil, err
+	}
+	return newRemoteMCPClient(conn.URL, authHeader), nil
+}
+
+func (a *App) runSearchRemote(ctx context.Context, global globalOptions, args []string) int {
+	opts, err := parseAskOptions(args)
+	if err != nil {
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("invalid search flags: %v", err))
+		return exitConfigInvalid
+	}
+
+	client, err := a.remoteToolClient(global)
+	if err != nil {
+		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("resolve server connection: %v", err))
+		return exitGeneric
+	}
+
+	payload, err := client.CallTool(ctx, protocol.ToolNameSearch, map[string]interface{}{
+		"query":       opts.question,
+		"k":           opts.k,
+		"index":       opts.index,
+		"path_prefix": opts.pathPrefix,
+		"file_glob":   opts.fileGlob,
+		"doc_types":   opts.docTypes,
+	})
+	if err != nil {
+		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("search failed: %v", err))
+		return exitGeneric
+	}
+	if err := emitJSON(a.stdout, payload); err != nil {
+		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("encode search json: %v", err))
+		return exitGeneric
+	}
+	return exitSuccess
+}
+
+type openFileOptions struct {
+	relPath   string
+	startLine int
+	endLine   int
+	page      int
+	startMS   int
+	endMS     int
+	maxChars  int
+}
+
+func parseOpenFileOptions(args []string) (openFileOptions, error) {
+	opts := openFileOptions{maxChars: 20000}
+	fs := flag.NewFlagSet("open-file", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	fs.IntVar(&opts.startLine, "start-line", 0, "start line")
+	fs.IntVar(&opts.endLine, "end-line", 0, "end line")
+	fs.IntVar(&opts.page, "page", 0, "page")
+	fs.IntVar(&opts.startMS, "start-ms", 0, "start ms")
+	fs.IntVar(&opts.endMS, "end-ms", 0, "end ms")
+	fs.IntVar(&opts.maxChars, "max-chars", opts.maxChars, "max chars")
+	if err := fs.Parse(args); err != nil {
+		return openFileOptions{}, err
+	}
+	if fs.NArg() != 1 {
+		return openFileOptions{}, errors.New("open-file command requires exactly one <rel-path> argument")
+	}
+	opts.relPath = strings.TrimSpace(fs.Arg(0))
+	if opts.relPath == "" {
+		return openFileOptions{}, errors.New("open-file path cannot be empty")
+	}
+	return opts, nil
+}
+
+func (a *App) runOpenFileRemote(ctx context.Context, global globalOptions, args []string) int {
+	opts, err := parseOpenFileOptions(args)
+	if err != nil {
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("invalid open-file flags: %v", err))
+		return exitConfigInvalid
+	}
+
+	client, err := a.remoteToolClient(global)
+	if err != nil {
+		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("resolve server connection: %v", err))
+		return exitGeneric
+	}
+
+	toolArgs := map[string]interface{}{
+		"rel_path":  opts.relPath,
+		"max_chars": opts.maxChars,
+	}
+	if opts.startLine > 0 {
+		toolArgs["start_line"] = opts.startLine
+	}
+	if opts.endLine > 0 {
+		toolArgs["end_line"] = opts.endLine
+	}
+	if opts.page > 0 {
+		toolArgs["page"] = opts.page
+	}
+	if opts.startMS > 0 {
+		toolArgs["start_ms"] = opts.startMS
+	}
+	if opts.endMS > 0 {
+		toolArgs["end_ms"] = opts.endMS
+	}
+
+	payload, err := client.CallTool(ctx, protocol.ToolNameOpenFile, toolArgs)
+	if err != nil {
+		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("open-file failed: %v", err))
+		return exitGeneric
+	}
+	if err := emitJSON(a.stdout, payload); err != nil {
+		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("encode open-file json: %v", err))
+		return exitGeneric
+	}
+	return exitSuccess
+}
+
+type listFilesOptions struct {
+	pathPrefix    string
+	glob          string
+	limit         int
+	offset        int
+	includeHidden bool
+}
+
+func parseListFilesOptions(args []string) (listFilesOptions, error) {
+	opts := listFilesOptions{limit: 200}
+	fs := flag.NewFlagSet("list-files", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	fs.StringVar(&opts.pathPrefix, "path-prefix", "", "path prefix")
+	fs.StringVar(&opts.glob, "glob", "", "glob")
+	fs.IntVar(&opts.limit, "limit", opts.limit, "limit")
+	fs.IntVar(&opts.offset, "offset", 0, "offset")
+	fs.BoolVar(&opts.includeHidden, "include-hidden", false, "include hidden files")
+	if err := fs.Parse(args); err != nil {
+		return listFilesOptions{}, err
+	}
+	if fs.NArg() != 0 {
+		return listFilesOptions{}, fmt.Errorf("list-files does not accept positional arguments: %s", strings.Join(fs.Args(), " "))
+	}
+	if opts.limit < 1 || opts.limit > 5000 {
+		return listFilesOptions{}, errors.New("limit must be between 1 and 5000")
+	}
+	if opts.offset < 0 {
+		return listFilesOptions{}, errors.New("offset must be >= 0")
+	}
+	return opts, nil
+}
+
+func (a *App) runListFilesRemote(ctx context.Context, global globalOptions, args []string) int {
+	opts, err := parseListFilesOptions(args)
+	if err != nil {
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("invalid list-files flags: %v", err))
+		return exitConfigInvalid
+	}
+
+	client, err := a.remoteToolClient(global)
+	if err != nil {
+		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("resolve server connection: %v", err))
+		return exitGeneric
+	}
+
+	payload, err := client.CallTool(ctx, protocol.ToolNameListFiles, map[string]interface{}{
+		"path_prefix":    opts.pathPrefix,
+		"glob":           opts.glob,
+		"limit":          opts.limit,
+		"offset":         opts.offset,
+		"include_hidden": opts.includeHidden,
+	})
+	if err != nil {
+		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("list-files failed: %v", err))
+		return exitGeneric
+	}
+
+	filesRaw, ok := payload["files"].([]interface{})
+	if !ok {
+		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, "list-files response missing files array")
+		return exitGeneric
+	}
+	for i, raw := range filesRaw {
+		fileObj, ok := raw.(map[string]interface{})
+		if !ok {
+			writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("list-files response has invalid file object at index %d", i))
+			return exitGeneric
+		}
+		if err := emitJSON(a.stdout, fileObj); err != nil {
+			writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("encode list-files ndjson: %v", err))
+			return exitGeneric
+		}
+	}
+	return exitSuccess
+}

--- a/internal/cli/remote_commands.go
+++ b/internal/cli/remote_commands.go
@@ -207,39 +207,54 @@ func (c *remoteMCPClient) CallTool(ctx context.Context, name string, arguments m
 		return nil, fmt.Errorf("tools/call failed with HTTP %d: %s", resp.StatusCode, rpcErrorSummary(body))
 	}
 
-	var envelope rpcResponse
-	if err := json.Unmarshal(body, &envelope); err != nil {
-		return nil, fmt.Errorf("decode tools/call response: %w", err)
-	}
-	if envelope.Error != nil {
-		return nil, fmt.Errorf("tools/call failed: %s", strings.TrimSpace(envelope.Error.Message))
-	}
-	if len(envelope.Result) == 0 {
-		return nil, errors.New("tools/call response missing result")
-	}
-
-	var result mcpToolCallResult
-	if err := json.Unmarshal(envelope.Result, &result); err != nil {
-		return nil, fmt.Errorf("decode tool result: %w", err)
+	result, err := decodeToolCallResult(body)
+	if err != nil {
+		return nil, err
 	}
 	if result.IsError {
-		errBody := "tool returned error"
-		if result.StructuredContent != nil {
-			if errorNode, ok := result.StructuredContent["error"].(map[string]interface{}); ok {
-				if msg, ok := errorNode["message"].(string); ok && strings.TrimSpace(msg) != "" {
-					errBody = strings.TrimSpace(msg)
-				}
-				if code, ok := errorNode["code"].(string); ok && strings.TrimSpace(code) != "" {
-					errBody = strings.TrimSpace(code) + ": " + errBody
-				}
-			}
-		}
-		return nil, errors.New(errBody)
+		return nil, errors.New(toolCallErrorMessage(result.StructuredContent))
 	}
 	if result.StructuredContent == nil {
 		return nil, errors.New("tool response missing structuredContent")
 	}
 	return result.StructuredContent, nil
+}
+
+func decodeToolCallResult(body []byte) (mcpToolCallResult, error) {
+	var envelope rpcResponse
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return mcpToolCallResult{}, fmt.Errorf("decode tools/call response: %w", err)
+	}
+	if envelope.Error != nil {
+		return mcpToolCallResult{}, fmt.Errorf("tools/call failed: %s", strings.TrimSpace(envelope.Error.Message))
+	}
+	if len(envelope.Result) == 0 {
+		return mcpToolCallResult{}, errors.New("tools/call response missing result")
+	}
+
+	var result mcpToolCallResult
+	if err := json.Unmarshal(envelope.Result, &result); err != nil {
+		return mcpToolCallResult{}, fmt.Errorf("decode tool result: %w", err)
+	}
+	return result, nil
+}
+
+func toolCallErrorMessage(structured map[string]interface{}) string {
+	errBody := "tool returned error"
+	if structured == nil {
+		return errBody
+	}
+	errorNode, ok := structured["error"].(map[string]interface{})
+	if !ok {
+		return errBody
+	}
+	if msg, ok := errorNode["message"].(string); ok && strings.TrimSpace(msg) != "" {
+		errBody = strings.TrimSpace(msg)
+	}
+	if code, ok := errorNode["code"].(string); ok && strings.TrimSpace(code) != "" {
+		errBody = strings.TrimSpace(code) + ": " + errBody
+	}
+	return errBody
 }
 
 func resolveRemoteConnection(global globalOptions) (remoteConnection, error) {

--- a/internal/cli/remote_commands.go
+++ b/internal/cli/remote_commands.go
@@ -52,6 +52,7 @@ type mcpToolCallResult struct {
 type remoteMCPClient struct {
 	endpoint   string
 	authHeader string
+	connection remoteConnection
 	httpClient *http.Client
 
 	mu        sync.Mutex
@@ -60,15 +61,24 @@ type remoteMCPClient struct {
 	nextID    atomic.Int64
 }
 
-func newRemoteMCPClient(endpoint, authHeader string) *remoteMCPClient {
+func newRemoteMCPClient(endpoint, authHeader string, connection remoteConnection) *remoteMCPClient {
 	return &remoteMCPClient{
 		endpoint:   strings.TrimSpace(endpoint),
 		authHeader: strings.TrimSpace(authHeader),
+		connection: connection,
 		httpClient: &http.Client{Timeout: 45 * time.Second},
 	}
 }
 
 func (c *remoteMCPClient) nextRequestID() int64 { return c.nextID.Add(1) }
+
+func rpcErrorSummary(body []byte) string {
+	var envelope rpcResponse
+	if err := json.Unmarshal(body, &envelope); err == nil && envelope.Error != nil && strings.TrimSpace(envelope.Error.Message) != "" {
+		return strings.TrimSpace(envelope.Error.Message)
+	}
+	return "upstream request failed"
+}
 
 func (c *remoteMCPClient) getSessionID() string {
 	c.mu.Lock()
@@ -96,8 +106,18 @@ func (c *remoteMCPClient) doRPC(ctx context.Context, reqBody rpcRequest, include
 	if err != nil {
 		return nil, nil, fmt.Errorf("create rpc request: %w", err)
 	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set(protocol.MCPProtocolVersionHeader, protocol.ProtocolDefaultVersion)
+	// Apply persisted connection headers first
+	for key, value := range c.connection.Headers {
+		req.Header.Set(key, value)
+	}
+	// Set default headers if not already present
+	if req.Header.Get("Content-Type") == "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if req.Header.Get(protocol.MCPProtocolVersionHeader) == "" {
+		req.Header.Set(protocol.MCPProtocolVersionHeader, protocol.ProtocolDefaultVersion)
+	}
+	// Override with auth header if provided (takes precedence)
 	if c.authHeader != "" {
 		req.Header.Set("Authorization", c.authHeader)
 	}
@@ -147,7 +167,7 @@ func (c *remoteMCPClient) ensureSession(ctx context.Context) error {
 		return err
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("initialize failed with HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		return fmt.Errorf("initialize failed with HTTP %d: %s", resp.StatusCode, rpcErrorSummary(body))
 	}
 
 	var envelope rpcResponse
@@ -184,7 +204,7 @@ func (c *remoteMCPClient) CallTool(ctx context.Context, name string, arguments m
 		return nil, err
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("tools/call failed with HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		return nil, fmt.Errorf("tools/call failed with HTTP %d: %s", resp.StatusCode, rpcErrorSummary(body))
 	}
 
 	var envelope rpcResponse
@@ -277,7 +297,7 @@ func (a *App) remoteToolClient(global globalOptions) (*remoteMCPClient, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newRemoteMCPClient(conn.URL, authHeader), nil
+	return newRemoteMCPClient(conn.URL, authHeader, conn), nil
 }
 
 func (a *App) runSearchRemote(ctx context.Context, global globalOptions, args []string) int {

--- a/internal/cli/remote_commands.go
+++ b/internal/cli/remote_commands.go
@@ -434,15 +434,15 @@ func (a *App) runAskRemote(ctx context.Context, global globalOptions, opts askOp
 }
 
 type openFileOptions struct {
-	relPath     string
-	startLine   int
-	endLine     int
-	page        int
-	startMS     int
-	endMS       int
-	maxChars    int
-	startMSSet  bool
-	endMSSet    bool
+	relPath    string
+	startLine  int
+	endLine    int
+	page       int
+	startMS    int
+	endMS      int
+	maxChars   int
+	startMSSet bool
+	endMSSet   bool
 }
 
 func parseOpenFileOptions(args []string) (openFileOptions, error) {

--- a/internal/cli/remote_commands.go
+++ b/internal/cli/remote_commands.go
@@ -312,6 +312,87 @@ func (a *App) runSearchRemote(ctx context.Context, global globalOptions, args []
 	return exitSuccess
 }
 
+func (a *App) runAskRemote(ctx context.Context, global globalOptions, opts askOptions, client *remoteMCPClient) int {
+	payload, err := client.CallTool(ctx, protocol.ToolNameAsk, map[string]interface{}{
+		"question":    opts.question,
+		"mode":        opts.mode,
+		"k":           opts.k,
+		"index":       opts.index,
+		"path_prefix": opts.pathPrefix,
+		"file_glob":   opts.fileGlob,
+		"doc_types":   opts.docTypes,
+	})
+	if err != nil {
+		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("ask failed: %v", err))
+		return exitGeneric
+	}
+
+	if global.jsonOutput {
+		if err := emitJSON(a.stdout, payload); err != nil {
+			writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("encode ask json: %v", err))
+			return exitGeneric
+		}
+		return exitSuccess
+	}
+	if global.quiet {
+		return exitSuccess
+	}
+
+	answer, _ := payload["answer"].(string)
+	citations, _ := payload["citations"].([]interface{})
+	hits, _ := payload["hits"].([]interface{})
+
+	writeln(a.stdout)
+	if strings.TrimSpace(answer) != "" {
+		writeln(a.stdout, answer)
+	}
+	if len(citations) > 0 {
+		s := a.sty(false)
+		writeln(a.stdout)
+		writef(a.stdout, "  %s\n", s.sectionHeader("Citations"))
+		for i, item := range citations {
+			citation, ok := item.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			relPath, _ := citation["rel_path"].(string)
+			chunkID, _ := citation["chunk_id"].(float64)
+			spanText := "?"
+			if span, ok := citation["span"].(map[string]interface{}); ok {
+				startLine, _ := span["start_line"].(float64)
+				endLine, _ := span["end_line"].(float64)
+				spanText = fmt.Sprintf("L%d-L%d", int64(startLine), int64(endLine))
+			}
+			writef(a.stdout, "  %s %s  %s\n",
+				s.Brand.Render(fmt.Sprintf("[%d]", i+1)),
+				s.Cyan.Render(relPath),
+				s.dim(fmt.Sprintf("chunk=%d span=%s", int64(chunkID), spanText)),
+			)
+		}
+	}
+	if opts.mode == "search_only" && len(hits) > 0 {
+		s := a.sty(false)
+		writeln(a.stdout)
+		writef(a.stdout, "  %s %s\n\n", s.sectionHeader("Search results"), s.dim(fmt.Sprintf("(%d hits)", len(hits))))
+		for i, item := range hits {
+			hit, ok := item.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			relPath, _ := hit["rel_path"].(string)
+			score, _ := hit["score"].(float64)
+			snippet, _ := hit["snippet"].(string)
+			if strings.TrimSpace(snippet) == "" {
+				snippet = "(no snippet)"
+			}
+			writef(a.stdout, "  %s %s  %s\n", s.Brand.Render(fmt.Sprintf("[%d]", i+1)), s.Cyan.Render(relPath), s.dim(fmt.Sprintf("score=%.4f", score)))
+			writef(a.stdout, "      %s\n", s.dim(snippet))
+		}
+	}
+	writeln(a.stdout)
+	return exitSuccess
+}
+
 type openFileOptions struct {
 	relPath   string
 	startLine int

--- a/internal/cli/remote_commands.go
+++ b/internal/cli/remote_commands.go
@@ -286,7 +286,12 @@ func resolveRemoteConnection(global globalOptions) (remoteConnection, error) {
 
 func authHeaderFromConnection(conn remoteConnection) (string, error) {
 	auth := strings.TrimSpace(conn.Headers["Authorization"])
-	if auth != "" && !strings.Contains(auth, "<") {
+	// Clear placeholder Authorization headers (containing template markers like "<")
+	if auth == "" || strings.Contains(auth, "<") {
+		delete(conn.Headers, "Authorization")
+		auth = ""
+	}
+	if auth != "" {
 		return auth, nil
 	}
 	if conn.TokenFile == "" {
@@ -429,13 +434,15 @@ func (a *App) runAskRemote(ctx context.Context, global globalOptions, opts askOp
 }
 
 type openFileOptions struct {
-	relPath   string
-	startLine int
-	endLine   int
-	page      int
-	startMS   int
-	endMS     int
-	maxChars  int
+	relPath     string
+	startLine   int
+	endLine     int
+	page        int
+	startMS     int
+	endMS       int
+	maxChars    int
+	startMSSet  bool
+	endMSSet    bool
 }
 
 func parseOpenFileOptions(args []string) (openFileOptions, error) {
@@ -451,6 +458,15 @@ func parseOpenFileOptions(args []string) (openFileOptions, error) {
 	if err := fs.Parse(args); err != nil {
 		return openFileOptions{}, err
 	}
+	// Track which flags were explicitly set
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "start-ms" {
+			opts.startMSSet = true
+		}
+		if f.Name == "end-ms" {
+			opts.endMSSet = true
+		}
+	})
 	if fs.NArg() != 1 {
 		return openFileOptions{}, errors.New("open-file command requires exactly one <rel-path> argument")
 	}
@@ -487,10 +503,10 @@ func (a *App) runOpenFileRemote(ctx context.Context, global globalOptions, args 
 	if opts.page > 0 {
 		toolArgs["page"] = opts.page
 	}
-	if opts.startMS > 0 {
+	if opts.startMSSet {
 		toolArgs["start_ms"] = opts.startMS
 	}
-	if opts.endMS > 0 {
+	if opts.endMSSet {
 		toolArgs["end_ms"] = opts.endMS
 	}
 

--- a/internal/mcp/middleware.go
+++ b/internal/mcp/middleware.go
@@ -134,10 +134,17 @@ func (s *Server) rpcEnvelopeMiddleware(next http.Handler) http.Handler {
 			}
 		}
 
+		// Preserve authScope from existing context if present
+		var authScope string
+		if existingRC, ok := r.Context().Value(requestContextKey{}).(requestContext); ok {
+			authScope = existingRC.authScope
+		}
+
 		ctx := context.WithValue(r.Context(), requestContextKey{}, requestContext{
-			req:   req,
-			id:    id,
-			hasID: hasID,
+			req:       req,
+			id:        id,
+			hasID:     hasID,
+			authScope: authScope,
 		})
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})

--- a/internal/mcp/middleware.go
+++ b/internal/mcp/middleware.go
@@ -15,9 +15,10 @@ type middleware func(http.Handler) http.Handler
 type requestContextKey struct{}
 
 type requestContext struct {
-	req   rpcRequest
-	id    interface{}
-	hasID bool
+	req       rpcRequest
+	id        interface{}
+	hasID     bool
+	authScope string
 }
 
 func (s *Server) withMiddlewares(h http.Handler, mws ...middleware) http.Handler {
@@ -63,8 +64,16 @@ func (s *Server) protocolValidationMiddleware(next http.Handler) http.Handler {
 
 func (s *Server) authMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !s.authorize(w, r) {
+		ok, authScope := s.authorize(w, r)
+		if !ok {
 			return
+		}
+		// Store authScope in context for later use
+		ctx := r.Context()
+		if rc, exists := ctx.Value(requestContextKey{}).(requestContext); exists {
+			rc.authScope = authScope
+			ctx = context.WithValue(ctx, requestContextKey{}, rc)
+			r = r.WithContext(ctx)
 		}
 		next.ServeHTTP(w, r)
 	})

--- a/internal/mcp/payment.go
+++ b/internal/mcp/payment.go
@@ -311,9 +311,14 @@ func (s *Server) getPaymentExecutionOutcome(key string) (paymentExecutionOutcome
 		return paymentExecutionOutcome{}, false
 	}
 	s.paymentMu.Lock()
-	defer s.paymentMu.Unlock()
-	s.prunePaymentOutcomesLocked(time.Now().UTC())
+	keysToDelete := s.prunePaymentOutcomesLocked(time.Now().UTC())
 	outcome, ok := s.paymentOutcomes[key]
+	s.paymentMu.Unlock()
+
+	// Perform store deletions outside the mutex
+	for _, k := range keysToDelete {
+		s.deletePersistedPaymentOutcome(k)
+	}
 	return outcome, ok
 }
 
@@ -322,20 +327,30 @@ func (s *Server) setPaymentExecutionOutcome(key string, outcome paymentExecution
 		return
 	}
 	s.paymentMu.Lock()
-	defer s.paymentMu.Unlock()
 	now := time.Now().UTC()
-	s.prunePaymentOutcomesLocked(now)
+	keysToDelete := s.prunePaymentOutcomesLocked(now)
 
 	// compare-and-swap: only write if there is no existing outcome.  Any
 	// stored outcome has a non-zero UpdatedAt, so we only need to check for
 	// existence rather than inspect the timestamp.
 	if _, ok := s.paymentOutcomes[key]; ok {
 		// already completed by another goroutine; skip overwrite.
+		s.paymentMu.Unlock()
+		// Perform store deletions outside the mutex
+		for _, k := range keysToDelete {
+			s.deletePersistedPaymentOutcome(k)
+		}
 		return
 	}
 
 	s.paymentOutcomes[key] = outcome
+	s.paymentMu.Unlock()
+
+	// Perform store operations outside the mutex
 	s.persistPaymentOutcome(key, outcome)
+	for _, k := range keysToDelete {
+		s.deletePersistedPaymentOutcome(k)
+	}
 }
 
 func (s *Server) markPaymentExecutionSettled(key, paymentResponse string) (paymentExecutionOutcome, bool) {

--- a/internal/mcp/payment.go
+++ b/internal/mcp/payment.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	storepkg "dir2mcp/internal/store"
 	"dir2mcp/internal/x402"
 )
 
@@ -334,6 +335,7 @@ func (s *Server) setPaymentExecutionOutcome(key string, outcome paymentExecution
 	}
 
 	s.paymentOutcomes[key] = outcome
+	s.persistPaymentOutcome(key, outcome)
 }
 
 func (s *Server) markPaymentExecutionSettled(key, paymentResponse string) (paymentExecutionOutcome, bool) {
@@ -348,6 +350,7 @@ func (s *Server) markPaymentExecutionSettled(key, paymentResponse string) (payme
 		outcome.PaymentResponse = strings.TrimSpace(paymentResponse)
 		outcome.UpdatedAt = time.Now().UTC()
 		s.paymentOutcomes[key] = outcome
+		s.persistPaymentOutcome(key, outcome)
 	}
 	s.paymentMu.Unlock()
 
@@ -359,6 +362,102 @@ func (s *Server) markPaymentExecutionSettled(key, paymentResponse string) (payme
 		return paymentExecutionOutcome{}, false
 	}
 	return outcome, true
+}
+
+func paymentOutcomeToRecord(key string, outcome paymentExecutionOutcome) (storepkg.MCPPaymentOutcomeRecord, bool) {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return storepkg.MCPPaymentOutcomeRecord{}, false
+	}
+	var (
+		resultJSON string
+		rpcErrJSON string
+	)
+	if outcome.Result != nil {
+		b, err := json.Marshal(outcome.Result)
+		if err != nil {
+			return storepkg.MCPPaymentOutcomeRecord{}, false
+		}
+		resultJSON = string(b)
+	}
+	if outcome.RPCError != nil {
+		b, err := json.Marshal(outcome.RPCError)
+		if err != nil {
+			return storepkg.MCPPaymentOutcomeRecord{}, false
+		}
+		rpcErrJSON = string(b)
+	}
+	updatedAt := outcome.UpdatedAt.UTC()
+	if updatedAt.IsZero() {
+		updatedAt = time.Now().UTC()
+	}
+	return storepkg.MCPPaymentOutcomeRecord{
+		ExecutionKey:    key,
+		StatusCode:      outcome.StatusCode,
+		ResultJSON:      resultJSON,
+		RPCErrorJSON:    rpcErrJSON,
+		RequiresSettle:  outcome.RequiresSettle,
+		Settled:         outcome.Settled,
+		PaymentResponse: strings.TrimSpace(outcome.PaymentResponse),
+		UpdatedAt:       updatedAt,
+	}, true
+}
+
+func paymentOutcomeFromRecord(rec storepkg.MCPPaymentOutcomeRecord) (paymentExecutionOutcome, bool) {
+	if strings.TrimSpace(rec.ExecutionKey) == "" || rec.UpdatedAt.IsZero() {
+		return paymentExecutionOutcome{}, false
+	}
+	var outcome paymentExecutionOutcome
+	outcome.StatusCode = rec.StatusCode
+	outcome.RequiresSettle = rec.RequiresSettle
+	outcome.Settled = rec.Settled
+	outcome.PaymentResponse = strings.TrimSpace(rec.PaymentResponse)
+	outcome.UpdatedAt = rec.UpdatedAt.UTC()
+	if strings.TrimSpace(rec.ResultJSON) != "" {
+		var result toolCallResult
+		if err := json.Unmarshal([]byte(rec.ResultJSON), &result); err != nil {
+			return paymentExecutionOutcome{}, false
+		}
+		outcome.Result = &result
+	}
+	if strings.TrimSpace(rec.RPCErrorJSON) != "" {
+		var rpcErr rpcError
+		if err := json.Unmarshal([]byte(rec.RPCErrorJSON), &rpcErr); err != nil {
+			return paymentExecutionOutcome{}, false
+		}
+		outcome.RPCError = &rpcErr
+	}
+	return outcome, true
+}
+
+func (s *Server) persistPaymentOutcome(key string, outcome paymentExecutionOutcome) {
+	store, ok := s.store.(paymentOutcomePersistenceStore)
+	if !ok || store == nil {
+		return
+	}
+	rec, ok := paymentOutcomeToRecord(key, outcome)
+	if !ok {
+		return
+	}
+	if err := store.UpsertMCPPaymentOutcome(context.Background(), rec); err != nil {
+		s.emitPaymentEvent("warning", "payment_outcome_persist_failed", map[string]interface{}{
+			"key": key,
+			"err": err.Error(),
+		})
+	}
+}
+
+func (s *Server) deletePersistedPaymentOutcome(key string) {
+	store, ok := s.store.(paymentOutcomePersistenceStore)
+	if !ok || store == nil {
+		return
+	}
+	if err := store.DeleteMCPPaymentOutcome(context.Background(), key); err != nil {
+		s.emitPaymentEvent("warning", "payment_outcome_delete_failed", map[string]interface{}{
+			"key": key,
+			"err": err.Error(),
+		})
+	}
 }
 
 // cloneRPCError returns a copy of the supplied rpcError.  callers may

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -56,10 +56,12 @@ const MaxSearchK = 50
 // sessionInfo holds metadata tracked for each active session.  `created` is the
 // time the session was started; `lastSeen` is updated on each successful
 // request.  The server uses both values to enforce inactivity timeouts and
-// optional absolute lifetimes.
+// optional absolute lifetimes.  `authScope` records the authenticated identity
+// for the session.
 type sessionInfo struct {
-	created  time.Time
-	lastSeen time.Time
+	created   time.Time
+	lastSeen  time.Time
+	authScope string
 }
 
 type sessionPersistenceStore interface {
@@ -222,8 +224,8 @@ func NewServer(cfg config.Config, retriever model.Retriever, opts ...ServerOptio
 	if cfg.Public && cfg.RateLimitRPS > 0 && cfg.RateLimitBurst > 0 {
 		s.rateLimiter = newIPRateLimiter(float64(cfg.RateLimitRPS), cfg.RateLimitBurst, cfg.TrustedProxies)
 	}
-	s.restoreRuntimeState(context.Background())
 	s.initPaymentConfig()
+	s.restoreRuntimeState(context.Background())
 	s.tools = s.buildToolRegistry()
 	return s
 }
@@ -323,7 +325,7 @@ func (s *Server) handleMCP(w http.ResponseWriter, r *http.Request) {
 
 	switch rc.req.Method {
 	case protocol.RPCMethodInitialize:
-		s.handleInitialize(w, rc.id, rc.hasID)
+		s.handleInitialize(w, r, rc.id, rc.hasID)
 	case protocol.RPCMethodNotificationsInitialized:
 		if !rc.hasID {
 			w.WriteHeader(http.StatusAccepted)
@@ -349,7 +351,7 @@ func (s *Server) handleMCP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (s *Server) handleInitialize(w http.ResponseWriter, id interface{}, hasID bool) {
+func (s *Server) handleInitialize(w http.ResponseWriter, r *http.Request, id interface{}, hasID bool) {
 	if !hasID {
 		writeError(w, http.StatusBadRequest, nil, -32600, "initialize requires id", "MISSING_FIELD", false)
 		return
@@ -360,7 +362,13 @@ func (s *Server) handleInitialize(w http.ResponseWriter, id interface{}, hasID b
 		writeError(w, http.StatusInternalServerError, id, -32603, "failed to initialize session", "", false)
 		return
 	}
-	s.storeSession(sessionID)
+
+	// Extract authScope from request context
+	var authScope string
+	if rc, ok := r.Context().Value(requestContextKey{}).(requestContext); ok {
+		authScope = rc.authScope
+	}
+	s.storeSession(sessionID, authScope)
 
 	w.Header().Set(protocol.MCPSessionHeader, sessionID)
 	writeResult(w, http.StatusOK, id, map[string]interface{}{
@@ -379,9 +387,9 @@ func (s *Server) handleInitialize(w http.ResponseWriter, id interface{}, hasID b
 	})
 }
 
-func (s *Server) authorize(w http.ResponseWriter, r *http.Request) bool {
+func (s *Server) authorize(w http.ResponseWriter, r *http.Request) (bool, string) {
 	if strings.EqualFold(s.cfg.AuthMode, "none") {
-		return true
+		return true, ""
 	}
 
 	expectedToken := s.authToken
@@ -390,21 +398,24 @@ func (s *Server) authorize(w http.ResponseWriter, r *http.Request) bool {
 
 	if len(authHeader) < len(bearerPrefix) || strings.ToLower(authHeader[:len(bearerPrefix)]) != bearerPrefix {
 		writeError(w, http.StatusUnauthorized, nil, -32000, "missing or invalid bearer token", protocol.ErrorCodeUnauthorized, false)
-		return false
+		return false, ""
 	}
 
 	providedToken := strings.TrimSpace(authHeader[len(bearerPrefix):])
 	if expectedToken == "" || providedToken == "" {
 		writeError(w, http.StatusUnauthorized, nil, -32000, "missing or invalid bearer token", protocol.ErrorCodeUnauthorized, false)
-		return false
+		return false, ""
 	}
 
 	if subtle.ConstantTimeCompare([]byte(providedToken), []byte(expectedToken)) != 1 {
 		writeError(w, http.StatusUnauthorized, nil, -32000, "missing or invalid bearer token", protocol.ErrorCodeUnauthorized, false)
-		return false
+		return false, ""
 	}
 
-	return true
+	// For successful auth, compute a hash of the token as the auth scope identifier
+	sum := sha256.Sum256([]byte(providedToken))
+	authScope := "token:" + hex.EncodeToString(sum[:8])
+	return true, authScope
 }
 
 func (s *Server) allowOrigin(w http.ResponseWriter, r *http.Request) bool {
@@ -550,11 +561,11 @@ func (s *Server) hasActiveSession(id string, now time.Time) (bool, string) {
 	return true, ""
 }
 
-func (s *Server) storeSession(id string) {
+func (s *Server) storeSession(id string, authScope string) {
 	s.sessionMu.Lock()
 	defer s.sessionMu.Unlock()
 	now := time.Now()
-	s.sessions[id] = sessionInfo{created: now, lastSeen: now}
+	s.sessions[id] = sessionInfo{created: now, lastSeen: now, authScope: authScope}
 	s.persistSession(id, s.sessions[id])
 }
 
@@ -660,7 +671,7 @@ func (s *Server) restoreSessions(ctx context.Context) {
 			_ = store.DeleteMCPSession(ctx, id)
 			continue
 		}
-		s.sessions[id] = sessionInfo{created: rec.Created, lastSeen: rec.LastSeen}
+		s.sessions[id] = sessionInfo{created: rec.Created, lastSeen: rec.LastSeen, authScope: rec.AuthScope}
 	}
 }
 
@@ -701,7 +712,7 @@ func (s *Server) persistSession(id string, si sessionInfo) {
 	if !ok || store == nil {
 		return
 	}
-	if err := store.UpsertMCPSession(context.Background(), id, si.created.UTC(), si.lastSeen.UTC(), ""); err != nil {
+	if err := store.UpsertMCPSession(context.Background(), id, si.created.UTC(), si.lastSeen.UTC(), si.authScope); err != nil {
 		log.Printf("warning: failed persisting session %s: %v", maskSessionID(id), err)
 	}
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -535,20 +535,21 @@ func (s *Server) hasActiveSession(id string, now time.Time) (bool, string) {
 	inactivity, maxLife := s.resolveSessionTimeouts()
 
 	s.sessionMu.Lock()
-	defer s.sessionMu.Unlock()
-
 	si, ok := s.sessions[id]
 	if !ok {
+		s.sessionMu.Unlock()
 		return false, ""
 	}
 	if now.Sub(si.lastSeen) > inactivity {
 		delete(s.sessions, id)
+		s.sessionMu.Unlock()
 		s.deletePersistedSession(id)
 		log.Printf("session %s expired due to inactivity", maskSessionID(id))
 		return false, "inactivity"
 	}
 	if maxLife > 0 && now.Sub(si.created) > maxLife {
 		delete(s.sessions, id)
+		s.sessionMu.Unlock()
 		s.deletePersistedSession(id)
 		log.Printf("session %s expired due to max lifetime", maskSessionID(id))
 		return false, "max-lifetime"
@@ -557,16 +558,18 @@ func (s *Server) hasActiveSession(id string, now time.Time) (bool, string) {
 	// update lastSeen
 	si.lastSeen = now
 	s.sessions[id] = si
+	s.sessionMu.Unlock()
 	s.persistSession(id, si)
 	return true, ""
 }
 
 func (s *Server) storeSession(id string, authScope string) {
-	s.sessionMu.Lock()
-	defer s.sessionMu.Unlock()
 	now := time.Now()
-	s.sessions[id] = sessionInfo{created: now, lastSeen: now, authScope: authScope}
-	s.persistSession(id, s.sessions[id])
+	si := sessionInfo{created: now, lastSeen: now, authScope: authScope}
+	s.sessionMu.Lock()
+	s.sessions[id] = si
+	s.sessionMu.Unlock()
+	s.persistSession(id, si)
 }
 
 func (s *Server) runSessionCleanup(ctx context.Context) {
@@ -629,18 +632,23 @@ func (s *Server) cleanupExpiredSessions(now time.Time) {
 	inactivity, maxLife := s.resolveSessionTimeouts()
 
 	s.sessionMu.Lock()
-	defer s.sessionMu.Unlock()
-
+	var toDelete []string
 	for id, si := range s.sessions {
 		if now.Sub(si.lastSeen) > inactivity {
+			toDelete = append(toDelete, id)
 			delete(s.sessions, id)
-			s.deletePersistedSession(id)
 			continue
 		}
 		if maxLife > 0 && now.Sub(si.created) > maxLife {
+			toDelete = append(toDelete, id)
 			delete(s.sessions, id)
-			s.deletePersistedSession(id)
 		}
+	}
+	s.sessionMu.Unlock()
+
+	// Perform I/O outside the lock
+	for _, id := range toDelete {
+		s.deletePersistedSession(id)
 	}
 }
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -28,6 +28,7 @@ import (
 	"dir2mcp/internal/config"
 	"dir2mcp/internal/model"
 	"dir2mcp/internal/protocol"
+	storepkg "dir2mcp/internal/store"
 	"dir2mcp/internal/x402"
 )
 
@@ -59,6 +60,18 @@ const MaxSearchK = 50
 type sessionInfo struct {
 	created  time.Time
 	lastSeen time.Time
+}
+
+type sessionPersistenceStore interface {
+	UpsertMCPSession(ctx context.Context, sessionID string, created, lastSeen time.Time) error
+	DeleteMCPSession(ctx context.Context, sessionID string) error
+	ListMCPSessions(ctx context.Context) ([]storepkg.MCPSessionRecord, error)
+}
+
+type paymentOutcomePersistenceStore interface {
+	UpsertMCPPaymentOutcome(ctx context.Context, rec storepkg.MCPPaymentOutcomeRecord) error
+	DeleteMCPPaymentOutcome(ctx context.Context, executionKey string) error
+	ListMCPPaymentOutcomes(ctx context.Context) ([]storepkg.MCPPaymentOutcomeRecord, error)
 }
 
 type Server struct {
@@ -209,6 +222,7 @@ func NewServer(cfg config.Config, retriever model.Retriever, opts ...ServerOptio
 	if cfg.Public && cfg.RateLimitRPS > 0 && cfg.RateLimitBurst > 0 {
 		s.rateLimiter = newIPRateLimiter(float64(cfg.RateLimitRPS), cfg.RateLimitBurst, cfg.TrustedProxies)
 	}
+	s.restoreRuntimeState(context.Background())
 	s.initPaymentConfig()
 	s.tools = s.buildToolRegistry()
 	return s
@@ -518,11 +532,13 @@ func (s *Server) hasActiveSession(id string, now time.Time) (bool, string) {
 	}
 	if now.Sub(si.lastSeen) > inactivity {
 		delete(s.sessions, id)
+		s.deletePersistedSession(id)
 		log.Printf("session %s expired due to inactivity", maskSessionID(id))
 		return false, "inactivity"
 	}
 	if maxLife > 0 && now.Sub(si.created) > maxLife {
 		delete(s.sessions, id)
+		s.deletePersistedSession(id)
 		log.Printf("session %s expired due to max lifetime", maskSessionID(id))
 		return false, "max-lifetime"
 	}
@@ -530,6 +546,7 @@ func (s *Server) hasActiveSession(id string, now time.Time) (bool, string) {
 	// update lastSeen
 	si.lastSeen = now
 	s.sessions[id] = si
+	s.persistSession(id, si)
 	return true, ""
 }
 
@@ -538,6 +555,7 @@ func (s *Server) storeSession(id string) {
 	defer s.sessionMu.Unlock()
 	now := time.Now()
 	s.sessions[id] = sessionInfo{created: now, lastSeen: now}
+	s.persistSession(id, s.sessions[id])
 }
 
 func (s *Server) runSessionCleanup(ctx context.Context) {
@@ -605,11 +623,96 @@ func (s *Server) cleanupExpiredSessions(now time.Time) {
 	for id, si := range s.sessions {
 		if now.Sub(si.lastSeen) > inactivity {
 			delete(s.sessions, id)
+			s.deletePersistedSession(id)
 			continue
 		}
 		if maxLife > 0 && now.Sub(si.created) > maxLife {
 			delete(s.sessions, id)
+			s.deletePersistedSession(id)
 		}
+	}
+}
+
+func (s *Server) restoreRuntimeState(ctx context.Context) {
+	s.restoreSessions(ctx)
+	s.restorePaymentOutcomes(ctx)
+}
+
+func (s *Server) restoreSessions(ctx context.Context) {
+	store, ok := s.store.(sessionPersistenceStore)
+	if !ok || store == nil {
+		return
+	}
+	records, err := store.ListMCPSessions(ctx)
+	if err != nil {
+		log.Printf("warning: failed loading persisted sessions: %v", err)
+		return
+	}
+	now := time.Now()
+	inactivity, maxLife := s.resolveSessionTimeouts()
+	for _, rec := range records {
+		id := strings.TrimSpace(rec.ID)
+		if id == "" || rec.Created.IsZero() || rec.LastSeen.IsZero() {
+			_ = store.DeleteMCPSession(ctx, id)
+			continue
+		}
+		if now.Sub(rec.LastSeen) > inactivity || (maxLife > 0 && now.Sub(rec.Created) > maxLife) {
+			_ = store.DeleteMCPSession(ctx, id)
+			continue
+		}
+		s.sessions[id] = sessionInfo{created: rec.Created, lastSeen: rec.LastSeen}
+	}
+}
+
+func (s *Server) restorePaymentOutcomes(ctx context.Context) {
+	store, ok := s.store.(paymentOutcomePersistenceStore)
+	if !ok || store == nil {
+		return
+	}
+	records, err := store.ListMCPPaymentOutcomes(ctx)
+	if err != nil {
+		log.Printf("warning: failed loading persisted payment outcomes: %v", err)
+		return
+	}
+	s.paymentMu.Lock()
+	for _, rec := range records {
+		outcome, ok := paymentOutcomeFromRecord(rec)
+		if !ok {
+			_ = store.DeleteMCPPaymentOutcome(ctx, rec.ExecutionKey)
+			continue
+		}
+		s.paymentOutcomes[rec.ExecutionKey] = outcome
+	}
+	s.prunePaymentOutcomesLocked(time.Now().UTC())
+	kept := make(map[string]struct{}, len(s.paymentOutcomes))
+	for key := range s.paymentOutcomes {
+		kept[key] = struct{}{}
+	}
+	s.paymentMu.Unlock()
+	for _, rec := range records {
+		if _, ok := kept[rec.ExecutionKey]; !ok {
+			_ = store.DeleteMCPPaymentOutcome(ctx, rec.ExecutionKey)
+		}
+	}
+}
+
+func (s *Server) persistSession(id string, si sessionInfo) {
+	store, ok := s.store.(sessionPersistenceStore)
+	if !ok || store == nil {
+		return
+	}
+	if err := store.UpsertMCPSession(context.Background(), id, si.created.UTC(), si.lastSeen.UTC()); err != nil {
+		log.Printf("warning: failed persisting session %s: %v", maskSessionID(id), err)
+	}
+}
+
+func (s *Server) deletePersistedSession(id string) {
+	store, ok := s.store.(sessionPersistenceStore)
+	if !ok || store == nil {
+		return
+	}
+	if err := store.DeleteMCPSession(context.Background(), id); err != nil {
+		log.Printf("warning: failed deleting persisted session %s: %v", maskSessionID(id), err)
 	}
 }
 
@@ -643,6 +746,7 @@ func (s *Server) prunePaymentOutcomesLocked(now time.Time) {
 	for key, outcome := range s.paymentOutcomes {
 		if outcome.UpdatedAt.IsZero() || outcome.UpdatedAt.Before(cutoff) {
 			delete(s.paymentOutcomes, key)
+			s.deletePersistedPaymentOutcome(key)
 		}
 	}
 
@@ -674,6 +778,7 @@ func (s *Server) prunePaymentOutcomesLocked(now time.Time) {
 	toDrop := len(entries) - maxItems
 	for i := 0; i < toDrop; i++ {
 		delete(s.paymentOutcomes, entries[i].key)
+		s.deletePersistedPaymentOutcome(entries[i].key)
 	}
 }
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -63,7 +63,7 @@ type sessionInfo struct {
 }
 
 type sessionPersistenceStore interface {
-	UpsertMCPSession(ctx context.Context, sessionID string, created, lastSeen time.Time) error
+	UpsertMCPSession(ctx context.Context, sessionID string, created, lastSeen time.Time, authScope string) error
 	DeleteMCPSession(ctx context.Context, sessionID string) error
 	ListMCPSessions(ctx context.Context) ([]storepkg.MCPSessionRecord, error)
 }
@@ -701,7 +701,7 @@ func (s *Server) persistSession(id string, si sessionInfo) {
 	if !ok || store == nil {
 		return
 	}
-	if err := store.UpsertMCPSession(context.Background(), id, si.created.UTC(), si.lastSeen.UTC()); err != nil {
+	if err := store.UpsertMCPSession(context.Background(), id, si.created.UTC(), si.lastSeen.UTC(), ""); err != nil {
 		log.Printf("warning: failed persisting session %s: %v", maskSessionID(id), err)
 	}
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -694,23 +694,34 @@ func (s *Server) restorePaymentOutcomes(ctx context.Context) {
 		return
 	}
 	s.paymentMu.Lock()
+	var keysToDelete []string
 	for _, rec := range records {
 		outcome, ok := paymentOutcomeFromRecord(rec)
 		if !ok {
-			_ = store.DeleteMCPPaymentOutcome(ctx, rec.ExecutionKey)
+			keysToDelete = append(keysToDelete, rec.ExecutionKey)
 			continue
 		}
 		s.paymentOutcomes[rec.ExecutionKey] = outcome
 	}
-	s.prunePaymentOutcomesLocked(time.Now().UTC())
+	prunedKeys := s.prunePaymentOutcomesLocked(time.Now().UTC())
+	keysToDelete = append(keysToDelete, prunedKeys...)
 	kept := make(map[string]struct{}, len(s.paymentOutcomes))
 	for key := range s.paymentOutcomes {
 		kept[key] = struct{}{}
 	}
 	s.paymentMu.Unlock()
+
+	// Perform store deletions outside the mutex
+	for _, key := range keysToDelete {
+		if err := store.DeleteMCPPaymentOutcome(ctx, key); err != nil {
+			log.Printf("warning: failed deleting invalid payment outcome %s: %v", key, err)
+		}
+	}
 	for _, rec := range records {
 		if _, ok := kept[rec.ExecutionKey]; !ok {
-			_ = store.DeleteMCPPaymentOutcome(ctx, rec.ExecutionKey)
+			if err := store.DeleteMCPPaymentOutcome(ctx, rec.ExecutionKey); err != nil {
+				log.Printf("warning: failed deleting pruned payment outcome %s: %v", rec.ExecutionKey, err)
+			}
 		}
 	}
 }
@@ -751,11 +762,18 @@ func (s *Server) runPaymentOutcomeCleanup(ctx context.Context) {
 
 func (s *Server) cleanupPaymentOutcomes(now time.Time) {
 	s.paymentMu.Lock()
-	defer s.paymentMu.Unlock()
-	s.prunePaymentOutcomesLocked(now)
+	keysToDelete := s.prunePaymentOutcomesLocked(now)
+	s.paymentMu.Unlock()
+
+	// Perform store deletions outside the mutex
+	for _, key := range keysToDelete {
+		s.deletePersistedPaymentOutcome(key)
+	}
 }
 
-func (s *Server) prunePaymentOutcomesLocked(now time.Time) {
+func (s *Server) prunePaymentOutcomesLocked(now time.Time) []string {
+	var keysToDelete []string
+
 	ttl := s.paymentTTL
 	if ttl <= 0 {
 		ttl = paymentOutcomeTTL
@@ -765,7 +783,7 @@ func (s *Server) prunePaymentOutcomesLocked(now time.Time) {
 	for key, outcome := range s.paymentOutcomes {
 		if outcome.UpdatedAt.IsZero() || outcome.UpdatedAt.Before(cutoff) {
 			delete(s.paymentOutcomes, key)
-			s.deletePersistedPaymentOutcome(key)
+			keysToDelete = append(keysToDelete, key)
 		}
 	}
 
@@ -774,7 +792,7 @@ func (s *Server) prunePaymentOutcomesLocked(now time.Time) {
 		maxItems = paymentOutcomeMaxEntries
 	}
 	if len(s.paymentOutcomes) <= maxItems {
-		return
+		return keysToDelete
 	}
 
 	type entry struct {
@@ -797,8 +815,9 @@ func (s *Server) prunePaymentOutcomesLocked(now time.Time) {
 	toDrop := len(entries) - maxItems
 	for i := 0; i < toDrop; i++ {
 		delete(s.paymentOutcomes, entries[i].key)
-		s.deletePersistedPaymentOutcome(entries[i].key)
+		keysToDelete = append(keysToDelete, entries[i].key)
 	}
+	return keysToDelete
 }
 
 func generateSessionID() (string, error) {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -364,6 +364,25 @@ func (s *Server) handleStatsTool(ctx context.Context, args map[string]interface{
 			}(),
 		},
 	}
+	s.sessionMu.RLock()
+	sessionItems := make([]map[string]interface{}, 0, len(s.sessions))
+	for id, si := range s.sessions {
+		sessionItems = append(sessionItems, map[string]interface{}{
+			"id":             maskSessionID(id),
+			"created_unix":   si.created.Unix(),
+			"last_seen_unix": si.lastSeen.Unix(),
+		})
+	}
+	s.sessionMu.RUnlock()
+	sort.Slice(sessionItems, func(i, j int) bool {
+		left, _ := sessionItems[i]["id"].(string)
+		right, _ := sessionItems[j]["id"].(string)
+		return left < right
+	})
+	structured["sessions"] = map[string]interface{}{
+		"active": len(sessionItems),
+		"items":  sessionItems,
+	}
 
 	text := fmt.Sprintf(
 		"indexing running=%t scanned=%d indexed=%d errors=%d",
@@ -2319,7 +2338,28 @@ func statsOutputSchema() map[string]interface{} {
 				},
 				"required": []string{"embed_text", "embed_code", "ocr", "stt_provider", "stt_model", "chat"},
 			},
+			"sessions": map[string]interface{}{
+				"type":                 "object",
+				"additionalProperties": false,
+				"properties": map[string]interface{}{
+					"active": map[string]interface{}{"type": "integer"},
+					"items": map[string]interface{}{
+						"type": "array",
+						"items": map[string]interface{}{
+							"type":                 "object",
+							"additionalProperties": false,
+							"properties": map[string]interface{}{
+								"id":             map[string]interface{}{"type": "string"},
+								"created_unix":   map[string]interface{}{"type": "integer"},
+								"last_seen_unix": map[string]interface{}{"type": "integer"},
+							},
+							"required": []string{"id", "created_unix", "last_seen_unix"},
+						},
+					},
+				},
+				"required": []string{"active", "items"},
+			},
 		},
-		"required": []string{"root", "state_dir", "protocol_version", "doc_counts", "total_docs", "doc_counts_available", "indexing", "models"},
+		"required": []string{"root", "state_dir", "protocol_version", "doc_counts", "total_docs", "doc_counts_available", "indexing", "models", "sessions"},
 	}
 }

--- a/internal/mcp/transport_sdk.go
+++ b/internal/mcp/transport_sdk.go
@@ -164,7 +164,7 @@ func (t *SDKTransport) checkPreRequest(w http.ResponseWriter, req *http.Request)
 		writeError(w, http.StatusUnsupportedMediaType, nil, -32600, "Content-Type must be application/json", "INVALID_FIELD", false)
 		return false
 	}
-	if !t.server.authorize(w, req) {
+	if ok, _ := t.server.authorize(w, req); !ok {
 		return false
 	}
 	if !t.server.allowOrigin(w, req) {
@@ -255,7 +255,9 @@ func (t *SDKTransport) handleSDKInitialize(w http.ResponseWriter, req *http.Requ
 	rec := newBufferedResponseWriter()
 	sdkHandler.ServeHTTP(rec, req)
 	if sessionID := strings.TrimSpace(rec.header.Get(protocol.MCPSessionHeader)); sessionID != "" {
-		t.server.storeSession(sessionID)
+		// Extract authScope from the authorize call result
+		_, authScope := t.server.authorize(nil, req)
+		t.server.storeSession(sessionID, authScope)
 	}
 	copyBufferedResponse(w, rec)
 }

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -1123,7 +1123,7 @@ func (s *SQLiteStore) UpsertMCPSession(ctx context.Context, sessionID string, cr
 		 VALUES(?, ?, ?, ?)
 		 ON CONFLICT(session_id) DO UPDATE SET
 		   last_seen_unix=excluded.last_seen_unix,
-		   auth_scope=excluded.auth_scope`,
+		   auth_scope=COALESCE(NULLIF(excluded.auth_scope, ''), mcp_sessions.auth_scope)`,
 		sessionID,
 		created.UTC().Unix(),
 		lastSeen.UTC().Unix(),

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -3,7 +3,6 @@ package store
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -1209,38 +1208,6 @@ func (s *SQLiteStore) ListMCPSessions(ctx context.Context) ([]MCPSessionRecord, 
 	return out, rows.Err()
 }
 
-// sanitizePaymentJSON filters a JSON string to retain only allowlisted fields.
-// This prevents sensitive or unexpected fields from being persisted to disk.
-func sanitizePaymentJSON(raw string) string {
-	raw = strings.TrimSpace(raw)
-	if raw == "" {
-		return ""
-	}
-	allowed := []string{"ok", "txHash", "status", "network", "amount"}
-	var parsed map[string]interface{}
-	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
-		return ""
-	}
-	filtered := make(map[string]interface{}, len(allowed))
-	for _, key := range allowed {
-		if v, ok := parsed[key]; ok {
-			// Only keep primitives to avoid nested sensitive data
-			switch v.(type) {
-			case string, float64, bool, nil:
-				filtered[key] = v
-			}
-		}
-	}
-	if len(filtered) == 0 {
-		return ""
-	}
-	b, err := json.Marshal(filtered)
-	if err != nil {
-		return ""
-	}
-	return string(b)
-}
-
 func (s *SQLiteStore) UpsertMCPPaymentOutcome(ctx context.Context, rec MCPPaymentOutcomeRecord) error {
 	rec.ExecutionKey = strings.TrimSpace(rec.ExecutionKey)
 	if rec.ExecutionKey == "" {
@@ -1255,11 +1222,6 @@ func (s *SQLiteStore) UpsertMCPPaymentOutcome(ctx context.Context, rec MCPPaymen
 		return err
 	}
 	defer s.ReleaseDB()
-
-	// Sanitize sensitive fields before persisting
-	sanitizedResultJSON := sanitizePaymentJSON(rec.ResultJSON)
-	sanitizedRPCErrorJSON := sanitizePaymentJSON(rec.RPCErrorJSON)
-	sanitizedPaymentResponse := sanitizePaymentJSON(rec.PaymentResponse)
 
 	_, err = db.ExecContext(
 		ctx,
@@ -1277,11 +1239,11 @@ func (s *SQLiteStore) UpsertMCPPaymentOutcome(ctx context.Context, rec MCPPaymen
 			updated_unix=excluded.updated_unix`,
 		rec.ExecutionKey,
 		rec.StatusCode,
-		sanitizedResultJSON,
-		sanitizedRPCErrorJSON,
+		strings.TrimSpace(rec.ResultJSON),
+		strings.TrimSpace(rec.RPCErrorJSON),
 		boolToInt(rec.RequiresSettle),
 		boolToInt(rec.Settled),
-		sanitizedPaymentResponse,
+		strings.TrimSpace(rec.PaymentResponse),
 		rec.UpdatedAt.UTC().Unix(),
 	)
 	return err

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -1147,7 +1147,12 @@ func (s *SQLiteStore) ListMCPSessions(ctx context.Context) ([]MCPSessionRecord, 
 	}
 	defer s.ReleaseDB()
 
-	rows, err := db.QueryContext(ctx, `SELECT session_id, created_unix, last_seen_unix FROM mcp_sessions`)
+	rows, err := db.QueryContext(
+		ctx,
+		`SELECT session_id, created_unix, last_seen_unix
+		 FROM mcp_sessions
+		 ORDER BY last_seen_unix DESC, created_unix DESC, session_id ASC`,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -1137,7 +1137,7 @@ func (s *SQLiteStore) UpsertMCPSession(ctx context.Context, sessionID string, cr
 		`INSERT INTO mcp_sessions(session_id, created_unix, last_seen_unix, auth_scope)
 		 VALUES(?, ?, ?, ?)
 		 ON CONFLICT(session_id) DO UPDATE SET
-		   last_seen_unix=excluded.last_seen_unix,
+		   last_seen_unix=MAX(mcp_sessions.last_seen_unix, excluded.last_seen_unix),
 		   auth_scope=COALESCE(NULLIF(excluded.auth_scope, ''), mcp_sessions.auth_scope)`,
 		sessionID,
 		created.UTC().Unix(),

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -32,9 +32,10 @@ type SQLiteStore struct {
 }
 
 type MCPSessionRecord struct {
-	ID       string
-	Created  time.Time
-	LastSeen time.Time
+	ID        string
+	Created   time.Time
+	LastSeen  time.Time
+	AuthScope string
 }
 
 type MCPPaymentOutcomeRecord struct {
@@ -307,7 +308,8 @@ CREATE TABLE IF NOT EXISTS settings (
 CREATE TABLE IF NOT EXISTS mcp_sessions (
   session_id TEXT PRIMARY KEY,
   created_unix INTEGER NOT NULL,
-  last_seen_unix INTEGER NOT NULL
+  last_seen_unix INTEGER NOT NULL,
+  auth_scope TEXT NOT NULL DEFAULT ''
 );
 
 CREATE TABLE IF NOT EXISTS mcp_payment_outcomes (
@@ -337,6 +339,10 @@ CREATE INDEX IF NOT EXISTS idx_mcp_payment_outcomes_updated ON mcp_payment_outco
 		return err
 	}
 	if _, err := db.ExecContext(ctx, `ALTER TABLE documents ADD COLUMN source_type TEXT NOT NULL DEFAULT 'filesystem'`); err != nil && !isDuplicateColumnError(err) {
+		_ = db.Close()
+		return err
+	}
+	if _, err := db.ExecContext(ctx, `ALTER TABLE mcp_sessions ADD COLUMN auth_scope TEXT NOT NULL DEFAULT ''`); err != nil && !isDuplicateColumnError(err) {
 		_ = db.Close()
 		return err
 	}
@@ -1092,7 +1098,7 @@ func (s *SQLiteStore) MarkFailed(ctx context.Context, labels []uint64, reason st
 	return s.markEmbeddingStatus(ctx, labels, "error", reason)
 }
 
-func (s *SQLiteStore) UpsertMCPSession(ctx context.Context, sessionID string, created, lastSeen time.Time) error {
+func (s *SQLiteStore) UpsertMCPSession(ctx context.Context, sessionID string, created, lastSeen time.Time, authScope string) error {
 	sessionID = strings.TrimSpace(sessionID)
 	if sessionID == "" {
 		return errors.New("session_id is required")
@@ -1103,6 +1109,7 @@ func (s *SQLiteStore) UpsertMCPSession(ctx context.Context, sessionID string, cr
 	if lastSeen.IsZero() {
 		lastSeen = created
 	}
+	authScope = strings.TrimSpace(authScope)
 
 	db, err := s.ensureDB(ctx)
 	if err != nil {
@@ -1112,14 +1119,15 @@ func (s *SQLiteStore) UpsertMCPSession(ctx context.Context, sessionID string, cr
 
 	_, err = db.ExecContext(
 		ctx,
-		`INSERT INTO mcp_sessions(session_id, created_unix, last_seen_unix)
-		 VALUES(?, ?, ?)
+		`INSERT INTO mcp_sessions(session_id, created_unix, last_seen_unix, auth_scope)
+		 VALUES(?, ?, ?, ?)
 		 ON CONFLICT(session_id) DO UPDATE SET
-		   created_unix=excluded.created_unix,
-		   last_seen_unix=excluded.last_seen_unix`,
+		   last_seen_unix=excluded.last_seen_unix,
+		   auth_scope=excluded.auth_scope`,
 		sessionID,
 		created.UTC().Unix(),
 		lastSeen.UTC().Unix(),
+		authScope,
 	)
 	return err
 }
@@ -1149,7 +1157,7 @@ func (s *SQLiteStore) ListMCPSessions(ctx context.Context) ([]MCPSessionRecord, 
 
 	rows, err := db.QueryContext(
 		ctx,
-		`SELECT session_id, created_unix, last_seen_unix
+		`SELECT session_id, created_unix, last_seen_unix, COALESCE(auth_scope, '')
 		 FROM mcp_sessions
 		 ORDER BY last_seen_unix DESC, created_unix DESC, session_id ASC`,
 	)
@@ -1164,7 +1172,7 @@ func (s *SQLiteStore) ListMCPSessions(ctx context.Context) ([]MCPSessionRecord, 
 			rec                   MCPSessionRecord
 			createdUnix, lastUnix int64
 		)
-		if err := rows.Scan(&rec.ID, &createdUnix, &lastUnix); err != nil {
+		if err := rows.Scan(&rec.ID, &createdUnix, &lastUnix, &rec.AuthScope); err != nil {
 			return nil, err
 		}
 		rec.Created = time.Unix(createdUnix, 0).UTC()

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -31,6 +31,23 @@ type SQLiteStore struct {
 	cond      *sync.Cond
 }
 
+type MCPSessionRecord struct {
+	ID       string
+	Created  time.Time
+	LastSeen time.Time
+}
+
+type MCPPaymentOutcomeRecord struct {
+	ExecutionKey    string
+	StatusCode      int
+	ResultJSON      string
+	RPCErrorJSON    string
+	RequiresSettle  bool
+	Settled         bool
+	PaymentResponse string
+	UpdatedAt       time.Time
+}
+
 // dbExecutor abstracts the methods needed to run SQL statements in either a
 // *sql.DB or *sql.Tx.  Upserts on representations share the same logic and the
 // two store types can both supply an executor implementing this interface.
@@ -287,6 +304,23 @@ CREATE TABLE IF NOT EXISTS settings (
   value TEXT NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS mcp_sessions (
+  session_id TEXT PRIMARY KEY,
+  created_unix INTEGER NOT NULL,
+  last_seen_unix INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS mcp_payment_outcomes (
+  execution_key TEXT PRIMARY KEY,
+  status_code INTEGER NOT NULL,
+  result_json TEXT NOT NULL DEFAULT '',
+  rpc_error_json TEXT NOT NULL DEFAULT '',
+  requires_settle INTEGER NOT NULL DEFAULT 0,
+  settled INTEGER NOT NULL DEFAULT 0,
+  payment_response TEXT NOT NULL DEFAULT '',
+  updated_unix INTEGER NOT NULL
+);
+
 CREATE INDEX IF NOT EXISTS idx_documents_rel_path ON documents(rel_path);
 CREATE INDEX IF NOT EXISTS idx_documents_deleted ON documents(deleted);
 CREATE INDEX IF NOT EXISTS idx_representations_doc_id ON representations(doc_id);
@@ -295,6 +329,8 @@ CREATE INDEX IF NOT EXISTS idx_chunks_embedding_status ON chunks(embedding_statu
 CREATE INDEX IF NOT EXISTS idx_chunks_index_kind ON chunks(index_kind);
 CREATE INDEX IF NOT EXISTS idx_chunks_rel_path_deleted ON chunks(rel_path, deleted);
 CREATE INDEX IF NOT EXISTS idx_spans_chunk_id_span_id ON spans(chunk_id, span_id);
+CREATE INDEX IF NOT EXISTS idx_mcp_sessions_last_seen ON mcp_sessions(last_seen_unix);
+CREATE INDEX IF NOT EXISTS idx_mcp_payment_outcomes_updated ON mcp_payment_outcomes(updated_unix);
 `
 	if _, err := db.ExecContext(ctx, schema); err != nil {
 		_ = db.Close()
@@ -1054,6 +1090,183 @@ func (s *SQLiteStore) MarkEmbedded(ctx context.Context, labels []uint64) error {
 
 func (s *SQLiteStore) MarkFailed(ctx context.Context, labels []uint64, reason string) error {
 	return s.markEmbeddingStatus(ctx, labels, "error", reason)
+}
+
+func (s *SQLiteStore) UpsertMCPSession(ctx context.Context, sessionID string, created, lastSeen time.Time) error {
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return errors.New("session_id is required")
+	}
+	if created.IsZero() {
+		created = time.Now().UTC()
+	}
+	if lastSeen.IsZero() {
+		lastSeen = created
+	}
+
+	db, err := s.ensureDB(ctx)
+	if err != nil {
+		return err
+	}
+	defer s.ReleaseDB()
+
+	_, err = db.ExecContext(
+		ctx,
+		`INSERT INTO mcp_sessions(session_id, created_unix, last_seen_unix)
+		 VALUES(?, ?, ?)
+		 ON CONFLICT(session_id) DO UPDATE SET
+		   created_unix=excluded.created_unix,
+		   last_seen_unix=excluded.last_seen_unix`,
+		sessionID,
+		created.UTC().Unix(),
+		lastSeen.UTC().Unix(),
+	)
+	return err
+}
+
+func (s *SQLiteStore) DeleteMCPSession(ctx context.Context, sessionID string) error {
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return nil
+	}
+
+	db, err := s.ensureDB(ctx)
+	if err != nil {
+		return err
+	}
+	defer s.ReleaseDB()
+
+	_, err = db.ExecContext(ctx, `DELETE FROM mcp_sessions WHERE session_id = ?`, sessionID)
+	return err
+}
+
+func (s *SQLiteStore) ListMCPSessions(ctx context.Context) ([]MCPSessionRecord, error) {
+	db, err := s.ensureDB(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer s.ReleaseDB()
+
+	rows, err := db.QueryContext(ctx, `SELECT session_id, created_unix, last_seen_unix FROM mcp_sessions`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := make([]MCPSessionRecord, 0)
+	for rows.Next() {
+		var (
+			rec                   MCPSessionRecord
+			createdUnix, lastUnix int64
+		)
+		if err := rows.Scan(&rec.ID, &createdUnix, &lastUnix); err != nil {
+			return nil, err
+		}
+		rec.Created = time.Unix(createdUnix, 0).UTC()
+		rec.LastSeen = time.Unix(lastUnix, 0).UTC()
+		out = append(out, rec)
+	}
+	return out, rows.Err()
+}
+
+func (s *SQLiteStore) UpsertMCPPaymentOutcome(ctx context.Context, rec MCPPaymentOutcomeRecord) error {
+	rec.ExecutionKey = strings.TrimSpace(rec.ExecutionKey)
+	if rec.ExecutionKey == "" {
+		return errors.New("execution_key is required")
+	}
+	if rec.UpdatedAt.IsZero() {
+		rec.UpdatedAt = time.Now().UTC()
+	}
+
+	db, err := s.ensureDB(ctx)
+	if err != nil {
+		return err
+	}
+	defer s.ReleaseDB()
+
+	_, err = db.ExecContext(
+		ctx,
+		`INSERT INTO mcp_payment_outcomes(
+			execution_key, status_code, result_json, rpc_error_json,
+			requires_settle, settled, payment_response, updated_unix
+		) VALUES(?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(execution_key) DO UPDATE SET
+			status_code=excluded.status_code,
+			result_json=excluded.result_json,
+			rpc_error_json=excluded.rpc_error_json,
+			requires_settle=excluded.requires_settle,
+			settled=excluded.settled,
+			payment_response=excluded.payment_response,
+			updated_unix=excluded.updated_unix`,
+		rec.ExecutionKey,
+		rec.StatusCode,
+		strings.TrimSpace(rec.ResultJSON),
+		strings.TrimSpace(rec.RPCErrorJSON),
+		boolToInt(rec.RequiresSettle),
+		boolToInt(rec.Settled),
+		strings.TrimSpace(rec.PaymentResponse),
+		rec.UpdatedAt.UTC().Unix(),
+	)
+	return err
+}
+
+func (s *SQLiteStore) DeleteMCPPaymentOutcome(ctx context.Context, executionKey string) error {
+	executionKey = strings.TrimSpace(executionKey)
+	if executionKey == "" {
+		return nil
+	}
+	db, err := s.ensureDB(ctx)
+	if err != nil {
+		return err
+	}
+	defer s.ReleaseDB()
+
+	_, err = db.ExecContext(ctx, `DELETE FROM mcp_payment_outcomes WHERE execution_key = ?`, executionKey)
+	return err
+}
+
+func (s *SQLiteStore) ListMCPPaymentOutcomes(ctx context.Context) ([]MCPPaymentOutcomeRecord, error) {
+	db, err := s.ensureDB(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer s.ReleaseDB()
+
+	rows, err := db.QueryContext(
+		ctx,
+		`SELECT execution_key, status_code, result_json, rpc_error_json, requires_settle, settled, payment_response, updated_unix
+		 FROM mcp_payment_outcomes`,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := make([]MCPPaymentOutcomeRecord, 0)
+	for rows.Next() {
+		var (
+			rec                     MCPPaymentOutcomeRecord
+			requiresSettle, settled int
+			updatedUnix             int64
+		)
+		if err := rows.Scan(
+			&rec.ExecutionKey,
+			&rec.StatusCode,
+			&rec.ResultJSON,
+			&rec.RPCErrorJSON,
+			&requiresSettle,
+			&settled,
+			&rec.PaymentResponse,
+			&updatedUnix,
+		); err != nil {
+			return nil, err
+		}
+		rec.RequiresSettle = requiresSettle == 1
+		rec.Settled = settled == 1
+		rec.UpdatedAt = time.Unix(updatedUnix, 0).UTC()
+		out = append(out, rec)
+	}
+	return out, rows.Err()
 }
 
 func (s *SQLiteStore) markEmbeddingStatus(ctx context.Context, labels []uint64, status, reason string) error {

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -1240,7 +1240,8 @@ func (s *SQLiteStore) ListMCPPaymentOutcomes(ctx context.Context) ([]MCPPaymentO
 	rows, err := db.QueryContext(
 		ctx,
 		`SELECT execution_key, status_code, result_json, rpc_error_json, requires_settle, settled, payment_response, updated_unix
-		 FROM mcp_payment_outcomes`,
+		 FROM mcp_payment_outcomes
+		 ORDER BY updated_unix DESC`,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -236,6 +237,32 @@ func NewSQLiteStore(path string) *SQLiteStore {
 func (s *SQLiteStore) initLocked(ctx context.Context) error {
 	if s.db != nil {
 		return nil
+	}
+
+	// Ensure parent directory exists with restrictive permissions
+	dir := filepath.Dir(s.path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create database directory: %w", err)
+	}
+
+	// Check if database file already exists
+	dbExists := false
+	if _, err := os.Stat(s.path); err == nil {
+		dbExists = true
+	}
+
+	// If database doesn't exist, create it with restrictive permissions (0600)
+	if !dbExists {
+		f, err := os.OpenFile(s.path, os.O_CREATE|os.O_RDWR, 0o600)
+		if err != nil {
+			return fmt.Errorf("create database file: %w", err)
+		}
+		_ = f.Close()
+	} else {
+		// If database exists, ensure it has restrictive permissions
+		if err := os.Chmod(s.path, 0o600); err != nil {
+			return fmt.Errorf("set database file permissions: %w", err)
+		}
 	}
 
 	db, err := sql.Open("sqlite", s.path)
@@ -1182,6 +1209,38 @@ func (s *SQLiteStore) ListMCPSessions(ctx context.Context) ([]MCPSessionRecord, 
 	return out, rows.Err()
 }
 
+// sanitizePaymentJSON filters a JSON string to retain only allowlisted fields.
+// This prevents sensitive or unexpected fields from being persisted to disk.
+func sanitizePaymentJSON(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	allowed := []string{"ok", "txHash", "status", "network", "amount"}
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		return ""
+	}
+	filtered := make(map[string]interface{}, len(allowed))
+	for _, key := range allowed {
+		if v, ok := parsed[key]; ok {
+			// Only keep primitives to avoid nested sensitive data
+			switch v.(type) {
+			case string, float64, bool, nil:
+				filtered[key] = v
+			}
+		}
+	}
+	if len(filtered) == 0 {
+		return ""
+	}
+	b, err := json.Marshal(filtered)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
 func (s *SQLiteStore) UpsertMCPPaymentOutcome(ctx context.Context, rec MCPPaymentOutcomeRecord) error {
 	rec.ExecutionKey = strings.TrimSpace(rec.ExecutionKey)
 	if rec.ExecutionKey == "" {
@@ -1196,6 +1255,11 @@ func (s *SQLiteStore) UpsertMCPPaymentOutcome(ctx context.Context, rec MCPPaymen
 		return err
 	}
 	defer s.ReleaseDB()
+
+	// Sanitize sensitive fields before persisting
+	sanitizedResultJSON := sanitizePaymentJSON(rec.ResultJSON)
+	sanitizedRPCErrorJSON := sanitizePaymentJSON(rec.RPCErrorJSON)
+	sanitizedPaymentResponse := sanitizePaymentJSON(rec.PaymentResponse)
 
 	_, err = db.ExecContext(
 		ctx,
@@ -1213,11 +1277,11 @@ func (s *SQLiteStore) UpsertMCPPaymentOutcome(ctx context.Context, rec MCPPaymen
 			updated_unix=excluded.updated_unix`,
 		rec.ExecutionKey,
 		rec.StatusCode,
-		strings.TrimSpace(rec.ResultJSON),
-		strings.TrimSpace(rec.RPCErrorJSON),
+		sanitizedResultJSON,
+		sanitizedRPCErrorJSON,
 		boolToInt(rec.RequiresSettle),
 		boolToInt(rec.Settled),
-		strings.TrimSpace(rec.PaymentResponse),
+		sanitizedPaymentResponse,
 		rec.UpdatedAt.UTC().Unix(),
 	)
 	return err

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -244,24 +244,13 @@ func (s *SQLiteStore) initLocked(ctx context.Context) error {
 		return fmt.Errorf("create database directory: %w", err)
 	}
 
-	// Check if database file already exists
-	dbExists := false
-	if _, err := os.Stat(s.path); err == nil {
-		dbExists = true
+	f, err := os.OpenFile(s.path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return fmt.Errorf("open database file: %w", err)
 	}
-
-	// If database doesn't exist, create it with restrictive permissions (0600)
-	if !dbExists {
-		f, err := os.OpenFile(s.path, os.O_CREATE|os.O_RDWR, 0o600)
-		if err != nil {
-			return fmt.Errorf("create database file: %w", err)
-		}
-		_ = f.Close()
-	} else {
-		// If database exists, ensure it has restrictive permissions
-		if err := os.Chmod(s.path, 0o600); err != nil {
-			return fmt.Errorf("set database file permissions: %w", err)
-		}
+	_ = f.Close()
+	if err := os.Chmod(s.path, 0o600); err != nil {
+		return fmt.Errorf("set database file permissions: %w", err)
 	}
 
 	db, err := sql.Open("sqlite", s.path)

--- a/tests/cli/remote_commands_test.go
+++ b/tests/cli/remote_commands_test.go
@@ -146,7 +146,7 @@ func TestRemoteCommandsReturnNonZeroWhenServerIsUnavailable(t *testing.T) {
 	tmp := t.TempDir()
 	writeConnectionMetadata(t, tmp, fmt.Sprintf("http://127.0.0.1:%d/mcp", unused), "")
 
-	commands := [][]string{{"search", "q"}, {"open-file", "docs/a.md"}, {"list-files"}}
+	commands := [][]string{{"ask", "q"}, {"search", "q"}, {"open-file", "docs/a.md"}, {"list-files"}}
 	for _, cmdArgs := range commands {
 		t.Run(strings.Join(cmdArgs, "_"), func(t *testing.T) {
 			var stdout, stderr bytes.Buffer
@@ -161,6 +161,45 @@ func TestRemoteCommandsReturnNonZeroWhenServerIsUnavailable(t *testing.T) {
 				t.Fatalf("expected error output for %v", cmdArgs)
 			}
 		})
+	}
+}
+
+func TestAskCommandUsesConnectionMetadataAndPrintsJSON(t *testing.T) {
+	ts := newMCPTestServer(t, func(name string, args map[string]interface{}) map[string]interface{} {
+		if name != protocol.ToolNameAsk {
+			t.Fatalf("unexpected tool name: %s", name)
+		}
+		if question, _ := args["question"].(string); question != "what is indexed?" {
+			t.Fatalf("unexpected question: %#v", args["question"])
+		}
+		return map[string]interface{}{
+			"question":          "what is indexed?",
+			"answer":            "Indexed docs are available.",
+			"citations":         []interface{}{},
+			"hits":              []interface{}{},
+			"indexing_complete": true,
+		}
+	})
+	defer ts.Close()
+
+	tmp := t.TempDir()
+	writeConnectionMetadata(t, tmp, ts.URL, "")
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	withWorkingDir(t, tmp, func() {
+		code := app.RunWithContext(context.Background(), []string{"--json", "ask", "what is indexed?"})
+		if code != 0 {
+			t.Fatalf("unexpected exit code: %d stderr=%s", code, stderr.String())
+		}
+	})
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal ask output: %v raw=%s", err, stdout.String())
+	}
+	if payload["answer"] != "Indexed docs are available." {
+		t.Fatalf("unexpected answer in payload: %#v", payload["answer"])
 	}
 }
 

--- a/tests/cli/remote_commands_test.go
+++ b/tests/cli/remote_commands_test.go
@@ -4,13 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -142,9 +139,8 @@ func TestListFilesCommandPrintsOneJSONLinePerFile(t *testing.T) {
 }
 
 func TestRemoteCommandsReturnNonZeroWhenServerIsUnavailable(t *testing.T) {
-	unused := mustUnusedPort(t)
 	tmp := t.TempDir()
-	writeConnectionMetadata(t, tmp, fmt.Sprintf("http://127.0.0.1:%d/mcp", unused), "")
+	writeConnectionMetadata(t, tmp, "http://127.0.0.1:0/mcp", "")
 
 	commands := [][]string{{"ask", "q"}, {"search", "q"}, {"open-file", "docs/a.md"}, {"list-files"}}
 	for _, cmdArgs := range commands {
@@ -285,23 +281,4 @@ func writeConnectionMetadata(t *testing.T, root, url, tokenFile string) {
 	if err := os.WriteFile(filepath.Join(stateDir, "connection.json"), append(raw, '\n'), 0o644); err != nil {
 		t.Fatalf("write connection.json: %v", err)
 	}
-}
-
-func mustUnusedPort(t *testing.T) int {
-	t.Helper()
-	l, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen: %v", err)
-	}
-	defer func() { _ = l.Close() }()
-	addr := l.Addr().String()
-	_, port, err := net.SplitHostPort(addr)
-	if err != nil {
-		t.Fatalf("split host port: %v", err)
-	}
-	p, err := strconv.Atoi(port)
-	if err != nil {
-		t.Fatalf("atoi port: %v", err)
-	}
-	return p
 }

--- a/tests/cli/remote_commands_test.go
+++ b/tests/cli/remote_commands_test.go
@@ -1,0 +1,268 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"dir2mcp/internal/cli"
+	"dir2mcp/internal/protocol"
+)
+
+func TestSearchCommandUsesConnectionMetadataAndPrintsJSON(t *testing.T) {
+	ts := newMCPTestServer(t, func(name string, args map[string]interface{}) map[string]interface{} {
+		if name != protocol.ToolNameSearch {
+			t.Fatalf("unexpected tool name: %s", name)
+		}
+		if query, _ := args["query"].(string); query != "auth flow" {
+			t.Fatalf("unexpected query: %#v", args["query"])
+		}
+		return map[string]interface{}{
+			"query":             "auth flow",
+			"k":                 10,
+			"index_used":        "text",
+			"indexing_complete": true,
+			"hits": []interface{}{
+				map[string]interface{}{"rel_path": "docs/a.md", "score": 0.7},
+			},
+		}
+	})
+	defer ts.Close()
+
+	tmp := t.TempDir()
+	writeConnectionMetadata(t, tmp, ts.URL, "")
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	withWorkingDir(t, tmp, func() {
+		code := app.RunWithContext(context.Background(), []string{"search", "auth flow"})
+		if code != 0 {
+			t.Fatalf("unexpected exit code: %d stderr=%s", code, stderr.String())
+		}
+	})
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal search output: %v raw=%s", err, stdout.String())
+	}
+	if payload["query"] != "auth flow" {
+		t.Fatalf("unexpected query in payload: %#v", payload["query"])
+	}
+}
+
+func TestOpenFileCommandUsesConnectionMetadataAndPrintsJSON(t *testing.T) {
+	ts := newMCPTestServer(t, func(name string, args map[string]interface{}) map[string]interface{} {
+		if name != protocol.ToolNameOpenFile {
+			t.Fatalf("unexpected tool name: %s", name)
+		}
+		if relPath, _ := args["rel_path"].(string); relPath != "docs/spec.md" {
+			t.Fatalf("unexpected rel_path: %#v", args["rel_path"])
+		}
+		return map[string]interface{}{
+			"rel_path":  "docs/spec.md",
+			"doc_type":  "md",
+			"content":   "hello",
+			"truncated": false,
+		}
+	})
+	defer ts.Close()
+
+	tmp := t.TempDir()
+	writeConnectionMetadata(t, tmp, ts.URL, "")
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	withWorkingDir(t, tmp, func() {
+		code := app.RunWithContext(context.Background(), []string{"open-file", "docs/spec.md"})
+		if code != 0 {
+			t.Fatalf("unexpected exit code: %d stderr=%s", code, stderr.String())
+		}
+	})
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal open-file output: %v raw=%s", err, stdout.String())
+	}
+	if payload["rel_path"] != "docs/spec.md" {
+		t.Fatalf("unexpected rel_path in payload: %#v", payload["rel_path"])
+	}
+}
+
+func TestListFilesCommandPrintsOneJSONLinePerFile(t *testing.T) {
+	ts := newMCPTestServer(t, func(name string, args map[string]interface{}) map[string]interface{} {
+		if name != protocol.ToolNameListFiles {
+			t.Fatalf("unexpected tool name: %s", name)
+		}
+		return map[string]interface{}{
+			"limit":  200,
+			"offset": 0,
+			"total":  2,
+			"files": []interface{}{
+				map[string]interface{}{"rel_path": "a.md", "doc_type": "md", "size_bytes": 1, "mtime_unix": 1, "status": "ok", "deleted": false},
+				map[string]interface{}{"rel_path": "b.go", "doc_type": "code", "size_bytes": 2, "mtime_unix": 2, "status": "ok", "deleted": false},
+			},
+		}
+	})
+	defer ts.Close()
+
+	tmp := t.TempDir()
+	writeConnectionMetadata(t, tmp, ts.URL, "")
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	withWorkingDir(t, tmp, func() {
+		code := app.RunWithContext(context.Background(), []string{"list-files"})
+		if code != 0 {
+			t.Fatalf("unexpected exit code: %d stderr=%s", code, stderr.String())
+		}
+	})
+
+	lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 ndjson lines, got %d raw=%q", len(lines), stdout.String())
+	}
+	for i, line := range lines {
+		var obj map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &obj); err != nil {
+			t.Fatalf("line %d is not valid json: %v line=%q", i, err, line)
+		}
+		if _, ok := obj["rel_path"]; !ok {
+			t.Fatalf("line %d missing rel_path: %#v", i, obj)
+		}
+	}
+}
+
+func TestRemoteCommandsReturnNonZeroWhenServerIsUnavailable(t *testing.T) {
+	unused := mustUnusedPort(t)
+	tmp := t.TempDir()
+	writeConnectionMetadata(t, tmp, fmt.Sprintf("http://127.0.0.1:%d/mcp", unused), "")
+
+	commands := [][]string{{"search", "q"}, {"open-file", "docs/a.md"}, {"list-files"}}
+	for _, cmdArgs := range commands {
+		t.Run(strings.Join(cmdArgs, "_"), func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			app := cli.NewAppWithIO(&stdout, &stderr)
+			withWorkingDir(t, tmp, func() {
+				code := app.RunWithContext(context.Background(), cmdArgs)
+				if code == 0 {
+					t.Fatalf("expected non-zero exit code for %v", cmdArgs)
+				}
+			})
+			if strings.TrimSpace(stderr.String()) == "" {
+				t.Fatalf("expected error output for %v", cmdArgs)
+			}
+		})
+	}
+}
+
+func newMCPTestServer(t *testing.T, onToolCall func(name string, args map[string]interface{}) map[string]interface{}) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		defer r.Body.Close()
+
+		var req struct {
+			Method string `json:"method"`
+			ID     int64  `json:"id"`
+			Params struct {
+				Name      string                 `json:"name"`
+				Arguments map[string]interface{} `json:"arguments"`
+			} `json:"params"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+
+		if req.Method == protocol.RPCMethodInitialize {
+			w.Header().Set(protocol.MCPSessionHeader, "session-1")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      req.ID,
+				"result": map[string]interface{}{
+					"protocolVersion": protocol.ProtocolDefaultVersion,
+				},
+			})
+			return
+		}
+
+		if req.Method != protocol.RPCMethodToolsCall {
+			t.Fatalf("unexpected method: %s", req.Method)
+		}
+		if got := r.Header.Get(protocol.MCPSessionHeader); got == "" {
+			t.Fatal("expected MCP session header on tools/call")
+		}
+
+		structured := onToolCall(req.Params.Name, req.Params.Arguments)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"jsonrpc": "2.0",
+			"id":      req.ID,
+			"result": map[string]interface{}{
+				"isError":           false,
+				"structuredContent": structured,
+				"content":           []interface{}{map[string]interface{}{"type": "text", "text": "ok"}},
+			},
+		})
+	}))
+}
+
+func writeConnectionMetadata(t *testing.T, root, url, tokenFile string) {
+	t.Helper()
+	stateDir := filepath.Join(root, ".dir2mcp")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	payload := map[string]interface{}{
+		"transport": "mcp_streamable_http",
+		"url":       url,
+		"headers": map[string]string{
+			protocol.MCPProtocolVersionHeader: protocol.ProtocolDefaultVersion,
+		},
+		"session": map[string]interface{}{
+			"uses_mcp_session_id":    true,
+			"header_name":            protocol.MCPSessionHeader,
+			"assigned_on_initialize": true,
+		},
+		"public":       false,
+		"token_source": "none",
+	}
+	if tokenFile != "" {
+		payload["token_file"] = tokenFile
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal connection payload: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "connection.json"), append(raw, '\n'), 0o644); err != nil {
+		t.Fatalf("write connection.json: %v", err)
+	}
+}
+
+func mustUnusedPort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer l.Close()
+	addr := l.Addr().String()
+	_, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		t.Fatalf("split host port: %v", err)
+	}
+	p, err := strconv.Atoi(port)
+	if err != nil {
+		t.Fatalf("atoi port: %v", err)
+	}
+	return p
+}

--- a/tests/cli/remote_commands_test.go
+++ b/tests/cli/remote_commands_test.go
@@ -209,7 +209,7 @@ func newMCPTestServer(t *testing.T, onToolCall func(name string, args map[string
 		if r.Method != http.MethodPost {
 			t.Fatalf("unexpected method: %s", r.Method)
 		}
-		defer r.Body.Close()
+		defer func() { _ = r.Body.Close() }()
 
 		var req struct {
 			Method string `json:"method"`
@@ -293,7 +293,7 @@ func mustUnusedPort(t *testing.T) int {
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
-	defer l.Close()
+	defer func() { _ = l.Close() }()
 	addr := l.Addr().String()
 	_, port, err := net.SplitHostPort(addr)
 	if err != nil {

--- a/tests/mcp/server_test.go
+++ b/tests/mcp/server_test.go
@@ -1,10 +1,12 @@
 package tests
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -13,6 +15,7 @@ import (
 	"dir2mcp/internal/config"
 	"dir2mcp/internal/mcp"
 	"dir2mcp/internal/protocol"
+	"dir2mcp/internal/store"
 )
 
 func postToolsListWithSession(serverURL, mcpPath, sessionID string) (*http.Response, error) {
@@ -171,6 +174,33 @@ func TestSessionExpiration_MaxLifetimeHeader(t *testing.T) {
 	// "max-lifetime" X-MCP-Session-Expired header, so additional
 	// checks here would be redundant. Keep the call above for its
 	// built-in validation.
+}
+
+func TestSessionPersistsAcrossServerRestart(t *testing.T) {
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+	cfg.SessionInactivityTimeout = time.Hour
+	cfg.SessionMaxLifetime = 0
+
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	if err := st.Init(context.Background()); err != nil {
+		t.Fatalf("Init store failed: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+
+	server1 := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st)).Handler())
+	sessionID := initializeSession(t, server1.URL+cfg.MCPPath)
+	server1.Close()
+
+	server2 := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st)).Handler())
+	defer server2.Close()
+
+	resp := postRPC(t, server2.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":44,"method":"tools/list","params":{}}`)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected persisted session to remain valid, status=%d body=%s", resp.StatusCode, string(body))
+	}
 }
 
 func TestMCPInitialize_RejectsMissingJSONRPCVersion(t *testing.T) {

--- a/tests/mcp/tools_test.go
+++ b/tests/mcp/tools_test.go
@@ -792,6 +792,17 @@ func TestMCPToolsCallStats_ReturnsStructuredContent(t *testing.T) {
 	if !ok || sttProvider == "" {
 		t.Fatalf("expected non-empty string models.stt_provider, got %#v", modelsRaw["stt_provider"])
 	}
+	sessionsRaw, ok := envelope.Result.StructuredContent["sessions"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected sessions object, got %#v", envelope.Result.StructuredContent["sessions"])
+	}
+	if active, ok := sessionsRaw["active"].(float64); !ok || active < 1 {
+		t.Fatalf("expected sessions.active >= 1, got %#v", sessionsRaw["active"])
+	}
+	items, ok := sessionsRaw["items"].([]interface{})
+	if !ok || len(items) == 0 {
+		t.Fatalf("expected non-empty sessions.items, got %#v", sessionsRaw["items"])
+	}
 }
 
 func TestMCPToolsCallStats_UsesRetrieverStats(t *testing.T) {
@@ -874,6 +885,13 @@ func TestMCPToolsCallStats_UsesRetrieverStats(t *testing.T) {
 	}
 	if !retriever.statsCalled.Load() {
 		t.Fatal("expected retriever.Stats to be called")
+	}
+	sessionsRaw, ok := envelope.Result.StructuredContent["sessions"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected sessions object, got %#v", envelope.Result.StructuredContent["sessions"])
+	}
+	if active, ok := sessionsRaw["active"].(float64); !ok || active < 1 {
+		t.Fatalf("expected sessions.active >= 1, got %#v", sessionsRaw["active"])
 	}
 }
 

--- a/tests/mcp/x402_test.go
+++ b/tests/mcp/x402_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -16,6 +17,7 @@ import (
 	"dir2mcp/internal/mcp"
 	"dir2mcp/internal/model"
 	"dir2mcp/internal/protocol"
+	"dir2mcp/internal/store"
 )
 
 func TestX402ToolsCall_UnpaidReturns402WithPaymentRequiredHeader(t *testing.T) {
@@ -319,6 +321,62 @@ func TestX402ToolsCall_SettleRetryReplaysCachedOutcomeWithoutReexecution(t *test
 	}
 	if fac.settleCalls.Load() != 2 {
 		t.Fatalf("settle calls=%d want=2", fac.settleCalls.Load())
+	}
+}
+
+func TestX402ToolsCall_CachedOutcomePersistsAcrossRestart(t *testing.T) {
+	t.Parallel()
+	fac := newFacilitatorStub(t)
+	fac.verifyStatus = http.StatusOK
+	fac.settleStatuses = []int{http.StatusServiceUnavailable, http.StatusOK}
+	fac.settleBodies = []string{
+		`{"message":"settlement unavailable"}`,
+		`{"ok":true,"success":true,"transaction":"abc123","txHash":"abc123","network":"eip155:8453"}`,
+	}
+	facServer := httptest.NewServer(fac)
+	defer facServer.Close()
+
+	cfg := x402EnabledTestConfig("https://resource.example.com")
+	cfg.AuthMode = "none"
+	cfg.X402.FacilitatorURL = facServer.URL
+
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	if err := st.Init(context.Background()); err != nil {
+		t.Fatalf("Init store failed: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+
+	retriever := &countingSearchRetriever{}
+	server1 := httptest.NewServer(mcp.NewServer(cfg, retriever, mcp.WithStore(st)).Handler())
+	sessionID := initializeSession(t, server1.URL+cfg.MCPPath)
+	body := `{"jsonrpc":"2.0","id":301,"method":"tools/call","params":{"name":"dir2mcp.search","arguments":{"query":"foo"}}}`
+
+	first := postRPCWithHeaders(t, server1.URL+cfg.MCPPath, sessionID, body, map[string]string{
+		"PAYMENT-SIGNATURE": "restart-stable-signature",
+	})
+	assertRPCErrorCodeAndRetryable(t, first, http.StatusServiceUnavailable, "PAYMENT_SETTLEMENT_UNAVAILABLE", true)
+	_ = first.Body.Close()
+	if retriever.searchCalls.Load() != 1 {
+		t.Fatalf("search calls after first request=%d want=1", retriever.searchCalls.Load())
+	}
+	server1.Close()
+
+	server2 := httptest.NewServer(mcp.NewServer(cfg, retriever, mcp.WithStore(st)).Handler())
+	defer server2.Close()
+
+	second := postRPCWithHeaders(t, server2.URL+cfg.MCPPath, sessionID, body, map[string]string{
+		"PAYMENT-SIGNATURE": "restart-stable-signature",
+	})
+	defer func() { _ = second.Body.Close() }()
+	if second.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(second.Body)
+		t.Fatalf("status=%d want=%d body=%s", second.StatusCode, http.StatusOK, string(payload))
+	}
+	if strings.TrimSpace(second.Header.Get("PAYMENT-RESPONSE")) == "" {
+		t.Fatal("expected PAYMENT-RESPONSE header after restart retry settlement")
+	}
+	if retriever.searchCalls.Load() != 1 {
+		t.Fatalf("search calls after restart retry=%d want=1 (must replay persisted outcome)", retriever.searchCalls.Load())
 	}
 }
 

--- a/tests/store/sqlite_store_test.go
+++ b/tests/store/sqlite_store_test.go
@@ -783,3 +783,86 @@ func TestSQLiteStoreConcurrentReadWriteWithWAL(t *testing.T) {
 		t.Fatalf("unexpected final listing size total=%d len=%d", total, len(got))
 	}
 }
+
+func TestSQLiteStore_MCPSessionPersistenceRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	created := time.Now().UTC().Add(-2 * time.Minute).Truncate(time.Second)
+	lastSeen := created.Add(30 * time.Second)
+	if err := st.UpsertMCPSession(ctx, "sess_1", created, lastSeen); err != nil {
+		t.Fatalf("UpsertMCPSession failed: %v", err)
+	}
+
+	sessions, err := st.ListMCPSessions(ctx)
+	if err != nil {
+		t.Fatalf("ListMCPSessions failed: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(sessions))
+	}
+	if sessions[0].ID != "sess_1" || !sessions[0].Created.Equal(created) || !sessions[0].LastSeen.Equal(lastSeen) {
+		t.Fatalf("unexpected session: %+v", sessions[0])
+	}
+
+	if err := st.DeleteMCPSession(ctx, "sess_1"); err != nil {
+		t.Fatalf("DeleteMCPSession failed: %v", err)
+	}
+	sessions, err = st.ListMCPSessions(ctx)
+	if err != nil {
+		t.Fatalf("ListMCPSessions failed: %v", err)
+	}
+	if len(sessions) != 0 {
+		t.Fatalf("expected 0 sessions, got %d", len(sessions))
+	}
+}
+
+func TestSQLiteStore_MCPPaymentOutcomePersistenceRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	now := time.Now().UTC().Truncate(time.Second)
+	in := store.MCPPaymentOutcomeRecord{
+		ExecutionKey:    "sig:params",
+		StatusCode:      200,
+		ResultJSON:      `{"ok":true}`,
+		RPCErrorJSON:    "",
+		RequiresSettle:  true,
+		Settled:         false,
+		PaymentResponse: "",
+		UpdatedAt:       now,
+	}
+	if err := st.UpsertMCPPaymentOutcome(ctx, in); err != nil {
+		t.Fatalf("UpsertMCPPaymentOutcome failed: %v", err)
+	}
+
+	got, err := st.ListMCPPaymentOutcomes(ctx)
+	if err != nil {
+		t.Fatalf("ListMCPPaymentOutcomes failed: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 outcome, got %d", len(got))
+	}
+	if got[0] != in {
+		t.Fatalf("unexpected outcome: got=%+v want=%+v", got[0], in)
+	}
+
+	if err := st.DeleteMCPPaymentOutcome(ctx, "sig:params"); err != nil {
+		t.Fatalf("DeleteMCPPaymentOutcome failed: %v", err)
+	}
+	got, err = st.ListMCPPaymentOutcomes(ctx)
+	if err != nil {
+		t.Fatalf("ListMCPPaymentOutcomes failed: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected 0 outcomes, got %d", len(got))
+	}
+}

--- a/tests/store/sqlite_store_test.go
+++ b/tests/store/sqlite_store_test.go
@@ -794,7 +794,7 @@ func TestSQLiteStore_MCPSessionPersistenceRoundTrip(t *testing.T) {
 
 	created := time.Now().UTC().Add(-2 * time.Minute).Truncate(time.Second)
 	lastSeen := created.Add(30 * time.Second)
-	if err := st.UpsertMCPSession(ctx, "sess_1", created, lastSeen); err != nil {
+	if err := st.UpsertMCPSession(ctx, "sess_1", created, lastSeen, "test-scope"); err != nil {
 		t.Fatalf("UpsertMCPSession failed: %v", err)
 	}
 


### PR DESCRIPTION
## Summary
- add first-class remote CLI commands for Unix composition: `search`, `open-file`, `list-files`
- wire CLI remote commands to running MCP server via `connection.json` with machine-readable stdout output and non-zero error exits
- persist MCP session metadata and payment execution outcomes in sqlite store
- restore persisted sessions/payment outcomes on server startup and prune expired entries
- add/extend tests for CLI remote command behavior and runtime persistence across restart

## Issues
- closes #123
- closes #124

## Verification
- go test ./tests/cli -count=1
- go test ./tests/store -count=1
- go test ./tests/mcp -count=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New CLI remote commands: search, open-file, list-files (JSON; list-files emits one JSON line per file). Ask now prefers a configured remote server when available.
  * CLI can call remote tools via a cached session-based HTTP JSON-RPC client.
  * Server stats now include session counts and session items.

* **Bug Fixes / Reliability**
  * Sessions and payment outcomes persist across server restarts; persisted entries are validated and pruned.

* **Tests**
  * Added tests for remote CLI commands, MCP persistence, session restore, and payment-outcome replay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->