### PR TITLE
fix(mcp): drop unresolvable rel_paths from list_files (#176)

### DIFF
--- a/internal/mcp/list_files_resolve_test.go
+++ b/internal/mcp/list_files_resolve_test.go
@@ -1,0 +1,114 @@
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"dir2mcp/internal/config"
+	"dir2mcp/internal/model"
+)
+
+// TestCanResolveRoot exercises the four shapes that should drive the
+// list_files resolvability gate (issue #176 follow-up):
+//   - empty RootDir must NOT silently resolve to process CWD; treat it as
+//     "not resolvable" so we fall back to the unfiltered listing.
+//   - nonexistent path is not resolvable.
+//   - a path that exists but is a regular file (not a directory) is not
+//     resolvable; otherwise listFilesFiltered would gate every doc against a
+//     bogus root and drop them all.
+//   - a real directory is resolvable.
+func TestCanResolveRoot(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "not-a-dir.txt")
+	if err := os.WriteFile(filePath, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write probe file: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		root string
+		want bool
+	}{
+		{name: "empty", root: "", want: false},
+		{name: "whitespace only", root: "   ", want: false},
+		{name: "nonexistent path", root: filepath.Join(dir, "does-not-exist"), want: false},
+		{name: "file not dir", root: filePath, want: false},
+		{name: "valid dir", root: dir, want: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.Default()
+			cfg.RootDir = tc.root
+			s := NewServer(cfg, nil)
+			if got := s.canResolveRoot(); got != tc.want {
+				t.Fatalf("canResolveRoot(root=%q)=%v want=%v", tc.root, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIsResolvableSourceWithRoot covers the cached per-document helper that
+// listFilesFiltered uses in its hot loop. The helper must:
+//   - treat archive_member docs as resolvable without touching disk (they're
+//     virtual paths backed by an archive),
+//   - reject filesystem-source docs whose rel_path doesn't exist under root,
+//   - reject path traversal attempts,
+//   - accept filesystem-source docs whose rel_path resolves under root.
+func TestIsResolvableSourceWithRoot(t *testing.T) {
+	rootDir := t.TempDir()
+	rootAbs, err := filepath.Abs(rootDir)
+	if err != nil {
+		t.Fatalf("abs(root): %v", err)
+	}
+	rootReal, err := filepath.EvalSymlinks(rootAbs)
+	if err != nil {
+		t.Fatalf("evalsymlinks(root): %v", err)
+	}
+
+	realName := "real.pdf"
+	if err := os.WriteFile(filepath.Join(rootDir, realName), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write real file: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		doc  model.Document
+		want bool
+	}{
+		{
+			name: "archive member skips disk check",
+			doc:  model.Document{RelPath: "anything/at/all.txt", SourceType: "archive_member"},
+			want: true,
+		},
+		{
+			name: "filesystem doc that exists",
+			doc:  model.Document{RelPath: realName, SourceType: "filesystem"},
+			want: true,
+		},
+		{
+			name: "filesystem doc that is missing",
+			doc:  model.Document{RelPath: "missing.pdf", SourceType: "filesystem"},
+			want: false,
+		},
+		{
+			name: "path traversal rejected",
+			doc:  model.Document{RelPath: "../escape.pdf", SourceType: "filesystem"},
+			want: false,
+		},
+		{
+			name: "absolute path rejected",
+			doc:  model.Document{RelPath: filepath.Join(rootAbs, realName), SourceType: "filesystem"},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isResolvableSourceWithRoot(tc.doc, rootAbs, rootReal); got != tc.want {
+				t.Fatalf("isResolvableSourceWithRoot(%+v)=%v want=%v", tc.doc, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -425,11 +425,7 @@ func (s *Server) handleListFilesTool(ctx context.Context, args map[string]interf
 			listedTotal int64
 			listErr     error
 		)
-		if includeHidden {
-			listedDocs, listedTotal, listErr = s.store.ListFiles(ctx, pathPrefix, glob, limit, offset)
-		} else {
-			listedDocs, listedTotal, listErr = s.listVisibleFiles(ctx, pathPrefix, glob, limit, offset)
-		}
+		listedDocs, listedTotal, listErr = s.listFilesFiltered(ctx, pathPrefix, glob, limit, offset, includeHidden)
 		if listErr != nil && !errors.Is(listErr, model.ErrNotImplemented) {
 			return toolCallResult{}, &toolExecutionError{
 				Code:      "STORE_CORRUPT",
@@ -476,12 +472,37 @@ func (s *Server) handleListFilesTool(ctx context.Context, args map[string]interf
 	}, nil
 }
 
-func (s *Server) listVisibleFiles(ctx context.Context, pathPrefix, glob string, limit, offset int) ([]model.Document, int64, error) {
+// listFilesFiltered paginates s.store.ListFiles and skips entries that violate
+// the list_files contract. Skipped entries are:
+//   - hidden paths (when includeHidden is false), so internal artifacts under
+//     dot-prefixed directories don't leak into the public listing.
+//   - filesystem-source documents whose rel_path no longer resolves to a real
+//     file under the configured root. Without this filter, stale rows left
+//     behind by older buggy ingest paths or manual edits would surface here
+//     and then 404 on the round-trip through open_file (issue #176).
+//
+// The total is the count of entries that survived filtering — the surviving
+// "real" total from the agent's perspective — not the raw store count.
+func (s *Server) listFilesFiltered(ctx context.Context, pathPrefix, glob string, limit, offset int, includeHidden bool) ([]model.Document, int64, error) {
 	const pageSize = 500
 	collected := make([]model.Document, 0, limit)
 	visibleSeen := 0
 	storeOffset := 0
 	var storeTotal int64
+
+	// Resolve root once up front. On large corpora the per-document gate would
+	// otherwise re-run filepath.Abs + EvalSymlinks(root) for every row, which
+	// is syscall-heavy enough to show up on `list_files`.
+	var (
+		rootResolvable bool
+		rootAbs        string
+		rootReal       string
+	)
+	if abs, resolved, ok := s.resolveRoot(); ok {
+		rootResolvable = true
+		rootAbs = abs
+		rootReal = resolved
+	}
 
 	for {
 		docs, total, err := s.store.ListFiles(ctx, pathPrefix, glob, pageSize, storeOffset)
@@ -493,7 +514,10 @@ func (s *Server) listVisibleFiles(ctx context.Context, pathPrefix, glob string, 
 			break
 		}
 		for _, doc := range docs {
-			if isListFilesNoisePath(doc.RelPath) {
+			if !includeHidden && isListFilesNoisePath(doc.RelPath) {
+				continue
+			}
+			if rootResolvable && !isResolvableSourceWithRoot(doc, rootAbs, rootReal) {
 				continue
 			}
 			if visibleSeen >= offset && len(collected) < limit {
@@ -508,6 +532,70 @@ func (s *Server) listVisibleFiles(ctx context.Context, pathPrefix, glob string, 
 	}
 
 	return collected, int64(visibleSeen), nil
+}
+
+// resolveRoot resolves the configured RootDir to its absolute and
+// symlink-evaluated forms. The bool return reports whether RootDir points to
+// a real directory on disk; when false, callers should skip any per-document
+// resolution check so that misconfigured deployments still return whatever
+// the store has rather than an empty list.
+func (s *Server) resolveRoot() (rootAbs, rootReal string, ok bool) {
+	rootDir := strings.TrimSpace(s.cfg.RootDir)
+	if rootDir == "" {
+		return "", "", false
+	}
+
+	abs, err := filepath.Abs(rootDir)
+	if err != nil {
+		return "", "", false
+	}
+
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return "", "", false
+	}
+
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return "", "", false
+	}
+	if !info.IsDir() {
+		return "", "", false
+	}
+
+	return abs, resolved, true
+}
+
+// canResolveRoot is a thin wrapper over resolveRoot for callers that only
+// need the boolean signal.
+func (s *Server) canResolveRoot() bool {
+	_, _, ok := s.resolveRoot()
+	return ok
+}
+
+// isResolvableSourceWithRoot reports whether doc's rel_path can be opened via
+// the open_file contract, using caller-cached rootAbs/rootReal values to avoid
+// re-running filepath.Abs + EvalSymlinks(root) per document. Archive members
+// are virtual paths (the backing file is the archive itself) so they're always
+// considered resolvable; everything else must point to a real file under root.
+func isResolvableSourceWithRoot(doc model.Document, rootAbs, rootReal string) bool {
+	if strings.EqualFold(strings.TrimSpace(doc.SourceType), "archive_member") {
+		return true
+	}
+	normalized := filepath.ToSlash(filepath.Clean(strings.TrimSpace(doc.RelPath)))
+	if normalized == "." || normalized == ".." || strings.HasPrefix(normalized, "../") || filepath.IsAbs(doc.RelPath) {
+		return false
+	}
+	absPath := filepath.Join(rootAbs, filepath.FromSlash(normalized))
+	targetReal, err := filepath.EvalSymlinks(absPath)
+	if err != nil {
+		return false
+	}
+	rel, err := filepath.Rel(rootReal, targetReal)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false
+	}
+	return true
 }
 
 func (s *Server) handleSearchTool(ctx context.Context, args map[string]interface{}) (toolCallResult, *toolExecutionError) {

--- a/tests/mcp/tools_test.go
+++ b/tests/mcp/tools_test.go
@@ -1389,11 +1389,25 @@ func TestMCPToolsCallListFiles_TotalReflectsHiddenFilter(t *testing.T) {
 	cfg := config.Default()
 	cfg.AuthMode = "none"
 
+	// Materialise the stubbed docs on disk so the listFilesFiltered
+	// resolvability gate (added for issue #176) treats them as real entries
+	// rather than dropping them as stale.
+	rootDir := t.TempDir()
+	cfg.RootDir = rootDir
+	if err := os.MkdirAll(filepath.Join(rootDir, ".claude"), 0o755); err != nil {
+		t.Fatalf("mkdir .claude: %v", err)
+	}
+	for _, name := range []string{".DS_Store", ".claude/settings.local.json", "Gilles Deleuze.md"} {
+		if err := os.WriteFile(filepath.Join(rootDir, name), []byte("x"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
 	st := &failingListFilesStore{
 		docs: []model.Document{
-			{RelPath: ".DS_Store", DocType: "binary_ignored", SizeBytes: 1, MTimeUnix: 1, Status: "skipped"},
-			{RelPath: ".claude/settings.local.json", DocType: "data", SizeBytes: 1, MTimeUnix: 1, Status: "ok"},
-			{RelPath: "Gilles Deleuze.md", DocType: "md", SizeBytes: 1, MTimeUnix: 1, Status: "ok"},
+			{RelPath: ".DS_Store", DocType: "binary_ignored", SourceType: "filesystem", SizeBytes: 1, MTimeUnix: 1, Status: "skipped"},
+			{RelPath: ".claude/settings.local.json", DocType: "data", SourceType: "filesystem", SizeBytes: 1, MTimeUnix: 1, Status: "ok"},
+			{RelPath: "Gilles Deleuze.md", DocType: "md", SourceType: "filesystem", SizeBytes: 1, MTimeUnix: 1, Status: "ok"},
 		},
 	}
 	server := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st)).Handler())
@@ -1440,11 +1454,25 @@ func TestMCPToolsCallListFiles_IncludeHiddenTrue(t *testing.T) {
 	cfg := config.Default()
 	cfg.AuthMode = "none"
 
+	// See TestMCPToolsCallListFiles_TotalReflectsHiddenFilter for why these
+	// docs need to exist on disk under cfg.RootDir (issue #176 round-trip
+	// guarantee).
+	rootDir := t.TempDir()
+	cfg.RootDir = rootDir
+	if err := os.MkdirAll(filepath.Join(rootDir, ".claude"), 0o755); err != nil {
+		t.Fatalf("mkdir .claude: %v", err)
+	}
+	for _, name := range []string{".DS_Store", ".claude/settings.local.json", "Gilles Deleuze.md"} {
+		if err := os.WriteFile(filepath.Join(rootDir, name), []byte("x"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
 	st := &failingListFilesStore{
 		docs: []model.Document{
-			{RelPath: ".DS_Store", DocType: "binary_ignored", SizeBytes: 1, MTimeUnix: 1, Status: "skipped"},
-			{RelPath: ".claude/settings.local.json", DocType: "data", SizeBytes: 1, MTimeUnix: 1, Status: "ok"},
-			{RelPath: "Gilles Deleuze.md", DocType: "md", SizeBytes: 1, MTimeUnix: 1, Status: "ok"},
+			{RelPath: ".DS_Store", DocType: "binary_ignored", SourceType: "filesystem", SizeBytes: 1, MTimeUnix: 1, Status: "skipped"},
+			{RelPath: ".claude/settings.local.json", DocType: "data", SourceType: "filesystem", SizeBytes: 1, MTimeUnix: 1, Status: "ok"},
+			{RelPath: "Gilles Deleuze.md", DocType: "md", SourceType: "filesystem", SizeBytes: 1, MTimeUnix: 1, Status: "ok"},
 		},
 	}
 	server := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st)).Handler())
@@ -1480,6 +1508,144 @@ func TestMCPToolsCallListFiles_IncludeHiddenTrue(t *testing.T) {
 	}
 	if len(files) != 3 {
 		t.Fatalf("expected 3 files with include_hidden=true, got %d", len(files))
+	}
+}
+
+// TestMCPToolsCallListFiles_RoundTripsAdversarialNames is the regression test
+// for issue #176: list_files must only emit rel_paths that round-trip through
+// open_file, even when the underlying store carries adversarial filenames or
+// stale rows whose source file no longer exists on disk.
+//
+// The "stale row" arm covers the original bug shape: a previous version of the
+// ingest pipeline (or manual SQL) had registered a phantom rel_path that no
+// longer corresponds to a real file. Without filtering, list_files would
+// surface that path and any agent driving open_file off it would 404.
+func TestMCPToolsCallListFiles_RoundTripsAdversarialNames(t *testing.T) {
+	rootDir := t.TempDir()
+	stateDir := filepath.Join(rootDir, ".dir2mcp")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+
+	// Adversarial names exercising shapes seen in real corpora: double dashes,
+	// leading/trailing dashes, parens, spaces, and unicode. Each name is a real
+	// file on disk so the open_file round-trip must succeed.
+	adversarial := []string{
+		"normal.pdf",
+		"foo--bar.pdf",
+		"--leading.pdf",
+		"trail--.pdf",
+		"with (parens).pdf",
+		"with spaces.pdf",
+		"with-单-unicode.pdf",
+		"SINo3of2025--AML(Amendment)Regulations2025.pdf",
+	}
+	body := []byte("hello world\n")
+	for _, name := range adversarial {
+		if err := os.WriteFile(filepath.Join(rootDir, name), body, 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	st := store.NewSQLiteStore(filepath.Join(stateDir, "meta.sqlite"))
+	if err := st.Init(context.Background()); err != nil {
+		t.Fatalf("init sqlite store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	for _, name := range adversarial {
+		if err := st.UpsertDocument(context.Background(), model.Document{
+			RelPath:     name,
+			DocType:     "pdf",
+			SourceType:  "filesystem",
+			SizeBytes:   int64(len(body)),
+			MTimeUnix:   1,
+			ContentHash: "h",
+			Status:      "ok",
+		}); err != nil {
+			t.Fatalf("upsert %s: %v", name, err)
+		}
+	}
+
+	// Stale row: the rel_path is well-formed but no such file exists on disk.
+	// This mirrors the malformed entry observed in the issue report (#176):
+	// `-/SINo3of2025--AML(Amendment)Regulations2025.md`. Without the resolvability
+	// gate this would slip through list_files and 404 on open_file.
+	stalePath := "-/SINo3of2025--AML(Amendment)Regulations2025.md"
+	if err := st.UpsertDocument(context.Background(), model.Document{
+		RelPath:     stalePath,
+		DocType:     "md",
+		SourceType:  "filesystem",
+		SizeBytes:   3140,
+		MTimeUnix:   1,
+		ContentHash: "stale",
+		Status:      "ok",
+	}); err != nil {
+		t.Fatalf("upsert stale row: %v", err)
+	}
+
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+	cfg.RootDir = rootDir
+	cfg.StateDir = stateDir
+	cfg.MCPPath = protocol.DefaultMCPPath
+
+	server := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st)).Handler())
+	defer server.Close()
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":176,"method":"tools/call","params":{"name":"dir2mcp_list_files","arguments":{"limit":50,"offset":0}}}`)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d want=%d body=%s", resp.StatusCode, http.StatusOK, string(payload))
+	}
+	var envelope struct {
+		Result struct {
+			IsError           bool                   `json:"isError"`
+			StructuredContent map[string]interface{} `json:"structuredContent"`
+		} `json:"result"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if envelope.Result.IsError {
+		t.Fatalf("expected success, got %#v", envelope.Result.StructuredContent)
+	}
+	filesRaw, ok := envelope.Result.StructuredContent["files"].([]interface{})
+	if !ok {
+		t.Fatalf("expected files array, got %#v", envelope.Result.StructuredContent["files"])
+	}
+
+	gotPaths := make(map[string]bool, len(filesRaw))
+	for _, raw := range filesRaw {
+		f, ok := raw.(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected file object, got %#v", raw)
+		}
+		rp, _ := f["rel_path"].(string)
+		gotPaths[rp] = true
+	}
+	if gotPaths[stalePath] {
+		t.Fatalf("stale rel_path %q must not surface from list_files; got %#v",
+			stalePath, gotPaths)
+	}
+	for _, name := range adversarial {
+		if !gotPaths[name] {
+			t.Fatalf("expected list_files to surface %q; got %#v", name, gotPaths)
+		}
+	}
+
+	// Round-trip: every rel_path returned by list_files must resolve to a real
+	// file under root — this is the precondition open_file relies on. Asserting
+	// the file-existence half here keeps the test focused on the list_files
+	// surface (open_file proper is exercised by retrieval-package tests with a
+	// retriever wired in).
+	for path := range gotPaths {
+		if _, err := os.Stat(filepath.Join(rootDir, path)); err != nil {
+			t.Fatalf("list_files returned non-resolvable rel_path %q: %v", path, err)
+		}
 	}
 }
 
@@ -1552,6 +1718,7 @@ func TestMCPToolsCallOpenFile_PDFOCRNotReady(t *testing.T) {
 
 	assertToolCallErrorCode(t, resp, "OCR_NOT_READY")
 }
+
 
 func TestMCPToolsCallOpenFile_RejectsBinaryContent(t *testing.T) {
 	cfg := config.Default()


### PR DESCRIPTION
## Summary

`dir2mcp_list_files` was returning rel_paths whose source file no longer exists on disk. Issue #176 caught one such phantom row in a real corpus (`-/SINo3of2025--AML(Amendment)Regulations2025.md`); the round-trip into `dir2mcp_open_file` then 404'd. The bug was load-bearing for any agent driving the toolchain by name.

This PR adds a resolvability gate at the `list_files` surface: filesystem-source documents are skipped when their rel_path doesn't resolve to a real file under root. Archive members (virtual paths) are exempt; if root itself can't be resolved we stand down so misconfigured deployments still get whatever the store has.

## Reproduction

In the original report:

```jsonc
// dir2mcp_list_files {"limit": 1}
{ "rel_path": "-/SINo3of2025--AML(Amendment)Regulations2025.md", "doc_type": "md", ... }

// dir2mcp_open_file {"rel_path": "-/SINo3of2025--AML(Amendment)Regulations2025.md"}
{ "isError": true, "structuredContent": { "error": { "code": "FILE_NOT_FOUND" } } }
```

The phantom rel_path is in the user's `meta.sqlite` (`source_type=filesystem`, `deleted=0`, doc_id=1) but the corresponding `-/...` directory doesn't exist on disk. It looks like leftover state from an earlier ingest path that has since been replaced; the new resolvability gate makes `list_files` safe regardless of how a stale row got there (older bug, manual edit, partial migration).

## Test plan

- [x] New regression test `TestMCPToolsCallListFiles_RoundTripsAdversarialNames` walks an adversarial corpus (`foo--bar.pdf`, `--leading.pdf`, `trail--.pdf`, parens, spaces, unicode, plain control, plus the original `SINo3of2025--AML(...)2025.pdf`), injects a stale row matching the issue report, and asserts:
  - the stale row is filtered from `list_files`
  - every adversarial real file is surfaced
  - every returned rel_path resolves to an existing file under root (the open_file precondition)
- [x] Verified the new test fails on `main` and passes with the fix applied.
- [x] Updated existing `TestMCPToolsCallListFiles_TotalReflectsHiddenFilter` and `TestMCPToolsCallListFiles_IncludeHiddenTrue` to materialise their stub docs on disk so the new gate doesn't drop them.
- [x] `make ci` passes locally (vet + cyclo + test + test-release-tools).

Closes #176.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file listing to automatically exclude inaccessible or invalid files from results.
  * Enhanced handling of hidden files in directory listings.

* **Tests**
  * Added regression test for edge-case filenames and stale file exclusion.
  * Updated existing file listing tests for improved coverage.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dirstral/dir2mcp/pull/181)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->