### PR TITLE
feat(anthropic): Messages API adapter (Generator)

### DIFF
--- a/internal/anthropic/client.go
+++ b/internal/anthropic/client.go
@@ -1,0 +1,266 @@
+// Package anthropic provides a direct-HTTP adapter for the Anthropic
+// Messages API (POST {base}/v1/messages). It is chat-only: Anthropic
+// exposes no embeddings/OCR/STT/TTS/rerank surface, so this package
+// implements model.Generator and nothing else (SPEC 8.1.2).
+//
+// It mirrors internal/openai and internal/cohere (BaseURL/APIKey/
+// HTTPClient, bounded exponential retry, typed model.ProviderError,
+// per-call GenerationTimeout via a shallow-copy of HTTPClient) so
+// callers can depend on model.Generator without taking a hard
+// dependency on this package.
+package anthropic
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+const (
+	defaultBaseURL           = "https://api.anthropic.com"
+	defaultRequestTimeout    = 30 * time.Second
+	defaultGenerationTimeout = 120 * time.Second
+	defaultMaxRetries        = 3
+	defaultInitialBackoff    = 250 * time.Millisecond
+	defaultMaxBackoff        = 2 * time.Second
+	defaultMaxTokens         = 4096
+
+	// anthropicVersion is the required API version header value pinned
+	// by Anthropic's Messages API.
+	anthropicVersion = "2023-06-01"
+
+	// DefaultChatModel is a fallback used only when the caller passes
+	// an empty model name. The config resolver normally supplies an
+	// explicit model per profile.
+	DefaultChatModel = "claude-sonnet-4-6"
+)
+
+// Client is an Anthropic Messages API adapter.
+//
+// Error codes (carried on *model.ProviderError):
+//   - ANTHROPIC_AUTH (non-retryable): missing key, 401/403
+//   - ANTHROPIC_RATE_LIMIT (retryable): 429
+//   - ANTHROPIC_FAILED (retryable for network/5xx, else non-retryable)
+type Client struct {
+	BaseURL           string
+	APIKey            string
+	HTTPClient        *http.Client
+	MaxRetries        int
+	InitialBackoff    time.Duration
+	MaxBackoff        time.Duration
+	GenerationTimeout time.Duration
+	// DefaultChatModel is used when Generate is called and no model has
+	// been configured on the client.
+	DefaultChatModel string
+}
+
+// compile-time assertion that *Client implements model.Generator.
+var _ model.Generator = (*Client)(nil)
+
+// NewClient constructs a client with safe default retry/timeout settings.
+// An empty baseURL falls back to the public Anthropic endpoint.
+func NewClient(baseURL, apiKey string) *Client {
+	baseURL = strings.TrimSpace(baseURL)
+	apiKey = strings.TrimSpace(apiKey)
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+	return &Client{
+		BaseURL:           strings.TrimRight(baseURL, "/"),
+		APIKey:            apiKey,
+		HTTPClient:        &http.Client{Timeout: defaultRequestTimeout},
+		MaxRetries:        defaultMaxRetries,
+		InitialBackoff:    defaultInitialBackoff,
+		MaxBackoff:        defaultMaxBackoff,
+		GenerationTimeout: defaultGenerationTimeout,
+		DefaultChatModel:  DefaultChatModel,
+	}
+}
+
+type generateMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type generateRequest struct {
+	Model     string            `json:"model"`
+	MaxTokens int               `json:"max_tokens"`
+	Messages  []generateMessage `json:"messages"`
+}
+
+type generateResponse struct {
+	Content []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	} `json:"content"`
+}
+
+// Generate implements model.Generator via {base}/v1/messages.
+func (c *Client) Generate(ctx context.Context, prompt string) (string, error) {
+	if strings.TrimSpace(c.APIKey) == "" {
+		return "", &model.ProviderError{Code: "ANTHROPIC_AUTH", Message: "missing Anthropic API key", Retryable: false}
+	}
+	chatModel := strings.TrimSpace(c.DefaultChatModel)
+	if chatModel == "" {
+		chatModel = DefaultChatModel
+	}
+
+	maxRetries := c.MaxRetries
+	if maxRetries < 0 {
+		maxRetries = 0
+	}
+	timeout := c.GenerationTimeout
+	if timeout <= 0 {
+		timeout = defaultGenerationTimeout
+	}
+
+	var lastErr error
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		if attempt > 0 {
+			if err := c.wait(ctx, c.backoffForAttempt(attempt-1)); err != nil {
+				return "", err
+			}
+		}
+		text, err := c.generateOnce(ctx, chatModel, prompt, timeout)
+		if err == nil {
+			return text, nil
+		}
+		lastErr = err
+		var pErr *model.ProviderError
+		if errors.As(err, &pErr) && !pErr.Retryable {
+			return "", err
+		}
+	}
+	return "", lastErr
+}
+
+func (c *Client) generateOnce(ctx context.Context, chatModel, prompt string, timeout time.Duration) (string, error) {
+	body, err := json.Marshal(generateRequest{
+		Model:     chatModel,
+		MaxTokens: defaultMaxTokens,
+		Messages:  []generateMessage{{Role: "user", Content: prompt}},
+	})
+	if err != nil {
+		return "", &model.ProviderError{Code: "ANTHROPIC_FAILED", Message: "failed to marshal generation request", Retryable: false, Cause: err}
+	}
+	resp, err := c.doJSON(ctx, "/v1/messages", body, timeout)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return "", httpError(resp)
+	}
+
+	var parsed generateResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return "", &model.ProviderError{Code: "ANTHROPIC_FAILED", Message: "failed to decode generation response", Retryable: false, StatusCode: resp.StatusCode, Cause: err}
+	}
+	text := strings.TrimSpace(contentToText(parsed))
+	if text == "" {
+		return "", &model.ProviderError{Code: "ANTHROPIC_FAILED", Message: "generation response had empty content", Retryable: false, StatusCode: resp.StatusCode}
+	}
+	return text, nil
+}
+
+// contentToText concatenates the text parts of an Anthropic Messages
+// response ([{"type":"text","text":"..."}]); non-text blocks are
+// ignored.
+func contentToText(parsed generateResponse) string {
+	var b strings.Builder
+	for _, p := range parsed.Content {
+		if p.Type == "" || p.Type == "text" {
+			b.WriteString(p.Text)
+		}
+	}
+	return b.String()
+}
+
+func (c *Client) doJSON(ctx context.Context, path string, body []byte, timeout time.Duration) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+path, bytes.NewReader(body))
+	if err != nil {
+		return nil, &model.ProviderError{Code: "ANTHROPIC_FAILED", Message: "failed to build request", Retryable: false, Cause: err}
+	}
+	req.Header.Set("x-api-key", c.APIKey)
+	req.Header.Set("anthropic-version", anthropicVersion)
+	req.Header.Set("content-type", "application/json")
+
+	resp, err := clientWithTimeout(c.HTTPClient, timeout).Do(req)
+	if err != nil {
+		return nil, &model.ProviderError{Code: "ANTHROPIC_FAILED", Message: "request failed", Retryable: true, Cause: err}
+	}
+	return resp, nil
+}
+
+// clientWithTimeout returns an *http.Client that uses the per-call
+// timeout. The default client built by NewClient carries the short
+// (30s) request timeout, so Messages calls — which use the longer
+// GenerationTimeout — must override it even when HTTPClient is set
+// (mirrors internal/openai). The base client's Transport is shared via
+// a shallow copy so connection pooling is preserved.
+func clientWithTimeout(base *http.Client, timeout time.Duration) *http.Client {
+	if base == nil {
+		return &http.Client{Timeout: timeout}
+	}
+	cp := *base
+	cp.Timeout = timeout
+	return &cp
+}
+
+func httpError(resp *http.Response) error {
+	bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	msg := strings.TrimSpace(string(bodyBytes))
+	if msg == "" {
+		msg = "upstream returned non-200 response"
+	}
+	switch {
+	case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
+		return &model.ProviderError{Code: "ANTHROPIC_AUTH", Message: msg, Retryable: false, StatusCode: resp.StatusCode}
+	case resp.StatusCode == http.StatusTooManyRequests:
+		return &model.ProviderError{Code: "ANTHROPIC_RATE_LIMIT", Message: msg, Retryable: true, StatusCode: resp.StatusCode}
+	case resp.StatusCode >= http.StatusInternalServerError:
+		return &model.ProviderError{Code: "ANTHROPIC_FAILED", Message: msg, Retryable: true, StatusCode: resp.StatusCode}
+	default:
+		return &model.ProviderError{Code: "ANTHROPIC_FAILED", Message: msg, Retryable: false, StatusCode: resp.StatusCode}
+	}
+}
+
+func (c *Client) backoffForAttempt(attempt int) time.Duration {
+	initial := c.InitialBackoff
+	if initial <= 0 {
+		initial = defaultInitialBackoff
+	}
+	maxBackoff := c.MaxBackoff
+	if maxBackoff <= 0 {
+		maxBackoff = defaultMaxBackoff
+	}
+	backoff := initial
+	for i := 0; i < attempt; i++ {
+		backoff *= 2
+		if backoff >= maxBackoff {
+			return maxBackoff
+		}
+	}
+	return backoff
+}
+
+func (c *Client) wait(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/tests/anthropic/client_test.go
+++ b/tests/anthropic/client_test.go
@@ -1,0 +1,175 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/anthropic"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+func newClient(url string) *anthropic.Client {
+	c := anthropic.NewClient(url, "test-key")
+	c.InitialBackoff = time.Millisecond
+	c.MaxBackoff = time.Millisecond
+	return c
+}
+
+func asProviderErr(err error, target **model.ProviderError) bool {
+	if err == nil {
+		return false
+	}
+	pe, ok := err.(*model.ProviderError)
+	if ok {
+		*target = pe
+	}
+	return ok && strings.HasPrefix(pe.Code, "ANTHROPIC_")
+}
+
+func TestGenerate_HappyPathConcatenatesTextParts(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/messages" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		if got := r.Header.Get("x-api-key"); got != "test-key" {
+			t.Errorf("x-api-key = %q", got)
+		}
+		if got := r.Header.Get("anthropic-version"); got != "2023-06-01" {
+			t.Errorf("anthropic-version = %q", got)
+		}
+		if got := r.Header.Get("content-type"); got != "application/json" {
+			t.Errorf("content-type = %q", got)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"content": []map[string]any{
+				{"type": "text", "text": "hello "},
+				{"type": "text", "text": "world"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	out, err := newClient(srv.URL).Generate(context.Background(), "hi")
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	if out != "hello world" {
+		t.Fatalf("content = %q, want %q", out, "hello world")
+	}
+}
+
+func TestGenerate_MissingKeyIsNonRetryableAuthNoCall(t *testing.T) {
+	var called int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&called, 1)
+	}))
+	defer srv.Close()
+
+	c := anthropic.NewClient(srv.URL, "")
+	_, err := c.Generate(context.Background(), "hi")
+	var pe *model.ProviderError
+	if !asProviderErr(err, &pe) || pe.Code != "ANTHROPIC_AUTH" || pe.Retryable {
+		t.Fatalf("want non-retryable ANTHROPIC_AUTH, got %v", err)
+	}
+	if n := atomic.LoadInt32(&called); n != 0 {
+		t.Fatalf("missing key must not perform an HTTP call, got %d calls", n)
+	}
+}
+
+func TestGenerate_RateLimitRetriesThenSucceeds(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 { // first call: transient 429
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"content": []map[string]any{{"type": "text", "text": "ok"}},
+		})
+	}))
+	defer srv.Close()
+
+	out, err := newClient(srv.URL).Generate(context.Background(), "hi")
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	if out != "ok" {
+		t.Fatalf("content = %q, want %q", out, "ok")
+	}
+	if n := atomic.LoadInt32(&calls); n != 2 {
+		t.Fatalf("calls = %d, want 2 (1 retry + success)", n)
+	}
+}
+
+func TestHTTPErrorMapping(t *testing.T) {
+	cases := []struct {
+		status    int
+		wantCode  string
+		retryable bool
+	}{
+		{http.StatusUnauthorized, "ANTHROPIC_AUTH", false},
+		{http.StatusForbidden, "ANTHROPIC_AUTH", false},
+		{http.StatusTooManyRequests, "ANTHROPIC_RATE_LIMIT", true},
+		{http.StatusBadGateway, "ANTHROPIC_FAILED", true},
+		{http.StatusBadRequest, "ANTHROPIC_FAILED", false},
+	}
+	for _, tc := range cases {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(tc.status)
+		}))
+		c := newClient(srv.URL)
+		c.MaxRetries = 0
+		_, err := c.Generate(context.Background(), "hi")
+		srv.Close()
+		var pe *model.ProviderError
+		if !asProviderErr(err, &pe) || pe.Code != tc.wantCode || pe.Retryable != tc.retryable {
+			t.Fatalf("status %d: got %v, want %s retryable=%v", tc.status, err, tc.wantCode, tc.retryable)
+		}
+	}
+}
+
+func TestGenerate_NoContentIsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"content": []any{}})
+	}))
+	defer srv.Close()
+	_, err := newClient(srv.URL).Generate(context.Background(), "hi")
+	var pe *model.ProviderError
+	if !asProviderErr(err, &pe) || pe.Code != "ANTHROPIC_FAILED" {
+		t.Fatalf("want ANTHROPIC_FAILED, got %v", err)
+	}
+}
+
+// TestGenerate_UsesGenerationTimeoutNotDefault mirrors the openai
+// adapter test: NewClient always sets HTTPClient (30s), so the per-call
+// GenerationTimeout must still be applied. With a 50ms GenerationTimeout
+// and a 300ms-slow server, Generate must fail fast (~50ms) rather than
+// hang toward the 30s default.
+func TestGenerate_UsesGenerationTimeoutNotDefault(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(300 * time.Millisecond)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"content": []map[string]any{{"type": "text", "text": "late"}},
+		})
+	}))
+	defer srv.Close()
+
+	c := anthropic.NewClient(srv.URL, "test-key") // default HTTPClient: 30s
+	c.MaxRetries = 0
+	c.GenerationTimeout = 50 * time.Millisecond
+
+	start := time.Now()
+	_, err := c.Generate(context.Background(), "hi")
+	if err == nil {
+		t.Fatal("want timeout error, got nil")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("Generate did not honor GenerationTimeout (took %s)", elapsed)
+	}
+}


### PR DESCRIPTION
PR E-anthropic of the multi-provider initiative (Design 0001 / SPEC §8.1.2). Built in parallel with the Cohere/Gemini adapters.

New `internal/anthropic` implementing `model.Generator` via the Anthropic **Messages API** (`POST /v1/messages`, `x-api-key` + `anthropic-version` headers, text-parts concatenated). Anthropic is **chat-only** per the capability matrix (no embeddings/OCR/STT/TTS/rerank).

- Mirrors `internal/openai`/`internal/cohere`: `BaseURL`/`APIKey`/`HTTPClient`, bounded exponential retry, `clientWithTimeout` (per-call `GenerationTimeout` applied even with the default client — the bug class from #191), typed `model.ProviderError` (`ANTHROPIC_AUTH`/`ANTHROPIC_RATE_LIMIT`/`ANTHROPIC_FAILED`), compile-time `model.Generator` assertion, `DefaultChatModel = claude-sonnet-4-6`.
- httptest coverage: happy path + header assertions, missing-key non-retryable (no HTTP call), 429 retry-then-success, error-code mapping table, no-content error, GenerationTimeout-honored.

**Additive only** — not wired into config/selection (that's the serial PR C). `make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)