### PR TITLE
feat(cli): retrieval + rerank + embed-preflight through the resolver (C2-iii-a)

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -590,21 +590,33 @@ func saveEnvLocalKey(path, keyName, value string) error {
 // already encodes the read-only/ingest nuances; a nil embedder later
 // surfaces as ErrMissingEmbedder at query time (matching the previous
 // keyless-client behavior).
-func (a *App) resolveModelClients(cfg config.Config) (model.Embedder, model.Generator) {
+// Returns the embedder, generator, and the resolved embed text/code
+// model names (from the chosen embed profile) so the retrieval service
+// and embedding workers use the right model for the selected provider
+// instead of the hardcoded mistral defaults. Empty names mean "let the
+// adapter use its provider default".
+func (a *App) resolveModelClients(cfg config.Config) (model.Embedder, model.Generator, string, string) {
 	r := cfg.Providers()
 	var embedder model.Embedder
+	var textModel, codeModel string
 	if ep, err := r.Resolve(provider.CapEmbed); err == nil {
 		if e, ferr := providerfactory.Embedder(ep); ferr == nil {
 			embedder = e
+			textModel, codeModel = ep.EmbedTextModel, ep.EmbedCodeModel
 		}
 	}
 	var gen model.Generator
 	if cp, err := r.Resolve(provider.CapChat); err == nil {
+		// Legacy/flag chat_model still wins during the transition,
+		// regardless of which provider resolves for chat.
+		if m := strings.TrimSpace(cfg.ChatModel); m != "" {
+			cp.ChatModel = m
+		}
 		if g, ferr := providerfactory.Generator(cp); ferr == nil {
 			gen = g
 		}
 	}
-	return embedder, gen
+	return embedder, gen, textModel, codeModel
 }
 
 // configureReranker wires the optional Cohere rerank stage onto the
@@ -622,6 +634,17 @@ func (a *App) configureReranker(ret *retrieval.Service, cfg config.Config) {
 		return // explicit opt-out wins
 	}
 	asked := explicit && *cfg.RerankEnabled
+
+	// Honor the legacy flat rerank_provider during the transition: a
+	// non-cohere value preserves the prior "unsupported provider
+	// disables rerank" behavior (only cohere serves rerank — SPEC
+	// 8.1.2).
+	if rpName := strings.ToLower(strings.TrimSpace(cfg.RerankProvider)); rpName != "" && rpName != "cohere" {
+		if asked {
+			writef(a.stderr, "warning: rerank.provider %q unsupported; reranking disabled\n", cfg.RerankProvider)
+		}
+		return
+	}
 
 	rp, err := cfg.Providers().Resolve(provider.CapRerank)
 	if err != nil {
@@ -668,8 +691,10 @@ func (a *App) buildRetrieverForAsk(ctx context.Context, cfg config.Config, st mo
 		return nil, nil, fmt.Errorf("load code index: %w", err)
 	}
 
-	embedder, generator := a.resolveModelClients(cfg)
+	embedder, generator, etm, ecm := a.resolveModelClients(cfg)
 	ret := retrieval.NewService(st, textIx, embedder, generator)
+	ret.SetQueryEmbeddingModel(etm)
+	ret.SetCodeEmbeddingModel(ecm)
 	ret.SetCodeIndex(codeIx)
 	ret.SetRootDir(cfg.RootDir)
 	ret.SetStateDir(cfg.StateDir)

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -21,14 +21,14 @@ import (
 
 	"github.com/dirstral/dir2mcp/internal/appstate"
 	"github.com/dirstral/dir2mcp/internal/buildinfo"
-	"github.com/dirstral/dir2mcp/internal/cohere"
 	"github.com/dirstral/dir2mcp/internal/config"
 	"github.com/dirstral/dir2mcp/internal/index"
 	"github.com/dirstral/dir2mcp/internal/ingest"
 	"github.com/dirstral/dir2mcp/internal/mcp"
-	"github.com/dirstral/dir2mcp/internal/mistral"
 	"github.com/dirstral/dir2mcp/internal/model"
 	"github.com/dirstral/dir2mcp/internal/protocol"
+	"github.com/dirstral/dir2mcp/internal/provider"
+	"github.com/dirstral/dir2mcp/internal/providerfactory"
 	"github.com/dirstral/dir2mcp/internal/retrieval"
 	"github.com/dirstral/dir2mcp/internal/store"
 )
@@ -580,45 +580,66 @@ func saveEnvLocalKey(path, keyName, value string) error {
 	return os.WriteFile(path, []byte(strings.Join(out, "\n")+"\n"), 0o600)
 }
 
+// resolveModelClients builds the embed + chat adapters for the
+// retrieval service through the provider resolver (SPEC 8.1.3) +
+// providerfactory. It is **best-effort by design**: unresolved
+// embed/chat yields a nil client so the server can still boot (e.g.
+// read-only serving an existing index, where the embedder may never be
+// exercised). The hard requirement is enforced once, in the §2.5
+// startup preflight (checkMistralAPIKey + requiresMistralAPIKey), which
+// already encodes the read-only/ingest nuances; a nil embedder later
+// surfaces as ErrMissingEmbedder at query time (matching the previous
+// keyless-client behavior).
+func (a *App) resolveModelClients(cfg config.Config) (model.Embedder, model.Generator) {
+	r := cfg.Providers()
+	var embedder model.Embedder
+	if ep, err := r.Resolve(provider.CapEmbed); err == nil {
+		if e, ferr := providerfactory.Embedder(ep); ferr == nil {
+			embedder = e
+		}
+	}
+	var gen model.Generator
+	if cp, err := r.Resolve(provider.CapChat); err == nil {
+		if g, ferr := providerfactory.Generator(cp); ferr == nil {
+			gen = g
+		}
+	}
+	return embedder, gen
+}
+
 // configureReranker wires the optional Cohere rerank stage onto the
-// retrieval service. Reranking is capability-driven: it activates
-// automatically when a rerank provider credential is present (mirrors
-// how the Mistral key gates embedding/OCR). cfg.RerankEnabled is a
-// tri-state override:
+// retrieval service through the resolver (SPEC 8.1.3). cfg.RerankEnabled
+// is a tri-state override:
 //
-//	nil    -> auto: on iff a credential is present
-//	*false -> force off even when a credential is present
-//	*true  -> require it; warn + fail-open if no credential
+//	nil    -> auto: on iff a rerank provider resolves
+//	*false -> force off even when one resolves
+//	*true  -> require it; warn + fail-open if none resolves
 //
-// It is a fail-open optimization, not a hard dependency. Shared by the
-// `up` and `ask` retrieval paths.
+// Fail-open optimization, not a hard dependency. Shared by `up`/`ask`.
 func (a *App) configureReranker(ret *retrieval.Service, cfg config.Config) {
 	explicit := cfg.RerankEnabled != nil
-	// Explicit opt-out wins, even with a credential present.
 	if explicit && !*cfg.RerankEnabled {
-		return
+		return // explicit opt-out wins
 	}
 	asked := explicit && *cfg.RerankEnabled
 
-	provider := strings.ToLower(strings.TrimSpace(cfg.RerankProvider))
-	if provider == "" {
-		provider = "cohere"
-	}
-	if provider != "cohere" {
+	rp, err := cfg.Providers().Resolve(provider.CapRerank)
+	if err != nil {
+		// No eligible rerank provider (or an invalid explicit binding).
+		// Auto mode stays silent; only warn when explicitly asked.
 		if asked {
-			writef(a.stderr, "warning: rerank.provider %q unsupported; reranking disabled\n", cfg.RerankProvider)
+			writef(a.stderr, "warning: rerank.enabled is set but no rerank provider resolved (%v); reranking disabled\n", err)
 		}
 		return
 	}
-	if strings.TrimSpace(cfg.CohereAPIKey) == "" {
-		// Only warn when the operator explicitly asked for reranking;
-		// auto mode stays silent (no credential simply means off).
+	rk, err := providerfactory.Reranker(rp)
+	if err != nil {
 		if asked {
-			writef(a.stderr, "warning: rerank.enabled is set but COHERE_API_KEY is not present; reranking disabled\n")
+			writef(a.stderr, "warning: rerank provider %q unusable (%v); reranking disabled\n", rp.Name, err)
 		}
 		return
 	}
-	ret.SetReranker(cohere.NewClient(cfg.CohereBaseURL, cfg.CohereAPIKey), cfg.RerankModel, cfg.RerankCandidatePool)
+	ret.SetReranker(rk, rp.RerankModel, cfg.RerankCandidatePool)
 	ret.SetRerankEnabled(true)
 }
 
@@ -647,11 +668,8 @@ func (a *App) buildRetrieverForAsk(ctx context.Context, cfg config.Config, st mo
 		return nil, nil, fmt.Errorf("load code index: %w", err)
 	}
 
-	client := mistral.NewClient(cfg.MistralBaseURL, cfg.MistralAPIKey)
-	if cfg.MistralMaxOCRPayloadBytes > 0 {
-		client.MaxOCRPayloadBytes = cfg.MistralMaxOCRPayloadBytes
-	}
-	ret := retrieval.NewService(st, textIx, client, client)
+	embedder, generator := a.resolveModelClients(cfg)
+	ret := retrieval.NewService(st, textIx, embedder, generator)
 	ret.SetCodeIndex(codeIx)
 	ret.SetRootDir(cfg.RootDir)
 	ret.SetStateDir(cfg.StateDir)

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -52,8 +52,10 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 	defer func() { _ = textIx.Close() }()
 	defer func() { _ = codeIx.Close() }()
 
-	embedder, generator := a.resolveModelClients(cfg)
+	embedder, generator, etm, ecm := a.resolveModelClients(cfg)
 	ret := retrieval.NewService(st, textIx, embedder, generator)
+	ret.SetQueryEmbeddingModel(etm)
+	ret.SetCodeEmbeddingModel(ecm)
 	ret.SetCodeIndex(codeIx)
 	ret.SetRootDir(cfg.RootDir)
 	ret.SetStateDir(cfg.StateDir)
@@ -113,7 +115,7 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 	defer a.stopPersistenceWithLog(persistence)
 
 	embedErrCh := make(chan error, 4)
-	startEmbeddingIfNotReadOnly(runCtx, opts.readOnly, st, textIx, codeIx, embedder, ret, indexingState, embedErrCh, a.stderr, opts.jsonOutput, cfg.EmbedModelText, cfg.EmbedModelCode)
+	startEmbeddingIfNotReadOnly(runCtx, opts.readOnly, st, textIx, codeIx, embedder, ret, indexingState, embedErrCh, a.stderr, opts.jsonOutput, etm, ecm)
 
 	mcpAddr := ln.Addr().String()
 	if cfg.Public {
@@ -380,11 +382,33 @@ func (a *App) checkMistralAPIKey(cfg *config.Config, opts upOptions, nonInteract
 	if !requiresMistralAPIKey(*cfg, opts) {
 		return exitSuccess
 	}
-	if _, err := cfg.Providers().Resolve(provider.CapEmbed); err == nil {
+	// Legacy fast-path: a Mistral key satisfies embed AND the legacy
+	// Mistral-backed OCR/STT paths — unchanged behavior during the
+	// transition (those ingest paths flip in C2-iii-a2 / #39).
+	if strings.TrimSpace(cfg.MistralAPIKey) != "" {
 		return exitSuccess
 	}
-	const msg = "CONFIG_INVALID: no embedding provider configured"
-	const hint = "Set a provider credential (e.g. MISTRAL_API_KEY / OPENAI_API_KEY) or configure providers: in .dir2mcp.yaml"
+	// Keyless start is allowed only when an embed provider resolves
+	// elsewhere AND no legacy Mistral-only ingest path is still active.
+	_, embErr := cfg.Providers().Resolve(provider.CapEmbed)
+	legacyIngest := legacyIngestRequiresMistral(*cfg)
+	if embErr == nil && !legacyIngest {
+		return exitSuccess
+	}
+
+	msg := "CONFIG_INVALID: no embedding provider configured"
+	hint := "Set a provider credential (e.g. MISTRAL_API_KEY / OPENAI_API_KEY) or configure providers: in .dir2mcp.yaml"
+	var ce *provider.ConfigError
+	switch {
+	case errors.As(embErr, &ce):
+		// Surface the actionable reason (bad explicit binding /
+		// incapable kind) instead of the generic message (ce.Error()
+		// is already CONFIG_INVALID-prefixed).
+		msg = ce.Error()
+	case embErr == nil && legacyIngest:
+		msg = "CONFIG_INVALID: OCR/STT still requires MISTRAL_API_KEY (legacy path)"
+		hint = "Set MISTRAL_API_KEY, or disable the Mistral STT/extractor ingest paths"
+	}
 	if opts.jsonOutput {
 		writeCLIError(a.stderr, true, exitConfigInvalid, msg, hint, "Or run: dir2mcp config init")
 		return exitConfigInvalid
@@ -395,20 +419,27 @@ func (a *App) checkMistralAPIKey(cfg *config.Config, opts upOptions, nonInteract
 		writeln(a.stderr, hint)
 		writeln(a.stderr, "Or run: dir2mcp config init")
 	} else {
-		writef(a.stderr, "%s no embedding provider configured\n", se.errPrefix())
+		writef(a.stderr, "%s %s\n", se.errPrefix(), strings.TrimPrefix(msg, "CONFIG_INVALID: "))
 		writeln(a.stderr, "Run: dir2mcp config init")
 	}
 	return exitConfigInvalid
 }
 
 func requiresMistralAPIKey(cfg config.Config, opts upOptions) bool {
-	// Embedding workers require Mistral credentials unless running read-only.
+	// Embedding workers require a model provider unless running read-only.
 	if !opts.readOnly {
 		return true
 	}
+	// In read-only mode, only the still-legacy Mistral-backed ingest
+	// paths require it.
+	return legacyIngestRequiresMistral(cfg)
+}
 
-	// In read-only mode, require a key only when an enabled ingest path still
-	// depends on Mistral providers.
+// legacyIngestRequiresMistral reports whether an enabled ingest path is
+// still on the legacy Mistral-backed OCR/STT code (not yet flipped to
+// the resolver — that is C2-iii-a2 / #39). While true, a Mistral key is
+// still required regardless of which embed provider resolves.
+func legacyIngestRequiresMistral(cfg config.Config) bool {
 	if strings.EqualFold(strings.TrimSpace(cfg.STTProvider), "mistral") {
 		return true
 	}

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -21,9 +21,9 @@ import (
 	"github.com/dirstral/dir2mcp/internal/index"
 	"github.com/dirstral/dir2mcp/internal/ingest"
 	"github.com/dirstral/dir2mcp/internal/mcp"
-	"github.com/dirstral/dir2mcp/internal/mistral"
 	"github.com/dirstral/dir2mcp/internal/model"
 	"github.com/dirstral/dir2mcp/internal/protocol"
+	"github.com/dirstral/dir2mcp/internal/provider"
 	"github.com/dirstral/dir2mcp/internal/retrieval"
 )
 
@@ -52,14 +52,8 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 	defer func() { _ = textIx.Close() }()
 	defer func() { _ = codeIx.Close() }()
 
-	client := mistral.NewClient(cfg.MistralBaseURL, cfg.MistralAPIKey)
-	if cfg.MistralMaxOCRPayloadBytes > 0 {
-		client.MaxOCRPayloadBytes = cfg.MistralMaxOCRPayloadBytes
-	}
-	if strings.TrimSpace(cfg.ChatModel) != "" {
-		client.DefaultChatModel = strings.TrimSpace(cfg.ChatModel)
-	}
-	ret := retrieval.NewService(st, textIx, client, client)
+	embedder, generator := a.resolveModelClients(cfg)
+	ret := retrieval.NewService(st, textIx, embedder, generator)
 	ret.SetCodeIndex(codeIx)
 	ret.SetRootDir(cfg.RootDir)
 	ret.SetStateDir(cfg.StateDir)
@@ -119,7 +113,7 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 	defer a.stopPersistenceWithLog(persistence)
 
 	embedErrCh := make(chan error, 4)
-	startEmbeddingIfNotReadOnly(runCtx, opts.readOnly, st, textIx, codeIx, client, ret, indexingState, embedErrCh, a.stderr, opts.jsonOutput, cfg.EmbedModelText, cfg.EmbedModelCode)
+	startEmbeddingIfNotReadOnly(runCtx, opts.readOnly, st, textIx, codeIx, embedder, ret, indexingState, embedErrCh, a.stderr, opts.jsonOutput, cfg.EmbedModelText, cfg.EmbedModelCode)
 
 	mcpAddr := ln.Addr().String()
 	if cfg.Public {
@@ -375,31 +369,33 @@ func (a *App) applyPublicMode(cfg *config.Config, opts upOptions) int {
 }
 
 // checkMistralAPIKey reports a user-friendly error when the API key is missing.
+// checkMistralAPIKey is the §2.5 startup preflight for the embedding
+// provider. Generalized (SPEC 8.1.3): instead of demanding
+// MISTRAL_API_KEY specifically, it requires that an embed provider
+// *resolves* (a credentialed or credential-less profile that can serve
+// embed). Mistral via MISTRAL_API_KEY remains the default that
+// satisfies it. (Name kept until the C2-iii-b clean break to avoid
+// caller churn.)
 func (a *App) checkMistralAPIKey(cfg *config.Config, opts upOptions, nonInteractiveMode bool) int {
-	if strings.TrimSpace(cfg.MistralAPIKey) != "" {
-		return exitSuccess
-	}
 	if !requiresMistralAPIKey(*cfg, opts) {
 		return exitSuccess
 	}
+	if _, err := cfg.Providers().Resolve(provider.CapEmbed); err == nil {
+		return exitSuccess
+	}
+	const msg = "CONFIG_INVALID: no embedding provider configured"
+	const hint = "Set a provider credential (e.g. MISTRAL_API_KEY / OPENAI_API_KEY) or configure providers: in .dir2mcp.yaml"
 	if opts.jsonOutput {
-		writeCLIError(
-			a.stderr,
-			true,
-			exitConfigInvalid,
-			"CONFIG_INVALID: Missing MISTRAL_API_KEY",
-			"Set env: MISTRAL_API_KEY=...",
-			"Or run: dir2mcp config init",
-		)
+		writeCLIError(a.stderr, true, exitConfigInvalid, msg, hint, "Or run: dir2mcp config init")
 		return exitConfigInvalid
 	}
 	se := a.sty(opts.jsonOutput)
 	if nonInteractiveMode {
-		writef(a.stderr, "%s CONFIG_INVALID: Missing MISTRAL_API_KEY\n", se.errPrefix())
-		writeln(a.stderr, "Set env: MISTRAL_API_KEY=...")
+		writef(a.stderr, "%s %s\n", se.errPrefix(), msg)
+		writeln(a.stderr, hint)
 		writeln(a.stderr, "Or run: dir2mcp config init")
 	} else {
-		writef(a.stderr, "%s Missing MISTRAL_API_KEY\n", se.errPrefix())
+		writef(a.stderr, "%s no embedding provider configured\n", se.errPrefix())
 		writeln(a.stderr, "Run: dir2mcp config init")
 	}
 	return exitConfigInvalid
@@ -751,7 +747,7 @@ func (a *App) stopPersistenceWithLog(persistence *index.PersistenceManager) {
 
 // startEmbeddingIfNotReadOnly starts embedding workers when readOnly is false
 // and the store exposes the ChunkSource interface.
-func startEmbeddingIfNotReadOnly(ctx context.Context, readOnly bool, st model.Store, textIx, codeIx model.Index, client *mistral.Client, ret *retrieval.Service, indexingState *appstate.IndexingState, embedErrCh chan error, stderr io.Writer, jsonOutput bool, embedModelText, embedModelCode string) {
+func startEmbeddingIfNotReadOnly(ctx context.Context, readOnly bool, st model.Store, textIx, codeIx model.Index, embedder model.Embedder, ret *retrieval.Service, indexingState *appstate.IndexingState, embedErrCh chan error, stderr io.Writer, jsonOutput bool, embedModelText, embedModelCode string) {
 	if readOnly {
 		return
 	}
@@ -760,7 +756,7 @@ func startEmbeddingIfNotReadOnly(ctx context.Context, readOnly bool, st model.St
 		return
 	}
 	embedLogger := pickEmbedLogger(stderr, jsonOutput)
-	startEmbeddingWorkers(ctx, chunkSource, textIx, codeIx, client, ret, indexingState, embedErrCh, embedLogger, embedModelText, embedModelCode)
+	startEmbeddingWorkers(ctx, chunkSource, textIx, codeIx, embedder, ret, indexingState, embedErrCh, embedLogger, embedModelText, embedModelCode)
 }
 
 // printHumanConnectionIfVerbose prints the human-readable connection block

--- a/internal/config/providers.go
+++ b/internal/config/providers.go
@@ -69,9 +69,14 @@ func builtinProfiles() map[string]providerProfileYAML {
 // builtinPrecedence is the deterministic auto-selection order (SPEC
 // 8.1.3): Mistral first (historical default), then the rest. User-only
 // profiles are appended in declared order after these.
+// `local` is intentionally excluded: it is credential-less and would
+// otherwise silently win auto-selection when no real credential is
+// set, masking a missing-credential misconfig (and pointing at a
+// localhost endpoint that is usually not running). It remains fully
+// usable via an explicit `model.<cap>.provider: local` binding.
 var builtinPrecedence = []string{
 	"mistral", "mistral-ocr", "openai", "gemini", "cohere",
-	"anthropic", "elevenlabs", "openrouter", "local",
+	"anthropic", "elevenlabs", "openrouter",
 }
 
 // extractProvidersSubtree returns only the top-level `providers:` and

--- a/tests/config/providers_config_test.go
+++ b/tests/config/providers_config_test.go
@@ -42,12 +42,18 @@ func TestProviders_BuiltinAutoSelectByCredential(t *testing.T) {
 }
 
 func TestProviders_NoCredentialEmbedFails(t *testing.T) {
-	// no provider creds at all; local (credential-less) is openai-kind
-	// so it CAN serve embed -> auto-selects local. Assert that.
+	// No creds and no explicit binding: auto-select must NOT silently
+	// fall through to the credential-less `local` (it's excluded from
+	// auto precedence) — embed must fail so preflight surfaces it.
 	cfg := loadCfg(t, "version: 1\n")
-	p, err := cfg.Providers().Resolve(provider.CapEmbed)
+	if _, err := cfg.Providers().Resolve(provider.CapEmbed); err == nil {
+		t.Fatal("embed must not resolve with no credentials and no explicit binding")
+	}
+	// But an explicit `local` binding works (credential-less, eligible).
+	exp := loadCfg(t, "model:\n  embed:\n    provider: local\n")
+	p, err := exp.Providers().Resolve(provider.CapEmbed)
 	if err != nil || p.Name != "local" {
-		t.Fatalf("expected credential-less 'local' for embed, got %+v %v", p, err)
+		t.Fatalf("explicit local embed should resolve, got %+v %v", p, err)
 	}
 }
 

--- a/tests/config/providers_config_test.go
+++ b/tests/config/providers_config_test.go
@@ -42,6 +42,14 @@ func TestProviders_BuiltinAutoSelectByCredential(t *testing.T) {
 }
 
 func TestProviders_NoCredentialEmbedFails(t *testing.T) {
+	// Deterministic: blank any embed-capable provider key the host/CI
+	// may already export (Resolve reads process env via cfg.Providers).
+	for _, k := range []string{
+		"MISTRAL_API_KEY", "OPENAI_API_KEY", "OPENROUTER_API_KEY",
+		"GEMINI_API_KEY", "COHERE_API_KEY", "ANTHROPIC_API_KEY", "ELEVENLABS_API_KEY",
+	} {
+		t.Setenv(k, "")
+	}
 	// No creds and no explicit binding: auto-select must NOT silently
 	// fall through to the credential-less `local` (it's excluded from
 	// auto precedence) — embed must fail so preflight surfaces it.


### PR DESCRIPTION
**PR C2-iii-a** — the functional flip of the multi-provider keystone (Design 0001 / SPEC §8.1). Builds on the resolver (#195), factory (#196), config schema (#197).

### What flips
- `resolveModelClients` builds embed + chat via `cfg.Providers()` + `providerfactory`. **Best-effort by design**: an unresolved client is `nil` so a read-only server still boots (embedder may never be exercised); a nil embedder later surfaces `ErrMissingEmbedder` at query time — matching the previous keyless-client leniency.
- `up` and `ask` retrieval construction + `configureReranker` now resolve through `Resolve(CapEmbed/CapChat/CapRerank)`. **Mistral chat/embed re-expression**: they flow through the OpenAI backbone via the built-in `mistral` profile; the bespoke `internal/mistral` is no longer constructed for chat/embed in the retrieval path.
- **§2.5 preflight generalized**: `checkMistralAPIKey` now requires an embed provider to *resolve* (any credentialed/connector profile) rather than `MISTRAL_API_KEY` specifically — generic `CONFIG_INVALID` + hint. The `requiresMistralAPIKey` read-only/ingest gating is preserved.
- Credential-less `local` removed from **auto** precedence (kept for explicit `model.*.provider: local`) so a missing credential yields a clean preflight failure instead of silently dialing localhost.

### Scope / safety
Legacy flat fields are **retained** (the `seedLegacy` bridge from #197) so build + behavior are preserved — Mistral via `MISTRAL_API_KEY` remains the working default. **Remaining C2-iii increments** (separate PRs): ingest OCR/STT + TTS flip, snapshot embed-identity (§8.1.4), then the clean-break removal of the legacy fields. `make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Provider selection mechanism now uses capability-driven resolution instead of hard-coded clients.
  * Local provider no longer auto-selects when credentials are unavailable.
  * Improved error messaging for missing API credentials and reranking configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dirstral/dir2mcp/pull/198?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->