### PR TITLE
feat(ingest): representation provenance + STT/OCR identity-driven re-derivation (#263)

### DIFF
--- a/internal/ingest/derivation.go
+++ b/internal/ingest/derivation.go
@@ -158,22 +158,32 @@ func (s *Service) transcriptCacheKey(content []byte) string {
 
 // ocrCacheKey returns the on-disk OCR cache filename stem for the given content,
 // folding the active OCR derivation identity into the key (SPEC §8.6.7). Keying
-// on the bytes alone would return the previous extractor's cached text after an
-// OCR model swap that the re-ingest gate forced re-extraction for, silently
-// defeating the re-derivation. An empty active identity (no extractor / no
-// model concept) folds in "", preserving the historical bytes-only key.
+// on the bytes alone would return the PREVIOUS extractor's cached text after an
+// OCR model/provider swap that the re-ingest gate forced re-extraction for,
+// silently defeating the re-derivation.
+//
+// The identity is folded whenever it is non-empty — which includes PROVIDER-only
+// identities (docling / docling-serve / custom commands, which have no model).
+// All extractors share one `cache/ocr` directory, so a docling↔docling-serve
+// swap (which ocrStale treats as stale, since the provider differs) MUST land on
+// a different cache key; folding the provider-bearing identity guarantees that.
+// An empty active identity (no extractor configured) folds in nothing, preserving
+// the historical bytes-only key for the no-OCR path.
 func (s *Service) ocrCacheKey(content []byte) string {
-	// Only model-bearing extractors (e.g. mistral OCR) need the identity folded
-	// in: model-less extractors (docling / docling-serve / custom commands) are
-	// deterministic for the same bytes and use a distinct cache directory per
-	// provider, so their historical bytes-only key is preserved and a swap between
-	// them already lands in a different cache tree.
-	_, modelName := s.extractorProviderModel()
-	if strings.TrimSpace(modelName) == "" {
+	identity := s.activeOCRIdentity()
+	if identity == "" {
 		return computeContentHash(content)
 	}
-	combined := strings.Join([]string{computeContentHash(content), s.activeOCRIdentity()}, "\x00")
+	combined := strings.Join([]string{computeContentHash(content), identity}, "\x00")
 	return computeContentHash([]byte(combined))
+}
+
+// OCRCacheKey exposes ocrCacheKey for tests in the tests/ tree, so the
+// provider/model → cache-key binding (SPEC §8.6.7) can be asserted directly —
+// in particular that a provider-only swap (docling↔docling-serve) yields a
+// distinct key even though neither extractor carries a model.
+func (s *Service) OCRCacheKey(content []byte) string {
+	return s.ocrCacheKey(content)
 }
 
 // derivationIdentity builds the canonical, order-stable derivation-identity

--- a/internal/ingest/derivation.go
+++ b/internal/ingest/derivation.go
@@ -1,0 +1,239 @@
+package ingest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/dirstral/dir2mcp/internal/provider"
+)
+
+// Representation provenance and identity-driven re-derivation (spec §8.6.7).
+//
+// Derived representations (transcripts, extracted markdown) record the
+// provider+model that produced them in meta_json (§5.2). The re-ingest gate
+// builds a "derivation identity" string from those structured fields and
+// compares it to the active model's identity; on mismatch the representation is
+// stale and is re-derived → re-chunked → re-embedded. This is the
+// per-representation analogue of the corpus-lifetime embed identity (§8.1.4):
+// the comparison is built from explicit fields (capability/provider/model/
+// version/language), never an opaque blob, and an EMPTY recorded identity always
+// passes so a pre-upgrade corpus (reps written before provenance was persisted)
+// is never mass re-derived on first upgrade.
+
+// sttTranscriptMetaJSON builds the meta_json persisted on a bare
+// machine-transcribed transcript representation. It records source=stt plus the
+// active STT derivation identity (provider/model/language, §5.2/§8.6.7) so a
+// later STT model swap can be detected and the transcript re-derived. Fields are
+// omitted (omitempty) when unset, so a setup with no resolved STT identity still
+// produces valid meta_json (and an empty recorded identity that the gate treats
+// as "always passes").
+func (s *Service) sttTranscriptMetaJSON() (string, error) {
+	meta := transcriptMeta{
+		Source:     sttSource,
+		Language:   strings.TrimSpace(s.transcriptLanguage),
+		Timestamps: true,
+		Provider:   strings.TrimSpace(s.sttProvider),
+		Model:      strings.TrimSpace(s.sttModel),
+	}
+	encoded, err := json.Marshal(meta)
+	if err != nil {
+		return "", err
+	}
+	return string(encoded), nil
+}
+
+// activeTranscriptIdentity is the STT derivation identity of the currently
+// configured transcriber, in the same canonical form derivationIdentity emits
+// for a recorded transcript representation. It is compared against the identity
+// read from a stored transcript to decide whether an STT model swap has made the
+// transcript stale (§8.6.7).
+func (s *Service) activeTranscriptIdentity() string {
+	return derivationIdentity(string(provider.CapSTT),
+		s.sttProvider, s.sttModel, "", s.transcriptLanguage)
+}
+
+// activeOCRIdentity is the OCR/extraction derivation identity of the currently
+// configured extractor, in the same canonical form derivationIdentity emits for
+// the stored extracted_markdown representation's meta_json. Empty when no
+// extractor is configured.
+func (s *Service) activeOCRIdentity() string {
+	prov, modelName := s.extractorProviderModel()
+	if prov == "" && modelName == "" {
+		return ""
+	}
+	return derivationIdentity(string(provider.CapOCR), prov, modelName, "", "")
+}
+
+// derivationIdentityStale reports whether a document whose content is unchanged
+// must nonetheless be reprocessed because a derived representation's recorded
+// derivation identity no longer matches the active model's identity (spec
+// §8.6.7). It probes the bare transcript representation against the active STT
+// identity and the extracted_markdown representation against the active OCR
+// identity. A mismatch on either returns true and logs a scoped warn (mirroring
+// the embed-identity → reindex UX, §8.1.4) so re-derivation is observable.
+//
+// It NEVER invalidates on:
+//   - an empty recorded identity (pre-upgrade reps, backward-compat): the first
+//     upgrade must not force a corpus-wide re-derivation;
+//   - a sidecar-sourced transcript: authored, not model-derived (§8.6.4);
+//   - a missing store capability, a missing document, or a representation the
+//     active pipeline cannot produce (e.g. an OCR rep with STT off): fail open.
+//
+// The caller is responsible for only invoking this on the content-unchanged,
+// status==ok path; under --force/reindex the normal gate already returns true.
+func (s *Service) derivationIdentityStale(ctx context.Context, relPath string) bool {
+	reader, ok := s.store.(representationMetaReader)
+	if !ok {
+		return false
+	}
+	if s.transcriptStale(ctx, reader, relPath) {
+		return true
+	}
+	return s.ocrStale(ctx, reader, relPath)
+}
+
+// transcriptStale reports whether the document's stored machine transcript was
+// produced by a different STT model than the active one (§8.6.7). It self-skips
+// (returns false) when STT is off (no active identity to compare against), so a
+// run that simply has no transcriber configured never invalidates an existing
+// transcript.
+func (s *Service) transcriptStale(ctx context.Context, reader representationMetaReader, relPath string) bool {
+	if s.transcriber == nil {
+		return false
+	}
+	active := s.activeTranscriptIdentity()
+	metaJSON, err := reader.RepresentationMetaByType(ctx, relPath, RepTypeTranscript)
+	if err != nil || metaJSON == "" {
+		return false
+	}
+	recorded, ok := transcriptIdentityFromMeta(metaJSON)
+	if !ok || recorded == active {
+		return false
+	}
+	s.getLogger().Printf(
+		"STT model changed for %s (transcript derived with %q, configured %q); re-transcribing this representation",
+		relPath, recorded, active)
+	return true
+}
+
+// ocrStale reports whether the document's stored extracted_markdown was produced
+// by a different OCR/extraction model than the active one (§8.6.7). It self-skips
+// when no extractor is configured.
+func (s *Service) ocrStale(ctx context.Context, reader representationMetaReader, relPath string) bool {
+	if s.extractor == nil {
+		return false
+	}
+	active := s.activeOCRIdentity()
+	if active == "" {
+		return false
+	}
+	metaJSON, err := reader.RepresentationMetaByType(ctx, relPath, RepTypeExtractedMarkdown)
+	if err != nil || metaJSON == "" {
+		return false
+	}
+	recorded, ok := ocrIdentityFromMeta(metaJSON)
+	if !ok || recorded == active {
+		return false
+	}
+	s.getLogger().Printf(
+		"OCR model changed for %s (extraction derived with %q, configured %q); re-extracting this representation",
+		relPath, recorded, active)
+	return true
+}
+
+// ocrCacheKey returns the on-disk OCR cache filename stem for the given content,
+// folding the active OCR derivation identity into the key (SPEC §8.6.7). Keying
+// on the bytes alone would return the previous extractor's cached text after an
+// OCR model swap that the re-ingest gate forced re-extraction for, silently
+// defeating the re-derivation. An empty active identity (no extractor / no
+// model concept) folds in "", preserving the historical bytes-only key.
+func (s *Service) ocrCacheKey(content []byte) string {
+	active := s.activeOCRIdentity()
+	if active == "" {
+		return computeContentHash(content)
+	}
+	combined := strings.Join([]string{computeContentHash(content), active}, "\x00")
+	return computeContentHash([]byte(combined))
+}
+
+// derivationIdentity builds the canonical, order-stable derivation-identity
+// string from the structured fields the spec defines (§8.6.7:
+// {capability, provider, model, version, language}). It is intentionally NOT an
+// opaque hash so the value is greppable in logs and diffable in tests. All
+// fields are trimmed and lower-cased for the capability (a fixed token) while
+// provider/model/version/language are trimmed only, preserving case that a
+// provider may treat as significant in a model id.
+func derivationIdentity(capability, prov, modelName, version, language string) string {
+	return fmt.Sprintf("%s|%s|%s|%s|%s",
+		strings.ToLower(strings.TrimSpace(capability)),
+		strings.TrimSpace(prov),
+		strings.TrimSpace(modelName),
+		strings.TrimSpace(version),
+		strings.TrimSpace(language))
+}
+
+// transcriptIdentityFromMeta builds the recorded STT derivation identity of a
+// stored transcript representation from its meta_json. It returns ("", false)
+// for a transcript that carries no STT identity and MUST NOT be invalidated by
+// an STT model change: a sidecar-sourced transcript (§8.6.4/§8.6.7), a
+// translated transcript (its provenance is the translate provider, screened
+// elsewhere), or a pre-upgrade transcript whose provider/model were never
+// recorded (backward-compat: empty identity always passes). A non-empty result
+// is in the same canonical form as activeTranscriptIdentity.
+func transcriptIdentityFromMeta(metaJSON string) (string, bool) {
+	metaJSON = strings.TrimSpace(metaJSON)
+	if metaJSON == "" {
+		return "", false
+	}
+	var meta transcriptMeta
+	if err := json.Unmarshal([]byte(metaJSON), &meta); err != nil {
+		// Unparseable meta is treated as "no recorded identity": fail open rather
+		// than force-re-transcribe on a meta we cannot read.
+		return "", false
+	}
+	// Sidecar transcripts are authored, not model-derived: never invalidated by
+	// an STT model change (§8.6.7).
+	if strings.TrimSpace(meta.Source) == sidecarSource {
+		return "", false
+	}
+	// A translated transcript's STT provenance is not the source-transcript STT
+	// model; it is handled by the source transcript's re-derivation cascade.
+	if strings.TrimSpace(meta.Source) == translationSource {
+		return "", false
+	}
+	// Backward-compat: a pre-upgrade STT transcript recorded no provider/model.
+	// An empty identity always passes so the first upgrade does not force a
+	// corpus-wide re-transcription (mirrors VerifyEmbedIdentity's fresh-index
+	// rule).
+	if strings.TrimSpace(meta.Provider) == "" && strings.TrimSpace(meta.Model) == "" {
+		return "", false
+	}
+	return derivationIdentity(string(provider.CapSTT),
+		meta.Provider, meta.Model, meta.ModelVersion, meta.Language), true
+}
+
+// ocrIdentityFromMeta builds the recorded OCR/extraction derivation identity of
+// a stored extracted_markdown representation from its meta_json. It returns
+// ("", false) when no provider/model was recorded (a pre-upgrade extraction, or
+// an extractor whose meta carries no model): an empty identity always passes
+// (backward-compat). A non-empty result is in the same canonical form as
+// activeOCRIdentity.
+func ocrIdentityFromMeta(metaJSON string) (string, bool) {
+	metaJSON = strings.TrimSpace(metaJSON)
+	if metaJSON == "" {
+		return "", false
+	}
+	var meta map[string]string
+	if err := json.Unmarshal([]byte(metaJSON), &meta); err != nil {
+		return "", false
+	}
+	prov := strings.TrimSpace(meta["provider"])
+	modelName := strings.TrimSpace(meta["model"])
+	version := strings.TrimSpace(meta["model_version"])
+	if prov == "" && modelName == "" {
+		return "", false
+	}
+	return derivationIdentity(string(provider.CapOCR), prov, modelName, version, ""), true
+}

--- a/internal/ingest/derivation.go
+++ b/internal/ingest/derivation.go
@@ -143,6 +143,19 @@ func (s *Service) ocrStale(ctx context.Context, reader representationMetaReader,
 	return true
 }
 
+// transcriptCacheKey returns the on-disk transcript cache filename stem for the
+// given media bytes, folding the active STT derivation identity into the key
+// (SPEC §8.6.7) so a model swap does not return the previous model's cached
+// transcript. When no STT provider/model is resolved (no transcriber, or an
+// identity with empty provider+model) the historical bytes-only key is preserved.
+func (s *Service) transcriptCacheKey(content []byte) string {
+	if strings.TrimSpace(s.sttProvider) == "" && strings.TrimSpace(s.sttModel) == "" {
+		return computeContentHash(content)
+	}
+	combined := strings.Join([]string{computeContentHash(content), s.activeTranscriptIdentity()}, "\x00")
+	return computeContentHash([]byte(combined))
+}
+
 // ocrCacheKey returns the on-disk OCR cache filename stem for the given content,
 // folding the active OCR derivation identity into the key (SPEC §8.6.7). Keying
 // on the bytes alone would return the previous extractor's cached text after an
@@ -150,11 +163,16 @@ func (s *Service) ocrStale(ctx context.Context, reader representationMetaReader,
 // defeating the re-derivation. An empty active identity (no extractor / no
 // model concept) folds in "", preserving the historical bytes-only key.
 func (s *Service) ocrCacheKey(content []byte) string {
-	active := s.activeOCRIdentity()
-	if active == "" {
+	// Only model-bearing extractors (e.g. mistral OCR) need the identity folded
+	// in: model-less extractors (docling / docling-serve / custom commands) are
+	// deterministic for the same bytes and use a distinct cache directory per
+	// provider, so their historical bytes-only key is preserved and a swap between
+	// them already lands in a different cache tree.
+	_, modelName := s.extractorProviderModel()
+	if strings.TrimSpace(modelName) == "" {
 		return computeContentHash(content)
 	}
-	combined := strings.Join([]string{computeContentHash(content), active}, "\x00")
+	combined := strings.Join([]string{computeContentHash(content), s.activeOCRIdentity()}, "\x00")
 	return computeContentHash([]byte(combined))
 }
 

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -903,6 +903,29 @@ func (s *Service) persistBuildError(ctx context.Context, f DiscoveredFile, secre
 	return buildErr
 }
 
+// resolveNeedsProcessing decides whether a document's representations must be
+// (re)generated. content_hash is the primary trigger (or --force, or a brand-new
+// document, via needsReprocessing). Two further triggers apply on otherwise
+// unchanged content:
+//   - a document that previously failed representation generation is retried so
+//     a transient error recovers without a full reindex;
+//   - a derived representation whose recorded derivation identity no longer
+//     matches the active STT/OCR model is stale and must be re-derived (spec
+//     §8.6.7). The identity probe runs only when the content gate did not already
+//     trigger and the new document is ok, so it adds no work on the common path.
+func (s *Service) resolveNeedsProcessing(ctx context.Context, existingDoc, doc model.Document, forceReindex bool) bool {
+	if needsReprocessing(existingDoc.ContentHash, doc.ContentHash, forceReindex) {
+		return true
+	}
+	if existingDoc.Status == "error" {
+		return true
+	}
+	if doc.Status == "ok" && s.derivationIdentityStale(ctx, doc.RelPath) {
+		return true
+	}
+	return false
+}
+
 // refreshDocID re-reads the persisted document after an upsert to obtain the
 // store-assigned DocID needed for downstream representation creation
 // (UpsertDocument returns only an error). A not-found result is ignored — it
@@ -939,19 +962,7 @@ func (s *Service) processDocument(ctx context.Context, f DiscoveredFile, secretP
 		return fmt.Errorf("get existing document: %w", err)
 	}
 
-	needsProcessing := needsReprocessing(existingDoc.ContentHash, doc.ContentHash, forceReindex)
-	// Documents that previously failed representation generation should be
-	// retried on the next run even if their content has not changed, so the
-	// operator does not need a full reindex to recover from a transient error.
-	if existingDoc.Status == "error" {
-		needsProcessing = true
-	}
-	// Derivation-identity gate (spec §8.6.7): even with identical content_hash, a
-	// derived representation (transcript/OCR) whose recorded provider/model no
-	// longer matches the active model is stale and must be re-derived.
-	if !needsProcessing && doc.Status == "ok" && s.derivationIdentityStale(ctx, doc.RelPath) {
-		needsProcessing = true
-	}
+	needsProcessing := s.resolveNeedsProcessing(ctx, existingDoc, doc, forceReindex)
 	if err := s.store.UpsertDocument(ctx, doc); err != nil {
 		return fmt.Errorf("upsert document: %w", err)
 	}
@@ -1118,17 +1129,7 @@ func (s *Service) processDocumentFromContent(ctx context.Context, relPath string
 	if err != nil && !isNotFoundError(err) {
 		return fmt.Errorf("get existing document: %w", err)
 	}
-	needsProcessing := needsReprocessing(existingDoc.ContentHash, doc.ContentHash, forceReindex)
-	if existingDoc.Status == "error" {
-		needsProcessing = true
-	}
-	// Derivation-identity gate (spec §8.6.7): re-derive a stale transcript/OCR
-	// representation when its recorded model differs from the active one, even on
-	// unchanged content. Archive members carry the same derived representations as
-	// top-level documents, so they observe the same rule.
-	if !needsProcessing && doc.Status == "ok" && s.derivationIdentityStale(ctx, relPath) {
-		needsProcessing = true
-	}
+	needsProcessing := s.resolveNeedsProcessing(ctx, existingDoc, doc, forceReindex)
 
 	if err := s.store.UpsertDocument(ctx, doc); err != nil {
 		return fmt.Errorf("upsert document: %w", err)

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -75,6 +75,14 @@ type Service struct {
 	// configured, in which case the language detector self-skips.
 	transcriptLanguage string
 
+	// sttProvider/sttModel record the resolved STT provider profile name and
+	// model so each machine-transcribed transcript representation can carry its
+	// STT derivation identity in meta_json (SPEC §5.2/§8.6.7) and the re-ingest
+	// gate can invalidate a stale transcript when the active STT model changes.
+	// Empty when STT is off or no STT-capable profile resolves.
+	sttProvider string
+	sttModel    string
+
 	// translator is the chat/generation client used to translate transcripts
 	// into the configured target language(s) (SPEC §8.6.2). It is the chat
 	// capability binding resolved at construction, or nil when translation is
@@ -193,6 +201,17 @@ type sidecarTranscriptRetirer interface {
 	SoftDeleteSidecarTranscripts(ctx context.Context, relPath string) (int, error)
 }
 
+// representationMetaReader is the optional store capability used by the
+// derivation-identity re-ingest gate (spec §8.6.7): it reads the recorded
+// meta_json of a document's active representation of a given rep_type so the
+// ingest service can compare its STT/OCR derivation identity to the active
+// model's identity. A store that does not implement it disables identity-driven
+// re-derivation (content_hash remains the only reprocess trigger), preserving
+// prior behaviour.
+type representationMetaReader interface {
+	RepresentationMetaByType(ctx context.Context, relPath, repType string) (string, error)
+}
+
 func NewService(cfg config.Config, store model.Store) (*Service, error) {
 	svc := &Service{
 		cfg:                             cfg,
@@ -215,6 +234,13 @@ func NewService(cfg config.Config, store model.Store) (*Service, error) {
 		svc.qualityGate = quality.New(quality.DefaultConfig())
 	}
 	svc.transcriptLanguage = sttExpectedLanguage(cfg)
+	// Resolve the STT derivation identity (SPEC §8.6.7) from the same profile the
+	// transcriber uses, so a recorded transcript identity can be compared against
+	// the active one to detect a model swap. Empty when STT is off.
+	if prof, ok := resolveSTTProfile(cfg); ok {
+		svc.sttProvider = strings.TrimSpace(prof.Name)
+		svc.sttModel = strings.TrimSpace(prof.STTModel)
+	}
 	// Resolve the optional transcript-translation binding (SPEC §8.6.2). When
 	// translation is enabled we resolve the chat capability and build a
 	// generator; when off (default), or no chat provider resolves, the field
@@ -444,12 +470,27 @@ func (s *Service) captionWordFilter() *subtitle.WordFilter {
 }
 
 func sttExpectedLanguage(cfg config.Config) string {
+	prof, ok := resolveSTTProfile(cfg)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(prof.STTLanguage)
+}
+
+// resolveSTTProfile resolves the active STT provider profile (SPEC 8.1.3),
+// mirroring the provider selection in TranscriberFromConfigWithLanguage. It
+// returns ok=false when STT is off, when no STT-capable profile resolves, or
+// when the selector is unrecognised — in all of which cases callers treat STT as
+// having no derivation identity. It is the single resolution point shared by the
+// expected-language hint and the STT derivation identity recorded on transcript
+// representations (§8.6.7), so both observe the exact same profile.
+func resolveSTTProfile(cfg config.Config) (provider.Profile, bool) {
 	sel := strings.ToLower(strings.TrimSpace(cfg.STTProvider))
 	if sel == "" {
 		sel = transcriberProviderAuto
 	}
 	if sel == transcriberProviderOff || sel == "none" || sel == "disabled" {
-		return ""
+		return provider.Profile{}, false
 	}
 	r := cfg.Providers()
 	var (
@@ -466,12 +507,12 @@ func sttExpectedLanguage(cfg config.Config) string {
 	case transcriberProviderAuto:
 		prof, err = r.Resolve(provider.CapSTT)
 	default:
-		return ""
+		return provider.Profile{}, false
 	}
 	if err != nil {
-		return ""
+		return provider.Profile{}, false
 	}
-	return strings.TrimSpace(prof.STTLanguage)
+	return prof, true
 }
 
 // translatorFromConfig resolves the chat-capability binding used to translate
@@ -797,6 +838,15 @@ func (s *Service) trySkipUnchangedRemoteDocument(ctx context.Context, f Discover
 	if currentFP != existing.SidecarFingerprint {
 		return false, nil
 	}
+	// Derivation-identity gate (spec §8.6.7): the ETag/fingerprint fast path
+	// proves the BYTES are unchanged, but a transcript/OCR representation may
+	// still be stale because the active STT/OCR model changed since it was
+	// derived. When the recorded derivation identity no longer matches, fall back
+	// to the full read/hash path so the stale representation is re-derived rather
+	// than silently skipped. Only meaningful for an existing ok document.
+	if existing.Status == "ok" && s.derivationIdentityStale(ctx, f.RelPath) {
+		return false, nil
+	}
 	s.skipUnchangedRemoteDocument(ctx, f, existing, seen)
 	return true, nil
 }
@@ -884,6 +934,12 @@ func (s *Service) processDocument(ctx context.Context, f DiscoveredFile, secretP
 	// retried on the next run even if their content has not changed, so the
 	// operator does not need a full reindex to recover from a transient error.
 	if existingDoc.Status == "error" {
+		needsProcessing = true
+	}
+	// Derivation-identity gate (spec §8.6.7): even with identical content_hash, a
+	// derived representation (transcript/OCR) whose recorded provider/model no
+	// longer matches the active model is stale and must be re-derived.
+	if !needsProcessing && doc.Status == "ok" && s.derivationIdentityStale(ctx, doc.RelPath) {
 		needsProcessing = true
 	}
 	if err := s.store.UpsertDocument(ctx, doc); err != nil {
@@ -1054,6 +1110,13 @@ func (s *Service) processDocumentFromContent(ctx context.Context, relPath string
 	}
 	needsProcessing := needsReprocessing(existingDoc.ContentHash, doc.ContentHash, forceReindex)
 	if existingDoc.Status == "error" {
+		needsProcessing = true
+	}
+	// Derivation-identity gate (spec §8.6.7): re-derive a stale transcript/OCR
+	// representation when its recorded model differs from the active one, even on
+	// unchanged content. Archive members carry the same derived representations as
+	// top-level documents, so they observe the same rule.
+	if !needsProcessing && doc.Status == "ok" && s.derivationIdentityStale(ctx, relPath) {
 		needsProcessing = true
 	}
 
@@ -1699,7 +1762,7 @@ func (s *Service) readOrComputeStructured(ctx context.Context, doc model.Documen
 	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
 		return StructuredExtraction{}, fmt.Errorf("create docling cache dir: %w", err)
 	}
-	cachePath := filepath.Join(cacheDir, computeContentHash(content)+".json")
+	cachePath := filepath.Join(cacheDir, s.ocrCacheKey(content)+".json")
 	if cached, err := os.ReadFile(cachePath); err == nil {
 		var res StructuredExtraction
 		if json.Unmarshal(cached, &res) == nil && len(res.Blocks) > 0 {
@@ -1737,21 +1800,21 @@ func (s *Service) extractionMetaJSON() string {
 	if s == nil || s.extractor == nil {
 		return ""
 	}
-	meta := map[string]string{}
+	prov, modelName := s.extractorProviderModel()
+	meta := map[string]string{"provider": prov}
+	if modelName != "" {
+		meta["model"] = modelName
+	}
 	switch ex := s.extractor.(type) {
 	case *doclingExtractor:
-		meta["provider"] = "docling"
 		meta["command"] = strings.TrimSpace(ex.commandTemplate)
 	case *doclingServeExtractor:
-		meta["provider"] = "docling-serve"
 		// Sanitized (scheme/host/path only): this is persisted per-document, so
 		// any userinfo/query in the URL must not become durable metadata.
 		meta["serve_url"] = SanitizeServeURL(ex.baseURL)
 	case *mistral.Client:
-		meta["provider"] = "mistral"
-		meta["model"] = strings.TrimSpace(ex.DefaultOCRModel)
+		// provider/model already set from extractorProviderModel.
 	default:
-		meta["provider"] = "custom"
 		meta["type"] = fmt.Sprintf("%T", s.extractor)
 	}
 	encoded, err := json.Marshal(meta)
@@ -1759,6 +1822,28 @@ func (s *Service) extractionMetaJSON() string {
 		return ""
 	}
 	return string(encoded)
+}
+
+// extractorProviderModel returns the provider name and model recorded for the
+// active OCR/extraction backend, the structured fields that form its OCR
+// derivation identity (§8.6.7). model is empty for backends that have no model
+// concept (docling / docling-serve / custom commands), so their identity is
+// provider-only and stable across runs. Returns ("","") when no extractor is
+// configured.
+func (s *Service) extractorProviderModel() (providerName string, modelName string) {
+	if s == nil || s.extractor == nil {
+		return "", ""
+	}
+	switch ex := s.extractor.(type) {
+	case *doclingExtractor:
+		return "docling", ""
+	case *doclingServeExtractor:
+		return "docling-serve", ""
+	case *mistral.Client:
+		return "mistral", strings.TrimSpace(ex.DefaultOCRModel)
+	default:
+		return "custom", ""
+	}
 }
 
 // GenerateOCRMarkdownRepresentation exposes OCR representation generation for tests.
@@ -1843,10 +1928,15 @@ func (s *Service) generateTranscriptRepresentation(ctx context.Context, doc mode
 		Duration:         duration,
 	})
 
+	metaJSON, err := s.sttTranscriptMetaJSON()
+	if err != nil {
+		return fmt.Errorf("marshal transcript meta: %w", err)
+	}
 	rep := model.Representation{
 		DocID:       doc.DocID,
 		RepType:     RepTypeTranscript,
 		RepHash:     computeRepHash([]byte(transcriptText)),
+		MetaJSON:    metaJSON,
 		CreatedUnix: time.Now().Unix(),
 		Deleted:     false,
 	}
@@ -2237,7 +2327,7 @@ func (s *Service) readOrComputeOCR(ctx context.Context, doc model.Document, cont
 		return "", fmt.Errorf("create ocr cache dir: %w", err)
 	}
 
-	cachePath := filepath.Join(cacheDir, computeContentHash(content)+".md")
+	cachePath := filepath.Join(cacheDir, s.ocrCacheKey(content)+".md")
 	if cached, err := os.ReadFile(cachePath); err == nil {
 		return string(cached), nil
 	}
@@ -2324,7 +2414,18 @@ func (s *Service) readOrComputeTranscriptWithWords(ctx context.Context, doc mode
 		return "", nil, fmt.Errorf("create transcript cache dir: %w", err)
 	}
 
-	base := computeContentHash(content) + TranscriptLangSuffix(language)
+	// Key the cache on the media bytes AND the active STT derivation identity
+	// (SPEC §8.6.7), not the bytes alone: when the STT provider/model changes the
+	// re-ingest gate forces re-transcription, and a bytes-only key would return
+	// the previous model's cached text — silently defeating the re-derivation. The
+	// TranscriptLangSuffix is retained on the filename so cache files stay
+	// human-identifiable by language. A setup with no resolved STT identity folds
+	// in the empty string, preserving the historical key for that case.
+	cacheKey := strings.Join([]string{
+		computeContentHash(content),
+		s.activeTranscriptIdentity(),
+	}, "\x00")
+	base := computeContentHash([]byte(cacheKey)) + TranscriptLangSuffix(language)
 	cachePath := filepath.Join(cacheDir, base+".txt")
 	wordsPath := filepath.Join(cacheDir, base+".words.json")
 	if cached, err := os.ReadFile(cachePath); err == nil {

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -613,6 +613,16 @@ func (s *Service) SetTranscriptLanguage(language string) {
 	s.transcriptLanguage = strings.TrimSpace(language)
 }
 
+// SetSTTIdentity overrides the recorded STT derivation identity (provider name
+// and model) written into machine transcript meta_json and compared by the
+// re-ingest gate (spec §8.6.7). It mirrors SetTranscriptLanguage / SetTranslator
+// for tests that need a deterministic STT identity without resolving a real STT
+// provider profile. Values are trimmed.
+func (s *Service) SetSTTIdentity(providerName, model string) {
+	s.sttProvider = strings.TrimSpace(providerName)
+	s.sttModel = strings.TrimSpace(model)
+}
+
 // SetCorpusFS overrides the corpus filesystem backend used for discovery and
 // byte reads. Passing nil restores the default local-filesystem backend rooted
 // at cfg.RootDir.
@@ -2419,13 +2429,9 @@ func (s *Service) readOrComputeTranscriptWithWords(ctx context.Context, doc mode
 	// re-ingest gate forces re-transcription, and a bytes-only key would return
 	// the previous model's cached text — silently defeating the re-derivation. The
 	// TranscriptLangSuffix is retained on the filename so cache files stay
-	// human-identifiable by language. A setup with no resolved STT identity folds
-	// in the empty string, preserving the historical key for that case.
-	cacheKey := strings.Join([]string{
-		computeContentHash(content),
-		s.activeTranscriptIdentity(),
-	}, "\x00")
-	base := computeContentHash([]byte(cacheKey)) + TranscriptLangSuffix(language)
+	// human-identifiable by language. With no resolved STT identity the historical
+	// bytes-only key is preserved.
+	base := s.transcriptCacheKey(content) + TranscriptLangSuffix(language)
 	cachePath := filepath.Join(cacheDir, base+".txt")
 	wordsPath := filepath.Join(cacheDir, base+".words.json")
 	if cached, err := os.ReadFile(cachePath); err == nil {

--- a/internal/ingest/sidecar.go
+++ b/internal/ingest/sidecar.go
@@ -24,6 +24,12 @@ var sidecarExtensions = []string{".vtt", ".srt", ".ttml"}
 // NOT invalidated by an STT model change (spec §8.6.7).
 const sidecarSource = "sidecar"
 
+// sttSource is the meta_json source value recorded on a machine-transcribed
+// transcript representation (spec §5.2 `source: stt`). Unlike a sidecar it is
+// model-derived, so it carries an STT provider/model derivation identity and IS
+// re-derived when the active STT model changes (§8.6.7).
+const sttSource = "stt"
+
 // translationSource is the meta_json source value recorded on a transcript
 // representation produced by translating another transcript (spec §8.6.2). It is
 // model-derived (unlike a sidecar), so it carries its translate provider/model
@@ -50,6 +56,18 @@ type transcriptMeta struct {
 	Language   string `json:"language,omitempty"`
 	Timestamps bool   `json:"timestamps"`
 	Format     string `json:"format,omitempty"`
+
+	// Provider / Model / ModelVersion record the STT derivation identity on a
+	// machine-transcribed transcript (Source == "stt", spec §5.2/§8.6.7): the
+	// resolved STT provider profile name, its model, and an optional model
+	// version. They are the runtime analogue of the embed identity (§8.1.4) and
+	// drive per-representation re-derivation when the active STT model changes.
+	// Omitted (omitempty) on sidecar transcripts (Source == "sidecar"), which are
+	// authored — not model-derived — and MUST NOT be invalidated by an STT model
+	// change (§8.6.7).
+	Provider     string `json:"provider,omitempty"`
+	Model        string `json:"model,omitempty"`
+	ModelVersion string `json:"model_version,omitempty"`
 
 	// SourceLanguage / TranslateProvider / TranslateModel are recorded only on a
 	// translated transcript (Source == "translation", spec §8.6.2/§5.2): the

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -993,6 +993,61 @@ func (s *SQLiteStore) TranscriptRepresentations(ctx context.Context, relPath str
 	return out, nil
 }
 
+// RepresentationMetaByType returns the meta_json of the active (non-deleted)
+// representation of repType for the document at relPath. It is the read side of
+// the derivation-identity re-ingest gate (spec §8.6.7): the ingest service reads
+// the stored transcript/OCR representation's recorded provider/model identity
+// and compares it to the active model's identity to decide whether the
+// representation is stale and must be re-derived. An empty string (with a nil
+// error) means the document exists but has no such representation (or it carries
+// no meta_json); the document-missing case is reported as os.ErrNotExist so the
+// caller can distinguish it. repType is matched exactly, so passing
+// "transcript" returns only the bare machine/translated transcript identity row,
+// never a language-suffixed sidecar rep_type.
+func (s *SQLiteStore) RepresentationMetaByType(ctx context.Context, relPath, repType string) (string, error) {
+	normalizedPath, err := normalizeRelPath(relPath)
+	if err != nil {
+		return "", err
+	}
+
+	db, err := s.ensureDB(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer s.ReleaseDB()
+
+	var docID int64
+	if err := db.QueryRowContext(
+		ctx,
+		`SELECT doc_id FROM documents WHERE rel_path = ? AND deleted = 0 LIMIT 1`,
+		normalizedPath,
+	).Scan(&docID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", os.ErrNotExist
+		}
+		return "", err
+	}
+
+	var metaJSON string
+	if err := db.QueryRowContext(
+		ctx,
+		`SELECT meta_json
+		 FROM representations
+		 WHERE doc_id = ? AND rep_type = ? AND deleted = 0
+		 ORDER BY rep_id ASC
+		 LIMIT 1`,
+		docID,
+		strings.TrimSpace(repType),
+	).Scan(&metaJSON); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			// Document exists but has no representation of this type yet.
+			return "", nil
+		}
+		return "", err
+	}
+	return metaJSON, nil
+}
+
 // SoftDeleteSidecarTranscripts tombstones (deleted = 1) the document's
 // sidecar-sourced transcript representations and their chunks, returning the
 // number of representations retired. A representation is treated as

--- a/tests/ingest/derivation_identity_test.go
+++ b/tests/ingest/derivation_identity_test.go
@@ -408,3 +408,45 @@ func (g *recordingGenerator) Generate(_ context.Context, _ string) (string, erro
 	g.calls++
 	return g.out, nil
 }
+
+// TestOCRCacheKey_ProviderOnlySwapDiffersKey locks the fix for the provider-only
+// OCR cache collision (CodeRabbit on #301): all extractors share one cache/ocr
+// directory, and docling / docling-serve carry no model, so a bytes-only key
+// would let a docling↔docling-serve swap read the previous provider's cached
+// output even though ocrStale correctly marks it stale. The cache key MUST fold
+// the provider-bearing identity so the two land on distinct keys, while the same
+// provider keeps a stable key.
+func TestOCRCacheKey_ProviderOnlySwapDiffersKey(t *testing.T) {
+	t.Parallel()
+	content := []byte("identical-pdf-bytes")
+	st := newRealStore(t)
+	cfg := config.Config{RootDir: t.TempDir(), StateDir: t.TempDir(), STTProvider: "off"}
+
+	newSvc := func(ex model.DocumentExtractor) *ingest.Service {
+		s := mustNewIngestService(t, cfg, st)
+		s.SetDocumentExtractor(ex)
+		return s
+	}
+
+	docling := newSvc(ingest.NewDoclingExtractor("docling"))
+	doclingServe := newSvc(ingest.NewDoclingServeExtractor("http://example.test"))
+	doclingAgain := newSvc(ingest.NewDoclingExtractor("docling"))
+
+	kDocling := docling.OCRCacheKey(content)
+	kServe := doclingServe.OCRCacheKey(content)
+	kDoclingAgain := doclingAgain.OCRCacheKey(content)
+
+	if kDocling == kServe {
+		t.Fatalf("docling and docling-serve must not share an OCR cache key (got %q for both)", kDocling)
+	}
+	if kDocling != kDoclingAgain {
+		t.Fatalf("same provider must yield a stable OCR cache key: %q != %q", kDocling, kDoclingAgain)
+	}
+
+	// No extractor configured -> empty identity -> historical bytes-only key,
+	// distinct from any provider-folded key.
+	none := mustNewIngestService(t, cfg, st)
+	if kNone := none.OCRCacheKey(content); kNone == kDocling || kNone == kServe {
+		t.Fatalf("no-extractor key %q must differ from provider-folded keys", kNone)
+	}
+}

--- a/tests/ingest/derivation_identity_test.go
+++ b/tests/ingest/derivation_identity_test.go
@@ -1,0 +1,410 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/mistral"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// newRealStore returns an initialized on-disk SQLiteStore (it persists documents
+// and representations across scans, and implements RepresentationMetaByType so
+// the derivation-identity gate is exercised end to end, spec §8.6.7).
+func newRealStore(t *testing.T) *store.SQLiteStore {
+	t.Helper()
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	if err := st.Init(context.Background()); err != nil {
+		t.Fatalf("store init: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	return st
+}
+
+// sttService builds a service rooted at root with a deterministic STT identity
+// and a fakeTranscriber, without resolving a real provider profile.
+func sttService(t *testing.T, root, stateDir string, st model.Store, provider, sttModel, language string, tr *fakeTranscriber) *ingest.Service {
+	t.Helper()
+	svc := mustNewIngestService(t, config.Config{RootDir: root, StateDir: stateDir, STTProvider: "off"}, st)
+	svc.SetTranscriber(tr)
+	svc.SetSTTIdentity(provider, sttModel)
+	svc.SetTranscriptLanguage(language)
+	return svc
+}
+
+func transcriptMetaFor(t *testing.T, st *store.SQLiteStore, relPath string) string {
+	t.Helper()
+	meta, err := st.RepresentationMetaByType(context.Background(), relPath, ingest.RepTypeTranscript)
+	if err != nil {
+		t.Fatalf("RepresentationMetaByType(%s): %v", relPath, err)
+	}
+	return meta
+}
+
+// TestSTTIdentity_PersistedOnBareTranscriptRep is the regression guard for the
+// core bug: the bare machine transcript was persisted with NO meta_json, so the
+// STT provider/model were never recorded (spec §5.2/§8.6.7).
+func TestSTTIdentity_PersistedOnBareTranscriptRep(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "talk.mp3"), "fake-audio")
+	st := newRealStore(t)
+
+	svc := sttService(t, root, t.TempDir(), st, "whisper", "whisper-large-v3", "en",
+		&fakeTranscriber{text: "[00:00] hello world"})
+
+	f := ingest.DiscoveredFile{RelPath: "talk.mp3", SizeBytes: 10, MTimeUnix: time.Now().Unix()}
+	if err := svc.ProcessDocument(context.Background(), f, nil, false); err != nil {
+		t.Fatalf("ProcessDocument: %v", err)
+	}
+
+	meta := transcriptMetaFor(t, st, "talk.mp3")
+	if meta == "" {
+		t.Fatal("bare transcript rep persisted with empty meta_json (regression: STT identity not recorded)")
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(meta), &parsed); err != nil {
+		t.Fatalf("transcript meta is not valid json (%q): %v", meta, err)
+	}
+	if parsed["source"] != "stt" {
+		t.Errorf("source = %v, want stt", parsed["source"])
+	}
+	if parsed["provider"] != "whisper" {
+		t.Errorf("provider = %v, want whisper", parsed["provider"])
+	}
+	if parsed["model"] != "whisper-large-v3" {
+		t.Errorf("model = %v, want whisper-large-v3", parsed["model"])
+	}
+	if parsed["language"] != "en" {
+		t.Errorf("language = %v, want en", parsed["language"])
+	}
+}
+
+// TestSTTModelSwap_InvalidatesAndRederives asserts that changing the active STT
+// model re-derives the transcript even though the media bytes (content_hash) are
+// unchanged (spec §8.6.7).
+func TestSTTModelSwap_InvalidatesAndRederives(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "talk.mp3"), "fake-audio")
+	st := newRealStore(t)
+	stateDir := t.TempDir()
+	f := ingest.DiscoveredFile{RelPath: "talk.mp3", SizeBytes: 10, MTimeUnix: time.Now().Unix()}
+
+	// Scan 1: Voxtral.
+	tr1 := &fakeTranscriber{text: "[00:00] from voxtral"}
+	svc1 := sttService(t, root, stateDir, st, "mistral-ocr", "voxtral-mini-latest", "en", tr1)
+	if err := svc1.ProcessDocument(context.Background(), f, nil, false); err != nil {
+		t.Fatalf("scan1: %v", err)
+	}
+	if tr1.calls != 1 {
+		t.Fatalf("scan1 STT calls = %d, want 1", tr1.calls)
+	}
+
+	// Scan 2: swap to self-hosted whisper-large-v3. Same bytes, different model.
+	tr2 := &fakeTranscriber{text: "[00:00] from whisper"}
+	svc2 := sttService(t, root, stateDir, st, "whisper", "whisper-large-v3", "en", tr2)
+	if err := svc2.ProcessDocument(context.Background(), f, nil, false); err != nil {
+		t.Fatalf("scan2: %v", err)
+	}
+	if tr2.calls != 1 {
+		t.Fatalf("scan2 STT calls = %d, want 1 (model swap must re-transcribe unchanged media)", tr2.calls)
+	}
+	meta := transcriptMetaFor(t, st, "talk.mp3")
+	if !strings.Contains(meta, "whisper-large-v3") || !strings.Contains(meta, `"provider":"whisper"`) {
+		t.Fatalf("transcript meta not refreshed to new STT identity: %q", meta)
+	}
+}
+
+// TestSTTNoSwap_NoChurn asserts that re-scanning with the SAME STT identity and
+// unchanged content does NOT re-transcribe (no needless churn).
+func TestSTTNoSwap_NoChurn(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "talk.mp3"), "fake-audio")
+	st := newRealStore(t)
+	stateDir := t.TempDir()
+	f := ingest.DiscoveredFile{RelPath: "talk.mp3", SizeBytes: 10, MTimeUnix: time.Now().Unix()}
+
+	tr1 := &fakeTranscriber{text: "[00:00] hello"}
+	svc1 := sttService(t, root, stateDir, st, "whisper", "whisper-large-v3", "en", tr1)
+	if err := svc1.ProcessDocument(context.Background(), f, nil, false); err != nil {
+		t.Fatalf("scan1: %v", err)
+	}
+
+	tr2 := &fakeTranscriber{text: "[00:00] hello"}
+	svc2 := sttService(t, root, stateDir, st, "whisper", "whisper-large-v3", "en", tr2)
+	if err := svc2.ProcessDocument(context.Background(), f, nil, false); err != nil {
+		t.Fatalf("scan2: %v", err)
+	}
+	if tr2.calls != 0 {
+		t.Fatalf("scan2 STT calls = %d, want 0 (identical identity + content must not re-transcribe)", tr2.calls)
+	}
+}
+
+// TestEmptyRecordedIdentity_Passes is the backward-compat guard: a pre-upgrade
+// transcript recorded no provider/model. An empty recorded identity MUST pass so
+// the first upgrade does not force a corpus-wide re-transcription (mirrors
+// VerifyEmbedIdentity's fresh-index rule).
+func TestEmptyRecordedIdentity_Passes(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "talk.mp3"), "fake-audio")
+	st := newRealStore(t)
+	stateDir := t.TempDir()
+	f := ingest.DiscoveredFile{RelPath: "talk.mp3", SizeBytes: 10, MTimeUnix: time.Now().Unix()}
+
+	// Scan 1 simulates a pre-upgrade run: NO STT identity recorded (empty meta).
+	tr1 := &fakeTranscriber{text: "[00:00] legacy"}
+	svc1 := sttService(t, root, stateDir, st, "", "", "", tr1)
+	if err := svc1.ProcessDocument(context.Background(), f, nil, false); err != nil {
+		t.Fatalf("scan1: %v", err)
+	}
+
+	// Scan 2 with a NOW-configured STT identity must NOT re-transcribe the
+	// legacy transcript whose identity was never recorded.
+	tr2 := &fakeTranscriber{text: "[00:00] upgraded"}
+	svc2 := sttService(t, root, stateDir, st, "whisper", "whisper-large-v3", "en", tr2)
+	if err := svc2.ProcessDocument(context.Background(), f, nil, false); err != nil {
+		t.Fatalf("scan2: %v", err)
+	}
+	if tr2.calls != 0 {
+		t.Fatalf("scan2 STT calls = %d, want 0 (empty recorded identity must pass; no mass re-transcribe)", tr2.calls)
+	}
+}
+
+// TestForceReindex_StillWins asserts --force re-transcribes regardless of a
+// matching identity.
+func TestForceReindex_StillWins(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "talk.mp3"), "fake-audio")
+	st := newRealStore(t)
+	stateDir := t.TempDir()
+	f := ingest.DiscoveredFile{RelPath: "talk.mp3", SizeBytes: 10, MTimeUnix: time.Now().Unix()}
+
+	tr1 := &fakeTranscriber{text: "[00:00] hello"}
+	svc1 := sttService(t, root, stateDir, st, "whisper", "whisper-large-v3", "en", tr1)
+	if err := svc1.ProcessDocument(context.Background(), f, nil, false); err != nil {
+		t.Fatalf("scan1: %v", err)
+	}
+
+	// Scan 2 uses a fresh cache dir (same store, so content_hash is unchanged)
+	// so a forced re-derivation actually re-invokes the provider rather than
+	// being served by the transcript cache. With --force the identity gate is
+	// irrelevant: reprocessing must happen regardless.
+	tr2 := &fakeTranscriber{text: "[00:00] hello"}
+	svc2 := sttService(t, root, t.TempDir(), st, "whisper", "whisper-large-v3", "en", tr2)
+	if err := svc2.ProcessDocument(context.Background(), f, nil, true); err != nil {
+		t.Fatalf("scan2 (force): %v", err)
+	}
+	if tr2.calls != 1 {
+		t.Fatalf("scan2 STT calls = %d, want 1 (force must re-transcribe even on identical identity)", tr2.calls)
+	}
+}
+
+// TestSidecarExemption_STTSwapDoesNotInvalidate asserts that a sidecar-sourced
+// transcript is NOT re-derived when the STT model changes: sidecars are
+// authored, not model-derived (spec §8.6.4/§8.6.7). The transcriber must never
+// be called because the authored sidecar stands in for STT.
+func TestSidecarExemption_STTSwapDoesNotInvalidate(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "talk.mp3"), "fake-audio")
+	writeFile(t, filepath.Join(root, "talk.vtt"),
+		"WEBVTT\n\n00:00:00.000 --> 00:00:02.000\nauthored caption\n")
+	st := newRealStore(t)
+	stateDir := t.TempDir()
+	f := ingest.DiscoveredFile{RelPath: "talk.mp3", SizeBytes: 10, MTimeUnix: time.Now().Unix()}
+
+	// Scan 1: sidecar is ingested; STT must not run.
+	tr1 := &explodingTranscriber{t: t}
+	svc1 := mustNewIngestService(t, config.Config{RootDir: root, StateDir: stateDir, STTProvider: "off"}, st)
+	svc1.SetTranscriber(tr1)
+	svc1.SetSTTIdentity("mistral-ocr", "voxtral-mini-latest")
+	if err := svc1.ProcessDocument(context.Background(), f, nil, false); err != nil {
+		t.Fatalf("scan1: %v", err)
+	}
+	meta1 := transcriptMetaFor(t, st, "talk.mp3")
+	if !strings.Contains(meta1, `"source":"sidecar"`) {
+		t.Fatalf("expected sidecar-sourced transcript, got meta %q", meta1)
+	}
+
+	// Scan 2: swap STT model. The sidecar transcript must NOT be invalidated, and
+	// the exploding transcriber must never be called.
+	tr2 := &explodingTranscriber{t: t}
+	svc2 := mustNewIngestService(t, config.Config{RootDir: root, StateDir: stateDir, STTProvider: "off"}, st)
+	svc2.SetTranscriber(tr2)
+	svc2.SetSTTIdentity("whisper", "whisper-large-v3")
+	if err := svc2.ProcessDocument(context.Background(), f, nil, false); err != nil {
+		t.Fatalf("scan2: %v", err)
+	}
+	meta2 := transcriptMetaFor(t, st, "talk.mp3")
+	if !strings.Contains(meta2, `"source":"sidecar"`) {
+		t.Fatalf("sidecar transcript must survive STT model swap, got meta %q", meta2)
+	}
+}
+
+// TestTranslationCascade_RefreshesOnSTTSwap asserts that when an STT transcript
+// is re-derived after a model swap, a translated transcript of it is refreshed
+// rather than left stale (spec §8.6.2/§8.6.7).
+func TestTranslationCascade_RefreshesOnSTTSwap(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "talk.mp3"), "fake-audio")
+	st := newRealStore(t)
+	stateDir := t.TempDir()
+	f := ingest.DiscoveredFile{RelPath: "talk.mp3", SizeBytes: 10, MTimeUnix: time.Now().Unix()}
+
+	// Scan 1: Voxtral source transcript + an en translation.
+	tr1 := &fakeTranscriber{text: "[00:00] bonjour"}
+	gen1 := &recordingGenerator{out: "[00:00] hello v1"}
+	svc1 := sttService(t, root, stateDir, st, "mistral-ocr", "voxtral-mini-latest", "fr", tr1)
+	svc1.SetTranslator(gen1, "mistral", "mistral-large", []string{"en"})
+	if err := svc1.ProcessDocument(context.Background(), f, nil, false); err != nil {
+		t.Fatalf("scan1: %v", err)
+	}
+	if gen1.calls == 0 {
+		t.Fatal("scan1 expected a translation call")
+	}
+
+	// Scan 2: swap STT model -> source text changes -> translation must re-run.
+	tr2 := &fakeTranscriber{text: "[00:00] salut tout le monde"}
+	gen2 := &recordingGenerator{out: "[00:00] hello v2"}
+	svc2 := sttService(t, root, stateDir, st, "whisper", "whisper-large-v3", "fr", tr2)
+	svc2.SetTranslator(gen2, "mistral", "mistral-large", []string{"en"})
+	if err := svc2.ProcessDocument(context.Background(), f, nil, false); err != nil {
+		t.Fatalf("scan2: %v", err)
+	}
+	if tr2.calls != 1 {
+		t.Fatalf("scan2 STT calls = %d, want 1 (swap re-transcribes)", tr2.calls)
+	}
+	if gen2.calls == 0 {
+		t.Fatal("scan2 expected the translation to refresh after the source transcript was re-derived")
+	}
+
+	// The translated transcript must reflect the refreshed text, not the stale v1.
+	enMeta, err := st.RepresentationMetaByType(context.Background(), "talk.mp3", ingest.TranscriptRepType("en"))
+	if err != nil {
+		t.Fatalf("RepresentationMetaByType(en): %v", err)
+	}
+	if !strings.Contains(enMeta, `"source":"translation"`) {
+		t.Fatalf("expected translated transcript rep, got meta %q", enMeta)
+	}
+}
+
+// TestOCRModelSwap_InvalidatesAndRederives asserts that changing the active OCR
+// model re-extracts the document even though the bytes are unchanged (§8.6.7).
+// It uses a Mistral client pointed at a local stub so the provider/model is the
+// real extraction identity, with a counter to confirm re-extraction.
+func TestOCRModelSwap_InvalidatesAndRederives(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "doc.pdf"), "fake-pdf-bytes")
+	st := newRealStore(t)
+	stateDir := t.TempDir()
+	f := ingest.DiscoveredFile{RelPath: "doc.pdf", SizeBytes: 14, MTimeUnix: time.Now().Unix()}
+
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"pages":[{"markdown":"extracted page text"}]}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	newMistral := func(ocrModel string) *mistral.Client {
+		c := mistral.NewClient(srv.URL, "test-key")
+		c.DefaultOCRModel = ocrModel
+		return c
+	}
+
+	// Scan 1: OCR with model "mistral-ocr-2024".
+	svc1 := mustNewIngestService(t, config.Config{RootDir: root, StateDir: stateDir, STTProvider: "off"}, st)
+	svc1.SetOCR(newMistral("mistral-ocr-2024"))
+	if err := svc1.ProcessDocument(context.Background(), f, nil, false); err != nil {
+		t.Fatalf("scan1: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("scan1 OCR calls = %d, want 1", calls)
+	}
+	meta1, _ := st.RepresentationMetaByType(context.Background(), "doc.pdf", ingest.RepTypeExtractedMarkdown)
+	if !strings.Contains(meta1, "mistral-ocr-2024") {
+		t.Fatalf("scan1 OCR meta missing model: %q", meta1)
+	}
+
+	// Scan 2: swap to model "mistral-ocr-2025". Same bytes -> must re-extract.
+	calls = 0
+	svc2 := mustNewIngestService(t, config.Config{RootDir: root, StateDir: stateDir, STTProvider: "off"}, st)
+	svc2.SetOCR(newMistral("mistral-ocr-2025"))
+	if err := svc2.ProcessDocument(context.Background(), f, nil, false); err != nil {
+		t.Fatalf("scan2: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("scan2 OCR calls = %d, want 1 (OCR model swap must re-extract unchanged bytes)", calls)
+	}
+	meta2, _ := st.RepresentationMetaByType(context.Background(), "doc.pdf", ingest.RepTypeExtractedMarkdown)
+	if !strings.Contains(meta2, "mistral-ocr-2025") {
+		t.Fatalf("scan2 OCR meta not refreshed: %q", meta2)
+	}
+}
+
+// TestOCRNoSwap_NoChurn asserts that re-scanning with the SAME OCR model and
+// unchanged bytes does NOT re-extract.
+func TestOCRNoSwap_NoChurn(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "doc.pdf"), "fake-pdf-bytes")
+	st := newRealStore(t)
+	stateDir := t.TempDir()
+	f := ingest.DiscoveredFile{RelPath: "doc.pdf", SizeBytes: 14, MTimeUnix: time.Now().Unix()}
+
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"pages":[{"markdown":"extracted page text"}]}`))
+	}))
+	t.Cleanup(srv.Close)
+	newMistral := func() *mistral.Client {
+		c := mistral.NewClient(srv.URL, "test-key")
+		c.DefaultOCRModel = "mistral-ocr-2025"
+		return c
+	}
+
+	svc1 := mustNewIngestService(t, config.Config{RootDir: root, StateDir: stateDir, STTProvider: "off"}, st)
+	svc1.SetOCR(newMistral())
+	if err := svc1.ProcessDocument(context.Background(), f, nil, false); err != nil {
+		t.Fatalf("scan1: %v", err)
+	}
+	calls = 0
+	svc2 := mustNewIngestService(t, config.Config{RootDir: root, StateDir: stateDir, STTProvider: "off"}, st)
+	svc2.SetOCR(newMistral())
+	if err := svc2.ProcessDocument(context.Background(), f, nil, false); err != nil {
+		t.Fatalf("scan2: %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("scan2 OCR calls = %d, want 0 (identical OCR identity + bytes must not re-extract)", calls)
+	}
+}
+
+// recordingGenerator is a model.Generator stub that records call count and
+// returns a fixed translated body.
+type recordingGenerator struct {
+	out   string
+	calls int
+}
+
+func (g *recordingGenerator) Generate(_ context.Context, _ string) (string, error) {
+	g.calls++
+	return g.out, nil
+}

--- a/tests/ingest/ocr_test.go
+++ b/tests/ingest/ocr_test.go
@@ -119,7 +119,7 @@ func TestGenerateOCRMarkdownRepresentation_PersistsPagedChunks(t *testing.T) {
 		t.Fatalf("expected stale chunk cleanup call")
 	}
 
-	cachePath := filepath.Join(stateDir, "cache", "ocr", ingest.ComputeContentHash(content)+".md")
+	cachePath := filepath.Join(stateDir, "cache", "ocr", svc.OCRCacheKey(content)+".md")
 	if _, err := os.Stat(cachePath); err != nil {
 		t.Fatalf("expected OCR cache file at %s: %v", cachePath, err)
 	}
@@ -128,18 +128,21 @@ func TestGenerateOCRMarkdownRepresentation_PersistsPagedChunks(t *testing.T) {
 func TestReadOrComputeOCR_UsesCache(t *testing.T) {
 	stateDir := t.TempDir()
 	content := []byte("same bytes")
-	cachePath := filepath.Join(stateDir, "cache", "ocr", ingest.ComputeContentHash(content)+".md")
+
+	ocr := &fakeOCR{text: "fresh ocr"}
+	svc := mustNewIngestService(t, config.Config{StateDir: stateDir}, nil)
+	svc.SetOCR(ocr)
+	doc := model.Document{RelPath: "docs/spec.pdf"}
+
+	// Seed the cache at the key the configured extractor actually uses (the OCR
+	// derivation identity is folded into the key, §8.6.7), not the bytes-only hash.
+	cachePath := filepath.Join(stateDir, "cache", "ocr", svc.OCRCacheKey(content)+".md")
 	if err := os.MkdirAll(filepath.Dir(cachePath), 0o755); err != nil {
 		t.Fatalf("mkdir cache dir: %v", err)
 	}
 	if err := os.WriteFile(cachePath, []byte("cached ocr"), 0o644); err != nil {
 		t.Fatalf("seed cache: %v", err)
 	}
-
-	ocr := &fakeOCR{text: "fresh ocr"}
-	svc := mustNewIngestService(t, config.Config{StateDir: stateDir}, nil)
-	svc.SetOCR(ocr)
-	doc := model.Document{RelPath: "docs/spec.pdf"}
 
 	got, err := svc.ReadOrComputeOCR(context.Background(), doc, content)
 	if err != nil {

--- a/tests/ingest/sidecar_test.go
+++ b/tests/ingest/sidecar_test.go
@@ -265,8 +265,16 @@ func TestSidecar_ForceReindex_RunsSTTInsteadOfSidecar(t *testing.T) {
 	if stt.calls != 1 {
 		t.Fatalf("expected STT to run once under --force, got %d call(s)", stt.calls)
 	}
-	if len(st.reps) != 1 || st.reps[0].MetaJSON != "" {
-		t.Fatalf("expected one STT transcript rep with no sidecar meta, got %+v", st.reps)
+	if len(st.reps) != 1 || st.reps[0].RepType != ingest.RepTypeTranscript {
+		t.Fatalf("expected one bare STT transcript rep, got %+v", st.reps)
+	}
+	// The STT transcript now records source=stt (not sidecar) and an STT
+	// derivation identity (spec §8.6.7); it must NOT be a sidecar rep.
+	if strings.Contains(st.reps[0].MetaJSON, `"source":"sidecar"`) {
+		t.Fatalf("STT transcript must not carry sidecar source, got meta %q", st.reps[0].MetaJSON)
+	}
+	if !strings.Contains(st.reps[0].MetaJSON, `"source":"stt"`) {
+		t.Fatalf("STT transcript must record source=stt, got meta %q", st.reps[0].MetaJSON)
 	}
 }
 
@@ -371,8 +379,11 @@ func TestSidecar_PathExcludes_NotUsedAsSidecar(t *testing.T) {
 	if stt.calls != 1 {
 		t.Fatalf("expected STT to run once (excluded .vtt must not suppress it), got %d call(s)", stt.calls)
 	}
-	if len(st.reps) != 1 || st.reps[0].MetaJSON != "" {
-		t.Fatalf("expected one STT transcript rep with no sidecar meta, got %+v", st.reps)
+	if len(st.reps) != 1 || st.reps[0].RepType != ingest.RepTypeTranscript {
+		t.Fatalf("expected one bare STT transcript rep, got %+v", st.reps)
+	}
+	if strings.Contains(st.reps[0].MetaJSON, `"source":"sidecar"`) {
+		t.Fatalf("STT transcript must not carry sidecar source, got meta %q", st.reps[0].MetaJSON)
 	}
 }
 

--- a/tests/store/representation_meta_by_type_test.go
+++ b/tests/store/representation_meta_by_type_test.go
@@ -1,0 +1,83 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// TestRepresentationMetaByType covers the read side of the derivation-identity
+// re-ingest gate (spec §8.6.7): it returns the active representation's meta_json
+// for an exact rep_type, an empty string when the document has no such
+// representation, and os.ErrNotExist when the document is missing.
+func TestRepresentationMetaByType(t *testing.T) {
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	if err := st.Init(context.Background()); err != nil {
+		t.Fatalf("store init: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	ctx := context.Background()
+
+	if err := st.UpsertDocument(ctx, model.Document{RelPath: "talk.mp3", DocType: "audio"}); err != nil {
+		t.Fatalf("upsert document: %v", err)
+	}
+	doc, err := st.GetDocumentByPath(ctx, "talk.mp3")
+	if err != nil {
+		t.Fatalf("get document: %v", err)
+	}
+
+	const meta = `{"source":"stt","provider":"whisper","model":"whisper-large-v3"}`
+	if _, err := st.UpsertRepresentation(ctx, model.Representation{
+		DocID:    doc.DocID,
+		RepType:  "transcript",
+		RepHash:  "h1",
+		MetaJSON: meta,
+	}); err != nil {
+		t.Fatalf("upsert representation: %v", err)
+	}
+
+	got, err := st.RepresentationMetaByType(ctx, "talk.mp3", "transcript")
+	if err != nil {
+		t.Fatalf("RepresentationMetaByType(transcript): %v", err)
+	}
+	if got != meta {
+		t.Fatalf("meta = %q, want %q", got, meta)
+	}
+
+	// Exact rep_type match: a language-suffixed transcript is not returned for
+	// the bare "transcript" lookup.
+	if _, err := st.UpsertRepresentation(ctx, model.Representation{
+		DocID:    doc.DocID,
+		RepType:  "transcript-en",
+		RepHash:  "h2",
+		MetaJSON: `{"source":"translation"}`,
+	}); err != nil {
+		t.Fatalf("upsert translated representation: %v", err)
+	}
+	got, err = st.RepresentationMetaByType(ctx, "talk.mp3", "transcript")
+	if err != nil {
+		t.Fatalf("RepresentationMetaByType(transcript) after translation: %v", err)
+	}
+	if got != meta {
+		t.Fatalf("bare transcript meta changed by language-suffixed rep: got %q", got)
+	}
+
+	// No representation of this type: empty string, nil error.
+	got, err = st.RepresentationMetaByType(ctx, "talk.mp3", "extracted_markdown")
+	if err != nil {
+		t.Fatalf("RepresentationMetaByType(extracted_markdown): %v", err)
+	}
+	if got != "" {
+		t.Fatalf("expected empty meta for absent rep_type, got %q", got)
+	}
+
+	// Missing document: os.ErrNotExist.
+	if _, err := st.RepresentationMetaByType(ctx, "missing.mp3", "transcript"); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("missing document err = %v, want os.ErrNotExist", err)
+	}
+}


### PR DESCRIPTION
## Summary

Implements issue #263: representation provenance + identity-driven re-transcription (STT/OCR model identity).

dir2mcp already has an EMBED IDENTITY (`provider|model|dim`) whose mismatch forces a vector reindex. This PR applies the same pattern to TRANSCRIPTS and OCR per spec 0.17.0 §8.6.7 / §5.2: each derived representation records the STT/OCR model that produced it, and when the active model changes the representation is invalidated and re-derived (re-derive → re-chunk → re-embed), scoped to that single representation rather than the whole index.

**Core bug fixed:** the bare machine transcript representation was persisted with NO `meta_json`, so STT provider/model were never recorded — a model swap (e.g. Voxtral → self-hosted whisper-large-v3) left stale transcripts silently.

This is implementation-only (no spec PR, no `dirstral-spec` re-pin). Provenance is NOT surfaced in citations (out of scope).

## How the identity string is built and compared

`derivationIdentity(capability, provider, model, version, language)` produces a canonical, greppable string from the structured fields the spec defines (`{capability, provider, model, version, language}`) — not an opaque blob:

- STT: `stt|<provider>|<model>|<version>|<language>`
- OCR: `ocr|<provider>|<model>||`

On the content-unchanged, status==ok re-ingest path the gate reads the stored representation's `meta_json`, rebuilds its recorded identity, and compares it to the active model's identity. On mismatch it forces reprocessing and logs a scoped warn mirroring the embed-identity → reindex UX. The gate is wired into all three reprocess paths: the local document path, the archive-member path, and the remote (S3) ETag fast-path skip.

The transcript and OCR caches now fold the active derivation identity into their cache key, so a forced re-derivation after a model swap does not return the previous model's cached output.

## Backward-compat (empty identity)

An EMPTY recorded identity always passes (no invalidation), mirroring `VerifyEmbedIdentity`'s fresh-index rule: a pre-upgrade transcript that recorded no provider/model is never invalidated, so the first upgrade does not force a corpus-wide re-transcription.

## Sidecar exemption

A sidecar-sourced transcript (`source: sidecar`) is authored, not model-derived (§8.6.4/§8.6.7). Its identity probe returns "no identity" so an STT model change never invalidates it (a change to the sidecar file itself still re-ingests via the existing mtime/fingerprint gate). Translated transcripts (`source: translation`) are likewise not screened by the STT identity; they refresh via the source-transcript re-derivation cascade.

## Tests added

`tests/ingest/derivation_identity_test.go`:
- STT identity persisted on the bare transcript rep (regression on the empty-meta_json bug)
- STT model swap invalidates + re-derives on unchanged content
- no-swap no-op (no churn)
- empty recorded identity passes (no mass re-transcribe on upgrade)
- force-reindex still wins
- sidecar exemption (swap does NOT invalidate a sidecar transcript)
- translation cascade refreshes when the source transcript is re-derived
- OCR model swap invalidates + re-extracts (Mistral client against a local stub); OCR no-swap no-op

`tests/store/representation_meta_by_type_test.go`: the new `RepresentationMetaByType` read helper (exact rep_type match, absent-rep empty string, missing-doc `os.ErrNotExist`).

## Files changed

- `internal/ingest/sidecar.go` — `transcriptMeta` gains `provider`/`model`/`model_version` (omitempty); `sttSource` constant
- `internal/ingest/derivation.go` (new) — identity builders, meta parsers, the staleness gate, identity-aware cache keys
- `internal/ingest/service.go` — populate STT identity on the bare transcript rep; resolve STT profile once (shared helper); `resolveNeedsProcessing` folds the three reprocess triggers; gate wired into the remote skip path; OCR/transcript cache keys; `SetSTTIdentity` test setter
- `internal/store/sqlite_store.go` — `RepresentationMetaByType` read helper (no schema change; `meta_json` already exists)

`make check` passes (gofmt, go vet, golangci-lint incl. staticcheck = 0 issues, gocyclo ≤15, all Go tests, python unittests, build).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Changing speech-to-text or optical character recognition model settings now triggers automatic regeneration of transcripts and extracted text to prevent reuse of outputs from previous models
* Sidecar-provided transcripts remain exempt from automatic regeneration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->