### PR TITLE
feat(ingest): opt-in directory-discovery scan cache for large local trees (#267 item 5)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -206,6 +206,18 @@ type Config struct {
 	// (#268 Qdrant, #269 pgvector) extend.
 	IndexBackend string
 
+	// IngestScanCache opts IN to a directory-discovery scan cache (issue #267
+	// item 5, config `ingest.scan_cache`). For large local archives the corpus is
+	// re-walked from scratch on every run; the cache persists a per-directory
+	// signature (the directory's own mtime plus its direct children's
+	// name/size/mtime/mode) so an unchanged directory skips re-reading and
+	// re-sorting its entries. Correctness is never traded for speed: every cached
+	// child file is still stat'd so an in-place modification is detected, and any
+	// add/remove/rename (which bumps the parent directory mtime) or stat failure
+	// falls the directory back to a full re-walk. Default OFF: discovery behaves
+	// exactly as before. Only consulted for the local-filesystem backend.
+	IngestScanCache bool
+
 	// IngestWatch enables a filesystem watcher so a running server keeps
 	// indexing added/changed/deleted files after the initial scan. Opt-in.
 	IngestWatch bool
@@ -417,6 +429,7 @@ type fileConfig struct {
 	IngestArchivesMode        *string
 	IngestExtractor           *string
 	IndexBackend              *string
+	IngestScanCache           *bool
 	IngestWatch               *bool
 	IngestWatchDebounce       *time.Duration
 	STTProvider               *string
@@ -518,6 +531,7 @@ type persistedConfig struct {
 	IngestArchivesMode        string        `yaml:"ingest_archives_mode"`
 	IngestExtractor           string        `yaml:"ingest_extractor"`
 	IndexBackend              string        `yaml:"index_backend"`
+	IngestScanCache           bool          `yaml:"ingest_scan_cache"`
 	IngestWatch               bool          `yaml:"ingest_watch"`
 	IngestWatchDebounce       time.Duration `yaml:"ingest_watch_debounce"`
 	STTProvider               string        `yaml:"stt_provider"`
@@ -658,6 +672,7 @@ func Default() Config {
 		IngestArchivesMode:        "deep",
 		IngestExtractor:           "auto",
 		IndexBackend:              "memory",
+		IngestScanCache:           false,
 		IngestWatch:               false,
 		IngestWatchDebounce:       500 * time.Millisecond,
 		STTProvider:               "mistral",
@@ -762,6 +777,7 @@ func buildPersistedConfig(cfg *Config) persistedConfig {
 		IngestArchivesMode:        cfg.IngestArchivesMode,
 		IngestExtractor:           cfg.IngestExtractor,
 		IndexBackend:              cfg.IndexBackend,
+		IngestScanCache:           cfg.IngestScanCache,
 		IngestWatch:               cfg.IngestWatch,
 		IngestWatchDebounce:       cfg.IngestWatchDebounce,
 		STTProvider:               cfg.STTProvider,
@@ -1365,6 +1381,9 @@ func applyIngestModesFileParsed(cfg *Config, fc fileConfig) {
 	if fc.IndexBackend != nil {
 		cfg.IndexBackend = *fc.IndexBackend
 	}
+	if fc.IngestScanCache != nil {
+		cfg.IngestScanCache = *fc.IngestScanCache
+	}
 	if fc.IngestWatch != nil {
 		cfg.IngestWatch = *fc.IngestWatch
 	}
@@ -1691,6 +1710,8 @@ var configKeyAliases = map[string]string{
 	"follow_symlinks":                      "ingest.follow_symlinks",
 	"ingest_max_file_mb":                   "ingest.max_file_mb",
 	"max_file_mb":                          "ingest.max_file_mb",
+	"ingest_scan_cache":                    "ingest.scan_cache",
+	"scan_cache":                           "ingest.scan_cache",
 	"ingest_watch":                         "ingest.watch",
 	"ingest_watch_debounce":                "ingest.watch_debounce",
 	"ingest_pdf_mode":                      "ingest.pdf.mode",
@@ -1818,6 +1839,7 @@ var boolFileScalarTargets = map[string]func(*fileConfig) **bool{
 	"rag.generate_answer":     func(c *fileConfig) **bool { return &c.RAGGenerateAnswer },
 	"ingest.gitignore":        func(c *fileConfig) **bool { return &c.IngestGitignore },
 	"ingest.follow_symlinks":  func(c *fileConfig) **bool { return &c.IngestFollowSymlinks },
+	"ingest.scan_cache":       func(c *fileConfig) **bool { return &c.IngestScanCache },
 	"ingest.watch":            func(c *fileConfig) **bool { return &c.IngestWatch },
 	"quality_gates_enabled":   func(c *fileConfig) **bool { return &c.QualityGatesEnabled },
 	"media_sidecars_disabled": func(c *fileConfig) **bool { return &c.MediaSidecarsDisabled },
@@ -2229,6 +2251,7 @@ func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	writeScalar("ingest_archives_mode", cfg.IngestArchivesMode)
 	writeScalar("ingest_extractor", cfg.IngestExtractor)
 	writeScalar("index_backend", cfg.IndexBackend)
+	writeBool("ingest_scan_cache", cfg.IngestScanCache)
 	writeBool("ingest_watch", cfg.IngestWatch)
 	writeScalar("ingest_watch_debounce", cfg.IngestWatchDebounce.String())
 	writeScalar("stt_provider", cfg.STTProvider)
@@ -2456,6 +2479,11 @@ func applyIngestEnvOverrides(cfg *Config, env map[string]string) {
 	} {
 		if raw, ok := envLookup(o.key, env); ok && strings.TrimSpace(raw) != "" {
 			*o.field = strings.TrimSpace(raw)
+		}
+	}
+	if raw, ok := envLookup("DIR2MCP_INGEST_SCAN_CACHE", env); ok && strings.TrimSpace(raw) != "" {
+		if parsed, err := strconv.ParseBool(strings.TrimSpace(raw)); err == nil {
+			cfg.IngestScanCache = parsed
 		}
 	}
 	if raw, ok := envLookup("DIR2MCP_INGEST_WATCH", env); ok && strings.TrimSpace(raw) != "" {

--- a/internal/corpusfs/corpusfs.go
+++ b/internal/corpusfs/corpusfs.go
@@ -55,6 +55,58 @@ type Options struct {
 	MaxSizeBytes   int64
 	UseGitIgnore   bool
 	FollowSymlinks bool
+	// ScanCache, when non-nil, is an optional directory-discovery cache (issue
+	// #267 item 5) consulted by the LocalFS walker. It lets an unchanged
+	// directory skip re-reading and re-sorting its entries while still detecting
+	// added/removed/modified files. nil disables it (a full re-walk every run);
+	// only the local-filesystem backend honors it.
+	ScanCache ScanCache
+}
+
+// CachedDirEntry is a directory child's identity recorded in the scan cache: its
+// name, whether it is a directory, and (for regular files) the size/mtime used
+// to detect an in-place modification. It is the minimal stat fingerprint the
+// walker compares against the live filesystem on a cache hit.
+type CachedDirEntry struct {
+	Name      string
+	IsDir     bool
+	SizeBytes int64
+	MTimeUnix int64
+	// Mode is the file mode bits recorded for a regular file so a cache hit can
+	// reconstruct the DiscoveredFile.Mode without re-stat beyond the size/mtime
+	// confirmation the walker already performs.
+	Mode uint32
+}
+
+// CachedDirSignature is the persisted fingerprint of a single directory: the
+// directory's own mtime (which POSIX bumps on any add/remove/rename of a direct
+// child) plus the sorted list of its direct children. A live directory whose
+// mtime equals DirMTimeUnix has the same set of children as when the signature
+// was stored, so the walker can validate the cached children with per-file stats
+// instead of re-reading the directory.
+type CachedDirSignature struct {
+	DirMTimeUnix int64
+	Entries      []CachedDirEntry
+}
+
+// ScanCache persists per-directory discovery signatures keyed by a directory's
+// rel path (the corpus-root-relative slash path; "" is the root). It is a cheap,
+// correctness-preserving optimization: the walker only ever trusts it after
+// confirming the directory's own mtime is unchanged AND re-stat'ing every cached
+// child, so a stale or wrong cache can never cause a changed file to be missed —
+// at worst it triggers a full re-walk of the affected directory.
+//
+// Implementations must be safe for the walker's usage (sequential within one
+// Walk). Lookup returning ok=false (or any inconsistency) must make the walker
+// fall back to a full directory read.
+type ScanCache interface {
+	// LookupDir returns the cached signature for relDir, or ok=false when none is
+	// recorded. An error is treated by the walker as a cache miss (full re-walk).
+	LookupDir(relDir string) (sig CachedDirSignature, ok bool, err error)
+	// StoreDir records the freshly observed signature for relDir, replacing any
+	// previous entry. Errors are non-fatal to discovery (the walk still returns
+	// correct results; the cache simply does not improve next time).
+	StoreDir(relDir string, sig CachedDirSignature) error
 }
 
 // DefaultOptions returns discovery defaults: the 10 MiB cap, gitignore off, and

--- a/internal/corpusfs/local.go
+++ b/internal/corpusfs/local.go
@@ -384,7 +384,10 @@ func (w *discoverWalker) walkDirFromCache(ctx context.Context, absDir, relDir st
 		return false, nil //nolint:nilerr // a cache error/miss/mtime drift is a full-read fallback
 	}
 
-	confirmed, ok := w.validateCachedChildren(absDir, relDir, sig.Entries)
+	confirmed, ok, err := w.validateCachedChildren(ctx, absDir, relDir, sig.Entries)
+	if err != nil {
+		return false, err
+	}
 	if !ok {
 		return false, nil
 	}
@@ -398,16 +401,19 @@ func (w *discoverWalker) walkDirFromCache(ctx context.Context, absDir, relDir st
 // filesystem WITHOUT mutating walker state, so a late mismatch leaves nothing
 // half-applied before the full-read fallback. ok=false means the directory must
 // be re-read in full.
-func (w *discoverWalker) validateCachedChildren(absDir, relDir string, entries []CachedDirEntry) ([]cachedChild, bool) {
+func (w *discoverWalker) validateCachedChildren(ctx context.Context, absDir, relDir string, entries []CachedDirEntry) ([]cachedChild, bool, error) {
 	confirmed := make([]cachedChild, 0, len(entries))
 	for _, e := range entries {
+		if err := ctx.Err(); err != nil {
+			return nil, false, err
+		}
 		fullPath := filepath.Join(absDir, e.Name)
 		lstat, statErr := os.Lstat(fullPath)
 		if statErr != nil || lstat.Mode()&os.ModeSymlink != 0 {
-			return nil, false // child vanished/changed identity or is a symlink.
+			return nil, false, nil // child vanished/changed identity or is a symlink.
 		}
 		if !cachedChildMatches(e, lstat) {
-			return nil, false
+			return nil, false, nil
 		}
 		relPath := e.Name
 		if relDir != "" {
@@ -415,7 +421,7 @@ func (w *discoverWalker) validateCachedChildren(absDir, relDir string, entries [
 		}
 		confirmed = append(confirmed, cachedChild{entry: e, relPath: relPath, fullPath: fullPath, lstat: lstat})
 	}
-	return confirmed, true
+	return confirmed, true, nil
 }
 
 // cachedChildMatches reports whether a live stat is consistent with the cached

--- a/internal/corpusfs/local.go
+++ b/internal/corpusfs/local.go
@@ -224,6 +224,40 @@ func (w *discoverWalker) walkDir(ctx context.Context, absDir, relDir string, par
 		return err
 	}
 
+	// Fast path: when a scan cache is configured and this directory's own mtime
+	// is unchanged, its set of direct children is unchanged too (POSIX bumps a
+	// directory's mtime on any add/remove/rename of a direct child). Validate the
+	// cached children with cheap per-file stats — which still catches an in-place
+	// file modification — and skip re-reading and re-sorting the directory. Any
+	// inconsistency makes served become false so we fall through to a full read.
+	if served, err := w.walkDirFromCache(ctx, absDir, relDir, rules); err != nil {
+		return err
+	} else if served {
+		return nil
+	}
+
+	return w.walkDirFull(ctx, absDir, relDir, rules)
+}
+
+// walkDirFull performs the authoritative directory read: it lists, sorts, and
+// processes every entry, and (when caching is enabled and the read is clean)
+// persists a fresh signature for next time.
+func (w *discoverWalker) walkDirFull(ctx context.Context, absDir, relDir string, rules []gitIgnoreRule) error {
+	// Capture the directory mtime BEFORE reading its entries. Storing the
+	// pre-read mtime (and re-confirming it is unchanged after the read) closes a
+	// TOCTOU: if a child is added concurrently with the read, the mtime bumps and
+	// we decline to cache a possibly-partial snapshot rather than risk recording a
+	// new mtime against a stale child set (which a later run would wrongly trust).
+	caching := w.options.ScanCache != nil && !w.options.FollowSymlinks
+	var preReadMTime int64
+	if caching {
+		if info, statErr := os.Stat(absDir); statErr == nil {
+			preReadMTime = info.ModTime().Unix()
+		} else {
+			caching = false
+		}
+	}
+
 	entries, err := os.ReadDir(absDir)
 	if err != nil {
 		return err
@@ -232,43 +266,78 @@ func (w *discoverWalker) walkDir(ctx context.Context, absDir, relDir string, par
 		return entries[i].Name() < entries[j].Name()
 	})
 
+	// sigEntries accumulates the freshly observed children so the directory's
+	// signature can be persisted for the next run. Only populated when caching is
+	// enabled and the directory is fully readable (no per-entry error aborts).
+	var sigEntries []CachedDirEntry
+
 	for _, entry := range entries {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-
-		name := entry.Name()
-		relPath := name
-		if relDir != "" {
-			relPath = relDir + "/" + name
-		}
-		fullPath := filepath.Join(absDir, name)
-
-		lstat, err := os.Lstat(fullPath)
+		sigEntry, ok, err := w.processFullEntry(ctx, absDir, relDir, entry.Name(), rules)
 		if err != nil {
 			return err
 		}
-
-		if lstat.Mode()&os.ModeSymlink != 0 {
-			if !w.options.FollowSymlinks {
-				continue
-			}
-			if err := w.handleSymlink(ctx, fullPath, relPath, rules); err != nil {
-				return err
-			}
+		if !ok {
+			// A symlink child makes the cached signature ambiguous (resolution and
+			// cycle-detection are stateful), so do not persist a signature for this
+			// directory: the next run re-reads it fully.
+			caching = false
 			continue
 		}
-
-		if lstat.IsDir() {
-			if err := w.visitDir(ctx, fullPath, relPath, name, rules); err != nil {
-				return err
-			}
-			continue
+		if caching {
+			sigEntries = append(sigEntries, sigEntry)
 		}
+	}
 
-		if !w.shouldAddFile(lstat, relPath, rules) {
-			continue
+	if caching {
+		w.storeDirSignature(absDir, relDir, preReadMTime, sigEntries)
+	}
+	return nil
+}
+
+// processFullEntry handles a single freshly-read child of a directory: it stats
+// it, recurses into directories, appends regular files that pass policy, and
+// follows symlinks per options. It returns the entry's cache signature plus
+// cacheable=false when the child (a symlink) makes the directory ineligible for
+// caching.
+func (w *discoverWalker) processFullEntry(ctx context.Context, absDir, relDir, name string, rules []gitIgnoreRule) (CachedDirEntry, bool, error) {
+	relPath := name
+	if relDir != "" {
+		relPath = relDir + "/" + name
+	}
+	fullPath := filepath.Join(absDir, name)
+
+	lstat, err := os.Lstat(fullPath)
+	if err != nil {
+		return CachedDirEntry{}, false, err
+	}
+
+	if lstat.Mode()&os.ModeSymlink != 0 {
+		if !w.options.FollowSymlinks {
+			return CachedDirEntry{}, false, nil
 		}
+		if err := w.handleSymlink(ctx, fullPath, relPath, rules); err != nil {
+			return CachedDirEntry{}, false, err
+		}
+		return CachedDirEntry{}, false, nil
+	}
+
+	if lstat.IsDir() {
+		if err := w.visitDir(ctx, fullPath, relPath, name, rules); err != nil {
+			return CachedDirEntry{}, false, err
+		}
+		return CachedDirEntry{Name: name, IsDir: true}, true, nil
+	}
+
+	sig := CachedDirEntry{
+		Name:      name,
+		SizeBytes: lstat.Size(),
+		MTimeUnix: lstat.ModTime().Unix(),
+		Mode:      uint32(lstat.Mode()),
+	}
+	if w.shouldAddFile(lstat, relPath, rules) {
 		*w.files = append(*w.files, DiscoveredFile{
 			AbsPath:   fullPath,
 			RelPath:   relPath,
@@ -277,8 +346,134 @@ func (w *discoverWalker) walkDir(ctx context.Context, absDir, relDir string, par
 			Mode:      lstat.Mode(),
 		})
 	}
+	return sig, true, nil
+}
 
+// cachedChild pairs a validated cache entry with the live stat used to confirm
+// it, so the emit pass can reuse the stat without re-calling Lstat.
+type cachedChild struct {
+	entry    CachedDirEntry
+	relPath  string
+	fullPath string
+	lstat    os.FileInfo
+}
+
+// walkDirFromCache attempts to serve absDir from the scan cache. It returns
+// served=true only when the cache holds a signature whose recorded directory
+// mtime equals the live directory mtime AND every cached child still matches the
+// live filesystem (a regular file's size+mtime unchanged, a directory still a
+// directory). On a hit it appends the surviving files (applying the same
+// gitignore/size policies) and recurses into child directories exactly as the
+// full path would. served=false means the caller must perform a full read; the
+// cache is never trusted without these confirmations, so a stale entry can only
+// cost a re-walk, never a missed change.
+func (w *discoverWalker) walkDirFromCache(ctx context.Context, absDir, relDir string, rules []gitIgnoreRule) (bool, error) {
+	if w.options.ScanCache == nil || w.options.FollowSymlinks {
+		return false, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+
+	info, err := os.Stat(absDir)
+	if err != nil {
+		return false, nil //nolint:nilerr // unreadable dir is a miss; full path reports the error
+	}
+	sig, ok, err := w.options.ScanCache.LookupDir(relDir)
+	if err != nil || !ok || sig.DirMTimeUnix != info.ModTime().Unix() {
+		return false, nil //nolint:nilerr // a cache error/miss/mtime drift is a full-read fallback
+	}
+
+	confirmed, ok := w.validateCachedChildren(absDir, relDir, sig.Entries)
+	if !ok {
+		return false, nil
+	}
+	if err := w.emitCachedChildren(ctx, confirmed, rules); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// validateCachedChildren confirms every cached child still matches the live
+// filesystem WITHOUT mutating walker state, so a late mismatch leaves nothing
+// half-applied before the full-read fallback. ok=false means the directory must
+// be re-read in full.
+func (w *discoverWalker) validateCachedChildren(absDir, relDir string, entries []CachedDirEntry) ([]cachedChild, bool) {
+	confirmed := make([]cachedChild, 0, len(entries))
+	for _, e := range entries {
+		fullPath := filepath.Join(absDir, e.Name)
+		lstat, statErr := os.Lstat(fullPath)
+		if statErr != nil || lstat.Mode()&os.ModeSymlink != 0 {
+			return nil, false // child vanished/changed identity or is a symlink.
+		}
+		if !cachedChildMatches(e, lstat) {
+			return nil, false
+		}
+		relPath := e.Name
+		if relDir != "" {
+			relPath = relDir + "/" + e.Name
+		}
+		confirmed = append(confirmed, cachedChild{entry: e, relPath: relPath, fullPath: fullPath, lstat: lstat})
+	}
+	return confirmed, true
+}
+
+// cachedChildMatches reports whether a live stat is consistent with the cached
+// entry: a directory must still be a directory; a regular file must still be a
+// regular file with the same size and mtime (so an in-place modification fails).
+func cachedChildMatches(e CachedDirEntry, lstat os.FileInfo) bool {
+	if e.IsDir {
+		return lstat.IsDir()
+	}
+	if lstat.IsDir() || !lstat.Mode().IsRegular() {
+		return false
+	}
+	return lstat.Size() == e.SizeBytes && lstat.ModTime().Unix() == e.MTimeUnix
+}
+
+// emitCachedChildren appends the confirmed files and recurses into confirmed
+// subdirectories using the identical policy as the full path.
+func (w *discoverWalker) emitCachedChildren(ctx context.Context, confirmed []cachedChild, rules []gitIgnoreRule) error {
+	for _, p := range confirmed {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if p.entry.IsDir {
+			if err := w.visitDir(ctx, p.fullPath, p.relPath, p.entry.Name, rules); err != nil {
+				return err
+			}
+			continue
+		}
+		if !w.shouldAddFile(p.lstat, p.relPath, rules) {
+			continue
+		}
+		*w.files = append(*w.files, DiscoveredFile{
+			AbsPath:   p.fullPath,
+			RelPath:   p.relPath,
+			SizeBytes: p.lstat.Size(),
+			MTimeUnix: p.lstat.ModTime().Unix(),
+			Mode:      p.lstat.Mode(),
+		})
+	}
 	return nil
+}
+
+// storeDirSignature persists the freshly observed directory signature, but only
+// if the directory's mtime has not changed since it was sampled before the read
+// (preReadMTime). A changed mtime means a child was added/removed/renamed during
+// the read, so the captured child set may be partial; in that case we skip the
+// store rather than record a new mtime against a stale set (which a later run
+// would wrongly trust). Errors are non-fatal: discovery already produced correct
+// results; a failed store only forgoes the optimization next run.
+func (w *discoverWalker) storeDirSignature(absDir, relDir string, preReadMTime int64, entries []CachedDirEntry) {
+	info, err := os.Stat(absDir)
+	if err != nil || info.ModTime().Unix() != preReadMTime {
+		return
+	}
+	_ = w.options.ScanCache.StoreDir(relDir, CachedDirSignature{
+		DirMTimeUnix: preReadMTime,
+		Entries:      entries,
+	})
 }
 
 func (w *discoverWalker) handleSymlink(ctx context.Context, symlinkPath, relPath string, rules []gitIgnoreRule) error {

--- a/internal/ingest/discover.go
+++ b/internal/ingest/discover.go
@@ -71,6 +71,10 @@ type DiscoverOptions struct {
 	UseGitIgnore   bool
 	FollowSymlinks bool
 	MediaVariants  MediaVariantOptions
+	// ScanCache, when non-nil, is the optional directory-discovery cache (issue
+	// #267 item 5) passed through to the local-filesystem walker. nil = disabled
+	// (a full re-walk every run). See corpusfs.ScanCache.
+	ScanCache corpusfs.ScanCache
 }
 
 // DefaultDiscoverOptions returns discovery defaults used by ingestion.
@@ -92,6 +96,7 @@ func (o DiscoverOptions) corpusfsOptions() corpusfs.Options {
 		MaxSizeBytes:   o.MaxSizeBytes,
 		UseGitIgnore:   o.UseGitIgnore,
 		FollowSymlinks: o.FollowSymlinks,
+		ScanCache:      o.ScanCache,
 	}
 }
 

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -27,6 +27,7 @@ import (
 	"github.com/dirstral/dir2mcp/internal/provider"
 	"github.com/dirstral/dir2mcp/internal/providerfactory"
 	"github.com/dirstral/dir2mcp/internal/quality"
+	"github.com/dirstral/dir2mcp/internal/scancache"
 	"github.com/dirstral/dir2mcp/internal/store"
 	"github.com/dirstral/dir2mcp/internal/subtitle"
 )
@@ -687,6 +688,30 @@ func (s *Service) corpusFS() corpusfs.CorpusFS {
 	return corpusfs.NewLocalFS(s.cfg.RootDir)
 }
 
+// openScanCache returns an opened directory-discovery scan cache (issue #267
+// item 5) when the feature is enabled in config AND the active corpus backend is
+// the local filesystem; otherwise it returns nil so discovery performs an
+// unoptimized full walk. The cache only benefits (and is only honored by) the
+// local-filesystem walker — object-store backends key change detection off the
+// ETag instead — so it is never opened for a remote source. The caller owns the
+// returned cache's lifetime and must Close it.
+func (s *Service) openScanCache() *scancache.SQLiteCache {
+	if !s.cfg.IngestScanCache {
+		return nil
+	}
+	switch strings.ToLower(strings.TrimSpace(s.cfg.Source.Kind)) {
+	case "", "local", "nfs":
+		// local-filesystem backends only.
+	default:
+		return nil
+	}
+	stateDir := strings.TrimSpace(s.cfg.StateDir)
+	if stateDir == "" {
+		return nil
+	}
+	return scancache.Open(scancache.DefaultPath(stateDir))
+}
+
 // SetQualityGate overrides the output quality gate (spec 0.16.0). A nil gate
 // disables screening so generated transcript/OCR text is chunked and embedded
 // without quarantine. Mirrors SetTranscriber for tests.
@@ -781,6 +806,16 @@ func (s *Service) runScan(ctx context.Context) error {
 	}
 
 	discoverOpts := DiscoverOptionsFromConfig(s.cfg)
+	// Attach the optional directory-discovery scan cache (issue #267 item 5) for
+	// the local-filesystem backend only. It is opened for the duration of this
+	// scan and closed afterward; a failure to open it is non-fatal (we just walk
+	// without the optimization). The walker only ever trusts it after confirming
+	// each directory's mtime and re-stat'ing its children, so it cannot cause a
+	// changed file to be missed.
+	if cache := s.openScanCache(); cache != nil {
+		defer func() { _ = cache.Close() }()
+		discoverOpts.ScanCache = cache
+	}
 	discovered, err := s.corpusFS().Walk(ctx, s.cfg.RootDir, discoverOpts.corpusfsOptions())
 	if err != nil {
 		return err

--- a/internal/scancache/scancache.go
+++ b/internal/scancache/scancache.go
@@ -1,0 +1,191 @@
+// Package scancache provides an optional, sqlite-backed directory-discovery
+// cache for the corpusfs LocalFS walker (issue #267 item 5). It persists a
+// per-directory signature — the directory's own mtime plus the sorted
+// name/size/mtime/mode of its direct children — so a subsequent scan of a large
+// local archive can skip re-reading and re-sorting directories whose contents
+// are unchanged, while still detecting any added/removed/modified file.
+//
+// The cache is purely a performance optimization: the walker only trusts a
+// signature after confirming the directory's live mtime is unchanged AND
+// re-stat'ing every cached child, so a stale or corrupt cache can never cause a
+// changed file to be missed — at worst it triggers a full re-walk. It therefore
+// stores no authoritative state and is safe to delete at any time.
+//
+// It reuses the same pure-Go modernc.org/sqlite driver as internal/store, so it
+// introduces no new heavyweight dependency, and follows the same single-writer
+// connection-pool + WAL pragmas to avoid lock contention.
+package scancache
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/dirstral/dir2mcp/internal/corpusfs"
+
+	_ "modernc.org/sqlite" // pure-Go sqlite driver (shared with internal/store).
+)
+
+// SQLiteCache is a sqlite-backed corpusfs.ScanCache. It is opened lazily on the
+// first Lookup/Store and is safe for the walker's sequential use within a single
+// Walk. Construct it with Open and release it with Close.
+type SQLiteCache struct {
+	path string
+
+	mu sync.Mutex
+	db *sql.DB
+
+	// hits/misses count fast-path outcomes for observability and tests:
+	// LookupDir increments hits when it returns a stored signature and misses
+	// otherwise. They are advisory metrics, not part of the cache contract.
+	hits   int64
+	misses int64
+}
+
+// compile-time assertion that SQLiteCache satisfies the consumer interface.
+var _ corpusfs.ScanCache = (*SQLiteCache)(nil)
+
+// Open returns a SQLiteCache backed by the sqlite file at path, creating its
+// parent directory. The database file and schema are created lazily on first
+// use, so Open itself performs no I/O beyond recording the path.
+func Open(path string) *SQLiteCache {
+	return &SQLiteCache{path: path}
+}
+
+// DefaultPath returns the conventional scan-cache location under a state dir,
+// alongside the other content-addressed caches (state/cache/*).
+func DefaultPath(stateDir string) string {
+	return filepath.Join(stateDir, "cache", "scan.sqlite")
+}
+
+func (c *SQLiteCache) ensureDB(ctx context.Context) (*sql.DB, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.db != nil {
+		return c.db, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(c.path), 0o700); err != nil {
+		return nil, fmt.Errorf("scancache: create cache directory: %w", err)
+	}
+	db, err := sql.Open("sqlite", c.path)
+	if err != nil {
+		return nil, fmt.Errorf("scancache: open db: %w", err)
+	}
+	// Serialize through a single connection and enable WAL, mirroring
+	// internal/store so concurrent processes do not trip SQLITE_BUSY. Order
+	// matters: busy_timeout must precede the WAL switch.
+	db.SetMaxOpenConns(1)
+	for _, pragma := range []string{
+		`PRAGMA busy_timeout=5000;`,
+		`PRAGMA journal_mode=WAL;`,
+	} {
+		if _, err := db.ExecContext(ctx, pragma); err != nil {
+			_ = db.Close()
+			return nil, fmt.Errorf("scancache: pragma: %w", err)
+		}
+	}
+	schema := `
+CREATE TABLE IF NOT EXISTS dir_signatures (
+  rel_dir       TEXT PRIMARY KEY,
+  dir_mtime_unix INTEGER NOT NULL,
+  entries_json  TEXT NOT NULL
+);`
+	if _, err := db.ExecContext(ctx, schema); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("scancache: init schema: %w", err)
+	}
+	c.db = db
+	return db, nil
+}
+
+// LookupDir returns the cached signature for relDir. A missing row, a database
+// error, or unparseable JSON all surface as a miss (ok=false, err=nil) so the
+// walker simply falls back to a full directory read.
+func (c *SQLiteCache) LookupDir(relDir string) (corpusfs.CachedDirSignature, bool, error) {
+	ctx := context.Background()
+	db, err := c.ensureDB(ctx)
+	if err != nil {
+		c.recordMiss()
+		return corpusfs.CachedDirSignature{}, false, nil //nolint:nilerr // a cache error is a miss
+	}
+
+	var mtime int64
+	var entriesJSON string
+	row := db.QueryRowContext(ctx,
+		`SELECT dir_mtime_unix, entries_json FROM dir_signatures WHERE rel_dir = ?`, relDir)
+	if err := row.Scan(&mtime, &entriesJSON); err != nil {
+		c.recordMiss()
+		return corpusfs.CachedDirSignature{}, false, nil //nolint:nilerr // no row / scan error -> miss
+	}
+
+	var entries []corpusfs.CachedDirEntry
+	if entriesJSON != "" {
+		if err := json.Unmarshal([]byte(entriesJSON), &entries); err != nil {
+			c.recordMiss()
+			return corpusfs.CachedDirSignature{}, false, nil //nolint:nilerr // corrupt row -> miss
+		}
+	}
+	c.recordHit()
+	return corpusfs.CachedDirSignature{DirMTimeUnix: mtime, Entries: entries}, true, nil
+}
+
+// StoreDir upserts the signature for relDir.
+func (c *SQLiteCache) StoreDir(relDir string, sig corpusfs.CachedDirSignature) error {
+	ctx := context.Background()
+	db, err := c.ensureDB(ctx)
+	if err != nil {
+		return err
+	}
+	entriesJSON, err := json.Marshal(sig.Entries)
+	if err != nil {
+		return fmt.Errorf("scancache: marshal entries: %w", err)
+	}
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO dir_signatures (rel_dir, dir_mtime_unix, entries_json)
+		 VALUES (?, ?, ?)
+		 ON CONFLICT(rel_dir) DO UPDATE SET
+		   dir_mtime_unix = excluded.dir_mtime_unix,
+		   entries_json   = excluded.entries_json`,
+		relDir, sig.DirMTimeUnix, string(entriesJSON))
+	if err != nil {
+		return fmt.Errorf("scancache: store signature: %w", err)
+	}
+	return nil
+}
+
+// Close releases the underlying database handle. It is safe to call more than
+// once and on a cache that was never used.
+func (c *SQLiteCache) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.db == nil {
+		return nil
+	}
+	err := c.db.Close()
+	c.db = nil
+	return err
+}
+
+// Stats returns the number of cache hits and misses observed by LookupDir since
+// the cache was opened. Intended for observability and tests.
+func (c *SQLiteCache) Stats() (hits, misses int64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.hits, c.misses
+}
+
+func (c *SQLiteCache) recordHit() {
+	c.mu.Lock()
+	c.hits++
+	c.mu.Unlock()
+}
+
+func (c *SQLiteCache) recordMiss() {
+	c.mu.Lock()
+	c.misses++
+	c.mu.Unlock()
+}

--- a/tests/config/scan_cache_config_test.go
+++ b/tests/config/scan_cache_config_test.go
@@ -67,6 +67,9 @@ func TestScanCache_NestedAndFlatKeys(t *testing.T) {
 
 // TestScanCache_EnvOverride verifies DIR2MCP_INGEST_SCAN_CACHE flips the flag.
 func TestScanCache_EnvOverride(t *testing.T) {
+	// Pin source/index so ambient DIR2MCP_* in CI/dev shells can't perturb the load.
+	t.Setenv("DIR2MCP_SOURCE_KIND", "local")
+	t.Setenv("DIR2MCP_INDEX_BACKEND", "memory")
 	t.Setenv("DIR2MCP_INGEST_SCAN_CACHE", "true")
 	cfg, err := config.Load("")
 	if err != nil {

--- a/tests/config/scan_cache_config_test.go
+++ b/tests/config/scan_cache_config_test.go
@@ -1,0 +1,78 @@
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+)
+
+// TestScanCache_DefaultsOff asserts the scan cache is opt-in: the baseline
+// config has it disabled (safe full-walk behavior).
+func TestScanCache_DefaultsOff(t *testing.T) {
+	if config.Default().IngestScanCache {
+		t.Fatal("IngestScanCache should default to false (opt-in)")
+	}
+}
+
+// TestScanCache_SaveLoadRoundTrip verifies the flag survives a SaveFile/LoadFile
+// cycle through the persisted YAML.
+func TestScanCache_SaveLoadRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".dir2mcp.yaml")
+
+	cfg := config.Default()
+	cfg.RootDir = "/tmp/repo"
+	cfg.StateDir = "/tmp/repo/.dir2mcp"
+	cfg.IngestScanCache = true
+
+	if err := config.SaveFile(path, cfg); err != nil {
+		t.Fatalf("SaveFile: %v", err)
+	}
+	loaded, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if !loaded.IngestScanCache {
+		t.Fatal("IngestScanCache did not round-trip: got false, want true")
+	}
+}
+
+// TestScanCache_NestedAndFlatKeys verifies both the canonical nested key
+// (ingest.scan_cache) and the flat alias (scan_cache) load the flag.
+func TestScanCache_NestedAndFlatKeys(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		yaml string
+	}{
+		{name: "nested", yaml: "ingest:\n  scan_cache: true\n"},
+		{name: "flat_alias", yaml: "scan_cache: true\n"},
+		{name: "flat_prefixed", yaml: "ingest_scan_cache: true\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), ".dir2mcp.yaml")
+			if err := os.WriteFile(path, []byte(tc.yaml), 0o644); err != nil {
+				t.Fatalf("write yaml: %v", err)
+			}
+			cfg, err := config.LoadFile(path)
+			if err != nil {
+				t.Fatalf("LoadFile: %v", err)
+			}
+			if !cfg.IngestScanCache {
+				t.Fatalf("expected IngestScanCache=true for %s yaml", tc.name)
+			}
+		})
+	}
+}
+
+// TestScanCache_EnvOverride verifies DIR2MCP_INGEST_SCAN_CACHE flips the flag.
+func TestScanCache_EnvOverride(t *testing.T) {
+	t.Setenv("DIR2MCP_INGEST_SCAN_CACHE", "true")
+	cfg, err := config.Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.IngestScanCache {
+		t.Fatal("DIR2MCP_INGEST_SCAN_CACHE=true did not enable IngestScanCache")
+	}
+}

--- a/tests/corpusfs/scancache_walk_test.go
+++ b/tests/corpusfs/scancache_walk_test.go
@@ -1,0 +1,198 @@
+package tests
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/corpusfs"
+)
+
+// fakeScanCache is an in-memory corpusfs.ScanCache used to observe the LocalFS
+// walker's fast-path behavior without touching sqlite. It records per-directory
+// signatures and counts hits/misses so tests can assert when the walker reused a
+// cached directory versus re-read it.
+type fakeScanCache struct {
+	sigs    map[string]corpusfs.CachedDirSignature
+	hits    int
+	misses  int
+	stores  int
+	lookups int
+}
+
+func newFakeScanCache() *fakeScanCache {
+	return &fakeScanCache{sigs: map[string]corpusfs.CachedDirSignature{}}
+}
+
+func (c *fakeScanCache) LookupDir(relDir string) (corpusfs.CachedDirSignature, bool, error) {
+	c.lookups++
+	sig, ok := c.sigs[relDir]
+	if ok {
+		c.hits++
+	} else {
+		c.misses++
+	}
+	return sig, ok, nil
+}
+
+func (c *fakeScanCache) StoreDir(relDir string, sig corpusfs.CachedDirSignature) error {
+	c.stores++
+	c.sigs[relDir] = sig
+	return nil
+}
+
+func relPaths(files []corpusfs.DiscoveredFile) []string {
+	out := make([]string, 0, len(files))
+	for _, f := range files {
+		out = append(out, f.RelPath)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func walkWith(t *testing.T, root string, cache corpusfs.ScanCache) []corpusfs.DiscoveredFile {
+	t.Helper()
+	files, err := corpusfs.NewLocalFS(root).Walk(context.Background(), root, corpusfs.Options{
+		MaxSizeBytes: 1 << 20,
+		ScanCache:    cache,
+	})
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	return files
+}
+
+// TestScanCache_UnchangedTreeSkipsReWalk verifies that a second walk of an
+// unchanged tree is served from the cache (every directory is a hit and no
+// directory is re-stored) and returns byte-identical discovery results.
+func TestScanCache_UnchangedTreeSkipsReWalk(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "a.txt"), []byte("alpha"))
+	mustWrite(t, filepath.Join(root, "sub", "b.txt"), []byte("beta"))
+	mustWrite(t, filepath.Join(root, "sub", "deep", "c.txt"), []byte("gamma"))
+
+	cache := newFakeScanCache()
+
+	first := walkWith(t, root, cache)
+	if cache.stores == 0 {
+		t.Fatalf("first walk should populate the cache, got 0 stores")
+	}
+	firstStores := cache.stores
+
+	// Reset only the counters; keep the populated signatures.
+	cache.hits, cache.misses, cache.stores, cache.lookups = 0, 0, 0, 0
+
+	second := walkWith(t, root, cache)
+
+	if cache.misses != 0 {
+		t.Fatalf("unchanged tree: expected 0 cache misses, got %d (hits=%d)", cache.misses, cache.hits)
+	}
+	if cache.hits == 0 {
+		t.Fatalf("unchanged tree: expected cache hits on the re-walk, got 0")
+	}
+	if cache.stores != 0 {
+		t.Fatalf("unchanged tree: expected no re-stores on a fully-cached walk, got %d (first=%d)", cache.stores, firstStores)
+	}
+
+	if got, want := relPaths(second), relPaths(first); len(got) != len(want) {
+		t.Fatalf("result size changed: first=%v second=%v", want, got)
+	} else {
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("result mismatch at %d: first=%q second=%q", i, want[i], got[i])
+			}
+		}
+	}
+}
+
+// TestScanCache_DetectsModifiedFile verifies that an in-place modification (which
+// does NOT bump the parent directory mtime) is still detected: the affected
+// directory falls back to a full re-read and the new size is reported.
+func TestScanCache_DetectsModifiedFile(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "sub", "b.txt")
+	mustWrite(t, filepath.Join(root, "a.txt"), []byte("alpha"))
+	mustWrite(t, target, []byte("beta"))
+
+	cache := newFakeScanCache()
+	_ = walkWith(t, root, cache)
+
+	// Modify b.txt in place with a strictly newer mtime so the change is
+	// unambiguous regardless of filesystem mtime granularity.
+	mustWrite(t, target, []byte("beta-modified-and-longer"))
+	future := time.Now().Add(2 * time.Second)
+	if err := os.Chtimes(target, future, future); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	files := walkWith(t, root, cache)
+	var found bool
+	for _, f := range files {
+		if f.RelPath == "sub/b.txt" {
+			found = true
+			if f.SizeBytes != int64(len("beta-modified-and-longer")) {
+				t.Fatalf("modified file size not detected: got %d", f.SizeBytes)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("modified file sub/b.txt missing from results")
+	}
+}
+
+// TestScanCache_DetectsAddedAndRemovedFile verifies that adding and removing a
+// file (both bump the parent directory mtime) invalidate the cached directory so
+// the change is reflected on the next walk.
+func TestScanCache_DetectsAddedAndRemovedFile(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "dir", "keep.txt"), []byte("keep"))
+	mustWrite(t, filepath.Join(root, "dir", "remove.txt"), []byte("bye"))
+
+	cache := newFakeScanCache()
+	_ = walkWith(t, root, cache)
+
+	// Add one file and remove another in the same directory.
+	mustWrite(t, filepath.Join(root, "dir", "added.txt"), []byte("new"))
+	if err := os.Remove(filepath.Join(root, "dir", "remove.txt")); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+
+	got := relPaths(walkWith(t, root, cache))
+	want := []string{"dir/added.txt", "dir/keep.txt"}
+	if len(got) != len(want) {
+		t.Fatalf("add/remove not detected: got %v want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("add/remove mismatch: got %v want %v", got, want)
+		}
+	}
+}
+
+// TestScanCache_DisabledMatchesFullWalk verifies that a nil cache (the default)
+// reproduces the exact discovery output of a cache-backed walk over the same
+// tree: the cache is a pure optimization with no effect on results.
+func TestScanCache_DisabledMatchesFullWalk(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "a.txt"), []byte("alpha"))
+	mustWrite(t, filepath.Join(root, "sub", "b.txt"), []byte("beta"))
+	mustWrite(t, filepath.Join(root, "sub", "deep", "c.txt"), []byte("gamma"))
+
+	nilCacheWalk := relPaths(walkWith(t, root, nil))
+
+	cache := newFakeScanCache()
+	_ = walkWith(t, root, cache)                     // populate
+	cachedWalk := relPaths(walkWith(t, root, cache)) // served from cache
+
+	if len(nilCacheWalk) != len(cachedWalk) {
+		t.Fatalf("cache changed result set: nil=%v cached=%v", nilCacheWalk, cachedWalk)
+	}
+	for i := range nilCacheWalk {
+		if nilCacheWalk[i] != cachedWalk[i] {
+			t.Fatalf("cache changed result at %d: nil=%q cached=%q", i, nilCacheWalk[i], cachedWalk[i])
+		}
+	}
+}

--- a/tests/ingest/scan_cache_test.go
+++ b/tests/ingest/scan_cache_test.go
@@ -1,0 +1,188 @@
+package tests
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/scancache"
+)
+
+// scanCacheTestConfig builds a config with the scan cache enabled and an
+// isolated state dir so the cache sqlite file is created under a temp tree.
+func scanCacheTestConfig(t *testing.T, root string) config.Config {
+	t.Helper()
+	cfg := config.Default()
+	cfg.RootDir = root
+	cfg.StateDir = filepath.Join(t.TempDir(), "state")
+	cfg.IngestScanCache = true
+	return cfg
+}
+
+// TestServiceRun_ScanCacheUnchangedTreeYieldsSameDocs verifies that a second
+// run over an unchanged tree (served from the persisted scan cache) produces the
+// same active documents as the first run, and that the cache file is created.
+func TestServiceRun_ScanCacheUnchangedTreeYieldsSameDocs(t *testing.T) {
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, "a.txt"), []byte("alpha text"))
+	mustWriteFile(t, filepath.Join(root, "sub", "b.txt"), []byte("beta text"))
+
+	cfg := scanCacheTestConfig(t, root)
+
+	st := newMemoryStore()
+	svc := mustNewIngestService(t, cfg, st)
+	if err := svc.Run(context.Background()); err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+
+	cachePath := scancache.DefaultPath(cfg.StateDir)
+	if _, err := os.Stat(cachePath); err != nil {
+		t.Fatalf("scan cache file not created at %s: %v", cachePath, err)
+	}
+
+	firstActive := activeDocPaths(st)
+
+	// Second run with the cache warm.
+	st2 := newMemoryStore()
+	svc2 := mustNewIngestService(t, cfg, st2)
+	if err := svc2.Run(context.Background()); err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+	secondActive := activeDocPaths(st2)
+
+	assertStringSetsEqual(t, "unchanged tree active docs", firstActive, secondActive)
+	if _, ok := secondActive["a.txt"]; !ok {
+		t.Fatalf("expected a.txt active after cached run, got %v", secondActive)
+	}
+	if _, ok := secondActive["sub/b.txt"]; !ok {
+		t.Fatalf("expected sub/b.txt active after cached run, got %v", secondActive)
+	}
+}
+
+// TestServiceRun_ScanCacheDetectsModifiedFile verifies that an in-place
+// modification (which does NOT bump the parent directory mtime) is still picked
+// up on a cached re-run: the document's content hash changes.
+func TestServiceRun_ScanCacheDetectsModifiedFile(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "sub", "b.txt")
+	mustWriteFile(t, filepath.Join(root, "a.txt"), []byte("alpha"))
+	mustWriteFile(t, target, []byte("beta original"))
+
+	cfg := scanCacheTestConfig(t, root)
+	st := newMemoryStore()
+	if err := mustNewIngestService(t, cfg, st).Run(context.Background()); err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+	beforeHash := st.docs["sub/b.txt"].ContentHash
+	if beforeHash == "" {
+		t.Fatalf("expected a content hash for sub/b.txt after first run")
+	}
+
+	// Modify in place with a strictly newer mtime to defeat mtime granularity.
+	mustWriteFile(t, target, []byte("beta CHANGED and much longer than before"))
+	future := time.Now().Add(2 * time.Second)
+	if err := os.Chtimes(target, future, future); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	st2 := newMemoryStore()
+	if err := mustNewIngestService(t, cfg, st2).Run(context.Background()); err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+	afterHash := st2.docs["sub/b.txt"].ContentHash
+	if afterHash == "" {
+		t.Fatalf("sub/b.txt missing after modification re-run")
+	}
+	if afterHash == beforeHash {
+		t.Fatalf("modified file not detected through scan cache: hash unchanged (%s)", afterHash)
+	}
+}
+
+// TestServiceRun_ScanCacheDetectsAddAndRemove verifies that adding and removing
+// files (both bump the parent directory mtime, invalidating the cached
+// signature) are reflected on a cached re-run.
+func TestServiceRun_ScanCacheDetectsAddAndRemove(t *testing.T) {
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, "dir", "keep.txt"), []byte("keep"))
+	mustWriteFile(t, filepath.Join(root, "dir", "remove.txt"), []byte("bye"))
+
+	cfg := scanCacheTestConfig(t, root)
+	st := newMemoryStore()
+	if err := mustNewIngestService(t, cfg, st).Run(context.Background()); err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+
+	mustWriteFile(t, filepath.Join(root, "dir", "added.txt"), []byte("new file"))
+	if err := os.Remove(filepath.Join(root, "dir", "remove.txt")); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+
+	st2 := newMemoryStore()
+	if err := mustNewIngestService(t, cfg, st2).Run(context.Background()); err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+	active := activeDocPaths(st2)
+	if _, ok := active["dir/added.txt"]; !ok {
+		t.Fatalf("added file not detected through scan cache: %v", active)
+	}
+	if _, ok := active["dir/remove.txt"]; ok {
+		t.Fatalf("removed file still active after scan cache re-run: %v", active)
+	}
+	if _, ok := active["dir/keep.txt"]; !ok {
+		t.Fatalf("kept file missing after scan cache re-run: %v", active)
+	}
+}
+
+// TestServiceRun_ScanCacheDisabledNoCacheFile verifies the default (cache off)
+// performs a full walk and never creates the cache file.
+func TestServiceRun_ScanCacheDisabledNoCacheFile(t *testing.T) {
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, "a.txt"), []byte("alpha"))
+	mustWriteFile(t, filepath.Join(root, "sub", "b.txt"), []byte("beta"))
+
+	cfg := scanCacheTestConfig(t, root)
+	cfg.IngestScanCache = false // explicit: default behavior, full walk.
+
+	st := newMemoryStore()
+	if err := mustNewIngestService(t, cfg, st).Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if _, err := os.Stat(scancache.DefaultPath(cfg.StateDir)); !os.IsNotExist(err) {
+		t.Fatalf("scan cache file should not exist when disabled (err=%v)", err)
+	}
+
+	active := activeDocPaths(st)
+	if _, ok := active["a.txt"]; !ok {
+		t.Fatalf("a.txt missing on full walk: %v", active)
+	}
+	if _, ok := active["sub/b.txt"]; !ok {
+		t.Fatalf("sub/b.txt missing on full walk: %v", active)
+	}
+}
+
+func activeDocPaths(st *memoryStore) map[string]struct{} {
+	out := map[string]struct{}{}
+	for relPath, doc := range st.docs {
+		if doc.Deleted {
+			continue
+		}
+		out[relPath] = struct{}{}
+	}
+	return out
+}
+
+func assertStringSetsEqual(t *testing.T, label string, want, got map[string]struct{}) {
+	t.Helper()
+	if len(want) != len(got) {
+		t.Fatalf("%s: set size mismatch want=%v got=%v", label, want, got)
+	}
+	for k := range want {
+		if _, ok := got[k]; !ok {
+			t.Fatalf("%s: missing %q in got=%v", label, k, got)
+		}
+	}
+}

--- a/tests/scancache/scancache_test.go
+++ b/tests/scancache/scancache_test.go
@@ -1,0 +1,94 @@
+package tests
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/corpusfs"
+	"github.com/dirstral/dir2mcp/internal/scancache"
+)
+
+func TestSQLiteCache_StoreAndLookupRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cache", "scan.sqlite")
+	c := scancache.Open(path)
+	defer func() { _ = c.Close() }()
+
+	sig := corpusfs.CachedDirSignature{
+		DirMTimeUnix: 1700000000,
+		Entries: []corpusfs.CachedDirEntry{
+			{Name: "a.txt", SizeBytes: 5, MTimeUnix: 1699999999, Mode: 0o644},
+			{Name: "sub", IsDir: true},
+		},
+	}
+	if err := c.StoreDir("docs", sig); err != nil {
+		t.Fatalf("StoreDir: %v", err)
+	}
+
+	got, ok, err := c.LookupDir("docs")
+	if err != nil {
+		t.Fatalf("LookupDir: %v", err)
+	}
+	if !ok {
+		t.Fatalf("LookupDir: expected hit")
+	}
+	if got.DirMTimeUnix != sig.DirMTimeUnix {
+		t.Fatalf("mtime mismatch: got %d want %d", got.DirMTimeUnix, sig.DirMTimeUnix)
+	}
+	if len(got.Entries) != 2 {
+		t.Fatalf("entry count mismatch: got %d want 2", len(got.Entries))
+	}
+	if got.Entries[0].Name != "a.txt" || got.Entries[0].SizeBytes != 5 || got.Entries[0].Mode != 0o644 {
+		t.Fatalf("file entry round-trip mismatch: %+v", got.Entries[0])
+	}
+	if !got.Entries[1].IsDir || got.Entries[1].Name != "sub" {
+		t.Fatalf("dir entry round-trip mismatch: %+v", got.Entries[1])
+	}
+}
+
+func TestSQLiteCache_LookupMissReturnsNoError(t *testing.T) {
+	c := scancache.Open(filepath.Join(t.TempDir(), "scan.sqlite"))
+	defer func() { _ = c.Close() }()
+
+	_, ok, err := c.LookupDir("nope")
+	if err != nil {
+		t.Fatalf("LookupDir miss should not error: %v", err)
+	}
+	if ok {
+		t.Fatalf("LookupDir: expected miss")
+	}
+}
+
+func TestSQLiteCache_StoreUpsertsAndPersists(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "scan.sqlite")
+
+	c := scancache.Open(path)
+	if err := c.StoreDir("d", corpusfs.CachedDirSignature{DirMTimeUnix: 1}); err != nil {
+		t.Fatalf("first store: %v", err)
+	}
+	// Overwrite the same key with a new mtime.
+	if err := c.StoreDir("d", corpusfs.CachedDirSignature{DirMTimeUnix: 2}); err != nil {
+		t.Fatalf("upsert store: %v", err)
+	}
+	if err := c.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	// Reopen the same file: the value must survive (persistence) and reflect the
+	// upsert (mtime=2, not 1).
+	reopened := scancache.Open(path)
+	defer func() { _ = reopened.Close() }()
+	got, ok, err := reopened.LookupDir("d")
+	if err != nil || !ok {
+		t.Fatalf("reopened LookupDir: ok=%v err=%v", ok, err)
+	}
+	if got.DirMTimeUnix != 2 {
+		t.Fatalf("upsert not persisted: got mtime %d want 2", got.DirMTimeUnix)
+	}
+}
+
+func TestSQLiteCache_DefaultPath(t *testing.T) {
+	want := filepath.Join("state", "cache", "scan.sqlite")
+	if got := scancache.DefaultPath("state"); got != want {
+		t.Fatalf("DefaultPath: got %q want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Implements **only item 5 ("Scan caching for large local trees") of #267**. dir2mcp re-walks the corpus tree from scratch on every run; for large local archives this is slow. This adds an **opt-in**, correctness-first directory-discovery scan cache so an unchanged directory skips re-reading and re-sorting its entries, while every add/remove/modify is still detected.

This is a pure internal performance optimization — **no MCP tool schema, citation, or persisted-document contract changes.** The cache lives in its own sqlite file and stores no authoritative state.

## What changed

- **Config** (`internal/config`): new opt-in `ingest.scan_cache` bool (flat aliases `scan_cache` / `ingest_scan_cache`, env `DIR2MCP_INGEST_SCAN_CACHE`). **Default OFF** — discovery behaves exactly as before. Wired through fileConfig, persisted YAML, file/env appliers, the bool scalar table, and the snapshot round-trip.
- **corpusfs** (`internal/corpusfs`): the `LocalFS` walker consults an optional `ScanCache`. It persists a per-directory signature — the directory's own mtime plus its direct children's name/size/mtime/mode. On a re-walk, a directory whose mtime is unchanged is served from the cache (skipping `ReadDir` + sort + per-dir gitignore parse).
- **scancache** (`internal/scancache`): a sqlite-backed `ScanCache` reusing the existing pure-Go `modernc.org/sqlite` driver and store-style single-writer + WAL pragmas. **No new dependency.** Stored at `state/cache/scan.sqlite`, alongside the existing content-addressed caches.
- **ingest** (`internal/ingest`): opens/closes the cache around the scan when enabled AND the backend is local/nfs (object stores key change detection off the ETag and ignore the cache). The sidecar enumeration and the filesystem watcher are deliberately left cache-free.

## Correctness (never trade correctness for speed)

The walker only trusts the cache after confirming **both**:
1. the directory's live mtime equals the recorded mtime (POSIX bumps it on any add/remove/rename of a direct child), and
2. every cached child still matches on a fresh `Lstat` — a regular file's size **and** mtime unchanged.

An in-place file modification bumps the file mtime (not the parent dir mtime), so it is caught by (2). Any mismatch, missing child, unexpected symlink, stat failure, cache error, or corrupt row falls the directory back to a full re-read. A TOCTOU guard declines to store a signature if the directory mtime changed during the read. Net effect: a stale/wrong/corrupt cache can only cost a re-walk, never cause a changed file to be missed.

## Tests (external `tests/<pkg>` packages)

- `tests/config`: `TestScanCache_DefaultsOff`, `TestScanCache_SaveLoadRoundTrip`, `TestScanCache_NestedAndFlatKeys`, `TestScanCache_EnvOverride`
- `tests/corpusfs`: `TestScanCache_UnchangedTreeSkipsReWalk`, `TestScanCache_DetectsModifiedFile`, `TestScanCache_DetectsAddedAndRemovedFile`, `TestScanCache_DisabledMatchesFullWalk`
- `tests/scancache`: `TestSQLiteCache_StoreAndLookupRoundTrip`, `TestSQLiteCache_LookupMissReturnsNoError`, `TestSQLiteCache_StoreUpsertsAndPersists`, `TestSQLiteCache_DefaultPath`
- `tests/ingest`: `TestServiceRun_ScanCacheUnchangedTreeYieldsSameDocs`, `TestServiceRun_ScanCacheDetectsModifiedFile`, `TestServiceRun_ScanCacheDetectsAddAndRemove`, `TestServiceRun_ScanCacheDisabledNoCacheFile`

`make check` passes fully green locally (lint, vet, gocyclo, build, all suites).

Part of #267 (item 5). Does not close #267.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a directory-discovery scan cache configuration option to optimize scanning of large local archives. The feature is disabled by default and can be enabled via configuration file or environment variable for improved performance on repeated scans.

* **Tests**
  * Added comprehensive test coverage for scan cache configuration, behavior, and SQLite persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->