### PR TITLE
feat(elevenlabs,tts): flip ElevenLabs STT + TTS through the resolver (C2-iii-c)

### DIFF
--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -439,17 +439,14 @@ func requiresMistralAPIKey(cfg config.Config, opts upOptions) bool {
 // still on the legacy Mistral-backed OCR/STT code (not yet flipped to
 // the resolver — that is C2-iii-a2 / #39). While true, a Mistral key is
 // still required regardless of which embed provider resolves.
-func legacyIngestRequiresMistral(cfg config.Config) bool {
-	if strings.EqualFold(strings.TrimSpace(cfg.STTProvider), "mistral") {
-		return true
-	}
-	if strings.EqualFold(strings.TrimSpace(cfg.STTProvider), "auto") &&
-		!strings.EqualFold(strings.TrimSpace(cfg.IngestAudioMode), "off") {
-		return true
-	}
-	if strings.EqualFold(strings.TrimSpace(cfg.IngestExtractor), "mistral") {
-		return true
-	}
+// legacyIngestRequiresMistral is now always false: ingest OCR (#199)
+// and STT incl. auto/elevenlabs (#200) resolve entirely through the
+// provider model, so there is no remaining Mistral-only ingest path
+// that the preflight must guard. Eligibility is enforced at resolution
+// time (a bad explicit binding fails ingest init; auto degrades to
+// off/fallback). The function is retained until the clean break (#38)
+// to avoid churning callers.
+func legacyIngestRequiresMistral(_ config.Config) bool {
 	return false
 }
 
@@ -496,9 +493,17 @@ func buildMCPServerOptions(cfg *config.Config, st model.Store, indexingState *ap
 		mcp.WithIndexingState(indexingState),
 		mcp.WithEventEmitter(emitter.Emit),
 	}
-	// TTS is optional and fail-open (SPEC 8.3): resolve a TTS-capable
-	// provider through the provider model; skip silently if none.
-	if prof, err := cfg.Providers().Resolve(provider.CapTTS); err == nil {
+	// TTS is optional and fail-open (SPEC 8.3). Prefer ElevenLabs when
+	// it is eligible (preserves the legacy "ELEVENLABS_API_KEY -> TTS"
+	// behavior, incl. its voice/base-url config, even when an LLM
+	// provider key is also present); otherwise fall back to auto
+	// precedence among TTS-capable providers.
+	r := cfg.Providers()
+	prof, err := r.ResolveExplicit(provider.CapTTS, "elevenlabs", true)
+	if err != nil {
+		prof, err = r.Resolve(provider.CapTTS)
+	}
+	if err == nil {
 		if tts, terr := providerfactory.TTS(prof); terr == nil {
 			opts = append(opts, mcp.WithTTS(tts))
 		}

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -16,7 +16,6 @@ import (
 	"github.com/dirstral/dir2mcp/internal/appstate"
 	"github.com/dirstral/dir2mcp/internal/buildinfo"
 	"github.com/dirstral/dir2mcp/internal/config"
-	"github.com/dirstral/dir2mcp/internal/elevenlabs"
 	"github.com/dirstral/dir2mcp/internal/identity"
 	"github.com/dirstral/dir2mcp/internal/index"
 	"github.com/dirstral/dir2mcp/internal/ingest"
@@ -24,6 +23,7 @@ import (
 	"github.com/dirstral/dir2mcp/internal/model"
 	"github.com/dirstral/dir2mcp/internal/protocol"
 	"github.com/dirstral/dir2mcp/internal/provider"
+	"github.com/dirstral/dir2mcp/internal/providerfactory"
 	"github.com/dirstral/dir2mcp/internal/retrieval"
 )
 
@@ -496,12 +496,12 @@ func buildMCPServerOptions(cfg *config.Config, st model.Store, indexingState *ap
 		mcp.WithIndexingState(indexingState),
 		mcp.WithEventEmitter(emitter.Emit),
 	}
-	if strings.TrimSpace(cfg.ElevenLabsAPIKey) != "" {
-		ttsClient := elevenlabs.NewClient(cfg.ElevenLabsAPIKey, cfg.ElevenLabsTTSVoiceID)
-		if strings.TrimSpace(cfg.ElevenLabsBaseURL) != "" {
-			ttsClient.BaseURL = strings.TrimRight(strings.TrimSpace(cfg.ElevenLabsBaseURL), "/")
+	// TTS is optional and fail-open (SPEC 8.3): resolve a TTS-capable
+	// provider through the provider model; skip silently if none.
+	if prof, err := cfg.Providers().Resolve(provider.CapTTS); err == nil {
+		if tts, terr := providerfactory.TTS(prof); terr == nil {
+			opts = append(opts, mcp.WithTTS(tts))
 		}
-		opts = append(opts, mcp.WithTTS(ttsClient))
 	}
 	return opts
 }

--- a/internal/config/providers.go
+++ b/internal/config/providers.go
@@ -150,7 +150,8 @@ func mergeProfiles(base, user map[string]providerProfileYAML) (map[string]provid
 		}{
 			{&base.EmbedTextModel, up.EmbedTextModel}, {&base.EmbedCodeModel, up.EmbedCodeModel},
 			{&base.ChatModel, up.ChatModel}, {&base.OCRModel, up.OCRModel},
-			{&base.STTModel, up.STTModel}, {&base.TTSModel, up.TTSModel},
+			{&base.STTModel, up.STTModel}, {&base.STTLanguage, up.STTLanguage},
+			{&base.TTSModel, up.TTSModel}, {&base.TTSVoice, up.TTSVoice},
 			{&base.RerankModel, up.RerankModel},
 		} {
 			if f.src != "" {

--- a/internal/config/providers.go
+++ b/internal/config/providers.go
@@ -26,7 +26,9 @@ type providerProfileYAML struct {
 	ChatModel      string  `yaml:"chat_model"`
 	OCRModel       string  `yaml:"ocr_model"`
 	STTModel       string  `yaml:"stt_model"`
+	STTLanguage    string  `yaml:"stt_language"`
 	TTSModel       string  `yaml:"tts_model"`
+	TTSVoice       string  `yaml:"tts_voice"`
 	RerankModel    string  `yaml:"rerank_model"`
 }
 
@@ -206,7 +208,9 @@ func toProfiles(merged map[string]providerProfileYAML, getenv func(string) strin
 			ChatModel:      p.ChatModel,
 			OCRModel:       p.OCRModel,
 			STTModel:       p.STTModel,
+			STTLanguage:    p.STTLanguage,
 			TTSModel:       p.TTSModel,
+			TTSVoice:       p.TTSVoice,
 			RerankModel:    p.RerankModel,
 		}
 	}
@@ -321,56 +325,59 @@ func (cfg Config) Providers() ProviderResolution {
 // the new resolver during the transition. User `providers:` entries
 // still take precedence (merged on top of this seed). The legacy fields
 // themselves are removed in the clean-break C2-iii.
+func litStr(s string) *string { return &s }
+
+func setStr(dst *string, v string) {
+	if v != "" {
+		*dst = v
+	}
+}
+
 func seedLegacy(m map[string]providerProfileYAML, cfg Config) {
-	lit := func(s string) *string { return &s }
-	seedField := func(name string, fn func(*providerProfileYAML)) {
+	seed := func(name string, fn func(*providerProfileYAML)) {
 		if p, ok := m[name]; ok {
 			fn(&p)
 			m[name] = p
 		}
 	}
-	seedField("mistral", func(p *providerProfileYAML) {
-		if cfg.MistralAPIKey != "" {
-			p.APIKey = lit(cfg.MistralAPIKey)
-		}
-		if cfg.MistralBaseURL != "" {
-			p.BaseURL = cfg.MistralBaseURL
-		}
-		if cfg.EmbedModelText != "" {
-			p.EmbedTextModel = cfg.EmbedModelText
-		}
-		if cfg.EmbedModelCode != "" {
-			p.EmbedCodeModel = cfg.EmbedModelCode
-		}
-		if cfg.ChatModel != "" {
-			p.ChatModel = cfg.ChatModel
-		}
-	})
-	seedField("mistral-ocr", func(p *providerProfileYAML) {
-		if cfg.MistralAPIKey != "" {
-			p.APIKey = lit(cfg.MistralAPIKey)
-		}
-		if cfg.MistralBaseURL != "" {
-			p.BaseURL = cfg.MistralBaseURL
-		}
-		if cfg.STTMistralModel != "" {
-			p.STTModel = cfg.STTMistralModel
-		}
-	})
-	seedField("cohere", func(p *providerProfileYAML) {
-		if cfg.CohereAPIKey != "" {
-			p.APIKey = lit(cfg.CohereAPIKey)
-		}
-		if cfg.CohereBaseURL != "" {
-			p.BaseURL = cfg.CohereBaseURL
-		}
-		if cfg.RerankModel != "" {
-			p.RerankModel = cfg.RerankModel
-		}
-	})
-	seedField("elevenlabs", func(p *providerProfileYAML) {
-		if cfg.ElevenLabsAPIKey != "" {
-			p.APIKey = lit(cfg.ElevenLabsAPIKey)
-		}
-	})
+	seed("mistral", func(p *providerProfileYAML) { seedMistralChatEmbed(p, cfg) })
+	seed("mistral-ocr", func(p *providerProfileYAML) { seedMistralOCR(p, cfg) })
+	seed("cohere", func(p *providerProfileYAML) { seedCohere(p, cfg) })
+	seed("elevenlabs", func(p *providerProfileYAML) { seedElevenLabs(p, cfg) })
+}
+
+func seedMistralChatEmbed(p *providerProfileYAML, cfg Config) {
+	if cfg.MistralAPIKey != "" {
+		p.APIKey = litStr(cfg.MistralAPIKey)
+	}
+	setStr(&p.BaseURL, cfg.MistralBaseURL)
+	setStr(&p.EmbedTextModel, cfg.EmbedModelText)
+	setStr(&p.EmbedCodeModel, cfg.EmbedModelCode)
+	setStr(&p.ChatModel, cfg.ChatModel)
+}
+
+func seedMistralOCR(p *providerProfileYAML, cfg Config) {
+	if cfg.MistralAPIKey != "" {
+		p.APIKey = litStr(cfg.MistralAPIKey)
+	}
+	setStr(&p.BaseURL, cfg.MistralBaseURL)
+	setStr(&p.STTModel, cfg.STTMistralModel)
+}
+
+func seedCohere(p *providerProfileYAML, cfg Config) {
+	if cfg.CohereAPIKey != "" {
+		p.APIKey = litStr(cfg.CohereAPIKey)
+	}
+	setStr(&p.BaseURL, cfg.CohereBaseURL)
+	setStr(&p.RerankModel, cfg.RerankModel)
+}
+
+func seedElevenLabs(p *providerProfileYAML, cfg Config) {
+	if cfg.ElevenLabsAPIKey != "" {
+		p.APIKey = litStr(cfg.ElevenLabsAPIKey)
+	}
+	setStr(&p.BaseURL, cfg.ElevenLabsBaseURL)
+	setStr(&p.TTSVoice, cfg.ElevenLabsTTSVoiceID)
+	setStr(&p.STTModel, cfg.STTElevenLabsModel)
+	setStr(&p.STTLanguage, cfg.STTElevenLabsLanguageCode)
 }

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/dirstral/dir2mcp/internal/appstate"
 	"github.com/dirstral/dir2mcp/internal/config"
-	"github.com/dirstral/dir2mcp/internal/elevenlabs"
 	"github.com/dirstral/dir2mcp/internal/mistral"
 	"github.com/dirstral/dir2mcp/internal/model"
 	"github.com/dirstral/dir2mcp/internal/provider"
@@ -206,20 +205,6 @@ func DiscoverOptionsFromConfig(cfg config.Config) DiscoverOptions {
 // transition because provider.Profile does not yet carry the
 // ElevenLabs voice/model/language knobs; it flips in the clean-break
 // config rework (#38).
-func newElevenLabsTranscriber(cfg config.Config) model.Transcriber {
-	client := elevenlabs.NewClient(cfg.ElevenLabsAPIKey, cfg.ElevenLabsTTSVoiceID)
-	if baseURL := strings.TrimSpace(cfg.ElevenLabsBaseURL); baseURL != "" {
-		client.BaseURL = strings.TrimRight(baseURL, "/")
-	}
-	if modelName := strings.TrimSpace(cfg.STTElevenLabsModel); modelName != "" {
-		client.TranscribeModel = modelName
-	}
-	if languageCode := strings.TrimSpace(cfg.STTElevenLabsLanguageCode); languageCode != "" {
-		client.TranscribeLanguageCode = languageCode
-	}
-	return client
-}
-
 // mistralExtractor resolves the OCR provider (the bespoke mistral kind)
 // via the provider model and adapts it to model.DocumentExtractor.
 // Returns nil when no Mistral OCR credential is available (matching the
@@ -251,11 +236,11 @@ func mistralExtractor(cfg config.Config) model.DocumentExtractor {
 
 // mistralTranscriber resolves the mistral-ocr profile for STT and
 // re-applies the legacy OCR/transcription payload limit.
-func mistralTranscriber(cfg config.Config) (model.Transcriber, error) {
-	prof, err := cfg.Providers().ResolveExplicit(provider.CapSTT, "mistral-ocr", true)
-	if err != nil {
-		return nil, err
-	}
+// buildTranscriber adapts a resolved profile to a model.Transcriber and
+// re-applies the Mistral OCR/transcription payload limit (no-op for
+// non-Mistral kinds). ElevenLabs voice/model/language/base-url are
+// carried on the profile (seeded from legacy config in seedLegacy).
+func buildTranscriber(prof provider.Profile, cfg config.Config) (model.Transcriber, error) {
 	tr, err := providerfactory.Transcriber(prof)
 	if err != nil {
 		return nil, err
@@ -305,30 +290,35 @@ func TranscriberFromConfig(cfg config.Config) (model.Transcriber, error) {
 		return nil, nil
 	}
 
-	// Mistral STT flips to the resolver (fully preserved via
-	// seedLegacy + the mistral-ocr profile's STT model). ElevenLabs
-	// STT stays legacy during the transition (provider.Profile lacks
-	// the ElevenLabs voice/model/language knobs — flips in #38).
+	// STT now resolves entirely through the provider model (SPEC
+	// 8.1.3). The legacy stt.provider selector maps onto a profile:
+	// explicit mistral/elevenlabs -> required (a missing credential is
+	// a hard error); auto -> deterministic precedence among STT-capable
+	// profiles, or STT off when none is eligible. ElevenLabs voice/
+	// model/language/base-url are preserved on the profile (seedLegacy).
+	r := cfg.Providers()
 	switch sel {
 	case transcriberProviderMistral:
-		tr, err := mistralTranscriber(cfg)
+		prof, err := r.ResolveExplicit(provider.CapSTT, "mistral-ocr", true)
 		if err != nil {
 			return nil, fmt.Errorf("stt provider %q: %w", sel, err)
 		}
-		return tr, nil
+		return buildTranscriber(prof, cfg)
 	case transcriberProviderElevenLabs:
-		if strings.TrimSpace(cfg.ElevenLabsAPIKey) == "" {
-			return nil, fmt.Errorf("stt provider %q requires ELEVENLABS_API_KEY", sel)
+		prof, err := r.ResolveExplicit(provider.CapSTT, "elevenlabs", true)
+		if err != nil {
+			return nil, fmt.Errorf("stt provider %q: %w", sel, err)
 		}
-		return newElevenLabsTranscriber(cfg), nil
+		return buildTranscriber(prof, cfg)
 	case transcriberProviderAuto:
-		if tr, err := mistralTranscriber(cfg); err == nil {
-			return tr, nil
+		prof, err := r.Resolve(provider.CapSTT)
+		if errors.Is(err, provider.ErrNoProvider) {
+			return nil, nil // nothing eligible -> STT off
 		}
-		if strings.TrimSpace(cfg.ElevenLabsAPIKey) != "" {
-			return newElevenLabsTranscriber(cfg), nil
+		if err != nil {
+			return nil, fmt.Errorf("stt provider %q: %w", sel, err)
 		}
-		return nil, nil // auto + nothing eligible -> STT off
+		return buildTranscriber(prof, cfg)
 	default:
 		return nil, fmt.Errorf("unsupported transcriber provider %q", sel)
 	}

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -200,11 +200,6 @@ func DiscoverOptionsFromConfig(cfg config.Config) DiscoverOptions {
 	return options
 }
 
-// newElevenLabsTranscriber builds the legacy ElevenLabs STT client.
-// ElevenLabs STT/TTS stays on this legacy construction during the
-// transition because provider.Profile does not yet carry the
-// ElevenLabs voice/model/language knobs; it flips in the clean-break
-// config rework (#38).
 // mistralExtractor resolves the OCR provider (the bespoke mistral kind)
 // via the provider model and adapts it to model.DocumentExtractor.
 // Returns nil when no Mistral OCR credential is available (matching the
@@ -234,8 +229,6 @@ func mistralExtractor(cfg config.Config) model.DocumentExtractor {
 	return ex
 }
 
-// mistralTranscriber resolves the mistral-ocr profile for STT and
-// re-applies the legacy OCR/transcription payload limit.
 // buildTranscriber adapts a resolved profile to a model.Transcriber and
 // re-applies the Mistral OCR/transcription payload limit (no-op for
 // non-Mistral kinds). ElevenLabs voice/model/language/base-url are

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -290,28 +290,32 @@ func TranscriberFromConfig(cfg config.Config) (model.Transcriber, error) {
 	// profiles, or STT off when none is eligible. ElevenLabs voice/
 	// model/language/base-url are preserved on the profile (seedLegacy).
 	r := cfg.Providers()
+	// build wraps BOTH resolver and factory/build failures with the
+	// selected provider so the error contract is consistent regardless
+	// of where the failure occurred.
+	build := func(prof provider.Profile, err error) (model.Transcriber, error) {
+		if err != nil {
+			return nil, fmt.Errorf("stt provider %q: %w", sel, err)
+		}
+		tr, berr := buildTranscriber(prof, cfg)
+		if berr != nil {
+			return nil, fmt.Errorf("stt provider %q: %w", sel, berr)
+		}
+		return tr, nil
+	}
 	switch sel {
 	case transcriberProviderMistral:
 		prof, err := r.ResolveExplicit(provider.CapSTT, "mistral-ocr", true)
-		if err != nil {
-			return nil, fmt.Errorf("stt provider %q: %w", sel, err)
-		}
-		return buildTranscriber(prof, cfg)
+		return build(prof, err)
 	case transcriberProviderElevenLabs:
 		prof, err := r.ResolveExplicit(provider.CapSTT, "elevenlabs", true)
-		if err != nil {
-			return nil, fmt.Errorf("stt provider %q: %w", sel, err)
-		}
-		return buildTranscriber(prof, cfg)
+		return build(prof, err)
 	case transcriberProviderAuto:
 		prof, err := r.Resolve(provider.CapSTT)
 		if errors.Is(err, provider.ErrNoProvider) {
 			return nil, nil // nothing eligible -> STT off
 		}
-		if err != nil {
-			return nil, fmt.Errorf("stt provider %q: %w", sel, err)
-		}
-		return buildTranscriber(prof, cfg)
+		return build(prof, err)
 	default:
 		return nil, fmt.Errorf("unsupported transcriber provider %q", sel)
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -103,7 +103,9 @@ type Profile struct {
 	ChatModel      string
 	OCRModel       string
 	STTModel       string
+	STTLanguage    string // optional STT language hint (e.g. ElevenLabs)
 	TTSModel       string
+	TTSVoice       string // TTS voice id/name (e.g. ElevenLabs voice, OpenAI voice)
 	RerankModel    string
 }
 

--- a/internal/providerfactory/factory.go
+++ b/internal/providerfactory/factory.go
@@ -188,11 +188,17 @@ func TTS(p provider.Profile) (TTSSynthesizer, error) {
 		if p.TTSModel != "" {
 			c.DefaultTTSModel = p.TTSModel
 		}
+		if p.TTSVoice != "" {
+			c.DefaultTTSVoice = p.TTSVoice
+		}
 		return c, nil
 	case provider.KindGemini:
 		c := gemini.NewClient(p.BaseURL, p.APIKey)
 		if p.TTSModel != "" {
 			c.DefaultTTSModel = p.TTSModel
+		}
+		if p.TTSVoice != "" {
+			c.DefaultTTSVoice = p.TTSVoice
 		}
 		return c, nil
 	default:

--- a/internal/providerfactory/factory.go
+++ b/internal/providerfactory/factory.go
@@ -11,6 +11,7 @@ package providerfactory
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/dirstral/dir2mcp/internal/anthropic"
 	"github.com/dirstral/dir2mcp/internal/cohere"
@@ -142,8 +143,7 @@ func Transcriber(p provider.Profile) (model.Transcriber, error) {
 		}
 		return c, nil
 	case provider.KindElevenLabs:
-		// elevenlabs.NewClient(apiKey, voiceID); voiceID is TTS-only.
-		return elevenlabs.NewClient(p.APIKey, ""), nil
+		return newElevenLabs(p), nil
 	case provider.KindOpenAI:
 		c := openai.NewClient(p.BaseURL, p.APIKey)
 		if p.STTModel != "" {
@@ -161,12 +161,28 @@ func Transcriber(p provider.Profile) (model.Transcriber, error) {
 	}
 }
 
+// newElevenLabs builds an ElevenLabs client carrying the profile's
+// voice / STT model / language / base URL (shared by Transcriber+TTS).
+func newElevenLabs(p provider.Profile) *elevenlabs.Client {
+	c := elevenlabs.NewClient(p.APIKey, p.TTSVoice)
+	if p.BaseURL != "" {
+		c.BaseURL = strings.TrimRight(strings.TrimSpace(p.BaseURL), "/")
+	}
+	if p.STTModel != "" {
+		c.TranscribeModel = p.STTModel
+	}
+	if p.STTLanguage != "" {
+		c.TranscribeLanguageCode = p.STTLanguage
+	}
+	return c
+}
+
 // TTS builds a TTSSynthesizer for TTS-capable kinds: `elevenlabs`,
 // `openai`, `gemini` (SPEC 8.1.2). openai TTS is endpoint-dependent.
 func TTS(p provider.Profile) (TTSSynthesizer, error) {
 	switch p.Kind {
 	case provider.KindElevenLabs:
-		return elevenlabs.NewClient(p.APIKey, ""), nil
+		return newElevenLabs(p), nil
 	case provider.KindOpenAI:
 		c := openai.NewClient(p.BaseURL, p.APIKey)
 		if p.TTSModel != "" {

--- a/tests/ingest/service_test.go
+++ b/tests/ingest/service_test.go
@@ -654,9 +654,12 @@ func TestTranscriberFromConfig_ExplicitProviderRequiresCredentials(t *testing.T)
 			wantErr:  "mistral-ocr",
 		},
 		{
+			// legacy stt.provider "elevenlabs" now resolves the
+			// elevenlabs profile; without a credential the resolver
+			// returns a CONFIG_INVALID naming that profile.
 			name:     "elevenlabs missing key",
 			provider: "elevenlabs",
-			wantErr:  "requires ELEVENLABS_API_KEY",
+			wantErr:  "elevenlabs",
 		},
 	}
 


### PR DESCRIPTION
**PR C2-iii-c** — completes the wiring flip (Design 0001 / SPEC §8.1). Builds on #199.

- **`provider.Profile`** gains `TTSVoice` + `STTLanguage`; `providers:` YAML grows `tts_voice`/`stt_language` (§16.2 completeness).
- **`seedLegacy`** now seeds the `elevenlabs` profile from legacy config (api key, base_url, TTS voice, STT model, STT language) — so existing ElevenLabs configs keep working through the resolver. Refactored into per-provider helpers (gocyclo budget).
- **`providerfactory.newElevenLabs`** carries the profile's voice/model/language/base-url; shared by `Transcriber` + `TTS`.
- **ingest STT** now resolves entirely through the provider model (the legacy `newElevenLabsTranscriber` is gone); `buildTranscriber` unifies factory build + the Mistral OCR-limit re-apply; `auto` uses `Resolve(CapSTT)`.
- **TTS** (`buildMCPServerOptions`) resolved via `providerfactory.TTS(CapTTS)`, fail-open per SPEC §8.3.

All ElevenLabs voice/model/language/base-url config is preserved through the resolver — behavior-preserving. `make check` green.

**Remaining:** §8.1.4 snapshot embed-identity (own PR), then the clean break (#38: remove legacy `mistral:`/embed/chat fields + `seedLegacy` + spec/README).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring STT language preferences in provider settings.
  * Added support for configuring TTS voice selection in provider settings.

* **Bug Fixes & Improvements**
  * Improved provider resolution for speech-to-text and text-to-speech services.
  * Enhanced ElevenLabs integration through unified provider model.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dirstral/dir2mcp/pull/200?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->