### PR TITLE
feat(config): clean-break removal of spec-removed provider config (C2-iii-b / 38c)

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -1111,6 +1111,9 @@ func loadConfigForDaemonParent(global globalOptions) (config.Config, error) {
 	return cfg, nil
 }
 
+// saveEffectiveConfigSnapshot writes the effective (post-merge) config
+// snapshot, recording where each secret was sourced from
+// (env/configured/…) without persisting the secret values themselves.
 func saveEffectiveConfigSnapshot(cfg config.Config, auth authMaterial, x402TokenSource string) error {
 	sources := config.SecretSourceMetadata{}
 	if strings.TrimSpace(cfg.ElevenLabsAPIKey) != "" {

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -1113,12 +1113,6 @@ func loadConfigForDaemonParent(global globalOptions) (config.Config, error) {
 
 func saveEffectiveConfigSnapshot(cfg config.Config, auth authMaterial, x402TokenSource string) error {
 	sources := config.SecretSourceMetadata{}
-	if strings.TrimSpace(cfg.MistralAPIKey) != "" {
-		sources.MistralAPIKey = "configured"
-		if strings.TrimSpace(os.Getenv("MISTRAL_API_KEY")) != "" {
-			sources.MistralAPIKey = "env"
-		}
-	}
 	if strings.TrimSpace(cfg.ElevenLabsAPIKey) != "" {
 		sources.ElevenLabsAPIKey = "configured"
 		if strings.TrimSpace(os.Getenv("ELEVENLABS_API_KEY")) != "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -300,6 +300,8 @@ type persistedConfig struct {
 	X402PayTo            string `yaml:"x402_pay_to"`
 }
 
+// Default returns the baseline Config (used as the starting point
+// before dotenv/env/file overrides are layered on).
 func Default() Config {
 	return Config{
 		RootDir:         ".",
@@ -399,6 +401,9 @@ func LoadFile(path string) (Config, error) {
 	return load(path, nil, false)
 }
 
+// buildPersistedConfig projects a Config onto persistedConfig, the
+// subset that is safe to write to disk (secrets are intentionally
+// excluded so they never land in the YAML/snapshot).
 func buildPersistedConfig(cfg *Config) persistedConfig {
 	if cfg == nil {
 		return persistedConfig{}
@@ -575,6 +580,10 @@ func appendSnapshotEmbedIdentity(raw []byte, id string) []byte {
 	return append(raw, []byte("embed_identity: "+id+"\n")...)
 }
 
+// appendSnapshotSecretSourceMetadata appends a `secret_sources:` block
+// to raw recording where each secret was sourced from (env/file/…)
+// without writing the secret values themselves. Empty entries are
+// skipped; the block is omitted entirely when no sources are set.
 func appendSnapshotSecretSourceMetadata(raw []byte, sources SecretSourceMetadata) []byte {
 	entries := []struct {
 		key   string
@@ -609,6 +618,9 @@ func appendSnapshotSecretSourceMetadata(raw []byte, sources SecretSourceMetadata
 	return append(raw, []byte(buf.String())...)
 }
 
+// parseSecretSourceMetadata reads the `secret_sources:` block back out
+// of a snapshot into SecretSourceMetadata (the inverse of
+// appendSnapshotSecretSourceMetadata).
 func parseSecretSourceMetadata(raw []byte) (SecretSourceMetadata, error) {
 	meta := SecretSourceMetadata{}
 	scanner := bufio.NewScanner(strings.NewReader(string(raw)))
@@ -638,6 +650,8 @@ func parseSecretSourceMetadata(raw []byte) (SecretSourceMetadata, error) {
 	return meta, nil
 }
 
+// applySecretSourceField assigns a single parsed `secret_sources.<name>`
+// key/value onto meta; unknown keys are ignored.
 func applySecretSourceField(meta *SecretSourceMetadata, key, value string) {
 	switch key {
 	case "secret_sources.elevenlabs_api_key":
@@ -833,6 +847,10 @@ func applyRerankFileParsed(cfg *Config, fc fileConfig) {
 	}
 }
 
+// applyModelClientsFileParsed overlays the parsed ingest/ElevenLabs
+// client settings from the config file onto cfg (only keys present in
+// the file are applied; the spec-removed Mistral client keys are no
+// longer handled here).
 func applyModelClientsFileParsed(cfg *Config, fc fileConfig) {
 	if fc.DoclingCommand != nil {
 		cfg.DoclingCommand = *fc.DoclingCommand
@@ -1261,6 +1279,9 @@ func setBoolFileScalar(cfg *fileConfig, key, value string) error {
 	return nil
 }
 
+// setIntFileScalar parses value as an int and assigns it to the
+// fileConfig field selected by key; returns an error for an unknown key
+// or a non-integer value.
 func setIntFileScalar(cfg *fileConfig, key, value string) error {
 	var target **int
 	switch key {
@@ -1365,6 +1386,9 @@ func setRerankStringFileScalar(cfg *fileConfig, key, value string) bool {
 	return true
 }
 
+// setModelStringFileScalar assigns a model/provider-related flat string
+// key onto the fileConfig (rerank keys first, then ElevenLabs/STT). The
+// spec-removed Mistral/embed/chat keys are no longer accepted here.
 func setModelStringFileScalar(cfg *fileConfig, key, value string) {
 	if setRerankStringFileScalar(cfg, key, value) {
 		return
@@ -1465,6 +1489,8 @@ func isListConfigKey(key string) bool {
 	}
 }
 
+// marshalConfigYAML renders a persistedConfig as the flat-key YAML
+// written to .dir2mcp.yaml / the effective snapshot.
 func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	var b strings.Builder
 	writeScalar := func(key, value string) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,8 +12,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/dirstral/dir2mcp/internal/mistral"
 )
 
 const DefaultProtocolVersion = "2025-11-25"
@@ -21,7 +19,6 @@ const DefaultProtocolVersion = "2025-11-25"
 const EffectiveConfigSnapshotFile = ".dir2mcp.yaml.snapshot"
 
 type SecretSourceMetadata struct {
-	MistralAPIKey        string
 	ElevenLabsAPIKey     string
 	CohereAPIKey         string
 	X402FacilitatorToken string
@@ -76,12 +73,6 @@ type Config struct {
 	// ResolvedAuthToken is a runtime-only token value injected by CLI wiring.
 	// It is not loaded from disk and should not be persisted.
 	ResolvedAuthToken string
-	MistralAPIKey     string
-	MistralBaseURL    string
-	// MistralMaxOCRPayloadBytes optionally overrides the maximum encoded
-	// payload size accepted by the Mistral client for OCR/image processing
-	// and audio transcription requests. Values <= 0 use client defaults.
-	MistralMaxOCRPayloadBytes int
 	// DoclingCommand optionally configures a local docling CLI command
 	// template used for rich document extraction.
 	DoclingCommand       string
@@ -98,18 +89,6 @@ type Config struct {
 	// field is intentionally not persisted to disk.
 	Warnings []error
 
-	// EmbedModelText and EmbedModelCode specify the names of the Mistral
-	// embedding models used for text and code chunks respectively.  They are
-	// exposed via configuration so operators can override the hardcoded
-	// defaults if the upstream API changes or custom models are desired.
-	EmbedModelText string
-	EmbedModelCode string
-	// ChatModel specifies the Mistral chat/completion model used for
-	// RAG-style generation.  Operators can override the hardcoded default
-	// when upstream introduces a new alias or model.  Environment variable
-	// DIR2MCP_CHAT_MODEL also affects this value.
-	ChatModel string
-
 	RAGSystemPrompt     string
 	RAGGenerateAnswer   bool
 	RAGKDefault         int
@@ -123,9 +102,8 @@ type Config struct {
 	RetrievalHybridEnabled bool
 	// Rerank* configure the optional post-fusion rerank stage (SPEC
 	// 9.1.1). Reranking auto-activates when a provider credential is
-	// present (mirrors how MistralAPIKey gates embedding/OCR).
-	// CohereAPIKey is a secret: env-sourced, never persisted to the
-	// config snapshot (mirrors MistralAPIKey).
+	// present. CohereAPIKey is a secret: env-sourced, never persisted
+	// to the config snapshot.
 	//
 	// RerankEnabled is a tri-state override (nil = auto: on iff a
 	// credential is present; *false = force off even with a credential;
@@ -136,7 +114,7 @@ type Config struct {
 	CohereAPIKey   string
 	// CohereBaseURL overrides the Cohere API endpoint (self-hosted /
 	// proxied deployments and tests). Empty = provider default. Not a
-	// secret; persisted like MistralBaseURL.
+	// secret; persisted to the config snapshot.
 	CohereBaseURL         string
 	RerankModel           string
 	RerankCandidatePool   int
@@ -183,30 +161,24 @@ type Config struct {
 }
 
 type fileConfig struct {
-	RootDir                   *string
-	StateDir                  *string
-	ListenAddr                *string
-	MCPPath                   *string
-	ProtocolVersion           *string
-	Public                    *bool
-	AuthMode                  *string
-	ServerName                *string
-	RateLimitRPS              *int
-	RateLimitBurst            *int
-	TrustedProxies            []string
-	PathExcludes              []string
-	SecretPatterns            []string
-	MistralAPIKey             *string
-	MistralBaseURL            *string
-	MistralMaxOCRPayloadBytes *int
-	DoclingCommand            *string
+	RootDir         *string
+	StateDir        *string
+	ListenAddr      *string
+	MCPPath         *string
+	ProtocolVersion *string
+	Public          *bool
+	AuthMode        *string
+	ServerName      *string
+	RateLimitRPS    *int
+	RateLimitBurst  *int
+	TrustedProxies  []string
+	PathExcludes    []string
+	SecretPatterns  []string
+	DoclingCommand  *string
 
 	ElevenLabsBaseURL         *string
 	ElevenLabsTTSVoiceID      *string
 	AllowedOrigins            []string
-	EmbedModelText            *string
-	EmbedModelCode            *string
-	ChatModel                 *string
 	RAGSystemPrompt           *string
 	RAGGenerateAnswer         *bool
 	RAGKDefault               *int
@@ -257,22 +229,20 @@ type fileConfig struct {
 }
 
 type persistedConfig struct {
-	RootDir                   string   `yaml:"root_dir"`
-	StateDir                  string   `yaml:"state_dir"`
-	ListenAddr                string   `yaml:"listen_addr"`
-	MCPPath                   string   `yaml:"mcp_path"`
-	ProtocolVersion           string   `yaml:"protocol_version"`
-	Public                    bool     `yaml:"public"`
-	AuthMode                  string   `yaml:"auth_mode"`
-	ServerName                string   `yaml:"server_name"`
-	RateLimitRPS              int      `yaml:"rate_limit_rps"`
-	RateLimitBurst            int      `yaml:"rate_limit_burst"`
-	TrustedProxies            []string `yaml:"trusted_proxies"`
-	PathExcludes              []string `yaml:"path_excludes"`
-	SecretPatterns            []string `yaml:"secret_patterns"`
-	MistralBaseURL            string   `yaml:"mistral_base_url"`
-	MistralMaxOCRPayloadBytes int      `yaml:"mistral_max_ocr_payload_bytes"`
-	DoclingCommand            string   `yaml:"docling_command"`
+	RootDir         string   `yaml:"root_dir"`
+	StateDir        string   `yaml:"state_dir"`
+	ListenAddr      string   `yaml:"listen_addr"`
+	MCPPath         string   `yaml:"mcp_path"`
+	ProtocolVersion string   `yaml:"protocol_version"`
+	Public          bool     `yaml:"public"`
+	AuthMode        string   `yaml:"auth_mode"`
+	ServerName      string   `yaml:"server_name"`
+	RateLimitRPS    int      `yaml:"rate_limit_rps"`
+	RateLimitBurst  int      `yaml:"rate_limit_burst"`
+	TrustedProxies  []string `yaml:"trusted_proxies"`
+	PathExcludes    []string `yaml:"path_excludes"`
+	SecretPatterns  []string `yaml:"secret_patterns"`
+	DoclingCommand  string   `yaml:"docling_command"`
 	// optional session timeouts expressed as YAML duration strings
 	SessionInactivityTimeout time.Duration `yaml:"session_inactivity_timeout"`
 	SessionMaxLifetime       time.Duration `yaml:"session_max_lifetime"`
@@ -281,9 +251,6 @@ type persistedConfig struct {
 	ElevenLabsBaseURL         string   `yaml:"elevenlabs_base_url"`
 	ElevenLabsTTSVoiceID      string   `yaml:"elevenlabs_tts_voice_id"`
 	AllowedOrigins            []string `yaml:"allowed_origins"`
-	EmbedModelText            string   `yaml:"embed_model_text"`
-	EmbedModelCode            string   `yaml:"embed_model_code"`
-	ChatModel                 string   `yaml:"chat_model"`
 	RAGSystemPrompt           string   `yaml:"rag_system_prompt"`
 	RAGGenerateAnswer         bool     `yaml:"rag_generate_answer"`
 	RAGKDefault               int      `yaml:"rag_k_default"`
@@ -370,8 +337,6 @@ func Default() Config {
 			`(?i)token\s*[:=]\s*[A-Za-z0-9_.-]{20,}`,
 			`sk_[a-z0-9]{32}|api_[A-Za-z0-9]{32}`,
 		},
-		MistralAPIKey:        "",
-		MistralBaseURL:       "",
 		ElevenLabsAPIKey:     "",
 		ElevenLabsBaseURL:    "",
 		ElevenLabsTTSVoiceID: "JBFqnCBsd6RMkjVDRZzb",
@@ -379,10 +344,6 @@ func Default() Config {
 			"http://localhost",
 			"http://127.0.0.1",
 		},
-		// default embedding models
-		EmbedModelText:         "mistral-embed",
-		EmbedModelCode:         "codestral-embed",
-		ChatModel:              mistral.DefaultChatModel,
 		RAGSystemPrompt:        "",
 		RAGGenerateAnswer:      true,
 		RAGKDefault:            10,
@@ -457,8 +418,6 @@ func buildPersistedConfig(cfg *Config) persistedConfig {
 		TrustedProxies:            append([]string(nil), cfg.TrustedProxies...),
 		PathExcludes:              append([]string(nil), cfg.PathExcludes...),
 		SecretPatterns:            append([]string(nil), cfg.SecretPatterns...),
-		MistralBaseURL:            cfg.MistralBaseURL,
-		MistralMaxOCRPayloadBytes: cfg.MistralMaxOCRPayloadBytes,
 		DoclingCommand:            cfg.DoclingCommand,
 		SessionInactivityTimeout:  cfg.SessionInactivityTimeout,
 		SessionMaxLifetime:        cfg.SessionMaxLifetime,
@@ -466,9 +425,6 @@ func buildPersistedConfig(cfg *Config) persistedConfig {
 		ElevenLabsBaseURL:         cfg.ElevenLabsBaseURL,
 		ElevenLabsTTSVoiceID:      cfg.ElevenLabsTTSVoiceID,
 		AllowedOrigins:            append([]string(nil), cfg.AllowedOrigins...),
-		EmbedModelText:            cfg.EmbedModelText,
-		EmbedModelCode:            cfg.EmbedModelCode,
-		ChatModel:                 cfg.ChatModel,
 		RAGSystemPrompt:           cfg.RAGSystemPrompt,
 		RAGGenerateAnswer:         cfg.RAGGenerateAnswer,
 		RAGKDefault:               cfg.RAGKDefault,
@@ -624,7 +580,6 @@ func appendSnapshotSecretSourceMetadata(raw []byte, sources SecretSourceMetadata
 		key   string
 		value string
 	}{
-		{key: "mistral_api_key", value: strings.TrimSpace(sources.MistralAPIKey)},
 		{key: "elevenlabs_api_key", value: strings.TrimSpace(sources.ElevenLabsAPIKey)},
 		{key: "cohere_api_key", value: strings.TrimSpace(sources.CohereAPIKey)},
 		{key: "x402_facilitator_token", value: strings.TrimSpace(sources.X402FacilitatorToken)},
@@ -685,8 +640,6 @@ func parseSecretSourceMetadata(raw []byte) (SecretSourceMetadata, error) {
 
 func applySecretSourceField(meta *SecretSourceMetadata, key, value string) {
 	switch key {
-	case "secret_sources.mistral_api_key":
-		meta.MistralAPIKey = value
 	case "secret_sources.elevenlabs_api_key":
 		meta.ElevenLabsAPIKey = value
 	case "secret_sources.cohere_api_key":
@@ -881,17 +834,8 @@ func applyRerankFileParsed(cfg *Config, fc fileConfig) {
 }
 
 func applyModelClientsFileParsed(cfg *Config, fc fileConfig) {
-	if fc.MistralBaseURL != nil {
-		cfg.MistralBaseURL = *fc.MistralBaseURL
-	}
-	if fc.MistralMaxOCRPayloadBytes != nil {
-		cfg.MistralMaxOCRPayloadBytes = *fc.MistralMaxOCRPayloadBytes
-	}
 	if fc.DoclingCommand != nil {
 		cfg.DoclingCommand = *fc.DoclingCommand
-	}
-	if fc.MistralAPIKey != nil {
-		cfg.MistralAPIKey = *fc.MistralAPIKey
 	}
 	if fc.ElevenLabsBaseURL != nil {
 		cfg.ElevenLabsBaseURL = *fc.ElevenLabsBaseURL
@@ -901,15 +845,6 @@ func applyModelClientsFileParsed(cfg *Config, fc fileConfig) {
 	}
 	if fc.ElevenLabsTTSVoiceID != nil {
 		cfg.ElevenLabsTTSVoiceID = *fc.ElevenLabsTTSVoiceID
-	}
-	if fc.EmbedModelText != nil {
-		cfg.EmbedModelText = *fc.EmbedModelText
-	}
-	if fc.EmbedModelCode != nil {
-		cfg.EmbedModelCode = *fc.EmbedModelCode
-	}
-	if fc.ChatModel != nil {
-		cfg.ChatModel = *fc.ChatModel
 	}
 }
 
@@ -1195,15 +1130,8 @@ var configKeyAliases = map[string]string{
 	"security.allowed_origins":             "allowed_origins",
 	"security.path_excludes":               "path_excludes",
 	"security.secret_patterns":             "secret_patterns",
-	"mistral.embed_text_model":             "embed_model_text",
-	"mistral.embed_code_model":             "embed_model_code",
-	"mistral.chat_model":                   "chat_model",
-	"mistral.max_ocr_payload_bytes":        "mistral_max_ocr_payload_bytes",
 	"docling.command":                      "docling_command",
 	"ingest.docling.command":               "docling_command",
-	"mistral.api_key":                      "mistral_api_key",
-	"stt.mistral.api_key":                  "mistral_api_key",
-	"secrets.mistral_api_key":              "mistral_api_key",
 	"stt.elevenlabs.api_key":               "elevenlabs_api_key",
 	"secrets.elevenlabs_api_key":           "elevenlabs_api_key",
 	"secrets.x402_facilitator_url":         "x402_facilitator_url",
@@ -1352,8 +1280,6 @@ func setIntFileScalar(cfg *fileConfig, key, value string) error {
 		target = &cfg.ChunkingOverlapTokens
 	case "ingest.max_file_mb":
 		target = &cfg.IngestMaxFileMB
-	case "mistral_max_ocr_payload_bytes":
-		target = &cfg.MistralMaxOCRPayloadBytes
 	case "rerank.candidate_pool":
 		target = &cfg.RerankCandidatePool
 	default:
@@ -1444,22 +1370,12 @@ func setModelStringFileScalar(cfg *fileConfig, key, value string) {
 		return
 	}
 	switch key {
-	case "mistral_base_url":
-		cfg.MistralBaseURL = strPtr(value)
-	case "mistral_api_key":
-		cfg.MistralAPIKey = strPtr(value)
 	case "elevenlabs_base_url":
 		cfg.ElevenLabsBaseURL = strPtr(value)
 	case "elevenlabs_api_key":
 		cfg.ElevenLabsAPIKey = strPtr(value)
 	case "elevenlabs_tts_voice_id":
 		cfg.ElevenLabsTTSVoiceID = strPtr(value)
-	case "embed_model_text":
-		cfg.EmbedModelText = strPtr(value)
-	case "embed_model_code":
-		cfg.EmbedModelCode = strPtr(value)
-	case "chat_model":
-		cfg.ChatModel = strPtr(value)
 	case "docling_command":
 		cfg.DoclingCommand = strPtr(value)
 	case "rag.system_prompt":
@@ -1592,8 +1508,6 @@ func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	writeList("trusted_proxies", cfg.TrustedProxies)
 	writeList("path_excludes", cfg.PathExcludes)
 	writeList("secret_patterns", cfg.SecretPatterns)
-	writeScalar("mistral_base_url", cfg.MistralBaseURL)
-	writeInt("mistral_max_ocr_payload_bytes", cfg.MistralMaxOCRPayloadBytes)
 	writeScalar("docling_command", cfg.DoclingCommand)
 	writeScalar("session_inactivity_timeout", cfg.SessionInactivityTimeout.String())
 	writeScalar("session_max_lifetime", cfg.SessionMaxLifetime.String())
@@ -1601,9 +1515,6 @@ func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	writeScalar("elevenlabs_base_url", cfg.ElevenLabsBaseURL)
 	writeScalar("elevenlabs_tts_voice_id", cfg.ElevenLabsTTSVoiceID)
 	writeList("allowed_origins", cfg.AllowedOrigins)
-	writeScalar("embed_model_text", cfg.EmbedModelText)
-	writeScalar("embed_model_code", cfg.EmbedModelCode)
-	writeScalar("chat_model", cfg.ChatModel)
 	writeBool("rag_generate_answer", cfg.RAGGenerateAnswer)
 	writeInt("rag_k_default", cfg.RAGKDefault)
 	writeScalar("rag_system_prompt", cfg.RAGSystemPrompt)
@@ -1676,7 +1587,7 @@ func applyEnvOverrides(cfg *Config, overrideEnv map[string]string) {
 	if raw, ok := envLookup("DIR2MCP_SERVER_NAME", overrideEnv); ok {
 		cfg.ServerName = strings.TrimSpace(raw)
 	}
-	applyMistralEnvOverrides(cfg, overrideEnv)
+	applyIngestEnvOverrides(cfg, overrideEnv)
 	applyElevenLabsEnvOverrides(cfg, overrideEnv)
 	applyRerankEnvOverrides(cfg, overrideEnv)
 	applyNetworkEnvOverrides(cfg, overrideEnv)
@@ -1705,23 +1616,13 @@ func applyRerankEnvOverrides(cfg *Config, env map[string]string) {
 	}
 }
 
-func applyMistralEnvOverrides(cfg *Config, env map[string]string) {
-	if apiKey, ok := envLookup("MISTRAL_API_KEY", env); ok && strings.TrimSpace(apiKey) != "" {
-		cfg.MistralAPIKey = apiKey
-	}
-	if baseURL, ok := envLookup("MISTRAL_BASE_URL", env); ok && strings.TrimSpace(baseURL) != "" {
-		cfg.MistralBaseURL = baseURL
-	}
-	applyMistralNumericEnvOverrides(cfg, env)
-	applyMistralModelEnvOverrides(cfg, env)
-}
-
-func applyMistralNumericEnvOverrides(cfg *Config, env map[string]string) {
-	if raw, ok := envLookup("DIR2MCP_MISTRAL_MAX_OCR_PAYLOAD_BYTES", env); ok {
-		if n, err := strconv.Atoi(strings.TrimSpace(raw)); err == nil && n > 0 {
-			cfg.MistralMaxOCRPayloadBytes = n
-		}
-	}
+// applyIngestEnvOverrides applies the ingest-related env overrides.
+// Mistral provider credentials/models are no longer flat config: the
+// MISTRAL_API_KEY env var is consumed by the built-in `mistral`/
+// `mistral-ocr` profiles via their ${MISTRAL_API_KEY} placeholder
+// (expanded at resolution time); base URL / model overrides go through
+// providers:/model: in .dir2mcp.yaml.
+func applyIngestEnvOverrides(cfg *Config, env map[string]string) {
 	if raw, ok := envLookup("DIR2MCP_DOCLING_COMMAND", env); ok && strings.TrimSpace(raw) != "" {
 		cfg.DoclingCommand = strings.TrimSpace(raw)
 	}
@@ -1732,18 +1633,6 @@ func applyMistralNumericEnvOverrides(cfg *Config, env map[string]string) {
 		if parsed, err := strconv.ParseBool(strings.TrimSpace(raw)); err == nil {
 			cfg.RetrievalHybridEnabled = parsed
 		}
-	}
-}
-
-func applyMistralModelEnvOverrides(cfg *Config, env map[string]string) {
-	if m, ok := envLookup("DIR2MCP_EMBED_MODEL_TEXT", env); ok && strings.TrimSpace(m) != "" {
-		cfg.EmbedModelText = strings.TrimSpace(m)
-	}
-	if m, ok := envLookup("DIR2MCP_EMBED_MODEL_CODE", env); ok && strings.TrimSpace(m) != "" {
-		cfg.EmbedModelCode = strings.TrimSpace(m)
-	}
-	if m, ok := envLookup("DIR2MCP_CHAT_MODEL", env); ok && strings.TrimSpace(m) != "" {
-		cfg.ChatModel = strings.TrimSpace(m)
 	}
 }
 

--- a/internal/config/providers.go
+++ b/internal/config/providers.go
@@ -352,12 +352,6 @@ func (cfg Config) Providers() ProviderResolution {
 	return cfg.providersDoc.resolve(base, nil)
 }
 
-// seedLegacy overlays the spec-retained flat stt:/rerank: config
-// (SPEC 0.7.0 §16.2 retains these shapes) onto the built-in profiles
-// so the resolver honors them. The monolithic mistral chat/embed
-// surface was removed in the clean break (C2-iii); only the
-// STT/rerank-relevant settings are bridged here. User `providers:`
-// entries still take precedence (merged on top of this seed).
 func litStr(s string) *string { return &s }
 
 func setStr(dst *string, v string) {
@@ -366,6 +360,12 @@ func setStr(dst *string, v string) {
 	}
 }
 
+// seedLegacy overlays the spec-retained flat stt:/rerank: config
+// (SPEC 0.7.0 §16.2 retains these shapes) onto the built-in profiles
+// so the resolver honors them. The monolithic mistral chat/embed
+// surface was removed in the clean break (C2-iii); only the
+// STT/rerank-relevant settings are bridged here. User `providers:`
+// entries still take precedence (merged on top of this seed).
 func seedLegacy(m map[string]providerProfileYAML, cfg Config) {
 	seed := func(name string, fn func(*providerProfileYAML)) {
 		if p, ok := m[name]; ok {

--- a/internal/config/providers.go
+++ b/internal/config/providers.go
@@ -352,11 +352,12 @@ func (cfg Config) Providers() ProviderResolution {
 	return cfg.providersDoc.resolve(base, nil)
 }
 
-// seedLegacy overlays already-loaded legacy flat config onto the
-// built-in profiles so file-based legacy configs keep working through
-// the new resolver during the transition. User `providers:` entries
-// still take precedence (merged on top of this seed). The legacy fields
-// themselves are removed in the clean-break C2-iii.
+// seedLegacy overlays the spec-retained flat stt:/rerank: config
+// (SPEC 0.7.0 §16.2 retains these shapes) onto the built-in profiles
+// so the resolver honors them. The monolithic mistral chat/embed
+// surface was removed in the clean break (C2-iii); only the
+// STT/rerank-relevant settings are bridged here. User `providers:`
+// entries still take precedence (merged on top of this seed).
 func litStr(s string) *string { return &s }
 
 func setStr(dst *string, v string) {
@@ -372,27 +373,19 @@ func seedLegacy(m map[string]providerProfileYAML, cfg Config) {
 			m[name] = p
 		}
 	}
-	seed("mistral", func(p *providerProfileYAML) { seedMistralChatEmbed(p, cfg) })
+	// The monolithic `mistral` chat/embed profile is fully removed
+	// config (clean break): its credential resolves via the built-in
+	// ${MISTRAL_API_KEY} placeholder or an explicit providers: entry.
 	seed("mistral-ocr", func(p *providerProfileYAML) { seedMistralOCR(p, cfg) })
 	seed("cohere", func(p *providerProfileYAML) { seedCohere(p, cfg) })
 	seed("elevenlabs", func(p *providerProfileYAML) { seedElevenLabs(p, cfg) })
 }
 
-func seedMistralChatEmbed(p *providerProfileYAML, cfg Config) {
-	if cfg.MistralAPIKey != "" {
-		p.APIKey = litStr(cfg.MistralAPIKey)
-	}
-	setStr(&p.BaseURL, cfg.MistralBaseURL)
-	setStr(&p.EmbedTextModel, cfg.EmbedModelText)
-	setStr(&p.EmbedCodeModel, cfg.EmbedModelCode)
-	setStr(&p.ChatModel, cfg.ChatModel)
-}
-
+// seedMistralOCR bridges only the spec-retained Mistral STT model
+// (stt.mistral.model, §16.2) onto the mistral-ocr profile. The
+// credential and base URL are no longer flat config — the profile
+// keeps its built-in ${MISTRAL_API_KEY} / default base URL.
 func seedMistralOCR(p *providerProfileYAML, cfg Config) {
-	if cfg.MistralAPIKey != "" {
-		p.APIKey = litStr(cfg.MistralAPIKey)
-	}
-	setStr(&p.BaseURL, cfg.MistralBaseURL)
 	setStr(&p.STTModel, cfg.STTMistralModel)
 }
 

--- a/internal/config/providers.go
+++ b/internal/config/providers.go
@@ -352,8 +352,13 @@ func (cfg Config) Providers() ProviderResolution {
 	return cfg.providersDoc.resolve(base, nil)
 }
 
+// litStr returns a pointer to s, used to set a providerProfileYAML
+// api_key to a concrete literal (distinct from an absent/credential-less
+// nil api_key).
 func litStr(s string) *string { return &s }
 
+// setStr overwrites *dst with v only when v is non-empty, so a blank
+// flat-config value never clobbers a built-in profile default.
 func setStr(dst *string, v string) {
 	if v != "" {
 		*dst = v
@@ -389,6 +394,8 @@ func seedMistralOCR(p *providerProfileYAML, cfg Config) {
 	setStr(&p.STTModel, cfg.STTMistralModel)
 }
 
+// seedCohere bridges the spec-retained flat rerank.cohere config
+// (api_key/base_url/model, SPEC 0.7.0 §16.2) onto the cohere profile.
 func seedCohere(p *providerProfileYAML, cfg Config) {
 	if cfg.CohereAPIKey != "" {
 		p.APIKey = litStr(cfg.CohereAPIKey)
@@ -397,6 +404,9 @@ func seedCohere(p *providerProfileYAML, cfg Config) {
 	setStr(&p.RerankModel, cfg.RerankModel)
 }
 
+// seedElevenLabs bridges the spec-retained flat stt.elevenlabs config
+// (api_key/base_url/voice/model/language, SPEC 0.7.0 §16.2) onto the
+// elevenlabs profile.
 func seedElevenLabs(p *providerProfileYAML, cfg Config) {
 	if cfg.ElevenLabsAPIKey != "" {
 		p.APIKey = litStr(cfg.ElevenLabsAPIKey)

--- a/tests/cli/up_command_test.go
+++ b/tests/cli/up_command_test.go
@@ -491,9 +491,12 @@ func TestReindexRejectsUnexpectedArguments(t *testing.T) {
 // causing the ingest service to be unaware of any environment overrides.
 func TestReindexPassesConfigToNewIngestor(t *testing.T) {
 	tmp := t.TempDir()
-	// exercise a non-default value so we can distinguish default vs loaded
-	t.Setenv("MISTRAL_API_KEY", "abc123")
-	t.Setenv("MISTRAL_BASE_URL", "https://example.local/")
+	// Exercise a non-default value so we can distinguish default vs
+	// loaded. The provider clean break (#38) removed the MISTRAL_*
+	// env→Config mapping; DIR2MCP_DOCLING_COMMAND remains a loader-applied
+	// env override and is a clean, observable proxy for "the loaded
+	// config (not config.Default()) reached the ingestor".
+	t.Setenv("DIR2MCP_DOCLING_COMMAND", "cat {input}")
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -515,11 +518,8 @@ func TestReindexPassesConfigToNewIngestor(t *testing.T) {
 		}
 	})
 
-	if seenCfg.MistralAPIKey != "abc123" {
-		t.Fatalf("config not propagated to ingestor: got api key %q", seenCfg.MistralAPIKey)
-	}
-	if seenCfg.MistralBaseURL != "https://example.local/" {
-		t.Fatalf("config not propagated to ingestor: got base url %q", seenCfg.MistralBaseURL)
+	if seenCfg.DoclingCommand != "cat {input}" {
+		t.Fatalf("config not propagated to ingestor: got docling command %q", seenCfg.DoclingCommand)
 	}
 }
 

--- a/tests/config/config_snapshot_test.go
+++ b/tests/config/config_snapshot_test.go
@@ -14,7 +14,7 @@ func TestSaveEffectiveSnapshot_RedactsSecretsAndPersistsSourceMetadata(t *testin
 	cfg := snapshotTestConfig(stateDir)
 
 	path, err := config.SaveEffectiveSnapshot(cfg, config.SecretSourceMetadata{
-		MistralAPIKey:        "env",
+		CohereAPIKey:         "env",
 		ElevenLabsAPIKey:     "keychain",
 		X402FacilitatorToken: "file",
 		AuthToken:            "session",
@@ -34,7 +34,7 @@ func TestSaveEffectiveSnapshot_RedactsSecretsAndPersistsSourceMetadata(t *testin
 func snapshotTestConfig(stateDir string) config.Config {
 	cfg := config.Default()
 	cfg.StateDir = stateDir
-	cfg.MistralAPIKey = "mistral-secret"
+	cfg.CohereAPIKey = "cohere-secret"
 	cfg.ElevenLabsAPIKey = "elevenlabs-secret"
 	cfg.X402.FacilitatorToken = "x402-secret"
 	cfg.ResolvedAuthToken = "auth-secret"
@@ -51,13 +51,13 @@ func assertSnapshotRedaction(t *testing.T, path string) {
 	}
 	text := string(raw)
 
-	if strings.Contains(text, "mistral-secret") || strings.Contains(text, "elevenlabs-secret") || strings.Contains(text, "x402-secret") || strings.Contains(text, "auth-secret") {
+	if strings.Contains(text, "cohere-secret") || strings.Contains(text, "elevenlabs-secret") || strings.Contains(text, "x402-secret") || strings.Contains(text, "auth-secret") {
 		t.Fatalf("snapshot contains plaintext secret:\n%s", text)
 	}
 	if !strings.Contains(text, "secret_sources:") {
 		t.Fatalf("snapshot missing secret_sources block:\n%s", text)
 	}
-	if !strings.Contains(text, "mistral_api_key: env") || !strings.Contains(text, "auth_token: session") {
+	if !strings.Contains(text, "cohere_api_key: env") || !strings.Contains(text, "auth_token: session") {
 		t.Fatalf("snapshot missing expected source metadata:\n%s", text)
 	}
 }
@@ -74,10 +74,10 @@ func assertSnapshotRoundtrip(t *testing.T, path string) {
 	if loadedCfg.ServerTLSCertFile != "/tls/cert.pem" {
 		t.Fatalf("ServerTLSCertFile=%q", loadedCfg.ServerTLSCertFile)
 	}
-	if loadedCfg.MistralAPIKey != "" || loadedCfg.ElevenLabsAPIKey != "" || loadedCfg.X402.FacilitatorToken != "" || loadedCfg.ResolvedAuthToken != "" {
+	if loadedCfg.CohereAPIKey != "" || loadedCfg.ElevenLabsAPIKey != "" || loadedCfg.X402.FacilitatorToken != "" || loadedCfg.ResolvedAuthToken != "" {
 		t.Fatalf("loaded snapshot should not hydrate secret values")
 	}
-	if loadedSources.MistralAPIKey != "env" || loadedSources.ElevenLabsAPIKey != "keychain" || loadedSources.X402FacilitatorToken != "file" || loadedSources.AuthToken != "session" {
+	if loadedSources.CohereAPIKey != "env" || loadedSources.ElevenLabsAPIKey != "keychain" || loadedSources.X402FacilitatorToken != "file" || loadedSources.AuthToken != "session" {
 		t.Fatalf("unexpected loaded sources: %+v", loadedSources)
 	}
 }
@@ -89,7 +89,7 @@ func TestLoadEffectiveSnapshot_ReadsNestedSecretSourceMetadata(t *testing.T) {
 		"state_dir: /tmp/state\n"+
 		"rag.max_context_chars: 4321\n"+
 		"secret_sources:\n"+
-		"  mistral_api_key: env\n"+
+		"  cohere_api_key: env\n"+
 		"  elevenlabs_api_key: file\n")
 
 	cfg, sources, err := config.LoadEffectiveSnapshot(path)
@@ -99,7 +99,7 @@ func TestLoadEffectiveSnapshot_ReadsNestedSecretSourceMetadata(t *testing.T) {
 	if cfg.RAGMaxContextChars != 4321 {
 		t.Fatalf("RAGMaxContextChars=%d", cfg.RAGMaxContextChars)
 	}
-	if sources.MistralAPIKey != "env" || sources.ElevenLabsAPIKey != "file" {
+	if sources.CohereAPIKey != "env" || sources.ElevenLabsAPIKey != "file" {
 		t.Fatalf("unexpected source metadata: %+v", sources)
 	}
 }

--- a/tests/config/config_test.go
+++ b/tests/config/config_test.go
@@ -8,61 +8,50 @@ import (
 	"time"
 
 	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/provider"
 	"github.com/dirstral/dir2mcp/tests/testutil"
 )
 
-func TestLoad_UsesDotEnvWhenEnvIsMissing(t *testing.T) {
-	tmp := t.TempDir()
-	writeFile(t, filepath.Join(tmp, ".env"), "MISTRAL_API_KEY=from_dotenv\nMISTRAL_BASE_URL=https://dotenv.local\n")
-
+// resolvedEmbedAPIKey loads via config.Load (which applies dotenv into
+// the process env) and returns the credential the provider resolver
+// expands for the built-in mistral profile's ${MISTRAL_API_KEY}
+// placeholder. Post clean-break (#38) the Mistral credential is no
+// longer a Config field — dotenv/env feeds the resolver, not Config.
+func resolvedEmbedAPIKey(t *testing.T, tmp string) string {
+	t.Helper()
+	var key string
 	testutil.WithWorkingDir(t, tmp, func() {
-		t.Setenv("MISTRAL_API_KEY", "")
-		t.Setenv("MISTRAL_BASE_URL", "")
 		cfg, err := config.Load("")
 		if err != nil {
 			t.Fatalf("Load failed: %v", err)
 		}
-		if cfg.MistralAPIKey != "from_dotenv" {
-			t.Fatalf("unexpected api key: %q", cfg.MistralAPIKey)
+		p, err := cfg.Providers().Resolve(provider.CapEmbed)
+		if err != nil {
+			t.Fatalf("resolve embed: %v", err)
 		}
-		if cfg.MistralBaseURL != "https://dotenv.local" {
-			t.Fatalf("unexpected base URL: %q", cfg.MistralBaseURL)
-		}
+		key = p.APIKey
 	})
+	return key
+}
+
+func TestLoad_UsesDotEnvWhenEnvIsMissing(t *testing.T) {
+	tmp := t.TempDir()
+	writeFile(t, filepath.Join(tmp, ".env"), "MISTRAL_API_KEY=from_dotenv\n")
+
+	t.Setenv("MISTRAL_API_KEY", "")
+	if got := resolvedEmbedAPIKey(t, tmp); got != "from_dotenv" {
+		t.Fatalf("unexpected resolved api key: %q", got)
+	}
 }
 
 func TestLoad_EnvOverridesDotEnv(t *testing.T) {
 	tmp := t.TempDir()
-	writeFile(t, filepath.Join(tmp, ".env"), "MISTRAL_API_KEY=from_dotenv\nMISTRAL_BASE_URL=https://dotenv.local\n")
+	writeFile(t, filepath.Join(tmp, ".env"), "MISTRAL_API_KEY=from_dotenv\n")
 
-	testutil.WithWorkingDir(t, tmp, func() {
-		t.Setenv("MISTRAL_API_KEY", "from_env")
-		t.Setenv("MISTRAL_BASE_URL", "https://env.local")
-		cfg, err := config.Load("")
-		if err != nil {
-			t.Fatalf("Load failed: %v", err)
-		}
-		if cfg.MistralAPIKey != "from_env" {
-			t.Fatalf("unexpected api key: %q", cfg.MistralAPIKey)
-		}
-		if cfg.MistralBaseURL != "https://env.local" {
-			t.Fatalf("unexpected base URL: %q", cfg.MistralBaseURL)
-		}
-	})
-}
-
-func TestLoad_MistralMaxOCRPayloadBytes_FromEnv(t *testing.T) {
-	tmp := t.TempDir()
-	testutil.WithWorkingDir(t, tmp, func() {
-		t.Setenv("DIR2MCP_MISTRAL_MAX_OCR_PAYLOAD_BYTES", "26214400")
-		cfg, err := config.Load("")
-		if err != nil {
-			t.Fatalf("Load failed: %v", err)
-		}
-		if cfg.MistralMaxOCRPayloadBytes != 26214400 {
-			t.Fatalf("unexpected mistral max ocr payload bytes: %d", cfg.MistralMaxOCRPayloadBytes)
-		}
-	})
+	t.Setenv("MISTRAL_API_KEY", "from_env")
+	if got := resolvedEmbedAPIKey(t, tmp); got != "from_env" {
+		t.Fatalf("unexpected resolved api key: %q", got)
+	}
 }
 
 func TestConfigValidateRejectsInvalidIngestExtractor(t *testing.T) {
@@ -75,23 +64,13 @@ func TestConfigValidateRejectsInvalidIngestExtractor(t *testing.T) {
 
 func TestLoad_DotEnvLocalOverridesDotEnv(t *testing.T) {
 	tmp := t.TempDir()
-	writeFile(t, filepath.Join(tmp, ".env"), "MISTRAL_API_KEY=from_env_file\nMISTRAL_BASE_URL=https://env-file.local\n")
-	writeFile(t, filepath.Join(tmp, ".env.local"), "MISTRAL_API_KEY=from_env_local\nMISTRAL_BASE_URL=https://env-local.local\n")
+	writeFile(t, filepath.Join(tmp, ".env"), "MISTRAL_API_KEY=from_env_file\n")
+	writeFile(t, filepath.Join(tmp, ".env.local"), "MISTRAL_API_KEY=from_env_local\n")
 
-	testutil.WithWorkingDir(t, tmp, func() {
-		t.Setenv("MISTRAL_API_KEY", "")
-		t.Setenv("MISTRAL_BASE_URL", "")
-		cfg, err := config.Load("")
-		if err != nil {
-			t.Fatalf("Load failed: %v", err)
-		}
-		if cfg.MistralAPIKey != "from_env_local" {
-			t.Fatalf("unexpected api key: %q", cfg.MistralAPIKey)
-		}
-		if cfg.MistralBaseURL != "https://env-local.local" {
-			t.Fatalf("unexpected base URL: %q", cfg.MistralBaseURL)
-		}
-	})
+	t.Setenv("MISTRAL_API_KEY", "")
+	if got := resolvedEmbedAPIKey(t, tmp); got != "from_env_local" {
+		t.Fatalf("unexpected resolved api key: %q", got)
+	}
 }
 
 func TestLoad_UsesDotEnvWhenEnvIsMissing_ElevenLabs(t *testing.T) {
@@ -635,38 +614,46 @@ func TestDefault_RateLimitValues(t *testing.T) {
 	}
 }
 
+// Post clean-break (#38) the embed model names are profile config
+// (built-in mistral defaults; overridable via model.embed.* per SPEC
+// §16.2), not Config fields. Resolve through the provider resolver.
 func TestDefault_EmbedModels(t *testing.T) {
-	cfg := config.Default()
-	if cfg.EmbedModelText != "mistral-embed" {
-		t.Fatalf("unexpected default text embed model: %q", cfg.EmbedModelText)
+	t.Setenv("MISTRAL_API_KEY", "k")
+	p, err := loadCfg(t, "version: 1\n").Providers().Resolve(provider.CapEmbed)
+	if err != nil {
+		t.Fatalf("resolve embed: %v", err)
 	}
-	if cfg.EmbedModelCode != "codestral-embed" {
-		t.Fatalf("unexpected default code embed model: %q", cfg.EmbedModelCode)
+	if p.EmbedTextModel != "mistral-embed" {
+		t.Fatalf("unexpected default text embed model: %q", p.EmbedTextModel)
+	}
+	if p.EmbedCodeModel != "codestral-embed" {
+		t.Fatalf("unexpected default code embed model: %q", p.EmbedCodeModel)
 	}
 }
 
-func TestLoad_EnvOverridesEmbedModels(t *testing.T) {
-	tmp := t.TempDir()
-	testutil.WithWorkingDir(t, tmp, func() {
-		t.Setenv("DIR2MCP_EMBED_MODEL_TEXT", "foo-model")
-		t.Setenv("DIR2MCP_EMBED_MODEL_CODE", "bar-model")
-		cfg, err := config.Load("")
-		if err != nil {
-			t.Fatalf("Load failed: %v", err)
-		}
-		if cfg.EmbedModelText != "foo-model" {
-			t.Fatalf("unexpected embed model text: %q", cfg.EmbedModelText)
-		}
-		if cfg.EmbedModelCode != "bar-model" {
-			t.Fatalf("unexpected embed model code: %q", cfg.EmbedModelCode)
-		}
-	})
+func TestModel_OverridesEmbedModels(t *testing.T) {
+	t.Setenv("MISTRAL_API_KEY", "k")
+	yaml := "model:\n  embed:\n    text_model: foo-model\n    code_model: bar-model\n"
+	p, err := loadCfg(t, yaml).Providers().Resolve(provider.CapEmbed)
+	if err != nil {
+		t.Fatalf("resolve embed: %v", err)
+	}
+	if p.EmbedTextModel != "foo-model" {
+		t.Fatalf("unexpected embed model text: %q", p.EmbedTextModel)
+	}
+	if p.EmbedCodeModel != "bar-model" {
+		t.Fatalf("unexpected embed model code: %q", p.EmbedCodeModel)
+	}
 }
 
 func TestDefault_ChatModel(t *testing.T) {
-	cfg := config.Default()
-	if cfg.ChatModel != "mistral-small-2506" {
-		t.Fatalf("unexpected default chat model: %q", cfg.ChatModel)
+	t.Setenv("MISTRAL_API_KEY", "k")
+	p, err := loadCfg(t, "version: 1\n").Providers().Resolve(provider.CapChat)
+	if err != nil {
+		t.Fatalf("resolve chat: %v", err)
+	}
+	if p.ChatModel != "mistral-small-2506" {
+		t.Fatalf("unexpected default chat model: %q", p.ChatModel)
 	}
 }
 
@@ -752,18 +739,16 @@ func TestLoad_RejectsNegativeRAGAndChunkingTunables(t *testing.T) {
 	}
 }
 
-func TestLoad_EnvOverridesChatModel(t *testing.T) {
-	tmp := t.TempDir()
-	testutil.WithWorkingDir(t, tmp, func() {
-		t.Setenv("DIR2MCP_CHAT_MODEL", "new-chat")
-		cfg, err := config.Load("")
-		if err != nil {
-			t.Fatalf("Load failed: %v", err)
-		}
-		if cfg.ChatModel != "new-chat" {
-			t.Fatalf("unexpected chat model: %q", cfg.ChatModel)
-		}
-	})
+func TestModel_OverridesChatModel(t *testing.T) {
+	t.Setenv("MISTRAL_API_KEY", "k")
+	yaml := "model:\n  chat:\n    model: new-chat\n"
+	p, err := loadCfg(t, yaml).Providers().Resolve(provider.CapChat)
+	if err != nil {
+		t.Fatalf("resolve chat: %v", err)
+	}
+	if p.ChatModel != "new-chat" {
+		t.Fatalf("unexpected chat model: %q", p.ChatModel)
+	}
 }
 
 func TestLoad_RateLimitEnvOverrides(t *testing.T) {

--- a/tests/config/config_yaml_test.go
+++ b/tests/config/config_yaml_test.go
@@ -54,32 +54,21 @@ func TestLoadFile_ReadsYAMLValues(t *testing.T) {
 func TestLoad_FileThenEnvOverridesYAML(t *testing.T) {
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, ".dir2mcp.yaml")
-	writeFile(t, path, ""+
-		"mistral_base_url: https://yaml.example\n"+
-		"mistral_max_ocr_payload_bytes: 111\n"+
-		"embed_model_text: yaml-embed\n")
+	// The Mistral flat keys / DIR2MCP_* model env vars were removed in
+	// the provider clean break (#38); docling_command remains a flat
+	// YAML key whose DIR2MCP_DOCLING_COMMAND env override still applies,
+	// so it exercises the same file-then-env precedence path.
+	writeFile(t, path, "docling_command: yaml-docling {input}\n")
 
 	testutil.WithWorkingDir(t, tmp, func() {
-		t.Setenv("MISTRAL_BASE_URL", "https://env.example")
-		t.Setenv("DIR2MCP_MISTRAL_MAX_OCR_PAYLOAD_BYTES", "222")
-		t.Setenv("DIR2MCP_EMBED_MODEL_TEXT", "env-embed")
-		t.Setenv("DIR2MCP_DOCLING_COMMAND", "docling --to md --output - {input}")
+		t.Setenv("DIR2MCP_DOCLING_COMMAND", "env-docling {input}")
 
 		cfg, err := config.Load(".dir2mcp.yaml")
 		if err != nil {
 			t.Fatalf("Load failed: %v", err)
 		}
-		if cfg.MistralBaseURL != "https://env.example" {
-			t.Fatalf("MistralBaseURL=%q want=%q", cfg.MistralBaseURL, "https://env.example")
-		}
-		if cfg.EmbedModelText != "env-embed" {
-			t.Fatalf("EmbedModelText=%q want=%q", cfg.EmbedModelText, "env-embed")
-		}
-		if cfg.MistralMaxOCRPayloadBytes != 222 {
-			t.Fatalf("MistralMaxOCRPayloadBytes=%d want=%d", cfg.MistralMaxOCRPayloadBytes, 222)
-		}
-		if cfg.DoclingCommand != "docling --to md --output - {input}" {
-			t.Fatalf("DoclingCommand=%q", cfg.DoclingCommand)
+		if cfg.DoclingCommand != "env-docling {input}" {
+			t.Fatalf("DoclingCommand=%q want env override of YAML", cfg.DoclingCommand)
 		}
 	})
 }
@@ -91,8 +80,7 @@ func TestSaveFile_WritesNonSecretYAML(t *testing.T) {
 	cfg := config.Default()
 	cfg.RootDir = "/tmp/repo"
 	cfg.StateDir = "/tmp/repo/.dir2mcp"
-	cfg.MistralMaxOCRPayloadBytes = 26214400
-	cfg.MistralAPIKey = "super-secret"
+	cfg.DoclingCommand = "docling --to md - {input}"
 	cfg.ElevenLabsAPIKey = "another-secret"
 	cfg.AllowedOrigins = []string{"http://localhost", "https://example.com"}
 
@@ -108,16 +96,13 @@ func TestSaveFile_WritesNonSecretYAML(t *testing.T) {
 	if !strings.Contains(text, "root_dir: /tmp/repo") {
 		t.Fatalf("saved yaml missing root_dir, got:\n%s", text)
 	}
-	if !strings.Contains(text, "mistral_max_ocr_payload_bytes: 26214400") {
-		t.Fatalf("saved yaml missing mistral_max_ocr_payload_bytes, got:\n%s", text)
-	}
 	if !strings.Contains(text, "docling_command:") {
 		t.Fatalf("saved yaml missing docling_command, got:\n%s", text)
 	}
-	if strings.Contains(strings.ToLower(text), "mistral_api_key") {
-		t.Fatalf("saved yaml must not include MISTRAL_API_KEY key, got:\n%s", text)
+	if strings.Contains(strings.ToLower(text), "elevenlabs_api_key") {
+		t.Fatalf("saved yaml must not include the ELEVENLABS_API_KEY key, got:\n%s", text)
 	}
-	if strings.Contains(text, "super-secret") || strings.Contains(text, "another-secret") {
+	if strings.Contains(text, "another-secret") {
 		t.Fatalf("saved yaml must not include secret values, got:\n%s", text)
 	}
 }
@@ -209,7 +194,6 @@ func TestLoadFile_ReadsNestedSpecStyleKeys(t *testing.T) {
 		"    cert_file: /tmp/cert.pem\n"+
 		"    key_file: /tmp/key.pem\n"+
 		"secrets:\n"+
-		"  mistral_api_key: nested-mistral\n"+
 		"  elevenlabs_api_key: nested-eleven\n"+
 		"  x402_facilitator_url: https://facilitator.example\n")
 
@@ -282,9 +266,6 @@ func assertNestedServerAndSecrets(t *testing.T, cfg config.Config) {
 	if cfg.ServerTLSKeyFile != "/tmp/key.pem" {
 		t.Fatalf("ServerTLSKeyFile=%q", cfg.ServerTLSKeyFile)
 	}
-	if cfg.MistralAPIKey != "nested-mistral" {
-		t.Fatalf("MistralAPIKey=%q", cfg.MistralAPIKey)
-	}
 	if cfg.ElevenLabsAPIKey != "nested-eleven" {
 		t.Fatalf("ElevenLabsAPIKey=%q", cfg.ElevenLabsAPIKey)
 	}
@@ -311,7 +292,6 @@ func TestLoadFile_FlatAliasesRemainSupportedForNestedFields(t *testing.T) {
 		"stt_mistral_model: voxtral-mini-latest\n"+
 		"stt_elevenlabs_model: scribe\n"+
 		"elevenlabs_language_code: en\n"+
-		"secrets.mistral_api_key: flat-mistral\n"+
 		"secrets.elevenlabs_api_key: flat-eleven\n"+
 		"secrets.x402_facilitator_url: https://flat-facilitator.example\n"+
 		"tls_cert_file: /etc/cert.pem\n"+
@@ -358,8 +338,8 @@ func assertFlatSTTAliases(t *testing.T, cfg config.Config) {
 
 func assertFlatSecretsAndTLSAliases(t *testing.T, cfg config.Config) {
 	t.Helper()
-	if cfg.MistralAPIKey != "flat-mistral" || cfg.ElevenLabsAPIKey != "flat-eleven" {
-		t.Fatalf("secret aliases not applied: mistral=%q eleven=%q", cfg.MistralAPIKey, cfg.ElevenLabsAPIKey)
+	if cfg.ElevenLabsAPIKey != "flat-eleven" {
+		t.Fatalf("secret alias not applied: eleven=%q", cfg.ElevenLabsAPIKey)
 	}
 	if cfg.X402.FacilitatorURL != "https://flat-facilitator.example" {
 		t.Fatalf("x402 facilitator alias not applied: %q", cfg.X402.FacilitatorURL)

--- a/tests/config/embed_identity_test.go
+++ b/tests/config/embed_identity_test.go
@@ -41,9 +41,10 @@ func TestEmbedIdentity_SnapshotRecordsAndVerifies(t *testing.T) {
 	}
 
 	// Changed embed model -> refused with a CONFIG_INVALID-class error.
-	changed := config.Default()
+	// Post clean-break (#38) the embed model name is provider config
+	// (model.embed.text_model per SPEC §16.2), not a Config field.
+	changed := loadCfg(t, "model:\n  embed:\n    text_model: some-other-embed-v9\n")
 	changed.StateDir = dir
-	changed.EmbedModelText = "some-other-embed-v9" // seeds the mistral profile
 	err = changed.VerifyEmbedIdentity(dir)
 	if err == nil || !strings.Contains(err.Error(), "CONFIG_INVALID") {
 		t.Fatalf("changed embed identity must be refused, got: %v", err)

--- a/tests/ingest/docling_extractor_test.go
+++ b/tests/ingest/docling_extractor_test.go
@@ -28,8 +28,11 @@ func TestDocumentExtractorFromConfig_PrefersDoclingCommand(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping POSIX-only command test on Windows")
 	}
+	// A Mistral credential is present (resolves the OCR profile via the
+	// built-in ${MISTRAL_API_KEY} placeholder post clean-break #38), yet
+	// the configured docling command must still take precedence.
+	t.Setenv("MISTRAL_API_KEY", "test-key")
 	cfg := config.Config{
-		MistralAPIKey:  "test-key",
 		DoclingCommand: "cat {input}",
 	}
 

--- a/tests/ingest/helpers_test.go
+++ b/tests/ingest/helpers_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -12,7 +13,9 @@ import (
 func mustNewIngestService(t *testing.T, cfg config.Config, st model.Store) *ingest.Service {
 	t.Helper()
 	provider := strings.ToLower(strings.TrimSpace(cfg.STTProvider))
-	if provider == "mistral" && strings.TrimSpace(cfg.MistralAPIKey) == "" {
+	// Post clean-break (#38) the Mistral credential resolves from env
+	// via the built-in ${MISTRAL_API_KEY} placeholder, not a Config field.
+	if provider == "mistral" && strings.TrimSpace(os.Getenv("MISTRAL_API_KEY")) == "" {
 		cfg.STTProvider = "off"
 	}
 	svc, err := ingest.NewService(cfg, st)

--- a/tests/ingest/service_test.go
+++ b/tests/ingest/service_test.go
@@ -665,9 +665,14 @@ func TestTranscriberFromConfig_ExplicitProviderRequiresCredentials(t *testing.T)
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			// Credentials resolve from env via the built-in
+			// ${MISTRAL_API_KEY}/${ELEVENLABS_API_KEY} placeholders
+			// (clean break #38). Clear them so the resolver returns a
+			// CONFIG_INVALID naming the explicitly-bound profile.
+			t.Setenv("MISTRAL_API_KEY", "")
+			t.Setenv("ELEVENLABS_API_KEY", "")
 			cfg := config.Default()
 			cfg.STTProvider = tc.provider
-			cfg.MistralAPIKey = ""
 			cfg.ElevenLabsAPIKey = ""
 
 			transcriber, err := ingest.TranscriberFromConfig(cfg)
@@ -685,9 +690,10 @@ func TestTranscriberFromConfig_ExplicitProviderRequiresCredentials(t *testing.T)
 }
 
 func TestTranscriberFromConfig_AutoProviderWithoutCredentialsReturnsNil(t *testing.T) {
+	t.Setenv("MISTRAL_API_KEY", "")
+	t.Setenv("ELEVENLABS_API_KEY", "")
 	cfg := config.Default()
 	cfg.STTProvider = "auto"
-	cfg.MistralAPIKey = ""
 	cfg.ElevenLabsAPIKey = ""
 
 	transcriber, err := ingest.TranscriberFromConfig(cfg)

--- a/tests/mcp/tools_test.go
+++ b/tests/mcp/tools_test.go
@@ -146,7 +146,6 @@ func requireRetryableAndResetBody(t *testing.T, resp *http.Response) {
 
 func TestMCPToolsCallTranscribe_ProviderFailureIsRetryable(t *testing.T) {
 	cfg, st, _ := setupMCPToolStore(t, "voice.wav", "audio", []byte("RIFF0000WAVEfmt data"))
-	cfg.MistralAPIKey = "test-key"
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/v1/audio/transcriptions" {
@@ -156,7 +155,7 @@ func TestMCPToolsCallTranscribe_ProviderFailureIsRetryable(t *testing.T) {
 		http.NotFound(w, r)
 	}))
 	defer upstream.Close()
-	cfg.MistralBaseURL = upstream.URL
+	cfg = withMistralUpstream(t, cfg, "mistral-ocr", upstream.URL)
 
 	server := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st)).Handler())
 	defer server.Close()
@@ -175,7 +174,6 @@ func TestMCPToolsCallTranscribe_ProviderFailureIsRetryable(t *testing.T) {
 
 func TestMCPToolsCallTranscribe_Success(t *testing.T) {
 	cfg, st, _ := setupMCPToolStore(t, "voice.wav", "audio", []byte("RIFF0000WAVEfmt data"))
-	cfg.MistralAPIKey = "test-key"
 	var gotLanguage string
 
 	// use a channel to propagate handler errors back to the main goroutine
@@ -196,7 +194,7 @@ func TestMCPToolsCallTranscribe_Success(t *testing.T) {
 		_, _ = io.WriteString(w, `{"segments":[{"start":1,"end":2,"text":"alpha"},{"start":3,"end":4,"text":"beta"}]}`)
 	}))
 	defer upstream.Close()
-	cfg.MistralBaseURL = upstream.URL
+	cfg = withMistralUpstream(t, cfg, "mistral-ocr", upstream.URL)
 
 	server := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st)).Handler())
 	defer server.Close()
@@ -269,7 +267,6 @@ func TestMCPToolsCallTranscribe_CreatesAudioDocWhenNotYetIndexed(t *testing.T) {
 	cfg.StateDir = stateDir
 	cfg.MCPPath = protocol.DefaultMCPPath
 	cfg.AuthMode = "none"
-	cfg.MistralAPIKey = "test-key"
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/audio/transcriptions" {
@@ -285,7 +282,7 @@ func TestMCPToolsCallTranscribe_CreatesAudioDocWhenNotYetIndexed(t *testing.T) {
 		_, _ = io.WriteString(w, `{"segments":[{"start":1,"end":2,"text":"alpha"}]}`)
 	}))
 	defer upstream.Close()
-	cfg.MistralBaseURL = upstream.URL
+	cfg = withMistralUpstream(t, cfg, "mistral-ocr", upstream.URL)
 
 	server := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st)).Handler())
 	defer server.Close()
@@ -333,7 +330,6 @@ func TestMCPToolsCallAnnotate_MissingSchema(t *testing.T) {
 
 func TestMCPToolsCallAnnotate_ProviderFailure(t *testing.T) {
 	cfg, st, _ := setupMCPToolStore(t, "note.txt", "text", []byte("alpha note"))
-	cfg.MistralAPIKey = "test-key"
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Mistral chat now routes through the OpenAI-compatible
@@ -346,7 +342,7 @@ func TestMCPToolsCallAnnotate_ProviderFailure(t *testing.T) {
 		http.NotFound(w, r)
 	}))
 	defer upstream.Close()
-	cfg.MistralBaseURL = upstream.URL
+	cfg = withMistralUpstream(t, cfg, "mistral", upstream.URL)
 
 	server := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st)).Handler())
 	defer server.Close()
@@ -359,7 +355,6 @@ func TestMCPToolsCallAnnotate_ProviderFailure(t *testing.T) {
 
 func TestMCPToolsCallAnnotate_Success(t *testing.T) {
 	cfg, st, _ := setupMCPToolStore(t, "note.txt", "text", []byte("alpha note"))
-	cfg.MistralAPIKey = "test-key"
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Mistral chat now routes through the OpenAI-compatible
@@ -374,7 +369,7 @@ func TestMCPToolsCallAnnotate_Success(t *testing.T) {
 		_, _ = io.WriteString(w, `{"choices":[{"message":{"content":"{\"summary\":\"alpha\",\"tags\":[\"x\"]}"}}]}`)
 	}))
 	defer upstream.Close()
-	cfg.MistralBaseURL = upstream.URL
+	cfg = withMistralUpstream(t, cfg, "mistral", upstream.URL)
 
 	server := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st)).Handler())
 	defer server.Close()
@@ -410,7 +405,10 @@ func TestMCPToolsCallAnnotate_Success(t *testing.T) {
 
 func TestMCPToolsCallAnnotate_PromptTooLarge(t *testing.T) {
 	cfg, st, _ := setupMCPToolStore(t, "note.txt", "text", []byte("small"))
-	cfg.MistralAPIKey = "test-key"
+	// Chat resolves to the built-in mistral profile via the env-sourced
+	// ${MISTRAL_API_KEY} placeholder (clean break #38); no upstream is
+	// hit — the prompt-size guard rejects before any provider call.
+	t.Setenv("MISTRAL_API_KEY", "test-key")
 
 	server := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st)).Handler())
 	defer server.Close()
@@ -443,7 +441,6 @@ func TestMCPToolsCallTranscribeAndAsk_MissingQuestion(t *testing.T) {
 
 func TestMCPToolsCallTranscribeAndAsk_Success(t *testing.T) {
 	cfg, st, _ := setupMCPToolStore(t, "voice.wav", "audio", []byte("RIFF0000WAVEfmt data"))
-	cfg.MistralAPIKey = "test-key"
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/audio/transcriptions" {
@@ -456,7 +453,7 @@ func TestMCPToolsCallTranscribeAndAsk_Success(t *testing.T) {
 		_, _ = io.WriteString(w, `{"segments":[{"start":1,"end":2,"text":"alpha in transcript"}]}`)
 	}))
 	defer upstream.Close()
-	cfg.MistralBaseURL = upstream.URL
+	cfg = withMistralUpstream(t, cfg, "mistral-ocr", upstream.URL)
 
 	retriever := &askAudioRetrieverStub{
 		askResult: model.AskResult{
@@ -498,6 +495,36 @@ func TestMCPToolsCallTranscribeAndAsk_Success(t *testing.T) {
 	if got := envelope.Result.StructuredContent["transcript_provider"]; got != "mistral" {
 		t.Fatalf("unexpected transcript_provider: %#v", got)
 	}
+}
+
+// withMistralUpstream rebuilds cfg so the named Mistral provider profile
+// resolves to a fake upstream server. Post clean-break (#38) the
+// credential and base URL are provider config — an env-sourced
+// ${MISTRAL_API_KEY} plus a `providers:` base_url override loaded via
+// config.LoadFile (providersDoc is unexported, set only on load) — not
+// Config fields. `profile` is:
+//   - "mistral":     OpenAI-backbone chat, POST {base}/chat/completions
+//   - "mistral-ocr": native client, POST {base}/v1/audio/transcriptions
+//
+// The runtime/programmatic fields from `base` are carried onto the
+// loaded cfg (LoadFile only knows the providers subtree + defaults).
+func withMistralUpstream(t *testing.T, base config.Config, profile, upstreamURL string) config.Config {
+	t.Helper()
+	t.Setenv("MISTRAL_API_KEY", "test-key")
+	p := filepath.Join(t.TempDir(), ".dir2mcp.yaml")
+	body := "providers:\n  " + profile + ":\n    base_url: " + upstreamURL + "\n"
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatalf("write provider cfg: %v", err)
+	}
+	loaded, err := config.LoadFile(p)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	loaded.RootDir = base.RootDir
+	loaded.StateDir = base.StateDir
+	loaded.MCPPath = base.MCPPath
+	loaded.AuthMode = base.AuthMode
+	return loaded
 }
 
 func setupMCPToolStore(t *testing.T, relPath, docType string, content []byte) (config.Config, *store.SQLiteStore, string) {

--- a/tests/up_command_test.go
+++ b/tests/up_command_test.go
@@ -199,9 +199,12 @@ func TestReindexConfigLoadErrorReturnsExitCode2(t *testing.T) {
 // causing the ingest service to be unaware of any environment overrides.
 func TestReindexPassesConfigToNewIngestor(t *testing.T) {
 	tmp := t.TempDir()
-	// exercise a non-default value so we can distinguish default vs loaded
-	t.Setenv("MISTRAL_API_KEY", "abc123")
-	t.Setenv("MISTRAL_BASE_URL", "https://example.local/")
+	// Exercise a non-default value so we can distinguish default vs
+	// loaded. The provider clean break (#38) removed the MISTRAL_*
+	// env→Config mapping; DIR2MCP_DOCLING_COMMAND remains a loader-applied
+	// env override and is a clean, observable proxy for "the loaded
+	// config (not config.Default()) reached the ingestor".
+	t.Setenv("DIR2MCP_DOCLING_COMMAND", "cat {input}")
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -221,11 +224,8 @@ func TestReindexPassesConfigToNewIngestor(t *testing.T) {
 		}
 	})
 
-	if seenCfg.MistralAPIKey != "abc123" {
-		t.Fatalf("config not propagated to ingestor: got api key %q", seenCfg.MistralAPIKey)
-	}
-	if seenCfg.MistralBaseURL != "https://example.local/" {
-		t.Fatalf("config not propagated to ingestor: got base url %q", seenCfg.MistralBaseURL)
+	if seenCfg.DoclingCommand != "cat {input}" {
+		t.Fatalf("config not propagated to ingestor: got docling command %q", seenCfg.DoclingCommand)
 	}
 }
 


### PR DESCRIPTION
## Summary

Final sub-PR of the decomposed **C2-iii-b** clean break, following **#203 (38a)** and **#204 (38b)**. SPEC 0.7.0 (`spec/versioning.md`) ratifies removing the monolithic `mistral:`/embed/chat config surface — *"a clean break is acceptable (no compatibility users)"* — so this is **conformance to already-merged 0.7.0** and needs no new dirstral-spec PR (same governance basis as #202).

> Tracking note: this work is tracked internally as **C2-iii-b**; it is *not* linked to GitHub issue #38 (an unrelated, already-closed ElevenLabs-agent issue). The intentional sibling cross-links are PRs #203 / #204 / #202.

This deletes the spec-removed `Config` fields, their seed helpers, and the flat parser/alias/env/snapshot plumbing, then migrates the test surface to the provider resolver + `providers:`/`model:` YAML (SPEC §16.2).

## Removed

- `Config` fields: `MistralAPIKey`, `MistralBaseURL`, `MistralMaxOCRPayloadBytes`, `EmbedModelText`, `EmbedModelCode`, `ChatModel`
- `SecretSourceMetadata.MistralAPIKey` + the snapshot `mistral_api_key` source-metadata block
- `seedMistralChatEmbed`; the flat alias/parser/`writeScalar`/env entries for the above
- `applyMistral*EnvOverrides` collapsed into a single `applyIngestEnvOverrides` (keeps `DIR2MCP_DOCLING_COMMAND`/`INGEST_EXTRACTOR`/`RETRIEVAL_HYBRID_ENABLED`)

## Behavior notes (clean break — no compatibility users)

- The Mistral credential now resolves **only** via the built-in `${MISTRAL_API_KEY}` placeholder or an explicit `providers:` entry (matches the SPEC §16.2 example). The literal `stt.mistral.api_key` / `secrets.mistral_api_key` / `mistral_api_key` flat YAML keys are no longer honored.
- `DIR2MCP_{MISTRAL_BASE_URL,MISTRAL_MAX_OCR_PAYLOAD_BYTES,EMBED_MODEL_*,CHAT_MODEL}` env overrides are removed; model selection is via `model.embed.*` / `model.chat.*` per SPEC §16.2.
- **`stt:`/`rerank:` shapes are retained** (spec-faithful narrow break): `seedMistralOCR` keeps the `stt.mistral.model` bridge; `seedCohere`/`seedElevenLabs` unchanged.
- Built-in profiles unchanged and consistent with SPEC §16.2: `mistral` `base_url` keeps `/v1` (OpenAI backbone posts `{base}/chat/completions`); `mistral-ocr` has no `base_url` (native client default). This also resolves the deferred #203 Copilot note.

## Test migration

Migrated to the spec-faithful surface rather than deleted where the underlying behavior still exists:

- Credentials via `t.Setenv("MISTRAL_API_KEY", ...)` (flows through the resolver's `${MISTRAL_API_KEY}` placeholder)
- `base_url` / model overrides via a `providers:`/`model:` YAML loaded through `config.LoadFile` (new `withMistralUpstream` helper in `tests/mcp`)
- Snapshot secret-source + nested/flat-alias coverage repointed to `cohere`/`elevenlabs` (still-valid secrets)
- Dropped the fully-removed `mistral_max_ocr_payload_bytes` env test (no spec equivalent)

## Verification

- `make check` green (gofmt, `go vet`, golangci-lint, misspell, all Go suites, Python tests, build)
- Scope limited to the 3 production files + migrated test files; no unrelated changes

Completes the **C2-iii-b** clean break together with #203 (38a) and #204 (38b); unblocks closing the **C2-iii umbrella (PR C)**. No `Closes`/`Fixes` issue keyword is used intentionally — there is no matching GitHub issue (this is SPEC 0.7.0 conformance, tracked internally).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for configuring Docling command settings.

* **Refactor**
  * Configuration management refactored to use environment variables and provider profiles for credentials and model settings instead of direct configuration fields.
  * Mistral API key and embedding/chat model configuration now obtained through environment variables and provider overrides rather than flat config fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dirstral/dir2mcp/pull/205?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
