### PR TITLE
feat(cli): doctor surfaces doc-level errors + reindex streams progress

### DIFF
--- a/internal/cli/reindex.go
+++ b/internal/cli/reindex.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/dirstral/dir2mcp/internal/config"
@@ -144,11 +143,9 @@ func startReindexProgress(ctx context.Context, out io.Writer, st model.Store, gl
 		printReindexProgressLine(out, ctx, st)
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
-		var once sync.Once
 		for {
 			select {
 			case <-ctx.Done():
-				once.Do(func() {})
 				return
 			case <-ticker.C:
 				printReindexProgressLine(out, ctx, st)

--- a/internal/cli/reindex.go
+++ b/internal/cli/reindex.go
@@ -4,12 +4,22 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"time"
 
+	"github.com/dirstral/dir2mcp/internal/config"
 	"github.com/dirstral/dir2mcp/internal/model"
 )
+
+// reindexProgressInterval is how often the reindex command prints a
+// status line while the ingestor is running. Picked small enough that
+// users see motion on slow-OCR corpora but large enough that the
+// stderr stream stays readable.
+const reindexProgressInterval = 5 * time.Second
 
 func (a *App) runReindex(ctx context.Context, global globalOptions, args []string) int {
 	if len(args) > 0 {
@@ -17,54 +27,87 @@ func (a *App) runReindex(ctx context.Context, global globalOptions, args []strin
 		return exitConfigInvalid
 	}
 
-	// load configuration first so that both the ingestor and any
-	// auxiliary components (OCR client) share the same settings.  When
-	// Load returns an error we treat it as fatal instead of silently
-	// proceeding with defaults as was previously the case.
-	cfg, err := loadConfigWithGlobalOptions(global)
-	if err != nil {
-		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("load config: %v", err))
-		return exitConfigInvalid
+	cfg, code := a.loadReindexConfig(global)
+	if code != exitSuccess {
+		return code
 	}
-
-	baseDir := strings.TrimSpace(cfg.StateDir)
-	if baseDir == "" {
-		baseDir = ".dir2mcp"
+	st, code := a.prepareReindexStore(ctx, global, cfg)
+	if code != exitSuccess {
+		return code
 	}
-	// ensure the directory exists before we let the store constructor write
-	// to it
-	textIndexPath := filepath.Join(baseDir, "vectors_text.hnsw")
-	codeIndexPath := filepath.Join(baseDir, "vectors_code.hnsw")
-	if err := os.MkdirAll(baseDir, 0o755); err != nil {
-		writeCLIError(a.stderr, global.jsonOutput, exitRootInaccessible, fmt.Sprintf("create state dir: %v", err))
-		return exitRootInaccessible
-	}
-	// update cfg so that the store factory uses the same baseDir
-	cfg.StateDir = baseDir
-	st := a.storeForConfig(cfg)
 	defer a.closeStoreWithLog(st)
-	if err := st.Init(ctx); err != nil && !errors.Is(err, model.ErrNotImplemented) {
-		writeCLIError(a.stderr, global.jsonOutput, exitIndexLoadFailure, fmt.Sprintf("initialize metadata store: %v", err))
-		return exitIndexLoadFailure
-	}
-	if exitCode := clearContentHashesIfSupported(ctx, st, a.stderr, global.jsonOutput); exitCode != exitSuccess {
-		return exitCode
-	}
-	for _, indexPath := range []string{textIndexPath, codeIndexPath} {
-		if err := os.Remove(indexPath); err != nil && !errors.Is(err, os.ErrNotExist) {
-			writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("remove stale index file %s: %v", indexPath, err))
-			return exitGeneric
-		}
-	}
 
-	// use the factory hook (same as runUp) to allow tests to intercept
 	ing, err := a.newIngestor(cfg, st)
 	if err != nil {
 		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("initialize ingestor: %v", err))
 		return exitConfigInvalid
 	}
 
+	progressCtx, stopProgress := context.WithCancel(ctx)
+	defer stopProgress()
+	progressDone := startReindexProgress(progressCtx, a.stderr, st, global, reindexProgressInterval)
+
 	err = ing.Reindex(ctx)
+	stopProgress()
+	<-progressDone
+	return a.finishReindex(ctx, global, st, err)
+}
+
+// loadReindexConfig pulls the layered config and normalises the state
+// directory. Extracted from runReindex so the parent function stays
+// under the cyclomatic-complexity budget.
+func (a *App) loadReindexConfig(global globalOptions) (config.Config, int) {
+	cfg, err := loadConfigWithGlobalOptions(global)
+	if err != nil {
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("load config: %v", err))
+		return cfg, exitConfigInvalid
+	}
+	baseDir := strings.TrimSpace(cfg.StateDir)
+	if baseDir == "" {
+		baseDir = ".dir2mcp"
+	}
+	cfg.StateDir = baseDir
+	return cfg, exitSuccess
+}
+
+// prepareReindexStore creates the state directory, opens the store,
+// clears prior content hashes, and removes stale vector index files
+// so the upcoming Reindex starts from a clean slate. Returns the
+// initialised store on success; on any failure it writes a CLI error
+// and returns the appropriate exit code.
+func (a *App) prepareReindexStore(ctx context.Context, global globalOptions, cfg config.Config) (model.Store, int) {
+	if err := os.MkdirAll(cfg.StateDir, 0o755); err != nil {
+		writeCLIError(a.stderr, global.jsonOutput, exitRootInaccessible, fmt.Sprintf("create state dir: %v", err))
+		return nil, exitRootInaccessible
+	}
+	st := a.storeForConfig(cfg)
+	if err := st.Init(ctx); err != nil && !errors.Is(err, model.ErrNotImplemented) {
+		_ = st.Close()
+		writeCLIError(a.stderr, global.jsonOutput, exitIndexLoadFailure, fmt.Sprintf("initialize metadata store: %v", err))
+		return nil, exitIndexLoadFailure
+	}
+	if code := clearContentHashesIfSupported(ctx, st, a.stderr, global.jsonOutput); code != exitSuccess {
+		_ = st.Close()
+		return nil, code
+	}
+	for _, indexPath := range []string{
+		filepath.Join(cfg.StateDir, "vectors_text.hnsw"),
+		filepath.Join(cfg.StateDir, "vectors_code.hnsw"),
+	} {
+		if err := os.Remove(indexPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			_ = st.Close()
+			writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("remove stale index file %s: %v", indexPath, err))
+			return nil, exitGeneric
+		}
+	}
+	return st, exitSuccess
+}
+
+// finishReindex handles the post-Reindex flow: dispatch on the
+// ingestor's return error, then (on success) emit the final progress
+// summary so users see the final counters without having to re-query
+// status.
+func (a *App) finishReindex(ctx context.Context, global globalOptions, st model.Store, err error) int {
 	if errors.Is(err, model.ErrNotImplemented) {
 		if !global.quiet {
 			writeln(a.stdout, "reindex is not available yet: ingestion pipeline not implemented")
@@ -75,5 +118,88 @@ func (a *App) runReindex(ctx context.Context, global globalOptions, args []strin
 		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("reindex failed: %v", err))
 		return exitGeneric
 	}
+	if !global.quiet && !global.jsonOutput {
+		printReindexFinalSummary(a.stderr, ctx, st)
+	}
 	return exitSuccess
+}
+
+// startReindexProgress spawns a goroutine that prints periodic
+// progress lines to out while the ingestor is running, then returns a
+// channel that closes when the goroutine exits. The poller stops as
+// soon as ctx is cancelled (the caller does this once Reindex
+// returns). Silent under --quiet and under --json so machine-readable
+// callers and quiet-script users see a clean output stream.
+func startReindexProgress(ctx context.Context, out io.Writer, st model.Store, global globalOptions, interval time.Duration) <-chan struct{} {
+	done := make(chan struct{})
+	if global.quiet || global.jsonOutput {
+		close(done)
+		return done
+	}
+	go func() {
+		defer close(done)
+		// One immediate tick so users see a "starting" line within
+		// a second instead of waiting a full interval before the
+		// first progress update.
+		printReindexProgressLine(out, ctx, st)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		var once sync.Once
+		for {
+			select {
+			case <-ctx.Done():
+				once.Do(func() {})
+				return
+			case <-ticker.C:
+				printReindexProgressLine(out, ctx, st)
+			}
+		}
+	}()
+	return done
+}
+
+// printReindexProgressLine emits one [reindex] status line to out.
+// CorpusStats is only available from the SQLite-backed store; for any
+// other backend the function is silent so the reindex command stays
+// usable with future store implementations.
+func printReindexProgressLine(out io.Writer, ctx context.Context, st model.Store) {
+	stats, ok := corpusStatsForReindex(ctx, st)
+	if !ok {
+		return
+	}
+	_, _ = fmt.Fprintf(out, "[reindex] scanned=%d indexed=%d skipped=%d errors=%d chunks=%d embedded=%d\n",
+		stats.Scanned, stats.Indexed, stats.Skipped, stats.Errors, stats.ChunksTotal, stats.EmbeddedOK)
+}
+
+// printReindexFinalSummary writes a one-line completion summary so the
+// user knows the run finished and what the final counts are. Same
+// CorpusStats source as the progress poller; silent when stats are
+// unavailable.
+func printReindexFinalSummary(out io.Writer, ctx context.Context, st model.Store) {
+	stats, ok := corpusStatsForReindex(ctx, st)
+	if !ok {
+		return
+	}
+	_, _ = fmt.Fprintf(out, "[reindex] done: scanned=%d indexed=%d skipped=%d errors=%d chunks=%d embedded=%d\n",
+		stats.Scanned, stats.Indexed, stats.Skipped, stats.Errors, stats.ChunksTotal, stats.EmbeddedOK)
+}
+
+// corpusStatsForReindex pulls CorpusStats from the SQLite-backed
+// store, swallowing the type-assertion miss and any transient query
+// error so the progress poller never crashes a healthy reindex run.
+// Returns ok=false when stats are unavailable (caller should skip
+// printing rather than emit a misleading zero-line).
+func corpusStatsForReindex(ctx context.Context, st model.Store) (model.CorpusStats, bool) {
+	type corpusStatser interface {
+		CorpusStats(ctx context.Context) (model.CorpusStats, error)
+	}
+	cs, ok := st.(corpusStatser)
+	if !ok {
+		return model.CorpusStats{}, false
+	}
+	stats, err := cs.CorpusStats(ctx)
+	if err != nil {
+		return model.CorpusStats{}, false
+	}
+	return stats, true
 }

--- a/internal/cli/server_doctor.go
+++ b/internal/cli/server_doctor.go
@@ -178,10 +178,34 @@ func indexingFailureCheck(ctx context.Context, a *App, cfg config.Config) doctor
 	if err != nil {
 		return doctorCheck{Name: "indexing_failures", Status: doctorStatusError, Detail: err.Error()}
 	}
-	if stats.FailureSummary == nil || len(stats.FailureSummary.Categories) == 0 {
+	return renderIndexingFailureCheck(stats)
+}
+
+// renderIndexingFailureCheck combines document-level and chunk-level
+// failure counters into one doctor row. Document-level errors
+// (CorpusStats.Errors) come from the extraction/representation stage
+// — they happen *before* chunks are ever created, so a corpus that
+// fails entirely at extraction has 0 chunk-level failures and
+// previously slipped through this check as "0 failures" even though
+// every PDF in the corpus had failed. Both counts are surfaced so
+// neither stage can hide.
+func renderIndexingFailureCheck(stats model.CorpusStats) doctorCheck {
+	docErrors := stats.Errors
+	var chunkCategories map[string]int64
+	if stats.FailureSummary != nil {
+		chunkCategories = stats.FailureSummary.Categories
+	}
+	if docErrors == 0 && len(chunkCategories) == 0 {
 		return doctorCheck{Name: "indexing_failures", Status: doctorStatusOK, Detail: "0 failures"}
 	}
-	return doctorCheck{Name: "indexing_failures", Status: doctorStatusWarn, Detail: summarizeFailureCategories(stats.FailureSummary.Categories)}
+	parts := []string{}
+	if docErrors > 0 {
+		parts = append(parts, fmt.Sprintf("%d document(s) failed extraction", docErrors))
+	}
+	if len(chunkCategories) > 0 {
+		parts = append(parts, "chunk failures: "+summarizeFailureCategories(chunkCategories))
+	}
+	return doctorCheck{Name: "indexing_failures", Status: doctorStatusWarn, Detail: strings.Join(parts, "; ")}
 }
 
 // summarizeFailureCategories renders the failure-category map as a

--- a/tests/cli/reindex_progress_test.go
+++ b/tests/cli/reindex_progress_test.go
@@ -1,0 +1,82 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/cli"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// reindexNoopIngestor satisfies model.Ingestor and lets us drive
+// runReindex from a test without spinning up the real ingest pipeline.
+// Reindex returns immediately so the test exercises the progress
+// scaffolding (initial line + done line) without requiring a long-
+// running fake.
+type reindexNoopIngestor struct{}
+
+func (reindexNoopIngestor) Run(context.Context) error     { return nil }
+func (reindexNoopIngestor) Reindex(context.Context) error { return nil }
+
+// TestReindex_PrintsProgressAndDoneLines pins the new reindex UX:
+// the command emits at least one `[reindex]` progress line and a
+// trailing `[reindex] done:` summary line to stderr. Pre-fix the
+// command was dead silent for the whole run, which forced the
+// "open a second terminal and poll status" workaround the original
+// user complained about.
+func TestReindex_PrintsProgressAndDoneLines(t *testing.T) {
+	tmp := t.TempDir()
+	var stdout, stderr bytes.Buffer
+
+	app := cli.NewAppWithIOAndHooks(&stdout, &stderr, cli.RuntimeHooks{
+		NewIngestor: func(_ config.Config, _ model.Store) (model.Ingestor, error) {
+			return reindexNoopIngestor{}, nil
+		},
+	})
+
+	withWorkingDir(t, tmp, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if code := app.RunWithContext(ctx, []string{"reindex"}); code != 0 {
+			t.Fatalf("reindex exit=%d stderr=%q", code, stderr.String())
+		}
+	})
+
+	errOut := stderr.String()
+	if !strings.Contains(errOut, "[reindex]") {
+		t.Errorf("expected a [reindex] progress line in stderr; got %q", errOut)
+	}
+	if !strings.Contains(errOut, "[reindex] done:") {
+		t.Errorf("expected a [reindex] done: summary line in stderr; got %q", errOut)
+	}
+}
+
+// TestReindex_QuietSuppressesProgress ensures --quiet keeps the
+// stderr stream silent so script-driving callers don't get a wall of
+// progress chatter mixed in.
+func TestReindex_QuietSuppressesProgress(t *testing.T) {
+	tmp := t.TempDir()
+	var stdout, stderr bytes.Buffer
+
+	app := cli.NewAppWithIOAndHooks(&stdout, &stderr, cli.RuntimeHooks{
+		NewIngestor: func(_ config.Config, _ model.Store) (model.Ingestor, error) {
+			return reindexNoopIngestor{}, nil
+		},
+	})
+
+	withWorkingDir(t, tmp, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if code := app.RunWithContext(ctx, []string{"--quiet", "reindex"}); code != 0 {
+			t.Fatalf("reindex exit=%d stderr=%q", code, stderr.String())
+		}
+	})
+
+	if strings.Contains(stderr.String(), "[reindex]") {
+		t.Errorf("--quiet should suppress progress lines; got %q", stderr.String())
+	}
+}

--- a/tests/cli/server_doctor_test.go
+++ b/tests/cli/server_doctor_test.go
@@ -2,11 +2,15 @@ package tests
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/dirstral/dir2mcp/internal/cli"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
 	"github.com/dirstral/dir2mcp/tests/testutil"
 )
 
@@ -62,6 +66,66 @@ func TestServerDoctor_JSONReportSurfacesOCRFallback(t *testing.T) {
 		}
 		if failures := findCheck(report.Checks, "indexing_failures"); failures == nil || failures.Status != "ok" {
 			t.Errorf("expected indexing_failures=ok on fresh state, got %+v", failures)
+		}
+	})
+}
+
+// TestServerDoctor_SurfacesDocumentLevelFailures pins the fix for
+// the original "0 failures" lie. Before the fix, doctor only counted
+// chunk-level embedding failures. A corpus where every PDF failed
+// extraction (and so never produced chunks) was reported as
+// "0 failures" even though the entire run had collapsed at the
+// document stage. The check must now report doc-level errors too.
+func TestServerDoctor_SurfacesDocumentLevelFailures(t *testing.T) {
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, ".dir2mcp")
+	t.Setenv("MISTRAL_API_KEY", "test-key")
+	t.Setenv("PATH", t.TempDir())
+
+	// Seed the store with a failed-at-extraction document; no chunks
+	// are ever created, mirroring the docling-failed-on-every-PDF
+	// scenario from the original client install.
+	ctx := context.Background()
+	st := store.NewSQLiteStore(filepath.Join(stateDir, "meta.sqlite"))
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("init store: %v", err)
+	}
+	if err := st.UpsertDocument(ctx, model.Document{
+		RelPath:   "doomed.pdf",
+		DocType:   "pdf",
+		SizeBytes: 1234,
+		Status:    "error",
+	}); err != nil {
+		t.Fatalf("upsert error doc: %v", err)
+	}
+	_ = st.Close()
+
+	testutil.WithWorkingDir(t, tmp, func() {
+		var stdout, stderr bytes.Buffer
+		app := cli.NewAppWithIO(&stdout, &stderr)
+		code := app.Run([]string{"--json", "doctor"})
+		if code != 0 {
+			t.Fatalf("doctor exit=%d stderr=%q", code, stderr.String())
+		}
+		var report struct {
+			Checks []struct {
+				Name   string `json:"name"`
+				Status string `json:"status"`
+				Detail string `json:"detail"`
+			} `json:"checks"`
+		}
+		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+			t.Fatalf("decode doctor JSON: %v", err)
+		}
+		failures := findCheck(report.Checks, "indexing_failures")
+		if failures == nil {
+			t.Fatalf("indexing_failures check missing")
+		}
+		if failures.Status != "warn" {
+			t.Errorf("indexing_failures status = %q, want warn (1 doc failed)", failures.Status)
+		}
+		if !strings.Contains(failures.Detail, "1 document") || !strings.Contains(failures.Detail, "failed extraction") {
+			t.Errorf("indexing_failures detail = %q, want substring '1 document(s) failed extraction'", failures.Detail)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Two diagnostic-visibility fixes driven by a recent debugging session where:
1. \`dir2mcp doctor\` cheerfully reported \"0 failures\" while every PDF in the corpus had failed extraction
2. \`dir2mcp reindex\` ran in silence for minutes, forcing a second-terminal \`dir2mcp status\` poll just to know whether anything was happening

### doctor: \`indexing_failures\` counts doc-level errors
Previously only consumed \`CorpusStats.FailureSummary\` (chunk-level, sourced from \`embedding_status='error'\`). When docling crashed on every PDF, no chunks were ever produced — so the chunk summary was legitimately empty and doctor lied with \"0 failures\". Now also reports \`CorpusStats.Errors\` (doc-level), e.g.:

\`\`\`
indexing_failures    warn   89 document(s) failed extraction
\`\`\`

Both stages surface; neither can hide.

### reindex: streams progress to stderr
Spawns a background poller that prints every 5 s:

\`\`\`
[reindex] scanned=12 indexed=10 skipped=1 errors=1 chunks=8 embedded=8
[reindex] scanned=24 indexed=22 skipped=1 errors=1 chunks=16 embedded=16
[reindex] done: scanned=89 indexed=87 skipped=1 errors=1 chunks=152 embedded=152
\`\`\`

Quiet under \`--quiet\` and \`--json\` so script/machine-readable callers see a clean stream. Progress data comes from \`CorpusStats\`; the type-assertion lets non-sqlite stores degrade silently.

Cyclomatic cleanup: \`runReindex\` split into \`loadReindexConfig\` + \`prepareReindexStore\` + \`finishReindex\` so the parent stays under the project's complexity budget after the new scaffolding.

## Test plan
- [x] \`make check\` green
- [x] \`TestServerDoctor_SurfacesDocumentLevelFailures\` seeds a status='error' document and asserts the doctor JSON report now flags indexing_failures as warn
- [x] \`TestReindex_PrintsProgressAndDoneLines\` asserts both starting and done lines reach stderr (via RuntimeHooks no-op ingestor)
- [x] \`TestReindex_QuietSuppressesProgress\` proves --quiet keeps the poller silent

## Follow-up queued
\`list-files\` JSON rows still lack an \`error_message\` field, so support-bundles can't yet show *why* each doc failed. That needs an additive chunks-style schema migration plus threading through every UpsertDocument error site in \`internal/ingest/service.go\` — focused PR coming.

## Companion tap PR
[dirstral/homebrew-tap#14](https://github.com/dirstral/homebrew-tap/pull/14) pins torch/torchvision/transformers in \`dir2mcp-full\` so docling installs stop crashing from PyPI version drift. Independent of this PR; merge order doesn't matter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reindex command now displays periodic progress updates during indexing operations
  * Added `--quiet` flag support to suppress progress output

* **Improvements**
  * Doctor command now detects both document-level and chunk-level indexing failures with enhanced diagnostics

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dirstral/dir2mcp/pull/211?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->