### PR TITLE
feat(media): optional leading-silence trim + VAD toggle for transcription

### DIFF
--- a/internal/avutil/avutil.go
+++ b/internal/avutil/avutil.go
@@ -121,8 +121,12 @@ func DetectLeadingSilence(ctx context.Context, path string, thresholdDB, minDura
 		minDurationSec = DefaultSilenceMinDuration
 	}
 
+	// Always cap the probe at silenceProbeTimeout: apply it when the caller has
+	// no deadline, OR when the caller's deadline is further out than the probe
+	// cap, so a long-lived ingest context cannot let ffmpeg run unbounded. A
+	// nearer caller deadline is left in force (it is the stricter bound).
 	probeCtx := ctx
-	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+	if deadline, hasDeadline := ctx.Deadline(); !hasDeadline || time.Until(deadline) > silenceProbeTimeout {
 		var cancel context.CancelFunc
 		probeCtx, cancel = context.WithTimeout(ctx, silenceProbeTimeout)
 		defer cancel()

--- a/internal/avutil/avutil.go
+++ b/internal/avutil/avutil.go
@@ -67,6 +67,168 @@ func Duration(ctx context.Context, path string) (time.Duration, error) {
 	return time.Duration(secs * float64(time.Second)), nil
 }
 
+// DefaultSilenceThresholdDB is the noise floor (in dBFS) below which audio is
+// treated as silence by DetectLeadingSilence. It mirrors livevtt's
+// archive_transcriber default (-40 dB): conservative enough that low-level room
+// tone is not mistaken for speech, loose enough that genuine dead air is caught.
+const DefaultSilenceThresholdDB = -40.0
+
+// DefaultSilenceMinDuration is the minimum continuous silence (seconds) ffmpeg's
+// silencedetect must observe before reporting a silence period. A short floor
+// avoids treating sub-half-second gaps as leading silence.
+const DefaultSilenceMinDuration = 0.5
+
+// maxLeadingSilenceTrim bounds how much leading silence DetectLeadingSilence is
+// willing to report. Mirrors livevtt's "< 5s" guard: trimming only the brief
+// dead air typical before speech starts, never a long musical/ident intro that
+// is legitimately part of the media. A detected leading silence at or beyond
+// this bound is treated as "no leading silence" (return 0) so timestamps are
+// never shifted by a large, likely-wrong amount.
+const maxLeadingSilenceTrim = 5 * time.Second
+
+// silenceProbeTimeout bounds the silencedetect pass independently of any caller
+// deadline, so a pathological input cannot hang ingest. silencedetect must
+// decode the whole stream, so this is more generous than a metadata probe.
+const silenceProbeTimeout = 60 * time.Second
+
+// DetectLeadingSilence reports the duration of silence at the very start of the
+// media at path, detected via ffmpeg's `silencedetect` filter. It returns 0 when
+// the media starts with speech, when ffmpeg reports no leading silence, when the
+// detected leading silence is implausibly long (>= maxLeadingSilenceTrim), or
+// when ffmpeg is unavailable — i.e. callers can treat any non-positive result as
+// "do not trim" and never need to special-case the tool being absent.
+//
+// It is graceful by contract: a missing ffmpeg binary returns (0, nil), not an
+// error, so leading-silence trimming silently degrades to a no-op rather than
+// failing ingest. A genuine ffmpeg execution failure is returned so the caller
+// can log it, but such callers still treat it as "no trim".
+//
+// thresholdDB and minDurationSec are the silencedetect `noise`/`d` parameters;
+// non-positive values fall back to the package defaults. Detection is
+// deterministic for a given input and parameters.
+func DetectLeadingSilence(ctx context.Context, path string, thresholdDB, minDurationSec float64) (time.Duration, error) {
+	bin, err := exec.LookPath("ffmpeg")
+	if err != nil {
+		// Tool absent: graceful no-op, never fatal (mirrors Duration's
+		// ErrToolNotFound contract but folded into a 0 so silence trimming is
+		// purely best-effort).
+		return 0, nil
+	}
+	if thresholdDB >= 0 {
+		thresholdDB = DefaultSilenceThresholdDB
+	}
+	if minDurationSec <= 0 {
+		minDurationSec = DefaultSilenceMinDuration
+	}
+
+	probeCtx := ctx
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		var cancel context.CancelFunc
+		probeCtx, cancel = context.WithTimeout(ctx, silenceProbeTimeout)
+		defer cancel()
+	}
+
+	filter := fmt.Sprintf("silencedetect=noise=%sdB:d=%s",
+		strconv.FormatFloat(thresholdDB, 'f', -1, 64),
+		strconv.FormatFloat(minDurationSec, 'f', -1, 64),
+	)
+	cmd := exec.CommandContext(probeCtx, bin,
+		"-nostdin",
+		"-i", path,
+		"-af", filter,
+		"-f", "null",
+		"-",
+	)
+	// silencedetect writes its report to stderr; stdout is the (discarded) null
+	// muxer output.
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return 0, fmt.Errorf("ffmpeg silencedetect %q: %w: %s", path, err, strings.TrimSpace(stderr.String()))
+	}
+	return parseLeadingSilence(stderr.String()), nil
+}
+
+// parseLeadingSilence extracts the leading-silence duration from ffmpeg
+// silencedetect stderr output. silencedetect emits lines such as:
+//
+//	[silencedetect @ 0x..] silence_start: 0
+//	[silencedetect @ 0x..] silence_end: 1.234 | silence_duration: 1.234
+//
+// Leading silence is present only when a silence period starts at (or
+// effectively at) the very beginning of the stream; the trim amount is that
+// period's `silence_end`. We scan for the earliest silence_start and, when it is
+// at the start, take its matching silence_end. A silence period that does not
+// begin at the start is ignored (it is a mid-stream gap, not leading silence).
+// Returns 0 when no qualifying leading silence is found or it is implausibly
+// long (>= maxLeadingSilenceTrim).
+func parseLeadingSilence(stderr string) time.Duration {
+	const (
+		startTag = "silence_start:"
+		endTag   = "silence_end:"
+	)
+	// startEpsilonSec tolerates ffmpeg reporting the first silence_start as a
+	// tiny positive offset (e.g. 0.0001) rather than exactly 0.
+	const startEpsilonSec = 0.05
+
+	leadingActive := false
+	for _, line := range strings.Split(stderr, "\n") {
+		if idx := strings.Index(line, startTag); idx >= 0 {
+			val, ok := parseFloatField(line[idx+len(startTag):])
+			if !ok {
+				continue
+			}
+			// Only the first silence period matters for leading silence, and
+			// only if it starts at the very beginning.
+			if val <= startEpsilonSec {
+				leadingActive = true
+			} else if !leadingActive {
+				// First silence period starts mid-stream -> no leading silence.
+				return 0
+			}
+			continue
+		}
+		if !leadingActive {
+			continue
+		}
+		if idx := strings.Index(line, endTag); idx >= 0 {
+			val, ok := parseFloatField(line[idx+len(endTag):])
+			if !ok || val <= 0 {
+				return 0
+			}
+			d := time.Duration(val * float64(time.Second))
+			if d >= maxLeadingSilenceTrim {
+				return 0
+			}
+			return d
+		}
+	}
+	return 0
+}
+
+// ParseLeadingSilence is the exported counterpart of parseLeadingSilence,
+// exposed for tests in the tests/ tree so leading-silence parsing can be
+// verified against captured ffmpeg silencedetect output without requiring the
+// ffmpeg binary.
+func ParseLeadingSilence(silencedetectStderr string) time.Duration {
+	return parseLeadingSilence(silencedetectStderr)
+}
+
+// parseFloatField reads the first whitespace-delimited token from s as a float.
+// It tolerates a trailing "| silence_duration: ..." continuation by reading only
+// the first field.
+func parseFloatField(s string) (float64, bool) {
+	fields := strings.Fields(s)
+	if len(fields) == 0 {
+		return 0, false
+	}
+	v, err := strconv.ParseFloat(fields[0], 64)
+	if err != nil {
+		return 0, false
+	}
+	return v, true
+}
+
 // ExtractSegment cuts the window [startMS, endMS) from the media at a local
 // filesystem path and returns the resulting container bytes. It uses stream copy
 // (no re-encode) so the MIME type is unchanged, extraction is fast, and the

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -249,6 +249,31 @@ type Config struct {
 	// carries no language- or domain-specific phrases.
 	MediaFilterWords []string
 
+	// MediaTrimLeadingSilence opts IN to trimming leading silence from media
+	// transcripts (dir2mcp#258, config `media.trim_leading_silence`). When true
+	// and ffmpeg is available, the duration of dead air before the first speech
+	// is detected (ffmpeg silencedetect) and subtracted from every transcript
+	// segment/word timestamp (clamped at 0) so timings align to first speech.
+	//
+	// Default OFF. livevtt defaulted this on for its broadcast capture use case,
+	// but dir2mcp is general-purpose: silence trimming is a heuristic that can
+	// shift timestamps for media where the leading "silence" is intentional, so
+	// it is opt-in here. ffmpeg absent / detection failure -> no trim, no error.
+	MediaTrimLeadingSilence bool
+
+	// MediaSilenceThresholdDB is the noise floor (dBFS) below which audio counts
+	// as silence for leading-silence detection (config
+	// `media.silence_threshold_db`). Zero/positive falls back to the avutil
+	// default (-40 dB). Only consulted when MediaTrimLeadingSilence is true.
+	MediaSilenceThresholdDB float64
+
+	// MediaVAD enables a provider-side voice-activity-detection filter where the
+	// STT provider supports it (config `media.vad`). For the self-hosted whisper
+	// provider this sets the OpenAI-compatible `vad_filter` form field so the
+	// server skips non-speech audio. Providers without VAD support ignore it.
+	// Default OFF.
+	MediaVAD bool
+
 	// QualityGatesEnabled is the master switch for the output quality gate
 	// (spec 0.16.0): when true (default), generated transcript/OCR text is
 	// screened for degenerate output (repetition loops, empty output,
@@ -357,6 +382,9 @@ type fileConfig struct {
 	MediaTranslateEnabled     *bool
 	MediaTranslateTargetLangs []string
 	MediaFilterWords          []string
+	MediaTrimLeadingSilence   *bool
+	MediaSilenceThresholdDB   *float64
+	MediaVAD                  *bool
 	ElevenLabsAPIKey          *string
 	ServerTLSCertFile         *string
 	ServerTLSKeyFile          *string
@@ -449,6 +477,9 @@ type persistedConfig struct {
 	MediaTranslateEnabled     bool          `yaml:"media_translate_enabled"`
 	MediaTranslateTargetLangs []string      `yaml:"media_translate_target_langs"`
 	MediaFilterWords          []string      `yaml:"media_filter_words"`
+	MediaTrimLeadingSilence   bool          `yaml:"media_trim_leading_silence"`
+	MediaSilenceThresholdDB   float64       `yaml:"media_silence_threshold_db"`
+	MediaVAD                  bool          `yaml:"media_vad"`
 	ServerTLSCertFile         string        `yaml:"server_tls_cert_file"`
 	ServerTLSKeyFile          string        `yaml:"server_tls_key_file"`
 
@@ -676,6 +707,9 @@ func buildPersistedConfig(cfg *Config) persistedConfig {
 		MediaTranslateEnabled:     cfg.MediaTranslateEnabled,
 		MediaTranslateTargetLangs: append([]string(nil), cfg.MediaTranslateTargetLangs...),
 		MediaFilterWords:          append([]string(nil), cfg.MediaFilterWords...),
+		MediaTrimLeadingSilence:   cfg.MediaTrimLeadingSilence,
+		MediaSilenceThresholdDB:   cfg.MediaSilenceThresholdDB,
+		MediaVAD:                  cfg.MediaVAD,
 		ServerTLSCertFile:         cfg.ServerTLSCertFile,
 		ServerTLSKeyFile:          cfg.ServerTLSKeyFile,
 		X402Mode:                  cfg.X402.Mode,
@@ -1299,6 +1333,15 @@ func applySTTFileParsed(cfg *Config, fc fileConfig) {
 	if fc.MediaFilterWords != nil {
 		cfg.MediaFilterWords = normalizeStringSlice(fc.MediaFilterWords)
 	}
+	if fc.MediaTrimLeadingSilence != nil {
+		cfg.MediaTrimLeadingSilence = *fc.MediaTrimLeadingSilence
+	}
+	if fc.MediaSilenceThresholdDB != nil {
+		cfg.MediaSilenceThresholdDB = *fc.MediaSilenceThresholdDB
+	}
+	if fc.MediaVAD != nil {
+		cfg.MediaVAD = *fc.MediaVAD
+	}
 }
 
 // applyX402FileParsed copies the set x402 file fields onto cfg.X402.
@@ -1567,6 +1610,9 @@ var configKeyAliases = map[string]string{
 	"media_translate_target_langs":         "media.translate.target_langs",
 	"media_filter_words":                   "media.filter_words",
 	"filter_words":                         "media.filter_words",
+	"media_trim_leading_silence":           "media.trim_leading_silence",
+	"media_silence_threshold_db":           "media.silence_threshold_db",
+	"media_vad":                            "media.vad",
 	"stt_provider":                         "stt.provider",
 	"stt_mistral_model":                    "stt.mistral.model",
 	"stt_elevenlabs_model":                 "stt.elevenlabs.model",
@@ -1644,6 +1690,9 @@ func setFileScalarValue(cfg *fileConfig, key, value string) error {
 	if err := setIntFileScalar(cfg, key, value); err != nil {
 		return err
 	}
+	if err := setFloatFileScalar(cfg, key, value); err != nil {
+		return err
+	}
 	if err := setDurationFileScalar(cfg, key, value); err != nil {
 		return err
 	}
@@ -1654,41 +1703,39 @@ func setFileScalarValue(cfg *fileConfig, key, value string) error {
 // setBoolFileScalar parses value as a bool and assigns it to the
 // fileConfig field selected by key; unknown keys are a no-op and an
 // unparseable value is an error.
+// boolFileScalarTargets maps a canonical config key to the accessor that
+// selects the corresponding *bool field on a fileConfig. Driving setBoolFileScalar
+// from a table (rather than a switch) keeps its cyclomatic complexity flat as
+// more boolean keys are added.
+var boolFileScalarTargets = map[string]func(*fileConfig) **bool{
+	"public":                  func(c *fileConfig) **bool { return &c.Public },
+	"rag.generate_answer":     func(c *fileConfig) **bool { return &c.RAGGenerateAnswer },
+	"ingest.gitignore":        func(c *fileConfig) **bool { return &c.IngestGitignore },
+	"ingest.follow_symlinks":  func(c *fileConfig) **bool { return &c.IngestFollowSymlinks },
+	"ingest.watch":            func(c *fileConfig) **bool { return &c.IngestWatch },
+	"quality_gates_enabled":   func(c *fileConfig) **bool { return &c.QualityGatesEnabled },
+	"media_sidecars_disabled": func(c *fileConfig) **bool { return &c.MediaSidecarsDisabled },
+	"media.variants.group":    func(c *fileConfig) **bool { return &c.MediaVariantsGroup },
+	"media.translate.enabled": func(c *fileConfig) **bool { return &c.MediaTranslateEnabled },
+	"media.trim_leading_silence": func(c *fileConfig) **bool {
+		return &c.MediaTrimLeadingSilence
+	},
+	"media.vad":                func(c *fileConfig) **bool { return &c.MediaVAD },
+	"x402_tools_call_enabled":  func(c *fileConfig) **bool { return &c.X402ToolsCallEnabled },
+	"retrieval.hybrid.enabled": func(c *fileConfig) **bool { return &c.RetrievalHybridEnabled },
+	"rerank.enabled":           func(c *fileConfig) **bool { return &c.RerankEnabled },
+}
+
 func setBoolFileScalar(cfg *fileConfig, key, value string) error {
-	var target **bool
-	switch key {
-	case "public":
-		target = &cfg.Public
-	case "rag.generate_answer":
-		target = &cfg.RAGGenerateAnswer
-	case "ingest.gitignore":
-		target = &cfg.IngestGitignore
-	case "ingest.follow_symlinks":
-		target = &cfg.IngestFollowSymlinks
-	case "ingest.watch":
-		target = &cfg.IngestWatch
-	case "quality_gates_enabled":
-		target = &cfg.QualityGatesEnabled
-	case "media_sidecars_disabled":
-		target = &cfg.MediaSidecarsDisabled
-	case "media.variants.group":
-		target = &cfg.MediaVariantsGroup
-	case "media.translate.enabled":
-		target = &cfg.MediaTranslateEnabled
-	case "x402_tools_call_enabled":
-		target = &cfg.X402ToolsCallEnabled
-	case "retrieval.hybrid.enabled":
-		target = &cfg.RetrievalHybridEnabled
-	case "rerank.enabled":
-		target = &cfg.RerankEnabled
-	default:
+	accessor, ok := boolFileScalarTargets[key]
+	if !ok {
 		return nil
 	}
 	parsed, err := strconv.ParseBool(value)
 	if err != nil {
 		return fmt.Errorf("invalid boolean for %s", key)
 	}
-	*target = boolPtr(parsed)
+	*accessor(cfg) = boolPtr(parsed)
 	return nil
 }
 
@@ -1724,6 +1771,25 @@ func setIntFileScalar(cfg *fileConfig, key, value string) error {
 		return fmt.Errorf("invalid integer for %s", key)
 	}
 	*target = intPtr(parsed)
+	return nil
+}
+
+// setFloatFileScalar parses value as a float64 and assigns it to the
+// fileConfig field selected by key; unknown keys are a no-op and an
+// unparseable value is an error.
+func setFloatFileScalar(cfg *fileConfig, key, value string) error {
+	var target **float64
+	switch key {
+	case "media.silence_threshold_db":
+		target = &cfg.MediaSilenceThresholdDB
+	default:
+		return nil
+	}
+	parsed, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return fmt.Errorf("invalid number for %s", key)
+	}
+	*target = floatPtr(parsed)
 	return nil
 }
 
@@ -2049,6 +2115,9 @@ func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	writeBool("media_translate_enabled", cfg.MediaTranslateEnabled)
 	writeList("media_translate_target_langs", cfg.MediaTranslateTargetLangs)
 	writeList("media_filter_words", cfg.MediaFilterWords)
+	writeBool("media_trim_leading_silence", cfg.MediaTrimLeadingSilence)
+	writeScalar("media_silence_threshold_db", strconv.FormatFloat(cfg.MediaSilenceThresholdDB, 'f', -1, 64))
+	writeBool("media_vad", cfg.MediaVAD)
 	writeScalar("server_tls_cert_file", cfg.ServerTLSCertFile)
 	writeScalar("server_tls_key_file", cfg.ServerTLSKeyFile)
 	writeScalar("x402_mode", cfg.X402Mode)
@@ -2103,6 +2172,8 @@ func boolPtr(value bool) *bool { return &value }
 
 // intPtr returns a pointer to value.
 func intPtr(value int) *int { return &value }
+
+func floatPtr(value float64) *float64 { return &value }
 
 // applyEnvOverrides layers all supported environment-variable overrides
 // onto cfg. Env always wins when present (an empty DIR2MCP_SERVER_NAME

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
 	"net"
 	"net/url"
@@ -1785,8 +1786,11 @@ func setFloatFileScalar(cfg *fileConfig, key, value string) error {
 	default:
 		return nil
 	}
+	// strconv.ParseFloat accepts "NaN"/"Inf"/"Infinity"; reject non-finite
+	// values here so a malformed threshold fails at config-parse time (explicit,
+	// deterministic) rather than surfacing later during ffmpeg execution.
 	parsed, err := strconv.ParseFloat(value, 64)
-	if err != nil {
+	if err != nil || math.IsNaN(parsed) || math.IsInf(parsed, 0) {
 		return fmt.Errorf("invalid number for %s", key)
 	}
 	*target = floatPtr(parsed)

--- a/internal/ingest/represent.go
+++ b/internal/ingest/represent.go
@@ -671,6 +671,39 @@ func applyWordFilterToSegments(segs []chunkSegment, filter *subtitle.WordFilter)
 	return out
 }
 
+// shiftTranscriptSpans subtracts offsetMS from every "time" span's bounds and
+// from every attached word timestamp, clamping at 0 (dir2mcp#258 leading-silence
+// trim). It mutates segs in place and is deterministic for a given input. A
+// non-positive offset is a no-op; non-time spans are left untouched. Bounds stay
+// valid (EndMS > StartMS); a span that would collapse keeps a 1ms width so the
+// downstream EndMS > StartMS invariant holds.
+func shiftTranscriptSpans(segs []chunkSegment, offsetMS int) {
+	if offsetMS <= 0 {
+		return
+	}
+	for i := range segs {
+		if segs[i].Span.Kind != "time" {
+			continue
+		}
+		segs[i].Span.StartMS = clampShift(segs[i].Span.StartMS, offsetMS)
+		segs[i].Span.EndMS = clampShift(segs[i].Span.EndMS, offsetMS)
+		if segs[i].Span.EndMS <= segs[i].Span.StartMS {
+			segs[i].Span.EndMS = segs[i].Span.StartMS + 1
+		}
+		for w := range segs[i].Span.Words {
+			segs[i].Span.Words[w].T = clampShift(segs[i].Span.Words[w].T, offsetMS)
+		}
+	}
+}
+
+// clampShift subtracts offsetMS from ms, never returning below 0.
+func clampShift(ms, offsetMS int) int {
+	if shifted := ms - offsetMS; shifted > 0 {
+		return shifted
+	}
+	return 0
+}
+
 // attachWordsToTimeSpans assigns words to the chunk whose "time" span covers the
 // word's start time, mutating each chunk's span.Words in place. Words are
 // processed in order; a word is placed in the first chunk for which
@@ -1109,6 +1142,26 @@ func ChunkTranscriptByTimeFiltered(content string, filter *subtitle.WordFilter) 
 	out := make([]ChunkSegment, 0, len(raw))
 	for _, seg := range raw {
 		out = append(out, ChunkSegment(seg))
+	}
+	return out
+}
+
+// ShiftTranscriptSpans is the exported counterpart of shiftTranscriptSpans,
+// exposed for tests in the tests/ tree. It subtracts offsetMS from every "time"
+// span's bounds and attached word timestamps (clamped at 0) and returns the
+// shifted segments; the input slice is not modified.
+func ShiftTranscriptSpans(segs []ChunkSegment, offsetMS int) []ChunkSegment {
+	raw := make([]chunkSegment, len(segs))
+	for i, seg := range segs {
+		raw[i] = chunkSegment(seg)
+		if seg.Span.Words != nil {
+			raw[i].Span.Words = append([]model.WordSpan(nil), seg.Span.Words...)
+		}
+	}
+	shiftTranscriptSpans(raw, offsetMS)
+	out := make([]ChunkSegment, len(raw))
+	for i, seg := range raw {
+		out[i] = ChunkSegment(seg)
 	}
 	return out
 }

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -107,6 +107,14 @@ type Service struct {
 	// ffprobe binary.
 	ProbeDurationFunc func(ctx context.Context, path string) (time.Duration, error)
 
+	// DetectLeadingSilenceFunc overrides leading-silence detection used by the
+	// optional transcript trim (dir2mcp#258, config media.trim_leading_silence).
+	// Defaults to a thin wrapper over avutil.DetectLeadingSilence (ffmpeg
+	// silencedetect) when nil; tests set it to supply a deterministic offset
+	// without requiring the ffmpeg binary. It MUST be graceful: returning
+	// (0, err) is treated as "do not trim".
+	DetectLeadingSilenceFunc func(ctx context.Context, path string) (time.Duration, error)
+
 	// optional logger for diagnostics; defaults to log.Default() when nil.
 	// Tests can provide their own logger to avoid mutating global state.
 	// Access must go through the logger() helper or SetLogger; the field
@@ -387,6 +395,9 @@ func TranscriberFromConfigWithLanguage(cfg config.Config, language string) (mode
 		if langOverride != "" {
 			prof.STTLanguage = langOverride
 		}
+		// media.vad (dir2mcp#258) is a global toggle, applied onto whichever STT
+		// profile resolves; providers without VAD support ignore it.
+		prof.STTVAD = cfg.MediaVAD
 		tr, berr := buildTranscriber(prof)
 		if berr != nil {
 			return nil, fmt.Errorf("stt provider %q: %w", sel, berr)
@@ -1345,6 +1356,38 @@ func (s *Service) probeDuration(ctx context.Context, doc model.Document) (time.D
 	return probe(ctx, localPath)
 }
 
+// detectLeadingSilence resolves the leading-silence duration for doc's media
+// using the configured detector (DetectLeadingSilenceFunc, defaulting to
+// avutil.DetectLeadingSilence with the configured threshold). It is graceful by
+// contract: any error, or ffmpeg being absent, yields a 0 offset (no trim).
+// Media is resolved through the CorpusFS (Localize) so non-local backends still
+// get the behavior; for LocalFS this is the real path with a no-op cleanup.
+func (s *Service) detectLeadingSilence(ctx context.Context, doc model.Document) time.Duration {
+	localPath, cleanup, err := s.corpusFS().Localize(ctx, doc.RelPath)
+	if err != nil {
+		s.getLogger().Printf("leading-silence trim: localize %s: %v (skipping trim)", doc.RelPath, err)
+		return 0
+	}
+	defer cleanup()
+
+	detect := s.DetectLeadingSilenceFunc
+	if detect == nil {
+		thresholdDB := s.cfg.MediaSilenceThresholdDB
+		detect = func(ctx context.Context, path string) (time.Duration, error) {
+			return avutil.DetectLeadingSilence(ctx, path, thresholdDB, 0)
+		}
+	}
+	offset, derr := detect(ctx, localPath)
+	if derr != nil {
+		s.getLogger().Printf("leading-silence trim: detect %s: %v (skipping trim)", doc.RelPath, derr)
+		return 0
+	}
+	if offset < 0 {
+		return 0
+	}
+	return offset
+}
+
 // mediaTimeSpans probes doc's duration and windows it into contiguous,
 // non-overlapping `time` spans of at most windowMS (SPEC 8.1.7). Returns nil
 // when the duration can't be determined (undecodable, or ffprobe absent),
@@ -1806,6 +1849,15 @@ func (s *Service) generateTranscriptRepresentation(ctx context.Context, doc mode
 	segments := chunkTranscriptByTimeWithWordsFiltered(transcriptText, words, s.captionWordFilter())
 	if len(segments) == 0 {
 		return nil
+	}
+	// Optional leading-silence trim (dir2mcp#258): when enabled, subtract the
+	// detected dead-air offset from every time span and word timestamp so the
+	// transcript aligns to first speech. Disabled (default) leaves spans
+	// untouched; ffmpeg absent / detection failure -> 0 offset -> no change.
+	if s.cfg.MediaTrimLeadingSilence {
+		if offset := s.detectLeadingSilence(ctx, doc); offset > 0 {
+			shiftTranscriptSpans(segments, int(offset.Milliseconds()))
+		}
 	}
 	if err := s.repGen.upsertChunksForRepresentation(ctx, repID, "text", segments, decision); err != nil {
 		return fmt.Errorf("persist transcript chunks: %w", err)

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -1853,10 +1853,14 @@ func (s *Service) generateTranscriptRepresentation(ctx context.Context, doc mode
 	// Optional leading-silence trim (dir2mcp#258): when enabled, subtract the
 	// detected dead-air offset from every time span and word timestamp so the
 	// transcript aligns to first speech. Disabled (default) leaves spans
-	// untouched; ffmpeg absent / detection failure -> 0 offset -> no change.
+	// untouched; ffmpeg absent / detection failure -> 0 offset -> no change. The
+	// offset is captured so the SAME shift is applied to any translated
+	// transcripts below, keeping source/translated time windows aligned.
+	trimOffsetMS := 0
 	if s.cfg.MediaTrimLeadingSilence {
 		if offset := s.detectLeadingSilence(ctx, doc); offset > 0 {
-			shiftTranscriptSpans(segments, int(offset.Milliseconds()))
+			trimOffsetMS = int(offset.Milliseconds())
+			shiftTranscriptSpans(segments, trimOffsetMS)
 		}
 	}
 	if err := s.repGen.upsertChunksForRepresentation(ctx, repID, "text", segments, decision); err != nil {
@@ -1873,7 +1877,7 @@ func (s *Service) generateTranscriptRepresentation(ctx context.Context, doc mode
 	// Translation is a best-effort enrichment: any failure (chat provider error,
 	// translated-rep persistence) is logged and counted but NOT propagated, so a
 	// failed translation never marks the source transcript's document as errored.
-	if err := s.translateTranscriptRepresentations(ctx, doc, content, transcriptText, duration); err != nil {
+	if err := s.translateTranscriptRepresentations(ctx, doc, content, transcriptText, duration, trimOffsetMS); err != nil {
 		s.getLogger().Printf("transcript translation skipped for %s: %v", doc.RelPath, err)
 		s.addErrors(1)
 	}
@@ -1890,7 +1894,7 @@ func (s *Service) generateTranscriptRepresentation(ctx context.Context, doc mode
 // TranscriptRepType(lang) so it coexists with the source transcript and any
 // sidecar per-language reps; routes through the output quality gate; and records
 // source_language + translate provider/model in meta_json.
-func (s *Service) translateTranscriptRepresentations(ctx context.Context, doc model.Document, content []byte, sourceText string, duration time.Duration) error {
+func (s *Service) translateTranscriptRepresentations(ctx context.Context, doc model.Document, content []byte, sourceText string, duration time.Duration, trimOffsetMS int) error {
 	if s.translator == nil || len(s.translateTargetLangs) == 0 {
 		return nil
 	}
@@ -1902,7 +1906,7 @@ func (s *Service) translateTranscriptRepresentations(ctx context.Context, doc mo
 			// Skip a no-op translation into the source language itself.
 			continue
 		}
-		if err := s.translateOneTranscript(ctx, doc, content, sourceText, sourceLang, lang, duration); err != nil {
+		if err := s.translateOneTranscript(ctx, doc, content, sourceText, sourceLang, lang, duration, trimOffsetMS); err != nil {
 			// Best-effort per language: a failure on one target must not suppress
 			// the remaining targets. Log here and keep going; the first error is
 			// returned so the caller can log/count it (non-fatally).
@@ -1944,7 +1948,7 @@ func sameLanguage(a, b string) bool {
 // is cached per-language (TranscriptLangSuffix) keyed by the SOURCE content hash
 // so re-ingesting an unchanged document reuses the cached translation instead of
 // re-calling the chat provider.
-func (s *Service) translateOneTranscript(ctx context.Context, doc model.Document, content []byte, sourceText, sourceLang, targetLang string, duration time.Duration) error {
+func (s *Service) translateOneTranscript(ctx context.Context, doc model.Document, content []byte, sourceText, sourceLang, targetLang string, duration time.Duration, trimOffsetMS int) error {
 	translated, err := s.readOrComputeTranslation(ctx, content, sourceText, targetLang)
 	if err != nil {
 		return fmt.Errorf("translate transcript for %s into %q: %w", doc.RelPath, targetLang, err)
@@ -1997,6 +2001,12 @@ func (s *Service) translateOneTranscript(ctx context.Context, doc model.Document
 	segments := chunkTranscriptByTime(translated)
 	if len(segments) == 0 {
 		return nil
+	}
+	// Apply the same leading-silence trim offset as the source transcript so the
+	// translated time windows stay aligned with the source (dir2mcp#258). A zero
+	// offset (trim disabled / no silence detected) is a no-op.
+	if trimOffsetMS > 0 {
+		shiftTranscriptSpans(segments, trimOffsetMS)
 	}
 	if err := s.repGen.upsertChunksForRepresentation(ctx, repID, "text", segments, decision); err != nil {
 		return fmt.Errorf("persist translated transcript chunks: %w", err)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -127,9 +127,15 @@ type Profile struct {
 	OCRModel        string
 	STTModel        string
 	STTLanguage     string // optional STT language hint (e.g. ElevenLabs)
-	TTSModel        string
-	TTSVoice        string // TTS voice id/name (e.g. ElevenLabs voice, OpenAI voice)
-	RerankModel     string
+	// STTVAD requests a provider-side voice-activity-detection filter where
+	// supported (dir2mcp#258, config `media.vad`). For the self-hosted whisper
+	// provider this maps to the OpenAI-compatible `vad_filter` form field;
+	// providers without VAD support ignore it. It is not part of the STT
+	// identity, so toggling it is not reindex-bound.
+	STTVAD      bool
+	TTSModel    string
+	TTSVoice    string // TTS voice id/name (e.g. ElevenLabs voice, OpenAI voice)
+	RerankModel string
 }
 
 // Eligible reports whether the profile may be selected/preflighted

--- a/internal/providerfactory/factory.go
+++ b/internal/providerfactory/factory.go
@@ -212,6 +212,7 @@ func Transcriber(p provider.Profile) (model.Transcriber, error) {
 		if lang := strings.TrimSpace(p.STTLanguage); lang != "" {
 			c.DefaultLanguage = lang
 		}
+		c.VADFilter = p.STTVAD
 		return c, nil
 	case provider.KindMistral:
 		c := mistral.NewClient(p.BaseURL, p.APIKey)

--- a/internal/whisperapi/client.go
+++ b/internal/whisperapi/client.go
@@ -84,6 +84,12 @@ type Client struct {
 	// segments + word timestamps per spec §8.6.1) or "json" (segments only).
 	// Empty falls back to ResponseFormatVerboseJSON.
 	ResponseFormat string
+
+	// VADFilter, when true, sends the OpenAI-compatible `vad_filter=true` form
+	// field so a server that supports voice-activity detection (e.g.
+	// faster-whisper) skips non-speech audio (dir2mcp#258, config `media.vad`).
+	// Servers without VAD support ignore the field. Default false.
+	VADFilter bool
 }
 
 // compile-time interface check.
@@ -234,6 +240,11 @@ func (c *Client) buildBody(relPath string, data []byte) ([]byte, *multipart.Writ
 	if language := strings.TrimSpace(c.DefaultLanguage); language != "" {
 		if err := writer.WriteField("language", language); err != nil {
 			return fail("failed to write transcription language", err)
+		}
+	}
+	if c.VADFilter {
+		if err := writer.WriteField("vad_filter", "true"); err != nil {
+			return fail("failed to write transcription vad_filter", err)
 		}
 	}
 	if err := writer.Close(); err != nil {

--- a/tests/avutil/leading_silence_test.go
+++ b/tests/avutil/leading_silence_test.go
@@ -1,0 +1,76 @@
+package tests
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/avutil"
+)
+
+// TestParseLeadingSilence covers the silencedetect stderr parsing that drives
+// the optional leading-silence transcript trim (dir2mcp#258). The detector
+// itself shells out to ffmpeg; parsing is the deterministic part worth testing
+// without the binary.
+func TestParseLeadingSilence(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		stderr string
+		want   time.Duration
+	}{
+		{
+			name: "leading silence at exact zero",
+			stderr: "[silencedetect @ 0x1] silence_start: 0\n" +
+				"[silencedetect @ 0x1] silence_end: 1.234 | silence_duration: 1.234\n",
+			want: 1234 * time.Millisecond,
+		},
+		{
+			name: "leading silence within start epsilon",
+			stderr: "[silencedetect @ 0x1] silence_start: 0.012\n" +
+				"[silencedetect @ 0x1] silence_end: 2.5 | silence_duration: 2.488\n",
+			want: 2500 * time.Millisecond,
+		},
+		{
+			name: "first silence is mid-stream -> no leading silence",
+			stderr: "[silencedetect @ 0x1] silence_start: 12.0\n" +
+				"[silencedetect @ 0x1] silence_end: 14.0 | silence_duration: 2.0\n",
+			want: 0,
+		},
+		{
+			name:   "no silence reported -> zero",
+			stderr: "size=N/A time=00:01:00.00 bitrate=N/A speed=120x\n",
+			want:   0,
+		},
+		{
+			name: "implausibly long leading silence is rejected",
+			stderr: "[silencedetect @ 0x1] silence_start: 0\n" +
+				"[silencedetect @ 0x1] silence_end: 42.0 | silence_duration: 42.0\n",
+			want: 0,
+		},
+		{
+			name: "leading silence then later gap takes only the leading one",
+			stderr: "[silencedetect @ 0x1] silence_start: 0\n" +
+				"[silencedetect @ 0x1] silence_end: 0.9 | silence_duration: 0.9\n" +
+				"[silencedetect @ 0x1] silence_start: 30.0\n" +
+				"[silencedetect @ 0x1] silence_end: 31.0 | silence_duration: 1.0\n",
+			want: 900 * time.Millisecond,
+		},
+		{
+			name:   "empty output -> zero",
+			stderr: "",
+			want:   0,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := avutil.ParseLeadingSilence(tc.stderr)
+			if got != tc.want {
+				t.Fatalf("ParseLeadingSilence = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/tests/config/media_variants_config_test.go
+++ b/tests/config/media_variants_config_test.go
@@ -136,6 +136,25 @@ func TestMediaSilenceThreshold_NestedYAMLApplies(t *testing.T) {
 	}
 }
 
+// TestMediaSilenceThreshold_RejectsNonFinite asserts that NaN/Inf strings (which
+// strconv.ParseFloat accepts) are rejected at config-parse time rather than
+// surfacing later during ffmpeg execution.
+func TestMediaSilenceThreshold_RejectsNonFinite(t *testing.T) {
+	for _, bad := range []string{"NaN", "Inf", "+Inf", "-Inf", "Infinity"} {
+		tmp := t.TempDir()
+		path := filepath.Join(tmp, ".dir2mcp.yaml")
+		writeFile(t, path, strings.Join([]string{
+			"root_dir: /tmp/repo",
+			"state_dir: /tmp/repo/.dir2mcp",
+			"media_silence_threshold_db: " + bad,
+		}, "\n")+"\n")
+
+		if _, err := config.LoadFile(path); err == nil {
+			t.Errorf("LoadFile with media_silence_threshold_db=%q = nil error, want rejection", bad)
+		}
+	}
+}
+
 // TestMediaVariants_NestedYAMLApplies locks the nested spec-style block
 // (media: -> variants: -> group/select) so it is actually applied rather than
 // silently falling back to defaults (regression: isMapSectionKey must recognize

--- a/tests/config/media_variants_config_test.go
+++ b/tests/config/media_variants_config_test.go
@@ -61,6 +61,81 @@ func TestMediaVariants_RoundTripsThroughSaveLoad(t *testing.T) {
 	}
 }
 
+// TestMediaLeadingSilence_RoundTripsThroughSaveLoad exercises the new
+// leading-silence/VAD scalars (dir2mcp#258), including the float plumbing for a
+// negative dB threshold (setFloatFileScalar/floatPtr), through save/load.
+func TestMediaLeadingSilence_RoundTripsThroughSaveLoad(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+
+	cfg := config.Default()
+	cfg.RootDir = "/tmp/repo"
+	cfg.StateDir = "/tmp/repo/.dir2mcp"
+	cfg.MediaTrimLeadingSilence = true
+	cfg.MediaSilenceThresholdDB = -42.5
+	cfg.MediaVAD = true
+	if err := config.SaveFile(path, cfg); err != nil {
+		t.Fatalf("SaveFile failed: %v", err)
+	}
+	loaded, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile failed: %v", err)
+	}
+	if !loaded.MediaTrimLeadingSilence {
+		t.Errorf("media.trim_leading_silence did not round-trip")
+	}
+	if loaded.MediaSilenceThresholdDB != -42.5 {
+		t.Errorf("media.silence_threshold_db did not round-trip: got %v, want -42.5", loaded.MediaSilenceThresholdDB)
+	}
+	if !loaded.MediaVAD {
+		t.Errorf("media.vad did not round-trip")
+	}
+}
+
+// TestMediaLeadingSilence_Defaults locks the opt-in defaults: trimming and VAD
+// off, threshold left at zero so avutil applies its own -40 dB default.
+func TestMediaLeadingSilence_Defaults(t *testing.T) {
+	cfg := config.Default()
+	if cfg.MediaTrimLeadingSilence {
+		t.Errorf("media.trim_leading_silence must default to false")
+	}
+	if cfg.MediaVAD {
+		t.Errorf("media.vad must default to false")
+	}
+	if cfg.MediaSilenceThresholdDB != 0 {
+		t.Errorf("media.silence_threshold_db default = %v, want 0 (avutil default applies)", cfg.MediaSilenceThresholdDB)
+	}
+}
+
+// TestMediaSilenceThreshold_NestedYAMLApplies asserts the nested media: block
+// carries the negative-dB float scalar through the bespoke YAML scanner.
+func TestMediaSilenceThreshold_NestedYAMLApplies(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+	writeFile(t, path, strings.Join([]string{
+		"root_dir: /tmp/repo",
+		"state_dir: /tmp/repo/.dir2mcp",
+		"media:",
+		"  trim_leading_silence: true",
+		"  silence_threshold_db: -40",
+		"  vad: true",
+	}, "\n")+"\n")
+
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile(nested media) = %v, want nil", err)
+	}
+	if !cfg.MediaTrimLeadingSilence {
+		t.Errorf("nested media.trim_leading_silence not applied")
+	}
+	if cfg.MediaSilenceThresholdDB != -40 {
+		t.Errorf("nested media.silence_threshold_db = %v, want -40", cfg.MediaSilenceThresholdDB)
+	}
+	if !cfg.MediaVAD {
+		t.Errorf("nested media.vad not applied")
+	}
+}
+
 // TestMediaVariants_NestedYAMLApplies locks the nested spec-style block
 // (media: -> variants: -> group/select) so it is actually applied rather than
 // silently falling back to defaults (regression: isMapSectionKey must recognize

--- a/tests/ingest/leading_silence_test.go
+++ b/tests/ingest/leading_silence_test.go
@@ -115,6 +115,48 @@ func TestGenerateTranscript_LeadingSilenceTrimEnabled(t *testing.T) {
 	}
 }
 
+// TestGenerateTranscript_LeadingSilenceTrim_ShiftsTranslatedSpans asserts the
+// trim offset is propagated to translated transcripts (dir2mcp#258): with trim
+// enabled AND translation on, both the source and translated time windows are
+// shifted by the same detected offset so they stay aligned.
+func TestGenerateTranscript_LeadingSilenceTrim_ShiftsTranslatedSpans(t *testing.T) {
+	t.Parallel()
+	st := &fakeIngestStore{}
+	root, content := mediaDocRoot(t)
+	svc := mustNewIngestService(t, config.Config{
+		StateDir:                t.TempDir(),
+		RootDir:                 root,
+		MediaTrimLeadingSilence: true,
+	}, st)
+	svc.SetTranscriber(&fakeTranscriber{text: "[00:00] intro\n[00:02] chapter one\n[00:05] chapter two"})
+	svc.SetTranscriptLanguage("de")
+	svc.SetTranslator(&fakeTranslator{}, "mistral", "m", []string{"en"})
+	svc.DetectLeadingSilenceFunc = func(context.Context, string) (time.Duration, error) {
+		return 2 * time.Second, nil
+	}
+
+	doc := model.Document{DocID: 104, RelPath: "audio/lecture.mp3", DocType: "audio"}
+	if err := svc.GenerateTranscriptRepresentation(context.Background(), doc, content); err != nil {
+		t.Fatalf("GenerateTranscriptRepresentation failed: %v", err)
+	}
+
+	// 3 source spans (shifted) + 3 translated spans (must be shifted identically).
+	if len(st.spans) != 6 {
+		t.Fatalf("expected 3 source + 3 translated spans, got %d", len(st.spans))
+	}
+	// Baseline [0,2000)[2000,5000)[5000,6000); a 2000ms trim -> [0,1)[0,3000)[3000,4000).
+	want := [][2]int{{0, 1}, {0, 3000}, {3000, 4000}}
+	for half, label := range []string{"source", "translated"} {
+		base := st.spans[half*3 : half*3+3]
+		for i, w := range want {
+			if base[i].StartMS != w[0] || base[i].EndMS != w[1] {
+				t.Errorf("%s span[%d] = [%d,%d), want [%d,%d)", label, i,
+					base[i].StartMS, base[i].EndMS, w[0], w[1])
+			}
+		}
+	}
+}
+
 // TestGenerateTranscript_LeadingSilenceTrimDisabled asserts spans are untouched
 // when the toggle is off, even if a detector would report silence.
 func TestGenerateTranscript_LeadingSilenceTrimDisabled(t *testing.T) {

--- a/tests/ingest/leading_silence_test.go
+++ b/tests/ingest/leading_silence_test.go
@@ -1,0 +1,217 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// TestShiftTranscriptSpans_ShiftsAndClamps verifies the pure span shift used by
+// the leading-silence trim (dir2mcp#258): every "time" span's bounds and word
+// timestamps are reduced by the offset and clamped at 0.
+func TestShiftTranscriptSpans_ShiftsAndClamps(t *testing.T) {
+	t.Parallel()
+	const transcript = "[00:00] intro\n[00:02] chapter one\n[00:05] chapter two"
+	words := []model.TimedWord{
+		{Word: "intro", StartMS: 0, EndMS: 800},
+		{Word: "chapter", StartMS: 2000, EndMS: 2500},
+		{Word: "two", StartMS: 5400, EndMS: 5800},
+	}
+	base := ingest.ChunkTranscriptByTimeWithWords(transcript, words)
+
+	const offsetMS = 1500
+	shifted := ingest.ShiftTranscriptSpans(base, offsetMS)
+
+	if len(shifted) != len(base) {
+		t.Fatalf("shift changed chunk count: %d vs %d", len(shifted), len(base))
+	}
+	for i := range base {
+		if shifted[i].Text != base[i].Text {
+			t.Errorf("chunk[%d] text changed by shift: %q vs %q", i, shifted[i].Text, base[i].Text)
+		}
+		if base[i].Span.Kind != "time" {
+			continue
+		}
+		wantStart := clamp(base[i].Span.StartMS - offsetMS)
+		wantEnd := clamp(base[i].Span.EndMS - offsetMS)
+		if wantEnd <= wantStart {
+			wantEnd = wantStart + 1
+		}
+		if shifted[i].Span.StartMS != wantStart || shifted[i].Span.EndMS != wantEnd {
+			t.Errorf("chunk[%d] span = [%d,%d), want [%d,%d)", i,
+				shifted[i].Span.StartMS, shifted[i].Span.EndMS, wantStart, wantEnd)
+		}
+		for w := range base[i].Span.Words {
+			wantT := clamp(base[i].Span.Words[w].T - offsetMS)
+			if shifted[i].Span.Words[w].T != wantT {
+				t.Errorf("chunk[%d] word[%d] T = %d, want %d", i, w, shifted[i].Span.Words[w].T, wantT)
+			}
+		}
+	}
+
+	// First span started at 0 -> clamps to 0, never negative.
+	if shifted[0].Span.StartMS < 0 {
+		t.Errorf("first span start went negative: %d", shifted[0].Span.StartMS)
+	}
+
+	// The input must not be mutated by the exported wrapper.
+	if base[1].Span.StartMS != 2000 {
+		t.Errorf("input span was mutated: got %d, want 2000", base[1].Span.StartMS)
+	}
+}
+
+func TestShiftTranscriptSpans_ZeroOffsetIsNoOp(t *testing.T) {
+	t.Parallel()
+	base := ingest.ChunkTranscriptByTime("[00:00] intro\n[00:02] chapter one")
+	for _, off := range []int{0, -100} {
+		got := ingest.ShiftTranscriptSpans(base, off)
+		for i := range base {
+			if got[i].Span.StartMS != base[i].Span.StartMS || got[i].Span.EndMS != base[i].Span.EndMS {
+				t.Fatalf("offset %d shifted spans: %+v vs %+v", off, got[i].Span, base[i].Span)
+			}
+		}
+	}
+}
+
+// TestGenerateTranscript_LeadingSilenceTrimEnabled exercises the full ingest
+// path with the trim enabled and a stubbed detector reporting 2s of leading
+// silence; every persisted time span must be shifted back by 2000ms (clamped).
+func TestGenerateTranscript_LeadingSilenceTrimEnabled(t *testing.T) {
+	t.Parallel()
+	st := &fakeIngestStore{}
+	root, content := mediaDocRoot(t)
+	svc := mustNewIngestService(t, config.Config{
+		StateDir:                t.TempDir(),
+		RootDir:                 root,
+		MediaTrimLeadingSilence: true,
+	}, st)
+	svc.SetTranscriber(&fakeTranscriber{text: "[00:00] intro\n[00:02] chapter one\n[00:05] chapter two"})
+	svc.DetectLeadingSilenceFunc = func(context.Context, string) (time.Duration, error) {
+		return 2 * time.Second, nil
+	}
+
+	doc := model.Document{DocID: 101, RelPath: "audio/lecture.mp3", DocType: "audio"}
+	if err := svc.GenerateTranscriptRepresentation(context.Background(), doc, content); err != nil {
+		t.Fatalf("GenerateTranscriptRepresentation failed: %v", err)
+	}
+
+	if len(st.spans) != 3 {
+		t.Fatalf("expected 3 spans, got %d", len(st.spans))
+	}
+	// Baseline spans are [0,2000) [2000,5000) [5000,6000); a 2000ms trim yields
+	// [0,1) (clamped+widened) [0,3000) [3000,4000).
+	want := [][2]int{{0, 1}, {0, 3000}, {3000, 4000}}
+	for i, w := range want {
+		if st.spans[i].StartMS != w[0] || st.spans[i].EndMS != w[1] {
+			t.Errorf("span[%d] = [%d,%d), want [%d,%d)", i, st.spans[i].StartMS, st.spans[i].EndMS, w[0], w[1])
+		}
+	}
+}
+
+// TestGenerateTranscript_LeadingSilenceTrimDisabled asserts spans are untouched
+// when the toggle is off, even if a detector would report silence.
+func TestGenerateTranscript_LeadingSilenceTrimDisabled(t *testing.T) {
+	t.Parallel()
+	st := &fakeIngestStore{}
+	root, content := mediaDocRoot(t)
+	svc := mustNewIngestService(t, config.Config{
+		StateDir: t.TempDir(),
+		RootDir:  root,
+		// MediaTrimLeadingSilence defaults to false.
+	}, st)
+	svc.SetTranscriber(&fakeTranscriber{text: "[00:00] intro\n[00:02] chapter one\n[00:05] chapter two"})
+	called := false
+	svc.DetectLeadingSilenceFunc = func(context.Context, string) (time.Duration, error) {
+		called = true
+		return 2 * time.Second, nil
+	}
+
+	doc := model.Document{DocID: 102, RelPath: "audio/lecture.mp3", DocType: "audio"}
+	if err := svc.GenerateTranscriptRepresentation(context.Background(), doc, content); err != nil {
+		t.Fatalf("GenerateTranscriptRepresentation failed: %v", err)
+	}
+	if called {
+		t.Error("detector was invoked while trim is disabled")
+	}
+	assertSpanWindows(t, st, [][2]int{{0, 2000}, {2000, 5000}, {5000, 6000}})
+}
+
+// TestGenerateTranscript_LeadingSilenceDetectorError asserts a detector error or
+// absent ffmpeg (0 offset) leaves spans unchanged — graceful, never fatal.
+func TestGenerateTranscript_LeadingSilenceDetectorError(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		fn   func(context.Context, string) (time.Duration, error)
+	}{
+		{"detector error", func(context.Context, string) (time.Duration, error) {
+			return 0, errors.New("ffmpeg blew up")
+		}},
+		{"tool absent / no silence", func(context.Context, string) (time.Duration, error) {
+			return 0, nil
+		}},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			st := &fakeIngestStore{}
+			root, content := mediaDocRoot(t)
+			svc := mustNewIngestService(t, config.Config{
+				StateDir:                t.TempDir(),
+				RootDir:                 root,
+				MediaTrimLeadingSilence: true,
+			}, st)
+			svc.SetTranscriber(&fakeTranscriber{text: "[00:00] intro\n[00:02] chapter one\n[00:05] chapter two"})
+			svc.DetectLeadingSilenceFunc = tc.fn
+
+			doc := model.Document{DocID: 103, RelPath: "audio/lecture.mp3", DocType: "audio"}
+			if err := svc.GenerateTranscriptRepresentation(context.Background(), doc, content); err != nil {
+				t.Fatalf("GenerateTranscriptRepresentation failed: %v", err)
+			}
+			assertSpanWindows(t, st, [][2]int{{0, 2000}, {2000, 5000}, {5000, 6000}})
+		})
+	}
+}
+
+// mediaDocRoot creates a temp corpus root containing audio/lecture.mp3 so the
+// service's CorpusFS.Localize resolves cleanly, and returns the root plus the
+// file content used as the transcribe input.
+func mediaDocRoot(t *testing.T) (string, []byte) {
+	t.Helper()
+	root := t.TempDir()
+	content := []byte("fake-audio-bytes")
+	mediaPath := filepath.Join(root, "audio", "lecture.mp3")
+	if err := os.MkdirAll(filepath.Dir(mediaPath), 0o755); err != nil {
+		t.Fatalf("mkdir media dir: %v", err)
+	}
+	if err := os.WriteFile(mediaPath, content, 0o644); err != nil {
+		t.Fatalf("write media file: %v", err)
+	}
+	return root, content
+}
+
+func assertSpanWindows(t *testing.T, st *fakeIngestStore, want [][2]int) {
+	t.Helper()
+	if len(st.spans) != len(want) {
+		t.Fatalf("expected %d spans, got %d", len(want), len(st.spans))
+	}
+	for i, w := range want {
+		if st.spans[i].StartMS != w[0] || st.spans[i].EndMS != w[1] {
+			t.Errorf("span[%d] = [%d,%d), want [%d,%d)", i, st.spans[i].StartMS, st.spans[i].EndMS, w[0], w[1])
+		}
+	}
+}
+
+func clamp(ms int) int {
+	if ms < 0 {
+		return 0
+	}
+	return ms
+}

--- a/tests/whisperapi/client_test.go
+++ b/tests/whisperapi/client_test.go
@@ -43,6 +43,8 @@ type parsedForm struct {
 	fileName       string
 	auth           string
 	hasAuth        bool
+	vadFilter      string
+	hasVADFilter   bool
 }
 
 func parseMultipart(t *testing.T, r *http.Request) parsedForm {
@@ -74,6 +76,9 @@ func parseMultipart(t *testing.T, r *http.Request) parsedForm {
 			out.responseFormat = string(data)
 		case "file":
 			out.fileName = part.FileName()
+		case "vad_filter":
+			out.vadFilter = string(data)
+			out.hasVADFilter = true
 		}
 	}
 	return out
@@ -145,6 +150,43 @@ func TestVerboseJSONResponseFormat(t *testing.T) {
 	}
 	if got.responseFormat != "verbose_json" {
 		t.Errorf("response_format = %q, want verbose_json", got.responseFormat)
+	}
+}
+
+// TestVADFilterField asserts the OpenAI-compatible vad_filter=true multipart
+// field is sent only when VADFilter is enabled (dir2mcp#258, config media.vad),
+// and is omitted entirely by default so non-VAD servers see no extra field.
+func TestVADFilterField(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		enabled bool
+		wantSet bool
+	}{
+		{"enabled sends vad_filter=true", true, true},
+		{"disabled omits vad_filter", false, false},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			var got parsedForm
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				got = parseMultipart(t, r)
+				_, _ = io.WriteString(w, jsonSegments)
+			}))
+			defer srv.Close()
+
+			c := newClient(srv.URL, "")
+			c.VADFilter = tc.enabled
+
+			if _, err := c.Transcribe(context.Background(), "a.wav", []byte("x")); err != nil {
+				t.Fatalf("Transcribe: %v", err)
+			}
+			if got.hasVADFilter != tc.wantSet {
+				t.Fatalf("vad_filter present = %v, want %v", got.hasVADFilter, tc.wantSet)
+			}
+			if tc.wantSet && got.vadFilter != "true" {
+				t.Errorf("vad_filter = %q, want true", got.vadFilter)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Closes #258. Part of epic #261 (livevtt absorption).

## What

Adds an **opt-in, general-purpose** leading-silence trim for media transcripts, mirroring livevtt's `--trim-silence`, so transcript timestamps align to first speech and dead air is not sent to STT. Also adds an optional VAD toggle threaded to the whisper provider.

## Changes

- **`internal/avutil`** — new `DetectLeadingSilence` helper running `ffmpeg -af silencedetect=noise=<dB>:d=<s>` with a bounded timeout and the same sanitized invocation style as the existing helpers. Returns the leading-silence duration; **graceful** (ffmpeg absent or detection failure -> `0`, never fatal), bounded to <5s like livevtt to avoid trimming a long intentional intro. `ExtractSegment`/`ExtractSegmentURL` are **not** modified (kept separate to minimize conflict with PR #294).
- **`internal/config`** — `media.trim_leading_silence` (bool, **default OFF**), `media.silence_threshold_db` (float, default -40 dB), `media.vad` (bool, default OFF). Default-off rationale: livevtt defaulted trim on for broadcast capture, but dir2mcp is general-purpose and silence-trim is a heuristic that can shift timestamps where leading silence is intentional, so it is opt-in here.
- **`internal/ingest/service.go`** — when enabled, detect leading silence (injectable `DetectLeadingSilenceFunc`, mirroring `ProbeDurationFunc`) and subtract the offset from every transcript **time span and word timestamp**, clamped >=0, deterministically. Disabled (default) or detector error/absent -> spans unchanged. Change is localized to the transcription path to minimize conflict with PR #293.
- **whisper provider** — `media.vad` threads through `provider.Profile.STTVAD` to the OpenAI-compatible `vad_filter` form field on the whisper client; other STT providers ignore it.

## Tests (`tests/`, package `tests`)

- `tests/avutil` — `silencedetect` stderr parsing (leading-at-zero, within-epsilon, mid-stream-only, implausibly-long-rejected, none/empty).
- `tests/ingest` — pure span shift + clamp; full ingest path with a **stubbed detector**: N ms leading silence -> spans shifted by N (clamped); disabled = unchanged + detector not invoked; detector error / tool-absent = unchanged. No real ffmpeg required.

## Governance

SPEC §8.6 (media surface) is **silent** on silence-trim/VAD; this is config-driven ingest preprocessing with no wire/tool contract, so **no dirstral-spec PR is required**. The submodule is **not** re-pinned.

## Rebase note

Expect a later rebase: PR #294 (S3 range-read) touches `internal/avutil` and PR #293 (translation) touches `internal/ingest/service.go` + `internal/config/config.go`. Additions here are isolated (new avutil function, new config fields, new transcription-path block) to keep conflicts minimal.

`make check` passes locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added leading-silence detection for audio media with configurable silence threshold and minimum duration parameters.
  * Transcripts now automatically align to first detected speech when silence trimming is enabled.
  * Added voice-activity-detection (VAD) filtering toggle to skip non-speech segments during transcription.

* **Tests**
  * Added tests for silence detection, transcript time-shifting, and VAD filtering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->