### PR TITLE
feat(gemini): embed + chat via OpenAI-compatible endpoint

### DIFF
--- a/internal/gemini/client.go
+++ b/internal/gemini/client.go
@@ -3,10 +3,10 @@
 // {base}/chat/completions). Per SPEC 8.1.2 a `gemini` profile may serve
 // embed ✅ chat ✅ stt ✅ tts ✅; this adapter implements the embed + chat
 // capabilities (model.Embedder / model.Generator) by reusing the same
-// OpenAI-compatible wire shape as internal/openai, selected purely by the
-// Gemini base URL + Gemini model names.
+// OpenAI-compatible wire shape as internal/mistral, selected purely by
+// the Gemini base URL + Gemini model names.
 //
-// It mirrors internal/openai and internal/cohere (BaseURL/APIKey/
+// It mirrors internal/mistral and internal/cohere (BaseURL/APIKey/
 // HTTPClient, bounded exponential retry, typed model.ProviderError) so
 // callers can depend on model.Embedder / model.Generator without taking
 // a hard dependency on this package.
@@ -125,7 +125,7 @@ func (c *Client) Embed(ctx context.Context, modelName string, _ model.EmbedRole,
 	}
 	modelName = strings.TrimSpace(modelName)
 	if modelName == "" {
-		modelName = c.DefaultEmbedModel
+		modelName = strings.TrimSpace(c.DefaultEmbedModel)
 		if modelName == "" {
 			modelName = DefaultEmbedModel
 		}
@@ -248,6 +248,9 @@ func (c *Client) Generate(ctx context.Context, prompt string) (string, error) {
 	if strings.TrimSpace(c.APIKey) == "" {
 		return "", &model.ProviderError{Code: "GEMINI_AUTH", Message: "missing Gemini API key", Retryable: false}
 	}
+	if strings.TrimSpace(prompt) == "" {
+		return "", &model.ProviderError{Code: "GEMINI_FAILED", Message: "prompt is required", Retryable: false}
+	}
 	chatModel := strings.TrimSpace(c.DefaultChatModel)
 	if chatModel == "" {
 		chatModel = DefaultChatModel
@@ -329,13 +332,16 @@ func contentToText(raw json.RawMessage) string {
 		Text string `json:"text"`
 	}
 	if err := json.Unmarshal(raw, &parts); err == nil {
-		var b strings.Builder
+		// Join text parts with newlines to match the existing Generator
+		// adapter (internal/mistral) so multiple parts don't merge into a
+		// different user-visible answer (e.g. "firstsecond").
+		texts := make([]string, 0, len(parts))
 		for _, p := range parts {
 			if p.Type == "" || p.Type == "text" {
-				b.WriteString(p.Text)
+				texts = append(texts, p.Text)
 			}
 		}
-		return b.String()
+		return strings.Join(texts, "\n")
 	}
 	return ""
 }
@@ -360,7 +366,7 @@ func (c *Client) doJSON(ctx context.Context, path string, body []byte, timeout t
 // timeout. The default client built by NewClient carries the short
 // (30s) request timeout, so chat completions — which use the longer
 // GenerationTimeout — must override it even when HTTPClient is set
-// (mirrors internal/openai). The base client's Transport is shared via
+// (mirrors internal/mistral). The base client's Transport is shared via
 // a shallow copy so connection pooling is preserved.
 func clientWithTimeout(base *http.Client, timeout time.Duration) *http.Client {
 	if base == nil {

--- a/internal/gemini/client.go
+++ b/internal/gemini/client.go
@@ -1,0 +1,423 @@
+// Package gemini provides a direct-HTTP adapter for Google Gemini via its
+// OpenAI-compatible API surface (POST {base}/embeddings, POST
+// {base}/chat/completions). Per SPEC 8.1.2 a `gemini` profile may serve
+// embed ✅ chat ✅ stt ✅ tts ✅; this adapter implements the embed + chat
+// capabilities (model.Embedder / model.Generator) by reusing the same
+// OpenAI-compatible wire shape as internal/openai, selected purely by the
+// Gemini base URL + Gemini model names.
+//
+// It mirrors internal/openai and internal/cohere (BaseURL/APIKey/
+// HTTPClient, bounded exponential retry, typed model.ProviderError) so
+// callers can depend on model.Embedder / model.Generator without taking
+// a hard dependency on this package.
+//
+// Gemini embeddings are symmetric, so the model.EmbedRole is accepted
+// and intentionally ignored (SPEC 8.1.5) — observable behavior MUST NOT
+// differ by role for this provider.
+//
+// TODO(spec 8.1.2): native Gemini STT/TTS. The capability matrix marks
+// `gemini` as stt ✅ tts ✅, but this adapter implements embed + chat
+// only. Audio (model.Transcriber / TTS) is deferred to a follow-up PR
+// and is intentionally not implemented here.
+package gemini
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+const (
+	// defaultBaseURL is Gemini's OpenAI-compatible endpoint. The adapter
+	// appends /embeddings and /chat/completions to this base.
+	defaultBaseURL           = "https://generativelanguage.googleapis.com/v1beta/openai"
+	defaultRequestTimeout    = 30 * time.Second
+	defaultGenerationTimeout = 120 * time.Second
+	defaultMaxRetries        = 3
+	defaultInitialBackoff    = 250 * time.Millisecond
+	defaultMaxBackoff        = 2 * time.Second
+	defaultBatchSize         = 64
+
+	// DefaultEmbedModel / DefaultChatModel are fallbacks used only when
+	// the caller passes an empty model name. The config resolver
+	// normally supplies explicit models per profile.
+	DefaultEmbedModel = "text-embedding-004"
+	DefaultChatModel  = "gemini-2.5-flash"
+)
+
+// Client is a Gemini adapter that speaks the OpenAI-compatible wire
+// protocol.
+//
+// Error codes (carried on *model.ProviderError):
+//   - GEMINI_AUTH (non-retryable): missing key, 401/403
+//   - GEMINI_RATE_LIMIT (retryable): 429
+//   - GEMINI_FAILED (retryable for network/5xx, else non-retryable)
+type Client struct {
+	BaseURL           string
+	APIKey            string
+	HTTPClient        *http.Client
+	MaxRetries        int
+	InitialBackoff    time.Duration
+	MaxBackoff        time.Duration
+	BatchSize         int
+	GenerationTimeout time.Duration
+	// DefaultEmbedModel/DefaultChatModel are used when the corresponding
+	// call is made with an empty model name.
+	DefaultEmbedModel string
+	DefaultChatModel  string
+}
+
+// compile-time assertions that *Client implements the model contracts.
+var (
+	_ model.Embedder  = (*Client)(nil)
+	_ model.Generator = (*Client)(nil)
+)
+
+// NewClient constructs a client with safe default retry/timeout settings.
+// An empty baseURL falls back to Gemini's OpenAI-compatible endpoint.
+func NewClient(baseURL, apiKey string) *Client {
+	baseURL = strings.TrimSpace(baseURL)
+	apiKey = strings.TrimSpace(apiKey)
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+	return &Client{
+		BaseURL:           strings.TrimRight(baseURL, "/"),
+		APIKey:            apiKey,
+		HTTPClient:        &http.Client{Timeout: defaultRequestTimeout},
+		MaxRetries:        defaultMaxRetries,
+		InitialBackoff:    defaultInitialBackoff,
+		MaxBackoff:        defaultMaxBackoff,
+		BatchSize:         defaultBatchSize,
+		GenerationTimeout: defaultGenerationTimeout,
+		DefaultEmbedModel: DefaultEmbedModel,
+		DefaultChatModel:  DefaultChatModel,
+	}
+}
+
+type embedRequest struct {
+	Model string   `json:"model"`
+	Input []string `json:"input"`
+}
+
+type embedResponse struct {
+	Data []struct {
+		Index     int       `json:"index"`
+		Embedding []float64 `json:"embedding"`
+	} `json:"data"`
+}
+
+// Embed implements model.Embedder. Gemini embeddings are symmetric, so
+// the input role is accepted and ignored (SPEC 8.1.5). Inputs are sent
+// in BatchSize-sized batches; each batch is retried with bounded
+// exponential backoff, and vectors are reordered to match input order.
+func (c *Client) Embed(ctx context.Context, modelName string, _ model.EmbedRole, inputs []string) ([][]float32, error) {
+	if strings.TrimSpace(c.APIKey) == "" {
+		return nil, &model.ProviderError{Code: "GEMINI_AUTH", Message: "missing Gemini API key", Retryable: false}
+	}
+	modelName = strings.TrimSpace(modelName)
+	if modelName == "" {
+		modelName = c.DefaultEmbedModel
+		if modelName == "" {
+			modelName = DefaultEmbedModel
+		}
+	}
+	if len(inputs) == 0 {
+		return [][]float32{}, nil
+	}
+
+	batchSize := c.BatchSize
+	if batchSize <= 0 {
+		batchSize = defaultBatchSize
+	}
+
+	out := make([][]float32, 0, len(inputs))
+	for start := 0; start < len(inputs); start += batchSize {
+		end := start + batchSize
+		if end > len(inputs) {
+			end = len(inputs)
+		}
+		vectors, err := c.embedBatchWithRetry(ctx, modelName, inputs[start:end])
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, vectors...)
+	}
+	return out, nil
+}
+
+func (c *Client) embedBatchWithRetry(ctx context.Context, modelName string, inputs []string) ([][]float32, error) {
+	maxRetries := c.MaxRetries
+	if maxRetries < 0 {
+		maxRetries = 0
+	}
+	var lastErr error
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		if attempt > 0 {
+			if err := c.wait(ctx, c.backoffForAttempt(attempt-1)); err != nil {
+				return nil, err
+			}
+		}
+		vectors, err := c.embedBatch(ctx, modelName, inputs)
+		if err == nil {
+			return vectors, nil
+		}
+		lastErr = err
+		var pErr *model.ProviderError
+		if errors.As(err, &pErr) && !pErr.Retryable {
+			return nil, err
+		}
+	}
+	return nil, lastErr
+}
+
+func (c *Client) embedBatch(ctx context.Context, modelName string, inputs []string) ([][]float32, error) {
+	body, err := json.Marshal(embedRequest{Model: modelName, Input: inputs})
+	if err != nil {
+		return nil, &model.ProviderError{Code: "GEMINI_FAILED", Message: "failed to marshal embedding request", Retryable: false, Cause: err}
+	}
+	resp, err := c.doJSON(ctx, "/embeddings", body, defaultRequestTimeout)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, httpError(resp)
+	}
+
+	var parsed embedResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil, &model.ProviderError{Code: "GEMINI_FAILED", Message: "failed to decode embedding response", Retryable: false, StatusCode: resp.StatusCode, Cause: err}
+	}
+	if len(parsed.Data) != len(inputs) {
+		return nil, &model.ProviderError{Code: "GEMINI_FAILED", Message: fmt.Sprintf("embedding response size mismatch: got %d vectors for %d inputs", len(parsed.Data), len(inputs)), Retryable: false, StatusCode: resp.StatusCode}
+	}
+
+	vectors := make([][]float32, len(inputs))
+	seen := make([]bool, len(inputs))
+	for _, item := range parsed.Data {
+		if item.Index < 0 || item.Index >= len(inputs) {
+			return nil, &model.ProviderError{Code: "GEMINI_FAILED", Message: fmt.Sprintf("embedding response contains out-of-range index %d", item.Index), Retryable: false, StatusCode: resp.StatusCode}
+		}
+		if seen[item.Index] {
+			return nil, &model.ProviderError{Code: "GEMINI_FAILED", Message: fmt.Sprintf("embedding response contains duplicate index %d", item.Index), Retryable: false, StatusCode: resp.StatusCode}
+		}
+		vec := make([]float32, len(item.Embedding))
+		for i, v := range item.Embedding {
+			vec[i] = float32(v)
+		}
+		vectors[item.Index] = vec
+		seen[item.Index] = true
+	}
+	for i := range seen {
+		if !seen[i] {
+			return nil, &model.ProviderError{Code: "GEMINI_FAILED", Message: fmt.Sprintf("embedding response missing index %d", i), Retryable: false, StatusCode: resp.StatusCode}
+		}
+	}
+	return vectors, nil
+}
+
+type generateMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type generateRequest struct {
+	Model    string            `json:"model"`
+	Messages []generateMessage `json:"messages"`
+}
+
+type generateResponse struct {
+	Choices []struct {
+		Message struct {
+			Content json.RawMessage `json:"content"`
+		} `json:"message"`
+	} `json:"choices"`
+}
+
+// Generate implements model.Generator via {base}/chat/completions.
+func (c *Client) Generate(ctx context.Context, prompt string) (string, error) {
+	if strings.TrimSpace(c.APIKey) == "" {
+		return "", &model.ProviderError{Code: "GEMINI_AUTH", Message: "missing Gemini API key", Retryable: false}
+	}
+	chatModel := strings.TrimSpace(c.DefaultChatModel)
+	if chatModel == "" {
+		chatModel = DefaultChatModel
+	}
+
+	maxRetries := c.MaxRetries
+	if maxRetries < 0 {
+		maxRetries = 0
+	}
+	timeout := c.GenerationTimeout
+	if timeout <= 0 {
+		timeout = defaultGenerationTimeout
+	}
+
+	var lastErr error
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		if attempt > 0 {
+			if err := c.wait(ctx, c.backoffForAttempt(attempt-1)); err != nil {
+				return "", err
+			}
+		}
+		text, err := c.generateOnce(ctx, chatModel, prompt, timeout)
+		if err == nil {
+			return text, nil
+		}
+		lastErr = err
+		var pErr *model.ProviderError
+		if errors.As(err, &pErr) && !pErr.Retryable {
+			return "", err
+		}
+	}
+	return "", lastErr
+}
+
+func (c *Client) generateOnce(ctx context.Context, chatModel, prompt string, timeout time.Duration) (string, error) {
+	body, err := json.Marshal(generateRequest{
+		Model:    chatModel,
+		Messages: []generateMessage{{Role: "user", Content: prompt}},
+	})
+	if err != nil {
+		return "", &model.ProviderError{Code: "GEMINI_FAILED", Message: "failed to marshal generation request", Retryable: false, Cause: err}
+	}
+	resp, err := c.doJSON(ctx, "/chat/completions", body, timeout)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return "", httpError(resp)
+	}
+
+	var parsed generateResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return "", &model.ProviderError{Code: "GEMINI_FAILED", Message: "failed to decode generation response", Retryable: false, StatusCode: resp.StatusCode, Cause: err}
+	}
+	if len(parsed.Choices) == 0 {
+		return "", &model.ProviderError{Code: "GEMINI_FAILED", Message: "generation response had no choices", Retryable: false, StatusCode: resp.StatusCode}
+	}
+	text := strings.TrimSpace(contentToText(parsed.Choices[0].Message.Content))
+	if text == "" {
+		return "", &model.ProviderError{Code: "GEMINI_FAILED", Message: "generation response had empty content", Retryable: false, StatusCode: resp.StatusCode}
+	}
+	return text, nil
+}
+
+// contentToText accepts either a plain string content or the OpenAI
+// structured content array ([{"type":"text","text":"..."}]) and returns
+// the concatenated text.
+func contentToText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	var parts []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(raw, &parts); err == nil {
+		var b strings.Builder
+		for _, p := range parts {
+			if p.Type == "" || p.Type == "text" {
+				b.WriteString(p.Text)
+			}
+		}
+		return b.String()
+	}
+	return ""
+}
+
+func (c *Client) doJSON(ctx context.Context, path string, body []byte, timeout time.Duration) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+path, bytes.NewReader(body))
+	if err != nil {
+		return nil, &model.ProviderError{Code: "GEMINI_FAILED", Message: "failed to build request", Retryable: false, Cause: err}
+	}
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := clientWithTimeout(c.HTTPClient, timeout).Do(req)
+	if err != nil {
+		return nil, &model.ProviderError{Code: "GEMINI_FAILED", Message: "request failed", Retryable: true, Cause: err}
+	}
+	return resp, nil
+}
+
+// clientWithTimeout returns an *http.Client that uses the per-call
+// timeout. The default client built by NewClient carries the short
+// (30s) request timeout, so chat completions — which use the longer
+// GenerationTimeout — must override it even when HTTPClient is set
+// (mirrors internal/openai). The base client's Transport is shared via
+// a shallow copy so connection pooling is preserved.
+func clientWithTimeout(base *http.Client, timeout time.Duration) *http.Client {
+	if base == nil {
+		return &http.Client{Timeout: timeout}
+	}
+	cp := *base
+	cp.Timeout = timeout
+	return &cp
+}
+
+func httpError(resp *http.Response) error {
+	bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	msg := strings.TrimSpace(string(bodyBytes))
+	if msg == "" {
+		msg = "upstream returned non-200 response"
+	}
+	switch {
+	case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
+		return &model.ProviderError{Code: "GEMINI_AUTH", Message: msg, Retryable: false, StatusCode: resp.StatusCode}
+	case resp.StatusCode == http.StatusTooManyRequests:
+		return &model.ProviderError{Code: "GEMINI_RATE_LIMIT", Message: msg, Retryable: true, StatusCode: resp.StatusCode}
+	case resp.StatusCode >= http.StatusInternalServerError:
+		return &model.ProviderError{Code: "GEMINI_FAILED", Message: msg, Retryable: true, StatusCode: resp.StatusCode}
+	default:
+		return &model.ProviderError{Code: "GEMINI_FAILED", Message: msg, Retryable: false, StatusCode: resp.StatusCode}
+	}
+}
+
+func (c *Client) backoffForAttempt(attempt int) time.Duration {
+	initial := c.InitialBackoff
+	if initial <= 0 {
+		initial = defaultInitialBackoff
+	}
+	maxBackoff := c.MaxBackoff
+	if maxBackoff <= 0 {
+		maxBackoff = defaultMaxBackoff
+	}
+	backoff := initial
+	for i := 0; i < attempt; i++ {
+		backoff *= 2
+		if backoff >= maxBackoff {
+			return maxBackoff
+		}
+	}
+	return backoff
+}
+
+func (c *Client) wait(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/tests/gemini/client_test.go
+++ b/tests/gemini/client_test.go
@@ -1,0 +1,248 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/gemini"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+func newClient(url string) *gemini.Client {
+	c := gemini.NewClient(url, "test-key")
+	c.InitialBackoff = time.Millisecond
+	c.MaxBackoff = time.Millisecond
+	return c
+}
+
+// embedResp echoes one item per input, embedding[0] = first byte of the
+// input string, returned in REVERSED order to exercise index reordering.
+func embedResp(inputs []string) map[string]any {
+	n := len(inputs)
+	data := make([]map[string]any, n)
+	for i := 0; i < n; i++ {
+		p := n - 1 - i
+		data[i] = map[string]any{"index": p, "embedding": []float64{float64(inputs[p][0]), 0.5}}
+	}
+	return map[string]any{"data": data}
+}
+
+func TestEmbed_BatchesPreservesOrderAndRetries(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The adapter appends "/embeddings" to the configured BaseURL;
+		// any version segment is part of the operator's BaseURL, not
+		// added here. This test's base has none, so the path is exactly
+		// "/embeddings" (versioned base covered by
+		// TestEndpointPathJoinPreservesVersion).
+		if r.URL.Path != "/embeddings" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("auth = %q", got)
+		}
+		n := atomic.AddInt32(&calls, 1)
+		if n == 1 { // first batch: one transient 429 then success
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		var req struct {
+			Input []string `json:"input"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		_ = json.NewEncoder(w).Encode(embedResp(req.Input))
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL)
+	c.BatchSize = 2 // forces 2 batches for 3 inputs (a,b) then (c)
+	in := []string{"a", "b", "c"}
+	vecs, err := c.Embed(context.Background(), "text-embedding-004", model.EmbedDocument, in)
+	if err != nil {
+		t.Fatalf("embed: %v", err)
+	}
+	if len(vecs) != 3 {
+		t.Fatalf("got %d vectors, want 3", len(vecs))
+	}
+	// Each output vector must correspond to its input across batch
+	// boundaries (embedding[0] == first byte of the input string).
+	for i, s := range in {
+		if vecs[i][0] != float32(s[0]) {
+			t.Fatalf("order not preserved at %d: got %v, want first-byte of %q", i, vecs[i], s)
+		}
+	}
+	if n := atomic.LoadInt32(&calls); n != 3 { // 1 retry (429) + 2 batches
+		t.Fatalf("calls = %d, want 3", n)
+	}
+}
+
+// TestEndpointPathJoinPreservesVersion verifies the adapter appends the
+// endpoint to a BaseURL that already carries a version segment, so an
+// operator-configured ".../v1beta/openai" yields
+// ".../v1beta/openai/embeddings".
+func TestEndpointPathJoinPreservesVersion(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{{"index": 0, "embedding": []float64{1}}},
+		})
+	}))
+	defer srv.Close()
+
+	c := gemini.NewClient(srv.URL+"/v1beta/openai", "test-key")
+	if _, err := c.Embed(context.Background(), "m", model.EmbedDocument, []string{"x"}); err != nil {
+		t.Fatalf("embed: %v", err)
+	}
+	if gotPath != "/v1beta/openai/embeddings" {
+		t.Fatalf("path = %q, want /v1beta/openai/embeddings", gotPath)
+	}
+}
+
+func TestEmbed_MissingKeyIsNonRetryableAuth(t *testing.T) {
+	c := gemini.NewClient("http://127.0.0.1:0", "")
+	_, err := c.Embed(context.Background(), "m", model.EmbedQuery, []string{"x"})
+	var pe *model.ProviderError
+	if !asProviderErr(err, &pe) || pe.Code != "GEMINI_AUTH" || pe.Retryable {
+		t.Fatalf("want non-retryable GEMINI_AUTH, got %v", err)
+	}
+}
+
+func TestEmbed_EmptyInputsNoCall(t *testing.T) {
+	c := gemini.NewClient("http://127.0.0.1:0", "k")
+	v, err := c.Embed(context.Background(), "m", model.EmbedDocument, nil)
+	if err != nil || len(v) != 0 {
+		t.Fatalf("want ([],nil), got %v %v", v, err)
+	}
+}
+
+// TestEmbed_SymmetricRoleByteIdentical pins SPEC 8.1.5: Gemini is a
+// symmetric embedder, so the raw request bytes MUST be identical for
+// EmbedDocument and EmbedQuery (role accepted and ignored).
+func TestEmbed_SymmetricRoleByteIdentical(t *testing.T) {
+	var bodies []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		bodies = append(bodies, string(raw))
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{{"index": 0, "embedding": []float64{1}}},
+		})
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL)
+	for _, role := range []model.EmbedRole{model.EmbedDocument, model.EmbedQuery} {
+		if _, err := c.Embed(context.Background(), "m", role, []string{"hi"}); err != nil {
+			t.Fatalf("embed (%s): %v", role, err)
+		}
+	}
+	if len(bodies) != 2 || bodies[0] != bodies[1] {
+		t.Fatalf("symmetric provider must send byte-identical request:\n%q\n%q", bodies[0], bodies[1])
+	}
+}
+
+func TestGenerate_HappyPathAndStructuredContent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{
+				{"message": map[string]any{"content": []map[string]any{
+					{"type": "text", "text": "hello "},
+					{"type": "text", "text": "world"},
+				}}},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	out, err := newClient(srv.URL).Generate(context.Background(), "hi")
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	if out != "hello world" {
+		t.Fatalf("content = %q, want %q", out, "hello world")
+	}
+}
+
+// TestGenerate_UsesGenerationTimeoutNotDefault locks the same invariant
+// as internal/openai: NewClient always sets HTTPClient (30s), so the
+// per-call GenerationTimeout must still be applied. With a 50ms
+// GenerationTimeout and a 300ms-slow server, Generate must fail fast
+// (~50ms) rather than hang toward the 30s default.
+func TestGenerate_UsesGenerationTimeoutNotDefault(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(300 * time.Millisecond)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{{"message": map[string]any{"content": "late"}}},
+		})
+	}))
+	defer srv.Close()
+
+	c := gemini.NewClient(srv.URL, "test-key") // default HTTPClient: 30s
+	c.MaxRetries = 0
+	c.GenerationTimeout = 50 * time.Millisecond
+
+	start := time.Now()
+	_, err := c.Generate(context.Background(), "hi")
+	if err == nil {
+		t.Fatal("want timeout error, got nil")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("Generate did not honor GenerationTimeout (took %s)", elapsed)
+	}
+}
+
+func TestGenerate_NoChoicesIsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"choices": []any{}})
+	}))
+	defer srv.Close()
+	_, err := newClient(srv.URL).Generate(context.Background(), "hi")
+	var pe *model.ProviderError
+	if !asProviderErr(err, &pe) || pe.Code != "GEMINI_FAILED" {
+		t.Fatalf("want GEMINI_FAILED, got %v", err)
+	}
+}
+
+func TestHTTPErrorMapping(t *testing.T) {
+	cases := []struct {
+		status    int
+		wantCode  string
+		retryable bool
+	}{
+		{http.StatusUnauthorized, "GEMINI_AUTH", false},
+		{http.StatusTooManyRequests, "GEMINI_RATE_LIMIT", true},
+		{http.StatusBadGateway, "GEMINI_FAILED", true},
+		{http.StatusBadRequest, "GEMINI_FAILED", false},
+	}
+	for _, tc := range cases {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(tc.status)
+		}))
+		c := newClient(srv.URL)
+		c.MaxRetries = 0
+		_, err := c.Embed(context.Background(), "m", model.EmbedDocument, []string{"x"})
+		srv.Close()
+		var pe *model.ProviderError
+		if !asProviderErr(err, &pe) || pe.Code != tc.wantCode || pe.Retryable != tc.retryable {
+			t.Fatalf("status %d: got %v, want %s retryable=%v", tc.status, err, tc.wantCode, tc.retryable)
+		}
+	}
+}
+
+func asProviderErr(err error, target **model.ProviderError) bool {
+	if err == nil {
+		return false
+	}
+	pe, ok := err.(*model.ProviderError)
+	if ok {
+		*target = pe
+	}
+	return ok && strings.HasPrefix(pe.Code, "GEMINI_")
+}

--- a/tests/gemini/client_test.go
+++ b/tests/gemini/client_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -153,7 +154,7 @@ func TestGenerate_HappyPathAndStructuredContent(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"choices": []map[string]any{
 				{"message": map[string]any{"content": []map[string]any{
-					{"type": "text", "text": "hello "},
+					{"type": "text", "text": "hello"},
 					{"type": "text", "text": "world"},
 				}}},
 			},
@@ -165,13 +166,14 @@ func TestGenerate_HappyPathAndStructuredContent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("generate: %v", err)
 	}
-	if out != "hello world" {
-		t.Fatalf("content = %q, want %q", out, "hello world")
+	// Multiple text parts are newline-joined (mirrors internal/mistral).
+	if out != "hello\nworld" {
+		t.Fatalf("content = %q, want %q", out, "hello\nworld")
 	}
 }
 
 // TestGenerate_UsesGenerationTimeoutNotDefault locks the same invariant
-// as internal/openai: NewClient always sets HTTPClient (30s), so the
+// as internal/mistral: NewClient always sets HTTPClient (30s), so the
 // per-call GenerationTimeout must still be applied. With a 50ms
 // GenerationTimeout and a 300ms-slow server, Generate must fail fast
 // (~50ms) rather than hang toward the 30s default.
@@ -217,6 +219,7 @@ func TestHTTPErrorMapping(t *testing.T) {
 		retryable bool
 	}{
 		{http.StatusUnauthorized, "GEMINI_AUTH", false},
+		{http.StatusForbidden, "GEMINI_AUTH", false},
 		{http.StatusTooManyRequests, "GEMINI_RATE_LIMIT", true},
 		{http.StatusBadGateway, "GEMINI_FAILED", true},
 		{http.StatusBadRequest, "GEMINI_FAILED", false},
@@ -236,13 +239,122 @@ func TestHTTPErrorMapping(t *testing.T) {
 	}
 }
 
+func TestGenerate_RequestShapeAndStringContent(t *testing.T) {
+	var gotPath, gotAuth, gotModel string
+	var gotMsgs int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		var req struct {
+			Model    string `json:"model"`
+			Messages []struct {
+				Role string `json:"role"`
+			} `json:"messages"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		gotModel, gotMsgs = req.Model, len(req.Messages)
+		// Primary OpenAI-compatible shape: content is a plain string.
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{{"message": map[string]any{"content": "pong"}}},
+		})
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL)
+	c.DefaultChatModel = "gemini-custom"
+	out, err := c.Generate(context.Background(), "ping")
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	if out != "pong" {
+		t.Fatalf("content = %q, want pong (string-content path)", out)
+	}
+	if gotPath != "/chat/completions" {
+		t.Fatalf("path = %q, want /chat/completions", gotPath)
+	}
+	if gotAuth != "Bearer test-key" {
+		t.Fatalf("auth = %q", gotAuth)
+	}
+	if gotModel != "gemini-custom" || gotMsgs != 1 {
+		t.Fatalf("request shape: model=%q messages=%d", gotModel, gotMsgs)
+	}
+}
+
+func TestGenerate_MissingKeyIsNonRetryableAuth(t *testing.T) {
+	c := gemini.NewClient("http://127.0.0.1:0", "")
+	_, err := c.Generate(context.Background(), "hi")
+	var pe *model.ProviderError
+	if !asProviderErr(err, &pe) || pe.Code != "GEMINI_AUTH" || pe.Retryable {
+		t.Fatalf("want non-retryable GEMINI_AUTH, got %v", err)
+	}
+}
+
+// TestEmbed_DefaultModelFallback covers the empty-model fallback to the
+// (overridable) DefaultEmbedModel — the request body must carry it.
+func TestEmbed_DefaultModelFallback(t *testing.T) {
+	var gotModel string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Model string `json:"model"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		gotModel = req.Model
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{{"index": 0, "embedding": []float64{1}}},
+		})
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL)
+	c.DefaultEmbedModel = "embed-override"
+	if _, err := c.Embed(context.Background(), "", model.EmbedDocument, []string{"x"}); err != nil {
+		t.Fatalf("embed: %v", err)
+	}
+	if gotModel != "embed-override" {
+		t.Fatalf("model = %q, want embed-override (DefaultEmbedModel fallback)", gotModel)
+	}
+}
+
+// TestNonRetryableStopsImmediately asserts a non-retryable HTTP status
+// (400) is attempted exactly once even with retries enabled — for both
+// Embed and Generate.
+func TestNonRetryableStopsImmediately(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		call func(*gemini.Client) error
+	}{
+		{"embed", func(c *gemini.Client) error {
+			_, e := c.Embed(context.Background(), "m", model.EmbedDocument, []string{"x"})
+			return e
+		}},
+		{"generate", func(c *gemini.Client) error {
+			_, e := c.Generate(context.Background(), "hi")
+			return e
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var calls int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				atomic.AddInt32(&calls, 1)
+				w.WriteHeader(http.StatusBadRequest)
+			}))
+			defer srv.Close()
+			c := newClient(srv.URL) // MaxRetries default (3)
+			if err := tc.call(c); err == nil {
+				t.Fatal("want error")
+			}
+			if n := atomic.LoadInt32(&calls); n != 1 {
+				t.Fatalf("non-retryable 400 attempted %d times, want 1", n)
+			}
+		})
+	}
+}
+
+// asProviderErr unwraps via errors.As (repo convention) so wrapped
+// provider errors are still recognized.
 func asProviderErr(err error, target **model.ProviderError) bool {
-	if err == nil {
+	if !errors.As(err, target) {
 		return false
 	}
-	pe, ok := err.(*model.ProviderError)
-	if ok {
-		*target = pe
-	}
-	return ok && strings.HasPrefix(pe.Code, "GEMINI_")
+	return strings.HasPrefix((*target).Code, "GEMINI_")
 }


### PR DESCRIPTION
## PR E-gemini

Adds a new `internal/gemini` adapter implementing `model.Embedder` and `model.Generator` for Google Gemini via its **OpenAI-compatible endpoint** (base `https://generativelanguage.googleapis.com/v1beta/openai`, Bearer api key, `/embeddings` + `/chat/completions`).

### Scope

- **embed + chat only.** Per SPEC §8.1.2 the `gemini` kind is embed ✅ chat ✅ stt ✅ tts ✅; this PR implements the `Embedder` + `Generator` interfaces.
- **STT/TTS explicitly deferred** to a follow-up PR (SPEC 8.1.2 follow-up). A `// TODO(spec 8.1.2): native Gemini STT/TTS` package-doc note makes the gap explicit; no audio is implemented here.

### Design

- Mirrors `internal/openai` wire logic and conventions exactly: bounded exponential retry, typed `*model.ProviderError` with codes `GEMINI_AUTH` (non-retryable) / `GEMINI_RATE_LIMIT` (retryable) / `GEMINI_FAILED`, `clientWithTimeout` shallow-copy so `GenerationTimeout` applies even with the default `HTTPClient`, and compile-time `model.Embedder` / `model.Generator` assertions.
- Defaults: `text-embedding-004` (embed), `gemini-2.5-flash` (chat).
- Gemini embeddings are symmetric, so `model.EmbedRole` is accepted and ignored (SPEC §8.1.5) — request bytes are byte-identical across `document` / `query`.

### Constraints honored

- **Additive and not wired.** No changes to `internal/config`, `internal/cli`, or any wiring — new package + tests only.
- Tests (`tests/gemini`, httptest) mirror `tests/openai`: batching + order with retry, byte-identical request per role (8.1.5), missing-key non-retryable `GEMINI_AUTH`, error-code mapping table, chat happy / no-choices, `GenerationTimeout` honored with default `HTTPClient`, versioned-base path join.
- `make check` — `fmt`/`vet`/`golangci-lint` (0 issues)/`gocyclo<=15`/build all green; `tests/gemini` passes. The only failing test is the pre-existing, unrelated `tests/security` `TestRepoSplitBoundary_NoDirstralCLIImports`, which trips on **other agents' nested `.claude/worktrees/` copies of that test file** (an environmental multi-agent artifact) — zero gemini files involved.

### Open item

- ⚠️ Native Gemini STT/TTS deferred (SPEC §8.1.2 `gemini` stt ✅ tts ✅) — tracked via the `TODO(spec 8.1.2)` package-doc note, to be implemented in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)