### PR TITLE
feat(store): persist per-doc error_message + surface in support bundle

### DIFF
--- a/internal/cli/support_bundle.go
+++ b/internal/cli/support_bundle.go
@@ -210,9 +210,28 @@ func marshalStatusJSON(ctx context.Context, a *App, cfg config.Config) ([]byte, 
 	}, "", "  ")
 }
 
-// marshalListFilesJSON returns the same payload `dir2mcp list-files
-// --json` would emit. Reads directly from the sqlite store so it works
-// without the daemon running.
+// supportBundleFileRow is the per-document shape emitted in the bundle's
+// list-files.json. It deliberately uses snake_case keys (matching the
+// MCP tool conventions) and adds error_message — a maintainer-facing
+// field that is intentionally NOT part of the spec-bound MCP list_files
+// tool output (SPEC §15.5 uses additionalProperties:false, and the
+// support bundle is a diagnostic artifact outside that contract).
+type supportBundleFileRow struct {
+	RelPath      string `json:"rel_path"`
+	DocType      string `json:"doc_type"`
+	SourceType   string `json:"source_type,omitempty"`
+	Title        string `json:"title,omitempty"`
+	SizeBytes    int64  `json:"size_bytes"`
+	MTimeUnix    int64  `json:"mtime_unix"`
+	Status       string `json:"status"`
+	Deleted      bool   `json:"deleted"`
+	ErrorMessage string `json:"error_message,omitempty"`
+}
+
+// marshalListFilesJSON dumps the per-document list with extraction-error
+// messages included so maintainers can tell from the bundle alone *why*
+// a document failed, not just *that* it did. Reads directly from the
+// sqlite store so it works without the daemon running.
 func marshalListFilesJSON(ctx context.Context, a *App, cfg config.Config) ([]byte, error) {
 	metaPath := filepath.Join(cfg.StateDir, "meta.sqlite")
 	if _, err := os.Stat(metaPath); err != nil {
@@ -230,8 +249,22 @@ func marshalListFilesJSON(ctx context.Context, a *App, cfg config.Config) ([]byt
 	if err != nil {
 		return nil, fmt.Errorf("list files: %w", err)
 	}
+	rows := make([]supportBundleFileRow, 0, len(docs))
+	for _, d := range docs {
+		rows = append(rows, supportBundleFileRow{
+			RelPath:      d.RelPath,
+			DocType:      d.DocType,
+			SourceType:   d.SourceType,
+			Title:        d.Title,
+			SizeBytes:    d.SizeBytes,
+			MTimeUnix:    d.MTimeUnix,
+			Status:       d.Status,
+			Deleted:      d.Deleted,
+			ErrorMessage: d.ErrorMessage,
+		})
+	}
 	return json.MarshalIndent(map[string]interface{}{
-		"files": docs,
+		"files": rows,
 		"total": total,
 	}, "", "  ")
 }

--- a/internal/ingest/exclude.go
+++ b/internal/ingest/exclude.go
@@ -45,6 +45,26 @@ func HasSecretMatch(sample []byte, patterns []*regexp.Regexp) bool {
 	return false
 }
 
+// RedactSecretsInMessage replaces any substring matching one of the
+// configured secret patterns with the literal "[REDACTED]". Used before
+// persisting upstream error text to documents.error_message (and thus
+// to the support bundle) so that a provider error that quotes back the
+// triggering payload — e.g. a misconfigured Authorization header or an
+// echoed API key — cannot leak through the diagnostic surface.
+func RedactSecretsInMessage(msg string, patterns []*regexp.Regexp) string {
+	if msg == "" {
+		return msg
+	}
+	out := msg
+	for _, rx := range patterns {
+		if rx == nil {
+			continue
+		}
+		out = rx.ReplaceAllString(out, "[REDACTED]")
+	}
+	return out
+}
+
 func matchesAnyPathExclude(relPath string, globs []string) bool {
 	return MatchesAnyPathExclude(relPath, globs)
 }

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -492,7 +492,7 @@ func (s *Service) processDocument(ctx context.Context, f DiscoveredFile, secretP
 			MTimeUnix:    f.MTimeUnix,
 			Status:       "error",
 			Deleted:      false,
-			ErrorMessage: buildErr.Error(),
+			ErrorMessage: RedactSecretsInMessage(buildErr.Error(), secretPatterns),
 		}
 		if err := s.store.UpsertDocument(ctx, doc); err != nil {
 			return fmt.Errorf("upsert error document: %w", err)
@@ -560,7 +560,7 @@ func (s *Service) processDocument(ctx context.Context, f DiscoveredFile, secretP
 		// and operators can identify it via status queries.  Silence the upsert
 		// error since the original rep error is the more actionable signal.
 		doc.Status = "error"
-		doc.ErrorMessage = err.Error()
+		doc.ErrorMessage = RedactSecretsInMessage(err.Error(), secretPatterns)
 		_ = s.store.UpsertDocument(ctx, doc)
 		return fmt.Errorf("generate representations: %w", err)
 	}
@@ -701,7 +701,7 @@ func (s *Service) processDocumentFromContent(ctx context.Context, relPath string
 		// and operators can identify it via status queries.  Silence the upsert
 		// error since the original rep error is the more actionable signal.
 		doc.Status = "error"
-		doc.ErrorMessage = err.Error()
+		doc.ErrorMessage = RedactSecretsInMessage(err.Error(), secretPatterns)
 		_ = s.store.UpsertDocument(ctx, doc)
 		return fmt.Errorf("generate representations: %w", err)
 	}

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -486,12 +486,13 @@ func (s *Service) processDocument(ctx context.Context, f DiscoveredFile, secretP
 	doc, content, buildErr := s.buildDocumentWithContent(f, secretPatterns)
 	if buildErr != nil {
 		doc = model.Document{
-			RelPath:   f.RelPath,
-			DocType:   ClassifyDocType(f.RelPath),
-			SizeBytes: f.SizeBytes,
-			MTimeUnix: f.MTimeUnix,
-			Status:    "error",
-			Deleted:   false,
+			RelPath:      f.RelPath,
+			DocType:      ClassifyDocType(f.RelPath),
+			SizeBytes:    f.SizeBytes,
+			MTimeUnix:    f.MTimeUnix,
+			Status:       "error",
+			Deleted:      false,
+			ErrorMessage: buildErr.Error(),
 		}
 		if err := s.store.UpsertDocument(ctx, doc); err != nil {
 			return fmt.Errorf("upsert error document: %w", err)
@@ -559,6 +560,7 @@ func (s *Service) processDocument(ctx context.Context, f DiscoveredFile, secretP
 		// and operators can identify it via status queries.  Silence the upsert
 		// error since the original rep error is the more actionable signal.
 		doc.Status = "error"
+		doc.ErrorMessage = err.Error()
 		_ = s.store.UpsertDocument(ctx, doc)
 		return fmt.Errorf("generate representations: %w", err)
 	}
@@ -699,6 +701,7 @@ func (s *Service) processDocumentFromContent(ctx context.Context, relPath string
 		// and operators can identify it via status queries.  Silence the upsert
 		// error since the original rep error is the more actionable signal.
 		doc.Status = "error"
+		doc.ErrorMessage = err.Error()
 		_ = s.store.UpsertDocument(ctx, doc)
 		return fmt.Errorf("generate representations: %w", err)
 	}

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -16,6 +16,15 @@ type Document struct {
 	ContentHash string
 	Status      string
 	Deleted     bool
+	// ErrorMessage is populated when Status == "error" with a short
+	// human-readable description of why ingest failed (extraction
+	// crash, representation generation failure, etc.). Surfaced in
+	// the support bundle's list-files.json so a maintainer can tell
+	// *why* a document failed without having to grep server.log. The
+	// field is intentionally not part of the MCP `list_files` tool
+	// output (that schema is fixed by SPEC §15.5 with
+	// additionalProperties:false); it is a diagnostic-bundle field.
+	ErrorMessage string
 }
 
 type Representation struct {

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -287,6 +287,12 @@ func applyAdditiveColumnMigrations(ctx context.Context, db *sql.DB) error {
 		// surface "rate_limit: 67, payload_too_large: 21" instead of
 		// just an aggregate failure count.
 		`ALTER TABLE chunks ADD COLUMN error_category TEXT NOT NULL DEFAULT ''`,
+		// error_message stores a short human-readable explanation when
+		// a document ends up with status='error' (extraction crash,
+		// representation generation failure). Surfaced in the support
+		// bundle's list-files.json so maintainers can tell *why* a doc
+		// failed without grepping server.log.
+		`ALTER TABLE documents ADD COLUMN error_message TEXT NOT NULL DEFAULT ''`,
 	}
 	for _, stmt := range migrations {
 		if _, err := db.ExecContext(ctx, stmt); err != nil && !isDuplicateColumnError(err) {
@@ -496,10 +502,16 @@ func (s *SQLiteStore) UpsertDocument(ctx context.Context, doc model.Document) er
 	}
 	defer s.ReleaseDB()
 
+	// error_message is unconditionally overwritten by excluded.error_message
+	// so a successful re-ingest after a prior error clears the stale message
+	// (caller passes "" for healthy docs, the failure-recovery message
+	// otherwise). Title intentionally uses the CASE-preserve pattern because
+	// title can be extracted *after* the first upsert; error_message has no
+	// such two-phase write, so the always-replace semantics are correct.
 	_, err = db.ExecContext(
 		ctx,
-		`INSERT INTO documents(rel_path, doc_type, source_type, size_bytes, mtime_unix, content_hash, status, deleted, title)
-		 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`INSERT INTO documents(rel_path, doc_type, source_type, size_bytes, mtime_unix, content_hash, status, deleted, title, error_message)
+		 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		 ON CONFLICT(rel_path) DO UPDATE SET
 		   doc_type=excluded.doc_type,
 		   source_type=excluded.source_type,
@@ -508,7 +520,8 @@ func (s *SQLiteStore) UpsertDocument(ctx context.Context, doc model.Document) er
 		   content_hash=excluded.content_hash,
 		   status=excluded.status,
 		   deleted=excluded.deleted,
-		   title=CASE WHEN excluded.title <> '' THEN excluded.title ELSE documents.title END`,
+		   title=CASE WHEN excluded.title <> '' THEN excluded.title ELSE documents.title END,
+		   error_message=excluded.error_message`,
 		relPath,
 		normalizeDocType(doc.DocType),
 		normalizeSourceType(doc.SourceType),
@@ -518,8 +531,47 @@ func (s *SQLiteStore) UpsertDocument(ctx context.Context, doc model.Document) er
 		normalizeStatus(doc.Status),
 		boolToInt(doc.Deleted),
 		strings.TrimSpace(doc.Title),
+		sanitizeDocErrorMessage(doc.ErrorMessage),
 	)
 	return err
+}
+
+// sanitizeDocErrorMessage normalises a free-text upstream error before it
+// is persisted to documents.error_message. We strip leading/trailing
+// whitespace, replace embedded control characters with spaces (so the
+// message stays one line in the support bundle), and cap the length at
+// 512 bytes so a runaway stack trace can't bloat the documents table.
+// Truncation respects UTF-8 boundaries to avoid persisting an invalid
+// trailing rune.
+func sanitizeDocErrorMessage(msg string) string {
+	msg = strings.TrimSpace(msg)
+	if msg == "" {
+		return ""
+	}
+	const maxBytes = 512
+	var b strings.Builder
+	b.Grow(len(msg))
+	for _, r := range msg {
+		if r == '\n' || r == '\r' || r == '\t' {
+			b.WriteByte(' ')
+			continue
+		}
+		if r < 0x20 || r == 0x7f {
+			b.WriteByte(' ')
+			continue
+		}
+		b.WriteRune(r)
+	}
+	out := b.String()
+	if len(out) <= maxBytes {
+		return out
+	}
+	// Truncate on a rune boundary.
+	cut := maxBytes
+	for cut > 0 && (out[cut]&0xC0) == 0x80 {
+		cut--
+	}
+	return out[:cut]
 }
 
 func (s *SQLiteStore) UpsertChunkTask(ctx context.Context, task model.ChunkTask) error {
@@ -878,7 +930,7 @@ func (s *SQLiteStore) GetDocumentByPath(ctx context.Context, relPath string) (mo
 	var deleted int
 	row := db.QueryRowContext(
 		ctx,
-		`SELECT doc_id, rel_path, doc_type, source_type, size_bytes, mtime_unix, content_hash, status, deleted, title
+		`SELECT doc_id, rel_path, doc_type, source_type, size_bytes, mtime_unix, content_hash, status, deleted, title, error_message
 		 FROM documents WHERE rel_path = ?`,
 		normalizedPath,
 	)
@@ -893,6 +945,7 @@ func (s *SQLiteStore) GetDocumentByPath(ctx context.Context, relPath string) (mo
 		&doc.Status,
 		&deleted,
 		&doc.Title,
+		&doc.ErrorMessage,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return model.Document{}, os.ErrNotExist
@@ -919,7 +972,7 @@ func (s *SQLiteStore) ListFiles(ctx context.Context, prefix, glob string, limit,
 
 	normalizedPrefix := normalizePrefix(prefix)
 
-	query := `SELECT doc_id, rel_path, doc_type, source_type, size_bytes, mtime_unix, content_hash, status, deleted, title FROM documents`
+	query := `SELECT doc_id, rel_path, doc_type, source_type, size_bytes, mtime_unix, content_hash, status, deleted, title, error_message FROM documents`
 	where := []string{"deleted = 0"}
 	args := make([]any, 0, 4)
 	if normalizedPrefix != "" {
@@ -955,6 +1008,7 @@ func (s *SQLiteStore) ListFiles(ctx context.Context, prefix, glob string, limit,
 			&doc.Status,
 			&deleted,
 			&doc.Title,
+			&doc.ErrorMessage,
 		); err != nil {
 			return nil, 0, err
 		}

--- a/tests/cli/support_bundle_test.go
+++ b/tests/cli/support_bundle_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"context"
 	"encoding/json"
 	"io"
 	"os"
@@ -12,6 +13,8 @@ import (
 	"testing"
 
 	"github.com/dirstral/dir2mcp/internal/cli"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
 	"github.com/dirstral/dir2mcp/tests/testutil"
 )
 
@@ -67,6 +70,85 @@ func TestSupportBundle_AssemblesDiagnosticsArchive(t *testing.T) {
 		}
 	}
 	assertOCRDiagnostic(t, entries["routing.json"])
+}
+
+// TestSupportBundle_ListFilesIncludesErrorMessage pins the follow-up
+// fix to the original failing-install diagnostic story: before this
+// change the bundle's list-files.json told maintainers *that* a doc
+// failed (status="error") but never *why* — the upstream extraction
+// error was logged to server.log only. Now the bundle carries
+// documents.error_message so maintainers can triage a failed corpus
+// from the bundle alone.
+func TestSupportBundle_ListFilesIncludesErrorMessage(t *testing.T) {
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, ".dir2mcp")
+	t.Setenv("MISTRAL_API_KEY", "test-key")
+	t.Setenv("PATH", t.TempDir())
+
+	// Seed a failed document so the bundle's list-files.json has
+	// something to carry the new error_message field for.
+	ctx := context.Background()
+	st := store.NewSQLiteStore(filepath.Join(stateDir, "meta.sqlite"))
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("init store: %v", err)
+	}
+	const wantMessage = "docling extraction failed: unsupported PDF v1.7"
+	if err := st.UpsertDocument(ctx, model.Document{
+		RelPath:      "doomed.pdf",
+		DocType:      "pdf",
+		SizeBytes:    1234,
+		Status:       "error",
+		ErrorMessage: wantMessage,
+	}); err != nil {
+		t.Fatalf("upsert error doc: %v", err)
+	}
+	_ = st.Close()
+
+	bundlePath := filepath.Join(tmp, "bundle.tar.gz")
+	testutil.WithWorkingDir(t, tmp, func() {
+		var stdout, stderr bytes.Buffer
+		app := cli.NewAppWithIO(&stdout, &stderr)
+		code := app.Run([]string{"support-bundle", "--output", bundlePath})
+		if code != 0 {
+			t.Fatalf("support-bundle exit=%d stderr=%q", code, stderr.String())
+		}
+	})
+
+	entries := extractTarGz(t, bundlePath)
+	listBody, ok := entries["list-files.json"]
+	if !ok {
+		t.Fatalf("bundle missing list-files.json")
+	}
+	var listed struct {
+		Files []struct {
+			RelPath      string `json:"rel_path"`
+			Status       string `json:"status"`
+			ErrorMessage string `json:"error_message"`
+		} `json:"files"`
+	}
+	if err := json.Unmarshal(listBody, &listed); err != nil {
+		t.Fatalf("decode list-files.json: %v body=%s", err, listBody)
+	}
+	var found *struct {
+		RelPath      string `json:"rel_path"`
+		Status       string `json:"status"`
+		ErrorMessage string `json:"error_message"`
+	}
+	for i := range listed.Files {
+		if listed.Files[i].RelPath == "doomed.pdf" {
+			found = &listed.Files[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("list-files.json missing doomed.pdf row: %s", listBody)
+	}
+	if found.Status != "error" {
+		t.Errorf("status = %q, want error", found.Status)
+	}
+	if found.ErrorMessage != wantMessage {
+		t.Errorf("error_message = %q, want %q", found.ErrorMessage, wantMessage)
+	}
 }
 
 // TestSupportBundle_JSONFlagParseError ensures the support-bundle

--- a/tests/ingest/ingest_test.go
+++ b/tests/ingest/ingest_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/dirstral/dir2mcp/internal/ingest"
@@ -256,6 +257,68 @@ func TestHasSecretMatch(t *testing.T) {
 			result := ingest.HasSecretMatch(tt.content, patterns)
 			if result != tt.expected {
 				t.Errorf("hasSecretMatch() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestRedactSecretsInMessage pins the per-document error_message
+// redaction (PR #212 + CodeRabbit follow-up): upstream provider error
+// strings sometimes echo back the triggering payload (Authorization
+// headers, API keys, etc.). Persisting those raw into
+// documents.error_message would re-export them in the support bundle.
+// RedactSecretsInMessage reuses the user's configured secret patterns
+// so any string matching a configured pattern is replaced with
+// "[REDACTED]" before write.
+func TestRedactSecretsInMessage(t *testing.T) {
+	patterns, err := ingest.CompileSecretPatterns([]string{
+		`AKIA[0-9A-Z]{16}`,
+		`sk_[a-z0-9]{32}`,
+	})
+	if err != nil {
+		t.Fatalf("compile patterns: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		in      string
+		wantSub string // expected substring after redaction
+		mustNot string // must NOT appear in the output
+	}{
+		{
+			name:    "AWS key in error text",
+			in:      "upstream rejected request: AKIAIOSFODNN7EXAMPLE invalid signature",
+			wantSub: "[REDACTED]",
+			mustNot: "AKIAIOSFODNN7EXAMPLE",
+		},
+		{
+			name:    "API key in error text",
+			in:      "401 unauthorized using key sk_12345678901234567890123456789012",
+			wantSub: "[REDACTED]",
+			mustNot: "sk_12345678901234567890123456789012",
+		},
+		{
+			name:    "benign message left intact",
+			in:      "docling extraction failed: unsupported PDF version 1.7",
+			wantSub: "unsupported PDF version 1.7",
+			mustNot: "[REDACTED]",
+		},
+		{
+			name:    "empty message stays empty",
+			in:      "",
+			wantSub: "",
+			mustNot: "[REDACTED]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ingest.RedactSecretsInMessage(tt.in, patterns)
+			if tt.wantSub != "" && !strings.Contains(got, tt.wantSub) {
+				t.Errorf("got %q, want substring %q", got, tt.wantSub)
+			}
+			if tt.mustNot != "" && strings.Contains(got, tt.mustNot) {
+				t.Errorf("got %q, must NOT contain %q", got, tt.mustNot)
 			}
 		})
 	}

--- a/tests/store/document_error_message_roundtrip_test.go
+++ b/tests/store/document_error_message_roundtrip_test.go
@@ -1,0 +1,145 @@
+package tests
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// TestSQLiteStore_DocumentErrorMessageRoundtrip pins the persistence
+// behaviour of documents.error_message: it round-trips through both
+// GetDocumentByPath and ListFiles, control characters are stripped so
+// the message stays one line in the support bundle, and a successful
+// re-ingest (Status="ok", empty ErrorMessage) clears the stale message
+// rather than leaving the prior failure footprint in place.
+func TestSQLiteStore_DocumentErrorMessageRoundtrip(t *testing.T) {
+	ctx := context.Background()
+	st := newTempSQLiteStore(t, ctx)
+	defer func() { _ = st.Close() }()
+
+	failed := model.Document{
+		RelPath:      "broken.pdf",
+		DocType:      "pdf",
+		SizeBytes:    2048,
+		MTimeUnix:    1_700_000_000,
+		Status:       "error",
+		ErrorMessage: "docling extraction failed\n\tunsupported PDF version 1.7",
+	}
+	if err := st.UpsertDocument(ctx, failed); err != nil {
+		t.Fatalf("UpsertDocument(failed): %v", err)
+	}
+
+	assertGetErrorMessageSanitized(t, ctx, st, failed.RelPath)
+	assertListFilesCarriesErrorMessage(t, ctx, st, failed.RelPath)
+	assertSuccessfulReingestClearsMessage(t, ctx, st, failed)
+}
+
+// assertGetErrorMessageSanitized verifies GetDocumentByPath returns a
+// non-empty error_message with its embedded control characters
+// stripped — the field must stay one line so the support bundle is
+// readable per-row.
+func assertGetErrorMessageSanitized(t *testing.T, ctx context.Context, st *store.SQLiteStore, relPath string) {
+	t.Helper()
+	got, err := st.GetDocumentByPath(ctx, relPath)
+	if err != nil {
+		t.Fatalf("GetDocumentByPath(%s): %v", relPath, err)
+	}
+	if got.Status != "error" {
+		t.Errorf("status = %q, want error", got.Status)
+	}
+	if !strings.Contains(got.ErrorMessage, "docling extraction failed") {
+		t.Errorf("error_message lost substance: %q", got.ErrorMessage)
+	}
+	if strings.ContainsAny(got.ErrorMessage, "\n\r\t") {
+		t.Errorf("error_message should have control chars stripped: %q", got.ErrorMessage)
+	}
+}
+
+// assertListFilesCarriesErrorMessage verifies the same error_message
+// is exposed via ListFiles so the support bundle can carry it without
+// an extra per-doc lookup.
+func assertListFilesCarriesErrorMessage(t *testing.T, ctx context.Context, st *store.SQLiteStore, relPath string) {
+	t.Helper()
+	docs, _, err := st.ListFiles(ctx, "", "", 10, 0)
+	if err != nil {
+		t.Fatalf("ListFiles: %v", err)
+	}
+	for _, d := range docs {
+		if d.RelPath != relPath {
+			continue
+		}
+		if !strings.Contains(d.ErrorMessage, "docling extraction failed") {
+			t.Errorf("ListFiles error_message = %q, want substring 'docling extraction failed'", d.ErrorMessage)
+		}
+		return
+	}
+	t.Fatalf("ListFiles missing %s", relPath)
+}
+
+// assertSuccessfulReingestClearsMessage pins the "clear stale" half of
+// the contract: a re-ingest with Status="ok" and empty ErrorMessage
+// must wipe the prior failure message, not leave it visible to
+// doctor / support-bundle as if the document were still broken.
+func assertSuccessfulReingestClearsMessage(t *testing.T, ctx context.Context, st *store.SQLiteStore, prior model.Document) {
+	t.Helper()
+	recovered := prior
+	recovered.Status = "ok"
+	recovered.ErrorMessage = ""
+	if err := st.UpsertDocument(ctx, recovered); err != nil {
+		t.Fatalf("UpsertDocument(recovered): %v", err)
+	}
+	got, err := st.GetDocumentByPath(ctx, recovered.RelPath)
+	if err != nil {
+		t.Fatalf("GetDocumentByPath(recovered): %v", err)
+	}
+	if got.ErrorMessage != "" {
+		t.Errorf("error_message not cleared after successful re-ingest: %q", got.ErrorMessage)
+	}
+	if got.Status != "ok" {
+		t.Errorf("status = %q, want ok", got.Status)
+	}
+}
+
+// TestSQLiteStore_DocumentErrorMessageTruncation verifies that runaway
+// upstream errors (stack traces, blob dumps) are capped before they
+// reach the documents table so a single bad doc can't bloat the store.
+func TestSQLiteStore_DocumentErrorMessageTruncation(t *testing.T) {
+	ctx := context.Background()
+	st := newTempSQLiteStore(t, ctx)
+	defer func() { _ = st.Close() }()
+
+	huge := strings.Repeat("A", 4096)
+	doc := model.Document{
+		RelPath:      "huge-error.pdf",
+		DocType:      "pdf",
+		Status:       "error",
+		ErrorMessage: huge,
+	}
+	if err := st.UpsertDocument(ctx, doc); err != nil {
+		t.Fatalf("UpsertDocument: %v", err)
+	}
+	got, err := st.GetDocumentByPath(ctx, doc.RelPath)
+	if err != nil {
+		t.Fatalf("GetDocumentByPath: %v", err)
+	}
+	if len(got.ErrorMessage) > 512 {
+		t.Errorf("error_message len = %d, want <= 512 (truncation cap)", len(got.ErrorMessage))
+	}
+	if len(got.ErrorMessage) == 0 {
+		t.Errorf("error_message was emptied entirely; expected truncation, not deletion")
+	}
+}
+
+func newTempSQLiteStore(t *testing.T, ctx context.Context) *store.SQLiteStore {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "meta.sqlite")
+	st := store.NewSQLiteStore(dbPath)
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	return st
+}


### PR DESCRIPTION
## Summary

- Persist a sanitized `error_message` on documents whenever ingest sets `status='error'` (extraction crash, representation generation failure).
- Surface it in the support bundle's `list-files.json` so maintainers can triage a failed corpus from the bundle alone — no `server.log` grep needed.
- Closes the diagnostic gap left over from #210/#211: doctor now says "1 document failed extraction" but didn't reveal *why*; the bundle now does.

## Scope decisions

- **MCP `list_files` tool output is unchanged.** SPEC §15.5 uses `additionalProperties: false`; adding `error_message` there would be a spec violation. The new field lives only on the support-bundle diagnostic artifact, which has no spec contract — so no `dirstral-spec` PR is required.
- `sanitizeDocErrorMessage` strips control chars (so one line per row in the bundle) and caps at 512 bytes on a rune boundary so a runaway stack trace can't bloat the documents table.
- `UpsertDocument`'s ON CONFLICT clause replaces (not preserves) `error_message`, so a successful re-ingest after a prior failure clears the stale message instead of leaving a recovered document looking broken.

## Surface area

- `internal/model/types.go` — new `Document.ErrorMessage` field.
- `internal/store/sqlite_store.go` — additive `error_message` migration + `sanitizeDocErrorMessage`; wired through `UpsertDocument`, `GetDocumentByPath`, `ListFiles`.
- `internal/ingest/service.go` — three error sites pass the message.
- `internal/cli/support_bundle.go` — explicit `supportBundleFileRow` shape (snake_case, `omitempty`).
- `tests/store/document_error_message_roundtrip_test.go` — roundtrip, control-char sanitization, truncation cap, clear-on-recovery.
- `tests/cli/support_bundle_test.go` — bundle integration.

## Test plan

- [x] `go test ./internal/store/... ./tests/store/... ./tests/cli/... ./tests/ingest/...`
- [x] `make check` (gofmt, vet, golangci-lint, gocyclo<=15, all tests, scripts unittests, build)
- [ ] CodeRabbit review run + findings addressed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Support bundles now include detailed error messages for failed document ingestion, providing clearer diagnostics when document processing encounters failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dirstral/dir2mcp/pull/212?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->