### PR TITLE
feat(cohere): embed (asymmetric) + chat alongside rerank

### DIFF
--- a/internal/cohere/client.go
+++ b/internal/cohere/client.go
@@ -113,7 +113,12 @@ func retry[T any](ctx context.Context, c *Client, op func() (T, error)) (T, erro
 	for attempt := 0; attempt <= maxRetries; attempt++ {
 		if attempt > 0 {
 			if err := c.wait(ctx, c.backoffForAttempt(attempt-1)); err != nil {
-				return zero, err
+				return zero, &model.ProviderError{
+					Code:      "COHERE_FAILED",
+					Message:   "request canceled during retry backoff",
+					Retryable: false,
+					Cause:     err,
+				}
 			}
 		}
 		out, err := op()
@@ -228,6 +233,9 @@ func inputTypeForRole(role model.EmbedRole) string {
 // Inputs are sent in BatchSize-sized batches; each batch is retried with
 // bounded exponential backoff, and vectors preserve input order.
 func (c *Client) Embed(ctx context.Context, modelName string, role model.EmbedRole, inputs []string) ([][]float32, error) {
+	if len(inputs) == 0 {
+		return [][]float32{}, nil
+	}
 	if strings.TrimSpace(c.APIKey) == "" {
 		return nil, &model.ProviderError{Code: "COHERE_AUTH", Message: "missing Cohere API key", Retryable: false}
 	}
@@ -237,9 +245,6 @@ func (c *Client) Embed(ctx context.Context, modelName string, role model.EmbedRo
 		if modelName == "" {
 			modelName = DefaultEmbedModel
 		}
-	}
-	if len(inputs) == 0 {
-		return [][]float32{}, nil
 	}
 
 	batchSize := c.BatchSize
@@ -412,20 +417,20 @@ func clientWithTimeout(base *http.Client, timeout time.Duration) *http.Client {
 }
 
 func cohereHTTPError(resp *http.Response) error {
-	bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-	msg := strings.TrimSpace(string(bodyBytes))
-	if msg == "" {
-		msg = "upstream returned non-200 response"
-	}
+	// Drain (bounded) so the connection can be reused, but never surface
+	// the raw upstream body: it can echo prompt/document content
+	// (CLAUDE.md: do not put raw sensitive payloads in error messages).
+	// The HTTP status is sufficient and machine-parseable via StatusCode.
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
 	switch {
 	case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
-		return &model.ProviderError{Code: "COHERE_AUTH", Message: msg, Retryable: false, StatusCode: resp.StatusCode}
+		return &model.ProviderError{Code: "COHERE_AUTH", Message: fmt.Sprintf("cohere request rejected (HTTP %d)", resp.StatusCode), Retryable: false, StatusCode: resp.StatusCode}
 	case resp.StatusCode == http.StatusTooManyRequests:
-		return &model.ProviderError{Code: "COHERE_RATE_LIMIT", Message: msg, Retryable: true, StatusCode: resp.StatusCode}
+		return &model.ProviderError{Code: "COHERE_RATE_LIMIT", Message: "cohere rate limited (HTTP 429)", Retryable: true, StatusCode: resp.StatusCode}
 	case resp.StatusCode >= http.StatusInternalServerError:
-		return &model.ProviderError{Code: "COHERE_FAILED", Message: msg, Retryable: true, StatusCode: resp.StatusCode}
+		return &model.ProviderError{Code: "COHERE_FAILED", Message: fmt.Sprintf("cohere upstream error (HTTP %d)", resp.StatusCode), Retryable: true, StatusCode: resp.StatusCode}
 	default:
-		return &model.ProviderError{Code: "COHERE_FAILED", Message: msg, Retryable: false, StatusCode: resp.StatusCode}
+		return &model.ProviderError{Code: "COHERE_FAILED", Message: fmt.Sprintf("cohere request failed (HTTP %d)", resp.StatusCode), Retryable: false, StatusCode: resp.StatusCode}
 	}
 }
 

--- a/internal/cohere/client.go
+++ b/internal/cohere/client.go
@@ -1,8 +1,14 @@
 // Package cohere provides a minimal direct-HTTP adapter for the Cohere
-// Rerank v2 API (POST /v2/rerank). It mirrors internal/mistral's client
-// shape (BaseURL/APIKey/HTTPClient, bounded exponential retry, typed
-// model.ProviderError) so retrieval can depend on a model.Reranker
-// without taking a hard dependency on this package.
+// v2 API: Rerank (POST /v2/rerank), Embed (POST /v2/embed), and Chat
+// (POST /v2/chat). It mirrors internal/mistral and internal/openai's
+// client shape (BaseURL/APIKey/HTTPClient, bounded exponential retry,
+// typed model.ProviderError) so retrieval can depend on model.Reranker /
+// model.Embedder / model.Generator without taking a hard dependency on
+// this package.
+//
+// Cohere embeddings are ASYMMETRIC (SPEC 8.1.5): the input role is
+// mapped onto Cohere's `input_type` (search_document / search_query) and
+// observably changes the request — unlike the symmetric OpenAI adapter.
 //
 // Reranking in dir2mcp is fail-open: callers treat any error from this
 // client as "skip rerank, keep fused order" (see internal/retrieval).
@@ -23,37 +29,55 @@ import (
 )
 
 const (
-	defaultBaseURL        = "https://api.cohere.com"
-	defaultRequestTimeout = 30 * time.Second
-	defaultMaxRetries     = 3
-	defaultInitialBackoff = 250 * time.Millisecond
-	defaultMaxBackoff     = 2 * time.Second
+	defaultBaseURL           = "https://api.cohere.com"
+	defaultRequestTimeout    = 30 * time.Second
+	defaultGenerationTimeout = 120 * time.Second
+	defaultMaxRetries        = 3
+	defaultInitialBackoff    = 250 * time.Millisecond
+	defaultMaxBackoff        = 2 * time.Second
+	defaultBatchSize         = 96
 
 	// DefaultRerankModel is Cohere's current GA cross-encoder rerank
 	// model. Callers may override via Client.DefaultModel or the
 	// modelName argument to Rerank.
 	DefaultRerankModel = "rerank-v3.5"
+
+	// DefaultEmbedModel / DefaultChatModel are fallbacks used only when
+	// the caller passes an empty model name. The config resolver
+	// normally supplies explicit models per profile.
+	DefaultEmbedModel = "embed-v4.0"
+	DefaultChatModel  = "command-a-03-2025"
 )
 
-// Client is a Cohere Rerank API adapter.
+// Client is a Cohere v2 API adapter (rerank + embed + chat).
 //
 // Error codes (carried on *model.ProviderError):
-//   - COHERE_AUTH (non-retryable): 401/403
+//   - COHERE_AUTH (non-retryable): missing key, 401/403
 //   - COHERE_RATE_LIMIT (retryable): 429
 //   - COHERE_FAILED (retryable for network/5xx, else non-retryable)
 type Client struct {
-	BaseURL        string
-	APIKey         string
-	HTTPClient     *http.Client
-	MaxRetries     int
-	InitialBackoff time.Duration
-	MaxBackoff     time.Duration
+	BaseURL           string
+	APIKey            string
+	HTTPClient        *http.Client
+	MaxRetries        int
+	InitialBackoff    time.Duration
+	MaxBackoff        time.Duration
+	BatchSize         int
+	GenerationTimeout time.Duration
 	// DefaultModel is used when Rerank is called with an empty modelName.
 	DefaultModel string
+	// DefaultEmbedModel/DefaultChatModel are used when the corresponding
+	// call is made with an empty model name.
+	DefaultEmbedModel string
+	DefaultChatModel  string
 }
 
-// compile-time assertion that *Client implements model.Reranker.
-var _ model.Reranker = (*Client)(nil)
+// compile-time assertions that *Client implements the model contracts.
+var (
+	_ model.Reranker  = (*Client)(nil)
+	_ model.Embedder  = (*Client)(nil)
+	_ model.Generator = (*Client)(nil)
+)
 
 // NewClient constructs a client with safe default retry/timeout settings.
 func NewClient(baseURL, apiKey string) *Client {
@@ -63,14 +87,46 @@ func NewClient(baseURL, apiKey string) *Client {
 		baseURL = defaultBaseURL
 	}
 	return &Client{
-		BaseURL:        strings.TrimRight(baseURL, "/"),
-		APIKey:         apiKey,
-		HTTPClient:     &http.Client{Timeout: defaultRequestTimeout},
-		MaxRetries:     defaultMaxRetries,
-		InitialBackoff: defaultInitialBackoff,
-		MaxBackoff:     defaultMaxBackoff,
-		DefaultModel:   DefaultRerankModel,
+		BaseURL:           strings.TrimRight(baseURL, "/"),
+		APIKey:            apiKey,
+		HTTPClient:        &http.Client{Timeout: defaultRequestTimeout},
+		MaxRetries:        defaultMaxRetries,
+		InitialBackoff:    defaultInitialBackoff,
+		MaxBackoff:        defaultMaxBackoff,
+		BatchSize:         defaultBatchSize,
+		GenerationTimeout: defaultGenerationTimeout,
+		DefaultModel:      DefaultRerankModel,
+		DefaultEmbedModel: DefaultEmbedModel,
+		DefaultChatModel:  DefaultChatModel,
 	}
+}
+
+// retry runs op with bounded exponential backoff, stopping early on a
+// non-retryable *model.ProviderError. T is the per-attempt result type.
+func retry[T any](ctx context.Context, c *Client, op func() (T, error)) (T, error) {
+	maxRetries := c.MaxRetries
+	if maxRetries < 0 {
+		maxRetries = 0
+	}
+	var zero T
+	var lastErr error
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		if attempt > 0 {
+			if err := c.wait(ctx, c.backoffForAttempt(attempt-1)); err != nil {
+				return zero, err
+			}
+		}
+		out, err := op()
+		if err == nil {
+			return out, nil
+		}
+		lastErr = err
+		var pErr *model.ProviderError
+		if errors.As(err, &pErr) && !pErr.Retryable {
+			return zero, err
+		}
+	}
+	return zero, lastErr
 }
 
 type rerankRequest struct {
@@ -104,29 +160,9 @@ func (c *Client) Rerank(ctx context.Context, modelName, query string, documents 
 			modelName = DefaultRerankModel
 		}
 	}
-
-	maxRetries := c.MaxRetries
-	if maxRetries < 0 {
-		maxRetries = 0
-	}
-	var lastErr error
-	for attempt := 0; attempt <= maxRetries; attempt++ {
-		if attempt > 0 {
-			if err := c.wait(ctx, c.backoffForAttempt(attempt-1)); err != nil {
-				return nil, err
-			}
-		}
-		results, err := c.rerankOnce(ctx, modelName, query, documents, topN)
-		if err == nil {
-			return results, nil
-		}
-		lastErr = err
-		var pErr *model.ProviderError
-		if errors.As(err, &pErr) && !pErr.Retryable {
-			return nil, err
-		}
-	}
-	return nil, lastErr
+	return retry(ctx, c, func() ([]model.Reranked, error) {
+		return c.rerankOnce(ctx, modelName, query, documents, topN)
+	})
 }
 
 func (c *Client) rerankOnce(ctx context.Context, modelName, query string, documents []string, topN int) ([]model.Reranked, error) {
@@ -139,24 +175,11 @@ func (c *Client) rerankOnce(ctx context.Context, modelName, query string, docume
 		return nil, &model.ProviderError{Code: "COHERE_FAILED", Message: "failed to marshal rerank request", Retryable: false, Cause: err}
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+"/v2/rerank", bytes.NewReader(body))
+	resp, err := c.doJSON(ctx, "/v2/rerank", body, defaultRequestTimeout)
 	if err != nil {
-		return nil, &model.ProviderError{Code: "COHERE_FAILED", Message: "failed to build rerank request", Retryable: false, Cause: err}
-	}
-	req.Header.Set("Authorization", "Bearer "+c.APIKey)
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "application/json")
-
-	client := c.HTTPClient
-	if client == nil {
-		client = &http.Client{Timeout: defaultRequestTimeout}
-	}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, &model.ProviderError{Code: "COHERE_FAILED", Message: "rerank request failed", Retryable: true, Cause: err}
+		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
-
 	if resp.StatusCode != http.StatusOK {
 		return nil, cohereHTTPError(resp)
 	}
@@ -174,6 +197,218 @@ func (c *Client) rerankOnce(ctx context.Context, modelName, query string, docume
 		out = append(out, model.Reranked{Index: r.Index, RelevanceScore: r.RelevanceScore})
 	}
 	return out, nil
+}
+
+type embedRequest struct {
+	Model          string   `json:"model"`
+	Texts          []string `json:"texts"`
+	InputType      string   `json:"input_type"`
+	EmbeddingTypes []string `json:"embedding_types"`
+}
+
+type embedResponse struct {
+	Embeddings struct {
+		Float [][]float64 `json:"float"`
+	} `json:"embeddings"`
+}
+
+// inputTypeForRole maps the SPEC 8.1.5 input role onto Cohere's
+// asymmetric `input_type`. EmbedQuery -> "search_query"; everything
+// else (including EmbedDocument) -> "search_document".
+func inputTypeForRole(role model.EmbedRole) string {
+	if role == model.EmbedQuery {
+		return "search_query"
+	}
+	return "search_document"
+}
+
+// Embed implements model.Embedder. Cohere embeddings are ASYMMETRIC
+// (SPEC 8.1.5): the role is mapped onto `input_type`
+// (search_document / search_query) and observably changes the request.
+// Inputs are sent in BatchSize-sized batches; each batch is retried with
+// bounded exponential backoff, and vectors preserve input order.
+func (c *Client) Embed(ctx context.Context, modelName string, role model.EmbedRole, inputs []string) ([][]float32, error) {
+	if strings.TrimSpace(c.APIKey) == "" {
+		return nil, &model.ProviderError{Code: "COHERE_AUTH", Message: "missing Cohere API key", Retryable: false}
+	}
+	modelName = strings.TrimSpace(modelName)
+	if modelName == "" {
+		modelName = c.DefaultEmbedModel
+		if modelName == "" {
+			modelName = DefaultEmbedModel
+		}
+	}
+	if len(inputs) == 0 {
+		return [][]float32{}, nil
+	}
+
+	batchSize := c.BatchSize
+	if batchSize <= 0 {
+		batchSize = defaultBatchSize
+	}
+	inputType := inputTypeForRole(role)
+
+	out := make([][]float32, 0, len(inputs))
+	for start := 0; start < len(inputs); start += batchSize {
+		end := start + batchSize
+		if end > len(inputs) {
+			end = len(inputs)
+		}
+		batch := inputs[start:end]
+		vectors, err := retry(ctx, c, func() ([][]float32, error) {
+			return c.embedBatch(ctx, modelName, inputType, batch)
+		})
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, vectors...)
+	}
+	return out, nil
+}
+
+func (c *Client) embedBatch(ctx context.Context, modelName, inputType string, inputs []string) ([][]float32, error) {
+	body, err := json.Marshal(embedRequest{
+		Model:          modelName,
+		Texts:          inputs,
+		InputType:      inputType,
+		EmbeddingTypes: []string{"float"},
+	})
+	if err != nil {
+		return nil, &model.ProviderError{Code: "COHERE_FAILED", Message: "failed to marshal embedding request", Retryable: false, Cause: err}
+	}
+	resp, err := c.doJSON(ctx, "/v2/embed", body, defaultRequestTimeout)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, cohereHTTPError(resp)
+	}
+
+	var parsed embedResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil, &model.ProviderError{Code: "COHERE_FAILED", Message: "failed to decode embedding response", Retryable: false, StatusCode: resp.StatusCode, Cause: err}
+	}
+	floats := parsed.Embeddings.Float
+	if len(floats) != len(inputs) {
+		return nil, &model.ProviderError{Code: "COHERE_FAILED", Message: fmt.Sprintf("embedding response size mismatch: got %d vectors for %d inputs", len(floats), len(inputs)), Retryable: false, StatusCode: resp.StatusCode}
+	}
+
+	vectors := make([][]float32, len(inputs))
+	for i, v := range floats {
+		vec := make([]float32, len(v))
+		for j, f := range v {
+			vec[j] = float32(f)
+		}
+		vectors[i] = vec
+	}
+	return vectors, nil
+}
+
+type chatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type chatRequest struct {
+	Model    string        `json:"model"`
+	Messages []chatMessage `json:"messages"`
+}
+
+type chatResponse struct {
+	Message struct {
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+	} `json:"message"`
+}
+
+// Generate implements model.Generator via Cohere's v2 /v2/chat endpoint.
+func (c *Client) Generate(ctx context.Context, prompt string) (string, error) {
+	if strings.TrimSpace(c.APIKey) == "" {
+		return "", &model.ProviderError{Code: "COHERE_AUTH", Message: "missing Cohere API key", Retryable: false}
+	}
+	chatModel := strings.TrimSpace(c.DefaultChatModel)
+	if chatModel == "" {
+		chatModel = DefaultChatModel
+	}
+	timeout := c.GenerationTimeout
+	if timeout <= 0 {
+		timeout = defaultGenerationTimeout
+	}
+	return retry(ctx, c, func() (string, error) {
+		return c.generateOnce(ctx, chatModel, prompt, timeout)
+	})
+}
+
+func (c *Client) generateOnce(ctx context.Context, chatModel, prompt string, timeout time.Duration) (string, error) {
+	body, err := json.Marshal(chatRequest{
+		Model:    chatModel,
+		Messages: []chatMessage{{Role: "user", Content: prompt}},
+	})
+	if err != nil {
+		return "", &model.ProviderError{Code: "COHERE_FAILED", Message: "failed to marshal generation request", Retryable: false, Cause: err}
+	}
+	resp, err := c.doJSON(ctx, "/v2/chat", body, timeout)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return "", cohereHTTPError(resp)
+	}
+
+	var parsed chatResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return "", &model.ProviderError{Code: "COHERE_FAILED", Message: "failed to decode generation response", Retryable: false, StatusCode: resp.StatusCode, Cause: err}
+	}
+	var b strings.Builder
+	for _, p := range parsed.Message.Content {
+		if p.Type == "" || p.Type == "text" {
+			b.WriteString(p.Text)
+		}
+	}
+	text := strings.TrimSpace(b.String())
+	if text == "" {
+		return "", &model.ProviderError{Code: "COHERE_FAILED", Message: "generation response had empty content", Retryable: false, StatusCode: resp.StatusCode}
+	}
+	return text, nil
+}
+
+// doJSON issues an authenticated POST with a JSON body. The per-call
+// timeout overrides the (short) default request timeout carried by the
+// client built in NewClient, so chat completions can use the longer
+// GenerationTimeout even when HTTPClient is set.
+func (c *Client) doJSON(ctx context.Context, path string, body []byte, timeout time.Duration) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+path, bytes.NewReader(body))
+	if err != nil {
+		return nil, &model.ProviderError{Code: "COHERE_FAILED", Message: "failed to build request", Retryable: false, Cause: err}
+	}
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := clientWithTimeout(c.HTTPClient, timeout).Do(req)
+	if err != nil {
+		return nil, &model.ProviderError{Code: "COHERE_FAILED", Message: "request failed", Retryable: true, Cause: err}
+	}
+	return resp, nil
+}
+
+// clientWithTimeout returns an *http.Client that uses the per-call
+// timeout. The default client built by NewClient carries the short
+// (30s) request timeout, so chat completions — which use the longer
+// GenerationTimeout — must override it even when HTTPClient is set
+// (mirrors internal/openai). The base client's Transport is shared via
+// a shallow copy so connection pooling is preserved.
+func clientWithTimeout(base *http.Client, timeout time.Duration) *http.Client {
+	if base == nil {
+		return &http.Client{Timeout: timeout}
+	}
+	cp := *base
+	cp.Timeout = timeout
+	return &cp
 }
 
 func cohereHTTPError(resp *http.Response) error {

--- a/tests/cohere/embed_chat_test.go
+++ b/tests/cohere/embed_chat_test.go
@@ -1,0 +1,278 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/cohere"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// embedResp echoes one vector per input where vec[0] = first byte of the
+// corresponding input string, preserving order (Cohere returns float
+// vectors positionally under embeddings.float).
+func embedResp(inputs []string) map[string]any {
+	floats := make([][]float64, len(inputs))
+	for i, s := range inputs {
+		floats[i] = []float64{float64(s[0]), 0.5}
+	}
+	return map[string]any{"embeddings": map[string]any{"float": floats}}
+}
+
+type embedBody struct {
+	Model          string   `json:"model"`
+	Texts          []string `json:"texts"`
+	InputType      string   `json:"input_type"`
+	EmbeddingTypes []string `json:"embedding_types"`
+}
+
+// TestEmbed_AsymmetricInputTypeByRole pins SPEC 8.1.5: Cohere is an
+// ASYMMETRIC embedder, so the wire request MUST carry
+// input_type=search_document for EmbedDocument and search_query for
+// EmbedQuery (decoded-body assertion).
+func TestEmbed_AsymmetricInputTypeByRole(t *testing.T) {
+	var raws [][]byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/embed" {
+			t.Errorf("path = %s, want /v2/embed", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("auth = %q", got)
+		}
+		raw, _ := io.ReadAll(r.Body)
+		raws = append(raws, raw)
+		var req struct {
+			Texts []string `json:"texts"`
+		}
+		_ = json.Unmarshal(raw, &req)
+		_ = json.NewEncoder(w).Encode(embedResp(req.Texts))
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL)
+	cases := []struct {
+		role model.EmbedRole
+		want string
+	}{
+		{model.EmbedDocument, "search_document"},
+		{model.EmbedQuery, "search_query"},
+	}
+	for _, tc := range cases {
+		if _, err := c.Embed(context.Background(), "embed-v4.0", tc.role, []string{"hi"}); err != nil {
+			t.Fatalf("embed (%s): %v", tc.role, err)
+		}
+	}
+	if len(raws) != 2 {
+		t.Fatalf("want 2 requests, got %d", len(raws))
+	}
+	for i, tc := range cases {
+		var b embedBody
+		if err := json.Unmarshal(raws[i], &b); err != nil {
+			t.Fatalf("decode body %d: %v", i, err)
+		}
+		if b.InputType != tc.want {
+			t.Fatalf("role %s: input_type = %q, want %q (raw=%s)", tc.role, b.InputType, tc.want, raws[i])
+		}
+		if b.Model != "embed-v4.0" || len(b.Texts) != 1 || b.Texts[0] != "hi" {
+			t.Fatalf("unexpected embed body: %+v", b)
+		}
+		if len(b.EmbeddingTypes) != 1 || b.EmbeddingTypes[0] != "float" {
+			t.Fatalf("embedding_types = %v, want [float]", b.EmbeddingTypes)
+		}
+	}
+	// Asymmetric: the two raw bodies must differ (unlike symmetric OpenAI).
+	if string(raws[0]) == string(raws[1]) {
+		t.Fatalf("asymmetric provider must send role-dependent bodies; both = %s", raws[0])
+	}
+}
+
+func TestEmbed_BatchesPreserveOrderAndRetry(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		if n == 1 { // first batch: one transient 429 then success
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		var req struct {
+			Texts []string `json:"texts"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		_ = json.NewEncoder(w).Encode(embedResp(req.Texts))
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL)
+	c.BatchSize = 2 // 3 inputs -> batches (a,b) then (c)
+	in := []string{"a", "b", "c"}
+	vecs, err := c.Embed(context.Background(), "embed-v4.0", model.EmbedDocument, in)
+	if err != nil {
+		t.Fatalf("embed: %v", err)
+	}
+	if len(vecs) != 3 {
+		t.Fatalf("got %d vectors, want 3", len(vecs))
+	}
+	for i, s := range in {
+		if vecs[i][0] != float32(s[0]) {
+			t.Fatalf("order not preserved at %d: got %v, want first byte of %q", i, vecs[i], s)
+		}
+	}
+	if n := atomic.LoadInt32(&calls); n != 3 { // 1 retry (429) + 2 batches
+		t.Fatalf("calls = %d, want 3", n)
+	}
+}
+
+func TestEmbed_EmptyInputsNoCall(t *testing.T) {
+	c := cohere.NewClient("http://127.0.0.1:0", "k")
+	v, err := c.Embed(context.Background(), "m", model.EmbedDocument, nil)
+	if err != nil || len(v) != 0 {
+		t.Fatalf("want ([],nil), got %v %v", v, err)
+	}
+}
+
+func TestEmbed_MissingKeyIsNonRetryableAuth(t *testing.T) {
+	c := cohere.NewClient("http://127.0.0.1:0", "")
+	_, err := c.Embed(context.Background(), "m", model.EmbedQuery, []string{"x"})
+	assertProviderError(t, err, "COHERE_AUTH", false)
+}
+
+func TestEmbed_DefaultModelWhenEmpty(t *testing.T) {
+	var b embedBody
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &b)
+		_ = json.NewEncoder(w).Encode(embedResp([]string{"x"}))
+	}))
+	defer srv.Close()
+	if _, err := newClient(srv.URL).Embed(context.Background(), "", model.EmbedDocument, []string{"x"}); err != nil {
+		t.Fatalf("embed: %v", err)
+	}
+	if b.Model != cohere.DefaultEmbedModel {
+		t.Fatalf("model = %q, want default %q", b.Model, cohere.DefaultEmbedModel)
+	}
+}
+
+func TestEmbed_SizeMismatchRejected(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"embeddings":{"float":[[1,2]]}}`))
+	}))
+	defer srv.Close()
+	_, err := newClient(srv.URL).Embed(context.Background(), "m", model.EmbedDocument, []string{"a", "b"})
+	assertProviderError(t, err, "COHERE_FAILED", false)
+}
+
+func TestEmbed_StatusMapping(t *testing.T) {
+	cases := []struct {
+		name      string
+		status    int
+		wantCode  string
+		retryable bool
+	}{
+		{"unauthorized", http.StatusUnauthorized, "COHERE_AUTH", false},
+		{"rate limit", http.StatusTooManyRequests, "COHERE_RATE_LIMIT", true},
+		{"server error", http.StatusBadGateway, "COHERE_FAILED", true},
+		{"bad request", http.StatusBadRequest, "COHERE_FAILED", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(`{"message":"boom"}`))
+			}))
+			defer srv.Close()
+			c := newClient(srv.URL)
+			c.MaxRetries = 0
+			_, err := c.Embed(context.Background(), "m", model.EmbedDocument, []string{"x"})
+			assertProviderError(t, err, tc.wantCode, tc.retryable)
+		})
+	}
+}
+
+type chatBody struct {
+	Model    string `json:"model"`
+	Messages []struct {
+		Role    string `json:"role"`
+		Content string `json:"content"`
+	} `json:"messages"`
+}
+
+func TestGenerate_HappyPathConcatsTextParts(t *testing.T) {
+	var b chatBody
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &b)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"message": map[string]any{"content": []map[string]any{
+				{"type": "text", "text": "hello "},
+				{"type": "text", "text": "world"},
+			}},
+		})
+	}))
+	defer srv.Close()
+
+	out, err := newClient(srv.URL).Generate(context.Background(), "hi there")
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	if out != "hello world" {
+		t.Fatalf("content = %q, want %q", out, "hello world")
+	}
+	if gotPath != "/v2/chat" {
+		t.Fatalf("path = %q, want /v2/chat", gotPath)
+	}
+	if b.Model != cohere.DefaultChatModel {
+		t.Fatalf("model = %q, want %q", b.Model, cohere.DefaultChatModel)
+	}
+	if len(b.Messages) != 1 || b.Messages[0].Role != "user" || b.Messages[0].Content != "hi there" {
+		t.Fatalf("unexpected chat body: %+v", b)
+	}
+}
+
+func TestGenerate_EmptyContentIsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"message":{"content":[]}}`))
+	}))
+	defer srv.Close()
+	_, err := newClient(srv.URL).Generate(context.Background(), "hi")
+	assertProviderError(t, err, "COHERE_FAILED", false)
+}
+
+func TestGenerate_MissingKeyIsNonRetryableAuth(t *testing.T) {
+	c := cohere.NewClient("http://127.0.0.1:0", "")
+	_, err := c.Generate(context.Background(), "hi")
+	assertProviderError(t, err, "COHERE_AUTH", false)
+}
+
+func TestGenerate_StatusMapping(t *testing.T) {
+	cases := []struct {
+		name      string
+		status    int
+		wantCode  string
+		retryable bool
+	}{
+		{"unauthorized", http.StatusUnauthorized, "COHERE_AUTH", false},
+		{"rate limit", http.StatusTooManyRequests, "COHERE_RATE_LIMIT", true},
+		{"server error", http.StatusInternalServerError, "COHERE_FAILED", true},
+		{"bad request", http.StatusBadRequest, "COHERE_FAILED", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(`{"message":"boom"}`))
+			}))
+			defer srv.Close()
+			c := newClient(srv.URL)
+			c.MaxRetries = 0
+			_, err := c.Generate(context.Background(), "hi")
+			assertProviderError(t, err, tc.wantCode, tc.retryable)
+		})
+	}
+}

--- a/tests/cohere/embed_chat_test.go
+++ b/tests/cohere/embed_chat_test.go
@@ -76,10 +76,11 @@ func TestEmbed_AsymmetricInputTypeByRole(t *testing.T) {
 			t.Fatalf("decode body %d: %v", i, err)
 		}
 		if b.InputType != tc.want {
-			t.Fatalf("role %s: input_type = %q, want %q (raw=%s)", tc.role, b.InputType, tc.want, raws[i])
+			t.Fatalf("role %s: input_type = %q, want %q", tc.role, b.InputType, tc.want)
 		}
 		if b.Model != "embed-v4.0" || len(b.Texts) != 1 || b.Texts[0] != "hi" {
-			t.Fatalf("unexpected embed body: %+v", b)
+			// sanitized: report shape, not raw input content
+			t.Fatalf("unexpected embed body: model=%q texts=%d", b.Model, len(b.Texts))
 		}
 		if len(b.EmbeddingTypes) != 1 || b.EmbeddingTypes[0] != "float" {
 			t.Fatalf("embedding_types = %v, want [float]", b.EmbeddingTypes)
@@ -87,7 +88,7 @@ func TestEmbed_AsymmetricInputTypeByRole(t *testing.T) {
 	}
 	// Asymmetric: the two raw bodies must differ (unlike symmetric OpenAI).
 	if string(raws[0]) == string(raws[1]) {
-		t.Fatalf("asymmetric provider must send role-dependent bodies; both = %s", raws[0])
+		t.Fatalf("asymmetric provider must send role-dependent bodies (identical len=%d)", len(raws[0]))
 	}
 }
 
@@ -231,7 +232,13 @@ func TestGenerate_HappyPathConcatsTextParts(t *testing.T) {
 		t.Fatalf("model = %q, want %q", b.Model, cohere.DefaultChatModel)
 	}
 	if len(b.Messages) != 1 || b.Messages[0].Role != "user" || b.Messages[0].Content != "hi there" {
-		t.Fatalf("unexpected chat body: %+v", b)
+		// sanitized: report shape, not raw prompt content
+		t.Fatalf("unexpected chat body: model=%q messages=%d role=%q", b.Model, len(b.Messages), func() string {
+			if len(b.Messages) > 0 {
+				return b.Messages[0].Role
+			}
+			return ""
+		}())
 	}
 }
 


### PR DESCRIPTION
PR D of the multi-provider initiative (SPEC §8.1.2 — cohere = embed ✅ chat ✅ rerank ✅; §8.1.5 — asymmetric embeddings). Built in parallel with the Anthropic/Gemini adapters.

Extends the existing rerank-only `internal/cohere` client:

- **Embed** (`POST /v2/embed`): **asymmetric** per §8.1.5 — `model.EmbedRole` maps to Cohere `input_type` (`EmbedQuery` → `search_query`, else `search_document`), observably changing the request (unlike symmetric OpenAI/Mistral). `embedding_types:["float"]`, batched (96) + retry, order preserved, strict count match.
- **Generate** (`POST /v2/chat`): text-parts concatenated.
- Refactored shared `retry[T]` / `doJSON` / `clientWithTimeout` helpers — **rerank behavior and request shape unchanged**; existing rerank tests intact. Compile-time `model.Embedder` + `model.Generator` assertions.
- `tests/cohere/embed_chat_test.go`: asymmetric `input_type` by role (decoded + raw-bytes-differ), batching/order, error mapping, chat concat.

**Additive only** — not wired into config/selection (serial PR C). `make check` green (isolated).

**Wire-shape note for review:** Cohere v2 `/v2/embed` returns `{embeddings:{float:[...]}}` positionally (no per-item index — strict count match enforced); `/v2/chat` assumed `{message:{content:[{type:text,text}]}}`. Flagging in case a live account differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cohere adapter now supports embeddings with batching and role-aware inputs
  * Cohere adapter now supports chat-based text generation with configurable per-request timeouts

* **Bug Fixes**
  * Improved retry behavior and more robust error mapping for network and provider errors

* **Tests**
  * Added end-to-end tests covering embeddings, batching, role behavior, generation, and error paths

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dirstral/dir2mcp/pull/194?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->