### PR TITLE
feat(config): snapshot embed-identity guard (SPEC 8.1.4) (C2-iii-d)

### DIFF
--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -837,6 +837,13 @@ func (a *App) prepareUpConfig(opts upOptions) (config.Config, authMaterial, stri
 	if code := a.checkMistralAPIKey(&cfg, opts, nonInteractiveMode); code != exitSuccess {
 		return config.Config{}, authMaterial{}, "", "", false, code
 	}
+	// SPEC 8.1.4: refuse to mix vector spaces if the embed
+	// provider/model changed since the index was built.
+	if err := cfg.VerifyEmbedIdentity(cfg.StateDir); err != nil {
+		writeCLIError(a.stderr, opts.jsonOutput, exitConfigInvalid, err.Error(),
+			"The embed provider/model changed since the index was built — run `dir2mcp reindex`, or restore the previous embed config.")
+		return config.Config{}, authMaterial{}, "", "", false, exitConfigInvalid
+	}
 	auth, err := prepareAuthMaterial(cfg)
 	if err != nil {
 		writeCLIError(a.stderr, opts.jsonOutput, exitAuthOrPayment, fmt.Sprintf("auth setup: %v", err))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -563,6 +563,7 @@ func SaveEffectiveSnapshot(cfg Config, sources SecretSourceMetadata) (string, er
 		return "", fmt.Errorf("marshal snapshot yaml: %w", err)
 	}
 	raw = appendSnapshotSecretSourceMetadata(raw, sources)
+	raw = appendSnapshotEmbedIdentity(raw, cfg.Providers().EmbedIdentity())
 	if len(raw) == 0 || raw[len(raw)-1] != '\n' {
 		raw = append(raw, '\n')
 	}
@@ -600,6 +601,22 @@ func LoadEffectiveSnapshot(path string) (Config, SecretSourceMetadata, error) {
 		return Config{}, SecretSourceMetadata{}, err
 	}
 	return cfg, sources, nil
+}
+
+// appendSnapshotEmbedIdentity records the resolved embed identity
+// (provider+models) in the snapshot so a later load can detect a
+// changed embed provider/model and refuse to mix vector spaces
+// (SPEC 8.1.4). A top-level scalar — ignored by the flat config parser
+// and the providers:/model: yaml subtree decode on reload.
+func appendSnapshotEmbedIdentity(raw []byte, id string) []byte {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return raw
+	}
+	if len(raw) > 0 && raw[len(raw)-1] != '\n' {
+		raw = append(raw, '\n')
+	}
+	return append(raw, []byte("embed_identity: "+id+"\n")...)
 }
 
 func appendSnapshotSecretSourceMetadata(raw []byte, sources SecretSourceMetadata) []byte {

--- a/internal/config/providers.go
+++ b/internal/config/providers.go
@@ -302,6 +302,37 @@ func (r ProviderResolution) ResolveExplicit(cap provider.Capability, explicit st
 	return r.applyModelOverrides(cap, p), nil
 }
 
+// readSnapshotEmbedIdentity returns the embed_identity recorded in the
+// effective snapshot for stateDir, or "" if there is no snapshot / no
+// recorded identity (a fresh index — VerifyEmbedIdentity treats that as
+// always-compatible).
+func readSnapshotEmbedIdentity(stateDir string) string {
+	raw, err := os.ReadFile(EffectiveSnapshotPath(stateDir))
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(raw), "\n") {
+		if line != strings.TrimLeft(line, " \t") { // top-level only
+			continue
+		}
+		if v, ok := strings.CutPrefix(strings.TrimSpace(line), "embed_identity:"); ok {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}
+
+// VerifyEmbedIdentity enforces the SPEC 8.1.4 corpus-lifetime invariant:
+// if a prior snapshot recorded a different embed identity than the one
+// resolved now, refuse to serve (the index's vectors are not comparable
+// across embed providers/models). A fresh state dir (no snapshot)
+// always passes. Returns a *provider.ConfigError on mismatch.
+func (cfg Config) VerifyEmbedIdentity(stateDir string) error {
+	recorded := readSnapshotEmbedIdentity(stateDir)
+	current := cfg.Providers().EmbedIdentity()
+	return provider.VerifyEmbedIdentity(recorded, current)
+}
+
 // EmbedIdentity is the corpus-lifetime identity of the resolved embed
 // provider (SPEC 8.1.4), or "" if embed cannot be resolved.
 func (r ProviderResolution) EmbedIdentity() string {

--- a/tests/config/embed_identity_test.go
+++ b/tests/config/embed_identity_test.go
@@ -1,0 +1,51 @@
+package tests
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+)
+
+// SPEC 8.1.4: the resolved embed identity is recorded in the snapshot
+// and a changed embed provider/model on reload is refused (no silent
+// vector-space mixing).
+func TestEmbedIdentity_SnapshotRecordsAndVerifies(t *testing.T) {
+	t.Setenv("MISTRAL_API_KEY", "mk")
+	dir := t.TempDir()
+
+	// Fresh state dir (no snapshot) always passes.
+	cfg := config.Default()
+	cfg.StateDir = dir
+	if err := cfg.VerifyEmbedIdentity(dir); err != nil {
+		t.Fatalf("fresh state dir must pass: %v", err)
+	}
+
+	// Save the snapshot; it must record embed_identity.
+	if _, err := config.SaveEffectiveSnapshot(cfg, config.SecretSourceMetadata{}); err != nil {
+		t.Fatalf("SaveEffectiveSnapshot: %v", err)
+	}
+	raw, err := os.ReadFile(config.EffectiveSnapshotPath(dir))
+	if err != nil {
+		t.Fatalf("read snapshot: %v", err)
+	}
+	want := "embed_identity: mistral|mistral-embed|codestral-embed"
+	if !strings.Contains(string(raw), want) {
+		t.Fatalf("snapshot missing %q:\n%s", want, raw)
+	}
+
+	// Same identity -> passes.
+	if err := cfg.VerifyEmbedIdentity(dir); err != nil {
+		t.Fatalf("matching identity must pass: %v", err)
+	}
+
+	// Changed embed model -> refused with a CONFIG_INVALID-class error.
+	changed := config.Default()
+	changed.StateDir = dir
+	changed.EmbedModelText = "some-other-embed-v9" // seeds the mistral profile
+	err = changed.VerifyEmbedIdentity(dir)
+	if err == nil || !strings.Contains(err.Error(), "CONFIG_INVALID") {
+		t.Fatalf("changed embed identity must be refused, got: %v", err)
+	}
+}


### PR DESCRIPTION
**PR C2-iii-d** — the §8.1.4 corpus-lifetime invariant. Builds on #200.

Vectors from different embed providers/models are not comparable, so the resolved embed identity must be bound to the index and re-checked on load.

- **`SaveEffectiveSnapshot`** now records `embed_identity: <provider>|<text-model>|<code-model>` (a top-level scalar — ignored by the flat parser and the `providers:`/`model:` yaml subtree on reload, so it can't break loading).
- **`cfg.VerifyEmbedIdentity(stateDir)`** reads the prior snapshot's recorded identity and compares it to the currently-resolved one (`provider.VerifyEmbedIdentity`). A fresh state dir (no snapshot) always passes.
- **`up` preflight** (right after the embed preflight, before indexing/snapshot-overwrite) refuses to start with `CONFIG_INVALID` + a `dir2mcp reindex` hint when the embed provider/model changed since the index was built — **no silent vector-space mixing**.
- Test: identity recorded, match passes, changed embed model refused.

`make check` green. **Last remaining:** #38 — the clean break (remove the legacy `mistral:`/embed/chat/stt config fields + `seedLegacy` + spec §16.2/README), which completes Design 0001 / spec 0.7.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)