### PR TITLE
feat(ingest): docling-serve HTTP extraction backend (spec 0.10.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,8 +246,9 @@ ingest:
     serve_url: http://127.0.0.1:5001
 ```
 
-- Run the container yourself, e.g.: `docker run --rm -p 5001:5001 ghcr.io/docling-project/docling-serve-cpu`. dir2mcp does **not** start or stop it — lifecycle is user-managed; it probes and fails fast.
-- `extractor: docling-serve` **requires** a reachable `serve_url`. An empty or unreachable endpoint **disables** the extractor (it does **not** silently fall back to the CLI); `dir2mcp doctor` reports it as a warning via a `/health` probe.
+- Run the container yourself, e.g.: `docker run --rm -p 5001:5001 ghcr.io/docling-project/docling-serve-cpu`. dir2mcp does **not** start or stop it — lifecycle is user-managed.
+- `extractor: docling-serve` **requires** a non-empty `serve_url`: an empty value is rejected at startup (`CONFIG_INVALID`). It never silently falls back to the docling CLI.
+- A configured-but-**unreachable** endpoint is not a fallback either — `dir2mcp doctor` flags it via a `/health` probe, and document extraction errors per file at runtime until the endpoint comes back.
 - Under `extractor: auto`, docling-serve is used only when the docling CLI isn't on `PATH` (local CLI is preferred); an empty `serve_url` simply means the HTTP transport isn't considered.
 - Env equivalent: `DIR2MCP_DOCLING_SERVE_URL=http://127.0.0.1:5001`.
 

--- a/README.md
+++ b/README.md
@@ -247,9 +247,9 @@ ingest:
 ```
 
 - Run the container yourself, e.g.: `docker run --rm -p 5001:5001 ghcr.io/docling-project/docling-serve-cpu`. dir2mcp does **not** start or stop it — lifecycle is user-managed.
-- `extractor: docling-serve` **requires** a non-empty `serve_url`: an empty value is rejected at startup (`CONFIG_INVALID`). It never silently falls back to the docling CLI.
-- A configured-but-**unreachable** endpoint is not a fallback either — `dir2mcp doctor` flags it via a `/health` probe, and document extraction errors per file at runtime until the endpoint comes back.
-- Under `extractor: auto`, docling-serve is used only when the docling CLI isn't on `PATH` (local CLI is preferred); an empty `serve_url` simply means the HTTP transport isn't considered.
+- `extractor: docling-serve` **requires** a non-empty, reachable `serve_url`: an empty or unreachable endpoint is rejected at startup (`CONFIG_INVALID`). It never silently falls back to the docling CLI.
+- `dir2mcp doctor` reports the same availability decision, so a dead `docling-serve` endpoint shows up as an unavailable extractor instead of surfacing only later as per-document runtime failures.
+- Under `extractor: auto`, docling-serve is used only when the docling CLI isn't on `PATH` (local CLI is preferred); an empty `serve_url` means the HTTP transport isn't considered, and an unreachable one is skipped in favor of another available extractor (for example Mistral OCR).
 - Env equivalent: `DIR2MCP_DOCLING_SERVE_URL=http://127.0.0.1:5001`.
 
 ### Continuous incremental indexing (optional)

--- a/README.md
+++ b/README.md
@@ -208,8 +208,9 @@ vary by deployment. The commonly used variables are:
 | Variable | Required | Description |
 |---|---|---|
 | `MISTRAL_API_KEY` | Conditional | Required for embeddings, Mistral-based extraction/STT, and generation; not required for docling-only read-only extraction flows |
-| `DIR2MCP_INGEST_EXTRACTOR` | No | Extraction provider mode: `auto` (default), `docling`, `mistral`, or `off` |
+| `DIR2MCP_INGEST_EXTRACTOR` | No | Extraction mode: `auto` (default), `docling`, `docling-serve`, `mistral`, or `off` |
 | `DIR2MCP_DOCLING_COMMAND` | No | Optional local command template for document extraction (default: `docling --to json --output - {input}`); when set/available, it is preferred for PDF/image/office-style document extraction. The default requests structured JSON so ingestion preserves reading order, section hierarchy, and per-element page/bbox provenance (region citations); a custom `--to md` template still works and falls back to flat Markdown |
+| `DIR2MCP_DOCLING_SERVE_URL` | No | HTTP endpoint of a running [docling-serve](https://github.com/docling-project/docling-serve) container (e.g. `http://127.0.0.1:5001`). Required when `ingest.extractor=docling-serve`; under `auto` it is used only when the docling CLI is not on `PATH` |
 | `DIR2MCP_INGEST_WATCH` | No | When `true`, a running `dir2mcp up` keeps a filesystem watcher live and incrementally indexes added/changed/deleted files (default: `false`) |
 | `DIR2MCP_INGEST_WATCH_DEBOUNCE` | No | Per-file debounce window for coalescing editor write bursts before re-indexing (default: `500ms`) |
 | `MISTRAL_BASE_URL` | No | Mistral base URL (default: `https://api.mistral.ai`) |
@@ -233,6 +234,22 @@ For Homebrew and other installed workflows, you can persist this in `.dir2mcp.ya
 ingest_extractor: auto
 docling_command: docling --to json --output - {input}
 ```
+
+### docling extraction over HTTP (docling-serve)
+
+Instead of spawning the docling CLI per document, dir2mcp can call a long-running [**docling-serve**](https://github.com/docling-project/docling-serve) HTTP container. This is the same docling engine and produces **byte-identical** output (the same structured `DoclingDocument` → Markdown + region citations) — only the transport differs (spec 0.10.0 §7.4.B).
+
+```yaml
+ingest:
+  extractor: docling-serve         # or: auto
+  docling:
+    serve_url: http://127.0.0.1:5001
+```
+
+- Run the container yourself, e.g.: `docker run --rm -p 5001:5001 ghcr.io/docling-project/docling-serve-cpu`. dir2mcp does **not** start or stop it — lifecycle is user-managed; it probes and fails fast.
+- `extractor: docling-serve` **requires** a reachable `serve_url`. An empty or unreachable endpoint **disables** the extractor (it does **not** silently fall back to the CLI); `dir2mcp doctor` reports it as a warning via a `/health` probe.
+- Under `extractor: auto`, docling-serve is used only when the docling CLI isn't on `PATH` (local CLI is preferred); an empty `serve_url` simply means the HTTP transport isn't considered.
+- Env equivalent: `DIR2MCP_DOCLING_SERVE_URL=http://127.0.0.1:5001`.
 
 ### Continuous incremental indexing (optional)
 

--- a/internal/cli/server_doctor.go
+++ b/internal/cli/server_doctor.go
@@ -145,7 +145,8 @@ func extractorCheck(cfg config.Config) doctorCheck {
 		if err := ingest.ProbeDoclingServe(context.Background(), cfg.IngestDoclingServeURL); err != nil {
 			// An unreachable endpoint is a disabled extractor (spec §7.4.B/
 			// §7.7); warn so the operator knows document extraction won't run.
-			return doctorCheck{Name: "extractor", Status: doctorStatusWarn, Detail: fmt.Sprintf("docling-serve endpoint %s %v", cfg.IngestDoclingServeURL, err)}
+			// The URL is sanitized — doctor output flows into the support bundle.
+			return doctorCheck{Name: "extractor", Status: doctorStatusWarn, Detail: fmt.Sprintf("docling-serve endpoint %s: %v", ingest.SanitizeServeURL(cfg.IngestDoclingServeURL), err)}
 		}
 	}
 	return doctorCheck{Name: "extractor", Status: status, Detail: detail}

--- a/internal/cli/server_doctor.go
+++ b/internal/cli/server_doctor.go
@@ -141,14 +141,6 @@ func extractorCheck(cfg config.Config) doctorCheck {
 	if d.Source == "fallback" {
 		status = doctorStatusWarn
 	}
-	if d.Name == "docling-serve" {
-		if err := ingest.ProbeDoclingServe(context.Background(), cfg.IngestDoclingServeURL); err != nil {
-			// An unreachable endpoint is a disabled extractor (spec §7.4.B/
-			// §7.7); warn so the operator knows document extraction won't run.
-			// The URL is sanitized — doctor output flows into the support bundle.
-			return doctorCheck{Name: "extractor", Status: doctorStatusWarn, Detail: fmt.Sprintf("docling-serve endpoint %s: %v", ingest.SanitizeServeURL(cfg.IngestDoclingServeURL), err)}
-		}
-	}
 	return doctorCheck{Name: "extractor", Status: status, Detail: detail}
 }
 

--- a/internal/cli/server_doctor.go
+++ b/internal/cli/server_doctor.go
@@ -141,6 +141,13 @@ func extractorCheck(cfg config.Config) doctorCheck {
 	if d.Source == "fallback" {
 		status = doctorStatusWarn
 	}
+	if d.Name == "docling-serve" {
+		if err := ingest.ProbeDoclingServe(context.Background(), cfg.IngestDoclingServeURL); err != nil {
+			// An unreachable endpoint is a disabled extractor (spec §7.4.B/
+			// §7.7); warn so the operator knows document extraction won't run.
+			return doctorCheck{Name: "extractor", Status: doctorStatusWarn, Detail: fmt.Sprintf("docling-serve endpoint %s %v", cfg.IngestDoclingServeURL, err)}
+		}
+	}
 	return doctorCheck{Name: "extractor", Status: status, Detail: detail}
 }
 

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -314,9 +314,11 @@ func (a *App) validateUpConfig(cfg *config.Config, opts upOptions) int {
 		writeCLIError(a.stderr, opts.jsonOutput, exitConfigInvalid, "CONFIG_INVALID: ingest.extractor=docling but docling command is unavailable")
 		return exitConfigInvalid
 	}
-	if strings.EqualFold(strings.TrimSpace(cfg.IngestExtractor), "docling-serve") && ingest.DocumentExtractorFromConfig(*cfg) == nil {
-		writeCLIError(a.stderr, opts.jsonOutput, exitConfigInvalid, "CONFIG_INVALID: ingest.extractor=docling-serve but ingest.docling.serve_url is empty")
-		return exitConfigInvalid
+	if strings.EqualFold(strings.TrimSpace(cfg.IngestExtractor), "docling-serve") {
+		if d := ingest.DescribeDocumentExtractor(*cfg); d.Name == "" {
+			writeCLIError(a.stderr, opts.jsonOutput, exitConfigInvalid, fmt.Sprintf("CONFIG_INVALID: %s", d.Reason))
+			return exitConfigInvalid
+		}
 	}
 	if err := ensureRootAccessible(cfg.RootDir); err != nil {
 		writeCLIError(a.stderr, opts.jsonOutput, exitRootInaccessible, fmt.Sprintf("root inaccessible: %v", err))

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -314,6 +314,10 @@ func (a *App) validateUpConfig(cfg *config.Config, opts upOptions) int {
 		writeCLIError(a.stderr, opts.jsonOutput, exitConfigInvalid, "CONFIG_INVALID: ingest.extractor=docling but docling command is unavailable")
 		return exitConfigInvalid
 	}
+	if strings.EqualFold(strings.TrimSpace(cfg.IngestExtractor), "docling-serve") && ingest.DocumentExtractorFromConfig(*cfg) == nil {
+		writeCLIError(a.stderr, opts.jsonOutput, exitConfigInvalid, "CONFIG_INVALID: ingest.extractor=docling-serve but ingest.docling.serve_url is empty")
+		return exitConfigInvalid
+	}
 	if err := ensureRootAccessible(cfg.RootDir); err != nil {
 		writeCLIError(a.stderr, opts.jsonOutput, exitRootInaccessible, fmt.Sprintf("root inaccessible: %v", err))
 		return exitRootInaccessible

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -75,10 +75,15 @@ type Config struct {
 	ResolvedAuthToken string
 	// DoclingCommand optionally configures a local docling CLI command
 	// template used for rich document extraction.
-	DoclingCommand       string
-	ElevenLabsAPIKey     string
-	ElevenLabsBaseURL    string
-	ElevenLabsTTSVoiceID string
+	DoclingCommand string
+	// IngestDoclingServeURL is the HTTP endpoint of a running docling-serve
+	// container (e.g. http://127.0.0.1:5001). Required when
+	// ingest.extractor=docling-serve; under extractor=auto an empty value
+	// simply means the HTTP transport is not used (spec 0.10.0 §7.4.B).
+	IngestDoclingServeURL string
+	ElevenLabsAPIKey      string
+	ElevenLabsBaseURL     string
+	ElevenLabsTTSVoiceID  string
 	// AllowedOrigins is always initialized with local defaults and then extended
 	// via env/CLI comma-separated origin lists.
 	AllowedOrigins []string
@@ -182,6 +187,7 @@ type fileConfig struct {
 	SecretPatterns  []string
 	DoclingCommand  *string
 
+	IngestDoclingServeURL     *string
 	ElevenLabsBaseURL         *string
 	ElevenLabsTTSVoiceID      *string
 	AllowedOrigins            []string
@@ -251,6 +257,7 @@ type persistedConfig struct {
 	PathExcludes    []string `yaml:"path_excludes"`
 	SecretPatterns  []string `yaml:"secret_patterns"`
 	DoclingCommand  string   `yaml:"docling_command"`
+	DoclingServeURL string   `yaml:"docling_serve_url"`
 	// optional session timeouts expressed as YAML duration strings
 	SessionInactivityTimeout time.Duration `yaml:"session_inactivity_timeout"`
 	SessionMaxLifetime       time.Duration `yaml:"session_max_lifetime"`
@@ -438,6 +445,7 @@ func buildPersistedConfig(cfg *Config) persistedConfig {
 		PathExcludes:              append([]string(nil), cfg.PathExcludes...),
 		SecretPatterns:            append([]string(nil), cfg.SecretPatterns...),
 		DoclingCommand:            cfg.DoclingCommand,
+		DoclingServeURL:           cfg.IngestDoclingServeURL,
 		SessionInactivityTimeout:  cfg.SessionInactivityTimeout,
 		SessionMaxLifetime:        cfg.SessionMaxLifetime,
 		HealthCheckInterval:       cfg.HealthCheckInterval,
@@ -898,6 +906,9 @@ func applyModelClientsFileParsed(cfg *Config, fc fileConfig) {
 	if fc.DoclingCommand != nil {
 		cfg.DoclingCommand = *fc.DoclingCommand
 	}
+	if fc.IngestDoclingServeURL != nil {
+		cfg.IngestDoclingServeURL = *fc.IngestDoclingServeURL
+	}
 	if fc.ElevenLabsBaseURL != nil {
 		cfg.ElevenLabsBaseURL = *fc.ElevenLabsBaseURL
 	}
@@ -1228,6 +1239,8 @@ var configKeyAliases = map[string]string{
 	"security.secret_patterns":             "secret_patterns",
 	"docling.command":                      "docling_command",
 	"ingest.docling.command":               "docling_command",
+	"docling.serve_url":                    "docling_serve_url",
+	"ingest.docling.serve_url":             "docling_serve_url",
 	"stt.elevenlabs.api_key":               "elevenlabs_api_key",
 	"secrets.elevenlabs_api_key":           "elevenlabs_api_key",
 	"secrets.x402_facilitator_url":         "x402_facilitator_url",
@@ -1504,6 +1517,8 @@ func setModelStringFileScalar(cfg *fileConfig, key, value string) {
 		cfg.ElevenLabsTTSVoiceID = strPtr(value)
 	case "docling_command":
 		cfg.DoclingCommand = strPtr(value)
+	case "docling_serve_url":
+		cfg.IngestDoclingServeURL = strPtr(value)
 	case "rag.system_prompt":
 		cfg.RAGSystemPrompt = strPtr(value)
 	case "chunking.strategy":
@@ -1646,6 +1661,7 @@ func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	writeList("path_excludes", cfg.PathExcludes)
 	writeList("secret_patterns", cfg.SecretPatterns)
 	writeScalar("docling_command", cfg.DoclingCommand)
+	writeScalar("docling_serve_url", cfg.DoclingServeURL)
 	writeScalar("session_inactivity_timeout", cfg.SessionInactivityTimeout.String())
 	writeScalar("session_max_lifetime", cfg.SessionMaxLifetime.String())
 	writeScalar("health_check_interval", cfg.HealthCheckInterval.String())
@@ -1774,6 +1790,9 @@ func applyRerankEnvOverrides(cfg *Config, env map[string]string) {
 func applyIngestEnvOverrides(cfg *Config, env map[string]string) {
 	if raw, ok := envLookup("DIR2MCP_DOCLING_COMMAND", env); ok && strings.TrimSpace(raw) != "" {
 		cfg.DoclingCommand = strings.TrimSpace(raw)
+	}
+	if raw, ok := envLookup("DIR2MCP_DOCLING_SERVE_URL", env); ok && strings.TrimSpace(raw) != "" {
+		cfg.IngestDoclingServeURL = strings.TrimSpace(raw)
 	}
 	if raw, ok := envLookup("DIR2MCP_INGEST_EXTRACTOR", env); ok && strings.TrimSpace(raw) != "" {
 		cfg.IngestExtractor = strings.TrimSpace(raw)
@@ -1975,16 +1994,16 @@ func (c *Config) Validate() error {
 }
 
 // validateIngestExtractor normalizes IngestExtractor (defaulting empty)
-// and rejects any value outside auto/docling/mistral/off.
+// and rejects any value outside auto/docling/docling-serve/mistral/off.
 func (c *Config) validateIngestExtractor() error {
 	extractorMode := strings.ToLower(strings.TrimSpace(c.IngestExtractor))
 	if extractorMode == "" {
 		extractorMode = Default().IngestExtractor
 	}
 	switch extractorMode {
-	case "auto", "docling", "mistral", "off":
+	case "auto", "docling", "docling-serve", "mistral", "off":
 	default:
-		return fmt.Errorf("ingest.extractor must be one of auto, docling, mistral, off: %q", c.IngestExtractor)
+		return fmt.Errorf("ingest.extractor must be one of auto, docling, docling-serve, mistral, off: %q", c.IngestExtractor)
 	}
 	c.IngestExtractor = extractorMode
 	return nil

--- a/internal/ingest/decision.go
+++ b/internal/ingest/decision.go
@@ -1,6 +1,7 @@
 package ingest
 
 import (
+	"context"
 	"os/exec"
 	"strings"
 
@@ -32,8 +33,13 @@ type ExtractorDecision struct {
 // DescribeDocumentExtractor returns the selection result for cfg
 // without building an extractor. It MUST stay in lockstep with
 // DocumentExtractorFromConfig so the banner reflects what the runtime
-// will actually use.
+// will actually use. For docling-serve, availability includes endpoint
+// reachability per spec 0.10.0 §7.4.B.
 func DescribeDocumentExtractor(cfg config.Config) ExtractorDecision {
+	return describeDocumentExtractor(context.Background(), cfg)
+}
+
+func describeDocumentExtractor(ctx context.Context, cfg config.Config) ExtractorDecision {
 	mode := strings.ToLower(strings.TrimSpace(cfg.IngestExtractor))
 	if mode == "" {
 		mode = "auto"
@@ -50,30 +56,51 @@ func DescribeDocumentExtractor(cfg config.Config) ExtractorDecision {
 		}
 		return ExtractorDecision{Source: "disabled", Reason: "ingest.extractor=docling but docling command is unavailable"}
 	case "docling-serve":
-		if strings.TrimSpace(cfg.IngestDoclingServeURL) != "" {
-			// Reachability is verified by the doctor /health probe, not here:
-			// DescribeDocumentExtractor stays I/O-free for the startup banner.
-			return ExtractorDecision{Name: "docling-serve", Source: "explicit", Reason: "configured docling-serve endpoint"}
-		}
-		return ExtractorDecision{Source: "disabled", Reason: "ingest.extractor=docling-serve but ingest.docling.serve_url is empty"}
+		return describeExplicitDoclingServe(ctx, cfg)
 	case "mistral":
 		if mistralOCRAvailable(cfg) {
 			return ExtractorDecision{Name: "mistral-ocr", Source: "explicit"}
 		}
 		return ExtractorDecision{Source: "disabled", Reason: "ingest.extractor=mistral but the mistral-ocr provider has no credential"}
 	default: // auto
-		if tpl := strings.TrimSpace(cfg.DoclingCommand); tpl != "" {
-			return ExtractorDecision{Name: "docling", Source: "auto", Reason: "configured docling command"}
-		}
-		if _, err := exec.LookPath("docling"); err == nil {
-			return ExtractorDecision{Name: "docling", Source: "auto", Reason: "auto-detected on PATH"}
-		}
-		if strings.TrimSpace(cfg.IngestDoclingServeURL) != "" {
-			return ExtractorDecision{Name: "docling-serve", Source: "auto", Reason: "configured docling-serve endpoint; docling CLI not found"}
-		}
-		if mistralOCRAvailable(cfg) {
-			return ExtractorDecision{Name: "mistral-ocr", Source: "fallback", Reason: "docling not found on PATH; falling back to Mistral OCR"}
-		}
+		return describeAutoDocumentExtractor(ctx, cfg)
+	}
+}
+
+func describeExplicitDoclingServe(ctx context.Context, cfg config.Config) ExtractorDecision {
+	serveURL := strings.TrimSpace(cfg.IngestDoclingServeURL)
+	switch {
+	case serveURL == "":
+		return ExtractorDecision{Source: "disabled", Reason: "ingest.extractor=docling-serve but ingest.docling.serve_url is empty"}
+	case ProbeDoclingServe(ctx, serveURL) == nil:
+		return ExtractorDecision{Name: "docling-serve", Source: "explicit", Reason: "configured docling-serve endpoint"}
+	default:
+		return ExtractorDecision{Source: "disabled", Reason: "ingest.extractor=docling-serve but the docling-serve endpoint is unreachable"}
+	}
+}
+
+func describeAutoDocumentExtractor(ctx context.Context, cfg config.Config) ExtractorDecision {
+	if tpl := strings.TrimSpace(cfg.DoclingCommand); tpl != "" {
+		return ExtractorDecision{Name: "docling", Source: "auto", Reason: "configured docling command"}
+	}
+	if _, err := exec.LookPath("docling"); err == nil {
+		return ExtractorDecision{Name: "docling", Source: "auto", Reason: "auto-detected on PATH"}
+	}
+	return describeAutoWithoutDoclingCLI(ctx, cfg)
+}
+
+func describeAutoWithoutDoclingCLI(ctx context.Context, cfg config.Config) ExtractorDecision {
+	serveURL := strings.TrimSpace(cfg.IngestDoclingServeURL)
+	switch {
+	case serveURL != "" && ProbeDoclingServe(ctx, serveURL) == nil:
+		return ExtractorDecision{Name: "docling-serve", Source: "auto", Reason: "configured docling-serve endpoint; docling CLI not found"}
+	case mistralOCRAvailable(cfg) && serveURL != "":
+		return ExtractorDecision{Name: "mistral-ocr", Source: "fallback", Reason: "docling not found on PATH; docling-serve endpoint unreachable; falling back to Mistral OCR"}
+	case mistralOCRAvailable(cfg):
+		return ExtractorDecision{Name: "mistral-ocr", Source: "fallback", Reason: "docling not found on PATH; falling back to Mistral OCR"}
+	case serveURL != "":
+		return ExtractorDecision{Source: "disabled", Reason: "docling not found on PATH; docling-serve endpoint unreachable; and no Mistral credential"}
+	default:
 		return ExtractorDecision{Source: "disabled", Reason: "no extractor available: docling not on PATH, no docling-serve URL, and no Mistral credential"}
 	}
 }

--- a/internal/ingest/decision.go
+++ b/internal/ingest/decision.go
@@ -35,8 +35,21 @@ type ExtractorDecision struct {
 // DocumentExtractorFromConfig so the banner reflects what the runtime
 // will actually use. For docling-serve, availability includes endpoint
 // reachability per spec 0.10.0 §7.4.B.
+//
+// This convenience form uses a background context; the docling-serve
+// reachability probe it may run is therefore uncancellable and can block
+// for up to the probe timeout. Hot paths that already hold a request
+// context (e.g. MCP tool handlers) should call
+// DescribeDocumentExtractorContext instead.
 func DescribeDocumentExtractor(cfg config.Config) ExtractorDecision {
 	return describeDocumentExtractor(context.Background(), cfg)
+}
+
+// DescribeDocumentExtractorContext is DescribeDocumentExtractor with a
+// caller-provided context so the docling-serve reachability probe honours
+// cancellation and deadlines.
+func DescribeDocumentExtractorContext(ctx context.Context, cfg config.Config) ExtractorDecision {
+	return describeDocumentExtractor(ctx, cfg)
 }
 
 func describeDocumentExtractor(ctx context.Context, cfg config.Config) ExtractorDecision {

--- a/internal/ingest/decision.go
+++ b/internal/ingest/decision.go
@@ -16,7 +16,7 @@ import (
 // the construction cost.
 type ExtractorDecision struct {
 	// Name is the selected extractor identifier: "docling",
-	// "mistral-ocr", or "" when no extractor is available.
+	// "docling-serve", "mistral-ocr", or "" when no extractor is available.
 	Name string
 	// Source describes how the choice was made: "explicit" (user
 	// pinned via ingest.extractor), "auto" (auto-detected as the
@@ -49,6 +49,13 @@ func DescribeDocumentExtractor(cfg config.Config) ExtractorDecision {
 			return ExtractorDecision{Name: "docling", Source: "explicit", Reason: "auto-detected on PATH"}
 		}
 		return ExtractorDecision{Source: "disabled", Reason: "ingest.extractor=docling but docling command is unavailable"}
+	case "docling-serve":
+		if strings.TrimSpace(cfg.IngestDoclingServeURL) != "" {
+			// Reachability is verified by the doctor /health probe, not here:
+			// DescribeDocumentExtractor stays I/O-free for the startup banner.
+			return ExtractorDecision{Name: "docling-serve", Source: "explicit", Reason: "configured docling-serve endpoint"}
+		}
+		return ExtractorDecision{Source: "disabled", Reason: "ingest.extractor=docling-serve but ingest.docling.serve_url is empty"}
 	case "mistral":
 		if mistralOCRAvailable(cfg) {
 			return ExtractorDecision{Name: "mistral-ocr", Source: "explicit"}
@@ -61,10 +68,13 @@ func DescribeDocumentExtractor(cfg config.Config) ExtractorDecision {
 		if _, err := exec.LookPath("docling"); err == nil {
 			return ExtractorDecision{Name: "docling", Source: "auto", Reason: "auto-detected on PATH"}
 		}
+		if strings.TrimSpace(cfg.IngestDoclingServeURL) != "" {
+			return ExtractorDecision{Name: "docling-serve", Source: "auto", Reason: "configured docling-serve endpoint; docling CLI not found"}
+		}
 		if mistralOCRAvailable(cfg) {
 			return ExtractorDecision{Name: "mistral-ocr", Source: "fallback", Reason: "docling not found on PATH; falling back to Mistral OCR"}
 		}
-		return ExtractorDecision{Source: "disabled", Reason: "no extractor available: docling not on PATH and no Mistral credential"}
+		return ExtractorDecision{Source: "disabled", Reason: "no extractor available: docling not on PATH, no docling-serve URL, and no Mistral credential"}
 	}
 }
 

--- a/internal/ingest/docling_serve_extractor.go
+++ b/internal/ingest/docling_serve_extractor.go
@@ -1,0 +1,188 @@
+package ingest
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/ingest/docling"
+)
+
+const (
+	// doclingServeConvertPath returns a structured DoclingDocument
+	// (json_content) for an uploaded file.
+	doclingServeConvertPath = "/v1/convert/file"
+	// doclingServeReadyPath gates on model load; used by doctor probes.
+	doclingServeReadyPath = "/health"
+	// doclingServeTimeout is a generous backstop for conversions when the
+	// caller's context carries no deadline.
+	doclingServeTimeout = 10 * time.Minute
+)
+
+// doclingServeExtractor extracts structured documents by calling a docling-serve
+// HTTP container instead of spawning the docling CLI. Output is byte-identical
+// to the CLI path (same DoclingDocument -> Markdown + region spans), per spec
+// 0.10.0 §7.4.B: the transport differs, the engine and result do not.
+type doclingServeExtractor struct {
+	baseURL string
+	client  *http.Client
+}
+
+// NewDoclingServeExtractor returns an extractor backed by the docling-serve HTTP
+// endpoint at baseURL (e.g. http://127.0.0.1:5001). A trailing slash is trimmed.
+func NewDoclingServeExtractor(baseURL string) *doclingServeExtractor {
+	return &doclingServeExtractor{
+		baseURL: strings.TrimRight(strings.TrimSpace(baseURL), "/"),
+		client:  &http.Client{Timeout: doclingServeTimeout},
+	}
+}
+
+// doclingServeResponse is the subset of the docling-serve convert response we
+// consume: the structured DoclingDocument carried in document.json_content.
+type doclingServeResponse struct {
+	Document struct {
+		JSONContent json.RawMessage `json:"json_content"`
+	} `json:"document"`
+	Status string `json:"status"`
+}
+
+// buildConvertRequest assembles the multipart upload requesting structured JSON
+// (to_formats=json), which is what makes the output byte-compatible with the
+// CLI `--to json` path.
+func (d *doclingServeExtractor) buildConvertRequest(ctx context.Context, relPath string, data []byte) (*http.Request, error) {
+	var body bytes.Buffer
+	mw := multipart.NewWriter(&body)
+	filename := filepath.Base(relPath)
+	if filename == "" || filename == "." || filename == string(filepath.Separator) {
+		filename = "document"
+	}
+	part, err := mw.CreateFormFile("files", filename)
+	if err != nil {
+		return nil, fmt.Errorf("build docling-serve request: %w", err)
+	}
+	if _, err := part.Write(data); err != nil {
+		return nil, fmt.Errorf("write docling-serve request: %w", err)
+	}
+	if err := mw.WriteField("to_formats", "json"); err != nil {
+		return nil, fmt.Errorf("build docling-serve request: %w", err)
+	}
+	if err := mw.Close(); err != nil {
+		return nil, fmt.Errorf("finalize docling-serve request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, d.baseURL+doclingServeConvertPath, &body)
+	if err != nil {
+		return nil, fmt.Errorf("create docling-serve request: %w", err)
+	}
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	req.Header.Set("Accept", "application/json")
+	return req, nil
+}
+
+// convert uploads data to docling-serve and returns the raw DoclingDocument
+// JSON (the same bytes the CLI `--to json` path emits on stdout).
+func (d *doclingServeExtractor) convert(ctx context.Context, relPath string, data []byte) ([]byte, error) {
+	if d.baseURL == "" {
+		return nil, fmt.Errorf("docling-serve endpoint is not configured")
+	}
+	req, err := d.buildConvertRequest(ctx, relPath, data)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("docling-serve request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	payload, err := io.ReadAll(io.LimitReader(resp.Body, maxDoclingStdoutBytes))
+	if err != nil {
+		return nil, fmt.Errorf("read docling-serve response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("docling-serve returned HTTP %d: %s", resp.StatusCode, httpBodySnippet(payload))
+	}
+
+	var parsed doclingServeResponse
+	if err := json.Unmarshal(payload, &parsed); err != nil {
+		return nil, fmt.Errorf("decode docling-serve response: %w", err)
+	}
+	if len(parsed.Document.JSONContent) == 0 || string(parsed.Document.JSONContent) == "null" {
+		return nil, fmt.Errorf("docling-serve response missing json_content (status %q)", parsed.Status)
+	}
+	return parsed.Document.JSONContent, nil
+}
+
+// Extract returns the rendered Markdown representation.
+func (d *doclingServeExtractor) Extract(ctx context.Context, relPath string, data []byte) (string, error) {
+	res, err := d.ExtractStructured(ctx, relPath, data)
+	if err != nil {
+		return "", err
+	}
+	return res.Markdown, nil
+}
+
+// ExtractStructured uploads the file to docling-serve and parses the returned
+// DoclingDocument exactly as the CLI path does, so the two transports yield the
+// same Markdown, blocks, and title.
+func (d *doclingServeExtractor) ExtractStructured(ctx context.Context, relPath string, data []byte) (StructuredExtraction, error) {
+	raw, err := d.convert(ctx, relPath, data)
+	if err != nil {
+		return StructuredExtraction{}, err
+	}
+	doc, err := docling.Parse(raw)
+	if err != nil {
+		return StructuredExtraction{}, fmt.Errorf("parse structured docling-serve output for %s: %w", relPath, err)
+	}
+	blocks := doc.Linearize()
+	return StructuredExtraction{
+		Markdown: docling.RenderMarkdown(blocks),
+		Blocks:   blocks,
+		Title:    doc.Title(),
+	}, nil
+}
+
+// ProbeDoclingServe checks that a docling-serve endpoint is reachable and
+// healthy, for diagnostics (the daemon-side `dir2mcp doctor`). It returns nil
+// when the endpoint responds 200 on its health path, otherwise a descriptive
+// error. Per spec 0.10.0 §7.4.B/§7.7 an unreachable endpoint is a disabled
+// extractor, so callers surface a probe failure as a warning, not a hard error.
+func ProbeDoclingServe(ctx context.Context, baseURL string) error {
+	base := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if base == "" {
+		return fmt.Errorf("endpoint is not configured")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+doclingServeReadyPath, nil)
+	if err != nil {
+		return err
+	}
+	client := &http.Client{Timeout: 3 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("unreachable: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("health check returned HTTP %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// httpBodySnippet returns a short, single-line excerpt of a response body for
+// error messages.
+func httpBodySnippet(b []byte) string {
+	s := strings.TrimSpace(string(b))
+	s = strings.ReplaceAll(s, "\n", " ")
+	if len(s) > 200 {
+		s = s[:200] + "…"
+	}
+	return s
+}

--- a/internal/ingest/docling_serve_extractor.go
+++ b/internal/ingest/docling_serve_extractor.go
@@ -78,7 +78,7 @@ func (d *doclingServeExtractor) buildConvertRequest(ctx context.Context, relPath
 		return nil, fmt.Errorf("finalize docling-serve request: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, d.baseURL+doclingServeConvertPath, &body)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, joinServeURL(d.baseURL, doclingServeConvertPath), &body)
 	if err != nil {
 		return nil, fmt.Errorf("create docling-serve request: %w", err)
 	}
@@ -169,7 +169,7 @@ func ProbeDoclingServe(ctx context.Context, baseURL string) error {
 	if base == "" {
 		return fmt.Errorf("endpoint is not configured")
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+doclingServeReadyPath, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, joinServeURL(base, doclingServeReadyPath), nil)
 	if err != nil {
 		return err
 	}
@@ -183,6 +183,21 @@ func ProbeDoclingServe(ctx context.Context, baseURL string) error {
 		return fmt.Errorf("health check returned HTTP %d", resp.StatusCode)
 	}
 	return nil
+}
+
+// joinServeURL appends apiPath to base's path while preserving any userinfo and
+// query string (which a deployment may use to carry auth or signed routing
+// params). Plain concatenation would corrupt such URLs — for
+// "http://h/?token=x" it would yield "http://h/?token=x/v1/convert/file", so
+// the path lands inside the query. Falls back to concatenation only when base
+// is unparseable, which the caller's own validation already rejects upstream.
+func joinServeURL(base, apiPath string) string {
+	u, err := url.Parse(base)
+	if err != nil || u.Host == "" {
+		return base + apiPath
+	}
+	u.Path = strings.TrimRight(u.Path, "/") + apiPath
+	return u.String()
 }
 
 // SanitizeServeURL reduces a docling-serve endpoint to scheme://host/path,

--- a/internal/ingest/docling_serve_extractor.go
+++ b/internal/ingest/docling_serve_extractor.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"net/url"
 	"path/filepath"
 	"strings"
 	"time"
@@ -103,12 +104,20 @@ func (d *doclingServeExtractor) convert(ctx context.Context, relPath string, dat
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	payload, err := io.ReadAll(io.LimitReader(resp.Body, maxDoclingStdoutBytes))
+	// Read one byte past the limit so an over-size response surfaces as a clear
+	// "too large" error rather than a confusing truncated-JSON decode failure.
+	payload, err := io.ReadAll(io.LimitReader(resp.Body, maxDoclingStdoutBytes+1))
 	if err != nil {
 		return nil, fmt.Errorf("read docling-serve response: %w", err)
 	}
+	if len(payload) > maxDoclingStdoutBytes {
+		return nil, fmt.Errorf("docling-serve response exceeded %d bytes", maxDoclingStdoutBytes)
+	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("docling-serve returned HTTP %d: %s", resp.StatusCode, httpBodySnippet(payload))
+		// Deliberately do NOT echo the response body: this error is persisted as
+		// Document.ErrorMessage, and an untrusted body could carry document
+		// fragments or credential-bearing routing details.
+		return nil, fmt.Errorf("docling-serve returned HTTP %d", resp.StatusCode)
 	}
 
 	var parsed doclingServeResponse
@@ -176,13 +185,15 @@ func ProbeDoclingServe(ctx context.Context, baseURL string) error {
 	return nil
 }
 
-// httpBodySnippet returns a short, single-line excerpt of a response body for
-// error messages.
-func httpBodySnippet(b []byte) string {
-	s := strings.TrimSpace(string(b))
-	s = strings.ReplaceAll(s, "\n", " ")
-	if len(s) > 200 {
-		s = s[:200] + "…"
+// SanitizeServeURL reduces a docling-serve endpoint to scheme://host/path,
+// dropping any userinfo, query, or fragment. Used before the endpoint is
+// written to diagnostic surfaces (extraction metadata, the doctor report) so a
+// URL carrying credentials or signed routing params never becomes durable or
+// logged. Returns "" when the URL cannot be parsed.
+func SanitizeServeURL(raw string) string {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || u.Host == "" {
+		return ""
 	}
-	return s
+	return u.Scheme + "://" + u.Host + u.Path
 }

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -226,8 +226,18 @@ func buildTranscriber(prof provider.Profile) (model.Transcriber, error) {
 // Priority: configured docling command, auto-detected docling binary, then
 // Mistral OCR (via the provider model). Selection mirrors
 // DescribeDocumentExtractor so the diagnostic banner is always in sync.
+//
+// It uses a background context for any reachability probe; callers on hot
+// paths that hold a request context should use
+// DocumentExtractorFromConfigContext so the probe is cancellable.
 func DocumentExtractorFromConfig(cfg config.Config) model.DocumentExtractor {
-	decision := DescribeDocumentExtractor(cfg)
+	return DocumentExtractorFromConfigContext(context.Background(), cfg)
+}
+
+// DocumentExtractorFromConfigContext is DocumentExtractorFromConfig with a
+// caller-provided context, threaded into the docling-serve reachability probe.
+func DocumentExtractorFromConfigContext(ctx context.Context, cfg config.Config) model.DocumentExtractor {
+	decision := DescribeDocumentExtractorContext(ctx, cfg)
 	switch decision.Name {
 	case "docling":
 		tpl := strings.TrimSpace(cfg.DoclingCommand)

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -1103,7 +1103,9 @@ func (s *Service) extractionMetaJSON() string {
 		meta["command"] = strings.TrimSpace(ex.commandTemplate)
 	case *doclingServeExtractor:
 		meta["provider"] = "docling-serve"
-		meta["serve_url"] = ex.baseURL
+		// Sanitized (scheme/host/path only): this is persisted per-document, so
+		// any userinfo/query in the URL must not become durable metadata.
+		meta["serve_url"] = SanitizeServeURL(ex.baseURL)
 	case *mistral.Client:
 		meta["provider"] = "mistral"
 		meta["model"] = strings.TrimSpace(ex.DefaultOCRModel)

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -232,6 +232,8 @@ func DocumentExtractorFromConfig(cfg config.Config) model.DocumentExtractor {
 	case "docling":
 		tpl := strings.TrimSpace(cfg.DoclingCommand)
 		return NewDoclingExtractor(tpl)
+	case "docling-serve":
+		return NewDoclingServeExtractor(cfg.IngestDoclingServeURL)
 	case "mistral-ocr":
 		return mistralExtractor(cfg)
 	default:
@@ -1099,6 +1101,9 @@ func (s *Service) extractionMetaJSON() string {
 	case *doclingExtractor:
 		meta["provider"] = "docling"
 		meta["command"] = strings.TrimSpace(ex.commandTemplate)
+	case *doclingServeExtractor:
+		meta["provider"] = "docling-serve"
+		meta["serve_url"] = ex.baseURL
 	case *mistral.Client:
 		meta["provider"] = "mistral"
 		meta["model"] = strings.TrimSpace(ex.DefaultOCRModel)

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1738,7 +1738,7 @@ func (s *Server) sourceTextForAnnotation(ctx context.Context, doc model.Document
 				return "", "", &toolExecutionError{Code: protocol.ErrorCodePermissionDenied, Message: err.Error(), Retryable: false}
 			}
 		}
-		extractor := ingest.DocumentExtractorFromConfig(s.cfg)
+		extractor := ingest.DocumentExtractorFromConfigContext(ctx, s.cfg)
 		if extractor == nil {
 			return "", "", &toolExecutionError{
 				Code:      "CONFIG_INVALID",

--- a/tests/config/config_test.go
+++ b/tests/config/config_test.go
@@ -62,6 +62,15 @@ func TestConfigValidateRejectsInvalidIngestExtractor(t *testing.T) {
 	}
 }
 
+func TestConfigValidateAcceptsDoclingServeExtractor(t *testing.T) {
+	cfg := config.Default()
+	cfg.IngestExtractor = "docling-serve"
+	cfg.IngestDoclingServeURL = "http://127.0.0.1:5001"
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("docling-serve must be a valid extractor: %v", err)
+	}
+}
+
 func TestLoad_DotEnvLocalOverridesDotEnv(t *testing.T) {
 	tmp := t.TempDir()
 	writeFile(t, filepath.Join(tmp, ".env"), "MISTRAL_API_KEY=from_env_file\n")

--- a/tests/config/config_yaml_test.go
+++ b/tests/config/config_yaml_test.go
@@ -119,6 +119,7 @@ func TestSaveFile_WatchSettingsRoundTrip(t *testing.T) {
 	cfg.StateDir = "/tmp/repo/.dir2mcp"
 	cfg.IngestWatch = true
 	cfg.IngestWatchDebounce = 1500 * time.Millisecond
+	cfg.IngestDoclingServeURL = "http://127.0.0.1:5001"
 
 	if err := config.SaveFile(path, cfg); err != nil {
 		t.Fatalf("SaveFile failed: %v", err)
@@ -133,6 +134,9 @@ func TestSaveFile_WatchSettingsRoundTrip(t *testing.T) {
 	}
 	if loaded.IngestWatchDebounce != 1500*time.Millisecond {
 		t.Errorf("IngestWatchDebounce did not round-trip: got %v, want 1.5s", loaded.IngestWatchDebounce)
+	}
+	if loaded.IngestDoclingServeURL != "http://127.0.0.1:5001" {
+		t.Errorf("IngestDoclingServeURL did not round-trip: got %q", loaded.IngestDoclingServeURL)
 	}
 }
 
@@ -201,6 +205,7 @@ func TestLoadFile_ReadsNestedSpecStyleKeys(t *testing.T) {
 		"  extractor: docling\n"+
 		"  docling:\n"+
 		"    command: docling --to md --output - {input}\n"+
+		"    serve_url: http://127.0.0.1:5001\n"+
 		"  pdf:\n"+
 		"    mode: ocr\n"+
 		"  images:\n"+
@@ -270,6 +275,9 @@ func assertNestedIngestFields(t *testing.T, cfg config.Config) {
 	}
 	if cfg.DoclingCommand != "docling --to md --output - {input}" {
 		t.Fatalf("DoclingCommand=%q", cfg.DoclingCommand)
+	}
+	if cfg.IngestDoclingServeURL != "http://127.0.0.1:5001" {
+		t.Fatalf("IngestDoclingServeURL=%q", cfg.IngestDoclingServeURL)
 	}
 	if !cfg.IngestWatch {
 		t.Fatal("expected IngestWatch=true")

--- a/tests/ingest/docling_extractor_test.go
+++ b/tests/ingest/docling_extractor_test.go
@@ -2,6 +2,8 @@ package tests
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -51,11 +53,12 @@ func TestDocumentExtractorFromConfig_PrefersDoclingCommand(t *testing.T) {
 }
 
 func TestDescribeDocumentExtractor_DoclingServe(t *testing.T) {
-	// Explicit docling-serve with a URL is selected (reachability is a doctor
-	// concern, not a Describe concern).
+	healthyURL := healthyDoclingServeURL(t)
+
+	// Explicit docling-serve with a reachable URL is selected.
 	d := ingest.DescribeDocumentExtractor(config.Config{
 		IngestExtractor:       "docling-serve",
-		IngestDoclingServeURL: "http://127.0.0.1:5001",
+		IngestDoclingServeURL: healthyURL,
 	})
 	if d.Name != "docling-serve" || d.Source != "explicit" {
 		t.Fatalf("explicit docling-serve: got name=%q source=%q", d.Name, d.Source)
@@ -67,6 +70,15 @@ func TestDescribeDocumentExtractor_DoclingServe(t *testing.T) {
 	if d.Name != "" || d.Source != "disabled" {
 		t.Fatalf("docling-serve without URL should be disabled: got name=%q source=%q", d.Name, d.Source)
 	}
+
+	// Explicit docling-serve with an unreachable URL is unavailable.
+	d = ingest.DescribeDocumentExtractor(config.Config{
+		IngestExtractor:       "docling-serve",
+		IngestDoclingServeURL: unreachableDoclingServeURL(t),
+	})
+	if d.Name != "" || d.Source != "disabled" {
+		t.Fatalf("docling-serve with unreachable URL should be disabled: got name=%q source=%q", d.Name, d.Source)
+	}
 }
 
 func TestDescribeDocumentExtractor_AutoUsesServeURLWhenNoCLI(t *testing.T) {
@@ -76,17 +88,46 @@ func TestDescribeDocumentExtractor_AutoUsesServeURLWhenNoCLI(t *testing.T) {
 	t.Setenv("MISTRAL_API_KEY", "")
 	d := ingest.DescribeDocumentExtractor(config.Config{
 		IngestExtractor:       "auto",
-		IngestDoclingServeURL: "http://127.0.0.1:5001",
+		IngestDoclingServeURL: healthyDoclingServeURL(t),
 	})
 	if d.Name != "docling-serve" {
 		t.Fatalf("auto with serve_url and no CLI: got name=%q (%s)", d.Name, d.Reason)
 	}
 }
 
+func TestDescribeDocumentExtractor_AutoPrefersServeOverMistral(t *testing.T) {
+	if _, err := exec.LookPath("docling"); err == nil {
+		t.Skip("docling CLI present on PATH; auto would prefer it")
+	}
+	t.Setenv("MISTRAL_API_KEY", "fake-key")
+	d := ingest.DescribeDocumentExtractor(config.Config{
+		IngestExtractor:       "auto",
+		IngestDoclingServeURL: healthyDoclingServeURL(t),
+	})
+	if d.Name != "docling-serve" {
+		t.Fatalf("auto with serve_url and Mistral credential: got name=%q (%s)", d.Name, d.Reason)
+	}
+}
+
+func TestDescribeDocumentExtractor_AutoFallsBackWhenServeUnreachable(t *testing.T) {
+	if _, err := exec.LookPath("docling"); err == nil {
+		t.Skip("docling CLI present on PATH; auto would prefer it")
+	}
+	t.Setenv("MISTRAL_API_KEY", "fake-key")
+	d := ingest.DescribeDocumentExtractor(config.Config{
+		IngestExtractor:       "auto",
+		IngestDoclingServeURL: unreachableDoclingServeURL(t),
+	})
+	if d.Name != "mistral-ocr" || d.Source != "fallback" {
+		t.Fatalf("auto with unreachable serve_url should fall back to Mistral: got name=%q source=%q (%s)", d.Name, d.Source, d.Reason)
+	}
+}
+
 func TestDocumentExtractorFromConfig_DoclingServe(t *testing.T) {
+	healthyURL := healthyDoclingServeURL(t)
 	ext := ingest.DocumentExtractorFromConfig(config.Config{
 		IngestExtractor:       "docling-serve",
-		IngestDoclingServeURL: "http://127.0.0.1:5001",
+		IngestDoclingServeURL: healthyURL,
 	})
 	if ext == nil {
 		t.Fatal("expected a docling-serve extractor")
@@ -95,4 +136,33 @@ func TestDocumentExtractorFromConfig_DoclingServe(t *testing.T) {
 	if ingest.DocumentExtractorFromConfig(config.Config{IngestExtractor: "docling-serve"}) != nil {
 		t.Fatal("docling-serve with empty URL should resolve to no extractor")
 	}
+	if ingest.DocumentExtractorFromConfig(config.Config{
+		IngestExtractor:       "docling-serve",
+		IngestDoclingServeURL: unreachableDoclingServeURL(t),
+	}) != nil {
+		t.Fatal("docling-serve with unreachable URL should resolve to no extractor")
+	}
+}
+
+func healthyDoclingServeURL(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/health" {
+			http.NotFound(w, r)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+func unreachableDoclingServeURL(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	url := srv.URL
+	srv.Close()
+	return url
 }

--- a/tests/ingest/docling_extractor_test.go
+++ b/tests/ingest/docling_extractor_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"os/exec"
 	"runtime"
 	"strings"
 	"testing"
@@ -46,5 +47,52 @@ func TestDocumentExtractorFromConfig_PrefersDoclingCommand(t *testing.T) {
 	}
 	if strings.TrimSpace(out) != "docling preferred" {
 		t.Fatalf("unexpected output: %q", out)
+	}
+}
+
+func TestDescribeDocumentExtractor_DoclingServe(t *testing.T) {
+	// Explicit docling-serve with a URL is selected (reachability is a doctor
+	// concern, not a Describe concern).
+	d := ingest.DescribeDocumentExtractor(config.Config{
+		IngestExtractor:       "docling-serve",
+		IngestDoclingServeURL: "http://127.0.0.1:5001",
+	})
+	if d.Name != "docling-serve" || d.Source != "explicit" {
+		t.Fatalf("explicit docling-serve: got name=%q source=%q", d.Name, d.Source)
+	}
+
+	// Explicit docling-serve with an empty URL is disabled (no silent CLI
+	// fallback) per spec 0.10.0 §7.4.B.
+	d = ingest.DescribeDocumentExtractor(config.Config{IngestExtractor: "docling-serve"})
+	if d.Name != "" || d.Source != "disabled" {
+		t.Fatalf("docling-serve without URL should be disabled: got name=%q source=%q", d.Name, d.Source)
+	}
+}
+
+func TestDescribeDocumentExtractor_AutoUsesServeURLWhenNoCLI(t *testing.T) {
+	if _, err := exec.LookPath("docling"); err == nil {
+		t.Skip("docling CLI present on PATH; auto would prefer it")
+	}
+	t.Setenv("MISTRAL_API_KEY", "")
+	d := ingest.DescribeDocumentExtractor(config.Config{
+		IngestExtractor:       "auto",
+		IngestDoclingServeURL: "http://127.0.0.1:5001",
+	})
+	if d.Name != "docling-serve" {
+		t.Fatalf("auto with serve_url and no CLI: got name=%q (%s)", d.Name, d.Reason)
+	}
+}
+
+func TestDocumentExtractorFromConfig_DoclingServe(t *testing.T) {
+	ext := ingest.DocumentExtractorFromConfig(config.Config{
+		IngestExtractor:       "docling-serve",
+		IngestDoclingServeURL: "http://127.0.0.1:5001",
+	})
+	if ext == nil {
+		t.Fatal("expected a docling-serve extractor")
+	}
+	// Empty URL -> no extractor (disabled), so up.go can reject the combination.
+	if ingest.DocumentExtractorFromConfig(config.Config{IngestExtractor: "docling-serve"}) != nil {
+		t.Fatal("docling-serve with empty URL should resolve to no extractor")
 	}
 }

--- a/tests/ingest/docling_serve_extractor_test.go
+++ b/tests/ingest/docling_serve_extractor_test.go
@@ -71,14 +71,34 @@ func TestDoclingServeExtractor_Extract_ParsesJSONContent(t *testing.T) {
 }
 
 func TestDoclingServeExtractor_Extract_ErrorsOnNon200(t *testing.T) {
+	const secretMarker = "SECRET-LEAK-token-abc123"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		http.Error(w, "boom", http.StatusInternalServerError)
+		http.Error(w, secretMarker, http.StatusInternalServerError)
 	}))
 	defer srv.Close()
 
 	ext := ingest.NewDoclingServeExtractor(srv.URL)
-	if _, err := ext.Extract(context.Background(), "report.pdf", []byte("x")); err == nil {
+	_, err := ext.Extract(context.Background(), "report.pdf", []byte("x"))
+	if err == nil {
 		t.Fatal("expected error on HTTP 500, got nil")
+	}
+	// The error is persisted as Document.ErrorMessage — it must not echo the
+	// (untrusted) response body.
+	if strings.Contains(err.Error(), secretMarker) {
+		t.Errorf("error leaked response body: %v", err)
+	}
+}
+
+func TestSanitizeServeURL(t *testing.T) {
+	cases := map[string]string{
+		"http://127.0.0.1:5001":                   "http://127.0.0.1:5001",
+		"http://user:pass@host:5001/v1?token=sec": "http://host:5001/v1",
+		"https://example.com/base/":               "https://example.com/base/",
+	}
+	for in, want := range cases {
+		if got := ingest.SanitizeServeURL(in); got != want {
+			t.Errorf("SanitizeServeURL(%q) = %q, want %q", in, got, want)
+		}
 	}
 }
 

--- a/tests/ingest/docling_serve_extractor_test.go
+++ b/tests/ingest/docling_serve_extractor_test.go
@@ -1,0 +1,120 @@
+package tests
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/ingest"
+)
+
+// servedDoc is a minimal DoclingDocument the docling-serve stub returns inside
+// document.json_content — the same shape the CLI emits via `--to json`.
+const servedDoc = `{
+  "schema_name": "DoclingDocument",
+  "version": "1.2.0",
+  "name": "Served Doc",
+  "pages": { "1": { "size": { "width": 612, "height": 792 }, "page_no": 1 } },
+  "body": { "self_ref": "#/body", "children": [
+    { "$ref": "#/texts/0" },
+    { "$ref": "#/texts/1" }
+  ]},
+  "texts": [
+    { "self_ref": "#/texts/0", "label": "title", "text": "Served Doc",
+      "prov": [{ "page_no": 1, "bbox": { "l": 72, "t": 700, "r": 540, "b": 720, "coord_origin": "BOTTOMLEFT" }}] },
+    { "self_ref": "#/texts/1", "label": "paragraph", "text": "Hello from docling-serve.",
+      "prov": [{ "page_no": 1, "bbox": { "l": 72, "t": 600, "r": 540, "b": 620, "coord_origin": "BOTTOMLEFT" }}] }
+  ]
+}`
+
+func TestDoclingServeExtractor_Extract_ParsesJSONContent(t *testing.T) {
+	var gotPath, gotForm, gotFile string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			t.Errorf("parse multipart: %v", err)
+		}
+		gotForm = r.FormValue("to_formats")
+		if f, _, err := r.FormFile("files"); err == nil {
+			b, _ := io.ReadAll(f)
+			gotFile = string(b)
+			_ = f.Close()
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":"success","document":{"json_content":`+servedDoc+`}}`)
+	}))
+	defer srv.Close()
+
+	ext := ingest.NewDoclingServeExtractor(srv.URL)
+	md, err := ext.Extract(context.Background(), "report.pdf", []byte("PDF-BYTES"))
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if !strings.Contains(md, "Hello from docling-serve.") {
+		t.Errorf("rendered markdown missing body text; got:\n%s", md)
+	}
+
+	// The request must hit the convert endpoint, request JSON output, and carry
+	// the uploaded file content.
+	if gotPath != "/v1/convert/file" {
+		t.Errorf("convert path = %q, want /v1/convert/file", gotPath)
+	}
+	if gotForm != "json" {
+		t.Errorf("to_formats = %q, want json", gotForm)
+	}
+	if gotFile != "PDF-BYTES" {
+		t.Errorf("uploaded file = %q, want PDF-BYTES", gotFile)
+	}
+}
+
+func TestDoclingServeExtractor_Extract_ErrorsOnNon200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	ext := ingest.NewDoclingServeExtractor(srv.URL)
+	if _, err := ext.Extract(context.Background(), "report.pdf", []byte("x")); err == nil {
+		t.Fatal("expected error on HTTP 500, got nil")
+	}
+}
+
+func TestDoclingServeExtractor_Extract_ErrorsOnMissingJSONContent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"status":"failure","document":{"json_content":null}}`)
+	}))
+	defer srv.Close()
+
+	ext := ingest.NewDoclingServeExtractor(srv.URL)
+	if _, err := ext.Extract(context.Background(), "report.pdf", []byte("x")); err == nil {
+		t.Fatal("expected error when json_content is missing, got nil")
+	}
+}
+
+func TestProbeDoclingServe(t *testing.T) {
+	healthy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/health" {
+			t.Errorf("probe path = %q, want /health", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer healthy.Close()
+	if err := ingest.ProbeDoclingServe(context.Background(), healthy.URL); err != nil {
+		t.Errorf("ProbeDoclingServe(healthy) = %v, want nil", err)
+	}
+
+	down := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer down.Close()
+	if err := ingest.ProbeDoclingServe(context.Background(), down.URL); err == nil {
+		t.Error("ProbeDoclingServe(503) = nil, want error")
+	}
+
+	if err := ingest.ProbeDoclingServe(context.Background(), ""); err == nil {
+		t.Error("ProbeDoclingServe(\"\") = nil, want error")
+	}
+}

--- a/tests/ingest/docling_serve_extractor_test.go
+++ b/tests/ingest/docling_serve_extractor_test.go
@@ -71,9 +71,11 @@ func TestDoclingServeExtractor_Extract_ParsesJSONContent(t *testing.T) {
 }
 
 func TestDoclingServeExtractor_Extract_ErrorsOnNon200(t *testing.T) {
-	const secretMarker = "SECRET-LEAK-token-abc123"
+	// A neutral, non-credential-shaped sentinel so secret scanners don't flag
+	// this fixture; it still stands in for an untrusted, must-not-leak body.
+	const responseBodyMarker = "do-not-echo-this-response-body"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		http.Error(w, secretMarker, http.StatusInternalServerError)
+		http.Error(w, responseBodyMarker, http.StatusInternalServerError)
 	}))
 	defer srv.Close()
 
@@ -84,8 +86,32 @@ func TestDoclingServeExtractor_Extract_ErrorsOnNon200(t *testing.T) {
 	}
 	// The error is persisted as Document.ErrorMessage — it must not echo the
 	// (untrusted) response body.
-	if strings.Contains(err.Error(), secretMarker) {
+	if strings.Contains(err.Error(), responseBodyMarker) {
 		t.Errorf("error leaked response body: %v", err)
+	}
+}
+
+func TestDoclingServeExtractor_PreservesQueryWhenJoiningPath(t *testing.T) {
+	var gotPath, gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":"success","document":{"json_content":`+servedDoc+`}}`)
+	}))
+	defer srv.Close()
+
+	// A serve_url carrying a routing/auth query must still hit the convert path
+	// (not "?token=secret/v1/convert/file") and keep the query on the wire.
+	ext := ingest.NewDoclingServeExtractor(srv.URL + "/?token=secret")
+	if _, err := ext.Extract(context.Background(), "report.pdf", []byte("x")); err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if gotPath != "/v1/convert/file" {
+		t.Errorf("convert path = %q, want /v1/convert/file", gotPath)
+	}
+	if gotQuery != "token=secret" {
+		t.Errorf("query = %q, want token=secret preserved on the wire", gotQuery)
 	}
 }
 


### PR DESCRIPTION
## Summary

Implements **Feature B**: the `docling-serve` extraction transport specified in spec **0.10.0 §7.4.B** (merged in dirstral-spec#9). dir2mcp can now call a long-running [docling-serve](https://github.com/docling-project/docling-serve) HTTP container instead of spawning the docling CLI per document. Same engine, **byte-identical output** (structured `DoclingDocument` → Markdown + region citations) — only the transport differs.

This is the gated code half of the governance loop: it **re-pins the `dirstral-spec` submodule** to the merged 0.10.0 commit (`684316e`).

## Config

```yaml
ingest:
  extractor: docling-serve         # or: auto
  docling:
    serve_url: http://127.0.0.1:5001
```

Env: `DIR2MCP_DOCLING_SERVE_URL=http://127.0.0.1:5001`. Run the container yourself (e.g. `docker run --rm -p 5001:5001 ghcr.io/docling-project/docling-serve-cpu`) — lifecycle is user-managed; dir2mcp probes and fails fast.

## Behavior (matches the normative spec)

- `doclingServeExtractor` POSTs the file to `{serve_url}/v1/convert/file` with `to_formats=json`, then feeds `document.json_content` through the **existing** `docling.Parse` → linearize → render pipeline. It implements `ExtractStructured`, so it automatically gets the structured chunking + region-citation path (no special-casing).
- **No silent fallback**: explicit `extractor: docling-serve` requires a non-empty `serve_url`; empty ⇒ disabled (CONFIG_INVALID at startup). Under `auto`, docling-serve is used only when the docling CLI is not on `PATH`.
- `dir2mcp doctor` probes `{serve_url}/health` and reports an unreachable endpoint as a **warning** — an unreachable endpoint is a disabled extractor (§7.4.B/§7.7), not a hard failure.

## Tests

- Hermetic `httptest` coverage: convert happy path (asserts endpoint, `to_formats=json`, uploaded bytes, rendered Markdown), HTTP-error path, missing `json_content` path, `/health` probe (ok/unhealthy/empty), selection logic (explicit + auto), and config round-trip / validation / nested-key parsing.
- `make check` green; no integration gate needed (all stubbed).

## Notes

- Touches no §8 provider/capability matrix — extraction stays its own selection axis, exactly as the spec stipulates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added HTTP-based document extraction support via docling-serve endpoint configuration.
  * Auto mode now falls back to docling-serve when local extraction is unavailable.

* **Configuration**
  * Added `DIR2MCP_DOCLING_SERVE_URL` environment variable for docling-serve endpoint setup.
  * Endpoint reachability validation at startup.

* **Documentation**
  * Updated README with docling-serve configuration examples and availability rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->