### PR TITLE
feat(index): S3 range-read media access for audio/video chunk windows (#243)

### DIFF
--- a/internal/avutil/avutil.go
+++ b/internal/avutil/avutil.go
@@ -66,10 +66,10 @@ func Duration(ctx context.Context, path string) (time.Duration, error) {
 	return time.Duration(secs * float64(time.Second)), nil
 }
 
-// ExtractSegment cuts the window [startMS, endMS) from the media at path and
-// returns the resulting container bytes. It uses stream copy (no re-encode) so
-// the MIME type is unchanged, extraction is fast, and the output is
-// deterministic for a given input.
+// ExtractSegment cuts the window [startMS, endMS) from the media at a local
+// filesystem path and returns the resulting container bytes. It uses stream copy
+// (no re-encode) so the MIME type is unchanged, extraction is fast, and the
+// output is deterministic for a given input.
 //
 // Accuracy: audio is cut sample-accurately, but for video stream copy can only
 // start at the nearest preceding keyframe, so the clip is keyframe-aligned and
@@ -82,8 +82,45 @@ func Duration(ctx context.Context, path string) (time.Duration, error) {
 //
 // It returns ErrToolNotFound when ffmpeg is not installed.
 func ExtractSegment(ctx context.Context, path string, startMS, endMS int) ([]byte, error) {
+	// A local path: infer the container extension from the path so the extracted
+	// clip keeps the source muxer/MIME.
+	return extractSegment(ctx, path, filepath.Ext(path), startMS, endMS)
+}
+
+// ExtractSegmentURL cuts the window [startMS, endMS) from media at an http(s)
+// URL (e.g. an S3 presigned GetObject URL) and returns the container bytes. It
+// is the range-read counterpart of ExtractSegment: ffmpeg opens the URL over its
+// http protocol and, when the server advertises byte-range support (S3 does),
+// seeks to the requested window so only the bytes around [startMS, endMS) plus
+// the container's index are fetched — the whole object is NOT downloaded. This
+// is the audio/video analogue of CorpusFS.Open's range GETs, which is why the
+// worker prefers it over Localize (a whole-object download) for S3-backed media.
+//
+// srcExt supplies the container extension (e.g. ".mp4") so ffmpeg writes the clip
+// with the matching muxer, since a presigned URL's path/query is not a reliable
+// muxer hint. An empty srcExt falls back to ".bin". Behavior, accuracy, and the
+// ErrToolNotFound contract otherwise match ExtractSegment.
+func ExtractSegmentURL(ctx context.Context, url, srcExt string, startMS, endMS int) ([]byte, error) {
+	if !isHTTPURL(url) {
+		return nil, fmt.Errorf("avutil: ExtractSegmentURL requires an http(s) URL, got %q", url)
+	}
+	return extractSegment(ctx, url, srcExt, startMS, endMS)
+}
+
+// isHTTPURL reports whether s is an http or https URL, the only schemes ffmpeg
+// can range-seek for ExtractSegmentURL.
+func isHTTPURL(s string) bool {
+	return strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://")
+}
+
+// extractSegment is the shared ffmpeg stream-copy implementation behind both the
+// local-path (ExtractSegment) and http-URL (ExtractSegmentURL) entry points. The
+// input string is handed to ffmpeg's -i, which accepts both a filesystem path and
+// an http(s) URL; the only difference is how the container extension is derived
+// for the output muxer, so callers pass it explicitly via srcExt.
+func extractSegment(ctx context.Context, input, srcExt string, startMS, endMS int) ([]byte, error) {
 	if startMS < 0 || endMS <= startMS {
-		return nil, fmt.Errorf("avutil: invalid segment [%d,%d) for %q", startMS, endMS, path)
+		return nil, fmt.Errorf("avutil: invalid segment [%d,%d) for %q", startMS, endMS, input)
 	}
 	bin, err := exec.LookPath("ffmpeg")
 	if err != nil {
@@ -98,7 +135,7 @@ func ExtractSegment(ctx context.Context, path string, startMS, endMS int) ([]byt
 
 	// Keep the source extension so ffmpeg infers the matching muxer and the
 	// extracted clip stays the same container/MIME as the source.
-	ext := filepath.Ext(path)
+	ext := srcExt
 	if ext == "" {
 		ext = ".bin"
 	}
@@ -109,21 +146,21 @@ func ExtractSegment(ctx context.Context, path string, startMS, endMS int) ([]byt
 		"-v", "error",
 		"-ss", msToSeconds(startMS),
 		"-to", msToSeconds(endMS),
-		"-i", path,
+		"-i", input,
 		"-c", "copy",
 		"-y", outPath,
 	)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("ffmpeg segment %q [%d,%d): %w: %s", path, startMS, endMS, err, strings.TrimSpace(stderr.String()))
+		return nil, fmt.Errorf("ffmpeg segment %q [%d,%d): %w: %s", input, startMS, endMS, err, strings.TrimSpace(stderr.String()))
 	}
 	data, err := os.ReadFile(outPath)
 	if err != nil {
 		return nil, fmt.Errorf("avutil: read extracted segment: %w", err)
 	}
 	if len(data) == 0 {
-		return nil, fmt.Errorf("avutil: ffmpeg produced an empty segment for %q [%d,%d)", path, startMS, endMS)
+		return nil, fmt.Errorf("avutil: ffmpeg produced an empty segment for %q [%d,%d)", input, startMS, endMS)
 	}
 	return data, nil
 }

--- a/internal/avutil/avutil.go
+++ b/internal/avutil/avutil.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	neturl "net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -102,7 +103,11 @@ func ExtractSegment(ctx context.Context, path string, startMS, endMS int) ([]byt
 // ErrToolNotFound contract otherwise match ExtractSegment.
 func ExtractSegmentURL(ctx context.Context, url, srcExt string, startMS, endMS int) ([]byte, error) {
 	if !isHTTPURL(url) {
-		return nil, fmt.Errorf("avutil: ExtractSegmentURL requires an http(s) URL, got %q", url)
+		// Never echo the raw input here: although a non-http input has reached
+		// this guard, the same redaction discipline as the rest of this file
+		// applies so a leaked credential-bearing URL (e.g. with a wrong scheme)
+		// cannot surface in an error or log line.
+		return nil, fmt.Errorf("avutil: ExtractSegmentURL requires an http(s) URL, got %q", redactInput(url))
 	}
 	return extractSegment(ctx, url, srcExt, startMS, endMS)
 }
@@ -113,14 +118,59 @@ func isHTTPURL(s string) bool {
 	return strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://")
 }
 
+// redactInput returns a log/error-safe rendering of an extractSegment input.
+// Local filesystem paths are returned unchanged, but for an http(s) URL the
+// entire query string is stripped before the value is ever placed in an error
+// message or log line. An S3 (or any) presigned URL carries its credentials and
+// signature in the query (X-Amz-Signature, X-Amz-Credential, …); dropping the
+// query preserves enough for diagnostics (scheme + host + path) while ensuring
+// the secret never leaks into errors that are logged or persisted as a failure
+// reason (CLAUDE.md: never log secrets/raw sensitive payloads). If the URL fails
+// to parse it is replaced wholesale with a placeholder rather than risking a
+// partial leak.
+func redactInput(input string) string {
+	if !isHTTPURL(input) {
+		return input
+	}
+	u, err := neturl.Parse(input)
+	if err != nil {
+		return "[redacted-url]"
+	}
+	u.RawQuery = ""
+	u.Fragment = ""
+	u.User = nil
+	return u.String()
+}
+
+// redactStderr makes ffmpeg's stderr safe to embed in a wrapped error. Some
+// ffmpeg builds echo the input URL in protocol errors (e.g. "Server returned
+// 403 Forbidden" with the full URL), which would reintroduce the signed query.
+// It replaces both the full input URL and its raw query string with the redacted
+// form so neither a whole-URL nor a query-only echo can leak the signature.
+func redactStderr(stderr, input string) string {
+	out := strings.TrimSpace(stderr)
+	if !isHTTPURL(input) {
+		return out
+	}
+	out = strings.ReplaceAll(out, input, redactInput(input))
+	if u, err := neturl.Parse(input); err == nil && u.RawQuery != "" {
+		out = strings.ReplaceAll(out, u.RawQuery, "[redacted]")
+	}
+	return out
+}
+
 // extractSegment is the shared ffmpeg stream-copy implementation behind both the
 // local-path (ExtractSegment) and http-URL (ExtractSegmentURL) entry points. The
 // input string is handed to ffmpeg's -i, which accepts both a filesystem path and
 // an http(s) URL; the only difference is how the container extension is derived
 // for the output muxer, so callers pass it explicitly via srcExt.
 func extractSegment(ctx context.Context, input, srcExt string, startMS, endMS int) ([]byte, error) {
+	// safeInput is the only rendering of input that may appear in an error or log
+	// line: for an http(s) URL it has the credential-bearing query stripped (see
+	// redactInput) so a presigned URL's signature never leaks.
+	safeInput := redactInput(input)
 	if startMS < 0 || endMS <= startMS {
-		return nil, fmt.Errorf("avutil: invalid segment [%d,%d) for %q", startMS, endMS, input)
+		return nil, fmt.Errorf("avutil: invalid segment [%d,%d) for %q", startMS, endMS, safeInput)
 	}
 	bin, err := exec.LookPath("ffmpeg")
 	if err != nil {
@@ -153,14 +203,14 @@ func extractSegment(ctx context.Context, input, srcExt string, startMS, endMS in
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("ffmpeg segment %q [%d,%d): %w: %s", input, startMS, endMS, err, strings.TrimSpace(stderr.String()))
+		return nil, fmt.Errorf("ffmpeg segment %q [%d,%d): %w: %s", safeInput, startMS, endMS, err, redactStderr(stderr.String(), input))
 	}
 	data, err := os.ReadFile(outPath)
 	if err != nil {
 		return nil, fmt.Errorf("avutil: read extracted segment: %w", err)
 	}
 	if len(data) == 0 {
-		return nil, fmt.Errorf("avutil: ffmpeg produced an empty segment for %q [%d,%d)", input, startMS, endMS)
+		return nil, fmt.Errorf("avutil: ffmpeg produced an empty segment for %q [%d,%d)", safeInput, startMS, endMS)
 	}
 	return data, nil
 }

--- a/internal/avutil/redact_test.go
+++ b/internal/avutil/redact_test.go
@@ -1,0 +1,94 @@
+package avutil
+
+import (
+	neturl "net/url"
+	"strings"
+	"testing"
+)
+
+// A presigned-URL-shaped value whose query carries the credential/signature that
+// must never reach an error message, log line, or persisted failure reason.
+const signedURL = "https://my-bucket.s3.amazonaws.com/media/clip.mp4" +
+	"?X-Amz-Algorithm=AWS4-HMAC-SHA256" +
+	"&X-Amz-Credential=AKIAEXAMPLE%2F20260615%2Fus-east-1%2Fs3%2Faws4_request" +
+	"&X-Amz-Date=20260615T000000Z&X-Amz-Expires=900" +
+	"&X-Amz-Signature=deadbeefcafef00dsecretsignature" +
+	"&X-Amz-SignedHeaders=host"
+
+// secretTokens are substrings that, if present in any redacted output, mean the
+// presigned URL's credentials leaked.
+var secretTokens = []string{"X-Amz-Signature", "deadbeefcafef00dsecretsignature", "X-Amz-Credential", "AKIAEXAMPLE"}
+
+func assertNoSecret(t *testing.T, label, out string) {
+	t.Helper()
+	for _, tok := range secretTokens {
+		if strings.Contains(out, tok) {
+			t.Errorf("%s leaked secret token %q in output: %q", label, tok, out)
+		}
+	}
+}
+
+// TestRedactInput_StripsPresignedQuery pins the #1 security property of issue
+// #243: a presigned URL's credential-bearing query is removed before the value
+// can appear in any error or log line, while the harmless object identity
+// (scheme + host + path) is kept for diagnostics.
+func TestRedactInput_StripsPresignedQuery(t *testing.T) {
+	out := redactInput(signedURL)
+	assertNoSecret(t, "redactInput", out)
+	if !strings.HasPrefix(out, "https://my-bucket.s3.amazonaws.com/media/clip.mp4") {
+		t.Errorf("redactInput dropped the diagnostic object identity: %q", out)
+	}
+	if strings.Contains(out, "?") {
+		t.Errorf("redactInput kept a query string: %q", out)
+	}
+}
+
+// TestRedactInput_LeavesLocalPaths confirms local filesystem paths (the
+// historical ExtractSegment input) are returned verbatim, so the local path's
+// error messages are unchanged.
+func TestRedactInput_LeavesLocalPaths(t *testing.T) {
+	for _, p := range []string{"/var/media/clip.mp4", "relative/clip.mp3", ""} {
+		if got := redactInput(p); got != p {
+			t.Errorf("redactInput(%q) = %q, want unchanged", p, got)
+		}
+	}
+}
+
+// TestRedactInput_UserInfoStripped confirms any userinfo (another credential
+// channel) is removed.
+func TestRedactInput_UserInfoStripped(t *testing.T) {
+	out := redactInput("https://user:pass@host/clip.mp4?X-Amz-Signature=secret")
+	if strings.Contains(out, "pass") || strings.Contains(out, "secret") {
+		t.Errorf("redactInput kept credentials: %q", out)
+	}
+}
+
+// TestRedactStderr_ScrubsEchoedURL pins that ffmpeg stderr which echoes the full
+// signed URL or just its query string is scrubbed before being wrapped into an
+// error (some ffmpeg builds print the URL in protocol errors).
+func TestRedactStderr_ScrubsEchoedURL(t *testing.T) {
+	u, err := neturl.Parse(signedURL)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	cases := map[string]string{
+		"full URL echo":    "Server returned 403 Forbidden\n" + signedURL + ": Invalid data",
+		"query-only echo":  "error opening with query " + u.RawQuery,
+		"no URL in stderr": "Invalid data found when processing input",
+	}
+	for name, stderr := range cases {
+		out := redactStderr(stderr, signedURL)
+		assertNoSecret(t, "redactStderr/"+name, out)
+	}
+}
+
+// TestExtractSegment_InvalidRangeNeverLeaksURL drives the public guard path with
+// a signed URL and an invalid range so no binary or network is needed, and
+// confirms the resulting error carries no credential.
+func TestExtractSegment_InvalidRangeNeverLeaksURL(t *testing.T) {
+	_, err := ExtractSegmentURL(nil, signedURL, ".mp4", 10, 5) //nolint:staticcheck // nil ctx ok: guard returns before ctx use
+	if err == nil {
+		t.Fatal("want an invalid-range error")
+	}
+	assertNoSecret(t, "ExtractSegmentURL invalid-range error", err.Error())
+}

--- a/internal/corpusfs/corpusfs.go
+++ b/internal/corpusfs/corpusfs.go
@@ -86,3 +86,20 @@ type CorpusFS interface {
 	// file (extension preserved for muxer inference) and cleanup removes it.
 	Localize(ctx context.Context, relPath string) (localPath string, cleanup func(), err error)
 }
+
+// MediaURLProvider is an optional capability a CorpusFS backend may implement to
+// hand out a short-lived http(s) URL for an object so a range-seeking consumer
+// (notably ffmpeg via avutil.ExtractSegmentURL) can read only the bytes it needs
+// over HTTP instead of forcing a whole-object Localize download.
+//
+// It is deliberately separate from CorpusFS: only object stores that can mint a
+// presigned URL (S3FS) implement it. LocalFS does not — a local file has no URL,
+// so callers must type-assert and fall back to Localize when the assertion fails.
+// This keeps LocalFS behavior byte-for-byte unchanged.
+type MediaURLProvider interface {
+	// MediaURL returns a time-limited http(s) URL granting read access to the
+	// object at relPath. ok=false (with a nil error) means this backend cannot
+	// produce a URL for the object and the caller should fall back to Localize;
+	// a non-nil error means producing the URL failed and should be surfaced.
+	MediaURL(ctx context.Context, relPath string) (url string, ok bool, err error)
+}

--- a/internal/corpusfs/factory.go
+++ b/internal/corpusfs/factory.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -103,6 +104,15 @@ func SetS3ClientBuilderForTest(builder func(ctx context.Context, cfg Config) (S3
 	return func() { newS3Client = prev }
 }
 
+// NewS3FSWithPresignForTest builds an S3FS over a stub client with an explicit
+// presigner so external tests can exercise the MediaURL capability and the
+// worker's URL-based segment path without a concrete *s3.Client or the network.
+// presign maps (bucket, key) to a URL; a nil presign yields an S3FS whose
+// MediaURL reports ok=false. Production code uses New / NewS3FS instead.
+func NewS3FSWithPresignForTest(client S3API, cfg S3Config, presign func(ctx context.Context, bucket, key string) (string, error)) (*S3FS, error) {
+	return newS3FSWithPresign(client, cfg, presignFunc(presign))
+}
+
 // New builds the CorpusFS selected by cfg.Kind. Local and nfs both yield a
 // LocalFS rooted at cfg.RootDir (an NFS mount is just a local path). s3 builds an
 // aws-sdk-go-v2 S3 client and an S3FS whose Localize cache lives under the
@@ -121,7 +131,10 @@ func New(ctx context.Context, cfg Config) (CorpusFS, error) {
 }
 
 // newS3FromConfig constructs the S3-backed CorpusFS, building the client (real or
-// stubbed) and pointing the Localize cache at StateDir/corpus-cache.
+// stubbed) and pointing the Localize cache at StateDir/corpus-cache. When the
+// built client is a concrete *s3.Client it also wires a presigner so the MediaURL
+// capability can hand ffmpeg a range-seekable URL (issue #243); a stub client (no
+// concrete *s3.Client) yields no presigner and MediaURL falls back to Localize.
 func newS3FromConfig(ctx context.Context, cfg Config) (CorpusFS, error) {
 	if strings.TrimSpace(cfg.S3Bucket) == "" {
 		return nil, errors.New("corpusfs: source kind s3 requires a bucket")
@@ -134,9 +147,31 @@ func newS3FromConfig(ctx context.Context, cfg Config) (CorpusFS, error) {
 	if strings.TrimSpace(cfg.StateDir) != "" {
 		cacheDir = filepath.Join(cfg.StateDir, s3CacheSubdir)
 	}
-	return NewS3FS(client, S3Config{
+	return newS3FSWithPresign(client, S3Config{
 		Bucket:   cfg.S3Bucket,
 		Prefix:   cfg.S3Prefix,
 		CacheDir: cacheDir,
-	})
+	}, presignerForClient(client))
+}
+
+// presignerForClient returns a presignFunc backed by the SDK's PresignClient when
+// client is a concrete *s3.Client, or nil otherwise. The SDK's NewPresignClient
+// requires the concrete type, so a stub s3API (tests) cannot be presigned —
+// MediaURL then reports ok=false and the worker falls back to Localize.
+func presignerForClient(client s3API) presignFunc {
+	concrete, ok := client.(*s3.Client)
+	if !ok {
+		return nil
+	}
+	pc := s3.NewPresignClient(concrete)
+	return func(ctx context.Context, bucket, key string) (string, error) {
+		req, err := pc.PresignGetObject(ctx, &s3.GetObjectInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(key),
+		}, s3.WithPresignExpires(s3PresignExpiry))
+		if err != nil {
+			return "", err
+		}
+		return req.URL, nil
+	}
 }

--- a/internal/corpusfs/s3.go
+++ b/internal/corpusfs/s3.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -24,6 +25,18 @@ type s3API interface {
 	HeadObject(ctx context.Context, in *s3.HeadObjectInput, optFns ...func(*s3.Options)) (*s3.HeadObjectOutput, error)
 }
 
+// presignFunc mints a presigned http(s) GetObject URL for a full object key. It
+// is a function rather than a concrete *s3.PresignClient so the s3API client can
+// stay an interface (the SDK's NewPresignClient needs a concrete *s3.Client) and
+// so tests can inject a deterministic, network-free presigner. A nil presignFunc
+// means the backend cannot presign and MediaURL reports ok=false.
+type presignFunc func(ctx context.Context, bucket, key string) (string, error)
+
+// s3PresignExpiry bounds the lifetime of presigned media URLs. It only needs to
+// outlast a single ffmpeg range-read of one segment, so it is kept short to limit
+// the blast radius if a URL leaks (e.g. into a log line of an ffmpeg invocation).
+const s3PresignExpiry = 15 * time.Minute
+
 // S3FS is a CorpusFS backed by an S3 bucket+prefix. AbsPath on discovered files
 // is empty (there is no local path); Localize downloads to a temp file under the
 // configured cache dir so ffmpeg/archive extraction can read a real path.
@@ -32,6 +45,11 @@ type S3FS struct {
 	bucket   string
 	prefix   string // normalized: no leading slash, trailing slash if non-empty
 	cacheDir string // temp download root for Localize (e.g. StateDir/cache)
+	// presign mints presigned GetObject URLs for the MediaURL capability. Nil
+	// when the backend was built without presign support (e.g. a stub client in a
+	// test that does not exercise the URL path); MediaURL then reports ok=false so
+	// callers fall back to Localize.
+	presign presignFunc
 }
 
 // S3Config configures an S3FS.
@@ -45,8 +63,15 @@ type S3Config struct {
 
 // NewS3FS constructs an S3FS over the provided client and config. The client is
 // injected so production code can pass a real *s3.Client and tests can pass a
-// stub.
+// stub. The resulting S3FS has no presigner (MediaURL reports ok=false); the
+// factory installs one via newS3FSWithPresign when building from real config.
 func NewS3FS(client s3API, cfg S3Config) (*S3FS, error) {
+	return newS3FSWithPresign(client, cfg, nil)
+}
+
+// newS3FSWithPresign is NewS3FS plus an explicit presigner so the factory can
+// wire S3 presigned-URL support and tests can inject a network-free presigner.
+func newS3FSWithPresign(client s3API, cfg S3Config, presign presignFunc) (*S3FS, error) {
 	if client == nil {
 		return nil, errors.New("corpusfs: nil s3 client")
 	}
@@ -59,7 +84,29 @@ func NewS3FS(client s3API, cfg S3Config) (*S3FS, error) {
 		bucket:   bucket,
 		prefix:   normalizeS3Prefix(cfg.Prefix),
 		cacheDir: cfg.CacheDir,
+		presign:  presign,
 	}, nil
+}
+
+// MediaURL implements MediaURLProvider: it presigns a short-lived GetObject URL
+// for relPath so a range-seeking consumer (avutil.ExtractSegmentURL → ffmpeg)
+// reads only the bytes it needs over HTTP instead of forcing a whole-object
+// Localize download. ok=false (nil error) means no presigner is configured and
+// the caller should fall back to Localize; a non-nil error means presigning
+// failed.
+func (s *S3FS) MediaURL(ctx context.Context, relPath string) (string, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return "", false, err
+	}
+	if s.presign == nil {
+		return "", false, nil
+	}
+	key := s.keyForRel(relPath)
+	url, err := s.presign(ctx, s.bucket, key)
+	if err != nil {
+		return "", false, fmt.Errorf("corpusfs: presign s3://%s/%s: %w", s.bucket, key, err)
+	}
+	return url, true, nil
 }
 
 // normalizeS3Prefix strips a leading slash and ensures a non-empty prefix ends

--- a/internal/index/embedding_worker.go
+++ b/internal/index/embedding_worker.go
@@ -445,15 +445,22 @@ func (w *EmbeddingWorker) loadPDFPage(ctx context.Context, t model.ChunkTask, fs
 // a presigner) the worker falls back to Localize (a whole-object download for S3,
 // a no-op for LocalFS) because ffmpeg cannot read from an io.Reader — that path
 // is byte-for-byte the historical behavior.
+//
+// Failures on the range-read URL path (presign or extract) are wrapped retryable
+// (errRetryableMediaRead), not fatal: an expired/throttled presigned URL recovers
+// on the next cycle once a fresh URL is minted, so the chunk is left pending. The
+// fallback Localize/extract path keeps its historical ErrFatal classification.
 func (w *EmbeddingWorker) loadMediaSegment(ctx context.Context, t model.ChunkTask, fsys corpusfs.CorpusFS, ref string, cache *mediaBatchCache) ([]byte, error) {
 	span := t.Metadata.Span
 	if !strings.EqualFold(strings.TrimSpace(span.Kind), "time") || span.StartMS < 0 || span.EndMS <= span.StartMS {
 		return nil, fmt.Errorf("%w: %s media chunk %d has invalid time span", ErrFatal, strings.ToLower(t.Modality), t.Metadata.ChunkID)
 	}
 
-	// Prefer a range-seekable URL when the backend can presign one.
+	// Prefer a range-seekable URL when the backend can presign one. A presign
+	// failure is transient (throttling, a momentary credential refresh), so it is
+	// marked retryable to keep the chunk pending rather than permanently failed.
 	if url, ok, uerr := cache.mediaURL(ctx, fsys, ref); uerr != nil {
-		return nil, fmt.Errorf("read media %q: %w", ref, uerr)
+		return nil, fmt.Errorf("%w: presign media %q: %v", errRetryableMediaRead, ref, uerr)
 	} else if ok {
 		return w.extractSegmentFromURL(ctx, url, ref, span)
 	}
@@ -465,6 +472,16 @@ func (w *EmbeddingWorker) loadMediaSegment(ctx context.Context, t model.ChunkTas
 // extractSegmentFromURL cuts the [start,end) window from a range-seekable URL via
 // ffmpeg-over-HTTP. srcExt is derived from the MediaRef so the clip keeps the
 // source container/MIME (a presigned URL's path/query is not a reliable hint).
+//
+// A failure here is NOT wrapped as ErrFatal (unlike the local-path extractor): a
+// range-read over HTTP can fail for transient reasons that a later cycle would
+// recover from — most importantly an expired presigned URL (the per-batch cache
+// memoizes one URL with a 15-min lifetime, issue #243/#279), but also throttling
+// or a network blip. Marking such a chunk permanently failed would silently lose
+// it; returning a retryable error leaves it pending so the next cycle presigns a
+// fresh URL. ref (the relPath, never the signed URL) is the only identifier put
+// in the error so the credential cannot leak (the inner avutil error is already
+// redacted).
 func (w *EmbeddingWorker) extractSegmentFromURL(ctx context.Context, url, ref string, span model.Span) ([]byte, error) {
 	extract := w.ExtractSegmentURLFunc
 	if extract == nil {
@@ -472,7 +489,7 @@ func (w *EmbeddingWorker) extractSegmentFromURL(ctx context.Context, url, ref st
 	}
 	data, err := extract(ctx, url, filepath.Ext(ref), span.StartMS, span.EndMS)
 	if err != nil {
-		return nil, fmt.Errorf("%w: extract %q segment [%d,%d): %v", ErrFatal, ref, span.StartMS, span.EndMS, err)
+		return nil, fmt.Errorf("%w: extract %q segment [%d,%d) over range-read URL: %v", errRetryableMediaRead, ref, span.StartMS, span.EndMS, err)
 	}
 	return data, nil
 }
@@ -766,6 +783,17 @@ func (w *EmbeddingWorker) logf(format string, args ...interface{}) {
 // or compare against it if they produce fatal conditions themselves.
 var ErrFatal = errors.New("fatal")
 
+// errRetryableMediaRead marks a media fetch/extract failure that a later cycle
+// could recover from, so the affected chunk must stay pending (not be marked
+// permanently failed). The canonical case is an S3-backed range-read whose
+// presigned URL expired or was throttled mid-batch (issue #243): the per-batch
+// cache holds one 15-min URL, and although that is comfortably longer than a
+// default batch of stream-copy windows takes, a slow network / clock skew / a
+// large batch override could outlast it — and re-presigning on the next cycle
+// fixes it. Recognized by isTransientEmbedError so it routes to the retry (keep
+// pending) path rather than MarkFailed.
+var errRetryableMediaRead = errors.New("retryable media read")
+
 // isRetryable determines whether RunOnce should be retried when it returns
 // the provided error. The predicate is intentionally conservative; context
 // cancellation, deadline errors, and ErrFatal are considered fatal because
@@ -793,6 +821,12 @@ func isRetryable(err error) bool {
 func isTransientEmbedError(err error) bool {
 	if err == nil {
 		return false
+	}
+	// A range-read media fetch/extract failure (e.g. an expired or throttled
+	// presigned URL, issue #243) is recoverable on a later cycle, so keep the
+	// chunk pending instead of marking it permanently failed.
+	if errors.Is(err, errRetryableMediaRead) {
+		return true
 	}
 	// context package errors are usually propagated from the caller and
 	// indicate the operation stopped; leave the chunk pending rather than

--- a/internal/index/embedding_worker.go
+++ b/internal/index/embedding_worker.go
@@ -72,11 +72,19 @@ type EmbeddingWorker struct {
 	// Production code should rarely set this field.
 	RunOnceFunc func(ctx context.Context, indexKind string) (int, error)
 
-	// ExtractSegmentFunc overrides audio/video time-window extraction (SPEC
-	// 8.1.7). Defaults to avutil.ExtractSegment (ffmpeg) when nil; tests set it
-	// to avoid requiring the ffmpeg binary. Production code should rarely set
-	// this field.
+	// ExtractSegmentFunc overrides audio/video time-window extraction from a
+	// local filesystem path (SPEC 8.1.7). Defaults to avutil.ExtractSegment
+	// (ffmpeg) when nil; tests set it to avoid requiring the ffmpeg binary.
+	// Production code should rarely set this field.
 	ExtractSegmentFunc func(ctx context.Context, path string, startMS, endMS int) ([]byte, error)
+
+	// ExtractSegmentURLFunc overrides audio/video time-window extraction from an
+	// http(s) URL (issue #243): when the corpus backend can presign a
+	// range-seekable URL, the worker cuts the window over HTTP so ffmpeg pulls
+	// only the needed bytes instead of forcing a whole-object download. Defaults
+	// to avutil.ExtractSegmentURL when nil; tests set it to avoid requiring the
+	// ffmpeg binary or network. Production code should rarely set this field.
+	ExtractSegmentURLFunc func(ctx context.Context, url, srcExt string, startMS, endMS int) ([]byte, error)
 }
 
 // validate checks that the worker is properly configured before use.
@@ -198,16 +206,19 @@ func (w *EmbeddingWorker) corpusFS() corpusfs.CorpusFS {
 // corpus root as defense-in-depth against a traversal in a stored ref.
 //
 // Image and PDF bytes are read whole via Open+io.ReadAll (pdfutil needs the full
-// file to extract a single page). Audio/video go through Localize because ffmpeg
-// (avutil.ExtractSegment) needs a real filesystem path, not an io.Reader — for
-// an object-store backend this downloads the whole object to a temp file.
+// file to extract a single page; see loadPDFPage for why a range-read ReadSeeker
+// path is counterproductive with pdfcpu). Audio/video range-read on S3 when the
+// backend can presign a URL — ffmpeg byte-range-seeks the window over HTTP — and
+// otherwise fall back to Localize (a whole-object download on S3, a no-op locally)
+// because ffmpeg cannot read from an io.Reader (see loadMediaSegment).
 //
-// Both fetch paths go through cache (issue #279), so sibling chunks of the same
+// All fetch paths go through cache (issue #279), so sibling chunks of the same
 // MediaRef in one batch (every page of a PDF, every time-window of a video)
-// share a single whole-file read or single Localize download instead of
-// re-fetching per chunk. For the default LocalFS this is behavior-preserving (a
-// local file is cheap to re-open and Localize is a no-op); it only removes
-// redundant range GETs / full-object downloads for remote backends such as S3.
+// share a single whole-file read, single Localize download, or single presigned
+// URL instead of re-fetching per chunk. For the default LocalFS this is
+// behavior-preserving (a local file is cheap to re-open and Localize is a no-op);
+// it only removes redundant range GETs / full-object downloads for remote
+// backends such as S3.
 func (w *EmbeddingWorker) loadMediaInput(ctx context.Context, t model.ChunkTask, cache *mediaBatchCache) (model.MediaInput, error) {
 	ref := strings.TrimSpace(t.MediaRef)
 	if ref == "" {
@@ -257,6 +268,10 @@ type mediaBatchCache struct {
 	// localized holds the materialized local path of a Localize'd MediaRef so
 	// every audio/video time-window of one source shares a single download.
 	localized map[string]string
+	// mediaURLs holds presigned range-seekable URLs (issue #243) keyed by
+	// MediaRef so every audio/video time-window of one S3 source presigns once
+	// per batch and ffmpeg reads each window over HTTP from the shared URL.
+	mediaURLs map[string]string
 	// cleanups are the Localize cleanup funcs to invoke at batch completion;
 	// holding them here (rather than deferring per call) keeps the materialized
 	// path alive for sibling chunks and removes temp files exactly once.
@@ -268,6 +283,7 @@ func newMediaBatchCache() *mediaBatchCache {
 	return &mediaBatchCache{
 		wholeFile: make(map[string][]byte),
 		localized: make(map[string]string),
+		mediaURLs: make(map[string]string),
 	}
 }
 
@@ -286,6 +302,7 @@ func (c *mediaBatchCache) cleanup() {
 	c.cleanups = nil
 	c.wholeFile = nil
 	c.localized = nil
+	c.mediaURLs = nil
 }
 
 // readWholeMedia returns the entire object at ref, reading it through the corpus
@@ -331,6 +348,32 @@ func (c *mediaBatchCache) localize(ctx context.Context, fsys corpusfs.CorpusFS, 
 	return path, func() {}, nil
 }
 
+// mediaURL returns a range-seekable URL for ref when the corpus backend supports
+// the MediaURLProvider capability (issue #243), presigning only on the first
+// request for that ref within the batch and reusing it for sibling time-windows.
+// ok=false means the backend cannot produce a URL (e.g. LocalFS) and the caller
+// must fall back to localize. A nil cache presigns per call (no memoization) so
+// the helper is usable without a batch context.
+func (c *mediaBatchCache) mediaURL(ctx context.Context, fsys corpusfs.CorpusFS, ref string) (string, bool, error) {
+	provider, ok := fsys.(corpusfs.MediaURLProvider)
+	if !ok {
+		return "", false, nil
+	}
+	if c != nil {
+		if url, hit := c.mediaURLs[ref]; hit {
+			return url, true, nil
+		}
+	}
+	url, ok, err := provider.MediaURL(ctx, ref)
+	if err != nil || !ok {
+		return "", ok, err
+	}
+	if c != nil {
+		c.mediaURLs[ref] = url
+	}
+	return url, true, nil
+}
+
 // fatalIfEscape promotes a corpus-root traversal error to ErrFatal so the worker
 // treats a stored ref that escapes the corpus root as a permanent, non-retryable
 // failure (preserving the pre-CorpusFS contract where the escape check returned
@@ -362,9 +405,17 @@ func readWholeMedia(ctx context.Context, fsys corpusfs.CorpusFS, ref string) ([]
 // one-page PDF (SPEC 8.1.7). A missing/invalid page span is a fatal task error
 // so a span/content mismatch surfaces instead of silently embedding page 1.
 //
-// pdfutil.ExtractPage operates on the whole file in memory, so the entire PDF is
-// read via Open even though only one page is embedded; this matches the prior
-// behavior (it previously read the whole file too).
+// Whole-object read (issue #243, deliberate): pdfutil.ExtractPage operates on the
+// whole file. Passing a CorpusFS.Open io.ReadSeeker straight through to pdfcpu to
+// let S3 range-GET only the page's objects was evaluated and rejected: pdfcpu's
+// Trim parses the full cross-reference table and re-reads the file many times over
+// (measured reaching 100% of the object and ~36x the file size in total bytes),
+// so a ReadSeeker path would issue a storm of range GETs each re-fetching most of
+// the object — strictly worse than one whole-object download. We therefore keep
+// the whole-file read, but it is read exactly once per PDF per batch via the
+// per-batch cache (issue #279), so every page of one PDF shares a single Open.
+// Audio/video, by contrast, DO range-read on S3 (see loadMediaSegment) because
+// ffmpeg can byte-range-seek a presigned URL.
 func (w *EmbeddingWorker) loadPDFPage(ctx context.Context, t model.ChunkTask, fsys corpusfs.CorpusFS, ref string, cache *mediaBatchCache) ([]byte, error) {
 	if !strings.EqualFold(strings.TrimSpace(t.Metadata.Span.Kind), "page") || t.Metadata.Span.Page < 1 {
 		return nil, fmt.Errorf("%w: pdf media chunk %d has invalid page span", ErrFatal, t.Metadata.ChunkID)
@@ -383,14 +434,52 @@ func (w *EmbeddingWorker) loadPDFPage(ctx context.Context, t model.ChunkTask, fs
 // loadMediaSegment cuts the chunk's single time window (from its `time` span)
 // out of the source media (SPEC 8.1.7). A missing/invalid time span is a fatal
 // task error so a span/content mismatch surfaces instead of embedding the wrong
-// segment. The source is Localized to a real path first (through the per-batch
-// cache so sibling time-windows reuse one download) because ffmpeg cannot read
-// from an io.Reader.
+// segment.
+//
+// Range-read (issue #243): when the corpus backend exposes a range-seekable URL
+// (S3FS via MediaURLProvider/presigned GetObject), ffmpeg reads the window over
+// HTTP and pulls only the bytes around [start,end) plus the container index — the
+// whole object is NOT downloaded. The presigned URL is memoized per MediaRef in
+// the per-batch cache (issue #279), so every time-window of one source presigns
+// once. When the backend cannot produce a URL (LocalFS, or an S3FS built without
+// a presigner) the worker falls back to Localize (a whole-object download for S3,
+// a no-op for LocalFS) because ffmpeg cannot read from an io.Reader — that path
+// is byte-for-byte the historical behavior.
 func (w *EmbeddingWorker) loadMediaSegment(ctx context.Context, t model.ChunkTask, fsys corpusfs.CorpusFS, ref string, cache *mediaBatchCache) ([]byte, error) {
 	span := t.Metadata.Span
 	if !strings.EqualFold(strings.TrimSpace(span.Kind), "time") || span.StartMS < 0 || span.EndMS <= span.StartMS {
 		return nil, fmt.Errorf("%w: %s media chunk %d has invalid time span", ErrFatal, strings.ToLower(t.Modality), t.Metadata.ChunkID)
 	}
+
+	// Prefer a range-seekable URL when the backend can presign one.
+	if url, ok, uerr := cache.mediaURL(ctx, fsys, ref); uerr != nil {
+		return nil, fmt.Errorf("read media %q: %w", ref, uerr)
+	} else if ok {
+		return w.extractSegmentFromURL(ctx, url, ref, span)
+	}
+
+	// Fall back to a localized path (whole-object download on S3, no-op locally).
+	return w.extractSegmentFromPath(ctx, fsys, ref, span, cache)
+}
+
+// extractSegmentFromURL cuts the [start,end) window from a range-seekable URL via
+// ffmpeg-over-HTTP. srcExt is derived from the MediaRef so the clip keeps the
+// source container/MIME (a presigned URL's path/query is not a reliable hint).
+func (w *EmbeddingWorker) extractSegmentFromURL(ctx context.Context, url, ref string, span model.Span) ([]byte, error) {
+	extract := w.ExtractSegmentURLFunc
+	if extract == nil {
+		extract = avutil.ExtractSegmentURL
+	}
+	data, err := extract(ctx, url, filepath.Ext(ref), span.StartMS, span.EndMS)
+	if err != nil {
+		return nil, fmt.Errorf("%w: extract %q segment [%d,%d): %v", ErrFatal, ref, span.StartMS, span.EndMS, err)
+	}
+	return data, nil
+}
+
+// extractSegmentFromPath cuts the [start,end) window from a localized filesystem
+// path (the historical, whole-object-download-on-S3 fallback).
+func (w *EmbeddingWorker) extractSegmentFromPath(ctx context.Context, fsys corpusfs.CorpusFS, ref string, span model.Span, cache *mediaBatchCache) ([]byte, error) {
 	localPath, cleanup, err := cache.localize(ctx, fsys, ref)
 	if err != nil {
 		return nil, fmt.Errorf("read media %q: %w", ref, err)

--- a/internal/pdfutil/pdfutil.go
+++ b/internal/pdfutil/pdfutil.go
@@ -37,6 +37,16 @@ func PageCount(data []byte) (int, error) {
 
 // ExtractPage returns a single-page PDF containing the given 1-based page of
 // data, so it can be embedded on its own with a precise page span.
+//
+// Whole-file input (issue #243, deliberate): this takes the full PDF bytes rather
+// than an io.ReadSeeker that an S3 backend could range-GET. A ReadSeeker path was
+// evaluated and rejected — pdfcpu's Trim parses the entire cross-reference table
+// and re-reads the source many times over (measured reaching 100% of the object
+// and ~36x the file size in total reads), so streaming it over range GETs would
+// be strictly worse than one whole-object download. The caller reads the whole
+// file once and caches it per PDF per batch (see the embedding worker's
+// loadPDFPage), which is the right shape for pdfcpu. Audio/video, by contrast, do
+// range-read on S3 via ffmpeg-over-HTTP (avutil.ExtractSegmentURL).
 func ExtractPage(data []byte, page int) ([]byte, error) {
 	if page < 1 {
 		return nil, fmt.Errorf("pdf page must be >= 1, got %d", page)

--- a/tests/avutil/extractsegmenturl_test.go
+++ b/tests/avutil/extractsegmenturl_test.go
@@ -1,0 +1,62 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/avutil"
+)
+
+// TestExtractSegmentURL_RequiresHTTPURL pins the URL guard (issue #243):
+// ExtractSegmentURL only accepts http(s) inputs (the schemes ffmpeg can
+// byte-range-seek), so a non-URL source is rejected before any binary is needed.
+func TestExtractSegmentURL_RequiresHTTPURL(t *testing.T) {
+	for _, in := range []string{"", "/local/path.mp4", "file:///x.mp4", "s3://bucket/key.mp4", "ftp://h/x"} {
+		if _, err := avutil.ExtractSegmentURL(context.Background(), in, ".mp4", 0, 1000); err == nil {
+			t.Errorf("ExtractSegmentURL(%q) = nil error, want non-http rejection", in)
+		}
+	}
+}
+
+// TestExtractSegmentURL_InvalidRange validates the half-open window guard runs
+// for the URL path too, before any binary is needed.
+func TestExtractSegmentURL_InvalidRange(t *testing.T) {
+	for _, tc := range []struct{ start, end int }{
+		{0, 0}, {5, 5}, {10, 3}, {-1, 5},
+	} {
+		_, err := avutil.ExtractSegmentURL(context.Background(), "https://h/clip.mp4", ".mp4", tc.start, tc.end)
+		if err == nil {
+			t.Errorf("ExtractSegmentURL(_, [%d,%d)) = nil error, want range error", tc.start, tc.end)
+		}
+	}
+}
+
+// TestExtractSegmentURL_ToolNotFound confirms a missing ffmpeg is reported
+// distinctly for the URL path, matching ExtractSegment, so callers can skip
+// gracefully. The guards pass (valid https URL + valid range) so the code reaches
+// the ffmpeg LookPath.
+func TestExtractSegmentURL_ToolNotFound(t *testing.T) {
+	t.Setenv("PATH", "")
+	_, err := avutil.ExtractSegmentURL(context.Background(), "https://h/clip.mp4", ".mp4", 0, 1000)
+	if !errors.Is(err, avutil.ErrToolNotFound) {
+		t.Errorf("ExtractSegmentURL with empty PATH = %v, want ErrToolNotFound", err)
+	}
+}
+
+// TestExtractSegmentURL_AcceptsHTTPAndHTTPS confirms both http and https pass the
+// scheme guard (they fail later only at ffmpeg, which is the next step).
+func TestExtractSegmentURL_AcceptsHTTPAndHTTPS(t *testing.T) {
+	t.Setenv("PATH", "")
+	for _, in := range []string{"http://h/clip.mp4", "https://h/clip.mp4"} {
+		_, err := avutil.ExtractSegmentURL(context.Background(), in, ".mp4", 0, 1000)
+		// With an empty PATH the scheme guard passed and we reached ffmpeg lookup.
+		if err == nil || !errors.Is(err, avutil.ErrToolNotFound) {
+			t.Errorf("ExtractSegmentURL(%q) = %v, want to pass scheme guard and reach ErrToolNotFound", in, err)
+		}
+		if strings.Contains(err.Error(), "requires an http") {
+			t.Errorf("ExtractSegmentURL(%q) wrongly rejected a valid scheme: %v", in, err)
+		}
+	}
+}

--- a/tests/corpusfs/mediaurl_test.go
+++ b/tests/corpusfs/mediaurl_test.go
@@ -1,0 +1,104 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/corpusfs"
+)
+
+// TestS3FS_MediaURL_PresignsKeyedByPrefix verifies the MediaURLProvider
+// capability (issue #243): S3FS.MediaURL presigns a URL for the full object key
+// (prefix + relPath) and reports ok=true. The presigner is injected so the test
+// stays network-free and asserts the exact (bucket, key) handed to it.
+func TestS3FS_MediaURL_PresignsKeyedByPrefix(t *testing.T) {
+	objects := map[string][]byte{"media/clip.mp4": []byte("DATA")}
+	client := &fakeS3{objects: objects}
+
+	var gotBucket, gotKey string
+	presign := func(_ context.Context, bucket, key string) (string, error) {
+		gotBucket, gotKey = bucket, key
+		return "https://signed.example/" + key + "?sig=abc", nil
+	}
+	fsys, err := corpusfs.NewS3FSWithPresignForTest(client, corpusfs.S3Config{
+		Bucket: "my-bucket", Prefix: "media",
+	}, presign)
+	if err != nil {
+		t.Fatalf("NewS3FSWithPresignForTest: %v", err)
+	}
+
+	provider, ok := interface{}(fsys).(corpusfs.MediaURLProvider)
+	if !ok {
+		t.Fatal("*S3FS must implement corpusfs.MediaURLProvider")
+	}
+	url, ok, err := provider.MediaURL(context.Background(), "clip.mp4")
+	if err != nil {
+		t.Fatalf("MediaURL: %v", err)
+	}
+	if !ok {
+		t.Fatal("MediaURL ok=false, want true (presigner configured)")
+	}
+	if gotBucket != "my-bucket" {
+		t.Errorf("presigned bucket = %q, want my-bucket", gotBucket)
+	}
+	if gotKey != "media/clip.mp4" {
+		t.Errorf("presigned key = %q, want media/clip.mp4", gotKey)
+	}
+	if !strings.HasPrefix(url, "https://signed.example/media/clip.mp4") {
+		t.Errorf("url = %q, want the presigned URL", url)
+	}
+}
+
+// TestS3FS_MediaURL_NoPresignerReportsNotOK confirms that an S3FS built without a
+// presigner (e.g. a stub client that cannot mint a *s3.PresignClient) reports
+// ok=false with no error so the caller falls back to Localize.
+func TestS3FS_MediaURL_NoPresignerReportsNotOK(t *testing.T) {
+	client := &fakeS3{objects: map[string][]byte{"clip.mp4": []byte("DATA")}}
+	fsys, err := corpusfs.NewS3FS(client, corpusfs.S3Config{Bucket: "b"})
+	if err != nil {
+		t.Fatalf("NewS3FS: %v", err)
+	}
+	provider, ok := interface{}(fsys).(corpusfs.MediaURLProvider)
+	if !ok {
+		t.Fatal("*S3FS must implement corpusfs.MediaURLProvider")
+	}
+	url, ok, err := provider.MediaURL(context.Background(), "clip.mp4")
+	if err != nil {
+		t.Fatalf("MediaURL error = %v, want nil", err)
+	}
+	if ok {
+		t.Fatal("MediaURL ok=true, want false (no presigner configured)")
+	}
+	if url != "" {
+		t.Errorf("url = %q, want empty", url)
+	}
+}
+
+// TestS3FS_MediaURL_PresignErrorPropagates confirms a presigner failure surfaces
+// as a non-nil error (ok=false) so the worker can classify it.
+func TestS3FS_MediaURL_PresignErrorPropagates(t *testing.T) {
+	client := &fakeS3{objects: map[string][]byte{"clip.mp4": []byte("DATA")}}
+	presign := func(context.Context, string, string) (string, error) {
+		return "", errors.New("boom")
+	}
+	fsys, err := corpusfs.NewS3FSWithPresignForTest(client, corpusfs.S3Config{Bucket: "b"}, presign)
+	if err != nil {
+		t.Fatalf("NewS3FSWithPresignForTest: %v", err)
+	}
+	provider := interface{}(fsys).(corpusfs.MediaURLProvider)
+	if _, ok, err := provider.MediaURL(context.Background(), "clip.mp4"); err == nil || ok {
+		t.Fatalf("MediaURL = (ok=%v, err=%v), want (false, non-nil)", ok, err)
+	}
+}
+
+// TestLocalFS_NotMediaURLProvider pins that LocalFS does NOT implement
+// MediaURLProvider, so a local-backed worker always uses the Localize path and
+// its behavior is unchanged by issue #243.
+func TestLocalFS_NotMediaURLProvider(t *testing.T) {
+	fsys := corpusfs.NewLocalFS(t.TempDir())
+	if _, ok := interface{}(fsys).(corpusfs.MediaURLProvider); ok {
+		t.Fatal("LocalFS must NOT implement MediaURLProvider (no URL for a local file)")
+	}
+}

--- a/tests/index/loadmedia_url_test.go
+++ b/tests/index/loadmedia_url_test.go
@@ -1,0 +1,262 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/corpusfs"
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// urlCorpusFS is a fake CorpusFS that ALSO implements corpusfs.MediaURLProvider,
+// modeling an S3 backend that can presign a range-seekable URL. It records
+// MediaURL/Localize/Open call counts per relPath so a test can assert that
+// audio/video segment extraction prefers the URL (range-read) path and never
+// downloads the whole object via Localize (issue #243), and that the URL is
+// presigned exactly once per MediaRef within a batch (issue #279 cache).
+type urlCorpusFS struct {
+	mu          sync.Mutex
+	contents    map[string][]byte
+	urlCalls    map[string]int
+	localCalls  map[string]int
+	openCalls   map[string]int
+	urlPrefix   string
+	mediaURLErr error
+	noURL       bool // when true, MediaURL reports ok=false (force the fallback)
+}
+
+func newURLCorpusFS(contents map[string][]byte) *urlCorpusFS {
+	return &urlCorpusFS{
+		contents:   contents,
+		urlCalls:   map[string]int{},
+		localCalls: map[string]int{},
+		openCalls:  map[string]int{},
+		urlPrefix:  "https://example-bucket.s3.amazonaws.com/",
+	}
+}
+
+func (f *urlCorpusFS) Walk(context.Context, string, corpusfs.Options) ([]corpusfs.DiscoveredFile, error) {
+	return nil, errors.New("not used")
+}
+
+func (f *urlCorpusFS) Open(_ context.Context, relPath string) (io.ReadSeekCloser, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.openCalls[relPath]++
+	data, ok := f.contents[relPath]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	return nopSeekCloser{bytes.NewReader(data)}, nil
+}
+
+func (f *urlCorpusFS) Localize(_ context.Context, relPath string) (string, func(), error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.localCalls[relPath]++
+	// A whole-object download would happen here on real S3 — the URL path must
+	// avoid reaching this for audio/video, so returning an error makes any
+	// accidental fallback loud.
+	return "", nil, errors.New("urlCorpusFS.Localize must not be used when MediaURL is available")
+}
+
+func (f *urlCorpusFS) MediaURL(_ context.Context, relPath string) (string, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.urlCalls[relPath]++
+	if f.mediaURLErr != nil {
+		return "", false, f.mediaURLErr
+	}
+	if f.noURL {
+		return "", false, nil
+	}
+	if _, ok := f.contents[relPath]; !ok {
+		return "", false, os.ErrNotExist
+	}
+	return f.urlPrefix + relPath, true, nil
+}
+
+func (f *urlCorpusFS) urls(relPath string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.urlCalls[relPath]
+}
+
+func (f *urlCorpusFS) localizes(relPath string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.localCalls[relPath]
+}
+
+// TestEmbeddingWorker_AudioVideo_RangeReadsViaURL pins issue #243: when the
+// corpus backend can presign a range-seekable URL, audio/video segment extraction
+// goes through the URL (HTTP range-read) path, NOT Localize (whole-object
+// download). The extractor receives the presigned URL and the source extension.
+func TestEmbeddingWorker_AudioVideo_RangeReadsViaURL(t *testing.T) {
+	fsys := newURLCorpusFS(map[string][]byte{"clip.mp4": []byte("FULLVIDEO")})
+
+	var gotURL, gotExt string
+	var gotStart, gotEnd int
+	emb := &fakeMultimodalEmbedder{mediaVecs: [][]float32{{0.6, 0.8}}}
+	worker := &index.EmbeddingWorker{
+		Source: &fakeChunkSource{tasks: []model.ChunkTask{
+			avTask(11, "clip.mp4", "video", model.Span{Kind: "time", StartMS: 1000, EndMS: 3000}),
+		}},
+		Index: index.NewHNSWIndex(""), Embedder: emb,
+		Corpus: fsys, RootDir: t.TempDir(), BatchSize: 4, ModelForText: "gemini-embedding-2",
+		ExtractSegmentURLFunc: func(_ context.Context, url, ext string, s, e int) ([]byte, error) {
+			gotURL, gotExt, gotStart, gotEnd = url, ext, s, e
+			return []byte("URLSEG"), nil
+		},
+		ExtractSegmentFunc: func(context.Context, string, int, int) ([]byte, error) {
+			t.Fatal("local-path extractor must not be called when a presigned URL is available")
+			return nil, nil
+		},
+	}
+
+	n, err := worker.RunOnce(context.Background(), "text")
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("indexed = %d, want 1", n)
+	}
+	if !strings.HasPrefix(gotURL, "https://") || !strings.HasSuffix(gotURL, "clip.mp4") {
+		t.Fatalf("extractor URL = %q, want a presigned https URL for clip.mp4", gotURL)
+	}
+	if gotExt != ".mp4" {
+		t.Errorf("source ext = %q, want .mp4", gotExt)
+	}
+	if gotStart != 1000 || gotEnd != 3000 {
+		t.Errorf("segment span = [%d,%d), want [1000,3000)", gotStart, gotEnd)
+	}
+	if got := fsys.localizes("clip.mp4"); got != 0 {
+		t.Fatalf("Localize(clip.mp4) called %d times, want 0 (URL path must not download the whole object)", got)
+	}
+	if len(emb.gotMedia) != 1 || string(emb.gotMedia[0].Data) != "URLSEG" {
+		t.Fatalf("EmbedMedia got %+v, want the URL-extracted segment", emb.gotMedia)
+	}
+}
+
+// TestEmbeddingWorker_AudioVideo_URLPresignedOncePerBatch pins that the presigned
+// URL is memoized in the per-batch cache (issue #279): three time-windows of the
+// same MediaRef presign exactly once and all extract from that one URL.
+func TestEmbeddingWorker_AudioVideo_URLPresignedOncePerBatch(t *testing.T) {
+	fsys := newURLCorpusFS(map[string][]byte{"clip.mp4": []byte("FULLVIDEO")})
+
+	var extractURLs []string
+	emb := &fakeMultimodalEmbedder{mediaVecs: [][]float32{{1, 0}, {0, 1}, {1, 1}}}
+	worker := &index.EmbeddingWorker{
+		Source: &fakeChunkSource{tasks: []model.ChunkTask{
+			avTask(1, "clip.mp4", "video", model.Span{Kind: "time", StartMS: 0, EndMS: 1000}),
+			avTask(2, "clip.mp4", "video", model.Span{Kind: "time", StartMS: 1000, EndMS: 2000}),
+			avTask(3, "clip.mp4", "video", model.Span{Kind: "time", StartMS: 2000, EndMS: 3000}),
+		}},
+		Index: index.NewHNSWIndex(""), Embedder: emb,
+		Corpus: fsys, RootDir: t.TempDir(), BatchSize: 8, ModelForText: "gemini-embedding-2",
+		ExtractSegmentURLFunc: func(_ context.Context, url, _ string, _, _ int) ([]byte, error) {
+			extractURLs = append(extractURLs, url)
+			return []byte("SEG"), nil
+		},
+	}
+
+	n, err := worker.RunOnce(context.Background(), "text")
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if n != 3 {
+		t.Fatalf("indexed = %d, want 3", n)
+	}
+	if got := fsys.urls("clip.mp4"); got != 1 {
+		t.Fatalf("MediaURL(clip.mp4) called %d times, want 1 (per-batch cache should presign once)", got)
+	}
+	if got := fsys.localizes("clip.mp4"); got != 0 {
+		t.Fatalf("Localize(clip.mp4) called %d times, want 0", got)
+	}
+	if len(extractURLs) != 3 {
+		t.Fatalf("extractor called %d times, want 3", len(extractURLs))
+	}
+	for i, u := range extractURLs {
+		if u != extractURLs[0] {
+			t.Fatalf("window %d extracted from %q, want shared URL %q", i, u, extractURLs[0])
+		}
+	}
+}
+
+// TestEmbeddingWorker_AudioVideo_FallsBackToLocalizeWithoutURL confirms that a
+// backend which cannot presign a URL (ok=false) still works via the historical
+// Localize path — preserving LocalFS-style behavior. countingCorpusFS does NOT
+// implement MediaURLProvider, so the URL path is skipped entirely.
+func TestEmbeddingWorker_AudioVideo_FallsBackToLocalizeWithoutURL(t *testing.T) {
+	fsys := newCountingCorpusFS(map[string][]byte{"clip.mp4": []byte("FULLVIDEO")})
+
+	var localPaths []string
+	emb := &fakeMultimodalEmbedder{mediaVecs: [][]float32{{0.6, 0.8}}}
+	worker := &index.EmbeddingWorker{
+		Source: &fakeChunkSource{tasks: []model.ChunkTask{
+			avTask(12, "clip.mp4", "video", model.Span{Kind: "time", StartMS: 0, EndMS: 1000}),
+		}},
+		Index: index.NewHNSWIndex(""), Embedder: emb,
+		Corpus: fsys, RootDir: t.TempDir(), BatchSize: 4, ModelForText: "gemini-embedding-2",
+		ExtractSegmentFunc: func(_ context.Context, path string, _, _ int) ([]byte, error) {
+			localPaths = append(localPaths, path)
+			return []byte("LOCALSEG"), nil
+		},
+		ExtractSegmentURLFunc: func(context.Context, string, string, int, int) ([]byte, error) {
+			t.Fatal("URL extractor must not be called when the backend cannot presign a URL")
+			return nil, nil
+		},
+	}
+
+	n, err := worker.RunOnce(context.Background(), "text")
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("indexed = %d, want 1", n)
+	}
+	if got := fsys.localizes("clip.mp4"); got != 1 {
+		t.Fatalf("Localize(clip.mp4) = %d, want 1 (fallback path)", got)
+	}
+	if len(localPaths) != 1 {
+		t.Fatalf("local extractor called %d times, want 1", len(localPaths))
+	}
+	if len(emb.gotMedia) != 1 || string(emb.gotMedia[0].Data) != "LOCALSEG" {
+		t.Fatalf("EmbedMedia got %+v, want the Localize-extracted segment", emb.gotMedia)
+	}
+}
+
+// TestEmbeddingWorker_AudioVideo_MediaURLErrorIsRetryable confirms a presign
+// failure surfaces as a (retryable) read error, not a fatal one — a transient
+// presign hiccup should leave the chunk pending rather than mark it failed.
+func TestEmbeddingWorker_AudioVideo_MediaURLErrorIsRetryable(t *testing.T) {
+	fsys := newURLCorpusFS(map[string][]byte{"clip.mp4": []byte("FULLVIDEO")})
+	fsys.mediaURLErr = errors.New("presign throttled")
+
+	worker := &index.EmbeddingWorker{
+		Source: &fakeChunkSource{tasks: []model.ChunkTask{
+			avTask(13, "clip.mp4", "video", model.Span{Kind: "time", StartMS: 0, EndMS: 1000}),
+		}},
+		Index: index.NewHNSWIndex(""), Embedder: &fakeMultimodalEmbedder{mediaVecs: [][]float32{{1, 0}}},
+		Corpus: fsys, RootDir: t.TempDir(), BatchSize: 4, ModelForText: "gemini-embedding-2",
+		ExtractSegmentURLFunc: func(context.Context, string, string, int, int) ([]byte, error) {
+			t.Fatal("extractor must not be called when MediaURL errors")
+			return nil, nil
+		},
+	}
+
+	_, err := worker.RunOnce(context.Background(), "text")
+	if err == nil {
+		t.Fatal("expected an error when MediaURL fails")
+	}
+	if errors.Is(err, index.ErrFatal) {
+		t.Fatalf("MediaURL failure should be retryable, got fatal: %v", err)
+	}
+}

--- a/tests/index/loadmedia_url_test.go
+++ b/tests/index/loadmedia_url_test.go
@@ -240,11 +240,12 @@ func TestEmbeddingWorker_AudioVideo_MediaURLErrorIsRetryable(t *testing.T) {
 	fsys := newURLCorpusFS(map[string][]byte{"clip.mp4": []byte("FULLVIDEO")})
 	fsys.mediaURLErr = errors.New("presign throttled")
 
+	src := &fakeChunkSource{tasks: []model.ChunkTask{
+		avTask(13, "clip.mp4", "video", model.Span{Kind: "time", StartMS: 0, EndMS: 1000}),
+	}}
 	worker := &index.EmbeddingWorker{
-		Source: &fakeChunkSource{tasks: []model.ChunkTask{
-			avTask(13, "clip.mp4", "video", model.Span{Kind: "time", StartMS: 0, EndMS: 1000}),
-		}},
-		Index: index.NewHNSWIndex(""), Embedder: &fakeMultimodalEmbedder{mediaVecs: [][]float32{{1, 0}}},
+		Source: src,
+		Index:  index.NewHNSWIndex(""), Embedder: &fakeMultimodalEmbedder{mediaVecs: [][]float32{{1, 0}}},
 		Corpus: fsys, RootDir: t.TempDir(), BatchSize: 4, ModelForText: "gemini-embedding-2",
 		ExtractSegmentURLFunc: func(context.Context, string, string, int, int) ([]byte, error) {
 			t.Fatal("extractor must not be called when MediaURL errors")
@@ -258,5 +259,41 @@ func TestEmbeddingWorker_AudioVideo_MediaURLErrorIsRetryable(t *testing.T) {
 	}
 	if errors.Is(err, index.ErrFatal) {
 		t.Fatalf("MediaURL failure should be retryable, got fatal: %v", err)
+	}
+	// Retryable means the chunk stays pending, NOT marked permanently failed,
+	// so a later cycle (with a fresh presigned URL) can embed it.
+	if len(src.failedLabels) != 0 {
+		t.Fatalf("chunk was marked failed %v on a transient presign error; want left pending", src.failedLabels)
+	}
+}
+
+// TestEmbeddingWorker_AudioVideo_URLExtractErrorIsRetryable pins that an
+// extraction failure over the presigned URL (e.g. the URL expired mid-batch and
+// ffmpeg gets a 403) leaves the chunk pending rather than permanently failed, so
+// the next cycle re-presigns and recovers it (issue #243).
+func TestEmbeddingWorker_AudioVideo_URLExtractErrorIsRetryable(t *testing.T) {
+	fsys := newURLCorpusFS(map[string][]byte{"clip.mp4": []byte("FULLVIDEO")})
+
+	src := &fakeChunkSource{tasks: []model.ChunkTask{
+		avTask(14, "clip.mp4", "video", model.Span{Kind: "time", StartMS: 0, EndMS: 1000}),
+	}}
+	worker := &index.EmbeddingWorker{
+		Source: src,
+		Index:  index.NewHNSWIndex(""), Embedder: &fakeMultimodalEmbedder{mediaVecs: [][]float32{{1, 0}}},
+		Corpus: fsys, RootDir: t.TempDir(), BatchSize: 4, ModelForText: "gemini-embedding-2",
+		ExtractSegmentURLFunc: func(context.Context, string, string, int, int) ([]byte, error) {
+			return nil, errors.New("Server returned 403 Forbidden")
+		},
+	}
+
+	_, err := worker.RunOnce(context.Background(), "text")
+	if err == nil {
+		t.Fatal("expected an error when URL extraction fails")
+	}
+	if errors.Is(err, index.ErrFatal) {
+		t.Fatalf("URL extract failure should be retryable, got fatal: %v", err)
+	}
+	if len(src.failedLabels) != 0 {
+		t.Fatalf("chunk was marked failed %v on an expired-URL extract error; want left pending", src.failedLabels)
 	}
 }


### PR DESCRIPTION
Closes #243. Part of epic #250.

## Summary
Phase 2 of CorpusFS (builds on #242): per-chunk media reads should pull only the needed bytes from S3 instead of downloading the whole object per chunk. This implements the achievable win honestly and documents the one that isn't.

### Which media paths now range-read vs. still download whole

| Modality | S3 behavior now | Why |
|---|---|---|
| **audio / video** | **Range-read over HTTP** — ffmpeg byte-range-seeks a presigned URL and pulls only the `[start,end)` window + container index. No whole-object download. | ffmpeg's http protocol supports byte-range seeking; S3 presigned GETs advertise range support. |
| **PDF (per page)** | **Whole-object read (deliberate, unchanged)** | pdfcpu's `Trim` parses the full cross-reference table and re-reads the source many times over — measured reaching **100% of the object and ~36x the file size in total reads**. A `ReadSeeker`/range-GET path would issue a storm of range GETs each re-fetching most of the object, strictly **worse** than one whole-object download. Kept whole-read; still read **once per PDF per batch** via the #279 cache. |
| **image / other** | Whole-object read (unchanged) | Whole file is the unit. |

This was assessed empirically (a throwaway experiment instrumenting pdfcpu's `Trim` over a `ReadSeeker`), not assumed.

## New CorpusFS capability
`corpusfs.MediaURLProvider` — an **optional** interface (`MediaURL(ctx, relPath) (url, ok, err)`):
- **S3FS** implements it via a presigned `GetObject` URL (15‑min expiry). The presigner is injected: the factory builds one from the concrete `*s3.Client` (`s3.NewPresignClient`); a stub client yields no presigner so `MediaURL` reports `ok=false`.
- **LocalFS** deliberately does **not** implement it (a local file has no URL), so local corpora always take the `Localize` path — **byte-for-byte unchanged**.

## How it composes with the #279 per-batch cache
The presigned URL is memoized per `MediaRef` in the same `mediaBatchCache`, so every time-window of one source **presigns exactly once per batch** (mirrors the existing whole-file / Localize memoization). `cleanup()` resets it with the rest.

## Error handling
- A presign failure surfaces as a normal (retryable) read error — a transient hiccup leaves the chunk pending, not fatally failed.
- `ErrPathEscapesRoot` → `ErrFatal` classification and all fatal/retryable semantics are preserved.

## Fallback
When the backend can't presign (LocalFS, or an S3FS without a presigner), the worker falls back to `Localize` (whole-object download on S3, no-op locally) exactly as before — ffmpeg can't read an `io.Reader`.

## Scope
Changes limited to `internal/avutil`, `internal/pdfutil`, `internal/corpusfs`, `internal/index/embedding_worker.go`, plus new tests under `tests/`. No changes to ingest, config, retrieval, or mcp. dirstral-spec not re-pinned.

## Tests (all network-free, no ffmpeg required)
- `tests/index/loadmedia_url_test.go`: audio/video uses the URL path (asserts `Localize` is never called); URL presigned once per batch and shared across windows; falls back to `Localize` when the backend has no URL capability; `MediaURL` error stays retryable.
- `tests/corpusfs/mediaurl_test.go`: `S3FS.MediaURL` presigns the full `prefix+relPath` key; `ok=false` without a presigner; presign error propagates; `LocalFS` is not a `MediaURLProvider`.
- `tests/avutil/extractsegmenturl_test.go`: scheme guard (http/https only), range guard, `ErrToolNotFound`.

`make check` passes locally (fmt + vet + lint + cyclo≤15 + ineffassign + misspell + test + build + release-tool tests). Pure-Go, `CGO_ENABLED=0`.