### PR TITLE
test(mcp): payment outcome survives server restart (#124)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,8 @@ dir2mcp is a Go monorepo for deploying a directory as an MCP knowledge server. I
 - `internal/cli`: CLI command orchestration (`up`, `status`, `ask`, `reindex`, `config`, `version`)
 - `internal/config`: config load/merge/validation
 - `internal/ingest`: file discovery, OCR/transcription/annotation representation generation
+- `internal/pdfutil`: pure-Go PDF helpers (page count, per-page extraction) for multimodal media chunks
+- `internal/avutil`: audio/video helpers (ffprobe duration, ffmpeg time-window extraction) for multimodal media chunks
 - `internal/retrieval`: search/ask/open_file logic
 - `internal/mcp`: JSON-RPC/MCP server and tools
 - `internal/mistral`: Mistral client adapters

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ model:
 - **Matryoshka dimensions** (`text_dim`/`code_dim`): request a smaller vector to shrink the index. dir2mcp sends Gemini's `outputDimensionality` and L2-normalizes the truncated vectors. The knob is Gemini-only — setting it on a provider that can't honor it is rejected at startup (`CONFIG_INVALID`).
 - **Reindex-bound (spec §8.1.4/§8.1.6):** the embed provider, model, **and requested dimension** form the corpus-lifetime embed identity. Switching to Gemini, or changing the dimension later, requires a `dir2mcp reindex` (the server refuses to mix vector spaces and tells you to reindex).
 
-#### Multimodal embeddings (`gemini-embedding-2`, preview — in progress)
+#### Multimodal embeddings (`gemini-embedding-2`, preview — implemented, default-off)
 
 Spec §8.1.7 (0.14.0) defines an opt-in `model.embed.multimodal` mode (`off` default | `augment` | `replace`) that embeds media directly into the same vector space via the multimodal `gemini-embedding-2` model. It is being implemented in phases against a **Public Preview** model:
 
@@ -336,7 +336,7 @@ model:
 
 - **Images**, **PDFs**, **audio**, and **video** are supported today. Under `augment` the document is indexed *both* as text (image OCR / docling PDF text / audio transcript, if configured) *and* as direct media embeddings; under `replace` it is embedded directly *instead of* text. A PDF is embedded **per page** (each page is its own vector with a page citation); audio and video are embedded **per time window** (each window is its own vector with a `start_ms`/`end_ms` citation). A text query then retrieves images, PDF pages, and media windows from the shared space.
 - **Audio/video duration probing and window extraction** use the external `ffprobe`/`ffmpeg` binaries. When they are absent, audio/video are skipped for direct embedding and the file keeps its text path (audio transcript) — a graceful fallback, not an error. Direct audio embedding covers MP3/WAV; video covers MP4/MOV (the formats the preview model accepts). Other audio formats keep only their transcript; video has no text path.
-- `augment`/`replace` require `provider: gemini` with `text_model` and `code_model` both `gemini-embedding-2` (validated at startup; otherwise `CONFIG_INVALID`), and the mode is reindex-bound (§8.1.4). `off` (default) is fully behavior-preserving.
+- `augment`/`replace` require `provider: gemini` with `text_model` and `code_model` both `gemini-embedding-2` (validated at startup; otherwise `CONFIG_INVALID`), and the mode is reindex-bound (§8.1.4). `off` (default) is fully behavior-preserving. The mode is **YAML-only** (`model.embed.multimodal`); there is no environment-variable override, since it is a deploy-time, reindex-bound choice.
 - **Retrieval & citations.** Media hits surface in `search`/`ask` results with their `modality` and `media_ref`. To avoid double-counting, a coarse page-image candidate is dropped when a text/region candidate survives for the same `(rel_path, page)`. `ask` grounds on available text (an `augment` hit's OCR/transcript); a `replace`-mode media-only hit is cited without quoted context. `open_file` on a media-only chunk returns the non-retryable `MEDIA_NO_TEXT` (never raw bytes), distinct from the retryable `OCR_NOT_READY` when text is merely pending.
 
 See [Design 0003](dirstral-spec/docs/design/0003-multimodal-embeddings.md).
@@ -507,7 +507,7 @@ Normative docs are maintained in the [`dirstral-spec`](https://github.com/dirstr
 - [dirstral-spec/docs/SPEC.md](dirstral-spec/docs/SPEC.md) — normative behavior, schemas, and runtime contracts
 - [dirstral-spec/docs/ECOSYSTEM.md](dirstral-spec/docs/ECOSYSTEM.md) — ecosystem/market/discovery/payment context
 - [dirstral-spec/docs/x402-payment-adapter-spec.md](dirstral-spec/docs/x402-payment-adapter-spec.md) — facilitator adapter contract
-- dir2mcp implements spec version `0.5.x` ([versioning](dirstral-spec/spec/versioning.md))
+- dir2mcp implements spec version `0.14.x` ([versioning](dirstral-spec/spec/versioning.md))
 
 ## Development
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -8,7 +8,7 @@ single source of truth and this copy can no longer drift.
 - In-tree (pinned submodule): [`dirstral-spec/docs/SPEC.md`](../dirstral-spec/docs/SPEC.md)
 - Upstream: <https://github.com/dirstral/dirstral-spec/blob/main/docs/SPEC.md>
 
-dir2mcp implements spec version `0.5.x` — see [`dirstral-spec/spec/versioning.md`](../dirstral-spec/spec/versioning.md).
+dir2mcp implements spec version `0.14.x` — see [`dirstral-spec/spec/versioning.md`](../dirstral-spec/spec/versioning.md).
 
 If the `dirstral-spec/` directory is empty, fetch the submodule:
 

--- a/docs/x402-payment-adapter-spec.md
+++ b/docs/x402-payment-adapter-spec.md
@@ -8,7 +8,7 @@ single source of truth and this copy can no longer drift.
 - In-tree (pinned submodule): [`dirstral-spec/docs/x402-payment-adapter-spec.md`](../dirstral-spec/docs/x402-payment-adapter-spec.md)
 - Upstream: <https://github.com/dirstral/dirstral-spec/blob/main/docs/x402-payment-adapter-spec.md>
 
-dir2mcp implements spec version `0.5.x` — see [`dirstral-spec/spec/versioning.md`](../dirstral-spec/spec/versioning.md).
+dir2mcp implements spec version `0.14.x` — see [`dirstral-spec/spec/versioning.md`](../dirstral-spec/spec/versioning.md).
 
 If the `dirstral-spec/` directory is empty, fetch the submodule:
 

--- a/tests/mcp/x402_persistence_test.go
+++ b/tests/mcp/x402_persistence_test.go
@@ -1,0 +1,77 @@
+package tests
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// TestX402PaymentOutcomePersistsAcrossServerRestart pins issue #124's payment
+// guarantee: a settled payment outcome is persisted to the store, so after a
+// server restart the same payment request is replayed from the persisted
+// outcome instead of being re-verified/re-settled against the facilitator.
+func TestX402PaymentOutcomePersistsAcrossServerRestart(t *testing.T) {
+	fac := newFacilitatorStub(t)
+	fac.verifyStatus = http.StatusOK
+	fac.settleStatus = http.StatusOK
+	fac.verifyBody = `{"ok":true,"isValid":true,"payer":"payer-1"}`
+	fac.settleBody = `{"ok":true,"success":true,"transaction":"abc123","txHash":"abc123","network":"eip155:8453"}`
+	facServer := httptest.NewServer(fac)
+	defer facServer.Close()
+
+	cfg := x402EnabledTestConfig("https://resource.example.com")
+	cfg.AuthMode = "none"
+	cfg.X402.FacilitatorURL = facServer.URL
+
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	if err := st.Init(t.Context()); err != nil {
+		t.Fatalf("Init store: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+
+	const paidCall = `{"jsonrpc":"2.0","id":102,"method":"tools/call","params":{"name":"dir2mcp_stats","arguments":{}}}`
+	const sig = "signed-payment-payload"
+
+	// Server 1: a paid call verifies + settles exactly once.
+	server1 := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st)).Handler())
+	session1 := initializeSession(t, server1.URL+cfg.MCPPath)
+	resp1 := postRPCWithHeaders(t, server1.URL+cfg.MCPPath, session1, paidCall, map[string]string{"PAYMENT-SIGNATURE": sig})
+	if resp1.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp1.Body)
+		_ = resp1.Body.Close()
+		t.Fatalf("paid call status=%d want=200 body=%s", resp1.StatusCode, string(body))
+	}
+	_ = resp1.Body.Close()
+	if fac.verifyCalls.Load() != 1 || fac.settleCalls.Load() != 1 {
+		t.Fatalf("after first paid call: verify=%d settle=%d, want 1/1", fac.verifyCalls.Load(), fac.settleCalls.Load())
+	}
+	server1.Close()
+
+	// Server 2: same store. Re-issuing the identical payment (same signature +
+	// params => same execution key) must replay the persisted settled outcome
+	// WITHOUT calling the facilitator again.
+	server2 := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st)).Handler())
+	defer server2.Close()
+	session2 := initializeSession(t, server2.URL+cfg.MCPPath)
+	resp2 := postRPCWithHeaders(t, server2.URL+cfg.MCPPath, session2, paidCall, map[string]string{"PAYMENT-SIGNATURE": sig})
+	defer func() { _ = resp2.Body.Close() }()
+	if resp2.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp2.Body)
+		t.Fatalf("replayed call status=%d want=200 body=%s", resp2.StatusCode, string(body))
+	}
+	if strings.TrimSpace(resp2.Header.Get("PAYMENT-RESPONSE")) == "" {
+		t.Error("expected PAYMENT-RESPONSE header on the replayed paid call")
+	}
+	if got := fac.verifyCalls.Load(); got != 1 {
+		t.Errorf("verify calls after restart=%d, want 1 (no re-verification)", got)
+	}
+	if got := fac.settleCalls.Load(); got != 1 {
+		t.Errorf("settle calls after restart=%d, want 1 (no re-settlement)", got)
+	}
+}


### PR DESCRIPTION
## What

Completes the test plan for **#124** (persist session and payment state to disk). The persistence infrastructure already exists on `main` — `mcp_sessions` + `mcp_payment_outcomes` SQLite tables, `restoreSessions`/`restorePaymentOutcomes` on startup, security-filtered records (no signatures/tokens), and the store round-trip is already tested (`TestSQLiteStore_MCPPaymentOutcomePersistenceRoundTrip`). Session **server**-restart survival is covered by `TestSessionPersistsAcrossServerRestart`. The one remaining gap was the **payment**-side server-level guarantee.

## Test added

`TestX402PaymentOutcomePersistsAcrossServerRestart` — drives the real x402 flow against a facilitator stub:
- A paid `tools/call` on server 1 (shared store) verifies + settles **once**.
- After restarting onto a fresh server with the same store, the identical payment (same `PAYMENT-SIGNATURE` + params ⇒ same execution key) is **replayed from the persisted outcome**: HTTP 200 with a `PAYMENT-RESPONSE` header and **zero** additional facilitator verify/settle calls.

This pins #124's "a settled payment is not re-verified after restart."

## Scope notes

- `stats` already exposes the active **session** list (#124's "expose via stats" item). Exposing payment-outcome counts there would change the `stats` output schema, which is mirrored in `dirstral-spec/spec/tools/schemas/stats.json` — a spec-governed contract change, out of scope for this test-only PR.
- With this, #124 is functionally complete; recommend closing it once merged.

`make check` passes locally.