### PR TITLE
fix(ci): install ineffassign and misspell in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,12 @@ jobs:
       - name: Install gocyclo
         run: go install github.com/fzipp/gocyclo/cmd/gocyclo@v0.6.0
 
+      - name: Install ineffassign
+        run: go install github.com/gordonklaus/ineffassign@latest
+
+      - name: Install misspell
+        run: go install github.com/client9/misspell/cmd/misspell@v0.3.4
+
       - name: Add Go bin to PATH
         run: echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 


### PR DESCRIPTION
## Summary
- install ineffassign in release workflow before `make ci`
- install misspell in release workflow before `make ci`
- unblock tagged release pipeline so GoReleaser and tap bump can run

## Why
The v0.5.4 tag workflow failed in Run checks because ineffassign was missing on the runner.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the release workflow with additional code quality verification tools to improve the release process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dirstral/dir2mcp/pull/207?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->