### PR TITLE
feat(retrieval): bump default k from 10 to 15 (#160)

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1081,7 +1081,7 @@ All schemas are JSON Schema (draft-agnostic, compatible with common validators).
   "additionalProperties": false,
   "properties": {
     "query": { "type": "string", "minLength": 1 },
-    "k": { "type": "integer", "minimum": 1, "maximum": 50, "default": 10 },
+    "k": { "type": "integer", "minimum": 1, "maximum": 50, "default": 15 },
     "index": { "type": "string", "enum": ["auto", "text", "code", "both"], "default": "auto" },
     "path_prefix": { "type": "string" },
     "file_glob": { "type": "string" },
@@ -1129,7 +1129,7 @@ All schemas are JSON Schema (draft-agnostic, compatible with common validators).
   "additionalProperties": false,
   "properties": {
     "question": { "type": "string", "minLength": 1 },
-    "k": { "type": "integer", "minimum": 1, "maximum": 50, "default": 10 },
+    "k": { "type": "integer", "minimum": 1, "maximum": 50, "default": 15 },
     "mode": { "type": "string", "enum": ["answer", "search_only"], "default": "answer" },
     "index": { "type": "string", "enum": ["auto", "text", "code", "both"], "default": "auto" },
     "path_prefix": { "type": "string" },
@@ -1462,7 +1462,7 @@ filters is impossible.
   "properties": {
     "rel_path": { "type": "string", "minLength": 1 },
     "question": { "type": "string", "minLength": 1 },
-    "k": { "type": "integer", "minimum": 1, "maximum": 50, "default": 10 }
+    "k": { "type": "integer", "minimum": 1, "maximum": 50, "default": 15 }
   },
   "required": ["rel_path", "question"]
 }
@@ -1534,7 +1534,7 @@ mistral:
 
 rag:
   generate_answer: true
-  k_default: 10
+  k_default: 15
   system_prompt: |
     You are a retrieval-augmented assistant.
     Use citations and never invent sources.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1476,9 +1476,9 @@ filters is impossible.
 
 ### 15.10 `dir2mcp.ask_audio` (optional extension)
 
-**Description:** same as `ask` but includes audio output (TTS). Optional and additive.
+**Description:** same as `ask` but includes audio output (TTS). Optional and additive. The input schema inherits all fields of `dir2mcp.ask` (`question`, `k`, `mode`, `index`, `path_prefix`, `file_glob`, `doc_types`) plus the audio-specific fields shown below.
 
-Input schema:
+Input schema (audio-specific fields; the rest mirror `dir2mcp.ask`):
 
 ```json
 {
@@ -1486,6 +1486,7 @@ Input schema:
   "additionalProperties": false,
   "properties": {
     "question": { "type": "string", "minLength": 1 },
+    "k": { "type": "integer", "minimum": 1, "maximum": 50, "default": 15 },
     "voice_id": { "type": "string" },
     "format": { "type": "string", "enum": ["mp3", "wav"], "default": "mp3" }
   },

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -48,7 +48,7 @@ const (
 
 // DefaultSearchK is used when tools/call search arguments omit k or provide
 // a non-positive value.
-const DefaultSearchK = 10
+const DefaultSearchK = 15
 
 // MaxSearchK is the highest allowed k value for search/ask requests.
 const MaxSearchK = 50

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1983,7 +1983,7 @@ func searchInputSchema() map[string]interface{} {
 		"additionalProperties": false,
 		"properties": map[string]interface{}{
 			"query":       map[string]interface{}{"type": "string", "minLength": 1},
-			"k":           map[string]interface{}{"type": "integer", "minimum": 1, "maximum": 50, "default": 10},
+			"k":           map[string]interface{}{"type": "integer", "minimum": 1, "maximum": 50, "default": 15},
 			"index":       map[string]interface{}{"type": "string", "enum": []string{"auto", "text", "code", "both"}, "default": "auto"},
 			"path_prefix": map[string]interface{}{"type": "string"},
 			"file_glob":   map[string]interface{}{"type": "string"},
@@ -2015,7 +2015,7 @@ func askInputSchema() map[string]interface{} {
 		"additionalProperties": false,
 		"properties": map[string]interface{}{
 			"question":    map[string]interface{}{"type": "string", "minLength": 1},
-			"k":           map[string]interface{}{"type": "integer", "minimum": 1, "maximum": 50, "default": 10},
+			"k":           map[string]interface{}{"type": "integer", "minimum": 1, "maximum": 50, "default": 15},
 			"mode":        map[string]interface{}{"type": "string", "enum": []string{"answer", "search_only"}, "default": "answer"},
 			"index":       map[string]interface{}{"type": "string", "enum": []string{"auto", "text", "code", "both"}, "default": "auto"},
 			"path_prefix": map[string]interface{}{"type": "string"},
@@ -2163,7 +2163,7 @@ func transcribeAndAskInputSchema() map[string]interface{} {
 		"properties": map[string]interface{}{
 			"rel_path": map[string]interface{}{"type": "string", "minLength": 1},
 			"question": map[string]interface{}{"type": "string", "minLength": 1},
-			"k":        map[string]interface{}{"type": "integer", "minimum": 1, "maximum": 50, "default": 10},
+			"k":        map[string]interface{}{"type": "integer", "minimum": 1, "maximum": 50, "default": 15},
 		},
 		"required": []string{"rel_path", "question"},
 	}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1983,7 +1983,7 @@ func searchInputSchema() map[string]interface{} {
 		"additionalProperties": false,
 		"properties": map[string]interface{}{
 			"query":       map[string]interface{}{"type": "string", "minLength": 1},
-			"k":           map[string]interface{}{"type": "integer", "minimum": 1, "maximum": 50, "default": 15},
+			"k":           map[string]interface{}{"type": "integer", "minimum": 1, "maximum": MaxSearchK, "default": DefaultSearchK},
 			"index":       map[string]interface{}{"type": "string", "enum": []string{"auto", "text", "code", "both"}, "default": "auto"},
 			"path_prefix": map[string]interface{}{"type": "string"},
 			"file_glob":   map[string]interface{}{"type": "string"},

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2015,7 +2015,7 @@ func askInputSchema() map[string]interface{} {
 		"additionalProperties": false,
 		"properties": map[string]interface{}{
 			"question":    map[string]interface{}{"type": "string", "minLength": 1},
-			"k":           map[string]interface{}{"type": "integer", "minimum": 1, "maximum": 50, "default": 15},
+			"k":           map[string]interface{}{"type": "integer", "minimum": 1, "maximum": MaxSearchK, "default": DefaultSearchK},
 			"mode":        map[string]interface{}{"type": "string", "enum": []string{"answer", "search_only"}, "default": "answer"},
 			"index":       map[string]interface{}{"type": "string", "enum": []string{"auto", "text", "code", "both"}, "default": "auto"},
 			"path_prefix": map[string]interface{}{"type": "string"},

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2163,7 +2163,7 @@ func transcribeAndAskInputSchema() map[string]interface{} {
 		"properties": map[string]interface{}{
 			"rel_path": map[string]interface{}{"type": "string", "minLength": 1},
 			"question": map[string]interface{}{"type": "string", "minLength": 1},
-			"k":        map[string]interface{}{"type": "integer", "minimum": 1, "maximum": 50, "default": 15},
+			"k":        map[string]interface{}{"type": "integer", "minimum": 1, "maximum": MaxSearchK, "default": DefaultSearchK},
 		},
 		"required": []string{"rel_path", "question"},
 	}

--- a/internal/retrieval/engine.go
+++ b/internal/retrieval/engine.go
@@ -282,7 +282,7 @@ func (e *Engine) AskWithContext(ctx context.Context, question string, opts AskOp
 
 	k := opts.K
 	if k <= 0 {
-		k = 10
+		k = 15
 	}
 
 	timeout := e.askTimeout

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -433,7 +433,7 @@ func (s *Service) Search(ctx context.Context, query model.SearchQuery) ([]model.
 
 	k := query.K
 	if k <= 0 {
-		k = 10
+		k = 15
 	}
 
 	mode := strings.ToLower(strings.TrimSpace(query.Index))

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -467,7 +467,7 @@ func (s *Service) Ask(ctx context.Context, question string, query model.SearchQu
 		query.Query = question
 	}
 	if query.K <= 0 {
-		query.K = 10
+		query.K = 15
 	}
 
 	hits, err := s.Search(ctx, query)


### PR DESCRIPTION
Closes #160.

## Summary
- Default k for `dir2mcp.search`, `.ask`, `.ask_audio`, `.transcribe_and_ask` raised from 10 → 15.
- Updated `DefaultSearchK` constant, all four MCP tool input schemas, the retrieval engine/service fallbacks, and 4 SPEC.md mentions.

## Why
On a real legal corpus (~89 PDFs, ~2.7k chunks) the chunk that correctly answered an AML reporting question landed at rank ~12 — just outside the default top-10. Re-asking with `k=20` produced a clean grounded answer. k=15 is the smallest bump that catches the failures observed in practice.

This is a stopgap for #158 (hybrid retrieval); cost difference for typical short Q&A is negligible.

## Test plan
- [x] `make ci` passes locally
- [x] Existing tests reference `mcp.DefaultSearchK` by name → auto-update; no test bumps required
- [ ] CI matrix on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Increased default retrieval result count from 10 to 15 for search, ask, and transcribe_and_ask functions when the limit is not explicitly specified, providing more comprehensive results by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->