### PR TITLE
fix: release homebrew owner casing for goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -31,7 +31,7 @@ checksum:
 
 release:
   github:
-    owner: Dirstral
+    owner: dirstral
     name: dir2mcp
   name_template: "{{.ProjectName}} {{.Tag}}"
 
@@ -40,11 +40,11 @@ brews:
     ids:
       - dir2mcp-archive
     repository:
-      owner: Dirstral
+      owner: dirstral
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     directory: Formula
-    homepage: https://github.com/Dirstral/dir2mcp
+    homepage: https://github.com/dirstral/dir2mcp
     description: Deploy any local directory as an MCP knowledge server with indexing, retrieval, and citations.
     license: MIT
     install: |

--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ make benchmark    # run retrieval benchmarks
 
 Release automation:
 - Pushing a `v*` tag triggers `.github/workflows/release.yml` and publishes artifacts via GoReleaser.
-- Homebrew formula updates require `HOMEBREW_TAP_GITHUB_TOKEN` with write access to `Dirstral/homebrew-tap`.
+- Homebrew formula updates require `HOMEBREW_TAP_GITHUB_TOKEN` with write access to `dirstral/homebrew-tap`.
 
 API notes:
 - `retrieval.NewEngine` now requires a context as its first parameter:


### PR DESCRIPTION
Summary:
- switch GoReleaser GitHub owner references to lowercase dirstral
- align Homebrew tap repository owner with the org path used by the token
- update README token-scope example to dirstral/homebrew-tap

Validation:
- go test ./tests/cli -count=1