### PR TITLE
feat(doctor): surface silent extraction/embedding coverage gaps

### DIFF
--- a/internal/cli/server_doctor.go
+++ b/internal/cli/server_doctor.go
@@ -62,6 +62,7 @@ func (a *App) runServerDoctor(ctx context.Context, global globalOptions, args []
 		providerCheck(cfg, "embed", provider.CapEmbed, true),
 		providerCheck(cfg, "chat", provider.CapChat, false),
 		extractorCheck(cfg),
+		extractionCoverageCheck(ctx, a, cfg),
 		indexingFailureCheck(ctx, a, cfg),
 	)
 	return a.renderDoctorReport(global, checks)
@@ -141,6 +142,76 @@ func extractorCheck(cfg config.Config) doctorCheck {
 		status = doctorStatusWarn
 	}
 	return doctorCheck{Name: "extractor", Status: status, Detail: detail}
+}
+
+// extractionCoverageCheck surfaces the two silent failures behind a corpus
+// that returns "no relevant context" on every ask: (A) documents that need an
+// extractor (pdf/image/document) exist, but no extractor is available, so they
+// produce no searchable text; and (B) chunks exist but none are embedded, so
+// search matches nothing. Both are reported with the concrete document/chunk
+// counts and the remedial command, since the user-facing symptom (empty
+// answers) gives no hint of the cause.
+//
+// Like indexingFailureCheck, it reads CorpusStats from the SQLite store and
+// degrades gracefully when there is no index yet or the store is not
+// SQLite-backed.
+func extractionCoverageCheck(ctx context.Context, a *App, cfg config.Config) doctorCheck {
+	const name = "extraction_coverage"
+	metaPath := filepath.Join(cfg.StateDir, "meta.sqlite")
+	if _, err := os.Stat(metaPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return doctorCheck{Name: name, Status: doctorStatusOK, Detail: "no index yet"}
+		}
+		return doctorCheck{Name: name, Status: doctorStatusError, Detail: fmt.Sprintf("stat %s: %v", metaPath, err)}
+	}
+	st := a.storeForConfig(cfg)
+	defer func() { _ = st.Close() }()
+	sqliteStore, ok := st.(*store.SQLiteStore)
+	if !ok {
+		return doctorCheck{Name: name, Status: doctorStatusWarn, Detail: "store is not SQLite-backed; coverage aggregation unavailable"}
+	}
+	if err := sqliteStore.Init(ctx); err != nil && !errors.Is(err, model.ErrNotImplemented) {
+		return doctorCheck{Name: name, Status: doctorStatusError, Detail: fmt.Sprintf("initialize store: %v", err)}
+	}
+	stats, err := sqliteStore.CorpusStats(ctx)
+	if err != nil {
+		return doctorCheck{Name: name, Status: doctorStatusError, Detail: err.Error()}
+	}
+
+	// Count documents whose type requires an extractor to become searchable.
+	var extractable int64
+	for docType, n := range stats.DocCounts {
+		if ingest.ShouldGenerateExtractedMarkdown(docType) {
+			extractable += n
+		}
+	}
+
+	// (A) Extractable documents exist but no extractor will run: those
+	// documents produce no representation, no chunks, and never appear in any
+	// answer. This is a hard configuration dead-end, so it is an error.
+	if extractable > 0 {
+		if d := ingest.DescribeDocumentExtractor(cfg); d.Name == "" {
+			detail := fmt.Sprintf(
+				"%d document(s) need extraction (pdf/image/document) but no extractor is available: %s. "+
+					"They produce no searchable text. Install docling or set MISTRAL_API_KEY, then run `dir2mcp reindex`.",
+				extractable, d.Reason)
+			return doctorCheck{Name: name, Status: doctorStatusError, Detail: detail}
+		}
+	}
+
+	// (B) Chunks were created but none are embedded: extraction succeeded yet
+	// search still matches nothing. Warn (it can also be a transient mid-index
+	// state) with the remedial action.
+	if stats.ChunksTotal > 0 && stats.EmbeddedOK == 0 {
+		detail := fmt.Sprintf(
+			"%d chunk(s) indexed but 0 embedded; no embedding provider has run. "+
+				"Set a provider credential (e.g. MISTRAL_API_KEY / OPENAI_API_KEY) and run `dir2mcp reindex`.",
+			stats.ChunksTotal)
+		return doctorCheck{Name: name, Status: doctorStatusWarn, Detail: detail}
+	}
+
+	return doctorCheck{Name: name, Status: doctorStatusOK, Detail: fmt.Sprintf(
+		"%d extractable doc(s); %d/%d chunks embedded", extractable, stats.EmbeddedOK, stats.ChunksTotal)}
 }
 
 // indexingFailureCheck reads the store-level FailureSummary (set by

--- a/internal/cli/server_doctor.go
+++ b/internal/cli/server_doctor.go
@@ -200,7 +200,8 @@ func extractionCoverageCheck(ctx context.Context, a *App, cfg config.Config) doc
 		if d := ingest.DescribeDocumentExtractor(cfg); d.Name == "" {
 			detail := fmt.Sprintf(
 				"%d document(s) need extraction (pdf/image/document) but no extractor is available: %s. "+
-					"They produce no searchable text. Install docling or set MISTRAL_API_KEY, then run `dir2mcp reindex`.",
+					"They produce no searchable text. Enable an extractor (set ingest.extractor to auto/docling/mistral, "+
+					"not off), then make one available (install docling or set MISTRAL_API_KEY), and run `dir2mcp reindex`.",
 				extractable, d.Reason)
 			return doctorCheck{Name: name, Status: doctorStatusError, Detail: detail}
 		}

--- a/internal/cli/server_doctor.go
+++ b/internal/cli/server_doctor.go
@@ -179,8 +179,15 @@ func extractionCoverageCheck(ctx context.Context, a *App, cfg config.Config) doc
 	}
 
 	// Count documents whose type requires an extractor to become searchable.
+	// Restrict to index-eligible rows (deleted=0 AND status='ok') so skipped
+	// or already-errored documents don't inflate the "needs extraction" count
+	// or trip a false error — those are surfaced by indexing_failures instead.
+	okCounts, err := sqliteStore.ActiveDocCountsByStatus(ctx, "ok")
+	if err != nil {
+		return doctorCheck{Name: name, Status: doctorStatusError, Detail: err.Error()}
+	}
 	var extractable int64
-	for docType, n := range stats.DocCounts {
+	for docType, n := range okCounts {
 		if ingest.ShouldGenerateExtractedMarkdown(docType) {
 			extractable += n
 		}

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -60,6 +60,48 @@ type dbExecutor interface {
 	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
 }
 
+// ActiveDocCountsByStatus returns per-doc_type counts of non-deleted documents
+// filtered to the given status (e.g. "ok"). Diagnostics that must reflect only
+// the documents the indexer will actually attempt to process use this so they
+// do not count skipped/errored rows. An empty status counts all non-deleted
+// documents (equivalent to the corpus-wide DocCounts).
+func (s *SQLiteStore) ActiveDocCountsByStatus(ctx context.Context, status string) (map[string]int64, error) {
+	db, err := s.ensureDB(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer s.ReleaseDB()
+
+	query := `SELECT doc_type, COUNT(*) FROM documents WHERE deleted = 0 GROUP BY doc_type`
+	args := []any{}
+	if strings.TrimSpace(status) != "" {
+		query = `SELECT doc_type, COUNT(*) FROM documents WHERE deleted = 0 AND status = ? GROUP BY doc_type`
+		args = append(args, status)
+	}
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	counts := make(map[string]int64)
+	for rows.Next() {
+		var (
+			docType string
+			count   int64
+		)
+		if err := rows.Scan(&docType, &count); err != nil {
+			return nil, err
+		}
+		docType = strings.TrimSpace(docType)
+		if docType == "" {
+			docType = "unknown"
+		}
+		counts[docType] += count
+	}
+	return counts, rows.Err()
+}
+
 // activeDocCountsWith encapsulates the query logic previously found in
 // SQLiteStore.ActiveDocCounts.  It accepts any dbExecutor so callers can reuse
 // an existing *sql.DB or a *sql.Tx without having to open a handle again.

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -74,9 +74,11 @@ func (s *SQLiteStore) ActiveDocCountsByStatus(ctx context.Context, status string
 
 	query := `SELECT doc_type, COUNT(*) FROM documents WHERE deleted = 0 GROUP BY doc_type`
 	args := []any{}
-	if strings.TrimSpace(status) != "" {
+	// Trim once and use the trimmed value for both the conditional and the SQL
+	// arg, so a whitespace-padded status doesn't silently match nothing.
+	if trimmed := strings.TrimSpace(status); trimmed != "" {
 		query = `SELECT doc_type, COUNT(*) FROM documents WHERE deleted = 0 AND status = ? GROUP BY doc_type`
-		args = append(args, status)
+		args = append(args, trimmed)
 	}
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {

--- a/tests/cli/server_doctor_coverage_test.go
+++ b/tests/cli/server_doctor_coverage_test.go
@@ -1,0 +1,142 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/cli"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+	"github.com/dirstral/dir2mcp/tests/testutil"
+)
+
+// runDoctorReport runs `dir2mcp --json doctor` in tmp and returns the decoded
+// checks. It mirrors the setup the sibling doctor tests use.
+func runDoctorReport(t *testing.T, tmp string) []struct {
+	Name   string `json:"name"`
+	Status string `json:"status"`
+	Detail string `json:"detail"`
+} {
+	t.Helper()
+	var report struct {
+		Checks []struct {
+			Name   string `json:"name"`
+			Status string `json:"status"`
+			Detail string `json:"detail"`
+		} `json:"checks"`
+	}
+	testutil.WithWorkingDir(t, tmp, func() {
+		var stdout, stderr bytes.Buffer
+		app := cli.NewAppWithIO(&stdout, &stderr)
+		if code := app.Run([]string{"--json", "doctor"}); code != 0 && code != 1 {
+			t.Fatalf("doctor exit=%d stderr=%q", code, stderr.String())
+		}
+		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+			t.Fatalf("decode doctor JSON: %v body=%q", err, stdout.String())
+		}
+	})
+	return report.Checks
+}
+
+// seedDoctorStore initializes the SQLite metadata store under tmp/.dir2mcp and
+// runs fn against it, then closes it.
+func seedDoctorStore(t *testing.T, tmp string, fn func(ctx context.Context, st *store.SQLiteStore)) {
+	t.Helper()
+	ctx := context.Background()
+	st := store.NewSQLiteStore(filepath.Join(tmp, ".dir2mcp", "meta.sqlite"))
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("init store: %v", err)
+	}
+	fn(ctx, st)
+	_ = st.Close()
+}
+
+// TestServerDoctor_ExtractionCoverage_NoExtractor pins the loud diagnostic for
+// the lean-build failure mode: extractable documents (PDFs) exist but no
+// extractor is available, so they never become searchable. The check must be
+// an error and name the remedy.
+func TestServerDoctor_ExtractionCoverage_NoExtractor(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("MISTRAL_API_KEY", "")             // no Mistral OCR fallback
+	t.Setenv("DIR2MCP_INGEST_EXTRACTOR", "off") // force extractor decision to disabled
+	t.Setenv("PATH", t.TempDir())               // no docling on PATH
+
+	seedDoctorStore(t, tmp, func(ctx context.Context, st *store.SQLiteStore) {
+		for _, p := range []string{"a.pdf", "b.pdf"} {
+			if err := st.UpsertDocument(ctx, model.Document{RelPath: p, DocType: "pdf", Status: "ok"}); err != nil {
+				t.Fatalf("seed %s: %v", p, err)
+			}
+		}
+	})
+
+	c := findCheck(runDoctorReport(t, tmp), "extraction_coverage")
+	if c == nil {
+		t.Fatal("extraction_coverage check missing")
+	}
+	if c.Status != "error" {
+		t.Errorf("status = %q, want error", c.Status)
+	}
+	for _, want := range []string{"2 document(s) need extraction", "no extractor", "reindex"} {
+		if !strings.Contains(c.Detail, want) {
+			t.Errorf("detail missing %q: %s", want, c.Detail)
+		}
+	}
+}
+
+// TestServerDoctor_ExtractionCoverage_NoEmbeddings pins the second silent
+// failure: chunks were created but none embedded, so search matches nothing.
+func TestServerDoctor_ExtractionCoverage_NoEmbeddings(t *testing.T) {
+	tmp := t.TempDir()
+	// A docling command makes the extractor "available" so we exercise the
+	// embedding branch, not the no-extractor branch. `cat` is a harmless stand-in.
+	t.Setenv("DIR2MCP_INGEST_EXTRACTOR", "docling")
+	t.Setenv("DIR2MCP_DOCLING_COMMAND", "cat {input}")
+
+	seedDoctorStore(t, tmp, func(ctx context.Context, st *store.SQLiteStore) {
+		if err := st.UpsertDocument(ctx, model.Document{RelPath: "notes.md", DocType: "md", Status: "ok"}); err != nil {
+			t.Fatalf("seed doc: %v", err)
+		}
+		repID, err := st.UpsertRepresentation(ctx, model.Representation{DocID: 1, RepType: "raw_text", RepHash: "h1"})
+		if err != nil {
+			t.Fatalf("seed rep: %v", err)
+		}
+		// A pending (not embedded) chunk: chunks_total=1, embedded_ok=0.
+		if _, err := st.InsertChunkWithSpans(ctx, model.Chunk{
+			RepID: repID, Ordinal: 0, Text: "hello", TextHash: "t1",
+			IndexKind: "text", EmbeddingStatus: "pending",
+		}, []model.Span{{Kind: "lines", StartLine: 1, EndLine: 1}}); err != nil {
+			t.Fatalf("seed chunk: %v", err)
+		}
+	})
+
+	c := findCheck(runDoctorReport(t, tmp), "extraction_coverage")
+	if c == nil {
+		t.Fatal("extraction_coverage check missing")
+	}
+	if c.Status != "warn" {
+		t.Errorf("status = %q, want warn", c.Status)
+	}
+	for _, want := range []string{"indexed but 0 embedded", "MISTRAL_API_KEY", "reindex"} {
+		if !strings.Contains(c.Detail, want) {
+			t.Errorf("detail missing %q: %s", want, c.Detail)
+		}
+	}
+}
+
+// TestServerDoctor_ExtractionCoverage_NoIndex confirms the check passes
+// cleanly when there is no index yet (fresh install, nothing ingested).
+func TestServerDoctor_ExtractionCoverage_NoIndex(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("MISTRAL_API_KEY", "test-key")
+	c := findCheck(runDoctorReport(t, tmp), "extraction_coverage")
+	if c == nil {
+		t.Fatal("extraction_coverage check missing")
+	}
+	if c.Status != "ok" {
+		t.Errorf("status = %q (%s), want ok (no index yet)", c.Status, c.Detail)
+	}
+}

--- a/tests/cli/server_doctor_coverage_test.go
+++ b/tests/cli/server_doctor_coverage_test.go
@@ -52,7 +52,9 @@ func seedDoctorStore(t *testing.T, tmp string, fn func(ctx context.Context, st *
 		t.Fatalf("init store: %v", err)
 	}
 	fn(ctx, st)
-	_ = st.Close()
+	if err := st.Close(); err != nil {
+		t.Logf("warning: store close failed: %v", err)
+	}
 }
 
 // TestServerDoctor_ExtractionCoverage_NoExtractor pins the loud diagnostic for
@@ -100,7 +102,13 @@ func TestServerDoctor_ExtractionCoverage_NoEmbeddings(t *testing.T) {
 		if err := st.UpsertDocument(ctx, model.Document{RelPath: "notes.md", DocType: "md", Status: "ok"}); err != nil {
 			t.Fatalf("seed doc: %v", err)
 		}
-		repID, err := st.UpsertRepresentation(ctx, model.Representation{DocID: 1, RepType: "raw_text", RepHash: "h1"})
+		// Fetch the assigned doc_id rather than assuming it is 1, so the test
+		// is robust to bootstrap rows or schema changes.
+		doc, err := st.GetDocumentByPath(ctx, "notes.md")
+		if err != nil {
+			t.Fatalf("get seeded doc: %v", err)
+		}
+		repID, err := st.UpsertRepresentation(ctx, model.Representation{DocID: doc.DocID, RepType: "raw_text", RepHash: "h1"})
 		if err != nil {
 			t.Fatalf("seed rep: %v", err)
 		}
@@ -124,6 +132,38 @@ func TestServerDoctor_ExtractionCoverage_NoEmbeddings(t *testing.T) {
 		if !strings.Contains(c.Detail, want) {
 			t.Errorf("detail missing %q: %s", want, c.Detail)
 		}
+	}
+}
+
+// TestServerDoctor_ExtractionCoverage_SkippedNotCounted pins that only
+// index-eligible (status='ok') extractable documents are counted: a skipped
+// PDF must not trip the "needs extraction" error on its own.
+func TestServerDoctor_ExtractionCoverage_SkippedNotCounted(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("MISTRAL_API_KEY", "")
+	t.Setenv("DIR2MCP_INGEST_EXTRACTOR", "off")
+	t.Setenv("PATH", t.TempDir())
+
+	seedDoctorStore(t, tmp, func(ctx context.Context, st *store.SQLiteStore) {
+		// One ok PDF (counts) and one skipped PDF (must NOT count).
+		if err := st.UpsertDocument(ctx, model.Document{RelPath: "ok.pdf", DocType: "pdf", Status: "ok"}); err != nil {
+			t.Fatalf("seed ok pdf: %v", err)
+		}
+		if err := st.UpsertDocument(ctx, model.Document{RelPath: "big.pdf", DocType: "pdf", Status: "skipped"}); err != nil {
+			t.Fatalf("seed skipped pdf: %v", err)
+		}
+	})
+
+	c := findCheck(runDoctorReport(t, tmp), "extraction_coverage")
+	if c == nil {
+		t.Fatal("extraction_coverage check missing")
+	}
+	if c.Status != "error" {
+		t.Errorf("status = %q, want error", c.Status)
+	}
+	// Exactly one document should be counted, not two.
+	if !strings.Contains(c.Detail, "1 document(s) need extraction") {
+		t.Errorf("expected only the ok pdf counted (1), got: %s", c.Detail)
 	}
 }
 


### PR DESCRIPTION
## Summary

Track 2 of the client indexing investigation: make the **silent** failure behind an always-empty `ask()` **loud and actionable** in `dir2mcp doctor`.

The client (lean `dir2mcp`, legal PDF corpus) kept getting "No relevant context found" with no indication why. That message just means zero search hits — but the *cause* (PDFs discovered, no extractor → no chunks; or chunks created but never embedded) was invisible in every diagnostic surface. The data existed; it was just never combined.

## Change

New `extraction_coverage` check in `dir2mcp doctor`:

- **(A) error** — extractable docs (pdf/image/document) exist but no extractor is available: *"N document(s) need extraction but no extractor is available: <reason>. Install docling or set MISTRAL_API_KEY, then run `dir2mcp reindex`."* This is exactly the lean-build dead-end.
- **(B) warn** — `chunks_total > 0 && embedded_ok == 0`: *"N chunk(s) indexed but 0 embedded; set a provider credential and reindex."*
- Degrades gracefully: `ok "no index yet"` when there's no meta.sqlite; `warn` for a non-SQLite store.

Reads `CorpusStats` via the same pattern as the existing `indexingFailureCheck` — crosses per-doc-type counts with `DescribeDocumentExtractor` and `embedded_ok`.

## Scope

Diagnostics-only — **no MCP wire-contract / spec change**, no change to the `dir2mcp_stats` tool. Local `doctor` surface only. The `up` banner and `status` command already show the extractor decision; this adds the cross-referenced coverage verdict where an operator triaging "empty answers" will look.

## Verification

`make check` green (29 packages; gofmt/vet/golangci-lint/gocyclo clean). New tests cover the no-extractor error, no-embeddings warn, and no-index ok paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a doctor preflight check that reports extraction/embedding coverage and provides actionable remediation hints when extraction or embedding issues are detected.
* **Tests**
  * Expanded test coverage for the doctor command across multiple extraction/embedding scenarios, including no extractor, no embeddings, skipped documents, and fresh state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->