### PR TITLE
harden(ingest): isolate docling subprocess env from host Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ Under `auto`, the fallback cascade is **docling CLI → docling-serve → Mistra
 - *`OCR: disabled`* — no extractor is available: install docling (or use the `-full` track), point `serve_url` at a docling-serve container, or set `MISTRAL_API_KEY`.
 - *docling-serve rejected at startup (`CONFIG_INVALID`)* — `extractor: docling-serve` needs a non-empty, reachable `serve_url`; it never silently falls back to the CLI.
 - *Switching extractors across re-indexes* is safe — docling and Mistral OCR both produce the same `extracted_markdown` representation; only the richness of span provenance (structured `region` spans vs. `page` spans) differs.
+- *docling import errors / "two versions" of a Python package* — the docling CLI subprocess runs with a sanitized environment (`PYTHONPATH`/`PYTHONHOME` removed, `PYTHONNOUSERSITE=1`), so a conda install or stray `PYTHONPATH` in your shell can't shadow the bundled venv's pinned packages. With the `-full` track the venv is fully version-locked.
 
 ### docling extraction over HTTP (docling-serve)
 

--- a/internal/ingest/docling_extractor.go
+++ b/internal/ingest/docling_extractor.go
@@ -27,6 +27,34 @@ const (
 
 var errDoclingOutputTooLarge = errors.New("docling output exceeded configured limit")
 
+// SanitizeDoclingEnv returns env (in os.Environ "KEY=VALUE" form) with the
+// Python path-injection variables removed and user site-packages disabled, so
+// a docling subprocess resolves imports exclusively from its bundled venv.
+//
+// The docling binary is the venv's own console script, so its interpreter
+// already prefers the venv's site-packages — but PYTHONPATH entries are still
+// appended to sys.path and PYTHONHOME overrides the prefix entirely, either of
+// which can shadow the venv's pinned dependencies with a foreign version (the
+// classic "two versions installed" failure). PYTHONNOUSERSITE=1 additionally
+// keeps any user-site packages out of the path.
+func SanitizeDoclingEnv(env []string) []string {
+	out := make([]string, 0, len(env)+1)
+	for _, kv := range env {
+		key, _, ok := strings.Cut(kv, "=")
+		if !ok {
+			out = append(out, kv)
+			continue
+		}
+		switch key {
+		case "PYTHONPATH", "PYTHONHOME", "PYTHONNOUSERSITE":
+			// Drop path injectors; PYTHONNOUSERSITE is re-added canonically below.
+			continue
+		}
+		out = append(out, kv)
+	}
+	return append(out, "PYTHONNOUSERSITE=1")
+}
+
 type doclingExtractor struct {
 	commandTemplate string
 }
@@ -100,6 +128,11 @@ func (d *doclingExtractor) run(ctx context.Context, relPath string, data []byte)
 		return "", err
 	}
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	// Run docling with a sanitized environment so it uses only its bundled
+	// venv. A stray PYTHONPATH/PYTHONHOME in the caller's shell (e.g. from a
+	// conda install) would otherwise be added to the venv interpreter's
+	// sys.path and shadow the venv's pinned packages with a different version.
+	cmd.Env = SanitizeDoclingEnv(os.Environ())
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &limitedBuffer{buf: &stdout, limit: maxDoclingStdoutBytes}
 	cmd.Stderr = &limitedBuffer{buf: &stderr, limit: maxDoclingStderrBytes}

--- a/tests/ingest/docling_env_test.go
+++ b/tests/ingest/docling_env_test.go
@@ -1,0 +1,85 @@
+package tests
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/ingest"
+)
+
+// envValue returns the value of key in an os.Environ-style slice, and whether
+// it was present.
+func envValue(env []string, key string) (string, bool) {
+	for _, kv := range env {
+		if k, v, ok := strings.Cut(kv, "="); ok && k == key {
+			return v, true
+		}
+	}
+	return "", false
+}
+
+func countKey(env []string, key string) int {
+	n := 0
+	for _, kv := range env {
+		if k, _, ok := strings.Cut(kv, "="); ok && k == key {
+			n++
+		}
+	}
+	return n
+}
+
+func TestSanitizeDoclingEnv_DropsPythonPathInjectors(t *testing.T) {
+	in := []string{
+		"PATH=/usr/bin:/bin",
+		"PYTHONPATH=/opt/conda/lib/python3.11/site-packages",
+		"PYTHONHOME=/opt/conda",
+		"HOME=/Users/stas",
+	}
+	out := ingest.SanitizeDoclingEnv(in)
+
+	if _, ok := envValue(out, "PYTHONPATH"); ok {
+		t.Errorf("PYTHONPATH should be removed, got it in: %v", out)
+	}
+	if _, ok := envValue(out, "PYTHONHOME"); ok {
+		t.Errorf("PYTHONHOME should be removed, got it in: %v", out)
+	}
+	// Unrelated variables are preserved untouched.
+	if v, ok := envValue(out, "PATH"); !ok || v != "/usr/bin:/bin" {
+		t.Errorf("PATH should be preserved, got %q ok=%v", v, ok)
+	}
+	if v, ok := envValue(out, "HOME"); !ok || v != "/Users/stas" {
+		t.Errorf("HOME should be preserved, got %q ok=%v", v, ok)
+	}
+}
+
+func TestSanitizeDoclingEnv_ForcesNoUserSite(t *testing.T) {
+	// A caller-provided PYTHONNOUSERSITE must be replaced with the canonical
+	// value, with no duplicate entry left behind.
+	in := []string{"PYTHONNOUSERSITE=0", "FOO=bar"}
+	out := ingest.SanitizeDoclingEnv(in)
+
+	if got := countKey(out, "PYTHONNOUSERSITE"); got != 1 {
+		t.Fatalf("expected exactly one PYTHONNOUSERSITE entry, got %d in %v", got, out)
+	}
+	if v, _ := envValue(out, "PYTHONNOUSERSITE"); v != "1" {
+		t.Errorf("PYTHONNOUSERSITE should be forced to 1, got %q", v)
+	}
+}
+
+func TestSanitizeDoclingEnv_AddsNoUserSiteWhenAbsent(t *testing.T) {
+	out := ingest.SanitizeDoclingEnv([]string{"PATH=/usr/bin"})
+	if !slices.Contains(out, "PYTHONNOUSERSITE=1") {
+		t.Errorf("PYTHONNOUSERSITE=1 should be added, got %v", out)
+	}
+}
+
+func TestSanitizeDoclingEnv_HandlesMalformedEntries(t *testing.T) {
+	// Entries without '=' (rare but legal in os.Environ) are passed through
+	// rather than dropped or panicking.
+	in := []string{"WEIRD", "PATH=/bin"}
+	out := ingest.SanitizeDoclingEnv(in)
+	if !slices.Contains(out, "WEIRD") {
+		t.Errorf("malformed entry should be preserved, got %v", out)
+	}
+}


### PR DESCRIPTION
## Why

`dir2mcp-full` runs docling from a dedicated venv, but the Go side spawned the docling CLI **inheriting the full shell environment** (`docling_extractor.go` set no `cmd.Env`). A venv interpreter still honors `PYTHONPATH` (appended to `sys.path`) and `PYTHONHOME` (overrides the prefix), so a conda install or a stray `PYTHONPATH` in the user's shell can **shadow the venv's pinned packages with a different version** — the classic "two versions installed" import crash (observed on a real user's laptop).

The new dependency lock (homebrew-tap #19) guarantees the venv *contains* the right packages; this guarantees docling actually *uses* them.

## What

- Add `SanitizeDoclingEnv`: strips `PYTHONPATH`/`PYTHONHOME` and forces `PYTHONNOUSERSITE=1`, deduping any caller-supplied value.
- Apply it to the docling CLI subprocess (`cmd.Env`) in `run()`. docling now resolves imports exclusively from its bundled venv regardless of the caller's shell.
- Only affects the local docling **CLI** path; `docling-serve` (HTTP) is unaffected.

## Scope / governance

Non-normative — no change to any tool/error/spec contract, just how the existing extractor subprocess is spawned. No `dirstral-spec` PR or submodule re-pin required.

## Tests

`tests/ingest/docling_env_test.go` covers: drops the injectors, preserves unrelated vars, forces `PYTHONNOUSERSITE=1` (no duplicate), adds it when absent, tolerates malformed entries. `make check` green.

## Docs

README docling troubleshooting note for the "two versions" symptom.