### PR TITLE
feat(ingest): ingest subtitle sidecars as media transcripts (#253)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -203,6 +203,13 @@ type Config struct {
 	STTElevenLabsModel        string
 	STTElevenLabsLanguageCode string
 
+	// MediaSidecarsDisabled opts OUT of subtitle sidecar ingestion (spec
+	// §8.6.4). Sidecar ingestion is enabled by default (spec default
+	// media.sidecars.enabled: true): a .vtt/.srt/.ttml file next to a media file
+	// is ingested as that media's transcript instead of running STT. Set this
+	// true to disable that and always run STT (the kill-switch opt-out).
+	MediaSidecarsDisabled bool
+
 	// QualityGatesEnabled is the master switch for the output quality gate
 	// (spec 0.16.0): when true (default), generated transcript/OCR text is
 	// screened for degenerate output (repetition loops, empty output,
@@ -305,6 +312,7 @@ type fileConfig struct {
 	STTElevenLabsModel        *string
 	STTElevenLabsLanguageCode *string
 	QualityGatesEnabled       *bool
+	MediaSidecarsDisabled     *bool
 	ElevenLabsAPIKey          *string
 	ServerTLSCertFile         *string
 	ServerTLSKeyFile          *string
@@ -391,6 +399,7 @@ type persistedConfig struct {
 	STTElevenLabsModel        string        `yaml:"stt_elevenlabs_model"`
 	STTElevenLabsLanguageCode string        `yaml:"stt_elevenlabs_language_code"`
 	QualityGatesEnabled       bool          `yaml:"quality_gates_enabled"`
+	MediaSidecarsDisabled     bool          `yaml:"media_sidecars_disabled"`
 	ServerTLSCertFile         string        `yaml:"server_tls_cert_file"`
 	ServerTLSKeyFile          string        `yaml:"server_tls_key_file"`
 
@@ -608,6 +617,7 @@ func buildPersistedConfig(cfg *Config) persistedConfig {
 		STTElevenLabsModel:        cfg.STTElevenLabsModel,
 		STTElevenLabsLanguageCode: cfg.STTElevenLabsLanguageCode,
 		QualityGatesEnabled:       cfg.QualityGatesEnabled,
+		MediaSidecarsDisabled:     cfg.MediaSidecarsDisabled,
 		ServerTLSCertFile:         cfg.ServerTLSCertFile,
 		ServerTLSKeyFile:          cfg.ServerTLSKeyFile,
 		X402Mode:                  cfg.X402.Mode,
@@ -1213,6 +1223,9 @@ func applySTTFileParsed(cfg *Config, fc fileConfig) {
 	if fc.QualityGatesEnabled != nil {
 		cfg.QualityGatesEnabled = *fc.QualityGatesEnabled
 	}
+	if fc.MediaSidecarsDisabled != nil {
+		cfg.MediaSidecarsDisabled = *fc.MediaSidecarsDisabled
+	}
 }
 
 // applyX402FileParsed copies the set x402 file fields onto cfg.X402.
@@ -1575,6 +1588,8 @@ func setBoolFileScalar(cfg *fileConfig, key, value string) error {
 		target = &cfg.IngestWatch
 	case "quality_gates_enabled":
 		target = &cfg.QualityGatesEnabled
+	case "media_sidecars_disabled":
+		target = &cfg.MediaSidecarsDisabled
 	case "x402_tools_call_enabled":
 		target = &cfg.X402ToolsCallEnabled
 	case "retrieval.hybrid.enabled":
@@ -1937,6 +1952,7 @@ func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	writeScalar("stt_elevenlabs_model", cfg.STTElevenLabsModel)
 	writeScalar("stt_elevenlabs_language_code", cfg.STTElevenLabsLanguageCode)
 	writeBool("quality_gates_enabled", cfg.QualityGatesEnabled)
+	writeBool("media_sidecars_disabled", cfg.MediaSidecarsDisabled)
 	writeScalar("server_tls_cert_file", cfg.ServerTLSCertFile)
 	writeScalar("server_tls_key_file", cfg.ServerTLSKeyFile)
 	writeScalar("x402_mode", cfg.X402Mode)

--- a/internal/ingest/hash.go
+++ b/internal/ingest/hash.go
@@ -30,6 +30,24 @@ func ComputeRepHash(content []byte) string {
 	return ComputeContentHash(content)
 }
 
+// mediaContentHash returns the document content hash, folding in a sidecar
+// fingerprint when present. With an empty fingerprint it is exactly
+// computeContentHash(content), so non-media documents and media without sidecars
+// keep their historical hash. A non-empty fingerprint (sidecar paths + mtimes)
+// changes the hash whenever a sidecar is added, removed, or modified, which the
+// incremental gate (§7.6) uses to re-process the media even though its bytes are
+// unchanged.
+func mediaContentHash(content []byte, sidecarFingerprint string) string {
+	if sidecarFingerprint == "" {
+		return computeContentHash(content)
+	}
+	combined := make([]byte, 0, len(content)+len(sidecarFingerprint)+1)
+	combined = append(combined, content...)
+	combined = append(combined, '\x00')
+	combined = append(combined, sidecarFingerprint...)
+	return computeContentHash(combined)
+}
+
 // needsReprocessing determines if a document needs to be reprocessed based on
 // hash comparison. Returns true if the document should be reprocessed.
 func needsReprocessing(oldHash, newHash string, forceReindex bool) bool {

--- a/internal/ingest/represent.go
+++ b/internal/ingest/represent.go
@@ -1039,17 +1039,28 @@ func chunkSubtitleCues(cues []subtitle.Cue) []chunkSegment {
 			continue
 		}
 		cueLen := utf8.RuneCountInString(text)
-		// Start a new chunk when the buffer would overflow the transcript chunk
-		// size; a single oversized cue still becomes its own chunk.
-		if haveOpen && bufLen+cueLen > TranscriptChunkMaxChars {
+		// flush() joins buffered cue texts with "\n", so budget one rune for the
+		// separator that will precede this cue when the buffer is non-empty;
+		// otherwise a merged chunk can exceed TranscriptChunkMaxChars by the
+		// number of joins. sepLen is 0 when no chunk is open (the first cue needs
+		// no separator) and resets to 0 after a flush.
+		sepLen := 0
+		if haveOpen {
+			sepLen = 1
+		}
+		// Start a new chunk when the buffer (plus the join separator) would
+		// overflow the transcript chunk size; a single oversized cue still becomes
+		// its own chunk.
+		if haveOpen && bufLen+sepLen+cueLen > TranscriptChunkMaxChars {
 			flush()
+			sepLen = 0
 		}
 		if !haveOpen {
 			startMS = cue.StartMS
 			haveOpen = true
 		}
 		buf = append(buf, text)
-		bufLen += cueLen
+		bufLen += sepLen + cueLen
 		endMS = cue.EndMS
 	}
 	flush()

--- a/internal/ingest/represent.go
+++ b/internal/ingest/represent.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/dirstral/dir2mcp/internal/ingest/docling"
 	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/subtitle"
 )
 
 // transcriptTimestampBracketedRe matches leading timestamps in [mm:ss] or
@@ -979,6 +980,74 @@ func ChunkTextByChars(content string, maxChars, overlapChars, minChars int) []Ch
 // primarily provided so that tests can exercise the chunking logic directly.
 func ChunkTranscriptByTime(content string) []ChunkSegment {
 	raw := chunkTranscriptByTime(content)
+	out := make([]ChunkSegment, 0, len(raw))
+	for _, seg := range raw {
+		out = append(out, ChunkSegment(seg))
+	}
+	return out
+}
+
+// chunkSubtitleCues turns parsed subtitle cues into time-spanned transcript
+// chunks. Unlike chunkTranscriptByTime (which estimates timing from a flat text
+// transcript), the cues already carry authoritative [StartMS, EndMS] windows, so
+// timing is taken verbatim — the source of the deterministic, stable citations a
+// sidecar transcript provides. Adjacent cues are merged greedily until the
+// accumulated text would exceed TranscriptChunkMaxChars; the merged chunk's span
+// is [first cue start, last merged cue end]. Cues are processed in their given
+// order (callers sort by start time first), so the output is deterministic.
+func chunkSubtitleCues(cues []subtitle.Cue) []chunkSegment {
+	out := make([]chunkSegment, 0, len(cues))
+	var (
+		buf      []string
+		startMS  int
+		endMS    int
+		haveOpen bool
+		bufLen   int
+	)
+	flush := func() {
+		if !haveOpen {
+			return
+		}
+		text := strings.TrimSpace(strings.Join(buf, "\n"))
+		if text != "" {
+			span := model.Span{Kind: "time", StartMS: startMS, EndMS: endMS}
+			if span.EndMS <= span.StartMS {
+				span.EndMS = span.StartMS + 1
+			}
+			out = append(out, chunkSegment{Text: text, Span: span})
+		}
+		buf = buf[:0]
+		bufLen = 0
+		haveOpen = false
+	}
+
+	for _, cue := range cues {
+		text := strings.TrimSpace(cue.Text)
+		if text == "" {
+			continue
+		}
+		cueLen := utf8.RuneCountInString(text)
+		// Start a new chunk when the buffer would overflow the transcript chunk
+		// size; a single oversized cue still becomes its own chunk.
+		if haveOpen && bufLen+cueLen > TranscriptChunkMaxChars {
+			flush()
+		}
+		if !haveOpen {
+			startMS = cue.StartMS
+			haveOpen = true
+		}
+		buf = append(buf, text)
+		bufLen += cueLen
+		endMS = cue.EndMS
+	}
+	flush()
+	return out
+}
+
+// ChunkSubtitleCues exposes chunkSubtitleCues for tests, converting the
+// unexported segment type to the public ChunkSegment.
+func ChunkSubtitleCues(cues []subtitle.Cue) []ChunkSegment {
+	raw := chunkSubtitleCues(cues)
 	out := make([]ChunkSegment, 0, len(raw))
 	for _, seg := range raw {
 		out = append(out, ChunkSegment(seg))

--- a/internal/ingest/represent.go
+++ b/internal/ingest/represent.go
@@ -44,6 +44,18 @@ const (
 	RepTypeAnnotationText = "annotation_text"
 )
 
+// TranscriptRepType returns the rep_type for a transcript in the given language.
+// The empty (source/undifferentiated) language keeps the bare "transcript"
+// rep_type so it remains interchangeable with the STT transcript; each
+// non-empty language gets a distinct, suffixed rep_type ("transcript-en") so
+// per-language transcripts coexist under the store's UNIQUE(doc_id, rep_type)
+// constraint instead of overwriting one another (spec §8.6.2/§8.6.4 keying).
+// The matching read-side query (store.TranscriptRepresentations) selects both
+// the bare and the suffixed forms.
+func TranscriptRepType(language string) string {
+	return RepTypeTranscript + TranscriptLangSuffix(language)
+}
+
 // RepresentationGenerator handles creation of representations from documents
 type RepresentationGenerator struct {
 	store model.RepresentationStore

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -140,6 +140,13 @@ type Service struct {
 	// convenient for tests.
 	ocrCacheWrites     int
 	ocrCachePruneEvery int
+
+	// sidecarIndex maps every discovered file's rel_path to its mtime, built once
+	// per scan (setSidecarIndex). The transcript path uses it to detect subtitle
+	// sidecars next to a media file and to mtime-gate their ingestion (§8.6.4).
+	// Nil until a scan sets it; direct callers fall back to a one-shot walk.
+	sidecarIndex map[string]int64
+	sidecarMu    sync.RWMutex
 }
 
 // ErrTranscriptProviderFailure marks failures originating from the transcript
@@ -574,6 +581,9 @@ func (s *Service) runScan(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	// Record discovered file mtimes so the transcript path can detect subtitle
+	// sidecars next to media files and mtime-gate their ingestion (§8.6.4).
+	s.setSidecarIndex(discovered)
 
 	compiledSecrets, err := compileSecretPatterns(s.cfg.SecretPatterns)
 	if err != nil {
@@ -685,7 +695,7 @@ func (s *Service) processDocument(ctx context.Context, f DiscoveredFile, secretP
 		return nil
 	}
 
-	if err := s.generateRepresentations(ctx, doc, content); err != nil {
+	if err := s.generateRepresentations(ctx, doc, content, forceReindex); err != nil {
 		// Persist error status so the next incremental run retries this document
 		// and operators can identify it via status queries.  Silence the upsert
 		// error since the original rep error is the more actionable signal.
@@ -835,7 +845,7 @@ func (s *Service) processDocumentFromContent(ctx context.Context, relPath string
 	if !needsProcessing || doc.Status != "ok" {
 		return nil
 	}
-	if err := s.generateRepresentations(ctx, doc, content); err != nil {
+	if err := s.generateRepresentations(ctx, doc, content, forceReindex); err != nil {
 		// Persist error status so the next incremental run retries this document
 		// and operators can identify it via status queries.  Silence the upsert
 		// error since the original rep error is the more actionable signal.
@@ -867,7 +877,12 @@ func (s *Service) buildDocumentWithContent(ctx context.Context, f DiscoveredFile
 	if err != nil {
 		return doc, nil, fmt.Errorf("read %s: %w", f.RelPath, err)
 	}
-	doc.ContentHash = computeContentHash(content)
+	// Fold any subtitle sidecar fingerprint (sibling paths + mtimes) into the
+	// media document's content hash so the incremental gate (§7.6) re-processes
+	// the media when a sidecar is added, removed, or modified — even though the
+	// media bytes are unchanged. Empty for non-media docs or media with no
+	// sidecar, preserving the existing hash exactly.
+	doc.ContentHash = mediaContentHash(content, s.sidecarFingerprint(ctx, f.RelPath, docType))
 
 	// certain document types we don't want to ingest at all.
 	// "archive" and "binary_ignored" were already skipped.
@@ -1166,7 +1181,7 @@ func isEmbeddableAudio(relPath string) bool {
 	}
 }
 
-func (s *Service) generateRepresentations(ctx context.Context, doc model.Document, content []byte) error {
+func (s *Service) generateRepresentations(ctx context.Context, doc model.Document, content []byte, forceReindex bool) error {
 	if s.repGen == nil {
 		return nil
 	}
@@ -1196,7 +1211,26 @@ func (s *Service) generateRepresentations(ctx context.Context, doc model.Documen
 	// transcript when audio media chunks were produced (SPEC 8.1.7). `augment`
 	// and `off` keep the transcript path unchanged.
 	skipTranscript := s.embedMultimodal == "replace" && mediaProduced
-	if doc.DocType == "audio" && s.transcriber != nil && !skipTranscript {
+	if skipTranscript {
+		return nil
+	}
+
+	// Subtitle sidecar precedence (§8.6.4): a subtitle file (.vtt/.srt/.ttml)
+	// next to the media is ingested AS the transcript instead of running STT — an
+	// authored transcript is authoritative. `--force`/reindex overrides the gate
+	// and re-runs STT instead. Sidecar ingestion bypasses the quality gate
+	// (authored, not model-derived; §8.6.6/§8.6.7).
+	if !forceReindex {
+		ingested, err := s.ingestSidecarTranscripts(ctx, doc)
+		if err != nil {
+			return err
+		}
+		if ingested {
+			return nil
+		}
+	}
+
+	if doc.DocType == "audio" && s.transcriber != nil {
 		if err := s.generateTranscriptRepresentation(ctx, doc, content); err != nil {
 			// Provider/transient failures should not fail the entire ingest run.
 			// Persistence/cache failures should still propagate.

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -157,6 +157,13 @@ type documentDeleteMarker interface {
 	MarkDocumentDeleted(ctx context.Context, relPath string) error
 }
 
+// sidecarTranscriptRetirer is the optional store capability used on a forced STT
+// reindex to tombstone a document's stale sidecar-sourced transcript
+// representations before the fresh machine transcript is written (spec §8.6.4).
+type sidecarTranscriptRetirer interface {
+	SoftDeleteSidecarTranscripts(ctx context.Context, relPath string) (int, error)
+}
+
 func NewService(cfg config.Config, store model.Store) (*Service, error) {
 	svc := &Service{
 		cfg:                             cfg,
@@ -1215,11 +1222,16 @@ func (s *Service) generateRepresentations(ctx context.Context, doc model.Documen
 		return nil
 	}
 
-	// Subtitle sidecar precedence (§8.6.4): a subtitle file (.vtt/.srt/.ttml)
-	// next to the media is ingested AS the transcript instead of running STT — an
-	// authored transcript is authoritative. `--force`/reindex overrides the gate
-	// and re-runs STT instead. Sidecar ingestion bypasses the quality gate
-	// (authored, not model-derived; §8.6.6/§8.6.7).
+	return s.generateTranscriptOrSidecar(ctx, doc, content, forceReindex)
+}
+
+// generateTranscriptOrSidecar resolves a media document's transcript. Subtitle
+// sidecar precedence (§8.6.4): a subtitle file (.vtt/.srt/.ttml) next to the
+// media is ingested AS the transcript instead of running STT — an authored
+// transcript is authoritative. `--force`/reindex overrides the gate, retiring
+// any stale sidecar transcripts and re-running STT. Sidecar ingestion bypasses
+// the quality gate (authored, not model-derived; §8.6.6/§8.6.7).
+func (s *Service) generateTranscriptOrSidecar(ctx context.Context, doc model.Document, content []byte, forceReindex bool) error {
 	if !forceReindex {
 		ingested, err := s.ingestSidecarTranscripts(ctx, doc)
 		if err != nil {
@@ -1228,20 +1240,51 @@ func (s *Service) generateRepresentations(ctx context.Context, doc model.Documen
 		if ingested {
 			return nil
 		}
+	} else if err := s.retireStaleSidecarTranscripts(ctx, doc); err != nil {
+		return err
 	}
 
-	if doc.DocType == "audio" && s.transcriber != nil {
-		if err := s.generateTranscriptRepresentation(ctx, doc, content); err != nil {
-			// Provider/transient failures should not fail the entire ingest run.
-			// Persistence/cache failures should still propagate.
-			if errors.Is(err, ErrTranscriptProviderFailure) {
-				s.getLogger().Printf("transcription skipped for %s: %v", doc.RelPath, err)
-				s.addErrors(1)
-				return nil
-			}
-			return err
+	if doc.DocType != "audio" || s.transcriber == nil {
+		return nil
+	}
+	if err := s.generateTranscriptRepresentation(ctx, doc, content); err != nil {
+		// Provider/transient failures should not fail the entire ingest run.
+		// Persistence/cache failures should still propagate.
+		if errors.Is(err, ErrTranscriptProviderFailure) {
+			s.getLogger().Printf("transcription skipped for %s: %v", doc.RelPath, err)
+			s.addErrors(1)
+			return nil
 		}
-		s.addRepresentations(1)
+		return err
+	}
+	s.addRepresentations(1)
+	return nil
+}
+
+// retireStaleSidecarTranscripts tombstones a media document's existing
+// sidecar-sourced transcript representations before a forced STT reindex
+// regenerates the transcript. Without this, the stale "transcript-<lang>" sidecar
+// rows stay live and surface alongside the fresh STT transcript in
+// retrieval/export (spec §8.6.4). It is a no-op for non-media docs, when the
+// store lacks the optional retirer capability, or when the document has no
+// sidecar transcripts (reported as os.ErrNotExist).
+func (s *Service) retireStaleSidecarTranscripts(ctx context.Context, doc model.Document) error {
+	if !isSidecarMediaType(doc.DocType) {
+		return nil
+	}
+	retirer, ok := s.store.(sidecarTranscriptRetirer)
+	if !ok {
+		return nil
+	}
+	n, err := retirer.SoftDeleteSidecarTranscripts(ctx, doc.RelPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("retire stale sidecar transcripts for %s: %w", doc.RelPath, err)
+	}
+	if n > 0 {
+		s.getLogger().Printf("retired %d stale sidecar transcript(s) for %s before STT reindex", n, doc.RelPath)
 	}
 	return nil
 }

--- a/internal/ingest/sidecar.go
+++ b/internal/ingest/sidecar.go
@@ -50,9 +50,14 @@ type transcriptMeta struct {
 // transcript path can detect media siblings (sidecars) and gate ingestion on
 // their freshness without an extra filesystem stat. It is set once per scan from
 // the same walk that drives discovery, so it works for any CorpusFS backend.
+// PathExcludes are honoured here so an operator who excludes e.g. "**/*.vtt"
+// never has those files read or persisted as transcripts (the exclude contract).
 func (s *Service) setSidecarIndex(files []DiscoveredFile) {
 	idx := make(map[string]int64, len(files))
 	for _, f := range files {
+		if matchesAnyPathExclude(f.RelPath, s.cfg.PathExcludes) {
+			continue
+		}
 		idx[f.RelPath] = f.MTimeUnix
 	}
 	s.sidecarMu.Lock()
@@ -80,29 +85,46 @@ func (s *Service) findSidecars(ctx context.Context, mediaRelPath string) []sidec
 		return nil
 	}
 	base := stripExt(mediaRelPath)
-	prefix := base + "."
+	// mediaExt is the media file's own extension token (e.g. "mp3"), lowercased
+	// and without the leading dot. A sidecar whose single tail token equals it —
+	// "clip.mp3.vtt" for media "clip.mp3" — is the media filename plus a subtitle
+	// extension, not a language-tagged sidecar, so it must be rejected.
+	mediaExt := strings.TrimPrefix(strings.ToLower(path.Ext(mediaRelPath)), ".")
 	var out []sidecarFile
 	for relPath, mtime := range index {
-		if !strings.HasPrefix(relPath, prefix) {
-			continue
-		}
 		ext := strings.ToLower(path.Ext(relPath))
 		if !isSidecarExt(ext) {
 			continue
 		}
-		// middle is the dotted segment(s) between the media base and the sidecar
-		// extension: "" for "clip.vtt", ".en" for "clip.en.vtt". It is derived
-		// from the stem (path without its extension) so an undifferentiated
-		// sidecar — whose stem equals the media base — yields an empty middle
-		// rather than mistaking the bare extension for a language tag. A multi-dot
-		// middle (e.g. "clip.foo.bar.vtt") takes the last dotted segment as the
-		// language tag.
-		middle := strings.TrimPrefix(strings.TrimSuffix(relPath, ext), base)
-		middle = strings.TrimPrefix(middle, ".")
+		// stem is the sidecar path without its subtitle extension. tail is the
+		// remainder after the media base. Only the documented shapes bind:
+		//   "<base><ext>"        → tail == ""        (no language)
+		//   "<base>.<lang><ext>" → tail == ".<lang>" (single token, no extra dots)
+		// Anything else — an extra dotted segment ("clip.notes.en.vtt") or the
+		// media extension reused as the token ("clip.mp3.vtt") for media
+		// "clip.mp3" — is NOT this media's sidecar and is skipped, so it cannot
+		// wrongly suppress STT.
+		stem := strings.TrimSuffix(relPath, ext)
+		if !strings.HasPrefix(stem, base) {
+			continue
+		}
+		tail := strings.TrimPrefix(stem, base)
 		lang := ""
-		if middle != "" {
-			parts := strings.Split(middle, ".")
-			lang = strings.TrimSpace(parts[len(parts)-1])
+		switch {
+		case tail == "":
+			// undifferentiated sidecar, no language tag
+		case strings.HasPrefix(tail, ".") && !strings.Contains(tail[1:], "."):
+			lang = strings.TrimSpace(tail[1:])
+			if lang == "" {
+				continue
+			}
+			if mediaExt != "" && strings.EqualFold(lang, mediaExt) {
+				// e.g. "clip.mp3.vtt" for media "clip.mp3": the token is the
+				// media's own extension, not a language tag.
+				continue
+			}
+		default:
+			continue
 		}
 		out = append(out, sidecarFile{RelPath: relPath, Lang: lang, Ext: ext, MTimeUnix: mtime})
 	}
@@ -132,6 +154,11 @@ func (s *Service) sidecarIndexOrWalk(ctx context.Context) map[string]int64 {
 	}
 	out := make(map[string]int64, len(files))
 	for _, f := range files {
+		// Honour PathExcludes here too so excluded files (e.g. "**/*.vtt") are
+		// never used as sidecars on the standalone fallback path.
+		if matchesAnyPathExclude(f.RelPath, s.cfg.PathExcludes) {
+			continue
+		}
 		out[f.RelPath] = f.MTimeUnix
 	}
 	return out

--- a/internal/ingest/sidecar.go
+++ b/internal/ingest/sidecar.go
@@ -90,10 +90,15 @@ func (s *Service) findSidecars(ctx context.Context, mediaRelPath string) []sidec
 		if !isSidecarExt(ext) {
 			continue
 		}
-		// middle is the text between the media base and the sidecar extension:
-		// "" for "clip.vtt", "en" for "clip.en.vtt". A multi-dot middle (e.g.
-		// "clip.foo.bar.vtt") takes the last dotted segment as the language tag.
-		middle := strings.TrimSuffix(relPath[len(prefix):], ext)
+		// middle is the dotted segment(s) between the media base and the sidecar
+		// extension: "" for "clip.vtt", ".en" for "clip.en.vtt". It is derived
+		// from the stem (path without its extension) so an undifferentiated
+		// sidecar — whose stem equals the media base — yields an empty middle
+		// rather than mistaking the bare extension for a language tag. A multi-dot
+		// middle (e.g. "clip.foo.bar.vtt") takes the last dotted segment as the
+		// language tag.
+		middle := strings.TrimPrefix(strings.TrimSuffix(relPath, ext), base)
+		middle = strings.TrimPrefix(middle, ".")
 		lang := ""
 		if middle != "" {
 			parts := strings.Split(middle, ".")
@@ -263,7 +268,7 @@ func (s *Service) persistSidecarTranscript(ctx context.Context, doc model.Docume
 	}
 	rep := model.Representation{
 		DocID:       doc.DocID,
-		RepType:     RepTypeTranscript,
+		RepType:     TranscriptRepType(lang),
 		RepHash:     sidecarRepHash(lang, cues),
 		MetaJSON:    string(metaJSON),
 		CreatedUnix: time.Now().Unix(),

--- a/internal/ingest/sidecar.go
+++ b/internal/ingest/sidecar.go
@@ -1,0 +1,338 @@
+package ingest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"path"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/subtitle"
+)
+
+// sidecarExtensions are the subtitle sidecar formats recognised next to a media
+// file (spec §8.6.4). They are checked case-insensitively.
+var sidecarExtensions = []string{".vtt", ".srt", ".ttml"}
+
+// sidecarSource is the meta_json source value recorded on a sidecar-derived
+// transcript representation. Sidecar transcripts are authored, not
+// model-derived, so they carry no STT provider/model derivation identity and are
+// NOT invalidated by an STT model change (spec §8.6.7).
+const sidecarSource = "sidecar"
+
+// sidecarFile is a discovered subtitle sidecar for a media document: its corpus
+// rel_path, the language tag parsed from the filename (empty when the sidecar is
+// undifferentiated, e.g. "clip.vtt"), the lowercased extension, and the sidecar
+// file's modification time used for the mtime freshness gate (§7.6).
+type sidecarFile struct {
+	RelPath   string
+	Lang      string
+	Ext       string
+	MTimeUnix int64
+}
+
+// transcriptMeta is the meta_json shape persisted on a transcript
+// representation (spec §5.2). For sidecar transcripts Source is "sidecar" and
+// the STT provider/model fields are omitted (omitempty) so the representation
+// carries no model derivation identity (§8.6.7).
+type transcriptMeta struct {
+	Source     string `json:"source,omitempty"`
+	Language   string `json:"language,omitempty"`
+	Timestamps bool   `json:"timestamps"`
+	Format     string `json:"format,omitempty"`
+}
+
+// setSidecarIndex records the mtime of every discovered file by rel_path so the
+// transcript path can detect media siblings (sidecars) and gate ingestion on
+// their freshness without an extra filesystem stat. It is set once per scan from
+// the same walk that drives discovery, so it works for any CorpusFS backend.
+func (s *Service) setSidecarIndex(files []DiscoveredFile) {
+	idx := make(map[string]int64, len(files))
+	for _, f := range files {
+		idx[f.RelPath] = f.MTimeUnix
+	}
+	s.sidecarMu.Lock()
+	s.sidecarIndex = idx
+	s.sidecarMu.Unlock()
+}
+
+// sidecarsEnabled reports whether subtitle sidecar ingestion is active. It
+// defaults to true (spec default media.sidecars.enabled: true) and is disabled
+// only by an explicit opt-out.
+func (s *Service) sidecarsEnabled() bool {
+	return !s.cfg.MediaSidecarsDisabled
+}
+
+// findSidecars returns the subtitle sidecars sitting next to the media document,
+// resolved through the corpus FS so it works for any backend. A sidecar matches
+// when its path is "<media-without-ext>.<ext>" (undifferentiated) or
+// "<media-without-ext>.<lang>.<ext>" (per-language). Results are sorted by
+// (language, extension) for deterministic selection. When the scan-built index
+// is unavailable (e.g. a direct GenerateTranscriptRepresentation call in tests),
+// it falls back to walking the corpus once.
+func (s *Service) findSidecars(ctx context.Context, mediaRelPath string) []sidecarFile {
+	index := s.sidecarIndexOrWalk(ctx)
+	if len(index) == 0 {
+		return nil
+	}
+	base := stripExt(mediaRelPath)
+	prefix := base + "."
+	var out []sidecarFile
+	for relPath, mtime := range index {
+		if !strings.HasPrefix(relPath, prefix) {
+			continue
+		}
+		ext := strings.ToLower(path.Ext(relPath))
+		if !isSidecarExt(ext) {
+			continue
+		}
+		// middle is the text between the media base and the sidecar extension:
+		// "" for "clip.vtt", "en" for "clip.en.vtt". A multi-dot middle (e.g.
+		// "clip.foo.bar.vtt") takes the last dotted segment as the language tag.
+		middle := strings.TrimSuffix(relPath[len(prefix):], ext)
+		lang := ""
+		if middle != "" {
+			parts := strings.Split(middle, ".")
+			lang = strings.TrimSpace(parts[len(parts)-1])
+		}
+		out = append(out, sidecarFile{RelPath: relPath, Lang: lang, Ext: ext, MTimeUnix: mtime})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Lang != out[j].Lang {
+			return out[i].Lang < out[j].Lang
+		}
+		return out[i].Ext < out[j].Ext
+	})
+	return out
+}
+
+// sidecarIndexOrWalk returns the scan-built sidecar index, falling back to a
+// one-shot corpus walk when none was set (direct/standalone calls). The walk
+// result is not cached so a standalone call always sees current mtimes.
+func (s *Service) sidecarIndexOrWalk(ctx context.Context) map[string]int64 {
+	s.sidecarMu.RLock()
+	idx := s.sidecarIndex
+	s.sidecarMu.RUnlock()
+	if idx != nil {
+		return idx
+	}
+	files, err := s.corpusFS().Walk(ctx, s.cfg.RootDir, DiscoverOptionsFromConfig(s.cfg).corpusfsOptions())
+	if err != nil {
+		s.getLogger().Printf("sidecar walk for %s failed: %v", s.cfg.RootDir, err)
+		return nil
+	}
+	out := make(map[string]int64, len(files))
+	for _, f := range files {
+		out[f.RelPath] = f.MTimeUnix
+	}
+	return out
+}
+
+// sidecarFingerprint returns a stable fingerprint of the media document's
+// sidecars (their sorted rel_paths and mtimes). Folding it into the media
+// document's content hash makes the incremental gate (§7.6) re-process the media
+// whenever a sidecar is added, removed, or modified — even though the media
+// bytes are unchanged. Returns "" when sidecars are disabled or the document is
+// not a media type with any sidecar.
+func (s *Service) sidecarFingerprint(ctx context.Context, relPath, docType string) string {
+	if !s.sidecarsEnabled() || !isSidecarMediaType(docType) {
+		return ""
+	}
+	sidecars := s.findSidecars(ctx, relPath)
+	if len(sidecars) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(sidecars))
+	for _, sc := range sidecars {
+		parts = append(parts, fmt.Sprintf("%s@%d", sc.RelPath, sc.MTimeUnix))
+	}
+	return strings.Join(parts, "\n")
+}
+
+// ingestSidecarTranscripts ingests the media document's subtitle sidecars as its
+// transcript representation(s), one representation per language, and reports
+// whether any were ingested. When it returns true the caller MUST skip STT — an
+// authored sidecar is authoritative over machine transcription (§8.6.4). Sidecar
+// transcripts bypass the output quality gate: they are authored text, not
+// model-derived output, so quarantining them as degenerate model output would be
+// wrong (§8.6.6/§8.6.7). A parse failure for one sidecar is logged and skipped;
+// remaining sidecars (and, if none parse, STT) still proceed.
+func (s *Service) ingestSidecarTranscripts(ctx context.Context, doc model.Document) (bool, error) {
+	if !s.sidecarsEnabled() || !isSidecarMediaType(doc.DocType) {
+		return false, nil
+	}
+	groups := s.collectSidecarCues(ctx, doc)
+	if len(groups) == 0 {
+		return false, nil
+	}
+	langs := make([]string, 0, len(groups))
+	for lang := range groups {
+		langs = append(langs, lang)
+	}
+	sort.Strings(langs)
+
+	ingested := false
+	for _, lang := range langs {
+		segments := chunkSubtitleCues(groups[lang])
+		if len(segments) == 0 {
+			continue
+		}
+		if err := s.persistSidecarTranscript(ctx, doc, lang, groups[lang], segments); err != nil {
+			return ingested, err
+		}
+		s.addRepresentations(1)
+		ingested = true
+	}
+	return ingested, nil
+}
+
+// collectSidecarCues parses every sidecar of the media document and groups the
+// resulting cues by language. A per-language sidecar (clip.en.vtt) contributes
+// to its own language; a bilingual TTML contributes to each xml:lang it carries.
+// Each language's cues are sorted by start time for stable, deterministic spans.
+func (s *Service) collectSidecarCues(ctx context.Context, doc model.Document) map[string][]subtitle.Cue {
+	groups := map[string][]subtitle.Cue{}
+	for _, sc := range s.findSidecars(ctx, doc.RelPath) {
+		content, err := s.readSidecar(ctx, sc.RelPath)
+		if err != nil {
+			s.getLogger().Printf("sidecar read %s: %v", sc.RelPath, err)
+			continue
+		}
+		for lang, cues := range parseSidecar(sc, content) {
+			groups[lang] = append(groups[lang], cues...)
+		}
+	}
+	for lang := range groups {
+		cues := groups[lang]
+		sort.SliceStable(cues, func(i, j int) bool {
+			if cues[i].StartMS != cues[j].StartMS {
+				return cues[i].StartMS < cues[j].StartMS
+			}
+			return cues[i].EndMS < cues[j].EndMS
+		})
+		groups[lang] = cues
+	}
+	return groups
+}
+
+// parseSidecar parses one sidecar file into language-keyed cue sets. VTT/SRT
+// carry a single (file-level) language taken from the filename; TTML may be
+// bilingual and is split per xml:lang, with the filename language used as a
+// fallback for any cues that declare none.
+func parseSidecar(sc sidecarFile, content string) map[string][]subtitle.Cue {
+	out := map[string][]subtitle.Cue{}
+	switch sc.Ext {
+	case ".ttml":
+		groups, err := subtitle.ParseTTMLByLang(content)
+		if err != nil {
+			return out
+		}
+		for _, g := range groups {
+			lang := g.Lang
+			if lang == "" {
+				lang = sc.Lang
+			}
+			out[lang] = append(out[lang], g.Cues...)
+		}
+	case ".srt":
+		if cues, err := subtitle.ParseSRT(content); err == nil {
+			out[sc.Lang] = cues
+		}
+	default: // .vtt
+		if cues, err := subtitle.ParseVTT(content); err == nil {
+			out[sc.Lang] = cues
+		}
+	}
+	return out
+}
+
+// persistSidecarTranscript writes one language's sidecar cues as a transcript
+// representation plus its time-spanned chunks. The chunks are inserted healthy
+// (no quarantine decision) so they embed normally; sidecar text is never
+// screened by the quality gate (§8.6.6/§8.6.7). meta_json records source=sidecar
+// and the language so retrieval and re-derivation treat it as authored.
+func (s *Service) persistSidecarTranscript(ctx context.Context, doc model.Document, lang string, cues []subtitle.Cue, segments []chunkSegment) error {
+	meta := transcriptMeta{Source: sidecarSource, Language: lang, Timestamps: true}
+	metaJSON, err := json.Marshal(meta)
+	if err != nil {
+		return fmt.Errorf("marshal sidecar transcript meta: %w", err)
+	}
+	rep := model.Representation{
+		DocID:       doc.DocID,
+		RepType:     RepTypeTranscript,
+		RepHash:     sidecarRepHash(lang, cues),
+		MetaJSON:    string(metaJSON),
+		CreatedUnix: time.Now().Unix(),
+		Deleted:     false,
+	}
+	repID, err := s.repGen.store.UpsertRepresentation(ctx, rep)
+	if err != nil {
+		return fmt.Errorf("upsert sidecar transcript representation: %w", err)
+	}
+	// quarantineDecision{} = insert healthy chunks; sidecar text bypasses the gate.
+	if err := s.repGen.upsertChunksForRepresentation(ctx, repID, "text", segments, quarantineDecision{}); err != nil {
+		return fmt.Errorf("persist sidecar transcript chunks: %w", err)
+	}
+	return nil
+}
+
+// sidecarRepHash derives a stable rep_hash from the language and cue content so
+// an unchanged sidecar dedups across re-ingests and a changed one produces a new
+// representation identity.
+func sidecarRepHash(lang string, cues []subtitle.Cue) string {
+	var b strings.Builder
+	b.WriteString(lang)
+	b.WriteByte('\n')
+	for _, c := range cues {
+		fmt.Fprintf(&b, "%d-%d:%s\n", c.StartMS, c.EndMS, c.Text)
+	}
+	return computeRepHash([]byte(b.String()))
+}
+
+// readSidecar reads a sidecar file's bytes through the corpus FS and normalises
+// them to valid UTF-8 with LF line endings.
+func (s *Service) readSidecar(ctx context.Context, relPath string) (string, error) {
+	rc, err := s.corpusFS().Open(ctx, relPath)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = rc.Close() }()
+	raw, err := io.ReadAll(rc)
+	if err != nil {
+		return "", err
+	}
+	return string(NormalizeUTF8(raw)), nil
+}
+
+// IngestSidecarTranscripts exposes sidecar transcript ingestion for tests. It
+// returns whether any sidecar was ingested (true means STT should be skipped).
+func (s *Service) IngestSidecarTranscripts(ctx context.Context, doc model.Document) (bool, error) {
+	return s.ingestSidecarTranscripts(ctx, doc)
+}
+
+// isSidecarMediaType reports whether a sidecar transcript may stand in for STT
+// on this doc type. Audio and video are the media types that carry transcripts
+// (§8.6.4).
+func isSidecarMediaType(docType string) bool {
+	return docType == "audio" || docType == "video"
+}
+
+// isSidecarExt reports whether ext (lowercased, with leading dot) is a
+// recognised subtitle sidecar extension.
+func isSidecarExt(ext string) bool {
+	for _, e := range sidecarExtensions {
+		if ext == e {
+			return true
+		}
+	}
+	return false
+}
+
+// stripExt removes the final extension from a path, preserving directories.
+func stripExt(p string) string {
+	return strings.TrimSuffix(p, path.Ext(p))
+}

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -941,14 +941,19 @@ func (s *SQLiteStore) TranscriptRepresentations(ctx context.Context, relPath str
 		return nil, err
 	}
 
+	// Match the bare "transcript" rep_type and any language-suffixed
+	// "transcript-<lang>" so per-language sidecar/translated transcripts (each a
+	// distinct rep_type under UNIQUE(doc_id, rep_type)) are all surfaced; the
+	// caller selects among them by meta_json language.
 	rows, err := db.QueryContext(
 		ctx,
 		`SELECT rep_id, meta_json
 		 FROM representations
-		 WHERE doc_id = ? AND rep_type = ? AND deleted = 0
+		 WHERE doc_id = ? AND (rep_type = ? OR rep_type LIKE ?) AND deleted = 0
 		 ORDER BY rep_id ASC`,
 		docID,
 		"transcript",
+		"transcript-%",
 	)
 	if err != nil {
 		return nil, err

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -974,6 +974,89 @@ func (s *SQLiteStore) TranscriptRepresentations(ctx context.Context, relPath str
 	return out, nil
 }
 
+// SoftDeleteSidecarTranscripts tombstones (deleted = 1) the document's
+// sidecar-sourced transcript representations and their chunks, returning the
+// number of representations retired. A representation is treated as
+// sidecar-sourced when its rep_type is a language-suffixed "transcript-<lang>"
+// (per-language sidecars persist under that rep_type) OR its rep_type is the
+// bare "transcript" with meta_json source == "sidecar". This lets a forced STT
+// reindex clear stale authored sidecar transcripts before writing the fresh
+// machine transcript, so retrieval/export never mix the two (spec §8.6.4). The
+// document-missing case is reported as os.ErrNotExist for parity with
+// TranscriptRepresentations.
+func (s *SQLiteStore) SoftDeleteSidecarTranscripts(ctx context.Context, relPath string) (int, error) {
+	normalizedPath, err := normalizeRelPath(relPath)
+	if err != nil {
+		return 0, err
+	}
+
+	db, err := s.ensureDB(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer s.ReleaseDB()
+
+	var docID int64
+	if err := db.QueryRowContext(
+		ctx,
+		`SELECT doc_id FROM documents WHERE rel_path = ? AND deleted = 0 LIMIT 1`,
+		normalizedPath,
+	).Scan(&docID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, os.ErrNotExist
+		}
+		return 0, err
+	}
+
+	// Identify the sidecar-sourced transcript reps: every "transcript-<lang>"
+	// (per-language sidecar rep_type) plus any bare "transcript" whose meta_json
+	// declares source == "sidecar". JSON containment is matched with LIKE rather
+	// than a JSON function to stay portable across SQLite builds.
+	const sidecarSourcePredicate = `(rep_type LIKE 'transcript-%' OR (rep_type = 'transcript' AND meta_json LIKE '%"source":"sidecar"%'))`
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	rows, err := tx.QueryContext(
+		ctx,
+		`SELECT rep_id FROM representations WHERE doc_id = ? AND deleted = 0 AND `+sidecarSourcePredicate,
+		docID,
+	)
+	if err != nil {
+		return 0, err
+	}
+	var repIDs []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			_ = rows.Close()
+			return 0, err
+		}
+		repIDs = append(repIDs, id)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return 0, err
+	}
+	_ = rows.Close()
+
+	for _, id := range repIDs {
+		if _, err := tx.ExecContext(ctx, `UPDATE chunks SET deleted = 1 WHERE rep_id = ?`, id); err != nil {
+			return 0, err
+		}
+		if _, err := tx.ExecContext(ctx, `UPDATE representations SET deleted = 1 WHERE rep_id = ?`, id); err != nil {
+			return 0, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	return len(repIDs), nil
+}
+
 // TranscriptSpanChunks returns the active chunks of a transcript representation
 // joined to their span rows, ordered by span start then end. Only "time" spans
 // carry subtitle timing; the span is reconstructed through the same

--- a/internal/subtitle/parser.go
+++ b/internal/subtitle/parser.go
@@ -220,10 +220,21 @@ func stripInlineTags(s string) string {
 	return strings.TrimSpace(inlineTagRe.ReplaceAllString(s, ""))
 }
 
-// splitLines splits content on LF after normalising CRLF and lone CR to LF so
-// the scanner sees uniform line breaks regardless of the file's origin OS.
+// splitLines splits content on LF after stripping a leading UTF-8 BOM and
+// normalising CRLF and lone CR to LF so the scanner sees uniform line breaks
+// regardless of the file's origin OS. Windows-authored subtitle files commonly
+// carry a BOM; left in place it would prevent the first line from matching the
+// WEBVTT header or a timing line.
 func splitLines(content string) []string {
+	content = stripBOM(content)
 	content = strings.ReplaceAll(content, "\r\n", "\n")
 	content = strings.ReplaceAll(content, "\r", "\n")
 	return strings.Split(content, "\n")
+}
+
+// stripBOM removes a single leading UTF-8 BOM (U+FEFF), if present. Such a mark
+// is non-whitespace, so left in place it would block the WEBVTT-header / timing
+// line match on the first line of a Windows-authored subtitle file.
+func stripBOM(content string) string {
+	return strings.TrimPrefix(content, "\uFEFF")
 }

--- a/internal/subtitle/parser.go
+++ b/internal/subtitle/parser.go
@@ -1,0 +1,229 @@
+package subtitle
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// ParseError is returned when a subtitle document cannot be parsed into any
+// cues. It is intentionally lightweight (a message string) so callers can log a
+// content-free diagnostic without coupling to a richer error type.
+type ParseError struct{ Msg string }
+
+func (e *ParseError) Error() string { return e.Msg }
+
+// cueTimingRe matches a "start --> end" line in WebVTT/SRT. The timestamps may
+// use either a dot (VTT) or a comma (SRT) before the millisecond field, and the
+// hours component is optional (VTT permits "MM:SS.mmm"). Trailing cue settings
+// after the end timestamp (VTT positioning, e.g. "align:start") are ignored.
+var cueTimingRe = regexp.MustCompile(`^\s*(\d{1,2}:)?(\d{1,2}):(\d{2})[.,](\d{1,3})\s*-->\s*(\d{1,2}:)?(\d{1,2}):(\d{2})[.,](\d{1,3})`)
+
+// ParseVTT parses a WebVTT document into ordered cues. It is robust to common
+// real-world variation: an optional "WEBVTT" header line, optional cue
+// identifier lines preceding a timing line, NOTE and STYLE/REGION blocks (which
+// are skipped), and either dot or comma millisecond separators. Cues are
+// returned in document order with 1-based Index values; cues whose text is empty
+// after trimming are dropped. A document with no parseable cue yields a
+// *ParseError so the caller can fall back to STT rather than ingesting nothing.
+func ParseVTT(content string) ([]Cue, error) {
+	return parseVTTSRT(content)
+}
+
+// ParseSRT parses a SubRip (SRT) document into ordered cues. SRT blocks are an
+// optional numeric index line, a "HH:MM:SS,mmm --> HH:MM:SS,mmm" timing line,
+// and one or more text lines, separated by blank lines. The parser is tolerant
+// of dot or comma separators and of a missing index line. See ParseVTT for the
+// shared return contract.
+func ParseSRT(content string) ([]Cue, error) {
+	return parseVTTSRT(content)
+}
+
+// parseVTTSRT parses the shared block structure of WebVTT and SRT. Because the
+// two formats differ only in header/metadata conventions and the millisecond
+// separator (both of which this parser already tolerates), a single
+// line-oriented scanner handles both: it walks lines, recognises a timing line
+// by its "-->" shape, accumulates the following non-empty lines as cue text, and
+// flushes on a blank line or the next timing line. Identifier/index lines,
+// the WEBVTT header, and NOTE/STYLE/REGION blocks are ignored.
+func parseVTTSRT(content string) ([]Cue, error) {
+	sc := &cueScanner{}
+	skipBlock := false
+	for _, raw := range splitLines(content) {
+		line := strings.TrimRight(raw, " \t")
+		trimmed := strings.TrimSpace(line)
+
+		if trimmed == "" {
+			sc.flush()
+			skipBlock = false
+			continue
+		}
+		if skipBlock {
+			continue
+		}
+		if isMetadataBlockStart(trimmed) {
+			skipBlock = true
+			continue
+		}
+		if s, e, ok := parseTimingLine(trimmed); ok {
+			sc.startCue(s, e)
+			continue
+		}
+		if isVTTHeader(trimmed) {
+			continue
+		}
+		sc.addLine(line)
+	}
+	sc.flush()
+
+	if len(sc.cues) == 0 {
+		return nil, &ParseError{Msg: "subtitle: no cues parsed"}
+	}
+	return sc.cues, nil
+}
+
+// cueScanner accumulates the parser's per-cue state. Splitting it out of
+// parseVTTSRT keeps that function's branch count low (gocyclo) while making the
+// "timing line starts a cue, blank line flushes it" lifecycle explicit.
+type cueScanner struct {
+	cues       []Cue
+	haveTiming bool
+	start, end int
+	textLines  []string
+}
+
+// startCue begins a new cue at the given bounds, first flushing any in-progress
+// cue. Any text accumulated before the timing line is a cue identifier (VTT) or
+// index line (SRT), not cue text, so flush discards it.
+func (c *cueScanner) startCue(start, end int) {
+	c.flush()
+	c.haveTiming = true
+	c.start, c.end = start, end
+}
+
+// addLine accumulates a content line. Before a timing line is seen the line is an
+// identifier/index/header candidate, so only the most recent is kept (and later
+// discarded by flush); after a timing line it is cue text.
+func (c *cueScanner) addLine(line string) {
+	if c.haveTiming {
+		c.textLines = append(c.textLines, line)
+		return
+	}
+	c.textLines = c.textLines[:0]
+	c.textLines = append(c.textLines, line)
+}
+
+// flush emits the in-progress cue (if any) and resets the buffer. A cue with
+// empty text after trimming/tag-stripping is dropped.
+func (c *cueScanner) flush() {
+	if c.haveTiming {
+		if text := joinCueText(c.textLines); text != "" {
+			c.cues = append(c.cues, Cue{Index: len(c.cues) + 1, StartMS: c.start, EndMS: c.end, Text: text})
+		}
+	}
+	c.haveTiming = false
+	c.textLines = c.textLines[:0]
+}
+
+// joinCueText joins the accumulated text lines of a cue with newlines, trims the
+// result, and strips inline tags. Empty lines are dropped so a trailing blank
+// does not introduce spurious whitespace.
+func joinCueText(lines []string) string {
+	parts := make([]string, 0, len(lines))
+	for _, l := range lines {
+		l = stripInlineTags(strings.TrimSpace(l))
+		if l != "" {
+			parts = append(parts, l)
+		}
+	}
+	return strings.TrimSpace(strings.Join(parts, "\n"))
+}
+
+// parseTimingLine parses a "start --> end" line into millisecond bounds. It
+// returns ok=false when the line is not a timing line. end is clamped to be ≥
+// start so a malformed cue never produces a negative-length window.
+func parseTimingLine(line string) (startMS, endMS int, ok bool) {
+	m := cueTimingRe.FindStringSubmatch(line)
+	if m == nil {
+		return 0, 0, false
+	}
+	startMS = timestampToMS(m[1], m[2], m[3], m[4])
+	endMS = timestampToMS(m[5], m[6], m[7], m[8])
+	if endMS < startMS {
+		endMS = startMS
+	}
+	return startMS, endMS, true
+}
+
+// timestampToMS converts captured "[HH:]MM:SS" + millis fields into total
+// milliseconds. The hours group includes its trailing colon (e.g. "01:") or is
+// empty; the millis string is right-padded to three digits so ".5" means 500ms.
+func timestampToMS(hh, mm, ss, ms string) int {
+	hours := 0
+	if hh != "" {
+		hours, _ = strconv.Atoi(strings.TrimSuffix(hh, ":"))
+	}
+	minutes, _ := strconv.Atoi(mm)
+	seconds, _ := strconv.Atoi(ss)
+	millis, _ := strconv.Atoi(padMillis(ms))
+	total := ((hours*60+minutes)*60+seconds)*1000 + millis
+	if total < 0 {
+		total = 0
+	}
+	return total
+}
+
+// padMillis right-pads a millisecond field to exactly three digits so a
+// fractional second written with fewer digits (".5" / ".05") scales correctly,
+// and truncates any excess so a four-digit field cannot overflow the field.
+func padMillis(ms string) string {
+	switch {
+	case len(ms) == 0:
+		return "000"
+	case len(ms) >= 3:
+		return ms[:3]
+	default:
+		return ms + strings.Repeat("0", 3-len(ms))
+	}
+}
+
+func isVTTHeader(line string) bool {
+	return strings.HasPrefix(line, "WEBVTT")
+}
+
+// isMetadataBlockStart reports whether a line begins a WebVTT NOTE, STYLE, or
+// REGION block (all of which carry no cue text and run to the next blank line).
+func isMetadataBlockStart(line string) bool {
+	switch {
+	case line == "NOTE" || strings.HasPrefix(line, "NOTE "):
+		return true
+	case line == "STYLE":
+		return true
+	case line == "REGION":
+		return true
+	default:
+		return false
+	}
+}
+
+// inlineTagRe matches WebVTT/TTML inline markup (e.g. <c.color>, <v Speaker>,
+// <00:00:01.000>, </i>) that should not appear in indexed cue text.
+var inlineTagRe = regexp.MustCompile(`</?[^>]+>`)
+
+// stripInlineTags removes inline markup from cue text so the indexed transcript
+// is plain text. It is deterministic and leaves non-tag angle content untouched
+// only when it is not a well-formed tag.
+func stripInlineTags(s string) string {
+	if !strings.ContainsRune(s, '<') {
+		return s
+	}
+	return strings.TrimSpace(inlineTagRe.ReplaceAllString(s, ""))
+}
+
+// splitLines splits content on LF after normalising CRLF and lone CR to LF so
+// the scanner sees uniform line breaks regardless of the file's origin OS.
+func splitLines(content string) []string {
+	content = strings.ReplaceAll(content, "\r\n", "\n")
+	content = strings.ReplaceAll(content, "\r", "\n")
+	return strings.Split(content, "\n")
+}

--- a/internal/subtitle/ttml.go
+++ b/internal/subtitle/ttml.go
@@ -33,6 +33,15 @@ func ParseTTML(content string) ([]Cue, error) {
 	if len(all) == 0 {
 		return nil, &ParseError{Msg: "subtitle: no TTML cues parsed"}
 	}
+	// ParseTTMLByLang returns language-sorted groups, so the naive flatten above
+	// is language-grouped, not document (time) order. Sort by start time
+	// (tie-break end time) so the flattened stream matches the doc-order contract.
+	sort.SliceStable(all, func(i, j int) bool {
+		if all[i].StartMS != all[j].StartMS {
+			return all[i].StartMS < all[j].StartMS
+		}
+		return all[i].EndMS < all[j].EndMS
+	})
 	reindex(all)
 	return all, nil
 }

--- a/internal/subtitle/ttml.go
+++ b/internal/subtitle/ttml.go
@@ -1,0 +1,261 @@
+package subtitle
+
+import (
+	"encoding/xml"
+	"io"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// LangCues pairs a (possibly empty) language tag with the cues authored in that
+// language. A monolingual TTML file yields a single LangCues with Lang == "";
+// a bilingual file (per-language <div>/<p> via xml:lang) yields one per language.
+type LangCues struct {
+	Lang string
+	Cues []Cue
+}
+
+// ParseTTML parses a TTML (Timed Text Markup Language) document into ordered
+// cues, flattening every language present into one cue stream in document order.
+// Use ParseTTMLByLang when per-language separation is required (bilingual
+// subtitles). Returns a *ParseError when no timed paragraph is found.
+func ParseTTML(content string) ([]Cue, error) {
+	groups, err := ParseTTMLByLang(content)
+	if err != nil {
+		return nil, err
+	}
+	var all []Cue
+	for _, g := range groups {
+		all = append(all, g.Cues...)
+	}
+	if len(all) == 0 {
+		return nil, &ParseError{Msg: "subtitle: no TTML cues parsed"}
+	}
+	reindex(all)
+	return all, nil
+}
+
+// ParseTTMLByLang parses a TTML document into per-language cue sets. The
+// language for a <p> is the nearest xml:lang in scope (on the <p>, an ancestor
+// <div>/<body>, or the root <tt>), defaulting to "" when none is declared.
+// Groups are returned sorted by language tag for determinism (empty language
+// first), each with 1-based cue indices. Bilingual files thus produce distinct
+// per-language transcript inputs (spec §8.6.4).
+func ParseTTMLByLang(content string) ([]LangCues, error) {
+	byLang := map[string][]Cue{}
+	dec := xml.NewDecoder(strings.NewReader(content))
+	langStack := []string{""}
+	tickRate := 0 // ticks per second, if a tt@ttp:tickRate is declared
+
+	for {
+		tok, err := dec.Token()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, &ParseError{Msg: "subtitle: TTML parse error: " + err.Error()}
+		}
+		switch el := tok.(type) {
+		case xml.StartElement:
+			lang := inheritedLang(langStack, el)
+			langStack = append(langStack, lang)
+			if local(el.Name) == "tt" {
+				if tr := attrValue(el, "tickRate"); tr != "" {
+					tickRate, _ = strconv.Atoi(tr)
+				}
+			}
+			if local(el.Name) == "p" {
+				cue, ok := decodeTTMLParagraph(dec, el, tickRate)
+				// The paragraph's own content was consumed by decodeTTMLParagraph
+				// up to its EndElement, so pop the lang we just pushed for it.
+				langStack = langStack[:len(langStack)-1]
+				if ok {
+					byLang[lang] = append(byLang[lang], cue)
+				}
+			}
+		case xml.EndElement:
+			if len(langStack) > 1 {
+				langStack = langStack[:len(langStack)-1]
+			}
+		}
+	}
+
+	groups := make([]LangCues, 0, len(byLang))
+	langs := make([]string, 0, len(byLang))
+	for l := range byLang {
+		langs = append(langs, l)
+	}
+	sort.Strings(langs)
+	for _, l := range langs {
+		cues := byLang[l]
+		reindex(cues)
+		groups = append(groups, LangCues{Lang: l, Cues: cues})
+	}
+	if len(groups) == 0 {
+		return nil, &ParseError{Msg: "subtitle: no TTML cues parsed"}
+	}
+	return groups, nil
+}
+
+// decodeTTMLParagraph reads a <p> element's begin/end timing and inner text
+// (flattening nested spans and converting <br/> to newlines), returning the cue
+// and whether it carries usable timing and text. The decoder is advanced to the
+// paragraph's EndElement.
+func decodeTTMLParagraph(dec *xml.Decoder, start xml.StartElement, tickRate int) (Cue, bool) {
+	beginMS, hasBegin := parseTTMLTime(attrValue(start, "begin"), tickRate)
+	endMS, hasEnd := parseTTMLTime(attrValue(start, "end"), tickRate)
+
+	var b strings.Builder
+	depth := 1
+	for depth > 0 {
+		tok, err := dec.Token()
+		if err != nil {
+			break
+		}
+		switch el := tok.(type) {
+		case xml.StartElement:
+			depth++
+			if local(el.Name) == "br" {
+				b.WriteByte('\n')
+			}
+		case xml.EndElement:
+			depth--
+		case xml.CharData:
+			b.Write(el)
+		}
+	}
+
+	text := normalizeTTMLText(b.String())
+	if text == "" || !hasBegin {
+		return Cue{}, false
+	}
+	if !hasEnd || endMS < beginMS {
+		endMS = beginMS
+	}
+	return Cue{StartMS: beginMS, EndMS: endMS, Text: text}, true
+}
+
+// ttmlWhitespaceRe collapses runs of spaces/tabs within a line; TTML treats
+// inter-element whitespace loosely and authored files often indent paragraph
+// text.
+var ttmlWhitespaceRe = regexp.MustCompile(`[ \t]+`)
+
+// normalizeTTMLText trims and collapses whitespace per line while preserving
+// explicit <br/>-derived newlines, yielding clean plain text for indexing.
+func normalizeTTMLText(s string) string {
+	lines := strings.Split(s, "\n")
+	out := make([]string, 0, len(lines))
+	for _, l := range lines {
+		l = strings.TrimSpace(ttmlWhitespaceRe.ReplaceAllString(l, " "))
+		if l != "" {
+			out = append(out, l)
+		}
+	}
+	return strings.TrimSpace(strings.Join(out, "\n"))
+}
+
+// parseTTMLTime parses a TTML time expression into milliseconds. It supports the
+// two common forms: clock time "HH:MM:SS[.mmm]" / "HH:MM:SS:frames" and offset
+// time with a unit suffix ("12.5s", "500ms", "1500t" ticks). Returns ok=false
+// for an empty or unrecognised expression.
+func parseTTMLTime(v string, tickRate int) (ms int, ok bool) {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return 0, false
+	}
+	if strings.Contains(v, ":") {
+		return parseTTMLClock(v)
+	}
+	return parseTTMLOffset(v, tickRate)
+}
+
+// parseTTMLClock parses "HH:MM:SS[.fraction]" (a trailing ":frames" component,
+// if present, is ignored as we lack frame-rate context). Returns ok=false on a
+// malformed clock value.
+func parseTTMLClock(v string) (int, bool) {
+	parts := strings.Split(v, ":")
+	if len(parts) < 3 {
+		return 0, false
+	}
+	hours, err1 := strconv.Atoi(parts[0])
+	minutes, err2 := strconv.Atoi(parts[1])
+	secField := parts[2]
+	frac := 0
+	if dot := strings.IndexByte(secField, '.'); dot >= 0 {
+		frac, _ = strconv.Atoi(padMillis(secField[dot+1:]))
+		secField = secField[:dot]
+	}
+	seconds, err3 := strconv.Atoi(secField)
+	if err1 != nil || err2 != nil || err3 != nil {
+		return 0, false
+	}
+	total := ((hours*60+minutes)*60+seconds)*1000 + frac
+	if total < 0 {
+		return 0, false
+	}
+	return total, true
+}
+
+// parseTTMLOffset parses an offset-time value with a unit suffix: "s"
+// (seconds), "ms" (milliseconds), or "t" (ticks, scaled by tickRate when
+// declared). Returns ok=false for an unsupported unit or unparseable number.
+func parseTTMLOffset(v string, tickRate int) (int, bool) {
+	switch {
+	case strings.HasSuffix(v, "ms"):
+		n, err := strconv.ParseFloat(strings.TrimSuffix(v, "ms"), 64)
+		if err != nil {
+			return 0, false
+		}
+		return int(n), true
+	case strings.HasSuffix(v, "s"):
+		n, err := strconv.ParseFloat(strings.TrimSuffix(v, "s"), 64)
+		if err != nil {
+			return 0, false
+		}
+		return int(n * 1000), true
+	case strings.HasSuffix(v, "t"):
+		n, err := strconv.ParseFloat(strings.TrimSuffix(v, "t"), 64)
+		if err != nil || tickRate <= 0 {
+			return 0, false
+		}
+		return int(n / float64(tickRate) * 1000), true
+	default:
+		return 0, false
+	}
+}
+
+// inheritedLang returns the effective xml:lang for an element: its own xml:lang
+// when present, otherwise the language inherited from the enclosing scope.
+func inheritedLang(stack []string, el xml.StartElement) string {
+	for _, a := range el.Attr {
+		if a.Name.Local == "lang" && (a.Name.Space == "xml" || strings.HasSuffix(a.Name.Space, "XML/1998/namespace")) {
+			return strings.TrimSpace(a.Value)
+		}
+	}
+	if len(stack) > 0 {
+		return stack[len(stack)-1]
+	}
+	return ""
+}
+
+// attrValue returns the value of the named (local) attribute, ignoring
+// namespace, or "" when absent.
+func attrValue(el xml.StartElement, name string) string {
+	for _, a := range el.Attr {
+		if a.Name.Local == name {
+			return strings.TrimSpace(a.Value)
+		}
+	}
+	return ""
+}
+
+func local(n xml.Name) string { return n.Local }
+
+// reindex assigns contiguous 1-based Index values to cues in order.
+func reindex(cues []Cue) {
+	for i := range cues {
+		cues[i].Index = i + 1
+	}
+}

--- a/tests/ingest/sidecar_test.go
+++ b/tests/ingest/sidecar_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/dirstral/dir2mcp/internal/config"
 	"github.com/dirstral/dir2mcp/internal/ingest"
 	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
 )
 
 // mapStore is a minimal Store + RepresentationStore that records documents by
@@ -170,9 +171,80 @@ func TestSidecar_PerLanguage_DistinctTranscripts(t *testing.T) {
 	if len(st.reps) != 2 {
 		t.Fatalf("expected two per-language transcript representations, got %d", len(st.reps))
 	}
-	// Languages are processed sorted: "en" first, then "fr".
+	// Languages are processed sorted: "en" first, then "fr". Each language gets
+	// a distinct rep_type ("transcript-en"/"transcript-fr") so the two rows
+	// coexist under UNIQUE(doc_id, rep_type) instead of overwriting each other.
 	assertSidecarMeta(t, st.reps[0].MetaJSON, "en")
 	assertSidecarMeta(t, st.reps[1].MetaJSON, "fr")
+	if st.reps[0].RepType == st.reps[1].RepType {
+		t.Fatalf("expected distinct per-language rep_types, both were %q", st.reps[0].RepType)
+	}
+}
+
+// TestSidecar_PerLanguage_RealStorePersistsBoth guards the
+// UNIQUE(doc_id, rep_type) collision: against the real SQLite store, two
+// per-language sidecars MUST persist as two distinct transcript representations
+// (selectable by language), not collapse into one.
+func TestSidecar_PerLanguage_RealStorePersistsBoth(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "talk.mp3"), "fake-audio")
+	writeFile(t, filepath.Join(root, "talk.en.vtt"), "WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nhello\n")
+	writeFile(t, filepath.Join(root, "talk.fr.vtt"), "WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nbonjour\n")
+
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	if err := st.Init(context.Background()); err != nil {
+		t.Fatalf("store init: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	svc := newSidecarService(t, root, t.TempDir(), st)
+
+	if err := st.UpsertDocument(context.Background(), model.Document{RelPath: "talk.mp3", DocType: "audio"}); err != nil {
+		t.Fatalf("upsert document: %v", err)
+	}
+	doc, err := st.GetDocumentByPath(context.Background(), "talk.mp3")
+	if err != nil {
+		t.Fatalf("get document: %v", err)
+	}
+	if _, err := svc.IngestSidecarTranscripts(context.Background(), doc); err != nil {
+		t.Fatalf("IngestSidecarTranscripts: %v", err)
+	}
+
+	reps, err := st.TranscriptRepresentations(context.Background(), "talk.mp3")
+	if err != nil {
+		t.Fatalf("TranscriptRepresentations: %v", err)
+	}
+	if len(reps) != 2 {
+		t.Fatalf("expected 2 per-language transcript reps in real store, got %d (%+v)", len(reps), reps)
+	}
+}
+
+// TestSidecar_Undifferentiated_HasNoLanguage verifies that an undifferentiated
+// sidecar ("clip.vtt", not "clip.en.vtt") is recorded with an EMPTY language —
+// the bare extension must not be mistaken for a language tag.
+func TestSidecar_Undifferentiated_HasNoLanguage(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "media", "lecture.mp3"), "fake-audio")
+	writeFile(t, filepath.Join(root, "media", "lecture.vtt"),
+		"WEBVTT\n\n00:00:00.000 --> 00:00:02.000\nIntro\n")
+
+	st := &fakeIngestStore{}
+	svc := newSidecarService(t, root, t.TempDir(), st)
+
+	doc := model.Document{DocID: 1, RelPath: "media/lecture.mp3", DocType: "audio"}
+	if _, err := svc.IngestSidecarTranscripts(context.Background(), doc); err != nil {
+		t.Fatalf("IngestSidecarTranscripts: %v", err)
+	}
+	if len(st.reps) != 1 {
+		t.Fatalf("expected one transcript representation, got %d", len(st.reps))
+	}
+	if got := st.reps[0].RepType; got != ingest.RepTypeTranscript {
+		t.Fatalf("undifferentiated sidecar must use the bare transcript rep_type, got %q", got)
+	}
+	if strings.Contains(st.reps[0].MetaJSON, `"language"`) {
+		t.Fatalf("undifferentiated sidecar must record no language, got meta %s", st.reps[0].MetaJSON)
+	}
 }
 
 func TestSidecar_ForceReindex_RunsSTTInsteadOfSidecar(t *testing.T) {

--- a/tests/ingest/sidecar_test.go
+++ b/tests/ingest/sidecar_test.go
@@ -307,6 +307,136 @@ func TestSidecar_FreshSidecarReprocessesUnchangedMedia(t *testing.T) {
 	}
 }
 
+// TestSidecar_FilenameMatching_RejectsExtraDottedSuffixes guards CodeRabbit
+// finding sidecar.go ~105: only "<base><ext>" (no lang) and "<base>.<lang><ext>"
+// (single token, no extra dots) bind to the media. Files with an extra dotted
+// segment — "clip.mp3.vtt" or "clip.notes.en.vtt" for media "clip.mp3" — must
+// NOT be treated as that media's sidecars (and so must not suppress STT).
+func TestSidecar_FilenameMatching_RejectsExtraDottedSuffixes(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "clip.mp3"), "fake-audio")
+	// Valid sidecars (must bind):
+	writeFile(t, filepath.Join(root, "clip.vtt"), "WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nundiff\n")
+	writeFile(t, filepath.Join(root, "clip.en.vtt"), "WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nenglish\n")
+	// Invalid (extra dotted suffix) — must NOT bind to clip.mp3:
+	writeFile(t, filepath.Join(root, "clip.mp3.vtt"), "WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nwrong\n")
+	writeFile(t, filepath.Join(root, "clip.notes.en.vtt"), "WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nnotes\n")
+
+	st := &fakeIngestStore{}
+	svc := newSidecarService(t, root, t.TempDir(), st)
+
+	doc := model.Document{DocID: 1, RelPath: "clip.mp3", DocType: "audio"}
+	ingested, err := svc.IngestSidecarTranscripts(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("IngestSidecarTranscripts: %v", err)
+	}
+	if !ingested {
+		t.Fatal("expected the valid sidecars to be ingested")
+	}
+	// Exactly two reps: the undifferentiated (bare "transcript") and the English
+	// ("transcript-en"). The two extra-dotted files must contribute nothing.
+	if len(st.reps) != 2 {
+		t.Fatalf("expected exactly 2 transcript reps (clip.vtt + clip.en.vtt), got %d: %+v", len(st.reps), st.reps)
+	}
+	repTypes := map[string]bool{}
+	for _, r := range st.reps {
+		repTypes[r.RepType] = true
+	}
+	if !repTypes[ingest.RepTypeTranscript] || !repTypes[ingest.TranscriptRepType("en")] {
+		t.Fatalf("expected bare + en transcript rep_types, got %v", repTypes)
+	}
+}
+
+// TestSidecar_PathExcludes_NotUsedAsSidecar guards CodeRabbit finding
+// sidecar.go ~137 / service.go seeding: a sidecar whose rel_path matches a
+// configured PathExclude must be ignored entirely — neither read nor persisted —
+// so STT runs instead of being suppressed by an excluded subtitle file.
+func TestSidecar_PathExcludes_NotUsedAsSidecar(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "song.mp3"), "fake-audio")
+	writeFile(t, filepath.Join(root, "song.vtt"), "WEBVTT\n\n00:00:00.000 --> 00:00:02.000\nexcluded sidecar\n")
+
+	st := &fakeIngestStore{}
+	stt := &fakeTranscriber{text: "[00:00] from stt"}
+	cfg := config.Config{RootDir: root, StateDir: t.TempDir(), PathExcludes: []string{"**/*.vtt"}}
+	svc := mustNewIngestService(t, cfg, st)
+	svc.SetTranscriber(stt)
+
+	f := ingest.DiscoveredFile{RelPath: "song.mp3", SizeBytes: 10, MTimeUnix: time.Now().Unix()}
+	if err := svc.ProcessDocument(context.Background(), f, nil, false); err != nil {
+		t.Fatalf("ProcessDocument: %v", err)
+	}
+	if stt.calls != 1 {
+		t.Fatalf("expected STT to run once (excluded .vtt must not suppress it), got %d call(s)", stt.calls)
+	}
+	if len(st.reps) != 1 || st.reps[0].MetaJSON != "" {
+		t.Fatalf("expected one STT transcript rep with no sidecar meta, got %+v", st.reps)
+	}
+}
+
+// TestSidecar_ForceReindex_RetiresStaleSidecarReps guards CodeRabbit finding
+// service.go ~1231: on a forced STT reindex the document's existing
+// sidecar-sourced "transcript-<lang>" reps must be tombstoned before the fresh
+// STT transcript is written, so TranscriptRepresentations returns only the live
+// STT rep — never a stale sidecar transcript alongside it.
+func TestSidecar_ForceReindex_RetiresStaleSidecarReps(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "talk.mp3"), "fake-audio")
+	writeFile(t, filepath.Join(root, "talk.en.vtt"), "WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nold sidecar\n")
+
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	if err := st.Init(context.Background()); err != nil {
+		t.Fatalf("store init: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	// First, ingest the sidecar as the transcript (no STT).
+	sidecarSvc := newSidecarService(t, root, t.TempDir(), st)
+	if err := st.UpsertDocument(context.Background(), model.Document{RelPath: "talk.mp3", DocType: "audio"}); err != nil {
+		t.Fatalf("upsert document: %v", err)
+	}
+	doc, err := st.GetDocumentByPath(context.Background(), "talk.mp3")
+	if err != nil {
+		t.Fatalf("get document: %v", err)
+	}
+	if _, err := sidecarSvc.IngestSidecarTranscripts(context.Background(), doc); err != nil {
+		t.Fatalf("IngestSidecarTranscripts: %v", err)
+	}
+	reps, err := st.TranscriptRepresentations(context.Background(), "talk.mp3")
+	if err != nil {
+		t.Fatalf("TranscriptRepresentations: %v", err)
+	}
+	if len(reps) != 1 || !strings.Contains(reps[0].MetaJSON, `"source":"sidecar"`) {
+		t.Fatalf("expected one live sidecar transcript rep before force, got %+v", reps)
+	}
+
+	// Now force a reindex: STT must run and the stale sidecar rep must be retired.
+	sttSvc := mustNewIngestService(t, config.Config{RootDir: root, StateDir: t.TempDir()}, st)
+	stt := &fakeTranscriber{text: "[00:00] fresh stt"}
+	sttSvc.SetTranscriber(stt)
+	f := ingest.DiscoveredFile{RelPath: "talk.mp3", SizeBytes: 10, MTimeUnix: time.Now().Unix()}
+	if err := sttSvc.ProcessDocument(context.Background(), f, nil, true); err != nil {
+		t.Fatalf("ProcessDocument(force): %v", err)
+	}
+	if stt.calls != 1 {
+		t.Fatalf("expected STT to run once under --force, got %d", stt.calls)
+	}
+
+	reps, err = st.TranscriptRepresentations(context.Background(), "talk.mp3")
+	if err != nil {
+		t.Fatalf("TranscriptRepresentations after force: %v", err)
+	}
+	if len(reps) != 1 {
+		t.Fatalf("expected exactly 1 live transcript rep after force (stale sidecar retired), got %d: %+v", len(reps), reps)
+	}
+	if strings.Contains(reps[0].MetaJSON, `"source":"sidecar"`) {
+		t.Fatalf("expected the live rep to be the fresh STT transcript, but it is still a sidecar: %s", reps[0].MetaJSON)
+	}
+}
+
 func assertSidecarMeta(t *testing.T, metaJSON, wantLang string) {
 	t.Helper()
 	if metaJSON == "" {

--- a/tests/ingest/sidecar_test.go
+++ b/tests/ingest/sidecar_test.go
@@ -1,0 +1,249 @@
+package tests
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// mapStore is a minimal Store + RepresentationStore that records documents by
+// rel_path across runs so the incremental gate (content-hash comparison) behaves
+// like the real store. It is used by the full-Run sidecar tests.
+type mapStore struct {
+	docs  map[string]model.Document
+	reps  []model.Representation
+	chunk int
+}
+
+func newMapStore() *mapStore { return &mapStore{docs: map[string]model.Document{}} }
+
+func (m *mapStore) Init(context.Context) error { return nil }
+func (m *mapStore) Close() error               { return nil }
+func (m *mapStore) UpsertDocument(_ context.Context, doc model.Document) error {
+	if doc.DocID == 0 {
+		if prev, ok := m.docs[doc.RelPath]; ok {
+			doc.DocID = prev.DocID
+		} else {
+			doc.DocID = int64(len(m.docs) + 1)
+		}
+	}
+	m.docs[doc.RelPath] = doc
+	return nil
+}
+func (m *mapStore) GetDocumentByPath(_ context.Context, relPath string) (model.Document, error) {
+	if d, ok := m.docs[relPath]; ok {
+		return d, nil
+	}
+	return model.Document{}, os.ErrNotExist
+}
+func (m *mapStore) ListFiles(context.Context, string, string, int, int) ([]model.Document, int64, error) {
+	out := make([]model.Document, 0, len(m.docs))
+	for _, d := range m.docs {
+		out = append(out, d)
+	}
+	return out, int64(len(out)), nil
+}
+func (m *mapStore) UpsertRepresentation(_ context.Context, rep model.Representation) (int64, error) {
+	m.reps = append(m.reps, rep)
+	return int64(len(m.reps)), nil
+}
+func (m *mapStore) InsertChunkWithSpans(_ context.Context, _ model.Chunk, _ []model.Span) (int64, error) {
+	m.chunk++
+	return int64(m.chunk), nil
+}
+func (m *mapStore) SoftDeleteChunksFromOrdinal(context.Context, int64, int) error { return nil }
+func (m *mapStore) WithTx(ctx context.Context, fn func(tx model.RepresentationStore) error) error {
+	return fn(m)
+}
+func (m *mapStore) lastHashFor(relPath string) string { return m.docs[relPath].ContentHash }
+
+// explodingTranscriber fails the test the moment Transcribe is called. Sidecar
+// ingestion MUST short-circuit STT, so any call indicates the precedence rule
+// was not honoured.
+type explodingTranscriber struct{ t *testing.T }
+
+func (e *explodingTranscriber) Transcribe(context.Context, string, []byte) (string, error) {
+	e.t.Fatalf("STT must not be called when a subtitle sidecar exists")
+	return "", nil
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// newSidecarService builds a service rooted at root with an exploding
+// transcriber so a stray STT call fails the test.
+func newSidecarService(t *testing.T, root, stateDir string, st model.Store) *ingest.Service {
+	t.Helper()
+	svc := mustNewIngestService(t, config.Config{RootDir: root, StateDir: stateDir}, st)
+	svc.SetTranscriber(&explodingTranscriber{t: t})
+	return svc
+}
+
+func TestSidecar_VTT_IngestsTranscriptWithoutSTT(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "media", "lecture.mp3"), "fake-audio")
+	writeFile(t, filepath.Join(root, "media", "lecture.vtt"),
+		"WEBVTT\n\n00:00:00.000 --> 00:00:02.000\nIntro\n\n00:00:02.000 --> 00:00:05.000\nChapter one\n")
+
+	st := &fakeIngestStore{}
+	svc := newSidecarService(t, root, t.TempDir(), st)
+
+	doc := model.Document{DocID: 1, RelPath: "media/lecture.mp3", DocType: "audio"}
+	ingested, err := svc.IngestSidecarTranscripts(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("IngestSidecarTranscripts: %v", err)
+	}
+	if !ingested {
+		t.Fatal("expected sidecar to be ingested")
+	}
+	if len(st.reps) != 1 || st.reps[0].RepType != ingest.RepTypeTranscript {
+		t.Fatalf("expected one transcript representation, got %+v", st.reps)
+	}
+	if len(st.chunks) != 1 {
+		t.Fatalf("expected one merged transcript chunk, got %d", len(st.chunks))
+	}
+	if len(st.spans) != 1 || st.spans[0].Kind != "time" || st.spans[0].StartMS != 0 || st.spans[0].EndMS != 5000 {
+		t.Fatalf("unexpected span: %+v", st.spans)
+	}
+	assertSidecarMeta(t, st.reps[0].MetaJSON, "")
+}
+
+func TestSidecar_SRT_IngestsTranscriptWithoutSTT(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "clip.mp4"), "fake-video")
+	writeFile(t, filepath.Join(root, "clip.srt"),
+		"1\n00:00:00,000 --> 00:00:01,500\nHello\n\n2\n00:00:01,500 --> 00:00:03,000\nGoodbye\n")
+
+	st := &fakeIngestStore{}
+	svc := newSidecarService(t, root, t.TempDir(), st)
+
+	doc := model.Document{DocID: 2, RelPath: "clip.mp4", DocType: "video"}
+	ingested, err := svc.IngestSidecarTranscripts(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("IngestSidecarTranscripts: %v", err)
+	}
+	if !ingested {
+		t.Fatal("expected sidecar to be ingested")
+	}
+	if len(st.reps) != 1 {
+		t.Fatalf("expected one representation, got %d", len(st.reps))
+	}
+	if len(st.spans) != 1 || st.spans[0].EndMS != 3000 {
+		t.Fatalf("unexpected spans: %+v", st.spans)
+	}
+}
+
+func TestSidecar_PerLanguage_DistinctTranscripts(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "talk.mp3"), "fake-audio")
+	writeFile(t, filepath.Join(root, "talk.en.vtt"), "WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nhello\n")
+	writeFile(t, filepath.Join(root, "talk.fr.vtt"), "WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nbonjour\n")
+
+	st := &fakeIngestStore{}
+	svc := newSidecarService(t, root, t.TempDir(), st)
+
+	doc := model.Document{DocID: 3, RelPath: "talk.mp3", DocType: "audio"}
+	ingested, err := svc.IngestSidecarTranscripts(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("IngestSidecarTranscripts: %v", err)
+	}
+	if !ingested {
+		t.Fatal("expected sidecars to be ingested")
+	}
+	if len(st.reps) != 2 {
+		t.Fatalf("expected two per-language transcript representations, got %d", len(st.reps))
+	}
+	// Languages are processed sorted: "en" first, then "fr".
+	assertSidecarMeta(t, st.reps[0].MetaJSON, "en")
+	assertSidecarMeta(t, st.reps[1].MetaJSON, "fr")
+}
+
+func TestSidecar_ForceReindex_RunsSTTInsteadOfSidecar(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "song.mp3"), "fake-audio")
+	writeFile(t, filepath.Join(root, "song.vtt"), "WEBVTT\n\n00:00:00.000 --> 00:00:02.000\nignored sidecar\n")
+
+	st := &fakeIngestStore{}
+	stt := &fakeTranscriber{text: "[00:00] from stt"}
+	svc := mustNewIngestService(t, config.Config{RootDir: root, StateDir: t.TempDir()}, st)
+	svc.SetTranscriber(stt)
+
+	f := ingest.DiscoveredFile{RelPath: "song.mp3", SizeBytes: 10, MTimeUnix: time.Now().Unix()}
+	if err := svc.ProcessDocument(context.Background(), f, nil, true); err != nil {
+		t.Fatalf("ProcessDocument(force): %v", err)
+	}
+	if stt.calls != 1 {
+		t.Fatalf("expected STT to run once under --force, got %d call(s)", stt.calls)
+	}
+	if len(st.reps) != 1 || st.reps[0].MetaJSON != "" {
+		t.Fatalf("expected one STT transcript rep with no sidecar meta, got %+v", st.reps)
+	}
+}
+
+func TestSidecar_FreshSidecarReprocessesUnchangedMedia(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mediaPath := filepath.Join(root, "rec.mp3")
+	sidecarPath := filepath.Join(root, "rec.vtt")
+	writeFile(t, mediaPath, "fake-audio")
+	writeFile(t, sidecarPath, "WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nv1\n")
+
+	st := newMapStore()
+	svc := newSidecarService(t, root, t.TempDir(), st)
+
+	// First scan: media is new, sidecar is ingested.
+	if err := svc.Run(context.Background()); err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+	firstHash := st.lastHashFor("rec.mp3")
+	if firstHash == "" {
+		t.Fatal("expected media document to be recorded on first run")
+	}
+
+	// Modify only the sidecar (media bytes unchanged) and bump its mtime so the
+	// fingerprint changes and the incremental gate re-processes the media.
+	writeFile(t, sidecarPath, "WEBVTT\n\n00:00:00.000 --> 00:00:02.000\nv2 updated\n")
+	future := time.Now().Add(2 * time.Hour)
+	if err := os.Chtimes(sidecarPath, future, future); err != nil {
+		t.Fatalf("chtimes sidecar: %v", err)
+	}
+
+	if err := svc.Run(context.Background()); err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+	secondHash := st.lastHashFor("rec.mp3")
+	if secondHash == firstHash {
+		t.Fatalf("expected media content hash to change after sidecar update (was %q)", firstHash)
+	}
+}
+
+func assertSidecarMeta(t *testing.T, metaJSON, wantLang string) {
+	t.Helper()
+	if metaJSON == "" {
+		t.Fatal("expected non-empty sidecar transcript meta_json")
+	}
+	if !strings.Contains(metaJSON, `"source":"sidecar"`) {
+		t.Fatalf("expected source=sidecar in meta_json, got %s", metaJSON)
+	}
+	if wantLang != "" && !strings.Contains(metaJSON, `"language":"`+wantLang+`"`) {
+		t.Fatalf("expected language=%q in meta_json, got %s", wantLang, metaJSON)
+	}
+}

--- a/tests/ingest/subtitle_chunk_test.go
+++ b/tests/ingest/subtitle_chunk_test.go
@@ -1,0 +1,65 @@
+package tests
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/subtitle"
+)
+
+// TestChunkSubtitleCues_BudgetsJoinSeparators guards CodeRabbit finding
+// represent.go ~1053: chunkSubtitleCues merges cues with "\n" joins, so the
+// separators must be counted against TranscriptChunkMaxChars. Cues whose texts
+// plus their join separators sum to just over the cap must split, and NO emitted
+// chunk may exceed TranscriptChunkMaxChars (before this fix the unbudgeted
+// newlines pushed a merged chunk over the cap).
+func TestChunkSubtitleCues_BudgetsJoinSeparators(t *testing.T) {
+	t.Parallel()
+
+	const max = ingest.TranscriptChunkMaxChars
+	// Two equal cues each just under half the cap so their texts alone fit
+	// (2*cueLen <= max) but with the joining "\n" they overflow
+	// (2*cueLen + 1 > max), forcing a split that only the separator budget
+	// detects.
+	cueLen := max/2 + 1 // 2*cueLen = max+2 > max; with sep = max+3
+	cueText := strings.Repeat("a", cueLen)
+
+	cues := []subtitle.Cue{
+		{Index: 1, StartMS: 0, EndMS: 1000, Text: cueText},
+		{Index: 2, StartMS: 1000, EndMS: 2000, Text: cueText},
+	}
+
+	segs := ingest.ChunkSubtitleCues(cues)
+	if len(segs) != 2 {
+		t.Fatalf("expected the two cues to split into 2 chunks (separator budgeted), got %d", len(segs))
+	}
+	for i, s := range segs {
+		if n := utf8.RuneCountInString(s.Text); n > max {
+			t.Fatalf("chunk %d exceeds TranscriptChunkMaxChars: %d > %d", i, n, max)
+		}
+	}
+}
+
+// TestChunkSubtitleCues_MergesWithinBudget confirms the separator budget does
+// not over-split: two cues that fit together (texts + the joining newline stay
+// at or under the cap) still merge into one chunk spanning both.
+func TestChunkSubtitleCues_MergesWithinBudget(t *testing.T) {
+	t.Parallel()
+
+	cues := []subtitle.Cue{
+		{Index: 1, StartMS: 0, EndMS: 1000, Text: "hello"},
+		{Index: 2, StartMS: 1000, EndMS: 2500, Text: "world"},
+	}
+	segs := ingest.ChunkSubtitleCues(cues)
+	if len(segs) != 1 {
+		t.Fatalf("expected the two small cues to merge into 1 chunk, got %d", len(segs))
+	}
+	if segs[0].Text != "hello\nworld" {
+		t.Fatalf("expected merged text %q, got %q", "hello\nworld", segs[0].Text)
+	}
+	if segs[0].Span.StartMS != 0 || segs[0].Span.EndMS != 2500 {
+		t.Fatalf("expected merged span [0,2500], got [%d,%d]", segs[0].Span.StartMS, segs[0].Span.EndMS)
+	}
+}

--- a/tests/ingest/subtitle_parser_test.go
+++ b/tests/ingest/subtitle_parser_test.go
@@ -147,6 +147,34 @@ func TestParseVTT_HoursAndCRLF(t *testing.T) {
 	assertCue(t, cues[0], 1, want, ((1*60+2)*60+4)*1000, "Deep into the file")
 }
 
+func TestParseSRT_LeadingBOMTolerated(t *testing.T) {
+	t.Parallel()
+	// A leading UTF-8 BOM (common in Windows-authored subtitles) must not block
+	// the first cue's timing line from matching.
+	in := "\uFEFF1\n00:00:00,000 --> 00:00:01,000\nWith BOM\n"
+	cues, err := subtitle.ParseSRT(in)
+	if err != nil {
+		t.Fatalf("ParseSRT: %v", err)
+	}
+	if len(cues) != 1 {
+		t.Fatalf("expected 1 cue, got %d", len(cues))
+	}
+	assertCue(t, cues[0], 1, 0, 1000, "With BOM")
+}
+
+func TestParseVTT_LeadingBOMTolerated(t *testing.T) {
+	t.Parallel()
+	in := "\uFEFFWEBVTT\n\n00:00:00.000 --> 00:00:02.000\nHeader after BOM\n"
+	cues, err := subtitle.ParseVTT(in)
+	if err != nil {
+		t.Fatalf("ParseVTT: %v", err)
+	}
+	if len(cues) != 1 {
+		t.Fatalf("expected 1 cue, got %d", len(cues))
+	}
+	assertCue(t, cues[0], 1, 0, 2000, "Header after BOM")
+}
+
 func TestParseTTML_Monolingual(t *testing.T) {
 	t.Parallel()
 	in := `<?xml version="1.0" encoding="UTF-8"?>

--- a/tests/ingest/subtitle_parser_test.go
+++ b/tests/ingest/subtitle_parser_test.go
@@ -1,0 +1,206 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/subtitle"
+)
+
+func TestChunkSubtitleCues_MergesCuesAndPreservesSpanBounds(t *testing.T) {
+	t.Parallel()
+	cues := []subtitle.Cue{
+		{Index: 1, StartMS: 0, EndMS: 1000, Text: "alpha"},
+		{Index: 2, StartMS: 1000, EndMS: 2500, Text: "beta"},
+		{Index: 3, StartMS: 2500, EndMS: 4000, Text: "gamma"},
+	}
+	segs := ingest.ChunkSubtitleCues(cues)
+	// Short cues merge into a single chunk; the span covers first start..last end.
+	if len(segs) != 1 {
+		t.Fatalf("expected 1 merged chunk, got %d", len(segs))
+	}
+	if segs[0].Span.Kind != "time" || segs[0].Span.StartMS != 0 || segs[0].Span.EndMS != 4000 {
+		t.Fatalf("unexpected span: %+v", segs[0].Span)
+	}
+	if segs[0].Text != "alpha\nbeta\ngamma" {
+		t.Fatalf("unexpected merged text: %q", segs[0].Text)
+	}
+}
+
+func TestChunkSubtitleCues_SkipsEmptyCues(t *testing.T) {
+	t.Parallel()
+	cues := []subtitle.Cue{
+		{StartMS: 0, EndMS: 1000, Text: "  "},
+		{StartMS: 1000, EndMS: 2000, Text: "real"},
+	}
+	segs := ingest.ChunkSubtitleCues(cues)
+	if len(segs) != 1 || segs[0].Text != "real" {
+		t.Fatalf("expected single 'real' chunk, got %+v", segs)
+	}
+	if segs[0].Span.StartMS != 1000 || segs[0].Span.EndMS != 2000 {
+		t.Fatalf("unexpected span: %+v", segs[0].Span)
+	}
+}
+
+func assertCue(t *testing.T, got subtitle.Cue, wantIdx, wantStart, wantEnd int, wantText string) {
+	t.Helper()
+	if got.Index != wantIdx || got.StartMS != wantStart || got.EndMS != wantEnd || got.Text != wantText {
+		t.Fatalf("cue mismatch: got {idx=%d start=%d end=%d text=%q} want {idx=%d start=%d end=%d text=%q}",
+			got.Index, got.StartMS, got.EndMS, got.Text, wantIdx, wantStart, wantEnd, wantText)
+	}
+}
+
+func TestParseVTT_BasicCues(t *testing.T) {
+	t.Parallel()
+	in := "WEBVTT\n\n00:00:00.000 --> 00:00:02.500\nHello world\n\n00:00:02.500 --> 00:00:05.000\nSecond line\n"
+	cues, err := subtitle.ParseVTT(in)
+	if err != nil {
+		t.Fatalf("ParseVTT: %v", err)
+	}
+	if len(cues) != 2 {
+		t.Fatalf("expected 2 cues, got %d", len(cues))
+	}
+	assertCue(t, cues[0], 1, 0, 2500, "Hello world")
+	assertCue(t, cues[1], 2, 2500, 5000, "Second line")
+}
+
+func TestParseVTT_SkipsNoteStyleAndIdentifiers(t *testing.T) {
+	t.Parallel()
+	in := "WEBVTT\n" +
+		"\n" +
+		"NOTE this is a comment\n" +
+		"spanning two lines\n" +
+		"\n" +
+		"STYLE\n" +
+		"::cue { color: yellow }\n" +
+		"\n" +
+		"cue-id-1\n" +
+		"00:01.000 --> 00:02.000 align:start\n" +
+		"<v Alice>Hi there</v>\n" +
+		"\n"
+	cues, err := subtitle.ParseVTT(in)
+	if err != nil {
+		t.Fatalf("ParseVTT: %v", err)
+	}
+	if len(cues) != 1 {
+		t.Fatalf("expected 1 cue, got %d (%+v)", len(cues), cues)
+	}
+	// MM:SS form (no hours) and inline tags stripped; cue settings ignored.
+	assertCue(t, cues[0], 1, 1000, 2000, "Hi there")
+}
+
+func TestParseVTT_MultiLineCueText(t *testing.T) {
+	t.Parallel()
+	in := "WEBVTT\n\n00:00:00.000 --> 00:00:03.000\nline one\nline two\n"
+	cues, err := subtitle.ParseVTT(in)
+	if err != nil {
+		t.Fatalf("ParseVTT: %v", err)
+	}
+	if len(cues) != 1 {
+		t.Fatalf("expected 1 cue, got %d", len(cues))
+	}
+	assertCue(t, cues[0], 1, 0, 3000, "line one\nline two")
+}
+
+func TestParseVTT_NoCuesReturnsError(t *testing.T) {
+	t.Parallel()
+	if _, err := subtitle.ParseVTT("WEBVTT\n\nNOTE only a note\n"); err == nil {
+		t.Fatal("expected error for cue-less VTT")
+	}
+}
+
+func TestParseSRT_BasicCuesWithCommaSeparator(t *testing.T) {
+	t.Parallel()
+	in := "1\n00:00:00,000 --> 00:00:02,000\nFirst\n\n2\n00:00:02,000 --> 00:00:04,250\nSecond\n"
+	cues, err := subtitle.ParseSRT(in)
+	if err != nil {
+		t.Fatalf("ParseSRT: %v", err)
+	}
+	if len(cues) != 2 {
+		t.Fatalf("expected 2 cues, got %d", len(cues))
+	}
+	assertCue(t, cues[0], 1, 0, 2000, "First")
+	assertCue(t, cues[1], 2, 2000, 4250, "Second")
+}
+
+func TestParseSRT_MissingIndexLineTolerated(t *testing.T) {
+	t.Parallel()
+	in := "00:00:01,000 --> 00:00:02,000\nNo index here\n"
+	cues, err := subtitle.ParseSRT(in)
+	if err != nil {
+		t.Fatalf("ParseSRT: %v", err)
+	}
+	if len(cues) != 1 {
+		t.Fatalf("expected 1 cue, got %d", len(cues))
+	}
+	assertCue(t, cues[0], 1, 1000, 2000, "No index here")
+}
+
+func TestParseVTT_HoursAndCRLF(t *testing.T) {
+	t.Parallel()
+	in := "WEBVTT\r\n\r\n01:02:03.400 --> 01:02:04.000\r\nDeep into the file\r\n"
+	cues, err := subtitle.ParseVTT(in)
+	if err != nil {
+		t.Fatalf("ParseVTT: %v", err)
+	}
+	want := ((1*60+2)*60+3)*1000 + 400
+	assertCue(t, cues[0], 1, want, ((1*60+2)*60+4)*1000, "Deep into the file")
+}
+
+func TestParseTTML_Monolingual(t *testing.T) {
+	t.Parallel()
+	in := `<?xml version="1.0" encoding="UTF-8"?>
+<tt xmlns="http://www.w3.org/ns/ttml" xml:lang="en">
+  <body><div>
+    <p begin="00:00:00.000" end="00:00:02.000">Hello</p>
+    <p begin="2s" end="4s">World<br/>again</p>
+  </div></body>
+</tt>`
+	cues, err := subtitle.ParseTTML(in)
+	if err != nil {
+		t.Fatalf("ParseTTML: %v", err)
+	}
+	if len(cues) != 2 {
+		t.Fatalf("expected 2 cues, got %d (%+v)", len(cues), cues)
+	}
+	assertCue(t, cues[0], 1, 0, 2000, "Hello")
+	assertCue(t, cues[1], 2, 2000, 4000, "World\nagain")
+}
+
+func TestParseTTMLByLang_Bilingual(t *testing.T) {
+	t.Parallel()
+	in := `<tt xmlns="http://www.w3.org/ns/ttml">
+  <body>
+    <div xml:lang="en"><p begin="0s" end="1s">cat</p></div>
+    <div xml:lang="fr"><p begin="0s" end="1s">chat</p></div>
+  </body>
+</tt>`
+	groups, err := subtitle.ParseTTMLByLang(in)
+	if err != nil {
+		t.Fatalf("ParseTTMLByLang: %v", err)
+	}
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 language groups, got %d", len(groups))
+	}
+	// Sorted by language tag: "en" then "fr".
+	if groups[0].Lang != "en" || len(groups[0].Cues) != 1 || groups[0].Cues[0].Text != "cat" {
+		t.Fatalf("unexpected en group: %+v", groups[0])
+	}
+	if groups[1].Lang != "fr" || len(groups[1].Cues) != 1 || groups[1].Cues[0].Text != "chat" {
+		t.Fatalf("unexpected fr group: %+v", groups[1])
+	}
+}
+
+func TestParseTTML_OffsetTimes(t *testing.T) {
+	t.Parallel()
+	in := `<tt xmlns="http://www.w3.org/ns/ttml">
+  <body><div>
+    <p begin="500ms" end="1500ms">half second start</p>
+  </div></body>
+</tt>`
+	cues, err := subtitle.ParseTTML(in)
+	if err != nil {
+		t.Fatalf("ParseTTML: %v", err)
+	}
+	assertCue(t, cues[0], 1, 500, 1500, "half second start")
+}

--- a/tests/subtitle/subtitle_test.go
+++ b/tests/subtitle/subtitle_test.go
@@ -117,3 +117,43 @@ func TestBuildAndRenderRoundTrip(t *testing.T) {
 		t.Errorf("round-trip SRT:\n got: %q\nwant: %q", got, wantSRT)
 	}
 }
+
+// TestParseTTML_ReturnsCuesInDocumentTimeOrder guards CodeRabbit finding
+// ttml.go ~37: ParseTTML flattens ParseTTMLByLang's language-sorted groups, so
+// without an explicit time sort the output is language-grouped, not the document
+// (time) order the doc comment promises. This bilingual TTML interleaves cues by
+// time across "en"/"fr"; ParseTTML must return them in ascending StartMS order.
+func TestParseTTML_ReturnsCuesInDocumentTimeOrder(t *testing.T) {
+	const ttml = `<?xml version="1.0" encoding="UTF-8"?>
+<tt xmlns="http://www.w3.org/ns/ttml" xmlns:xml="http://www.w3.org/XML/1998/namespace">
+  <body>
+    <div xml:lang="fr">
+      <p begin="00:00:01.000" end="00:00:02.000">bonjour</p>
+      <p begin="00:00:03.000" end="00:00:04.000">au revoir</p>
+    </div>
+    <div xml:lang="en">
+      <p begin="00:00:00.000" end="00:00:01.000">hello</p>
+      <p begin="00:00:02.000" end="00:00:03.000">goodbye</p>
+    </div>
+  </body>
+</tt>`
+
+	cues, err := subtitle.ParseTTML(ttml)
+	if err != nil {
+		t.Fatalf("ParseTTML: %v", err)
+	}
+	wantStart := []int{0, 1000, 2000, 3000}
+	wantText := []string{"hello", "bonjour", "goodbye", "au revoir"}
+	if len(cues) != len(wantStart) {
+		t.Fatalf("expected %d cues, got %d (%+v)", len(wantStart), len(cues), cues)
+	}
+	for i, c := range cues {
+		if c.StartMS != wantStart[i] || c.Text != wantText[i] {
+			t.Fatalf("cue %d: got (start=%d, text=%q), want (start=%d, text=%q)",
+				i, c.StartMS, c.Text, wantStart[i], wantText[i])
+		}
+		if c.Index != i+1 {
+			t.Fatalf("cue %d: expected 1-based index %d, got %d", i, i+1, c.Index)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Ingest a `.vtt`/`.srt`/`.ttml` file sitting next to an audio/video file **as that media's transcript** instead of running STT. An authored transcript is authoritative over machine transcription, so when a fresh sidecar is present STT is skipped entirely.

Closes #253. Part of epic #261 (livevtt absorption).

## Parser surface (`internal/subtitle`)

- `ParseVTT(content) ([]Cue, error)` / `ParseSRT(content) ([]Cue, error)` — shared line-oriented scanner. Tolerant of dot vs comma millisecond separators, optional hours (`MM:SS.mmm`), optional cue identifier / numeric index lines, the `WEBVTT` header, and `NOTE`/`STYLE`/`REGION` blocks (skipped). Inline tags (`<v Speaker>`, `<c.color>`, `</i>`) are stripped. Returns a `*ParseError` when no cue parses so callers can fall back to STT.
- `ParseTTML(content) ([]Cue, error)` and `ParseTTMLByLang(content) ([]LangCues, error)` — clock times (`HH:MM:SS[.mmm]`), offset times (`s`/`ms`/`t` ticks via `ttp:tickRate`), `<br/>` → newline, nested-span flattening, and per-`xml:lang` split for bilingual files.
- Each `Cue` carries `Index` (1-based), `StartMS`, `EndMS`, `Text`. The `Cue` type is shared with the #254 export renderer.

## Sidecar vs STT precedence + mtime gating

- Sidecars are detected next to the media through the corpus FS (works for any CorpusFS backend), matching `<media-without-ext>.<ext>` and `<media-without-ext>.<lang>.<ext>`.
- A sidecar's mtime is folded into the media document's **content hash**, so the incremental gate re-processes the media when a sidecar is added, removed, or modified — even though the media bytes are unchanged. Non-media docs and media without sidecars keep their historical hash exactly.
- When a fresh sidecar is ingested, **STT is skipped**. `--force`/reindex overrides the gate and re-runs STT instead.
- Multiple per-language sidecars (`talk.en.vtt`, `talk.fr.vtt`) become **distinct per-language transcript representations**, each with `meta_json` `language` + `source:"sidecar"`. Bilingual TTML splits per `xml:lang` the same way.
- Cues are chunked into time-spanned transcript chunks using the cues' verbatim `[StartMS, EndMS]` timing (greedy merge under `TranscriptChunkMaxChars`), matching the existing transcript chunk shape. Spans are deterministic (cues sorted by start, then end).
- Kill-switch opt-out `media_sidecars_disabled` (enabled by default).

## Quality gate

Sidecar transcripts **bypass the output quality gate**. The gate (spec 0.16.0) screens model-derived output for degenerate text (repetition loops, empty output). Sidecars are authored, not model-derived, so quarantining them would be wrong — chunks are inserted healthy.

## Round-trip with #254

Sidecar ingest reuses the same `subtitle.Cue` type and `model.Span{Kind:"time"}` transcript chunk shape that #254's VTT/SRT export renders from, so an imported sidecar round-trips back out through the export path.

## Tests

- `tests/ingest/sidecar_test.go`: sibling `.vtt` and `.srt` each ingest a transcript with correct spans and **zero STT calls** (an exploding transcriber fails the test if called); per-language sidecars produce distinct reps with correct `meta_json`; `--force` re-runs STT (sidecar ignored); a freshly modified sidecar reprocesses unchanged media.
- `tests/ingest/subtitle_parser_test.go`: VTT/SRT/TTML parser unit tests with exact cue index/bounds/text expectations (multi-line cues, CRLF + hours, NOTE/STYLE skip, missing SRT index, TTML offset times, bilingual split) plus chunk-merge span-bound assertions.

`make check` passes locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Media documents now automatically ingest subtitle sidecar files, supporting VTT, SRT, and TTML formats
  * Per-language subtitle transcript generation for improved multilingual content handling
  * Subtitle sidecars take precedence over automatic speech-to-text transcription when available
  * New configuration option to disable subtitle sidecar ingestion

<!-- end of auto-generated comment: release notes by coderabbit.ai -->