### PR TITLE
harden(ingest): treat present-but-broken docling as unavailable (spec 0.15.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,8 @@ PDFs and images are converted to text by an **extractor**, selected with `ingest
 
 Under `auto`, the fallback cascade is **docling CLI → docling-serve → Mistral OCR → disabled**. The chosen extractor is reported at startup and by `dir2mcp doctor` (e.g. `OCR: mistral-ocr (fallback; docling not found on PATH)`), so the active path is visible rather than inferred per document.
 
+An extractor counts as *available* only when it can actually **run**, not merely when it is configured (spec 0.15.0 §7.4). The `docling` CLI is functional-checked (a quick `docling --version` probe, cached for the run); a binary that is present but broken — e.g. a venv with ABI-incompatible dependencies — is treated as **unavailable**, exactly as an unreachable `serve_url` makes `docling-serve` unavailable. Under `auto` a broken docling is skipped and the cascade continues; under explicit `docling` it disables extraction (no silent fallback). `dir2mcp doctor` reports the real state instead of a false "healthy".
+
 **Troubleshooting:**
 - *`OCR: disabled`* — no extractor is available: install docling (or use the `-full` track), point `serve_url` at a docling-serve container, or set `MISTRAL_API_KEY`.
 - *docling-serve rejected at startup (`CONFIG_INVALID`)* — `extractor: docling-serve` needs a non-empty, reachable `serve_url`; it never silently falls back to the CLI.

--- a/internal/ingest/decision.go
+++ b/internal/ingest/decision.go
@@ -2,7 +2,6 @@ package ingest
 
 import (
 	"context"
-	"os/exec"
 	"strings"
 
 	"github.com/dirstral/dir2mcp/internal/config"
@@ -61,13 +60,7 @@ func describeDocumentExtractor(ctx context.Context, cfg config.Config) Extractor
 	case "off":
 		return ExtractorDecision{Source: "disabled", Reason: "ingest.extractor=off"}
 	case "docling":
-		if tpl := strings.TrimSpace(cfg.DoclingCommand); tpl != "" {
-			return ExtractorDecision{Name: "docling", Source: "explicit", Reason: "configured docling command"}
-		}
-		if _, err := exec.LookPath("docling"); err == nil {
-			return ExtractorDecision{Name: "docling", Source: "explicit", Reason: "auto-detected on PATH"}
-		}
-		return ExtractorDecision{Source: "disabled", Reason: "ingest.extractor=docling but docling command is unavailable"}
+		return describeExplicitDocling(ctx, cfg)
 	case "docling-serve":
 		return describeExplicitDoclingServe(ctx, cfg)
 	case "mistral":
@@ -92,29 +85,50 @@ func describeExplicitDoclingServe(ctx context.Context, cfg config.Config) Extrac
 	}
 }
 
-func describeAutoDocumentExtractor(ctx context.Context, cfg config.Config) ExtractorDecision {
-	if tpl := strings.TrimSpace(cfg.DoclingCommand); tpl != "" {
-		return ExtractorDecision{Name: "docling", Source: "auto", Reason: "configured docling command"}
+// describeExplicitDocling resolves the docling CLI for ingest.extractor=docling.
+// Per spec 0.15.0 §7.4 the extractor is available only when it both resolves
+// AND passes a functional check; a present-but-broken docling disables
+// extraction (no silent fallback to another engine), mirroring explicit
+// docling-serve.
+func describeExplicitDocling(ctx context.Context, cfg config.Config) ExtractorDecision {
+	bin, source, ok := resolveDoclingBinary(cfg)
+	if !ok {
+		return ExtractorDecision{Source: "disabled", Reason: "ingest.extractor=docling but docling command is unavailable"}
 	}
-	if _, err := exec.LookPath("docling"); err == nil {
-		return ExtractorDecision{Name: "docling", Source: "auto", Reason: "auto-detected on PATH"}
+	if err := doclingFunctionalCheck(ctx, bin); err != nil {
+		return ExtractorDecision{Source: "disabled", Reason: "ingest.extractor=docling but the docling command is present yet failed its functional check"}
 	}
-	return describeAutoWithoutDoclingCLI(ctx, cfg)
+	return ExtractorDecision{Name: "docling", Source: "explicit", Reason: doclingResolvedReason(source)}
 }
 
-func describeAutoWithoutDoclingCLI(ctx context.Context, cfg config.Config) ExtractorDecision {
+func describeAutoDocumentExtractor(ctx context.Context, cfg config.Config) ExtractorDecision {
+	if bin, source, ok := resolveDoclingBinary(cfg); ok {
+		if err := doclingFunctionalCheck(ctx, bin); err == nil {
+			return ExtractorDecision{Name: "docling", Source: "auto", Reason: doclingResolvedReason(source)}
+		}
+		// Resolved but non-functional: skip it and continue the cascade so a
+		// broken docling install degrades gracefully (spec 0.15.0 §7.4).
+		return describeAutoWithoutDoclingCLI(ctx, cfg, "docling CLI present but failed its functional check")
+	}
+	return describeAutoWithoutDoclingCLI(ctx, cfg, "docling not found on PATH")
+}
+
+// describeAutoWithoutDoclingCLI continues the auto cascade when the docling CLI
+// is unavailable. doclingReason explains why (not on PATH, or present but
+// non-functional) and prefixes the fallback reasons.
+func describeAutoWithoutDoclingCLI(ctx context.Context, cfg config.Config, doclingReason string) ExtractorDecision {
 	serveURL := strings.TrimSpace(cfg.IngestDoclingServeURL)
 	switch {
 	case serveURL != "" && ProbeDoclingServe(ctx, serveURL) == nil:
-		return ExtractorDecision{Name: "docling-serve", Source: "auto", Reason: "configured docling-serve endpoint; docling CLI not found"}
+		return ExtractorDecision{Name: "docling-serve", Source: "auto", Reason: doclingReason + "; using configured docling-serve endpoint"}
 	case mistralOCRAvailable(cfg) && serveURL != "":
-		return ExtractorDecision{Name: "mistral-ocr", Source: "fallback", Reason: "docling not found on PATH; docling-serve endpoint unreachable; falling back to Mistral OCR"}
+		return ExtractorDecision{Name: "mistral-ocr", Source: "fallback", Reason: doclingReason + "; docling-serve endpoint unreachable; falling back to Mistral OCR"}
 	case mistralOCRAvailable(cfg):
-		return ExtractorDecision{Name: "mistral-ocr", Source: "fallback", Reason: "docling not found on PATH; falling back to Mistral OCR"}
+		return ExtractorDecision{Name: "mistral-ocr", Source: "fallback", Reason: doclingReason + "; falling back to Mistral OCR"}
 	case serveURL != "":
-		return ExtractorDecision{Source: "disabled", Reason: "docling not found on PATH; docling-serve endpoint unreachable; and no Mistral credential"}
+		return ExtractorDecision{Source: "disabled", Reason: doclingReason + "; docling-serve endpoint unreachable; and no Mistral credential"}
 	default:
-		return ExtractorDecision{Source: "disabled", Reason: "no extractor available: docling not on PATH, no docling-serve URL, and no Mistral credential"}
+		return ExtractorDecision{Source: "disabled", Reason: "no extractor available: " + doclingReason + ", no docling-serve URL, and no Mistral credential"}
 	}
 }
 

--- a/internal/ingest/docling_probe.go
+++ b/internal/ingest/docling_probe.go
@@ -16,14 +16,22 @@ import (
 // cannot stall startup or `dir2mcp doctor`.
 const doclingProbeTimeout = 20 * time.Second
 
-// doclingProbeCache memoizes the functional-check result per resolved binary
-// for the process lifetime. Spec 0.15.0 §7.4 says implementations SHOULD cache
-// the result for the run rather than probing per document; a long-running
-// daemon whose docling is repaired mid-run picks up the change on the next
+// doclingProbeEntry memoizes one binary's functional-check result; the
+// sync.Once ensures the probe runs at most once per binary even under
+// concurrent callers.
+type doclingProbeEntry struct {
+	once sync.Once
+	err  error
+}
+
+// doclingProbeEntries caches functional-check results per resolved binary for
+// the process lifetime. Spec 0.15.0 §7.4 says implementations SHOULD cache the
+// result for the run rather than probing per document; a long-running daemon
+// whose docling is repaired mid-run picks up the change on the next
 // `dir2mcp up`.
 var (
-	doclingProbeMu    sync.Mutex
-	doclingProbeCache = map[string]error{}
+	doclingProbeMu      sync.Mutex
+	doclingProbeEntries = map[string]*doclingProbeEntry{}
 )
 
 // resolveDoclingBinary returns the docling executable that would run for cfg,
@@ -70,18 +78,19 @@ func doclingFunctionalCheck(ctx context.Context, bin string) error {
 	}
 
 	doclingProbeMu.Lock()
-	cached, ok := doclingProbeCache[bin]
-	doclingProbeMu.Unlock()
-	if ok {
-		return cached
+	entry, ok := doclingProbeEntries[bin]
+	if !ok {
+		entry = &doclingProbeEntry{}
+		doclingProbeEntries[bin] = entry
 	}
-
-	err := runDoclingVersionProbe(ctx, bin)
-
-	doclingProbeMu.Lock()
-	doclingProbeCache[bin] = err
 	doclingProbeMu.Unlock()
-	return err
+
+	// At most one probe per binary; concurrent callers for the same bin wait,
+	// callers for other bins proceed independently.
+	entry.once.Do(func() {
+		entry.err = runDoclingVersionProbe(ctx, bin)
+	})
+	return entry.err
 }
 
 // looksLikeDocling reports whether bin's base name identifies the real docling

--- a/internal/ingest/docling_probe.go
+++ b/internal/ingest/docling_probe.go
@@ -1,0 +1,104 @@
+package ingest
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+)
+
+// doclingProbeTimeout bounds the docling functional check so a hung binary
+// cannot stall startup or `dir2mcp doctor`.
+const doclingProbeTimeout = 20 * time.Second
+
+// doclingProbeCache memoizes the functional-check result per resolved binary
+// for the process lifetime. Spec 0.15.0 §7.4 says implementations SHOULD cache
+// the result for the run rather than probing per document; a long-running
+// daemon whose docling is repaired mid-run picks up the change on the next
+// `dir2mcp up`.
+var (
+	doclingProbeMu    sync.Mutex
+	doclingProbeCache = map[string]error{}
+)
+
+// resolveDoclingBinary returns the docling executable that would run for cfg,
+// how it was resolved ("command" from ingest.docling.command, or "path" from
+// PATH), and whether it resolved at all. The binary value itself is never
+// surfaced in diagnostics (a user command/path may be sensitive); callers map
+// source to a redacted reason via doclingResolvedReason.
+func resolveDoclingBinary(cfg config.Config) (bin, source string, ok bool) {
+	if tpl := strings.TrimSpace(cfg.DoclingCommand); tpl != "" {
+		if fields := strings.Fields(tpl); len(fields) > 0 {
+			return fields[0], "command", true
+		}
+	}
+	if p, err := exec.LookPath("docling"); err == nil {
+		return p, "path", true
+	}
+	return "", "", false
+}
+
+// doclingResolvedReason maps a resolveDoclingBinary source to the redacted
+// reason used in diagnostics.
+func doclingResolvedReason(source string) string {
+	if source == "path" {
+		return "auto-detected on PATH"
+	}
+	return "configured docling command"
+}
+
+// doclingFunctionalCheck reports whether a resolved docling binary actually
+// runs (spec 0.15.0 §7.4: an extractor is available only when it resolves AND
+// passes a lightweight functional check). A docling whose bundled virtualenv
+// has ABI-incompatible dependencies resolves but crashes at import, so it must
+// be treated as unavailable rather than selected and then failing every
+// document.
+//
+// The check applies only to actual docling binaries (basename "docling"),
+// which covers the bundled venv and a PATH docling — the cases where the import
+// crash occurs. A custom ingest.docling.command may point at a wrapper that does
+// not understand --version, so such commands keep the prior "resolvable ==
+// available" behavior and are not probed.
+func doclingFunctionalCheck(ctx context.Context, bin string) error {
+	if !looksLikeDocling(bin) {
+		return nil
+	}
+
+	doclingProbeMu.Lock()
+	cached, ok := doclingProbeCache[bin]
+	doclingProbeMu.Unlock()
+	if ok {
+		return cached
+	}
+
+	err := runDoclingVersionProbe(ctx, bin)
+
+	doclingProbeMu.Lock()
+	doclingProbeCache[bin] = err
+	doclingProbeMu.Unlock()
+	return err
+}
+
+// looksLikeDocling reports whether bin's base name identifies the real docling
+// CLI (which supports `--version`).
+func looksLikeDocling(bin string) bool {
+	base := strings.ToLower(filepath.Base(strings.TrimSpace(bin)))
+	base = strings.TrimSuffix(base, ".exe")
+	return base == "docling"
+}
+
+// runDoclingVersionProbe runs `<bin> --version` with a sanitized environment
+// (see SanitizeDoclingEnv) and a bounded timeout, discarding output. A non-nil
+// return means the binary is present but non-functional.
+func runDoclingVersionProbe(ctx context.Context, bin string) error {
+	pctx, cancel := context.WithTimeout(ctx, doclingProbeTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(pctx, bin, "--version")
+	cmd.Env = SanitizeDoclingEnv(os.Environ())
+	return cmd.Run()
+}

--- a/tests/ingest/docling_functional_check_test.go
+++ b/tests/ingest/docling_functional_check_test.go
@@ -1,0 +1,125 @@
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+)
+
+// makeDoclingStub writes an executable named "docling" (so it is treated as a
+// real docling binary) that ignores its arguments and exits with exitCode. It
+// returns the absolute path. Each call uses a fresh temp dir, so the per-binary
+// functional-check cache never collides across tests.
+func makeDoclingStub(t *testing.T, exitCode int) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "docling")
+	script := "#!/bin/sh\nexit " + strconv.Itoa(exitCode) + "\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write docling stub: %v", err)
+	}
+	return path
+}
+
+func TestDescribeDocumentExtractor_AutoSelectsFunctionalDocling(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX stub script")
+	}
+	d := ingest.DescribeDocumentExtractor(config.Config{
+		IngestExtractor: "auto",
+		DoclingCommand:  makeDoclingStub(t, 0),
+	})
+	if d.Name != "docling" || d.Source != "auto" {
+		t.Fatalf("functional docling should be selected under auto: got name=%q source=%q (%s)", d.Name, d.Source, d.Reason)
+	}
+}
+
+func TestDescribeDocumentExtractor_AutoSkipsBrokenDocling(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX stub script")
+	}
+	// No Mistral credential and no serve URL: a broken docling under auto must
+	// not be selected, leaving no extractor (rather than failing every doc).
+	t.Setenv("MISTRAL_API_KEY", "")
+	d := ingest.DescribeDocumentExtractor(config.Config{
+		IngestExtractor: "auto",
+		DoclingCommand:  makeDoclingStub(t, 1),
+	})
+	if d.Name == "docling" {
+		t.Fatalf("broken docling must not be selected under auto: got name=%q (%s)", d.Name, d.Reason)
+	}
+	if d.Name != "" || d.Source != "disabled" {
+		t.Fatalf("expected disabled with no fallback available: got name=%q source=%q (%s)", d.Name, d.Source, d.Reason)
+	}
+	if !strings.Contains(d.Reason, "functional check") {
+		t.Errorf("reason should explain the functional-check failure: %q", d.Reason)
+	}
+}
+
+func TestDescribeDocumentExtractor_AutoBrokenDoclingFallsBackToMistral(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX stub script")
+	}
+	t.Setenv("MISTRAL_API_KEY", "fake-key")
+	d := ingest.DescribeDocumentExtractor(config.Config{
+		IngestExtractor: "auto",
+		DoclingCommand:  makeDoclingStub(t, 1),
+	})
+	if d.Name != "mistral-ocr" || d.Source != "fallback" {
+		t.Fatalf("broken docling under auto should fall back to Mistral: got name=%q source=%q (%s)", d.Name, d.Source, d.Reason)
+	}
+}
+
+func TestDescribeDocumentExtractor_ExplicitBrokenDoclingDisables(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX stub script")
+	}
+	// Even with a Mistral credential present, explicit docling must NOT silently
+	// fall back — a present-but-broken command disables extraction.
+	t.Setenv("MISTRAL_API_KEY", "fake-key")
+	d := ingest.DescribeDocumentExtractor(config.Config{
+		IngestExtractor: "docling",
+		DoclingCommand:  makeDoclingStub(t, 1),
+	})
+	if d.Name != "" || d.Source != "disabled" {
+		t.Fatalf("explicit broken docling should be disabled (no fallback): got name=%q source=%q (%s)", d.Name, d.Source, d.Reason)
+	}
+	if !strings.Contains(d.Reason, "functional check") {
+		t.Errorf("reason should explain the functional-check failure: %q", d.Reason)
+	}
+}
+
+func TestDescribeDocumentExtractor_ExplicitFunctionalDoclingSelected(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX stub script")
+	}
+	d := ingest.DescribeDocumentExtractor(config.Config{
+		IngestExtractor: "docling",
+		DoclingCommand:  makeDoclingStub(t, 0),
+	})
+	if d.Name != "docling" || d.Source != "explicit" {
+		t.Fatalf("functional docling should be selected: got name=%q source=%q (%s)", d.Name, d.Source, d.Reason)
+	}
+}
+
+func TestDescribeDocumentExtractor_CustomNonDoclingCommandNotProbed(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX command test")
+	}
+	// A custom command whose basename is not "docling" is not functional-checked
+	// (it may not understand --version); it stays available if configured, as
+	// before. "/bin/false" would fail a --version probe, but is not probed here.
+	d := ingest.DescribeDocumentExtractor(config.Config{
+		IngestExtractor: "docling",
+		DoclingCommand:  "/bin/false {input}",
+	})
+	if d.Name != "docling" || d.Source != "explicit" {
+		t.Fatalf("non-docling custom command must not be probed: got name=%q source=%q (%s)", d.Name, d.Source, d.Reason)
+	}
+}


### PR DESCRIPTION
## Summary

Implements **spec 0.15.0 §7.4** (merged in dirstral-spec #16): an extractor is *available* only when it both **resolves** AND passes a **functional check** — not merely when it's configured. The `docling` CLI is now probed (`docling --version`, sanitized env, cached per resolved binary for the run). A binary that resolves but crashes — e.g. a bundled venv with ABI-incompatible dependencies (the "two versions" failure observed on a real laptop) — is treated as **unavailable**, exactly as an unreachable `serve_url` already makes `docling-serve` unavailable.

## Behavior

- **`auto`**: a broken docling is skipped and the cascade continues (docling-serve → Mistral OCR → disabled) instead of failing every document.
- **explicit `docling`**: a present-but-broken command disables extraction with **no silent fallback**, mirroring explicit `docling-serve`.
- **`doctor` / startup banner**: surface the real decision + reason automatically — they already delegate to `DescribeDocumentExtractor`, and the builder (`DocumentExtractorFromConfig`) switches on `decision.Name`, so selection stays in lockstep.

## Scope

- The probe targets **actual docling binaries** (basename `docling`) — the bundled venv and a PATH docling, where the import crash happens. A custom `ingest.docling.command` wrapper (which may not understand `--version`) keeps the prior "resolvable == available" behavior, so existing custom-command configs are unaffected.
- Reuses `SanitizeDoclingEnv` (from #234) for the probe, so the check itself is immune to host-Python shadowing.

## Governance

Re-pins the `dirstral-spec` submodule to the merged **0.15.0** commit (`ecb2364`) per the spec-first governance loop.

## Tests

`tests/ingest/docling_functional_check_test.go`: auto selects functional docling; auto skips broken docling (→ disabled / → Mistral fallback); explicit broken disables with no fallback; explicit functional selected; custom non-docling command not probed. Existing extractor/doctor tests unchanged and green. `make check` passes.

## Docs

README extractor section documents the functional check + graceful degradation.

Completes the docling robustness arc: dependency lock (homebrew-tap #19) pins the venv contents, env isolation (#234) makes docling use only that venv, and this PR detects a broken venv and degrades gracefully instead of failing silently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Document extraction now performs a runtime functional check of the docling CLI; broken docling is treated as unavailable.
  * In auto mode, a non-functional docling is skipped so fallbacks run; when docling is explicitly configured, a broken docling disables extraction (no silent fallback).
  * Health reporting now reflects real extractor availability.

* **Documentation**
  * Updated extractor availability docs to describe the new functional-check behavior and fallback semantics.

* **Tests**
  * Added functional tests covering extractor selection and docling probe behavior.

* **Chores**
  * Updated specification submodule reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->