### PR TITLE
feat(media): config-driven caption filter-words (ingest + subtitle export)

### DIFF
--- a/internal/cli/export.go
+++ b/internal/cli/export.go
@@ -66,7 +66,8 @@ func (a *App) runExport(ctx context.Context, global globalOptions, args []string
 		return exitGeneric
 	}
 
-	rendered, code := a.renderTranscriptExport(ctx, global, ts, opts)
+	filter := subtitle.NewWordFilter(cfg.MediaFilterWords)
+	rendered, code := a.renderTranscriptExport(ctx, global, ts, opts, filter)
 	if code != exitSuccess {
 		return code
 	}
@@ -78,7 +79,7 @@ func (a *App) runExport(ctx context.Context, global globalOptions, args []string
 // from its chunks, and renders them in the requested format. It returns the
 // serialized document, or an exit code on error (no transcript, no chunks,
 // unknown language, store failure).
-func (a *App) renderTranscriptExport(ctx context.Context, global globalOptions, ts transcriptStore, opts exportOptions) (string, int) {
+func (a *App) renderTranscriptExport(ctx context.Context, global globalOptions, ts transcriptStore, opts exportOptions, filter *subtitle.WordFilter) (string, int) {
 	reps, err := ts.TranscriptRepresentations(ctx, opts.relPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -110,6 +111,11 @@ func (a *App) renderTranscriptExport(ctx context.Context, global globalOptions, 
 		chunks = append(chunks, subtitle.TranscriptChunk{Text: r.Text, Span: r.Span})
 	}
 	cues := subtitle.BuildCues(chunks)
+	// Apply the configured caption word filter (media.filter_words) on export so
+	// exported VTT/SRT never contain the boilerplate/credits/watermark phrases,
+	// consistent with how ingest strips them before embedding. Cues empty after
+	// filtering are dropped. An empty config leaves cues unchanged.
+	cues = subtitle.FilterCues(cues, filter)
 	if len(cues) == 0 {
 		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("document %q transcript has no time-coded cues to export", opts.relPath))
 		return "", exitGeneric

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -239,6 +239,15 @@ type Config struct {
 	// consulted when MediaTranslateEnabled is true; enabling translation with an
 	// empty list is CONFIG_INVALID.
 	MediaTranslateTargetLangs []string
+	// MediaFilterWords is an optional, general-purpose list of boilerplate /
+	// credits / watermark phrases stripped from transcript and subtitle text
+	// (config `media.filter_words`). Matching is case-insensitive substring
+	// removal; the same filter is applied during transcript chunking (so the
+	// phrases are never embedded) and on subtitle export (so VTT/SRT never
+	// contain them). Empty by default = off: behavior is unchanged everywhere
+	// when no phrases are configured. There are NO built-in defaults — the list
+	// carries no language- or domain-specific phrases.
+	MediaFilterWords []string
 
 	// QualityGatesEnabled is the master switch for the output quality gate
 	// (spec 0.16.0): when true (default), generated transcript/OCR text is
@@ -347,6 +356,7 @@ type fileConfig struct {
 	MediaVariantsSelect       *string
 	MediaTranslateEnabled     *bool
 	MediaTranslateTargetLangs []string
+	MediaFilterWords          []string
 	ElevenLabsAPIKey          *string
 	ServerTLSCertFile         *string
 	ServerTLSKeyFile          *string
@@ -438,6 +448,7 @@ type persistedConfig struct {
 	MediaVariantsSelect       string        `yaml:"media_variants_select"`
 	MediaTranslateEnabled     bool          `yaml:"media_translate_enabled"`
 	MediaTranslateTargetLangs []string      `yaml:"media_translate_target_langs"`
+	MediaFilterWords          []string      `yaml:"media_filter_words"`
 	ServerTLSCertFile         string        `yaml:"server_tls_cert_file"`
 	ServerTLSKeyFile          string        `yaml:"server_tls_key_file"`
 
@@ -664,6 +675,7 @@ func buildPersistedConfig(cfg *Config) persistedConfig {
 		MediaVariantsSelect:       cfg.MediaVariantsSelect,
 		MediaTranslateEnabled:     cfg.MediaTranslateEnabled,
 		MediaTranslateTargetLangs: append([]string(nil), cfg.MediaTranslateTargetLangs...),
+		MediaFilterWords:          append([]string(nil), cfg.MediaFilterWords...),
 		ServerTLSCertFile:         cfg.ServerTLSCertFile,
 		ServerTLSKeyFile:          cfg.ServerTLSKeyFile,
 		X402Mode:                  cfg.X402.Mode,
@@ -1284,6 +1296,9 @@ func applySTTFileParsed(cfg *Config, fc fileConfig) {
 	if fc.MediaTranslateTargetLangs != nil {
 		cfg.MediaTranslateTargetLangs = normalizeStringSlice(fc.MediaTranslateTargetLangs)
 	}
+	if fc.MediaFilterWords != nil {
+		cfg.MediaFilterWords = normalizeStringSlice(fc.MediaFilterWords)
+	}
 }
 
 // applyX402FileParsed copies the set x402 file fields onto cfg.X402.
@@ -1550,6 +1565,8 @@ var configKeyAliases = map[string]string{
 	"media_variants_select":                "media.variants.select",
 	"media_translate_enabled":              "media.translate.enabled",
 	"media_translate_target_langs":         "media.translate.target_langs",
+	"media_filter_words":                   "media.filter_words",
+	"filter_words":                         "media.filter_words",
 	"stt_provider":                         "stt.provider",
 	"stt_mistral_model":                    "stt.mistral.model",
 	"stt_elevenlabs_model":                 "stt.elevenlabs.model",
@@ -1926,6 +1943,8 @@ func setFileListValue(cfg *fileConfig, key, value string) {
 		appendValue(&cfg.AllowedOrigins, value)
 	case "media.translate.target_langs":
 		appendValue(&cfg.MediaTranslateTargetLangs, value)
+	case "media.filter_words":
+		appendValue(&cfg.MediaFilterWords, value)
 	}
 }
 
@@ -1934,7 +1953,7 @@ func setFileListValue(cfg *fileConfig, key, value string) {
 func isListConfigKey(key string) bool {
 	key = canonicalizeConfigKey(key)
 	switch key {
-	case "trusted_proxies", "path_excludes", "secret_patterns", "allowed_origins", "media.translate.target_langs":
+	case "trusted_proxies", "path_excludes", "secret_patterns", "allowed_origins", "media.translate.target_langs", "media.filter_words":
 		return true
 	default:
 		return false
@@ -2029,6 +2048,7 @@ func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	writeScalar("media_variants_select", cfg.MediaVariantsSelect)
 	writeBool("media_translate_enabled", cfg.MediaTranslateEnabled)
 	writeList("media_translate_target_langs", cfg.MediaTranslateTargetLangs)
+	writeList("media_filter_words", cfg.MediaFilterWords)
 	writeScalar("server_tls_cert_file", cfg.ServerTLSCertFile)
 	writeScalar("server_tls_key_file", cfg.ServerTLSKeyFile)
 	writeScalar("x402_mode", cfg.X402Mode)

--- a/internal/ingest/represent.go
+++ b/internal/ingest/represent.go
@@ -632,12 +632,43 @@ func maxF(a, b float64) float64 {
 // produces output byte-for-byte identical to chunkTranscriptByTime, so a
 // provider without word timing is unaffected.
 func chunkTranscriptByTimeWithWords(content string, words []model.TimedWord) []chunkSegment {
+	return chunkTranscriptByTimeWithWordsFiltered(content, words, nil)
+}
+
+// chunkTranscriptByTimeWithWordsFiltered is chunkTranscriptByTimeWithWords with
+// an optional caption word filter (config media.filter_words) applied to each
+// chunk's text after chunking. A nil/inactive filter leaves the output
+// byte-for-byte identical. Word timing is attached after filtering so words tied
+// to a dropped (now-empty) chunk are not retained.
+func chunkTranscriptByTimeWithWordsFiltered(content string, words []model.TimedWord, filter *subtitle.WordFilter) []chunkSegment {
 	segs := chunkTranscriptByTime(content)
+	segs = applyWordFilterToSegments(segs, filter)
 	if len(words) == 0 || len(segs) == 0 {
 		return segs
 	}
 	attachWordsToTimeSpans(segs, words)
 	return segs
+}
+
+// applyWordFilterToSegments strips configured filter phrases from each segment's
+// text (case-insensitive substring removal) and drops segments whose text is
+// empty after filtering. A nil/inactive filter returns segs unchanged so the
+// empty-config path is a no-op. Spans (timing) are preserved verbatim on the
+// surviving segments.
+func applyWordFilterToSegments(segs []chunkSegment, filter *subtitle.WordFilter) []chunkSegment {
+	if !filter.Active() {
+		return segs
+	}
+	out := make([]chunkSegment, 0, len(segs))
+	for _, seg := range segs {
+		filtered := filter.Apply(seg.Text)
+		if strings.TrimSpace(filtered) == "" {
+			continue
+		}
+		seg.Text = filtered
+		out = append(out, seg)
+	}
+	return out
 }
 
 // attachWordsToTimeSpans assigns words to the chunk whose "time" span covers the
@@ -1070,6 +1101,18 @@ func ChunkTranscriptByTimeWithWords(content string, words []model.TimedWord) []C
 	return out
 }
 
+// ChunkTranscriptByTimeFiltered is the exported counterpart of
+// chunkTranscriptByTimeWithWordsFiltered (no word timing), exposed for tests in
+// the tests/ tree. A nil/inactive filter is identical to ChunkTranscriptByTime.
+func ChunkTranscriptByTimeFiltered(content string, filter *subtitle.WordFilter) []ChunkSegment {
+	raw := chunkTranscriptByTimeWithWordsFiltered(content, nil, filter)
+	out := make([]ChunkSegment, 0, len(raw))
+	for _, seg := range raw {
+		out = append(out, ChunkSegment(seg))
+	}
+	return out
+}
+
 // chunkSubtitleCues turns parsed subtitle cues into time-spanned transcript
 // chunks. Unlike chunkTranscriptByTime (which estimates timing from a flat text
 // transcript), the cues already carry authoritative [StartMS, EndMS] windows, so
@@ -1079,6 +1122,15 @@ func ChunkTranscriptByTimeWithWords(content string, words []model.TimedWord) []C
 // is [first cue start, last merged cue end]. Cues are processed in their given
 // order (callers sort by start time first), so the output is deterministic.
 func chunkSubtitleCues(cues []subtitle.Cue) []chunkSegment {
+	return chunkSubtitleCuesFiltered(cues, nil)
+}
+
+// chunkSubtitleCuesFiltered is chunkSubtitleCues with an optional caption word
+// filter (config media.filter_words) applied to each cue's text before merging.
+// A cue empty after filtering is dropped (it never contributes to a chunk), so
+// it neither adds text nor extends a merged chunk's time span. A nil/inactive
+// filter is a no-op, leaving the output identical to the unfiltered path.
+func chunkSubtitleCuesFiltered(cues []subtitle.Cue, filter *subtitle.WordFilter) []chunkSegment {
 	out := make([]chunkSegment, 0, len(cues))
 	var (
 		buf      []string
@@ -1106,6 +1158,9 @@ func chunkSubtitleCues(cues []subtitle.Cue) []chunkSegment {
 
 	for _, cue := range cues {
 		text := strings.TrimSpace(cue.Text)
+		if filter.Active() {
+			text = strings.TrimSpace(filter.Apply(text))
+		}
 		if text == "" {
 			continue
 		}
@@ -1142,6 +1197,17 @@ func chunkSubtitleCues(cues []subtitle.Cue) []chunkSegment {
 // unexported segment type to the public ChunkSegment.
 func ChunkSubtitleCues(cues []subtitle.Cue) []ChunkSegment {
 	raw := chunkSubtitleCues(cues)
+	out := make([]ChunkSegment, 0, len(raw))
+	for _, seg := range raw {
+		out = append(out, ChunkSegment(seg))
+	}
+	return out
+}
+
+// ChunkSubtitleCuesFiltered exposes chunkSubtitleCuesFiltered for tests. A
+// nil/inactive filter is identical to ChunkSubtitleCues.
+func ChunkSubtitleCuesFiltered(cues []subtitle.Cue, filter *subtitle.WordFilter) []ChunkSegment {
+	raw := chunkSubtitleCuesFiltered(cues, filter)
 	out := make([]ChunkSegment, 0, len(raw))
 	for _, seg := range raw {
 		out = append(out, ChunkSegment(seg))

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -28,6 +28,7 @@ import (
 	"github.com/dirstral/dir2mcp/internal/providerfactory"
 	"github.com/dirstral/dir2mcp/internal/quality"
 	"github.com/dirstral/dir2mcp/internal/store"
+	"github.com/dirstral/dir2mcp/internal/subtitle"
 )
 
 // annotationChunk* constants mirror the hardcoded parameters previously
@@ -423,6 +424,14 @@ func TranscriberFromConfigWithLanguage(cfg config.Config, language string) (mode
 // all of which cases the quality gate's language detector self-skips. Resolving
 // from the profile (rather than the legacy stt.elevenlabs_language_code field)
 // ensures Mistral/provider-profile setups still feed the gate a language.
+// captionWordFilter builds the shared caption word filter from
+// media.filter_words. The same filter is used for STT transcript chunking and
+// sidecar-cue chunking so configured phrases are stripped consistently before
+// embedding. An empty config yields an inactive filter (no-op).
+func (s *Service) captionWordFilter() *subtitle.WordFilter {
+	return subtitle.NewWordFilter(s.cfg.MediaFilterWords)
+}
+
 func sttExpectedLanguage(cfg config.Config) string {
 	sel := strings.ToLower(strings.TrimSpace(cfg.STTProvider))
 	if sel == "" {
@@ -1794,7 +1803,7 @@ func (s *Service) generateTranscriptRepresentation(ctx context.Context, doc mode
 		return fmt.Errorf("upsert transcript representation: %w", err)
 	}
 
-	segments := chunkTranscriptByTimeWithWords(transcriptText, words)
+	segments := chunkTranscriptByTimeWithWordsFiltered(transcriptText, words, s.captionWordFilter())
 	if len(segments) == 0 {
 		return nil
 	}

--- a/internal/ingest/sidecar.go
+++ b/internal/ingest/sidecar.go
@@ -223,7 +223,7 @@ func (s *Service) ingestSidecarTranscripts(ctx context.Context, doc model.Docume
 
 	ingested := false
 	for _, lang := range langs {
-		segments := chunkSubtitleCues(groups[lang])
+		segments := chunkSubtitleCuesFiltered(groups[lang], s.captionWordFilter())
 		if len(segments) == 0 {
 			continue
 		}

--- a/internal/subtitle/filter.go
+++ b/internal/subtitle/filter.go
@@ -1,0 +1,143 @@
+package subtitle
+
+import "strings"
+
+// WordFilter strips configured boilerplate/credits/watermark phrases from
+// transcript and subtitle text before it is chunked/embedded (ingest) and on
+// subtitle export (VTT/SRT). It is intentionally general-purpose: the phrase
+// list comes entirely from configuration (media.filter_words) and is empty by
+// default, so a zero/empty filter is a no-op everywhere.
+//
+// Matching is case-insensitive substring removal: every (case-insensitively)
+// matched occurrence of a configured phrase is deleted from the text. A line or
+// cue whose text is empty after removal is dropped by the callers (chunkers and
+// renderers already skip empty text), so a phrase that constitutes an entire
+// caption removes that caption.
+//
+// The same WordFilter is shared by the ingest chunkers and the export renderers
+// so a phrase configured once is stripped consistently in both places.
+type WordFilter struct {
+	// lowered holds the lower-cased, non-empty phrases used for
+	// case-insensitive matching, in configuration order.
+	lowered []string
+}
+
+// NewWordFilter builds a WordFilter from a phrase list. Empty/whitespace-only
+// phrases are skipped (they would otherwise match everywhere). The returned
+// filter is deterministic and safe for concurrent read use. A nil/empty list
+// yields a filter whose Active() is false and whose Apply is the identity.
+func NewWordFilter(phrases []string) *WordFilter {
+	f := &WordFilter{}
+	for _, p := range phrases {
+		if strings.TrimSpace(p) == "" {
+			continue
+		}
+		f.lowered = append(f.lowered, strings.ToLower(p))
+	}
+	return f
+}
+
+// Active reports whether the filter has any phrases to strip. When false,
+// callers can skip Apply entirely (it would be a no-op) so behavior is
+// byte-identical to having no filter configured.
+func (f *WordFilter) Active() bool {
+	return f != nil && len(f.lowered) > 0
+}
+
+// Apply removes every case-insensitive occurrence of each configured phrase
+// from text and returns the result with surrounding whitespace trimmed. When
+// the filter is inactive it returns text unchanged. The result may be empty,
+// which callers treat as "drop this line/cue".
+//
+// Phrases are applied in configuration order; removing one phrase can expose a
+// later phrase, which is acceptable and deterministic.
+func (f *WordFilter) Apply(text string) string {
+	if !f.Active() {
+		return text
+	}
+	for _, low := range f.lowered {
+		text = removeAllFold(text, low)
+	}
+	return strings.TrimSpace(text)
+}
+
+// FilterCues applies the word filter to each cue's text and drops cues whose
+// text is empty after filtering, re-indexing the survivors so the returned
+// slice is gap-free (RenderSRT renumbers too, but re-indexing keeps Cue.Index
+// meaningful for any other consumer). A nil/inactive filter returns cues
+// unchanged (same elements, same order) so the empty-config export path is a
+// no-op. Timing is preserved verbatim on surviving cues.
+func FilterCues(cues []Cue, filter *WordFilter) []Cue {
+	if !filter.Active() {
+		return cues
+	}
+	out := make([]Cue, 0, len(cues))
+	for _, cue := range cues {
+		text := filter.Apply(cue.Text)
+		if strings.TrimSpace(text) == "" {
+			continue
+		}
+		cue.Index = len(out) + 1
+		cue.Text = text
+		out = append(out, cue)
+	}
+	return out
+}
+
+// removeAllFold deletes every case-insensitive occurrence of phraseLow (already
+// lower-cased) from s, preserving the casing of the surviving text.
+//
+// It folds s rune-by-rune into a lower-cased copy while recording, for every
+// byte position in the folded copy, the originating byte offset in s. Folding a
+// rune can change its byte length (e.g. some non-ASCII characters), so this
+// per-byte map keeps match offsets exact rather than assuming length-preserving
+// folding.
+func removeAllFold(s, phraseLow string) string {
+	if phraseLow == "" {
+		return s
+	}
+	low, srcOf := foldWithOffsets(s)
+	var out strings.Builder
+	searchFrom := 0 // byte offset into low
+	srcCursor := 0  // byte offset into s, last copied position
+	for {
+		rel := strings.Index(low[searchFrom:], phraseLow)
+		if rel < 0 {
+			out.WriteString(s[srcCursor:])
+			break
+		}
+		matchLowStart := searchFrom + rel
+		matchLowEnd := matchLowStart + len(phraseLow)
+		srcStart := srcOf[matchLowStart]
+		srcEnd := srcOf[matchLowEnd]
+		if srcStart < srcCursor {
+			srcStart = srcCursor
+		}
+		out.WriteString(s[srcCursor:srcStart])
+		srcCursor = srcEnd
+		searchFrom = matchLowEnd
+	}
+	return out.String()
+}
+
+// foldWithOffsets returns the lower-cased form of s together with a slice srcOf
+// of length len(folded)+1 where srcOf[i] is the byte offset in s that the i-th
+// byte of the folded string originates from (and srcOf[len] == len(s)). This
+// lets callers map a match span in the folded string back to an exact byte span
+// in the original.
+func foldWithOffsets(s string) (folded string, srcOf []int) {
+	var b strings.Builder
+	srcOf = make([]int, 0, len(s)+1)
+	for i, r := range s {
+		lr := strings.ToLower(string(r))
+		// Each byte of the folded rune maps back to the rune's start in s. Match
+		// boundaries always fall on rune starts in s, so mapping every folded
+		// byte of a rune to its source start is sufficient and exact.
+		for j := 0; j < len(lr); j++ {
+			srcOf = append(srcOf, i)
+		}
+		b.WriteString(lr)
+	}
+	srcOf = append(srcOf, len(s))
+	return b.String(), srcOf
+}

--- a/tests/cli/export_filter_words_test.go
+++ b/tests/cli/export_filter_words_test.go
@@ -1,0 +1,138 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/cli"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// seedFilterExportStore seeds a transcript whose middle chunk is pure
+// boilerplate and whose other chunks contain an inline boilerplate phrase, so an
+// export filter can be observed dropping/stripping them.
+func seedFilterExportStore(t *testing.T, stateDir, relPath string) {
+	t.Helper()
+	ctx := context.Background()
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	st := store.NewSQLiteStore(filepath.Join(stateDir, "meta.sqlite"))
+	defer func() { _ = st.Close() }()
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if err := st.UpsertDocument(ctx, model.Document{
+		RelPath: relPath, DocType: "audio", SourceType: "local", Status: "ok",
+	}); err != nil {
+		t.Fatalf("UpsertDocument: %v", err)
+	}
+	doc, err := st.GetDocumentByPath(ctx, relPath)
+	if err != nil {
+		t.Fatalf("GetDocumentByPath: %v", err)
+	}
+	err = st.WithTx(ctx, func(tx model.RepresentationStore) error {
+		repID, err := tx.UpsertRepresentation(ctx, model.Representation{
+			DocID: doc.DocID, RepType: "transcript", RepHash: "h1",
+		})
+		if err != nil {
+			return err
+		}
+		chunks := []struct {
+			text  string
+			start int
+			end   int
+		}{
+			{"Real opening line", 0, 2000},
+			{"Subscribe to our channel", 2000, 4000},              // pure boilerplate -> dropped
+			{"Real closing Subscribe to our channel", 4000, 6000}, // inline phrase stripped
+		}
+		for i, c := range chunks {
+			if _, err := tx.InsertChunkWithSpans(ctx,
+				model.Chunk{RepID: repID, Ordinal: i, Text: c.text, IndexKind: "text"},
+				[]model.Span{{Kind: "time", StartMS: c.start, EndMS: c.end}},
+			); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("seed transcript: %v", err)
+	}
+}
+
+// TestExportAppliesFilterWords pins that media.filter_words configured in
+// .dir2mcp.yaml strips boilerplate from exported VTT: the pure-boilerplate cue
+// is dropped and the inline phrase is removed, while real text and timing
+// survive.
+func TestExportAppliesFilterWords(t *testing.T) {
+	tmp := t.TempDir()
+	seedFilterExportStore(t, filepath.Join(tmp, ".dir2mcp"), "media/talk.mp3")
+	// Config drives the filter; the phrase is general-purpose (no built-in list).
+	cfgYAML := strings.Join([]string{
+		"media:",
+		"  filter_words:",
+		"    - subscribe to our channel",
+	}, "\n") + "\n"
+	if err := os.WriteFile(filepath.Join(tmp, ".dir2mcp.yaml"), []byte(cfgYAML), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	withWorkingDir(t, tmp, func() {
+		code := app.RunWithContext(context.Background(),
+			[]string{"export", "--format", "vtt", "media/talk.mp3"})
+		if code != 0 {
+			t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
+		}
+	})
+
+	out := stdout.String()
+	if strings.Contains(strings.ToLower(out), "subscribe to our channel") {
+		t.Fatalf("filtered phrase leaked into exported VTT:\n%s", out)
+	}
+	if !strings.Contains(out, "Real opening line") {
+		t.Fatalf("real opening cue missing from export:\n%s", out)
+	}
+	if !strings.Contains(out, "Real closing") {
+		t.Fatalf("real closing cue (phrase stripped) missing from export:\n%s", out)
+	}
+	// The pure-boilerplate cue's window [00:02,00:04] must not be present as a
+	// standalone cue (its only text was the filtered phrase).
+	if strings.Contains(out, "00:00:02.000 --> 00:00:04.000") {
+		t.Fatalf("boilerplate-only cue was not dropped:\n%s", out)
+	}
+}
+
+// TestExportNoFilterWordsUnchanged pins that with no media.filter_words config
+// the export is byte-identical to today (no accidental stripping).
+func TestExportNoFilterWordsUnchanged(t *testing.T) {
+	tmp := t.TempDir()
+	seedFilterExportStore(t, filepath.Join(tmp, ".dir2mcp"), "media/talk.mp3")
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	withWorkingDir(t, tmp, func() {
+		code := app.RunWithContext(context.Background(),
+			[]string{"export", "--format", "vtt", "media/talk.mp3"})
+		if code != 0 {
+			t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
+		}
+	})
+
+	out := stdout.String()
+	want := "WEBVTT\n\n" +
+		"00:00:00.000 --> 00:00:02.000\nReal opening line\n\n" +
+		"00:00:02.000 --> 00:00:04.000\nSubscribe to our channel\n\n" +
+		"00:00:04.000 --> 00:00:06.000\nReal closing Subscribe to our channel\n\n"
+	if out != want {
+		t.Fatalf("export without filter changed:\n got %q\nwant %q", out, want)
+	}
+}

--- a/tests/config/media_filter_words_config_test.go
+++ b/tests/config/media_filter_words_config_test.go
@@ -1,0 +1,87 @@
+package tests
+
+import (
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+)
+
+// TestMediaFilterWords_DefaultsEmpty pins the off-by-default contract: there are
+// NO built-in filter phrases, so the feature is inactive unless configured.
+func TestMediaFilterWords_DefaultsEmpty(t *testing.T) {
+	cfg := config.Default()
+	if len(cfg.MediaFilterWords) != 0 {
+		t.Fatalf("media.filter_words must default to empty, got %#v", cfg.MediaFilterWords)
+	}
+}
+
+// TestMediaFilterWords_RoundTripsThroughSaveLoad pins persistence of the list
+// through SaveFile/LoadFile (flat-key YAML).
+func TestMediaFilterWords_RoundTripsThroughSaveLoad(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+
+	cfg := config.Default()
+	cfg.RootDir = "/tmp/repo"
+	cfg.StateDir = "/tmp/repo/.dir2mcp"
+	cfg.MediaFilterWords = []string{"Subscribe to our channel", "watermark"}
+	if err := config.SaveFile(path, cfg); err != nil {
+		t.Fatalf("SaveFile failed: %v", err)
+	}
+	loaded, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile failed: %v", err)
+	}
+	if !reflect.DeepEqual(loaded.MediaFilterWords, cfg.MediaFilterWords) {
+		t.Fatalf("media.filter_words did not round-trip: got %#v want %#v",
+			loaded.MediaFilterWords, cfg.MediaFilterWords)
+	}
+}
+
+// TestMediaFilterWords_NestedYAMLApplies pins the nested spec-style block
+// (media: -> filter_words: -> list items) is applied (isMapSectionKey + list-key
+// handling).
+func TestMediaFilterWords_NestedYAMLApplies(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+	writeFile(t, path, strings.Join([]string{
+		"root_dir: /tmp/repo",
+		"state_dir: /tmp/repo/.dir2mcp",
+		"media:",
+		"  filter_words:",
+		"    - Subscribe to our channel",
+		"    - watermark",
+	}, "\n")+"\n")
+
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile(nested media.filter_words) = %v, want nil", err)
+	}
+	want := []string{"Subscribe to our channel", "watermark"}
+	if !reflect.DeepEqual(cfg.MediaFilterWords, want) {
+		t.Fatalf("nested media.filter_words not applied: got %#v want %#v", cfg.MediaFilterWords, want)
+	}
+}
+
+// TestMediaFilterWords_FlatAliasApplies pins that the flat alias key (and the
+// short `filter_words` alias) resolve to media.filter_words.
+func TestMediaFilterWords_FlatAliasApplies(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+	writeFile(t, path, strings.Join([]string{
+		"root_dir: /tmp/repo",
+		"filter_words:",
+		"  - boilerplate",
+	}, "\n")+"\n")
+
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile(flat filter_words) = %v, want nil", err)
+	}
+	if !reflect.DeepEqual(cfg.MediaFilterWords, []string{"boilerplate"}) {
+		t.Fatalf("flat filter_words alias not applied: got %#v", cfg.MediaFilterWords)
+	}
+}

--- a/tests/ingest/filter_words_test.go
+++ b/tests/ingest/filter_words_test.go
@@ -1,0 +1,135 @@
+package tests
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/subtitle"
+)
+
+// transcriptFixture is a small time-stamped transcript whose middle line is
+// pure boilerplate (a credit/watermark line) plus a trailing-phrase line.
+const transcriptFixture = "[00:00] Welcome to the show\n" +
+	"[00:02] Subscribe to our channel\n" +
+	"[00:05] Today we discuss Subscribe to our channel deterministic exports"
+
+// TestTranscriptChunkingEmptyFilterUnchanged pins that an empty/inactive filter
+// produces output identical to the unfiltered chunker, so the empty-config path
+// changes nothing.
+func TestTranscriptChunkingEmptyFilterUnchanged(t *testing.T) {
+	base := ingest.ChunkTranscriptByTime(transcriptFixture)
+	for _, f := range []*subtitle.WordFilter{nil, subtitle.NewWordFilter(nil), subtitle.NewWordFilter([]string{"  "})} {
+		got := ingest.ChunkTranscriptByTimeFiltered(transcriptFixture, f)
+		if !reflect.DeepEqual(got, base) {
+			t.Fatalf("empty filter changed transcript chunks:\n got %#v\nwant %#v", got, base)
+		}
+	}
+}
+
+// TestTranscriptChunkingStripsPhrases pins that configured phrases are removed
+// from transcript chunk text (so they never get embedded), that a chunk which
+// is pure boilerplate is dropped, and that time spans on survivors are intact.
+func TestTranscriptChunkingStripsPhrases(t *testing.T) {
+	f := subtitle.NewWordFilter([]string{"Subscribe to our channel"})
+	got := ingest.ChunkTranscriptByTimeFiltered(transcriptFixture, f)
+
+	if len(got) == 0 {
+		t.Fatal("expected surviving chunks, got none")
+	}
+	for _, seg := range got {
+		if strings.Contains(strings.ToLower(seg.Text), "subscribe to our channel") {
+			t.Fatalf("filtered phrase leaked into chunk text: %q", seg.Text)
+		}
+		if seg.Span.Kind != "time" {
+			t.Fatalf("chunk lost its time span: %#v", seg.Span)
+		}
+	}
+	// The boilerplate-only line ("Subscribe to our channel" at 00:02) must be
+	// dropped, so its text must not appear anywhere and the welcome + final lines
+	// survive.
+	joined := strings.ToLower(joinSegText(got))
+	if !strings.Contains(joined, "welcome to the show") {
+		t.Fatalf("expected welcome line to survive: %q", joined)
+	}
+	if !strings.Contains(joined, "today we discuss") || !strings.Contains(joined, "deterministic exports") {
+		t.Fatalf("expected final line to survive with phrase removed: %q", joined)
+	}
+}
+
+// TestSubtitleCueChunkingFilter pins the sidecar-cue chunker: a cue that is pure
+// boilerplate is dropped (its time span never merges into a chunk) and inline
+// phrases are stripped, case-insensitively.
+func TestSubtitleCueChunkingFilter(t *testing.T) {
+	cues := []subtitle.Cue{
+		{Index: 1, StartMS: 0, EndMS: 1000, Text: "Hello there"},
+		{Index: 2, StartMS: 1000, EndMS: 2000, Text: "SUBSCRIBE NOW"},
+		{Index: 3, StartMS: 2000, EndMS: 3000, Text: "Real content subscribe now here"},
+	}
+	f := subtitle.NewWordFilter([]string{"subscribe now"})
+	got := ingest.ChunkSubtitleCuesFiltered(cues, f)
+
+	joined := strings.ToLower(joinSegText(got))
+	if strings.Contains(joined, "subscribe now") {
+		t.Fatalf("filtered phrase leaked into sidecar chunks: %q", joined)
+	}
+	if !strings.Contains(joined, "hello there") || !strings.Contains(joined, "real content") {
+		t.Fatalf("expected real cues to survive: %q", joined)
+	}
+
+	// Empty/inactive filter is identical to the unfiltered chunker.
+	base := ingest.ChunkSubtitleCues(cues)
+	if got2 := ingest.ChunkSubtitleCuesFiltered(cues, subtitle.NewWordFilter(nil)); !reflect.DeepEqual(got2, base) {
+		t.Fatalf("inactive filter changed sidecar chunks:\n got %#v\nwant %#v", got2, base)
+	}
+}
+
+// TestFilterConsistentIngestAndExport pins that the same filter applied to the
+// same source text strips the same phrase at ingest (transcript chunking) and at
+// export (cue filtering). Building cues from the filtered transcript chunks and
+// re-filtering them on export must not contain the phrase either way.
+func TestFilterConsistentIngestAndExport(t *testing.T) {
+	const text = "[00:00] keep this line\n[00:02] drop watermark only"
+	f := subtitle.NewWordFilter([]string{"watermark only"})
+
+	// Ingest side: chunk with filter.
+	ingestSegs := ingest.ChunkTranscriptByTimeFiltered(text, f)
+
+	// Export side: build cues from the SAME unfiltered chunks and filter on
+	// export. Both paths must agree that "watermark only" is gone.
+	rawSegs := ingest.ChunkTranscriptByTime(text)
+	chunks := make([]subtitle.TranscriptChunk, 0, len(rawSegs))
+	for _, s := range rawSegs {
+		chunks = append(chunks, subtitle.TranscriptChunk{Text: s.Text, Span: s.Span})
+	}
+	exportCues := subtitle.FilterCues(subtitle.BuildCues(chunks), f)
+
+	ingestJoined := strings.ToLower(joinSegText(ingestSegs))
+	var exportJoined strings.Builder
+	for _, c := range exportCues {
+		exportJoined.WriteString(strings.ToLower(c.Text))
+		exportJoined.WriteString(" ")
+	}
+	if strings.Contains(ingestJoined, "watermark only") {
+		t.Fatalf("phrase leaked at ingest: %q", ingestJoined)
+	}
+	if strings.Contains(exportJoined.String(), "watermark only") {
+		t.Fatalf("phrase leaked at export: %q", exportJoined.String())
+	}
+	// Both keep the real line.
+	if !strings.Contains(ingestJoined, "keep this line") {
+		t.Fatalf("ingest dropped real content: %q", ingestJoined)
+	}
+	if !strings.Contains(exportJoined.String(), "keep this line") {
+		t.Fatalf("export dropped real content: %q", exportJoined.String())
+	}
+}
+
+func joinSegText(segs []ingest.ChunkSegment) string {
+	parts := make([]string, 0, len(segs))
+	for _, s := range segs {
+		parts = append(parts, s.Text)
+	}
+	return strings.Join(parts, " | ")
+}

--- a/tests/subtitle/filter_test.go
+++ b/tests/subtitle/filter_test.go
@@ -1,0 +1,93 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/subtitle"
+)
+
+// TestWordFilterInactiveIdentity pins that an empty/whitespace-only phrase list
+// yields an inactive filter whose Apply is the identity, so the empty-config
+// path is a no-op everywhere.
+func TestWordFilterInactiveIdentity(t *testing.T) {
+	for _, phrases := range [][]string{nil, {}, {"", "   "}} {
+		f := subtitle.NewWordFilter(phrases)
+		if f.Active() {
+			t.Fatalf("filter %v: Active()=true, want false", phrases)
+		}
+		const in = "Subscribe to TV Rain for more"
+		if got := f.Apply(in); got != in {
+			t.Fatalf("inactive Apply changed text: got %q want %q", got, in)
+		}
+	}
+}
+
+// TestWordFilterCaseInsensitiveSubstring pins case-insensitive substring
+// removal: every matched occurrence (regardless of casing) is stripped while the
+// surrounding text keeps its original casing.
+func TestWordFilterCaseInsensitiveSubstring(t *testing.T) {
+	f := subtitle.NewWordFilter([]string{"watermark"})
+	got := f.Apply("Keep WATERMARK this WaterMark text")
+	want := "Keep  this  text"
+	// Apply trims outer whitespace but not the interior double-spaces left by
+	// removal; assert the phrase is gone and casing of survivors is preserved.
+	if got != want {
+		t.Fatalf("case-insensitive removal: got %q want %q", got, want)
+	}
+}
+
+// TestWordFilterEmptyAfterFilter pins that a text consisting solely of (a)
+// filter phrase(s) becomes empty after Apply, which callers treat as "drop".
+func TestWordFilterEmptyAfterFilter(t *testing.T) {
+	f := subtitle.NewWordFilter([]string{"credits", "the end"})
+	if got := f.Apply("  Credits  "); got != "" {
+		t.Fatalf("phrase-only text should be empty after filter, got %q", got)
+	}
+	if got := f.Apply("THE END credits"); got != "" {
+		t.Fatalf("multi-phrase-only text should be empty after filter, got %q", got)
+	}
+}
+
+// TestWordFilterMultiPhraseOrder pins that multiple phrases are all applied and
+// that removing one phrase can expose another (deterministic, config-order).
+func TestWordFilterMultiPhraseOrder(t *testing.T) {
+	f := subtitle.NewWordFilter([]string{"ab", "c"})
+	// Both phrases are applied (case-insensitively): "xABcy" loses "AB" and "c".
+	got := f.Apply("xABcy")
+	if got != "xy" {
+		t.Fatalf("multi-phrase removal: got %q want %q", got, "xy")
+	}
+}
+
+// TestFilterCusDropsAndReindexes pins FilterCues: cues empty after filtering are
+// dropped and survivors are contiguously re-indexed; timing is preserved.
+func TestFilterCuesDropsAndReindexes(t *testing.T) {
+	cues := []subtitle.Cue{
+		{Index: 1, StartMS: 0, EndMS: 1000, Text: "Hello world"},
+		{Index: 2, StartMS: 1000, EndMS: 2000, Text: "Subscribe now"},
+		{Index: 3, StartMS: 2000, EndMS: 3000, Text: "Goodbye Subscribe now"},
+	}
+	f := subtitle.NewWordFilter([]string{"subscribe now"})
+	got := subtitle.FilterCues(cues, f)
+	if len(got) != 2 {
+		t.Fatalf("FilterCues len = %d, want 2 (one cue dropped): %#v", len(got), got)
+	}
+	if got[0].Index != 1 || got[0].Text != "Hello world" || got[0].StartMS != 0 || got[0].EndMS != 1000 {
+		t.Fatalf("cue[0] = %#v, want untouched Hello world", got[0])
+	}
+	if got[1].Index != 2 || got[1].Text != "Goodbye" || got[1].StartMS != 2000 || got[1].EndMS != 3000 {
+		t.Fatalf("cue[1] = %#v, want re-indexed filtered Goodbye with original timing", got[1])
+	}
+}
+
+// TestFilterCuesInactiveIdentity pins that an inactive filter returns the cues
+// unchanged (no-op), so the empty-config export path is byte-identical.
+func TestFilterCuesInactiveIdentity(t *testing.T) {
+	cues := []subtitle.Cue{
+		{Index: 1, StartMS: 0, EndMS: 1000, Text: "Subscribe now"},
+	}
+	got := subtitle.FilterCues(cues, subtitle.NewWordFilter(nil))
+	if len(got) != 1 || got[0].Text != "Subscribe now" {
+		t.Fatalf("inactive FilterCues changed cues: %#v", got)
+	}
+}


### PR DESCRIPTION
## What

Adds an optional, **general-purpose** `media.filter_words` list that strips boilerplate / credits / watermark phrases from transcripts **before they are chunked/embedded** and from **exported VTT/SRT** cues.

Closes #259. Part of epic #261 (livevtt absorption).

## Config

- `media.filter_words` — string list, **default empty = off**.
  - Nested form under `media:`, plus flat aliases `media_filter_words` and `filter_words`.
  - Persisted in the YAML snapshot; registered in the list-config + map-section handling.
- **No built-in defaults** — the list carries no language- or domain-specific phrases (keeps dir2mcp general-purpose).

## Where the filter applies (shared helper)

A single `subtitle.WordFilter` is applied at:
- **Ingest**: STT transcript chunking (`chunkTranscriptByTimeWithWordsFiltered`) and sidecar-cue chunking (`chunkSubtitleCuesFiltered`) — so filtered text never gets embedded.
- **Export**: cue filtering (`subtitle.FilterCues`) before VTT/SRT rendering — so exported subtitles never contain the phrases.

## Match semantics

- Case-insensitive **substring** removal of every configured phrase.
- A line / cue whose text is **empty after removal is dropped**.
- Deterministic; phrases applied in config order.
- **Empty list = identical behavior to today** everywhere (verified by tests).

## Governance

SPEC §8.6 (media transcription/translation/subtitle surface) does **not** cover caption filter-words. This is purely config-driven **ingest** behavior with **no wire/tool contract change**, so per the project's spec-governance rule it does **not** require a dirstral-spec PR. The submodule pointer is **not** re-pinned.

## Tests (tests/, package tests)

- `tests/subtitle/filter_test.go` — WordFilter case-insensitivity, empty-after-filter drop, inactive no-op, FilterCues drop + re-index.
- `tests/ingest/filter_words_test.go` — transcript + sidecar-cue chunking strip phrases / drop empty cues; empty-filter equivalence; ingest↔export consistency.
- `tests/config/media_filter_words_config_test.go` — default empty, Save/Load round-trip, nested + flat-alias YAML.
- `tests/cli/export_filter_words_test.go` — end-to-end export drops/strips with config; byte-identical without config.

## Checks

`go build`, `go vet`, `gofmt`, `gocyclo -over 15`, `ineffassign`, `misspell`, and the relevant test suites pass. `golangci-lint` reports 0 issues for the changed packages. (Note: a sibling worktree under `.claude/worktrees/` currently contains an unrelated in-flight file that makes the repo-wide `golangci-lint run` report one issue outside this branch's scope.)

## Note re #293

PR #293 (translation) is in flight and also touches `internal/ingest/represent.go` and `internal/config/config.go`. Changes here are kept localized; expect a possible rebase.