### PR TITLE
feat: speaker diarization (speaker-attributed transcripts) (#266)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -289,6 +289,19 @@ type Config struct {
 	// Default OFF.
 	MediaVAD bool
 
+	// MediaDiarizeEnabled is the TRI-STATE speaker-diarization opt-out/in
+	// (config `media.diarize.enabled`, SPEC §8.6.8). It is a *bool to distinguish
+	// the three states the spec requires:
+	//   - nil (omitted): AUTO — diarization auto-enables when the active STT
+	//     backend advertises CapDiarize (capability-driven activation).
+	//   - false: force OFF regardless of backend capability (the kill switch).
+	//   - true: REQUIRE diarization — CONFIG_INVALID if no configured STT backend
+	//     advertises the capability.
+	// Default OFF (a backend without the capability never auto-enables). It is a
+	// *bool here (not in the overrides block) because the tri-state must survive
+	// all the way to runtime, not be flattened to a plain bool at merge time.
+	MediaDiarizeEnabled *bool
+
 	// MediaAudioWindowSec / MediaVideoWindowSec configure the direct-embedding
 	// media chunk window length, in seconds, for audio and video respectively
 	// (SPEC 8.1.7; config `media.audio_window_sec` / `media.video_window_sec`).
@@ -420,6 +433,7 @@ type fileConfig struct {
 	MediaTrimLeadingSilence   *bool
 	MediaSilenceThresholdDB   *float64
 	MediaVAD                  *bool
+	MediaDiarizeEnabled       *bool
 	MediaAudioWindowSec       *int
 	MediaVideoWindowSec       *int
 	MediaClipMaxDurationMS    *int
@@ -524,8 +538,12 @@ type persistedConfig struct {
 	MediaVideoWindowSec       int           `yaml:"media_video_window_sec"`
 	MediaClipMaxDurationMS    int           `yaml:"media_clip_max_duration_ms"`
 	MediaClipMaxBytes         int           `yaml:"media_clip_max_bytes"`
-	ServerTLSCertFile         string        `yaml:"server_tls_cert_file"`
-	ServerTLSKeyFile          string        `yaml:"server_tls_key_file"`
+	// MediaDiarizeEnabled is the tri-state diarization opt (SPEC §8.6.8): a
+	// *bool so the snapshot can round-trip omitted (nil) vs. false vs. true
+	// without collapsing the auto/off distinction.
+	MediaDiarizeEnabled *bool  `yaml:"media_diarize_enabled,omitempty"`
+	ServerTLSCertFile   string `yaml:"server_tls_cert_file"`
+	ServerTLSKeyFile    string `yaml:"server_tls_key_file"`
 
 	// The following fields configure optional x402 payment gating.  The
 	// facilitator token itself is treated like any other sensitive API key:
@@ -760,6 +778,7 @@ func buildPersistedConfig(cfg *Config) persistedConfig {
 		MediaTrimLeadingSilence:   cfg.MediaTrimLeadingSilence,
 		MediaSilenceThresholdDB:   cfg.MediaSilenceThresholdDB,
 		MediaVAD:                  cfg.MediaVAD,
+		MediaDiarizeEnabled:       copyBoolPtr(cfg.MediaDiarizeEnabled),
 		MediaAudioWindowSec:       cfg.MediaAudioWindowSec,
 		MediaVideoWindowSec:       cfg.MediaVideoWindowSec,
 		MediaClipMaxDurationMS:    cfg.MediaClipMaxDurationMS,
@@ -1406,6 +1425,11 @@ func applyMediaFileParsed(cfg *Config, fc fileConfig) {
 	if fc.MediaVAD != nil {
 		cfg.MediaVAD = *fc.MediaVAD
 	}
+	if fc.MediaDiarizeEnabled != nil {
+		// Tri-state: copy the pointer (a fresh copy) so an explicit false/true
+		// from the file is preserved as a distinct state from omitted (nil).
+		cfg.MediaDiarizeEnabled = copyBoolPtr(fc.MediaDiarizeEnabled)
+	}
 	if fc.MediaAudioWindowSec != nil {
 		cfg.MediaAudioWindowSec = *fc.MediaAudioWindowSec
 	}
@@ -1690,6 +1714,7 @@ var configKeyAliases = map[string]string{
 	"media_trim_leading_silence":           "media.trim_leading_silence",
 	"media_silence_threshold_db":           "media.silence_threshold_db",
 	"media_vad":                            "media.vad",
+	"media_diarize_enabled":                "media.diarize.enabled",
 	"media_audio_window_sec":               "media.audio_window_sec",
 	"media_video_window_sec":               "media.video_window_sec",
 	"media_clip_max_duration_ms":           "media.clip.max_duration_ms",
@@ -1750,7 +1775,7 @@ func isMapSectionKey(key string) bool {
 		return true
 	case "source", "source.s3":
 		return true
-	case "media", "media.variants", "media.translate", "media.clip":
+	case "media", "media.variants", "media.translate", "media.clip", "media.diarize":
 		return true
 	case "index.pgvector":
 		return true
@@ -1802,6 +1827,7 @@ var boolFileScalarTargets = map[string]func(*fileConfig) **bool{
 		return &c.MediaTrimLeadingSilence
 	},
 	"media.vad":                func(c *fileConfig) **bool { return &c.MediaVAD },
+	"media.diarize.enabled":    func(c *fileConfig) **bool { return &c.MediaDiarizeEnabled },
 	"x402_tools_call_enabled":  func(c *fileConfig) **bool { return &c.X402ToolsCallEnabled },
 	"retrieval.hybrid.enabled": func(c *fileConfig) **bool { return &c.RetrievalHybridEnabled },
 	"dedup.retrieval":          func(c *fileConfig) **bool { return &c.DedupRetrieval },
@@ -2219,6 +2245,12 @@ func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	writeBool("media_trim_leading_silence", cfg.MediaTrimLeadingSilence)
 	writeScalar("media_silence_threshold_db", strconv.FormatFloat(cfg.MediaSilenceThresholdDB, 'f', -1, 64))
 	writeBool("media_vad", cfg.MediaVAD)
+	// Tri-state (SPEC §8.6.8): only emit when explicitly set so an omitted
+	// (auto) diarization config round-trips as omitted rather than collapsing to
+	// false. nil means auto-enable when the backend advertises the capability.
+	if cfg.MediaDiarizeEnabled != nil {
+		writeBool("media_diarize_enabled", *cfg.MediaDiarizeEnabled)
+	}
 	writeInt("media_audio_window_sec", cfg.MediaAudioWindowSec)
 	writeInt("media_video_window_sec", cfg.MediaVideoWindowSec)
 	writeInt("media_clip_max_duration_ms", cfg.MediaClipMaxDurationMS)
@@ -2274,6 +2306,17 @@ func strPtr(value string) *string { return &value }
 
 // boolPtr returns a pointer to value.
 func boolPtr(value bool) *bool { return &value }
+
+// copyBoolPtr returns a new pointer to the same bool value, or nil when the
+// input is nil. It preserves a tri-state *bool (nil / false / true) across a
+// snapshot copy without aliasing the original pointer.
+func copyBoolPtr(value *bool) *bool {
+	if value == nil {
+		return nil
+	}
+	v := *value
+	return &v
+}
 
 // intPtr returns a pointer to value.
 func intPtr(value int) *int { return &value }
@@ -2609,6 +2652,10 @@ func (c *Config) Validate() error {
 	}
 
 	if err := c.validateMediaTranslate(); err != nil {
+		return err
+	}
+
+	if err := c.validateMediaDiarize(); err != nil {
 		return err
 	}
 

--- a/internal/config/providers.go
+++ b/internal/config/providers.go
@@ -325,6 +325,106 @@ func (r ProviderResolution) ResolveExplicit(cap provider.Capability, explicit st
 	return r.applyModelOverrides(cap, p), nil
 }
 
+// resolveSTTProfileForCapability resolves the active STT provider profile the
+// same way the ingest service does (SPEC 8.1.3), so config-time diarization
+// gating observes the exact backend that will actually transcribe. It returns
+// ok=false when STT is off, when no STT-capable profile resolves, or when the
+// selector is unrecognised. Kept package-local and selector-table-driven so its
+// cyclomatic complexity stays flat.
+func resolveSTTProfileForCapability(cfg Config) (provider.Profile, bool) {
+	sel := strings.ToLower(strings.TrimSpace(cfg.STTProvider))
+	if sel == "" {
+		sel = "auto"
+	}
+	switch sel {
+	case "off", "none", "disabled":
+		return provider.Profile{}, false
+	}
+	r := cfg.Providers()
+	explicitBySelector := map[string]string{
+		"mistral":    "mistral-ocr",
+		"elevenlabs": "elevenlabs",
+		"whisper":    "whisper",
+	}
+	var (
+		prof provider.Profile
+		err  error
+	)
+	if sel == "auto" {
+		prof, err = r.Resolve(provider.CapSTT)
+	} else if explicit, ok := explicitBySelector[sel]; ok {
+		prof, err = r.ResolveExplicit(provider.CapSTT, explicit, true)
+	} else {
+		return provider.Profile{}, false
+	}
+	if err != nil {
+		return provider.Profile{}, false
+	}
+	return prof, true
+}
+
+// diarizeStateForProfile resolves the effective diarization activation for the
+// given (already-resolved) STT profile under the tri-state config (SPEC §8.6.8):
+//
+//   - enabled == nil (auto): active iff the backend advertises CapDiarize
+//     (capability-driven activation).
+//   - enabled == false: always inactive (the kill switch).
+//   - enabled == true: REQUIRED — active when the backend is capable; when it is
+//     NOT, capable is false and the caller (ValidateDiarization) maps that to
+//     CONFIG_INVALID.
+//
+// It returns (active, capable): active is the resolved on/off; capable reports
+// whether the backend advertises the capability (used to detect the
+// required-but-incapable error).
+func diarizeStateForProfile(enabled *bool, prof provider.Profile) (active, capable bool) {
+	capable = provider.Can(prof.Kind, provider.CapDiarize) != provider.Unsupported
+	switch {
+	case enabled != nil && !*enabled:
+		return false, capable
+	case enabled != nil && *enabled:
+		return capable, capable
+	default: // auto
+		return capable, capable
+	}
+}
+
+// DiarizationActive reports whether speaker diarization is active for
+// model-derived transcripts given the config and the resolved STT profile (SPEC
+// §8.6.8). It is the single decision point the ingest service uses to decide
+// whether to record diarize provenance and fold the diarize identity into the
+// transcript derivation identity. It never errors: the required-but-incapable
+// case is surfaced as CONFIG_INVALID by ValidateDiarization at startup, not here.
+func DiarizationActive(cfg Config, prof provider.Profile) bool {
+	active, _ := diarizeStateForProfile(cfg.MediaDiarizeEnabled, prof)
+	return active
+}
+
+// validateMediaDiarize enforces the diarization config invariants (SPEC §8.6.8):
+// diarization requires a diarization-capable STT backend. When
+// media.diarize.enabled is true but no configured STT backend advertises the
+// capability, startup MUST fail CONFIG_INVALID with remediation. The auto (nil)
+// and explicit-false states never fail: auto simply stays off on an incapable
+// backend, and false forces it off. With STT off entirely, an explicit true is
+// also CONFIG_INVALID (there is no backend to diarize).
+func (c *Config) validateMediaDiarize() error {
+	enabled := c.MediaDiarizeEnabled
+	// Only an explicit `true` can fail validation; auto/false are always valid.
+	if enabled == nil || !*enabled {
+		return nil
+	}
+	prof, ok := resolveSTTProfileForCapability(*c)
+	if !ok {
+		return fmt.Errorf(
+			"CONFIG_INVALID: media.diarize.enabled=true requires a diarization-capable STT backend, but speech-to-text is not configured; set stt.provider to a diarization-capable backend (e.g. a self-hosted WhisperX/pyannote endpoint via stt.provider=whisper) or remove media.diarize.enabled")
+	}
+	if _, capable := diarizeStateForProfile(enabled, prof); !capable {
+		return fmt.Errorf(
+			"CONFIG_INVALID: media.diarize.enabled=true but the active STT provider %q (kind %q) does not advertise speaker diarization; use a diarization-capable backend (e.g. a self-hosted WhisperX/pyannote endpoint via stt.provider=whisper), set media.diarize.enabled=false, or omit it to auto-enable only when supported",
+			prof.Name, prof.Kind)
+	}
+	return nil
+}
+
 // readSnapshotEmbedIdentity returns the embed_identity recorded in the
 // effective snapshot for stateDir, or "" if there is no snapshot / no
 // recorded identity (a fresh index — VerifyEmbedIdentity treats that as

--- a/internal/index/embedding_worker.go
+++ b/internal/index/embedding_worker.go
@@ -555,22 +555,28 @@ func mediaMIMEType(relPath string) string {
 // payloadFromTask projects a chunk task's metadata into the IndexPayload the
 // index stores alongside the vector (issue #247). The span's time bounds are
 // surfaced as StartMS/EndMS so a backend filtering on media windows has them
-// without re-reading the span; Language/Speaker are not carried on ChunkMetadata
-// today and are left empty for backends to populate when available.
+// without re-reading the span; Speaker/SpeakerLabel are likewise surfaced from a
+// diarized transcript's "time" span (SPEC §8.6.8) so a FilteringIndex can push
+// down a speaker filter without re-reading the span. They are empty on every
+// non-diarized transcript, so payloads are byte-identical to today. Language is
+// not carried on ChunkMetadata today and is left empty for backends to populate
+// when available.
 func payloadFromTask(t model.ChunkTask) model.IndexPayload {
 	meta := t.Metadata
 	return model.IndexPayload{
-		ChunkID:  meta.ChunkID,
-		RelPath:  meta.RelPath,
-		DocType:  meta.DocType,
-		RepType:  meta.RepType,
-		Modality: meta.Modality,
-		Title:    meta.Title,
-		StartMS:  meta.Span.StartMS,
-		EndMS:    meta.Span.EndMS,
-		Snippet:  meta.Snippet,
-		Span:     meta.Span,
-		MediaRef: meta.MediaRef,
+		ChunkID:      meta.ChunkID,
+		RelPath:      meta.RelPath,
+		DocType:      meta.DocType,
+		RepType:      meta.RepType,
+		Modality:     meta.Modality,
+		Title:        meta.Title,
+		StartMS:      meta.Span.StartMS,
+		EndMS:        meta.Span.EndMS,
+		Speaker:      meta.Span.Speaker,
+		SpeakerLabel: meta.Span.SpeakerLabel,
+		Snippet:      meta.Snippet,
+		Span:         meta.Span,
+		MediaRef:     meta.MediaRef,
 	}
 }
 

--- a/internal/index/pgvectorindex/sql.go
+++ b/internal/index/pgvectorindex/sql.go
@@ -249,11 +249,14 @@ LIMIT %s`, q, qualifiedTable(schema, table), where, q, limitPH)
 }
 
 // CanFilterFilter reports whether every active predicate of the filter is
-// expressible in SQL. PathGlob is the only unsupported predicate; when it is
-// set the backend cannot push down and retrieval must filter in Go. This is the
-// pure decision function behind the FilteringIndex.CanFilter method.
+// expressible in SQL. PathGlob and Speaker are the unsupported predicates; when
+// either is set the backend cannot push down and retrieval must filter in Go.
+// Speaker (diarized transcript filter, SPEC §8.6.8) is intentionally left to the
+// Go-side matchFilters re-check so speaker filtering stays on the single,
+// authoritative model.Filter.Match path. This is the pure decision function
+// behind the FilteringIndex.CanFilter method.
 func CanFilterFilter(f model.Filter) bool {
-	return f.PathGlob == ""
+	return f.PathGlob == "" && strings.TrimSpace(f.Speaker) == ""
 }
 
 // MarshalPayload serialises the full IndexPayload (including the nested Span)

--- a/internal/index/qdrantindex/filter.go
+++ b/internal/index/qdrantindex/filter.go
@@ -32,6 +32,14 @@ func canFilter(filter model.Filter) bool {
 	if filter.PathPrefix != "" || filter.PathGlob != "" {
 		return false
 	}
+	// Speaker (diarized transcript filter, SPEC §8.6.8) is evaluated by the
+	// Go-side matchFilters re-check, mirroring the path predicates: decline
+	// push-down so retrieval applies it after materialisation. Declining is
+	// always safe (overfetch-then-filter), and it keeps speaker filtering on the
+	// single, authoritative model.Filter.Match path.
+	if strings.TrimSpace(filter.Speaker) != "" {
+		return false
+	}
 	return true
 }
 

--- a/internal/ingest/derivation.go
+++ b/internal/ingest/derivation.go
@@ -22,20 +22,76 @@ import (
 // passes so a pre-upgrade corpus (reps written before provenance was persisted)
 // is never mass re-derived on first upgrade.
 
+// Diarizer is the injectable model-driven speaker-diarization seam (SPEC §8.6.8).
+// Given the source media bytes and the transcript's time-spanned segments, it
+// returns a speaker id (and optional label) per segment ordinal. dir2mcp ships no
+// default implementation: the diarization-capable backend (self-hosted
+// WhisperX/pyannote) is integrated out-of-band and injected via SetDiarizer. The
+// returned ids MUST be stable and deterministic across re-runs of the same media
+// with the same backend (§8.6.8); an implementation that cannot attribute a
+// segment returns an empty id for it (that segment degrades to un-attributed).
+type Diarizer interface {
+	Diarize(ctx context.Context, media []byte, segments []SpeakerSegment) ([]SpeakerAttribution, error)
+}
+
+// SpeakerSegment is one transcript segment handed to a Diarizer: its [start,end]
+// in ms and its text. It is a stable, dependency-light shape so the seam does not
+// expose internal chunk types.
+type SpeakerSegment struct {
+	StartMS int
+	EndMS   int
+	Text    string
+}
+
+// SpeakerAttribution is a Diarizer's result for one segment (by position): the
+// stable speaker id and an optional human-readable label. An empty ID means the
+// segment is left un-attributed.
+type SpeakerAttribution struct {
+	ID    string
+	Label string
+}
+
+// activeDiarizeIdentity is the diarization derivation identity of the currently
+// configured diarizer (SPEC §8.6.7/§8.6.8), in the canonical derivationIdentity
+// form. Empty when diarization is inactive, so it folds nothing into the
+// transcript identity and never forces a re-derivation on a non-diarized corpus.
+func (s *Service) activeDiarizeIdentity() string {
+	if !s.diarizeActive {
+		return ""
+	}
+	return derivationIdentity(string(provider.CapDiarize),
+		s.diarizeProvider, s.diarizeModel, "", "")
+}
+
 // sttTranscriptMetaJSON builds the meta_json persisted on a bare
 // machine-transcribed transcript representation. It records source=stt plus the
 // active STT derivation identity (provider/model/language, §5.2/§8.6.7) so a
-// later STT model swap can be detected and the transcript re-derived. Fields are
+// later STT model swap can be detected and the transcript re-derived. When
+// diarization is active it additionally records diarized + the diarize
+// provider/model (§8.6.8) so a diarize-backend swap re-derives too. Fields are
 // omitted (omitempty) when unset, so a setup with no resolved STT identity still
 // produces valid meta_json (and an empty recorded identity that the gate treats
 // as "always passes").
-func (s *Service) sttTranscriptMetaJSON() (string, error) {
+func (s *Service) sttTranscriptMetaJSON(speakers []Speaker) (string, error) {
 	meta := transcriptMeta{
 		Source:     sttSource,
 		Language:   strings.TrimSpace(s.transcriptLanguage),
 		Timestamps: true,
 		Provider:   strings.TrimSpace(s.sttProvider),
 		Model:      strings.TrimSpace(s.sttModel),
+	}
+	if s.diarizeActive {
+		// Record the diarize backend identity whenever diarization is active so a
+		// backend/model swap re-derives the transcript (§8.6.7), even before any
+		// attribution lands. `diarized` and the speakers set reflect the
+		// attribution actually present on the segments (§5.2): a capable backend
+		// with no diarizer wired yet yields no speakers, so diarized stays false.
+		meta.DiarizeProvider = strings.TrimSpace(s.diarizeProvider)
+		meta.DiarizeModel = strings.TrimSpace(s.diarizeModel)
+		if len(speakers) > 0 {
+			meta.Diarized = true
+			meta.Speakers = speakers
+		}
 	}
 	encoded, err := json.Marshal(meta)
 	if err != nil {
@@ -44,14 +100,28 @@ func (s *Service) sttTranscriptMetaJSON() (string, error) {
 	return string(encoded), nil
 }
 
-// activeTranscriptIdentity is the STT derivation identity of the currently
-// configured transcriber, in the same canonical form derivationIdentity emits
-// for a recorded transcript representation. It is compared against the identity
-// read from a stored transcript to decide whether an STT model swap has made the
-// transcript stale (§8.6.7).
+// activeTranscriptIdentity is the STT (+ diarize, when active) derivation
+// identity of the currently configured transcriber, in the same canonical form
+// derivationIdentity emits for a recorded transcript representation. It is
+// compared against the identity read from a stored transcript to decide whether
+// an STT — or diarization (§8.6.8) — model swap has made the transcript stale
+// (§8.6.7). The diarize identity is appended only when diarization is active, so
+// a non-diarized corpus's identity is unchanged.
 func (s *Service) activeTranscriptIdentity() string {
-	return derivationIdentity(string(provider.CapSTT),
-		s.sttProvider, s.sttModel, "", s.transcriptLanguage)
+	return joinTranscriptIdentity(
+		derivationIdentity(string(provider.CapSTT), s.sttProvider, s.sttModel, "", s.transcriptLanguage),
+		s.activeDiarizeIdentity())
+}
+
+// joinTranscriptIdentity appends a non-empty diarize identity to the STT
+// identity with a stable separator, so a diarize-backend change re-derives the
+// transcript (§8.6.7/§8.6.8). An empty diarize identity returns the STT identity
+// unchanged, keeping a non-diarized transcript's recorded identity byte-stable.
+func joinTranscriptIdentity(sttIdentity, diarizeIdentity string) string {
+	if strings.TrimSpace(diarizeIdentity) == "" {
+		return sttIdentity
+	}
+	return sttIdentity + "#" + diarizeIdentity
 }
 
 // activeOCRIdentity is the OCR/extraction derivation identity of the currently
@@ -238,8 +308,20 @@ func transcriptIdentityFromMeta(metaJSON string) (string, bool) {
 	if strings.TrimSpace(meta.Provider) == "" && strings.TrimSpace(meta.Model) == "" {
 		return "", false
 	}
-	return derivationIdentity(string(provider.CapSTT),
-		meta.Provider, meta.Model, meta.ModelVersion, meta.Language), true
+	sttIdentity := derivationIdentity(string(provider.CapSTT),
+		meta.Provider, meta.Model, meta.ModelVersion, meta.Language)
+	// Fold the recorded diarize identity (§8.6.8) into the transcript identity so
+	// a diarize provider/model change is detected as stale. Only model-derived
+	// diarization records a provider/model; a sidecar-supplied <v> attribution
+	// records diarized:true with NO provider/model, so it folds in nothing and is
+	// never invalidated by a diarize-backend change (mirrors §8.6.7 for authored
+	// sources). A pre-upgrade transcript with neither field is unchanged.
+	diarizeIdentity := ""
+	if strings.TrimSpace(meta.DiarizeProvider) != "" || strings.TrimSpace(meta.DiarizeModel) != "" {
+		diarizeIdentity = derivationIdentity(string(provider.CapDiarize),
+			meta.DiarizeProvider, meta.DiarizeModel, "", "")
+	}
+	return joinTranscriptIdentity(sttIdentity, diarizeIdentity), true
 }
 
 // ocrIdentityFromMeta builds the recorded OCR/extraction derivation identity of

--- a/internal/ingest/represent.go
+++ b/internal/ingest/represent.go
@@ -1183,14 +1183,26 @@ func chunkSubtitleCues(cues []subtitle.Cue) []chunkSegment {
 // A cue empty after filtering is dropped (it never contributes to a chunk), so
 // it neither adds text nor extends a merged chunk's time span. A nil/inactive
 // filter is a no-op, leaving the output identical to the unfiltered path.
+//
+// When cues carry WebVTT <v Name> speaker attribution (SPEC §8.6.8) the merge is
+// additionally split on speaker boundary so every produced chunk has a single
+// speaker, and the chunk's "time" span carries a stable per-transcript speaker
+// id (S1, S2, …) plus the human-readable label. Speaker ids are assigned in
+// first-appearance order over the (caller-sorted, by start time) cues, so they
+// are deterministic and stable across re-indexing. Speaker attribution is
+// metadata only: it never changes chunk text or span bounds, and a transcript
+// with no <v> tags produces byte-identical output to before.
 func chunkSubtitleCuesFiltered(cues []subtitle.Cue, filter *subtitle.WordFilter) []chunkSegment {
 	out := make([]chunkSegment, 0, len(cues))
+	ids := newSpeakerIDAssigner()
 	var (
-		buf      []string
-		startMS  int
-		endMS    int
-		haveOpen bool
-		bufLen   int
+		buf          []string
+		startMS      int
+		endMS        int
+		haveOpen     bool
+		bufLen       int
+		speaker      string // stable id (S1…) of the open chunk; "" when undiarized
+		speakerLabel string // human-readable name of the open chunk
 	)
 	flush := func() {
 		if !haveOpen {
@@ -1198,7 +1210,7 @@ func chunkSubtitleCuesFiltered(cues []subtitle.Cue, filter *subtitle.WordFilter)
 		}
 		text := strings.TrimSpace(strings.Join(buf, "\n"))
 		if text != "" {
-			span := model.Span{Kind: "time", StartMS: startMS, EndMS: endMS}
+			span := model.Span{Kind: "time", StartMS: startMS, EndMS: endMS, Speaker: speaker, SpeakerLabel: speakerLabel}
 			if span.EndMS <= span.StartMS {
 				span.EndMS = span.StartMS + 1
 			}
@@ -1207,6 +1219,8 @@ func chunkSubtitleCuesFiltered(cues []subtitle.Cue, filter *subtitle.WordFilter)
 		buf = buf[:0]
 		bufLen = 0
 		haveOpen = false
+		speaker = ""
+		speakerLabel = ""
 	}
 
 	for _, cue := range cues {
@@ -1217,6 +1231,7 @@ func chunkSubtitleCuesFiltered(cues []subtitle.Cue, filter *subtitle.WordFilter)
 		if text == "" {
 			continue
 		}
+		cueID, cueLabel := ids.assign(cue.Speaker)
 		cueLen := utf8.RuneCountInString(text)
 		// flush() joins buffered cue texts with "\n", so budget one rune for the
 		// separator that will precede this cue when the buffer is non-empty;
@@ -1228,15 +1243,18 @@ func chunkSubtitleCuesFiltered(cues []subtitle.Cue, filter *subtitle.WordFilter)
 			sepLen = 1
 		}
 		// Start a new chunk when the buffer (plus the join separator) would
-		// overflow the transcript chunk size; a single oversized cue still becomes
+		// overflow the transcript chunk size OR when the speaker changes (so a
+		// chunk never mixes two speakers); a single oversized cue still becomes
 		// its own chunk.
-		if haveOpen && bufLen+sepLen+cueLen > TranscriptChunkMaxChars {
+		if haveOpen && (bufLen+sepLen+cueLen > TranscriptChunkMaxChars || cueID != speaker) {
 			flush()
 			sepLen = 0
 		}
 		if !haveOpen {
 			startMS = cue.StartMS
 			haveOpen = true
+			speaker = cueID
+			speakerLabel = cueLabel
 		}
 		buf = append(buf, text)
 		bufLen += sepLen + cueLen
@@ -1244,6 +1262,37 @@ func chunkSubtitleCuesFiltered(cues []subtitle.Cue, filter *subtitle.WordFilter)
 	}
 	flush()
 	return out
+}
+
+// speakerIDAssigner maps a human-readable WebVTT voice name to a stable
+// per-transcript speaker id (S1, S2, …) in first-appearance order (SPEC §8.6.8).
+// Because the cues it is fed are sorted by start time, the mapping is
+// deterministic and reproducible across re-indexing of the same transcript.
+type speakerIDAssigner struct {
+	byName map[string]string
+	next   int
+}
+
+func newSpeakerIDAssigner() *speakerIDAssigner {
+	return &speakerIDAssigner{byName: map[string]string{}}
+}
+
+// assign returns the stable id and the human-readable label for a cue's voice
+// name. An empty name yields ("", "") so an undiarized cue carries no
+// attribution. The first time a name is seen it is allocated the next S-id; the
+// same name always maps to the same id thereafter.
+func (a *speakerIDAssigner) assign(name string) (id, label string) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", ""
+	}
+	if existing, ok := a.byName[name]; ok {
+		return existing, name
+	}
+	a.next++
+	id = fmt.Sprintf("S%d", a.next)
+	a.byName[name] = id
+	return id, name
 }
 
 // ChunkSubtitleCues exposes chunkSubtitleCues for tests, converting the

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -83,6 +83,27 @@ type Service struct {
 	sttProvider string
 	sttModel    string
 
+	// diarizeActive reports whether speaker diarization is active for
+	// model-derived transcripts (SPEC §8.6.8): true only when diarization is
+	// enabled (tri-state) AND the active STT backend advertises CapDiarize.
+	// When active, diarizeProvider/diarizeModel record the diarization-capable
+	// backend's profile name and STT model so a model-derived transcript carries
+	// its diarize derivation identity (§8.6.7) and a backend change re-derives.
+	// All three are zero when diarization is off (the default), making the STT
+	// transcript path byte-identical to today.
+	diarizeActive   bool
+	diarizeProvider string
+	diarizeModel    string
+
+	// diarizer is the optional, injectable model-driven diarization seam
+	// (SPEC §8.6.8). dir2mcp ships NO default diarizer: the capable backend
+	// (self-hosted WhisperX/pyannote) is integrated out-of-band and wired in via
+	// SetDiarizer. When nil and diarization is active, model-derived transcripts
+	// remain un-attributed (sidecar <v> attribution still works); the config gate
+	// guarantees diarize:true without a capable backend is CONFIG_INVALID, so a
+	// nil diarizer here is never a silent partial-config.
+	diarizer Diarizer
+
 	// translator is the chat/generation client used to translate transcripts
 	// into the configured target language(s) (SPEC §8.6.2). It is the chat
 	// capability binding resolved at construction, or nil when translation is
@@ -240,6 +261,16 @@ func NewService(cfg config.Config, store model.Store) (*Service, error) {
 	if prof, ok := resolveSTTProfile(cfg); ok {
 		svc.sttProvider = strings.TrimSpace(prof.Name)
 		svc.sttModel = strings.TrimSpace(prof.STTModel)
+		// Resolve the diarization binding (SPEC §8.6.8) from the SAME STT profile:
+		// diarization is active when enabled (tri-state) AND the backend advertises
+		// CapDiarize. The diarize derivation identity (§8.6.7) is the backend's
+		// provider name + STT model, so a backend/model swap re-derives. When
+		// inactive the fields stay empty and the STT path is unchanged.
+		if config.DiarizationActive(cfg, prof) {
+			svc.diarizeActive = true
+			svc.diarizeProvider = strings.TrimSpace(prof.Name)
+			svc.diarizeModel = strings.TrimSpace(prof.STTModel)
+		}
 	}
 	// Resolve the optional transcript-translation binding (SPEC §8.6.2). When
 	// translation is enabled we resolve the chat capability and build a
@@ -621,6 +652,21 @@ func (s *Service) SetTranscriptLanguage(language string) {
 func (s *Service) SetSTTIdentity(providerName, model string) {
 	s.sttProvider = strings.TrimSpace(providerName)
 	s.sttModel = strings.TrimSpace(model)
+}
+
+// SetDiarizer wires the optional model-driven diarization seam (SPEC §8.6.8) and
+// records the diarize derivation identity (provider name + model, §8.6.7). It is
+// the injection point for an out-of-band diarization-capable backend (dir2mcp
+// ships no default diarizer). Passing a non-nil diarizer activates the
+// model-driven attribution path; the provider/model are written into a diarized
+// transcript's meta_json and folded into its derivation identity. Values are
+// trimmed. Primarily for wiring and tests; production resolution happens in
+// NewService from the STT profile + diarize config.
+func (s *Service) SetDiarizer(d Diarizer, providerName, modelName string) {
+	s.diarizer = d
+	s.diarizeActive = d != nil
+	s.diarizeProvider = strings.TrimSpace(providerName)
+	s.diarizeModel = strings.TrimSpace(modelName)
 }
 
 // SetCorpusFS overrides the corpus filesystem backend used for discovery and
@@ -1970,7 +2016,20 @@ func (s *Service) generateTranscriptRepresentation(ctx context.Context, doc mode
 		Duration:         duration,
 	})
 
-	metaJSON, err := s.sttTranscriptMetaJSON()
+	segments := chunkTranscriptByTimeWithWordsFiltered(transcriptText, words, s.captionWordFilter())
+	if len(segments) == 0 {
+		return nil
+	}
+	// Optional model-driven speaker diarization (SPEC §8.6.8): when active and a
+	// diarizer is injected, attribute each segment to a speaker. This is metadata
+	// only — it stamps span.Speaker/SpeakerLabel and never changes chunk text or
+	// span bounds. With no diarizer (the default), this is a no-op and the
+	// transcript is un-attributed exactly as today (sidecar <v> attribution is
+	// unaffected). Run BEFORE the meta is built so diarized/speakers reflect the
+	// attribution that is actually present on the segments.
+	s.applyDiarization(ctx, doc, content, segments)
+
+	metaJSON, err := s.sttTranscriptMetaJSON(distinctSpeakers(segments))
 	if err != nil {
 		return fmt.Errorf("marshal transcript meta: %w", err)
 	}
@@ -1987,10 +2046,6 @@ func (s *Service) generateTranscriptRepresentation(ctx context.Context, doc mode
 		return fmt.Errorf("upsert transcript representation: %w", err)
 	}
 
-	segments := chunkTranscriptByTimeWithWordsFiltered(transcriptText, words, s.captionWordFilter())
-	if len(segments) == 0 {
-		return nil
-	}
 	// Optional leading-silence trim (dir2mcp#258): when enabled, subtract the
 	// detected dead-air offset from every time span and word timestamp so the
 	// transcript aligns to first speech. Disabled (default) leaves spans
@@ -2023,6 +2078,41 @@ func (s *Service) generateTranscriptRepresentation(ctx context.Context, doc mode
 		s.addErrors(1)
 	}
 	return nil
+}
+
+// applyDiarization stamps speaker attribution onto the transcript segments via
+// the injected diarizer (SPEC §8.6.8). It self-skips when diarization is
+// inactive or no diarizer is wired, leaving segments un-attributed (the default,
+// byte-identical to a non-diarized transcript). It is best-effort and fail-open:
+// a diarizer error degrades to a flat transcript rather than failing ingest
+// (§8.6.8 degenerate-output rule). Attribution is metadata only — it sets
+// span.Speaker/SpeakerLabel and never alters chunk text or span bounds.
+func (s *Service) applyDiarization(ctx context.Context, doc model.Document, content []byte, segments []chunkSegment) {
+	if !s.diarizeActive || s.diarizer == nil || len(segments) == 0 {
+		return
+	}
+	in := make([]SpeakerSegment, 0, len(segments))
+	for _, seg := range segments {
+		in = append(in, SpeakerSegment{StartMS: seg.Span.StartMS, EndMS: seg.Span.EndMS, Text: seg.Text})
+	}
+	attrs, err := s.diarizer.Diarize(ctx, content, in)
+	if err != nil {
+		s.getLogger().Printf("diarization skipped for %s (degrading to flat transcript): %v", doc.RelPath, err)
+		return
+	}
+	if len(attrs) != len(segments) {
+		s.getLogger().Printf("diarization skipped for %s: diarizer returned %d attributions for %d segments",
+			doc.RelPath, len(attrs), len(segments))
+		return
+	}
+	for i := range segments {
+		id := strings.TrimSpace(attrs[i].ID)
+		if id == "" {
+			continue // un-attributed segment degrades to flat
+		}
+		segments[i].Span.Speaker = id
+		segments[i].Span.SpeakerLabel = strings.TrimSpace(attrs[i].Label)
+	}
 }
 
 // translateTranscriptRepresentations produces, for each configured target

--- a/internal/ingest/sidecar.go
+++ b/internal/ingest/sidecar.go
@@ -76,6 +76,50 @@ type transcriptMeta struct {
 	SourceLanguage    string `json:"source_language,omitempty"`
 	TranslateProvider string `json:"translate_provider,omitempty"`
 	TranslateModel    string `json:"translate_model,omitempty"`
+
+	// Diarized / DiarizeProvider / DiarizeModel / Speakers record speaker
+	// attribution on a diarized transcript (Source any; spec §8.6.8/§5.2).
+	// Diarized is true when the transcript carries per-segment speakers. A
+	// model-derived diarization additionally records DiarizeProvider/DiarizeModel
+	// (part of the derivation identity, §8.6.7); a sidecar that supplied <v>
+	// voice tags is diarized WITHOUT a model, so those stay empty (omitempty).
+	// Speakers is the distinct set of {id,label} present, for discovery. All
+	// fields are omitted on a non-diarized transcript so meta_json is unchanged.
+	Diarized        bool      `json:"diarized,omitempty"`
+	DiarizeProvider string    `json:"diarize_provider,omitempty"`
+	DiarizeModel    string    `json:"diarize_model,omitempty"`
+	Speakers        []Speaker `json:"speakers,omitempty"`
+}
+
+// Speaker is one distinct speaker recorded in a diarized transcript's meta_json
+// (spec §8.6.8): the stable per-transcript id (e.g. "S1") and an optional
+// human-readable label. The per-segment attribution lives on the segment "time"
+// span's extra_json.speaker (§5.4); this set is for discovery/listing.
+type Speaker struct {
+	ID    string `json:"id"`
+	Label string `json:"label,omitempty"`
+}
+
+// distinctSpeakers returns the distinct speakers present across the transcript
+// segments in first-appearance order (deterministic, matching the S-id
+// allocation order in chunkSubtitleCuesFiltered), for the transcript meta_json
+// speakers set (SPEC §8.6.8). Segments with no speaker contribute nothing, so an
+// undiarized transcript yields an empty slice (and meta omits the field).
+func distinctSpeakers(segments []chunkSegment) []Speaker {
+	seen := make(map[string]struct{})
+	var out []Speaker
+	for _, seg := range segments {
+		id := strings.TrimSpace(seg.Span.Speaker)
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, Speaker{ID: id, Label: strings.TrimSpace(seg.Span.SpeakerLabel)})
+	}
+	return out
 }
 
 // setSidecarIndex records the mtime of every discovered file by rel_path so the
@@ -321,6 +365,14 @@ func parseSidecar(sc sidecarFile, content string) map[string][]subtitle.Cue {
 // and the language so retrieval and re-derivation treat it as authored.
 func (s *Service) persistSidecarTranscript(ctx context.Context, doc model.Document, lang string, cues []subtitle.Cue, segments []chunkSegment) error {
 	meta := transcriptMeta{Source: sidecarSource, Language: lang, Timestamps: true}
+	// A sidecar that carried <v> voice tags yields speaker-attributed segments
+	// (SPEC §8.6.8). Such a transcript is diarized WITHOUT a model, so it records
+	// diarized:true and the speakers set but NO diarize_provider/model (mirrors
+	// §8.6.7 for authored sources). A sidecar with no voice tags is unchanged.
+	if speakers := distinctSpeakers(segments); len(speakers) > 0 {
+		meta.Diarized = true
+		meta.Speakers = speakers
+	}
 	metaJSON, err := json.Marshal(meta)
 	if err != nil {
 		return fmt.Errorf("marshal sidecar transcript meta: %w", err)
@@ -352,7 +404,10 @@ func sidecarRepHash(lang string, cues []subtitle.Cue) string {
 	b.WriteString(lang)
 	b.WriteByte('\n')
 	for _, c := range cues {
-		fmt.Fprintf(&b, "%d-%d:%s\n", c.StartMS, c.EndMS, c.Text)
+		// Fold the voice/speaker name into the hash so a sidecar edit that changes
+		// ONLY a <v Name> tag (which is stripped from the cue text) still yields a
+		// new representation identity and re-derives the attribution (SPEC §8.6.8).
+		fmt.Fprintf(&b, "%d-%d:%s\t%s\n", c.StartMS, c.EndMS, c.Speaker, c.Text)
 	}
 	return computeRepHash([]byte(b.String()))
 }

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -706,7 +706,7 @@ func isResolvableSourceWithRoot(doc model.Document, rootAbs, rootReal string) bo
 
 func (s *Server) handleSearchTool(ctx context.Context, args map[string]interface{}) (toolCallResult, *toolExecutionError) {
 	if err := assertNoUnknownArguments(args, map[string]struct{}{
-		"query": {}, "k": {}, "index": {}, "path_prefix": {}, "file_glob": {}, "doc_types": {},
+		"query": {}, "k": {}, "index": {}, "path_prefix": {}, "file_glob": {}, "doc_types": {}, "speaker": {},
 	}); err != nil {
 		return toolCallResult{}, &toolExecutionError{Code: "INVALID_FIELD", Message: err.Error(), Retryable: false}
 	}
@@ -729,11 +729,15 @@ func (s *Server) handleSearchTool(ctx context.Context, args map[string]interface
 	if toolErr != nil {
 		return toolCallResult{}, toolErr
 	}
+	speaker, err := parseOptionalString(args, "speaker")
+	if err != nil {
+		return toolCallResult{}, &toolExecutionError{Code: "INVALID_FIELD", Message: err.Error(), Retryable: false}
+	}
 	if s.retriever == nil {
 		return toolCallResult{}, &toolExecutionError{Code: protocol.ErrorCodeIndexNotReady, Message: "retriever not configured", Retryable: false}
 	}
 	hits, searchErr := s.retriever.Search(ctx, model.SearchQuery{
-		Query: query, K: k, Index: indexName, PathPrefix: pathPrefix, FileGlob: fileGlob, DocTypes: docTypes,
+		Query: query, K: k, Index: indexName, PathPrefix: pathPrefix, FileGlob: fileGlob, DocTypes: docTypes, Speaker: speaker,
 	})
 	if searchErr != nil {
 		return toolCallResult{}, mapSearchError(searchErr)
@@ -2251,11 +2255,22 @@ func buildOpenFileSpan(span model.Span) map[string]interface{} {
 			"page": span.Page,
 		}
 	case "time":
-		return map[string]interface{}{
+		out := map[string]interface{}{
 			"kind":     "time",
 			"start_ms": span.StartMS,
 			"end_ms":   span.EndMS,
 		}
+		// Additive (SPEC §8.6.8/§9.2): a diarized transcript's time span surfaces
+		// the stable speaker id and optional label. Omitted when absent, so a
+		// non-diarized span is byte-identical to before and consumers degrade to
+		// a flat citation.
+		if speaker := strings.TrimSpace(span.Speaker); speaker != "" {
+			out["speaker"] = speaker
+			if label := strings.TrimSpace(span.SpeakerLabel); label != "" {
+				out["speaker_label"] = label
+			}
+		}
+		return out
 	case "region":
 		return buildRegionSpan(span)
 	default:
@@ -2539,6 +2554,14 @@ func spanDefinitionSchema() map[string]interface{} {
 					"kind":     map[string]interface{}{"const": "time"},
 					"start_ms": map[string]interface{}{"type": "integer"},
 					"end_ms":   map[string]interface{}{"type": "integer"},
+					"speaker": map[string]interface{}{
+						"type":        "string",
+						"description": "Optional (SPEC §8.6.8): stable per-transcript speaker id on a diarized transcript.",
+					},
+					"speaker_label": map[string]interface{}{
+						"type":        "string",
+						"description": "Optional human-readable speaker name (SPEC §8.6.8).",
+					},
 				},
 				"required": []string{"kind", "start_ms", "end_ms"},
 			},
@@ -2617,6 +2640,10 @@ func searchInputSchema() map[string]interface{} {
 			"path_prefix": map[string]interface{}{"type": "string"},
 			"file_glob":   map[string]interface{}{"type": "string"},
 			"doc_types":   map[string]interface{}{"type": "array", "items": map[string]interface{}{"type": "string"}},
+			"speaker": map[string]interface{}{
+				"type":        "string",
+				"description": "Optional (SPEC §8.6.8): restrict time-spanned transcript hits to this speaker id. A corpus without diarized transcripts returns no speaker-filtered hits.",
+			},
 		},
 		"required": []string{"query"},
 	}

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -98,6 +98,14 @@ type Span struct {
 	// behaviour identical to a words-absent transcript. Its presence makes Span
 	// non-comparable, so callers must not use Span as a map key.
 	Words []WordSpan
+	// Speaker is the stable per-transcript speaker identifier (e.g. "S1") on a
+	// diarized transcript's "time" span (spec §8.6.8). SpeakerLabel is an
+	// optional human-readable name (e.g. a WebVTT <v Name> voice tag). Both are
+	// metadata only and additive: they never change the chunk text or span
+	// bounds, and they are empty on every non-diarized transcript so behaviour
+	// is byte-identical to today. Persisted in the "time" span's extra_json.
+	Speaker      string
+	SpeakerLabel string
 }
 
 // WordSpan is one per-word timestamp on a "time" span (spec §8.6.1). The JSON
@@ -147,16 +155,28 @@ type IndexPayload struct {
 	Title    string
 	StartMS  int
 	EndMS    int
-	Language string
-	Speaker  string
-	Snippet  string
-	Span     Span
-	MediaRef string
+	Language     string
+	Speaker      string
+	SpeakerLabel string
+	Snippet      string
+	Span         Span
+	MediaRef     string
 }
 
 // ToSearchHit materialises a SearchHit from the payload. Score is left zero;
 // the caller sets it from the IndexHit.
 func (p IndexPayload) ToSearchHit() SearchHit {
+	span := p.Span
+	// Some backends (e.g. Qdrant) store the diarized speaker as a flat payload
+	// field but do not persist the nested Span (SPEC §8.6.8): bridge the flat
+	// Speaker/SpeakerLabel onto a "time" span so the Go-side speaker filter and
+	// the citation surface still see the attribution. The Span value is
+	// authoritative when it already carries a speaker (e.g. pgvector round-trips
+	// the full Span), so we only fill in the gap.
+	if strings.EqualFold(strings.TrimSpace(span.Kind), "time") && strings.TrimSpace(span.Speaker) == "" {
+		span.Speaker = p.Speaker
+		span.SpeakerLabel = p.SpeakerLabel
+	}
 	return SearchHit{
 		ChunkID:  p.ChunkID,
 		RelPath:  p.RelPath,
@@ -164,7 +184,7 @@ func (p IndexPayload) ToSearchHit() SearchHit {
 		DocType:  p.DocType,
 		RepType:  p.RepType,
 		Snippet:  p.Snippet,
-		Span:     p.Span,
+		Span:     span,
 		Modality: p.Modality,
 		MediaRef: p.MediaRef,
 	}
@@ -190,11 +210,15 @@ type IndexHit struct {
 //   - PathGlob:   keep only rel_paths matching this path.Match glob.
 //   - DocTypes:   keep only these doc types (case-insensitive).
 //   - ExcludeOrphans: drop chunks with an empty rel_path (orphaned/evicted).
+//   - Speaker: keep only time-spanned transcript chunks attributed to this
+//     stable speaker id (case-insensitive). Empty disables the predicate. A
+//     corpus without diarized transcripts simply matches nothing (SPEC §8.6.8).
 type Filter struct {
 	PathPrefix     string
 	PathGlob       string
 	DocTypes       []string
 	ExcludeOrphans bool
+	Speaker        string
 }
 
 // IsZero reports whether the filter has no active predicate.
@@ -202,7 +226,8 @@ func (f Filter) IsZero() bool {
 	return f.PathPrefix == "" &&
 		f.PathGlob == "" &&
 		len(f.DocTypes) == 0 &&
-		!f.ExcludeOrphans
+		!f.ExcludeOrphans &&
+		strings.TrimSpace(f.Speaker) == ""
 }
 
 // Match reports whether the payload satisfies every active predicate. It
@@ -238,6 +263,16 @@ func (f Filter) Match(p IndexPayload) bool {
 			return false
 		}
 	}
+	// Speaker restricts to time-spanned transcript segments attributed to the
+	// requested stable speaker id (SPEC §8.6.8). A payload that carries no
+	// speaker (non-diarized transcript or any non-time chunk) never matches a
+	// non-empty speaker filter, so a corpus without diarized transcripts returns
+	// no speaker-filtered hits.
+	if speaker := strings.TrimSpace(f.Speaker); speaker != "" {
+		if !strings.EqualFold(speaker, strings.TrimSpace(p.Speaker)) {
+			return false
+		}
+	}
 	return true
 }
 
@@ -248,6 +283,11 @@ type SearchQuery struct {
 	PathPrefix string
 	FileGlob   string
 	DocTypes   []string
+	// Speaker optionally restricts time-spanned transcript hits to segments
+	// attributed to this stable speaker id (SPEC §8.6.8/§15.2). Empty disables
+	// the filter; a corpus without diarized transcripts returns no
+	// speaker-filtered hits.
+	Speaker string
 }
 
 type SearchHit struct {

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -147,14 +147,14 @@ type BBox struct {
 // a subset; retrieval falls back to its in-memory chunk metadata when a field
 // is empty.
 type IndexPayload struct {
-	ChunkID  uint64
-	RelPath  string
-	DocType  string
-	RepType  string
-	Modality string
-	Title    string
-	StartMS  int
-	EndMS    int
+	ChunkID      uint64
+	RelPath      string
+	DocType      string
+	RepType      string
+	Modality     string
+	Title        string
+	StartMS      int
+	EndMS        int
 	Language     string
 	Speaker      string
 	SpeakerLabel string

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -40,6 +40,12 @@ const (
 	CapSTT    Capability = "stt"
 	CapTTS    Capability = "tts"
 	CapRerank Capability = "rerank"
+	// CapDiarize is speaker diarization on a transcript (SPEC §8.6.8). It is
+	// optional and provider-dependent: only a diarization-capable STT backend
+	// (a self-hosted WhisperX / pyannote-backed endpoint, KindWhisper) advertises
+	// it. Binding diarization to a backend that lacks the capability is rejected
+	// as CONFIG_INVALID, consistent with the capability matrix (8.1.2).
+	CapDiarize Capability = "diarize"
 )
 
 // Support is a capability-matrix cell state.
@@ -84,8 +90,12 @@ var matrix = map[Kind]map[Capability]Support{
 		// Self-hosted OpenAI-compatible STT (dir2mcp#240). Statically
 		// STT-capable: the standard /v1/audio/transcriptions contract is
 		// fixed, so unlike kind:openai (EndpointDependent) we mark it
-		// Supported.
-		CapSTT: Supported,
+		// Supported. A self-hosted WhisperX / pyannote-backed endpoint is the
+		// diarization-capable backend (SPEC §8.6.8), so it advertises
+		// CapDiarize; no other kind does, which keeps diarization opt-in and
+		// provider-dependent.
+		CapSTT:     Supported,
+		CapDiarize: Supported,
 	},
 }
 

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -1471,6 +1471,7 @@ func filterFromQuery(q model.SearchQuery) model.Filter {
 		PathPrefix: q.PathPrefix,
 		PathGlob:   q.FileGlob,
 		DocTypes:   q.DocTypes,
+		Speaker:    q.Speaker,
 	}
 }
 
@@ -1924,6 +1925,57 @@ func ensureAnswerAttributions(answer string, citations []model.Citation) string 
 	return answer + "\n\nSources: " + strings.Join(missing[:limit], ", ")
 }
 
+// FormatCitation renders a human-readable citation string for a span (SPEC §9.3).
+// The base forms are path-only ([rel_path]), page ([rel_path@p=N]), line range
+// ([rel_path@L12-48]), and time ([rel_path@t=02:13-02:41]). On a diarized
+// transcript a time span MAY append the speaker — preferring the human-readable
+// label, falling back to the stable id — as " › Speaker" (§8.6.8), e.g.
+// [interview.mp4@t=02:13-02:41 › S2]. The base form is used unchanged when no
+// speaker is present, so a non-diarized transcript citation is byte-identical to
+// before.
+func FormatCitation(relPath string, span model.Span) string {
+	relPath = strings.TrimSpace(relPath)
+	suffix := ""
+	speaker := ""
+	switch strings.ToLower(strings.TrimSpace(span.Kind)) {
+	case "page":
+		if span.Page > 0 {
+			suffix = fmt.Sprintf("@p=%d", span.Page)
+		}
+	case "lines":
+		if span.StartLine > 0 && span.EndLine >= span.StartLine {
+			suffix = fmt.Sprintf("@L%d-%d", span.StartLine, span.EndLine)
+		}
+	case "time":
+		suffix = "@t=" + formatCitationTime(span.StartMS) + "-" + formatCitationTime(span.EndMS)
+		// Prefer the label, fall back to the stable id (SPEC §9.3 example uses S2).
+		if speaker = strings.TrimSpace(span.SpeakerLabel); speaker == "" {
+			speaker = strings.TrimSpace(span.Speaker)
+		}
+	}
+	out := "[" + relPath + suffix
+	if speaker != "" {
+		out += " › " + speaker
+	}
+	return out + "]"
+}
+
+// formatCitationTime renders a millisecond offset as mm:ss (or hh:mm:ss past one
+// hour) for the §9.3 time-span citation form. Negative input clamps to zero.
+func formatCitationTime(ms int) string {
+	if ms < 0 {
+		ms = 0
+	}
+	totalSeconds := ms / 1000
+	seconds := totalSeconds % 60
+	minutes := (totalSeconds / 60) % 60
+	hours := totalSeconds / 3600
+	if hours > 0 {
+		return fmt.Sprintf("%02d:%02d:%02d", hours, minutes, seconds)
+	}
+	return fmt.Sprintf("%02d:%02d", minutes, seconds)
+}
+
 func matchFilters(hit model.SearchHit, query model.SearchQuery) bool {
 	// Orphaned or evicted chunks have an empty RelPath and must never be
 	// surfaced to callers regardless of any other filter criteria.
@@ -1954,6 +2006,18 @@ func matchFilters(hit model.SearchHit, query model.SearchQuery) bool {
 			}
 		}
 		if !docTypeMatch {
+			return false
+		}
+	}
+
+	// Optional speaker filter (SPEC §8.6.8/§15.2): restrict to time-spanned
+	// transcript hits attributed to the requested stable speaker id
+	// (case-insensitive). A hit whose span carries no speaker — every non-time
+	// chunk and every non-diarized transcript — never matches a non-empty
+	// speaker filter, so a corpus without diarized transcripts returns no
+	// speaker-filtered hits. Empty filter is a no-op (behaviour unchanged).
+	if speaker := strings.TrimSpace(query.Speaker); speaker != "" {
+		if !strings.EqualFold(speaker, strings.TrimSpace(hit.Span.Speaker)) {
 			return false
 		}
 	}

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -1816,7 +1816,13 @@ func spanFromRow(kind string, start, end int, extraJSON string) model.Span {
 		if start < 0 || end < 0 || end < start {
 			return model.Span{Kind: "lines"}
 		}
-		return model.Span{Kind: "time", StartMS: start, EndMS: end, Words: wordsFromExtraJSON(extraJSON)}
+		speaker, speakerLabel := speakerFromExtraJSON(extraJSON)
+		return model.Span{
+			Kind: "time", StartMS: start, EndMS: end,
+			Words:        wordsFromExtraJSON(extraJSON),
+			Speaker:      speaker,
+			SpeakerLabel: speakerLabel,
+		}
 	case "region":
 		return regionSpanFromRow(start, end, extraJSON)
 	case "lines":
@@ -1856,6 +1862,30 @@ func wordsFromExtraJSON(extraJSON string) []model.WordSpan {
 		return nil
 	}
 	return out
+}
+
+// speakerFromExtraJSON reconstructs the diarized speaker attribution of a "time"
+// span from its stored extra_json (spec §8.6.8). It tolerates a NULL/empty/
+// malformed payload by returning empty strings so a non-diarized transcript span
+// degrades to a flat, un-attributed citation (the behaviour for a transcript
+// without diarization). A speaker_label with no stable speaker id is dropped:
+// the id is the canonical attribution and a label alone is not a valid speaker.
+func speakerFromExtraJSON(extraJSON string) (speaker, speakerLabel string) {
+	if strings.TrimSpace(extraJSON) == "" {
+		return "", ""
+	}
+	var payload struct {
+		Speaker      string `json:"speaker"`
+		SpeakerLabel string `json:"speaker_label"`
+	}
+	if err := json.Unmarshal([]byte(extraJSON), &payload); err != nil {
+		return "", ""
+	}
+	speaker = strings.TrimSpace(payload.Speaker)
+	if speaker == "" {
+		return "", ""
+	}
+	return speaker, strings.TrimSpace(payload.SpeakerLabel)
 }
 
 // regionSpanFromRow reconstructs a region span from its stored columns. A
@@ -2362,7 +2392,7 @@ func spanToRow(span model.Span) (kind string, start int, end int, extraJSON stri
 		if span.StartMS < 0 || span.EndMS < 0 || span.EndMS < span.StartMS {
 			return "", 0, 0, "", errors.New("invalid time span")
 		}
-		extra, eErr := timeSpanExtraJSON(span.Words)
+		extra, eErr := timeSpanExtraJSON(span.Words, span.Speaker, span.SpeakerLabel)
 		if eErr != nil {
 			return "", 0, 0, "", eErr
 		}
@@ -2374,20 +2404,32 @@ func spanToRow(span model.Span) (kind string, start int, end int, extraJSON stri
 	}
 }
 
-// timeSpanExtraJSON marshals per-word timing for a "time" span into the stored
-// extra_json shape `{"words":[{"t":..,"d":..,"w":".."}]}` (spec §8.6.1).
-// Returns the empty string (stored as SQL NULL, preserving prior behaviour) when
-// there is no word timing, so words-absent transcripts round-trip unchanged.
-func timeSpanExtraJSON(words []model.WordSpan) (string, error) {
-	if len(words) == 0 {
+// timeSpanExtraJSON marshals the optional metadata of a "time" span into the
+// stored extra_json object: per-word timing (`words`, spec §8.6.1) plus the
+// diarized speaker attribution (`speaker`/`speaker_label`, spec §8.6.8). Each
+// field is emitted only when present (omitempty), so a transcript with neither
+// returns the empty string (stored as SQL NULL) and round-trips byte-identically
+// to before diarization existed. speaker/speaker_label are trimmed; an empty
+// speaker drops both (a label without a stable id is not a valid attribution).
+func timeSpanExtraJSON(words []model.WordSpan, speaker, speakerLabel string) (string, error) {
+	speaker = strings.TrimSpace(speaker)
+	speakerLabel = strings.TrimSpace(speakerLabel)
+	if speaker == "" {
+		// A label with no stable id is not a valid attribution; drop both so the
+		// stored shape never carries a dangling speaker_label.
+		speakerLabel = ""
+	}
+	if len(words) == 0 && speaker == "" {
 		return "", nil
 	}
 	payload := struct {
-		Words []model.WordSpan `json:"words"`
-	}{Words: words}
+		Words        []model.WordSpan `json:"words,omitempty"`
+		Speaker      string           `json:"speaker,omitempty"`
+		SpeakerLabel string           `json:"speaker_label,omitempty"`
+	}{Words: words, Speaker: speaker, SpeakerLabel: speakerLabel}
 	encoded, err := json.Marshal(payload)
 	if err != nil {
-		return "", fmt.Errorf("marshal time span words: %w", err)
+		return "", fmt.Errorf("marshal time span extra_json: %w", err)
 	}
 	return string(encoded), nil
 }

--- a/internal/subtitle/parser.go
+++ b/internal/subtitle/parser.go
@@ -114,11 +114,14 @@ func (c *cueScanner) addLine(line string) {
 }
 
 // flush emits the in-progress cue (if any) and resets the buffer. A cue with
-// empty text after trimming/tag-stripping is dropped.
+// empty text after trimming/tag-stripping is dropped. The cue's speaker is the
+// first WebVTT <v Name> voice tag found in its text lines (SPEC §8.6.8); empty
+// when the cue carries no voice markup, preserving prior behaviour.
 func (c *cueScanner) flush() {
 	if c.haveTiming {
 		if text := joinCueText(c.textLines); text != "" {
-			c.cues = append(c.cues, Cue{Index: len(c.cues) + 1, StartMS: c.start, EndMS: c.end, Text: text})
+			speaker := voiceTagName(c.textLines)
+			c.cues = append(c.cues, Cue{Index: len(c.cues) + 1, StartMS: c.start, EndMS: c.end, Text: text, Speaker: speaker})
 		}
 	}
 	c.haveTiming = false
@@ -209,6 +212,32 @@ func isMetadataBlockStart(line string) bool {
 // inlineTagRe matches WebVTT/TTML inline markup (e.g. <c.color>, <v Speaker>,
 // <00:00:01.000>, </i>) that should not appear in indexed cue text.
 var inlineTagRe = regexp.MustCompile(`</?[^>]+>`)
+
+// voiceTagRe matches a WebVTT voice span start tag and captures the speaker
+// name (SPEC §8.6.8). The tag is `<v Name>` or `<v.class1.class2 Name>`: the
+// `v` tag name is optionally followed by `.`-separated classes, then required
+// whitespace, then the annotation (speaker name) up to the closing `>`. The
+// name capture is non-greedy and trimmed by the caller. Case-insensitive on the
+// tag name only.
+var voiceTagRe = regexp.MustCompile(`(?i)<v(?:\.[^\s.>]+)*\s+([^>]*)>`)
+
+// voiceTagName returns the speaker name from the first WebVTT <v Name> voice tag
+// across a cue's text lines, or "" when none is present. Voice tags without a
+// name (`<v>`) yield "". The returned name is trimmed; it is metadata only and
+// never alters the cue text (which has all inline tags stripped separately).
+func voiceTagName(lines []string) string {
+	for _, l := range lines {
+		if !strings.Contains(l, "<v") && !strings.Contains(l, "<V") {
+			continue
+		}
+		if m := voiceTagRe.FindStringSubmatch(l); m != nil {
+			if name := strings.TrimSpace(m[1]); name != "" {
+				return name
+			}
+		}
+	}
+	return ""
+}
 
 // stripInlineTags removes inline markup from cue text so the indexed transcript
 // is plain text. It is deterministic and leaves non-tag angle content untouched

--- a/internal/subtitle/subtitle.go
+++ b/internal/subtitle/subtitle.go
@@ -21,6 +21,13 @@ type Cue struct {
 	StartMS int
 	EndMS   int
 	Text    string
+	// Speaker is the human-readable voice/speaker name parsed from a WebVTT
+	// <v Name> voice tag on the cue (SPEC §8.6.8). It is metadata only: it never
+	// appears in Text (voice tags are stripped) and is empty for cues with no
+	// voice markup, so a transcript without <v> tags is unchanged. A sidecar
+	// that carries voice tags can populate speaker attribution WITHOUT a
+	// diarization model.
+	Speaker string
 }
 
 // TranscriptChunk pairs a transcript chunk's text with its time span. It is the
@@ -38,9 +45,10 @@ type TranscriptChunk struct {
 // A chunk whose span is non-time is dropped, since subtitles require timing.
 func BuildCues(chunks []TranscriptChunk) []Cue {
 	type timed struct {
-		start int
-		end   int
-		text  string
+		start   int
+		end     int
+		text    string
+		speaker string
 	}
 	timedChunks := make([]timed, 0, len(chunks))
 	for _, ch := range chunks {
@@ -59,7 +67,14 @@ func BuildCues(chunks []TranscriptChunk) []Cue {
 		if end < start {
 			end = start
 		}
-		timedChunks = append(timedChunks, timed{start: start, end: end, text: text})
+		// Prefer the human-readable label, falling back to the stable id, so a
+		// diarized transcript exports voice markup (SPEC §8.6.3); empty for a
+		// non-diarized transcript so the export is unchanged.
+		speaker := strings.TrimSpace(ch.Span.SpeakerLabel)
+		if speaker == "" {
+			speaker = strings.TrimSpace(ch.Span.Speaker)
+		}
+		timedChunks = append(timedChunks, timed{start: start, end: end, text: text, speaker: speaker})
 	}
 
 	sort.SliceStable(timedChunks, func(i, j int) bool {
@@ -76,6 +91,7 @@ func BuildCues(chunks []TranscriptChunk) []Cue {
 			StartMS: tc.start,
 			EndMS:   tc.end,
 			Text:    tc.text,
+			Speaker: tc.speaker,
 		})
 	}
 	return cues
@@ -98,10 +114,30 @@ func RenderVTT(cues []Cue) string {
 		b.WriteString(" --> ")
 		b.WriteString(formatTimestampVTT(cue.EndMS))
 		b.WriteByte('\n')
+		// Carry speaker as a WebVTT <v Name> voice tag when present (SPEC §8.6.3);
+		// a cue with no speaker renders exactly as before. The name is sanitised
+		// so it can never break out of the tag.
+		if speaker := sanitizeVoiceName(cue.Speaker); speaker != "" {
+			b.WriteString("<v ")
+			b.WriteString(speaker)
+			b.WriteByte('>')
+		}
 		b.WriteString(text)
 		b.WriteString("\n\n")
 	}
 	return b.String()
+}
+
+// sanitizeVoiceName makes a speaker name safe to embed in a WebVTT <v Name> tag:
+// it trims whitespace and strips '<' and '>' so the name cannot terminate the
+// tag or inject markup. Returns "" for an empty/blank name so the caller omits
+// the voice tag entirely.
+func sanitizeVoiceName(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return ""
+	}
+	return strings.TrimSpace(strings.NewReplacer("<", "", ">", "").Replace(name))
 }
 
 // RenderSRT serializes cues as a SubRip (SRT) document: a 1-based index line,

--- a/tests/config/media_diarize_config_test.go
+++ b/tests/config/media_diarize_config_test.go
@@ -1,0 +1,121 @@
+package tests
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/provider"
+)
+
+// TestMediaDiarize_DefaultIsAuto confirms diarization defaults to the tri-state
+// "auto" (nil pointer), neither forced on nor off (SPEC §8.6.8).
+func TestMediaDiarize_DefaultIsAuto(t *testing.T) {
+	cfg := config.Default()
+	if cfg.MediaDiarizeEnabled != nil {
+		t.Fatalf("media.diarize.enabled must default to nil (auto), got %v", *cfg.MediaDiarizeEnabled)
+	}
+}
+
+// TestMediaDiarize_OmitValidatesWithAnyBackend: with diarization omitted (auto),
+// validation passes regardless of the STT backend (it simply stays off on an
+// incapable backend).
+func TestMediaDiarize_OmitValidatesWithAnyBackend(t *testing.T) {
+	cfg := config.Default()
+	cfg.STTProvider = "off"
+	cfg.MediaDiarizeEnabled = nil
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("omitted diarize must validate, got: %v", err)
+	}
+}
+
+// TestMediaDiarize_FalseValidatesWithAnyBackend: forced-off always validates.
+func TestMediaDiarize_FalseValidatesWithAnyBackend(t *testing.T) {
+	cfg := config.Default()
+	cfg.STTProvider = "off"
+	f := false
+	cfg.MediaDiarizeEnabled = &f
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("diarize=false must validate, got: %v", err)
+	}
+}
+
+// TestMediaDiarize_TrueWithCapableBackend: enabled:true with a
+// diarization-capable STT backend (self-hosted whisper) validates.
+func TestMediaDiarize_TrueWithCapableBackend(t *testing.T) {
+	cfg := config.Default()
+	cfg.STTProvider = "whisper" // credential-less, advertises CapDiarize
+	tr := true
+	cfg.MediaDiarizeEnabled = &tr
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("diarize=true with a capable backend must validate, got: %v", err)
+	}
+}
+
+// TestMediaDiarize_TrueWithNoBackend_ConfigInvalid: enabled:true with STT off
+// (no backend to diarize) is CONFIG_INVALID (SPEC §8.6.8).
+func TestMediaDiarize_TrueWithNoBackend_ConfigInvalid(t *testing.T) {
+	cfg := config.Default()
+	cfg.STTProvider = "off"
+	tr := true
+	cfg.MediaDiarizeEnabled = &tr
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected CONFIG_INVALID for diarize=true with no STT backend")
+	}
+	if !strings.Contains(err.Error(), "CONFIG_INVALID") {
+		t.Fatalf("error must be CONFIG_INVALID, got: %v", err)
+	}
+}
+
+// TestMediaDiarize_TrueWithIncapableBackend_ConfigInvalid: enabled:true with an
+// eligible but diarization-incapable STT backend (Mistral, kind=mistral) is
+// CONFIG_INVALID. A credential is provided so the profile resolves (eligible)
+// but the capability matrix does not advertise CapDiarize for it.
+func TestMediaDiarize_TrueWithIncapableBackend_ConfigInvalid(t *testing.T) {
+	// Sanity: confirm the test's premise — mistral kind is NOT diarize-capable
+	// while whisper is — so this test fails loudly if the matrix changes.
+	if provider.Can(provider.KindMistral, provider.CapDiarize) != provider.Unsupported {
+		t.Fatal("precondition: mistral must not advertise CapDiarize")
+	}
+	if provider.Can(provider.KindWhisper, provider.CapDiarize) == provider.Unsupported {
+		t.Fatal("precondition: whisper must advertise CapDiarize")
+	}
+	t.Setenv("MISTRAL_API_KEY", "test-key-so-mistral-ocr-is-eligible")
+	cfg := config.Default()
+	cfg.STTProvider = "mistral"
+	tr := true
+	cfg.MediaDiarizeEnabled = &tr
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected CONFIG_INVALID for diarize=true with an incapable STT backend")
+	}
+	if !strings.Contains(err.Error(), "CONFIG_INVALID") {
+		t.Fatalf("error must be CONFIG_INVALID, got: %v", err)
+	}
+}
+
+// TestMediaDiarize_RoundTripsThroughSaveLoad confirms an explicit tri-state
+// value survives a save/load cycle (false is preserved, not collapsed to auto).
+func TestMediaDiarize_RoundTripsThroughSaveLoad(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+
+	cfg := config.Default()
+	cfg.RootDir = "/tmp/repo"
+	cfg.StateDir = "/tmp/repo/.dir2mcp"
+	cfg.STTProvider = "whisper"
+	tr := true
+	cfg.MediaDiarizeEnabled = &tr
+	if err := config.SaveFile(path, cfg); err != nil {
+		t.Fatalf("SaveFile: %v", err)
+	}
+	loaded, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if loaded.MediaDiarizeEnabled == nil || !*loaded.MediaDiarizeEnabled {
+		t.Fatalf("diarize=true did not round-trip, got %v", loaded.MediaDiarizeEnabled)
+	}
+}

--- a/tests/ingest/diarization_test.go
+++ b/tests/ingest/diarization_test.go
@@ -1,0 +1,275 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/subtitle"
+)
+
+// TestChunkSubtitleCues_VoiceTags_StableSpeakerIDs verifies that WebVTT <v>
+// voice tags become stable, deterministic per-transcript speaker ids on the
+// time span (SPEC §8.6.8): ids are allocated in first-appearance order, the same
+// name maps to the same id, and chunks never merge across a speaker boundary.
+func TestChunkSubtitleCues_VoiceTags_StableSpeakerIDs(t *testing.T) {
+	t.Parallel()
+	cues := []subtitle.Cue{
+		{StartMS: 0, EndMS: 1000, Text: "hello", Speaker: "Alice"},
+		{StartMS: 1000, EndMS: 2000, Text: "hi back", Speaker: "Bob"},
+		{StartMS: 2000, EndMS: 3000, Text: "again", Speaker: "Alice"},
+	}
+	segs := ingest.ChunkSubtitleCues(cues)
+	if len(segs) != 3 {
+		t.Fatalf("expected 3 chunks (split on speaker boundary), got %d: %+v", len(segs), segs)
+	}
+	want := []struct {
+		id, label, text string
+	}{
+		{"S1", "Alice", "hello"},
+		{"S2", "Bob", "hi back"},
+		{"S1", "Alice", "again"}, // same name -> same id
+	}
+	for i, w := range want {
+		if segs[i].Span.Speaker != w.id || segs[i].Span.SpeakerLabel != w.label {
+			t.Errorf("chunk[%d] speaker=%q label=%q, want id=%q label=%q",
+				i, segs[i].Span.Speaker, segs[i].Span.SpeakerLabel, w.id, w.label)
+		}
+		if segs[i].Text != w.text {
+			t.Errorf("chunk[%d] text=%q, want %q", i, segs[i].Text, w.text)
+		}
+	}
+}
+
+// TestChunkSubtitleCues_Deterministic confirms the same input yields identical
+// speaker ids across repeated runs (stable across re-indexing).
+func TestChunkSubtitleCues_Deterministic(t *testing.T) {
+	t.Parallel()
+	cues := []subtitle.Cue{
+		{StartMS: 0, EndMS: 1000, Text: "a", Speaker: "X"},
+		{StartMS: 1000, EndMS: 2000, Text: "b", Speaker: "Y"},
+	}
+	first := ingest.ChunkSubtitleCues(cues)
+	second := ingest.ChunkSubtitleCues(cues)
+	if len(first) != len(second) {
+		t.Fatalf("non-deterministic chunk count: %d vs %d", len(first), len(second))
+	}
+	for i := range first {
+		if first[i].Span.Speaker != second[i].Span.Speaker {
+			t.Errorf("chunk[%d] speaker id changed across runs: %q vs %q",
+				i, first[i].Span.Speaker, second[i].Span.Speaker)
+		}
+	}
+	if first[0].Span.Speaker != "S1" || first[1].Span.Speaker != "S2" {
+		t.Errorf("unexpected ids: %q, %q", first[0].Span.Speaker, first[1].Span.Speaker)
+	}
+}
+
+// TestChunkSubtitleCues_NoVoiceTags_MetadataOnly verifies that, with no voice
+// tags, chunk text and span bounds are byte-identical to a non-diarized
+// transcript and no speaker is set (speaker is purely additive metadata).
+func TestChunkSubtitleCues_NoVoiceTags_MetadataOnly(t *testing.T) {
+	t.Parallel()
+	cues := []subtitle.Cue{
+		{StartMS: 0, EndMS: 1000, Text: "alpha"},
+		{StartMS: 1000, EndMS: 2500, Text: "beta"},
+	}
+	segs := ingest.ChunkSubtitleCues(cues)
+	if len(segs) != 1 {
+		t.Fatalf("expected 1 merged chunk, got %d", len(segs))
+	}
+	if segs[0].Text != "alpha\nbeta" {
+		t.Errorf("text = %q, want %q", segs[0].Text, "alpha\nbeta")
+	}
+	if segs[0].Span.StartMS != 0 || segs[0].Span.EndMS != 2500 {
+		t.Errorf("span = [%d,%d], want [0,2500]", segs[0].Span.StartMS, segs[0].Span.EndMS)
+	}
+	if segs[0].Span.Speaker != "" || segs[0].Span.SpeakerLabel != "" {
+		t.Errorf("expected no speaker, got id=%q label=%q", segs[0].Span.Speaker, segs[0].Span.SpeakerLabel)
+	}
+}
+
+// fakeDiarizer is a deterministic test diarizer that attributes every segment to
+// a single configured speaker, so the derivation-identity gate can be exercised
+// without a real diarization backend.
+type fakeDiarizer struct {
+	id    string
+	label string
+	calls int
+}
+
+func (d *fakeDiarizer) Diarize(_ context.Context, _ []byte, segs []ingest.SpeakerSegment) ([]ingest.SpeakerAttribution, error) {
+	d.calls++
+	out := make([]ingest.SpeakerAttribution, len(segs))
+	for i := range segs {
+		out[i] = ingest.SpeakerAttribution{ID: d.id, Label: d.label}
+	}
+	return out, nil
+}
+
+// TestDiarizeModelSwap_InvalidatesAndRederives confirms a change to the
+// diarization provider/model invalidates an unchanged transcript and re-derives
+// it (SPEC §8.6.7/§8.6.8): the diarize identity is part of the transcript
+// derivation identity.
+func TestDiarizeModelSwap_InvalidatesAndRederives(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "talk.mp3"), "fake-audio")
+	st := newRealStore(t)
+	stateDir := t.TempDir()
+	f := ingest.DiscoveredFile{RelPath: "talk.mp3", SizeBytes: 10, MTimeUnix: 1234567890}
+
+	// Scan 1: diarized with pyannote v1.
+	tr1 := &fakeTranscriber{text: "[00:00] hello world"}
+	svc1 := sttService(t, root, stateDir, st, "whisper", "whisper-large-v3", "en", tr1)
+	svc1.SetDiarizer(&fakeDiarizer{id: "S1", label: "Speaker"}, "whisper", "pyannote-v1")
+	if err := svc1.ProcessDocument(context.Background(), f, nil, false); err != nil {
+		t.Fatalf("scan1: %v", err)
+	}
+	if tr1.calls != 1 {
+		t.Fatalf("scan1 STT calls = %d, want 1", tr1.calls)
+	}
+
+	// Scan 2: same bytes + same STT model, but swap the diarize model to v2.
+	tr2 := &fakeTranscriber{text: "[00:00] hello world"}
+	svc2 := sttService(t, root, stateDir, st, "whisper", "whisper-large-v3", "en", tr2)
+	svc2.SetDiarizer(&fakeDiarizer{id: "S1", label: "Speaker"}, "whisper", "pyannote-v2")
+	if err := svc2.ProcessDocument(context.Background(), f, nil, false); err != nil {
+		t.Fatalf("scan2: %v", err)
+	}
+	if tr2.calls != 1 {
+		t.Fatalf("scan2 STT calls = %d, want 1 (diarize model swap must re-derive unchanged media)", tr2.calls)
+	}
+	meta := transcriptMetaFor(t, st, "talk.mp3")
+	if want := `"diarize_model":"pyannote-v2"`; !strings.Contains(meta, want) {
+		t.Fatalf("transcript meta not refreshed to new diarize identity (%s): %q", want, meta)
+	}
+}
+
+// TestDiarizeNoSwap_NoChurn asserts re-scanning with the SAME diarize identity
+// and unchanged content does NOT re-transcribe.
+func TestDiarizeNoSwap_NoChurn(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "talk.mp3"), "fake-audio")
+	st := newRealStore(t)
+	stateDir := t.TempDir()
+	f := ingest.DiscoveredFile{RelPath: "talk.mp3", SizeBytes: 10, MTimeUnix: 1234567890}
+
+	tr1 := &fakeTranscriber{text: "[00:00] hello"}
+	svc1 := sttService(t, root, stateDir, st, "whisper", "whisper-large-v3", "en", tr1)
+	svc1.SetDiarizer(&fakeDiarizer{id: "S1", label: "Speaker"}, "whisper", "pyannote-v1")
+	if err := svc1.ProcessDocument(context.Background(), f, nil, false); err != nil {
+		t.Fatalf("scan1: %v", err)
+	}
+
+	tr2 := &fakeTranscriber{text: "[00:00] hello"}
+	svc2 := sttService(t, root, stateDir, st, "whisper", "whisper-large-v3", "en", tr2)
+	svc2.SetDiarizer(&fakeDiarizer{id: "S1", label: "Speaker"}, "whisper", "pyannote-v1")
+	if err := svc2.ProcessDocument(context.Background(), f, nil, false); err != nil {
+		t.Fatalf("scan2: %v", err)
+	}
+	if tr2.calls != 0 {
+		t.Fatalf("scan2 STT calls = %d, want 0 (identical diarize identity + content must not re-derive)", tr2.calls)
+	}
+}
+
+// TestSidecar_VoiceTags_DiarizedMeta verifies a sidecar carrying <v> tags
+// produces a diarized transcript representation: meta_json records diarized:true
+// and the speakers set, WITHOUT a diarize_provider/model (sidecar-sourced
+// attribution is not model-derived, SPEC §8.6.8/§8.6.7).
+func TestSidecar_VoiceTags_DiarizedMeta(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "interview.mp3"), "fake-audio")
+	writeFile(t, filepath.Join(root, "interview.vtt"),
+		"WEBVTT\n\n"+
+			"00:00:00.000 --> 00:00:02.000\n<v Host>Welcome\n\n"+
+			"00:00:02.000 --> 00:00:04.000\n<v Guest>Thanks for having me\n")
+
+	st := &fakeIngestStore{}
+	svc := newSidecarService(t, root, t.TempDir(), st)
+
+	doc := model.Document{DocID: 1, RelPath: "interview.mp3", DocType: "audio"}
+	ingested, err := svc.IngestSidecarTranscripts(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("IngestSidecarTranscripts: %v", err)
+	}
+	if !ingested || len(st.reps) != 1 {
+		t.Fatalf("expected one ingested transcript rep, got ingested=%v reps=%d", ingested, len(st.reps))
+	}
+
+	var meta struct {
+		Source          string `json:"source"`
+		Diarized        bool   `json:"diarized"`
+		DiarizeProvider string `json:"diarize_provider"`
+		DiarizeModel    string `json:"diarize_model"`
+		Speakers        []struct {
+			ID    string `json:"id"`
+			Label string `json:"label"`
+		} `json:"speakers"`
+	}
+	if err := json.Unmarshal([]byte(st.reps[0].MetaJSON), &meta); err != nil {
+		t.Fatalf("meta json: %v (%q)", err, st.reps[0].MetaJSON)
+	}
+	if meta.Source != "sidecar" {
+		t.Errorf("source = %q, want sidecar", meta.Source)
+	}
+	if !meta.Diarized {
+		t.Error("expected diarized:true")
+	}
+	if meta.DiarizeProvider != "" || meta.DiarizeModel != "" {
+		t.Errorf("sidecar diarization must record NO provider/model, got %q/%q",
+			meta.DiarizeProvider, meta.DiarizeModel)
+	}
+	if len(meta.Speakers) != 2 || meta.Speakers[0].ID != "S1" || meta.Speakers[0].Label != "Host" ||
+		meta.Speakers[1].ID != "S2" || meta.Speakers[1].Label != "Guest" {
+		t.Errorf("unexpected speakers set: %+v", meta.Speakers)
+	}
+
+	// Each chunk's time span must carry its speaker (per-segment attribution).
+	if len(st.spans) != 2 {
+		t.Fatalf("expected 2 spans, got %d", len(st.spans))
+	}
+	if st.spans[0].Speaker != "S1" || st.spans[1].Speaker != "S2" {
+		t.Errorf("span speakers = %q,%q want S1,S2", st.spans[0].Speaker, st.spans[1].Speaker)
+	}
+}
+
+// TestSidecar_NoVoiceTags_NotDiarized confirms a plain sidecar (no <v> tags) is
+// NOT marked diarized, so meta_json is unchanged from before diarization existed.
+func TestSidecar_NoVoiceTags_NotDiarized(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "plain.mp3"), "fake-audio")
+	writeFile(t, filepath.Join(root, "plain.vtt"),
+		"WEBVTT\n\n00:00:00.000 --> 00:00:02.000\njust a caption\n")
+
+	st := &fakeIngestStore{}
+	svc := newSidecarService(t, root, t.TempDir(), st)
+
+	doc := model.Document{DocID: 1, RelPath: "plain.mp3", DocType: "audio"}
+	if _, err := svc.IngestSidecarTranscripts(context.Background(), doc); err != nil {
+		t.Fatalf("IngestSidecarTranscripts: %v", err)
+	}
+	if len(st.reps) != 1 {
+		t.Fatalf("expected one rep, got %d", len(st.reps))
+	}
+	var meta map[string]any
+	if err := json.Unmarshal([]byte(st.reps[0].MetaJSON), &meta); err != nil {
+		t.Fatalf("meta json: %v", err)
+	}
+	if _, ok := meta["diarized"]; ok {
+		t.Errorf("plain sidecar must not set diarized, got meta=%v", meta)
+	}
+	if _, ok := meta["speakers"]; ok {
+		t.Errorf("plain sidecar must not set speakers, got meta=%v", meta)
+	}
+	if len(st.spans) != 1 || st.spans[0].Speaker != "" {
+		t.Errorf("expected one un-attributed span, got %+v", st.spans)
+	}
+}

--- a/tests/ingest/diarization_test.go
+++ b/tests/ingest/diarization_test.go
@@ -203,18 +203,28 @@ func TestSidecar_VoiceTags_DiarizedMeta(t *testing.T) {
 		t.Fatalf("expected one ingested transcript rep, got ingested=%v reps=%d", ingested, len(st.reps))
 	}
 
-	var meta struct {
-		Source          string `json:"source"`
-		Diarized        bool   `json:"diarized"`
-		DiarizeProvider string `json:"diarize_provider"`
-		DiarizeModel    string `json:"diarize_model"`
-		Speakers        []struct {
-			ID    string `json:"id"`
-			Label string `json:"label"`
-		} `json:"speakers"`
-	}
-	if err := json.Unmarshal([]byte(st.reps[0].MetaJSON), &meta); err != nil {
-		t.Fatalf("meta json: %v (%q)", err, st.reps[0].MetaJSON)
+	assertDiarizedSidecarMeta(t, st.reps[0].MetaJSON)
+	assertSpanSpeakers(t, st.spans, "S1", "S2")
+}
+
+type diarizedMeta struct {
+	Source          string `json:"source"`
+	Diarized        bool   `json:"diarized"`
+	DiarizeProvider string `json:"diarize_provider"`
+	DiarizeModel    string `json:"diarize_model"`
+	Speakers        []struct {
+		ID    string `json:"id"`
+		Label string `json:"label"`
+	} `json:"speakers"`
+}
+
+// assertDiarizedSidecarMeta checks that a sidecar transcript's meta_json marks it
+// diarized with the {S1:Host, S2:Guest} speakers set and NO model provenance.
+func assertDiarizedSidecarMeta(t *testing.T, metaJSON string) {
+	t.Helper()
+	var meta diarizedMeta
+	if err := json.Unmarshal([]byte(metaJSON), &meta); err != nil {
+		t.Fatalf("meta json: %v (%q)", err, metaJSON)
 	}
 	if meta.Source != "sidecar" {
 		t.Errorf("source = %q, want sidecar", meta.Source)
@@ -226,17 +236,27 @@ func TestSidecar_VoiceTags_DiarizedMeta(t *testing.T) {
 		t.Errorf("sidecar diarization must record NO provider/model, got %q/%q",
 			meta.DiarizeProvider, meta.DiarizeModel)
 	}
-	if len(meta.Speakers) != 2 || meta.Speakers[0].ID != "S1" || meta.Speakers[0].Label != "Host" ||
-		meta.Speakers[1].ID != "S2" || meta.Speakers[1].Label != "Guest" {
-		t.Errorf("unexpected speakers set: %+v", meta.Speakers)
+	want := []struct{ id, label string }{{"S1", "Host"}, {"S2", "Guest"}}
+	if len(meta.Speakers) != len(want) {
+		t.Fatalf("speakers = %+v, want %d entries", meta.Speakers, len(want))
 	}
+	for i, w := range want {
+		if meta.Speakers[i].ID != w.id || meta.Speakers[i].Label != w.label {
+			t.Errorf("speakers[%d] = %+v, want {%s,%s}", i, meta.Speakers[i], w.id, w.label)
+		}
+	}
+}
 
-	// Each chunk's time span must carry its speaker (per-segment attribution).
-	if len(st.spans) != 2 {
-		t.Fatalf("expected 2 spans, got %d", len(st.spans))
+// assertSpanSpeakers checks each recorded span carries the expected speaker id.
+func assertSpanSpeakers(t *testing.T, spans []model.Span, want ...string) {
+	t.Helper()
+	if len(spans) != len(want) {
+		t.Fatalf("expected %d spans, got %d", len(want), len(spans))
 	}
-	if st.spans[0].Speaker != "S1" || st.spans[1].Speaker != "S2" {
-		t.Errorf("span speakers = %q,%q want S1,S2", st.spans[0].Speaker, st.spans[1].Speaker)
+	for i, w := range want {
+		if spans[i].Speaker != w {
+			t.Errorf("span[%d].Speaker = %q, want %q", i, spans[i].Speaker, w)
+		}
 	}
 }
 

--- a/tests/mcp/search_speaker_test.go
+++ b/tests/mcp/search_speaker_test.go
@@ -1,0 +1,149 @@
+package tests
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// TestMCPSearch_SpeakerFilterPassedThrough verifies the dir2mcp_search tool
+// accepts the optional speaker filter (SPEC §8.6.8/§15.2) and forwards it to the
+// retriever's SearchQuery.
+func TestMCPSearch_SpeakerFilterPassedThrough(t *testing.T) {
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+
+	var gotSpeaker string
+	retriever := &askAudioRetrieverStub{
+		indexingComplete: true,
+		OnSearch: func(q model.SearchQuery) ([]model.SearchHit, error) {
+			gotSpeaker = q.Speaker
+			return []model.SearchHit{}, nil
+		},
+	}
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"dir2mcp_search","arguments":{"query":"q","speaker":"S2"}}}`)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d body=%s", resp.StatusCode, string(payload))
+	}
+	if gotSpeaker != "S2" {
+		t.Fatalf("speaker filter not forwarded to retriever, got %q want S2", gotSpeaker)
+	}
+}
+
+// TestMCPSearch_TimeSpanSurfacesSpeaker verifies a diarized "time" span hit
+// serializes speaker/speaker_label additively (SPEC §8.6.8/§9.2), and a hit
+// without a speaker does not include the keys.
+func TestMCPSearch_TimeSpanSurfacesSpeaker(t *testing.T) {
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+
+	retriever := &askAudioRetrieverStub{
+		indexingComplete: true,
+		searchHits: []model.SearchHit{
+			{
+				ChunkID: 1, RelPath: "interview.mp4", DocType: "video", Score: 0.9, Snippet: "guest",
+				Span: model.Span{Kind: "time", StartMS: 133000, EndMS: 161000, Speaker: "S2", SpeakerLabel: "Guest"},
+			},
+			{
+				ChunkID: 2, RelPath: "plain.mp3", DocType: "audio", Score: 0.8, Snippet: "flat",
+				Span: model.Span{Kind: "time", StartMS: 0, EndMS: 1000},
+			},
+		},
+	}
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"dir2mcp_search","arguments":{"query":"q","k":5}}}`)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d body=%s", resp.StatusCode, string(payload))
+	}
+
+	var envelope struct {
+		Result struct {
+			StructuredContent map[string]interface{} `json:"structuredContent"`
+		} `json:"result"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	hits, _ := envelope.Result.StructuredContent["hits"].([]interface{})
+	if len(hits) != 2 {
+		t.Fatalf("expected 2 hits, got %d", len(hits))
+	}
+
+	diarized := hits[0].(map[string]interface{})["span"].(map[string]interface{})
+	if diarized["speaker"] != "S2" {
+		t.Errorf("diarized span.speaker = %#v, want S2", diarized["speaker"])
+	}
+	if diarized["speaker_label"] != "Guest" {
+		t.Errorf("diarized span.speaker_label = %#v, want Guest", diarized["speaker_label"])
+	}
+
+	flat := hits[1].(map[string]interface{})["span"].(map[string]interface{})
+	if _, ok := flat["speaker"]; ok {
+		t.Errorf("non-diarized span must not carry speaker, got %#v", flat)
+	}
+}
+
+// TestMCPSearch_SchemaAdvertisesSpeaker confirms the search tool's input schema
+// exposes the optional speaker filter and the shared Span schema's time variant
+// documents speaker/speaker_label.
+func TestMCPSearch_SchemaAdvertisesSpeaker(t *testing.T) {
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+	retriever := &askAudioRetrieverStub{indexingComplete: true}
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d body=%s", resp.StatusCode, string(payload))
+	}
+
+	var envelope struct {
+		Result struct {
+			Tools []struct {
+				Name        string                 `json:"name"`
+				InputSchema map[string]interface{} `json:"inputSchema"`
+			} `json:"tools"`
+		} `json:"result"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	var found bool
+	for _, tool := range envelope.Result.Tools {
+		if tool.Name != "dir2mcp_search" {
+			continue
+		}
+		found = true
+		props, _ := tool.InputSchema["properties"].(map[string]interface{})
+		if _, ok := props["speaker"]; !ok {
+			t.Errorf("dir2mcp_search input schema missing optional speaker filter, props=%v", props)
+		}
+	}
+	if !found {
+		t.Fatal("dir2mcp_search tool not advertised")
+	}
+}

--- a/tests/retrieval/speaker_filter_test.go
+++ b/tests/retrieval/speaker_filter_test.go
@@ -1,0 +1,162 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
+)
+
+// addVecSpeaker upserts a vector whose payload carries a diarized "time" span
+// speaker, mirroring what payloadFromTask stores in production so the HNSW
+// pushdown filter (model.Filter.Match over the payload) sees the attribution.
+func addVecSpeaker(t *testing.T, idx *index.HNSWIndex, id uint64, vec []float32, relPath, docType, speaker, label string, startMS, endMS int) {
+	t.Helper()
+	span := model.Span{Kind: "time", StartMS: startMS, EndMS: endMS, Speaker: speaker, SpeakerLabel: label}
+	payload := model.IndexPayload{
+		ChunkID: id, RelPath: relPath, DocType: docType,
+		StartMS: startMS, EndMS: endMS, Speaker: speaker, SpeakerLabel: label, Span: span,
+	}
+	if err := idx.Upsert(context.Background(), vec, payload); err != nil {
+		t.Fatalf("Upsert(%d): %v", id, err)
+	}
+}
+
+// TestSearch_SpeakerFilter_RestrictsTimeHits verifies the optional speaker
+// filter restricts results to time-spanned transcript hits attributed to that
+// speaker (SPEC §8.6.8/§15.2). Hits for other speakers, and non-time chunks, are
+// excluded.
+func TestSearch_SpeakerFilter_RestrictsTimeHits(t *testing.T) {
+	idx := index.NewHNSWIndex("")
+	addVecSpeaker(t, idx, 1, []float32{1, 0}, "interview.mp4", "video", "S1", "Host", 0, 2000)
+	addVecSpeaker(t, idx, 2, []float32{0.95, 0.05}, "interview.mp4", "video", "S2", "Guest", 2000, 4000)
+	addVecP(t, idx, 3, []float32{0.9, 0.1}, "notes.md", "md")
+
+	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+		"mistral-embed": {1, 0},
+	}}, nil)
+	svc.SetChunkMetadata(1, model.SearchHit{
+		RelPath: "interview.mp4", DocType: "video", Snippet: "host speaks",
+		Span: model.Span{Kind: "time", StartMS: 0, EndMS: 2000, Speaker: "S1", SpeakerLabel: "Host"},
+	})
+	svc.SetChunkMetadata(2, model.SearchHit{
+		RelPath: "interview.mp4", DocType: "video", Snippet: "guest speaks",
+		Span: model.Span{Kind: "time", StartMS: 2000, EndMS: 4000, Speaker: "S2", SpeakerLabel: "Guest"},
+	})
+	svc.SetChunkMetadata(3, model.SearchHit{
+		RelPath: "notes.md", DocType: "md", Snippet: "no speaker",
+		Span: model.Span{Kind: "lines", StartLine: 1, EndLine: 3},
+	})
+
+	hits, err := svc.Search(context.Background(), model.SearchQuery{Query: "speaks", K: 10, Speaker: "S2"})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(hits) != 1 {
+		t.Fatalf("speaker filter S2 should yield exactly 1 hit, got %d: %+v", len(hits), hits)
+	}
+	if hits[0].ChunkID != 2 || hits[0].Span.Speaker != "S2" {
+		t.Fatalf("unexpected hit: %+v", hits[0])
+	}
+}
+
+// TestSearch_SpeakerFilter_CaseInsensitive confirms the speaker filter matches
+// case-insensitively (consistent with the other matchFilters predicates).
+func TestSearch_SpeakerFilter_CaseInsensitive(t *testing.T) {
+	idx := index.NewHNSWIndex("")
+	addVecSpeaker(t, idx, 1, []float32{1, 0}, "a.mp3", "audio", "S1", "", 0, 1000)
+	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+		"mistral-embed": {1, 0},
+	}}, nil)
+	svc.SetChunkMetadata(1, model.SearchHit{
+		RelPath: "a.mp3", DocType: "audio", Snippet: "x",
+		Span: model.Span{Kind: "time", StartMS: 0, EndMS: 1000, Speaker: "S1"},
+	})
+	hits, err := svc.Search(context.Background(), model.SearchQuery{Query: "x", K: 5, Speaker: "s1"})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(hits) != 1 {
+		t.Fatalf("case-insensitive speaker filter should match, got %d hits", len(hits))
+	}
+}
+
+// TestSearch_SpeakerFilter_NoDiarizedCorpus_NoHits confirms that a speaker
+// filter over a corpus with no diarized transcripts returns no hits (SPEC
+// §8.6.8), without affecting an unfiltered search.
+func TestSearch_SpeakerFilter_NoDiarizedCorpus_NoHits(t *testing.T) {
+	idx := index.NewHNSWIndex("")
+	addVecP(t, idx, 1, []float32{1, 0}, "plain.mp3", "audio")
+	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+		"mistral-embed": {1, 0},
+	}}, nil)
+	svc.SetChunkMetadata(1, model.SearchHit{
+		RelPath: "plain.mp3", DocType: "audio", Snippet: "x",
+		Span: model.Span{Kind: "time", StartMS: 0, EndMS: 1000}, // no speaker
+	})
+
+	// Filtered: no diarized segment -> no hits.
+	filtered, err := svc.Search(context.Background(), model.SearchQuery{Query: "x", K: 5, Speaker: "S1"})
+	if err != nil {
+		t.Fatalf("Search filtered: %v", err)
+	}
+	if len(filtered) != 0 {
+		t.Fatalf("speaker filter over a non-diarized corpus must return no hits, got %d", len(filtered))
+	}
+
+	// Unfiltered: behaviour unchanged (the chunk is still returned).
+	unfiltered, err := svc.Search(context.Background(), model.SearchQuery{Query: "x", K: 5})
+	if err != nil {
+		t.Fatalf("Search unfiltered: %v", err)
+	}
+	if len(unfiltered) != 1 {
+		t.Fatalf("unfiltered search must be unaffected, got %d hits", len(unfiltered))
+	}
+}
+
+// TestFormatCitation_AppendsSpeaker covers the §9.3 human-readable citation
+// format: a diarized time span appends the speaker, and the base form is used
+// unchanged when no speaker is present.
+func TestFormatCitation_AppendsSpeaker(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		span model.Span
+		want string
+	}{
+		{
+			name: "time with label",
+			path: "interview.mp4",
+			span: model.Span{Kind: "time", StartMS: 133000, EndMS: 161000, Speaker: "S2", SpeakerLabel: "Guest"},
+			want: "[interview.mp4@t=02:13-02:41 › Guest]",
+		},
+		{
+			name: "time with id only",
+			path: "interview.mp4",
+			span: model.Span{Kind: "time", StartMS: 133000, EndMS: 161000, Speaker: "S2"},
+			want: "[interview.mp4@t=02:13-02:41 › S2]",
+		},
+		{
+			name: "time no speaker (base form unchanged)",
+			path: "interview.mp4",
+			span: model.Span{Kind: "time", StartMS: 133000, EndMS: 161000},
+			want: "[interview.mp4@t=02:13-02:41]",
+		},
+		{
+			name: "page span (no speaker surface)",
+			path: "doc.pdf",
+			span: model.Span{Kind: "page", Page: 4},
+			want: "[doc.pdf@p=4]",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := retrieval.FormatCitation(tc.path, tc.span)
+			if got != tc.want {
+				t.Errorf("FormatCitation = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/tests/store/spans_time_speaker_test.go
+++ b/tests/store/spans_time_speaker_test.go
@@ -1,0 +1,90 @@
+package tests
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// TestTimeSpanSpeakerRoundTrip pins that diarized speaker attribution on a "time"
+// span survives SpanToRow -> SpanFromRow via the extra_json speaker/speaker_label
+// fields (SPEC §8.6.8).
+func TestTimeSpanSpeakerRoundTrip(t *testing.T) {
+	in := model.Span{Kind: "time", StartMS: 1000, EndMS: 4000, Speaker: "S2", SpeakerLabel: "Guest"}
+
+	kind, start, end, extra, err := store.SpanToRow(in)
+	if err != nil {
+		t.Fatalf("SpanToRow: %v", err)
+	}
+	if extra == "" {
+		t.Fatal("time span with a speaker must produce non-empty extra_json")
+	}
+	var decoded struct {
+		Speaker      string `json:"speaker"`
+		SpeakerLabel string `json:"speaker_label"`
+	}
+	if err := json.Unmarshal([]byte(extra), &decoded); err != nil {
+		t.Fatalf("extra_json not valid JSON: %v (%s)", err, extra)
+	}
+	if decoded.Speaker != "S2" || decoded.SpeakerLabel != "Guest" {
+		t.Fatalf("extra_json speaker = %q/%q, want S2/Guest (%s)", decoded.Speaker, decoded.SpeakerLabel, extra)
+	}
+
+	out := store.SpanFromRow(kind, start, end, extra)
+	if out.Kind != "time" || out.StartMS != 1000 || out.EndMS != 4000 {
+		t.Fatalf("round-trip lost time bounds: %+v", out)
+	}
+	if out.Speaker != "S2" || out.SpeakerLabel != "Guest" {
+		t.Errorf("round-trip speaker = %q/%q, want S2/Guest", out.Speaker, out.SpeakerLabel)
+	}
+}
+
+// TestTimeSpanSpeakerAndWordsCoexist confirms speaker attribution and per-word
+// timing share the same extra_json object without clobbering each other.
+func TestTimeSpanSpeakerAndWordsCoexist(t *testing.T) {
+	in := model.Span{
+		Kind: "time", StartMS: 0, EndMS: 2000, Speaker: "S1", SpeakerLabel: "Host",
+		Words: []model.WordSpan{{T: 0, D: 500, W: "hello"}},
+	}
+	kind, start, end, extra, err := store.SpanToRow(in)
+	if err != nil {
+		t.Fatalf("SpanToRow: %v", err)
+	}
+	out := store.SpanFromRow(kind, start, end, extra)
+	if out.Speaker != "S1" || out.SpeakerLabel != "Host" {
+		t.Errorf("speaker lost: %q/%q", out.Speaker, out.SpeakerLabel)
+	}
+	if len(out.Words) != 1 || out.Words[0].W != "hello" {
+		t.Errorf("words lost: %+v", out.Words)
+	}
+}
+
+// TestTimeSpanNoSpeaker_NoExtraJSON pins backward compatibility: a time span with
+// no speaker and no words produces an empty extra_json (SQL NULL), so a
+// non-diarized transcript round-trips byte-identically to before.
+func TestTimeSpanNoSpeaker_NoExtraJSON(t *testing.T) {
+	in := model.Span{Kind: "time", StartMS: 0, EndMS: 2000}
+	_, _, _, extra, err := store.SpanToRow(in)
+	if err != nil {
+		t.Fatalf("SpanToRow: %v", err)
+	}
+	if strings.TrimSpace(extra) != "" {
+		t.Fatalf("non-diarized time span produced extra_json %q, want empty", extra)
+	}
+}
+
+// TestTimeSpanLabelWithoutID_Dropped confirms a speaker_label with no stable id
+// is dropped (an id is the canonical attribution; a bare label is not valid).
+func TestTimeSpanLabelWithoutID_Dropped(t *testing.T) {
+	in := model.Span{Kind: "time", StartMS: 0, EndMS: 1000, SpeakerLabel: "Dangling"}
+	_, _, _, extra, err := store.SpanToRow(in)
+	if err != nil {
+		t.Fatalf("SpanToRow: %v", err)
+	}
+	if strings.Contains(extra, "Dangling") {
+		t.Fatalf("speaker_label without an id must be dropped, got extra_json %q", extra)
+	}
+}

--- a/tests/subtitle/voice_tag_test.go
+++ b/tests/subtitle/voice_tag_test.go
@@ -1,0 +1,81 @@
+package tests
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/subtitle"
+)
+
+// TestParseVTT_VoiceTag_PopulatesSpeaker verifies the WebVTT <v Name> voice tag
+// is parsed into Cue.Speaker (SPEC §8.6.8) while being stripped from the indexed
+// cue text.
+func TestParseVTT_VoiceTag_PopulatesSpeaker(t *testing.T) {
+	t.Parallel()
+	in := "WEBVTT\n\n" +
+		"00:00:00.000 --> 00:00:02.000\n<v Roger Bingham>Hello there\n\n" +
+		"00:00:02.000 --> 00:00:04.000\n<v Neil deGrasse Tyson>Good evening\n"
+	cues, err := subtitle.ParseVTT(in)
+	if err != nil {
+		t.Fatalf("ParseVTT: %v", err)
+	}
+	if len(cues) != 2 {
+		t.Fatalf("expected 2 cues, got %d", len(cues))
+	}
+	if cues[0].Speaker != "Roger Bingham" {
+		t.Errorf("cue[0].Speaker = %q, want %q", cues[0].Speaker, "Roger Bingham")
+	}
+	if cues[1].Speaker != "Neil deGrasse Tyson" {
+		t.Errorf("cue[1].Speaker = %q, want %q", cues[1].Speaker, "Neil deGrasse Tyson")
+	}
+	// The voice tag MUST be stripped from indexed text (metadata only).
+	if strings.Contains(cues[0].Text, "<v") || cues[0].Text != "Hello there" {
+		t.Errorf("cue[0].Text = %q, want %q (voice tag must be stripped)", cues[0].Text, "Hello there")
+	}
+}
+
+// TestParseVTT_VoiceTagWithClasses parses <v.class Name> (voice span with CSS
+// classes), keeping only the name.
+func TestParseVTT_VoiceTagWithClasses(t *testing.T) {
+	t.Parallel()
+	in := "WEBVTT\n\n00:00:00.000 --> 00:00:01.000\n<v.loud.first Bob>Shouting\n"
+	cues, err := subtitle.ParseVTT(in)
+	if err != nil {
+		t.Fatalf("ParseVTT: %v", err)
+	}
+	if len(cues) != 1 || cues[0].Speaker != "Bob" {
+		t.Fatalf("expected speaker Bob, got %+v", cues)
+	}
+}
+
+// TestParseVTT_NoVoiceTag_EmptySpeaker confirms a transcript without voice tags
+// carries no speaker, so behaviour is unchanged from before diarization.
+func TestParseVTT_NoVoiceTag_EmptySpeaker(t *testing.T) {
+	t.Parallel()
+	in := "WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nPlain caption\n"
+	cues, err := subtitle.ParseVTT(in)
+	if err != nil {
+		t.Fatalf("ParseVTT: %v", err)
+	}
+	if len(cues) != 1 || cues[0].Speaker != "" {
+		t.Fatalf("expected empty speaker, got %+v", cues)
+	}
+}
+
+// TestRenderVTT_EmitsVoiceTag confirms a cue with a speaker re-exports the <v>
+// voice tag (SPEC §8.6.3), and a cue without one renders unchanged.
+func TestRenderVTT_EmitsVoiceTag(t *testing.T) {
+	t.Parallel()
+	cues := []subtitle.Cue{
+		{StartMS: 0, EndMS: 1000, Text: "Hi", Speaker: "Alice"},
+		{StartMS: 1000, EndMS: 2000, Text: "Bye"},
+	}
+	out := subtitle.RenderVTT(cues)
+	if !strings.Contains(out, "<v Alice>Hi") {
+		t.Errorf("expected voice tag for Alice, got:\n%s", out)
+	}
+	// The speaker-less cue must not gain a voice tag.
+	if strings.Contains(out, "<v >") || strings.Contains(out, "<v>Bye") {
+		t.Errorf("speaker-less cue should not have a voice tag, got:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Summary

Implements GitHub issue #266 — **optional speaker diarization** (speaker-attributed transcripts) per SPEC §8.6.8 (+ §5.2/§5.4, §9.2/§9.3, §15.2). Speaker attribution is **metadata only**: it never changes chunk `text` or segment boundaries. Everything is **additive and OFF by default** — with diarization off and no `<v>` tags, behavior is byte-identical to today.

The fully-working-today path is the **WebVTT `<v Speaker>` sidecar** path. The model-driven diarization path is wired as an **injectable seam** (`SetDiarizer`); dir2mcp ships **no default diarizer**.

## What's included

**WebVTT `<v>` sidecar path (works now)**
- `internal/subtitle`: `Cue.Speaker` parsed from `<v Name>` / `<v.class Name>` voice tags (stripped from indexed text); `RenderVTT` re-emits `<v>` on export (§8.6.3).
- `internal/ingest`: subtitle cue chunking splits on speaker boundary and stamps a **stable, deterministic** per-transcript id (`S1`, `S2`, … in first-appearance order over time-sorted cues) plus the human label onto the `time` span. Sidecar rep_hash folds the voice name so a tag-only edit re-derives.

**Span / meta additions**
- `model.Span` + `IndexPayload` gain `Speaker`/`SpeakerLabel`; `time`-span `extra_json` carries `speaker`/`speaker_label` (omitempty), round-tripped via `spanFromRow` (`internal/store`).
- transcript `meta_json` gains `diarized` / `diarize_provider` / `diarize_model` / `speakers`.

**Search filter + citation**
- `dir2mcp_search` gains an optional `speaker` filter restricting time-spanned transcript hits (§15.2), evaluated by the Go-side `matchFilters` (pgvector/qdrant decline pushdown so it stays on one authoritative path).
- Hit `time` spans surface `speaker`/`speaker_label` additively (§9.2); common Span schema updated.
- `retrieval.FormatCitation` renders the §9.3 human-readable form, e.g. `[interview.mp4@t=02:13-02:41 > S2]` (label preferred, id fallback), unchanged when no speaker.

**Tri-state config + capability gate**
- `media.diarize.enabled` is a tri-state `*bool`: omit ⇒ auto-enable when the backend advertises the capability; `false` ⇒ force off; `true` ⇒ require it. Full flat+nested plumbing (`isMapSectionKey media.diarize`, key aliases, snapshot round-trip).
- New `provider.CapDiarize` capability; only `KindWhisper` (self-hosted WhisperX/pyannote endpoint) advertises it. `enabled:true` with no diarization-capable STT backend ⇒ `CONFIG_INVALID`; omit/false never fail.

**Derivation identity (§8.6.7)**
- The diarize provider/model joins the transcript derivation identity, so a diarize-backend change re-derives. Sidecar/pre-upgrade transcripts are never invalidated by a diarize-backend change.

## Tests (new, under `tests/`)
subtitle `<v>` → speaker; deterministic ids + metadata-only chunking; sidecar diarized meta; search `speaker` filter restricts time hits (incl. case-insensitive + empty-on-non-diarized-corpus); citation includes speaker; config tri-state incl. `enabled:true` + no/incapable backend ⇒ `CONFIG_INVALID`; derivation identity diarize-model swap re-derives / no-swap no churn; store extra_json round-trip; MCP schema + serialization.

## Notes
- `make check` passes locally (lint 0 issues, gocyclo clean, full suite green, build OK).
- `dirstral-spec` submodule is NOT re-pinned/committed.
- No default/fake diarization provider ships.

Closes #266
