### PR TITLE
fix(cli,smoke): inspector tool name; banner version + alignment

### DIFF
--- a/internal/buildinfo/version.go
+++ b/internal/buildinfo/version.go
@@ -2,6 +2,7 @@ package buildinfo
 
 import (
 	"runtime/debug"
+	"strings"
 	"sync"
 )
 
@@ -26,12 +27,27 @@ var (
 
 // String returns the user-facing build version. See resolveVersion for the
 // fallback chain.
+//
+// The result is memoized for the process lifetime via sync.Once so the
+// resolution work runs at most once. Tests that want to exercise the
+// resolution branches under different inputs should call resolveVersion
+// directly with synthetic BuildInfo rather than mutating the Version
+// package var and re-calling String — the second call always returns
+// the cached result and the new Version value is never observed.
 func String() string {
 	resolveOnce.Do(func() {
 		info, _ := debug.ReadBuildInfo()
 		resolved = resolveVersion(Version, info)
 	})
 	return resolved
+}
+
+// Display returns the version with a "v" prefix, suitable for direct
+// rendering to users. Centralized to avoid the
+// "v" + strings.TrimPrefix(buildinfo.String(), "v") dance at every call
+// site (see internal/cli/app.go for prior copies).
+func Display() string {
+	return "v" + strings.TrimPrefix(String(), "v")
 }
 
 // resolveVersion is split out from String for testability — it takes the
@@ -49,7 +65,11 @@ func String() string {
 //     "v0.0.0-20260508195411-8869f0aabbcc" instead of the placeholder.
 //  3. info.Settings vcs.revision (short), wrapped as "dev-<sha>", so even
 //     an in-tree `go build` from a clean checkout shows the commit it was
-//     built from.
+//     built from. We require at least 7 hex digits to guard against
+//     toolchain quirks that could plant a non-SHA value in vcs.revision
+//     and produce a meaningless "dev-<7 garbage chars>" string.
+//     If the build was made on a dirty tree (vcs.modified=true), append
+//     "+dirty" so the rendered version flags local changes.
 //  4. The "0.0.0-dev" placeholder as a final fallback.
 func resolveVersion(injected string, info *debug.BuildInfo) string {
 	if injected != "" && injected != defaultVersion {
@@ -59,11 +79,43 @@ func resolveVersion(injected string, info *debug.BuildInfo) string {
 		if v := info.Main.Version; v != "" && v != "(devel)" {
 			return v
 		}
+		var revision string
+		var dirty bool
 		for _, s := range info.Settings {
-			if s.Key == "vcs.revision" && len(s.Value) >= 7 {
-				return "dev-" + s.Value[:7]
+			switch s.Key {
+			case "vcs.revision":
+				if len(s.Value) >= 7 && isHex(s.Value) {
+					revision = s.Value[:7]
+				}
+			case "vcs.modified":
+				dirty = s.Value == "true"
 			}
+		}
+		if revision != "" {
+			out := "dev-" + revision
+			if dirty {
+				out += "+dirty"
+			}
+			return out
 		}
 	}
 	return defaultVersion
+}
+
+// isHex reports whether s is composed entirely of hexadecimal digits.
+// Used to validate vcs.revision before we treat its prefix as a Git SHA.
+func isHex(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= '0' && r <= '9':
+		case r >= 'a' && r <= 'f':
+		case r >= 'A' && r <= 'F':
+		default:
+			return false
+		}
+	}
+	return true
 }

--- a/internal/buildinfo/version.go
+++ b/internal/buildinfo/version.go
@@ -1,3 +1,69 @@
 package buildinfo
 
-var Version = "0.0.0-dev"
+import (
+	"runtime/debug"
+	"sync"
+)
+
+// defaultVersion is the placeholder baked into binaries that were built
+// without a -ldflags injection. GoReleaser overrides Version with the
+// release tag at link time (see .goreleaser.yaml); local `go build` /
+// `go install` users get the placeholder, and the resolveVersion fallback
+// then tries to surface something useful from the embedded debug info.
+const defaultVersion = "0.0.0-dev"
+
+// Version is the link-time-injected build version. Reading this directly is
+// fine for tests that want the raw injected value; production code that
+// renders the version to users should call String() instead so that
+// `go install`-style builds get the embedded VCS revision rather than the
+// bare "0.0.0-dev" placeholder.
+var Version = defaultVersion
+
+var (
+	resolveOnce sync.Once
+	resolved    string
+)
+
+// String returns the user-facing build version. See resolveVersion for the
+// fallback chain.
+func String() string {
+	resolveOnce.Do(func() {
+		info, _ := debug.ReadBuildInfo()
+		resolved = resolveVersion(Version, info)
+	})
+	return resolved
+}
+
+// resolveVersion is split out from String for testability — it takes the
+// inputs explicitly so tests can drive every branch without wrestling with
+// the package-level sync.Once or the real ReadBuildInfo result.
+//
+// Resolution order:
+//
+//  1. The link-time-injected `injected` string, when it differs from the
+//     default "0.0.0-dev" placeholder. (GoReleaser sets this on real
+//     releases.)
+//  2. info.Main.Version, when it is non-empty and not the Go toolchain's
+//     "(devel)" sentinel. This makes `go install` builds report e.g.
+//     "v0.5.2" or a pseudo-version like
+//     "v0.0.0-20260508195411-8869f0aabbcc" instead of the placeholder.
+//  3. info.Settings vcs.revision (short), wrapped as "dev-<sha>", so even
+//     an in-tree `go build` from a clean checkout shows the commit it was
+//     built from.
+//  4. The "0.0.0-dev" placeholder as a final fallback.
+func resolveVersion(injected string, info *debug.BuildInfo) string {
+	if injected != "" && injected != defaultVersion {
+		return injected
+	}
+	if info != nil {
+		if v := info.Main.Version; v != "" && v != "(devel)" {
+			return v
+		}
+		for _, s := range info.Settings {
+			if s.Key == "vcs.revision" && len(s.Value) >= 7 {
+				return "dev-" + s.Value[:7]
+			}
+		}
+	}
+	return defaultVersion
+}

--- a/internal/buildinfo/version_test.go
+++ b/internal/buildinfo/version_test.go
@@ -1,0 +1,72 @@
+package buildinfo
+
+import (
+	"runtime/debug"
+	"testing"
+)
+
+func TestResolveVersion_PrefersInjectedOverDebugInfo(t *testing.T) {
+	info := &debug.BuildInfo{Main: debug.Module{Version: "v9.9.9"}}
+	got := resolveVersion("0.5.2", info)
+	if got != "0.5.2" {
+		t.Errorf("injected version should win; got %q want %q", got, "0.5.2")
+	}
+}
+
+func TestResolveVersion_FallsBackToMainVersion(t *testing.T) {
+	info := &debug.BuildInfo{Main: debug.Module{Version: "v0.5.2"}}
+	got := resolveVersion(defaultVersion, info)
+	if got != "v0.5.2" {
+		t.Errorf("Main.Version should win when injected is the default; got %q", got)
+	}
+}
+
+func TestResolveVersion_SkipsDevelSentinel(t *testing.T) {
+	info := &debug.BuildInfo{
+		Main: debug.Module{Version: "(devel)"},
+		Settings: []debug.BuildSetting{
+			{Key: "vcs.revision", Value: "8869f0aabbcc1122334455"},
+		},
+	}
+	got := resolveVersion(defaultVersion, info)
+	if got != "dev-8869f0a" {
+		t.Errorf("(devel) Main.Version should yield to vcs.revision; got %q want %q", got, "dev-8869f0a")
+	}
+}
+
+func TestResolveVersion_FallsBackToVCSRevision(t *testing.T) {
+	info := &debug.BuildInfo{
+		Settings: []debug.BuildSetting{
+			{Key: "vcs.revision", Value: "0123456789abcdef"},
+		},
+	}
+	got := resolveVersion(defaultVersion, info)
+	if got != "dev-0123456" {
+		t.Errorf("vcs.revision should be surfaced as dev-<sha7>; got %q want %q", got, "dev-0123456")
+	}
+}
+
+func TestResolveVersion_ShortVCSRevisionIsIgnored(t *testing.T) {
+	info := &debug.BuildInfo{
+		Settings: []debug.BuildSetting{{Key: "vcs.revision", Value: "abcd"}},
+	}
+	got := resolveVersion(defaultVersion, info)
+	if got != defaultVersion {
+		t.Errorf("vcs.revision shorter than 7 chars should be ignored; got %q", got)
+	}
+}
+
+func TestResolveVersion_FinalFallbackIsDefault(t *testing.T) {
+	got := resolveVersion(defaultVersion, nil)
+	if got != defaultVersion {
+		t.Errorf("with no debug info and default injected, must return placeholder; got %q", got)
+	}
+}
+
+func TestResolveVersion_EmptyInjectedFallsThrough(t *testing.T) {
+	info := &debug.BuildInfo{Main: debug.Module{Version: "v0.5.2"}}
+	got := resolveVersion("", info)
+	if got != "v0.5.2" {
+		t.Errorf("empty injected (test/edge case) should fall through to debug info; got %q", got)
+	}
+}

--- a/internal/buildinfo/version_test.go
+++ b/internal/buildinfo/version_test.go
@@ -2,6 +2,7 @@ package buildinfo
 
 import (
 	"runtime/debug"
+	"strings"
 	"testing"
 )
 
@@ -68,5 +69,69 @@ func TestResolveVersion_EmptyInjectedFallsThrough(t *testing.T) {
 	got := resolveVersion("", info)
 	if got != "v0.5.2" {
 		t.Errorf("empty injected (test/edge case) should fall through to debug info; got %q", got)
+	}
+}
+
+func TestResolveVersion_NonHexVCSRevisionRejected(t *testing.T) {
+	// A toolchain that plants a non-SHA value in vcs.revision must not
+	// produce a "dev-<7 garbage chars>" string — fall through to the
+	// placeholder instead.
+	info := &debug.BuildInfo{
+		Settings: []debug.BuildSetting{
+			{Key: "vcs.revision", Value: "not-a-hex-revision-string"},
+		},
+	}
+	got := resolveVersion(defaultVersion, info)
+	if got != defaultVersion {
+		t.Errorf("non-hex vcs.revision should fall through to placeholder; got %q", got)
+	}
+}
+
+func TestResolveVersion_DirtyTreeAppendsMarker(t *testing.T) {
+	info := &debug.BuildInfo{
+		Settings: []debug.BuildSetting{
+			{Key: "vcs.revision", Value: "0123456789abcdef"},
+			{Key: "vcs.modified", Value: "true"},
+		},
+	}
+	got := resolveVersion(defaultVersion, info)
+	if got != "dev-0123456+dirty" {
+		t.Errorf("dirty-tree build should append +dirty marker; got %q want %q", got, "dev-0123456+dirty")
+	}
+}
+
+func TestResolveVersion_NonNilInfoButEmptyEverything(t *testing.T) {
+	got := resolveVersion(defaultVersion, &debug.BuildInfo{})
+	if got != defaultVersion {
+		t.Errorf("non-nil but empty BuildInfo should yield placeholder; got %q", got)
+	}
+}
+
+func TestDisplay_AlwaysHasSingleVPrefix(t *testing.T) {
+	d := Display()
+	if !strings.HasPrefix(d, "v") {
+		t.Errorf("Display must start with v; got %q", d)
+	}
+	if strings.HasPrefix(d, "vv") {
+		t.Errorf("Display must not double-prefix v; got %q", d)
+	}
+}
+
+func TestIsHex(t *testing.T) {
+	cases := map[string]bool{
+		"":                       false,
+		"abc":                    true,
+		"ABC":                    true,
+		"0123456789abcdef":       true,
+		"0123456789ABCDEF":       true,
+		"0123456789ABCDEFabcdef": true,
+		"abcg":                   false,
+		"hello":                  false,
+		"a-b":                    false,
+	}
+	for in, want := range cases {
+		if got := isHex(in); got != want {
+			t.Errorf("isHex(%q): got %v want %v", in, got, want)
+		}
 	}
 }

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -400,7 +400,7 @@ func (a *App) runCommand(ctx context.Context, globalOpts globalOptions, remainin
 		return a.runUp(ctx, upOpts)
 	case "version":
 		if !globalOpts.quiet {
-			writeln(a.stdout, "dir2mcp v"+strings.TrimPrefix(buildinfo.String(), "v"))
+			writeln(a.stdout, "dir2mcp "+buildinfo.Display())
 		}
 		return exitSuccess
 	default:
@@ -1712,7 +1712,7 @@ func (e *ndjsonEmitter) Emit(level, event string, data interface{}) {
 func (a *App) printHumanConnection(cfg config.Config, connection connectionPayload, auth authMaterial, readOnly bool) {
 	s := a.sty(false)
 	writeln(a.stdout)
-	writef(a.stdout, "  %s %s\n", s.banner(), s.dim("v"+strings.TrimPrefix(buildinfo.String(), "v")))
+	writef(a.stdout, "  %s %s\n", s.banner(), s.dim(buildinfo.Display()))
 	writeln(a.stdout, s.separator(44))
 	writeln(a.stdout)
 

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -400,7 +400,7 @@ func (a *App) runCommand(ctx context.Context, globalOpts globalOptions, remainin
 		return a.runUp(ctx, upOpts)
 	case "version":
 		if !globalOpts.quiet {
-			writeln(a.stdout, "dir2mcp v"+strings.TrimPrefix(buildinfo.Version, "v"))
+			writeln(a.stdout, "dir2mcp v"+strings.TrimPrefix(buildinfo.String(), "v"))
 		}
 		return exitSuccess
 	default:
@@ -1712,7 +1712,7 @@ func (e *ndjsonEmitter) Emit(level, event string, data interface{}) {
 func (a *App) printHumanConnection(cfg config.Config, connection connectionPayload, auth authMaterial, readOnly bool) {
 	s := a.sty(false)
 	writeln(a.stdout)
-	writef(a.stdout, "  %s %s\n", s.banner(), s.dim("v0.0.0-dev"))
+	writef(a.stdout, "  %s %s\n", s.banner(), s.dim("v"+strings.TrimPrefix(buildinfo.String(), "v")))
 	writeln(a.stdout, s.separator(44))
 	writeln(a.stdout)
 

--- a/internal/cli/style.go
+++ b/internal/cli/style.go
@@ -155,12 +155,14 @@ func (s styles) stat(label string, value interface{}) string {
 	return fmt.Sprintf("%s=%s", s.Dim.Render(label), s.Value.Render(fmt.Sprintf("%v", value)))
 }
 
-// subkv formats a nested key-value pair with a wider key column (for long header names).
+// subkv formats a key-value pair with the same 2-space indent as kv but a
+// wider key column to fit long MCP header names. Indent matches kv so the
+// "Required headers" rows align with "MCP endpoint" rows in the up banner.
 func (s styles) subkv(key, value string) string {
 	if !s.enabled {
-		return fmt.Sprintf("    %-24s %s", key+":", value)
+		return fmt.Sprintf("  %-24s %s", key+":", value)
 	}
-	return fmt.Sprintf("    %s %s",
+	return fmt.Sprintf("  %s %s",
 		s.Key.Render(fmt.Sprintf("%-24s", key+":")),
 		s.Value.Render(value),
 	)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -381,7 +381,7 @@ func (s *Server) handleInitialize(w http.ResponseWriter, r *http.Request, id int
 		"serverInfo": map[string]interface{}{
 			"name":    "dir2mcp",
 			"title":   "dir2mcp: Directory RAG MCP Server",
-			"version": buildinfo.Version,
+			"version": buildinfo.String(),
 		},
 		"instructions": "Use tools/list then tools/call. Results include citations.",
 	})

--- a/internal/mcp/transport_sdk.go
+++ b/internal/mcp/transport_sdk.go
@@ -341,7 +341,7 @@ func (s *Server) buildSDKServer() *sdkmcp.Server {
 	sdkServer := sdkmcp.NewServer(&sdkmcp.Implementation{
 		Name:    "dir2mcp",
 		Title:   "dir2mcp: Directory RAG MCP Server",
-		Version: buildinfo.Version,
+		Version: buildinfo.String(),
 	}, &sdkmcp.ServerOptions{
 		Instructions: "Use tools/list then tools/call. Results include citations.",
 	})

--- a/scripts/inspector-smoke.sh
+++ b/scripts/inspector-smoke.sh
@@ -101,6 +101,6 @@ run_inspector() {
 }
 
 run_inspector "tools/list"      --method tools/list
-run_inspector "list_files call" --method tools/call --tool-name dir2mcp.list_files
+run_inspector "list_files call" --method tools/call --tool-name dir2mcp_list_files
 
 echo "[smoke] all checks passed"

--- a/scripts/smoke_hosted_demo.sh
+++ b/scripts/smoke_hosted_demo.sh
@@ -106,8 +106,8 @@ if ! grep -q '"tools"' "${list_body}"; then
   exit 1
 fi
 
-echo "[4/4] tools/call dir2mcp.list_files"
-call_payload='{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"dir2mcp.list_files","arguments":{"limit":1}}}'
+echo "[4/4] tools/call dir2mcp_list_files"
+call_payload='{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"dir2mcp_list_files","arguments":{"limit":1}}}'
 call_result="$(post_json "${call_payload}" "${session_id}")"
 call_code="$(extract_result_line "${call_result}" 1)"
 call_headers="$(extract_result_line "${call_result}" 2)"

--- a/tests/cli/command_behavior_test.go
+++ b/tests/cli/command_behavior_test.go
@@ -904,7 +904,7 @@ func TestVersionUsesBuildInfo(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("unexpected exit code: %d stderr=%s", code, stderr.String())
 	}
-	want := "dir2mcp v" + strings.TrimPrefix(buildinfo.Version, "v")
+	want := "dir2mcp " + buildinfo.Display()
 	if strings.TrimSpace(stdout.String()) != want {
 		t.Fatalf("version output=%q want=%q", strings.TrimSpace(stdout.String()), want)
 	}

--- a/tests/cli/version_command_test.go
+++ b/tests/cli/version_command_test.go
@@ -19,7 +19,7 @@ func TestDir2MCPVersionCommand_UsesBuildVersion(t *testing.T) {
 	}
 
 	got := strings.TrimSpace(stdout.String())
-	want := "dir2mcp v" + strings.TrimPrefix(buildinfo.Version, "v")
+	want := "dir2mcp " + buildinfo.Display()
 	if got != want {
 		t.Fatalf("unexpected version output: %q", got)
 	}

--- a/tests/mcp/server_test.go
+++ b/tests/mcp/server_test.go
@@ -280,7 +280,7 @@ func TestMCPInitialize_UsesBuildInfoVersion(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if envelope.Result.ServerInfo.Version != buildinfo.Version {
-		t.Fatalf("server version=%q want=%q", envelope.Result.ServerInfo.Version, buildinfo.Version)
+	if envelope.Result.ServerInfo.Version != buildinfo.String() {
+		t.Fatalf("server version=%q want=%q", envelope.Result.ServerInfo.Version, buildinfo.String())
 	}
 }


### PR DESCRIPTION
Three fixes for `dir2mcp up` and the inspector-smoke CI job. Daemonizing `up` (so the prompt returns immediately + adding `dir2mcp down`) is intentionally not in this PR — that's a real behavior change with its own design questions and will land separately.

## 1. Inspector-smoke CI failure (regression from #172)

`scripts/inspector-smoke.sh` hardcoded the legacy `dir2mcp.list_files` tool name. The dot→underscore rename in #172 only swept `.go` and `.md` files, so the shell script went unfixed and the live server now responds with `unknown tool "dir2mcp.list_files"` — the failure that flipped the inspector-smoke job red on #172. Fix: `dir2mcp_list_files`.

## 2. Banner showed `v0.0.0-dev` even on real releases

`internal/cli/app.go` had a hardcoded `s.dim("v0.0.0-dev")` literal at the top of the `up` banner, so even a brew-installed v0.5.x binary printed the dev placeholder. Switched to a new `buildinfo.String()` helper and routed the four production read sites through it for consistency.

`buildinfo.String()` resolves user-facing version with a four-step chain:

1. ldflag-injected `Version` when it differs from the `0.0.0-dev` default (the GoReleaser path)
2. `runtime/debug.ReadBuildInfo().Main.Version` when non-empty and not `(devel)` (`go install` users get a real pseudo-version)
3. `vcs.revision` short-sha as `dev-<sha7>` (in-tree `go build` shows the commit it was built from)
4. `0.0.0-dev` placeholder fallback

`resolveVersion` is split out from `String` for testability — the package-level `sync.Once` is kept in `String` while tests drive `resolveVersion` directly with synthetic `BuildInfo` values.

## 3. Banner alignment

The "Required headers" sub-rows were nested under a 4-space indent (`subkv` used `"    %-24s"`) while "MCP endpoint" rows above used a 2-space indent (`kv` used `"  %-14s"`), so the lower section drifted right. Dropped `subkv`'s extra indent; both sections now start at column 2.

Before:
```
  URL:           http://...
  ...
    MCP-Protocol-Version:    2025-11-25
    ...
```

After:
```
  URL:           http://...
  ...
  MCP-Protocol-Version:    2025-11-25
  ...
```

Values still don't perfectly column-align between the two sections (header names are simply longer than `URL`/`Auth`/`Token file`), but the keys do, which is the visual fix users asked for.

## Test plan
- [x] `make ci` passes locally
- [x] 7 new tests in `internal/buildinfo/version_test.go` cover every branch of the resolver (ldflag wins, Main.Version fallback, `(devel)` skip, vcs.revision short-sha, too-short-revision rejection, final placeholder, empty-injected edge case)
- [x] Visual rendering of the new banner alignment confirmed locally
- [ ] CI matrix on this PR (especially inspector-smoke, which #172 broke and this fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced version information reporting with improved fallback resolution and display formatting.

* **Bug Fixes**
  * Corrected MCP tool naming in smoke tests (updated tool name format).
  * Improved output formatting consistency for key-value display.

* **Tests**
  * Added comprehensive test coverage for version resolution logic, edge cases, and output formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->