### PR TITLE
feat(ingest,mcp): extract and surface document titles in citations (#159)

### DIFF
--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -881,6 +881,7 @@ func (s *Service) generateRepresentations(ctx context.Context, doc model.Documen
 			return err
 		}
 		s.addRepresentations(1)
+		s.persistTitleIfFound(ctx, doc, string(content))
 		return nil
 	}
 
@@ -904,6 +905,22 @@ func (s *Service) generateRepresentations(ctx context.Context, doc model.Documen
 		s.addRepresentations(1)
 	}
 	return nil
+}
+
+// persistTitleIfFound runs the title heuristic on the supplied text body and,
+// if a title is extracted, re-upserts the document so the title column is
+// populated. Failures here are non-fatal: an empty or unwritten title only
+// degrades citation display, so we log and continue rather than aborting the
+// ingest of an otherwise-successful document.
+func (s *Service) persistTitleIfFound(ctx context.Context, doc model.Document, body string) {
+	title := ExtractTitle(body)
+	if title == "" || title == doc.Title {
+		return
+	}
+	doc.Title = title
+	if err := s.store.UpsertDocument(ctx, doc); err != nil {
+		s.getLogger().Printf("persist title for %s: %v", doc.RelPath, err)
+	}
 }
 
 // isUnexpectedStoreErr returns true when err is non-nil and is not a
@@ -948,6 +965,8 @@ func (s *Service) generateOCRMarkdownRepresentation(ctx context.Context, doc mod
 	if ocrText == "" {
 		return nil
 	}
+
+	s.persistTitleIfFound(ctx, doc, ocrText)
 
 	rep := model.Representation{
 		DocID:       doc.DocID,

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -881,7 +881,13 @@ func (s *Service) generateRepresentations(ctx context.Context, doc model.Documen
 			return err
 		}
 		s.addRepresentations(1)
-		s.persistTitleIfFound(ctx, doc, string(content))
+
+		const titleScanLimit = 4096
+		titleContent := content
+		if len(titleContent) > titleScanLimit {
+			titleContent = titleContent[:titleScanLimit]
+		}
+		s.persistTitleIfFound(ctx, doc, string(titleContent))
 		return nil
 	}
 

--- a/internal/ingest/title.go
+++ b/internal/ingest/title.go
@@ -3,6 +3,7 @@ package ingest
 import (
 	"strings"
 	"unicode"
+	"unicode/utf8"
 )
 
 // titleScanLimit caps how much of the document body the title heuristic
@@ -18,7 +19,8 @@ const titleMaxLen = 200
 // beginning of a text/markdown/OCR body. Used to humanize citations whose
 // rel_path is opaque (e.g. Windows 8.3-truncated PDF filenames).
 //
-// Heuristic, in order of preference:
+// Heuristic, in order of preference (markdown headings always win, even when
+// they appear after an earlier uppercase-line candidate):
 //  1. The first markdown heading line (`# Title`, `## Title`, ...).
 //  2. The first line that is mostly uppercase and looks title-like.
 //
@@ -28,9 +30,8 @@ func ExtractTitle(body string) string {
 	if body == "" {
 		return ""
 	}
-	if len(body) > titleScanLimit {
-		body = body[:titleScanLimit]
-	}
+	body = truncateOnRuneBoundary(body, titleScanLimit)
+	var uppercaseFallback string
 	for _, raw := range strings.Split(body, "\n") {
 		line := strings.TrimSpace(raw)
 		if line == "" {
@@ -39,11 +40,29 @@ func ExtractTitle(body string) string {
 		if title := titleFromMarkdownHeading(line); title != "" {
 			return title
 		}
-		if title := titleFromUppercaseLine(line); title != "" {
-			return title
+		if uppercaseFallback == "" {
+			if title := titleFromUppercaseLine(line); title != "" {
+				uppercaseFallback = title
+			}
 		}
 	}
-	return ""
+	return uppercaseFallback
+}
+
+// truncateOnRuneBoundary returns s truncated to at most maxBytes bytes, but
+// never splits a UTF-8 rune. Slicing by raw byte offset can produce invalid
+// UTF-8 (e.g. cutting a multi-byte rune in half), which would break later
+// rune-aware passes. Walk back from the cut point until we find a valid
+// rune boundary.
+func truncateOnRuneBoundary(s string, maxBytes int) string {
+	if len(s) <= maxBytes {
+		return s
+	}
+	cut := maxBytes
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut]
 }
 
 func titleFromMarkdownHeading(line string) string {

--- a/internal/ingest/title.go
+++ b/internal/ingest/title.go
@@ -85,8 +85,9 @@ func titleFromUppercaseLine(line string) string {
 
 func clampTitle(s string) string {
 	s = strings.TrimSpace(s)
-	if len(s) > titleMaxLen {
-		s = strings.TrimSpace(s[:titleMaxLen])
+	runes := []rune(s)
+	if len(runes) > titleMaxLen {
+		s = strings.TrimSpace(string(runes[:titleMaxLen]))
 	}
 	return s
 }

--- a/internal/ingest/title.go
+++ b/internal/ingest/title.go
@@ -1,0 +1,102 @@
+package ingest
+
+import (
+	"strings"
+	"unicode"
+)
+
+// titleScanLimit caps how much of the document body the title heuristic
+// inspects. The title nearly always appears within the first kilobyte of an
+// OCR'd act or markdown document.
+const titleScanLimit = 4000
+
+// titleMaxLen is the longest title we will surface; longer first-lines are
+// almost certainly body text mistakenly capitalized.
+const titleMaxLen = 200
+
+// ExtractTitle attempts to derive a human-readable document title from the
+// beginning of a text/markdown/OCR body. Used to humanize citations whose
+// rel_path is opaque (e.g. Windows 8.3-truncated PDF filenames).
+//
+// Heuristic, in order of preference:
+//  1. The first markdown heading line (`# Title`, `## Title`, ...).
+//  2. The first line that is mostly uppercase and looks title-like.
+//
+// Returns an empty string if no candidate is found. Callers should treat the
+// empty result as "no title available" and fall back to rel_path themselves.
+func ExtractTitle(body string) string {
+	if body == "" {
+		return ""
+	}
+	if len(body) > titleScanLimit {
+		body = body[:titleScanLimit]
+	}
+	for _, raw := range strings.Split(body, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" {
+			continue
+		}
+		if title := titleFromMarkdownHeading(line); title != "" {
+			return title
+		}
+		if title := titleFromUppercaseLine(line); title != "" {
+			return title
+		}
+	}
+	return ""
+}
+
+func titleFromMarkdownHeading(line string) string {
+	if !strings.HasPrefix(line, "#") {
+		return ""
+	}
+	stripped := strings.TrimLeft(line, "#")
+	stripped = strings.TrimSpace(stripped)
+	if stripped == "" {
+		return ""
+	}
+	return clampTitle(stripped)
+}
+
+// titleFromUppercaseLine returns the line if it looks like an act/document
+// title: at least 3 letters, mostly uppercase, no trailing sentence punctuation.
+func titleFromUppercaseLine(line string) string {
+	letters := 0
+	upper := 0
+	for _, r := range line {
+		if unicode.IsLetter(r) {
+			letters++
+			if unicode.IsUpper(r) {
+				upper++
+			}
+		}
+	}
+	if letters < 3 {
+		return ""
+	}
+	if float64(upper)/float64(letters) < 0.7 {
+		return ""
+	}
+	if last := lastNonSpace(line); last == '.' {
+		return ""
+	}
+	return clampTitle(line)
+}
+
+func clampTitle(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) > titleMaxLen {
+		s = strings.TrimSpace(s[:titleMaxLen])
+	}
+	return s
+}
+
+func lastNonSpace(s string) rune {
+	runes := []rune(s)
+	for i := len(runes) - 1; i >= 0; i-- {
+		if !unicode.IsSpace(runes[i]) {
+			return runes[i]
+		}
+	}
+	return 0
+}

--- a/internal/ingest/title_test.go
+++ b/internal/ingest/title_test.go
@@ -1,0 +1,91 @@
+package ingest
+
+import "testing"
+
+func TestExtractTitle(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "markdown h1",
+			body: "# Document Title\n\nbody text",
+			want: "Document Title",
+		},
+		{
+			name: "markdown h2",
+			body: "## Subtitle Heading\nmore body",
+			want: "Subtitle Heading",
+		},
+		{
+			name: "uppercase act title typical of OCR'd legal PDF",
+			body: "VIRGIN ISLANDS\n\n# PROLIFERATION FINANCING (PROHIBITION) ACT, 2021\n\narrangement of sections...",
+			want: "VIRGIN ISLANDS",
+		},
+		{
+			name: "leading whitespace and blank lines are skipped",
+			body: "\n\n   \n# Title After Blanks\n",
+			want: "Title After Blanks",
+		},
+		{
+			name: "lowercase prose is rejected",
+			body: "this is just a sentence in normal prose. It is not a title.",
+			want: "",
+		},
+		{
+			name: "uppercase line ending in a period is rejected (looks like a sentence)",
+			body: "THIS IS A SHOUTED SENTENCE.\n",
+			want: "",
+		},
+		{
+			name: "mostly-uppercase line shorter than 3 letters is rejected",
+			body: "X\n",
+			want: "",
+		},
+		{
+			name: "title is clamped to titleMaxLen",
+			body: "# " + repeat("A", 500),
+			want: repeat("A", titleMaxLen),
+		},
+		{
+			name: "empty body returns empty",
+			body: "",
+			want: "",
+		},
+		{
+			name: "scan limit honored — late title is found if before limit",
+			body: padding(titleScanLimit-200) + "# Late Title Within Window",
+			want: "Late Title Within Window",
+		},
+		{
+			name: "scan limit honored — title past limit is NOT found",
+			body: padding(titleScanLimit+200) + "# Title Past The Limit",
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ExtractTitle(tc.body)
+			if got != tc.want {
+				t.Errorf("ExtractTitle(...)\n got: %q\nwant: %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func repeat(s string, n int) string {
+	out := make([]byte, 0, len(s)*n)
+	for i := 0; i < n; i++ {
+		out = append(out, s...)
+	}
+	return string(out)
+}
+
+func padding(n int) string {
+	out := make([]byte, n)
+	for i := range out {
+		out[i] = ' '
+	}
+	return string(out)
+}

--- a/internal/ingest/title_test.go
+++ b/internal/ingest/title_test.go
@@ -19,8 +19,13 @@ func TestExtractTitle(t *testing.T) {
 			want: "Subtitle Heading",
 		},
 		{
-			name: "uppercase act title typical of OCR'd legal PDF",
+			name: "OCR'd legal PDF: heading wins over earlier all-caps jurisdiction header",
 			body: "VIRGIN ISLANDS\n\n# PROLIFERATION FINANCING (PROHIBITION) ACT, 2021\n\narrangement of sections...",
+			want: "PROLIFERATION FINANCING (PROHIBITION) ACT, 2021",
+		},
+		{
+			name: "uppercase fallback when no heading is present",
+			body: "VIRGIN ISLANDS\n\nsome body text that follows\n",
 			want: "VIRGIN ISLANDS",
 		},
 		{

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -445,14 +445,18 @@ func (s *Server) handleListFilesTool(ctx context.Context, args map[string]interf
 	files := make([]map[string]interface{}, 0, len(docs))
 	for _, doc := range docs {
 		status := normalizeFileStatus(doc.Status)
-		files = append(files, map[string]interface{}{
+		entry := map[string]interface{}{
 			"rel_path":   doc.RelPath,
 			"doc_type":   doc.DocType,
 			"size_bytes": doc.SizeBytes,
 			"mtime_unix": doc.MTimeUnix,
 			"status":     status,
 			"deleted":    doc.Deleted,
-		})
+		}
+		if title := strings.TrimSpace(doc.Title); title != "" {
+			entry["title"] = title
+		}
+		files = append(files, entry)
 	}
 
 	structured := map[string]interface{}{
@@ -1873,7 +1877,7 @@ func looksLikeBinaryContent(relPath, content string) bool {
 }
 
 func serializeHit(h model.SearchHit) map[string]interface{} {
-	return map[string]interface{}{
+	out := map[string]interface{}{
 		"chunk_id": h.ChunkID,
 		"rel_path": h.RelPath,
 		"doc_type": h.DocType,
@@ -1882,6 +1886,10 @@ func serializeHit(h model.SearchHit) map[string]interface{} {
 		"snippet":  h.Snippet,
 		"span":     buildOpenFileSpan(h.Span),
 	}
+	if title := strings.TrimSpace(h.Title); title != "" {
+		out["title"] = title
+	}
+	return out
 }
 
 func serializeSearchHits(hits []model.SearchHit) []map[string]interface{} {
@@ -1895,11 +1903,15 @@ func serializeSearchHits(hits []model.SearchHit) []map[string]interface{} {
 func buildAskStructuredContent(result model.AskResult) map[string]interface{} {
 	citations := make([]map[string]interface{}, 0, len(result.Citations))
 	for _, citation := range result.Citations {
-		citations = append(citations, map[string]interface{}{
+		entry := map[string]interface{}{
 			"chunk_id": citation.ChunkID,
 			"rel_path": citation.RelPath,
 			"span":     buildOpenFileSpan(citation.Span),
-		})
+		}
+		if title := strings.TrimSpace(citation.Title); title != "" {
+			entry["title"] = title
+		}
+		citations = append(citations, entry)
 	}
 
 	hits := make([]map[string]interface{}, 0, len(result.Hits))
@@ -1960,6 +1972,7 @@ func hitDefinitionSchema() map[string]interface{} {
 		"properties": map[string]interface{}{
 			"chunk_id": map[string]interface{}{"type": "integer"},
 			"rel_path": map[string]interface{}{"type": "string"},
+			"title":    map[string]interface{}{"type": "string"},
 			"doc_type": map[string]interface{}{"type": "string"},
 			"rep_type": map[string]interface{}{"type": "string"},
 			"score":    map[string]interface{}{"type": "number"},
@@ -2041,6 +2054,7 @@ func askOutputSchema() map[string]interface{} {
 					"properties": map[string]interface{}{
 						"chunk_id": map[string]interface{}{"type": "integer"},
 						"rel_path": map[string]interface{}{"type": "string"},
+						"title":    map[string]interface{}{"type": "string"},
 						"span":     map[string]interface{}{"$ref": "#/definitions/Span"},
 					},
 					"required": []string{"chunk_id", "rel_path", "span"},
@@ -2276,6 +2290,7 @@ func listFilesOutputSchema() map[string]interface{} {
 					"additionalProperties": false,
 					"properties": map[string]interface{}{
 						"rel_path":   map[string]interface{}{"type": "string"},
+						"title":      map[string]interface{}{"type": "string"},
 						"doc_type":   map[string]interface{}{"type": "string"},
 						"size_bytes": map[string]interface{}{"type": "integer"},
 						"mtime_unix": map[string]interface{}{"type": "integer"},

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -8,6 +8,7 @@ import (
 type Document struct {
 	DocID       int64
 	RelPath     string
+	Title       string
 	DocType     string
 	SourceType  string
 	SizeBytes   int64
@@ -60,6 +61,7 @@ type SearchQuery struct {
 type SearchHit struct {
 	ChunkID uint64
 	RelPath string
+	Title   string
 	DocType string
 	RepType string
 	Score   float64
@@ -70,6 +72,7 @@ type SearchHit struct {
 type ChunkMetadata struct {
 	ChunkID uint64
 	RelPath string
+	Title   string
 	DocType string
 	RepType string
 	Snippet string
@@ -83,6 +86,7 @@ func (m ChunkMetadata) ToSearchHit() SearchHit {
 	return SearchHit{
 		ChunkID: m.ChunkID,
 		RelPath: m.RelPath,
+		Title:   m.Title,
 		DocType: m.DocType,
 		RepType: m.RepType,
 		Snippet: m.Snippet,
@@ -147,6 +151,7 @@ func (t ChunkTask) Validate() error {
 type Citation struct {
 	ChunkID uint64
 	RelPath string
+	Title   string
 	Span    Span
 }
 

--- a/internal/retrieval/engine.go
+++ b/internal/retrieval/engine.go
@@ -256,6 +256,7 @@ type AskResult struct {
 // Citation references a source span.
 type Citation struct {
 	RelPath string
+	Title   string
 	Span    model.Span
 }
 
@@ -313,6 +314,7 @@ func (e *Engine) AskWithContext(ctx context.Context, question string, opts AskOp
 	for _, citation := range res.Citations {
 		citations = append(citations, Citation{
 			RelPath: citation.RelPath,
+			Title:   citation.Title,
 			Span:    citation.Span,
 		})
 	}
@@ -402,6 +404,7 @@ func preloadEngineChunkMetadata(ctx context.Context, source embeddedChunkMetadat
 				ret.SetChunkMetadataForIndex(kind, task.Metadata.ChunkID, model.SearchHit{
 					ChunkID: task.Metadata.ChunkID,
 					RelPath: task.Metadata.RelPath,
+					Title:   task.Metadata.Title,
 					DocType: task.Metadata.DocType,
 					RepType: task.Metadata.RepType,
 					Snippet: task.Metadata.Snippet,

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -480,6 +480,7 @@ func (s *Service) Ask(ctx context.Context, question string, query model.SearchQu
 		citations = append(citations, model.Citation{
 			ChunkID: hit.ChunkID,
 			RelPath: hit.RelPath,
+			Title:   hit.Title,
 			Span:    hit.Span,
 		})
 	}

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -1194,7 +1194,16 @@ func buildRAGPrompt(question string, hits []model.SearchHit, systemPrompt string
 	}
 	for i := 0; i < limit && remaining > 0; i++ {
 		h := hits[i]
-		line := "- [" + h.RelPath + "] "
+		// Keep the bracketed [rel_path] tag stable for the answering model
+		// (ensureAnswerAttributions relies on it for canonical citation
+		// matching). When a human-readable Title is available, surface it
+		// alongside the path as a parenthetical hint so the model has the
+		// document name in addition to its path.
+		line := "- [" + h.RelPath + "]"
+		if title := strings.TrimSpace(h.Title); title != "" {
+			line += " (" + title + ")"
+		}
+		line += " "
 		snippet := truncateSnippet(strings.TrimSpace(h.Snippet), 300)
 		if snippet == "" {
 			snippet = "(no snippet)"
@@ -1248,7 +1257,11 @@ func ensureAnswerAttributions(answer string, citations []model.Citation) string 
 		return answer
 	}
 
-	orderedSources := make([]string, 0, len(citations))
+	type sourceEntry struct {
+		rel   string
+		title string
+	}
+	ordered := make([]sourceEntry, 0, len(citations))
 	seen := make(map[string]struct{}, len(citations))
 	for _, c := range citations {
 		rel := strings.TrimSpace(c.RelPath)
@@ -1259,18 +1272,27 @@ func ensureAnswerAttributions(answer string, citations []model.Citation) string 
 			continue
 		}
 		seen[rel] = struct{}{}
-		orderedSources = append(orderedSources, rel)
+		ordered = append(ordered, sourceEntry{rel: rel, title: strings.TrimSpace(c.Title)})
 	}
-	if len(orderedSources) == 0 {
+	if len(ordered) == 0 {
 		return answer
 	}
 
-	missing := make([]string, 0, len(orderedSources))
-	for _, rel := range orderedSources {
-		tag := "[" + rel + "]"
-		if !strings.Contains(answer, tag) {
-			missing = append(missing, tag)
+	missing := make([]string, 0, len(ordered))
+	for _, src := range ordered {
+		// The canonical [rel_path] tag is what the model emits inline; we
+		// only need to add a Sources line for paths it failed to mention.
+		// When a human-readable title is present we surface it next to the
+		// path so the appended block is more readable than bare paths.
+		tag := "[" + src.rel + "]"
+		if strings.Contains(answer, tag) {
+			continue
 		}
+		display := tag
+		if src.title != "" {
+			display = tag + " (" + src.title + ")"
+		}
+		missing = append(missing, display)
 	}
 	if len(missing) == 0 {
 		return answer

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -267,6 +267,30 @@ func openDB(ctx context.Context, path string) (*sql.DB, error) {
 	return db, nil
 }
 
+// applyAdditiveColumnMigrations runs ALTER TABLE ADD COLUMN statements that
+// extend existing tables with new optional columns. Each statement is wrapped
+// with isDuplicateColumnError so that the migration is idempotent on
+// already-upgraded databases. Add new entries here when introducing additive
+// schema changes; do not modify existing entries (their effects are now
+// historical migrations).
+//
+// The 'title' column on documents was added for #159 — surface a
+// human-readable document title in citations alongside rel_path.
+func applyAdditiveColumnMigrations(ctx context.Context, db *sql.DB) error {
+	migrations := []string{
+		`ALTER TABLE documents ADD COLUMN source_type TEXT NOT NULL DEFAULT 'filesystem'`,
+		`ALTER TABLE mcp_sessions ADD COLUMN auth_scope TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE representations ADD COLUMN meta_json TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE documents ADD COLUMN title TEXT NOT NULL DEFAULT ''`,
+	}
+	for _, stmt := range migrations {
+		if _, err := db.ExecContext(ctx, stmt); err != nil && !isDuplicateColumnError(err) {
+			return err
+		}
+	}
+	return nil
+}
+
 // initLocked performs the same initialization work as Init but assumes
 // the caller already holds s.mu. This helper allows ensureDB to set up the
 // database under lock, closing a small race window against Close().
@@ -386,15 +410,7 @@ CREATE INDEX IF NOT EXISTS idx_mcp_payment_outcomes_updated ON mcp_payment_outco
 		_ = db.Close()
 		return err
 	}
-	if _, err := db.ExecContext(ctx, `ALTER TABLE documents ADD COLUMN source_type TEXT NOT NULL DEFAULT 'filesystem'`); err != nil && !isDuplicateColumnError(err) {
-		_ = db.Close()
-		return err
-	}
-	if _, err := db.ExecContext(ctx, `ALTER TABLE mcp_sessions ADD COLUMN auth_scope TEXT NOT NULL DEFAULT ''`); err != nil && !isDuplicateColumnError(err) {
-		_ = db.Close()
-		return err
-	}
-	if _, err := db.ExecContext(ctx, `ALTER TABLE representations ADD COLUMN meta_json TEXT NOT NULL DEFAULT ''`); err != nil && !isDuplicateColumnError(err) {
+	if err := applyAdditiveColumnMigrations(ctx, db); err != nil {
 		_ = db.Close()
 		return err
 	}
@@ -428,8 +444,8 @@ func (s *SQLiteStore) UpsertDocument(ctx context.Context, doc model.Document) er
 
 	_, err = db.ExecContext(
 		ctx,
-		`INSERT INTO documents(rel_path, doc_type, source_type, size_bytes, mtime_unix, content_hash, status, deleted)
-		 VALUES(?, ?, ?, ?, ?, ?, ?, ?)
+		`INSERT INTO documents(rel_path, doc_type, source_type, size_bytes, mtime_unix, content_hash, status, deleted, title)
+		 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)
 		 ON CONFLICT(rel_path) DO UPDATE SET
 		   doc_type=excluded.doc_type,
 		   source_type=excluded.source_type,
@@ -437,7 +453,8 @@ func (s *SQLiteStore) UpsertDocument(ctx context.Context, doc model.Document) er
 		   mtime_unix=excluded.mtime_unix,
 		   content_hash=excluded.content_hash,
 		   status=excluded.status,
-		   deleted=excluded.deleted`,
+		   deleted=excluded.deleted,
+		   title=CASE WHEN excluded.title <> '' THEN excluded.title ELSE documents.title END`,
 		relPath,
 		normalizeDocType(doc.DocType),
 		normalizeSourceType(doc.SourceType),
@@ -446,6 +463,7 @@ func (s *SQLiteStore) UpsertDocument(ctx context.Context, doc model.Document) er
 		strings.TrimSpace(doc.ContentHash),
 		normalizeStatus(doc.Status),
 		boolToInt(doc.Deleted),
+		strings.TrimSpace(doc.Title),
 	)
 	return err
 }
@@ -805,7 +823,7 @@ func (s *SQLiteStore) GetDocumentByPath(ctx context.Context, relPath string) (mo
 	var deleted int
 	row := db.QueryRowContext(
 		ctx,
-		`SELECT doc_id, rel_path, doc_type, source_type, size_bytes, mtime_unix, content_hash, status, deleted
+		`SELECT doc_id, rel_path, doc_type, source_type, size_bytes, mtime_unix, content_hash, status, deleted, title
 		 FROM documents WHERE rel_path = ?`,
 		normalizedPath,
 	)
@@ -819,6 +837,7 @@ func (s *SQLiteStore) GetDocumentByPath(ctx context.Context, relPath string) (mo
 		&doc.ContentHash,
 		&doc.Status,
 		&deleted,
+		&doc.Title,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return model.Document{}, os.ErrNotExist
@@ -845,7 +864,7 @@ func (s *SQLiteStore) ListFiles(ctx context.Context, prefix, glob string, limit,
 
 	normalizedPrefix := normalizePrefix(prefix)
 
-	query := `SELECT doc_id, rel_path, doc_type, source_type, size_bytes, mtime_unix, content_hash, status, deleted FROM documents`
+	query := `SELECT doc_id, rel_path, doc_type, source_type, size_bytes, mtime_unix, content_hash, status, deleted, title FROM documents`
 	where := []string{"deleted = 0"}
 	args := make([]any, 0, 4)
 	if normalizedPrefix != "" {
@@ -880,6 +899,7 @@ func (s *SQLiteStore) ListFiles(ctx context.Context, prefix, glob string, limit,
 			&doc.ContentHash,
 			&doc.Status,
 			&deleted,
+			&doc.Title,
 		); err != nil {
 			return nil, 0, err
 		}
@@ -1068,9 +1088,11 @@ func (s *SQLiteStore) ListEmbeddedChunkMetadata(ctx context.Context, indexKind s
 	            JOIN filtered_chunks fc ON fc.chunk_id = s.chunk_id
 	          )
 	          SELECT fc.chunk_id, fc.rel_path, fc.doc_type, fc.rep_type, fc.text, fc.index_kind,
-	                 COALESCE(sp.span_kind, ''), COALESCE(sp.start, 0), COALESCE(sp.end, 0)
+	                 COALESCE(sp.span_kind, ''), COALESCE(sp.start, 0), COALESCE(sp.end, 0),
+	                 COALESCE(d.title, '')
 	          FROM filtered_chunks fc
-	          LEFT JOIN ranked_spans sp ON sp.chunk_id = fc.chunk_id AND sp.rn = 1`
+	          LEFT JOIN ranked_spans sp ON sp.chunk_id = fc.chunk_id AND sp.rn = 1
+	          LEFT JOIN documents d ON d.rel_path = fc.rel_path`
 	if strings.TrimSpace(indexKind) != "" {
 		query += ` WHERE fc.index_kind = ?`
 		args = append(args, indexKind)
@@ -1096,8 +1118,9 @@ func (s *SQLiteStore) ListEmbeddedChunkMetadata(ctx context.Context, indexKind s
 			spanK   string
 			spanS   int
 			spanE   int
+			title   string
 		)
-		if err := rows.Scan(&chunkID, &relPath, &docType, &repType, &text, &kind, &spanK, &spanS, &spanE); err != nil {
+		if err := rows.Scan(&chunkID, &relPath, &docType, &repType, &text, &kind, &spanK, &spanS, &spanE, &title); err != nil {
 			return nil, err
 		}
 		if chunkID <= 0 {
@@ -1112,6 +1135,7 @@ func (s *SQLiteStore) ListEmbeddedChunkMetadata(ctx context.Context, indexKind s
 			Metadata: model.ChunkMetadata{
 				ChunkID: uid,
 				RelPath: relPath,
+				Title:   title,
 				DocType: docType,
 				RepType: repType,
 				Snippet: snippet(text, 240),

--- a/tests/store/document_title_roundtrip_test.go
+++ b/tests/store/document_title_roundtrip_test.go
@@ -1,0 +1,97 @@
+package tests
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"dir2mcp/internal/model"
+	"dir2mcp/internal/store"
+)
+
+// TestSQLiteStore_DocumentTitleRoundtrip verifies that the title column
+// (added for #159) persists across upsert and is returned by both
+// GetDocumentByPath and ListFiles. Empty titles must remain empty.
+func TestSQLiteStore_DocumentTitleRoundtrip(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "meta.sqlite")
+	st := store.NewSQLiteStore(dbPath)
+	defer func() { _ = st.Close() }()
+
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	titled := model.Document{
+		RelPath:   "acts/proliferation.pdf",
+		DocType:   "pdf",
+		Title:     "Proliferation Financing (Prohibition) Act, 2021",
+		SizeBytes: 1234,
+		MTimeUnix: 1_700_000_000,
+		Status:    "ok",
+	}
+	untitled := model.Document{
+		RelPath:   "notes/raw.md",
+		DocType:   "md",
+		SizeBytes: 100,
+		MTimeUnix: 1_700_000_001,
+		Status:    "ok",
+	}
+	for _, d := range []model.Document{titled, untitled} {
+		if err := st.UpsertDocument(ctx, d); err != nil {
+			t.Fatalf("UpsertDocument(%s): %v", d.RelPath, err)
+		}
+	}
+
+	got, err := st.GetDocumentByPath(ctx, titled.RelPath)
+	if err != nil {
+		t.Fatalf("GetDocumentByPath(titled): %v", err)
+	}
+	if got.Title != titled.Title {
+		t.Errorf("titled doc: title roundtrip failed\n got: %q\nwant: %q", got.Title, titled.Title)
+	}
+
+	got, err = st.GetDocumentByPath(ctx, untitled.RelPath)
+	if err != nil {
+		t.Fatalf("GetDocumentByPath(untitled): %v", err)
+	}
+	if got.Title != "" {
+		t.Errorf("untitled doc: expected empty title, got %q", got.Title)
+	}
+
+	// ListFiles should also return the title.
+	docs, _, err := st.ListFiles(ctx, "", "", 10, 0)
+	if err != nil {
+		t.Fatalf("ListFiles: %v", err)
+	}
+	for _, d := range docs {
+		switch d.RelPath {
+		case titled.RelPath:
+			if d.Title != titled.Title {
+				t.Errorf("ListFiles: titled doc title mismatch: got %q want %q", d.Title, titled.Title)
+			}
+		case untitled.RelPath:
+			if d.Title != "" {
+				t.Errorf("ListFiles: untitled doc should have empty title, got %q", d.Title)
+			}
+		}
+	}
+
+	// Re-upserting WITHOUT a title must not erase the previously-stored title.
+	noTitleUpdate := titled
+	noTitleUpdate.Title = ""
+	noTitleUpdate.SizeBytes = 9999
+	if err := st.UpsertDocument(ctx, noTitleUpdate); err != nil {
+		t.Fatalf("UpsertDocument(noTitleUpdate): %v", err)
+	}
+	got, err = st.GetDocumentByPath(ctx, titled.RelPath)
+	if err != nil {
+		t.Fatalf("GetDocumentByPath after empty-title update: %v", err)
+	}
+	if got.Title != titled.Title {
+		t.Errorf("title was erased by empty-title upsert: got %q want %q", got.Title, titled.Title)
+	}
+	if got.SizeBytes != 9999 {
+		t.Errorf("size_bytes update did not propagate: got %d", got.SizeBytes)
+	}
+}


### PR DESCRIPTION
Closes #159.

## Summary
Extract a human-readable document title at ingest time and surface it alongside `rel_path` in citations. Solves the cryptic-citation problem for PDFs with opaque filenames (Windows 8.3-truncated `ACTNO_~1_1.pdf`, etc.).

- **internal/ingest/title.go** — `ExtractTitle` heuristic: first markdown heading, else first mostly-uppercase title-like line. Bounded scan (4 KB), clamped output (200 chars).
- **internal/ingest/service.go** — `persistTitleIfFound` runs the heuristic on raw_text and OCR-extracted markdown, then re-upserts with the title set. Failures are logged, not fatal.
- **internal/store** — additive `title TEXT` column on `documents` (idempotent migration). `UpsertDocument` preserves an existing non-empty title when an incoming title is empty (so a partial reindex does not erase it). Refactored migrations into `applyAdditiveColumnMigrations` to keep `initLocked` under the cyclomatic-complexity budget.
- **internal/model** — `Title` added to `Document`, `ChunkMetadata`, `SearchHit`, `Citation`. `ToSearchHit` propagates it.
- **internal/retrieval** — title plumbed through `ChunkMetadata` preload, `SearchHit` construction, and `Citation` building.
- **internal/mcp** — `serializeHit`, list_files entries, and ask citations include `title` when non-empty (additive, backwards-compatible). All output schemas extended.

## Why
Tested against a real BVI legal corpus where `[ACTNO_~1_1.pdf, p.30]` citations were nearly useless — the OCR'd content correctly identified the doc as the Proliferation Financing (Prohibition) Act, 2021, but the citation surface didn't expose it.

## Test plan
- [x] `internal/ingest/title_test.go` — 11 cases covering markdown heading, OCR'd legal preamble, prose rejection, scan-limit, clamping
- [x] `tests/store/document_title_roundtrip_test.go` — title persists through Upsert / GetDocumentByPath / ListFiles; empty-title upsert does NOT erase a previously-stored title
- [x] `make ci` passes locally
- [ ] CI matrix on this PR

## Migration
Additive `ALTER TABLE`. Existing indexes load unchanged; title columns are NULL until each document is reprocessed by ingest.

## Merge note
Adds `applyAdditiveColumnMigrations` helper, which is also added independently by #158. The two PRs need to be reconciled at merge time (whichever lands second should rebase and absorb the other's migration entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)