### PR TITLE
feat(stt): self-hosted OpenAI-compatible whisper STT provider (#240)

### DIFF
--- a/internal/config/providers.go
+++ b/internal/config/providers.go
@@ -72,6 +72,13 @@ func builtinProfiles() map[string]providerProfileYAML {
 		"cohere":     {Kind: "cohere", APIKey: s("${COHERE_API_KEY}")},
 		"elevenlabs": {Kind: "elevenlabs", APIKey: s("${ELEVENLABS_API_KEY}")},
 		"local":      {Kind: "openai", BaseURL: "http://localhost:11434/v1"}, // credential-less
+		// whisper: self-hosted OpenAI-compatible STT (GPU-VPS path,
+		// dir2mcp#240). Credential-less by default (no api_key); operators
+		// point base_url (and optionally set api_key/stt_model) via a
+		// providers: entry or the WHISPER_BASE_URL env default. Excluded from
+		// builtinPrecedence (like `local`) so it never silently wins auto
+		// selection; reach it via stt_provider: whisper.
+		"whisper": {Kind: "whisper", BaseURL: "${WHISPER_BASE_URL}"},
 	}
 }
 

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -44,6 +44,7 @@ const (
 	transcriberProviderAuto       = "auto"
 	transcriberProviderMistral    = "mistral"
 	transcriberProviderElevenLabs = "elevenlabs"
+	transcriberProviderWhisper    = "whisper"
 	transcriberProviderOff        = "off"
 )
 
@@ -349,6 +350,12 @@ func TranscriberFromConfigWithLanguage(cfg config.Config, language string) (mode
 	case transcriberProviderElevenLabs:
 		prof, err := r.ResolveExplicit(provider.CapSTT, "elevenlabs", true)
 		return build(prof, err)
+	case transcriberProviderWhisper:
+		// Self-hosted OpenAI-compatible STT (dir2mcp#240). The profile is
+		// credential-less, so selection succeeds even without an api_key;
+		// a missing base_url surfaces as a provider error at first use.
+		prof, err := r.ResolveExplicit(provider.CapSTT, "whisper", true)
+		return build(prof, err)
 	case transcriberProviderAuto:
 		prof, err := r.Resolve(provider.CapSTT)
 		if errors.Is(err, provider.ErrNoProvider) {
@@ -385,6 +392,8 @@ func sttExpectedLanguage(cfg config.Config) string {
 		prof, err = r.ResolveExplicit(provider.CapSTT, "mistral-ocr", true)
 	case transcriberProviderElevenLabs:
 		prof, err = r.ResolveExplicit(provider.CapSTT, "elevenlabs", true)
+	case transcriberProviderWhisper:
+		prof, err = r.ResolveExplicit(provider.CapSTT, "whisper", true)
 	case transcriberProviderAuto:
 		prof, err = r.Resolve(provider.CapSTT)
 	default:

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -23,6 +23,11 @@ const (
 	KindGemini     Kind = "gemini"
 	KindCohere     Kind = "cohere"
 	KindElevenLabs Kind = "elevenlabs"
+	// KindWhisper is a self-hosted, OpenAI-compatible STT endpoint
+	// (the GPU-VPS path, dir2mcp#240): POST {base_url}/v1/audio/transcriptions.
+	// Distinct from KindOpenAI so STT auto-selection and the matrix can
+	// treat it as statically STT-capable (Supported) and credential-optional.
+	KindWhisper Kind = "whisper"
 )
 
 // Capability is a model capability bound to a provider profile.
@@ -74,6 +79,13 @@ var matrix = map[Kind]map[Capability]Support{
 	},
 	KindElevenLabs: {
 		CapSTT: Supported, CapTTS: Supported,
+	},
+	KindWhisper: {
+		// Self-hosted OpenAI-compatible STT (dir2mcp#240). Statically
+		// STT-capable: the standard /v1/audio/transcriptions contract is
+		// fixed, so unlike kind:openai (EndpointDependent) we mark it
+		// Supported.
+		CapSTT: Supported,
 	},
 }
 

--- a/internal/providerfactory/factory.go
+++ b/internal/providerfactory/factory.go
@@ -21,6 +21,7 @@ import (
 	"github.com/dirstral/dir2mcp/internal/model"
 	"github.com/dirstral/dir2mcp/internal/openai"
 	"github.com/dirstral/dir2mcp/internal/provider"
+	"github.com/dirstral/dir2mcp/internal/whisperapi"
 )
 
 // TTSSynthesizer is the optional text-to-speech surface (matches
@@ -198,10 +199,20 @@ func OCR(p provider.Profile) (model.OCR, error) {
 // Transcriber builds a model.Transcriber for STT-capable kinds:
 // `mistral` (Voxtral), `elevenlabs` (Scribe), `openai`
 // (OpenAI-compatible /v1/audio/transcriptions; endpoint-dependent per
-// SPEC 8.1.2 ³ — validated at first use), and `gemini` (native
-// generateContent with inline audio, SPEC 8.2).
+// SPEC 8.1.2 ³ — validated at first use), `gemini` (native
+// generateContent with inline audio, SPEC 8.2), and `whisper`
+// (self-hosted OpenAI-compatible STT, dir2mcp#240 — credential-optional).
 func Transcriber(p provider.Profile) (model.Transcriber, error) {
 	switch p.Kind {
+	case provider.KindWhisper:
+		c := whisperapi.NewClient(p.BaseURL, p.APIKey)
+		if p.STTModel != "" {
+			c.DefaultModel = p.STTModel
+		}
+		if lang := strings.TrimSpace(p.STTLanguage); lang != "" {
+			c.DefaultLanguage = lang
+		}
+		return c, nil
 	case provider.KindMistral:
 		c := mistral.NewClient(p.BaseURL, p.APIKey)
 		if p.STTModel != "" {

--- a/internal/whisperapi/client.go
+++ b/internal/whisperapi/client.go
@@ -1,0 +1,372 @@
+// Package whisperapi is a pure-Go client for a self-hosted,
+// OpenAI-compatible speech-to-text endpoint — the GPU-VPS path
+// (dir2mcp#240, epic #250).
+//
+// It targets the STANDARD OpenAI POST {BaseURL}/v1/audio/transcriptions
+// multipart contract, which is implemented by common self-hosted shims
+// (vLLM-audio, whisper-server, faster-whisper OpenAI servers). The
+// investigation behind #240 found that livevtt's own servers are NOT
+// OpenAI-compatible, so this client deliberately speaks the portable
+// standard endpoint rather than any livevtt-specific protocol.
+//
+// The endpoint may be credential-less (a self-hosted box on a private
+// network): a Bearer token is sent only when an api_key is configured.
+//
+// Transcripts are parsed into the same `[mm:ss] text` per-segment line
+// format the rest of the ingest pipeline expects (so chunkTranscriptByTime
+// works unchanged), mirroring the Mistral/Voxtral transcriber.
+package whisperapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+const (
+	defaultRequestTimeout = 120 * time.Second
+	defaultMaxRetries     = 3
+	defaultInitialBackoff = 250 * time.Millisecond
+	defaultMaxBackoff     = 2 * time.Second
+	// defaultMaxPayloadBytes bounds the audio payload size so callers
+	// avoid sending absurdly large blobs that fail upstream or time out.
+	defaultMaxPayloadBytes = 50 * 1024 * 1024
+
+	// DefaultModel is a sensible fallback model name. Self-hosted servers
+	// frequently ignore the field or accept "whisper-1" as an alias, but
+	// operators SHOULD set an explicit model via the provider profile.
+	DefaultModel = "whisper-1"
+
+	// ResponseFormatJSON yields segment-level timestamps.
+	ResponseFormatJSON = "json"
+	// ResponseFormatVerboseJSON additionally yields word-level timestamps
+	// (consumed by #252; this client already parses them into the struct).
+	ResponseFormatVerboseJSON = "verbose_json"
+)
+
+// Client speaks the OpenAI-compatible /v1/audio/transcriptions contract
+// against a self-hosted base URL.
+//
+// Error codes:
+//   - WHISPER_AUTH (non-retryable): upstream 401/403.
+//   - WHISPER_RATE_LIMIT (retryable): upstream 429.
+//   - WHISPER_FAILED (retryable for network/5xx, non-retryable otherwise).
+type Client struct {
+	BaseURL    string
+	APIKey     string
+	HTTPClient *http.Client
+
+	MaxRetries     int
+	InitialBackoff time.Duration
+	MaxBackoff     time.Duration
+	// MaxPayloadBytes bounds the audio payload size (bytes). Values <= 0
+	// fall back to defaultMaxPayloadBytes.
+	MaxPayloadBytes int
+
+	// DefaultModel is sent as the multipart `model` field. Empty falls
+	// back to the package DefaultModel constant.
+	DefaultModel string
+	// DefaultLanguage optionally sets the `language` hint. Empty means
+	// provider auto-detection (no language field is sent).
+	DefaultLanguage string
+	// ResponseFormat selects the response schema: "json" (default,
+	// segments) or "verbose_json" (segments + word timestamps). Empty
+	// falls back to ResponseFormatJSON.
+	ResponseFormat string
+}
+
+// compile-time interface check.
+var _ model.Transcriber = (*Client)(nil)
+
+// NewClient constructs a client with safe default retry/timeout settings.
+// apiKey may be empty for a credential-less self-hosted endpoint.
+func NewClient(baseURL, apiKey string) *Client {
+	return &Client{
+		BaseURL:         strings.TrimRight(strings.TrimSpace(baseURL), "/"),
+		APIKey:          strings.TrimSpace(apiKey),
+		HTTPClient:      &http.Client{Timeout: defaultRequestTimeout},
+		MaxRetries:      defaultMaxRetries,
+		InitialBackoff:  defaultInitialBackoff,
+		MaxBackoff:      defaultMaxBackoff,
+		MaxPayloadBytes: defaultMaxPayloadBytes,
+		DefaultModel:    DefaultModel,
+		ResponseFormat:  ResponseFormatJSON,
+	}
+}
+
+// transcribeResponse models the standard OpenAI transcription schema. The
+// `words` field is only populated when response_format=verbose_json; it is
+// carried here (unused by segment parsing today) so #252 can build
+// word-level timestamps on top of this struct without re-shaping it.
+type transcribeResponse struct {
+	Text     string              `json:"text"`
+	Language string              `json:"language,omitempty"`
+	Duration float64             `json:"duration,omitempty"`
+	Segments []transcriptSegment `json:"segments,omitempty"`
+}
+
+type transcriptSegment struct {
+	Start float64          `json:"start"`
+	End   float64          `json:"end"`
+	Text  string           `json:"text"`
+	Words []transcriptWord `json:"words,omitempty"`
+}
+
+// transcriptWord is the verbose_json word-level timestamp (#252). Present
+// only when response_format=verbose_json.
+type transcriptWord struct {
+	Word  string  `json:"word"`
+	Start float64 `json:"start"`
+	End   float64 `json:"end"`
+}
+
+// Transcribe implements model.Transcriber.
+func (c *Client) Transcribe(ctx context.Context, relPath string, data []byte) (string, error) {
+	if len(data) == 0 {
+		return "", &model.ProviderError{Code: "WHISPER_FAILED", Message: "transcription input is empty", Retryable: false}
+	}
+	maxPayload := c.MaxPayloadBytes
+	if maxPayload <= 0 {
+		maxPayload = defaultMaxPayloadBytes
+	}
+	if len(data) > maxPayload {
+		return "", &model.ProviderError{
+			Code:      "WHISPER_FAILED",
+			Message:   fmt.Sprintf("transcription input too large (%d bytes, limit %d)", len(data), maxPayload),
+			Retryable: false,
+		}
+	}
+	return c.transcribeWithRetry(ctx, relPath, data)
+}
+
+func (c *Client) transcribeWithRetry(ctx context.Context, relPath string, data []byte) (string, error) {
+	maxAttempts := c.MaxRetries + 1
+	if maxAttempts <= 0 {
+		maxAttempts = 1
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		out, err := c.transcribeOnce(ctx, relPath, data)
+		if err == nil {
+			return out, nil
+		}
+		lastErr = err
+
+		var providerErr *model.ProviderError
+		if !errors.As(err, &providerErr) || !providerErr.Retryable || attempt == maxAttempts-1 {
+			return "", err
+		}
+
+		if waitErr := c.wait(ctx, c.backoffForAttempt(attempt)); waitErr != nil {
+			return "", waitErr
+		}
+	}
+	return "", lastErr
+}
+
+// buildBody builds the multipart form body. Returns the raw body bytes and
+// the writer (for the Content-Type boundary), or a ProviderError.
+func (c *Client) buildBody(relPath string, data []byte) ([]byte, *multipart.Writer, error) {
+	fail := func(msg string, cause error) ([]byte, *multipart.Writer, error) {
+		return nil, nil, &model.ProviderError{Code: "WHISPER_FAILED", Message: msg, Retryable: false, Cause: cause}
+	}
+	fileName := strings.TrimSpace(filepath.Base(relPath))
+	if fileName == "" || fileName == "." || fileName == string(filepath.Separator) {
+		fileName = "audio.wav"
+	}
+
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	fileField, err := writer.CreateFormFile("file", fileName)
+	if err != nil {
+		return fail("failed to build transcription request body", err)
+	}
+	if _, err := fileField.Write(data); err != nil {
+		return fail("failed to write transcription input", err)
+	}
+
+	modelName := strings.TrimSpace(c.DefaultModel)
+	if modelName == "" {
+		modelName = DefaultModel
+	}
+	if err := writer.WriteField("model", modelName); err != nil {
+		return fail("failed to write transcription model", err)
+	}
+	if err := writer.WriteField("response_format", c.responseFormat()); err != nil {
+		return fail("failed to write transcription response_format", err)
+	}
+	if language := strings.TrimSpace(c.DefaultLanguage); language != "" {
+		if err := writer.WriteField("language", language); err != nil {
+			return fail("failed to write transcription language", err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		return fail("failed to finalize transcription request body", err)
+	}
+	return buf.Bytes(), writer, nil
+}
+
+// responseFormat returns the configured response format, defaulting to
+// json. An unknown value is passed through unchanged so operators can
+// target server-specific formats; only the empty value is defaulted.
+func (c *Client) responseFormat() string {
+	if f := strings.TrimSpace(c.ResponseFormat); f != "" {
+		return f
+	}
+	return ResponseFormatJSON
+}
+
+func (c *Client) transcribeOnce(ctx context.Context, relPath string, data []byte) (string, error) {
+	if strings.TrimSpace(c.BaseURL) == "" {
+		return "", &model.ProviderError{Code: "WHISPER_FAILED", Message: "missing whisper base_url", Retryable: false}
+	}
+	body, writer, err := c.buildBody(relPath, data)
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+"/v1/audio/transcriptions", bytes.NewReader(body))
+	if err != nil {
+		return "", &model.ProviderError{Code: "WHISPER_FAILED", Message: "failed to build transcription request", Retryable: false, Cause: err}
+	}
+	// Bearer auth is optional: only set it for credentialed endpoints.
+	if key := strings.TrimSpace(c.APIKey); key != "" {
+		req.Header.Set("Authorization", "Bearer "+key)
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	httpClient := c.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: defaultRequestTimeout}
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", &model.ProviderError{Code: "WHISPER_FAILED", Message: "transcription request failed", Retryable: true, Cause: err}
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", httpError(resp)
+	}
+
+	var parsed transcribeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return "", &model.ProviderError{
+			Code:      "WHISPER_FAILED",
+			Message:   "failed to decode transcription response",
+			Retryable: false,
+			Cause:     err,
+		}
+	}
+
+	if segText, ok := parseTranscriptSegments(parsed); ok {
+		return segText, nil
+	}
+	text := strings.TrimSpace(parsed.Text)
+	if text == "" {
+		return "", &model.ProviderError{
+			Code:      "WHISPER_FAILED",
+			Message:   "transcription response had no text content",
+			Retryable: false,
+		}
+	}
+	return text, nil
+}
+
+// parseTranscriptSegments converts timed segments into `[mm:ss] text`
+// lines (the format chunkTranscriptByTime consumes). Returns ("", false)
+// when no non-empty segments are present (caller falls back to flat text).
+func parseTranscriptSegments(parsed transcribeResponse) (string, bool) {
+	if len(parsed.Segments) == 0 {
+		return "", false
+	}
+	lines := make([]string, 0, len(parsed.Segments))
+	for _, seg := range parsed.Segments {
+		text := strings.TrimSpace(seg.Text)
+		if text == "" {
+			continue
+		}
+		startSec := int(seg.Start)
+		if startSec < 0 {
+			startSec = 0
+		}
+		mm := startSec / 60
+		ss := startSec % 60
+		lines = append(lines, "["+pad2(mm)+":"+pad2(ss)+"] "+text)
+	}
+	if len(lines) == 0 {
+		return "", false
+	}
+	return strings.Join(lines, "\n"), true
+}
+
+func httpError(resp *http.Response) error {
+	bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	errMsg := strings.TrimSpace(string(bodyBytes))
+	if errMsg == "" {
+		errMsg = "upstream returned non-200 response"
+	}
+	switch {
+	case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
+		return &model.ProviderError{Code: "WHISPER_AUTH", Message: errMsg, Retryable: false, StatusCode: resp.StatusCode}
+	case resp.StatusCode == http.StatusTooManyRequests:
+		return &model.ProviderError{Code: "WHISPER_RATE_LIMIT", Message: errMsg, Retryable: true, StatusCode: resp.StatusCode}
+	case resp.StatusCode >= http.StatusInternalServerError:
+		return &model.ProviderError{Code: "WHISPER_FAILED", Message: errMsg, Retryable: true, StatusCode: resp.StatusCode}
+	default:
+		return &model.ProviderError{Code: "WHISPER_FAILED", Message: errMsg, Retryable: false, StatusCode: resp.StatusCode}
+	}
+}
+
+func (c *Client) backoffForAttempt(attempt int) time.Duration {
+	initial := c.InitialBackoff
+	if initial <= 0 {
+		initial = defaultInitialBackoff
+	}
+	maxBackoff := c.MaxBackoff
+	if maxBackoff <= 0 {
+		maxBackoff = defaultMaxBackoff
+	}
+	backoff := initial
+	for i := 0; i < attempt; i++ {
+		backoff *= 2
+		if backoff >= maxBackoff {
+			return maxBackoff
+		}
+	}
+	return backoff
+}
+
+func (c *Client) wait(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func pad2(n int) string {
+	if n < 10 {
+		return "0" + strconv.Itoa(n)
+	}
+	return strconv.Itoa(n)
+}

--- a/tests/provider/provider_test.go
+++ b/tests/provider/provider_test.go
@@ -17,6 +17,7 @@ func TestMatrixMatchesSpec(t *testing.T) {
 		provider.KindGemini:     {provider.CapEmbed: S, provider.CapChat: S, provider.CapOCR: U, provider.CapSTT: S, provider.CapTTS: S, provider.CapRerank: U},
 		provider.KindCohere:     {provider.CapEmbed: S, provider.CapChat: S, provider.CapOCR: U, provider.CapSTT: U, provider.CapTTS: U, provider.CapRerank: S},
 		provider.KindElevenLabs: {provider.CapEmbed: U, provider.CapChat: U, provider.CapOCR: U, provider.CapSTT: S, provider.CapTTS: S, provider.CapRerank: U},
+		provider.KindWhisper:    {provider.CapEmbed: U, provider.CapChat: U, provider.CapOCR: U, provider.CapSTT: S, provider.CapTTS: U, provider.CapRerank: U},
 	}
 	for k, caps := range want {
 		for c, exp := range caps {

--- a/tests/providerfactory/factory_test.go
+++ b/tests/providerfactory/factory_test.go
@@ -51,7 +51,7 @@ func TestOCR(t *testing.T) {
 }
 
 func TestTranscriber(t *testing.T) {
-	for _, k := range []provider.Kind{provider.KindMistral, provider.KindElevenLabs, provider.KindOpenAI, provider.KindGemini} {
+	for _, k := range []provider.Kind{provider.KindMistral, provider.KindElevenLabs, provider.KindOpenAI, provider.KindGemini, provider.KindWhisper} {
 		if tr, err := providerfactory.Transcriber(prof(k)); err != nil || tr == nil {
 			t.Errorf("Transcriber(%s) = %v, %v", k, tr, err)
 		}

--- a/tests/whisperapi/client_test.go
+++ b/tests/whisperapi/client_test.go
@@ -1,0 +1,245 @@
+package tests
+
+import (
+	"context"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/whisperapi"
+)
+
+// jsonSegments is a standard OpenAI /v1/audio/transcriptions json response
+// with two timed segments (verbose_json additionally carries words[]).
+const jsonSegments = `{
+  "text": "hello there general",
+  "language": "en",
+  "duration": 75.0,
+  "segments": [
+    {"start": 0.0, "end": 4.2, "text": " hello there"},
+    {"start": 65.0, "end": 70.0, "text": "general"}
+  ]
+}`
+
+func newClient(url, apiKey string) *whisperapi.Client {
+	c := whisperapi.NewClient(url, apiKey)
+	c.InitialBackoff = time.Millisecond
+	c.MaxBackoff = time.Millisecond
+	return c
+}
+
+// parsedForm captures the multipart fields a request carried.
+type parsedForm struct {
+	model          string
+	language       string
+	responseFormat string
+	fileName       string
+	auth           string
+	hasAuth        bool
+}
+
+func parseMultipart(t *testing.T, r *http.Request) parsedForm {
+	t.Helper()
+	out := parsedForm{}
+	out.auth = r.Header.Get("Authorization")
+	out.hasAuth = out.auth != ""
+
+	_, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		t.Fatalf("parse content type: %v", err)
+	}
+	mr := multipart.NewReader(r.Body, params["boundary"])
+	for {
+		part, perr := mr.NextPart()
+		if perr == io.EOF {
+			break
+		}
+		if perr != nil {
+			t.Fatalf("read multipart part: %v", perr)
+		}
+		data, _ := io.ReadAll(part)
+		switch part.FormName() {
+		case "model":
+			out.model = string(data)
+		case "language":
+			out.language = string(data)
+		case "response_format":
+			out.responseFormat = string(data)
+		case "file":
+			out.fileName = part.FileName()
+		}
+	}
+	return out
+}
+
+// TestTranscribeSegmentsFormatting asserts the json segments response is
+// rendered as [mm:ss]-prefixed lines (the format chunkTranscriptByTime
+// consumes) and that the multipart fields are sent.
+func TestTranscribeSegmentsFormatting(t *testing.T) {
+	var got parsedForm
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/audio/transcriptions" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		got = parseMultipart(t, r)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, jsonSegments)
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL, "secret-key")
+	c.DefaultModel = "faster-whisper-large-v3"
+	c.DefaultLanguage = "en"
+
+	out, err := c.Transcribe(context.Background(), "podcast/ep1.mp3", []byte("audiobytes"))
+	if err != nil {
+		t.Fatalf("Transcribe: %v", err)
+	}
+
+	want := "[00:00] hello there\n[01:05] general"
+	if out != want {
+		t.Fatalf("transcript = %q, want %q", out, want)
+	}
+
+	// multipart fields
+	if got.model != "faster-whisper-large-v3" {
+		t.Errorf("model field = %q, want faster-whisper-large-v3", got.model)
+	}
+	if got.language != "en" {
+		t.Errorf("language field = %q, want en", got.language)
+	}
+	if got.responseFormat != "json" {
+		t.Errorf("response_format = %q, want json (default)", got.responseFormat)
+	}
+	if !strings.HasSuffix(got.fileName, "ep1.mp3") {
+		t.Errorf("file name = %q, want suffix ep1.mp3", got.fileName)
+	}
+	// auth header present when api_key set
+	if got.auth != "Bearer secret-key" {
+		t.Errorf("auth header = %q, want Bearer secret-key", got.auth)
+	}
+}
+
+// TestVerboseJSONResponseFormat asserts response_format=verbose_json is
+// sent when configured.
+func TestVerboseJSONResponseFormat(t *testing.T) {
+	var got parsedForm
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = parseMultipart(t, r)
+		_, _ = io.WriteString(w, jsonSegments)
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL, "")
+	c.ResponseFormat = whisperapi.ResponseFormatVerboseJSON
+
+	if _, err := c.Transcribe(context.Background(), "a.wav", []byte("x")); err != nil {
+		t.Fatalf("Transcribe: %v", err)
+	}
+	if got.responseFormat != "verbose_json" {
+		t.Errorf("response_format = %q, want verbose_json", got.responseFormat)
+	}
+}
+
+// TestNoAuthWhenCredentialLess asserts no Authorization header is sent for a
+// credential-less (self-hosted) endpoint, and the language field is omitted
+// when no language is configured.
+func TestNoAuthWhenCredentialLess(t *testing.T) {
+	var got parsedForm
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = parseMultipart(t, r)
+		_, _ = io.WriteString(w, jsonSegments)
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL, "") // no api_key
+
+	if _, err := c.Transcribe(context.Background(), "a.wav", []byte("x")); err != nil {
+		t.Fatalf("Transcribe: %v", err)
+	}
+	if got.hasAuth {
+		t.Errorf("auth header should be absent for credential-less endpoint, got %q", got.auth)
+	}
+	if got.language != "" {
+		t.Errorf("language field should be empty when unset, got %q", got.language)
+	}
+}
+
+// TestRetryOn5xx asserts a retryable 5xx is retried and eventually succeeds.
+func TestRetryOn5xx(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = io.WriteString(w, "overloaded")
+			return
+		}
+		_, _ = io.WriteString(w, jsonSegments)
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL, "k")
+	out, err := c.Transcribe(context.Background(), "a.wav", []byte("x"))
+	if err != nil {
+		t.Fatalf("Transcribe after retry: %v", err)
+	}
+	if n := atomic.LoadInt32(&calls); n != 2 {
+		t.Errorf("calls = %d, want 2 (one 5xx then success)", n)
+	}
+	if !strings.HasPrefix(out, "[00:00] hello there") {
+		t.Errorf("transcript = %q, want [mm:ss] formatting", out)
+	}
+}
+
+// TestAuthErrorNotRetried asserts a 401 is surfaced as a non-retryable
+// WHISPER_AUTH error and not retried.
+func TestAuthErrorNotRetried(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, "bad key")
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL, "k")
+	_, err := c.Transcribe(context.Background(), "a.wav", []byte("x"))
+	if err == nil {
+		t.Fatal("expected auth error")
+	}
+	pe, ok := err.(*model.ProviderError)
+	if !ok {
+		t.Fatalf("error type = %T, want *model.ProviderError", err)
+	}
+	if pe.Code != "WHISPER_AUTH" || pe.Retryable {
+		t.Errorf("err = %+v, want WHISPER_AUTH non-retryable", pe)
+	}
+	if n := atomic.LoadInt32(&calls); n != 1 {
+		t.Errorf("calls = %d, want 1 (auth error not retried)", n)
+	}
+}
+
+// TestFlatTextFallback asserts a response without segments falls back to the
+// flat text field.
+func TestFlatTextFallback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"text":"just flat text"}`)
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL, "k")
+	out, err := c.Transcribe(context.Background(), "a.wav", []byte("x"))
+	if err != nil {
+		t.Fatalf("Transcribe: %v", err)
+	}
+	if out != "just flat text" {
+		t.Errorf("transcript = %q, want flat text fallback", out)
+	}
+}

--- a/tests/whisperapi/client_test.go
+++ b/tests/whisperapi/client_test.go
@@ -243,3 +243,102 @@ func TestFlatTextFallback(t *testing.T) {
 		t.Errorf("transcript = %q, want flat text fallback", out)
 	}
 }
+
+// TestEmptyAudioRejected asserts empty input is rejected locally as a
+// non-retryable WHISPER_FAILED without any HTTP call.
+func TestEmptyAudioRejected(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		_, _ = io.WriteString(w, jsonSegments)
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL, "k")
+	_, err := c.Transcribe(context.Background(), "a.wav", nil)
+	if err == nil {
+		t.Fatal("expected error for empty audio")
+	}
+	pe, ok := err.(*model.ProviderError)
+	if !ok {
+		t.Fatalf("error type = %T, want *model.ProviderError", err)
+	}
+	if pe.Code != "WHISPER_FAILED" || pe.Retryable {
+		t.Errorf("err = %+v, want WHISPER_FAILED non-retryable", pe)
+	}
+	if n := atomic.LoadInt32(&calls); n != 0 {
+		t.Errorf("calls = %d, want 0 (no HTTP for empty input)", n)
+	}
+}
+
+// TestMalformedJSON asserts a 200 with an unparseable body surfaces as a
+// non-retryable WHISPER_FAILED decode error (not retried).
+func TestMalformedJSON(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		_, _ = io.WriteString(w, `{not valid json`)
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL, "k")
+	_, err := c.Transcribe(context.Background(), "a.wav", []byte("x"))
+	if err == nil {
+		t.Fatal("expected decode error")
+	}
+	pe, ok := err.(*model.ProviderError)
+	if !ok {
+		t.Fatalf("error type = %T, want *model.ProviderError", err)
+	}
+	if pe.Code != "WHISPER_FAILED" || pe.Retryable {
+		t.Errorf("err = %+v, want WHISPER_FAILED non-retryable", pe)
+	}
+	if n := atomic.LoadInt32(&calls); n != 1 {
+		t.Errorf("calls = %d, want 1 (decode error not retried)", n)
+	}
+}
+
+// TestNon200EmptyBody asserts a non-200 with an empty body still yields a
+// categorized ProviderError with a non-empty message (no panic, no leak).
+func TestNon200EmptyBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest) // 4xx, non-retryable, empty body
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL, "k")
+	_, err := c.Transcribe(context.Background(), "a.wav", []byte("x"))
+	if err == nil {
+		t.Fatal("expected error for non-200")
+	}
+	pe, ok := err.(*model.ProviderError)
+	if !ok {
+		t.Fatalf("error type = %T, want *model.ProviderError", err)
+	}
+	if pe.Code != "WHISPER_FAILED" || pe.Retryable {
+		t.Errorf("err = %+v, want WHISPER_FAILED non-retryable", pe)
+	}
+	if strings.TrimSpace(pe.Message) == "" {
+		t.Error("message should be non-empty even for empty upstream body")
+	}
+	if pe.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", pe.StatusCode)
+	}
+}
+
+// TestContextCancellationRespected asserts an already-cancelled context
+// short-circuits the request rather than hitting the server.
+func TestContextCancellationRespected(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, jsonSegments)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	c := newClient(srv.URL, "k")
+	if _, err := c.Transcribe(ctx, "a.wav", []byte("x")); err == nil {
+		t.Fatal("expected error for cancelled context")
+	}
+}


### PR DESCRIPTION
## Summary

Closes the STT self-hosting gap (the GPU-VPS path) by adding `internal/whisperapi`, a pure-Go client for a self-hosted **OpenAI-compatible** speech-to-text endpoint, and wiring it as an STT provider so a profile with a `base_url` resolves to it for `CapSTT`. Embed/chat self-hosting already worked via the `kind: openai` + `base_url` path; this completes the trio for STT.

Refs: #240, epic #250. Unblocks #252 (word-level timestamps) and #266 (diarization).

## Investigation honored

livevtt's own servers are **not** OpenAI-compatible, so this client deliberately speaks the *standard* OpenAI `POST {base_url}/v1/audio/transcriptions` multipart contract — the portable target that works with vLLM-audio, whisper-server, and faster-whisper OpenAI shims — rather than any livevtt-specific protocol.

## What's in it

- **`internal/whisperapi.Client`** (`model.Transcriber`):
  - Multipart POST with `file`, `model`, `response_format` (default `json`; `verbose_json` allowed), optional `language` hint.
  - Optional **Bearer auth**: sent only when an `api_key` is configured (self-hosted endpoints may be credential-less).
  - Retry/backoff for 5xx/429, mirroring the Mistral transcriber; non-retryable on 401/403/4xx.
  - Parses segments into the same `[mm:ss] text` per-segment transcript the pipeline already chunks (`chunkTranscriptByTime` unchanged); flat-text fallback when no segments.
  - **Response struct carries `words[]`** (populated by `verbose_json`) so #252 can build word-level timestamps on top of it without re-shaping — only segment parsing is consumed today.
  - No hardcoded language: it flows from the profile's `STTLanguage` exactly as today.

- **Provider wiring**:
  - New kind `whisper` in the matrix with `CapSTT: Supported` (distinct from `kind: openai`'s `EndpointDependent` — the standard endpoint contract is fixed, so it's statically STT-capable).
  - Built via `providerfactory.Transcriber`.

- **Config (reuses the existing provider-profile mechanism)**:
  - Built-in credential-less `whisper` profile; `base_url` from `${WHISPER_BASE_URL}` or a user `providers:` entry, with the usual `api_key`/`stt_model`/`stt_language` knobs.
  - Selected via `stt_provider: whisper`.
  - Excluded from auto-precedence (like `local`) so a credential-less profile never silently wins auto-selection.

## How the provider is selected

```yaml
stt_provider: whisper
providers:
  whisper:
    kind: whisper
    base_url: https://gpu-vps.example.com   # or ${WHISPER_BASE_URL}
    # api_key: ${WHISPER_API_KEY}           # optional (credential-less ok)
    # stt_model: faster-whisper-large-v3
    # stt_language: en
```

## Tests (package `tests`)

`tests/whisperapi` spins an `httptest.Server` emulating `/v1/audio/transcriptions` and asserts: `[mm:ss]` formatting from a json segments response; multipart `model`/`language`/`response_format` fields; Bearer header present when `api_key` set and **absent** when credential-less; `response_format=verbose_json` passthrough; retry on 5xx (succeeds on 2nd attempt); non-retryable `WHISPER_AUTH` on 401; flat-text fallback. Matrix + factory tests extended for the new kind.

## Checks

- `make check` passes locally (CGO_ENABLED=0, gocyclo ≤ 15).
- No submodule re-pin.