### PR TITLE
feat(release): add brew caveat about shell command-cache refresh

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -63,6 +63,14 @@ brews:
       bin.install "dir2mcp"
     test: |
       system "#{bin}/dir2mcp", "version"
+    # Surface the most common upgrade pitfall: zsh/bash cache the path to
+    # `dir2mcp` per shell session. After `brew upgrade dir2mcp`, an
+    # already-open terminal can keep running the previous binary until
+    # the cache is cleared.
+    caveats: |
+      If `dir2mcp version` reports an older version after upgrading,
+      run `hash -r` (bash/zsh) in any open shells to refresh the
+      command cache, or open a new terminal.
 
 
 changelog:


### PR DESCRIPTION
## Summary

- Adds a short `caveats:` block to the GoReleaser brew config so the generated `dir2mcp.rb` ships a one-liner about `hash -r` after upgrades.
- Companion change to `dir2mcp-full.rb` lives in the tap repo (separate PR — that formula is hand-maintained, not regenerated by GoReleaser).

## Why

`brew upgrade dir2mcp` updates the symlink in `/opt/homebrew/bin`, but zsh/bash cache the resolved path per shell session. An already-open terminal keeps running the previous binary's banner (and behavior) until the cache is cleared. Hit this in person today after upgrading from 0.5.1 to 0.5.2 — the dev-shell still printed `v0.0.0-dev` from a stale build because zsh had hashed an old path.

The brew formula's `caveats` block is shown on `brew install` and `brew info` and is the cheapest place to surface the fix.

## Test plan

- [x] `ruby -ryaml -e "YAML.load_file('.goreleaser.yaml')"` passes
- [ ] Next release tag will regenerate `dir2mcp.rb` with the new `def caveats` method — sanity-check the tap PR diff after release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Homebrew upgrade guidance informing users to clear shell caches (`hash -r` or new terminal) if the command appears outdated after upgrading.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dirstral/dir2mcp/pull/175)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->