### PR TITLE
feat: self-hosted OpenAI-compatible embed/OCR/STT endpoints (GPU VPS) (#240)

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,37 @@ ingest:
 - Under `extractor: auto`, docling-serve is used only when the docling CLI isn't on `PATH` (local CLI is preferred); an empty `serve_url` means the HTTP transport isn't considered, and an unreachable one is skipped in favor of another available extractor (for example Mistral OCR).
 - Env equivalent: `DIR2MCP_DOCLING_SERVE_URL=http://127.0.0.1:5001`.
 
+### Self-hosted / GPU-VPS provider endpoints (embed / OCR / STT)
+
+A self-hosted model server (on a GPU VPS or a trusted LAN) is a first-class provider: declare it under `providers:` with a custom `base_url` and bind it per capability (spec §8.5). No new provider `kind` is introduced, and a trusted-network endpoint may be **credential-less** (no `api_key`).
+
+```yaml
+providers:
+  gpu-embed:                 # OpenAI-compatible embed/chat (TEI, vLLM, Infinity, …)
+    kind: openai
+    base_url: http://gpu-vps:8080/v1
+    embed_text_model: bge-m3
+  whisper:                   # self-hosted STT (POST {base_url}/v1/audio/transcriptions)
+    kind: whisper
+    base_url: http://gpu-vps:9001/v1
+    stt_model: large-v3
+  gpu-ocr:                   # self-hosted bespoke OCR (POST {base_url}/v1/ocr)
+    kind: mistral            # base_url is the host ROOT; /v1/ocr is appended
+    base_url: http://gpu-vps:9100
+    ocr_model: my-ocr
+model:
+  embed:
+    provider: gpu-embed      # reindex-bound (the embed identity includes it)
+  ocr:
+    provider: gpu-ocr        # omit to keep the hosted mistral-ocr default
+stt_provider: whisper        # STT uses the legacy selector
+```
+
+- **Capability mapping** (which route serves each capability, spec §8.5): embed → `POST {base_url}/v1/embeddings`; chat → `/v1/chat/completions`; STT → `/v1/audio/transcriptions` (endpoint-dependent, validated at first use). **OCR has no OpenAI analog** — bind it only to a `kind: mistral` `/v1/ocr` endpoint (or use [docling-serve](#docling-extraction-over-http-docling-serve)); binding `model.ocr.provider` to a `kind: openai` profile is rejected as `CONFIG_INVALID`.
+- **`base_url` shape differs by kind:** a `kind: openai` `base_url` already includes `/v1`; a `kind: mistral` OCR `base_url` is the **host root** (the client appends `/v1/ocr`).
+- No shipped self-hosted defaults — you must declare the profile and bind it explicitly; nothing silently auto-selects a self-hosted endpoint.
+- For a full GPU-VPS topology (corpus over NFS/S3, vector backend, systemd), see [docs/dual-machine-deployment.md](docs/dual-machine-deployment.md).
+
 ### Continuous incremental indexing (optional)
 
 By default `dir2mcp up` scans the directory once at startup. Enable the **filesystem watcher** to keep the index continuously in sync with on-disk changes for the life of the process — added files are indexed, edited files are re-indexed, and removed files are tombstoned (evicted from retrieval).

--- a/docs/dual-machine-deployment.md
+++ b/docs/dual-machine-deployment.md
@@ -74,10 +74,21 @@ contract for self-hosted STT, so any server implementing those endpoints works
 (vLLM, Ollama, LM Studio, a whisper OpenAI shim, etc.). A self-hosted server on
 a trusted network may be **credential-less** — no API key required.
 
-> OCR note: OCR is **not** part of the OpenAI-compatible surface. A self-hosted
-> `kind: openai` profile is eligible for embed/chat/STT but not for OCR (OCR is a
-> native `mistral`-kind capability). If you need OCR, point the `ocr` capability
-> at a provider that supports it. (`dirstral-spec/docs/SPEC.md` §8.5.)
+> OCR note: OCR is **not** part of the OpenAI-compatible surface (SPEC §8.5: OCR
+> has no OpenAI analog). A self-hosted `kind: openai` profile is eligible for
+> embed/chat/STT but **not** for OCR — binding `model.ocr.provider` to a
+> `kind: openai` profile is rejected as `CONFIG_INVALID`. There are two
+> self-hosted OCR routes:
+>
+> 1. **docling-serve** (recommended) — run a [docling-serve](https://github.com/docling-project/docling-serve)
+>    container on the VPS and point `ingest.docling.serve_url` at it (e.g.
+>    `http://localhost:5001`). This is a distinct extractor, not a provider
+>    profile; see [Document extraction over HTTP](../README.md#docling-extraction-over-http-docling-serve).
+> 2. **A self-hosted `kind: mistral` `/v1/ocr` endpoint** — declare a
+>    `kind: mistral` profile whose `base_url` is the local OCR host and bind it
+>    via `model.ocr.provider` (shown below). dir2mcp will POST the bespoke
+>    `{base_url}/v1/ocr` request to that endpoint instead of the hosted Mistral
+>    default.
 
 ### 2.2 Point provider `base_url`s at localhost
 
@@ -102,11 +113,22 @@ providers:
     base_url: http://localhost:9000
     stt_model: <your-whisper-model>   # optional; servers often accept whisper-1
 
+  # Self-hosted OCR via a kind: mistral /v1/ocr endpoint (optional — see the OCR
+  # note above; docling-serve is the other route). base_url is the host ROOT:
+  # the bespoke OCR client appends /v1/ocr itself (unlike kind: openai base_urls,
+  # which already include /v1). A trusted-network endpoint may be credential-less.
+  gpu-ocr:
+    kind: mistral
+    base_url: http://localhost:9100
+    ocr_model: <your-ocr-model>
+
 model:
   embed:
     provider: vllm
   chat:
     provider: vllm
+  ocr:
+    provider: gpu-ocr               # omit to use the hosted mistral-ocr default
 
 # Self-hosted STT is reached via the legacy stt_provider selector.
 stt_provider: whisper

--- a/internal/config/providers.go
+++ b/internal/config/providers.go
@@ -260,6 +260,16 @@ func (r ProviderResolution) ByName() map[string]provider.Profile {
 	return r.byName
 }
 
+// OCRProviderName returns the explicit `model.ocr.provider` binding (SPEC
+// §16.2), trimmed, or "" when unset (auto). The ingest OCR resolution uses
+// it to honor a self-hosted bespoke-OCR profile (a `kind: mistral` profile on
+// a custom `base_url`, dir2mcp#240) instead of always assuming the built-in
+// `mistral-ocr` profile. An empty result means "use the historical default
+// profile".
+func (r ProviderResolution) OCRProviderName() string {
+	return strings.TrimSpace(r.doc.Model.OCR.Provider)
+}
+
 func (r ProviderResolution) explicit(cap provider.Capability) string {
 	switch cap {
 	case provider.CapEmbed:

--- a/internal/ingest/decision.go
+++ b/internal/ingest/decision.go
@@ -140,10 +140,26 @@ func describeAutoWithoutDoclingCLI(ctx context.Context, cfg config.Config, docli
 // "no secrets in diagnostics" contract enforced by the support-bundle
 // tests. The exec.LookPath result is also redacted for symmetry.
 
-// mistralOCRAvailable reports whether the mistral-ocr provider profile
-// resolves to a usable credential. Used by DescribeDocumentExtractor to
-// distinguish "fallback selected" from "no extractor at all".
+// ocrProviderName returns the bespoke-OCR provider PROFILE that ingest will
+// resolve: the explicit `model.ocr.provider` binding (SPEC §16.2) when set,
+// otherwise the built-in `mistral-ocr` profile (the historical default). This
+// is what lets an operator point OCR at a self-hosted bespoke-OCR endpoint —
+// a `kind: mistral` profile on a custom `base_url` (dir2mcp#240) — by binding
+// `model.ocr.provider` to it, instead of OCR always assuming `mistral-ocr`.
+func ocrProviderName(cfg config.Config) string {
+	if name := cfg.Providers().OCRProviderName(); name != "" {
+		return name
+	}
+	return "mistral-ocr"
+}
+
+// mistralOCRAvailable reports whether the configured bespoke-OCR provider
+// profile (see ocrProviderName) resolves to a usable, OCR-capable profile.
+// Used by DescribeDocumentExtractor to distinguish "fallback selected" from
+// "no extractor at all". A self-hosted profile may be credential-less, so this
+// reports availability whenever the profile is eligible and OCR-capable — not
+// only when an API key is present.
 func mistralOCRAvailable(cfg config.Config) bool {
-	_, err := cfg.Providers().ResolveExplicit(provider.CapOCR, "mistral-ocr", true)
+	_, err := cfg.Providers().ResolveExplicit(provider.CapOCR, ocrProviderName(cfg), true)
 	return err == nil
 }

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -364,13 +364,17 @@ func DiscoverOptionsFromConfig(cfg config.Config) DiscoverOptions {
 	return options
 }
 
-// mistralExtractor resolves the OCR provider (the bespoke mistral kind)
-// via the provider model and adapts it to model.DocumentExtractor.
-// Returns nil when no Mistral OCR credential is available (matching the
-// prior "no key -> no extractor" behavior). Docling is handled
-// separately below — it is a local tool, not a provider profile.
+// mistralExtractor resolves the bespoke-OCR provider (the `kind: mistral`
+// /v1/ocr surface) via the provider model and adapts it to
+// model.DocumentExtractor. It honors the explicit `model.ocr.provider`
+// binding (ocrProviderName) so an operator can point OCR at a self-hosted
+// bespoke-OCR endpoint — a `kind: mistral` profile on a custom `base_url`
+// (dir2mcp#240) — falling back to the built-in `mistral-ocr` profile when the
+// binding is unset. Returns nil when no OCR-capable profile resolves (matching
+// the prior "no key -> no extractor" behavior). Docling is handled separately
+// below — it is a local tool / docling-serve endpoint, not a provider profile.
 func mistralExtractor(cfg config.Config) model.DocumentExtractor {
-	prof, err := cfg.Providers().ResolveExplicit(provider.CapOCR, "mistral-ocr", true)
+	prof, err := cfg.Providers().ResolveExplicit(provider.CapOCR, ocrProviderName(cfg), true)
 	if err != nil {
 		return nil
 	}

--- a/tests/config/self_hosted_endpoints_test.go
+++ b/tests/config/self_hosted_endpoints_test.go
@@ -1,0 +1,167 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/provider"
+)
+
+// These tests pin the SPEC §8.5 self-hosted / OpenAI-compatible endpoint
+// contract (dir2mcp#240): a provider profile that carries only a custom
+// base_url (the GPU-VPS host) resolves end-to-end for each capability —
+// embed, OCR, and STT — without depending on a hosted SaaS credential.
+
+// TestSelfHosted_EmbedBaseURLResolves: a credential-less kind:openai profile
+// on a self-hosted base_url drives CapEmbed when bound via model.embed.provider
+// (SPEC §8.5 embed → POST /v1/embeddings). Self-hosted endpoints may be
+// credential-less and must still be eligible (§8.1.1/§8.1.3).
+func TestSelfHosted_EmbedBaseURLResolves(t *testing.T) {
+	yaml := "" +
+		"providers:\n" +
+		"  gpu-embed:\n" +
+		"    kind: openai\n" +
+		"    base_url: http://gpu-vps:8080/v1\n" +
+		"    embed_text_model: bge-m3\n" +
+		"model:\n" +
+		"  embed:\n" +
+		"    provider: gpu-embed\n"
+	r := loadCfg(t, yaml).Providers()
+
+	p, err := r.Resolve(provider.CapEmbed)
+	if err != nil {
+		t.Fatalf("resolve embed on self-hosted base_url: %v", err)
+	}
+	if p.Name != "gpu-embed" {
+		t.Fatalf("embed provider = %q, want gpu-embed", p.Name)
+	}
+	if p.Kind != provider.KindOpenAI {
+		t.Fatalf("embed kind = %q, want openai", p.Kind)
+	}
+	if !p.CredentialLess || !p.Eligible() {
+		t.Fatalf("credential-less self-hosted embed profile must be eligible: credLess=%v eligible=%v",
+			p.CredentialLess, p.Eligible())
+	}
+	if p.BaseURL != "http://gpu-vps:8080/v1" {
+		t.Fatalf("embed base_url = %q", p.BaseURL)
+	}
+	if p.EmbedTextModel != "bge-m3" {
+		t.Fatalf("embed text model = %q, want bge-m3", p.EmbedTextModel)
+	}
+	// The embed identity must encode the self-hosted profile + model so a
+	// change is corpus-lifetime / reindex-bound (SPEC §8.1.4 / §8.5).
+	if id := r.EmbedIdentity(); id != "gpu-embed|bge-m3||0|0|off" {
+		t.Fatalf("embed identity = %q", id)
+	}
+}
+
+// TestSelfHosted_OCRBaseURLResolves: a bespoke-OCR profile (kind:mistral, the
+// /v1/ocr surface) on a self-hosted base_url resolves for CapOCR when bound via
+// model.ocr.provider. Per SPEC §8.5 OCR has no OpenAI analog and stays a
+// bespoke surface, but its base_url is still operator-pointable at a GPU host.
+func TestSelfHosted_OCRBaseURLResolves(t *testing.T) {
+	yaml := "" +
+		"providers:\n" +
+		"  gpu-ocr:\n" +
+		"    kind: mistral\n" +
+		"    base_url: http://gpu-vps:9000/v1\n" +
+		"    ocr_model: my-ocr\n" +
+		"model:\n" +
+		"  ocr:\n" +
+		"    provider: gpu-ocr\n"
+	r := loadCfg(t, yaml).Providers()
+
+	// The explicit model.ocr.provider binding is what ingest reads.
+	if name := r.OCRProviderName(); name != "gpu-ocr" {
+		t.Fatalf("OCRProviderName = %q, want gpu-ocr", name)
+	}
+	p, err := r.Resolve(provider.CapOCR)
+	if err != nil {
+		t.Fatalf("resolve ocr on self-hosted base_url: %v", err)
+	}
+	if p.Name != "gpu-ocr" || p.Kind != provider.KindMistral {
+		t.Fatalf("ocr provider = %+v; want gpu-ocr kind=mistral", p)
+	}
+	if p.BaseURL != "http://gpu-vps:9000/v1" {
+		t.Fatalf("ocr base_url = %q", p.BaseURL)
+	}
+	if p.OCRModel != "my-ocr" {
+		t.Fatalf("ocr model = %q, want my-ocr", p.OCRModel)
+	}
+	if !p.CredentialLess || !p.Eligible() {
+		t.Fatalf("credential-less self-hosted ocr profile must be eligible: credLess=%v eligible=%v",
+			p.CredentialLess, p.Eligible())
+	}
+}
+
+// TestSelfHosted_OCRBaseURLRejectedForOpenAIKind pins SPEC §8.5: OCR is NOT
+// reachable through the OpenAI-compatible contract. Binding model.ocr.provider
+// to a kind:openai self-hosted profile is CONFIG_INVALID (matrix: ocr ❌ for
+// openai), so an operator is steered to docling-serve or a kind:mistral OCR
+// surface instead of silently producing no OCR.
+func TestSelfHosted_OCRBaseURLRejectedForOpenAIKind(t *testing.T) {
+	yaml := "" +
+		"providers:\n" +
+		"  gpu-openai:\n" +
+		"    kind: openai\n" +
+		"    base_url: http://gpu-vps:8080/v1\n" +
+		"model:\n" +
+		"  ocr:\n" +
+		"    provider: gpu-openai\n"
+	r := loadCfg(t, yaml).Providers()
+	if _, err := r.Resolve(provider.CapOCR); err == nil {
+		t.Fatal("ocr bound to kind:openai must be CONFIG_INVALID (SPEC §8.5: no OpenAI OCR analog)")
+	}
+}
+
+// TestSelfHosted_STTBaseURLResolves: the self-hosted whisper profile resolves
+// for CapSTT once its base_url is set (SPEC §8.5 stt → POST
+// /v1/audio/transcriptions). It is credential-less and eligible without a key.
+func TestSelfHosted_STTBaseURLResolves(t *testing.T) {
+	yaml := "" +
+		"providers:\n" +
+		"  whisper:\n" +
+		"    base_url: http://gpu-vps:9001/v1\n" +
+		"    stt_model: large-v3\n"
+	r := loadCfg(t, yaml).Providers()
+
+	p, err := r.ResolveExplicit(provider.CapSTT, "whisper", true)
+	if err != nil {
+		t.Fatalf("resolve stt on self-hosted whisper base_url: %v", err)
+	}
+	if p.Name != "whisper" || p.Kind != provider.KindWhisper {
+		t.Fatalf("stt provider = %+v; want whisper kind=whisper", p)
+	}
+	if p.BaseURL != "http://gpu-vps:9001/v1" {
+		t.Fatalf("stt base_url = %q", p.BaseURL)
+	}
+	if p.STTModel != "large-v3" {
+		t.Fatalf("stt model = %q, want large-v3", p.STTModel)
+	}
+	if !p.CredentialLess || !p.Eligible() {
+		t.Fatalf("credential-less self-hosted stt profile must be eligible: credLess=%v eligible=%v",
+			p.CredentialLess, p.Eligible())
+	}
+}
+
+// TestSelfHosted_STTOpenAIKindBaseURLResolves: a generic kind:openai
+// self-hosted endpoint also serves STT (endpoint-dependent, validated at first
+// use per SPEC §8.1.2 ³ / §8.5), so binding it for STT must resolve.
+func TestSelfHosted_STTOpenAIKindBaseURLResolves(t *testing.T) {
+	yaml := "" +
+		"providers:\n" +
+		"  gpu-stt:\n" +
+		"    kind: openai\n" +
+		"    base_url: http://gpu-vps:8080/v1\n" +
+		"    stt_model: whisper-1\n"
+	r := loadCfg(t, yaml).Providers()
+	p, err := r.ResolveExplicit(provider.CapSTT, "gpu-stt", true)
+	if err != nil {
+		t.Fatalf("resolve stt on self-hosted kind:openai base_url: %v", err)
+	}
+	if p.Name != "gpu-stt" || p.Kind != provider.KindOpenAI {
+		t.Fatalf("stt provider = %+v; want gpu-stt kind=openai", p)
+	}
+	if p.BaseURL != "http://gpu-vps:8080/v1" {
+		t.Fatalf("stt base_url = %q", p.BaseURL)
+	}
+}

--- a/tests/ingest/self_hosted_ocr_test.go
+++ b/tests/ingest/self_hosted_ocr_test.go
@@ -1,0 +1,121 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+)
+
+// loadYAMLConfig writes yaml to a temp .dir2mcp.yaml and loads it, so the
+// dynamic providers:/model: subtree (which carries model.ocr.provider) is
+// parsed — config.Config{} literals never populate it.
+func loadYAMLConfig(t *testing.T, yaml string) config.Config {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), ".dir2mcp.yaml")
+	if err := os.WriteFile(p, []byte(yaml), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg, err := config.LoadFile(p)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	return cfg
+}
+
+// TestSelfHostedOCR_IngestHonorsModelOCRProvider is the end-to-end ingest gap
+// for dir2mcp#240: with ingest.extractor=mistral and model.ocr.provider bound
+// to a self-hosted bespoke-OCR profile (kind:mistral on a custom base_url), the
+// extractor that ingest builds must call THAT endpoint — not the built-in
+// mistral-ocr SaaS default. Uses a fake OpenAI-compatible /v1/ocr server.
+func TestSelfHostedOCR_IngestHonorsModelOCRProvider(t *testing.T) {
+	var gotPath, gotModel string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if m, ok := body["model"].(string); ok {
+			gotModel = m
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"pages":[{"markdown":"self-hosted page"}]}`)
+	}))
+	defer srv.Close()
+
+	yaml := "" +
+		"ingest:\n" +
+		"  extractor: mistral\n" +
+		"providers:\n" +
+		"  gpu-ocr:\n" +
+		"    kind: mistral\n" +
+		// bespoke OCR appends /v1/ocr itself, so base_url is the host root
+		"    base_url: " + srv.URL + "\n" +
+		"    api_key: local-key\n" +
+		"    ocr_model: self-hosted-ocr\n" +
+		"model:\n" +
+		"  ocr:\n" +
+		"    provider: gpu-ocr\n"
+	cfg := loadYAMLConfig(t, yaml)
+
+	ex := ingest.DocumentExtractorFromConfig(cfg)
+	if ex == nil {
+		t.Fatal("expected an extractor from the self-hosted OCR binding")
+	}
+	out, err := ex.Extract(context.Background(), "scan.pdf", []byte("%PDF bytes"))
+	if err != nil {
+		t.Fatalf("Extract via self-hosted OCR: %v", err)
+	}
+	if gotPath != "/v1/ocr" {
+		t.Errorf("path = %q, want /v1/ocr on the self-hosted endpoint", gotPath)
+	}
+	if gotModel != "self-hosted-ocr" {
+		t.Errorf("model = %q, want the bound ocr_model self-hosted-ocr", gotModel)
+	}
+	if !strings.Contains(out, "self-hosted page") {
+		t.Fatalf("extracted text = %q", out)
+	}
+}
+
+// TestSelfHostedOCR_IngestFallsBackToMistralOCRWhenUnset confirms the change is
+// non-regressive: with no model.ocr.provider binding, ingest.extractor=mistral
+// still resolves the built-in mistral-ocr profile (the historical default).
+func TestSelfHostedOCR_IngestFallsBackToMistralOCRWhenUnset(t *testing.T) {
+	t.Setenv("MISTRAL_API_KEY", "test-key")
+	d := ingest.DescribeDocumentExtractor(config.Config{IngestExtractor: "mistral"})
+	if d.Name != "mistral-ocr" || d.Source != "explicit" {
+		t.Fatalf("unset binding should select built-in mistral-ocr: name=%q source=%q reason=%q",
+			d.Name, d.Source, d.Reason)
+	}
+}
+
+// TestSelfHostedOCR_IngestDisabledWhenBoundToOpenAIKind pins SPEC §8.5 at the
+// ingest layer: binding model.ocr.provider to a kind:openai profile yields no
+// extractor (OCR has no OpenAI analog), rather than silently mis-routing.
+func TestSelfHostedOCR_IngestDisabledWhenBoundToOpenAIKind(t *testing.T) {
+	yaml := "" +
+		"ingest:\n" +
+		"  extractor: mistral\n" +
+		"providers:\n" +
+		"  gpu-openai:\n" +
+		"    kind: openai\n" +
+		"    base_url: http://gpu-vps:8080/v1\n" +
+		"model:\n" +
+		"  ocr:\n" +
+		"    provider: gpu-openai\n"
+	cfg := loadYAMLConfig(t, yaml)
+	if ex := ingest.DocumentExtractorFromConfig(cfg); ex != nil {
+		t.Fatal("kind:openai OCR binding must yield no extractor (SPEC §8.5)")
+	}
+	d := ingest.DescribeDocumentExtractor(cfg)
+	if d.Name != "" || d.Source != "disabled" {
+		t.Fatalf("kind:openai OCR binding should be disabled: name=%q source=%q", d.Name, d.Source)
+	}
+}

--- a/tests/providerfactory/self_hosted_ocr_test.go
+++ b/tests/providerfactory/self_hosted_ocr_test.go
@@ -1,0 +1,99 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/provider"
+	"github.com/dirstral/dir2mcp/internal/providerfactory"
+)
+
+// TestSelfHostedOCR_EndToEnd drives the OCR adapter built by the factory from a
+// bespoke-OCR profile (kind:mistral) whose base_url points at a fake
+// self-hosted endpoint (dir2mcp#240 / SPEC §8.5). It asserts the request lands
+// on the bespoke /v1/ocr route with the profile's configured model, that the
+// custom base_url is honored (not the hosted SaaS default), and that a generic
+// page-markdown response decodes to extracted text. No network, no credential.
+func TestSelfHostedOCR_EndToEnd(t *testing.T) {
+	var (
+		gotPath   string
+		gotModel  string
+		gotAuth   string
+		gotMethod string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		gotAuth = r.Header.Get("Authorization")
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, "bad json", http.StatusBadRequest)
+			return
+		}
+		if m, ok := body["model"].(string); ok {
+			gotModel = m
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"pages":[{"markdown":"hello"},{"markdown":"world"}]}`)
+	}))
+	defer srv.Close()
+
+	// A self-hosted bespoke-OCR profile: kind:mistral on the fake base_url,
+	// with a custom OCR model name. The bespoke OCR client appends the
+	// /v1/ocr route itself, so base_url is the host ROOT (not a /v1 path) —
+	// unlike a kind:openai base_url which already includes /v1.
+	p := provider.Profile{
+		Name:     "gpu-ocr",
+		Kind:     provider.KindMistral,
+		BaseURL:  srv.URL,
+		OCRModel: "my-self-hosted-ocr",
+		APIKey:   "k", // mistral client requires a key; trusted-network deployments still set one
+	}
+
+	ocr, err := providerfactory.OCR(p)
+	if err != nil {
+		t.Fatalf("build OCR adapter for self-hosted profile: %v", err)
+	}
+
+	out, err := ocr.Extract(context.Background(), "scan.pdf", []byte("%PDF-1.4 bytes"))
+	if err != nil {
+		t.Fatalf("Extract against self-hosted OCR endpoint: %v", err)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotPath != "/v1/ocr" {
+		t.Errorf("path = %q, want /v1/ocr (the bespoke OCR route on the self-hosted base_url)", gotPath)
+	}
+	if gotModel != "my-self-hosted-ocr" {
+		t.Errorf("model = %q, want the profile's ocr_model my-self-hosted-ocr", gotModel)
+	}
+	if gotAuth != "Bearer k" {
+		t.Errorf("auth header = %q, want Bearer k", gotAuth)
+	}
+	if !strings.Contains(out, "hello") || !strings.Contains(out, "world") {
+		t.Fatalf("extracted text = %q, want both page markdowns", out)
+	}
+}
+
+// TestSelfHostedOCR_FactoryRejectsOpenAIKind pins SPEC §8.5 at the factory
+// boundary: there is no OpenAI-compatible OCR analog, so building an OCR
+// adapter from a kind:openai self-hosted profile must error rather than
+// silently mis-route to /chat/completions.
+func TestSelfHostedOCR_FactoryRejectsOpenAIKind(t *testing.T) {
+	p := provider.Profile{
+		Name:           "gpu-openai",
+		Kind:           provider.KindOpenAI,
+		BaseURL:        "http://gpu-vps:8080/v1",
+		CredentialLess: true,
+	}
+	if _, err := providerfactory.OCR(p); err == nil {
+		t.Fatal("OCR(kind:openai) must error (SPEC §8.5: OCR has no OpenAI analog)")
+	}
+}


### PR DESCRIPTION
Closes #240.

## Summary
Makes a custom-`base_url` provider profile drive **OCR** against a self-hosted endpoint, and verifies the same for **embed** and **STT**, per spec 0.16.0 §8.5 (self-hosted / OpenAI-compatible provider endpoints). Capability-driven and optional — no regression to the local-first default or the existing Mistral/docling paths. No spec change / no submodule re-pin (the contract is already in §8.5).

## What was already working vs the gap
- **Embed over `base_url`** — already worked via `kind: openai` + `base_url` (the `local`/custom-profile path). Verified with tests.
- **STT over `base_url`** — already worked (PR #274: `kind: whisper` profile + `stt.provider: whisper`; also `kind: openai` audio, endpoint-dependent). Verified with tests.
- **OCR over `base_url`** — the real gap. The ingest OCR resolution **hardcoded the `mistral-ocr` profile name** in `decision.go` and `service.go`, so an explicit `model.ocr.provider` binding (e.g. a `kind: mistral` `/v1/ocr` profile on a self-hosted `base_url`) was **silently ignored**. Per §8.5 OCR has no OpenAI analog, so the spec-faithful fix is to honor `model.ocr.provider` for the bespoke (`kind: mistral`) OCR surface — letting the operator point `base_url` at a GPU host — while docling-serve remains the other self-hosted OCR route.

## Changes
- `internal/config/providers.go`: add `ProviderResolution.OCRProviderName()` exposing the `model.ocr.provider` binding.
- `internal/ingest/decision.go` + `internal/ingest/service.go`: resolve the OCR extractor through the configured `model.ocr.provider` (new `ocrProviderName` helper), falling back to the built-in `mistral-ocr` when unset. Self-hosted profiles may be credential-less, so availability is judged by eligibility + capability.
- `providerfactory.OCR` keeps requiring `kind: mistral` (§8.5: no OpenAI OCR analog) but already honors `base_url`/`ocr_model`, so a self-hosted `kind: mistral` profile now drives OCR end-to-end.

## Docs
- `README.md`: new "Self-hosted / GPU-VPS provider endpoints (embed / OCR / STT)" section with a `providers:` block per capability, the §8.5 capability mapping, and the `base_url` shape gotcha (`kind: openai` includes `/v1`; bespoke OCR `base_url` is the host root, client appends `/v1/ocr`).
- `docs/dual-machine-deployment.md`: expanded the OCR note into the two real self-hosted OCR routes (docling-serve; `kind: mistral` `/v1/ocr` via `model.ocr.provider`) and added the OCR profile + binding to the example.

## Tests (external `tests/<pkg>` packages; no network, gated where needed)
- `tests/config/self_hosted_endpoints_test.go`: `TestSelfHosted_EmbedBaseURLResolves`, `TestSelfHosted_OCRBaseURLResolves`, `TestSelfHosted_OCRBaseURLRejectedForOpenAIKind`, `TestSelfHosted_STTBaseURLResolves`, `TestSelfHosted_STTOpenAIKindBaseURLResolves`.
- `tests/providerfactory/self_hosted_ocr_test.go`: `TestSelfHostedOCR_EndToEnd` (httptest fake of the `/v1/ocr` shape), `TestSelfHostedOCR_FactoryRejectsOpenAIKind`.
- `tests/ingest/self_hosted_ocr_test.go`: `TestSelfHostedOCR_IngestHonorsModelOCRProvider` (httptest end-to-end), `TestSelfHostedOCR_IngestFallsBackToMistralOCRWhenUnset` (non-regression), `TestSelfHostedOCR_IngestDisabledWhenBoundToOpenAIKind`.

`make check` is fully green (gofmt, go vet, golangci-lint, misspell, all suites, build).