### PR TITLE
feat(gemini): native STT/TTS via generateContent (spec 0.12.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ vary by deployment. The commonly used variables are:
 | `DIR2MCP_RERANK_MODEL` | No | Cohere rerank model override (default: `rerank-v3.5`) |
 | `ELEVENLABS_API_KEY` | No | ElevenLabs key for TTS/STT |
 | `ELEVENLABS_BASE_URL` | No | ElevenLabs base URL (default: `https://api.elevenlabs.io`) |
-| `GEMINI_API_KEY` | Optional | Google Gemini key; enables the `gemini` provider profile (embeddings, chat). Bind it explicitly to a capability (e.g. `model.embed.provider: gemini`) — auto-selection still prefers Mistral. Secret, never persisted |
+| `GEMINI_API_KEY` | Optional | Google Gemini key; enables the `gemini` provider profile (embeddings, chat, and native STT/TTS via `generateContent`). Bind it explicitly to a capability (e.g. `model.embed.provider: gemini`, `stt.provider: gemini`) — auto-selection still prefers Mistral. Secret, never persisted |
 
 For Homebrew and other installed workflows, you can persist this in `.dir2mcp.yaml`:
 

--- a/internal/gemini/client.go
+++ b/internal/gemini/client.go
@@ -15,23 +15,26 @@
 // mapped onto `taskType` (RETRIEVAL_DOCUMENT / RETRIEVAL_QUERY, and
 // CODE_RETRIEVAL_QUERY for a query against the configured code model).
 //
-// TODO(spec 8.1.2): native Gemini STT/TTS. The capability matrix marks
-// `gemini` as stt ✅ tts ✅, but this adapter implements embed + chat
-// only. Audio (model.Transcriber / TTS) is deferred to a follow-up PR
-// and is intentionally not implemented here.
+// STT (model.Transcriber) and TTS use the native
+// models/{model}:generateContent surface too (SPEC 8.2/8.3): STT sends the
+// audio as an inline-data part; TTS requests responseModalities:[AUDIO]
+// with a speechConfig voice and WAV-wraps the returned PCM. Gemini's
+// OpenAI-compatible layer exposes no /v1/audio/*, so only chat rides it.
 package gemini
 
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"math"
-	"mime/multipart"
 	"net/http"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -61,6 +64,11 @@ const (
 	DefaultSTTModel   = "gemini-2.5-flash"
 	DefaultTTSModel   = "gemini-2.5-flash-preview-tts"
 	DefaultTTSVoice   = "Kore"
+
+	// geminiTTSSampleRate is the sample rate of Gemini's TTS PCM output
+	// (signed 16-bit little-endian, mono); used to build the WAV header
+	// when the response mimeType omits an explicit rate.
+	geminiTTSSampleRate = 24000
 )
 
 // Client is a Gemini adapter that speaks the OpenAI-compatible wire
@@ -93,8 +101,11 @@ type Client struct {
 	EmbedCodeDim     int
 	DefaultChatModel string
 	DefaultSTTModel  string
-	DefaultTTSModel  string
-	DefaultTTSVoice  string
+	// DefaultSTTLanguage is an optional language hint included in the
+	// transcription prompt (SPEC 8.2 stt_language); empty omits it.
+	DefaultSTTLanguage string
+	DefaultTTSModel    string
+	DefaultTTSVoice    string
 }
 
 // compile-time assertions that *Client implements the model contracts.
@@ -466,12 +477,56 @@ func contentToText(raw json.RawMessage) string {
 	return ""
 }
 
-type transcriptionResponse struct {
-	Text string `json:"text"`
+// Native generateContent request/response shapes, shared by STT and TTS.
+// Gemini's OpenAI-compatible layer exposes no /v1/audio/*, so audio uses
+// models/{model}:generateContent (SPEC 8.2/8.3).
+type geminiInlineData struct {
+	MimeType string `json:"mimeType"`
+	Data     string `json:"data"` // base64
 }
 
-// Transcribe implements model.Transcriber via {base}/audio/transcriptions
-// on Gemini's OpenAI-compatible endpoint (SPEC 8.1.2 gemini stt).
+type geminiPart struct {
+	Text       string            `json:"text,omitempty"`
+	InlineData *geminiInlineData `json:"inlineData,omitempty"`
+}
+
+type geminiContent struct {
+	Parts []geminiPart `json:"parts"`
+}
+
+type geminiPrebuiltVoice struct {
+	VoiceName string `json:"voiceName"`
+}
+
+type geminiVoiceConfig struct {
+	PrebuiltVoiceConfig geminiPrebuiltVoice `json:"prebuiltVoiceConfig"`
+}
+
+type geminiSpeechConfig struct {
+	VoiceConfig geminiVoiceConfig `json:"voiceConfig"`
+}
+
+type geminiGenerationConfig struct {
+	ResponseModalities []string            `json:"responseModalities,omitempty"`
+	SpeechConfig       *geminiSpeechConfig `json:"speechConfig,omitempty"`
+}
+
+type geminiGenerateRequest struct {
+	Contents         []geminiContent         `json:"contents"`
+	GenerationConfig *geminiGenerationConfig `json:"generationConfig,omitempty"`
+}
+
+type geminiGenerateResponse struct {
+	Candidates []struct {
+		Content geminiContent `json:"content"`
+	} `json:"candidates"`
+}
+
+// Transcribe implements model.Transcriber via the native
+// models/{model}:generateContent surface: the audio is sent as an inline
+// data part with a transcription instruction, and the model's text output
+// is the transcript (SPEC 8.2). Gemini's OpenAI-compatible layer has no
+// /v1/audio/transcriptions.
 func (c *Client) Transcribe(ctx context.Context, relPath string, data []byte) (string, error) {
 	if strings.TrimSpace(c.APIKey) == "" {
 		return "", &model.ProviderError{Code: "GEMINI_AUTH", Message: "missing Gemini API key", Retryable: false}
@@ -493,55 +548,56 @@ func (c *Client) Transcribe(ctx context.Context, relPath string, data []byte) (s
 }
 
 func (c *Client) transcribeOnce(ctx context.Context, relPath string, data []byte, sttModel string, timeout time.Duration) (string, error) {
-	name := strings.TrimSpace(filepath.Base(relPath))
-	if name == "" || name == "." || name == string(filepath.Separator) {
-		name = "audio.wav"
+	prompt := "Generate a verbatim transcript of the speech in this audio. Return only the transcript text, with no commentary, labels, or timestamps."
+	if lang := strings.TrimSpace(c.DefaultSTTLanguage); lang != "" {
+		prompt += " The audio language is " + lang + "."
 	}
-	var buf bytes.Buffer
-	w := multipart.NewWriter(&buf)
-	ff, err := w.CreateFormFile("file", name)
-	if err == nil {
-		_, err = ff.Write(data)
-	}
-	if err == nil {
-		err = w.WriteField("model", sttModel)
-	}
-	if err == nil {
-		err = w.Close()
-	}
+	body, err := json.Marshal(geminiGenerateRequest{
+		Contents: []geminiContent{{Parts: []geminiPart{
+			{Text: prompt},
+			{InlineData: &geminiInlineData{MimeType: audioMIMEType(relPath), Data: base64.StdEncoding.EncodeToString(data)}},
+		}}},
+	})
 	if err != nil {
-		return "", &model.ProviderError{Code: "GEMINI_FAILED", Message: "failed to build transcription body", Retryable: false, Cause: err}
+		return "", &model.ProviderError{Code: "GEMINI_FAILED", Message: "failed to marshal transcription request", Retryable: false, Cause: err}
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+"/audio/transcriptions", bytes.NewReader(buf.Bytes()))
+	resp, err := c.doNativeJSON(ctx, "/models/"+sttModel+":generateContent", body, timeout)
 	if err != nil {
-		return "", &model.ProviderError{Code: "GEMINI_FAILED", Message: "failed to build transcription request", Retryable: false, Cause: err}
-	}
-	req.Header.Set("Authorization", "Bearer "+c.APIKey)
-	req.Header.Set("Content-Type", w.FormDataContentType())
-	resp, err := clientWithTimeout(c.HTTPClient, timeout).Do(req)
-	if err != nil {
-		return "", &model.ProviderError{Code: "GEMINI_FAILED", Message: "transcription request failed", Retryable: true, Cause: err}
+		return "", err
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return "", httpError(resp)
 	}
-	var parsed transcriptionResponse
+	var parsed geminiGenerateResponse
 	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
 		return "", &model.ProviderError{Code: "GEMINI_FAILED", Message: "failed to decode transcription response", Retryable: false, StatusCode: resp.StatusCode, Cause: err}
 	}
-	return strings.TrimSpace(parsed.Text), nil
+	text := strings.TrimSpace(firstCandidateText(parsed))
+	if text == "" {
+		return "", &model.ProviderError{Code: "GEMINI_FAILED", Message: "transcription response had no text", Retryable: false, StatusCode: resp.StatusCode}
+	}
+	return text, nil
 }
 
-type speechRequest struct {
-	Model string `json:"model"`
-	Input string `json:"input"`
-	Voice string `json:"voice"`
+// firstCandidateText concatenates the text parts of the first candidate.
+func firstCandidateText(r geminiGenerateResponse) string {
+	if len(r.Candidates) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for _, p := range r.Candidates[0].Content.Parts {
+		b.WriteString(p.Text)
+	}
+	return b.String()
 }
 
 // Synthesize implements the optional TTS surface (mcp.TTSSynthesizer
-// shape) via {base}/audio/speech, returning raw audio bytes. TTS is
-// fail-open per SPEC 8.3.
+// shape) via the native models/{model}:generateContent surface with
+// responseModalities:[AUDIO] + a speechConfig voice (SPEC 8.3). Gemini
+// returns raw PCM (s16le, 24kHz, mono); it is WAV-wrapped so the bytes are
+// directly playable, matching the other TTS adapters. TTS is fail-open
+// per SPEC 8.3.
 func (c *Client) Synthesize(ctx context.Context, text string) ([]byte, error) {
 	if strings.TrimSpace(c.APIKey) == "" {
 		return nil, &model.ProviderError{Code: "GEMINI_AUTH", Message: "missing Gemini API key", Retryable: false}
@@ -561,12 +617,18 @@ func (c *Client) Synthesize(ctx context.Context, text string) ([]byte, error) {
 	if timeout <= 0 {
 		timeout = defaultGenerationTimeout
 	}
-	body, err := json.Marshal(speechRequest{Model: ttsModel, Input: text, Voice: voice})
+	body, err := json.Marshal(geminiGenerateRequest{
+		Contents: []geminiContent{{Parts: []geminiPart{{Text: text}}}},
+		GenerationConfig: &geminiGenerationConfig{
+			ResponseModalities: []string{"AUDIO"},
+			SpeechConfig:       &geminiSpeechConfig{VoiceConfig: geminiVoiceConfig{PrebuiltVoiceConfig: geminiPrebuiltVoice{VoiceName: voice}}},
+		},
+	})
 	if err != nil {
 		return nil, &model.ProviderError{Code: "GEMINI_FAILED", Message: "failed to marshal tts request", Retryable: false, Cause: err}
 	}
 	return retryAudio(ctx, c, func() ([]byte, error) {
-		resp, err := c.doJSON(ctx, "/audio/speech", body, timeout)
+		resp, err := c.doNativeJSON(ctx, "/models/"+ttsModel+":generateContent", body, timeout)
 		if err != nil {
 			return nil, err
 		}
@@ -574,15 +636,100 @@ func (c *Client) Synthesize(ctx context.Context, text string) ([]byte, error) {
 		if resp.StatusCode != http.StatusOK {
 			return nil, httpError(resp)
 		}
-		audio, rerr := io.ReadAll(resp.Body)
-		if rerr != nil {
-			return nil, &model.ProviderError{Code: "GEMINI_FAILED", Message: "failed to read tts audio", Retryable: true, Cause: rerr}
+		var parsed geminiGenerateResponse
+		if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+			return nil, &model.ProviderError{Code: "GEMINI_FAILED", Message: "failed to decode tts response", Retryable: false, StatusCode: resp.StatusCode, Cause: err}
 		}
-		if len(audio) == 0 {
-			return nil, &model.ProviderError{Code: "GEMINI_FAILED", Message: "tts returned no audio", Retryable: false, StatusCode: resp.StatusCode}
+		pcm, rate, perr := firstAudioPart(parsed)
+		if perr != nil {
+			return nil, perr
 		}
-		return audio, nil
+		return wavWrapPCM16(pcm, rate), nil
 	})
+}
+
+// firstAudioPart returns the decoded PCM bytes and sample rate from the
+// first inline-audio part of the first candidate. The sample rate is
+// parsed from the part's mimeType (e.g. "audio/L16;rate=24000"),
+// defaulting to geminiTTSSampleRate.
+func firstAudioPart(r geminiGenerateResponse) ([]byte, int, error) {
+	if len(r.Candidates) == 0 {
+		return nil, 0, &model.ProviderError{Code: "GEMINI_FAILED", Message: "tts response had no candidates", Retryable: false}
+	}
+	for _, p := range r.Candidates[0].Content.Parts {
+		if p.InlineData == nil || p.InlineData.Data == "" {
+			continue
+		}
+		raw, err := base64.StdEncoding.DecodeString(p.InlineData.Data)
+		if err != nil {
+			return nil, 0, &model.ProviderError{Code: "GEMINI_FAILED", Message: "failed to decode tts audio", Retryable: false, Cause: err}
+		}
+		return raw, sampleRateFromMIME(p.InlineData.MimeType), nil
+	}
+	return nil, 0, &model.ProviderError{Code: "GEMINI_FAILED", Message: "tts response had no audio", Retryable: false}
+}
+
+// audioMIMEType maps a file extension to a Gemini-accepted audio MIME
+// type, defaulting to audio/wav for unknown/empty extensions.
+func audioMIMEType(relPath string) string {
+	switch strings.ToLower(strings.TrimPrefix(filepath.Ext(relPath), ".")) {
+	case "mp3":
+		return "audio/mp3"
+	case "aiff", "aif":
+		return "audio/aiff"
+	case "aac":
+		return "audio/aac"
+	case "ogg", "oga":
+		return "audio/ogg"
+	case "flac":
+		return "audio/flac"
+	case "m4a", "mp4":
+		return "audio/mp4"
+	default:
+		return "audio/wav"
+	}
+}
+
+// sampleRateFromMIME extracts the rate from a PCM mime type like
+// "audio/L16;rate=24000"; defaults to geminiTTSSampleRate.
+func sampleRateFromMIME(mime string) int {
+	for _, seg := range strings.Split(mime, ";") {
+		if v, ok := strings.CutPrefix(strings.TrimSpace(seg), "rate="); ok {
+			if n, err := strconv.Atoi(strings.TrimSpace(v)); err == nil && n > 0 {
+				return n
+			}
+		}
+	}
+	return geminiTTSSampleRate
+}
+
+// wavWrapPCM16 wraps raw signed-16-bit little-endian mono PCM in a minimal
+// RIFF/WAVE container so the bytes are directly playable (SPEC 8.3) —
+// Gemini returns headerless PCM, while every other TTS adapter returns a
+// self-describing container.
+func wavWrapPCM16(pcm []byte, sampleRate int) []byte {
+	if sampleRate <= 0 {
+		sampleRate = geminiTTSSampleRate
+	}
+	const numChannels, bitsPerSample = 1, 16
+	byteRate := sampleRate * numChannels * bitsPerSample / 8
+	blockAlign := numChannels * bitsPerSample / 8
+	var buf bytes.Buffer
+	buf.WriteString("RIFF")
+	_ = binary.Write(&buf, binary.LittleEndian, uint32(36+len(pcm)))
+	buf.WriteString("WAVE")
+	buf.WriteString("fmt ")
+	_ = binary.Write(&buf, binary.LittleEndian, uint32(16)) // PCM fmt chunk size
+	_ = binary.Write(&buf, binary.LittleEndian, uint16(1))  // audio format = PCM
+	_ = binary.Write(&buf, binary.LittleEndian, uint16(numChannels))
+	_ = binary.Write(&buf, binary.LittleEndian, uint32(sampleRate))
+	_ = binary.Write(&buf, binary.LittleEndian, uint32(byteRate))
+	_ = binary.Write(&buf, binary.LittleEndian, uint16(blockAlign))
+	_ = binary.Write(&buf, binary.LittleEndian, uint16(bitsPerSample))
+	buf.WriteString("data")
+	_ = binary.Write(&buf, binary.LittleEndian, uint32(len(pcm)))
+	buf.Write(pcm)
+	return buf.Bytes()
 }
 
 // retryAudio runs op with the client's bounded exponential backoff,

--- a/internal/gemini/client.go
+++ b/internal/gemini/client.go
@@ -1,10 +1,10 @@
-// Package gemini provides a direct-HTTP adapter for Google Gemini. Chat
-// (model.Generator) and STT use Gemini's OpenAI-compatible surface (POST
-// {base}/chat/completions); embeddings (model.Embedder) use Gemini's
-// NATIVE surface (POST {base-without-/openai}/models/{model}:batchEmbedContents)
-// because only the native API supports `taskType` (asymmetric embeddings,
-// SPEC 8.1.5) and `outputDimensionality` (Matryoshka/MRL, SPEC 8.1.6) —
-// the OpenAI-compatible /embeddings shim exposes neither.
+// Package gemini provides a direct-HTTP adapter for Google Gemini. Only
+// chat (model.Generator) uses Gemini's OpenAI-compatible surface (POST
+// {base}/chat/completions); embeddings (model.Embedder) and audio
+// (model.Transcriber / TTS) use Gemini's NATIVE surface
+// ({base-without-/openai}/models/{model}:{batchEmbedContents,generateContent})
+// because the OpenAI-compatible layer exposes neither `taskType`/
+// `outputDimensionality` (SPEC 8.1.5/8.1.6) nor `/v1/audio/*` (SPEC 8.2/8.3).
 //
 // It mirrors internal/mistral and internal/cohere (BaseURL/APIKey/
 // HTTPClient, bounded exponential retry, typed model.ProviderError) so
@@ -664,7 +664,11 @@ func firstAudioPart(r geminiGenerateResponse) ([]byte, int, error) {
 		if err != nil {
 			return nil, 0, &model.ProviderError{Code: "GEMINI_FAILED", Message: "failed to decode tts audio", Retryable: false, Cause: err}
 		}
-		return raw, sampleRateFromMIME(p.InlineData.MimeType), nil
+		rate, err := sampleRateFromMIME(p.InlineData.MimeType)
+		if err != nil {
+			return nil, 0, &model.ProviderError{Code: "GEMINI_FAILED", Message: err.Error(), Retryable: false}
+		}
+		return raw, rate, nil
 	}
 	return nil, 0, &model.ProviderError{Code: "GEMINI_FAILED", Message: "tts response had no audio", Retryable: false}
 }
@@ -690,17 +694,30 @@ func audioMIMEType(relPath string) string {
 	}
 }
 
-// sampleRateFromMIME extracts the rate from a PCM mime type like
-// "audio/L16;rate=24000"; defaults to geminiTTSSampleRate.
-func sampleRateFromMIME(mime string) int {
-	for _, seg := range strings.Split(mime, ";") {
+// sampleRateFromMIME extracts the rate from Gemini's PCM mime type (e.g.
+// "audio/L16;rate=24000"). wavWrapPCM16 only produces a correct file for
+// signed-16-bit little-endian PCM, so a non-L16 type or a malformed rate
+// is rejected (returning a structured error) rather than silently wrapped
+// into a "valid" WAV with corrupted audio. An empty mime type falls back
+// to the documented default rate.
+func sampleRateFromMIME(mime string) (int, error) {
+	m := strings.TrimSpace(strings.ToLower(mime))
+	if m == "" {
+		return geminiTTSSampleRate, nil
+	}
+	if !strings.HasPrefix(m, "audio/l16") {
+		return 0, fmt.Errorf("unsupported tts audio mime type %q (expected audio/L16 PCM)", mime)
+	}
+	for _, seg := range strings.Split(m, ";") {
 		if v, ok := strings.CutPrefix(strings.TrimSpace(seg), "rate="); ok {
-			if n, err := strconv.Atoi(strings.TrimSpace(v)); err == nil && n > 0 {
-				return n
+			n, err := strconv.Atoi(strings.TrimSpace(v))
+			if err != nil || n <= 0 {
+				return 0, fmt.Errorf("invalid sample rate in tts audio mime type %q", mime)
 			}
+			return n, nil
 		}
 	}
-	return geminiTTSSampleRate
+	return geminiTTSSampleRate, nil
 }
 
 // wavWrapPCM16 wraps raw signed-16-bit little-endian mono PCM in a minimal

--- a/internal/providerfactory/factory.go
+++ b/internal/providerfactory/factory.go
@@ -159,9 +159,10 @@ func OCR(p provider.Profile) (model.OCR, error) {
 }
 
 // Transcriber builds a model.Transcriber for STT-capable kinds:
-// `mistral` (Voxtral), `elevenlabs` (Scribe), and `openai`/`gemini`
-// (OpenAI-compatible /v1/audio/transcriptions; endpoint-dependent for
-// openai per SPEC 8.1.2 ³ — validated at first use).
+// `mistral` (Voxtral), `elevenlabs` (Scribe), `openai`
+// (OpenAI-compatible /v1/audio/transcriptions; endpoint-dependent per
+// SPEC 8.1.2 ³ — validated at first use), and `gemini` (native
+// generateContent with inline audio, SPEC 8.2).
 func Transcriber(p provider.Profile) (model.Transcriber, error) {
 	switch p.Kind {
 	case provider.KindMistral:
@@ -185,6 +186,9 @@ func Transcriber(p provider.Profile) (model.Transcriber, error) {
 		c := gemini.NewClient(p.BaseURL, p.APIKey)
 		if p.STTModel != "" {
 			c.DefaultSTTModel = p.STTModel
+		}
+		if lang := strings.TrimSpace(p.STTLanguage); lang != "" {
+			c.DefaultSTTLanguage = lang
 		}
 		return c, nil
 	default:

--- a/tests/gemini/client_test.go
+++ b/tests/gemini/client_test.go
@@ -1,7 +1,10 @@
 package tests
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -423,30 +426,179 @@ func TestNonRetryableStopsImmediately(t *testing.T) {
 	}
 }
 
-func TestTranscribeAndSynthesize(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/audio/transcriptions":
-			if ct := r.Header.Get("Content-Type"); !strings.HasPrefix(ct, "multipart/form-data") {
-				t.Errorf("transcribe content-type = %q", ct)
+// nativeGenContentReq is the native generateContent request shape (subset).
+type nativeGenContentReq struct {
+	Contents []struct {
+		Parts []struct {
+			Text       string `json:"text"`
+			InlineData *struct {
+				MimeType string `json:"mimeType"`
+				Data     string `json:"data"`
+			} `json:"inlineData"`
+		} `json:"parts"`
+	} `json:"contents"`
+	GenerationConfig struct {
+		ResponseModalities []string `json:"responseModalities"`
+		SpeechConfig       struct {
+			VoiceConfig struct {
+				PrebuiltVoiceConfig struct {
+					VoiceName string `json:"voiceName"`
+				} `json:"prebuiltVoiceConfig"`
+			} `json:"voiceConfig"`
+		} `json:"speechConfig"`
+	} `json:"generationConfig"`
+}
+
+// TestTranscribe_NativeGenerateContent verifies STT uses the native
+// generateContent surface: correct path + x-goog-api-key auth, audio sent
+// as an inline-data part with the extension-derived MIME type, and the
+// candidate text returned as the transcript (SPEC 8.2).
+func TestTranscribe_NativeGenerateContent(t *testing.T) {
+	for _, tc := range []struct{ file, wantMime string }{
+		{"a.wav", "audio/wav"},
+		{"a.mp3", "audio/mp3"},
+		{"a.flac", "audio/flac"},
+		{"noext", "audio/wav"},
+	} {
+		t.Run(tc.file, func(t *testing.T) {
+			var gotPath, gotKey, gotMime, gotData, gotPrompt string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath, gotKey = r.URL.Path, r.Header.Get("x-goog-api-key")
+				var req nativeGenContentReq
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				for _, p := range req.Contents[0].Parts {
+					if p.Text != "" {
+						gotPrompt = p.Text
+					}
+					if p.InlineData != nil {
+						gotMime, gotData = p.InlineData.MimeType, p.InlineData.Data
+					}
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"candidates": []map[string]any{{"content": map[string]any{
+						"parts": []map[string]any{{"text": "hello transcript"}},
+					}}},
+				})
+			}))
+			defer srv.Close()
+
+			c := newClient(srv.URL)
+			txt, err := c.Transcribe(context.Background(), tc.file, []byte("pcm"))
+			if err != nil || txt != "hello transcript" {
+				t.Fatalf("Transcribe = %q, %v", txt, err)
 			}
-			_ = json.NewEncoder(w).Encode(map[string]any{"text": "hello transcript"})
-		case "/audio/speech":
-			_, _ = w.Write([]byte("AUDIOBYTES"))
-		default:
-			t.Errorf("unexpected path %s", r.URL.Path)
-		}
+			if want := "/models/gemini-2.5-flash:generateContent"; gotPath != want {
+				t.Errorf("path = %q, want %q", gotPath, want)
+			}
+			if gotKey != "test-key" {
+				t.Errorf("api key header = %q, want test-key", gotKey)
+			}
+			if gotMime != tc.wantMime {
+				t.Errorf("mime = %q, want %q", gotMime, tc.wantMime)
+			}
+			if dec, _ := base64.StdEncoding.DecodeString(gotData); string(dec) != "pcm" {
+				t.Errorf("inline audio = %q, want base64(pcm)", gotData)
+			}
+			if !strings.Contains(strings.ToLower(gotPrompt), "transcript") {
+				t.Errorf("prompt = %q, want a transcription instruction", gotPrompt)
+			}
+		})
+	}
+}
+
+// TestTranscribe_LanguageHint verifies the optional STT language hint
+// (SPEC 8.2 stt_language) is woven into the transcription prompt.
+func TestTranscribe_LanguageHint(t *testing.T) {
+	var gotPrompt string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req nativeGenContentReq
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		gotPrompt = req.Contents[0].Parts[0].Text
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"candidates": []map[string]any{{"content": map[string]any{
+				"parts": []map[string]any{{"text": "hola"}},
+			}}},
+		})
 	}))
 	defer srv.Close()
 
 	c := newClient(srv.URL)
-	txt, err := c.Transcribe(context.Background(), "a.wav", []byte("pcm"))
-	if err != nil || txt != "hello transcript" {
-		t.Fatalf("Transcribe = %q, %v", txt, err)
+	c.DefaultSTTLanguage = "Spanish"
+	if _, err := c.Transcribe(context.Background(), "a.wav", []byte("pcm")); err != nil {
+		t.Fatalf("Transcribe: %v", err)
 	}
+	if !strings.Contains(gotPrompt, "Spanish") {
+		t.Errorf("prompt = %q, want it to mention the configured language", gotPrompt)
+	}
+}
+
+// TestSynthesize_NativeAudioWavWrapped verifies TTS uses generateContent
+// with responseModalities:[AUDIO] + the configured voice, and that the
+// returned raw PCM is WAV-wrapped (SPEC 8.3).
+func TestSynthesize_NativeAudioWavWrapped(t *testing.T) {
+	pcm := []byte{0x01, 0x02, 0x03, 0x04}
+	var gotPath string
+	var gotMods []string
+	var gotVoice string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		var req nativeGenContentReq
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		gotMods = req.GenerationConfig.ResponseModalities
+		gotVoice = req.GenerationConfig.SpeechConfig.VoiceConfig.PrebuiltVoiceConfig.VoiceName
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"candidates": []map[string]any{{"content": map[string]any{
+				"parts": []map[string]any{{"inlineData": map[string]any{
+					"mimeType": "audio/L16;rate=24000",
+					"data":     base64.StdEncoding.EncodeToString(pcm),
+				}}},
+			}}},
+		})
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL)
+	c.DefaultTTSVoice = "Puck"
 	audio, err := c.Synthesize(context.Background(), "say this")
-	if err != nil || string(audio) != "AUDIOBYTES" {
-		t.Fatalf("Synthesize = %q, %v", audio, err)
+	if err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+	if want := "/models/gemini-2.5-flash-preview-tts:generateContent"; gotPath != want {
+		t.Errorf("path = %q, want %q", gotPath, want)
+	}
+	if len(gotMods) != 1 || gotMods[0] != "AUDIO" {
+		t.Errorf("responseModalities = %v, want [AUDIO]", gotMods)
+	}
+	if gotVoice != "Puck" {
+		t.Errorf("voice = %q, want Puck", gotVoice)
+	}
+	// The output must be a 44-byte-header WAV wrapping the PCM payload.
+	if len(audio) != 44+len(pcm) {
+		t.Fatalf("wav length = %d, want %d", len(audio), 44+len(pcm))
+	}
+	if string(audio[0:4]) != "RIFF" || string(audio[8:12]) != "WAVE" {
+		t.Fatalf("missing RIFF/WAVE header: %x", audio[:12])
+	}
+	if rate := binary.LittleEndian.Uint32(audio[24:28]); rate != 24000 {
+		t.Errorf("sample rate = %d, want 24000", rate)
+	}
+	if !bytes.Equal(audio[44:], pcm) {
+		t.Errorf("PCM payload not preserved: got %x want %x", audio[44:], pcm)
+	}
+}
+
+// TestSynthesize_NoAudioPartErrors covers a candidate with no inline audio.
+func TestSynthesize_NoAudioPartErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"candidates": []map[string]any{{"content": map[string]any{
+				"parts": []map[string]any{{"text": "no audio here"}},
+			}}},
+		})
+	}))
+	defer srv.Close()
+	if _, err := newClient(srv.URL).Synthesize(context.Background(), "hi"); err == nil {
+		t.Fatal("want error when response carries no audio part")
 	}
 }
 

--- a/tests/gemini/client_test.go
+++ b/tests/gemini/client_test.go
@@ -449,6 +449,26 @@ type nativeGenContentReq struct {
 	} `json:"generationConfig"`
 }
 
+// decodeGenContent decodes a native generateContent request and validates
+// it has at least one content part, so a shape change surfaces as a clear
+// test failure (HTTP 400 + t.Errorf) instead of an out-of-range panic in
+// the handler goroutine. Returns ok=false when the caller must not index.
+func decodeGenContent(t *testing.T, w http.ResponseWriter, r *http.Request) (nativeGenContentReq, bool) {
+	t.Helper()
+	var req nativeGenContentReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		t.Errorf("decode generateContent request: %v", err)
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return req, false
+	}
+	if len(req.Contents) == 0 || len(req.Contents[0].Parts) == 0 {
+		t.Errorf("generateContent request has no content parts")
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return req, false
+	}
+	return req, true
+}
+
 // TestTranscribe_NativeGenerateContent verifies STT uses the native
 // generateContent surface: correct path + x-goog-api-key auth, audio sent
 // as an inline-data part with the extension-derived MIME type, and the
@@ -464,8 +484,10 @@ func TestTranscribe_NativeGenerateContent(t *testing.T) {
 			var gotPath, gotKey, gotMime, gotData, gotPrompt string
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				gotPath, gotKey = r.URL.Path, r.Header.Get("x-goog-api-key")
-				var req nativeGenContentReq
-				_ = json.NewDecoder(r.Body).Decode(&req)
+				req, ok := decodeGenContent(t, w, r)
+				if !ok {
+					return
+				}
 				for _, p := range req.Contents[0].Parts {
 					if p.Text != "" {
 						gotPrompt = p.Text
@@ -496,7 +518,10 @@ func TestTranscribe_NativeGenerateContent(t *testing.T) {
 			if gotMime != tc.wantMime {
 				t.Errorf("mime = %q, want %q", gotMime, tc.wantMime)
 			}
-			if dec, _ := base64.StdEncoding.DecodeString(gotData); string(dec) != "pcm" {
+			dec, derr := base64.StdEncoding.DecodeString(gotData)
+			if derr != nil {
+				t.Errorf("inline audio not valid base64 (%q): %v", gotData, derr)
+			} else if string(dec) != "pcm" {
 				t.Errorf("inline audio = %q, want base64(pcm)", gotData)
 			}
 			if !strings.Contains(strings.ToLower(gotPrompt), "transcript") {
@@ -511,8 +536,10 @@ func TestTranscribe_NativeGenerateContent(t *testing.T) {
 func TestTranscribe_LanguageHint(t *testing.T) {
 	var gotPrompt string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var req nativeGenContentReq
-		_ = json.NewDecoder(r.Body).Decode(&req)
+		req, ok := decodeGenContent(t, w, r)
+		if !ok {
+			return
+		}
 		gotPrompt = req.Contents[0].Parts[0].Text
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"candidates": []map[string]any{{"content": map[string]any{
@@ -542,8 +569,10 @@ func TestSynthesize_NativeAudioWavWrapped(t *testing.T) {
 	var gotVoice string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Path
-		var req nativeGenContentReq
-		_ = json.NewDecoder(r.Body).Decode(&req)
+		req, ok := decodeGenContent(t, w, r)
+		if !ok {
+			return
+		}
 		gotMods = req.GenerationConfig.ResponseModalities
 		gotVoice = req.GenerationConfig.SpeechConfig.VoiceConfig.PrebuiltVoiceConfig.VoiceName
 		_ = json.NewEncoder(w).Encode(map[string]any{


### PR DESCRIPTION
Code PR for **native Gemini STT/TTS**, gated on spec 0.12.0 (dirstral-spec#11, merged). Re-pins the `dirstral-spec` submodule to merge commit `8df80d0`. Completes the Gemini parity arc (embeddings shipped in #222).

## What changed
The `gemini` adapter called Gemini's OpenAI-compatible `/v1/audio/transcriptions` and `/v1/audio/speech` — endpoints **Gemini does not serve** (they only passed against a fake test server). Replaced with the native `models/{model}:generateContent` surface.

- **STT** — audio sent as an inline-data part (extension-derived MIME, e.g. `audio/wav`/`audio/mp3`) alongside a transcription instruction; the candidate text is the transcript. Optional `stt_language` is woven into the prompt.
- **TTS** — `generationConfig.responseModalities: ["AUDIO"]` + a `speechConfig` voice (`tts_voice`, default `Kore`; `tts_model` default `gemini-2.5-flash-preview-tts`). Gemini returns base64 raw PCM (s16le, 24 kHz, mono); the adapter decodes and **WAV-wraps** it so the bytes are directly playable, matching ElevenLabs/OpenAI. Fail-open preserved.
- Both reuse the native base (configured base minus `/openai`) + `x-goog-api-key` auth and the existing bounded-retry path.

## Not a loss of flexibility
The `kind: openai` audio path (the openai adapter, any OpenAI-compatible `base_url`) is **untouched** — operators who want OpenAI-compatible audio still select it via `kind: openai`. This PR only fixes the `kind: gemini` path, which was non-functional against real Gemini, and matches the merged spec (§8.1.1 "kind:openai Gemini serves chat only"; §8.2/§8.3 native mechanism).

## Tests
- `tests/gemini`: native STT path + `x-goog-api-key` + MIME inference (wav/mp3/flac/no-ext) + transcription prompt; STT language hint; TTS `responseModalities`+voice + RIFF/WAVE wrapping (header, sample rate, PCM payload preserved); no-audio-part error. Existing missing-key/empty-input guards retained.
- `make check` green (gofmt, vet, golangci-lint 0 issues, gocyclo, ineffassign, misspell, full `go test`, build).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gemini provider now supports native speech-to-text and text-to-speech capabilities.
  * Added optional language hint support for speech-to-text transcription to improve accuracy.

* **Documentation**
  * Updated environment variable documentation to reflect expanded Gemini provider capabilities for speech functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->