### PR TITLE
feat(openai): OpenAI-compatible backbone adapter (Embedder+Generator)

### DIFF
--- a/internal/openai/client.go
+++ b/internal/openai/client.go
@@ -1,0 +1,405 @@
+// Package openai provides a direct-HTTP adapter for the OpenAI-compatible
+// API surface (POST {base}/embeddings, POST {base}/chat/completions). It
+// is the provider-agnostic "backbone" (SPEC 8.1.1): the same wire shape
+// is served by OpenAI, OpenRouter, Groq, Together, Azure-style gateways,
+// local Ollama/vLLM/LM Studio, and Mistral chat/embeddings — selected
+// purely by BaseURL + model names.
+//
+// It mirrors internal/mistral and internal/cohere (BaseURL/APIKey/
+// HTTPClient, bounded exponential retry, typed model.ProviderError) so
+// callers can depend on model.Embedder / model.Generator without taking
+// a hard dependency on this package.
+//
+// OpenAI embeddings are symmetric, so the model.EmbedRole is accepted
+// and intentionally ignored (SPEC 8.1.5) — observable behavior MUST NOT
+// differ by role for this provider.
+package openai
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+const (
+	defaultBaseURL           = "https://api.openai.com/v1"
+	defaultRequestTimeout    = 30 * time.Second
+	defaultGenerationTimeout = 120 * time.Second
+	defaultMaxRetries        = 3
+	defaultInitialBackoff    = 250 * time.Millisecond
+	defaultMaxBackoff        = 2 * time.Second
+	defaultBatchSize         = 64
+
+	// DefaultEmbedModel / DefaultChatModel are fallbacks used only when
+	// the caller passes an empty model name. The config resolver
+	// normally supplies explicit models per profile.
+	DefaultEmbedModel = "text-embedding-3-small"
+	DefaultChatModel  = "gpt-4o-mini"
+)
+
+// Client is an OpenAI-compatible API adapter.
+//
+// Error codes (carried on *model.ProviderError):
+//   - OPENAI_AUTH (non-retryable): missing key, 401/403
+//   - OPENAI_RATE_LIMIT (retryable): 429
+//   - OPENAI_FAILED (retryable for network/5xx, else non-retryable)
+type Client struct {
+	BaseURL           string
+	APIKey            string
+	HTTPClient        *http.Client
+	MaxRetries        int
+	InitialBackoff    time.Duration
+	MaxBackoff        time.Duration
+	BatchSize         int
+	GenerationTimeout time.Duration
+	// DefaultEmbedModel/DefaultChatModel are used when the corresponding
+	// call is made with an empty model name.
+	DefaultEmbedModel string
+	DefaultChatModel  string
+}
+
+// compile-time assertions that *Client implements the model contracts.
+var (
+	_ model.Embedder  = (*Client)(nil)
+	_ model.Generator = (*Client)(nil)
+)
+
+// NewClient constructs a client with safe default retry/timeout settings.
+// An empty baseURL falls back to the public OpenAI endpoint; point it at
+// any OpenAI-compatible base (OpenRouter, Groq, Azure, local) to reuse
+// this adapter.
+func NewClient(baseURL, apiKey string) *Client {
+	baseURL = strings.TrimSpace(baseURL)
+	apiKey = strings.TrimSpace(apiKey)
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+	return &Client{
+		BaseURL:           strings.TrimRight(baseURL, "/"),
+		APIKey:            apiKey,
+		HTTPClient:        &http.Client{Timeout: defaultRequestTimeout},
+		MaxRetries:        defaultMaxRetries,
+		InitialBackoff:    defaultInitialBackoff,
+		MaxBackoff:        defaultMaxBackoff,
+		BatchSize:         defaultBatchSize,
+		GenerationTimeout: defaultGenerationTimeout,
+		DefaultEmbedModel: DefaultEmbedModel,
+		DefaultChatModel:  DefaultChatModel,
+	}
+}
+
+type embedRequest struct {
+	Model string   `json:"model"`
+	Input []string `json:"input"`
+}
+
+type embedResponse struct {
+	Data []struct {
+		Index     int       `json:"index"`
+		Embedding []float64 `json:"embedding"`
+	} `json:"data"`
+}
+
+// Embed implements model.Embedder. OpenAI embeddings are symmetric, so
+// the input role is accepted and ignored (SPEC 8.1.5). Inputs are sent
+// in BatchSize-sized batches; each batch is retried with bounded
+// exponential backoff, and vectors are reordered to match input order.
+func (c *Client) Embed(ctx context.Context, modelName string, _ model.EmbedRole, inputs []string) ([][]float32, error) {
+	if strings.TrimSpace(c.APIKey) == "" {
+		return nil, &model.ProviderError{Code: "OPENAI_AUTH", Message: "missing OpenAI API key", Retryable: false}
+	}
+	modelName = strings.TrimSpace(modelName)
+	if modelName == "" {
+		modelName = c.DefaultEmbedModel
+		if modelName == "" {
+			modelName = DefaultEmbedModel
+		}
+	}
+	if len(inputs) == 0 {
+		return [][]float32{}, nil
+	}
+
+	batchSize := c.BatchSize
+	if batchSize <= 0 {
+		batchSize = defaultBatchSize
+	}
+
+	out := make([][]float32, 0, len(inputs))
+	for start := 0; start < len(inputs); start += batchSize {
+		end := start + batchSize
+		if end > len(inputs) {
+			end = len(inputs)
+		}
+		vectors, err := c.embedBatchWithRetry(ctx, modelName, inputs[start:end])
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, vectors...)
+	}
+	return out, nil
+}
+
+func (c *Client) embedBatchWithRetry(ctx context.Context, modelName string, inputs []string) ([][]float32, error) {
+	maxRetries := c.MaxRetries
+	if maxRetries < 0 {
+		maxRetries = 0
+	}
+	var lastErr error
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		if attempt > 0 {
+			if err := c.wait(ctx, c.backoffForAttempt(attempt-1)); err != nil {
+				return nil, err
+			}
+		}
+		vectors, err := c.embedBatch(ctx, modelName, inputs)
+		if err == nil {
+			return vectors, nil
+		}
+		lastErr = err
+		var pErr *model.ProviderError
+		if errors.As(err, &pErr) && !pErr.Retryable {
+			return nil, err
+		}
+	}
+	return nil, lastErr
+}
+
+func (c *Client) embedBatch(ctx context.Context, modelName string, inputs []string) ([][]float32, error) {
+	body, err := json.Marshal(embedRequest{Model: modelName, Input: inputs})
+	if err != nil {
+		return nil, &model.ProviderError{Code: "OPENAI_FAILED", Message: "failed to marshal embedding request", Retryable: false, Cause: err}
+	}
+	resp, err := c.doJSON(ctx, "/embeddings", body, defaultRequestTimeout)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, httpError(resp)
+	}
+
+	var parsed embedResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil, &model.ProviderError{Code: "OPENAI_FAILED", Message: "failed to decode embedding response", Retryable: false, StatusCode: resp.StatusCode, Cause: err}
+	}
+	if len(parsed.Data) != len(inputs) {
+		return nil, &model.ProviderError{Code: "OPENAI_FAILED", Message: fmt.Sprintf("embedding response size mismatch: got %d vectors for %d inputs", len(parsed.Data), len(inputs)), Retryable: false, StatusCode: resp.StatusCode}
+	}
+
+	vectors := make([][]float32, len(inputs))
+	seen := make([]bool, len(inputs))
+	for _, item := range parsed.Data {
+		if item.Index < 0 || item.Index >= len(inputs) {
+			return nil, &model.ProviderError{Code: "OPENAI_FAILED", Message: fmt.Sprintf("embedding response contains out-of-range index %d", item.Index), Retryable: false, StatusCode: resp.StatusCode}
+		}
+		if seen[item.Index] {
+			return nil, &model.ProviderError{Code: "OPENAI_FAILED", Message: fmt.Sprintf("embedding response contains duplicate index %d", item.Index), Retryable: false, StatusCode: resp.StatusCode}
+		}
+		vec := make([]float32, len(item.Embedding))
+		for i, v := range item.Embedding {
+			vec[i] = float32(v)
+		}
+		vectors[item.Index] = vec
+		seen[item.Index] = true
+	}
+	for i := range seen {
+		if !seen[i] {
+			return nil, &model.ProviderError{Code: "OPENAI_FAILED", Message: fmt.Sprintf("embedding response missing index %d", i), Retryable: false, StatusCode: resp.StatusCode}
+		}
+	}
+	return vectors, nil
+}
+
+type generateMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type generateRequest struct {
+	Model    string            `json:"model"`
+	Messages []generateMessage `json:"messages"`
+}
+
+type generateResponse struct {
+	Choices []struct {
+		Message struct {
+			Content json.RawMessage `json:"content"`
+		} `json:"message"`
+	} `json:"choices"`
+}
+
+// Generate implements model.Generator via {base}/chat/completions.
+func (c *Client) Generate(ctx context.Context, prompt string) (string, error) {
+	if strings.TrimSpace(c.APIKey) == "" {
+		return "", &model.ProviderError{Code: "OPENAI_AUTH", Message: "missing OpenAI API key", Retryable: false}
+	}
+	chatModel := strings.TrimSpace(c.DefaultChatModel)
+	if chatModel == "" {
+		chatModel = DefaultChatModel
+	}
+
+	maxRetries := c.MaxRetries
+	if maxRetries < 0 {
+		maxRetries = 0
+	}
+	timeout := c.GenerationTimeout
+	if timeout <= 0 {
+		timeout = defaultGenerationTimeout
+	}
+
+	var lastErr error
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		if attempt > 0 {
+			if err := c.wait(ctx, c.backoffForAttempt(attempt-1)); err != nil {
+				return "", err
+			}
+		}
+		text, err := c.generateOnce(ctx, chatModel, prompt, timeout)
+		if err == nil {
+			return text, nil
+		}
+		lastErr = err
+		var pErr *model.ProviderError
+		if errors.As(err, &pErr) && !pErr.Retryable {
+			return "", err
+		}
+	}
+	return "", lastErr
+}
+
+func (c *Client) generateOnce(ctx context.Context, chatModel, prompt string, timeout time.Duration) (string, error) {
+	body, err := json.Marshal(generateRequest{
+		Model:    chatModel,
+		Messages: []generateMessage{{Role: "user", Content: prompt}},
+	})
+	if err != nil {
+		return "", &model.ProviderError{Code: "OPENAI_FAILED", Message: "failed to marshal generation request", Retryable: false, Cause: err}
+	}
+	resp, err := c.doJSON(ctx, "/chat/completions", body, timeout)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return "", httpError(resp)
+	}
+
+	var parsed generateResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return "", &model.ProviderError{Code: "OPENAI_FAILED", Message: "failed to decode generation response", Retryable: false, StatusCode: resp.StatusCode, Cause: err}
+	}
+	if len(parsed.Choices) == 0 {
+		return "", &model.ProviderError{Code: "OPENAI_FAILED", Message: "generation response had no choices", Retryable: false, StatusCode: resp.StatusCode}
+	}
+	text := strings.TrimSpace(contentToText(parsed.Choices[0].Message.Content))
+	if text == "" {
+		return "", &model.ProviderError{Code: "OPENAI_FAILED", Message: "generation response had empty content", Retryable: false, StatusCode: resp.StatusCode}
+	}
+	return text, nil
+}
+
+// contentToText accepts either a plain string content or the OpenAI
+// structured content array ([{"type":"text","text":"..."}]) and returns
+// the concatenated text.
+func contentToText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	var parts []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(raw, &parts); err == nil {
+		var b strings.Builder
+		for _, p := range parts {
+			if p.Type == "" || p.Type == "text" {
+				b.WriteString(p.Text)
+			}
+		}
+		return b.String()
+	}
+	return ""
+}
+
+func (c *Client) doJSON(ctx context.Context, path string, body []byte, timeout time.Duration) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+path, bytes.NewReader(body))
+	if err != nil {
+		return nil, &model.ProviderError{Code: "OPENAI_FAILED", Message: "failed to build request", Retryable: false, Cause: err}
+	}
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	client := c.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: timeout}
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, &model.ProviderError{Code: "OPENAI_FAILED", Message: "request failed", Retryable: true, Cause: err}
+	}
+	return resp, nil
+}
+
+func httpError(resp *http.Response) error {
+	bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	msg := strings.TrimSpace(string(bodyBytes))
+	if msg == "" {
+		msg = "upstream returned non-200 response"
+	}
+	switch {
+	case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
+		return &model.ProviderError{Code: "OPENAI_AUTH", Message: msg, Retryable: false, StatusCode: resp.StatusCode}
+	case resp.StatusCode == http.StatusTooManyRequests:
+		return &model.ProviderError{Code: "OPENAI_RATE_LIMIT", Message: msg, Retryable: true, StatusCode: resp.StatusCode}
+	case resp.StatusCode >= http.StatusInternalServerError:
+		return &model.ProviderError{Code: "OPENAI_FAILED", Message: msg, Retryable: true, StatusCode: resp.StatusCode}
+	default:
+		return &model.ProviderError{Code: "OPENAI_FAILED", Message: msg, Retryable: false, StatusCode: resp.StatusCode}
+	}
+}
+
+func (c *Client) backoffForAttempt(attempt int) time.Duration {
+	initial := c.InitialBackoff
+	if initial <= 0 {
+		initial = defaultInitialBackoff
+	}
+	maxBackoff := c.MaxBackoff
+	if maxBackoff <= 0 {
+		maxBackoff = defaultMaxBackoff
+	}
+	backoff := initial
+	for i := 0; i < attempt; i++ {
+		backoff *= 2
+		if backoff >= maxBackoff {
+			return maxBackoff
+		}
+	}
+	return backoff
+}
+
+func (c *Client) wait(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/internal/openai/client.go
+++ b/internal/openai/client.go
@@ -342,15 +342,26 @@ func (c *Client) doJSON(ctx context.Context, path string, body []byte, timeout t
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 
-	client := c.HTTPClient
-	if client == nil {
-		client = &http.Client{Timeout: timeout}
-	}
-	resp, err := client.Do(req)
+	resp, err := clientWithTimeout(c.HTTPClient, timeout).Do(req)
 	if err != nil {
 		return nil, &model.ProviderError{Code: "OPENAI_FAILED", Message: "request failed", Retryable: true, Cause: err}
 	}
 	return resp, nil
+}
+
+// clientWithTimeout returns an *http.Client that uses the per-call
+// timeout. The default client built by NewClient carries the short
+// (30s) request timeout, so chat completions — which use the longer
+// GenerationTimeout — must override it even when HTTPClient is set
+// (mirrors internal/mistral). The base client's Transport is shared via
+// a shallow copy so connection pooling is preserved.
+func clientWithTimeout(base *http.Client, timeout time.Duration) *http.Client {
+	if base == nil {
+		return &http.Client{Timeout: timeout}
+	}
+	cp := *base
+	cp.Timeout = timeout
+	return &cp
 }
 
 func httpError(resp *http.Response) error {

--- a/tests/openai/client_test.go
+++ b/tests/openai/client_test.go
@@ -37,7 +37,12 @@ func embedResp(inputs []string) map[string]any {
 func TestEmbed_BatchesPreservesOrderAndRetries(t *testing.T) {
 	var calls int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/embeddings" { // base URL carries the version path
+		// The adapter appends "/embeddings" to the configured BaseURL;
+		// any version segment (e.g. /v1) is part of the operator's
+		// BaseURL, not added here. This test's base has none, so the
+		// path is exactly "/embeddings" (versioned base covered by
+		// TestEndpointPathJoinPreservesVersion).
+		if r.URL.Path != "/embeddings" {
 			t.Errorf("path = %s", r.URL.Path)
 		}
 		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
@@ -75,6 +80,28 @@ func TestEmbed_BatchesPreservesOrderAndRetries(t *testing.T) {
 	}
 	if n := atomic.LoadInt32(&calls); n != 3 { // 1 retry (429) + 2 batches
 		t.Fatalf("calls = %d, want 3", n)
+	}
+}
+
+// TestEndpointPathJoinPreservesVersion verifies the adapter appends the
+// endpoint to a BaseURL that already carries a version segment, so an
+// operator-configured ".../v1" yields ".../v1/embeddings".
+func TestEndpointPathJoinPreservesVersion(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{{"index": 0, "embedding": []float64{1}}},
+		})
+	}))
+	defer srv.Close()
+
+	c := openai.NewClient(srv.URL+"/v1", "test-key")
+	if _, err := c.Embed(context.Background(), "m", model.EmbedDocument, []string{"x"}); err != nil {
+		t.Fatalf("embed: %v", err)
+	}
+	if gotPath != "/v1/embeddings" {
+		t.Fatalf("path = %q, want /v1/embeddings", gotPath)
 	}
 }
 
@@ -139,6 +166,34 @@ func TestGenerate_HappyPathAndStructuredContent(t *testing.T) {
 	}
 	if out != "hello world" {
 		t.Fatalf("content = %q, want %q", out, "hello world")
+	}
+}
+
+// TestGenerate_UsesGenerationTimeoutNotDefault locks the fix for the
+// PR #191 review: NewClient always sets HTTPClient (30s), so the
+// per-call GenerationTimeout must still be applied. With a 50ms
+// GenerationTimeout and a 300ms-slow server, Generate must fail fast
+// (~50ms) rather than hang toward the 30s default.
+func TestGenerate_UsesGenerationTimeoutNotDefault(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(300 * time.Millisecond)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{{"message": map[string]any{"content": "late"}}},
+		})
+	}))
+	defer srv.Close()
+
+	c := openai.NewClient(srv.URL, "test-key") // default HTTPClient: 30s
+	c.MaxRetries = 0
+	c.GenerationTimeout = 50 * time.Millisecond
+
+	start := time.Now()
+	_, err := c.Generate(context.Background(), "hi")
+	if err == nil {
+		t.Fatal("want timeout error, got nil")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("Generate did not honor GenerationTimeout (took %s)", elapsed)
 	}
 }
 

--- a/tests/openai/client_test.go
+++ b/tests/openai/client_test.go
@@ -1,0 +1,192 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/openai"
+)
+
+func newClient(url string) *openai.Client {
+	c := openai.NewClient(url, "test-key")
+	c.InitialBackoff = time.Millisecond
+	c.MaxBackoff = time.Millisecond
+	return c
+}
+
+// embedResp echoes one item per input, embedding[0] = first byte of the
+// input string, returned in REVERSED order to exercise index reordering.
+func embedResp(inputs []string) map[string]any {
+	n := len(inputs)
+	data := make([]map[string]any, n)
+	for i := 0; i < n; i++ {
+		p := n - 1 - i
+		data[i] = map[string]any{"index": p, "embedding": []float64{float64(inputs[p][0]), 0.5}}
+	}
+	return map[string]any{"data": data}
+}
+
+func TestEmbed_BatchesPreservesOrderAndRetries(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/embeddings" { // base URL carries the version path
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("auth = %q", got)
+		}
+		n := atomic.AddInt32(&calls, 1)
+		if n == 1 { // first batch: one transient 429 then success
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		var req struct {
+			Input []string `json:"input"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		_ = json.NewEncoder(w).Encode(embedResp(req.Input))
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL)
+	c.BatchSize = 2 // forces 2 batches for 3 inputs (a,b) then (c)
+	in := []string{"a", "b", "c"}
+	vecs, err := c.Embed(context.Background(), "text-embedding-3-small", model.EmbedDocument, in)
+	if err != nil {
+		t.Fatalf("embed: %v", err)
+	}
+	if len(vecs) != 3 {
+		t.Fatalf("got %d vectors, want 3", len(vecs))
+	}
+	// Each output vector must correspond to its input across batch
+	// boundaries (embedding[0] == first byte of the input string).
+	for i, s := range in {
+		if vecs[i][0] != float32(s[0]) {
+			t.Fatalf("order not preserved at %d: got %v, want first-byte of %q", i, vecs[i], s)
+		}
+	}
+	if n := atomic.LoadInt32(&calls); n != 3 { // 1 retry (429) + 2 batches
+		t.Fatalf("calls = %d, want 3", n)
+	}
+}
+
+func TestEmbed_MissingKeyIsNonRetryableAuth(t *testing.T) {
+	c := openai.NewClient("http://127.0.0.1:0", "")
+	_, err := c.Embed(context.Background(), "m", model.EmbedQuery, []string{"x"})
+	var pe *model.ProviderError
+	if !asProviderErr(err, &pe) || pe.Code != "OPENAI_AUTH" || pe.Retryable {
+		t.Fatalf("want non-retryable OPENAI_AUTH, got %v", err)
+	}
+}
+
+func TestEmbed_EmptyInputsNoCall(t *testing.T) {
+	c := openai.NewClient("http://127.0.0.1:0", "k")
+	v, err := c.Embed(context.Background(), "m", model.EmbedDocument, nil)
+	if err != nil || len(v) != 0 {
+		t.Fatalf("want ([],nil), got %v %v", v, err)
+	}
+}
+
+// TestEmbed_SymmetricRoleByteIdentical pins SPEC 8.1.5: OpenAI is a
+// symmetric embedder, so the raw request bytes MUST be identical for
+// EmbedDocument and EmbedQuery (role accepted and ignored).
+func TestEmbed_SymmetricRoleByteIdentical(t *testing.T) {
+	var bodies []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		bodies = append(bodies, string(raw))
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{{"index": 0, "embedding": []float64{1}}},
+		})
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL)
+	for _, role := range []model.EmbedRole{model.EmbedDocument, model.EmbedQuery} {
+		if _, err := c.Embed(context.Background(), "m", role, []string{"hi"}); err != nil {
+			t.Fatalf("embed (%s): %v", role, err)
+		}
+	}
+	if len(bodies) != 2 || bodies[0] != bodies[1] {
+		t.Fatalf("symmetric provider must send byte-identical request:\n%q\n%q", bodies[0], bodies[1])
+	}
+}
+
+func TestGenerate_HappyPathAndStructuredContent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{
+				{"message": map[string]any{"content": []map[string]any{
+					{"type": "text", "text": "hello "},
+					{"type": "text", "text": "world"},
+				}}},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	out, err := newClient(srv.URL).Generate(context.Background(), "hi")
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	if out != "hello world" {
+		t.Fatalf("content = %q, want %q", out, "hello world")
+	}
+}
+
+func TestGenerate_NoChoicesIsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"choices": []any{}})
+	}))
+	defer srv.Close()
+	_, err := newClient(srv.URL).Generate(context.Background(), "hi")
+	var pe *model.ProviderError
+	if !asProviderErr(err, &pe) || pe.Code != "OPENAI_FAILED" {
+		t.Fatalf("want OPENAI_FAILED, got %v", err)
+	}
+}
+
+func TestHTTPErrorMapping(t *testing.T) {
+	cases := []struct {
+		status    int
+		wantCode  string
+		retryable bool
+	}{
+		{http.StatusUnauthorized, "OPENAI_AUTH", false},
+		{http.StatusTooManyRequests, "OPENAI_RATE_LIMIT", true},
+		{http.StatusBadGateway, "OPENAI_FAILED", true},
+		{http.StatusBadRequest, "OPENAI_FAILED", false},
+	}
+	for _, tc := range cases {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(tc.status)
+		}))
+		c := newClient(srv.URL)
+		c.MaxRetries = 0
+		_, err := c.Embed(context.Background(), "m", model.EmbedDocument, []string{"x"})
+		srv.Close()
+		var pe *model.ProviderError
+		if !asProviderErr(err, &pe) || pe.Code != tc.wantCode || pe.Retryable != tc.retryable {
+			t.Fatalf("status %d: got %v, want %s retryable=%v", tc.status, err, tc.wantCode, tc.retryable)
+		}
+	}
+}
+
+func asProviderErr(err error, target **model.ProviderError) bool {
+	if err == nil {
+		return false
+	}
+	pe, ok := err.(*model.ProviderError)
+	if ok {
+		*target = pe
+	}
+	return ok && strings.HasPrefix(pe.Code, "OPENAI_")
+}


### PR DESCRIPTION
**PR B of the multi-provider implementation** (Design 0001 / SPEC §8.1.1). Follows #190 (merged).

## What

New `internal/openai` — a direct-HTTP adapter for the OpenAI-compatible wire surface (`POST {base}/embeddings`, `POST {base}/chat/completions`). This is the **backbone**: one adapter serves OpenAI, OpenRouter, Groq, Together, Azure-style gateways, local Ollama/vLLM/LM Studio, **and Mistral chat/embed** — selected purely by `BaseURL` + model names.

- Implements `model.Embedder` (with `EmbedRole`; OpenAI is **symmetric** → role accepted and ignored, **SPEC §8.1.5**) and `model.Generator`.
- Mirrors `internal/mistral`/`internal/cohere`: `BaseURL`/`APIKey`/`HTTPClient`, bounded exponential retry, typed `model.ProviderError` (`OPENAI_AUTH` / `OPENAI_RATE_LIMIT` / `OPENAI_FAILED`), batched embeddings with index reordering, flexible chat content (string *or* parts array).
- Compile-time assertions for both interfaces.

## Tests (httptest)

Batching + cross-batch order preservation, retry-then-success on 429, missing-key→non-retryable auth, empty-input no-call, **byte-identical request per role** (the §8.1.5 guarantee, raw-bytes per the #190 review lesson), full error-code mapping table, chat happy-path + structured-content + no-choices.

## Scope

**Additive only** — not yet wired into config/selection. Wiring + the `providers:`/`model:` schema + Mistral re-expression is **PR C** (the big one). `make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)