### PR TITLE
feat(ingest): multimodal image embedding under augment/replace (spec 8.1.7)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(brew info *)",
+      "Bash(brew list *)",
+      "Bash(brew outdated *)"
+    ]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -293,7 +293,22 @@ model:
 
 #### Multimodal embeddings (`gemini-embedding-2`, preview — in progress)
 
-Spec §8.1.7 (0.13.0) defines an opt-in `model.embed.multimodal` mode (`off` default | `augment` | `replace`) that embeds images/audio/video/PDFs directly into the same vector space via the multimodal `gemini-embedding-2` model. This is being implemented in phases against a **Public Preview** model: the current build wires the provider plumbing (the `gemini-embedding-2` adapter with media-part embedding, the config knob, and the all-axes validation that `augment`/`replace` require `provider: gemini` with `text_model` and `code_model` both `gemini-embedding-2`), but the ingestion/retrieval pipeline that produces media chunks is **not wired yet** — so leaving `multimodal: off` (the default) is the only supported setting for now. See [Design 0003](dirstral-spec/docs/design/0003-multimodal-embeddings.md).
+Spec §8.1.7 (0.13.0) defines an opt-in `model.embed.multimodal` mode (`off` default | `augment` | `replace`) that embeds media directly into the same vector space via the multimodal `gemini-embedding-2` model. It is being implemented in phases against a **Public Preview** model:
+
+```yaml
+model:
+  embed:
+    provider: gemini
+    text_model: gemini-embedding-2
+    code_model: gemini-embedding-2
+    multimodal: augment      # off (default) | augment | replace
+```
+
+- **Images** are supported today: under `augment` an image is indexed *both* as OCR text (if an extractor is configured) and as a direct image embedding; under `replace` it is embedded directly *instead of* OCR. A text query then retrieves images from the shared space.
+- **PDF, audio, and video** media chunking is **not wired yet** (follow-up phases); those still go through the existing OCR/STT→text path regardless of mode.
+- `augment`/`replace` require `provider: gemini` with `text_model` and `code_model` both `gemini-embedding-2` (validated at startup; otherwise `CONFIG_INVALID`), and the mode is reindex-bound (§8.1.4). `off` (default) is fully behavior-preserving.
+
+See [Design 0003](dirstral-spec/docs/design/0003-multimodal-embeddings.md).
 
 ### Server identity
 

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -115,7 +115,7 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 	defer a.stopPersistenceWithLog(persistence)
 
 	embedErrCh := make(chan error, 4)
-	startEmbeddingIfNotReadOnly(runCtx, opts.readOnly, st, textIx, codeIx, embedder, ret, indexingState, embedErrCh, a.stderr, opts.jsonOutput, etm, ecm)
+	startEmbeddingIfNotReadOnly(runCtx, opts.readOnly, st, textIx, codeIx, embedder, ret, indexingState, embedErrCh, a.stderr, opts.jsonOutput, etm, ecm, cfg.RootDir)
 
 	mcpAddr := ln.Addr().String()
 	if cfg.Public {
@@ -683,7 +683,7 @@ func startEmbeddingWorkers(
 	indexingState *appstate.IndexingState,
 	errCh chan<- error,
 	logger *log.Logger,
-	textModel, codeModel string,
+	textModel, codeModel, rootDir string,
 ) {
 	if st == nil || embedder == nil {
 		return
@@ -700,6 +700,7 @@ func startEmbeddingWorkers(
 			Embedder:     embedder,
 			ModelForText: textModel,
 			ModelForCode: codeModel,
+			RootDir:      rootDir,
 			BatchSize:    32,
 			Logger:       logger,
 			OnIndexedChunk: func(label uint64, metadata model.ChunkMetadata) {
@@ -793,7 +794,7 @@ func (a *App) stopPersistenceWithLog(persistence *index.PersistenceManager) {
 
 // startEmbeddingIfNotReadOnly starts embedding workers when readOnly is false
 // and the store exposes the ChunkSource interface.
-func startEmbeddingIfNotReadOnly(ctx context.Context, readOnly bool, st model.Store, textIx, codeIx model.Index, embedder model.Embedder, ret *retrieval.Service, indexingState *appstate.IndexingState, embedErrCh chan error, stderr io.Writer, jsonOutput bool, embedModelText, embedModelCode string) {
+func startEmbeddingIfNotReadOnly(ctx context.Context, readOnly bool, st model.Store, textIx, codeIx model.Index, embedder model.Embedder, ret *retrieval.Service, indexingState *appstate.IndexingState, embedErrCh chan error, stderr io.Writer, jsonOutput bool, embedModelText, embedModelCode, rootDir string) {
 	if readOnly {
 		return
 	}
@@ -802,7 +803,7 @@ func startEmbeddingIfNotReadOnly(ctx context.Context, readOnly bool, st model.St
 		return
 	}
 	embedLogger := pickEmbedLogger(stderr, jsonOutput)
-	startEmbeddingWorkers(ctx, chunkSource, textIx, codeIx, embedder, ret, indexingState, embedErrCh, embedLogger, embedModelText, embedModelCode)
+	startEmbeddingWorkers(ctx, chunkSource, textIx, codeIx, embedder, ret, indexingState, embedErrCh, embedLogger, embedModelText, embedModelCode, rootDir)
 }
 
 // printHumanConnectionIfVerbose prints the human-readable connection block

--- a/internal/gemini/client.go
+++ b/internal/gemini/client.go
@@ -110,9 +110,10 @@ type Client struct {
 
 // compile-time assertions that *Client implements the model contracts.
 var (
-	_ model.Embedder    = (*Client)(nil)
-	_ model.Generator   = (*Client)(nil)
-	_ model.Transcriber = (*Client)(nil)
+	_ model.Embedder           = (*Client)(nil)
+	_ model.MultimodalEmbedder = (*Client)(nil)
+	_ model.Generator          = (*Client)(nil)
+	_ model.Transcriber        = (*Client)(nil)
 )
 
 // NewClient constructs a client with safe default retry/timeout settings.
@@ -148,13 +149,6 @@ type geminiEmbedSingleRequest struct {
 	Content              geminiContent `json:"content"`
 	TaskType             string        `json:"taskType,omitempty"`
 	OutputDimensionality *int          `json:"outputDimensionality,omitempty"`
-}
-
-// MediaInput is one non-text item to embed (SPEC 8.1.7): the media bytes
-// plus their MIME type (e.g. "image/png", "audio/mp3", "application/pdf").
-type MediaInput struct {
-	MimeType string
-	Data     []byte
 }
 
 type geminiBatchEmbedRequest struct {
@@ -193,7 +187,7 @@ func (c *Client) Embed(ctx context.Context, modelName string, role model.EmbedRo
 // same native batchEmbedContents surface, sending each item as an
 // inline-data part (SPEC 8.1.7). Role→taskType and dimension/normalization
 // behave as for Embed.
-func (c *Client) EmbedMedia(ctx context.Context, modelName string, role model.EmbedRole, items []MediaInput) ([][]float32, error) {
+func (c *Client) EmbedMedia(ctx context.Context, modelName string, role model.EmbedRole, items []model.MediaInput) ([][]float32, error) {
 	modelName, dim, taskType, err := c.embedParams(modelName, role)
 	if err != nil {
 		return nil, err

--- a/internal/index/embedding_worker.go
+++ b/internal/index/embedding_worker.go
@@ -172,11 +172,21 @@ func (w *EmbeddingWorker) loadMediaInput(t model.ChunkTask) (model.MediaInput, e
 	if err != nil {
 		return model.MediaInput{}, fmt.Errorf("%w: resolve root: %v", ErrFatal, err)
 	}
-	abs := filepath.Join(root, filepath.FromSlash(ref))
-	if abs != root && !strings.HasPrefix(abs, root+string(os.PathSeparator)) {
+	// Resolve symlinks on both the root and the target so a symlink *within*
+	// the corpus that points outside it cannot smuggle out-of-root bytes in
+	// (a lexical Join+HasPrefix check alone would miss that).
+	realRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		realRoot = root // root should exist; fall back to the lexical form
+	}
+	resolved, err := filepath.EvalSymlinks(filepath.Join(realRoot, filepath.FromSlash(ref)))
+	if err != nil {
+		return model.MediaInput{}, fmt.Errorf("read media %q: %w", ref, err)
+	}
+	if resolved != realRoot && !strings.HasPrefix(resolved, realRoot+string(os.PathSeparator)) {
 		return model.MediaInput{}, fmt.Errorf("%w: media_ref %q escapes the corpus root", ErrFatal, ref)
 	}
-	data, err := os.ReadFile(abs)
+	data, err := os.ReadFile(resolved)
 	if err != nil {
 		return model.MediaInput{}, fmt.Errorf("read media %q: %w", ref, err)
 	}

--- a/internal/index/embedding_worker.go
+++ b/internal/index/embedding_worker.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -34,6 +36,12 @@ type EmbeddingWorker struct {
 	ModelForCode   string
 	BatchSize      int
 	OnIndexedChunk func(label uint64, metadata model.ChunkMetadata)
+
+	// RootDir is the corpus root used to resolve a media chunk's MediaRef
+	// (a corpus rel_path) to bytes for multimodal embedding (SPEC 8.1.7).
+	// Required only when media chunks are present; text-only corpora may
+	// leave it empty.
+	RootDir string
 
 	// Logger is optional; if non‑nil its Printf method will be used for
 	// informational messages. When nil the standard library's log package
@@ -90,6 +98,128 @@ func buildEmbedBatch(tasks []model.ChunkTask) (validTasks []model.ChunkTask, inp
 		labels = append(labels, chunkID)
 	}
 	return validTasks, inputs, labels, nil
+}
+
+// embedTasks embeds validTasks and returns vectors aligned 1:1 with them:
+// text chunks go through Embedder.Embed, media chunks (SPEC 8.1.7) through
+// MultimodalEmbedder.EmbedMedia after their bytes are read from RootDir.
+// Both kinds share one model + vector space.
+func (w *EmbeddingWorker) embedTasks(ctx context.Context, modelName string, validTasks []model.ChunkTask) ([][]float32, error) {
+	vectors := make([][]float32, len(validTasks))
+
+	textIdx := make([]int, 0, len(validTasks))
+	textInputs := make([]string, 0, len(validTasks))
+	mediaIdx := make([]int, 0)
+	mediaItems := make([]model.MediaInput, 0)
+	for i, t := range validTasks {
+		if isMediaModality(t.Modality) {
+			item, err := w.loadMediaInput(t)
+			if err != nil {
+				return nil, err
+			}
+			mediaIdx = append(mediaIdx, i)
+			mediaItems = append(mediaItems, item)
+			continue
+		}
+		textIdx = append(textIdx, i)
+		textInputs = append(textInputs, t.Text)
+	}
+
+	if len(textInputs) > 0 {
+		v, err := w.Embedder.Embed(ctx, modelName, model.EmbedDocument, textInputs)
+		if err != nil {
+			return nil, err
+		}
+		if len(v) != len(textInputs) {
+			return nil, fmt.Errorf("%w: embedding vector count mismatch", ErrFatal)
+		}
+		for k, idx := range textIdx {
+			vectors[idx] = v[k]
+		}
+	}
+
+	if len(mediaItems) > 0 {
+		me, ok := w.Embedder.(model.MultimodalEmbedder)
+		if !ok {
+			return nil, fmt.Errorf("%w: embedder %T does not support media (multimodal) embedding", ErrFatal, w.Embedder)
+		}
+		v, err := me.EmbedMedia(ctx, modelName, model.EmbedDocument, mediaItems)
+		if err != nil {
+			return nil, err
+		}
+		if len(v) != len(mediaItems) {
+			return nil, fmt.Errorf("%w: embedding vector count mismatch", ErrFatal)
+		}
+		for k, idx := range mediaIdx {
+			vectors[idx] = v[k]
+		}
+	}
+	return vectors, nil
+}
+
+// loadMediaInput reads a media chunk's source bytes (resolved from RootDir +
+// MediaRef) and infers its MIME type. The resolved path is constrained to
+// RootDir as defense-in-depth against a traversal in a stored ref.
+func (w *EmbeddingWorker) loadMediaInput(t model.ChunkTask) (model.MediaInput, error) {
+	ref := strings.TrimSpace(t.MediaRef)
+	if ref == "" {
+		return model.MediaInput{}, fmt.Errorf("%w: media chunk %d has no media_ref", ErrFatal, t.Metadata.ChunkID)
+	}
+	if strings.TrimSpace(w.RootDir) == "" {
+		return model.MediaInput{}, fmt.Errorf("%w: media embedding requires a corpus root", ErrFatal)
+	}
+	root, err := filepath.Abs(w.RootDir)
+	if err != nil {
+		return model.MediaInput{}, fmt.Errorf("%w: resolve root: %v", ErrFatal, err)
+	}
+	abs := filepath.Join(root, filepath.FromSlash(ref))
+	if abs != root && !strings.HasPrefix(abs, root+string(os.PathSeparator)) {
+		return model.MediaInput{}, fmt.Errorf("%w: media_ref %q escapes the corpus root", ErrFatal, ref)
+	}
+	data, err := os.ReadFile(abs)
+	if err != nil {
+		return model.MediaInput{}, fmt.Errorf("read media %q: %w", ref, err)
+	}
+	return model.MediaInput{MimeType: mediaMIMEType(ref), Data: data}, nil
+}
+
+// isMediaModality reports whether a chunk modality denotes embeddable media.
+func isMediaModality(modality string) bool {
+	switch strings.ToLower(strings.TrimSpace(modality)) {
+	case "image", "audio", "video", "pdf":
+		return true
+	default:
+		return false
+	}
+}
+
+// mediaMIMEType maps a file extension to a MIME type for multimodal
+// embedding, defaulting to application/octet-stream.
+func mediaMIMEType(relPath string) string {
+	switch strings.ToLower(strings.TrimPrefix(filepath.Ext(relPath), ".")) {
+	case "png":
+		return "image/png"
+	case "jpg", "jpeg":
+		return "image/jpeg"
+	case "webp":
+		return "image/webp"
+	case "gif":
+		return "image/gif"
+	case "bmp":
+		return "image/bmp"
+	case "pdf":
+		return "application/pdf"
+	case "mp3":
+		return "audio/mp3"
+	case "wav":
+		return "audio/wav"
+	case "mp4":
+		return "video/mp4"
+	case "mov":
+		return "video/quicktime"
+	default:
+		return "application/octet-stream"
+	}
 }
 
 // indexChunks adds each vector to the index and fires the OnIndexedChunk hook.
@@ -168,12 +298,14 @@ func (w *EmbeddingWorker) RunOnce(ctx context.Context, indexKind string) (int, e
 	}
 
 	modelName := w.modelForKind(indexKind)
-	validTasks, inputs, labels, err := buildEmbedBatch(tasks)
+	validTasks, _, labels, err := buildEmbedBatch(tasks)
 	if err != nil {
 		return 0, err
 	}
 
-	vectors, err := w.Embedder.Embed(ctx, modelName, model.EmbedDocument, inputs)
+	// Text chunks embed via Embed; media chunks (SPEC 8.1.7) embed via
+	// EmbedMedia. embedTasks returns vectors aligned 1:1 with validTasks.
+	vectors, err := w.embedTasks(ctx, modelName, validTasks)
 	if err != nil {
 		// distinguish between transient errors (which we want to retry later)
 		// and permanent failures for which the chunks should be marked as

--- a/internal/ingest/represent.go
+++ b/internal/ingest/represent.go
@@ -26,12 +26,11 @@ var transcriptTimestampBareRe = regexp.MustCompile(`^\s*(\d{1,2}):(\d{2})(?::(\d
 
 const (
 	// RepTypeRawText is the representation type for raw text content
+	RepTypeRawText = "raw_text"
 	// RepTypeMedia is a chunk embedded directly from source media bytes via
 	// the multimodal embedder (SPEC 8.1.7), as opposed to extracted/transcribed
 	// text. The chunk has no text body; its bytes live at the document path.
 	RepTypeMedia = "media"
-
-	RepTypeRawText = "raw_text"
 	// RepTypeExtractedMarkdown is the representation type for extractor-generated markdown
 	RepTypeExtractedMarkdown = "extracted_markdown"
 	// RepTypeOCRMarkdown is retained as a backward-compatible alias.

--- a/internal/ingest/represent.go
+++ b/internal/ingest/represent.go
@@ -26,6 +26,11 @@ var transcriptTimestampBareRe = regexp.MustCompile(`^\s*(\d{1,2}):(\d{2})(?::(\d
 
 const (
 	// RepTypeRawText is the representation type for raw text content
+	// RepTypeMedia is a chunk embedded directly from source media bytes via
+	// the multimodal embedder (SPEC 8.1.7), as opposed to extracted/transcribed
+	// text. The chunk has no text body; its bytes live at the document path.
+	RepTypeMedia = "media"
+
 	RepTypeRawText = "raw_text"
 	// RepTypeExtractedMarkdown is the representation type for extractor-generated markdown
 	RepTypeExtractedMarkdown = "extracted_markdown"
@@ -142,6 +147,45 @@ func (rg *RepresentationGenerator) GenerateRawTextFromContent(ctx context.Contex
 		return nil
 	})
 }
+
+// GenerateMediaChunk emits a single media chunk for a whole-file media
+// document (currently images) so it is embedded directly from its bytes via
+// the multimodal embedder (SPEC 8.1.7), rather than via extracted text. The
+// chunk carries no text; the embedding worker reads its bytes from MediaRef
+// (the corpus rel_path). Provenance is a page-1 span. contentHash dedups the
+// representation across unchanged re-ingests.
+func (rg *RepresentationGenerator) GenerateMediaChunk(ctx context.Context, doc model.Document, contentHash string) error {
+	rep := model.Representation{
+		DocID:       doc.DocID,
+		RepType:     RepTypeMedia,
+		RepHash:     contentHash,
+		CreatedUnix: time.Now().Unix(),
+		Deleted:     false,
+	}
+	return rg.store.WithTx(ctx, func(tx model.RepresentationStore) error {
+		repID, err := tx.UpsertRepresentation(ctx, rep)
+		if err != nil {
+			return fmt.Errorf("upsert media representation: %w", err)
+		}
+		chunk := model.Chunk{
+			RepID:           repID,
+			Ordinal:         0,
+			Text:            "",
+			IndexKind:       "text", // media shares the text vector space
+			EmbeddingStatus: "pending",
+			Modality:        doc.DocType, // "image" today; audio/video/pdf later
+			MediaRef:        doc.RelPath,
+		}
+		if _, err := tx.InsertChunkWithSpans(ctx, chunk, []model.Span{{Kind: "page", Page: 1}}); err != nil {
+			return fmt.Errorf("insert media chunk: %w", err)
+		}
+		if err := tx.SoftDeleteChunksFromOrdinal(ctx, repID, 1); err != nil {
+			return fmt.Errorf("soft delete stale media chunks: %w", err)
+		}
+		return nil
+	})
+}
+
 func (rg *RepresentationGenerator) upsertChunksForRepresentation(ctx context.Context, repID int64, indexKind string, segments []chunkSegment) error {
 	// wrap the entire operation in a transaction so we don't end up with a
 	// partial set of chunks if an insertion fails halfway through.  The store

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -49,6 +49,12 @@ type Service struct {
 	extractor     model.DocumentExtractor
 	transcriber   model.Transcriber
 
+	// embedMultimodal is the resolved multimodal embedding mode (SPEC
+	// 8.1.7): "off" (default), "augment", or "replace". When augment/
+	// replace, media documents additionally (or exclusively) get a media
+	// chunk embedded directly from their bytes.
+	embedMultimodal string
+
 	// optional logger for diagnostics; defaults to log.Default() when nil.
 	// Tests can provide their own logger to avoid mutating global state.
 	// Access must go through the logger() helper or SetLogger; the field
@@ -127,6 +133,11 @@ func NewService(cfg config.Config, store model.Store) (*Service, error) {
 	svc.transcriber = transcriber
 	if rs, ok := store.(model.RepresentationStore); ok {
 		svc.repGen = NewRepresentationGenerator(rs)
+	}
+	// Resolve the multimodal embedding mode once (SPEC 8.1.7); a missing or
+	// unresolvable embed profile leaves it off (text-only).
+	if ep, err := cfg.Providers().Resolve(provider.CapEmbed); err == nil {
+		svc.embedMultimodal = provider.NormalizeEmbedMultimodal(ep.EmbedMultimodal)
 	}
 	return svc, nil
 }
@@ -880,6 +891,30 @@ func (s *Service) addRepresentations(delta int64) {
 	}
 }
 
+// generateExtractedAndMediaRepresentations handles non-text "visual"
+// documents: the OCR/extractor text representation and, under multimodal
+// augment/replace (SPEC 8.1.7), a direct media chunk. In `replace` an image
+// is embedded from its bytes instead of via OCR→text (OCR is skipped);
+// `augment` keeps OCR and adds the media chunk.
+func (s *Service) generateExtractedAndMediaRepresentations(ctx context.Context, doc model.Document, content []byte) error {
+	embedImage := (s.embedMultimodal == "augment" || s.embedMultimodal == "replace") && doc.DocType == "image"
+	skipOCR := s.embedMultimodal == "replace" && doc.DocType == "image"
+
+	if ShouldGenerateExtractedMarkdown(doc.DocType) && s.extractor != nil && !skipOCR {
+		if err := s.generateOCRMarkdownRepresentation(ctx, doc, content); err != nil {
+			return err
+		}
+		s.addRepresentations(1)
+	}
+	if embedImage {
+		if err := s.repGen.GenerateMediaChunk(ctx, doc, computeRepHash(content)); err != nil {
+			return err
+		}
+		s.addRepresentations(1)
+	}
+	return nil
+}
+
 func (s *Service) generateRepresentations(ctx context.Context, doc model.Document, content []byte) error {
 	if s.repGen == nil {
 		return nil
@@ -902,11 +937,8 @@ func (s *Service) generateRepresentations(ctx context.Context, doc model.Documen
 		return nil
 	}
 
-	if ShouldGenerateExtractedMarkdown(doc.DocType) && s.extractor != nil {
-		if err := s.generateOCRMarkdownRepresentation(ctx, doc, content); err != nil {
-			return err
-		}
-		s.addRepresentations(1)
+	if err := s.generateExtractedAndMediaRepresentations(ctx, doc, content); err != nil {
+		return err
 	}
 	if doc.DocType == "audio" && s.transcriber != nil {
 		if err := s.generateTranscriptRepresentation(ctx, doc, content); err != nil {

--- a/internal/model/interfaces.go
+++ b/internal/model/interfaces.go
@@ -71,6 +71,24 @@ type Embedder interface {
 	Embed(ctx context.Context, model string, role EmbedRole, inputs []string) ([][]float32, error)
 }
 
+// MediaInput is one non-text item to embed (SPEC 8.1.7): the media bytes
+// plus their MIME type (e.g. "image/png", "audio/mp3", "application/pdf").
+type MediaInput struct {
+	MimeType string
+	Data     []byte
+}
+
+// MultimodalEmbedder is an optional capability for embedders that can embed
+// non-text media into the SAME vector space as text (SPEC 8.1.7). The
+// embedding worker type-asserts the configured Embedder against this to
+// embed media chunks; an embedder that does not implement it cannot serve a
+// multimodal corpus (validation rejects that config upstream). Vectors MUST
+// be comparable to those from Embed (same provider/model/dimension).
+type MultimodalEmbedder interface {
+	Embedder
+	EmbedMedia(ctx context.Context, model string, role EmbedRole, items []MediaInput) ([][]float32, error)
+}
+
 type OCR interface {
 	Extract(ctx context.Context, relPath string, data []byte) (string, error)
 }

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -47,6 +47,13 @@ type Chunk struct {
 	EmbeddingStatus string
 	EmbeddingError  string
 	Deleted         bool
+	// Modality is the chunk's content modality for multimodal embeddings
+	// (SPEC 8.1.7): "" / "text" (default), or "image"/"audio"/"video"/"pdf".
+	Modality string
+	// MediaRef is the corpus rel_path of the source media for a non-text
+	// chunk; the embedding worker reads those bytes and embeds them
+	// directly. Empty for text chunks.
+	MediaRef string
 }
 
 type Span struct {
@@ -153,6 +160,11 @@ type ChunkTask struct {
 	Text      string
 	IndexKind string
 	Metadata  ChunkMetadata
+	// Modality / MediaRef carry multimodal-chunk info (SPEC 8.1.7): for a
+	// non-text chunk, Modality is image/audio/video/pdf and MediaRef is the
+	// corpus rel_path whose bytes the worker embeds. Empty/"text" for text.
+	Modality string
+	MediaRef string
 }
 
 // NewChunkTask returns a task with the supplied components. If the provided

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -1878,8 +1878,16 @@ func normalizeIndexKind(indexKind string) string {
 // an empty text body for media chunks (SPEC 8.1.7) — a media chunk carries no
 // text; its bytes are read from media_ref at embed time.
 func validateChunkText(chunk model.Chunk) error {
-	if strings.TrimSpace(chunk.Text) == "" && normalizeModality(chunk.Modality) == "text" {
-		return errors.New("chunk text must be non-empty")
+	if normalizeModality(chunk.Modality) == "text" {
+		if strings.TrimSpace(chunk.Text) == "" {
+			return errors.New("chunk text must be non-empty")
+		}
+		return nil
+	}
+	// A media chunk carries no text but MUST reference its source bytes, so
+	// the failure is deterministic at write time rather than later at embed.
+	if strings.TrimSpace(chunk.MediaRef) == "" {
+		return errors.New("media chunk must have a media_ref")
 	}
 	return nil
 }

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -207,8 +207,8 @@ func lookupChunkDocContext(ctx context.Context, exec dbExecutor, repID int64) (r
 func insertChunkWithSpansWith(ctx context.Context, exec dbExecutor, chunk model.Chunk, spans []model.Span, relPath, docType, repType string) (int64, error) {
 	_, err := exec.ExecContext(
 		ctx,
-		`INSERT INTO chunks(rep_id, ordinal, rel_path, doc_type, rep_type, text, text_hash, tokens_est, index_kind, embedding_status, embedding_error, deleted)
-		 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`INSERT INTO chunks(rep_id, ordinal, rel_path, doc_type, rep_type, text, text_hash, tokens_est, index_kind, modality, media_ref, embedding_status, embedding_error, deleted)
+		 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		 ON CONFLICT(rep_id, ordinal) DO UPDATE SET
 		   rel_path=excluded.rel_path,
 		   doc_type=excluded.doc_type,
@@ -217,6 +217,8 @@ func insertChunkWithSpansWith(ctx context.Context, exec dbExecutor, chunk model.
 		   text_hash=excluded.text_hash,
 		   tokens_est=excluded.tokens_est,
 		   index_kind=excluded.index_kind,
+		   modality=excluded.modality,
+		   media_ref=excluded.media_ref,
 		   embedding_status=excluded.embedding_status,
 		   embedding_error=excluded.embedding_error,
 		   deleted=excluded.deleted`,
@@ -229,6 +231,8 @@ func insertChunkWithSpansWith(ctx context.Context, exec dbExecutor, chunk model.
 		strings.TrimSpace(chunk.TextHash),
 		0,
 		normalizeIndexKind(chunk.IndexKind),
+		normalizeModality(chunk.Modality),
+		strings.TrimSpace(chunk.MediaRef),
 		normalizeEmbeddingStatus(chunk.EmbeddingStatus),
 		strings.TrimSpace(chunk.EmbeddingError),
 		boolToInt(chunk.Deleted),
@@ -343,6 +347,13 @@ func applyAdditiveColumnMigrations(ctx context.Context, db *sql.DB) error {
 		// bundle's list-files.json so maintainers can tell *why* a doc
 		// failed without grepping server.log.
 		`ALTER TABLE documents ADD COLUMN error_message TEXT NOT NULL DEFAULT ''`,
+		// modality / media_ref support multimodal embeddings (SPEC 8.1.7):
+		// modality is text|image|audio|video|pdf; media_ref is the corpus
+		// rel_path of the source media for a non-text chunk (the embedding
+		// worker reads those bytes and embeds them directly). Text chunks
+		// keep modality='text', media_ref=''.
+		`ALTER TABLE chunks ADD COLUMN modality TEXT NOT NULL DEFAULT 'text'`,
+		`ALTER TABLE chunks ADD COLUMN media_ref TEXT NOT NULL DEFAULT ''`,
 	}
 	for _, stmt := range migrations {
 		if _, err := db.ExecContext(ctx, stmt); err != nil && !isDuplicateColumnError(err) {
@@ -416,6 +427,8 @@ CREATE TABLE IF NOT EXISTS chunks (
   text_hash TEXT NOT NULL DEFAULT '',
   tokens_est INTEGER NOT NULL DEFAULT 0,
   index_kind TEXT NOT NULL DEFAULT 'text',
+  modality TEXT NOT NULL DEFAULT 'text',
+  media_ref TEXT NOT NULL DEFAULT '',
   embedding_status TEXT NOT NULL DEFAULT 'pending',
   embedding_error TEXT NOT NULL DEFAULT '',
   error_category TEXT NOT NULL DEFAULT '',
@@ -682,8 +695,8 @@ func (s *SQLiteStore) InsertChunkWithSpans(ctx context.Context, chunk model.Chun
 	if chunk.RepID <= 0 {
 		return 0, errors.New("rep_id must be > 0")
 	}
-	if strings.TrimSpace(chunk.Text) == "" {
-		return 0, errors.New("chunk text must be non-empty")
+	if err := validateChunkText(chunk); err != nil {
+		return 0, err
 	}
 
 	db, err := s.ensureDB(ctx)
@@ -799,8 +812,8 @@ func (t *txSQLiteStore) InsertChunkWithSpans(ctx context.Context, chunk model.Ch
 	if chunk.RepID <= 0 {
 		return 0, errors.New("rep_id must be > 0")
 	}
-	if strings.TrimSpace(chunk.Text) == "" {
-		return 0, errors.New("chunk text must be non-empty")
+	if err := validateChunkText(chunk); err != nil {
+		return 0, err
 	}
 
 	relPath, docType, repType, err := lookupChunkDocContext(ctx, t.tx, chunk.RepID)
@@ -1229,7 +1242,7 @@ func (s *SQLiteStore) NextPending(ctx context.Context, limit int, indexKind stri
 
 	args := []any{"pending"}
 	query := `WITH filtered_chunks AS (
-	            SELECT c.chunk_id, c.rel_path, c.doc_type, c.rep_type, c.text, c.index_kind
+	            SELECT c.chunk_id, c.rel_path, c.doc_type, c.rep_type, c.text, c.index_kind, c.modality, c.media_ref
 	            FROM chunks c
 	            WHERE c.embedding_status = ? AND c.deleted = 0 AND c.chunk_id > 0
 	          ),
@@ -1239,7 +1252,7 @@ func (s *SQLiteStore) NextPending(ctx context.Context, limit int, indexKind stri
 	            FROM spans s
 	            JOIN filtered_chunks fc ON fc.chunk_id = s.chunk_id
 	          )
-	          SELECT fc.chunk_id, fc.rel_path, fc.doc_type, fc.rep_type, fc.text, fc.index_kind,
+	          SELECT fc.chunk_id, fc.rel_path, fc.doc_type, fc.rep_type, fc.text, fc.index_kind, fc.modality, fc.media_ref,
 	                 COALESCE(sp.span_kind, ''), COALESCE(sp.start, 0), COALESCE(sp.end, 0), COALESCE(sp.extra_json, '')
 	          FROM filtered_chunks fc
 	          LEFT JOIN ranked_spans sp ON sp.chunk_id = fc.chunk_id AND sp.rn = 1`
@@ -1265,12 +1278,14 @@ func (s *SQLiteStore) NextPending(ctx context.Context, limit int, indexKind stri
 			repType   string
 			text      string
 			idxKind   string
+			modality  string
+			mediaRef  string
 			spanK     string
 			spanS     int
 			spanE     int
 			spanExtra string
 		)
-		if err := rows.Scan(&chunkID, &relPath, &docType, &repType, &text, &idxKind, &spanK, &spanS, &spanE, &spanExtra); err != nil {
+		if err := rows.Scan(&chunkID, &relPath, &docType, &repType, &text, &idxKind, &modality, &mediaRef, &spanK, &spanS, &spanE, &spanExtra); err != nil {
 			return nil, err
 		}
 		if chunkID <= 0 {
@@ -1278,14 +1293,17 @@ func (s *SQLiteStore) NextPending(ctx context.Context, limit int, indexKind stri
 		}
 		uid := uint64(chunkID)
 		span := spanFromRow(spanK, spanS, spanE, spanExtra)
-		tasks = append(tasks, model.NewChunkTask(uid, text, idxKind, model.ChunkMetadata{
+		task := model.NewChunkTask(uid, text, idxKind, model.ChunkMetadata{
 			ChunkID: uid,
 			RelPath: relPath,
 			DocType: docType,
 			RepType: repType,
 			Snippet: snippet(text, 240),
 			Span:    span,
-		}))
+		})
+		task.Modality = modality
+		task.MediaRef = mediaRef
+		tasks = append(tasks, task)
 	}
 	return tasks, rows.Err()
 }
@@ -1851,6 +1869,27 @@ func normalizeIndexKind(indexKind string) string {
 	switch strings.ToLower(strings.TrimSpace(indexKind)) {
 	case "code":
 		return "code"
+	default:
+		return "text"
+	}
+}
+
+// validateChunkText enforces non-empty text for text chunks, while allowing
+// an empty text body for media chunks (SPEC 8.1.7) — a media chunk carries no
+// text; its bytes are read from media_ref at embed time.
+func validateChunkText(chunk model.Chunk) error {
+	if strings.TrimSpace(chunk.Text) == "" && normalizeModality(chunk.Modality) == "text" {
+		return errors.New("chunk text must be non-empty")
+	}
+	return nil
+}
+
+// normalizeModality maps a chunk modality to a known value, defaulting to
+// "text" (SPEC 8.1.7).
+func normalizeModality(modality string) string {
+	switch strings.ToLower(strings.TrimSpace(modality)) {
+	case "image", "audio", "video", "pdf":
+		return strings.ToLower(strings.TrimSpace(modality))
 	default:
 		return "text"
 	}

--- a/tests/gemini/client_test.go
+++ b/tests/gemini/client_test.go
@@ -182,7 +182,7 @@ func TestEmbedMedia_NativeInlineData(t *testing.T) {
 	defer srv.Close()
 
 	c := newClient(srv.URL)
-	items := []gemini.MediaInput{
+	items := []model.MediaInput{
 		{MimeType: "image/png", Data: []byte("PNGBYTES")},
 		{MimeType: "audio/mp3", Data: []byte("MP3BYTES")},
 	}
@@ -210,7 +210,7 @@ func TestEmbedMedia_NativeInlineData(t *testing.T) {
 // TestEmbedMedia_EmptyItemErrors covers a media item with no bytes.
 func TestEmbedMedia_EmptyItemErrors(t *testing.T) {
 	c := gemini.NewClient("http://127.0.0.1:0", "k")
-	_, err := c.EmbedMedia(context.Background(), "gemini-embedding-2", model.EmbedDocument, []gemini.MediaInput{{MimeType: "image/png"}})
+	_, err := c.EmbedMedia(context.Background(), "gemini-embedding-2", model.EmbedDocument, []model.MediaInput{{MimeType: "image/png"}})
 	if err == nil {
 		t.Fatal("empty media item must error before any HTTP call")
 	}

--- a/tests/index/embedding_worker_test.go
+++ b/tests/index/embedding_worker_test.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"log"
 	"net"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -13,6 +15,81 @@ import (
 	"github.com/dirstral/dir2mcp/internal/index"
 	"github.com/dirstral/dir2mcp/internal/model"
 )
+
+// fakeMultimodalEmbedder implements model.MultimodalEmbedder for the media path.
+type fakeMultimodalEmbedder struct {
+	gotMedia  []model.MediaInput
+	mediaVecs [][]float32
+	textVecs  [][]float32
+}
+
+func (e *fakeMultimodalEmbedder) Embed(_ context.Context, _ string, _ model.EmbedRole, _ []string) ([][]float32, error) {
+	return e.textVecs, nil
+}
+
+func (e *fakeMultimodalEmbedder) EmbedMedia(_ context.Context, _ string, _ model.EmbedRole, items []model.MediaInput) ([][]float32, error) {
+	e.gotMedia = append(e.gotMedia, items...)
+	return e.mediaVecs, nil
+}
+
+func mediaTask(label uint64, relPath, modality string) model.ChunkTask {
+	tk := model.NewChunkTask(label, "", "text", model.ChunkMetadata{ChunkID: label, RelPath: relPath, DocType: modality})
+	tk.Modality = modality
+	tk.MediaRef = relPath
+	return tk
+}
+
+// TestEmbeddingWorker_RunOnce_MediaChunk pins SPEC 8.1.7: a media chunk is
+// embedded via EmbedMedia from bytes read at RootDir/MediaRef, with the MIME
+// inferred from the extension, and its vector is indexed.
+func TestEmbeddingWorker_RunOnce_MediaChunk(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "pic.png"), []byte("PNGDATA"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	source := &fakeChunkSource{tasks: []model.ChunkTask{mediaTask(7, "pic.png", "image")}}
+	idx := index.NewHNSWIndex("")
+	emb := &fakeMultimodalEmbedder{mediaVecs: [][]float32{{0.6, 0.8}}}
+	worker := &index.EmbeddingWorker{
+		Source: source, Index: idx, Embedder: emb,
+		RootDir: root, BatchSize: 4, ModelForText: "gemini-embedding-2",
+	}
+
+	n, err := worker.RunOnce(context.Background(), "text")
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("indexed = %d, want 1", n)
+	}
+	if len(emb.gotMedia) != 1 || string(emb.gotMedia[0].Data) != "PNGDATA" {
+		t.Fatalf("media bytes not passed to EmbedMedia: %+v", emb.gotMedia)
+	}
+	if emb.gotMedia[0].MimeType != "image/png" {
+		t.Fatalf("mime = %q, want image/png", emb.gotMedia[0].MimeType)
+	}
+	if len(source.embedded) != 1 || source.embedded[0] != 7 {
+		t.Fatalf("embedded labels = %v, want [7]", source.embedded)
+	}
+}
+
+// TestEmbeddingWorker_MediaChunk_NonMultimodalEmbedderFails: a media chunk with
+// a text-only embedder is a fatal config error (validation should prevent it
+// upstream, but the worker must not silently mis-embed).
+func TestEmbeddingWorker_MediaChunk_NonMultimodalEmbedderFails(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "pic.png"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	source := &fakeChunkSource{tasks: []model.ChunkTask{mediaTask(9, "pic.png", "image")}}
+	worker := &index.EmbeddingWorker{
+		Source: source, Index: index.NewHNSWIndex(""), Embedder: &fakeEmbedder{},
+		RootDir: root, BatchSize: 4,
+	}
+	if _, err := worker.RunOnce(context.Background(), "text"); err == nil {
+		t.Fatal("media chunk with a text-only embedder must error")
+	}
+}
 
 type fakeChunkSource struct {
 	tasks          []model.ChunkTask

--- a/tests/ingest/multimodal_test.go
+++ b/tests/ingest/multimodal_test.go
@@ -1,0 +1,112 @@
+package tests
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// loadMultimodalConfig writes a config binding embed to Gemini's multimodal
+// model with the given mode and returns the loaded config rooted at root.
+func loadMultimodalConfig(t *testing.T, root, mode string) config.Config {
+	t.Helper()
+	yaml := "version: 1\n" +
+		"model:\n" +
+		"  embed:\n" +
+		"    provider: gemini\n" +
+		"    text_model: gemini-embedding-2\n" +
+		"    code_model: gemini-embedding-2\n" +
+		"    multimodal: " + mode + "\n"
+	cfgPath := filepath.Join(t.TempDir(), ".dir2mcp.yaml")
+	if err := os.WriteFile(cfgPath, []byte(yaml), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg, err := config.LoadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	cfg.RootDir = root
+	return cfg
+}
+
+// TestProcessDocument_AugmentEmitsImageMediaChunk pins SPEC 8.1.7 ingestion:
+// under model.embed.multimodal=augment, an image document yields a pending
+// media chunk (modality=image, media_ref=relpath, empty text) for direct
+// multimodal embedding by the worker.
+func TestProcessDocument_AugmentEmitsImageMediaChunk(t *testing.T) {
+	t.Setenv("GEMINI_API_KEY", "gk")
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "pic.png"), []byte("PNGDATA"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	if err := st.Init(context.Background()); err != nil {
+		t.Fatalf("init store: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+
+	svc := mustNewIngestService(t, loadMultimodalConfig(t, root, "augment"), st)
+	df := ingest.DiscoveredFile{
+		AbsPath:   filepath.Join(root, "pic.png"),
+		RelPath:   "pic.png",
+		SizeBytes: int64(len("PNGDATA")),
+	}
+	if err := svc.ProcessDocument(context.Background(), df, nil, false); err != nil {
+		t.Fatalf("ProcessDocument: %v", err)
+	}
+
+	tasks, err := st.NextPending(context.Background(), 10, "text")
+	if err != nil {
+		t.Fatalf("NextPending: %v", err)
+	}
+	var media int
+	for _, tk := range tasks {
+		if tk.Modality == "image" {
+			media++
+			if tk.MediaRef != "pic.png" {
+				t.Errorf("media_ref = %q, want pic.png", tk.MediaRef)
+			}
+			if tk.Text != "" {
+				t.Errorf("media chunk text = %q, want empty", tk.Text)
+			}
+		}
+	}
+	if media != 1 {
+		t.Fatalf("got %d image media chunks, want 1 (tasks=%d)", media, len(tasks))
+	}
+}
+
+// TestProcessDocument_OffEmitsNoMediaChunk confirms the default (off) mode is
+// behavior-preserving: an image yields no media chunk.
+func TestProcessDocument_OffEmitsNoMediaChunk(t *testing.T) {
+	t.Setenv("GEMINI_API_KEY", "gk")
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "pic.png"), []byte("PNGDATA"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	if err := st.Init(context.Background()); err != nil {
+		t.Fatalf("init store: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+
+	svc := mustNewIngestService(t, loadMultimodalConfig(t, root, "off"), st)
+	df := ingest.DiscoveredFile{AbsPath: filepath.Join(root, "pic.png"), RelPath: "pic.png", SizeBytes: 7}
+	if err := svc.ProcessDocument(context.Background(), df, nil, false); err != nil {
+		t.Fatalf("ProcessDocument: %v", err)
+	}
+	tasks, err := st.NextPending(context.Background(), 10, "text")
+	if err != nil {
+		t.Fatalf("NextPending: %v", err)
+	}
+	for _, tk := range tasks {
+		if tk.Modality == "image" {
+			t.Fatalf("off mode must not emit media chunks, got %+v", tk)
+		}
+	}
+}


### PR DESCRIPTION
Phase 2 of multimodal embeddings (Design 0003 / spec §8.1.7) — the first slice that **produces and embeds media chunks end-to-end**, for **images**. Builds on the default-off adapter (#224).

## What now works
With `model.embed.multimodal: augment` (and `provider: gemini`, both embed models `gemini-embedding-2`):
- An **image** is indexed as OCR text (if an extractor is configured) **and** as a **direct image embedding** in the same vector space — so a text query can retrieve images.
- `replace` embeds the image **instead of** OCR→text.
- `off` (default) is **fully behavior-preserving**.

## Layers (all on this PR)
- **`model.MultimodalEmbedder`** interface + `model.MediaInput`; `gemini.Client` satisfies it (`EmbedMedia` retyped, compile-time asserted).
- **Store**: additive `chunks.modality` + `chunks.media_ref` columns (migration + CREATE TABLE); `InsertChunkWithSpans` permits empty text for media chunks; `NextPending` carries them; `model.Chunk`/`ChunkTask` extended.
- **Embedding worker**: media tasks read bytes from `RootDir`/`media_ref` (MIME by extension; resolved path constrained to root as defense-in-depth) and embed via `EmbedMedia`; text + media share one model and index. Non-multimodal embedder on a media chunk is a fatal error.
- **Ingest service**: emits a media chunk for images under augment/replace (mode resolved once at construction); `replace` skips OCR for images. Corpus root threaded to the worker.

## Tests
- `tests/index`: worker media path (bytes + inferred MIME + indexed vector); media chunk with a text-only embedder errors.
- `tests/ingest`: service-level `augment` emits exactly one image media chunk (modality/media_ref/empty-text); `off` emits none.
- (Existing) factory multimodal validation, config-knob parse, `gemini.EmbedMedia` native path.
- `make check` green (gofmt, vet, golangci-lint 0 issues, gocyclo, ineffassign, misspell, full `go test`, build).

## Not in this slice (follow-up phases)
PDF per-page, audio/video windowing, cross-modal retrieval citations/`open_file` for media (`MEDIA_NO_TEXT`), and `ask`-over-media grounding. The `gemini-embedding-2` model is Public Preview.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added multimodal image embedding with configurable modes: `augment` (OCR + image embeddings), `replace` (image embeddings only), or `off` (disabled).

* **Documentation**
  * Updated documentation clarifying multimodal embedding modes, current image support, and limitations on PDF/audio/video processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dirstral/dir2mcp/pull/225?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->