### PR TITLE
fix(smoke): hosted demo smoke no-auth path under set -u (bash 3.2)

### DIFF
--- a/scripts/smoke_hosted_demo.sh
+++ b/scripts/smoke_hosted_demo.sh
@@ -41,7 +41,7 @@ post_json() {
     curl -sS -o "${body_file}" -D "${headers_file}" -w "%{http_code}" \
       -X POST "${URL}" \
       "${headers[@]}" \
-      "${auth_headers[@]}" \
+      ${auth_headers[@]+"${auth_headers[@]}"} \
       --data "${body}"
   )"
 


### PR DESCRIPTION
## What

Fixes `scripts/smoke_hosted_demo.sh` so the **hosted MCP smoke runbook** (SPEC §3.4) actually runs against a **no-auth** endpoint. Surfaced while re-running the smoke for the release epic (#12).

## Bug

When `DIR2MCP_DEMO_TOKEN` is unset, `auth_headers` is an empty array. Under `set -euo pipefail`, expanding `"${auth_headers[@]}"` trips **`unbound variable`** on bash 3.2 (the macOS default). So `initialize` errored out before any pass condition was evaluated — and this is precisely the spec's documented *token-optional / no-auth* scenario.

```
[1/3] initialize
./scripts/smoke_hosted_demo.sh: line 47: auth_headers[@]: unbound variable
error: initialize failed with HTTP
```

## Fix

Use the bash 3.2-safe empty-array expansion `${auth_headers[@]+"${auth_headers[@]}"}` — includes the `Authorization` header when a token is set, omits it cleanly when not.

## Verification (reproducible)

Against a local `dir2mcp up --auth none --read-only` server:

```
DIR2MCP_DEMO_URL=http://127.0.0.1:<port>/mcp ./scripts/smoke_hosted_demo.sh
[1/3] initialize
[2/4] notifications/initialized
[3/4] tools/list
[4/4] tools/call dir2mcp_list_files
ok: hosted demo smoke checks passed
```

Exit 0; all SPEC §3.4 pass conditions met (200 + `MCP-Session-Id`, tool metadata, `list_files` JSON-RPC). The token path is unchanged (array is populated → header included).

Part of #12 (hosted remote MCP smoke with reproducible steps).