### PR TITLE
feat(retrieval): retrieval-time cross-file de-duplication (#265)

### DIFF
--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -78,12 +78,16 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 	ret.SetOversampleFactor(cfg.RAGOversampleFactor)
 	a.configureReranker(ret, cfg)
 	ret.SetCrossFileDedupEnabled(cfg.DedupRetrieval)
-	a.loadCrossFileDedupHashes(ctx, cfg, st, ret)
 
 	// events are emitted to stdout only after we create the emitter; moving
 	// creation before the preload call lets us report failures from that
 	// bootstrap step as structured events (see dirstral-spec/docs/SPEC.md for NDJSON schema).
 	emitter := newNDJSONEmitter(a.stdout, opts.jsonOutput)
+
+	// Load the cross-file dedup hash map AFTER the emitter exists so a load
+	// failure is reported as a structured NDJSON warning event (machine-parseable
+	// in JSON/automation flows), consistent with other bootstrap steps.
+	a.loadCrossFileDedupHashes(ctx, cfg, st, ret, emitter)
 
 	indexingState := initIndexingState(ctx, st, ret, emitter, a.stderr)
 	ret.SetIndexingCompleteProvider(func() bool {
@@ -867,8 +871,10 @@ func warnConfigSnapshotErr(stderr io.Writer, quiet bool, err error) {
 // retrieval-time cross-file de-duplication (SPEC 9.2) onto the retrieval
 // service. It is a no-op when dedup is disabled, or when the store does not
 // implement model.DocumentHashLister; a load error is non-fatal (dedup simply
-// stays a pass-through) since it must never block server startup.
-func (a *App) loadCrossFileDedupHashes(ctx context.Context, cfg config.Config, st model.Store, ret *retrieval.Service) {
+// stays a pass-through) since it must never block server startup. A load failure
+// is reported as a structured NDJSON warning event (machine-parseable in
+// JSON/automation flows), mirroring the embedded-chunk-metadata bootstrap step.
+func (a *App) loadCrossFileDedupHashes(ctx context.Context, cfg config.Config, st model.Store, ret *retrieval.Service, emitter *ndjsonEmitter) {
 	if !cfg.DedupRetrieval || st == nil || ret == nil {
 		return
 	}
@@ -878,6 +884,11 @@ func (a *App) loadCrossFileDedupHashes(ctx context.Context, cfg config.Config, s
 	}
 	hashes, err := lister.ListDocumentHashes(ctx)
 	if err != nil {
+		if emitter != nil {
+			emitter.Emit("warning", "bootstrap_cross_file_dedup_hashes", map[string]interface{}{
+				"error": err.Error(),
+			})
+		}
 		writef(a.stderr, "warning: load document hashes for retrieval dedup: %v\n", err)
 		return
 	}

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -77,6 +77,8 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 	ret.SetMaxContextChars(cfg.RAGMaxContextChars)
 	ret.SetOversampleFactor(cfg.RAGOversampleFactor)
 	a.configureReranker(ret, cfg)
+	ret.SetCrossFileDedupEnabled(cfg.DedupRetrieval)
+	a.loadCrossFileDedupHashes(ctx, cfg, st, ret)
 
 	// events are emitted to stdout only after we create the emitter; moving
 	// creation before the preload call lets us report failures from that
@@ -859,6 +861,27 @@ func warnConfigSnapshotErr(stderr io.Writer, quiet bool, err error) {
 	if err != nil && !quiet {
 		writef(stderr, "warning: write config snapshot: %v\n", err)
 	}
+}
+
+// loadCrossFileDedupHashes wires the rel_path → content_hash map used by
+// retrieval-time cross-file de-duplication (SPEC 9.2) onto the retrieval
+// service. It is a no-op when dedup is disabled, or when the store does not
+// implement model.DocumentHashLister; a load error is non-fatal (dedup simply
+// stays a pass-through) since it must never block server startup.
+func (a *App) loadCrossFileDedupHashes(ctx context.Context, cfg config.Config, st model.Store, ret *retrieval.Service) {
+	if !cfg.DedupRetrieval || st == nil || ret == nil {
+		return
+	}
+	lister, ok := st.(model.DocumentHashLister)
+	if !ok {
+		return
+	}
+	hashes, err := lister.ListDocumentHashes(ctx)
+	if err != nil {
+		writef(a.stderr, "warning: load document hashes for retrieval dedup: %v\n", err)
+		return
+	}
+	ret.SetDocumentHashes(hashes)
 }
 
 // initIndexingState creates a new IndexingState and optionally preloads

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -153,6 +153,11 @@ type Config struct {
 	// is true for new deployments; existing indexes auto-backfill the FTS
 	// table on first start.
 	RetrievalHybridEnabled bool
+	// DedupRetrieval enables retrieval-time cross-file de-duplication (SPEC
+	// 9.2): when true, search collapses candidate hits whose source documents
+	// share an identical content_hash to a single best-ranked survivor before
+	// rerank/truncation. Default false (every candidate is returned as before).
+	DedupRetrieval bool
 	// Rerank* configure the optional post-fusion rerank stage (SPEC
 	// 9.1.1). Reranking auto-activates when a provider credential is
 	// present. CohereAPIKey is a secret: env-sourced, never persisted
@@ -362,6 +367,7 @@ type fileConfig struct {
 	RAGMaxContextChars        *int
 	RAGOversampleFactor       *int
 	RetrievalHybridEnabled    *bool
+	DedupRetrieval            *bool
 	RerankEnabled             *bool
 	RerankProvider            *string
 	CohereAPIKey              *string
@@ -460,6 +466,7 @@ type persistedConfig struct {
 	RAGMaxContextChars        int           `yaml:"rag_max_context_chars"`
 	RAGOversampleFactor       int           `yaml:"rag_oversample_factor"`
 	RetrievalHybridEnabled    bool          `yaml:"retrieval_hybrid_enabled"`
+	DedupRetrieval            bool          `yaml:"dedup_retrieval"`
 	RerankEnabled             bool          `yaml:"rerank_enabled"`
 	RerankProvider            string        `yaml:"rerank_provider"`
 	CohereBaseURL             string        `yaml:"cohere_base_url"`
@@ -589,6 +596,9 @@ func Default() Config {
 		RAGMaxContextChars:     20000,
 		RAGOversampleFactor:    5,
 		RetrievalHybridEnabled: true,
+		// DedupRetrieval defaults to false (SPEC 9.2): retrieval-time
+		// cross-file de-duplication is off unless explicitly enabled.
+		DedupRetrieval: false,
 		// RerankEnabled left nil: auto mode (activates iff a rerank
 		// provider credential is present). See rerankEnabledEffective.
 		RerankProvider:            "cohere",
@@ -692,6 +702,7 @@ func buildPersistedConfig(cfg *Config) persistedConfig {
 		RAGMaxContextChars:        cfg.RAGMaxContextChars,
 		RAGOversampleFactor:       cfg.RAGOversampleFactor,
 		RetrievalHybridEnabled:    cfg.RetrievalHybridEnabled,
+		DedupRetrieval:            cfg.DedupRetrieval,
 		RerankEnabled:             rerankEnabledEffective(cfg),
 		RerankProvider:            cfg.RerankProvider,
 		CohereBaseURL:             cfg.CohereBaseURL,
@@ -1243,6 +1254,9 @@ func applyModelRAGFileParsed(cfg *Config, fc fileConfig) {
 	if fc.RetrievalHybridEnabled != nil {
 		cfg.RetrievalHybridEnabled = *fc.RetrievalHybridEnabled
 	}
+	if fc.DedupRetrieval != nil {
+		cfg.DedupRetrieval = *fc.DedupRetrieval
+	}
 	if fc.SessionInactivityTimeout != nil {
 		cfg.SessionInactivityTimeout = *fc.SessionInactivityTimeout
 	}
@@ -1604,6 +1618,7 @@ var configKeyAliases = map[string]string{
 	"oversample_factor":                    "rag.oversample_factor",
 	"retrieval_hybrid_enabled":             "retrieval.hybrid.enabled",
 	"hybrid_enabled":                       "retrieval.hybrid.enabled",
+	"dedup_retrieval":                      "dedup.retrieval",
 	"rerank_enabled":                       "rerank.enabled",
 	"rerank.cohere.api_key":                "cohere_api_key",
 	"rerank.cohere.base_url":               "cohere_base_url",
@@ -1695,7 +1710,7 @@ func canonicalizeConfigKey(key string) string {
 // (so child keys should be prefixed) rather than a scalar/list key.
 func isMapSectionKey(key string) bool {
 	switch key {
-	case "rag", "ingest", "ingest.docling", "stt", "stt.mistral", "stt.elevenlabs", "server", "server.tls", "secret_sources", "mistral", "docling", "security", "security.auth", "x402", "x402.route_policy", "x402.route_policy.tools_call", "chunking", "retrieval", "retrieval.hybrid", "rerank", "rerank.cohere", "index":
+	case "rag", "ingest", "ingest.docling", "stt", "stt.mistral", "stt.elevenlabs", "server", "server.tls", "secret_sources", "mistral", "docling", "security", "security.auth", "x402", "x402.route_policy", "x402.route_policy.tools_call", "chunking", "retrieval", "retrieval.hybrid", "rerank", "rerank.cohere", "index", "dedup":
 		return true
 	case "ingest.pdf", "ingest.images", "ingest.audio", "ingest.archives", "secrets", "index.qdrant":
 		return true
@@ -1755,6 +1770,7 @@ var boolFileScalarTargets = map[string]func(*fileConfig) **bool{
 	"media.vad":                func(c *fileConfig) **bool { return &c.MediaVAD },
 	"x402_tools_call_enabled":  func(c *fileConfig) **bool { return &c.X402ToolsCallEnabled },
 	"retrieval.hybrid.enabled": func(c *fileConfig) **bool { return &c.RetrievalHybridEnabled },
+	"dedup.retrieval":          func(c *fileConfig) **bool { return &c.DedupRetrieval },
 	"rerank.enabled":           func(c *fileConfig) **bool { return &c.RerankEnabled },
 }
 
@@ -2135,6 +2151,7 @@ func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	writeInt("rag_max_context_chars", cfg.RAGMaxContextChars)
 	writeInt("rag_oversample_factor", cfg.RAGOversampleFactor)
 	writeBool("retrieval_hybrid_enabled", cfg.RetrievalHybridEnabled)
+	writeBool("dedup_retrieval", cfg.DedupRetrieval)
 	writeBool("rerank_enabled", cfg.RerankEnabled)
 	writeScalar("rerank_provider", cfg.RerankProvider)
 	writeScalar("cohere_base_url", cfg.CohereBaseURL)

--- a/internal/model/interfaces.go
+++ b/internal/model/interfaces.go
@@ -24,6 +24,25 @@ type LexicalSearcher interface {
 	SearchBM25(ctx context.Context, query string, k int, indexKind string) ([]SearchHit, error)
 }
 
+// DocumentHash pairs a document's canonical rel_path with its content_hash
+// (SPEC §7.6). Retrieval-time cross-file de-duplication (SPEC §9.2) uses these
+// to group candidate hits whose source documents are byte-identical.
+type DocumentHash struct {
+	RelPath     string
+	ContentHash string
+}
+
+// DocumentHashLister is an optional capability stores may implement so the
+// retrieval service can map a hit's rel_path to its content_hash for
+// retrieval-time cross-file de-duplication (SPEC §9.2). The retrieval service
+// type-asserts against this interface, mirroring the LexicalSearcher
+// optional-capability pattern; stores that do not implement it simply yield no
+// dedup map and search behaves exactly as before (pass-through). Only
+// non-deleted documents are returned.
+type DocumentHashLister interface {
+	ListDocumentHashes(ctx context.Context) ([]DocumentHash, error)
+}
+
 // Index is the core vector-store contract every backend must satisfy (issue
 // #247). The in-memory HNSW is the conforming default; external/on-disk
 // backends (Qdrant #268, pgvector #269, on-disk #246) implement the same

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -1674,6 +1674,13 @@ func (s *Service) searchBothIndices(ctx context.Context, query string, k int, te
 		}
 		return out[i].Score > out[j].Score
 	})
+	// Cross-file dedup applies to the MERGED pool too (SPEC 9.2): each
+	// searchSingleIndex call above deduped within its own axis, but a
+	// byte-identical duplicate can still surface once in the text pool and once
+	// in the code pool. Collapse across the merged, normalized, score-sorted
+	// pool (keeping the best-ranked survivor) before rerank/truncation, so
+	// index=both matches single-index behavior.
+	out = s.dedupCrossFileCandidates(out)
 	// index=both: rerank once on the merged, normalized pool (SPEC 9.1.1).
 	return s.rerankPool(ctx, query, out, k), nil
 }

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -113,6 +113,16 @@ type Service struct {
 	rerankEnabled       bool
 	rerankModel         string
 	rerankCandidatePool int
+	// crossFileDedupEnabled toggles retrieval-time cross-file de-duplication
+	// (SPEC 9.2): when true, candidate hits whose source documents share an
+	// identical content_hash collapse to one best-ranked survivor. Default
+	// false (pass-through). Wired from config.DedupRetrieval at construction.
+	crossFileDedupEnabled bool
+	// groupKeyByRelPath maps a document rel_path to its content_hash (SPEC
+	// 7.6), populated at startup from a model.DocumentHashLister. It is the
+	// grouping key for cross-file dedup; an empty/absent value disables
+	// grouping for that path (entries are never collapsed together).
+	groupKeyByRelPath map[string]string
 }
 
 // compile-time assertion that Service implements model.Retriever.  This
@@ -189,6 +199,36 @@ func (s *Service) SetRerankEnabled(enabled bool) {
 	s.metaMu.Lock()
 	defer s.metaMu.Unlock()
 	s.rerankEnabled = enabled
+}
+
+// SetCrossFileDedupEnabled toggles retrieval-time cross-file de-duplication
+// (SPEC 9.2). The engine wires this from config.DedupRetrieval at construction
+// time. Default off ⇒ search returns the pre-dedup candidate set unchanged.
+func (s *Service) SetCrossFileDedupEnabled(enabled bool) {
+	s.metaMu.Lock()
+	defer s.metaMu.Unlock()
+	s.crossFileDedupEnabled = enabled
+}
+
+// SetDocumentHashes installs the rel_path → content_hash map used to group
+// candidate hits for cross-file dedup (SPEC 9.2). Entries with an empty
+// content_hash are ignored (never grouped together). The map is copied so the
+// caller may reuse its slice/map. Passing nil clears the map (pass-through).
+func (s *Service) SetDocumentHashes(hashes []model.DocumentHash) {
+	s.metaMu.Lock()
+	defer s.metaMu.Unlock()
+	if len(hashes) == 0 {
+		s.groupKeyByRelPath = nil
+		return
+	}
+	m := make(map[string]string, len(hashes))
+	for _, h := range hashes {
+		if strings.TrimSpace(h.ContentHash) == "" {
+			continue
+		}
+		m[h.RelPath] = h.ContentHash
+	}
+	s.groupKeyByRelPath = m
 }
 
 func (s *Service) SetLogger(l *log.Logger) {
@@ -1201,12 +1241,14 @@ func (s *Service) searchSingleIndex(ctx context.Context, query string, k int, mo
 	}
 	if fused, ok := s.runHybridSearch(ctx, query, k, indexName, filtered); ok {
 		fused = dedupMediaCandidates(fused)
+		fused = s.dedupCrossFileCandidates(fused)
 		if allowRerank {
 			return s.rerankPool(ctx, query, fused, k), nil
 		}
 		return truncateSearchHits(fused, k), nil
 	}
 	filtered = dedupMediaCandidates(filtered)
+	filtered = s.dedupCrossFileCandidates(filtered)
 	if allowRerank {
 		return s.rerankPool(ctx, query, filtered, k), nil
 	}
@@ -1271,6 +1313,47 @@ func dedupMediaCandidates(hits []model.SearchHit) []model.SearchHit {
 				}
 			}
 		}
+		out = append(out, h)
+	}
+	return out
+}
+
+// dedupCrossFileCandidates implements SPEC 9.2 retrieval-time cross-file
+// de-duplication: collapse candidate hits whose source documents share an
+// identical content_hash (SPEC 7.6) to a single best-ranked survivor, keeping
+// the (already canonical) rel_path of the first survivor in the group. It runs
+// AFTER candidate generation/fusion and dedupMediaCandidates, and BEFORE rerank
+// (SPEC 9.1.1) and truncation to k — so the candidate POOL shrinks, preserving
+// the no-result-loss guarantee (a query MAY then return fewer than k hits).
+//
+// Grouping is by content_hash directly. Hits whose rel_path has no known (or an
+// empty) content_hash are passed through untouched and NEVER grouped together.
+// The first (best pre-rerank) survivor per group is kept and the relative order
+// of survivors is preserved, so the result is deterministic. When disabled or
+// when no hash map is loaded, this is a pass-through.
+func (s *Service) dedupCrossFileCandidates(hits []model.SearchHit) []model.SearchHit {
+	s.metaMu.RLock()
+	enabled := s.crossFileDedupEnabled
+	groupKeyByRelPath := s.groupKeyByRelPath
+	s.metaMu.RUnlock()
+
+	if !enabled || len(groupKeyByRelPath) == 0 || len(hits) == 0 {
+		return hits
+	}
+
+	seen := make(map[string]struct{}, len(hits))
+	out := make([]model.SearchHit, 0, len(hits))
+	for _, h := range hits {
+		contentHash := groupKeyByRelPath[h.RelPath]
+		if contentHash == "" {
+			// Unknown/empty content_hash: never grouped, always kept.
+			out = append(out, h)
+			continue
+		}
+		if _, dup := seen[contentHash]; dup {
+			continue
+		}
+		seen[contentHash] = struct{}{}
 		out = append(out, h)
 	}
 	return out

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -786,6 +786,39 @@ func (s *SQLiteStore) ClearDocumentContentHashes(ctx context.Context) error {
 	return err
 }
 
+// ListDocumentHashes returns the (rel_path, content_hash) pair for every
+// non-deleted document. It backs retrieval-time cross-file de-duplication
+// (SPEC §9.2): the retrieval service maps a hit's rel_path to its content_hash
+// to collapse byte-identical duplicate sources. Implements
+// model.DocumentHashLister.
+func (s *SQLiteStore) ListDocumentHashes(ctx context.Context) ([]model.DocumentHash, error) {
+	db, err := s.ensureDB(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer s.ReleaseDB()
+
+	rows, err := db.QueryContext(ctx,
+		`SELECT rel_path, content_hash FROM documents WHERE deleted = 0`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	hashes := make([]model.DocumentHash, 0)
+	for rows.Next() {
+		var h model.DocumentHash
+		if err := rows.Scan(&h.RelPath, &h.ContentHash); err != nil {
+			return nil, err
+		}
+		hashes = append(hashes, h)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return hashes, nil
+}
+
 // WithTx begins a new database transaction and passes a transaction-bound
 // representation store to the supplied callback. If the callback returns an
 // error the transaction is rolled back; otherwise it is committed.  The

--- a/tests/config/dedup_config_test.go
+++ b/tests/config/dedup_config_test.go
@@ -1,0 +1,81 @@
+package tests
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+)
+
+// TestDedup_DefaultOff pins SPEC 9.2: dedup.retrieval defaults to false.
+func TestDedup_DefaultOff(t *testing.T) {
+	cfg := config.Default()
+	if cfg.DedupRetrieval {
+		t.Fatalf("dedup.retrieval must default to false, got true")
+	}
+}
+
+// TestDedup_NestedYAMLRoundTrips pins the nested-mapping form
+// (dedup: \n  retrieval: true) parses onto Config.DedupRetrieval.
+func TestDedup_NestedYAMLRoundTrips(t *testing.T) {
+	tmp := t.TempDir()
+	path := tmp + "/.dir2mcp.yaml"
+	writeFile(t, path, strings.Join([]string{
+		"dedup:",
+		"  retrieval: true",
+		"",
+	}, "\n"))
+
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if !cfg.DedupRetrieval {
+		t.Fatalf("dedup.retrieval=true must enable DedupRetrieval, got false")
+	}
+}
+
+// TestDedup_FlatAliasRoundTrips pins the flat snake_case alias
+// (dedup_retrieval -> dedup.retrieval).
+func TestDedup_FlatAliasRoundTrips(t *testing.T) {
+	tmp := t.TempDir()
+	path := tmp + "/.dir2mcp.yaml"
+	writeFile(t, path, "dedup_retrieval: true\n")
+
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if !cfg.DedupRetrieval {
+		t.Fatalf("dedup_retrieval: true must enable DedupRetrieval, got false")
+	}
+}
+
+// TestDedup_SnapshotRoundTrips pins the persisted-snapshot round-trip: the
+// flag survives SaveEffectiveSnapshot -> on-disk YAML -> LoadEffectiveSnapshot.
+func TestDedup_SnapshotRoundTrips(t *testing.T) {
+	cfg := config.Default()
+	cfg.StateDir = t.TempDir()
+	cfg.DedupRetrieval = true
+
+	path, err := config.SaveEffectiveSnapshot(cfg, config.SecretSourceMetadata{})
+	if err != nil {
+		t.Fatalf("SaveEffectiveSnapshot: %v", err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !strings.Contains(string(raw), "dedup_retrieval: true") {
+		t.Fatalf("snapshot must persist dedup_retrieval: true:\n%s", raw)
+	}
+
+	loaded, _, err := config.LoadEffectiveSnapshot(path)
+	if err != nil {
+		t.Fatalf("LoadEffectiveSnapshot: %v", err)
+	}
+	if !loaded.DedupRetrieval {
+		t.Fatalf("loaded snapshot must carry DedupRetrieval=true, got false")
+	}
+}

--- a/tests/retrieval/cross_file_dedup_test.go
+++ b/tests/retrieval/cross_file_dedup_test.go
@@ -130,3 +130,42 @@ func TestSearch_CrossFileDedup_NoMapIsPassThrough(t *testing.T) {
 		t.Fatalf("no hash map must pass through; got %v", got)
 	}
 }
+
+// TestSearch_CrossFileDedup_IndexBothMergedPool pins SPEC 9.2 for index=both:
+// a byte-identical duplicate that surfaces once in the text pool and once in the
+// code pool (as distinct chunks) must collapse to a single survivor in the
+// merged pool, not just within each axis.
+func TestSearch_CrossFileDedup_IndexBothMergedPool(t *testing.T) {
+	textIdx := index.NewHNSWIndex("")
+	codeIdx := index.NewHNSWIndex("")
+	addVec(t, textIdx, 1, []float32{1, 0})       // a.md      (hash H1) in text axis
+	addVec(t, codeIdx, 2, []float32{0.99, 0.01}) // copy/a.md (hash H1) in code axis
+
+	svc := retrieval.NewService(nil, textIdx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+		"mistral-embed":   {1, 0},
+		"codestral-embed": {1, 0},
+	}}, nil)
+	svc.SetCodeIndex(codeIdx)
+	svc.SetCrossFileDedupEnabled(true)
+	svc.SetDocumentHashes([]model.DocumentHash{
+		{RelPath: "a.md", ContentHash: "H1"},
+		{RelPath: "copy/a.md", ContentHash: "H1"},
+	})
+	svc.SetChunkMetadata(1, model.SearchHit{RelPath: "a.md", Snippet: "alpha"})
+	svc.SetChunkMetadata(2, model.SearchHit{RelPath: "copy/a.md", Snippet: "alpha"})
+
+	hits, err := svc.Search(context.Background(), model.SearchQuery{Query: "alpha", K: 10, Index: "both"})
+	if err != nil {
+		t.Fatalf("Search(index=both): %v", err)
+	}
+	if len(hits) != 1 {
+		ids := make([]uint64, 0, len(hits))
+		for _, h := range hits {
+			ids = append(ids, h.ChunkID)
+		}
+		t.Fatalf("index=both cross-file dedup: expected 1 survivor, got %v", ids)
+	}
+	if hits[0].ChunkID != 1 {
+		t.Fatalf("expected best-ranked survivor chunk 1, got %d", hits[0].ChunkID)
+	}
+}

--- a/tests/retrieval/cross_file_dedup_test.go
+++ b/tests/retrieval/cross_file_dedup_test.go
@@ -1,0 +1,132 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
+)
+
+// newCrossFileDedupService builds a vector-only retrieval service over the
+// given index (nil store keeps hybrid search from engaging) wired with the
+// SPEC 9.2 cross-file dedup toggle and rel_path → content_hash map.
+func newCrossFileDedupService(idx *index.HNSWIndex, enabled bool, hashes []model.DocumentHash) *retrieval.Service {
+	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+		"mistral-embed": {1, 0},
+	}}, nil)
+	svc.SetCrossFileDedupEnabled(enabled)
+	svc.SetDocumentHashes(hashes)
+	return svc
+}
+
+func searchChunkIDs(t *testing.T, svc *retrieval.Service, query string) []uint64 {
+	t.Helper()
+	hits, err := svc.Search(context.Background(), model.SearchQuery{Query: query, K: 10})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	ids := make([]uint64, 0, len(hits))
+	for _, h := range hits {
+		ids = append(ids, h.ChunkID)
+	}
+	return ids
+}
+
+// TestSearch_CrossFileDedup_CollapsesAliasesKeepsBestRanked pins SPEC 9.2: two
+// alias documents (same content_hash, different rel_path) collapse to a single
+// survivor, the best-ranked one is kept, and the relative order of the
+// remaining distinct hit is preserved.
+func TestSearch_CrossFileDedup_CollapsesAliasesKeepsBestRanked(t *testing.T) {
+	idx := index.NewHNSWIndex("")
+	// chunk 1 (a.md) ranks best, chunk 2 (copy/a.md) is its byte-identical
+	// alias and ranks slightly lower, chunk 3 (b.md) is distinct.
+	addVec(t, idx, 1, []float32{1, 0})       // a.md       (hash H1) - best
+	addVec(t, idx, 2, []float32{0.99, 0.01}) // copy/a.md  (hash H1) - alias
+	addVec(t, idx, 3, []float32{0.95, 0.05}) // b.md       (hash H2) - distinct
+
+	svc := newCrossFileDedupService(idx, true, []model.DocumentHash{
+		{RelPath: "a.md", ContentHash: "H1"},
+		{RelPath: "copy/a.md", ContentHash: "H1"},
+		{RelPath: "b.md", ContentHash: "H2"},
+	})
+	svc.SetChunkMetadata(1, model.SearchHit{RelPath: "a.md", Snippet: "alpha"})
+	svc.SetChunkMetadata(2, model.SearchHit{RelPath: "copy/a.md", Snippet: "alpha"})
+	svc.SetChunkMetadata(3, model.SearchHit{RelPath: "b.md", Snippet: "beta"})
+
+	got := searchChunkIDs(t, svc, "alpha")
+
+	// Expect [1, 3]: chunk 2 (alias of chunk 1) collapsed; best-ranked alias
+	// (chunk 1) kept; distinct chunk 3 preserved after it.
+	want := []uint64{1, 3}
+	if len(got) != len(want) {
+		t.Fatalf("expected %v survivors, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("order/survivor mismatch: want %v, got %v", want, got)
+		}
+	}
+}
+
+// TestSearch_CrossFileDedup_DisabledIsPassThrough pins SPEC 9.2 default-off:
+// with dedup.retrieval=false the pre-dedup candidate set is returned unchanged,
+// even though two candidates share a content_hash.
+func TestSearch_CrossFileDedup_DisabledIsPassThrough(t *testing.T) {
+	idx := index.NewHNSWIndex("")
+	addVec(t, idx, 1, []float32{1, 0})
+	addVec(t, idx, 2, []float32{0.99, 0.01})
+
+	svc := newCrossFileDedupService(idx, false, []model.DocumentHash{
+		{RelPath: "a.md", ContentHash: "H1"},
+		{RelPath: "copy/a.md", ContentHash: "H1"},
+	})
+	svc.SetChunkMetadata(1, model.SearchHit{RelPath: "a.md", Snippet: "alpha"})
+	svc.SetChunkMetadata(2, model.SearchHit{RelPath: "copy/a.md", Snippet: "alpha"})
+
+	got := searchChunkIDs(t, svc, "alpha")
+	if len(got) != 2 {
+		t.Fatalf("disabled dedup must pass through both candidates; got %v", got)
+	}
+}
+
+// TestSearch_CrossFileDedup_EmptyContentHashNotCollapsed pins SPEC 9.2: an
+// empty/absent content_hash is NEVER grouped — two such candidates both survive
+// even with dedup enabled.
+func TestSearch_CrossFileDedup_EmptyContentHashNotCollapsed(t *testing.T) {
+	idx := index.NewHNSWIndex("")
+	addVec(t, idx, 1, []float32{1, 0})
+	addVec(t, idx, 2, []float32{0.99, 0.01})
+
+	// Both rel_paths map to an empty content_hash (SetDocumentHashes drops
+	// these), so neither is grouped.
+	svc := newCrossFileDedupService(idx, true, []model.DocumentHash{
+		{RelPath: "a.md", ContentHash: ""},
+		{RelPath: "b.md", ContentHash: ""},
+	})
+	svc.SetChunkMetadata(1, model.SearchHit{RelPath: "a.md", Snippet: "alpha"})
+	svc.SetChunkMetadata(2, model.SearchHit{RelPath: "b.md", Snippet: "alpha"})
+
+	got := searchChunkIDs(t, svc, "alpha")
+	if len(got) != 2 {
+		t.Fatalf("empty content_hash must never collapse; got %v", got)
+	}
+}
+
+// TestSearch_CrossFileDedup_NoMapIsPassThrough pins the pass-through path when
+// the store yielded no hash map (enabled but empty): search is unchanged.
+func TestSearch_CrossFileDedup_NoMapIsPassThrough(t *testing.T) {
+	idx := index.NewHNSWIndex("")
+	addVec(t, idx, 1, []float32{1, 0})
+	addVec(t, idx, 2, []float32{0.99, 0.01})
+
+	svc := newCrossFileDedupService(idx, true, nil)
+	svc.SetChunkMetadata(1, model.SearchHit{RelPath: "a.md", Snippet: "alpha"})
+	svc.SetChunkMetadata(2, model.SearchHit{RelPath: "copy/a.md", Snippet: "alpha"})
+
+	got := searchChunkIDs(t, svc, "alpha")
+	if len(got) != 2 {
+		t.Fatalf("no hash map must pass through; got %v", got)
+	}
+}


### PR DESCRIPTION
## Summary

Implements **retrieval-time cross-file de-duplication** (GitHub #265, SPEC §9.2 / §7.9, pinned spec 0.18.0) — and **only** that. No ingest-time canonicalization, no near-dup detection.

When `dedup.retrieval: true`, search collapses candidate hits whose source documents share an identical `content_hash` (§7.6) to a single best-ranked survivor, keeping the canonical `rel_path`. It runs **after** candidate generation/fusion and the existing media dedup, but **before** rerank (§9.1.1) and truncation to `k` — so the candidate *pool* shrinks (a query MAY legitimately return fewer than `k` hits), preserving the §9.1.1 no-result-loss guarantee. Default **off** ⇒ exact pre-dedup pass-through.

## Seam + wiring

- `internal/retrieval/service.go`: new `crossFileDedupEnabled` + `groupKeyByRelPath` fields, `SetCrossFileDedupEnabled` / `SetDocumentHashes` setters, and `dedupCrossFileCandidates(hits)` invoked immediately after `dedupMediaCandidates(...)` in **both** the fused and vector-only paths of `searchSingleIndex`, before rerank/truncation. Collapses by same non-empty `content_hash`, keeps the first (best pre-rerank) survivor, preserves order; pass-through when disabled / empty map / unknown or empty hash.

## Store read

- `internal/model/interfaces.go`: `DocumentHash{RelPath, ContentHash}` + optional `DocumentHashLister` capability (mirrors `LexicalSearcher`).
- `internal/store/sqlite_store.go`: `ListDocumentHashes(ctx)` → `SELECT rel_path, content_hash FROM documents WHERE deleted = 0`.
- `internal/cli/up.go`: on `up`, enable from `cfg.DedupRetrieval` and (when on) type-assert the store to `model.DocumentHashLister` to load the `rel_path → content_hash` map onto the service. Load failures are non-fatal (dedup stays pass-through) — never blocks startup.

## Config key

`dedup.retrieval` (bool, default **false**) wired end-to-end: `Config.DedupRetrieval`, `fileConfig`/`persistedConfig` (`dedup_retrieval` yaml tag), `dedup_retrieval → dedup.retrieval` alias, `dedup` map section, `boolFileScalarTargets`, apply/build/writeBool.

## Tests (`tests/` package)

- `tests/retrieval/cross_file_dedup_test.go`: two alias docs (same hash, different rel_path) → one survivor, best-ranked kept, order preserved; `dedup.retrieval:false` → pass-through; empty `content_hash` not collapsed; empty map → pass-through.
- `tests/config/dedup_config_test.go`: default-off, nested-YAML, flat alias, snapshot round-trip.

## Checks

`make check` passes locally (fmt, vet, lint, gocyclo ≤15, ineffassign, misspell, full test suite, release-tools, build) — exit 0. `dirstral-spec` submodule unchanged (stays 0.18.0).

Closes #265


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable cross-file deduplication for search results. When enabled, duplicate content across different files is automatically collapsed to a single best-ranked result.

* **Tests**
  * Added comprehensive test coverage for deduplication configuration and search behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->