### PR TITLE
fix(store): eliminate SQLITE_BUSY contention during embedding writes (#161)

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -1365,9 +1365,7 @@ func runCorpusWriterWithInterval(ctx context.Context, stateDir string, st model.
 		interval = 5 * time.Second
 	}
 	// Emit an initial snapshot immediately, then refresh while indexing runs.
-	if err := writeCorpusSnapshot(ctx, stateDir, st, indexingState, stderr, emitter); err != nil {
-		writef(stderr, "write corpus snapshot: %v\n", err)
-	}
+	logSnapshotErr(stderr, writeCorpusSnapshot(ctx, stateDir, st, indexingState, stderr, emitter))
 
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
@@ -1379,11 +1377,23 @@ func runCorpusWriterWithInterval(ctx context.Context, stateDir string, st model.
 			if indexingState != nil && !indexingState.Snapshot().Running {
 				continue
 			}
-			if err := writeCorpusSnapshot(ctx, stateDir, st, indexingState, stderr, emitter); err != nil {
-				writef(stderr, "write corpus snapshot: %v\n", err)
-			}
+			logSnapshotErr(stderr, writeCorpusSnapshot(ctx, stateDir, st, indexingState, stderr, emitter))
 		}
 	}
+}
+
+// logSnapshotErr writes a corpus-snapshot error to stderr unless it is a
+// context cancellation. Cancellation is the normal shutdown signal — emitting
+// it as plaintext on stderr pollutes the JSON event stream the caller may be
+// consuming and provides no actionable information. Suppress it.
+func logSnapshotErr(stderr io.Writer, err error) {
+	if err == nil {
+		return
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return
+	}
+	writef(stderr, "write corpus snapshot: %v\n", err)
 }
 
 func writeCorpusSnapshot(ctx context.Context, stateDir string, st model.Store, indexingState *appstate.IndexingState, stderr io.Writer, emitter *ndjsonEmitter) error {

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -251,9 +251,13 @@ func openDB(ctx context.Context, path string) (*sql.DB, error) {
 		return nil, err
 	}
 	db.SetMaxOpenConns(1)
+	// Order matters: busy_timeout MUST come before journal_mode. Switching to
+	// WAL itself can fail with SQLITE_BUSY if another process holds the
+	// database lock; without busy_timeout already in effect, that PRAGMA
+	// returns immediately rather than waiting.
 	for _, pragma := range []string{
-		`PRAGMA journal_mode=WAL;`,
 		`PRAGMA busy_timeout=5000;`,
+		`PRAGMA journal_mode=WAL;`,
 	} {
 		if _, err := db.ExecContext(ctx, pragma); err != nil {
 			_ = db.Close()

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -235,12 +235,14 @@ func NewSQLiteStore(path string) *SQLiteStore {
 // openDB opens the SQLite file and applies the connection-pool and pragma
 // settings that protect against in-process and cross-process write contention:
 //
-//   - SetMaxOpenConns(1) serializes all writers through a single connection.
-//     Without this, the database/sql pool can hand out multiple connections to
-//     concurrent goroutines (chunk writers and embedding-mark batches), each
-//     starting its own write transaction, producing SQLITE_BUSY. Readers remain
-//     concurrent thanks to WAL mode (readers do not share the writer connection).
-//   - PRAGMA journal_mode=WAL keeps reads non-blocking against writes.
+//   - SetMaxOpenConns(1) serializes all operations through this single
+//     *sql.DB handle. Without this, the database/sql pool can hand out
+//     multiple connections to concurrent goroutines (chunk writers and
+//     embedding-mark batches), each starting its own write transaction and
+//     producing SQLITE_BUSY.
+//   - PRAGMA journal_mode=WAL reduces SQLite-level read/write blocking for
+//     other connections and processes, even though operations through this
+//     handle are still serialized by the single-connection pool.
 //   - PRAGMA busy_timeout instructs SQLite to wait rather than return BUSY
 //     immediately when an external process holds the database lock.
 func openDB(ctx context.Context, path string) (*sql.DB, error) {

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -232,6 +232,35 @@ func NewSQLiteStore(path string) *SQLiteStore {
 	return s
 }
 
+// openDB opens the SQLite file and applies the connection-pool and pragma
+// settings that protect against in-process and cross-process write contention:
+//
+//   - SetMaxOpenConns(1) serializes all writers through a single connection.
+//     Without this, the database/sql pool can hand out multiple connections to
+//     concurrent goroutines (chunk writers and embedding-mark batches), each
+//     starting its own write transaction, producing SQLITE_BUSY. Readers remain
+//     concurrent thanks to WAL mode (readers do not share the writer connection).
+//   - PRAGMA journal_mode=WAL keeps reads non-blocking against writes.
+//   - PRAGMA busy_timeout instructs SQLite to wait rather than return BUSY
+//     immediately when an external process holds the database lock.
+func openDB(ctx context.Context, path string) (*sql.DB, error) {
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		return nil, err
+	}
+	db.SetMaxOpenConns(1)
+	for _, pragma := range []string{
+		`PRAGMA journal_mode=WAL;`,
+		`PRAGMA busy_timeout=5000;`,
+	} {
+		if _, err := db.ExecContext(ctx, pragma); err != nil {
+			_ = db.Close()
+			return nil, err
+		}
+	}
+	return db, nil
+}
+
 // initLocked performs the same initialization work as Init but assumes
 // the caller already holds s.mu. This helper allows ensureDB to set up the
 // database under lock, closing a small race window against Close().
@@ -255,13 +284,8 @@ func (s *SQLiteStore) initLocked(ctx context.Context) error {
 		return fmt.Errorf("set database file permissions: %w", err)
 	}
 
-	db, err := sql.Open("sqlite", s.path)
+	db, err := openDB(ctx, s.path)
 	if err != nil {
-		return err
-	}
-
-	if _, err := db.ExecContext(ctx, `PRAGMA journal_mode=WAL;`); err != nil {
-		_ = db.Close()
 		return err
 	}
 

--- a/tests/store/sqlite_concurrent_writers_test.go
+++ b/tests/store/sqlite_concurrent_writers_test.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"dir2mcp/internal/model"
 	"dir2mcp/internal/store"
@@ -31,7 +32,12 @@ func TestSQLiteStore_ConcurrentWritersNoBusy(t *testing.T) {
 		marksPerMarker   = 50
 	)
 
-	ctx := context.Background()
+	// Bound the test so a regression that re-introduces lock contention or
+	// blocking causes a fast, descriptive failure rather than an unbounded
+	// CI hang. 30s is generous for the workload below on cold cache.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
 	dbPath := filepath.Join(t.TempDir(), "meta.sqlite")
 	st := store.NewSQLiteStore(dbPath)
 	defer func() { _ = st.Close() }()

--- a/tests/store/sqlite_concurrent_writers_test.go
+++ b/tests/store/sqlite_concurrent_writers_test.go
@@ -1,0 +1,108 @@
+package tests
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"dir2mcp/internal/model"
+	"dir2mcp/internal/store"
+)
+
+// TestSQLiteStore_ConcurrentWritersNoBusy guards against the SQLITE_BUSY
+// regression observed during fresh indexing of moderately-sized corpora. Two
+// kinds of writers run in parallel against the same store:
+//   - chunk writers (UpsertChunkTask) — simulating the ingest goroutine
+//   - embedding markers (MarkEmbedded) — simulating the embedding worker
+//
+// Without a single-writer connection or a busy_timeout, the in-process
+// contention between these two paths used to produce SQLITE_BUSY (5) errors
+// that were retried up to 3 times. The fix in initLocked sets
+// SetMaxOpenConns(1) and a busy_timeout pragma so this test must complete with
+// zero errors from any writer goroutine.
+func TestSQLiteStore_ConcurrentWritersNoBusy(t *testing.T) {
+	const (
+		chunkWriters     = 8
+		writesPerWriter  = 200
+		embeddingMarkers = 4
+		marksPerMarker   = 50
+	)
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "meta.sqlite")
+	st := store.NewSQLiteStore(dbPath)
+	defer func() { _ = st.Close() }()
+
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	var (
+		wg       sync.WaitGroup
+		busyHits int64
+		anyErr   atomic.Value
+	)
+
+	recordErr := func(stage string, err error) {
+		if err == nil {
+			return
+		}
+		// Track BUSY specifically so a regression fails with a clear signal.
+		if strings.Contains(strings.ToLower(err.Error()), "busy") {
+			atomic.AddInt64(&busyHits, 1)
+		}
+		anyErr.Store(stage + ": " + err.Error())
+	}
+
+	// Chunk writers
+	for w := 0; w < chunkWriters; w++ {
+		writerID := w
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < writesPerWriter; i++ {
+				label := uint64(writerID*writesPerWriter + i + 1)
+				task := model.NewChunkTask(label, "concurrent text", "text", model.ChunkMetadata{
+					ChunkID: label,
+					RelPath: "docs/concurrent.md",
+					DocType: "md",
+					RepType: "raw_text",
+				})
+				if err := st.UpsertChunkTask(ctx, task); err != nil {
+					recordErr("UpsertChunkTask", err)
+					return
+				}
+			}
+		}()
+	}
+
+	// Embedding markers — try to mark labels as embedded as soon as they may
+	// have been written. These calls run concurrently with the writers above
+	// to maximize lock contention on the underlying database.
+	for m := 0; m < embeddingMarkers; m++ {
+		markerID := m
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < marksPerMarker; i++ {
+				labels := []uint64{uint64(markerID*marksPerMarker + i + 1)}
+				if err := st.MarkEmbedded(ctx, labels); err != nil {
+					recordErr("MarkEmbedded", err)
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	if hits := atomic.LoadInt64(&busyHits); hits > 0 {
+		t.Fatalf("SQLITE_BUSY regression: %d BUSY error(s) under concurrent writers", hits)
+	}
+	if err := anyErr.Load(); err != nil {
+		t.Fatalf("unexpected writer error: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #161.

## Summary
- `internal/store/sqlite_store.go`: extracted SQLite open into `openDB`, which calls `SetMaxOpenConns(1)` and sets `PRAGMA busy_timeout=5000` alongside the existing `journal_mode=WAL`.
- New `tests/store/sqlite_concurrent_writers_test.go` exercises 8 chunk writers + 4 embedding markers in parallel and asserts zero BUSY hits.

## Why
First-time indexing of moderately-sized corpora (~2.7k chunks) surfaced:
```
mark embedded attempt 1/3 failed: database is locked (5) (SQLITE_BUSY)
```
Indexing self-recovered on retry, but the warning indicated two writers contending. Root cause: `sql.Open` did not constrain the connection pool, so the pool could hand out multiple connections to concurrent goroutines (chunk writers and embedding-mark batches), each starting its own write transaction. SQLite allows only one concurrent writer.

`SetMaxOpenConns(1)` eliminates in-process contention by serializing writes through a single connection. WAL mode keeps reads non-blocking. `busy_timeout` guards against external concurrent processes.

## Test plan
- [x] `make ci` passes locally
- [x] New regression test passes under `-race`
- [ ] CI matrix on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved shutdown behavior to prevent spurious error messages during normal application termination.
  * Enhanced data storage reliability and performance under concurrent write operations through optimized connection settings and error handling.

* **Tests**
  * Added regression test to verify robust behavior when multiple write operations occur simultaneously.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->