### PR TITLE
chore(ci): harden workflow baseline

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   checks:
     runs-on: ubuntu-latest
@@ -61,7 +68,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Run inspector smoke test
         run: make inspector-smoke


### PR DESCRIPTION
Summary:
- add workflow-level permissions contents:read
- add concurrency cancel-in-progress guard
- update inspector-smoke Node runtime to 22

Notes:
- structural CI hardening only