### PR TITLE
feat(retrieval): optional Cohere reranking (SPEC 9.1.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,9 @@ vary by deployment. The commonly used variables are:
 | `DIR2MCP_HEALTH_CHECK_INTERVAL` | No | Connector health poll interval (default: `5s`) |
 | `DIR2MCP_ALLOWED_ORIGINS` | No | Comma-separated additional browser origins |
 | `DIR2MCP_X402_FACILITATOR_TOKEN` | No | x402 facilitator bearer token |
+| `COHERE_API_KEY` | Conditional | Required only when reranking is enabled (`rerank.enabled: true`, provider `cohere`); secret, never persisted to the config snapshot |
+| `DIR2MCP_RERANK_ENABLED` | No | Enable the optional post-fusion rerank stage (`true`/`false`) |
+| `DIR2MCP_RERANK_MODEL` | No | Cohere rerank model override (default: `rerank-v3.5`) |
 | `ELEVENLABS_API_KEY` | No | ElevenLabs key for TTS/STT |
 | `ELEVENLABS_BASE_URL` | No | ElevenLabs base URL (default: `https://api.elevenlabs.io`) |
 
@@ -238,6 +241,26 @@ Each `dir2mcp up` instance reports a unique MCP server name derived from the ind
 - Developer builds (binaries built locally without a release tag — `dir2mcp version` reports `v0.0.0-dev` or `vdev-<sha>`, optionally with `+dirty`) use a `dir2mcp-dev-<slug>-<6-hex>` prefix instead, so a dev build run from your repo shows up as a distinct entry alongside the brew-installed release in `claude mcp list`.
 - Override via YAML (`server.name: my-alias`) or env (`DIR2MCP_SERVER_NAME=my-alias`). Overrides apply verbatim and bypass the default generated name, including the `dir2mcp-dev-...` prefix used by dev builds.
 - The `dir2mcp up` banner prints a ready-to-paste `claude mcp add --transport http <name> <url> ...` line using this name; the client-side alias you register with is yours to choose.
+
+### Reranking (optional)
+
+An optional post-fusion **reranking** stage can re-score retrieval candidates with a cross-encoder for higher answer quality. It is **off by default** and **fail-open** — any provider error (missing key, network, rate limit) silently falls back to the normal fused order, so a query never fails because reranking failed. Spec: `dirstral-spec/docs/SPEC.md` §9.1.1.
+
+- Provider: **Cohere** (`POST /v2/rerank`, default model `rerank-v3.5`).
+- Enable via YAML:
+
+  ```yaml
+  rerank:
+    enabled: true
+    provider: cohere
+    candidate_pool: 50      # fused candidates re-scored before truncation to k
+    cohere:
+      api_key: ${COHERE_API_KEY}
+      model: rerank-v3.5
+  ```
+
+- Or via env: `DIR2MCP_RERANK_ENABLED=true` + `COHERE_API_KEY=...` (env wins over YAML for the key; the key is a secret and is never written to the config snapshot).
+- For `index=both`, reranking is applied once to the merged candidate pool. Ordering is deterministic (relevance desc, then `chunk_id`).
 
 ### Auth token behavior
 

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Each `dir2mcp up` instance reports a unique MCP server name derived from the ind
 
 ### Reranking (optional)
 
-An optional post-fusion **reranking** stage can re-score retrieval candidates with a cross-encoder for higher answer quality. It is **capability-driven** — it activates automatically when a rerank provider credential is present (the same way the Mistral key gates embedding/OCR) — and **fail-open**: any provider error (missing key, network, rate limit) silently falls back to the normal fused order, so a query never fails because reranking failed. Spec: `dirstral-spec/docs/SPEC.md` §9.1.1.
+An optional post-fusion **reranking** stage can re-score retrieval candidates with a cross-encoder for higher answer quality. It is **capability-driven** — it activates automatically when a rerank provider credential is present (the same way the Mistral key gates embedding/OCR). A missing credential is a startup condition, not a query failure: in auto mode reranking simply stays off (silent); if you explicitly set `rerank.enabled: true` without a credential the server warns at startup and runs without reranking. Once active it is **fail-open** — any *runtime* provider error (network, rate limit, non-2xx) silently falls back to the normal fused order, so a query never fails because reranking failed. Spec: `dirstral-spec/docs/SPEC.md` §9.1.1.
 
 - Provider: **Cohere** (`POST /v2/rerank`, default model `rerank-v3.5`).
 - **Auto-enable**: just provide the credential — `COHERE_API_KEY=...` (or `rerank.cohere.api_key` in YAML). No enable flag required.

--- a/README.md
+++ b/README.md
@@ -213,8 +213,8 @@ vary by deployment. The commonly used variables are:
 | `DIR2MCP_HEALTH_CHECK_INTERVAL` | No | Connector health poll interval (default: `5s`) |
 | `DIR2MCP_ALLOWED_ORIGINS` | No | Comma-separated additional browser origins |
 | `DIR2MCP_X402_FACILITATOR_TOKEN` | No | x402 facilitator bearer token |
-| `COHERE_API_KEY` | Conditional | Required only when reranking is enabled (`rerank.enabled: true`, provider `cohere`); secret, never persisted to the config snapshot |
-| `DIR2MCP_RERANK_ENABLED` | No | Enable the optional post-fusion rerank stage (`true`/`false`) |
+| `COHERE_API_KEY` | Optional | When set, auto-enables the post-fusion rerank stage (provider `cohere`); secret, never persisted to the config snapshot |
+| `DIR2MCP_RERANK_ENABLED` | No | Tri-state override of the auto behavior: `false` forces reranking off even with a credential; `true` requires it (warns + falls back if no credential) |
 | `DIR2MCP_RERANK_MODEL` | No | Cohere rerank model override (default: `rerank-v3.5`) |
 | `ELEVENLABS_API_KEY` | No | ElevenLabs key for TTS/STT |
 | `ELEVENLABS_BASE_URL` | No | ElevenLabs base URL (default: `https://api.elevenlabs.io`) |
@@ -244,14 +244,18 @@ Each `dir2mcp up` instance reports a unique MCP server name derived from the ind
 
 ### Reranking (optional)
 
-An optional post-fusion **reranking** stage can re-score retrieval candidates with a cross-encoder for higher answer quality. It is **off by default** and **fail-open** — any provider error (missing key, network, rate limit) silently falls back to the normal fused order, so a query never fails because reranking failed. Spec: `dirstral-spec/docs/SPEC.md` §9.1.1.
+An optional post-fusion **reranking** stage can re-score retrieval candidates with a cross-encoder for higher answer quality. It is **capability-driven** — it activates automatically when a rerank provider credential is present (the same way the Mistral key gates embedding/OCR) — and **fail-open**: any provider error (missing key, network, rate limit) silently falls back to the normal fused order, so a query never fails because reranking failed. Spec: `dirstral-spec/docs/SPEC.md` §9.1.1.
 
 - Provider: **Cohere** (`POST /v2/rerank`, default model `rerank-v3.5`).
-- Enable via YAML:
+- **Auto-enable**: just provide the credential — `COHERE_API_KEY=...` (or `rerank.cohere.api_key` in YAML). No enable flag required.
+- Optional YAML (every field optional; shown with defaults):
 
   ```yaml
   rerank:
-    enabled: true
+    # `enabled` is an optional override:
+    #   omitted -> auto (on iff a credential is present)
+    #   false   -> force off even when a credential is present
+    #   true    -> require it (warns + falls back if no credential)
     provider: cohere
     candidate_pool: 50      # fused candidates re-scored before truncation to k
     cohere:
@@ -259,7 +263,7 @@ An optional post-fusion **reranking** stage can re-score retrieval candidates wi
       model: rerank-v3.5
   ```
 
-- Or via env: `DIR2MCP_RERANK_ENABLED=true` + `COHERE_API_KEY=...` (env wins over YAML for the key; the key is a secret and is never written to the config snapshot).
+- Env overrides: `COHERE_API_KEY=...` auto-enables; `DIR2MCP_RERANK_ENABLED=false` opts out even with a credential; `DIR2MCP_RERANK_MODEL=...` overrides the model. Env wins over YAML for the key; the key is a secret and is never written to the config snapshot.
 - For `index=both`, reranking is applied once to the merged candidate pool. Ordering is deterministic (relevance desc, then `chunk_id`).
 
 ### Auth token behavior

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/dirstral/dir2mcp/internal/appstate"
 	"github.com/dirstral/dir2mcp/internal/buildinfo"
+	"github.com/dirstral/dir2mcp/internal/cohere"
 	"github.com/dirstral/dir2mcp/internal/config"
 	"github.com/dirstral/dir2mcp/internal/index"
 	"github.com/dirstral/dir2mcp/internal/ingest"
@@ -579,6 +580,31 @@ func saveEnvLocalKey(path, keyName, value string) error {
 	return os.WriteFile(path, []byte(strings.Join(out, "\n")+"\n"), 0o600)
 }
 
+// configureReranker wires the optional Cohere rerank stage onto the
+// retrieval service. Enabled only when rerank.enabled is set, the
+// provider is supported, and a Cohere key is present; otherwise it
+// warns and leaves reranking off (it is a fail-open optimization, not
+// a hard dependency). Shared by the `up` and `ask` retrieval paths.
+func (a *App) configureReranker(ret *retrieval.Service, cfg config.Config) {
+	if !cfg.RerankEnabled {
+		return
+	}
+	provider := strings.ToLower(strings.TrimSpace(cfg.RerankProvider))
+	if provider == "" {
+		provider = "cohere"
+	}
+	if provider != "cohere" {
+		writef(a.stderr, "warning: rerank.provider %q unsupported; reranking disabled\n", cfg.RerankProvider)
+		return
+	}
+	if strings.TrimSpace(cfg.CohereAPIKey) == "" {
+		writef(a.stderr, "warning: rerank enabled but COHERE_API_KEY is not set; reranking disabled\n")
+		return
+	}
+	ret.SetReranker(cohere.NewClient("", cfg.CohereAPIKey), cfg.RerankModel, cfg.RerankCandidatePool)
+	ret.SetRerankEnabled(true)
+}
+
 func (a *App) buildRetrieverForAsk(ctx context.Context, cfg config.Config, st model.Store) (model.Retriever, func(), error) {
 	if a != nil && a.newRetriever != nil {
 		return a.newRetriever(cfg, st), nil, nil
@@ -616,6 +642,7 @@ func (a *App) buildRetrieverForAsk(ctx context.Context, cfg config.Config, st mo
 	ret.SetRAGSystemPrompt(cfg.RAGSystemPrompt)
 	ret.SetMaxContextChars(cfg.RAGMaxContextChars)
 	ret.SetOversampleFactor(cfg.RAGOversampleFactor)
+	a.configureReranker(ret, cfg)
 
 	if metadataStore, ok := st.(embeddedChunkLister); ok {
 		if _, err := preloadEmbeddedChunkMetadata(ctx, metadataStore, ret); err != nil && !errors.Is(err, model.ErrNotImplemented) {

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -618,7 +618,7 @@ func (a *App) configureReranker(ret *retrieval.Service, cfg config.Config) {
 		}
 		return
 	}
-	ret.SetReranker(cohere.NewClient("", cfg.CohereAPIKey), cfg.RerankModel, cfg.RerankCandidatePool)
+	ret.SetReranker(cohere.NewClient(cfg.CohereBaseURL, cfg.CohereAPIKey), cfg.RerankModel, cfg.RerankCandidatePool)
 	ret.SetRerankEnabled(true)
 }
 

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -581,24 +581,41 @@ func saveEnvLocalKey(path, keyName, value string) error {
 }
 
 // configureReranker wires the optional Cohere rerank stage onto the
-// retrieval service. Enabled only when rerank.enabled is set, the
-// provider is supported, and a Cohere key is present; otherwise it
-// warns and leaves reranking off (it is a fail-open optimization, not
-// a hard dependency). Shared by the `up` and `ask` retrieval paths.
+// retrieval service. Reranking is capability-driven: it activates
+// automatically when a rerank provider credential is present (mirrors
+// how the Mistral key gates embedding/OCR). cfg.RerankEnabled is a
+// tri-state override:
+//
+//	nil    -> auto: on iff a credential is present
+//	*false -> force off even when a credential is present
+//	*true  -> require it; warn + fail-open if no credential
+//
+// It is a fail-open optimization, not a hard dependency. Shared by the
+// `up` and `ask` retrieval paths.
 func (a *App) configureReranker(ret *retrieval.Service, cfg config.Config) {
-	if !cfg.RerankEnabled {
+	explicit := cfg.RerankEnabled != nil
+	// Explicit opt-out wins, even with a credential present.
+	if explicit && !*cfg.RerankEnabled {
 		return
 	}
+	asked := explicit && *cfg.RerankEnabled
+
 	provider := strings.ToLower(strings.TrimSpace(cfg.RerankProvider))
 	if provider == "" {
 		provider = "cohere"
 	}
 	if provider != "cohere" {
-		writef(a.stderr, "warning: rerank.provider %q unsupported; reranking disabled\n", cfg.RerankProvider)
+		if asked {
+			writef(a.stderr, "warning: rerank.provider %q unsupported; reranking disabled\n", cfg.RerankProvider)
+		}
 		return
 	}
 	if strings.TrimSpace(cfg.CohereAPIKey) == "" {
-		writef(a.stderr, "warning: rerank enabled but COHERE_API_KEY is not set; reranking disabled\n")
+		// Only warn when the operator explicitly asked for reranking;
+		// auto mode stays silent (no credential simply means off).
+		if asked {
+			writef(a.stderr, "warning: rerank.enabled is set but COHERE_API_KEY is not present; reranking disabled\n")
+		}
 		return
 	}
 	ret.SetReranker(cohere.NewClient("", cfg.CohereAPIKey), cfg.RerankModel, cfg.RerankCandidatePool)

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -67,6 +67,7 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 	ret.SetRAGSystemPrompt(cfg.RAGSystemPrompt)
 	ret.SetMaxContextChars(cfg.RAGMaxContextChars)
 	ret.SetOversampleFactor(cfg.RAGOversampleFactor)
+	a.configureReranker(ret, cfg)
 
 	// events are emitted to stdout only after we create the emitter; moving
 	// creation before the preload call lets us report failures from that

--- a/internal/cohere/client.go
+++ b/internal/cohere/client.go
@@ -1,0 +1,228 @@
+// Package cohere provides a minimal direct-HTTP adapter for the Cohere
+// Rerank v2 API (POST /v2/rerank). It mirrors internal/mistral's client
+// shape (BaseURL/APIKey/HTTPClient, bounded exponential retry, typed
+// model.ProviderError) so retrieval can depend on a model.Reranker
+// without taking a hard dependency on this package.
+//
+// Reranking in dir2mcp is fail-open: callers treat any error from this
+// client as "skip rerank, keep fused order" (see internal/retrieval).
+package cohere
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+const (
+	defaultBaseURL        = "https://api.cohere.com"
+	defaultRequestTimeout = 30 * time.Second
+	defaultMaxRetries     = 3
+	defaultInitialBackoff = 250 * time.Millisecond
+	defaultMaxBackoff     = 2 * time.Second
+
+	// DefaultRerankModel is Cohere's current GA cross-encoder rerank
+	// model. Callers may override via Client.DefaultModel or the
+	// modelName argument to Rerank.
+	DefaultRerankModel = "rerank-v3.5"
+)
+
+// Client is a Cohere Rerank API adapter.
+//
+// Error codes (carried on *model.ProviderError):
+//   - COHERE_AUTH (non-retryable): 401/403
+//   - COHERE_RATE_LIMIT (retryable): 429
+//   - COHERE_FAILED (retryable for network/5xx, else non-retryable)
+type Client struct {
+	BaseURL        string
+	APIKey         string
+	HTTPClient     *http.Client
+	MaxRetries     int
+	InitialBackoff time.Duration
+	MaxBackoff     time.Duration
+	// DefaultModel is used when Rerank is called with an empty modelName.
+	DefaultModel string
+}
+
+// compile-time assertion that *Client implements model.Reranker.
+var _ model.Reranker = (*Client)(nil)
+
+// NewClient constructs a client with safe default retry/timeout settings.
+func NewClient(baseURL, apiKey string) *Client {
+	baseURL = strings.TrimSpace(baseURL)
+	apiKey = strings.TrimSpace(apiKey)
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+	return &Client{
+		BaseURL:        strings.TrimRight(baseURL, "/"),
+		APIKey:         apiKey,
+		HTTPClient:     &http.Client{Timeout: defaultRequestTimeout},
+		MaxRetries:     defaultMaxRetries,
+		InitialBackoff: defaultInitialBackoff,
+		MaxBackoff:     defaultMaxBackoff,
+		DefaultModel:   DefaultRerankModel,
+	}
+}
+
+type rerankRequest struct {
+	Model     string   `json:"model"`
+	Query     string   `json:"query"`
+	Documents []string `json:"documents"`
+	TopN      int      `json:"top_n,omitempty"`
+}
+
+type rerankResponse struct {
+	Results []struct {
+		Index          int     `json:"index"`
+		RelevanceScore float64 `json:"relevance_score"`
+	} `json:"results"`
+}
+
+// Rerank re-scores documents against query using Cohere's /v2/rerank
+// endpoint and returns results ordered best-first. topN <= 0 requests
+// all documents back. An empty documents slice short-circuits to an
+// empty result without an API call.
+func (c *Client) Rerank(ctx context.Context, modelName, query string, documents []string, topN int) ([]model.Reranked, error) {
+	if len(documents) == 0 {
+		return nil, nil
+	}
+	if strings.TrimSpace(c.APIKey) == "" {
+		return nil, &model.ProviderError{Code: "COHERE_AUTH", Message: "missing Cohere API key", Retryable: false}
+	}
+	if strings.TrimSpace(modelName) == "" {
+		modelName = c.DefaultModel
+		if modelName == "" {
+			modelName = DefaultRerankModel
+		}
+	}
+
+	maxRetries := c.MaxRetries
+	if maxRetries < 0 {
+		maxRetries = 0
+	}
+	var lastErr error
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		if attempt > 0 {
+			if err := c.wait(ctx, c.backoffForAttempt(attempt-1)); err != nil {
+				return nil, err
+			}
+		}
+		results, err := c.rerankOnce(ctx, modelName, query, documents, topN)
+		if err == nil {
+			return results, nil
+		}
+		lastErr = err
+		var pErr *model.ProviderError
+		if errors.As(err, &pErr) && !pErr.Retryable {
+			return nil, err
+		}
+	}
+	return nil, lastErr
+}
+
+func (c *Client) rerankOnce(ctx context.Context, modelName, query string, documents []string, topN int) ([]model.Reranked, error) {
+	payload := rerankRequest{Model: modelName, Query: query, Documents: documents}
+	if topN > 0 {
+		payload.TopN = topN
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, &model.ProviderError{Code: "COHERE_FAILED", Message: "failed to marshal rerank request", Retryable: false, Cause: err}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+"/v2/rerank", bytes.NewReader(body))
+	if err != nil {
+		return nil, &model.ProviderError{Code: "COHERE_FAILED", Message: "failed to build rerank request", Retryable: false, Cause: err}
+	}
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	client := c.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: defaultRequestTimeout}
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, &model.ProviderError{Code: "COHERE_FAILED", Message: "rerank request failed", Retryable: true, Cause: err}
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, cohereHTTPError(resp)
+	}
+
+	var parsed rerankResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil, &model.ProviderError{Code: "COHERE_FAILED", Message: "failed to decode rerank response", Retryable: false, StatusCode: resp.StatusCode, Cause: err}
+	}
+
+	out := make([]model.Reranked, 0, len(parsed.Results))
+	for _, r := range parsed.Results {
+		if r.Index < 0 || r.Index >= len(documents) {
+			return nil, &model.ProviderError{Code: "COHERE_FAILED", Message: fmt.Sprintf("rerank response contains out-of-range index %d", r.Index), Retryable: false, StatusCode: resp.StatusCode}
+		}
+		out = append(out, model.Reranked{Index: r.Index, RelevanceScore: r.RelevanceScore})
+	}
+	return out, nil
+}
+
+func cohereHTTPError(resp *http.Response) error {
+	bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	msg := strings.TrimSpace(string(bodyBytes))
+	if msg == "" {
+		msg = "upstream returned non-200 response"
+	}
+	switch {
+	case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
+		return &model.ProviderError{Code: "COHERE_AUTH", Message: msg, Retryable: false, StatusCode: resp.StatusCode}
+	case resp.StatusCode == http.StatusTooManyRequests:
+		return &model.ProviderError{Code: "COHERE_RATE_LIMIT", Message: msg, Retryable: true, StatusCode: resp.StatusCode}
+	case resp.StatusCode >= http.StatusInternalServerError:
+		return &model.ProviderError{Code: "COHERE_FAILED", Message: msg, Retryable: true, StatusCode: resp.StatusCode}
+	default:
+		return &model.ProviderError{Code: "COHERE_FAILED", Message: msg, Retryable: false, StatusCode: resp.StatusCode}
+	}
+}
+
+func (c *Client) backoffForAttempt(attempt int) time.Duration {
+	initial := c.InitialBackoff
+	if initial <= 0 {
+		initial = defaultInitialBackoff
+	}
+	maxBackoff := c.MaxBackoff
+	if maxBackoff <= 0 {
+		maxBackoff = defaultMaxBackoff
+	}
+	backoff := initial
+	for i := 0; i < attempt; i++ {
+		backoff *= 2
+		if backoff >= maxBackoff {
+			return maxBackoff
+		}
+	}
+	return backoff
+}
+
+func (c *Client) wait(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -131,9 +131,13 @@ type Config struct {
 	// credential is present; *false = force off even with a credential;
 	// *true = require it, warn+fail-open if no credential). Resolve the
 	// effective decision via rerankEnabledEffective / configureReranker.
-	RerankEnabled         *bool
-	RerankProvider        string
-	CohereAPIKey          string
+	RerankEnabled  *bool
+	RerankProvider string
+	CohereAPIKey   string
+	// CohereBaseURL overrides the Cohere API endpoint (self-hosted /
+	// proxied deployments and tests). Empty = provider default. Not a
+	// secret; persisted like MistralBaseURL.
+	CohereBaseURL         string
 	RerankModel           string
 	RerankCandidatePool   int
 	ChunkingStrategy      string
@@ -206,6 +210,7 @@ type fileConfig struct {
 	RerankEnabled             *bool
 	RerankProvider            *string
 	CohereAPIKey              *string
+	CohereBaseURL             *string
 	RerankModel               *string
 	RerankCandidatePool       *int
 	ChunkingStrategy          *string
@@ -281,6 +286,7 @@ type persistedConfig struct {
 	RetrievalHybridEnabled    bool     `yaml:"retrieval_hybrid_enabled"`
 	RerankEnabled             bool     `yaml:"rerank_enabled"`
 	RerankProvider            string   `yaml:"rerank_provider"`
+	CohereBaseURL             string   `yaml:"cohere_base_url"`
 	RerankModel               string   `yaml:"rerank_model"`
 	RerankCandidatePool       int      `yaml:"rerank_candidate_pool"`
 	ChunkingStrategy          string   `yaml:"chunking_strategy"`
@@ -381,6 +387,7 @@ func Default() Config {
 		// provider credential is present). See rerankEnabledEffective.
 		RerankProvider:            "cohere",
 		CohereAPIKey:              "",
+		CohereBaseURL:             "",
 		RerankModel:               "rerank-v3.5",
 		RerankCandidatePool:       50,
 		ChunkingStrategy:          "",
@@ -464,6 +471,7 @@ func buildPersistedConfig(cfg *Config) persistedConfig {
 		RetrievalHybridEnabled:    cfg.RetrievalHybridEnabled,
 		RerankEnabled:             rerankEnabledEffective(cfg),
 		RerankProvider:            cfg.RerankProvider,
+		CohereBaseURL:             cfg.CohereBaseURL,
 		RerankModel:               cfg.RerankModel,
 		RerankCandidatePool:       cfg.RerankCandidatePool,
 		ChunkingStrategy:          cfg.ChunkingStrategy,
@@ -818,8 +826,8 @@ func rerankEnabledEffective(cfg *Config) bool {
 }
 
 // applyRerankFileParsed copies parsed rerank.* file values onto cfg.
-// Split out of applyModelClientsFileParsed to keep that function under
-// the gocyclo budget.
+// Split out of applyModelFileParsed (its only caller) to keep that
+// function under the gocyclo budget.
 func applyRerankFileParsed(cfg *Config, fc fileConfig) {
 	if fc.RerankEnabled != nil {
 		cfg.RerankEnabled = boolPtr(*fc.RerankEnabled)
@@ -829,6 +837,9 @@ func applyRerankFileParsed(cfg *Config, fc fileConfig) {
 	}
 	if fc.CohereAPIKey != nil {
 		cfg.CohereAPIKey = *fc.CohereAPIKey
+	}
+	if fc.CohereBaseURL != nil {
+		cfg.CohereBaseURL = *fc.CohereBaseURL
 	}
 	if fc.RerankModel != nil {
 		cfg.RerankModel = *fc.RerankModel
@@ -1179,6 +1190,7 @@ var configKeyAliases = map[string]string{
 	"hybrid_enabled":                       "retrieval.hybrid.enabled",
 	"rerank_enabled":                       "rerank.enabled",
 	"rerank.cohere.api_key":                "cohere_api_key",
+	"rerank.cohere.base_url":               "cohere_base_url",
 	"rerank.cohere.model":                  "rerank_model",
 	"rerank.provider":                      "rerank_provider",
 	"rerank.model":                         "rerank_model",
@@ -1377,7 +1389,29 @@ func setServerStringFileScalar(cfg *fileConfig, key, value string) {
 	}
 }
 
+// setRerankStringFileScalar handles rerank.* string scalars. Split out
+// of setModelStringFileScalar to keep that function under the gocyclo
+// budget. Reports whether key was a rerank scalar.
+func setRerankStringFileScalar(cfg *fileConfig, key, value string) bool {
+	switch key {
+	case "rerank_provider":
+		cfg.RerankProvider = strPtr(value)
+	case "cohere_api_key":
+		cfg.CohereAPIKey = strPtr(value)
+	case "cohere_base_url":
+		cfg.CohereBaseURL = strPtr(value)
+	case "rerank_model":
+		cfg.RerankModel = strPtr(value)
+	default:
+		return false
+	}
+	return true
+}
+
 func setModelStringFileScalar(cfg *fileConfig, key, value string) {
+	if setRerankStringFileScalar(cfg, key, value) {
+		return
+	}
 	switch key {
 	case "mistral_base_url":
 		cfg.MistralBaseURL = strPtr(value)
@@ -1387,12 +1421,6 @@ func setModelStringFileScalar(cfg *fileConfig, key, value string) {
 		cfg.ElevenLabsBaseURL = strPtr(value)
 	case "elevenlabs_api_key":
 		cfg.ElevenLabsAPIKey = strPtr(value)
-	case "rerank_provider":
-		cfg.RerankProvider = strPtr(value)
-	case "cohere_api_key":
-		cfg.CohereAPIKey = strPtr(value)
-	case "rerank_model":
-		cfg.RerankModel = strPtr(value)
 	case "elevenlabs_tts_voice_id":
 		cfg.ElevenLabsTTSVoiceID = strPtr(value)
 	case "embed_model_text":
@@ -1553,6 +1581,7 @@ func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	writeBool("retrieval_hybrid_enabled", cfg.RetrievalHybridEnabled)
 	writeBool("rerank_enabled", cfg.RerankEnabled)
 	writeScalar("rerank_provider", cfg.RerankProvider)
+	writeScalar("cohere_base_url", cfg.CohereBaseURL)
 	writeScalar("rerank_model", cfg.RerankModel)
 	writeInt("rerank_candidate_pool", cfg.RerankCandidatePool)
 	writeScalar("chunking_strategy", cfg.ChunkingStrategy)
@@ -1631,6 +1660,9 @@ func applyEnvOverrides(cfg *Config, overrideEnv map[string]string) {
 func applyRerankEnvOverrides(cfg *Config, env map[string]string) {
 	if v, ok := envLookup("COHERE_API_KEY", env); ok && strings.TrimSpace(v) != "" {
 		cfg.CohereAPIKey = v
+	}
+	if v, ok := envLookup("COHERE_BASE_URL", env); ok && strings.TrimSpace(v) != "" {
+		cfg.CohereBaseURL = strings.TrimSpace(v)
 	}
 	if v, ok := envLookup("DIR2MCP_RERANK_ENABLED", env); ok && strings.TrimSpace(v) != "" {
 		if b, err := strconv.ParseBool(strings.TrimSpace(v)); err == nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,7 @@ const EffectiveConfigSnapshotFile = ".dir2mcp.yaml.snapshot"
 type SecretSourceMetadata struct {
 	MistralAPIKey        string
 	ElevenLabsAPIKey     string
+	CohereAPIKey         string
 	X402FacilitatorToken string
 	AuthToken            string
 }
@@ -120,9 +121,17 @@ type Config struct {
 	// is true for new deployments; existing indexes auto-backfill the FTS
 	// table on first start.
 	RetrievalHybridEnabled bool
-	ChunkingStrategy       string
-	ChunkingMaxTokens      int
-	ChunkingOverlapTokens  int
+	// Rerank* configure the optional post-fusion rerank stage (SPEC
+	// 9.1.1). Off by default. CohereAPIKey is a secret: env-sourced,
+	// never persisted to the config snapshot (mirrors MistralAPIKey).
+	RerankEnabled         bool
+	RerankProvider        string
+	CohereAPIKey          string
+	RerankModel           string
+	RerankCandidatePool   int
+	ChunkingStrategy      string
+	ChunkingMaxTokens     int
+	ChunkingOverlapTokens int
 
 	IngestGitignore      bool
 	IngestFollowSymlinks bool
@@ -187,6 +196,11 @@ type fileConfig struct {
 	RAGMaxContextChars        *int
 	RAGOversampleFactor       *int
 	RetrievalHybridEnabled    *bool
+	RerankEnabled             *bool
+	RerankProvider            *string
+	CohereAPIKey              *string
+	RerankModel               *string
+	RerankCandidatePool       *int
 	ChunkingStrategy          *string
 	ChunkingMaxTokens         *int
 	ChunkingOverlapTokens     *int
@@ -258,6 +272,10 @@ type persistedConfig struct {
 	RAGMaxContextChars        int      `yaml:"rag_max_context_chars"`
 	RAGOversampleFactor       int      `yaml:"rag_oversample_factor"`
 	RetrievalHybridEnabled    bool     `yaml:"retrieval_hybrid_enabled"`
+	RerankEnabled             bool     `yaml:"rerank_enabled"`
+	RerankProvider            string   `yaml:"rerank_provider"`
+	RerankModel               string   `yaml:"rerank_model"`
+	RerankCandidatePool       int      `yaml:"rerank_candidate_pool"`
 	ChunkingStrategy          string   `yaml:"chunking_strategy"`
 	ChunkingMaxTokens         int      `yaml:"chunking_max_tokens"`
 	ChunkingOverlapTokens     int      `yaml:"chunking_overlap_tokens"`
@@ -352,6 +370,11 @@ func Default() Config {
 		RAGMaxContextChars:        20000,
 		RAGOversampleFactor:       5,
 		RetrievalHybridEnabled:    true,
+		RerankEnabled:             false,
+		RerankProvider:            "cohere",
+		CohereAPIKey:              "",
+		RerankModel:               "rerank-v3.5",
+		RerankCandidatePool:       50,
 		ChunkingStrategy:          "",
 		ChunkingMaxTokens:         0,
 		ChunkingOverlapTokens:     0,
@@ -431,6 +454,10 @@ func buildPersistedConfig(cfg *Config) persistedConfig {
 		RAGMaxContextChars:        cfg.RAGMaxContextChars,
 		RAGOversampleFactor:       cfg.RAGOversampleFactor,
 		RetrievalHybridEnabled:    cfg.RetrievalHybridEnabled,
+		RerankEnabled:             cfg.RerankEnabled,
+		RerankProvider:            cfg.RerankProvider,
+		RerankModel:               cfg.RerankModel,
+		RerankCandidatePool:       cfg.RerankCandidatePool,
 		ChunkingStrategy:          cfg.ChunkingStrategy,
 		ChunkingMaxTokens:         cfg.ChunkingMaxTokens,
 		ChunkingOverlapTokens:     cfg.ChunkingOverlapTokens,
@@ -560,6 +587,7 @@ func appendSnapshotSecretSourceMetadata(raw []byte, sources SecretSourceMetadata
 	}{
 		{key: "mistral_api_key", value: strings.TrimSpace(sources.MistralAPIKey)},
 		{key: "elevenlabs_api_key", value: strings.TrimSpace(sources.ElevenLabsAPIKey)},
+		{key: "cohere_api_key", value: strings.TrimSpace(sources.CohereAPIKey)},
 		{key: "x402_facilitator_token", value: strings.TrimSpace(sources.X402FacilitatorToken)},
 		{key: "auth_token", value: strings.TrimSpace(sources.AuthToken)},
 	}
@@ -622,6 +650,8 @@ func applySecretSourceField(meta *SecretSourceMetadata, key, value string) {
 		meta.MistralAPIKey = value
 	case "secret_sources.elevenlabs_api_key":
 		meta.ElevenLabsAPIKey = value
+	case "secret_sources.cohere_api_key":
+		meta.CohereAPIKey = value
 	case "secret_sources.x402_facilitator_token":
 		meta.X402FacilitatorToken = value
 	case "secret_sources.auth_token":
@@ -762,7 +792,29 @@ func applyServerNetworkFileParsed(cfg *Config, fc fileConfig) {
 
 func applyModelFileParsed(cfg *Config, fc fileConfig) {
 	applyModelClientsFileParsed(cfg, fc)
+	applyRerankFileParsed(cfg, fc)
 	applyModelRAGFileParsed(cfg, fc)
+}
+
+// applyRerankFileParsed copies parsed rerank.* file values onto cfg.
+// Split out of applyModelClientsFileParsed to keep that function under
+// the gocyclo budget.
+func applyRerankFileParsed(cfg *Config, fc fileConfig) {
+	if fc.RerankEnabled != nil {
+		cfg.RerankEnabled = *fc.RerankEnabled
+	}
+	if fc.RerankProvider != nil {
+		cfg.RerankProvider = *fc.RerankProvider
+	}
+	if fc.CohereAPIKey != nil {
+		cfg.CohereAPIKey = *fc.CohereAPIKey
+	}
+	if fc.RerankModel != nil {
+		cfg.RerankModel = *fc.RerankModel
+	}
+	if fc.RerankCandidatePool != nil {
+		cfg.RerankCandidatePool = *fc.RerankCandidatePool
+	}
 }
 
 func applyModelClientsFileParsed(cfg *Config, fc fileConfig) {
@@ -1104,6 +1156,12 @@ var configKeyAliases = map[string]string{
 	"oversample_factor":                    "rag.oversample_factor",
 	"retrieval_hybrid_enabled":             "retrieval.hybrid.enabled",
 	"hybrid_enabled":                       "retrieval.hybrid.enabled",
+	"rerank_enabled":                       "rerank.enabled",
+	"rerank.cohere.api_key":                "cohere_api_key",
+	"rerank.cohere.model":                  "rerank_model",
+	"rerank.provider":                      "rerank_provider",
+	"rerank.model":                         "rerank_model",
+	"rerank_candidate_pool":                "rerank.candidate_pool",
 	"chunking_strategy":                    "chunking.strategy",
 	"chunking_max_tokens":                  "chunking.max_tokens",
 	"chunking_overlap_tokens":              "chunking.overlap_tokens",
@@ -1158,7 +1216,7 @@ func canonicalizeConfigKey(key string) string {
 
 func isMapSectionKey(key string) bool {
 	switch key {
-	case "rag", "ingest", "ingest.docling", "stt", "stt.mistral", "stt.elevenlabs", "server", "server.tls", "secret_sources", "mistral", "docling", "security", "security.auth", "x402", "x402.route_policy", "x402.route_policy.tools_call", "chunking", "retrieval", "retrieval.hybrid":
+	case "rag", "ingest", "ingest.docling", "stt", "stt.mistral", "stt.elevenlabs", "server", "server.tls", "secret_sources", "mistral", "docling", "security", "security.auth", "x402", "x402.route_policy", "x402.route_policy.tools_call", "chunking", "retrieval", "retrieval.hybrid", "rerank", "rerank.cohere":
 		return true
 	case "ingest.pdf", "ingest.images", "ingest.audio", "ingest.archives", "secrets":
 		return true
@@ -1198,6 +1256,8 @@ func setBoolFileScalar(cfg *fileConfig, key, value string) error {
 		target = &cfg.X402ToolsCallEnabled
 	case "retrieval.hybrid.enabled":
 		target = &cfg.RetrievalHybridEnabled
+	case "rerank.enabled":
+		target = &cfg.RerankEnabled
 	default:
 		return nil
 	}
@@ -1230,6 +1290,8 @@ func setIntFileScalar(cfg *fileConfig, key, value string) error {
 		target = &cfg.IngestMaxFileMB
 	case "mistral_max_ocr_payload_bytes":
 		target = &cfg.MistralMaxOCRPayloadBytes
+	case "rerank.candidate_pool":
+		target = &cfg.RerankCandidatePool
 	default:
 		return nil
 	}
@@ -1304,6 +1366,12 @@ func setModelStringFileScalar(cfg *fileConfig, key, value string) {
 		cfg.ElevenLabsBaseURL = strPtr(value)
 	case "elevenlabs_api_key":
 		cfg.ElevenLabsAPIKey = strPtr(value)
+	case "rerank_provider":
+		cfg.RerankProvider = strPtr(value)
+	case "cohere_api_key":
+		cfg.CohereAPIKey = strPtr(value)
+	case "rerank_model":
+		cfg.RerankModel = strPtr(value)
 	case "elevenlabs_tts_voice_id":
 		cfg.ElevenLabsTTSVoiceID = strPtr(value)
 	case "embed_model_text":
@@ -1462,6 +1530,10 @@ func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	writeInt("rag_max_context_chars", cfg.RAGMaxContextChars)
 	writeInt("rag_oversample_factor", cfg.RAGOversampleFactor)
 	writeBool("retrieval_hybrid_enabled", cfg.RetrievalHybridEnabled)
+	writeBool("rerank_enabled", cfg.RerankEnabled)
+	writeScalar("rerank_provider", cfg.RerankProvider)
+	writeScalar("rerank_model", cfg.RerankModel)
+	writeInt("rerank_candidate_pool", cfg.RerankCandidatePool)
 	writeScalar("chunking_strategy", cfg.ChunkingStrategy)
 	writeInt("chunking_max_tokens", cfg.ChunkingMaxTokens)
 	writeInt("chunking_overlap_tokens", cfg.ChunkingOverlapTokens)
@@ -1525,9 +1597,28 @@ func applyEnvOverrides(cfg *Config, overrideEnv map[string]string) {
 	}
 	applyMistralEnvOverrides(cfg, overrideEnv)
 	applyElevenLabsEnvOverrides(cfg, overrideEnv)
+	applyRerankEnvOverrides(cfg, overrideEnv)
 	applyNetworkEnvOverrides(cfg, overrideEnv)
 	applySessionEnvOverrides(cfg, overrideEnv)
 	applyX402EnvOverrides(cfg, overrideEnv)
+}
+
+// applyRerankEnvOverrides sources the Cohere key (secret) and
+// optional rerank toggles from the environment. COHERE_API_KEY
+// follows the same env-wins-if-nonempty rule as MISTRAL_API_KEY and
+// is never persisted.
+func applyRerankEnvOverrides(cfg *Config, env map[string]string) {
+	if v, ok := envLookup("COHERE_API_KEY", env); ok && strings.TrimSpace(v) != "" {
+		cfg.CohereAPIKey = v
+	}
+	if v, ok := envLookup("DIR2MCP_RERANK_ENABLED", env); ok && strings.TrimSpace(v) != "" {
+		if b, err := strconv.ParseBool(strings.TrimSpace(v)); err == nil {
+			cfg.RerankEnabled = b
+		}
+	}
+	if v, ok := envLookup("DIR2MCP_RERANK_MODEL", env); ok && strings.TrimSpace(v) != "" {
+		cfg.RerankModel = strings.TrimSpace(v)
+	}
 }
 
 func applyMistralEnvOverrides(cfg *Config, env map[string]string) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -122,9 +122,16 @@ type Config struct {
 	// table on first start.
 	RetrievalHybridEnabled bool
 	// Rerank* configure the optional post-fusion rerank stage (SPEC
-	// 9.1.1). Off by default. CohereAPIKey is a secret: env-sourced,
-	// never persisted to the config snapshot (mirrors MistralAPIKey).
-	RerankEnabled         bool
+	// 9.1.1). Reranking auto-activates when a provider credential is
+	// present (mirrors how MistralAPIKey gates embedding/OCR).
+	// CohereAPIKey is a secret: env-sourced, never persisted to the
+	// config snapshot (mirrors MistralAPIKey).
+	//
+	// RerankEnabled is a tri-state override (nil = auto: on iff a
+	// credential is present; *false = force off even with a credential;
+	// *true = require it, warn+fail-open if no credential). Resolve the
+	// effective decision via rerankEnabledEffective / configureReranker.
+	RerankEnabled         *bool
 	RerankProvider        string
 	CohereAPIKey          string
 	RerankModel           string
@@ -361,16 +368,17 @@ func Default() Config {
 			"http://127.0.0.1",
 		},
 		// default embedding models
-		EmbedModelText:            "mistral-embed",
-		EmbedModelCode:            "codestral-embed",
-		ChatModel:                 mistral.DefaultChatModel,
-		RAGSystemPrompt:           "",
-		RAGGenerateAnswer:         true,
-		RAGKDefault:               10,
-		RAGMaxContextChars:        20000,
-		RAGOversampleFactor:       5,
-		RetrievalHybridEnabled:    true,
-		RerankEnabled:             false,
+		EmbedModelText:         "mistral-embed",
+		EmbedModelCode:         "codestral-embed",
+		ChatModel:              mistral.DefaultChatModel,
+		RAGSystemPrompt:        "",
+		RAGGenerateAnswer:      true,
+		RAGKDefault:            10,
+		RAGMaxContextChars:     20000,
+		RAGOversampleFactor:    5,
+		RetrievalHybridEnabled: true,
+		// RerankEnabled left nil: auto mode (activates iff a rerank
+		// provider credential is present). See rerankEnabledEffective.
 		RerankProvider:            "cohere",
 		CohereAPIKey:              "",
 		RerankModel:               "rerank-v3.5",
@@ -454,7 +462,7 @@ func buildPersistedConfig(cfg *Config) persistedConfig {
 		RAGMaxContextChars:        cfg.RAGMaxContextChars,
 		RAGOversampleFactor:       cfg.RAGOversampleFactor,
 		RetrievalHybridEnabled:    cfg.RetrievalHybridEnabled,
-		RerankEnabled:             cfg.RerankEnabled,
+		RerankEnabled:             rerankEnabledEffective(cfg),
 		RerankProvider:            cfg.RerankProvider,
 		RerankModel:               cfg.RerankModel,
 		RerankCandidatePool:       cfg.RerankCandidatePool,
@@ -796,12 +804,25 @@ func applyModelFileParsed(cfg *Config, fc fileConfig) {
 	applyModelRAGFileParsed(cfg, fc)
 }
 
+// rerankEnabledEffective resolves the tri-state RerankEnabled override
+// into the effective on/off decision used for the persisted snapshot:
+// an explicit value wins; when unset (nil), reranking is on iff a
+// rerank provider credential is present. Runtime activation in
+// configureReranker applies the same rule plus provider validation and
+// the explicit-true-but-no-credential warning.
+func rerankEnabledEffective(cfg *Config) bool {
+	if cfg.RerankEnabled != nil {
+		return *cfg.RerankEnabled
+	}
+	return strings.TrimSpace(cfg.CohereAPIKey) != ""
+}
+
 // applyRerankFileParsed copies parsed rerank.* file values onto cfg.
 // Split out of applyModelClientsFileParsed to keep that function under
 // the gocyclo budget.
 func applyRerankFileParsed(cfg *Config, fc fileConfig) {
 	if fc.RerankEnabled != nil {
-		cfg.RerankEnabled = *fc.RerankEnabled
+		cfg.RerankEnabled = boolPtr(*fc.RerankEnabled)
 	}
 	if fc.RerankProvider != nil {
 		cfg.RerankProvider = *fc.RerankProvider
@@ -1613,7 +1634,7 @@ func applyRerankEnvOverrides(cfg *Config, env map[string]string) {
 	}
 	if v, ok := envLookup("DIR2MCP_RERANK_ENABLED", env); ok && strings.TrimSpace(v) != "" {
 		if b, err := strconv.ParseBool(strings.TrimSpace(v)); err == nil {
-			cfg.RerankEnabled = b
+			cfg.RerankEnabled = boolPtr(b)
 		}
 	}
 	if v, ok := envLookup("DIR2MCP_RERANK_MODEL", env); ok && strings.TrimSpace(v) != "" {

--- a/internal/model/interfaces.go
+++ b/internal/model/interfaces.go
@@ -73,6 +73,22 @@ type Generator interface {
 	Generate(ctx context.Context, prompt string) (string, error)
 }
 
+// Reranked is one rescored candidate: Index is the position in the
+// documents slice passed to Rerank; RelevanceScore is the provider's
+// relevance (higher = better). Results are returned best-first.
+type Reranked struct {
+	Index          int
+	RelevanceScore float64
+}
+
+// Reranker re-scores documents against a query (e.g. a cross-encoder
+// rerank API). Retrieval is fail-open: callers treat any error as
+// "skip rerank, keep the pre-rerank order". An empty documents slice
+// yields (nil, nil) with no provider call.
+type Reranker interface {
+	Rerank(ctx context.Context, model, query string, documents []string, topN int) ([]Reranked, error)
+}
+
 // RepresentationStore defines the subset of store operations used by the
 // ingest package for handling representations and their chunks.  It is
 // defined here in the model package to avoid cyclic dependencies between the

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -169,17 +169,18 @@ func (s *Service) SetHybridEnabled(enabled bool) {
 
 // SetReranker wires an optional rerank provider. modelName is the
 // provider model (empty = provider default); pool caps how many fused
-// candidates are re-scored (<=0 uses the default). Mirrors how the
+// candidates are re-scored. pool <= 0 keeps the currently-configured
+// value (default-initialized in NewService) so callers can swap the
+// reranker without resetting an operator-tuned pool. Mirrors how the
 // engine wires SetHybridEnabled from config.
 func (s *Service) SetReranker(r model.Reranker, modelName string, pool int) {
 	s.metaMu.Lock()
 	defer s.metaMu.Unlock()
 	s.reranker = r
 	s.rerankModel = strings.TrimSpace(modelName)
-	if pool <= 0 {
-		pool = defaultRerankCandidatePool
+	if pool > 0 {
+		s.rerankCandidatePool = pool
 	}
-	s.rerankCandidatePool = pool
 }
 
 // SetRerankEnabled toggles the optional rerank stage. The engine wires
@@ -1180,11 +1181,18 @@ func (s *Service) rerankPool(ctx context.Context, query string, hits []model.Sea
 	if pool <= 0 {
 		pool = defaultRerankCandidatePool
 	}
-	if len(hits) > pool {
-		hits = hits[:pool]
+	// fused keeps the full pre-rerank order for fail-open fallback;
+	// cand is the (capped) slice actually sent to the provider. Never
+	// shrink the fallback to the pool: a misconfigured pool < k must
+	// still return up to k results on a rerank failure (and on success
+	// the un-reranked tail is appended below).
+	fused := hits
+	cand := fused
+	if len(cand) > pool {
+		cand = cand[:pool]
 	}
-	docs := make([]string, len(hits))
-	for i, h := range hits {
+	docs := make([]string, len(cand))
+	for i, h := range cand {
 		docs[i] = h.Snippet
 	}
 	results, err := rr.Rerank(ctx, rmodel, query, docs, k)
@@ -1192,15 +1200,15 @@ func (s *Service) rerankPool(ctx context.Context, query string, hits []model.Sea
 		if err != nil {
 			s.logf("rerank: provider error, falling back to fused order: %v", err)
 		}
-		return truncateSearchHits(hits, k)
+		return truncateSearchHits(fused, k)
 	}
-	out := make([]model.SearchHit, 0, len(results))
+	out := make([]model.SearchHit, 0, len(fused))
 	for _, r := range results {
-		if r.Index < 0 || r.Index >= len(hits) {
+		if r.Index < 0 || r.Index >= len(cand) {
 			s.logf("rerank: out-of-range index %d, falling back to fused order", r.Index)
-			return truncateSearchHits(hits, k)
+			return truncateSearchHits(fused, k)
 		}
-		h := hits[r.Index]
+		h := cand[r.Index]
 		h.Score = r.RelevanceScore
 		out = append(out, h)
 	}
@@ -1210,6 +1218,11 @@ func (s *Service) rerankPool(ctx context.Context, query string, hits []model.Sea
 		}
 		return out[i].ChunkID < out[j].ChunkID
 	})
+	// Preserve fused candidates beyond the reranked pool so rerank only
+	// reorders and never returns fewer than k when more were available.
+	if len(fused) > len(cand) {
+		out = append(out, fused[len(cand):]...)
+	}
 	return truncateSearchHits(out, k)
 }
 

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -106,6 +106,13 @@ type Service struct {
 	// true; the engine can disable it via SetHybridEnabled when the operator
 	// sets retrieval.hybrid.enabled=false.
 	hybridEnabled bool
+	// reranker, when set and rerankEnabled, re-scores the fused candidate
+	// pool before truncation to k (see SPEC 9.1.1). Fail-open: any error
+	// falls back to the pre-rerank order.
+	reranker            model.Reranker
+	rerankEnabled       bool
+	rerankModel         string
+	rerankCandidatePool int
 }
 
 // compile-time assertion that Service implements model.Retriever.  This
@@ -141,13 +148,14 @@ func NewService(store model.Store, index model.Index, embedder model.Embedder, g
 			"text": make(map[uint64]model.SearchHit),
 			"code": make(map[uint64]model.SearchHit),
 		},
-		rootDir:         ".",
-		stateDir:        filepath.Join(".", ".dir2mcp"),
-		protocolVersion: "2025-11-25",
-		excludeRegexps:  make(map[string]*regexp.Regexp),
-		pathExcludes:    append([]string(nil), defaultPathExcludes...),
-		secretPatterns:  compiledPatterns,
-		hybridEnabled:   true,
+		rootDir:             ".",
+		stateDir:            filepath.Join(".", ".dir2mcp"),
+		protocolVersion:     "2025-11-25",
+		excludeRegexps:      make(map[string]*regexp.Regexp),
+		pathExcludes:        append([]string(nil), defaultPathExcludes...),
+		secretPatterns:      compiledPatterns,
+		hybridEnabled:       true,
+		rerankCandidatePool: defaultRerankCandidatePool,
 	}
 }
 
@@ -157,6 +165,29 @@ func (s *Service) SetHybridEnabled(enabled bool) {
 	s.metaMu.Lock()
 	defer s.metaMu.Unlock()
 	s.hybridEnabled = enabled
+}
+
+// SetReranker wires an optional rerank provider. modelName is the
+// provider model (empty = provider default); pool caps how many fused
+// candidates are re-scored (<=0 uses the default). Mirrors how the
+// engine wires SetHybridEnabled from config.
+func (s *Service) SetReranker(r model.Reranker, modelName string, pool int) {
+	s.metaMu.Lock()
+	defer s.metaMu.Unlock()
+	s.reranker = r
+	s.rerankModel = strings.TrimSpace(modelName)
+	if pool <= 0 {
+		pool = defaultRerankCandidatePool
+	}
+	s.rerankCandidatePool = pool
+}
+
+// SetRerankEnabled toggles the optional rerank stage. The engine wires
+// this from config.RerankEnabled at construction time.
+func (s *Service) SetRerankEnabled(enabled bool) {
+	s.metaMu.Lock()
+	defer s.metaMu.Unlock()
+	s.rerankEnabled = enabled
 }
 
 func (s *Service) SetLogger(l *log.Logger) {
@@ -457,18 +488,18 @@ func (s *Service) Search(ctx context.Context, query model.SearchQuery) ([]model.
 	}
 	switch mode {
 	case "text":
-		return s.searchSingleIndex(ctx, query.Query, k, textModel, textIndex, "text", query)
+		return s.searchSingleIndex(ctx, query.Query, k, textModel, textIndex, "text", query, true)
 	case "code":
-		return s.searchSingleIndex(ctx, query.Query, k, codeModel, codeIndex, "code", query)
+		return s.searchSingleIndex(ctx, query.Query, k, codeModel, codeIndex, "code", query, true)
 	case "both":
 		return s.searchBothIndices(ctx, query.Query, k, textModel, codeModel, textIndex, codeIndex, query)
 	case "auto":
 		if looksLikeCodeQuery(query.Query) {
-			return s.searchSingleIndex(ctx, query.Query, k, codeModel, codeIndex, "code", query)
+			return s.searchSingleIndex(ctx, query.Query, k, codeModel, codeIndex, "code", query, true)
 		}
-		return s.searchSingleIndex(ctx, query.Query, k, textModel, textIndex, "text", query)
+		return s.searchSingleIndex(ctx, query.Query, k, textModel, textIndex, "text", query, true)
 	default:
-		return s.searchSingleIndex(ctx, query.Query, k, textModel, textIndex, "text", query)
+		return s.searchSingleIndex(ctx, query.Query, k, textModel, textIndex, "text", query, true)
 	}
 }
 
@@ -1057,13 +1088,18 @@ func (s *Service) searchHitForLabel(indexName string, label uint64) model.Search
 	}
 }
 
+// defaultRerankCandidatePool bounds how many fused candidates are sent
+// to the rerank provider before truncation to k. 50 matches the
+// hybrid candidate pool and keeps latency/cost predictable.
+const defaultRerankCandidatePool = 50
+
 // ErrMissingEmbedder is returned when the service was created without
 // a configured embedder and a search attempt is made. This prevents a
 // nil-pointer panic in searchSingleIndex while giving callers a clear
 // failure reason.
 var ErrMissingEmbedder = errors.New("embedder not configured")
 
-func (s *Service) searchSingleIndex(ctx context.Context, query string, k int, modelName string, idx model.Index, indexName string, filters model.SearchQuery) ([]model.SearchHit, error) {
+func (s *Service) searchSingleIndex(ctx context.Context, query string, k int, modelName string, idx model.Index, indexName string, filters model.SearchQuery, allowRerank bool) ([]model.SearchHit, error) {
 	if s.embedder == nil {
 		// caller should have provided an embedder via NewService or
 		// SetEmbedder (not currently available).  Return an explicit
@@ -1087,7 +1123,13 @@ func (s *Service) searchSingleIndex(ctx context.Context, query string, k int, mo
 		return nil, err
 	}
 	if fused, ok := s.runHybridSearch(ctx, query, k, indexName, filtered); ok {
+		if allowRerank {
+			return s.rerankPool(ctx, query, fused, k), nil
+		}
 		return truncateSearchHits(fused, k), nil
+	}
+	if allowRerank {
+		return s.rerankPool(ctx, query, filtered, k), nil
 	}
 	return truncateSearchHits(filtered, k), nil
 }
@@ -1115,6 +1157,60 @@ func (s *Service) hybridVectorCandidateLimit(k int, idx model.Index) int {
 		return hybridCandidatePoolSize
 	}
 	return k
+}
+
+// rerankPool applies the optional rerank stage to a fused candidate
+// pool and returns the best k. When rerank is disabled or no reranker
+// is configured it is exactly truncateSearchHits(hits, k). It is
+// fail-open: any provider error keeps the pre-rerank order. Output is
+// deterministically ordered (relevance desc, then chunk_id asc) so ties
+// don't depend on provider response ordering (SPEC 9.1.1). Extracted
+// from the search paths to keep their cyclomatic complexity in budget.
+func (s *Service) rerankPool(ctx context.Context, query string, hits []model.SearchHit, k int) []model.SearchHit {
+	s.metaMu.RLock()
+	enabled := s.rerankEnabled
+	rr := s.reranker
+	rmodel := s.rerankModel
+	pool := s.rerankCandidatePool
+	s.metaMu.RUnlock()
+
+	if !enabled || rr == nil || len(hits) <= 1 {
+		return truncateSearchHits(hits, k)
+	}
+	if pool <= 0 {
+		pool = defaultRerankCandidatePool
+	}
+	if len(hits) > pool {
+		hits = hits[:pool]
+	}
+	docs := make([]string, len(hits))
+	for i, h := range hits {
+		docs[i] = h.Snippet
+	}
+	results, err := rr.Rerank(ctx, rmodel, query, docs, k)
+	if err != nil || len(results) == 0 {
+		if err != nil {
+			s.logf("rerank: provider error, falling back to fused order: %v", err)
+		}
+		return truncateSearchHits(hits, k)
+	}
+	out := make([]model.SearchHit, 0, len(results))
+	for _, r := range results {
+		if r.Index < 0 || r.Index >= len(hits) {
+			s.logf("rerank: out-of-range index %d, falling back to fused order", r.Index)
+			return truncateSearchHits(hits, k)
+		}
+		h := hits[r.Index]
+		h.Score = r.RelevanceScore
+		out = append(out, h)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Score != out[j].Score {
+			return out[i].Score > out[j].Score
+		}
+		return out[i].ChunkID < out[j].ChunkID
+	})
+	return truncateSearchHits(out, k)
 }
 
 func truncateSearchHits(hits []model.SearchHit, k int) []model.SearchHit {
@@ -1219,11 +1315,11 @@ func searchExhausted(filteredLen, k, labelsLen, n int) bool {
 
 func (s *Service) searchBothIndices(ctx context.Context, query string, k int, textModel, codeModel string, textIndex, codeIndex model.Index, filters model.SearchQuery) ([]model.SearchHit, error) {
 	// each single-index call will apply the overfetch multiplier internally
-	textHits, err := s.searchSingleIndex(ctx, query, k, textModel, textIndex, "text", filters)
+	textHits, err := s.searchSingleIndex(ctx, query, k, textModel, textIndex, "text", filters, false)
 	if err != nil {
 		return nil, err
 	}
-	codeHits, err := s.searchSingleIndex(ctx, query, k, codeModel, codeIndex, "code", filters)
+	codeHits, err := s.searchSingleIndex(ctx, query, k, codeModel, codeIndex, "code", filters, false)
 	if err != nil {
 		return nil, err
 	}
@@ -1255,10 +1351,8 @@ func (s *Service) searchBothIndices(ctx context.Context, query string, k int, te
 		}
 		return out[i].Score > out[j].Score
 	})
-	if len(out) > k {
-		out = out[:k]
-	}
-	return out, nil
+	// index=both: rerank once on the merged, normalized pool (SPEC 9.1.1).
+	return s.rerankPool(ctx, query, out, k), nil
 }
 
 func normalizeScores(hits []model.SearchHit) {

--- a/tests/cohere/client_test.go
+++ b/tests/cohere/client_test.go
@@ -1,0 +1,202 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/cohere"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+func newClient(url string) *cohere.Client {
+	c := cohere.NewClient(url, "test-key")
+	c.InitialBackoff = time.Millisecond
+	c.MaxBackoff = 2 * time.Millisecond
+	return c
+}
+
+func TestRerank_RequestShapeAndOrdering(t *testing.T) {
+	var gotAuth, gotPath string
+	var body rerankBody
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotPath = r.URL.Path
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &body)
+		w.Header().Set("Content-Type", "application/json")
+		// deliberately out of order; client must preserve provider order
+		_, _ = w.Write([]byte(`{"results":[{"index":2,"relevance_score":0.91},{"index":0,"relevance_score":0.40}]}`))
+	}))
+	defer srv.Close()
+
+	res, err := newClient(srv.URL).Rerank(context.Background(), "rerank-v3.5", "q", []string{"a", "b", "c"}, 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotPath != "/v2/rerank" {
+		t.Fatalf("path = %q, want /v2/rerank", gotPath)
+	}
+	if gotAuth != "Bearer test-key" {
+		t.Fatalf("auth = %q, want Bearer test-key", gotAuth)
+	}
+	if body.Model != "rerank-v3.5" || body.Query != "q" || len(body.Documents) != 3 || body.TopN != 2 {
+		t.Fatalf("unexpected request body: %+v", body)
+	}
+	if len(res) != 2 || res[0].Index != 2 || res[1].Index != 0 {
+		t.Fatalf("provider order not preserved: %+v", res)
+	}
+	if res[0].RelevanceScore != 0.91 {
+		t.Fatalf("score not parsed: %+v", res[0])
+	}
+}
+
+func TestRerank_EmptyDocumentsShortCircuits(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("API must not be called for empty documents")
+	}))
+	defer srv.Close()
+	res, err := newClient(srv.URL).Rerank(context.Background(), "", "q", nil, 0)
+	if err != nil || res != nil {
+		t.Fatalf("want (nil,nil), got (%v,%v)", res, err)
+	}
+}
+
+func TestRerank_MissingKeyIsNonRetryableAuth(t *testing.T) {
+	c := cohere.NewClient("http://127.0.0.1:0", "")
+	_, err := c.Rerank(context.Background(), "", "q", []string{"a"}, 0)
+	assertProviderError(t, err, "COHERE_AUTH", false)
+}
+
+func TestRerank_DefaultModelWhenEmpty(t *testing.T) {
+	var body rerankBody
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &body)
+		_, _ = w.Write([]byte(`{"results":[]}`))
+	}))
+	defer srv.Close()
+	if _, err := newClient(srv.URL).Rerank(context.Background(), "", "q", []string{"a"}, 0); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if body.Model != cohere.DefaultRerankModel {
+		t.Fatalf("model = %q, want default %q", body.Model, cohere.DefaultRerankModel)
+	}
+}
+
+func TestRerank_StatusMapping(t *testing.T) {
+	cases := []struct {
+		name      string
+		status    int
+		wantCode  string
+		retryable bool
+	}{
+		{"unauthorized", http.StatusUnauthorized, "COHERE_AUTH", false},
+		{"forbidden", http.StatusForbidden, "COHERE_AUTH", false},
+		{"rate limit", http.StatusTooManyRequests, "COHERE_RATE_LIMIT", true},
+		{"server error", http.StatusBadGateway, "COHERE_FAILED", true},
+		{"bad request", http.StatusBadRequest, "COHERE_FAILED", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(`{"message":"boom"}`))
+			}))
+			defer srv.Close()
+			_, err := newClient(srv.URL).Rerank(context.Background(), "m", "q", []string{"a"}, 0)
+			assertProviderError(t, err, tc.wantCode, tc.retryable)
+		})
+	}
+}
+
+func TestRerank_RetriesThenSucceeds(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		_, _ = w.Write([]byte(`{"results":[{"index":0,"relevance_score":1}]}`))
+	}))
+	defer srv.Close()
+	res, err := newClient(srv.URL).Rerank(context.Background(), "m", "q", []string{"a"}, 0)
+	if err != nil {
+		t.Fatalf("expected success after retries, got %v", err)
+	}
+	if len(res) != 1 || atomic.LoadInt32(&calls) != 3 {
+		t.Fatalf("calls=%d res=%+v", calls, res)
+	}
+}
+
+func TestRerank_NonRetryableStopsImmediately(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+	_, err := newClient(srv.URL).Rerank(context.Background(), "m", "q", []string{"a"}, 0)
+	assertProviderError(t, err, "COHERE_FAILED", false)
+	if atomic.LoadInt32(&calls) != 1 {
+		t.Fatalf("non-retryable must not retry; calls=%d", calls)
+	}
+}
+
+func TestRerank_ContextCancelDuringBackoff(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+	c := cohere.NewClient(srv.URL, "k")
+	c.InitialBackoff = 50 * time.Millisecond
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { time.Sleep(10 * time.Millisecond); cancel() }()
+	_, err := c.Rerank(ctx, "m", "q", []string{"a"}, 0)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("want context.Canceled, got %v", err)
+	}
+}
+
+func TestRerank_OutOfRangeIndexRejected(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"results":[{"index":9,"relevance_score":1}]}`))
+	}))
+	defer srv.Close()
+	_, err := newClient(srv.URL).Rerank(context.Background(), "m", "q", []string{"a"}, 0)
+	assertProviderError(t, err, "COHERE_FAILED", false)
+}
+
+type rerankBody struct {
+	Model     string   `json:"model"`
+	Query     string   `json:"query"`
+	Documents []string `json:"documents"`
+	TopN      int      `json:"top_n"`
+}
+
+func assertProviderError(t *testing.T, err error, wantCode string, wantRetryable bool) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected error %s, got nil", wantCode)
+	}
+	var pErr *model.ProviderError
+	if !errors.As(err, &pErr) {
+		t.Fatalf("error is not *model.ProviderError: %v", err)
+	}
+	if pErr.Code != wantCode {
+		t.Fatalf("code = %q, want %q (msg=%q)", pErr.Code, wantCode, pErr.Message)
+	}
+	if pErr.Retryable != wantRetryable {
+		t.Fatalf("retryable = %v, want %v", pErr.Retryable, wantRetryable)
+	}
+	if strings.TrimSpace(pErr.Message) == "" {
+		t.Fatalf("provider error message is empty")
+	}
+}

--- a/tests/config/rerank_config_test.go
+++ b/tests/config/rerank_config_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/dirstral/dir2mcp/tests/testutil"
 )
 
+func rerankBoolPtr(b bool) *bool { return &b }
+
 func TestRerank_NestedYAMLRoundTrips(t *testing.T) {
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, ".dir2mcp.yaml")
@@ -28,8 +30,8 @@ func TestRerank_NestedYAMLRoundTrips(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadFile: %v", err)
 	}
-	if !cfg.RerankEnabled {
-		t.Fatalf("RerankEnabled=false, want true")
+	if cfg.RerankEnabled == nil || !*cfg.RerankEnabled {
+		t.Fatalf("RerankEnabled=%v, want explicit true", cfg.RerankEnabled)
 	}
 	if cfg.RerankProvider != "cohere" {
 		t.Fatalf("RerankProvider=%q, want cohere", cfg.RerankProvider)
@@ -47,8 +49,8 @@ func TestRerank_NestedYAMLRoundTrips(t *testing.T) {
 
 func TestRerank_DefaultsWhenUnset(t *testing.T) {
 	cfg := config.Default()
-	if cfg.RerankEnabled {
-		t.Fatal("rerank must be disabled by default")
+	if cfg.RerankEnabled != nil {
+		t.Fatalf("rerank.enabled must be unset (auto) by default, got %v", *cfg.RerankEnabled)
 	}
 	if cfg.RerankProvider != "cohere" {
 		t.Fatalf("default provider=%q, want cohere", cfg.RerankProvider)
@@ -77,8 +79,8 @@ func TestRerank_EnvOverrides(t *testing.T) {
 		if cfg.CohereAPIKey != "env-cohere-secret" {
 			t.Fatalf("env must win for key; got %q", cfg.CohereAPIKey)
 		}
-		if !cfg.RerankEnabled {
-			t.Fatal("DIR2MCP_RERANK_ENABLED=true must enable")
+		if cfg.RerankEnabled == nil || !*cfg.RerankEnabled {
+			t.Fatalf("DIR2MCP_RERANK_ENABLED=true must set explicit true, got %v", cfg.RerankEnabled)
 		}
 		if cfg.RerankModel != "rerank-english-v3.0" {
 			t.Fatalf("DIR2MCP_RERANK_MODEL override failed; got %q", cfg.RerankModel)
@@ -90,7 +92,7 @@ func TestRerank_CohereKeyNeverPersisted(t *testing.T) {
 	stateDir := t.TempDir()
 	cfg := config.Default()
 	cfg.StateDir = stateDir
-	cfg.RerankEnabled = true
+	cfg.RerankEnabled = rerankBoolPtr(true)
 	cfg.CohereAPIKey = "cohere-plaintext-secret"
 
 	path, err := config.SaveEffectiveSnapshot(cfg, config.SecretSourceMetadata{
@@ -124,5 +126,42 @@ func TestRerank_CohereKeyNeverPersisted(t *testing.T) {
 	}
 	if sources.CohereAPIKey != "env" {
 		t.Fatalf("secret source metadata not round-tripped; got %q", sources.CohereAPIKey)
+	}
+}
+
+// TestRerank_EffectiveResolution pins the tri-state -> effective rule
+// used for the persisted snapshot: explicit value wins; when unset
+// (auto), reranking is on iff a credential is present.
+func TestRerank_EffectiveResolution(t *testing.T) {
+	cases := []struct {
+		name    string
+		enabled *bool
+		key     string
+		want    string
+	}{
+		{"auto+credential -> on", nil, "cohere-secret", "rerank_enabled: true"},
+		{"auto+no-credential -> off", nil, "", "rerank_enabled: false"},
+		{"explicit false beats credential", rerankBoolPtr(false), "cohere-secret", "rerank_enabled: false"},
+		{"explicit true without credential", rerankBoolPtr(true), "", "rerank_enabled: true"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.Default()
+			cfg.StateDir = t.TempDir()
+			cfg.RerankEnabled = tc.enabled
+			cfg.CohereAPIKey = tc.key
+
+			path, err := config.SaveEffectiveSnapshot(cfg, config.SecretSourceMetadata{})
+			if err != nil {
+				t.Fatalf("SaveEffectiveSnapshot: %v", err)
+			}
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("ReadFile: %v", err)
+			}
+			if !strings.Contains(string(raw), tc.want) {
+				t.Fatalf("want %q in snapshot, got:\n%s", tc.want, raw)
+			}
+		})
 	}
 }

--- a/tests/config/rerank_config_test.go
+++ b/tests/config/rerank_config_test.go
@@ -47,6 +47,49 @@ func TestRerank_NestedYAMLRoundTrips(t *testing.T) {
 	}
 }
 
+func TestRerank_CohereBaseURLRoundTrips(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+	writeFile(t, path, strings.Join([]string{
+		"rerank:",
+		"  cohere:",
+		"    base_url: https://cohere.internal.example",
+		"",
+	}, "\n"))
+
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if cfg.CohereBaseURL != "https://cohere.internal.example" {
+		t.Fatalf("CohereBaseURL=%q, want https://cohere.internal.example", cfg.CohereBaseURL)
+	}
+
+	// COHERE_BASE_URL env wins; base URL is NOT a secret -> persisted.
+	testutil.WithWorkingDir(t, tmp, func() {
+		t.Setenv("COHERE_BASE_URL", "https://env.cohere.example")
+		c, err := config.Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if c.CohereBaseURL != "https://env.cohere.example" {
+			t.Fatalf("env override failed; got %q", c.CohereBaseURL)
+		}
+		c.StateDir = t.TempDir()
+		snap, err := config.SaveEffectiveSnapshot(c, config.SecretSourceMetadata{})
+		if err != nil {
+			t.Fatalf("SaveEffectiveSnapshot: %v", err)
+		}
+		raw, err := os.ReadFile(snap)
+		if err != nil {
+			t.Fatalf("ReadFile: %v", err)
+		}
+		if !strings.Contains(string(raw), "cohere_base_url: https://env.cohere.example") {
+			t.Fatalf("base URL must persist (not a secret):\n%s", raw)
+		}
+	})
+}
+
 func TestRerank_DefaultsWhenUnset(t *testing.T) {
 	cfg := config.Default()
 	if cfg.RerankEnabled != nil {

--- a/tests/config/rerank_config_test.go
+++ b/tests/config/rerank_config_test.go
@@ -1,0 +1,128 @@
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/tests/testutil"
+)
+
+func TestRerank_NestedYAMLRoundTrips(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+	writeFile(t, path, strings.Join([]string{
+		"rerank:",
+		"  enabled: true",
+		"  provider: cohere",
+		"  candidate_pool: 25",
+		"  cohere:",
+		"    api_key: yaml-cohere-secret",
+		"    model: rerank-v3.5",
+		"",
+	}, "\n"))
+
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if !cfg.RerankEnabled {
+		t.Fatalf("RerankEnabled=false, want true")
+	}
+	if cfg.RerankProvider != "cohere" {
+		t.Fatalf("RerankProvider=%q, want cohere", cfg.RerankProvider)
+	}
+	if cfg.RerankCandidatePool != 25 {
+		t.Fatalf("RerankCandidatePool=%d, want 25", cfg.RerankCandidatePool)
+	}
+	if cfg.RerankModel != "rerank-v3.5" {
+		t.Fatalf("RerankModel=%q, want rerank-v3.5", cfg.RerankModel)
+	}
+	if cfg.CohereAPIKey != "yaml-cohere-secret" {
+		t.Fatalf("CohereAPIKey=%q, want yaml-cohere-secret", cfg.CohereAPIKey)
+	}
+}
+
+func TestRerank_DefaultsWhenUnset(t *testing.T) {
+	cfg := config.Default()
+	if cfg.RerankEnabled {
+		t.Fatal("rerank must be disabled by default")
+	}
+	if cfg.RerankProvider != "cohere" {
+		t.Fatalf("default provider=%q, want cohere", cfg.RerankProvider)
+	}
+	if cfg.RerankModel != "rerank-v3.5" {
+		t.Fatalf("default model=%q, want rerank-v3.5", cfg.RerankModel)
+	}
+	if cfg.RerankCandidatePool != 50 {
+		t.Fatalf("default candidate_pool=%d, want 50", cfg.RerankCandidatePool)
+	}
+}
+
+func TestRerank_EnvOverrides(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+	writeFile(t, path, "rerank:\n  enabled: false\n  cohere:\n    api_key: yaml-key\n")
+
+	testutil.WithWorkingDir(t, tmp, func() {
+		t.Setenv("COHERE_API_KEY", "env-cohere-secret")
+		t.Setenv("DIR2MCP_RERANK_ENABLED", "true")
+		t.Setenv("DIR2MCP_RERANK_MODEL", "rerank-english-v3.0")
+		cfg, err := config.Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.CohereAPIKey != "env-cohere-secret" {
+			t.Fatalf("env must win for key; got %q", cfg.CohereAPIKey)
+		}
+		if !cfg.RerankEnabled {
+			t.Fatal("DIR2MCP_RERANK_ENABLED=true must enable")
+		}
+		if cfg.RerankModel != "rerank-english-v3.0" {
+			t.Fatalf("DIR2MCP_RERANK_MODEL override failed; got %q", cfg.RerankModel)
+		}
+	})
+}
+
+func TestRerank_CohereKeyNeverPersisted(t *testing.T) {
+	stateDir := t.TempDir()
+	cfg := config.Default()
+	cfg.StateDir = stateDir
+	cfg.RerankEnabled = true
+	cfg.CohereAPIKey = "cohere-plaintext-secret"
+
+	path, err := config.SaveEffectiveSnapshot(cfg, config.SecretSourceMetadata{
+		CohereAPIKey: "env",
+	})
+	if err != nil {
+		t.Fatalf("SaveEffectiveSnapshot: %v", err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	text := string(raw)
+	if strings.Contains(text, "cohere-plaintext-secret") {
+		t.Fatalf("snapshot leaked the Cohere API key:\n%s", text)
+	}
+	if !strings.Contains(text, "cohere_api_key: env") {
+		t.Fatalf("snapshot missing cohere secret-source metadata:\n%s", text)
+	}
+	// Non-secret rerank fields SHOULD persist.
+	if !strings.Contains(text, "rerank_enabled: true") {
+		t.Fatalf("snapshot missing rerank_enabled:\n%s", text)
+	}
+
+	loaded, sources, err := config.LoadEffectiveSnapshot(path)
+	if err != nil {
+		t.Fatalf("LoadEffectiveSnapshot: %v", err)
+	}
+	if loaded.CohereAPIKey != "" {
+		t.Fatalf("loaded snapshot must not carry the key, got %q", loaded.CohereAPIKey)
+	}
+	if sources.CohereAPIKey != "env" {
+		t.Fatalf("secret source metadata not round-tripped; got %q", sources.CohereAPIKey)
+	}
+}

--- a/tests/retrieval/rerank_test.go
+++ b/tests/retrieval/rerank_test.go
@@ -1,0 +1,179 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
+)
+
+// fakeReranker records the documents it was asked to score and returns
+// a caller-supplied ordering (indices into the documents slice).
+type fakeReranker struct {
+	mu       sync.Mutex
+	calls    int
+	lastDocs []string
+	order    []int // indices, best-first; nil => identity
+	err      error
+}
+
+func (f *fakeReranker) Rerank(_ context.Context, _ string, _ string, docs []string, topN int) ([]model.Reranked, error) {
+	f.mu.Lock()
+	f.calls++
+	f.lastDocs = append([]string(nil), docs...)
+	f.mu.Unlock()
+	if f.err != nil {
+		return nil, f.err
+	}
+	order := f.order
+	if order == nil {
+		order = make([]int, len(docs))
+		for i := range docs {
+			order[i] = i
+		}
+	}
+	out := make([]model.Reranked, 0, len(order))
+	for rank, idx := range order {
+		if idx < 0 || idx >= len(docs) {
+			continue
+		}
+		out = append(out, model.Reranked{Index: idx, RelevanceScore: float64(len(order) - rank)})
+	}
+	return out, nil
+}
+
+func rerankTestService(t *testing.T) *retrieval.Service {
+	t.Helper()
+	idx := index.NewHNSWIndex("")
+	for id, vec := range map[uint64][]float32{1: {1, 0}, 2: {0.9, 0.1}, 3: {0.8, 0.2}} {
+		if err := idx.Add(id, vec); err != nil {
+			t.Fatalf("idx.Add: %v", err)
+		}
+	}
+	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+		"mistral-embed":   {1, 0},
+		"codestral-embed": {0, 1},
+	}}, nil)
+	svc.SetChunkMetadata(1, model.SearchHit{ChunkID: 1, RelPath: "a.md", DocType: "md", Snippet: "alpha"})
+	svc.SetChunkMetadata(2, model.SearchHit{ChunkID: 2, RelPath: "b.md", DocType: "md", Snippet: "beta"})
+	svc.SetChunkMetadata(3, model.SearchHit{ChunkID: 3, RelPath: "c.md", DocType: "md", Snippet: "gamma"})
+	return svc
+}
+
+func search(t *testing.T, svc *retrieval.Service, k int) []model.SearchHit {
+	t.Helper()
+	hits, err := svc.Search(context.Background(), model.SearchQuery{Query: "alpha", K: k, Index: "text"})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	return hits
+}
+
+func TestRerank_DisabledLeavesFusedOrder(t *testing.T) {
+	svc := rerankTestService(t)
+	fr := &fakeReranker{order: []int{2, 1, 0}} // would reverse if consulted
+	svc.SetReranker(fr, "m", 50)               // configured but...
+	// SetRerankEnabled not called -> disabled by default
+	baseline := search(t, svc, 3)
+
+	if fr.calls != 0 {
+		t.Fatalf("reranker must not be called when disabled; calls=%d", fr.calls)
+	}
+	if len(baseline) == 0 {
+		t.Fatal("expected hits")
+	}
+}
+
+func TestRerank_EnabledReordersByProviderScore(t *testing.T) {
+	svc := rerankTestService(t)
+	before := search(t, svc, 3)
+	if len(before) < 3 {
+		t.Fatalf("need >=3 fused hits, got %d", len(before))
+	}
+	// Ask the reranker to invert the fused order.
+	inv := make([]int, len(before))
+	for i := range inv {
+		inv[i] = len(before) - 1 - i
+	}
+	fr := &fakeReranker{order: inv}
+	svc.SetReranker(fr, "m", 50)
+	svc.SetRerankEnabled(true)
+
+	after := search(t, svc, 3)
+	if fr.calls != 1 {
+		t.Fatalf("reranker calls=%d, want 1", fr.calls)
+	}
+	if after[0].ChunkID != before[len(before)-1].ChunkID {
+		t.Fatalf("rerank did not reorder: after[0]=%d before-last=%d", after[0].ChunkID, before[len(before)-1].ChunkID)
+	}
+	// Score must be overwritten with provider relevance, sorted desc.
+	for i := 1; i < len(after); i++ {
+		if after[i-1].Score < after[i].Score {
+			t.Fatalf("not sorted by relevance desc: %v", after)
+		}
+	}
+}
+
+func TestRerank_ProviderErrorFallsBackToFusedOrder(t *testing.T) {
+	svc := rerankTestService(t)
+	before := search(t, svc, 3)
+
+	fr := &fakeReranker{err: errors.New("cohere down"), order: []int{2, 1, 0}}
+	svc.SetReranker(fr, "m", 50)
+	svc.SetRerankEnabled(true)
+
+	after := search(t, svc, 3)
+	if len(after) != len(before) {
+		t.Fatalf("len mismatch after fallback: %d vs %d", len(after), len(before))
+	}
+	for i := range before {
+		if after[i].ChunkID != before[i].ChunkID {
+			t.Fatalf("fail-open must preserve fused order; pos %d: %d vs %d", i, after[i].ChunkID, before[i].ChunkID)
+		}
+	}
+}
+
+func TestRerank_CandidatePoolCapRespected(t *testing.T) {
+	svc := rerankTestService(t)
+	fr := &fakeReranker{}
+	svc.SetReranker(fr, "m", 2) // cap pool to 2
+	svc.SetRerankEnabled(true)
+
+	_ = search(t, svc, 3)
+	fr.mu.Lock()
+	got := len(fr.lastDocs)
+	fr.mu.Unlock()
+	if got != 2 {
+		t.Fatalf("candidate pool cap not applied: reranker saw %d docs, want 2", got)
+	}
+}
+
+func TestRerank_BothModeReranksOnceOnMergedPool(t *testing.T) {
+	idx := index.NewHNSWIndex("")
+	for id, vec := range map[uint64][]float32{1: {1, 0}, 2: {0, 1}} {
+		if err := idx.Add(id, vec); err != nil {
+			t.Fatalf("idx.Add: %v", err)
+		}
+	}
+	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+		"mistral-embed":   {1, 0},
+		"codestral-embed": {0, 1},
+	}}, nil)
+	svc.SetChunkMetadata(1, model.SearchHit{ChunkID: 1, RelPath: "a.md", DocType: "md", Snippet: "alpha"})
+	svc.SetChunkMetadata(2, model.SearchHit{ChunkID: 2, RelPath: "b.go", DocType: "code", Snippet: "beta"})
+
+	fr := &fakeReranker{}
+	svc.SetReranker(fr, "m", 50)
+	svc.SetRerankEnabled(true)
+
+	if _, err := svc.Search(context.Background(), model.SearchQuery{Query: "x", K: 5, Index: "both"}); err != nil {
+		t.Fatalf("Search both: %v", err)
+	}
+	if fr.calls != 1 {
+		t.Fatalf("index=both must rerank exactly once on the merged pool; calls=%d", fr.calls)
+	}
+}

--- a/tests/retrieval/rerank_test.go
+++ b/tests/retrieval/rerank_test.go
@@ -152,17 +152,66 @@ func TestRerank_CandidatePoolCapRespected(t *testing.T) {
 	}
 }
 
-func TestRerank_BothModeReranksOnceOnMergedPool(t *testing.T) {
-	idx := index.NewHNSWIndex("")
-	for id, vec := range map[uint64][]float32{1: {1, 0}, 2: {0, 1}} {
-		if err := idx.Add(id, vec); err != nil {
-			t.Fatalf("idx.Add: %v", err)
+func TestRerank_FailOpenReturnsFullFusedNotPoolWhenPoolBelowK(t *testing.T) {
+	svc := rerankTestService(t)
+	before := search(t, svc, 3) // 3 fused hits
+	if len(before) != 3 {
+		t.Fatalf("need 3 fused hits, got %d", len(before))
+	}
+	fr := &fakeReranker{err: errors.New("cohere down")}
+	svc.SetReranker(fr, "m", 2) // pool < k
+	svc.SetRerankEnabled(true)
+
+	after := search(t, svc, 3)
+	if len(after) != len(before) {
+		t.Fatalf("fail-open with pool<k must still return full fused k: got %d want %d", len(after), len(before))
+	}
+	for i := range before {
+		if after[i].ChunkID != before[i].ChunkID {
+			t.Fatalf("fail-open must preserve fused order at %d: %d vs %d", i, after[i].ChunkID, before[i].ChunkID)
 		}
 	}
-	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
-		"mistral-embed":   {1, 0},
-		"codestral-embed": {0, 1},
+}
+
+func TestRerank_SuccessKeepsUnrerankedTailWhenPoolBelowK(t *testing.T) {
+	svc := rerankTestService(t)
+	before := search(t, svc, 3)
+	fr := &fakeReranker{order: []int{1, 0}} // invert the 2 pooled docs
+	svc.SetReranker(fr, "m", 2)             // pool < k=3
+	svc.SetRerankEnabled(true)
+
+	after := search(t, svc, 3)
+	if len(after) != 3 {
+		t.Fatalf("rerank must not drop results when pool<k: got %d want 3", len(after))
+	}
+	fr.mu.Lock()
+	seen := len(fr.lastDocs)
+	fr.mu.Unlock()
+	if seen != 2 {
+		t.Fatalf("pool cap not applied: reranker saw %d docs, want 2", seen)
+	}
+	if after[2].ChunkID != before[2].ChunkID {
+		t.Fatalf("un-reranked tail must be preserved last: got %d want %d", after[2].ChunkID, before[2].ChunkID)
+	}
+}
+
+func TestRerank_BothModeReranksOnceOnMergedPool(t *testing.T) {
+	// Distinct text and code indices so index=both genuinely merges two
+	// non-empty pools; without separate indices the assertion could pass
+	// on a single-index result.
+	textIdx := index.NewHNSWIndex("")
+	if err := textIdx.Add(1, []float32{1, 0}); err != nil {
+		t.Fatalf("textIdx.Add: %v", err)
+	}
+	codeIdx := index.NewHNSWIndex("")
+	if err := codeIdx.Add(2, []float32{0, 1}); err != nil {
+		t.Fatalf("codeIdx.Add: %v", err)
+	}
+	svc := retrieval.NewService(nil, textIdx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+		"mistral-embed":   {1, 0}, // text query -> matches id 1 in textIdx
+		"codestral-embed": {0, 1}, // code query -> matches id 2 in codeIdx
 	}}, nil)
+	svc.SetCodeIndex(codeIdx)
 	svc.SetChunkMetadata(1, model.SearchHit{ChunkID: 1, RelPath: "a.md", DocType: "md", Snippet: "alpha"})
 	svc.SetChunkMetadata(2, model.SearchHit{ChunkID: 2, RelPath: "b.go", DocType: "code", Snippet: "beta"})
 
@@ -175,5 +224,17 @@ func TestRerank_BothModeReranksOnceOnMergedPool(t *testing.T) {
 	}
 	if fr.calls != 1 {
 		t.Fatalf("index=both must rerank exactly once on the merged pool; calls=%d", fr.calls)
+	}
+	// The single rerank call must see the merged pool: hits from both
+	// the text index (alpha) and the code index (beta).
+	fr.mu.Lock()
+	docs := append([]string(nil), fr.lastDocs...)
+	fr.mu.Unlock()
+	seen := map[string]bool{}
+	for _, d := range docs {
+		seen[d] = true
+	}
+	if !seen["alpha"] || !seen["beta"] {
+		t.Fatalf("reranker must see the merged two-index pool; saw docs=%v", docs)
 	}
 }


### PR DESCRIPTION
## ⚠️ Gated on [dirstral-spec#5](https://github.com/dirstral/dirstral-spec/pull/5)

This implements spec **§8.4 / §9.1.1** from dirstral-spec#5 (`0.6.0`). **Do not merge before #5 merges.** Pre-merge step: re-pin the `dirstral-spec` submodule to #5's merged main SHA, re-run `make check`. (This PR intentionally does **not** touch the submodule — it's still at the `0.5.0` pin, which is fine: the code doesn't read the spec; the `secret_patterns` test only needs the §7.2 block, present in `0.5.0`.)

## Summary

Optional, **off-by-default**, **fail-open** post-fusion reranking with **Cohere** as the first provider. Reorder-only — the result contract (§9.2) is unchanged.

## Changes

- **`internal/cohere`** — direct-HTTP `/v2/rerank` adapter mirroring `internal/mistral` (bounded exponential retry, typed `model.ProviderError` with `COHERE_AUTH`/`COHERE_RATE_LIMIT`/`COHERE_FAILED`); satisfies the new `model.Reranker` interface (compile-time asserted).
- **`internal/model`** — `Reranker` interface + `Reranked` result type (decouples retrieval from the cohere package, same pattern as `Embedder`).
- **`internal/retrieval`** — `rerankPool` helper: caps to `candidate_pool`, sends query + each hit's `snippet`, reorders by provider score, **deterministic** (relevance desc, then `chunk_id`), **fail-open** (any error/empty → pre-rerank order). Applied in `searchSingleIndex` for single-index routes and **once on the merged pool** for `index=both` (per §9.1.1). `SetReranker`/`SetRerankEnabled` mirror `SetHybridEnabled`.
- **`internal/config`** — nested `rerank.*` namespace mirroring `stt.*` (parser map-section, aliases, file/env/scalar plumbing, `marshalConfigYAML`). `CohereAPIKey` is a **secret**: env-sourced (`COHERE_API_KEY`), **excluded from the snapshot**, recorded in `SecretSourceMetadata`.
- **`cli`** — `configureReranker` wired into both the `up` and `ask` retrieval paths; warns and stays off when enabled without a usable provider/key (it's an optimization, not a hard dependency).
- **`README`** — Reranking section + `COHERE_API_KEY`/`DIR2MCP_RERANK_*` env rows.

## Test plan

- [x] `internal`/`tests/cohere` — httptest stub: request shape, auth header, default model, status→error mapping, retry-then-success, non-retryable-stops, ctx-cancel during backoff, out-of-range index
- [x] `tests/retrieval/rerank_test.go` — disabled (not called), enabled reorders by provider score, provider error → fused-order fallback, candidate-pool cap, `index=both` reranks exactly once on merged pool
- [x] `tests/config/rerank_config_test.go` — nested YAML round-trip, defaults, env precedence (`COHERE_API_KEY` wins), **Cohere key never persisted** + secret-source metadata round-trips
- [x] `make check` green (full suite + lint + gofmt + gocyclo + python + build); rerank insertion extracted to keep gocyclo ≤15
- [ ] **Pre-merge:** submodule re-pin to dirstral-spec#5 merged SHA + `make check`

## Notes

Fail-open by design (mirrors `hybrid.go`'s BM25 fallback) — reranking never fails a query. No new tool/tool-schema field/error code, so no `spec/tools/schemas/*` or taxonomy change (matches dirstral-spec#5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added optional post-retrieval reranking using Cohere cross-encoder models (default: rerank-v3.5)
- Enable reranking via YAML configuration or environment variables (COHERE_API_KEY, DIR2MCP_RERANK_ENABLED, DIR2MCP_RERANK_MODEL)
- Graceful fallback preserves original search ranking if reranking fails
- Reranking applies seamlessly to single and multi-index searches

**Documentation**
- Updated configuration documentation with reranking setup and behavior details

**Tests**
- Added comprehensive test suites for reranking functionality and configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dirstral/dir2mcp/pull/188?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->