### PR TITLE
fix(mcp): rename tool surface from dir2mcp.X to dir2mcp_X

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Notes:
 What it verifies:
 - `initialize` returns HTTP 200 and a valid `MCP-Session-Id`
 - `tools/list` returns HTTP 200 with tool metadata
-- `tools/call` for `dir2mcp.list_files` returns HTTP 200, or HTTP 402 with `PAYMENT-REQUIRED` when x402 is enabled
+- `tools/call` for `dir2mcp_list_files` returns HTTP 200, or HTTP 402 with `PAYMENT-REQUIRED` when x402 is enabled
 
 ### Tunnel setup (copy/paste)
 
@@ -169,15 +169,15 @@ Running `dir2mcp` with no arguments prints usage, which you can consult anytime 
 
 | Tool | Description |
 |---|---|
-| `dir2mcp.search` | Semantic search over indexed content |
-| `dir2mcp.ask` | RAG-style question answering with citations |
-| `dir2mcp.ask_audio` | Ask with TTS audio response |
-| `dir2mcp.transcribe` | Transcribe an audio file from the corpus |
-| `dir2mcp.annotate` | Structured annotation of a document |
-| `dir2mcp.transcribe_and_ask` | Transcribe then ask over the result |
-| `dir2mcp.open_file` | Retrieve a file by path with span context |
-| `dir2mcp.list_files` | List indexed files with metadata |
-| `dir2mcp.stats` | Corpus statistics |
+| `dir2mcp_search` | Semantic search over indexed content |
+| `dir2mcp_ask` | RAG-style question answering with citations |
+| `dir2mcp_ask_audio` | Ask with TTS audio response |
+| `dir2mcp_transcribe` | Transcribe an audio file from the corpus |
+| `dir2mcp_annotate` | Structured annotation of a document |
+| `dir2mcp_transcribe_and_ask` | Transcribe then ask over the result |
+| `dir2mcp_open_file` | Retrieve a file by path with span context |
+| `dir2mcp_list_files` | List indexed files with metadata |
+| `dir2mcp_stats` | Corpus statistics |
 
 ## Configuration
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -268,7 +268,7 @@ Expected pass conditions:
 
 * `initialize` returns HTTP `200` and includes `MCP-Session-Id`.
 * `tools/list` returns HTTP `200` and includes tool metadata.
-* `tools/call` against `dir2mcp.list_files` returns either:
+* `tools/call` against `dir2mcp_list_files` returns either:
   * HTTP `200` with JSON-RPC body, or
   * HTTP `402` with `PAYMENT-REQUIRED` when x402 route gating is enabled.
 
@@ -899,7 +899,7 @@ Request:
   "jsonrpc": "2.0",
   "id": 3,
   "method": "tools/call",
-  "params": { "name": "dir2mcp.search", "arguments": { "query": "..." } }
+  "params": { "name": "dir2mcp_search", "arguments": { "query": "..." } }
 }
 ```
 
@@ -946,21 +946,21 @@ Example tool execution error:
 
 ### 13.1 Core tool set
 
-* `dir2mcp.search`
-* `dir2mcp.ask`
-* `dir2mcp.open_file`
-* `dir2mcp.list_files`
-* `dir2mcp.stats`
+* `dir2mcp_search`
+* `dir2mcp_ask`
+* `dir2mcp_open_file`
+* `dir2mcp_list_files`
+* `dir2mcp_stats`
 
 ### 13.2 Recommended extended tools
 
-* `dir2mcp.transcribe` (audio → transcript, uses configured provider)
-* `dir2mcp.annotate` (document → structured JSON + flattened text)
-* `dir2mcp.transcribe_and_ask` (audio → transcript → ask)
+* `dir2mcp_transcribe` (audio → transcript, uses configured provider)
+* `dir2mcp_annotate` (document → structured JSON + flattened text)
+* `dir2mcp_transcribe_and_ask` (audio → transcript → ask)
 
 ### 13.3 Optional extension
 
-* `dir2mcp.ask_audio` (answer → audio via ElevenLabs TTS)
+* `dir2mcp_ask_audio` (answer → audio via ElevenLabs TTS)
 
 ---
 
@@ -1069,7 +1069,7 @@ All schemas are JSON Schema (draft-agnostic, compatible with common validators).
 
 ---
 
-### 15.2 `dir2mcp.search`
+### 15.2 `dir2mcp_search`
 
 **Description:** semantic retrieval across indexed content.
 
@@ -1117,7 +1117,7 @@ All schemas are JSON Schema (draft-agnostic, compatible with common validators).
 
 ---
 
-### 15.3 `dir2mcp.ask`
+### 15.3 `dir2mcp_ask`
 
 **Description:** RAG answer with citations; can run search-only.
 
@@ -1175,7 +1175,7 @@ All schemas are JSON Schema (draft-agnostic, compatible with common validators).
 
 ---
 
-### 15.4 `dir2mcp.open_file`
+### 15.4 `dir2mcp_open_file`
 
 **Description:** open an exact source slice for verification (lines/page/time).
 
@@ -1235,7 +1235,7 @@ filters is impossible.
 
 ---
 
-### 15.5 `dir2mcp.list_files`
+### 15.5 `dir2mcp_list_files`
 
 **Description:** list files under root for navigation and filter selection.
 
@@ -1287,7 +1287,7 @@ filters is impossible.
 
 ---
 
-### 15.6 `dir2mcp.stats`
+### 15.6 `dir2mcp_stats`
 
 **Description:** status/progress/health for indexing and models.
 
@@ -1360,7 +1360,7 @@ filters is impossible.
 
 ---
 
-### 15.7 `dir2mcp.transcribe` (recommended)
+### 15.7 `dir2mcp_transcribe` (recommended)
 
 **Description:** force transcription for an audio file, persist transcript representation, and (optionally) return segments.
 
@@ -1411,7 +1411,7 @@ filters is impossible.
 
 ---
 
-### 15.8 `dir2mcp.annotate` (recommended)
+### 15.8 `dir2mcp_annotate` (recommended)
 
 **Description:** run structured extraction on a document with provided JSON schema; store JSON; optionally index flattened text.
 
@@ -1449,7 +1449,7 @@ filters is impossible.
 
 ---
 
-### 15.9 `dir2mcp.transcribe_and_ask` (recommended)
+### 15.9 `dir2mcp_transcribe_and_ask` (recommended)
 
 **Description:** ensure transcript exists (transcribe if missing/stale), then answer a question using transcript (and optionally whole corpus if configured).
 
@@ -1468,17 +1468,17 @@ filters is impossible.
 }
 ```
 
-**Output schema:** same as `dir2mcp.ask` output schema, plus:
+**Output schema:** same as `dir2mcp_ask` output schema, plus:
 
 * `transcript_provider`, `transcript_model`, and `transcribed` boolean.
 
 ---
 
-### 15.10 `dir2mcp.ask_audio` (optional extension)
+### 15.10 `dir2mcp_ask_audio` (optional extension)
 
-**Description:** same as `ask` but includes audio output (TTS). Optional and additive. The input schema inherits all fields of `dir2mcp.ask` (`question`, `k`, `mode`, `index`, `path_prefix`, `file_glob`, `doc_types`) plus the audio-specific fields shown below.
+**Description:** same as `ask` but includes audio output (TTS). Optional and additive. The input schema inherits all fields of `dir2mcp_ask` (`question`, `k`, `mode`, `index`, `path_prefix`, `file_glob`, `doc_types`) plus the audio-specific fields shown below.
 
-Input schema (audio-specific fields; the rest mirror `dir2mcp.ask`):
+Input schema (audio-specific fields; the rest mirror `dir2mcp_ask`):
 
 ```json
 {

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -1,15 +1,21 @@
 package protocol
 
+// MCP tool names. Underscore-separated rather than dot-separated because
+// Claude Desktop validates MCP tool names against the regex
+// ^[a-zA-Z0-9_-]{1,64}$ and rejects the entire tool list when any name
+// contains characters outside that set. Underscores keep the dir2mcp_*
+// family visually grouped while staying compatible with the strictest
+// known frontend.
 const (
-	ToolNameSearch           = "dir2mcp.search"
-	ToolNameAsk              = "dir2mcp.ask"
-	ToolNameAskAudio         = "dir2mcp.ask_audio"
-	ToolNameOpenFile         = "dir2mcp.open_file"
-	ToolNameListFiles        = "dir2mcp.list_files"
-	ToolNameStats            = "dir2mcp.stats"
-	ToolNameTranscribe       = "dir2mcp.transcribe"
-	ToolNameAnnotate         = "dir2mcp.annotate"
-	ToolNameTranscribeAndAsk = "dir2mcp.transcribe_and_ask"
+	ToolNameSearch           = "dir2mcp_search"
+	ToolNameAsk              = "dir2mcp_ask"
+	ToolNameAskAudio         = "dir2mcp_ask_audio"
+	ToolNameOpenFile         = "dir2mcp_open_file"
+	ToolNameListFiles        = "dir2mcp_list_files"
+	ToolNameStats            = "dir2mcp_stats"
+	ToolNameTranscribe       = "dir2mcp_transcribe"
+	ToolNameAnnotate         = "dir2mcp_annotate"
+	ToolNameTranscribeAndAsk = "dir2mcp_transcribe_and_ask"
 )
 
 const (

--- a/tests/conformance/helpers_test.go
+++ b/tests/conformance/helpers_test.go
@@ -176,14 +176,14 @@ func decodeRPCError(t *testing.T, body []byte) (code int, message string) {
 
 // statsCallBody returns a JSON-RPC tools/call body for dir2mcp.stats.
 func statsCallBody(id int) string {
-	return `{"jsonrpc":"2.0","id":` + strconv.Itoa(id) + `,"method":"tools/call","params":{"name":"dir2mcp.stats","arguments":{}}}`
+	return `{"jsonrpc":"2.0","id":` + strconv.Itoa(id) + `,"method":"tools/call","params":{"name":"dir2mcp_stats","arguments":{}}}`
 }
 
 // listFilesCallBody returns a JSON-RPC tools/call body for dir2mcp.list_files
 // targeting the given directory.
 func listFilesCallBody(id int, dir string) string {
 	b, _ := json.Marshal(dir)
-	return `{"jsonrpc":"2.0","id":` + strconv.Itoa(id) + `,"method":"tools/call","params":{"name":"dir2mcp.list_files","arguments":{"path_prefix":` + string(b) + `}}}`
+	return `{"jsonrpc":"2.0","id":` + strconv.Itoa(id) + `,"method":"tools/call","params":{"name":"dir2mcp_list_files","arguments":{"path_prefix":` + string(b) + `}}}`
 }
 
 // headerPresent returns true if the named header is set and non-empty.

--- a/tests/conformance/tools_test.go
+++ b/tests/conformance/tools_test.go
@@ -44,10 +44,10 @@ func TestTools_ListContainsExpectedTools(t *testing.T) {
 	}
 
 	required := []string{
-		"dir2mcp.list_files",
-		"dir2mcp.search",
-		"dir2mcp.open_file",
-		"dir2mcp.ask",
+		"dir2mcp_list_files",
+		"dir2mcp_search",
+		"dir2mcp_open_file",
+		"dir2mcp_ask",
 	}
 	for _, name := range required {
 		if !nameSet[name] {
@@ -123,7 +123,7 @@ func TestTools_CallUnknownToolReturnsError(t *testing.T) {
 	sid := initSession(t, srv.URL+cfg.MCPPath)
 
 	resp := sendRPC(t, srv.URL+cfg.MCPPath, sid,
-		`{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"dir2mcp.does_not_exist","arguments":{}}}`,
+		`{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"dir2mcp_does_not_exist","arguments":{}}}`,
 		nil,
 	)
 	body := readBody(t, resp)
@@ -147,7 +147,7 @@ func TestTools_CallMissingRequiredParamReturnsError(t *testing.T) {
 	sid := initSession(t, srv.URL+cfg.MCPPath)
 
 	resp := sendRPC(t, srv.URL+cfg.MCPPath, sid,
-		`{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"dir2mcp.search","arguments":{}}}`,
+		`{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"dir2mcp_search","arguments":{}}}`,
 		nil,
 	)
 	body := readBody(t, resp)

--- a/tests/elevenlabsbridge/bridge_test.go
+++ b/tests/elevenlabsbridge/bridge_test.go
@@ -223,7 +223,7 @@ func TestAskEndpointCallsDir2McpAsk(t *testing.T) {
 			if k, ok := args["k"].(float64); ok {
 				rec.K = int(k)
 			}
-			if rec.ToolName != "dir2mcp.ask" {
+			if rec.ToolName != "dir2mcp_ask" {
 				handlerErrCh <- fmt.Errorf("tool=%q want dir2mcp.ask", rec.ToolName)
 				w.WriteHeader(http.StatusBadRequest)
 				return
@@ -294,7 +294,7 @@ func TestAskEndpointCallsDir2McpAsk(t *testing.T) {
 	if requests[1].SessionID != "session-123" {
 		t.Fatalf("expected session id to be forwarded, got %#v", requests[1].SessionID)
 	}
-	if requests[1].ToolName != "dir2mcp.ask" {
+	if requests[1].ToolName != "dir2mcp_ask" {
 		t.Fatalf("tool=%q", requests[1].ToolName)
 	}
 	if requests[1].Question != "what is alpha?" {

--- a/tests/mcp/tools_test.go
+++ b/tests/mcp/tools_test.go
@@ -96,7 +96,7 @@ func TestMCPToolsCallTranscribe_MissingRelPath(t *testing.T) {
 	defer server.Close()
 
 	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
-	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":30,"method":"tools/call","params":{"name":"dir2mcp.transcribe","arguments":{}}}`)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":30,"method":"tools/call","params":{"name":"dir2mcp_transcribe","arguments":{}}}`)
 	defer func() {
 		_ = resp.Body.Close()
 	}()
@@ -162,7 +162,7 @@ func TestMCPToolsCallTranscribe_ProviderFailureIsRetryable(t *testing.T) {
 	defer server.Close()
 
 	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
-	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":31,"method":"tools/call","params":{"name":"dir2mcp.transcribe","arguments":{"rel_path":"voice.wav"}}}`)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":31,"method":"tools/call","params":{"name":"dir2mcp_transcribe","arguments":{"rel_path":"voice.wav"}}}`)
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
@@ -202,7 +202,7 @@ func TestMCPToolsCallTranscribe_Success(t *testing.T) {
 	defer server.Close()
 
 	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
-	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":32,"method":"tools/call","params":{"name":"dir2mcp.transcribe","arguments":{"rel_path":"voice.wav","timestamps":true,"language":"fr"}}}`)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":32,"method":"tools/call","params":{"name":"dir2mcp_transcribe","arguments":{"rel_path":"voice.wav","timestamps":true,"language":"fr"}}}`)
 	defer func() { _ = resp.Body.Close() }()
 	// check if the upstream handler encountered an error
 	select {
@@ -291,7 +291,7 @@ func TestMCPToolsCallTranscribe_CreatesAudioDocWhenNotYetIndexed(t *testing.T) {
 	defer server.Close()
 
 	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
-	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":320,"method":"tools/call","params":{"name":"dir2mcp.transcribe","arguments":{"rel_path":"audio/voice.wav"}}}`)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":320,"method":"tools/call","params":{"name":"dir2mcp_transcribe","arguments":{"rel_path":"audio/voice.wav"}}}`)
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		payload, _ := io.ReadAll(resp.Body)
@@ -326,7 +326,7 @@ func TestMCPToolsCallAnnotate_MissingSchema(t *testing.T) {
 	defer server.Close()
 
 	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
-	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":33,"method":"tools/call","params":{"name":"dir2mcp.annotate","arguments":{"rel_path":"note.txt"}}}`)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":33,"method":"tools/call","params":{"name":"dir2mcp_annotate","arguments":{"rel_path":"note.txt"}}}`)
 	defer func() { _ = resp.Body.Close() }()
 	assertToolCallErrorCode(t, resp, "MISSING_FIELD")
 }
@@ -349,7 +349,7 @@ func TestMCPToolsCallAnnotate_ProviderFailure(t *testing.T) {
 	defer server.Close()
 
 	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
-	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":34,"method":"tools/call","params":{"name":"dir2mcp.annotate","arguments":{"rel_path":"note.txt","schema_json":{"type":"object"}}}}`)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":34,"method":"tools/call","params":{"name":"dir2mcp_annotate","arguments":{"rel_path":"note.txt","schema_json":{"type":"object"}}}}`)
 	defer func() { _ = resp.Body.Close() }()
 	assertToolCallErrorCode(t, resp, "ANNOTATE_FAILED")
 }
@@ -375,7 +375,7 @@ func TestMCPToolsCallAnnotate_Success(t *testing.T) {
 	defer server.Close()
 
 	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
-	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":35,"method":"tools/call","params":{"name":"dir2mcp.annotate","arguments":{"rel_path":"note.txt","schema_json":{"type":"object","properties":{"summary":{"type":"string"}}},"index_flattened_text":true}}}`)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":35,"method":"tools/call","params":{"name":"dir2mcp_annotate","arguments":{"rel_path":"note.txt","schema_json":{"type":"object","properties":{"summary":{"type":"string"}}},"index_flattened_text":true}}}`)
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		payload, _ := io.ReadAll(resp.Body)
@@ -417,7 +417,7 @@ func TestMCPToolsCallAnnotate_PromptTooLarge(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal schema: %v", err)
 	}
-	rpc := fmt.Sprintf(`{"jsonrpc":"2.0","id":40,"method":"tools/call","params":{"name":"dir2mcp.annotate","arguments":{"rel_path":"note.txt","schema_json":%s}}}`, string(schemaBytes))
+	rpc := fmt.Sprintf(`{"jsonrpc":"2.0","id":40,"method":"tools/call","params":{"name":"dir2mcp_annotate","arguments":{"rel_path":"note.txt","schema_json":%s}}}`, string(schemaBytes))
 	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, rpc)
 	defer func() { _ = resp.Body.Close() }()
 	assertToolCallErrorCode(t, resp, "ANNOTATE_FAILED")
@@ -431,7 +431,7 @@ func TestMCPToolsCallTranscribeAndAsk_MissingQuestion(t *testing.T) {
 	defer server.Close()
 
 	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
-	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":36,"method":"tools/call","params":{"name":"dir2mcp.transcribe_and_ask","arguments":{"rel_path":"voice.wav"}}}`)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":36,"method":"tools/call","params":{"name":"dir2mcp_transcribe_and_ask","arguments":{"rel_path":"voice.wav"}}}`)
 	defer func() { _ = resp.Body.Close() }()
 	assertToolCallErrorCode(t, resp, "MISSING_FIELD")
 }
@@ -468,7 +468,7 @@ func TestMCPToolsCallTranscribeAndAsk_Success(t *testing.T) {
 	defer server.Close()
 
 	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
-	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":37,"method":"tools/call","params":{"name":"dir2mcp.transcribe_and_ask","arguments":{"rel_path":"voice.wav","question":"what is alpha?","k":5}}}`)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":37,"method":"tools/call","params":{"name":"dir2mcp_transcribe_and_ask","arguments":{"rel_path":"voice.wav","question":"what is alpha?","k":5}}}`)
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		payload, _ := io.ReadAll(resp.Body)
@@ -545,7 +545,7 @@ func TestMCPToolsCallAskAudio_NilRetrieverReturnsIndexNotReady(t *testing.T) {
 	defer server.Close()
 
 	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
-	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":20,"method":"tools/call","params":{"name":"dir2mcp.ask_audio","arguments":{"question":"What is indexed?"}}}`)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":20,"method":"tools/call","params":{"name":"dir2mcp_ask_audio","arguments":{"question":"What is indexed?"}}}`)
 	defer func() {
 		_ = resp.Body.Close()
 	}()
@@ -564,7 +564,7 @@ func TestMCPToolsCallAskAudio_AskNotImplementedReturnsGracefulSuccess(t *testing
 	defer server.Close()
 
 	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
-	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":21,"method":"tools/call","params":{"name":"dir2mcp.ask_audio","arguments":{"question":"What is indexed?"}}}`)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":21,"method":"tools/call","params":{"name":"dir2mcp_ask_audio","arguments":{"question":"What is indexed?"}}}`)
 	defer func() {
 		_ = resp.Body.Close()
 	}()
@@ -614,7 +614,7 @@ func TestMCPToolsCallAskAudio_WithoutTTSReturnsTextOnly(t *testing.T) {
 	defer server.Close()
 
 	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
-	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":22,"method":"tools/call","params":{"name":"dir2mcp.ask_audio","arguments":{"question":"What is indexed?"}}}`)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":22,"method":"tools/call","params":{"name":"dir2mcp_ask_audio","arguments":{"question":"What is indexed?"}}}`)
 	defer func() {
 		_ = resp.Body.Close()
 	}()
@@ -670,7 +670,7 @@ func TestMCPToolsCallAskAudio_WithTTSReturnsTextAndAudio(t *testing.T) {
 	defer server.Close()
 
 	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
-	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":23,"method":"tools/call","params":{"name":"dir2mcp.ask_audio","arguments":{"question":"What is indexed?"}}}`)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":23,"method":"tools/call","params":{"name":"dir2mcp_ask_audio","arguments":{"question":"What is indexed?"}}}`)
 	defer func() {
 		_ = resp.Body.Close()
 	}()
@@ -737,7 +737,7 @@ func TestMCPToolsCallStats_ReturnsStructuredContent(t *testing.T) {
 
 	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
 
-	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"dir2mcp.stats","arguments":{}}}`)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"dir2mcp_stats","arguments":{}}}`)
 	defer func() {
 		_ = resp.Body.Close()
 	}()
@@ -834,7 +834,7 @@ func TestMCPToolsCallStats_UsesRetrieverStats(t *testing.T) {
 	defer server.Close()
 
 	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
-	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":33,"method":"tools/call","params":{"name":"dir2mcp.stats","arguments":{}}}`)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":33,"method":"tools/call","params":{"name":"dir2mcp_stats","arguments":{}}}`)
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		payload, _ := io.ReadAll(resp.Body)
@@ -906,7 +906,7 @@ func TestMCPToolsCallListFiles_GracefulWithoutSQLiteStore(t *testing.T) {
 
 	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
 
-	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"dir2mcp.list_files","arguments":{"limit":10,"offset":0}}}`)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"dir2mcp_list_files","arguments":{"limit":10,"offset":0}}}`)
 	defer func() {
 		_ = resp.Body.Close()
 	}()
@@ -955,7 +955,7 @@ func TestMCPToolsCallStats_RejectsUnknownArgument(t *testing.T) {
 
 	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
 
-	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"dir2mcp.stats","arguments":{"unexpected":true}}}`)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"dir2mcp_stats","arguments":{"unexpected":true}}}`)
 	defer func() {
 		_ = resp.Body.Close()
 	}()
@@ -974,7 +974,7 @@ func TestMCPToolsCallListFiles_RejectsUnknownArgument(t *testing.T) {
 
 	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
 
-	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"dir2mcp.list_files","arguments":{"limit":10,"offset":0,"foo":"bar"}}}`)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"dir2mcp_list_files","arguments":{"limit":10,"offset":0,"foo":"bar"}}}`)
 	defer func() {
 		_ = resp.Body.Close()
 	}()
@@ -993,7 +993,7 @@ func TestMCPToolsCallListFiles_RejectsLimitWrongType(t *testing.T) {
 
 	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
 
-	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"dir2mcp.list_files","arguments":{"limit":"10","offset":0}}}`)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"dir2mcp_list_files","arguments":{"limit":"10","offset":0}}}`)
 	defer func() {
 		_ = resp.Body.Close()
 	}()
@@ -1019,12 +1019,12 @@ func TestMCPToolsCallListFiles_RejectsLimitOutOfRange(t *testing.T) {
 	}{
 		{
 			name: "limit_zero",
-			body: `{"jsonrpc":"2.0","id":8,"method":"tools/call","params":{"name":"dir2mcp.list_files","arguments":{"limit":0,"offset":0}}}`,
+			body: `{"jsonrpc":"2.0","id":8,"method":"tools/call","params":{"name":"dir2mcp_list_files","arguments":{"limit":0,"offset":0}}}`,
 			code: "INVALID_RANGE",
 		},
 		{
 			name: "limit_too_large",
-			body: `{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"dir2mcp.list_files","arguments":{"limit":5001,"offset":0}}}`,
+			body: `{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"dir2mcp_list_files","arguments":{"limit":5001,"offset":0}}}`,
 			code: "INVALID_RANGE",
 		},
 	} {
@@ -1049,7 +1049,7 @@ func TestMCPToolsCallListFiles_RejectsOffsetWrongType(t *testing.T) {
 
 	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
 
-	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":10,"method":"tools/call","params":{"name":"dir2mcp.list_files","arguments":{"limit":10,"offset":"0"}}}`)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":10,"method":"tools/call","params":{"name":"dir2mcp_list_files","arguments":{"limit":10,"offset":"0"}}}`)
 	defer func() {
 		_ = resp.Body.Close()
 	}()
@@ -1068,7 +1068,7 @@ func TestMCPToolsCallListFiles_RejectsNegativeOffset(t *testing.T) {
 
 	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
 
-	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":11,"method":"tools/call","params":{"name":"dir2mcp.list_files","arguments":{"limit":10,"offset":-1}}}`)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":11,"method":"tools/call","params":{"name":"dir2mcp_list_files","arguments":{"limit":10,"offset":-1}}}`)
 	defer func() {
 		_ = resp.Body.Close()
 	}()
@@ -1089,7 +1089,7 @@ func TestMCPToolsCallListFiles_StoreFailureReturnsStoreCorrupt(t *testing.T) {
 
 	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
 
-	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":12,"method":"tools/call","params":{"name":"dir2mcp.list_files","arguments":{"limit":10,"offset":0}}}`)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":12,"method":"tools/call","params":{"name":"dir2mcp_list_files","arguments":{"limit":10,"offset":0}}}`)
 	defer func() {
 		_ = resp.Body.Close()
 	}()
@@ -1117,7 +1117,7 @@ func TestMCPToolsCallAsk_ReturnsStructuredAnswerAndCitations(t *testing.T) {
 	defer server.Close()
 
 	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
-	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":13,"method":"tools/call","params":{"name":"dir2mcp.ask","arguments":{"question":"what is alpha?","k":3,"index":"both"}}}`)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":13,"method":"tools/call","params":{"name":"dir2mcp_ask","arguments":{"question":"what is alpha?","k":3,"index":"both"}}}`)
 	defer func() {
 		_ = resp.Body.Close()
 	}()
@@ -1167,7 +1167,7 @@ func TestMCPToolsCallAsk_SearchOnly(t *testing.T) {
 	defer server.Close()
 
 	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
-	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":14,"method":"tools/call","params":{"name":"dir2mcp.ask","arguments":{"question":"q?","mode":"search_only","k":5}}}`)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":14,"method":"tools/call","params":{"name":"dir2mcp_ask","arguments":{"question":"q?","mode":"search_only","k":5}}}`)
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
@@ -1237,7 +1237,7 @@ func TestMCPToolsCallSearch_StructuredHitsSchemaShape(t *testing.T) {
 	defer server.Close()
 
 	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
-	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":77,"method":"tools/call","params":{"name":"dir2mcp.search","arguments":{"query":"payment flow","k":5}}}`)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":77,"method":"tools/call","params":{"name":"dir2mcp_search","arguments":{"query":"payment flow","k":5}}}`)
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
@@ -1287,7 +1287,7 @@ func TestMCPToolsCallSearch_RequiredOutputFieldsPresent(t *testing.T) {
 	defer server.Close()
 
 	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
-	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":94,"method":"tools/call","params":{"name":"dir2mcp.search","arguments":{"query":"anything"}}}`)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":94,"method":"tools/call","params":{"name":"dir2mcp_search","arguments":{"query":"anything"}}}`)
 	defer func() { _ = resp.Body.Close() }()
 
 	var envelope struct {
@@ -1326,7 +1326,7 @@ func TestMCPToolsCallAsk_RequiredOutputFieldsPresent(t *testing.T) {
 	defer server.Close()
 
 	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
-	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":95,"method":"tools/call","params":{"name":"dir2mcp.ask","arguments":{"question":"anything"}}}`)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":95,"method":"tools/call","params":{"name":"dir2mcp_ask","arguments":{"question":"anything"}}}`)
 	defer func() { _ = resp.Body.Close() }()
 
 	var envelope struct {
@@ -1400,7 +1400,7 @@ func TestMCPToolsCallListFiles_TotalReflectsHiddenFilter(t *testing.T) {
 	defer server.Close()
 
 	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
-	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":91,"method":"tools/call","params":{"name":"dir2mcp.list_files","arguments":{"limit":10,"offset":0}}}`)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":91,"method":"tools/call","params":{"name":"dir2mcp_list_files","arguments":{"limit":10,"offset":0}}}`)
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
@@ -1451,7 +1451,7 @@ func TestMCPToolsCallListFiles_IncludeHiddenTrue(t *testing.T) {
 	defer server.Close()
 
 	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
-	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":92,"method":"tools/call","params":{"name":"dir2mcp.list_files","arguments":{"limit":10,"offset":0,"include_hidden":true}}}`)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":92,"method":"tools/call","params":{"name":"dir2mcp_list_files","arguments":{"limit":10,"offset":0,"include_hidden":true}}}`)
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
@@ -1495,7 +1495,7 @@ func TestMCPToolsCallOpenFile_RejectsBinaryContent(t *testing.T) {
 	defer server.Close()
 
 	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
-	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":93,"method":"tools/call","params":{"name":"dir2mcp.open_file","arguments":{"rel_path":"recording.mp3"}}}`)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":93,"method":"tools/call","params":{"name":"dir2mcp_open_file","arguments":{"rel_path":"recording.mp3"}}}`)
 	defer func() { _ = resp.Body.Close() }()
 
 	assertToolCallErrorCode(t, resp, "DOC_TYPE_UNSUPPORTED")

--- a/tests/mcp/transport_test.go
+++ b/tests/mcp/transport_test.go
@@ -221,7 +221,7 @@ func TestSDKTransport_X402MissingPaymentSignature(t *testing.T) {
 		t.Fatal("expected session id from initialize")
 	}
 
-	callReq, err := http.NewRequest(http.MethodPost, url, strings.NewReader(`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"dir2mcp.stats","arguments":{}}}`))
+	callReq, err := http.NewRequest(http.MethodPost, url, strings.NewReader(`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"dir2mcp_stats","arguments":{}}}`))
 	if err != nil {
 		cancel()
 		t.Fatalf("create tools/call request: %v", err)

--- a/tests/mcp/x402_test.go
+++ b/tests/mcp/x402_test.go
@@ -29,7 +29,7 @@ func TestX402ToolsCall_UnpaidReturns402WithPaymentRequiredHeader(t *testing.T) {
 	defer server.Close()
 
 	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
-	resp := postRPCWithHeaders(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":101,"method":"tools/call","params":{"name":"dir2mcp.stats","arguments":{}}}`, nil)
+	resp := postRPCWithHeaders(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":101,"method":"tools/call","params":{"name":"dir2mcp_stats","arguments":{}}}`, nil)
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusPaymentRequired {
@@ -56,7 +56,7 @@ func TestX402ToolsCall_ModeOnIncompleteConfigFailOpen(t *testing.T) {
 	defer server.Close()
 
 	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
-	resp := postRPCWithHeaders(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":1001,"method":"tools/call","params":{"name":"dir2mcp.stats","arguments":{}}}`, nil)
+	resp := postRPCWithHeaders(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":1001,"method":"tools/call","params":{"name":"dir2mcp_stats","arguments":{}}}`, nil)
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
@@ -86,7 +86,7 @@ func TestX402ToolsCall_PaidRetrySucceedsAndReturnsPaymentResponse(t *testing.T) 
 	defer server.Close()
 
 	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
-	resp := postRPCWithHeaders(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":102,"method":"tools/call","params":{"name":"dir2mcp.stats","arguments":{}}}`, map[string]string{
+	resp := postRPCWithHeaders(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":102,"method":"tools/call","params":{"name":"dir2mcp_stats","arguments":{}}}`, map[string]string{
 		"PAYMENT-SIGNATURE": "signed-payment-payload",
 	})
 	defer func() { _ = resp.Body.Close() }()
@@ -122,7 +122,7 @@ func TestX402ToolsCall_VerifyTransientFailureIsRetryable503(t *testing.T) {
 	defer server.Close()
 
 	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
-	resp := postRPCWithHeaders(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":103,"method":"tools/call","params":{"name":"dir2mcp.stats","arguments":{}}}`, map[string]string{
+	resp := postRPCWithHeaders(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":103,"method":"tools/call","params":{"name":"dir2mcp_stats","arguments":{}}}`, map[string]string{
 		"PAYMENT-SIGNATURE": "signed-payment-payload",
 	})
 	defer func() { _ = resp.Body.Close() }()
@@ -146,7 +146,7 @@ func TestX402ToolsCall_VerifyInvalidReturns402WithChallenge(t *testing.T) {
 	defer server.Close()
 
 	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
-	resp := postRPCWithHeaders(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":104,"method":"tools/call","params":{"name":"dir2mcp.stats","arguments":{}}}`, map[string]string{
+	resp := postRPCWithHeaders(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":104,"method":"tools/call","params":{"name":"dir2mcp_stats","arguments":{}}}`, map[string]string{
 		"PAYMENT-SIGNATURE": "signed-payment-payload",
 	})
 	defer func() { _ = resp.Body.Close() }()
@@ -176,7 +176,7 @@ func TestX402ToolsCall_ToolErrorDoesNotSettle(t *testing.T) {
 	defer server.Close()
 
 	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
-	resp := postRPCWithHeaders(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":105,"method":"tools/call","params":{"name":"dir2mcp.unknown","arguments":{}}}`, map[string]string{
+	resp := postRPCWithHeaders(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":105,"method":"tools/call","params":{"name":"dir2mcp_unknown","arguments":{}}}`, map[string]string{
 		"PAYMENT-SIGNATURE": "signed-payment-payload",
 	})
 	defer func() { _ = resp.Body.Close() }()
@@ -207,7 +207,7 @@ func TestX402ToolsCall_SettleTransientFailureIsRetryable503(t *testing.T) {
 	defer server.Close()
 
 	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
-	resp := postRPCWithHeaders(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":108,"method":"tools/call","params":{"name":"dir2mcp.stats","arguments":{}}}`, map[string]string{
+	resp := postRPCWithHeaders(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":108,"method":"tools/call","params":{"name":"dir2mcp_stats","arguments":{}}}`, map[string]string{
 		"PAYMENT-SIGNATURE": "signed-payment-payload",
 	})
 	defer func() { _ = resp.Body.Close() }()
@@ -259,7 +259,7 @@ func TestX402ToolsCall_FacilitatorBearerTokenForwarded(t *testing.T) {
 	defer server.Close()
 
 	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
-	resp := postRPCWithHeaders(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":107,"method":"tools/call","params":{"name":"dir2mcp.stats","arguments":{}}}`, map[string]string{
+	resp := postRPCWithHeaders(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":107,"method":"tools/call","params":{"name":"dir2mcp_stats","arguments":{}}}`, map[string]string{
 		"PAYMENT-SIGNATURE": "signed-payment-payload",
 	})
 	defer func() { _ = resp.Body.Close() }()
@@ -294,7 +294,7 @@ func TestX402ToolsCall_SettleRetryReplaysCachedOutcomeWithoutReexecution(t *test
 	defer server.Close()
 
 	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
-	body := `{"jsonrpc":"2.0","id":201,"method":"tools/call","params":{"name":"dir2mcp.search","arguments":{"query":"foo"}}}`
+	body := `{"jsonrpc":"2.0","id":201,"method":"tools/call","params":{"name":"dir2mcp_search","arguments":{"query":"foo"}}}`
 
 	first := postRPCWithHeaders(t, server.URL+cfg.MCPPath, sessionID, body, map[string]string{
 		"PAYMENT-SIGNATURE": "stable-payment-signature",
@@ -349,7 +349,7 @@ func TestX402ToolsCall_CachedOutcomePersistsAcrossRestart(t *testing.T) {
 	retriever := &countingSearchRetriever{}
 	server1 := httptest.NewServer(mcp.NewServer(cfg, retriever, mcp.WithStore(st)).Handler())
 	sessionID := initializeSession(t, server1.URL+cfg.MCPPath)
-	body := `{"jsonrpc":"2.0","id":301,"method":"tools/call","params":{"name":"dir2mcp.search","arguments":{"query":"foo"}}}`
+	body := `{"jsonrpc":"2.0","id":301,"method":"tools/call","params":{"name":"dir2mcp_search","arguments":{"query":"foo"}}}`
 
 	first := postRPCWithHeaders(t, server1.URL+cfg.MCPPath, sessionID, body, map[string]string{
 		"PAYMENT-SIGNATURE": "restart-stable-signature",

--- a/tests/x402/parity_test.go
+++ b/tests/x402/parity_test.go
@@ -134,7 +134,7 @@ func paritySendRPC(t *testing.T, mcpURL, sessionID, body string, extraHeaders ma
 
 // toolsCallBody returns a JSON-RPC tools/call body for dir2mcp.stats.
 func toolsCallBody(id int) string {
-	return `{"jsonrpc":"2.0","id":` + strconv.Itoa(id) + `,"method":"tools/call","params":{"name":"dir2mcp.stats","arguments":{}}}`
+	return `{"jsonrpc":"2.0","id":` + strconv.Itoa(id) + `,"method":"tools/call","params":{"name":"dir2mcp_stats","arguments":{}}}`
 }
 
 // decodeErrorCode extracts the canonical error code from a JSON-RPC error


### PR DESCRIPTION
## Summary
Renames the 9 MCP tool names from `dir2mcp.X` to `dir2mcp_X`. Underscores satisfy Claude Desktop's frontend regex; dots don't.

## Why
Claude Desktop validates MCP tool names against `^[a-zA-Z0-9_-]{1,64}$` and rejects the entire `tools/list` response when any name contains characters outside that set. Symptom on the user side:

```
tools.2.FrontendRemoteMcpToolDefinition.name: String should match pattern '^[a-zA-Z0-9_-]{1,64}$'
```

The MCP spec is permissive on names, but the strictest known consumer (Claude Desktop) is the one that matters in practice. Underscores keep the `dir2mcp_*` family visually grouped while staying compatible with every client we know of.

## Scope
- `internal/protocol/constants.go` — 9 tool-name constants renamed; added a comment block explaining the rule so a future contributor doesn't restore the dots.
- Tests + docs swept with `sed -E 's/"dir2mcp\.([a-z_]+)"/"dir2mcp_\1"/g'` (and the equivalent for backtick-quoted prose). 10 files touched in total.
- Wire protocol and tool input/output schemas unchanged.

## Downstream impact
Clients that hardcoded the literal `dir2mcp.X` names (the dirstral-cli has its own ToolNameX consts that import from `protocol/constants`, so it follows automatically; ad-hoc curl scripts will need updating) will need to switch to `dir2mcp_X`.

## Test plan
- [x] `make ci` passes locally
- [x] Tool-name string sweep verified zero remaining `\"dir2mcp\.` literals across .go and .md
- [ ] CI matrix on this PR
- [ ] **Real-world validation:** after merge + v0.5.2 release, restart Claude Desktop and confirm the tools panel populates and a prompt that hits dir2mcp succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Renamed all MCP tool identifiers to use underscore-separated format (e.g., `dir2mcp_search` instead of `dir2mcp.search`). Update any tool references in configurations or integrations accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->