### PR TITLE
refactor(mcp): flip newMistralClient through the provider resolver (#38a)

### DIFF
--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -275,6 +275,16 @@ func DocumentExtractorFromConfig(cfg config.Config) model.DocumentExtractor {
 }
 
 func TranscriberFromConfig(cfg config.Config) (model.Transcriber, error) {
+	return TranscriberFromConfigWithLanguage(cfg, "")
+}
+
+// TranscriberFromConfigWithLanguage is TranscriberFromConfig with a
+// per-request language override (the `language` arg of the transcribe
+// MCP tool). A non-empty language is applied onto the resolved profile
+// before the adapter is built so it reaches the wire (e.g. Mistral's
+// `language` form field); empty leaves the profile's configured
+// STTLanguage untouched.
+func TranscriberFromConfigWithLanguage(cfg config.Config, language string) (model.Transcriber, error) {
 	sel := strings.ToLower(strings.TrimSpace(cfg.STTProvider))
 	if sel == "" {
 		sel = transcriberProviderAuto
@@ -290,12 +300,16 @@ func TranscriberFromConfig(cfg config.Config) (model.Transcriber, error) {
 	// profiles, or STT off when none is eligible. ElevenLabs voice/
 	// model/language/base-url are preserved on the profile (seedLegacy).
 	r := cfg.Providers()
+	langOverride := strings.TrimSpace(language)
 	// build wraps BOTH resolver and factory/build failures with the
 	// selected provider so the error contract is consistent regardless
 	// of where the failure occurred.
 	build := func(prof provider.Profile, err error) (model.Transcriber, error) {
 		if err != nil {
 			return nil, fmt.Errorf("stt provider %q: %w", sel, err)
+		}
+		if langOverride != "" {
+			prof.STTLanguage = langOverride
 		}
 		tr, berr := buildTranscriber(prof, cfg)
 		if berr != nil {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -19,6 +19,8 @@ import (
 	"github.com/dirstral/dir2mcp/internal/mistral"
 	"github.com/dirstral/dir2mcp/internal/model"
 	"github.com/dirstral/dir2mcp/internal/protocol"
+	"github.com/dirstral/dir2mcp/internal/provider"
+	"github.com/dirstral/dir2mcp/internal/providerfactory"
 )
 
 const (
@@ -914,7 +916,7 @@ func (s *Server) handleAnnotateTool(ctx context.Context, args map[string]interfa
 		sourceText = string(runes[:maxChars])
 	}
 
-	client, toolErr := s.newMistralClient()
+	client, toolErr := s.newGenerator()
 	if toolErr != nil {
 		return toolCallResult{}, toolErr
 	}
@@ -1595,18 +1597,22 @@ func (s *Server) ensureTranscriptForAudioDoc(ctx context.Context, doc model.Docu
 		}
 	}
 
-	client, toolErr := s.newMistralClient()
-	if toolErr != nil {
-		return "", false, false, toolErr
+	// STT resolves through the provider model (SPEC 8.1.3); the legacy
+	// stt.provider selector still maps onto a profile during the
+	// transition. The per-request language override is threaded onto the
+	// resolved profile so it reaches the wire.
+	transcriber, tErr := ingest.TranscriberFromConfigWithLanguage(s.cfg, language)
+	if tErr != nil {
+		return "", false, false, &toolExecutionError{Code: "CONFIG_INVALID", Message: tErr.Error(), Retryable: false}
 	}
-	if strings.TrimSpace(language) != "" {
-		client.DefaultTranscribeLanguage = strings.TrimSpace(language)
+	if transcriber == nil {
+		return "", false, false, &toolExecutionError{Code: "CONFIG_INVALID", Message: "no speech-to-text provider configured", Retryable: false}
 	}
 	ing, err := ingest.NewService(s.cfg, s.store)
 	if err != nil {
 		return "", false, false, &toolExecutionError{Code: "CONFIG_INVALID", Message: err.Error(), Retryable: false}
 	}
-	ing.SetTranscriber(client)
+	ing.SetTranscriber(transcriber)
 
 	// generate transcript text first so we can accurately determine whether
 	// there is anything worth indexing.
@@ -1724,19 +1730,29 @@ func escapeGlobLiteral(input string) string {
 	return b.String()
 }
 
-func (s *Server) newMistralClient() (*mistral.Client, *toolExecutionError) {
-	apiKey := strings.TrimSpace(s.cfg.MistralAPIKey)
-	if apiKey == "" {
-		return nil, &toolExecutionError{Code: "CONFIG_INVALID", Message: "MISTRAL_API_KEY is required", Retryable: false}
-	}
-	client := mistral.NewClient(s.cfg.MistralBaseURL, apiKey)
-	if s.cfg.MistralMaxOCRPayloadBytes > 0 {
-		client.MaxOCRPayloadBytes = s.cfg.MistralMaxOCRPayloadBytes
+// newGenerator resolves the chat provider through the provider model
+// (SPEC 8.1.3) and builds its adapter. It replaces the legacy
+// Mistral-only annotate client: Mistral chat now routes through the
+// OpenAI-compatible backbone like any other provider. The legacy flat
+// chat_model still wins during the transition (mirrors
+// cli.resolveModelClients; removed with the field in the clean break).
+func (s *Server) newGenerator() (model.Generator, *toolExecutionError) {
+	cp, err := s.cfg.Providers().Resolve(provider.CapChat)
+	if err != nil {
+		var ce *provider.ConfigError
+		if errors.As(err, &ce) {
+			return nil, &toolExecutionError{Code: "CONFIG_INVALID", Message: ce.Error(), Retryable: false}
+		}
+		return nil, &toolExecutionError{Code: "CONFIG_INVALID", Message: "no chat provider configured", Retryable: false}
 	}
 	if modelName := strings.TrimSpace(s.cfg.ChatModel); modelName != "" {
-		client.DefaultChatModel = modelName
+		cp.ChatModel = modelName
 	}
-	return client, nil
+	gen, ferr := providerfactory.Generator(cp)
+	if ferr != nil {
+		return nil, &toolExecutionError{Code: "CONFIG_INVALID", Message: ferr.Error(), Retryable: false}
+	}
+	return gen, nil
 }
 
 func parseJSONObjectFromModelOutput(raw string) (map[string]interface{}, error) {

--- a/internal/providerfactory/factory.go
+++ b/internal/providerfactory/factory.go
@@ -141,8 +141,8 @@ func Transcriber(p provider.Profile) (model.Transcriber, error) {
 		if p.STTModel != "" {
 			c.DefaultTranscribeModel = p.STTModel
 		}
-		if p.STTLanguage != "" {
-			c.DefaultTranscribeLanguage = p.STTLanguage
+		if lang := strings.TrimSpace(p.STTLanguage); lang != "" {
+			c.DefaultTranscribeLanguage = lang
 		}
 		return c, nil
 	case provider.KindElevenLabs:

--- a/internal/providerfactory/factory.go
+++ b/internal/providerfactory/factory.go
@@ -141,6 +141,9 @@ func Transcriber(p provider.Profile) (model.Transcriber, error) {
 		if p.STTModel != "" {
 			c.DefaultTranscribeModel = p.STTModel
 		}
+		if p.STTLanguage != "" {
+			c.DefaultTranscribeLanguage = p.STTLanguage
+		}
 		return c, nil
 	case provider.KindElevenLabs:
 		return newElevenLabs(p), nil

--- a/tests/mcp/tools_test.go
+++ b/tests/mcp/tools_test.go
@@ -336,7 +336,10 @@ func TestMCPToolsCallAnnotate_ProviderFailure(t *testing.T) {
 	cfg.MistralAPIKey = "test-key"
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/v1/chat/completions" {
+		// Mistral chat now routes through the OpenAI-compatible
+		// backbone: POST {base}/chat/completions (not the native
+		// /v1/chat/completions path).
+		if r.URL.Path == "/chat/completions" {
 			http.Error(w, `{"error":"boom"}`, http.StatusInternalServerError)
 			return
 		}
@@ -359,7 +362,9 @@ func TestMCPToolsCallAnnotate_Success(t *testing.T) {
 	cfg.MistralAPIKey = "test-key"
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/v1/chat/completions" {
+		// Mistral chat now routes through the OpenAI-compatible
+		// backbone: POST {base}/chat/completions.
+		if r.URL.Path != "/chat/completions" {
 			http.NotFound(w, r)
 			return
 		}


### PR DESCRIPTION
## What

First of three PRs for the **#38 clean break** (C2-iii-b), scoped per the user-confirmed **spec-faithful narrow break**: remove only the spec-removed monolithic `mistral`/embed/chat surface; the `stt:`/`rerank:` YAML shapes are explicitly **retained** per SPEC 0.7.0 §16.2. No new dirstral-spec PR — 0.7.0 already ratifies this clean break (*"the monolithic `mistral:` block is removed … a clean break is acceptable"*), so this is conformance work like #202.

This PR flips `internal/mcp/tools.go` off the direct Mistral client:

- **annotate** → resolver-backed `model.Generator` (`CapChat`). Mistral chat now routes through the OpenAI-compatible backbone like every other provider. The legacy flat `chat_model` still wins during the transition (mirrors `cli.resolveModelClients`; the field is deleted in 38c).
- **transcribe** → `ingest.TranscriberFromConfigWithLanguage`, which resolves STT through the provider model (SPEC §8.1.3) and threads the per-request `language` override onto the resolved profile so it reaches the wire.
- `providerfactory.Transcriber` now honors profile `STTLanguage` for the **Mistral** kind (parity with ElevenLabs; required for the per-request language hint to survive the flip).
- `newMistralClient` removed.

## Behavior / wire impact

- Mistral **chat** (annotate): native `/v1/chat/completions` → backbone `{base}/chat/completions`. Annotate test mocks migrated accordingly.
- Mistral **STT** (transcribe): unchanged — default `STTProvider: "mistral"` maps to the `mistral-ocr` profile (`kind: mistral`), so it stays on the native `/v1/audio/transcriptions` path. No transcribe mock changes needed.

## Tests

- Full `tests/mcp` suite green (annotate, transcribe, transcribe_and_ask).
- `make check` green locally.

## Follow-ups (sequential, each its own PR + approval)

- **38b** — repoint the remaining spec-removed-field read sites to the resolver; drop the `--embed-model-*`/`--chat-model`/`--mistral-max-ocr-payload-bytes` flags.
- **38c** — delete the spec-removed `Config` fields + `seedMistralChatEmbed`/`seedMistralOCR` + flat-parser cases; migrate the legacy-field test surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for language override on a per-request basis in speech-to-text transcription, enabling flexible language selection without requiring global configuration changes.

* **Improvements**
  * Enhanced provider selection logic for chat and transcription services to support multiple providers through unified, provider-agnostic configuration handling while maintaining backward compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dirstral/dir2mcp/pull/203?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->