### PR TITLE
feat(ingest): continuous incremental indexing via filesystem watcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,8 @@ vary by deployment. The commonly used variables are:
 | `MISTRAL_API_KEY` | Conditional | Required for embeddings, Mistral-based extraction/STT, and generation; not required for docling-only read-only extraction flows |
 | `DIR2MCP_INGEST_EXTRACTOR` | No | Extraction provider mode: `auto` (default), `docling`, `mistral`, or `off` |
 | `DIR2MCP_DOCLING_COMMAND` | No | Optional local command template for document extraction (default: `docling --to json --output - {input}`); when set/available, it is preferred for PDF/image/office-style document extraction. The default requests structured JSON so ingestion preserves reading order, section hierarchy, and per-element page/bbox provenance (region citations); a custom `--to md` template still works and falls back to flat Markdown |
+| `DIR2MCP_INGEST_WATCH` | No | When `true`, a running `dir2mcp up` keeps a filesystem watcher live and incrementally indexes added/changed/deleted files (default: `false`) |
+| `DIR2MCP_INGEST_WATCH_DEBOUNCE` | No | Per-file debounce window for coalescing editor write bursts before re-indexing (default: `500ms`) |
 | `MISTRAL_BASE_URL` | No | Mistral base URL (default: `https://api.mistral.ai`) |
 | `DIR2MCP_AUTH_TOKEN` | No | Auth token override |
 | `DIR2MCP_SERVER_NAME` | No | Override the MCP server name (and suggested `claude mcp add` alias). Defaults to a unique `dir2mcp-<slug>-<6-hex>` derived from the indexed directory |
@@ -231,6 +233,23 @@ For Homebrew and other installed workflows, you can persist this in `.dir2mcp.ya
 ingest_extractor: auto
 docling_command: docling --to json --output - {input}
 ```
+
+### Continuous incremental indexing (optional)
+
+By default `dir2mcp up` scans the directory once at startup. Enable the **filesystem watcher** to keep the index continuously in sync with on-disk changes for the life of the process — added files are indexed, edited files are re-indexed, and removed files are tombstoned (evicted from retrieval).
+
+```yaml
+ingest:
+  watch: true            # default: false
+  watch_debounce: 500ms  # coalesce editor write bursts before re-indexing
+```
+
+Notes:
+
+- The watcher runs alongside the existing embedding worker, so newly indexed files become searchable automatically without a manual `reindex`.
+- It is **best-effort, not a correctness guarantee**: a low-frequency safety rescan reconciles anything missed (kernel event coalescing, OS watch limits on very large trees), so the index converges even if individual events are dropped.
+- Excluded paths, `.gitignore` rules, and size/type limits apply to watched changes exactly as they do to the initial scan.
+- Env equivalents: `DIR2MCP_INGEST_WATCH=true`, `DIR2MCP_INGEST_WATCH_DEBOUNCE=500ms`.
 
 ### Server identity
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/fsnotify/fsnotify v1.10.1
 	github.com/modelcontextprotocol/go-sdk v1.4.1
 	github.com/x402-foundation/x402/go v0.0.0-20260516161513-e35becffdc85
 	golang.org/x/term v0.40.0

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
+github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=
 github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -548,7 +548,13 @@ type watchable interface {
 func startWatchWorker(runCtx context.Context, readOnly, enabled bool, ing interface {
 	Run(context.Context) error
 }, stderr io.Writer) {
-	if readOnly || !enabled {
+	if !enabled {
+		return
+	}
+	if readOnly {
+		// Don't leave the knob silently inert — tell the operator continuous
+		// sync is disabled because the server is read-only.
+		_, _ = fmt.Fprintln(stderr, "warning: ingest.watch is enabled but ignored in read-only mode; continuous indexing is disabled")
 		return
 	}
 	w, ok := ing.(watchable)

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -146,6 +146,7 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 	ingestErrCh := make(chan error, 1)
 	go runCorpusWriter(runCtx, cfg.StateDir, st, indexingState, a.stderr, emitter)
 	startIngestWorker(runCtx, opts.readOnly, ing, indexingState, ingestErrCh)
+	startWatchWorker(runCtx, opts.readOnly, cfg.IngestWatch, ing, a.stderr)
 
 	return a.runEventLoop(runCtx, cancel, &cfg, st, indexingState, emitter, serverErrCh, ingestErrCh, embedErrCh, stdinQuitCh)
 }
@@ -529,6 +530,35 @@ func startIngestWorker(runCtx context.Context, readOnly bool, ing interface {
 			return
 		}
 		ingestErrCh <- runErr
+	}()
+}
+
+// watchable is implemented by ingestors that support continuous incremental
+// indexing via a filesystem watcher.
+type watchable interface {
+	Watch(context.Context) error
+}
+
+// startWatchWorker launches the filesystem watcher in the background when
+// ingest.watch is enabled and the ingestor supports it. It runs concurrently
+// with the initial scan; processDocument hash-diffs, so any overlap is a cheap
+// no-op. Watcher failures are non-fatal — the watcher's own periodic safety
+// rescan reconciles drift — so a setup error is logged rather than terminating
+// the server.
+func startWatchWorker(runCtx context.Context, readOnly, enabled bool, ing interface {
+	Run(context.Context) error
+}, stderr io.Writer) {
+	if readOnly || !enabled {
+		return
+	}
+	w, ok := ing.(watchable)
+	if !ok {
+		return
+	}
+	go func() {
+		if err := w.Watch(runCtx); err != nil && runCtx.Err() == nil {
+			_, _ = fmt.Fprintf(stderr, "watch: %v\n", err)
+		}
 	}()
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -130,6 +130,12 @@ type Config struct {
 	IngestAudioMode      string
 	IngestArchivesMode   string
 	IngestExtractor      string
+	// IngestWatch enables a filesystem watcher so a running server keeps
+	// indexing added/changed/deleted files after the initial scan. Opt-in.
+	IngestWatch bool
+	// IngestWatchDebounce coalesces editor write bursts: a path is processed
+	// once it has been quiet for this long.
+	IngestWatchDebounce time.Duration
 
 	STTProvider               string
 	STTMistralModel           string
@@ -202,6 +208,8 @@ type fileConfig struct {
 	IngestAudioMode           *string
 	IngestArchivesMode        *string
 	IngestExtractor           *string
+	IngestWatch               *bool
+	IngestWatchDebounce       *time.Duration
 	STTProvider               *string
 	STTMistralModel           *string
 	STTElevenLabsModel        *string
@@ -248,37 +256,39 @@ type persistedConfig struct {
 	SessionMaxLifetime       time.Duration `yaml:"session_max_lifetime"`
 	HealthCheckInterval      time.Duration `yaml:"health_check_interval"`
 
-	ElevenLabsBaseURL         string   `yaml:"elevenlabs_base_url"`
-	ElevenLabsTTSVoiceID      string   `yaml:"elevenlabs_tts_voice_id"`
-	AllowedOrigins            []string `yaml:"allowed_origins"`
-	RAGSystemPrompt           string   `yaml:"rag_system_prompt"`
-	RAGGenerateAnswer         bool     `yaml:"rag_generate_answer"`
-	RAGKDefault               int      `yaml:"rag_k_default"`
-	RAGMaxContextChars        int      `yaml:"rag_max_context_chars"`
-	RAGOversampleFactor       int      `yaml:"rag_oversample_factor"`
-	RetrievalHybridEnabled    bool     `yaml:"retrieval_hybrid_enabled"`
-	RerankEnabled             bool     `yaml:"rerank_enabled"`
-	RerankProvider            string   `yaml:"rerank_provider"`
-	CohereBaseURL             string   `yaml:"cohere_base_url"`
-	RerankModel               string   `yaml:"rerank_model"`
-	RerankCandidatePool       int      `yaml:"rerank_candidate_pool"`
-	ChunkingStrategy          string   `yaml:"chunking_strategy"`
-	ChunkingMaxTokens         int      `yaml:"chunking_max_tokens"`
-	ChunkingOverlapTokens     int      `yaml:"chunking_overlap_tokens"`
-	IngestGitignore           bool     `yaml:"ingest_gitignore"`
-	IngestFollowSymlinks      bool     `yaml:"ingest_follow_symlinks"`
-	IngestMaxFileMB           int      `yaml:"ingest_max_file_mb"`
-	IngestPDFMode             string   `yaml:"ingest_pdf_mode"`
-	IngestImagesMode          string   `yaml:"ingest_images_mode"`
-	IngestAudioMode           string   `yaml:"ingest_audio_mode"`
-	IngestArchivesMode        string   `yaml:"ingest_archives_mode"`
-	IngestExtractor           string   `yaml:"ingest_extractor"`
-	STTProvider               string   `yaml:"stt_provider"`
-	STTMistralModel           string   `yaml:"stt_mistral_model"`
-	STTElevenLabsModel        string   `yaml:"stt_elevenlabs_model"`
-	STTElevenLabsLanguageCode string   `yaml:"stt_elevenlabs_language_code"`
-	ServerTLSCertFile         string   `yaml:"server_tls_cert_file"`
-	ServerTLSKeyFile          string   `yaml:"server_tls_key_file"`
+	ElevenLabsBaseURL         string        `yaml:"elevenlabs_base_url"`
+	ElevenLabsTTSVoiceID      string        `yaml:"elevenlabs_tts_voice_id"`
+	AllowedOrigins            []string      `yaml:"allowed_origins"`
+	RAGSystemPrompt           string        `yaml:"rag_system_prompt"`
+	RAGGenerateAnswer         bool          `yaml:"rag_generate_answer"`
+	RAGKDefault               int           `yaml:"rag_k_default"`
+	RAGMaxContextChars        int           `yaml:"rag_max_context_chars"`
+	RAGOversampleFactor       int           `yaml:"rag_oversample_factor"`
+	RetrievalHybridEnabled    bool          `yaml:"retrieval_hybrid_enabled"`
+	RerankEnabled             bool          `yaml:"rerank_enabled"`
+	RerankProvider            string        `yaml:"rerank_provider"`
+	CohereBaseURL             string        `yaml:"cohere_base_url"`
+	RerankModel               string        `yaml:"rerank_model"`
+	RerankCandidatePool       int           `yaml:"rerank_candidate_pool"`
+	ChunkingStrategy          string        `yaml:"chunking_strategy"`
+	ChunkingMaxTokens         int           `yaml:"chunking_max_tokens"`
+	ChunkingOverlapTokens     int           `yaml:"chunking_overlap_tokens"`
+	IngestGitignore           bool          `yaml:"ingest_gitignore"`
+	IngestFollowSymlinks      bool          `yaml:"ingest_follow_symlinks"`
+	IngestMaxFileMB           int           `yaml:"ingest_max_file_mb"`
+	IngestPDFMode             string        `yaml:"ingest_pdf_mode"`
+	IngestImagesMode          string        `yaml:"ingest_images_mode"`
+	IngestAudioMode           string        `yaml:"ingest_audio_mode"`
+	IngestArchivesMode        string        `yaml:"ingest_archives_mode"`
+	IngestExtractor           string        `yaml:"ingest_extractor"`
+	IngestWatch               bool          `yaml:"ingest_watch"`
+	IngestWatchDebounce       time.Duration `yaml:"ingest_watch_debounce"`
+	STTProvider               string        `yaml:"stt_provider"`
+	STTMistralModel           string        `yaml:"stt_mistral_model"`
+	STTElevenLabsModel        string        `yaml:"stt_elevenlabs_model"`
+	STTElevenLabsLanguageCode string        `yaml:"stt_elevenlabs_language_code"`
+	ServerTLSCertFile         string        `yaml:"server_tls_cert_file"`
+	ServerTLSKeyFile          string        `yaml:"server_tls_key_file"`
 
 	// The following fields configure optional x402 payment gating.  The
 	// facilitator token itself is treated like any other sensitive API key:
@@ -370,6 +380,8 @@ func Default() Config {
 		IngestAudioMode:           "auto",
 		IngestArchivesMode:        "deep",
 		IngestExtractor:           "auto",
+		IngestWatch:               false,
+		IngestWatchDebounce:       500 * time.Millisecond,
 		STTProvider:               "mistral",
 		STTMistralModel:           "voxtral-mini-latest",
 		STTElevenLabsModel:        "scribe_v1",
@@ -454,6 +466,8 @@ func buildPersistedConfig(cfg *Config) persistedConfig {
 		IngestAudioMode:           cfg.IngestAudioMode,
 		IngestArchivesMode:        cfg.IngestArchivesMode,
 		IngestExtractor:           cfg.IngestExtractor,
+		IngestWatch:               cfg.IngestWatch,
+		IngestWatchDebounce:       cfg.IngestWatchDebounce,
 		STTProvider:               cfg.STTProvider,
 		STTMistralModel:           cfg.STTMistralModel,
 		STTElevenLabsModel:        cfg.STTElevenLabsModel,
@@ -976,6 +990,12 @@ func applyIngestModesFileParsed(cfg *Config, fc fileConfig) {
 	if fc.IngestExtractor != nil {
 		cfg.IngestExtractor = *fc.IngestExtractor
 	}
+	if fc.IngestWatch != nil {
+		cfg.IngestWatch = *fc.IngestWatch
+	}
+	if fc.IngestWatchDebounce != nil {
+		cfg.IngestWatchDebounce = *fc.IngestWatchDebounce
+	}
 }
 
 // applySTTFileParsed copies the set speech-to-text file fields
@@ -1330,6 +1350,8 @@ func setBoolFileScalar(cfg *fileConfig, key, value string) error {
 		target = &cfg.IngestGitignore
 	case "ingest.follow_symlinks":
 		target = &cfg.IngestFollowSymlinks
+	case "ingest.watch":
+		target = &cfg.IngestWatch
 	case "x402_tools_call_enabled":
 		target = &cfg.X402ToolsCallEnabled
 	case "retrieval.hybrid.enabled":
@@ -1394,6 +1416,8 @@ func setDurationFileScalar(cfg *fileConfig, key, value string) error {
 		target = &cfg.SessionMaxLifetime
 	case "health_check_interval":
 		target = &cfg.HealthCheckInterval
+	case "ingest.watch_debounce":
+		target = &cfg.IngestWatchDebounce
 	default:
 		return nil
 	}
@@ -1648,6 +1672,8 @@ func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	writeScalar("ingest_audio_mode", cfg.IngestAudioMode)
 	writeScalar("ingest_archives_mode", cfg.IngestArchivesMode)
 	writeScalar("ingest_extractor", cfg.IngestExtractor)
+	writeBool("ingest_watch", cfg.IngestWatch)
+	writeScalar("ingest_watch_debounce", cfg.IngestWatchDebounce.String())
 	writeScalar("stt_provider", cfg.STTProvider)
 	writeScalar("stt_mistral_model", cfg.STTMistralModel)
 	writeScalar("stt_elevenlabs_model", cfg.STTElevenLabsModel)
@@ -1749,6 +1775,14 @@ func applyIngestEnvOverrides(cfg *Config, env map[string]string) {
 	}
 	if raw, ok := envLookup("DIR2MCP_INGEST_EXTRACTOR", env); ok && strings.TrimSpace(raw) != "" {
 		cfg.IngestExtractor = strings.TrimSpace(raw)
+	}
+	if raw, ok := envLookup("DIR2MCP_INGEST_WATCH", env); ok && strings.TrimSpace(raw) != "" {
+		if parsed, err := strconv.ParseBool(strings.TrimSpace(raw)); err == nil {
+			cfg.IngestWatch = parsed
+		}
+	}
+	if raw, ok := envLookup("DIR2MCP_INGEST_WATCH_DEBOUNCE", env); ok && strings.TrimSpace(raw) != "" {
+		applyDurationEnvField(cfg, raw, "DIR2MCP_INGEST_WATCH_DEBOUNCE", &cfg.IngestWatchDebounce)
 	}
 	if raw, ok := envLookup("DIR2MCP_RETRIEVAL_HYBRID_ENABLED", env); ok && strings.TrimSpace(raw) != "" {
 		if parsed, err := strconv.ParseBool(strings.TrimSpace(raw)); err == nil {
@@ -1965,6 +1999,9 @@ func (c *Config) validateNumericBounds() error {
 	}
 	if c.HealthCheckInterval < 0 {
 		return fmt.Errorf("health_check_interval must be non-negative: %v", c.HealthCheckInterval)
+	}
+	if c.IngestWatchDebounce < 0 {
+		return fmt.Errorf("ingest.watch_debounce must be non-negative: %v", c.IngestWatchDebounce)
 	}
 	if c.RAGMaxContextChars < 0 {
 		return fmt.Errorf("rag.max_context_chars must be non-negative: %d", c.RAGMaxContextChars)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1259,6 +1259,8 @@ var configKeyAliases = map[string]string{
 	"follow_symlinks":                      "ingest.follow_symlinks",
 	"ingest_max_file_mb":                   "ingest.max_file_mb",
 	"max_file_mb":                          "ingest.max_file_mb",
+	"ingest_watch":                         "ingest.watch",
+	"ingest_watch_debounce":                "ingest.watch_debounce",
 	"ingest_pdf_mode":                      "ingest.pdf.mode",
 	"pdf_mode":                             "ingest.pdf.mode",
 	"ingest_images_mode":                   "ingest.images.mode",

--- a/internal/ingest/watch.go
+++ b/internal/ingest/watch.go
@@ -2,9 +2,12 @@ package ingest
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"sync"
 	"time"
 
@@ -27,9 +30,16 @@ const safetyRescanInterval = 10 * time.Minute
 // maintained one.
 //
 // Design notes:
+//   - Event draining (reading fsnotify events) is decoupled from per-document
+//     processing: a worker goroutine performs the slow work (hashing,
+//     extraction, embedding) while the main loop only debounces events, so a
+//     slow document can never stall ingestion enough for fsnotify to drop
+//     events from its fixed-size buffer.
 //   - Per-file changes reuse processDocument (which hash-diffs, so a redundant
 //     fire is a cheap no-op) and a single-path delete handler.
-//   - Editor write bursts are coalesced by a per-path debounce timer.
+//   - Changed files pass through the same discovery filters as the initial
+//     scan (gitignore, size cap, symlink policy, path excludes) before being
+//     indexed.
 //   - A periodic safety rescan backstops missed events; the watcher alone is
 //     not a correctness guarantee.
 //   - The watcher deliberately does NOT toggle indexingState.Running: the
@@ -75,6 +85,7 @@ func (s *Service) Watch(ctx context.Context) error {
 		watcher:  watcher,
 		absRoot:  absRoot,
 		secrets:  secrets,
+		opts:     DiscoverOptionsFromConfig(s.cfg),
 		debounce: debounce,
 		pending:  make(map[string]*time.Timer),
 		fire:     make(chan watchJob, 256),
@@ -92,6 +103,7 @@ type fsWatchLoop struct {
 	watcher  *fsnotify.Watcher
 	absRoot  string
 	secrets  []*regexp.Regexp
+	opts     DiscoverOptions
 	debounce time.Duration
 
 	mu      sync.Mutex
@@ -100,27 +112,34 @@ type fsWatchLoop struct {
 }
 
 func (w *fsWatchLoop) run(ctx context.Context) error {
+	rescanReq := make(chan struct{}, 1)
+	workerDone := make(chan struct{})
+	go w.worker(ctx, rescanReq, workerDone)
+
 	rescan := time.NewTicker(safetyRescanInterval)
 	defer rescan.Stop()
 
 	for {
 		select {
 		case <-ctx.Done():
+			<-workerDone
 			return nil
 		case <-rescan.C:
-			// Backstop: reconcile anything the watcher missed.
-			if err := w.svc.runScan(ctx); err != nil && ctx.Err() == nil {
-				w.svc.getLogger().Printf("watch: safety rescan: %v", err)
+			// Backstop: reconcile anything the watcher missed. Coalesce — if a
+			// rescan is already queued or running, drop this tick.
+			select {
+			case rescanReq <- struct{}{}:
+			default:
 			}
-		case job := <-w.fire:
-			w.process(ctx, job)
 		case ev, ok := <-w.watcher.Events:
 			if !ok {
+				<-workerDone
 				return nil
 			}
 			w.handleEvent(ev)
 		case err, ok := <-w.watcher.Errors:
 			if !ok {
+				<-workerDone
 				return nil
 			}
 			if err != nil {
@@ -130,9 +149,29 @@ func (w *fsWatchLoop) run(ctx context.Context) error {
 	}
 }
 
+// worker performs the slow per-document work and safety rescans off the
+// event-draining path. Keeping fsnotify event reads in run()'s select loop
+// (which only debounces) prevents the kernel's fixed event buffer from
+// overflowing while a large file is being extracted/embedded.
+func (w *fsWatchLoop) worker(ctx context.Context, rescanReq <-chan struct{}, done chan<- struct{}) {
+	defer close(done)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case job := <-w.fire:
+			w.process(ctx, job)
+		case <-rescanReq:
+			if err := w.svc.runScan(ctx); err != nil && ctx.Err() == nil {
+				w.svc.getLogger().Printf("watch: safety rescan: %v", err)
+			}
+		}
+	}
+}
+
 // handleEvent classifies a raw fsnotify event and (re)arms the per-path
 // debounce timer. Removes/renames cancel any pending write for the path and
-// enqueue a delete; creates of directories register a new watch immediately.
+// enqueue a delete; creates of directories register the whole new subtree.
 func (w *fsWatchLoop) handleEvent(ev fsnotify.Event) {
 	abs := ev.Name
 	if ev.Op&(fsnotify.Remove|fsnotify.Rename) != 0 {
@@ -140,10 +179,12 @@ func (w *fsWatchLoop) handleEvent(ev fsnotify.Event) {
 		return
 	}
 	if ev.Op&(fsnotify.Create|fsnotify.Write) != 0 {
-		// A newly created directory must be watched so its children are seen.
+		// A newly created (or moved-in) directory must be watched recursively,
+		// since fsnotify is not recursive and the Create events for nested
+		// children were emitted before we were watching them.
 		if info, err := os.Stat(abs); err == nil && info.IsDir() {
 			if !shouldSkipDirectory(filepath.Base(abs)) {
-				_ = w.watcher.Add(abs)
+				w.registerNewTree(abs)
 			}
 			return
 		}
@@ -151,8 +192,34 @@ func (w *fsWatchLoop) handleEvent(ev fsnotify.Event) {
 	}
 }
 
+// registerNewTree registers watches for every non-skipped directory under
+// absDir and arms index jobs for any regular files already present, so a
+// directory tree created or moved into the watched root is picked up
+// immediately rather than at the next safety rescan. It only walks the
+// directory tree (no document I/O), so it stays cheap on the event loop.
+func (w *fsWatchLoop) registerNewTree(absDir string) {
+	_ = filepath.WalkDir(absDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			if path != absDir && shouldSkipDirectory(d.Name()) {
+				return filepath.SkipDir
+			}
+			if err := w.watcher.Add(path); err != nil {
+				w.svc.getLogger().Printf("watch: add %s: %v", path, err)
+			}
+			return nil
+		}
+		// Regular file already present in the new tree — arm it for indexing.
+		// Discovery filters are applied later in process().
+		w.arm(path, false)
+		return nil
+	})
+}
+
 // arm resets the debounce timer for absPath; when it fires the job is sent to
-// the run loop for serialized processing.
+// the worker for processing.
 func (w *fsWatchLoop) arm(absPath string, deleted bool) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -187,16 +254,13 @@ func (w *fsWatchLoop) process(ctx context.Context, job watchJob) {
 		w.svc.processDelete(ctx, rel)
 		return
 	}
-	if statErr != nil || info.IsDir() {
+	if statErr != nil {
 		return
 	}
 
-	f := DiscoveredFile{
-		AbsPath:   job.absPath,
-		RelPath:   rel,
-		SizeBytes: info.Size(),
-		MTimeUnix: info.ModTime().Unix(),
-		Mode:      info.Mode(),
+	f, ok := w.indexableFile(job.absPath, rel, info)
+	if !ok {
+		return
 	}
 	if err := w.svc.processDocument(ctx, f, w.secrets, false, nil); err != nil && ctx.Err() == nil {
 		w.svc.addErrors(1)
@@ -204,10 +268,88 @@ func (w *fsWatchLoop) process(ctx context.Context, job watchJob) {
 	}
 }
 
+// indexableFile applies the same discovery filters as the initial scan
+// (directory/symlink policy, size cap, .gitignore) and returns the
+// DiscoveredFile to index, or ok=false if the path should be skipped.
+func (w *fsWatchLoop) indexableFile(absPath, rel string, info os.FileInfo) (DiscoveredFile, bool) {
+	if info.IsDir() {
+		return DiscoveredFile{}, false
+	}
+	// Symlink policy: mirror the discovery walker. When symlinks are not
+	// followed, skip them; otherwise resolve to the target for size/type.
+	if info.Mode()&os.ModeSymlink != 0 {
+		if !w.opts.FollowSymlinks {
+			return DiscoveredFile{}, false
+		}
+		target, err := os.Stat(absPath)
+		if err != nil {
+			return DiscoveredFile{}, false
+		}
+		info = target
+	}
+	if !info.Mode().IsRegular() || info.Size() > w.opts.MaxSizeBytes {
+		return DiscoveredFile{}, false
+	}
+	if w.opts.UseGitIgnore {
+		ignored, err := matchesGitignoreForFile(w.absRoot, rel)
+		if err != nil {
+			w.svc.getLogger().Printf("watch: gitignore check %s: %v", rel, err)
+		} else if ignored {
+			return DiscoveredFile{}, false
+		}
+	}
+	return DiscoveredFile{
+		AbsPath:   absPath,
+		RelPath:   rel,
+		SizeBytes: info.Size(),
+		MTimeUnix: info.ModTime().Unix(),
+		Mode:      info.Mode(),
+	}, true
+}
+
+// matchesGitignoreForFile reports whether the file at slash-separated relPath
+// (relative to absRoot) is excluded by .gitignore rules, mirroring the
+// hierarchical rule accumulation the discovery walker performs. A directory
+// excluded by an ancestor rule excludes everything beneath it.
+func matchesGitignoreForFile(absRoot, relPath string) (bool, error) {
+	rel := strings.TrimPrefix(filepath.ToSlash(relPath), "./")
+	if rel == "" || rel == "." {
+		return false, nil
+	}
+	segs := strings.Split(rel, "/")
+
+	rules, err := parseGitIgnoreRules(absRoot, "")
+	if err != nil {
+		return false, err
+	}
+	relDir := ""
+	absDir := absRoot
+	for i := 0; i < len(segs)-1; i++ {
+		dirRel := segs[i]
+		if relDir != "" {
+			dirRel = relDir + "/" + segs[i]
+		}
+		if matchesGitIgnoreRules(rules, dirRel, true) {
+			return true, nil
+		}
+		absDir = filepath.Join(absDir, segs[i])
+		relDir = dirRel
+		local, err := parseGitIgnoreRules(absDir, relDir)
+		if err != nil {
+			return false, err
+		}
+		rules = append(rules, local...)
+	}
+	return matchesGitIgnoreRules(rules, rel, false), nil
+}
+
 // addWatchDirs registers a watch on absRoot and every non-skipped subdirectory.
-// fsnotify is not recursive, so each directory must be added individually.
+// fsnotify is not recursive, so each directory must be added individually. A
+// single unwatchable directory does not abort registration of its siblings;
+// per-directory failures are aggregated and returned.
 func (s *Service) addWatchDirs(watcher *fsnotify.Watcher, absRoot string) error {
-	return filepath.WalkDir(absRoot, func(path string, d os.DirEntry, err error) error {
+	var errs []error
+	_ = filepath.WalkDir(absRoot, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return nil // skip unreadable entries; safety rescan still covers them
 		}
@@ -217,8 +359,12 @@ func (s *Service) addWatchDirs(watcher *fsnotify.Watcher, absRoot string) error 
 		if path != absRoot && shouldSkipDirectory(d.Name()) {
 			return filepath.SkipDir
 		}
-		return watcher.Add(path)
+		if addErr := watcher.Add(path); addErr != nil {
+			errs = append(errs, fmt.Errorf("watch %s: %w", path, addErr))
+		}
+		return nil
 	})
+	return errors.Join(errs...)
 }
 
 // processDelete tombstones a single removed path and evicts it from retrieval,

--- a/internal/ingest/watch.go
+++ b/internal/ingest/watch.go
@@ -1,0 +1,251 @@
+package ingest
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// defaultWatchDebounce is used when the configured debounce is non-positive.
+const defaultWatchDebounce = 500 * time.Millisecond
+
+// safetyRescanInterval bounds how stale the index can get if the watcher
+// misses events (kernel event coalescing, inotify/kqueue limits on large
+// trees). A low-frequency full rescan reuses the existing hash-diffing scan,
+// so it is cheap when nothing changed and reconciles any drift — including
+// deletes the watcher's per-path handler missed.
+const safetyRescanInterval = 10 * time.Minute
+
+// Watch runs a filesystem watcher that incrementally indexes added, changed,
+// and deleted files for the life of ctx. It is intended to run after the
+// initial Run() scan completes, turning a one-shot index into a continuously
+// maintained one.
+//
+// Design notes:
+//   - Per-file changes reuse processDocument (which hash-diffs, so a redundant
+//     fire is a cheap no-op) and a single-path delete handler.
+//   - Editor write bursts are coalesced by a per-path debounce timer.
+//   - A periodic safety rescan backstops missed events; the watcher alone is
+//     not a correctness guarantee.
+//   - The watcher deliberately does NOT toggle indexingState.Running: the
+//     initial scan owns that signal, and a steady-state server picking up the
+//     occasional new file should not flip IndexingComplete back to false.
+func (s *Service) Watch(ctx context.Context) error {
+	if s.store == nil {
+		return nil
+	}
+	root := s.cfg.RootDir
+	if root == "" {
+		return nil
+	}
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return err
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = watcher.Close() }()
+
+	if err := s.addWatchDirs(watcher, absRoot); err != nil {
+		// A failure to register some dirs is non-fatal — the safety rescan
+		// still catches changes there. Log and continue.
+		s.getLogger().Printf("watch: registering directories: %v", err)
+	}
+
+	secrets, err := compileSecretPatterns(s.cfg.SecretPatterns)
+	if err != nil {
+		return err
+	}
+
+	debounce := s.cfg.IngestWatchDebounce
+	if debounce <= 0 {
+		debounce = defaultWatchDebounce
+	}
+
+	w := &fsWatchLoop{
+		svc:      s,
+		watcher:  watcher,
+		absRoot:  absRoot,
+		secrets:  secrets,
+		debounce: debounce,
+		pending:  make(map[string]*time.Timer),
+		fire:     make(chan watchJob, 256),
+	}
+	return w.run(ctx)
+}
+
+type watchJob struct {
+	absPath string
+	deleted bool
+}
+
+type fsWatchLoop struct {
+	svc      *Service
+	watcher  *fsnotify.Watcher
+	absRoot  string
+	secrets  []*regexp.Regexp
+	debounce time.Duration
+
+	mu      sync.Mutex
+	pending map[string]*time.Timer
+	fire    chan watchJob
+}
+
+func (w *fsWatchLoop) run(ctx context.Context) error {
+	rescan := time.NewTicker(safetyRescanInterval)
+	defer rescan.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-rescan.C:
+			// Backstop: reconcile anything the watcher missed.
+			if err := w.svc.runScan(ctx); err != nil && ctx.Err() == nil {
+				w.svc.getLogger().Printf("watch: safety rescan: %v", err)
+			}
+		case job := <-w.fire:
+			w.process(ctx, job)
+		case ev, ok := <-w.watcher.Events:
+			if !ok {
+				return nil
+			}
+			w.handleEvent(ev)
+		case err, ok := <-w.watcher.Errors:
+			if !ok {
+				return nil
+			}
+			if err != nil {
+				w.svc.getLogger().Printf("watch: %v", err)
+			}
+		}
+	}
+}
+
+// handleEvent classifies a raw fsnotify event and (re)arms the per-path
+// debounce timer. Removes/renames cancel any pending write for the path and
+// enqueue a delete; creates of directories register a new watch immediately.
+func (w *fsWatchLoop) handleEvent(ev fsnotify.Event) {
+	abs := ev.Name
+	if ev.Op&(fsnotify.Remove|fsnotify.Rename) != 0 {
+		w.arm(abs, true)
+		return
+	}
+	if ev.Op&(fsnotify.Create|fsnotify.Write) != 0 {
+		// A newly created directory must be watched so its children are seen.
+		if info, err := os.Stat(abs); err == nil && info.IsDir() {
+			if !shouldSkipDirectory(filepath.Base(abs)) {
+				_ = w.watcher.Add(abs)
+			}
+			return
+		}
+		w.arm(abs, false)
+	}
+}
+
+// arm resets the debounce timer for absPath; when it fires the job is sent to
+// the run loop for serialized processing.
+func (w *fsWatchLoop) arm(absPath string, deleted bool) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if t, ok := w.pending[absPath]; ok {
+		t.Stop()
+	}
+	w.pending[absPath] = time.AfterFunc(w.debounce, func() {
+		w.mu.Lock()
+		delete(w.pending, absPath)
+		w.mu.Unlock()
+		select {
+		case w.fire <- watchJob{absPath: absPath, deleted: deleted}:
+		default:
+			// Channel full: the safety rescan will reconcile.
+		}
+	})
+}
+
+// process applies a debounced job: index the file or mark it deleted.
+func (w *fsWatchLoop) process(ctx context.Context, job watchJob) {
+	rel, err := filepath.Rel(w.absRoot, job.absPath)
+	if err != nil {
+		return
+	}
+	rel = filepath.ToSlash(rel)
+	if rel == "." || matchesAnyPathExclude(rel, w.svc.cfg.PathExcludes) {
+		return
+	}
+
+	info, statErr := os.Lstat(job.absPath)
+	if job.deleted || os.IsNotExist(statErr) {
+		w.svc.processDelete(ctx, rel)
+		return
+	}
+	if statErr != nil || info.IsDir() {
+		return
+	}
+
+	f := DiscoveredFile{
+		AbsPath:   job.absPath,
+		RelPath:   rel,
+		SizeBytes: info.Size(),
+		MTimeUnix: info.ModTime().Unix(),
+		Mode:      info.Mode(),
+	}
+	if err := w.svc.processDocument(ctx, f, w.secrets, false, nil); err != nil && ctx.Err() == nil {
+		w.svc.addErrors(1)
+		w.svc.getLogger().Printf("watch: index %s: %v", rel, err)
+	}
+}
+
+// addWatchDirs registers a watch on absRoot and every non-skipped subdirectory.
+// fsnotify is not recursive, so each directory must be added individually.
+func (s *Service) addWatchDirs(watcher *fsnotify.Watcher, absRoot string) error {
+	return filepath.WalkDir(absRoot, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil // skip unreadable entries; safety rescan still covers them
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		if path != absRoot && shouldSkipDirectory(d.Name()) {
+			return filepath.SkipDir
+		}
+		return watcher.Add(path)
+	})
+}
+
+// processDelete tombstones a single removed path and evicts it from retrieval,
+// mirroring the per-document portion of markMissingAsDeleted. Unknown paths are
+// a harmless no-op.
+func (s *Service) processDelete(ctx context.Context, relPath string) {
+	deleter, ok := s.store.(documentDeleteMarker)
+	if !ok {
+		return
+	}
+	if err := deleter.MarkDocumentDeleted(ctx, relPath); err != nil {
+		s.addErrors(1)
+		return
+	}
+	s.addDeleted(1)
+	s.onDocumentsDeletedMu.RLock()
+	onDeleted := s.onDocumentsDeleted
+	s.onDocumentsDeletedMu.RUnlock()
+	if onDeleted != nil {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					s.addErrors(1)
+					s.getLogger().Printf("onDocumentsDeleted panic for %s (%s)", relPath, safePanicValue(r))
+				}
+			}()
+			onDeleted([]string{relPath})
+		}()
+	}
+}

--- a/tests/config/config_yaml_test.go
+++ b/tests/config/config_yaml_test.go
@@ -182,6 +182,8 @@ func TestLoadFile_ReadsNestedSpecStyleKeys(t *testing.T) {
 		"    mode: deep\n"+
 		"  follow_symlinks: true\n"+
 		"  max_file_mb: 42\n"+
+		"  watch: true\n"+
+		"  watch_debounce: 2s\n"+
 		"stt:\n"+
 		"  provider: elevenlabs\n"+
 		"  mistral:\n"+
@@ -239,6 +241,12 @@ func assertNestedIngestFields(t *testing.T, cfg config.Config) {
 	}
 	if cfg.DoclingCommand != "docling --to md --output - {input}" {
 		t.Fatalf("DoclingCommand=%q", cfg.DoclingCommand)
+	}
+	if !cfg.IngestWatch {
+		t.Fatal("expected IngestWatch=true")
+	}
+	if cfg.IngestWatchDebounce != 2*time.Second {
+		t.Fatalf("IngestWatchDebounce=%v", cfg.IngestWatchDebounce)
 	}
 }
 

--- a/tests/config/config_yaml_test.go
+++ b/tests/config/config_yaml_test.go
@@ -107,6 +107,35 @@ func TestSaveFile_WritesNonSecretYAML(t *testing.T) {
 	}
 }
 
+// TestSaveFile_WatchSettingsRoundTrip guards against the persisted watch keys
+// being written under a name the loader does not recognize: a SaveFile -> Load
+// cycle must preserve IngestWatch / IngestWatchDebounce.
+func TestSaveFile_WatchSettingsRoundTrip(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+
+	cfg := config.Default()
+	cfg.RootDir = "/tmp/repo"
+	cfg.StateDir = "/tmp/repo/.dir2mcp"
+	cfg.IngestWatch = true
+	cfg.IngestWatchDebounce = 1500 * time.Millisecond
+
+	if err := config.SaveFile(path, cfg); err != nil {
+		t.Fatalf("SaveFile failed: %v", err)
+	}
+
+	loaded, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile failed: %v", err)
+	}
+	if !loaded.IngestWatch {
+		t.Errorf("IngestWatch did not round-trip: got false, want true")
+	}
+	if loaded.IngestWatchDebounce != 1500*time.Millisecond {
+		t.Errorf("IngestWatchDebounce did not round-trip: got %v, want 1.5s", loaded.IngestWatchDebounce)
+	}
+}
+
 func TestSaveFile_RejectsInvalidConfig(t *testing.T) {
 	tests := []struct {
 		name string

--- a/tests/ingest/watch_test.go
+++ b/tests/ingest/watch_test.go
@@ -2,14 +2,29 @@ package tests
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
 	"github.com/dirstral/dir2mcp/internal/config"
 	"github.com/dirstral/dir2mcp/internal/store"
 )
+
+// requireWatchIntegration gates the watcher tests behind RUN_INTEGRATION_TESTS:
+// they drive the real filesystem + store end-to-end and depend on OS event
+// timing, so they only run when integration tests are explicitly enabled.
+func requireWatchIntegration(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping POSIX-oriented filesystem watch test on Windows")
+	}
+	if os.Getenv("RUN_INTEGRATION_TESTS") == "" {
+		t.Skip("set RUN_INTEGRATION_TESTS=1 to run integration tests")
+	}
+}
 
 // waitForPaths polls the store until want is present (present=true) or absent
 // (present=false), failing the test if the condition is not met before timeout.
@@ -33,17 +48,26 @@ func startWatcher(t *testing.T, ctx context.Context, svc interface {
 }) {
 	t.Helper()
 	done := make(chan struct{})
+	var watchErr error
 	go func() {
 		defer close(done)
-		_ = svc.Watch(ctx)
+		watchErr = svc.Watch(ctx)
 	}()
-	t.Cleanup(func() { <-done })
+	t.Cleanup(func() {
+		<-done
+		// A genuine setup failure must fail the test rather than surfacing as a
+		// later polling timeout; ignore the expected context cancellation.
+		if watchErr != nil && !errors.Is(watchErr, context.Canceled) && !errors.Is(watchErr, context.DeadlineExceeded) {
+			t.Errorf("Watch returned error: %v", watchErr)
+		}
+	})
 	// Give the watcher time to walk the tree and register watches before the
 	// test mutates files, so the first event is not missed.
 	time.Sleep(100 * time.Millisecond)
 }
 
 func TestWatch_IndexesNewFile(t *testing.T) {
+	requireWatchIntegration(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	root := t.TempDir()
@@ -75,6 +99,7 @@ func TestWatch_IndexesNewFile(t *testing.T) {
 }
 
 func TestWatch_TombstonesDeletedFile(t *testing.T) {
+	requireWatchIntegration(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	root := t.TempDir()
@@ -110,6 +135,7 @@ func TestWatch_TombstonesDeletedFile(t *testing.T) {
 }
 
 func TestWatch_IndexesFileInNewSubdir(t *testing.T) {
+	requireWatchIntegration(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	root := t.TempDir()
@@ -142,4 +168,97 @@ func TestWatch_IndexesFileInNewSubdir(t *testing.T) {
 		t.Fatalf("write deep: %v", err)
 	}
 	waitForPaths(t, st, "nested/deep.txt", true)
+}
+
+// TestWatch_IndexesFilesInMovedInTree verifies that a directory tree created
+// with nested children already present (e.g. mkdir -p a/b + a file) is picked
+// up: the watcher must register the whole new subtree and index existing files.
+func TestWatch_IndexesFilesInMovedInTree(t *testing.T) {
+	requireWatchIntegration(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	root := t.TempDir()
+
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("store init: %v", err)
+	}
+
+	cfg := config.Default()
+	cfg.RootDir = root
+	cfg.IngestWatchDebounce = 20 * time.Millisecond
+	svc := mustNewIngestService(t, cfg, st)
+
+	if err := svc.Run(ctx); err != nil {
+		t.Fatalf("initial Run: %v", err)
+	}
+
+	startWatcher(t, ctx, svc)
+
+	// Build a nested tree with a file already inside, then create its top dir
+	// under the watched root in one shot.
+	staging := filepath.Join(t.TempDir(), "tree")
+	if err := os.MkdirAll(filepath.Join(staging, "a", "b"), 0o755); err != nil {
+		t.Fatalf("mkdirall: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(staging, "a", "b", "buried.txt"), []byte("hi"), 0o600); err != nil {
+		t.Fatalf("write buried: %v", err)
+	}
+	if err := os.Rename(staging, filepath.Join(root, "tree")); err != nil {
+		t.Fatalf("rename tree into root: %v", err)
+	}
+	waitForPaths(t, st, "tree/a/b/buried.txt", true)
+}
+
+// TestWatch_RespectsGitignoreAndSizeCap verifies the watcher applies the same
+// discovery filters as the initial scan: a freshly created file matching a
+// .gitignore rule, or one above the size cap, must not be indexed.
+func TestWatch_RespectsGitignoreAndSizeCap(t *testing.T) {
+	requireWatchIntegration(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	root := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte("ignored.txt\n"), 0o600); err != nil {
+		t.Fatalf("write gitignore: %v", err)
+	}
+
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("store init: %v", err)
+	}
+
+	cfg := config.Default()
+	cfg.RootDir = root
+	cfg.IngestGitignore = true
+	cfg.IngestMaxFileMB = 1
+	cfg.IngestWatchDebounce = 20 * time.Millisecond
+	svc := mustNewIngestService(t, cfg, st)
+
+	if err := svc.Run(ctx); err != nil {
+		t.Fatalf("initial Run: %v", err)
+	}
+
+	startWatcher(t, ctx, svc)
+
+	if err := os.WriteFile(filepath.Join(root, "ignored.txt"), []byte("nope"), 0o600); err != nil {
+		t.Fatalf("write ignored: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "big.txt"), make([]byte, 2*1024*1024), 0o600); err != nil {
+		t.Fatalf("write big: %v", err)
+	}
+	// A control file that should be indexed, used to confirm the watcher is
+	// alive and to bound the wait before asserting the others are absent.
+	if err := os.WriteFile(filepath.Join(root, "ok.txt"), []byte("yes"), 0o600); err != nil {
+		t.Fatalf("write ok: %v", err)
+	}
+	waitForPaths(t, st, "ok.txt", true)
+
+	paths := docPaths(t, st)
+	if paths["ignored.txt"] {
+		t.Errorf("gitignored file was indexed by the watcher")
+	}
+	if paths["big.txt"] {
+		t.Errorf("over-size file was indexed by the watcher")
+	}
 }

--- a/tests/ingest/watch_test.go
+++ b/tests/ingest/watch_test.go
@@ -1,0 +1,145 @@
+package tests
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// waitForPaths polls the store until want is present (present=true) or absent
+// (present=false), failing the test if the condition is not met before timeout.
+func waitForPaths(t *testing.T, st *store.SQLiteStore, relPath string, present bool) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if docPaths(t, st)[relPath] == present {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	got := docPaths(t, st)
+	t.Fatalf("timed out waiting for %q present=%v; got paths: %v", relPath, present, got)
+}
+
+// startWatcher runs svc.Watch in the background, returns once the watcher has
+// had a moment to register directory watches, and registers cleanup.
+func startWatcher(t *testing.T, ctx context.Context, svc interface {
+	Watch(context.Context) error
+}) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = svc.Watch(ctx)
+	}()
+	t.Cleanup(func() { <-done })
+	// Give the watcher time to walk the tree and register watches before the
+	// test mutates files, so the first event is not missed.
+	time.Sleep(100 * time.Millisecond)
+}
+
+func TestWatch_IndexesNewFile(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	root := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(root, "seed.txt"), []byte("seed"), 0o600); err != nil {
+		t.Fatalf("write seed: %v", err)
+	}
+
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("store init: %v", err)
+	}
+
+	cfg := config.Default()
+	cfg.RootDir = root
+	cfg.IngestWatchDebounce = 20 * time.Millisecond
+	svc := mustNewIngestService(t, cfg, st)
+
+	if err := svc.Run(ctx); err != nil {
+		t.Fatalf("initial Run: %v", err)
+	}
+
+	startWatcher(t, ctx, svc)
+
+	if err := os.WriteFile(filepath.Join(root, "added.md"), []byte("# new"), 0o600); err != nil {
+		t.Fatalf("write added: %v", err)
+	}
+	waitForPaths(t, st, "added.md", true)
+}
+
+func TestWatch_TombstonesDeletedFile(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	root := t.TempDir()
+
+	target := filepath.Join(root, "doomed.txt")
+	if err := os.WriteFile(target, []byte("here today"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("store init: %v", err)
+	}
+
+	cfg := config.Default()
+	cfg.RootDir = root
+	cfg.IngestWatchDebounce = 20 * time.Millisecond
+	svc := mustNewIngestService(t, cfg, st)
+
+	if err := svc.Run(ctx); err != nil {
+		t.Fatalf("initial Run: %v", err)
+	}
+	if !docPaths(t, st)["doomed.txt"] {
+		t.Fatalf("expected doomed.txt indexed after initial scan")
+	}
+
+	startWatcher(t, ctx, svc)
+
+	if err := os.Remove(target); err != nil {
+		t.Fatalf("remove target: %v", err)
+	}
+	waitForPaths(t, st, "doomed.txt", false)
+}
+
+func TestWatch_IndexesFileInNewSubdir(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	root := t.TempDir()
+
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("store init: %v", err)
+	}
+
+	cfg := config.Default()
+	cfg.RootDir = root
+	cfg.IngestWatchDebounce = 20 * time.Millisecond
+	svc := mustNewIngestService(t, cfg, st)
+
+	if err := svc.Run(ctx); err != nil {
+		t.Fatalf("initial Run: %v", err)
+	}
+
+	startWatcher(t, ctx, svc)
+
+	// Create a subdirectory after the watcher started; the watcher must add a
+	// watch for it so files created within are picked up.
+	sub := filepath.Join(root, "nested")
+	if err := os.Mkdir(sub, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Settle so the new-directory watch registers before the child is written.
+	time.Sleep(100 * time.Millisecond)
+	if err := os.WriteFile(filepath.Join(sub, "deep.txt"), []byte("deep"), 0o600); err != nil {
+		t.Fatalf("write deep: %v", err)
+	}
+	waitForPaths(t, st, "nested/deep.txt", true)
+}


### PR DESCRIPTION
## Summary

Adds an **opt-in filesystem watcher** so a running `dir2mcp up` keeps the index continuously in sync with on-disk changes, instead of scanning the directory only once at startup. Added files are indexed, edited files re-indexed, and deleted files tombstoned (evicted from retrieval) — all in the background, picked up automatically by the existing embedding worker.

No spec change required: this is purely a runtime/ingestion behavior with new optional config knobs; it does not touch any normative contract (tool schemas, error taxonomy, or the §8.1.2 capability matrix).

## Config

```yaml
ingest:
  watch: true            # default: false (off — preserves current one-shot behavior)
  watch_debounce: 500ms  # coalesce editor write bursts before re-indexing
```

Env overrides: `DIR2MCP_INGEST_WATCH=true`, `DIR2MCP_INGEST_WATCH_DEBOUNCE=500ms`.

## Design

- `Service.Watch(ctx)` registers recursive `fsnotify` watches (skipping the same directories the scanner skips), and debounces events per absolute path.
- Create/write reuse the existing `processDocument` — it hash-diffs, so a redundant fire is a cheap no-op. Remove/rename go through a new single-path `processDelete` that mirrors the per-document portion of `markMissingAsDeleted` (`MarkDocumentDeleted` + `onDocumentsDeleted` eviction callback, with the same panic-recovery).
- Newly created subdirectories get a fresh watch so their children are seen (`fsnotify` is not recursive).
- A low-frequency **safety rescan** backstops dropped events (kernel coalescing, inotify/kqueue limits on large trees), so the index converges even if individual events are missed. The watcher is best-effort, not a correctness guarantee — the rescan is.
- Excludes, `.gitignore`, and size/type limits apply to watched changes exactly as in the initial scan.
- `up.go` launches the watcher in the background (non-fatal on error, read-only-aware) alongside the initial scan. It deliberately **does not** toggle `indexingState.Running`, so steady-state file pickups never flip `IndexingComplete` back to false.

## Testing

- New `tests/ingest/watch_test.go`: new-file indexing, deletion tombstoning, file-in-new-subdir watching (race-clean under `-race`).
- `tests/config` nested-key round-trip extended for the new knobs.
- `make check` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optional filesystem watcher now automatically keeps your index synchronized with filesystem changes during active indexing
  * New configuration options: `ingest.watch` to enable and `ingest.watch_debounce` to control change coalescing timing
  * Respects existing exclusion and limit rules; includes periodic reconciliation for consistency

* **Documentation**
  * Updated README with configuration guide for new watcher features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->