### PR TITLE
feat(cli): service command to auto-start daemon at login (launchd)

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,10 +164,17 @@ DIR2MCP_DEMO_TOKEN="$(cat .dir2mcp/secret.token)" \
 | `uninstall <client>` | Remove dir2mcp from a supported MCP client |
 | `doctor <client>` | Run client-integration diagnostics |
 | `print-config <client>` | Print the MCP-server JSON snippet a client expects |
+| `service install\|uninstall\|status` | Auto-start the daemon at login so the corpus survives a reboot (macOS launchd) |
 | `version` | Print version |
 
 Running `dir2mcp` with no arguments prints usage, which you can consult anytime to see available commands.
 `ask`, `search`, `open-file`, and `list-files` are legacy compatibility shims; new client/orchestrator UX belongs in `dirstral-cli`.
+
+### Auto-start at login (macOS)
+
+`dir2mcp up` runs a background daemon, but it does not come back on its own after a reboot. `dir2mcp service install` registers a per-corpus launchd agent that restarts `dir2mcp up --foreground` at every login (and on crash), so the MCP server stays connected across reboots. Use `service status` to inspect it and `service uninstall` to remove it.
+
+The launchd job starts from a clean environment and will **not** inherit a `MISTRAL_API_KEY` you only `export`ed in a shell. Persist the credential first with `dir2mcp config init` (writes `.env.local` in the corpus directory) so the booted daemon can find it; `service install` warns when no persisted credential is present.
 
 ## MCP Tools
 

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -74,6 +74,7 @@ var commands = map[string]struct{}{
 	"doctor":         {},
 	"print-config":   {},
 	"support-bundle": {},
+	"service":        {},
 	"version":        {},
 }
 
@@ -453,8 +454,9 @@ func (a *App) runCommand(ctx context.Context, globalOpts globalOptions, remainin
 }
 
 // runSimpleCommand dispatches the non-up/down commands (status, reindex,
-// config, bridge, install, uninstall, doctor, print-config) plus the legacy
-// shims, returning handled=false when command is none of these.
+// config, bridge, install, uninstall, doctor, print-config, support-bundle,
+// service) plus the legacy shims, returning handled=false when command is
+// none of these.
 func (a *App) runSimpleCommand(ctx context.Context, globalOpts globalOptions, command string, args []string) (int, bool) {
 	if code, handled := a.runLegacyShimCommand(ctx, globalOpts, command, args); handled {
 		return code, true
@@ -479,6 +481,8 @@ func (a *App) runSimpleCommand(ctx context.Context, globalOpts globalOptions, co
 		return a.runPrintConfig(ctx, globalOpts, args), true
 	case "support-bundle":
 		return a.runSupportBundle(ctx, globalOpts, args), true
+	case "service":
+		return a.runService(ctx, globalOpts, args), true
 	default:
 		return 0, false
 	}
@@ -531,6 +535,7 @@ func (a *App) printUsage() {
 		{"doctor", "run client integration diagnostics (e.g. dir2mcp doctor claude)"},
 		{"print-config", "print the MCP-server JSON snippet for a client"},
 		{"support-bundle", "collect logs + config + status into a shareable tar.gz"},
+		{"service", "auto-start the daemon at login (macOS launchd): install|uninstall|status"},
 		{"version", "print build version"},
 	}
 	for _, c := range cmds {

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -594,10 +594,11 @@ func saveEnvLocalKey(path, keyName, value string) error {
 		}
 	}
 	prefix := keyName + "="
+	exportPrefix := "export " + keyName + "="
 	lines := strings.Split(string(existing), "\n")
 	out := make([]string, 0, len(lines))
 	for _, line := range lines {
-		if !strings.HasPrefix(line, prefix) {
+		if !strings.HasPrefix(line, prefix) && !strings.HasPrefix(line, exportPrefix) {
 			out = append(out, line)
 		}
 	}

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -1,0 +1,369 @@
+package cli
+
+import (
+	"bufio"
+	"context"
+	"encoding/xml"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// serviceSpec is the platform-agnostic description of the supervised
+// daemon a `dir2mcp service install` writes. The OS backend turns it
+// into a launchd plist (macOS) or, in a follow-up, a systemd user unit.
+type serviceSpec struct {
+	Label      string
+	BinaryPath string
+	WorkingDir string
+	Args       []string
+	LogPath    string
+}
+
+// serviceState is the backend's view of an installed service.
+type serviceState struct {
+	Installed bool
+	Running   bool
+	Detail    string
+	UnitPath  string
+}
+
+// serviceManager abstracts the OS service backend (launchd today). The
+// concrete implementation is selected at build time via newServiceManager
+// in the per-GOOS file.
+type serviceManager interface {
+	backendName() string
+	install(spec serviceSpec) (unitPath string, err error)
+	uninstall(label string) (unitPath string, removed bool, err error)
+	status(label string) (serviceState, error)
+}
+
+// serviceCredentialEnvKeys are the provider credential variables a
+// persisted .env.local can carry. The launchd/systemd job does NOT
+// inherit credentials exported in an interactive shell, so the install
+// preflight checks these against the corpus dotenv to warn operators
+// before the daemon fails at boot with "no embedding provider configured".
+var serviceCredentialEnvKeys = []string{
+	"MISTRAL_API_KEY",
+	"OPENAI_API_KEY",
+	"OPENROUTER_API_KEY",
+	"ANTHROPIC_API_KEY",
+	"GEMINI_API_KEY",
+	"COHERE_API_KEY",
+	"ELEVENLABS_API_KEY",
+}
+
+// serviceContext bundles the resolved per-corpus values both install and
+// uninstall need: the supervisor label, the corpus working directory
+// (also where .env.local must live so the booted daemon resolves
+// credentials), the state dir, and the dir2mcp binary path.
+type serviceContext struct {
+	label      string
+	serverName string
+	workingDir string
+	stateDir   string
+	binaryPath string
+	logPath    string
+}
+
+func (a *App) runService(_ context.Context, global globalOptions, args []string) int {
+	if len(args) == 0 {
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid,
+			"service requires a subcommand: install, uninstall, or status")
+		return exitConfigInvalid
+	}
+	sub, rest := args[0], args[1:]
+	switch sub {
+	case "install":
+		return a.runServiceInstall(global, rest)
+	case "uninstall":
+		return a.runServiceUninstall(global, rest)
+	case "status":
+		return a.runServiceStatus(global, rest)
+	default:
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid,
+			fmt.Sprintf("unknown service subcommand: %s", sub),
+			"Use one of: install, uninstall, status")
+		return exitConfigInvalid
+	}
+}
+
+// serviceLabel derives a launchd/systemd-friendly reverse-DNS label from
+// the auto-derived (or overridden) server name, which already encodes the
+// corpus slug + path hash and so is stable and unique per directory.
+func serviceLabel(serverName string) string {
+	return "com.dirstral." + strings.TrimSpace(serverName)
+}
+
+func (a *App) resolveServiceContext(global globalOptions, nameOverride string) (serviceContext, error) {
+	cfg, err := loadConfigWithGlobalOptions(global)
+	if err != nil {
+		return serviceContext{}, fmt.Errorf("load config: %w", err)
+	}
+	name := resolveClaudeServerName(&cfg, nameOverride)
+	abs, err := filepath.Abs(cfg.RootDir)
+	if err != nil {
+		abs = cfg.RootDir
+	}
+	stateDir := strings.TrimSpace(cfg.StateDir)
+	if stateDir == "" {
+		stateDir = filepath.Join(abs, ".dir2mcp")
+	}
+	bin, err := os.Executable()
+	if err != nil {
+		return serviceContext{}, fmt.Errorf("locate dir2mcp executable: %w", err)
+	}
+	return serviceContext{
+		label:      serviceLabel(name),
+		serverName: name,
+		workingDir: abs,
+		stateDir:   stateDir,
+		binaryPath: bin,
+		logPath:    filepath.Join(stateDir, "service.log"),
+	}, nil
+}
+
+func (a *App) runServiceInstall(global globalOptions, args []string) int {
+	name, code := a.parseServiceFlags("service install", global, args)
+	if code != exitSuccess {
+		return code
+	}
+	sc, mgr, code := a.serviceContextAndManager(global, name)
+	if code != exitSuccess {
+		return code
+	}
+	if err := os.MkdirAll(sc.stateDir, 0o755); err != nil {
+		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("create state dir %s: %v", sc.stateDir, err))
+		return exitGeneric
+	}
+	a.warnIfNoPersistentCredential(sc.workingDir)
+
+	unitPath, err := mgr.install(serviceSpec{
+		Label:      sc.label,
+		BinaryPath: sc.binaryPath,
+		WorkingDir: sc.workingDir,
+		Args:       []string{"up", "--foreground"},
+		LogPath:    sc.logPath,
+	})
+	if err != nil {
+		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("install service: %v", err))
+		return exitGeneric
+	}
+
+	if global.jsonOutput {
+		return a.emitServiceJSON(map[string]interface{}{
+			"action": "install", "label": sc.label, "backend": mgr.backendName(),
+			"unit_path": unitPath, "working_dir": sc.workingDir, "binary": sc.binaryPath,
+		})
+	}
+	writef(a.stdout, "installed %s service %q\n", mgr.backendName(), sc.label)
+	writef(a.stdout, "  unit:    %s\n", unitPath)
+	writef(a.stdout, "  workdir: %s\n", sc.workingDir)
+	writeln(a.stdout, "the daemon will start now and again at every login")
+	return exitSuccess
+}
+
+func (a *App) runServiceUninstall(global globalOptions, args []string) int {
+	name, code := a.parseServiceFlags("service uninstall", global, args)
+	if code != exitSuccess {
+		return code
+	}
+	sc, mgr, code := a.serviceContextAndManager(global, name)
+	if code != exitSuccess {
+		return code
+	}
+	unitPath, removed, err := mgr.uninstall(sc.label)
+	if err != nil {
+		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("uninstall service: %v", err))
+		return exitGeneric
+	}
+	if global.jsonOutput {
+		return a.emitServiceJSON(map[string]interface{}{
+			"action": "uninstall", "label": sc.label, "backend": mgr.backendName(),
+			"unit_path": unitPath, "removed": removed,
+		})
+	}
+	if removed {
+		writef(a.stdout, "removed %s service %q (%s)\n", mgr.backendName(), sc.label, unitPath)
+	} else {
+		writef(a.stdout, "no %s service %q was installed\n", mgr.backendName(), sc.label)
+	}
+	return exitSuccess
+}
+
+func (a *App) runServiceStatus(global globalOptions, args []string) int {
+	name, code := a.parseServiceFlags("service status", global, args)
+	if code != exitSuccess {
+		return code
+	}
+	sc, mgr, code := a.serviceContextAndManager(global, name)
+	if code != exitSuccess {
+		return code
+	}
+	state, err := mgr.status(sc.label)
+	if err != nil {
+		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("service status: %v", err))
+		return exitGeneric
+	}
+	if global.jsonOutput {
+		return a.emitServiceJSON(map[string]interface{}{
+			"action": "status", "label": sc.label, "backend": mgr.backendName(),
+			"installed": state.Installed, "running": state.Running,
+			"detail": state.Detail, "unit_path": state.UnitPath,
+		})
+	}
+	writef(a.stdout, "%s service %q\n", mgr.backendName(), sc.label)
+	writef(a.stdout, "  installed: %t\n", state.Installed)
+	writef(a.stdout, "  running:   %t\n", state.Running)
+	if strings.TrimSpace(state.Detail) != "" {
+		writef(a.stdout, "  detail:    %s\n", state.Detail)
+	}
+	return exitSuccess
+}
+
+// parseServiceFlags parses the shared --name flag for a service
+// subcommand and rejects positional arguments.
+func (a *App) parseServiceFlags(usage string, global globalOptions, args []string) (string, int) {
+	fs := flag.NewFlagSet(usage, flag.ContinueOnError)
+	fs.SetOutput(ioDiscard{})
+	name := fs.String("name", "", "service name override (defaults to the auto-derived server name)")
+	if err := fs.Parse(args); err != nil {
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("invalid %s flags: %v", usage, err))
+		return "", exitConfigInvalid
+	}
+	if len(fs.Args()) > 0 {
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid,
+			fmt.Sprintf("%s does not accept positional arguments: %s", usage, strings.Join(fs.Args(), " ")))
+		return "", exitConfigInvalid
+	}
+	return *name, exitSuccess
+}
+
+// serviceContextAndManager resolves the per-corpus context and the OS
+// backend, mapping their errors to the right exit codes.
+func (a *App) serviceContextAndManager(global globalOptions, name string) (serviceContext, serviceManager, int) {
+	sc, err := a.resolveServiceContext(global, name)
+	if err != nil {
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, err.Error())
+		return serviceContext{}, nil, exitConfigInvalid
+	}
+	mgr, err := newServiceManager()
+	if err != nil {
+		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, err.Error())
+		return serviceContext{}, nil, exitGeneric
+	}
+	return sc, mgr, exitSuccess
+}
+
+func (a *App) emitServiceJSON(payload map[string]interface{}) int {
+	if err := emitJSON(a.stdout, payload); err != nil {
+		writeCLIError(a.stderr, true, exitGeneric, fmt.Sprintf("encode service json: %v", err))
+		return exitGeneric
+	}
+	return exitSuccess
+}
+
+// warnIfNoPersistentCredential surfaces the launchd/systemd credential
+// trap: the supervised job starts from a clean environment, so a key that
+// only lives as a shell `export` will be gone at boot. We warn (rather
+// than block) so operators who configure credentials another way — e.g. a
+// literal providers: api_key in .dir2mcp.yaml — are not stopped.
+func (a *App) warnIfNoPersistentCredential(workingDir string) {
+	if persistentCredentialInDotenv(workingDir) {
+		return
+	}
+	writef(a.stderr, "warning: no persisted provider credential found in %s\n", filepath.Join(workingDir, ".env.local"))
+	writeln(a.stderr, "  The service starts from a clean environment and will NOT inherit credentials exported in your shell.")
+	writeln(a.stderr, "  Run `dir2mcp config init` to persist MISTRAL_API_KEY to .env.local (or add a providers: block to .dir2mcp.yaml),")
+	writeln(a.stderr, "  otherwise the daemon will fail at boot with \"no embedding provider configured\".")
+}
+
+// persistentCredentialInDotenv reports whether the corpus dir holds a
+// dotenv file (.env.local preferred, then .env) that defines a non-empty
+// provider credential the booted daemon could read.
+func persistentCredentialInDotenv(dir string) bool {
+	for _, name := range []string{".env.local", ".env"} {
+		if dotenvHasCredential(filepath.Join(dir, name)) {
+			return true
+		}
+	}
+	return false
+}
+
+func dotenvHasCredential(path string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		line = strings.TrimPrefix(line, "export ")
+		key, value, ok := strings.Cut(line, "=")
+		if !ok || !isServiceCredentialKey(strings.TrimSpace(key)) {
+			continue
+		}
+		if strings.Trim(strings.TrimSpace(value), `"'`) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func isServiceCredentialKey(key string) bool {
+	for _, k := range serviceCredentialEnvKeys {
+		if key == k {
+			return true
+		}
+	}
+	return false
+}
+
+// renderLaunchdPlist builds a macOS LaunchAgent property list for spec.
+// It lives in the shared (untagged) file so its output is unit-tested on
+// every platform; only the launchctl invocation is darwin-gated. Every
+// string value is XML-escaped so corpus paths containing & or < cannot
+// corrupt the plist.
+func renderLaunchdPlist(spec serviceSpec) string {
+	program := append([]string{spec.BinaryPath}, spec.Args...)
+
+	var b strings.Builder
+	b.WriteString(xml.Header)
+	b.WriteString("<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n")
+	b.WriteString("<plist version=\"1.0\">\n<dict>\n")
+	writePlistString(&b, "Label", spec.Label)
+	b.WriteString("  <key>ProgramArguments</key>\n  <array>\n")
+	for _, arg := range program {
+		b.WriteString("    <string>")
+		xmlEscape(&b, arg)
+		b.WriteString("</string>\n")
+	}
+	b.WriteString("  </array>\n")
+	writePlistString(&b, "WorkingDirectory", spec.WorkingDir)
+	writePlistString(&b, "StandardOutPath", spec.LogPath)
+	writePlistString(&b, "StandardErrorPath", spec.LogPath)
+	b.WriteString("  <key>RunAtLoad</key>\n  <true/>\n")
+	b.WriteString("  <key>KeepAlive</key>\n  <true/>\n")
+	writePlistString(&b, "ProcessType", "Background")
+	b.WriteString("</dict>\n</plist>\n")
+	return b.String()
+}
+
+func writePlistString(b *strings.Builder, key, value string) {
+	b.WriteString("  <key>")
+	xmlEscape(b, key)
+	b.WriteString("</key>\n  <string>")
+	xmlEscape(b, value)
+	b.WriteString("</string>\n")
+}
+
+func xmlEscape(b *strings.Builder, s string) {
+	_ = xml.EscapeText(b, []byte(s))
+}

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -68,6 +68,7 @@ type serviceContext struct {
 	logPath    string
 }
 
+// runService dispatches `dir2mcp service <subcommand>`.
 func (a *App) runService(_ context.Context, global globalOptions, args []string) int {
 	if len(args) == 0 {
 		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid,
@@ -97,7 +98,28 @@ func serviceLabel(serverName string) string {
 	return "com.dirstral." + strings.TrimSpace(serverName)
 }
 
+// validateServiceName rejects name overrides that could cause path
+// traversal when the label is used as a filename under ~/Library/LaunchAgents.
+// Auto-derived names (identity.AutoServerName) are already safe; this
+// guard covers explicit --name overrides that bypass that derivation.
+func validateServiceName(name string) error {
+	if strings.ContainsAny(name, `/\`) {
+		return fmt.Errorf("service name %q must not contain path separators (/ or \\)", name)
+	}
+	if filepath.IsAbs(name) {
+		return fmt.Errorf("service name %q must not be an absolute path", name)
+	}
+	return nil
+}
+
+// resolveServiceContext loads config, derives the per-corpus label /
+// binary / paths, and validates any explicit name override for path safety.
 func (a *App) resolveServiceContext(global globalOptions, nameOverride string) (serviceContext, error) {
+	if t := strings.TrimSpace(nameOverride); t != "" {
+		if err := validateServiceName(t); err != nil {
+			return serviceContext{}, err
+		}
+	}
 	cfg, err := loadConfigWithGlobalOptions(global)
 	if err != nil {
 		return serviceContext{}, fmt.Errorf("load config: %w", err)
@@ -125,6 +147,7 @@ func (a *App) resolveServiceContext(global globalOptions, nameOverride string) (
 	}, nil
 }
 
+// runServiceInstall handles `dir2mcp service install`.
 func (a *App) runServiceInstall(global globalOptions, args []string) int {
 	name, code := a.parseServiceFlags("service install", global, args)
 	if code != exitSuccess {
@@ -134,17 +157,28 @@ func (a *App) runServiceInstall(global globalOptions, args []string) int {
 	if code != exitSuccess {
 		return code
 	}
-	if err := os.MkdirAll(sc.stateDir, 0o755); err != nil {
+	if err := os.MkdirAll(sc.stateDir, 0o700); err != nil {
 		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("create state dir %s: %v", sc.stateDir, err))
 		return exitGeneric
 	}
 	a.warnIfNoPersistentCredential(sc.workingDir)
 
+	// Propagate global flag overrides so the installed service restarts
+	// with the exact same config/state-dir the operator used for install,
+	// rather than re-discovering defaults from the working directory alone.
+	serviceArgs := []string{"up", "--foreground"}
+	if p := strings.TrimSpace(global.configPath); p != "" {
+		serviceArgs = append(serviceArgs, "--config", p)
+	}
+	if p := strings.TrimSpace(global.stateDir); p != "" {
+		serviceArgs = append(serviceArgs, "--state-dir", p)
+	}
+
 	unitPath, err := mgr.install(serviceSpec{
 		Label:      sc.label,
 		BinaryPath: sc.binaryPath,
 		WorkingDir: sc.workingDir,
-		Args:       []string{"up", "--foreground"},
+		Args:       serviceArgs,
 		LogPath:    sc.logPath,
 	})
 	if err != nil {
@@ -165,6 +199,7 @@ func (a *App) runServiceInstall(global globalOptions, args []string) int {
 	return exitSuccess
 }
 
+// runServiceUninstall handles `dir2mcp service uninstall`.
 func (a *App) runServiceUninstall(global globalOptions, args []string) int {
 	name, code := a.parseServiceFlags("service uninstall", global, args)
 	if code != exitSuccess {
@@ -193,6 +228,7 @@ func (a *App) runServiceUninstall(global globalOptions, args []string) int {
 	return exitSuccess
 }
 
+// runServiceStatus handles `dir2mcp service status`.
 func (a *App) runServiceStatus(global globalOptions, args []string) int {
 	name, code := a.parseServiceFlags("service status", global, args)
 	if code != exitSuccess {
@@ -257,6 +293,8 @@ func (a *App) serviceContextAndManager(global globalOptions, name string) (servi
 	return sc, mgr, exitSuccess
 }
 
+// emitServiceJSON marshals payload as JSON to stdout, returning the
+// appropriate exit code.
 func (a *App) emitServiceJSON(payload map[string]interface{}) int {
 	if err := emitJSON(a.stdout, payload); err != nil {
 		writeCLIError(a.stderr, true, exitGeneric, fmt.Sprintf("encode service json: %v", err))
@@ -292,6 +330,10 @@ func persistentCredentialInDotenv(dir string) bool {
 	return false
 }
 
+// dotenvHasCredential scans a single dotenv file and returns true if it
+// contains at least one non-empty provider credential. Returns false on
+// any I/O or scan error (conservative: assume no credential rather than
+// masking the read failure as a credential hit).
 func dotenvHasCredential(path string) bool {
 	f, err := os.Open(path)
 	if err != nil {
@@ -314,9 +356,14 @@ func dotenvHasCredential(path string) bool {
 			return true
 		}
 	}
+	// A scan error means we couldn't read the full file. Treat as no
+	// credential found (conservative) — if the warning fires the operator
+	// can explicitly confirm credentials are configured another way.
 	return false
 }
 
+// isServiceCredentialKey reports whether key names a known provider
+// credential variable that .env.local can supply to the booted daemon.
 func isServiceCredentialKey(key string) bool {
 	for _, k := range serviceCredentialEnvKeys {
 		if key == k {
@@ -356,6 +403,8 @@ func renderLaunchdPlist(spec serviceSpec) string {
 	return b.String()
 }
 
+// writePlistString writes a <key>/<string> pair into a plist builder,
+// XML-escaping both the key and value.
 func writePlistString(b *strings.Builder, key, value string) {
 	b.WriteString("  <key>")
 	xmlEscape(b, key)
@@ -364,6 +413,8 @@ func writePlistString(b *strings.Builder, key, value string) {
 	b.WriteString("</string>\n")
 }
 
+// xmlEscape writes s XML-escaped into b, so special characters in corpus
+// paths (& < >) cannot corrupt the plist document.
 func xmlEscape(b *strings.Builder, s string) {
 	_ = xml.EscapeText(b, []byte(s))
 }

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/dirstral/dir2mcp/internal/config"
 )
 
 // serviceSpec is the platform-agnostic description of the supervised
@@ -114,15 +116,17 @@ func validateServiceName(name string) error {
 
 // resolveServiceContext loads config, derives the per-corpus label /
 // binary / paths, and validates any explicit name override for path safety.
-func (a *App) resolveServiceContext(global globalOptions, nameOverride string) (serviceContext, error) {
+// It returns the loaded config alongside the context so callers can
+// extract provider env-var refs for credential auto-persist.
+func (a *App) resolveServiceContext(global globalOptions, nameOverride string) (serviceContext, config.Config, error) {
 	if t := strings.TrimSpace(nameOverride); t != "" {
 		if err := validateServiceName(t); err != nil {
-			return serviceContext{}, err
+			return serviceContext{}, config.Config{}, err
 		}
 	}
 	cfg, err := loadConfigWithGlobalOptions(global)
 	if err != nil {
-		return serviceContext{}, fmt.Errorf("load config: %w", err)
+		return serviceContext{}, config.Config{}, fmt.Errorf("load config: %w", err)
 	}
 	name := resolveClaudeServerName(&cfg, nameOverride)
 	abs, err := filepath.Abs(cfg.RootDir)
@@ -135,7 +139,7 @@ func (a *App) resolveServiceContext(global globalOptions, nameOverride string) (
 	}
 	bin, err := os.Executable()
 	if err != nil {
-		return serviceContext{}, fmt.Errorf("locate dir2mcp executable: %w", err)
+		return serviceContext{}, config.Config{}, fmt.Errorf("locate dir2mcp executable: %w", err)
 	}
 	return serviceContext{
 		label:      serviceLabel(name),
@@ -144,7 +148,7 @@ func (a *App) resolveServiceContext(global globalOptions, nameOverride string) (
 		stateDir:   stateDir,
 		binaryPath: bin,
 		logPath:    filepath.Join(stateDir, "service.log"),
-	}, nil
+	}, cfg, nil
 }
 
 // runServiceInstall handles `dir2mcp service install`.
@@ -153,7 +157,7 @@ func (a *App) runServiceInstall(global globalOptions, args []string) int {
 	if code != exitSuccess {
 		return code
 	}
-	sc, mgr, code := a.serviceContextAndManager(global, name)
+	sc, cfg, mgr, code := a.serviceContextAndManager(global, name)
 	if code != exitSuccess {
 		return code
 	}
@@ -161,7 +165,7 @@ func (a *App) runServiceInstall(global globalOptions, args []string) int {
 		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("create state dir %s: %v", sc.stateDir, err))
 		return exitGeneric
 	}
-	a.persistAndWarnCredentials(sc.workingDir)
+	a.persistAndWarnCredentials(sc.workingDir, cfg)
 
 	// Propagate global flag overrides so the installed service restarts
 	// with the exact same config/state-dir the operator used for install,
@@ -205,7 +209,7 @@ func (a *App) runServiceUninstall(global globalOptions, args []string) int {
 	if code != exitSuccess {
 		return code
 	}
-	sc, mgr, code := a.serviceContextAndManager(global, name)
+	sc, _, mgr, code := a.serviceContextAndManager(global, name)
 	if code != exitSuccess {
 		return code
 	}
@@ -234,7 +238,7 @@ func (a *App) runServiceStatus(global globalOptions, args []string) int {
 	if code != exitSuccess {
 		return code
 	}
-	sc, mgr, code := a.serviceContextAndManager(global, name)
+	sc, _, mgr, code := a.serviceContextAndManager(global, name)
 	if code != exitSuccess {
 		return code
 	}
@@ -278,19 +282,20 @@ func (a *App) parseServiceFlags(usage string, global globalOptions, args []strin
 }
 
 // serviceContextAndManager resolves the per-corpus context and the OS
-// backend, mapping their errors to the right exit codes.
-func (a *App) serviceContextAndManager(global globalOptions, name string) (serviceContext, serviceManager, int) {
-	sc, err := a.resolveServiceContext(global, name)
+// backend, mapping their errors to the right exit codes. The loaded
+// config is also returned so callers can access provider env-var refs.
+func (a *App) serviceContextAndManager(global globalOptions, name string) (serviceContext, config.Config, serviceManager, int) {
+	sc, cfg, err := a.resolveServiceContext(global, name)
 	if err != nil {
 		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, err.Error())
-		return serviceContext{}, nil, exitConfigInvalid
+		return serviceContext{}, config.Config{}, nil, exitConfigInvalid
 	}
 	mgr, err := newServiceManager()
 	if err != nil {
 		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, err.Error())
-		return serviceContext{}, nil, exitGeneric
+		return serviceContext{}, config.Config{}, nil, exitGeneric
 	}
-	return sc, mgr, exitSuccess
+	return sc, cfg, mgr, exitSuccess
 }
 
 // emitServiceJSON marshals payload as JSON to stdout, returning the
@@ -309,11 +314,15 @@ func (a *App) emitServiceJSON(payload map[string]interface{}) int {
 // .env.local in the corpus working directory, so the launchd service can
 // read them after a reboot — launchd does not inherit shell exports.
 //
+// The set of keys to check is derived from cfg.ProviderEnvVarRefs() so
+// custom providers defined via providers: in .dir2mcp.yaml with ${MY_KEY}
+// placeholders are covered in addition to the built-in providers.
+//
 // If no credentials are found in the environment AND none are already
 // persisted in .env.local / .env, a warning is printed instead.
-func (a *App) persistAndWarnCredentials(workingDir string) {
+func (a *App) persistAndWarnCredentials(workingDir string, cfg config.Config) {
 	envPath := filepath.Join(workingDir, ".env.local")
-	saved := persistCredentialsFromEnv(envPath)
+	saved := persistCredentialsFromEnv(envPath, cfg.ProviderEnvVarRefs())
 	if len(saved) > 0 {
 		for _, key := range saved {
 			writef(a.stdout, "  saved %s to %s (will survive reboots)\n", key, envPath)
@@ -327,17 +336,16 @@ func (a *App) persistAndWarnCredentials(workingDir string) {
 	}
 	writef(a.stderr, "warning: no persisted provider credential found in %s\n", envPath)
 	writeln(a.stderr, "  The service starts from a clean environment and will NOT inherit credentials exported in your shell.")
-	writeln(a.stderr, "  Run `dir2mcp config init` to persist MISTRAL_API_KEY to .env.local (or add a providers: block to .dir2mcp.yaml),")
+	writeln(a.stderr, "  Run `dir2mcp config init` to persist the credential to .env.local (or add a providers: block to .dir2mcp.yaml),")
 	writeln(a.stderr, "  otherwise the daemon will fail at boot with \"no embedding provider configured\".")
 }
 
-// persistCredentialsFromEnv writes each serviceCredentialEnvKeys key
-// found non-empty in os.Getenv into the dotenv file at envPath, using the
-// same upsert semantics as `dir2mcp config init`. Returns the list of
-// keys that were saved.
-func persistCredentialsFromEnv(envPath string) []string {
+// persistCredentialsFromEnv writes each key in envVarRefs that is found
+// non-empty in os.Getenv into the dotenv file at envPath, using the same
+// upsert semantics as `dir2mcp config init`. Returns the list of keys saved.
+func persistCredentialsFromEnv(envPath string, envVarRefs []string) []string {
 	var saved []string
-	for _, key := range serviceCredentialEnvKeys {
+	for _, key := range envVarRefs {
 		val := strings.TrimSpace(os.Getenv(key))
 		if val == "" {
 			continue

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -161,7 +161,7 @@ func (a *App) runServiceInstall(global globalOptions, args []string) int {
 		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("create state dir %s: %v", sc.stateDir, err))
 		return exitGeneric
 	}
-	a.warnIfNoPersistentCredential(sc.workingDir)
+	a.persistAndWarnCredentials(sc.workingDir)
 
 	// Propagate global flag overrides so the installed service restarts
 	// with the exact same config/state-dir the operator used for install,
@@ -303,19 +303,51 @@ func (a *App) emitServiceJSON(payload map[string]interface{}) int {
 	return exitSuccess
 }
 
-// warnIfNoPersistentCredential surfaces the launchd/systemd credential
-// trap: the supervised job starts from a clean environment, so a key that
-// only lives as a shell `export` will be gone at boot. We warn (rather
-// than block) so operators who configure credentials another way — e.g. a
-// literal providers: api_key in .dir2mcp.yaml — are not stopped.
-func (a *App) warnIfNoPersistentCredential(workingDir string) {
+// persistAndWarnCredentials is called during `service install`. It looks
+// for provider credentials in the current process environment (from the
+// operator's `export KEY=...` session) and persists any it finds to
+// .env.local in the corpus working directory, so the launchd service can
+// read them after a reboot — launchd does not inherit shell exports.
+//
+// If no credentials are found in the environment AND none are already
+// persisted in .env.local / .env, a warning is printed instead.
+func (a *App) persistAndWarnCredentials(workingDir string) {
+	envPath := filepath.Join(workingDir, ".env.local")
+	saved := persistCredentialsFromEnv(envPath)
+	if len(saved) > 0 {
+		for _, key := range saved {
+			writef(a.stdout, "  saved %s to %s (will survive reboots)\n", key, envPath)
+		}
+		return
+	}
+	// Nothing in the current environment to auto-save. Fall back to the
+	// warning if there's also nothing already persisted in a dotenv file.
 	if persistentCredentialInDotenv(workingDir) {
 		return
 	}
-	writef(a.stderr, "warning: no persisted provider credential found in %s\n", filepath.Join(workingDir, ".env.local"))
+	writef(a.stderr, "warning: no persisted provider credential found in %s\n", envPath)
 	writeln(a.stderr, "  The service starts from a clean environment and will NOT inherit credentials exported in your shell.")
 	writeln(a.stderr, "  Run `dir2mcp config init` to persist MISTRAL_API_KEY to .env.local (or add a providers: block to .dir2mcp.yaml),")
 	writeln(a.stderr, "  otherwise the daemon will fail at boot with \"no embedding provider configured\".")
+}
+
+// persistCredentialsFromEnv writes each serviceCredentialEnvKeys key
+// found non-empty in os.Getenv into the dotenv file at envPath, using the
+// same upsert semantics as `dir2mcp config init`. Returns the list of
+// keys that were saved.
+func persistCredentialsFromEnv(envPath string) []string {
+	var saved []string
+	for _, key := range serviceCredentialEnvKeys {
+		val := strings.TrimSpace(os.Getenv(key))
+		if val == "" {
+			continue
+		}
+		if err := saveEnvLocalKey(envPath, key, val); err != nil {
+			continue
+		}
+		saved = append(saved, key)
+	}
+	return saved
 }
 
 // persistentCredentialInDotenv reports whether the corpus dir holds a

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/dirstral/dir2mcp/internal/config"
@@ -40,21 +41,6 @@ type serviceManager interface {
 	install(spec serviceSpec) (unitPath string, err error)
 	uninstall(label string) (unitPath string, removed bool, err error)
 	status(label string) (serviceState, error)
-}
-
-// serviceCredentialEnvKeys are the provider credential variables a
-// persisted .env.local can carry. The launchd/systemd job does NOT
-// inherit credentials exported in an interactive shell, so the install
-// preflight checks these against the corpus dotenv to warn operators
-// before the daemon fails at boot with "no embedding provider configured".
-var serviceCredentialEnvKeys = []string{
-	"MISTRAL_API_KEY",
-	"OPENAI_API_KEY",
-	"OPENROUTER_API_KEY",
-	"ANTHROPIC_API_KEY",
-	"GEMINI_API_KEY",
-	"COHERE_API_KEY",
-	"ELEVENLABS_API_KEY",
 }
 
 // serviceContext bundles the resolved per-corpus values both install and
@@ -100,16 +86,20 @@ func serviceLabel(serverName string) string {
 	return "com.dirstral." + strings.TrimSpace(serverName)
 }
 
-// validateServiceName rejects name overrides that could cause path
-// traversal when the label is used as a filename under ~/Library/LaunchAgents.
-// Auto-derived names (identity.AutoServerName) are already safe; this
-// guard covers explicit --name overrides that bypass that derivation.
+// validateServiceName rejects name overrides that could produce an invalid
+// launchd label or a dangerous plist filename. Auto-derived names are already
+// safe; this guard covers explicit --name overrides that bypass that derivation.
+// Allowed characters: A-Za-z0-9 plus dot, underscore, and hyphen — the same
+// set permitted in reverse-DNS launchd labels.
 func validateServiceName(name string) error {
-	if strings.ContainsAny(name, `/\`) {
-		return fmt.Errorf("service name %q must not contain path separators (/ or \\)", name)
+	if strings.TrimSpace(name) == "" {
+		return fmt.Errorf("service name must not be empty or whitespace-only")
 	}
-	if filepath.IsAbs(name) {
-		return fmt.Errorf("service name %q must not be an absolute path", name)
+	for _, r := range name {
+		ok := (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '.' || r == '_' || r == '-'
+		if !ok {
+			return fmt.Errorf("service name %q contains disallowed character %q (allowed: A-Za-z0-9._-)", name, string(r))
+		}
 	}
 	return nil
 }
@@ -331,7 +321,8 @@ func (a *App) emitServiceJSON(payload map[string]interface{}) int {
 // into failed and reported as warnings in text mode.
 func (a *App) persistAndWarnCredentials(workingDir string, cfg config.Config, jsonOut, quiet bool) (saved, failed []string) {
 	envPath := filepath.Join(workingDir, ".env.local")
-	saved, failed = persistCredentialsFromEnv(envPath, cfg.ProviderEnvVarRefs())
+	refs := cfg.ProviderEnvVarRefs()
+	saved, failed = persistCredentialsFromEnv(envPath, refs)
 
 	if jsonOut || quiet {
 		return
@@ -347,7 +338,7 @@ func (a *App) persistAndWarnCredentials(workingDir string, cfg config.Config, js
 	}
 	// Nothing in the current environment to auto-save. Fall back to the
 	// warning if there's also nothing already persisted in a dotenv file.
-	if persistentCredentialInDotenv(workingDir) {
+	if persistentCredentialInDotenv(workingDir, refs) {
 		return
 	}
 	writef(a.stderr, "warning: no persisted provider credential found in %s\n", envPath)
@@ -384,10 +375,10 @@ func persistCredentialsFromEnv(envPath string, envVarRefs []string) (saved, fail
 
 // persistentCredentialInDotenv reports whether the corpus dir holds a
 // dotenv file (.env.local preferred, then .env) that defines a non-empty
-// provider credential the booted daemon could read.
-func persistentCredentialInDotenv(dir string) bool {
+// value for any of the given credential env var names.
+func persistentCredentialInDotenv(dir string, refs []string) bool {
 	for _, name := range []string{".env.local", ".env"} {
-		if dotenvHasCredential(filepath.Join(dir, name)) {
+		if dotenvHasCredential(filepath.Join(dir, name), refs) {
 			return true
 		}
 	}
@@ -395,10 +386,10 @@ func persistentCredentialInDotenv(dir string) bool {
 }
 
 // dotenvHasCredential scans a single dotenv file and returns true if it
-// contains at least one non-empty provider credential. Returns false on
-// any I/O or scan error (conservative: assume no credential rather than
+// contains at least one non-empty assignment for a key in refs. Returns false
+// on any I/O or scan error (conservative: assume no credential rather than
 // masking the read failure as a credential hit).
-func dotenvHasCredential(path string) bool {
+func dotenvHasCredential(path string, refs []string) bool {
 	f, err := os.Open(path)
 	if err != nil {
 		return false
@@ -413,7 +404,7 @@ func dotenvHasCredential(path string) bool {
 		}
 		line = strings.TrimPrefix(line, "export ")
 		key, value, ok := strings.Cut(line, "=")
-		if !ok || !isServiceCredentialKey(strings.TrimSpace(key)) {
+		if !ok || !slices.Contains(refs, strings.TrimSpace(key)) {
 			continue
 		}
 		if strings.Trim(strings.TrimSpace(value), `"'`) != "" {
@@ -423,17 +414,6 @@ func dotenvHasCredential(path string) bool {
 	// A scan error means we couldn't read the full file. Treat as no
 	// credential found (conservative) — if the warning fires the operator
 	// can explicitly confirm credentials are configured another way.
-	return false
-}
-
-// isServiceCredentialKey reports whether key names a known provider
-// credential variable that .env.local can supply to the booted daemon.
-func isServiceCredentialKey(key string) bool {
-	for _, k := range serviceCredentialEnvKeys {
-		if key == k {
-			return true
-		}
-	}
 	return false
 }
 

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -137,6 +137,9 @@ func (a *App) resolveServiceContext(global globalOptions, nameOverride string) (
 	if stateDir == "" {
 		stateDir = filepath.Join(abs, ".dir2mcp")
 	}
+	if !filepath.IsAbs(stateDir) {
+		stateDir = filepath.Join(abs, stateDir)
+	}
 	bin, err := os.Executable()
 	if err != nil {
 		return serviceContext{}, config.Config{}, fmt.Errorf("locate dir2mcp executable: %w", err)
@@ -165,7 +168,7 @@ func (a *App) runServiceInstall(global globalOptions, args []string) int {
 		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("create state dir %s: %v", sc.stateDir, err))
 		return exitGeneric
 	}
-	a.persistAndWarnCredentials(sc.workingDir, cfg)
+	savedCreds, failedCreds := a.persistAndWarnCredentials(sc.workingDir, cfg, global.jsonOutput, global.quiet)
 
 	// Propagate global flag overrides so the installed service restarts
 	// with the exact same config/state-dir the operator used for install,
@@ -194,12 +197,16 @@ func (a *App) runServiceInstall(global globalOptions, args []string) int {
 		return a.emitServiceJSON(map[string]interface{}{
 			"action": "install", "label": sc.label, "backend": mgr.backendName(),
 			"unit_path": unitPath, "working_dir": sc.workingDir, "binary": sc.binaryPath,
+			"persisted_credentials": savedCreds,
+			"failed_credentials":    failedCreds,
 		})
 	}
-	writef(a.stdout, "installed %s service %q\n", mgr.backendName(), sc.label)
-	writef(a.stdout, "  unit:    %s\n", unitPath)
-	writef(a.stdout, "  workdir: %s\n", sc.workingDir)
-	writeln(a.stdout, "the daemon will start now and again at every login")
+	if !global.quiet {
+		writef(a.stdout, "installed %s service %q\n", mgr.backendName(), sc.label)
+		writef(a.stdout, "  unit:    %s\n", unitPath)
+		writef(a.stdout, "  workdir: %s\n", sc.workingDir)
+		writeln(a.stdout, "the daemon will start now and again at every login")
+	}
 	return exitSuccess
 }
 
@@ -224,10 +231,12 @@ func (a *App) runServiceUninstall(global globalOptions, args []string) int {
 			"unit_path": unitPath, "removed": removed,
 		})
 	}
-	if removed {
-		writef(a.stdout, "removed %s service %q (%s)\n", mgr.backendName(), sc.label, unitPath)
-	} else {
-		writef(a.stdout, "no %s service %q was installed\n", mgr.backendName(), sc.label)
+	if !global.quiet {
+		if removed {
+			writef(a.stdout, "removed %s service %q (%s)\n", mgr.backendName(), sc.label, unitPath)
+		} else {
+			writef(a.stdout, "no %s service %q was installed\n", mgr.backendName(), sc.label)
+		}
 	}
 	return exitSuccess
 }
@@ -254,11 +263,13 @@ func (a *App) runServiceStatus(global globalOptions, args []string) int {
 			"detail": state.Detail, "unit_path": state.UnitPath,
 		})
 	}
-	writef(a.stdout, "%s service %q\n", mgr.backendName(), sc.label)
-	writef(a.stdout, "  installed: %t\n", state.Installed)
-	writef(a.stdout, "  running:   %t\n", state.Running)
-	if strings.TrimSpace(state.Detail) != "" {
-		writef(a.stdout, "  detail:    %s\n", state.Detail)
+	if !global.quiet {
+		writef(a.stdout, "%s service %q\n", mgr.backendName(), sc.label)
+		writef(a.stdout, "  installed: %t\n", state.Installed)
+		writef(a.stdout, "  running:   %t\n", state.Running)
+		if strings.TrimSpace(state.Detail) != "" {
+			writef(a.stdout, "  detail:    %s\n", state.Detail)
+		}
 	}
 	return exitSuccess
 }
@@ -314,19 +325,24 @@ func (a *App) emitServiceJSON(payload map[string]interface{}) int {
 // .env.local in the corpus working directory, so the launchd service can
 // read them after a reboot — launchd does not inherit shell exports.
 //
-// The set of keys to check is derived from cfg.ProviderEnvVarRefs() so
-// custom providers defined via providers: in .dir2mcp.yaml with ${MY_KEY}
-// placeholders are covered in addition to the built-in providers.
-//
-// If no credentials are found in the environment AND none are already
-// persisted in .env.local / .env, a warning is printed instead.
-func (a *App) persistAndWarnCredentials(workingDir string, cfg config.Config) {
+// In JSON or quiet mode all normal output is suppressed; the caller
+// receives (saved, failed) to include in structured output instead.
+// Write failures and invalid values (containing newlines) are collected
+// into failed and reported as warnings in text mode.
+func (a *App) persistAndWarnCredentials(workingDir string, cfg config.Config, jsonOut, quiet bool) (saved, failed []string) {
 	envPath := filepath.Join(workingDir, ".env.local")
-	saved := persistCredentialsFromEnv(envPath, cfg.ProviderEnvVarRefs())
+	saved, failed = persistCredentialsFromEnv(envPath, cfg.ProviderEnvVarRefs())
+
+	if jsonOut || quiet {
+		return
+	}
+	for _, key := range saved {
+		writef(a.stdout, "  saved %s to %s (will survive reboots)\n", key, envPath)
+	}
+	for _, key := range failed {
+		writef(a.stderr, "  warning: failed to persist %s to %s (check file permissions or key value)\n", key, envPath)
+	}
 	if len(saved) > 0 {
-		for _, key := range saved {
-			writef(a.stdout, "  saved %s to %s (will survive reboots)\n", key, envPath)
-		}
 		return
 	}
 	// Nothing in the current environment to auto-save. Fall back to the
@@ -338,24 +354,32 @@ func (a *App) persistAndWarnCredentials(workingDir string, cfg config.Config) {
 	writeln(a.stderr, "  The service starts from a clean environment and will NOT inherit credentials exported in your shell.")
 	writeln(a.stderr, "  Run `dir2mcp config init` to persist the credential to .env.local (or add a providers: block to .dir2mcp.yaml),")
 	writeln(a.stderr, "  otherwise the daemon will fail at boot with \"no embedding provider configured\".")
+	return
 }
 
 // persistCredentialsFromEnv writes each key in envVarRefs that is found
 // non-empty in os.Getenv into the dotenv file at envPath, using the same
-// upsert semantics as `dir2mcp config init`. Returns the list of keys saved.
-func persistCredentialsFromEnv(envPath string, envVarRefs []string) []string {
-	var saved []string
+// upsert semantics as `dir2mcp config init`. Returns (saved, failed):
+// saved are keys that were written successfully; failed are keys whose
+// values contained newlines (would corrupt the dotenv file) or whose
+// write failed (permissions, disk full, etc.).
+func persistCredentialsFromEnv(envPath string, envVarRefs []string) (saved, failed []string) {
 	for _, key := range envVarRefs {
 		val := strings.TrimSpace(os.Getenv(key))
 		if val == "" {
 			continue
 		}
+		if strings.ContainsAny(val, "\r\n") {
+			failed = append(failed, key)
+			continue
+		}
 		if err := saveEnvLocalKey(envPath, key, val); err != nil {
+			failed = append(failed, key)
 			continue
 		}
 		saved = append(saved, key)
 	}
-	return saved
+	return
 }
 
 // persistentCredentialInDotenv reports whether the corpus dir holds a

--- a/internal/cli/service_darwin.go
+++ b/internal/cli/service_darwin.go
@@ -1,0 +1,119 @@
+//go:build darwin
+
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// launchdManager supervises a per-corpus dir2mcp daemon as a macOS
+// LaunchAgent. runCmd is injectable so the bootstrap/bootout/print
+// sequence can be unit-tested without touching the real launchd.
+type launchdManager struct {
+	uid    int
+	home   string
+	runCmd func(name string, args ...string) (string, error)
+}
+
+func newServiceManager() (serviceManager, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolve home dir: %w", err)
+	}
+	return &launchdManager{
+		uid:  os.Getuid(),
+		home: home,
+		runCmd: func(name string, args ...string) (string, error) {
+			out, err := exec.Command(name, args...).CombinedOutput()
+			return string(out), err
+		},
+	}, nil
+}
+
+func (m *launchdManager) backendName() string { return "launchd" }
+
+func (m *launchdManager) plistPath(label string) string {
+	return filepath.Join(m.home, "Library", "LaunchAgents", label+".plist")
+}
+
+func (m *launchdManager) domainTarget() string {
+	return fmt.Sprintf("gui/%d", m.uid)
+}
+
+func (m *launchdManager) serviceTarget(label string) string {
+	return fmt.Sprintf("gui/%d/%s", m.uid, label)
+}
+
+func (m *launchdManager) install(spec serviceSpec) (string, error) {
+	plistPath := m.plistPath(spec.Label)
+	if err := os.MkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
+		return "", fmt.Errorf("create LaunchAgents dir: %w", err)
+	}
+	if err := os.WriteFile(plistPath, []byte(renderLaunchdPlist(spec)), 0o644); err != nil {
+		return "", fmt.Errorf("write plist %s: %w", plistPath, err)
+	}
+	// Reload idempotently: bootout an existing copy (ignore the error
+	// when nothing is loaded yet), then bootstrap the fresh plist.
+	_, _ = m.runCmd("launchctl", "bootout", m.domainTarget(), plistPath)
+	if out, err := m.runCmd("launchctl", "bootstrap", m.domainTarget(), plistPath); err != nil {
+		return plistPath, fmt.Errorf("launchctl bootstrap: %w: %s", err, strings.TrimSpace(out))
+	}
+	// RunAtLoad starts it on bootstrap; kickstart -k forces a clean
+	// (re)start so reinstalls pick up the new plist immediately.
+	if out, err := m.runCmd("launchctl", "kickstart", "-k", m.serviceTarget(spec.Label)); err != nil {
+		return plistPath, fmt.Errorf("launchctl kickstart: %w: %s", err, strings.TrimSpace(out))
+	}
+	return plistPath, nil
+}
+
+func (m *launchdManager) uninstall(label string) (string, bool, error) {
+	plistPath := m.plistPath(label)
+	// Unload first (ignore error: it may already be stopped/absent),
+	// then remove the plist so it won't reload at next login.
+	_, _ = m.runCmd("launchctl", "bootout", m.domainTarget(), plistPath)
+	if _, err := os.Stat(plistPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return plistPath, false, nil
+		}
+		return plistPath, false, fmt.Errorf("stat plist %s: %w", plistPath, err)
+	}
+	if err := os.Remove(plistPath); err != nil {
+		return plistPath, false, fmt.Errorf("remove plist %s: %w", plistPath, err)
+	}
+	return plistPath, true, nil
+}
+
+func (m *launchdManager) status(label string) (serviceState, error) {
+	plistPath := m.plistPath(label)
+	state := serviceState{UnitPath: plistPath}
+	if _, err := os.Stat(plistPath); err == nil {
+		state.Installed = true
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return state, fmt.Errorf("stat plist %s: %w", plistPath, err)
+	}
+
+	out, err := m.runCmd("launchctl", "print", m.serviceTarget(label))
+	if err != nil {
+		// Not loaded into the user's GUI domain. If the plist is on
+		// disk it's installed-but-stopped; otherwise fully absent.
+		if state.Installed {
+			state.Detail = "installed, not loaded"
+		} else {
+			state.Detail = "not installed"
+		}
+		return state, nil
+	}
+	state.Installed = true
+	if strings.Contains(out, "state = running") {
+		state.Running = true
+		state.Detail = "running"
+	} else {
+		state.Detail = "loaded, not running"
+	}
+	return state, nil
+}

--- a/internal/cli/service_darwin.go
+++ b/internal/cli/service_darwin.go
@@ -20,6 +20,7 @@ type launchdManager struct {
 	runCmd func(name string, args ...string) (string, error)
 }
 
+// newServiceManager returns the macOS launchd backend.
 func newServiceManager() (serviceManager, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -35,20 +36,30 @@ func newServiceManager() (serviceManager, error) {
 	}, nil
 }
 
+// backendName identifies this manager in CLI output.
 func (m *launchdManager) backendName() string { return "launchd" }
 
+// plistPath returns the canonical LaunchAgent plist path for label.
+// filepath.Base clamps any residual path separators in label so it
+// cannot escape the LaunchAgents directory, even if upstream validation
+// is somehow bypassed.
 func (m *launchdManager) plistPath(label string) string {
-	return filepath.Join(m.home, "Library", "LaunchAgents", label+".plist")
+	return filepath.Join(m.home, "Library", "LaunchAgents", filepath.Base(label)+".plist")
 }
 
+// domainTarget returns the launchctl GUI domain target for this user.
 func (m *launchdManager) domainTarget() string {
 	return fmt.Sprintf("gui/%d", m.uid)
 }
 
+// serviceTarget returns the launchctl service target for label in this
+// user's GUI domain.
 func (m *launchdManager) serviceTarget(label string) string {
 	return fmt.Sprintf("gui/%d/%s", m.uid, label)
 }
 
+// install writes the LaunchAgent plist and bootstraps it into the user's
+// GUI domain, kicking off an immediate (re)start via kickstart -k.
 func (m *launchdManager) install(spec serviceSpec) (string, error) {
 	plistPath := m.plistPath(spec.Label)
 	if err := os.MkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
@@ -71,6 +82,8 @@ func (m *launchdManager) install(spec serviceSpec) (string, error) {
 	return plistPath, nil
 }
 
+// uninstall bootouts the service from the user's GUI domain and removes
+// the plist file. Returns removed=false when the service was not installed.
 func (m *launchdManager) uninstall(label string) (string, bool, error) {
 	plistPath := m.plistPath(label)
 	// Unload first (ignore error: it may already be stopped/absent),
@@ -88,6 +101,19 @@ func (m *launchdManager) uninstall(label string) (string, bool, error) {
 	return plistPath, true, nil
 }
 
+// launchdNotFoundPhrases are substrings launchctl prints when a service
+// is not registered in the domain. Only these known-absent outputs are
+// treated as "not installed / not loaded"; any other error is returned
+// to the caller so genuine command failures don't masquerade as absent.
+var launchdNotFoundPhrases = []string{
+	"could not find service",
+	"not found in domain",
+}
+
+// status queries the launchd GUI domain for label and returns whether the
+// service is installed (plist on disk) and running (active in domain).
+// Only explicit "service not found" outputs from launchctl are treated
+// as absent state; other command failures are returned as errors.
 func (m *launchdManager) status(label string) (serviceState, error) {
 	plistPath := m.plistPath(label)
 	state := serviceState{UnitPath: plistPath}
@@ -99,14 +125,20 @@ func (m *launchdManager) status(label string) (serviceState, error) {
 
 	out, err := m.runCmd("launchctl", "print", m.serviceTarget(label))
 	if err != nil {
-		// Not loaded into the user's GUI domain. If the plist is on
-		// disk it's installed-but-stopped; otherwise fully absent.
-		if state.Installed {
-			state.Detail = "installed, not loaded"
-		} else {
-			state.Detail = "not installed"
+		// Distinguish "service not registered" (normal absent state) from
+		// real command failures (permission denied, domain error, etc.).
+		msg := strings.ToLower(strings.TrimSpace(out))
+		for _, phrase := range launchdNotFoundPhrases {
+			if strings.Contains(msg, phrase) {
+				if state.Installed {
+					state.Detail = "installed, not loaded"
+				} else {
+					state.Detail = "not installed"
+				}
+				return state, nil
+			}
 		}
-		return state, nil
+		return state, fmt.Errorf("launchctl print %s: %w: %s", m.serviceTarget(label), err, strings.TrimSpace(out))
 	}
 	state.Installed = true
 	if strings.Contains(out, "state = running") {

--- a/internal/cli/service_darwin_test.go
+++ b/internal/cli/service_darwin_test.go
@@ -139,13 +139,48 @@ func TestLaunchdManager_StatusReportsRunning(t *testing.T) {
 	}
 }
 
+// TestLaunchdManager_StatusReportsNotInstalled pins the "service absent"
+// path: launchctl exits non-zero AND prints "Could not find service",
+// which is the known-absent phrase the status method uses to distinguish
+// a clean absent state from a real command failure.
 func TestLaunchdManager_StatusReportsNotInstalled(t *testing.T) {
-	mgr, _ := newFakeLaunchd(t, "Could not find service", fmt.Errorf("exit status 113"))
+	mgr, _ := newFakeLaunchd(t, "Could not find service \"com.dirstral.absent\" in domain for port", fmt.Errorf("exit status 113"))
 	state, err := mgr.status("com.dirstral.absent")
 	if err != nil {
-		t.Fatalf("status: %v", err)
+		t.Fatalf("status should not error for a known-absent service: %v", err)
 	}
 	if state.Installed || state.Running {
 		t.Errorf("expected absent service, got %+v", state)
+	}
+}
+
+// TestLaunchdManager_StatusErrorsOnCommandFailure pins that a launchctl
+// failure whose output does not match a known-absent phrase is surfaced
+// as an error rather than silently reported as "not installed".
+func TestLaunchdManager_StatusErrorsOnCommandFailure(t *testing.T) {
+	mgr, _ := newFakeLaunchd(t, "permission denied", fmt.Errorf("exit status 1"))
+	_, err := mgr.status("com.dirstral.some-label")
+	if err == nil {
+		t.Fatal("expected status to surface non-absent launchctl failure as error")
+	}
+	if !strings.Contains(err.Error(), "launchctl print") {
+		t.Errorf("error should mention launchctl print: %v", err)
+	}
+}
+
+// TestLaunchdManager_PlistPathClampsTraversal verifies the filepath.Base
+// defense-in-depth in plistPath: even if a label containing separators
+// somehow reaches the method, the returned path stays inside LaunchAgents.
+func TestLaunchdManager_PlistPathClampsTraversal(t *testing.T) {
+	mgr, _ := newFakeLaunchd(t, "", nil)
+	crafted := "../../etc/evil"
+	got := mgr.plistPath(crafted)
+	base := filepath.Base(got)
+	launchAgentsDir := filepath.Join(mgr.home, "Library", "LaunchAgents")
+	if !strings.HasPrefix(got, launchAgentsDir) {
+		t.Errorf("plistPath escaped LaunchAgents dir: %q", got)
+	}
+	if base != "evil.plist" {
+		t.Errorf("expected clamped basename evil.plist, got %q", base)
 	}
 }

--- a/internal/cli/service_darwin_test.go
+++ b/internal/cli/service_darwin_test.go
@@ -1,0 +1,151 @@
+//go:build darwin
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type recordedCmd struct {
+	name string
+	args []string
+}
+
+func newFakeLaunchd(t *testing.T, output string, runErr error) (*launchdManager, *[]recordedCmd) {
+	t.Helper()
+	home := t.TempDir()
+	calls := &[]recordedCmd{}
+	mgr := &launchdManager{
+		uid:  501,
+		home: home,
+		runCmd: func(name string, args ...string) (string, error) {
+			*calls = append(*calls, recordedCmd{name: name, args: args})
+			return output, runErr
+		},
+	}
+	return mgr, calls
+}
+
+func TestLaunchdManager_InstallWritesPlistAndBootstraps(t *testing.T) {
+	mgr, calls := newFakeLaunchd(t, "", nil)
+	spec := serviceSpec{
+		Label:      "com.dirstral.dir2mcp-demo-abc123",
+		BinaryPath: "/usr/local/bin/dir2mcp",
+		WorkingDir: "/Users/me/legal",
+		Args:       []string{"up", "--foreground"},
+		LogPath:    "/Users/me/legal/.dir2mcp/service.log",
+	}
+
+	unitPath, err := mgr.install(spec)
+	if err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	wantPath := filepath.Join(mgr.home, "Library", "LaunchAgents", spec.Label+".plist")
+	if unitPath != wantPath {
+		t.Errorf("unitPath = %q, want %q", unitPath, wantPath)
+	}
+	body, readErr := os.ReadFile(wantPath)
+	if readErr != nil {
+		t.Fatalf("plist not written: %v", readErr)
+	}
+	if !strings.Contains(string(body), spec.Label) {
+		t.Errorf("plist missing label:\n%s", body)
+	}
+
+	wantSeq := []string{"bootout", "bootstrap", "kickstart"}
+	if len(*calls) != len(wantSeq) {
+		t.Fatalf("got %d launchctl calls, want %d: %+v", len(*calls), len(wantSeq), *calls)
+	}
+	for i, want := range wantSeq {
+		c := (*calls)[i]
+		if c.name != "launchctl" || len(c.args) == 0 || c.args[0] != want {
+			t.Errorf("call %d = %+v, want launchctl %s ...", i, c, want)
+		}
+	}
+}
+
+func TestLaunchdManager_InstallSurfacesBootstrapFailure(t *testing.T) {
+	mgr, _ := newFakeLaunchd(t, "Bootstrap failed: 5: Input/output error", fmt.Errorf("exit status 5"))
+	// bootout is best-effort (error ignored), but bootstrap failure must
+	// surface. The fake returns an error for every call, so bootstrap fails.
+	_, err := mgr.install(serviceSpec{Label: "com.dirstral.x", BinaryPath: "/bin/dir2mcp", WorkingDir: "/x"})
+	if err == nil {
+		t.Fatal("expected bootstrap failure to surface")
+	}
+	if !strings.Contains(err.Error(), "bootstrap") {
+		t.Errorf("error should mention bootstrap: %v", err)
+	}
+}
+
+func TestLaunchdManager_UninstallRemovesPlist(t *testing.T) {
+	mgr, calls := newFakeLaunchd(t, "", nil)
+	label := "com.dirstral.dir2mcp-demo-abc123"
+	plistPath := mgr.plistPath(label)
+	if err := os.MkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(plistPath, []byte("<plist/>"), 0o644); err != nil {
+		t.Fatalf("seed plist: %v", err)
+	}
+
+	_, removed, err := mgr.uninstall(label)
+	if err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+	if !removed {
+		t.Error("expected removed=true for an existing plist")
+	}
+	if _, statErr := os.Stat(plistPath); !os.IsNotExist(statErr) {
+		t.Errorf("plist still present after uninstall: %v", statErr)
+	}
+	if len(*calls) != 1 || (*calls)[0].args[0] != "bootout" {
+		t.Errorf("expected a single bootout call, got %+v", *calls)
+	}
+}
+
+func TestLaunchdManager_UninstallAbsentIsNoop(t *testing.T) {
+	mgr, _ := newFakeLaunchd(t, "", nil)
+	_, removed, err := mgr.uninstall("com.dirstral.not-installed")
+	if err != nil {
+		t.Fatalf("uninstall absent: %v", err)
+	}
+	if removed {
+		t.Error("expected removed=false when no plist exists")
+	}
+}
+
+func TestLaunchdManager_StatusReportsRunning(t *testing.T) {
+	mgr, _ := newFakeLaunchd(t, "service = {\n\tstate = running\n}\n", nil)
+	label := "com.dirstral.dir2mcp-demo-abc123"
+	plistPath := mgr.plistPath(label)
+	if err := os.MkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(plistPath, []byte("<plist/>"), 0o644); err != nil {
+		t.Fatalf("seed plist: %v", err)
+	}
+
+	state, err := mgr.status(label)
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if !state.Installed || !state.Running {
+		t.Errorf("expected installed+running, got %+v", state)
+	}
+}
+
+func TestLaunchdManager_StatusReportsNotInstalled(t *testing.T) {
+	mgr, _ := newFakeLaunchd(t, "Could not find service", fmt.Errorf("exit status 113"))
+	state, err := mgr.status("com.dirstral.absent")
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if state.Installed || state.Running {
+		t.Errorf("expected absent service, got %+v", state)
+	}
+}

--- a/internal/cli/service_darwin_test.go
+++ b/internal/cli/service_darwin_test.go
@@ -177,8 +177,8 @@ func TestLaunchdManager_PlistPathClampsTraversal(t *testing.T) {
 	got := mgr.plistPath(crafted)
 	base := filepath.Base(got)
 	launchAgentsDir := filepath.Join(mgr.home, "Library", "LaunchAgents")
-	if !strings.HasPrefix(got, launchAgentsDir) {
-		t.Errorf("plistPath escaped LaunchAgents dir: %q", got)
+	if filepath.Dir(got) != launchAgentsDir {
+		t.Errorf("plistPath escaped LaunchAgents dir: %q (want parent %s)", got, launchAgentsDir)
 	}
 	if base != "evil.plist" {
 		t.Errorf("expected clamped basename evil.plist, got %q", base)

--- a/internal/cli/service_other.go
+++ b/internal/cli/service_other.go
@@ -1,0 +1,15 @@
+//go:build !darwin
+
+package cli
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// newServiceManager reports that login auto-start is not yet wired for
+// this platform. macOS (launchd) is supported today; a Linux systemd
+// user-unit backend is a planned follow-up.
+func newServiceManager() (serviceManager, error) {
+	return nil, fmt.Errorf("dir2mcp service is not yet supported on %s (macOS/launchd only for now)", runtime.GOOS)
+}

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -92,6 +92,80 @@ func TestPersistentCredentialInDotenv(t *testing.T) {
 	}
 }
 
+// TestPersistCredentialsFromEnv pins the auto-save behaviour: any
+// serviceCredentialEnvKeys key found in the current environment is written
+// to .env.local so the launchd service can read it after a reboot.
+func TestPersistCredentialsFromEnv(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env.local")
+
+	t.Setenv("MISTRAL_API_KEY", "sk-live-value")
+	t.Setenv("OPENAI_API_KEY", "")
+
+	saved := persistCredentialsFromEnv(envPath)
+	if len(saved) != 1 || saved[0] != "MISTRAL_API_KEY" {
+		t.Fatalf("expected [MISTRAL_API_KEY], got %v", saved)
+	}
+
+	body, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatalf("read .env.local: %v", err)
+	}
+	if !strings.Contains(string(body), "MISTRAL_API_KEY=sk-live-value") {
+		t.Errorf(".env.local missing expected key=value:\n%s", body)
+	}
+	if strings.Contains(string(body), "OPENAI_API_KEY") {
+		t.Errorf(".env.local should not contain empty key OPENAI_API_KEY:\n%s", body)
+	}
+
+	// File must be written 0o600 (owner-read-write only).
+	fi, err := os.Stat(envPath)
+	if err != nil {
+		t.Fatalf("stat .env.local: %v", err)
+	}
+	if fi.Mode().Perm() != 0o600 {
+		t.Errorf(".env.local permissions = %v, want 0600", fi.Mode().Perm())
+	}
+}
+
+// TestPersistCredentialsFromEnv_NoneSet returns empty when no known key
+// is in the environment.
+func TestPersistCredentialsFromEnv_NoneSet(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env.local")
+	for _, k := range serviceCredentialEnvKeys {
+		t.Setenv(k, "")
+	}
+	saved := persistCredentialsFromEnv(envPath)
+	if len(saved) != 0 {
+		t.Errorf("expected nothing saved, got %v", saved)
+	}
+	if _, err := os.Stat(envPath); !os.IsNotExist(err) {
+		t.Error(".env.local should not be created when no credentials are set")
+	}
+}
+
+// TestPersistCredentialsFromEnv_Upsert verifies the existing value in
+// .env.local is replaced when a newer value is in the environment.
+func TestPersistCredentialsFromEnv_Upsert(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env.local")
+	if err := os.WriteFile(envPath, []byte("MISTRAL_API_KEY=old-value\n"), 0o600); err != nil {
+		t.Fatalf("seed .env.local: %v", err)
+	}
+
+	t.Setenv("MISTRAL_API_KEY", "new-value")
+	persistCredentialsFromEnv(envPath)
+
+	body, _ := os.ReadFile(envPath)
+	if !strings.Contains(string(body), "MISTRAL_API_KEY=new-value") {
+		t.Errorf("expected upserted new-value:\n%s", body)
+	}
+	if strings.Contains(string(body), "old-value") {
+		t.Errorf("old-value should have been replaced:\n%s", body)
+	}
+}
+
 // TestValidateServiceName pins path-traversal rejection for explicit
 // --name overrides. Auto-derived names are safe; this guards operator
 // overrides that could embed path separators.

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -62,6 +62,10 @@ func TestRenderLaunchdPlist(t *testing.T) {
 }
 
 func TestPersistentCredentialInDotenv(t *testing.T) {
+	refs := []string{
+		"MISTRAL_API_KEY", "OPENAI_API_KEY", "OPENROUTER_API_KEY",
+		"ANTHROPIC_API_KEY", "GEMINI_API_KEY", "COHERE_API_KEY", "ELEVENLABS_API_KEY",
+	}
 	tests := []struct {
 		name string
 		file string // "" => no file written
@@ -85,7 +89,7 @@ func TestPersistentCredentialInDotenv(t *testing.T) {
 					t.Fatalf("write %s: %v", tc.file, err)
 				}
 			}
-			if got := persistentCredentialInDotenv(dir); got != tc.want {
+			if got := persistentCredentialInDotenv(dir, refs); got != tc.want {
 				t.Errorf("persistentCredentialInDotenv = %v, want %v", got, tc.want)
 			}
 		})
@@ -165,6 +169,28 @@ func TestPersistCredentialsFromEnv_Upsert(t *testing.T) {
 	}
 }
 
+// TestPersistCredentialsFromEnv_ExportPrefixUpsert verifies that an existing
+// "export KEY=old" line in .env.local is replaced — not left alongside — when
+// the new value is written, so the earlier export line cannot shadow the update.
+func TestPersistCredentialsFromEnv_ExportPrefixUpsert(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env.local")
+	if err := os.WriteFile(envPath, []byte("export MISTRAL_API_KEY=old-value\n"), 0o600); err != nil {
+		t.Fatalf("seed .env.local: %v", err)
+	}
+
+	t.Setenv("MISTRAL_API_KEY", "new-value")
+	persistCredentialsFromEnv(envPath, []string{"MISTRAL_API_KEY"})
+
+	body, _ := os.ReadFile(envPath)
+	if !strings.Contains(string(body), "MISTRAL_API_KEY=new-value") {
+		t.Errorf("expected new-value to be written:\n%s", body)
+	}
+	if strings.Contains(string(body), "old-value") {
+		t.Errorf("old-value from export line should have been removed:\n%s", body)
+	}
+}
+
 // TestPersistCredentialsFromEnv_CustomKey pins that envVarRefs is not
 // limited to built-in providers: a custom key like MY_PROVIDER_API_KEY
 // supplied via providers: api_key: "${MY_PROVIDER_API_KEY}" in YAML is
@@ -205,9 +231,9 @@ func TestPersistCredentialsFromEnv_NewlineRejected(t *testing.T) {
 	}
 }
 
-// TestValidateServiceName pins path-traversal rejection for explicit
-// --name overrides. Auto-derived names are safe; this guards operator
-// overrides that could embed path separators.
+// TestValidateServiceName pins the allowlist validation for explicit --name
+// overrides. Only A-Za-z0-9._- are permitted; whitespace, control chars,
+// path separators, and absolute paths must all be rejected.
 func TestValidateServiceName(t *testing.T) {
 	for _, tc := range []struct {
 		name    string
@@ -220,6 +246,9 @@ func TestValidateServiceName(t *testing.T) {
 		{"/etc/evil", true},
 		{"foo/bar", true},
 		{`foo\bar`, true},
+		{"foo bar", true},        // space not allowed
+		{" ", true},              // whitespace-only
+		{"hello\x00world", true}, // null byte
 	} {
 		err := validateServiceName(tc.name)
 		if (err != nil) != tc.wantErr {

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -92,9 +92,9 @@ func TestPersistentCredentialInDotenv(t *testing.T) {
 	}
 }
 
-// TestPersistCredentialsFromEnv pins the auto-save behaviour: any
-// serviceCredentialEnvKeys key found in the current environment is written
-// to .env.local so the launchd service can read it after a reboot.
+// TestPersistCredentialsFromEnv pins the auto-save behaviour: any key in
+// envVarRefs found in the current environment is written to .env.local so
+// the launchd service can read it after a reboot.
 func TestPersistCredentialsFromEnv(t *testing.T) {
 	dir := t.TempDir()
 	envPath := filepath.Join(dir, ".env.local")
@@ -102,7 +102,7 @@ func TestPersistCredentialsFromEnv(t *testing.T) {
 	t.Setenv("MISTRAL_API_KEY", "sk-live-value")
 	t.Setenv("OPENAI_API_KEY", "")
 
-	saved := persistCredentialsFromEnv(envPath)
+	saved := persistCredentialsFromEnv(envPath, []string{"MISTRAL_API_KEY", "OPENAI_API_KEY"})
 	if len(saved) != 1 || saved[0] != "MISTRAL_API_KEY" {
 		t.Fatalf("expected [MISTRAL_API_KEY], got %v", saved)
 	}
@@ -128,15 +128,14 @@ func TestPersistCredentialsFromEnv(t *testing.T) {
 	}
 }
 
-// TestPersistCredentialsFromEnv_NoneSet returns empty when no known key
-// is in the environment.
+// TestPersistCredentialsFromEnv_NoneSet returns empty when no key in
+// envVarRefs is in the environment.
 func TestPersistCredentialsFromEnv_NoneSet(t *testing.T) {
 	dir := t.TempDir()
 	envPath := filepath.Join(dir, ".env.local")
-	for _, k := range serviceCredentialEnvKeys {
-		t.Setenv(k, "")
-	}
-	saved := persistCredentialsFromEnv(envPath)
+	t.Setenv("MISTRAL_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+	saved := persistCredentialsFromEnv(envPath, []string{"MISTRAL_API_KEY", "OPENAI_API_KEY"})
 	if len(saved) != 0 {
 		t.Errorf("expected nothing saved, got %v", saved)
 	}
@@ -155,7 +154,7 @@ func TestPersistCredentialsFromEnv_Upsert(t *testing.T) {
 	}
 
 	t.Setenv("MISTRAL_API_KEY", "new-value")
-	persistCredentialsFromEnv(envPath)
+	persistCredentialsFromEnv(envPath, []string{"MISTRAL_API_KEY"})
 
 	body, _ := os.ReadFile(envPath)
 	if !strings.Contains(string(body), "MISTRAL_API_KEY=new-value") {
@@ -163,6 +162,24 @@ func TestPersistCredentialsFromEnv_Upsert(t *testing.T) {
 	}
 	if strings.Contains(string(body), "old-value") {
 		t.Errorf("old-value should have been replaced:\n%s", body)
+	}
+}
+
+// TestPersistCredentialsFromEnv_CustomKey pins that envVarRefs is not
+// limited to built-in providers: a custom key like MY_PROVIDER_API_KEY
+// supplied via providers: api_key: "${MY_PROVIDER_API_KEY}" in YAML is
+// also saved when found in the current environment.
+func TestPersistCredentialsFromEnv_CustomKey(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env.local")
+	t.Setenv("MY_PROVIDER_API_KEY", "custom-secret")
+	saved := persistCredentialsFromEnv(envPath, []string{"MISTRAL_API_KEY", "MY_PROVIDER_API_KEY"})
+	if len(saved) != 1 || saved[0] != "MY_PROVIDER_API_KEY" {
+		t.Fatalf("expected [MY_PROVIDER_API_KEY], got %v", saved)
+	}
+	body, _ := os.ReadFile(envPath)
+	if !strings.Contains(string(body), "MY_PROVIDER_API_KEY=custom-secret") {
+		t.Errorf(".env.local missing custom key:\n%s", body)
 	}
 }
 

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -1,0 +1,110 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestServiceLabel(t *testing.T) {
+	got := serviceLabel("dir2mcp-stas-legal-main-45a264")
+	want := "com.dirstral.dir2mcp-stas-legal-main-45a264"
+	if got != want {
+		t.Fatalf("serviceLabel = %q, want %q", got, want)
+	}
+	if got := serviceLabel("  spaced  "); got != "com.dirstral.spaced" {
+		t.Errorf("serviceLabel did not trim: %q", got)
+	}
+}
+
+func TestRenderLaunchdPlist(t *testing.T) {
+	spec := serviceSpec{
+		Label:      "com.dirstral.dir2mcp-demo-abc123",
+		BinaryPath: "/usr/local/bin/dir2mcp",
+		WorkingDir: "/Users/me/legal & co",
+		Args:       []string{"up", "--foreground"},
+		LogPath:    "/Users/me/legal & co/.dir2mcp/service.log",
+	}
+	out := renderLaunchdPlist(spec)
+
+	for _, want := range []string{
+		"<key>Label</key>",
+		"<string>com.dirstral.dir2mcp-demo-abc123</string>",
+		"<key>ProgramArguments</key>",
+		"<string>/usr/local/bin/dir2mcp</string>",
+		"<string>up</string>",
+		"<string>--foreground</string>",
+		"<key>RunAtLoad</key>",
+		"<key>KeepAlive</key>",
+		"<true/>",
+		"<key>WorkingDirectory</key>",
+		"<key>ProcessType</key>",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("plist missing %q\n---\n%s", want, out)
+		}
+	}
+
+	// WorkingDirectory carries an ampersand: it must be XML-escaped so
+	// the plist stays well-formed.
+	if !strings.Contains(out, "legal &amp; co") {
+		t.Errorf("plist did not XML-escape working dir:\n%s", out)
+	}
+	if strings.Contains(out, "legal & co") {
+		t.Errorf("plist contains a raw unescaped ampersand:\n%s", out)
+	}
+	if !strings.HasPrefix(out, "<?xml") {
+		t.Errorf("plist missing XML header: %q", out[:min(20, len(out))])
+	}
+}
+
+func TestPersistentCredentialInDotenv(t *testing.T) {
+	tests := []struct {
+		name string
+		file string // "" => no file written
+		body string
+		want bool
+	}{
+		{"env_local_with_key", ".env.local", "MISTRAL_API_KEY=sk-real-value\n", true},
+		{"env_local_export_prefix", ".env.local", "export OPENAI_API_KEY=abc123\n", true},
+		{"env_local_quoted", ".env.local", "MISTRAL_API_KEY=\"quoted-secret\"\n", true},
+		{"env_fallback", ".env", "COHERE_API_KEY=xyz\n", true},
+		{"empty_value", ".env.local", "MISTRAL_API_KEY=\n", false},
+		{"unrelated_key", ".env.local", "SOME_OTHER_VAR=1\n", false},
+		{"comment_only", ".env.local", "# MISTRAL_API_KEY=ignored\n", false},
+		{"no_file", "", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if tc.file != "" {
+				if err := os.WriteFile(filepath.Join(dir, tc.file), []byte(tc.body), 0o600); err != nil {
+					t.Fatalf("write %s: %v", tc.file, err)
+				}
+			}
+			if got := persistentCredentialInDotenv(dir); got != tc.want {
+				t.Errorf("persistentCredentialInDotenv = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRunService_RejectsBadSubcommand pins the dispatch guard rails that
+// run before any OS backend is touched, so they behave identically on
+// every platform.
+func TestRunService_RejectsBadSubcommand(t *testing.T) {
+	for _, args := range [][]string{nil, {"bogus"}} {
+		var out, errBuf bytes.Buffer
+		app := NewAppWithIO(&out, &errBuf)
+		code := app.runService(context.Background(), globalOptions{}, args)
+		if code != exitConfigInvalid {
+			t.Errorf("args=%v: code=%d, want %d", args, code, exitConfigInvalid)
+		}
+		if !strings.Contains(errBuf.String(), "subcommand") {
+			t.Errorf("args=%v: stderr missing subcommand hint: %q", args, errBuf.String())
+		}
+	}
+}

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -102,7 +102,7 @@ func TestPersistCredentialsFromEnv(t *testing.T) {
 	t.Setenv("MISTRAL_API_KEY", "sk-live-value")
 	t.Setenv("OPENAI_API_KEY", "")
 
-	saved := persistCredentialsFromEnv(envPath, []string{"MISTRAL_API_KEY", "OPENAI_API_KEY"})
+	saved, _ := persistCredentialsFromEnv(envPath, []string{"MISTRAL_API_KEY", "OPENAI_API_KEY"})
 	if len(saved) != 1 || saved[0] != "MISTRAL_API_KEY" {
 		t.Fatalf("expected [MISTRAL_API_KEY], got %v", saved)
 	}
@@ -135,7 +135,7 @@ func TestPersistCredentialsFromEnv_NoneSet(t *testing.T) {
 	envPath := filepath.Join(dir, ".env.local")
 	t.Setenv("MISTRAL_API_KEY", "")
 	t.Setenv("OPENAI_API_KEY", "")
-	saved := persistCredentialsFromEnv(envPath, []string{"MISTRAL_API_KEY", "OPENAI_API_KEY"})
+	saved, _ := persistCredentialsFromEnv(envPath, []string{"MISTRAL_API_KEY", "OPENAI_API_KEY"})
 	if len(saved) != 0 {
 		t.Errorf("expected nothing saved, got %v", saved)
 	}
@@ -173,13 +173,35 @@ func TestPersistCredentialsFromEnv_CustomKey(t *testing.T) {
 	dir := t.TempDir()
 	envPath := filepath.Join(dir, ".env.local")
 	t.Setenv("MY_PROVIDER_API_KEY", "custom-secret")
-	saved := persistCredentialsFromEnv(envPath, []string{"MISTRAL_API_KEY", "MY_PROVIDER_API_KEY"})
+	saved, _ := persistCredentialsFromEnv(envPath, []string{"MISTRAL_API_KEY", "MY_PROVIDER_API_KEY"})
 	if len(saved) != 1 || saved[0] != "MY_PROVIDER_API_KEY" {
 		t.Fatalf("expected [MY_PROVIDER_API_KEY], got %v", saved)
 	}
 	body, _ := os.ReadFile(envPath)
 	if !strings.Contains(string(body), "MY_PROVIDER_API_KEY=custom-secret") {
 		t.Errorf(".env.local missing custom key:\n%s", body)
+	}
+}
+
+// TestPersistCredentialsFromEnv_NewlineRejected pins that values containing
+// \r or \n are placed in the failed list rather than written to .env.local,
+// preventing newline injection that could corrupt the file format.
+func TestPersistCredentialsFromEnv_NewlineRejected(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env.local")
+	t.Setenv("MISTRAL_API_KEY", "good-value")
+	t.Setenv("OPENAI_API_KEY", "bad\nvalue")
+
+	saved, failed := persistCredentialsFromEnv(envPath, []string{"MISTRAL_API_KEY", "OPENAI_API_KEY"})
+	if len(saved) != 1 || saved[0] != "MISTRAL_API_KEY" {
+		t.Errorf("saved = %v, want [MISTRAL_API_KEY]", saved)
+	}
+	if len(failed) != 1 || failed[0] != "OPENAI_API_KEY" {
+		t.Errorf("failed = %v, want [OPENAI_API_KEY]", failed)
+	}
+	body, _ := os.ReadFile(envPath)
+	if strings.Contains(string(body), "OPENAI_API_KEY") {
+		t.Errorf(".env.local must not contain rejected key: %s", body)
 	}
 }
 

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -92,6 +92,29 @@ func TestPersistentCredentialInDotenv(t *testing.T) {
 	}
 }
 
+// TestValidateServiceName pins path-traversal rejection for explicit
+// --name overrides. Auto-derived names are safe; this guards operator
+// overrides that could embed path separators.
+func TestValidateServiceName(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		wantErr bool
+	}{
+		{"dir2mcp-legal-abc123", false},
+		{"com.dirstral.foo", false},
+		{"simple", false},
+		{"../../etc/evil", true},
+		{"/etc/evil", true},
+		{"foo/bar", true},
+		{`foo\bar`, true},
+	} {
+		err := validateServiceName(tc.name)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("validateServiceName(%q): got err=%v, wantErr=%v", tc.name, err, tc.wantErr)
+		}
+	}
+}
+
 // TestRunService_RejectsBadSubcommand pins the dispatch guard rails that
 // run before any OS backend is touched, so they behave identically on
 // every platform.

--- a/internal/config/providers.go
+++ b/internal/config/providers.go
@@ -352,6 +352,36 @@ func (cfg Config) Providers() ProviderResolution {
 	return cfg.providersDoc.resolve(base, nil)
 }
 
+// ProviderEnvVarRefs returns the distinct environment variable names
+// referenced in api_key fields across all provider profiles (builtin +
+// user-defined). For example, a builtin profile with api_key "${MISTRAL_API_KEY}"
+// contributes "MISTRAL_API_KEY", and a user profile with api_key "${MY_KEY}"
+// contributes "MY_KEY". Used by `dir2mcp service install` to auto-persist
+// every relevant credential to .env.local, not just the hardcoded list.
+func (cfg Config) ProviderEnvVarRefs() []string {
+	base := builtinProfiles()
+	seedLegacy(base, cfg)
+	merged, _ := mergeProfiles(base, cfg.providersDoc.Providers)
+
+	seen := make(map[string]struct{})
+	var refs []string
+	for _, p := range merged {
+		if p.APIKey == nil {
+			continue
+		}
+		os.Expand(*p.APIKey, func(key string) string {
+			if key != "" {
+				if _, ok := seen[key]; !ok {
+					seen[key] = struct{}{}
+					refs = append(refs, key)
+				}
+			}
+			return ""
+		})
+	}
+	return refs
+}
+
 // litStr returns a pointer to s, used to set a providerProfileYAML
 // api_key to a concrete literal (distinct from an absent/credential-less
 // nil api_key).

--- a/internal/config/providers.go
+++ b/internal/config/providers.go
@@ -11,6 +11,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/dirstral/dir2mcp/internal/provider"
@@ -379,6 +380,7 @@ func (cfg Config) ProviderEnvVarRefs() []string {
 			return ""
 		})
 	}
+	sort.Strings(refs)
 	return refs
 }
 

--- a/tests/config/providers_config_test.go
+++ b/tests/config/providers_config_test.go
@@ -128,3 +128,35 @@ func TestProviders_EmbedIdentityStable(t *testing.T) {
 		t.Fatalf("embed identity = %q", id)
 	}
 }
+
+func TestProviders_EnvVarRefs(t *testing.T) {
+	// Default config (no custom providers): built-in profiles reference
+	// the standard credential env vars.
+	refs := loadCfg(t, "version: 1\n").ProviderEnvVarRefs()
+	inRefs := func(key string) bool {
+		for _, r := range refs {
+			if r == key {
+				return true
+			}
+		}
+		return false
+	}
+	for _, want := range []string{"MISTRAL_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY"} {
+		if !inRefs(want) {
+			t.Errorf("ProviderEnvVarRefs missing built-in key %q; got %v", want, refs)
+		}
+	}
+	// A custom provider with ${MY_CUSTOM_KEY} must also appear.
+	custom := loadCfg(t, "providers:\n  myprovider:\n    kind: openai\n    api_key: ${MY_CUSTOM_KEY}\n")
+	customRefs := custom.ProviderEnvVarRefs()
+	if !func() bool {
+		for _, r := range customRefs {
+			if r == "MY_CUSTOM_KEY" {
+				return true
+			}
+		}
+		return false
+	}() {
+		t.Errorf("ProviderEnvVarRefs missing custom key MY_CUSTOM_KEY; got %v", customRefs)
+	}
+}

--- a/tests/security/cli_boundary_test.go
+++ b/tests/security/cli_boundary_test.go
@@ -40,6 +40,7 @@ func TestRepoSplitBoundary_CLICommandSurface(t *testing.T) {
 		"doctor":         {},
 		"print-config":   {},
 		"support-bundle": {},
+		"service":        {},
 		"version":        {},
 	}
 
@@ -178,6 +179,11 @@ func TestRepoSplitBoundary_InternalCLIFileOwnership(t *testing.T) {
 		"remote_commands.go":        {},
 		"routing_decision.go":       {},
 		"server_doctor.go":          {},
+		"service.go":                {},
+		"service_darwin.go":         {},
+		"service_darwin_test.go":    {},
+		"service_other.go":          {},
+		"service_test.go":           {},
 		"status.go":                 {},
 		"style.go":                  {},
 		"support_bundle.go":         {},


### PR DESCRIPTION
## Summary

A client's MCP server went `Server disconnected` after a laptop reboot. Root cause is two converging gaps that surface together on reboot:

1. **Daemon doesn't persist.** `dir2mcp up` double-forks a detached `setsid` daemon (`up_daemon.go`) reparented to launchd, but there's no LaunchAgent/login integration — nothing re-spawns it at boot. After reboot the daemon is simply gone (`dir2mcp down` → "no daemon registered").
2. **Credential doesn't persist** unless it's in `.env.local`. A `MISTRAL_API_KEY` that only lived as a shell `export` dies with the login session, so `dir2mcp up` then fails with `CONFIG_INVALID: no embedding provider configured`.

This PR adds `dir2mcp service install|uninstall|status`, which registers a **per-corpus macOS LaunchAgent** that supervises the daemon across reboots and crashes.

### How it works
- Runs `dir2mcp up --foreground` under launchd with `RunAtLoad` + `KeepAlive`. `--foreground` (`up.go`) runs the server in-process (no double-fork), so launchd can supervise it directly. `connection.json` is still published, so the existing MCP client entry reconnects; `dir2mcp status` (sqlite/corpus-snapshot based) is unaffected.
- `WorkingDirectory` is set to the corpus root. This is load-bearing twice over: it indexes the right directory **and** makes the booted daemon resolve credentials from `.env.local` (read cwd-relative by `loadDotEnvFiles`), which matters because launchd does **not** inherit shell `export`s.
- Label is `com.dirstral.<server-name>`, reusing the stable per-corpus `identity.AutoServerName` (slug + path hash).
- `install` runs a **credential preflight** and warns (does not block) when no persisted credential is found in `.env.local`/`.env`, pointing the operator at `dir2mcp config init` — closing the exact trap the client hit.
- Idempotent install (`bootout` → `bootstrap` → `kickstart -k`); `uninstall` unloads and removes the plist; `status` reports installed/running.

### Scope
- macOS/launchd only this PR. Non-darwin returns a clear unsupported error (`service_other.go`); a **Linux systemd user-unit** backend is a planned follow-up behind the same `serviceManager` interface.
- CLI/operator concern only — no MCP tool/spec surface change. Added to the canonical command map + repo-split boundary allowlist accordingly.

## Test plan
- [x] `make check` green (build, vet, gocyclo ≤ 15, full suite, python, release build)
- [x] Pure helpers unit-tested cross-platform: label derivation, plist rendering incl. XML escaping, `.env.local`/`.env` credential scanner, dispatch guard rails (`service_test.go`)
- [x] launchd backend tested via injected `runCmd` (darwin-tagged): install writes plist + issues `bootout`/`bootstrap`/`kickstart`; bootstrap failure surfaces; uninstall removes plist; status parses `state = running` (`service_darwin_test.go`)
- [x] Smoke: usage lists `service`; `service`/`service bogus` exit 2; `service status` reports not-installed via read-only `launchctl print`
- [ ] **Live launchd install/uninstall not exercised in CI** — the unit tests mock `launchctl` (a real run mutates the login session). Recommend a manual install→reboot→`status` pass before relying on it in the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `service` subcommand with `install`, `uninstall`, and `status` to manage an auto-start agent on macOS.

* **Documentation**
  * README updated with service command docs and an “Auto-start at login (macOS)” guide, including note about persisted credentials required for the agent.

* **Platform**
  * Service management is available on macOS; other platforms report unsupported.

* **Tests**
  * Added tests covering macOS agent install/uninstall/status and related validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dirstral/dir2mcp/pull/214?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->