### PR TITLE
docs: fix 0.14 drift + re-pin spec submodule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,8 @@ dir2mcp is a Go monorepo for deploying a directory as an MCP knowledge server. I
 - `internal/cli`: CLI command orchestration (`up`, `status`, `ask`, `reindex`, `config`, `version`)
 - `internal/config`: config load/merge/validation
 - `internal/ingest`: file discovery, OCR/transcription/annotation representation generation
+- `internal/pdfutil`: pure-Go PDF helpers (page count, per-page extraction) for multimodal media chunks
+- `internal/avutil`: audio/video helpers (ffprobe duration, ffmpeg time-window extraction) for multimodal media chunks
 - `internal/retrieval`: search/ask/open_file logic
 - `internal/mcp`: JSON-RPC/MCP server and tools
 - `internal/mistral`: Mistral client adapters

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ model:
 - **Matryoshka dimensions** (`text_dim`/`code_dim`): request a smaller vector to shrink the index. dir2mcp sends Gemini's `outputDimensionality` and L2-normalizes the truncated vectors. The knob is Gemini-only — setting it on a provider that can't honor it is rejected at startup (`CONFIG_INVALID`).
 - **Reindex-bound (spec §8.1.4/§8.1.6):** the embed provider, model, **and requested dimension** form the corpus-lifetime embed identity. Switching to Gemini, or changing the dimension later, requires a `dir2mcp reindex` (the server refuses to mix vector spaces and tells you to reindex).
 
-#### Multimodal embeddings (`gemini-embedding-2`, preview — in progress)
+#### Multimodal embeddings (`gemini-embedding-2`, preview — implemented, default-off)
 
 Spec §8.1.7 (0.14.0) defines an opt-in `model.embed.multimodal` mode (`off` default | `augment` | `replace`) that embeds media directly into the same vector space via the multimodal `gemini-embedding-2` model. It is being implemented in phases against a **Public Preview** model:
 
@@ -336,7 +336,7 @@ model:
 
 - **Images**, **PDFs**, **audio**, and **video** are supported today. Under `augment` the document is indexed *both* as text (image OCR / docling PDF text / audio transcript, if configured) *and* as direct media embeddings; under `replace` it is embedded directly *instead of* text. A PDF is embedded **per page** (each page is its own vector with a page citation); audio and video are embedded **per time window** (each window is its own vector with a `start_ms`/`end_ms` citation). A text query then retrieves images, PDF pages, and media windows from the shared space.
 - **Audio/video duration probing and window extraction** use the external `ffprobe`/`ffmpeg` binaries. When they are absent, audio/video are skipped for direct embedding and the file keeps its text path (audio transcript) — a graceful fallback, not an error. Direct audio embedding covers MP3/WAV; video covers MP4/MOV (the formats the preview model accepts). Other audio formats keep only their transcript; video has no text path.
-- `augment`/`replace` require `provider: gemini` with `text_model` and `code_model` both `gemini-embedding-2` (validated at startup; otherwise `CONFIG_INVALID`), and the mode is reindex-bound (§8.1.4). `off` (default) is fully behavior-preserving.
+- `augment`/`replace` require `provider: gemini` with `text_model` and `code_model` both `gemini-embedding-2` (validated at startup; otherwise `CONFIG_INVALID`), and the mode is reindex-bound (§8.1.4). `off` (default) is fully behavior-preserving. The mode is **YAML-only** (`model.embed.multimodal`); there is no environment-variable override, since it is a deploy-time, reindex-bound choice.
 - **Retrieval & citations.** Media hits surface in `search`/`ask` results with their `modality` and `media_ref`. To avoid double-counting, a coarse page-image candidate is dropped when a text/region candidate survives for the same `(rel_path, page)`. `ask` grounds on available text (an `augment` hit's OCR/transcript); a `replace`-mode media-only hit is cited without quoted context. `open_file` on a media-only chunk returns the non-retryable `MEDIA_NO_TEXT` (never raw bytes), distinct from the retryable `OCR_NOT_READY` when text is merely pending.
 
 See [Design 0003](dirstral-spec/docs/design/0003-multimodal-embeddings.md).
@@ -507,7 +507,7 @@ Normative docs are maintained in the [`dirstral-spec`](https://github.com/dirstr
 - [dirstral-spec/docs/SPEC.md](dirstral-spec/docs/SPEC.md) — normative behavior, schemas, and runtime contracts
 - [dirstral-spec/docs/ECOSYSTEM.md](dirstral-spec/docs/ECOSYSTEM.md) — ecosystem/market/discovery/payment context
 - [dirstral-spec/docs/x402-payment-adapter-spec.md](dirstral-spec/docs/x402-payment-adapter-spec.md) — facilitator adapter contract
-- dir2mcp implements spec version `0.5.x` ([versioning](dirstral-spec/spec/versioning.md))
+- dir2mcp implements spec version `0.14.x` ([versioning](dirstral-spec/spec/versioning.md))
 
 ## Development
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -8,7 +8,7 @@ single source of truth and this copy can no longer drift.
 - In-tree (pinned submodule): [`dirstral-spec/docs/SPEC.md`](../dirstral-spec/docs/SPEC.md)
 - Upstream: <https://github.com/dirstral/dirstral-spec/blob/main/docs/SPEC.md>
 
-dir2mcp implements spec version `0.5.x` — see [`dirstral-spec/spec/versioning.md`](../dirstral-spec/spec/versioning.md).
+dir2mcp implements spec version `0.14.x` — see [`dirstral-spec/spec/versioning.md`](../dirstral-spec/spec/versioning.md).
 
 If the `dirstral-spec/` directory is empty, fetch the submodule:
 

--- a/docs/x402-payment-adapter-spec.md
+++ b/docs/x402-payment-adapter-spec.md
@@ -8,7 +8,7 @@ single source of truth and this copy can no longer drift.
 - In-tree (pinned submodule): [`dirstral-spec/docs/x402-payment-adapter-spec.md`](../dirstral-spec/docs/x402-payment-adapter-spec.md)
 - Upstream: <https://github.com/dirstral/dirstral-spec/blob/main/docs/x402-payment-adapter-spec.md>
 
-dir2mcp implements spec version `0.5.x` — see [`dirstral-spec/spec/versioning.md`](../dirstral-spec/spec/versioning.md).
+dir2mcp implements spec version `0.14.x` — see [`dirstral-spec/spec/versioning.md`](../dirstral-spec/spec/versioning.md).
 
 If the `dirstral-spec/` directory is empty, fetch the submodule:
 


### PR DESCRIPTION
## What

Docs/spec drift pass (workstream "2") — reconcile documentation with the merged multimodal arc (#224–#230) and spec **0.14.0**. Docs + submodule pin only; no code change.

## Changes

- **Re-pin `dirstral-spec`** → `b9f2bc6` (the merged 0.14 status-refresh: §0.2 implementation note + compatibility-matrix row).
- **Spec version references** `0.5.x` → `0.14.x` in `README.md`, `docs/SPEC.md`, `docs/x402-payment-adapter-spec.md`.
- **README multimodal section** — heading `preview — in progress` → `preview — implemented, default-off`; add a note that `model.embed.multimodal` is **YAML-only** (deploy-time, reindex-bound; no env override).
- **CLAUDE.md** — add `internal/pdfutil` and `internal/avutil` to the repository layout (added during the multimodal media-windowing work).

## Verification

`make check` passes (includes link checks). The submodule re-pin is the standard gated step after the spec-side status refresh merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Multimodal Gemini embedding feature now officially marked as implemented and available as a default-off option
  * Clarified that multimodal embedding configuration options for content augment and replace settings are YAML-only with no environment variable overrides
  * Updated specification version references from 0.5.x to 0.14.x across documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->