### PR TITLE
fix(mcp): list_files fails open under symlinked root (#286 Bug A)

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -679,26 +679,54 @@ func (s *Server) canResolveRoot() bool {
 	return ok
 }
 
-// isResolvableSourceWithRoot reports whether doc's rel_path can be opened via
-// the open_file contract, using caller-cached rootAbs/rootReal values to avoid
-// re-running filepath.Abs + EvalSymlinks(root) per document. Archive members
-// are virtual paths (the backing file is the archive itself) so they're always
-// considered resolvable; everything else must point to a real file under root.
+// isResolvableSourceWithRoot reports whether doc's rel_path should be surfaced
+// by list_files, using caller-cached rootAbs/rootReal values to avoid re-running
+// filepath.Abs + EvalSymlinks(root) per document. Archive members are virtual
+// paths (the backing file is the archive itself) so they're always considered
+// resolvable.
+//
+// The filter is deliberately fail-OPEN (issue #286 Bug A): a document is only
+// excluded when we can AFFIRMATIVELY determine its source is gone (the path does
+// not exist) or genuinely lives outside the configured root. On any resolution
+// ambiguity — EvalSymlinks failing for a reason other than "not exist", or a
+// filepath.Rel error — we INCLUDE the document. This keeps real corpora visible
+// under symlinked roots (macOS /Users↔/private, /tmp→/private/tmp, or a corpus
+// reached through a symlinked path component), where the older fail-closed check
+// silently emptied the whole listing for files that actually exist.
+//
+// Both the root (rootReal, already EvalSymlinks-resolved by resolveRoot) and the
+// candidate target are compared in their symlink-resolved form so equivalent
+// symlinked paths match.
 func isResolvableSourceWithRoot(doc model.Document, rootAbs, rootReal string) bool {
 	if strings.EqualFold(strings.TrimSpace(doc.SourceType), "archive_member") {
 		return true
 	}
 	normalized := filepath.ToSlash(filepath.Clean(strings.TrimSpace(doc.RelPath)))
 	if normalized == "." || normalized == ".." || strings.HasPrefix(normalized, "../") || filepath.IsAbs(doc.RelPath) {
+		// An affirmatively malformed rel_path (traversal / absolute) can never
+		// round-trip through open_file, so excluding it is safe.
 		return false
 	}
 	absPath := filepath.Join(rootAbs, filepath.FromSlash(normalized))
 	targetReal, err := filepath.EvalSymlinks(absPath)
 	if err != nil {
-		return false
+		// Only treat a definitive "does not exist" as proof the source is gone.
+		// Any other error (permissions, transient I/O, symlink-evaluation
+		// ambiguity) is inconclusive, so we fail open and keep the document.
+		if errors.Is(err, fs.ErrNotExist) {
+			return false
+		}
+		return true
 	}
 	rel, err := filepath.Rel(rootReal, targetReal)
-	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+	if err != nil {
+		// We could not compute a relationship to the root; that is ambiguous,
+		// not proof the file is outside the root, so fail open and include it.
+		return true
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		// The resolved target sits outside the resolved root: affirmatively
+		// out-of-bounds, so exclude it.
 		return false
 	}
 	return true

--- a/tests/mcp/tools_test.go
+++ b/tests/mcp/tools_test.go
@@ -1729,6 +1729,177 @@ func assertAdversarialPaths(t *testing.T, rootDir string, gotPaths map[string]bo
 	}
 }
 
+// TestMCPToolsCallListFiles_SymlinkedRootStillLists is the regression test for
+// issue #286 Bug A: list_files must keep surfacing real files when the
+// configured root is reached through a symlink (the macOS shape where
+// /Users↔/private or /tmp→/private/tmp, or a corpus directory itself, is a
+// symlink). The older filter resolved both root and candidate with EvalSymlinks
+// and then fail-CLOSED on any resolution error, which silently emptied the whole
+// listing for files that actually exist. The fix is fail-OPEN: only exclude when
+// a source is provably gone/outside-root. A genuinely stale row (no backing
+// file) must still be excluded so the round-trip-through-open_file contract from
+// issue #176 holds.
+func TestMCPToolsCallListFiles_SymlinkedRootStillLists(t *testing.T) {
+	// realRoot holds the actual corpus; linkRoot is a symlink pointing at it and
+	// is what the daemon is configured with. The store still records rel_paths
+	// relative to the root (same shape either way).
+	base := t.TempDir()
+	realRoot := filepath.Join(base, "real-corpus")
+	if err := os.MkdirAll(realRoot, 0o755); err != nil {
+		t.Fatalf("mkdir real root: %v", err)
+	}
+	linkRoot := filepath.Join(base, "linked-corpus")
+	if err := os.Symlink(realRoot, linkRoot); err != nil {
+		t.Skipf("symlinks unsupported on this platform: %v", err)
+	}
+
+	stateDir := filepath.Join(realRoot, ".dir2mcp")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+
+	present := []string{
+		"normal.pdf",
+		"acts/foo.pdf",
+		"acts/sub/bar.pdf",
+	}
+	stalePath := "ghost/missing.pdf"
+
+	// The shared helper writes files with os.WriteFile (no mkdir), so create the
+	// nested parents up front for the files that live in subdirectories.
+	for _, name := range present {
+		if dir := filepath.Dir(name); dir != "." {
+			if err := os.MkdirAll(filepath.Join(realRoot, dir), 0o755); err != nil {
+				t.Fatalf("mkdir parent for %s: %v", name, err)
+			}
+		}
+	}
+
+	// setupAdversarialListFilesStore writes the present files to realRoot and
+	// registers all of them plus the stale (file-less) row in the store.
+	st := setupAdversarialListFilesStore(t, realRoot, stateDir, present, stalePath)
+
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+	// Configure the daemon with the SYMLINK path, not the real directory.
+	cfg.RootDir = linkRoot
+	cfg.StateDir = stateDir
+	cfg.MCPPath = protocol.DefaultMCPPath
+
+	server := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st)).Handler())
+	defer server.Close()
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+
+	gotPaths := callListFilesAndExtractPaths(t, server.URL+cfg.MCPPath, sessionID)
+
+	if len(gotPaths) == 0 {
+		t.Fatalf("list_files returned nothing under symlinked root %q (Bug A)", linkRoot)
+	}
+	for _, name := range present {
+		if !gotPaths[name] {
+			t.Fatalf("expected list_files to surface real file %q under symlinked root; got %#v", name, gotPaths)
+		}
+	}
+	if gotPaths[stalePath] {
+		t.Fatalf("stale rel_path %q (no backing file) must not surface even under symlinked root; got %#v", stalePath, gotPaths)
+	}
+}
+
+// TestMCPToolsCallListFiles_FailsOpenOnInconclusiveResolution is the
+// deterministic regression for issue #286 Bug A's core: list_files must INCLUDE
+// a document when its source cannot be conclusively resolved, rather than
+// silently dropping it. The old filter excluded a doc whenever EvalSymlinks
+// returned ANY error; here we make EvalSymlinks fail with a permission error
+// (EACCES, not ErrNotExist) for a file that genuinely exists by removing search
+// permission on its parent directory. Under the old fail-CLOSED behavior the
+// file vanished from the listing; the fix fails OPEN and keeps it. A genuinely
+// missing file (ErrNotExist) must still be excluded.
+func TestMCPToolsCallListFiles_FailsOpenOnInconclusiveResolution(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root bypasses directory permission checks")
+	}
+
+	rootDir := t.TempDir()
+	stateDir := filepath.Join(rootDir, ".dir2mcp")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+
+	// "open.pdf" resolves normally. "locked/inside.pdf" exists on disk but its
+	// parent has its search bit stripped, so EvalSymlinks returns EACCES — an
+	// inconclusive error that must NOT cause exclusion.
+	plainName := "open.pdf"
+	lockedDir := "locked"
+	lockedName := filepath.ToSlash(filepath.Join(lockedDir, "inside.pdf"))
+	stalePath := "ghost/missing.pdf"
+
+	body := []byte("hello world\n")
+	if err := os.WriteFile(filepath.Join(rootDir, plainName), body, 0o644); err != nil {
+		t.Fatalf("write plain file: %v", err)
+	}
+	lockedAbsDir := filepath.Join(rootDir, lockedDir)
+	if err := os.MkdirAll(lockedAbsDir, 0o755); err != nil {
+		t.Fatalf("mkdir locked dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(lockedAbsDir, "inside.pdf"), body, 0o644); err != nil {
+		t.Fatalf("write locked file: %v", err)
+	}
+
+	st := store.NewSQLiteStore(filepath.Join(stateDir, "meta.sqlite"))
+	if err := st.Init(context.Background()); err != nil {
+		t.Fatalf("init store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	for _, rel := range []string{plainName, lockedName, stalePath} {
+		if err := st.UpsertDocument(context.Background(), model.Document{
+			RelPath:     rel,
+			DocType:     "pdf",
+			SourceType:  "filesystem",
+			SizeBytes:   int64(len(body)),
+			MTimeUnix:   1,
+			ContentHash: "h",
+			Status:      "ok",
+		}); err != nil {
+			t.Fatalf("upsert %s: %v", rel, err)
+		}
+	}
+
+	// Strip search permission on the locked parent so EvalSymlinks on its child
+	// fails with EACCES. Restore before cleanup so t.TempDir can remove it.
+	if err := os.Chmod(lockedAbsDir, 0o000); err != nil {
+		t.Fatalf("chmod locked dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(lockedAbsDir, 0o755) })
+
+	// Confirm the platform actually denies traversal; if not (e.g. some CI
+	// filesystems), the scenario is moot and we skip rather than assert wrongly.
+	if _, err := filepath.EvalSymlinks(filepath.Join(lockedAbsDir, "inside.pdf")); err == nil || errors.Is(err, os.ErrNotExist) {
+		t.Skipf("platform does not enforce directory search permission (EvalSymlinks err=%v); cannot exercise inconclusive-resolution path", err)
+	}
+
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+	cfg.RootDir = rootDir
+	cfg.StateDir = stateDir
+	cfg.MCPPath = protocol.DefaultMCPPath
+
+	server := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st)).Handler())
+	defer server.Close()
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+
+	gotPaths := callListFilesAndExtractPaths(t, server.URL+cfg.MCPPath, sessionID)
+
+	if !gotPaths[plainName] {
+		t.Fatalf("expected list_files to surface normally-resolvable %q; got %#v", plainName, gotPaths)
+	}
+	if !gotPaths[lockedName] {
+		t.Fatalf("list_files dropped %q on inconclusive (EACCES) resolution; filter must fail OPEN (Bug A); got %#v", lockedName, gotPaths)
+	}
+	if gotPaths[stalePath] {
+		t.Fatalf("genuinely missing %q must still be excluded; got %#v", stalePath, gotPaths)
+	}
+}
+
 // TestMCPToolsCallOpenFile_PDFNoSpan_DocumentSpan asserts that calling
 // open_file on a .pdf without span arguments returns the OCR text and tags
 // the structured content with span.kind=document so callers can distinguish


### PR DESCRIPTION
## Summary

Fixes #286, a p1 bug surfaced from a real MCP session over a legal-PDF corpus on macOS where two corpus-navigation tools failed.

### Bug A — `list_files` silently empties under a symlinked root (fixed here)

`internal/mcp/tools.go` `isResolvableSourceWithRoot` excluded **any** document whose source could not be resolved via `filepath.EvalSymlinks` / `filepath.Rel`. On macOS, symlinked roots (`/Users`↔`/private`, `/tmp`→`/private/tmp`, or a corpus reached through a symlinked path component) could make that resolution fail for files that **actually exist**, so the entire listing was silently emptied.

The filter is now **fail-open**: a document is excluded only when its source is **affirmatively** gone or out-of-bounds, namely:

- `EvalSymlinks` returns `fs.ErrNotExist` → source is provably gone → exclude.
- clean `filepath.Rel(rootReal, targetReal)` yields a parent escape (`..`) → provably outside root → exclude.
- a malformed rel_path (`.`, `..`, `../…`, absolute) → can never round-trip through `open_file` → exclude.

Every other outcome — `EvalSymlinks` failing for a non-`ErrNotExist` reason (permissions, transient I/O, symlink-evaluation ambiguity) or a `Rel` error — is **inconclusive**, so the document is **kept**. Both the root and the candidate are still compared in their symlink-resolved form, so equivalent symlinked paths match. The existing issue-#176 contract (stale, file-less rows must stay excluded so `list_files` paths round-trip through `open_file`) is preserved.

### Bug B — `path_prefix` matched nothing in search/ask (already fixed on main)

This was already resolved on `main` (PR #287, commit `aecaa2a`): `internal/store/sqlite_store.go` and `internal/retrieval/service.go` now share `model.NormalizePathPrefix` / `model.MatchesPathPrefix` (`internal/model/pathprefix.go`), so `list_files` and `search`/`ask` apply identical prefix normalization (strip leading `./` and `/`, clean, slash-normalize, ASCII case-fold to match SQLite `LIKE`). Cross-check coverage already exists (`tests/store/path_prefix_consistency_test.go`, `tests/model/path_prefix_test.go`). No further change was needed for Bug B.

## Tests

Added to the external `tests` package under `tests/mcp` (`tools_test.go`):

- `TestMCPToolsCallListFiles_FailsOpenOnInconclusiveResolution` — strips the search bit on a file's parent directory so `EvalSymlinks` returns `EACCES` (not `ErrNotExist`) for a file that genuinely exists, and asserts the file is still listed while a genuinely missing row stays excluded. Verified to **fail on the pre-fix code** and pass after.
- `TestMCPToolsCallListFiles_SymlinkedRootStillLists` — points the daemon root at a symlink to the real corpus and asserts real files (including nested ones) still list while a stale file-less row stays excluded.

The pre-existing `TestMCPToolsCallListFiles_RoundTripsAdversarialNames` (#176) continues to pass.

## Verification

- No MCP tool input/output JSON schema or citation-provenance contract changed (behavior-only fix).
- `golangci-lint cache clean` then `make check` run green from the worktree root (gofmt, vet, lint, cyclo, ineffassign, misspell, all Go tests, python release tools, build).
- `dirstral-spec` submodule not re-pinned (init only).

Closes #286
