### PR TITLE
feat(gemini): multimodal embedding adapter slice (spec 0.13.0, default-off)

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,10 @@ model:
 - **Matryoshka dimensions** (`text_dim`/`code_dim`): request a smaller vector to shrink the index. dir2mcp sends Gemini's `outputDimensionality` and L2-normalizes the truncated vectors. The knob is Gemini-only — setting it on a provider that can't honor it is rejected at startup (`CONFIG_INVALID`).
 - **Reindex-bound (spec §8.1.4/§8.1.6):** the embed provider, model, **and requested dimension** form the corpus-lifetime embed identity. Switching to Gemini, or changing the dimension later, requires a `dir2mcp reindex` (the server refuses to mix vector spaces and tells you to reindex).
 
+#### Multimodal embeddings (`gemini-embedding-2`, preview — in progress)
+
+Spec §8.1.7 (0.13.0) defines an opt-in `model.embed.multimodal` mode (`off` default | `augment` | `replace`) that embeds images/audio/video/PDFs directly into the same vector space via the multimodal `gemini-embedding-2` model. This is being implemented in phases against a **Public Preview** model: the current build wires the provider plumbing (the `gemini-embedding-2` adapter with media-part embedding, the config knob, and the all-axes validation that `augment`/`replace` require `provider: gemini` with `text_model` and `code_model` both `gemini-embedding-2`), but the ingestion/retrieval pipeline that produces media chunks is **not wired yet** — so leaving `multimodal: off` (the default) is the only supported setting for now. See [Design 0003](dirstral-spec/docs/design/0003-multimodal-embeddings.md).
+
 ### Server identity
 
 Each `dir2mcp up` instance reports a unique MCP server name derived from the indexed directory, so running multiple corpora side-by-side (e.g., `dir2mcp-stas-legal-a1b2c3` and `dir2mcp-research-notes-9f44ee`) keeps them distinguishable in your MCP client list.

--- a/internal/config/providers.go
+++ b/internal/config/providers.go
@@ -36,12 +36,13 @@ type providerProfileYAML struct {
 }
 
 type capBindingYAML struct {
-	Provider  string `yaml:"provider"`
-	TextModel string `yaml:"text_model"`
-	CodeModel string `yaml:"code_model"`
-	TextDim   int    `yaml:"text_dim"`
-	CodeDim   int    `yaml:"code_dim"`
-	Model     string `yaml:"model"`
+	Provider   string `yaml:"provider"`
+	TextModel  string `yaml:"text_model"`
+	CodeModel  string `yaml:"code_model"`
+	TextDim    int    `yaml:"text_dim"`
+	CodeDim    int    `yaml:"code_dim"`
+	Multimodal string `yaml:"multimodal"`
+	Model      string `yaml:"model"`
 }
 
 type providersDoc struct {
@@ -295,6 +296,7 @@ func (r ProviderResolution) applyModelOverrides(cap provider.Capability, p provi
 		if r.doc.Model.Embed.CodeDim > 0 {
 			p.EmbedCodeDim = r.doc.Model.Embed.CodeDim
 		}
+		set(&p.EmbedMultimodal, r.doc.Model.Embed.Multimodal)
 	case provider.CapChat:
 		set(&p.ChatModel, r.doc.Model.Chat.Model)
 	case provider.CapOCR:

--- a/internal/gemini/client.go
+++ b/internal/gemini/client.go
@@ -143,19 +143,18 @@ func NewClient(baseURL, apiKey string) *Client {
 // Native batchEmbedContents request/response shapes. The native API
 // (unlike the OpenAI-compatible /embeddings shim) carries taskType and
 // outputDimensionality, and returns embeddings in request order.
-type geminiEmbedContentPart struct {
-	Text string `json:"text"`
-}
-
-type geminiEmbedContent struct {
-	Parts []geminiEmbedContentPart `json:"parts"`
-}
-
 type geminiEmbedSingleRequest struct {
-	Model                string             `json:"model"`
-	Content              geminiEmbedContent `json:"content"`
-	TaskType             string             `json:"taskType,omitempty"`
-	OutputDimensionality *int               `json:"outputDimensionality,omitempty"`
+	Model                string        `json:"model"`
+	Content              geminiContent `json:"content"`
+	TaskType             string        `json:"taskType,omitempty"`
+	OutputDimensionality *int          `json:"outputDimensionality,omitempty"`
+}
+
+// MediaInput is one non-text item to embed (SPEC 8.1.7): the media bytes
+// plus their MIME type (e.g. "image/png", "audio/mp3", "application/pdf").
+type MediaInput struct {
+	MimeType string
+	Data     []byte
 }
 
 type geminiBatchEmbedRequest struct {
@@ -176,8 +175,48 @@ type geminiBatchEmbedResponse struct {
 // BatchSize-sized batches, each retried with bounded exponential backoff;
 // the native batch response preserves request order.
 func (c *Client) Embed(ctx context.Context, modelName string, role model.EmbedRole, inputs []string) ([][]float32, error) {
+	modelName, dim, taskType, err := c.embedParams(modelName, role)
+	if err != nil {
+		return nil, err
+	}
+	if len(inputs) == 0 {
+		return [][]float32{}, nil
+	}
+	reqs := make([]geminiEmbedSingleRequest, len(inputs))
+	for i, in := range inputs {
+		reqs[i] = c.embedReq(modelName, taskType, dim, geminiPart{Text: in})
+	}
+	return c.embedBatched(ctx, modelName, dim, reqs)
+}
+
+// EmbedMedia embeds non-text media (images, audio, video, PDFs) via the
+// same native batchEmbedContents surface, sending each item as an
+// inline-data part (SPEC 8.1.7). Role→taskType and dimension/normalization
+// behave as for Embed.
+func (c *Client) EmbedMedia(ctx context.Context, modelName string, role model.EmbedRole, items []MediaInput) ([][]float32, error) {
+	modelName, dim, taskType, err := c.embedParams(modelName, role)
+	if err != nil {
+		return nil, err
+	}
+	if len(items) == 0 {
+		return [][]float32{}, nil
+	}
+	reqs := make([]geminiEmbedSingleRequest, len(items))
+	for i, it := range items {
+		if len(it.Data) == 0 {
+			return nil, &model.ProviderError{Code: "GEMINI_FAILED", Message: "media input is empty", Retryable: false}
+		}
+		part := geminiPart{InlineData: &geminiInlineData{MimeType: it.MimeType, Data: base64.StdEncoding.EncodeToString(it.Data)}}
+		reqs[i] = c.embedReq(modelName, taskType, dim, part)
+	}
+	return c.embedBatched(ctx, modelName, dim, reqs)
+}
+
+// embedParams resolves the effective model name, requested output dimension,
+// and taskType for an embed call (shared by Embed/EmbedMedia).
+func (c *Client) embedParams(modelName string, role model.EmbedRole) (string, int, string, error) {
 	if strings.TrimSpace(c.APIKey) == "" {
-		return nil, &model.ProviderError{Code: "GEMINI_AUTH", Message: "missing Gemini API key", Retryable: false}
+		return "", 0, "", &model.ProviderError{Code: "GEMINI_AUTH", Message: "missing Gemini API key", Retryable: false}
 	}
 	modelName = strings.TrimSpace(modelName)
 	if modelName == "" {
@@ -186,29 +225,42 @@ func (c *Client) Embed(ctx context.Context, modelName string, role model.EmbedRo
 			modelName = DefaultEmbedModel
 		}
 	}
-	if len(inputs) == 0 {
-		return [][]float32{}, nil
-	}
-
 	isCode := c.CodeEmbedModel != "" && modelName == strings.TrimSpace(c.CodeEmbedModel)
-	taskType := geminiTaskType(role, isCode)
 	dim := c.EmbedTextDim
 	if isCode {
 		dim = c.EmbedCodeDim
 	}
+	return modelName, dim, geminiTaskType(role, isCode), nil
+}
 
+// embedReq builds one native embed request for a single content part.
+func (c *Client) embedReq(modelName, taskType string, dim int, part geminiPart) geminiEmbedSingleRequest {
+	r := geminiEmbedSingleRequest{
+		Model:    "models/" + modelName,
+		Content:  geminiContent{Parts: []geminiPart{part}},
+		TaskType: taskType,
+	}
+	if dim > 0 {
+		d := dim
+		r.OutputDimensionality = &d
+	}
+	return r
+}
+
+// embedBatched sends reqs in BatchSize-sized batches (each retried) and
+// concatenates the vectors in request order.
+func (c *Client) embedBatched(ctx context.Context, modelName string, dim int, reqs []geminiEmbedSingleRequest) ([][]float32, error) {
 	batchSize := c.BatchSize
 	if batchSize <= 0 {
 		batchSize = defaultBatchSize
 	}
-
-	out := make([][]float32, 0, len(inputs))
-	for start := 0; start < len(inputs); start += batchSize {
+	out := make([][]float32, 0, len(reqs))
+	for start := 0; start < len(reqs); start += batchSize {
 		end := start + batchSize
-		if end > len(inputs) {
-			end = len(inputs)
+		if end > len(reqs) {
+			end = len(reqs)
 		}
-		vectors, err := c.embedBatchWithRetry(ctx, modelName, taskType, dim, inputs[start:end])
+		vectors, err := c.embedReqsWithRetry(ctx, modelName, dim, reqs[start:end])
 		if err != nil {
 			return nil, err
 		}
@@ -230,7 +282,7 @@ func geminiTaskType(role model.EmbedRole, isCode bool) string {
 	return "RETRIEVAL_DOCUMENT"
 }
 
-func (c *Client) embedBatchWithRetry(ctx context.Context, modelName, taskType string, dim int, inputs []string) ([][]float32, error) {
+func (c *Client) embedReqsWithRetry(ctx context.Context, modelName string, dim int, reqs []geminiEmbedSingleRequest) ([][]float32, error) {
 	maxRetries := c.MaxRetries
 	if maxRetries < 0 {
 		maxRetries = 0
@@ -242,7 +294,7 @@ func (c *Client) embedBatchWithRetry(ctx context.Context, modelName, taskType st
 				return nil, err
 			}
 		}
-		vectors, err := c.embedBatchNative(ctx, modelName, taskType, dim, inputs)
+		vectors, err := c.embedReqsNative(ctx, modelName, dim, reqs)
 		if err == nil {
 			return vectors, nil
 		}
@@ -255,27 +307,12 @@ func (c *Client) embedBatchWithRetry(ctx context.Context, modelName, taskType st
 	return nil, lastErr
 }
 
-func (c *Client) embedBatchNative(ctx context.Context, modelName, taskType string, dim int, inputs []string) ([][]float32, error) {
-	qualified := "models/" + modelName
-	reqs := make([]geminiEmbedSingleRequest, len(inputs))
-	for i, in := range inputs {
-		r := geminiEmbedSingleRequest{
-			Model:    qualified,
-			Content:  geminiEmbedContent{Parts: []geminiEmbedContentPart{{Text: in}}},
-			TaskType: taskType,
-		}
-		if dim > 0 {
-			d := dim
-			r.OutputDimensionality = &d
-		}
-		reqs[i] = r
-	}
+func (c *Client) embedReqsNative(ctx context.Context, modelName string, dim int, reqs []geminiEmbedSingleRequest) ([][]float32, error) {
 	body, err := json.Marshal(geminiBatchEmbedRequest{Requests: reqs})
 	if err != nil {
 		return nil, &model.ProviderError{Code: "GEMINI_FAILED", Message: "failed to marshal embedding request", Retryable: false, Cause: err}
 	}
-
-	resp, err := c.doNativeJSON(ctx, "/"+qualified+":batchEmbedContents", body, defaultRequestTimeout)
+	resp, err := c.doNativeJSON(ctx, "/models/"+modelName+":batchEmbedContents", body, defaultRequestTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -288,11 +325,11 @@ func (c *Client) embedBatchNative(ctx context.Context, modelName, taskType strin
 	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
 		return nil, &model.ProviderError{Code: "GEMINI_FAILED", Message: "failed to decode embedding response", Retryable: false, StatusCode: resp.StatusCode, Cause: err}
 	}
-	if len(parsed.Embeddings) != len(inputs) {
-		return nil, &model.ProviderError{Code: "GEMINI_FAILED", Message: fmt.Sprintf("embedding response size mismatch: got %d vectors for %d inputs", len(parsed.Embeddings), len(inputs)), Retryable: false, StatusCode: resp.StatusCode}
+	if len(parsed.Embeddings) != len(reqs) {
+		return nil, &model.ProviderError{Code: "GEMINI_FAILED", Message: fmt.Sprintf("embedding response size mismatch: got %d vectors for %d inputs", len(parsed.Embeddings), len(reqs)), Retryable: false, StatusCode: resp.StatusCode}
 	}
 
-	vectors := make([][]float32, len(inputs))
+	vectors := make([][]float32, len(reqs))
 	for i, e := range parsed.Embeddings {
 		vec := make([]float32, len(e.Values))
 		for j, v := range e.Values {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -106,13 +106,18 @@ type Profile struct {
 	// identity (SPEC 8.1.4), so a change is reindex-bound.
 	EmbedTextDim int
 	EmbedCodeDim int
-	ChatModel    string
-	OCRModel     string
-	STTModel     string
-	STTLanguage  string // optional STT language hint (e.g. ElevenLabs)
-	TTSModel     string
-	TTSVoice     string // TTS voice id/name (e.g. ElevenLabs voice, OpenAI voice)
-	RerankModel  string
+	// EmbedMultimodal is the multimodal embedding mode (SPEC 8.1.7):
+	// "" / "off" (text-only), "augment", or "replace". augment/replace
+	// require a multimodal model on every axis; part of the embed identity
+	// (SPEC 8.1.4), so a change is reindex-bound.
+	EmbedMultimodal string
+	ChatModel       string
+	OCRModel        string
+	STTModel        string
+	STTLanguage     string // optional STT language hint (e.g. ElevenLabs)
+	TTSModel        string
+	TTSVoice        string // TTS voice id/name (e.g. ElevenLabs voice, OpenAI voice)
+	RerankModel     string
 }
 
 // Eligible reports whether the profile may be selected/preflighted
@@ -182,16 +187,29 @@ func Select(precedence []Profile, byName map[string]Profile, cap Capability, exp
 
 // EmbedIdentity is the corpus-lifetime embed identity (SPEC 8.1.4):
 // provider name + text/code model + requested text/code output dimension
-// (8.1.6). It is recorded in the config snapshot/index and compared on
-// load. Role (8.1.5) is deliberately excluded — it does not affect
-// vector-space compatibility, but the requested dimension does.
+// (8.1.6) + multimodal mode (8.1.7). It is recorded in the config
+// snapshot/index and compared on load. Role (8.1.5) is deliberately
+// excluded — it does not affect vector-space compatibility, but the
+// requested dimension and multimodal mode do.
 func EmbedIdentity(p Profile) string {
-	return fmt.Sprintf("%s|%s|%s|%d|%d",
+	return fmt.Sprintf("%s|%s|%s|%d|%d|%s",
 		strings.TrimSpace(p.Name),
 		strings.TrimSpace(p.EmbedTextModel),
 		strings.TrimSpace(p.EmbedCodeModel),
 		p.EmbedTextDim,
-		p.EmbedCodeDim)
+		p.EmbedCodeDim,
+		NormalizeEmbedMultimodal(p.EmbedMultimodal))
+}
+
+// NormalizeEmbedMultimodal lower-cases/trims the multimodal mode and maps
+// the empty value to "off", so "" and "off" are equivalent everywhere
+// (identity comparison and validation).
+func NormalizeEmbedMultimodal(mode string) string {
+	m := strings.ToLower(strings.TrimSpace(mode))
+	if m == "" {
+		return "off"
+	}
+	return m
 }
 
 // VerifyEmbedIdentity returns a *ConfigError when a recorded embed
@@ -216,17 +234,24 @@ func VerifyEmbedIdentity(recorded, current string) error {
 	}
 }
 
-// normalizeEmbedIdentity upgrades a legacy 3-field identity
-// (provider|text_model|code_model) to the current 5-field form by
-// appending the native "|0|0" dimension pair, so a corpus indexed before
-// 8.1.6 with native dimensions still matches after an upgrade. Non-legacy
-// (empty or already 5-field) values are returned unchanged.
+// normalizeEmbedIdentity upgrades a legacy recorded identity to the
+// current 6-field form before comparison, so upgrading an existing corpus
+// that used native dimensions and no multimodal mode does not force a
+// spurious reindex:
+//   - pre-8.1.6 (3 fields: provider|text|code) → append "|0|0|off"
+//   - pre-8.1.7 (5 fields: …|tdim|cdim)        → append "|off"
+//
+// Empty (fresh index) and already-6-field values are returned unchanged.
 func normalizeEmbedIdentity(id string) string {
 	if id == "" {
 		return ""
 	}
-	if strings.Count(id, "|") == 2 {
-		return id + "|0|0"
+	switch strings.Count(id, "|") {
+	case 2:
+		return id + "|0|0|off"
+	case 4:
+		return id + "|off"
+	default:
+		return id
 	}
-	return id
 }

--- a/internal/providerfactory/factory.go
+++ b/internal/providerfactory/factory.go
@@ -50,6 +50,33 @@ func validateEmbedDim(p provider.Profile) error {
 	return nil
 }
 
+// multimodalEmbedModel is the only model that serves multimodal embeddings
+// today (SPEC 8.1.7).
+const multimodalEmbedModel = "gemini-embedding-2"
+
+// validateEmbedMultimodal enforces SPEC 8.1.7. The mode must be a known
+// value; `augment`/`replace` map every modality into one shared vector
+// space, so the ENTIRE binding — provider and BOTH the text and code model
+// axes — must resolve to the multimodal model on Gemini, else CONFIG_INVALID
+// (mixing incomparable vectors in one index is forbidden, §8.1.4).
+func validateEmbedMultimodal(p provider.Profile) error {
+	mode := provider.NormalizeEmbedMultimodal(p.EmbedMultimodal)
+	switch mode {
+	case "off":
+		return nil
+	case "augment", "replace":
+		if p.Kind != provider.KindGemini ||
+			p.EmbedTextModel != multimodalEmbedModel ||
+			p.EmbedCodeModel != multimodalEmbedModel {
+			return fmt.Errorf("CONFIG_INVALID: embed.multimodal=%q requires provider=gemini with embed.text_model and embed.code_model both set to %q (got kind=%q text_model=%q code_model=%q)",
+				mode, multimodalEmbedModel, p.Kind, p.EmbedTextModel, p.EmbedCodeModel)
+		}
+		return nil
+	default:
+		return fmt.Errorf("CONFIG_INVALID: embed.multimodal=%q is invalid (expected off, augment, or replace)", mode)
+	}
+}
+
 // Embedder builds a model.Embedder for the profile (kinds: openai,
 // mistral, cohere, gemini). The per-call model still comes from the
 // caller; Default*Model is only a fallback for empty model names.
@@ -61,6 +88,11 @@ func Embedder(p provider.Profile) (model.Embedder, error) {
 	// SPEC 8.1.6 dimension validation applies to every kind (negative is
 	// always invalid; a fixed positive dim is Gemini-only).
 	if err := validateEmbedDim(p); err != nil {
+		return nil, err
+	}
+	// SPEC 8.1.7: validate the multimodal mode + its single-shared-space
+	// constraint before building any adapter.
+	if err := validateEmbedMultimodal(p); err != nil {
 		return nil, err
 	}
 	switch p.Kind {

--- a/internal/providerfactory/factory.go
+++ b/internal/providerfactory/factory.go
@@ -65,11 +65,16 @@ func validateEmbedMultimodal(p provider.Profile) error {
 	case "off":
 		return nil
 	case "augment", "replace":
+		// Trim the model fields to match provider.EmbedIdentity (which
+		// trims), so a value with incidental whitespace isn't rejected as
+		// CONFIG_INVALID when it is treated as equivalent for identity.
+		textModel := strings.TrimSpace(p.EmbedTextModel)
+		codeModel := strings.TrimSpace(p.EmbedCodeModel)
 		if p.Kind != provider.KindGemini ||
-			p.EmbedTextModel != multimodalEmbedModel ||
-			p.EmbedCodeModel != multimodalEmbedModel {
+			textModel != multimodalEmbedModel ||
+			codeModel != multimodalEmbedModel {
 			return fmt.Errorf("CONFIG_INVALID: embed.multimodal=%q requires provider=gemini with embed.text_model and embed.code_model both set to %q (got kind=%q text_model=%q code_model=%q)",
-				mode, multimodalEmbedModel, p.Kind, p.EmbedTextModel, p.EmbedCodeModel)
+				mode, multimodalEmbedModel, p.Kind, textModel, codeModel)
 		}
 		return nil
 	default:

--- a/tests/config/providers_config_test.go
+++ b/tests/config/providers_config_test.go
@@ -125,9 +125,9 @@ func TestProviders_UserOverrideAndCustomProfile(t *testing.T) {
 func TestProviders_EmbedIdentityStable(t *testing.T) {
 	t.Setenv("MISTRAL_API_KEY", "mk")
 	id := loadCfg(t, "version: 1\n").Providers().EmbedIdentity()
-	// provider|text_model|code_model|text_dim|code_dim (SPEC 8.1.4/8.1.6);
-	// default Mistral has no requested dims (native).
-	if id != "mistral|mistral-embed|codestral-embed|0|0" {
+	// provider|text_model|code_model|text_dim|code_dim|multimodal
+	// (SPEC 8.1.4/8.1.6/8.1.7); default Mistral: native dims, mode off.
+	if id != "mistral|mistral-embed|codestral-embed|0|0|off" {
 		t.Fatalf("embed identity = %q", id)
 	}
 }
@@ -155,8 +155,32 @@ func TestProviders_EmbedDimensionKnob(t *testing.T) {
 		t.Fatalf("dims = text:%d code:%d, want 1536/768", p.EmbedTextDim, p.EmbedCodeDim)
 	}
 	id := r.EmbedIdentity()
-	if !strings.HasSuffix(id, "|1536|768") {
+	if !strings.Contains(id, "|1536|768|") {
 		t.Fatalf("embed identity %q must encode requested dims", id)
+	}
+}
+
+// TestProviders_EmbedMultimodalKnob pins SPEC 8.1.7: model.embed.multimodal
+// parses, resolves onto the embed profile, and enters the embed identity.
+func TestProviders_EmbedMultimodalKnob(t *testing.T) {
+	t.Setenv("GEMINI_API_KEY", "gk")
+	yaml := "version: 1\n" +
+		"model:\n" +
+		"  embed:\n" +
+		"    provider: gemini\n" +
+		"    text_model: gemini-embedding-2\n" +
+		"    code_model: gemini-embedding-2\n" +
+		"    multimodal: augment\n"
+	r := loadCfg(t, yaml).Providers()
+	p, err := r.Resolve(provider.CapEmbed)
+	if err != nil {
+		t.Fatalf("resolve embed: %v", err)
+	}
+	if p.EmbedMultimodal != "augment" {
+		t.Fatalf("multimodal = %q, want augment", p.EmbedMultimodal)
+	}
+	if !strings.HasSuffix(r.EmbedIdentity(), "|augment") {
+		t.Fatalf("embed identity %q must encode the multimodal mode", r.EmbedIdentity())
 	}
 }
 

--- a/tests/config/providers_config_test.go
+++ b/tests/config/providers_config_test.go
@@ -155,8 +155,8 @@ func TestProviders_EmbedDimensionKnob(t *testing.T) {
 		t.Fatalf("dims = text:%d code:%d, want 1536/768", p.EmbedTextDim, p.EmbedCodeDim)
 	}
 	id := r.EmbedIdentity()
-	if !strings.Contains(id, "|1536|768|") {
-		t.Fatalf("embed identity %q must encode requested dims", id)
+	if !strings.HasSuffix(id, "|1536|768|off") {
+		t.Fatalf("embed identity %q must encode requested dims (and off mode)", id)
 	}
 }
 

--- a/tests/gemini/client_test.go
+++ b/tests/gemini/client_test.go
@@ -31,7 +31,11 @@ type nativeEmbedReq struct {
 		Model   string `json:"model"`
 		Content struct {
 			Parts []struct {
-				Text string `json:"text"`
+				Text       string `json:"text"`
+				InlineData *struct {
+					MimeType string `json:"mimeType"`
+					Data     string `json:"data"`
+				} `json:"inlineData"`
 			} `json:"parts"`
 		} `json:"content"`
 		TaskType             string `json:"taskType"`
@@ -151,6 +155,67 @@ func TestEmbed_EmptyInputsNoCall(t *testing.T) {
 // asymmetric embedder, so the role maps onto taskType —
 // document → RETRIEVAL_DOCUMENT, query → RETRIEVAL_QUERY — and a query
 // against the configured code model → CODE_RETRIEVAL_QUERY.
+// TestEmbedMedia_NativeInlineData pins SPEC 8.1.7: EmbedMedia sends each
+// item as an inline-data part (base64 + MIME) to batchEmbedContents, with
+// the role→taskType mapping, and returns one vector per item in order.
+func TestEmbedMedia_NativeInlineData(t *testing.T) {
+	var gotPath, gotTask string
+	var gotMimes, gotData []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		req := decodeNativeEmbed(t, r)
+		for _, rq := range req.Requests {
+			gotTask = rq.TaskType
+			for _, p := range rq.Content.Parts {
+				if p.InlineData != nil {
+					gotMimes = append(gotMimes, p.InlineData.MimeType)
+					gotData = append(gotData, p.InlineData.Data)
+				}
+			}
+		}
+		embs := make([]map[string]any, len(req.Requests))
+		for i := range req.Requests {
+			embs[i] = map[string]any{"values": []float64{float64(i), 0.5}}
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"embeddings": embs})
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL)
+	items := []gemini.MediaInput{
+		{MimeType: "image/png", Data: []byte("PNGBYTES")},
+		{MimeType: "audio/mp3", Data: []byte("MP3BYTES")},
+	}
+	vecs, err := c.EmbedMedia(context.Background(), "gemini-embedding-2", model.EmbedDocument, items)
+	if err != nil {
+		t.Fatalf("EmbedMedia: %v", err)
+	}
+	if len(vecs) != 2 {
+		t.Fatalf("got %d vectors, want 2", len(vecs))
+	}
+	if want := "/models/gemini-embedding-2:batchEmbedContents"; gotPath != want {
+		t.Errorf("path = %q, want %q", gotPath, want)
+	}
+	if gotTask != "RETRIEVAL_DOCUMENT" {
+		t.Errorf("taskType = %q, want RETRIEVAL_DOCUMENT", gotTask)
+	}
+	if len(gotMimes) != 2 || gotMimes[0] != "image/png" || gotMimes[1] != "audio/mp3" {
+		t.Errorf("mimes = %v, want [image/png audio/mp3]", gotMimes)
+	}
+	if d, _ := base64.StdEncoding.DecodeString(gotData[0]); string(d) != "PNGBYTES" {
+		t.Errorf("first media payload = %q, want base64(PNGBYTES)", gotData[0])
+	}
+}
+
+// TestEmbedMedia_EmptyItemErrors covers a media item with no bytes.
+func TestEmbedMedia_EmptyItemErrors(t *testing.T) {
+	c := gemini.NewClient("http://127.0.0.1:0", "k")
+	_, err := c.EmbedMedia(context.Background(), "gemini-embedding-2", model.EmbedDocument, []gemini.MediaInput{{MimeType: "image/png"}})
+	if err == nil {
+		t.Fatal("empty media item must error before any HTTP call")
+	}
+}
+
 func TestEmbed_AsymmetricRoleMapsTaskType(t *testing.T) {
 	var gotTask string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/tests/provider/provider_test.go
+++ b/tests/provider/provider_test.go
@@ -132,9 +132,9 @@ func TestSelectAutoPrecedence(t *testing.T) {
 func TestEmbedIdentity(t *testing.T) {
 	p := provider.Profile{Name: "mistral", EmbedTextModel: "mistral-embed", EmbedCodeModel: "codestral-embed"}
 	id := provider.EmbedIdentity(p)
-	// Identity is provider|text_model|code_model|text_dim|code_dim
-	// (SPEC 8.1.4/8.1.6); unset dims record as 0 (native).
-	if id != "mistral|mistral-embed|codestral-embed|0|0" {
+	// Identity is provider|text_model|code_model|text_dim|code_dim|multimodal
+	// (SPEC 8.1.4/8.1.6/8.1.7); unset dims record as 0, mode as off.
+	if id != "mistral|mistral-embed|codestral-embed|0|0|off" {
 		t.Fatalf("identity = %q", id)
 	}
 	if err := provider.VerifyEmbedIdentity("", id); err != nil {
@@ -143,7 +143,7 @@ func TestEmbedIdentity(t *testing.T) {
 	if err := provider.VerifyEmbedIdentity(id, id); err != nil {
 		t.Errorf("matching identity must pass: %v", err)
 	}
-	_ = cfgErr(t, provider.VerifyEmbedIdentity("openai|text-embedding-3-small||0|0", id))
+	_ = cfgErr(t, provider.VerifyEmbedIdentity("openai|text-embedding-3-small||0|0|off", id))
 	// A different requested output dimension is a distinct identity
 	// (reindex-bound, SPEC 8.1.6): same provider+models but dim 768 must
 	// not match the native (dim 0) identity.
@@ -152,15 +152,25 @@ func TestEmbedIdentity(t *testing.T) {
 	if native == dimmed {
 		t.Fatalf("requested dimension must change embed identity: %q == %q", native, dimmed)
 	}
-	// A legacy 3-field identity (pre-8.1.6 snapshot, no dims) must NOT
-	// force a spurious reindex against the equivalent native 5-field
-	// identity — it is normalized to "|0|0" before comparison.
-	legacy := "mistral|mistral-embed|codestral-embed"
-	if err := provider.VerifyEmbedIdentity(legacy, "mistral|mistral-embed|codestral-embed|0|0"); err != nil {
-		t.Errorf("legacy 3-field identity must match native 5-field: %v", err)
+	// A different multimodal mode is a distinct identity (reindex-bound,
+	// SPEC 8.1.7).
+	mm := provider.EmbedIdentity(provider.Profile{Name: "gemini", EmbedTextModel: "gemini-embedding-2", EmbedCodeModel: "gemini-embedding-2", EmbedMultimodal: "augment"})
+	if mm == provider.EmbedIdentity(provider.Profile{Name: "gemini", EmbedTextModel: "gemini-embedding-2", EmbedCodeModel: "gemini-embedding-2"}) {
+		t.Fatalf("multimodal mode must change embed identity")
+	}
+	// Legacy identities must NOT force a spurious reindex against the
+	// equivalent current identity: a 3-field (pre-8.1.6) normalizes to
+	// "|0|0|off" and a 5-field (pre-8.1.7) to "|off".
+	legacy3 := "mistral|mistral-embed|codestral-embed"
+	if err := provider.VerifyEmbedIdentity(legacy3, "mistral|mistral-embed|codestral-embed|0|0|off"); err != nil {
+		t.Errorf("legacy 3-field identity must match native current: %v", err)
+	}
+	legacy5 := "mistral|mistral-embed|codestral-embed|0|0"
+	if err := provider.VerifyEmbedIdentity(legacy5, "mistral|mistral-embed|codestral-embed|0|0|off"); err != nil {
+		t.Errorf("legacy 5-field identity must match off-mode current: %v", err)
 	}
 	// But a legacy identity vs a non-native dimension still mismatches.
-	_ = cfgErr(t, provider.VerifyEmbedIdentity(legacy, "mistral|mistral-embed|codestral-embed|768|0"))
+	_ = cfgErr(t, provider.VerifyEmbedIdentity(legacy3, "mistral|mistral-embed|codestral-embed|768|0|off"))
 }
 
 func mustErr(_ provider.Profile, err error) error {

--- a/tests/providerfactory/factory_test.go
+++ b/tests/providerfactory/factory_test.go
@@ -136,6 +136,43 @@ func TestEmbedder_DimRejectedForNonGemini(t *testing.T) {
 	}
 }
 
+// TestEmbedder_Multimodal pins SPEC 8.1.7: augment/replace require
+// provider=gemini with both embed models = gemini-embedding-2; off and any
+// other binding combination behave accordingly.
+func TestEmbedder_Multimodal(t *testing.T) {
+	good := provider.Profile{
+		Name: "gemini", Kind: provider.KindGemini, APIKey: "k",
+		EmbedTextModel: "gemini-embedding-2", EmbedCodeModel: "gemini-embedding-2",
+	}
+	for _, mode := range []string{"augment", "replace"} {
+		p := good
+		p.EmbedMultimodal = mode
+		if _, err := providerfactory.Embedder(p); err != nil {
+			t.Errorf("mode %q with gemini-embedding-2 on both axes must be valid: %v", mode, err)
+		}
+	}
+	// off (and empty) is always valid, including on non-gemini providers.
+	for _, p := range []provider.Profile{
+		{Name: "mistral", Kind: provider.KindOpenAI, APIKey: "k", EmbedMultimodal: "off"},
+		{Name: "mistral", Kind: provider.KindOpenAI, APIKey: "k"},
+	} {
+		if _, err := providerfactory.Embedder(p); err != nil {
+			t.Errorf("off/empty multimodal must be valid: %v", err)
+		}
+	}
+	// Invalid combinations are CONFIG_INVALID.
+	bad := []provider.Profile{
+		{Name: "mistral", Kind: provider.KindOpenAI, APIKey: "k", EmbedTextModel: "mistral-embed", EmbedCodeModel: "mistral-embed", EmbedMultimodal: "augment"},            // wrong kind/model
+		{Name: "gemini", Kind: provider.KindGemini, APIKey: "k", EmbedTextModel: "gemini-embedding-2", EmbedCodeModel: "gemini-embedding-001", EmbedMultimodal: "replace"}, // code axis not multimodal
+		{Name: "gemini", Kind: provider.KindGemini, APIKey: "k", EmbedTextModel: "gemini-embedding-2", EmbedCodeModel: "gemini-embedding-2", EmbedMultimodal: "bogus"},     // unknown mode
+	}
+	for i, p := range bad {
+		if _, err := providerfactory.Embedder(p); err == nil {
+			t.Errorf("bad multimodal config #%d must be CONFIG_INVALID, got nil", i)
+		}
+	}
+}
+
 // TestEmbedder_NegativeDimRejected pins SPEC 8.1.6: a negative dimension is
 // CONFIG_INVALID for every kind, including Gemini (it would otherwise form
 // a distinct identity yet behave like "unset" at runtime).


### PR DESCRIPTION
Phase 1 of multimodal embeddings (`gemini-embedding-2`), gated on spec 0.13.0 (dirstral-spec#13, merged). Re-pins the submodule to merge commit `9f11d31`. **Default-off** — this wires the provider plumbing only; the ingestion/store/retrieval pipeline that produces media chunks is a later phase, so `multimodal: off` (default) is the only behavior change-free setting.

## What this slice does
- **Config** — `model.embed.multimodal: off | augment | replace` parsed and resolved onto the embed profile.
- **Validation (SPEC §8.1.7)** — `validateEmbedMultimodal`: `augment`/`replace` require `provider: gemini` with **both** `embed.text_model` **and** `embed.code_model` set to `gemini-embedding-2` (single shared space, §8.1.4), else `CONFIG_INVALID`; an unknown mode is rejected. Runs for every kind in the factory before any adapter is built.
- **Embed identity (SPEC §8.1.4)** — now `provider|text|code|text_dim|code_dim|mode`; legacy 3-field (pre-8.1.6) and 5-field (pre-8.1.7) recorded identities are normalized to the 6-field form, so upgrading an existing native/off corpus does **not** force a spurious reindex.
- **Adapter (SPEC §8.1.7)** — `gemini.Client.EmbedMedia(ctx, model, role, []MediaInput)` sends each item as an inline-data part (`mimeType` + base64) to the native `batchEmbedContents`, with the role→`taskType` mapping and dimension/normalization, sharing a refactored reqs-based batch/retry core with the text `Embed` path.

## Explicitly NOT in this slice
Ingestion media-chunking, store columns, cross-modal retrieval, `ask` grounding, `replace`-mode `open_file`/`MEDIA_NO_TEXT` — these are the next phases per [Design 0003](https://github.com/dirstral/dirstral-spec/blob/main/docs/design/0003-multimodal-embeddings.md). The model is Public Preview, so the adapter is wired but pipeline activation is deferred.

## Tests
- `tests/provider`: identity includes the mode; legacy 3/5-field normalization match/mismatch.
- `tests/providerfactory`: multimodal validation matrix (valid augment/replace; off/empty always valid; wrong kind/model and unknown mode → `CONFIG_INVALID`).
- `tests/config`: `multimodal` knob parses + enters identity.
- `tests/gemini`: `EmbedMedia` native inline-data path (path, `taskType`, MIME + base64 payload, order), empty-item guard.
- `make check` green (gofmt, vet, golangci-lint 0 issues, gocyclo, ineffassign, misspell, full `go test`, build).