### PR TITLE
feat(ingest): optional configurable transcript translation (spec §8.6.2)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -226,6 +226,20 @@ type Config struct {
 	// lexically-lowest path. Only consulted when MediaVariantsGroup is true.
 	MediaVariantsSelect string
 
+	// MediaTranslateEnabled opts IN to translating transcripts into one or more
+	// target languages (spec §8.6.2, config `media.translate.enabled`). Off by
+	// default. When enabled, each source transcript additionally yields one
+	// translated transcript representation per target language. Enabling this
+	// with an empty MediaTranslateTargetLangs is CONFIG_INVALID.
+	MediaTranslateEnabled bool
+
+	// MediaTranslateTargetLangs lists the target language tag(s) transcripts are
+	// translated into (spec §8.6.2, config `media.translate.target_langs`). There
+	// is NO built-in default (general-purpose: no language is assumed). Only
+	// consulted when MediaTranslateEnabled is true; enabling translation with an
+	// empty list is CONFIG_INVALID.
+	MediaTranslateTargetLangs []string
+
 	// QualityGatesEnabled is the master switch for the output quality gate
 	// (spec 0.16.0): when true (default), generated transcript/OCR text is
 	// screened for degenerate output (repetition loops, empty output,
@@ -331,6 +345,8 @@ type fileConfig struct {
 	MediaSidecarsDisabled     *bool
 	MediaVariantsGroup        *bool
 	MediaVariantsSelect       *string
+	MediaTranslateEnabled     *bool
+	MediaTranslateTargetLangs []string
 	ElevenLabsAPIKey          *string
 	ServerTLSCertFile         *string
 	ServerTLSKeyFile          *string
@@ -420,6 +436,8 @@ type persistedConfig struct {
 	MediaSidecarsDisabled     bool          `yaml:"media_sidecars_disabled"`
 	MediaVariantsGroup        bool          `yaml:"media_variants_group"`
 	MediaVariantsSelect       string        `yaml:"media_variants_select"`
+	MediaTranslateEnabled     bool          `yaml:"media_translate_enabled"`
+	MediaTranslateTargetLangs []string      `yaml:"media_translate_target_langs"`
 	ServerTLSCertFile         string        `yaml:"server_tls_cert_file"`
 	ServerTLSKeyFile          string        `yaml:"server_tls_key_file"`
 
@@ -542,6 +560,8 @@ func Default() Config {
 		QualityGatesEnabled:       true,
 		MediaVariantsGroup:        false,
 		MediaVariantsSelect:       "best",
+		MediaTranslateEnabled:     false,
+		MediaTranslateTargetLangs: nil,
 		ServerTLSCertFile:         "",
 		ServerTLSKeyFile:          "",
 		X402: X402Config{
@@ -642,6 +662,8 @@ func buildPersistedConfig(cfg *Config) persistedConfig {
 		MediaSidecarsDisabled:     cfg.MediaSidecarsDisabled,
 		MediaVariantsGroup:        cfg.MediaVariantsGroup,
 		MediaVariantsSelect:       cfg.MediaVariantsSelect,
+		MediaTranslateEnabled:     cfg.MediaTranslateEnabled,
+		MediaTranslateTargetLangs: append([]string(nil), cfg.MediaTranslateTargetLangs...),
 		ServerTLSCertFile:         cfg.ServerTLSCertFile,
 		ServerTLSKeyFile:          cfg.ServerTLSKeyFile,
 		X402Mode:                  cfg.X402.Mode,
@@ -1256,6 +1278,12 @@ func applySTTFileParsed(cfg *Config, fc fileConfig) {
 	if fc.MediaVariantsSelect != nil {
 		cfg.MediaVariantsSelect = *fc.MediaVariantsSelect
 	}
+	if fc.MediaTranslateEnabled != nil {
+		cfg.MediaTranslateEnabled = *fc.MediaTranslateEnabled
+	}
+	if fc.MediaTranslateTargetLangs != nil {
+		cfg.MediaTranslateTargetLangs = normalizeStringSlice(fc.MediaTranslateTargetLangs)
+	}
 }
 
 // applyX402FileParsed copies the set x402 file fields onto cfg.X402.
@@ -1520,6 +1548,8 @@ var configKeyAliases = map[string]string{
 	"backend":                              "index.backend",
 	"media_variants_group":                 "media.variants.group",
 	"media_variants_select":                "media.variants.select",
+	"media_translate_enabled":              "media.translate.enabled",
+	"media_translate_target_langs":         "media.translate.target_langs",
 	"stt_provider":                         "stt.provider",
 	"stt_mistral_model":                    "stt.mistral.model",
 	"stt_elevenlabs_model":                 "stt.elevenlabs.model",
@@ -1576,7 +1606,7 @@ func isMapSectionKey(key string) bool {
 		return true
 	case "source", "source.s3":
 		return true
-	case "media", "media.variants":
+	case "media", "media.variants", "media.translate":
 		return true
 	case "index.pgvector":
 		return true
@@ -1626,6 +1656,8 @@ func setBoolFileScalar(cfg *fileConfig, key, value string) error {
 		target = &cfg.MediaSidecarsDisabled
 	case "media.variants.group":
 		target = &cfg.MediaVariantsGroup
+	case "media.translate.enabled":
+		target = &cfg.MediaTranslateEnabled
 	case "x402_tools_call_enabled":
 		target = &cfg.X402ToolsCallEnabled
 	case "retrieval.hybrid.enabled":
@@ -1892,6 +1924,8 @@ func setFileListValue(cfg *fileConfig, key, value string) {
 		appendValue(&cfg.SecretPatterns, value)
 	case "allowed_origins":
 		appendValue(&cfg.AllowedOrigins, value)
+	case "media.translate.target_langs":
+		appendValue(&cfg.MediaTranslateTargetLangs, value)
 	}
 }
 
@@ -1900,7 +1934,7 @@ func setFileListValue(cfg *fileConfig, key, value string) {
 func isListConfigKey(key string) bool {
 	key = canonicalizeConfigKey(key)
 	switch key {
-	case "trusted_proxies", "path_excludes", "secret_patterns", "allowed_origins":
+	case "trusted_proxies", "path_excludes", "secret_patterns", "allowed_origins", "media.translate.target_langs":
 		return true
 	default:
 		return false
@@ -1993,6 +2027,8 @@ func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	writeBool("media_sidecars_disabled", cfg.MediaSidecarsDisabled)
 	writeBool("media_variants_group", cfg.MediaVariantsGroup)
 	writeScalar("media_variants_select", cfg.MediaVariantsSelect)
+	writeBool("media_translate_enabled", cfg.MediaTranslateEnabled)
+	writeList("media_translate_target_langs", cfg.MediaTranslateTargetLangs)
 	writeScalar("server_tls_cert_file", cfg.ServerTLSCertFile)
 	writeScalar("server_tls_key_file", cfg.ServerTLSKeyFile)
 	writeScalar("x402_mode", cfg.X402Mode)
@@ -2376,6 +2412,10 @@ func (c *Config) Validate() error {
 		return err
 	}
 
+	if err := c.validateMediaTranslate(); err != nil {
+		return err
+	}
+
 	if err := c.validateNumericBounds(); err != nil {
 		return err
 	}
@@ -2406,6 +2446,38 @@ func (c *Config) validateMediaVariants() error {
 		return fmt.Errorf("media.variants.select must be one of best, first: %q", c.MediaVariantsSelect)
 	}
 	c.MediaVariantsSelect = sel
+	return nil
+}
+
+// validateMediaTranslate enforces the transcript-translation config invariants
+// (spec §8.6.2): translation is opt-in and off by default, and the target
+// language list has NO built-in default. Enabling translation with an empty (or
+// all-blank) target_langs is CONFIG_INVALID. When enabled the list is
+// normalized (trimmed, lower-cased, de-duplicated) so downstream keying via
+// TranscriptLangSuffix is stable. When translation is disabled the list is left
+// untouched, so toggling it back on restores any previously-saved targets.
+func (c *Config) validateMediaTranslate() error {
+	if !c.MediaTranslateEnabled {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(c.MediaTranslateTargetLangs))
+	out := make([]string, 0, len(c.MediaTranslateTargetLangs))
+	for _, lang := range c.MediaTranslateTargetLangs {
+		l := strings.ToLower(strings.TrimSpace(lang))
+		if l == "" {
+			continue
+		}
+		if _, dup := seen[l]; dup {
+			continue
+		}
+		seen[l] = struct{}{}
+		out = append(out, l)
+	}
+	if len(out) == 0 {
+		return errors.New("media.translate.enabled=true requires a non-empty " +
+			"media.translate.target_langs (no default target language)")
+	}
+	c.MediaTranslateTargetLangs = out
 	return nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2467,6 +2467,17 @@ func (c *Config) validateMediaTranslate() error {
 		if l == "" {
 			continue
 		}
+		// Reject tags outside the cache-safe alphabet (BCP-47 letters/digits/
+		// hyphen). TranscriptLangSuffix strips any other rune, so e.g. "en_us"
+		// and "enus" would collapse to the same translation-cache suffix and
+		// reuse the wrong translated text. Require an already-safe form.
+		for _, r := range l {
+			safe := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-'
+			if !safe {
+				return fmt.Errorf("media.translate.target_langs contains an invalid language tag %q "+
+					"(use BCP-47 letters/digits/hyphen, e.g. \"en\" or \"pt-br\")", lang)
+			}
+		}
 		if _, dup := seen[l]; dup {
 			continue
 		}

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -1817,6 +1817,7 @@ func (s *Service) translateOneTranscript(ctx context.Context, doc model.Document
 	if err != nil {
 		return fmt.Errorf("upsert translated transcript representation: %w", err)
 	}
+	s.addRepresentations(1)
 
 	// Chunk the translated text with the same transcript chunker so its time
 	// spans line up with the source segments (the translation preserves each

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -74,6 +74,26 @@ type Service struct {
 	// configured, in which case the language detector self-skips.
 	transcriptLanguage string
 
+	// translator is the chat/generation client used to translate transcripts
+	// into the configured target language(s) (SPEC §8.6.2). It is the chat
+	// capability binding resolved at construction, or nil when translation is
+	// disabled or no chat-capable provider resolves (in which case the optional
+	// translate step self-skips). It is a model.Generator so the same prompt
+	// path works for any chat provider (mistral/openai/gemini/cohere).
+	translator model.Generator
+
+	// translateTargetLangs holds the normalized target language tags transcripts
+	// are translated into when translation is enabled (SPEC §8.6.2). Empty when
+	// translation is off. Validation guarantees a non-empty list whenever
+	// translation is enabled (enabling with an empty list is CONFIG_INVALID).
+	translateTargetLangs []string
+
+	// translateProvider/translateModel record the resolved chat provider/model
+	// used for translation so each translated transcript representation can carry
+	// its translation derivation identity in meta_json (SPEC §5.2/§8.6.7).
+	translateProvider string
+	translateModel    string
+
 	// embedMultimodal is the resolved multimodal embedding mode (SPEC
 	// 8.1.7): "off" (default), "augment", or "replace". When augment/
 	// replace, media documents additionally (or exclusively) get a media
@@ -186,6 +206,20 @@ func NewService(cfg config.Config, store model.Store) (*Service, error) {
 		svc.qualityGate = quality.New(quality.DefaultConfig())
 	}
 	svc.transcriptLanguage = sttExpectedLanguage(cfg)
+	// Resolve the optional transcript-translation binding (SPEC §8.6.2). When
+	// translation is enabled we resolve the chat capability and build a
+	// generator; when off (default), or no chat provider resolves, the field
+	// stays nil and the translate step self-skips so behaviour is unchanged.
+	svc.translateTargetLangs = append([]string(nil), cfg.MediaTranslateTargetLangs...)
+	if cfg.MediaTranslateEnabled && len(svc.translateTargetLangs) > 0 {
+		if tr, prof, terr := translatorFromConfig(cfg); terr == nil && tr != nil {
+			svc.translator = tr
+			svc.translateProvider = prof.Name
+			svc.translateModel = strings.TrimSpace(prof.ChatModel)
+		} else if terr != nil {
+			svc.getLogger().Printf("transcript translation disabled: %v", terr)
+		}
+	}
 	// Resolve the multimodal embedding mode once (SPEC 8.1.7); a missing or
 	// unresolvable embed profile leaves it off (text-only).
 	if ep, err := cfg.Providers().Resolve(provider.CapEmbed); err == nil {
@@ -420,6 +454,26 @@ func sttExpectedLanguage(cfg config.Config) string {
 	return strings.TrimSpace(prof.STTLanguage)
 }
 
+// translatorFromConfig resolves the chat-capability binding used to translate
+// transcripts (SPEC §8.6.2: "uses the chat capability unless a dedicated
+// binding is configured") and builds a model.Generator from it. A dedicated
+// translate provider/model can be configured by binding the chat capability to
+// a specific provider; with no explicit binding the resolver picks the first
+// eligible chat-capable profile in precedence order. Returns ErrNoProvider
+// (wrapped) when nothing eligible resolves so the caller can leave translation
+// off rather than failing ingest.
+func translatorFromConfig(cfg config.Config) (model.Generator, provider.Profile, error) {
+	prof, err := cfg.Providers().Resolve(provider.CapChat)
+	if err != nil {
+		return nil, provider.Profile{}, fmt.Errorf("resolve chat provider for translation: %w", err)
+	}
+	gen, err := providerfactory.Generator(prof)
+	if err != nil {
+		return nil, provider.Profile{}, fmt.Errorf("build translation generator (%s): %w", prof.Name, err)
+	}
+	return gen, prof, nil
+}
+
 // healthCheckInterval returns the configured base poll interval for connector
 // health probes. It mirrors the behaviour described in VISION.md: when the
 // configuration value is zero (or the receiver is nil) the default from
@@ -472,6 +526,30 @@ func (s *Service) SetOCR(ocr model.OCR) {
 
 func (s *Service) SetTranscriber(transcriber model.Transcriber) {
 	s.transcriber = transcriber
+}
+
+// SetTranslator overrides the transcript-translation binding and its target
+// languages, primarily for tests. Passing a nil generator (or empty langs)
+// disables translation. The recorded provider/model are written into translated
+// transcripts' meta_json. Target languages are normalized (trimmed/lower-cased).
+func (s *Service) SetTranslator(translator model.Generator, providerName, modelName string, targetLangs []string) {
+	s.translator = translator
+	s.translateProvider = strings.TrimSpace(providerName)
+	s.translateModel = strings.TrimSpace(modelName)
+	norm := make([]string, 0, len(targetLangs))
+	for _, l := range targetLangs {
+		if t := strings.ToLower(strings.TrimSpace(l)); t != "" {
+			norm = append(norm, t)
+		}
+	}
+	s.translateTargetLangs = norm
+}
+
+// SetTranscriptLanguage overrides the recorded source-transcript language,
+// primarily for tests that need a deterministic source_language without
+// resolving an STT provider profile.
+func (s *Service) SetTranscriptLanguage(language string) {
+	s.transcriptLanguage = strings.TrimSpace(language)
 }
 
 // SetCorpusFS overrides the corpus filesystem backend used for discovery and
@@ -1611,6 +1689,131 @@ func (s *Service) generateTranscriptRepresentation(ctx context.Context, doc mode
 	}
 	if err := s.repGen.upsertChunksForRepresentation(ctx, repID, "text", segments, decision); err != nil {
 		return fmt.Errorf("persist transcript chunks: %w", err)
+	}
+
+	// Optional translation step (SPEC §8.6.2): after the source transcript
+	// representation is persisted, produce one additional per-language transcript
+	// representation for each configured target language. This sits AFTER the
+	// source transcript so a translation failure never blocks the authoritative
+	// transcript, and each translated transcript routes through the same quality
+	// gate (it IS model output, unlike sidecar transcripts which bypass it).
+	if err := s.translateTranscriptRepresentations(ctx, doc, content, transcriptText, duration); err != nil {
+		return err
+	}
+	return nil
+}
+
+// translateTranscriptRepresentations produces, for each configured target
+// language, a translated transcript representation that is time-aligned to the
+// source transcript (SPEC §8.6.2). It self-skips (returns nil) when translation
+// is disabled, no translator resolved, or no target languages are configured —
+// so behaviour with translation off is identical to before. Each translated
+// transcript: is cached per-language via TranscriptLangSuffix so it is not
+// recomputed across re-ingests; carries a distinct rep_type via
+// TranscriptRepType(lang) so it coexists with the source transcript and any
+// sidecar per-language reps; routes through the output quality gate; and records
+// source_language + translate provider/model in meta_json.
+func (s *Service) translateTranscriptRepresentations(ctx context.Context, doc model.Document, content []byte, sourceText string, duration time.Duration) error {
+	if s.translator == nil || len(s.translateTargetLangs) == 0 {
+		return nil
+	}
+	sourceLang := strings.TrimSpace(s.transcriptLanguage)
+	for _, lang := range s.translateTargetLangs {
+		lang = strings.ToLower(strings.TrimSpace(lang))
+		if lang == "" || sameLanguage(lang, sourceLang) {
+			// Skip a no-op translation into the source language itself.
+			continue
+		}
+		if err := s.translateOneTranscript(ctx, doc, content, sourceText, sourceLang, lang, duration); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// sameLanguage reports whether two language tags name the same language for the
+// purpose of skipping a no-op self-translation. The comparison is loose: a tag
+// matches if it equals the other or shares its primary subtag (so "en" matches
+// "en-US"). An empty source language never matches (auto-detected/unknown), so
+// translation always proceeds when the source language was not pinned.
+func sameLanguage(a, b string) bool {
+	a = strings.ToLower(strings.TrimSpace(a))
+	b = strings.ToLower(strings.TrimSpace(b))
+	if a == "" || b == "" {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	primary := func(s string) string {
+		if i := strings.IndexAny(s, "-_"); i >= 0 {
+			return s[:i]
+		}
+		return s
+	}
+	return primary(a) == primary(b)
+}
+
+// translateOneTranscript translates the source transcript into a single target
+// language and persists it as a transcript representation. The translated text
+// is cached per-language (TranscriptLangSuffix) keyed by the SOURCE content hash
+// so re-ingesting an unchanged document reuses the cached translation instead of
+// re-calling the chat provider.
+func (s *Service) translateOneTranscript(ctx context.Context, doc model.Document, content []byte, sourceText, sourceLang, targetLang string, duration time.Duration) error {
+	translated, err := s.readOrComputeTranslation(ctx, content, sourceText, targetLang)
+	if err != nil {
+		return fmt.Errorf("translate transcript for %s into %q: %w", doc.RelPath, targetLang, err)
+	}
+	translated = strings.TrimSpace(translated)
+	if translated == "" {
+		return nil
+	}
+
+	// A translated transcript is model output, so it routes through the output
+	// quality gate exactly like an STT transcript (anti-hallucination). The
+	// expected language is the TARGET language: the gate's language detector
+	// should accept the translated text, not the source.
+	decision := s.screenOutputQuality(doc.RelPath, "transcript-translation", translated, quality.Context{
+		Modality:         quality.ModalityTranscript,
+		ExpectedLanguage: targetLang,
+		Duration:         duration,
+	})
+
+	meta := transcriptMeta{
+		Source:            translationSource,
+		Language:          targetLang,
+		SourceLanguage:    sourceLang,
+		TranslateProvider: s.translateProvider,
+		TranslateModel:    s.translateModel,
+		Timestamps:        true,
+	}
+	metaJSON, err := json.Marshal(meta)
+	if err != nil {
+		return fmt.Errorf("marshal translated transcript meta: %w", err)
+	}
+
+	rep := model.Representation{
+		DocID:       doc.DocID,
+		RepType:     TranscriptRepType(targetLang),
+		RepHash:     computeRepHash([]byte(translated)),
+		MetaJSON:    string(metaJSON),
+		CreatedUnix: time.Now().Unix(),
+		Deleted:     false,
+	}
+	repID, err := s.repGen.store.UpsertRepresentation(ctx, rep)
+	if err != nil {
+		return fmt.Errorf("upsert translated transcript representation: %w", err)
+	}
+
+	// Chunk the translated text with the same transcript chunker so its time
+	// spans line up with the source segments (the translation preserves each
+	// segment's verbatim [mm:ss] marker).
+	segments := chunkTranscriptByTime(translated)
+	if len(segments) == 0 {
+		return nil
+	}
+	if err := s.repGen.upsertChunksForRepresentation(ctx, repID, "text", segments, decision); err != nil {
+		return fmt.Errorf("persist translated transcript chunks: %w", err)
 	}
 	return nil
 }

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -1697,8 +1697,13 @@ func (s *Service) generateTranscriptRepresentation(ctx context.Context, doc mode
 	// source transcript so a translation failure never blocks the authoritative
 	// transcript, and each translated transcript routes through the same quality
 	// gate (it IS model output, unlike sidecar transcripts which bypass it).
+	//
+	// Translation is a best-effort enrichment: any failure (chat provider error,
+	// translated-rep persistence) is logged and counted but NOT propagated, so a
+	// failed translation never marks the source transcript's document as errored.
 	if err := s.translateTranscriptRepresentations(ctx, doc, content, transcriptText, duration); err != nil {
-		return err
+		s.getLogger().Printf("transcript translation skipped for %s: %v", doc.RelPath, err)
+		s.addErrors(1)
 	}
 	return nil
 }
@@ -1718,6 +1723,7 @@ func (s *Service) translateTranscriptRepresentations(ctx context.Context, doc mo
 		return nil
 	}
 	sourceLang := strings.TrimSpace(s.transcriptLanguage)
+	var firstErr error
 	for _, lang := range s.translateTargetLangs {
 		lang = strings.ToLower(strings.TrimSpace(lang))
 		if lang == "" || sameLanguage(lang, sourceLang) {
@@ -1725,10 +1731,17 @@ func (s *Service) translateTranscriptRepresentations(ctx context.Context, doc mo
 			continue
 		}
 		if err := s.translateOneTranscript(ctx, doc, content, sourceText, sourceLang, lang, duration); err != nil {
-			return err
+			// Best-effort per language: a failure on one target must not suppress
+			// the remaining targets. Log here and keep going; the first error is
+			// returned so the caller can log/count it (non-fatally).
+			s.getLogger().Printf("transcript translation failed for %s into %q: %v", doc.RelPath, lang, err)
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
 		}
 	}
-	return nil
+	return firstErr
 }
 
 // sameLanguage reports whether two language tags name the same language for the

--- a/internal/ingest/sidecar.go
+++ b/internal/ingest/sidecar.go
@@ -24,6 +24,12 @@ var sidecarExtensions = []string{".vtt", ".srt", ".ttml"}
 // NOT invalidated by an STT model change (spec §8.6.7).
 const sidecarSource = "sidecar"
 
+// translationSource is the meta_json source value recorded on a transcript
+// representation produced by translating another transcript (spec §8.6.2). It is
+// model-derived (unlike a sidecar), so it carries its translate provider/model
+// derivation identity and IS screened by the output quality gate.
+const translationSource = "translation"
+
 // sidecarFile is a discovered subtitle sidecar for a media document: its corpus
 // rel_path, the language tag parsed from the filename (empty when the sidecar is
 // undifferentiated, e.g. "clip.vtt"), the lowercased extension, and the sidecar
@@ -44,6 +50,14 @@ type transcriptMeta struct {
 	Language   string `json:"language,omitempty"`
 	Timestamps bool   `json:"timestamps"`
 	Format     string `json:"format,omitempty"`
+
+	// SourceLanguage / TranslateProvider / TranslateModel are recorded only on a
+	// translated transcript (Source == "translation", spec §8.6.2/§5.2): the
+	// language it was translated from plus the chat provider/model that produced
+	// it. Omitted (omitempty) on STT and sidecar transcripts.
+	SourceLanguage    string `json:"source_language,omitempty"`
+	TranslateProvider string `json:"translate_provider,omitempty"`
+	TranslateModel    string `json:"translate_model,omitempty"`
 }
 
 // setSidecarIndex records the mtime of every discovered file by rel_path so the

--- a/internal/ingest/translate.go
+++ b/internal/ingest/translate.go
@@ -1,0 +1,148 @@
+package ingest
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// readOrComputeTranslation returns the source transcript translated into
+// targetLang, caching the result under <state>/cache/translate keyed by the
+// SOURCE content hash plus the target-language suffix (TranscriptLangSuffix), so
+// re-ingesting an unchanged document reuses the cached translation instead of
+// re-calling the chat provider (SPEC §8.6.2 caching parity with the transcript
+// cache). The cache is keyed by source content, not target text, because the
+// same source media always yields the same translation for a given target.
+func (s *Service) readOrComputeTranslation(ctx context.Context, content []byte, sourceText, targetLang string) (string, error) {
+	cacheDir := filepath.Join(s.cfg.StateDir, "cache", "translate")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		return "", fmt.Errorf("create translate cache dir: %w", err)
+	}
+
+	base := computeContentHash(content) + TranscriptLangSuffix(targetLang)
+	cachePath := filepath.Join(cacheDir, base+".txt")
+	if cached, err := os.ReadFile(cachePath); err == nil {
+		return string(cached), nil
+	}
+
+	translated, err := s.translateTranscriptText(ctx, sourceText, targetLang)
+	if err != nil {
+		return "", err
+	}
+
+	out := strings.ReplaceAll(strings.ReplaceAll(translated, "\r\n", "\n"), "\r", "\n")
+	if err := os.WriteFile(cachePath, []byte(out), 0o644); err != nil {
+		return "", fmt.Errorf("write translate cache: %w", err)
+	}
+	return out, nil
+}
+
+// translateTranscriptText translates a segment-formatted transcript into
+// targetLang while keeping it time-aligned to the source (SPEC §8.6.2): each
+// source line's leading [mm:ss] / mm:ss timestamp marker is preserved VERBATIM
+// and only the spoken text is translated, so chunkTranscriptByTime produces the
+// same time spans for the translated transcript as for the source. Lines are
+// translated segment-by-segment via the chat Generator; a line with no timestamp
+// marker is translated as-is (its leading-marker, if any, is empty).
+func (s *Service) translateTranscriptText(ctx context.Context, sourceText, targetLang string) (string, error) {
+	lines := strings.Split(sourceText, "\n")
+	out := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			out = append(out, "")
+			continue
+		}
+		marker, body := splitTimestampMarker(line)
+		translatedBody, err := s.translateLine(ctx, body, targetLang)
+		if err != nil {
+			return "", err
+		}
+		translatedBody = strings.TrimSpace(translatedBody)
+		switch {
+		case marker == "":
+			out = append(out, translatedBody)
+		case translatedBody == "":
+			out = append(out, marker)
+		default:
+			out = append(out, marker+" "+translatedBody)
+		}
+	}
+	return strings.Join(out, "\n"), nil
+}
+
+// translateLine translates a single line of transcript text into targetLang via
+// the chat Generator. Empty/whitespace input short-circuits to empty so the chat
+// provider is never called for a marker-only line. The prompt asks for the
+// translation only (no preamble), which the trim downstream normalizes.
+func (s *Service) translateLine(ctx context.Context, text, targetLang string) (string, error) {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return "", nil
+	}
+	prompt := buildTranslatePrompt(text, targetLang)
+	translated, err := s.translator.Generate(ctx, prompt)
+	if err != nil {
+		return "", err
+	}
+	return translated, nil
+}
+
+// buildTranslatePrompt builds a deterministic, general-purpose translation
+// prompt. It pins the TARGET language only (the source language is auto-detected
+// by the model, matching SPEC §8.6.2's auto-detection default) and instructs the
+// model to return the translation alone so the output needs no post-parsing.
+func buildTranslatePrompt(text, targetLang string) string {
+	var b strings.Builder
+	b.WriteString("Translate the following text into ")
+	b.WriteString(targetLang)
+	b.WriteString(". Preserve meaning faithfully. Return only the translated text, ")
+	b.WriteString("with no preamble, quotes, or explanation.\n\n")
+	b.WriteString(text)
+	return b.String()
+}
+
+// splitTimestampMarker splits a transcript line into its leading timestamp
+// marker (verbatim, e.g. "[00:12]" or "00:12") and the remaining text. When the
+// line has no recognized leading timestamp the marker is empty and the whole
+// trimmed line is returned as the text. Keeping the marker byte-for-byte ensures
+// the translated transcript's time spans line up with the source.
+func splitTimestampMarker(line string) (marker, text string) {
+	trimmed := strings.TrimRight(strings.TrimLeft(line, " \t"), " \t")
+	if trimmed == "" {
+		return "", ""
+	}
+	startMS, body, ok := parseTranscriptTimestamp(trimmed)
+	if !ok {
+		return "", trimmed
+	}
+	// Recover the verbatim marker as the prefix of the trimmed line preceding the
+	// parsed body, so the original bracket/format is preserved exactly.
+	if body == "" {
+		return trimmed, ""
+	}
+	idx := strings.LastIndex(trimmed, body)
+	if idx <= 0 {
+		// Fall back to a normalized [mm:ss] marker when the body could not be
+		// located as a suffix (should not happen for parsed lines).
+		return formatTimestampMarker(startMS), body
+	}
+	return strings.TrimRight(trimmed[:idx], " \t"), body
+}
+
+// formatTimestampMarker renders a millisecond offset as a bracketed [mm:ss] or
+// [hh:mm:ss] marker, matching the transcript timestamp format.
+func formatTimestampMarker(ms int) string {
+	if ms < 0 {
+		ms = 0
+	}
+	totalSec := ms / 1000
+	h := totalSec / 3600
+	m := (totalSec % 3600) / 60
+	sec := totalSec % 60
+	if h > 0 {
+		return fmt.Sprintf("[%02d:%02d:%02d]", h, m, sec)
+	}
+	return fmt.Sprintf("[%02d:%02d]", m, sec)
+}

--- a/internal/ingest/translate.go
+++ b/internal/ingest/translate.go
@@ -21,7 +21,20 @@ func (s *Service) readOrComputeTranslation(ctx context.Context, content []byte, 
 		return "", fmt.Errorf("create translate cache dir: %w", err)
 	}
 
-	base := computeContentHash(content) + TranscriptLangSuffix(targetLang)
+	// Key the cache on the full translation identity, not just the source media
+	// bytes: the same media re-translated after the source transcript text, the
+	// chat provider, or the model changes must NOT return stale text (the rep's
+	// meta_json records the new provider/model, so a stale body would be
+	// mislabeled). The TranscriptLangSuffix is retained on the filename so cache
+	// files stay human-identifiable by language.
+	cacheIdentity := strings.Join([]string{
+		computeContentHash(content),
+		computeContentHash([]byte(sourceText)),
+		strings.TrimSpace(s.translateProvider),
+		strings.TrimSpace(s.translateModel),
+		strings.ToLower(strings.TrimSpace(targetLang)),
+	}, "\x00")
+	base := computeContentHash([]byte(cacheIdentity)) + TranscriptLangSuffix(targetLang)
 	cachePath := filepath.Join(cacheDir, base+".txt")
 	if cached, err := os.ReadFile(cachePath); err == nil {
 		return string(cached), nil
@@ -59,7 +72,12 @@ func (s *Service) translateTranscriptText(ctx context.Context, sourceText, targe
 		if err != nil {
 			return "", err
 		}
-		translatedBody = strings.TrimSpace(translatedBody)
+		// Collapse any internal newlines/whitespace runs the chat provider may
+		// have returned into single spaces, so one source segment stays exactly
+		// one output line — otherwise an extra line would desync the translated
+		// transcript's time spans from the source (chunkTranscriptByTime keys on
+		// per-line [mm:ss] markers).
+		translatedBody = strings.Join(strings.Fields(translatedBody), " ")
 		switch {
 		case marker == "":
 			out = append(out, translatedBody)

--- a/tests/ingest/transcript_translate_test.go
+++ b/tests/ingest/transcript_translate_test.go
@@ -1,0 +1,308 @@
+package tests
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// fakeTranslator is a deterministic model.Generator stand-in for transcript
+// translation tests: it appends a per-call tag so the translated text differs
+// from the source, and counts Generate calls so cache reuse can be asserted.
+type fakeTranslator struct {
+	mu     sync.Mutex
+	calls  int
+	prompt string
+}
+
+func (f *fakeTranslator) Generate(_ context.Context, prompt string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	f.prompt = prompt
+	// The prompt ends with the source line text after a blank line; echo a
+	// translated marker plus the original so output is non-empty and traceable.
+	parts := strings.Split(prompt, "\n\n")
+	src := parts[len(parts)-1]
+	return "translated:" + src, nil
+}
+
+func (f *fakeTranslator) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+// TestTranscriptTranslation_Disabled_NoExtraReps confirms that with translation
+// off (the default), only the single source transcript representation is
+// produced — behaviour is identical to before the feature existed.
+func TestTranscriptTranslation_Disabled_NoExtraReps(t *testing.T) {
+	t.Parallel()
+	stateDir := t.TempDir()
+	st := &fakeIngestStore{}
+	svc := mustNewIngestService(t, config.Config{StateDir: stateDir}, st)
+	svc.SetTranscriber(&fakeTranscriber{text: "[00:00] intro\n[00:02] chapter one"})
+	// Translator left nil (translation disabled).
+
+	doc := model.Document{DocID: 7, RelPath: "audio/talk.mp3", DocType: "audio"}
+	if err := svc.GenerateTranscriptRepresentation(context.Background(), doc, []byte("audio")); err != nil {
+		t.Fatalf("GenerateTranscriptRepresentation: %v", err)
+	}
+
+	if len(st.reps) != 1 {
+		t.Fatalf("expected exactly one transcript rep with translation off, got %d (%+v)", len(st.reps), st.reps)
+	}
+	if st.reps[0].RepType != ingest.RepTypeTranscript {
+		t.Fatalf("expected source rep_type %q, got %q", ingest.RepTypeTranscript, st.reps[0].RepType)
+	}
+}
+
+// TestTranscriptTranslation_ProducesPerLanguageRep verifies that enabling
+// translation for target "en" produces a second transcript-en representation
+// that is time-aligned to the source segments and records the translation
+// derivation metadata.
+func TestTranscriptTranslation_ProducesPerLanguageRep(t *testing.T) {
+	t.Parallel()
+	stateDir := t.TempDir()
+	st := &fakeIngestStore{}
+	svc := mustNewIngestService(t, config.Config{StateDir: stateDir}, st)
+	svc.SetTranscriber(&fakeTranscriber{text: "[00:00] intro\n[00:02] chapter one\n[00:05] chapter two"})
+	tr := &fakeTranslator{}
+	svc.SetTranscriptLanguage("de")
+	svc.SetTranslator(tr, "mistral", "mistral-small-2506", []string{"en"})
+
+	doc := model.Document{DocID: 9, RelPath: "audio/lecture.mp3", DocType: "audio"}
+	if err := svc.GenerateTranscriptRepresentation(context.Background(), doc, []byte("audio")); err != nil {
+		t.Fatalf("GenerateTranscriptRepresentation: %v", err)
+	}
+
+	if len(st.reps) != 2 {
+		t.Fatalf("expected source + translated transcript reps, got %d (%+v)", len(st.reps), st.reps)
+	}
+
+	var translated *model.Representation
+	for i := range st.reps {
+		if st.reps[i].RepType == ingest.TranscriptRepType("en") {
+			translated = &st.reps[i]
+		}
+	}
+	if translated == nil {
+		t.Fatalf("expected a %q representation, got reps %+v", ingest.TranscriptRepType("en"), st.reps)
+	}
+
+	meta := translated.MetaJSON
+	for _, want := range []string{
+		`"source":"translation"`,
+		`"language":"en"`,
+		`"source_language":"de"`,
+		`"translate_provider":"mistral"`,
+		`"translate_model":"mistral-small-2506"`,
+	} {
+		if !strings.Contains(meta, want) {
+			t.Fatalf("translated transcript meta_json missing %s: %s", want, meta)
+		}
+	}
+
+	// Time-aligned: the translated transcript must produce the same three time
+	// spans as the source. Source spans precede translated spans in insertion
+	// order; assert the last three (translated) line up with the known source
+	// windows: 0-2000, 2000-5000, 5000-6000.
+	if len(st.spans) != 6 {
+		t.Fatalf("expected 3 source + 3 translated time spans, got %d (%+v)", len(st.spans), st.spans)
+	}
+	translatedSpans := st.spans[3:]
+	wantWindows := [][2]int{{0, 2000}, {2000, 5000}, {5000, 6000}}
+	for i, w := range wantWindows {
+		got := translatedSpans[i]
+		if got.Kind != "time" || got.StartMS != w[0] || got.EndMS != w[1] {
+			t.Fatalf("translated span %d not time-aligned: got %+v want kind=time start=%d end=%d", i, got, w[0], w[1])
+		}
+	}
+}
+
+// TestTranscriptTranslation_CacheReused verifies the per-language translation
+// cache (TranscriptLangSuffix): a second run over the same source content reuses
+// the cached translation instead of re-calling the chat provider.
+func TestTranscriptTranslation_CacheReused(t *testing.T) {
+	t.Parallel()
+	stateDir := t.TempDir()
+	content := []byte("audio-bytes")
+
+	run := func(tr *fakeTranslator) {
+		st := &fakeIngestStore{}
+		svc := mustNewIngestService(t, config.Config{StateDir: stateDir}, st)
+		svc.SetTranscriber(&fakeTranscriber{text: "[00:00] one line"})
+		svc.SetTranscriptLanguage("de")
+		svc.SetTranslator(tr, "mistral", "m", []string{"en"})
+		doc := model.Document{DocID: 3, RelPath: "audio/clip.mp3", DocType: "audio"}
+		if err := svc.GenerateTranscriptRepresentation(context.Background(), doc, content); err != nil {
+			t.Fatalf("GenerateTranscriptRepresentation: %v", err)
+		}
+	}
+
+	tr := &fakeTranslator{}
+	run(tr)
+	if tr.callCount() == 0 {
+		t.Fatalf("expected translator to be called on first run")
+	}
+	firstCalls := tr.callCount()
+
+	// Second run with the SAME stateDir/content: the translation must come from
+	// cache, so Generate is not called again.
+	tr2 := &fakeTranslator{}
+	run(tr2)
+	if tr2.callCount() != 0 {
+		t.Fatalf("expected cached translation reused (0 calls) on second run, got %d", tr2.callCount())
+	}
+	_ = firstCalls
+}
+
+// TestTranscriptTranslation_RealStoreSearchable confirms the translated
+// transcript is surfaced by store.TranscriptRepresentations alongside the source
+// transcript when persisted to a real sqlite store.
+func TestTranscriptTranslation_RealStoreSearchable(t *testing.T) {
+	t.Parallel()
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	if err := st.Init(context.Background()); err != nil {
+		t.Fatalf("store init: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	svc := mustNewIngestService(t, config.Config{StateDir: t.TempDir()}, st)
+	svc.SetTranscriber(&fakeTranscriber{text: "[00:00] hello\n[00:02] world"})
+	svc.SetTranscriptLanguage("de")
+	svc.SetTranslator(&fakeTranslator{}, "mistral", "m", []string{"en"})
+
+	if err := st.UpsertDocument(context.Background(), model.Document{RelPath: "talk.mp3", DocType: "audio"}); err != nil {
+		t.Fatalf("upsert document: %v", err)
+	}
+	doc, err := st.GetDocumentByPath(context.Background(), "talk.mp3")
+	if err != nil {
+		t.Fatalf("get document: %v", err)
+	}
+	if err := svc.GenerateTranscriptRepresentation(context.Background(), doc, []byte("audio")); err != nil {
+		t.Fatalf("GenerateTranscriptRepresentation: %v", err)
+	}
+
+	reps, err := st.TranscriptRepresentations(context.Background(), "talk.mp3")
+	if err != nil {
+		t.Fatalf("TranscriptRepresentations: %v", err)
+	}
+	if len(reps) != 2 {
+		t.Fatalf("expected source + translated transcript reps in real store, got %d (%+v)", len(reps), reps)
+	}
+	var sawTranslation bool
+	for _, r := range reps {
+		if strings.Contains(r.MetaJSON, `"source":"translation"`) &&
+			strings.Contains(r.MetaJSON, `"language":"en"`) {
+			sawTranslation = true
+		}
+	}
+	if !sawTranslation {
+		t.Fatalf("translated transcript not surfaced by TranscriptRepresentations: %+v", reps)
+	}
+}
+
+// degenerateTranslator is a model.Generator that returns a degenerate
+// (repetition-loop) translation so the output quality gate quarantines it.
+type degenerateTranslator struct{}
+
+func (degenerateTranslator) Generate(_ context.Context, _ string) (string, error) {
+	return strings.Repeat("merci ", 60), nil
+}
+
+// TestTranscriptTranslation_RoutesThroughQualityGate proves a translated
+// transcript is screened by the output quality gate (anti-hallucination) like
+// any model output — it does NOT bypass the gate the way sidecar transcripts do.
+// A degenerate translation is quarantined (its chunks inserted error/quality_gate)
+// while the clean source transcript's chunks remain pending.
+func TestTranscriptTranslation_RoutesThroughQualityGate(t *testing.T) {
+	t.Parallel()
+	stateDir := t.TempDir()
+	st := &fakeIngestStore{}
+	svc := mustNewIngestService(t, config.Config{StateDir: stateDir, QualityGatesEnabled: true}, st)
+	svc.SetTranscriber(&fakeTranscriber{text: "[00:00] a clean source line\n[00:02] another clean line"})
+	svc.SetTranscriptLanguage("de")
+	svc.SetTranslator(degenerateTranslator{}, "mistral", "m", []string{"en"})
+
+	doc := model.Document{DocID: 11, RelPath: "audio/talk.mp3", DocType: "audio"}
+	if err := svc.GenerateTranscriptRepresentation(context.Background(), doc, []byte("audio")); err != nil {
+		t.Fatalf("GenerateTranscriptRepresentation: %v", err)
+	}
+
+	// Find the translated chunks (their rep is transcript-en, the second rep).
+	if len(st.reps) != 2 {
+		t.Fatalf("expected source + translated reps, got %d", len(st.reps))
+	}
+	var translatedRepID int64
+	for i := range st.reps {
+		if st.reps[i].RepType == ingest.TranscriptRepType("en") {
+			translatedRepID = int64(i + 1) // fakeIngestStore assigns rep IDs sequentially from 1
+		}
+	}
+	if translatedRepID == 0 {
+		t.Fatalf("translated rep not found")
+	}
+
+	var sawQuarantined, sawPending bool
+	for _, c := range st.chunks {
+		if c.RepID == translatedRepID {
+			if c.EmbeddingStatus == "error" && c.ErrorCategory == string(store.ErrorCategoryQualityGate) {
+				sawQuarantined = true
+			}
+		} else if c.EmbeddingStatus == "pending" {
+			sawPending = true
+		}
+	}
+	if !sawQuarantined {
+		t.Fatalf("expected degenerate translated chunks to be quarantined by the quality gate; chunks=%+v", st.chunks)
+	}
+	if !sawPending {
+		t.Fatalf("expected clean source transcript chunks to remain pending; chunks=%+v", st.chunks)
+	}
+}
+
+// TestTranscriptTranslation_ValidationRejectsEmptyTargets verifies that enabling
+// translation with an empty target_langs is CONFIG_INVALID, while leaving it off
+// is valid (general-purpose: no default target language).
+func TestTranscriptTranslation_ValidationRejectsEmptyTargets(t *testing.T) {
+	t.Parallel()
+
+	enabledNoTargets := config.Default()
+	enabledNoTargets.MediaTranslateEnabled = true
+	enabledNoTargets.MediaTranslateTargetLangs = nil
+	if err := enabledNoTargets.Validate(); err == nil {
+		t.Fatalf("expected CONFIG_INVALID when translation enabled with empty target_langs")
+	}
+
+	enabledBlankTargets := config.Default()
+	enabledBlankTargets.MediaTranslateEnabled = true
+	enabledBlankTargets.MediaTranslateTargetLangs = []string{"  ", ""}
+	if err := enabledBlankTargets.Validate(); err == nil {
+		t.Fatalf("expected CONFIG_INVALID when translation enabled with all-blank target_langs")
+	}
+
+	enabledWithTargets := config.Default()
+	enabledWithTargets.MediaTranslateEnabled = true
+	enabledWithTargets.MediaTranslateTargetLangs = []string{"EN", "en", "fr"}
+	if err := enabledWithTargets.Validate(); err != nil {
+		t.Fatalf("expected valid config with targets, got %v", err)
+	}
+	if got := enabledWithTargets.MediaTranslateTargetLangs; len(got) != 2 || got[0] != "en" || got[1] != "fr" {
+		t.Fatalf("expected normalized de-duped lower-cased targets [en fr], got %v", got)
+	}
+
+	off := config.Default()
+	off.MediaTranslateEnabled = false
+	off.MediaTranslateTargetLangs = nil
+	if err := off.Validate(); err != nil {
+		t.Fatalf("translation off must be valid, got %v", err)
+	}
+}

--- a/tests/ingest/transcript_translate_test.go
+++ b/tests/ingest/transcript_translate_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -207,6 +208,42 @@ func TestTranscriptTranslation_RealStoreSearchable(t *testing.T) {
 	}
 	if !sawTranslation {
 		t.Fatalf("translated transcript not surfaced by TranscriptRepresentations: %+v", reps)
+	}
+}
+
+// failingTranslator is a model.Generator that always errors, simulating a chat
+// provider failure during translation.
+type failingTranslator struct{}
+
+func (failingTranslator) Generate(_ context.Context, _ string) (string, error) {
+	return "", errors.New("chat provider unavailable")
+}
+
+// TestTranscriptTranslation_FailureIsNonFatal proves that a translation provider
+// failure does NOT fail the ingest of the document and does NOT prevent the
+// authoritative source transcript representation from being persisted. The
+// source transcript is written before translation is attempted, and a
+// translation error is swallowed (best-effort enrichment), so
+// GenerateTranscriptRepresentation returns nil with the single source rep intact.
+func TestTranscriptTranslation_FailureIsNonFatal(t *testing.T) {
+	t.Parallel()
+	stateDir := t.TempDir()
+	st := &fakeIngestStore{}
+	svc := mustNewIngestService(t, config.Config{StateDir: stateDir}, st)
+	svc.SetTranscriber(&fakeTranscriber{text: "[00:00] intro\n[00:02] chapter one"})
+	svc.SetTranscriptLanguage("de")
+	svc.SetTranslator(failingTranslator{}, "mistral", "m", []string{"en"})
+
+	doc := model.Document{DocID: 21, RelPath: "audio/talk.mp3", DocType: "audio"}
+	if err := svc.GenerateTranscriptRepresentation(context.Background(), doc, []byte("audio")); err != nil {
+		t.Fatalf("translation failure must be non-fatal, got error: %v", err)
+	}
+
+	if len(st.reps) != 1 {
+		t.Fatalf("expected only the source transcript rep to survive a failed translation, got %d (%+v)", len(st.reps), st.reps)
+	}
+	if st.reps[0].RepType != ingest.RepTypeTranscript {
+		t.Fatalf("expected surviving rep to be the source transcript %q, got %q", ingest.RepTypeTranscript, st.reps[0].RepType)
 	}
 }
 


### PR DESCRIPTION
Closes #256. Part of epic #261 (livevtt absorption — translation/subtitle).

Implements MERGED spec **§8.6.2** (transcript language detection + optional translation): translation is OPT-IN and off by default; target language(s) are CONFIGURABLE with **NO built-in default** (enabling translation with no target = `CONFIG_INVALID`); transcripts are keyed per-language; translated transcripts record `source_language` + the translate provider/model; translation uses the **chat capability**.

## What changed

### Config (`internal/config/config.go`)
- New keys `media.translate.enabled` (bool, default `false`) and `media.translate.target_langs` (list, no default), wired through the full field/overlay/yaml/default/merge/marshal pattern (mirrors `media.variants.*`).
- `isMapSectionKey` now recognizes `media.translate`; `media.translate.target_langs` registered as a list key.
- `Validate()` → `validateMediaTranslate`: enabling translation with empty/all-blank `target_langs` is `CONFIG_INVALID`; targets are normalized (trim/lower-case/de-dup). Off (default) is unchanged.

### Ingest (`internal/ingest/`)
- `generateTranscriptRepresentation` now runs an optional translate step **after** the source transcript is persisted (so a translation failure never blocks the authoritative transcript).
- For each target language it produces a second `transcript` representation via `TranscriptRepType(lang)` → `transcript-<lang>` (coexists with the source transcript and any sidecar per-language reps; surfaced by `store.TranscriptRepresentations`, which already matches `transcript` + `transcript-%`).
- **Time-aligned**: each source segment's verbatim `[mm:ss]` marker is preserved and only the spoken text is translated, so `chunkTranscriptByTime` yields the same time spans.
- Translations are **cached per-language** via `TranscriptLangSuffix` (keyed by source content hash) so they aren't recomputed across re-ingests.
- `meta_json` records `source: "translation"`, `language` (target), `source_language`, `translate_provider`, `translate_model`.
- Translation uses `model.Generator` resolved from the chat capability (`provider.CapChat` via `providerfactory.Generator`); a dedicated binding is supported by binding chat to a specific provider/model.

### Quality gate
- A translated transcript IS model output, so it routes through the existing output quality gate (anti-hallucination) like STT/OCR output — it does **not** bypass it (contrast with sidecar transcripts). Covered by a test that quarantines a degenerate translation while the clean source stays pending.

## General-purpose
No default target language and no Russian/TV-Rain specifics; source language is auto-detected/recorded as today.

## Tests (`tests/ingest/transcript_translate_test.go`)
- translation off → no extra reps (unchanged);
- target `["en"]` → `transcript-en` rep, time-aligned spans, surfaced via `TranscriptRepresentations`;
- enabling with empty/blank `target_langs` → validation error;
- meta records `source_language`/`translate_provider`/`translate_model`;
- per-language cache reused (translate called once across re-runs);
- degenerate translation routes through + is quarantined by the quality gate.
All via a fake chat/translate provider (no network).

## Checks
`gofmt`/`go vet`/`go build (CGO_ENABLED=0)`/`gocyclo -over 15`/`ineffassign`/`misspell` clean; `golangci-lint run` reports 0 issues on the changed packages. (`make check` also walks sibling `.claude/worktrees/` checkouts, surfacing a pre-existing unrelated `internal/index/embedding_worker.go` staticcheck artifact from another agent's worktree — not part of this change.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in transcript translation via configuration (`media.translate`) with support for multiple target languages.
  * Translated transcript representations and time-aligned chunks are persisted and reused using disk-backed caching.
  * Added translation provenance metadata (source language, provider, model) on translated transcripts.
* **Bug Fixes**
  * Translation is best-effort: provider/model resolution or translation failures no longer block ingestion.
* **Tests**
  * Expanded transcript translation test coverage for disabled vs enabled behavior, per-language outputs, cache reuse, non-fatal failures, quality-gate routing, and validation/normalization of target languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->