### PR TITLE
fix(release): remove stale dirstral targets from goreleaser

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v*"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 permissions:
   contents: write
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,19 +17,6 @@ builds:
     ldflags:
       - -s -w -X dir2mcp/internal/cli.Version={{.Version}} -X dir2mcp/internal/cli.Commit={{.Commit}} -X dir2mcp/internal/cli.Date={{.Date}}
 
-  - id: dirstral
-    env:
-      - CGO_ENABLED=0
-    goos:
-      - darwin
-      - linux
-    goarch:
-      - amd64
-      - arm64
-    main: ./cmd/dirstral
-    binary: dirstral
-    ldflags:
-      - -s -w -X dir2mcp/internal/dirstral/app.Version={{.Tag}} -X dir2mcp/internal/dirstral/app.Commit={{.Commit}} -X dir2mcp/internal/dirstral/app.Date={{.Date}}
 
 archives:
   - id: dir2mcp-archive
@@ -38,11 +25,6 @@ archives:
     formats: [tar.gz]
     name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
-  - id: dirstral-archive
-    ids:
-      - dirstral
-    formats: [tar.gz]
-    name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
 checksum:
   name_template: checksums.txt
@@ -70,21 +52,6 @@ brews:
     test: |
       system "#{bin}/dir2mcp", "version"
 
-  - name: dirstral
-    ids:
-      - dirstral-archive
-    repository:
-      owner: Dirstral
-      name: homebrew-tap
-      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-    directory: Formula
-    homepage: https://github.com/Dirstral/dir2mcp
-    description: Interactive TUI client for dir2mcp knowledge bases.
-    license: MIT
-    install: |
-      bin.install "dirstral"
-    test: |
-      system "#{bin}/dirstral", "version"
 
 changelog:
   sort: asc


### PR DESCRIPTION
Summary:\n- remove obsolete dirstral build target\n- remove obsolete dirstral archive target\n- remove obsolete dirstral brew target\n\nReason:\n- release workflow fails because cmd/dirstral no longer exists

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to use Node 24 for improved compatibility.
  * Updated release build configuration to support new build infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->