### PR TITLE
feat(ingest): incremental S3 change detection via ETag/size (spec §7.8.3)

### DIFF
--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -763,6 +763,16 @@ func (s *Service) trySkipUnchangedRemoteDocument(ctx context.Context, f Discover
 	if !etagUnchanged(f, existing, forceReindex) {
 		return false, nil
 	}
+	// A media object's own ETag does not reflect changes to an adjacent subtitle
+	// sidecar (.srt/.vtt/.ttml): buildDocumentWithContent folds the sidecar
+	// fingerprint into ContentHash, but the ETag fast-path runs before that
+	// recompute. So a sidecar added/changed/removed while the media bytes are
+	// unchanged would be missed. Conservatively bypass the ETag skip for
+	// sidecar-capable media so the full read+hash path re-detects the sidecar
+	// (#253/#283 interaction). Non-media remote objects keep the fast path.
+	if isSidecarMediaType(ClassifyDocType(f.RelPath)) {
+		return false, nil
+	}
 	s.skipUnchangedRemoteDocument(ctx, f, existing, seen)
 	return true, nil
 }

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -715,24 +715,129 @@ func (s *Service) runScan(ctx context.Context) error {
 	return s.markMissingAsDeleted(ctx, existing, seen)
 }
 
+// etagUnchanged reports whether a remote (object-store) source object can be
+// treated as unchanged without re-reading its bytes (SPEC §7.8.3, #245). The
+// ETag is the cheap change token for S3: when the discovered object carries a
+// non-empty ETag, a prior document recorded the same ETag and size, and that
+// document is healthy (active, not in error status), the object body has not
+// changed and a full GET + content_hash recompute is unnecessary.
+//
+// It is deliberately conservative and a strict no-op for local/NFS corpora,
+// whose DiscoveredFile.ETag is always empty: there the (size, mtime) pre-check
+// plus content_hash confirm path is left entirely intact. A forced reindex
+// always bypasses the skip so an operator can recover regardless of token state.
+func etagUnchanged(f DiscoveredFile, existing model.Document, forceReindex bool) bool {
+	if forceReindex {
+		return false
+	}
+	if strings.TrimSpace(f.ETag) == "" {
+		return false
+	}
+	if existing.Deleted || existing.Status == "error" {
+		return false
+	}
+	if strings.TrimSpace(existing.ETag) != strings.TrimSpace(f.ETag) {
+		return false
+	}
+	// Size is part of the cheap S3 signal alongside the ETag; a mismatch means
+	// the object differs even if a (truncated/legacy) ETag happens to collide.
+	return existing.SizeBytes == f.SizeBytes
+}
+
+// trySkipUnchangedRemoteDocument implements the remote (S3) incremental fast
+// path (SPEC §7.8.3, #245). It looks up the recorded document and, when the
+// object's ETag+size signal an unchanged body, records run-progress counters and
+// returns handled=true so the caller skips the GET + content_hash recompute. It
+// returns handled=false (no error) when the object is new, changed, or local
+// (empty ETag), letting the normal read/hash path run; a genuine store failure
+// is returned as an error. content_hash stays the canonical identity and the
+// stored row is left untouched on the skip path.
+func (s *Service) trySkipUnchangedRemoteDocument(ctx context.Context, f DiscoveredFile, forceReindex bool, seen map[string]struct{}) (bool, error) {
+	existing, err := s.store.GetDocumentByPath(ctx, f.RelPath)
+	if err != nil {
+		if isUnexpectedStoreErr(err) {
+			return false, fmt.Errorf("get existing document: %w", err)
+		}
+		return false, nil
+	}
+	if !etagUnchanged(f, existing, forceReindex) {
+		return false, nil
+	}
+	s.skipUnchangedRemoteDocument(ctx, f, existing, seen)
+	return true, nil
+}
+
+// skipUnchangedRemoteDocument records the run-progress counters for an object
+// whose ETag matched (so it was not re-read) and preserves the existing
+// behavior for archive containers, whose already-ingested members must be
+// retained in `seen` so markMissingAsDeleted does not tombstone them. The stored
+// document row is intentionally left untouched: its content_hash, ETag, and
+// representations are still valid. Counters mirror the unchanged-content path so
+// status totals stay consistent across runs.
+func (s *Service) skipUnchangedRemoteDocument(ctx context.Context, f DiscoveredFile, existing model.Document, seen map[string]struct{}) {
+	switch existing.Status {
+	case "ok":
+		s.addIndexed(1)
+	case "skipped", "secret_excluded":
+		s.addSkipped(1)
+	}
+	// An unchanged archive still owns its previously-extracted members; retain
+	// them so they are not treated as deletions this run.
+	if existing.DocType == "archive" && seen != nil {
+		s.retainArchiveMembers(ctx, f.RelPath, seen)
+	}
+}
+
+// persistBuildError records a document whose body could not be read/built as a
+// status="error" row (with the source ETag preserved) and returns the original
+// build error. The scan error counter is intentionally not incremented here:
+// runScan already counts any non-nil return value as an error.
+func (s *Service) persistBuildError(ctx context.Context, f DiscoveredFile, secretPatterns []*regexp.Regexp, buildErr error) error {
+	doc := model.Document{
+		RelPath:      f.RelPath,
+		DocType:      ClassifyDocType(f.RelPath),
+		SizeBytes:    f.SizeBytes,
+		MTimeUnix:    f.MTimeUnix,
+		ETag:         f.ETag,
+		Status:       "error",
+		Deleted:      false,
+		ErrorMessage: RedactSecretsInMessage(buildErr.Error(), secretPatterns),
+	}
+	if err := s.store.UpsertDocument(ctx, doc); err != nil {
+		return fmt.Errorf("upsert error document: %w", err)
+	}
+	return buildErr
+}
+
+// refreshDocID re-reads the persisted document after an upsert to obtain the
+// store-assigned DocID needed for downstream representation creation
+// (UpsertDocument returns only an error). A not-found result is ignored — it
+// would be surprising immediately after a successful upsert and is already
+// handled by the store; any other error is propagated.
+func (s *Service) refreshDocID(ctx context.Context, doc *model.Document) error {
+	updated, err := s.store.GetDocumentByPath(ctx, doc.RelPath)
+	if err == nil {
+		doc.DocID = updated.DocID
+		return nil
+	}
+	if isNotFoundError(err) {
+		return nil
+	}
+	return fmt.Errorf("fetch document after upsert: %w", err)
+}
+
 func (s *Service) processDocument(ctx context.Context, f DiscoveredFile, secretPatterns []*regexp.Regexp, forceReindex bool, seen map[string]struct{}) error {
+	// Remote (S3) incremental fast path (SPEC §7.8.3, #245): when the object's
+	// ETag+size match the recorded document, the body is unchanged, so skip the
+	// full GET + content_hash recompute entirely. No-op for local/NFS corpora
+	// (empty ETag) and under --force/reindex.
+	if handled, err := s.trySkipUnchangedRemoteDocument(ctx, f, forceReindex, seen); err != nil || handled {
+		return err
+	}
+
 	doc, content, buildErr := s.buildDocumentWithContent(ctx, f, secretPatterns)
 	if buildErr != nil {
-		doc = model.Document{
-			RelPath:      f.RelPath,
-			DocType:      ClassifyDocType(f.RelPath),
-			SizeBytes:    f.SizeBytes,
-			MTimeUnix:    f.MTimeUnix,
-			Status:       "error",
-			Deleted:      false,
-			ErrorMessage: RedactSecretsInMessage(buildErr.Error(), secretPatterns),
-		}
-		if err := s.store.UpsertDocument(ctx, doc); err != nil {
-			return fmt.Errorf("upsert error document: %w", err)
-		}
-		// s.addErrors(1) is intentionally omitted here; runScan already
-		// increments the error counter for any non-nil return value.
-		return buildErr
+		return s.persistBuildError(ctx, f, secretPatterns, buildErr)
 	}
 
 	existingDoc, err := s.store.GetDocumentByPath(ctx, doc.RelPath)
@@ -751,16 +856,8 @@ func (s *Service) processDocument(ctx context.Context, f DiscoveredFile, secretP
 		return fmt.Errorf("upsert document: %w", err)
 	}
 
-	// after upsert we need the persisted DocID for downstream
-	// representation creation.  The store implementation assigns the ID,
-	// but UpsertDocument only returns an error, so query the record again
-	// and update the local copy.  We ignore not-found errors because that
-	// would be surprising immediately after a successful upsert and is
-	// already handled by the store implementation.
-	if updated, err := s.store.GetDocumentByPath(ctx, doc.RelPath); err == nil {
-		doc.DocID = updated.DocID
-	} else if !isNotFoundError(err) {
-		return fmt.Errorf("fetch document after upsert: %w", err)
+	if err := s.refreshDocID(ctx, &doc); err != nil {
+		return err
 	}
 
 	switch doc.Status {
@@ -957,8 +1054,12 @@ func (s *Service) buildDocumentWithContent(ctx context.Context, f DiscoveredFile
 		DocType:   docType,
 		SizeBytes: f.SizeBytes,
 		MTimeUnix: f.MTimeUnix,
-		Status:    "ok",
-		Deleted:   false,
+		// Record the source's cheap change token (S3 ETag; empty for local/NFS)
+		// so a later incremental scan can skip the re-read when it is unchanged
+		// (SPEC §7.8.3, #245). content_hash below stays the canonical identity.
+		ETag:    f.ETag,
+		Status:  "ok",
+		Deleted: false,
 	}
 
 	rc, err := s.corpusFS().Open(ctx, f.RelPath)

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -16,8 +16,15 @@ type Document struct {
 	SizeBytes   int64
 	MTimeUnix   int64
 	ContentHash string
-	Status      string
-	Deleted     bool
+	// ETag is the remote backend's cheap change token (S3 object ETag) when the
+	// document was discovered from an object store. It is empty for local/NFS
+	// corpora. The ETag MUST NOT be treated as a content hash (multipart and
+	// SSE-KMS ETags are not MD5 of the body); it only decides whether a re-read
+	// + content_hash recompute is warranted (SPEC §7.8.3). content_hash stays the
+	// canonical identity.
+	ETag    string
+	Status  string
+	Deleted bool
 	// ErrorMessage is populated when Status == "error" with a short
 	// human-readable description of why ingest failed (extraction
 	// crash, representation generation failure, etc.). Surfaced in

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -356,6 +356,11 @@ func applyAdditiveColumnMigrations(ctx context.Context, db *sql.DB) error {
 		// keep modality='text', media_ref=''.
 		`ALTER TABLE chunks ADD COLUMN modality TEXT NOT NULL DEFAULT 'text'`,
 		`ALTER TABLE chunks ADD COLUMN media_ref TEXT NOT NULL DEFAULT ''`,
+		// etag stores a remote object store's cheap change token (S3 object
+		// ETag) so an incremental scan can skip re-reading + re-hashing an
+		// unchanged object (SPEC §7.8.3, #245). Empty for local/NFS corpora,
+		// whose change detection keeps using (size, mtime) then content_hash.
+		`ALTER TABLE documents ADD COLUMN etag TEXT NOT NULL DEFAULT ''`,
 	}
 	for _, stmt := range migrations {
 		if _, err := db.ExecContext(ctx, stmt); err != nil && !isDuplicateColumnError(err) {
@@ -402,6 +407,7 @@ CREATE TABLE IF NOT EXISTS documents (
   size_bytes INTEGER NOT NULL DEFAULT 0,
   mtime_unix INTEGER NOT NULL DEFAULT 0,
   content_hash TEXT NOT NULL DEFAULT '',
+  etag TEXT NOT NULL DEFAULT '',
   status TEXT NOT NULL DEFAULT 'ok',
   deleted INTEGER NOT NULL DEFAULT 0
 );
@@ -575,14 +581,15 @@ func (s *SQLiteStore) UpsertDocument(ctx context.Context, doc model.Document) er
 	// such two-phase write, so the always-replace semantics are correct.
 	_, err = db.ExecContext(
 		ctx,
-		`INSERT INTO documents(rel_path, doc_type, source_type, size_bytes, mtime_unix, content_hash, status, deleted, title, error_message)
-		 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`INSERT INTO documents(rel_path, doc_type, source_type, size_bytes, mtime_unix, content_hash, etag, status, deleted, title, error_message)
+		 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		 ON CONFLICT(rel_path) DO UPDATE SET
 		   doc_type=excluded.doc_type,
 		   source_type=excluded.source_type,
 		   size_bytes=excluded.size_bytes,
 		   mtime_unix=excluded.mtime_unix,
 		   content_hash=excluded.content_hash,
+		   etag=excluded.etag,
 		   status=excluded.status,
 		   deleted=excluded.deleted,
 		   title=CASE WHEN excluded.title <> '' THEN excluded.title ELSE documents.title END,
@@ -593,6 +600,7 @@ func (s *SQLiteStore) UpsertDocument(ctx context.Context, doc model.Document) er
 		doc.SizeBytes,
 		doc.MTimeUnix,
 		strings.TrimSpace(doc.ContentHash),
+		strings.TrimSpace(doc.ETag),
 		normalizeStatus(doc.Status),
 		boolToInt(doc.Deleted),
 		strings.TrimSpace(doc.Title),
@@ -1215,7 +1223,7 @@ func (s *SQLiteStore) GetDocumentByPath(ctx context.Context, relPath string) (mo
 	var deleted int
 	row := db.QueryRowContext(
 		ctx,
-		`SELECT doc_id, rel_path, doc_type, source_type, size_bytes, mtime_unix, content_hash, status, deleted, title, error_message
+		`SELECT doc_id, rel_path, doc_type, source_type, size_bytes, mtime_unix, content_hash, etag, status, deleted, title, error_message
 		 FROM documents WHERE rel_path = ?`,
 		normalizedPath,
 	)
@@ -1227,6 +1235,7 @@ func (s *SQLiteStore) GetDocumentByPath(ctx context.Context, relPath string) (mo
 		&doc.SizeBytes,
 		&doc.MTimeUnix,
 		&doc.ContentHash,
+		&doc.ETag,
 		&doc.Status,
 		&deleted,
 		&doc.Title,
@@ -1257,7 +1266,7 @@ func (s *SQLiteStore) ListFiles(ctx context.Context, prefix, glob string, limit,
 
 	normalizedPrefix := model.NormalizePathPrefix(prefix)
 
-	query := `SELECT doc_id, rel_path, doc_type, source_type, size_bytes, mtime_unix, content_hash, status, deleted, title, error_message FROM documents`
+	query := `SELECT doc_id, rel_path, doc_type, source_type, size_bytes, mtime_unix, content_hash, etag, status, deleted, title, error_message FROM documents`
 	where := []string{"deleted = 0"}
 	args := make([]any, 0, 4)
 	if normalizedPrefix != "" {
@@ -1290,6 +1299,7 @@ func (s *SQLiteStore) ListFiles(ctx context.Context, prefix, glob string, limit,
 			&doc.SizeBytes,
 			&doc.MTimeUnix,
 			&doc.ContentHash,
+			&doc.ETag,
 			&doc.Status,
 			&deleted,
 			&doc.Title,
@@ -1340,7 +1350,7 @@ func (s *SQLiteStore) RecentFailures(ctx context.Context, limit int) ([]model.Do
 
 	rows, err := db.QueryContext(
 		ctx,
-		`SELECT doc_id, rel_path, doc_type, source_type, size_bytes, mtime_unix, content_hash, status, deleted, title, error_message
+		`SELECT doc_id, rel_path, doc_type, source_type, size_bytes, mtime_unix, content_hash, etag, status, deleted, title, error_message
 		 FROM documents
 		 WHERE status = 'error' AND deleted = 0
 		 ORDER BY mtime_unix DESC, rel_path ASC
@@ -1364,6 +1374,7 @@ func (s *SQLiteStore) RecentFailures(ctx context.Context, limit int) ([]model.Do
 			&doc.SizeBytes,
 			&doc.MTimeUnix,
 			&doc.ContentHash,
+			&doc.ETag,
 			&doc.Status,
 			&deleted,
 			&doc.Title,

--- a/tests/ingest/etag_incremental_test.go
+++ b/tests/ingest/etag_incremental_test.go
@@ -396,3 +396,51 @@ func TestRunScan_LocalEmptyETagUsesContentHash(t *testing.T) {
 		t.Errorf("local content_hash changed unexpectedly: %q", doc.ContentHash)
 	}
 }
+
+// TestRunScan_S3ETagSidecarMediaNotSkipped confirms the ETag fast-path does NOT
+// skip sidecar-capable media (audio/video): a subtitle sidecar (.srt/.vtt) can
+// be added/changed/removed while the media object's own ETag is unchanged, and
+// buildDocumentWithContent folds the sidecar fingerprint into ContentHash only
+// on the full read path. So such media must always be re-read incrementally
+// (#245/#253/#283 interaction). Non-media objects keep the cheap ETag skip.
+func TestRunScan_S3ETagSidecarMediaNotSkipped(t *testing.T) {
+	fs := newFakeRemoteFS()
+	fs.add("clip.mp4", "etag-stable", "media bytes") // sidecar-capable (video)
+	fs.add("notes.txt", "etag-stable", "text body")  // non-media control
+
+	st := newRemoteScanStore()
+	st.seed(model.Document{
+		DocID:       1,
+		RelPath:     "clip.mp4",
+		DocType:     "video",
+		SizeBytes:   int64(len("media bytes")),
+		ContentHash: ingest.ComputeContentHash([]byte("media bytes")),
+		ETag:        "etag-stable",
+		Status:      "ok",
+	})
+	st.seed(model.Document{
+		DocID:       2,
+		RelPath:     "notes.txt",
+		DocType:     "text",
+		SizeBytes:   int64(len("text body")),
+		ContentHash: ingest.ComputeContentHash([]byte("text body")),
+		ETag:        "etag-stable",
+		Status:      "ok",
+	})
+
+	svc := mustNewIngestService(t, config.Config{RootDir: "/corpus"}, st)
+	svc.SetCorpusFS(fs)
+
+	if err := svc.Run(context.Background()); err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	// Sidecar-capable media must be re-read even with an unchanged ETag so a
+	// changed/added/removed sidecar is detected via the content_hash recompute.
+	if got := fs.openCount("clip.mp4"); got == 0 {
+		t.Errorf("sidecar-capable media with matching ETag was ETag-skipped; it must be re-read")
+	}
+	// Non-media object keeps the cheap ETag skip (regression guard).
+	if got := fs.openCount("notes.txt"); got != 0 {
+		t.Errorf("non-media object with matching ETag was re-read; it should ETag-skip (got %d opens)", got)
+	}
+}

--- a/tests/ingest/etag_incremental_test.go
+++ b/tests/ingest/etag_incremental_test.go
@@ -1,0 +1,331 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/appstate"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/corpusfs"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// fakeRemoteFS is a stub object-store CorpusFS that serves a fixed set of
+// in-memory objects (each carrying an ETag, mimicking S3 discovery) and counts
+// Open calls so a test can assert whether an object's body was actually read
+// during a scan. Localize is unused by the change-detection path under test.
+type fakeRemoteFS struct {
+	files   []corpusfs.DiscoveredFile
+	bodies  map[string][]byte
+	mu      sync.Mutex
+	opens   map[string]int
+	openErr map[string]error
+}
+
+func newFakeRemoteFS() *fakeRemoteFS {
+	return &fakeRemoteFS{
+		bodies:  map[string][]byte{},
+		opens:   map[string]int{},
+		openErr: map[string]error{},
+	}
+}
+
+func (f *fakeRemoteFS) add(relPath, etag, body string) {
+	f.files = append(f.files, corpusfs.DiscoveredFile{
+		RelPath:   relPath,
+		SizeBytes: int64(len(body)),
+		ETag:      etag,
+	})
+	f.bodies[relPath] = []byte(body)
+}
+
+func (f *fakeRemoteFS) Walk(_ context.Context, _ string, _ corpusfs.Options) ([]corpusfs.DiscoveredFile, error) {
+	out := append([]corpusfs.DiscoveredFile(nil), f.files...)
+	sort.Slice(out, func(i, j int) bool { return out[i].RelPath < out[j].RelPath })
+	return out, nil
+}
+
+func (f *fakeRemoteFS) Open(_ context.Context, relPath string) (io.ReadSeekCloser, error) {
+	f.mu.Lock()
+	f.opens[relPath]++
+	err := f.openErr[relPath]
+	f.mu.Unlock()
+	if err != nil {
+		return nil, err
+	}
+	return nopReadSeekCloser{bytes.NewReader(f.bodies[relPath])}, nil
+}
+
+func (f *fakeRemoteFS) Localize(_ context.Context, relPath string) (string, func(), error) {
+	return "", func() {}, os.ErrNotExist
+}
+
+func (f *fakeRemoteFS) openCount(relPath string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.opens[relPath]
+}
+
+type nopReadSeekCloser struct{ *bytes.Reader }
+
+func (nopReadSeekCloser) Close() error { return nil }
+
+// remoteScanStore is a Store implementation backed by an in-memory map, with the
+// optional documentDeleteMarker capability so a missing source object can be
+// tombstoned. It is the persistence half of the S3 change-detection scenarios.
+type remoteScanStore struct {
+	mu   sync.Mutex
+	docs map[string]model.Document
+
+	upsertCalls map[string]int
+	deleted     map[string]bool
+}
+
+func newRemoteScanStore() *remoteScanStore {
+	return &remoteScanStore{
+		docs:        map[string]model.Document{},
+		upsertCalls: map[string]int{},
+		deleted:     map[string]bool{},
+	}
+}
+
+func (s *remoteScanStore) seed(doc model.Document) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.docs[doc.RelPath] = doc
+}
+
+func (s *remoteScanStore) Init(context.Context) error { return nil }
+func (s *remoteScanStore) Close() error               { return nil }
+
+func (s *remoteScanStore) UpsertDocument(_ context.Context, doc model.Document) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.upsertCalls[doc.RelPath]++
+	// Preserve the assigned DocID across upserts so refreshDocID is stable.
+	if existing, ok := s.docs[doc.RelPath]; ok && doc.DocID == 0 {
+		doc.DocID = existing.DocID
+	}
+	if doc.DocID == 0 {
+		doc.DocID = int64(len(s.docs) + 1)
+	}
+	s.docs[doc.RelPath] = doc
+	return nil
+}
+
+func (s *remoteScanStore) GetDocumentByPath(_ context.Context, relPath string) (model.Document, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	doc, ok := s.docs[relPath]
+	if !ok {
+		return model.Document{}, os.ErrNotExist
+	}
+	return doc, nil
+}
+
+func (s *remoteScanStore) ListFiles(_ context.Context, prefix, _ string, limit, offset int) ([]model.Document, int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	all := make([]model.Document, 0, len(s.docs))
+	for _, d := range s.docs {
+		if d.Deleted {
+			continue
+		}
+		all = append(all, d)
+	}
+	sort.Slice(all, func(i, j int) bool { return all[i].RelPath < all[j].RelPath })
+	total := int64(len(all))
+	if offset >= len(all) {
+		return nil, total, nil
+	}
+	end := offset + limit
+	if end > len(all) {
+		end = len(all)
+	}
+	return all[offset:end], total, nil
+}
+
+func (s *remoteScanStore) MarkDocumentDeleted(_ context.Context, relPath string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	doc := s.docs[relPath]
+	doc.RelPath = relPath
+	doc.Deleted = true
+	s.docs[relPath] = doc
+	s.deleted[relPath] = true
+	return nil
+}
+
+func (s *remoteScanStore) get(relPath string) (model.Document, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	d, ok := s.docs[relPath]
+	return d, ok
+}
+
+// TestRunScan_S3ETagChangeDetection drives a full incremental scan against a
+// stub object-store backend and asserts the SPEC §7.8.3 change-detection
+// behavior for S3 corpora (#245): an unchanged ETag skips the GET + re-hash and
+// leaves the document untouched; a changed ETag re-reads and reindexes; a new
+// object is ingested; and a removed object is tombstoned.
+func TestRunScan_S3ETagChangeDetection(t *testing.T) {
+	fs := newFakeRemoteFS()
+	fs.add("unchanged.txt", "etag-unchanged", "stable body")
+	fs.add("changed.txt", "etag-new", "new body")
+	fs.add("new.txt", "etag-fresh", "brand new")
+	// "removed.txt" is intentionally NOT added to the source: it exists only in
+	// the store, so the scan must tombstone it.
+
+	st := newRemoteScanStore()
+	st.seed(model.Document{
+		DocID:       1,
+		RelPath:     "unchanged.txt",
+		DocType:     "text",
+		SizeBytes:   int64(len("stable body")),
+		ContentHash: ingest.ComputeContentHash([]byte("stable body")),
+		ETag:        "etag-unchanged",
+		Status:      "ok",
+	})
+	st.seed(model.Document{
+		DocID:       2,
+		RelPath:     "changed.txt",
+		DocType:     "text",
+		SizeBytes:   int64(len("old body")),
+		ContentHash: ingest.ComputeContentHash([]byte("old body")),
+		ETag:        "etag-old",
+		Status:      "ok",
+	})
+	st.seed(model.Document{
+		DocID:       3,
+		RelPath:     "removed.txt",
+		DocType:     "text",
+		SizeBytes:   5,
+		ContentHash: ingest.ComputeContentHash([]byte("gone!")),
+		ETag:        "etag-removed",
+		Status:      "ok",
+	})
+
+	svc := mustNewIngestService(t, config.Config{RootDir: "/corpus"}, st)
+	svc.SetCorpusFS(fs)
+
+	if err := svc.Run(context.Background()); err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+
+	// Unchanged ETag: object body must NOT have been read, and the stored row
+	// (content_hash, ETag) must be untouched (no upsert).
+	if got := fs.openCount("unchanged.txt"); got != 0 {
+		t.Errorf("unchanged object was re-read %d time(s); expected 0 (ETag skip)", got)
+	}
+	if got := st.upsertCalls["unchanged.txt"]; got != 0 {
+		t.Errorf("unchanged object was upserted %d time(s); expected 0", got)
+	}
+	if doc, _ := st.get("unchanged.txt"); doc.ContentHash != ingest.ComputeContentHash([]byte("stable body")) {
+		t.Errorf("unchanged content_hash mutated: %q", doc.ContentHash)
+	}
+
+	// Changed ETag: object must be re-read and reindexed (new hash + new ETag
+	// persisted).
+	if got := fs.openCount("changed.txt"); got == 0 {
+		t.Errorf("changed object was not re-read; expected a GET")
+	}
+	if doc, ok := st.get("changed.txt"); !ok {
+		t.Errorf("changed object missing from store")
+	} else {
+		if doc.ContentHash != ingest.ComputeContentHash([]byte("new body")) {
+			t.Errorf("changed content_hash not recomputed: %q", doc.ContentHash)
+		}
+		if doc.ETag != "etag-new" {
+			t.Errorf("changed ETag not updated: %q", doc.ETag)
+		}
+	}
+
+	// New object: read and ingested with its ETag recorded.
+	if got := fs.openCount("new.txt"); got == 0 {
+		t.Errorf("new object was not read")
+	}
+	if doc, ok := st.get("new.txt"); !ok {
+		t.Errorf("new object not ingested")
+	} else if doc.ETag != "etag-fresh" {
+		t.Errorf("new object ETag not recorded: %q", doc.ETag)
+	}
+
+	// Removed object: tombstoned.
+	if !st.deleted["removed.txt"] {
+		t.Errorf("removed object was not tombstoned")
+	}
+}
+
+// TestRunScan_S3ETagForceReindexBypassesSkip confirms that a forced reindex
+// re-reads even an object whose ETag is unchanged (the skip is incremental-only,
+// SPEC §7.8.3).
+func TestRunScan_S3ETagForceReindexBypassesSkip(t *testing.T) {
+	fs := newFakeRemoteFS()
+	fs.add("doc.txt", "etag-stable", "body")
+
+	st := newRemoteScanStore()
+	st.seed(model.Document{
+		DocID:       1,
+		RelPath:     "doc.txt",
+		DocType:     "text",
+		SizeBytes:   int64(len("body")),
+		ContentHash: ingest.ComputeContentHash([]byte("body")),
+		ETag:        "etag-stable",
+		Status:      "ok",
+	})
+
+	svc := mustNewIngestService(t, config.Config{RootDir: "/corpus"}, st)
+	svc.SetCorpusFS(fs)
+	// Reindex forces only when an IndexingState in full mode is attached (the
+	// CLI wires this); attach one so forceReindex is true.
+	svc.SetIndexingState(appstate.NewIndexingState(appstate.ModeFull))
+
+	if err := svc.Reindex(context.Background()); err != nil {
+		t.Fatalf("Reindex failed: %v", err)
+	}
+	if got := fs.openCount("doc.txt"); got == 0 {
+		t.Errorf("force reindex did not re-read object despite matching ETag")
+	}
+}
+
+// TestRunScan_LocalEmptyETagUsesContentHash confirms the local/NFS path is
+// unaffected: with an empty ETag the (size,mtime)→content_hash gate decides, so
+// an unchanged-hash document still reads its body (no ETag skip) but is not
+// re-represented, while a changed body reindexes.
+func TestRunScan_LocalEmptyETagUsesContentHash(t *testing.T) {
+	fs := newFakeRemoteFS()
+	// Empty ETag mimics LocalFS discovery.
+	fs.add("local.txt", "", "same body")
+
+	st := newRemoteScanStore()
+	st.seed(model.Document{
+		DocID:       1,
+		RelPath:     "local.txt",
+		DocType:     "text",
+		SizeBytes:   int64(len("same body")),
+		ContentHash: ingest.ComputeContentHash([]byte("same body")),
+		ETag:        "",
+		Status:      "ok",
+	})
+
+	svc := mustNewIngestService(t, config.Config{RootDir: "/corpus"}, st)
+	svc.SetCorpusFS(fs)
+
+	if err := svc.Run(context.Background()); err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	// Local path has no cheap ETag token, so the body IS read to confirm the
+	// content_hash (the historical behavior must be intact).
+	if got := fs.openCount("local.txt"); got == 0 {
+		t.Errorf("local (empty ETag) object was not read; ETag skip must not apply locally")
+	}
+	if doc, _ := st.get("local.txt"); doc.ContentHash != ingest.ComputeContentHash([]byte("same body")) {
+		t.Errorf("local content_hash changed unexpectedly: %q", doc.ContentHash)
+	}
+}

--- a/tests/ingest/etag_incremental_test.go
+++ b/tests/ingest/etag_incremental_test.go
@@ -262,6 +262,73 @@ func TestRunScan_S3ETagChangeDetection(t *testing.T) {
 	}
 }
 
+// TestRunScan_S3ETagSizeMismatchForcesReRead confirms the size guard in
+// etagUnchanged: when the stored ETag matches the discovered object but the size
+// differs (e.g. a truncated/legacy ETag collision), the object MUST be re-read
+// and re-hashed rather than silently skipped (SPEC §7.8.3 — content_hash stays
+// canonical). This is the highest-risk silent-staleness branch.
+func TestRunScan_S3ETagSizeMismatchForcesReRead(t *testing.T) {
+	fs := newFakeRemoteFS()
+	fs.add("doc.txt", "etag-collide", "fresh longer body")
+
+	st := newRemoteScanStore()
+	st.seed(model.Document{
+		DocID:       1,
+		RelPath:     "doc.txt",
+		DocType:     "text",
+		SizeBytes:   int64(len("old body")), // deliberately different size
+		ContentHash: ingest.ComputeContentHash([]byte("old body")),
+		ETag:        "etag-collide", // same token as discovered object
+		Status:      "ok",
+	})
+
+	svc := mustNewIngestService(t, config.Config{RootDir: "/corpus"}, st)
+	svc.SetCorpusFS(fs)
+
+	if err := svc.Run(context.Background()); err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if got := fs.openCount("doc.txt"); got == 0 {
+		t.Errorf("ETag matched but size differed; object must be re-read (no skip)")
+	}
+	if doc, _ := st.get("doc.txt"); doc.ContentHash != ingest.ComputeContentHash([]byte("fresh longer body")) {
+		t.Errorf("content_hash not recomputed on size-mismatch re-read: %q", doc.ContentHash)
+	}
+}
+
+// TestRunScan_S3ETagErrorStatusForcesReprocess confirms that a document
+// previously recorded as status="error" is re-processed even when its ETag and
+// size still match the discovered object, so a transient ingest failure recovers
+// on the next incremental scan without a full reindex (SPEC §7.8.3).
+func TestRunScan_S3ETagErrorStatusForcesReprocess(t *testing.T) {
+	fs := newFakeRemoteFS()
+	fs.add("doc.txt", "etag-stable", "body")
+
+	st := newRemoteScanStore()
+	st.seed(model.Document{
+		DocID:       1,
+		RelPath:     "doc.txt",
+		DocType:     "text",
+		SizeBytes:   int64(len("body")),
+		ContentHash: ingest.ComputeContentHash([]byte("body")),
+		ETag:        "etag-stable",
+		Status:      "error", // prior ingest failed
+	})
+
+	svc := mustNewIngestService(t, config.Config{RootDir: "/corpus"}, st)
+	svc.SetCorpusFS(fs)
+
+	if err := svc.Run(context.Background()); err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if got := fs.openCount("doc.txt"); got == 0 {
+		t.Errorf("error-status document with matching ETag was skipped; it must re-process")
+	}
+	if doc, _ := st.get("doc.txt"); doc.Status != "ok" {
+		t.Errorf("error-status document not recovered after re-process: status=%q", doc.Status)
+	}
+}
+
 // TestRunScan_S3ETagForceReindexBypassesSkip confirms that a forced reindex
 // re-reads even an object whose ETag is unchanged (the skip is incremental-only,
 // SPEC §7.8.3).


### PR DESCRIPTION
## Summary

Implements incremental change detection for remote (S3) corpora using ETag + size as the cheap change signal, per **merged SPEC §7.8.3**. An object whose recorded ETag and size match the discovered object is treated as unchanged and **skipped without a GET or content_hash recompute** — the big remote win (no full download just to hash an unchanged object).

Closes #245. Part of epic #250.

## Behavior (SPEC §7.8.3)

- **S3 (ETag present):** ETag(+size) is the cheap change token. On a match, the object body is **not** re-read and the stored row is left untouched. On ETag change / absent stored ETag / forced reindex, the body is read and `content_hash` is recomputed as before. The ETag is **never** treated as a content hash (multipart/SSE-KMS ETags are not MD5 of the body); `content_hash` stays the canonical identity.
- **Local/NFS (ETag empty):** unchanged — the historical `(size, mtime)` pre-check then `content_hash` confirm path is fully intact (the ETag skip is a strict no-op when the discovered ETag is empty).
- **Deletions:** a source object present in the store but absent from enumeration is still tombstoned.
- Deterministic; no behavior change for local corpora.

## Storage / migration

The ETag is stored in a new **`etag` column on `documents`** (lowest-migration option per the spec). It is added via an idempotent additive `ALTER TABLE ... ADD COLUMN etag TEXT NOT NULL DEFAULT ''` (matching the existing additive-migration pattern) plus the fresh-schema column; **no data backfill is required** (existing rows default to empty, which simply forces a one-time re-read on next scan).

## Tests

`tests/ingest/etag_incremental_test.go` drives full incremental scans against a stub object-store `CorpusFS` (counts `Open` calls) + an in-memory store:
- unchanged ETag → object **not** re-read, document untouched (no upsert, hash preserved)
- changed ETag → re-read + reindex (new hash + ETag persisted)
- new object → ingested with ETag recorded
- removed object → tombstoned
- force reindex → bypasses the skip even with matching ETag
- local (empty ETag) → body still read, `content_hash` path unchanged

No network access.

## Checks

- `make check` passes locally (gofmt, go vet, golangci-lint 0 issues, gocyclo ≤15, all tests).
- Pure-Go, `CGO_ENABLED=0` build verified.
- `dirstral-spec` submodule **not** re-pinned.

## Notes

PR #293 (translation) is in flight touching `internal/ingest/service.go`; this branch is off `main` and may need a rebase. The change-detection edits are localized to `processDocument` and its new helpers (`trySkipUnchangedRemoteDocument`, `skipUnchangedRemoteDocument`, plus refactor-out helpers `persistBuildError`/`refreshDocID` extracted only to keep `processDocument` under the gocyclo≤15 limit); the transcript/translation functions are untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced incremental change detection for S3-backed document corpora, enabling faster ingestion by skipping unnecessary re-reads of unchanged remote objects.

* **Bug Fixes**
  * Improved error handling in the document processing pipeline with centralized error persistence and status tracking.

* **Tests**
  * Added comprehensive test coverage for incremental ingestion behavior across multiple change-detection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->