### PR TITLE
refactor(cli): action-first verbs (install/uninstall/doctor/print-config)

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,10 @@ DIR2MCP_DEMO_TOKEN="$(cat .dir2mcp/secret.token)" \
 | `reindex` | Force full re-ingestion |
 | `config init` | Create a baseline `.dir2mcp.yaml` |
 | `config print` | Print effective config |
+| `install <client>` | Install dir2mcp into a supported MCP client (e.g. `dir2mcp install claude`) |
+| `uninstall <client>` | Remove dir2mcp from a supported MCP client |
+| `doctor <client>` | Run client-integration diagnostics |
+| `print-config <client>` | Print the MCP-server JSON snippet a client expects |
 | `version` | Print version |
 
 Running `dir2mcp` with no arguments prints usage, which you can consult anytime to see available commands.

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -58,18 +58,21 @@ const (
 )
 
 var commands = map[string]struct{}{
-	"up":         {},
-	"down":       {},
-	"status":     {},
-	"ask":        {},
-	"search":     {},
-	"open-file":  {},
-	"list-files": {},
-	"reindex":    {},
-	"bridge":     {},
-	"config":     {},
-	"claude":     {},
-	"version":    {},
+	"up":           {},
+	"down":         {},
+	"status":       {},
+	"ask":          {},
+	"search":       {},
+	"open-file":    {},
+	"list-files":   {},
+	"reindex":      {},
+	"bridge":       {},
+	"config":       {},
+	"install":      {},
+	"uninstall":    {},
+	"doctor":       {},
+	"print-config": {},
+	"version":      {},
 }
 
 type App struct {
@@ -439,8 +442,14 @@ func (a *App) runSimpleCommand(ctx context.Context, globalOpts globalOptions, co
 		return a.runConfig(ctx, globalOpts, args), true
 	case "bridge":
 		return a.runBridge(ctx, globalOpts, args), true
-	case "claude":
-		return a.runClaude(ctx, globalOpts, args), true
+	case "install":
+		return a.runInstall(ctx, globalOpts, args), true
+	case "uninstall":
+		return a.runUninstall(ctx, globalOpts, args), true
+	case "doctor":
+		return a.runDoctor(ctx, globalOpts, args), true
+	case "print-config":
+		return a.runPrintConfig(ctx, globalOpts, args), true
 	default:
 		return 0, false
 	}
@@ -484,11 +493,14 @@ func (a *App) printUsage() {
 		{"reindex", "force a full re-index of all documents"},
 		{"bridge", "run helper adapters (for example ElevenLabs webhooks)"},
 		{"config", "view or edit configuration"},
-		{"claude", "configure Claude Desktop MCP connection"},
+		{"install", "install dir2mcp into a client (e.g. dir2mcp install claude)"},
+		{"uninstall", "remove dir2mcp from a client (e.g. dir2mcp uninstall claude)"},
+		{"doctor", "run client integration diagnostics (e.g. dir2mcp doctor claude)"},
+		{"print-config", "print the MCP-server JSON snippet for a client"},
 		{"version", "print build version"},
 	}
 	for _, c := range cmds {
-		writef(o, "  %-12s %s\n", s.Bold.Render(c[0]), s.Dim.Render(c[1]))
+		writef(o, "  %-13s %s\n", s.Bold.Render(c[0]), s.Dim.Render(c[1]))
 	}
 	writeln(o)
 

--- a/internal/cli/claude_cmd.go
+++ b/internal/cli/claude_cmd.go
@@ -20,37 +20,17 @@ type claudeServerConfig struct {
 	Args    []string `json:"args,omitempty"`
 }
 
-func (a *App) runClaude(ctx context.Context, global globalOptions, args []string) int {
-	if len(args) == 0 {
-		writeln(a.stdout, "claude command: supported subcommands are print-config, install, uninstall, and doctor")
-		return exitSuccess
-	}
-	switch args[0] {
-	case "print-config":
-		return a.runClaudePrintConfig(global, args[1:])
-	case "install":
-		return a.runClaudeInstall(global, args[1:])
-	case "uninstall":
-		return a.runClaudeUninstall(global, args[1:])
-	case "doctor":
-		return a.runClaudeDoctor(ctx, global, args[1:])
-	default:
-		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("unknown claude subcommand: %s", args[0]))
-		return exitConfigInvalid
-	}
-}
-
 func (a *App) runClaudePrintConfig(global globalOptions, args []string) int {
-	fs := flag.NewFlagSet("claude print-config", flag.ContinueOnError)
+	fs := flag.NewFlagSet("print-config claude", flag.ContinueOnError)
 	fs.SetOutput(ioDiscard{})
 	serverName := fs.String("name", "dir2mcp", "server name")
 	stateDir := fs.String("state-dir", "", "state directory containing connection.json")
 	if err := fs.Parse(args); err != nil {
-		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("invalid claude print-config flags: %v", err))
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("invalid print-config claude flags: %v", err))
 		return exitConfigInvalid
 	}
 	if len(fs.Args()) > 0 {
-		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("claude print-config does not accept positional arguments: %s", strings.Join(fs.Args(), " ")))
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("print-config claude does not accept positional arguments: %s", strings.Join(fs.Args(), " ")))
 		return exitConfigInvalid
 	}
 
@@ -94,17 +74,17 @@ func (a *App) runClaudePrintConfig(global globalOptions, args []string) int {
 }
 
 func (a *App) runClaudeInstall(global globalOptions, args []string) int {
-	fs := flag.NewFlagSet("claude install", flag.ContinueOnError)
+	fs := flag.NewFlagSet("install claude", flag.ContinueOnError)
 	fs.SetOutput(ioDiscard{})
 	serverName := fs.String("name", "dir2mcp", "server name")
 	stateDir := fs.String("state-dir", "", "state directory containing connection.json")
 	configPath := fs.String("config-path", defaultClaudeDesktopConfigPath(), "Claude Desktop config path")
 	if err := fs.Parse(args); err != nil {
-		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("invalid claude install flags: %v", err))
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("invalid install claude flags: %v", err))
 		return exitConfigInvalid
 	}
 	if len(fs.Args()) > 0 {
-		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("claude install does not accept positional arguments: %s", strings.Join(fs.Args(), " ")))
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("install claude does not accept positional arguments: %s", strings.Join(fs.Args(), " ")))
 		return exitConfigInvalid
 	}
 
@@ -178,16 +158,16 @@ func (a *App) runClaudeInstall(global globalOptions, args []string) int {
 }
 
 func (a *App) runClaudeUninstall(global globalOptions, args []string) int {
-	fs := flag.NewFlagSet("claude uninstall", flag.ContinueOnError)
+	fs := flag.NewFlagSet("uninstall claude", flag.ContinueOnError)
 	fs.SetOutput(ioDiscard{})
 	serverName := fs.String("name", "dir2mcp", "server name to remove from Claude config")
 	configPath := fs.String("config-path", defaultClaudeDesktopConfigPath(), "Claude Desktop config path")
 	if err := fs.Parse(args); err != nil {
-		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("invalid claude uninstall flags: %v", err))
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("invalid uninstall claude flags: %v", err))
 		return exitConfigInvalid
 	}
 	if len(fs.Args()) > 0 {
-		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("claude uninstall does not accept positional arguments: %s", strings.Join(fs.Args(), " ")))
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("uninstall claude does not accept positional arguments: %s", strings.Join(fs.Args(), " ")))
 		return exitConfigInvalid
 	}
 
@@ -261,15 +241,15 @@ func (a *App) runClaudeUninstall(global globalOptions, args []string) int {
 }
 
 func (a *App) runClaudeDoctor(ctx context.Context, global globalOptions, args []string) int {
-	fs := flag.NewFlagSet("claude doctor", flag.ContinueOnError)
+	fs := flag.NewFlagSet("doctor claude", flag.ContinueOnError)
 	fs.SetOutput(ioDiscard{})
 	stateDir := fs.String("state-dir", "", "state directory containing connection.json")
 	if err := fs.Parse(args); err != nil {
-		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("invalid claude doctor flags: %v", err))
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("invalid doctor claude flags: %v", err))
 		return exitConfigInvalid
 	}
 	if len(fs.Args()) > 0 {
-		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("claude doctor does not accept positional arguments: %s", strings.Join(fs.Args(), " ")))
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("doctor claude does not accept positional arguments: %s", strings.Join(fs.Args(), " ")))
 		return exitConfigInvalid
 	}
 

--- a/internal/cli/client_cmds.go
+++ b/internal/cli/client_cmds.go
@@ -1,0 +1,113 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// supportedClients enumerates the MCP clients dir2mcp can configure
+// today. As more clients land, add them here and route the new entry
+// through each verb's switch — the top-level surface (`install`,
+// `uninstall`, `doctor`, `print-config`) stays flat.
+var supportedClients = []string{"claude"}
+
+// extractClient reads the leading positional argument as the client
+// name and returns it (lowercased, trimmed) along with the remaining
+// args. When the leading positional is missing, an actionable usage
+// error is written and ok is false; the caller should return
+// exitConfigInvalid in that case.
+func extractClient(a *App, jsonOutput bool, verb string, args []string) (client string, rest []string, ok bool) {
+	if len(args) == 0 {
+		writeCLIError(a.stderr, jsonOutput, exitConfigInvalid,
+			fmt.Sprintf("dir2mcp %s requires a client name", verb),
+			"Supported clients: "+strings.Join(supportedClientsSorted(), ", "),
+			fmt.Sprintf("Example: dir2mcp %s claude", verb),
+		)
+		return "", nil, false
+	}
+	return strings.ToLower(strings.TrimSpace(args[0])), args[1:], true
+}
+
+func supportedClientsSorted() []string {
+	out := append([]string(nil), supportedClients...)
+	sort.Strings(out)
+	return out
+}
+
+// unknownClientError writes the standard "we don't know that client"
+// message and returns exitConfigInvalid. Centralized so every verb
+// dispatcher emits the same hint.
+func unknownClientError(a *App, jsonOutput bool, verb, client string) int {
+	writeCLIError(a.stderr, jsonOutput, exitConfigInvalid,
+		fmt.Sprintf("unknown client %q for %s", client, verb),
+		"Supported clients: "+strings.Join(supportedClientsSorted(), ", "),
+	)
+	return exitConfigInvalid
+}
+
+// runInstall installs the dir2mcp MCP server entry into the requested
+// client's configuration. Today the only supported client is claude
+// (Claude Desktop); future clients (chatgpt, cursor, ...) plug into
+// the same switch.
+func (a *App) runInstall(_ context.Context, global globalOptions, args []string) int {
+	client, rest, ok := extractClient(a, global.jsonOutput, "install", args)
+	if !ok {
+		return exitConfigInvalid
+	}
+	switch client {
+	case "claude":
+		return a.runClaudeInstall(global, rest)
+	default:
+		return unknownClientError(a, global.jsonOutput, "install", client)
+	}
+}
+
+// runUninstall removes the dir2mcp MCP server entry from the
+// requested client's configuration. Idempotent — uninstalling a
+// not-installed client is a clean no-op.
+func (a *App) runUninstall(_ context.Context, global globalOptions, args []string) int {
+	client, rest, ok := extractClient(a, global.jsonOutput, "uninstall", args)
+	if !ok {
+		return exitConfigInvalid
+	}
+	switch client {
+	case "claude":
+		return a.runClaudeUninstall(global, rest)
+	default:
+		return unknownClientError(a, global.jsonOutput, "uninstall", client)
+	}
+}
+
+// runDoctor runs client-specific diagnostics — bridge command
+// resolution, connection URL validity, endpoint reachability, token
+// presence — for the requested client.
+func (a *App) runDoctor(ctx context.Context, global globalOptions, args []string) int {
+	client, rest, ok := extractClient(a, global.jsonOutput, "doctor", args)
+	if !ok {
+		return exitConfigInvalid
+	}
+	switch client {
+	case "claude":
+		return a.runClaudeDoctor(ctx, global, rest)
+	default:
+		return unknownClientError(a, global.jsonOutput, "doctor", client)
+	}
+}
+
+// runPrintConfig emits the JSON snippet the requested client expects
+// in its MCP-server configuration block. Useful for users who want to
+// merge into a config they manage manually instead of running install.
+func (a *App) runPrintConfig(_ context.Context, global globalOptions, args []string) int {
+	client, rest, ok := extractClient(a, global.jsonOutput, "print-config", args)
+	if !ok {
+		return exitConfigInvalid
+	}
+	switch client {
+	case "claude":
+		return a.runClaudePrintConfig(global, rest)
+	default:
+		return unknownClientError(a, global.jsonOutput, "print-config", client)
+	}
+}

--- a/tests/cli/claude_command_test.go
+++ b/tests/cli/claude_command_test.go
@@ -43,7 +43,7 @@ func TestClaudePrintConfigEmitsMCPServerBlock(t *testing.T) {
 	code := app.RunWithContext(context.Background(), []string{
 		"--state-dir", stateDir,
 		"--json",
-		"claude", "print-config",
+		"print-config", "claude",
 		"--name", "stas-legal-dir2mcp",
 	})
 	if code != 0 {
@@ -101,7 +101,7 @@ func TestClaudeInstallUpdatesConfigFile(t *testing.T) {
 
 	code := app.RunWithContext(context.Background(), []string{
 		"--state-dir", stateDir,
-		"claude", "install",
+		"install", "claude",
 		"--name", "stas-legal-dir2mcp",
 		"--config-path", configPath,
 	})
@@ -139,7 +139,7 @@ func TestClaudeDoctorPassesWithValidState(t *testing.T) {
 	code := app.RunWithContext(context.Background(), []string{
 		"--state-dir", stateDir,
 		"--json",
-		"claude", "doctor",
+		"doctor", "claude",
 	})
 	var payload map[string]interface{}
 	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
@@ -181,7 +181,7 @@ func TestClaudeDoctorFailsMissingToken(t *testing.T) {
 
 	code := app.RunWithContext(context.Background(), []string{
 		"--state-dir", stateDir,
-		"claude", "doctor",
+		"doctor", "claude",
 	})
 	if code == 0 {
 		t.Fatalf("expected non-zero exit code, got stdout=%s stderr=%s", stdout.String(), stderr.String())
@@ -207,7 +207,7 @@ func TestClaudeInstallFailsMissingBridge(t *testing.T) {
 	app := cli.NewAppWithIO(&stdout, &stderr)
 	code := app.RunWithContext(context.Background(), []string{
 		"--state-dir", stateDir,
-		"claude", "install",
+		"install", "claude",
 		"--config-path", configPath,
 	})
 	if code == 0 {
@@ -271,7 +271,7 @@ func TestClaudeUninstallRemovesEntryAndPreservesUnrelatedKeys(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	app := cli.NewAppWithIO(&stdout, &stderr)
 	code := app.RunWithContext(context.Background(), []string{
-		"claude", "uninstall",
+		"uninstall", "claude",
 		"--config-path", configPath,
 	})
 	if code != 0 {
@@ -317,7 +317,7 @@ func TestClaudeUninstallDropsEmptyMCPServersBlock(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	app := cli.NewAppWithIO(&stdout, &stderr)
 	code := app.RunWithContext(context.Background(), []string{
-		"claude", "uninstall",
+		"uninstall", "claude",
 		"--config-path", configPath,
 	})
 	if code != 0 {
@@ -347,7 +347,7 @@ func TestClaudeUninstallIsIdempotentWhenEntryAbsent(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	app := cli.NewAppWithIO(&stdout, &stderr)
 	code := app.RunWithContext(context.Background(), []string{
-		"claude", "uninstall",
+		"uninstall", "claude",
 		"--config-path", configPath,
 	})
 	if code != 0 {

--- a/tests/cli/client_dispatch_test.go
+++ b/tests/cli/client_dispatch_test.go
@@ -1,0 +1,147 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/cli"
+)
+
+// The action-first client verbs (install/uninstall/doctor/print-config)
+// share one dispatcher. These tests pin the two user-facing error
+// paths that dispatcher owns — missing <client> positional and an
+// unsupported <client> — across every verb, in both human and JSON
+// output modes. Without this, a regression in those branches would go
+// uncaught since the happy-path tests only exercise `claude`.
+
+var clientVerbs = []string{"install", "uninstall", "doctor", "print-config"}
+
+func TestClientVerb_MissingClient_Human(t *testing.T) {
+	for _, verb := range clientVerbs {
+		t.Run(verb, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			app := cli.NewAppWithIO(&stdout, &stderr)
+
+			code := app.RunWithContext(context.Background(), []string{verb})
+
+			if code != 2 {
+				t.Fatalf("exit code = %d, want 2 (CONFIG_INVALID); stderr=%s", code, stderr.String())
+			}
+			errOut := stderr.String()
+			if !strings.Contains(errOut, "requires a client name") {
+				t.Fatalf("stderr missing 'requires a client name': %q", errOut)
+			}
+			if !strings.Contains(errOut, "claude") {
+				t.Fatalf("stderr should list supported clients incl. claude: %q", errOut)
+			}
+			if !strings.Contains(errOut, "dir2mcp "+verb+" claude") {
+				t.Fatalf("stderr should show the example invocation: %q", errOut)
+			}
+		})
+	}
+}
+
+func TestClientVerb_MissingClient_JSON(t *testing.T) {
+	for _, verb := range clientVerbs {
+		t.Run(verb, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			app := cli.NewAppWithIO(&stdout, &stderr)
+
+			code := app.RunWithContext(context.Background(), []string{"--json", verb})
+
+			if code != 2 {
+				t.Fatalf("exit code = %d, want 2; stderr=%s", code, stderr.String())
+			}
+			payload := decodeCLIError(t, stderr.Bytes())
+			if payload.ExitCode != 2 {
+				t.Fatalf("payload exit_code = %d, want 2", payload.ExitCode)
+			}
+			if payload.Error.Code != "CONFIG_INVALID" {
+				t.Fatalf("payload error.code = %q, want CONFIG_INVALID", payload.Error.Code)
+			}
+			if !strings.Contains(payload.Error.Message, "requires a client name") {
+				t.Fatalf("payload error.message unexpected: %q", payload.Error.Message)
+			}
+		})
+	}
+}
+
+func TestClientVerb_UnknownClient_Human(t *testing.T) {
+	for _, verb := range clientVerbs {
+		t.Run(verb, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			app := cli.NewAppWithIO(&stdout, &stderr)
+
+			code := app.RunWithContext(context.Background(), []string{verb, "chatgpt"})
+
+			if code != 2 {
+				t.Fatalf("exit code = %d, want 2; stderr=%s", code, stderr.String())
+			}
+			errOut := stderr.String()
+			if !strings.Contains(errOut, "unknown client") || !strings.Contains(errOut, "chatgpt") {
+				t.Fatalf("stderr should name the unknown client: %q", errOut)
+			}
+			if !strings.Contains(errOut, "claude") {
+				t.Fatalf("stderr should list supported clients incl. claude: %q", errOut)
+			}
+		})
+	}
+}
+
+func TestClientVerb_UnknownClient_JSON(t *testing.T) {
+	for _, verb := range clientVerbs {
+		t.Run(verb, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			app := cli.NewAppWithIO(&stdout, &stderr)
+
+			code := app.RunWithContext(context.Background(), []string{"--json", verb, "chatgpt"})
+
+			if code != 2 {
+				t.Fatalf("exit code = %d, want 2; stderr=%s", code, stderr.String())
+			}
+			payload := decodeCLIError(t, stderr.Bytes())
+			if payload.Error.Code != "CONFIG_INVALID" {
+				t.Fatalf("payload error.code = %q, want CONFIG_INVALID", payload.Error.Code)
+			}
+			if !strings.Contains(payload.Error.Message, "unknown client") {
+				t.Fatalf("payload error.message unexpected: %q", payload.Error.Message)
+			}
+		})
+	}
+}
+
+// TestClientVerb_ClientNameCaseInsensitive confirms the dispatcher
+// lowercases the positional, so `Claude` routes the same as `claude`
+// (it reaches the claude leaf and fails later on missing connection
+// state, not at the dispatcher with an unknown-client error).
+func TestClientVerb_ClientNameCaseInsensitive(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+
+	code := app.RunWithContext(context.Background(), []string{"--state-dir", t.TempDir(), "doctor", "CLAUDE"})
+
+	if code == 2 && strings.Contains(stderr.String(), "unknown client") {
+		t.Fatalf("`CLAUDE` should route to the claude leaf, not unknown-client: %q", stderr.String())
+	}
+}
+
+type cliErrorEnvelope struct {
+	Error struct {
+		Code    string   `json:"code"`
+		Message string   `json:"message"`
+		Hints   []string `json:"hints"`
+	} `json:"error"`
+	ExitCode int `json:"exit_code"`
+}
+
+func decodeCLIError(t *testing.T, raw []byte) cliErrorEnvelope {
+	t.Helper()
+	var env cliErrorEnvelope
+	if err := json.Unmarshal(bytes.TrimSpace(raw), &env); err != nil {
+		t.Fatalf("decode CLI error JSON: %v raw=%s", err, string(raw))
+	}
+	return env
+}

--- a/tests/security/cli_boundary_test.go
+++ b/tests/security/cli_boundary_test.go
@@ -25,18 +25,21 @@ func TestRepoSplitBoundary_CLICommandSurface(t *testing.T) {
 	commands := extractCommandsMap(t, file)
 
 	expected := map[string]struct{}{
-		"up":         {},
-		"down":       {},
-		"status":     {},
-		"ask":        {},
-		"search":     {},
-		"open-file":  {},
-		"list-files": {},
-		"reindex":    {},
-		"bridge":     {},
-		"config":     {},
-		"claude":     {},
-		"version":    {},
+		"up":           {},
+		"down":         {},
+		"status":       {},
+		"ask":          {},
+		"search":       {},
+		"open-file":    {},
+		"list-files":   {},
+		"reindex":      {},
+		"bridge":       {},
+		"config":       {},
+		"install":      {},
+		"uninstall":    {},
+		"doctor":       {},
+		"print-config": {},
+		"version":      {},
 	}
 
 	assertCommandSurface(t, commands, expected)
@@ -158,6 +161,7 @@ func TestRepoSplitBoundary_InternalCLIFileOwnership(t *testing.T) {
 		"ask.go":                    {},
 		"bridge.go":                 {},
 		"claude_cmd.go":             {},
+		"client_cmds.go":            {},
 		"config_cmd.go":             {},
 		"corpus_snapshot_test.go":   {},
 		"corpus_writer_test.go":     {},


### PR DESCRIPTION
## Summary

Removes the `dir2mcp claude` subcommand group. The four operations it hosted are now top-level verbs that take a `<client>` positional:

| Before | After |
|---|---|
| `dir2mcp claude install` | `dir2mcp install claude` |
| `dir2mcp claude uninstall` | `dir2mcp uninstall claude` |
| `dir2mcp claude doctor` | `dir2mcp doctor claude` |
| `dir2mcp claude print-config` | `dir2mcp print-config claude` |

## Why

As more MCP clients land (chatgpt, cursor, ...), action-first keeps the surface flat. Future clients add **zero new top-level commands** — they just become additional valid `<client>` values. The verb-takes-a-client mental model is also more discoverable than "find the right object then look up its verbs."

## Implementation

- New `internal/cli/client_cmds.go` hosts the four verb dispatchers with a single `supportedClients` enumeration. Adding a client = one switch arm per verb plus an entry in `supportedClients`.
- The leaf implementations (`runClaudeInstall`, `runClaudeUninstall`, `runClaudeDoctor`, `runClaudePrintConfig`) keep their names; flag-set names updated to `install claude`, etc. for consistent error text.
- The old `runClaude` dispatcher is removed.
- `commands` map: `"claude"` removed; `"install"`, `"uninstall"`, `"doctor"`, `"print-config"` added.
- `printUsage` table updated with the new verbs.
- Missing `<client>` positional surfaces an actionable error: `dir2mcp install requires a client name. Supported clients: claude. Example: dir2mcp install claude`.

## Tests

- [x] `tests/cli/claude_command_test.go` argv flipped throughout (8 sites).
- [x] `tests/security/cli_boundary_test.go`: command-surface expected map updated; `client_cmds.go` added to `internal/cli` ownership allow-list.
- [x] `make check` (full Go suite + lint + gofmt + python tests + build) green locally.

## Docs

- README CLI table lists the new top-level verbs.

## Notes

Per the prior "no users" framing, this is a hard switch with no compatibility shim. Anyone running `dir2mcp claude install` muscle-memory will get a usage error pointing at the new form. Per repo PR checklist: no unrelated files changed, behavior changes covered by tests, docs in sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Restructured CLI to use action-first command format.
  * Added top-level commands: install, uninstall, doctor, and print-config that accept a client parameter.
  * Commands now follow `<action> <client>` pattern (e.g., install claude).

* **Documentation**
  * Updated CLI command reference guide.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dirstral/dir2mcp/pull/186)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->