### PR TITLE
feat(stt): carry faster-whisper word-level timestamps as transcript provenance (#252)

### DIFF
--- a/internal/ingest/represent.go
+++ b/internal/ingest/represent.go
@@ -623,6 +623,65 @@ func maxF(a, b float64) float64 {
 	return b
 }
 
+// chunkTranscriptByTimeWithWords chunks a transcript exactly like
+// chunkTranscriptByTime (same chunks, same text, same time spans — see spec
+// §8.6.1: word timing is metadata only and MUST NOT add chunks or change text),
+// then attaches each per-word timestamp to the chunk whose time span contains
+// the word's start. Words are stored relative-to-nothing — their absolute ms
+// offsets are kept as {t,d,w} on the chunk's span. A nil/empty words slice
+// produces output byte-for-byte identical to chunkTranscriptByTime, so a
+// provider without word timing is unaffected.
+func chunkTranscriptByTimeWithWords(content string, words []model.TimedWord) []chunkSegment {
+	segs := chunkTranscriptByTime(content)
+	if len(words) == 0 || len(segs) == 0 {
+		return segs
+	}
+	attachWordsToTimeSpans(segs, words)
+	return segs
+}
+
+// attachWordsToTimeSpans assigns words to the chunk whose "time" span covers the
+// word's start time, mutating each chunk's span.Words in place. Words are
+// processed in order; a word is placed in the first chunk for which
+// StartMS <= word.start < EndMS (the final time chunk also catches a word at or
+// beyond its EndMS so trailing words are not dropped). Chunks without a time
+// span are skipped. The chunk text and span bounds are never modified.
+func attachWordsToTimeSpans(segs []chunkSegment, words []model.TimedWord) {
+	for _, w := range words {
+		idx := timeSpanIndexForWord(segs, w.StartMS)
+		if idx < 0 {
+			continue
+		}
+		dur := w.EndMS - w.StartMS
+		if dur < 0 {
+			dur = 0
+		}
+		segs[idx].Span.Words = append(segs[idx].Span.Words, model.WordSpan{
+			T: w.StartMS,
+			D: dur,
+			W: w.Word,
+		})
+	}
+}
+
+// timeSpanIndexForWord returns the index of the time-spanned chunk that owns a
+// word starting at startMS, or -1 when no chunk does. A word inside [StartMS,
+// EndMS) belongs to that chunk; a word at/after the last time chunk's EndMS is
+// assigned to that last time chunk so trailing words are retained.
+func timeSpanIndexForWord(segs []chunkSegment, startMS int) int {
+	lastTime := -1
+	for i := range segs {
+		if segs[i].Span.Kind != "time" {
+			continue
+		}
+		lastTime = i
+		if startMS >= segs[i].Span.StartMS && startMS < segs[i].Span.EndMS {
+			return i
+		}
+	}
+	return lastTime
+}
+
 func chunkTranscriptByTime(content string) []chunkSegment {
 	// normalize line endings just like NormalizeUTF8 does; this ensures both
 	// "\r\n" and lone "\r" are converted to "\n" before we split.  we
@@ -992,6 +1051,18 @@ func ChunkTextByChars(content string, maxChars, overlapChars, minChars int) []Ch
 // primarily provided so that tests can exercise the chunking logic directly.
 func ChunkTranscriptByTime(content string) []ChunkSegment {
 	raw := chunkTranscriptByTime(content)
+	out := make([]ChunkSegment, 0, len(raw))
+	for _, seg := range raw {
+		out = append(out, ChunkSegment(seg))
+	}
+	return out
+}
+
+// ChunkTranscriptByTimeWithWords is the exported counterpart of
+// chunkTranscriptByTimeWithWords, exposed for tests in the tests/ tree. With a
+// nil/empty words slice it is identical to ChunkTranscriptByTime.
+func ChunkTranscriptByTimeWithWords(content string, words []model.TimedWord) []ChunkSegment {
+	raw := chunkTranscriptByTimeWithWords(content, words)
 	out := make([]ChunkSegment, 0, len(raw))
 	for _, seg := range raw {
 		out = append(out, ChunkSegment(seg))

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -1573,7 +1573,7 @@ func (s *Service) generateTranscriptRepresentation(ctx context.Context, doc mode
 		return nil
 	}
 
-	transcriptText, err := s.readOrComputeTranscript(ctx, doc, content, "")
+	transcriptText, words, err := s.readOrComputeTranscriptWithWords(ctx, doc, content, "")
 	if err != nil {
 		return err
 	}
@@ -1605,7 +1605,7 @@ func (s *Service) generateTranscriptRepresentation(ctx context.Context, doc mode
 		return fmt.Errorf("upsert transcript representation: %w", err)
 	}
 
-	segments := chunkTranscriptByTime(transcriptText)
+	segments := chunkTranscriptByTimeWithWords(transcriptText, words)
 	if len(segments) == 0 {
 		return nil
 	}
@@ -1896,29 +1896,43 @@ func TranscriptLangSuffix(language string) string {
 }
 
 func (s *Service) readOrComputeTranscript(ctx context.Context, doc model.Document, content []byte, language string) (string, error) {
+	text, _, err := s.readOrComputeTranscriptWithWords(ctx, doc, content, language)
+	return text, err
+}
+
+// readOrComputeTranscriptWithWords is readOrComputeTranscript plus the optional
+// per-word timing the provider returned (spec §8.6.1, #252). The segment text is
+// the authoritative cache key/value (the .txt cache file); word timing is a
+// best-effort sidecar (.words.json) carried only when the transcriber implements
+// model.StructuredTranscriber. A missing or unreadable sidecar yields nil words
+// — behaviour identical to a provider without word timing.
+func (s *Service) readOrComputeTranscriptWithWords(ctx context.Context, doc model.Document, content []byte, language string) (string, []model.TimedWord, error) {
 	if s.transcriber == nil {
-		return "", errors.New("transcriber not configured")
+		return "", nil, errors.New("transcriber not configured")
 	}
 
 	cacheDir := filepath.Join(s.cfg.StateDir, "cache", "transcribe")
 	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
-		return "", fmt.Errorf("create transcript cache dir: %w", err)
+		return "", nil, fmt.Errorf("create transcript cache dir: %w", err)
 	}
 
-	cachePath := filepath.Join(cacheDir, computeContentHash(content)+TranscriptLangSuffix(language)+".txt")
+	base := computeContentHash(content) + TranscriptLangSuffix(language)
+	cachePath := filepath.Join(cacheDir, base+".txt")
+	wordsPath := filepath.Join(cacheDir, base+".words.json")
 	if cached, err := os.ReadFile(cachePath); err == nil {
-		return string(cached), nil
+		return string(cached), readCachedWords(wordsPath), nil
 	}
 
-	transcript, err := s.transcriber.Transcribe(ctx, doc.RelPath, content)
+	transcript, words, err := s.transcribe(ctx, doc, content)
 	if err != nil {
-		return "", fmt.Errorf("%w: transcribe %s: %w", ErrTranscriptProviderFailure, doc.RelPath, err)
+		return "", nil, fmt.Errorf("%w: transcribe %s: %w", ErrTranscriptProviderFailure, doc.RelPath, err)
 	}
 
 	transcriptBytes := []byte(strings.ReplaceAll(strings.ReplaceAll(transcript, "\r\n", "\n"), "\r", "\n"))
 	if err := os.WriteFile(cachePath, transcriptBytes, 0o644); err != nil {
-		return "", fmt.Errorf("write transcript cache: %w", err)
+		return "", nil, fmt.Errorf("write transcript cache: %w", err)
 	}
+	s.writeCachedWords(wordsPath, words)
 	shouldEnforceAfterWrite := s.markOCRCacheWrite()
 	if shouldEnforceAfterWrite {
 		// Reuse the same cache-policy limits/hooks as OCR for now so transcript
@@ -1936,7 +1950,57 @@ func (s *Service) readOrComputeTranscript(ctx context.Context, doc model.Documen
 			s.getLogger().Printf("enforceCachePolicy(%s) failed: %v", cacheDir, err)
 		}
 	}
-	return string(transcriptBytes), nil
+	return string(transcriptBytes), words, nil
+}
+
+// transcribe calls the configured transcriber, preferring the structured
+// (word-timing) capability when available. Providers that do not implement
+// model.StructuredTranscriber return no words, leaving downstream behaviour
+// unchanged.
+func (s *Service) transcribe(ctx context.Context, doc model.Document, content []byte) (string, []model.TimedWord, error) {
+	if st, ok := s.transcriber.(model.StructuredTranscriber); ok {
+		res, err := st.TranscribeStructured(ctx, doc.RelPath, content)
+		if err != nil {
+			return "", nil, err
+		}
+		return res.Text, res.Words, nil
+	}
+	text, err := s.transcriber.Transcribe(ctx, doc.RelPath, content)
+	if err != nil {
+		return "", nil, err
+	}
+	return text, nil, nil
+}
+
+// readCachedWords loads per-word timing from the sidecar cache file, returning
+// nil on any error (missing/corrupt sidecar degrades to no word timing).
+func readCachedWords(path string) []model.TimedWord {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var words []model.TimedWord
+	if err := json.Unmarshal(raw, &words); err != nil {
+		return nil
+	}
+	return words
+}
+
+// writeCachedWords persists per-word timing alongside the transcript text. It is
+// best-effort: a write failure is logged and ignored so word timing never blocks
+// transcript ingest. No sidecar is written when there are no words.
+func (s *Service) writeCachedWords(path string, words []model.TimedWord) {
+	if len(words) == 0 {
+		return
+	}
+	raw, err := json.Marshal(words)
+	if err != nil {
+		s.getLogger().Printf("marshal transcript words cache: %v", err)
+		return
+	}
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		s.getLogger().Printf("write transcript words cache (%s): %v", path, err)
+	}
 }
 
 // ReadOrComputeTranscript exposes transcript cache lookup/computation for tests.

--- a/internal/model/interfaces.go
+++ b/internal/model/interfaces.go
@@ -143,6 +143,38 @@ type Transcriber interface {
 	Transcribe(ctx context.Context, relPath string, data []byte) (string, error)
 }
 
+// TimedWord is one per-word timestamp returned by a structured transcriber.
+// StartMS/EndMS are absolute offsets from the start of the media (spec §8.6.1).
+type TimedWord struct {
+	Word    string
+	StartMS int
+	EndMS   int
+}
+
+// TranscriptResult is the structured output of a StructuredTranscriber: the
+// SAME `[mm:ss] text` segment string a plain Transcriber returns (so the
+// existing chunker is unaffected), PLUS optional per-word timing. Words is nil
+// when the provider returned no word-level timestamps.
+type TranscriptResult struct {
+	// Text is the segment-formatted transcript identical to Transcriber.Transcribe.
+	Text string
+	// Words is the flat, time-ordered list of per-word timestamps across the whole
+	// transcript. Empty/nil when unavailable.
+	Words []TimedWord
+}
+
+// StructuredTranscriber is an OPTIONAL capability a Transcriber MAY implement to
+// expose per-word timing alongside the segment text (spec §8.6.1, issue #252).
+// The ingest pipeline type-asserts the configured transcriber against this; a
+// transcriber that does not implement it simply yields no word timing and the
+// pipeline behaves exactly as before. Implementations MUST return a Text value
+// byte-for-byte equal to what Transcribe would return for the same input so the
+// downstream segment chunker is unchanged.
+type StructuredTranscriber interface {
+	Transcriber
+	TranscribeStructured(ctx context.Context, relPath string, data []byte) (TranscriptResult, error)
+}
+
 type Generator interface {
 	Generate(ctx context.Context, prompt string) (string, error)
 }

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -75,6 +75,23 @@ type Span struct {
 	// bounding box, and section breadcrumb. nil for all other kinds, which
 	// keeps Span comparable for the scalar kinds.
 	Region *RegionSpan
+	// Words optionally carries per-word timing for a "time" span when the STT
+	// provider returned word-level timestamps (spec §8.6.1). It is metadata
+	// only: it never changes the chunk text and never creates extra chunks.
+	// Persisted in the span's extra_json as a `words` array. Nil/empty for
+	// every other span kind and for providers without word timing, which keeps
+	// behaviour identical to a words-absent transcript. Its presence makes Span
+	// non-comparable, so callers must not use Span as a map key.
+	Words []WordSpan
+}
+
+// WordSpan is one per-word timestamp on a "time" span (spec §8.6.1). The JSON
+// tags match the stored extra_json shape exactly: `t` = word start in ms, `d` =
+// word duration in ms, `w` = the word/token text.
+type WordSpan struct {
+	T int    `json:"t"`
+	D int    `json:"d"`
+	W string `json:"w"`
 }
 
 // RegionSpan localizes a chunk to a rectangular area within a page range of a

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -1659,7 +1659,7 @@ func spanFromRow(kind string, start, end int, extraJSON string) model.Span {
 		if start < 0 || end < 0 || end < start {
 			return model.Span{Kind: "lines"}
 		}
-		return model.Span{Kind: "time", StartMS: start, EndMS: end}
+		return model.Span{Kind: "time", StartMS: start, EndMS: end, Words: wordsFromExtraJSON(extraJSON)}
 	case "region":
 		return regionSpanFromRow(start, end, extraJSON)
 	case "lines":
@@ -1668,6 +1668,37 @@ func spanFromRow(kind string, start, end int, extraJSON string) model.Span {
 		}
 	}
 	return model.Span{Kind: "lines"}
+}
+
+// wordsFromExtraJSON reconstructs per-word timing for a "time" span from its
+// stored extra_json (spec §8.6.1). It tolerates a NULL/empty/malformed payload
+// by returning nil so a time citation degrades cleanly to segment-level (the
+// behaviour for a transcript without word timing). Words with empty text are
+// dropped; negative durations are clamped to 0.
+func wordsFromExtraJSON(extraJSON string) []model.WordSpan {
+	if strings.TrimSpace(extraJSON) == "" {
+		return nil
+	}
+	var payload struct {
+		Words []model.WordSpan `json:"words"`
+	}
+	if err := json.Unmarshal([]byte(extraJSON), &payload); err != nil || len(payload.Words) == 0 {
+		return nil
+	}
+	out := make([]model.WordSpan, 0, len(payload.Words))
+	for _, w := range payload.Words {
+		if strings.TrimSpace(w.W) == "" {
+			continue
+		}
+		if w.D < 0 {
+			w.D = 0
+		}
+		out = append(out, w)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // regionSpanFromRow reconstructs a region span from its stored columns. A
@@ -2174,12 +2205,34 @@ func spanToRow(span model.Span) (kind string, start int, end int, extraJSON stri
 		if span.StartMS < 0 || span.EndMS < 0 || span.EndMS < span.StartMS {
 			return "", 0, 0, "", errors.New("invalid time span")
 		}
-		return "time", span.StartMS, span.EndMS, "", nil
+		extra, eErr := timeSpanExtraJSON(span.Words)
+		if eErr != nil {
+			return "", 0, 0, "", eErr
+		}
+		return "time", span.StartMS, span.EndMS, extra, nil
 	case "region":
 		return regionSpanToRow(span.Region)
 	default:
 		return "", 0, 0, "", fmt.Errorf("unsupported span kind: %q", span.Kind)
 	}
+}
+
+// timeSpanExtraJSON marshals per-word timing for a "time" span into the stored
+// extra_json shape `{"words":[{"t":..,"d":..,"w":".."}]}` (spec §8.6.1).
+// Returns the empty string (stored as SQL NULL, preserving prior behaviour) when
+// there is no word timing, so words-absent transcripts round-trip unchanged.
+func timeSpanExtraJSON(words []model.WordSpan) (string, error) {
+	if len(words) == 0 {
+		return "", nil
+	}
+	payload := struct {
+		Words []model.WordSpan `json:"words"`
+	}{Words: words}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("marshal time span words: %w", err)
+	}
+	return string(encoded), nil
 }
 
 // regionSpanToRow validates and flattens a region span: the page range goes to

--- a/internal/whisperapi/client.go
+++ b/internal/whisperapi/client.go
@@ -80,9 +80,9 @@ type Client struct {
 	// DefaultLanguage optionally sets the `language` hint. Empty means
 	// provider auto-detection (no language field is sent).
 	DefaultLanguage string
-	// ResponseFormat selects the response schema: "json" (default,
-	// segments) or "verbose_json" (segments + word timestamps). Empty
-	// falls back to ResponseFormatJSON.
+	// ResponseFormat selects the response schema: "verbose_json" (default,
+	// segments + word timestamps per spec §8.6.1) or "json" (segments only).
+	// Empty falls back to ResponseFormatVerboseJSON.
 	ResponseFormat string
 }
 
@@ -101,7 +101,11 @@ func NewClient(baseURL, apiKey string) *Client {
 		MaxBackoff:      defaultMaxBackoff,
 		MaxPayloadBytes: defaultMaxPayloadBytes,
 		DefaultModel:    DefaultModel,
-		ResponseFormat:  ResponseFormatJSON,
+		// Default to verbose_json so the server returns per-word timestamps
+		// (spec §8.6.1, #252). Segment parsing is unaffected — verbose_json is a
+		// superset of json — and operators MAY override to "json" via the
+		// provider profile if their server omits or mishandles word timing.
+		ResponseFormat: ResponseFormatVerboseJSON,
 	}
 }
 
@@ -114,6 +118,10 @@ type transcribeResponse struct {
 	Language string              `json:"language,omitempty"`
 	Duration float64             `json:"duration,omitempty"`
 	Segments []transcriptSegment `json:"segments,omitempty"`
+	// Words is the top-level word array some verbose_json servers return
+	// instead of (or in addition to) per-segment words. Used as a fallback
+	// when no segment carries its own words (#252).
+	Words []transcriptWord `json:"words,omitempty"`
 }
 
 type transcriptSegment struct {
@@ -131,17 +139,30 @@ type transcriptWord struct {
 	End   float64 `json:"end"`
 }
 
-// Transcribe implements model.Transcriber.
+// Transcribe implements model.Transcriber. It returns only the segment text so
+// the contract is unchanged; per-word timing is available via
+// TranscribeStructured.
 func (c *Client) Transcribe(ctx context.Context, relPath string, data []byte) (string, error) {
+	res, err := c.TranscribeStructured(ctx, relPath, data)
+	if err != nil {
+		return "", err
+	}
+	return res.Text, nil
+}
+
+// TranscribeStructured implements model.StructuredTranscriber: it returns the
+// same segment text as Transcribe plus per-word timing when the server provided
+// it (spec §8.6.1, #252). Words is nil when the response carried none.
+func (c *Client) TranscribeStructured(ctx context.Context, relPath string, data []byte) (model.TranscriptResult, error) {
 	if len(data) == 0 {
-		return "", &model.ProviderError{Code: "WHISPER_FAILED", Message: "transcription input is empty", Retryable: false}
+		return model.TranscriptResult{}, &model.ProviderError{Code: "WHISPER_FAILED", Message: "transcription input is empty", Retryable: false}
 	}
 	maxPayload := c.MaxPayloadBytes
 	if maxPayload <= 0 {
 		maxPayload = defaultMaxPayloadBytes
 	}
 	if len(data) > maxPayload {
-		return "", &model.ProviderError{
+		return model.TranscriptResult{}, &model.ProviderError{
 			Code:      "WHISPER_FAILED",
 			Message:   fmt.Sprintf("transcription input too large (%d bytes, limit %d)", len(data), maxPayload),
 			Retryable: false,
@@ -150,7 +171,10 @@ func (c *Client) Transcribe(ctx context.Context, relPath string, data []byte) (s
 	return c.transcribeWithRetry(ctx, relPath, data)
 }
 
-func (c *Client) transcribeWithRetry(ctx context.Context, relPath string, data []byte) (string, error) {
+// compile-time interface check for the optional word-timing capability.
+var _ model.StructuredTranscriber = (*Client)(nil)
+
+func (c *Client) transcribeWithRetry(ctx context.Context, relPath string, data []byte) (model.TranscriptResult, error) {
 	maxAttempts := c.MaxRetries + 1
 	if maxAttempts <= 0 {
 		maxAttempts = 1
@@ -166,14 +190,14 @@ func (c *Client) transcribeWithRetry(ctx context.Context, relPath string, data [
 
 		var providerErr *model.ProviderError
 		if !errors.As(err, &providerErr) || !providerErr.Retryable || attempt == maxAttempts-1 {
-			return "", err
+			return model.TranscriptResult{}, err
 		}
 
 		if waitErr := c.wait(ctx, c.backoffForAttempt(attempt)); waitErr != nil {
-			return "", waitErr
+			return model.TranscriptResult{}, waitErr
 		}
 	}
-	return "", lastErr
+	return model.TranscriptResult{}, lastErr
 }
 
 // buildBody builds the multipart form body. Returns the raw body bytes and
@@ -219,27 +243,28 @@ func (c *Client) buildBody(relPath string, data []byte) ([]byte, *multipart.Writ
 }
 
 // responseFormat returns the configured response format, defaulting to
-// json. An unknown value is passed through unchanged so operators can
-// target server-specific formats; only the empty value is defaulted.
+// verbose_json (the word-timing superset). An unknown value is passed through
+// unchanged so operators can target server-specific formats; only the empty
+// value is defaulted.
 func (c *Client) responseFormat() string {
 	if f := strings.TrimSpace(c.ResponseFormat); f != "" {
 		return f
 	}
-	return ResponseFormatJSON
+	return ResponseFormatVerboseJSON
 }
 
-func (c *Client) transcribeOnce(ctx context.Context, relPath string, data []byte) (string, error) {
+func (c *Client) transcribeOnce(ctx context.Context, relPath string, data []byte) (model.TranscriptResult, error) {
 	if strings.TrimSpace(c.BaseURL) == "" {
-		return "", &model.ProviderError{Code: "WHISPER_FAILED", Message: "missing whisper base_url", Retryable: false}
+		return model.TranscriptResult{}, &model.ProviderError{Code: "WHISPER_FAILED", Message: "missing whisper base_url", Retryable: false}
 	}
 	body, writer, err := c.buildBody(relPath, data)
 	if err != nil {
-		return "", err
+		return model.TranscriptResult{}, err
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+"/v1/audio/transcriptions", bytes.NewReader(body))
 	if err != nil {
-		return "", &model.ProviderError{Code: "WHISPER_FAILED", Message: "failed to build transcription request", Retryable: false, Cause: err}
+		return model.TranscriptResult{}, &model.ProviderError{Code: "WHISPER_FAILED", Message: "failed to build transcription request", Retryable: false, Cause: err}
 	}
 	// Bearer auth is optional: only set it for credentialed endpoints.
 	if key := strings.TrimSpace(c.APIKey); key != "" {
@@ -254,17 +279,17 @@ func (c *Client) transcribeOnce(ctx context.Context, relPath string, data []byte
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return "", &model.ProviderError{Code: "WHISPER_FAILED", Message: "transcription request failed", Retryable: true, Cause: err}
+		return model.TranscriptResult{}, &model.ProviderError{Code: "WHISPER_FAILED", Message: "transcription request failed", Retryable: true, Cause: err}
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", httpError(resp)
+		return model.TranscriptResult{}, httpError(resp)
 	}
 
 	var parsed transcribeResponse
 	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
-		return "", &model.ProviderError{
+		return model.TranscriptResult{}, &model.ProviderError{
 			Code:      "WHISPER_FAILED",
 			Message:   "failed to decode transcription response",
 			Retryable: false,
@@ -273,17 +298,63 @@ func (c *Client) transcribeOnce(ctx context.Context, relPath string, data []byte
 	}
 
 	if segText, ok := parseTranscriptSegments(parsed); ok {
-		return segText, nil
+		return model.TranscriptResult{Text: segText, Words: parsed.timedWords()}, nil
 	}
 	text := strings.TrimSpace(parsed.Text)
 	if text == "" {
-		return "", &model.ProviderError{
+		return model.TranscriptResult{}, &model.ProviderError{
 			Code:      "WHISPER_FAILED",
 			Message:   "transcription response had no text content",
 			Retryable: false,
 		}
 	}
-	return text, nil
+	// Flat-text fallback (no segments): words have no segment frame to anchor
+	// against, so emit text only.
+	return model.TranscriptResult{Text: text}, nil
+}
+
+// timedWords flattens the verbose_json word timestamps into a time-ordered
+// []model.TimedWord with absolute ms offsets (#252). It prefers per-segment
+// words and falls back to a top-level words array; returns nil when neither is
+// present or all words are empty/zero-length, so a words-absent response yields
+// no word timing.
+func (r transcribeResponse) timedWords() []model.TimedWord {
+	var raw []transcriptWord
+	for _, seg := range r.Segments {
+		raw = append(raw, seg.Words...)
+	}
+	if len(raw) == 0 {
+		raw = r.Words
+	}
+	if len(raw) == 0 {
+		return nil
+	}
+	out := make([]model.TimedWord, 0, len(raw))
+	for _, w := range raw {
+		word := strings.TrimSpace(w.Word)
+		if word == "" {
+			continue
+		}
+		startMS := secondsToMS(w.Start)
+		endMS := secondsToMS(w.End)
+		if endMS < startMS {
+			endMS = startMS
+		}
+		out = append(out, model.TimedWord{Word: word, StartMS: startMS, EndMS: endMS})
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// secondsToMS converts fractional seconds to whole milliseconds, clamping
+// negative values to 0.
+func secondsToMS(sec float64) int {
+	if sec <= 0 {
+		return 0
+	}
+	return int(sec*1000 + 0.5)
 }
 
 // parseTranscriptSegments converts timed segments into `[mm:ss] text`

--- a/tests/index/qdrant_index_test.go
+++ b/tests/index/qdrant_index_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"context"
 	"errors"
+	"reflect"
 	"sort"
 	"testing"
 
@@ -157,7 +158,9 @@ func TestQdrant_UpsertCreatesCollectionAndRoundTrips(t *testing.T) {
 	// Span is intentionally not persisted in Qdrant, so it does not round-trip;
 	// every other field must.
 	in.Span = model.Span{}
-	if got != in {
+	// IndexPayload embeds Span, which carries a slice (Words) and is therefore
+	// not comparable with ==; compare structurally.
+	if !reflect.DeepEqual(got, in) {
 		t.Fatalf("payload did not round-trip: got %+v want %+v", got, in)
 	}
 }

--- a/tests/ingest/transcribe_test.go
+++ b/tests/ingest/transcribe_test.go
@@ -248,3 +248,73 @@ func TestTranscriptIngest_EndToEnd_AppearsInAskWithCitations(t *testing.T) {
 		t.Fatalf("expected transcript hit, got %+v", res.Hits)
 	}
 }
+
+// fakeStructuredTranscriber implements model.StructuredTranscriber, returning
+// segment text plus per-word timing (mirrors the whisper client #252).
+type fakeStructuredTranscriber struct {
+	text  string
+	words []model.TimedWord
+}
+
+func (f *fakeStructuredTranscriber) Transcribe(_ context.Context, _ string, _ []byte) (string, error) {
+	return f.text, nil
+}
+
+func (f *fakeStructuredTranscriber) TranscribeStructured(_ context.Context, _ string, _ []byte) (model.TranscriptResult, error) {
+	return model.TranscriptResult{Text: f.text, Words: f.words}, nil
+}
+
+// TestGenerateTranscriptRepresentation_AttachesWordSpans asserts a structured
+// transcriber's per-word timing is carried onto the persisted transcript chunk
+// spans (spec §8.6.1) without changing the chunk count or text.
+func TestGenerateTranscriptRepresentation_AttachesWordSpans(t *testing.T) {
+	t.Parallel()
+	stateDir := t.TempDir()
+	st := &fakeIngestStore{}
+	svc := mustNewIngestService(t, config.Config{StateDir: stateDir}, st)
+	svc.SetTranscriber(&fakeStructuredTranscriber{
+		text: "[00:00] intro\n[00:02] chapter one\n[00:05] chapter two",
+		words: []model.TimedWord{
+			{Word: "intro", StartMS: 0, EndMS: 800},
+			{Word: "chapter", StartMS: 2000, EndMS: 2500},
+			{Word: "one", StartMS: 2500, EndMS: 2900},
+			{Word: "chapter", StartMS: 5000, EndMS: 5400},
+			{Word: "two", StartMS: 5400, EndMS: 5800},
+		},
+	})
+
+	doc := model.Document{DocID: 88, RelPath: "audio/lecture.mp3", DocType: "audio"}
+	content := []byte("structured-audio-bytes")
+
+	if err := svc.GenerateTranscriptRepresentation(context.Background(), doc, content); err != nil {
+		t.Fatalf("GenerateTranscriptRepresentation failed: %v", err)
+	}
+
+	// Same three chunks/spans as the words-absent baseline.
+	if len(st.chunks) != 3 || len(st.spans) != 3 {
+		t.Fatalf("chunks=%d spans=%d, want 3/3 (words must not add chunks)", len(st.chunks), len(st.spans))
+	}
+
+	// Words land in the chunk whose time span contains them.
+	total := 0
+	for _, sp := range st.spans {
+		for _, w := range sp.Words {
+			total++
+			if w.T < sp.StartMS {
+				t.Errorf("word %q at %dms before span [%d,%d)", w.W, w.T, sp.StartMS, sp.EndMS)
+			}
+		}
+	}
+	if total != 5 {
+		t.Fatalf("attached %d words across spans, want 5", total)
+	}
+	if len(st.spans[0].Words) != 1 || st.spans[0].Words[0].W != "intro" || st.spans[0].Words[0].D != 800 {
+		t.Errorf("first span words = %+v, want [{0,800,intro}]", st.spans[0].Words)
+	}
+
+	// A per-language words sidecar cache is written next to the transcript.
+	wordsCache := filepath.Join(stateDir, "cache", "transcribe", ingest.ComputeContentHash(content)+".words.json")
+	if _, err := os.Stat(wordsCache); err != nil {
+		t.Fatalf("expected words sidecar cache at %s: %v", wordsCache, err)
+	}
+}

--- a/tests/ingest/transcript_words_test.go
+++ b/tests/ingest/transcript_words_test.go
@@ -1,0 +1,110 @@
+package tests
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// twoSegmentTranscript has two timestamped segments at 0s and 65s, matching the
+// whisper client's [mm:ss] segment formatting.
+const twoSegmentTranscript = "[00:00] hello there\n[01:05] general kenobi"
+
+// TestChunkTranscriptWordsWithinRange asserts per-word timing is attached to the
+// chunk whose time span contains the word (spec §8.6.1), without changing chunk
+// text, span bounds, or chunk count versus the words-absent baseline.
+func TestChunkTranscriptWordsWithinRange(t *testing.T) {
+	baseline := ingest.ChunkTranscriptByTime(twoSegmentTranscript)
+	words := []model.TimedWord{
+		{Word: "hello", StartMS: 0, EndMS: 500},
+		{Word: "there", StartMS: 500, EndMS: 1000},
+		{Word: "general", StartMS: 65000, EndMS: 65800},
+		{Word: "kenobi", StartMS: 65800, EndMS: 66500},
+	}
+	withWords := ingest.ChunkTranscriptByTimeWithWords(twoSegmentTranscript, words)
+
+	// No extra chunks, identical text and span bounds.
+	if len(withWords) != len(baseline) {
+		t.Fatalf("chunk count = %d, want %d (words must not add chunks)", len(withWords), len(baseline))
+	}
+	for i := range baseline {
+		if withWords[i].Text != baseline[i].Text {
+			t.Errorf("chunk[%d] text changed: %q vs %q", i, withWords[i].Text, baseline[i].Text)
+		}
+		if withWords[i].Span.Kind != baseline[i].Span.Kind ||
+			withWords[i].Span.StartMS != baseline[i].Span.StartMS ||
+			withWords[i].Span.EndMS != baseline[i].Span.EndMS {
+			t.Errorf("chunk[%d] span bounds changed: %+v vs %+v", i, withWords[i].Span, baseline[i].Span)
+		}
+	}
+
+	// Every word lands in a chunk whose time span contains its start.
+	total := 0
+	for _, seg := range withWords {
+		for _, w := range seg.Span.Words {
+			total++
+			if w.T < seg.Span.StartMS || w.T >= seg.Span.EndMS {
+				// The final chunk also catches trailing words at/after its end;
+				// only flag a word that falls before this chunk's start.
+				if w.T < seg.Span.StartMS {
+					t.Errorf("word %q at %dms outside span [%d,%d)", w.W, w.T, seg.Span.StartMS, seg.Span.EndMS)
+				}
+			}
+		}
+	}
+	if total != len(words) {
+		t.Errorf("attached %d words, want all %d", total, len(words))
+	}
+
+	// First chunk owns the first two words with correct {t,d,w}.
+	first := withWords[0].Span.Words
+	wantFirst := []model.WordSpan{{T: 0, D: 500, W: "hello"}, {T: 500, D: 500, W: "there"}}
+	if !reflect.DeepEqual(first, wantFirst) {
+		t.Errorf("first chunk words = %+v, want %+v", first, wantFirst)
+	}
+}
+
+// TestChunkTranscriptWordsAbsentUnchanged asserts that passing no words produces
+// output byte-for-byte identical to ChunkTranscriptByTime (backward compat).
+func TestChunkTranscriptWordsAbsentUnchanged(t *testing.T) {
+	baseline := ingest.ChunkTranscriptByTime(twoSegmentTranscript)
+
+	nilWords := ingest.ChunkTranscriptByTimeWithWords(twoSegmentTranscript, nil)
+	if !reflect.DeepEqual(nilWords, baseline) {
+		t.Errorf("nil words diverged from baseline:\n got %+v\nwant %+v", nilWords, baseline)
+	}
+	emptyWords := ingest.ChunkTranscriptByTimeWithWords(twoSegmentTranscript, []model.TimedWord{})
+	if !reflect.DeepEqual(emptyWords, baseline) {
+		t.Errorf("empty words diverged from baseline:\n got %+v\nwant %+v", emptyWords, baseline)
+	}
+	for _, seg := range nilWords {
+		if seg.Span.Words != nil {
+			t.Errorf("words-absent chunk carries words: %+v", seg.Span.Words)
+		}
+	}
+}
+
+// TestChunkTranscriptTrailingWordsRetained asserts a word at/after the last
+// chunk's end is still attached (to the last time chunk) rather than dropped.
+func TestChunkTranscriptTrailingWordsRetained(t *testing.T) {
+	words := []model.TimedWord{
+		{Word: "general", StartMS: 65000, EndMS: 65800},
+		// well past the estimated end of the last segment
+		{Word: "trailing", StartMS: 999000, EndMS: 999500},
+	}
+	chunks := ingest.ChunkTranscriptByTimeWithWords(twoSegmentTranscript, words)
+
+	var found bool
+	for _, seg := range chunks {
+		for _, w := range seg.Span.Words {
+			if w.W == "trailing" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Error("trailing word was dropped; expected attachment to the last time chunk")
+	}
+}

--- a/tests/store/spans_time_words_test.go
+++ b/tests/store/spans_time_words_test.go
@@ -1,0 +1,89 @@
+package tests
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// TestTimeSpanWordsRoundTrip pins that per-word timing on a "time" span survives
+// SpanToRow -> SpanFromRow via the extra_json `words` array (spec §8.6.1, #252).
+func TestTimeSpanWordsRoundTrip(t *testing.T) {
+	in := model.Span{
+		Kind:    "time",
+		StartMS: 1000,
+		EndMS:   4000,
+		Words: []model.WordSpan{
+			{T: 1000, D: 400, W: "hello"},
+			{T: 1400, D: 500, W: "world"},
+		},
+	}
+
+	kind, start, end, extra, err := store.SpanToRow(in)
+	if err != nil {
+		t.Fatalf("SpanToRow: %v", err)
+	}
+	if kind != "time" || start != 1000 || end != 4000 {
+		t.Fatalf("row = (%q,%d,%d), want (time,1000,4000)", kind, start, end)
+	}
+	if extra == "" {
+		t.Fatal("time span with words must produce a non-empty extra_json payload")
+	}
+
+	// extra_json must use the spec shape {"words":[{"t","d","w"}]}.
+	var decoded struct {
+		Words []map[string]any `json:"words"`
+	}
+	if err := json.Unmarshal([]byte(extra), &decoded); err != nil {
+		t.Fatalf("extra_json not valid JSON: %v (%s)", err, extra)
+	}
+	if len(decoded.Words) != 2 {
+		t.Fatalf("extra_json words = %d, want 2 (%s)", len(decoded.Words), extra)
+	}
+	for _, key := range []string{"t", "d", "w"} {
+		if _, ok := decoded.Words[0][key]; !ok {
+			t.Errorf("extra_json word missing %q key: %s", key, extra)
+		}
+	}
+
+	out := store.SpanFromRow(kind, start, end, extra)
+	if out.Kind != "time" || out.StartMS != 1000 || out.EndMS != 4000 {
+		t.Fatalf("round-trip lost time bounds: %+v", out)
+	}
+	if !reflect.DeepEqual(out.Words, in.Words) {
+		t.Errorf("round-trip words = %+v, want %+v", out.Words, in.Words)
+	}
+}
+
+// TestTimeSpanWithoutWordsHasNoExtraJSON pins backward compatibility: a time
+// span without words produces an empty extra_json (stored as SQL NULL), so
+// pre-#252 transcripts round-trip unchanged.
+func TestTimeSpanWithoutWordsHasNoExtraJSON(t *testing.T) {
+	in := model.Span{Kind: "time", StartMS: 0, EndMS: 2000}
+
+	kind, start, end, extra, err := store.SpanToRow(in)
+	if err != nil {
+		t.Fatalf("SpanToRow: %v", err)
+	}
+	if strings.TrimSpace(extra) != "" {
+		t.Fatalf("words-absent time span produced extra_json %q, want empty", extra)
+	}
+
+	out := store.SpanFromRow(kind, start, end, extra)
+	if out.Kind != "time" || out.StartMS != 0 || out.EndMS != 2000 || out.Words != nil {
+		t.Fatalf("round-trip = %+v, want clean time span with nil words", out)
+	}
+}
+
+// TestTimeSpanMalformedWordsDegrade pins that a malformed extra_json payload on
+// a time span degrades to no word timing rather than failing the read.
+func TestTimeSpanMalformedWordsDegrade(t *testing.T) {
+	out := store.SpanFromRow("time", 0, 1000, "{not valid json")
+	if out.Kind != "time" || out.Words != nil {
+		t.Fatalf("malformed words did not degrade cleanly: %+v", out)
+	}
+}

--- a/tests/whisperapi/client_test.go
+++ b/tests/whisperapi/client_test.go
@@ -115,8 +115,8 @@ func TestTranscribeSegmentsFormatting(t *testing.T) {
 	if got.language != "en" {
 		t.Errorf("language field = %q, want en", got.language)
 	}
-	if got.responseFormat != "json" {
-		t.Errorf("response_format = %q, want json (default)", got.responseFormat)
+	if got.responseFormat != "verbose_json" {
+		t.Errorf("response_format = %q, want verbose_json (default, #252)", got.responseFormat)
 	}
 	if !strings.HasSuffix(got.fileName, "ep1.mp3") {
 		t.Errorf("file name = %q, want suffix ep1.mp3", got.fileName)
@@ -341,4 +341,110 @@ func TestContextCancellationRespected(t *testing.T) {
 	if _, err := c.Transcribe(ctx, "a.wav", []byte("x")); err == nil {
 		t.Fatal("expected error for cancelled context")
 	}
+}
+
+// verboseJSONWords is a verbose_json response carrying per-segment word
+// timestamps (the faster-whisper / OpenAI-compatible shape #252 parses).
+const verboseJSONWords = `{
+  "text": "hello there general",
+  "language": "en",
+  "duration": 75.0,
+  "segments": [
+    {"start": 0.0, "end": 4.2, "text": " hello there", "words": [
+      {"word": "hello", "start": 0.0, "end": 0.5},
+      {"word": "there", "start": 0.5, "end": 1.0}
+    ]},
+    {"start": 65.0, "end": 70.0, "text": "general", "words": [
+      {"word": "general", "start": 65.0, "end": 65.8}
+    ]}
+  ]
+}`
+
+// verboseJSONTopLevelWords carries a top-level words[] array instead of
+// per-segment words (some servers emit this shape).
+const verboseJSONTopLevelWords = `{
+  "text": "hello there",
+  "segments": [{"start": 0.0, "end": 2.0, "text": "hello there"}],
+  "words": [
+    {"word": "hello", "start": 0.0, "end": 0.5},
+    {"word": "there", "start": 0.5, "end": 1.0}
+  ]
+}`
+
+// TestTranscribeStructuredWords asserts TranscribeStructured returns the same
+// segment text as Transcribe plus parsed per-word timing in ms (#252).
+func TestTranscribeStructuredWords(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, verboseJSONWords)
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL, "k")
+	res, err := c.TranscribeStructured(context.Background(), "a.wav", []byte("x"))
+	if err != nil {
+		t.Fatalf("TranscribeStructured: %v", err)
+	}
+
+	wantText := "[00:00] hello there\n[01:05] general"
+	if res.Text != wantText {
+		t.Fatalf("text = %q, want %q", res.Text, wantText)
+	}
+	want := []model.TimedWord{
+		{Word: "hello", StartMS: 0, EndMS: 500},
+		{Word: "there", StartMS: 500, EndMS: 1000},
+		{Word: "general", StartMS: 65000, EndMS: 65800},
+	}
+	if len(res.Words) != len(want) {
+		t.Fatalf("words len = %d, want %d (%+v)", len(res.Words), len(want), res.Words)
+	}
+	for i := range want {
+		if res.Words[i] != want[i] {
+			t.Errorf("word[%d] = %+v, want %+v", i, res.Words[i], want[i])
+		}
+	}
+}
+
+// TestTranscribeStructuredTopLevelWords asserts a top-level words[] array is
+// used as a fallback when segments carry no words.
+func TestTranscribeStructuredTopLevelWords(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, verboseJSONTopLevelWords)
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL, "k")
+	res, err := c.TranscribeStructured(context.Background(), "a.wav", []byte("x"))
+	if err != nil {
+		t.Fatalf("TranscribeStructured: %v", err)
+	}
+	if len(res.Words) != 2 || res.Words[1].Word != "there" || res.Words[1].StartMS != 500 {
+		t.Fatalf("top-level words = %+v, want 2 words ending at there@500ms", res.Words)
+	}
+}
+
+// TestTranscribeStructuredWordsAbsent asserts a segments-only response yields a
+// transcript with no word timing (identical to the words-absent path).
+func TestTranscribeStructuredWordsAbsent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, jsonSegments)
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL, "k")
+	res, err := c.TranscribeStructured(context.Background(), "a.wav", []byte("x"))
+	if err != nil {
+		t.Fatalf("TranscribeStructured: %v", err)
+	}
+	if res.Words != nil {
+		t.Errorf("words = %+v, want nil for segments-only response", res.Words)
+	}
+	if res.Text != "[00:00] hello there\n[01:05] general" {
+		t.Errorf("text = %q", res.Text)
+	}
+}
+
+// TestClientImplementsStructuredTranscriber documents the optional capability
+// contract: the whisper client is a model.StructuredTranscriber.
+func TestClientImplementsStructuredTranscriber(t *testing.T) {
+	var _ model.StructuredTranscriber = whisperapi.NewClient("http://x", "")
 }


### PR DESCRIPTION
## Summary

Implements #252 (epic #261): parse faster-whisper / OpenAI-compatible **word-level** timestamps from the self-hosted STT endpoint and carry them as transcript provenance, per **merged spec §8.6.1**. Depends on merged #240 (the self-hosted whisper STT provider).

Per-word timing is **metadata only**: it MUST NOT create extra chunks, MUST NOT change chunk text, and **citations stay segment-level**.

## What changed

- **`internal/model`**
  - `Span` gains an optional `Words []WordSpan` (`WordSpan{T, D, W}` in ms). Present only on `time` spans; nil everywhere else.
  - New optional `StructuredTranscriber` interface (`Transcriber` + `TranscribeStructured`) plus `TranscriptResult`/`TimedWord`. Providers that don't implement it simply yield no words.
- **`internal/whisperapi/client.go`**
  - Implements `StructuredTranscriber`. `TranscribeStructured` returns the **same** `[mm:ss]` segment string as `Transcribe` plus parsed per-word timing (per-segment `words`, with a top-level `words[]` fallback).
  - Default `response_format` is now `verbose_json` (superset of `json`; operators may override). `Transcribe` is unchanged in contract — it returns `.Text`.
- **`internal/ingest`**
  - `chunkTranscriptByTimeWithWords` chunks identically to `chunkTranscriptByTime`, then attaches each word to the chunk whose time span contains its start. Nil/empty words ⇒ byte-for-byte identical output.
  - The transcriber→chunker path type-asserts the optional interface; words flow through and are cached as a `.words.json` sidecar next to the transcript text cache.
- **`internal/store/sqlite_store.go`**
  - `spanToRow`/`spanFromRow` marshal/unmarshal `words` in a `time` span's `extra_json` as `{"words":[{"t","d","w"}]}`. Words-absent ⇒ NULL `extra_json` (unchanged). Malformed payloads degrade to no word timing.

## Backward compatibility

- `model.Transcriber.Transcribe(ctx, relPath, data) string` contract is unchanged; other providers are untouched.
- Words-absent transcripts produce identical chunks/text/spans and NULL `extra_json`.
- Adding the `Words` slice makes `Span` (and the `Span`-embedding `IndexPayload`) non-comparable; one existing `==` assertion was switched to `reflect.DeepEqual`.

## Tests (tests/, package tests)

- whisperapi: parse-level word extraction (per-segment + top-level fallback), words-absent ⇒ nil, verbose_json default, interface conformance.
- ingest: words attached within chunk time spans, no extra chunks / unchanged text, words-absent identical to baseline, trailing words retained, end-to-end structured transcriber → persisted span words + sidecar cache.
- store: `time`-span words round-trip + extra_json shape, words-absent NULL, malformed-degrades.

`make check` passes locally (gofmt, vet, gocyclo≤15, misspell, full test suite, build). Built with `CGO_ENABLED=0`. The `dirstral-spec` submodule was **not** re-pinned.
