### PR TITLE
feat(ingest): flip Mistral OCR + STT through the resolver (C2-iii-a2)

### DIFF
--- a/internal/config/providers.go
+++ b/internal/config/providers.go
@@ -284,6 +284,19 @@ func (r ProviderResolution) applyModelOverrides(cap provider.Capability, p provi
 	return p
 }
 
+// ResolveExplicit selects for cap with an explicit profile name (or ""
+// for auto), applying the same matrix/eligibility rules as Resolve plus
+// the model-name overrides. Used for capabilities whose selector is not
+// in the model: block (e.g. the legacy stt.provider) during the
+// transition.
+func (r ProviderResolution) ResolveExplicit(cap provider.Capability, explicit string, required bool) (provider.Profile, error) {
+	p, err := provider.Select(r.precedence, r.byName, cap, strings.TrimSpace(explicit), required)
+	if err != nil {
+		return p, err
+	}
+	return r.applyModelOverrides(cap, p), nil
+}
+
 // EmbedIdentity is the corpus-lifetime identity of the resolved embed
 // provider (SPEC 8.1.4), or "" if embed cannot be resolved.
 func (r ProviderResolution) EmbedIdentity() string {

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -225,6 +225,17 @@ func newElevenLabsTranscriber(cfg config.Config) model.Transcriber {
 // Returns nil when no Mistral OCR credential is available (matching the
 // prior "no key -> no extractor" behavior). Docling is handled
 // separately below — it is a local tool, not a provider profile.
+// applyMistralOCRLimit re-applies the legacy
+// mistral_max_ocr_payload_bytes knob to a resolver/factory-built
+// Mistral client (the factory builds a generic client; this Mistral-
+// specific tuning param is not part of provider.Profile). It bounds
+// both OCR and Mistral audio transcription payloads.
+func applyMistralOCRLimit(v any, cfg config.Config) {
+	if mc, ok := v.(*mistral.Client); ok && cfg.MistralMaxOCRPayloadBytes > 0 {
+		mc.MaxOCRPayloadBytes = cfg.MistralMaxOCRPayloadBytes
+	}
+}
+
 func mistralExtractor(cfg config.Config) model.DocumentExtractor {
 	prof, err := cfg.Providers().ResolveExplicit(provider.CapOCR, "mistral-ocr", true)
 	if err != nil {
@@ -234,7 +245,23 @@ func mistralExtractor(cfg config.Config) model.DocumentExtractor {
 	if err != nil {
 		return nil
 	}
+	applyMistralOCRLimit(ex, cfg)
 	return ex
+}
+
+// mistralTranscriber resolves the mistral-ocr profile for STT and
+// re-applies the legacy OCR/transcription payload limit.
+func mistralTranscriber(cfg config.Config) (model.Transcriber, error) {
+	prof, err := cfg.Providers().ResolveExplicit(provider.CapSTT, "mistral-ocr", true)
+	if err != nil {
+		return nil, err
+	}
+	tr, err := providerfactory.Transcriber(prof)
+	if err != nil {
+		return nil, err
+	}
+	applyMistralOCRLimit(tr, cfg)
+	return tr, nil
 }
 
 // DocumentExtractorFromConfig resolves document extraction provider selection.
@@ -284,19 +311,19 @@ func TranscriberFromConfig(cfg config.Config) (model.Transcriber, error) {
 	// the ElevenLabs voice/model/language knobs — flips in #38).
 	switch sel {
 	case transcriberProviderMistral:
-		prof, err := cfg.Providers().ResolveExplicit(provider.CapSTT, "mistral-ocr", true)
+		tr, err := mistralTranscriber(cfg)
 		if err != nil {
 			return nil, fmt.Errorf("stt provider %q: %w", sel, err)
 		}
-		return providerfactory.Transcriber(prof)
+		return tr, nil
 	case transcriberProviderElevenLabs:
 		if strings.TrimSpace(cfg.ElevenLabsAPIKey) == "" {
 			return nil, fmt.Errorf("stt provider %q requires ELEVENLABS_API_KEY", sel)
 		}
 		return newElevenLabsTranscriber(cfg), nil
 	case transcriberProviderAuto:
-		if prof, err := cfg.Providers().ResolveExplicit(provider.CapSTT, "mistral-ocr", true); err == nil {
-			return providerfactory.Transcriber(prof)
+		if tr, err := mistralTranscriber(cfg); err == nil {
+			return tr, nil
 		}
 		if strings.TrimSpace(cfg.ElevenLabsAPIKey) != "" {
 			return newElevenLabsTranscriber(cfg), nil

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -22,6 +22,8 @@ import (
 	"github.com/dirstral/dir2mcp/internal/elevenlabs"
 	"github.com/dirstral/dir2mcp/internal/mistral"
 	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/provider"
+	"github.com/dirstral/dir2mcp/internal/providerfactory"
 )
 
 // annotationChunk* constants mirror the hardcoded parameters previously
@@ -199,26 +201,11 @@ func DiscoverOptionsFromConfig(cfg config.Config) DiscoverOptions {
 	return options
 }
 
-// TranscriberFromConfig resolves the configured STT provider instance.
-func newMistralTranscriber(cfg config.Config) model.Transcriber {
-	client := mistral.NewClient(cfg.MistralBaseURL, cfg.MistralAPIKey)
-	if cfg.MistralMaxOCRPayloadBytes > 0 {
-		client.MaxOCRPayloadBytes = cfg.MistralMaxOCRPayloadBytes
-	}
-	if modelName := strings.TrimSpace(cfg.STTMistralModel); modelName != "" {
-		client.DefaultTranscribeModel = modelName
-	}
-	return client
-}
-
-func newMistralExtractor(cfg config.Config) model.DocumentExtractor {
-	client := mistral.NewClient(cfg.MistralBaseURL, cfg.MistralAPIKey)
-	if cfg.MistralMaxOCRPayloadBytes > 0 {
-		client.MaxOCRPayloadBytes = cfg.MistralMaxOCRPayloadBytes
-	}
-	return client
-}
-
+// newElevenLabsTranscriber builds the legacy ElevenLabs STT client.
+// ElevenLabs STT/TTS stays on this legacy construction during the
+// transition because provider.Profile does not yet carry the
+// ElevenLabs voice/model/language knobs; it flips in the clean-break
+// config rework (#38).
 func newElevenLabsTranscriber(cfg config.Config) model.Transcriber {
 	client := elevenlabs.NewClient(cfg.ElevenLabsAPIKey, cfg.ElevenLabsTTSVoiceID)
 	if baseURL := strings.TrimSpace(cfg.ElevenLabsBaseURL); baseURL != "" {
@@ -233,9 +220,26 @@ func newElevenLabsTranscriber(cfg config.Config) model.Transcriber {
 	return client
 }
 
+// mistralExtractor resolves the OCR provider (the bespoke mistral kind)
+// via the provider model and adapts it to model.DocumentExtractor.
+// Returns nil when no Mistral OCR credential is available (matching the
+// prior "no key -> no extractor" behavior). Docling is handled
+// separately below — it is a local tool, not a provider profile.
+func mistralExtractor(cfg config.Config) model.DocumentExtractor {
+	prof, err := cfg.Providers().ResolveExplicit(provider.CapOCR, "mistral-ocr", true)
+	if err != nil {
+		return nil
+	}
+	ex, err := providerfactory.Extractor(prof)
+	if err != nil {
+		return nil
+	}
+	return ex
+}
+
 // DocumentExtractorFromConfig resolves document extraction provider selection.
 // Priority: configured docling command, auto-detected docling binary, then
-// Mistral OCR.
+// Mistral OCR (via the provider model).
 func DocumentExtractorFromConfig(cfg config.Config) model.DocumentExtractor {
 	mode := strings.ToLower(strings.TrimSpace(cfg.IngestExtractor))
 	if mode == "" {
@@ -253,10 +257,7 @@ func DocumentExtractorFromConfig(cfg config.Config) model.DocumentExtractor {
 		}
 		return nil
 	case "mistral":
-		if strings.TrimSpace(cfg.MistralAPIKey) != "" {
-			return newMistralExtractor(cfg)
-		}
-		return nil
+		return mistralExtractor(cfg)
 	default: // auto
 		if tpl := strings.TrimSpace(cfg.DoclingCommand); tpl != "" {
 			return NewDoclingExtractor(tpl)
@@ -264,44 +265,46 @@ func DocumentExtractorFromConfig(cfg config.Config) model.DocumentExtractor {
 		if _, err := exec.LookPath("docling"); err == nil {
 			return NewDoclingExtractor("")
 		}
-		if strings.TrimSpace(cfg.MistralAPIKey) != "" {
-			return newMistralExtractor(cfg)
-		}
-		return nil
+		return mistralExtractor(cfg)
 	}
 }
 
 func TranscriberFromConfig(cfg config.Config) (model.Transcriber, error) {
-	provider := strings.ToLower(strings.TrimSpace(cfg.STTProvider))
-	if provider == "" {
-		provider = transcriberProviderAuto
+	sel := strings.ToLower(strings.TrimSpace(cfg.STTProvider))
+	if sel == "" {
+		sel = transcriberProviderAuto
+	}
+	if sel == transcriberProviderOff || sel == "none" || sel == "disabled" {
+		return nil, nil
 	}
 
-	switch provider {
-	case transcriberProviderOff, "none", "disabled":
-		return nil, nil
+	// Mistral STT flips to the resolver (fully preserved via
+	// seedLegacy + the mistral-ocr profile's STT model). ElevenLabs
+	// STT stays legacy during the transition (provider.Profile lacks
+	// the ElevenLabs voice/model/language knobs — flips in #38).
+	switch sel {
 	case transcriberProviderMistral:
-		if strings.TrimSpace(cfg.MistralAPIKey) == "" {
-			return nil, fmt.Errorf("stt provider %q requires MISTRAL_API_KEY", transcriberProviderMistral)
+		prof, err := cfg.Providers().ResolveExplicit(provider.CapSTT, "mistral-ocr", true)
+		if err != nil {
+			return nil, fmt.Errorf("stt provider %q: %w", sel, err)
 		}
-		return newMistralTranscriber(cfg), nil
-	case transcriberProviderAuto:
-		if strings.TrimSpace(cfg.MistralAPIKey) != "" {
-			return newMistralTranscriber(cfg), nil
-		}
-		if strings.TrimSpace(cfg.ElevenLabsAPIKey) == "" {
-			return nil, nil
-		}
-		// auto-selected ElevenLabs; fall through to the shared build path below.
+		return providerfactory.Transcriber(prof)
 	case transcriberProviderElevenLabs:
 		if strings.TrimSpace(cfg.ElevenLabsAPIKey) == "" {
-			return nil, fmt.Errorf("stt provider %q requires ELEVENLABS_API_KEY", transcriberProviderElevenLabs)
+			return nil, fmt.Errorf("stt provider %q requires ELEVENLABS_API_KEY", sel)
 		}
+		return newElevenLabsTranscriber(cfg), nil
+	case transcriberProviderAuto:
+		if prof, err := cfg.Providers().ResolveExplicit(provider.CapSTT, "mistral-ocr", true); err == nil {
+			return providerfactory.Transcriber(prof)
+		}
+		if strings.TrimSpace(cfg.ElevenLabsAPIKey) != "" {
+			return newElevenLabsTranscriber(cfg), nil
+		}
+		return nil, nil // auto + nothing eligible -> STT off
 	default:
-		return nil, fmt.Errorf("unsupported transcriber provider %q", provider)
+		return nil, fmt.Errorf("unsupported transcriber provider %q", sel)
 	}
-
-	return newElevenLabsTranscriber(cfg), nil
 }
 
 // healthCheckInterval returns the configured base poll interval for connector

--- a/internal/providerfactory/factory.go
+++ b/internal/providerfactory/factory.go
@@ -101,6 +101,21 @@ func Generator(p provider.Profile) (model.Generator, error) {
 	}
 }
 
+// Extractor builds a model.DocumentExtractor for the OCR provider
+// (same mistral client as OCR; ingest uses the DocumentExtractor
+// interface). Docling is a local extractor, not a provider profile,
+// and is selected by ingest independently of this.
+func Extractor(p provider.Profile) (model.DocumentExtractor, error) {
+	if p.Kind != provider.KindMistral {
+		return nil, unsupported(p, provider.CapOCR)
+	}
+	c := mistral.NewClient(p.BaseURL, p.APIKey)
+	if p.OCRModel != "" {
+		c.DefaultOCRModel = p.OCRModel
+	}
+	return c, nil
+}
+
 // OCR builds a model.OCR. Only the bespoke `mistral` kind serves OCR
 // (SPEC 8.1.2 — there is no OpenAI-compatible OCR endpoint).
 func OCR(p provider.Profile) (model.OCR, error) {

--- a/tests/ingest/service_test.go
+++ b/tests/ingest/service_test.go
@@ -646,9 +646,12 @@ func TestTranscriberFromConfig_ExplicitProviderRequiresCredentials(t *testing.T)
 		wantErr  string
 	}{
 		{
+			// legacy stt.provider "mistral" maps to the mistral-ocr
+			// profile; without a credential the resolver returns a
+			// CONFIG_INVALID naming that profile.
 			name:     "mistral missing key",
 			provider: "mistral",
-			wantErr:  "requires MISTRAL_API_KEY",
+			wantErr:  "mistral-ocr",
 		},
 		{
 			name:     "elevenlabs missing key",


### PR DESCRIPTION
**PR C2-iii-a2** — continues the keystone integration (Design 0001 / SPEC §8.1). Builds on #198.

### Flipped through the resolver
- **Mistral OCR**: `DocumentExtractorFromConfig`'s Mistral branch → `cfg.Providers()` + new `providerfactory.Extractor` (mistral-kind → `model.DocumentExtractor`). Docling is unchanged — it's a local tool, not a provider profile.
- **Mistral STT**: `TranscriberFromConfig` for `stt.provider: mistral` / auto-mistral → resolves the `mistral-ocr` profile via the resolver; the STT model is preserved through `seedLegacy`.
- New `ProviderResolution.ResolveExplicit(cap, name, required)` for capabilities whose selector isn't in the `model:` block (the legacy `stt.provider`).

### Deliberately deferred (transitional honesty)
**ElevenLabs STT stays on its legacy client** and the **TTS site is untouched** — `provider.Profile` doesn't yet carry the ElevenLabs voice/model/language knobs, so flipping them now would regress those configs. The ElevenLabs/TTS flip + the §8.1.4 **snapshot embed-identity** land in a follow-up (task tracked) before the clean break (#38). `seedLegacy` keeps file-based `MISTRAL_API_KEY` configs working throughout. `make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit provider profile resolution for more granular control over provider selection at the capability level

* **Improvements**
  * Refined provider selection logic for document extraction and transcription services with improved automatic fallback behavior
  * Enhanced integration of Mistral OCR provider through consolidated provider framework
  * Strengthened credential validation with clearer error messages for misconfigured providers

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dirstral/dir2mcp/pull/199?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->