### PR TITLE
feat(cli): generalize ask.go embed preflight through the resolver (C2-iii-e)

### DIFF
--- a/internal/cli/ask.go
+++ b/internal/cli/ask.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/provider"
 )
 
 func (a *App) runAsk(ctx context.Context, global globalOptions, args []string) int {
@@ -44,26 +45,27 @@ func (a *App) runAskLocal(ctx context.Context, global globalOptions, opts askOpt
 		cfg.StateDir = filepath.Join(".", ".dir2mcp")
 	}
 
-	if strings.TrimSpace(cfg.MistralAPIKey) == "" {
+	// SPEC 8.1.3 preflight: an embed provider must resolve (generalized
+	// from the legacy MISTRAL_API_KEY-specific check; mirrors `up`).
+	if _, embErr := cfg.Providers().Resolve(provider.CapEmbed); embErr != nil {
+		msg := "CONFIG_INVALID: no embedding provider configured"
+		hint := "Set a provider credential (e.g. MISTRAL_API_KEY / OPENAI_API_KEY) or configure providers: in .dir2mcp.yaml"
+		var ce *provider.ConfigError
+		if errors.As(embErr, &ce) {
+			msg = ce.Error()
+		}
 		if global.jsonOutput {
-			writeCLIError(
-				a.stderr,
-				true,
-				exitConfigInvalid,
-				"CONFIG_INVALID: Missing MISTRAL_API_KEY",
-				"Set env: MISTRAL_API_KEY=...",
-				"Or run: dir2mcp config init",
-			)
+			writeCLIError(a.stderr, true, exitConfigInvalid, msg, hint, "Or run: dir2mcp config init")
 			return exitConfigInvalid
 		}
 		se := a.sty(global.jsonOutput)
 		nonInteractiveMode := global.nonInteractive || !isTerminal(os.Stdin) || !isTerminal(os.Stdout)
 		if nonInteractiveMode {
-			writef(a.stderr, "%s CONFIG_INVALID: Missing MISTRAL_API_KEY\n", se.errPrefix())
-			writeln(a.stderr, "Set env: MISTRAL_API_KEY=...")
+			writef(a.stderr, "%s %s\n", se.errPrefix(), msg)
+			writeln(a.stderr, hint)
 			writeln(a.stderr, "Or run: dir2mcp config init")
 		} else {
-			writef(a.stderr, "%s Missing MISTRAL_API_KEY\n", se.errPrefix())
+			writef(a.stderr, "%s %s\n", se.errPrefix(), strings.TrimPrefix(msg, "CONFIG_INVALID: "))
 			writeln(a.stderr, "Run: dir2mcp config init")
 		}
 		return exitConfigInvalid

--- a/tests/cli/ask_preflight_test.go
+++ b/tests/cli/ask_preflight_test.go
@@ -60,7 +60,7 @@ func TestAskPreflight_NonMistralCredentialPasses(t *testing.T) {
 	})
 	withWorkingDir(t, tmp, func() {
 		code := app.RunWithContext(context.Background(),
-			[]string{"ask", "--mode", "search_only", "alpha"})
+			[]string{"ask", "--non-interactive", "--mode", "search_only", "alpha"})
 		if code != 0 {
 			t.Fatalf("non-Mistral credential should pass preflight; code=%d stderr=%s", code, stderr.String())
 		}

--- a/tests/cli/ask_preflight_test.go
+++ b/tests/cli/ask_preflight_test.go
@@ -1,0 +1,96 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/cli"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+func clearProviderEnv(t *testing.T) {
+	t.Helper()
+	for _, k := range []string{
+		"MISTRAL_API_KEY", "OPENAI_API_KEY", "OPENROUTER_API_KEY",
+		"GEMINI_API_KEY", "COHERE_API_KEY", "ANTHROPIC_API_KEY", "ELEVENLABS_API_KEY",
+	} {
+		t.Setenv(k, "")
+	}
+}
+
+// No embed provider resolves -> generalized CONFIG_INVALID preflight.
+func TestAskPreflight_NoProviderRejected(t *testing.T) {
+	tmp := t.TempDir()
+	clearProviderEnv(t)
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIOAndHooks(&stdout, &stderr, cli.RuntimeHooks{})
+	withWorkingDir(t, tmp, func() {
+		code := app.RunWithContext(context.Background(),
+			[]string{"ask", "--non-interactive", "--mode", "search_only", "q"})
+		if code == 0 {
+			t.Fatalf("expected non-zero exit, stderr=%s", stderr.String())
+		}
+	})
+	if !strings.Contains(stderr.String(), "no embedding provider configured") {
+		t.Fatalf("stderr should mention no embedding provider; got: %s", stderr.String())
+	}
+}
+
+// A non-Mistral embed credential satisfies the preflight (no longer
+// Mistral-specific): the command proceeds past it and search succeeds.
+func TestAskPreflight_NonMistralCredentialPasses(t *testing.T) {
+	tmp := t.TempDir()
+	clearProviderEnv(t)
+	t.Setenv("OPENAI_API_KEY", "ok")
+
+	stub := &commandTestRetrieverStub{
+		searchHits: []model.SearchHit{
+			{ChunkID: 1, RelPath: "a.md", DocType: "md", RepType: "raw_text", Score: 0.9, Snippet: "alpha"},
+		},
+	}
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIOAndHooks(&stdout, &stderr, cli.RuntimeHooks{
+		NewStore:     func(config.Config) model.Store { return &commandTestNoopStore{} },
+		NewRetriever: func(config.Config, model.Store) model.Retriever { return stub },
+	})
+	withWorkingDir(t, tmp, func() {
+		code := app.RunWithContext(context.Background(),
+			[]string{"ask", "--mode", "search_only", "alpha"})
+		if code != 0 {
+			t.Fatalf("non-Mistral credential should pass preflight; code=%d stderr=%s", code, stderr.String())
+		}
+	})
+	if strings.Contains(stderr.String(), "no embedding provider configured") {
+		t.Fatalf("preflight wrongly rejected a non-Mistral credential: %s", stderr.String())
+	}
+}
+
+// An explicit, incapable embed binding surfaces the resolver's
+// actionable *provider.ConfigError verbatim (not the generic message).
+func TestAskPreflight_IncapableExplicitBindingSurfacesConfigError(t *testing.T) {
+	tmp := t.TempDir()
+	clearProviderEnv(t)
+	t.Setenv("ANTHROPIC_API_KEY", "ak")
+	if err := os.WriteFile(filepath.Join(tmp, ".dir2mcp.yaml"),
+		[]byte("model:\n  embed:\n    provider: anthropic\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIOAndHooks(&stdout, &stderr, cli.RuntimeHooks{})
+	withWorkingDir(t, tmp, func() {
+		if code := app.RunWithContext(context.Background(),
+			[]string{"ask", "--non-interactive", "--mode", "search_only", "q"}); code == 0 {
+			t.Fatalf("incapable explicit embed binding must fail, stderr=%s", stderr.String())
+		}
+	})
+	out := stderr.String()
+	if !strings.Contains(out, "CONFIG_INVALID") || !strings.Contains(out, "embed") {
+		t.Fatalf("expected the resolver ConfigError surfaced; got: %s", out)
+	}
+}


### PR DESCRIPTION
**PR C2-iii-e** — a small, isolated step toward the clean break.

`ask.go`'s startup preflight previously demanded `MISTRAL_API_KEY` specifically. It now requires an **embed provider to resolve** (`cfg.Providers().Resolve(CapEmbed)`), mirroring the already-merged `up.go` generalized preflight, and surfaces a `*provider.ConfigError` verbatim (actionable) when an explicit binding is invalid — reserving the generic message for the true no-provider case.

- Behavior-preserving for the Mistral default (`MISTRAL_API_KEY` still satisfies it via the built-in profile + `seedLegacy`).
- Isolated to `ask.go`; **no test fallout**; `make check` green.

### Scope note (honest)
The full clean break (#38) grew on inspection — `mcp/tools.go`'s `newMistralClient` is a still-legacy runtime path (annotate=chat, transcribe=STT) whose flip drags mcp-test migration, plus `config_cmd`/CLI-flag repointing, the field+`seedLegacy` deletion, and a large legacy-field test migration + spec §16.2/README. That is tracked as the final **#38** (likely sub-PRs). This PR lands the one clean, zero-risk slice now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preflight now correctly detects whether an embedding provider is configured and blocks execution if none is found.
  * Error messages are clearer and include actionable hints for configuring providers or initializing config.
  * Non-Mistral providers (e.g., OpenAI) are accepted when valid; incorrectly bound providers surface a CONFIG_INVALID embed error.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dirstral/dir2mcp/pull/202?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->