### PR TITLE
feat(providerfactory + audio): factory + close SPEC 8.1.2 audio gap (C2-i)

### DIFF
--- a/internal/gemini/client.go
+++ b/internal/gemini/client.go
@@ -28,7 +28,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -51,6 +53,9 @@ const (
 	// normally supplies explicit models per profile.
 	DefaultEmbedModel = "text-embedding-004"
 	DefaultChatModel  = "gemini-2.5-flash"
+	DefaultSTTModel   = "gemini-2.5-flash"
+	DefaultTTSModel   = "gemini-2.5-flash-preview-tts"
+	DefaultTTSVoice   = "Kore"
 )
 
 // Client is a Gemini adapter that speaks the OpenAI-compatible wire
@@ -73,12 +78,16 @@ type Client struct {
 	// call is made with an empty model name.
 	DefaultEmbedModel string
 	DefaultChatModel  string
+	DefaultSTTModel   string
+	DefaultTTSModel   string
+	DefaultTTSVoice   string
 }
 
 // compile-time assertions that *Client implements the model contracts.
 var (
-	_ model.Embedder  = (*Client)(nil)
-	_ model.Generator = (*Client)(nil)
+	_ model.Embedder    = (*Client)(nil)
+	_ model.Generator   = (*Client)(nil)
+	_ model.Transcriber = (*Client)(nil)
 )
 
 // NewClient constructs a client with safe default retry/timeout settings.
@@ -100,6 +109,9 @@ func NewClient(baseURL, apiKey string) *Client {
 		GenerationTimeout: defaultGenerationTimeout,
 		DefaultEmbedModel: DefaultEmbedModel,
 		DefaultChatModel:  DefaultChatModel,
+		DefaultSTTModel:   DefaultSTTModel,
+		DefaultTTSModel:   DefaultTTSModel,
+		DefaultTTSVoice:   DefaultTTSVoice,
 	}
 }
 
@@ -344,6 +356,153 @@ func contentToText(raw json.RawMessage) string {
 		return strings.Join(texts, "\n")
 	}
 	return ""
+}
+
+type transcriptionResponse struct {
+	Text string `json:"text"`
+}
+
+// Transcribe implements model.Transcriber via {base}/audio/transcriptions
+// on Gemini's OpenAI-compatible endpoint (SPEC 8.1.2 gemini stt).
+func (c *Client) Transcribe(ctx context.Context, relPath string, data []byte) (string, error) {
+	if strings.TrimSpace(c.APIKey) == "" {
+		return "", &model.ProviderError{Code: "GEMINI_AUTH", Message: "missing Gemini API key", Retryable: false}
+	}
+	if len(data) == 0 {
+		return "", &model.ProviderError{Code: "GEMINI_FAILED", Message: "transcription input is empty", Retryable: false}
+	}
+	sttModel := strings.TrimSpace(c.DefaultSTTModel)
+	if sttModel == "" {
+		sttModel = DefaultSTTModel
+	}
+	timeout := c.GenerationTimeout
+	if timeout <= 0 {
+		timeout = defaultGenerationTimeout
+	}
+	return retryAudio(ctx, c, func() (string, error) {
+		return c.transcribeOnce(ctx, relPath, data, sttModel, timeout)
+	})
+}
+
+func (c *Client) transcribeOnce(ctx context.Context, relPath string, data []byte, sttModel string, timeout time.Duration) (string, error) {
+	name := strings.TrimSpace(filepath.Base(relPath))
+	if name == "" || name == "." || name == string(filepath.Separator) {
+		name = "audio.wav"
+	}
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	ff, err := w.CreateFormFile("file", name)
+	if err == nil {
+		_, err = ff.Write(data)
+	}
+	if err == nil {
+		err = w.WriteField("model", sttModel)
+	}
+	if err == nil {
+		err = w.Close()
+	}
+	if err != nil {
+		return "", &model.ProviderError{Code: "GEMINI_FAILED", Message: "failed to build transcription body", Retryable: false, Cause: err}
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+"/audio/transcriptions", bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		return "", &model.ProviderError{Code: "GEMINI_FAILED", Message: "failed to build transcription request", Retryable: false, Cause: err}
+	}
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("Content-Type", w.FormDataContentType())
+	resp, err := clientWithTimeout(c.HTTPClient, timeout).Do(req)
+	if err != nil {
+		return "", &model.ProviderError{Code: "GEMINI_FAILED", Message: "transcription request failed", Retryable: true, Cause: err}
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return "", httpError(resp)
+	}
+	var parsed transcriptionResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return "", &model.ProviderError{Code: "GEMINI_FAILED", Message: "failed to decode transcription response", Retryable: false, StatusCode: resp.StatusCode, Cause: err}
+	}
+	return strings.TrimSpace(parsed.Text), nil
+}
+
+type speechRequest struct {
+	Model string `json:"model"`
+	Input string `json:"input"`
+	Voice string `json:"voice"`
+}
+
+// Synthesize implements the optional TTS surface (mcp.TTSSynthesizer
+// shape) via {base}/audio/speech, returning raw audio bytes. TTS is
+// fail-open per SPEC 8.3.
+func (c *Client) Synthesize(ctx context.Context, text string) ([]byte, error) {
+	if strings.TrimSpace(c.APIKey) == "" {
+		return nil, &model.ProviderError{Code: "GEMINI_AUTH", Message: "missing Gemini API key", Retryable: false}
+	}
+	if strings.TrimSpace(text) == "" {
+		return nil, &model.ProviderError{Code: "GEMINI_FAILED", Message: "tts input is empty", Retryable: false}
+	}
+	ttsModel := strings.TrimSpace(c.DefaultTTSModel)
+	if ttsModel == "" {
+		ttsModel = DefaultTTSModel
+	}
+	voice := strings.TrimSpace(c.DefaultTTSVoice)
+	if voice == "" {
+		voice = DefaultTTSVoice
+	}
+	timeout := c.GenerationTimeout
+	if timeout <= 0 {
+		timeout = defaultGenerationTimeout
+	}
+	body, err := json.Marshal(speechRequest{Model: ttsModel, Input: text, Voice: voice})
+	if err != nil {
+		return nil, &model.ProviderError{Code: "GEMINI_FAILED", Message: "failed to marshal tts request", Retryable: false, Cause: err}
+	}
+	return retryAudio(ctx, c, func() ([]byte, error) {
+		resp, err := c.doJSON(ctx, "/audio/speech", body, timeout)
+		if err != nil {
+			return nil, err
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			return nil, httpError(resp)
+		}
+		audio, rerr := io.ReadAll(resp.Body)
+		if rerr != nil {
+			return nil, &model.ProviderError{Code: "GEMINI_FAILED", Message: "failed to read tts audio", Retryable: true, Cause: rerr}
+		}
+		if len(audio) == 0 {
+			return nil, &model.ProviderError{Code: "GEMINI_FAILED", Message: "tts returned no audio", Retryable: false, StatusCode: resp.StatusCode}
+		}
+		return audio, nil
+	})
+}
+
+// retryAudio runs op with the client's bounded exponential backoff,
+// stopping early on a non-retryable *model.ProviderError.
+func retryAudio[T any](ctx context.Context, c *Client, op func() (T, error)) (T, error) {
+	maxRetries := c.MaxRetries
+	if maxRetries < 0 {
+		maxRetries = 0
+	}
+	var zero T
+	var lastErr error
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		if attempt > 0 {
+			if err := c.wait(ctx, c.backoffForAttempt(attempt-1)); err != nil {
+				return zero, err
+			}
+		}
+		out, err := op()
+		if err == nil {
+			return out, nil
+		}
+		lastErr = err
+		var pErr *model.ProviderError
+		if errors.As(err, &pErr) && !pErr.Retryable {
+			return zero, err
+		}
+	}
+	return zero, lastErr
 }
 
 func (c *Client) doJSON(ctx context.Context, path string, body []byte, timeout time.Duration) (*http.Response, error) {

--- a/internal/openai/client.go
+++ b/internal/openai/client.go
@@ -22,7 +22,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -38,11 +40,15 @@ const (
 	defaultMaxBackoff        = 2 * time.Second
 	defaultBatchSize         = 64
 
-	// DefaultEmbedModel / DefaultChatModel are fallbacks used only when
-	// the caller passes an empty model name. The config resolver
-	// normally supplies explicit models per profile.
+	// DefaultEmbedModel / DefaultChatModel / DefaultSTTModel /
+	// DefaultTTSModel / DefaultTTSVoice are fallbacks used only when the
+	// caller passes an empty value. The config resolver normally
+	// supplies explicit models per profile.
 	DefaultEmbedModel = "text-embedding-3-small"
 	DefaultChatModel  = "gpt-4o-mini"
+	DefaultSTTModel   = "whisper-1"
+	DefaultTTSModel   = "tts-1"
+	DefaultTTSVoice   = "alloy"
 )
 
 // Client is an OpenAI-compatible API adapter.
@@ -60,16 +66,21 @@ type Client struct {
 	MaxBackoff        time.Duration
 	BatchSize         int
 	GenerationTimeout time.Duration
-	// DefaultEmbedModel/DefaultChatModel are used when the corresponding
-	// call is made with an empty model name.
+	// DefaultEmbedModel/DefaultChatModel/DefaultSTTModel/DefaultTTSModel/
+	// DefaultTTSVoice are used when the corresponding call is made with
+	// an empty value.
 	DefaultEmbedModel string
 	DefaultChatModel  string
+	DefaultSTTModel   string
+	DefaultTTSModel   string
+	DefaultTTSVoice   string
 }
 
 // compile-time assertions that *Client implements the model contracts.
 var (
-	_ model.Embedder  = (*Client)(nil)
-	_ model.Generator = (*Client)(nil)
+	_ model.Embedder    = (*Client)(nil)
+	_ model.Generator   = (*Client)(nil)
+	_ model.Transcriber = (*Client)(nil)
 )
 
 // NewClient constructs a client with safe default retry/timeout settings.
@@ -93,6 +104,9 @@ func NewClient(baseURL, apiKey string) *Client {
 		GenerationTimeout: defaultGenerationTimeout,
 		DefaultEmbedModel: DefaultEmbedModel,
 		DefaultChatModel:  DefaultChatModel,
+		DefaultSTTModel:   DefaultSTTModel,
+		DefaultTTSModel:   DefaultTTSModel,
+		DefaultTTSVoice:   DefaultTTSVoice,
 	}
 }
 
@@ -331,6 +345,156 @@ func contentToText(raw json.RawMessage) string {
 		return b.String()
 	}
 	return ""
+}
+
+type transcriptionResponse struct {
+	Text string `json:"text"`
+}
+
+// Transcribe implements model.Transcriber via {base}/audio/transcriptions
+// (OpenAI multipart Whisper / gpt-4o-transcribe). Endpoint-dependent per
+// SPEC 8.1.2 ³: a compatible base lacking audio surfaces a provider
+// error here, never CONFIG_INVALID.
+func (c *Client) Transcribe(ctx context.Context, relPath string, data []byte) (string, error) {
+	if strings.TrimSpace(c.APIKey) == "" {
+		return "", &model.ProviderError{Code: "OPENAI_AUTH", Message: "missing OpenAI API key", Retryable: false}
+	}
+	if len(data) == 0 {
+		return "", &model.ProviderError{Code: "OPENAI_FAILED", Message: "transcription input is empty", Retryable: false}
+	}
+	sttModel := strings.TrimSpace(c.DefaultSTTModel)
+	if sttModel == "" {
+		sttModel = DefaultSTTModel
+	}
+	timeout := c.GenerationTimeout
+	if timeout <= 0 {
+		timeout = defaultGenerationTimeout
+	}
+	return retryAudio(ctx, c, func() (string, error) {
+		return c.transcribeOnce(ctx, relPath, data, sttModel, timeout)
+	})
+}
+
+func (c *Client) transcribeOnce(ctx context.Context, relPath string, data []byte, sttModel string, timeout time.Duration) (string, error) {
+	name := strings.TrimSpace(filepath.Base(relPath))
+	if name == "" || name == "." || name == string(filepath.Separator) {
+		name = "audio.wav"
+	}
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	ff, err := w.CreateFormFile("file", name)
+	if err == nil {
+		_, err = ff.Write(data)
+	}
+	if err == nil {
+		err = w.WriteField("model", sttModel)
+	}
+	if err == nil {
+		err = w.Close()
+	}
+	if err != nil {
+		return "", &model.ProviderError{Code: "OPENAI_FAILED", Message: "failed to build transcription body", Retryable: false, Cause: err}
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+"/audio/transcriptions", bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		return "", &model.ProviderError{Code: "OPENAI_FAILED", Message: "failed to build transcription request", Retryable: false, Cause: err}
+	}
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("Content-Type", w.FormDataContentType())
+	resp, err := clientWithTimeout(c.HTTPClient, timeout).Do(req)
+	if err != nil {
+		return "", &model.ProviderError{Code: "OPENAI_FAILED", Message: "transcription request failed", Retryable: true, Cause: err}
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return "", httpError(resp)
+	}
+	var parsed transcriptionResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return "", &model.ProviderError{Code: "OPENAI_FAILED", Message: "failed to decode transcription response", Retryable: false, StatusCode: resp.StatusCode, Cause: err}
+	}
+	return strings.TrimSpace(parsed.Text), nil
+}
+
+type speechRequest struct {
+	Model string `json:"model"`
+	Input string `json:"input"`
+	Voice string `json:"voice"`
+}
+
+// Synthesize implements the optional TTS surface (mcp.TTSSynthesizer
+// shape) via {base}/audio/speech, returning raw audio bytes. TTS is
+// fail-open per SPEC 8.3 — callers proceed without audio on error.
+func (c *Client) Synthesize(ctx context.Context, text string) ([]byte, error) {
+	if strings.TrimSpace(c.APIKey) == "" {
+		return nil, &model.ProviderError{Code: "OPENAI_AUTH", Message: "missing OpenAI API key", Retryable: false}
+	}
+	if strings.TrimSpace(text) == "" {
+		return nil, &model.ProviderError{Code: "OPENAI_FAILED", Message: "tts input is empty", Retryable: false}
+	}
+	ttsModel := strings.TrimSpace(c.DefaultTTSModel)
+	if ttsModel == "" {
+		ttsModel = DefaultTTSModel
+	}
+	voice := strings.TrimSpace(c.DefaultTTSVoice)
+	if voice == "" {
+		voice = DefaultTTSVoice
+	}
+	timeout := c.GenerationTimeout
+	if timeout <= 0 {
+		timeout = defaultGenerationTimeout
+	}
+	body, err := json.Marshal(speechRequest{Model: ttsModel, Input: text, Voice: voice})
+	if err != nil {
+		return nil, &model.ProviderError{Code: "OPENAI_FAILED", Message: "failed to marshal tts request", Retryable: false, Cause: err}
+	}
+	return retryAudio(ctx, c, func() ([]byte, error) {
+		resp, err := c.doJSON(ctx, "/audio/speech", body, timeout)
+		if err != nil {
+			return nil, err
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			return nil, httpError(resp)
+		}
+		audio, rerr := io.ReadAll(resp.Body)
+		if rerr != nil {
+			return nil, &model.ProviderError{Code: "OPENAI_FAILED", Message: "failed to read tts audio", Retryable: true, Cause: rerr}
+		}
+		if len(audio) == 0 {
+			return nil, &model.ProviderError{Code: "OPENAI_FAILED", Message: "tts returned no audio", Retryable: false, StatusCode: resp.StatusCode}
+		}
+		return audio, nil
+	})
+}
+
+// retryAudio runs op with the client's bounded exponential backoff,
+// stopping early on a non-retryable *model.ProviderError (shared by
+// Transcribe/Synthesize).
+func retryAudio[T any](ctx context.Context, c *Client, op func() (T, error)) (T, error) {
+	maxRetries := c.MaxRetries
+	if maxRetries < 0 {
+		maxRetries = 0
+	}
+	var zero T
+	var lastErr error
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		if attempt > 0 {
+			if err := c.wait(ctx, c.backoffForAttempt(attempt-1)); err != nil {
+				return zero, err
+			}
+		}
+		out, err := op()
+		if err == nil {
+			return out, nil
+		}
+		lastErr = err
+		var pErr *model.ProviderError
+		if errors.As(err, &pErr) && !pErr.Retryable {
+			return zero, err
+		}
+	}
+	return zero, lastErr
 }
 
 func (c *Client) doJSON(ctx context.Context, path string, body []byte, timeout time.Duration) (*http.Response, error) {

--- a/internal/providerfactory/factory.go
+++ b/internal/providerfactory/factory.go
@@ -9,6 +9,7 @@
 package providerfactory
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/dirstral/dir2mcp/internal/anthropic"
@@ -21,12 +22,12 @@ import (
 	"github.com/dirstral/dir2mcp/internal/provider"
 )
 
-// ErrCapabilityUnimplemented is returned when a profile's kind is marked
-// capable by the SPEC 8.1.2 matrix but the adapter does not yet
-// implement that capability in this release. Currently this is only
-// STT/TTS for kinds `openai` and `gemini` (deferred — see #192 / task
-// tracking; the matrix is normative but the wire adapters are pending).
-var ErrCapabilityUnimplemented = fmt.Errorf("provider capability not implemented in this release")
+// TTSSynthesizer is the optional text-to-speech surface (matches
+// mcp.TTSSynthesizer; declared locally to keep this package free of an
+// mcp import). TTS is fail-open per SPEC 8.3.
+type TTSSynthesizer interface {
+	Synthesize(ctx context.Context, text string) ([]byte, error)
+}
 
 func unsupported(p provider.Profile, cap provider.Capability) error {
 	return fmt.Errorf("provider kind %q cannot serve %s", p.Kind, cap)
@@ -113,11 +114,10 @@ func OCR(p provider.Profile) (model.OCR, error) {
 	return c, nil
 }
 
-// Transcriber builds a model.Transcriber. Implemented for `mistral`
-// (Voxtral) and `elevenlabs` (Scribe). `openai`/`gemini` are matrix-
-// capable but their Transcribe adapters are not yet implemented in this
-// release → ErrCapabilityUnimplemented (so callers degrade explicitly
-// rather than mis-route STT).
+// Transcriber builds a model.Transcriber for STT-capable kinds:
+// `mistral` (Voxtral), `elevenlabs` (Scribe), and `openai`/`gemini`
+// (OpenAI-compatible /v1/audio/transcriptions; endpoint-dependent for
+// openai per SPEC 8.1.2 ³ — validated at first use).
 func Transcriber(p provider.Profile) (model.Transcriber, error) {
 	switch p.Kind {
 	case provider.KindMistral:
@@ -129,10 +129,43 @@ func Transcriber(p provider.Profile) (model.Transcriber, error) {
 	case provider.KindElevenLabs:
 		// elevenlabs.NewClient(apiKey, voiceID); voiceID is TTS-only.
 		return elevenlabs.NewClient(p.APIKey, ""), nil
-	case provider.KindOpenAI, provider.KindGemini:
-		return nil, fmt.Errorf("%w: %s STT", ErrCapabilityUnimplemented, p.Kind)
+	case provider.KindOpenAI:
+		c := openai.NewClient(p.BaseURL, p.APIKey)
+		if p.STTModel != "" {
+			c.DefaultSTTModel = p.STTModel
+		}
+		return c, nil
+	case provider.KindGemini:
+		c := gemini.NewClient(p.BaseURL, p.APIKey)
+		if p.STTModel != "" {
+			c.DefaultSTTModel = p.STTModel
+		}
+		return c, nil
 	default:
 		return nil, unsupported(p, provider.CapSTT)
+	}
+}
+
+// TTS builds a TTSSynthesizer for TTS-capable kinds: `elevenlabs`,
+// `openai`, `gemini` (SPEC 8.1.2). openai TTS is endpoint-dependent.
+func TTS(p provider.Profile) (TTSSynthesizer, error) {
+	switch p.Kind {
+	case provider.KindElevenLabs:
+		return elevenlabs.NewClient(p.APIKey, ""), nil
+	case provider.KindOpenAI:
+		c := openai.NewClient(p.BaseURL, p.APIKey)
+		if p.TTSModel != "" {
+			c.DefaultTTSModel = p.TTSModel
+		}
+		return c, nil
+	case provider.KindGemini:
+		c := gemini.NewClient(p.BaseURL, p.APIKey)
+		if p.TTSModel != "" {
+			c.DefaultTTSModel = p.TTSModel
+		}
+		return c, nil
+	default:
+		return nil, unsupported(p, provider.CapTTS)
 	}
 }
 

--- a/internal/providerfactory/factory.go
+++ b/internal/providerfactory/factory.go
@@ -1,0 +1,149 @@
+// Package providerfactory constructs concrete model.* adapters from a
+// resolved provider.Profile (SPEC 0.7.0 / Design 0001). It is the
+// impl-side counterpart to the pure internal/provider resolver: the
+// resolver decides *which* profile serves a capability (matrix +
+// selection), this package builds the wire client for it.
+//
+// It is the single place that imports every adapter, keeping
+// internal/provider dependency-free.
+package providerfactory
+
+import (
+	"fmt"
+
+	"github.com/dirstral/dir2mcp/internal/anthropic"
+	"github.com/dirstral/dir2mcp/internal/cohere"
+	"github.com/dirstral/dir2mcp/internal/elevenlabs"
+	"github.com/dirstral/dir2mcp/internal/gemini"
+	"github.com/dirstral/dir2mcp/internal/mistral"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/openai"
+	"github.com/dirstral/dir2mcp/internal/provider"
+)
+
+// ErrCapabilityUnimplemented is returned when a profile's kind is marked
+// capable by the SPEC 8.1.2 matrix but the adapter does not yet
+// implement that capability in this release. Currently this is only
+// STT/TTS for kinds `openai` and `gemini` (deferred — see #192 / task
+// tracking; the matrix is normative but the wire adapters are pending).
+var ErrCapabilityUnimplemented = fmt.Errorf("provider capability not implemented in this release")
+
+func unsupported(p provider.Profile, cap provider.Capability) error {
+	return fmt.Errorf("provider kind %q cannot serve %s", p.Kind, cap)
+}
+
+// Embedder builds a model.Embedder for the profile (kinds: openai,
+// mistral, cohere, gemini). The per-call model still comes from the
+// caller; Default*Model is only a fallback for empty model names.
+func Embedder(p provider.Profile) (model.Embedder, error) {
+	switch p.Kind {
+	case provider.KindOpenAI:
+		c := openai.NewClient(p.BaseURL, p.APIKey)
+		if p.EmbedTextModel != "" {
+			c.DefaultEmbedModel = p.EmbedTextModel
+		}
+		return c, nil
+	case provider.KindGemini:
+		c := gemini.NewClient(p.BaseURL, p.APIKey)
+		if p.EmbedTextModel != "" {
+			c.DefaultEmbedModel = p.EmbedTextModel
+		}
+		return c, nil
+	case provider.KindCohere:
+		c := cohere.NewClient(p.BaseURL, p.APIKey)
+		if p.EmbedTextModel != "" {
+			c.DefaultEmbedModel = p.EmbedTextModel
+		}
+		return c, nil
+	case provider.KindMistral:
+		// Mistral chat/embed run on the OpenAI-compatible backbone
+		// (SPEC 8.1.1 re-expression); the bespoke mistral client keeps
+		// only OCR/Voxtral. A `mistral` *profile* therefore uses
+		// kind=openai for embed; reaching here means a kind:mistral
+		// binding for embed, which the matrix forbids.
+		return nil, unsupported(p, provider.CapEmbed)
+	default:
+		return nil, unsupported(p, provider.CapEmbed)
+	}
+}
+
+// Generator builds a model.Generator (kinds: openai, gemini, cohere,
+// anthropic).
+func Generator(p provider.Profile) (model.Generator, error) {
+	switch p.Kind {
+	case provider.KindOpenAI:
+		c := openai.NewClient(p.BaseURL, p.APIKey)
+		if p.ChatModel != "" {
+			c.DefaultChatModel = p.ChatModel
+		}
+		return c, nil
+	case provider.KindGemini:
+		c := gemini.NewClient(p.BaseURL, p.APIKey)
+		if p.ChatModel != "" {
+			c.DefaultChatModel = p.ChatModel
+		}
+		return c, nil
+	case provider.KindCohere:
+		c := cohere.NewClient(p.BaseURL, p.APIKey)
+		if p.ChatModel != "" {
+			c.DefaultChatModel = p.ChatModel
+		}
+		return c, nil
+	case provider.KindAnthropic:
+		c := anthropic.NewClient(p.BaseURL, p.APIKey)
+		if p.ChatModel != "" {
+			c.DefaultChatModel = p.ChatModel
+		}
+		return c, nil
+	default:
+		return nil, unsupported(p, provider.CapChat)
+	}
+}
+
+// OCR builds a model.OCR. Only the bespoke `mistral` kind serves OCR
+// (SPEC 8.1.2 — there is no OpenAI-compatible OCR endpoint).
+func OCR(p provider.Profile) (model.OCR, error) {
+	if p.Kind != provider.KindMistral {
+		return nil, unsupported(p, provider.CapOCR)
+	}
+	c := mistral.NewClient(p.BaseURL, p.APIKey)
+	if p.OCRModel != "" {
+		c.DefaultOCRModel = p.OCRModel
+	}
+	return c, nil
+}
+
+// Transcriber builds a model.Transcriber. Implemented for `mistral`
+// (Voxtral) and `elevenlabs` (Scribe). `openai`/`gemini` are matrix-
+// capable but their Transcribe adapters are not yet implemented in this
+// release → ErrCapabilityUnimplemented (so callers degrade explicitly
+// rather than mis-route STT).
+func Transcriber(p provider.Profile) (model.Transcriber, error) {
+	switch p.Kind {
+	case provider.KindMistral:
+		c := mistral.NewClient(p.BaseURL, p.APIKey)
+		if p.STTModel != "" {
+			c.DefaultTranscribeModel = p.STTModel
+		}
+		return c, nil
+	case provider.KindElevenLabs:
+		// elevenlabs.NewClient(apiKey, voiceID); voiceID is TTS-only.
+		return elevenlabs.NewClient(p.APIKey, ""), nil
+	case provider.KindOpenAI, provider.KindGemini:
+		return nil, fmt.Errorf("%w: %s STT", ErrCapabilityUnimplemented, p.Kind)
+	default:
+		return nil, unsupported(p, provider.CapSTT)
+	}
+}
+
+// Reranker builds a model.Reranker (only `cohere`).
+func Reranker(p provider.Profile) (model.Reranker, error) {
+	if p.Kind != provider.KindCohere {
+		return nil, unsupported(p, provider.CapRerank)
+	}
+	c := cohere.NewClient(p.BaseURL, p.APIKey)
+	if p.RerankModel != "" {
+		c.DefaultModel = p.RerankModel
+	}
+	return c, nil
+}

--- a/tests/gemini/client_test.go
+++ b/tests/gemini/client_test.go
@@ -350,6 +350,50 @@ func TestNonRetryableStopsImmediately(t *testing.T) {
 	}
 }
 
+func TestTranscribeAndSynthesize(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/audio/transcriptions":
+			if ct := r.Header.Get("Content-Type"); !strings.HasPrefix(ct, "multipart/form-data") {
+				t.Errorf("transcribe content-type = %q", ct)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"text": "hello transcript"})
+		case "/audio/speech":
+			_, _ = w.Write([]byte("AUDIOBYTES"))
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL)
+	txt, err := c.Transcribe(context.Background(), "a.wav", []byte("pcm"))
+	if err != nil || txt != "hello transcript" {
+		t.Fatalf("Transcribe = %q, %v", txt, err)
+	}
+	audio, err := c.Synthesize(context.Background(), "say this")
+	if err != nil || string(audio) != "AUDIOBYTES" {
+		t.Fatalf("Synthesize = %q, %v", audio, err)
+	}
+}
+
+func TestAudioMissingKeyAndEmptyInput(t *testing.T) {
+	nokey := gemini.NewClient("http://127.0.0.1:0", "")
+	if _, err := nokey.Transcribe(context.Background(), "a.wav", []byte("x")); err == nil {
+		t.Error("Transcribe missing key must error")
+	}
+	if _, err := nokey.Synthesize(context.Background(), "x"); err == nil {
+		t.Error("Synthesize missing key must error")
+	}
+	keyed := gemini.NewClient("http://127.0.0.1:0", "k")
+	if _, err := keyed.Transcribe(context.Background(), "a.wav", nil); err == nil {
+		t.Error("Transcribe empty data must error (no HTTP call)")
+	}
+	if _, err := keyed.Synthesize(context.Background(), "  "); err == nil {
+		t.Error("Synthesize empty text must error (no HTTP call)")
+	}
+}
+
 // asProviderErr unwraps via errors.As (repo convention) so wrapped
 // provider errors are still recognized.
 func asProviderErr(err error, target **model.ProviderError) bool {

--- a/tests/openai/client_test.go
+++ b/tests/openai/client_test.go
@@ -235,6 +235,50 @@ func TestHTTPErrorMapping(t *testing.T) {
 	}
 }
 
+func TestTranscribeAndSynthesize(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/audio/transcriptions":
+			if ct := r.Header.Get("Content-Type"); !strings.HasPrefix(ct, "multipart/form-data") {
+				t.Errorf("transcribe content-type = %q", ct)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"text": "hello transcript"})
+		case "/audio/speech":
+			_, _ = w.Write([]byte("AUDIOBYTES"))
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL)
+	txt, err := c.Transcribe(context.Background(), "a.wav", []byte("pcm"))
+	if err != nil || txt != "hello transcript" {
+		t.Fatalf("Transcribe = %q, %v", txt, err)
+	}
+	audio, err := c.Synthesize(context.Background(), "say this")
+	if err != nil || string(audio) != "AUDIOBYTES" {
+		t.Fatalf("Synthesize = %q, %v", audio, err)
+	}
+}
+
+func TestAudioMissingKeyAndEmptyInput(t *testing.T) {
+	nokey := openai.NewClient("http://127.0.0.1:0", "")
+	if _, err := nokey.Transcribe(context.Background(), "a.wav", []byte("x")); err == nil {
+		t.Error("Transcribe missing key must error")
+	}
+	if _, err := nokey.Synthesize(context.Background(), "x"); err == nil {
+		t.Error("Synthesize missing key must error")
+	}
+	keyed := openai.NewClient("http://127.0.0.1:0", "k")
+	if _, err := keyed.Transcribe(context.Background(), "a.wav", nil); err == nil {
+		t.Error("Transcribe empty data must error (no HTTP call)")
+	}
+	if _, err := keyed.Synthesize(context.Background(), "  "); err == nil {
+		t.Error("Synthesize empty text must error (no HTTP call)")
+	}
+}
+
 func asProviderErr(err error, target **model.ProviderError) bool {
 	if err == nil {
 		return false

--- a/tests/providerfactory/factory_test.go
+++ b/tests/providerfactory/factory_test.go
@@ -1,0 +1,93 @@
+package tests
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/openai"
+	"github.com/dirstral/dir2mcp/internal/provider"
+	"github.com/dirstral/dir2mcp/internal/providerfactory"
+)
+
+func prof(k provider.Kind) provider.Profile {
+	return provider.Profile{Name: string(k), Kind: k, APIKey: "key"}
+}
+
+func TestEmbedder(t *testing.T) {
+	for _, k := range []provider.Kind{provider.KindOpenAI, provider.KindGemini, provider.KindCohere} {
+		if e, err := providerfactory.Embedder(prof(k)); err != nil || e == nil {
+			t.Errorf("Embedder(%s) = %v, %v; want non-nil", k, e, err)
+		}
+	}
+	for _, k := range []provider.Kind{provider.KindMistral, provider.KindAnthropic, provider.KindElevenLabs} {
+		if _, err := providerfactory.Embedder(prof(k)); err == nil {
+			t.Errorf("Embedder(%s) must error (matrix: not capable)", k)
+		}
+	}
+}
+
+func TestGenerator(t *testing.T) {
+	for _, k := range []provider.Kind{provider.KindOpenAI, provider.KindGemini, provider.KindCohere, provider.KindAnthropic} {
+		if g, err := providerfactory.Generator(prof(k)); err != nil || g == nil {
+			t.Errorf("Generator(%s) = %v, %v", k, g, err)
+		}
+	}
+	for _, k := range []provider.Kind{provider.KindMistral, provider.KindElevenLabs} {
+		if _, err := providerfactory.Generator(prof(k)); err == nil {
+			t.Errorf("Generator(%s) must error", k)
+		}
+	}
+}
+
+func TestOCR(t *testing.T) {
+	if o, err := providerfactory.OCR(prof(provider.KindMistral)); err != nil || o == nil {
+		t.Fatalf("OCR(mistral) = %v, %v", o, err)
+	}
+	for _, k := range []provider.Kind{provider.KindOpenAI, provider.KindGemini, provider.KindCohere, provider.KindAnthropic, provider.KindElevenLabs} {
+		if _, err := providerfactory.OCR(prof(k)); err == nil {
+			t.Errorf("OCR(%s) must error (only mistral serves OCR)", k)
+		}
+	}
+}
+
+func TestTranscriber(t *testing.T) {
+	for _, k := range []provider.Kind{provider.KindMistral, provider.KindElevenLabs} {
+		if tr, err := providerfactory.Transcriber(prof(k)); err != nil || tr == nil {
+			t.Errorf("Transcriber(%s) = %v, %v", k, tr, err)
+		}
+	}
+	// matrix-capable but not yet implemented -> explicit sentinel
+	for _, k := range []provider.Kind{provider.KindOpenAI, provider.KindGemini} {
+		_, err := providerfactory.Transcriber(prof(k))
+		if !errors.Is(err, providerfactory.ErrCapabilityUnimplemented) {
+			t.Errorf("Transcriber(%s) want ErrCapabilityUnimplemented, got %v", k, err)
+		}
+	}
+	if _, err := providerfactory.Transcriber(prof(provider.KindCohere)); err == nil {
+		t.Error("Transcriber(cohere) must error (not STT-capable)")
+	}
+}
+
+func TestReranker(t *testing.T) {
+	if r, err := providerfactory.Reranker(prof(provider.KindCohere)); err != nil || r == nil {
+		t.Fatalf("Reranker(cohere) = %v, %v", r, err)
+	}
+	for _, k := range []provider.Kind{provider.KindOpenAI, provider.KindMistral, provider.KindGemini, provider.KindAnthropic, provider.KindElevenLabs} {
+		if _, err := providerfactory.Reranker(prof(k)); err == nil {
+			t.Errorf("Reranker(%s) must error", k)
+		}
+	}
+}
+
+func TestModelDefaultsPropagate(t *testing.T) {
+	p := provider.Profile{Name: "x", Kind: provider.KindOpenAI, APIKey: "k",
+		EmbedTextModel: "my-embed", ChatModel: "my-chat"}
+	e, _ := providerfactory.Embedder(p)
+	if oc, ok := e.(*openai.Client); !ok || oc.DefaultEmbedModel != "my-embed" {
+		t.Fatalf("embed default not propagated: %#v", e)
+	}
+	g, _ := providerfactory.Generator(p)
+	if oc, ok := g.(*openai.Client); !ok || oc.DefaultChatModel != "my-chat" {
+		t.Fatalf("chat default not propagated: %#v", g)
+	}
+}

--- a/tests/providerfactory/factory_test.go
+++ b/tests/providerfactory/factory_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/dirstral/dir2mcp/internal/openai"
@@ -51,20 +50,28 @@ func TestOCR(t *testing.T) {
 }
 
 func TestTranscriber(t *testing.T) {
-	for _, k := range []provider.Kind{provider.KindMistral, provider.KindElevenLabs} {
+	for _, k := range []provider.Kind{provider.KindMistral, provider.KindElevenLabs, provider.KindOpenAI, provider.KindGemini} {
 		if tr, err := providerfactory.Transcriber(prof(k)); err != nil || tr == nil {
 			t.Errorf("Transcriber(%s) = %v, %v", k, tr, err)
 		}
 	}
-	// matrix-capable but not yet implemented -> explicit sentinel
-	for _, k := range []provider.Kind{provider.KindOpenAI, provider.KindGemini} {
-		_, err := providerfactory.Transcriber(prof(k))
-		if !errors.Is(err, providerfactory.ErrCapabilityUnimplemented) {
-			t.Errorf("Transcriber(%s) want ErrCapabilityUnimplemented, got %v", k, err)
+	for _, k := range []provider.Kind{provider.KindCohere, provider.KindAnthropic} {
+		if _, err := providerfactory.Transcriber(prof(k)); err == nil {
+			t.Errorf("Transcriber(%s) must error (not STT-capable)", k)
 		}
 	}
-	if _, err := providerfactory.Transcriber(prof(provider.KindCohere)); err == nil {
-		t.Error("Transcriber(cohere) must error (not STT-capable)")
+}
+
+func TestTTS(t *testing.T) {
+	for _, k := range []provider.Kind{provider.KindElevenLabs, provider.KindOpenAI, provider.KindGemini} {
+		if s, err := providerfactory.TTS(prof(k)); err != nil || s == nil {
+			t.Errorf("TTS(%s) = %v, %v", k, s, err)
+		}
+	}
+	for _, k := range []provider.Kind{provider.KindMistral, provider.KindCohere, provider.KindAnthropic} {
+		if _, err := providerfactory.TTS(prof(k)); err == nil {
+			t.Errorf("TTS(%s) must error (not TTS-capable)", k)
+		}
 	}
 }
 


### PR DESCRIPTION
**PR C2-i** of the multi-provider keystone (Design 0001 / SPEC §8.1). The impl-side counterpart to the pure `internal/provider` resolver (#195) **plus** the openai/gemini audio adapters that close the §8.1.2 spec-vs-impl gap (your "full support" call).

### Factory (`internal/providerfactory`)
`provider.Profile` + capability → concrete wire client. `Embedder`/`Generator`/`OCR`/`Transcriber`/`Reranker`/`TTS`; switch on `Profile.Kind`, propagate per-capability default model; defensive errors for unsupported pairs. Single package importing every adapter (keeps `internal/provider` dependency-free).

### Audio gap closed (§8.1.2 now fully true)
- `internal/openai`: `Transcribe` (model.Transcriber via `/v1/audio/transcriptions`, multipart Whisper/gpt-4o-transcribe) + `Synthesize` (TTS via `/v1/audio/speech`).
- `internal/gemini`: same two methods on its OpenAI-compatible endpoint.
- The earlier `ErrCapabilityUnimplemented` degrade is **removed** — `Transcriber()` builds openai/gemini; new `TTS()` builder (elevenlabs/openai/gemini). No half-wired matrix cells remain.

httptest coverage for the new audio methods (happy + missing-key + empty-input no-call) for both adapters; factory capable/incapable matrices pinned. **Additive, not yet wired** (resolver→retrieval/ingest wiring + Mistral re-expression is C2-ii/iii). `make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added speech-to-text transcription capabilities across multiple AI providers with configurable default models.
  * Added text-to-speech synthesis support with customizable voice and model selection.

* **Tests**
  * Added comprehensive test coverage for audio features and provider factory dispatch across supported capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dirstral/dir2mcp/pull/196?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->