### PR TITLE
chore(mod): canonicalize module path to github.com/dirstral/dir2mcp

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -21,7 +21,7 @@ builds:
     # injected into unused symbols and have been dropped — re-add when
     # the runtime actually reads them.
     ldflags:
-      - -s -w -X dir2mcp/internal/buildinfo.Version={{.Version}}
+      - -s -w -X github.com/dirstral/dir2mcp/internal/buildinfo.Version={{.Version}}
 
 
 archives:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 build: build-dir2mcp
 
 DIR2MCP_VERSION ?= 0.0.0-dev
-DIR2MCP_LDFLAGS ?= -X dir2mcp/internal/buildinfo.Version=$(DIR2MCP_VERSION)
+DIR2MCP_LDFLAGS ?= -X github.com/dirstral/dir2mcp/internal/buildinfo.Version=$(DIR2MCP_VERSION)
 GOBIN_DIR := $(shell sh -c 'gobin=$$(go env GOBIN); if [ -n "$$gobin" ]; then echo "$$gobin"; else echo "$$(go env GOPATH | cut -d: -f1)/bin"; fi')
 ifndef GOCYCLO_BIN
 GOCYCLO_BIN := $(shell command -v gocyclo 2>/dev/null || echo "$(GOBIN_DIR)/gocyclo")

--- a/cmd/dir2mcp/main.go
+++ b/cmd/dir2mcp/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"dir2mcp/internal/cli"
+	"github.com/dirstral/dir2mcp/internal/cli"
 )
 
 func main() {

--- a/cmd/elevenlabs-bridge/main.go
+++ b/cmd/elevenlabs-bridge/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"dir2mcp/internal/cli"
+	"github.com/dirstral/dir2mcp/internal/cli"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module dir2mcp
+module github.com/dirstral/dir2mcp
 
 go 1.24.2
 

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -19,17 +19,17 @@ import (
 	"syscall"
 	"time"
 
-	"dir2mcp/internal/appstate"
-	"dir2mcp/internal/buildinfo"
-	"dir2mcp/internal/config"
-	"dir2mcp/internal/index"
-	"dir2mcp/internal/ingest"
-	"dir2mcp/internal/mcp"
-	"dir2mcp/internal/mistral"
-	"dir2mcp/internal/model"
-	"dir2mcp/internal/protocol"
-	"dir2mcp/internal/retrieval"
-	"dir2mcp/internal/store"
+	"github.com/dirstral/dir2mcp/internal/appstate"
+	"github.com/dirstral/dir2mcp/internal/buildinfo"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/mistral"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/protocol"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
+	"github.com/dirstral/dir2mcp/internal/store"
 )
 
 const (

--- a/internal/cli/ask.go
+++ b/internal/cli/ask.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/model"
 )
 
 func (a *App) runAsk(ctx context.Context, global globalOptions, args []string) int {

--- a/internal/cli/bridge.go
+++ b/internal/cli/bridge.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strings"
 
-	"dir2mcp/internal/elevenlabsbridge"
+	"github.com/dirstral/dir2mcp/internal/elevenlabsbridge"
 )
 
 func (a *App) runBridge(ctx context.Context, global globalOptions, args []string) int {

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/config"
 )
 
 func (a *App) emitConfigCreatedMessage(global globalOptions, configPath string, created bool) {

--- a/internal/cli/corpus_snapshot_test.go
+++ b/internal/cli/corpus_snapshot_test.go
@@ -6,8 +6,8 @@ import (
 	"math"
 	"testing"
 
-	"dir2mcp/internal/appstate"
-	"dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/appstate"
+	"github.com/dirstral/dir2mcp/internal/model"
 )
 
 type fakeCorpusStore struct {

--- a/internal/cli/corpus_writer_test.go
+++ b/internal/cli/corpus_writer_test.go
@@ -13,8 +13,8 @@ import (
 	"testing"
 	"time"
 
-	"dir2mcp/internal/appstate"
-	"dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/appstate"
+	"github.com/dirstral/dir2mcp/internal/model"
 )
 
 type mutableCorpusStore struct {

--- a/internal/cli/reindex.go
+++ b/internal/cli/reindex.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/model"
 )
 
 func (a *App) runReindex(ctx context.Context, global globalOptions, args []string) int {

--- a/internal/cli/remote_commands.go
+++ b/internal/cli/remote_commands.go
@@ -16,7 +16,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"dir2mcp/internal/protocol"
+	"github.com/dirstral/dir2mcp/internal/protocol"
 )
 
 type remoteConnection struct {

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -9,7 +9,7 @@ import (
 	"sort"
 	"strings"
 
-	"dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/model"
 )
 
 func (a *App) runStatus(ctx context.Context, global globalOptions, args []string) int {

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -13,16 +13,16 @@ import (
 	"strings"
 	"time"
 
-	"dir2mcp/internal/appstate"
-	"dir2mcp/internal/config"
-	"dir2mcp/internal/elevenlabs"
-	"dir2mcp/internal/index"
-	"dir2mcp/internal/ingest"
-	"dir2mcp/internal/mcp"
-	"dir2mcp/internal/mistral"
-	"dir2mcp/internal/model"
-	"dir2mcp/internal/protocol"
-	"dir2mcp/internal/retrieval"
+	"github.com/dirstral/dir2mcp/internal/appstate"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/elevenlabs"
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/mistral"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/protocol"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
 )
 
 func (a *App) runUp(ctx context.Context, opts upOptions) int {

--- a/internal/cli/up_daemon.go
+++ b/internal/cli/up_daemon.go
@@ -10,7 +10,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/config"
 )
 
 // runUpAsDaemonParent spawns a detached child process that runs the

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	"dir2mcp/internal/mistral"
+	"github.com/dirstral/dir2mcp/internal/mistral"
 )
 
 const DefaultProtocolVersion = "2025-11-25"

--- a/internal/elevenlabs/client.go
+++ b/internal/elevenlabs/client.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"time"
 
-	"dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/model"
 )
 
 const (

--- a/internal/elevenlabsbridge/client.go
+++ b/internal/elevenlabsbridge/client.go
@@ -12,7 +12,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"dir2mcp/internal/protocol"
+	"github.com/dirstral/dir2mcp/internal/protocol"
 )
 
 const (

--- a/internal/elevenlabsbridge/server.go
+++ b/internal/elevenlabsbridge/server.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"dir2mcp/internal/protocol"
+	"github.com/dirstral/dir2mcp/internal/protocol"
 )
 
 const defaultAskK = 3

--- a/internal/index/embedding_worker.go
+++ b/internal/index/embedding_worker.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/model"
 )
 
 type ChunkSource interface {

--- a/internal/index/persistence.go
+++ b/internal/index/persistence.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/model"
 )
 
 type IndexedFile struct {

--- a/internal/ingest/represent.go
+++ b/internal/ingest/represent.go
@@ -12,7 +12,7 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/model"
 )
 
 // transcriptTimestampBracketedRe matches leading timestamps in [mm:ss] or

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -17,11 +17,11 @@ import (
 	"sync"
 	"time"
 
-	"dir2mcp/internal/appstate"
-	"dir2mcp/internal/config"
-	"dir2mcp/internal/elevenlabs"
-	"dir2mcp/internal/mistral"
-	"dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/appstate"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/elevenlabs"
+	"github.com/dirstral/dir2mcp/internal/mistral"
+	"github.com/dirstral/dir2mcp/internal/model"
 )
 
 // annotationChunk* constants mirror the hardcoded parameters previously

--- a/internal/ingest/service_flatten_test.go
+++ b/internal/ingest/service_flatten_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/config"
 )
 
 func TestFlattenJSONForIndexing_MapAndArray(t *testing.T) {

--- a/internal/mcp/list_files_resolve_test.go
+++ b/internal/mcp/list_files_resolve_test.go
@@ -5,8 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"dir2mcp/internal/config"
-	"dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/model"
 )
 
 // TestCanResolveRoot exercises the four shapes that should drive the

--- a/internal/mcp/middleware.go
+++ b/internal/mcp/middleware.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"dir2mcp/internal/protocol"
+	"github.com/dirstral/dir2mcp/internal/protocol"
 )
 
 type middleware func(http.Handler) http.Handler

--- a/internal/mcp/payment.go
+++ b/internal/mcp/payment.go
@@ -14,8 +14,8 @@ import (
 	"sync"
 	"time"
 
-	storepkg "dir2mcp/internal/store"
-	"dir2mcp/internal/x402"
+	storepkg "github.com/dirstral/dir2mcp/internal/store"
+	"github.com/dirstral/dir2mcp/internal/x402"
 )
 
 type paymentExecutionOutcome struct {

--- a/internal/mcp/payment_log_cache_test.go
+++ b/internal/mcp/payment_log_cache_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/config"
 )
 
 // badWriter implements io.Writer but always returns an error. It is used to

--- a/internal/mcp/payment_test.go
+++ b/internal/mcp/payment_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/config"
 )
 
 func TestInitPaymentConfig_ModeOnIncompleteConfigDisablesGating(t *testing.T) {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -23,13 +23,13 @@ import (
 	"sync"
 	"time"
 
-	"dir2mcp/internal/appstate"
-	"dir2mcp/internal/buildinfo"
-	"dir2mcp/internal/config"
-	"dir2mcp/internal/model"
-	"dir2mcp/internal/protocol"
-	storepkg "dir2mcp/internal/store"
-	"dir2mcp/internal/x402"
+	"github.com/dirstral/dir2mcp/internal/appstate"
+	"github.com/dirstral/dir2mcp/internal/buildinfo"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/protocol"
+	storepkg "github.com/dirstral/dir2mcp/internal/store"
+	"github.com/dirstral/dir2mcp/internal/x402"
 )
 
 const (

--- a/internal/mcp/server_internal_test.go
+++ b/internal/mcp/server_internal_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/config"
 )
 
 // The six legacy tests below described various combinations of the

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -15,10 +15,10 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"dir2mcp/internal/ingest"
-	"dir2mcp/internal/mistral"
-	"dir2mcp/internal/model"
-	"dir2mcp/internal/protocol"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/mistral"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/protocol"
 )
 
 const (

--- a/internal/mcp/transport_sdk.go
+++ b/internal/mcp/transport_sdk.go
@@ -14,8 +14,8 @@ import (
 	"strings"
 	"time"
 
-	"dir2mcp/internal/buildinfo"
-	"dir2mcp/internal/protocol"
+	"github.com/dirstral/dir2mcp/internal/buildinfo"
+	"github.com/dirstral/dir2mcp/internal/protocol"
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 

--- a/internal/mistral/client.go
+++ b/internal/mistral/client.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"time"
 
-	"dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/model"
 )
 
 const (

--- a/internal/retrieval/engine.go
+++ b/internal/retrieval/engine.go
@@ -10,11 +10,11 @@ import (
 	"sync"
 	"time"
 
-	"dir2mcp/internal/config"
-	"dir2mcp/internal/index"
-	"dir2mcp/internal/mistral"
-	"dir2mcp/internal/model"
-	"dir2mcp/internal/store"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/mistral"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
 )
 
 type engineRetriever interface {

--- a/internal/retrieval/engine_preload_test.go
+++ b/internal/retrieval/engine_preload_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/model"
 )
 
 type blockingMetadataSource struct{}

--- a/internal/retrieval/hybrid.go
+++ b/internal/retrieval/hybrid.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"sort"
 
-	"dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/model"
 )
 
 // rrfK is the reciprocal-rank-fusion smoothing constant. 60 is the value

--- a/internal/retrieval/hybrid_test.go
+++ b/internal/retrieval/hybrid_test.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"testing"
 
-	"dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/model"
 )
 
 func TestFuseRRF_DisjointLists(t *testing.T) {

--- a/internal/retrieval/large_corpus_test.go
+++ b/internal/retrieval/large_corpus_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"testing"
 
-	"dir2mcp/internal/index"
-	"dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
 )
 
 type uniformEmbedder struct {

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 	"sync"
 
-	"dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/model"
 )
 
 var (

--- a/internal/retrieval/service_test.go
+++ b/internal/retrieval/service_test.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"testing"
 
-	"dir2mcp/internal/index"
-	"dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
 )
 
 type fakeRetrievalEmbedder struct {

--- a/internal/store/sqlite_bm25.go
+++ b/internal/store/sqlite_bm25.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/model"
 )
 
 // SearchBM25 implements model.LexicalSearcher. It runs an FTS5 MATCH query

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -14,8 +14,8 @@ import (
 
 	_ "modernc.org/sqlite"
 
-	"dir2mcp/internal/mistral"
-	"dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/mistral"
+	"github.com/dirstral/dir2mcp/internal/model"
 )
 
 const relPathErrorMessage = "rel_path must be a non-empty relative path without parent-traversal or absolute paths"

--- a/tests/cli/app_public_url_test.go
+++ b/tests/cli/app_public_url_test.go
@@ -3,7 +3,7 @@ package tests
 import (
 	"testing"
 
-	"dir2mcp/internal/cli"
+	"github.com/dirstral/dir2mcp/internal/cli"
 )
 
 func TestPublicURLAddress_UsesConfiguredHostAndResolvedPort(t *testing.T) {

--- a/tests/cli/claude_command_test.go
+++ b/tests/cli/claude_command_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"dir2mcp/internal/cli"
+	"github.com/dirstral/dir2mcp/internal/cli"
 )
 
 func TestClaudePrintConfigEmitsMCPServerBlock(t *testing.T) {

--- a/tests/cli/command_behavior_test.go
+++ b/tests/cli/command_behavior_test.go
@@ -10,12 +10,12 @@ import (
 	"strings"
 	"testing"
 
-	"dir2mcp/internal/buildinfo"
-	"dir2mcp/internal/cli"
-	"dir2mcp/internal/config"
-	"dir2mcp/internal/mcp"
-	"dir2mcp/internal/model"
-	"dir2mcp/internal/store"
+	"github.com/dirstral/dir2mcp/internal/buildinfo"
+	"github.com/dirstral/dir2mcp/internal/cli"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
 )
 
 type commandTestNoopStore struct{}

--- a/tests/cli/daemon_preflight_test.go
+++ b/tests/cli/daemon_preflight_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"dir2mcp/internal/cli"
+	"github.com/dirstral/dir2mcp/internal/cli"
 )
 
 // TestDaemonParent_MissingMistralAPIKeyFailsFast is the regression test

--- a/tests/cli/down_test.go
+++ b/tests/cli/down_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"dir2mcp/internal/cli"
+	"github.com/dirstral/dir2mcp/internal/cli"
 )
 
 // TestDown_NoPidFile_IsIdempotent: dir2mcp down on a directory with no

--- a/tests/cli/remote_commands_test.go
+++ b/tests/cli/remote_commands_test.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"testing"
 
-	"dir2mcp/internal/cli"
-	"dir2mcp/internal/protocol"
+	"github.com/dirstral/dir2mcp/internal/cli"
+	"github.com/dirstral/dir2mcp/internal/protocol"
 )
 
 func TestSearchCommandUsesConnectionMetadataAndPrintsJSON(t *testing.T) {

--- a/tests/cli/up_allowed_origins_flag_test.go
+++ b/tests/cli/up_allowed_origins_flag_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"dir2mcp/internal/cli"
-	"dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/cli"
+	"github.com/dirstral/dir2mcp/internal/config"
 )
 
 func TestUpAllowedOriginsFlag_IsAcceptedByCLI(t *testing.T) {

--- a/tests/cli/up_command_test.go
+++ b/tests/cli/up_command_test.go
@@ -23,10 +23,10 @@ import (
 	"testing"
 	"time"
 
-	"dir2mcp/internal/cli"
-	"dir2mcp/internal/config"
-	"dir2mcp/internal/model"
-	"dir2mcp/internal/store"
+	"github.com/dirstral/dir2mcp/internal/cli"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
 )
 
 var cwdMu sync.Mutex

--- a/tests/cli/up_embed_model_flag_test.go
+++ b/tests/cli/up_embed_model_flag_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"dir2mcp/internal/cli"
+	"github.com/dirstral/dir2mcp/internal/cli"
 )
 
 func TestUpModelFlags_IsAcceptedByCLI(t *testing.T) {

--- a/tests/cli/version_command_test.go
+++ b/tests/cli/version_command_test.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"testing"
 
-	"dir2mcp/internal/buildinfo"
-	"dir2mcp/internal/cli"
+	"github.com/dirstral/dir2mcp/internal/buildinfo"
+	"github.com/dirstral/dir2mcp/internal/cli"
 )
 
 func TestDir2MCPVersionCommand_UsesBuildVersion(t *testing.T) {

--- a/tests/config/config_snapshot_test.go
+++ b/tests/config/config_snapshot_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/config"
 )
 
 func TestSaveEffectiveSnapshot_RedactsSecretsAndPersistsSourceMetadata(t *testing.T) {

--- a/tests/config/config_test.go
+++ b/tests/config/config_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"dir2mcp/internal/config"
-	"dir2mcp/tests/testutil"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/tests/testutil"
 )
 
 func TestLoad_UsesDotEnvWhenEnvIsMissing(t *testing.T) {

--- a/tests/config/config_yaml_test.go
+++ b/tests/config/config_yaml_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"dir2mcp/internal/config"
-	"dir2mcp/tests/testutil"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/tests/testutil"
 )
 
 func TestLoadFile_ReadsYAMLValues(t *testing.T) {

--- a/tests/config/x402_config_test.go
+++ b/tests/config/x402_config_test.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"testing"
 
-	"dir2mcp/internal/config"
-	"dir2mcp/tests/testutil"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/tests/testutil"
 )
 
 func TestLoad_EnvOverridesX402(t *testing.T) {

--- a/tests/conformance/errors_test.go
+++ b/tests/conformance/errors_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/config"
 )
 
 // TestErrors_JSONRPCErrorShape verifies that all JSON-RPC error responses

--- a/tests/conformance/helpers_test.go
+++ b/tests/conformance/helpers_test.go
@@ -18,10 +18,10 @@ import (
 	"testing"
 	"time"
 
-	"dir2mcp/internal/config"
-	"dir2mcp/internal/mcp"
-	"dir2mcp/internal/protocol"
-	"dir2mcp/internal/x402"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/protocol"
+	"github.com/dirstral/dir2mcp/internal/x402"
 )
 
 // ---------------------------------------------------------------------------

--- a/tests/conformance/lifecycle_test.go
+++ b/tests/conformance/lifecycle_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"dir2mcp/internal/config"
-	"dir2mcp/internal/protocol"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/protocol"
 )
 
 // TestLifecycle_Initialize verifies that an initialize request returns HTTP 200

--- a/tests/conformance/x402_test.go
+++ b/tests/conformance/x402_test.go
@@ -8,8 +8,8 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"dir2mcp/internal/mcp"
-	"dir2mcp/internal/x402"
+	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/x402"
 )
 
 // TestX402_ModeOff_NoPaymentHeaders verifies that when mode=off, tools/call

--- a/tests/elevenlabs/client_test.go
+++ b/tests/elevenlabs/client_test.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"testing"
 
-	"dir2mcp/internal/elevenlabs"
-	"dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/elevenlabs"
+	"github.com/dirstral/dir2mcp/internal/model"
 )
 
 type elevenLabsRoundTripFunc func(*http.Request) (*http.Response, error)

--- a/tests/elevenlabsbridge/bridge_test.go
+++ b/tests/elevenlabsbridge/bridge_test.go
@@ -13,8 +13,8 @@ import (
 	"sync"
 	"testing"
 
-	"dir2mcp/internal/elevenlabsbridge"
-	"dir2mcp/tests/testutil"
+	"github.com/dirstral/dir2mcp/internal/elevenlabsbridge"
+	"github.com/dirstral/dir2mcp/tests/testutil"
 )
 
 type recordedMCPRequest struct {

--- a/tests/index/embedding_worker_test.go
+++ b/tests/index/embedding_worker_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"dir2mcp/internal/index"
-	"dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
 )
 
 type fakeChunkSource struct {

--- a/tests/index/hnsw_index_test.go
+++ b/tests/index/hnsw_index_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/index"
 )
 
 func TestHNSWIndex_AddAndSearch(t *testing.T) {

--- a/tests/index/persistence_test.go
+++ b/tests/index/persistence_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/index"
 )
 
 type fakePersistIndex struct {

--- a/tests/ingest/archive_ingest_test.go
+++ b/tests/ingest/archive_ingest_test.go
@@ -10,9 +10,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"dir2mcp/internal/config"
-	"dir2mcp/internal/model"
-	"dir2mcp/internal/store"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
 )
 
 // buildZip returns the bytes of a zip archive containing the provided files.

--- a/tests/ingest/classify_test.go
+++ b/tests/ingest/classify_test.go
@@ -3,7 +3,7 @@ package tests
 import (
 	"testing"
 
-	"dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/ingest"
 )
 
 func TestClassifyDocType_Smoke(t *testing.T) {

--- a/tests/ingest/discover_test.go
+++ b/tests/ingest/discover_test.go
@@ -8,7 +8,7 @@ import (
 	"slices"
 	"testing"
 
-	"dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/ingest"
 )
 
 func TestDiscoverFiles_SkipsDefaultExcludedDirsSymlinksAndLargeFiles(t *testing.T) {

--- a/tests/ingest/docling_extractor_test.go
+++ b/tests/ingest/docling_extractor_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"dir2mcp/internal/config"
-	"dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/ingest"
 )
 
 func TestDoclingExtractor_Extract_UsesConfiguredCommand(t *testing.T) {

--- a/tests/ingest/helpers_test.go
+++ b/tests/ingest/helpers_test.go
@@ -4,9 +4,9 @@ import (
 	"strings"
 	"testing"
 
-	"dir2mcp/internal/config"
-	"dir2mcp/internal/ingest"
-	"dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/model"
 )
 
 func mustNewIngestService(t *testing.T, cfg config.Config, st model.Store) *ingest.Service {

--- a/tests/ingest/incremental_test.go
+++ b/tests/ingest/incremental_test.go
@@ -6,9 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"dir2mcp/internal/config"
-	"dir2mcp/internal/ingest"
-	"dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/model"
 )
 
 type fakeIncrementalStore struct {

--- a/tests/ingest/ingest_test.go
+++ b/tests/ingest/ingest_test.go
@@ -3,7 +3,7 @@ package tests
 import (
 	"testing"
 
-	"dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/ingest"
 )
 
 // Test hash computation functions

--- a/tests/ingest/ocr_test.go
+++ b/tests/ingest/ocr_test.go
@@ -11,9 +11,9 @@ import (
 	"testing"
 	"time"
 
-	"dir2mcp/internal/config"
-	"dir2mcp/internal/ingest"
-	"dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/model"
 )
 
 type fakeOCR struct {

--- a/tests/ingest/represent_test.go
+++ b/tests/ingest/represent_test.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"testing"
 
-	"dir2mcp/internal/ingest"
-	"dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/model"
 )
 
 func TestNewRepresentationGeneratorNil(t *testing.T) {

--- a/tests/ingest/service_test.go
+++ b/tests/ingest/service_test.go
@@ -15,11 +15,11 @@ import (
 	"testing"
 	"time"
 
-	"dir2mcp/internal/appstate"
-	"dir2mcp/internal/config"
-	"dir2mcp/internal/elevenlabs"
-	"dir2mcp/internal/ingest"
-	"dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/appstate"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/elevenlabs"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/model"
 )
 
 func TestServiceRun_ProcessesFilesAndMarksMissingDeleted(t *testing.T) {

--- a/tests/ingest/transcribe_test.go
+++ b/tests/ingest/transcribe_test.go
@@ -8,10 +8,10 @@ import (
 	"testing"
 	"time"
 
-	"dir2mcp/internal/config"
-	"dir2mcp/internal/ingest"
-	"dir2mcp/internal/model"
-	"dir2mcp/internal/retrieval"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
 )
 
 type fakeTranscriber struct {

--- a/tests/mcp/cors_public_test.go
+++ b/tests/mcp/cors_public_test.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 	"testing"
 
-	"dir2mcp/internal/cli"
-	"dir2mcp/internal/config"
-	"dir2mcp/internal/mcp"
-	"dir2mcp/internal/protocol"
+	"github.com/dirstral/dir2mcp/internal/cli"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/protocol"
 )
 
 // TestCORS_PreflightReturns204 verifies allowed-origin preflight requests return 204 with CORS headers.

--- a/tests/mcp/origin_allowlist_test.go
+++ b/tests/mcp/origin_allowlist_test.go
@@ -7,9 +7,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"dir2mcp/internal/config"
-	"dir2mcp/internal/mcp"
-	"dir2mcp/tests/testutil"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/tests/testutil"
 )
 
 func TestOriginAllowlist_NoOriginHeaderPasses(t *testing.T) {

--- a/tests/mcp/rate_limit_test.go
+++ b/tests/mcp/rate_limit_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"dir2mcp/internal/config"
-	"dir2mcp/internal/mcp"
-	"dir2mcp/internal/protocol"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/protocol"
 )
 
 func TestRateLimit_NotActiveWhenServerIsNotPublic(t *testing.T) {

--- a/tests/mcp/server_test.go
+++ b/tests/mcp/server_test.go
@@ -11,11 +11,11 @@ import (
 	"testing"
 	"time"
 
-	"dir2mcp/internal/buildinfo"
-	"dir2mcp/internal/config"
-	"dir2mcp/internal/mcp"
-	"dir2mcp/internal/protocol"
-	"dir2mcp/internal/store"
+	"github.com/dirstral/dir2mcp/internal/buildinfo"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/protocol"
+	"github.com/dirstral/dir2mcp/internal/store"
 )
 
 func postToolsListWithSession(serverURL, mcpPath, sessionID string) (*http.Response, error) {

--- a/tests/mcp/tools_test.go
+++ b/tests/mcp/tools_test.go
@@ -16,11 +16,11 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"dir2mcp/internal/config"
-	"dir2mcp/internal/mcp"
-	"dir2mcp/internal/model"
-	"dir2mcp/internal/protocol"
-	"dir2mcp/internal/store"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/protocol"
+	"github.com/dirstral/dir2mcp/internal/store"
 )
 
 // TestMCPToolsList_RegistersDayOneToolsWithSchemas verifies that tools/list

--- a/tests/mcp/transport_test.go
+++ b/tests/mcp/transport_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"dir2mcp/internal/config"
-	"dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/mcp"
 )
 
 func TestNewTransport_IsSDK(t *testing.T) {

--- a/tests/mcp/x402_test.go
+++ b/tests/mcp/x402_test.go
@@ -13,11 +13,11 @@ import (
 	"testing"
 	"time"
 
-	"dir2mcp/internal/config"
-	"dir2mcp/internal/mcp"
-	"dir2mcp/internal/model"
-	"dir2mcp/internal/protocol"
-	"dir2mcp/internal/store"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/protocol"
+	"github.com/dirstral/dir2mcp/internal/store"
 )
 
 func TestX402ToolsCall_UnpaidReturns402WithPaymentRequiredHeader(t *testing.T) {

--- a/tests/mistral/client_embed_test.go
+++ b/tests/mistral/client_embed_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"dir2mcp/internal/mistral"
-	"dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/mistral"
+	"github.com/dirstral/dir2mcp/internal/model"
 )
 
 type embedTestRequest struct {

--- a/tests/mistral/client_generate_test.go
+++ b/tests/mistral/client_generate_test.go
@@ -12,8 +12,8 @@ import (
 	"testing"
 	"time"
 
-	"dir2mcp/internal/mistral"
-	"dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/mistral"
+	"github.com/dirstral/dir2mcp/internal/model"
 )
 
 func TestGenerate_SuccessStringContent(t *testing.T) {

--- a/tests/mistral/client_integration_test.go
+++ b/tests/mistral/client_integration_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"dir2mcp/internal/mistral"
+	"github.com/dirstral/dir2mcp/internal/mistral"
 )
 
 func TestEmbed_Integration_MistralAPI(t *testing.T) {

--- a/tests/mistral/client_runtime_integration_test.go
+++ b/tests/mistral/client_runtime_integration_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"dir2mcp/internal/mistral"
+	"github.com/dirstral/dir2mcp/internal/mistral"
 )
 
 func TestTranscribe_Integration_MistralAPI(t *testing.T) {

--- a/tests/mistral/client_test.go
+++ b/tests/mistral/client_test.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"testing"
 
-	"dir2mcp/internal/mistral"
-	"dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/mistral"
+	"github.com/dirstral/dir2mcp/internal/model"
 )
 
 type roundTripFunc func(*http.Request) (*http.Response, error)

--- a/tests/mistral/client_transcribe_test.go
+++ b/tests/mistral/client_transcribe_test.go
@@ -12,8 +12,8 @@ import (
 	"testing"
 	"time"
 
-	"dir2mcp/internal/mistral"
-	"dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/mistral"
+	"github.com/dirstral/dir2mcp/internal/model"
 )
 
 func TestTranscribe_FormatsSegments(t *testing.T) {

--- a/tests/mistral/ocr_integration_test.go
+++ b/tests/mistral/ocr_integration_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"dir2mcp/internal/mistral"
+	"github.com/dirstral/dir2mcp/internal/mistral"
 )
 
 func TestExtract_Integration_MistralOCR(t *testing.T) {

--- a/tests/retrieval/engine_test.go
+++ b/tests/retrieval/engine_test.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 	"testing"
 
-	"dir2mcp/internal/config"
-	"dir2mcp/internal/model"
-	"dir2mcp/internal/retrieval"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
 )
 
 func TestEngineAsk_WithEmptyIndexReturnsFallback(t *testing.T) {

--- a/tests/retrieval/open_file_exclusion_test.go
+++ b/tests/retrieval/open_file_exclusion_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"testing"
 
-	"dir2mcp/internal/model"
-	"dir2mcp/internal/retrieval"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
 )
 
 func TestOpenFile_SecretsBlocked(t *testing.T) {

--- a/tests/retrieval/open_file_pdf_default_test.go
+++ b/tests/retrieval/open_file_pdf_default_test.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"testing"
 
-	"dir2mcp/internal/model"
-	"dir2mcp/internal/retrieval"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
 )
 
 // writePDFAndOCRCache writes a fake PDF at relPath under root and seeds the

--- a/tests/retrieval/service_test.go
+++ b/tests/retrieval/service_test.go
@@ -13,9 +13,9 @@ import (
 	"sync"
 	"testing"
 
-	"dir2mcp/internal/index"
-	"dir2mcp/internal/model"
-	"dir2mcp/internal/retrieval"
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
 )
 
 type fakeRetrievalEmbedder struct {

--- a/tests/store/document_title_roundtrip_test.go
+++ b/tests/store/document_title_roundtrip_test.go
@@ -5,8 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"dir2mcp/internal/model"
-	"dir2mcp/internal/store"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
 )
 
 // TestSQLiteStore_DocumentTitleRoundtrip verifies that the title column

--- a/tests/store/list_files_deleted_test.go
+++ b/tests/store/list_files_deleted_test.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"dir2mcp/internal/model"
-	"dir2mcp/internal/store"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
 )
 
 // TestListFiles_ExcludesDeletedDocuments verifies that soft-deleted documents

--- a/tests/store/sqlite_bm25_test.go
+++ b/tests/store/sqlite_bm25_test.go
@@ -5,8 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"dir2mcp/internal/model"
-	"dir2mcp/internal/store"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
 )
 
 // TestSQLiteStore_SearchBM25_BasicAndBackfill verifies the FTS5-backed BM25

--- a/tests/store/sqlite_concurrent_writers_test.go
+++ b/tests/store/sqlite_concurrent_writers_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"dir2mcp/internal/model"
-	"dir2mcp/internal/store"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
 )
 
 // TestSQLiteStore_ConcurrentWritersNoBusy guards against the SQLITE_BUSY

--- a/tests/store/sqlite_store_test.go
+++ b/tests/store/sqlite_store_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 	"time"
 
-	"dir2mcp/internal/model"
-	"dir2mcp/internal/store"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
 )
 
 func TestSQLiteStore_PendingChunkLifecycle(t *testing.T) {

--- a/tests/up_command_test.go
+++ b/tests/up_command_test.go
@@ -17,11 +17,11 @@ import (
 	"testing"
 	"time"
 
-	"dir2mcp/internal/cli"
-	"dir2mcp/internal/config"
-	"dir2mcp/internal/model"
-	"dir2mcp/internal/protocol"
-	"dir2mcp/internal/store"
+	"github.com/dirstral/dir2mcp/internal/cli"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/protocol"
+	"github.com/dirstral/dir2mcp/internal/store"
 )
 
 var cwdMu sync.Mutex

--- a/tests/x402/facilitator_factory_test.go
+++ b/tests/x402/facilitator_factory_test.go
@@ -8,7 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"dir2mcp/internal/x402"
+	"github.com/dirstral/dir2mcp/internal/x402"
 )
 
 func validRequirement() x402.Requirement {

--- a/tests/x402/parity_test.go
+++ b/tests/x402/parity_test.go
@@ -20,10 +20,10 @@ import (
 	"testing"
 	"time"
 
-	"dir2mcp/internal/config"
-	"dir2mcp/internal/mcp"
-	"dir2mcp/internal/protocol"
-	"dir2mcp/internal/x402"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/protocol"
+	"github.com/dirstral/dir2mcp/internal/x402"
 )
 
 // ---------------------------------------------------------------------------

--- a/tests/x402/requirement_test.go
+++ b/tests/x402/requirement_test.go
@@ -3,7 +3,7 @@ package x402_test
 import (
 	"testing"
 
-	"dir2mcp/internal/x402"
+	"github.com/dirstral/dir2mcp/internal/x402"
 )
 
 func TestRequirementNormalize(t *testing.T) {


### PR DESCRIPTION
## Summary

Renames the Go module from the bare `dir2mcp` to the canonical `github.com/dirstral/dir2mcp`, and sweeps the 230 internal import statements + two ldflag references that hard-code the package path.

## Why

goreportcard.com fetches modules via `proxy.golang.org/$MODULE/@latest`. The bare `dir2mcp` is unresolvable through the proxy, so `Refresh now` fails with:

> Could not analyze the repository: could not download repo: could not get latest module version from https://proxy.golang.org/dir2mcp/@latest

The visible score (A+ from 2 months ago) is a stale snapshot from before the proxy stopped working. After this lands, the badge refresh works, and the score reflects the post-#182 state (gocyclo 100%).

The same change also unblocks any external Go consumer that wanted to import a package from this repo.

## Scope

Pure mechanical rename — no code semantics change.

| Surface | Before | After |
|---|---|---|
| `go.mod` | `module dir2mcp` | `module github.com/dirstral/dir2mcp` |
| All `*.go` imports | `"dir2mcp/internal/..."` | `"github.com/dirstral/dir2mcp/internal/..."` |
| Makefile `DIR2MCP_LDFLAGS` | `-X dir2mcp/internal/buildinfo.Version=...` | `-X github.com/dirstral/dir2mcp/internal/buildinfo.Version=...` |
| `.goreleaser.yaml` ldflags | same as above | same as above |

105 files touched, 230 insertions / 230 deletions (clean swap).

## Test plan

- [x] `go build ./...` clean
- [x] `make ci` passes (vet, broader cyclo from #182, ineffassign, misspell, full Go test suite, python tests)
- [x] CI green
- [ ] After merge: refresh goreportcard.com/report/github.com/Dirstral/dir2mcp and confirm the analysis succeeds with 100% across all sub-checks

## Notes

- This is the right time for this change — releases are tag-driven via GoReleaser, so existing `v0.5.x` tags continue to work; the next tag will publish the new module path. No `replace` directives needed.
- No external consumers exist (we're not a published library).
- The 4 files with pre-existing gofmt drift on origin/main are not touched here (still scope-clean).
