### PR TITLE
docs: correct stale Mistral integration-test commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,15 +67,15 @@ Skipped by default. To run:
 ```bash
 RUN_INTEGRATION_TESTS=1 \
 MISTRAL_API_KEY=... \
-    go test -v ./internal/mistral -run Integration
+    go test -v ./tests/mistral -run Integration
 RUN_INTEGRATION_TESTS=1 \
 MISTRAL_API_KEY=... \
 MISTRAL_OCR_SAMPLE=/path/to/file.pdf \
-    go test -v ./tests -run MistralOCR
+    go test -v ./tests/mistral -run MistralOCR
 RUN_INTEGRATION_TESTS=1 \
 MISTRAL_API_KEY=... \
 MISTRAL_STT_SAMPLE=/path/to/file.mp3 \
-    go test -v ./tests -run MistralSTT
+    go test -v ./tests/mistral -run Transcribe_Integration_MistralAPI
 ```
 
 ## MCP dev servers (Codex)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,9 +33,9 @@ dir2mcp is a Go monorepo for deploying a directory as an MCP knowledge server. I
 Integration tests are skipped by default. To run them:
 
 ```bash
-RUN_INTEGRATION_TESTS=1 MISTRAL_API_KEY=... go test -v ./internal/mistral -run Integration
-RUN_INTEGRATION_TESTS=1 MISTRAL_API_KEY=... MISTRAL_OCR_SAMPLE=/path/to/file.pdf go test -v ./tests -run MistralOCR
-RUN_INTEGRATION_TESTS=1 MISTRAL_API_KEY=... MISTRAL_STT_SAMPLE=/path/to/file.mp3 go test -v ./tests -run MistralSTT
+RUN_INTEGRATION_TESTS=1 MISTRAL_API_KEY=... go test -v ./tests/mistral -run Integration
+RUN_INTEGRATION_TESTS=1 MISTRAL_API_KEY=... MISTRAL_OCR_SAMPLE=/path/to/file.pdf go test -v ./tests/mistral -run MistralOCR
+RUN_INTEGRATION_TESTS=1 MISTRAL_API_KEY=... MISTRAL_STT_SAMPLE=/path/to/file.mp3 go test -v ./tests/mistral -run Transcribe_Integration_MistralAPI
 ```
 
 ## MCP dev servers (Claude Code)


### PR DESCRIPTION
Follow-up consistency fix to #220.

## Problem
The Mistral integration-test commands in `CLAUDE.md` and `AGENTS.md` were stale on every line:

- `go test ./internal/mistral -run Integration` — those tests no longer live under `internal/mistral`; they are in `tests/mistral`.
- `go test ./tests -run MistralOCR` — the OCR test (`TestExtract_Integration_MistralOCR`) is in the `tests/mistral` subpackage, which `./tests` does not reach.
- `go test ./tests -run MistralSTT` — **no** test name contains `MistralSTT`; the STT test is `TestTranscribe_Integration_MistralAPI`.

## Fix
Point all three commands at `./tests/mistral` with `-run` patterns that match real test functions:

| Command | Resolves to |
|---|---|
| `-run Integration` | all four `*_Integration_*` tests |
| `-run MistralOCR` | `TestExtract_Integration_MistralOCR` |
| `-run Transcribe_Integration_MistralAPI` | the STT test |

This matches the path already corrected in `GEMINI.md` (#220), so all three agent docs are now consistent and truthful.

## Verification
Confirmed each `-run` pattern resolves with `go test -list` (no integration run / API key needed):
- `-run Integration` -> Embed, Transcribe, Generate, Extract (OCR)
- `-run MistralOCR` -> Extract (OCR)
- `-run Transcribe_Integration_MistralAPI` -> Transcribe

Docs-only; no code changes.