### PR TITLE
perf(index): per-batch media cache so sibling chunks share one CorpusFS fetch (#279)

### DIFF
--- a/internal/index/embedding_worker.go
+++ b/internal/index/embedding_worker.go
@@ -122,13 +122,21 @@ func buildEmbedBatch(tasks []model.ChunkTask) (validTasks []model.ChunkTask, inp
 func (w *EmbeddingWorker) embedTasks(ctx context.Context, modelName string, validTasks []model.ChunkTask) ([][]float32, error) {
 	vectors := make([][]float32, len(validTasks))
 
+	// cache is scoped to this single embedTasks invocation so sibling chunks of
+	// the same MediaRef (many PDF pages, many video time-windows) share one
+	// backend fetch instead of each re-reading. It holds whole-file bytes and
+	// materialized local paths only for the duration of the batch, and its
+	// Localize temp files are cleaned up here at batch completion (issue #279).
+	cache := newMediaBatchCache()
+	defer cache.cleanup()
+
 	textIdx := make([]int, 0, len(validTasks))
 	textInputs := make([]string, 0, len(validTasks))
 	mediaIdx := make([]int, 0)
 	mediaItems := make([]model.MediaInput, 0)
 	for i, t := range validTasks {
 		if isMediaModality(t.Modality) {
-			item, err := w.loadMediaInput(ctx, t)
+			item, err := w.loadMediaInput(ctx, t, cache)
 			if err != nil {
 				return nil, err
 			}
@@ -193,7 +201,14 @@ func (w *EmbeddingWorker) corpusFS() corpusfs.CorpusFS {
 // file to extract a single page). Audio/video go through Localize because ffmpeg
 // (avutil.ExtractSegment) needs a real filesystem path, not an io.Reader — for
 // an object-store backend this downloads the whole object to a temp file.
-func (w *EmbeddingWorker) loadMediaInput(ctx context.Context, t model.ChunkTask) (model.MediaInput, error) {
+//
+// Both fetch paths go through cache (issue #279), so sibling chunks of the same
+// MediaRef in one batch (every page of a PDF, every time-window of a video)
+// share a single whole-file read or single Localize download instead of
+// re-fetching per chunk. For the default LocalFS this is behavior-preserving (a
+// local file is cheap to re-open and Localize is a no-op); it only removes
+// redundant range GETs / full-object downloads for remote backends such as S3.
+func (w *EmbeddingWorker) loadMediaInput(ctx context.Context, t model.ChunkTask, cache *mediaBatchCache) (model.MediaInput, error) {
 	ref := strings.TrimSpace(t.MediaRef)
 	if ref == "" {
 		return model.MediaInput{}, fmt.Errorf("%w: media chunk %d has no media_ref", ErrFatal, t.Metadata.ChunkID)
@@ -205,24 +220,115 @@ func (w *EmbeddingWorker) loadMediaInput(ctx context.Context, t model.ChunkTask)
 
 	switch strings.ToLower(strings.TrimSpace(t.Modality)) {
 	case "audio", "video":
-		data, aerr := w.loadMediaSegment(ctx, t, fsys, ref)
+		data, aerr := w.loadMediaSegment(ctx, t, fsys, ref, cache)
 		if aerr != nil {
 			return model.MediaInput{}, fatalIfEscape(aerr)
 		}
 		return model.MediaInput{MimeType: mediaMIMEType(ref), Data: data}, nil
 	case "pdf":
-		data, perr := w.loadPDFPage(ctx, t, fsys, ref)
+		data, perr := w.loadPDFPage(ctx, t, fsys, ref, cache)
 		if perr != nil {
 			return model.MediaInput{}, fatalIfEscape(perr)
 		}
 		return model.MediaInput{MimeType: mediaMIMEType(ref), Data: data}, nil
 	default: // image and other whole-file media
-		data, rerr := readWholeMedia(ctx, fsys, ref)
+		data, rerr := cache.readWholeMedia(ctx, fsys, ref)
 		if rerr != nil {
 			return model.MediaInput{}, fatalIfEscape(fmt.Errorf("read media %q: %w", ref, rerr))
 		}
 		return model.MediaInput{MimeType: mediaMIMEType(ref), Data: data}, nil
 	}
+}
+
+// mediaBatchCache memoizes media fetches across the sibling chunks of one
+// embedTasks invocation so a MediaRef shared by many chunks (a PDF read whole
+// for every page, or a video downloaded once per time-window) is fetched from
+// the corpus filesystem exactly once per batch instead of once per chunk
+// (issue #279). It is created and disposed inside a single embedTasks call, so
+// the cached whole-file bytes and any Localize temp files live only for the
+// batch's duration — there is no process-global state or unbounded growth.
+//
+// The zero value is not usable; construct one with newMediaBatchCache.
+type mediaBatchCache struct {
+	// wholeFile holds bytes read via Open+io.ReadAll, keyed by MediaRef. Used
+	// for image and PDF chunks (pdfutil needs the full file to extract a page),
+	// so every page of one PDF shares a single whole-file read.
+	wholeFile map[string][]byte
+	// localized holds the materialized local path of a Localize'd MediaRef so
+	// every audio/video time-window of one source shares a single download.
+	localized map[string]string
+	// cleanups are the Localize cleanup funcs to invoke at batch completion;
+	// holding them here (rather than deferring per call) keeps the materialized
+	// path alive for sibling chunks and removes temp files exactly once.
+	cleanups []func()
+}
+
+// newMediaBatchCache returns an empty, ready-to-use per-batch media cache.
+func newMediaBatchCache() *mediaBatchCache {
+	return &mediaBatchCache{
+		wholeFile: make(map[string][]byte),
+		localized: make(map[string]string),
+	}
+}
+
+// cleanup invokes every tracked Localize cleanup func (removing downloaded temp
+// files) and resets the cache. It is safe to call on a nil receiver and to call
+// more than once. embedTasks defers it so it runs at batch completion.
+func (c *mediaBatchCache) cleanup() {
+	if c == nil {
+		return
+	}
+	for _, fn := range c.cleanups {
+		if fn != nil {
+			fn()
+		}
+	}
+	c.cleanups = nil
+	c.wholeFile = nil
+	c.localized = nil
+}
+
+// readWholeMedia returns the entire object at ref, reading it through the corpus
+// filesystem only on the first request for that ref within the batch and serving
+// cached bytes to sibling chunks. A nil cache falls back to an uncached read so
+// the helper is usable without a batch context.
+func (c *mediaBatchCache) readWholeMedia(ctx context.Context, fsys corpusfs.CorpusFS, ref string) ([]byte, error) {
+	if c == nil {
+		return readWholeMedia(ctx, fsys, ref)
+	}
+	if data, ok := c.wholeFile[ref]; ok {
+		return data, nil
+	}
+	data, err := readWholeMedia(ctx, fsys, ref)
+	if err != nil {
+		return nil, err
+	}
+	c.wholeFile[ref] = data
+	return data, nil
+}
+
+// localize returns a real local path for ref, calling fsys.Localize only on the
+// first request for that ref within the batch and reusing the materialized path
+// for sibling chunks. The Localize cleanup is tracked on the cache and runs at
+// batch completion, not per call, so the path stays valid for all siblings. A
+// nil cache falls back to a per-call Localize+cleanup so the helper is usable
+// without a batch context.
+func (c *mediaBatchCache) localize(ctx context.Context, fsys corpusfs.CorpusFS, ref string) (string, func(), error) {
+	if c == nil {
+		return fsys.Localize(ctx, ref)
+	}
+	if path, ok := c.localized[ref]; ok {
+		return path, func() {}, nil
+	}
+	path, cleanup, err := fsys.Localize(ctx, ref)
+	if err != nil {
+		return "", nil, err
+	}
+	c.localized[ref] = path
+	c.cleanups = append(c.cleanups, cleanup)
+	// cleanup is owned by the cache; hand the caller a no-op so a per-call defer
+	// cannot remove a temp file still needed by sibling chunks.
+	return path, func() {}, nil
 }
 
 // fatalIfEscape promotes a corpus-root traversal error to ErrFatal so the worker
@@ -241,6 +347,8 @@ func fatalIfEscape(err error) error {
 }
 
 // readWholeMedia reads the entire object at ref through the corpus filesystem.
+// Callers within a batch should go through mediaBatchCache.readWholeMedia so the
+// read is shared across sibling chunks of the same MediaRef (issue #279).
 func readWholeMedia(ctx context.Context, fsys corpusfs.CorpusFS, ref string) ([]byte, error) {
 	rc, err := fsys.Open(ctx, ref)
 	if err != nil {
@@ -257,11 +365,11 @@ func readWholeMedia(ctx context.Context, fsys corpusfs.CorpusFS, ref string) ([]
 // pdfutil.ExtractPage operates on the whole file in memory, so the entire PDF is
 // read via Open even though only one page is embedded; this matches the prior
 // behavior (it previously read the whole file too).
-func (w *EmbeddingWorker) loadPDFPage(ctx context.Context, t model.ChunkTask, fsys corpusfs.CorpusFS, ref string) ([]byte, error) {
+func (w *EmbeddingWorker) loadPDFPage(ctx context.Context, t model.ChunkTask, fsys corpusfs.CorpusFS, ref string, cache *mediaBatchCache) ([]byte, error) {
 	if !strings.EqualFold(strings.TrimSpace(t.Metadata.Span.Kind), "page") || t.Metadata.Span.Page < 1 {
 		return nil, fmt.Errorf("%w: pdf media chunk %d has invalid page span", ErrFatal, t.Metadata.ChunkID)
 	}
-	data, err := readWholeMedia(ctx, fsys, ref)
+	data, err := cache.readWholeMedia(ctx, fsys, ref)
 	if err != nil {
 		return nil, fmt.Errorf("read media %q: %w", ref, err)
 	}
@@ -275,14 +383,15 @@ func (w *EmbeddingWorker) loadPDFPage(ctx context.Context, t model.ChunkTask, fs
 // loadMediaSegment cuts the chunk's single time window (from its `time` span)
 // out of the source media (SPEC 8.1.7). A missing/invalid time span is a fatal
 // task error so a span/content mismatch surfaces instead of embedding the wrong
-// segment. The source is Localized to a real path first because ffmpeg cannot
-// read from an io.Reader.
-func (w *EmbeddingWorker) loadMediaSegment(ctx context.Context, t model.ChunkTask, fsys corpusfs.CorpusFS, ref string) ([]byte, error) {
+// segment. The source is Localized to a real path first (through the per-batch
+// cache so sibling time-windows reuse one download) because ffmpeg cannot read
+// from an io.Reader.
+func (w *EmbeddingWorker) loadMediaSegment(ctx context.Context, t model.ChunkTask, fsys corpusfs.CorpusFS, ref string, cache *mediaBatchCache) ([]byte, error) {
 	span := t.Metadata.Span
 	if !strings.EqualFold(strings.TrimSpace(span.Kind), "time") || span.StartMS < 0 || span.EndMS <= span.StartMS {
 		return nil, fmt.Errorf("%w: %s media chunk %d has invalid time span", ErrFatal, strings.ToLower(t.Modality), t.Metadata.ChunkID)
 	}
-	localPath, cleanup, err := fsys.Localize(ctx, ref)
+	localPath, cleanup, err := cache.localize(ctx, fsys, ref)
 	if err != nil {
 		return nil, fmt.Errorf("read media %q: %w", ref, err)
 	}

--- a/tests/index/media_batch_cache_test.go
+++ b/tests/index/media_batch_cache_test.go
@@ -1,0 +1,247 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/corpusfs"
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// countingCorpusFS is a fake corpusfs.CorpusFS that records how many times Open
+// and Localize are invoked per relPath so a per-batch cache (issue #279) can be
+// asserted to collapse sibling-chunk fetches of the same MediaRef into one.
+type countingCorpusFS struct {
+	mu          sync.Mutex
+	contents    map[string][]byte
+	openCalls   map[string]int
+	localCalls  map[string]int
+	liveTemps   map[string]bool // temp paths still present (cleanup not yet run)
+	openErr     error
+	localizeErr error
+}
+
+func newCountingCorpusFS(contents map[string][]byte) *countingCorpusFS {
+	return &countingCorpusFS{
+		contents:   contents,
+		openCalls:  map[string]int{},
+		localCalls: map[string]int{},
+		liveTemps:  map[string]bool{},
+	}
+}
+
+func (f *countingCorpusFS) Walk(context.Context, string, corpusfs.Options) ([]corpusfs.DiscoveredFile, error) {
+	return nil, errors.New("not used")
+}
+
+func (f *countingCorpusFS) Open(_ context.Context, relPath string) (io.ReadSeekCloser, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.openCalls[relPath]++
+	if f.openErr != nil {
+		return nil, f.openErr
+	}
+	data, ok := f.contents[relPath]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	return nopSeekCloser{bytes.NewReader(data)}, nil
+}
+
+func (f *countingCorpusFS) Localize(_ context.Context, relPath string) (string, func(), error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.localCalls[relPath]++
+	if f.localizeErr != nil {
+		return "", nil, f.localizeErr
+	}
+	data, ok := f.contents[relPath]
+	if !ok {
+		return "", nil, os.ErrNotExist
+	}
+	// Materialize a temp file (mimicking an S3 download) preserving the
+	// extension so muxer inference works, and track it so the test can assert
+	// the cleanup func removed it at batch end.
+	dir, err := os.MkdirTemp("", "media-batch-cache")
+	if err != nil {
+		return "", nil, err
+	}
+	tmp := filepath.Join(dir, filepath.Base(relPath))
+	if werr := os.WriteFile(tmp, data, 0o600); werr != nil {
+		return "", nil, werr
+	}
+	f.liveTemps[tmp] = true
+	cleanup := func() {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		_ = os.RemoveAll(dir)
+		delete(f.liveTemps, tmp)
+	}
+	return tmp, cleanup, nil
+}
+
+func (f *countingCorpusFS) opens(relPath string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.openCalls[relPath]
+}
+
+func (f *countingCorpusFS) localizes(relPath string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.localCalls[relPath]
+}
+
+func (f *countingCorpusFS) liveTempCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.liveTemps)
+}
+
+type nopSeekCloser struct{ *bytes.Reader }
+
+func (nopSeekCloser) Close() error { return nil }
+
+// TestEmbeddingWorker_BatchCache_PDFWholeFileSharedAcrossPages pins issue #279:
+// three PDF chunks that are sibling pages of the SAME MediaRef must trigger
+// exactly one whole-file Open for that ref within a batch, not one per page.
+func TestEmbeddingWorker_BatchCache_PDFWholeFileSharedAcrossPages(t *testing.T) {
+	pdf := makeWorkerPDF(t, 3)
+	fsys := newCountingCorpusFS(map[string][]byte{"doc.pdf": pdf})
+
+	tasks := []model.ChunkTask{
+		avTask(1, "doc.pdf", "pdf", model.Span{Kind: "page", Page: 1}),
+		avTask(2, "doc.pdf", "pdf", model.Span{Kind: "page", Page: 2}),
+		avTask(3, "doc.pdf", "pdf", model.Span{Kind: "page", Page: 3}),
+	}
+	emb := &fakeMultimodalEmbedder{mediaVecs: [][]float32{{1, 0}, {0, 1}, {1, 1}}}
+	worker := &index.EmbeddingWorker{
+		Source: &fakeChunkSource{tasks: tasks}, Index: index.NewHNSWIndex(""), Embedder: emb,
+		Corpus: fsys, RootDir: t.TempDir(), BatchSize: 8, ModelForText: "gemini-embedding-2",
+	}
+
+	n, err := worker.RunOnce(context.Background(), "text")
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if n != 3 {
+		t.Fatalf("indexed = %d, want 3", n)
+	}
+	if got := fsys.opens("doc.pdf"); got != 1 {
+		t.Fatalf("Open(doc.pdf) called %d times, want 1 (per-batch cache should share the whole-file read)", got)
+	}
+	if len(emb.gotMedia) != 3 {
+		t.Fatalf("EmbedMedia got %d items, want 3", len(emb.gotMedia))
+	}
+}
+
+// TestEmbeddingWorker_BatchCache_VideoLocalizeSharedAcrossWindows pins issue
+// #279 for the Localize path: three video chunks that are different time-windows
+// of the SAME MediaRef must trigger exactly one Localize (one download), and the
+// materialized temp file must be cleaned up after the batch completes.
+func TestEmbeddingWorker_BatchCache_VideoLocalizeSharedAcrossWindows(t *testing.T) {
+	fsys := newCountingCorpusFS(map[string][]byte{"clip.mp4": []byte("FULLVIDEO")})
+
+	tasks := []model.ChunkTask{
+		avTask(1, "clip.mp4", "video", model.Span{Kind: "time", StartMS: 0, EndMS: 1000}),
+		avTask(2, "clip.mp4", "video", model.Span{Kind: "time", StartMS: 1000, EndMS: 2000}),
+		avTask(3, "clip.mp4", "video", model.Span{Kind: "time", StartMS: 2000, EndMS: 3000}),
+	}
+	var extractPaths []string
+	emb := &fakeMultimodalEmbedder{mediaVecs: [][]float32{{1, 0}, {0, 1}, {1, 1}}}
+	worker := &index.EmbeddingWorker{
+		Source: &fakeChunkSource{tasks: tasks}, Index: index.NewHNSWIndex(""), Embedder: emb,
+		Corpus: fsys, RootDir: t.TempDir(), BatchSize: 8, ModelForText: "gemini-embedding-2",
+		ExtractSegmentFunc: func(_ context.Context, path string, _, _ int) ([]byte, error) {
+			extractPaths = append(extractPaths, path)
+			return []byte("SEG"), nil
+		},
+	}
+
+	n, err := worker.RunOnce(context.Background(), "text")
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if n != 3 {
+		t.Fatalf("indexed = %d, want 3", n)
+	}
+	if got := fsys.localizes("clip.mp4"); got != 1 {
+		t.Fatalf("Localize(clip.mp4) called %d times, want 1 (per-batch cache should share the download)", got)
+	}
+	if len(extractPaths) != 3 {
+		t.Fatalf("extractor called %d times, want 3", len(extractPaths))
+	}
+	// All three windows must have been cut from the one materialized path.
+	for i, p := range extractPaths {
+		if p != extractPaths[0] {
+			t.Fatalf("window %d extracted from %q, want shared path %q", i, p, extractPaths[0])
+		}
+	}
+	if got := fsys.liveTempCount(); got != 0 {
+		t.Fatalf("%d Localize temp files survived the batch, want 0 (cleanup must run at batch end)", got)
+	}
+}
+
+// TestEmbeddingWorker_BatchCache_DifferentRefsFetchIndependently confirms the
+// cache keys on MediaRef: distinct refs in one batch each fetch once.
+func TestEmbeddingWorker_BatchCache_DifferentRefsFetchIndependently(t *testing.T) {
+	fsys := newCountingCorpusFS(map[string][]byte{
+		"a.png": []byte("AAA"),
+		"b.png": []byte("BBB"),
+	})
+	tasks := []model.ChunkTask{
+		mediaTask(1, "a.png", "image"),
+		mediaTask(2, "a.png", "image"),
+		mediaTask(3, "b.png", "image"),
+	}
+	emb := &fakeMultimodalEmbedder{mediaVecs: [][]float32{{1, 0}, {0, 1}, {1, 1}}}
+	worker := &index.EmbeddingWorker{
+		Source: &fakeChunkSource{tasks: tasks}, Index: index.NewHNSWIndex(""), Embedder: emb,
+		Corpus: fsys, RootDir: t.TempDir(), BatchSize: 8, ModelForText: "gemini-embedding-2",
+	}
+	if _, err := worker.RunOnce(context.Background(), "text"); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if got := fsys.opens("a.png"); got != 1 {
+		t.Fatalf("Open(a.png) = %d, want 1 (two sibling chunks share one read)", got)
+	}
+	if got := fsys.opens("b.png"); got != 1 {
+		t.Fatalf("Open(b.png) = %d, want 1", got)
+	}
+}
+
+// TestEmbeddingWorker_BatchCache_EscapeStillFatal confirms the cache does not
+// disturb fatal classification: a ref that escapes the corpus root is still a
+// permanent (ErrFatal) failure. Exercised against the real LocalFS containment
+// check (the cache wraps it without altering the error).
+func TestEmbeddingWorker_BatchCache_EscapeStillFatal(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	if err := os.WriteFile(filepath.Join(outside, "secret.png"), []byte("SECRET"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	escapeRef := "../" + filepath.Base(outside) + "/secret.png"
+
+	source := &fakeChunkSource{tasks: []model.ChunkTask{mediaTask(1, escapeRef, "image")}}
+	worker := &index.EmbeddingWorker{
+		Source: source, Index: index.NewHNSWIndex(""), Embedder: &fakeMultimodalEmbedder{mediaVecs: [][]float32{{1, 0}}},
+		RootDir: root, BatchSize: 4, ModelForText: "gemini-embedding-2",
+	}
+	n, err := worker.RunOnce(context.Background(), "text")
+	if !errors.Is(err, index.ErrFatal) {
+		t.Fatalf("expected fatal error on escaping media_ref, got %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("indexed = %d, want 0", n)
+	}
+	if len(source.failedLabels) != 1 || source.failedLabels[0] != 1 {
+		t.Fatalf("failed labels = %#v, want [1]", source.failedLabels)
+	}
+}


### PR DESCRIPTION
## What

Adds a per-batch media cache to `internal/index/embedding_worker.go` so sibling chunks of the **same** `MediaRef` no longer each re-fetch from the CorpusFS backend.

Resolves the deferred CodeRabbit finding from #277. Closes #279. Part of epic #250.

## Problem

`loadMediaInput` was a stateless per-chunk dispatcher. Sibling chunks of one `MediaRef` (every page of a PDF, every time-window of a video) each independently fetched:

- **PDF / image**: `Open` + `io.ReadAll` the whole file — once per page.
- **Audio / video**: `Localize` — which for an object-store backend (S3) downloads the **full object** to a temp file — once per window.

Against a non-local CorpusFS this multiplied one logical fetch by the chunk count.

## Change

A `mediaBatchCache` scoped to a single `embedTasks` invocation:

- **Keys**: `MediaRef`.
- **Whole-file path (image/pdf)**: caches the bytes per ref, so all PDF pages share one read (`pdfutil.ExtractPage` still needs the full file; the page extraction is unchanged).
- **Localize path (audio/video)**: caches the materialized local path per ref, so all time-windows share one download; `avutil.ExtractSegment` is still called per window against the shared path.
- **Cleanup**: every `Localize` cleanup func is tracked on the cache and invoked at batch completion (`defer cache.cleanup()` in `embedTasks`), keeping the path alive for siblings and removing temp files exactly once. Per-call callers get a no-op cleanup so a stray `defer` can't delete a file still in use.
- **Scope/lifetime**: created and disposed inside one `embedTasks` call — no process-global state, no unbounded growth; whole-file bytes are held only for the batch duration.

**Behavior preserved for the default LocalFS** (re-open is cheap, `Localize` is a no-op). Only redundant range GETs / full-object downloads for remote backends are removed. Fatal/retryable classification (`fatalIfEscape` / `ErrFatal`) is untouched. No embedding or span changes — only fetch counts change.

## Tests (`tests/index`, package `tests`)

New `media_batch_cache_test.go` with a counting fake `CorpusFS` (stub `Open`/`Localize`):

- 3 PDF pages of one ref → exactly **1** `Open`.
- 3 video windows of one ref → exactly **1** `Localize`, all windows cut from the shared path, and the temp file is cleaned up after the batch (live-temp count back to 0).
- Different refs fetch independently (each once).
- An escaping `media_ref` is still classified fatal (`ErrFatal`).

Reuses existing fakes (`fakeChunkSource`, `fakeMultimodalEmbedder`, `avTask`, `mediaTask`, `makeWorkerPDF`).

`make check` passes locally. `gocyclo` ≤ 15 (`embedTasks` = 13). Pure-Go, `CGO_ENABLED=0`. `dirstral-spec` not re-pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)