### PR TITLE
fix(release): declare dir2mcp ↔ dir2mcp-full conflict in goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -53,6 +53,12 @@ brews:
     homepage: https://github.com/dirstral/dir2mcp
     description: Deploy any local directory as an MCP knowledge server with indexing, retrieval, and citations.
     license: MIT
+    # Symmetric conflict with dir2mcp-full (which already declares the
+    # reverse). brew audit on the tap requires conflicts to be declared
+    # on both sides; without this, every regenerated dir2mcp.rb fails
+    # audit until manually patched.
+    conflicts:
+      - dir2mcp-full
     install: |
       bin.install "dir2mcp"
     test: |


### PR DESCRIPTION
## Summary
Adds \`conflicts: [dir2mcp-full]\` to the \`brews:\` block in \`.goreleaser.yaml\` so the regenerated lean formula keeps the symmetric conflict declaration.

## Why
brew audit on dirstral/homebrew-tap requires conflicts to be declared on both sides. \`dir2mcp-full.rb\` already has \`conflicts_with \"dir2mcp\"\`, but the GoReleaser-templated \`dir2mcp.rb\` was missing the reverse, so audit failed on the v0.5.1 release (see [tap PR #7](https://github.com/dirstral/homebrew-tap/pull/7) — audit job complained: *\"Formula dir2mcp should also have a conflict declared with dir2mcp-full\"*).

The audit failure on tap PR #7 was unblocked by patching \`dir2mcp.rb\` in place on the auto-bump branch. This PR closes the loop so the next GoReleaser regeneration doesn't drop the declaration again.

## Test plan
- [x] \`make ci\` passes locally
- [ ] CI matrix on this PR
- [ ] **Real-world validation:** the next tag pushed will regenerate \`dir2mcp.rb\` with the conflict line; the tap audit job for that release should pass without manual intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)