### PR TITLE
fix(retrieval): default open_file on PDFs to cached OCR text

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -983,6 +983,7 @@ Example tool execution error:
 * `PATH_OUTSIDE_ROOT`
 * `FILE_NOT_FOUND`
 * `DOC_TYPE_UNSUPPORTED`
+* `OCR_NOT_READY` (returned by `dir2mcp_open_file` for binary doc types — PDF, audio — when no OCR/transcript representation is cached yet; retryable once ingestion completes)
 
 ### 14.3 Index/state
 
@@ -1041,10 +1042,21 @@ All schemas are JSON Schema (draft-agnostic, compatible with common validators).
       "additionalProperties": false,
       "properties": { "kind": { "const": "time" }, "start_ms": { "type": "integer" }, "end_ms": { "type": "integer" } },
       "required": ["kind", "start_ms", "end_ms"]
+    },
+    {
+      "additionalProperties": false,
+      "properties": { "kind": { "const": "document" } },
+      "required": ["kind"]
     }
   ]
 }
 ```
+
+The `document` variant is emitted by `dir2mcp_open_file` when the requested
+`rel_path` is a binary doc type (PDF, audio) and the caller did not supply
+`page`, `start_ms/end_ms`, or `start_line/end_line`. It signals that
+`content` is the full OCR / transcript representation rather than a paged or
+timed slice.
 
 #### 15.1.2 `Hit`
 
@@ -1212,9 +1224,13 @@ filters is impossible.
 * Else if `start_line/end_line` provided → return file lines.
 * Else default:
 
-  * return first `max_chars` (or first N lines) for text/code,
-  * return page 1 for PDF OCR if available,
-  * return transcript beginning for audio.
+  * for text/code/markdown/html: return first `max_chars` of the file with no `span` set,
+  * for PDF: return the cached full-document OCR markdown with `span.kind="document"`; if the OCR cache hasn't been populated yet (e.g. ingest is still running) the tool MUST return error `OCR_NOT_READY` rather than the raw bytes,
+  * for audio: return the cached full-document transcript with `span.kind="document"`; same `OCR_NOT_READY` semantics as PDF when no transcript exists yet.
+
+The handler MUST NOT emit raw binary bytes through `content[].text` — that
+field is documented as text. PDFs and audio without a span argument resolve
+through the OCR / transcript cache, never through a direct file read.
 
 **Output schema (structuredContent):**
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1013,19 +1013,39 @@ func (s *Server) handleOpenFileTool(ctx context.Context, args map[string]interfa
 	if openErr != nil {
 		return toolCallResult{}, mapOpenFileError(openErr)
 	}
+	docType := inferDocType(relPath)
 	structured := map[string]interface{}{
-		"rel_path": relPath, "doc_type": inferDocType(relPath), "content": content, "truncated": truncated,
+		"rel_path": relPath, "doc_type": docType, "content": content, "truncated": truncated,
 	}
-	if looksLikeBinaryContent(relPath, content) {
+	if looksLikeBinaryContent(content) {
 		return toolCallResult{}, &toolExecutionError{Code: "DOC_TYPE_UNSUPPORTED", Message: "open_file does not support binary content; use transcribe for audio files", Retryable: false}
 	}
 	if strings.TrimSpace(span.Kind) != "" {
 		structured["span"] = buildOpenFileSpan(span)
+	} else if isBinaryDocTypeForOpenFile(docType) {
+		// For PDFs/audio with no requested span, the retriever has returned the
+		// cached OCR / transcript markdown. Surface this to the caller as
+		// span.kind=document so they can distinguish a full-document
+		// representation from a paged/timed slice.
+		structured["span"] = map[string]interface{}{"kind": "document"}
 	}
 	return toolCallResult{
 		Content:           []toolContentItem{{Type: "text", Text: content}},
 		StructuredContent: structured,
 	}, nil
+}
+
+// isBinaryDocTypeForOpenFile reports whether docType is one whose default
+// open_file response is served from an OCR / transcript cache rather than raw
+// file bytes (see issue #177). Keeping this private to mcp avoids leaking the
+// retriever-side notion of "binary doc type" into the public API surface.
+func isBinaryDocTypeForOpenFile(docType string) bool {
+	switch strings.ToLower(strings.TrimSpace(docType)) {
+	case "pdf", "audio":
+		return true
+	default:
+		return false
+	}
 }
 
 // parseMaxCharsArg parses the "max_chars" argument with a default and range.
@@ -1172,6 +1192,8 @@ func mapOpenFileError(err error) *toolExecutionError {
 		return &toolExecutionError{Code: "PATH_OUTSIDE_ROOT", Message: "path outside root", Retryable: false}
 	case errors.Is(err, model.ErrDocTypeUnsupported):
 		return &toolExecutionError{Code: "DOC_TYPE_UNSUPPORTED", Message: "doc type unsupported", Retryable: false}
+	case errors.Is(err, model.ErrOCRNotReady):
+		return &toolExecutionError{Code: "OCR_NOT_READY", Message: "ocr representation not yet available; retry once indexing completes or request a specific page/start_ms", Retryable: true}
 	case errors.Is(err, os.ErrNotExist):
 		return &toolExecutionError{Code: protocol.ErrorCodeFileNotFound, Message: "file not found", Retryable: false}
 	default:
@@ -1869,11 +1891,13 @@ func isListFilesNoisePath(relPath string) bool {
 	return false
 }
 
-func looksLikeBinaryContent(relPath, content string) bool {
-	if strings.IndexByte(content, 0) >= 0 {
-		return true
-	}
-	return inferDocType(relPath) == "audio"
+// looksLikeBinaryContent reports whether the payload is unsafe to surface as
+// MCP `text` content. The historical behavior also flagged audio doc types,
+// but since #177 binary types are served from the OCR / transcript cache and
+// the resulting markdown is text — so we now rely on the NUL-byte heuristic
+// alone and let the retriever decide what to return per doc_type.
+func looksLikeBinaryContent(content string) bool {
+	return strings.IndexByte(content, 0) >= 0
 }
 
 func serializeHit(h model.SearchHit) map[string]interface{} {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"unicode/utf8"
 
 	"dir2mcp/internal/ingest"
 	"dir2mcp/internal/mistral"
@@ -1018,7 +1019,7 @@ func (s *Server) handleOpenFileTool(ctx context.Context, args map[string]interfa
 		"rel_path": relPath, "doc_type": docType, "content": content, "truncated": truncated,
 	}
 	if looksLikeBinaryContent(content) {
-		return toolCallResult{}, &toolExecutionError{Code: "DOC_TYPE_UNSUPPORTED", Message: "open_file does not support binary content; use transcribe for audio files", Retryable: false}
+		return toolCallResult{}, &toolExecutionError{Code: "DOC_TYPE_UNSUPPORTED", Message: binaryContentMessageForDocType(docType), Retryable: false}
 	}
 	if strings.TrimSpace(span.Kind) != "" {
 		structured["span"] = buildOpenFileSpan(span)
@@ -1045,6 +1046,21 @@ func isBinaryDocTypeForOpenFile(docType string) bool {
 		return true
 	default:
 		return false
+	}
+}
+
+// binaryContentMessageForDocType picks a DOC_TYPE_UNSUPPORTED message tailored
+// to the inferred doc_type. The historical message hardcoded "use transcribe
+// for audio files", which was misleading when the same path was reached for a
+// PDF (or anything else) whose payload tripped the binary-content guard.
+func binaryContentMessageForDocType(docType string) string {
+	switch strings.ToLower(strings.TrimSpace(docType)) {
+	case "audio":
+		return "open_file does not support binary content; use transcribe for audio files"
+	case "pdf":
+		return "open_file does not support binary content; pass page=N to read a specific page once OCR has run"
+	default:
+		return "open_file does not support binary content; the resolved payload is not text"
 	}
 }
 
@@ -1892,13 +1908,57 @@ func isListFilesNoisePath(relPath string) bool {
 }
 
 // looksLikeBinaryContent reports whether the payload is unsafe to surface as
-// MCP `text` content. The historical behavior also flagged audio doc types,
-// but since #177 binary types are served from the OCR / transcript cache and
-// the resulting markdown is text — so we now rely on the NUL-byte heuristic
-// alone and let the retriever decide what to return per doc_type.
+// MCP `text` content. Some binary formats (mp3 frames, certain pdf byte
+// ranges) can lack NUL bytes entirely, so the NUL-byte signal alone is not
+// enough; we additionally reject payloads that aren't valid UTF-8 or whose
+// non-whitespace control-character density exceeds binaryControlCharThreshold
+// (sampled over the first binaryDetectionSampleBytes bytes to bound cost on
+// large payloads). The threshold is intentionally permissive — well-formed
+// markdown / source code is well under it, while typical binary data sails
+// past it — and the goal is "this clearly isn't text the agent can use,"
+// not perfect format detection.
 func looksLikeBinaryContent(content string) bool {
-	return strings.IndexByte(content, 0) >= 0
+	if content == "" {
+		return false
+	}
+	if strings.IndexByte(content, 0) >= 0 {
+		return true
+	}
+	sample := content
+	if len(sample) > binaryDetectionSampleBytes {
+		sample = sample[:binaryDetectionSampleBytes]
+	}
+	if !utf8.ValidString(sample) {
+		return true
+	}
+	var controls, total int
+	for _, r := range sample {
+		total++
+		// Standard whitespace (\t \n \r) is text, not "binary noise".
+		if r == '\t' || r == '\n' || r == '\r' {
+			continue
+		}
+		// C0 controls and DEL.
+		if r < 0x20 || r == 0x7f {
+			controls++
+		}
+	}
+	if total == 0 {
+		return false
+	}
+	return float64(controls)/float64(total) > binaryControlCharThreshold
 }
+
+const (
+	// binaryDetectionSampleBytes bounds how many bytes looksLikeBinaryContent
+	// scans for the control-character heuristic so very large text payloads
+	// (large OCR markdown, code dumps) don't pay an O(N) walk of the whole body.
+	binaryDetectionSampleBytes = 4096
+	// binaryControlCharThreshold is the ratio of non-whitespace C0 control bytes
+	// (excluding \t \n \r) above which we treat content as binary. 0.30 is well
+	// above realistic text payloads and well below typical binary streams.
+	binaryControlCharThreshold = 0.30
+)
 
 func serializeHit(h model.SearchHit) map[string]interface{} {
 	out := map[string]interface{}{

--- a/internal/mcp/tools_internal_test.go
+++ b/internal/mcp/tools_internal_test.go
@@ -1,0 +1,110 @@
+package mcp
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestLooksLikeBinaryContent exercises the heuristic upgrade landed for
+// PR #180: NUL-byte detection alone misses binary formats (mp3 frames, some
+// pdf byte ranges) that contain no NULs but plenty of non-text bytes. The
+// strengthened check rejects such payloads via UTF-8 validation plus a
+// non-whitespace control-character ratio, while leaving real text alone.
+func TestLooksLikeBinaryContent(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{
+			name:    "empty",
+			content: "",
+			want:    false,
+		},
+		{
+			name:    "pure ascii prose",
+			content: "Hello, world! This is plain ASCII text. The quick brown fox jumps over the lazy dog.",
+			want:    false,
+		},
+		{
+			name:    "valid utf-8 with emoji",
+			content: "résumé — naïve façade 🚀 — Привет, мир. これはテストです。",
+			want:    false,
+		},
+		{
+			name:    "whitespace only including \\t \\n \\r",
+			content: "\t\n\r\n\t  \n",
+			want:    false,
+		},
+		{
+			name:    "ascii markdown with code fences",
+			content: "# Title\n\n```go\nfunc main() {\n\tfmt.Println(\"hi\")\n}\n```\n",
+			want:    false,
+		},
+		{
+			name:    "embedded NUL byte",
+			content: "abc\x00def",
+			want:    true,
+		},
+		{
+			name:    "invalid utf-8 (lone continuation byte)",
+			content: "ok then \x80\x81 not utf8",
+			want:    true,
+		},
+		{
+			name: "high control-character ratio",
+			// no NULs, valid UTF-8, but >30% non-whitespace control bytes.
+			content: strings.Repeat("\x01\x02\x03\x04\x05x", 50),
+			want:    true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if got := looksLikeBinaryContent(tc.content); got != tc.want {
+				t.Fatalf("looksLikeBinaryContent(%q...) = %v; want %v", preview(tc.content), got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBinaryContentMessageForDocType verifies the DOC_TYPE_UNSUPPORTED message
+// is tailored to the inferred doc_type instead of always pointing at audio /
+// transcribe.
+func TestBinaryContentMessageForDocType(t *testing.T) {
+	cases := []struct {
+		docType     string
+		mustHave    []string
+		mustNotHave []string
+	}{
+		{docType: "audio", mustHave: []string{"transcribe"}},
+		{docType: "pdf", mustHave: []string{"page="}, mustNotHave: []string{"transcribe"}},
+		{docType: "md", mustNotHave: []string{"transcribe", "page="}},
+		{docType: "unknown", mustNotHave: []string{"transcribe", "page="}},
+		{docType: "", mustNotHave: []string{"transcribe", "page="}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run("doc_type="+tc.docType, func(t *testing.T) {
+			msg := binaryContentMessageForDocType(tc.docType)
+			for _, want := range tc.mustHave {
+				if !strings.Contains(msg, want) {
+					t.Fatalf("doc_type=%q message %q missing %q", tc.docType, msg, want)
+				}
+			}
+			for _, bad := range tc.mustNotHave {
+				if strings.Contains(msg, bad) {
+					t.Fatalf("doc_type=%q message %q must not contain %q", tc.docType, msg, bad)
+				}
+			}
+		})
+	}
+}
+
+func preview(s string) string {
+	if len(s) <= 40 {
+		return s
+	}
+	return s[:40]
+}

--- a/internal/model/errors.go
+++ b/internal/model/errors.go
@@ -27,6 +27,11 @@ var (
 
 	// ErrDocTypeUnsupported indicates the requested span/doc mode isn't supported.
 	ErrDocTypeUnsupported = errors.New("doc type unsupported")
+
+	// ErrOCRNotReady indicates that an OCR/transcript representation has not
+	// yet been computed for a binary document (e.g. PDF, audio). Callers
+	// should retry once ingestion completes rather than fall back to raw bytes.
+	ErrOCRNotReady = errors.New("ocr not ready")
 )
 
 type ProviderError struct {

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -666,6 +666,18 @@ func (s *Service) openFileFromOCRCache(stateDir, resolvedAbs, relPath string, se
 		stateDir = filepath.Join(".", ".dir2mcp")
 	}
 
+	// Reject directories explicitly, mirroring openFileFromResolvedPath. Without
+	// this guard os.Open succeeds on a directory and io.Copy on a directory file
+	// descriptor surfaces as an opaque OS error that the MCP layer would map to
+	// INTERNAL_ERROR; DOC_TYPE_UNSUPPORTED is the correct, actionable mapping.
+	info, err := os.Stat(resolvedAbs)
+	if err != nil {
+		return "", false, err
+	}
+	if info.IsDir() {
+		return "", false, model.ErrDocTypeUnsupported
+	}
+
 	sourceFile, err := os.Open(resolvedAbs)
 	if err != nil {
 		return "", false, err

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -666,12 +666,17 @@ func (s *Service) openFileFromOCRCache(stateDir, resolvedAbs, relPath string, se
 		stateDir = filepath.Join(".", ".dir2mcp")
 	}
 
-	raw, err := os.ReadFile(resolvedAbs)
+	sourceFile, err := os.Open(resolvedAbs)
 	if err != nil {
 		return "", false, err
 	}
-	sum := sha256.Sum256(raw)
-	hashHex := hex.EncodeToString(sum[:])
+	defer sourceFile.Close()
+
+	hasher := sha256.New()
+	if _, err := io.Copy(hasher, sourceFile); err != nil {
+		return "", false, err
+	}
+	hashHex := hex.EncodeToString(hasher.Sum(nil))
 
 	candidates := openFileOCRCacheCandidates(stateDir, hashHex, relPath)
 	for _, candidate := range candidates {

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -682,7 +682,7 @@ func (s *Service) openFileFromOCRCache(stateDir, resolvedAbs, relPath string, se
 	if err != nil {
 		return "", false, err
 	}
-	defer sourceFile.Close()
+	defer func() { _ = sourceFile.Close() }()
 
 	hasher := sha256.New()
 	if _, err := io.Copy(hasher, sourceFile); err != nil {

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -2,6 +2,8 @@ package retrieval
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -597,6 +599,7 @@ func (s *Service) openFile(ctx context.Context, relPath string, span model.Span,
 
 	s.metaMu.RLock()
 	rootDir := s.rootDir
+	stateDir := s.stateDir
 	pathExcludes := append([]string(nil), s.pathExcludes...)
 	secretPatterns := append([]*regexp.Regexp(nil), s.secretPatterns...)
 	s.metaMu.RUnlock()
@@ -619,7 +622,97 @@ func (s *Service) openFile(ctx context.Context, relPath string, span model.Span,
 		return "", false, err
 	}
 
+	// For binary documents (PDF, audio) with no explicit span, return the
+	// cached OCR/transcript markdown rather than the raw bytes. Without this,
+	// callers that don't pass page=N or start_ms/end_ms get an unusable text
+	// payload made of PDF stream bytes (see issue #177). Text-native types
+	// (md, txt, code, html) keep the existing default of returning file bytes.
+	if kind == "" && isBinaryDocType(normalizedRel) {
+		content, truncated, err := s.openFileFromOCRCache(stateDir, resolvedAbs, normalizedRel, secretPatterns, maxChars)
+		if err != nil {
+			return "", false, err
+		}
+		return content, truncated, nil
+	}
+
 	return s.openFileFromResolvedPath(resolvedAbs, secretPatterns, kind, span, maxChars)
+}
+
+// isBinaryDocType reports whether relPath has an extension whose contents are
+// not human-readable as raw bytes (PDF, audio formats). For these doc types
+// the default open_file response should serve the OCR / transcript cache.
+func isBinaryDocType(relPath string) bool {
+	switch strings.ToLower(filepath.Ext(strings.TrimSpace(relPath))) {
+	case ".pdf":
+		return true
+	case ".mp3", ".wav", ".m4a", ".flac":
+		return true
+	default:
+		return false
+	}
+}
+
+// openFileFromOCRCache reads the precomputed OCR (or transcript) representation
+// for a binary document. The cache layout mirrors what
+// internal/ingest.Service.readOrComputeOCR / readOrComputeTranscript write:
+// <stateDir>/cache/ocr/<sha256-of-source-bytes>.md for OCR, and
+// <stateDir>/cache/transcribe/<sha256-of-source-bytes>*.txt for transcripts.
+// When no cache file exists (e.g. ingest is still running), the function
+// returns model.ErrOCRNotReady so callers can surface an actionable error
+// rather than fall back to raw bytes.
+func (s *Service) openFileFromOCRCache(stateDir, resolvedAbs, relPath string, secretPatterns []*regexp.Regexp, maxChars int) (string, bool, error) {
+	stateDir = strings.TrimSpace(stateDir)
+	if stateDir == "" {
+		stateDir = filepath.Join(".", ".dir2mcp")
+	}
+
+	raw, err := os.ReadFile(resolvedAbs)
+	if err != nil {
+		return "", false, err
+	}
+	sum := sha256.Sum256(raw)
+	hashHex := hex.EncodeToString(sum[:])
+
+	candidates := openFileOCRCacheCandidates(stateDir, hashHex, relPath)
+	for _, candidate := range candidates {
+		data, readErr := os.ReadFile(candidate)
+		if readErr != nil {
+			if errors.Is(readErr, os.ErrNotExist) {
+				continue
+			}
+			return "", false, readErr
+		}
+		text := string(data)
+		if hasSecretMatch(secretPatterns, text) {
+			return "", false, model.ErrForbidden
+		}
+		out, truncated := truncateRunesWithFlag(text, maxChars)
+		return out, truncated, nil
+	}
+	return "", false, model.ErrOCRNotReady
+}
+
+// openFileOCRCacheCandidates returns the set of cache paths to consult, in
+// preference order, for a given source document. Audio transcripts are stored
+// with an optional language suffix (or none), so we glob for any matching
+// file. PDFs use a single .md path.
+func openFileOCRCacheCandidates(stateDir, hashHex, relPath string) []string {
+	switch strings.ToLower(filepath.Ext(relPath)) {
+	case ".pdf":
+		return []string{filepath.Join(stateDir, "cache", "ocr", hashHex+".md")}
+	case ".mp3", ".wav", ".m4a", ".flac":
+		// transcripts are written as <hash>[<-lang>].txt; default-language
+		// transcripts have no suffix, so the unsuffixed file is preferred.
+		out := []string{filepath.Join(stateDir, "cache", "transcribe", hashHex+".txt")}
+		matches, err := filepath.Glob(filepath.Join(stateDir, "cache", "transcribe", hashHex+"-*.txt"))
+		if err == nil {
+			sort.Strings(matches)
+			out = append(out, matches...)
+		}
+		return out
+	default:
+		return nil
+	}
 }
 
 func (s *Service) openFileFromMetadata(normalizedRel string, span model.Span, maxChars int, secretPatterns []*regexp.Regexp, kind string) (content string, truncated bool, handled bool, err error) {

--- a/tests/mcp/tools_test.go
+++ b/tests/mcp/tools_test.go
@@ -1483,13 +1483,87 @@ func TestMCPToolsCallListFiles_IncludeHiddenTrue(t *testing.T) {
 	}
 }
 
-func TestMCPToolsCallOpenFile_RejectsBinaryContent(t *testing.T) {
+// TestMCPToolsCallOpenFile_PDFNoSpan_DocumentSpan asserts that calling
+// open_file on a .pdf without span arguments returns the OCR text and tags
+// the structured content with span.kind=document so callers can distinguish
+// a full-document representation from a paged slice. Regression test for
+// issue #177 — without the fix the handler returned raw PDF bytes via the
+// content[].text field (an MCP spec violation) and emitted no span at all.
+func TestMCPToolsCallOpenFile_PDFNoSpan_DocumentSpan(t *testing.T) {
 	cfg := config.Default()
 	cfg.AuthMode = "none"
 
 	retriever := &askAudioRetrieverStub{
 		openFileConfigured: true,
-		openFileContent:    "fake audio bytes",
+		openFileContent:    "# Act\n\nARRANGEMENT OF SECTIONS",
+	}
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":94,"method":"tools/call","params":{"name":"dir2mcp_open_file","arguments":{"rel_path":"act.pdf"}}}`)
+	defer func() { _ = resp.Body.Close() }()
+
+	var envelope struct {
+		Result struct {
+			IsError           bool                   `json:"isError"`
+			Content           []map[string]any       `json:"content"`
+			StructuredContent map[string]interface{} `json:"structuredContent"`
+		} `json:"result"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if envelope.Result.IsError {
+		t.Fatalf("expected success, got isError=true: %#v", envelope.Result.StructuredContent)
+	}
+	span, ok := envelope.Result.StructuredContent["span"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected structuredContent.span, got %#v", envelope.Result.StructuredContent)
+	}
+	if span["kind"] != "document" {
+		t.Fatalf("expected span.kind=document, got %#v", span)
+	}
+	if envelope.Result.StructuredContent["doc_type"] != "pdf" {
+		t.Fatalf("expected doc_type=pdf, got %#v", envelope.Result.StructuredContent["doc_type"])
+	}
+	if got, _ := envelope.Result.StructuredContent["content"].(string); !strings.Contains(got, "ARRANGEMENT OF SECTIONS") {
+		t.Fatalf("expected OCR markdown content, got %q", got)
+	}
+}
+
+// TestMCPToolsCallOpenFile_PDFOCRNotReady asserts that when the retriever
+// reports that the OCR cache hasn't been populated yet, the tool surfaces
+// OCR_NOT_READY rather than swallowing the error or returning raw bytes.
+func TestMCPToolsCallOpenFile_PDFOCRNotReady(t *testing.T) {
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+
+	retriever := &askAudioRetrieverStub{
+		openFileConfigured: true,
+		openFileErr:        model.ErrOCRNotReady,
+	}
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":95,"method":"tools/call","params":{"name":"dir2mcp_open_file","arguments":{"rel_path":"missing.pdf"}}}`)
+	defer func() { _ = resp.Body.Close() }()
+
+	assertToolCallErrorCode(t, resp, "OCR_NOT_READY")
+}
+
+func TestMCPToolsCallOpenFile_RejectsBinaryContent(t *testing.T) {
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+
+	// content with an embedded NUL byte is the canonical "actually binary"
+	// signal the handler must refuse, regardless of doc_type. Since #177 the
+	// audio-extension shortcut was dropped because audio is now expected to
+	// resolve to a transcript representation upstream.
+	retriever := &askAudioRetrieverStub{
+		openFileConfigured: true,
+		openFileContent:    "raw\x00bytes",
 	}
 	server := httptest.NewServer(mcp.NewServer(cfg, retriever).Handler())
 	defer server.Close()

--- a/tests/mcp/tools_test.go
+++ b/tests/mcp/tools_test.go
@@ -1572,12 +1572,66 @@ func TestMCPToolsCallOpenFile_RejectsBinaryContent(t *testing.T) {
 	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":93,"method":"tools/call","params":{"name":"dir2mcp_open_file","arguments":{"rel_path":"recording.mp3"}}}`)
 	defer func() { _ = resp.Body.Close() }()
 
-	assertToolCallErrorCode(t, resp, "DOC_TYPE_UNSUPPORTED")
+	assertToolCallErrorCodeAndMessage(t, resp, "DOC_TYPE_UNSUPPORTED", []string{"transcribe"}, nil)
+}
+
+// TestMCPToolsCallOpenFile_RejectsBinaryContent_PDFMessage asserts that when
+// open_file rejects a binary payload for a .pdf rel_path, the
+// DOC_TYPE_UNSUPPORTED message mentions paging (the actionable fix for PDFs)
+// and does *not* mention transcribe (which is the wrong suggestion for PDFs).
+// Regression test for the PR #180 review finding that the message hardcoded
+// "use transcribe for audio files" for every doc_type.
+func TestMCPToolsCallOpenFile_RejectsBinaryContent_PDFMessage(t *testing.T) {
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+
+	retriever := &askAudioRetrieverStub{
+		openFileConfigured: true,
+		openFileContent:    "%PDF-1.4\x00stream",
+	}
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":96,"method":"tools/call","params":{"name":"dir2mcp_open_file","arguments":{"rel_path":"act.pdf"}}}`)
+	defer func() { _ = resp.Body.Close() }()
+
+	assertToolCallErrorCodeAndMessage(t, resp, "DOC_TYPE_UNSUPPORTED", []string{"page"}, []string{"transcribe"})
+}
+
+// TestMCPToolsCallOpenFile_RejectsBinaryContent_GenericMessage asserts the
+// fallback DOC_TYPE_UNSUPPORTED message for non-audio / non-pdf doc_types is
+// generic — no per-format suggestion that would be misleading.
+func TestMCPToolsCallOpenFile_RejectsBinaryContent_GenericMessage(t *testing.T) {
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+
+	retriever := &askAudioRetrieverStub{
+		openFileConfigured: true,
+		openFileContent:    "junk\x00bytes",
+	}
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	// .bin → inferDocType returns "unknown"; should hit the generic branch.
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":97,"method":"tools/call","params":{"name":"dir2mcp_open_file","arguments":{"rel_path":"blob.bin"}}}`)
+	defer func() { _ = resp.Body.Close() }()
+
+	assertToolCallErrorCodeAndMessage(t, resp, "DOC_TYPE_UNSUPPORTED", nil, []string{"transcribe", "page"})
 }
 
 // assertToolCallErrorCode validates that a tools/call response returned a
 // tool-level error payload with the expected canonical error code.
 func assertToolCallErrorCode(t *testing.T, resp *http.Response, wantCode string) {
+	t.Helper()
+	assertToolCallErrorCodeAndMessage(t, resp, wantCode, nil, nil)
+}
+
+// assertToolCallErrorCodeAndMessage extends assertToolCallErrorCode with
+// optional substring assertions on structuredContent.error.message. Pass
+// mustHave/mustNotHave nil/empty to skip the message check.
+func assertToolCallErrorCodeAndMessage(t *testing.T, resp *http.Response, wantCode string, mustHave, mustNotHave []string) {
 	t.Helper()
 
 	if resp.StatusCode != http.StatusOK {
@@ -1617,6 +1671,20 @@ func assertToolCallErrorCode(t *testing.T, resp *http.Response, wantCode string)
 	}
 	if gotCode != wantCode {
 		t.Fatalf("unexpected error code: got=%q want=%q full_error=%#v", gotCode, wantCode, errObj)
+	}
+	if len(mustHave) == 0 && len(mustNotHave) == 0 {
+		return
+	}
+	gotMsg, _ := errObj["message"].(string)
+	for _, want := range mustHave {
+		if !strings.Contains(gotMsg, want) {
+			t.Fatalf("error message missing substring %q: got=%q full_error=%#v", want, gotMsg, errObj)
+		}
+	}
+	for _, bad := range mustNotHave {
+		if strings.Contains(gotMsg, bad) {
+			t.Fatalf("error message must not contain %q: got=%q full_error=%#v", bad, gotMsg, errObj)
+		}
 	}
 }
 

--- a/tests/retrieval/open_file_pdf_default_test.go
+++ b/tests/retrieval/open_file_pdf_default_test.go
@@ -162,6 +162,32 @@ func TestOpenFile_MarkdownDefault_UnchangedBehavior(t *testing.T) {
 	}
 }
 
+// TestOpenFile_PDFExtensionOnDirectory_ReturnsErrDocTypeUnsupported asserts
+// that open_file on a path with a binary extension that actually resolves to a
+// directory returns ErrDocTypeUnsupported (mapped to DOC_TYPE_UNSUPPORTED at
+// the MCP layer) rather than bubbling an opaque OS error up as an
+// INTERNAL_ERROR. This mirrors how openFileFromResolvedPath rejects directory
+// targets and prevents the OCR-cache fallback from leaking EISDIR.
+func TestOpenFile_PDFExtensionOnDirectory_ReturnsErrDocTypeUnsupported(t *testing.T) {
+	root := t.TempDir()
+	stateDir := filepath.Join(root, ".dir2mcp")
+	// A directory whose name happens to end in .pdf — this would otherwise
+	// satisfy isBinaryDocType and route through openFileFromOCRCache.
+	dirPath := filepath.Join(root, "docs", "weird.pdf")
+	if err := os.MkdirAll(dirPath, 0o755); err != nil {
+		t.Fatalf("mkdir directory target: %v", err)
+	}
+
+	svc := retrieval.NewService(nil, nil, nil, nil)
+	svc.SetRootDir(root)
+	svc.SetStateDir(stateDir)
+
+	_, err := svc.OpenFile(context.Background(), "docs/weird.pdf", model.Span{}, 200)
+	if !errors.Is(err, model.ErrDocTypeUnsupported) {
+		t.Fatalf("expected ErrDocTypeUnsupported for a directory target, got %v", err)
+	}
+}
+
 // openFileWithMeta calls the *WithMeta variant via the interface assertion the
 // MCP handler uses, returning the truncation flag.
 func openFileWithMeta(t *testing.T, svc *retrieval.Service, relPath string, span model.Span, maxChars int) (string, bool, bool, error) {

--- a/tests/retrieval/open_file_pdf_default_test.go
+++ b/tests/retrieval/open_file_pdf_default_test.go
@@ -1,0 +1,178 @@
+package tests
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"dir2mcp/internal/model"
+	"dir2mcp/internal/retrieval"
+)
+
+// writePDFAndOCRCache writes a fake PDF at relPath under root and seeds the
+// OCR cache (under stateDir) with markdown keyed by sha256 of the PDF bytes.
+// Returns the byte content of the source so callers can compute their own
+// assertions if needed.
+func writePDFAndOCRCache(t *testing.T, root, stateDir, relPath, ocrMarkdown string) []byte {
+	t.Helper()
+	pdfBytes := []byte("%PDF-1.4\r%\xe2\xe3\xcf\xd3\r\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\ntrailer\n%%EOF")
+	absPath := filepath.Join(root, filepath.FromSlash(relPath))
+	if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
+		t.Fatalf("mkdir source: %v", err)
+	}
+	if err := os.WriteFile(absPath, pdfBytes, 0o644); err != nil {
+		t.Fatalf("write pdf: %v", err)
+	}
+	if ocrMarkdown != "" {
+		cacheDir := filepath.Join(stateDir, "cache", "ocr")
+		if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+			t.Fatalf("mkdir ocr cache: %v", err)
+		}
+		sum := sha256.Sum256(pdfBytes)
+		cachePath := filepath.Join(cacheDir, hex.EncodeToString(sum[:])+".md")
+		if err := os.WriteFile(cachePath, []byte(ocrMarkdown), 0o644); err != nil {
+			t.Fatalf("write ocr cache: %v", err)
+		}
+	}
+	return pdfBytes
+}
+
+func TestOpenFile_PDFNoSpan_ReturnsOCRMarkdown(t *testing.T) {
+	root := t.TempDir()
+	stateDir := filepath.Join(root, ".dir2mcp")
+	ocrText := "# Financial Investigation Agency Amendment Act\n\nARRANGEMENT OF SECTIONS\n\n1. Short title."
+	writePDFAndOCRCache(t, root, stateDir, "docs/act.pdf", ocrText)
+
+	svc := retrieval.NewService(nil, nil, nil, nil)
+	svc.SetRootDir(root)
+	svc.SetStateDir(stateDir)
+
+	out, err := svc.OpenFile(context.Background(), "docs/act.pdf", model.Span{}, 20000)
+	if err != nil {
+		t.Fatalf("OpenFile no-span on pdf returned err: %v", err)
+	}
+	if strings.HasPrefix(out, "%PDF") {
+		t.Fatalf("expected OCR markdown, got raw PDF bytes (first 80 chars): %q", out[:min(80, len(out))])
+	}
+	if !strings.Contains(out, "ARRANGEMENT OF SECTIONS") {
+		t.Fatalf("expected OCR markdown content, got %q", out)
+	}
+}
+
+func TestOpenFile_PDFNoSpan_TruncatesByMaxChars(t *testing.T) {
+	root := t.TempDir()
+	stateDir := filepath.Join(root, ".dir2mcp")
+	ocrText := strings.Repeat("x", 5000)
+	writePDFAndOCRCache(t, root, stateDir, "docs/long.pdf", ocrText)
+
+	svc := retrieval.NewService(nil, nil, nil, nil)
+	svc.SetRootDir(root)
+	svc.SetStateDir(stateDir)
+
+	// OpenFile (no -WithMeta) still applies maxChars internally.
+	out, err := svc.OpenFile(context.Background(), "docs/long.pdf", model.Span{}, 500)
+	if err != nil {
+		t.Fatalf("OpenFile err: %v", err)
+	}
+	if len([]rune(out)) != 500 {
+		t.Fatalf("expected exactly 500 chars after truncation, got %d", len([]rune(out)))
+	}
+
+	withMeta, _, truncated, err := openFileWithMeta(t, svc, "docs/long.pdf", model.Span{}, 500)
+	if err != nil {
+		t.Fatalf("OpenFileWithMeta err: %v", err)
+	}
+	if !truncated {
+		t.Fatalf("expected truncated=true when max_chars < cache length, got false (len=%d)", len([]rune(withMeta)))
+	}
+}
+
+func TestOpenFile_PDFNoCache_ReturnsErrOCRNotReady(t *testing.T) {
+	root := t.TempDir()
+	stateDir := filepath.Join(root, ".dir2mcp")
+	// Intentionally pass empty ocrMarkdown so the cache file is not created.
+	writePDFAndOCRCache(t, root, stateDir, "docs/missing.pdf", "")
+
+	svc := retrieval.NewService(nil, nil, nil, nil)
+	svc.SetRootDir(root)
+	svc.SetStateDir(stateDir)
+
+	_, err := svc.OpenFile(context.Background(), "docs/missing.pdf", model.Span{}, 200)
+	if !errors.Is(err, model.ErrOCRNotReady) {
+		t.Fatalf("expected ErrOCRNotReady, got %v", err)
+	}
+}
+
+func TestOpenFile_PDFWithPage_StillReadsRawBytesPath(t *testing.T) {
+	// With page=N the service routes through the existing page-slicing path
+	// rather than the new OCR-cache fallback. Use a text file that contains
+	// form-feed page separators to mimic OCR'd content the page slicer
+	// understands; the .pdf extension on the rel_path triggers the
+	// "binary doc type" branch only when no span is set.
+	root := t.TempDir()
+	stateDir := filepath.Join(root, ".dir2mcp")
+	filePath := filepath.Join(root, "docs", "paged.pdf")
+	if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filePath, []byte("page1-content\fpage2-content\fpage3-content"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	svc := retrieval.NewService(nil, nil, nil, nil)
+	svc.SetRootDir(root)
+	svc.SetStateDir(stateDir)
+
+	out, err := svc.OpenFile(context.Background(), "docs/paged.pdf", model.Span{Kind: "page", Page: 2}, 200)
+	if err != nil {
+		t.Fatalf("OpenFile with page=2 err: %v", err)
+	}
+	if out != "page2-content" {
+		t.Fatalf("page=2 should yield page 2 content, got %q", out)
+	}
+}
+
+func TestOpenFile_MarkdownDefault_UnchangedBehavior(t *testing.T) {
+	root := t.TempDir()
+	stateDir := filepath.Join(root, ".dir2mcp")
+	filePath := filepath.Join(root, "docs", "readme.md")
+	if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	body := "# Title\n\nHello world."
+	if err := os.WriteFile(filePath, []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	svc := retrieval.NewService(nil, nil, nil, nil)
+	svc.SetRootDir(root)
+	svc.SetStateDir(stateDir)
+
+	out, err := svc.OpenFile(context.Background(), "docs/readme.md", model.Span{}, 20000)
+	if err != nil {
+		t.Fatalf("OpenFile md no-span err: %v", err)
+	}
+	if out != body {
+		t.Fatalf("expected full markdown body, got %q", out)
+	}
+}
+
+// openFileWithMeta calls the *WithMeta variant via the interface assertion the
+// MCP handler uses, returning the truncation flag.
+func openFileWithMeta(t *testing.T, svc *retrieval.Service, relPath string, span model.Span, maxChars int) (string, bool, bool, error) {
+	t.Helper()
+	type withMeta interface {
+		OpenFileWithMeta(ctx context.Context, relPath string, span model.Span, maxChars int) (string, bool, error)
+	}
+	w, ok := interface{}(svc).(withMeta)
+	if !ok {
+		t.Fatalf("retrieval.Service does not implement OpenFileWithMeta")
+	}
+	content, truncated, err := w.OpenFileWithMeta(context.Background(), relPath, span, maxChars)
+	return content, false, truncated, err
+}


### PR DESCRIPTION
## Summary

Fixes #177. Without this patch, `dir2mcp_open_file` on a `.pdf` rel_path with no `page` argument returned the raw PDF stream bytes embedded in `content[].text` (e.g. `%PDF-1.4\r%����\r\n23 0 obj<<...trailer`). Agents can't do anything useful with those bytes and Claude Desktop has no way to know it should pass `page=N` first.

When the requested doc is a binary type (`.pdf`, audio) and no `page` / `start_ms` / `start_line` span is supplied, the retriever now hashes the source bytes, reads the precomputed cache (`.dir2mcp/cache/ocr/<sha>.md` for PDFs, `.dir2mcp/cache/transcribe/<sha>[-lang].txt` for audio), and returns that text instead. The mcp handler tags the structured response with `span.kind="document"` so callers can distinguish a full-document representation from a paged slice. When no cache exists yet (e.g. ingest is still running), the retriever returns a new `model.ErrOCRNotReady` and the mcp handler maps it to a new retryable `OCR_NOT_READY` error rather than leaking raw bytes.

This also resolves a latent MCP spec violation: `content[].text` is documented as text, not arbitrary bytes.

## Behavior change

- `dir2mcp_open_file` on a PDF with no positional span now returns OCR markdown text and `span.kind=document`, where previously it returned raw PDF stream bytes with no span.
- Same default for audio files.
- New error code `OCR_NOT_READY` (retryable=true) is returned for binary docs when the OCR/transcript cache has not been populated yet.
- Text-native docs (`.md`, `.txt`, code) are unchanged — they still return file content without a span field.
- The `looksLikeBinaryContent` guard no longer rejects payloads purely because the rel_path ends in `.mp3` — it now relies on NUL-byte detection alone, since binary types are now expected to resolve through the OCR/transcript cache upstream.

`docs/SPEC.md` was updated to document the new `document` span variant, the new `OCR_NOT_READY` error code, and the revised selection rules for `dir2mcp_open_file`.

## Test plan

- [x] `make ci` passes locally
- [x] New `tests/retrieval/open_file_pdf_default_test.go`:
  - PDF with cached OCR + no positional args returns OCR markdown text
  - PDF with cached OCR + `max_chars=500` truncates correctly and the `WithMeta` variant flags `truncated=true`
  - PDF without cached OCR + no positional args returns `model.ErrOCRNotReady` (not raw bytes)
  - PDF + `page=2` still routes through the page slicer (existing behavior preserved)
  - `.md` no-span still returns the full file content unchanged
- [x] New MCP-level tests in `tests/mcp/tools_test.go`:
  - PDF no-span emits `structuredContent.span.kind="document"` and the OCR text
  - PDF no-span with retriever returning `ErrOCRNotReady` surfaces tool-level `OCR_NOT_READY`
- [x] Existing `TestMCPToolsCallOpenFile_RejectsBinaryContent` updated to use a NUL-byte payload (the canonical binary signal) since the audio-extension shortcut no longer applies

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>