### PR TITLE
feat(cli): wizard offers OS keychain vs .env.local for credential storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ DIR2MCP_DEMO_TOKEN="$(cat .dir2mcp/secret.token)" \
 | `open-file <rel-path>` | Legacy compatibility shim; prefer `dirstral-cli` for client UX |
 | `list-files` | Legacy compatibility shim; prefer `dirstral-cli` for client UX |
 | `reindex` | Force full re-ingestion |
-| `config init` | Interactive setup wizard (on a TTY): prompts for provider API keys (saved to `.env.local`) and a corpus profile, then writes/updates `.dir2mcp.yaml`. Non-interactive (`--non-interactive`/`--json`/`--quiet`/no TTY) just writes a baseline config. `dir2mcp up` also launches this wizard on first run when started interactively (a TTY, and not `--json`/`--non-interactive`/read-only) and no embedding provider resolves. |
+| `config init` | Interactive setup wizard (on a TTY): prompts for provider API keys, where to store them (`.env.local` or the OS keychain), and a corpus profile, then writes/updates `.dir2mcp.yaml`. Non-interactive (`--non-interactive`/`--json`/`--quiet`/no TTY) just writes a baseline config. `dir2mcp up` also launches this wizard on first run when started interactively (a TTY, and not `--json`/`--non-interactive`/read-only) and no embedding provider resolves. |
 | `config print` | Print effective config |
 | `config set-secret <ENV_VAR>` | Store a provider credential in the OS keychain (encrypted at rest) instead of a plaintext `.env.local` |
 | `config rm-secret <ENV_VAR>` | Remove a credential from the OS keychain |

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -56,16 +56,32 @@ func (a *App) setupWizardEligible(global globalOptions) bool {
 	return isTerminal(os.Stdin) && isTerminal(os.Stdout)
 }
 
-// emitWizardSummary reports what the wizard persisted (saved credentials and
-// the applied corpus profile). No-op when nothing was collected or under
+// secretWriter returns the credential-upsert function for the chosen
+// destination: the .env.local writer for DestFile, or an OS keychain writer for
+// DestKeychain (path argument ignored).
+func secretWriter(dest setupwizard.SecretDest) func(path, keyName, value string) error {
+	if dest == setupwizard.DestKeychain {
+		return func(_ string, keyName, value string) error {
+			return secrets.Set(secrets.DefaultService, keyName, value)
+		}
+	}
+	return saveEnvLocalKey
+}
+
+// emitWizardSummary reports what the wizard persisted (saved credentials, where,
+// and the applied corpus profile). No-op when nothing was collected or under
 // quiet/JSON output.
-func (a *App) emitWizardSummary(global globalOptions, envPath string, savedKeys []string, profile setupwizard.Profile) {
+func (a *App) emitWizardSummary(global globalOptions, envPath string, savedKeys []string, dest setupwizard.SecretDest, profile setupwizard.Profile) {
 	if global.quiet || global.jsonOutput {
 		return
 	}
 	s := a.sty(false)
 	if len(savedKeys) > 0 {
-		writef(a.stdout, "%s saved %s to %s\n", s.Success.Render("✓"), strings.Join(savedKeys, ", "), envPath)
+		location := envPath
+		if dest == setupwizard.DestKeychain {
+			location = fmt.Sprintf("the OS keychain (service %q)", secrets.DefaultService)
+		}
+		writef(a.stdout, "%s saved %s to %s\n", s.Success.Render("✓"), strings.Join(savedKeys, ", "), location)
 	}
 	if profile != "" && profile != setupwizard.ProfileGeneral && profile != setupwizard.ProfileKeep {
 		writef(a.stdout, "%s applied corpus profile: %s\n", s.Success.Render("✓"), profile)
@@ -159,7 +175,7 @@ func (a *App) runConfigInit(global globalOptions, args []string) int {
 	// .env.local only — never the .dir2mcp.yaml snapshot. Non-TTY / --json /
 	// --quiet / --non-interactive paths skip the form and keep prior behavior.
 	envPath := filepath.Join(filepath.Dir(configPath), ".env.local")
-	savedKeys, chosenProfile, exitCode := a.runConfigInitWizard(global, configPath, envPath, !created, &cfg)
+	savedKeys, chosenProfile, dest, exitCode := a.runConfigInitWizard(global, configPath, envPath, !created, &cfg)
 	if exitCode >= 0 {
 		return exitCode
 	}
@@ -170,7 +186,7 @@ func (a *App) runConfigInit(global globalOptions, args []string) int {
 	}
 
 	a.emitConfigCreatedMessage(global, configPath, created)
-	a.emitWizardSummary(global, envPath, savedKeys, chosenProfile)
+	a.emitWizardSummary(global, envPath, savedKeys, dest, chosenProfile)
 	if a.setupWizardEligible(global) {
 		a.emitSetupVerification(global)
 	}
@@ -220,10 +236,11 @@ func (a *App) runConfigInit(global globalOptions, args []string) int {
 // exitCode: a negative exitCode means "continue" (form ran, was skipped, or the
 // user aborted into a baseline write); a non-negative exitCode is terminal and
 // the caller should return it.
-func (a *App) runConfigInitWizard(global globalOptions, configPath, envPath string, configExisted bool, cfg *config.Config) (savedKeys []string, profile setupwizard.Profile, exitCode int) {
+func (a *App) runConfigInitWizard(global globalOptions, configPath, envPath string, configExisted bool, cfg *config.Config) (savedKeys []string, profile setupwizard.Profile, dest setupwizard.SecretDest, exitCode int) {
 	exitCode = -1
+	dest = setupwizard.DestFile
 	if !a.setupWizardEligible(global) {
-		return savedKeys, profile, exitCode
+		return savedKeys, profile, dest, exitCode
 	}
 
 	res, err := setupwizard.Run(setupwizard.Input{
@@ -235,18 +252,21 @@ func (a *App) runConfigInitWizard(global globalOptions, configPath, envPath stri
 		writeln(a.stderr, "setup cancelled; writing baseline config only")
 	case err != nil:
 		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("setup wizard: %v", err))
-		return savedKeys, profile, exitGeneric
+		return savedKeys, profile, dest, exitGeneric
 	default:
 		setupwizard.ApplyCorpusProfile(cfg, res.Profile)
 		profile = res.Profile
-		savedKeys, err = setupwizard.PersistKeys(envPath, res.Keys, saveEnvLocalKey)
+		dest = res.Destination
+		savedKeys, err = setupwizard.PersistKeys(envPath, res.Keys, secretWriter(dest))
 		if err != nil {
-			writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("save .env.local: %v", err))
-			return savedKeys, profile, exitGeneric
+			writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("save credentials: %v", err))
+			return savedKeys, profile, dest, exitGeneric
 		}
-		a.protectSecretsFromGit(filepath.Dir(configPath))
+		if dest == setupwizard.DestFile {
+			a.protectSecretsFromGit(filepath.Dir(configPath))
+		}
 	}
-	return savedKeys, profile, exitCode
+	return savedKeys, profile, dest, exitCode
 }
 
 // protectSecretsFromGit appends .env.local and the state dir to .gitignore when

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -935,11 +935,13 @@ func (a *App) persistFirstRunSetup(opts upOptions, configPath, envPath string, c
 		writeCLIError(a.stderr, opts.jsonOutput, exitGeneric, fmt.Sprintf("save config file: %v", err))
 		return exitGeneric
 	}
-	if _, err := setupwizard.PersistKeys(envPath, res.Keys, saveEnvLocalKey); err != nil {
-		writeCLIError(a.stderr, opts.jsonOutput, exitGeneric, fmt.Sprintf("save .env.local: %v", err))
+	if _, err := setupwizard.PersistKeys(envPath, res.Keys, secretWriter(res.Destination)); err != nil {
+		writeCLIError(a.stderr, opts.jsonOutput, exitGeneric, fmt.Sprintf("save credentials: %v", err))
 		return exitGeneric
 	}
-	a.protectSecretsFromGit(filepath.Dir(configPath))
+	if res.Destination == setupwizard.DestFile {
+		a.protectSecretsFromGit(filepath.Dir(configPath))
+	}
 	return exitSuccess
 }
 

--- a/internal/setupwizard/wizard.go
+++ b/internal/setupwizard/wizard.go
@@ -149,12 +149,24 @@ func ApplyCorpusProfile(cfg *config.Config, profile Profile) {
 	}
 }
 
+// SecretDest is where the wizard persists the collected credentials.
+type SecretDest string
+
+const (
+	// DestFile writes credentials to .env.local (plaintext, 0600). Works with
+	// the background daemon.
+	DestFile SecretDest = "file"
+	// DestKeychain stores credentials in the OS keychain (encrypted at rest).
+	DestKeychain SecretDest = "keychain"
+)
+
 // Result holds the user's answers from the setup form: the collected
-// credentials (keyed by env var, empty entries dropped) and the chosen corpus
-// profile.
+// credentials (keyed by env var, empty entries dropped), the chosen corpus
+// profile, and where to persist the credentials.
 type Result struct {
-	Keys    map[string]string
-	Profile Profile
+	Keys        map[string]string
+	Profile     Profile
+	Destination SecretDest
 }
 
 // Input parameterizes the setup form with what is already known about the
@@ -185,6 +197,7 @@ func BuildForm(
 	keyValues map[string]*string,
 	configureMore *bool,
 	profile *string,
+	dest *string,
 	save *bool,
 	in Input,
 ) *huh.Form {
@@ -241,6 +254,17 @@ func BuildForm(
 			Value(profile),
 	)
 
+	destGroup := huh.NewGroup(
+		huh.NewSelect[string]().
+			Title("Where to store credentials?").
+			Description("Keychain is encrypted at rest; .env.local also works for the background service.").
+			Options(
+				huh.NewOption(".env.local file", string(DestFile)),
+				huh.NewOption("OS keychain (encrypted)", string(DestKeychain)),
+			).
+			Value(dest),
+	)
+
 	confirmGroup := huh.NewGroup(
 		huh.NewConfirm().
 			Title("Save these settings?").
@@ -249,7 +273,7 @@ func BuildForm(
 			Value(save),
 	)
 
-	return huh.NewForm(providerGroup, optionalGroup, profileGroup, confirmGroup).
+	return huh.NewForm(providerGroup, optionalGroup, destGroup, profileGroup, confirmGroup).
 		WithTheme(brandTheme())
 }
 
@@ -309,8 +333,9 @@ func Run(in Input) (Result, error) {
 	if in.ConfigExisted {
 		profile = string(ProfileKeep)
 	}
+	dest := string(DestFile)
 
-	form := BuildForm(keyValues, &configureMore, &profile, &save, in)
+	form := BuildForm(keyValues, &configureMore, &profile, &dest, &save, in)
 	if err := form.Run(); err != nil {
 		return Result{}, err
 	}
@@ -324,7 +349,7 @@ func Run(in Input) (Result, error) {
 			keys[env] = v
 		}
 	}
-	return Result{Keys: keys, Profile: Profile(profile)}, nil
+	return Result{Keys: keys, Profile: Profile(profile), Destination: SecretDest(dest)}, nil
 }
 
 // PersistKeys writes each non-empty collected credential via write (a dotenv

--- a/tests/setupwizard/wizard_test.go
+++ b/tests/setupwizard/wizard_test.go
@@ -205,14 +205,24 @@ func TestBuildForm_ConstructsWithoutPanic(t *testing.T) {
 	}
 	var more, save bool
 	profile := string(setupwizard.ProfileGeneral)
+	dest := string(setupwizard.DestFile)
 
 	for _, existed := range []bool{false, true} {
-		form := setupwizard.BuildForm(keyValues, &more, &profile, &save, setupwizard.Input{
+		form := setupwizard.BuildForm(keyValues, &more, &profile, &dest, &save, setupwizard.Input{
 			ExistingKeys:  map[string]bool{"MISTRAL_API_KEY": existed},
 			ConfigExisted: existed,
 		})
 		if form == nil {
 			t.Fatalf("BuildForm returned nil (configExisted=%t)", existed)
 		}
+	}
+}
+
+func TestSecretDestConstants(t *testing.T) {
+	if setupwizard.DestFile == setupwizard.DestKeychain {
+		t.Fatal("DestFile and DestKeychain must be distinct")
+	}
+	if setupwizard.DestFile != "file" || setupwizard.DestKeychain != "keychain" {
+		t.Fatalf("unexpected dest values: file=%q keychain=%q", setupwizard.DestFile, setupwizard.DestKeychain)
 	}
 }


### PR DESCRIPTION
## Summary
Connects the keychain backend (#237) to the setup wizard (#236): `config init` / `up` first-run now asks **where** to store the collected provider credentials.

- New **"Where to store credentials?"** select in the wizard: `.env.local file` (default — works with the background daemon) or **OS keychain (encrypted)** (SPEC §16.1.1 source #2).
- The choice drives the persist writer (`secretWriter`): file → `.env.local` (0600), keychain → `secrets.Set`. `.gitignore` protection runs only for the file destination; the summary line reports the real location.
- Centralized in `setupwizard` (`Result.Destination`, `SecretDest`); the brand theme/flow is unchanged.

## Tests
- New `TestSecretDestConstants`; `BuildForm` construction test updated for the new field.
- `make check` passes locally.

Branched off `main` (both #236 and #237 are merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Setup wizard now allows users to choose where to store provider credentials: in a plaintext configuration file or in the encrypted OS keychain.
  * Wizard summary now displays the location where credentials were saved.

* **Documentation**
  * Clarified `config init` CLI documentation to explain interactive vs. non-interactive mode behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->