### PR TITLE
style: gofmt -s simplify in elevenlabsbridge

### DIFF
--- a/internal/elevenlabsbridge/server.go
+++ b/internal/elevenlabsbridge/server.go
@@ -83,7 +83,7 @@ func (b *bridge) routes() {
 }
 
 func (b *bridge) methodGuard(allowed string, fn http.HandlerFunc, extra ...string) http.HandlerFunc {
-	allowedMethods := map[string]struct{}{allowed: struct{}{}}
+	allowedMethods := map[string]struct{}{allowed: {}}
 	for _, method := range extra {
 		allowedMethods[method] = struct{}{}
 	}


### PR DESCRIPTION
## What

Go Report Card flagged `internal/elevenlabsbridge/server.go` for `gofmt -s`.

```diff
-	allowedMethods := map[string]struct{}{allowed: struct{}{}}
+	allowedMethods := map[string]struct{}{allowed: {}}
```

The map literal value `struct{}{}` simplifies to `{}` because the element type is already given by the map type. This is the only file in the repo failing `gofmt -l -s .`.

## Verification

- `gofmt -l -s .` now returns clean
- `make check` passes locally (build + vet + all Go/python tests green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal HTTP request handling logic for improved code clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dirstral/dir2mcp/pull/215?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->