### PR TITLE
fix(retrieval,store): normalize path_prefix consistently across list_files and search/ask (#286)

### DIFF
--- a/internal/model/pathprefix.go
+++ b/internal/model/pathprefix.go
@@ -1,0 +1,78 @@
+package model
+
+import (
+	"path"
+	"strings"
+)
+
+// NormalizePathPrefix canonicalizes a caller-supplied path_prefix into the form
+// used to match against slash-normalized rel_paths. It is the single source of
+// truth shared by the store's list_files LIKE-prefix query and retrieval's
+// search/ask filtering, so the two can never drift (issue #286 Bug B).
+//
+// rel_paths are stored slash-normalized with no leading "./" or "/" and with
+// case preserved. The normalizer therefore:
+//   - trims surrounding whitespace
+//   - converts backslashes to forward slashes (so a Windows-style prefix maps
+//     onto the slash-normalized rel_path domain)
+//   - strips a single leading "./"
+//   - path.Clean's the result (collapsing "." and redundant separators)
+//   - strips a leading "/"
+//   - maps a prefix that cleans to "." (i.e. "no prefix") to the empty string
+//
+// An empty result means "no prefix filter".
+func NormalizePathPrefix(prefix string) string {
+	trimmed := strings.TrimSpace(prefix)
+	if trimmed == "" {
+		return ""
+	}
+	trimmed = strings.ReplaceAll(trimmed, "\\", "/")
+	trimmed = strings.TrimPrefix(trimmed, "./")
+	trimmed = path.Clean(trimmed)
+	trimmed = strings.TrimPrefix(trimmed, "/")
+	if trimmed == "." {
+		return ""
+	}
+	return trimmed
+}
+
+// MatchesPathPrefix reports whether relPath satisfies the given (raw, not yet
+// normalized) path_prefix. It normalizes the prefix via NormalizePathPrefix and
+// then applies the same matching rule the store's LIKE 'prefix%' query uses:
+// a case-insensitive (ASCII) prefix test. An empty/normalized-away prefix
+// matches everything. This mirrors list_files so a prefix that lists a file in
+// list_files also matches it in search/ask (issue #286 Bug B).
+//
+// Note this intentionally matches sub-segments the way SQLite LIKE does: the
+// prefix "act" matches "acts/foo.pdf". Keeping the two call sites byte-for-byte
+// consistent is the contract; changing segment semantics would change
+// list_files behavior too and is out of scope.
+func MatchesPathPrefix(relPath, prefix string) bool {
+	normalized := NormalizePathPrefix(prefix)
+	if normalized == "" {
+		return true
+	}
+	return hasASCIIPrefixFold(relPath, normalized)
+}
+
+// hasASCIIPrefixFold reports whether s begins with prefix, comparing ASCII
+// letters case-insensitively. This matches SQLite's default LIKE behavior,
+// which folds case for ASCII characters only (non-ASCII bytes compare exactly).
+func hasASCIIPrefixFold(s, prefix string) bool {
+	if len(s) < len(prefix) {
+		return false
+	}
+	for i := 0; i < len(prefix); i++ {
+		if asciiLower(s[i]) != asciiLower(prefix[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func asciiLower(b byte) byte {
+	if b >= 'A' && b <= 'Z' {
+		return b + ('a' - 'A')
+	}
+	return b
+}

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -152,7 +152,9 @@ type IndexHit struct {
 // logic (issue #247): a FilteringIndex that reports CanFilter true pushes these
 // predicates down to the backend; otherwise retrieval evaluates Match in Go.
 //
-//   - PathPrefix: keep only rel_paths with this prefix.
+//   - PathPrefix: keep only rel_paths with this prefix, normalized via
+//     NormalizePathPrefix and matched case-insensitively (ASCII) to agree with
+//     the store's list_files LIKE query (issue #286).
 //   - PathGlob:   keep only rel_paths matching this path.Match glob.
 //   - DocTypes:   keep only these doc types (case-insensitive).
 //   - ExcludeOrphans: drop chunks with an empty rel_path (orphaned/evicted).
@@ -173,14 +175,17 @@ func (f Filter) IsZero() bool {
 
 // Match reports whether the payload satisfies every active predicate. It
 // reproduces the semantics of retrieval's matchFilters: an empty rel_path is
-// rejected when ExcludeOrphans is set; PathPrefix is a string prefix; PathGlob
-// uses path.Match; DocTypes is a case-insensitive set membership.
+// rejected when ExcludeOrphans is set; PathPrefix is normalized and matched via
+// MatchesPathPrefix (consistent with list_files); PathGlob uses path.Match;
+// DocTypes is a case-insensitive set membership.
 func (f Filter) Match(p IndexPayload) bool {
 	relPath := p.RelPath
 	if f.ExcludeOrphans && strings.TrimSpace(relPath) == "" {
 		return false
 	}
-	if f.PathPrefix != "" && !strings.HasPrefix(relPath, f.PathPrefix) {
+	// Normalize path_prefix consistently with list_files / the store so search
+	// pushed down to a FilteringIndex agrees with list_files (issue #286 Bug B).
+	if !MatchesPathPrefix(relPath, f.PathPrefix) {
 		return false
 	}
 	if f.PathGlob != "" {

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -1841,7 +1841,10 @@ func matchFilters(hit model.SearchHit, query model.SearchQuery) bool {
 		return false
 	}
 
-	if query.PathPrefix != "" && !strings.HasPrefix(hit.RelPath, query.PathPrefix) {
+	// Normalize path_prefix the same way list_files does so a prefix that lists
+	// a file (e.g. "./acts", "/acts", "acts/", "ACTS") also matches it here
+	// (issue #286 Bug B). MatchesPathPrefix returns true for an empty prefix.
+	if !model.MatchesPathPrefix(hit.RelPath, query.PathPrefix) {
 		return false
 	}
 

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -1255,7 +1255,7 @@ func (s *SQLiteStore) ListFiles(ctx context.Context, prefix, glob string, limit,
 		offset = 0
 	}
 
-	normalizedPrefix := normalizePrefix(prefix)
+	normalizedPrefix := model.NormalizePathPrefix(prefix)
 
 	query := `SELECT doc_id, rel_path, doc_type, source_type, size_bytes, mtime_unix, content_hash, status, deleted, title, error_message FROM documents`
 	where := []string{"deleted = 0"}
@@ -2069,20 +2069,6 @@ func normalizeRelPath(relPath string) (string, error) {
 	}
 
 	return normalized, nil
-}
-
-func normalizePrefix(prefix string) string {
-	trimmed := strings.TrimSpace(prefix)
-	if trimmed == "" {
-		return ""
-	}
-	trimmed = strings.TrimPrefix(trimmed, "./")
-	trimmed = filepath.ToSlash(filepath.Clean(trimmed))
-	trimmed = strings.TrimPrefix(trimmed, "/")
-	if trimmed == "." {
-		return ""
-	}
-	return trimmed
 }
 
 func normalizeStatus(status string) string {

--- a/tests/model/path_prefix_test.go
+++ b/tests/model/path_prefix_test.go
@@ -1,0 +1,68 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// TestNormalizePathPrefix pins the shared path_prefix normalizer (issue #286).
+// It is the single source of truth for both list_files (store LIKE query) and
+// search/ask filtering, so its behavior must be explicit and stable.
+func TestNormalizePathPrefix(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", ""},
+		{"   ", ""},
+		{".", ""},
+		{"./", ""},
+		{"/", ""},
+		{"acts", "acts"},
+		{"acts/", "acts"},
+		{"./acts", "acts"},
+		{"/acts", "acts"},
+		{"  acts/  ", "acts"},
+		{"acts//foo", "acts/foo"},
+		{"acts/./foo", "acts/foo"},
+		{"acts/foo.pdf", "acts/foo.pdf"},
+		{"ACTS", "ACTS"}, // case preserved by the normalizer (folding happens at match time)
+		{`acts\foo`, "acts/foo"},
+	}
+	for _, tc := range cases {
+		if got := model.NormalizePathPrefix(tc.in); got != tc.want {
+			t.Errorf("NormalizePathPrefix(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestMatchesPathPrefix pins the shared matcher used by search/ask. It mirrors
+// the store's LIKE 'prefix%' semantics: case-insensitive (ASCII) prefix match,
+// matching across sub-segments, with an empty/normalized-away prefix matching
+// everything.
+func TestMatchesPathPrefix(t *testing.T) {
+	cases := []struct {
+		rel    string
+		prefix string
+		want   bool
+	}{
+		{"acts/foo.pdf", "", true},
+		{"acts/foo.pdf", "  ", true},
+		{"acts/foo.pdf", "acts", true},
+		{"acts/foo.pdf", "acts/", true},
+		{"acts/foo.pdf", "./acts", true},
+		{"acts/foo.pdf", "/acts", true},
+		{"acts/foo.pdf", "ACTS", true}, // ASCII case-insensitive, like SQLite LIKE
+		{"acts/foo.pdf", "act", true},  // store LIKE matches sub-segments
+		{"acts/foo.pdf", "acts/foo.pdf", true},
+		{"acts/foo.pdf", "xyz", false},
+		{"acts/foo.pdf", "other/", false},
+		{"acts/foo.pdf", "acts/foo.pdf/extra", false},
+	}
+	for _, tc := range cases {
+		if got := model.MatchesPathPrefix(tc.rel, tc.prefix); got != tc.want {
+			t.Errorf("MatchesPathPrefix(%q, %q) = %v, want %v", tc.rel, tc.prefix, got, tc.want)
+		}
+	}
+}

--- a/tests/retrieval/path_prefix_normalization_test.go
+++ b/tests/retrieval/path_prefix_normalization_test.go
@@ -1,0 +1,75 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
+)
+
+// TestSearch_PathPrefixNormalization is the regression test for issue #286
+// Bug B. list_files normalizes the path_prefix (strips leading "./" and "/",
+// path.Clean, slash) before its store LIKE query, so "./acts", "/acts" and
+// "acts/" all list acts/foo.pdf. But search/ask applied the RAW prefix via a
+// case-sensitive strings.HasPrefix, so the very prefixes that worked in
+// list_files silently matched nothing in search.
+//
+// After the fix both call sites share one normalizer, so a prefix that lists a
+// file in list_files also matches it in search/ask.
+func TestSearch_PathPrefixNormalization(t *testing.T) {
+	newSvc := func() *retrieval.Service {
+		idx := index.NewHNSWIndex("")
+		// addVecP sets the payload rel_path so the FilteringIndex evaluates the
+		// pushed-down path_prefix predicate (model.Filter.Match), exercising the
+		// same normalization the store applies in list_files.
+		addVecP(t, idx, 1, []float32{1, 0}, "acts/foo.pdf", "pdf")
+		svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+			"mistral-embed":   {1, 0},
+			"codestral-embed": {0, 1},
+		}}, nil)
+		svc.SetChunkMetadata(1, model.SearchHit{RelPath: "acts/foo.pdf", DocType: "pdf", Snippet: "alpha"})
+		return svc
+	}
+
+	// These all list acts/foo.pdf in list_files (store LIKE prefix%, which is
+	// case-insensitive for ASCII and matches across sub-segments); search/ask
+	// must agree. "act" is included because the store's LIKE matches it.
+	matchingPrefixes := []string{"acts", "acts/", "./acts", "/acts", "acts/foo.pdf", "ACTS", "act"}
+	for _, prefix := range matchingPrefixes {
+		t.Run("match/"+prefix, func(t *testing.T) {
+			svc := newSvc()
+			hits, err := svc.Search(context.Background(), model.SearchQuery{
+				Query:      "alpha",
+				K:          5,
+				PathPrefix: prefix,
+			})
+			if err != nil {
+				t.Fatalf("Search failed: %v", err)
+			}
+			if len(hits) != 1 || hits[0].RelPath != "acts/foo.pdf" {
+				t.Fatalf("prefix %q should match acts/foo.pdf; got %#v", prefix, hits)
+			}
+		})
+	}
+
+	// A prefix that does not match must return nothing (no over-matching).
+	nonMatchingPrefixes := []string{"xyz", "other/", "acts/foo.pdf/extra"}
+	for _, prefix := range nonMatchingPrefixes {
+		t.Run("nomatch/"+prefix, func(t *testing.T) {
+			svc := newSvc()
+			hits, err := svc.Search(context.Background(), model.SearchQuery{
+				Query:      "alpha",
+				K:          5,
+				PathPrefix: prefix,
+			})
+			if err != nil {
+				t.Fatalf("Search failed: %v", err)
+			}
+			if len(hits) != 0 {
+				t.Fatalf("prefix %q should match nothing; got %#v", prefix, hits)
+			}
+		})
+	}
+}

--- a/tests/store/path_prefix_consistency_test.go
+++ b/tests/store/path_prefix_consistency_test.go
@@ -1,0 +1,84 @@
+package tests
+
+import (
+	"context"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// TestListFilesAndSearchPrefixAgree is the cross-check for issue #286 Bug B:
+// list_files (the store's normalized LIKE 'prefix%' query) and search/ask (the
+// shared model.MatchesPathPrefix matcher) must return the same set of rel_paths
+// for the same path_prefix. Driving both off the same seeded corpus proves the
+// two code paths can no longer drift on prefix semantics.
+func TestListFilesAndSearchPrefixAgree(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	defer func() { _ = st.Close() }()
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	corpus := []string{
+		"acts/foo.pdf",
+		"acts/sub/bar.pdf",
+		"acts2/baz.pdf",
+		"Acts/upper.pdf",
+		"other/qux.pdf",
+	}
+	for _, rel := range corpus {
+		if err := st.UpsertDocument(ctx, model.Document{
+			RelPath:    rel,
+			DocType:    "pdf",
+			SourceType: "filesystem",
+			SizeBytes:  1,
+			MTimeUnix:  1,
+			Status:     "ok",
+		}); err != nil {
+			t.Fatalf("upsert %s: %v", rel, err)
+		}
+	}
+
+	prefixes := []string{"", "acts", "acts/", "./acts", "/acts", "ACTS", "act", "acts/sub", "other", "xyz", "acts/foo.pdf"}
+	for _, prefix := range prefixes {
+		// list_files side: store LIKE query.
+		docs, _, err := st.ListFiles(ctx, prefix, "", 1000, 0)
+		if err != nil {
+			t.Fatalf("ListFiles(%q): %v", prefix, err)
+		}
+		listSet := make([]string, 0, len(docs))
+		for _, d := range docs {
+			listSet = append(listSet, d.RelPath)
+		}
+		sort.Strings(listSet)
+
+		// search/ask side: shared matcher over the same corpus.
+		searchSet := make([]string, 0, len(corpus))
+		for _, rel := range corpus {
+			if model.MatchesPathPrefix(rel, prefix) {
+				searchSet = append(searchSet, rel)
+			}
+		}
+		sort.Strings(searchSet)
+
+		if !equalStrings(listSet, searchSet) {
+			t.Errorf("prefix %q: list_files=%v but search=%v (must agree)", prefix, listSet, searchSet)
+		}
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
Fixes Bug B of #286.

## Problem
`list_files` normalized the `path_prefix` (strip leading `./` and `/`, `path.Clean`, slash) before its store `LIKE` query, but `search`/`ask` applied the **raw** prefix via case-sensitive `strings.HasPrefix` with no normalization. So a prefix that matched in `list_files` silently matched **nothing** in search/ask — the model had to drop the filter to get results.

## Fix
Extract a shared `model.NormalizePathPrefix` / `model.MatchesPathPrefix` and use it in: the store `LIKE`-prefix path, retrieval `matchFilters`, and `model.Filter.Match`. `list_files` and `search`/`ask` now agree on prefix semantics (verified by a store↔search consistency test). Case-sensitivity aligned to the stores existing behavior.

Repro-first: `tests/retrieval/path_prefix_normalization_test.go` (`./acts`, `/acts`, `ACTS` now match `acts/foo.pdf`), `tests/store/path_prefix_consistency_test.go` (list_files set == search set per prefix), `tests/model/path_prefix_test.go` (helper unit tests).

## Split out
Bug A of #286 (`list_files` empty under a symlinked root) is **not** in this PR. Its one-sided leniency would diverge from `open_file`s strict resolver, and the exact production cause is unconfirmed pending a server.log — tracked as a follow-up.

Closes nothing automatically; #286 stays open for Bug A. SPEC declares `path_prefix` only as a string (no normative segment semantics), so no spec change.