### PR TITLE
fix(cli): preflight config validation in daemon parent before fork

### DIFF
--- a/internal/cli/up_daemon.go
+++ b/internal/cli/up_daemon.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+
+	"dir2mcp/internal/config"
 )
 
 // runUpAsDaemonParent spawns a detached child process that runs the
@@ -40,33 +42,19 @@ func (a *App) runUpAsDaemonParent(_ context.Context, opts upOptions) int {
 		writeCLIError(a.stderr, opts.jsonOutput, exitConfigInvalid, fmt.Sprintf("load config: %v", err))
 		return exitConfigInvalid
 	}
+	// Re-run the fast, config-only preconditions the child would run, so
+	// a misconfig (missing MISTRAL_API_KEY, --public without auth) fails
+	// here instead of after a 15s readiness timeout the user has to debug
+	// from server.log. Listener-bind failures stay in the child — those
+	// genuinely need the OS to refuse the port — and the readiness-error
+	// path already points the user at the log for those.
+	if code := a.preflightDaemonParentConfig(&cfg, opts); code != exitSuccess {
+		return code
+	}
 	stateDir := cfg.StateDir
-	if err := os.MkdirAll(stateDir, 0o700); err != nil {
-		writeCLIError(a.stderr, opts.jsonOutput, exitGeneric, fmt.Sprintf("create state dir %s: %v", stateDir, err))
-		return exitGeneric
-	}
-
 	pidPath := pidFilePath(stateDir)
-	if existing, err := readPIDFile(pidPath); err == nil {
-		if processIsAlive(existing) {
-			writeCLIError(a.stderr, opts.jsonOutput, exitGeneric,
-				fmt.Sprintf("dir2mcp is already running for %s (pid %d)", stateDir, existing),
-				"Stop it with `dir2mcp down`, or pass --foreground to run a one-off in this terminal.",
-			)
-			return exitGeneric
-		}
-		// Stale pid file — silently clean it up so the spawn below has a
-		// clear field to write into when the child becomes ready.
-		_ = removePIDFile(pidPath)
-	}
-	// Also remove a stale connection.json from a previous run. Without
-	// this, the parent's waitForConnectionFile would observe the old
-	// file the instant we start polling and return success before the
-	// new child has bound or claimed the pid file — producing a
-	// confusing "daemon ready but pid file missing" race window.
-	connPath := connectionFilePath(stateDir)
-	if err := os.Remove(connPath); err != nil && !errors.Is(err, os.ErrNotExist) {
-		writef(a.stderr, "warning: clean stale %s: %v\n", connPath, err)
+	if code := a.prepareDaemonStateDir(stateDir, pidPath, opts); code != exitSuccess {
+		return code
 	}
 
 	logPath := serverLogPath(stateDir)
@@ -178,6 +166,71 @@ func (a *App) printDaemonReady(stateDir, logPath string, pid int, connection con
 	writeln(a.stdout)
 	writef(a.stdout, "  %s\n", s.Success.Render("Ready for connections"))
 	writef(a.stdout, "  %s\n\n", s.dim("Stop with: dir2mcp down"))
+}
+
+// prepareDaemonStateDir ensures the state directory exists, refuses to
+// continue when an existing pid file points at a live process, and
+// clears stale state from a previous run that would confuse the parent's
+// readiness poll. Pulled out of runUpAsDaemonParent purely to keep that
+// function under the gocyclo=15 budget after the preflight check landed.
+//
+// Stale-state cleanup notes:
+//   - A pid file whose owner is dead is silently removed so the child's
+//     O_EXCL claim has a clear field.
+//   - A leftover connection.json from a previous run is removed because
+//     waitForConnectionFile would otherwise observe the old file the
+//     instant we start polling and return success before the new child
+//     has bound — producing a confusing "daemon ready but pid file
+//     missing" race window.
+func (a *App) prepareDaemonStateDir(stateDir, pidPath string, opts upOptions) int {
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		writeCLIError(a.stderr, opts.jsonOutput, exitGeneric, fmt.Sprintf("create state dir %s: %v", stateDir, err))
+		return exitGeneric
+	}
+	if existing, err := readPIDFile(pidPath); err == nil {
+		if processIsAlive(existing) {
+			writeCLIError(a.stderr, opts.jsonOutput, exitGeneric,
+				fmt.Sprintf("dir2mcp is already running for %s (pid %d)", stateDir, existing),
+				"Stop it with `dir2mcp down`, or pass --foreground to run a one-off in this terminal.",
+			)
+			return exitGeneric
+		}
+		_ = removePIDFile(pidPath)
+	}
+	connPath := connectionFilePath(stateDir)
+	if err := os.Remove(connPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		writef(a.stderr, "warning: clean stale %s: %v\n", connPath, err)
+	}
+	return exitSuccess
+}
+
+// preflightDaemonParentConfig runs the subset of config validation that
+// can fail in the child for purely config-level reasons — i.e. would
+// produce the same error regardless of whether the listener binds. By
+// running these in the parent before fork(), we trade a 15s readiness
+// timeout (and a misleading "did not become ready" message that frames
+// a config bug as a daemon/network bug) for the immediate, accurate
+// error the in-process body would have printed.
+//
+// Limited intentionally to the cfg-only checks: --public-requires-auth
+// and missing MISTRAL_API_KEY. Port-bind failures and other runtime
+// errors stay in the child — those need the OS state we can only
+// observe after the listener attempts to bind, and the existing
+// readiness-timeout path already directs the user to server.log for
+// them (see TestDaemonLifecycle_BindBusyReportsClearError).
+//
+// Mutates cfg with the flag overrides the checks read (--listen,
+// --auth, --public). That's safe because the spawned child re-loads
+// config from scratch via its own loadConfigWithGlobalOptions call;
+// the parent's mutations exist only for the duration of this preflight.
+func (a *App) preflightDaemonParentConfig(cfg *config.Config, opts upOptions) int {
+	applyScalarOverrides(cfg, opts)
+	if cfg.Public || opts.public {
+		if code := a.applyPublicMode(cfg, opts); code != exitSuccess {
+			return code
+		}
+	}
+	return a.checkMistralAPIKey(cfg, opts, upNonInteractiveMode(opts))
 }
 
 // generateDaemonNonce returns a 32-character hex string drawn from the

--- a/tests/cli/daemon_preflight_test.go
+++ b/tests/cli/daemon_preflight_test.go
@@ -1,0 +1,81 @@
+//go:build unix
+
+package tests
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"dir2mcp/internal/cli"
+)
+
+// TestDaemonParent_MissingMistralAPIKeyFailsFast is the regression test
+// for issue #178. Before the fix, `dir2mcp up --daemon` with no
+// MISTRAL_API_KEY would fork a child that exited instantly on
+// CONFIG_INVALID, and the parent would surface a misleading 15s
+// "did not become ready" timeout instead of the real config error.
+//
+// The fix moves the cfg-only preconditions (--public requires auth,
+// missing MISTRAL_API_KEY) into the daemon parent BEFORE spawn, so a
+// misconfig produces the same instant CONFIG_INVALID error the
+// in-process body would have emitted.
+//
+// We assert two things:
+//
+//  1. The call returns the expected CONFIG_INVALID exit code with the
+//     "Missing MISTRAL_API_KEY" message on stderr.
+//  2. It returns quickly — well under the 15s readiness timeout the
+//     buggy fork-then-wait path would have hit. A 5s budget is plenty
+//     of headroom for a slow CI runner while still being a fraction of
+//     the 15s window we're regression-guarding against.
+//
+// Forks never happen because the preflight fails first, so this test
+// stays in the unit budget (no RUN_INTEGRATION_TESTS gate).
+func TestDaemonParent_MissingMistralAPIKeyFailsFast(t *testing.T) {
+	tmp := t.TempDir()
+	// Explicitly clear MISTRAL_API_KEY for this test even if the host
+	// environment has it set — the whole point is the missing-key path.
+	t.Setenv("MISTRAL_API_KEY", "")
+	t.Setenv("DIR2MCP_AUTH_TOKEN", "")
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+
+	start := time.Now()
+	var code int
+	withWorkingDir(t, tmp, func() {
+		// --daemon forces shouldDaemonize() to return true even though
+		// stdout is a *bytes.Buffer (not a TTY). That's the route the
+		// parent would take in a real interactive shell.
+		// --listen 127.0.0.1:0 isn't strictly necessary (the preflight
+		// fails before bind), but keeps the test deterministic if the
+		// preflight order ever changes.
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		code = app.RunWithContext(ctx, []string{"up", "--daemon", "--listen", "127.0.0.1:0"})
+	})
+	elapsed := time.Since(start)
+
+	const exitConfigInvalid = 2
+	if code != exitConfigInvalid {
+		t.Fatalf("exit code: got=%d want=%d stderr=%q", code, exitConfigInvalid, stderr.String())
+	}
+
+	stderrStr := stderr.String()
+	if !strings.Contains(stderrStr, "MISTRAL_API_KEY") {
+		t.Errorf("stderr should mention MISTRAL_API_KEY, got: %q", stderrStr)
+	}
+	if strings.Contains(stderrStr, "did not become ready") {
+		t.Errorf("stderr should NOT contain the 15s readiness timeout (issue #178); got: %q", stderrStr)
+	}
+
+	// 5s is generous headroom over the cfg-only preflight (microseconds
+	// of work) while staying well clear of the 15s readiness timeout
+	// the pre-fix code would have hit.
+	if elapsed > 5*time.Second {
+		t.Errorf("preflight should fail fast (well under 15s readiness timeout); elapsed=%s", elapsed)
+	}
+}


### PR DESCRIPTION
Closes #178.

## Summary

- Run the cfg-only preconditions (`--public` requires auth, missing `MISTRAL_API_KEY`) in `runUpAsDaemonParent` *before* forking, so a misconfig fails instantly with the same `CONFIG_INVALID` error the in-process body would have emitted instead of the misleading 15s "did not become ready" timeout.
- Extract `prepareDaemonStateDir` to keep `runUpAsDaemonParent` under the gocyclo=15 budget once the preflight branch lands.
- Add `TestDaemonParent_MissingMistralAPIKeyFailsFast` (unit-test gated on `//go:build unix`, no `RUN_INTEGRATION_TESTS` needed) that asserts the daemon parent exits with code 2 and the `MISTRAL_API_KEY` message in well under 5s — versus 15.11s and the misleading timeout pre-fix.

## Why

Reproduced from #178: `unset MISTRAL_API_KEY && cd /tmp/some-corpus && dir2mcp up --daemon` would fork a child that exited instantly on `CONFIG_INVALID`, but the parent stayed blocked for 15s waiting for `connection.json` that would never arrive, then printed `daemon (pid NNNNN) did not become ready: timed out after 15s ...`. That framed a config bug as a daemon/network bug, sending users to `lsof`/`netstat` instead of `printenv`. The child's real error (`Missing MISTRAL_API_KEY`) was already in `.dir2mcp/server.log` the whole time.

Listener-bind failures (port-in-use, etc.) are intentionally left in the child path — those need OS state only observable after `net.Listen`, and `TestDaemonLifecycle_BindBusyReportsClearError` already covers them with a readiness-error message that points the user at the log.

The new preflight is implemented as a `(cfg *config.Config, opts upOptions) int` helper so we can reuse the existing `applyScalarOverrides` / `applyPublicMode` / `checkMistralAPIKey` functions instead of duplicating their logic. The parent's local mutations to `cfg` are scoped to the preflight call — the spawned child reloads config from scratch via its own `loadConfigWithGlobalOptions`, so there's no cross-process state leakage.

## Test plan

- [x] `make ci` passes locally (lint, vet, gocyclo, go test, python tests, build).
- [x] New `TestDaemonParent_MissingMistralAPIKeyFailsFast` reproduces the bug pre-fix (verified: exit code 4, 15.11s elapsed, "did not become ready" in stderr) and passes post-fix (exit code 2, ~0s elapsed, `MISTRAL_API_KEY` in stderr).
- [x] Manual repro: `cd /tmp/empty-corpus && env -u MISTRAL_API_KEY dir2mcp up --daemon` now exits in ~0.5s with `ERROR: CONFIG_INVALID: Missing MISTRAL_API_KEY` and creates no `.dir2mcp/` state dir.
- [x] Existing `TestDaemonLifecycle_*` integration tests still pass (gated behind `RUN_INTEGRATION_TESTS=1`; not re-run in CI).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Daemon startup now fails immediately with clear error messages when configuration issues (missing API keys, invalid settings) are detected, eliminating lengthy timeout waits.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dirstral/dir2mcp/pull/179)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->