### PR TITLE
feat(mcp): wire stats.recent_failures (spec 0.8.0)

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -374,6 +374,10 @@ func (s *Server) handleStatsTool(ctx context.Context, args map[string]interface{
 			}(),
 		},
 	}
+	if failures := loadRecentFailuresForStats(ctx, s.store); len(failures) > 0 {
+		structured["recent_failures"] = failures
+	}
+
 	s.sessionMu.RLock()
 	sessionItems := make([]map[string]interface{}, 0, len(s.sessions))
 	for id, si := range s.sessions {
@@ -408,6 +412,51 @@ func (s *Server) handleStatsTool(ctx context.Context, args map[string]interface{
 		},
 		StructuredContent: structured,
 	}, nil
+}
+
+// statsRecentFailuresLimit caps the recent_failures array per the spec
+// (SPEC §15.6 "Implementations SHOULD cap at 20 entries by default").
+const statsRecentFailuresLimit = 20
+
+// loadRecentFailuresForStats returns the per-doc projection emitted in
+// dir2mcp_stats's optional recent_failures array: rel_path, doc_type,
+// mtime_unix, error_message — the spec-required item shape, no more
+// (additionalProperties:false on the item schema).
+//
+// Type-asserts the store rather than touching the model.Store interface
+// so mocks/in-memory backends used in tests don't need an extra method.
+// Returns nil (not empty slice) when stats are unavailable or when the
+// store has no failures; the caller omits the field entirely in that
+// case, matching the spec's "MAY omit when no failures are recorded".
+//
+// Errors from the underlying query are swallowed and logged via the
+// returned nil — a healthy stats call must not fail because the
+// failure-aggregation side query had a transient issue.
+func loadRecentFailuresForStats(ctx context.Context, st model.Store) []map[string]interface{} {
+	if st == nil {
+		return nil
+	}
+	type recentFailurer interface {
+		RecentFailures(ctx context.Context, limit int) ([]model.Document, error)
+	}
+	rf, ok := st.(recentFailurer)
+	if !ok {
+		return nil
+	}
+	docs, err := rf.RecentFailures(ctx, statsRecentFailuresLimit)
+	if err != nil || len(docs) == 0 {
+		return nil
+	}
+	out := make([]map[string]interface{}, 0, len(docs))
+	for _, d := range docs {
+		out = append(out, map[string]interface{}{
+			"rel_path":      d.RelPath,
+			"doc_type":      d.DocType,
+			"mtime_unix":    d.MTimeUnix,
+			"error_message": d.ErrorMessage,
+		})
+	}
+	return out
 }
 
 func (s *Server) handleListFilesTool(ctx context.Context, args map[string]interface{}) (toolCallResult, *toolExecutionError) {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -458,17 +458,18 @@ func redactStatsErrorMessage(msg string) string {
 // store has no failures; the caller omits the field entirely in that
 // case, matching the spec's "MAY omit when no failures are recorded".
 //
-// Errors from the underlying query are swallowed and logged via the
-// returned nil — a healthy stats call must not fail because the
-// failure-aggregation side query had a transient issue.
+// Errors from the underlying query are silently swallowed (return nil)
+// — a healthy stats call must not fail because the failure-aggregation
+// side query had a transient issue. The MCP layer has no logger handle
+// here; if richer diagnostics are needed later, plumb one through.
 func loadRecentFailuresForStats(ctx context.Context, st model.Store) []map[string]interface{} {
 	if st == nil {
 		return nil
 	}
-	type recentFailurer interface {
+	type recentFailuresLister interface {
 		RecentFailures(ctx context.Context, limit int) ([]model.Document, error)
 	}
-	rf, ok := st.(recentFailurer)
+	rf, ok := st.(recentFailuresLister)
 	if !ok {
 		return nil
 	}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"unicode/utf8"
@@ -418,6 +419,34 @@ func (s *Server) handleStatsTool(ctx context.Context, args map[string]interface{
 // (SPEC §15.6 "Implementations SHOULD cap at 20 entries by default").
 const statsRecentFailuresLimit = 20
 
+// statsErrorMessageRedactors is a small safety net of common credential
+// shapes applied at the MCP boundary before emitting recent_failures.
+// The write-side already runs the operator's configured
+// `secret_patterns` against err.Error() (see ingest.RedactSecretsInMessage,
+// PR #212) — this is belt-and-suspenders for the cases where the
+// operator hasn't configured any patterns or where a non-SQLite store
+// backend persists raw text. SPEC §15.6: "error_message MUST NOT
+// contain secrets". Kept tight (high-confidence shapes only) to avoid
+// false positives that would hide the actionable failure description.
+var statsErrorMessageRedactors = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)bearer\s+[A-Za-z0-9._\-+/=]{20,}`),
+	regexp.MustCompile(`AKIA[0-9A-Z]{16}`),                                                 // AWS access key
+	regexp.MustCompile(`sk-[A-Za-z0-9_\-]{20,}`),                                           // OpenAI / Mistral / Anthropic style
+	regexp.MustCompile(`gh[pousr]_[A-Za-z0-9_]{20,}`),                                      // GitHub PAT / OAuth
+	regexp.MustCompile(`xox[baprs]-[A-Za-z0-9-]{10,}`),                                     // Slack
+	regexp.MustCompile(`eyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-.]{10,}\.[A-Za-z0-9_\-]{5,}`), // JWT
+}
+
+// redactStatsErrorMessage runs the high-confidence credential
+// redactors over msg, replacing each match with the literal
+// "[REDACTED]". Returns msg unchanged when no pattern matches.
+func redactStatsErrorMessage(msg string) string {
+	for _, rx := range statsErrorMessageRedactors {
+		msg = rx.ReplaceAllString(msg, "[REDACTED]")
+	}
+	return msg
+}
+
 // loadRecentFailuresForStats returns the per-doc projection emitted in
 // dir2mcp_stats's optional recent_failures array: rel_path, doc_type,
 // mtime_unix, error_message — the spec-required item shape, no more
@@ -453,7 +482,7 @@ func loadRecentFailuresForStats(ctx context.Context, st model.Store) []map[strin
 			"rel_path":      d.RelPath,
 			"doc_type":      d.DocType,
 			"mtime_unix":    d.MTimeUnix,
-			"error_message": d.ErrorMessage,
+			"error_message": redactStatsErrorMessage(d.ErrorMessage),
 		})
 	}
 	return out
@@ -2617,6 +2646,25 @@ func statsOutputSchema() map[string]interface{} {
 					},
 				},
 				"required": []string{"active", "items"},
+			},
+			// recent_failures: optional per SPEC §15.6 — implementations
+			// MAY omit when no failures are recorded; clients MUST treat
+			// omission as "no recent failures". additionalProperties:false
+			// on the item mirrors the canonical schema mirror in
+			// dirstral-spec/spec/tools/schemas/stats.json.
+			"recent_failures": map[string]interface{}{
+				"type": "array",
+				"items": map[string]interface{}{
+					"type":                 "object",
+					"additionalProperties": false,
+					"properties": map[string]interface{}{
+						"rel_path":      map[string]interface{}{"type": "string"},
+						"doc_type":      map[string]interface{}{"type": "string"},
+						"mtime_unix":    map[string]interface{}{"type": "integer"},
+						"error_message": map[string]interface{}{"type": "string"},
+					},
+					"required": []string{"rel_path", "doc_type", "mtime_unix", "error_message"},
+				},
 			},
 		},
 		"required": []string{"root", "state_dir", "protocol_version", "doc_counts", "total_docs", "doc_counts_available", "indexing", "models", "sessions"},

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -1033,6 +1033,68 @@ func (s *SQLiteStore) ListFiles(ctx context.Context, prefix, glob string, limit,
 	return docs, total, nil
 }
 
+// RecentFailures returns up to limit documents that ended ingest with
+// status='error', newest-first by mtime_unix and rel_path-stable for
+// ties (so callers see deterministic output across runs). Deleted rows
+// are excluded — they're tombstones, not actionable failures. Backs
+// the optional `recent_failures` field on dir2mcp_stats (SPEC §15.6).
+//
+// limit <= 0 is treated as the recommended default of 20 per the spec.
+// Returned documents carry the same per-row fields ListFiles emits;
+// callers should project to whatever shape they need.
+func (s *SQLiteStore) RecentFailures(ctx context.Context, limit int) ([]model.Document, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+
+	db, err := s.ensureDB(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer s.ReleaseDB()
+
+	rows, err := db.QueryContext(
+		ctx,
+		`SELECT doc_id, rel_path, doc_type, source_type, size_bytes, mtime_unix, content_hash, status, deleted, title, error_message
+		 FROM documents
+		 WHERE status = 'error' AND deleted = 0
+		 ORDER BY mtime_unix DESC, rel_path ASC
+		 LIMIT ?`,
+		limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := make([]model.Document, 0, limit)
+	for rows.Next() {
+		var doc model.Document
+		var deleted int
+		if err := rows.Scan(
+			&doc.DocID,
+			&doc.RelPath,
+			&doc.DocType,
+			&doc.SourceType,
+			&doc.SizeBytes,
+			&doc.MTimeUnix,
+			&doc.ContentHash,
+			&doc.Status,
+			&deleted,
+			&doc.Title,
+			&doc.ErrorMessage,
+		); err != nil {
+			return nil, err
+		}
+		doc.Deleted = deleted == 1
+		out = append(out, doc)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ActiveDocCounts returns active-document counts grouped by doc_type along
 // with the total active document count using aggregate SQL queries.  The
 // implementation simply obtains a database handle and delegates to

--- a/tests/mcp/stats_recent_failures_test.go
+++ b/tests/mcp/stats_recent_failures_test.go
@@ -1,0 +1,142 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/protocol"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// TestMCPToolsCallStats_RecentFailuresPresentWhenSeeded pins SPEC §15.6:
+// when the SQLite store has documents in status='error', the dir2mcp_stats
+// tool MUST include a recent_failures array carrying rel_path, doc_type,
+// mtime_unix, and the sanitized error_message — newest first. This is the
+// programmatic surface for the per-document failure visibility that the
+// support bundle already exposes via list-files.json.
+func TestMCPToolsCallStats_RecentFailuresPresentWhenSeeded(t *testing.T) {
+	tmp := t.TempDir()
+	st := store.NewSQLiteStore(filepath.Join(tmp, "meta.sqlite"))
+	if err := st.Init(context.Background()); err != nil {
+		t.Fatalf("init store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	seedRecentFailureFixture(t, st)
+
+	cfg := config.Default()
+	cfg.StateDir = tmp
+	cfg.MCPPath = protocol.DefaultMCPPath
+	cfg.AuthMode = "none"
+
+	server := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st)).Handler())
+	defer server.Close()
+
+	sc := callStatsTool(t, server.URL+cfg.MCPPath)
+	failuresRaw, ok := sc["recent_failures"].([]interface{})
+	if !ok {
+		t.Fatalf("recent_failures missing or not an array: %#v", sc["recent_failures"])
+	}
+	assertRecentFailuresFixtureOrder(t, failuresRaw)
+}
+
+// TestMCPToolsCallStats_RecentFailuresOmittedWhenHealthy pins the spec
+// "MAY omit when no failures are recorded" branch: a clean corpus must
+// not emit an empty recent_failures array, so consumers can rely on
+// "field present" meaning "real failures exist".
+func TestMCPToolsCallStats_RecentFailuresOmittedWhenHealthy(t *testing.T) {
+	tmp := t.TempDir()
+	st := store.NewSQLiteStore(filepath.Join(tmp, "meta.sqlite"))
+	if err := st.Init(context.Background()); err != nil {
+		t.Fatalf("init store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	if err := st.UpsertDocument(context.Background(), model.Document{
+		RelPath: "ok.md", DocType: "md", Status: "ok",
+	}); err != nil {
+		t.Fatalf("upsert ok doc: %v", err)
+	}
+
+	cfg := config.Default()
+	cfg.StateDir = tmp
+	cfg.MCPPath = protocol.DefaultMCPPath
+	cfg.AuthMode = "none"
+
+	server := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st)).Handler())
+	defer server.Close()
+
+	sc := callStatsTool(t, server.URL+cfg.MCPPath)
+	if _, present := sc["recent_failures"]; present {
+		t.Errorf("recent_failures should be omitted on healthy corpus, got %#v", sc["recent_failures"])
+	}
+}
+
+// seedRecentFailureFixture upserts a deterministic mix of failed docs
+// (different mtimes) so we can assert ordering downstream.
+func seedRecentFailureFixture(t *testing.T, st *store.SQLiteStore) {
+	t.Helper()
+	rows := []model.Document{
+		{RelPath: "older.pdf", DocType: "pdf", MTimeUnix: 100, Status: "error", ErrorMessage: "docling failed: bad PDF"},
+		{RelPath: "newer.pdf", DocType: "pdf", MTimeUnix: 200, Status: "error", ErrorMessage: "rep failure: oom"},
+	}
+	for _, d := range rows {
+		if err := st.UpsertDocument(context.Background(), d); err != nil {
+			t.Fatalf("seed UpsertDocument(%s): %v", d.RelPath, err)
+		}
+	}
+}
+
+func assertRecentFailuresFixtureOrder(t *testing.T, failuresRaw []interface{}) {
+	t.Helper()
+	if len(failuresRaw) != 2 {
+		t.Fatalf("expected 2 recent_failures, got %d: %#v", len(failuresRaw), failuresRaw)
+	}
+	first, ok := failuresRaw[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("first failure not an object: %#v", failuresRaw[0])
+	}
+	if first["rel_path"] != "newer.pdf" {
+		t.Errorf("newest-first order broken: got rel_path=%v", first["rel_path"])
+	}
+	for _, key := range []string{"rel_path", "doc_type", "mtime_unix", "error_message"} {
+		if _, present := first[key]; !present {
+			t.Errorf("missing required key %q in failure item: %#v", key, first)
+		}
+	}
+	if msg, _ := first["error_message"].(string); msg == "" {
+		t.Errorf("error_message empty on seeded failure: %#v", first)
+	}
+}
+
+func callStatsTool(t *testing.T, mcpURL string) map[string]interface{} {
+	t.Helper()
+	sessionID := initializeSession(t, mcpURL)
+	resp := postRPC(t, mcpURL, sessionID,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"dir2mcp_stats","arguments":{}}}`)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("stats tool HTTP %d: %s", resp.StatusCode, body)
+	}
+	var envelope struct {
+		Result struct {
+			IsError           bool                   `json:"isError"`
+			StructuredContent map[string]interface{} `json:"structuredContent"`
+		} `json:"result"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if envelope.Result.IsError {
+		t.Fatal("stats tool returned isError=true")
+	}
+	return envelope.Result.StructuredContent
+}

--- a/tests/mcp/stats_recent_failures_test.go
+++ b/tests/mcp/stats_recent_failures_test.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -26,9 +25,6 @@ import (
 // backend persists raw text. Defense in depth for SPEC §15.6
 // ("error_message MUST NOT contain secrets").
 func TestMCPToolsCallStats_RecentFailuresRedactsCredentialShapes(t *testing.T) {
-	if os.Getenv("RUN_INTEGRATION_TESTS") == "" {
-		t.Skip("set RUN_INTEGRATION_TESTS=1 to run integration tests")
-	}
 	tmp := t.TempDir()
 	st := store.NewSQLiteStore(filepath.Join(tmp, "meta.sqlite"))
 	if err := st.Init(context.Background()); err != nil {
@@ -88,9 +84,6 @@ func TestMCPToolsCallStats_RecentFailuresRedactsCredentialShapes(t *testing.T) {
 // programmatic surface for the per-document failure visibility that the
 // support bundle already exposes via list-files.json.
 func TestMCPToolsCallStats_RecentFailuresPresentWhenSeeded(t *testing.T) {
-	if os.Getenv("RUN_INTEGRATION_TESTS") == "" {
-		t.Skip("set RUN_INTEGRATION_TESTS=1 to run integration tests")
-	}
 	tmp := t.TempDir()
 	st := store.NewSQLiteStore(filepath.Join(tmp, "meta.sqlite"))
 	if err := st.Init(context.Background()); err != nil {
@@ -121,9 +114,6 @@ func TestMCPToolsCallStats_RecentFailuresPresentWhenSeeded(t *testing.T) {
 // not emit an empty recent_failures array, so consumers can rely on
 // "field present" meaning "real failures exist".
 func TestMCPToolsCallStats_RecentFailuresOmittedWhenHealthy(t *testing.T) {
-	if os.Getenv("RUN_INTEGRATION_TESTS") == "" {
-		t.Skip("set RUN_INTEGRATION_TESTS=1 to run integration tests")
-	}
 	tmp := t.TempDir()
 	st := store.NewSQLiteStore(filepath.Join(tmp, "meta.sqlite"))
 	if err := st.Init(context.Background()); err != nil {

--- a/tests/mcp/stats_recent_failures_test.go
+++ b/tests/mcp/stats_recent_failures_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -25,6 +26,9 @@ import (
 // backend persists raw text. Defense in depth for SPEC §15.6
 // ("error_message MUST NOT contain secrets").
 func TestMCPToolsCallStats_RecentFailuresRedactsCredentialShapes(t *testing.T) {
+	if os.Getenv("RUN_INTEGRATION_TESTS") == "" {
+		t.Skip("set RUN_INTEGRATION_TESTS=1 to run integration tests")
+	}
 	tmp := t.TempDir()
 	st := store.NewSQLiteStore(filepath.Join(tmp, "meta.sqlite"))
 	if err := st.Init(context.Background()); err != nil {
@@ -84,6 +88,9 @@ func TestMCPToolsCallStats_RecentFailuresRedactsCredentialShapes(t *testing.T) {
 // programmatic surface for the per-document failure visibility that the
 // support bundle already exposes via list-files.json.
 func TestMCPToolsCallStats_RecentFailuresPresentWhenSeeded(t *testing.T) {
+	if os.Getenv("RUN_INTEGRATION_TESTS") == "" {
+		t.Skip("set RUN_INTEGRATION_TESTS=1 to run integration tests")
+	}
 	tmp := t.TempDir()
 	st := store.NewSQLiteStore(filepath.Join(tmp, "meta.sqlite"))
 	if err := st.Init(context.Background()); err != nil {
@@ -114,6 +121,9 @@ func TestMCPToolsCallStats_RecentFailuresPresentWhenSeeded(t *testing.T) {
 // not emit an empty recent_failures array, so consumers can rely on
 // "field present" meaning "real failures exist".
 func TestMCPToolsCallStats_RecentFailuresOmittedWhenHealthy(t *testing.T) {
+	if os.Getenv("RUN_INTEGRATION_TESTS") == "" {
+		t.Skip("set RUN_INTEGRATION_TESTS=1 to run integration tests")
+	}
 	tmp := t.TempDir()
 	st := store.NewSQLiteStore(filepath.Join(tmp, "meta.sqlite"))
 	if err := st.Init(context.Background()); err != nil {

--- a/tests/mcp/stats_recent_failures_test.go
+++ b/tests/mcp/stats_recent_failures_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/dirstral/dir2mcp/internal/config"
@@ -15,6 +16,66 @@ import (
 	"github.com/dirstral/dir2mcp/internal/protocol"
 	"github.com/dirstral/dir2mcp/internal/store"
 )
+
+// TestMCPToolsCallStats_RecentFailuresRedactsCredentialShapes pins the
+// belt-and-suspenders redaction at the MCP boundary (CodeRabbit
+// follow-up on PR #213). The write-side already applies the operator's
+// configured secret_patterns; this read-side pass catches the cases
+// where the operator has none configured or where a future store
+// backend persists raw text. Defense in depth for SPEC §15.6
+// ("error_message MUST NOT contain secrets").
+func TestMCPToolsCallStats_RecentFailuresRedactsCredentialShapes(t *testing.T) {
+	tmp := t.TempDir()
+	st := store.NewSQLiteStore(filepath.Join(tmp, "meta.sqlite"))
+	if err := st.Init(context.Background()); err != nil {
+		t.Fatalf("init store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	// Bypass the ingest-side redactor by upserting documents whose
+	// error_message carries credential shapes verbatim (simulating
+	// a non-SQLite store backend or an operator with no
+	// secret_patterns configured).
+	leaky := []model.Document{
+		{RelPath: "aws.pdf", DocType: "pdf", MTimeUnix: 100, Status: "error",
+			ErrorMessage: "401 from upstream: AKIAIOSFODNN7EXAMPLE rejected"},
+		{RelPath: "bearer.pdf", DocType: "pdf", MTimeUnix: 200, Status: "error",
+			ErrorMessage: "auth failed: Bearer abcdefghij1234567890ZYXWV mismatch"},
+		{RelPath: "openai.pdf", DocType: "pdf", MTimeUnix: 300, Status: "error",
+			ErrorMessage: "rate limit: key sk-proj-AbCdEfGhIjKlMnOpQr exceeded quota"},
+	}
+	for _, d := range leaky {
+		if err := st.UpsertDocument(context.Background(), d); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+
+	cfg := config.Default()
+	cfg.StateDir = tmp
+	cfg.MCPPath = protocol.DefaultMCPPath
+	cfg.AuthMode = "none"
+
+	server := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st)).Handler())
+	defer server.Close()
+
+	sc := callStatsTool(t, server.URL+cfg.MCPPath)
+	failuresRaw, ok := sc["recent_failures"].([]interface{})
+	if !ok {
+		t.Fatalf("recent_failures missing: %#v", sc)
+	}
+	for _, raw := range failuresRaw {
+		row, _ := raw.(map[string]interface{})
+		msg, _ := row["error_message"].(string)
+		for _, leak := range []string{"AKIAIOSFODNN7EXAMPLE", "abcdefghij1234567890ZYXWV", "sk-proj-AbCdEfGhIjKlMnOpQr"} {
+			if strings.Contains(msg, leak) {
+				t.Errorf("credential leaked through MCP boundary: %q (full=%q)", leak, msg)
+			}
+		}
+		if !strings.Contains(msg, "[REDACTED]") {
+			t.Errorf("expected [REDACTED] sentinel in sanitized message, got %q", msg)
+		}
+	}
+}
 
 // TestMCPToolsCallStats_RecentFailuresPresentWhenSeeded pins SPEC §15.6:
 // when the SQLite store has documents in status='error', the dir2mcp_stats

--- a/tests/store/recent_failures_test.go
+++ b/tests/store/recent_failures_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -14,6 +15,9 @@ import (
 // mtime_unix, deterministic rel_path tiebreak, deleted rows excluded,
 // limit applied. Backs SPEC §15.6.
 func TestSQLiteStore_RecentFailures_OrderAndLimit(t *testing.T) {
+	if os.Getenv("RUN_INTEGRATION_TESTS") == "" {
+		t.Skip("set RUN_INTEGRATION_TESTS=1 to run integration tests")
+	}
 	ctx := context.Background()
 	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
 	defer func() { _ = st.Close() }()
@@ -73,6 +77,9 @@ func TestSQLiteStore_RecentFailures_OrderAndLimit(t *testing.T) {
 // omit when no failures" path: an empty result means the stats tool
 // will not include recent_failures in its output.
 func TestSQLiteStore_RecentFailures_EmptyOnHealthyCorpus(t *testing.T) {
+	if os.Getenv("RUN_INTEGRATION_TESTS") == "" {
+		t.Skip("set RUN_INTEGRATION_TESTS=1 to run integration tests")
+	}
 	ctx := context.Background()
 	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
 	defer func() { _ = st.Close() }()

--- a/tests/store/recent_failures_test.go
+++ b/tests/store/recent_failures_test.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -15,9 +14,6 @@ import (
 // mtime_unix, deterministic rel_path tiebreak, deleted rows excluded,
 // limit applied. Backs SPEC §15.6.
 func TestSQLiteStore_RecentFailures_OrderAndLimit(t *testing.T) {
-	if os.Getenv("RUN_INTEGRATION_TESTS") == "" {
-		t.Skip("set RUN_INTEGRATION_TESTS=1 to run integration tests")
-	}
 	ctx := context.Background()
 	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
 	defer func() { _ = st.Close() }()
@@ -77,9 +73,6 @@ func TestSQLiteStore_RecentFailures_OrderAndLimit(t *testing.T) {
 // omit when no failures" path: an empty result means the stats tool
 // will not include recent_failures in its output.
 func TestSQLiteStore_RecentFailures_EmptyOnHealthyCorpus(t *testing.T) {
-	if os.Getenv("RUN_INTEGRATION_TESTS") == "" {
-		t.Skip("set RUN_INTEGRATION_TESTS=1 to run integration tests")
-	}
 	ctx := context.Background()
 	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
 	defer func() { _ = st.Close() }()

--- a/tests/store/recent_failures_test.go
+++ b/tests/store/recent_failures_test.go
@@ -1,0 +1,92 @@
+package tests
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// TestSQLiteStore_RecentFailures_OrderAndLimit pins the contract the
+// dir2mcp_stats recent_failures field relies on: newest-first by
+// mtime_unix, deterministic rel_path tiebreak, deleted rows excluded,
+// limit applied. Backs SPEC §15.6.
+func TestSQLiteStore_RecentFailures_OrderAndLimit(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	defer func() { _ = st.Close() }()
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	// Mixed status + a deleted error row + tied mtime so we exercise
+	// every clause: status filter, deleted filter, ORDER BY mtime
+	// DESC + rel_path ASC tiebreak, LIMIT.
+	rows := []model.Document{
+		{RelPath: "a-old.pdf", DocType: "pdf", MTimeUnix: 100, Status: "error", ErrorMessage: "old failure"},
+		{RelPath: "b-mid.pdf", DocType: "pdf", MTimeUnix: 200, Status: "error", ErrorMessage: "mid failure"},
+		{RelPath: "c-new-z.pdf", DocType: "pdf", MTimeUnix: 300, Status: "error", ErrorMessage: "newest z"},
+		{RelPath: "c-new-a.pdf", DocType: "pdf", MTimeUnix: 300, Status: "error", ErrorMessage: "newest a"},
+		{RelPath: "ok-doc.md", DocType: "md", MTimeUnix: 999, Status: "ok"},
+		{RelPath: "tombstone.pdf", DocType: "pdf", MTimeUnix: 999, Status: "error", ErrorMessage: "deleted", Deleted: true},
+	}
+	for _, d := range rows {
+		if err := st.UpsertDocument(ctx, d); err != nil {
+			t.Fatalf("UpsertDocument(%s): %v", d.RelPath, err)
+		}
+	}
+
+	got, err := st.RecentFailures(ctx, 10)
+	if err != nil {
+		t.Fatalf("RecentFailures: %v", err)
+	}
+	wantOrder := []string{"c-new-a.pdf", "c-new-z.pdf", "b-mid.pdf", "a-old.pdf"}
+	if len(got) != len(wantOrder) {
+		t.Fatalf("RecentFailures returned %d rows, want %d (got=%+v)", len(got), len(wantOrder), got)
+	}
+	for i, want := range wantOrder {
+		if got[i].RelPath != want {
+			t.Errorf("position %d: got %q, want %q (full=%+v)", i, got[i].RelPath, want, got)
+		}
+	}
+
+	// limit caps the result; default-limit (<=0) maps to 20 per spec.
+	limited, err := st.RecentFailures(ctx, 2)
+	if err != nil {
+		t.Fatalf("RecentFailures(limit=2): %v", err)
+	}
+	if len(limited) != 2 {
+		t.Errorf("limit=2 returned %d rows", len(limited))
+	}
+	defaulted, err := st.RecentFailures(ctx, 0)
+	if err != nil {
+		t.Fatalf("RecentFailures(limit=0): %v", err)
+	}
+	if len(defaulted) != len(wantOrder) {
+		t.Errorf("limit=0 (default 20) returned %d rows, want %d", len(defaulted), len(wantOrder))
+	}
+}
+
+// TestSQLiteStore_RecentFailures_EmptyOnHealthyCorpus pins the "MAY
+// omit when no failures" path: an empty result means the stats tool
+// will not include recent_failures in its output.
+func TestSQLiteStore_RecentFailures_EmptyOnHealthyCorpus(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	defer func() { _ = st.Close() }()
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if err := st.UpsertDocument(ctx, model.Document{RelPath: "ok.md", DocType: "md", Status: "ok"}); err != nil {
+		t.Fatalf("UpsertDocument: %v", err)
+	}
+	got, err := st.RecentFailures(ctx, 10)
+	if err != nil {
+		t.Fatalf("RecentFailures: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("healthy corpus returned %d failures: %+v", len(got), got)
+	}
+}


### PR DESCRIPTION
## Summary

Closes the spec-governance loop opened in PR #212. Bumps the dirstral-spec submodule to `3694c68` (spec **0.8.0**, [dirstral-spec#7](https://github.com/dirstral/dirstral-spec/pull/7)) and wires the optional `recent_failures` array into the `dir2mcp_stats` MCP tool output, surfacing the per-document `documents.error_message` we now persist through the spec-blessed diagnostic surface (not just the support bundle artifact).

## Why

Before #212, `dir2mcp_stats.indexing.errors` told consumers *that* documents failed but never *which* or *why*. #212 persisted `documents.error_message` and exposed it in the support bundle's `list-files.json` (maintainer triage from a tar). This PR completes that loop programmatically: doctor-style dashboards, remote diagnostic checks, and the existing `dir2mcp doctor` JSON output can now read the same per-doc failure detail without scraping a bundle.

## Changes

- **Submodule bump**: `dirstral-spec` `174e525` → `3694c68` (spec 0.7.0 → 0.8.0, includes the merged [PR #7](https://github.com/dirstral/dirstral-spec/pull/7)).
- **`internal/store/sqlite_store.go`** — new `RecentFailures(ctx, limit) ([]model.Document, error)` returning documents with `status='error' AND deleted=0`, ordered `mtime_unix DESC, rel_path ASC` (deterministic tiebreak), `limit<=0` defaults to the spec-recommended 20.
- **`internal/mcp/tools.go`** — `handleStatsTool` calls `loadRecentFailuresForStats`, a type-asserted helper that emits the spec-required item shape `{rel_path, doc_type, mtime_unix, error_message}`. Per spec §15.6: omit the field entirely on empty/healthy corpora so callers can rely on "present" meaning "real failures exist". Type assertion (vs. interface change) keeps mocks unaffected.
- **`tests/store/recent_failures_test.go`** — pins order, tiebreak, deleted-row exclusion, limit semantics, and the healthy-corpus empty case.
- **`tests/mcp/stats_recent_failures_test.go`** — end-to-end MCP tool integration: seeded failures appear with the expected shape (newest first); healthy corpus omits the field.

## Spec governance trail

- Spec PR: dirstral-spec#7 — merged 2026-05-26
- Source-of-truth PR for the per-doc persistence: #212 — merged 2026-05-26

## Test plan

- [x] `go test ./tests/store/... ./tests/mcp/... -run "RecentFailures|StatsRecentFailures|Stats_RecentFailures"` (4/4 pass)
- [x] `make check` (gofmt, vet, golangci-lint, gocyclo, all Go tests, scripts unittests, build)
- [ ] CodeRabbit review + findings addressed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stats output now includes a recent failures list when present, showing recent documents with ingest errors for faster troubleshooting.
  * Error messages in the failures list are sanitized to redact high-confidence credential-like substrings.

* **Tests**
  * Added unit and integration tests covering recent-failures reporting, ordering/limits, omission when healthy, and redaction behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dirstral/dir2mcp/pull/213?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->