### PR TITLE
feat(retrieval): thread modality through results + page-image dedup (spec 8.1.7)

### DIFF
--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -705,14 +705,7 @@ func startEmbeddingWorkers(
 			Logger:       logger,
 			OnIndexedChunk: func(label uint64, metadata model.ChunkMetadata) {
 				if ret != nil {
-					ret.SetChunkMetadataForIndex(workerKind, label, model.SearchHit{
-						ChunkID: metadata.ChunkID,
-						RelPath: metadata.RelPath,
-						DocType: metadata.DocType,
-						RepType: metadata.RepType,
-						Snippet: metadata.Snippet,
-						Span:    metadata.Span,
-					})
+					ret.SetChunkMetadataForIndex(workerKind, label, metadata.ToSearchHit())
 				}
 				if indexingState != nil {
 					indexingState.AddEmbeddedOK(1)

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2205,6 +2205,12 @@ func serializeHit(h model.SearchHit) map[string]interface{} {
 	if title := strings.TrimSpace(h.Title); title != "" {
 		out["title"] = title
 	}
+	if modality := strings.TrimSpace(h.Modality); modality != "" {
+		out["modality"] = modality
+	}
+	if mediaRef := strings.TrimSpace(h.MediaRef); mediaRef != "" {
+		out["media_ref"] = mediaRef
+	}
 	return out
 }
 

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -110,16 +110,24 @@ type SearchHit struct {
 	Score   float64
 	Snippet string
 	Span    Span
+	// Modality / MediaRef identify a multimodal media chunk (SPEC 8.1.7):
+	// Modality is image/audio/video/pdf for a media chunk (empty for text),
+	// and MediaRef is the corpus rel_path whose bytes were embedded. They let
+	// retrieval dedup page-image candidates and mark media-only hits.
+	Modality string
+	MediaRef string
 }
 
 type ChunkMetadata struct {
-	ChunkID uint64
-	RelPath string
-	Title   string
-	DocType string
-	RepType string
-	Snippet string
-	Span    Span
+	ChunkID  uint64
+	RelPath  string
+	Title    string
+	DocType  string
+	RepType  string
+	Snippet  string
+	Span     Span
+	Modality string
+	MediaRef string
 }
 
 // ToSearchHit converts the lightweight chunk metadata back into a full
@@ -127,13 +135,15 @@ type ChunkMetadata struct {
 // SearchHit values but chunk tasks only need a subset of fields.
 func (m ChunkMetadata) ToSearchHit() SearchHit {
 	return SearchHit{
-		ChunkID: m.ChunkID,
-		RelPath: m.RelPath,
-		Title:   m.Title,
-		DocType: m.DocType,
-		RepType: m.RepType,
-		Snippet: m.Snippet,
-		Span:    m.Span,
+		ChunkID:  m.ChunkID,
+		RelPath:  m.RelPath,
+		Title:    m.Title,
+		DocType:  m.DocType,
+		RepType:  m.RepType,
+		Snippet:  m.Snippet,
+		Span:     m.Span,
+		Modality: m.Modality,
+		MediaRef: m.MediaRef,
 	}
 }
 

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -1124,15 +1124,80 @@ func (s *Service) searchSingleIndex(ctx context.Context, query string, k int, mo
 		return nil, err
 	}
 	if fused, ok := s.runHybridSearch(ctx, query, k, indexName, filtered); ok {
+		fused = dedupMediaCandidates(fused)
 		if allowRerank {
 			return s.rerankPool(ctx, query, fused, k), nil
 		}
 		return truncateSearchHits(fused, k), nil
 	}
+	filtered = dedupMediaCandidates(filtered)
 	if allowRerank {
 		return s.rerankPool(ctx, query, filtered, k), nil
 	}
 	return truncateSearchHits(filtered, k), nil
+}
+
+// isMediaHit reports whether a candidate is a direct media chunk (SPEC 8.1.7).
+func isMediaHit(h model.SearchHit) bool {
+	switch strings.ToLower(strings.TrimSpace(h.Modality)) {
+	case "image", "audio", "video", "pdf":
+		return true
+	default:
+		return false
+	}
+}
+
+// hitPage returns the document page a hit localizes to, if any. Page spans carry
+// it directly; region spans (structured extraction) carry it in the region.
+func hitPage(h model.SearchHit) (int, bool) {
+	switch strings.ToLower(strings.TrimSpace(h.Span.Kind)) {
+	case "page":
+		if h.Span.Page > 0 {
+			return h.Span.Page, true
+		}
+	case "region":
+		if h.Span.Region != nil && h.Span.Region.StartPage > 0 {
+			return h.Span.Region.StartPage, true
+		}
+	}
+	return 0, false
+}
+
+func mediaPageKey(relPath string, page int) string {
+	return relPath + "\x00" + strconv.Itoa(page)
+}
+
+// dedupMediaCandidates implements the SPEC 8.1.7 page-image dedup: drop a media
+// page-image candidate for (rel_path, page) only when a text/region candidate
+// for that same page survives, so a page is not double-counted. It runs BEFORE
+// truncation/rerank. Audio/video time-window media chunks, and media on pages
+// with no competing text/region candidate, are kept; distinct text/region
+// chunks are never collapsed into each other. Order is preserved.
+func dedupMediaCandidates(hits []model.SearchHit) []model.SearchHit {
+	textPages := make(map[string]struct{})
+	for _, h := range hits {
+		if isMediaHit(h) {
+			continue
+		}
+		if p, ok := hitPage(h); ok {
+			textPages[mediaPageKey(h.RelPath, p)] = struct{}{}
+		}
+	}
+	if len(textPages) == 0 {
+		return hits
+	}
+	out := make([]model.SearchHit, 0, len(hits))
+	for _, h := range hits {
+		if isMediaHit(h) {
+			if p, ok := hitPage(h); ok {
+				if _, dup := textPages[mediaPageKey(h.RelPath, p)]; dup {
+					continue
+				}
+			}
+		}
+		out = append(out, h)
+	}
+	return out
 }
 
 // hybridVectorCandidateLimit returns the number of vector candidates to

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -1294,12 +1294,14 @@ func (s *SQLiteStore) NextPending(ctx context.Context, limit int, indexKind stri
 		uid := uint64(chunkID)
 		span := spanFromRow(spanK, spanS, spanE, spanExtra)
 		task := model.NewChunkTask(uid, text, idxKind, model.ChunkMetadata{
-			ChunkID: uid,
-			RelPath: relPath,
-			DocType: docType,
-			RepType: repType,
-			Snippet: snippet(text, 240),
-			Span:    span,
+			ChunkID:  uid,
+			RelPath:  relPath,
+			DocType:  docType,
+			RepType:  repType,
+			Snippet:  snippet(text, 240),
+			Span:     span,
+			Modality: modality,
+			MediaRef: mediaRef,
 		})
 		task.Modality = modality
 		task.MediaRef = mediaRef
@@ -1323,7 +1325,7 @@ func (s *SQLiteStore) ListEmbeddedChunkMetadata(ctx context.Context, indexKind s
 
 	args := []any{"ok"}
 	query := `WITH filtered_chunks AS (
-	            SELECT c.chunk_id, c.rel_path, c.doc_type, c.rep_type, c.text, c.index_kind
+	            SELECT c.chunk_id, c.rel_path, c.doc_type, c.rep_type, c.text, c.index_kind, c.modality, c.media_ref
 	            FROM chunks c
 	            WHERE c.embedding_status = ? AND c.deleted = 0 AND c.chunk_id > 0
 	          ),
@@ -1335,7 +1337,7 @@ func (s *SQLiteStore) ListEmbeddedChunkMetadata(ctx context.Context, indexKind s
 	          )
 	          SELECT fc.chunk_id, fc.rel_path, fc.doc_type, fc.rep_type, fc.text, fc.index_kind,
 	                 COALESCE(sp.span_kind, ''), COALESCE(sp.start, 0), COALESCE(sp.end, 0), COALESCE(sp.extra_json, ''),
-	                 COALESCE(d.title, '')
+	                 COALESCE(d.title, ''), fc.modality, fc.media_ref
 	          FROM filtered_chunks fc
 	          LEFT JOIN ranked_spans sp ON sp.chunk_id = fc.chunk_id AND sp.rn = 1
 	          LEFT JOIN documents d ON d.rel_path = fc.rel_path`
@@ -1366,8 +1368,10 @@ func (s *SQLiteStore) ListEmbeddedChunkMetadata(ctx context.Context, indexKind s
 			spanE     int
 			spanExtra string
 			title     string
+			modality  string
+			mediaRef  string
 		)
-		if err := rows.Scan(&chunkID, &relPath, &docType, &repType, &text, &kind, &spanK, &spanS, &spanE, &spanExtra, &title); err != nil {
+		if err := rows.Scan(&chunkID, &relPath, &docType, &repType, &text, &kind, &spanK, &spanS, &spanE, &spanExtra, &title, &modality, &mediaRef); err != nil {
 			return nil, err
 		}
 		if chunkID <= 0 {
@@ -1379,14 +1383,18 @@ func (s *SQLiteStore) ListEmbeddedChunkMetadata(ctx context.Context, indexKind s
 			Label:     uid,
 			Text:      text,
 			IndexKind: kind,
+			Modality:  modality,
+			MediaRef:  mediaRef,
 			Metadata: model.ChunkMetadata{
-				ChunkID: uid,
-				RelPath: relPath,
-				Title:   title,
-				DocType: docType,
-				RepType: repType,
-				Snippet: snippet(text, 240),
-				Span:    span,
+				ChunkID:  uid,
+				RelPath:  relPath,
+				Title:    title,
+				DocType:  docType,
+				RepType:  repType,
+				Snippet:  snippet(text, 240),
+				Span:     span,
+				Modality: modality,
+				MediaRef: mediaRef,
 			},
 		})
 	}

--- a/tests/retrieval/media_dedup_test.go
+++ b/tests/retrieval/media_dedup_test.go
@@ -1,0 +1,83 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
+)
+
+// TestSearch_DedupsPageImageWhenTextSurvives pins SPEC 8.1.7: a page-image media
+// candidate for (rel_path, page) is dropped when a text/region candidate for the
+// same page survives, but media on a page with no competing text is kept.
+func TestSearch_DedupsPageImageWhenTextSurvives(t *testing.T) {
+	idx := index.NewHNSWIndex("")
+	for label, vec := range map[uint64][]float32{
+		1: {1, 0},       // text chunk, page 1
+		2: {0.99, 0.01}, // page-image media chunk, page 1 (duplicate of #1)
+		3: {0.98, 0.02}, // page-image media chunk, page 2 (no competing text)
+	} {
+		if err := idx.Add(label, vec); err != nil {
+			t.Fatalf("idx.Add(%d): %v", label, err)
+		}
+	}
+
+	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+		"mistral-embed": {1, 0},
+	}}, nil)
+	svc.SetChunkMetadata(1, model.SearchHit{RelPath: "doc.pdf", DocType: "pdf", Snippet: "page one text", Span: model.Span{Kind: "page", Page: 1}})
+	svc.SetChunkMetadata(2, model.SearchHit{RelPath: "doc.pdf", DocType: "pdf", Modality: "pdf", MediaRef: "doc.pdf", Span: model.Span{Kind: "page", Page: 1}})
+	svc.SetChunkMetadata(3, model.SearchHit{RelPath: "doc.pdf", DocType: "pdf", Modality: "pdf", MediaRef: "doc.pdf", Span: model.Span{Kind: "page", Page: 2}})
+
+	hits, err := svc.Search(context.Background(), model.SearchQuery{Query: "page", K: 10})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	got := map[uint64]bool{}
+	for _, h := range hits {
+		got[h.ChunkID] = true
+	}
+	if got[2] {
+		t.Errorf("page-image duplicate (chunk 2, page 1) must be dropped; hits=%v", got)
+	}
+	if !got[1] {
+		t.Errorf("text chunk (chunk 1) must survive; hits=%v", got)
+	}
+	if !got[3] {
+		t.Errorf("media on a text-free page (chunk 3, page 2) must be kept; hits=%v", got)
+	}
+}
+
+// TestSearch_KeepsTimeWindowMediaAlongsideTranscript pins SPEC 8.1.7: the dedup
+// rule is page-scoped — audio/video time-window media chunks are never dropped,
+// even when a transcript text chunk (also a time span) exists for the same file.
+func TestSearch_KeepsTimeWindowMediaAlongsideTranscript(t *testing.T) {
+	idx := index.NewHNSWIndex("")
+	for label, vec := range map[uint64][]float32{
+		1: {1, 0},       // transcript text chunk (time span)
+		2: {0.99, 0.01}, // audio media window (time span)
+	} {
+		if err := idx.Add(label, vec); err != nil {
+			t.Fatalf("idx.Add(%d): %v", label, err)
+		}
+	}
+	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+		"mistral-embed": {1, 0},
+	}}, nil)
+	svc.SetChunkMetadata(1, model.SearchHit{RelPath: "talk.mp3", DocType: "audio", Snippet: "spoken words", Span: model.Span{Kind: "time", StartMS: 0, EndMS: 120000}})
+	svc.SetChunkMetadata(2, model.SearchHit{RelPath: "talk.mp3", DocType: "audio", Modality: "audio", MediaRef: "talk.mp3", Span: model.Span{Kind: "time", StartMS: 0, EndMS: 120000}})
+
+	hits, err := svc.Search(context.Background(), model.SearchQuery{Query: "talk", K: 10})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	got := map[uint64]bool{}
+	for _, h := range hits {
+		got[h.ChunkID] = true
+	}
+	if !got[1] || !got[2] {
+		t.Fatalf("both transcript and audio-window chunks must survive (time spans are not page-deduped); hits=%v", got)
+	}
+}

--- a/tests/store/sqlite_store_test.go
+++ b/tests/store/sqlite_store_test.go
@@ -51,12 +51,13 @@ func TestSQLiteStore_PendingChunkLifecycle(t *testing.T) {
 	expectedText := "chunk text"
 	expectedIndexKind := "text"
 	expectedMetadata := model.ChunkMetadata{
-		ChunkID: 101,
-		RelPath: "docs/a.md",
-		DocType: "md",
-		RepType: "raw_text",
-		Snippet: "chunk text",
-		Span:    model.Span{Kind: "lines"},
+		ChunkID:  101,
+		RelPath:  "docs/a.md",
+		DocType:  "md",
+		RepType:  "raw_text",
+		Snippet:  "chunk text",
+		Span:     model.Span{Kind: "lines"},
+		Modality: "text", // chunks.modality defaults to 'text' (SPEC 8.1.7)
 	}
 	if tasks[0].Label != 101 || tasks[0].Metadata.ChunkID != 101 ||
 		tasks[0].Text != expectedText ||


### PR DESCRIPTION
## What

**Phase 2d-i** — the retrieval side of multimodal embedding. Media chunks (images, PDF pages, audio/video windows) are now visible to retrieval, and the SPEC §8.1.7 **page-image dedup** rule is enforced. **Code-only** — §8.1.7's retrieval rules are already normative (spec 0.13.0/0.14.0), so no spec PR.

## Changes

- **model** — `SearchHit` and `ChunkMetadata` gain `Modality`/`MediaRef`; `ToSearchHit()` carries them.
- **store** — `ListEmbeddedChunkMetadata` (reload path) and `NextPending` (live indexing path) now SELECT `chunks.modality`/`media_ref` and populate `ChunkMetadata`, so the field reaches retrieval both at startup and during live indexing.
- **cli** — `OnIndexedChunk` caches via `metadata.ToSearchHit()` instead of a hand-built `SearchHit`, so `modality`/`media_ref` (and `title`) flow into the retrieval metadata cache.
- **retrieval** — `dedupMediaCandidates` drops a page-image media candidate for `(rel_path, page)` **only when** a text/region candidate for that same page survives, applied **before** truncation/rerank (SPEC §8.1.7). Audio/video time-window media and media on text-free pages are kept; distinct text/region chunks are never collapsed.
- **mcp** — `serializeHit` exposes `modality`/`media_ref` in tool output when present, so clients can tell a hit is media-only.

## Why split

This is the foundational plumbing + dedup. **Phase 2d-ii** (next PR) builds on the `modality` now reaching retrieval: `open_file` → `MEDIA_NO_TEXT` for `replace`-mode media-only chunks, and `ask`-over-media grounding (media-only hits cited without quoted context).

## Behavior preservation

Text-only corpora are unaffected (`modality` defaults to `"text"`; dedup is a no-op when there are no media candidates). Existing image/PDF media chunks now simply become visible + deduped in results.

## Tests

- `tests/retrieval`: page-image dedup (drop the page-1 image dup, keep the page-1 text, keep a page-2 media chunk that has no competing text); time-window media kept alongside a transcript (dedup is page-scoped, not time-scoped).
- `tests/store`: round-trip asserts `ChunkMetadata.Modality` is populated.

`make check` passes locally.