### PR TITLE
fix(cli): don't report a healthy slow first-run daemon as a bind failure

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/dirstral/dir2mcp/internal/ingest"
 )
 
 // daemonChildEnv carries a per-spawn nonce that the parent sets on the
@@ -50,11 +52,51 @@ const pidFileName = "server.pid"
 // stdout/stderr inside the state directory. Append mode; never truncated.
 const serverLogName = "server.log"
 
+// daemonReadinessHeadroom is the slack added on top of the document-extractor
+// probe ceiling to cover index load and the listener bind that follow the
+// probe before the child writes connection.json. 25s on top of the 20s probe
+// gives a 45s total readiness window.
+const daemonReadinessHeadroom = 25 * time.Second
+
 // daemonReadinessTimeout caps how long the parent will wait for the child
-// to write connection.json before giving up and reporting bind failure.
-// The server typically binds within ~1s; 15s is generous headroom for
-// loaded developer machines.
-const daemonReadinessTimeout = 15 * time.Second
+// to write connection.json before reporting the daemon as still-starting.
+//
+// The server itself binds within ~1s, but the child resolves the document
+// extractor during startup BEFORE it binds. On dir2mcp-full with the default
+// IngestExtractor="auto" and docling on PATH, that runs the docling
+// functional probe (`docling --version`, which imports torch) bounded by
+// ingest.doclingProbeTimeout (20s) on a cold first run. The readiness window
+// MUST therefore stay comfortably above that probe ceiling, otherwise a
+// healthy-but-slow first run trips a false "not ready" while the child is
+// still warming up.
+//
+// We derive it from the probe ceiling (+ headroom) rather than hard-coding a
+// figure so the ordering invariant — readiness window > probe ceiling — can't
+// silently regress if the probe timeout is ever raised. Evaluates to 45s with
+// today's 20s probe. Do NOT lower the probe timeout to "fix" a slow start.
+var daemonReadinessTimeout = ingest.DoclingProbeTimeout() + daemonReadinessHeadroom
+
+// DaemonReadinessTimeout exposes the readiness window so external tests can
+// assert it stays above the document-extractor probe ceiling
+// (ingest.DoclingProbeTimeout). Read-only accessor.
+func DaemonReadinessTimeout() time.Duration { return daemonReadinessTimeout }
+
+// errDaemonStillStarting is the sentinel waitForConnectionFile wraps when the
+// readiness deadline expires while the child process is still alive. It marks
+// the "healthy-but-slow" case (e.g. a cold dir2mcp-full first run warming up
+// the docling/torch probe) so callers can report a friendly "still starting"
+// message and succeed, rather than treating it as the hard bind failure used
+// for a child that actually crashed. Use IsDaemonStillStarting to test for it.
+var errDaemonStillStarting = errors.New("daemon still starting")
+
+// IsDaemonStillStarting reports whether err indicates the daemon child was
+// still alive but had not yet written connection.json when the readiness
+// deadline expired (as opposed to having crashed). Exported so the readiness
+// classification — still-starting vs crashed vs ready — can be unit-tested
+// from the external tests package without exposing waitForConnectionFile.
+func IsDaemonStillStarting(err error) bool {
+	return errors.Is(err, errDaemonStillStarting)
+}
 
 // daemonReadinessPoll is the interval between connection.json existence
 // checks during startup.
@@ -236,10 +278,31 @@ func waitForConnectionFile(path string, childPid int, timeout time.Duration) (co
 			return connectionPayload{}, fmt.Errorf("daemon (pid %d) exited before becoming ready", childPid)
 		}
 		if time.Now().After(deadline) {
-			return connectionPayload{}, fmt.Errorf("timed out after %s waiting for daemon readiness: %v", timeout, lastErr)
+			// The child was observed alive this iteration (the exited check
+			// above returned), so this is the healthy-but-slow case: it just
+			// hasn't bound and written connection.json within the window.
+			// Wrap the sentinel so the parent can report "still starting"
+			// rather than the hard bind-failure used for a crashed child.
+			return connectionPayload{}, fmt.Errorf(
+				"timed out after %s waiting for daemon readiness: %v: %w",
+				timeout, lastErr, errDaemonStillStarting,
+			)
 		}
 		time.Sleep(daemonReadinessPoll)
 	}
+}
+
+// WaitForConnectionReady is a thin exported wrapper over waitForConnectionFile
+// so the readiness classification — ready vs still-starting vs crashed — can be
+// exercised from the external tests package (waitForConnectionFile itself stays
+// unexported). It returns whether the connection became ready and the
+// classifying error; pair it with IsDaemonStillStarting to distinguish the
+// healthy-but-slow case from a child that exited before binding.
+func WaitForConnectionReady(path string, childPid int, timeout time.Duration) (bool, error) {
+	if _, err := waitForConnectionFile(path, childPid, timeout); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // stopDaemon sends SIGTERM to pid, polls every daemonShutdownPoll for the

--- a/internal/cli/up_daemon.go
+++ b/internal/cli/up_daemon.go
@@ -44,8 +44,8 @@ func (a *App) runUpAsDaemonParent(_ context.Context, opts upOptions) int {
 	}
 	// Re-run the fast, config-only preconditions the child would run, so
 	// a misconfig (missing MISTRAL_API_KEY, --public without auth) fails
-	// here instead of after a 15s readiness timeout the user has to debug
-	// from server.log. Listener-bind failures stay in the child — those
+	// here instead of after the full readiness timeout the user has to
+	// debug from server.log. Listener-bind failures stay in the child — those
 	// genuinely need the OS to refuse the port — and the readiness-error
 	// path already points the user at the log for those.
 	if code := a.preflightDaemonParentConfig(&cfg, opts); code != exitSuccess {
@@ -115,6 +115,15 @@ func (a *App) runUpAsDaemonParent(_ context.Context, opts upOptions) int {
 
 	connection, err := waitForConnectionFile(connectionFilePath(stateDir), childPid, daemonReadinessTimeout)
 	if err != nil {
+		// Distinguish "still starting" (child alive, just slow — e.g. a cold
+		// dir2mcp-full first run warming up the docling/torch probe) from a
+		// real crash. The former is not a failure: the child keeps running
+		// and will bind shortly, so report it as a friendly success instead
+		// of the scary bind-failure path.
+		if IsDaemonStillStarting(err) {
+			a.reportDaemonStillStarting(childPid, logPath, opts)
+			return exitSuccess
+		}
 		writeCLIError(a.stderr, opts.jsonOutput, exitServerBindFailure,
 			fmt.Sprintf("daemon (pid %d) did not become ready: %v", childPid, err),
 			fmt.Sprintf("Inspect %s for startup errors.", logPath),
@@ -170,6 +179,39 @@ func (a *App) printDaemonReady(cfg config.Config, logPath string, pid int, conne
 	writef(a.stdout, "  %s\n\n", s.dim("Stop with: dir2mcp down"))
 }
 
+// reportDaemonStillStarting prints the friendly "still starting" notice for a
+// healthy-but-slow daemon whose child is alive but hasn't bound within the
+// readiness window (e.g. a cold dir2mcp-full first run warming up the
+// docling/torch probe). This is NOT a failure: the child keeps running and
+// will bind shortly, so the caller returns exitSuccess.
+//
+// In --json mode it emits a single clean, parseable object (status:
+// "starting") on stdout rather than an error payload, so a still-starting
+// result on a scripted run is a clear signal instead of a fatal error.
+func (a *App) reportDaemonStillStarting(pid int, logPath string, opts upOptions) {
+	if opts.jsonOutput {
+		_ = emitJSON(a.stdout, map[string]interface{}{
+			"status": "starting",
+			"pid":    pid,
+			"message": fmt.Sprintf(
+				"daemon (pid %d) is still starting; first run can take longer "+
+					"while models and the document extractor warm up", pid),
+			"log":  logPath,
+			"hint": "Check readiness with: dir2mcp status",
+		})
+		return
+	}
+	if opts.quiet {
+		return
+	}
+	s := a.sty(false)
+	writeln(a.stdout)
+	writef(a.stdout, "  %s %s\n", s.banner(), s.dim(fmt.Sprintf("daemon (pid %d) is still starting", pid)))
+	writef(a.stdout, "  %s\n", s.dim("First run can take longer while models and the document extractor warm up."))
+	writeln(a.stdout, s.kv("Logs", logPath))
+	writef(a.stdout, "  %s\n\n", s.dim("Check readiness with: dir2mcp status"))
+}
+
 // prepareDaemonStateDir ensures the state directory exists, refuses to
 // continue when an existing pid file points at a live process, and
 // clears stale state from a previous run that would confuse the parent's
@@ -209,7 +251,7 @@ func (a *App) prepareDaemonStateDir(stateDir, pidPath string, opts upOptions) in
 // preflightDaemonParentConfig runs the subset of config validation that
 // can fail in the child for purely config-level reasons — i.e. would
 // produce the same error regardless of whether the listener binds. By
-// running these in the parent before fork(), we trade a 15s readiness
+// running these in the parent before fork(), we trade a full readiness
 // timeout (and a misleading "did not become ready" message that frames
 // a config bug as a daemon/network bug) for the immediate, accurate
 // error the in-process body would have printed.

--- a/internal/ingest/docling_probe.go
+++ b/internal/ingest/docling_probe.go
@@ -16,6 +16,12 @@ import (
 // cannot stall startup or `dir2mcp doctor`.
 const doclingProbeTimeout = 20 * time.Second
 
+// DoclingProbeTimeout exposes the docling functional-probe ceiling so other
+// packages (and tests) can keep dependent timeouts — notably the daemon
+// readiness window — provably above it. Read-only accessor; the value itself
+// stays an internal constant.
+func DoclingProbeTimeout() time.Duration { return doclingProbeTimeout }
+
 // doclingProbeEntry memoizes one binary's functional-check result; the
 // sync.Once ensures the probe runs at most once per binary even under
 // concurrent callers.

--- a/tests/cli/daemon_readiness_test.go
+++ b/tests/cli/daemon_readiness_test.go
@@ -1,0 +1,122 @@
+//go:build unix
+
+package tests
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/cli"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+)
+
+// TestDaemonReadinessTimeoutExceedsDoclingProbe guards the ordering invariant
+// behind the first-run UX fix: the daemon readiness window MUST stay above the
+// document-extractor functional-probe ceiling. On dir2mcp-full a cold first run
+// runs the docling probe (which imports torch) BEFORE the child binds, so a
+// readiness window at or below the probe ceiling would trip a false "not ready"
+// even though the daemon comes up fine. If anyone raises the probe timeout
+// without raising the readiness window, this test fails before the regression
+// can ship.
+func TestDaemonReadinessTimeoutExceedsDoclingProbe(t *testing.T) {
+	readiness := cli.DaemonReadinessTimeout()
+	probe := ingest.DoclingProbeTimeout()
+	if readiness <= probe {
+		t.Fatalf("daemon readiness timeout (%s) must exceed docling probe ceiling (%s); "+
+			"a cold dir2mcp-full first run probes the extractor before binding, so the "+
+			"readiness window has to clear the probe with headroom", readiness, probe)
+	}
+	// Sanity-check there is meaningful headroom (index load + bind), not just a
+	// hair above the probe.
+	if readiness < probe+5*time.Second {
+		t.Errorf("daemon readiness timeout (%s) should leave headroom over the probe ceiling (%s) "+
+			"for index load and listener bind", readiness, probe)
+	}
+}
+
+// TestDaemonStillStartingClassification covers the three outcomes
+// waitForConnectionFile produces, via the exported WaitForConnectionReady
+// wrapper, without spinning up a real daemon:
+//
+//   - ready: connection.json with a URL is present -> success, no error
+//   - still-starting: child alive but no connection.json within the window ->
+//     errDaemonStillStarting (the healthy-but-slow first-run case)
+//   - crashed: child pid no longer alive -> a hard error that is NOT classified
+//     as still-starting
+func TestDaemonStillStartingClassification(t *testing.T) {
+	t.Run("ready", func(t *testing.T) {
+		dir := t.TempDir()
+		connPath := filepath.Join(dir, "connection.json")
+		if err := os.WriteFile(connPath, []byte(`{"url":"http://127.0.0.1:9999/mcp"}`), 0o600); err != nil {
+			t.Fatalf("write connection.json: %v", err)
+		}
+		ready, err := cli.WaitForConnectionReady(connPath, os.Getpid(), 2*time.Second)
+		if err != nil {
+			t.Fatalf("expected ready, got error: %v", err)
+		}
+		if !ready {
+			t.Fatalf("expected ready=true")
+		}
+		if cli.IsDaemonStillStarting(err) {
+			t.Errorf("ready result must not classify as still-starting")
+		}
+	})
+
+	t.Run("still starting", func(t *testing.T) {
+		dir := t.TempDir()
+		connPath := filepath.Join(dir, "connection.json") // never written
+		// os.Getpid() is alive for the duration of the test, so the deadline
+		// expires while the "child" is still alive -> still-starting.
+		ready, err := cli.WaitForConnectionReady(connPath, os.Getpid(), 250*time.Millisecond)
+		if ready {
+			t.Fatalf("expected not ready when connection.json never appears")
+		}
+		if err == nil {
+			t.Fatalf("expected an error on timeout")
+		}
+		if !cli.IsDaemonStillStarting(err) {
+			t.Fatalf("alive-but-slow child should classify as still-starting; got: %v", err)
+		}
+	})
+
+	t.Run("crashed", func(t *testing.T) {
+		dir := t.TempDir()
+		connPath := filepath.Join(dir, "connection.json") // never written
+		deadPid := spawnAndReapForDeadPID(t)
+		ready, err := cli.WaitForConnectionReady(connPath, deadPid, 5*time.Second)
+		if ready {
+			t.Fatalf("expected not ready for a dead child pid")
+		}
+		if err == nil {
+			t.Fatalf("expected an error for a dead child pid")
+		}
+		if cli.IsDaemonStillStarting(err) {
+			t.Errorf("a crashed child must NOT classify as still-starting (it is a real failure); got: %v", err)
+		}
+	})
+}
+
+// spawnAndReapForDeadPID starts a trivial child, waits for it to exit and be
+// reaped, and returns its now-dead pid. This gives the classification test a
+// pid that processIsAlive will report as not-alive without guessing an
+// arbitrary integer that might collide with a live process.
+func spawnAndReapForDeadPID(t *testing.T) int {
+	t.Helper()
+	cmd := exec.Command("true")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start throwaway process: %v", err)
+	}
+	pid := cmd.Process.Pid
+	if err := cmd.Wait(); err != nil {
+		// "true" exits 0; any error here means the process didn't run as expected.
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) {
+			t.Fatalf("wait throwaway process: %v", err)
+		}
+	}
+	return pid
+}


### PR DESCRIPTION
## Problem

On a cold **first run**, `dir2mcp up` printed a scary failure —

```
daemon (pid N) did not become ready: ...
Inspect .dir2mcp/server.log for startup errors.
```

— even though the daemon actually came up fine seconds later (a second `dir2mcp up` would report "already running"). This is the false failure Stas hit on his first run.

## Root cause

The daemon parent waits for the child to write `connection.json` with a **15s** readiness window (`daemonReadinessTimeout`). On `dir2mcp-full`, the child resolves the document extractor during startup (default `IngestExtractor="auto"`, docling on PATH), which runs the docling functional probe (`docling --version`, importing torch) bounded by `ingest.doclingProbeTimeout` = **20s**, *before* it binds and writes `connection.json`.

Since `15s < 20s`, on a cold first run the parent timed out and reported a hard `SERVER_BIND_FAILURE` while the healthy child finished the probe (~20s), bound, and wrote `connection.json`. `waitForConnectionFile` already distinguished "child exited" from "timed out while alive" — only the caller's messaging was wrong.

## Fix (two parts)

1. **Readiness window now exceeds the probe ceiling.** `daemonReadinessTimeout` is derived as `ingest.DoclingProbeTimeout() + 25s headroom` (= 45s today) rather than a hard-coded figure, so the ordering invariant (readiness > probe) can't silently regress if the probe timeout is ever raised. The probe timeout itself is unchanged.

2. **Distinguish "still starting" from "crashed."** A new sentinel `errDaemonStillStarting` is wrapped on the deadline-expired-while-child-alive branch. The parent now:
   - on still-starting: prints a friendly notice ("daemon (pid N) is still starting; first run can take longer while models and the document extractor warm up. Check readiness with: `dir2mcp status`") and returns **exitSuccess**;
   - on a child that actually exited: keeps the existing hard `SERVER_BIND_FAILURE` + "Inspect <log>".
   - `--json` mode emits a clean, parseable `{"status":"starting", ...}` object on stdout rather than an error payload.

## Tests

External-package tests under `tests/cli` (package `tests`, no internal `_test.go`, no real daemons spawned):
- classification of **ready / still-starting / crashed** via a thin exported wrapper `cli.WaitForConnectionReady` + the exported predicate `cli.IsDaemonStillStarting`;
- the **readiness > probe ceiling** ordering invariant via `cli.DaemonReadinessTimeout()` and `ingest.DoclingProbeTimeout()`.

New exported surface kept minimal: `IsDaemonStillStarting`, `DaemonReadinessTimeout`, `WaitForConnectionReady` (cli) and `DoclingProbeTimeout` (ingest), each documented and read-only.

`make check` passes locally.

## Notes

No tracking issue exists yet; one can be filed to track the first-run UX class of bugs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved daemon startup handling to better distinguish between a daemon still initializing and actual failures. Users now receive a helpful "still starting" notice when the daemon is taking longer than expected.
  * Daemon readiness timeout now adapts to document extraction configuration settings instead of using a fixed value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->