### PR TITLE
test(ingest): docling adapter golden contract tests + dual-track install docs (#145, #146)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,17 @@ Then verify:
 dir2mcp version
 ```
 
+### Install tracks: `dir2mcp` vs `dir2mcp-full`
+
+dir2mcp ships in two Homebrew formulas that install the **same binary** but differ in whether the [docling](https://github.com/docling-project/docling) structured-extraction runtime is bundled:
+
+| Track | Install | docling | Pick when |
+|---|---|---|---|
+| **Lean** (default) | `brew install dirstral/tap/dir2mcp` | **Not bundled** — bring your own | You already have `docling`, run a `docling-serve` container, extract via Mistral OCR, or index docling-free corpora |
+| **Full** | `brew install dirstral/tap/dir2mcp-full` | **Bundled** (docling runtime included) | You want local structured PDF/image extraction with zero extra setup |
+
+The two formulas are mutually exclusive (Homebrew refuses to install both at once). Choose **full** for batteries-included local extraction; choose **lean** if you bring docling yourself, run docling-serve, or rely on Mistral OCR. Either way, extraction is configurable at runtime via `ingest.extractor` (see [Document extraction](#document-extraction-modes--fallback)).
+
 Build-from-source remains available as an alternative:
 
 ```bash
@@ -235,6 +246,25 @@ For Homebrew and other installed workflows, you can persist this in `.dir2mcp.ya
 ingest_extractor: auto
 docling_command: docling --to json --output - {input}
 ```
+
+### Document extraction: modes & fallback
+
+PDFs and images are converted to text by an **extractor**, selected with `ingest.extractor` (env `DIR2MCP_INGEST_EXTRACTOR`):
+
+| Mode | Behavior |
+|---|---|
+| `auto` (default) | Prefer the local `docling` CLI; else a reachable `docling-serve`; else Mistral OCR; else disabled. |
+| `docling` | Local docling CLI only (fails if not on `PATH`). |
+| `docling-serve` | docling-serve HTTP only; requires a reachable `serve_url` (no fallback). |
+| `mistral` | Mistral OCR only (requires `MISTRAL_API_KEY`). |
+| `off` | No extraction (PDFs/images contribute no extracted text). |
+
+Under `auto`, the fallback cascade is **docling CLI → docling-serve → Mistral OCR → disabled**. The chosen extractor is reported at startup and by `dir2mcp doctor` (e.g. `OCR: mistral-ocr (fallback; docling not found on PATH)`), so the active path is visible rather than inferred per document.
+
+**Troubleshooting:**
+- *`OCR: disabled`* — no extractor is available: install docling (or use the `-full` track), point `serve_url` at a docling-serve container, or set `MISTRAL_API_KEY`.
+- *docling-serve rejected at startup (`CONFIG_INVALID`)* — `extractor: docling-serve` needs a non-empty, reachable `serve_url`; it never silently falls back to the CLI.
+- *Switching extractors across re-indexes* is safe — docling and Mistral OCR both produce the same `extracted_markdown` representation; only the richness of span provenance (structured `region` spans vs. `page` spans) differs.
 
 ### docling extraction over HTTP (docling-serve)
 

--- a/tests/ingest/docling_contract_test.go
+++ b/tests/ingest/docling_contract_test.go
@@ -1,0 +1,148 @@
+package tests
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/ingest/docling"
+)
+
+// loadDoclingSample reads the checked-in golden DoclingDocument fixture. It is
+// the same JSON shape the docling CLI (`--to json`) and docling-serve
+// (document.json_content) emit, so it pins the adapter's structural contract.
+func loadDoclingSample(t *testing.T) []byte {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("testdata", "docling_sample.json"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	return data
+}
+
+// findBlock returns the first block whose label and substring match.
+func findBlock(blocks []docling.Block, label, contains string) (docling.Block, bool) {
+	for _, b := range blocks {
+		if b.Label == label && strings.Contains(b.Text, contains) {
+			return b, true
+		}
+	}
+	return docling.Block{}, false
+}
+
+func countLabel(blocks []docling.Block, label string) int {
+	n := 0
+	for _, b := range blocks {
+		if b.Label == label {
+			n++
+		}
+	}
+	return n
+}
+
+// assertDoclingSampleContract pins the structural contract the rest of the
+// pipeline (chunking, citations) depends on: reading order, section breadcrumb,
+// per-element page/bbox provenance, labels, atomic tables, and figure captions.
+func assertDoclingSampleContract(t *testing.T, title, markdown string, blocks []docling.Block) {
+	t.Helper()
+
+	if title != "Quarterly Report" {
+		t.Errorf("title = %q, want %q", title, "Quarterly Report")
+	}
+
+	// Rendered markdown: heading levels, table as Markdown, caption, and the
+	// picture annotation as searchable text.
+	for _, want := range []string{
+		"# Quarterly Report",
+		"# Overview",
+		"## Regional Details",
+		"EMEA led growth this quarter.",
+		"| Region | Revenue |",
+		"| EMEA | 100 |",
+		"Table 1: Revenue by region.",
+		"Figure 1: Revenue chart.",
+		"Bar chart of revenue by region.",
+	} {
+		if !strings.Contains(markdown, want) {
+			t.Errorf("markdown missing %q\n---\n%s", want, markdown)
+		}
+	}
+
+	// The h2 paragraph carries the full breadcrumb and page-2 provenance.
+	if p, ok := findBlock(blocks, docling.LabelParagraph, "EMEA led growth"); ok {
+		if got := strings.Join(p.Section, " > "); got != "Overview > Regional Details" {
+			t.Errorf("paragraph breadcrumb = %q, want %q", got, "Overview > Regional Details")
+		}
+		if p.Page != 2 {
+			t.Errorf("paragraph page = %d, want 2", p.Page)
+		}
+		if p.BBox == nil || p.BBox.Page != 2 {
+			t.Errorf("paragraph bbox = %+v, want non-nil on page 2", p.BBox)
+		}
+	} else {
+		t.Error("expected a paragraph block for the h2 body text")
+	}
+
+	// The table is one atomic block under the right section.
+	if n := countLabel(blocks, docling.LabelTable); n != 1 {
+		t.Errorf("table block count = %d, want 1 (atomic)", n)
+	}
+	if tbl, ok := findBlock(blocks, docling.LabelTable, "| EMEA | 100 |"); ok {
+		if got := strings.Join(tbl.Section, " > "); got != "Overview > Regional Details" {
+			t.Errorf("table breadcrumb = %q, want %q", got, "Overview > Regional Details")
+		}
+	} else {
+		t.Error("expected an atomic table block with rendered rows")
+	}
+
+	// Title block is present and labeled.
+	if _, ok := findBlock(blocks, docling.LabelTitle, "Quarterly Report"); !ok {
+		t.Error("expected a title block")
+	}
+}
+
+// TestDoclingPipeline_GoldenContract pins the parse -> linearize -> render
+// contract directly against the golden DoclingDocument fixture. It runs in CI
+// (no docling binary) and catches adapter-protocol regressions in the
+// structured-extraction pipeline (#145).
+func TestDoclingPipeline_GoldenContract(t *testing.T) {
+	doc, err := docling.Parse(loadDoclingSample(t))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	blocks := doc.Linearize()
+	markdown := docling.RenderMarkdown(blocks)
+	assertDoclingSampleContract(t, doc.Title(), markdown, blocks)
+}
+
+// TestDoclingServeAdapter_GoldenContract drives the SAME golden fixture through
+// the docling-serve HTTP adapter (httptest, no container) and asserts the
+// adapter produces the identical structured contract. This exercises the
+// "docling-enabled path for supported formats" end-to-end in CI (#145).
+func TestDoclingServeAdapter_GoldenContract(t *testing.T) {
+	fixture := loadDoclingSample(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			t.Errorf("parse multipart: %v", err)
+		}
+		if got := r.FormValue("to_formats"); got != "json" {
+			t.Errorf("to_formats = %q, want json", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":"success","document":{"json_content":`+string(fixture)+`}}`)
+	}))
+	defer srv.Close()
+
+	ext := ingest.NewDoclingServeExtractor(srv.URL)
+	res, err := ext.ExtractStructured(context.Background(), "report.pdf", []byte("PDF-BYTES"))
+	if err != nil {
+		t.Fatalf("ExtractStructured: %v", err)
+	}
+	assertDoclingSampleContract(t, res.Title, res.Markdown, res.Blocks)
+}

--- a/tests/ingest/testdata/docling_sample.json
+++ b/tests/ingest/testdata/docling_sample.json
@@ -1,0 +1,76 @@
+{
+  "schema_name": "DoclingDocument",
+  "version": "1.2.0",
+  "name": "Quarterly Report",
+  "origin": { "filename": "report.pdf", "mimetype": "application/pdf" },
+  "pages": {
+    "1": { "size": { "width": 612, "height": 792 }, "page_no": 1 },
+    "2": { "size": { "width": 612, "height": 792 }, "page_no": 2 }
+  },
+  "body": {
+    "self_ref": "#/body",
+    "children": [
+      { "$ref": "#/texts/0" },
+      { "$ref": "#/texts/1" },
+      { "$ref": "#/texts/2" },
+      { "$ref": "#/texts/3" },
+      { "$ref": "#/texts/4" },
+      { "$ref": "#/tables/0" },
+      { "$ref": "#/pictures/0" }
+    ]
+  },
+  "texts": [
+    {
+      "self_ref": "#/texts/0", "label": "title", "text": "Quarterly Report",
+      "prov": [{ "page_no": 1, "bbox": { "l": 72, "t": 720, "r": 540, "b": 740, "coord_origin": "BOTTOMLEFT" } }]
+    },
+    {
+      "self_ref": "#/texts/1", "label": "section_header", "level": 1, "text": "Overview",
+      "prov": [{ "page_no": 1, "bbox": { "l": 72, "t": 680, "r": 300, "b": 700, "coord_origin": "BOTTOMLEFT" } }]
+    },
+    {
+      "self_ref": "#/texts/2", "label": "paragraph", "text": "Revenue grew across all regions.",
+      "prov": [{ "page_no": 1, "bbox": { "l": 72, "t": 640, "r": 540, "b": 660, "coord_origin": "BOTTOMLEFT" } }]
+    },
+    {
+      "self_ref": "#/texts/3", "label": "section_header", "level": 2, "text": "Regional Details",
+      "prov": [{ "page_no": 1, "bbox": { "l": 72, "t": 600, "r": 320, "b": 620, "coord_origin": "BOTTOMLEFT" } }]
+    },
+    {
+      "self_ref": "#/texts/4", "label": "paragraph", "text": "EMEA led growth this quarter.",
+      "prov": [{ "page_no": 2, "bbox": { "l": 72, "t": 700, "r": 540, "b": 720, "coord_origin": "BOTTOMLEFT" } }]
+    },
+    {
+      "self_ref": "#/texts/5", "label": "caption", "text": "Table 1: Revenue by region.",
+      "prov": [{ "page_no": 2, "bbox": { "l": 72, "t": 560, "r": 540, "b": 580, "coord_origin": "BOTTOMLEFT" } }]
+    },
+    {
+      "self_ref": "#/texts/6", "label": "caption", "text": "Figure 1: Revenue chart.",
+      "prov": [{ "page_no": 2, "bbox": { "l": 72, "t": 320, "r": 540, "b": 340, "coord_origin": "BOTTOMLEFT" } }]
+    }
+  ],
+  "tables": [
+    {
+      "self_ref": "#/tables/0", "label": "table",
+      "captions": [{ "$ref": "#/texts/5" }],
+      "prov": [{ "page_no": 2, "bbox": { "l": 72, "t": 600, "r": 540, "b": 660, "coord_origin": "BOTTOMLEFT" } }],
+      "data": {
+        "num_rows": 2, "num_cols": 2,
+        "table_cells": [
+          { "text": "Region", "row_span": 1, "col_span": 1, "start_row_offset_idx": 0, "end_row_offset_idx": 1, "start_col_offset_idx": 0, "end_col_offset_idx": 1, "column_header": true },
+          { "text": "Revenue", "row_span": 1, "col_span": 1, "start_row_offset_idx": 0, "end_row_offset_idx": 1, "start_col_offset_idx": 1, "end_col_offset_idx": 2, "column_header": true },
+          { "text": "EMEA", "row_span": 1, "col_span": 1, "start_row_offset_idx": 1, "end_row_offset_idx": 2, "start_col_offset_idx": 0, "end_col_offset_idx": 1 },
+          { "text": "100", "row_span": 1, "col_span": 1, "start_row_offset_idx": 1, "end_row_offset_idx": 2, "start_col_offset_idx": 1, "end_col_offset_idx": 2 }
+        ]
+      }
+    }
+  ],
+  "pictures": [
+    {
+      "self_ref": "#/pictures/0", "label": "picture",
+      "captions": [{ "$ref": "#/texts/6" }],
+      "annotations": [{ "kind": "description", "text": "Bar chart of revenue by region." }],
+      "prov": [{ "page_no": 2, "bbox": { "l": 72, "t": 360, "r": 540, "b": 540, "coord_origin": "BOTTOMLEFT" } }]
+    }
+  ]
+}


### PR DESCRIPTION
## What

Docling CI/install hardening. Addresses **#145** (CI coverage for the docling adapter contract) and **#146** (dual-track install docs). Code/test + docs only — no behavior change.

## #145 — CI catches adapter-protocol regressions

Adds a checked-in golden `DoclingDocument` fixture (`tests/ingest/testdata/docling_sample.json` — 2 pages, nested headings, a table, a captioned figure with provenance) and two contract tests that run in **normal CI** (no docling binary required):

- **`TestDoclingPipeline_GoldenContract`** — `Parse → Linearize → RenderMarkdown` asserts the structural contract the rest of the pipeline depends on: reading order, heading levels, **section breadcrumb**, per-element **page/bbox provenance**, element labels, **atomic table** rendering, and figure caption + annotation as searchable text.
- **`TestDoclingServeAdapter_GoldenContract`** — drives the *same* fixture through the `docling-serve` HTTP adapter (`httptest`, no container) and asserts the identical structured output, exercising the **docling-enabled path for supported formats** end-to-end in CI.

These deterministically catch adapter-protocol regressions. The third acceptance criterion — **fallback when docling is unavailable** — is already covered by `docling_extractor_test.go` (auto → docling-serve → Mistral cascade), which runs in `make check`.

## #146 — dual-track install + extractor docs

README gains:
- **Install tracks** — `dir2mcp` (lean; bring your own docling / docling-serve / Mistral OCR) vs `dir2mcp-full` (bundled docling runtime), when to pick each, and the mutual-exclusivity note.
- **Document extraction: modes & fallback** — the `auto|docling|docling-serve|mistral|off` modes, the `auto` cascade, how the chosen extractor is surfaced (startup banner / `dir2mcp doctor`), and troubleshooting.

## Out of scope (flagged)

**#149** (re-enable the macOS Intel `dir2mcp-full` lane) and the lean/full **install smoke** + OS matrix live in the `dirstral/homebrew-tap` repo and its runners, not here — they need tap-repo changes. The new contract tests are pure Go and run on whatever arch CI uses, so adapter regressions are caught regardless of the install-track matrix.

## Tests

`make check` passes locally; both new contract tests pass.