### PR TITLE
feat(ingest,store): persist sidecar fingerprint to restore ETag skip for unchanged media

### DIFF
--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -787,10 +787,14 @@ func (s *Service) trySkipUnchangedRemoteDocument(ctx context.Context, f Discover
 	// sidecar (.srt/.vtt/.ttml): buildDocumentWithContent folds the sidecar
 	// fingerprint into ContentHash, but the ETag fast-path runs before that
 	// recompute. So a sidecar added/changed/removed while the media bytes are
-	// unchanged would be missed. Conservatively bypass the ETag skip for
-	// sidecar-capable media so the full read+hash path re-detects the sidecar
-	// (#253/#283 interaction). Non-media remote objects keep the fast path.
-	if isSidecarMediaType(ClassifyDocType(f.RelPath)) {
+	// unchanged would be missed by an ETag-only comparison. Recompute the current
+	// sidecar fingerprint cheaply (sibling paths + mtimes from the in-memory
+	// sidecar index — no media read) and skip only when it ALSO matches the
+	// persisted value; re-read when either the ETag or the fingerprint differs
+	// (SPEC §7.8.3, #298). For non-media objects and media with no sidecar the
+	// fingerprint is empty on both sides, so the fast path behaves as before.
+	currentFP := s.sidecarFingerprint(ctx, f.RelPath, ClassifyDocType(f.RelPath))
+	if currentFP != existing.SidecarFingerprint {
 		return false, nil
 	}
 	s.skipUnchangedRemoteDocument(ctx, f, existing, seen)
@@ -1105,8 +1109,13 @@ func (s *Service) buildDocumentWithContent(ctx context.Context, f DiscoveredFile
 	// media document's content hash so the incremental gate (§7.6) re-processes
 	// the media when a sidecar is added, removed, or modified — even though the
 	// media bytes are unchanged. Empty for non-media docs or media with no
-	// sidecar, preserving the existing hash exactly.
-	doc.ContentHash = mediaContentHash(content, s.sidecarFingerprint(ctx, f.RelPath, docType))
+	// sidecar, preserving the existing hash exactly. The same fingerprint is
+	// persisted separately on the row (SidecarFingerprint) so the remote ETag
+	// fast path can detect a sidecar change without re-reading the media bytes
+	// (SPEC §7.8.3, #298).
+	sidecarFP := s.sidecarFingerprint(ctx, f.RelPath, docType)
+	doc.SidecarFingerprint = sidecarFP
+	doc.ContentHash = mediaContentHash(content, sidecarFP)
 
 	// certain document types we don't want to ingest at all.
 	// "archive" and "binary_ignored" were already skipped.

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -22,9 +22,17 @@ type Document struct {
 	// SSE-KMS ETags are not MD5 of the body); it only decides whether a re-read
 	// + content_hash recompute is warranted (SPEC §7.8.3). content_hash stays the
 	// canonical identity.
-	ETag    string
-	Status  string
-	Deleted bool
+	ETag string
+	// SidecarFingerprint is a stable, cheaply-recomputed signature of the media
+	// document's adjacent subtitle sidecars (their sorted rel_paths + mtimes). It
+	// is the SAME value folded into ContentHash on the full read+hash path,
+	// persisted separately so the remote (S3) ETag fast path can detect a sidecar
+	// added/changed/removed while the media object's own ETag is unchanged —
+	// without re-reading the media bytes (SPEC §7.8.3, #298). Empty for non-media
+	// documents and media with no sidecar.
+	SidecarFingerprint string
+	Status             string
+	Deleted            bool
 	// ErrorMessage is populated when Status == "error" with a short
 	// human-readable description of why ingest failed (extraction
 	// crash, representation generation failure, etc.). Surfaced in

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -361,6 +361,14 @@ func applyAdditiveColumnMigrations(ctx context.Context, db *sql.DB) error {
 		// unchanged object (SPEC §7.8.3, #245). Empty for local/NFS corpora,
 		// whose change detection keeps using (size, mtime) then content_hash.
 		`ALTER TABLE documents ADD COLUMN etag TEXT NOT NULL DEFAULT ''`,
+		// sidecar_fingerprint persists the same subtitle-sidecar signature
+		// (sorted rel_paths + mtimes) that buildDocumentWithContent folds into
+		// content_hash. Persisting it separately lets the remote (S3) ETag fast
+		// path detect a sidecar added/changed/removed while the media object's
+		// own ETag is unchanged, without re-reading the media bytes (SPEC
+		// §7.8.3, #298). Empty for local/NFS corpora, non-media docs, and media
+		// with no sidecar — preserving the historical fast-path behavior.
+		`ALTER TABLE documents ADD COLUMN sidecar_fingerprint TEXT NOT NULL DEFAULT ''`,
 	}
 	for _, stmt := range migrations {
 		if _, err := db.ExecContext(ctx, stmt); err != nil && !isDuplicateColumnError(err) {
@@ -408,6 +416,7 @@ CREATE TABLE IF NOT EXISTS documents (
   mtime_unix INTEGER NOT NULL DEFAULT 0,
   content_hash TEXT NOT NULL DEFAULT '',
   etag TEXT NOT NULL DEFAULT '',
+  sidecar_fingerprint TEXT NOT NULL DEFAULT '',
   status TEXT NOT NULL DEFAULT 'ok',
   deleted INTEGER NOT NULL DEFAULT 0
 );
@@ -581,8 +590,8 @@ func (s *SQLiteStore) UpsertDocument(ctx context.Context, doc model.Document) er
 	// such two-phase write, so the always-replace semantics are correct.
 	_, err = db.ExecContext(
 		ctx,
-		`INSERT INTO documents(rel_path, doc_type, source_type, size_bytes, mtime_unix, content_hash, etag, status, deleted, title, error_message)
-		 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`INSERT INTO documents(rel_path, doc_type, source_type, size_bytes, mtime_unix, content_hash, etag, sidecar_fingerprint, status, deleted, title, error_message)
+		 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		 ON CONFLICT(rel_path) DO UPDATE SET
 		   doc_type=excluded.doc_type,
 		   source_type=excluded.source_type,
@@ -590,6 +599,7 @@ func (s *SQLiteStore) UpsertDocument(ctx context.Context, doc model.Document) er
 		   mtime_unix=excluded.mtime_unix,
 		   content_hash=excluded.content_hash,
 		   etag=excluded.etag,
+		   sidecar_fingerprint=excluded.sidecar_fingerprint,
 		   status=excluded.status,
 		   deleted=excluded.deleted,
 		   title=CASE WHEN excluded.title <> '' THEN excluded.title ELSE documents.title END,
@@ -601,6 +611,7 @@ func (s *SQLiteStore) UpsertDocument(ctx context.Context, doc model.Document) er
 		doc.MTimeUnix,
 		strings.TrimSpace(doc.ContentHash),
 		strings.TrimSpace(doc.ETag),
+		doc.SidecarFingerprint,
 		normalizeStatus(doc.Status),
 		boolToInt(doc.Deleted),
 		strings.TrimSpace(doc.Title),
@@ -1223,7 +1234,7 @@ func (s *SQLiteStore) GetDocumentByPath(ctx context.Context, relPath string) (mo
 	var deleted int
 	row := db.QueryRowContext(
 		ctx,
-		`SELECT doc_id, rel_path, doc_type, source_type, size_bytes, mtime_unix, content_hash, etag, status, deleted, title, error_message
+		`SELECT doc_id, rel_path, doc_type, source_type, size_bytes, mtime_unix, content_hash, etag, sidecar_fingerprint, status, deleted, title, error_message
 		 FROM documents WHERE rel_path = ?`,
 		normalizedPath,
 	)
@@ -1236,6 +1247,7 @@ func (s *SQLiteStore) GetDocumentByPath(ctx context.Context, relPath string) (mo
 		&doc.MTimeUnix,
 		&doc.ContentHash,
 		&doc.ETag,
+		&doc.SidecarFingerprint,
 		&doc.Status,
 		&deleted,
 		&doc.Title,
@@ -1266,7 +1278,7 @@ func (s *SQLiteStore) ListFiles(ctx context.Context, prefix, glob string, limit,
 
 	normalizedPrefix := model.NormalizePathPrefix(prefix)
 
-	query := `SELECT doc_id, rel_path, doc_type, source_type, size_bytes, mtime_unix, content_hash, etag, status, deleted, title, error_message FROM documents`
+	query := `SELECT doc_id, rel_path, doc_type, source_type, size_bytes, mtime_unix, content_hash, etag, sidecar_fingerprint, status, deleted, title, error_message FROM documents`
 	where := []string{"deleted = 0"}
 	args := make([]any, 0, 4)
 	if normalizedPrefix != "" {
@@ -1300,6 +1312,7 @@ func (s *SQLiteStore) ListFiles(ctx context.Context, prefix, glob string, limit,
 			&doc.MTimeUnix,
 			&doc.ContentHash,
 			&doc.ETag,
+			&doc.SidecarFingerprint,
 			&doc.Status,
 			&deleted,
 			&doc.Title,
@@ -1350,7 +1363,7 @@ func (s *SQLiteStore) RecentFailures(ctx context.Context, limit int) ([]model.Do
 
 	rows, err := db.QueryContext(
 		ctx,
-		`SELECT doc_id, rel_path, doc_type, source_type, size_bytes, mtime_unix, content_hash, etag, status, deleted, title, error_message
+		`SELECT doc_id, rel_path, doc_type, source_type, size_bytes, mtime_unix, content_hash, etag, sidecar_fingerprint, status, deleted, title, error_message
 		 FROM documents
 		 WHERE status = 'error' AND deleted = 0
 		 ORDER BY mtime_unix DESC, rel_path ASC
@@ -1375,6 +1388,7 @@ func (s *SQLiteStore) RecentFailures(ctx context.Context, limit int) ([]model.Do
 			&doc.MTimeUnix,
 			&doc.ContentHash,
 			&doc.ETag,
+			&doc.SidecarFingerprint,
 			&doc.Status,
 			&deleted,
 			&doc.Title,

--- a/tests/ingest/etag_incremental_test.go
+++ b/tests/ingest/etag_incremental_test.go
@@ -45,6 +45,18 @@ func (f *fakeRemoteFS) add(relPath, etag, body string) {
 	f.bodies[relPath] = []byte(body)
 }
 
+// addWithMTime is add() with an explicit MTimeUnix so a test can pin the value
+// the sidecar fingerprint folds in ("rel_path@mtime").
+func (f *fakeRemoteFS) addWithMTime(relPath, etag, body string, mtime int64) {
+	f.files = append(f.files, corpusfs.DiscoveredFile{
+		RelPath:   relPath,
+		SizeBytes: int64(len(body)),
+		MTimeUnix: mtime,
+		ETag:      etag,
+	})
+	f.bodies[relPath] = []byte(body)
+}
+
 func (f *fakeRemoteFS) Walk(_ context.Context, _ string, _ corpusfs.Options) ([]corpusfs.DiscoveredFile, error) {
 	out := append([]corpusfs.DiscoveredFile(nil), f.files...)
 	sort.Slice(out, func(i, j int) bool { return out[i].RelPath < out[j].RelPath })
@@ -397,15 +409,14 @@ func TestRunScan_LocalEmptyETagUsesContentHash(t *testing.T) {
 	}
 }
 
-// TestRunScan_S3ETagSidecarMediaNotSkipped confirms the ETag fast-path does NOT
-// skip sidecar-capable media (audio/video): a subtitle sidecar (.srt/.vtt) can
-// be added/changed/removed while the media object's own ETag is unchanged, and
-// buildDocumentWithContent folds the sidecar fingerprint into ContentHash only
-// on the full read path. So such media must always be re-read incrementally
-// (#245/#253/#283 interaction). Non-media objects keep the cheap ETag skip.
-func TestRunScan_S3ETagSidecarMediaNotSkipped(t *testing.T) {
+// TestRunScan_S3ETagSidecarMediaNoSidecarSkips confirms that sidecar-capable
+// media (audio/video) WITHOUT any adjacent sidecar now keeps the cheap ETag fast
+// path: the persisted sidecar_fingerprint is empty and the cheaply-recomputed
+// current fingerprint is also empty, so an unchanged ETag skips the GET + re-hash
+// just like a non-media object (#298 replaces the conservative #295 carve-out).
+func TestRunScan_S3ETagSidecarMediaNoSidecarSkips(t *testing.T) {
 	fs := newFakeRemoteFS()
-	fs.add("clip.mp4", "etag-stable", "media bytes") // sidecar-capable (video)
+	fs.add("clip.mp4", "etag-stable", "media bytes") // sidecar-capable (video), no sidecar
 	fs.add("notes.txt", "etag-stable", "text body")  // non-media control
 
 	st := newRemoteScanStore()
@@ -416,7 +427,8 @@ func TestRunScan_S3ETagSidecarMediaNotSkipped(t *testing.T) {
 		SizeBytes:   int64(len("media bytes")),
 		ContentHash: ingest.ComputeContentHash([]byte("media bytes")),
 		ETag:        "etag-stable",
-		Status:      "ok",
+		// SidecarFingerprint intentionally empty: no sidecar at last scan.
+		Status: "ok",
 	})
 	st.seed(model.Document{
 		DocID:       2,
@@ -434,13 +446,127 @@ func TestRunScan_S3ETagSidecarMediaNotSkipped(t *testing.T) {
 	if err := svc.Run(context.Background()); err != nil {
 		t.Fatalf("Run failed: %v", err)
 	}
-	// Sidecar-capable media must be re-read even with an unchanged ETag so a
-	// changed/added/removed sidecar is detected via the content_hash recompute.
-	if got := fs.openCount("clip.mp4"); got == 0 {
-		t.Errorf("sidecar-capable media with matching ETag was ETag-skipped; it must be re-read")
+	// Sidecar-capable media with no sidecar and a matching empty fingerprint must
+	// ETag-skip (the whole point of #298: stop re-reading every media object).
+	if got := fs.openCount("clip.mp4"); got != 0 {
+		t.Errorf("sidecar-capable media without sidecar was re-read %d time(s); expected ETag skip (0)", got)
+	}
+	if got := st.upsertCalls["clip.mp4"]; got != 0 {
+		t.Errorf("sidecar-capable media without sidecar was upserted %d time(s); expected 0 (untouched on skip)", got)
 	}
 	// Non-media object keeps the cheap ETag skip (regression guard).
 	if got := fs.openCount("notes.txt"); got != 0 {
 		t.Errorf("non-media object with matching ETag was re-read; it should ETag-skip (got %d opens)", got)
+	}
+}
+
+// TestRunScan_S3ETagSidecarAddedForcesReRead confirms that adding a subtitle
+// sidecar next to a media object with an unchanged ETag breaks the ETag skip:
+// the cheaply-recomputed current fingerprint (now non-empty) no longer matches
+// the persisted (empty) fingerprint, so the media is re-read and re-hashed so the
+// sidecar transcript is ingested (#298).
+func TestRunScan_S3ETagSidecarAddedForcesReRead(t *testing.T) {
+	fs := newFakeRemoteFS()
+	fs.add("clip.mp4", "etag-stable", "media bytes")
+	// A subtitle sidecar appeared since the last scan (media ETag unchanged).
+	fs.add("clip.en.vtt", "etag-sub", "WEBVTT\n\n00:00.000 --> 00:01.000\nhi\n")
+
+	st := newRemoteScanStore()
+	st.seed(model.Document{
+		DocID:       1,
+		RelPath:     "clip.mp4",
+		DocType:     "video",
+		SizeBytes:   int64(len("media bytes")),
+		ContentHash: ingest.ComputeContentHash([]byte("media bytes")),
+		ETag:        "etag-stable",
+		// SidecarFingerprint empty: no sidecar existed at last scan.
+		Status: "ok",
+	})
+
+	svc := mustNewIngestService(t, config.Config{RootDir: "/corpus"}, st)
+	svc.SetCorpusFS(fs)
+
+	if err := svc.Run(context.Background()); err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if got := fs.openCount("clip.mp4"); got == 0 {
+		t.Errorf("media with newly-added sidecar (ETag unchanged) was ETag-skipped; it must be re-read")
+	}
+	// The recomputed row must now carry a non-empty persisted fingerprint so the
+	// next scan can skip when nothing changes again.
+	if doc, _ := st.get("clip.mp4"); doc.SidecarFingerprint == "" {
+		t.Errorf("expected non-empty persisted sidecar_fingerprint after re-read; got empty")
+	}
+}
+
+// TestRunScan_S3ETagSidecarUnchangedSkips confirms that media whose sidecar is
+// unchanged since the last scan (persisted fingerprint == current fingerprint)
+// keeps the cheap ETag skip — no media read despite being sidecar-capable (#298).
+func TestRunScan_S3ETagSidecarUnchangedSkips(t *testing.T) {
+	fs := newFakeRemoteFS()
+	fs.add("clip.mp4", "etag-stable", "media bytes")
+	fs.addWithMTime("clip.en.vtt", "etag-sub", "WEBVTT\n", 4242)
+
+	// Seed the row with the SAME fingerprint the scan will recompute for the
+	// unchanged sidecar (sorted "rel_path@mtime"). This mirrors what a prior
+	// successful ingest persisted.
+	st := newRemoteScanStore()
+	st.seed(model.Document{
+		DocID:              1,
+		RelPath:            "clip.mp4",
+		DocType:            "video",
+		SizeBytes:          int64(len("media bytes")),
+		ContentHash:        ingest.ComputeContentHash([]byte("media bytes")),
+		ETag:               "etag-stable",
+		SidecarFingerprint: "clip.en.vtt@4242",
+		Status:             "ok",
+	})
+
+	svc := mustNewIngestService(t, config.Config{RootDir: "/corpus"}, st)
+	svc.SetCorpusFS(fs)
+
+	if err := svc.Run(context.Background()); err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if got := fs.openCount("clip.mp4"); got != 0 {
+		t.Errorf("media with unchanged sidecar was re-read %d time(s); expected ETag skip (0)", got)
+	}
+	if got := st.upsertCalls["clip.mp4"]; got != 0 {
+		t.Errorf("media with unchanged sidecar was upserted %d time(s); expected 0 (untouched on skip)", got)
+	}
+}
+
+// TestRunScan_S3ETagSidecarChangedForcesReRead confirms that a sidecar whose
+// mtime changed since the last scan (persisted fingerprint differs from the
+// recomputed one) breaks the ETag skip even though the media object's ETag is
+// unchanged (#298).
+func TestRunScan_S3ETagSidecarChangedForcesReRead(t *testing.T) {
+	fs := newFakeRemoteFS()
+	fs.add("clip.mp4", "etag-stable", "media bytes")
+	fs.addWithMTime("clip.en.vtt", "etag-sub", "WEBVTT\n\n00:00.000 --> 00:01.000\nhi\n", 9999)
+
+	st := newRemoteScanStore()
+	st.seed(model.Document{
+		DocID:              1,
+		RelPath:            "clip.mp4",
+		DocType:            "video",
+		SizeBytes:          int64(len("media bytes")),
+		ContentHash:        ingest.ComputeContentHash([]byte("media bytes")),
+		ETag:               "etag-stable",
+		SidecarFingerprint: "clip.en.vtt@1111", // stale mtime
+		Status:             "ok",
+	})
+
+	svc := mustNewIngestService(t, config.Config{RootDir: "/corpus"}, st)
+	svc.SetCorpusFS(fs)
+
+	if err := svc.Run(context.Background()); err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if got := fs.openCount("clip.mp4"); got == 0 {
+		t.Errorf("media with changed sidecar (ETag unchanged) was ETag-skipped; it must be re-read")
+	}
+	if doc, _ := st.get("clip.mp4"); doc.SidecarFingerprint != "clip.en.vtt@9999" {
+		t.Errorf("persisted sidecar_fingerprint not refreshed: got %q", doc.SidecarFingerprint)
 	}
 }

--- a/tests/store/document_sidecar_fingerprint_roundtrip_test.go
+++ b/tests/store/document_sidecar_fingerprint_roundtrip_test.go
@@ -1,0 +1,96 @@
+package tests
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// TestSQLiteStore_DocumentSidecarFingerprintRoundtrip verifies that the
+// sidecar_fingerprint column (added for #298) persists across upsert and is
+// returned by both GetDocumentByPath and ListFiles. Unlike title, the
+// fingerprint must be REPLACED unconditionally on every upsert — including being
+// cleared back to empty when a sidecar is removed — so the remote ETag fast path
+// never compares against a stale value.
+func TestSQLiteStore_DocumentSidecarFingerprintRoundtrip(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "meta.sqlite")
+	st := store.NewSQLiteStore(dbPath)
+	defer func() { _ = st.Close() }()
+
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	withSidecar := model.Document{
+		RelPath:            "media/clip.mp4",
+		DocType:            "video",
+		SizeBytes:          4096,
+		MTimeUnix:          1_700_000_000,
+		SidecarFingerprint: "media/clip.en.vtt@1700000000\nmedia/clip.ru.srt@1700000050",
+		Status:             "ok",
+	}
+	noSidecar := model.Document{
+		RelPath:   "media/lonely.mp3",
+		DocType:   "audio",
+		SizeBytes: 2048,
+		MTimeUnix: 1_700_000_001,
+		Status:    "ok",
+	}
+	for _, d := range []model.Document{withSidecar, noSidecar} {
+		if err := st.UpsertDocument(ctx, d); err != nil {
+			t.Fatalf("UpsertDocument(%s): %v", d.RelPath, err)
+		}
+	}
+
+	assertGetFingerprint(t, ctx, st, withSidecar.RelPath, withSidecar.SidecarFingerprint)
+	assertGetFingerprint(t, ctx, st, noSidecar.RelPath, "")
+	assertListFilesFingerprint(t, ctx, st, withSidecar)
+	assertUpsertClearsFingerprint(t, ctx, st, withSidecar)
+}
+
+func assertGetFingerprint(t *testing.T, ctx context.Context, st *store.SQLiteStore, relPath, want string) {
+	t.Helper()
+	got, err := st.GetDocumentByPath(ctx, relPath)
+	if err != nil {
+		t.Fatalf("GetDocumentByPath(%s): %v", relPath, err)
+	}
+	if got.SidecarFingerprint != want {
+		t.Errorf("doc %s: sidecar_fingerprint mismatch\n got: %q\nwant: %q", relPath, got.SidecarFingerprint, want)
+	}
+}
+
+func assertListFilesFingerprint(t *testing.T, ctx context.Context, st *store.SQLiteStore, withSidecar model.Document) {
+	t.Helper()
+	docs, _, err := st.ListFiles(ctx, "", "", 10, 0)
+	if err != nil {
+		t.Fatalf("ListFiles: %v", err)
+	}
+	for _, d := range docs {
+		if d.RelPath == withSidecar.RelPath && d.SidecarFingerprint != withSidecar.SidecarFingerprint {
+			t.Errorf("ListFiles: sidecar_fingerprint mismatch: got %q want %q", d.SidecarFingerprint, withSidecar.SidecarFingerprint)
+		}
+	}
+}
+
+// assertUpsertClearsFingerprint upserts the same row with an empty fingerprint
+// (mimicking a removed sidecar) and asserts the stored value is cleared — the
+// always-replace semantics that distinguish it from title's CASE-preserve write.
+func assertUpsertClearsFingerprint(t *testing.T, ctx context.Context, st *store.SQLiteStore, withSidecar model.Document) {
+	t.Helper()
+	cleared := withSidecar
+	cleared.SidecarFingerprint = ""
+	if err := st.UpsertDocument(ctx, cleared); err != nil {
+		t.Fatalf("UpsertDocument(cleared): %v", err)
+	}
+	got, err := st.GetDocumentByPath(ctx, withSidecar.RelPath)
+	if err != nil {
+		t.Fatalf("GetDocumentByPath after clear: %v", err)
+	}
+	if got.SidecarFingerprint != "" {
+		t.Errorf("sidecar_fingerprint not cleared on re-upsert: got %q want empty", got.SidecarFingerprint)
+	}
+}

--- a/tests/store/document_sidecar_fingerprint_roundtrip_test.go
+++ b/tests/store/document_sidecar_fingerprint_roundtrip_test.go
@@ -69,10 +69,18 @@ func assertListFilesFingerprint(t *testing.T, ctx context.Context, st *store.SQL
 	if err != nil {
 		t.Fatalf("ListFiles: %v", err)
 	}
+	found := false
 	for _, d := range docs {
-		if d.RelPath == withSidecar.RelPath && d.SidecarFingerprint != withSidecar.SidecarFingerprint {
+		if d.RelPath != withSidecar.RelPath {
+			continue
+		}
+		found = true
+		if d.SidecarFingerprint != withSidecar.SidecarFingerprint {
 			t.Errorf("ListFiles: sidecar_fingerprint mismatch: got %q want %q", d.SidecarFingerprint, withSidecar.SidecarFingerprint)
 		}
+	}
+	if !found {
+		t.Fatalf("ListFiles did not return %q", withSidecar.RelPath)
 	}
 }
 


### PR DESCRIPTION
## Summary

Follow-up from #295 review. Closes #298.

The S3 ETag incremental fast path (#245) conservatively bypassed the ETag skip for **all** sidecar-capable media (audio/video) because a subtitle sidecar (`.srt`/`.vtt`/`.ttml`) can be added/changed/removed while the media object's own ETag is unchanged, and the sidecar fingerprint was only folded into `content_hash` on the full read+hash path (#295). As a result every audio/video object on S3 was re-read on every scan even when nothing changed.

## Fix

- Persist the sidecar fingerprint (the **same** value `buildDocumentWithContent` folds into `content_hash`) as a new `documents.sidecar_fingerprint` column.
- `trySkipUnchangedRemoteDocument` now cheaply recomputes the current sidecar fingerprint from the in-memory sidecar index (no media read) and compares **both** the media ETag **and** the fingerprint, skipping only when both are unchanged; re-reading when either differs.
- Removes the conservative `if isSidecarMediaType(...) { return false, nil }` carve-out from #295.

Behaviour is unchanged when there are no sidecars: the fingerprint is empty on both sides, so the ETag skip works exactly as for non-media objects.

## Schema migration

Additive `ALTER TABLE documents ADD COLUMN sidecar_fingerprint TEXT NOT NULL DEFAULT ''` appended to `applyAdditiveColumnMigrations` (idempotent via `isDuplicateColumnError`), plus the matching column in the fresh-DB `CREATE TABLE`. Persisted on Upsert (always-replace, so a removed sidecar clears it) and read back in `GetDocumentByPath`, `ListFiles`, and `RecentFailures`.

## Tests

- `tests/store/document_sidecar_fingerprint_roundtrip_test.go` — column roundtrip via Get/ListFiles, empty stays empty, always-replace clears on re-upsert.
- `tests/ingest/etag_incremental_test.go` — replaced the #295 "always re-read" test with fingerprint-based scenarios: no-sidecar media now ETag-skips; sidecar added / changed forces re-read; unchanged sidecar skips.

`make check` passes (gofmt, go vet, golangci-lint incl. staticcheck, all Go tests, python unittests, build).

The `dirstral-spec` submodule pointer is intentionally **not** re-pinned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subtitle sidecar change detection during remote incremental ingestion; media files with sidecars now properly refresh when subtitle files are added, modified, or removed, rather than relying solely on backend change indicators.

* **Tests**
  * Added comprehensive test coverage for sidecar persistence and change detection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->