### PR TITLE
feat(provider): capability matrix + selection + corpus-lifetime (SPEC 8.1.x)

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1,0 +1,202 @@
+// Package provider implements the spec 0.7.0 provider model: the
+// normative capability matrix (SPEC 8.1.2), per-capability provider
+// selection (8.1.3), and the embeddings corpus-lifetime identity
+// (8.1.4). It is pure resolution logic with no HTTP or config-file
+// dependency: the config layer builds Profiles and a deterministic
+// precedence order, calls Select per capability, and constructs the
+// concrete model.* adapter from the chosen Profile.Kind.
+package provider
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Kind is a provider adapter / wire protocol (SPEC 8.1.1).
+type Kind string
+
+const (
+	KindOpenAI     Kind = "openai" // OpenAI-compatible backbone (incl. Mistral chat/embed, local)
+	KindMistral    Kind = "mistral"
+	KindAnthropic  Kind = "anthropic"
+	KindGemini     Kind = "gemini"
+	KindCohere     Kind = "cohere"
+	KindElevenLabs Kind = "elevenlabs"
+)
+
+// Capability is a model capability bound to a provider profile.
+type Capability string
+
+const (
+	CapEmbed  Capability = "embed"
+	CapChat   Capability = "chat"
+	CapOCR    Capability = "ocr"
+	CapSTT    Capability = "stt"
+	CapTTS    Capability = "tts"
+	CapRerank Capability = "rerank"
+)
+
+// Support is a capability-matrix cell state.
+type Support int
+
+const (
+	// Unsupported: binding this capability to this kind MUST be rejected
+	// as CONFIG_INVALID (static validation, SPEC 8.1.2).
+	Unsupported Support = iota
+	// Supported: statically valid.
+	Supported
+	// EndpointDependent: implemented by the adapter but not statically
+	// verifiable (kind: openai audio). Validated at first use, never
+	// CONFIG_INVALID.
+	EndpointDependent
+)
+
+// matrix is the normative SPEC 8.1.2 capability table. Absent cells are
+// Unsupported.
+var matrix = map[Kind]map[Capability]Support{
+	KindOpenAI: {
+		CapEmbed: Supported, CapChat: Supported,
+		CapSTT: EndpointDependent, CapTTS: EndpointDependent,
+	},
+	KindMistral: {
+		CapOCR: Supported, CapSTT: Supported,
+	},
+	KindAnthropic: {
+		CapChat: Supported,
+	},
+	KindGemini: {
+		CapEmbed: Supported, CapChat: Supported,
+		CapSTT: Supported, CapTTS: Supported,
+	},
+	KindCohere: {
+		CapEmbed: Supported, CapChat: Supported, CapRerank: Supported,
+	},
+	KindElevenLabs: {
+		CapSTT: Supported, CapTTS: Supported,
+	},
+}
+
+// Can reports the matrix support for (kind, cap). Unknown kinds/caps are
+// Unsupported.
+func Can(k Kind, c Capability) Support {
+	if caps, ok := matrix[k]; ok {
+		return caps[c]
+	}
+	return Unsupported
+}
+
+// Profile is a resolved provider profile. APIKey is the already-resolved
+// secret (never persisted; see SPEC 16.1.1). CredentialLess marks a
+// profile that declares no api_key requirement at all (e.g. a local
+// Ollama/vLLM endpoint) — such profiles are eligible even with an empty
+// key, unlike a profile that expects a key whose env var is unset.
+type Profile struct {
+	Name           string
+	Kind           Kind
+	BaseURL        string
+	APIKey         string
+	CredentialLess bool
+
+	EmbedTextModel string
+	EmbedCodeModel string
+	ChatModel      string
+	OCRModel       string
+	STTModel       string
+	TTSModel       string
+	RerankModel    string
+}
+
+// Eligible reports whether the profile may be selected/preflighted
+// (SPEC 8.1.3): a credential is present, or it is credential-less.
+func (p Profile) Eligible() bool {
+	return strings.TrimSpace(p.APIKey) != "" || p.CredentialLess
+}
+
+// ErrNoProvider means no eligible+capable profile exists for a
+// capability in auto mode (SPEC 8.1.3 case 3). Callers decide: a
+// required capability fails preflight; an optional one stays off.
+var ErrNoProvider = errors.New("no eligible provider for capability")
+
+// ConfigError is a static-validation failure that the CLI surfaces as
+// CONFIG_INVALID (SPEC 8.1.2 / 8.1.3 case 1).
+type ConfigError struct {
+	Capability Capability
+	Profile    string
+	Reason     string
+}
+
+func (e *ConfigError) Error() string {
+	return fmt.Sprintf("CONFIG_INVALID: %s.provider %q: %s", e.Capability, e.Profile, e.Reason)
+}
+
+// Select resolves the profile for cap (SPEC 8.1.3).
+//
+//   - explicit != "": that profile must exist, the matrix must not mark
+//     the pair Unsupported, and (if required) it must be Eligible —
+//     otherwise a *ConfigError.
+//   - explicit == "" (auto): the first profile in precedence order that
+//     is Eligible and not Unsupported for cap. If none and required is
+//     false → ErrNoProvider; if required → ErrNoProvider too (the CLI
+//     turns that into a preflight failure).
+func Select(precedence []Profile, byName map[string]Profile, cap Capability, explicit string, required bool) (Profile, error) {
+	explicit = strings.TrimSpace(explicit)
+	if explicit != "" {
+		p, ok := byName[explicit]
+		if !ok {
+			return Profile{}, &ConfigError{Capability: cap, Profile: explicit, Reason: "no such provider profile"}
+		}
+		if Can(p.Kind, cap) == Unsupported {
+			// SPEC 8.1.2: incapable binding is always CONFIG_INVALID,
+			// regardless of required-ness (static validation).
+			return Profile{}, &ConfigError{Capability: cap, Profile: explicit,
+				Reason: fmt.Sprintf("provider kind %q cannot serve %s", p.Kind, cap)}
+		}
+		if !p.Eligible() {
+			// SPEC 8.1.3 case 1: CONFIG_INVALID only when the capability
+			// is required; an optional capability with an explicit but
+			// credential-less profile stays off (the rerank rule).
+			if required {
+				return Profile{}, &ConfigError{Capability: cap, Profile: explicit,
+					Reason: "required capability but the profile has no credential (set its API key)"}
+			}
+			return Profile{}, ErrNoProvider
+		}
+		return p, nil
+	}
+	for _, p := range precedence {
+		if p.Eligible() && Can(p.Kind, cap) != Unsupported {
+			return p, nil
+		}
+	}
+	return Profile{}, ErrNoProvider
+}
+
+// EmbedIdentity is the corpus-lifetime embed identity (SPEC 8.1.4):
+// provider name + text/code model. It is recorded in the config
+// snapshot/index and compared on load. Role (8.1.5) is deliberately
+// excluded — it does not affect vector-space compatibility.
+func EmbedIdentity(p Profile) string {
+	return fmt.Sprintf("%s|%s|%s",
+		strings.TrimSpace(p.Name),
+		strings.TrimSpace(p.EmbedTextModel),
+		strings.TrimSpace(p.EmbedCodeModel))
+}
+
+// VerifyEmbedIdentity returns a *ConfigError when a recorded embed
+// identity differs from the current one (SPEC 8.1.4 — the server MUST
+// NOT silently mix vector spaces). An empty recorded identity (fresh
+// index) always passes.
+func VerifyEmbedIdentity(recorded, current string) error {
+	recorded = strings.TrimSpace(recorded)
+	if recorded == "" || recorded == strings.TrimSpace(current) {
+		return nil
+	}
+	return &ConfigError{
+		Capability: CapEmbed,
+		Profile:    current,
+		Reason: fmt.Sprintf(
+			"embed identity changed (index built with %q, configured %q); embeddings are corpus-lifetime — reindex to change the embed provider/model",
+			recorded, current),
+	}
+}

--- a/tests/provider/provider_test.go
+++ b/tests/provider/provider_test.go
@@ -1,0 +1,149 @@
+package tests
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/provider"
+)
+
+// TestMatrixMatchesSpec pins the normative SPEC 8.1.2 table exactly.
+func TestMatrixMatchesSpec(t *testing.T) {
+	S, E, U := provider.Supported, provider.EndpointDependent, provider.Unsupported
+	want := map[provider.Kind]map[provider.Capability]provider.Support{
+		provider.KindOpenAI:     {provider.CapEmbed: S, provider.CapChat: S, provider.CapOCR: U, provider.CapSTT: E, provider.CapTTS: E, provider.CapRerank: U},
+		provider.KindMistral:    {provider.CapEmbed: U, provider.CapChat: U, provider.CapOCR: S, provider.CapSTT: S, provider.CapTTS: U, provider.CapRerank: U},
+		provider.KindAnthropic:  {provider.CapEmbed: U, provider.CapChat: S, provider.CapOCR: U, provider.CapSTT: U, provider.CapTTS: U, provider.CapRerank: U},
+		provider.KindGemini:     {provider.CapEmbed: S, provider.CapChat: S, provider.CapOCR: U, provider.CapSTT: S, provider.CapTTS: S, provider.CapRerank: U},
+		provider.KindCohere:     {provider.CapEmbed: S, provider.CapChat: S, provider.CapOCR: U, provider.CapSTT: U, provider.CapTTS: U, provider.CapRerank: S},
+		provider.KindElevenLabs: {provider.CapEmbed: U, provider.CapChat: U, provider.CapOCR: U, provider.CapSTT: S, provider.CapTTS: S, provider.CapRerank: U},
+	}
+	for k, caps := range want {
+		for c, exp := range caps {
+			if got := provider.Can(k, c); got != exp {
+				t.Errorf("Can(%s,%s)=%d, want %d", k, c, got, exp)
+			}
+		}
+	}
+	if provider.Can("nope", provider.CapChat) != provider.Unsupported {
+		t.Error("unknown kind must be Unsupported")
+	}
+	if provider.Can(provider.KindOpenAI, "nope") != provider.Unsupported {
+		t.Error("unknown capability must be Unsupported")
+	}
+}
+
+func TestEligible(t *testing.T) {
+	if !(provider.Profile{APIKey: "k"}).Eligible() {
+		t.Error("key present must be eligible")
+	}
+	if !(provider.Profile{CredentialLess: true}).Eligible() {
+		t.Error("credential-less must be eligible")
+	}
+	if (provider.Profile{APIKey: "  "}).Eligible() {
+		t.Error("blank key, not credential-less => not eligible")
+	}
+}
+
+func cfgErr(t *testing.T, err error) *provider.ConfigError {
+	t.Helper()
+	var ce *provider.ConfigError
+	if !errors.As(err, &ce) {
+		t.Fatalf("want *provider.ConfigError, got %v", err)
+	}
+	return ce
+}
+
+func TestSelectExplicit(t *testing.T) {
+	openai := provider.Profile{Name: "openai", Kind: provider.KindOpenAI, APIKey: "k"}
+	anth := provider.Profile{Name: "anthropic", Kind: provider.KindAnthropic, APIKey: "k"}
+	noKey := provider.Profile{Name: "openai-nokey", Kind: provider.KindOpenAI}
+	local := provider.Profile{Name: "local", Kind: provider.KindOpenAI, CredentialLess: true}
+	byName := map[string]provider.Profile{
+		"openai": openai, "anthropic": anth, "openai-nokey": noKey, "local": local,
+	}
+
+	// happy: capable + eligible
+	if p, err := provider.Select(nil, byName, provider.CapChat, "openai", true); err != nil || p.Name != "openai" {
+		t.Fatalf("explicit openai chat: %v %v", p, err)
+	}
+	// endpoint-dependent (openai STT) is NOT Unsupported -> allowed
+	if _, err := provider.Select(nil, byName, provider.CapSTT, "openai", true); err != nil {
+		t.Fatalf("explicit openai STT must be allowed (endpoint-dependent): %v", err)
+	}
+	// unknown profile
+	if ce := cfgErr(t, mustErr(provider.Select(nil, byName, provider.CapChat, "ghost", true))); ce.Reason == "" {
+		t.Error("want reason")
+	}
+	// kind cannot serve capability (anthropic embed)
+	ce := cfgErr(t, mustErr(provider.Select(nil, byName, provider.CapEmbed, "anthropic", true)))
+	if ce.Capability != provider.CapEmbed {
+		t.Errorf("ce.Capability=%s", ce.Capability)
+	}
+	// required + ineligible (declares key, none present) -> ConfigError
+	_ = cfgErr(t, mustErr(provider.Select(nil, byName, provider.CapChat, "openai-nokey", true)))
+	// optional + ineligible explicit (rerank-capable cohere, no key) ->
+	// ErrNoProvider (stays off, the rerank rule), NOT a hard
+	// ConfigError (SPEC 8.1.3 case 1).
+	byName["cohere-nokey"] = provider.Profile{Name: "cohere-nokey", Kind: provider.KindCohere}
+	if err := mustErr(provider.Select(nil, byName, provider.CapRerank, "cohere-nokey", false)); !errors.Is(err, provider.ErrNoProvider) {
+		t.Fatalf("optional+ineligible explicit should be ErrNoProvider, got %v", err)
+	}
+	// credential-less explicit is fine
+	if _, err := provider.Select(nil, byName, provider.CapChat, "local", true); err != nil {
+		t.Fatalf("credential-less explicit: %v", err)
+	}
+}
+
+func TestSelectAutoPrecedence(t *testing.T) {
+	mistral := provider.Profile{Name: "mistral", Kind: provider.KindMistral, APIKey: "k"} // no embed
+	openai := provider.Profile{Name: "openai", Kind: provider.KindOpenAI, APIKey: "k"}    // embed yes
+	cohere := provider.Profile{Name: "cohere", Kind: provider.KindCohere, APIKey: "k"}
+	byName := map[string]provider.Profile{"mistral": mistral, "openai": openai, "cohere": cohere}
+
+	// precedence [mistral, openai, cohere]: mistral can't embed -> openai wins
+	p, err := provider.Select([]provider.Profile{mistral, openai, cohere}, byName, provider.CapEmbed, "", true)
+	if err != nil || p.Name != "openai" {
+		t.Fatalf("auto embed: got %v %v, want openai", p.Name, err)
+	}
+	// rerank: only cohere capable
+	p, err = provider.Select([]provider.Profile{mistral, openai, cohere}, byName, provider.CapRerank, "", false)
+	if err != nil || p.Name != "cohere" {
+		t.Fatalf("auto rerank: got %v %v, want cohere", p.Name, err)
+	}
+	// ineligible skipped
+	openaiNoKey := provider.Profile{Name: "openai", Kind: provider.KindOpenAI}
+	p, err = provider.Select([]provider.Profile{openaiNoKey, cohere}, byName, provider.CapEmbed, "", false)
+	if err != nil || p.Name != "cohere" {
+		t.Fatalf("ineligible skipped: got %v %v, want cohere", p.Name, err)
+	}
+	// none capable+eligible -> ErrNoProvider
+	if _, err := provider.Select([]provider.Profile{mistral}, byName, provider.CapRerank, "", false); !errors.Is(err, provider.ErrNoProvider) {
+		t.Fatalf("want ErrNoProvider, got %v", err)
+	}
+	// credential-less local auto-selected
+	local := provider.Profile{Name: "local", Kind: provider.KindOpenAI, CredentialLess: true}
+	p, err = provider.Select([]provider.Profile{local}, byName, provider.CapChat, "", true)
+	if err != nil || p.Name != "local" {
+		t.Fatalf("credential-less auto: got %v %v", p.Name, err)
+	}
+}
+
+func TestEmbedIdentity(t *testing.T) {
+	p := provider.Profile{Name: "mistral", EmbedTextModel: "mistral-embed", EmbedCodeModel: "codestral-embed"}
+	id := provider.EmbedIdentity(p)
+	if id != "mistral|mistral-embed|codestral-embed" {
+		t.Fatalf("identity = %q", id)
+	}
+	if err := provider.VerifyEmbedIdentity("", id); err != nil {
+		t.Errorf("fresh index (empty recorded) must pass: %v", err)
+	}
+	if err := provider.VerifyEmbedIdentity(id, id); err != nil {
+		t.Errorf("matching identity must pass: %v", err)
+	}
+	_ = cfgErr(t, provider.VerifyEmbedIdentity("openai|text-embedding-3-small|", id))
+}
+
+func mustErr(_ provider.Profile, err error) error {
+	return err
+}


### PR DESCRIPTION
**PR C1** — the pure resolution core of the multi-provider keystone (Design 0001 / SPEC §8.1). Split out of the big PR C so the matrix/selection logic is reviewable in isolation; **additive, no wiring** (config + CLI integration + Mistral re-expression is the follow-up PR C2).

- **§8.1.2 capability matrix** — `Can(kind, cap)` → `Supported` / `EndpointDependent` / `Unsupported`. A test pins the spec table cell-for-cell. `openai` audio is `EndpointDependent` (implemented, validated at first use, never `CONFIG_INVALID`).
- **§8.1.3 selection** — `Profile.Eligible()` (credential present **or** credential-less local), and `Select()`: explicit → matrix-validate + eligibility (`CONFIG_INVALID` only when *required*; optional+ineligible stays off — the rerank rule); auto → first eligible+capable in a deterministic precedence; none → `ErrNoProvider`.
- **§8.1.4 corpus-lifetime** — `EmbedIdentity` / `VerifyEmbedIdentity`; a changed embed identity is `CONFIG_INVALID` (no silent vector-space mixing).

Pure logic, no HTTP/config-file deps. Exhaustive unit tests; `make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-provider support infrastructure with configurable capabilities across various AI providers
  * Implemented profile selection and eligibility validation logic
  * Added embedding corpus identity verification for compatibility

* **Tests**
  * Comprehensive test coverage for provider capabilities, selection rules, and identity verification

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dirstral/dir2mcp/pull/195?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->