### PR TITLE
feat(retrieval): configurable server-side relevance floor (min-score cutoff)

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,18 @@ An optional post-fusion **reranking** stage can re-score retrieval candidates wi
 - Env overrides: `COHERE_API_KEY=...` auto-enables; `DIR2MCP_RERANK_ENABLED=false` opts out even with a credential; `DIR2MCP_RERANK_MODEL=...` overrides the model. Env wins over YAML for the key; the key is a secret and is never written to the config snapshot.
 - For `index=both`, reranking is applied once to the merged candidate pool. Ordering is deterministic (relevance desc, then `chunk_id`).
 
+### Relevance floor (optional)
+
+An optional **relevance floor** drops low-similarity candidate hits before they reach the model, so a query with no strongly-relevant chunks returns fewer (or zero) results instead of diluting the answer with weak context. It is **server-side and config-only** — not an MCP tool parameter, so it changes no tool input/output schema.
+
+- The floor is applied **last**, after scoring/fusion, reranking, and dedup/truncation, using each hit's final (post-rerank) score. A hit whose score equals the floor is **kept** (strict less-than drops).
+- **Default `0` = disabled** (pass-through): behavior is unchanged unless you configure it. A negative value is rejected as invalid config.
+
+  ```yaml
+  retrieval:
+    min_score: 0.0   # 0 disables; e.g. 0.4 drops hits scoring below 0.4
+  ```
+
 ### Auth token behavior
 
 `dir2mcp` bearer auth can come from:

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -750,6 +750,7 @@ func (a *App) buildRetrieverForAsk(ctx context.Context, cfg config.Config, st mo
 	ret.SetMaxContextChars(cfg.RAGMaxContextChars)
 	ret.SetOversampleFactor(cfg.RAGOversampleFactor)
 	a.configureReranker(ret, cfg)
+	ret.SetMinScore(cfg.RetrievalMinScore)
 
 	if metadataStore, ok := st.(embeddedChunkLister); ok {
 		if _, err := preloadEmbeddedChunkMetadata(ctx, metadataStore, ret); err != nil && !errors.Is(err, model.ErrNotImplemented) {

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -78,6 +78,7 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 	ret.SetOversampleFactor(cfg.RAGOversampleFactor)
 	a.configureReranker(ret, cfg)
 	ret.SetCrossFileDedupEnabled(cfg.DedupRetrieval)
+	ret.SetMinScore(cfg.RetrievalMinScore)
 
 	// events are emitted to stdout only after we create the emitter; moving
 	// creation before the preload call lets us report failures from that

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -167,6 +167,14 @@ type Config struct {
 	// share an identical content_hash to a single best-ranked survivor before
 	// rerank/truncation. Default false (every candidate is returned as before).
 	DedupRetrieval bool
+	// RetrievalMinScore is a server-side relevance floor (config
+	// `retrieval.min_score`): candidate hits whose final (authoritative) score is
+	// strictly below this value are dropped after scoring/fusion/rerank and after
+	// dedup/truncation, before results reach the model. It is config-only (NOT an
+	// MCP tool parameter) so no tool input/output schema changes. Default 0 =
+	// disabled (no floor): behavior is unchanged unless configured, preserving the
+	// local-first, no-surprises default. Negative values are CONFIG_INVALID.
+	RetrievalMinScore float64
 	// Rerank* configure the optional post-fusion rerank stage (SPEC
 	// 9.1.1). Reranking auto-activates when a provider credential is
 	// present. CohereAPIKey is a secret: env-sourced, never persisted
@@ -399,6 +407,7 @@ type fileConfig struct {
 	RAGOversampleFactor       *int
 	RetrievalHybridEnabled    *bool
 	DedupRetrieval            *bool
+	RetrievalMinScore         *float64
 	RerankEnabled             *bool
 	RerankProvider            *string
 	CohereAPIKey              *string
@@ -501,6 +510,7 @@ type persistedConfig struct {
 	RAGOversampleFactor       int           `yaml:"rag_oversample_factor"`
 	RetrievalHybridEnabled    bool          `yaml:"retrieval_hybrid_enabled"`
 	DedupRetrieval            bool          `yaml:"dedup_retrieval"`
+	RetrievalMinScore         float64       `yaml:"retrieval_min_score"`
 	RerankEnabled             bool          `yaml:"rerank_enabled"`
 	RerankProvider            string        `yaml:"rerank_provider"`
 	CohereBaseURL             string        `yaml:"cohere_base_url"`
@@ -639,6 +649,9 @@ func Default() Config {
 		// DedupRetrieval defaults to false (SPEC 9.2): retrieval-time
 		// cross-file de-duplication is off unless explicitly enabled.
 		DedupRetrieval: false,
+		// RetrievalMinScore defaults to 0 (disabled): no relevance floor is
+		// applied unless explicitly configured.
+		RetrievalMinScore: 0,
 		// RerankEnabled left nil: auto mode (activates iff a rerank
 		// provider credential is present). See rerankEnabledEffective.
 		RerankProvider:            "cohere",
@@ -745,6 +758,7 @@ func buildPersistedConfig(cfg *Config) persistedConfig {
 		RAGOversampleFactor:       cfg.RAGOversampleFactor,
 		RetrievalHybridEnabled:    cfg.RetrievalHybridEnabled,
 		DedupRetrieval:            cfg.DedupRetrieval,
+		RetrievalMinScore:         cfg.RetrievalMinScore,
 		RerankEnabled:             rerankEnabledEffective(cfg),
 		RerankProvider:            cfg.RerankProvider,
 		CohereBaseURL:             cfg.CohereBaseURL,
@@ -1302,6 +1316,9 @@ func applyModelRAGFileParsed(cfg *Config, fc fileConfig) {
 	if fc.DedupRetrieval != nil {
 		cfg.DedupRetrieval = *fc.DedupRetrieval
 	}
+	if fc.RetrievalMinScore != nil {
+		cfg.RetrievalMinScore = *fc.RetrievalMinScore
+	}
 	if fc.SessionInactivityTimeout != nil {
 		cfg.SessionInactivityTimeout = *fc.SessionInactivityTimeout
 	}
@@ -1675,6 +1692,8 @@ var configKeyAliases = map[string]string{
 	"retrieval_hybrid_enabled":             "retrieval.hybrid.enabled",
 	"hybrid_enabled":                       "retrieval.hybrid.enabled",
 	"dedup_retrieval":                      "dedup.retrieval",
+	"retrieval_min_score":                  "retrieval.min_score",
+	"min_score":                            "retrieval.min_score",
 	"rerank_enabled":                       "rerank.enabled",
 	"rerank.cohere.api_key":                "cohere_api_key",
 	"rerank.cohere.base_url":               "cohere_base_url",
@@ -1905,6 +1924,8 @@ func setFloatFileScalar(cfg *fileConfig, key, value string) error {
 	switch key {
 	case "media.silence_threshold_db":
 		target = &cfg.MediaSilenceThresholdDB
+	case "retrieval.min_score":
+		target = &cfg.RetrievalMinScore
 	default:
 		return nil
 	}
@@ -2212,6 +2233,7 @@ func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	writeInt("rag_oversample_factor", cfg.RAGOversampleFactor)
 	writeBool("retrieval_hybrid_enabled", cfg.RetrievalHybridEnabled)
 	writeBool("dedup_retrieval", cfg.DedupRetrieval)
+	writeScalar("retrieval_min_score", strconv.FormatFloat(cfg.RetrievalMinScore, 'f', -1, 64))
 	writeBool("rerank_enabled", cfg.RerankEnabled)
 	writeScalar("rerank_provider", cfg.RerankProvider)
 	writeScalar("cohere_base_url", cfg.CohereBaseURL)
@@ -2855,6 +2877,14 @@ func (c *Config) validateNumericBounds() error {
 	}
 	if c.IngestMaxFileMB < 0 {
 		return fmt.Errorf("ingest.max_file_mb must be non-negative: %d", c.IngestMaxFileMB)
+	}
+	// retrieval.min_score is a relevance floor; 0 disables it. A negative floor is
+	// meaningless (it would never drop anything) so reject it explicitly. NaN/Inf
+	// are already rejected at parse time in setFloatFileScalar, but guard here too
+	// so a value injected programmatically (not via the file parser) still fails
+	// validation rather than silently corrupting the floor comparison.
+	if c.RetrievalMinScore < 0 || math.IsNaN(c.RetrievalMinScore) || math.IsInf(c.RetrievalMinScore, 0) {
+		return fmt.Errorf("retrieval.min_score must be a non-negative finite number: %v", c.RetrievalMinScore)
 	}
 	return nil
 }

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -123,6 +123,12 @@ type Service struct {
 	// grouping key for cross-file dedup; an empty/absent value disables
 	// grouping for that path (entries are never collapsed together).
 	groupKeyByRelPath map[string]string
+	// minScore is a server-side relevance floor (config retrieval.min_score):
+	// hits whose final (authoritative) Score is strictly below it are dropped
+	// from Search results, after scoring/fusion/rerank/dedup/truncation. It is
+	// config-only (never an MCP tool parameter). Default 0 ⇒ disabled
+	// (pass-through). Wired from config.RetrievalMinScore at construction.
+	minScore float64
 }
 
 // compile-time assertion that Service implements model.Retriever.  This
@@ -208,6 +214,17 @@ func (s *Service) SetCrossFileDedupEnabled(enabled bool) {
 	s.metaMu.Lock()
 	defer s.metaMu.Unlock()
 	s.crossFileDedupEnabled = enabled
+}
+
+// SetMinScore wires the server-side relevance floor (config retrieval.min_score).
+// Hits whose final authoritative Score is strictly below floor are dropped from
+// Search results, after scoring/fusion/rerank and after dedup/truncation. A
+// floor <= 0 disables the cutoff (pass-through). The engine wires this from
+// config.RetrievalMinScore at construction time, mirroring SetCrossFileDedupEnabled.
+func (s *Service) SetMinScore(floor float64) {
+	s.metaMu.Lock()
+	defer s.metaMu.Unlock()
+	s.minScore = floor
 }
 
 // SetDocumentHashes installs the rel_path → content_hash map used to group
@@ -527,21 +544,56 @@ func (s *Service) Search(ctx context.Context, query model.SearchQuery) ([]model.
 	if mode == "" {
 		mode = "auto"
 	}
+	var (
+		hits []model.SearchHit
+		err  error
+	)
 	switch mode {
 	case "text":
-		return s.searchSingleIndex(ctx, query.Query, k, textModel, textIndex, "text", query, true)
+		hits, err = s.searchSingleIndex(ctx, query.Query, k, textModel, textIndex, "text", query, true)
 	case "code":
-		return s.searchSingleIndex(ctx, query.Query, k, codeModel, codeIndex, "code", query, true)
+		hits, err = s.searchSingleIndex(ctx, query.Query, k, codeModel, codeIndex, "code", query, true)
 	case "both":
-		return s.searchBothIndices(ctx, query.Query, k, textModel, codeModel, textIndex, codeIndex, query)
+		hits, err = s.searchBothIndices(ctx, query.Query, k, textModel, codeModel, textIndex, codeIndex, query)
 	case "auto":
 		if looksLikeCodeQuery(query.Query) {
-			return s.searchSingleIndex(ctx, query.Query, k, codeModel, codeIndex, "code", query, true)
+			hits, err = s.searchSingleIndex(ctx, query.Query, k, codeModel, codeIndex, "code", query, true)
+		} else {
+			hits, err = s.searchSingleIndex(ctx, query.Query, k, textModel, textIndex, "text", query, true)
 		}
-		return s.searchSingleIndex(ctx, query.Query, k, textModel, textIndex, "text", query, true)
 	default:
-		return s.searchSingleIndex(ctx, query.Query, k, textModel, textIndex, "text", query, true)
+		hits, err = s.searchSingleIndex(ctx, query.Query, k, textModel, textIndex, "text", query, true)
 	}
+	if err != nil {
+		return nil, err
+	}
+	// Apply the server-side relevance floor LAST: after scoring/fusion/rerank
+	// (the per-mode searches above) and after their dedup/truncation, using each
+	// hit's final authoritative Score. Config-only; default 0 ⇒ pass-through.
+	return s.applyMinScoreFloor(hits), nil
+}
+
+// applyMinScoreFloor drops hits whose final authoritative Score is strictly
+// below the configured relevance floor (config retrieval.min_score). A floor
+// <= 0 disables the cutoff and returns hits unchanged (pass-through), preserving
+// the slice identity so callers see no allocation when unconfigured. Order is
+// preserved. This runs as the very last retrieval step so the comparison uses
+// the post-rerank score (or, when rerank is off, the fused score).
+func (s *Service) applyMinScoreFloor(hits []model.SearchHit) []model.SearchHit {
+	s.metaMu.RLock()
+	floor := s.minScore
+	s.metaMu.RUnlock()
+	if floor <= 0 || len(hits) == 0 {
+		return hits
+	}
+	out := make([]model.SearchHit, 0, len(hits))
+	for _, h := range hits {
+		if h.Score < floor {
+			continue
+		}
+		out = append(out, h)
+	}
+	return out
 }
 
 func (s *Service) Ask(ctx context.Context, question string, query model.SearchQuery) (model.AskResult, error) {

--- a/tests/config/retrieval_min_score_config_test.go
+++ b/tests/config/retrieval_min_score_config_test.go
@@ -1,0 +1,125 @@
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+)
+
+// TestRetrievalMinScore_DefaultDisabled pins the local-first default: the
+// relevance floor is 0 (disabled) unless explicitly configured.
+func TestRetrievalMinScore_DefaultDisabled(t *testing.T) {
+	cfg := config.Default()
+	if cfg.RetrievalMinScore != 0 {
+		t.Fatalf("retrieval.min_score must default to 0 (disabled), got %v", cfg.RetrievalMinScore)
+	}
+}
+
+// TestRetrievalMinScore_NestedYAMLRoundTrips pins the nested-mapping form
+// (retrieval: \n  min_score: 0.4) onto Config.RetrievalMinScore.
+func TestRetrievalMinScore_NestedYAMLRoundTrips(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+	writeFile(t, path, strings.Join([]string{
+		"retrieval:",
+		"  min_score: 0.42",
+		"",
+	}, "\n"))
+
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if cfg.RetrievalMinScore != 0.42 {
+		t.Fatalf("nested retrieval.min_score = %v, want 0.42", cfg.RetrievalMinScore)
+	}
+}
+
+// TestRetrievalMinScore_FlatAliasRoundTrips pins the flat snake_case alias
+// (retrieval_min_score -> retrieval.min_score).
+func TestRetrievalMinScore_FlatAliasRoundTrips(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+	writeFile(t, path, "retrieval_min_score: 0.25\n")
+
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if cfg.RetrievalMinScore != 0.25 {
+		t.Fatalf("flat retrieval_min_score = %v, want 0.25", cfg.RetrievalMinScore)
+	}
+}
+
+// TestRetrievalMinScore_SnapshotRoundTrips pins the persisted-snapshot
+// round-trip: the floor survives SaveEffectiveSnapshot -> YAML -> load.
+func TestRetrievalMinScore_SnapshotRoundTrips(t *testing.T) {
+	cfg := config.Default()
+	cfg.StateDir = t.TempDir()
+	cfg.RetrievalMinScore = 0.33
+
+	path, err := config.SaveEffectiveSnapshot(cfg, config.SecretSourceMetadata{})
+	if err != nil {
+		t.Fatalf("SaveEffectiveSnapshot: %v", err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !strings.Contains(string(raw), "retrieval_min_score: 0.33") {
+		t.Fatalf("snapshot must persist retrieval_min_score: 0.33:\n%s", raw)
+	}
+
+	loaded, _, err := config.LoadEffectiveSnapshot(path)
+	if err != nil {
+		t.Fatalf("LoadEffectiveSnapshot: %v", err)
+	}
+	if loaded.RetrievalMinScore != 0.33 {
+		t.Fatalf("loaded snapshot must carry RetrievalMinScore=0.33, got %v", loaded.RetrievalMinScore)
+	}
+}
+
+// TestRetrievalMinScore_RejectsNonFinite asserts NaN/Inf strings (which
+// strconv.ParseFloat accepts) are rejected at config-parse time rather than
+// silently corrupting the floor comparison.
+func TestRetrievalMinScore_RejectsNonFinite(t *testing.T) {
+	for _, bad := range []string{"NaN", "Inf", "+Inf", "-Inf", "Infinity"} {
+		tmp := t.TempDir()
+		path := filepath.Join(tmp, ".dir2mcp.yaml")
+		writeFile(t, path, "retrieval_min_score: "+bad+"\n")
+
+		if _, err := config.LoadFile(path); err == nil {
+			t.Errorf("LoadFile with retrieval_min_score=%q = nil error, want rejection", bad)
+		}
+	}
+}
+
+// TestRetrievalMinScore_RejectsNegative pins validation: a negative floor is
+// CONFIG_INVALID (it would never drop anything, so it is a misconfiguration).
+func TestRetrievalMinScore_RejectsNegative(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+	writeFile(t, path, "retrieval_min_score: -0.1\n")
+
+	_, err := config.LoadFile(path)
+	if err == nil {
+		t.Fatalf("LoadFile with negative retrieval_min_score = nil error, want rejection")
+	}
+	if !strings.Contains(err.Error(), "retrieval.min_score") {
+		t.Fatalf("error must mention retrieval.min_score, got: %v", err)
+	}
+}
+
+// TestRetrievalMinScore_ValidateRejectsNegativeProgrammatic pins that the
+// Validate() guard rejects a negative floor injected programmatically (not via
+// the file parser), so the comparison can never run with a bad floor.
+func TestRetrievalMinScore_ValidateRejectsNegativeProgrammatic(t *testing.T) {
+	cfg := config.Default()
+	cfg.RetrievalMinScore = -1
+	if err := cfg.Validate(); err == nil {
+		t.Fatalf("Validate with negative RetrievalMinScore = nil error, want rejection")
+	}
+}

--- a/tests/retrieval/min_score_floor_test.go
+++ b/tests/retrieval/min_score_floor_test.go
@@ -1,0 +1,112 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
+)
+
+// newMinScoreFloorService builds a vector-only retrieval service (nil store
+// keeps hybrid fusion from engaging, so each hit's Score is the raw cosine
+// similarity) with the server-side relevance floor configured.
+//
+// The three candidates have deterministic cosine scores against the query
+// vector {1, 0}: chunk 1 → 1.00, chunk 2 → 0.60, chunk 3 → 0.28.
+func newMinScoreFloorService(t *testing.T, floor float64) *retrieval.Service {
+	t.Helper()
+	idx := index.NewHNSWIndex("")
+	addVec(t, idx, 1, []float32{1, 0})       // cosine 1.00
+	addVec(t, idx, 2, []float32{0.6, 0.8})   // cosine 0.60 (unit vector)
+	addVec(t, idx, 3, []float32{0.28, 0.96}) // cosine 0.28 (unit vector)
+
+	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+		"mistral-embed": {1, 0},
+	}}, nil)
+	svc.SetChunkMetadata(1, model.SearchHit{RelPath: "a.md", Snippet: "alpha"})
+	svc.SetChunkMetadata(2, model.SearchHit{RelPath: "b.md", Snippet: "beta"})
+	svc.SetChunkMetadata(3, model.SearchHit{RelPath: "c.md", Snippet: "gamma"})
+	svc.SetMinScore(floor)
+	return svc
+}
+
+func searchFloorChunkIDs(t *testing.T, svc *retrieval.Service) []uint64 {
+	t.Helper()
+	hits, err := svc.Search(context.Background(), model.SearchQuery{Query: "alpha", K: 10})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	ids := make([]uint64, 0, len(hits))
+	for _, h := range hits {
+		ids = append(ids, h.ChunkID)
+	}
+	return ids
+}
+
+// TestSearch_MinScoreFloor_DropsSubThresholdHits pins the core behavior: with a
+// floor of 0.5, the two strong hits (scores 1.00 and 0.60) survive and the weak
+// hit (0.28) is dropped before results reach the model.
+func TestSearch_MinScoreFloor_DropsSubThresholdHits(t *testing.T) {
+	svc := newMinScoreFloorService(t, 0.5)
+	got := searchFloorChunkIDs(t, svc)
+	want := []uint64{1, 2}
+	if len(got) != len(want) {
+		t.Fatalf("expected %v survivors, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("order/survivor mismatch: want %v, got %v", want, got)
+		}
+	}
+}
+
+// TestSearch_MinScoreFloor_DisabledIsPassThrough pins the default-off behavior:
+// floor 0 returns every candidate unchanged, including the weak (0.28) hit.
+func TestSearch_MinScoreFloor_DisabledIsPassThrough(t *testing.T) {
+	svc := newMinScoreFloorService(t, 0)
+	got := searchFloorChunkIDs(t, svc)
+	if len(got) != 3 {
+		t.Fatalf("floor=0 must pass through all candidates; got %v", got)
+	}
+}
+
+// TestSearch_MinScoreFloor_NegativeIsPassThrough pins that a non-positive floor
+// (defensive: validation rejects negatives, but the service itself treats <= 0
+// as disabled) is a pass-through rather than dropping everything.
+func TestSearch_MinScoreFloor_NegativeIsPassThrough(t *testing.T) {
+	svc := newMinScoreFloorService(t, -1)
+	got := searchFloorChunkIDs(t, svc)
+	if len(got) != 3 {
+		t.Fatalf("floor<=0 must pass through all candidates; got %v", got)
+	}
+}
+
+// TestSearch_MinScoreFloor_BoundaryKeepsEqual pins the cutoff semantics: a hit
+// whose score equals the floor is KEPT (strict less-than drops). With floor
+// 0.60, chunks 1 (1.00) and 2 (0.60, equal) survive; chunk 3 (0.28) is dropped.
+func TestSearch_MinScoreFloor_BoundaryKeepsEqual(t *testing.T) {
+	svc := newMinScoreFloorService(t, 0.6)
+	got := searchFloorChunkIDs(t, svc)
+	want := []uint64{1, 2}
+	if len(got) != len(want) {
+		t.Fatalf("expected %v survivors (score == floor kept), got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("boundary mismatch: want %v, got %v", want, got)
+		}
+	}
+}
+
+// TestSearch_MinScoreFloor_DropsAllWhenAboveEveryScore pins that an aggressive
+// floor above every candidate's score yields zero hits (the floor may legitimately
+// return fewer than k — even zero — hits).
+func TestSearch_MinScoreFloor_DropsAllWhenAboveEveryScore(t *testing.T) {
+	svc := newMinScoreFloorService(t, 1.5)
+	got := searchFloorChunkIDs(t, svc)
+	if len(got) != 0 {
+		t.Fatalf("floor above all scores must drop everything; got %v", got)
+	}
+}


### PR DESCRIPTION
## What

Adds a configurable **server-side relevance floor** (min-score cutoff) to retrieval. Low-similarity candidate hits dilute grounded answers (cf. the Video-RAG project); this drops candidates whose final score is below a configurable threshold before they reach the model.

Closes #305

## Design

- **Config-only / server-side.** New knob `retrieval.min_score` (`RetrievalMinScore float64`). This is **not** an MCP tool parameter, so no tool input/output schema or citation contract changes (no spec gating).
- **Applied last** in `Service.Search`, after scoring/fusion, reranking, and the existing dedup/truncation steps, using each hit's final authoritative `Score` (post-rerank when rerank is on; fused score otherwise). A hit whose score **equals** the floor is kept (strict less-than drops). The floor may legitimately return fewer than `k` — or zero — hits.
- **Default `0` = disabled** (pass-through): behavior is unchanged unless configured, preserving the local-first, no-surprises default. A floor `<= 0` is treated as disabled in the service; the slice identity is preserved (no allocation) when unconfigured.
- **Validation:** NaN/Inf rejected at config-parse time (like `media.silence_threshold_db`); negatives rejected in `Validate()` (file-loaded and programmatic).
- **Wiring:** `Service.SetMinScore`, plumbed from CLI bootstrap (`up.go`) and the shared `ask` retrieval setup (`app.go`), mirroring `SetCrossFileDedupEnabled`.

Follows existing config patterns: yaml tag (`retrieval_min_score`), flat+nested key aliases (`retrieval.min_score`, `min_score`), float file-scalar setter, snapshot round-trip, `Default()` entry.

## Tests (external `tests/` packages)

`tests/retrieval/min_score_floor_test.go`:
- `TestSearch_MinScoreFloor_DropsSubThresholdHits`
- `TestSearch_MinScoreFloor_DisabledIsPassThrough`
- `TestSearch_MinScoreFloor_NegativeIsPassThrough`
- `TestSearch_MinScoreFloor_BoundaryKeepsEqual`
- `TestSearch_MinScoreFloor_DropsAllWhenAboveEveryScore`

`tests/config/retrieval_min_score_config_test.go`:
- `TestRetrievalMinScore_DefaultDisabled`
- `TestRetrievalMinScore_NestedYAMLRoundTrips`
- `TestRetrievalMinScore_FlatAliasRoundTrips`
- `TestRetrievalMinScore_SnapshotRoundTrips`
- `TestRetrievalMinScore_RejectsNonFinite`
- `TestRetrievalMinScore_RejectsNegative`
- `TestRetrievalMinScore_ValidateRejectsNegativeProgrammatic`

## Checks

- `golangci-lint cache clean` + `make check`: fully green (vet, golangci-lint, misspell, all Go + Python tests, build).
- No MCP tool schema / citation contract changes. No `dirstral-spec` re-pin.
- README documents the optional floor.
