### PR TITLE
feat(server): dev builds get a dir2mcp-dev- name prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,8 @@ dir2mcp up --mistral-max-ocr-payload-bytes 26214400
 Each `dir2mcp up` instance reports a unique MCP server name derived from the indexed directory, so running multiple corpora side-by-side (e.g., `dir2mcp-stas-legal-a1b2c3` and `dir2mcp-research-notes-9f44ee`) keeps them distinguishable in your MCP client list.
 
 - Default shape: `dir2mcp-<slug>-<6-hex>`, where `<slug>` is the slugified basename of the indexed directory and `<6-hex>` hashes its absolute path (so the name is stable across re-runs from the same location).
-- Override via YAML (`server.name: my-alias`) or env (`DIR2MCP_SERVER_NAME=my-alias`).
+- Developer builds (binaries built locally without a release tag — `dir2mcp version` reports `0.0.0-dev` or `dev-<sha>`) use a `dir2mcp-dev-<slug>-<6-hex>` prefix instead, so a dev build run from your repo shows up as a distinct entry alongside the brew-installed release in `claude mcp list`.
+- Override via YAML (`server.name: my-alias`) or env (`DIR2MCP_SERVER_NAME=my-alias`). Overrides apply verbatim and are not affected by the dev-prefix logic.
 - The `dir2mcp up` banner prints a ready-to-paste `claude mcp add --transport http <name> <url> ...` line using this name; the client-side alias you register with is yours to choose.
 
 ### Auth token behavior

--- a/README.md
+++ b/README.md
@@ -231,8 +231,8 @@ dir2mcp up --mistral-max-ocr-payload-bytes 26214400
 Each `dir2mcp up` instance reports a unique MCP server name derived from the indexed directory, so running multiple corpora side-by-side (e.g., `dir2mcp-stas-legal-a1b2c3` and `dir2mcp-research-notes-9f44ee`) keeps them distinguishable in your MCP client list.
 
 - Default shape: `dir2mcp-<slug>-<6-hex>`, where `<slug>` is the slugified basename of the indexed directory and `<6-hex>` hashes its absolute path (so the name is stable across re-runs from the same location).
-- Developer builds (binaries built locally without a release tag — `dir2mcp version` reports `0.0.0-dev` or `dev-<sha>`) use a `dir2mcp-dev-<slug>-<6-hex>` prefix instead, so a dev build run from your repo shows up as a distinct entry alongside the brew-installed release in `claude mcp list`.
-- Override via YAML (`server.name: my-alias`) or env (`DIR2MCP_SERVER_NAME=my-alias`). Overrides apply verbatim and are not affected by the dev-prefix logic.
+- Developer builds (binaries built locally without a release tag — `dir2mcp version` reports `v0.0.0-dev` or `vdev-<sha>`, optionally with `+dirty`) use a `dir2mcp-dev-<slug>-<6-hex>` prefix instead, so a dev build run from your repo shows up as a distinct entry alongside the brew-installed release in `claude mcp list`.
+- Override via YAML (`server.name: my-alias`) or env (`DIR2MCP_SERVER_NAME=my-alias`). Overrides apply verbatim and bypass the default generated name, including the `dir2mcp-dev-...` prefix used by dev builds.
 - The `dir2mcp up` banner prints a ready-to-paste `claude mcp add --transport http <name> <url> ...` line using this name; the client-side alias you register with is yours to choose.
 
 ### Auth token behavior

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -837,12 +837,14 @@ HTTP response headers include:
 `serverInfo.name` is per-instance: by default it is auto-derived as
 `dir2mcp-<slug>-<6-hex>` from the absolute path of the indexed directory
 so that operators running many `dir2mcp` instances can distinguish them
-in their MCP client list. Developer builds (no release ldflags
-injection) use a `dir2mcp-dev-<slug>-<6-hex>` prefix so a locally
-built binary coexists with brew-installed releases without identity
-collision. It can be overridden via the `server.name` YAML key or the
-`DIR2MCP_SERVER_NAME` env variable; overrides apply verbatim regardless
-of build type.
+in their MCP client list. Builds whose embedded version is recognized
+as a dev version (specifically `0.0.0-dev` or `dev-<sha>[+dirty]`) use
+a `dir2mcp-dev-<slug>-<6-hex>` prefix so local dev binaries can coexist
+with brew-installed releases without identity collision. Other non-release
+builds, including `go install` snapshots or pseudo-versions, still use
+the normal `dir2mcp-<slug>-<6-hex>` prefix. It can be overridden via the
+`server.name` YAML key or the `DIR2MCP_SERVER_NAME` env variable;
+overrides apply verbatim regardless of build type.
 
 Body:
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -837,8 +837,12 @@ HTTP response headers include:
 `serverInfo.name` is per-instance: by default it is auto-derived as
 `dir2mcp-<slug>-<6-hex>` from the absolute path of the indexed directory
 so that operators running many `dir2mcp` instances can distinguish them
-in their MCP client list. It can be overridden via the `server.name`
-YAML key or the `DIR2MCP_SERVER_NAME` env variable.
+in their MCP client list. Developer builds (no release ldflags
+injection) use a `dir2mcp-dev-<slug>-<6-hex>` prefix so a locally
+built binary coexists with brew-installed releases without identity
+collision. It can be overridden via the `server.name` YAML key or the
+`DIR2MCP_SERVER_NAME` env variable; overrides apply verbatim regardless
+of build type.
 
 Body:
 

--- a/internal/buildinfo/version.go
+++ b/internal/buildinfo/version.go
@@ -51,11 +51,12 @@ func Display() string {
 }
 
 // IsDev reports whether the running binary is a developer build —
-// either the bare "0.0.0-dev" placeholder (no link-time injection,
-// no debug info) or a "dev-<sha>" / "dev-<sha>+dirty" string produced
-// by resolveVersion's vcs.revision fallback. Released binaries (built
-// by GoReleaser with -ldflags injection) and `go install` snapshots
-// from a tagged or pseudo-version ref report false.
+// either the bare "0.0.0-dev" placeholder (meaning no injected,
+// module-derived, or vcs.revision-derived version was resolved) or a
+// "dev-<sha>" / "dev-<sha>+dirty" string produced by resolveVersion's
+// vcs.revision fallback. Released binaries (built by GoReleaser with
+// -ldflags injection) and `go install` snapshots from a tagged or
+// pseudo-version ref report false.
 //
 // Used by callers that want to make dev builds visibly distinct from
 // the brew-installed release at runtime — e.g., the auto-derived MCP

--- a/internal/buildinfo/version.go
+++ b/internal/buildinfo/version.go
@@ -50,6 +50,29 @@ func Display() string {
 	return "v" + strings.TrimPrefix(String(), "v")
 }
 
+// IsDev reports whether the running binary is a developer build —
+// either the bare "0.0.0-dev" placeholder (no link-time injection,
+// no debug info) or a "dev-<sha>" / "dev-<sha>+dirty" string produced
+// by resolveVersion's vcs.revision fallback. Released binaries (built
+// by GoReleaser with -ldflags injection) and `go install` snapshots
+// from a tagged or pseudo-version ref report false.
+//
+// Used by callers that want to make dev builds visibly distinct from
+// the brew-installed release at runtime — e.g., the auto-derived MCP
+// server name uses a "dir2mcp-dev-" prefix when this returns true so
+// dev and release instances coexist in `claude mcp list` without
+// colliding.
+func IsDev() bool {
+	return isDevVersion(String())
+}
+
+// isDevVersion is the testable core of IsDev — it operates on a
+// pre-resolved version string so tests can exercise every branch
+// without going through the package-level sync.Once.
+func isDevVersion(v string) bool {
+	return v == defaultVersion || strings.HasPrefix(v, "dev-")
+}
+
 // resolveVersion is split out from String for testability — it takes the
 // inputs explicitly so tests can drive every branch without wrestling with
 // the package-level sync.Once or the real ReadBuildInfo result.

--- a/internal/buildinfo/version_test.go
+++ b/internal/buildinfo/version_test.go
@@ -117,6 +117,24 @@ func TestDisplay_AlwaysHasSingleVPrefix(t *testing.T) {
 	}
 }
 
+func TestIsDevVersion(t *testing.T) {
+	cases := map[string]bool{
+		defaultVersion:           true,
+		"dev-0123456":            true,
+		"dev-0123456+dirty":      true,
+		"0.5.3":                  false,
+		"v0.5.3":                 false,
+		"v0.0.0-20260508-abc123": false, // pseudo-version from `go install`
+		"":                       false,
+		"development":            false, // similar prefix but not "dev-"
+	}
+	for in, want := range cases {
+		if got := isDevVersion(in); got != want {
+			t.Errorf("isDevVersion(%q): got %v want %v", in, got, want)
+		}
+	}
+}
+
 func TestIsHex(t *testing.T) {
 	cases := map[string]bool{
 		"":                       false,

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/dirstral/dir2mcp/internal/appstate"
+	"github.com/dirstral/dir2mcp/internal/buildinfo"
 	"github.com/dirstral/dir2mcp/internal/config"
 	"github.com/dirstral/dir2mcp/internal/elevenlabs"
 	"github.com/dirstral/dir2mcp/internal/identity"
@@ -230,12 +231,17 @@ func applyScalarOverrides(cfg *config.Config, opts upOptions) {
 // server, banner) can read a non-empty value without re-deriving the
 // auto-name. The override (if any) wins; otherwise we hash the absolute
 // RootDir so the name is stable across cwd changes and reinstalls.
+//
+// Dev builds use a `dir2mcp-dev-` prefix so a developer running their
+// in-tree binary alongside the brew-installed release sees two visibly
+// distinct entries in `claude mcp list` instead of colliding on the
+// same auto-derived name.
 func resolveServerName(cfg *config.Config) {
 	abs, err := filepath.Abs(cfg.RootDir)
 	if err != nil {
 		abs = cfg.RootDir
 	}
-	cfg.ServerName = identity.Resolve(abs, cfg.ServerName)
+	cfg.ServerName = identity.Resolve(abs, cfg.ServerName, buildinfo.IsDev())
 }
 
 // applyX402Overrides applies x402-specific flag overrides to cfg.

--- a/internal/identity/name.go
+++ b/internal/identity/name.go
@@ -23,38 +23,51 @@ const (
 	// 1-in-16M collision pressure per pair, which is more than enough
 	// for hand-managed MCP server lists.
 	hashLen = 6
-	// prefix is the project-wide name prefix. Kept here (not in the
-	// caller) so the suffix logic can guarantee a known, parseable shape.
-	prefix = "dir2mcp"
+	// releasePrefix is the project-wide name prefix used by released
+	// (GoReleaser-built) binaries.
+	releasePrefix = "dir2mcp"
+	// devPrefix is used by source/dev builds so a developer running
+	// their in-tree binary alongside the brew-installed release sees
+	// two visibly distinct entries in `claude mcp list` instead of
+	// colliding on the same auto-derived name.
+	devPrefix = "dir2mcp-dev"
 )
 
 // Resolve returns override (after whitespace trim) when non-empty,
-// otherwise the auto-derived name for rootAbs. Callers that thread a
-// config value should prefer this over AutoServerName so the override
-// path is the same everywhere.
-func Resolve(rootAbs, override string) string {
+// otherwise the auto-derived name for rootAbs. The dev flag selects
+// the project prefix (release vs dev) for the auto-derivation path; an
+// explicit override is always used verbatim regardless of build type.
+// Callers that thread a config value should prefer this over
+// AutoServerName so the override semantics stay in one place.
+func Resolve(rootAbs, override string, dev bool) string {
 	if t := strings.TrimSpace(override); t != "" {
 		return t
 	}
-	return AutoServerName(rootAbs)
+	return AutoServerName(rootAbs, dev)
 }
 
 // AutoServerName returns a stable, terminal-friendly identifier for a
 // dir2mcp instance keyed off the absolute path of the indexed directory.
 //
-// Shape: `dir2mcp-<slug>-<6-hex>` where <slug> is the lowercased,
-// dash-normalized basename of rootAbs (capped at slugMaxLen) and <6-hex>
-// is the first hashLen hex chars of sha256(rootAbs).
+// Shape: `<prefix>-<slug>-<6-hex>` where <prefix> is `dir2mcp` for
+// released binaries and `dir2mcp-dev` for developer builds (see
+// buildinfo.IsDev), <slug> is the lowercased dash-normalized basename
+// of rootAbs (capped at slugMaxLen), and <6-hex> is the first hashLen
+// hex chars of sha256(rootAbs).
 //
 // rootAbs is expected to already be absolute (callers should run it
 // through filepath.Abs); if it is not absolute, the hash is computed
 // over whatever was passed and identity is therefore only as stable as
 // the caller's normalization.
-func AutoServerName(rootAbs string) string {
+func AutoServerName(rootAbs string, dev bool) string {
 	clean := filepath.Clean(rootAbs)
 	slug := slugify(filepath.Base(clean))
 	sum := sha256.Sum256([]byte(clean))
-	return prefix + "-" + slug + "-" + hex.EncodeToString(sum[:])[:hashLen]
+	p := releasePrefix
+	if dev {
+		p = devPrefix
+	}
+	return p + "-" + slug + "-" + hex.EncodeToString(sum[:])[:hashLen]
 }
 
 // slugify lowercases s, replaces every non-[a-z0-9] rune with a single

--- a/internal/identity/name_test.go
+++ b/internal/identity/name_test.go
@@ -23,8 +23,8 @@ func TestAutoServerName(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := AutoServerName(tc.rootAbs)
-			wantPrefix := "dir2mcp-" + tc.wantSlug + "-"
+			got := AutoServerName(tc.rootAbs, false)
+			wantPrefix := releasePrefix + "-" + tc.wantSlug + "-"
 			if !strings.HasPrefix(got, wantPrefix) {
 				t.Fatalf("AutoServerName(%q) = %q, want prefix %q", tc.rootAbs, got, wantPrefix)
 			}
@@ -41,22 +41,47 @@ func TestAutoServerName(t *testing.T) {
 	}
 }
 
+func TestAutoServerNameDevPrefix(t *testing.T) {
+	const path = "/home/user/Stas Legal"
+	release := AutoServerName(path, false)
+	dev := AutoServerName(path, true)
+
+	if !strings.HasPrefix(release, releasePrefix+"-") {
+		t.Fatalf("release name %q lacks release prefix %q", release, releasePrefix)
+	}
+	if !strings.HasPrefix(dev, devPrefix+"-") {
+		t.Fatalf("dev name %q lacks dev prefix %q", dev, devPrefix)
+	}
+	if release == dev {
+		t.Fatalf("release and dev names should differ for the same path; got %q for both", release)
+	}
+	// Slug + hash suffix should be identical between release and dev —
+	// the only difference is the prefix segment.
+	releaseTail := strings.TrimPrefix(release, releasePrefix+"-")
+	devTail := strings.TrimPrefix(dev, devPrefix+"-")
+	if releaseTail != devTail {
+		t.Fatalf("dev and release should share slug+hash tail; got release=%q dev=%q", releaseTail, devTail)
+	}
+}
+
 func TestAutoServerNameDeterministic(t *testing.T) {
-	a := AutoServerName("/home/user/Stas Legal")
-	b := AutoServerName("/home/user/Stas Legal")
-	if a != b {
-		t.Fatalf("AutoServerName not deterministic: %q vs %q", a, b)
+	for _, dev := range []bool{false, true} {
+		a := AutoServerName("/home/user/Stas Legal", dev)
+		b := AutoServerName("/home/user/Stas Legal", dev)
+		if a != b {
+			t.Fatalf("AutoServerName not deterministic for dev=%v: %q vs %q", dev, a, b)
+		}
 	}
 }
 
 func TestAutoServerNameDistinctPathsDistinctNames(t *testing.T) {
-	a := AutoServerName("/home/user/Notes")
-	b := AutoServerName("/home/user/notes")
+	a := AutoServerName("/home/user/Notes", false)
+	b := AutoServerName("/home/user/notes", false)
 	if a == b {
 		t.Fatalf("AutoServerName should differ for case-distinct paths, got %q for both", a)
 	}
-	c := AutoServerName("/home/userA/notes")
-	d := AutoServerName("/home/userB/notes")
+	c := AutoServerName("/home/userA/notes", false)
+	d := AutoServerName("/home/userB/notes", false)
 	if c == d {
 		t.Fatalf("AutoServerName should differ for distinct parent dirs, got %q for both", c)
 	}
@@ -67,25 +92,28 @@ func TestResolve(t *testing.T) {
 		name     string
 		rootAbs  string
 		override string
+		dev      bool
 		want     string
 	}{
-		{"override wins", "/home/user/notes", "myalias", "myalias"},
-		{"override trimmed", "/home/user/notes", "  alias  ", "alias"},
-		{"empty override falls through", "/home/user/notes", "", AutoServerName("/home/user/notes")},
-		{"whitespace-only override falls through", "/home/user/notes", "   ", AutoServerName("/home/user/notes")},
+		{"override wins (release)", "/home/user/notes", "myalias", false, "myalias"},
+		{"override wins (dev)", "/home/user/notes", "myalias", true, "myalias"},
+		{"override trimmed", "/home/user/notes", "  alias  ", false, "alias"},
+		{"empty override falls through (release)", "/home/user/notes", "", false, AutoServerName("/home/user/notes", false)},
+		{"empty override falls through (dev)", "/home/user/notes", "", true, AutoServerName("/home/user/notes", true)},
+		{"whitespace-only override falls through", "/home/user/notes", "   ", false, AutoServerName("/home/user/notes", false)},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := Resolve(tc.rootAbs, tc.override); got != tc.want {
-				t.Fatalf("Resolve(%q, %q) = %q, want %q", tc.rootAbs, tc.override, got, tc.want)
+			if got := Resolve(tc.rootAbs, tc.override, tc.dev); got != tc.want {
+				t.Fatalf("Resolve(%q, %q, dev=%v) = %q, want %q", tc.rootAbs, tc.override, tc.dev, got, tc.want)
 			}
 		})
 	}
 }
 
 func TestAutoServerNameTrailingSlashEqualsClean(t *testing.T) {
-	a := AutoServerName("/var/lib/foo")
-	b := AutoServerName("/var/lib/foo/")
+	a := AutoServerName("/var/lib/foo", false)
+	b := AutoServerName("/var/lib/foo/", false)
 	if a != b {
 		t.Fatalf("AutoServerName should normalize trailing slash; got %q vs %q", a, b)
 	}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -211,7 +211,7 @@ func NewServer(cfg config.Config, retriever model.Retriever, opts ...ServerOptio
 		if absErr != nil {
 			abs = cfg.RootDir
 		}
-		cfg.ServerName = identity.AutoServerName(abs)
+		cfg.ServerName = identity.AutoServerName(abs, buildinfo.IsDev())
 	}
 	s := &Server{
 		cfg:             cfg,

--- a/tests/cli/up_command_test.go
+++ b/tests/cli/up_command_test.go
@@ -198,7 +198,9 @@ func TestUpBannerPrintsRegistrationHintWithUniqueName(t *testing.T) {
 	if err != nil {
 		t.Fatalf("evalsymlinks tmp: %v", err)
 	}
-	want := identity.AutoServerName(resolvedTmp)
+	// `go test`-built binaries are dev builds (no GoReleaser ldflags),
+	// so identity.AutoServerName uses the dir2mcp-dev- prefix here.
+	want := identity.AutoServerName(resolvedTmp, true)
 	if !strings.Contains(out, want) {
 		t.Fatalf("banner registration hint missing %q.\nstdout=%s", want, out)
 	}

--- a/tests/mcp/server_test.go
+++ b/tests/mcp/server_test.go
@@ -302,11 +302,15 @@ func TestMCPInitialize_ServerNameAutoDerivedWhenEmpty(t *testing.T) {
 	cfg.ServerName = ""
 
 	got := initializeServerInfoName(t, cfg)
-	if !strings.HasPrefix(got, "dir2mcp-") {
-		t.Fatalf("serverInfo.name=%q want auto-derived dir2mcp-* prefix", got)
+	// `go test` binaries have no GoReleaser ldflags injection, so they
+	// are dev builds and the auto-derived name must use the dir2mcp-dev-
+	// prefix to coexist with brew-installed release binaries in
+	// `claude mcp list`.
+	if !strings.HasPrefix(got, "dir2mcp-dev-") {
+		t.Fatalf("serverInfo.name=%q want dev-build prefix dir2mcp-dev-*", got)
 	}
 	parts := strings.Split(got, "-")
-	if len(parts) < 3 {
+	if len(parts) < 4 {
 		t.Fatalf("serverInfo.name=%q lacks slug+hash segments", got)
 	}
 	suffix := parts[len(parts)-1]


### PR DESCRIPTION
## Summary

Developer builds now auto-derive their MCP server name as `dir2mcp-dev-<slug>-<6-hex>` instead of `dir2mcp-<slug>-<6-hex>`. A contributor running an in-tree binary alongside the brew-installed release against the same corpus will see two visibly distinct entries in `claude mcp list` instead of colliding on the same identity.

```
brew (release):  dir2mcp-stas-legal-a1b2c3
in-tree (dev):   dir2mcp-dev-stas-legal-a1b2c3
```

## Why

Per the user's DX request: working on `dir2mcp` while also having brew's `dir2mcp` installed creates ambiguity in the MCP client list — you can't tell which version is currently answering tool calls. Path/binary management (direnv, brew unlink, suffixed binaries) is personal taste and not ours to dictate, but giving each build a self-evident identity in the client list is a small, focused fix.

## How it works

- New `buildinfo.IsDev()` returns true for the `0.0.0-dev` placeholder and `dev-<sha>` / `dev-<sha>+dirty` strings produced by the existing vcs.revision fallback. Released binaries (GoReleaser ldflags injection) and `go install` snapshots from a tagged or pseudo-version ref report false.
- `identity.AutoServerName(rootAbs string, dev bool)` and `identity.Resolve(rootAbs, override string, dev bool)` take an explicit `dev` flag so the identity package stays pure (no buildinfo dep).
- Call sites at `internal/cli/up.go:resolveServerName` and `internal/mcp/server.go:NewServer` (defensive default) pass `buildinfo.IsDev()` through.
- Explicit overrides (`server.name` YAML / `DIR2MCP_SERVER_NAME` env) apply verbatim regardless of build type — the dev prefix is auto-derivation only.

## Files

- `internal/buildinfo/version.go` — new `IsDev()` plus pure `isDevVersion(v)` helper for testability.
- `internal/buildinfo/version_test.go` — table-driven test covering placeholder, dev sentinel, dirty marker, released, pseudo-version, and `development` (false-prefix-match) cases.
- `internal/identity/name.go` — added `dev bool` parameter to `AutoServerName` and `Resolve`; selects between `dir2mcp` and `dir2mcp-dev` prefix.
- `internal/identity/name_test.go` — updated all call sites; added `TestAutoServerNameDevPrefix` asserting same slug+hash tail across release/dev builds, only the prefix differs.
- `internal/cli/up.go` — `resolveServerName` now passes `buildinfo.IsDev()` to `identity.Resolve`.
- `internal/mcp/server.go` — defensive default in `NewServer` does the same.
- `tests/mcp/server_test.go` — `TestMCPInitialize_ServerNameAutoDerivedWhenEmpty` tightened to require `dir2mcp-dev-` prefix (since `go test` binaries are dev builds).
- `tests/cli/up_command_test.go` — banner integration test computes expected name with `dev=true`.
- `README.md` + `docs/SPEC.md` — server-identity sections documented.

## Test plan

- [x] `go test ./internal/buildinfo/...` (new `IsDev` cases pass)
- [x] `go test ./internal/identity/...` (release vs dev prefix; same slug+hash tail; override still wins)
- [x] `go test ./tests/mcp/... -run TestMCPInitialize_ServerName` (auto-derive returns `dir2mcp-dev-...` under `go test`)
- [x] `go test ./tests/cli/... -run TestUpBannerPrintsRegistrationHintWithUniqueName` (banner matches `identity.AutoServerName(absTmp, true)`)
- [x] `make check` passes locally
- [ ] Manual smoke: build with `go build -o dir2mcp-dev ./cmd/dir2mcp`, run alongside brew binary against same corpus, confirm two distinct entries appear in `claude mcp list` after `claude mcp add` for each

## Notes

- Pseudo-versions from `go install ...@main` (e.g. `v0.0.0-20260514120000-abcdef123456`) are classified as released, not dev. They're a stable git ref the user explicitly chose, not a local edit-cycle build. If you want them treated as dev, easy follow-up: extend `isDevVersion` to cover the `v0.0.0-` prefix.
- Backwards-compat warning: anyone who already registered a dev build under the old `dir2mcp-...` auto-name will need to re-register after this lands — but per the prior PR's "no users yet" framing, this is expected and acceptable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated to clarify server naming behavior for developer versus release builds.

* **Improvements**
  * Developer builds now use a `dir2mcp-dev-` prefix for auto-derived server names, distinguishing them from release builds. Manual server name overrides remain consistent across all build types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dirstral/dir2mcp/pull/185)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->