### PR TITLE
feat(ingest): configurable media chunk window durations (#267 item 3)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -275,6 +275,16 @@ type Config struct {
 	// Default OFF.
 	MediaVAD bool
 
+	// MediaAudioWindowSec / MediaVideoWindowSec configure the direct-embedding
+	// media chunk window length, in seconds, for audio and video respectively
+	// (SPEC 8.1.7; config `media.audio_window_sec` / `media.video_window_sec`).
+	// A positive value overrides the built-in default (audio 120 s, video 60 s);
+	// a value exceeding the per-modality cap (audio 180 s, video 120 s) is
+	// clamped to the cap (with a warning). Zero/unset falls back to the default,
+	// so behavior is identical to the hardcoded constants when unconfigured.
+	MediaAudioWindowSec int
+	MediaVideoWindowSec int
+
 	// QualityGatesEnabled is the master switch for the output quality gate
 	// (spec 0.16.0): when true (default), generated transcript/OCR text is
 	// screened for degenerate output (repetition loops, empty output,
@@ -386,6 +396,8 @@ type fileConfig struct {
 	MediaTrimLeadingSilence   *bool
 	MediaSilenceThresholdDB   *float64
 	MediaVAD                  *bool
+	MediaAudioWindowSec       *int
+	MediaVideoWindowSec       *int
 	ElevenLabsAPIKey          *string
 	ServerTLSCertFile         *string
 	ServerTLSKeyFile          *string
@@ -481,6 +493,8 @@ type persistedConfig struct {
 	MediaTrimLeadingSilence   bool          `yaml:"media_trim_leading_silence"`
 	MediaSilenceThresholdDB   float64       `yaml:"media_silence_threshold_db"`
 	MediaVAD                  bool          `yaml:"media_vad"`
+	MediaAudioWindowSec       int           `yaml:"media_audio_window_sec"`
+	MediaVideoWindowSec       int           `yaml:"media_video_window_sec"`
 	ServerTLSCertFile         string        `yaml:"server_tls_cert_file"`
 	ServerTLSKeyFile          string        `yaml:"server_tls_key_file"`
 
@@ -711,6 +725,8 @@ func buildPersistedConfig(cfg *Config) persistedConfig {
 		MediaTrimLeadingSilence:   cfg.MediaTrimLeadingSilence,
 		MediaSilenceThresholdDB:   cfg.MediaSilenceThresholdDB,
 		MediaVAD:                  cfg.MediaVAD,
+		MediaAudioWindowSec:       cfg.MediaAudioWindowSec,
+		MediaVideoWindowSec:       cfg.MediaVideoWindowSec,
 		ServerTLSCertFile:         cfg.ServerTLSCertFile,
 		ServerTLSKeyFile:          cfg.ServerTLSKeyFile,
 		X402Mode:                  cfg.X402.Mode,
@@ -1316,6 +1332,13 @@ func applySTTFileParsed(cfg *Config, fc fileConfig) {
 	if fc.QualityGatesEnabled != nil {
 		cfg.QualityGatesEnabled = *fc.QualityGatesEnabled
 	}
+	applyMediaFileParsed(cfg, fc)
+}
+
+// applyMediaFileParsed copies the set media.* file fields onto cfg. It is split
+// out of applySTTFileParsed so each apply helper stays under the cyclomatic
+// complexity budget as more media scalars are added.
+func applyMediaFileParsed(cfg *Config, fc fileConfig) {
 	if fc.MediaSidecarsDisabled != nil {
 		cfg.MediaSidecarsDisabled = *fc.MediaSidecarsDisabled
 	}
@@ -1342,6 +1365,12 @@ func applySTTFileParsed(cfg *Config, fc fileConfig) {
 	}
 	if fc.MediaVAD != nil {
 		cfg.MediaVAD = *fc.MediaVAD
+	}
+	if fc.MediaAudioWindowSec != nil {
+		cfg.MediaAudioWindowSec = *fc.MediaAudioWindowSec
+	}
+	if fc.MediaVideoWindowSec != nil {
+		cfg.MediaVideoWindowSec = *fc.MediaVideoWindowSec
 	}
 }
 
@@ -1614,6 +1643,8 @@ var configKeyAliases = map[string]string{
 	"media_trim_leading_silence":           "media.trim_leading_silence",
 	"media_silence_threshold_db":           "media.silence_threshold_db",
 	"media_vad":                            "media.vad",
+	"media_audio_window_sec":               "media.audio_window_sec",
+	"media_video_window_sec":               "media.video_window_sec",
 	"stt_provider":                         "stt.provider",
 	"stt_mistral_model":                    "stt.mistral.model",
 	"stt_elevenlabs_model":                 "stt.elevenlabs.model",
@@ -1764,6 +1795,10 @@ func setIntFileScalar(cfg *fileConfig, key, value string) error {
 		target = &cfg.IngestMaxFileMB
 	case "rerank.candidate_pool":
 		target = &cfg.RerankCandidatePool
+	case "media.audio_window_sec":
+		target = &cfg.MediaAudioWindowSec
+	case "media.video_window_sec":
+		target = &cfg.MediaVideoWindowSec
 	default:
 		return nil
 	}
@@ -1771,8 +1806,19 @@ func setIntFileScalar(cfg *fileConfig, key, value string) error {
 	if err != nil {
 		return fmt.Errorf("invalid integer for %s", key)
 	}
+	if nonNegativeIntKeys[key] && parsed < 0 {
+		return fmt.Errorf("invalid integer for %s: must not be negative", key)
+	}
 	*target = intPtr(parsed)
 	return nil
+}
+
+// nonNegativeIntKeys lists canonical integer config keys whose value must not
+// be negative. A negative value is rejected at config-parse time (explicit,
+// deterministic) rather than being silently clamped later.
+var nonNegativeIntKeys = map[string]bool{
+	"media.audio_window_sec": true,
+	"media.video_window_sec": true,
 }
 
 // setFloatFileScalar parses value as a float64 and assigns it to the
@@ -2122,6 +2168,8 @@ func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	writeBool("media_trim_leading_silence", cfg.MediaTrimLeadingSilence)
 	writeScalar("media_silence_threshold_db", strconv.FormatFloat(cfg.MediaSilenceThresholdDB, 'f', -1, 64))
 	writeBool("media_vad", cfg.MediaVAD)
+	writeInt("media_audio_window_sec", cfg.MediaAudioWindowSec)
+	writeInt("media_video_window_sec", cfg.MediaVideoWindowSec)
 	writeScalar("server_tls_cert_file", cfg.ServerTLSCertFile)
 	writeScalar("server_tls_key_file", cfg.ServerTLSKeyFile)
 	writeScalar("x402_mode", cfg.X402Mode)

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -1309,12 +1309,14 @@ func (s *Service) resolveMediaWindowMS(cfgSec, defaultMS, capMS int, modality st
 	if cfgSec <= 0 {
 		return defaultMS
 	}
-	windowMS := cfgSec * 1000
-	if windowMS > capMS {
+	// Compare in seconds before converting to ms: a huge cfgSec would overflow
+	// cfgSec*1000 (wrapping negative and slipping past the cap), so the cap
+	// check must run first on the un-multiplied value.
+	if cfgSec > capMS/1000 {
 		s.getLogger().Printf("multimodal: configured %s window %ds exceeds the per-modality cap (%ds); clamping to the cap", modality, cfgSec, capMS/1000)
 		return capMS
 	}
-	return windowMS
+	return cfgSec * 1000
 }
 
 // mediaSpansFor returns the per-chunk spans to embed directly for doc under the

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -1290,6 +1290,33 @@ const (
 	videoWindowMS = 60 * 1000
 )
 
+// Per-modality window caps (SPEC 8.1.7): the maximum window length the
+// keyframe-drift logic in avutil.ExtractSegment can serve without a clip
+// exceeding the per-request duration cap (audio ≤ 180 s, video ≤ 120 s). A
+// configured window (media.audio_window_sec / media.video_window_sec) is
+// clamped to these so a misconfiguration can never push a clip over the cap.
+const (
+	audioWindowCapMS = 180 * 1000
+	videoWindowCapMS = 120 * 1000
+)
+
+// resolveMediaWindowMS returns the window length (ms) to use for windowing
+// media of the given doc type. A positive configured value (cfgSec seconds)
+// overrides the default; values exceeding the per-modality cap are clamped
+// (with a warning); zero/negative values fall back to the default. This keeps
+// behavior identical to the hardcoded constants when unconfigured (SPEC 8.1.7).
+func (s *Service) resolveMediaWindowMS(cfgSec, defaultMS, capMS int, modality string) int {
+	if cfgSec <= 0 {
+		return defaultMS
+	}
+	windowMS := cfgSec * 1000
+	if windowMS > capMS {
+		s.getLogger().Printf("multimodal: configured %s window %ds exceeds the per-modality cap (%ds); clamping to the cap", modality, cfgSec, capMS/1000)
+		return capMS
+	}
+	return windowMS
+}
+
 // mediaSpansFor returns the per-chunk spans to embed directly for doc under the
 // multimodal mode (SPEC 8.1.7): nil when media embedding is off or doc is not
 // an embeddable media type; one `page` span for an image; one `page` span per
@@ -1310,9 +1337,11 @@ func (s *Service) mediaSpansFor(ctx context.Context, doc model.Document, content
 		if !isEmbeddableAudio(doc.RelPath) {
 			return nil
 		}
-		return s.mediaTimeSpans(ctx, doc, audioWindowMS)
+		windowMS := s.resolveMediaWindowMS(s.cfg.MediaAudioWindowSec, audioWindowMS, audioWindowCapMS, "audio")
+		return s.mediaTimeSpans(ctx, doc, windowMS)
 	case "video":
-		return s.mediaTimeSpans(ctx, doc, videoWindowMS)
+		windowMS := s.resolveMediaWindowMS(s.cfg.MediaVideoWindowSec, videoWindowMS, videoWindowCapMS, "video")
+		return s.mediaTimeSpans(ctx, doc, windowMS)
 	default:
 		return nil
 	}

--- a/tests/config/media_window_config_test.go
+++ b/tests/config/media_window_config_test.go
@@ -1,0 +1,108 @@
+package tests
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+)
+
+// TestMediaWindow_Defaults locks the unset defaults to zero so the ingest path
+// falls back to the built-in window constants (audio 120 s, video 60 s),
+// keeping behavior identical when unconfigured (SPEC 8.1.7).
+func TestMediaWindow_Defaults(t *testing.T) {
+	cfg := config.Default()
+	if cfg.MediaAudioWindowSec != 0 {
+		t.Errorf("media.audio_window_sec default = %d, want 0 (constant fallback)", cfg.MediaAudioWindowSec)
+	}
+	if cfg.MediaVideoWindowSec != 0 {
+		t.Errorf("media.video_window_sec default = %d, want 0 (constant fallback)", cfg.MediaVideoWindowSec)
+	}
+}
+
+// TestMediaWindow_RoundTripsThroughSaveLoad exercises the int plumbing
+// (setIntFileScalar/intPtr, writeInt) for the new window scalars through
+// save/load.
+func TestMediaWindow_RoundTripsThroughSaveLoad(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+
+	cfg := config.Default()
+	cfg.RootDir = "/tmp/repo"
+	cfg.StateDir = "/tmp/repo/.dir2mcp"
+	cfg.MediaAudioWindowSec = 90
+	cfg.MediaVideoWindowSec = 45
+	if err := config.SaveFile(path, cfg); err != nil {
+		t.Fatalf("SaveFile failed: %v", err)
+	}
+	loaded, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile failed: %v", err)
+	}
+	if loaded.MediaAudioWindowSec != 90 {
+		t.Errorf("media.audio_window_sec did not round-trip: got %d, want 90", loaded.MediaAudioWindowSec)
+	}
+	if loaded.MediaVideoWindowSec != 45 {
+		t.Errorf("media.video_window_sec did not round-trip: got %d, want 45", loaded.MediaVideoWindowSec)
+	}
+}
+
+// TestMediaWindow_NestedYAMLApplies locks the nested media: block so the window
+// scalars are applied via the bespoke YAML scanner (isMapSectionKey("media")).
+func TestMediaWindow_NestedYAMLApplies(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+	writeFile(t, path, strings.Join([]string{
+		"root_dir: /tmp/repo",
+		"state_dir: /tmp/repo/.dir2mcp",
+		"media:",
+		"  audio_window_sec: 150",
+		"  video_window_sec: 100",
+	}, "\n")+"\n")
+
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile(nested media) = %v, want nil", err)
+	}
+	if cfg.MediaAudioWindowSec != 150 {
+		t.Errorf("nested media.audio_window_sec = %d, want 150", cfg.MediaAudioWindowSec)
+	}
+	if cfg.MediaVideoWindowSec != 100 {
+		t.Errorf("nested media.video_window_sec = %d, want 100", cfg.MediaVideoWindowSec)
+	}
+}
+
+// TestMediaWindow_RejectsNegative asserts a negative window value is rejected at
+// config-parse time (explicit, deterministic) rather than silently clamped.
+func TestMediaWindow_RejectsNegative(t *testing.T) {
+	for _, key := range []string{"media_audio_window_sec", "media_video_window_sec"} {
+		tmp := t.TempDir()
+		path := filepath.Join(tmp, ".dir2mcp.yaml")
+		writeFile(t, path, strings.Join([]string{
+			"root_dir: /tmp/repo",
+			"state_dir: /tmp/repo/.dir2mcp",
+			key + ": -5",
+		}, "\n")+"\n")
+
+		if _, err := config.LoadFile(path); err == nil {
+			t.Errorf("LoadFile with %s=-5 = nil error, want rejection", key)
+		}
+	}
+}
+
+// TestMediaWindow_RejectsNonInteger asserts a non-integer window value is
+// rejected at config-parse time.
+func TestMediaWindow_RejectsNonInteger(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+	writeFile(t, path, strings.Join([]string{
+		"root_dir: /tmp/repo",
+		"state_dir: /tmp/repo/.dir2mcp",
+		"media_audio_window_sec: abc",
+	}, "\n")+"\n")
+
+	if _, err := config.LoadFile(path); err == nil {
+		t.Error("LoadFile with media_audio_window_sec=abc = nil error, want rejection")
+	}
+}

--- a/tests/ingest/media_window_config_test.go
+++ b/tests/ingest/media_window_config_test.go
@@ -1,0 +1,117 @@
+package tests
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// processMediaWithWindowCfg ingests a single media file under augment mode with
+// a stubbed duration probe and the given configured window seconds (0 = unset,
+// falls back to the built-in constant), returning the per-modality time-window
+// chunk count and the last window end (ms).
+func processMediaWithWindowCfg(t *testing.T, name, modality string, dur time.Duration, audioSec, videoSec int) (windows, lastEndMS int) {
+	t.Helper()
+	t.Setenv("GEMINI_API_KEY", "gk")
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, name), []byte("MEDIADATA"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := loadMultimodalConfig(t, root, "augment")
+	cfg.STTProvider = "off"
+	cfg.MediaAudioWindowSec = audioSec
+	cfg.MediaVideoWindowSec = videoSec
+
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	if err := st.Init(context.Background()); err != nil {
+		t.Fatalf("init store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	svc := mustNewIngestService(t, cfg, st)
+	svc.ProbeDurationFunc = func(context.Context, string) (time.Duration, error) { return dur, nil }
+
+	df := ingest.DiscoveredFile{AbsPath: filepath.Join(root, name), RelPath: name, SizeBytes: int64(len("MEDIADATA"))}
+	if err := svc.ProcessDocument(context.Background(), df, nil, false); err != nil {
+		t.Fatalf("ProcessDocument: %v", err)
+	}
+	tasks, err := st.NextPending(context.Background(), 100, "text")
+	if err != nil {
+		t.Fatalf("NextPending: %v", err)
+	}
+	for _, tk := range tasks {
+		if tk.Modality != modality || tk.Metadata.Span.Kind != "time" {
+			continue
+		}
+		windows++
+		if tk.Metadata.Span.EndMS > lastEndMS {
+			lastEndMS = tk.Metadata.Span.EndMS
+		}
+	}
+	return windows, lastEndMS
+}
+
+// TestMediaWindow_ConfiguredAudioWindowHonored asserts a configured audio window
+// overrides the 120 s default: at 300 s with a 60 s window => 5 windows.
+func TestMediaWindow_ConfiguredAudioWindowHonored(t *testing.T) {
+	windows, last := processMediaWithWindowCfg(t, "talk.mp3", "audio", 300*time.Second, 60, 0)
+	if windows != 5 {
+		t.Fatalf("audio windows = %d, want 5 (60s window over 300s)", windows)
+	}
+	if last != 300000 {
+		t.Errorf("last audio window end = %dms, want 300000", last)
+	}
+}
+
+// TestMediaWindow_ConfiguredVideoWindowHonored asserts a configured video window
+// overrides the 60 s default: at 300 s with a 100 s window => 3 windows.
+func TestMediaWindow_ConfiguredVideoWindowHonored(t *testing.T) {
+	windows, last := processMediaWithWindowCfg(t, "clip.mp4", "video", 300*time.Second, 0, 100)
+	if windows != 3 {
+		t.Fatalf("video windows = %d, want 3 (100s window over 300s)", windows)
+	}
+	if last != 300000 {
+		t.Errorf("last video window end = %dms, want 300000", last)
+	}
+}
+
+// TestMediaWindow_UnsetFallsBackToDefault asserts an unset (0) window keeps the
+// built-in default: video defaults to 60 s, so 180 s => 3 windows (unchanged
+// behavior).
+func TestMediaWindow_UnsetFallsBackToDefault(t *testing.T) {
+	windows, _ := processMediaWithWindowCfg(t, "clip.mp4", "video", 180*time.Second, 0, 0)
+	if windows != 3 {
+		t.Fatalf("video windows with unset config = %d, want 3 (60s default)", windows)
+	}
+}
+
+// TestMediaWindow_AudioClampedToCap asserts an over-cap audio window is clamped
+// to the 180 s per-modality cap (SPEC 8.1.7): a 600 s window over 360 s of media
+// is clamped to 180 s => 2 windows (not 1, which an un-clamped 600 s would give).
+func TestMediaWindow_AudioClampedToCap(t *testing.T) {
+	windows, last := processMediaWithWindowCfg(t, "talk.mp3", "audio", 360*time.Second, 600, 0)
+	if windows != 2 {
+		t.Fatalf("audio windows = %d, want 2 (over-cap window clamped to 180s)", windows)
+	}
+	if last != 360000 {
+		t.Errorf("last audio window end = %dms, want 360000", last)
+	}
+}
+
+// TestMediaWindow_VideoClampedToCap asserts an over-cap video window is clamped
+// to the 120 s per-modality cap (SPEC 8.1.7): a 600 s window over 240 s is
+// clamped to 120 s => 2 windows.
+func TestMediaWindow_VideoClampedToCap(t *testing.T) {
+	windows, last := processMediaWithWindowCfg(t, "clip.mp4", "video", 240*time.Second, 0, 600)
+	if windows != 2 {
+		t.Fatalf("video windows = %d, want 2 (over-cap window clamped to 120s)", windows)
+	}
+	if last != 240000 {
+		t.Errorf("last video window end = %dms, want 240000", last)
+	}
+}

--- a/tests/ingest/media_window_config_test.go
+++ b/tests/ingest/media_window_config_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"math"
 	"os"
 	"path/filepath"
 	"testing"
@@ -113,5 +114,18 @@ func TestMediaWindow_VideoClampedToCap(t *testing.T) {
 	}
 	if last != 240000 {
 		t.Errorf("last video window end = %dms, want 240000", last)
+	}
+}
+
+// TestMediaWindow_OverflowClampedToCap asserts that an absurdly large configured
+// window (math.MaxInt) clamps to the cap rather than overflowing cfgSec*1000 to a
+// negative window. Over 360 s of audio at the 180 s cap => 2 windows.
+func TestMediaWindow_OverflowClampedToCap(t *testing.T) {
+	windows, last := processMediaWithWindowCfg(t, "talk.mp3", "audio", 360*time.Second, math.MaxInt, 0)
+	if windows != 2 {
+		t.Fatalf("audio windows = %d, want 2 (MaxInt window clamped to 180s, not overflowed)", windows)
+	}
+	if last != 360000 {
+		t.Errorf("last audio window end = %dms, want 360000", last)
 	}
 }


### PR DESCRIPTION
## Summary

Implements **item 3 of #267** — makes the hardcoded per-modality media chunk window durations configurable. Scoped to the *configurable* part only; content-aware/scene-cut alignment is left as a follow-up.

- The constants `audioWindowMS` (120 s) and `videoWindowMS` (60 s) in `internal/ingest/service.go` are now overridable via config.
- **New config keys:** `media.audio_window_sec` / `media.video_window_sec` (int seconds; aliases `media_audio_window_sec` / `media_video_window_sec`), nested under the existing `media:` YAML section, plumbed end-to-end mirroring `MediaSilenceThresholdDB`/`MediaVAD`.
- **Defaults unchanged:** unset (0) falls back to the existing constant, so behavior is identical when not configured. `Default()` needed no change.
- **Cap-clamping (SPEC §8.1.7):** new `audioWindowCapMS = 180_000` / `videoWindowCapMS = 120_000` (the per-modality caps the keyframe-drift logic relies on). A resolver `resolveMediaWindowMS(cfgSec, defaultMS, capMS, modality)` returns the default when unset, clamps + warns when a configured value exceeds the cap, else returns the configured window. Negative / non-integer values are rejected at config-parse time.
- **Refactor:** the two new apply-ifs pushed `applySTTFileParsed` to gocyclo 17, so the `Media*` apply-ifs were extracted into `applyMediaFileParsed` (keeps both functions under the ≤15 budget — no suppression).

## Tests
- `tests/config/media_window_config_test.go` — defaults/constant-fallback, save-load round-trip, nested-`media:` YAML apply, rejection of negative and non-integer values.
- `tests/ingest/media_window_config_test.go` — configured audio/video windows honored, unset falls back to default, over-cap audio (600 s→180 s) and video (600 s→120 s) clamped.
- Existing `TestProcessDocument_Video/AudioWindows` still pass unchanged.

`make check` passes locally (golangci-lint 0 issues, gocyclo OK, build OK). `dirstral-spec` submodule not re-pinned. No `Co-Authored-By` footer.

Closes part of #267 (item 3 only).