### PR TITLE
feat(diagnostics): doctor + failure-summary + structured error categories

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -272,17 +272,18 @@ type corpusSnapshot struct {
 // the ListFiles-only fallback path where those metrics cannot be derived from
 // the store. Consumers should treat -1 as "unknown", not as an error.
 type corpusIndexing struct {
-	Mode            string `json:"mode"`
-	Running         bool   `json:"running"`
-	Scanned         int64  `json:"scanned"`
-	Indexed         int64  `json:"indexed"`
-	Skipped         int64  `json:"skipped"`
-	Deleted         int64  `json:"deleted"`
-	Representations int64  `json:"representations"`
-	ChunksTotal     int64  `json:"chunks_total"`
-	EmbeddedOK      int64  `json:"embedded_ok"`
-	Errors          int64  `json:"errors"`
-	Unknown         int64  `json:"unknown"`
+	Mode            string                `json:"mode"`
+	Running         bool                  `json:"running"`
+	Scanned         int64                 `json:"scanned"`
+	Indexed         int64                 `json:"indexed"`
+	Skipped         int64                 `json:"skipped"`
+	Deleted         int64                 `json:"deleted"`
+	Representations int64                 `json:"representations"`
+	ChunksTotal     int64                 `json:"chunks_total"`
+	EmbeddedOK      int64                 `json:"embedded_ok"`
+	Errors          int64                 `json:"errors"`
+	Unknown         int64                 `json:"unknown"`
+	FailureSummary  *model.FailureSummary `json:"failure_summary,omitempty"`
 }
 
 // NewApp constructs an App wired to os.Stdout and os.Stderr.
@@ -1759,6 +1760,12 @@ func buildCorpusSnapshot(ctx context.Context, st model.Store, indexingState *app
 			EmbeddedOK:      idx.EmbeddedOK,
 			Errors:          idx.Errors,
 			Unknown:         idx.Unknown,
+			// FailureSummary travels straight through from the
+			// aggregate CorpusStats so `status --json` consumers see
+			// the same grouping the doctor renders. Omitted from JSON
+			// when no failures have been recorded (omitempty on the
+			// struct tag).
+			FailureSummary: corpusStats.FailureSummary,
 		},
 		DocCounts: docCounts,
 		TotalDocs: totalDocs,

--- a/internal/cli/client_cmds.go
+++ b/internal/cli/client_cmds.go
@@ -80,10 +80,16 @@ func (a *App) runUninstall(_ context.Context, global globalOptions, args []strin
 	}
 }
 
-// runDoctor runs client-specific diagnostics — bridge command
-// resolution, connection URL validity, endpoint reachability, token
-// presence — for the requested client.
+// runDoctor dispatches to either the daemon-side preflight (no
+// positional client argument) or a client-specific integration check
+// (`dir2mcp doctor claude`). The two paths are intentionally separate
+// commands sharing one CLI verb: the daemon flavour answers "is this
+// install healthy?", the client flavour answers "is this client wired
+// up correctly?".
 func (a *App) runDoctor(ctx context.Context, global globalOptions, args []string) int {
+	if len(args) == 0 {
+		return a.runServerDoctor(ctx, global, args)
+	}
 	client, rest, ok := extractClient(a, global.jsonOutput, "doctor", args)
 	if !ok {
 		return exitConfigInvalid

--- a/internal/cli/server_doctor.go
+++ b/internal/cli/server_doctor.go
@@ -155,7 +155,14 @@ func extractorCheck(cfg config.Config) doctorCheck {
 func indexingFailureCheck(ctx context.Context, a *App, cfg config.Config) doctorCheck {
 	metaPath := filepath.Join(cfg.StateDir, "meta.sqlite")
 	if _, err := os.Stat(metaPath); err != nil {
-		return doctorCheck{Name: "indexing_failures", Status: doctorStatusOK, Detail: "no index yet"}
+		// Only ENOENT is the legitimate "no index yet" path. A
+		// permission or I/O failure here would otherwise be reported
+		// as healthy, hiding the actual blocker.
+		if errors.Is(err, os.ErrNotExist) {
+			return doctorCheck{Name: "indexing_failures", Status: doctorStatusOK, Detail: "no index yet"}
+		}
+		return doctorCheck{Name: "indexing_failures", Status: doctorStatusError,
+			Detail: fmt.Sprintf("stat %s: %v", metaPath, err)}
 	}
 	st := a.storeForConfig(cfg)
 	defer func() { _ = st.Close() }()
@@ -189,9 +196,19 @@ func summarizeFailureCategories(categories map[string]int64) string {
 	for k, v := range categories {
 		entries = append(entries, entry{category: k, count: v})
 	}
-	// Insertion sort for stability + simplicity over a tiny N.
+	// Insertion sort for stability + simplicity over a tiny N. Tied
+	// counts break by category name ascending so the output is
+	// byte-identical across runs (Go map iteration would otherwise
+	// randomize the seed order before the sort, leaving ties
+	// non-deterministic).
 	for i := 1; i < len(entries); i++ {
-		for j := i; j > 0 && entries[j-1].count < entries[j].count; j-- {
+		for j := i; j > 0; j-- {
+			if entries[j-1].count > entries[j].count {
+				break
+			}
+			if entries[j-1].count == entries[j].count && entries[j-1].category < entries[j].category {
+				break
+			}
 			entries[j-1], entries[j] = entries[j], entries[j-1]
 		}
 	}

--- a/internal/cli/server_doctor.go
+++ b/internal/cli/server_doctor.go
@@ -1,0 +1,241 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/provider"
+	"github.com/dirstral/dir2mcp/internal/providerfactory"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// doctorCheck is one entry in the daemon-side `dir2mcp doctor` report.
+// Status is one of "ok", "warn", or "error"; Detail is rendered
+// verbatim in both the text and JSON output and should be a single
+// human-readable line explaining the result or, on failure, the
+// remediation hint.
+type doctorCheck struct {
+	Name   string `json:"name"`
+	Status string `json:"status"`
+	Detail string `json:"detail,omitempty"`
+}
+
+const (
+	doctorStatusOK    = "ok"
+	doctorStatusWarn  = "warn"
+	doctorStatusError = "error"
+)
+
+// runServerDoctor produces a daemon-side preflight report covering
+// config loadability, state-dir writability, provider resolution for
+// each capability the server uses, extractor availability, and recent
+// indexing-failure aggregation. It does NOT contact remote providers
+// — keeping the command fast and side-effect-free was deliberately
+// preferred over deeper "ping" checks that would slow it down and
+// could fail for transient unrelated reasons.
+func (a *App) runServerDoctor(ctx context.Context, global globalOptions, args []string) int {
+	if len(args) > 0 {
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid,
+			fmt.Sprintf("dir2mcp doctor (server-side) does not accept arguments: %s", strings.Join(args, " ")))
+		return exitConfigInvalid
+	}
+
+	cfg, cfgErr := loadConfigWithGlobalOptions(global)
+	checks := []doctorCheck{configCheck(cfgErr)}
+	if cfgErr != nil {
+		return a.renderDoctorReport(global, checks)
+	}
+	if strings.TrimSpace(cfg.StateDir) == "" {
+		cfg.StateDir = filepath.Join(".", ".dir2mcp")
+	}
+
+	checks = append(checks,
+		stateDirCheck(cfg.StateDir),
+		providerCheck(cfg, "embed", provider.CapEmbed, true),
+		providerCheck(cfg, "chat", provider.CapChat, false),
+		extractorCheck(cfg),
+		indexingFailureCheck(ctx, a, cfg),
+	)
+	return a.renderDoctorReport(global, checks)
+}
+
+// configCheck reports whether the layered config loaded cleanly.
+// A load failure short-circuits the rest of the doctor run since
+// every subsequent check depends on it.
+func configCheck(err error) doctorCheck {
+	if err != nil {
+		return doctorCheck{Name: "config", Status: doctorStatusError, Detail: err.Error()}
+	}
+	return doctorCheck{Name: "config", Status: doctorStatusOK, Detail: "loaded"}
+}
+
+// stateDirCheck verifies the configured state directory exists and is
+// writable. It deliberately uses a real probe (touch a temp file)
+// instead of a stat-only check because permission bits don't always
+// reflect the effective writability of a path (mounts, ACLs).
+func stateDirCheck(stateDir string) doctorCheck {
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		return doctorCheck{Name: "state_dir", Status: doctorStatusError, Detail: fmt.Sprintf("mkdir %s: %v", stateDir, err)}
+	}
+	probe, err := os.CreateTemp(stateDir, "doctor-probe-*")
+	if err != nil {
+		return doctorCheck{Name: "state_dir", Status: doctorStatusError, Detail: fmt.Sprintf("write %s: %v", stateDir, err)}
+	}
+	_ = probe.Close()
+	_ = os.Remove(probe.Name())
+	return doctorCheck{Name: "state_dir", Status: doctorStatusOK, Detail: stateDir}
+}
+
+// providerCheck resolves cap through the provider model and, when
+// resolved, asks providerfactory to build the matching adapter so the
+// check fails fast on a configured-but-unusable profile. required
+// distinguishes capabilities that must be present (embed) from those
+// that degrade gracefully when absent (chat).
+func providerCheck(cfg config.Config, label string, cap provider.Capability, required bool) doctorCheck {
+	prof, err := cfg.Providers().Resolve(cap)
+	if err != nil {
+		status := doctorStatusError
+		if !required {
+			status = doctorStatusWarn
+		}
+		var ce *provider.ConfigError
+		if errors.As(err, &ce) {
+			return doctorCheck{Name: "provider." + label, Status: status, Detail: ce.Error()}
+		}
+		return doctorCheck{Name: "provider." + label, Status: status, Detail: err.Error()}
+	}
+	if cap == provider.CapEmbed {
+		if _, ferr := providerfactory.Embedder(prof); ferr != nil {
+			return doctorCheck{Name: "provider." + label, Status: doctorStatusError,
+				Detail: fmt.Sprintf("profile %q unusable: %v", prof.Name, ferr)}
+		}
+	}
+	return doctorCheck{Name: "provider." + label, Status: doctorStatusOK, Detail: prof.Name}
+}
+
+// extractorCheck delegates to ingest.DescribeDocumentExtractor so the
+// doctor, the up banner, and the support-bundle all agree on the
+// routing story for OCR. Disabled extractors and fallback selections
+// surface as warns (not errors) — operators may intentionally turn
+// OCR off, and the Mistral fallback is functional even if not the
+// preferred choice.
+func extractorCheck(cfg config.Config) doctorCheck {
+	d := ingest.DescribeDocumentExtractor(cfg)
+	if d.Name == "" {
+		return doctorCheck{Name: "extractor", Status: doctorStatusWarn, Detail: d.Reason}
+	}
+	detail := d.Name
+	if d.Reason != "" {
+		detail = fmt.Sprintf("%s (%s)", d.Name, d.Reason)
+	}
+	status := doctorStatusOK
+	if d.Source == "fallback" {
+		status = doctorStatusWarn
+	}
+	return doctorCheck{Name: "extractor", Status: status, Detail: detail}
+}
+
+// indexingFailureCheck reads the store-level FailureSummary (set by
+// CorpusStats) and reports the dominant failure category, if any. The
+// goal is to surface "67 of 89 errors are rate_limit" at preflight
+// time so the operator knows where to look without having to grep
+// server.log. Missing state and zero-failure corpora both pass.
+//
+// The check requires the SQLite-backed store because CorpusStats is
+// not on the model.Store interface; with a non-sqlite store the check
+// degrades to a warn rather than failing the whole doctor run.
+func indexingFailureCheck(ctx context.Context, a *App, cfg config.Config) doctorCheck {
+	metaPath := filepath.Join(cfg.StateDir, "meta.sqlite")
+	if _, err := os.Stat(metaPath); err != nil {
+		return doctorCheck{Name: "indexing_failures", Status: doctorStatusOK, Detail: "no index yet"}
+	}
+	st := a.storeForConfig(cfg)
+	defer func() { _ = st.Close() }()
+	sqliteStore, ok := st.(*store.SQLiteStore)
+	if !ok {
+		return doctorCheck{Name: "indexing_failures", Status: doctorStatusWarn,
+			Detail: "store is not SQLite-backed; failure aggregation unavailable"}
+	}
+	if err := sqliteStore.Init(ctx); err != nil && !errors.Is(err, model.ErrNotImplemented) {
+		return doctorCheck{Name: "indexing_failures", Status: doctorStatusError, Detail: fmt.Sprintf("initialize store: %v", err)}
+	}
+	stats, err := sqliteStore.CorpusStats(ctx)
+	if err != nil {
+		return doctorCheck{Name: "indexing_failures", Status: doctorStatusError, Detail: err.Error()}
+	}
+	if stats.FailureSummary == nil || len(stats.FailureSummary.Categories) == 0 {
+		return doctorCheck{Name: "indexing_failures", Status: doctorStatusOK, Detail: "0 failures"}
+	}
+	return doctorCheck{Name: "indexing_failures", Status: doctorStatusWarn, Detail: summarizeFailureCategories(stats.FailureSummary.Categories)}
+}
+
+// summarizeFailureCategories renders the failure-category map as a
+// compact "category=count, ..." string sorted by count descending so
+// the most-frequent failure mode appears first.
+func summarizeFailureCategories(categories map[string]int64) string {
+	type entry struct {
+		category string
+		count    int64
+	}
+	entries := make([]entry, 0, len(categories))
+	for k, v := range categories {
+		entries = append(entries, entry{category: k, count: v})
+	}
+	// Insertion sort for stability + simplicity over a tiny N.
+	for i := 1; i < len(entries); i++ {
+		for j := i; j > 0 && entries[j-1].count < entries[j].count; j-- {
+			entries[j-1], entries[j] = entries[j], entries[j-1]
+		}
+	}
+	parts := make([]string, 0, len(entries))
+	for _, e := range entries {
+		parts = append(parts, fmt.Sprintf("%s=%d", e.category, e.count))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// renderDoctorReport emits checks as either JSON (one object with an
+// "ok" rollup boolean + the checks array) or as a human-readable text
+// block. Exit code is 0 unless any check is at error severity; warn
+// does not fail the command so operators can keep using doctor in
+// scripts that only care about hard failures.
+func (a *App) renderDoctorReport(global globalOptions, checks []doctorCheck) int {
+	exitCode := exitSuccess
+	for _, c := range checks {
+		if c.Status == doctorStatusError {
+			exitCode = exitGeneric
+			break
+		}
+	}
+
+	if global.jsonOutput {
+		_ = emitJSON(a.stdout, map[string]interface{}{
+			"ok":     exitCode == exitSuccess,
+			"checks": checks,
+		})
+		return exitCode
+	}
+
+	if !global.quiet {
+		printDoctorChecks(a.stdout, checks)
+	}
+	return exitCode
+}
+
+// printDoctorChecks emits checks as one line per check, with a
+// leading status tag so the output is easy to scan. Kept dependency-
+// free of the styles package so it works identically under --quiet
+// suppression and inside support-bundle captures.
+func printDoctorChecks(out io.Writer, checks []doctorCheck) {
+	for _, c := range checks {
+		_, _ = fmt.Fprintf(out, "%-20s %-5s  %s\n", c.Name, c.Status, c.Detail)
+	}
+}

--- a/internal/index/embedding_worker.go
+++ b/internal/index/embedding_worker.go
@@ -10,12 +10,20 @@ import (
 	"time"
 
 	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
 )
 
 type ChunkSource interface {
 	NextPending(ctx context.Context, limit int, indexKind string) ([]model.ChunkTask, error)
 	MarkEmbedded(ctx context.Context, labels []uint64) error
 	MarkFailed(ctx context.Context, labels []uint64, reason string) error
+	// MarkFailedWithCategory is the classification-aware variant. New
+	// failure write sites should use it so dir2mcp status / doctor /
+	// support-bundle can group errors by cause. category is the string
+	// form of store.ErrorCategory so the interface contract stays
+	// loose — implementations don't need to depend on the store
+	// package's type.
+	MarkFailedWithCategory(ctx context.Context, labels []uint64, category, reason string) error
 }
 
 type EmbeddingWorker struct {
@@ -95,7 +103,8 @@ func (w *EmbeddingWorker) indexChunks(ctx context.Context, validTasks []model.Ch
 					w.logf("mark embedded warning: failed to mark %d chunks as embedded before index error: %v labels=%v", idx, err, labels[:idx])
 				}
 			}
-			if mfErr := w.Source.MarkFailed(ctx, labels[idx:idx+1], addErr.Error()); mfErr != nil {
+			category := string(store.ClassifyError(addErr))
+			if mfErr := w.Source.MarkFailedWithCategory(ctx, labels[idx:idx+1], category, addErr.Error()); mfErr != nil {
 				w.logf("mark failed update error: %v (index error: %v) labels=%v", mfErr, addErr, labels[idx:idx+1])
 			}
 			return idx, addErr
@@ -176,14 +185,15 @@ func (w *EmbeddingWorker) RunOnce(ctx context.Context, indexKind string) (int, e
 		if isTransientEmbedError(err) {
 			return 0, err
 		}
-		if mfErr := w.Source.MarkFailed(ctx, labels, err.Error()); mfErr != nil {
+		category := string(store.ClassifyError(err))
+		if mfErr := w.Source.MarkFailedWithCategory(ctx, labels, category, err.Error()); mfErr != nil {
 			w.logf("mark failed update error: %v (source error: %v) labels=%v", mfErr, err, labels)
 		}
 		return 0, err
 	}
 	if len(vectors) != len(validTasks) {
 		reason := "embedding vector count mismatch"
-		if mfErr := w.Source.MarkFailed(ctx, labels, reason); mfErr != nil {
+		if mfErr := w.Source.MarkFailedWithCategory(ctx, labels, string(store.ErrorCategoryEmbeddingFailure), reason); mfErr != nil {
 			w.logf("mark failed update error: %v (reason: %s) labels=%v", mfErr, reason, labels)
 		}
 		return 0, errors.New(reason)

--- a/internal/index/embedding_worker.go
+++ b/internal/index/embedding_worker.go
@@ -104,7 +104,8 @@ func (w *EmbeddingWorker) indexChunks(ctx context.Context, validTasks []model.Ch
 				}
 			}
 			category := string(store.ClassifyError(addErr))
-			if mfErr := w.Source.MarkFailedWithCategory(ctx, labels[idx:idx+1], category, addErr.Error()); mfErr != nil {
+			reason := store.SanitizeReason(addErr.Error())
+			if mfErr := w.Source.MarkFailedWithCategory(ctx, labels[idx:idx+1], category, reason); mfErr != nil {
 				w.logf("mark failed update error: %v (index error: %v) labels=%v", mfErr, addErr, labels[idx:idx+1])
 			}
 			return idx, addErr
@@ -186,7 +187,8 @@ func (w *EmbeddingWorker) RunOnce(ctx context.Context, indexKind string) (int, e
 			return 0, err
 		}
 		category := string(store.ClassifyError(err))
-		if mfErr := w.Source.MarkFailedWithCategory(ctx, labels, category, err.Error()); mfErr != nil {
+		reason := store.SanitizeReason(err.Error())
+		if mfErr := w.Source.MarkFailedWithCategory(ctx, labels, category, reason); mfErr != nil {
 			w.logf("mark failed update error: %v (source error: %v) labels=%v", mfErr, err, labels)
 		}
 		return 0, err

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -175,6 +175,30 @@ type CorpusStats struct {
 	EmbeddedOK      int64            `json:"embedded_ok"`
 	Errors          int64            `json:"errors"`
 	Unknown         int64            `json:"unknown"`
+	// FailureSummary groups chunk-level embedding failures by
+	// store.ErrorCategory ("rate_limit", "payload_too_large", etc.)
+	// plus a small sample of representative {rel_path, message}
+	// pairs. Omitted from JSON when no failures have been recorded
+	// so existing consumers continue to see a flat shape on healthy
+	// corpora.
+	FailureSummary *FailureSummary `json:"failure_summary,omitempty"`
+}
+
+// FailureSummary aggregates chunk embedding errors for diagnostics.
+// Categories is keyed by the string form of store.ErrorCategory (kept
+// as plain map[string]int64 here so the model package does not depend
+// on internal/store).
+type FailureSummary struct {
+	Categories map[string]int64 `json:"categories"`
+	Samples    []FailureSample  `json:"samples,omitempty"`
+}
+
+// FailureSample is one representative failed chunk: enough information
+// to start triage without dumping the entire chunks table.
+type FailureSample struct {
+	RelPath  string `json:"rel_path"`
+	Category string `json:"category"`
+	Message  string `json:"message"`
 }
 
 // MarshalJSON ensures that a nil DocCounts map is encoded as an empty object

--- a/internal/model/types_test.go
+++ b/internal/model/types_test.go
@@ -68,8 +68,11 @@ func TestStatsJSONFlattening(t *testing.T) {
 	}
 
 	// sanity-check: every json tag in CorpusStats should appear in the above
-	// list. this catches developers who forget to update the expected slice
-	// when adding new stats fields.
+	// list, except for fields tagged omitempty (which legitimately don't
+	// appear when their value is the zero value, as is the case for
+	// failure_summary on the populated-but-summary-less fixture above).
+	// This still catches developers who forget to update the expected
+	// slice when adding new always-emitted stats fields.
 	csTags := make(map[string]struct{})
 	csType := reflect.TypeOf(CorpusStats{})
 	for i := 0; i < csType.NumField(); i++ {
@@ -77,7 +80,19 @@ func TestStatsJSONFlattening(t *testing.T) {
 		if tag == "" {
 			continue
 		}
-		csTags[strings.SplitN(tag, ",", 2)[0]] = struct{}{}
+		parts := strings.Split(tag, ",")
+		name := parts[0]
+		omitempty := false
+		for _, opt := range parts[1:] {
+			if opt == "omitempty" {
+				omitempty = true
+				break
+			}
+		}
+		if omitempty {
+			continue
+		}
+		csTags[name] = struct{}{}
 	}
 	for tag := range csTags {
 		found := false

--- a/internal/store/errcat.go
+++ b/internal/store/errcat.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"net"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 )
 
 // ErrorCategory is a coarse classification for chunk-embedding failures.
@@ -96,6 +98,67 @@ func containsAny(s string, needles []string) bool {
 		}
 	}
 	return false
+}
+
+// sanitizedReasonMaxBytes bounds the length of error reason strings
+// persisted into the chunks table. The cap is small enough that even
+// an attacker-controlled error body can't smuggle a useful secret or
+// payload chunk through the diagnostics surface, large enough to
+// preserve the prose prefix that humans actually read.
+const sanitizedReasonMaxBytes = 256
+
+// SanitizeReason produces a chunks.embedding_error payload that is
+// safe to surface through dir2mcp status / doctor / support-bundle.
+// Upstream error strings can interpolate raw request/response bodies
+// (OCR returning a PDF stream excerpt; HTTP clients including a
+// failing input fragment; etc.), and those bodies are exactly the
+// payloads the "no secrets in diagnostics" contract forbids us from
+// persisting. The sanitizer therefore:
+//
+//  1. Replaces every non-printable byte with a space so binary
+//     payload fragments collapse to whitespace runs instead of
+//     leaking through as raw bytes.
+//  2. Collapses whitespace runs so the previous step doesn't
+//     produce sprawling blank ranges.
+//  3. Truncates to sanitizedReasonMaxBytes with an elision marker
+//     so long payloads can't fill the column.
+//
+// Callers should pass the original err.Error() output; the returned
+// string is what they hand to MarkFailedWithCategory.
+func SanitizeReason(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.Grow(len(raw))
+	for _, r := range raw {
+		switch {
+		case r == utf8.RuneError:
+			// Invalid UTF-8 byte: drop it. These typically come
+			// from binary payload fragments that the upstream
+			// interpolated into the error string.
+			continue
+		case unicode.IsPrint(r):
+			b.WriteRune(r)
+		default:
+			// Whitespace and control bytes collapse to a single
+			// space; the strings.Fields pass below removes
+			// resulting runs.
+			b.WriteByte(' ')
+		}
+	}
+	out := strings.Join(strings.Fields(b.String()), " ")
+	const ellipsis = "…" // 3 bytes in UTF-8
+	if len(out) > sanitizedReasonMaxBytes {
+		cut := sanitizedReasonMaxBytes - len(ellipsis)
+		// Walk back to a rune boundary so we never split a
+		// multi-byte UTF-8 sequence mid-character.
+		for cut > 0 && !utf8.RuneStart(out[cut]) {
+			cut--
+		}
+		out = out[:cut] + ellipsis
+	}
+	return out
 }
 
 // isNetTransient reports whether err unwraps to a net.Error that

--- a/internal/store/errcat.go
+++ b/internal/store/errcat.go
@@ -1,0 +1,110 @@
+package store
+
+import (
+	"errors"
+	"net"
+	"strings"
+)
+
+// ErrorCategory is a coarse classification for chunk-embedding failures.
+// Categories exist so the indexing-error count surfaced by
+// `dir2mcp status` and `dir2mcp doctor` can be grouped by likely cause,
+// rather than just shown as a single "errors: N" total. The classifier
+// is deliberately permissive: callers receive ErrorCategoryUnknown for
+// any error they cannot pattern-match, and consumers must treat
+// unknown as the universal default.
+type ErrorCategory string
+
+const (
+	// ErrorCategoryUnknown is used when an error cannot be confidently
+	// classified. Always safe; never wrong.
+	ErrorCategoryUnknown ErrorCategory = "unknown"
+	// ErrorCategoryRateLimit indicates the upstream provider returned a
+	// 429 / quota-exceeded response. Retryable after backoff.
+	ErrorCategoryRateLimit ErrorCategory = "rate_limit"
+	// ErrorCategoryPayloadTooLarge indicates the upstream rejected the
+	// input because of size limits (HTTP 413, "payload too large",
+	// "file too large"). Not retryable without splitting the input.
+	ErrorCategoryPayloadTooLarge ErrorCategory = "payload_too_large"
+	// ErrorCategoryParseError indicates the document/representation
+	// could not be decoded or extracted at the source (corrupt PDF,
+	// unsupported format, OCR refused). Not retryable.
+	ErrorCategoryParseError ErrorCategory = "parse_error"
+	// ErrorCategoryTransientNet indicates a network-level failure
+	// (timeout, connection refused, DNS) that is generally retryable.
+	ErrorCategoryTransientNet ErrorCategory = "transient_net"
+	// ErrorCategoryAuth indicates an authentication / authorization
+	// failure (HTTP 401, 403, bad API key). Not retryable without
+	// updating the credential.
+	ErrorCategoryAuth ErrorCategory = "auth"
+	// ErrorCategoryEmbeddingFailure indicates the embed pipeline
+	// rejected the input for a reason other than the above (vector
+	// dimension mismatch, model output malformed). Not retryable.
+	ErrorCategoryEmbeddingFailure ErrorCategory = "embedding_failure"
+)
+
+// classifierRule pairs a category with the keyword set that triggers
+// it. Order matters: the first matching rule wins, so the more
+// specific categories (rate-limit, auth, payload) are listed before
+// catch-alls (parse, embedding).
+type classifierRule struct {
+	category ErrorCategory
+	keywords []string
+}
+
+// classifierRules is the keyword-driven classification table consumed
+// by ClassifyError. Split out as a package var so the function below
+// stays under the cyclomatic-complexity budget and so new keywords
+// can be added with a single-line edit rather than a new switch case.
+var classifierRules = []classifierRule{
+	{ErrorCategoryRateLimit, []string{"429", "rate limit", "rate-limit", "quota exceeded", "too many requests"}},
+	{ErrorCategoryPayloadTooLarge, []string{"413", "payload too large", "request entity too large", "file too large", "exceeds maximum size"}},
+	{ErrorCategoryAuth, []string{"401", "403", "unauthorized", "forbidden", "invalid api key", "authentication"}},
+	{ErrorCategoryTransientNet, []string{"timeout", "connection refused", "connection reset", "no such host", "context deadline exceeded", "i/o timeout"}},
+	{ErrorCategoryParseError, []string{"parse", "decode", "ocr", "extract", "corrupt", "unsupported"}},
+	{ErrorCategoryEmbeddingFailure, []string{"embedding", "embed", "vector", "dimension"}},
+}
+
+// ClassifyError returns the ErrorCategory that best describes err.
+// Classification is keyword/pattern-based against the error message
+// and well-known wrapped types (net errors, http status codes folded
+// into the string). Returns ErrorCategoryUnknown when no rule matches
+// so callers never need to special-case nil/empty input.
+func ClassifyError(err error) ErrorCategory {
+	if err == nil {
+		return ErrorCategoryUnknown
+	}
+	if isNetTransient(err) {
+		return ErrorCategoryTransientNet
+	}
+	msg := strings.ToLower(err.Error())
+	for _, rule := range classifierRules {
+		if containsAny(msg, rule.keywords) {
+			return rule.category
+		}
+	}
+	return ErrorCategoryUnknown
+}
+
+// containsAny reports whether s contains any of the needles. Pulled
+// out of ClassifyError so the rule loop stays a single concern
+// (which keyword set matched).
+func containsAny(s string, needles []string) bool {
+	for _, n := range needles {
+		if strings.Contains(s, n) {
+			return true
+		}
+	}
+	return false
+}
+
+// isNetTransient reports whether err unwraps to a net.Error that
+// claims itself to be a timeout. Separated so the keyword check above
+// stays readable.
+func isNetTransient(err error) bool {
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return netErr.Timeout()
+	}
+	return false
+}

--- a/internal/store/errcat_test.go
+++ b/internal/store/errcat_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"strings"
 	"testing"
 	"time"
 )
@@ -48,3 +49,46 @@ func (e *fakeTimeoutErr) Temporary() bool { return true }
 // the isNetTransient branch of the classifier is exercised.
 var _ net.Error = (*fakeTimeoutErr)(nil)
 var _ = time.Now // keep imports stable for follow-on tests
+
+func TestSanitizeReason(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"short prose", "ocr returned 429 rate limit", "ocr returned 429 rate limit"},
+		{
+			"binary scrubbed",
+			"ocr failed: \x00\x01\x02 PDFDATA \xff\xfe",
+			"ocr failed: PDFDATA",
+		},
+		{
+			"newlines collapsed",
+			"ocr failed:\n  line1\n  line2\n",
+			"ocr failed: line1 line2",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := SanitizeReason(tc.in); got != tc.want {
+				t.Errorf("SanitizeReason(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeReason_TruncatesLongInput(t *testing.T) {
+	// 1000-byte error body simulates an upstream interpolating a
+	// large response chunk. The sanitizer must cap the persisted
+	// reason regardless of input length so a single failure can't
+	// fill the column.
+	long := strings.Repeat("a", 1000)
+	got := SanitizeReason(long)
+	if len(got) > sanitizedReasonMaxBytes {
+		t.Fatalf("len(SanitizeReason) = %d, want <= %d", len(got), sanitizedReasonMaxBytes)
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("expected truncation marker '…' at end, got %q", got[len(got)-10:])
+	}
+}

--- a/internal/store/errcat_test.go
+++ b/internal/store/errcat_test.go
@@ -1,0 +1,50 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestClassifyError_KnownPatterns(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want ErrorCategory
+	}{
+		{"nil", nil, ErrorCategoryUnknown},
+		{"rate-limit-429", errors.New("upstream returned 429 too many requests"), ErrorCategoryRateLimit},
+		{"rate-limit-text", errors.New("rate limit exceeded for embedding endpoint"), ErrorCategoryRateLimit},
+		{"payload-413", errors.New("HTTP 413 request entity too large"), ErrorCategoryPayloadTooLarge},
+		{"payload-text", errors.New("file too large for OCR: 75MB"), ErrorCategoryPayloadTooLarge},
+		{"auth-401", errors.New("401 unauthorized"), ErrorCategoryAuth},
+		{"auth-403", errors.New("403 forbidden"), ErrorCategoryAuth},
+		{"auth-text", errors.New("invalid api key"), ErrorCategoryAuth},
+		{"net-deadline", context.DeadlineExceeded, ErrorCategoryTransientNet},
+		{"net-text", errors.New("connection refused"), ErrorCategoryTransientNet},
+		{"net-timeout", &fakeTimeoutErr{}, ErrorCategoryTransientNet},
+		{"parse", errors.New("ocr extract failed: corrupt PDF"), ErrorCategoryParseError},
+		{"embed", errors.New("vector dimension mismatch: got 1024 want 1536"), ErrorCategoryEmbeddingFailure},
+		{"unknown", errors.New("something else"), ErrorCategoryUnknown},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ClassifyError(tc.err); got != tc.want {
+				t.Errorf("ClassifyError(%v) = %q, want %q", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+type fakeTimeoutErr struct{}
+
+func (e *fakeTimeoutErr) Error() string   { return "i/o timeout" }
+func (e *fakeTimeoutErr) Timeout() bool   { return true }
+func (e *fakeTimeoutErr) Temporary() bool { return true }
+
+// Compile-time guarantee that fakeTimeoutErr satisfies net.Error so
+// the isNetTransient branch of the classifier is exercised.
+var _ net.Error = (*fakeTimeoutErr)(nil)
+var _ = time.Now // keep imports stable for follow-on tests

--- a/internal/store/failure_summary.go
+++ b/internal/store/failure_summary.go
@@ -1,0 +1,97 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// failureSummaryMaxSamples bounds how many representative failing
+// chunks we surface to status / doctor / support-bundle consumers.
+// Small on purpose: the diagnostic value comes from spotting *which*
+// kind of failure dominates, not from dumping every error string.
+const failureSummaryMaxSamples = 10
+
+// loadFailureSummary aggregates chunk-level embedding failures by
+// error_category and collects up to maxSamples representative
+// {rel_path, category, message} rows. Returns nil when there are no
+// failures so CorpusStats.FailureSummary stays omitted in the JSON.
+func loadFailureSummary(ctx context.Context, db *sql.DB, maxSamples int) (*model.FailureSummary, error) {
+	categories, err := loadFailureCategories(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	if len(categories) == 0 {
+		return nil, nil
+	}
+	samples, err := loadFailureSamples(ctx, db, maxSamples)
+	if err != nil {
+		return nil, err
+	}
+	return &model.FailureSummary{Categories: categories, Samples: samples}, nil
+}
+
+// loadFailureCategories returns a count of failed chunks per
+// error_category. An empty category string (legacy failures recorded
+// before the column existed, or via the unclassified MarkFailed entry
+// point) is normalized to "unknown" so consumers don't have to.
+func loadFailureCategories(ctx context.Context, db *sql.DB) (map[string]int64, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT COALESCE(NULLIF(error_category, ''), 'unknown') AS category, COUNT(*) AS n
+		FROM chunks
+		WHERE deleted = 0 AND embedding_status = 'error'
+		GROUP BY category
+		ORDER BY n DESC`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := map[string]int64{}
+	for rows.Next() {
+		var category string
+		var count int64
+		if err := rows.Scan(&category, &count); err != nil {
+			return nil, err
+		}
+		out[category] = count
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// loadFailureSamples returns up to maxSamples failing chunks with
+// rel_path / category / message. Ordered by category then chunk_id so
+// the sample distribution favours coverage across categories rather
+// than dumping the first N of one type.
+func loadFailureSamples(ctx context.Context, db *sql.DB, maxSamples int) ([]model.FailureSample, error) {
+	if maxSamples <= 0 {
+		return nil, nil
+	}
+	rows, err := db.QueryContext(ctx, `
+		SELECT rel_path, COALESCE(NULLIF(error_category, ''), 'unknown') AS category, embedding_error
+		FROM chunks
+		WHERE deleted = 0 AND embedding_status = 'error'
+		ORDER BY category, chunk_id
+		LIMIT ?`, maxSamples)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := make([]model.FailureSample, 0, maxSamples)
+	for rows.Next() {
+		var sample model.FailureSample
+		if err := rows.Scan(&sample.RelPath, &sample.Category, &sample.Message); err != nil {
+			return nil, err
+		}
+		out = append(out, sample)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -544,8 +544,8 @@ func (s *SQLiteStore) UpsertChunkTask(ctx context.Context, task model.ChunkTask)
 
 	_, err = db.ExecContext(
 		ctx,
-		`INSERT INTO chunks(chunk_id, rel_path, doc_type, rep_type, text, index_kind, embedding_status, embedding_error, deleted)
-		 VALUES(?, ?, ?, ?, ?, ?, 'pending', '', 0)
+		`INSERT INTO chunks(chunk_id, rel_path, doc_type, rep_type, text, index_kind, embedding_status, embedding_error, error_category, deleted)
+		 VALUES(?, ?, ?, ?, ?, ?, 'pending', '', '', 0)
 		 ON CONFLICT(chunk_id) DO UPDATE SET
 		   rel_path=excluded.rel_path,
 		   doc_type=excluded.doc_type,
@@ -554,7 +554,8 @@ func (s *SQLiteStore) UpsertChunkTask(ctx context.Context, task model.ChunkTask)
 		   index_kind=excluded.index_kind,
 		   deleted=0,
 		   embedding_status='pending',
-		   embedding_error=''`,
+		   embedding_error='',
+		   error_category=''`,
 		int64(task.Label),
 		relPath,
 		defaultIfEmpty(task.Metadata.DocType, "unknown"),

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -282,6 +282,11 @@ func applyAdditiveColumnMigrations(ctx context.Context, db *sql.DB) error {
 		`ALTER TABLE mcp_sessions ADD COLUMN auth_scope TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE representations ADD COLUMN meta_json TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE documents ADD COLUMN title TEXT NOT NULL DEFAULT ''`,
+		// error_category folds free-text embedding_error into a small
+		// enum (store.ErrorCategory) so dir2mcp status / doctor can
+		// surface "rate_limit: 67, payload_too_large: 21" instead of
+		// just an aggregate failure count.
+		`ALTER TABLE chunks ADD COLUMN error_category TEXT NOT NULL DEFAULT ''`,
 	}
 	for _, stmt := range migrations {
 		if _, err := db.ExecContext(ctx, stmt); err != nil && !isDuplicateColumnError(err) {
@@ -357,6 +362,7 @@ CREATE TABLE IF NOT EXISTS chunks (
   index_kind TEXT NOT NULL DEFAULT 'text',
   embedding_status TEXT NOT NULL DEFAULT 'pending',
   embedding_error TEXT NOT NULL DEFAULT '',
+  error_category TEXT NOT NULL DEFAULT '',
   deleted INTEGER NOT NULL DEFAULT 0,
   UNIQUE(rep_id, ordinal),
   FOREIGN KEY (rep_id) REFERENCES representations(rep_id) ON DELETE CASCADE
@@ -1035,6 +1041,12 @@ func (s *SQLiteStore) CorpusStats(ctx context.Context) (model.CorpusStats, error
 		return model.CorpusStats{}, err
 	}
 
+	summary, err := loadFailureSummary(ctx, db, failureSummaryMaxSamples)
+	if err != nil {
+		return model.CorpusStats{}, err
+	}
+	stats.FailureSummary = summary
+
 	return stats, nil
 }
 
@@ -1215,11 +1227,25 @@ func spanFromRow(kind string, start, end int) model.Span {
 }
 
 func (s *SQLiteStore) MarkEmbedded(ctx context.Context, labels []uint64) error {
-	return s.markEmbeddingStatus(ctx, labels, "ok", "")
+	return s.markEmbeddingStatus(ctx, labels, "ok", "", "")
 }
 
+// MarkFailed retains its original signature for callers that have not
+// yet adopted error classification; they are recorded with an empty
+// category (effectively ErrorCategoryUnknown for query/aggregation
+// purposes). New call sites should prefer MarkFailedWithCategory so
+// the failure surfaces in dir2mcp status / doctor breakdowns.
 func (s *SQLiteStore) MarkFailed(ctx context.Context, labels []uint64, reason string) error {
-	return s.markEmbeddingStatus(ctx, labels, "error", reason)
+	return s.markEmbeddingStatus(ctx, labels, "error", reason, "")
+}
+
+// MarkFailedWithCategory records a chunk-embedding failure together
+// with a classification category (see ClassifyError). Category is
+// stored alongside the existing free-text reason so the original
+// message stays available for debugging while aggregations operate on
+// the enum.
+func (s *SQLiteStore) MarkFailedWithCategory(ctx context.Context, labels []uint64, category ErrorCategory, reason string) error {
+	return s.markEmbeddingStatus(ctx, labels, "error", reason, string(category))
 }
 
 func (s *SQLiteStore) UpsertMCPSession(ctx context.Context, sessionID string, created, lastSeen time.Time, authScope string) error {
@@ -1407,7 +1433,7 @@ func (s *SQLiteStore) ListMCPPaymentOutcomes(ctx context.Context) ([]MCPPaymentO
 	return out, rows.Err()
 }
 
-func (s *SQLiteStore) markEmbeddingStatus(ctx context.Context, labels []uint64, status, reason string) error {
+func (s *SQLiteStore) markEmbeddingStatus(ctx context.Context, labels []uint64, status, reason, category string) error {
 	if len(labels) == 0 {
 		return nil
 	}
@@ -1433,14 +1459,15 @@ func (s *SQLiteStore) markEmbeddingStatus(ctx context.Context, labels []uint64, 
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	stmt, err := tx.PrepareContext(ctx, `UPDATE chunks SET embedding_status = ?, embedding_error = ? WHERE chunk_id = ?`)
+	stmt, err := tx.PrepareContext(ctx,
+		`UPDATE chunks SET embedding_status = ?, embedding_error = ?, error_category = ? WHERE chunk_id = ?`)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = stmt.Close() }()
 
 	for _, label := range labels {
-		if _, err := stmt.ExecContext(ctx, status, reason, int64(label)); err != nil {
+		if _, err := stmt.ExecContext(ctx, status, reason, category, int64(label)); err != nil {
 			return err
 		}
 	}

--- a/tests/cli/client_dispatch_test.go
+++ b/tests/cli/client_dispatch_test.go
@@ -17,10 +17,21 @@ import (
 // output modes. Without this, a regression in those branches would go
 // uncaught since the happy-path tests only exercise `claude`.
 
-var clientVerbs = []string{"install", "uninstall", "doctor", "print-config"}
+// clientVerbsRequiringClient lists verbs that hard-require a
+// positional <client>. "doctor" is NOT in this set: its no-arg form
+// now routes to the daemon-side preflight (runServerDoctor) and
+// must succeed without a client name. Doctor-specific behaviour is
+// covered by TestServerDoctor_* in server_doctor_test.go.
+var clientVerbsRequiringClient = []string{"install", "uninstall", "print-config"}
+
+// clientVerbsRejectingUnknownClient lists every verb that still
+// validates an explicit <client> positional. "doctor" stays here:
+// `dir2mcp doctor chatgpt` must still fail with an unknown-client
+// error even though `dir2mcp doctor` now succeeds.
+var clientVerbsRejectingUnknownClient = []string{"install", "uninstall", "doctor", "print-config"}
 
 func TestClientVerb_MissingClient_Human(t *testing.T) {
-	for _, verb := range clientVerbs {
+	for _, verb := range clientVerbsRequiringClient {
 		t.Run(verb, func(t *testing.T) {
 			var stdout, stderr bytes.Buffer
 			app := cli.NewAppWithIO(&stdout, &stderr)
@@ -45,7 +56,7 @@ func TestClientVerb_MissingClient_Human(t *testing.T) {
 }
 
 func TestClientVerb_MissingClient_JSON(t *testing.T) {
-	for _, verb := range clientVerbs {
+	for _, verb := range clientVerbsRequiringClient {
 		t.Run(verb, func(t *testing.T) {
 			var stdout, stderr bytes.Buffer
 			app := cli.NewAppWithIO(&stdout, &stderr)
@@ -70,7 +81,7 @@ func TestClientVerb_MissingClient_JSON(t *testing.T) {
 }
 
 func TestClientVerb_UnknownClient_Human(t *testing.T) {
-	for _, verb := range clientVerbs {
+	for _, verb := range clientVerbsRejectingUnknownClient {
 		t.Run(verb, func(t *testing.T) {
 			var stdout, stderr bytes.Buffer
 			app := cli.NewAppWithIO(&stdout, &stderr)
@@ -92,7 +103,7 @@ func TestClientVerb_UnknownClient_Human(t *testing.T) {
 }
 
 func TestClientVerb_UnknownClient_JSON(t *testing.T) {
-	for _, verb := range clientVerbs {
+	for _, verb := range clientVerbsRejectingUnknownClient {
 		t.Run(verb, func(t *testing.T) {
 			var stdout, stderr bytes.Buffer
 			app := cli.NewAppWithIO(&stdout, &stderr)

--- a/tests/cli/server_doctor_test.go
+++ b/tests/cli/server_doctor_test.go
@@ -1,0 +1,111 @@
+package tests
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/cli"
+	"github.com/dirstral/dir2mcp/tests/testutil"
+)
+
+// TestServerDoctor_JSONReportSurfacesOCRFallback runs `dir2mcp
+// --json doctor` (no client arg => daemon-side preflight) under the
+// same conditions that triggered the original client's failed
+// install: a Mistral API key is set but docling is not on PATH. The
+// doctor must flag the extractor as a warn-level fallback so the
+// operator sees the diagnostic before they ever try to index.
+func TestServerDoctor_JSONReportSurfacesOCRFallback(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("MISTRAL_API_KEY", "test-key")
+	t.Setenv("PATH", t.TempDir()) // no docling on PATH
+
+	testutil.WithWorkingDir(t, tmp, func() {
+		var stdout, stderr bytes.Buffer
+		app := cli.NewAppWithIO(&stdout, &stderr)
+		code := app.Run([]string{"--json", "doctor"})
+		if code != 0 {
+			t.Fatalf("doctor exit=%d stderr=%q", code, stderr.String())
+		}
+
+		var report struct {
+			OK     bool `json:"ok"`
+			Checks []struct {
+				Name   string `json:"name"`
+				Status string `json:"status"`
+				Detail string `json:"detail"`
+			} `json:"checks"`
+		}
+		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+			t.Fatalf("decode doctor JSON: %v body=%q", err, stdout.String())
+		}
+		if !report.OK {
+			t.Errorf("ok=false in report; expected warns only, got %+v", report.Checks)
+		}
+		extractor := findCheck(report.Checks, "extractor")
+		if extractor == nil {
+			t.Fatalf("doctor report missing extractor check: %+v", report.Checks)
+		}
+		if extractor.Status != "warn" {
+			t.Errorf("extractor status = %q, want warn (fallback to mistral-ocr)", extractor.Status)
+		}
+		if !strings.Contains(extractor.Detail, "docling not found") {
+			t.Errorf("extractor detail = %q, want fallback explanation (substring 'docling not found')", extractor.Detail)
+		}
+
+		// Sanity: the embed provider should resolve since
+		// MISTRAL_API_KEY is set; the indexing_failures check
+		// should report "no index yet" on a fresh state dir.
+		if embed := findCheck(report.Checks, "provider.embed"); embed == nil || embed.Status != "ok" {
+			t.Errorf("expected provider.embed=ok, got %+v", embed)
+		}
+		if failures := findCheck(report.Checks, "indexing_failures"); failures == nil || failures.Status != "ok" {
+			t.Errorf("expected indexing_failures=ok on fresh state, got %+v", failures)
+		}
+	})
+}
+
+// TestServerDoctor_NoArgRoutesToDaemon ensures `dir2mcp doctor`
+// without a positional argument hits the new daemon-side preflight
+// path (not the legacy client-arg-required error).
+func TestServerDoctor_NoArgRoutesToDaemon(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("MISTRAL_API_KEY", "test-key")
+	t.Setenv("PATH", t.TempDir())
+
+	testutil.WithWorkingDir(t, tmp, func() {
+		var stdout, stderr bytes.Buffer
+		app := cli.NewAppWithIO(&stdout, &stderr)
+		code := app.Run([]string{"doctor"})
+		if code != 0 {
+			t.Fatalf("doctor exit=%d stderr=%q", code, stderr.String())
+		}
+		out := stdout.String()
+		if !strings.Contains(out, "config") || !strings.Contains(out, "extractor") {
+			t.Errorf("doctor stdout missing daemon-check rows: %q", out)
+		}
+		if strings.Contains(stderr.String(), "requires a client name") {
+			t.Errorf("no-arg invocation hit the client-arg branch: %q", stderr.String())
+		}
+	})
+}
+
+type doctorCheckRow struct {
+	Name   string `json:"name"`
+	Status string `json:"status"`
+	Detail string `json:"detail"`
+}
+
+func findCheck(checks []struct {
+	Name   string `json:"name"`
+	Status string `json:"status"`
+	Detail string `json:"detail"`
+}, name string) *doctorCheckRow {
+	for _, c := range checks {
+		if c.Name == name {
+			return &doctorCheckRow{Name: c.Name, Status: c.Status, Detail: c.Detail}
+		}
+	}
+	return nil
+}

--- a/tests/index/embedding_worker_test.go
+++ b/tests/index/embedding_worker_test.go
@@ -15,10 +15,11 @@ import (
 )
 
 type fakeChunkSource struct {
-	tasks        []model.ChunkTask
-	embedded     []uint64
-	failedLabels []uint64
-	failedReason string
+	tasks          []model.ChunkTask
+	embedded       []uint64
+	failedLabels   []uint64
+	failedReason   string
+	failedCategory string
 	// markFailedErr, if non-nil, is returned from MarkFailed.
 	markFailedErr error
 }
@@ -37,6 +38,15 @@ func (s *fakeChunkSource) MarkEmbedded(_ context.Context, labels []uint64) error
 func (s *fakeChunkSource) MarkFailed(_ context.Context, labels []uint64, reason string) error {
 	s.failedLabels = append(s.failedLabels, labels...)
 	s.failedReason = reason
+	return s.markFailedErr
+}
+
+// MarkFailedWithCategory mirrors MarkFailed and additionally records
+// the supplied classification for tests that assert on grouping.
+func (s *fakeChunkSource) MarkFailedWithCategory(_ context.Context, labels []uint64, category, reason string) error {
+	s.failedLabels = append(s.failedLabels, labels...)
+	s.failedReason = reason
+	s.failedCategory = category
 	return s.markFailedErr
 }
 

--- a/tests/security/cli_boundary_test.go
+++ b/tests/security/cli_boundary_test.go
@@ -177,6 +177,7 @@ func TestRepoSplitBoundary_InternalCLIFileOwnership(t *testing.T) {
 		"registration_hint_test.go": {},
 		"remote_commands.go":        {},
 		"routing_decision.go":       {},
+		"server_doctor.go":          {},
 		"status.go":                 {},
 		"style.go":                  {},
 		"support_bundle.go":         {},


### PR DESCRIPTION
## Summary

Three diagnostic enhancements that compound to answer the question raised by the recent client failure ("89 of 91 PDFs failed indexing — why?") without needing log spelunking. Independent of [#209](https://github.com/dirstral/dir2mcp/pull/209) (banner reasons + support-bundle); rebasing after #209 lands will be a trivial deduplication of the inline extractor-check logic.

### #5 — Structured error categories (store layer)
- New \`store.ErrorCategory\` enum + \`ClassifyError\` keyword-driven classifier covering: \`rate_limit\`, \`payload_too_large\`, \`parse_error\`, \`transient_net\`, \`auth\`, \`embedding_failure\`, \`unknown\`.
- Additive \`chunks.error_category\` column (sqlite migration; idempotent).
- New \`MarkFailedWithCategory\` on \`ChunkSource\`; embedding worker classifies each error before writing, so every new failure lands with a category attached. Legacy \`MarkFailed\` retained for callers that haven't been updated — those rows aggregate as \`unknown\`.

### #3 — Failure aggregation in status
- New \`model.FailureSummary {categories: map[string]int64, samples: []FailureSample}\` field on \`CorpusStats\` (\`omitempty\` — healthy corpora keep the existing flat JSON shape).
- \`loadFailureSummary\` groups errors by category and collects up to 10 representative \`{rel_path, category, message}\` samples.
- \`corpusIndexing\` exposes \`FailureSummary\` so \`dir2mcp status --json\` carries it through to clients and the support-bundle.

### #1 — Server-side doctor
\`dir2mcp doctor\` (no client arg) now runs a daemon-side preflight instead of erroring:

\`\`\`
config               ok     loaded
state_dir            ok     .dir2mcp
provider.embed       ok     mistral
provider.chat        ok     mistral
extractor            warn   mistral-ocr (fallback; docling not found on PATH)
indexing_failures    warn   rate_limit=67, payload_too_large=21, unknown=1
\`\`\`

\`dir2mcp doctor claude\` continues to dispatch to the existing client-integration checks unchanged.

## Test plan
- [x] \`make check\` green (gofmt, vet, lint, cyclo, ineffassign, misspell, all unit + integration suites)
- [x] 14-case classifier table covering nil, HTTP-code matches, keyword matches, and the net.Error timeout unwrap path
- [x] Black-box doctor tests through \`cli.NewAppWithIO + app.Run\` covering both JSON output and the no-arg → daemon-doctor routing
- [x] \`client_dispatch_test.go\` split so doctor's relaxed no-arg behaviour doesn't break the per-verb invariants
- [x] \`types_test.go\` reverse-check skips \`omitempty\` fields so \`failure_summary\` doesn't fail the never-tag-without-key invariant
- [x] Boundary allowlist updated for the new \`internal/cli/server_doctor.go\`
- [x] Manual smoke: ran \`dir2mcp doctor\` and \`dir2mcp --json doctor\` on a fresh dir; verified extractor warn appears in the OCR-fallback case

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * `doctor` command now supports daemon-side preflight checks when invoked without a client argument, in addition to existing client-specific diagnostics
  * `status --json` output now includes a failure summary with categorized embedding errors and per-category counts

* **Chores**
  * Enhanced database schema to support error categorization and improved failure tracking

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dirstral/dir2mcp/pull/210?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->