### PR TITLE
feat(quality): standalone output-quality-gate package (#262)

### DIFF
--- a/internal/quality/config.go
+++ b/internal/quality/config.go
@@ -1,0 +1,115 @@
+package quality
+
+// Config bundles the configuration for every detector. Callers should
+// generally start from [DefaultConfig] and disable detectors selectively,
+// because [Config.WithDefaults] fills only unset thresholds and does not
+// force Enabled flags on.
+type Config struct {
+	Empty      EmptyConfig
+	Repetition RepetitionConfig
+	Gibberish  GibberishConfig
+	Language   LanguageConfig
+	Density    DensityConfig
+}
+
+// EmptyConfig configures the empty-output detector.
+type EmptyConfig struct {
+	Enabled  bool
+	MinChars int
+}
+
+// RepetitionConfig configures the repetition-loop detector.
+type RepetitionConfig struct {
+	Enabled           bool
+	NGram             int
+	MaxRepeatFraction float64
+	MinWords          int
+}
+
+// GibberishConfig configures the gibberish (non-printable) detector.
+type GibberishConfig struct {
+	Enabled                 bool
+	MaxNonPrintableFraction float64
+}
+
+// LanguageConfig configures the language/script-mismatch detector.
+type LanguageConfig struct {
+	Enabled              bool
+	MaxOffScriptFraction float64
+}
+
+// DensityConfig configures the low-text-density detector.
+type DensityConfig struct {
+	Enabled           bool
+	MinCharsPerMinute float64
+	MinSegmentRatio   float64
+}
+
+// DefaultConfig returns the recommended configuration with every detector
+// enabled and conservative thresholds.
+func DefaultConfig() Config {
+	return Config{
+		Empty: EmptyConfig{
+			Enabled:  true,
+			MinChars: 1,
+		},
+		Repetition: RepetitionConfig{
+			Enabled:           true,
+			NGram:             3,
+			MaxRepeatFraction: 0.30,
+			MinWords:          30,
+		},
+		Gibberish: GibberishConfig{
+			Enabled:                 true,
+			MaxNonPrintableFraction: 0.20,
+		},
+		Language: LanguageConfig{
+			Enabled:              true,
+			MaxOffScriptFraction: 0.50,
+		},
+		Density: DensityConfig{
+			Enabled:           true,
+			MinCharsPerMinute: 30,
+			MinSegmentRatio:   1.0 / 3.0,
+		},
+	}
+}
+
+// WithDefaults returns a copy of c with any unset or invalid (<= 0)
+// threshold filled in from [DefaultConfig]. Enabled flags are preserved
+// exactly as set; callers should start from DefaultConfig and disable
+// detectors selectively, since WithDefaults does not force Enabled=true.
+func (c Config) WithDefaults() Config {
+	d := DefaultConfig()
+
+	if c.Empty.MinChars <= 0 {
+		c.Empty.MinChars = d.Empty.MinChars
+	}
+
+	if c.Repetition.NGram <= 0 {
+		c.Repetition.NGram = d.Repetition.NGram
+	}
+	if c.Repetition.MaxRepeatFraction <= 0 {
+		c.Repetition.MaxRepeatFraction = d.Repetition.MaxRepeatFraction
+	}
+	if c.Repetition.MinWords <= 0 {
+		c.Repetition.MinWords = d.Repetition.MinWords
+	}
+
+	if c.Gibberish.MaxNonPrintableFraction <= 0 {
+		c.Gibberish.MaxNonPrintableFraction = d.Gibberish.MaxNonPrintableFraction
+	}
+
+	if c.Language.MaxOffScriptFraction <= 0 {
+		c.Language.MaxOffScriptFraction = d.Language.MaxOffScriptFraction
+	}
+
+	if c.Density.MinCharsPerMinute <= 0 {
+		c.Density.MinCharsPerMinute = d.Density.MinCharsPerMinute
+	}
+	if c.Density.MinSegmentRatio <= 0 {
+		c.Density.MinSegmentRatio = d.Density.MinSegmentRatio
+	}
+
+	return c
+}

--- a/internal/quality/detectors.go
+++ b/internal/quality/detectors.go
@@ -45,7 +45,6 @@ func (d repetitionDetector) Inspect(text string, _ Context) *Finding {
 	}
 	counts := make(map[string]int)
 	total := 0
-	var top string
 	topCount := 0
 	for i := 0; i+d.n <= len(words); i++ {
 		gram := strings.Join(words[i:i+d.n], " ")
@@ -53,7 +52,6 @@ func (d repetitionDetector) Inspect(text string, _ Context) *Finding {
 		total++
 		if counts[gram] > topCount {
 			topCount = counts[gram]
-			top = gram
 		}
 	}
 	if total == 0 {
@@ -61,10 +59,12 @@ func (d repetitionDetector) Inspect(text string, _ Context) *Finding {
 	}
 	frac := float64(topCount) / float64(total)
 	if frac > d.maxFrac {
+		// Detail is intentionally content-free: report only the repetition
+		// metrics, never the repeated phrase itself (which is raw input text).
 		return &Finding{
 			Reason: ReasonRepetitionLoop,
-			Detail: fmt.Sprintf("n-gram %q repeats %d/%d (%.0f%%)",
-				truncate(top, 40), topCount, total, frac*100),
+			Detail: fmt.Sprintf("top %d-gram repeats %d/%d (%.0f%%)",
+				d.n, topCount, total, frac*100),
 			Score: frac,
 		}
 	}
@@ -161,15 +161,13 @@ func (d densityDetector) Inspect(text string, ctx Context) *Finding {
 
 	if ctx.Duration > 0 {
 		minutes := ctx.Duration.Minutes()
-		if minutes >= 1 {
-			cpm := chars / minutes
-			if cpm < d.minCharsPerMinute {
-				return &Finding{
-					Reason: ReasonLowDensity,
-					Detail: fmt.Sprintf("%.0f chars over %.1f min = %.1f chars/min (minimum %.0f)",
-						chars, minutes, cpm, d.minCharsPerMinute),
-					Score: cpm,
-				}
+		cpm := chars / minutes
+		if cpm < d.minCharsPerMinute {
+			return &Finding{
+				Reason: ReasonLowDensity,
+				Detail: fmt.Sprintf("%.0f chars over %.1f min = %.1f chars/min (minimum %.0f)",
+					chars, minutes, cpm, d.minCharsPerMinute),
+				Score: cpm,
 			}
 		}
 	}
@@ -200,19 +198,6 @@ func countSegments(text string) int {
 		}
 	}
 	return n
-}
-
-// truncate shortens s to at most max runes, appending an ellipsis when it
-// trims. It is rune-aware so multibyte content is not split mid-rune.
-func truncate(s string, max int) string {
-	if utf8.RuneCountInString(s) <= max {
-		return s
-	}
-	runes := []rune(s)
-	if max <= 1 {
-		return string(runes[:max])
-	}
-	return string(runes[:max-1]) + "…"
 }
 
 // script identifies a writing system.
@@ -286,7 +271,9 @@ var languageScript = map[string]script{
 	"ru": scriptCyrillic,
 	"uk": scriptCyrillic,
 	"bg": scriptCyrillic,
-	"sr": scriptCyrillic,
+	// "sr" (Serbian) is deliberately omitted: it is digraphic (written in
+	// both Cyrillic and Latin), so a bare "sr" tag stays scriptUnknown and
+	// valid Latin Serbian output is not flagged as a language mismatch.
 	// Other single-script languages.
 	"el": scriptGreek,
 	"ar": scriptArabic,

--- a/internal/quality/detectors.go
+++ b/internal/quality/detectors.go
@@ -1,0 +1,313 @@
+package quality
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// emptyDetector flags output that is effectively empty after trimming
+// surrounding whitespace.
+type emptyDetector struct {
+	minChars int
+}
+
+func (emptyDetector) Name() string { return "empty" }
+
+func (d emptyDetector) Inspect(text string, _ Context) *Finding {
+	trimmed := strings.TrimSpace(text)
+	n := utf8.RuneCountInString(trimmed)
+	if n < d.minChars {
+		return &Finding{
+			Reason: ReasonEmptyOutput,
+			Detail: fmt.Sprintf("output has %d characters (minimum %d)", n, d.minChars),
+			Score:  1,
+		}
+	}
+	return nil
+}
+
+// repetitionDetector flags output dominated by a single repeated word
+// n-gram, the classic STT "thank you for watching" hallucination loop.
+type repetitionDetector struct {
+	n        int
+	maxFrac  float64
+	minWords int
+}
+
+func (repetitionDetector) Name() string { return "repetition" }
+
+func (d repetitionDetector) Inspect(text string, _ Context) *Finding {
+	words := strings.Fields(strings.ToLower(text))
+	if len(words) < d.minWords || len(words) < d.n {
+		return nil
+	}
+	counts := make(map[string]int)
+	total := 0
+	var top string
+	topCount := 0
+	for i := 0; i+d.n <= len(words); i++ {
+		gram := strings.Join(words[i:i+d.n], " ")
+		counts[gram]++
+		total++
+		if counts[gram] > topCount {
+			topCount = counts[gram]
+			top = gram
+		}
+	}
+	if total == 0 {
+		return nil
+	}
+	frac := float64(topCount) / float64(total)
+	if frac > d.maxFrac {
+		return &Finding{
+			Reason: ReasonRepetitionLoop,
+			Detail: fmt.Sprintf("n-gram %q repeats %d/%d (%.0f%%)",
+				truncate(top, 40), topCount, total, frac*100),
+			Score: frac,
+		}
+	}
+	return nil
+}
+
+// gibberishDetector flags output with too high a fraction of replacement,
+// control, or private-use runes, a signal of corrupted decoding.
+type gibberishDetector struct {
+	maxNonPrintable float64
+}
+
+func (gibberishDetector) Name() string { return "gibberish" }
+
+func (d gibberishDetector) Inspect(text string, _ Context) *Finding {
+	total := 0
+	bad := 0
+	for _, r := range text {
+		if unicode.IsSpace(r) {
+			continue
+		}
+		total++
+		if r == utf8.RuneError || r == '�' ||
+			unicode.Is(unicode.C, r) || unicode.Is(unicode.Co, r) {
+			bad++
+		}
+	}
+	if total == 0 {
+		return nil
+	}
+	frac := float64(bad) / float64(total)
+	if frac > d.maxNonPrintable {
+		return &Finding{
+			Reason: ReasonGibberish,
+			Detail: fmt.Sprintf("%d/%d non-printable runes (%.0f%%)", bad, total, frac*100),
+			Score:  frac,
+		}
+	}
+	return nil
+}
+
+// languageDetector flags output whose script does not match the expected
+// language's script. It is conservative: it only fires when the expected
+// language maps to a known single script and a majority of letters are
+// off-script.
+type languageDetector struct {
+	maxOffScript float64
+}
+
+func (languageDetector) Name() string { return "language" }
+
+func (d languageDetector) Inspect(text string, ctx Context) *Finding {
+	expected := scriptForLanguage(ctx.ExpectedLanguage)
+	if expected == scriptUnknown {
+		return nil
+	}
+	total := 0
+	off := 0
+	for _, r := range text {
+		if !unicode.IsLetter(r) {
+			continue
+		}
+		total++
+		if scriptOf(r) != expected {
+			off++
+		}
+	}
+	if total == 0 {
+		return nil
+	}
+	frac := float64(off) / float64(total)
+	if frac > d.maxOffScript {
+		return &Finding{
+			Reason: ReasonLanguageMismatch,
+			Detail: fmt.Sprintf("%d/%d letters off expected script %q (%.0f%%)",
+				off, total, expected, frac*100),
+			Score: frac,
+		}
+	}
+	return nil
+}
+
+// densityDetector flags output that is implausibly sparse relative to the
+// source media duration or the number of source segments.
+type densityDetector struct {
+	minCharsPerMinute float64
+	minSegmentRatio   float64
+}
+
+func (densityDetector) Name() string { return "density" }
+
+func (d densityDetector) Inspect(text string, ctx Context) *Finding {
+	chars := float64(utf8.RuneCountInString(strings.TrimSpace(text)))
+
+	if ctx.Duration > 0 {
+		minutes := ctx.Duration.Minutes()
+		if minutes >= 1 {
+			cpm := chars / minutes
+			if cpm < d.minCharsPerMinute {
+				return &Finding{
+					Reason: ReasonLowDensity,
+					Detail: fmt.Sprintf("%.0f chars over %.1f min = %.1f chars/min (minimum %.0f)",
+						chars, minutes, cpm, d.minCharsPerMinute),
+					Score: cpm,
+				}
+			}
+		}
+	}
+
+	if ctx.SourceSegmentCount > 0 {
+		segments := countSegments(text)
+		ratio := float64(segments) / float64(ctx.SourceSegmentCount)
+		if ratio < d.minSegmentRatio {
+			return &Finding{
+				Reason: ReasonLowDensity,
+				Detail: fmt.Sprintf("%d/%d source segments (ratio %.2f, minimum %.2f)",
+					segments, ctx.SourceSegmentCount, ratio, d.minSegmentRatio),
+				Score: ratio,
+			}
+		}
+	}
+
+	return nil
+}
+
+// countSegments counts the number of non-empty lines in text, used as a
+// proxy for the number of output segments.
+func countSegments(text string) int {
+	n := 0
+	for _, line := range strings.Split(text, "\n") {
+		if strings.TrimSpace(line) != "" {
+			n++
+		}
+	}
+	return n
+}
+
+// truncate shortens s to at most max runes, appending an ellipsis when it
+// trims. It is rune-aware so multibyte content is not split mid-rune.
+func truncate(s string, max int) string {
+	if utf8.RuneCountInString(s) <= max {
+		return s
+	}
+	runes := []rune(s)
+	if max <= 1 {
+		return string(runes[:max])
+	}
+	return string(runes[:max-1]) + "…"
+}
+
+// script identifies a writing system.
+type script string
+
+// Recognised scripts. scriptUnknown means "no single script could be
+// determined".
+const (
+	scriptUnknown    script = ""
+	scriptLatin      script = "Latin"
+	scriptCyrillic   script = "Cyrillic"
+	scriptGreek      script = "Greek"
+	scriptArabic     script = "Arabic"
+	scriptHebrew     script = "Hebrew"
+	scriptHan        script = "Han"
+	scriptHiragana   script = "Hiragana"
+	scriptKatakana   script = "Katakana"
+	scriptHangul     script = "Hangul"
+	scriptDevanagari script = "Devanagari"
+)
+
+// scriptRange pairs a script with its Unicode range table.
+type scriptRange struct {
+	script script
+	table  *unicode.RangeTable
+}
+
+// scriptRanges enumerates the scripts scriptOf can recognise, in lookup
+// order.
+var scriptRanges = []scriptRange{
+	{scriptLatin, unicode.Latin},
+	{scriptCyrillic, unicode.Cyrillic},
+	{scriptGreek, unicode.Greek},
+	{scriptArabic, unicode.Arabic},
+	{scriptHebrew, unicode.Hebrew},
+	{scriptHan, unicode.Han},
+	{scriptHiragana, unicode.Hiragana},
+	{scriptKatakana, unicode.Katakana},
+	{scriptHangul, unicode.Hangul},
+	{scriptDevanagari, unicode.Devanagari},
+}
+
+// scriptOf returns the script of rune r, or scriptUnknown if none match.
+func scriptOf(r rune) script {
+	for _, sr := range scriptRanges {
+		if unicode.Is(sr.table, r) {
+			return sr.script
+		}
+	}
+	return scriptUnknown
+}
+
+// languageScript maps primary language subtags to their dominant single
+// script. Languages with intrinsically mixed scripts (notably "ja", which
+// blends Han, Hiragana, and Katakana) are intentionally omitted so the
+// language detector stays silent rather than producing false positives.
+var languageScript = map[string]script{
+	// Latin-script languages.
+	"en": scriptLatin,
+	"de": scriptLatin,
+	"fr": scriptLatin,
+	"es": scriptLatin,
+	"it": scriptLatin,
+	"pt": scriptLatin,
+	"nl": scriptLatin,
+	"pl": scriptLatin,
+	"tr": scriptLatin,
+	"id": scriptLatin,
+	"vi": scriptLatin,
+	// Cyrillic-script languages.
+	"ru": scriptCyrillic,
+	"uk": scriptCyrillic,
+	"bg": scriptCyrillic,
+	"sr": scriptCyrillic,
+	// Other single-script languages.
+	"el": scriptGreek,
+	"ar": scriptArabic,
+	"fa": scriptArabic,
+	"ur": scriptArabic,
+	"he": scriptHebrew,
+	"zh": scriptHan,
+	"ko": scriptHangul,
+	"hi": scriptDevanagari,
+}
+
+// scriptForLanguage returns the dominant script for a language tag, or
+// scriptUnknown if the language is unknown or has mixed scripts. Only the
+// primary subtag (before any '-' or '_') is considered.
+func scriptForLanguage(lang string) script {
+	lang = strings.ToLower(strings.TrimSpace(lang))
+	if lang == "" {
+		return scriptUnknown
+	}
+	if i := strings.IndexAny(lang, "-_"); i >= 0 {
+		lang = lang[:i]
+	}
+	return languageScript[lang]
+}

--- a/internal/quality/quality.go
+++ b/internal/quality/quality.go
@@ -1,0 +1,143 @@
+// Package quality provides reusable, content-only gates that detect
+// degenerate or hallucinated STT/OCR/translation output before it is
+// chunked and embedded.
+//
+// All detectors are pure functions over text plus a small [Context]; they
+// have no dependencies on store, ingest, or embeddings. A detector that
+// lacks the input it needs (for example a language detector without an
+// expected language) reports nothing rather than guessing.
+package quality
+
+import "time"
+
+// Modality identifies the kind of content being inspected. It is advisory:
+// detectors do not currently branch on it, but it is carried for detail
+// strings and future use.
+type Modality string
+
+// Supported content modalities.
+const (
+	ModalityTranscript Modality = "transcript"
+	ModalityOCR        Modality = "ocr"
+	ModalityText       Modality = "text"
+)
+
+// Context carries optional signals about the content under inspection.
+// Every field is optional; a detector that lacks its required input
+// reports nothing.
+type Context struct {
+	// Modality is the kind of content being inspected.
+	Modality Modality
+	// Duration is the source media duration, used for density checks.
+	Duration time.Duration
+	// ExpectedLanguage is a BCP-47-ish language tag (e.g. "en", "ru",
+	// "pt-BR"); only the primary subtag is used.
+	ExpectedLanguage string
+	// SourceSegmentCount is the number of source segments (e.g. STT
+	// segments) the output is expected to roughly reflect.
+	SourceSegmentCount int
+}
+
+// Reason is a stable machine-readable identifier for why a [Finding] was
+// raised.
+type Reason string
+
+// Known finding reasons.
+const (
+	ReasonRepetitionLoop   Reason = "repetition_loop"
+	ReasonEmptyOutput      Reason = "empty_output"
+	ReasonLanguageMismatch Reason = "language_mismatch"
+	ReasonLowDensity       Reason = "low_text_density"
+	ReasonGibberish        Reason = "gibberish_ratio"
+)
+
+// Finding describes a single quality problem detected in the content.
+type Finding struct {
+	// Reason is the stable machine-readable cause.
+	Reason Reason
+	// Detail is a human-readable explanation; it may include excerpts.
+	Detail string
+	// Score is a detector-specific magnitude (typically a fraction in
+	// [0,1]) describing how strongly the gate tripped.
+	Score float64
+}
+
+// Detector inspects text and optionally reports a single [Finding].
+// Implementations must be pure and side-effect free.
+type Detector interface {
+	// Name returns a short stable identifier for the detector.
+	Name() string
+	// Inspect returns a non-nil Finding if the content trips the gate,
+	// or nil otherwise.
+	Inspect(text string, ctx Context) *Finding
+}
+
+// Verdict is the aggregate result of running a [Gate].
+type Verdict struct {
+	// Findings holds every non-nil finding, in detector (severity) order.
+	Findings []Finding
+}
+
+// OK reports whether no findings were raised.
+func (v Verdict) OK() bool { return len(v.Findings) == 0 }
+
+// Primary returns the highest-severity finding, or nil if the verdict is
+// clean. Findings are ordered by severity at evaluation time.
+func (v Verdict) Primary() *Finding {
+	if len(v.Findings) == 0 {
+		return nil
+	}
+	return &v.Findings[0]
+}
+
+// Gate runs an ordered set of detectors over content.
+type Gate struct {
+	detectors []Detector
+}
+
+// New builds a Gate from cfg. Defaults are filled via [Config.WithDefaults],
+// and detectors are appended in severity order (empty, repetition,
+// gibberish, language, density). Each detector is included only if its
+// corresponding Enabled flag is set.
+func New(cfg Config) *Gate {
+	cfg = cfg.WithDefaults()
+	g := &Gate{}
+	if cfg.Empty.Enabled {
+		g.detectors = append(g.detectors, emptyDetector{minChars: cfg.Empty.MinChars})
+	}
+	if cfg.Repetition.Enabled {
+		g.detectors = append(g.detectors, repetitionDetector{
+			n:        cfg.Repetition.NGram,
+			maxFrac:  cfg.Repetition.MaxRepeatFraction,
+			minWords: cfg.Repetition.MinWords,
+		})
+	}
+	if cfg.Gibberish.Enabled {
+		g.detectors = append(g.detectors, gibberishDetector{
+			maxNonPrintable: cfg.Gibberish.MaxNonPrintableFraction,
+		})
+	}
+	if cfg.Language.Enabled {
+		g.detectors = append(g.detectors, languageDetector{
+			maxOffScript: cfg.Language.MaxOffScriptFraction,
+		})
+	}
+	if cfg.Density.Enabled {
+		g.detectors = append(g.detectors, densityDetector{
+			minCharsPerMinute: cfg.Density.MinCharsPerMinute,
+			minSegmentRatio:   cfg.Density.MinSegmentRatio,
+		})
+	}
+	return g
+}
+
+// Evaluate runs every detector over text and collects all non-nil findings.
+func (g *Gate) Evaluate(text string, ctx Context) Verdict {
+	var v Verdict
+	for _, d := range g.detectors {
+		if f := d.Inspect(text, ctx); f != nil {
+			v.Findings = append(v.Findings, *f)
+		}
+	}
+	return v
+}

--- a/internal/quality/quality.go
+++ b/internal/quality/quality.go
@@ -55,7 +55,9 @@ const (
 type Finding struct {
 	// Reason is the stable machine-readable cause.
 	Reason Reason
-	// Detail is a human-readable explanation; it may include excerpts.
+	// Detail is a human-readable explanation containing only redacted
+	// metrics and counts — never raw transcript/OCR/translation excerpts —
+	// so it is always safe to persist or log when a gate trips.
 	Detail string
 	// Score is a detector-specific magnitude (typically a fraction in
 	// [0,1]) describing how strongly the gate tripped.

--- a/tests/quality/quality_test.go
+++ b/tests/quality/quality_test.go
@@ -1,0 +1,186 @@
+package tests
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/quality"
+)
+
+// cleanTranscript is a plausible, varied transcript that should pass every
+// default detector.
+const cleanTranscript = "Welcome back to the show. Today we are talking about " +
+	"the history of typesetting and how movable type changed the spread of " +
+	"ideas across Europe. Our guest has spent twenty years studying early " +
+	"printed books and will walk us through several rare examples from the " +
+	"fifteenth century before we open the floor to questions from listeners."
+
+// repetitionLoop is a degenerate STT hallucination loop. A four-word phrase
+// only reaches roughly a quarter of all trigrams, which sits under the
+// default 0.30 threshold, so we use a two-word phrase whose top trigram
+// dominates the output (~50%). See the deviation note in the PR body.
+var repetitionLoop = strings.Repeat("thank you ", 60)
+
+// cyrillicText is a short run of Cyrillic letters.
+const cyrillicText = "Привет, это пример текста на русском языке для проверки."
+
+// gibberishText is dominated by the Unicode replacement character.
+var gibberishText = strings.Repeat("�", 50) + " ok"
+
+func TestGate_Evaluate(t *testing.T) {
+	gate := quality.New(quality.DefaultConfig())
+
+	tests := []struct {
+		name       string
+		text       string
+		ctx        quality.Context
+		wantOK     bool
+		wantReason quality.Reason
+	}{
+		{
+			name:   "clean transcript passes",
+			text:   cleanTranscript,
+			ctx:    quality.Context{Modality: quality.ModalityTranscript},
+			wantOK: true,
+		},
+		{
+			name:       "repetition loop",
+			text:       repetitionLoop,
+			ctx:        quality.Context{Modality: quality.ModalityTranscript},
+			wantOK:     false,
+			wantReason: quality.ReasonRepetitionLoop,
+		},
+		{
+			name:       "empty output",
+			text:       "",
+			ctx:        quality.Context{Modality: quality.ModalityText},
+			wantOK:     false,
+			wantReason: quality.ReasonEmptyOutput,
+		},
+		{
+			name:       "whitespace only output",
+			text:       "   \n\t  ",
+			ctx:        quality.Context{Modality: quality.ModalityText},
+			wantOK:     false,
+			wantReason: quality.ReasonEmptyOutput,
+		},
+		{
+			name:       "cyrillic with expected english",
+			text:       cyrillicText,
+			ctx:        quality.Context{ExpectedLanguage: "en"},
+			wantOK:     false,
+			wantReason: quality.ReasonLanguageMismatch,
+		},
+		{
+			name:   "cyrillic with expected russian",
+			text:   cyrillicText,
+			ctx:    quality.Context{ExpectedLanguage: "ru"},
+			wantOK: true,
+		},
+		{
+			name:   "cyrillic with no expected language",
+			text:   cyrillicText,
+			ctx:    quality.Context{},
+			wantOK: true,
+		},
+		{
+			name:       "tiny text over long duration",
+			text:       "Okay.",
+			ctx:        quality.Context{Modality: quality.ModalityTranscript, Duration: 60 * time.Minute},
+			wantOK:     false,
+			wantReason: quality.ReasonLowDensity,
+		},
+		{
+			name:       "too few segments",
+			text:       "One line only.",
+			ctx:        quality.Context{SourceSegmentCount: 30},
+			wantOK:     false,
+			wantReason: quality.ReasonLowDensity,
+		},
+		{
+			name:       "gibberish ocr output",
+			text:       gibberishText,
+			ctx:        quality.Context{Modality: quality.ModalityOCR},
+			wantOK:     false,
+			wantReason: quality.ReasonGibberish,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v := gate.Evaluate(tc.text, tc.ctx)
+			if v.OK() != tc.wantOK {
+				t.Fatalf("OK() = %v, want %v; findings=%+v", v.OK(), tc.wantOK, v.Findings)
+			}
+			if tc.wantOK {
+				return
+			}
+			p := v.Primary()
+			if p == nil {
+				t.Fatalf("Primary() = nil, want reason %q", tc.wantReason)
+			}
+			if p.Reason != tc.wantReason {
+				t.Fatalf("Primary().Reason = %q, want %q; findings=%+v",
+					p.Reason, tc.wantReason, v.Findings)
+			}
+		})
+	}
+}
+
+func TestGate_OptOut(t *testing.T) {
+	cfg := quality.DefaultConfig()
+	cfg.Repetition.Enabled = false
+	gate := quality.New(cfg)
+
+	v := gate.Evaluate(repetitionLoop, quality.Context{Modality: quality.ModalityTranscript})
+	if !v.OK() {
+		t.Fatalf("expected OK() with repetition disabled, got findings=%+v", v.Findings)
+	}
+}
+
+func TestRepetition_ShortTextSkipped(t *testing.T) {
+	gate := quality.New(quality.DefaultConfig())
+
+	v := gate.Evaluate("yes yes yes", quality.Context{Modality: quality.ModalityTranscript})
+	for _, f := range v.Findings {
+		if f.Reason == quality.ReasonRepetitionLoop {
+			t.Fatalf("did not expect ReasonRepetitionLoop for short text; findings=%+v", v.Findings)
+		}
+	}
+}
+
+func TestConfig_WithDefaults_FillsThresholds(t *testing.T) {
+	got := quality.Config{}.WithDefaults()
+	want := quality.DefaultConfig()
+
+	if got.Empty.MinChars != want.Empty.MinChars {
+		t.Errorf("Empty.MinChars = %d, want %d", got.Empty.MinChars, want.Empty.MinChars)
+	}
+	if got.Repetition.NGram != want.Repetition.NGram {
+		t.Errorf("Repetition.NGram = %d, want %d", got.Repetition.NGram, want.Repetition.NGram)
+	}
+	if got.Repetition.MaxRepeatFraction != want.Repetition.MaxRepeatFraction {
+		t.Errorf("Repetition.MaxRepeatFraction = %v, want %v",
+			got.Repetition.MaxRepeatFraction, want.Repetition.MaxRepeatFraction)
+	}
+	if got.Repetition.MinWords != want.Repetition.MinWords {
+		t.Errorf("Repetition.MinWords = %d, want %d", got.Repetition.MinWords, want.Repetition.MinWords)
+	}
+	if got.Gibberish.MaxNonPrintableFraction != want.Gibberish.MaxNonPrintableFraction {
+		t.Errorf("Gibberish.MaxNonPrintableFraction = %v, want %v",
+			got.Gibberish.MaxNonPrintableFraction, want.Gibberish.MaxNonPrintableFraction)
+	}
+	if got.Language.MaxOffScriptFraction != want.Language.MaxOffScriptFraction {
+		t.Errorf("Language.MaxOffScriptFraction = %v, want %v",
+			got.Language.MaxOffScriptFraction, want.Language.MaxOffScriptFraction)
+	}
+	if got.Density.MinCharsPerMinute != want.Density.MinCharsPerMinute {
+		t.Errorf("Density.MinCharsPerMinute = %v, want %v",
+			got.Density.MinCharsPerMinute, want.Density.MinCharsPerMinute)
+	}
+	if got.Density.MinSegmentRatio != want.Density.MinSegmentRatio {
+		t.Errorf("Density.MinSegmentRatio = %v, want %v",
+			got.Density.MinSegmentRatio, want.Density.MinSegmentRatio)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a standalone, pure-Go `internal/quality` package: reusable, content-only gates that detect degenerate or hallucinated STT/OCR/translation output **before** it is chunked and embedded.

Detectors (run in severity order):
- **empty** — output effectively empty after trimming (`ReasonEmptyOutput`)
- **repetition** — a single word n-gram dominates the output, the classic STT "thank you for watching" loop (`ReasonRepetitionLoop`)
- **gibberish** — too many replacement / control / private-use runes (`ReasonGibberish`)
- **language** — letters off the expected language's script (`ReasonLanguageMismatch`); conservative, silent when the language is unknown or mixed-script (e.g. `ja` is intentionally omitted)
- **density** — implausibly sparse vs. media duration or source segment count (`ReasonLowDensity`)

All detectors are pure functions over text plus an optional `Context`; no dependencies on store/ingest/embeddings. Configurable via `Config` with `DefaultConfig()` and `WithDefaults()` (fills only unset thresholds, preserves Enabled flags).

## Scope

**Package + tests only.** This is a safe pure addition. The ingest-path wiring is **deliberately deferred** and gated on spec #251 (behavior-changing).

## Files
- `internal/quality/quality.go` — types, `Gate`, `Verdict`, `New`, `Evaluate`
- `internal/quality/detectors.go` — the five detectors + script identification helpers
- `internal/quality/config.go` — `Config`, `DefaultConfig`, `WithDefaults`
- `tests/quality/quality_test.go` — black-box tests (package `tests`, per repo boundary rule)

## Validation
`make check` passes locally: gofmt, `go vet ./...`, golangci-lint, gocyclo (-over 15), misspell, full Go test suite, and Python script tests all green.

## Deviation from the design
The reviewed design suggested the repetition fixture `strings.Repeat("thank you for watching ", 40)`. Empirically that four-word phrase tops out at ~0.253 of all trigrams, **under** the default `MaxRepeatFraction` of 0.30, so it would not trip. Per the instruction to "tune the fixtures, not the production defaults," the test uses `strings.Repeat("thank you ", 60)` (top trigram ~0.50), which trips reliably while keeping production thresholds intact.

Closes #262.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced text quality evaluation system that detects empty content, repetitive patterns, gibberish, language mismatches, and low-density text.
  * Quality assessments support context-aware evaluation including output modality, duration, expected language, and segment count.
  * Configurable detection thresholds with sensible defaults for all quality checks.

* **Tests**
  * Added comprehensive test suite covering quality evaluation across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->