### PR TITLE
feat(model): Embedder input role (SPEC 8.1.5) + spec 0.7.0 re-pin

### DIFF
--- a/internal/index/embedding_worker.go
+++ b/internal/index/embedding_worker.go
@@ -163,7 +163,7 @@ func (w *EmbeddingWorker) RunOnce(ctx context.Context, indexKind string) (int, e
 		return 0, err
 	}
 
-	vectors, err := w.Embedder.Embed(ctx, modelName, inputs)
+	vectors, err := w.Embedder.Embed(ctx, modelName, model.EmbedDocument, inputs)
 	if err != nil {
 		// distinguish between transient errors (which we want to retry later)
 		// and permanent failures for which the chunks should be marked as

--- a/internal/mistral/client.go
+++ b/internal/mistral/client.go
@@ -122,7 +122,9 @@ func NewClient(baseURL, apiKey string) *Client {
 	}
 }
 
-func (c *Client) Embed(ctx context.Context, modelName string, inputs []string) ([][]float32, error) {
+// Embed implements model.Embedder. Mistral embeddings are symmetric, so
+// the input role is accepted and intentionally ignored (SPEC 8.1.5).
+func (c *Client) Embed(ctx context.Context, modelName string, _ model.EmbedRole, inputs []string) ([][]float32, error) {
 	if strings.TrimSpace(c.APIKey) == "" {
 		return nil, &model.ProviderError{
 			Code:      "MISTRAL_AUTH",

--- a/internal/model/interfaces.go
+++ b/internal/model/interfaces.go
@@ -51,8 +51,24 @@ type Ingestor interface {
 	Reindex(ctx context.Context) error
 }
 
+// EmbedRole distinguishes corpus/index-time embeddings from search-time
+// query embeddings. Asymmetric providers (e.g. Cohere `input_type`,
+// Voyage) MUST map it to their mechanism; symmetric providers (OpenAI,
+// Mistral) accept it and MAY ignore it — behavior MUST NOT differ for
+// symmetric providers. The role is set by the call site, not by config,
+// and does not affect the corpus-lifetime embed identity (SPEC 8.1.4 /
+// 8.1.5).
+type EmbedRole string
+
+const (
+	// EmbedDocument is used when embedding corpus content at index time.
+	EmbedDocument EmbedRole = "document"
+	// EmbedQuery is used when embedding a search query at query time.
+	EmbedQuery EmbedRole = "query"
+)
+
 type Embedder interface {
-	Embed(ctx context.Context, model string, inputs []string) ([][]float32, error)
+	Embed(ctx context.Context, model string, role EmbedRole, inputs []string) ([][]float32, error)
 }
 
 type OCR interface {

--- a/internal/retrieval/large_corpus_test.go
+++ b/internal/retrieval/large_corpus_test.go
@@ -13,7 +13,7 @@ type uniformEmbedder struct {
 	vec []float32
 }
 
-func (u *uniformEmbedder) Embed(_ context.Context, _ string, texts []string) ([][]float32, error) {
+func (u *uniformEmbedder) Embed(_ context.Context, _ string, _ model.EmbedRole, texts []string) ([][]float32, error) {
 	out := make([][]float32, len(texts))
 	for i := range texts {
 		vec := make([]float32, len(u.vec))

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -1107,7 +1107,7 @@ func (s *Service) searchSingleIndex(ctx context.Context, query string, k int, mo
 		// error rather than letting the nil dereference panic later.
 		return nil, ErrMissingEmbedder
 	}
-	vectors, err := s.embedder.Embed(ctx, modelName, []string{query})
+	vectors, err := s.embedder.Embed(ctx, modelName, model.EmbedQuery, []string{query})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/retrieval/service_test.go
+++ b/internal/retrieval/service_test.go
@@ -46,14 +46,14 @@ func (f *fakeRetrievalIndex) Save(path string) error { return nil }
 func (f *fakeRetrievalIndex) Load(path string) error { return nil }
 func (f *fakeRetrievalIndex) Close() error           { return nil }
 
-func (e *fakeRetrievalEmbedder) Embed(_ context.Context, model string, texts []string) ([][]float32, error) {
+func (e *fakeRetrievalEmbedder) Embed(_ context.Context, modelName string, _ model.EmbedRole, texts []string) ([][]float32, error) {
 	// return one embedding per input text, matching the real embedder behaviour
 	n := len(texts)
 	if n == 0 {
 		return [][]float32{}, nil
 	}
 	var vec []float32
-	if v, ok := e.vectorsByModel[model]; ok {
+	if v, ok := e.vectorsByModel[modelName]; ok {
 		vec = v
 	} else {
 		vec = []float32{1, 0}

--- a/tests/index/embedding_worker_test.go
+++ b/tests/index/embedding_worker_test.go
@@ -66,7 +66,7 @@ func (w *testWorker) RunOnce(ctx context.Context, indexKind string) (int, error)
 	return 1, nil
 }
 
-func (e *fakeEmbedder) Embed(_ context.Context, _ string, _ []string) ([][]float32, error) {
+func (e *fakeEmbedder) Embed(_ context.Context, _ string, _ model.EmbedRole, _ []string) ([][]float32, error) {
 	if e.err != nil {
 		return nil, e.err
 	}
@@ -207,7 +207,7 @@ func TestEmbeddingWorker_RunOnce_EmbeddingTransient(t *testing.T) {
 // corrupt by the worker.
 type panicEmbedder struct{}
 
-func (p *panicEmbedder) Embed(_ context.Context, _ string, _ []string) ([][]float32, error) {
+func (p *panicEmbedder) Embed(_ context.Context, _ string, _ model.EmbedRole, _ []string) ([][]float32, error) {
 	panic("embedder should not be invoked for zero-label batches")
 }
 

--- a/tests/ingest/transcribe_test.go
+++ b/tests/ingest/transcribe_test.go
@@ -182,7 +182,7 @@ type staticEmbedder struct {
 // Embed returns one fixed vector per input text. The method copies the
 // underlying vector for each element of texts so callers can safely modify
 // the returned slices without affecting the mock's stored vector.
-func (e *staticEmbedder) Embed(ctx context.Context, model string, texts []string) ([][]float32, error) {
+func (e *staticEmbedder) Embed(_ context.Context, _ string, _ model.EmbedRole, texts []string) ([][]float32, error) {
 	out := make([][]float32, len(texts))
 	for i := range texts {
 		out[i] = append([]float32(nil), e.vec...)

--- a/tests/mistral/client_embed_test.go
+++ b/tests/mistral/client_embed_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -87,11 +88,12 @@ func TestEmbed_BatchesRequestsAndPreservesOrder(t *testing.T) {
 func TestEmbed_SymmetricProviderIgnoresRole(t *testing.T) {
 	var bodies []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var req embedTestRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			t.Errorf("decode: %v", err)
+		// Compare the RAW request bytes (not a struct round-trip, which
+		// would silently drop a role-specific field like input_type).
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
 		}
-		raw, _ := json.Marshal(req)
 		bodies = append(bodies, string(raw))
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"data": []map[string]any{{"index": 0, "embedding": []float64{1, 2}}},
@@ -109,7 +111,7 @@ func TestEmbed_SymmetricProviderIgnoresRole(t *testing.T) {
 		t.Fatalf("want 2 requests, got %d", len(bodies))
 	}
 	if bodies[0] != bodies[1] {
-		t.Fatalf("symmetric provider must send identical request regardless of role:\n document=%s\n query=%s", bodies[0], bodies[1])
+		t.Fatalf("symmetric provider must send byte-identical request regardless of role:\n document=%s\n query=%s", bodies[0], bodies[1])
 	}
 }
 

--- a/tests/mistral/client_embed_test.go
+++ b/tests/mistral/client_embed_test.go
@@ -64,7 +64,7 @@ func TestEmbed_BatchesRequestsAndPreservesOrder(t *testing.T) {
 	client.InitialBackoff = 1 * time.Millisecond
 	client.MaxBackoff = 1 * time.Millisecond
 
-	vectors, err := client.Embed(context.Background(), "mistral-embed", []string{"a", "b", "c"})
+	vectors, err := client.Embed(context.Background(), "mistral-embed", model.EmbedDocument, []string{"a", "b", "c"})
 	if err != nil {
 		t.Fatalf("embed failed: %v", err)
 	}
@@ -78,6 +78,38 @@ func TestEmbed_BatchesRequestsAndPreservesOrder(t *testing.T) {
 
 	if vectors[0][0] != 1.0 || vectors[1][0] != 2.0 || vectors[2][0] != 3.0 {
 		t.Fatalf("unexpected vector ordering: %#v", vectors)
+	}
+}
+
+// TestEmbed_SymmetricProviderIgnoresRole pins SPEC 8.1.5: Mistral is a
+// symmetric embedder, so the request it sends MUST be identical for
+// EmbedDocument and EmbedQuery (the role is accepted and ignored).
+func TestEmbed_SymmetricProviderIgnoresRole(t *testing.T) {
+	var bodies []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req embedTestRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode: %v", err)
+		}
+		raw, _ := json.Marshal(req)
+		bodies = append(bodies, string(raw))
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{{"index": 0, "embedding": []float64{1, 2}}},
+		})
+	}))
+	defer server.Close()
+
+	client := mistral.NewClient(server.URL, "test-key")
+	for _, role := range []model.EmbedRole{model.EmbedDocument, model.EmbedQuery} {
+		if _, err := client.Embed(context.Background(), "mistral-embed", role, []string{"hello"}); err != nil {
+			t.Fatalf("embed (%s): %v", role, err)
+		}
+	}
+	if len(bodies) != 2 {
+		t.Fatalf("want 2 requests, got %d", len(bodies))
+	}
+	if bodies[0] != bodies[1] {
+		t.Fatalf("symmetric provider must send identical request regardless of role:\n document=%s\n query=%s", bodies[0], bodies[1])
 	}
 }
 
@@ -104,7 +136,7 @@ func TestEmbed_RetriesOnRateLimitThenSucceeds(t *testing.T) {
 	client.InitialBackoff = 1 * time.Millisecond
 	client.MaxBackoff = 1 * time.Millisecond
 
-	vectors, err := client.Embed(context.Background(), "mistral-embed", []string{"retry-me"})
+	vectors, err := client.Embed(context.Background(), "mistral-embed", model.EmbedDocument, []string{"retry-me"})
 	if err != nil {
 		t.Fatalf("embed should have succeeded after retry: %v", err)
 	}
@@ -138,7 +170,7 @@ func TestEmbed_RetriesOnServerErrorThenSucceeds(t *testing.T) {
 	client.InitialBackoff = 1 * time.Millisecond
 	client.MaxBackoff = 1 * time.Millisecond
 
-	vectors, err := client.Embed(context.Background(), "mistral-embed", []string{"retry-5xx"})
+	vectors, err := client.Embed(context.Background(), "mistral-embed", model.EmbedDocument, []string{"retry-5xx"})
 	if err != nil {
 		t.Fatalf("embed should have succeeded after retry: %v", err)
 	}
@@ -160,7 +192,7 @@ func TestEmbed_MapsAuthErrors(t *testing.T) {
 	client := mistral.NewClient(server.URL, "bad-key")
 	client.MaxRetries = 0
 
-	_, err := client.Embed(context.Background(), "mistral-embed", []string{"x"})
+	_, err := client.Embed(context.Background(), "mistral-embed", model.EmbedDocument, []string{"x"})
 	if err == nil {
 		t.Fatal("expected error")
 	}

--- a/tests/mistral/client_integration_test.go
+++ b/tests/mistral/client_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/dirstral/dir2mcp/internal/mistral"
+	"github.com/dirstral/dir2mcp/internal/model"
 )
 
 func TestEmbed_Integration_MistralAPI(t *testing.T) {
@@ -34,7 +35,7 @@ func TestEmbed_Integration_MistralAPI(t *testing.T) {
 		"dir2mcp integration test sentence two",
 	}
 
-	vectors, err := client.Embed(ctx, "mistral-embed", inputs)
+	vectors, err := client.Embed(ctx, "mistral-embed", model.EmbedDocument, inputs)
 	if err != nil {
 		t.Fatalf("Embed returned error: %v", err)
 	}

--- a/tests/retrieval/service_test.go
+++ b/tests/retrieval/service_test.go
@@ -194,14 +194,14 @@ func (c *cancelAfterFirstSearchIndex) Save(path string) error { return nil }
 func (c *cancelAfterFirstSearchIndex) Load(path string) error { return nil }
 func (c *cancelAfterFirstSearchIndex) Close() error           { return nil }
 
-func (e *fakeRetrievalEmbedder) Embed(_ context.Context, model string, texts []string) ([][]float32, error) {
+func (e *fakeRetrievalEmbedder) Embed(_ context.Context, modelName string, _ model.EmbedRole, texts []string) ([][]float32, error) {
 	// return one embedding per input text, matching the real embedder behaviour
 	n := len(texts)
 	if n == 0 {
 		return [][]float32{}, nil
 	}
 	var vec []float32
-	if v, ok := e.vectorsByModel[model]; ok {
+	if v, ok := e.vectorsByModel[modelName]; ok {
 		vec = v
 	} else {
 		vec = []float32{1, 0}


### PR DESCRIPTION
**Phase 1 of the multi-provider implementation** (Design 0001 / spec 0.7.0). This is the first scoped, self-contained PR; the larger config/adapter work follows in gated follow-ups.

## What this does

1. **Re-pin** the `dirstral-spec` submodule `566e8b8 → 174e525` (spec **0.7.0** merged, #6).
2. **`model.Embedder` gains an `EmbedRole` parameter** (`document` | `query`), per **SPEC §8.1.5** / Design 0001 §5.6:
   - Set by the **call site**, not config: ingest/index → `EmbedDocument` (`embedding_worker`); search → `EmbedQuery` (`retrieval.Service`).
   - Asymmetric providers (Cohere `input_type`, Voyage — later phases) will map it; **symmetric providers (Mistral, OpenAI) accept and ignore it**.
   - Mistral `Embed` ignores the role → **observable behavior unchanged**, pinned by a new test asserting byte-identical requests for both roles.
3. All adapters, call sites, and test fakes updated to the new signature.

## Why it's safe / scoped

- Clean **internal, pre-1.0** interface break (no compatibility users).
- **No config or wire/MCP change** → conformance suite and `dirstral-cli` unaffected.
- Symmetric-provider behavior provably unchanged (new `TestEmbed_SymmetricProviderIgnoresRole`).
- `make check` fully green.

## Follow-ups (gated, in order)

- **PR B**: `internal/openai` backbone adapter (embed+chat, +audio)
- **PR C**: `providers:`/`model:` config + selection + Mistral re-expression (the big one)
- **PR D**: full Cohere (embed+chat) · **PR E**: Anthropic + Gemini

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added role-aware embedding support to distinguish between document and query embeddings.

* **Tests**
  * Added verification test for embedding provider behavior with different roles.
  * Updated test embedders to support new interface.

* **Chores**
  * Updated dependency reference.
  * Refactored embedder interface across codebase.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dirstral/dir2mcp/pull/190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->