### PR TITLE
docs: docstring coverage sweep for config.go and app.go

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -170,6 +170,8 @@ type optionalBoolFlag struct {
 	set   bool
 }
 
+// String renders the flag's current boolean value, returning "false" for a
+// nil receiver.
 func (o *optionalBoolFlag) String() string {
 	if o == nil {
 		return "false"
@@ -177,6 +179,8 @@ func (o *optionalBoolFlag) String() string {
 	return strconv.FormatBool(o.value)
 }
 
+// Set parses s as a boolean, records the value, and marks the flag as
+// explicitly set.
 func (o *optionalBoolFlag) Set(s string) error {
 	parsed, err := strconv.ParseBool(strings.TrimSpace(s))
 	if err != nil {
@@ -187,6 +191,8 @@ func (o *optionalBoolFlag) Set(s string) error {
 	return nil
 }
 
+// IsBoolFlag reports that this flag may be used without an explicit value,
+// allowing the bare --flag form.
 func (o *optionalBoolFlag) IsBoolFlag() bool {
 	return true
 }
@@ -278,10 +284,13 @@ type corpusIndexing struct {
 	Unknown         int64  `json:"unknown"`
 }
 
+// NewApp constructs an App wired to os.Stdout and os.Stderr.
 func NewApp() *App {
 	return NewAppWithIO(os.Stdout, os.Stderr)
 }
 
+// NewAppWithIO constructs an App with the given output writers and the
+// default ingestor/store constructors.
 func NewAppWithIO(stdout, stderr io.Writer) *App {
 	return &App{
 		stdout: stdout,
@@ -304,6 +313,9 @@ func NewAppWithIO(stdout, stderr io.Writer) *App {
 	}
 }
 
+// NewAppWithIOAndHooks constructs an App with the given writers, overriding
+// the default ingestor/store/retriever constructors with any non-nil hooks
+// (used by tests to inject fakes).
 func NewAppWithIOAndHooks(stdout, stderr io.Writer, hooks RuntimeHooks) *App {
 	app := NewAppWithIO(stdout, stderr)
 	if hooks.NewIngestor != nil {
@@ -318,10 +330,13 @@ func NewAppWithIOAndHooks(stdout, stderr io.Writer, hooks RuntimeHooks) *App {
 	return app
 }
 
+// writef writes a formatted string to out, discarding any write error.
 func writef(out io.Writer, format string, args ...interface{}) {
 	_, _ = fmt.Fprintf(out, format, args...)
 }
 
+// writeln writes args followed by a newline to out, discarding any write
+// error.
 func writeln(out io.Writer, args ...interface{}) {
 	_, _ = fmt.Fprintln(out, args...)
 }
@@ -342,6 +357,9 @@ func (a *App) sty(jsonMode bool) styles {
 	return s
 }
 
+// storeForConfig returns the metadata store for cfg, using the injected
+// newStore hook when present and otherwise the default sqlite store in the
+// state directory.
 func (a *App) storeForConfig(cfg config.Config) model.Store {
 	if a != nil && a.newStore != nil {
 		return a.newStore(cfg)
@@ -349,6 +367,9 @@ func (a *App) storeForConfig(cfg config.Config) model.Store {
 	return store.NewSQLiteStore(filepath.Join(cfg.StateDir, "meta.sqlite"))
 }
 
+// Run is the process entrypoint: it installs a signal-cancelled context,
+// dispatches args, and maps a clean exit after interruption to the
+// signal-interrupt exit code.
 func (a *App) Run(args []string) int {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
@@ -359,6 +380,8 @@ func (a *App) Run(args []string) int {
 	return code
 }
 
+// RunWithContext parses global flags and dispatches the remaining command
+// under ctx, printing usage when no command is given.
 func (a *App) RunWithContext(ctx context.Context, args []string) int {
 	if len(args) == 0 {
 		a.printUsage()
@@ -379,6 +402,9 @@ func (a *App) RunWithContext(ctx context.Context, args []string) int {
 	return a.runCommand(ctx, globalOpts, remaining, jsonRequested)
 }
 
+// runCommand validates the command name against the canonical command
+// surface and dispatches it, handling the up/down/version paths directly and
+// delegating the rest to runSimpleCommand.
 func (a *App) runCommand(ctx context.Context, globalOpts globalOptions, remaining []string, jsonRequested bool) int {
 	command := remaining[0]
 	// Validate against the canonical command surface before dispatch. The
@@ -424,6 +450,9 @@ func (a *App) runCommand(ctx context.Context, globalOpts globalOptions, remainin
 	}
 }
 
+// runSimpleCommand dispatches the non-up/down commands (status, reindex,
+// config, bridge, install, uninstall, doctor, print-config) plus the legacy
+// shims, returning handled=false when command is none of these.
 func (a *App) runSimpleCommand(ctx context.Context, globalOpts globalOptions, command string, args []string) (int, bool) {
 	if code, handled := a.runLegacyShimCommand(ctx, globalOpts, command, args); handled {
 		return code, true
@@ -451,6 +480,8 @@ func (a *App) runSimpleCommand(ctx context.Context, globalOpts globalOptions, co
 	}
 }
 
+// runLegacyShimCommand dispatches the legacy ask/search/open-file/list-files
+// compatibility shims, returning handled=false when command is none of them.
 func (a *App) runLegacyShimCommand(ctx context.Context, globalOpts globalOptions, command string, args []string) (int, bool) {
 	switch command {
 	case "ask":
@@ -466,6 +497,8 @@ func (a *App) runLegacyShimCommand(ctx context.Context, globalOpts globalOptions
 	}
 }
 
+// printUsage writes the styled top-level help text (commands and flag
+// groups) to stdout.
 func (a *App) printUsage() {
 	s := a.sty(false)
 	o := a.stdout
@@ -539,6 +572,8 @@ func (a *App) printUsage() {
 	}
 }
 
+// saveEnvLocalKey upserts keyName=value into the dotenv-style file at path,
+// replacing any existing assignment and writing the file 0o600.
 func saveEnvLocalKey(path, keyName, value string) error {
 	var existing []byte
 	if _, statErr := os.Stat(path); statErr == nil {
@@ -647,6 +682,11 @@ func (a *App) configureReranker(ret *retrieval.Service, cfg config.Config) {
 	ret.SetRerankEnabled(true)
 }
 
+// buildRetrieverForAsk constructs a retrieval service for the ask path:
+// it loads the text/code HNSW indexes, resolves the embed/chat clients,
+// wires reranking, and preloads embedded chunk metadata. It returns the
+// retriever plus a cleanup func that closes the loaded indexes. The injected
+// newRetriever hook short-circuits this when present.
 func (a *App) buildRetrieverForAsk(ctx context.Context, cfg config.Config, st model.Store) (model.Retriever, func(), error) {
 	if a != nil && a.newRetriever != nil {
 		return a.newRetriever(cfg, st), nil, nil
@@ -700,6 +740,8 @@ func (a *App) buildRetrieverForAsk(ctx context.Context, cfg config.Config, st mo
 	return ret, cleanup, nil
 }
 
+// parseAskOptions parses the ask subcommand flags and trailing question,
+// applying defaults and validating k, mode, index, and the doc-types filter.
 func parseAskOptions(args []string) (askOptions, error) {
 	opts := askOptions{
 		k:     mcp.DefaultSearchK,
@@ -765,6 +807,7 @@ func parseAskOptions(args []string) (askOptions, error) {
 	return opts, nil
 }
 
+// readCorpusSnapshot reads and JSON-decodes the corpus snapshot at path.
 func readCorpusSnapshot(path string) (corpusSnapshot, error) {
 	raw, err := os.ReadFile(path)
 	if err != nil {
@@ -777,12 +820,15 @@ func readCorpusSnapshot(path string) (corpusSnapshot, error) {
 	return snapshot, nil
 }
 
+// emitJSON encodes payload as JSON to out without HTML escaping.
 func emitJSON(out io.Writer, payload interface{}) error {
 	enc := json.NewEncoder(out)
 	enc.SetEscapeHTML(false)
 	return enc.Encode(payload)
 }
 
+// isJSONFlagEnabled reports whether arg is a --json/-json flag (bare or with
+// a truthy =value form).
 func isJSONFlagEnabled(arg string) bool {
 	if arg == "--json" || arg == "-json" {
 		return true
@@ -802,6 +848,8 @@ func isJSONFlagEnabled(arg string) bool {
 	return err == nil && enabled
 }
 
+// argsContainJSONFlag reports whether any arg enables JSON output, used to
+// format early errors before full flag parsing.
 func argsContainJSONFlag(args []string) bool {
 	for _, arg := range args {
 		if isJSONFlagEnabled(arg) {
@@ -811,6 +859,8 @@ func argsContainJSONFlag(args []string) bool {
 	return false
 }
 
+// exitCodeLabel maps an exit code to its stable machine-readable error code
+// string used in JSON error payloads.
 func exitCodeLabel(exitCode int) string {
 	switch exitCode {
 	case exitConfigInvalid:
@@ -828,6 +878,9 @@ func exitCodeLabel(exitCode int) string {
 	}
 }
 
+// writeCLIError writes an error to stderr, as a structured JSON payload when
+// jsonOutput is set (with a hand-rolled fallback if encoding fails) or as
+// plain text with optional hint lines otherwise.
 func writeCLIError(stderr io.Writer, jsonOutput bool, exitCode int, message string, hints ...string) {
 	if jsonOutput {
 		filteredHints := make([]string, 0, len(hints))
@@ -875,6 +928,7 @@ func writeCLIError(stderr io.Writer, jsonOutput bool, exitCode int, message stri
 	}
 }
 
+// serializeHits converts search hits into JSON-ready maps for CLI output.
 func serializeHits(hits []model.SearchHit) []map[string]interface{} {
 	out := make([]map[string]interface{}, 0, len(hits))
 	for _, hit := range hits {
@@ -891,6 +945,7 @@ func serializeHits(hits []model.SearchHit) []map[string]interface{} {
 	return out
 }
 
+// serializeCitations converts citations into JSON-ready maps for CLI output.
 func serializeCitations(citations []model.Citation) []map[string]interface{} {
 	out := make([]map[string]interface{}, 0, len(citations))
 	for _, citation := range citations {
@@ -903,6 +958,8 @@ func serializeCitations(citations []model.Citation) []map[string]interface{} {
 	return out
 }
 
+// serializeSpan converts a span into a JSON-ready map, shaped per its kind
+// (page, time, or the default line range).
 func serializeSpan(span model.Span) map[string]interface{} {
 	switch strings.ToLower(strings.TrimSpace(span.Kind)) {
 	case "page":
@@ -925,6 +982,8 @@ func serializeSpan(span model.Span) map[string]interface{} {
 	}
 }
 
+// formatSpan renders a span as a compact human-readable token (e.g.
+// "page:3", "time:1000-2000", or "lines:10-20").
 func formatSpan(span model.Span) string {
 	switch strings.ToLower(strings.TrimSpace(span.Kind)) {
 	case "page":
@@ -966,6 +1025,10 @@ func tryConsumeGlobalFlagSet(arg string, remaining []string, opts *globalOptions
 	return remaining, false, nil
 }
 
+// parseGlobalOptions consumes leading global flags from args, returning the
+// parsed options and the remaining command tokens. Unknown flags are
+// rejected only before the command position; everything after the first
+// non-flag token (including a trailing "--") is left for the subcommand.
 func parseGlobalOptions(args []string) (globalOptions, []string, error) {
 	opts := globalOptions{}
 	var remaining []string
@@ -1019,6 +1082,9 @@ func parseGlobalOptions(args []string) (globalOptions, []string, error) {
 	return opts, remaining, nil
 }
 
+// parseJSONFlagValue matches the --json/-json flag. matched reports whether
+// arg is the flag at all; enabled is its boolean value, with err set for an
+// unparseable =value form.
 func parseJSONFlagValue(arg string) (enabled bool, matched bool, err error) {
 	if arg == "--json" || arg == "-json" {
 		return true, true, nil
@@ -1042,6 +1108,9 @@ func parseJSONFlagValue(arg string) (enabled bool, matched bool, err error) {
 	return false, false, nil
 }
 
+// consumeGlobalFlagValue extracts the value for flagName from args,
+// supporting both --flag=value and --flag value forms, and returns the
+// number of tokens consumed.
 func consumeGlobalFlagValue(flagName string, args []string) (string, int, error) {
 	if len(args) == 0 {
 		return "", 0, fmt.Errorf("missing value for %s", flagName)
@@ -1063,6 +1132,8 @@ func consumeGlobalFlagValue(flagName string, args []string) (string, int, error)
 	return value, 2, nil
 }
 
+// resolveConfigPath returns the configured config path, defaulting to
+// ".dir2mcp.yaml" when none was supplied.
 func resolveConfigPath(global globalOptions) string {
 	if trimmed := strings.TrimSpace(global.configPath); trimmed != "" {
 		return trimmed
@@ -1070,6 +1141,9 @@ func resolveConfigPath(global globalOptions) string {
 	return ".dir2mcp.yaml"
 }
 
+// applyGlobalPathOverrides overlays the --dir and --state-dir global flags
+// onto cfg, deriving a default state directory under the new root when the
+// state directory was left at its default.
 func applyGlobalPathOverrides(cfg config.Config, global globalOptions) config.Config {
 	if root := strings.TrimSpace(global.rootDir); root != "" {
 		stateLooksDefault := strings.TrimSpace(cfg.StateDir) == "" ||
@@ -1085,6 +1159,9 @@ func applyGlobalPathOverrides(cfg config.Config, global globalOptions) config.Co
 	return cfg
 }
 
+// loadConfigWithGlobalOptions loads the config file, applies the global path
+// overrides, and writes the effective-config snapshot (a snapshot failure is
+// recorded as a non-fatal warning).
 func loadConfigWithGlobalOptions(global globalOptions) (config.Config, error) {
 	cfg, err := config.Load(resolveConfigPath(global))
 	if err != nil {
@@ -1140,6 +1217,8 @@ func saveEffectiveConfigSnapshot(cfg config.Config, auth authMaterial, x402Token
 	return err
 }
 
+// validateTLSFlags ensures the TLS cert and key flags are supplied together
+// and that each points to an existing regular file.
 func validateTLSFlags(certPath, keyPath string) error {
 	certPath = strings.TrimSpace(certPath)
 	keyPath = strings.TrimSpace(keyPath)
@@ -1161,6 +1240,9 @@ func validateTLSFlags(certPath, keyPath string) error {
 	return nil
 }
 
+// parseUpOptions parses the up subcommand flags on top of the global
+// options, applying the facilitator-token file-wins precedence and rejecting
+// the --daemon/--foreground and --daemon/--json conflicts.
 func parseUpOptions(global globalOptions, args []string) (upOptions, error) {
 	opts := upOptions{globalOptions: global}
 	fs := flag.NewFlagSet("up", flag.ContinueOnError)
@@ -1227,12 +1309,16 @@ func parseUpOptions(global globalOptions, args []string) (upOptions, error) {
 	return opts, nil
 }
 
+// closeStoreWithLog closes the store, logging any close error to stderr.
 func (a *App) closeStoreWithLog(st model.Store) {
 	if closeErr := st.Close(); closeErr != nil {
 		writef(a.stderr, "close store: %v\n", closeErr)
 	}
 }
 
+// clearContentHashesIfSupported clears stored document content hashes when
+// the store implements contentHashResetter (forcing re-ingestion), returning
+// an exit code; stores without the capability are a no-op success.
 func clearContentHashesIfSupported(ctx context.Context, st model.Store, stderr io.Writer, jsonOutput bool) int {
 	resetter, ok := interface{}(st).(contentHashResetter)
 	if !ok {
@@ -1245,6 +1331,7 @@ func clearContentHashesIfSupported(ctx context.Context, st model.Store, stderr i
 	return exitSuccess
 }
 
+// ensureRootAccessible verifies that root exists and is a directory.
 func ensureRootAccessible(root string) error {
 	info, err := os.Stat(root)
 	if err != nil {
@@ -1256,6 +1343,9 @@ func ensureRootAccessible(root string) error {
 	return nil
 }
 
+// prepareAuthMaterial resolves the bearer-token auth material for the
+// configured auth mode: "none" disables auth, "auto" delegates to
+// prepareAutoAuthMaterial, and "file:<path>" loads a token from disk.
 func prepareAuthMaterial(cfg config.Config) (authMaterial, error) {
 	mode := strings.TrimSpace(cfg.AuthMode)
 	if mode == "" {
@@ -1303,6 +1393,9 @@ func prepareAuthMaterial(cfg config.Config) (authMaterial, error) {
 	return authMaterial{}, fmt.Errorf("unsupported auth mode: %s", mode)
 }
 
+// prepareAutoAuthMaterial resolves auth material in "auto" mode: it prefers
+// the env-var token, otherwise reads the persisted secret.token, generating
+// and persisting a new random token when none exists.
 func prepareAutoAuthMaterial(cfg config.Config) (authMaterial, error) {
 	if token := strings.TrimSpace(os.Getenv(authTokenEnvVar)); token != "" {
 		return authMaterial{
@@ -1339,6 +1432,8 @@ func prepareAutoAuthMaterial(cfg config.Config) (authMaterial, error) {
 	}, nil
 }
 
+// readToken reads and trims the token at path; when allowMissing is set, a
+// missing file yields an empty token instead of an error.
 func readToken(path string, allowMissing bool) (string, error) {
 	content, err := os.ReadFile(path)
 	if err != nil {
@@ -1350,6 +1445,8 @@ func readToken(path string, allowMissing bool) (string, error) {
 	return strings.TrimSpace(string(content)), nil
 }
 
+// generateTokenHex returns a cryptographically random 32-byte token as a hex
+// string.
 func generateTokenHex() (string, error) {
 	buf := make([]byte, 32)
 	if _, err := rand.Read(buf); err != nil {
@@ -1358,6 +1455,8 @@ func generateTokenHex() (string, error) {
 	return hex.EncodeToString(buf), nil
 }
 
+// writeSecretToken writes token to path with 0o600 permissions, truncating
+// any existing file.
 func writeSecretToken(path, token string) error {
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 	if err != nil {
@@ -1373,6 +1472,8 @@ func writeSecretToken(path, token string) error {
 	return nil
 }
 
+// buildMCPURL assembles the MCP endpoint URL from the address and path,
+// choosing the https scheme when TLS is enabled.
 func buildMCPURL(addr, path string, tlsEnabled bool) string {
 	if !strings.HasPrefix(path, "/") {
 		path = "/" + path
@@ -1390,6 +1491,9 @@ func PublicURLAddress(configuredListenAddr, resolvedListenAddr string) string {
 	return publicURLAddress(configuredListenAddr, resolvedListenAddr)
 }
 
+// publicURLAddress joins the configured listen host with the resolved
+// runtime port (falling back to the configured port, then "0"), defaulting
+// the host to 0.0.0.0 when none was configured.
 func publicURLAddress(configuredListenAddr, resolvedListenAddr string) string {
 	configuredListenAddr = strings.TrimSpace(configuredListenAddr)
 	resolvedListenAddr = strings.TrimSpace(resolvedListenAddr)
@@ -1415,6 +1519,9 @@ func ExtractPortFromAddress(addr string) string {
 	return extractPortFromAddress(addr)
 }
 
+// extractPortFromAddress returns the numeric port from a host:port address,
+// with a best-effort fallback for malformed values that still end in a
+// numeric ":port" token, and "" when none can be determined.
 func extractPortFromAddress(addr string) string {
 	addr = strings.TrimSpace(addr)
 	if addr == "" {
@@ -1445,6 +1552,7 @@ func extractPortFromAddress(addr string) string {
 	return ""
 }
 
+// isNumericPort reports whether port is a non-empty string of ASCII digits.
 func isNumericPort(port string) bool {
 	if port == "" {
 		return false
@@ -1457,6 +1565,9 @@ func isNumericPort(port string) bool {
 	return true
 }
 
+// buildConnectionPayload assembles the connection.json payload describing
+// the MCP transport, URL, required headers, session policy, and token
+// source; the Authorization header hint is omitted when auth is disabled.
 func buildConnectionPayload(cfg config.Config, url string, auth authMaterial) connectionPayload {
 	headers := map[string]string{
 		protocol.MCPProtocolVersionHeader: cfg.ProtocolVersion,
@@ -1480,6 +1591,8 @@ func buildConnectionPayload(cfg config.Config, url string, auth authMaterial) co
 	}
 }
 
+// writeConnectionFile writes the connection payload as indented JSON to
+// path with 0o600 permissions (the file is credential-adjacent).
 func writeConnectionFile(path string, payload connectionPayload) error {
 	content, err := json.MarshalIndent(payload, "", "  ")
 	if err != nil {
@@ -1494,14 +1607,21 @@ func writeConnectionFile(path string, payload connectionPayload) error {
 	return os.WriteFile(path, content, 0o600)
 }
 
+// newNDJSONEmitter constructs an ndjsonEmitter that writes events to out
+// when enabled.
 func newNDJSONEmitter(out io.Writer, enabled bool) *ndjsonEmitter {
 	return &ndjsonEmitter{enabled: enabled, out: out}
 }
 
+// runCorpusWriter periodically writes the corpus snapshot using the default
+// 5s interval until ctx is cancelled.
 func runCorpusWriter(ctx context.Context, stateDir string, st model.Store, indexingState *appstate.IndexingState, stderr io.Writer, emitter *ndjsonEmitter) {
 	runCorpusWriterWithInterval(ctx, stateDir, st, indexingState, stderr, emitter, 5*time.Second)
 }
 
+// runCorpusWriterWithInterval emits an initial corpus snapshot, then
+// refreshes it every interval while indexing is running, returning when ctx
+// is cancelled. A non-positive interval defaults to 5s.
 func runCorpusWriterWithInterval(ctx context.Context, stateDir string, st model.Store, indexingState *appstate.IndexingState, stderr io.Writer, emitter *ndjsonEmitter, interval time.Duration) {
 	if interval <= 0 {
 		interval = 5 * time.Second
@@ -1538,6 +1658,9 @@ func logSnapshotErr(stderr io.Writer, err error) {
 	writef(stderr, "write corpus snapshot: %v\n", err)
 }
 
+// writeCorpusSnapshot builds the corpus snapshot and atomically writes it to
+// corpus.json in stateDir via a per-write temp file and rename (with a
+// Windows remove-and-retry fallback).
 func writeCorpusSnapshot(ctx context.Context, stateDir string, st model.Store, indexingState *appstate.IndexingState, stderr io.Writer, emitter *ndjsonEmitter) error {
 	snapshot, err := buildCorpusSnapshot(ctx, st, indexingState, stderr, emitter)
 	if err != nil {
@@ -1586,6 +1709,9 @@ func writeCorpusSnapshot(ctx context.Context, stateDir string, st model.Store, i
 	return nil
 }
 
+// buildCorpusSnapshot collects corpus stats and assembles a corpusSnapshot,
+// preferring live indexing-state counters when available and otherwise
+// deriving them from the store, including the code/total doc ratio.
 func buildCorpusSnapshot(ctx context.Context, st model.Store, indexingState *appstate.IndexingState, stderr io.Writer, emitter *ndjsonEmitter) (corpusSnapshot, error) {
 	corpusStats, err := collectCorpusStats(ctx, st, stderr, emitter)
 	if err != nil {
@@ -1636,6 +1762,9 @@ func buildCorpusSnapshot(ctx context.Context, st model.Store, indexingState *app
 	}, nil
 }
 
+// collectCorpusStats returns corpus statistics, preferring the store's
+// aggregate CorpusStats and otherwise falling back to a ListFiles scan
+// (which leaves representation/chunk/embed counters at the -1 sentinel).
 func collectCorpusStats(ctx context.Context, st model.Store, stderr io.Writer, emitter *ndjsonEmitter) (model.CorpusStats, error) {
 	if st == nil {
 		return model.CorpusStats{DocCounts: map[string]int64{}}, nil
@@ -1680,6 +1809,9 @@ func collectCorpusStats(ctx context.Context, st model.Store, stderr io.Writer, e
 	}, nil
 }
 
+// collectActiveDocCounts returns per-doc-type and total counts of non-deleted
+// documents, preferring the store's aggregate ActiveDocCounts and otherwise
+// paginating through ListFiles.
 func collectActiveDocCounts(ctx context.Context, st model.Store) (map[string]int64, int64, error) {
 	if st == nil {
 		return map[string]int64{}, 0, nil
@@ -1733,6 +1865,9 @@ type documentStatusCounts struct {
 	Unknown int64
 }
 
+// collectDocumentStatusCounts paginates through ListFiles and tallies
+// documents by status (indexed/skipped/error/deleted/unknown), reporting any
+// unexpected status values it encounters.
 func collectDocumentStatusCounts(ctx context.Context, st model.Store, stderr io.Writer, emitter *ndjsonEmitter) (documentStatusCounts, error) {
 	if st == nil {
 		return documentStatusCounts{}, nil
@@ -1789,6 +1924,9 @@ func collectDocumentStatusCounts(ctx context.Context, st model.Store, stderr io.
 	return counts, nil
 }
 
+// reportUnexpectedDocStatuses surfaces a sorted summary of unexpected
+// document statuses, emitting a structured NDJSON warning when an emitter is
+// active and otherwise a plain stderr warning.
 func reportUnexpectedDocStatuses(statusCounts map[string]int64, examples map[string]string, stderr io.Writer, emitter *ndjsonEmitter) {
 	parts := make([]string, 0, len(statusCounts))
 	for statusVal, count := range statusCounts {
@@ -1808,6 +1946,8 @@ func reportUnexpectedDocStatuses(statusCounts map[string]int64, examples map[str
 	}
 }
 
+// Emit writes a single timestamped NDJSON event line when the emitter is
+// enabled; encoding failures are silently dropped.
 func (e *ndjsonEmitter) Emit(level, event string, data interface{}) {
 	if !e.enabled {
 		return
@@ -1825,6 +1965,9 @@ func (e *ndjsonEmitter) Emit(level, event string, data interface{}) {
 	_, _ = fmt.Fprintln(e.out, string(encoded))
 }
 
+// printHumanConnection prints the styled "ready for connections" banner to
+// stdout, summarizing the mode, MCP endpoint URL, auth source, required
+// headers, and client registration hint.
 func (a *App) printHumanConnection(cfg config.Config, connection connectionPayload, auth authMaterial, readOnly bool) {
 	s := a.sty(false)
 	writeln(a.stdout)
@@ -1877,6 +2020,8 @@ func (a *App) printHumanConnection(cfg config.Config, connection connectionPaylo
 	writeln(a.stdout)
 }
 
+// isTerminal reports whether file is a character device (an interactive
+// terminal).
 func isTerminal(file *os.File) bool {
 	if file == nil {
 		return false

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -391,6 +391,8 @@ func Default() Config {
 	}
 }
 
+// Load returns defaults with dotenv/env overrides and, if path is
+// non-empty and exists, the YAML config file layered on top.
 func Load(path string) (Config, error) {
 	return load(path, nil, true)
 }
@@ -472,6 +474,8 @@ func buildPersistedConfig(cfg *Config) persistedConfig {
 	}
 }
 
+// SaveFile validates cfg and writes its persistable subset to path as
+// flat-key YAML (secrets excluded), creating parent directories.
 func SaveFile(path string, cfg Config) error {
 	if strings.TrimSpace(path) == "" {
 		return errors.New("config path is required")
@@ -503,6 +507,8 @@ func SaveFile(path string, cfg Config) error {
 	return nil
 }
 
+// EffectiveSnapshotPath returns the snapshot file path under stateDir,
+// falling back to the default state dir when stateDir is empty.
 func EffectiveSnapshotPath(stateDir string) string {
 	trimmed := strings.TrimSpace(stateDir)
 	if trimmed == "" {
@@ -511,6 +517,9 @@ func EffectiveSnapshotPath(stateDir string) string {
 	return filepath.Join(trimmed, EffectiveConfigSnapshotFile)
 }
 
+// SaveEffectiveSnapshot validates cfg and writes the effective config
+// snapshot (persistable subset plus secret-source metadata and the
+// resolved embed identity) with 0600 perms, returning its path.
 func SaveEffectiveSnapshot(cfg Config, sources SecretSourceMetadata) (string, error) {
 	if err := cfg.Validate(); err != nil {
 		return "", fmt.Errorf("validate config: %w", err)
@@ -538,6 +547,9 @@ func SaveEffectiveSnapshot(cfg Config, sources SecretSourceMetadata) (string, er
 	return path, nil
 }
 
+// LoadEffectiveSnapshot reads a snapshot written by
+// SaveEffectiveSnapshot, returning the layered+validated Config and the
+// recorded secret-source metadata.
 func LoadEffectiveSnapshot(path string) (Config, SecretSourceMetadata, error) {
 	raw, err := os.ReadFile(path)
 	if err != nil {
@@ -665,6 +677,9 @@ func applySecretSourceField(meta *SecretSourceMetadata, key, value string) {
 	}
 }
 
+// load builds a Config from defaults, optionally layering dotenv/env
+// overrides and a YAML file, then validates the result. It is the shared
+// implementation behind Load/LoadFile.
 func load(path string, overrideEnv map[string]string, applyEnv bool) (Config, error) {
 	// Start from defaults, then layer dotenv/env overrides.
 	cfg := Default()
@@ -708,6 +723,9 @@ func load(path string, overrideEnv map[string]string, applyEnv bool) (Config, er
 	return cfg, nil
 }
 
+// applyFileOverrides reads the YAML file at path and overlays its flat
+// keys onto cfg, and decodes the providers:/model: subtree into
+// cfg.providersDoc (SPEC 0.7.0 §16.2).
 func applyFileOverrides(cfg *Config, path string) error {
 	if cfg == nil {
 		return nil
@@ -738,6 +756,8 @@ func applyFileOverrides(cfg *Config, path string) error {
 	return nil
 }
 
+// applyParsedFileOverrides overlays a parsed fileConfig onto cfg by
+// dispatching to the server/model/ingest/x402 sub-appliers.
 func applyParsedFileOverrides(cfg *Config, fileCfg fileConfig) {
 	applyServerFileParsed(cfg, fileCfg)
 	applyModelFileParsed(cfg, fileCfg)
@@ -745,11 +765,15 @@ func applyParsedFileOverrides(cfg *Config, fileCfg fileConfig) {
 	applyX402FileParsed(cfg, fileCfg)
 }
 
+// applyServerFileParsed overlays parsed server core and network file
+// settings onto cfg.
 func applyServerFileParsed(cfg *Config, fc fileConfig) {
 	applyServerCoreFileParsed(cfg, fc)
 	applyServerNetworkFileParsed(cfg, fc)
 }
 
+// applyServerCoreFileParsed copies the set core server file fields
+// (paths, listen addr, protocol, auth, rate limits) onto cfg.
 func applyServerCoreFileParsed(cfg *Config, fc fileConfig) {
 	if fc.RootDir != nil {
 		cfg.RootDir = *fc.RootDir
@@ -783,6 +807,9 @@ func applyServerCoreFileParsed(cfg *Config, fc fileConfig) {
 	}
 }
 
+// applyServerNetworkFileParsed copies the set network-related file
+// fields (proxy/origin/exclude lists and TLS paths) onto cfg,
+// normalizing string slices.
 func applyServerNetworkFileParsed(cfg *Config, fc fileConfig) {
 	if fc.TrustedProxies != nil {
 		cfg.TrustedProxies = normalizeStringSlice(fc.TrustedProxies)
@@ -804,6 +831,8 @@ func applyServerNetworkFileParsed(cfg *Config, fc fileConfig) {
 	}
 }
 
+// applyModelFileParsed overlays parsed model client, rerank, and RAG
+// file settings onto cfg.
 func applyModelFileParsed(cfg *Config, fc fileConfig) {
 	applyModelClientsFileParsed(cfg, fc)
 	applyRerankFileParsed(cfg, fc)
@@ -866,6 +895,8 @@ func applyModelClientsFileParsed(cfg *Config, fc fileConfig) {
 	}
 }
 
+// applyModelRAGFileParsed copies the set RAG/retrieval and session/health
+// timing file fields onto cfg.
 func applyModelRAGFileParsed(cfg *Config, fc fileConfig) {
 	if fc.RAGSystemPrompt != nil {
 		cfg.RAGSystemPrompt = *fc.RAGSystemPrompt
@@ -896,12 +927,15 @@ func applyModelRAGFileParsed(cfg *Config, fc fileConfig) {
 	}
 }
 
+// applyIngestFileParsed overlays parsed chunking, ingest-mode, and STT
+// file settings onto cfg.
 func applyIngestFileParsed(cfg *Config, fc fileConfig) {
 	applyChunkingFileParsed(cfg, fc)
 	applyIngestModesFileParsed(cfg, fc)
 	applySTTFileParsed(cfg, fc)
 }
 
+// applyChunkingFileParsed copies the set chunking file fields onto cfg.
 func applyChunkingFileParsed(cfg *Config, fc fileConfig) {
 	if fc.ChunkingStrategy != nil {
 		cfg.ChunkingStrategy = *fc.ChunkingStrategy
@@ -914,6 +948,9 @@ func applyChunkingFileParsed(cfg *Config, fc fileConfig) {
 	}
 }
 
+// applyIngestModesFileParsed copies the set ingest discovery/mode file
+// fields (gitignore, symlinks, size limit, per-type modes, extractor)
+// onto cfg.
 func applyIngestModesFileParsed(cfg *Config, fc fileConfig) {
 	if fc.IngestGitignore != nil {
 		cfg.IngestGitignore = *fc.IngestGitignore
@@ -941,6 +978,8 @@ func applyIngestModesFileParsed(cfg *Config, fc fileConfig) {
 	}
 }
 
+// applySTTFileParsed copies the set speech-to-text file fields
+// (provider and Mistral/ElevenLabs model + language) onto cfg.
 func applySTTFileParsed(cfg *Config, fc fileConfig) {
 	if fc.STTProvider != nil {
 		cfg.STTProvider = *fc.STTProvider
@@ -956,6 +995,8 @@ func applySTTFileParsed(cfg *Config, fc fileConfig) {
 	}
 }
 
+// applyX402FileParsed copies the set x402 file fields onto cfg.X402.
+// Any file-supplied facilitator token is ignored (env-only).
 func applyX402FileParsed(cfg *Config, fc fileConfig) {
 	if fc.X402Mode != nil {
 		cfg.X402.Mode = *fc.X402Mode
@@ -988,6 +1029,8 @@ func applyX402FileParsed(cfg *Config, fc fileConfig) {
 	}
 }
 
+// normalizeStringSlice trims each value and drops empties, returning nil
+// when the input is nil.
 func normalizeStringSlice(values []string) []string {
 	if values == nil {
 		return nil
@@ -1003,6 +1046,9 @@ func normalizeStringSlice(values []string) []string {
 	return out
 }
 
+// parseConfigYAML parses the supported flat/nested-key YAML subset into
+// a fileConfig using a bespoke line scanner (lists, inline lists, and
+// indentation-derived section prefixes).
 func parseConfigYAML(raw []byte) (fileConfig, error) {
 	cfg := fileConfig{}
 	scanner := bufio.NewScanner(strings.NewReader(string(raw)))
@@ -1068,6 +1114,9 @@ func parseConfigYAML(raw []byte) (fileConfig, error) {
 	return cfg, nil
 }
 
+// resolveYAMLKey splits a "key: value" line, prefixes the key with the
+// nearest enclosing section, and returns its canonical form plus the
+// trimmed value.
 func resolveYAMLKey(line string, sectionByIndent map[int]string, indent int) (key, value string, err error) {
 	k, v, ok := strings.Cut(line, ":")
 	if !ok {
@@ -1080,6 +1129,8 @@ func resolveYAMLKey(line string, sectionByIndent map[int]string, indent int) (ke
 	return canonicalizeConfigKey(k), strings.TrimSpace(v), nil
 }
 
+// pruneStaleIndents drops section entries at or deeper than indent so
+// section prefixes don't leak across sibling/dedented blocks.
 func pruneStaleIndents(sectionByIndent map[int]string, indent int) {
 	for level := range sectionByIndent {
 		if level >= indent {
@@ -1088,6 +1139,9 @@ func pruneStaleIndents(sectionByIndent map[int]string, indent int) {
 	}
 }
 
+// handleYAMLEmptyValue handles a key with no inline value: starting a
+// list, opening a map section at indent, or setting an empty scalar.
+// Returns the list key when a block list begins.
 func handleYAMLEmptyValue(cfg *fileConfig, key string, sectionByIndent map[int]string, indent int) (newListKey string, err error) {
 	if isListConfigKey(key) {
 		setFileListValue(cfg, key, "")
@@ -1103,6 +1157,8 @@ func handleYAMLEmptyValue(cfg *fileConfig, key string, sectionByIndent map[int]s
 	return "", nil
 }
 
+// handleYAMLInlineList parses a bracketed inline list value (e.g.
+// "[a, b]") and appends its items to the list field selected by key.
 func handleYAMLInlineList(cfg *fileConfig, key, value string, lineNo int) error {
 	if !strings.HasSuffix(value, "]") {
 		return fmt.Errorf("line %d: malformed list value for %s", lineNo, key)
@@ -1124,6 +1180,8 @@ func handleYAMLInlineList(cfg *fileConfig, key, value string, lineNo int) error 
 	return nil
 }
 
+// nearestSectionPrefix returns the section name registered at the
+// greatest indent strictly less than indent, or "" if none.
 func nearestSectionPrefix(sectionByIndent map[int]string, indent int) string {
 	bestIndent := -1
 	best := ""
@@ -1216,6 +1274,8 @@ var configKeyAliases = map[string]string{
 	"x402.route_policy.tools_call.pay_to":  "x402_pay_to",
 }
 
+// canonicalizeConfigKey lower-cases and trims key and maps it through
+// configKeyAliases, returning the canonical form (or key unchanged).
 func canonicalizeConfigKey(key string) string {
 	key = strings.TrimSpace(strings.ToLower(key))
 	if canonical, ok := configKeyAliases[key]; ok {
@@ -1224,6 +1284,8 @@ func canonicalizeConfigKey(key string) string {
 	return key
 }
 
+// isMapSectionKey reports whether key names a nested mapping section
+// (so child keys should be prefixed) rather than a scalar/list key.
 func isMapSectionKey(key string) bool {
 	switch key {
 	case "rag", "ingest", "ingest.docling", "stt", "stt.mistral", "stt.elevenlabs", "server", "server.tls", "secret_sources", "mistral", "docling", "security", "security.auth", "x402", "x402.route_policy", "x402.route_policy.tools_call", "chunking", "retrieval", "retrieval.hybrid", "rerank", "rerank.cohere":
@@ -1237,6 +1299,9 @@ func isMapSectionKey(key string) bool {
 	}
 }
 
+// setFileScalarValue assigns a scalar value to the fileConfig field
+// matching key, trying bool, int, and duration parsers before falling
+// back to string assignment.
 func setFileScalarValue(cfg *fileConfig, key, value string) error {
 	if err := setBoolFileScalar(cfg, key, value); err != nil {
 		return err
@@ -1251,6 +1316,9 @@ func setFileScalarValue(cfg *fileConfig, key, value string) error {
 	return nil
 }
 
+// setBoolFileScalar parses value as a bool and assigns it to the
+// fileConfig field selected by key; unknown keys are a no-op and an
+// unparseable value is an error.
 func setBoolFileScalar(cfg *fileConfig, key, value string) error {
 	var target **bool
 	switch key {
@@ -1314,6 +1382,9 @@ func setIntFileScalar(cfg *fileConfig, key, value string) error {
 	return nil
 }
 
+// setDurationFileScalar parses value as a time.Duration and assigns it
+// to the fileConfig field selected by key; unknown keys are a no-op and
+// an unparseable value is an error.
 func setDurationFileScalar(cfg *fileConfig, key, value string) error {
 	var target **time.Duration
 	switch key {
@@ -1337,6 +1408,8 @@ func setDurationFileScalar(cfg *fileConfig, key, value string) error {
 	return nil
 }
 
+// setStringFileScalar dispatches a string key/value to the
+// server/model/ingest/x402 string setters.
 func setStringFileScalar(cfg *fileConfig, key, value string) {
 	setServerStringFileScalar(cfg, key, value)
 	setModelStringFileScalar(cfg, key, value)
@@ -1344,6 +1417,9 @@ func setStringFileScalar(cfg *fileConfig, key, value string) {
 	setX402StringFileScalar(cfg, key, value)
 }
 
+// setServerStringFileScalar assigns server-related string keys (paths,
+// listen addr, protocol, auth mode, server name, TLS files) onto the
+// fileConfig.
 func setServerStringFileScalar(cfg *fileConfig, key, value string) {
 	switch key {
 	case "root_dir":
@@ -1409,6 +1485,8 @@ func setModelStringFileScalar(cfg *fileConfig, key, value string) {
 	}
 }
 
+// setIngestStringFileScalar assigns ingest mode and STT string keys
+// onto the fileConfig.
 func setIngestStringFileScalar(cfg *fileConfig, key, value string) {
 	switch key {
 	case "ingest.pdf.mode":
@@ -1432,6 +1510,8 @@ func setIngestStringFileScalar(cfg *fileConfig, key, value string) {
 	}
 }
 
+// setX402StringFileScalar assigns x402 string keys onto the fileConfig;
+// the facilitator token key is deliberately ignored (env-only).
 func setX402StringFileScalar(cfg *fileConfig, key, value string) {
 	switch key {
 	case "x402_mode":
@@ -1455,6 +1535,9 @@ func setX402StringFileScalar(cfg *fileConfig, key, value string) {
 	}
 }
 
+// setFileListValue appends value to the list field selected by the
+// canonicalized key, initializing the slice on first use and skipping
+// blank items.
 func setFileListValue(cfg *fileConfig, key, value string) {
 	key = canonicalizeConfigKey(key)
 	appendValue := func(target *[]string, item string) {
@@ -1479,6 +1562,8 @@ func setFileListValue(cfg *fileConfig, key, value string) {
 	}
 }
 
+// isListConfigKey reports whether key (after canonicalization) maps to
+// a list-valued config field.
 func isListConfigKey(key string) bool {
 	key = canonicalizeConfigKey(key)
 	switch key {
@@ -1584,6 +1669,8 @@ func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	return []byte(b.String()), nil
 }
 
+// unquoteYAMLScalar trims value and strips matching single/double
+// quotes (interpreting escapes in double-quoted form).
 func unquoteYAMLScalar(value string) string {
 	value = strings.TrimSpace(value)
 	if len(value) >= 2 {
@@ -1599,10 +1686,18 @@ func unquoteYAMLScalar(value string) string {
 	return value
 }
 
+// strPtr returns a pointer to value.
 func strPtr(value string) *string { return &value }
-func boolPtr(value bool) *bool    { return &value }
-func intPtr(value int) *int       { return &value }
 
+// boolPtr returns a pointer to value.
+func boolPtr(value bool) *bool { return &value }
+
+// intPtr returns a pointer to value.
+func intPtr(value int) *int { return &value }
+
+// applyEnvOverrides layers all supported environment-variable overrides
+// onto cfg. Env always wins when present (an empty DIR2MCP_SERVER_NAME
+// clears a YAML-set name).
 func applyEnvOverrides(cfg *Config, overrideEnv map[string]string) {
 	if cfg == nil {
 		return
@@ -1662,6 +1757,8 @@ func applyIngestEnvOverrides(cfg *Config, env map[string]string) {
 	}
 }
 
+// applyElevenLabsEnvOverrides applies the ElevenLabs API key, base URL,
+// and voice ID env overrides (only when non-empty).
 func applyElevenLabsEnvOverrides(cfg *Config, env map[string]string) {
 	if apiKey, ok := envLookup("ELEVENLABS_API_KEY", env); ok && strings.TrimSpace(apiKey) != "" {
 		cfg.ElevenLabsAPIKey = apiKey
@@ -1674,6 +1771,9 @@ func applyElevenLabsEnvOverrides(cfg *Config, env map[string]string) {
 	}
 }
 
+// applyNetworkEnvOverrides merges allowed-origins and trusted-proxy env
+// lists and applies rate-limit env overrides (ignoring invalid/negative
+// numbers).
 func applyNetworkEnvOverrides(cfg *Config, env map[string]string) {
 	if allowedOrigins, ok := envLookup("DIR2MCP_ALLOWED_ORIGINS", env); ok {
 		cfg.AllowedOrigins = MergeAllowedOrigins(cfg.AllowedOrigins, allowedOrigins)
@@ -1693,6 +1793,9 @@ func applyNetworkEnvOverrides(cfg *Config, env map[string]string) {
 	}
 }
 
+// applySessionEnvOverrides applies the session inactivity/max-lifetime
+// and health-check-interval duration env overrides, preferring the new
+// inactivity var name and warning on the deprecated alias.
 func applySessionEnvOverrides(cfg *Config, env map[string]string) {
 	// session-related environment variables are durations parsed by time.ParseDuration.
 	// Syntactically invalid values (parse errors) are warned about but not fatal; values
@@ -1720,6 +1823,8 @@ func applySessionEnvOverrides(cfg *Config, env map[string]string) {
 	}
 }
 
+// applyDurationEnvField parses raw as a duration into target; an empty
+// value is ignored and a parse error is recorded as a non-fatal warning.
 func applyDurationEnvField(cfg *Config, raw, varName string, target *time.Duration) {
 	trimmed := strings.TrimSpace(raw)
 	if trimmed == "" {
@@ -1733,16 +1838,22 @@ func applyDurationEnvField(cfg *Config, raw, varName string, target *time.Durati
 	*target = d
 }
 
+// applyX402EnvOverrides applies the basic and route-policy x402 env
+// overrides onto cfg.X402.
 func applyX402EnvOverrides(cfg *Config, env map[string]string) {
 	applyX402BasicEnvOverrides(cfg, env)
 	applyX402RouteEnvOverrides(cfg, env)
 }
 
+// applyX402BasicEnvOverrides applies the x402 endpoint and pricing env
+// overrides onto cfg.X402.
 func applyX402BasicEnvOverrides(cfg *Config, env map[string]string) {
 	applyX402EndpointEnvOverrides(cfg, env)
 	applyX402PricingEnvOverrides(cfg, env)
 }
 
+// applyX402EndpointEnvOverrides applies the x402 mode, facilitator
+// URL/token, and resource base URL env overrides (only when non-empty).
 func applyX402EndpointEnvOverrides(cfg *Config, env map[string]string) {
 	if raw, ok := envLookup("DIR2MCP_X402_MODE", env); ok && strings.TrimSpace(raw) != "" {
 		cfg.X402.Mode = strings.TrimSpace(raw)
@@ -1758,6 +1869,9 @@ func applyX402EndpointEnvOverrides(cfg *Config, env map[string]string) {
 	}
 }
 
+// applyX402PricingEnvOverrides applies the x402 tools-call-enabled and
+// price env overrides (warning on an invalid boolean and accepting a
+// compatibility alias for the price var).
 func applyX402PricingEnvOverrides(cfg *Config, env map[string]string) {
 	if raw, ok := envLookup("DIR2MCP_X402_TOOLS_CALL_ENABLED", env); ok && strings.TrimSpace(raw) != "" {
 		trimmed := strings.TrimSpace(raw)
@@ -1779,6 +1893,8 @@ func applyX402PricingEnvOverrides(cfg *Config, env map[string]string) {
 	}
 }
 
+// applyX402RouteEnvOverrides applies the x402 route-policy network,
+// scheme, asset, and pay-to env overrides (only when non-empty).
 func applyX402RouteEnvOverrides(cfg *Config, env map[string]string) {
 	if raw, ok := envLookup("DIR2MCP_X402_NETWORK", env); ok && strings.TrimSpace(raw) != "" {
 		cfg.X402.Network = strings.TrimSpace(raw)
@@ -1822,6 +1938,8 @@ func (c *Config) Validate() error {
 	return nil
 }
 
+// validateIngestExtractor normalizes IngestExtractor (defaulting empty)
+// and rejects any value outside auto/docling/mistral/off.
 func (c *Config) validateIngestExtractor() error {
 	extractorMode := strings.ToLower(strings.TrimSpace(c.IngestExtractor))
 	if extractorMode == "" {
@@ -1836,6 +1954,8 @@ func (c *Config) validateIngestExtractor() error {
 	return nil
 }
 
+// validateNumericBounds rejects negative session/health durations, RAG,
+// chunking, and ingest size values.
 func (c *Config) validateNumericBounds() error {
 	if c.SessionInactivityTimeout < 0 {
 		return fmt.Errorf("session_inactivity_timeout must be non-negative: %v", c.SessionInactivityTimeout)
@@ -1867,6 +1987,8 @@ func (c *Config) validateNumericBounds() error {
 	return nil
 }
 
+// applyValidationDefaults rewrites zero SessionInactivityTimeout and
+// HealthCheckInterval to their Default() values.
 func (c *Config) applyValidationDefaults() {
 	if c.SessionInactivityTimeout == 0 {
 		// zero is shorthand for the default
@@ -1941,6 +2063,10 @@ func (c *Config) ValidateX402(strict bool) error {
 	return c.validateX402Strict()
 }
 
+// validateX402Strict enforces the strict-mode x402 requirements:
+// facilitator/resource URLs, a positive integer price, a valid
+// scheme, a CAIP-2 network, and non-empty asset/pay_to. It normalizes
+// scheme and network in place.
 func (c *Config) validateX402Strict() error {
 	if strings.TrimSpace(c.X402.FacilitatorURL) == "" {
 		return fmt.Errorf("x402 facilitator URL is required")
@@ -1987,6 +2113,9 @@ func (c *Config) validateX402Strict() error {
 	return nil
 }
 
+// normalizeX402URL validates rawURL has a scheme and host and returns
+// it with any trailing slash trimmed; an empty input yields "" with no
+// error.
 func normalizeX402URL(rawURL, label string) (string, error) {
 	rawURL = strings.TrimSpace(rawURL)
 	if rawURL == "" {
@@ -2007,6 +2136,8 @@ func normalizeX402URL(rawURL, label string) (string, error) {
 	return parsed.String(), nil
 }
 
+// isCAIP2Network reports whether value is a CAIP-2 "namespace:reference"
+// identifier with valid lengths and character classes.
 func isCAIP2Network(value string) bool {
 	parts := strings.Split(strings.TrimSpace(value), ":")
 	if len(parts) != 2 {
@@ -2020,6 +2151,8 @@ func isCAIP2Network(value string) bool {
 	return isCAIP2Namespace(ns) && isCAIP2Reference(ref)
 }
 
+// isCAIP2Namespace reports whether ns contains only lowercase letters
+// and digits.
 func isCAIP2Namespace(ns string) bool {
 	for _, r := range ns {
 		if (r < 'a' || r > 'z') && (r < '0' || r > '9') {
@@ -2029,6 +2162,8 @@ func isCAIP2Namespace(ns string) bool {
 	return true
 }
 
+// isCAIP2Reference reports whether ref contains only alphanumerics,
+// hyphen, or underscore.
 func isCAIP2Reference(ref string) bool {
 	for _, r := range ref {
 		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' {
@@ -2071,6 +2206,9 @@ func MergeAllowedOrigins(existing []string, csv string) []string {
 	return merged
 }
 
+// normalizeOriginKey returns a canonical dedup key for origin
+// (scheme://host[:port] with default ports dropped, or host:port / bare
+// host), or "" if origin is invalid.
 func normalizeOriginKey(origin string) string {
 	origin = strings.TrimSpace(origin)
 	if origin == "" {
@@ -2128,6 +2266,8 @@ func MergeTrustedProxies(existing []string, csv string) []string {
 	return merged
 }
 
+// normalizeTrustedProxyKey returns the canonical CIDR string for value
+// (a CIDR or a single IP widened to /32 or /128), or "" if invalid.
 func normalizeTrustedProxyKey(value string) string {
 	value = strings.TrimSpace(value)
 	if value == "" {
@@ -2152,6 +2292,8 @@ func normalizeTrustedProxyKey(value string) string {
 	return (&net.IPNet{IP: ip, Mask: net.CIDRMask(128, 128)}).String()
 }
 
+// loadDotEnvFiles loads each dotenv path in order, stopping at the
+// first error.
 func loadDotEnvFiles(paths []string, overrideEnv map[string]string) error {
 	for _, p := range paths {
 		if err := loadDotEnvFile(p, overrideEnv); err != nil {
@@ -2161,6 +2303,9 @@ func loadDotEnvFiles(paths []string, overrideEnv map[string]string) error {
 	return nil
 }
 
+// loadDotEnvFile parses a dotenv file (supporting "export" and
+// quoting), setting each key only when not already present and
+// non-empty. A missing file is not an error.
 func loadDotEnvFile(path string, overrideEnv map[string]string) error {
 	file, err := os.Open(path)
 	if err != nil {
@@ -2204,6 +2349,8 @@ func loadDotEnvFile(path string, overrideEnv map[string]string) error {
 	return scanner.Err()
 }
 
+// envLookup reads key from overrideEnv when non-nil, otherwise from the
+// process environment.
 func envLookup(key string, overrideEnv map[string]string) (string, bool) {
 	if overrideEnv != nil {
 		val, ok := overrideEnv[key]
@@ -2212,6 +2359,8 @@ func envLookup(key string, overrideEnv map[string]string) (string, bool) {
 	return os.LookupEnv(key)
 }
 
+// envSet writes key=value into overrideEnv when non-nil, otherwise into
+// the process environment.
 func envSet(key, value string, overrideEnv map[string]string) error {
 	if overrideEnv != nil {
 		overrideEnv[key] = value
@@ -2220,6 +2369,8 @@ func envSet(key, value string, overrideEnv map[string]string) error {
 	return os.Setenv(key, value)
 }
 
+// unquoteEnvValue strips matching surrounding quotes from a dotenv
+// value (interpreting escapes only for double quotes).
 func unquoteEnvValue(v string) string {
 	if len(v) >= 2 {
 		if strings.HasPrefix(v, "\"") && strings.HasSuffix(v, "\"") {


### PR DESCRIPTION
## Summary

Dedicated follow-up to the **C2-iii-b** clean break (PR #205). During #205's review, CodeRabbit's repo-wide **Docstring Coverage** pre-merge gate (80% threshold) flagged ~127 pre-existing undocumented functions in two large files. Documenting them inside #205 would have broken change scoping (and flipped CodeRabbit's *Out-of-Scope* check to fail), so per maintainer decision it was deferred to this dedicated PR — clearing the gate on its own merits without polluting the clean break.

## Changes

- Added Go doc comments to **all** previously-undocumented top-level functions/methods:
  - `internal/config/config.go` — 64 functions
  - `internal/cli/app.go` — 62 functions
- Comments follow Go convention (start with the symbol name), are terse/technical to match the existing house style, and accurately reflect each function's behavior (including the post-clean-break provider-resolution model where relevant).

## Scope / safety

- **Doc-comment-only**: no code, behavior, control flow, or imports changed.
- The single non-comment delta is `gofmt` re-collapsing the `strPtr`/`boolPtr`/`intPtr` column-alignment block once doc comments separate the declarations — signatures/bodies are byte-identical when whitespace-normalized.
- Zero undocumented top-level `func` declarations remain in either file.

## Verification

`make check` green: `gofmt`, `go vet`, `golangci-lint` (`0 issues`), `misspell`, all Go suites, Python tests, build.

No `Closes`/`Fixes` keyword — this is internal-quality work with no corresponding GitHub issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded code documentation and internal comments for improved clarity.

* **Refactor**
  * Restructured and reorganized internal helper logic for better maintainability and readability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dirstral/dir2mcp/pull/206?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->