### PR TITLE
feat(index): pure-Go on-disk vector backend + index.backend selector (#246)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/pdfcpu/pdfcpu v0.12.1
 	github.com/x402-foundation/x402/go v0.0.0-20260516161513-e35becffdc85
 	github.com/zalando/go-keyring v0.2.8
+	golang.org/x/exp v0.0.0-20231108232855-2478ac86f678
 	golang.org/x/term v0.42.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.32.0

--- a/internal/cli/reindex.go
+++ b/internal/cli/reindex.go
@@ -95,10 +95,11 @@ func (a *App) prepareReindexStore(ctx context.Context, global globalOptions, cfg
 		_ = st.Close()
 		return nil, code
 	}
-	// Remove both the current v2 snapshot files and the legacy pre-#247
-	// bare-map files so a stale snapshot of either shape cannot survive a
-	// reindex.
-	staleNames := append([]string{index.TextIndexFileName, index.CodeIndexFileName}, index.LegacyIndexFileNames...)
+	// Remove stale vector index files so a snapshot of any shape cannot survive
+	// a reindex: the current HNSW v2 files, the legacy pre-#247 bare-map files,
+	// and — when the disk backend is selected — its segment + identity sidecar
+	// (issue #246).
+	staleNames := index.StaleIndexFiles(cfg.IndexBackend)
 	for _, name := range staleNames {
 		indexPath := filepath.Join(cfg.StateDir, name)
 		if err := os.Remove(indexPath); err != nil && !errors.Is(err, os.ErrNotExist) {

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -54,13 +54,13 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 		return code
 	}
 
-	st, textIx, codeIx, code := a.initStoreAndIndices(ctx, &cfg, opts.jsonOutput)
+	st, textBuilt, codeBuilt, code := a.initStoreAndIndices(ctx, &cfg, opts.jsonOutput)
 	if code != exitSuccess {
 		return code
 	}
 	defer func() { _ = st.Close() }()
-	textIndexPath := filepath.Join(cfg.StateDir, index.TextIndexFileName)
-	codeIndexPath := filepath.Join(cfg.StateDir, index.CodeIndexFileName)
+	textIx, textIndexPath := textBuilt.index, textBuilt.path
+	codeIx, codeIndexPath := codeBuilt.index, codeBuilt.path
 	defer func() { _ = textIx.Close() }()
 	defer func() { _ = codeIx.Close() }()
 
@@ -437,59 +437,69 @@ func requiresMistralAPIKey(opts upOptions) bool {
 	return !opts.readOnly
 }
 
-// initStoreAndIndices initialises the metadata store and both HNSW indices.
-// On success the caller is responsible for closing all three.
-func (a *App) initStoreAndIndices(ctx context.Context, cfg *config.Config, jsonOutput bool) (model.Store, model.Index, model.Index, int) {
+// builtIndex pairs a constructed vector index with the on-disk path it persists
+// to, so runUp can wire the PersistenceManager with the backend-appropriate
+// path (HNSW v2 snapshot vs. disk segment).
+type builtIndex struct {
+	index model.Index
+	path  string
+}
+
+// initStoreAndIndices initialises the metadata store and both vector indices,
+// dispatching on cfg.IndexBackend ("memory" default | "disk", issue #246). On
+// success the caller is responsible for closing all three.
+func (a *App) initStoreAndIndices(ctx context.Context, cfg *config.Config, jsonOutput bool) (model.Store, builtIndex, builtIndex, int) {
 	st := a.storeForConfig(*cfg)
 	if err := st.Init(ctx); err != nil && !errors.Is(err, model.ErrNotImplemented) {
 		writeCLIError(a.stderr, jsonOutput, exitIndexLoadFailure, fmt.Sprintf("initialize metadata store: %v", err))
-		return nil, nil, nil, exitIndexLoadFailure
+		return nil, builtIndex{}, builtIndex{}, exitIndexLoadFailure
 	}
 
-	// The persisted snapshot format is versioned (vectors_*.v2.hnsw, issue
-	// #247): the v2 file carries vectors + per-vector payloads + the embed
-	// identity, where the legacy file held a bare vector map. A missing v2 file
-	// (incl. an existing corpus that only has the legacy file) is treated as a
-	// fresh index and repopulated on the next reindex — we deliberately do not
-	// decode legacy files to avoid gob ambiguity between the two shapes.
+	// The persisted snapshot format is versioned (issue #247): for the memory
+	// backend the v2 file (vectors_*.v2.hnsw) carries vectors + per-vector
+	// payloads + the embed identity, where the legacy file held a bare vector
+	// map; for the disk backend the segment (vectors_*.diskv1.idx) memory-maps
+	// vector payloads on disk (issue #246). A missing snapshot is treated as a
+	// fresh index and repopulated on the next reindex.
 	identity := cfg.Providers().EmbedIdentity()
-	textIx, code := a.loadHNSWIndex(ctx, cfg, index.TextIndexFileName, "text", identity, jsonOutput)
+	textIx, code := a.loadVectorIndex(ctx, cfg, index.KindText, identity, jsonOutput)
 	if code != exitSuccess {
 		_ = st.Close()
-		return nil, nil, nil, code
+		return nil, builtIndex{}, builtIndex{}, code
 	}
-	codeIx, code := a.loadHNSWIndex(ctx, cfg, index.CodeIndexFileName, "code", identity, jsonOutput)
+	codeIx, code := a.loadVectorIndex(ctx, cfg, index.KindCode, identity, jsonOutput)
 	if code != exitSuccess {
 		_ = st.Close()
-		_ = textIx.Close()
-		return nil, nil, nil, code
+		_ = textIx.index.Close()
+		return nil, builtIndex{}, builtIndex{}, code
 	}
 
 	return st, textIx, codeIx, exitSuccess
 }
 
-// loadHNSWIndex constructs a persisted HNSW index, restores it from its v2
-// snapshot, and reconciles its recorded embed identity with the configured one
-// (issue #247): EnsureIdentity resets the index when the identity is empty
-// (fresh) or differs, so a vector space built under a different embed
-// provider/model/dimension is never silently reused. fileName is the basename
-// under cfg.StateDir; kind is used only for error messages.
-func (a *App) loadHNSWIndex(ctx context.Context, cfg *config.Config, fileName, kind, identity string, jsonOutput bool) (model.Index, int) {
-	path := filepath.Join(cfg.StateDir, fileName)
-	ix := index.NewHNSWIndex(path)
-	if err := ix.Load(ctx, path); err != nil &&
-		!errors.Is(err, model.ErrNotImplemented) &&
-		!errors.Is(err, os.ErrNotExist) {
-		writeCLIError(a.stderr, jsonOutput, exitIndexLoadFailure, fmt.Sprintf("load %s index: %v", kind, err))
-		_ = ix.Close()
-		return nil, exitIndexLoadFailure
+// loadVectorIndex constructs the configured vector backend for one kind via the
+// index.backend dispatch (issue #246; #268/#269 will extend the switch),
+// restores it from its persisted snapshot, and reconciles its recorded embed
+// identity with the configured one (issue #247): EnsureIdentity resets the index
+// when the identity is empty (fresh) or differs, so a vector space built under a
+// different embed provider/model/dimension is never silently reused.
+func (a *App) loadVectorIndex(ctx context.Context, cfg *config.Config, kind, identity string, jsonOutput bool) (builtIndex, int) {
+	ix, path := index.NewBackend(cfg.IndexBackend, cfg.StateDir, kind)
+	if p, ok := ix.(model.Persistable); ok {
+		if err := p.Load(ctx, path); err != nil &&
+			!errors.Is(err, model.ErrNotImplemented) &&
+			!errors.Is(err, os.ErrNotExist) {
+			writeCLIError(a.stderr, jsonOutput, exitIndexLoadFailure, fmt.Sprintf("load %s index: %v", kind, err))
+			_ = ix.Close()
+			return builtIndex{}, exitIndexLoadFailure
+		}
 	}
 	if err := index.EnsureIdentity(ctx, ix, identity); err != nil {
 		writeCLIError(a.stderr, jsonOutput, exitIndexLoadFailure, fmt.Sprintf("reconcile %s index identity: %v", kind, err))
 		_ = ix.Close()
-		return nil, exitIndexLoadFailure
+		return builtIndex{}, exitIndexLoadFailure
 	}
-	return ix, exitSuccess
+	return builtIndex{index: ix, path: path}, exitSuccess
 }
 
 // buildMCPServerOptions constructs the list of mcp.ServerOption values,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -137,6 +137,15 @@ type Config struct {
 	IngestAudioMode      string
 	IngestArchivesMode   string
 	IngestExtractor      string
+
+	// IndexBackend selects the vector index backend (issue #246): "memory"
+	// (default, the in-memory HNSW) or "disk" (the Tier-B pure-Go on-disk
+	// backend that keeps vector payloads memory-mapped on disk for corpora
+	// that exceed RAM). The "memory" default is byte-identical to legacy
+	// behavior. This is the backend-selection seam future networked backends
+	// (#268 Qdrant, #269 pgvector) extend.
+	IndexBackend string
+
 	// IngestWatch enables a filesystem watcher so a running server keeps
 	// indexing added/changed/deleted files after the initial scan. Opt-in.
 	IngestWatch bool
@@ -224,6 +233,7 @@ type fileConfig struct {
 	IngestAudioMode           *string
 	IngestArchivesMode        *string
 	IngestExtractor           *string
+	IndexBackend              *string
 	IngestWatch               *bool
 	IngestWatchDebounce       *time.Duration
 	STTProvider               *string
@@ -299,6 +309,7 @@ type persistedConfig struct {
 	IngestAudioMode           string        `yaml:"ingest_audio_mode"`
 	IngestArchivesMode        string        `yaml:"ingest_archives_mode"`
 	IngestExtractor           string        `yaml:"ingest_extractor"`
+	IndexBackend              string        `yaml:"index_backend"`
 	IngestWatch               bool          `yaml:"ingest_watch"`
 	IngestWatchDebounce       time.Duration `yaml:"ingest_watch_debounce"`
 	STTProvider               string        `yaml:"stt_provider"`
@@ -399,6 +410,7 @@ func Default() Config {
 		IngestAudioMode:           "auto",
 		IngestArchivesMode:        "deep",
 		IngestExtractor:           "auto",
+		IndexBackend:              "memory",
 		IngestWatch:               false,
 		IngestWatchDebounce:       500 * time.Millisecond,
 		STTProvider:               "mistral",
@@ -487,6 +499,7 @@ func buildPersistedConfig(cfg *Config) persistedConfig {
 		IngestAudioMode:           cfg.IngestAudioMode,
 		IngestArchivesMode:        cfg.IngestArchivesMode,
 		IngestExtractor:           cfg.IngestExtractor,
+		IndexBackend:              cfg.IndexBackend,
 		IngestWatch:               cfg.IngestWatch,
 		IngestWatchDebounce:       cfg.IngestWatchDebounce,
 		STTProvider:               cfg.STTProvider,
@@ -1019,6 +1032,9 @@ func applyIngestModesFileParsed(cfg *Config, fc fileConfig) {
 	if fc.IngestExtractor != nil {
 		cfg.IngestExtractor = *fc.IngestExtractor
 	}
+	if fc.IndexBackend != nil {
+		cfg.IndexBackend = *fc.IndexBackend
+	}
 	if fc.IngestWatch != nil {
 		cfg.IngestWatch = *fc.IngestWatch
 	}
@@ -1305,6 +1321,8 @@ var configKeyAliases = map[string]string{
 	"archives_mode":                        "ingest.archives.mode",
 	"ingest_extractor":                     "ingest.extractor",
 	"extractor":                            "ingest.extractor",
+	"index_backend":                        "index.backend",
+	"backend":                              "index.backend",
 	"stt_provider":                         "stt.provider",
 	"stt_mistral_model":                    "stt.mistral.model",
 	"stt_elevenlabs_model":                 "stt.elevenlabs.model",
@@ -1344,7 +1362,7 @@ func canonicalizeConfigKey(key string) string {
 // (so child keys should be prefixed) rather than a scalar/list key.
 func isMapSectionKey(key string) bool {
 	switch key {
-	case "rag", "ingest", "ingest.docling", "stt", "stt.mistral", "stt.elevenlabs", "server", "server.tls", "secret_sources", "mistral", "docling", "security", "security.auth", "x402", "x402.route_policy", "x402.route_policy.tools_call", "chunking", "retrieval", "retrieval.hybrid", "rerank", "rerank.cohere":
+	case "rag", "ingest", "ingest.docling", "stt", "stt.mistral", "stt.elevenlabs", "server", "server.tls", "secret_sources", "mistral", "docling", "security", "security.auth", "x402", "x402.route_policy", "x402.route_policy.tools_call", "chunking", "retrieval", "retrieval.hybrid", "rerank", "rerank.cohere", "index":
 		return true
 	case "ingest.pdf", "ingest.images", "ingest.audio", "ingest.archives", "secrets":
 		return true
@@ -1563,6 +1581,8 @@ func setIngestStringFileScalar(cfg *fileConfig, key, value string) {
 		cfg.IngestArchivesMode = strPtr(value)
 	case "ingest.extractor":
 		cfg.IngestExtractor = strPtr(value)
+	case "index.backend":
+		cfg.IndexBackend = strPtr(value)
 	case "stt.provider":
 		cfg.STTProvider = strPtr(value)
 	case "stt.mistral.model":
@@ -1713,6 +1733,7 @@ func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	writeScalar("ingest_audio_mode", cfg.IngestAudioMode)
 	writeScalar("ingest_archives_mode", cfg.IngestArchivesMode)
 	writeScalar("ingest_extractor", cfg.IngestExtractor)
+	writeScalar("index_backend", cfg.IndexBackend)
 	writeBool("ingest_watch", cfg.IngestWatch)
 	writeScalar("ingest_watch_debounce", cfg.IngestWatchDebounce.String())
 	writeScalar("stt_provider", cfg.STTProvider)
@@ -1812,14 +1833,21 @@ func applyRerankEnvOverrides(cfg *Config, env map[string]string) {
 // (expanded at resolution time); base URL / model overrides go through
 // providers:/model: in .dir2mcp.yaml.
 func applyIngestEnvOverrides(cfg *Config, env map[string]string) {
-	if raw, ok := envLookup("DIR2MCP_DOCLING_COMMAND", env); ok && strings.TrimSpace(raw) != "" {
-		cfg.DoclingCommand = strings.TrimSpace(raw)
-	}
-	if raw, ok := envLookup("DIR2MCP_DOCLING_SERVE_URL", env); ok && strings.TrimSpace(raw) != "" {
-		cfg.IngestDoclingServeURL = strings.TrimSpace(raw)
-	}
-	if raw, ok := envLookup("DIR2MCP_INGEST_EXTRACTOR", env); ok && strings.TrimSpace(raw) != "" {
-		cfg.IngestExtractor = strings.TrimSpace(raw)
+	// Trimmed string overrides applied only when the variable is set and
+	// non-empty; collected in a table so adding a field stays linear in
+	// cyclomatic complexity.
+	for _, o := range []struct {
+		key   string
+		field *string
+	}{
+		{"DIR2MCP_DOCLING_COMMAND", &cfg.DoclingCommand},
+		{"DIR2MCP_DOCLING_SERVE_URL", &cfg.IngestDoclingServeURL},
+		{"DIR2MCP_INGEST_EXTRACTOR", &cfg.IngestExtractor},
+		{"DIR2MCP_INDEX_BACKEND", &cfg.IndexBackend},
+	} {
+		if raw, ok := envLookup(o.key, env); ok && strings.TrimSpace(raw) != "" {
+			*o.field = strings.TrimSpace(raw)
+		}
 	}
 	if raw, ok := envLookup("DIR2MCP_INGEST_WATCH", env); ok && strings.TrimSpace(raw) != "" {
 		if parsed, err := strconv.ParseBool(strings.TrimSpace(raw)); err == nil {
@@ -2006,6 +2034,10 @@ func (c *Config) Validate() error {
 		return err
 	}
 
+	if err := c.validateIndexBackend(); err != nil {
+		return err
+	}
+
 	if err := c.validateNumericBounds(); err != nil {
 		return err
 	}
@@ -2030,6 +2062,23 @@ func (c *Config) validateIngestExtractor() error {
 		return fmt.Errorf("ingest.extractor must be one of auto, docling, docling-serve, mistral, off: %q", c.IngestExtractor)
 	}
 	c.IngestExtractor = extractorMode
+	return nil
+}
+
+// validateIndexBackend normalizes IndexBackend (defaulting empty to the
+// "memory" baseline) and rejects any value outside memory/disk (issue #246).
+// Future networked backends (#268 Qdrant, #269 pgvector) extend this set.
+func (c *Config) validateIndexBackend() error {
+	backend := strings.ToLower(strings.TrimSpace(c.IndexBackend))
+	if backend == "" {
+		backend = Default().IndexBackend
+	}
+	switch backend {
+	case "memory", "disk":
+	default:
+		return fmt.Errorf("index.backend must be one of memory, disk: %q", c.IndexBackend)
+	}
+	c.IndexBackend = backend
 	return nil
 }
 

--- a/internal/index/backend.go
+++ b/internal/index/backend.go
@@ -1,0 +1,73 @@
+package index
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/dirstral/dir2mcp/internal/index/diskindex"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// Backend names for the index.backend selector (issue #246). The seam is
+// deliberately small so future networked backends (#268 Qdrant, #269 pgvector)
+// extend it with new cases rather than reworking the dispatch.
+const (
+	BackendMemory = "memory"
+	BackendDisk   = "disk"
+)
+
+// IndexKind names the two per-corpus vector indices.
+const (
+	KindText = "text"
+	KindCode = "code"
+)
+
+// NewBackend constructs the configured vector index for one kind ("text" or
+// "code") behind the model.Index interface, returning the constructed index and
+// the on-disk path it persists to (used by the caller to wire the
+// PersistenceManager and reindex cleanup).
+//
+//   - "memory" (default): the in-memory HNSW reference, persisted to the
+//     versioned vectors_<kind>.v2.hnsw snapshot. This path is byte-identical to
+//     legacy behavior.
+//   - "disk": the Tier-B pure-Go on-disk backend (internal/index/diskindex),
+//     persisted to vectors_<kind>.diskv1.idx with vector payloads kept
+//     memory-mapped on disk so the corpus is not bounded by RAM.
+//
+// An empty/unknown backend falls back to "memory"; config validation already
+// rejects unknown values, so this is defensive only.
+func NewBackend(backend, stateDir, kind string) (model.Index, string) {
+	switch strings.ToLower(strings.TrimSpace(backend)) {
+	case BackendDisk:
+		path := filepath.Join(stateDir, diskindex.SegmentFileName(kind))
+		return diskindex.New(path), path
+	default:
+		path := filepath.Join(stateDir, kindSnapshotFileName(kind))
+		return NewHNSWIndex(path), path
+	}
+}
+
+// kindSnapshotFileName maps an index kind to its HNSW v2 snapshot basename.
+func kindSnapshotFileName(kind string) string {
+	if kind == KindCode {
+		return CodeIndexFileName
+	}
+	return TextIndexFileName
+}
+
+// StaleIndexFiles returns the basenames that a reindex must remove from the
+// state directory for the given backend so a stale snapshot of any shape cannot
+// survive a rebuild. The HNSW basenames (current v2 + legacy) are always
+// included because a corpus may have been built under the memory backend before
+// switching; the disk backend's segment + identity sidecar are added when
+// selected.
+func StaleIndexFiles(backend string) []string {
+	names := append([]string{TextIndexFileName, CodeIndexFileName}, LegacyIndexFileNames...)
+	if strings.EqualFold(strings.TrimSpace(backend), BackendDisk) {
+		for _, kind := range []string{KindText, KindCode} {
+			seg := diskindex.SegmentFileName(kind)
+			names = append(names, seg, seg+diskindex.IdentitySidecarSuffix)
+		}
+	}
+	return names
+}

--- a/internal/index/diskindex/diskindex.go
+++ b/internal/index/diskindex/diskindex.go
@@ -238,14 +238,20 @@ func (d *DiskIndex) Search(ctx context.Context, vector []float32, k int, filter 
 		return []model.IndexHit{}, nil
 	}
 
+	// Lazily (re)open the mmap view under the write lock so the assignment to
+	// d.reader cannot race with a concurrent Search; the subsequent scan holds
+	// the read lock, during which no mutation can invalidate the view.
+	if err := d.ensureReader(); err != nil {
+		return nil, err
+	}
+
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
-	reader, err := d.readerLocked()
-	if err != nil {
-		return nil, err
-	}
+	reader := d.reader
 	if reader == nil {
+		// A concurrent mutation invalidated the view (or the segment is empty);
+		// with nothing mapped there is nothing to score.
 		return []model.IndexHit{}, nil
 	}
 
@@ -501,10 +507,22 @@ func (d *DiskIndex) Close() error {
 	return d.invalidateReaderLocked()
 }
 
+// ensureReader opens the mmap view if it is not already cached, taking the
+// write lock so the assignment to d.reader is exclusive (Search holds only the
+// read lock for its scan and must not write d.reader concurrently). A missing
+// segment file (fresh index) is not an error; d.reader simply stays nil.
+func (d *DiskIndex) ensureReader() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	_, err := d.readerLocked()
+	return err
+}
+
 // readerLocked returns the mmap reader, opening it lazily. Returns (nil, nil)
 // when no segment file exists yet (fresh index). The cached view is invalidated
 // on every mutation (appendRecord/Reset/Save), so a held view always reflects
-// the on-disk bytes the current locator offsets point at.
+// the on-disk bytes the current locator offsets point at. Callers must hold the
+// write lock (it may assign d.reader).
 func (d *DiskIndex) readerLocked() (*mmap.ReaderAt, error) {
 	if d.reader != nil {
 		return d.reader, nil

--- a/internal/index/diskindex/diskindex.go
+++ b/internal/index/diskindex/diskindex.go
@@ -1,0 +1,726 @@
+// Package diskindex implements the Tier-B on-disk vector backend (issue #246).
+//
+// It satisfies the merged pluggable model.Index contract (plus the optional
+// Persistable and FilteringIndex capabilities) exactly like the in-memory HNSW
+// reference (internal/index.HNSWIndex), but removes the all-vectors-in-RAM
+// ceiling: the navigational metadata (one fixed-size locator per chunk) stays
+// in a Go map, while the dense vector payloads live in a single on-disk segment
+// file that is memory-mapped and read on demand at search time.
+//
+// The whole point of Tier B is "no C extension": the implementation is pure Go.
+// It uses golang.org/x/exp/mmap (a pure-Go ReaderAt over a mmap'd file on
+// supported platforms, falling back to read syscalls otherwise) — there is no
+// cgo. The package therefore builds and runs with CGO_ENABLED=0.
+//
+// On-disk format (segment file, see writeRecord / scanSegment):
+//
+//	[8]  magic   "D2MDISK1"
+//	[4]  version uint32 (=1)
+//	... then a stream of records, each:
+//	[8]  chunkID    uint64 (little-endian)
+//	[1]  tombstone  byte   (0 = live, 1 = deleted)
+//	[4]  vecLen     uint32 (number of float32 elements)
+//	[4]  payloadLen uint32 (gob-encoded model.IndexPayload byte length)
+//	[vecLen*4] vector  float32 little-endian
+//	[payloadLen] payload gob bytes
+//
+// Mutations append a new record (Upsert) or a tombstone record (Delete); the
+// in-RAM locator map always points at the latest record for a chunk so the
+// effective state is the last-writer-wins fold over the log. Save() compacts the
+// live set into a fresh segment via atomic temp-file rename, reclaiming the
+// space held by superseded/tombstoned records. The identity (SPEC 8.1.4) is
+// stored in a sibling JSON file so it survives reopen without parsing vectors.
+package diskindex
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/binary"
+	"encoding/gob"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"sort"
+	"sync"
+
+	"golang.org/x/exp/mmap"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+const (
+	segmentMagic   = "D2MDISK1"
+	segmentVersion = uint32(1)
+	headerLen      = len(segmentMagic) + 4 // magic + version
+	recordHdrLen   = 8 + 1 + 4 + 4         // chunkID + tombstone + vecLen + payloadLen
+)
+
+// SegmentFileName is the on-disk segment basename for an index "kind"
+// (text/code). It mirrors index.TextIndexFileName / CodeIndexFileName but for
+// the disk backend, and is deliberately distinct so the two backends never
+// alias each other's files.
+func SegmentFileName(kind string) string {
+	return "vectors_" + kind + ".diskv1.idx"
+}
+
+// IdentitySidecarSuffix is appended to a segment path to locate the JSON
+// sidecar that stores the recorded embed identity. Exported so reindex cleanup
+// (internal/index.StaleIndexFiles) can name the sidecar without hardcoding it.
+const IdentitySidecarSuffix = ".identity.json"
+
+// identitySidecarPath returns the path of the JSON sidecar holding the recorded
+// embed identity for the given segment path.
+func identitySidecarPath(segmentPath string) string {
+	return segmentPath + IdentitySidecarSuffix
+}
+
+// locator records where a chunk's latest record lives in the segment file plus
+// its fixed-size shape, so the vector/payload can be read on demand without
+// holding them in RAM. This is the only per-vector state kept resident.
+type locator struct {
+	offset     int64
+	vecLen     uint32
+	payloadLen uint32
+}
+
+// DiskIndex is the on-disk backend. Only the locator map and identity are
+// resident; vectors/payloads are read from the mmap'd segment on demand.
+type DiskIndex struct {
+	path string
+
+	mu        sync.RWMutex
+	locators  map[uint64]locator
+	identity  string
+	appendEnd int64          // current end-of-file offset for the append log
+	reader    *mmap.ReaderAt // mmap view of the segment, nil until first read/Load
+}
+
+// compile-time assertions: DiskIndex satisfies the core contract and both
+// optional capabilities (issue #246/#247).
+var (
+	_ model.Index          = (*DiskIndex)(nil)
+	_ model.Persistable    = (*DiskIndex)(nil)
+	_ model.FilteringIndex = (*DiskIndex)(nil)
+)
+
+// New creates an empty disk index. path is the segment file used by Save/Load
+// and the append log; it may be empty for a purely in-process instance, in
+// which case Save/Load require an explicit path argument.
+func New(path string) *DiskIndex {
+	return &DiskIndex{
+		path:     path,
+		locators: make(map[uint64]locator),
+	}
+}
+
+// Upsert appends the vector+payload as the newest record and points the locator
+// at it. An empty vector or zero chunk_id is an error (matching HNSWIndex).
+func (d *DiskIndex) Upsert(ctx context.Context, vector []float32, payload model.IndexPayload) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if len(vector) == 0 {
+		return errors.New("vector cannot be empty")
+	}
+	if payload.ChunkID == 0 {
+		return errors.New("payload chunk_id cannot be zero")
+	}
+	if d.path == "" {
+		return errors.New("disk index requires a path")
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.appendRecord(payload.ChunkID, false, vector, payload)
+}
+
+// Delete writes a tombstone record for each id and drops the locator. Unknown
+// ids are ignored. Tombstones keep the on-disk log append-only and consistent;
+// space is reclaimed on the next Save (compaction).
+func (d *DiskIndex) Delete(ctx context.Context, chunkIDs []uint64) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if len(chunkIDs) == 0 {
+		return nil
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for _, id := range chunkIDs {
+		if _, ok := d.locators[id]; !ok {
+			continue
+		}
+		if err := d.appendRecord(id, true, nil, model.IndexPayload{}); err != nil {
+			return err
+		}
+		delete(d.locators, id)
+	}
+	return nil
+}
+
+// appendRecord appends one record to the segment, creating/initialising the
+// file (with header) on first write, and updates the locator map. The caller
+// must hold the write lock.
+func (d *DiskIndex) appendRecord(chunkID uint64, tombstone bool, vector []float32, payload model.IndexPayload) error {
+	f, err := os.OpenFile(d.path, os.O_RDWR|os.O_CREATE, 0o644)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	if err := d.ensureAppendEnd(f); err != nil {
+		return err
+	}
+	if _, err := f.Seek(d.appendEnd, io.SeekStart); err != nil {
+		return err
+	}
+	payloadBytes, err := encodePayload(payload)
+	if err != nil {
+		return err
+	}
+	recOffset := d.appendEnd
+	n, err := writeRecord(f, chunkID, tombstone, vector, payloadBytes)
+	if err != nil {
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		return err
+	}
+	d.appendEnd += int64(n)
+
+	if !tombstone {
+		d.locators[chunkID] = locator{
+			offset:     recOffset,
+			vecLen:     uint32(len(vector)),
+			payloadLen: uint32(len(payloadBytes)),
+		}
+	}
+	// The mmap view is now stale (file grew); drop it so the next read re-maps.
+	return d.invalidateReaderLocked()
+}
+
+// ensureAppendEnd initialises d.appendEnd from the open file, writing the header
+// on a fresh/empty file. Caller holds the write lock.
+func (d *DiskIndex) ensureAppendEnd(f *os.File) error {
+	if d.appendEnd != 0 {
+		return nil
+	}
+	info, err := f.Stat()
+	if err != nil {
+		return err
+	}
+	if info.Size() == 0 {
+		if err := writeHeader(f); err != nil {
+			return err
+		}
+		d.appendEnd = int64(headerLen)
+		return nil
+	}
+	d.appendEnd = info.Size()
+	return nil
+}
+
+// Search reads each candidate vector on demand from the mmap'd segment, scores
+// it by cosine similarity, and returns the k best (best-first). The filter is
+// applied over the on-disk payload via model.Filter.Match, so CanFilter is true.
+func (d *DiskIndex) Search(ctx context.Context, vector []float32, k int, filter model.Filter) ([]model.IndexHit, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if len(vector) == 0 {
+		return nil, errors.New("query vector cannot be empty")
+	}
+	if k <= 0 {
+		return []model.IndexHit{}, nil
+	}
+
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	reader, err := d.readerLocked()
+	if err != nil {
+		return nil, err
+	}
+	if reader == nil {
+		return []model.IndexHit{}, nil
+	}
+
+	applyFilter := !filter.IsZero()
+	scored := make([]model.IndexHit, 0, len(d.locators))
+	for id, loc := range d.locators {
+		if int(loc.vecLen) != len(vector) {
+			continue // dimension mismatch; skip like HNSW does
+		}
+		vec, payload, rerr := readRecordAt(reader, loc)
+		if rerr != nil {
+			return nil, rerr
+		}
+		if applyFilter && !filter.Match(payload) {
+			continue
+		}
+		scored = append(scored, model.IndexHit{
+			ChunkID: id,
+			Score:   cosineSimilarity(vector, vec),
+			Payload: payload,
+		})
+	}
+
+	sortHits(scored)
+	if len(scored) > k {
+		scored = scored[:k]
+	}
+	return scored, nil
+}
+
+// sortHits orders hits best-first with a deterministic chunkID tiebreak,
+// matching HNSWIndex.Search.
+func sortHits(hits []model.IndexHit) {
+	const eps = 1e-6
+	sort.Slice(hits, func(a, b int) bool {
+		diff := math.Abs(float64(hits[a].Score) - float64(hits[b].Score))
+		if diff <= eps {
+			return hits[a].ChunkID < hits[b].ChunkID
+		}
+		return hits[a].Score > hits[b].Score
+	})
+}
+
+// CanFilter reports that the backend evaluates filters itself: Search applies
+// model.Filter.Match over the on-disk payloads, so retrieval may push the
+// filter down rather than overfetch-then-filter.
+func (d *DiskIndex) CanFilter(filter model.Filter) bool {
+	return true
+}
+
+// Identity returns the recorded corpus-lifetime embed identity, or "" when
+// fresh.
+func (d *DiskIndex) Identity(ctx context.Context) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.identity, nil
+}
+
+// Reset discards all vectors/payloads (truncating the segment back to a fresh
+// header) and records identity as the new corpus-lifetime embed identity.
+func (d *DiskIndex) Reset(ctx context.Context, identity string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if err := d.invalidateReaderLocked(); err != nil {
+		return err
+	}
+	d.locators = make(map[uint64]locator)
+	d.identity = identity
+	d.appendEnd = 0
+
+	if d.path == "" {
+		return nil
+	}
+	if err := truncateSegment(d.path); err != nil {
+		return err
+	}
+	d.appendEnd = int64(headerLen)
+	return writeIdentitySidecar(identitySidecarPath(d.path), identity)
+}
+
+// truncateSegment rewrites path with just a fresh header.
+func truncateSegment(path string) error {
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	if err := writeHeader(f); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return err
+	}
+	return f.Close()
+}
+
+// Save compacts the live records into a fresh segment file at path (atomic
+// temp-file rename), reclaiming space held by superseded/tombstoned records,
+// and writes the identity sidecar. Vectors are streamed from the current mmap'd
+// segment to the new file without ever holding the whole corpus in RAM.
+func (d *DiskIndex) Save(ctx context.Context, path string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if path == "" {
+		path = d.path
+	}
+	if path == "" {
+		return errors.New("path is required")
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	reader, err := d.readerLocked()
+	if err != nil {
+		return err
+	}
+
+	tmpPath := path + ".tmp"
+	out, err := os.Create(tmpPath)
+	if err != nil {
+		return err
+	}
+	newLocators, newEnd, err := d.compactInto(out, reader)
+	if err != nil {
+		_ = out.Close()
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err := finalizeFile(out, tmpPath, path); err != nil {
+		return err
+	}
+
+	// Point ourselves at the freshly written, compacted segment.
+	d.path = path
+	d.locators = newLocators
+	d.appendEnd = newEnd
+	if err := d.invalidateReaderLocked(); err != nil {
+		return err
+	}
+	return writeIdentitySidecar(identitySidecarPath(path), d.identity)
+}
+
+// compactInto writes the header and every live record to out (buffered),
+// returning the rebuilt locator map and end offset. Caller holds the lock.
+func (d *DiskIndex) compactInto(out *os.File, reader *mmap.ReaderAt) (map[uint64]locator, int64, error) {
+	w := bufio.NewWriter(out)
+	if err := writeHeader(w); err != nil {
+		return nil, 0, err
+	}
+	offset := int64(headerLen)
+	newLocators := make(map[uint64]locator, len(d.locators))
+
+	// Deterministic order keeps the output byte-stable for a given live set.
+	ids := make([]uint64, 0, len(d.locators))
+	for id := range d.locators {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(a, b int) bool { return ids[a] < ids[b] })
+
+	for _, id := range ids {
+		loc := d.locators[id]
+		vec, payload, rerr := readRecordAt(reader, loc)
+		if rerr != nil {
+			return nil, 0, rerr
+		}
+		payloadBytes, err := encodePayload(payload)
+		if err != nil {
+			return nil, 0, err
+		}
+		n, err := writeRecord(w, id, false, vec, payloadBytes)
+		if err != nil {
+			return nil, 0, err
+		}
+		newLocators[id] = locator{offset: offset, vecLen: loc.vecLen, payloadLen: uint32(len(payloadBytes))}
+		offset += int64(n)
+	}
+	if err := w.Flush(); err != nil {
+		return nil, 0, err
+	}
+	return newLocators, offset, nil
+}
+
+// finalizeFile fsyncs, closes, and atomically renames tmpPath to path.
+func finalizeFile(out *os.File, tmpPath, path string) error {
+	if err := out.Sync(); err != nil {
+		_ = out.Close()
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err := out.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	return nil
+}
+
+// Load reopens the segment at path: it rebuilds the locator map by scanning
+// record headers (without retaining vectors) and reads the identity sidecar. A
+// missing segment is treated as a fresh index (no error), matching HNSWIndex.
+func (d *DiskIndex) Load(ctx context.Context, path string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if path == "" {
+		path = d.path
+	}
+	if path == "" {
+		return errors.New("path is required")
+	}
+
+	locators, end, scanErr := scanSegment(path)
+	if scanErr != nil {
+		if errors.Is(scanErr, os.ErrNotExist) {
+			d.mu.Lock()
+			d.path = path
+			d.identity = readIdentitySidecar(identitySidecarPath(path))
+			d.mu.Unlock()
+			return nil
+		}
+		return scanErr
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if err := d.invalidateReaderLocked(); err != nil {
+		return err
+	}
+	d.path = path
+	d.locators = locators
+	d.appendEnd = end
+	d.identity = readIdentitySidecar(identitySidecarPath(path))
+	return nil
+}
+
+// Close releases the mmap view.
+func (d *DiskIndex) Close() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.invalidateReaderLocked()
+}
+
+// readerLocked returns the mmap reader, opening it lazily. Returns (nil, nil)
+// when no segment file exists yet (fresh index). The cached view is invalidated
+// on every mutation (appendRecord/Reset/Save), so a held view always reflects
+// the on-disk bytes the current locator offsets point at.
+func (d *DiskIndex) readerLocked() (*mmap.ReaderAt, error) {
+	if d.reader != nil {
+		return d.reader, nil
+	}
+	if d.path == "" {
+		return nil, nil
+	}
+	r, err := mmap.Open(d.path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	d.reader = r
+	return r, nil
+}
+
+// invalidateReaderLocked closes and clears any cached mmap view. Caller holds
+// the write lock (or is otherwise exclusive).
+func (d *DiskIndex) invalidateReaderLocked() error {
+	if d.reader == nil {
+		return nil
+	}
+	err := d.reader.Close()
+	d.reader = nil
+	return err
+}
+
+// --- record / segment encoding ---
+
+// writeHeader writes the magic + version prefix.
+func writeHeader(w io.Writer) error {
+	if _, err := w.Write([]byte(segmentMagic)); err != nil {
+		return err
+	}
+	var v [4]byte
+	binary.LittleEndian.PutUint32(v[:], segmentVersion)
+	_, err := w.Write(v[:])
+	return err
+}
+
+// writeRecord encodes one record to w and returns the number of bytes written.
+func writeRecord(w io.Writer, chunkID uint64, tombstone bool, vector []float32, payloadBytes []byte) (int, error) {
+	hdr := make([]byte, recordHdrLen)
+	binary.LittleEndian.PutUint64(hdr[0:8], chunkID)
+	if tombstone {
+		hdr[8] = 1
+	}
+	binary.LittleEndian.PutUint32(hdr[9:13], uint32(len(vector)))
+	binary.LittleEndian.PutUint32(hdr[13:17], uint32(len(payloadBytes)))
+	if _, err := w.Write(hdr); err != nil {
+		return 0, err
+	}
+	vecBytes := float32sToBytes(vector)
+	if _, err := w.Write(vecBytes); err != nil {
+		return 0, err
+	}
+	if _, err := w.Write(payloadBytes); err != nil {
+		return 0, err
+	}
+	return recordHdrLen + len(vecBytes) + len(payloadBytes), nil
+}
+
+// readRecordAt reads the vector and payload for a locator from the mmap reader.
+func readRecordAt(reader *mmap.ReaderAt, loc locator) ([]float32, model.IndexPayload, error) {
+	vecBytesLen := int(loc.vecLen) * 4
+	buf := make([]byte, vecBytesLen+int(loc.payloadLen))
+	// The vector/payload start right after the record header.
+	if _, err := reader.ReadAt(buf, loc.offset+int64(recordHdrLen)); err != nil {
+		return nil, model.IndexPayload{}, err
+	}
+	vec := bytesToFloat32s(buf[:vecBytesLen])
+	payload, err := decodePayload(buf[vecBytesLen:])
+	if err != nil {
+		return nil, model.IndexPayload{}, err
+	}
+	return vec, payload, nil
+}
+
+// scanSegment reads the segment header + record headers to rebuild the locator
+// map (last-writer-wins, tombstones drop entries) without retaining vectors. It
+// returns the locator map and the end-of-file offset.
+func scanSegment(path string) (map[uint64]locator, int64, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer func() { _ = f.Close() }()
+
+	r := bufio.NewReader(f)
+	if err := verifyHeader(r); err != nil {
+		return nil, 0, err
+	}
+
+	locators := make(map[uint64]locator)
+	offset := int64(headerLen)
+	hdr := make([]byte, recordHdrLen)
+	for {
+		if _, err := io.ReadFull(r, hdr); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, 0, err
+		}
+		chunkID := binary.LittleEndian.Uint64(hdr[0:8])
+		tombstone := hdr[8] == 1
+		vecLen := binary.LittleEndian.Uint32(hdr[9:13])
+		payloadLen := binary.LittleEndian.Uint32(hdr[13:17])
+		bodyLen := int64(vecLen)*4 + int64(payloadLen)
+		if _, err := r.Discard(int(bodyLen)); err != nil {
+			return nil, 0, fmt.Errorf("truncated record body for chunk %d: %w", chunkID, err)
+		}
+		if tombstone {
+			delete(locators, chunkID)
+		} else {
+			locators[chunkID] = locator{offset: offset, vecLen: vecLen, payloadLen: payloadLen}
+		}
+		offset += int64(recordHdrLen) + bodyLen
+	}
+	return locators, offset, nil
+}
+
+// verifyHeader reads and validates the segment magic + version.
+func verifyHeader(r io.Reader) error {
+	hdr := make([]byte, headerLen)
+	if _, err := io.ReadFull(r, hdr); err != nil {
+		return fmt.Errorf("read segment header: %w", err)
+	}
+	if string(hdr[:len(segmentMagic)]) != segmentMagic {
+		return errors.New("diskindex: bad segment magic")
+	}
+	if v := binary.LittleEndian.Uint32(hdr[len(segmentMagic):]); v != segmentVersion {
+		return fmt.Errorf("diskindex: unsupported segment version %d", v)
+	}
+	return nil
+}
+
+// --- payload + identity sidecar codecs ---
+
+func encodePayload(p model.IndexPayload) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := gob.NewEncoder(&buf).Encode(p); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func decodePayload(b []byte) (model.IndexPayload, error) {
+	var p model.IndexPayload
+	if len(b) == 0 {
+		return p, nil
+	}
+	if err := gob.NewDecoder(bytes.NewReader(b)).Decode(&p); err != nil {
+		return model.IndexPayload{}, err
+	}
+	return p, nil
+}
+
+func writeIdentitySidecar(path, identity string) error {
+	data, err := json.Marshal(struct {
+		Identity string `json:"identity"`
+	}{Identity: identity})
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// readIdentitySidecar returns the recorded identity, or "" when the sidecar is
+// missing/unreadable (treated as a fresh index, like a missing snapshot).
+func readIdentitySidecar(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	var s struct {
+		Identity string `json:"identity"`
+	}
+	if json.Unmarshal(data, &s) != nil {
+		return ""
+	}
+	return s.Identity
+}
+
+// --- float32 <-> bytes (little-endian) ---
+
+func float32sToBytes(v []float32) []byte {
+	out := make([]byte, len(v)*4)
+	for i, f := range v {
+		binary.LittleEndian.PutUint32(out[i*4:], math.Float32bits(f))
+	}
+	return out
+}
+
+func bytesToFloat32s(b []byte) []float32 {
+	out := make([]float32, len(b)/4)
+	for i := range out {
+		out[i] = math.Float32frombits(binary.LittleEndian.Uint32(b[i*4:]))
+	}
+	return out
+}
+
+func cosineSimilarity(a, b []float32) float32 {
+	var dot, magA, magB float32
+	for idx := range a {
+		dot += a[idx] * b[idx]
+		magA += a[idx] * a[idx]
+		magB += b[idx] * b[idx]
+	}
+	if magA == 0 || magB == 0 {
+		return 0
+	}
+	return dot / float32(math.Sqrt(float64(magA*magB)))
+}

--- a/tests/config/config_test.go
+++ b/tests/config/config_test.go
@@ -71,6 +71,51 @@ func TestConfigValidateAcceptsDoclingServeExtractor(t *testing.T) {
 	}
 }
 
+func TestConfigDefaultIndexBackendIsMemory(t *testing.T) {
+	if got := config.Default().IndexBackend; got != "memory" {
+		t.Fatalf("default index.backend = %q, want memory", got)
+	}
+}
+
+func TestConfigValidateRejectsInvalidIndexBackend(t *testing.T) {
+	cfg := config.Default()
+	cfg.IndexBackend = "elasticsearch"
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected validation error for unknown index.backend")
+	}
+}
+
+func TestConfigValidateAcceptsDiskIndexBackend(t *testing.T) {
+	cfg := config.Default()
+	cfg.IndexBackend = "DISK"
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("disk must be a valid index.backend: %v", err)
+	}
+	if cfg.IndexBackend != "disk" {
+		t.Fatalf("index.backend should normalize to lowercase, got %q", cfg.IndexBackend)
+	}
+}
+
+func TestIndexBackendRoundTripsThroughSaveLoad(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+
+	cfg := config.Default()
+	cfg.RootDir = "/tmp/repo"
+	cfg.StateDir = "/tmp/repo/.dir2mcp"
+	cfg.IndexBackend = "disk"
+	if err := config.SaveFile(path, cfg); err != nil {
+		t.Fatalf("SaveFile failed: %v", err)
+	}
+	loaded, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile failed: %v", err)
+	}
+	if loaded.IndexBackend != "disk" {
+		t.Fatalf("index.backend did not round-trip: got %q, want disk", loaded.IndexBackend)
+	}
+}
+
 func TestLoad_DotEnvLocalOverridesDotEnv(t *testing.T) {
 	tmp := t.TempDir()
 	writeFile(t, filepath.Join(tmp, ".env"), "MISTRAL_API_KEY=from_env_file\n")

--- a/tests/index/disk_index_test.go
+++ b/tests/index/disk_index_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/dirstral/dir2mcp/internal/index"
@@ -311,6 +312,78 @@ func TestDiskIndex_UpsertRejectsEmptyVectorAndZeroID(t *testing.T) {
 	if err := idx.Upsert(ctx, []float32{1, 0}, model.IndexPayload{ChunkID: 0}); err == nil {
 		t.Fatal("expected error on zero chunk_id")
 	}
+}
+
+// TestDiskIndex_LoadBadMagicErrors verifies a segment whose header is not the
+// expected magic is reported as an error (graceful, not a panic), so a corrupt
+// or alien file is never silently treated as a valid index.
+func TestDiskIndex_LoadBadMagicErrors(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	segPath := filepath.Join(dir, diskindex.SegmentFileName("text"))
+	if err := os.WriteFile(segPath, []byte("NOTMAGIC\x01\x00\x00\x00garbage"), 0o644); err != nil {
+		t.Fatalf("seed corrupt segment: %v", err)
+	}
+	idx := diskindex.New(segPath)
+	t.Cleanup(func() { _ = idx.Close() })
+	if err := idx.Load(ctx, segPath); err == nil {
+		t.Fatal("expected an error loading a segment with bad magic, got nil")
+	}
+}
+
+// TestDiskIndex_LoadTruncatedBodyErrors verifies a segment truncated mid-record
+// (a torn write) is reported as an error rather than panicking or silently
+// dropping data.
+func TestDiskIndex_LoadTruncatedBodyErrors(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	segPath := filepath.Join(dir, diskindex.SegmentFileName("text"))
+
+	idx := diskindex.New(segPath)
+	mustUpsertDisk(t, idx, model.IndexPayload{ChunkID: 1, RelPath: "a.md"}, []float32{1, 2, 3})
+	if err := idx.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	info, err := os.Stat(segPath)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	// Lop bytes off the end so the final record's body is incomplete.
+	if err := os.Truncate(segPath, info.Size()-5); err != nil {
+		t.Fatalf("Truncate: %v", err)
+	}
+
+	reopened := diskindex.New(segPath)
+	t.Cleanup(func() { _ = reopened.Close() })
+	if err := reopened.Load(ctx, segPath); err == nil {
+		t.Fatal("expected an error loading a truncated segment, got nil")
+	}
+}
+
+// TestDiskIndex_ConcurrentSearch exercises Search from many goroutines after the
+// cached mmap view has been dropped, so the lazy re-open path runs concurrently.
+// It is meaningful under `go test -race`, guarding the d.reader assignment.
+func TestDiskIndex_ConcurrentSearch(t *testing.T) {
+	ctx := context.Background()
+	idx := newDiskIndex(t)
+	mustUpsertDisk(t, idx, model.IndexPayload{ChunkID: 1, RelPath: "a.md"}, []float32{1, 0})
+	mustUpsertDisk(t, idx, model.IndexPayload{ChunkID: 2, RelPath: "b.md"}, []float32{0, 1})
+	// Drop the cached reader so the first concurrent Search lazily re-opens it.
+	if err := idx.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := idx.Search(ctx, []float32{1, 0}, 5, model.Filter{}); err != nil {
+				t.Errorf("concurrent Search: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
 }
 
 // TestNewBackend_Dispatch verifies the index.backend selection seam (issue

--- a/tests/index/disk_index_test.go
+++ b/tests/index/disk_index_test.go
@@ -1,0 +1,377 @@
+package tests
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/index/diskindex"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// compile-time assertion that the disk backend satisfies the full contract.
+var (
+	_ model.Index          = (*diskindex.DiskIndex)(nil)
+	_ model.Persistable    = (*diskindex.DiskIndex)(nil)
+	_ model.FilteringIndex = (*diskindex.DiskIndex)(nil)
+)
+
+func newDiskIndex(t *testing.T) *diskindex.DiskIndex {
+	t.Helper()
+	dir := t.TempDir()
+	idx := diskindex.New(filepath.Join(dir, diskindex.SegmentFileName("text")))
+	t.Cleanup(func() { _ = idx.Close() })
+	return idx
+}
+
+func mustUpsertDisk(t *testing.T, idx *diskindex.DiskIndex, payload model.IndexPayload, vec []float32) {
+	t.Helper()
+	if err := idx.Upsert(context.Background(), vec, payload); err != nil {
+		t.Fatalf("Upsert(%d): %v", payload.ChunkID, err)
+	}
+}
+
+func TestDiskIndex_UpsertWithDocTypeFilter(t *testing.T) {
+	ctx := context.Background()
+	idx := newDiskIndex(t)
+	mustUpsertDisk(t, idx, model.IndexPayload{ChunkID: 1, RelPath: "docs/a.md", DocType: "md"}, []float32{1, 0})
+	mustUpsertDisk(t, idx, model.IndexPayload{ChunkID: 2, RelPath: "src/a.go", DocType: "code"}, []float32{0.99, 0.01})
+	mustUpsertDisk(t, idx, model.IndexPayload{ChunkID: 3, RelPath: "docs/b.md", DocType: "md"}, []float32{0.98, 0.02})
+
+	hits, err := idx.Search(ctx, []float32{1, 0}, 10, model.Filter{DocTypes: []string{"MD"}})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	got := chunkIDs(hits)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 md hits, got %v", got)
+	}
+	for _, id := range got {
+		if id == 2 {
+			t.Fatalf("code chunk 2 leaked past doctype filter: %v", got)
+		}
+	}
+}
+
+func TestDiskIndex_SearchWithPathPrefixAndGlobFilter(t *testing.T) {
+	ctx := context.Background()
+	idx := newDiskIndex(t)
+	mustUpsertDisk(t, idx, model.IndexPayload{ChunkID: 1, RelPath: "docs/a.md", DocType: "md"}, []float32{1, 0})
+	mustUpsertDisk(t, idx, model.IndexPayload{ChunkID: 2, RelPath: "docs/b.md", DocType: "md"}, []float32{0.99, 0.01})
+	mustUpsertDisk(t, idx, model.IndexPayload{ChunkID: 3, RelPath: "src/main.go", DocType: "code"}, []float32{0.98, 0.02})
+
+	hits, err := idx.Search(ctx, []float32{1, 0}, 10, model.Filter{PathPrefix: "docs/", PathGlob: "docs/a.*"})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	got := chunkIDs(hits)
+	if len(got) != 1 || got[0] != 1 {
+		t.Fatalf("expected only chunk 1 (docs/a.md), got %v", got)
+	}
+}
+
+func TestDiskIndex_UpsertReplacesVector(t *testing.T) {
+	ctx := context.Background()
+	idx := newDiskIndex(t)
+	mustUpsertDisk(t, idx, model.IndexPayload{ChunkID: 1, RelPath: "a.md"}, []float32{1, 0})
+	// Replace chunk 1 with a different payload/vector; last-writer-wins.
+	mustUpsertDisk(t, idx, model.IndexPayload{ChunkID: 1, RelPath: "renamed.md"}, []float32{0, 1})
+
+	hits, err := idx.Search(ctx, []float32{0, 1}, 10, model.Filter{})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(hits) != 1 || hits[0].ChunkID != 1 {
+		t.Fatalf("expected single chunk 1, got %v", chunkIDs(hits))
+	}
+	if hits[0].Payload.RelPath != "renamed.md" {
+		t.Fatalf("expected replaced payload rel_path renamed.md, got %q", hits[0].Payload.RelPath)
+	}
+}
+
+func TestDiskIndex_DeleteRemovesVector(t *testing.T) {
+	ctx := context.Background()
+	idx := newDiskIndex(t)
+	mustUpsertDisk(t, idx, model.IndexPayload{ChunkID: 1, RelPath: "a.md"}, []float32{1, 0})
+	mustUpsertDisk(t, idx, model.IndexPayload{ChunkID: 2, RelPath: "b.md"}, []float32{0.9, 0.1})
+
+	if err := idx.Delete(ctx, []uint64{1}); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	hits, err := idx.Search(ctx, []float32{1, 0}, 10, model.Filter{})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	got := chunkIDs(hits)
+	if len(got) != 1 || got[0] != 2 {
+		t.Fatalf("expected only chunk 2 after delete, got %v", got)
+	}
+	// Deleting an unknown id is a no-op, not an error.
+	if err := idx.Delete(ctx, []uint64{999}); err != nil {
+		t.Fatalf("Delete unknown id: %v", err)
+	}
+}
+
+func TestDiskIndex_IdentityAndReset(t *testing.T) {
+	ctx := context.Background()
+	idx := newDiskIndex(t)
+
+	id, err := idx.Identity(ctx)
+	if err != nil {
+		t.Fatalf("Identity: %v", err)
+	}
+	if id != "" {
+		t.Fatalf("fresh index identity should be empty, got %q", id)
+	}
+
+	mustUpsertDisk(t, idx, model.IndexPayload{ChunkID: 1, RelPath: "a.md"}, []float32{1, 0})
+	if err := idx.Reset(ctx, "mistral|mistral-embed|codestral-embed|0|0|off"); err != nil {
+		t.Fatalf("Reset: %v", err)
+	}
+
+	id, err = idx.Identity(ctx)
+	if err != nil {
+		t.Fatalf("Identity after reset: %v", err)
+	}
+	if id != "mistral|mistral-embed|codestral-embed|0|0|off" {
+		t.Fatalf("unexpected identity after reset: %q", id)
+	}
+	hits, err := idx.Search(ctx, []float32{1, 0}, 10, model.Filter{})
+	if err != nil {
+		t.Fatalf("Search after reset: %v", err)
+	}
+	if len(hits) != 0 {
+		t.Fatalf("expected empty index after reset, got %v", chunkIDs(hits))
+	}
+	// Upsert still works after Reset (segment was truncated to a fresh header).
+	mustUpsertDisk(t, idx, model.IndexPayload{ChunkID: 5, RelPath: "c.md"}, []float32{1, 0})
+	hits, _ = idx.Search(ctx, []float32{1, 0}, 10, model.Filter{})
+	if len(hits) != 1 || hits[0].ChunkID != 5 {
+		t.Fatalf("expected chunk 5 after post-reset upsert, got %v", chunkIDs(hits))
+	}
+}
+
+func TestDiskIndex_CanFilterAlwaysTrue(t *testing.T) {
+	idx := newDiskIndex(t)
+	if !idx.CanFilter(model.Filter{}) {
+		t.Fatal("disk backend should report CanFilter true for the zero filter")
+	}
+	if !idx.CanFilter(model.Filter{PathPrefix: "docs/", DocTypes: []string{"md"}}) {
+		t.Fatal("disk backend should report CanFilter true for a populated filter")
+	}
+}
+
+func TestDiskIndex_EnsureIdentityResetsOnMismatch(t *testing.T) {
+	ctx := context.Background()
+	idx := newDiskIndex(t)
+	mustUpsertDisk(t, idx, model.IndexPayload{ChunkID: 1, RelPath: "a.md"}, []float32{1, 0})
+
+	// Fresh (empty identity): reconcile resets to the configured identity.
+	if err := index.EnsureIdentity(ctx, idx, "ident-1"); err != nil {
+		t.Fatalf("EnsureIdentity (fresh): %v", err)
+	}
+	if id, _ := idx.Identity(ctx); id != "ident-1" {
+		t.Fatalf("expected identity ident-1, got %q", id)
+	}
+	if hits, _ := idx.Search(ctx, []float32{1, 0}, 10, model.Filter{}); len(hits) != 0 {
+		t.Fatalf("expected vectors cleared on fresh reconcile, got %v", chunkIDs(hits))
+	}
+
+	// Matching identity is a no-op: vectors are preserved.
+	mustUpsertDisk(t, idx, model.IndexPayload{ChunkID: 2, RelPath: "b.md"}, []float32{1, 0})
+	if err := index.EnsureIdentity(ctx, idx, "ident-1"); err != nil {
+		t.Fatalf("EnsureIdentity (match): %v", err)
+	}
+	if hits, _ := idx.Search(ctx, []float32{1, 0}, 10, model.Filter{}); len(hits) != 1 {
+		t.Fatalf("matching identity must not clear vectors, got %v", chunkIDs(hits))
+	}
+
+	// Changed identity resets again.
+	if err := index.EnsureIdentity(ctx, idx, "ident-2"); err != nil {
+		t.Fatalf("EnsureIdentity (mismatch): %v", err)
+	}
+	if hits, _ := idx.Search(ctx, []float32{1, 0}, 10, model.Filter{}); len(hits) != 0 {
+		t.Fatalf("expected vectors cleared on identity change, got %v", chunkIDs(hits))
+	}
+}
+
+// TestDiskIndex_PersistenceRoundTrip is the core Tier-B proof: Save to disk,
+// reopen a brand-new instance from the segment file (which only rebuilds the
+// fixed-size locator map — the vectors themselves stay memory-mapped on disk),
+// and verify a filtered search still returns the right payloads. The reopened
+// index never loads the whole corpus into a Go vector map, demonstrating the
+// removed all-vectors-in-RAM ceiling.
+func TestDiskIndex_PersistenceRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	segPath := filepath.Join(dir, diskindex.SegmentFileName("text"))
+
+	idx := diskindex.New(segPath)
+	if err := idx.Reset(ctx, "ident-rt"); err != nil {
+		t.Fatalf("Reset: %v", err)
+	}
+	mustUpsertDisk(t, idx, model.IndexPayload{ChunkID: 1, RelPath: "docs/a.md", DocType: "md", Snippet: "alpha"}, []float32{1, 0, 0})
+	mustUpsertDisk(t, idx, model.IndexPayload{ChunkID: 2, RelPath: "docs/b.md", DocType: "md", Snippet: "beta"}, []float32{0, 1, 0})
+	mustUpsertDisk(t, idx, model.IndexPayload{ChunkID: 3, RelPath: "src/c.go", DocType: "code", Snippet: "gamma"}, []float32{0, 0, 1})
+	// Delete one so compaction must drop a tombstoned record on Save.
+	if err := idx.Delete(ctx, []uint64{3}); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if err := idx.Save(ctx, segPath); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := idx.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Reopen from disk in a fresh instance.
+	reopened := diskindex.New(segPath)
+	t.Cleanup(func() { _ = reopened.Close() })
+	if err := reopened.Load(ctx, segPath); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	assertReopenedDiskIndex(t, reopened)
+}
+
+// assertReopenedDiskIndex verifies that a disk index reopened from its segment
+// preserves the identity, live vectors, payloads, filtering, and the deletion
+// applied before Save.
+func assertReopenedDiskIndex(t *testing.T, reopened *diskindex.DiskIndex) {
+	t.Helper()
+	ctx := context.Background()
+
+	if id, _ := reopened.Identity(ctx); id != "ident-rt" {
+		t.Fatalf("identity did not survive round-trip, got %q", id)
+	}
+
+	// Vectors survive: searching for the exact vector of chunk 1 returns it
+	// with its full payload, sourced from the memory-mapped segment.
+	hits, err := reopened.Search(ctx, []float32{1, 0, 0}, 10, model.Filter{})
+	if err != nil {
+		t.Fatalf("Search after reopen: %v", err)
+	}
+	if len(hits) != 2 {
+		t.Fatalf("expected 2 live vectors after reopen (chunk 3 deleted), got %v", chunkIDs(hits))
+	}
+	if hits[0].ChunkID != 1 {
+		t.Fatalf("expected chunk 1 best match for its own vector, got %v", chunkIDs(hits))
+	}
+	if hits[0].Payload.Snippet != "alpha" || hits[0].Payload.RelPath != "docs/a.md" {
+		t.Fatalf("payload did not survive round-trip: %+v", hits[0].Payload)
+	}
+	// The deleted chunk must not reappear.
+	for _, h := range hits {
+		if h.ChunkID == 3 {
+			t.Fatalf("deleted chunk 3 reappeared after reopen")
+		}
+	}
+
+	// Filtering still works on the reopened, disk-backed payloads.
+	mdHits, err := reopened.Search(ctx, []float32{1, 0, 0}, 10, model.Filter{DocTypes: []string{"md"}})
+	if err != nil {
+		t.Fatalf("filtered Search after reopen: %v", err)
+	}
+	if len(mdHits) != 2 {
+		t.Fatalf("expected 2 md hits after reopen, got %v", chunkIDs(mdHits))
+	}
+}
+
+// TestDiskIndex_LoadMissingSegmentIsFresh verifies a missing segment file is
+// treated as a fresh index (no error), matching the HNSW reference.
+func TestDiskIndex_LoadMissingSegmentIsFresh(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	segPath := filepath.Join(dir, diskindex.SegmentFileName("text"))
+
+	idx := diskindex.New(segPath)
+	t.Cleanup(func() { _ = idx.Close() })
+	if err := idx.Load(ctx, segPath); err != nil {
+		t.Fatalf("Load missing segment should be nil error, got %v", err)
+	}
+	if _, statErr := os.Stat(segPath); !os.IsNotExist(statErr) {
+		t.Fatalf("Load must not create the segment file")
+	}
+	hits, err := idx.Search(ctx, []float32{1, 0}, 10, model.Filter{})
+	if err != nil {
+		t.Fatalf("Search on fresh index: %v", err)
+	}
+	if len(hits) != 0 {
+		t.Fatalf("fresh index should have no hits, got %v", chunkIDs(hits))
+	}
+}
+
+func TestDiskIndex_UpsertRejectsEmptyVectorAndZeroID(t *testing.T) {
+	ctx := context.Background()
+	idx := newDiskIndex(t)
+	if err := idx.Upsert(ctx, nil, model.IndexPayload{ChunkID: 1}); err == nil {
+		t.Fatal("expected error on empty vector")
+	}
+	if err := idx.Upsert(ctx, []float32{1, 0}, model.IndexPayload{ChunkID: 0}); err == nil {
+		t.Fatal("expected error on zero chunk_id")
+	}
+}
+
+// TestNewBackend_Dispatch verifies the index.backend selection seam (issue
+// #246): "disk" constructs the on-disk backend and a default/unknown value
+// falls back to the in-memory HNSW.
+func TestNewBackend_Dispatch(t *testing.T) {
+	dir := t.TempDir()
+
+	memIx, memPath := index.NewBackend(index.BackendMemory, dir, index.KindText)
+	t.Cleanup(func() { _ = memIx.Close() })
+	if _, ok := memIx.(*index.HNSWIndex); !ok {
+		t.Fatalf("memory backend should construct *index.HNSWIndex, got %T", memIx)
+	}
+	if filepath.Base(memPath) != index.TextIndexFileName {
+		t.Fatalf("memory text path = %q, want basename %q", memPath, index.TextIndexFileName)
+	}
+
+	diskIx, diskPath := index.NewBackend(index.BackendDisk, dir, index.KindCode)
+	t.Cleanup(func() { _ = diskIx.Close() })
+	if _, ok := diskIx.(*diskindex.DiskIndex); !ok {
+		t.Fatalf("disk backend should construct *diskindex.DiskIndex, got %T", diskIx)
+	}
+	if filepath.Base(diskPath) != diskindex.SegmentFileName(index.KindCode) {
+		t.Fatalf("disk code path = %q, want basename %q", diskPath, diskindex.SegmentFileName(index.KindCode))
+	}
+
+	// Empty/unknown falls back to memory (config validation rejects unknowns).
+	fallbackIx, _ := index.NewBackend("", dir, index.KindText)
+	t.Cleanup(func() { _ = fallbackIx.Close() })
+	if _, ok := fallbackIx.(*index.HNSWIndex); !ok {
+		t.Fatalf("empty backend should fall back to *index.HNSWIndex, got %T", fallbackIx)
+	}
+}
+
+// TestStaleIndexFiles_IncludesDiskSegments verifies reindex cleanup names the
+// disk backend's segment + identity sidecar when "disk" is selected.
+func TestStaleIndexFiles_IncludesDiskSegments(t *testing.T) {
+	memNames := index.StaleIndexFiles(index.BackendMemory)
+	for _, name := range memNames {
+		if name == diskindex.SegmentFileName(index.KindText) {
+			t.Fatalf("memory backend should not list disk segments: %v", memNames)
+		}
+	}
+
+	diskNames := index.StaleIndexFiles(index.BackendDisk)
+	wantSeg := diskindex.SegmentFileName(index.KindText)
+	wantSidecar := wantSeg + diskindex.IdentitySidecarSuffix
+	if !containsStr(diskNames, wantSeg) || !containsStr(diskNames, wantSidecar) {
+		t.Fatalf("disk stale files missing segment/sidecar: %v", diskNames)
+	}
+	// The HNSW snapshots are always included so a prior memory build is cleaned.
+	if !containsStr(diskNames, index.TextIndexFileName) {
+		t.Fatalf("disk stale files should also clean HNSW snapshots: %v", diskNames)
+	}
+}
+
+func containsStr(s []string, want string) bool {
+	for _, v := range s {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Adds the Tier-B **pure-Go on-disk vector backend** (`internal/index/diskindex`) and the `index.backend` selection seam, so a corpus can grow past available RAM without any C extension. Closes #246. Part of epic #250.

The disk backend implements the merged `model.Index` contract plus the optional `Persistable` and `FilteringIndex` capabilities — same surface as the in-memory HNSW reference.

## CGO_ENABLED=0 mandatory

The implementation is **pure Go and builds/runs with `CGO_ENABLED=0`**. Vectors are read through `golang.org/x/exp/mmap`, a pure-Go `ReaderAt` over an mmap'd file (with a read-syscall fallback) — there is no cgo mmap.

## How the RAM ceiling is removed

Only a fixed-size **locator** per chunk (`offset + vecLen + payloadLen`) and the embed identity stay resident in a Go map. The dense vector **payloads live on disk** in a single segment file that is memory-mapped and read on demand at search time. Reopening an index rebuilds just the locator map by scanning record headers (vectors are never loaded into a Go vector map), so the corpus is no longer bounded by RAM.

## On-disk format (`vectors_<kind>.diskv1.idx`)

```
[8]  magic   "D2MDISK1"
[4]  version uint32 (=1)
... append log of records, each:
[8]  chunkID    uint64 LE
[1]  tombstone  byte (0 live / 1 deleted)
[4]  vecLen     uint32
[4]  payloadLen uint32
[vecLen*4] vector  float32 LE
[payloadLen] payload gob (model.IndexPayload)
```

- **Upsert** appends a new record; **Delete** appends a tombstone. The in-RAM locator map folds the log **last-writer-wins**, so effective state is the latest record per chunk.
- **Save** compacts the live set into a fresh segment via atomic temp-file rename, reclaiming space held by superseded/tombstoned records, streaming vectors from the current mmap without ever holding the whole corpus in RAM.
- The embed identity (SPEC 8.1.4) is stored in a JSON sidecar (`.identity.json`) so reopen survives without parsing vectors.

## index.backend dispatch

`index.NewBackend(backend, stateDir, kind)` selects the backend at index construction:

- `memory` (default): the in-memory HNSW, persisted to the versioned `vectors_<kind>.v2.hnsw` snapshot. **Byte-identical to legacy behavior.**
- `disk`: the on-disk backend above.

Config plumbing: `index.backend` key (aliases `index_backend`/`backend`), `DIR2MCP_INDEX_BACKEND` env, YAML round-trip, and validation rejecting anything outside `memory`/`disk`. `StaleIndexFiles` extends reindex cleanup to the disk segment + identity sidecar.

This switch is the seam that the future networked backends extend with new cases rather than reworking the dispatch — **#268 (Qdrant)** and **#269 (pgvector)**.

## Testing

- `make check` passes (gofmt, vet, golangci-lint 0 issues, gocyclo ≤15, all Go + Python tests, security boundary test).
- Verified a `CGO_ENABLED=0 go build ./...`.
- New tests (`tests/index/disk_index_test.go`, package `tests`): upsert/replace/delete, filter push-down, identity + reset, `EnsureIdentity` reconciliation, persistence round-trip (Save → reopen fresh instance → filtered search), missing-segment-is-fresh, backend dispatch, and stale-file cleanup. Plus config tests for the new key.