### PR TITLE
feat(ingest): wire output quality gate into transcription/OCR ingest (spec 0.16.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,7 +538,7 @@ Normative docs are maintained in the [`dirstral-spec`](https://github.com/dirstr
 - [dirstral-spec/docs/SPEC.md](dirstral-spec/docs/SPEC.md) — normative behavior, schemas, and runtime contracts
 - [dirstral-spec/docs/ECOSYSTEM.md](dirstral-spec/docs/ECOSYSTEM.md) — ecosystem/market/discovery/payment context
 - [dirstral-spec/docs/x402-payment-adapter-spec.md](dirstral-spec/docs/x402-payment-adapter-spec.md) — facilitator adapter contract
-- dir2mcp implements spec version `0.14.x` ([versioning](dirstral-spec/spec/versioning.md))
+- dir2mcp implements spec version `0.16.x` ([versioning](dirstral-spec/spec/versioning.md))
 
 ## Development
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -8,7 +8,7 @@ single source of truth and this copy can no longer drift.
 - In-tree (pinned submodule): [`dirstral-spec/docs/SPEC.md`](../dirstral-spec/docs/SPEC.md)
 - Upstream: <https://github.com/dirstral/dirstral-spec/blob/main/docs/SPEC.md>
 
-dir2mcp implements spec version `0.14.x` — see [`dirstral-spec/spec/versioning.md`](../dirstral-spec/spec/versioning.md).
+dir2mcp implements spec version `0.16.x` — see [`dirstral-spec/spec/versioning.md`](../dirstral-spec/spec/versioning.md).
 
 If the `dirstral-spec/` directory is empty, fetch the submodule:
 

--- a/docs/x402-payment-adapter-spec.md
+++ b/docs/x402-payment-adapter-spec.md
@@ -8,7 +8,7 @@ single source of truth and this copy can no longer drift.
 - In-tree (pinned submodule): [`dirstral-spec/docs/x402-payment-adapter-spec.md`](../dirstral-spec/docs/x402-payment-adapter-spec.md)
 - Upstream: <https://github.com/dirstral/dirstral-spec/blob/main/docs/x402-payment-adapter-spec.md>
 
-dir2mcp implements spec version `0.14.x` — see [`dirstral-spec/spec/versioning.md`](../dirstral-spec/spec/versioning.md).
+dir2mcp implements spec version `0.16.x` — see [`dirstral-spec/spec/versioning.md`](../dirstral-spec/spec/versioning.md).
 
 If the `dirstral-spec/` directory is empty, fetch the submodule:
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -149,6 +149,14 @@ type Config struct {
 	STTElevenLabsModel        string
 	STTElevenLabsLanguageCode string
 
+	// QualityGatesEnabled is the master switch for the output quality gate
+	// (spec 0.16.0): when true (default), generated transcript/OCR text is
+	// screened for degenerate output (repetition loops, empty output,
+	// off-script, low density, gibberish) before it is chunked and embedded,
+	// and failing chunks are quarantined instead of embedded. Set false to
+	// skip the gate entirely.
+	QualityGatesEnabled bool
+
 	ServerTLSCertFile string
 	ServerTLSKeyFile  string
 
@@ -222,6 +230,7 @@ type fileConfig struct {
 	STTMistralModel           *string
 	STTElevenLabsModel        *string
 	STTElevenLabsLanguageCode *string
+	QualityGatesEnabled       *bool
 	ElevenLabsAPIKey          *string
 	ServerTLSCertFile         *string
 	ServerTLSKeyFile          *string
@@ -296,6 +305,7 @@ type persistedConfig struct {
 	STTMistralModel           string        `yaml:"stt_mistral_model"`
 	STTElevenLabsModel        string        `yaml:"stt_elevenlabs_model"`
 	STTElevenLabsLanguageCode string        `yaml:"stt_elevenlabs_language_code"`
+	QualityGatesEnabled       bool          `yaml:"quality_gates_enabled"`
 	ServerTLSCertFile         string        `yaml:"server_tls_cert_file"`
 	ServerTLSKeyFile          string        `yaml:"server_tls_key_file"`
 
@@ -395,6 +405,7 @@ func Default() Config {
 		STTMistralModel:           "voxtral-mini-latest",
 		STTElevenLabsModel:        "scribe_v1",
 		STTElevenLabsLanguageCode: "",
+		QualityGatesEnabled:       true,
 		ServerTLSCertFile:         "",
 		ServerTLSKeyFile:          "",
 		X402: X402Config{
@@ -482,6 +493,7 @@ func buildPersistedConfig(cfg *Config) persistedConfig {
 		STTMistralModel:           cfg.STTMistralModel,
 		STTElevenLabsModel:        cfg.STTElevenLabsModel,
 		STTElevenLabsLanguageCode: cfg.STTElevenLabsLanguageCode,
+		QualityGatesEnabled:       cfg.QualityGatesEnabled,
 		ServerTLSCertFile:         cfg.ServerTLSCertFile,
 		ServerTLSKeyFile:          cfg.ServerTLSKeyFile,
 		X402Mode:                  cfg.X402.Mode,
@@ -1030,6 +1042,9 @@ func applySTTFileParsed(cfg *Config, fc fileConfig) {
 	if fc.STTElevenLabsLanguageCode != nil {
 		cfg.STTElevenLabsLanguageCode = *fc.STTElevenLabsLanguageCode
 	}
+	if fc.QualityGatesEnabled != nil {
+		cfg.QualityGatesEnabled = *fc.QualityGatesEnabled
+	}
 }
 
 // applyX402FileParsed copies the set x402 file fields onto cfg.X402.
@@ -1373,6 +1388,8 @@ func setBoolFileScalar(cfg *fileConfig, key, value string) error {
 		target = &cfg.IngestFollowSymlinks
 	case "ingest.watch":
 		target = &cfg.IngestWatch
+	case "quality_gates_enabled":
+		target = &cfg.QualityGatesEnabled
 	case "x402_tools_call_enabled":
 		target = &cfg.X402ToolsCallEnabled
 	case "retrieval.hybrid.enabled":
@@ -1702,6 +1719,7 @@ func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	writeScalar("stt_mistral_model", cfg.STTMistralModel)
 	writeScalar("stt_elevenlabs_model", cfg.STTElevenLabsModel)
 	writeScalar("stt_elevenlabs_language_code", cfg.STTElevenLabsLanguageCode)
+	writeBool("quality_gates_enabled", cfg.QualityGatesEnabled)
 	writeScalar("server_tls_cert_file", cfg.ServerTLSCertFile)
 	writeScalar("server_tls_key_file", cfg.ServerTLSKeyFile)
 	writeScalar("x402_mode", cfg.X402Mode)

--- a/internal/ingest/represent.go
+++ b/internal/ingest/represent.go
@@ -140,7 +140,7 @@ func (rg *RepresentationGenerator) GenerateRawTextFromContent(ctx context.Contex
 		if err != nil {
 			return fmt.Errorf("upsert representation: %w", err)
 		}
-		if err := rg.upsertChunksForRepresentationWithStore(ctx, tx, repID, indexKindForDocType(doc.DocType), segments); err != nil {
+		if err := rg.upsertChunksForRepresentationWithStore(ctx, tx, repID, indexKindForDocType(doc.DocType), segments, quarantineDecision{}); err != nil {
 			return err
 		}
 		return nil
@@ -192,16 +192,26 @@ func (rg *RepresentationGenerator) GenerateMediaChunks(ctx context.Context, doc 
 	})
 }
 
-func (rg *RepresentationGenerator) upsertChunksForRepresentation(ctx context.Context, repID int64, indexKind string, segments []chunkSegment) error {
+// quarantineDecision is the subset of the ingest quarantine decision the
+// chunk writer needs: when quarantine is set, chunks are inserted already-failed
+// (embedding_status=error) with the given embedding_error/error_category so the
+// embedding worker never embeds them (spec 0.16.0). The zero value inserts
+// healthy chunks (embedding_status=pending), preserving prior behaviour.
+
+func (rg *RepresentationGenerator) upsertChunksForRepresentation(ctx context.Context, repID int64, indexKind string, segments []chunkSegment, decision quarantineDecision) error {
 	// wrap the entire operation in a transaction so we don't end up with a
 	// partial set of chunks if an insertion fails halfway through.  The store
 	// implementation handles beginning/committing/rolling back the tx.
 	return rg.store.WithTx(ctx, func(tx model.RepresentationStore) error {
-		return rg.upsertChunksForRepresentationWithStore(ctx, tx, repID, indexKind, segments)
+		return rg.upsertChunksForRepresentationWithStore(ctx, tx, repID, indexKind, segments, decision)
 	})
 }
 
-func (rg *RepresentationGenerator) upsertChunksForRepresentationWithStore(ctx context.Context, st model.RepresentationStore, repID int64, indexKind string, segments []chunkSegment) error {
+func (rg *RepresentationGenerator) upsertChunksForRepresentationWithStore(ctx context.Context, st model.RepresentationStore, repID int64, indexKind string, segments []chunkSegment, decision quarantineDecision) error {
+	embeddingStatus := "pending"
+	if decision.quarantine {
+		embeddingStatus = "error"
+	}
 	for i, seg := range segments {
 		chunk := model.Chunk{
 			RepID:           repID,
@@ -209,7 +219,9 @@ func (rg *RepresentationGenerator) upsertChunksForRepresentationWithStore(ctx co
 			Text:            seg.Text,
 			TextHash:        computeRepHash([]byte(seg.Text)),
 			IndexKind:       indexKind,
-			EmbeddingStatus: "pending",
+			EmbeddingStatus: embeddingStatus,
+			EmbeddingError:  decision.embErr,
+			ErrorCategory:   decision.category,
 		}
 		// A kind-less span carries no provenance (e.g. a structured chunk whose
 		// source elements exposed no page); persist the chunk with no span row

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -59,6 +59,12 @@ type Service struct {
 	// gate as "skip screening", proceeding exactly as before the gate existed.
 	qualityGate *quality.Gate
 
+	// transcriptLanguage is the active STT provider profile's language tag
+	// (SPEC 8.1.3), resolved once at construction and fed to the quality
+	// gate's language detector. Empty when STT is off or no language is
+	// configured, in which case the language detector self-skips.
+	transcriptLanguage string
+
 	// embedMultimodal is the resolved multimodal embedding mode (SPEC
 	// 8.1.7): "off" (default), "augment", or "replace". When augment/
 	// replace, media documents additionally (or exclusively) get a media
@@ -156,6 +162,7 @@ func NewService(cfg config.Config, store model.Store) (*Service, error) {
 	if cfg.QualityGatesEnabled {
 		svc.qualityGate = quality.New(quality.DefaultConfig())
 	}
+	svc.transcriptLanguage = sttExpectedLanguage(cfg)
 	// Resolve the multimodal embedding mode once (SPEC 8.1.7); a missing or
 	// unresolvable embed profile leaves it off (text-only).
 	if ep, err := cfg.Providers().Resolve(provider.CapEmbed); err == nil {
@@ -343,6 +350,42 @@ func TranscriberFromConfigWithLanguage(cfg config.Config, language string) (mode
 	default:
 		return nil, fmt.Errorf("unsupported transcriber provider %q", sel)
 	}
+}
+
+// sttExpectedLanguage resolves the active STT provider profile's language tag
+// (SPEC 8.1.3), mirroring the provider selection in
+// TranscriberFromConfigWithLanguage. It returns "" when STT is off, when no
+// STT-capable profile resolves, or when the profile carries no language — in
+// all of which cases the quality gate's language detector self-skips. Resolving
+// from the profile (rather than the legacy stt.elevenlabs_language_code field)
+// ensures Mistral/provider-profile setups still feed the gate a language.
+func sttExpectedLanguage(cfg config.Config) string {
+	sel := strings.ToLower(strings.TrimSpace(cfg.STTProvider))
+	if sel == "" {
+		sel = transcriberProviderAuto
+	}
+	if sel == transcriberProviderOff || sel == "none" || sel == "disabled" {
+		return ""
+	}
+	r := cfg.Providers()
+	var (
+		prof provider.Profile
+		err  error
+	)
+	switch sel {
+	case transcriberProviderMistral:
+		prof, err = r.ResolveExplicit(provider.CapSTT, "mistral-ocr", true)
+	case transcriberProviderElevenLabs:
+		prof, err = r.ResolveExplicit(provider.CapSTT, "elevenlabs", true)
+	case transcriberProviderAuto:
+		prof, err = r.Resolve(provider.CapSTT)
+	default:
+		return ""
+	}
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(prof.STTLanguage)
 }
 
 // healthCheckInterval returns the configured base poll interval for connector
@@ -1374,11 +1417,14 @@ func (s *Service) screenOutputQuality(relPath, kind string, text string, qctx qu
 	}
 }
 
-// transcriptExpectedLanguage returns the configured STT language tag used to
-// drive the quality gate's language detector, or "" when none is configured
-// (in which case the language gate self-skips).
+// transcriptExpectedLanguage returns the active STT provider profile's language
+// tag used to drive the quality gate's language detector, or "" when none is
+// configured (in which case the language gate self-skips). The value is
+// resolved from the same provider profile the transcriber uses (SPEC 8.1.3),
+// not the legacy ElevenLabs-only field, so provider-profile setups (e.g.
+// Mistral) supply the correct expected language.
 func (s *Service) transcriptExpectedLanguage() string {
-	return strings.TrimSpace(s.cfg.STTElevenLabsLanguageCode)
+	return s.transcriptLanguage
 }
 
 func (s *Service) generateTranscriptRepresentation(ctx context.Context, doc model.Document, content []byte) error {

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -24,6 +24,8 @@ import (
 	"github.com/dirstral/dir2mcp/internal/pdfutil"
 	"github.com/dirstral/dir2mcp/internal/provider"
 	"github.com/dirstral/dir2mcp/internal/providerfactory"
+	"github.com/dirstral/dir2mcp/internal/quality"
+	"github.com/dirstral/dir2mcp/internal/store"
 )
 
 // annotationChunk* constants mirror the hardcoded parameters previously
@@ -50,6 +52,12 @@ type Service struct {
 	repGen        *RepresentationGenerator
 	extractor     model.DocumentExtractor
 	transcriber   model.Transcriber
+
+	// qualityGate screens generated transcript/OCR text for degenerate
+	// output before it is chunked and embedded (spec 0.16.0). Nil when the
+	// QualityGatesEnabled master switch is off — callers must treat a nil
+	// gate as "skip screening", proceeding exactly as before the gate existed.
+	qualityGate *quality.Gate
 
 	// embedMultimodal is the resolved multimodal embedding mode (SPEC
 	// 8.1.7): "off" (default), "augment", or "replace". When augment/
@@ -141,6 +149,12 @@ func NewService(cfg config.Config, store model.Store) (*Service, error) {
 	svc.transcriber = transcriber
 	if rs, ok := store.(model.RepresentationStore); ok {
 		svc.repGen = NewRepresentationGenerator(rs)
+	}
+	// Construct the output quality gate from config (spec 0.16.0). When the
+	// master switch is on we use the package defaults (per-threshold config is
+	// a follow-up); when off, the field stays nil and screening is skipped.
+	if cfg.QualityGatesEnabled {
+		svc.qualityGate = quality.New(quality.DefaultConfig())
 	}
 	// Resolve the multimodal embedding mode once (SPEC 8.1.7); a missing or
 	// unresolvable embed profile leaves it off (text-only).
@@ -383,6 +397,13 @@ func (s *Service) SetOCR(ocr model.OCR) {
 
 func (s *Service) SetTranscriber(transcriber model.Transcriber) {
 	s.transcriber = transcriber
+}
+
+// SetQualityGate overrides the output quality gate (spec 0.16.0). A nil gate
+// disables screening so generated transcript/OCR text is chunked and embedded
+// without quarantine. Mirrors SetTranscriber for tests.
+func (s *Service) SetQualityGate(gate *quality.Gate) {
+	s.qualityGate = gate
 }
 
 // ProcessDocument exposes single-document processing for external tests.
@@ -985,17 +1006,24 @@ func (s *Service) pdfPageSpans(doc model.Document, content []byte) []model.Span 
 	return spans
 }
 
-// mediaTimeSpans probes doc's duration and windows it into contiguous,
-// non-overlapping `time` spans of at most windowMS (SPEC 8.1.7). Returns nil
-// when the duration can't be determined (undecodable, or ffprobe absent),
-// keeping the text path; the condition is a non-fatal per-document warning.
-func (s *Service) mediaTimeSpans(ctx context.Context, doc model.Document, windowMS int) []model.Span {
+// probeDuration resolves doc's media duration using the configured probe
+// (ProbeDurationFunc, defaulting to avutil.Duration). It is the shared entry
+// point for both time-window chunking and the quality gate's density check.
+func (s *Service) probeDuration(ctx context.Context, doc model.Document) (time.Duration, error) {
 	absPath := filepath.Join(s.cfg.RootDir, filepath.FromSlash(doc.RelPath))
 	probe := s.ProbeDurationFunc
 	if probe == nil {
 		probe = avutil.Duration
 	}
-	d, err := probe(ctx, absPath)
+	return probe(ctx, absPath)
+}
+
+// mediaTimeSpans probes doc's duration and windows it into contiguous,
+// non-overlapping `time` spans of at most windowMS (SPEC 8.1.7). Returns nil
+// when the duration can't be determined (undecodable, or ffprobe absent),
+// keeping the text path; the condition is a non-fatal per-document warning.
+func (s *Service) mediaTimeSpans(ctx context.Context, doc model.Document, windowMS int) []model.Span {
+	d, err := s.probeDuration(ctx, doc)
 	if err != nil {
 		s.getLogger().Printf("multimodal: media duration unavailable for %s (%v); skipping direct media embedding", doc.RelPath, err)
 		return nil
@@ -1157,6 +1185,10 @@ func (s *Service) generateOCRMarkdownRepresentation(ctx context.Context, doc mod
 
 	s.persistTitleIfFound(ctx, doc, ocrText)
 
+	decision := s.screenOutputQuality(doc.RelPath, "ocr", ocrText, quality.Context{
+		Modality: quality.ModalityOCR,
+	})
+
 	rep := model.Representation{
 		DocID:       doc.DocID,
 		RepType:     RepTypeExtractedMarkdown,
@@ -1174,7 +1206,7 @@ func (s *Service) generateOCRMarkdownRepresentation(ctx context.Context, doc mod
 	if len(segments) == 0 {
 		return nil
 	}
-	if err := s.repGen.upsertChunksForRepresentation(ctx, repID, "text", segments); err != nil {
+	if err := s.repGen.upsertChunksForRepresentation(ctx, repID, "text", segments, decision); err != nil {
 		return fmt.Errorf("persist ocr chunks: %w", err)
 	}
 	return nil
@@ -1197,6 +1229,10 @@ func (s *Service) persistStructuredRepresentation(ctx context.Context, doc model
 		s.persistTitleIfFound(ctx, doc, md)
 	}
 
+	decision := s.screenOutputQuality(doc.RelPath, "ocr", md, quality.Context{
+		Modality: quality.ModalityOCR,
+	})
+
 	rep := model.Representation{
 		DocID:       doc.DocID,
 		RepType:     RepTypeExtractedMarkdown,
@@ -1214,7 +1250,7 @@ func (s *Service) persistStructuredRepresentation(ctx context.Context, doc model
 	if len(segments) == 0 {
 		return nil
 	}
-	if err := s.repGen.upsertChunksForRepresentation(ctx, repID, "text", segments); err != nil {
+	if err := s.repGen.upsertChunksForRepresentation(ctx, repID, "text", segments, decision); err != nil {
 		return fmt.Errorf("persist structured chunks: %w", err)
 	}
 	return nil
@@ -1296,6 +1332,55 @@ func (s *Service) GenerateOCRMarkdownRepresentation(ctx context.Context, doc mod
 	return s.generateOCRMarkdownRepresentation(ctx, doc, content)
 }
 
+// quarantineDecision carries the result of screening generated output through
+// the quality gate (spec 0.16.0). When quarantine is true the chunks for the
+// representation must be inserted already-failed (embedding_status=error with
+// category quality_gate) so the embedding worker never picks them up; the
+// embErr/category fields are the content-free values to persist.
+type quarantineDecision struct {
+	quarantine bool
+	embErr     string
+	category   string
+}
+
+// screenOutputQuality runs the quality gate over generated text. It returns a
+// zero-value (non-quarantine) decision when the gate is disabled (nil) or the
+// verdict is clean, so callers can always insert via the returned decision. On
+// a failed gate it logs a content-free warning and returns the quarantine
+// values. relPath/kind are used only for the diagnostic log line.
+func (s *Service) screenOutputQuality(relPath, kind string, text string, qctx quality.Context) quarantineDecision {
+	if s.qualityGate == nil {
+		return quarantineDecision{}
+	}
+	verdict := s.qualityGate.Evaluate(text, qctx)
+	if verdict.OK() {
+		return quarantineDecision{}
+	}
+	primary := verdict.Primary()
+	var reason quality.Reason
+	var detail string
+	if primary != nil {
+		reason = primary.Reason
+		detail = primary.Detail
+	}
+	// Detail is already redacted/content-free; SanitizeReason bounds/normalizes
+	// it for persistence into chunks.embedding_error.
+	embErr := store.SanitizeReason(detail)
+	s.getLogger().Printf("quality gate quarantined %s output for %s: reason=%s", kind, relPath, reason)
+	return quarantineDecision{
+		quarantine: true,
+		embErr:     embErr,
+		category:   string(store.ErrorCategoryQualityGate),
+	}
+}
+
+// transcriptExpectedLanguage returns the configured STT language tag used to
+// drive the quality gate's language detector, or "" when none is configured
+// (in which case the language gate self-skips).
+func (s *Service) transcriptExpectedLanguage() string {
+	return strings.TrimSpace(s.cfg.STTElevenLabsLanguageCode)
+}
+
 func (s *Service) generateTranscriptRepresentation(ctx context.Context, doc model.Document, content []byte) error {
 	if s.repGen == nil || s.transcriber == nil {
 		return nil
@@ -1310,6 +1395,16 @@ func (s *Service) generateTranscriptRepresentation(ctx context.Context, doc mode
 	if transcriptText == "" {
 		return nil
 	}
+
+	var duration time.Duration
+	if d, derr := s.probeDuration(ctx, doc); derr == nil {
+		duration = d
+	}
+	decision := s.screenOutputQuality(doc.RelPath, "transcript", transcriptText, quality.Context{
+		Modality:         quality.ModalityTranscript,
+		ExpectedLanguage: s.transcriptExpectedLanguage(),
+		Duration:         duration,
+	})
 
 	rep := model.Representation{
 		DocID:       doc.DocID,
@@ -1327,7 +1422,7 @@ func (s *Service) generateTranscriptRepresentation(ctx context.Context, doc mode
 	if len(segments) == 0 {
 		return nil
 	}
-	if err := s.repGen.upsertChunksForRepresentation(ctx, repID, "text", segments); err != nil {
+	if err := s.repGen.upsertChunksForRepresentation(ctx, repID, "text", segments, decision); err != nil {
 		return fmt.Errorf("persist transcript chunks: %w", err)
 	}
 	return nil
@@ -1377,7 +1472,7 @@ func (s *Service) StoreAnnotationRepresentations(ctx context.Context, doc model.
 		if upsertErr != nil {
 			return fmt.Errorf("upsert annotation json representation: %w", upsertErr)
 		}
-		if upsertErr := s.repGen.upsertChunksForRepresentationWithStore(ctx, tx, jsonRepID, "text", chunkTextByChars(jsonText, annotationChunkSize, annotationChunkOverlap, annotationChunkMinSize)); upsertErr != nil {
+		if upsertErr := s.repGen.upsertChunksForRepresentationWithStore(ctx, tx, jsonRepID, "text", chunkTextByChars(jsonText, annotationChunkSize, annotationChunkOverlap, annotationChunkMinSize), quarantineDecision{}); upsertErr != nil {
 			return fmt.Errorf("persist annotation json chunks: %w", upsertErr)
 		}
 
@@ -1402,7 +1497,7 @@ func (s *Service) StoreAnnotationRepresentations(ctx context.Context, doc model.
 		if upsertErr != nil {
 			return fmt.Errorf("upsert annotation text representation: %w", upsertErr)
 		}
-		if upsertErr := s.repGen.upsertChunksForRepresentationWithStore(ctx, tx, textRepID, "text", chunkTextByChars(flattened, annotationChunkSize, annotationChunkOverlap, annotationChunkMinSize)); upsertErr != nil {
+		if upsertErr := s.repGen.upsertChunksForRepresentationWithStore(ctx, tx, textRepID, "text", chunkTextByChars(flattened, annotationChunkSize, annotationChunkOverlap, annotationChunkMinSize), quarantineDecision{}); upsertErr != nil {
 			return fmt.Errorf("persist annotation text chunks: %w", upsertErr)
 		}
 		return nil

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -46,7 +46,12 @@ type Chunk struct {
 	IndexKind       string
 	EmbeddingStatus string
 	EmbeddingError  string
-	Deleted         bool
+	// ErrorCategory is the coarse failure classification persisted with a
+	// chunk when it is inserted already-failed (e.g. quarantined by the
+	// output quality gate). It mirrors store.ErrorCategory but is typed as a
+	// plain string here to avoid an import cycle. Empty for healthy chunks.
+	ErrorCategory string
+	Deleted       bool
 	// Modality is the chunk's content modality for multimodal embeddings
 	// (SPEC 8.1.7): "" / "text" (default), or "image"/"audio"/"video"/"pdf".
 	Modality string

--- a/internal/store/errcat.go
+++ b/internal/store/errcat.go
@@ -43,6 +43,13 @@ const (
 	// rejected the input for a reason other than the above (vector
 	// dimension mismatch, model output malformed). Not retryable.
 	ErrorCategoryEmbeddingFailure ErrorCategory = "embedding_failure"
+	// ErrorCategoryQualityGate indicates the output quality gate
+	// (spec 0.16.0) rejected the generated transcript/OCR text as
+	// degenerate (repetition loop, empty output, off-script, low
+	// density, gibberish) before it was embedded. The chunk is
+	// quarantined at insert time so the embedding worker never picks
+	// it up. Not retryable without a better extraction/transcription.
+	ErrorCategoryQualityGate ErrorCategory = "quality_gate"
 )
 
 // classifierRule pairs a category with the keyword set that triggers

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -207,8 +207,8 @@ func lookupChunkDocContext(ctx context.Context, exec dbExecutor, repID int64) (r
 func insertChunkWithSpansWith(ctx context.Context, exec dbExecutor, chunk model.Chunk, spans []model.Span, relPath, docType, repType string) (int64, error) {
 	_, err := exec.ExecContext(
 		ctx,
-		`INSERT INTO chunks(rep_id, ordinal, rel_path, doc_type, rep_type, text, text_hash, tokens_est, index_kind, modality, media_ref, embedding_status, embedding_error, deleted)
-		 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`INSERT INTO chunks(rep_id, ordinal, rel_path, doc_type, rep_type, text, text_hash, tokens_est, index_kind, modality, media_ref, embedding_status, embedding_error, error_category, deleted)
+		 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		 ON CONFLICT(rep_id, ordinal) DO UPDATE SET
 		   rel_path=excluded.rel_path,
 		   doc_type=excluded.doc_type,
@@ -221,6 +221,7 @@ func insertChunkWithSpansWith(ctx context.Context, exec dbExecutor, chunk model.
 		   media_ref=excluded.media_ref,
 		   embedding_status=excluded.embedding_status,
 		   embedding_error=excluded.embedding_error,
+		   error_category=excluded.error_category,
 		   deleted=excluded.deleted`,
 		chunk.RepID,
 		chunk.Ordinal,
@@ -235,6 +236,7 @@ func insertChunkWithSpansWith(ctx context.Context, exec dbExecutor, chunk model.
 		strings.TrimSpace(chunk.MediaRef),
 		normalizeEmbeddingStatus(chunk.EmbeddingStatus),
 		strings.TrimSpace(chunk.EmbeddingError),
+		strings.TrimSpace(chunk.ErrorCategory),
 		boolToInt(chunk.Deleted),
 	)
 	if err != nil {

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -851,7 +851,7 @@ func (s *SQLiteStore) GetChunksByRepID(ctx context.Context, repID int64) ([]mode
 
 	rows, err := db.QueryContext(
 		ctx,
-		`SELECT chunk_id, rep_id, ordinal, text, text_hash, index_kind, embedding_status, embedding_error, deleted
+		`SELECT chunk_id, rep_id, ordinal, text, text_hash, index_kind, embedding_status, embedding_error, error_category, deleted
 		 FROM chunks
 		 WHERE rep_id = ?
 		 ORDER BY ordinal ASC`,
@@ -877,6 +877,7 @@ func (s *SQLiteStore) GetChunksByRepID(ctx context.Context, repID int64) ([]mode
 			&chunk.IndexKind,
 			&chunk.EmbeddingStatus,
 			&chunk.EmbeddingError,
+			&chunk.ErrorCategory,
 			&deleted,
 		); err != nil {
 			return nil, err

--- a/tests/ingest/quality_gate_test.go
+++ b/tests/ingest/quality_gate_test.go
@@ -1,0 +1,131 @@
+package tests
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// TestQualityGate_QuarantinesDegenerateTranscript verifies that when the output
+// quality gate is enabled, a degenerate transcript (a repetition loop, the
+// classic STT hallucination) is quarantined: its chunks are inserted already
+// failed (embedding_status=error, error_category=quality_gate) so the embedding
+// worker — which only picks up embedding_status='pending' — never embeds them.
+func TestQualityGate_QuarantinesDegenerateTranscript(t *testing.T) {
+	t.Parallel()
+	stateDir := t.TempDir()
+	st := &fakeIngestStore{}
+	svc := mustNewIngestService(t, config.Config{StateDir: stateDir, QualityGatesEnabled: true}, st)
+	svc.SetTranscriber(&fakeTranscriber{text: strings.Repeat("thank you ", 60)})
+
+	doc := model.Document{DocID: 101, RelPath: "audio/loop.mp3", DocType: "audio"}
+	if err := svc.GenerateTranscriptRepresentation(context.Background(), doc, []byte("audio-bytes")); err != nil {
+		t.Fatalf("GenerateTranscriptRepresentation failed: %v", err)
+	}
+
+	if len(st.chunks) == 0 {
+		t.Fatal("expected transcript chunks to be persisted (quarantined), got none")
+	}
+	for i, c := range st.chunks {
+		if c.EmbeddingStatus != "error" {
+			t.Fatalf("chunk %d: expected embedding_status=error, got %q", i, c.EmbeddingStatus)
+		}
+		if c.EmbeddingStatus == "pending" {
+			t.Fatalf("chunk %d: quarantined chunk must not be pending (worker would embed it)", i)
+		}
+		if c.ErrorCategory != string(store.ErrorCategoryQualityGate) {
+			t.Fatalf("chunk %d: expected error_category=%q, got %q", i, store.ErrorCategoryQualityGate, c.ErrorCategory)
+		}
+		if strings.TrimSpace(c.EmbeddingError) == "" {
+			t.Fatalf("chunk %d: expected a content-free embedding_error reason, got empty", i)
+		}
+	}
+}
+
+// TestQualityGate_CleanTranscriptNotQuarantined is the companion case: a clean
+// transcript passes the gate, so its chunks are inserted pending and will be
+// embedded normally.
+func TestQualityGate_CleanTranscriptNotQuarantined(t *testing.T) {
+	t.Parallel()
+	stateDir := t.TempDir()
+	st := &fakeIngestStore{}
+	svc := mustNewIngestService(t, config.Config{StateDir: stateDir, QualityGatesEnabled: true}, st)
+	svc.SetTranscriber(&fakeTranscriber{text: "[00:00] welcome to the lecture today\n[00:02] we discuss several distinct topics in depth\n[00:05] including history geography and science across many regions"})
+
+	doc := model.Document{DocID: 102, RelPath: "audio/clean.mp3", DocType: "audio"}
+	if err := svc.GenerateTranscriptRepresentation(context.Background(), doc, []byte("audio-bytes")); err != nil {
+		t.Fatalf("GenerateTranscriptRepresentation failed: %v", err)
+	}
+
+	if len(st.chunks) == 0 {
+		t.Fatal("expected transcript chunks to be persisted, got none")
+	}
+	for i, c := range st.chunks {
+		if c.EmbeddingStatus != "pending" {
+			t.Fatalf("chunk %d: expected embedding_status=pending for clean output, got %q", i, c.EmbeddingStatus)
+		}
+		if c.ErrorCategory != "" {
+			t.Fatalf("chunk %d: clean chunk must have no error_category, got %q", i, c.ErrorCategory)
+		}
+		if c.EmbeddingError != "" {
+			t.Fatalf("chunk %d: clean chunk must have no embedding_error, got %q", i, c.EmbeddingError)
+		}
+	}
+}
+
+// TestQualityGate_DisabledViaSetter proves the master switch: with the gate
+// disabled (nil), even degenerate output is inserted pending — screening is
+// fully skipped, preserving pre-0.16.0 behaviour.
+func TestQualityGate_DisabledViaSetter(t *testing.T) {
+	t.Parallel()
+	stateDir := t.TempDir()
+	st := &fakeIngestStore{}
+	svc := mustNewIngestService(t, config.Config{StateDir: stateDir, QualityGatesEnabled: true}, st)
+	svc.SetQualityGate(nil) // disable screening
+	svc.SetTranscriber(&fakeTranscriber{text: strings.Repeat("thank you ", 60)})
+
+	doc := model.Document{DocID: 103, RelPath: "audio/loop2.mp3", DocType: "audio"}
+	if err := svc.GenerateTranscriptRepresentation(context.Background(), doc, []byte("audio-bytes")); err != nil {
+		t.Fatalf("GenerateTranscriptRepresentation failed: %v", err)
+	}
+
+	if len(st.chunks) == 0 {
+		t.Fatal("expected transcript chunks, got none")
+	}
+	for i, c := range st.chunks {
+		if c.EmbeddingStatus != "pending" {
+			t.Fatalf("chunk %d: gate disabled, expected pending, got %q", i, c.EmbeddingStatus)
+		}
+	}
+}
+
+// TestQualityGate_QuarantinesDegenerateOCR exercises the OCR flat path: a
+// degenerate OCR result is quarantined identically to the transcript path.
+func TestQualityGate_QuarantinesDegenerateOCR(t *testing.T) {
+	t.Parallel()
+	stateDir := t.TempDir()
+	st := &fakeIngestStore{}
+	svc := mustNewIngestService(t, config.Config{StateDir: stateDir, QualityGatesEnabled: true}, st)
+	svc.SetOCR(&fakeOCR{text: strings.Repeat("page header ", 80)})
+
+	doc := model.Document{DocID: 104, RelPath: "docs/loop.pdf", DocType: "pdf"}
+	if err := svc.GenerateOCRMarkdownRepresentation(context.Background(), doc, []byte("pdf-bytes")); err != nil {
+		t.Fatalf("GenerateOCRMarkdownRepresentation failed: %v", err)
+	}
+
+	if len(st.chunks) == 0 {
+		t.Fatal("expected OCR chunks to be persisted (quarantined), got none")
+	}
+	for i, c := range st.chunks {
+		if c.EmbeddingStatus != "error" {
+			t.Fatalf("chunk %d: expected embedding_status=error, got %q", i, c.EmbeddingStatus)
+		}
+		if c.ErrorCategory != string(store.ErrorCategoryQualityGate) {
+			t.Fatalf("chunk %d: expected error_category=%q, got %q", i, store.ErrorCategoryQualityGate, c.ErrorCategory)
+		}
+	}
+}

--- a/tests/ingest/quality_gate_test.go
+++ b/tests/ingest/quality_gate_test.go
@@ -100,6 +100,12 @@ func TestQualityGate_DisabledViaSetter(t *testing.T) {
 		if c.EmbeddingStatus != "pending" {
 			t.Fatalf("chunk %d: gate disabled, expected pending, got %q", i, c.EmbeddingStatus)
 		}
+		if c.ErrorCategory != "" {
+			t.Fatalf("chunk %d: gate disabled, expected empty error_category, got %q", i, c.ErrorCategory)
+		}
+		if c.EmbeddingError != "" {
+			t.Fatalf("chunk %d: gate disabled, expected empty embedding_error, got %q", i, c.EmbeddingError)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

First 0.16.0 implementation PR: wire the already-merged `internal/quality` package into the ingest pipeline so degenerate STT/OCR output is screened before it is chunked and embedded, and bundle the gated `dirstral-spec` re-pin to 0.16.0 in the same PR (repo convention).

### Gate wiring
- `ingest.Service` gains a `qualityGate *quality.Gate`, constructed at init from config: `quality.New(quality.DefaultConfig())` when the new master switch `QualityGatesEnabled` is true, otherwise `nil` (screening skipped). A `SetQualityGate(*quality.Gate)` setter mirrors `SetTranscriber` for tests.
- `generateTranscriptRepresentation` evaluates the gate over the trimmed transcript using `ModalityTranscript`, the configured STT language (`STTElevenLabsLanguageCode`, else `""`), and the probed media duration (`0` on probe error).
- `generateOCRMarkdownRepresentation` evaluates the gate over both the flat (`readOrComputeOCR`) and structured (`persistStructuredRepresentation`) sub-paths using `ModalityOCR` (no duration; empty expected-language → language gate self-skips).

### Quarantine semantics (insert-time)
- On a failed gate the representation and its chunks are **still persisted**, but the chunks are inserted **already-failed**: `embedding_status='error'`, `error_category='quality_gate'`, `embedding_error=store.SanitizeReason(verdict.Primary().Detail)` (detail is already redacted/content-free).
- This is done **at insert time**, not insert-then-`MarkFailed`, to avoid a transient `pending` window the embedding worker (which only picks up `embedding_status='pending'`) could race. To support it, `model.Chunk` gains an `ErrorCategory` field and `insertChunkWithSpansWith` now writes the existing `error_category` column.
- New `store.ErrorCategoryQualityGate` is aggregated by `failure_summary.go` (groups by `error_category`), so `dir2mcp status` / `doctor` surface it automatically. No schema migration — the column already exists.
- A content-free warn log is emitted on quarantine (reason identifier only, no raw content).

### Config
- Adds `QualityGatesEnabled bool` (yaml `quality_gates_enabled`), **default true**, following the `STT*` field pattern (Config field + file-overlay pointer + yaml tag + default + apply-override + scalar parser + writer).

### Bundled 0.16.0 re-pin
- Re-pin `dirstral-spec` submodule to `952f412` (merged 0.16.0 — dirstral-spec#17).
- Bump the implements-spec-version doc strings `0.14.x → 0.16.x` in `README.md`, `docs/SPEC.md`, `docs/x402-payment-adapter-spec.md` (mirrors the re-pin pattern from #231). The `spec 0.15.0 §7.4` feature reference in README is left untouched — it denotes the extractor-availability feature's spec version, not the pinned version.

### Tests (under `tests/`, package `tests`)
`tests/ingest/quality_gate_test.go`:
- degenerate transcript (`strings.Repeat("thank you ", 60)`) → chunks quarantined (`error` / `quality_gate`, never `pending`);
- clean transcript → chunks `pending`, no error category;
- gate disabled via `SetQualityGate(nil)` → degenerate output stays `pending` (master-switch proof);
- degenerate OCR (flat path) → quarantined identically.

## Deferred follow-ups
- **Fallback-model retry** on a failed gate (this PR quarantines directly).
- **Per-threshold quality config knobs** (gate currently uses `quality.DefaultConfig()`).

## Validation
`make check` passes locally (gofmt, vet, golangci-lint `0 issues`, gocyclo ≤15, ineffassign, misspell, full Go + Python suites incl. the `tests/security` CLI boundary test, build).

Refs #262 #251

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added output quality screening that detects and quarantines low-quality generated transcripts and OCR content; quarantined items are marked failed and skipped from further embedding/processing.
  * Added a configuration flag to enable/disable quality screening (enabled by default).

* **Documentation**
  * Updated spec compliance references from 0.14.x to 0.16.x across README and docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->