### PR TITLE
feat(retrieval): surface document title on hybrid BM25 hits

### DIFF
--- a/internal/store/sqlite_bm25.go
+++ b/internal/store/sqlite_bm25.go
@@ -38,9 +38,11 @@ func (s *SQLiteStore) SearchBM25(ctx context.Context, query string, k int, index
 
 	args := []any{matchExpr}
 	stmt := `SELECT c.chunk_id, c.rel_path, c.doc_type, c.rep_type, c.text,
+	                COALESCE(d.title, ''),
 	                bm25(chunks_fts) AS score
 	         FROM chunks_fts
 	         JOIN chunks c ON c.chunk_id = chunks_fts.rowid
+	         LEFT JOIN documents d ON d.rel_path = c.rel_path
 	         WHERE chunks_fts MATCH ? AND c.deleted = 0`
 	if kind := strings.TrimSpace(indexKind); kind != "" {
 		stmt += ` AND c.index_kind = ?`
@@ -63,9 +65,10 @@ func (s *SQLiteStore) SearchBM25(ctx context.Context, query string, k int, index
 			docType string
 			repType string
 			text    string
+			title   string
 			score   float64
 		)
-		if err := rows.Scan(&chunkID, &relPath, &docType, &repType, &text, &score); err != nil {
+		if err := rows.Scan(&chunkID, &relPath, &docType, &repType, &text, &title, &score); err != nil {
 			return nil, err
 		}
 		if chunkID <= 0 {
@@ -74,6 +77,7 @@ func (s *SQLiteStore) SearchBM25(ctx context.Context, query string, k int, index
 		hits = append(hits, model.SearchHit{
 			ChunkID: uint64(chunkID),
 			RelPath: relPath,
+			Title:   title,
 			DocType: docType,
 			RepType: repType,
 			Score:   -score,

--- a/tests/store/sqlite_bm25_test.go
+++ b/tests/store/sqlite_bm25_test.go
@@ -111,16 +111,17 @@ func TestSQLiteStore_SearchBM25_PopulatesTitle(t *testing.T) {
 	chunks := []struct {
 		label   uint64
 		relPath string
+		docType string
 		text    string
 	}{
-		{10, titled.RelPath, "section 35 reporting suspicious transactions"},
-		{11, untitled.RelPath, "untitled note about reporting"},
+		{10, titled.RelPath, titled.DocType, "section 35 reporting suspicious transactions"},
+		{11, untitled.RelPath, untitled.DocType, "untitled note about reporting"},
 	}
 	for _, c := range chunks {
 		task := model.NewChunkTask(c.label, c.text, "text", model.ChunkMetadata{
 			ChunkID: c.label,
 			RelPath: c.relPath,
-			DocType: "md",
+			DocType: c.docType,
 			RepType: "raw_text",
 		})
 		if err := st.UpsertChunkTask(ctx, task); err != nil {

--- a/tests/store/sqlite_bm25_test.go
+++ b/tests/store/sqlite_bm25_test.go
@@ -129,7 +129,10 @@ func TestSQLiteStore_SearchBM25_PopulatesTitle(t *testing.T) {
 		}
 	}
 
-	ls := interface{}(st).(model.LexicalSearcher)
+	ls, ok := interface{}(st).(model.LexicalSearcher)
+	if !ok {
+		t.Fatalf("store does not implement model.LexicalSearcher")
+	}
 	hits, err := ls.SearchBM25(ctx, "reporting", 5, "text")
 	if err != nil {
 		t.Fatalf("SearchBM25: %v", err)

--- a/tests/store/sqlite_bm25_test.go
+++ b/tests/store/sqlite_bm25_test.go
@@ -78,3 +78,74 @@ func TestSQLiteStore_SearchBM25_BasicAndBackfill(t *testing.T) {
 		t.Errorf("index_kind filter should have excluded text chunks, got %d hits", len(hits))
 	}
 }
+
+// TestSQLiteStore_SearchBM25_PopulatesTitle verifies BM25 hits carry the
+// document title (added in #166) via the LEFT JOIN in SearchBM25. Hits for a
+// document without a title still return successfully with an empty Title.
+func TestSQLiteStore_SearchBM25_PopulatesTitle(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "meta.sqlite")
+	st := store.NewSQLiteStore(dbPath)
+	defer func() { _ = st.Close() }()
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	titled := model.Document{
+		RelPath: "acts/proliferation.pdf",
+		DocType: "pdf",
+		Title:   "Proliferation Financing (Prohibition) Act, 2021",
+		Status:  "ok",
+	}
+	untitled := model.Document{
+		RelPath: "notes/raw.md",
+		DocType: "md",
+		Status:  "ok",
+	}
+	for _, d := range []model.Document{titled, untitled} {
+		if err := st.UpsertDocument(ctx, d); err != nil {
+			t.Fatalf("UpsertDocument(%s): %v", d.RelPath, err)
+		}
+	}
+
+	chunks := []struct {
+		label   uint64
+		relPath string
+		text    string
+	}{
+		{10, titled.RelPath, "section 35 reporting suspicious transactions"},
+		{11, untitled.RelPath, "untitled note about reporting"},
+	}
+	for _, c := range chunks {
+		task := model.NewChunkTask(c.label, c.text, "text", model.ChunkMetadata{
+			ChunkID: c.label,
+			RelPath: c.relPath,
+			DocType: "md",
+			RepType: "raw_text",
+		})
+		if err := st.UpsertChunkTask(ctx, task); err != nil {
+			t.Fatalf("UpsertChunkTask(%d): %v", c.label, err)
+		}
+	}
+
+	ls := interface{}(st).(model.LexicalSearcher)
+	hits, err := ls.SearchBM25(ctx, "reporting", 5, "text")
+	if err != nil {
+		t.Fatalf("SearchBM25: %v", err)
+	}
+	if len(hits) < 2 {
+		t.Fatalf("expected at least two hits, got %d", len(hits))
+	}
+	for _, h := range hits {
+		switch h.RelPath {
+		case titled.RelPath:
+			if h.Title != titled.Title {
+				t.Errorf("titled hit should carry title; got %q want %q", h.Title, titled.Title)
+			}
+		case untitled.RelPath:
+			if h.Title != "" {
+				t.Errorf("untitled hit should have empty title, got %q", h.Title)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Follow-up to #166 (titles) + #167 (hybrid retrieval).

## Summary
- `SearchBM25` now `LEFT JOIN documents ON d.rel_path = c.rel_path` and selects `COALESCE(d.title, '')` so each `SearchHit` carries the title alongside `rel_path`.
- Extended `tests/store/sqlite_bm25_test.go` with a case that upserts a titled and an untitled document, runs BM25, and asserts titles propagate when present and stay empty when absent.

## Why
#167's `sqlite_bm25.go` was written before #166 landed, so it omitted the join to keep the branches independent. Without it, the lexical half of hybrid retrieval drops the title column — chunks fused to the top via BM25 would surface as `[ACTNO_~1_1.pdf]` even when the document title was known. This restores the citation parity the title work was meant to deliver.

## Test plan
- [x] `make ci` passes locally
- [x] New `TestSQLiteStore_SearchBM25_PopulatesTitle` passes
- [x] CI matrix on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)