### PR TITLE
feat(mcp): add dir2mcp_open_media_clip tool (#264)

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ The launchd job starts from a clean environment and will **not** inherit a `MIST
 | `dir2mcp_annotate` | Structured annotation of a document |
 | `dir2mcp_transcribe_and_ask` | Transcribe then ask over the result |
 | `dir2mcp_open_file` | Retrieve a file by path with span context |
+| `dir2mcp_open_media_clip` | Extract the audio/video snippet for a media hit (time span) |
 | `dir2mcp_list_files` | List indexed files with metadata |
 | `dir2mcp_stats` | Corpus statistics |
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1824,38 +1824,32 @@ func setBoolFileScalar(cfg *fileConfig, key, value string) error {
 // setIntFileScalar parses value as an int and assigns it to the
 // fileConfig field selected by key; returns an error for an unknown key
 // or a non-integer value.
+// intFileScalarTargets maps a canonical integer config key to an accessor that
+// returns the address of the matching *int fileConfig field. Using a table
+// keeps setIntFileScalar a flat dispatch (one new entry per key) rather than an
+// ever-growing switch that trips the cyclomatic-complexity gate.
+var intFileScalarTargets = map[string]func(*fileConfig) **int{
+	"rate_limit_rps":             func(c *fileConfig) **int { return &c.RateLimitRPS },
+	"rate_limit_burst":           func(c *fileConfig) **int { return &c.RateLimitBurst },
+	"rag.k_default":              func(c *fileConfig) **int { return &c.RAGKDefault },
+	"rag.max_context_chars":      func(c *fileConfig) **int { return &c.RAGMaxContextChars },
+	"rag.oversample_factor":      func(c *fileConfig) **int { return &c.RAGOversampleFactor },
+	"chunking.max_tokens":        func(c *fileConfig) **int { return &c.ChunkingMaxTokens },
+	"chunking.overlap_tokens":    func(c *fileConfig) **int { return &c.ChunkingOverlapTokens },
+	"ingest.max_file_mb":         func(c *fileConfig) **int { return &c.IngestMaxFileMB },
+	"rerank.candidate_pool":      func(c *fileConfig) **int { return &c.RerankCandidatePool },
+	"media.audio_window_sec":     func(c *fileConfig) **int { return &c.MediaAudioWindowSec },
+	"media.video_window_sec":     func(c *fileConfig) **int { return &c.MediaVideoWindowSec },
+	"media.clip.max_duration_ms": func(c *fileConfig) **int { return &c.MediaClipMaxDurationMS },
+	"media.clip.max_bytes":       func(c *fileConfig) **int { return &c.MediaClipMaxBytes },
+}
+
 func setIntFileScalar(cfg *fileConfig, key, value string) error {
-	var target **int
-	switch key {
-	case "rate_limit_rps":
-		target = &cfg.RateLimitRPS
-	case "rate_limit_burst":
-		target = &cfg.RateLimitBurst
-	case "rag.k_default":
-		target = &cfg.RAGKDefault
-	case "rag.max_context_chars":
-		target = &cfg.RAGMaxContextChars
-	case "rag.oversample_factor":
-		target = &cfg.RAGOversampleFactor
-	case "chunking.max_tokens":
-		target = &cfg.ChunkingMaxTokens
-	case "chunking.overlap_tokens":
-		target = &cfg.ChunkingOverlapTokens
-	case "ingest.max_file_mb":
-		target = &cfg.IngestMaxFileMB
-	case "rerank.candidate_pool":
-		target = &cfg.RerankCandidatePool
-	case "media.audio_window_sec":
-		target = &cfg.MediaAudioWindowSec
-	case "media.video_window_sec":
-		target = &cfg.MediaVideoWindowSec
-	case "media.clip.max_duration_ms":
-		target = &cfg.MediaClipMaxDurationMS
-	case "media.clip.max_bytes":
-		target = &cfg.MediaClipMaxBytes
-	default:
+	accessor, ok := intFileScalarTargets[key]
+	if !ok {
 		return nil
 	}
+	target := accessor(cfg)
 	parsed, err := strconv.Atoi(value)
 	if err != nil {
 		return fmt.Errorf("invalid integer for %s", key)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,15 @@ const DefaultProtocolVersion = "2025-11-25"
 
 const EffectiveConfigSnapshotFile = ".dir2mcp.yaml.snapshot"
 
+// DefaultMediaClipMaxDurationMS / DefaultMediaClipMaxBytes are the built-in
+// bounds for the dir2mcp_open_media_clip tool (SPEC §15.11): a 2-minute span
+// cap and a 25 MiB inline byte cap. Both are overridable via
+// media.clip.max_duration_ms / media.clip.max_bytes.
+const (
+	DefaultMediaClipMaxDurationMS = 120000
+	DefaultMediaClipMaxBytes      = 26214400
+)
+
 type SecretSourceMetadata struct {
 	ElevenLabsAPIKey     string
 	CohereAPIKey         string
@@ -290,6 +299,15 @@ type Config struct {
 	MediaAudioWindowSec int
 	MediaVideoWindowSec int
 
+	// MediaClipMaxDurationMS / MediaClipMaxBytes bound the
+	// dir2mcp_open_media_clip tool (SPEC §15.11; config `media.clip.max_duration_ms`
+	// / `media.clip.max_bytes`). A requested span whose duration exceeds
+	// MediaClipMaxDurationMS, or an extracted clip whose size exceeds
+	// MediaClipMaxBytes, is rejected with the non-retryable CLIP_TOO_LARGE error.
+	// Defaults: 120000 ms (2 min) and 26214400 bytes (25 MiB).
+	MediaClipMaxDurationMS int
+	MediaClipMaxBytes      int
+
 	// QualityGatesEnabled is the master switch for the output quality gate
 	// (spec 0.16.0): when true (default), generated transcript/OCR text is
 	// screened for degenerate output (repetition loops, empty output,
@@ -404,6 +422,8 @@ type fileConfig struct {
 	MediaVAD                  *bool
 	MediaAudioWindowSec       *int
 	MediaVideoWindowSec       *int
+	MediaClipMaxDurationMS    *int
+	MediaClipMaxBytes         *int
 	ElevenLabsAPIKey          *string
 	ServerTLSCertFile         *string
 	ServerTLSKeyFile          *string
@@ -502,6 +522,8 @@ type persistedConfig struct {
 	MediaVAD                  bool          `yaml:"media_vad"`
 	MediaAudioWindowSec       int           `yaml:"media_audio_window_sec"`
 	MediaVideoWindowSec       int           `yaml:"media_video_window_sec"`
+	MediaClipMaxDurationMS    int           `yaml:"media_clip_max_duration_ms"`
+	MediaClipMaxBytes         int           `yaml:"media_clip_max_bytes"`
 	ServerTLSCertFile         string        `yaml:"server_tls_cert_file"`
 	ServerTLSKeyFile          string        `yaml:"server_tls_key_file"`
 
@@ -625,6 +647,8 @@ func Default() Config {
 		STTElevenLabsModel:        "scribe_v1",
 		STTElevenLabsLanguageCode: "",
 		QualityGatesEnabled:       true,
+		MediaClipMaxDurationMS:    DefaultMediaClipMaxDurationMS,
+		MediaClipMaxBytes:         DefaultMediaClipMaxBytes,
 		MediaVariantsGroup:        false,
 		MediaVariantsSelect:       "best",
 		MediaTranslateEnabled:     false,
@@ -738,6 +762,8 @@ func buildPersistedConfig(cfg *Config) persistedConfig {
 		MediaVAD:                  cfg.MediaVAD,
 		MediaAudioWindowSec:       cfg.MediaAudioWindowSec,
 		MediaVideoWindowSec:       cfg.MediaVideoWindowSec,
+		MediaClipMaxDurationMS:    cfg.MediaClipMaxDurationMS,
+		MediaClipMaxBytes:         cfg.MediaClipMaxBytes,
 		ServerTLSCertFile:         cfg.ServerTLSCertFile,
 		ServerTLSKeyFile:          cfg.ServerTLSKeyFile,
 		X402Mode:                  cfg.X402.Mode,
@@ -1386,6 +1412,12 @@ func applyMediaFileParsed(cfg *Config, fc fileConfig) {
 	if fc.MediaVideoWindowSec != nil {
 		cfg.MediaVideoWindowSec = *fc.MediaVideoWindowSec
 	}
+	if fc.MediaClipMaxDurationMS != nil {
+		cfg.MediaClipMaxDurationMS = *fc.MediaClipMaxDurationMS
+	}
+	if fc.MediaClipMaxBytes != nil {
+		cfg.MediaClipMaxBytes = *fc.MediaClipMaxBytes
+	}
 }
 
 // applyX402FileParsed copies the set x402 file fields onto cfg.X402.
@@ -1660,6 +1692,8 @@ var configKeyAliases = map[string]string{
 	"media_vad":                            "media.vad",
 	"media_audio_window_sec":               "media.audio_window_sec",
 	"media_video_window_sec":               "media.video_window_sec",
+	"media_clip_max_duration_ms":           "media.clip.max_duration_ms",
+	"media_clip_max_bytes":                 "media.clip.max_bytes",
 	"stt_provider":                         "stt.provider",
 	"stt_mistral_model":                    "stt.mistral.model",
 	"stt_elevenlabs_model":                 "stt.elevenlabs.model",
@@ -1716,7 +1750,7 @@ func isMapSectionKey(key string) bool {
 		return true
 	case "source", "source.s3":
 		return true
-	case "media", "media.variants", "media.translate":
+	case "media", "media.variants", "media.translate", "media.clip":
 		return true
 	case "index.pgvector":
 		return true
@@ -1815,6 +1849,10 @@ func setIntFileScalar(cfg *fileConfig, key, value string) error {
 		target = &cfg.MediaAudioWindowSec
 	case "media.video_window_sec":
 		target = &cfg.MediaVideoWindowSec
+	case "media.clip.max_duration_ms":
+		target = &cfg.MediaClipMaxDurationMS
+	case "media.clip.max_bytes":
+		target = &cfg.MediaClipMaxBytes
 	default:
 		return nil
 	}
@@ -1833,8 +1871,10 @@ func setIntFileScalar(cfg *fileConfig, key, value string) error {
 // be negative. A negative value is rejected at config-parse time (explicit,
 // deterministic) rather than being silently clamped later.
 var nonNegativeIntKeys = map[string]bool{
-	"media.audio_window_sec": true,
-	"media.video_window_sec": true,
+	"media.audio_window_sec":     true,
+	"media.video_window_sec":     true,
+	"media.clip.max_duration_ms": true,
+	"media.clip.max_bytes":       true,
 }
 
 // setFloatFileScalar parses value as a float64 and assigns it to the
@@ -2187,6 +2227,8 @@ func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	writeBool("media_vad", cfg.MediaVAD)
 	writeInt("media_audio_window_sec", cfg.MediaAudioWindowSec)
 	writeInt("media_video_window_sec", cfg.MediaVideoWindowSec)
+	writeInt("media_clip_max_duration_ms", cfg.MediaClipMaxDurationMS)
+	writeInt("media_clip_max_bytes", cfg.MediaClipMaxBytes)
 	writeScalar("server_tls_cert_file", cfg.ServerTLSCertFile)
 	writeScalar("server_tls_key_file", cfg.ServerTLSKeyFile)
 	writeScalar("x402_mode", cfg.X402Mode)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/dirstral/dir2mcp/internal/appstate"
+	"github.com/dirstral/dir2mcp/internal/avutil"
 	"github.com/dirstral/dir2mcp/internal/buildinfo"
 	"github.com/dirstral/dir2mcp/internal/config"
 	"github.com/dirstral/dir2mcp/internal/identity"
@@ -120,6 +121,12 @@ type Server struct {
 	execKeyMu map[string]*keyMutex
 
 	eventEmitter func(level, event string, data interface{})
+
+	// extractSegment cuts [startMS, endMS) from a local media file and returns
+	// the container bytes for dir2mcp_open_media_clip (SPEC §15.11). It defaults
+	// to avutil.ExtractSegment and is an injectable seam so tests can stub
+	// extraction without ffmpeg on PATH.
+	extractSegment func(ctx context.Context, path string, startMS, endMS int) ([]byte, error)
 }
 
 type rpcRequest struct {
@@ -195,6 +202,16 @@ func WithTTS(tts TTSSynthesizer) ServerOption {
 	}
 }
 
+// WithExtractSegment overrides the media-clip extraction function used by
+// dir2mcp_open_media_clip (SPEC §15.11). Production leaves it unset so the
+// server falls back to avutil.ExtractSegment; tests inject a stub to exercise
+// the handler without ffmpeg on PATH.
+func WithExtractSegment(fn func(ctx context.Context, path string, startMS, endMS int) ([]byte, error)) ServerOption {
+	return func(s *Server) {
+		s.extractSegment = fn
+	}
+}
+
 func WithEventEmitter(fn func(level, event string, data interface{})) ServerOption {
 	return func(s *Server) {
 		s.eventEmitter = fn
@@ -232,6 +249,9 @@ func NewServer(cfg config.Config, retriever model.Retriever, opts ...ServerOptio
 	}
 	if s.indexing == nil {
 		s.indexing = appstate.NewIndexingState(appstate.ModeIncremental)
+	}
+	if s.extractSegment == nil {
+		s.extractSegment = avutil.ExtractSegment
 	}
 	if cfg.Public && cfg.RateLimitRPS > 0 && cfg.RateLimitBurst > 0 {
 		s.rateLimiter = newIPRateLimiter(float64(cfg.RateLimitRPS), cfg.RateLimitBurst, cfg.TrustedProxies)

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -16,6 +16,8 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"github.com/dirstral/dir2mcp/internal/avutil"
+	"github.com/dirstral/dir2mcp/internal/config"
 	"github.com/dirstral/dir2mcp/internal/ingest"
 	"github.com/dirstral/dir2mcp/internal/mistral"
 	"github.com/dirstral/dir2mcp/internal/model"
@@ -49,6 +51,7 @@ var toolOrder = []string{
 	protocol.ToolNameAnnotate,
 	protocol.ToolNameTranscribeAndAsk,
 	protocol.ToolNameOpenFile,
+	protocol.ToolNameOpenMediaClip,
 	protocol.ToolNameListFiles,
 	protocol.ToolNameStats,
 }
@@ -89,6 +92,14 @@ type toolExecutionError struct {
 
 type retrieverOpenFileWithMeta interface {
 	OpenFileWithMeta(ctx context.Context, relPath string, span model.Span, maxChars int) (string, bool, error)
+}
+
+// storeChunkMediaSpan is the optional store capability that resolves a chunk id
+// to its source media (rel_path/doc_type) and time span for
+// dir2mcp_open_media_clip (SPEC §15.11). It is type-asserted on s.store so a
+// store without media-chunk support degrades to the rel_path+range input path.
+type storeChunkMediaSpan interface {
+	ChunkMediaSpanByID(ctx context.Context, chunkID int64) (relPath, docType string, span model.Span, err error)
 }
 
 type voiceAwareTTSSynthesizer interface {
@@ -145,6 +156,13 @@ func (s *Server) buildToolRegistry() map[string]toolDefinition {
 			InputSchema:  openFileInputSchema(),
 			OutputSchema: openFileOutputSchema(),
 			handler:      s.handleOpenFileTool,
+		},
+		protocol.ToolNameOpenMediaClip: {
+			Name:         protocol.ToolNameOpenMediaClip,
+			Description:  "Extract the audio/video snippet for a media hit (time span); the media analogue of open_file.",
+			InputSchema:  openMediaClipInputSchema(),
+			OutputSchema: openMediaClipOutputSchema(),
+			handler:      s.handleOpenMediaClipTool,
 		},
 		protocol.ToolNameListFiles: {
 			Name:         protocol.ToolNameListFiles,
@@ -1210,6 +1228,242 @@ func (s *Server) handleOpenFileTool(ctx context.Context, args map[string]interfa
 		Content:           []toolContentItem{{Type: "text", Text: content}},
 		StructuredContent: structured,
 	}, nil
+}
+
+// mediaClipRequest is the resolved target of an open_media_clip call: the
+// source media rel_path/doc_type and the [startMS, endMS) span to extract.
+type mediaClipRequest struct {
+	relPath string
+	docType string
+	startMS int
+	endMS   int
+}
+
+// handleOpenMediaClipTool implements dir2mcp_open_media_clip (SPEC §15.11): the
+// time-media analogue of open_file. It resolves a chunk_id (or rel_path + range)
+// to a source media file and time span, enforces the configured clip bounds,
+// extracts the snippet via the injectable extractSegment seam, and returns the
+// bytes inline (base64 + an audio/video content item). reference mode is not yet
+// materialized, so it falls back to inline and notes it.
+func (s *Server) handleOpenMediaClipTool(ctx context.Context, args map[string]interface{}) (toolCallResult, *toolExecutionError) {
+	if err := assertNoUnknownArguments(args, map[string]struct{}{
+		"chunk_id": {}, "rel_path": {}, "start_ms": {}, "end_ms": {}, "return": {},
+	}); err != nil {
+		return toolCallResult{}, &toolExecutionError{Code: "INVALID_FIELD", Message: err.Error(), Retryable: false}
+	}
+	returnMode, toolErr := parseMediaClipReturnArg(args)
+	if toolErr != nil {
+		return toolCallResult{}, toolErr
+	}
+	req, toolErr := s.resolveMediaClipRequest(ctx, args)
+	if toolErr != nil {
+		return toolCallResult{}, toolErr
+	}
+	if !isMediaDocType(req.docType) {
+		return toolCallResult{}, &toolExecutionError{Code: "DOC_TYPE_UNSUPPORTED", Message: "open_media_clip requires an audio/video document; " + req.relPath + " is " + req.docType, Retryable: false}
+	}
+	if req.startMS >= req.endMS {
+		return toolCallResult{}, &toolExecutionError{Code: "INVALID_RANGE", Message: "start_ms must be < end_ms", Retryable: false}
+	}
+
+	maxDurationMS := s.cfg.MediaClipMaxDurationMS
+	if maxDurationMS <= 0 {
+		maxDurationMS = config.DefaultMediaClipMaxDurationMS
+	}
+	maxBytes := s.cfg.MediaClipMaxBytes
+	if maxBytes <= 0 {
+		maxBytes = config.DefaultMediaClipMaxBytes
+	}
+	if req.endMS-req.startMS > maxDurationMS {
+		return toolCallResult{}, &toolExecutionError{Code: "CLIP_TOO_LARGE", Message: fmt.Sprintf("requested clip duration %dms exceeds max %dms; request a shorter span", req.endMS-req.startMS, maxDurationMS), Retryable: false}
+	}
+
+	absPath, pathErr := s.resolveDocumentPath(req.relPath)
+	if pathErr != nil {
+		return toolCallResult{}, mapPathError(pathErr)
+	}
+	extract := s.extractSegment
+	if extract == nil {
+		extract = avutil.ExtractSegment
+	}
+	data, extractErr := extract(ctx, absPath, req.startMS, req.endMS)
+	if extractErr != nil {
+		// Bytes/URLs are never echoed; map every extraction failure (including a
+		// missing ffmpeg) to the non-secret MEDIA_CLIP_FAILED contract.
+		return toolCallResult{}, &toolExecutionError{Code: "MEDIA_CLIP_FAILED", Message: "media clip extraction failed", Retryable: errors.Is(extractErr, avutil.ErrToolNotFound)}
+	}
+	if len(data) > maxBytes {
+		return toolCallResult{}, &toolExecutionError{Code: "CLIP_TOO_LARGE", Message: fmt.Sprintf("extracted clip is %d bytes, exceeds max %d; request a shorter span", len(data), maxBytes), Retryable: false}
+	}
+
+	mimeType := mediaClipMIMEForPath(req.relPath, req.docType)
+	encoded := base64.StdEncoding.EncodeToString(data)
+	structured := map[string]interface{}{
+		"rel_path":    req.relPath,
+		"doc_type":    req.docType,
+		"span":        buildOpenFileSpan(model.Span{Kind: "time", StartMS: req.startMS, EndMS: req.endMS}),
+		"mime_type":   mimeType,
+		"duration_ms": req.endMS - req.startMS,
+		"size_bytes":  len(data),
+		"return":      "inline",
+		"data":        encoded,
+	}
+	// reference was requested but is not yet supported: fall back to inline and
+	// note it (never error solely because reference was asked for, per §15.11).
+	if returnMode == "reference" {
+		structured["reference_fallback"] = "reference return not supported; falling back to inline"
+	}
+	contentType := "audio"
+	if strings.EqualFold(strings.TrimSpace(req.docType), "video") {
+		contentType = "video"
+	}
+	return toolCallResult{
+		// Media bytes travel only via the typed data item, never a text item.
+		Content:           []toolContentItem{{Type: contentType, Data: encoded, MIMEType: mimeType}},
+		StructuredContent: structured,
+	}, nil
+}
+
+// parseMediaClipReturnArg parses the optional "return" argument (inline|reference).
+func parseMediaClipReturnArg(args map[string]interface{}) (string, *toolExecutionError) {
+	mode, err := parseOptionalString(args, "return")
+	if err != nil {
+		return "", &toolExecutionError{Code: "INVALID_FIELD", Message: err.Error(), Retryable: false}
+	}
+	mode = strings.ToLower(strings.TrimSpace(mode))
+	if mode == "" {
+		mode = "inline"
+	}
+	switch mode {
+	case "inline", "reference":
+		return mode, nil
+	default:
+		return "", &toolExecutionError{Code: "INVALID_FIELD", Message: "return must be one of inline,reference", Retryable: false}
+	}
+}
+
+// resolveMediaClipRequest resolves the open_media_clip selection rules into a
+// concrete media target + span. A chunk_id resolves to its source media and
+// chunk span; an explicit start_ms/end_ms provided alongside chunk_id overrides
+// the chunk span. Otherwise rel_path + start_ms + end_ms must all be provided.
+func (s *Server) resolveMediaClipRequest(ctx context.Context, args map[string]interface{}) (mediaClipRequest, *toolExecutionError) {
+	chunkID, hasChunkID, err := parseOptionalIntegerWithPresence(args, "chunk_id")
+	if err != nil {
+		return mediaClipRequest{}, &toolExecutionError{Code: "INVALID_FIELD", Message: err.Error(), Retryable: false}
+	}
+	relPath, err := parseOptionalString(args, "rel_path")
+	if err != nil {
+		return mediaClipRequest{}, &toolExecutionError{Code: "INVALID_FIELD", Message: err.Error(), Retryable: false}
+	}
+	relPath = strings.TrimSpace(relPath)
+	startMS, hasStart, err := parseOptionalIntegerWithPresence(args, "start_ms")
+	if err != nil {
+		return mediaClipRequest{}, &toolExecutionError{Code: "INVALID_FIELD", Message: err.Error(), Retryable: false}
+	}
+	endMS, hasEnd, err := parseOptionalIntegerWithPresence(args, "end_ms")
+	if err != nil {
+		return mediaClipRequest{}, &toolExecutionError{Code: "INVALID_FIELD", Message: err.Error(), Retryable: false}
+	}
+	if (hasStart && startMS < 0) || (hasEnd && endMS < 0) {
+		return mediaClipRequest{}, &toolExecutionError{Code: "INVALID_RANGE", Message: "start_ms/end_ms must be >= 0", Retryable: false}
+	}
+	if hasStart != hasEnd {
+		return mediaClipRequest{}, &toolExecutionError{Code: "INVALID_FIELD", Message: "both start_ms and end_ms must be provided together", Retryable: false}
+	}
+
+	if hasChunkID {
+		return s.resolveMediaClipByChunk(ctx, chunkID, hasStart, startMS, endMS)
+	}
+
+	// rel_path + range path.
+	if relPath == "" {
+		return mediaClipRequest{}, &toolExecutionError{Code: "MISSING_FIELD", Message: "provide chunk_id, or rel_path with start_ms and end_ms", Retryable: false}
+	}
+	if !hasStart {
+		return mediaClipRequest{}, &toolExecutionError{Code: "MISSING_FIELD", Message: "rel_path requires start_ms and end_ms", Retryable: false}
+	}
+	doc, toolErr := s.lookupDocumentForTool(ctx, relPath)
+	if toolErr != nil {
+		return mediaClipRequest{}, toolErr
+	}
+	docType := strings.TrimSpace(doc.DocType)
+	if docType == "" {
+		docType = ingest.ClassifyDocType(doc.RelPath)
+	}
+	return mediaClipRequest{relPath: doc.RelPath, docType: docType, startMS: startMS, endMS: endMS}, nil
+}
+
+// resolveMediaClipByChunk resolves a chunk_id to its source media and span,
+// applying an explicit start_ms/end_ms override (still bounded to that media).
+func (s *Server) resolveMediaClipByChunk(ctx context.Context, chunkID int, hasRange bool, startMS, endMS int) (mediaClipRequest, *toolExecutionError) {
+	if chunkID <= 0 {
+		return mediaClipRequest{}, &toolExecutionError{Code: "INVALID_FIELD", Message: "chunk_id must be > 0", Retryable: false}
+	}
+	resolver, ok := s.store.(storeChunkMediaSpan)
+	if !ok || s.store == nil {
+		return mediaClipRequest{}, &toolExecutionError{Code: "DOC_TYPE_UNSUPPORTED", Message: "chunk_id resolution is not supported by this store; pass rel_path with start_ms and end_ms", Retryable: false}
+	}
+	relPath, docType, span, err := resolver.ChunkMediaSpanByID(ctx, int64(chunkID))
+	if err != nil {
+		if errors.Is(err, model.ErrNotFound) || errors.Is(err, os.ErrNotExist) {
+			return mediaClipRequest{}, &toolExecutionError{Code: protocol.ErrorCodeFileNotFound, Message: "chunk not found", Retryable: false}
+		}
+		return mediaClipRequest{}, &toolExecutionError{Code: "STORE_CORRUPT", Message: err.Error(), Retryable: false}
+	}
+	req := mediaClipRequest{
+		relPath: strings.TrimSpace(relPath),
+		docType: strings.TrimSpace(docType),
+		startMS: span.StartMS,
+		endMS:   span.EndMS,
+	}
+	if req.docType == "" {
+		req.docType = ingest.ClassifyDocType(req.relPath)
+	}
+	// An explicit range overrides the chunk's span (still bounded to this media).
+	if hasRange {
+		req.startMS = startMS
+		req.endMS = endMS
+	} else if strings.TrimSpace(span.Kind) != "time" {
+		// Non-time chunk with no explicit range: there is no span to clip.
+		return mediaClipRequest{}, &toolExecutionError{Code: "INVALID_RANGE", Message: "chunk has no time span; provide start_ms and end_ms", Retryable: false}
+	}
+	return req, nil
+}
+
+// isMediaDocType reports whether docType is a clip-able audio/video type.
+func isMediaDocType(docType string) bool {
+	switch strings.ToLower(strings.TrimSpace(docType)) {
+	case "audio", "video":
+		return true
+	default:
+		return false
+	}
+}
+
+// mediaClipMIMEForPath picks a container MIME type for an extracted clip from
+// the source file extension (stream-copy keeps the source muxer), falling back
+// to a generic audio/video type by doc_type when the extension is unknown.
+func mediaClipMIMEForPath(relPath, docType string) string {
+	switch strings.ToLower(filepath.Ext(strings.TrimSpace(relPath))) {
+	case ".mp3":
+		return "audio/mpeg"
+	case ".wav":
+		return "audio/wav"
+	case ".m4a", ".aac":
+		return "audio/mp4"
+	case ".flac":
+		return "audio/flac"
+	case ".ogg", ".opus":
+		return "audio/ogg"
+	case ".mp4":
+		return "video/mp4"
+	case ".mov":
+		return "video/quicktime"
+	}
+	if strings.EqualFold(strings.TrimSpace(docType), "video") {
+		return "video/mp4"
+	}
+	return "audio/mpeg"
 }
 
 // isBinaryDocTypeForOpenFile reports whether docType is one whose default
@@ -2616,6 +2870,56 @@ func openFileOutputSchema() map[string]interface{} {
 			"truncated": map[string]interface{}{"type": "boolean"},
 		},
 		"required":    []string{"rel_path", "doc_type", "content", "truncated"},
+		"definitions": sharedDefinitions(),
+	}
+}
+
+func openMediaClipInputSchema() map[string]interface{} {
+	return map[string]interface{}{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": map[string]interface{}{
+			"chunk_id": map[string]interface{}{"type": "integer", "description": "Hit chunk id; resolved to its source media and time span."},
+			"rel_path": map[string]interface{}{"type": "string", "minLength": 1},
+			"start_ms": map[string]interface{}{"type": "integer", "minimum": 0},
+			"end_ms":   map[string]interface{}{"type": "integer", "minimum": 0},
+			"return":   map[string]interface{}{"type": "string", "enum": []string{"inline", "reference"}, "default": "inline"},
+		},
+		"anyOf": []interface{}{
+			map[string]interface{}{"required": []string{"chunk_id"}},
+			map[string]interface{}{"required": []string{"rel_path", "start_ms", "end_ms"}},
+		},
+	}
+}
+
+func openMediaClipOutputSchema() map[string]interface{} {
+	return map[string]interface{}{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": map[string]interface{}{
+			"rel_path":           map[string]interface{}{"type": "string"},
+			"doc_type":           map[string]interface{}{"type": "string"},
+			"span":               map[string]interface{}{"$ref": "#/definitions/Span"},
+			"mime_type":          map[string]interface{}{"type": "string"},
+			"duration_ms":        map[string]interface{}{"type": "integer"},
+			"size_bytes":         map[string]interface{}{"type": "integer"},
+			"return":             map[string]interface{}{"type": "string", "enum": []string{"inline", "reference"}},
+			"data":               map[string]interface{}{"type": "string", "contentEncoding": "base64", "description": "Present when return=inline: base64 clip bytes."},
+			"uri":                map[string]interface{}{"type": "string", "description": "Present when return=reference: short-lived fetch URI."},
+			"expires_unix":       map[string]interface{}{"type": "integer", "description": "Present when return=reference: expiry of uri."},
+			"reference_fallback": map[string]interface{}{"type": "string", "description": "Set when reference was requested but inline was returned instead."},
+		},
+		"required": []string{"rel_path", "doc_type", "span", "mime_type", "return"},
+		"allOf": []interface{}{
+			map[string]interface{}{
+				"if":   map[string]interface{}{"properties": map[string]interface{}{"return": map[string]interface{}{"const": "inline"}}, "required": []string{"return"}},
+				"then": map[string]interface{}{"required": []string{"data"}},
+			},
+			map[string]interface{}{
+				"if":   map[string]interface{}{"properties": map[string]interface{}{"return": map[string]interface{}{"const": "reference"}}, "required": []string{"return"}},
+				"then": map[string]interface{}{"required": []string{"uri", "expires_unix"}},
+			},
+		},
 		"definitions": sharedDefinitions(),
 	}
 }

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1289,8 +1289,11 @@ func (s *Server) handleOpenMediaClipTool(ctx context.Context, args map[string]in
 	data, extractErr := extract(ctx, absPath, req.startMS, req.endMS)
 	if extractErr != nil {
 		// Bytes/URLs are never echoed; map every extraction failure (including a
-		// missing ffmpeg) to the non-secret MEDIA_CLIP_FAILED contract.
-		return toolCallResult{}, &toolExecutionError{Code: "MEDIA_CLIP_FAILED", Message: "media clip extraction failed", Retryable: errors.Is(extractErr, avutil.ErrToolNotFound)}
+		// missing ffmpeg) to the non-secret MEDIA_CLIP_FAILED contract. It is
+		// non-retryable: re-issuing the same request will not change the outcome
+		// (a missing ffmpeg needs operator action; a decode failure for these
+		// bytes/span is deterministic) — distinct from OCR_NOT_READY.
+		return toolCallResult{}, &toolExecutionError{Code: "MEDIA_CLIP_FAILED", Message: "media clip extraction failed", Retryable: false}
 	}
 	if len(data) > maxBytes {
 		return toolCallResult{}, &toolExecutionError{Code: "CLIP_TOO_LARGE", Message: fmt.Sprintf("extracted clip is %d bytes, exceeds max %d; request a shorter span", len(data), maxBytes), Retryable: false}

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -16,6 +16,7 @@ const (
 	ToolNameTranscribe       = "dir2mcp_transcribe"
 	ToolNameAnnotate         = "dir2mcp_annotate"
 	ToolNameTranscribeAndAsk = "dir2mcp_transcribe_and_ask"
+	ToolNameOpenMediaClip    = "dir2mcp_open_media_clip"
 )
 
 const (

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -1217,6 +1217,50 @@ func (s *SQLiteStore) TranscriptSpanChunks(ctx context.Context, repID int64) ([]
 	return out, nil
 }
 
+// ChunkMediaSpanByID resolves a chunk id to its source media (rel_path,
+// doc_type) and its time span, for the dir2mcp_open_media_clip tool (SPEC
+// §15.11). The chunk's source is read straight from the chunks row (which
+// carries rel_path/doc_type) and the span from the joined spans row. A missing
+// chunk (or a chunk with no span / a deleted chunk) is reported as
+// model.ErrNotFound so the caller can map it to FILE_NOT_FOUND. The returned
+// span has whatever kind the chunk carries; callers that require a time span
+// validate doc_type/span.Kind themselves.
+func (s *SQLiteStore) ChunkMediaSpanByID(ctx context.Context, chunkID int64) (relPath, docType string, span model.Span, err error) {
+	if chunkID <= 0 {
+		return "", "", model.Span{}, model.ErrNotFound
+	}
+
+	db, err := s.ensureDB(ctx)
+	if err != nil {
+		return "", "", model.Span{}, err
+	}
+	defer s.ReleaseDB()
+
+	row := db.QueryRowContext(
+		ctx,
+		`SELECT c.rel_path, c.doc_type, sp.span_kind, sp.start, sp.end, COALESCE(sp.extra_json, '')
+		 FROM chunks c
+		 JOIN spans sp ON sp.chunk_id = c.chunk_id
+		 WHERE c.chunk_id = ? AND c.deleted = 0
+		 ORDER BY sp.start ASC, sp.end ASC
+		 LIMIT 1`,
+		chunkID,
+	)
+	var (
+		kind      string
+		start     int
+		end       int
+		extraJSON string
+	)
+	if err := row.Scan(&relPath, &docType, &kind, &start, &end, &extraJSON); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", "", model.Span{}, model.ErrNotFound
+		}
+		return "", "", model.Span{}, err
+	}
+	return relPath, docType, spanFromRow(kind, start, end, extraJSON), nil
+}
+
 func (s *SQLiteStore) MarkDocumentDeleted(ctx context.Context, relPath string) error {
 	normalizedPath, err := normalizeRelPath(relPath)
 	if err != nil {

--- a/tests/config/media_clip_config_test.go
+++ b/tests/config/media_clip_config_test.go
@@ -1,0 +1,97 @@
+package tests
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+)
+
+// TestMediaClip_Defaults locks the built-in clip bounds (SPEC §15.11): a
+// 2-minute span cap and a 25 MiB inline byte cap.
+func TestMediaClip_Defaults(t *testing.T) {
+	cfg := config.Default()
+	if cfg.MediaClipMaxDurationMS != config.DefaultMediaClipMaxDurationMS {
+		t.Errorf("media.clip.max_duration_ms default = %d, want %d", cfg.MediaClipMaxDurationMS, config.DefaultMediaClipMaxDurationMS)
+	}
+	if cfg.MediaClipMaxBytes != config.DefaultMediaClipMaxBytes {
+		t.Errorf("media.clip.max_bytes default = %d, want %d", cfg.MediaClipMaxBytes, config.DefaultMediaClipMaxBytes)
+	}
+	if config.DefaultMediaClipMaxDurationMS != 120000 {
+		t.Errorf("DefaultMediaClipMaxDurationMS = %d, want 120000", config.DefaultMediaClipMaxDurationMS)
+	}
+	if config.DefaultMediaClipMaxBytes != 26214400 {
+		t.Errorf("DefaultMediaClipMaxBytes = %d, want 26214400", config.DefaultMediaClipMaxBytes)
+	}
+}
+
+// TestMediaClip_RoundTripsThroughSaveLoad exercises the int plumbing
+// (setIntFileScalar/intPtr, writeInt) for the clip bound scalars.
+func TestMediaClip_RoundTripsThroughSaveLoad(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+
+	cfg := config.Default()
+	cfg.RootDir = "/tmp/repo"
+	cfg.StateDir = "/tmp/repo/.dir2mcp"
+	cfg.MediaClipMaxDurationMS = 30000
+	cfg.MediaClipMaxBytes = 1048576
+	if err := config.SaveFile(path, cfg); err != nil {
+		t.Fatalf("SaveFile failed: %v", err)
+	}
+	loaded, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile failed: %v", err)
+	}
+	if loaded.MediaClipMaxDurationMS != 30000 {
+		t.Errorf("media.clip.max_duration_ms did not round-trip: got %d, want 30000", loaded.MediaClipMaxDurationMS)
+	}
+	if loaded.MediaClipMaxBytes != 1048576 {
+		t.Errorf("media.clip.max_bytes did not round-trip: got %d, want 1048576", loaded.MediaClipMaxBytes)
+	}
+}
+
+// TestMediaClip_NestedYAMLApplies locks the nested media.clip: block so the
+// bound scalars are applied via the YAML scanner (isMapSectionKey("media.clip")).
+func TestMediaClip_NestedYAMLApplies(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+	writeFile(t, path, strings.Join([]string{
+		"root_dir: /tmp/repo",
+		"state_dir: /tmp/repo/.dir2mcp",
+		"media:",
+		"  clip:",
+		"    max_duration_ms: 45000",
+		"    max_bytes: 2097152",
+	}, "\n")+"\n")
+
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile(nested media.clip) = %v, want nil", err)
+	}
+	if cfg.MediaClipMaxDurationMS != 45000 {
+		t.Errorf("nested media.clip.max_duration_ms = %d, want 45000", cfg.MediaClipMaxDurationMS)
+	}
+	if cfg.MediaClipMaxBytes != 2097152 {
+		t.Errorf("nested media.clip.max_bytes = %d, want 2097152", cfg.MediaClipMaxBytes)
+	}
+}
+
+// TestMediaClip_RejectsNegative asserts negative clip bounds are rejected at
+// config-parse time rather than silently clamped.
+func TestMediaClip_RejectsNegative(t *testing.T) {
+	for _, key := range []string{"media_clip_max_duration_ms", "media_clip_max_bytes"} {
+		tmp := t.TempDir()
+		path := filepath.Join(tmp, ".dir2mcp.yaml")
+		writeFile(t, path, strings.Join([]string{
+			"root_dir: /tmp/repo",
+			"state_dir: /tmp/repo/.dir2mcp",
+			key + ": -1",
+		}, "\n")+"\n")
+
+		if _, err := config.LoadFile(path); err == nil {
+			t.Errorf("LoadFile with %s=-1 = nil error, want rejection", key)
+		}
+	}
+}

--- a/tests/mcp/open_media_clip_test.go
+++ b/tests/mcp/open_media_clip_test.go
@@ -133,13 +133,20 @@ func TestOpenMediaClip_ByChunkID_InlineBase64Shape(t *testing.T) {
 	if clip.gotFrom != 1000 || clip.gotTo != 4000 {
 		t.Fatalf("extract called with [%d,%d), want [1000,4000)", clip.gotFrom, clip.gotTo)
 	}
-	// Bytes MUST travel via a typed data item, never a text item.
+	assertSingleMediaContentItem(t, sc, "audio", wantData)
+}
+
+// assertSingleMediaContentItem verifies the tool returned exactly one typed
+// media content item carrying the base64 bytes, and never a text item (media
+// bytes must travel via data/uri only, per SPEC §15.11).
+func assertSingleMediaContentItem(t *testing.T, sc map[string]interface{}, wantType, wantData string) {
+	t.Helper()
 	content, _ := sc["__content"].([]map[string]interface{})
 	if len(content) != 1 {
 		t.Fatalf("content items = %d, want 1: %#v", len(content), content)
 	}
-	if content[0]["type"] != "audio" {
-		t.Fatalf("content item type = %#v, want audio", content[0]["type"])
+	if content[0]["type"] != wantType {
+		t.Fatalf("content item type = %#v, want %s", content[0]["type"], wantType)
 	}
 	if content[0]["data"] != wantData {
 		t.Fatalf("content item data mismatch")

--- a/tests/mcp/open_media_clip_test.go
+++ b/tests/mcp/open_media_clip_test.go
@@ -1,0 +1,307 @@
+package tests
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/avutil"
+	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// clipExtractStub records the last extraction request and returns canned bytes
+// (or an error), so open_media_clip can be exercised without ffmpeg on PATH.
+type clipExtractStub struct {
+	data    []byte
+	err     error
+	gotPath string
+	gotFrom int
+	gotTo   int
+}
+
+func (c *clipExtractStub) extract(_ context.Context, path string, startMS, endMS int) ([]byte, error) {
+	c.gotPath = path
+	c.gotFrom = startMS
+	c.gotTo = endMS
+	if c.err != nil {
+		return nil, c.err
+	}
+	return c.data, nil
+}
+
+// seedAudioChunk inserts an audio document + transcript representation + a chunk
+// carrying a `time` span, returning the chunk id so chunk_id resolution can be
+// exercised.
+func seedAudioChunk(t *testing.T, st *store.SQLiteStore, relPath string, startMS, endMS int) int64 {
+	t.Helper()
+	ctx := context.Background()
+	doc, err := st.GetDocumentByPath(ctx, relPath)
+	if err != nil {
+		t.Fatalf("get document by path %q: %v", relPath, err)
+	}
+	repID, err := st.UpsertRepresentation(ctx, model.Representation{
+		DocID:       doc.DocID,
+		RepType:     "transcript",
+		RepHash:     "rep-hash",
+		CreatedUnix: time.Now().Unix(),
+	})
+	if err != nil {
+		t.Fatalf("upsert representation: %v", err)
+	}
+	chunkID, err := st.InsertChunkWithSpans(ctx, model.Chunk{
+		RepID:   repID,
+		Ordinal: 0,
+		Text:    "hello world",
+	}, []model.Span{{Kind: "time", StartMS: startMS, EndMS: endMS}})
+	if err != nil {
+		t.Fatalf("insert chunk with spans: %v", err)
+	}
+	return chunkID
+}
+
+func decodeClipResult(t *testing.T, resp *http.Response) map[string]interface{} {
+	t.Helper()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d want=200 body=%s", resp.StatusCode, string(body))
+	}
+	var envelope struct {
+		Result struct {
+			IsError           bool                     `json:"isError"`
+			Content           []map[string]interface{} `json:"content"`
+			StructuredContent map[string]interface{}   `json:"structuredContent"`
+		} `json:"result"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if envelope.Result.IsError {
+		t.Fatalf("expected success, got error: %#v", envelope.Result.StructuredContent)
+	}
+	// Carry the content array through for the bytes-channel assertion.
+	envelope.Result.StructuredContent["__content"] = envelope.Result.Content
+	return envelope.Result.StructuredContent
+}
+
+func TestOpenMediaClip_ByChunkID_InlineBase64Shape(t *testing.T) {
+	cfg, st, _ := setupMCPToolStore(t, "voice.mp3", "audio", []byte("RIFF0000WAVEfmt data"))
+	chunkID := seedAudioChunk(t, st, "voice.mp3", 1000, 4000)
+
+	clip := &clipExtractStub{data: []byte("FAKE_MP3_CLIP_BYTES")}
+	server := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st), mcp.WithExtractSegment(clip.extract)).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":40,"method":"tools/call","params":{"name":"dir2mcp_open_media_clip","arguments":{"chunk_id":`+strconv.FormatInt(chunkID, 10)+`}}}`)
+	defer func() { _ = resp.Body.Close() }()
+
+	sc := decodeClipResult(t, resp)
+	if sc["rel_path"] != "voice.mp3" {
+		t.Fatalf("rel_path = %#v, want voice.mp3", sc["rel_path"])
+	}
+	if sc["doc_type"] != "audio" {
+		t.Fatalf("doc_type = %#v, want audio", sc["doc_type"])
+	}
+	if sc["return"] != "inline" {
+		t.Fatalf("return = %#v, want inline", sc["return"])
+	}
+	if sc["mime_type"] != "audio/mpeg" {
+		t.Fatalf("mime_type = %#v, want audio/mpeg", sc["mime_type"])
+	}
+	wantData := base64.StdEncoding.EncodeToString(clip.data)
+	if sc["data"] != wantData {
+		t.Fatalf("data = %#v, want base64(%q)", sc["data"], clip.data)
+	}
+	if sc["size_bytes"].(float64) != float64(len(clip.data)) {
+		t.Fatalf("size_bytes = %#v, want %d", sc["size_bytes"], len(clip.data))
+	}
+	if sc["duration_ms"].(float64) != 3000 {
+		t.Fatalf("duration_ms = %#v, want 3000", sc["duration_ms"])
+	}
+	span, _ := sc["span"].(map[string]interface{})
+	if span == nil || span["kind"] != "time" {
+		t.Fatalf("span = %#v, want time span", sc["span"])
+	}
+	if clip.gotFrom != 1000 || clip.gotTo != 4000 {
+		t.Fatalf("extract called with [%d,%d), want [1000,4000)", clip.gotFrom, clip.gotTo)
+	}
+	// Bytes MUST travel via a typed data item, never a text item.
+	content, _ := sc["__content"].([]map[string]interface{})
+	if len(content) != 1 {
+		t.Fatalf("content items = %d, want 1: %#v", len(content), content)
+	}
+	if content[0]["type"] != "audio" {
+		t.Fatalf("content item type = %#v, want audio", content[0]["type"])
+	}
+	if content[0]["data"] != wantData {
+		t.Fatalf("content item data mismatch")
+	}
+	if _, hasText := content[0]["text"]; hasText {
+		t.Fatalf("content item must not carry a text field for media bytes")
+	}
+}
+
+func TestOpenMediaClip_ExplicitRangeOverridesChunkSpan(t *testing.T) {
+	cfg, st, _ := setupMCPToolStore(t, "voice.mp3", "audio", []byte("data"))
+	chunkID := seedAudioChunk(t, st, "voice.mp3", 1000, 4000)
+
+	clip := &clipExtractStub{data: []byte("X")}
+	server := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st), mcp.WithExtractSegment(clip.extract)).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":41,"method":"tools/call","params":{"name":"dir2mcp_open_media_clip","arguments":{"chunk_id":`+strconv.FormatInt(chunkID, 10)+`,"start_ms":500,"end_ms":1500}}}`)
+	defer func() { _ = resp.Body.Close() }()
+
+	sc := decodeClipResult(t, resp)
+	if sc["duration_ms"].(float64) != 1000 {
+		t.Fatalf("duration_ms = %#v, want 1000 (explicit override)", sc["duration_ms"])
+	}
+	if clip.gotFrom != 500 || clip.gotTo != 1500 {
+		t.Fatalf("extract called with [%d,%d), want [500,1500)", clip.gotFrom, clip.gotTo)
+	}
+}
+
+func TestOpenMediaClip_ByRelPathAndRange(t *testing.T) {
+	cfg, st, _ := setupMCPToolStore(t, "clip.mp4", "video", []byte("data"))
+
+	clip := &clipExtractStub{data: []byte("VIDEO")}
+	server := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st), mcp.WithExtractSegment(clip.extract)).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":42,"method":"tools/call","params":{"name":"dir2mcp_open_media_clip","arguments":{"rel_path":"clip.mp4","start_ms":0,"end_ms":2000}}}`)
+	defer func() { _ = resp.Body.Close() }()
+
+	sc := decodeClipResult(t, resp)
+	if sc["doc_type"] != "video" {
+		t.Fatalf("doc_type = %#v, want video", sc["doc_type"])
+	}
+	if sc["mime_type"] != "video/mp4" {
+		t.Fatalf("mime_type = %#v, want video/mp4", sc["mime_type"])
+	}
+	content, _ := sc["__content"].([]map[string]interface{})
+	if len(content) != 1 || content[0]["type"] != "video" {
+		t.Fatalf("content item = %#v, want one video item", content)
+	}
+}
+
+func TestOpenMediaClip_OverDuration_ClipTooLarge(t *testing.T) {
+	cfg, st, _ := setupMCPToolStore(t, "voice.mp3", "audio", []byte("data"))
+	cfg.MediaClipMaxDurationMS = 5000
+
+	clip := &clipExtractStub{data: []byte("should-not-be-reached")}
+	server := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st), mcp.WithExtractSegment(clip.extract)).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":43,"method":"tools/call","params":{"name":"dir2mcp_open_media_clip","arguments":{"rel_path":"voice.mp3","start_ms":0,"end_ms":6000}}}`)
+	defer func() { _ = resp.Body.Close() }()
+
+	assertToolCallErrorCode(t, resp, "CLIP_TOO_LARGE")
+	if clip.gotPath != "" {
+		t.Fatalf("extraction must not run for an over-duration request; got path %q", clip.gotPath)
+	}
+}
+
+func TestOpenMediaClip_OverBytes_ClipTooLarge(t *testing.T) {
+	cfg, st, _ := setupMCPToolStore(t, "voice.mp3", "audio", []byte("data"))
+	cfg.MediaClipMaxBytes = 8
+
+	clip := &clipExtractStub{data: make([]byte, 64)}
+	server := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st), mcp.WithExtractSegment(clip.extract)).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":44,"method":"tools/call","params":{"name":"dir2mcp_open_media_clip","arguments":{"rel_path":"voice.mp3","start_ms":0,"end_ms":1000}}}`)
+	defer func() { _ = resp.Body.Close() }()
+
+	assertToolCallErrorCode(t, resp, "CLIP_TOO_LARGE")
+}
+
+func TestOpenMediaClip_NonMediaDocType_Unsupported(t *testing.T) {
+	cfg, st, _ := setupMCPToolStore(t, "notes.txt", "text", []byte("plain text"))
+
+	server := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st), mcp.WithExtractSegment((&clipExtractStub{}).extract)).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":45,"method":"tools/call","params":{"name":"dir2mcp_open_media_clip","arguments":{"rel_path":"notes.txt","start_ms":0,"end_ms":1000}}}`)
+	defer func() { _ = resp.Body.Close() }()
+
+	assertToolCallErrorCode(t, resp, "DOC_TYPE_UNSUPPORTED")
+}
+
+func TestOpenMediaClip_ExtractionFailure_MediaClipFailed(t *testing.T) {
+	cfg, st, _ := setupMCPToolStore(t, "voice.mp3", "audio", []byte("data"))
+
+	clip := &clipExtractStub{err: avutil.ErrToolNotFound}
+	server := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st), mcp.WithExtractSegment(clip.extract)).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":46,"method":"tools/call","params":{"name":"dir2mcp_open_media_clip","arguments":{"rel_path":"voice.mp3","start_ms":0,"end_ms":1000}}}`)
+	defer func() { _ = resp.Body.Close() }()
+
+	assertToolCallErrorCode(t, resp, "MEDIA_CLIP_FAILED")
+}
+
+func TestOpenMediaClip_MissingChunk_FileNotFound(t *testing.T) {
+	cfg, st, _ := setupMCPToolStore(t, "voice.mp3", "audio", []byte("data"))
+
+	server := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st), mcp.WithExtractSegment((&clipExtractStub{}).extract)).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":47,"method":"tools/call","params":{"name":"dir2mcp_open_media_clip","arguments":{"chunk_id":999999}}}`)
+	defer func() { _ = resp.Body.Close() }()
+
+	assertToolCallErrorCode(t, resp, "FILE_NOT_FOUND")
+}
+
+func TestOpenMediaClip_ReferenceFallsBackToInline(t *testing.T) {
+	cfg, st, _ := setupMCPToolStore(t, "voice.mp3", "audio", []byte("data"))
+
+	clip := &clipExtractStub{data: []byte("BYTES")}
+	server := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st), mcp.WithExtractSegment(clip.extract)).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":48,"method":"tools/call","params":{"name":"dir2mcp_open_media_clip","arguments":{"rel_path":"voice.mp3","start_ms":0,"end_ms":1000,"return":"reference"}}}`)
+	defer func() { _ = resp.Body.Close() }()
+
+	sc := decodeClipResult(t, resp)
+	if sc["return"] != "inline" {
+		t.Fatalf("return = %#v, want inline (reference fallback)", sc["return"])
+	}
+	if sc["data"] == nil || sc["data"] == "" {
+		t.Fatalf("expected inline data on reference fallback, got %#v", sc["data"])
+	}
+	if _, hasURI := sc["uri"]; hasURI {
+		t.Fatalf("inline fallback must not emit a uri")
+	}
+	if sc["reference_fallback"] == nil || sc["reference_fallback"] == "" {
+		t.Fatalf("expected reference_fallback note, got %#v", sc["reference_fallback"])
+	}
+}
+
+func TestOpenMediaClip_InvalidRange(t *testing.T) {
+	cfg, st, _ := setupMCPToolStore(t, "voice.mp3", "audio", []byte("data"))
+
+	server := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st), mcp.WithExtractSegment((&clipExtractStub{}).extract)).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":49,"method":"tools/call","params":{"name":"dir2mcp_open_media_clip","arguments":{"rel_path":"voice.mp3","start_ms":2000,"end_ms":2000}}}`)
+	defer func() { _ = resp.Body.Close() }()
+
+	assertToolCallErrorCode(t, resp, "INVALID_RANGE")
+}

--- a/tests/mcp/open_media_clip_test.go
+++ b/tests/mcp/open_media_clip_test.go
@@ -86,6 +86,9 @@ func decodeClipResult(t *testing.T, resp *http.Response) map[string]interface{} 
 	if envelope.Result.IsError {
 		t.Fatalf("expected success, got error: %#v", envelope.Result.StructuredContent)
 	}
+	if envelope.Result.StructuredContent == nil {
+		t.Fatalf("expected structuredContent in successful response, got nil")
+	}
 	// Carry the content array through for the bytes-channel assertion.
 	envelope.Result.StructuredContent["__content"] = envelope.Result.Content
 	return envelope.Result.StructuredContent


### PR DESCRIPTION
Implements GitHub issue #264: the `dir2mcp_open_media_clip` MCP tool (SPEC §15.11 + §13.2), the time-media analogue of `open_file`. Given a `chunk_id` (resolved to source media + time span) **or** `rel_path`+`start_ms`+`end_ms`, it extracts the audio/video snippet for that span and returns it inline (base64).

## What landed

**Config** (`internal/config/config.go`)
- New bounds `media.clip.max_duration_ms` (default 120000) and `media.clip.max_bytes` (default 26214400), mirrored end-to-end (Config field, fileConfig `*int`, persistedConfig yaml tags, `buildPersistedConfig`, `Default()`, apply-merge, alias map, `isMapSectionKey("media.clip")`, `setIntFileScalar`, `nonNegativeIntKeys`, save path).
- `setIntFileScalar` refactored from a switch to a key→accessor table (keeps gocyclo ≤15 as keys grow).

**Store** (`internal/store/sqlite_store.go`)
- `ChunkMediaSpanByID(ctx, chunkID) (relPath, docType, span, err)` — chunks JOIN spans; missing/deleted chunk → `model.ErrNotFound`.

**Tool** (`internal/mcp`)
- `protocol.ToolNameOpenMediaClip`, registered in `toolOrder` + `buildToolRegistry`.
- `openMediaClipInputSchema`/`openMediaClipOutputSchema` matching `spec/tools/schemas/open_media_clip.json` (anyOf chunk_id | rel_path+range; conditional-required data vs uri+expires_unix).
- `handleOpenMediaClipTool` + helpers; `storeChunkMediaSpan` capability type-asserted on the store; explicit `start_ms`/`end_ms` override the chunk span (still bounded to that media); rel_path path resolves via `lookupDocumentForTool`/`resolveDocumentPath`.
- Injectable `extractSegment` seam on the Server (defaults to `avutil.ExtractSegment`, `WithExtractSegment` for tests).

**Bounds / error mapping**
- duration `(end-start) > max` → `CLIP_TOO_LARGE` (before extraction); `len(data) > maxBytes` → `CLIP_TOO_LARGE` (after); extraction error (incl. `avutil.ErrToolNotFound`) → `MEDIA_CLIP_FAILED`; non-media doc_type → `DOC_TYPE_UNSUPPORTED`; missing chunk → `FILE_NOT_FOUND`; `start_ms >= end_ms` → `INVALID_RANGE`.

**Inline / reference**
- Inline fully implemented (base64 `data` + `mime_type` + an `audio`/`video`-typed `content[]` item). Media bytes never travel via a `text` item. `return=reference` falls back to inline with a `reference_fallback` note (never errors solely for requesting reference).

## Tests (under `tests/`, not internal)
- `tests/mcp/open_media_clip_test.go`: chunk_id + explicit-range override; inline base64 shape (+ typed content item, no text leak); over-duration & over-bytes → `CLIP_TOO_LARGE`; non-media → `DOC_TYPE_UNSUPPORTED`; stubbed extraction failure → `MEDIA_CLIP_FAILED`; missing chunk → `FILE_NOT_FOUND`; reference→inline fallback; invalid range.
- `tests/config/media_clip_config_test.go`: defaults, save/load round-trip, nested YAML, negative rejection.

`make check` passes locally. `dirstral-spec` submodule is **not** re-pinned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added media clip extraction capability to extract audio/video snippets using configurable time spans and size limits.
  * Introduced new configuration options to set maximum duration and file size for extracted clips.

* **Documentation**
  * Updated documentation to reflect new media clip extraction feature.

* **Tests**
  * Added comprehensive test coverage for media clip configuration and extraction functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->