### PR TITLE
feat(index): formalize pluggable model.Index interface (#247)

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -693,6 +693,24 @@ func (a *App) configureReranker(ret *retrieval.Service, cfg config.Config) {
 	ret.SetRerankEnabled(true)
 }
 
+// openHNSWForAsk constructs a persisted HNSW index, restores it from its v2
+// snapshot, and reconciles its recorded embed identity with the configured one
+// (issue #247). On any error it closes the index and returns the error.
+func openHNSWForAsk(ctx context.Context, path, identity string) (*index.HNSWIndex, error) {
+	ix := index.NewHNSWIndex(path)
+	if err := ix.Load(ctx, path); err != nil &&
+		!errors.Is(err, model.ErrNotImplemented) &&
+		!errors.Is(err, os.ErrNotExist) {
+		_ = ix.Close()
+		return nil, err
+	}
+	if err := index.EnsureIdentity(ctx, ix, identity); err != nil {
+		_ = ix.Close()
+		return nil, err
+	}
+	return ix, nil
+}
+
 // buildRetrieverForAsk constructs a retrieval service for the ask path:
 // it loads the text/code HNSW indexes, resolves the embed/chat clients,
 // wires reranking, and preloads embedded chunk metadata. It returns the
@@ -703,23 +721,16 @@ func (a *App) buildRetrieverForAsk(ctx context.Context, cfg config.Config, st mo
 		return a.newRetriever(cfg, st), nil, nil
 	}
 
-	textIndexPath := filepath.Join(cfg.StateDir, "vectors_text.hnsw")
-	codeIndexPath := filepath.Join(cfg.StateDir, "vectors_code.hnsw")
-
-	textIx := index.NewHNSWIndex(textIndexPath)
-	if err := textIx.Load(textIndexPath); err != nil &&
-		!errors.Is(err, model.ErrNotImplemented) &&
-		!errors.Is(err, os.ErrNotExist) {
-		_ = textIx.Close()
+	// v2 snapshot filenames + per-index embed-identity reconciliation (issue
+	// #247); see internal/index for the format rationale.
+	identity := cfg.Providers().EmbedIdentity()
+	textIx, err := openHNSWForAsk(ctx, filepath.Join(cfg.StateDir, index.TextIndexFileName), identity)
+	if err != nil {
 		return nil, nil, fmt.Errorf("load text index: %w", err)
 	}
-
-	codeIx := index.NewHNSWIndex(codeIndexPath)
-	if err := codeIx.Load(codeIndexPath); err != nil &&
-		!errors.Is(err, model.ErrNotImplemented) &&
-		!errors.Is(err, os.ErrNotExist) {
+	codeIx, err := openHNSWForAsk(ctx, filepath.Join(cfg.StateDir, index.CodeIndexFileName), identity)
+	if err != nil {
 		_ = textIx.Close()
-		_ = codeIx.Close()
 		return nil, nil, fmt.Errorf("load code index: %w", err)
 	}
 

--- a/internal/cli/reindex.go
+++ b/internal/cli/reindex.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/index"
 	"github.com/dirstral/dir2mcp/internal/model"
 )
 
@@ -94,10 +95,12 @@ func (a *App) prepareReindexStore(ctx context.Context, global globalOptions, cfg
 		_ = st.Close()
 		return nil, code
 	}
-	for _, indexPath := range []string{
-		filepath.Join(cfg.StateDir, "vectors_text.hnsw"),
-		filepath.Join(cfg.StateDir, "vectors_code.hnsw"),
-	} {
+	// Remove both the current v2 snapshot files and the legacy pre-#247
+	// bare-map files so a stale snapshot of either shape cannot survive a
+	// reindex.
+	staleNames := append([]string{index.TextIndexFileName, index.CodeIndexFileName}, index.LegacyIndexFileNames...)
+	for _, name := range staleNames {
+		indexPath := filepath.Join(cfg.StateDir, name)
 		if err := os.Remove(indexPath); err != nil && !errors.Is(err, os.ErrNotExist) {
 			_ = st.Close()
 			writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("remove stale index file %s: %v", indexPath, err))

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -59,8 +59,8 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 		return code
 	}
 	defer func() { _ = st.Close() }()
-	textIndexPath := filepath.Join(cfg.StateDir, "vectors_text.hnsw")
-	codeIndexPath := filepath.Join(cfg.StateDir, "vectors_code.hnsw")
+	textIndexPath := filepath.Join(cfg.StateDir, index.TextIndexFileName)
+	codeIndexPath := filepath.Join(cfg.StateDir, index.CodeIndexFileName)
 	defer func() { _ = textIx.Close() }()
 	defer func() { _ = codeIx.Close() }()
 
@@ -446,30 +446,50 @@ func (a *App) initStoreAndIndices(ctx context.Context, cfg *config.Config, jsonO
 		return nil, nil, nil, exitIndexLoadFailure
 	}
 
-	textIndexPath := filepath.Join(cfg.StateDir, "vectors_text.hnsw")
-	textIx := index.NewHNSWIndex(textIndexPath)
-	if err := textIx.Load(textIndexPath); err != nil &&
-		!errors.Is(err, model.ErrNotImplemented) &&
-		!errors.Is(err, os.ErrNotExist) {
-		writeCLIError(a.stderr, jsonOutput, exitIndexLoadFailure, fmt.Sprintf("load text index: %v", err))
+	// The persisted snapshot format is versioned (vectors_*.v2.hnsw, issue
+	// #247): the v2 file carries vectors + per-vector payloads + the embed
+	// identity, where the legacy file held a bare vector map. A missing v2 file
+	// (incl. an existing corpus that only has the legacy file) is treated as a
+	// fresh index and repopulated on the next reindex — we deliberately do not
+	// decode legacy files to avoid gob ambiguity between the two shapes.
+	identity := cfg.Providers().EmbedIdentity()
+	textIx, code := a.loadHNSWIndex(ctx, cfg, index.TextIndexFileName, "text", identity, jsonOutput)
+	if code != exitSuccess {
 		_ = st.Close()
-		_ = textIx.Close()
-		return nil, nil, nil, exitIndexLoadFailure
+		return nil, nil, nil, code
 	}
-
-	codeIndexPath := filepath.Join(cfg.StateDir, "vectors_code.hnsw")
-	codeIx := index.NewHNSWIndex(codeIndexPath)
-	if err := codeIx.Load(codeIndexPath); err != nil &&
-		!errors.Is(err, model.ErrNotImplemented) &&
-		!errors.Is(err, os.ErrNotExist) {
-		writeCLIError(a.stderr, jsonOutput, exitIndexLoadFailure, fmt.Sprintf("load code index: %v", err))
+	codeIx, code := a.loadHNSWIndex(ctx, cfg, index.CodeIndexFileName, "code", identity, jsonOutput)
+	if code != exitSuccess {
 		_ = st.Close()
 		_ = textIx.Close()
-		_ = codeIx.Close()
-		return nil, nil, nil, exitIndexLoadFailure
+		return nil, nil, nil, code
 	}
 
 	return st, textIx, codeIx, exitSuccess
+}
+
+// loadHNSWIndex constructs a persisted HNSW index, restores it from its v2
+// snapshot, and reconciles its recorded embed identity with the configured one
+// (issue #247): EnsureIdentity resets the index when the identity is empty
+// (fresh) or differs, so a vector space built under a different embed
+// provider/model/dimension is never silently reused. fileName is the basename
+// under cfg.StateDir; kind is used only for error messages.
+func (a *App) loadHNSWIndex(ctx context.Context, cfg *config.Config, fileName, kind, identity string, jsonOutput bool) (model.Index, int) {
+	path := filepath.Join(cfg.StateDir, fileName)
+	ix := index.NewHNSWIndex(path)
+	if err := ix.Load(ctx, path); err != nil &&
+		!errors.Is(err, model.ErrNotImplemented) &&
+		!errors.Is(err, os.ErrNotExist) {
+		writeCLIError(a.stderr, jsonOutput, exitIndexLoadFailure, fmt.Sprintf("load %s index: %v", kind, err))
+		_ = ix.Close()
+		return nil, exitIndexLoadFailure
+	}
+	if err := index.EnsureIdentity(ctx, ix, identity); err != nil {
+		writeCLIError(a.stderr, jsonOutput, exitIndexLoadFailure, fmt.Sprintf("reconcile %s index identity: %v", kind, err))
+		_ = ix.Close()
+		return nil, exitIndexLoadFailure
+	}
+	return ix, exitSuccess
 }
 
 // buildMCPServerOptions constructs the list of mcp.ServerOption values,

--- a/internal/index/embedding_worker.go
+++ b/internal/index/embedding_worker.go
@@ -297,12 +297,34 @@ func mediaMIMEType(relPath string) string {
 	}
 }
 
+// payloadFromTask projects a chunk task's metadata into the IndexPayload the
+// index stores alongside the vector (issue #247). The span's time bounds are
+// surfaced as StartMS/EndMS so a backend filtering on media windows has them
+// without re-reading the span; Language/Speaker are not carried on ChunkMetadata
+// today and are left empty for backends to populate when available.
+func payloadFromTask(t model.ChunkTask) model.IndexPayload {
+	meta := t.Metadata
+	return model.IndexPayload{
+		ChunkID:  meta.ChunkID,
+		RelPath:  meta.RelPath,
+		DocType:  meta.DocType,
+		RepType:  meta.RepType,
+		Modality: meta.Modality,
+		Title:    meta.Title,
+		StartMS:  meta.Span.StartMS,
+		EndMS:    meta.Span.EndMS,
+		Snippet:  meta.Snippet,
+		Span:     meta.Span,
+		MediaRef: meta.MediaRef,
+	}
+}
+
 // indexChunks adds each vector to the index and fires the OnIndexedChunk hook.
 // On an index error it marks the failed chunk and, if any chunks were already
 // added, marks those as embedded first.
 func (w *EmbeddingWorker) indexChunks(ctx context.Context, validTasks []model.ChunkTask, labels []uint64, vectors [][]float32) (int, error) {
 	for idx := range validTasks {
-		if addErr := w.Index.Add(validTasks[idx].Metadata.ChunkID, vectors[idx]); addErr != nil {
+		if addErr := w.Index.Upsert(ctx, vectors[idx], payloadFromTask(validTasks[idx])); addErr != nil {
 			if idx > 0 {
 				if err := w.Source.MarkEmbedded(ctx, labels[:idx]); err != nil {
 					w.logf("mark embedded warning: failed to mark %d chunks as embedded before index error: %v labels=%v", idx, err, labels[:idx])

--- a/internal/index/hnsw_index.go
+++ b/internal/index/hnsw_index.go
@@ -1,6 +1,7 @@
 package index
 
 import (
+	"context"
 	"encoding/gob"
 	"errors"
 	"log"
@@ -9,12 +10,38 @@ import (
 	"sort"
 	"sync"
 	"sync/atomic"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// Persisted snapshot basenames (issue #247). The ".v2" marker distinguishes
+// the payload-carrying gob shape (hnswSnapshot) from the legacy bare-map files
+// (vectors_{text,code}.hnsw); a missing v2 file is a fresh index, repopulated by
+// reindex, so legacy files are never decoded.
+const (
+	TextIndexFileName = "vectors_text.v2.hnsw"
+	CodeIndexFileName = "vectors_code.v2.hnsw"
+)
+
+// LegacyIndexFileNames are the pre-#247 bare-map snapshot basenames. reindex
+// removes them alongside the current files so a stale legacy snapshot cannot
+// linger after an upgrade.
+var LegacyIndexFileNames = []string{"vectors_text.hnsw", "vectors_code.hnsw"}
+
+// compile-time assertions that HNSWIndex satisfies the core Index contract and
+// the optional Persistable / FilteringIndex capabilities (issue #247).
+var (
+	_ model.Index          = (*HNSWIndex)(nil)
+	_ model.Persistable    = (*HNSWIndex)(nil)
+	_ model.FilteringIndex = (*HNSWIndex)(nil)
 )
 
 type HNSWIndex struct {
-	path    string
-	mu      sync.RWMutex
-	vectors map[uint64][]float32
+	path     string
+	mu       sync.RWMutex
+	vectors  map[uint64][]float32
+	payloads map[uint64]model.IndexPayload
+	identity string
 
 	// Logger is optional; if non-nil its Printf method will be used for
 	// informational messages. When nil the standard library's log package
@@ -40,116 +67,196 @@ type HNSWIndexMetrics struct {
 	DimensionMismatch atomic.Int64
 }
 
+// hnswSnapshot is the on-disk gob shape (issue #247). It is a distinct,
+// self-describing struct rather than a bare map[uint64][]float32 so the payload
+// metadata and embed identity persist alongside the vectors. To avoid gob
+// decode ambiguity with the legacy bare-map format, the persisted filename is
+// versioned (see NewHNSWIndex / vectors_*.v2.hnsw); a missing v2 file is treated
+// as a fresh index that reindex will repopulate.
+type hnswSnapshot struct {
+	Vectors  map[uint64][]float32
+	Payloads map[uint64]model.IndexPayload
+	Identity string
+}
+
 // NewHNSWIndex creates an empty in-memory HNSW index. The optional
 // path argument is used by Save/Load; if non-empty those methods will
 // persist to the given file.
 func NewHNSWIndex(path string) *HNSWIndex {
 	return &HNSWIndex{
-		path:    path,
-		vectors: make(map[uint64][]float32),
+		path:     path,
+		vectors:  make(map[uint64][]float32),
+		payloads: make(map[uint64]model.IndexPayload),
 	}
 }
 
-func (i *HNSWIndex) Add(label uint64, vector []float32) error {
+// Upsert stores (or replaces) the vector and its payload, keyed by
+// payload.ChunkID.
+func (i *HNSWIndex) Upsert(ctx context.Context, vector []float32, payload model.IndexPayload) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if len(vector) == 0 {
 		return errors.New("vector cannot be empty")
 	}
-
-	i.mu.Lock()
-	defer i.mu.Unlock()
+	if payload.ChunkID == 0 {
+		return errors.New("payload chunk_id cannot be zero")
+	}
 
 	copied := make([]float32, len(vector))
 	copy(copied, vector)
-	i.vectors[label] = copied
+
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.vectors[payload.ChunkID] = copied
+	i.payloads[payload.ChunkID] = payload
 	return nil
 }
 
-func (i *HNSWIndex) Search(vector []float32, k int) ([]uint64, []float32, error) {
+// Delete removes the vectors and payloads for the given chunk IDs. Unknown IDs
+// are ignored.
+func (i *HNSWIndex) Delete(ctx context.Context, chunkIDs []uint64) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if len(chunkIDs) == 0 {
+		return nil
+	}
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	for _, id := range chunkIDs {
+		delete(i.vectors, id)
+		delete(i.payloads, id)
+	}
+	return nil
+}
+
+// scoredCandidate pairs a chunk_id with its cosine score during search.
+type scoredCandidate struct {
+	chunkID uint64
+	score   float32
+	payload model.IndexPayload
+}
+
+// Search returns the k best matches for vector, filtered by filter. The filter
+// is applied inline (CanFilter is always true for the pure-Go HNSW), so callers
+// may push it down rather than overfetch-then-filter.
+func (i *HNSWIndex) Search(ctx context.Context, vector []float32, k int, filter model.Filter) ([]model.IndexHit, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if len(vector) == 0 {
-		return nil, nil, errors.New("query vector cannot be empty")
+		return nil, errors.New("query vector cannot be empty")
 	}
 	if k <= 0 {
-		return []uint64{}, []float32{}, nil
+		return []model.IndexHit{}, nil
 	}
 
-	type scored struct {
-		label uint64
-		score float32
+	candidates, mismatches := i.collectCandidates(vector, filter)
+	for _, m := range mismatches {
+		i.logf("dimension mismatch: chunk_id=%d candidate_len=%d query_len=%d", m.chunkID, m.candLen, m.queryLen)
 	}
 
-	// We only hold the read lock long enough to inspect each vector's
-	// length, bump the metric on mismatch, and copy candidates for later
-	// scoring.
-	// define local types for readability
-	type mismatch struct {
-		label    uint64
-		candLen  int
-		queryLen int
+	scored := make([]scoredCandidate, 0, len(candidates))
+	for _, c := range candidates {
+		c.score = cosineSimilarity(vector, c.vector)
+		scored = append(scored, scoredCandidate{chunkID: c.chunkID, score: c.score, payload: c.payload})
 	}
-	type candidate struct {
-		label  uint64
-		vector []float32
+
+	const eps = 1e-6
+	sort.Slice(scored, func(a, b int) bool {
+		diff := math.Abs(float64(scored[a].score) - float64(scored[b].score))
+		if diff <= eps {
+			return scored[a].chunkID < scored[b].chunkID
+		}
+		return scored[a].score > scored[b].score
+	})
+
+	if len(scored) > k {
+		scored = scored[:k]
 	}
+	hits := make([]model.IndexHit, len(scored))
+	for idx, s := range scored {
+		hits[idx] = model.IndexHit{ChunkID: s.chunkID, Score: s.score, Payload: s.payload}
+	}
+	return hits, nil
+}
+
+// searchCandidate carries a copied vector + payload for scoring outside the
+// lock.
+type searchCandidate struct {
+	chunkID uint64
+	vector  []float32
+	score   float32
+	payload model.IndexPayload
+}
+
+type dimMismatch struct {
+	chunkID  uint64
+	candLen  int
+	queryLen int
+}
+
+// collectCandidates snapshots, under the read lock, the vectors whose dimension
+// matches the query and whose payload satisfies the filter. Dimension
+// mismatches are returned for logging outside the lock.
+func (i *HNSWIndex) collectCandidates(vector []float32, filter model.Filter) ([]searchCandidate, []dimMismatch) {
 	var (
-		mismatches []mismatch
-		candidates []candidate
+		candidates []searchCandidate
+		mismatches []dimMismatch
 	)
+	applyFilter := !filter.IsZero()
 
 	i.mu.RLock()
-	// collect matching candidates while holding the lock
-	for label, cand := range i.vectors {
+	for id, cand := range i.vectors {
 		if len(cand) != len(vector) {
-			mismatches = append(mismatches, mismatch{label, len(cand), len(vector)})
+			mismatches = append(mismatches, dimMismatch{id, len(cand), len(vector)})
 			if i.Metrics != nil {
-				// atomic counter; update under lock to keep close to observation
 				i.Metrics.DimensionMismatch.Add(1)
 			}
 			continue
 		}
+		payload := i.payloads[id]
+		if applyFilter && !filter.Match(payload) {
+			continue
+		}
 		copyVec := make([]float32, len(cand))
 		copy(copyVec, cand)
-		candidates = append(candidates, candidate{label, copyVec})
+		candidates = append(candidates, searchCandidate{chunkID: id, vector: copyVec, payload: payload})
 	}
 	i.mu.RUnlock()
+	return candidates, mismatches
+}
 
-	// perform logging outside the lock to avoid blocking other routines
-	for _, m := range mismatches {
-		i.logf("dimension mismatch: label=%d candidate_len=%d query_len=%d", m.label, m.candLen, m.queryLen)
+// CanFilter reports whether the backend can evaluate the filter itself. The
+// pure-Go HNSW evaluates every predicate inline, so it always can.
+func (i *HNSWIndex) CanFilter(filter model.Filter) bool {
+	return true
+}
+
+// Identity returns the recorded corpus-lifetime embed identity, or "" when the
+// index is fresh.
+func (i *HNSWIndex) Identity(ctx context.Context) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
 	}
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return i.identity, nil
+}
 
-	// now that the lock is released, compute similarities
-	scoredItems := make([]scored, 0, len(candidates))
-	for _, c := range candidates {
-		scoredItems = append(scoredItems, scored{
-			label: c.label,
-			score: cosineSimilarity(vector, c.vector),
-		})
+// Reset clears all vectors/payloads and records identity as the new
+// corpus-lifetime embed identity.
+func (i *HNSWIndex) Reset(ctx context.Context, identity string) error {
+	if err := ctx.Err(); err != nil {
+		return err
 	}
-
-	// eps is the tolerance used when comparing two float32 similarity
-	// scores.  Values that differ by less than eps are treated as equal and
-	// the tie is broken by label to guarantee a stable, deterministic order.
-	const eps = 1e-6
-	sort.Slice(scoredItems, func(a, b int) bool {
-		diff := math.Abs(float64(scoredItems[a].score) - float64(scoredItems[b].score))
-		if diff <= eps {
-			return scoredItems[a].label < scoredItems[b].label
-		}
-		return scoredItems[a].score > scoredItems[b].score
-	})
-
-	if len(scoredItems) > k {
-		scoredItems = scoredItems[:k]
-	}
-
-	labels := make([]uint64, len(scoredItems))
-	scores := make([]float32, len(scoredItems))
-	for idx, item := range scoredItems {
-		labels[idx] = item.label
-		scores[idx] = item.score
-	}
-
-	return labels, scores, nil
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.vectors = make(map[uint64][]float32)
+	i.payloads = make(map[uint64]model.IndexPayload)
+	i.identity = identity
+	return nil
 }
 
 // logf is a small helper that routes messages to the configured logger or
@@ -162,7 +269,12 @@ func (i *HNSWIndex) logf(format string, args ...interface{}) {
 	log.Printf(format, args...)
 }
 
-func (i *HNSWIndex) Save(path string) error {
+// Save snapshots the index (vectors + payloads + identity) to path via gob,
+// using an atomic temp-file rename. See hnswSnapshot for the format rationale.
+func (i *HNSWIndex) Save(ctx context.Context, path string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if path == "" {
 		path = i.path
 	}
@@ -176,26 +288,13 @@ func (i *HNSWIndex) Save(path string) error {
 		return err
 	}
 
-	// take a snapshot of vectors while holding the read lock. doing this
-	// prevents Add/other writers from blocking on our long-running gob
-	// encoding and file operations. the snapshot is a deep copy of the map
-	// and each slice so that we don't race with callers who might mutate
-	// the original slices after we release the lock.
-	var snapshot map[uint64][]float32
-	i.mu.RLock()
-	snapshot = make(map[uint64][]float32, len(i.vectors))
-	for k, v := range i.vectors {
-		copied := make([]float32, len(v))
-		copy(copied, v)
-		snapshot[k] = copied
-	}
-	i.mu.RUnlock()
+	// Snapshot under the read lock so concurrent Upsert/Delete don't block on
+	// the gob encoding and file I/O, and so we deep-copy each slice rather than
+	// race with callers who might mutate the originals later.
+	snapshot := i.snapshot()
 
-	// perform encoding and all file I/O on the snapshot without holding
-	// any locks. preserve existing cleanup semantics.
 	enc := gob.NewEncoder(file)
-	err = enc.Encode(snapshot)
-	if err != nil {
+	if err := enc.Encode(snapshot); err != nil {
 		closeErr := file.Close()
 		_ = os.Remove(tmpPath)
 		return errors.Join(err, closeErr)
@@ -216,7 +315,30 @@ func (i *HNSWIndex) Save(path string) error {
 	return nil
 }
 
-func (i *HNSWIndex) Load(path string) error {
+// snapshot deep-copies the index state under the read lock for persistence.
+func (i *HNSWIndex) snapshot() hnswSnapshot {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	vectors := make(map[uint64][]float32, len(i.vectors))
+	for k, v := range i.vectors {
+		copied := make([]float32, len(v))
+		copy(copied, v)
+		vectors[k] = copied
+	}
+	payloads := make(map[uint64]model.IndexPayload, len(i.payloads))
+	for k, v := range i.payloads {
+		payloads[k] = v
+	}
+	return hnswSnapshot{Vectors: vectors, Payloads: payloads, Identity: i.identity}
+}
+
+// Load restores the index from a v2 snapshot file. A missing file is treated as
+// a fresh index (no error) — a legacy bare-map file under the old name is simply
+// not present at the v2 path, so the corpus is repopulated on the next reindex.
+func (i *HNSWIndex) Load(ctx context.Context, path string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if path == "" {
 		path = i.path
 	}
@@ -233,14 +355,22 @@ func (i *HNSWIndex) Load(path string) error {
 	}
 	defer func() { _ = file.Close() }()
 
-	loaded := make(map[uint64][]float32)
+	var snapshot hnswSnapshot
 	dec := gob.NewDecoder(file)
-	if err := dec.Decode(&loaded); err != nil {
+	if err := dec.Decode(&snapshot); err != nil {
 		return err
+	}
+	if snapshot.Vectors == nil {
+		snapshot.Vectors = make(map[uint64][]float32)
+	}
+	if snapshot.Payloads == nil {
+		snapshot.Payloads = make(map[uint64]model.IndexPayload)
 	}
 
 	i.mu.Lock()
-	i.vectors = loaded
+	i.vectors = snapshot.Vectors
+	i.payloads = snapshot.Payloads
+	i.identity = snapshot.Identity
 	i.mu.Unlock()
 	return nil
 }

--- a/internal/index/persistence.go
+++ b/internal/index/persistence.go
@@ -63,10 +63,7 @@ func (m *PersistenceManager) LoadAll(ctx context.Context) error {
 		if idx.Index == nil {
 			continue
 		}
-		// always check the context *before* doing any work. load
-		// implementations currently have a simple `Load(path string)`
-		// signature and are therefore unable to observe the context
-		// directly, so this pre-flight check gives callers a chance to
+		// always check the context *before* doing any work, so callers can
 		// bail out early if cancellation has already been requested.
 		select {
 		case <-ctx.Done():
@@ -74,7 +71,14 @@ func (m *PersistenceManager) LoadAll(ctx context.Context) error {
 		default:
 		}
 
-		if err := idx.Index.Load(idx.Path); err != nil {
+		// Persistence is an optional capability (issue #247): networked
+		// backends (Qdrant, pgvector) own their storage and don't implement
+		// Persistable, so they are silently skipped here.
+		p, ok := idx.Index.(model.Persistable)
+		if !ok {
+			continue
+		}
+		if err := p.Load(ctx, idx.Path); err != nil {
 			return err
 		}
 
@@ -103,11 +107,39 @@ func (m *PersistenceManager) SaveAll() error {
 		if idx.Index == nil {
 			continue
 		}
-		if err := idx.Index.Save(idx.Path); err != nil {
+		// Save is an optional capability (issue #247); skip backends that own
+		// their own persistence.
+		p, ok := idx.Index.(model.Persistable)
+		if !ok {
+			continue
+		}
+		if err := p.Save(context.Background(), idx.Path); err != nil {
 			combined = errors.Join(combined, err)
 		}
 	}
 	return combined
+}
+
+// EnsureIdentity reconciles an index's recorded corpus-lifetime embed identity
+// (SPEC 8.1.4) with the configured one, per index (issue #247). When the index
+// is fresh (empty recorded identity) or the recorded identity differs from the
+// configured one, the index is Reset to the configured identity — discarding any
+// vectors built under a different embed provider/model/dimension so vector
+// spaces are never silently mixed. A match is a no-op. This complements the
+// process-level config.VerifyEmbedIdentity check, which fails the startup before
+// any index work when a populated corpus's snapshot identity changed.
+func EnsureIdentity(ctx context.Context, idx model.Index, configuredIdentity string) error {
+	if idx == nil {
+		return nil
+	}
+	recorded, err := idx.Identity(ctx)
+	if err != nil {
+		return err
+	}
+	if recorded == configuredIdentity {
+		return nil
+	}
+	return idx.Reset(ctx, configuredIdentity)
 }
 
 func (m *PersistenceManager) Start(ctx context.Context) {

--- a/internal/model/interfaces.go
+++ b/internal/model/interfaces.go
@@ -24,12 +24,52 @@ type LexicalSearcher interface {
 	SearchBM25(ctx context.Context, query string, k int, indexKind string) ([]SearchHit, error)
 }
 
+// Index is the core vector-store contract every backend must satisfy (issue
+// #247). The in-memory HNSW is the conforming default; external/on-disk
+// backends (Qdrant #268, pgvector #269, on-disk #246) implement the same
+// interface. Optional capabilities (Persistable, FilteringIndex) are layered on
+// top and discovered via type assertion, mirroring the LexicalSearcher /
+// MultimodalEmbedder pattern.
+//
+// Implementations should be safe for concurrent use; retrieval calls Search
+// concurrently with the embedding worker's Upsert.
 type Index interface {
-	Add(label uint64, vector []float32) error
-	Search(vector []float32, k int) ([]uint64, []float32, error)
-	Save(path string) error
-	Load(path string) error
+	// Upsert stores (or replaces) the vector and its payload, keyed by
+	// payload.ChunkID. An empty vector is an error.
+	Upsert(ctx context.Context, vector []float32, payload IndexPayload) error
+	// Delete removes the vectors (and payloads) for the given chunk IDs.
+	// Unknown IDs are ignored.
+	Delete(ctx context.Context, chunkIDs []uint64) error
+	// Search returns the k best matches for vector, ordered best-first.
+	// A non-zero filter restricts the result set; backends that report
+	// CanFilter false simply ignore it (retrieval applies the filter itself).
+	Search(ctx context.Context, vector []float32, k int, filter Filter) ([]IndexHit, error)
+	// Identity returns the recorded corpus-lifetime embed identity (SPEC
+	// 8.1.4), or "" when the index is fresh.
+	Identity(ctx context.Context) (string, error)
+	// Reset clears all vectors/payloads and records identity as the new
+	// corpus-lifetime embed identity. Called when the embed identity changes.
+	Reset(ctx context.Context, identity string) error
 	Close() error
+}
+
+// Persistable is the optional capability for indexes that can durably
+// snapshot/restore themselves to a path (issue #247). The in-memory HNSW and
+// the future on-disk backend implement it; networked backends (Qdrant,
+// pgvector) own their persistence and do not. PersistenceManager type-asserts
+// against this interface and silently skips indexes that do not implement it.
+type Persistable interface {
+	Save(ctx context.Context, path string) error
+	Load(ctx context.Context, path string) error
+}
+
+// FilteringIndex is the optional capability for indexes that can evaluate a
+// Filter inside the backend (issue #247). When CanFilter reports true for a
+// given filter, retrieval pushes the filter down to Search and trusts the
+// backend-filtered results (skipping the overfetch-then-filter loop); otherwise
+// it falls back to fetching a wider candidate pool and filtering in Go.
+type FilteringIndex interface {
+	CanFilter(filter Filter) bool
 }
 
 type Retriever interface {

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -3,6 +3,8 @@ package model
 import (
 	"encoding/json"
 	"fmt"
+	"path"
+	"strings"
 )
 
 type Document struct {
@@ -95,6 +97,111 @@ type BBox struct {
 	R           float64 `json:"r"`
 	B           float64 `json:"b"`
 	CoordOrigin string  `json:"coord_origin"`
+}
+
+// IndexPayload is the per-vector metadata an Index stores alongside the dense
+// vector (issue #247). It carries everything retrieval needs to materialise a
+// SearchHit and everything a Filter needs to predicate on, so an external or
+// on-disk backend can serve filtered search without dir2mcp re-fetching chunk
+// metadata from SQLite. Backends that cannot persist the full payload may store
+// a subset; retrieval falls back to its in-memory chunk metadata when a field
+// is empty.
+type IndexPayload struct {
+	ChunkID  uint64
+	RelPath  string
+	DocType  string
+	RepType  string
+	Modality string
+	Title    string
+	StartMS  int
+	EndMS    int
+	Language string
+	Speaker  string
+	Snippet  string
+	Span     Span
+	MediaRef string
+}
+
+// ToSearchHit materialises a SearchHit from the payload. Score is left zero;
+// the caller sets it from the IndexHit.
+func (p IndexPayload) ToSearchHit() SearchHit {
+	return SearchHit{
+		ChunkID:  p.ChunkID,
+		RelPath:  p.RelPath,
+		Title:    p.Title,
+		DocType:  p.DocType,
+		RepType:  p.RepType,
+		Snippet:  p.Snippet,
+		Span:     p.Span,
+		Modality: p.Modality,
+		MediaRef: p.MediaRef,
+	}
+}
+
+// IndexHit is one scored result from Index.Search. Score is the cosine
+// similarity (higher is better). Payload carries the stored metadata for the
+// matched vector.
+type IndexHit struct {
+	ChunkID uint64
+	Score   float32
+	Payload IndexPayload
+}
+
+// Filter expresses the predicates retrieval applies to candidate vectors. It is
+// the in-process, backend-agnostic shape of dir2mcp's overfetch-then-filter
+// logic (issue #247): a FilteringIndex that reports CanFilter true pushes these
+// predicates down to the backend; otherwise retrieval evaluates Match in Go.
+//
+//   - PathPrefix: keep only rel_paths with this prefix.
+//   - PathGlob:   keep only rel_paths matching this path.Match glob.
+//   - DocTypes:   keep only these doc types (case-insensitive).
+//   - ExcludeOrphans: drop chunks with an empty rel_path (orphaned/evicted).
+type Filter struct {
+	PathPrefix     string
+	PathGlob       string
+	DocTypes       []string
+	ExcludeOrphans bool
+}
+
+// IsZero reports whether the filter has no active predicate.
+func (f Filter) IsZero() bool {
+	return f.PathPrefix == "" &&
+		f.PathGlob == "" &&
+		len(f.DocTypes) == 0 &&
+		!f.ExcludeOrphans
+}
+
+// Match reports whether the payload satisfies every active predicate. It
+// reproduces the semantics of retrieval's matchFilters: an empty rel_path is
+// rejected when ExcludeOrphans is set; PathPrefix is a string prefix; PathGlob
+// uses path.Match; DocTypes is a case-insensitive set membership.
+func (f Filter) Match(p IndexPayload) bool {
+	relPath := p.RelPath
+	if f.ExcludeOrphans && strings.TrimSpace(relPath) == "" {
+		return false
+	}
+	if f.PathPrefix != "" && !strings.HasPrefix(relPath, f.PathPrefix) {
+		return false
+	}
+	if f.PathGlob != "" {
+		matched, err := path.Match(f.PathGlob, relPath)
+		if err != nil || !matched {
+			return false
+		}
+	}
+	if len(f.DocTypes) > 0 {
+		match := false
+		for _, dt := range f.DocTypes {
+			if strings.EqualFold(strings.TrimSpace(dt), strings.TrimSpace(p.DocType)) {
+				match = true
+				break
+			}
+		}
+		if !match {
+			return false
+		}
+	}
+	return true
 }
 
 type SearchQuery struct {

--- a/internal/retrieval/large_corpus_test.go
+++ b/internal/retrieval/large_corpus_test.go
@@ -76,14 +76,21 @@ func buildLargeCorpusService(tb testing.TB, total int) *Service {
 	textIdx := index.NewHNSWIndex("")
 	codeIdx := index.NewHNSWIndex("")
 
+	ctx := context.Background()
 	for i := 1; i <= total; i++ {
 		label := uint64(i)
 		vec := []float32{1, 0}
 		if i%2 == 0 {
 			vec = []float32{0.95, 0.05}
 		}
-		if err := textIdx.Add(label, vec); err != nil {
-			tb.Fatalf("textIdx.Add(%d) failed: %v", i, err)
+		textPayload := model.IndexPayload{
+			ChunkID: label,
+			RelPath: fmt.Sprintf("docs/%03d.md", i),
+			DocType: "md",
+			Snippet: fmt.Sprintf("snippet-%d", i),
+		}
+		if err := textIdx.Upsert(ctx, vec, textPayload); err != nil {
+			tb.Fatalf("textIdx.Upsert(%d) failed: %v", i, err)
 		}
 		if i%3 == 0 {
 			// we intentionally reuse the same `label` value here that was already
@@ -93,8 +100,8 @@ func buildLargeCorpusService(tb testing.TB, total int) *Service {
 			// hits coming from textIdx and codeIdx. documenting the design choice
 			// helps future readers understand why some labels appear in both
 			// indexes and ensures coverage of the deduplication logic.
-			if err := codeIdx.Add(label, []float32{1, 0}); err != nil {
-				tb.Fatalf("codeIdx.Add(%d) failed: %v", i, err)
+			if err := codeIdx.Upsert(ctx, []float32{1, 0}, textPayload); err != nil {
+				tb.Fatalf("codeIdx.Upsert(%d) failed: %v", i, err)
 			}
 		}
 	}

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -1377,11 +1377,80 @@ func truncateSearchHits(hits []model.SearchHit, k int) []model.SearchHit {
 	return hits[:k]
 }
 
-// collectVectorCandidates runs the dense-vector search loop with overfetch and
-// filter-aware re-fetch behavior. Extracted from searchSingleIndex so the
-// outer function stays under the cyclomatic-complexity budget after hybrid
-// fusion was layered on top.
+// filterFromQuery projects the retrieval-level SearchQuery predicates into the
+// backend-agnostic model.Filter (issue #247). ExcludeOrphans is intentionally
+// NOT pushed down: orphan/eviction state lives in the retrieval service's
+// in-memory chunk metadata, not in the backend payload, so it is enforced by
+// the post-materialization matchFilters re-check instead (a backend payload
+// always carries a rel_path).
+func filterFromQuery(q model.SearchQuery) model.Filter {
+	return model.Filter{
+		PathPrefix: q.PathPrefix,
+		PathGlob:   q.FileGlob,
+		DocTypes:   q.DocTypes,
+	}
+}
+
+// collectVectorCandidates gathers up to k filtered dense-vector candidates. When
+// the index can evaluate the filter itself (FilteringIndex + CanFilter) the
+// filter is pushed down and the backend-filtered results are trusted; otherwise
+// it falls back to the legacy overfetch-then-filter loop. Extracted from
+// searchSingleIndex so the outer function stays under the cyclomatic-complexity
+// budget after hybrid fusion was layered on top.
 func (s *Service) collectVectorCandidates(
+	ctx context.Context,
+	vector []float32,
+	idx model.Index,
+	indexName string,
+	filters model.SearchQuery,
+	k int,
+) ([]model.SearchHit, error) {
+	filter := filterFromQuery(filters)
+	if fi, ok := idx.(model.FilteringIndex); ok && fi.CanFilter(filter) {
+		return s.collectPushedDownCandidates(ctx, vector, idx, indexName, filters, filter, k)
+	}
+	return s.collectOverfetchedCandidates(ctx, vector, idx, indexName, filters, k)
+}
+
+// collectPushedDownCandidates asks the backend for k filtered hits in a single
+// Search and materialises SearchHits from the returned payloads. The full
+// matchFilters re-check is still applied after materialisation so the retrieval
+// service's in-memory state (orphan/eviction, see searchHitFromIndexHit) is
+// honoured even when the backend already pre-filtered on path/doctype.
+func (s *Service) collectPushedDownCandidates(
+	ctx context.Context,
+	vector []float32,
+	idx model.Index,
+	indexName string,
+	filters model.SearchQuery,
+	filter model.Filter,
+	k int,
+) ([]model.SearchHit, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	hits, err := idx.Search(ctx, vector, k, filter)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]model.SearchHit, 0, len(hits))
+	for _, h := range hits {
+		hit := s.searchHitFromIndexHit(indexName, h)
+		if !matchFilters(hit, filters) {
+			continue
+		}
+		out = append(out, hit)
+		if len(out) >= k {
+			break
+		}
+	}
+	return out, nil
+}
+
+// collectOverfetchedCandidates runs the legacy overfetch loop for backends that
+// cannot filter themselves: it requests a widening unfiltered candidate pool and
+// applies matchFilters in Go.
+func (s *Service) collectOverfetchedCandidates(
 	ctx context.Context,
 	vector []float32,
 	idx model.Index,
@@ -1395,22 +1464,22 @@ func (s *Service) collectVectorCandidates(
 	s.metaMu.RLock()
 	overfetchMultiplier := s.overfetchMultiplier
 	s.metaMu.RUnlock()
-	cap := k
-	if cap > 1024 {
-		cap = 1024
+	capHint := k
+	if capHint > 1024 {
+		capHint = 1024
 	}
-	filtered := make([]model.SearchHit, 0, cap)
-	seen := make(map[uint64]struct{}, cap)
+	filtered := make([]model.SearchHit, 0, capHint)
+	seen := make(map[uint64]struct{}, capHint)
 	for n := initialSearchFanout(k, overfetchMultiplier); len(filtered) < k; {
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		labels, scores, err := idx.Search(vector, n)
+		hits, err := idx.Search(ctx, vector, n, model.Filter{})
 		if err != nil {
 			return nil, err
 		}
-		s.collectFilteredHits(labels, scores, indexName, filters, k, seen, &filtered)
-		if searchExhausted(len(filtered), k, len(labels), n) {
+		s.collectFilteredHits(hits, indexName, filters, k, seen, &filtered)
+		if searchExhausted(len(filtered), k, len(hits), n) {
 			break
 		}
 		n = nextSearchFanout(n)
@@ -1418,26 +1487,64 @@ func (s *Service) collectVectorCandidates(
 	return filtered, nil
 }
 
-// collectFilteredHits walks one batch of (label, score) pairs returned by the
-// vector index and appends matching hits to dst until k results are gathered.
-// Hits already represented in `seen` are skipped to avoid duplicates across
-// fanout iterations.
+// searchHitFromIndexHit materialises a SearchHit from a backend IndexHit. It
+// prefers the in-memory chunk metadata (searchHitForLabel) when present so
+// existing fakes and the HNSW path keep their established behavior, and falls
+// back to the backend-supplied payload for fields the in-memory metadata lacks
+// (a non-default backend may be the only source of the rel_path/doc_type).
+func (s *Service) searchHitFromIndexHit(indexName string, h model.IndexHit) model.SearchHit {
+	hit := s.searchHitForLabel(indexName, h.ChunkID)
+	// The in-memory chunk metadata is authoritative for the default HNSW path:
+	// a missing entry there is the eviction/orphan signal (EvictDocuments
+	// deletes the entry), so we must NOT resurrect such a chunk from the backend
+	// payload. Only fall back to the payload when the service holds no in-memory
+	// metadata at all — i.e. a non-default backend is the sole source of truth.
+	if strings.TrimSpace(hit.RelPath) == "" && !s.hasInMemoryMetadata() {
+		if payloadHit := h.Payload.ToSearchHit(); strings.TrimSpace(payloadHit.RelPath) != "" {
+			hit = payloadHit
+			hit.ChunkID = h.ChunkID
+		}
+	}
+	hit.Score = float64(h.Score)
+	return hit
+}
+
+// hasInMemoryMetadata reports whether any chunk metadata has been registered in
+// the service (via SetChunkMetadata*). When true the in-memory maps are the
+// authoritative source for materialising hits; when false (e.g. an external
+// backend that never populated them) hits are materialised from the backend
+// payload instead.
+func (s *Service) hasInMemoryMetadata() bool {
+	s.metaMu.RLock()
+	defer s.metaMu.RUnlock()
+	if len(s.chunkByLabel) > 0 {
+		return true
+	}
+	for _, byIndex := range s.chunkByIndex {
+		if len(byIndex) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// collectFilteredHits walks one batch of index hits and appends matching hits to
+// dst until k results are gathered. Hits already represented in `seen` are
+// skipped to avoid duplicates across fanout iterations.
 func (s *Service) collectFilteredHits(
-	labels []uint64,
-	scores []float32,
+	hits []model.IndexHit,
 	indexName string,
 	filters model.SearchQuery,
 	k int,
 	seen map[uint64]struct{},
 	dst *[]model.SearchHit,
 ) {
-	for i, label := range labels {
-		if _, ok := seen[label]; ok {
+	for _, h := range hits {
+		if _, ok := seen[h.ChunkID]; ok {
 			continue
 		}
-		seen[label] = struct{}{}
-		hit := s.searchHitForLabel(indexName, label)
-		hit.Score = float64(scores[i])
+		seen[h.ChunkID] = struct{}{}
+		hit := s.searchHitFromIndexHit(indexName, h)
 		if !matchFilters(hit, filters) {
 			continue
 		}

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -1393,10 +1393,12 @@ func filterFromQuery(q model.SearchQuery) model.Filter {
 
 // collectVectorCandidates gathers up to k filtered dense-vector candidates. When
 // the index can evaluate the filter itself (FilteringIndex + CanFilter) the
-// filter is pushed down and the backend-filtered results are trusted; otherwise
-// it falls back to the legacy overfetch-then-filter loop. Extracted from
-// searchSingleIndex so the outer function stays under the cyclomatic-complexity
-// budget after hybrid fusion was layered on top.
+// filter is pushed down to narrow the backend's candidate pool; otherwise an
+// empty filter is passed and the predicates are evaluated in Go. In both cases
+// the same widening overfetch loop runs and matchFilters is re-applied so the
+// in-memory orphan/eviction state is honoured. Extracted from searchSingleIndex
+// so the outer function stays under the cyclomatic-complexity budget after
+// hybrid fusion was layered on top.
 func (s *Service) collectVectorCandidates(
 	ctx context.Context,
 	vector []float32,
@@ -1406,56 +1408,33 @@ func (s *Service) collectVectorCandidates(
 	k int,
 ) ([]model.SearchHit, error) {
 	filter := filterFromQuery(filters)
+	// Only push the filter down when the backend can evaluate it itself;
+	// otherwise pass an empty filter so payload-blind backends behave as
+	// before. Either way we run the same widening overfetch loop and re-apply
+	// matchFilters in Go: pushing the filter down narrows the candidate pool
+	// the backend returns, but the in-memory orphan/eviction state (which the
+	// backend payload does not know about, see searchHitFromIndexHit) is still
+	// enforced by the post-materialization re-check. Without the widening loop a
+	// pushed-down search would under-return whenever the re-check drops an
+	// evicted-but-still-indexed chunk.
+	backendFilter := model.Filter{}
 	if fi, ok := idx.(model.FilteringIndex); ok && fi.CanFilter(filter) {
-		return s.collectPushedDownCandidates(ctx, vector, idx, indexName, filters, filter, k)
+		backendFilter = filter
 	}
-	return s.collectOverfetchedCandidates(ctx, vector, idx, indexName, filters, k)
+	return s.collectFilteredCandidates(ctx, vector, idx, indexName, filters, backendFilter, k)
 }
 
-// collectPushedDownCandidates asks the backend for k filtered hits in a single
-// Search and materialises SearchHits from the returned payloads. The full
-// matchFilters re-check is still applied after materialisation so the retrieval
-// service's in-memory state (orphan/eviction, see searchHitFromIndexHit) is
-// honoured even when the backend already pre-filtered on path/doctype.
-func (s *Service) collectPushedDownCandidates(
+// collectFilteredCandidates runs the widening overfetch loop: it requests a
+// widening candidate pool from the backend (with backendFilter pushed down when
+// the backend supports it, or an empty filter otherwise) and applies
+// matchFilters in Go until k results are gathered or the backend is exhausted.
+func (s *Service) collectFilteredCandidates(
 	ctx context.Context,
 	vector []float32,
 	idx model.Index,
 	indexName string,
 	filters model.SearchQuery,
-	filter model.Filter,
-	k int,
-) ([]model.SearchHit, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-	hits, err := idx.Search(ctx, vector, k, filter)
-	if err != nil {
-		return nil, err
-	}
-	out := make([]model.SearchHit, 0, len(hits))
-	for _, h := range hits {
-		hit := s.searchHitFromIndexHit(indexName, h)
-		if !matchFilters(hit, filters) {
-			continue
-		}
-		out = append(out, hit)
-		if len(out) >= k {
-			break
-		}
-	}
-	return out, nil
-}
-
-// collectOverfetchedCandidates runs the legacy overfetch loop for backends that
-// cannot filter themselves: it requests a widening unfiltered candidate pool and
-// applies matchFilters in Go.
-func (s *Service) collectOverfetchedCandidates(
-	ctx context.Context,
-	vector []float32,
-	idx model.Index,
-	indexName string,
-	filters model.SearchQuery,
+	backendFilter model.Filter,
 	k int,
 ) ([]model.SearchHit, error) {
 	// Read overfetch under lock to avoid races with SetOverfetchMultiplier.
@@ -1474,7 +1453,7 @@ func (s *Service) collectOverfetchedCandidates(
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		hits, err := idx.Search(ctx, vector, n, model.Filter{})
+		hits, err := idx.Search(ctx, vector, n, backendFilter)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/retrieval/service_test.go
+++ b/internal/retrieval/service_test.go
@@ -37,14 +37,38 @@ type fakeRetrievalIndex struct {
 	lastK int
 }
 
-func (f *fakeRetrievalIndex) Add(label uint64, vector []float32) error { return nil }
-func (f *fakeRetrievalIndex) Search(vector []float32, k int) ([]uint64, []float32, error) {
-	f.lastK = k
-	return []uint64{}, []float32{}, nil
+func (f *fakeRetrievalIndex) Upsert(_ context.Context, _ []float32, _ model.IndexPayload) error {
+	return nil
 }
-func (f *fakeRetrievalIndex) Save(path string) error { return nil }
-func (f *fakeRetrievalIndex) Load(path string) error { return nil }
-func (f *fakeRetrievalIndex) Close() error           { return nil }
+func (f *fakeRetrievalIndex) Delete(_ context.Context, _ []uint64) error { return nil }
+func (f *fakeRetrievalIndex) Search(_ context.Context, _ []float32, k int, _ model.Filter) ([]model.IndexHit, error) {
+	f.lastK = k
+	return []model.IndexHit{}, nil
+}
+func (f *fakeRetrievalIndex) Identity(context.Context) (string, error) { return "", nil }
+func (f *fakeRetrievalIndex) Reset(context.Context, string) error      { return nil }
+func (f *fakeRetrievalIndex) Close() error                             { return nil }
+
+// addVec upserts a vector keyed by id with an empty payload. Used by tests that
+// drive filtering through the service's in-memory chunk metadata (SetChunkMetadata)
+// rather than the index payload, and search without push-down predicates.
+func addVec(t *testing.T, idx *index.HNSWIndex, id uint64, vec []float32) {
+	t.Helper()
+	if err := idx.Upsert(context.Background(), vec, model.IndexPayload{ChunkID: id}); err != nil {
+		t.Fatalf("Upsert(%d) failed: %v", id, err)
+	}
+}
+
+// addVecP upserts a vector keyed by id with a rel_path/doc_type payload, so a
+// FilteringIndex (HNSW) can evaluate path/doctype predicates pushed down from
+// the query.
+func addVecP(t *testing.T, idx *index.HNSWIndex, id uint64, vec []float32, relPath, docType string) {
+	t.Helper()
+	payload := model.IndexPayload{ChunkID: id, RelPath: relPath, DocType: docType}
+	if err := idx.Upsert(context.Background(), vec, payload); err != nil {
+		t.Fatalf("Upsert(%d) failed: %v", id, err)
+	}
+}
 
 func (e *fakeRetrievalEmbedder) Embed(_ context.Context, modelName string, _ model.EmbedRole, texts []string) ([][]float32, error) {
 	// return one embedding per input text, matching the real embedder behaviour
@@ -69,9 +93,7 @@ func TestAsk_GeneratorErrorLogged(t *testing.T) {
 	buf := &bytes.Buffer{}
 
 	idx := index.NewHNSWIndex("")
-	if err := idx.Add(1, []float32{1, 0}); err != nil {
-		t.Fatalf("idx.Add failed: %v", err)
-	}
+	addVec(t, idx, 1, []float32{1, 0})
 
 	longQ := strings.Repeat("x", 100)
 	svc := NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{"mistral-embed": {1, 0}}}, &fakeGenerator{out: "unused", err: errors.New("oh no")})
@@ -96,9 +118,7 @@ func TestAsk_GeneratorErrorLogged(t *testing.T) {
 
 func TestAsk_IndexingCompleteFlag(t *testing.T) {
 	idx := index.NewHNSWIndex("")
-	if err := idx.Add(1, []float32{1, 0}); err != nil {
-		t.Fatalf("idx.Add failed: %v", err)
-	}
+	addVec(t, idx, 1, []float32{1, 0})
 	// provider returns false to simulate ongoing indexing
 	svc := NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{"mistral-embed": {1, 0}}}, nil)
 	svc.SetIndexingCompleteProvider(func() bool { return false })
@@ -115,9 +135,7 @@ func TestAsk_IndexingCompleteFlag(t *testing.T) {
 
 func TestAsk_IndexingCompleteDefaultTrue(t *testing.T) {
 	idx := index.NewHNSWIndex("")
-	if err := idx.Add(1, []float32{1, 0}); err != nil {
-		t.Fatalf("idx.Add failed: %v", err)
-	}
+	addVec(t, idx, 1, []float32{1, 0})
 	svc := NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{"mistral-embed": {1, 0}}}, nil)
 	// no provider set, should default to true
 	svc.SetChunkMetadata(1, model.SearchHit{RelPath: "doc.txt", DocType: "md", Snippet: "hi"})
@@ -136,9 +154,7 @@ func TestAsk_IndexingCompleteDefaultTrue(t *testing.T) {
 // prevents regressions when the interface changes.
 func TestIndexingCompleteAccessorDirect(t *testing.T) {
 	idx := index.NewHNSWIndex("")
-	if err := idx.Add(1, []float32{1, 0}); err != nil {
-		t.Fatalf("idx.Add failed: %v", err)
-	}
+	addVec(t, idx, 1, []float32{1, 0})
 	svc := NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{"mistral-embed": {1, 0}}}, nil)
 
 	// default provider nil -> should report true
@@ -154,9 +170,7 @@ func TestIndexingCompleteAccessorDirect(t *testing.T) {
 
 func TestIndexingComplete_CanceledContext(t *testing.T) {
 	idx := index.NewHNSWIndex("")
-	if err := idx.Add(1, []float32{1, 0}); err != nil {
-		t.Fatalf("idx.Add failed: %v", err)
-	}
+	addVec(t, idx, 1, []float32{1, 0})
 	svc := NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{"mistral-embed": {1, 0}}}, nil)
 	// provider returns true but should not be invoked
 	svc.SetIndexingCompleteProvider(func() bool { t.Fatal("provider should not be called"); return true })
@@ -174,15 +188,9 @@ func TestIndexingComplete_CanceledContext(t *testing.T) {
 
 func TestSearch_ReturnsRankedHitsWithFilters(t *testing.T) {
 	idx := index.NewHNSWIndex("")
-	if err := idx.Add(1, []float32{1, 0}); err != nil {
-		t.Fatalf("idx.Add failed: %v", err)
-	}
-	if err := idx.Add(2, []float32{0.9, 0.1}); err != nil {
-		t.Fatalf("idx.Add failed: %v", err)
-	}
-	if err := idx.Add(3, []float32{0, 1}); err != nil {
-		t.Fatalf("idx.Add failed: %v", err)
-	}
+	addVecP(t, idx, 1, []float32{1, 0}, "docs/a.md", "md")
+	addVecP(t, idx, 2, []float32{0.9, 0.1}, "src/main.go", "code")
+	addVecP(t, idx, 3, []float32{0, 1}, "docs/b.md", "md")
 
 	svc := NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
 		"mistral-embed":   {1, 0},
@@ -212,12 +220,8 @@ func TestSearch_ReturnsRankedHitsWithFilters(t *testing.T) {
 
 func TestSearch_FileGlobFilter(t *testing.T) {
 	idx := index.NewHNSWIndex("")
-	if err := idx.Add(10, []float32{1, 0}); err != nil {
-		t.Fatalf("idx.Add failed: %v", err)
-	}
-	if err := idx.Add(20, []float32{0.8, 0.2}); err != nil {
-		t.Fatalf("idx.Add failed: %v", err)
-	}
+	addVecP(t, idx, 10, []float32{1, 0}, "src/a.go", "code")
+	addVecP(t, idx, 20, []float32{0.8, 0.2}, "docs/a.md", "md")
 
 	svc := NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
 		"mistral-embed":   {1, 0},
@@ -296,18 +300,10 @@ func TestSearch_OverflowProtection(t *testing.T) {
 func TestSearch_BothMode_DedupesAndNormalizes(t *testing.T) {
 	textIdx := index.NewHNSWIndex("")
 	codeIdx := index.NewHNSWIndex("")
-	if err := textIdx.Add(1, []float32{1, 0}); err != nil {
-		t.Fatalf("textIdx.Add failed: %v", err)
-	}
-	if err := textIdx.Add(2, []float32{0.8, 0.2}); err != nil {
-		t.Fatalf("textIdx.Add failed: %v", err)
-	}
-	if err := codeIdx.Add(2, []float32{0.9, 0.1}); err != nil { // duplicate label across indexes
-		t.Fatalf("codeIdx.Add failed: %v", err)
-	}
-	if err := codeIdx.Add(3, []float32{1, 0}); err != nil {
-		t.Fatalf("codeIdx.Add failed: %v", err)
-	}
+	addVec(t, textIdx, 1, []float32{1, 0})
+	addVec(t, textIdx, 2, []float32{0.8, 0.2})
+	addVec(t, codeIdx, 2, []float32{0.9, 0.1}) // duplicate label across indexes
+	addVec(t, codeIdx, 3, []float32{1, 0})
 
 	svc := NewService(nil, textIdx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
 		"mistral-embed":   {1, 0},
@@ -549,9 +545,7 @@ func TestLooksLikeCodeQuery(t *testing.T) {
 
 func TestAsk_FallbackAndCitations(t *testing.T) {
 	idx := index.NewHNSWIndex("")
-	if err := idx.Add(1, []float32{1, 0}); err != nil {
-		t.Fatalf("idx.Add failed: %v", err)
-	}
+	addVec(t, idx, 1, []float32{1, 0})
 	svc := NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
 		"mistral-embed": {1, 0},
 	}}, nil)
@@ -584,9 +578,7 @@ func TestAsk_FallbackAndCitations(t *testing.T) {
 
 func TestAsk_UsesGeneratorWhenAvailable(t *testing.T) {
 	idx := index.NewHNSWIndex("")
-	if err := idx.Add(1, []float32{1, 0}); err != nil {
-		t.Fatalf("idx.Add failed: %v", err)
-	}
+	addVec(t, idx, 1, []float32{1, 0})
 	svc := NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
 		"mistral-embed": {1, 0},
 	}}, &fakeGenerator{out: "Generated answer with [docs/a.md]"})
@@ -607,12 +599,8 @@ func TestAsk_UsesGeneratorWhenAvailable(t *testing.T) {
 
 func TestAsk_AppendsMissingAttributions(t *testing.T) {
 	idx := index.NewHNSWIndex("")
-	if err := idx.Add(1, []float32{1, 0}); err != nil {
-		t.Fatalf("idx.Add failed: %v", err)
-	}
-	if err := idx.Add(2, []float32{0.9, 0.1}); err != nil {
-		t.Fatalf("idx.Add failed: %v", err)
-	}
+	addVec(t, idx, 1, []float32{1, 0})
+	addVec(t, idx, 2, []float32{0.9, 0.1})
 	svc := NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
 		"mistral-embed": {1, 0},
 	}}, &fakeGenerator{out: "Generated summary without explicit source tags."})
@@ -641,12 +629,8 @@ func TestAsk_AppendsMissingAttributions(t *testing.T) {
 
 func TestAsk_AppendsOnlyMissingAttributions(t *testing.T) {
 	idx := index.NewHNSWIndex("")
-	if err := idx.Add(1, []float32{1, 0}); err != nil {
-		t.Fatalf("idx.Add failed: %v", err)
-	}
-	if err := idx.Add(2, []float32{0.9, 0.1}); err != nil {
-		t.Fatalf("idx.Add failed: %v", err)
-	}
+	addVec(t, idx, 1, []float32{1, 0})
+	addVec(t, idx, 2, []float32{0.9, 0.1})
 	svc := NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
 		"mistral-embed": {1, 0},
 	}}, &fakeGenerator{out: "Generated summary with [docs/a.md] already present."})

--- a/tests/index/embedding_worker_test.go
+++ b/tests/index/embedding_worker_test.go
@@ -295,6 +295,51 @@ func TestEmbeddingWorker_RunOnce_Success(t *testing.T) {
 	}
 }
 
+// TestEmbeddingWorker_RunOnce_ProjectsPayload pins issue #247: the worker
+// Upserts each vector with an IndexPayload projected from the chunk's metadata
+// (rel_path/doc_type/span/modality), so the index itself can serve filtered
+// search. We assert by querying the index and inspecting the returned payload.
+func TestEmbeddingWorker_RunOnce_ProjectsPayload(t *testing.T) {
+	source := &fakeChunkSource{
+		tasks: []model.ChunkTask{
+			model.NewChunkTask(31, "spoken", "", model.ChunkMetadata{
+				ChunkID: 31, RelPath: "audio/talk.mp3", DocType: "audio",
+				Snippet: "spoken words",
+				Span:    model.Span{Kind: "time", StartMS: 1000, EndMS: 5000},
+			}),
+		},
+	}
+	idx := index.NewHNSWIndex("")
+	worker := &index.EmbeddingWorker{
+		Source:       source,
+		Index:        idx,
+		Embedder:     &fakeEmbedder{vectors: [][]float32{{1, 0}}},
+		BatchSize:    4,
+		ModelForText: "mistral-embed",
+	}
+
+	if _, err := worker.RunOnce(context.Background(), "text"); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	// A doctype-filtered search proves the payload doc_type was stored, and the
+	// returned payload proves the rest of the projection round-tripped.
+	hits, err := idx.Search(context.Background(), []float32{1, 0}, 5, model.Filter{DocTypes: []string{"audio"}})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(hits) != 1 || hits[0].ChunkID != 31 {
+		t.Fatalf("expected chunk 31 via doctype-filtered search, got %v", hits)
+	}
+	p := hits[0].Payload
+	if p.RelPath != "audio/talk.mp3" || p.DocType != "audio" || p.Snippet != "spoken words" {
+		t.Fatalf("payload not projected from metadata: %#v", p)
+	}
+	if p.Span.Kind != "time" || p.StartMS != 1000 || p.EndMS != 5000 {
+		t.Fatalf("span/time bounds not projected: %#v", p)
+	}
+}
+
 func TestEmbeddingWorker_RunOnce_EmbeddingFailure(t *testing.T) {
 	source := &fakeChunkSource{
 		tasks: []model.ChunkTask{

--- a/tests/index/hnsw_index_test.go
+++ b/tests/index/hnsw_index_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"bytes"
+	"context"
 	"log"
 	"os"
 	"path/filepath"
@@ -9,41 +10,44 @@ import (
 	"testing"
 
 	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
 )
 
-func TestHNSWIndex_AddAndSearch(t *testing.T) {
-	idx := index.NewHNSWIndex("")
-	if err := idx.Add(1, []float32{1, 0}); err != nil {
-		t.Fatalf("Add failed: %v", err)
+// upsertVec is a small helper that stores a vector keyed by id with a minimal
+// payload (rel_path derived from id so the chunk is not treated as an orphan
+// under a filter). It keeps the direct-index tests terse after the #247 API
+// change from Add(label, vec) to Upsert(ctx, vec, payload).
+func upsertVec(t *testing.T, idx *index.HNSWIndex, id uint64, vec []float32) {
+	t.Helper()
+	payload := model.IndexPayload{ChunkID: id, RelPath: "doc.txt", DocType: "md"}
+	if err := idx.Upsert(context.Background(), vec, payload); err != nil {
+		t.Fatalf("Upsert(%d) failed: %v", id, err)
 	}
-	if err := idx.Add(2, []float32{0.9, 0.1}); err != nil {
-		t.Fatalf("Add failed: %v", err)
-	}
-	if err := idx.Add(3, []float32{0, 1}); err != nil {
-		t.Fatalf("Add failed: %v", err)
-	}
+}
 
-	labels, scores, err := idx.Search([]float32{1, 0}, 2)
+func TestHNSWIndex_UpsertAndSearch(t *testing.T) {
+	idx := index.NewHNSWIndex("")
+	upsertVec(t, idx, 1, []float32{1, 0})
+	upsertVec(t, idx, 2, []float32{0.9, 0.1})
+	upsertVec(t, idx, 3, []float32{0, 1})
+
+	hits, err := idx.Search(context.Background(), []float32{1, 0}, 2, model.Filter{})
 	if err != nil {
 		t.Fatalf("Search failed: %v", err)
 	}
-	// check we got the right number of results
-	if len(labels) != 2 || len(scores) != 2 {
-		t.Fatalf("unexpected result lengths: labels=%d scores=%d", len(labels), len(scores))
+	if len(hits) != 2 {
+		t.Fatalf("unexpected result length: %d", len(hits))
 	}
-
-	// verify both returned labels are correct and in expected order
-	if labels[0] != 1 {
-		t.Fatalf("expected top label 1, got %d", labels[0])
+	if hits[0].ChunkID != 1 {
+		t.Fatalf("expected top chunk 1, got %d", hits[0].ChunkID)
 	}
-	if labels[1] != 2 {
-		t.Fatalf("expected second label 2, got %d", labels[1])
+	if hits[1].ChunkID != 2 {
+		t.Fatalf("expected second chunk 2, got %d", hits[1].ChunkID)
 	}
-
 	// for cosine similarity higher score is better, so results should be
 	// non‑increasing
-	if scores[0] < scores[1] {
-		t.Fatalf("expected scores[0] >= scores[1], got %v and %v", scores[0], scores[1])
+	if hits[0].Score < hits[1].Score {
+		t.Fatalf("expected scores[0] >= scores[1], got %v and %v", hits[0].Score, hits[1].Score)
 	}
 }
 
@@ -54,20 +58,16 @@ func TestHNSWIndex_DimensionMismatch(t *testing.T) {
 	idx.Logger = log.New(&buf, "", 0)
 	idx.Metrics = &index.HNSWIndexMetrics{}
 
-	if err := idx.Add(1, []float32{1, 0}); err != nil {
-		t.Fatalf("Add failed: %v", err)
-	}
+	upsertVec(t, idx, 1, []float32{1, 0})
 	// add a vector with incorrect dimension
-	if err := idx.Add(2, []float32{1, 0, 0}); err != nil {
-		t.Fatalf("Add failed: %v", err)
-	}
+	upsertVec(t, idx, 2, []float32{1, 0, 0})
 
-	labels, _, err := idx.Search([]float32{1, 0}, 10)
+	hits, err := idx.Search(context.Background(), []float32{1, 0}, 10, model.Filter{})
 	if err != nil {
 		t.Fatalf("Search failed: %v", err)
 	}
-	if len(labels) != 1 || labels[0] != 1 {
-		t.Fatalf("unexpected labels after mismatch: %v", labels)
+	if len(hits) != 1 || hits[0].ChunkID != 1 {
+		t.Fatalf("unexpected hits after mismatch: %v", hits)
 	}
 	// read via Load to respect the atomic.Int64 API
 	if idx.Metrics.DimensionMismatch.Load() != 1 {
@@ -83,10 +83,8 @@ func TestHNSWIndex_SaveAndLoad(t *testing.T) {
 	file := filepath.Join(tmp, "idx.bin")
 
 	idx := index.NewHNSWIndex(file)
-	if err := idx.Add(7, []float32{0.1, 0.2, 0.3}); err != nil {
-		t.Fatalf("Add failed: %v", err)
-	}
-	if err := idx.Save(""); err != nil {
+	upsertVec(t, idx, 7, []float32{0.1, 0.2, 0.3})
+	if err := idx.Save(context.Background(), ""); err != nil {
 		t.Fatalf("Save failed: %v", err)
 	}
 	if _, err := os.Stat(file); err != nil {
@@ -94,80 +92,75 @@ func TestHNSWIndex_SaveAndLoad(t *testing.T) {
 	}
 
 	loaded := index.NewHNSWIndex(file)
-	if err := loaded.Load(""); err != nil {
+	if err := loaded.Load(context.Background(), ""); err != nil {
 		t.Fatalf("Load failed: %v", err)
 	}
-	labels, _, err := loaded.Search([]float32{0.1, 0.2, 0.3}, 1)
+	hits, err := loaded.Search(context.Background(), []float32{0.1, 0.2, 0.3}, 1, model.Filter{})
 	if err != nil {
 		t.Fatalf("Search failed: %v", err)
 	}
-	if len(labels) != 1 || labels[0] != 7 {
-		t.Fatalf("unexpected loaded search result: %#v", labels)
+	if len(hits) != 1 || hits[0].ChunkID != 7 {
+		t.Fatalf("unexpected loaded search result: %#v", hits)
+	}
+	// the persisted payload round-trips alongside the vector.
+	if hits[0].Payload.RelPath != "doc.txt" {
+		t.Fatalf("expected payload to survive save/load, got %q", hits[0].Payload.RelPath)
 	}
 }
 
 func TestHNSWIndex_SearchEmptyIndex(t *testing.T) {
 	idx := index.NewHNSWIndex("")
-	// should not panic and should return empty slices
-	labels, scores, err := idx.Search([]float32{1, 0}, 1)
+	// should not panic and should return empty slice
+	hits, err := idx.Search(context.Background(), []float32{1, 0}, 1, model.Filter{})
 	if err != nil {
 		t.Fatalf("expected no error searching empty index, got %v", err)
 	}
-	if len(labels) != 0 || len(scores) != 0 {
-		t.Fatalf("expected empty results from empty index, got labels=%v scores=%v", labels, scores)
+	if len(hits) != 0 {
+		t.Fatalf("expected empty results from empty index, got %v", hits)
 	}
 }
 
 func TestHNSWIndex_KGreaterThanItems(t *testing.T) {
 	idx := index.NewHNSWIndex("")
-	if err := idx.Add(10, []float32{1, 0}); err != nil {
-		t.Fatalf("Add failed: %v", err)
-	}
-	if err := idx.Add(20, []float32{0, 1}); err != nil {
-		t.Fatalf("Add failed: %v", err)
-	}
+	upsertVec(t, idx, 10, []float32{1, 0})
+	upsertVec(t, idx, 20, []float32{0, 1})
 
-	labels, scores, err := idx.Search([]float32{1, 0}, 5)
+	hits, err := idx.Search(context.Background(), []float32{1, 0}, 5, model.Filter{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(labels) != 2 || len(scores) != 2 {
-		t.Fatalf("expected 2 results when k>items, got %d", len(labels))
+	if len(hits) != 2 {
+		t.Fatalf("expected 2 results when k>items, got %d", len(hits))
 	}
 }
 
-func TestHNSWIndex_AddDuplicateLabels(t *testing.T) {
+func TestHNSWIndex_UpsertDuplicateChunkIDs(t *testing.T) {
 	idx := index.NewHNSWIndex("")
-	// add the same label twice with different vectors; second add should
-	// overwrite the first
-	if err := idx.Add(1, []float32{1, 0}); err != nil {
-		t.Fatalf("add failed: %v", err)
-	}
-	if err := idx.Add(1, []float32{0, 1}); err != nil {
-		t.Fatalf("second add failed: %v", err)
-	}
+	// upsert the same chunk_id twice with different vectors; the second upsert
+	// should overwrite the first
+	upsertVec(t, idx, 1, []float32{1, 0})
+	upsertVec(t, idx, 1, []float32{0, 1})
 
-	// search for a vector similar to the second addition and ensure the
-	// returned score reflects the overwritten vector
-	labels, scores, err := idx.Search([]float32{0, 1}, 1)
+	// search for a vector similar to the second upsert and ensure the returned
+	// score reflects the overwritten vector
+	hits, err := idx.Search(context.Background(), []float32{0, 1}, 1, model.Filter{})
 	if err != nil {
 		t.Fatalf("search failed: %v", err)
 	}
-	if len(labels) != 1 {
-		t.Fatalf("expected 1 label after duplicate add, got %d", len(labels))
+	if len(hits) != 1 {
+		t.Fatalf("expected 1 hit after duplicate upsert, got %d", len(hits))
 	}
-	if labels[0] != 1 {
-		t.Fatalf("expected label 1, got %d", labels[0])
+	if hits[0].ChunkID != 1 {
+		t.Fatalf("expected chunk 1, got %d", hits[0].ChunkID)
 	}
-	if scores[0] < 0.9 { // cosine similarity for identical vectors should be 1
-		t.Fatalf("expected high score after overwrite, got %v", scores[0])
+	if hits[0].Score < 0.9 { // cosine similarity for identical vectors should be 1
+		t.Fatalf("expected high score after overwrite, got %v", hits[0].Score)
 	}
 }
 
 func TestHNSWIndex_LoadNonExistentFile(t *testing.T) {
 	idx := index.NewHNSWIndex("/nonexistent")
-	err := idx.Load("")
-	if err != nil {
+	if err := idx.Load(context.Background(), ""); err != nil {
 		t.Fatalf("expected nil for nonexistent file, got %v", err)
 	}
 }

--- a/tests/index/persistence_test.go
+++ b/tests/index/persistence_test.go
@@ -9,9 +9,26 @@ import (
 	"time"
 
 	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
 )
 
+// coreIndexStub provides no-op implementations of the non-persistence
+// model.Index methods so the persistence-focused fakes below only need to
+// define Save/Load (the model.Persistable capability the PersistenceManager
+// type-asserts).
+type coreIndexStub struct{}
+
+func (coreIndexStub) Upsert(context.Context, []float32, model.IndexPayload) error { return nil }
+func (coreIndexStub) Delete(context.Context, []uint64) error                      { return nil }
+func (coreIndexStub) Search(context.Context, []float32, int, model.Filter) ([]model.IndexHit, error) {
+	return nil, nil
+}
+func (coreIndexStub) Identity(context.Context) (string, error) { return "", nil }
+func (coreIndexStub) Reset(context.Context, string) error      { return nil }
+func (coreIndexStub) Close() error                             { return nil }
+
 type fakePersistIndex struct {
+	coreIndexStub
 	loadCalls int32
 	saveCalls int32
 	loadErr   error
@@ -22,22 +39,19 @@ type fakePersistIndex struct {
 	saveNotify chan struct{}
 }
 
-// notifyIndex is a minimal implementation of model.Index used by tests
-// that need to observe when Load begins. It sends a notification on the
-// provided channel immediately when Load is called; if the `done` channel
-// is non-nil, Load blocks until it is closed. This allows tests to control
-// the duration of the call.
+// notifyIndex is a minimal implementation of model.Index + model.Persistable
+// used by tests that need to observe when Load begins. It sends a notification
+// on the provided channel immediately when Load is called; if the `done`
+// channel is non-nil, Load blocks until it is closed. This allows tests to
+// control the duration of the call.
 type notifyIndex struct {
+	coreIndexStub
 	started chan struct{}
 	done    chan struct{}
 }
 
-func (n *notifyIndex) Add(label uint64, vector []float32) error { return nil }
-func (n *notifyIndex) Search(vector []float32, k int) ([]uint64, []float32, error) {
-	return nil, nil, nil
-}
-func (n *notifyIndex) Save(path string) error { return nil }
-func (n *notifyIndex) Load(path string) error {
+func (n *notifyIndex) Save(context.Context, string) error { return nil }
+func (n *notifyIndex) Load(context.Context, string) error {
 	select {
 	case n.started <- struct{}{}:
 	default:
@@ -47,21 +61,8 @@ func (n *notifyIndex) Load(path string) error {
 	}
 	return nil
 }
-func (n *notifyIndex) Close() error { return nil }
 
-func (f *fakePersistIndex) Add(label uint64, vector []float32) error {
-	_ = label
-	_ = vector
-	return nil
-}
-
-func (f *fakePersistIndex) Search(vector []float32, k int) ([]uint64, []float32, error) {
-	_ = vector
-	_ = k
-	return nil, nil, nil
-}
-
-func (f *fakePersistIndex) Save(path string) error {
+func (f *fakePersistIndex) Save(_ context.Context, path string) error {
 	_ = path
 	atomic.AddInt32(&f.saveCalls, 1)
 	if f.saveNotify != nil {
@@ -74,13 +75,11 @@ func (f *fakePersistIndex) Save(path string) error {
 	return f.saveErr
 }
 
-func (f *fakePersistIndex) Load(path string) error {
+func (f *fakePersistIndex) Load(_ context.Context, path string) error {
 	_ = path
 	atomic.AddInt32(&f.loadCalls, 1)
 	return f.loadErr
 }
-
-func (f *fakePersistIndex) Close() error { return nil }
 
 func TestPersistenceManager_LoadAndSaveAll(t *testing.T) {
 	i1 := &fakePersistIndex{}
@@ -236,15 +235,13 @@ func TestPersistenceManager_LoadAll_CancelDuring(t *testing.T) {
 // concurrentIndex tracks active Save calls and reports if more than one
 // happens at the same time (violating serialization guarantees).
 type concurrentIndex struct {
+	coreIndexStub
 	running int32
 	errCh   chan error
 }
 
-func (c *concurrentIndex) Add(label uint64, vector []float32) error { return nil }
-func (c *concurrentIndex) Search(vector []float32, k int) ([]uint64, []float32, error) {
-	return nil, nil, nil
-}
-func (c *concurrentIndex) Save(path string) error {
+func (c *concurrentIndex) Save(_ context.Context, path string) error {
+	_ = path
 	if atomic.AddInt32(&c.running, 1) > 1 {
 		select {
 		case c.errCh <- errors.New("concurrent save"):
@@ -257,7 +254,8 @@ func (c *concurrentIndex) Save(path string) error {
 	return nil
 }
 
-func (c *concurrentIndex) Load(path string) error {
+func (c *concurrentIndex) Load(_ context.Context, path string) error {
+	_ = path
 	if atomic.AddInt32(&c.running, 1) > 1 {
 		select {
 		case c.errCh <- errors.New("concurrent load/save"):
@@ -269,8 +267,6 @@ func (c *concurrentIndex) Load(path string) error {
 	atomic.AddInt32(&c.running, -1)
 	return nil
 }
-
-func (c *concurrentIndex) Close() error { return nil }
 
 func TestPersistenceManager_SaveAll_Serializes(t *testing.T) {
 	ci := &concurrentIndex{errCh: make(chan error, 1)}

--- a/tests/index/pluggable_index_test.go
+++ b/tests/index/pluggable_index_test.go
@@ -1,0 +1,168 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// chunkIDs collects the chunk IDs from a hit slice, preserving order.
+func chunkIDs(hits []model.IndexHit) []uint64 {
+	out := make([]uint64, len(hits))
+	for i, h := range hits {
+		out[i] = h.ChunkID
+	}
+	return out
+}
+
+func TestHNSWIndex_SearchWithDocTypeFilter(t *testing.T) {
+	ctx := context.Background()
+	idx := index.NewHNSWIndex("")
+	mustUpsert(t, idx, model.IndexPayload{ChunkID: 1, RelPath: "docs/a.md", DocType: "md"}, []float32{1, 0})
+	mustUpsert(t, idx, model.IndexPayload{ChunkID: 2, RelPath: "src/a.go", DocType: "code"}, []float32{0.99, 0.01})
+	mustUpsert(t, idx, model.IndexPayload{ChunkID: 3, RelPath: "docs/b.md", DocType: "md"}, []float32{0.98, 0.02})
+
+	hits, err := idx.Search(ctx, []float32{1, 0}, 10, model.Filter{DocTypes: []string{"MD"}})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	got := chunkIDs(hits)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 md hits, got %v", got)
+	}
+	for _, id := range got {
+		if id == 2 {
+			t.Fatalf("code chunk 2 leaked past doctype filter: %v", got)
+		}
+	}
+}
+
+func TestHNSWIndex_SearchWithPathPrefixAndGlobFilter(t *testing.T) {
+	ctx := context.Background()
+	idx := index.NewHNSWIndex("")
+	mustUpsert(t, idx, model.IndexPayload{ChunkID: 1, RelPath: "docs/a.md", DocType: "md"}, []float32{1, 0})
+	mustUpsert(t, idx, model.IndexPayload{ChunkID: 2, RelPath: "docs/b.md", DocType: "md"}, []float32{0.99, 0.01})
+	mustUpsert(t, idx, model.IndexPayload{ChunkID: 3, RelPath: "src/main.go", DocType: "code"}, []float32{0.98, 0.02})
+
+	hits, err := idx.Search(ctx, []float32{1, 0}, 10, model.Filter{PathPrefix: "docs/", PathGlob: "docs/a.*"})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	got := chunkIDs(hits)
+	if len(got) != 1 || got[0] != 1 {
+		t.Fatalf("expected only chunk 1 (docs/a.md), got %v", got)
+	}
+}
+
+func TestHNSWIndex_DeleteRemovesVector(t *testing.T) {
+	ctx := context.Background()
+	idx := index.NewHNSWIndex("")
+	mustUpsert(t, idx, model.IndexPayload{ChunkID: 1, RelPath: "a.md"}, []float32{1, 0})
+	mustUpsert(t, idx, model.IndexPayload{ChunkID: 2, RelPath: "b.md"}, []float32{0.9, 0.1})
+
+	if err := idx.Delete(ctx, []uint64{1}); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	hits, err := idx.Search(ctx, []float32{1, 0}, 10, model.Filter{})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	got := chunkIDs(hits)
+	if len(got) != 1 || got[0] != 2 {
+		t.Fatalf("expected only chunk 2 after delete, got %v", got)
+	}
+	// Deleting an unknown id is a no-op, not an error.
+	if err := idx.Delete(ctx, []uint64{999}); err != nil {
+		t.Fatalf("Delete unknown id: %v", err)
+	}
+}
+
+func TestHNSWIndex_IdentityAndReset(t *testing.T) {
+	ctx := context.Background()
+	idx := index.NewHNSWIndex("")
+
+	id, err := idx.Identity(ctx)
+	if err != nil {
+		t.Fatalf("Identity: %v", err)
+	}
+	if id != "" {
+		t.Fatalf("fresh index identity should be empty, got %q", id)
+	}
+
+	mustUpsert(t, idx, model.IndexPayload{ChunkID: 1, RelPath: "a.md"}, []float32{1, 0})
+	if err := idx.Reset(ctx, "mistral|mistral-embed|codestral-embed|0|0|off"); err != nil {
+		t.Fatalf("Reset: %v", err)
+	}
+
+	id, err = idx.Identity(ctx)
+	if err != nil {
+		t.Fatalf("Identity after reset: %v", err)
+	}
+	if id != "mistral|mistral-embed|codestral-embed|0|0|off" {
+		t.Fatalf("unexpected identity after reset: %q", id)
+	}
+	// Reset clears all vectors.
+	hits, err := idx.Search(ctx, []float32{1, 0}, 10, model.Filter{})
+	if err != nil {
+		t.Fatalf("Search after reset: %v", err)
+	}
+	if len(hits) != 0 {
+		t.Fatalf("expected empty index after reset, got %v", chunkIDs(hits))
+	}
+}
+
+func TestEnsureIdentity_ResetsOnMismatchAndEmpty(t *testing.T) {
+	ctx := context.Background()
+	idx := index.NewHNSWIndex("")
+	mustUpsert(t, idx, model.IndexPayload{ChunkID: 1, RelPath: "a.md"}, []float32{1, 0})
+
+	// Fresh index (empty identity) reconciles to the configured one and is reset.
+	if err := index.EnsureIdentity(ctx, idx, "ident-1"); err != nil {
+		t.Fatalf("EnsureIdentity (fresh): %v", err)
+	}
+	if id, _ := idx.Identity(ctx); id != "ident-1" {
+		t.Fatalf("expected identity ident-1, got %q", id)
+	}
+	if hits, _ := idx.Search(ctx, []float32{1, 0}, 10, model.Filter{}); len(hits) != 0 {
+		t.Fatalf("expected vectors cleared on fresh reconcile, got %v", chunkIDs(hits))
+	}
+
+	// A matching identity is a no-op: vectors are preserved.
+	mustUpsert(t, idx, model.IndexPayload{ChunkID: 2, RelPath: "b.md"}, []float32{1, 0})
+	if err := index.EnsureIdentity(ctx, idx, "ident-1"); err != nil {
+		t.Fatalf("EnsureIdentity (match): %v", err)
+	}
+	if hits, _ := idx.Search(ctx, []float32{1, 0}, 10, model.Filter{}); len(hits) != 1 {
+		t.Fatalf("matching identity must not clear vectors, got %v", chunkIDs(hits))
+	}
+
+	// A changed identity resets again (vector space changed).
+	if err := index.EnsureIdentity(ctx, idx, "ident-2"); err != nil {
+		t.Fatalf("EnsureIdentity (mismatch): %v", err)
+	}
+	if id, _ := idx.Identity(ctx); id != "ident-2" {
+		t.Fatalf("expected identity ident-2, got %q", id)
+	}
+	if hits, _ := idx.Search(ctx, []float32{1, 0}, 10, model.Filter{}); len(hits) != 0 {
+		t.Fatalf("expected vectors cleared on identity change, got %v", chunkIDs(hits))
+	}
+}
+
+func TestHNSWIndex_CanFilterAlwaysTrue(t *testing.T) {
+	idx := index.NewHNSWIndex("")
+	if !idx.CanFilter(model.Filter{}) {
+		t.Fatal("pure-Go HNSW should report CanFilter true for the zero filter")
+	}
+	if !idx.CanFilter(model.Filter{PathPrefix: "docs/", DocTypes: []string{"md"}}) {
+		t.Fatal("pure-Go HNSW should report CanFilter true for a populated filter")
+	}
+}
+
+func mustUpsert(t *testing.T, idx *index.HNSWIndex, payload model.IndexPayload, vec []float32) {
+	t.Helper()
+	if err := idx.Upsert(context.Background(), vec, payload); err != nil {
+		t.Fatalf("Upsert(%d): %v", payload.ChunkID, err)
+	}
+}

--- a/tests/ingest/transcribe_test.go
+++ b/tests/ingest/transcribe_test.go
@@ -163,16 +163,17 @@ type fixedLabelsIndex struct {
 	labels []uint64
 }
 
-func (i *fixedLabelsIndex) Add(uint64, []float32) error { return nil }
-func (i *fixedLabelsIndex) Save(string) error           { return nil }
-func (i *fixedLabelsIndex) Load(string) error           { return nil }
-func (i *fixedLabelsIndex) Close() error                { return nil }
-func (i *fixedLabelsIndex) Search([]float32, int) ([]uint64, []float32, error) {
-	scores := make([]float32, len(i.labels))
-	for n := range scores {
-		scores[n] = float32(len(scores) - n)
+func (i *fixedLabelsIndex) Upsert(context.Context, []float32, model.IndexPayload) error { return nil }
+func (i *fixedLabelsIndex) Delete(context.Context, []uint64) error                      { return nil }
+func (i *fixedLabelsIndex) Identity(context.Context) (string, error)                    { return "", nil }
+func (i *fixedLabelsIndex) Reset(context.Context, string) error                         { return nil }
+func (i *fixedLabelsIndex) Close() error                                                { return nil }
+func (i *fixedLabelsIndex) Search(_ context.Context, _ []float32, _ int, _ model.Filter) ([]model.IndexHit, error) {
+	hits := make([]model.IndexHit, len(i.labels))
+	for n, label := range i.labels {
+		hits[n] = model.IndexHit{ChunkID: label, Score: float32(len(i.labels) - n)}
 	}
-	return append([]uint64(nil), i.labels...), scores, nil
+	return hits, nil
 }
 
 type staticEmbedder struct {

--- a/tests/retrieval/media_dedup_test.go
+++ b/tests/retrieval/media_dedup_test.go
@@ -19,9 +19,7 @@ func TestSearch_DedupsPageImageWhenTextSurvives(t *testing.T) {
 		2: {0.99, 0.01}, // page-image media chunk, page 1 (duplicate of #1)
 		3: {0.98, 0.02}, // page-image media chunk, page 2 (no competing text)
 	} {
-		if err := idx.Add(label, vec); err != nil {
-			t.Fatalf("idx.Add(%d): %v", label, err)
-		}
+		addVec(t, idx, label, vec)
 	}
 
 	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
@@ -59,9 +57,7 @@ func TestSearch_KeepsTimeWindowMediaAlongsideTranscript(t *testing.T) {
 		1: {1, 0},       // transcript text chunk (time span)
 		2: {0.99, 0.01}, // audio media window (time span)
 	} {
-		if err := idx.Add(label, vec); err != nil {
-			t.Fatalf("idx.Add(%d): %v", label, err)
-		}
+		addVec(t, idx, label, vec)
 	}
 	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
 		"mistral-embed": {1, 0},

--- a/tests/retrieval/media_open_file_test.go
+++ b/tests/retrieval/media_open_file_test.go
@@ -142,9 +142,7 @@ func TestOpenFile_TextFile_UnaffectedByMediaGuard(t *testing.T) {
 // without quoted context rather than dropping it as a missing snippet.
 func TestAsk_MediaOnlyHit_CitedWithoutQuotedText(t *testing.T) {
 	idx := index.NewHNSWIndex("")
-	if err := idx.Add(1, []float32{1, 0}); err != nil {
-		t.Fatal(err)
-	}
+	addVec(t, idx, 1, []float32{1, 0})
 	gen := &fakeGenerator{out: "an answer [clip.mp4]"}
 	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
 		"mistral-embed": {1, 0},

--- a/tests/retrieval/pushdown_test.go
+++ b/tests/retrieval/pushdown_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/dirstral/dir2mcp/internal/index"
 	"github.com/dirstral/dir2mcp/internal/model"
 	"github.com/dirstral/dir2mcp/internal/retrieval"
 )
@@ -107,5 +108,53 @@ func TestSearch_PushDownExcludesNonMatchingPaths(t *testing.T) {
 	}
 	if len(hits) != 1 || hits[0].RelPath != "docs/a.md" {
 		t.Fatalf("expected only docs/a.md via push-down prefix, got %v", hits)
+	}
+}
+
+// TestSearch_PushDownWidensPastEvictedChunks is a regression test for the
+// push-down under-fetch bug: the real HNSW index reports CanFilter true, so the
+// filter is pushed down, but in-memory eviction (EvictDocuments) removes only
+// the service's chunk metadata — the vector + payload stay in the HNSW. The
+// post-materialization matchFilters re-check drops those evicted chunks (their
+// in-memory rel_path is gone), so the search must widen the candidate pool to
+// still return k valid hits rather than letting evicted-but-indexed chunks
+// silently shrink the result set below k.
+func TestSearch_PushDownWidensPastEvictedChunks(t *testing.T) {
+	ctx := context.Background()
+	idx := index.NewHNSWIndex("")
+	// 5 chunks under docs/, all matching the path-prefix filter. The first two
+	// (highest-scoring) will be evicted in-memory after indexing.
+	addVecP(t, idx, 1, []float32{1, 0}, "docs/a.md", "md")
+	addVecP(t, idx, 2, []float32{0.99, 0.01}, "docs/b.md", "md")
+	addVecP(t, idx, 3, []float32{0.98, 0.02}, "docs/c.md", "md")
+	addVecP(t, idx, 4, []float32{0.97, 0.03}, "docs/d.md", "md")
+	addVecP(t, idx, 5, []float32{0.96, 0.04}, "docs/e.md", "md")
+
+	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+		"mistral-embed": {1, 0},
+	}}, nil)
+	for id, rel := range map[uint64]string{
+		1: "docs/a.md", 2: "docs/b.md", 3: "docs/c.md", 4: "docs/d.md", 5: "docs/e.md",
+	} {
+		svc.SetChunkMetadata(id, model.SearchHit{RelPath: rel, DocType: "md", Snippet: rel})
+	}
+
+	// Evict the two top-scoring docs in-memory only (their HNSW vectors remain).
+	svc.EvictDocuments([]string{"docs/a.md", "docs/b.md"})
+
+	hits, err := svc.Search(ctx, model.SearchQuery{Query: "q", K: 3, PathPrefix: "docs/"})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	// Without the widening loop the search would return only chunks 3..5 minus
+	// the slots wasted on the evicted 1 and 2 — i.e. fewer than k. We must get
+	// the full k surviving docs.
+	if len(hits) != 3 {
+		t.Fatalf("expected 3 surviving hits after eviction, got %d (%v)", len(hits), hits)
+	}
+	for _, h := range hits {
+		if h.RelPath == "docs/a.md" || h.RelPath == "docs/b.md" {
+			t.Fatalf("evicted chunk leaked into results: %v", hits)
+		}
 	}
 }

--- a/tests/retrieval/pushdown_test.go
+++ b/tests/retrieval/pushdown_test.go
@@ -1,0 +1,111 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
+)
+
+// payloadFilteringIndex is a stand-in for an external/on-disk backend (issue
+// #247): it stores payloads, evaluates the pushed-down Filter itself
+// (CanFilter true), and returns hits with populated payloads. Crucially the
+// test registers NO in-memory chunk metadata on the service, so retrieval must
+// materialise SearchHits from the backend payload — exercising the
+// FilteringIndex push-down path end to end.
+type payloadFilteringIndex struct {
+	vectors  map[uint64][]float32
+	payloads map[uint64]model.IndexPayload
+	// lastFilter records the filter the service pushed down on the last Search.
+	lastFilter model.Filter
+}
+
+func newPayloadFilteringIndex() *payloadFilteringIndex {
+	return &payloadFilteringIndex{
+		vectors:  map[uint64][]float32{},
+		payloads: map[uint64]model.IndexPayload{},
+	}
+}
+
+func (p *payloadFilteringIndex) Upsert(_ context.Context, vec []float32, payload model.IndexPayload) error {
+	p.vectors[payload.ChunkID] = vec
+	p.payloads[payload.ChunkID] = payload
+	return nil
+}
+func (p *payloadFilteringIndex) Delete(_ context.Context, ids []uint64) error {
+	for _, id := range ids {
+		delete(p.vectors, id)
+		delete(p.payloads, id)
+	}
+	return nil
+}
+func (p *payloadFilteringIndex) CanFilter(model.Filter) bool { return true }
+func (p *payloadFilteringIndex) Search(_ context.Context, _ []float32, k int, filter model.Filter) ([]model.IndexHit, error) {
+	p.lastFilter = filter
+	hits := make([]model.IndexHit, 0, len(p.payloads))
+	for id, payload := range p.payloads {
+		if !filter.Match(payload) {
+			continue
+		}
+		hits = append(hits, model.IndexHit{ChunkID: id, Score: 1, Payload: payload})
+		if len(hits) >= k {
+			break
+		}
+	}
+	return hits, nil
+}
+func (p *payloadFilteringIndex) Identity(context.Context) (string, error) { return "", nil }
+func (p *payloadFilteringIndex) Reset(context.Context, string) error      { return nil }
+func (p *payloadFilteringIndex) Close() error                             { return nil }
+
+func TestSearch_PushesFilterDownAndMaterialisesFromPayload(t *testing.T) {
+	idx := newPayloadFilteringIndex()
+	ctx := context.Background()
+	_ = idx.Upsert(ctx, []float32{1, 0}, model.IndexPayload{ChunkID: 1, RelPath: "docs/a.md", DocType: "md", Snippet: "alpha"})
+	_ = idx.Upsert(ctx, []float32{1, 0}, model.IndexPayload{ChunkID: 2, RelPath: "src/main.go", DocType: "code", Snippet: "beta"})
+
+	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+		"mistral-embed": {1, 0},
+	}}, nil)
+	// Deliberately register NO chunk metadata — the backend payload is the only
+	// source of rel_path/doc_type/snippet.
+
+	hits, err := svc.Search(ctx, model.SearchQuery{
+		Query:    "alpha",
+		K:        5,
+		DocTypes: []string{"md"},
+	})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(hits) != 1 {
+		t.Fatalf("expected 1 md hit from push-down, got %d (%v)", len(hits), hits)
+	}
+	if hits[0].RelPath != "docs/a.md" || hits[0].Snippet != "alpha" {
+		t.Fatalf("hit not materialised from payload: %#v", hits[0])
+	}
+	// The doctype predicate must have been pushed to the backend.
+	if len(idx.lastFilter.DocTypes) != 1 || idx.lastFilter.DocTypes[0] != "md" {
+		t.Fatalf("expected doctype filter pushed down, got %#v", idx.lastFilter)
+	}
+}
+
+func TestSearch_PushDownExcludesNonMatchingPaths(t *testing.T) {
+	idx := newPayloadFilteringIndex()
+	ctx := context.Background()
+	_ = idx.Upsert(ctx, []float32{1, 0}, model.IndexPayload{ChunkID: 1, RelPath: "docs/a.md", DocType: "md", Snippet: "a"})
+	_ = idx.Upsert(ctx, []float32{1, 0}, model.IndexPayload{ChunkID: 2, RelPath: "other/b.md", DocType: "md", Snippet: "b"})
+
+	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+		"mistral-embed": {1, 0},
+	}}, nil)
+
+	hits, err := svc.Search(ctx, model.SearchQuery{Query: "q", K: 5, PathPrefix: "docs/"})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(hits) != 1 || hits[0].RelPath != "docs/a.md" {
+		t.Fatalf("expected only docs/a.md via push-down prefix, got %v", hits)
+	}
+}

--- a/tests/retrieval/rerank_test.go
+++ b/tests/retrieval/rerank_test.go
@@ -50,9 +50,7 @@ func rerankTestService(t *testing.T) *retrieval.Service {
 	t.Helper()
 	idx := index.NewHNSWIndex("")
 	for id, vec := range map[uint64][]float32{1: {1, 0}, 2: {0.9, 0.1}, 3: {0.8, 0.2}} {
-		if err := idx.Add(id, vec); err != nil {
-			t.Fatalf("idx.Add: %v", err)
-		}
+		addVec(t, idx, id, vec)
 	}
 	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
 		"mistral-embed":   {1, 0},
@@ -200,13 +198,9 @@ func TestRerank_BothModeReranksOnceOnMergedPool(t *testing.T) {
 	// non-empty pools; without separate indices the assertion could pass
 	// on a single-index result.
 	textIdx := index.NewHNSWIndex("")
-	if err := textIdx.Add(1, []float32{1, 0}); err != nil {
-		t.Fatalf("textIdx.Add: %v", err)
-	}
+	addVec(t, textIdx, 1, []float32{1, 0})
 	codeIdx := index.NewHNSWIndex("")
-	if err := codeIdx.Add(2, []float32{0, 1}); err != nil {
-		t.Fatalf("codeIdx.Add: %v", err)
-	}
+	addVec(t, codeIdx, 2, []float32{0, 1})
 	svc := retrieval.NewService(nil, textIdx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
 		"mistral-embed":   {1, 0}, // text query -> matches id 1 in textIdx
 		"codestral-embed": {0, 1}, // code query -> matches id 2 in codeIdx

--- a/tests/retrieval/service_test.go
+++ b/tests/retrieval/service_test.go
@@ -143,14 +143,32 @@ type fakeRetrievalIndex struct {
 	lastK int
 }
 
-func (f *fakeRetrievalIndex) Add(label uint64, vector []float32) error { return nil }
-func (f *fakeRetrievalIndex) Search(vector []float32, k int) ([]uint64, []float32, error) {
-	f.lastK = k
-	return []uint64{}, []float32{}, nil
+func (f *fakeRetrievalIndex) Upsert(_ context.Context, _ []float32, _ model.IndexPayload) error {
+	return nil
 }
-func (f *fakeRetrievalIndex) Save(path string) error { return nil }
-func (f *fakeRetrievalIndex) Load(path string) error { return nil }
-func (f *fakeRetrievalIndex) Close() error           { return nil }
+func (f *fakeRetrievalIndex) Delete(_ context.Context, _ []uint64) error { return nil }
+func (f *fakeRetrievalIndex) Search(_ context.Context, _ []float32, k int, _ model.Filter) ([]model.IndexHit, error) {
+	f.lastK = k
+	return []model.IndexHit{}, nil
+}
+func (f *fakeRetrievalIndex) Identity(context.Context) (string, error) { return "", nil }
+func (f *fakeRetrievalIndex) Reset(context.Context, string) error      { return nil }
+func (f *fakeRetrievalIndex) Close() error                             { return nil }
+
+// hitsFrom builds IndexHits (chunk_id + score) from parallel label/score slices,
+// truncated to k. Payloads are intentionally empty: these fakes drive
+// materialisation through the service's in-memory chunk metadata and exercise
+// the overfetch fallback path (they do not implement FilteringIndex).
+func hitsFrom(labels []uint64, scores []float32, k int) []model.IndexHit {
+	if k > len(labels) {
+		k = len(labels)
+	}
+	out := make([]model.IndexHit, k)
+	for i := 0; i < k; i++ {
+		out[i] = model.IndexHit{ChunkID: labels[i], Score: scores[i]}
+	}
+	return out
+}
 
 type expandingRetrievalIndex struct {
 	labels  []uint64
@@ -158,19 +176,17 @@ type expandingRetrievalIndex struct {
 	queries []int
 }
 
-func (e *expandingRetrievalIndex) Add(label uint64, vector []float32) error { return nil }
-func (e *expandingRetrievalIndex) Search(vector []float32, k int) ([]uint64, []float32, error) {
-	e.queries = append(e.queries, k)
-	if k > len(e.labels) {
-		k = len(e.labels)
-	}
-	labels := append([]uint64(nil), e.labels[:k]...)
-	scores := append([]float32(nil), e.scores[:k]...)
-	return labels, scores, nil
+func (e *expandingRetrievalIndex) Upsert(_ context.Context, _ []float32, _ model.IndexPayload) error {
+	return nil
 }
-func (e *expandingRetrievalIndex) Save(path string) error { return nil }
-func (e *expandingRetrievalIndex) Load(path string) error { return nil }
-func (e *expandingRetrievalIndex) Close() error           { return nil }
+func (e *expandingRetrievalIndex) Delete(_ context.Context, _ []uint64) error { return nil }
+func (e *expandingRetrievalIndex) Search(_ context.Context, _ []float32, k int, _ model.Filter) ([]model.IndexHit, error) {
+	e.queries = append(e.queries, k)
+	return hitsFrom(e.labels, e.scores, k), nil
+}
+func (e *expandingRetrievalIndex) Identity(context.Context) (string, error) { return "", nil }
+func (e *expandingRetrievalIndex) Reset(context.Context, string) error      { return nil }
+func (e *expandingRetrievalIndex) Close() error                             { return nil }
 
 type cancelAfterFirstSearchIndex struct {
 	labels []uint64
@@ -179,20 +195,39 @@ type cancelAfterFirstSearchIndex struct {
 	cancel func()
 }
 
-func (c *cancelAfterFirstSearchIndex) Add(label uint64, vector []float32) error { return nil }
-func (c *cancelAfterFirstSearchIndex) Search(vector []float32, k int) ([]uint64, []float32, error) {
+func (c *cancelAfterFirstSearchIndex) Upsert(_ context.Context, _ []float32, _ model.IndexPayload) error {
+	return nil
+}
+func (c *cancelAfterFirstSearchIndex) Delete(_ context.Context, _ []uint64) error { return nil }
+func (c *cancelAfterFirstSearchIndex) Search(_ context.Context, _ []float32, k int, _ model.Filter) ([]model.IndexHit, error) {
 	c.calls++
 	if c.calls == 1 && c.cancel != nil {
 		c.cancel()
 	}
-	if k > len(c.labels) {
-		k = len(c.labels)
-	}
-	return append([]uint64(nil), c.labels[:k]...), append([]float32(nil), c.scores[:k]...), nil
+	return hitsFrom(c.labels, c.scores, k), nil
 }
-func (c *cancelAfterFirstSearchIndex) Save(path string) error { return nil }
-func (c *cancelAfterFirstSearchIndex) Load(path string) error { return nil }
-func (c *cancelAfterFirstSearchIndex) Close() error           { return nil }
+func (c *cancelAfterFirstSearchIndex) Identity(context.Context) (string, error) { return "", nil }
+func (c *cancelAfterFirstSearchIndex) Reset(context.Context, string) error      { return nil }
+func (c *cancelAfterFirstSearchIndex) Close() error                             { return nil }
+
+// addVec upserts a vector keyed by id with an empty payload (filtering driven by
+// the service's in-memory chunk metadata).
+func addVec(t *testing.T, idx *index.HNSWIndex, id uint64, vec []float32) {
+	t.Helper()
+	if err := idx.Upsert(context.Background(), vec, model.IndexPayload{ChunkID: id}); err != nil {
+		t.Fatalf("Upsert(%d) failed: %v", id, err)
+	}
+}
+
+// addVecP upserts a vector keyed by id with a rel_path/doc_type payload so a
+// FilteringIndex can evaluate pushed-down path/doctype predicates.
+func addVecP(t *testing.T, idx *index.HNSWIndex, id uint64, vec []float32, relPath, docType string) {
+	t.Helper()
+	payload := model.IndexPayload{ChunkID: id, RelPath: relPath, DocType: docType}
+	if err := idx.Upsert(context.Background(), vec, payload); err != nil {
+		t.Fatalf("Upsert(%d) failed: %v", id, err)
+	}
+}
 
 func (e *fakeRetrievalEmbedder) Embed(_ context.Context, modelName string, _ model.EmbedRole, texts []string) ([][]float32, error) {
 	// return one embedding per input text, matching the real embedder behaviour
@@ -219,9 +254,7 @@ func TestAsk_GeneratorErrorLogged(t *testing.T) {
 	buf := &bytes.Buffer{}
 
 	idx := index.NewHNSWIndex("")
-	if err := idx.Add(1, []float32{1, 0}); err != nil {
-		t.Fatalf("idx.Add failed: %v", err)
-	}
+	addVec(t, idx, 1, []float32{1, 0})
 
 	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{"mistral-embed": {1, 0}}}, &fakeGenerator{out: "unused", err: errors.New("oh no")})
 	svc.SetLogger(log.New(buf, "", 0))
@@ -247,15 +280,9 @@ func TestAsk_GeneratorErrorLogged(t *testing.T) {
 
 func TestSearch_ReturnsRankedHitsWithFilters(t *testing.T) {
 	idx := index.NewHNSWIndex("")
-	if err := idx.Add(1, []float32{1, 0}); err != nil {
-		t.Fatalf("idx.Add failed: %v", err)
-	}
-	if err := idx.Add(2, []float32{0.9, 0.1}); err != nil {
-		t.Fatalf("idx.Add failed: %v", err)
-	}
-	if err := idx.Add(3, []float32{0, 1}); err != nil {
-		t.Fatalf("idx.Add failed: %v", err)
-	}
+	addVecP(t, idx, 1, []float32{1, 0}, "docs/a.md", "md")
+	addVecP(t, idx, 2, []float32{0.9, 0.1}, "src/main.go", "code")
+	addVecP(t, idx, 3, []float32{0, 1}, "docs/b.md", "md")
 
 	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
 		"mistral-embed":   {1, 0},
@@ -285,12 +312,8 @@ func TestSearch_ReturnsRankedHitsWithFilters(t *testing.T) {
 
 func TestSearch_FileGlobFilter(t *testing.T) {
 	idx := index.NewHNSWIndex("")
-	if err := idx.Add(10, []float32{1, 0}); err != nil {
-		t.Fatalf("idx.Add failed: %v", err)
-	}
-	if err := idx.Add(20, []float32{0.8, 0.2}); err != nil {
-		t.Fatalf("idx.Add failed: %v", err)
-	}
+	addVecP(t, idx, 10, []float32{1, 0}, "src/a.go", "code")
+	addVecP(t, idx, 20, []float32{0.8, 0.2}, "docs/a.md", "md")
 
 	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
 		"mistral-embed":   {1, 0},
@@ -378,18 +401,10 @@ func TestSearch_OverflowProtection(t *testing.T) {
 func TestSearch_BothMode_DedupesAndNormalizes(t *testing.T) {
 	textIdx := index.NewHNSWIndex("")
 	codeIdx := index.NewHNSWIndex("")
-	if err := textIdx.Add(1, []float32{1, 0}); err != nil {
-		t.Fatalf("textIdx.Add failed: %v", err)
-	}
-	if err := textIdx.Add(2, []float32{0.8, 0.2}); err != nil {
-		t.Fatalf("textIdx.Add failed: %v", err)
-	}
-	if err := codeIdx.Add(2, []float32{0.9, 0.1}); err != nil { // duplicate label across indexes
-		t.Fatalf("codeIdx.Add failed: %v", err)
-	}
-	if err := codeIdx.Add(3, []float32{1, 0}); err != nil {
-		t.Fatalf("codeIdx.Add failed: %v", err)
-	}
+	addVec(t, textIdx, 1, []float32{1, 0})
+	addVec(t, textIdx, 2, []float32{0.8, 0.2})
+	addVec(t, codeIdx, 2, []float32{0.9, 0.1}) // duplicate label across indexes
+	addVec(t, codeIdx, 3, []float32{1, 0})
 
 	svc := retrieval.NewService(nil, textIdx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
 		"mistral-embed":   {1, 0},
@@ -632,9 +647,7 @@ func TestLooksLikeCodeQuery(t *testing.T) {
 
 func TestAsk_FallbackAndCitations(t *testing.T) {
 	idx := index.NewHNSWIndex("")
-	if err := idx.Add(1, []float32{1, 0}); err != nil {
-		t.Fatalf("idx.Add failed: %v", err)
-	}
+	addVec(t, idx, 1, []float32{1, 0})
 	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
 		"mistral-embed": {1, 0},
 	}}, nil)
@@ -757,9 +770,7 @@ func TestStats_FallbackFromListFiles(t *testing.T) {
 
 func TestAsk_UsesGeneratorWhenAvailable(t *testing.T) {
 	idx := index.NewHNSWIndex("")
-	if err := idx.Add(1, []float32{1, 0}); err != nil {
-		t.Fatalf("idx.Add failed: %v", err)
-	}
+	addVec(t, idx, 1, []float32{1, 0})
 	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
 		"mistral-embed": {1, 0},
 	}}, &fakeGenerator{out: "Generated answer with [docs/a.md]"})
@@ -780,9 +791,7 @@ func TestAsk_UsesGeneratorWhenAvailable(t *testing.T) {
 
 func TestAsk_UsesConfiguredSystemPromptAndContextBudget(t *testing.T) {
 	idx := index.NewHNSWIndex("")
-	if err := idx.Add(1, []float32{1, 0}); err != nil {
-		t.Fatalf("idx.Add failed: %v", err)
-	}
+	addVec(t, idx, 1, []float32{1, 0})
 
 	gen := &fakeGenerator{out: "ok [docs/a.md]"}
 	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
@@ -816,9 +825,7 @@ func TestAsk_UsesConfiguredSystemPromptAndContextBudget(t *testing.T) {
 
 func TestAsk_DefaultSystemPromptCompatibility(t *testing.T) {
 	idx := index.NewHNSWIndex("")
-	if err := idx.Add(1, []float32{1, 0}); err != nil {
-		t.Fatalf("idx.Add failed: %v", err)
-	}
+	addVec(t, idx, 1, []float32{1, 0})
 
 	gen := &fakeGenerator{out: "ok [docs/a.md]"}
 	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
@@ -836,12 +843,8 @@ func TestAsk_DefaultSystemPromptCompatibility(t *testing.T) {
 
 func TestAsk_AppendsMissingAttributions(t *testing.T) {
 	idx := index.NewHNSWIndex("")
-	if err := idx.Add(1, []float32{1, 0}); err != nil {
-		t.Fatalf("idx.Add failed: %v", err)
-	}
-	if err := idx.Add(2, []float32{0.9, 0.1}); err != nil {
-		t.Fatalf("idx.Add failed: %v", err)
-	}
+	addVec(t, idx, 1, []float32{1, 0})
+	addVec(t, idx, 2, []float32{0.9, 0.1})
 	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
 		"mistral-embed": {1, 0},
 	}}, &fakeGenerator{out: "Generated summary without explicit source tags."})
@@ -870,12 +873,8 @@ func TestAsk_AppendsMissingAttributions(t *testing.T) {
 
 func TestAsk_AppendsOnlyMissingAttributions(t *testing.T) {
 	idx := index.NewHNSWIndex("")
-	if err := idx.Add(1, []float32{1, 0}); err != nil {
-		t.Fatalf("idx.Add failed: %v", err)
-	}
-	if err := idx.Add(2, []float32{0.9, 0.1}); err != nil {
-		t.Fatalf("idx.Add failed: %v", err)
-	}
+	addVec(t, idx, 1, []float32{1, 0})
+	addVec(t, idx, 2, []float32{0.9, 0.1})
 	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
 		"mistral-embed": {1, 0},
 	}}, &fakeGenerator{out: "Generated summary with [docs/a.md] already present."})
@@ -913,9 +912,7 @@ func TestEvictDocument_RemovesChunksFromSearch(t *testing.T) {
 	idx := index.NewHNSWIndex("")
 	// labels 1 (docs/kept.md) and 2 (docs/deleted.md) are both in the index.
 	for _, l := range []uint64{1, 2} {
-		if err := idx.Add(l, []float32{1, 0}); err != nil {
-			t.Fatalf("idx.Add(%d): %v", l, err)
-		}
+		addVec(t, idx, l, []float32{1, 0})
 	}
 
 	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
@@ -962,9 +959,7 @@ func TestEvictDocument_RemovesChunksFromSearch(t *testing.T) {
 func TestEvictDocuments_RemovesMultipleDocumentsFromSearch(t *testing.T) {
 	idx := index.NewHNSWIndex("")
 	for _, l := range []uint64{1, 2, 3} {
-		if err := idx.Add(l, []float32{1, 0}); err != nil {
-			t.Fatalf("idx.Add(%d): %v", l, err)
-		}
+		addVec(t, idx, l, []float32{1, 0})
 	}
 
 	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
@@ -1068,9 +1063,7 @@ func TestSearch_StopsExpandingWhenContextCanceled(t *testing.T) {
 // results, exercising the matchFilters guard via the public API.
 func TestSearch_EmptyRelPathChunkNotReturned(t *testing.T) {
 	idx := index.NewHNSWIndex("")
-	if err := idx.Add(99, []float32{1, 0}); err != nil {
-		t.Fatalf("idx.Add: %v", err)
-	}
+	addVec(t, idx, 99, []float32{1, 0})
 
 	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
 		"mistral-embed": {1, 0},


### PR DESCRIPTION
## Summary

Formalizes a pluggable `model.Index` interface (issue #247) so external/on-disk vector backends can implement it, keeping the pure-Go in-memory HNSW as the conforming default with unchanged behavior and `CGO_ENABLED=0`.

Closes #247. Part of epic #250. Enables Tier B on-disk (#246), Qdrant (#268), and pgvector (#269) — those backends build on this interface.

## What changed

- **Core `Index`** (`internal/model/interfaces.go`): `Upsert(ctx, vector, IndexPayload)`, `Delete(ctx, chunkIDs)`, `Search(ctx, vector, k, Filter) []IndexHit`, `Identity`, `Reset`, `Close`.
- **Optional capabilities** (type-asserted, like `LexicalSearcher`/`MultimodalEmbedder`):
  - `Persistable` (`Save`/`Load`) — HNSW implements it; `PersistenceManager` type-asserts and skips backends that own their storage.
  - `FilteringIndex` (`CanFilter`) — when true, retrieval pushes the `Filter` down and trusts backend-filtered results; otherwise falls back to overfetch-then-filter.
- **New types** (`internal/model/types.go`): `IndexPayload`, `IndexHit`, `Filter` (with `IsZero`/`Match` reproducing `matchFilters`: path prefix, `path.Match` glob, case-insensitive doctype set, orphan exclusion).
- **HNSW conforms** (`internal/index/hnsw_index.go`): stores `payloads` + `identity`; `Search` scans cosine + `filter.Match` inline; `CanFilter` always true; `Save`/`Load` move under `Persistable`.
- **Retrieval** (`internal/retrieval/service.go`): `collectVectorCandidates` pushes the filter down via `FilteringIndex` when available (materializing from backend payload, falling back to in-memory chunk metadata), else keeps the widening overfetch loop. Hybrid RRF / media dedup / rerank unchanged.
- **Embedding worker**: `indexChunks` now `Upsert`s with an `IndexPayload` projected from `ChunkMetadata`.
- **Identity wiring**: `index.EnsureIdentity(ctx, idx, configuredIdentity)` per index at startup (`up`/`ask`), `Reset` on mismatch/empty; complements the existing process-level `VerifyEmbedIdentity`.

## Persistence-format decision

Bumped the on-disk filename to `vectors_{text,code}.v2.hnsw`, holding a self-describing gob struct (vectors + payloads + identity) instead of a bare `map[uint64][]float32`. A missing v2 file is treated as **fresh / repopulated by reindex** — legacy bare-map files are never decoded, avoiding gob ambiguity. `reindex` removes both v2 and legacy files.

## Interface deviations / blast radius

- `Index` method signatures changed (`Add`→`Upsert`, `Search` now takes `ctx`+`Filter` and returns `[]IndexHit`, `Save`/`Load` gained `ctx` and moved under `Persistable`). Updated all call sites: `internal/cli/{up,app,reindex}.go`, `internal/index/{persistence,embedding_worker}.go`, `internal/retrieval/service.go`, and every test fake.
- `ExcludeOrphans` is intentionally **not** pushed down: orphan/eviction state lives in the retrieval service's in-memory chunk metadata (not the backend payload), so it's enforced by the post-materialization `matchFilters` re-check. The in-memory metadata stays authoritative for the default HNSW path, so eviction behavior is preserved.
- Scope held: no Qdrant/pgvector/on-disk backends; submodule not re-pinned.

## Tests

New `tests/index/pluggable_index_test.go` (Upsert+Search with doctype/prefix/glob filters, Delete, Identity/Reset, EnsureIdentity, CanFilter), `tests/retrieval/pushdown_test.go` (push-down end-to-end with payload materialization via an external-backend-style fake), and a worker payload-projection test. Existing HNSW/retrieval/persistence tests and fakes updated to the new interface.

`make check` passes (exit 0); `CGO_ENABLED=0 go build ./...` clean.