### PR TITLE
dist: Nix flake + overlay + nix-darwin/home-manager service modules (#272, #292)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -75,23 +75,19 @@ brews:
 
 # Nix flake publisher (lean dir2mcp binary only; docling-full is out of
 # scope and ships via container/Homebrew). GoReleaser regenerates a versioned
-# flake derivation on every tag and pushes it to a flake repository, mirroring
-# how the Homebrew `brews` block above pushes to homebrew-tap.
+# flake derivation on every tag and pushes it to dirstral/nix-user-repository,
+# mirroring how the Homebrew `brews` block above pushes to homebrew-tap.
 #
-# TODO(maintainer): before the first real release with Nix enabled, confirm
-# the target flake repository below exists and that
-# NIX_USER_REPOSITORY_GITHUB_TOKEN (a PAT with `repo` scope on that repo) is
-# set as a repository secret, exactly like HOMEBREW_TAP_GITHUB_TOKEN. The repo
-# name `nix-user-repository` is a placeholder convention -- adjust owner/name
-# to the actual flake repo.
+# REQUIRED before the first release with this block on `main`:
+# set NIX_USER_REPOSITORY_GITHUB_TOKEN (a PAT with `repo` scope on
+# dirstral/nix-user-repository) as a repository secret on dir2mcp, exactly like
+# HOMEBREW_TAP_GITHUB_TOKEN. Without it, the nix publish step fails the release.
 nix:
   - name: dir2mcp
     ids:
       - dir2mcp-archive
     repository:
       owner: dirstral
-      # TODO(maintainer): create this repo (or rename to the real target) and
-      # provision the token below before enabling Nix publishing on a tag.
       name: nix-user-repository
       token: "{{ .Env.NIX_USER_REPOSITORY_GITHUB_TOKEN }}"
     homepage: https://github.com/dirstral/dir2mcp

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -73,6 +73,36 @@ brews:
       command cache, or open a new terminal.
 
 
+# Nix flake publisher (lean dir2mcp binary only; docling-full is out of
+# scope and ships via container/Homebrew). GoReleaser regenerates a versioned
+# flake derivation on every tag and pushes it to a flake repository, mirroring
+# how the Homebrew `brews` block above pushes to homebrew-tap.
+#
+# TODO(maintainer): before the first real release with Nix enabled, confirm
+# the target flake repository below exists and that
+# NIX_USER_REPOSITORY_GITHUB_TOKEN (a PAT with `repo` scope on that repo) is
+# set as a repository secret, exactly like HOMEBREW_TAP_GITHUB_TOKEN. The repo
+# name `nix-user-repository` is a placeholder convention -- adjust owner/name
+# to the actual flake repo.
+nix:
+  - name: dir2mcp
+    ids:
+      - dir2mcp-archive
+    repository:
+      owner: dirstral
+      # TODO(maintainer): create this repo (or rename to the real target) and
+      # provision the token below before enabling Nix publishing on a tag.
+      name: nix-user-repository
+      token: "{{ .Env.NIX_USER_REPOSITORY_GITHUB_TOKEN }}"
+    homepage: https://github.com/dirstral/dir2mcp
+    description: Deploy any local directory as an MCP knowledge server with indexing, retrieval, and citations (lean binary).
+    license: mit
+    # Lean binary install; no docling runtime bundled.
+    install: |
+      mkdir -p $out/bin
+      cp -vr ./dir2mcp $out/bin/dir2mcp
+
+
 changelog:
   sort: asc
   filters:

--- a/README.md
+++ b/README.md
@@ -70,7 +70,56 @@ Or add it to a profile:
 nix profile install github:dirstral/dir2mcp
 ```
 
-The flake builds the lean binary only (no bundled docling runtime); for batteries-included structured extraction, use the `dir2mcp-full` Homebrew formula or the docling-full container. A `devShells.default` with the Go toolchain is also exposed (`nix develop`).
+The flake builds the lean binary only (no bundled docling runtime); for batteries-included structured extraction, use the `dir2mcp-full` Homebrew formula or the docling-full container. A `devShells.default` with the Go toolchain is also exposed (`nix develop`). The flake also exposes `overlays.default` (adds `pkgs.dir2mcp` to any nixpkgs), plus `darwinModules.default` and `homeManagerModules.default` for the declarative service below.
+
+#### Declarative service (nix-darwin / home-manager)
+
+The flake ships service modules that run `dir2mcp up --foreground` under a supervisor (launchd on macOS, systemd `--user` on Linux), so the corpus server starts at login and is restarted on failure. These require the flake's modules — they are not part of nixpkgs.
+
+Add the input and the module to your config. **nix-darwin:**
+
+```nix
+{
+  inputs.dir2mcp.url = "github:dirstral/dir2mcp";
+
+  # in your darwinConfiguration modules list:
+  modules = [
+    dir2mcp.darwinModules.default
+    {
+      services.dir2mcp = {
+        enable = true;
+        rootDir = "/Users/me/Documents/corpus";
+        # Secrets (MISTRAL_API_KEY, OPENAI_API_KEY, DIR2MCP_AUTH_TOKEN, ...)
+        # live in this file, NOT in the nix store. Manage it yourself with
+        # restrictive permissions.
+        environmentFile = "/Users/me/.config/dir2mcp/env";
+      };
+    }
+  ];
+}
+```
+
+**home-manager** (works on macOS via launchd and on Linux via systemd `--user`):
+
+```nix
+{
+  inputs.dir2mcp.url = "github:dirstral/dir2mcp";
+
+  # in your homeConfiguration modules list:
+  modules = [
+    dir2mcp.homeManagerModules.default
+    {
+      services.dir2mcp = {
+        enable = true;
+        rootDir = "/home/me/corpus";
+        environmentFile = "/home/me/.config/dir2mcp/env";
+      };
+    }
+  ];
+}
+```
+
+Optional knobs: `stateDir`, `listen`, `extraArgs` (e.g. `[ "--public" "--auth" "auto" ]`), and `package` (defaults to this flake's lean build). On macOS, launchd has no native `EnvironmentFile`, so the module sources `environmentFile` via a small wrapper script at start; on Linux it is wired to systemd's native `EnvironmentFile=`. Either way the secret values stay outside the world-readable nix store.
 
 Build-from-source remains available as an alternative:
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,22 @@ dir2mcp ships in two Homebrew formulas that install the **same binary** but diff
 
 The two formulas are mutually exclusive (Homebrew refuses to install both at once). Choose **full** for batteries-included local extraction; choose **lean** if you bring docling yourself, run docling-serve, or rely on Mistral OCR. Either way, extraction is configurable at runtime via `ingest.extractor` (see [Document extraction](#document-extraction-modes--fallback)).
 
+### Nix (macOS + Linux)
+
+A [Nix flake](flake.nix) packages the **lean** `dir2mcp` binary for `x86_64`/`aarch64` on both Linux and macOS. Run it without installing:
+
+```bash
+nix run github:dirstral/dir2mcp -- version
+```
+
+Or add it to a profile:
+
+```bash
+nix profile install github:dirstral/dir2mcp
+```
+
+The flake builds the lean binary only (no bundled docling runtime); for batteries-included structured extraction, use the `dir2mcp-full` Homebrew formula or the docling-full container. A `devShells.default` with the Go toolchain is also exposed (`nix develop`).
+
 Build-from-source remains available as an alternative:
 
 ```bash

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -63,7 +63,12 @@
       overlays.default = final: prev: {
         dir2mcp = final.callPackage ./nix/package.nix {
           src = self;
-          version = "0.0.0-dev";
+          # Identify a from-source build by the flake's git revision so
+          # `dir2mcp version` isn't a bare "0.0.0-dev". A clean checkout yields
+          # the short rev, a dirty tree the dirty short rev, and a non-git source
+          # falls back to "0.0.0-dev". A tagged release ships via GoReleaser's nix
+          # publisher with the real version, independent of this.
+          version = "0.0.0-dev+g${self.shortRev or self.dirtyShortRev or "unknown"}";
         };
       };
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,89 @@
+{
+  description = "dir2mcp - deploy any local directory as an MCP knowledge server (lean binary)";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachSystem [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ]
+      (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+
+          # Keep this in sync with the released tag. GoReleaser's nix
+          # publisher generates a versioned flake on each release; this
+          # hand-written flake tracks the source tree for `nix run` /
+          # `nix build` from a checkout.
+          version = "0.0.0-dev";
+
+          dir2mcp = pkgs.buildGoModule {
+            pname = "dir2mcp";
+            inherit version;
+
+            src = self;
+
+            # NOTE (maintainer / CI): replace `lib.fakeHash` with the real
+            # vendor hash on the first build. Run `nix build`, then copy the
+            # `got:` hash from the mismatch error into this field. GoReleaser's
+            # nix publisher computes this automatically for the derivation it
+            # generates; this value only matters when building this
+            # hand-written flake directly.
+            vendorHash = pkgs.lib.fakeHash;
+
+            subPackages = [ "cmd/dir2mcp" ];
+
+            # Inject the version into the symbol the runtime reads
+            # (internal/buildinfo.Version), mirroring .goreleaser.yaml and
+            # the Makefile. Lean binary only -- no docling runtime bundled.
+            ldflags = [
+              "-s"
+              "-w"
+              "-X github.com/dirstral/dir2mcp/internal/buildinfo.Version=${version}"
+            ];
+
+            # Lean build: CGO is disabled in the release matrix.
+            env.CGO_ENABLED = "0";
+
+            # Skip tests during the package build; integration suites need
+            # external credentials and the full check matrix runs in CI.
+            doCheck = false;
+
+            meta = with pkgs.lib; {
+              description = "Deploy any local directory as an MCP knowledge server with indexing, retrieval, and citations (lean binary; docling-full ships via container/Homebrew).";
+              homepage = "https://github.com/dirstral/dir2mcp";
+              license = licenses.mit;
+              mainProgram = "dir2mcp";
+              platforms = platforms.unix;
+            };
+          };
+        in
+        {
+          packages = {
+            default = dir2mcp;
+            dir2mcp = dir2mcp;
+          };
+
+          apps.default = {
+            type = "app";
+            program = "${dir2mcp}/bin/dir2mcp";
+          };
+
+          devShells.default = pkgs.mkShell {
+            packages = [
+              pkgs.go
+              pkgs.gopls
+              pkgs.gotools
+            ];
+          };
+        }
+      );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,13 @@
 
   outputs =
     { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachSystem [
+    # Per-system outputs (packages / apps / devShells) are produced via
+    # eachSystem and merged (//) with the system-agnostic outputs (overlay,
+    # nix-darwin module, home-manager module). The package itself is defined
+    # once in nix/package.nix and exposed through overlays.default so the
+    # per-system build, the overlay, and the service modules all share a single
+    # source of truth.
+    (flake-utils.lib.eachSystem [
       "x86_64-linux"
       "aarch64-linux"
       "x86_64-darwin"
@@ -17,64 +23,20 @@
       (
         system:
         let
-          pkgs = import nixpkgs { inherit system; };
-
-          # Keep this in sync with the released tag. GoReleaser's nix
-          # publisher generates a versioned flake on each release; this
-          # hand-written flake tracks the source tree for `nix run` /
-          # `nix build` from a checkout.
-          version = "0.0.0-dev";
-
-          dir2mcp = pkgs.buildGoModule {
-            pname = "dir2mcp";
-            inherit version;
-
-            src = self;
-
-            # NOTE (maintainer / CI): replace `lib.fakeHash` with the real
-            # vendor hash on the first build. Run `nix build`, then copy the
-            # `got:` hash from the mismatch error into this field. GoReleaser's
-            # nix publisher computes this automatically for the derivation it
-            # generates; this value only matters when building this
-            # hand-written flake directly.
-            vendorHash = pkgs.lib.fakeHash;
-
-            subPackages = [ "cmd/dir2mcp" ];
-
-            # Inject the version into the symbol the runtime reads
-            # (internal/buildinfo.Version), mirroring .goreleaser.yaml and
-            # the Makefile. Lean binary only -- no docling runtime bundled.
-            ldflags = [
-              "-s"
-              "-w"
-              "-X github.com/dirstral/dir2mcp/internal/buildinfo.Version=${version}"
-            ];
-
-            # Lean build: CGO is disabled in the release matrix.
-            env.CGO_ENABLED = "0";
-
-            # Skip tests during the package build; integration suites need
-            # external credentials and the full check matrix runs in CI.
-            doCheck = false;
-
-            meta = with pkgs.lib; {
-              description = "Deploy any local directory as an MCP knowledge server with indexing, retrieval, and citations (lean binary; docling-full ships via container/Homebrew).";
-              homepage = "https://github.com/dirstral/dir2mcp";
-              license = licenses.mit;
-              mainProgram = "dir2mcp";
-              platforms = platforms.unix;
-            };
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [ self.overlays.default ];
           };
         in
         {
           packages = {
-            default = dir2mcp;
-            dir2mcp = dir2mcp;
+            default = pkgs.dir2mcp;
+            dir2mcp = pkgs.dir2mcp;
           };
 
           apps.default = {
             type = "app";
-            program = "${dir2mcp}/bin/dir2mcp";
+            program = "${pkgs.dir2mcp}/bin/dir2mcp";
           };
 
           devShells.default = pkgs.mkShell {
@@ -85,5 +47,32 @@
             ];
           };
         }
-      );
+      ))
+    // {
+      # System-agnostic outputs.
+
+      # Overlay: adds `dir2mcp` to any nixpkgs instance. `final.callPackage`
+      # supplies { lib, buildGoModule }; we pass `src = self` (the flake's own
+      # source tree) explicitly so the build works identically whether invoked
+      # from this flake's per-system packages or from a downstream consumer's
+      # nixpkgs that applies this overlay.
+      #
+      # Keep this in sync with the released tag. GoReleaser's nix publisher
+      # generates a versioned flake on each release; this hand-written flake
+      # tracks the source tree for `nix run` / `nix build` from a checkout.
+      overlays.default = final: prev: {
+        dir2mcp = final.callPackage ./nix/package.nix {
+          src = self;
+          version = "0.0.0-dev";
+        };
+      };
+
+      # nix-darwin service module (launchd). `import` returns a function of
+      # `self`, applied here so the module can default `package` to this flake's
+      # build for the host system.
+      darwinModules.default = import ./nix/darwin-module.nix self;
+
+      # home-manager service module (launchd on darwin, systemd --user on linux).
+      homeManagerModules.default = import ./nix/home-manager-module.nix self;
+    };
 }

--- a/nix/darwin-module.nix
+++ b/nix/darwin-module.nix
@@ -1,0 +1,114 @@
+self:
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.dir2mcp;
+
+  # launchd has no native EnvironmentFile facility (unlike systemd). To keep
+  # secrets (MISTRAL_API_KEY, OPENAI_API_KEY, DIR2MCP_AUTH_TOKEN, ...) OUT of
+  # the world-readable nix store, we never bake them into the plist. Instead we
+  # generate a tiny wrapper script whose only nix-store-resident content is the
+  # *path* to the operator-managed environmentFile; the secrets themselves are
+  # sourced at runtime with `set -a` so they are exported into dir2mcp's
+  # environment. dir2mcp's built-in providers read these via ${VAR} expansion.
+  baseArgs = [
+    "up"
+    "--foreground"
+    "--dir"
+    cfg.rootDir
+  ]
+  ++ lib.optionals (cfg.stateDir != null) [ "--state-dir" cfg.stateDir ]
+  ++ lib.optionals (cfg.listen != null) [ "--listen" cfg.listen ]
+  ++ cfg.extraArgs;
+
+  # Quote each argument for safe embedding in the shell wrapper.
+  quotedArgs = lib.concatStringsSep " " (map lib.escapeShellArg baseArgs);
+
+  wrapper = pkgs.writeShellScript "dir2mcp-up" ''
+    set -eu
+    ${lib.optionalString (cfg.environmentFile != null) ''
+      set -a
+      . ${lib.escapeShellArg (toString cfg.environmentFile)}
+      set +a
+    ''}
+    exec ${cfg.package}/bin/dir2mcp ${quotedArgs}
+  '';
+in
+{
+  options.services.dir2mcp = {
+    enable = lib.mkEnableOption "the dir2mcp MCP knowledge server (launchd-supervised)";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = self.packages.${pkgs.system}.default;
+      defaultText = lib.literalExpression "dir2mcp.packages.\${system}.default";
+      description = "The dir2mcp package to run.";
+    };
+
+    rootDir = lib.mkOption {
+      type = lib.types.str;
+      example = "/Users/me/Documents/corpus";
+      description = "Absolute path to the corpus directory to serve (dir2mcp `--dir`). Required when the service is enabled.";
+    };
+
+    stateDir = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "/Users/me/Documents/corpus/.dir2mcp";
+      description = "State / cache directory (dir2mcp `--state-dir`). When null, dir2mcp derives `<rootDir>/.dir2mcp`.";
+    };
+
+    listen = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "127.0.0.1:8765";
+      description = "Listen address (dir2mcp `--listen`). When null, dir2mcp uses its built-in default.";
+    };
+
+    extraArgs = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [ "--public" "--auth" "auto" ];
+      description = "Additional arguments appended to `dir2mcp up --foreground`.";
+    };
+
+    environmentFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      example = "/Users/me/.config/dir2mcp/env";
+      description = ''
+        Path to a file containing `KEY=value` lines (e.g. MISTRAL_API_KEY,
+        OPENAI_API_KEY, DIR2MCP_AUTH_TOKEN). The file is read at service start
+        and its variables are exported into dir2mcp's environment. The file's
+        *path* is referenced from the launchd job; its contents are NOT copied
+        into the nix store, so secrets stay outside the world-readable store.
+        Manage this file outside Nix (e.g. with restrictive permissions).
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.rootDir != "";
+        message = "services.dir2mcp.rootDir must be set to the corpus directory when the service is enabled.";
+      }
+    ];
+
+    # nix-darwin's `launchd.user.agents` installs a per-user LaunchAgent
+    # (~/Library/LaunchAgents). This is the right scope for a personal corpus
+    # server that needs the operator's home directory and credentials; use
+    # `launchd.daemons` instead only for a system-wide (root) service.
+    launchd.user.agents.dir2mcp = {
+      serviceConfig = {
+        ProgramArguments = [ "${wrapper}" ];
+        WorkingDirectory = cfg.rootDir;
+        RunAtLoad = true;
+        KeepAlive = true;
+        ProcessType = "Background";
+        StandardOutPath = "/tmp/dir2mcp.out.log";
+        StandardErrorPath = "/tmp/dir2mcp.err.log";
+      };
+    };
+  };
+}

--- a/nix/home-manager-module.nix
+++ b/nix/home-manager-module.nix
@@ -1,0 +1,130 @@
+self:
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.dir2mcp;
+
+  baseArgs = [
+    "up"
+    "--foreground"
+    "--dir"
+    cfg.rootDir
+  ]
+  ++ lib.optionals (cfg.stateDir != null) [ "--state-dir" cfg.stateDir ]
+  ++ lib.optionals (cfg.listen != null) [ "--listen" cfg.listen ]
+  ++ cfg.extraArgs;
+
+  quotedArgs = lib.concatStringsSep " " (map lib.escapeShellArg baseArgs);
+
+  # On darwin, launchd has no native EnvironmentFile, so we source the file in
+  # a wrapper (same approach as the nix-darwin module). On linux, systemd's
+  # native `EnvironmentFile=` is used instead and this wrapper does not need to
+  # source anything — but using one wrapper for both keeps the ExecStart
+  # identical across platforms.
+  wrapper = pkgs.writeShellScript "dir2mcp-up" ''
+    set -eu
+    ${lib.optionalString (cfg.environmentFile != null && pkgs.stdenv.isDarwin) ''
+      set -a
+      . ${lib.escapeShellArg (toString cfg.environmentFile)}
+      set +a
+    ''}
+    exec ${cfg.package}/bin/dir2mcp ${quotedArgs}
+  '';
+in
+{
+  options.services.dir2mcp = {
+    enable = lib.mkEnableOption "the dir2mcp MCP knowledge server (home-manager service)";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = self.packages.${pkgs.system}.default;
+      defaultText = lib.literalExpression "dir2mcp.packages.\${system}.default";
+      description = "The dir2mcp package to run.";
+    };
+
+    rootDir = lib.mkOption {
+      type = lib.types.str;
+      example = "/home/me/corpus";
+      description = "Absolute path to the corpus directory to serve (dir2mcp `--dir`). Required when the service is enabled.";
+    };
+
+    stateDir = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "/home/me/corpus/.dir2mcp";
+      description = "State / cache directory (dir2mcp `--state-dir`). When null, dir2mcp derives `<rootDir>/.dir2mcp`.";
+    };
+
+    listen = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "127.0.0.1:8765";
+      description = "Listen address (dir2mcp `--listen`). When null, dir2mcp uses its built-in default.";
+    };
+
+    extraArgs = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [ "--public" "--auth" "auto" ];
+      description = "Additional arguments appended to `dir2mcp up --foreground`.";
+    };
+
+    environmentFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      example = "/home/me/.config/dir2mcp/env";
+      description = ''
+        Path to a file containing `KEY=value` lines (e.g. MISTRAL_API_KEY,
+        OPENAI_API_KEY, DIR2MCP_AUTH_TOKEN). On Linux it is wired to systemd's
+        native `EnvironmentFile=`; on darwin it is sourced at start by a
+        wrapper (launchd has no EnvironmentFile). Either way its contents are
+        NOT copied into the nix store. Manage this file outside Nix with
+        restrictive permissions.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.rootDir != "";
+        message = "services.dir2mcp.rootDir must be set to the corpus directory when the service is enabled.";
+      }
+    ];
+
+    # Darwin: home-manager installs a per-user LaunchAgent.
+    launchd.agents.dir2mcp = lib.mkIf pkgs.stdenv.isDarwin {
+      enable = true;
+      config = {
+        ProgramArguments = [ "${wrapper}" ];
+        WorkingDirectory = cfg.rootDir;
+        RunAtLoad = true;
+        KeepAlive = true;
+        ProcessType = "Background";
+        StandardOutPath = "/tmp/dir2mcp.out.log";
+        StandardErrorPath = "/tmp/dir2mcp.err.log";
+      };
+    };
+
+    # Linux: home-manager installs a systemd --user unit. systemd supports
+    # EnvironmentFile= natively, so secrets are loaded by systemd (not baked
+    # into the store).
+    systemd.user.services.dir2mcp = lib.mkIf pkgs.stdenv.isLinux {
+      Unit = {
+        Description = "dir2mcp MCP knowledge server";
+        After = [ "network.target" ];
+      };
+      Service = {
+        ExecStart = "${wrapper}";
+        WorkingDirectory = cfg.rootDir;
+        Restart = "on-failure";
+        RestartSec = 5;
+      } // lib.optionalAttrs (cfg.environmentFile != null) {
+        EnvironmentFile = toString cfg.environmentFile;
+      };
+      Install = {
+        WantedBy = [ "default.target" ];
+      };
+    };
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -9,12 +9,13 @@ buildGoModule {
   pname = "dir2mcp";
   inherit version src;
 
-  # NOTE (maintainer / CI): replace `lib.fakeHash` with the real vendor hash on
-  # the first build. Run `nix build`, then copy the `got:` hash from the
-  # mismatch error into this field. GoReleaser's nix publisher computes this
+  # Hash of the vendored Go module set (go.mod/go.sum). Recompute on any
+  # dependency change: set this to `lib.fakeHash`, run `nix build .#dir2mcp`,
+  # and copy the `got:` sha256 from the mismatch error back here. It is
+  # independent of the version/ldflags. GoReleaser's nix publisher computes this
   # automatically for the derivation it generates; this value only matters when
   # building this hand-written flake directly.
-  vendorHash = lib.fakeHash;
+  vendorHash = "sha256-Dl04jHfBLoG5yPykhUAX+jGS18PQoI+x2AwgIat11Oo=";
 
   subPackages = [ "cmd/dir2mcp" ];
 

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,44 @@
+{ lib, buildGoModule, src, version ? "0.0.0-dev" }:
+
+# callPackage-able derivation for the lean dir2mcp binary. The flake passes
+# `src = self` (the repo root) so both the per-system `packages.default` build
+# and the `overlays.default` consume the exact same source tree and build
+# logic — a single source of truth. Downstream callers (overlay consumers) get
+# `pkgs.dir2mcp` for free.
+buildGoModule {
+  pname = "dir2mcp";
+  inherit version src;
+
+  # NOTE (maintainer / CI): replace `lib.fakeHash` with the real vendor hash on
+  # the first build. Run `nix build`, then copy the `got:` hash from the
+  # mismatch error into this field. GoReleaser's nix publisher computes this
+  # automatically for the derivation it generates; this value only matters when
+  # building this hand-written flake directly.
+  vendorHash = lib.fakeHash;
+
+  subPackages = [ "cmd/dir2mcp" ];
+
+  # Inject the version into the symbol the runtime reads
+  # (internal/buildinfo.Version), mirroring .goreleaser.yaml and the Makefile.
+  # Lean binary only -- no docling runtime bundled.
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/dirstral/dir2mcp/internal/buildinfo.Version=${version}"
+  ];
+
+  # Lean build: CGO is disabled in the release matrix.
+  env.CGO_ENABLED = "0";
+
+  # Skip tests during the package build; integration suites need external
+  # credentials and the full check matrix runs in CI.
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Deploy any local directory as an MCP knowledge server with indexing, retrieval, and citations (lean binary; docling-full ships via container/Homebrew).";
+    homepage = "https://github.com/dirstral/dir2mcp";
+    license = licenses.mit;
+    mainProgram = "dir2mcp";
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
Adds Nix support: a package flake (`nix run`/`nix build`), an `overlays.default`, and `darwinModules.default` + `homeManagerModules.default` that run dir2mcp as a declarative launchd/systemd service (`dir2mcp up --foreground`). Also wires the GoReleaser `nix:` publisher (full setup: maintainer creates `dirstral/nix-user-repository` + `NIX_USER_REPOSITORY_GITHUB_TOKEN`).

Implements #272 (flake) and #292 (overlay + service modules). Distribution milestone.

## ⚠️ Required maintainer validation before merge (Nix could not be run in the authoring environment)
dir2mcp CI only runs `go build`/tests — it does NOT eval Nix. The flake/modules are structurally authored to standard conventions but MUST be validated by the maintainer:
1. **`nix flake check`** — evals the flake, overlay, and both modules (incl. the wrapper-script antiquotation).
2. **`nix build .#dir2mcp`** → replace `vendorHash = lib.fakeHash` in `nix/package.nix` with the `got:` hash from the mismatch error, rebuild to confirm, commit the real hash. **(Still pending — this gates merge.)**
3. **`darwin-rebuild switch`** (nix-darwin) and **`home-manager switch`** (macOS + Linux) with `services.dir2mcp.enable = true` to validate the service modules.
4. For the GoReleaser publisher: create `dirstral/nix-user-repository` + add the `NIX_USER_REPOSITORY_GITHUB_TOKEN` secret before the next release tag.

## Surface
- `packages.default`/`.dir2mcp`, `apps.default`, `devShells.default` (4 systems), `overlays.default`, `darwinModules.default`, `homeManagerModules.default`.
- `services.dir2mcp` options: `enable`, `package`, `rootDir`, `stateDir`, `listen`, `extraArgs`, `environmentFile` (secrets kept OUT of the nix store: launchd via a `set -a; . envfile` wrapper since launchd has no native EnvironmentFile; systemd via native `EnvironmentFile=`).
- Lean binary only; docling-full stays on container/Homebrew.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Nix flake support to build and run the lean `dir2mcp` binary on macOS and Linux.
  * Exposed flake outputs for package installs, app entrypoint, Go devShell, and downstream overlays.
  * Added Nix modules to run `dir2mcp` as a persistent service (launchd on macOS, systemd user on Linux).
* **Documentation**
  * Expanded the README with Nix usage, including declarative service setup and safe environment/secrets handling.
* **Chores**
  * Updated release configuration to publish Nix builds via GoReleaser.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->