### PR TITLE
feat: structured docling extraction with region provenance (spec 0.9.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ vary by deployment. The commonly used variables are:
 |---|---|---|
 | `MISTRAL_API_KEY` | Conditional | Required for embeddings, Mistral-based extraction/STT, and generation; not required for docling-only read-only extraction flows |
 | `DIR2MCP_INGEST_EXTRACTOR` | No | Extraction provider mode: `auto` (default), `docling`, `mistral`, or `off` |
-| `DIR2MCP_DOCLING_COMMAND` | No | Optional local command template for document extraction (default: `docling --to md --output - {input}`); when set/available, it is preferred for PDF/image/office-style document extraction |
+| `DIR2MCP_DOCLING_COMMAND` | No | Optional local command template for document extraction (default: `docling --to json --output - {input}`); when set/available, it is preferred for PDF/image/office-style document extraction. The default requests structured JSON so ingestion preserves reading order, section hierarchy, and per-element page/bbox provenance (region citations); a custom `--to md` template still works and falls back to flat Markdown |
 | `MISTRAL_BASE_URL` | No | Mistral base URL (default: `https://api.mistral.ai`) |
 | `DIR2MCP_AUTH_TOKEN` | No | Auth token override |
 | `DIR2MCP_SERVER_NAME` | No | Override the MCP server name (and suggested `claude mcp add` alias). Defaults to a unique `dir2mcp-<slug>-<6-hex>` derived from the indexed directory |
@@ -229,7 +229,7 @@ For Homebrew and other installed workflows, you can persist this in `.dir2mcp.ya
 
 ```yaml
 ingest_extractor: auto
-docling_command: docling --to md --output - {input}
+docling_command: docling --to json --output - {input}
 ```
 
 ### Server identity

--- a/internal/ingest/docling/docling_test.go
+++ b/internal/ingest/docling/docling_test.go
@@ -1,0 +1,233 @@
+package docling
+
+import (
+	"strings"
+	"testing"
+)
+
+// sampleDoc is a small DoclingDocument exercising the structures dir2mcp
+// linearizes: a title, nested section headers, paragraphs with provenance, a
+// list item, a table with a caption, and a figure with a caption + annotation.
+// Reading order is driven by body.children (intentionally not the order of the
+// texts array) so the test pins that references — not array order — win.
+const sampleDoc = `{
+  "schema_name": "DoclingDocument",
+  "version": "1.2.0",
+  "name": "Quarterly Report",
+  "pages": { "1": { "size": { "width": 612, "height": 792 }, "page_no": 1 } },
+  "body": { "self_ref": "#/body", "children": [
+    { "$ref": "#/texts/0" },
+    { "$ref": "#/texts/1" },
+    { "$ref": "#/texts/2" },
+    { "$ref": "#/texts/3" },
+    { "$ref": "#/texts/4" },
+    { "$ref": "#/tables/0" },
+    { "$ref": "#/pictures/0" }
+  ]},
+  "texts": [
+    { "self_ref": "#/texts/0", "label": "title", "text": "Quarterly Report",
+      "prov": [{ "page_no": 1, "bbox": { "l": 72, "t": 700, "r": 540, "b": 720, "coord_origin": "BOTTOMLEFT" }, "charspan": [0, 16] }] },
+    { "self_ref": "#/texts/1", "label": "section_header", "level": 1, "text": "Results",
+      "prov": [{ "page_no": 1, "bbox": { "l": 72, "t": 650, "r": 300, "b": 670, "coord_origin": "BOTTOMLEFT" }}] },
+    { "self_ref": "#/texts/2", "label": "section_header", "level": 2, "text": "Revenue",
+      "prov": [{ "page_no": 1, "bbox": { "l": 72, "t": 620, "r": 280, "b": 635, "coord_origin": "BOTTOMLEFT" }}] },
+    { "self_ref": "#/texts/3", "label": "paragraph", "text": "Revenue grew 20% year over year.",
+      "prov": [{ "page_no": 1, "bbox": { "l": 72, "t": 590, "r": 500, "b": 610, "coord_origin": "BOTTOMLEFT" }}] },
+    { "self_ref": "#/texts/4", "label": "list_item", "text": "North America led growth.",
+      "prov": [{ "page_no": 1, "bbox": { "l": 90, "t": 560, "r": 480, "b": 575, "coord_origin": "BOTTOMLEFT" }}] },
+    { "self_ref": "#/texts/5", "label": "caption", "text": "Table 1: Revenue by region." }
+  ],
+  "tables": [
+    { "self_ref": "#/tables/0", "label": "table",
+      "captions": [{ "$ref": "#/texts/5" }],
+      "prov": [{ "page_no": 1, "bbox": { "l": 72, "t": 400, "r": 540, "b": 540, "coord_origin": "BOTTOMLEFT" }}],
+      "data": { "num_rows": 2, "num_cols": 2, "table_cells": [
+        { "text": "Region", "start_row_offset_idx": 0, "end_row_offset_idx": 1, "start_col_offset_idx": 0, "end_col_offset_idx": 1, "column_header": true },
+        { "text": "Revenue", "start_row_offset_idx": 0, "end_row_offset_idx": 1, "start_col_offset_idx": 1, "end_col_offset_idx": 2, "column_header": true },
+        { "text": "NA", "start_row_offset_idx": 1, "end_row_offset_idx": 2, "start_col_offset_idx": 0, "end_col_offset_idx": 1 },
+        { "text": "$5M", "start_row_offset_idx": 1, "end_row_offset_idx": 2, "start_col_offset_idx": 1, "end_col_offset_idx": 2 }
+      ]}}
+  ],
+  "pictures": [
+    { "self_ref": "#/pictures/0", "label": "picture",
+      "captions": [],
+      "annotations": [{ "kind": "classification", "predicted_class": "bar_chart" }],
+      "prov": [{ "page_no": 1, "bbox": { "l": 72, "t": 200, "r": 540, "b": 380, "coord_origin": "BOTTOMLEFT" }}] }
+  ]
+}`
+
+func TestParse_RejectsMalformed(t *testing.T) {
+	if _, err := Parse([]byte("not json")); err == nil {
+		t.Fatal("expected error for non-JSON input")
+	}
+	if _, err := Parse([]byte(`{"body": {"children": []}}`)); err == nil {
+		t.Fatal("expected error for empty body")
+	}
+}
+
+func TestLinearize_ReadingOrderAndBlocks(t *testing.T) {
+	doc, err := Parse([]byte(sampleDoc))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	blocks := doc.Linearize()
+
+	// title, Results, Revenue, paragraph, list_item, table, picture = 7
+	if len(blocks) != 7 {
+		t.Fatalf("expected 7 blocks, got %d: %+v", len(blocks), labels(blocks))
+	}
+	wantLabels := []string{
+		LabelTitle, LabelSectionHeader, LabelSectionHeader,
+		LabelParagraph, LabelListItem, LabelTable, LabelPicture,
+	}
+	for i, want := range wantLabels {
+		if blocks[i].Label != want {
+			t.Errorf("block %d label = %q, want %q", i, blocks[i].Label, want)
+		}
+	}
+}
+
+func TestLinearize_SectionBreadcrumb(t *testing.T) {
+	doc, _ := Parse([]byte(sampleDoc))
+	blocks := doc.Linearize()
+
+	// The paragraph sits under Results > Revenue.
+	para := blockByText(blocks, "Revenue grew 20% year over year.")
+	if para == nil {
+		t.Fatal("paragraph block not found")
+	}
+	got := strings.Join(para.Section, " > ")
+	if got != "Results > Revenue" {
+		t.Errorf("paragraph breadcrumb = %q, want %q", got, "Results > Revenue")
+	}
+
+	// The level-2 header itself sits under Results (its breadcrumb excludes
+	// itself).
+	rev := blockByText(blocks, "Revenue")
+	if rev == nil || len(rev.Section) != 1 || rev.Section[0] != "Results" {
+		t.Errorf("Revenue header breadcrumb = %v, want [Results]", sectionOf(rev))
+	}
+
+	// The level-1 header has no parent section.
+	res := blockByText(blocks, "Results")
+	if res == nil || len(res.Section) != 0 {
+		t.Errorf("Results header breadcrumb = %v, want []", sectionOf(res))
+	}
+}
+
+func TestLinearize_ProvenanceNormalizedToTopLeft(t *testing.T) {
+	doc, _ := Parse([]byte(sampleDoc))
+	blocks := doc.Linearize()
+	para := blockByText(blocks, "Revenue grew 20% year over year.")
+	if para == nil || para.BBox == nil {
+		t.Fatal("paragraph bbox missing")
+	}
+	if para.Page != 1 {
+		t.Errorf("page = %d, want 1", para.Page)
+	}
+	// Source was BOTTOMLEFT t=590,b=610 on a 792-tall page → TOPLEFT
+	// top = 792-610 = 182, bottom = 792-590 = 202.
+	if para.BBox.CoordOrigin != "TOPLEFT" {
+		t.Errorf("coord_origin = %q, want TOPLEFT", para.BBox.CoordOrigin)
+	}
+	if para.BBox.T != 182 || para.BBox.B != 202 {
+		t.Errorf("normalized bbox T/B = %v/%v, want 182/202", para.BBox.T, para.BBox.B)
+	}
+	if para.BBox.L != 72 || para.BBox.R != 500 {
+		t.Errorf("bbox L/R = %v/%v, want 72/500", para.BBox.L, para.BBox.R)
+	}
+}
+
+func TestTitle(t *testing.T) {
+	doc, _ := Parse([]byte(sampleDoc))
+	if got := doc.Title(); got != "Quarterly Report" {
+		t.Errorf("Title() = %q, want %q", got, "Quarterly Report")
+	}
+}
+
+func TestTableRendersAtomicallyWithCaption(t *testing.T) {
+	doc, _ := Parse([]byte(sampleDoc))
+	blocks := doc.Linearize()
+	var table *Block
+	for i := range blocks {
+		if blocks[i].Label == LabelTable {
+			table = &blocks[i]
+		}
+	}
+	if table == nil {
+		t.Fatal("table block not found")
+	}
+	for _, want := range []string{"| Region | Revenue |", "| --- | --- |", "| NA | $5M |", "Table 1: Revenue by region."} {
+		if !strings.Contains(table.Text, want) {
+			t.Errorf("table text missing %q:\n%s", want, table.Text)
+		}
+	}
+	// The caption must not also appear as its own standalone block.
+	if blockByText(blocks, "Table 1: Revenue by region.") != nil {
+		t.Error("caption leaked as a standalone block; should be folded into the table")
+	}
+}
+
+func TestPictureAnnotationIndexed(t *testing.T) {
+	doc, _ := Parse([]byte(sampleDoc))
+	blocks := doc.Linearize()
+	pic := blockByLabel(blocks, LabelPicture)
+	if pic == nil {
+		t.Fatal("picture block not found")
+	}
+	if !strings.Contains(pic.Text, "bar_chart") {
+		t.Errorf("picture text missing classification: %q", pic.Text)
+	}
+}
+
+func TestRenderMarkdown(t *testing.T) {
+	doc, _ := Parse([]byte(sampleDoc))
+	md := RenderMarkdown(doc.Linearize())
+	for _, want := range []string{
+		"# Quarterly Report",
+		"# Results",
+		"## Revenue",
+		"Revenue grew 20% year over year.",
+		"- North America led growth.",
+		"| Region | Revenue |",
+	} {
+		if !strings.Contains(md, want) {
+			t.Errorf("rendered markdown missing %q:\n%s", want, md)
+		}
+	}
+}
+
+// --- helpers ---
+
+func labels(bs []Block) []string {
+	out := make([]string, len(bs))
+	for i, b := range bs {
+		out[i] = b.Label
+	}
+	return out
+}
+
+func blockByText(bs []Block, text string) *Block {
+	for i := range bs {
+		if strings.TrimSpace(bs[i].Text) == text {
+			return &bs[i]
+		}
+	}
+	return nil
+}
+
+func blockByLabel(bs []Block, label string) *Block {
+	for i := range bs {
+		if bs[i].Label == label {
+			return &bs[i]
+		}
+	}
+	return nil
+}
+
+func sectionOf(b *Block) []string {
+	if b == nil {
+		return nil
+	}
+	return b.Section
+}

--- a/internal/ingest/docling/document.go
+++ b/internal/ingest/docling/document.go
@@ -1,0 +1,212 @@
+// Package docling parses the structured DoclingDocument JSON emitted by
+// `docling --to json` and linearizes it into an ordered sequence of blocks
+// that preserve reading order, the section-heading hierarchy, and per-element
+// provenance (page + bounding box). This is the structure that flat Markdown
+// extraction discards; dir2mcp carries it through to `region` spans and
+// region-accurate citations (see dirstral-spec §5.4, §7.4.B).
+package docling
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Document is the subset of the DoclingDocument model that dir2mcp consumes.
+// Unknown fields are tolerated (docling evolves its schema): only the parts we
+// linearize are modeled, and the document version/schema name are retained so
+// callers can guard against incompatible drift.
+type Document struct {
+	SchemaName string              `json:"schema_name"`
+	Version    string              `json:"version"`
+	Name       string              `json:"name"`
+	Origin     *origin             `json:"origin"`
+	Body       *node               `json:"body"`
+	Furniture  *node               `json:"furniture"`
+	Groups     []*node             `json:"groups"`
+	Texts      []*textItem         `json:"texts"`
+	Tables     []*tableItem        `json:"tables"`
+	Pictures   []*pictureItem      `json:"pictures"`
+	Pages      map[string]pageInfo `json:"pages"`
+}
+
+type origin struct {
+	Filename string `json:"filename"`
+	MIMEType string `json:"mimetype"`
+}
+
+type pageInfo struct {
+	Size *struct {
+		Width  float64 `json:"width"`
+		Height float64 `json:"height"`
+	} `json:"size"`
+	PageNo int `json:"page_no"`
+}
+
+// node is the common shape of body/furniture/group containers: a self
+// reference plus an ordered list of child references that drive reading order.
+type node struct {
+	SelfRef  string     `json:"self_ref"`
+	Label    string     `json:"label"`
+	Children []*refItem `json:"children"`
+}
+
+// refItem is an internal reference. Docling has used both "$ref" and "cref"
+// across versions; we accept either.
+type refItem struct {
+	Ref  string `json:"$ref"`
+	CRef string `json:"cref"`
+}
+
+func (r *refItem) target() string {
+	if r == nil {
+		return ""
+	}
+	if strings.TrimSpace(r.Ref) != "" {
+		return r.Ref
+	}
+	return r.CRef
+}
+
+// textItem covers paragraphs, headings, list items, code, formulas, captions —
+// anything with a textual representation.
+type textItem struct {
+	SelfRef string `json:"self_ref"`
+	Label   string `json:"label"`
+	Text    string `json:"text"`
+	Orig    string `json:"orig"`
+	Level   int    `json:"level"`
+	Prov    []prov `json:"prov"`
+}
+
+type tableItem struct {
+	SelfRef  string     `json:"self_ref"`
+	Label    string     `json:"label"`
+	Data     *tableData `json:"data"`
+	Captions []*refItem `json:"captions"`
+	Prov     []prov     `json:"prov"`
+}
+
+type tableData struct {
+	NumRows    int           `json:"num_rows"`
+	NumCols    int           `json:"num_cols"`
+	Grid       [][]tableCell `json:"grid"`
+	TableCells []tableCell   `json:"table_cells"`
+}
+
+type tableCell struct {
+	Text           string `json:"text"`
+	RowSpan        int    `json:"row_span"`
+	ColSpan        int    `json:"col_span"`
+	StartRowOffset int    `json:"start_row_offset_idx"`
+	EndRowOffset   int    `json:"end_row_offset_idx"`
+	StartColOffset int    `json:"start_col_offset_idx"`
+	EndColOffset   int    `json:"end_col_offset_idx"`
+	ColumnHeader   bool   `json:"column_header"`
+	RowHeader      bool   `json:"row_header"`
+}
+
+type pictureItem struct {
+	SelfRef     string       `json:"self_ref"`
+	Label       string       `json:"label"`
+	Captions    []*refItem   `json:"captions"`
+	Annotations []annotation `json:"annotations"`
+	Prov        []prov       `json:"prov"`
+}
+
+// annotation carries enrichment output (e.g. picture classification or a
+// generated description). Docling shapes vary by annotation kind; we read the
+// fields commonly present and ignore the rest.
+type annotation struct {
+	Kind           string `json:"kind"`
+	Text           string `json:"text"`
+	PredictedClass string `json:"predicted_class"`
+}
+
+func (a annotation) describe() string {
+	if t := strings.TrimSpace(a.Text); t != "" {
+		return t
+	}
+	return strings.TrimSpace(a.PredictedClass)
+}
+
+type prov struct {
+	PageNo   int      `json:"page_no"`
+	BBox     *rawBBox `json:"bbox"`
+	CharSpan []int    `json:"charspan"`
+}
+
+type rawBBox struct {
+	L           float64 `json:"l"`
+	T           float64 `json:"t"`
+	R           float64 `json:"r"`
+	B           float64 `json:"b"`
+	CoordOrigin string  `json:"coord_origin"`
+}
+
+// Parse decodes DoclingDocument JSON. It returns an error for malformed JSON or
+// for a payload that lacks the structural minimum (a body with children); the
+// caller falls back to flat extraction in that case.
+func Parse(data []byte) (*Document, error) {
+	var doc Document
+	dec := json.NewDecoder(strings.NewReader(string(data)))
+	if err := dec.Decode(&doc); err != nil {
+		return nil, fmt.Errorf("parse docling document: %w", err)
+	}
+	if doc.Body == nil || len(doc.Body.Children) == 0 {
+		return nil, fmt.Errorf("docling document has no body content")
+	}
+	return &doc, nil
+}
+
+// resolveText returns the textItem for a "#/texts/N" reference, or nil.
+func (d *Document) resolveText(target string) *textItem {
+	if i, ok := refIndex(target, "texts"); ok && i >= 0 && i < len(d.Texts) {
+		return d.Texts[i]
+	}
+	return nil
+}
+
+// pageHeight returns the height of a page (for TOPLEFT normalization), or 0 if
+// unknown. Docling keys the pages map by stringified page number.
+func (d *Document) pageHeight(pageNo int) float64 {
+	if d.Pages == nil {
+		return 0
+	}
+	if p, ok := d.Pages[strconv.Itoa(pageNo)]; ok && p.Size != nil {
+		return p.Size.Height
+	}
+	return 0
+}
+
+// refIndex parses a reference like "#/texts/3" into (3, true) when its
+// collection matches want.
+func refIndex(target, want string) (int, bool) {
+	parts := strings.Split(strings.TrimPrefix(target, "#/"), "/")
+	if len(parts) != 2 || parts[0] != want {
+		return 0, false
+	}
+	i, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, false
+	}
+	return i, true
+}
+
+// refCollection returns the collection name of a reference ("texts", "tables",
+// "pictures", "groups", "body", …) and its index.
+func refCollection(target string) (string, int) {
+	parts := strings.Split(strings.TrimPrefix(target, "#/"), "/")
+	if len(parts) == 0 {
+		return "", -1
+	}
+	if len(parts) == 1 {
+		return parts[0], -1
+	}
+	i, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return parts[0], -1
+	}
+	return parts[0], i
+}

--- a/internal/ingest/docling/linearize.go
+++ b/internal/ingest/docling/linearize.go
@@ -1,0 +1,370 @@
+package docling
+
+import "strings"
+
+// BBox is a bounding box in the source document's point space. CoordOrigin
+// records the origin actually stored ("TOPLEFT" or "BOTTOMLEFT"), matching
+// dirstral-spec §5.4.
+type BBox struct {
+	Page        int     `json:"page"`
+	L           float64 `json:"l"`
+	T           float64 `json:"t"`
+	R           float64 `json:"r"`
+	B           float64 `json:"b"`
+	CoordOrigin string  `json:"coord_origin"`
+}
+
+// Block is one element in reading order with its provenance and the active
+// section breadcrumb. Label is normalized to the spec's discrete set:
+// paragraph, section_header, list_item, table, caption, code, formula,
+// picture, title.
+type Block struct {
+	Label    string
+	Text     string
+	Level    int      // heading level for section_header/title
+	Page     int      // primary page (first prov page); 0 when unknown
+	BBox     *BBox    // union on the primary page; nil when no provenance
+	Section  []string // heading breadcrumb (outermost first), excludes self
+	CharSpan []int    // optional char offsets into the source element
+}
+
+const (
+	LabelParagraph     = "paragraph"
+	LabelSectionHeader = "section_header"
+	LabelListItem      = "list_item"
+	LabelTable         = "table"
+	LabelCaption       = "caption"
+	LabelCode          = "code"
+	LabelFormula       = "formula"
+	LabelPicture       = "picture"
+	LabelTitle         = "title"
+)
+
+// normalizeLabel maps docling's DocItemLabel values onto the spec's discrete
+// label set. Unknown labels degrade to paragraph so their text is still
+// indexed.
+func normalizeLabel(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "title":
+		return LabelTitle
+	case "section_header", "subtitle-level-1":
+		return LabelSectionHeader
+	case "list_item":
+		return LabelListItem
+	case "table":
+		return LabelTable
+	case "caption":
+		return LabelCaption
+	case "code":
+		return LabelCode
+	case "formula":
+		return LabelFormula
+	case "picture":
+		return LabelPicture
+	case "paragraph", "text", "":
+		return LabelParagraph
+	default:
+		return LabelParagraph
+	}
+}
+
+// Title returns the document title from the first title-labeled text element,
+// falling back to the document name. Empty when neither is present.
+func (d *Document) Title() string {
+	for _, t := range d.Texts {
+		if t != nil && normalizeLabel(t.Label) == LabelTitle {
+			if s := strings.TrimSpace(t.Text); s != "" {
+				return s
+			}
+		}
+	}
+	return strings.TrimSpace(d.Name)
+}
+
+// headingFrame tracks one open section in the breadcrumb stack.
+type headingFrame struct {
+	level int
+	text  string
+}
+
+// Linearize walks the body tree in reading order, resolving references and
+// recursing into groups, and returns the ordered blocks. It threads the
+// section-heading breadcrumb so every block beneath a heading carries it, and
+// attaches per-element provenance (primary page + union bbox).
+func (d *Document) Linearize() []Block {
+	w := &walker{doc: d, seen: map[string]bool{}}
+	w.walk(d.Body)
+	return w.blocks
+}
+
+type walker struct {
+	doc    *Document
+	blocks []Block
+	stack  []headingFrame // open headings, shallowest first
+	seen   map[string]bool
+}
+
+func (w *walker) breadcrumb() []string {
+	if len(w.stack) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(w.stack))
+	for _, f := range w.stack {
+		out = append(out, f.text)
+	}
+	return out
+}
+
+// pushHeading updates the breadcrumb stack: a heading at level L closes any
+// open headings at level >= L before becoming the new deepest frame.
+func (w *walker) pushHeading(level int, text string) {
+	if level <= 0 {
+		level = 1
+	}
+	for len(w.stack) > 0 && w.stack[len(w.stack)-1].level >= level {
+		w.stack = w.stack[:len(w.stack)-1]
+	}
+	w.stack = append(w.stack, headingFrame{level: level, text: text})
+}
+
+func (w *walker) walk(n *node) {
+	if n == nil {
+		return
+	}
+	for _, child := range n.Children {
+		w.visit(child.target())
+	}
+}
+
+func (w *walker) visit(target string) {
+	if target == "" || w.seen[target] {
+		return
+	}
+	coll, idx := refCollection(target)
+	switch coll {
+	case "texts":
+		if idx >= 0 && idx < len(w.doc.Texts) {
+			w.seen[target] = true
+			w.emitText(w.doc.Texts[idx])
+		}
+	case "tables":
+		if idx >= 0 && idx < len(w.doc.Tables) {
+			w.seen[target] = true
+			w.emitTable(w.doc.Tables[idx])
+		}
+	case "pictures":
+		if idx >= 0 && idx < len(w.doc.Pictures) {
+			w.seen[target] = true
+			w.emitPicture(w.doc.Pictures[idx])
+		}
+	case "groups":
+		if idx >= 0 && idx < len(w.doc.Groups) {
+			w.seen[target] = true
+			w.walk(w.doc.Groups[idx]) // groups hold no content; recurse for order
+		}
+	}
+}
+
+func (w *walker) emitText(t *textItem) {
+	if t == nil {
+		return
+	}
+	label := normalizeLabel(t.Label)
+	text := strings.TrimSpace(t.Text)
+	if text == "" {
+		text = strings.TrimSpace(t.Orig)
+	}
+
+	if label == LabelTitle {
+		// The document title is metadata, not a section: it is emitted as a
+		// block (and feeds documents.title) but does NOT enter the section
+		// breadcrumb stack, so content beneath it is not nested under the title.
+		page, bbox := primaryProv(t.Prov, w.doc)
+		w.blocks = append(w.blocks, Block{
+			Label:    LabelTitle,
+			Text:     text,
+			Level:    t.Level,
+			Page:     page,
+			BBox:     bbox,
+			Section:  w.breadcrumb(),
+			CharSpan: charSpan(t.Prov),
+		})
+		return
+	}
+
+	if label == LabelSectionHeader {
+		// Section headers update the breadcrumb using their declared level.
+		level := t.Level
+		page, bbox := primaryProv(t.Prov, w.doc)
+		// The heading's own breadcrumb is the context it sits under (computed
+		// before it is pushed), so it is not self-referential.
+		w.blocks = append(w.blocks, Block{
+			Label:    LabelSectionHeader,
+			Text:     text,
+			Level:    level,
+			Page:     page,
+			BBox:     bbox,
+			Section:  w.breadcrumb(),
+			CharSpan: charSpan(t.Prov),
+		})
+		if text != "" {
+			w.pushHeading(level, text)
+		}
+		return
+	}
+
+	if text == "" {
+		return
+	}
+	page, bbox := primaryProv(t.Prov, w.doc)
+	w.blocks = append(w.blocks, Block{
+		Label:    label,
+		Text:     text,
+		Page:     page,
+		BBox:     bbox,
+		Section:  w.breadcrumb(),
+		CharSpan: charSpan(t.Prov),
+	})
+}
+
+func (w *walker) emitTable(t *tableItem) {
+	if t == nil {
+		return
+	}
+	md := renderTableMarkdown(t.Data)
+	if cap := w.captionText(t.Captions); cap != "" {
+		md = strings.TrimRight(md, "\n") + "\n\n" + cap
+	}
+	if strings.TrimSpace(md) == "" {
+		return
+	}
+	page, bbox := primaryProv(t.Prov, w.doc)
+	w.blocks = append(w.blocks, Block{
+		Label:   LabelTable,
+		Text:    md,
+		Page:    page,
+		BBox:    bbox,
+		Section: w.breadcrumb(),
+	})
+}
+
+func (w *walker) emitPicture(p *pictureItem) {
+	if p == nil {
+		return
+	}
+	var parts []string
+	if cap := w.captionText(p.Captions); cap != "" {
+		parts = append(parts, cap)
+	}
+	for _, a := range p.Annotations {
+		if d := a.describe(); d != "" {
+			parts = append(parts, d)
+		}
+	}
+	if len(parts) == 0 {
+		return // a figure with no caption/annotation carries no searchable text
+	}
+	page, bbox := primaryProv(p.Prov, w.doc)
+	w.blocks = append(w.blocks, Block{
+		Label:   LabelPicture,
+		Text:    strings.Join(parts, "\n\n"),
+		Page:    page,
+		BBox:    bbox,
+		Section: w.breadcrumb(),
+	})
+}
+
+func (w *walker) captionText(refs []*refItem) string {
+	var parts []string
+	for _, r := range refs {
+		if t := w.doc.resolveText(r.target()); t != nil {
+			if s := strings.TrimSpace(t.Text); s != "" {
+				parts = append(parts, s)
+				w.seen[r.target()] = true // don't also emit the caption standalone
+			}
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+// primaryProv returns the primary page (first provenance entry's page) and the
+// union bbox of all provenance entries on that page, normalized to TOPLEFT when
+// the page height is known. Returns (0, nil) when there is no provenance.
+func primaryProv(provs []prov, d *Document) (int, *BBox) {
+	first := -1
+	for _, p := range provs {
+		if p.PageNo > 0 {
+			first = p.PageNo
+			break
+		}
+	}
+	if first < 0 {
+		return 0, nil
+	}
+	var union *BBox
+	for _, p := range provs {
+		if p.PageNo != first || p.BBox == nil {
+			continue
+		}
+		b := normalizeBBox(first, p.BBox, d.pageHeight(first))
+		if union == nil {
+			union = &b
+			continue
+		}
+		union.L = min64(union.L, b.L)
+		union.T = min64(union.T, b.T)
+		union.R = max64(union.R, b.R)
+		union.B = max64(union.B, b.B)
+	}
+	return first, union
+}
+
+// normalizeBBox converts a docling bbox to TOPLEFT origin when pageHeight is
+// known; otherwise it preserves the reported origin (per spec: SHOULD
+// normalize, MUST record the origin actually stored). The returned box always
+// has L<=R and T<=B in the stored coordinate space.
+func normalizeBBox(page int, raw *rawBBox, pageHeight float64) BBox {
+	origin := strings.ToUpper(strings.TrimSpace(raw.CoordOrigin))
+	if origin == "" {
+		origin = "TOPLEFT"
+	}
+	l, r := minmax(raw.L, raw.R)
+	if origin == "BOTTOMLEFT" && pageHeight > 0 {
+		// Flip vertical axis: top = H - b, bottom = H - t.
+		top := pageHeight - max64(raw.T, raw.B)
+		bot := pageHeight - min64(raw.T, raw.B)
+		return BBox{Page: page, L: l, T: top, R: r, B: bot, CoordOrigin: "TOPLEFT"}
+	}
+	t, b := minmax(raw.T, raw.B)
+	return BBox{Page: page, L: l, T: t, R: r, B: b, CoordOrigin: origin}
+}
+
+func charSpan(provs []prov) []int {
+	for _, p := range provs {
+		if len(p.CharSpan) == 2 {
+			return []int{p.CharSpan[0], p.CharSpan[1]}
+		}
+	}
+	return nil
+}
+
+func minmax(a, b float64) (float64, float64) {
+	if a <= b {
+		return a, b
+	}
+	return b, a
+}
+
+func min64(a, b float64) float64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func max64(a, b float64) float64 {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/internal/ingest/docling/linearize.go
+++ b/internal/ingest/docling/linearize.go
@@ -278,7 +278,13 @@ func (w *walker) captionText(refs []*refItem) string {
 	var parts []string
 	for _, r := range refs {
 		if t := w.doc.resolveText(r.target()); t != nil {
-			if s := strings.TrimSpace(t.Text); s != "" {
+			// Mirror emitText's Text-or-Orig fallback so captions are not lost
+			// when docling populates only orig.
+			s := strings.TrimSpace(t.Text)
+			if s == "" {
+				s = strings.TrimSpace(t.Orig)
+			}
+			if s != "" {
 				parts = append(parts, s)
 				w.seen[r.target()] = true // don't also emit the caption standalone
 			}

--- a/internal/ingest/docling/render.go
+++ b/internal/ingest/docling/render.go
@@ -1,0 +1,142 @@
+package docling
+
+import (
+	"strings"
+)
+
+// RenderMarkdown linearizes the document to Markdown in reading order. This is
+// the text persisted as the extracted_markdown representation (dirstral-spec
+// §7.4.B "What is persisted"): structure is rendered to Markdown here, while
+// page/bbox/section provenance travels separately on the blocks (and onward to
+// region spans). Headings render as ATX (`#`) by level, tables as Markdown
+// tables, everything else as paragraphs.
+func RenderMarkdown(blocks []Block) string {
+	var b strings.Builder
+	for i, blk := range blocks {
+		if i > 0 {
+			b.WriteString("\n\n")
+		}
+		switch blk.Label {
+		case LabelTitle:
+			b.WriteString("# ")
+			b.WriteString(blk.Text)
+		case LabelSectionHeader:
+			level := blk.Level
+			if level < 1 {
+				level = 1
+			}
+			if level > 6 {
+				level = 6
+			}
+			b.WriteString(strings.Repeat("#", level))
+			b.WriteString(" ")
+			b.WriteString(blk.Text)
+		case LabelListItem:
+			b.WriteString("- ")
+			b.WriteString(blk.Text)
+		case LabelCode:
+			b.WriteString("```\n")
+			b.WriteString(strings.TrimRight(blk.Text, "\n"))
+			b.WriteString("\n```")
+		default:
+			// paragraph, table (already Markdown), caption, formula, picture
+			b.WriteString(blk.Text)
+		}
+	}
+	return b.String()
+}
+
+// renderTableMarkdown converts docling TableData into a GitHub-flavored
+// Markdown table. It reconstructs a row/column grid from the cells, honoring
+// row/column offsets, and treats the first row as the header when any cell in
+// it is flagged as a column header. Empty or malformed table data yields "".
+func renderTableMarkdown(d *tableData) string {
+	if d == nil {
+		return ""
+	}
+	cells := flattenCells(d)
+	if len(cells) == 0 {
+		return ""
+	}
+
+	nRows, nCols := d.NumRows, d.NumCols
+	for _, c := range cells {
+		if c.EndRowOffset > nRows {
+			nRows = c.EndRowOffset
+		}
+		if c.EndColOffset > nCols {
+			nCols = c.EndColOffset
+		}
+	}
+	if nRows <= 0 || nCols <= 0 {
+		return ""
+	}
+
+	grid := make([][]string, nRows)
+	for r := range grid {
+		grid[r] = make([]string, nCols)
+	}
+	headerRow := -1
+	for _, c := range cells {
+		r := c.StartRowOffset
+		col := c.StartColOffset
+		if r < 0 || r >= nRows || col < 0 || col >= nCols {
+			continue
+		}
+		grid[r][col] = sanitizeCell(c.Text)
+		if c.ColumnHeader && (headerRow == -1 || r < headerRow) {
+			headerRow = r
+		}
+	}
+	if headerRow == -1 {
+		headerRow = 0
+	}
+
+	var b strings.Builder
+	writeRow := func(row []string) {
+		b.WriteString("|")
+		for _, cell := range row {
+			b.WriteString(" ")
+			b.WriteString(cell)
+			b.WriteString(" |")
+		}
+		b.WriteString("\n")
+	}
+	writeRow(grid[headerRow])
+	// separator
+	b.WriteString("|")
+	for c := 0; c < nCols; c++ {
+		b.WriteString(" --- |")
+	}
+	b.WriteString("\n")
+	for r := 0; r < nRows; r++ {
+		if r == headerRow {
+			continue
+		}
+		writeRow(grid[r])
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// flattenCells returns the table cells from whichever representation docling
+// populated: the flat table_cells list, or the 2D grid.
+func flattenCells(d *tableData) []tableCell {
+	if len(d.TableCells) > 0 {
+		return d.TableCells
+	}
+	var out []tableCell
+	for _, row := range d.Grid {
+		out = append(out, row...)
+	}
+	return out
+}
+
+// sanitizeCell makes cell text safe for a single Markdown table cell: newlines
+// become spaces and pipes are escaped so they don't break the column layout.
+func sanitizeCell(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", " ")
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r", " ")
+	s = strings.ReplaceAll(s, "|", "\\|")
+	return strings.TrimSpace(s)
+}

--- a/internal/ingest/docling/render.go
+++ b/internal/ingest/docling/render.go
@@ -58,7 +58,17 @@ func renderTableMarkdown(d *tableData) string {
 	if len(cells) == 0 {
 		return ""
 	}
+	nRows, nCols := tableDimensions(d, cells)
+	if nRows <= 0 || nCols <= 0 {
+		return ""
+	}
+	grid, headerRow := buildTableGrid(cells, nRows, nCols)
+	return renderGridMarkdown(grid, headerRow, nCols)
+}
 
+// tableDimensions returns the row/column count, expanding the declared
+// num_rows/num_cols to cover any cell offsets that exceed them.
+func tableDimensions(d *tableData, cells []tableCell) (int, int) {
 	nRows, nCols := d.NumRows, d.NumCols
 	for _, c := range cells {
 		if c.EndRowOffset > nRows {
@@ -68,18 +78,20 @@ func renderTableMarkdown(d *tableData) string {
 			nCols = c.EndColOffset
 		}
 	}
-	if nRows <= 0 || nCols <= 0 {
-		return ""
-	}
+	return nRows, nCols
+}
 
+// buildTableGrid places cells into a 2D grid by their start offsets and returns
+// the grid plus the chosen header row (the topmost row with a column-header
+// cell, or 0 when none is flagged).
+func buildTableGrid(cells []tableCell, nRows, nCols int) ([][]string, int) {
 	grid := make([][]string, nRows)
 	for r := range grid {
 		grid[r] = make([]string, nCols)
 	}
 	headerRow := -1
 	for _, c := range cells {
-		r := c.StartRowOffset
-		col := c.StartColOffset
+		r, col := c.StartRowOffset, c.StartColOffset
 		if r < 0 || r >= nRows || col < 0 || col >= nCols {
 			continue
 		}
@@ -91,7 +103,12 @@ func renderTableMarkdown(d *tableData) string {
 	if headerRow == -1 {
 		headerRow = 0
 	}
+	return grid, headerRow
+}
 
+// renderGridMarkdown emits a GitHub-flavored Markdown table: the header row, a
+// separator, then the remaining rows in order.
+func renderGridMarkdown(grid [][]string, headerRow, nCols int) string {
 	var b strings.Builder
 	writeRow := func(row []string) {
 		b.WriteString("|")
@@ -103,13 +120,12 @@ func renderTableMarkdown(d *tableData) string {
 		b.WriteString("\n")
 	}
 	writeRow(grid[headerRow])
-	// separator
 	b.WriteString("|")
 	for c := 0; c < nCols; c++ {
 		b.WriteString(" --- |")
 	}
 	b.WriteString("\n")
-	for r := 0; r < nRows; r++ {
+	for r := 0; r < len(grid); r++ {
 		if r == headerRow {
 			continue
 		}

--- a/internal/ingest/docling_extractor.go
+++ b/internal/ingest/docling_extractor.go
@@ -9,9 +9,16 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/dirstral/dir2mcp/internal/ingest/docling"
 )
 
-const defaultDoclingCommand = "docling --to md --output - {input}"
+// defaultDoclingCommand requests structured JSON (DoclingDocument) so the
+// pipeline can preserve reading order, section hierarchy, and per-element
+// page/bbox provenance (spec 0.9.0 §7.4.B). When a custom docling_command
+// emits flat Markdown instead, Extract transparently falls back to treating
+// the output as Markdown.
+const defaultDoclingCommand = "docling --to json --output - {input}"
 
 const (
 	maxDoclingStdoutBytes = 100 * 1024 * 1024
@@ -47,7 +54,27 @@ func NewDoclingExtractor(commandTemplate string) *doclingExtractor {
 	return &doclingExtractor{commandTemplate: tpl}
 }
 
-func (d *doclingExtractor) Extract(ctx context.Context, relPath string, data []byte) (string, error) {
+// StructuredExtraction is the result of structured docling extraction: the
+// rendered Markdown persisted as the extracted_markdown representation, the
+// ordered blocks (reading order + section breadcrumb + provenance) that drive
+// section-aware chunking and region spans, and the document title.
+type StructuredExtraction struct {
+	Markdown string
+	Blocks   []docling.Block
+	Title    string
+}
+
+// structuredExtractor is implemented by extractors that can emit a structured
+// document model. The ingest service type-asserts against it to choose the
+// structured path; extractors that only produce flat text (e.g. Mistral OCR)
+// do not implement it and use the page-separated path.
+type structuredExtractor interface {
+	ExtractStructured(ctx context.Context, relPath string, data []byte) (StructuredExtraction, error)
+}
+
+// run executes the configured docling command against data and returns the
+// trimmed stdout.
+func (d *doclingExtractor) run(ctx context.Context, relPath string, data []byte) (string, error) {
 	ext := filepath.Ext(relPath)
 	if ext == "" {
 		ext = ".bin"
@@ -92,6 +119,42 @@ func (d *doclingExtractor) Extract(ctx context.Context, relPath string, data []b
 		return "", fmt.Errorf("docling command produced empty output")
 	}
 	return out, nil
+}
+
+// Extract returns Markdown suitable for chunking/indexing. When the command
+// emits a structured DoclingDocument (the default `--to json`), the document is
+// linearized to Markdown in reading order; when it emits flat Markdown (a
+// custom `--to md` command), the output is returned as-is.
+func (d *doclingExtractor) Extract(ctx context.Context, relPath string, data []byte) (string, error) {
+	out, err := d.run(ctx, relPath, data)
+	if err != nil {
+		return "", err
+	}
+	if doc, perr := docling.Parse([]byte(out)); perr == nil {
+		return docling.RenderMarkdown(doc.Linearize()), nil
+	}
+	// Not a DoclingDocument (custom --to md command): treat as flat Markdown.
+	return out, nil
+}
+
+// ExtractStructured runs the command and parses the structured DoclingDocument.
+// It returns an error when the output is not a parseable DoclingDocument, so
+// callers can fall back to the flat path.
+func (d *doclingExtractor) ExtractStructured(ctx context.Context, relPath string, data []byte) (StructuredExtraction, error) {
+	out, err := d.run(ctx, relPath, data)
+	if err != nil {
+		return StructuredExtraction{}, err
+	}
+	doc, err := docling.Parse([]byte(out))
+	if err != nil {
+		return StructuredExtraction{}, err
+	}
+	blocks := doc.Linearize()
+	return StructuredExtraction{
+		Markdown: docling.RenderMarkdown(blocks),
+		Blocks:   blocks,
+		Title:    doc.Title(),
+	}, nil
 }
 
 func buildDoclingCommandArgs(template, inputPath string) ([]string, error) {

--- a/internal/ingest/docling_extractor.go
+++ b/internal/ingest/docling_extractor.go
@@ -130,11 +130,26 @@ func (d *doclingExtractor) Extract(ctx context.Context, relPath string, data []b
 	if err != nil {
 		return "", err
 	}
-	if doc, perr := docling.Parse([]byte(out)); perr == nil {
+	doc, perr := docling.Parse([]byte(out))
+	if perr == nil {
 		return docling.RenderMarkdown(doc.Linearize()), nil
 	}
-	// Not a DoclingDocument (custom --to md command): treat as flat Markdown.
+	// Output that looks like JSON but failed to parse is a structured-extraction
+	// failure (truncated/schema-drifted DoclingDocument); fail fast rather than
+	// persisting raw JSON as the representation. Genuinely non-JSON output is a
+	// custom flat-Markdown command (--to md), returned as-is.
+	if looksLikeJSON(out) {
+		return "", fmt.Errorf("parse structured docling output for %s: %w", relPath, perr)
+	}
 	return out, nil
+}
+
+// looksLikeJSON reports whether trimmed output begins with a JSON object or
+// array delimiter, used to distinguish a broken DoclingDocument from a
+// deliberate flat-Markdown command.
+func looksLikeJSON(out string) bool {
+	t := strings.TrimSpace(out)
+	return strings.HasPrefix(t, "{") || strings.HasPrefix(t, "[")
 }
 
 // ExtractStructured runs the command and parses the structured DoclingDocument.

--- a/internal/ingest/represent.go
+++ b/internal/ingest/represent.go
@@ -161,7 +161,14 @@ func (rg *RepresentationGenerator) upsertChunksForRepresentationWithStore(ctx co
 			IndexKind:       indexKind,
 			EmbeddingStatus: "pending",
 		}
-		if _, err := st.InsertChunkWithSpans(ctx, chunk, []model.Span{seg.Span}); err != nil {
+		// A kind-less span carries no provenance (e.g. a structured chunk whose
+		// source elements exposed no page); persist the chunk with no span row
+		// rather than fabricating one.
+		var spans []model.Span
+		if strings.TrimSpace(seg.Span.Kind) != "" {
+			spans = []model.Span{seg.Span}
+		}
+		if _, err := st.InsertChunkWithSpans(ctx, chunk, spans); err != nil {
 			return fmt.Errorf("insert chunk %d: %w", i, err)
 		}
 	}
@@ -344,7 +351,8 @@ func newStructuredChunker() *structuredChunker {
 		maxChars:     maxChars,
 		overlapChars: overlapChars,
 		minChars:     minChars,
-		lastPage:     1,
+		// 0 = no page observed yet; spanForBlocks must not fabricate page 1.
+		lastPage: 0,
 	}
 }
 
@@ -433,9 +441,12 @@ func sameSection(a, b []string) bool {
 
 // spanForBlocks derives a span for a chunk from its source blocks: a region
 // span (page range + union bbox on the primary page + section) when a bounding
-// box is available, otherwise a page span on the primary (or last-known) page.
-// lastPage carries forward the most recent known page so blocks lacking
-// provenance still cite a plausible page rather than page 0.
+// box is available, otherwise a page span on the primary (or last-seen) page.
+// lastPage carries forward the most recent *observed* page (0 = none seen yet)
+// so a block lacking its own page still cites the surrounding page rather than a
+// fabricated page 1. When no page has ever been observed it returns a kind-less
+// span, which the chunk writer persists with no provenance row (spec: a region
+// citation degrades to page-level, never to a made-up page).
 func spanForBlocks(bs []docling.Block, lastPage *int) model.Span {
 	startPage, endPage, primary := blockPageRange(bs)
 	section, label := blockSectionLabel(bs)
@@ -456,6 +467,10 @@ func spanForBlocks(bs []docling.Block, lastPage *int) model.Span {
 	page := primary
 	if page <= 0 {
 		page = *lastPage
+	}
+	if page <= 0 {
+		// No page ever observed: emit no provenance rather than inventing one.
+		return model.Span{}
 	}
 	return model.Span{Kind: "page", Page: page}
 }

--- a/internal/ingest/represent.go
+++ b/internal/ingest/represent.go
@@ -304,62 +304,92 @@ const (
 // carries a region span (page range + primary-page bbox + section), degrading
 // to a page span when a block lacks a bounding box.
 func chunkStructuredBlocks(blocks []docling.Block) []chunkSegment {
-	maxChars, overlapChars, minChars := normalizeTextChunkParams(
-		structuredChunkMaxChars, structuredChunkOverlapChars, structuredChunkMinChars)
-
-	lastPage := 1
-	out := make([]chunkSegment, 0, len(blocks))
-
-	var buf []docling.Block
-	var bufText strings.Builder
-	var bufSection []string
-
-	flush := func() {
-		text := strings.TrimSpace(bufText.String())
-		buffered := buf
-		buf = nil
-		bufText.Reset()
-		bufSection = nil
-		if text == "" || len(buffered) == 0 {
-			return
-		}
-		span := spanForBlocks(buffered, &lastPage)
-		for _, piece := range splitTextBySize(text, maxChars, overlapChars, minChars) {
-			out = append(out, chunkSegment{Text: piece, Span: span})
-		}
-	}
-
+	c := newStructuredChunker()
 	for _, b := range blocks {
 		if strings.TrimSpace(b.Text) == "" {
 			continue
 		}
 		if b.Label == docling.LabelTable {
-			// Tables are atomic: flush any pending text, then emit the table as
-			// a single segment regardless of size.
-			flush()
-			out = append(out, chunkSegment{
-				Text: b.Text,
-				Span: spanForBlocks([]docling.Block{b}, &lastPage),
-			})
+			// Tables are atomic: flush any pending prose, then emit the table
+			// as a single segment regardless of size.
+			c.flush()
+			c.emitAtomic(b)
 			continue
 		}
-		if len(buf) > 0 && !sameSection(bufSection, b.Section) {
-			flush()
-		}
-		if len(buf) == 0 {
-			bufSection = b.Section
-		}
-		if bufText.Len() > 0 {
-			bufText.WriteString("\n\n")
-		}
-		bufText.WriteString(b.Text)
-		buf = append(buf, b)
-		if bufText.Len() >= maxChars {
-			flush()
-		}
+		c.add(b)
 	}
-	flush()
-	return out
+	c.flush()
+	return c.out
+}
+
+// structuredChunker accumulates consecutive same-section blocks and flushes
+// them into size-bounded segments, each tagged with a region span. It exists to
+// keep chunkStructuredBlocks simple (one branch per block kind) by moving the
+// buffer bookkeeping behind add/flush/emitAtomic.
+type structuredChunker struct {
+	maxChars     int
+	overlapChars int
+	minChars     int
+	lastPage     int
+	out          []chunkSegment
+	buf          []docling.Block
+	bufText      strings.Builder
+	bufSection   []string
+}
+
+func newStructuredChunker() *structuredChunker {
+	maxChars, overlapChars, minChars := normalizeTextChunkParams(
+		structuredChunkMaxChars, structuredChunkOverlapChars, structuredChunkMinChars)
+	return &structuredChunker{
+		maxChars:     maxChars,
+		overlapChars: overlapChars,
+		minChars:     minChars,
+		lastPage:     1,
+	}
+}
+
+// add appends a prose block to the buffer, starting a new chunk when the
+// section breadcrumb changes and flushing when the buffer reaches max size.
+func (c *structuredChunker) add(b docling.Block) {
+	if len(c.buf) > 0 && !sameSection(c.bufSection, b.Section) {
+		c.flush()
+	}
+	if len(c.buf) == 0 {
+		c.bufSection = b.Section
+	}
+	if c.bufText.Len() > 0 {
+		c.bufText.WriteString("\n\n")
+	}
+	c.bufText.WriteString(b.Text)
+	c.buf = append(c.buf, b)
+	if c.bufText.Len() >= c.maxChars {
+		c.flush()
+	}
+}
+
+// emitAtomic appends a single block as its own chunk (used for tables).
+func (c *structuredChunker) emitAtomic(b docling.Block) {
+	c.out = append(c.out, chunkSegment{
+		Text: b.Text,
+		Span: spanForBlocks([]docling.Block{b}, &c.lastPage),
+	})
+}
+
+// flush turns the buffered blocks into one or more size-bounded segments
+// sharing a single region span, then resets the buffer.
+func (c *structuredChunker) flush() {
+	text := strings.TrimSpace(c.bufText.String())
+	buffered := c.buf
+	c.buf = nil
+	c.bufText.Reset()
+	c.bufSection = nil
+	if text == "" || len(buffered) == 0 {
+		return
+	}
+	span := spanForBlocks(buffered, &c.lastPage)
+	for _, piece := range splitTextBySize(text, c.maxChars, c.overlapChars, c.minChars) {
+		c.out = append(c.out, chunkSegment{Text: piece, Span: span})
+	}
 }
 
 // ChunkStructuredBlocks splits structured document blocks using the same
@@ -407,16 +437,33 @@ func sameSection(a, b []string) bool {
 // lastPage carries forward the most recent known page so blocks lacking
 // provenance still cite a plausible page rather than page 0.
 func spanForBlocks(bs []docling.Block, lastPage *int) model.Span {
-	startPage, endPage, primary := 0, 0, 0
-	var section []string
-	label := ""
+	startPage, endPage, primary := blockPageRange(bs)
+	section, label := blockSectionLabel(bs)
+	union := unionBBoxOnPage(bs, primary)
+
+	if primary > 0 {
+		*lastPage = primary
+	}
+	if union != nil {
+		return model.Span{Kind: "region", Region: &model.RegionSpan{
+			StartPage: startPage,
+			EndPage:   endPage,
+			BBox:      union,
+			Section:   section,
+			Label:     label,
+		}}
+	}
+	page := primary
+	if page <= 0 {
+		page = *lastPage
+	}
+	return model.Span{Kind: "page", Page: page}
+}
+
+// blockPageRange returns the first, last, and primary (first in reading order)
+// page across the blocks, ignoring blocks without a page.
+func blockPageRange(bs []docling.Block) (startPage, endPage, primary int) {
 	for _, b := range bs {
-		if label == "" {
-			label = b.Label
-		}
-		if section == nil && len(b.Section) > 0 {
-			section = b.Section
-		}
 		if b.Page <= 0 {
 			continue
 		}
@@ -430,7 +477,26 @@ func spanForBlocks(bs []docling.Block, lastPage *int) model.Span {
 			primary = b.Page
 		}
 	}
+	return startPage, endPage, primary
+}
 
+// blockSectionLabel returns the first non-empty section breadcrumb and the
+// first block label across the blocks.
+func blockSectionLabel(bs []docling.Block) (section []string, label string) {
+	for _, b := range bs {
+		if label == "" {
+			label = b.Label
+		}
+		if section == nil && len(b.Section) > 0 {
+			section = b.Section
+		}
+	}
+	return section, label
+}
+
+// unionBBoxOnPage returns the smallest rectangle enclosing all block bounding
+// boxes on the primary page, or nil when none have a box there.
+func unionBBoxOnPage(bs []docling.Block, primary int) *model.BBox {
 	var union *model.BBox
 	for _, b := range bs {
 		if b.Page != primary || b.BBox == nil {
@@ -450,24 +516,7 @@ func spanForBlocks(bs []docling.Block, lastPage *int) model.Span {
 		union.R = maxF(union.R, mb.R)
 		union.B = maxF(union.B, mb.B)
 	}
-
-	if primary > 0 {
-		*lastPage = primary
-	}
-	if union != nil {
-		return model.Span{Kind: "region", Region: &model.RegionSpan{
-			StartPage: startPage,
-			EndPage:   endPage,
-			BBox:      union,
-			Section:   section,
-			Label:     label,
-		}}
-	}
-	page := primary
-	if page <= 0 {
-		page = *lastPage
-	}
-	return model.Span{Kind: "page", Page: page}
+	return union
 }
 
 func minF(a, b float64) float64 {

--- a/internal/ingest/represent.go
+++ b/internal/ingest/represent.go
@@ -12,6 +12,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/dirstral/dir2mcp/internal/ingest/docling"
 	"github.com/dirstral/dir2mcp/internal/model"
 )
 
@@ -285,6 +286,202 @@ func chunkOCRByPages(content string) []chunkSegment {
 		})
 	}
 	return out
+}
+
+// Structured-document chunking parameters (spec §7.5 size constraints). They
+// mirror the raw-text defaults so structured and plain text chunk at a
+// comparable granularity.
+const (
+	structuredChunkMaxChars     = 2500
+	structuredChunkOverlapChars = 250
+	structuredChunkMinChars     = 200
+)
+
+// chunkStructuredBlocks implements section/element-aware chunking over the
+// ordered blocks of a structured document (spec §7.5): consecutive blocks
+// sharing the same section breadcrumb are grouped, then split by size; tables
+// are kept atomic (never merged with surrounding text nor split). Each segment
+// carries a region span (page range + primary-page bbox + section), degrading
+// to a page span when a block lacks a bounding box.
+func chunkStructuredBlocks(blocks []docling.Block) []chunkSegment {
+	maxChars, overlapChars, minChars := normalizeTextChunkParams(
+		structuredChunkMaxChars, structuredChunkOverlapChars, structuredChunkMinChars)
+
+	lastPage := 1
+	out := make([]chunkSegment, 0, len(blocks))
+
+	var buf []docling.Block
+	var bufText strings.Builder
+	var bufSection []string
+
+	flush := func() {
+		text := strings.TrimSpace(bufText.String())
+		buffered := buf
+		buf = nil
+		bufText.Reset()
+		bufSection = nil
+		if text == "" || len(buffered) == 0 {
+			return
+		}
+		span := spanForBlocks(buffered, &lastPage)
+		for _, piece := range splitTextBySize(text, maxChars, overlapChars, minChars) {
+			out = append(out, chunkSegment{Text: piece, Span: span})
+		}
+	}
+
+	for _, b := range blocks {
+		if strings.TrimSpace(b.Text) == "" {
+			continue
+		}
+		if b.Label == docling.LabelTable {
+			// Tables are atomic: flush any pending text, then emit the table as
+			// a single segment regardless of size.
+			flush()
+			out = append(out, chunkSegment{
+				Text: b.Text,
+				Span: spanForBlocks([]docling.Block{b}, &lastPage),
+			})
+			continue
+		}
+		if len(buf) > 0 && !sameSection(bufSection, b.Section) {
+			flush()
+		}
+		if len(buf) == 0 {
+			bufSection = b.Section
+		}
+		if bufText.Len() > 0 {
+			bufText.WriteString("\n\n")
+		}
+		bufText.WriteString(b.Text)
+		buf = append(buf, b)
+		if bufText.Len() >= maxChars {
+			flush()
+		}
+	}
+	flush()
+	return out
+}
+
+// ChunkStructuredBlocks splits structured document blocks using the same
+// section-aware policy as ingestion. Exported so tests can exercise the logic
+// directly (mirrors ChunkTextByChars/ChunkCodeByLines).
+func ChunkStructuredBlocks(blocks []docling.Block) []ChunkSegment {
+	raw := chunkStructuredBlocks(blocks)
+	out := make([]ChunkSegment, 0, len(raw))
+	for _, seg := range raw {
+		out = append(out, ChunkSegment(seg))
+	}
+	return out
+}
+
+// splitTextBySize breaks text into size-bounded pieces, reusing the char
+// chunker but discarding its line spans (structured chunks carry region spans).
+func splitTextBySize(text string, maxChars, overlapChars, minChars int) []string {
+	segs := chunkTextByChars(text, maxChars, overlapChars, minChars)
+	if len(segs) == 0 {
+		return []string{text}
+	}
+	out := make([]string, 0, len(segs))
+	for _, s := range segs {
+		out = append(out, s.Text)
+	}
+	return out
+}
+
+// sameSection reports whether two section breadcrumbs are identical.
+func sameSection(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// spanForBlocks derives a span for a chunk from its source blocks: a region
+// span (page range + union bbox on the primary page + section) when a bounding
+// box is available, otherwise a page span on the primary (or last-known) page.
+// lastPage carries forward the most recent known page so blocks lacking
+// provenance still cite a plausible page rather than page 0.
+func spanForBlocks(bs []docling.Block, lastPage *int) model.Span {
+	startPage, endPage, primary := 0, 0, 0
+	var section []string
+	label := ""
+	for _, b := range bs {
+		if label == "" {
+			label = b.Label
+		}
+		if section == nil && len(b.Section) > 0 {
+			section = b.Section
+		}
+		if b.Page <= 0 {
+			continue
+		}
+		if startPage == 0 || b.Page < startPage {
+			startPage = b.Page
+		}
+		if b.Page > endPage {
+			endPage = b.Page
+		}
+		if primary == 0 {
+			primary = b.Page
+		}
+	}
+
+	var union *model.BBox
+	for _, b := range bs {
+		if b.Page != primary || b.BBox == nil {
+			continue
+		}
+		mb := model.BBox{
+			Page: b.BBox.Page, L: b.BBox.L, T: b.BBox.T,
+			R: b.BBox.R, B: b.BBox.B, CoordOrigin: b.BBox.CoordOrigin,
+		}
+		if union == nil {
+			cp := mb
+			union = &cp
+			continue
+		}
+		union.L = minF(union.L, mb.L)
+		union.T = minF(union.T, mb.T)
+		union.R = maxF(union.R, mb.R)
+		union.B = maxF(union.B, mb.B)
+	}
+
+	if primary > 0 {
+		*lastPage = primary
+	}
+	if union != nil {
+		return model.Span{Kind: "region", Region: &model.RegionSpan{
+			StartPage: startPage,
+			EndPage:   endPage,
+			BBox:      union,
+			Section:   section,
+			Label:     label,
+		}}
+	}
+	page := primary
+	if page <= 0 {
+		page = *lastPage
+	}
+	return model.Span{Kind: "page", Page: page}
+}
+
+func minF(a, b float64) float64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func maxF(a, b float64) float64 {
+	if a > b {
+		return a
+	}
+	return b
 }
 
 func chunkTranscriptByTime(content string) []chunkSegment {

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -961,6 +961,17 @@ func (s *Service) generateOCRMarkdownRepresentation(ctx context.Context, doc mod
 		return nil
 	}
 
+	// Structured path: when the extractor exposes a DoclingDocument, preserve
+	// its structure (reading order, section breadcrumb, page/bbox provenance)
+	// as region spans. Falls through to the flat path when the extractor is not
+	// structured, or yields no parseable structure (custom --to md command).
+	if se, ok := s.extractor.(structuredExtractor); ok {
+		res, err := s.readOrComputeStructured(ctx, doc, content, se)
+		if err == nil && len(res.Blocks) > 0 {
+			return s.persistStructuredRepresentation(ctx, doc, res)
+		}
+	}
+
 	ocrText, err := s.readOrComputeOCR(ctx, doc, content)
 	if err != nil {
 		return err
@@ -994,6 +1005,89 @@ func (s *Service) generateOCRMarkdownRepresentation(ctx context.Context, doc mod
 		return fmt.Errorf("persist ocr chunks: %w", err)
 	}
 	return nil
+}
+
+// persistStructuredRepresentation stores the extracted_markdown representation
+// from a structured extraction: the rendered Markdown is the representation
+// text (rep_hash is computed over it, as in the flat path), while the document
+// structure is carried as region spans on section-aware chunks. The title from
+// the document's title element is preferred over the text heuristic.
+func (s *Service) persistStructuredRepresentation(ctx context.Context, doc model.Document, res StructuredExtraction) error {
+	md := strings.TrimSpace(res.Markdown)
+	if md == "" {
+		return nil
+	}
+
+	if title := strings.TrimSpace(res.Title); title != "" {
+		s.persistTitle(ctx, doc, title)
+	} else {
+		s.persistTitleIfFound(ctx, doc, md)
+	}
+
+	rep := model.Representation{
+		DocID:       doc.DocID,
+		RepType:     RepTypeExtractedMarkdown,
+		RepHash:     computeRepHash([]byte(md)),
+		MetaJSON:    s.extractionMetaJSON(),
+		CreatedUnix: time.Now().Unix(),
+		Deleted:     false,
+	}
+	repID, err := s.repGen.store.UpsertRepresentation(ctx, rep)
+	if err != nil {
+		return fmt.Errorf("upsert structured representation: %w", err)
+	}
+
+	segments := chunkStructuredBlocks(res.Blocks)
+	if len(segments) == 0 {
+		return nil
+	}
+	if err := s.repGen.upsertChunksForRepresentation(ctx, repID, "text", segments); err != nil {
+		return fmt.Errorf("persist structured chunks: %w", err)
+	}
+	return nil
+}
+
+// readOrComputeStructured returns the structured extraction for content,
+// caching the result as JSON under <state>/cache/docling keyed by content hash
+// so re-indexing does not re-run docling. The cache is an implementation
+// detail (spec §7.4.B: the raw DoclingDocument is not a representation).
+func (s *Service) readOrComputeStructured(ctx context.Context, doc model.Document, content []byte, se structuredExtractor) (StructuredExtraction, error) {
+	cacheDir := filepath.Join(s.cfg.StateDir, "cache", "docling")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		return StructuredExtraction{}, fmt.Errorf("create docling cache dir: %w", err)
+	}
+	cachePath := filepath.Join(cacheDir, computeContentHash(content)+".json")
+	if cached, err := os.ReadFile(cachePath); err == nil {
+		var res StructuredExtraction
+		if json.Unmarshal(cached, &res) == nil && len(res.Blocks) > 0 {
+			return res, nil
+		}
+	}
+
+	res, err := se.ExtractStructured(ctx, doc.RelPath, content)
+	if err != nil {
+		return StructuredExtraction{}, err
+	}
+	if encoded, mErr := json.Marshal(res); mErr == nil {
+		if wErr := os.WriteFile(cachePath, encoded, 0o644); wErr != nil {
+			s.getLogger().Printf("cache structured extraction for %s: %v", doc.RelPath, wErr)
+		}
+	}
+	return res, nil
+}
+
+// persistTitle sets documents.title to an explicit title (e.g. from a
+// structured document's title element), preferring it over the heuristic.
+// Non-fatal: a failed write only degrades citation display.
+func (s *Service) persistTitle(ctx context.Context, doc model.Document, title string) {
+	title = strings.TrimSpace(title)
+	if title == "" || title == doc.Title {
+		return
+	}
+	doc.Title = title
+	if err := s.store.UpsertDocument(ctx, doc); err != nil {
+		s.getLogger().Printf("persist title for %s: %v", doc.RelPath, err)
+	}
 }
 
 func (s *Service) extractionMetaJSON() string {

--- a/internal/mcp/region_span_test.go
+++ b/internal/mcp/region_span_test.go
@@ -1,0 +1,80 @@
+package mcp
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// TestBuildOpenFileSpan_Region pins the region span rendering in MCP tool
+// output (spec §15.1.1): page range + primary-page bbox + section breadcrumb.
+func TestBuildOpenFileSpan_Region(t *testing.T) {
+	span := model.Span{
+		Kind: "region",
+		Region: &model.RegionSpan{
+			StartPage: 3,
+			EndPage:   3,
+			BBox:      &model.BBox{Page: 3, L: 72, T: 90.5, R: 523, B: 410.2, CoordOrigin: "TOPLEFT"},
+			Section:   []string{"Results", "3.1 Revenue"},
+			Label:     "paragraph",
+		},
+	}
+	got := buildOpenFileSpan(span)
+
+	if got["kind"] != "region" {
+		t.Fatalf("kind = %v, want region", got["kind"])
+	}
+	if got["start_page"] != 3 || got["end_page"] != 3 {
+		t.Errorf("page range = %v-%v, want 3-3", got["start_page"], got["end_page"])
+	}
+	bbox, ok := got["bbox"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("bbox missing or wrong type: %T", got["bbox"])
+	}
+	if bbox["page"] != 3 || bbox["l"] != 72.0 || bbox["coord_origin"] != "TOPLEFT" {
+		t.Errorf("bbox fields wrong: %+v", bbox)
+	}
+	if !reflect.DeepEqual(got["section"], []string{"Results", "3.1 Revenue"}) {
+		t.Errorf("section = %v, want [Results 3.1 Revenue]", got["section"])
+	}
+	// label is internal provenance, not part of the wire Span shape.
+	if _, present := got["label"]; present {
+		t.Errorf("label must not be emitted in the wire span: %+v", got)
+	}
+}
+
+// TestBuildOpenFileSpan_RegionDegrades pins that a malformed region span (no
+// bbox) degrades to a page span on the start page, and to the document variant
+// when no page is available, so clients always receive a usable citation.
+func TestBuildOpenFileSpan_RegionDegrades(t *testing.T) {
+	noBBox := buildOpenFileSpan(model.Span{
+		Kind:   "region",
+		Region: &model.RegionSpan{StartPage: 5, EndPage: 5},
+	})
+	if noBBox["kind"] != "page" || noBBox["page"] != 5 {
+		t.Errorf("no-bbox region = %+v, want page span on 5", noBBox)
+	}
+
+	empty := buildOpenFileSpan(model.Span{Kind: "region"})
+	if empty["kind"] != "document" {
+		t.Errorf("payload-less region = %+v, want document variant", empty)
+	}
+}
+
+// TestBuildOpenFileSpan_ScalarKindsUnchanged guards that adding region did not
+// disturb the existing kinds.
+func TestBuildOpenFileSpan_ScalarKindsUnchanged(t *testing.T) {
+	lines := buildOpenFileSpan(model.Span{Kind: "lines", StartLine: 12, EndLine: 48})
+	if lines["kind"] != "lines" || lines["start_line"] != 12 || lines["end_line"] != 48 {
+		t.Errorf("lines span wrong: %+v", lines)
+	}
+	page := buildOpenFileSpan(model.Span{Kind: "page", Page: 7})
+	if page["kind"] != "page" || page["page"] != 7 {
+		t.Errorf("page span wrong: %+v", page)
+	}
+	tm := buildOpenFileSpan(model.Span{Kind: "time", StartMS: 1000, EndMS: 5000})
+	if tm["kind"] != "time" || tm["start_ms"] != 1000 || tm["end_ms"] != 5000 {
+		t.Errorf("time span wrong: %+v", tm)
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1970,6 +1970,13 @@ func inferDocType(relPath string) string {
 	}
 }
 
+// BuildOpenFileSpan exposes buildOpenFileSpan for tests in the tests/ tree
+// (the repo keeps all test files there, per AGENTS.md). It is a thin wrapper
+// with no behavior of its own.
+func BuildOpenFileSpan(span model.Span) map[string]interface{} {
+	return buildOpenFileSpan(span)
+}
+
 func buildOpenFileSpan(span model.Span) map[string]interface{} {
 	kind := strings.TrimSpace(span.Kind)
 	switch kind {
@@ -2269,6 +2276,41 @@ func spanDefinitionSchema() map[string]interface{} {
 					"end_ms":   map[string]interface{}{"type": "integer"},
 				},
 				"required": []string{"kind", "start_ms", "end_ms"},
+			},
+			map[string]interface{}{
+				"type":                 "object",
+				"additionalProperties": false,
+				"properties": map[string]interface{}{
+					"kind":       map[string]interface{}{"const": "region"},
+					"start_page": map[string]interface{}{"type": "integer"},
+					"end_page":   map[string]interface{}{"type": "integer"},
+					"bbox": map[string]interface{}{
+						"type":                 "object",
+						"additionalProperties": false,
+						"properties": map[string]interface{}{
+							"page":         map[string]interface{}{"type": "integer"},
+							"l":            map[string]interface{}{"type": "number"},
+							"t":            map[string]interface{}{"type": "number"},
+							"r":            map[string]interface{}{"type": "number"},
+							"b":            map[string]interface{}{"type": "number"},
+							"coord_origin": map[string]interface{}{"type": "string"},
+						},
+						"required": []string{"page", "l", "t", "r", "b", "coord_origin"},
+					},
+					"section": map[string]interface{}{
+						"type":  "array",
+						"items": map[string]interface{}{"type": "string"},
+					},
+				},
+				"required": []string{"kind", "start_page", "end_page", "bbox", "section"},
+			},
+			map[string]interface{}{
+				"type":                 "object",
+				"additionalProperties": false,
+				"properties": map[string]interface{}{
+					"kind": map[string]interface{}{"const": "document"},
+				},
+				"required": []string{"kind"},
 			},
 		},
 	}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1990,10 +1990,49 @@ func buildOpenFileSpan(span model.Span) map[string]interface{} {
 			"start_ms": span.StartMS,
 			"end_ms":   span.EndMS,
 		}
+	case "region":
+		return buildRegionSpan(span)
 	default:
 		return map[string]interface{}{
 			"kind": kind,
 		}
+	}
+}
+
+// buildRegionSpan renders a region span per spec §15.1.1: page range plus the
+// primary-page bounding box and section breadcrumb. A region span missing its
+// payload or bbox degrades to a page span on the start page (or the document
+// variant when even that is unavailable), so clients always get a usable
+// citation.
+func buildRegionSpan(span model.Span) map[string]interface{} {
+	r := span.Region
+	if r == nil || r.BBox == nil {
+		page := 0
+		if r != nil {
+			page = r.StartPage
+		}
+		if page <= 0 {
+			return map[string]interface{}{"kind": "document"}
+		}
+		return map[string]interface{}{"kind": "page", "page": page}
+	}
+	section := r.Section
+	if section == nil {
+		section = []string{}
+	}
+	return map[string]interface{}{
+		"kind":       "region",
+		"start_page": r.StartPage,
+		"end_page":   r.EndPage,
+		"bbox": map[string]interface{}{
+			"page":         r.BBox.Page,
+			"l":            r.BBox.L,
+			"t":            r.BBox.T,
+			"r":            r.BBox.R,
+			"b":            r.BBox.B,
+			"coord_origin": r.BBox.CoordOrigin,
+		},
+		"section": section,
 	}
 }
 

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -56,6 +56,33 @@ type Span struct {
 	Page      int
 	StartMS   int
 	EndMS     int
+	// Region is set only when Kind == "region" (structured document
+	// extraction, spec §5.4). It carries the page range, primary-page
+	// bounding box, and section breadcrumb. nil for all other kinds, which
+	// keeps Span comparable for the scalar kinds.
+	Region *RegionSpan
+}
+
+// RegionSpan localizes a chunk to a rectangular area within a page range of a
+// structured document (dirstral-spec §5.4 "region" span kind). It is the
+// in-memory shape of the spans.extra_json blob for region spans.
+type RegionSpan struct {
+	StartPage int      `json:"-"`
+	EndPage   int      `json:"-"`
+	BBox      *BBox    `json:"bbox,omitempty"`
+	Section   []string `json:"section,omitempty"`
+	Label     string   `json:"label,omitempty"`
+}
+
+// BBox is a bounding box in the source document's point space. CoordOrigin is
+// the origin actually stored ("TOPLEFT" or "BOTTOMLEFT").
+type BBox struct {
+	Page        int     `json:"page"`
+	L           float64 `json:"l"`
+	T           float64 `json:"t"`
+	R           float64 `json:"r"`
+	B           float64 `json:"b"`
+	CoordOrigin string  `json:"coord_origin"`
 }
 
 type SearchQuery struct {

--- a/internal/store/spans_region_test.go
+++ b/internal/store/spans_region_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/dirstral/dir2mcp/internal/model"
@@ -38,21 +39,24 @@ func TestRegionSpanRoundTrip(t *testing.T) {
 	if out.Kind != "region" || out.Region == nil {
 		t.Fatalf("round-trip lost region: %+v", out)
 	}
-	r := out.Region
-	if r.StartPage != 3 || r.EndPage != 3 {
-		t.Errorf("page range = %d-%d, want 3-3", r.StartPage, r.EndPage)
+	assertRegionEquals(t, out.Region, in.Region)
+}
+
+// assertRegionEquals fails t when the round-tripped region differs from want in
+// any of its page range, bbox, section, or label fields.
+func assertRegionEquals(t *testing.T, got, want *model.RegionSpan) {
+	t.Helper()
+	if got.StartPage != want.StartPage || got.EndPage != want.EndPage {
+		t.Errorf("page range = %d-%d, want %d-%d", got.StartPage, got.EndPage, want.StartPage, want.EndPage)
 	}
-	if r.BBox == nil || r.BBox.L != 72 || r.BBox.T != 90.5 || r.BBox.R != 523 || r.BBox.B != 410.2 {
-		t.Errorf("bbox lost: %+v", r.BBox)
+	if got.BBox == nil || *got.BBox != *want.BBox {
+		t.Errorf("bbox = %+v, want %+v", got.BBox, want.BBox)
 	}
-	if r.BBox != nil && r.BBox.CoordOrigin != "TOPLEFT" {
-		t.Errorf("coord_origin = %q, want TOPLEFT", r.BBox.CoordOrigin)
+	if strings.Join(got.Section, "|") != strings.Join(want.Section, "|") {
+		t.Errorf("section = %v, want %v", got.Section, want.Section)
 	}
-	if len(r.Section) != 2 || r.Section[0] != "Results" || r.Section[1] != "3.1 Revenue" {
-		t.Errorf("section = %v, want [Results 3.1 Revenue]", r.Section)
-	}
-	if r.Label != "paragraph" {
-		t.Errorf("label = %q, want paragraph", r.Label)
+	if got.Label != want.Label {
+		t.Errorf("label = %q, want %q", got.Label, want.Label)
 	}
 }
 
@@ -103,7 +107,7 @@ func TestRegionSpanToRow_Rejects(t *testing.T) {
 // usable citation. Mirrors the spec's "treat as a page-level citation" rule.
 func TestRegionSpanFromRow_DegradesToPage(t *testing.T) {
 	for name, extra := range map[string]string{
-		"empty extra":   "",
+		"empty extra":    "",
 		"malformed json": "{not json",
 		"no bbox":        `{"section":["A"]}`,
 	} {

--- a/internal/store/spans_region_test.go
+++ b/internal/store/spans_region_test.go
@@ -1,0 +1,145 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// TestRegionSpanRoundTrip pins that a region span survives spanToRow ->
+// spanFromRow: page range comes back from start/end, and bbox/section/label
+// come back from the extra_json payload (spec 0.9.0 §5.4).
+func TestRegionSpanRoundTrip(t *testing.T) {
+	in := model.Span{
+		Kind: "region",
+		Region: &model.RegionSpan{
+			StartPage: 3,
+			EndPage:   3,
+			BBox: &model.BBox{
+				Page: 3, L: 72, T: 90.5, R: 523, B: 410.2, CoordOrigin: "TOPLEFT",
+			},
+			Section: []string{"Results", "3.1 Revenue"},
+			Label:   "paragraph",
+		},
+	}
+
+	kind, start, end, extra, err := spanToRow(in)
+	if err != nil {
+		t.Fatalf("spanToRow: %v", err)
+	}
+	if kind != "region" || start != 3 || end != 3 {
+		t.Fatalf("row = (%q,%d,%d), want (region,3,3)", kind, start, end)
+	}
+	if extra == "" {
+		t.Fatal("region span must produce a non-empty extra_json payload")
+	}
+
+	out := spanFromRow(kind, start, end, extra)
+	if out.Kind != "region" || out.Region == nil {
+		t.Fatalf("round-trip lost region: %+v", out)
+	}
+	r := out.Region
+	if r.StartPage != 3 || r.EndPage != 3 {
+		t.Errorf("page range = %d-%d, want 3-3", r.StartPage, r.EndPage)
+	}
+	if r.BBox == nil || r.BBox.L != 72 || r.BBox.T != 90.5 || r.BBox.R != 523 || r.BBox.B != 410.2 {
+		t.Errorf("bbox lost: %+v", r.BBox)
+	}
+	if r.BBox != nil && r.BBox.CoordOrigin != "TOPLEFT" {
+		t.Errorf("coord_origin = %q, want TOPLEFT", r.BBox.CoordOrigin)
+	}
+	if len(r.Section) != 2 || r.Section[0] != "Results" || r.Section[1] != "3.1 Revenue" {
+		t.Errorf("section = %v, want [Results 3.1 Revenue]", r.Section)
+	}
+	if r.Label != "paragraph" {
+		t.Errorf("label = %q, want paragraph", r.Label)
+	}
+}
+
+// TestRegionSpanMultiPage covers a region whose elements span more than one
+// page: start/end carry the full range while bbox stays on the primary page.
+func TestRegionSpanMultiPage(t *testing.T) {
+	in := model.Span{
+		Kind: "region",
+		Region: &model.RegionSpan{
+			StartPage: 4,
+			EndPage:   5,
+			BBox:      &model.BBox{Page: 4, L: 10, T: 20, R: 30, B: 40, CoordOrigin: "TOPLEFT"},
+		},
+	}
+	kind, start, end, extra, err := spanToRow(in)
+	if err != nil {
+		t.Fatalf("spanToRow: %v", err)
+	}
+	out := spanFromRow(kind, start, end, extra)
+	if out.Region == nil || out.Region.StartPage != 4 || out.Region.EndPage != 5 {
+		t.Fatalf("page range lost: %+v", out.Region)
+	}
+	if out.Region.BBox == nil || out.Region.BBox.Page != 4 {
+		t.Errorf("primary bbox page = %v, want 4", out.Region.BBox)
+	}
+}
+
+// TestRegionSpanToRow_Rejects pins the validation guards in spanToRow.
+func TestRegionSpanToRow_Rejects(t *testing.T) {
+	cases := map[string]model.Span{
+		"missing region payload": {Kind: "region"},
+		"missing bbox":           {Kind: "region", Region: &model.RegionSpan{StartPage: 1, EndPage: 1}},
+		"bad page range":         {Kind: "region", Region: &model.RegionSpan{StartPage: 5, EndPage: 2, BBox: &model.BBox{}}},
+		"zero start page":        {Kind: "region", Region: &model.RegionSpan{StartPage: 0, EndPage: 1, BBox: &model.BBox{}}},
+	}
+	for name, span := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, _, _, _, err := spanToRow(span); err == nil {
+				t.Errorf("expected error for %q", name)
+			}
+		})
+	}
+}
+
+// TestRegionSpanFromRow_DegradesToPage pins the read-side fallback: a region
+// row whose extra_json is missing or malformed degrades to a page span on the
+// start page (never a region span with a nil bbox), so clients still get a
+// usable citation. Mirrors the spec's "treat as a page-level citation" rule.
+func TestRegionSpanFromRow_DegradesToPage(t *testing.T) {
+	for name, extra := range map[string]string{
+		"empty extra":   "",
+		"malformed json": "{not json",
+		"no bbox":        `{"section":["A"]}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := spanFromRow("region", 7, 7, extra)
+			if got.Kind != "page" || got.Page != 7 {
+				t.Errorf("degraded span = %+v, want page span on page 7", got)
+			}
+		})
+	}
+
+	// A region row with an unusable page range degrades to lines.
+	if got := spanFromRow("region", 0, 0, `{"bbox":{"page":1}}`); got.Kind != "lines" {
+		t.Errorf("zero page range should degrade to lines, got %+v", got)
+	}
+}
+
+// TestScalarSpansUnaffected pins that the existing kinds still round-trip with
+// an empty extra_json (stored as NULL) and no Region payload.
+func TestScalarSpansUnaffected(t *testing.T) {
+	cases := []model.Span{
+		{Kind: "lines", StartLine: 12, EndLine: 48},
+		{Kind: "page", Page: 3},
+		{Kind: "time", StartMS: 1000, EndMS: 5000},
+	}
+	for _, in := range cases {
+		kind, start, end, extra, err := spanToRow(in)
+		if err != nil {
+			t.Fatalf("spanToRow(%+v): %v", in, err)
+		}
+		if extra != "" {
+			t.Errorf("%s span must have empty extra_json, got %q", kind, extra)
+		}
+		out := spanFromRow(kind, start, end, extra)
+		if out.Kind != in.Kind || out.Region != nil {
+			t.Errorf("round-trip changed %+v -> %+v", in, out)
+		}
+	}
+}

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -1344,29 +1344,34 @@ func spanFromRow(kind string, start, end int, extraJSON string) model.Span {
 		}
 		return model.Span{Kind: "time", StartMS: start, EndMS: end}
 	case "region":
-		// A region span requires a well-formed extra_json payload with a
-		// bbox. If anything is missing or malformed, degrade to a page span
-		// on start (per spec: region clients fall back to page-level), or to
-		// lines when even the page range is unusable.
-		if start <= 0 || end <= 0 || end < start || strings.TrimSpace(extraJSON) == "" {
-			if start > 0 {
-				return model.Span{Kind: "page", Page: start}
-			}
-			return model.Span{Kind: "lines"}
-		}
-		var r model.RegionSpan
-		if err := json.Unmarshal([]byte(extraJSON), &r); err != nil || r.BBox == nil {
-			return model.Span{Kind: "page", Page: start}
-		}
-		r.StartPage = start
-		r.EndPage = end
-		return model.Span{Kind: "region", Region: &r}
+		return regionSpanFromRow(start, end, extraJSON)
 	case "lines":
 		if start > 0 && end >= start {
 			return model.Span{Kind: "lines", StartLine: start, EndLine: end}
 		}
 	}
 	return model.Span{Kind: "lines"}
+}
+
+// regionSpanFromRow reconstructs a region span from its stored columns. A
+// region requires a well-formed extra_json payload with a bbox; if anything is
+// missing or malformed it degrades to a page span on the start page (per spec:
+// region clients fall back to page-level), or to lines when even the page range
+// is unusable.
+func regionSpanFromRow(start, end int, extraJSON string) model.Span {
+	if start <= 0 || end <= 0 || end < start || strings.TrimSpace(extraJSON) == "" {
+		if start > 0 {
+			return model.Span{Kind: "page", Page: start}
+		}
+		return model.Span{Kind: "lines"}
+	}
+	var r model.RegionSpan
+	if err := json.Unmarshal([]byte(extraJSON), &r); err != nil || r.BBox == nil {
+		return model.Span{Kind: "page", Page: start}
+	}
+	r.StartPage = start
+	r.EndPage = end
+	return model.Span{Kind: "region", Region: &r}
 }
 
 func (s *SQLiteStore) MarkEmbedded(ctx context.Context, labels []uint64) error {
@@ -1827,24 +1832,30 @@ func spanToRow(span model.Span) (kind string, start int, end int, extraJSON stri
 		}
 		return "time", span.StartMS, span.EndMS, "", nil
 	case "region":
-		r := span.Region
-		if r == nil {
-			return "", 0, 0, "", errors.New("invalid region span: missing region payload")
-		}
-		if r.StartPage <= 0 || r.EndPage <= 0 || r.EndPage < r.StartPage {
-			return "", 0, 0, "", errors.New("invalid region span: bad page range")
-		}
-		if r.BBox == nil {
-			return "", 0, 0, "", errors.New("invalid region span: missing bbox")
-		}
-		encoded, mErr := json.Marshal(r)
-		if mErr != nil {
-			return "", 0, 0, "", fmt.Errorf("marshal region span: %w", mErr)
-		}
-		return "region", r.StartPage, r.EndPage, string(encoded), nil
+		return regionSpanToRow(span.Region)
 	default:
 		return "", 0, 0, "", fmt.Errorf("unsupported span kind: %q", span.Kind)
 	}
+}
+
+// regionSpanToRow validates and flattens a region span: the page range goes to
+// start/end and the bbox/section/label payload is marshaled to extra_json. A
+// region MUST carry a bbox and a valid page range (spec §5.4).
+func regionSpanToRow(r *model.RegionSpan) (kind string, start int, end int, extraJSON string, err error) {
+	if r == nil {
+		return "", 0, 0, "", errors.New("invalid region span: missing region payload")
+	}
+	if r.StartPage <= 0 || r.EndPage <= 0 || r.EndPage < r.StartPage {
+		return "", 0, 0, "", errors.New("invalid region span: bad page range")
+	}
+	if r.BBox == nil {
+		return "", 0, 0, "", errors.New("invalid region span: missing bbox")
+	}
+	encoded, mErr := json.Marshal(r)
+	if mErr != nil {
+		return "", 0, 0, "", fmt.Errorf("marshal region span: %w", mErr)
+	}
+	return "region", r.StartPage, r.EndPage, string(encoded), nil
 }
 
 func boolToInt(v bool) int {

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -207,17 +208,22 @@ func insertChunkWithSpansWith(ctx context.Context, exec dbExecutor, chunk model.
 	}
 
 	for _, span := range spans {
-		spanKind, startValue, endValue, spanErr := spanToRow(span)
+		spanKind, startValue, endValue, extraJSON, spanErr := spanToRow(span)
 		if spanErr != nil {
 			return 0, spanErr
 		}
+		var extra any // NULL for scalar kinds, JSON text for region spans
+		if extraJSON != "" {
+			extra = extraJSON
+		}
 		if _, err := exec.ExecContext(
 			ctx,
-			`INSERT INTO spans (chunk_id, span_kind, start, end, extra_json) VALUES (?, ?, ?, ?, NULL)`,
+			`INSERT INTO spans (chunk_id, span_kind, start, end, extra_json) VALUES (?, ?, ?, ?, ?)`,
 			chunkID,
 			spanKind,
 			startValue,
 			endValue,
+			extra,
 		); err != nil {
 			return 0, err
 		}
@@ -1184,13 +1190,13 @@ func (s *SQLiteStore) NextPending(ctx context.Context, limit int, indexKind stri
 	            WHERE c.embedding_status = ? AND c.deleted = 0 AND c.chunk_id > 0
 	          ),
 	          ranked_spans AS (
-	            SELECT s.chunk_id, s.span_kind, s.start, s."end",
+	            SELECT s.chunk_id, s.span_kind, s.start, s."end", s.extra_json,
 	                   ROW_NUMBER() OVER (PARTITION BY s.chunk_id ORDER BY s.span_id) AS rn
 	            FROM spans s
 	            JOIN filtered_chunks fc ON fc.chunk_id = s.chunk_id
 	          )
 	          SELECT fc.chunk_id, fc.rel_path, fc.doc_type, fc.rep_type, fc.text, fc.index_kind,
-	                 COALESCE(sp.span_kind, ''), COALESCE(sp.start, 0), COALESCE(sp.end, 0)
+	                 COALESCE(sp.span_kind, ''), COALESCE(sp.start, 0), COALESCE(sp.end, 0), COALESCE(sp.extra_json, '')
 	          FROM filtered_chunks fc
 	          LEFT JOIN ranked_spans sp ON sp.chunk_id = fc.chunk_id AND sp.rn = 1`
 	if strings.TrimSpace(indexKind) != "" {
@@ -1209,24 +1215,25 @@ func (s *SQLiteStore) NextPending(ctx context.Context, limit int, indexKind stri
 	tasks := make([]model.ChunkTask, 0, limit)
 	for rows.Next() {
 		var (
-			chunkID int64
-			relPath string
-			docType string
-			repType string
-			text    string
-			idxKind string
-			spanK   string
-			spanS   int
-			spanE   int
+			chunkID   int64
+			relPath   string
+			docType   string
+			repType   string
+			text      string
+			idxKind   string
+			spanK     string
+			spanS     int
+			spanE     int
+			spanExtra string
 		)
-		if err := rows.Scan(&chunkID, &relPath, &docType, &repType, &text, &idxKind, &spanK, &spanS, &spanE); err != nil {
+		if err := rows.Scan(&chunkID, &relPath, &docType, &repType, &text, &idxKind, &spanK, &spanS, &spanE, &spanExtra); err != nil {
 			return nil, err
 		}
 		if chunkID <= 0 {
 			return nil, fmt.Errorf("invalid non-positive chunk_id from database: %d", chunkID)
 		}
 		uid := uint64(chunkID)
-		span := spanFromRow(spanK, spanS, spanE)
+		span := spanFromRow(spanK, spanS, spanE, spanExtra)
 		tasks = append(tasks, model.NewChunkTask(uid, text, idxKind, model.ChunkMetadata{
 			ChunkID: uid,
 			RelPath: relPath,
@@ -1259,13 +1266,13 @@ func (s *SQLiteStore) ListEmbeddedChunkMetadata(ctx context.Context, indexKind s
 	            WHERE c.embedding_status = ? AND c.deleted = 0 AND c.chunk_id > 0
 	          ),
 	          ranked_spans AS (
-	            SELECT s.chunk_id, s.span_kind, s.start, s."end",
+	            SELECT s.chunk_id, s.span_kind, s.start, s."end", s.extra_json,
 	                   ROW_NUMBER() OVER (PARTITION BY s.chunk_id ORDER BY s.span_id) AS rn
 	            FROM spans s
 	            JOIN filtered_chunks fc ON fc.chunk_id = s.chunk_id
 	          )
 	          SELECT fc.chunk_id, fc.rel_path, fc.doc_type, fc.rep_type, fc.text, fc.index_kind,
-	                 COALESCE(sp.span_kind, ''), COALESCE(sp.start, 0), COALESCE(sp.end, 0),
+	                 COALESCE(sp.span_kind, ''), COALESCE(sp.start, 0), COALESCE(sp.end, 0), COALESCE(sp.extra_json, ''),
 	                 COALESCE(d.title, '')
 	          FROM filtered_chunks fc
 	          LEFT JOIN ranked_spans sp ON sp.chunk_id = fc.chunk_id AND sp.rn = 1
@@ -1286,25 +1293,26 @@ func (s *SQLiteStore) ListEmbeddedChunkMetadata(ctx context.Context, indexKind s
 	out := make([]model.ChunkTask, 0, limit)
 	for rows.Next() {
 		var (
-			chunkID int64
-			relPath string
-			docType string
-			repType string
-			text    string
-			kind    string
-			spanK   string
-			spanS   int
-			spanE   int
-			title   string
+			chunkID   int64
+			relPath   string
+			docType   string
+			repType   string
+			text      string
+			kind      string
+			spanK     string
+			spanS     int
+			spanE     int
+			spanExtra string
+			title     string
 		)
-		if err := rows.Scan(&chunkID, &relPath, &docType, &repType, &text, &kind, &spanK, &spanS, &spanE, &title); err != nil {
+		if err := rows.Scan(&chunkID, &relPath, &docType, &repType, &text, &kind, &spanK, &spanS, &spanE, &spanExtra, &title); err != nil {
 			return nil, err
 		}
 		if chunkID <= 0 {
 			return nil, fmt.Errorf("invalid non-positive chunk_id from database: %d", chunkID)
 		}
 		uid := uint64(chunkID)
-		span := spanFromRow(spanK, spanS, spanE)
+		span := spanFromRow(spanK, spanS, spanE, spanExtra)
 		out = append(out, model.ChunkTask{
 			Label:     uid,
 			Text:      text,
@@ -1323,7 +1331,7 @@ func (s *SQLiteStore) ListEmbeddedChunkMetadata(ctx context.Context, indexKind s
 	return out, rows.Err()
 }
 
-func spanFromRow(kind string, start, end int) model.Span {
+func spanFromRow(kind string, start, end int, extraJSON string) model.Span {
 	switch strings.ToLower(strings.TrimSpace(kind)) {
 	case "page":
 		if start <= 0 || end <= 0 || end != start {
@@ -1335,6 +1343,24 @@ func spanFromRow(kind string, start, end int) model.Span {
 			return model.Span{Kind: "lines"}
 		}
 		return model.Span{Kind: "time", StartMS: start, EndMS: end}
+	case "region":
+		// A region span requires a well-formed extra_json payload with a
+		// bbox. If anything is missing or malformed, degrade to a page span
+		// on start (per spec: region clients fall back to page-level), or to
+		// lines when even the page range is unusable.
+		if start <= 0 || end <= 0 || end < start || strings.TrimSpace(extraJSON) == "" {
+			if start > 0 {
+				return model.Span{Kind: "page", Page: start}
+			}
+			return model.Span{Kind: "lines"}
+		}
+		var r model.RegionSpan
+		if err := json.Unmarshal([]byte(extraJSON), &r); err != nil || r.BBox == nil {
+			return model.Span{Kind: "page", Page: start}
+		}
+		r.StartPage = start
+		r.EndPage = end
+		return model.Span{Kind: "region", Region: &r}
 	case "lines":
 		if start > 0 && end >= start {
 			return model.Span{Kind: "lines", StartLine: start, EndLine: end}
@@ -1780,25 +1806,44 @@ func normalizeEmbeddingStatus(status string) string {
 	}
 }
 
-func spanToRow(span model.Span) (kind string, start int, end int, err error) {
+// spanToRow flattens a span to its stored columns. extraJSON is the empty
+// string for the scalar kinds (stored as SQL NULL) and a JSON object for
+// region spans carrying bbox/section/label (spec §5.4).
+func spanToRow(span model.Span) (kind string, start int, end int, extraJSON string, err error) {
 	switch strings.ToLower(strings.TrimSpace(span.Kind)) {
 	case "lines":
 		if span.StartLine <= 0 || span.EndLine <= 0 || span.EndLine < span.StartLine {
-			return "", 0, 0, errors.New("invalid lines span")
+			return "", 0, 0, "", errors.New("invalid lines span")
 		}
-		return "lines", span.StartLine, span.EndLine, nil
+		return "lines", span.StartLine, span.EndLine, "", nil
 	case "page":
 		if span.Page <= 0 {
-			return "", 0, 0, errors.New("invalid page span")
+			return "", 0, 0, "", errors.New("invalid page span")
 		}
-		return "page", span.Page, span.Page, nil
+		return "page", span.Page, span.Page, "", nil
 	case "time":
 		if span.StartMS < 0 || span.EndMS < 0 || span.EndMS < span.StartMS {
-			return "", 0, 0, errors.New("invalid time span")
+			return "", 0, 0, "", errors.New("invalid time span")
 		}
-		return "time", span.StartMS, span.EndMS, nil
+		return "time", span.StartMS, span.EndMS, "", nil
+	case "region":
+		r := span.Region
+		if r == nil {
+			return "", 0, 0, "", errors.New("invalid region span: missing region payload")
+		}
+		if r.StartPage <= 0 || r.EndPage <= 0 || r.EndPage < r.StartPage {
+			return "", 0, 0, "", errors.New("invalid region span: bad page range")
+		}
+		if r.BBox == nil {
+			return "", 0, 0, "", errors.New("invalid region span: missing bbox")
+		}
+		encoded, mErr := json.Marshal(r)
+		if mErr != nil {
+			return "", 0, 0, "", fmt.Errorf("marshal region span: %w", mErr)
+		}
+		return "region", r.StartPage, r.EndPage, string(encoded), nil
 	default:
-		return "", 0, 0, fmt.Errorf("unsupported span kind: %q", span.Kind)
+		return "", 0, 0, "", fmt.Errorf("unsupported span kind: %q", span.Kind)
 	}
 }
 

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -1374,6 +1374,18 @@ func regionSpanFromRow(start, end int, extraJSON string) model.Span {
 	return model.Span{Kind: "region", Region: &r}
 }
 
+// SpanToRow and SpanFromRow expose the span <-> row mapping for tests in the
+// tests/ tree (the repo keeps all test files there, per AGENTS.md). They are
+// thin wrappers over the unexported helpers and carry no behavior of their own.
+func SpanToRow(span model.Span) (kind string, start, end int, extraJSON string, err error) {
+	return spanToRow(span)
+}
+
+// SpanFromRow is the read-side counterpart to SpanToRow; see its doc.
+func SpanFromRow(kind string, start, end int, extraJSON string) model.Span {
+	return spanFromRow(kind, start, end, extraJSON)
+}
+
 func (s *SQLiteStore) MarkEmbedded(ctx context.Context, labels []uint64) error {
 	return s.markEmbeddingStatus(ctx, labels, "ok", "", "")
 }

--- a/tests/ingest/docling_structured_test.go
+++ b/tests/ingest/docling_structured_test.go
@@ -2,12 +2,26 @@ package tests
 
 import (
 	"context"
+	"os"
 	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/dirstral/dir2mcp/internal/ingest"
 )
+
+// requireDoclingIntegration gates the extractor tests that shell out to an
+// external command: they are skipped on Windows (POSIX-only `cat` stand-in) and
+// unless RUN_INTEGRATION_TESTS is set, per the repo's integration-test policy.
+func requireDoclingIntegration(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping POSIX-only command test on Windows")
+	}
+	if os.Getenv("RUN_INTEGRATION_TESTS") == "" {
+		t.Skip("set RUN_INTEGRATION_TESTS=1 to run integration tests")
+	}
+}
 
 // structuredJSON is a minimal DoclingDocument with a title, a section header,
 // and a paragraph carrying provenance, used to exercise the structured path
@@ -30,9 +44,7 @@ const structuredJSON = `{
 // emits DoclingDocument JSON; the extractor returns ordered blocks, rendered
 // Markdown, and the title.
 func TestDoclingExtractor_ExtractStructured(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping POSIX-only command test on Windows")
-	}
+	requireDoclingIntegration(t)
 	ex := ingest.NewDoclingExtractor("cat {input}")
 	res, err := ex.ExtractStructured(context.Background(), "doc.json", []byte(structuredJSON))
 	if err != nil {
@@ -71,9 +83,7 @@ func TestDoclingExtractor_ExtractStructured(t *testing.T) {
 // Extract entrypoint linearizes a DoclingDocument to Markdown (so the default
 // `--to json` command still yields Markdown for the extracted_markdown rep).
 func TestDoclingExtractor_Extract_RendersStructuredAsMarkdown(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping POSIX-only command test on Windows")
-	}
+	requireDoclingIntegration(t)
 	ex := ingest.NewDoclingExtractor("cat {input}")
 	md, err := ex.Extract(context.Background(), "doc.json", []byte(structuredJSON))
 	if err != nil {
@@ -91,9 +101,7 @@ func TestDoclingExtractor_Extract_RendersStructuredAsMarkdown(t *testing.T) {
 // TestDoclingExtractor_Extract_FlatFallback pins backward compatibility: a
 // custom command emitting non-JSON (flat Markdown) is returned verbatim.
 func TestDoclingExtractor_Extract_FlatFallback(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping POSIX-only command test on Windows")
-	}
+	requireDoclingIntegration(t)
 	ex := ingest.NewDoclingExtractor("cat {input}")
 	md, err := ex.Extract(context.Background(), "sample.md", []byte("# Plain markdown\n\nbody"))
 	if err != nil {

--- a/tests/ingest/docling_structured_test.go
+++ b/tests/ingest/docling_structured_test.go
@@ -1,0 +1,105 @@
+package tests
+
+import (
+	"context"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/ingest"
+)
+
+// structuredJSON is a minimal DoclingDocument with a title, a section header,
+// and a paragraph carrying provenance, used to exercise the structured path
+// through the docling extractor without a real docling binary.
+const structuredJSON = `{
+  "schema_name": "DoclingDocument", "version": "1.2.0", "name": "Report",
+  "pages": { "1": { "size": { "width": 612, "height": 792 }, "page_no": 1 } },
+  "body": { "self_ref": "#/body", "children": [
+    { "$ref": "#/texts/0" }, { "$ref": "#/texts/1" }, { "$ref": "#/texts/2" }
+  ]},
+  "texts": [
+    { "self_ref": "#/texts/0", "label": "title", "text": "Report" },
+    { "self_ref": "#/texts/1", "label": "section_header", "level": 1, "text": "Results" },
+    { "self_ref": "#/texts/2", "label": "paragraph", "text": "Revenue grew.",
+      "prov": [{ "page_no": 1, "bbox": { "l": 72, "t": 100, "r": 500, "b": 120, "coord_origin": "TOPLEFT" }}] }
+  ]
+}`
+
+// TestDoclingExtractor_ExtractStructured pins the structured path: the command
+// emits DoclingDocument JSON; the extractor returns ordered blocks, rendered
+// Markdown, and the title.
+func TestDoclingExtractor_ExtractStructured(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping POSIX-only command test on Windows")
+	}
+	ex := ingest.NewDoclingExtractor("cat {input}")
+	res, err := ex.ExtractStructured(context.Background(), "doc.json", []byte(structuredJSON))
+	if err != nil {
+		t.Fatalf("ExtractStructured: %v", err)
+	}
+	if res.Title != "Report" {
+		t.Errorf("title = %q, want Report", res.Title)
+	}
+	if len(res.Blocks) != 3 {
+		t.Fatalf("blocks = %d, want 3", len(res.Blocks))
+	}
+	for _, want := range []string{"# Report", "# Results", "Revenue grew."} {
+		if !strings.Contains(res.Markdown, want) {
+			t.Errorf("markdown missing %q:\n%s", want, res.Markdown)
+		}
+	}
+	// The paragraph block must carry its page provenance.
+	found := false
+	for _, b := range res.Blocks {
+		if strings.TrimSpace(b.Text) == "Revenue grew." {
+			found = true
+			if b.Page != 1 || b.BBox == nil {
+				t.Errorf("paragraph provenance lost: page=%d bbox=%v", b.Page, b.BBox)
+			}
+			if len(b.Section) != 1 || b.Section[0] != "Results" {
+				t.Errorf("paragraph section = %v, want [Results]", b.Section)
+			}
+		}
+	}
+	if !found {
+		t.Error("paragraph block not found")
+	}
+}
+
+// TestDoclingExtractor_Extract_RendersStructuredAsMarkdown pins that the flat
+// Extract entrypoint linearizes a DoclingDocument to Markdown (so the default
+// `--to json` command still yields Markdown for the extracted_markdown rep).
+func TestDoclingExtractor_Extract_RendersStructuredAsMarkdown(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping POSIX-only command test on Windows")
+	}
+	ex := ingest.NewDoclingExtractor("cat {input}")
+	md, err := ex.Extract(context.Background(), "doc.json", []byte(structuredJSON))
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if !strings.Contains(md, "# Results") || !strings.Contains(md, "Revenue grew.") {
+		t.Errorf("structured output not rendered to markdown:\n%s", md)
+	}
+	// Raw JSON must not leak into the representation text.
+	if strings.Contains(md, "self_ref") || strings.Contains(md, "schema_name") {
+		t.Errorf("raw docling JSON leaked into markdown:\n%s", md)
+	}
+}
+
+// TestDoclingExtractor_Extract_FlatFallback pins backward compatibility: a
+// custom command emitting non-JSON (flat Markdown) is returned verbatim.
+func TestDoclingExtractor_Extract_FlatFallback(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping POSIX-only command test on Windows")
+	}
+	ex := ingest.NewDoclingExtractor("cat {input}")
+	md, err := ex.Extract(context.Background(), "sample.md", []byte("# Plain markdown\n\nbody"))
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if strings.TrimSpace(md) != "# Plain markdown\n\nbody" {
+		t.Errorf("flat fallback altered output: %q", md)
+	}
+}

--- a/tests/ingest/structured_chunk_test.go
+++ b/tests/ingest/structured_chunk_test.go
@@ -1,0 +1,106 @@
+package tests
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/ingest/docling"
+)
+
+func bbox(page int) *docling.BBox {
+	return &docling.BBox{Page: page, L: 10, T: 20, R: 30, B: 40, CoordOrigin: "TOPLEFT"}
+}
+
+// TestChunkStructuredBlocks_GroupsBySectionWithRegionSpans pins that
+// consecutive blocks in the same section are grouped into one chunk carrying a
+// region span with that section breadcrumb, and a new section starts a new
+// chunk.
+func TestChunkStructuredBlocks_GroupsBySectionWithRegionSpans(t *testing.T) {
+	blocks := []docling.Block{
+		{Label: "section_header", Text: "Results", Page: 1, BBox: bbox(1)},
+		{Label: "paragraph", Text: "First point.", Page: 1, BBox: bbox(1), Section: []string{"Results"}},
+		{Label: "paragraph", Text: "Second point.", Page: 1, BBox: bbox(1), Section: []string{"Results"}},
+		{Label: "section_header", Text: "Outlook", Page: 2, BBox: bbox(2), Section: []string{}},
+		{Label: "paragraph", Text: "Future stuff.", Page: 2, BBox: bbox(2), Section: []string{"Outlook"}},
+	}
+	segs := ingest.ChunkStructuredBlocks(blocks)
+	if len(segs) == 0 {
+		t.Fatal("no segments produced")
+	}
+
+	// Every segment must carry a region span with a bbox.
+	for i, s := range segs {
+		if s.Span.Kind != "region" {
+			t.Errorf("segment %d kind = %q, want region", i, s.Span.Kind)
+			continue
+		}
+		if s.Span.Region == nil || s.Span.Region.BBox == nil {
+			t.Errorf("segment %d missing region/bbox: %+v", i, s.Span)
+		}
+	}
+
+	// The two "Results" paragraphs should land in a chunk whose span breadcrumb
+	// is [Results].
+	var resultsSeg *ingest.ChunkSegment
+	for i := range segs {
+		if strings.Contains(segs[i].Text, "First point.") {
+			resultsSeg = &segs[i]
+		}
+	}
+	if resultsSeg == nil {
+		t.Fatal("Results content not found in any segment")
+	}
+	if !strings.Contains(resultsSeg.Text, "Second point.") {
+		t.Errorf("expected both Results paragraphs grouped, got: %q", resultsSeg.Text)
+	}
+	if r := resultsSeg.Span.Region; r == nil || len(r.Section) != 1 || r.Section[0] != "Results" {
+		t.Errorf("Results chunk section = %v, want [Results]", sectionOf(resultsSeg))
+	}
+}
+
+// TestChunkStructuredBlocks_TableIsAtomic pins that a table block becomes its
+// own chunk, not merged with surrounding paragraphs.
+func TestChunkStructuredBlocks_TableIsAtomic(t *testing.T) {
+	blocks := []docling.Block{
+		{Label: "paragraph", Text: "Intro paragraph.", Page: 1, BBox: bbox(1), Section: []string{"S"}},
+		{Label: "table", Text: "| A | B |\n| --- | --- |\n| 1 | 2 |", Page: 1, BBox: bbox(1), Section: []string{"S"}},
+		{Label: "paragraph", Text: "Trailing paragraph.", Page: 1, BBox: bbox(1), Section: []string{"S"}},
+	}
+	segs := ingest.ChunkStructuredBlocks(blocks)
+
+	var tableSeg *ingest.ChunkSegment
+	for i := range segs {
+		if strings.Contains(segs[i].Text, "| A | B |") {
+			tableSeg = &segs[i]
+		}
+	}
+	if tableSeg == nil {
+		t.Fatal("table segment not found")
+	}
+	if strings.Contains(tableSeg.Text, "Intro paragraph.") || strings.Contains(tableSeg.Text, "Trailing paragraph.") {
+		t.Errorf("table not atomic, merged with prose: %q", tableSeg.Text)
+	}
+}
+
+// TestChunkStructuredBlocks_PageSpanFallback pins that a block without a
+// bounding box degrades to a page span rather than a region span.
+func TestChunkStructuredBlocks_PageSpanFallback(t *testing.T) {
+	blocks := []docling.Block{
+		{Label: "paragraph", Text: "No geometry here.", Page: 4, BBox: nil, Section: []string{"X"}},
+	}
+	segs := ingest.ChunkStructuredBlocks(blocks)
+	if len(segs) != 1 {
+		t.Fatalf("segments = %d, want 1", len(segs))
+	}
+	if segs[0].Span.Kind != "page" || segs[0].Span.Page != 4 {
+		t.Errorf("span = %+v, want page span on page 4", segs[0].Span)
+	}
+}
+
+func sectionOf(s *ingest.ChunkSegment) []string {
+	if s == nil || s.Span.Region == nil {
+		return nil
+	}
+	return s.Span.Region.Section
+}

--- a/tests/mcp/region_span_test.go
+++ b/tests/mcp/region_span_test.go
@@ -1,9 +1,10 @@
-package mcp
+package tests
 
 import (
 	"reflect"
 	"testing"
 
+	"github.com/dirstral/dir2mcp/internal/mcp"
 	"github.com/dirstral/dir2mcp/internal/model"
 )
 
@@ -20,7 +21,7 @@ func TestBuildOpenFileSpan_Region(t *testing.T) {
 			Label:     "paragraph",
 		},
 	}
-	got := buildOpenFileSpan(span)
+	got := mcp.BuildOpenFileSpan(span)
 
 	if got["kind"] != "region" {
 		t.Fatalf("kind = %v, want region", got["kind"])
@@ -48,7 +49,7 @@ func TestBuildOpenFileSpan_Region(t *testing.T) {
 // bbox) degrades to a page span on the start page, and to the document variant
 // when no page is available, so clients always receive a usable citation.
 func TestBuildOpenFileSpan_RegionDegrades(t *testing.T) {
-	noBBox := buildOpenFileSpan(model.Span{
+	noBBox := mcp.BuildOpenFileSpan(model.Span{
 		Kind:   "region",
 		Region: &model.RegionSpan{StartPage: 5, EndPage: 5},
 	})
@@ -56,7 +57,7 @@ func TestBuildOpenFileSpan_RegionDegrades(t *testing.T) {
 		t.Errorf("no-bbox region = %+v, want page span on 5", noBBox)
 	}
 
-	empty := buildOpenFileSpan(model.Span{Kind: "region"})
+	empty := mcp.BuildOpenFileSpan(model.Span{Kind: "region"})
 	if empty["kind"] != "document" {
 		t.Errorf("payload-less region = %+v, want document variant", empty)
 	}
@@ -65,15 +66,15 @@ func TestBuildOpenFileSpan_RegionDegrades(t *testing.T) {
 // TestBuildOpenFileSpan_ScalarKindsUnchanged guards that adding region did not
 // disturb the existing kinds.
 func TestBuildOpenFileSpan_ScalarKindsUnchanged(t *testing.T) {
-	lines := buildOpenFileSpan(model.Span{Kind: "lines", StartLine: 12, EndLine: 48})
+	lines := mcp.BuildOpenFileSpan(model.Span{Kind: "lines", StartLine: 12, EndLine: 48})
 	if lines["kind"] != "lines" || lines["start_line"] != 12 || lines["end_line"] != 48 {
 		t.Errorf("lines span wrong: %+v", lines)
 	}
-	page := buildOpenFileSpan(model.Span{Kind: "page", Page: 7})
+	page := mcp.BuildOpenFileSpan(model.Span{Kind: "page", Page: 7})
 	if page["kind"] != "page" || page["page"] != 7 {
 		t.Errorf("page span wrong: %+v", page)
 	}
-	tm := buildOpenFileSpan(model.Span{Kind: "time", StartMS: 1000, EndMS: 5000})
+	tm := mcp.BuildOpenFileSpan(model.Span{Kind: "time", StartMS: 1000, EndMS: 5000})
 	if tm["kind"] != "time" || tm["start_ms"] != 1000 || tm["end_ms"] != 5000 {
 		t.Errorf("time span wrong: %+v", tm)
 	}

--- a/tests/store/spans_region_test.go
+++ b/tests/store/spans_region_test.go
@@ -1,14 +1,15 @@
-package store
+package tests
 
 import (
 	"strings"
 	"testing"
 
 	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
 )
 
-// TestRegionSpanRoundTrip pins that a region span survives spanToRow ->
-// spanFromRow: page range comes back from start/end, and bbox/section/label
+// TestRegionSpanRoundTrip pins that a region span survives SpanToRow ->
+// SpanFromRow: the page range comes back from start/end, and bbox/section/label
 // come back from the extra_json payload (spec 0.9.0 §5.4).
 func TestRegionSpanRoundTrip(t *testing.T) {
 	in := model.Span{
@@ -16,17 +17,15 @@ func TestRegionSpanRoundTrip(t *testing.T) {
 		Region: &model.RegionSpan{
 			StartPage: 3,
 			EndPage:   3,
-			BBox: &model.BBox{
-				Page: 3, L: 72, T: 90.5, R: 523, B: 410.2, CoordOrigin: "TOPLEFT",
-			},
-			Section: []string{"Results", "3.1 Revenue"},
-			Label:   "paragraph",
+			BBox:      &model.BBox{Page: 3, L: 72, T: 90.5, R: 523, B: 410.2, CoordOrigin: "TOPLEFT"},
+			Section:   []string{"Results", "3.1 Revenue"},
+			Label:     "paragraph",
 		},
 	}
 
-	kind, start, end, extra, err := spanToRow(in)
+	kind, start, end, extra, err := store.SpanToRow(in)
 	if err != nil {
-		t.Fatalf("spanToRow: %v", err)
+		t.Fatalf("SpanToRow: %v", err)
 	}
 	if kind != "region" || start != 3 || end != 3 {
 		t.Fatalf("row = (%q,%d,%d), want (region,3,3)", kind, start, end)
@@ -35,7 +34,7 @@ func TestRegionSpanRoundTrip(t *testing.T) {
 		t.Fatal("region span must produce a non-empty extra_json payload")
 	}
 
-	out := spanFromRow(kind, start, end, extra)
+	out := store.SpanFromRow(kind, start, end, extra)
 	if out.Kind != "region" || out.Region == nil {
 		t.Fatalf("round-trip lost region: %+v", out)
 	}
@@ -71,11 +70,11 @@ func TestRegionSpanMultiPage(t *testing.T) {
 			BBox:      &model.BBox{Page: 4, L: 10, T: 20, R: 30, B: 40, CoordOrigin: "TOPLEFT"},
 		},
 	}
-	kind, start, end, extra, err := spanToRow(in)
+	kind, start, end, extra, err := store.SpanToRow(in)
 	if err != nil {
-		t.Fatalf("spanToRow: %v", err)
+		t.Fatalf("SpanToRow: %v", err)
 	}
-	out := spanFromRow(kind, start, end, extra)
+	out := store.SpanFromRow(kind, start, end, extra)
 	if out.Region == nil || out.Region.StartPage != 4 || out.Region.EndPage != 5 {
 		t.Fatalf("page range lost: %+v", out.Region)
 	}
@@ -84,7 +83,7 @@ func TestRegionSpanMultiPage(t *testing.T) {
 	}
 }
 
-// TestRegionSpanToRow_Rejects pins the validation guards in spanToRow.
+// TestRegionSpanToRow_Rejects pins the validation guards in SpanToRow.
 func TestRegionSpanToRow_Rejects(t *testing.T) {
 	cases := map[string]model.Span{
 		"missing region payload": {Kind: "region"},
@@ -94,7 +93,7 @@ func TestRegionSpanToRow_Rejects(t *testing.T) {
 	}
 	for name, span := range cases {
 		t.Run(name, func(t *testing.T) {
-			if _, _, _, _, err := spanToRow(span); err == nil {
+			if _, _, _, _, err := store.SpanToRow(span); err == nil {
 				t.Errorf("expected error for %q", name)
 			}
 		})
@@ -112,7 +111,7 @@ func TestRegionSpanFromRow_DegradesToPage(t *testing.T) {
 		"no bbox":        `{"section":["A"]}`,
 	} {
 		t.Run(name, func(t *testing.T) {
-			got := spanFromRow("region", 7, 7, extra)
+			got := store.SpanFromRow("region", 7, 7, extra)
 			if got.Kind != "page" || got.Page != 7 {
 				t.Errorf("degraded span = %+v, want page span on page 7", got)
 			}
@@ -120,7 +119,7 @@ func TestRegionSpanFromRow_DegradesToPage(t *testing.T) {
 	}
 
 	// A region row with an unusable page range degrades to lines.
-	if got := spanFromRow("region", 0, 0, `{"bbox":{"page":1}}`); got.Kind != "lines" {
+	if got := store.SpanFromRow("region", 0, 0, `{"bbox":{"page":1}}`); got.Kind != "lines" {
 		t.Errorf("zero page range should degrade to lines, got %+v", got)
 	}
 }
@@ -134,14 +133,14 @@ func TestScalarSpansUnaffected(t *testing.T) {
 		{Kind: "time", StartMS: 1000, EndMS: 5000},
 	}
 	for _, in := range cases {
-		kind, start, end, extra, err := spanToRow(in)
+		kind, start, end, extra, err := store.SpanToRow(in)
 		if err != nil {
-			t.Fatalf("spanToRow(%+v): %v", in, err)
+			t.Fatalf("SpanToRow(%+v): %v", in, err)
 		}
 		if extra != "" {
 			t.Errorf("%s span must have empty extra_json, got %q", kind, extra)
 		}
-		out := spanFromRow(kind, start, end, extra)
+		out := store.SpanFromRow(kind, start, end, extra)
 		if out.Kind != in.Kind || out.Region != nil {
 			t.Errorf("round-trip changed %+v -> %+v", in, out)
 		}


### PR DESCRIPTION
## Summary

Makes dir2mcp consume docling's **structured `DoclingDocument`** output instead of flat Markdown, preserving reading order, section hierarchy, per-element page/bounding-box provenance, atomic tables, and figure captions — and surfaces that provenance in client-facing citations as a new `region` span kind.

Implements spec **0.9.0** (dirstral-spec#8, merged). The submodule is re-pinned to it as the base commit of this branch (the gated re-pin half of the spec-governance loop).

## Commits

1. `chore(spec)` — re-pin dirstral-spec submodule to 0.9.0 (`f333ad8`).
2. **Phase 1** `internal/ingest/docling` package — tolerant `DoclingDocument` JSON model; reading-order linearizer (resolves `$ref`/`cref`, threads a section-heading breadcrumb, attaches per-element primary-page + union bbox normalized to TOPLEFT); Markdown renderer; title from the TITLE element. Unit tests against a JSON fixture (no docling binary needed).
3. **Phase 2** `region` span kind — `model.Span` gains `Region *RegionSpan` (nil for scalar kinds, so `Span` stays comparable). Stored via the existing `spans.extra_json` column — **no schema migration**. Read/write round-trip + degradation tests.
4. **Phase 3** structured extractor — default docling command switches to `--to json`; `Extract` linearizes JSON → Markdown (falls back to verbatim for custom `--to md`); new `ExtractStructured` behind a `structuredExtractor` interface. Mistral OCR keeps the flat/page-separated path.
5. **Phase 4** section-aware chunking + rep-gen — group consecutive blocks by section breadcrumb then split by size; tables atomic; each chunk carries a region span (degrading to a page span when provenance is absent). `extracted_markdown` stays rendered Markdown; raw JSON cached privately under `<state>/cache/docling`. Title prefers the document's title element.
6. **Phase 5** MCP citation surface — `buildOpenFileSpan` (shared by open_file / search hits / ask citations) renders the `region` kind per §15.1.1, degrading to page/document.
7. `fix(ingest)` — **wires the structured path into `generateOCRMarkdownRepresentation`** (the phase-4 service.go edit had not landed, leaving the structured path dead code) and brings the new functions under the gocyclo budget.
8. `docs(readme)` — update the docling default to `--to json` and document region citations.

## Compatibility

Additive and backward compatible. Existing `lines|page|time` spans, the flat-Markdown fallback for custom `docling_command` setups, and the Mistral OCR path are unchanged. Documents indexed before this change keep their old spans until re-indexed.

## Verification

`make check` passes: build, gofmt, `go vet`, golangci-lint, gocyclo (`-over 15`), 23 Go test packages, and the python suites all green. New tests cover the docling linearizer, region span store round-trip + degradation, the structured extractor path, section-aware chunking (atomic tables / page fallback), and MCP region span rendering.

## Scoping notes

- No new per-flag config knobs: the existing `docling_command` template remains the single override for docling flags (table-mode/OCR/enrichment), matching spec 0.9.0 which introduced no new config surface.
- Citations: the structured MCP span output is the client-facing provenance surface (region/bbox/section flow through search/ask/open_file). The human-readable answer attribution cites by `[rel_path]` and is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
