### PR TITLE
feat(gemini): native embedding parity (taskType + Matryoshka dims)

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ model:
     code_dim: 3072
 ```
 
-- **Asymmetric `task_type`** (better retrieval quality): the document/query role is mapped automatically — corpus content embeds as `RETRIEVAL_DOCUMENT`, search queries as `RETRIEVAL_QUERY`, and a query against the configured `code_model` as `CODE_RETRIEVAL_QUERY`. No configuration needed; the role is set by the call site.
+- **Asymmetric `taskType`** (better retrieval quality): the document/query role is mapped automatically — corpus content embeds as `RETRIEVAL_DOCUMENT`, search queries as `RETRIEVAL_QUERY`, and a query against the configured `code_model` as `CODE_RETRIEVAL_QUERY`. No configuration needed; the role is set by the call site.
 - **Matryoshka dimensions** (`text_dim`/`code_dim`): request a smaller vector to shrink the index. dir2mcp sends Gemini's `outputDimensionality` and L2-normalizes the truncated vectors. The knob is Gemini-only — setting it on a provider that can't honor it is rejected at startup (`CONFIG_INVALID`).
 - **Reindex-bound (spec §8.1.4/§8.1.6):** the embed provider, model, **and requested dimension** form the corpus-lifetime embed identity. Switching to Gemini, or changing the dimension later, requires a `dir2mcp reindex` (the server refuses to mix vector spaces and tells you to reindex).
 

--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ vary by deployment. The commonly used variables are:
 | `DIR2MCP_RERANK_MODEL` | No | Cohere rerank model override (default: `rerank-v3.5`) |
 | `ELEVENLABS_API_KEY` | No | ElevenLabs key for TTS/STT |
 | `ELEVENLABS_BASE_URL` | No | ElevenLabs base URL (default: `https://api.elevenlabs.io`) |
+| `GEMINI_API_KEY` | Optional | Google Gemini key; enables the `gemini` provider profile (embeddings, chat). Bind it explicitly to a capability (e.g. `model.embed.provider: gemini`) — auto-selection still prefers Mistral. Secret, never persisted |
 
 For Homebrew and other installed workflows, you can persist this in `.dir2mcp.yaml`:
 
@@ -268,6 +269,27 @@ Notes:
 - It is **best-effort, not a correctness guarantee**: a low-frequency safety rescan reconciles anything missed (kernel event coalescing, OS watch limits on very large trees), so the index converges even if individual events are dropped.
 - Excluded paths, `.gitignore` rules, and size/type limits apply to watched changes exactly as they do to the initial scan.
 - Env equivalents: `DIR2MCP_INGEST_WATCH=true`, `DIR2MCP_INGEST_WATCH_DEBOUNCE=500ms`.
+
+### Gemini embeddings (`gemini-embedding-001`)
+
+dir2mcp can use Google's [Gemini Embedding model](https://deepmind.google/models/gemini/embedding/) (`gemini-embedding-001`) at full parity via Gemini's **native** embed API. Set `GEMINI_API_KEY` and bind embeddings to the `gemini` provider (auto-selection still prefers Mistral, so the binding is explicit):
+
+```yaml
+model:
+  embed:                       # reindex-bound — see note below
+    provider: gemini
+    text_model: gemini-embedding-001
+    code_model: gemini-embedding-001
+    # Optional Matryoshka output dimensionality (native 3072; truncatable
+    # to 1536 / 768). Omit for the native dimension. Truncated vectors are
+    # re-normalized automatically.
+    text_dim: 3072
+    code_dim: 3072
+```
+
+- **Asymmetric `task_type`** (better retrieval quality): the document/query role is mapped automatically — corpus content embeds as `RETRIEVAL_DOCUMENT`, search queries as `RETRIEVAL_QUERY`, and a query against the configured `code_model` as `CODE_RETRIEVAL_QUERY`. No configuration needed; the role is set by the call site.
+- **Matryoshka dimensions** (`text_dim`/`code_dim`): request a smaller vector to shrink the index. dir2mcp sends Gemini's `outputDimensionality` and L2-normalizes the truncated vectors. The knob is Gemini-only — setting it on a provider that can't honor it is rejected at startup (`CONFIG_INVALID`).
+- **Reindex-bound (spec §8.1.4/§8.1.6):** the embed provider, model, **and requested dimension** form the corpus-lifetime embed identity. Switching to Gemini, or changing the dimension later, requires a `dir2mcp reindex` (the server refuses to mix vector spaces and tells you to reindex).
 
 ### Server identity
 

--- a/internal/config/providers.go
+++ b/internal/config/providers.go
@@ -24,6 +24,8 @@ type providerProfileYAML struct {
 	APIKey         *string `yaml:"api_key"` // pointer: distinguish "absent" (credential-less) from ""
 	EmbedTextModel string  `yaml:"embed_text_model"`
 	EmbedCodeModel string  `yaml:"embed_code_model"`
+	EmbedTextDim   int     `yaml:"embed_text_dim"`
+	EmbedCodeDim   int     `yaml:"embed_code_dim"`
 	ChatModel      string  `yaml:"chat_model"`
 	OCRModel       string  `yaml:"ocr_model"`
 	STTModel       string  `yaml:"stt_model"`
@@ -37,6 +39,8 @@ type capBindingYAML struct {
 	Provider  string `yaml:"provider"`
 	TextModel string `yaml:"text_model"`
 	CodeModel string `yaml:"code_model"`
+	TextDim   int    `yaml:"text_dim"`
+	CodeDim   int    `yaml:"code_dim"`
 	Model     string `yaml:"model"`
 }
 
@@ -62,10 +66,11 @@ func builtinProfiles() map[string]providerProfileYAML {
 		"openai":      {Kind: "openai", APIKey: s("${OPENAI_API_KEY}")},
 		"openrouter":  {Kind: "openai", BaseURL: "https://openrouter.ai/api/v1", APIKey: s("${OPENROUTER_API_KEY}")},
 		"anthropic":   {Kind: "anthropic", APIKey: s("${ANTHROPIC_API_KEY}")},
-		"gemini":      {Kind: "gemini", APIKey: s("${GEMINI_API_KEY}")},
-		"cohere":      {Kind: "cohere", APIKey: s("${COHERE_API_KEY}")},
-		"elevenlabs":  {Kind: "elevenlabs", APIKey: s("${ELEVENLABS_API_KEY}")},
-		"local":       {Kind: "openai", BaseURL: "http://localhost:11434/v1"}, // credential-less
+		"gemini": {Kind: "gemini", APIKey: s("${GEMINI_API_KEY}"),
+			EmbedTextModel: "gemini-embedding-001", EmbedCodeModel: "gemini-embedding-001", ChatModel: "gemini-2.5-flash"},
+		"cohere":     {Kind: "cohere", APIKey: s("${COHERE_API_KEY}")},
+		"elevenlabs": {Kind: "elevenlabs", APIKey: s("${ELEVENLABS_API_KEY}")},
+		"local":      {Kind: "openai", BaseURL: "http://localhost:11434/v1"}, // credential-less
 	}
 }
 
@@ -207,6 +212,8 @@ func toProfiles(merged map[string]providerProfileYAML, getenv func(string) strin
 			CredentialLess: credLess,
 			EmbedTextModel: p.EmbedTextModel,
 			EmbedCodeModel: p.EmbedCodeModel,
+			EmbedTextDim:   p.EmbedTextDim,
+			EmbedCodeDim:   p.EmbedCodeDim,
 			ChatModel:      p.ChatModel,
 			OCRModel:       p.OCRModel,
 			STTModel:       p.STTModel,
@@ -282,6 +289,12 @@ func (r ProviderResolution) applyModelOverrides(cap provider.Capability, p provi
 	case provider.CapEmbed:
 		set(&p.EmbedTextModel, r.doc.Model.Embed.TextModel)
 		set(&p.EmbedCodeModel, r.doc.Model.Embed.CodeModel)
+		if r.doc.Model.Embed.TextDim > 0 {
+			p.EmbedTextDim = r.doc.Model.Embed.TextDim
+		}
+		if r.doc.Model.Embed.CodeDim > 0 {
+			p.EmbedCodeDim = r.doc.Model.Embed.CodeDim
+		}
 	case provider.CapChat:
 		set(&p.ChatModel, r.doc.Model.Chat.Model)
 	case provider.CapOCR:

--- a/internal/gemini/client.go
+++ b/internal/gemini/client.go
@@ -1,19 +1,19 @@
-// Package gemini provides a direct-HTTP adapter for Google Gemini via its
-// OpenAI-compatible API surface (POST {base}/embeddings, POST
-// {base}/chat/completions). Per SPEC 8.1.2 a `gemini` profile may serve
-// embed ✅ chat ✅ stt ✅ tts ✅; this adapter implements the embed + chat
-// capabilities (model.Embedder / model.Generator) by reusing the same
-// OpenAI-compatible wire shape as internal/mistral, selected purely by
-// the Gemini base URL + Gemini model names.
+// Package gemini provides a direct-HTTP adapter for Google Gemini. Chat
+// (model.Generator) and STT use Gemini's OpenAI-compatible surface (POST
+// {base}/chat/completions); embeddings (model.Embedder) use Gemini's
+// NATIVE surface (POST {base-without-/openai}/models/{model}:batchEmbedContents)
+// because only the native API supports `taskType` (asymmetric embeddings,
+// SPEC 8.1.5) and `outputDimensionality` (Matryoshka/MRL, SPEC 8.1.6) —
+// the OpenAI-compatible /embeddings shim exposes neither.
 //
 // It mirrors internal/mistral and internal/cohere (BaseURL/APIKey/
 // HTTPClient, bounded exponential retry, typed model.ProviderError) so
 // callers can depend on model.Embedder / model.Generator without taking
 // a hard dependency on this package.
 //
-// Gemini embeddings are symmetric, so the model.EmbedRole is accepted
-// and intentionally ignored (SPEC 8.1.5) — observable behavior MUST NOT
-// differ by role for this provider.
+// Gemini embeddings are ASYMMETRIC (SPEC 8.1.5): the model.EmbedRole is
+// mapped onto `taskType` (RETRIEVAL_DOCUMENT / RETRIEVAL_QUERY, and
+// CODE_RETRIEVAL_QUERY for a query against the configured code model).
 //
 // TODO(spec 8.1.2): native Gemini STT/TTS. The capability matrix marks
 // `gemini` as stt ✅ tts ✅, but this adapter implements embed + chat
@@ -28,6 +28,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"mime/multipart"
 	"net/http"
 	"path/filepath"
@@ -38,9 +39,13 @@ import (
 )
 
 const (
-	// defaultBaseURL is Gemini's OpenAI-compatible endpoint. The adapter
-	// appends /embeddings and /chat/completions to this base.
-	defaultBaseURL           = "https://generativelanguage.googleapis.com/v1beta/openai"
+	// defaultBaseURL is Gemini's OpenAI-compatible endpoint (chat/STT).
+	// The adapter appends /chat/completions to this base.
+	defaultBaseURL = "https://generativelanguage.googleapis.com/v1beta/openai"
+	// geminiNativeBaseURL is the native API base used for embeddings
+	// (models/{model}:batchEmbedContents) — the OpenAI-compat base minus
+	// the trailing /openai. Used when BaseURL is the default/empty.
+	geminiNativeBaseURL      = "https://generativelanguage.googleapis.com/v1beta"
 	defaultRequestTimeout    = 30 * time.Second
 	defaultGenerationTimeout = 120 * time.Second
 	defaultMaxRetries        = 3
@@ -51,7 +56,7 @@ const (
 	// DefaultEmbedModel / DefaultChatModel are fallbacks used only when
 	// the caller passes an empty model name. The config resolver
 	// normally supplies explicit models per profile.
-	DefaultEmbedModel = "text-embedding-004"
+	DefaultEmbedModel = "gemini-embedding-001"
 	DefaultChatModel  = "gemini-2.5-flash"
 	DefaultSTTModel   = "gemini-2.5-flash"
 	DefaultTTSModel   = "gemini-2.5-flash-preview-tts"
@@ -77,10 +82,19 @@ type Client struct {
 	// DefaultEmbedModel/DefaultChatModel are used when the corresponding
 	// call is made with an empty model name.
 	DefaultEmbedModel string
-	DefaultChatModel  string
-	DefaultSTTModel   string
-	DefaultTTSModel   string
-	DefaultTTSVoice   string
+	// CodeEmbedModel is the resolved code-embedding model name; a query
+	// against it selects Gemini's CODE_RETRIEVAL_QUERY task type (SPEC
+	// 8.1.5). Empty disables the code-aware refinement.
+	CodeEmbedModel string
+	// EmbedTextDim / EmbedCodeDim request a specific output dimensionality
+	// (Matryoshka/MRL, SPEC 8.1.6); zero means the model's native size.
+	// When set, returned vectors are L2-normalized.
+	EmbedTextDim     int
+	EmbedCodeDim     int
+	DefaultChatModel string
+	DefaultSTTModel  string
+	DefaultTTSModel  string
+	DefaultTTSVoice  string
 }
 
 // compile-time assertions that *Client implements the model contracts.
@@ -115,23 +129,42 @@ func NewClient(baseURL, apiKey string) *Client {
 	}
 }
 
-type embedRequest struct {
-	Model string   `json:"model"`
-	Input []string `json:"input"`
+// Native batchEmbedContents request/response shapes. The native API
+// (unlike the OpenAI-compatible /embeddings shim) carries taskType and
+// outputDimensionality, and returns embeddings in request order.
+type geminiEmbedContentPart struct {
+	Text string `json:"text"`
 }
 
-type embedResponse struct {
-	Data []struct {
-		Index     int       `json:"index"`
-		Embedding []float64 `json:"embedding"`
-	} `json:"data"`
+type geminiEmbedContent struct {
+	Parts []geminiEmbedContentPart `json:"parts"`
 }
 
-// Embed implements model.Embedder. Gemini embeddings are symmetric, so
-// the input role is accepted and ignored (SPEC 8.1.5). Inputs are sent
-// in BatchSize-sized batches; each batch is retried with bounded
-// exponential backoff, and vectors are reordered to match input order.
-func (c *Client) Embed(ctx context.Context, modelName string, _ model.EmbedRole, inputs []string) ([][]float32, error) {
+type geminiEmbedSingleRequest struct {
+	Model                string             `json:"model"`
+	Content              geminiEmbedContent `json:"content"`
+	TaskType             string             `json:"taskType,omitempty"`
+	OutputDimensionality *int               `json:"outputDimensionality,omitempty"`
+}
+
+type geminiBatchEmbedRequest struct {
+	Requests []geminiEmbedSingleRequest `json:"requests"`
+}
+
+type geminiBatchEmbedResponse struct {
+	Embeddings []struct {
+		Values []float64 `json:"values"`
+	} `json:"embeddings"`
+}
+
+// Embed implements model.Embedder via Gemini's native embed surface
+// (models/{model}:batchEmbedContents). The input role maps onto taskType
+// (SPEC 8.1.5); a query against the configured code model uses
+// CODE_RETRIEVAL_QUERY. When a non-native output dimension is requested
+// (SPEC 8.1.6) the returned vectors are L2-normalized. Inputs are sent in
+// BatchSize-sized batches, each retried with bounded exponential backoff;
+// the native batch response preserves request order.
+func (c *Client) Embed(ctx context.Context, modelName string, role model.EmbedRole, inputs []string) ([][]float32, error) {
 	if strings.TrimSpace(c.APIKey) == "" {
 		return nil, &model.ProviderError{Code: "GEMINI_AUTH", Message: "missing Gemini API key", Retryable: false}
 	}
@@ -146,6 +179,13 @@ func (c *Client) Embed(ctx context.Context, modelName string, _ model.EmbedRole,
 		return [][]float32{}, nil
 	}
 
+	isCode := c.CodeEmbedModel != "" && modelName == strings.TrimSpace(c.CodeEmbedModel)
+	taskType := geminiTaskType(role, isCode)
+	dim := c.EmbedTextDim
+	if isCode {
+		dim = c.EmbedCodeDim
+	}
+
 	batchSize := c.BatchSize
 	if batchSize <= 0 {
 		batchSize = defaultBatchSize
@@ -157,7 +197,7 @@ func (c *Client) Embed(ctx context.Context, modelName string, _ model.EmbedRole,
 		if end > len(inputs) {
 			end = len(inputs)
 		}
-		vectors, err := c.embedBatchWithRetry(ctx, modelName, inputs[start:end])
+		vectors, err := c.embedBatchWithRetry(ctx, modelName, taskType, dim, inputs[start:end])
 		if err != nil {
 			return nil, err
 		}
@@ -166,7 +206,20 @@ func (c *Client) Embed(ctx context.Context, modelName string, _ model.EmbedRole,
 	return out, nil
 }
 
-func (c *Client) embedBatchWithRetry(ctx context.Context, modelName string, inputs []string) ([][]float32, error) {
+// geminiTaskType maps the SPEC 8.1.5 input role onto Gemini's taskType.
+// Documents always embed as RETRIEVAL_DOCUMENT; a query embeds as
+// RETRIEVAL_QUERY, or CODE_RETRIEVAL_QUERY when it targets the code model.
+func geminiTaskType(role model.EmbedRole, isCode bool) string {
+	if role == model.EmbedQuery {
+		if isCode {
+			return "CODE_RETRIEVAL_QUERY"
+		}
+		return "RETRIEVAL_QUERY"
+	}
+	return "RETRIEVAL_DOCUMENT"
+}
+
+func (c *Client) embedBatchWithRetry(ctx context.Context, modelName, taskType string, dim int, inputs []string) ([][]float32, error) {
 	maxRetries := c.MaxRetries
 	if maxRetries < 0 {
 		maxRetries = 0
@@ -178,7 +231,7 @@ func (c *Client) embedBatchWithRetry(ctx context.Context, modelName string, inpu
 				return nil, err
 			}
 		}
-		vectors, err := c.embedBatch(ctx, modelName, inputs)
+		vectors, err := c.embedBatchNative(ctx, modelName, taskType, dim, inputs)
 		if err == nil {
 			return vectors, nil
 		}
@@ -191,12 +244,27 @@ func (c *Client) embedBatchWithRetry(ctx context.Context, modelName string, inpu
 	return nil, lastErr
 }
 
-func (c *Client) embedBatch(ctx context.Context, modelName string, inputs []string) ([][]float32, error) {
-	body, err := json.Marshal(embedRequest{Model: modelName, Input: inputs})
+func (c *Client) embedBatchNative(ctx context.Context, modelName, taskType string, dim int, inputs []string) ([][]float32, error) {
+	qualified := "models/" + modelName
+	reqs := make([]geminiEmbedSingleRequest, len(inputs))
+	for i, in := range inputs {
+		r := geminiEmbedSingleRequest{
+			Model:    qualified,
+			Content:  geminiEmbedContent{Parts: []geminiEmbedContentPart{{Text: in}}},
+			TaskType: taskType,
+		}
+		if dim > 0 {
+			d := dim
+			r.OutputDimensionality = &d
+		}
+		reqs[i] = r
+	}
+	body, err := json.Marshal(geminiBatchEmbedRequest{Requests: reqs})
 	if err != nil {
 		return nil, &model.ProviderError{Code: "GEMINI_FAILED", Message: "failed to marshal embedding request", Retryable: false, Cause: err}
 	}
-	resp, err := c.doJSON(ctx, "/embeddings", body, defaultRequestTimeout)
+
+	resp, err := c.doNativeJSON(ctx, "/"+qualified+":batchEmbedContents", body, defaultRequestTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -205,36 +273,76 @@ func (c *Client) embedBatch(ctx context.Context, modelName string, inputs []stri
 		return nil, httpError(resp)
 	}
 
-	var parsed embedResponse
+	var parsed geminiBatchEmbedResponse
 	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
 		return nil, &model.ProviderError{Code: "GEMINI_FAILED", Message: "failed to decode embedding response", Retryable: false, StatusCode: resp.StatusCode, Cause: err}
 	}
-	if len(parsed.Data) != len(inputs) {
-		return nil, &model.ProviderError{Code: "GEMINI_FAILED", Message: fmt.Sprintf("embedding response size mismatch: got %d vectors for %d inputs", len(parsed.Data), len(inputs)), Retryable: false, StatusCode: resp.StatusCode}
+	if len(parsed.Embeddings) != len(inputs) {
+		return nil, &model.ProviderError{Code: "GEMINI_FAILED", Message: fmt.Sprintf("embedding response size mismatch: got %d vectors for %d inputs", len(parsed.Embeddings), len(inputs)), Retryable: false, StatusCode: resp.StatusCode}
 	}
 
 	vectors := make([][]float32, len(inputs))
-	seen := make([]bool, len(inputs))
-	for _, item := range parsed.Data {
-		if item.Index < 0 || item.Index >= len(inputs) {
-			return nil, &model.ProviderError{Code: "GEMINI_FAILED", Message: fmt.Sprintf("embedding response contains out-of-range index %d", item.Index), Retryable: false, StatusCode: resp.StatusCode}
+	for i, e := range parsed.Embeddings {
+		vec := make([]float32, len(e.Values))
+		for j, v := range e.Values {
+			vec[j] = float32(v)
 		}
-		if seen[item.Index] {
-			return nil, &model.ProviderError{Code: "GEMINI_FAILED", Message: fmt.Sprintf("embedding response contains duplicate index %d", item.Index), Retryable: false, StatusCode: resp.StatusCode}
+		if dim > 0 {
+			l2Normalize(vec)
 		}
-		vec := make([]float32, len(item.Embedding))
-		for i, v := range item.Embedding {
-			vec[i] = float32(v)
-		}
-		vectors[item.Index] = vec
-		seen[item.Index] = true
-	}
-	for i := range seen {
-		if !seen[i] {
-			return nil, &model.ProviderError{Code: "GEMINI_FAILED", Message: fmt.Sprintf("embedding response missing index %d", i), Retryable: false, StatusCode: resp.StatusCode}
-		}
+		vectors[i] = vec
 	}
 	return vectors, nil
+}
+
+// nativeBaseURL derives Gemini's native API base from the configured
+// (OpenAI-compatible) base by dropping a trailing "/openai" segment, so
+// embeddings reach models/{model}:batchEmbedContents while chat keeps
+// using the OpenAI-compatible base.
+func (c *Client) nativeBaseURL() string {
+	b := strings.TrimRight(c.BaseURL, "/")
+	if trimmed := strings.TrimSuffix(b, "/openai"); trimmed != b {
+		return trimmed
+	}
+	if b == "" {
+		return geminiNativeBaseURL
+	}
+	return b
+}
+
+// doNativeJSON POSTs to Gemini's native API, authenticating with the
+// x-goog-api-key header so the key never lands in a URL/query string.
+func (c *Client) doNativeJSON(ctx context.Context, path string, body []byte, timeout time.Duration) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.nativeBaseURL()+path, bytes.NewReader(body))
+	if err != nil {
+		return nil, &model.ProviderError{Code: "GEMINI_FAILED", Message: "failed to build request", Retryable: false, Cause: err}
+	}
+	req.Header.Set("x-goog-api-key", c.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err := clientWithTimeout(c.HTTPClient, timeout).Do(req)
+	if err != nil {
+		return nil, &model.ProviderError{Code: "GEMINI_FAILED", Message: "request failed", Retryable: true, Cause: err}
+	}
+	return resp, nil
+}
+
+// l2Normalize scales v to unit L2 length in place. MRL-truncated Gemini
+// vectors (outputDimensionality below the native size) are not
+// pre-normalized, and the index's cosine/IP scoring assumes unit vectors
+// (SPEC 8.1.6). A zero vector is left unchanged.
+func l2Normalize(v []float32) {
+	var sum float64
+	for _, x := range v {
+		sum += float64(x) * float64(x)
+	}
+	if sum == 0 {
+		return
+	}
+	inv := float32(1.0 / math.Sqrt(sum))
+	for i := range v {
+		v[i] *= inv
+	}
 }
 
 type generateMessage struct {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -100,13 +100,19 @@ type Profile struct {
 
 	EmbedTextModel string
 	EmbedCodeModel string
-	ChatModel      string
-	OCRModel       string
-	STTModel       string
-	STTLanguage    string // optional STT language hint (e.g. ElevenLabs)
-	TTSModel       string
-	TTSVoice       string // TTS voice id/name (e.g. ElevenLabs voice, OpenAI voice)
-	RerankModel    string
+	// EmbedTextDim / EmbedCodeDim request a specific embedding output
+	// dimensionality for Matryoshka/MRL models (SPEC 8.1.6), per axis.
+	// Zero means "the model's native dimension". Part of the embed
+	// identity (SPEC 8.1.4), so a change is reindex-bound.
+	EmbedTextDim int
+	EmbedCodeDim int
+	ChatModel    string
+	OCRModel     string
+	STTModel     string
+	STTLanguage  string // optional STT language hint (e.g. ElevenLabs)
+	TTSModel     string
+	TTSVoice     string // TTS voice id/name (e.g. ElevenLabs voice, OpenAI voice)
+	RerankModel  string
 }
 
 // Eligible reports whether the profile may be selected/preflighted
@@ -175,14 +181,17 @@ func Select(precedence []Profile, byName map[string]Profile, cap Capability, exp
 }
 
 // EmbedIdentity is the corpus-lifetime embed identity (SPEC 8.1.4):
-// provider name + text/code model. It is recorded in the config
-// snapshot/index and compared on load. Role (8.1.5) is deliberately
-// excluded — it does not affect vector-space compatibility.
+// provider name + text/code model + requested text/code output dimension
+// (8.1.6). It is recorded in the config snapshot/index and compared on
+// load. Role (8.1.5) is deliberately excluded — it does not affect
+// vector-space compatibility, but the requested dimension does.
 func EmbedIdentity(p Profile) string {
-	return fmt.Sprintf("%s|%s|%s",
+	return fmt.Sprintf("%s|%s|%s|%d|%d",
 		strings.TrimSpace(p.Name),
 		strings.TrimSpace(p.EmbedTextModel),
-		strings.TrimSpace(p.EmbedCodeModel))
+		strings.TrimSpace(p.EmbedCodeModel),
+		p.EmbedTextDim,
+		p.EmbedCodeDim)
 }
 
 // VerifyEmbedIdentity returns a *ConfigError when a recorded embed

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -197,17 +197,36 @@ func EmbedIdentity(p Profile) string {
 // VerifyEmbedIdentity returns a *ConfigError when a recorded embed
 // identity differs from the current one (SPEC 8.1.4 — the server MUST
 // NOT silently mix vector spaces). An empty recorded identity (fresh
-// index) always passes.
+// index) always passes. A legacy 3-field identity (pre-8.1.6, no
+// dimension) is normalized to the native "|0|0" form before comparison so
+// upgrading an existing native-dimension corpus does not force a spurious
+// reindex.
 func VerifyEmbedIdentity(recorded, current string) error {
-	recorded = strings.TrimSpace(recorded)
-	if recorded == "" || recorded == strings.TrimSpace(current) {
+	recorded = normalizeEmbedIdentity(strings.TrimSpace(recorded))
+	current = strings.TrimSpace(current)
+	if recorded == "" || recorded == current {
 		return nil
 	}
 	return &ConfigError{
 		Capability: CapEmbed,
 		Profile:    current,
 		Reason: fmt.Sprintf(
-			"embed identity changed (index built with %q, configured %q); embeddings are corpus-lifetime — reindex to change the embed provider/model",
+			"embed identity changed (index built with %q, configured %q); embeddings are corpus-lifetime — reindex to change the embed provider/model/dimension",
 			recorded, current),
 	}
+}
+
+// normalizeEmbedIdentity upgrades a legacy 3-field identity
+// (provider|text_model|code_model) to the current 5-field form by
+// appending the native "|0|0" dimension pair, so a corpus indexed before
+// 8.1.6 with native dimensions still matches after an upgrade. Non-legacy
+// (empty or already 5-field) values are returned unchanged.
+func normalizeEmbedIdentity(id string) string {
+	if id == "" {
+		return ""
+	}
+	if strings.Count(id, "|") == 2 {
+		return id + "|0|0"
+	}
+	return id
 }

--- a/internal/providerfactory/factory.go
+++ b/internal/providerfactory/factory.go
@@ -34,12 +34,30 @@ func unsupported(p provider.Profile, cap provider.Capability) error {
 	return fmt.Errorf("provider kind %q cannot serve %s", p.Kind, cap)
 }
 
+// rejectEmbedDim fails when a fixed output dimension is requested for a
+// provider kind that cannot honor it (SPEC 8.1.6: unsupported dimensions
+// are CONFIG_INVALID, never silently ignored). Only Gemini supports the
+// knob today.
+func rejectEmbedDim(p provider.Profile) error {
+	if p.EmbedTextDim > 0 || p.EmbedCodeDim > 0 {
+		return fmt.Errorf("CONFIG_INVALID: embed provider kind %q does not support a fixed output dimension (embed.text_dim/code_dim); remove it or use a Matryoshka-capable provider (gemini)", p.Kind)
+	}
+	return nil
+}
+
 // Embedder builds a model.Embedder for the profile (kinds: openai,
 // mistral, cohere, gemini). The per-call model still comes from the
 // caller; Default*Model is only a fallback for empty model names.
+//
+// The embedding output-dimension knob (EmbedTextDim/EmbedCodeDim, SPEC
+// 8.1.6) is only honored by Gemini today; requesting it on any other
+// kind is rejected as CONFIG_INVALID rather than silently ignored.
 func Embedder(p provider.Profile) (model.Embedder, error) {
 	switch p.Kind {
 	case provider.KindOpenAI:
+		if err := rejectEmbedDim(p); err != nil {
+			return nil, err
+		}
 		c := openai.NewClient(p.BaseURL, p.APIKey)
 		if p.EmbedTextModel != "" {
 			c.DefaultEmbedModel = p.EmbedTextModel
@@ -50,8 +68,14 @@ func Embedder(p provider.Profile) (model.Embedder, error) {
 		if p.EmbedTextModel != "" {
 			c.DefaultEmbedModel = p.EmbedTextModel
 		}
+		c.CodeEmbedModel = p.EmbedCodeModel
+		c.EmbedTextDim = p.EmbedTextDim
+		c.EmbedCodeDim = p.EmbedCodeDim
 		return c, nil
 	case provider.KindCohere:
+		if err := rejectEmbedDim(p); err != nil {
+			return nil, err
+		}
 		c := cohere.NewClient(p.BaseURL, p.APIKey)
 		if p.EmbedTextModel != "" {
 			c.DefaultEmbedModel = p.EmbedTextModel

--- a/internal/providerfactory/factory.go
+++ b/internal/providerfactory/factory.go
@@ -34,12 +34,17 @@ func unsupported(p provider.Profile, cap provider.Capability) error {
 	return fmt.Errorf("provider kind %q cannot serve %s", p.Kind, cap)
 }
 
-// rejectEmbedDim fails when a fixed output dimension is requested for a
-// provider kind that cannot honor it (SPEC 8.1.6: unsupported dimensions
-// are CONFIG_INVALID, never silently ignored). Only Gemini supports the
-// knob today.
-func rejectEmbedDim(p provider.Profile) error {
-	if p.EmbedTextDim > 0 || p.EmbedCodeDim > 0 {
+// validateEmbedDim enforces SPEC 8.1.6 on the requested output dimension.
+// A negative dimension is always CONFIG_INVALID (it would otherwise form a
+// distinct embed identity yet behave like "unset" at runtime, where checks
+// use > 0). A positive (fixed) dimension is only honored by
+// Matryoshka-capable kinds (Gemini today); requesting it on any other kind
+// is CONFIG_INVALID rather than silently ignored.
+func validateEmbedDim(p provider.Profile) error {
+	if p.EmbedTextDim < 0 || p.EmbedCodeDim < 0 {
+		return fmt.Errorf("CONFIG_INVALID: embed.text_dim/code_dim must be non-negative (got text=%d code=%d)", p.EmbedTextDim, p.EmbedCodeDim)
+	}
+	if p.Kind != provider.KindGemini && (p.EmbedTextDim > 0 || p.EmbedCodeDim > 0) {
 		return fmt.Errorf("CONFIG_INVALID: embed provider kind %q does not support a fixed output dimension (embed.text_dim/code_dim); remove it or use a Matryoshka-capable provider (gemini)", p.Kind)
 	}
 	return nil
@@ -53,11 +58,13 @@ func rejectEmbedDim(p provider.Profile) error {
 // 8.1.6) is only honored by Gemini today; requesting it on any other
 // kind is rejected as CONFIG_INVALID rather than silently ignored.
 func Embedder(p provider.Profile) (model.Embedder, error) {
+	// SPEC 8.1.6 dimension validation applies to every kind (negative is
+	// always invalid; a fixed positive dim is Gemini-only).
+	if err := validateEmbedDim(p); err != nil {
+		return nil, err
+	}
 	switch p.Kind {
 	case provider.KindOpenAI:
-		if err := rejectEmbedDim(p); err != nil {
-			return nil, err
-		}
 		c := openai.NewClient(p.BaseURL, p.APIKey)
 		if p.EmbedTextModel != "" {
 			c.DefaultEmbedModel = p.EmbedTextModel
@@ -73,9 +80,6 @@ func Embedder(p provider.Profile) (model.Embedder, error) {
 		c.EmbedCodeDim = p.EmbedCodeDim
 		return c, nil
 	case provider.KindCohere:
-		if err := rejectEmbedDim(p); err != nil {
-			return nil, err
-		}
 		c := cohere.NewClient(p.BaseURL, p.APIKey)
 		if p.EmbedTextModel != "" {
 			c.DefaultEmbedModel = p.EmbedTextModel

--- a/tests/config/providers_config_test.go
+++ b/tests/config/providers_config_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/dirstral/dir2mcp/internal/config"
@@ -124,8 +125,38 @@ func TestProviders_UserOverrideAndCustomProfile(t *testing.T) {
 func TestProviders_EmbedIdentityStable(t *testing.T) {
 	t.Setenv("MISTRAL_API_KEY", "mk")
 	id := loadCfg(t, "version: 1\n").Providers().EmbedIdentity()
-	if id != "mistral|mistral-embed|codestral-embed" {
+	// provider|text_model|code_model|text_dim|code_dim (SPEC 8.1.4/8.1.6);
+	// default Mistral has no requested dims (native).
+	if id != "mistral|mistral-embed|codestral-embed|0|0" {
 		t.Fatalf("embed identity = %q", id)
+	}
+}
+
+// TestProviders_EmbedDimensionKnob pins SPEC 8.1.6: model.embed.text_dim/
+// code_dim parse, resolve onto the embed profile, and enter the embed
+// identity (so a dimension change is reindex-bound).
+func TestProviders_EmbedDimensionKnob(t *testing.T) {
+	t.Setenv("GEMINI_API_KEY", "gk")
+	yaml := "version: 1\n" +
+		"model:\n" +
+		"  embed:\n" +
+		"    provider: gemini\n" +
+		"    text_dim: 1536\n" +
+		"    code_dim: 768\n"
+	r := loadCfg(t, yaml).Providers()
+	p, err := r.Resolve(provider.CapEmbed)
+	if err != nil {
+		t.Fatalf("resolve embed: %v", err)
+	}
+	if p.Name != "gemini" {
+		t.Fatalf("embed provider = %q, want gemini", p.Name)
+	}
+	if p.EmbedTextDim != 1536 || p.EmbedCodeDim != 768 {
+		t.Fatalf("dims = text:%d code:%d, want 1536/768", p.EmbedTextDim, p.EmbedCodeDim)
+	}
+	id := r.EmbedIdentity()
+	if !strings.HasSuffix(id, "|1536|768") {
+		t.Fatalf("embed identity %q must encode requested dims", id)
 	}
 }
 

--- a/tests/gemini/client_test.go
+++ b/tests/gemini/client_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -23,49 +22,71 @@ func newClient(url string) *gemini.Client {
 	return c
 }
 
-// embedResp echoes one item per input, embedding[0] = first byte of the
-// input string, returned in REVERSED order to exercise index reordering.
-func embedResp(inputs []string) map[string]any {
-	n := len(inputs)
-	data := make([]map[string]any, n)
-	for i := 0; i < n; i++ {
-		p := n - 1 - i
-		data[i] = map[string]any{"index": p, "embedding": []float64{float64(inputs[p][0]), 0.5}}
+// nativeEmbedReq is the native batchEmbedContents request body shape.
+type nativeEmbedReq struct {
+	Requests []struct {
+		Model   string `json:"model"`
+		Content struct {
+			Parts []struct {
+				Text string `json:"text"`
+			} `json:"parts"`
+		} `json:"content"`
+		TaskType             string `json:"taskType"`
+		OutputDimensionality *int   `json:"outputDimensionality"`
+	} `json:"requests"`
+}
+
+func decodeNativeEmbed(t *testing.T, r *http.Request) nativeEmbedReq {
+	t.Helper()
+	var req nativeEmbedReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		t.Fatalf("decode native embed request: %v", err)
 	}
-	return map[string]any{"data": data}
+	return req
+}
+
+// embedRespFor returns the native batchEmbedContents response: one
+// embedding per request, IN REQUEST ORDER (the native batch API preserves
+// order), with values[0] = first byte of the request's text so order
+// preservation across batches is verifiable.
+func embedRespFor(req nativeEmbedReq) map[string]any {
+	embs := make([]map[string]any, len(req.Requests))
+	for i, r := range req.Requests {
+		first := 0.0
+		if len(r.Content.Parts) > 0 && r.Content.Parts[0].Text != "" {
+			first = float64(r.Content.Parts[0].Text[0])
+		}
+		embs[i] = map[string]any{"values": []float64{first, 0.5}}
+	}
+	return map[string]any{"embeddings": embs}
 }
 
 func TestEmbed_BatchesPreservesOrderAndRetries(t *testing.T) {
 	var calls int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// The adapter appends "/embeddings" to the configured BaseURL;
-		// any version segment is part of the operator's BaseURL, not
-		// added here. This test's base has none, so the path is exactly
-		// "/embeddings" (versioned base covered by
-		// TestEndpointPathJoinPreservesVersion).
-		if r.URL.Path != "/embeddings" {
-			t.Errorf("path = %s", r.URL.Path)
+		// Embeddings use the native surface: base (no /openai here) +
+		// /models/{model}:batchEmbedContents, authenticated with the
+		// x-goog-api-key header (versioned base covered by
+		// TestEmbed_NativeEndpointPath).
+		if want := "/models/gemini-embedding-001:batchEmbedContents"; r.URL.Path != want {
+			t.Errorf("path = %s, want %s", r.URL.Path, want)
 		}
-		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
-			t.Errorf("auth = %q", got)
+		if got := r.Header.Get("x-goog-api-key"); got != "test-key" {
+			t.Errorf("api key header = %q", got)
 		}
 		n := atomic.AddInt32(&calls, 1)
 		if n == 1 { // first batch: one transient 429 then success
 			w.WriteHeader(http.StatusTooManyRequests)
 			return
 		}
-		var req struct {
-			Input []string `json:"input"`
-		}
-		_ = json.NewDecoder(r.Body).Decode(&req)
-		_ = json.NewEncoder(w).Encode(embedResp(req.Input))
+		_ = json.NewEncoder(w).Encode(embedRespFor(decodeNativeEmbed(t, r)))
 	}))
 	defer srv.Close()
 
 	c := newClient(srv.URL)
 	c.BatchSize = 2 // forces 2 batches for 3 inputs (a,b) then (c)
 	in := []string{"a", "b", "c"}
-	vecs, err := c.Embed(context.Background(), "text-embedding-004", model.EmbedDocument, in)
+	vecs, err := c.Embed(context.Background(), "gemini-embedding-001", model.EmbedDocument, in)
 	if err != nil {
 		t.Fatalf("embed: %v", err)
 	}
@@ -73,7 +94,7 @@ func TestEmbed_BatchesPreservesOrderAndRetries(t *testing.T) {
 		t.Fatalf("got %d vectors, want 3", len(vecs))
 	}
 	// Each output vector must correspond to its input across batch
-	// boundaries (embedding[0] == first byte of the input string).
+	// boundaries (values[0] == first byte of the input string).
 	for i, s := range in {
 		if vecs[i][0] != float32(s[0]) {
 			t.Fatalf("order not preserved at %d: got %v, want first-byte of %q", i, vecs[i], s)
@@ -84,17 +105,16 @@ func TestEmbed_BatchesPreservesOrderAndRetries(t *testing.T) {
 	}
 }
 
-// TestEndpointPathJoinPreservesVersion verifies the adapter appends the
-// endpoint to a BaseURL that already carries a version segment, so an
-// operator-configured ".../v1beta/openai" yields
-// ".../v1beta/openai/embeddings".
-func TestEndpointPathJoinPreservesVersion(t *testing.T) {
+// TestEmbed_NativeEndpointPath verifies that embeddings target the native
+// surface: the configured OpenAI-compatible base (".../v1beta/openai") has
+// its trailing "/openai" dropped, then "/models/{model}:batchEmbedContents"
+// is appended — so an operator base of ".../v1beta/openai" yields
+// ".../v1beta/models/m:batchEmbedContents".
+func TestEmbed_NativeEndpointPath(t *testing.T) {
 	var gotPath string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Path
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"data": []map[string]any{{"index": 0, "embedding": []float64{1}}},
-		})
+		_ = json.NewEncoder(w).Encode(embedRespFor(decodeNativeEmbed(t, r)))
 	}))
 	defer srv.Close()
 
@@ -102,8 +122,8 @@ func TestEndpointPathJoinPreservesVersion(t *testing.T) {
 	if _, err := c.Embed(context.Background(), "m", model.EmbedDocument, []string{"x"}); err != nil {
 		t.Fatalf("embed: %v", err)
 	}
-	if gotPath != "/v1beta/openai/embeddings" {
-		t.Fatalf("path = %q, want /v1beta/openai/embeddings", gotPath)
+	if want := "/v1beta/models/m:batchEmbedContents"; gotPath != want {
+		t.Fatalf("path = %q, want %q", gotPath, want)
 	}
 }
 
@@ -124,28 +144,80 @@ func TestEmbed_EmptyInputsNoCall(t *testing.T) {
 	}
 }
 
-// TestEmbed_SymmetricRoleByteIdentical pins SPEC 8.1.5: Gemini is a
-// symmetric embedder, so the raw request bytes MUST be identical for
-// EmbedDocument and EmbedQuery (role accepted and ignored).
-func TestEmbed_SymmetricRoleByteIdentical(t *testing.T) {
-	var bodies []string
+// TestEmbed_AsymmetricRoleMapsTaskType pins SPEC 8.1.5: Gemini is an
+// asymmetric embedder, so the role maps onto taskType —
+// document → RETRIEVAL_DOCUMENT, query → RETRIEVAL_QUERY — and a query
+// against the configured code model → CODE_RETRIEVAL_QUERY.
+func TestEmbed_AsymmetricRoleMapsTaskType(t *testing.T) {
+	var gotTask string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		raw, _ := io.ReadAll(r.Body)
-		bodies = append(bodies, string(raw))
+		req := decodeNativeEmbed(t, r)
+		gotTask = req.Requests[0].TaskType
+		_ = json.NewEncoder(w).Encode(embedRespFor(req))
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL)
+	c.CodeEmbedModel = "code-embed"
+
+	cases := []struct {
+		name      string
+		modelName string
+		role      model.EmbedRole
+		want      string
+	}{
+		{"text document", "text-embed", model.EmbedDocument, "RETRIEVAL_DOCUMENT"},
+		{"text query", "text-embed", model.EmbedQuery, "RETRIEVAL_QUERY"},
+		{"code document", "code-embed", model.EmbedDocument, "RETRIEVAL_DOCUMENT"},
+		{"code query", "code-embed", model.EmbedQuery, "CODE_RETRIEVAL_QUERY"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := c.Embed(context.Background(), tc.modelName, tc.role, []string{"hi"}); err != nil {
+				t.Fatalf("embed: %v", err)
+			}
+			if gotTask != tc.want {
+				t.Fatalf("taskType = %q, want %q", gotTask, tc.want)
+			}
+		})
+	}
+}
+
+// TestEmbed_OutputDimensionalityAndNormalize pins SPEC 8.1.6: a requested
+// output dimension is sent as outputDimensionality, and the returned
+// vector is L2-normalized to unit length.
+func TestEmbed_OutputDimensionalityAndNormalize(t *testing.T) {
+	var gotDim *int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		req := decodeNativeEmbed(t, r)
+		gotDim = req.Requests[0].OutputDimensionality
+		// Return a non-unit vector [3,4] (norm 5) to prove normalization.
 		_ = json.NewEncoder(w).Encode(map[string]any{
-			"data": []map[string]any{{"index": 0, "embedding": []float64{1}}},
+			"embeddings": []map[string]any{{"values": []float64{3, 4}}},
 		})
 	}))
 	defer srv.Close()
 
 	c := newClient(srv.URL)
-	for _, role := range []model.EmbedRole{model.EmbedDocument, model.EmbedQuery} {
-		if _, err := c.Embed(context.Background(), "m", role, []string{"hi"}); err != nil {
-			t.Fatalf("embed (%s): %v", role, err)
-		}
+	c.EmbedTextDim = 768
+	vecs, err := c.Embed(context.Background(), "m", model.EmbedDocument, []string{"x"})
+	if err != nil {
+		t.Fatalf("embed: %v", err)
 	}
-	if len(bodies) != 2 || bodies[0] != bodies[1] {
-		t.Fatalf("symmetric provider must send byte-identical request:\n%q\n%q", bodies[0], bodies[1])
+	if gotDim == nil || *gotDim != 768 {
+		t.Fatalf("outputDimensionality = %v, want 768", gotDim)
+	}
+	// [3,4]/5 = [0.6,0.8]; norm must be ~1.
+	got := vecs[0]
+	if d := got[0] - 0.6; d > 1e-6 || d < -1e-6 {
+		t.Fatalf("vec[0] = %v, want 0.6 (normalized)", got[0])
+	}
+	var norm float64
+	for _, v := range got {
+		norm += float64(v) * float64(v)
+	}
+	if norm < 0.999 || norm > 1.001 {
+		t.Fatalf("vector not unit length: norm^2 = %v", norm)
 	}
 }
 
@@ -292,16 +364,12 @@ func TestGenerate_MissingKeyIsNonRetryableAuth(t *testing.T) {
 // TestEmbed_DefaultModelFallback covers the empty-model fallback to the
 // (overridable) DefaultEmbedModel — the request body must carry it.
 func TestEmbed_DefaultModelFallback(t *testing.T) {
-	var gotModel string
+	var gotModel, gotPath string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var req struct {
-			Model string `json:"model"`
-		}
-		_ = json.NewDecoder(r.Body).Decode(&req)
-		gotModel = req.Model
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"data": []map[string]any{{"index": 0, "embedding": []float64{1}}},
-		})
+		gotPath = r.URL.Path
+		req := decodeNativeEmbed(t, r)
+		gotModel = req.Requests[0].Model
+		_ = json.NewEncoder(w).Encode(embedRespFor(req))
 	}))
 	defer srv.Close()
 
@@ -310,8 +378,13 @@ func TestEmbed_DefaultModelFallback(t *testing.T) {
 	if _, err := c.Embed(context.Background(), "", model.EmbedDocument, []string{"x"}); err != nil {
 		t.Fatalf("embed: %v", err)
 	}
-	if gotModel != "embed-override" {
-		t.Fatalf("model = %q, want embed-override (DefaultEmbedModel fallback)", gotModel)
+	// The native request qualifies the model as "models/{model}" and the
+	// URL path carries the same model id.
+	if gotModel != "models/embed-override" {
+		t.Fatalf("model = %q, want models/embed-override (DefaultEmbedModel fallback)", gotModel)
+	}
+	if want := "/models/embed-override:batchEmbedContents"; gotPath != want {
+		t.Fatalf("path = %q, want %q", gotPath, want)
 	}
 }
 

--- a/tests/provider/provider_test.go
+++ b/tests/provider/provider_test.go
@@ -132,7 +132,9 @@ func TestSelectAutoPrecedence(t *testing.T) {
 func TestEmbedIdentity(t *testing.T) {
 	p := provider.Profile{Name: "mistral", EmbedTextModel: "mistral-embed", EmbedCodeModel: "codestral-embed"}
 	id := provider.EmbedIdentity(p)
-	if id != "mistral|mistral-embed|codestral-embed" {
+	// Identity is provider|text_model|code_model|text_dim|code_dim
+	// (SPEC 8.1.4/8.1.6); unset dims record as 0 (native).
+	if id != "mistral|mistral-embed|codestral-embed|0|0" {
 		t.Fatalf("identity = %q", id)
 	}
 	if err := provider.VerifyEmbedIdentity("", id); err != nil {
@@ -141,7 +143,15 @@ func TestEmbedIdentity(t *testing.T) {
 	if err := provider.VerifyEmbedIdentity(id, id); err != nil {
 		t.Errorf("matching identity must pass: %v", err)
 	}
-	_ = cfgErr(t, provider.VerifyEmbedIdentity("openai|text-embedding-3-small|", id))
+	_ = cfgErr(t, provider.VerifyEmbedIdentity("openai|text-embedding-3-small||0|0", id))
+	// A different requested output dimension is a distinct identity
+	// (reindex-bound, SPEC 8.1.6): same provider+models but dim 768 must
+	// not match the native (dim 0) identity.
+	native := provider.EmbedIdentity(provider.Profile{Name: "gemini", EmbedTextModel: "gemini-embedding-001"})
+	dimmed := provider.EmbedIdentity(provider.Profile{Name: "gemini", EmbedTextModel: "gemini-embedding-001", EmbedTextDim: 768})
+	if native == dimmed {
+		t.Fatalf("requested dimension must change embed identity: %q == %q", native, dimmed)
+	}
 }
 
 func mustErr(_ provider.Profile, err error) error {

--- a/tests/provider/provider_test.go
+++ b/tests/provider/provider_test.go
@@ -152,6 +152,15 @@ func TestEmbedIdentity(t *testing.T) {
 	if native == dimmed {
 		t.Fatalf("requested dimension must change embed identity: %q == %q", native, dimmed)
 	}
+	// A legacy 3-field identity (pre-8.1.6 snapshot, no dims) must NOT
+	// force a spurious reindex against the equivalent native 5-field
+	// identity — it is normalized to "|0|0" before comparison.
+	legacy := "mistral|mistral-embed|codestral-embed"
+	if err := provider.VerifyEmbedIdentity(legacy, "mistral|mistral-embed|codestral-embed|0|0"); err != nil {
+		t.Errorf("legacy 3-field identity must match native 5-field: %v", err)
+	}
+	// But a legacy identity vs a non-native dimension still mismatches.
+	_ = cfgErr(t, provider.VerifyEmbedIdentity(legacy, "mistral|mistral-embed|codestral-embed|768|0"))
 }
 
 func mustErr(_ provider.Profile, err error) error {

--- a/tests/providerfactory/factory_test.go
+++ b/tests/providerfactory/factory_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"testing"
 
+	"github.com/dirstral/dir2mcp/internal/gemini"
 	"github.com/dirstral/dir2mcp/internal/openai"
 	"github.com/dirstral/dir2mcp/internal/provider"
 	"github.com/dirstral/dir2mcp/internal/providerfactory"
@@ -96,5 +97,41 @@ func TestModelDefaultsPropagate(t *testing.T) {
 	g, _ := providerfactory.Generator(p)
 	if oc, ok := g.(*openai.Client); !ok || oc.DefaultChatModel != "my-chat" {
 		t.Fatalf("chat default not propagated: %#v", g)
+	}
+}
+
+// TestEmbedder_GeminiDimsAndCodeModel verifies the Matryoshka dimension
+// and code-model fields (SPEC 8.1.5/8.1.6) propagate to the gemini client.
+func TestEmbedder_GeminiDimsAndCodeModel(t *testing.T) {
+	p := provider.Profile{
+		Name: "gemini", Kind: provider.KindGemini, APIKey: "k",
+		EmbedTextModel: "gemini-embedding-001", EmbedCodeModel: "gemini-embedding-001",
+		EmbedTextDim: 1536, EmbedCodeDim: 768,
+	}
+	e, err := providerfactory.Embedder(p)
+	if err != nil {
+		t.Fatalf("embedder: %v", err)
+	}
+	gc, ok := e.(*gemini.Client)
+	if !ok {
+		t.Fatalf("want *gemini.Client, got %T", e)
+	}
+	if gc.DefaultEmbedModel != "gemini-embedding-001" || gc.CodeEmbedModel != "gemini-embedding-001" {
+		t.Fatalf("models not propagated: %+v", gc)
+	}
+	if gc.EmbedTextDim != 1536 || gc.EmbedCodeDim != 768 {
+		t.Fatalf("dims not propagated: text=%d code=%d", gc.EmbedTextDim, gc.EmbedCodeDim)
+	}
+}
+
+// TestEmbedder_DimRejectedForNonGemini pins SPEC 8.1.6: a fixed output
+// dimension on a provider that can't honor it is CONFIG_INVALID, not
+// silently ignored.
+func TestEmbedder_DimRejectedForNonGemini(t *testing.T) {
+	for _, k := range []provider.Kind{provider.KindOpenAI, provider.KindCohere} {
+		p := provider.Profile{Name: string(k), Kind: k, APIKey: "k", EmbedTextDim: 768}
+		if _, err := providerfactory.Embedder(p); err == nil {
+			t.Fatalf("kind %q: want CONFIG_INVALID for embed dim, got nil", k)
+		}
 	}
 }

--- a/tests/providerfactory/factory_test.go
+++ b/tests/providerfactory/factory_test.go
@@ -135,3 +135,15 @@ func TestEmbedder_DimRejectedForNonGemini(t *testing.T) {
 		}
 	}
 }
+
+// TestEmbedder_NegativeDimRejected pins SPEC 8.1.6: a negative dimension is
+// CONFIG_INVALID for every kind, including Gemini (it would otherwise form
+// a distinct identity yet behave like "unset" at runtime).
+func TestEmbedder_NegativeDimRejected(t *testing.T) {
+	for _, k := range []provider.Kind{provider.KindGemini, provider.KindOpenAI} {
+		p := provider.Profile{Name: string(k), Kind: k, APIKey: "k", EmbedCodeDim: -1}
+		if _, err := providerfactory.Embedder(p); err == nil {
+			t.Fatalf("kind %q: want CONFIG_INVALID for negative dim, got nil", k)
+		}
+	}
+}


### PR DESCRIPTION
Code PR for **Gemini embedding parity** with `gemini-embedding-001`, gated on spec 0.11.0 (dirstral-spec#10, merged). Re-pins the `dirstral-spec` submodule to the merge commit `83a672a`.

## What changed
The `gemini` embed adapter rode Gemini's OpenAI-compatible `/embeddings` shim (default `text-embedding-004`, role ignored). That shim cannot send `taskType` or `outputDimensionality`, so it missed the two headline features of `gemini-embedding-001`. This PR moves embeddings to Gemini's **native** `models/{model}:batchEmbedContents` surface.

- **Native embed path** — `x-goog-api-key` auth; native base derived from the configured OpenAI-compat base by dropping a trailing `/openai`. Chat/STT stay on the OpenAI-compat surface.
- **Asymmetric `taskType`** (spec §8.1.5): `document`→`RETRIEVAL_DOCUMENT`, `query`→`RETRIEVAL_QUERY`, and a query against the configured **code** model →`CODE_RETRIEVAL_QUERY` (the code-aware refinement). Role is set by the call site (indexing vs. retrieval) — no config.
- **Matryoshka dims** (spec §8.1.6): `model.embed.text_dim`/`code_dim` send `outputDimensionality` and the adapter **L2-normalizes** truncated vectors. Setting the knob on a non-Gemini provider is `CONFIG_INVALID` (never silently ignored).
- **Reindex-bound identity** (spec §8.1.4): the requested dimension joins provider+model in `EmbedIdentity`, so a dimension/model change forces a reindex.
- Default gemini embed model → `gemini-embedding-001`.

## Config
```yaml
model:
  embed:
    provider: gemini
    text_model: gemini-embedding-001
    code_model: gemini-embedding-001
    text_dim: 3072   # optional; 1536 / 768 also valid (re-normalized)
    code_dim: 3072
```
Auto-selection still prefers Mistral, so using Gemini is an explicit binding.

## Tests
- `tests/gemini`: native request/response shape, path + auth header, batch order across retries, role→`taskType` (incl. code query), `outputDimensionality` + normalization, default-model fallback.
- `tests/providerfactory`: dim/code-model propagation to the client; dim rejected (`CONFIG_INVALID`) for non-Gemini kinds.
- `tests/config` + `tests/provider`: `text_dim`/`code_dim` parse + resolve; embed identity encodes the requested dims (reindex-bound).
- `make check` green (gofmt, vet, golangci-lint 0 issues, gocyclo, ineffassign, misspell, full `go test`, build).

## Follow-up
Native Gemini STT/TTS remain the deferred TODO (separate spec+code slice).