### PR TITLE
fix(cli): default install claude to resolved server name

### DIFF
--- a/internal/cli/claude_cmd.go
+++ b/internal/cli/claude_cmd.go
@@ -13,11 +13,21 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/dirstral/dir2mcp/internal/config"
 )
 
 type claudeServerConfig struct {
 	Command string   `json:"command"`
 	Args    []string `json:"args,omitempty"`
+}
+
+func resolveClaudeServerName(cfg *config.Config, override string) string {
+	resolveServerName(cfg)
+	if t := strings.TrimSpace(override); t != "" {
+		return t
+	}
+	return cfg.ServerName
 }
 
 func (a *App) runClaudePrintConfig(global globalOptions, args []string) int {
@@ -39,11 +49,7 @@ func (a *App) runClaudePrintConfig(global globalOptions, args []string) int {
 		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("load config: %v", err))
 		return exitConfigInvalid
 	}
-	resolveServerName(&cfg)
-	effectiveServerName := strings.TrimSpace(*serverName)
-	if effectiveServerName == "" {
-		effectiveServerName = cfg.ServerName
-	}
+	effectiveServerName := resolveClaudeServerName(&cfg, *serverName)
 	effectiveStateDir := cfg.StateDir
 	if strings.TrimSpace(*stateDir) != "" {
 		effectiveStateDir = strings.TrimSpace(*stateDir)
@@ -98,11 +104,7 @@ func (a *App) runClaudeInstall(global globalOptions, args []string) int {
 		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("load config: %v", err))
 		return exitConfigInvalid
 	}
-	resolveServerName(&cfg)
-	effectiveServerName := strings.TrimSpace(*serverName)
-	if effectiveServerName == "" {
-		effectiveServerName = cfg.ServerName
-	}
+	effectiveServerName := resolveClaudeServerName(&cfg, *serverName)
 	effectiveStateDir := cfg.StateDir
 	if strings.TrimSpace(*stateDir) != "" {
 		effectiveStateDir = strings.TrimSpace(*stateDir)
@@ -170,7 +172,7 @@ func (a *App) runClaudeInstall(global globalOptions, args []string) int {
 func (a *App) runClaudeUninstall(global globalOptions, args []string) int {
 	fs := flag.NewFlagSet("uninstall claude", flag.ContinueOnError)
 	fs.SetOutput(ioDiscard{})
-	serverName := fs.String("name", "dir2mcp", "server name to remove from Claude config")
+	serverName := fs.String("name", "", "server name to remove (defaults to configured/auto-derived name)")
 	configPath := fs.String("config-path", defaultClaudeDesktopConfigPath(), "Claude Desktop config path")
 	if err := fs.Parse(args); err != nil {
 		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("invalid uninstall claude flags: %v", err))
@@ -180,6 +182,12 @@ func (a *App) runClaudeUninstall(global globalOptions, args []string) int {
 		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("uninstall claude does not accept positional arguments: %s", strings.Join(fs.Args(), " ")))
 		return exitConfigInvalid
 	}
+	cfg, err := loadConfigWithGlobalOptions(global)
+	if err != nil {
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("load config: %v", err))
+		return exitConfigInvalid
+	}
+	effectiveServerName := resolveClaudeServerName(&cfg, *serverName)
 
 	// Loading the file into a map preserves any unrelated mcpServers entries
 	// the user may have configured for other tools — we only touch our own.
@@ -199,7 +207,7 @@ func (a *App) runClaudeUninstall(global globalOptions, args []string) int {
 		}
 	}
 
-	_, present := mcpServers[*serverName]
+	_, present := mcpServers[effectiveServerName]
 	if !present {
 		// Idempotent no-op: it's not an error to uninstall something that
 		// isn't installed. Report and exit clean so scripts can run this
@@ -207,7 +215,7 @@ func (a *App) runClaudeUninstall(global globalOptions, args []string) int {
 		if global.jsonOutput {
 			if err := emitJSON(a.stdout, map[string]interface{}{
 				"path":        *configPath,
-				"server_name": *serverName,
+				"server_name": effectiveServerName,
 				"removed":     false,
 				"reason":      "entry_not_present",
 			}); err != nil {
@@ -216,11 +224,11 @@ func (a *App) runClaudeUninstall(global globalOptions, args []string) int {
 			}
 			return exitSuccess
 		}
-		writef(a.stdout, "no MCP server %q in %s; nothing to remove\n", *serverName, *configPath)
+		writef(a.stdout, "no MCP server %q in %s; nothing to remove\n", effectiveServerName, *configPath)
 		return exitSuccess
 	}
 
-	delete(mcpServers, *serverName)
+	delete(mcpServers, effectiveServerName)
 	if len(mcpServers) == 0 {
 		// Drop the now-empty mcpServers key entirely so the resulting JSON
 		// matches the never-installed shape (modulo any unrelated keys).
@@ -237,7 +245,7 @@ func (a *App) runClaudeUninstall(global globalOptions, args []string) int {
 	if global.jsonOutput {
 		if err := emitJSON(a.stdout, map[string]interface{}{
 			"path":        *configPath,
-			"server_name": *serverName,
+			"server_name": effectiveServerName,
 			"removed":     true,
 		}); err != nil {
 			writeCLIError(a.stderr, true, exitGeneric, fmt.Sprintf("encode claude uninstall json: %v", err))
@@ -245,7 +253,7 @@ func (a *App) runClaudeUninstall(global globalOptions, args []string) int {
 		}
 		return exitSuccess
 	}
-	writef(a.stdout, "removed MCP server %q from %s\n", *serverName, *configPath)
+	writef(a.stdout, "removed MCP server %q from %s\n", effectiveServerName, *configPath)
 	writef(a.stdout, "restart Claude Desktop to drop the server entry\n")
 	return exitSuccess
 }

--- a/internal/cli/claude_cmd.go
+++ b/internal/cli/claude_cmd.go
@@ -23,7 +23,7 @@ type claudeServerConfig struct {
 func (a *App) runClaudePrintConfig(global globalOptions, args []string) int {
 	fs := flag.NewFlagSet("print-config claude", flag.ContinueOnError)
 	fs.SetOutput(ioDiscard{})
-	serverName := fs.String("name", "dir2mcp", "server name")
+	serverName := fs.String("name", "", "server name (defaults to configured/auto-derived name)")
 	stateDir := fs.String("state-dir", "", "state directory containing connection.json")
 	if err := fs.Parse(args); err != nil {
 		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("invalid print-config claude flags: %v", err))
@@ -39,6 +39,11 @@ func (a *App) runClaudePrintConfig(global globalOptions, args []string) int {
 		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("load config: %v", err))
 		return exitConfigInvalid
 	}
+	resolveServerName(&cfg)
+	effectiveServerName := strings.TrimSpace(*serverName)
+	if effectiveServerName == "" {
+		effectiveServerName = cfg.ServerName
+	}
 	effectiveStateDir := cfg.StateDir
 	if strings.TrimSpace(*stateDir) != "" {
 		effectiveStateDir = strings.TrimSpace(*stateDir)
@@ -53,7 +58,7 @@ func (a *App) runClaudePrintConfig(global globalOptions, args []string) int {
 
 	payload := map[string]interface{}{
 		"mcpServers": map[string]interface{}{
-			*serverName: entry,
+			effectiveServerName: entry,
 		},
 	}
 	if global.jsonOutput {
@@ -76,7 +81,7 @@ func (a *App) runClaudePrintConfig(global globalOptions, args []string) int {
 func (a *App) runClaudeInstall(global globalOptions, args []string) int {
 	fs := flag.NewFlagSet("install claude", flag.ContinueOnError)
 	fs.SetOutput(ioDiscard{})
-	serverName := fs.String("name", "dir2mcp", "server name")
+	serverName := fs.String("name", "", "server name (defaults to configured/auto-derived name)")
 	stateDir := fs.String("state-dir", "", "state directory containing connection.json")
 	configPath := fs.String("config-path", defaultClaudeDesktopConfigPath(), "Claude Desktop config path")
 	if err := fs.Parse(args); err != nil {
@@ -92,6 +97,11 @@ func (a *App) runClaudeInstall(global globalOptions, args []string) int {
 	if err != nil {
 		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("load config: %v", err))
 		return exitConfigInvalid
+	}
+	resolveServerName(&cfg)
+	effectiveServerName := strings.TrimSpace(*serverName)
+	if effectiveServerName == "" {
+		effectiveServerName = cfg.ServerName
 	}
 	effectiveStateDir := cfg.StateDir
 	if strings.TrimSpace(*stateDir) != "" {
@@ -128,7 +138,7 @@ func (a *App) runClaudeInstall(global globalOptions, args []string) int {
 		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("prepare Claude MCP entry: %v", err))
 		return exitGeneric
 	}
-	mcpServers[*serverName] = entryRaw
+	mcpServers[effectiveServerName] = entryRaw
 	root["mcpServers"] = mcpServers
 
 	if err := os.MkdirAll(filepath.Dir(*configPath), 0o755); err != nil {
@@ -143,7 +153,7 @@ func (a *App) runClaudeInstall(global globalOptions, args []string) int {
 	if global.jsonOutput {
 		if err := emitJSON(a.stdout, map[string]interface{}{
 			"path":        *configPath,
-			"server_name": *serverName,
+			"server_name": effectiveServerName,
 			"command":     commandPath,
 			"updated":     true,
 		}); err != nil {
@@ -152,7 +162,7 @@ func (a *App) runClaudeInstall(global globalOptions, args []string) int {
 		}
 		return exitSuccess
 	}
-	writef(a.stdout, "updated %s with MCP server %q\n", *configPath, *serverName)
+	writef(a.stdout, "updated %s with MCP server %q\n", *configPath, effectiveServerName)
 	writef(a.stdout, "restart Claude Desktop to load the updated MCP server entry\n")
 	return exitSuccess
 }

--- a/tests/cli/claude_command_test.go
+++ b/tests/cli/claude_command_test.go
@@ -137,50 +137,15 @@ func TestClaudeInstallDefaultsToResolvedServerName(t *testing.T) {
 	if err := os.MkdirAll(rootDir, 0o755); err != nil {
 		t.Fatalf("mkdir root: %v", err)
 	}
-	stateDir := filepath.Join(tmp, "state")
-	if err := os.MkdirAll(stateDir, 0o755); err != nil {
-		t.Fatalf("mkdir state: %v", err)
-	}
-	tokenPath := filepath.Join(stateDir, "secret.token")
-	if err := os.WriteFile(tokenPath, []byte("tok-auto\n"), 0o600); err != nil {
-		t.Fatalf("write token: %v", err)
-	}
-	connection := map[string]interface{}{
-		"transport":    "mcp_streamable_http",
-		"url":          "http://127.0.0.1:9882/mcp",
-		"headers":      map[string]string{"MCP-Protocol-Version": "2025-11-25"},
-		"session":      map[string]interface{}{"uses_mcp_session_id": true, "header_name": "MCP-Session-Id", "assigned_on_initialize": true},
-		"public":       false,
-		"token_source": "secret.token",
-		"token_file":   tokenPath,
-	}
-	raw, _ := json.Marshal(connection)
-	if err := os.WriteFile(filepath.Join(stateDir, "connection.json"), raw, 0o644); err != nil {
-		t.Fatalf("write connection: %v", err)
-	}
+	stateDir, _ := writeClaudeStateFixture(t, tmp, "tok-auto")
 
 	configPath := filepath.Join(tmp, "claude_desktop_config.json")
 	if err := os.WriteFile(configPath, []byte("{\"preferences\":{\"coworkWebSearchEnabled\":true}}\n"), 0o644); err != nil {
 		t.Fatalf("write initial config: %v", err)
 	}
 
-	absRoot, err := filepath.Abs(rootDir)
-	if err != nil {
-		t.Fatalf("abs root: %v", err)
-	}
-	wantName := identity.Resolve(absRoot, "", buildinfo.IsDev())
-	wantPrefix := wantName[:strings.LastIndex(wantName, "-")+1]
-
-	oldWD, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	if err := os.Chdir(rootDir); err != nil {
-		t.Fatalf("chdir root: %v", err)
-	}
-	t.Cleanup(func() {
-		_ = os.Chdir(oldWD)
-	})
+	wantPrefix := resolvedServerNamePrefix(t, rootDir)
+	withCWD(t, rootDir)
 
 	var stdout, stderr bytes.Buffer
 	app := cli.NewAppWithIO(&stdout, &stderr)
@@ -218,6 +183,34 @@ func TestClaudeInstallDefaultsToResolvedServerName(t *testing.T) {
 	if _, legacy := mcpServers["dir2mcp"]; legacy {
 		t.Fatalf("legacy fixed server name should not be written by default: %+v", mcpServers)
 	}
+}
+
+func resolvedServerNamePrefix(t *testing.T, rootDir string) string {
+	t.Helper()
+	absRoot, err := filepath.Abs(rootDir)
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+	wantName := identity.Resolve(absRoot, "", buildinfo.IsDev())
+	idx := strings.LastIndex(wantName, "-")
+	if idx <= 0 {
+		t.Fatalf("unexpected resolved name without separator: %q", wantName)
+	}
+	return wantName[:idx+1]
+}
+
+func withCWD(t *testing.T, dir string) {
+	t.Helper()
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir %s: %v", dir, err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(oldWD)
+	})
 }
 
 func TestClaudeDoctorPassesWithValidState(t *testing.T) {
@@ -364,6 +357,7 @@ func TestClaudeUninstallRemovesEntryAndPreservesUnrelatedKeys(t *testing.T) {
 	code := app.RunWithContext(context.Background(), []string{
 		"uninstall", "claude",
 		"--config-path", configPath,
+		"--name", "dir2mcp",
 	})
 	if code != 0 {
 		t.Fatalf("unexpected exit code: %d stderr=%s", code, stderr.String())
@@ -410,6 +404,7 @@ func TestClaudeUninstallDropsEmptyMCPServersBlock(t *testing.T) {
 	code := app.RunWithContext(context.Background(), []string{
 		"uninstall", "claude",
 		"--config-path", configPath,
+		"--name", "dir2mcp",
 	})
 	if code != 0 {
 		t.Fatalf("unexpected exit code: %d stderr=%s", code, stderr.String())

--- a/tests/cli/claude_command_test.go
+++ b/tests/cli/claude_command_test.go
@@ -9,7 +9,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/dirstral/dir2mcp/internal/buildinfo"
 	"github.com/dirstral/dir2mcp/internal/cli"
+	"github.com/dirstral/dir2mcp/internal/identity"
 )
 
 func TestClaudePrintConfigEmitsMCPServerBlock(t *testing.T) {
@@ -126,6 +128,95 @@ func TestClaudeInstallUpdatesConfigFile(t *testing.T) {
 	}
 	if _, ok := mcpServers["stas-legal-dir2mcp"]; !ok {
 		t.Fatalf("named server not written: %+v", mcpServers)
+	}
+}
+
+func TestClaudeInstallDefaultsToResolvedServerName(t *testing.T) {
+	tmp := t.TempDir()
+	rootDir := filepath.Join(tmp, "stas-legal-main")
+	if err := os.MkdirAll(rootDir, 0o755); err != nil {
+		t.Fatalf("mkdir root: %v", err)
+	}
+	stateDir := filepath.Join(tmp, "state")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state: %v", err)
+	}
+	tokenPath := filepath.Join(stateDir, "secret.token")
+	if err := os.WriteFile(tokenPath, []byte("tok-auto\n"), 0o600); err != nil {
+		t.Fatalf("write token: %v", err)
+	}
+	connection := map[string]interface{}{
+		"transport":    "mcp_streamable_http",
+		"url":          "http://127.0.0.1:9882/mcp",
+		"headers":      map[string]string{"MCP-Protocol-Version": "2025-11-25"},
+		"session":      map[string]interface{}{"uses_mcp_session_id": true, "header_name": "MCP-Session-Id", "assigned_on_initialize": true},
+		"public":       false,
+		"token_source": "secret.token",
+		"token_file":   tokenPath,
+	}
+	raw, _ := json.Marshal(connection)
+	if err := os.WriteFile(filepath.Join(stateDir, "connection.json"), raw, 0o644); err != nil {
+		t.Fatalf("write connection: %v", err)
+	}
+
+	configPath := filepath.Join(tmp, "claude_desktop_config.json")
+	if err := os.WriteFile(configPath, []byte("{\"preferences\":{\"coworkWebSearchEnabled\":true}}\n"), 0o644); err != nil {
+		t.Fatalf("write initial config: %v", err)
+	}
+
+	absRoot, err := filepath.Abs(rootDir)
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+	wantName := identity.Resolve(absRoot, "", buildinfo.IsDev())
+	wantPrefix := wantName[:strings.LastIndex(wantName, "-")+1]
+
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(rootDir); err != nil {
+		t.Fatalf("chdir root: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(oldWD)
+	})
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	code := app.RunWithContext(context.Background(), []string{
+		"--state-dir", stateDir,
+		"install", "claude",
+		"--config-path", configPath,
+	})
+	if code != 0 {
+		t.Fatalf("unexpected exit code: %d stderr=%s", code, stderr.String())
+	}
+
+	updatedRaw, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read updated config: %v", err)
+	}
+	var updated map[string]interface{}
+	if err := json.Unmarshal(updatedRaw, &updated); err != nil {
+		t.Fatalf("unmarshal updated config: %v raw=%s", err, string(updatedRaw))
+	}
+	mcpServers, ok := updated["mcpServers"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("mcpServers missing after install: %+v", updated)
+	}
+	var found bool
+	for k := range mcpServers {
+		if strings.HasPrefix(k, wantPrefix) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("auto-derived server prefix %q not written: %+v", wantPrefix, mcpServers)
+	}
+	if _, legacy := mcpServers["dir2mcp"]; legacy {
+		t.Fatalf("legacy fixed server name should not be written by default: %+v", mcpServers)
 	}
 }
 


### PR DESCRIPTION
## Summary
- make `install claude` default to the resolved server name (configured or auto-derived)
- apply the same defaulting behavior to `print-config claude`
- add a regression test proving default install no longer writes literal `dir2mcp`

## Why
The up banner advertises unique names (e.g. `dir2mcp-stas-legal-<hash>`), but `dir2mcp install claude` previously hardcoded `dir2mcp` unless `--name` was supplied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `install claude` and `print-config claude` commands now intelligently resolve the MCP server name when not explicitly specified, ensuring consistent configuration generation across all output formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dirstral/dir2mcp/pull/208?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->