### PR TITLE
feat(embed): distributed embedding workers via job queue (#248)

### DIFF
--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -144,7 +144,7 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 	defer a.stopPersistenceWithLog(persistence)
 
 	embedErrCh := make(chan error, 4)
-	startEmbeddingIfNotReadOnly(runCtx, opts.readOnly, st, textIx, codeIx, embedder, ret, indexingState, embedErrCh, a.stderr, opts.jsonOutput, etm, ecm, cfg.RootDir, corpusFS)
+	startEmbeddingIfNotReadOnly(runCtx, cfg, opts.readOnly, st, textIx, codeIx, embedder, ret, indexingState, embedErrCh, a.stderr, opts.jsonOutput, etm, ecm, cfg.RootDir, corpusFS)
 
 	mcpAddr := ln.Addr().String()
 	if cfg.Public {
@@ -967,8 +967,11 @@ func (a *App) stopPersistenceWithLog(persistence *index.PersistenceManager) {
 }
 
 // startEmbeddingIfNotReadOnly starts embedding workers when readOnly is false
-// and the store exposes the ChunkSource interface.
-func startEmbeddingIfNotReadOnly(ctx context.Context, readOnly bool, st model.Store, textIx, codeIx model.Index, embedder model.Embedder, ret *retrieval.Service, indexingState *appstate.IndexingState, embedErrCh chan error, stderr io.Writer, jsonOutput bool, embedModelText, embedModelCode, rootDir string, corpusFS corpusfs.CorpusFS) {
+// and the store exposes the ChunkSource interface. When distributed embedding is
+// enabled (issue #248, SPEC §8.7) it instead starts the in-process degenerate
+// case of the coordinator+worker topology; otherwise it keeps the historical
+// in-process embedding loop unchanged (local-first single-binary default, §1.2).
+func startEmbeddingIfNotReadOnly(ctx context.Context, cfg config.Config, readOnly bool, st model.Store, textIx, codeIx model.Index, embedder model.Embedder, ret *retrieval.Service, indexingState *appstate.IndexingState, embedErrCh chan error, stderr io.Writer, jsonOutput bool, embedModelText, embedModelCode, rootDir string, corpusFS corpusfs.CorpusFS) {
 	if readOnly {
 		return
 	}
@@ -977,6 +980,10 @@ func startEmbeddingIfNotReadOnly(ctx context.Context, readOnly bool, st model.St
 		return
 	}
 	embedLogger := pickEmbedLogger(stderr, jsonOutput)
+	if cfg.DistributedEmbed.Enabled {
+		startDistributedEmbedding(ctx, cfg, st, chunkSource, textIx, codeIx, embedder, ret, indexingState, embedErrCh, embedLogger, embedModelText, embedModelCode, rootDir, corpusFS)
+		return
+	}
 	startEmbeddingWorkers(ctx, chunkSource, textIx, codeIx, embedder, ret, indexingState, embedErrCh, embedLogger, embedModelText, embedModelCode, rootDir, corpusFS)
 }
 

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -144,7 +144,12 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 	defer a.stopPersistenceWithLog(persistence)
 
 	embedErrCh := make(chan error, 4)
-	startEmbeddingIfNotReadOnly(runCtx, cfg, opts.readOnly, st, textIx, codeIx, embedder, ret, indexingState, embedErrCh, a.stderr, opts.jsonOutput, etm, ecm, cfg.RootDir, corpusFS)
+	if err := startEmbeddingIfNotReadOnly(runCtx, cfg, opts.readOnly, st, textIx, codeIx, embedder, ret, indexingState, embedErrCh, a.stderr, opts.jsonOutput, etm, ecm, cfg.RootDir, corpusFS); err != nil {
+		// A distributed-embedding setup failure is fatal: refuse to run a server
+		// that would silently never drain its pending queue.
+		writeCLIError(a.stderr, opts.jsonOutput, exitConfigInvalid, fmt.Sprintf("start embedding: %v", err))
+		return exitConfigInvalid
+	}
 
 	mcpAddr := ln.Addr().String()
 	if cfg.Public {
@@ -971,20 +976,23 @@ func (a *App) stopPersistenceWithLog(persistence *index.PersistenceManager) {
 // enabled (issue #248, SPEC §8.7) it instead starts the in-process degenerate
 // case of the coordinator+worker topology; otherwise it keeps the historical
 // in-process embedding loop unchanged (local-first single-binary default, §1.2).
-func startEmbeddingIfNotReadOnly(ctx context.Context, cfg config.Config, readOnly bool, st model.Store, textIx, codeIx model.Index, embedder model.Embedder, ret *retrieval.Service, indexingState *appstate.IndexingState, embedErrCh chan error, stderr io.Writer, jsonOutput bool, embedModelText, embedModelCode, rootDir string, corpusFS corpusfs.CorpusFS) {
+// It returns an error only for a distributed-mode SETUP failure (broker cannot be
+// built, store lacks ChunkTaskByID, no embed identity), which the caller treats as
+// fatal — the historical in-process path never errors here.
+func startEmbeddingIfNotReadOnly(ctx context.Context, cfg config.Config, readOnly bool, st model.Store, textIx, codeIx model.Index, embedder model.Embedder, ret *retrieval.Service, indexingState *appstate.IndexingState, embedErrCh chan error, stderr io.Writer, jsonOutput bool, embedModelText, embedModelCode, rootDir string, corpusFS corpusfs.CorpusFS) error {
 	if readOnly {
-		return
+		return nil
 	}
 	chunkSource, ok := st.(index.ChunkSource)
 	if !ok {
-		return
+		return nil
 	}
 	embedLogger := pickEmbedLogger(stderr, jsonOutput)
 	if cfg.DistributedEmbed.Enabled {
-		startDistributedEmbedding(ctx, cfg, st, chunkSource, textIx, codeIx, embedder, ret, indexingState, embedErrCh, embedLogger, embedModelText, embedModelCode, rootDir, corpusFS)
-		return
+		return startDistributedEmbedding(ctx, cfg, st, chunkSource, textIx, codeIx, embedder, ret, indexingState, embedErrCh, embedLogger, embedModelText, embedModelCode, rootDir, corpusFS)
 	}
 	startEmbeddingWorkers(ctx, chunkSource, textIx, codeIx, embedder, ret, indexingState, embedErrCh, embedLogger, embedModelText, embedModelCode, rootDir, corpusFS)
+	return nil
 }
 
 // printHumanConnectionIfVerbose prints the human-readable connection block

--- a/internal/cli/up_distributed_embed.go
+++ b/internal/cli/up_distributed_embed.go
@@ -47,23 +47,23 @@ func startDistributedEmbedding(
 	logger *log.Logger,
 	textModel, codeModel, rootDir string,
 	corpusFS corpusfs.CorpusFS,
-) {
+) error {
+	// Setup failures are returned (not sent to errCh) so the caller can FAIL FAST:
+	// a server that cannot start its embedding topology would otherwise run
+	// silently with nothing draining the pending queue.
 	fetcher, ok := st.(distributedTaskFetcher)
 	if !ok {
-		errCh <- errors.New("distributed embedding: store does not support ChunkTaskByID")
-		return
+		return errors.New("distributed embedding: store does not support ChunkTaskByID")
 	}
 
 	identityStr := cfg.Providers().EmbedIdentity()
 	if identityStr == "" {
-		errCh <- errors.New("distributed embedding: embed identity could not be resolved")
-		return
+		return errors.New("distributed embedding: embed identity could not be resolved")
 	}
 
 	broker, err := buildEmbedBroker(ctx, cfg)
 	if err != nil {
-		errCh <- fmt.Errorf("distributed embedding: build broker: %v", err)
-		return
+		return fmt.Errorf("distributed embedding: build broker: %w", err)
 	}
 
 	// Build a per-kind embedder reusing the in-process embedding path so the
@@ -76,8 +76,9 @@ func startDistributedEmbedding(
 		embedders["code"] = newEmbedStep(chunkSource, codeIndex, embedder, ret, indexingState, textModel, codeModel, rootDir, corpusFS, logger, "code")
 	}
 	if len(embedders) == 0 {
-		errCh <- errors.New("distributed embedding: no index axis configured")
-		return
+		// Post-open abort: close the broker so its SQLite handle is not leaked.
+		_ = broker.Close()
+		return errors.New("distributed embedding: no index axis configured")
 	}
 
 	coord := &embedqueue.Coordinator{
@@ -96,10 +97,18 @@ func startDistributedEmbedding(
 		Logger:        logger,
 	}
 
-	// Coordinator: periodically enqueue chunks that are still pending. A single
-	// pass drains the current backlog; a ticker picks up chunks added later
-	// (incremental ingest) without a global ordering requirement (SPEC §8.7.3).
-	go runCoordinatorLoop(ctx, coord, logger)
+	// Close the broker when the run context ends so its handle (e.g. a SQLite DB)
+	// is released on shutdown.
+	go func() {
+		<-ctx.Done()
+		_ = broker.Close()
+	}()
+
+	// Coordinator: periodically enqueue chunks that are still pending. Each pass
+	// enqueues the current pending head; the ticker drives the full drain as the
+	// head clears and picks up chunks added later (incremental ingest), with no
+	// global ordering requirement (SPEC §8.7.3).
+	go runCoordinatorLoop(ctx, coord, errCh, logger)
 
 	// Worker: drain the queue. Errors are surfaced on errCh (cancellation is not
 	// an error), mirroring startEmbeddingWorkers.
@@ -109,12 +118,13 @@ func startDistributedEmbedding(
 			errCh <- fmt.Errorf("distributed embed worker: %w", rerr)
 		}
 	}()
+	return nil
 }
 
 // runCoordinatorLoop enqueues pending chunks on a fixed interval until ctx is
 // cancelled. Re-enqueuing is safe: already-embedded chunks are no longer pending,
 // and a duplicate job is idempotent at the embed layer (SPEC §8.7.3).
-func runCoordinatorLoop(ctx context.Context, coord *embedqueue.Coordinator, logger *log.Logger) {
+func runCoordinatorLoop(ctx context.Context, coord *embedqueue.Coordinator, errCh chan<- error, logger *log.Logger) {
 	ticker := time.NewTicker(2 * time.Second)
 	defer ticker.Stop()
 	for {
@@ -122,6 +132,13 @@ func runCoordinatorLoop(ctx context.Context, coord *embedqueue.Coordinator, logg
 			!errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 			if logger != nil {
 				logger.Printf("distributed embedding: enqueue pending: %v", err)
+			}
+			// Also surface it as a structured event (the human logger is discarded
+			// in JSON mode). Non-blocking: a transient enqueue error must not stall
+			// the loop if errCh is full.
+			select {
+			case errCh <- fmt.Errorf("distributed embedding: enqueue pending: %w", err):
+			default:
 			}
 		}
 		select {

--- a/internal/cli/up_distributed_embed.go
+++ b/internal/cli/up_distributed_embed.go
@@ -1,0 +1,191 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"path/filepath"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/appstate"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/corpusfs"
+	"github.com/dirstral/dir2mcp/internal/embedqueue"
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
+)
+
+// distributedTaskFetcher is the read-by-id capability the distributed worker
+// needs from the shared store (SPEC §8.7.4). The metadata store satisfies it.
+type distributedTaskFetcher interface {
+	ChunkTaskByID(ctx context.Context, chunkID uint64) (model.ChunkTask, string, error)
+}
+
+// startDistributedEmbedding runs the in-process degenerate case of the
+// distributed coordinator+worker topology (issue #248, SPEC §8.7): it builds the
+// configured broker, starts a coordinator that enqueues pending chunks, and a
+// worker that drains the queue by reusing the exact in-process embedding path
+// (index.EmbeddingWorker.EmbedAndIndex). This changes WHERE embedding runs (via a
+// broker) but not WHAT is persisted; with distributed mode off this function is
+// never reached and behavior is byte-identical to before.
+//
+// The full cross-machine deployment (a standalone worker process) lands in
+// follow-up #249, which wraps embedqueue.Run in a CLI subcommand; this PR ships
+// the reusable run-loop, not that subcommand.
+func startDistributedEmbedding(
+	ctx context.Context,
+	cfg config.Config,
+	st model.Store,
+	chunkSource index.ChunkSource,
+	textIndex, codeIndex model.Index,
+	embedder model.Embedder,
+	ret *retrieval.Service,
+	indexingState *appstate.IndexingState,
+	errCh chan<- error,
+	logger *log.Logger,
+	textModel, codeModel, rootDir string,
+	corpusFS corpusfs.CorpusFS,
+) {
+	fetcher, ok := st.(distributedTaskFetcher)
+	if !ok {
+		errCh <- errors.New("distributed embedding: store does not support ChunkTaskByID")
+		return
+	}
+
+	identityStr := cfg.Providers().EmbedIdentity()
+	if identityStr == "" {
+		errCh <- errors.New("distributed embedding: embed identity could not be resolved")
+		return
+	}
+
+	broker, err := buildEmbedBroker(ctx, cfg)
+	if err != nil {
+		errCh <- fmt.Errorf("distributed embedding: build broker: %v", err)
+		return
+	}
+
+	// Build a per-kind embedder reusing the in-process embedding path so the
+	// distributed worker shares all embed/media-load/index/mark logic.
+	embedders := make(map[string]embedqueue.Embedder)
+	if textIndex != nil {
+		embedders["text"] = newEmbedStep(chunkSource, textIndex, embedder, ret, indexingState, textModel, codeModel, rootDir, corpusFS, logger, "text")
+	}
+	if codeIndex != nil {
+		embedders["code"] = newEmbedStep(chunkSource, codeIndex, embedder, ret, indexingState, textModel, codeModel, rootDir, corpusFS, logger, "code")
+	}
+	if len(embedders) == 0 {
+		errCh <- errors.New("distributed embedding: no index axis configured")
+		return
+	}
+
+	coord := &embedqueue.Coordinator{
+		Source:        chunkSource,
+		Broker:        broker,
+		CorpusID:      rootDir,
+		SourceKind:    cfg.Source.Kind,
+		EmbedIdentity: identityStr,
+	}
+
+	workerCfg := embedqueue.Config{
+		Broker:        broker,
+		Fetcher:       fetcher,
+		Embedders:     embedders,
+		EmbedIdentity: identityStr,
+		Logger:        logger,
+	}
+
+	// Coordinator: periodically enqueue chunks that are still pending. A single
+	// pass drains the current backlog; a ticker picks up chunks added later
+	// (incremental ingest) without a global ordering requirement (SPEC §8.7.3).
+	go runCoordinatorLoop(ctx, coord, logger)
+
+	// Worker: drain the queue. Errors are surfaced on errCh (cancellation is not
+	// an error), mirroring startEmbeddingWorkers.
+	go func() {
+		if rerr := embedqueue.Run(ctx, workerCfg); rerr != nil &&
+			!errors.Is(rerr, context.Canceled) && !errors.Is(rerr, context.DeadlineExceeded) {
+			errCh <- fmt.Errorf("distributed embed worker: %w", rerr)
+		}
+	}()
+}
+
+// runCoordinatorLoop enqueues pending chunks on a fixed interval until ctx is
+// cancelled. Re-enqueuing is safe: already-embedded chunks are no longer pending,
+// and a duplicate job is idempotent at the embed layer (SPEC §8.7.3).
+func runCoordinatorLoop(ctx context.Context, coord *embedqueue.Coordinator, logger *log.Logger) {
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+	for {
+		if _, err := coord.EnqueuePending(ctx, ""); err != nil &&
+			!errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			if logger != nil {
+				logger.Printf("distributed embedding: enqueue pending: %v", err)
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+// newEmbedStep builds an index.EmbeddingWorker configured for one axis and
+// returns it as an embedqueue.Embedder (EmbedAndIndex). It reuses the identical
+// embed/media-load/index/mark logic the in-process loop uses; only the source of
+// tasks differs (leased jobs instead of NextPending polling).
+func newEmbedStep(
+	source index.ChunkSource,
+	ix model.Index,
+	embedder model.Embedder,
+	ret *retrieval.Service,
+	indexingState *appstate.IndexingState,
+	textModel, codeModel, rootDir string,
+	corpusFS corpusfs.CorpusFS,
+	logger *log.Logger,
+	kind string,
+) *index.EmbeddingWorker {
+	return &index.EmbeddingWorker{
+		// Source provides the MarkEmbedded/MarkFailed* status writes EmbedAndIndex
+		// performs (the in-process loop's exact write path). NextPending is unused
+		// here — the distributed worker feeds tasks from leased jobs instead.
+		Source:       source,
+		Index:        ix,
+		Embedder:     embedder,
+		ModelForText: textModel,
+		ModelForCode: codeModel,
+		RootDir:      rootDir,
+		Corpus:       corpusFS,
+		BatchSize:    32,
+		Logger:       logger,
+		OnIndexedChunk: func(label uint64, metadata model.ChunkMetadata) {
+			if ret != nil {
+				ret.SetChunkMetadataForIndex(kind, label, metadata.ToSearchHit())
+			}
+			if indexingState != nil {
+				indexingState.AddEmbeddedOK(1)
+			}
+		},
+	}
+}
+
+// buildEmbedBroker constructs the configured broker (SPEC §8.7.4). The built-in
+// "memory" and "sqlite" implementations are dependency-free; an external value
+// would be dispatched to an adapter (not shipped in this PR — #248 ships the
+// interface + defaults).
+func buildEmbedBroker(ctx context.Context, cfg config.Config) (embedqueue.Broker, error) {
+	switch cfg.DistributedEmbed.Broker {
+	case "", "memory":
+		return embedqueue.NewMemBroker(cfg.DistributedEmbed.MaxAttempts), nil
+	case "sqlite":
+		path := cfg.DistributedEmbed.BrokerSQLitePath
+		if path == "" {
+			path = filepath.Join(cfg.StateDir, "embed-queue.db")
+		}
+		return embedqueue.NewSQLiteBroker(ctx, path, cfg.DistributedEmbed.MaxAttempts)
+	default:
+		return nil, fmt.Errorf("unsupported distributed_embed.broker %q (built-ins: memory, sqlite)", cfg.DistributedEmbed.Broker)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,6 +64,40 @@ type SourceConfig struct {
 	S3SessionToken    string
 }
 
+// DistributedEmbedConfig configures the optional distributed-embedding job queue
+// (issue #248, SPEC §8.7). It is capability-driven and off by default: the
+// distributed mode activates only when Enabled is true. When off, the pipeline
+// runs the in-process embedding loop unchanged (SPEC §1.2, §8.7.4).
+//
+// The broker transport is implementation-defined (SPEC §8.7.4): Broker selects a
+// shipped default ("memory" in-process, or "sqlite" persistent) or an external
+// adapter. Connection parameters that are secrets (e.g. a broker URL with
+// embedded credentials) follow SPEC §16.1.1 and are NEVER persisted to the
+// config snapshot — only the non-sensitive Broker selector and the SQLite path
+// are persisted.
+type DistributedEmbedConfig struct {
+	// Enabled turns on the distributed coordinator+worker mode. When true the
+	// coordinator enqueues pending chunks and workers drain the queue; the
+	// in-process loop is not started. Requires a shared external (Tier C) vector
+	// store (SPEC §8.7.4) — validation rejects an embedded Tier A/B backend.
+	Enabled bool
+	// Broker selects the queue implementation: "memory" (default, in-process,
+	// single-node degenerate case) or "sqlite" (persistent, pure-Go). External
+	// adapters MAY define additional values.
+	Broker string
+	// BrokerSQLitePath is the SQLite queue file path when Broker=="sqlite".
+	// Empty defaults to <state_dir>/embed-queue.db. Non-sensitive; persisted.
+	BrokerSQLitePath string
+	// BrokerURL is the connection URL for an external broker (NATS/Redis/SQS).
+	// It MAY embed credentials, so it is treated as a runtime-only secret
+	// (SPEC §16.1.1): sourced from the environment / secret store and NEVER
+	// persisted to the snapshot. Empty for the built-in brokers.
+	BrokerURL string
+	// MaxAttempts bounds redelivery before a job is dead-lettered (SPEC §8.7.3).
+	// Non-positive falls back to the broker default (5).
+	MaxAttempts int
+}
+
 // QdrantConfig configures the optional Qdrant vector index backend (issue #268),
 // selected via index.backend=qdrant. URL and Collection are persisted invariants;
 // APIKey is a runtime-only secret resolved through the existing env/keychain/
@@ -385,6 +419,11 @@ type Config struct {
 	// Source selects the corpus backend (local/nfs/s3). See SourceConfig.
 	Source SourceConfig
 
+	// DistributedEmbed configures the optional distributed-embedding job queue
+	// (issue #248, SPEC §8.7). Off by default: when disabled the in-process
+	// embedding loop runs unchanged (local-first single-binary default, §1.2).
+	DistributedEmbed DistributedEmbedConfig
+
 	// providersDoc holds the parsed `providers:`/`model:` subtree (SPEC
 	// 0.7.0 §8.1/§16.2), decoded with yaml.v3 separately from the
 	// bespoke flat parser. Unexported/runtime-derived: not persisted,
@@ -490,6 +529,12 @@ type fileConfig struct {
 	IndexPgvectorDSN         *string
 	IndexPgvectorSchema      *string
 	IndexPgvectorTable       *string
+	// Distributed embedding (issue #248, SPEC §8.7). BrokerURL is a runtime-only
+	// secret and is intentionally absent so it can never be written to disk.
+	DistributedEmbedEnabled     *bool
+	DistributedEmbedBroker      *string
+	DistributedEmbedSQLitePath  *string
+	DistributedEmbedMaxAttempts *int
 }
 
 type persistedConfig struct {
@@ -606,6 +651,16 @@ type persistedConfig struct {
 	// secret store) at runtime. Schema/table are non-sensitive invariants.
 	IndexPgvectorSchema string `yaml:"index_pgvector_schema"`
 	IndexPgvectorTable  string `yaml:"index_pgvector_table"`
+
+	// Distributed embedding (issue #248, SPEC §8.7). The broker URL is sensitive
+	// (may embed credentials) and is intentionally NOT declared here so it can
+	// never be written to disk; it is sourced from DIR2MCP_DISTRIBUTED_EMBED_BROKER_URL
+	// at runtime (SPEC §16.1.1). The enable flag, broker selector, SQLite path,
+	// and max-attempts are non-sensitive invariants.
+	DistributedEmbedEnabled     bool   `yaml:"distributed_embed_enabled"`
+	DistributedEmbedBroker      string `yaml:"distributed_embed_broker"`
+	DistributedEmbedSQLitePath  string `yaml:"distributed_embed_sqlite_path"`
+	DistributedEmbedMaxAttempts int    `yaml:"distributed_embed_max_attempts"`
 }
 
 // Default returns the baseline Config (used as the starting point
@@ -841,6 +896,14 @@ func buildPersistedConfig(cfg *Config) persistedConfig {
 		// and intentionally omitted (sourced from env/secret store at runtime).
 		IndexPgvectorSchema: cfg.IndexPgvectorSchema,
 		IndexPgvectorTable:  cfg.IndexPgvectorTable,
+		// Distributed embedding (issue #248): enable flag, broker selector,
+		// SQLite path, and max-attempts are persistable invariants. BrokerURL is a
+		// secret (may embed credentials) and is intentionally omitted so it never
+		// lands in the YAML/snapshot (SPEC §16.1.1).
+		DistributedEmbedEnabled:     cfg.DistributedEmbed.Enabled,
+		DistributedEmbedBroker:      cfg.DistributedEmbed.Broker,
+		DistributedEmbedSQLitePath:  cfg.DistributedEmbed.BrokerSQLitePath,
+		DistributedEmbedMaxAttempts: cfg.DistributedEmbed.MaxAttempts,
 	}
 }
 
@@ -1172,6 +1235,18 @@ func applySourceFileParsed(cfg *Config, fc fileConfig) {
 	}
 	if fc.IndexPgvectorTable != nil {
 		cfg.IndexPgvectorTable = *fc.IndexPgvectorTable
+	}
+	if fc.DistributedEmbedEnabled != nil {
+		cfg.DistributedEmbed.Enabled = *fc.DistributedEmbedEnabled
+	}
+	if fc.DistributedEmbedBroker != nil {
+		cfg.DistributedEmbed.Broker = *fc.DistributedEmbedBroker
+	}
+	if fc.DistributedEmbedSQLitePath != nil {
+		cfg.DistributedEmbed.BrokerSQLitePath = *fc.DistributedEmbedSQLitePath
+	}
+	if fc.DistributedEmbedMaxAttempts != nil {
+		cfg.DistributedEmbed.MaxAttempts = *fc.DistributedEmbedMaxAttempts
 	}
 }
 
@@ -1793,6 +1868,11 @@ var configKeyAliases = map[string]string{
 	"index.pgvector.dsn":                   "index_pgvector_dsn",
 	"index.pgvector.schema":                "index_pgvector_schema",
 	"index.pgvector.table":                 "index_pgvector_table",
+	"distributed_embed.enabled":            "distributed_embed_enabled",
+	"distributed_embed.broker":             "distributed_embed_broker",
+	"distributed_embed.sqlite_path":        "distributed_embed_sqlite_path",
+	"distributed_embed.broker_url":         "distributed_embed_broker_url",
+	"distributed_embed.max_attempts":       "distributed_embed_max_attempts",
 }
 
 // canonicalizeConfigKey lower-cases and trims key and maps it through
@@ -1873,6 +1953,9 @@ var boolFileScalarTargets = map[string]func(*fileConfig) **bool{
 	"retrieval.hybrid.enabled": func(c *fileConfig) **bool { return &c.RetrievalHybridEnabled },
 	"dedup.retrieval":          func(c *fileConfig) **bool { return &c.DedupRetrieval },
 	"rerank.enabled":           func(c *fileConfig) **bool { return &c.RerankEnabled },
+	"distributed_embed_enabled": func(c *fileConfig) **bool {
+		return &c.DistributedEmbedEnabled
+	},
 }
 
 func setBoolFileScalar(cfg *fileConfig, key, value string) error {
@@ -1909,6 +1992,9 @@ var intFileScalarTargets = map[string]func(*fileConfig) **int{
 	"media.video_window_sec":     func(c *fileConfig) **int { return &c.MediaVideoWindowSec },
 	"media.clip.max_duration_ms": func(c *fileConfig) **int { return &c.MediaClipMaxDurationMS },
 	"media.clip.max_bytes":       func(c *fileConfig) **int { return &c.MediaClipMaxBytes },
+	"distributed_embed_max_attempts": func(c *fileConfig) **int {
+		return &c.DistributedEmbedMaxAttempts
+	},
 }
 
 func setIntFileScalar(cfg *fileConfig, key, value string) error {
@@ -2025,6 +2111,10 @@ func setSourceStringFileScalar(cfg *fileConfig, key, value string) {
 		cfg.IndexPgvectorSchema = strPtr(value)
 	case "index_pgvector_table":
 		cfg.IndexPgvectorTable = strPtr(value)
+	case "distributed_embed_broker":
+		cfg.DistributedEmbedBroker = strPtr(value)
+	case "distributed_embed_sqlite_path":
+		cfg.DistributedEmbedSQLitePath = strPtr(value)
 	}
 }
 
@@ -2325,6 +2415,12 @@ func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	writeScalar("index_pgvector_schema", cfg.IndexPgvectorSchema)
 	writeScalar("index_pgvector_table", cfg.IndexPgvectorTable)
 	// index_pgvector_dsn is a secret and never written to disk (env/keychain/.env.local-only).
+	writeBool("distributed_embed_enabled", cfg.DistributedEmbedEnabled)
+	writeScalar("distributed_embed_broker", cfg.DistributedEmbedBroker)
+	writeScalar("distributed_embed_sqlite_path", cfg.DistributedEmbedSQLitePath)
+	writeInt("distributed_embed_max_attempts", cfg.DistributedEmbedMaxAttempts)
+	// distributed_embed_broker_url is a secret (may embed credentials) and is
+	// never written to disk (env/keychain/.env.local-only, SPEC §16.1.1).
 
 	return []byte(b.String()), nil
 }
@@ -2390,6 +2486,28 @@ func applyEnvOverrides(cfg *Config, overrideEnv map[string]string) {
 	applySourceEnvOverrides(cfg, overrideEnv)
 	applyQdrantEnvOverrides(cfg, overrideEnv)
 	applyIndexEnvOverrides(cfg, overrideEnv)
+	applyDistributedEmbedEnvOverrides(cfg, overrideEnv)
+}
+
+// applyDistributedEmbedEnvOverrides applies the distributed-embedding env
+// overrides (issue #248, SPEC §8.7). Enabled/broker/sqlite_path/max_attempts are
+// non-secret settings. The broker URL is a runtime-only secret (it may embed
+// credentials): resolved through the existing precedence (env → keychain →
+// file/.env.local) and NEVER persisted to the snapshot (SPEC §16.1.1).
+func applyDistributedEmbedEnvOverrides(cfg *Config, env map[string]string) {
+	if raw, ok := envLookup("DIR2MCP_DISTRIBUTED_EMBED_ENABLED", env); ok {
+		if parsed, err := strconv.ParseBool(strings.TrimSpace(raw)); err == nil {
+			cfg.DistributedEmbed.Enabled = parsed
+		}
+	}
+	setTrimmedEnv(env, "DIR2MCP_DISTRIBUTED_EMBED_BROKER", &cfg.DistributedEmbed.Broker)
+	setTrimmedEnv(env, "DIR2MCP_DISTRIBUTED_EMBED_SQLITE_PATH", &cfg.DistributedEmbed.BrokerSQLitePath)
+	if raw, ok := envLookup("DIR2MCP_DISTRIBUTED_EMBED_MAX_ATTEMPTS", env); ok {
+		if parsed, err := strconv.Atoi(strings.TrimSpace(raw)); err == nil {
+			cfg.DistributedEmbed.MaxAttempts = parsed
+		}
+	}
+	setSecretEnv(env, "DIR2MCP_DISTRIBUTED_EMBED_BROKER_URL", &cfg.DistributedEmbed.BrokerURL)
 }
 
 // applyIndexEnvOverrides sources vector-index backend settings from the
@@ -2715,6 +2833,9 @@ func (c *Config) Validate() error {
 	if err := c.validateSource(); err != nil {
 		return err
 	}
+	if err := c.validateDistributedEmbed(); err != nil {
+		return err
+	}
 	c.applyValidationDefaults()
 	if c.SessionMaxLifetime > 0 && c.SessionMaxLifetime < c.SessionInactivityTimeout {
 		return fmt.Errorf("session_max_lifetime (%v) must be >= session_inactivity_timeout (%v)",
@@ -2967,6 +3088,55 @@ func (c *Config) validateSourceRuntimeSecrets() error {
 			"(set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY via environment, keychain, or .env.local)")
 	}
 	return nil
+}
+
+// validateDistributedEmbed enforces the distributed-embedding invariants
+// (issue #248, SPEC §8.7). It is a no-op when distributed mode is off (the
+// in-process loop runs, §1.2). When enabled it: (1) normalizes/validates the
+// broker selector (memory|sqlite, or an external value), and (2) REQUIRES a
+// shared external Tier-C vector store (qdrant/pgvector, §8.7.4) — the embedded
+// Tier A/B backends are single-node and cannot be shared across workers, so a
+// distributed pool over an embedded backend is rejected as CONFIG_INVALID. The
+// broker URL credential is never validated here (it is a runtime-only secret
+// resolved per §16.1.1, absent on file/snapshot loads).
+func (c *Config) validateDistributedEmbed() error {
+	if !c.DistributedEmbed.Enabled {
+		return nil
+	}
+	broker := strings.ToLower(strings.TrimSpace(c.DistributedEmbed.Broker))
+	if broker == "" {
+		broker = "memory"
+	}
+	switch broker {
+	case "memory", "sqlite":
+		// built-in, dependency-free brokers (SPEC §8.7.4 default impl)
+	default:
+		// An external adapter value is allowed but MUST carry a connection URL so
+		// the topology is actually reachable.
+		if strings.TrimSpace(c.DistributedEmbed.BrokerURL) == "" {
+			return fmt.Errorf("distributed_embed.broker=%q requires distributed_embed.broker_url "+
+				"(set DIR2MCP_DISTRIBUTED_EMBED_BROKER_URL)", c.DistributedEmbed.Broker)
+		}
+	}
+	c.DistributedEmbed.Broker = broker
+	if c.DistributedEmbed.MaxAttempts < 0 {
+		return fmt.Errorf("distributed_embed.max_attempts must be non-negative: %d", c.DistributedEmbed.MaxAttempts)
+	}
+
+	// Tier C is a PREREQUISITE of the distributed mode (SPEC §8.7.4): the embedded
+	// Tier A/B backends (memory/disk) are single-node and not a shared store.
+	backend := strings.ToLower(strings.TrimSpace(c.IndexBackend))
+	if backend == "" {
+		backend = Default().IndexBackend
+	}
+	switch backend {
+	case "qdrant", "pgvector":
+		return nil
+	default:
+		return fmt.Errorf("distributed_embed.enabled requires an external Tier C vector store "+
+			"(index.backend=qdrant or pgvector); the embedded backend %q is single-node and cannot be "+
+			"shared across distributed workers (SPEC §8.7.4)", backend)
+	}
 }
 
 // finalizeLoaded runs the standard post-load validation: Validate (persisted

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1126,24 +1126,12 @@ func load(path string, overrideEnv map[string]string, applyEnv bool) (Config, er
 		}
 	}
 	if path == "" {
-		if applyEnv {
-			applyEnvOverrides(&cfg, overrideEnv)
-		}
-		if err := cfg.finalizeLoaded(applyEnv); err != nil {
-			return Config{}, err
-		}
-		return cfg, nil
+		return finalizeLoadedConfig(cfg, overrideEnv, applyEnv)
 	}
 
 	if _, err := os.Stat(path); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			if applyEnv {
-				applyEnvOverrides(&cfg, overrideEnv)
-			}
-			if err := cfg.finalizeLoaded(applyEnv); err != nil {
-				return Config{}, err
-			}
-			return cfg, nil
+			return finalizeLoadedConfig(cfg, overrideEnv, applyEnv)
 		}
 		return Config{}, fmt.Errorf("stat config: %w", err)
 	}
@@ -1151,8 +1139,18 @@ func load(path string, overrideEnv map[string]string, applyEnv bool) (Config, er
 	if err := applyFileOverrides(&cfg, path); err != nil {
 		return Config{}, err
 	}
+	return finalizeLoadedConfig(cfg, overrideEnv, applyEnv)
+}
+
+// finalizeLoadedConfig applies env overrides (when applyEnv) and runs the
+// post-load validation, returning the resolved config. Shared by every load
+// branch (no-path, missing-file, and file-present) so the env-apply + validate
+// sequence — and its error handling — lives in one place.
+func finalizeLoadedConfig(cfg Config, overrideEnv map[string]string, applyEnv bool) (Config, error) {
 	if applyEnv {
-		applyEnvOverrides(&cfg, overrideEnv)
+		if err := applyEnvOverrides(&cfg, overrideEnv); err != nil {
+			return Config{}, err
+		}
 	}
 	if err := cfg.finalizeLoaded(applyEnv); err != nil {
 		return Config{}, err
@@ -1899,6 +1897,8 @@ func isMapSectionKey(key string) bool {
 		return true
 	case "index.pgvector":
 		return true
+	case "distributed_embed":
+		return true
 	case "ingest.extractor":
 		return false
 	default:
@@ -2467,9 +2467,9 @@ func floatPtr(value float64) *float64 { return &value }
 // applyEnvOverrides layers all supported environment-variable overrides
 // onto cfg. Env always wins when present (an empty DIR2MCP_SERVER_NAME
 // clears a YAML-set name).
-func applyEnvOverrides(cfg *Config, overrideEnv map[string]string) {
+func applyEnvOverrides(cfg *Config, overrideEnv map[string]string) error {
 	if cfg == nil {
-		return
+		return nil
 	}
 	// Env always wins when present so DIR2MCP_SERVER_NAME="" can clear a
 	// YAML-set server.name and fall through to the auto-derived name at
@@ -2486,28 +2486,35 @@ func applyEnvOverrides(cfg *Config, overrideEnv map[string]string) {
 	applySourceEnvOverrides(cfg, overrideEnv)
 	applyQdrantEnvOverrides(cfg, overrideEnv)
 	applyIndexEnvOverrides(cfg, overrideEnv)
-	applyDistributedEmbedEnvOverrides(cfg, overrideEnv)
+	return applyDistributedEmbedEnvOverrides(cfg, overrideEnv)
 }
 
 // applyDistributedEmbedEnvOverrides applies the distributed-embedding env
 // overrides (issue #248, SPEC §8.7). Enabled/broker/sqlite_path/max_attempts are
 // non-secret settings. The broker URL is a runtime-only secret (it may embed
 // credentials): resolved through the existing precedence (env → keychain →
-// file/.env.local) and NEVER persisted to the snapshot (SPEC §16.1.1).
-func applyDistributedEmbedEnvOverrides(cfg *Config, env map[string]string) {
+// file/.env.local) and NEVER persisted to the snapshot (SPEC §16.1.1). A
+// malformed boolean/integer override is reported rather than silently ignored, so
+// automation cannot believe an override applied when it did not.
+func applyDistributedEmbedEnvOverrides(cfg *Config, env map[string]string) error {
 	if raw, ok := envLookup("DIR2MCP_DISTRIBUTED_EMBED_ENABLED", env); ok {
-		if parsed, err := strconv.ParseBool(strings.TrimSpace(raw)); err == nil {
-			cfg.DistributedEmbed.Enabled = parsed
+		parsed, err := strconv.ParseBool(strings.TrimSpace(raw))
+		if err != nil {
+			return fmt.Errorf("invalid DIR2MCP_DISTRIBUTED_EMBED_ENABLED %q: want a boolean", raw)
 		}
+		cfg.DistributedEmbed.Enabled = parsed
 	}
 	setTrimmedEnv(env, "DIR2MCP_DISTRIBUTED_EMBED_BROKER", &cfg.DistributedEmbed.Broker)
 	setTrimmedEnv(env, "DIR2MCP_DISTRIBUTED_EMBED_SQLITE_PATH", &cfg.DistributedEmbed.BrokerSQLitePath)
 	if raw, ok := envLookup("DIR2MCP_DISTRIBUTED_EMBED_MAX_ATTEMPTS", env); ok {
-		if parsed, err := strconv.Atoi(strings.TrimSpace(raw)); err == nil {
-			cfg.DistributedEmbed.MaxAttempts = parsed
+		parsed, err := strconv.Atoi(strings.TrimSpace(raw))
+		if err != nil {
+			return fmt.Errorf("invalid DIR2MCP_DISTRIBUTED_EMBED_MAX_ATTEMPTS %q: want an integer", raw)
 		}
+		cfg.DistributedEmbed.MaxAttempts = parsed
 	}
 	setSecretEnv(env, "DIR2MCP_DISTRIBUTED_EMBED_BROKER_URL", &cfg.DistributedEmbed.BrokerURL)
+	return nil
 }
 
 // applyIndexEnvOverrides sources vector-index backend settings from the
@@ -3093,7 +3100,8 @@ func (c *Config) validateSourceRuntimeSecrets() error {
 // validateDistributedEmbed enforces the distributed-embedding invariants
 // (issue #248, SPEC §8.7). It is a no-op when distributed mode is off (the
 // in-process loop runs, §1.2). When enabled it: (1) normalizes/validates the
-// broker selector (memory|sqlite, or an external value), and (2) REQUIRES a
+// broker selector (only the built-in memory|sqlite brokers are constructible in
+// this build), and (2) REQUIRES a
 // shared external Tier-C vector store (qdrant/pgvector, §8.7.4) — the embedded
 // Tier A/B backends are single-node and cannot be shared across workers, so a
 // distributed pool over an embedded backend is rejected as CONFIG_INVALID. The
@@ -3111,12 +3119,14 @@ func (c *Config) validateDistributedEmbed() error {
 	case "memory", "sqlite":
 		// built-in, dependency-free brokers (SPEC §8.7.4 default impl)
 	default:
-		// An external adapter value is allowed but MUST carry a connection URL so
-		// the topology is actually reachable.
-		if strings.TrimSpace(c.DistributedEmbed.BrokerURL) == "" {
-			return fmt.Errorf("distributed_embed.broker=%q requires distributed_embed.broker_url "+
-				"(set DIR2MCP_DISTRIBUTED_EMBED_BROKER_URL)", c.DistributedEmbed.Broker)
-		}
+		// Stay in sync with buildEmbedBroker (internal/cli), which can only
+		// construct the built-in brokers: an external adapter value would validate
+		// here but then fail at startup. Reject it up front. External brokers
+		// (NATS/Redis/SQS) plug in behind the Broker interface but ship in a
+		// follow-up, not this build.
+		return fmt.Errorf("distributed_embed.broker=%q is not supported in this build "+
+			"(built-in brokers: memory, sqlite); external broker adapters are not yet implemented",
+			c.DistributedEmbed.Broker)
 	}
 	c.DistributedEmbed.Broker = broker
 	if c.DistributedEmbed.MaxAttempts < 0 {

--- a/internal/embedqueue/broker.go
+++ b/internal/embedqueue/broker.go
@@ -1,0 +1,76 @@
+package embedqueue
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// ErrNoJob is returned by Broker.Lease when no job is currently available. It is
+// not a failure — the worker run-loop treats it as "queue empty, back off and
+// retry" rather than an error to surface.
+var ErrNoJob = errors.New("embedqueue: no job available")
+
+// Lease is a claimed job plus the opaque token a worker uses to Ack or Nack it.
+// A lease is held for a broker-defined visibility timeout; if the worker neither
+// Acks nor Nacks before the lease expires the job becomes re-claimable by another
+// worker (SPEC §8.7.3 lease expiry / at-least-once delivery).
+type Lease struct {
+	// Job is the leased unit of work.
+	Job Job
+	// Token identifies this lease to Ack/Nack. It is opaque to the worker.
+	Token string
+	// Deadline is when the lease expires and the job becomes re-claimable. A
+	// worker SHOULD finish (Ack/Nack) before it; a worker that observes the
+	// deadline has passed MUST treat its in-flight write as possibly raced by a
+	// redelivery (idempotency, keyed by chunk_id, makes that safe — §8.7.3).
+	Deadline time.Time
+}
+
+// Broker is the implementation-defined transport that carries embedding jobs
+// from the coordinator to the workers (SPEC §8.7.4). Any queue providing
+// at-least-once delivery, a redelivery/visibility mechanism, and a dead-letter
+// path satisfies the contract — NATS, Redis, SQS, or the default in-process /
+// SQLite-backed implementations shipped in this package.
+//
+// Implementations MUST be safe for concurrent use by the coordinator (Enqueue)
+// and many workers (Lease/Ack/Nack) at once.
+type Broker interface {
+	// Enqueue adds a job to the queue. Enqueuing a job whose chunk_id is already
+	// queued is allowed (at-least-once delivery is assumed) and idempotent at the
+	// embedding layer because vector writes are keyed by chunk_id (§8.7.3).
+	Enqueue(ctx context.Context, job Job) error
+
+	// Lease claims the next available job and returns it with a lease token and
+	// deadline. The job is hidden from other workers until the lease expires or
+	// the worker Acks/Nacks it. Returns ErrNoJob when the queue is empty.
+	Lease(ctx context.Context, visibility time.Duration) (Lease, error)
+
+	// Ack marks a leased job done; it is removed from the queue. Acking an
+	// expired/unknown lease token is a no-op (the job may have been redelivered).
+	Ack(ctx context.Context, token string) error
+
+	// Nack returns a leased job for redelivery. If the job has already been
+	// delivered maxAttempts times it is moved to the dead-letter store instead of
+	// being requeued (SPEC §8.7.3 dead-lettering). retryAfter delays the next
+	// delivery; zero makes the job immediately re-claimable.
+	Nack(ctx context.Context, token string, retryAfter time.Duration) error
+
+	// Stats reports queue depth for observability and for tests/coordinator
+	// drain-detection. It never blocks on in-flight work.
+	Stats(ctx context.Context) (Stats, error)
+
+	// Close releases any resources the broker holds.
+	Close() error
+}
+
+// Stats is a point-in-time view of the queue (SPEC §8.7.4 observability).
+type Stats struct {
+	// Pending is the number of jobs available to be leased.
+	Pending int
+	// InFlight is the number of jobs currently leased (not yet Acked/Nacked and
+	// not yet expired).
+	InFlight int
+	// DeadLettered is the number of jobs that exhausted their retries.
+	DeadLettered int
+}

--- a/internal/embedqueue/coordinator.go
+++ b/internal/embedqueue/coordinator.go
@@ -32,12 +32,17 @@ type Coordinator struct {
 	BatchSize int
 }
 
-// EnqueuePending drains every pending chunk of indexKind ("text"/"code", or ""
-// for both) into the broker and returns the number of jobs enqueued. It reads in
-// batches until the store reports no more pending chunks, so one call enqueues
-// the full backlog. Re-running it is safe: a chunk already enqueued and embedded
-// is no longer pending, and a duplicate job is idempotent at the embed layer
-// (vector writes keyed by chunk_id, §8.7.3).
+// EnqueuePending enqueues the currently-pending chunks of indexKind ("text"/
+// "code", or "" for both) into the broker and returns the number of jobs
+// submitted. NextPending keeps returning the same pending head until those chunks
+// leave the pending state (a worker marks them ok/error out-of-band), and the
+// interface has no offset cursor, so one call enqueues the head it observes — NOT
+// necessarily the entire backlog. The coordinator loop (runCoordinatorLoop) calls
+// this on a ticker, so as the head drains the next pending chunks are picked up;
+// the broker dedups by chunk_id+index_kind, so repeated ticks never pile up
+// duplicate live jobs (SPEC §8.7.3). Re-running is always safe: an already-
+// embedded chunk is no longer pending, and a duplicate job is idempotent at the
+// embed layer (vector writes keyed by chunk_id).
 func (c *Coordinator) EnqueuePending(ctx context.Context, indexKind string) (int, error) {
 	if c.Source == nil || c.Broker == nil {
 		return 0, fmt.Errorf("embedqueue: coordinator requires a source and broker")

--- a/internal/embedqueue/coordinator.go
+++ b/internal/embedqueue/coordinator.go
@@ -1,0 +1,128 @@
+package embedqueue
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// PendingSource is the read side of the chunk store the coordinator drains: it
+// returns chunks whose embedding_status is "pending" (SPEC §5.3). The metadata
+// store (internal/store.SQLiteStore) already satisfies it via NextPending, so the
+// coordinator reuses the exact pending-selection the in-process loop uses.
+type PendingSource interface {
+	NextPending(ctx context.Context, limit int, indexKind string) ([]model.ChunkTask, error)
+}
+
+// Coordinator enqueues embedding jobs for pending chunks (SPEC §8.7.1). It owns
+// no embedding compute — it only translates the store's pending chunks into
+// broker jobs bound to the current corpus reference and embed identity (§8.7.2).
+// It is opt-in: the in-process loop remains the default and this type is only
+// constructed when distributed mode is enabled.
+type Coordinator struct {
+	Source        PendingSource
+	Broker        Broker
+	CorpusID      string
+	SourceKind    string
+	EmbedIdentity string
+	// BatchSize bounds how many pending chunks are read per drain pass. A
+	// non-positive value defaults to 256.
+	BatchSize int
+}
+
+// EnqueuePending drains every pending chunk of indexKind ("text"/"code", or ""
+// for both) into the broker and returns the number of jobs enqueued. It reads in
+// batches until the store reports no more pending chunks, so one call enqueues
+// the full backlog. Re-running it is safe: a chunk already enqueued and embedded
+// is no longer pending, and a duplicate job is idempotent at the embed layer
+// (vector writes keyed by chunk_id, §8.7.3).
+func (c *Coordinator) EnqueuePending(ctx context.Context, indexKind string) (int, error) {
+	if c.Source == nil || c.Broker == nil {
+		return 0, fmt.Errorf("embedqueue: coordinator requires a source and broker")
+	}
+	if strings.TrimSpace(c.EmbedIdentity) == "" {
+		return 0, fmt.Errorf("embedqueue: coordinator requires an embed identity")
+	}
+	batch := c.BatchSize
+	if batch <= 0 {
+		batch = 256
+	}
+
+	total := 0
+	// NextPending returns the same chunks until they leave the pending state, so
+	// we track which chunk_ids we have already enqueued this call to avoid a
+	// re-read of the same head re-enqueuing them in a tight loop. Embedding marks
+	// them ok/error out-of-band; within one call we simply stop once a batch
+	// yields nothing new.
+	seen := make(map[uint64]struct{})
+	for {
+		select {
+		case <-ctx.Done():
+			return total, ctx.Err()
+		default:
+		}
+		tasks, err := c.Source.NextPending(ctx, batch, indexKind)
+		if err != nil {
+			return total, fmt.Errorf("embedqueue: read pending: %w", err)
+		}
+		enqueuedThisPass := 0
+		for _, t := range tasks {
+			id := t.Metadata.ChunkID
+			if id == 0 {
+				id = t.Label
+			}
+			if _, dup := seen[id]; dup {
+				continue
+			}
+			job := c.jobFromTask(t)
+			if err := c.Broker.Enqueue(ctx, job); err != nil {
+				return total, fmt.Errorf("embedqueue: enqueue chunk %d: %w", id, err)
+			}
+			seen[id] = struct{}{}
+			total++
+			enqueuedThisPass++
+		}
+		// Stop when a pass enqueued nothing new: either the store is empty or it
+		// keeps returning the same already-enqueued head (status not yet updated).
+		if enqueuedThisPass == 0 {
+			return total, nil
+		}
+	}
+}
+
+// jobFromTask projects a pending chunk task into a broker Job (SPEC §8.7.2):
+// corpus ref + chunk identity + payload identity + the enqueue-time embed
+// identity. No bytes are carried — the worker reads them via CorpusFS (§7.10).
+func (c *Coordinator) jobFromTask(t model.ChunkTask) Job {
+	id := t.Metadata.ChunkID
+	if id == 0 {
+		id = t.Label
+	}
+	idxKind := strings.TrimSpace(t.IndexKind)
+	if idxKind == "" {
+		idxKind = "text"
+	}
+	span := t.Metadata.Span
+	return Job{
+		CorpusID:  c.CorpusID,
+		Source:    c.SourceKind,
+		ChunkID:   id,
+		IndexKind: idxKind,
+		// TextHash (payload identity, §8.7.2) is left empty here: NextPending does
+		// not surface the chunk's text_hash, and it is not load-bearing for
+		// correctness — the worker re-reads the AUTHORITATIVE task (text, span,
+		// tombstone status) from the shared store by chunk_id (ChunkTaskByID), so
+		// a since-changed or tombstoned chunk is handled there.
+		Modality: t.Modality,
+		RelPath:  t.MediaRef,
+		Span: Span{
+			Kind:    span.Kind,
+			Page:    span.Page,
+			StartMS: span.StartMS,
+			EndMS:   span.EndMS,
+		},
+		EmbedIdentity: c.EmbedIdentity,
+	}
+}

--- a/internal/embedqueue/job.go
+++ b/internal/embedqueue/job.go
@@ -1,0 +1,109 @@
+// Package embedqueue implements the optional distributed-embedding job queue
+// (SPEC §8.7): a coordinator enqueues embedding jobs for pending chunks and one
+// or more stateless embed-workers lease those jobs, read the referenced corpus
+// bytes directly via CorpusFS (§7.10), embed via the configured provider, and
+// write the resulting vectors + chunk status back to a shared store.
+//
+// The package is additive and off by default. The single-binary default keeps
+// running the in-process embedding loop (internal/index.EmbeddingWorker) with no
+// broker; the distributed mode is the degenerate-case generalization where the
+// transport is an external broker and embedding compute lives on separate hosts.
+//
+// The broker transport is implementation-defined (SPEC §8.7.4): this package
+// ships the Broker interface plus a default, dependency-free implementation
+// (in-process and SQLite-backed, both pure-Go) sufficient for the single-node
+// degenerate case and for tests. External-broker adapters (NATS/Redis/SQS) plug
+// in behind the Broker interface without touching the coordinator or worker.
+package embedqueue
+
+import (
+	"errors"
+	"strings"
+)
+
+// Job is one unit of embedding work (SPEC §8.7.2). It identifies its work
+// precisely enough that any worker can execute it WITHOUT coordinator-relayed
+// payload bytes: the worker reads the referenced corpus bytes directly via
+// CorpusFS (§7.10).
+//
+// A Job carries no secret material (no broker credentials, no presigned URLs, no
+// media bytes) so it is safe to serialize onto a broker and to log by ID.
+type Job struct {
+	// --- corpus reference (which corpus + how to read its bytes) ---
+
+	// CorpusID is the stable corpus identity (SPEC §5.5) the chunk belongs to.
+	// It scopes the shared Tier-C collection/namespace and lets a worker reject
+	// a job for a corpus it is not configured to serve.
+	CorpusID string
+	// Source is the corpus source binding (SPEC §7.8) — "local", "nfs", or "s3"
+	// — that tells the worker which CorpusFS backend to read bytes through.
+	Source string
+
+	// --- chunk identity (which vector axis to write) ---
+
+	// ChunkID is the chunk's stable id and ANN label (SPEC §5.3). Vector writes
+	// are keyed by it, which is what makes redelivery idempotent (§8.7.3).
+	ChunkID uint64
+	// IndexKind routes the write to the correct axis: "text" or "code" (§6.1).
+	IndexKind string
+
+	// --- payload identity (which exact bytes to embed) ---
+
+	// TextHash is the chunk's content hash (SPEC §5.3) for a text chunk. It lets
+	// a worker detect a stale job whose chunk text changed since enqueue.
+	TextHash string
+	// Modality is "" / "text" for a text chunk, or "image"/"audio"/"video"/"pdf"
+	// for a media chunk (SPEC §8.1.7).
+	Modality string
+	// RelPath is the corpus rel_path of the source media for a media chunk; the
+	// worker reads those bytes via CorpusFS. Empty for text chunks.
+	RelPath string
+	// Span is the media chunk's window (SPEC §5.4): the page for a PDF chunk or
+	// the time window for an audio/video chunk, so the worker fetches and windows
+	// the exact bytes via CorpusFS range reads. Zero for text chunks.
+	Span Span
+
+	// --- embed identity the job was enqueued under (SPEC §8.1.4) ---
+
+	// EmbedIdentity is the corpus-lifetime embed identity
+	// (provider|text_model|code_model|text_dim|code_dim|multimodal) the
+	// coordinator enqueued the job under. A worker whose configured embed
+	// provider does not match this MUST reject the job rather than write a vector
+	// from the wrong vector space (SPEC §8.7.3, §6.4).
+	EmbedIdentity string
+}
+
+// Span is the media-chunk window carried on a Job (SPEC §5.4). It mirrors the
+// scalar fields of model.Span needed to re-fetch and window media bytes, kept
+// local so the broker payload has no dependency on the model package and stays a
+// flat, serialization-friendly shape.
+type Span struct {
+	// Kind is "page" for a PDF page chunk or "time" for an audio/video window.
+	Kind string
+	// Page is the 1-based page number for a "page" span.
+	Page int
+	// StartMS/EndMS bound a "time" span window in milliseconds.
+	StartMS int
+	EndMS   int
+}
+
+// Validate checks that a job carries the minimum identity needed to execute it.
+func (j Job) Validate() error {
+	if j.ChunkID == 0 {
+		return errors.New("embedqueue: job has zero chunk_id")
+	}
+	if strings.TrimSpace(j.EmbedIdentity) == "" {
+		return errors.New("embedqueue: job has empty embed identity")
+	}
+	return nil
+}
+
+// IsMedia reports whether the job embeds non-text media (SPEC §8.1.7).
+func (j Job) IsMedia() bool {
+	switch strings.ToLower(strings.TrimSpace(j.Modality)) {
+	case "image", "audio", "video", "pdf":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/embedqueue/membroker.go
+++ b/internal/embedqueue/membroker.go
@@ -64,6 +64,19 @@ func (b *MemBroker) Enqueue(_ context.Context, job Job) error {
 	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	// Dedup: skip when a LIVE (pending or in-flight) job for this chunk_id+
+	// index_kind already exists, so re-enqueuing the same still-pending head
+	// across coordinator ticks does not pile up duplicate jobs (SPEC §8.7.3).
+	for _, mj := range b.pending {
+		if mj.job.ChunkID == job.ChunkID && mj.job.IndexKind == job.IndexKind {
+			return nil
+		}
+	}
+	for _, mj := range b.inflight {
+		if mj.job.ChunkID == job.ChunkID && mj.job.IndexKind == job.IndexKind {
+			return nil
+		}
+	}
 	b.pending = append(b.pending, &memJob{job: job})
 	return nil
 }

--- a/internal/embedqueue/membroker.go
+++ b/internal/embedqueue/membroker.go
@@ -1,0 +1,161 @@
+package embedqueue
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// MemBroker is the default dependency-free, in-process Broker (SPEC §8.7.4). It
+// is the degenerate single-node case: the coordinator and workers share one
+// process and one queue with no external broker. It implements the full contract
+// — at-least-once delivery, lease/visibility expiry, redelivery, and a
+// dead-letter store — so it exercises the same worker code path a real broker
+// would, which is exactly what the single-binary default and the test suite need.
+//
+// MemBroker is safe for concurrent Enqueue/Lease/Ack/Nack.
+type MemBroker struct {
+	mu          sync.Mutex
+	pending     []*memJob // FIFO of claimable jobs (respecting notBefore)
+	inflight    map[string]*memJob
+	deadLetter  []*memJob
+	maxAttempts int
+	tokenSeq    atomic.Uint64
+	now         func() time.Time // injectable clock for deterministic tests
+}
+
+type memJob struct {
+	job       Job
+	attempts  int
+	token     string
+	deadline  time.Time
+	notBefore time.Time // job is not claimable before this (Nack retryAfter)
+}
+
+// NewMemBroker returns an in-process broker. maxAttempts bounds redelivery: a job
+// Nacked after being delivered maxAttempts times is dead-lettered (SPEC §8.7.3).
+// A non-positive maxAttempts defaults to 5.
+func NewMemBroker(maxAttempts int) *MemBroker {
+	if maxAttempts <= 0 {
+		maxAttempts = 5
+	}
+	return &MemBroker{
+		inflight:    make(map[string]*memJob),
+		maxAttempts: maxAttempts,
+		now:         time.Now,
+	}
+}
+
+// SetClock overrides the broker's clock for deterministic lease-expiry tests.
+func (b *MemBroker) SetClock(now func() time.Time) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if now != nil {
+		b.now = now
+	}
+}
+
+// Enqueue appends a job to the pending FIFO.
+func (b *MemBroker) Enqueue(_ context.Context, job Job) error {
+	if err := job.Validate(); err != nil {
+		return err
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.pending = append(b.pending, &memJob{job: job})
+	return nil
+}
+
+// Lease reclaims any expired in-flight jobs, then claims the first pending job
+// whose notBefore has passed.
+func (b *MemBroker) Lease(_ context.Context, visibility time.Duration) (Lease, error) {
+	if visibility <= 0 {
+		visibility = 30 * time.Second
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	now := b.now()
+	b.reclaimExpiredLocked(now)
+
+	idx := -1
+	for i, mj := range b.pending {
+		if !mj.notBefore.After(now) {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return Lease{}, ErrNoJob
+	}
+
+	mj := b.pending[idx]
+	b.pending = append(b.pending[:idx], b.pending[idx+1:]...)
+	mj.attempts++
+	mj.token = fmt.Sprintf("mem-%d", b.tokenSeq.Add(1))
+	mj.deadline = now.Add(visibility)
+	b.inflight[mj.token] = mj
+	return Lease{Job: mj.job, Token: mj.token, Deadline: mj.deadline}, nil
+}
+
+// reclaimExpiredLocked moves in-flight jobs whose lease deadline has passed back
+// to pending so a crashed/abandoned worker cannot strand a chunk (SPEC §8.7.3
+// lease expiry). Caller holds b.mu.
+func (b *MemBroker) reclaimExpiredLocked(now time.Time) {
+	for token, mj := range b.inflight {
+		if now.After(mj.deadline) {
+			delete(b.inflight, token)
+			mj.token = ""
+			b.pending = append(b.pending, mj)
+		}
+	}
+}
+
+// Ack removes a leased job. An unknown/expired token is a no-op (it may have been
+// reclaimed and redelivered).
+func (b *MemBroker) Ack(_ context.Context, token string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	delete(b.inflight, token)
+	return nil
+}
+
+// Nack returns a leased job for redelivery, or dead-letters it once it has
+// exhausted maxAttempts (SPEC §8.7.3). An unknown/expired token is a no-op.
+func (b *MemBroker) Nack(_ context.Context, token string, retryAfter time.Duration) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	mj, ok := b.inflight[token]
+	if !ok {
+		return nil
+	}
+	delete(b.inflight, token)
+	mj.token = ""
+	if mj.attempts >= b.maxAttempts {
+		b.deadLetter = append(b.deadLetter, mj)
+		return nil
+	}
+	if retryAfter > 0 {
+		mj.notBefore = b.now().Add(retryAfter)
+	}
+	b.pending = append(b.pending, mj)
+	return nil
+}
+
+// Stats reports queue depth, reclaiming expired leases first so InFlight is
+// accurate.
+func (b *MemBroker) Stats(_ context.Context) (Stats, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.reclaimExpiredLocked(b.now())
+	return Stats{
+		Pending:      len(b.pending),
+		InFlight:     len(b.inflight),
+		DeadLettered: len(b.deadLetter),
+	}, nil
+}
+
+// Close is a no-op for the in-process broker.
+func (b *MemBroker) Close() error { return nil }

--- a/internal/embedqueue/sqlitebroker.go
+++ b/internal/embedqueue/sqlitebroker.go
@@ -2,10 +2,11 @@ package embedqueue
 
 import (
 	"context"
+	"crypto/rand"
 	"database/sql"
+	"encoding/hex"
 	"errors"
 	"fmt"
-	"sync/atomic"
 	"time"
 
 	_ "modernc.org/sqlite" // pure-Go SQLite driver (CGO_ENABLED=0, SPEC §6.5)
@@ -26,7 +27,6 @@ type SQLiteBroker struct {
 	db          *sql.DB
 	ownsDB      bool
 	maxAttempts int
-	tokenSeq    atomic.Uint64
 	now         func() time.Time
 }
 
@@ -52,6 +52,9 @@ func NewSQLiteBrokerWithDB(ctx context.Context, db *sql.DB, maxAttempts int) (*S
 }
 
 func newSQLiteBroker(ctx context.Context, db *sql.DB, ownsDB bool, maxAttempts int) (*SQLiteBroker, error) {
+	if db == nil {
+		return nil, errors.New("embedqueue: sqlite broker requires a non-nil *sql.DB")
+	}
 	if maxAttempts <= 0 {
 		maxAttempts = 5
 	}
@@ -100,17 +103,40 @@ CREATE INDEX IF NOT EXISTS idx_embed_jobs_token ON embed_jobs(token);
 	return nil
 }
 
+// newLeaseToken builds a globally unique lease token: a random 128-bit suffix so
+// tokens never collide across SQLiteBroker instances sharing one DB file. Without
+// this, two instances reusing a row id + a process-local counter could mint the
+// same token, letting a stale Ack/Nack from one instance's expired lease match a
+// different instance's current lease for the same job (SPEC §8.7.3). The row id
+// is included only for readability. crypto/rand failure is surfaced, never masked.
+func newLeaseToken(id int64) (string, error) {
+	var buf [16]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", fmt.Errorf("embedqueue: generate lease token: %w", err)
+	}
+	return fmt.Sprintf("sql-%d-%s", id, hex.EncodeToString(buf[:])), nil
+}
+
 // Enqueue inserts a job in the pending state.
 func (b *SQLiteBroker) Enqueue(ctx context.Context, job Job) error {
 	if err := job.Validate(); err != nil {
 		return err
 	}
+	// Dedup: do not insert when a LIVE (pending or in-flight) job already exists
+	// for this chunk_id+index_kind, so re-enqueuing the same still-pending head
+	// across coordinator ticks cannot pile up duplicate jobs (SPEC §8.7.3). A
+	// dead-lettered job does NOT block a fresh enqueue (a later retry is allowed).
 	_, err := b.db.ExecContext(ctx, `
 INSERT INTO embed_jobs(corpus_id, source, chunk_id, index_kind, text_hash, modality,
   rel_path, span_kind, span_page, span_start_ms, span_end_ms, embed_identity, state)
-VALUES(?,?,?,?,?,?,?,?,?,?,?,?, 'pending')`,
+SELECT ?,?,?,?,?,?,?,?,?,?,?,?, 'pending'
+WHERE NOT EXISTS (
+  SELECT 1 FROM embed_jobs
+   WHERE chunk_id = ? AND index_kind = ? AND state IN ('pending','inflight')
+)`,
 		job.CorpusID, job.Source, int64(job.ChunkID), job.IndexKind, job.TextHash, job.Modality,
-		job.RelPath, job.Span.Kind, job.Span.Page, job.Span.StartMS, job.Span.EndMS, job.EmbedIdentity)
+		job.RelPath, job.Span.Kind, job.Span.Page, job.Span.StartMS, job.Span.EndMS, job.EmbedIdentity,
+		int64(job.ChunkID), job.IndexKind)
 	if err != nil {
 		return fmt.Errorf("embedqueue: enqueue: %w", err)
 	}
@@ -159,7 +185,10 @@ SELECT id, corpus_id, source, chunk_id, index_kind, text_hash, modality, rel_pat
 	}
 	job.ChunkID = uint64(chunkID)
 
-	token := fmt.Sprintf("sql-%d-%d", id, b.tokenSeq.Add(1))
+	token, err := newLeaseToken(id)
+	if err != nil {
+		return Lease{}, err
+	}
 	deadline := b.now().Add(visibility)
 	if _, err := tx.ExecContext(ctx,
 		`UPDATE embed_jobs SET state='inflight', token=?, deadline_ns=?, attempts=attempts+1

--- a/internal/embedqueue/sqlitebroker.go
+++ b/internal/embedqueue/sqlitebroker.go
@@ -1,0 +1,251 @@
+package embedqueue
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	_ "modernc.org/sqlite" // pure-Go SQLite driver (CGO_ENABLED=0, SPEC §6.5)
+)
+
+// SQLiteBroker is the default persistent Broker (SPEC §8.7.4): a dependency-free,
+// pure-Go (CGO_ENABLED=0, §6.5) broker backed by a SQLite table reusing the same
+// modernc.org/sqlite driver the metadata store already uses. It survives a
+// coordinator restart (jobs are durable) and, when pointed at a shared SQLite
+// file on an NFS-reachable path, lets a single-host-plus-NFS worker pool drain a
+// queue without an external broker. A cross-machine pool over a real network
+// broker plugs in behind the Broker interface instead.
+//
+// Lease/visibility, redelivery, and dead-lettering are implemented with the
+// notBefore/deadline/attempts columns; an expired lease is reclaimed lazily on
+// the next Lease (SPEC §8.7.3 lease expiry).
+type SQLiteBroker struct {
+	db          *sql.DB
+	ownsDB      bool
+	maxAttempts int
+	tokenSeq    atomic.Uint64
+	now         func() time.Time
+}
+
+// NewSQLiteBroker opens (or creates) a SQLite-backed queue at path. maxAttempts
+// bounds redelivery before dead-lettering (non-positive defaults to 5).
+func NewSQLiteBroker(ctx context.Context, path string, maxAttempts int) (*SQLiteBroker, error) {
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		return nil, fmt.Errorf("embedqueue: open sqlite broker: %w", err)
+	}
+	b, err := newSQLiteBroker(ctx, db, true, maxAttempts)
+	if err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return b, nil
+}
+
+// NewSQLiteBrokerWithDB wraps an already-open *sql.DB (e.g. shared with the
+// metadata store). The caller retains ownership of db; Close does not close it.
+func NewSQLiteBrokerWithDB(ctx context.Context, db *sql.DB, maxAttempts int) (*SQLiteBroker, error) {
+	return newSQLiteBroker(ctx, db, false, maxAttempts)
+}
+
+func newSQLiteBroker(ctx context.Context, db *sql.DB, ownsDB bool, maxAttempts int) (*SQLiteBroker, error) {
+	if maxAttempts <= 0 {
+		maxAttempts = 5
+	}
+	b := &SQLiteBroker{db: db, ownsDB: ownsDB, maxAttempts: maxAttempts, now: time.Now}
+	if err := b.migrate(ctx); err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// SetClock overrides the broker's clock for deterministic lease-expiry tests.
+func (b *SQLiteBroker) SetClock(now func() time.Time) {
+	if now != nil {
+		b.now = now
+	}
+}
+
+func (b *SQLiteBroker) migrate(ctx context.Context) error {
+	const ddl = `
+CREATE TABLE IF NOT EXISTS embed_jobs (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  corpus_id     TEXT NOT NULL,
+  source        TEXT NOT NULL,
+  chunk_id      INTEGER NOT NULL,
+  index_kind    TEXT NOT NULL,
+  text_hash     TEXT NOT NULL,
+  modality      TEXT NOT NULL,
+  rel_path      TEXT NOT NULL,
+  span_kind     TEXT NOT NULL,
+  span_page     INTEGER NOT NULL,
+  span_start_ms INTEGER NOT NULL,
+  span_end_ms   INTEGER NOT NULL,
+  embed_identity TEXT NOT NULL,
+  attempts      INTEGER NOT NULL DEFAULT 0,
+  state         TEXT NOT NULL DEFAULT 'pending',  -- pending | inflight | dead
+  token         TEXT,
+  deadline_ns   INTEGER NOT NULL DEFAULT 0,
+  not_before_ns INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_embed_jobs_state ON embed_jobs(state, not_before_ns);
+CREATE INDEX IF NOT EXISTS idx_embed_jobs_token ON embed_jobs(token);
+`
+	if _, err := b.db.ExecContext(ctx, ddl); err != nil {
+		return fmt.Errorf("embedqueue: migrate broker schema: %w", err)
+	}
+	return nil
+}
+
+// Enqueue inserts a job in the pending state.
+func (b *SQLiteBroker) Enqueue(ctx context.Context, job Job) error {
+	if err := job.Validate(); err != nil {
+		return err
+	}
+	_, err := b.db.ExecContext(ctx, `
+INSERT INTO embed_jobs(corpus_id, source, chunk_id, index_kind, text_hash, modality,
+  rel_path, span_kind, span_page, span_start_ms, span_end_ms, embed_identity, state)
+VALUES(?,?,?,?,?,?,?,?,?,?,?,?, 'pending')`,
+		job.CorpusID, job.Source, int64(job.ChunkID), job.IndexKind, job.TextHash, job.Modality,
+		job.RelPath, job.Span.Kind, job.Span.Page, job.Span.StartMS, job.Span.EndMS, job.EmbedIdentity)
+	if err != nil {
+		return fmt.Errorf("embedqueue: enqueue: %w", err)
+	}
+	return nil
+}
+
+// Lease reclaims expired leases, then atomically claims the oldest claimable
+// pending job.
+func (b *SQLiteBroker) Lease(ctx context.Context, visibility time.Duration) (Lease, error) {
+	if visibility <= 0 {
+		visibility = 30 * time.Second
+	}
+	nowNS := b.now().UnixNano()
+
+	tx, err := b.db.BeginTx(ctx, nil)
+	if err != nil {
+		return Lease{}, fmt.Errorf("embedqueue: lease begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// Reclaim expired in-flight leases (SPEC §8.7.3 lease expiry).
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE embed_jobs SET state='pending', token=NULL, deadline_ns=0
+		   WHERE state='inflight' AND deadline_ns < ?`, nowNS); err != nil {
+		return Lease{}, fmt.Errorf("embedqueue: lease reclaim: %w", err)
+	}
+
+	var (
+		id  int64
+		job Job
+	)
+	row := tx.QueryRowContext(ctx, `
+SELECT id, corpus_id, source, chunk_id, index_kind, text_hash, modality, rel_path,
+       span_kind, span_page, span_start_ms, span_end_ms, embed_identity
+  FROM embed_jobs
+ WHERE state='pending' AND not_before_ns <= ?
+ ORDER BY id LIMIT 1`, nowNS)
+	var chunkID int64
+	if err := row.Scan(&id, &job.CorpusID, &job.Source, &chunkID, &job.IndexKind, &job.TextHash,
+		&job.Modality, &job.RelPath, &job.Span.Kind, &job.Span.Page, &job.Span.StartMS,
+		&job.Span.EndMS, &job.EmbedIdentity); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return Lease{}, ErrNoJob
+		}
+		return Lease{}, fmt.Errorf("embedqueue: lease select: %w", err)
+	}
+	job.ChunkID = uint64(chunkID)
+
+	token := fmt.Sprintf("sql-%d-%d", id, b.tokenSeq.Add(1))
+	deadline := b.now().Add(visibility)
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE embed_jobs SET state='inflight', token=?, deadline_ns=?, attempts=attempts+1
+		   WHERE id=?`, token, deadline.UnixNano(), id); err != nil {
+		return Lease{}, fmt.Errorf("embedqueue: lease claim: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return Lease{}, fmt.Errorf("embedqueue: lease commit: %w", err)
+	}
+	return Lease{Job: job, Token: token, Deadline: deadline}, nil
+}
+
+// Ack deletes the leased job. An unknown/expired token deletes nothing.
+func (b *SQLiteBroker) Ack(ctx context.Context, token string) error {
+	if _, err := b.db.ExecContext(ctx,
+		`DELETE FROM embed_jobs WHERE token=? AND state='inflight'`, token); err != nil {
+		return fmt.Errorf("embedqueue: ack: %w", err)
+	}
+	return nil
+}
+
+// Nack requeues the leased job, or dead-letters it once attempts reach
+// maxAttempts (SPEC §8.7.3). An unknown/expired token is a no-op.
+func (b *SQLiteBroker) Nack(ctx context.Context, token string, retryAfter time.Duration) error {
+	tx, err := b.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("embedqueue: nack begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var id, attempts int64
+	row := tx.QueryRowContext(ctx,
+		`SELECT id, attempts FROM embed_jobs WHERE token=? AND state='inflight'`, token)
+	if err := row.Scan(&id, &attempts); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil
+		}
+		return fmt.Errorf("embedqueue: nack select: %w", err)
+	}
+
+	if int(attempts) >= b.maxAttempts {
+		if _, err := tx.ExecContext(ctx,
+			`UPDATE embed_jobs SET state='dead', token=NULL, deadline_ns=0 WHERE id=?`, id); err != nil {
+			return fmt.Errorf("embedqueue: nack dead-letter: %w", err)
+		}
+		return tx.Commit()
+	}
+
+	notBefore := int64(0)
+	if retryAfter > 0 {
+		notBefore = b.now().Add(retryAfter).UnixNano()
+	}
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE embed_jobs SET state='pending', token=NULL, deadline_ns=0, not_before_ns=? WHERE id=?`,
+		notBefore, id); err != nil {
+		return fmt.Errorf("embedqueue: nack requeue: %w", err)
+	}
+	return tx.Commit()
+}
+
+// Stats reports queue depth, reclaiming expired leases first so in-flight counts
+// are accurate.
+func (b *SQLiteBroker) Stats(ctx context.Context) (Stats, error) {
+	nowNS := b.now().UnixNano()
+	if _, err := b.db.ExecContext(ctx,
+		`UPDATE embed_jobs SET state='pending', token=NULL, deadline_ns=0
+		   WHERE state='inflight' AND deadline_ns < ?`, nowNS); err != nil {
+		return Stats{}, fmt.Errorf("embedqueue: stats reclaim: %w", err)
+	}
+	var s Stats
+	row := b.db.QueryRowContext(ctx, `
+SELECT
+  COALESCE(SUM(CASE WHEN state='pending'  THEN 1 ELSE 0 END), 0),
+  COALESCE(SUM(CASE WHEN state='inflight' THEN 1 ELSE 0 END), 0),
+  COALESCE(SUM(CASE WHEN state='dead'     THEN 1 ELSE 0 END), 0)
+FROM embed_jobs`)
+	if err := row.Scan(&s.Pending, &s.InFlight, &s.DeadLettered); err != nil {
+		return Stats{}, fmt.Errorf("embedqueue: stats: %w", err)
+	}
+	return s, nil
+}
+
+// Close closes the underlying DB only when the broker owns it.
+func (b *SQLiteBroker) Close() error {
+	if b.ownsDB && b.db != nil {
+		return b.db.Close()
+	}
+	return nil
+}

--- a/internal/embedqueue/worker.go
+++ b/internal/embedqueue/worker.go
@@ -152,7 +152,8 @@ func Run(ctx context.Context, cfg Config) error {
 func (cfg Config) process(ctx context.Context, lease Lease) {
 	job := lease.Job
 	if err := job.Validate(); err != nil {
-		cfg.logf("embedqueue: invalid job (token=%s): %v", lease.Token, err)
+		// Never log lease.Token — it is an opaque lease credential (§16.1.1).
+		cfg.logf("embedqueue: invalid job for chunk %d: %v", job.ChunkID, err)
 		_ = cfg.Broker.Nack(ctx, lease.Token, cfg.retryAfter())
 		return
 	}

--- a/internal/embedqueue/worker.go
+++ b/internal/embedqueue/worker.go
@@ -1,0 +1,220 @@
+package embedqueue
+
+import (
+	"context"
+	"errors"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// TaskFetcher loads the authoritative chunk task for a leased job from the shared
+// store (SPEC §8.7.4 — chunk metadata/status lives in a store reachable by all
+// workers). The metadata store satisfies it via ChunkTaskByID, which returns
+// model.ErrNotFound for a missing or tombstoned chunk so the worker can skip it
+// (tombstone safety, §8.7.3 / §6.6).
+type TaskFetcher interface {
+	ChunkTaskByID(ctx context.Context, chunkID uint64) (model.ChunkTask, string, error)
+}
+
+// Embedder is the embed→index→mark step the worker reuses. It is satisfied by
+// *index.EmbeddingWorker.EmbedAndIndex, so the distributed worker shares the
+// exact embed/media-load/index/mark logic of the in-process loop rather than
+// duplicating it (idempotent, keyed by chunk_id — §8.7.3).
+type Embedder interface {
+	EmbedAndIndex(ctx context.Context, indexKind string, tasks []model.ChunkTask) (int, error)
+}
+
+// Config configures a distributed embed-worker run-loop (SPEC §8.7.1, the
+// embed-worker / compute-plane role). All fields except the optional Logger and
+// the tuning knobs are required.
+type Config struct {
+	// Broker is the queue the worker leases jobs from.
+	Broker Broker
+	// Fetcher loads the authoritative chunk task for a leased job.
+	Fetcher TaskFetcher
+	// Embedders maps an index kind ("text"/"code") to the embed→index→mark step
+	// for that axis. A job whose index_kind has no embedder is dead-lettered
+	// (misconfiguration, never a vector in the wrong space).
+	Embedders map[string]Embedder
+
+	// EmbedIdentity is THIS worker's configured embed identity (SPEC §8.1.4). A
+	// job whose EmbedIdentity differs is rejected (Nacked for redelivery /
+	// dead-lettering) rather than embedded, preserving the single-space invariant
+	// across a heterogeneous pool (§8.7.3, §6.4).
+	EmbedIdentity string
+
+	// LeaseDuration is the visibility timeout for a leased job. Non-positive
+	// defaults to 30s.
+	LeaseDuration time.Duration
+	// PollInterval is how long the loop waits after an empty queue before leasing
+	// again. Non-positive defaults to 500ms.
+	PollInterval time.Duration
+	// RetryAfter delays redelivery of a Nacked (transiently failed) job.
+	// Non-positive defaults to 2s.
+	RetryAfter time.Duration
+
+	// Logger is optional; nil routes to the standard log package. The worker logs
+	// only job ids and error categories — never broker credentials, media bytes,
+	// or presigned URLs.
+	Logger *log.Logger
+}
+
+func (c Config) validate() error {
+	if c.Broker == nil {
+		return errors.New("embedqueue: worker requires a broker")
+	}
+	if c.Fetcher == nil {
+		return errors.New("embedqueue: worker requires a task fetcher")
+	}
+	if len(c.Embedders) == 0 {
+		return errors.New("embedqueue: worker requires at least one embedder")
+	}
+	if strings.TrimSpace(c.EmbedIdentity) == "" {
+		return errors.New("embedqueue: worker requires an embed identity")
+	}
+	return nil
+}
+
+func (c Config) leaseDuration() time.Duration {
+	if c.LeaseDuration <= 0 {
+		return 30 * time.Second
+	}
+	return c.LeaseDuration
+}
+
+func (c Config) pollInterval() time.Duration {
+	if c.PollInterval <= 0 {
+		return 500 * time.Millisecond
+	}
+	return c.PollInterval
+}
+
+func (c Config) retryAfter() time.Duration {
+	if c.RetryAfter <= 0 {
+		return 2 * time.Second
+	}
+	return c.RetryAfter
+}
+
+func (c Config) logf(format string, args ...any) {
+	if c.Logger != nil {
+		c.Logger.Printf(format, args...)
+		return
+	}
+	log.Printf(format, args...)
+}
+
+// Run is the distributed embed-worker run-loop (SPEC §8.7.1). It leases jobs,
+// reads the authoritative chunk via the shared store, enforces per-job embed
+// identity, embeds via the shared in-process embedding path, and Acks on success
+// or Nacks (redelivery / dead-letter) on transient failure. It blocks until ctx
+// is cancelled and returns ctx.Err() then.
+//
+// It is exported as a reusable function because follow-up #249 wraps it in a CLI
+// subcommand; #249 (the subcommand) is out of scope here.
+func Run(ctx context.Context, cfg Config) error {
+	if err := cfg.validate(); err != nil {
+		return err
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		lease, err := cfg.Broker.Lease(ctx, cfg.leaseDuration())
+		if errors.Is(err, ErrNoJob) {
+			if waitErr := sleepCtx(ctx, cfg.pollInterval()); waitErr != nil {
+				return waitErr
+			}
+			continue
+		}
+		if err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			cfg.logf("embedqueue: lease error: %v", err)
+			if waitErr := sleepCtx(ctx, cfg.pollInterval()); waitErr != nil {
+				return waitErr
+			}
+			continue
+		}
+		cfg.process(ctx, lease)
+	}
+}
+
+// process executes one leased job and Acks/Nacks it. A permanent failure (embed
+// identity mismatch, unknown index kind, tombstoned chunk) Acks/Nacks terminally
+// so the job does not loop; a transient failure Nacks for redelivery.
+func (cfg Config) process(ctx context.Context, lease Lease) {
+	job := lease.Job
+	if err := job.Validate(); err != nil {
+		cfg.logf("embedqueue: invalid job (token=%s): %v", lease.Token, err)
+		_ = cfg.Broker.Nack(ctx, lease.Token, cfg.retryAfter())
+		return
+	}
+
+	// Per-job embed identity enforcement (SPEC §8.7.3 / §6.4): a worker whose
+	// embed identity does not match the job MUST NOT write a vector. This is a
+	// permanent mismatch for THIS worker, so Nack for redelivery to a matching
+	// worker (or eventual dead-lettering) — never embed.
+	if strings.TrimSpace(job.EmbedIdentity) != strings.TrimSpace(cfg.EmbedIdentity) {
+		cfg.logf("embedqueue: embed identity mismatch for chunk %d (job=%q worker=%q); rejecting",
+			job.ChunkID, job.EmbedIdentity, cfg.EmbedIdentity)
+		_ = cfg.Broker.Nack(ctx, lease.Token, cfg.retryAfter())
+		return
+	}
+
+	indexKind := strings.ToLower(strings.TrimSpace(job.IndexKind))
+	if indexKind == "" {
+		indexKind = "text"
+	}
+	emb, ok := cfg.Embedders[indexKind]
+	if !ok {
+		cfg.logf("embedqueue: no embedder for index_kind %q (chunk %d); rejecting", indexKind, job.ChunkID)
+		_ = cfg.Broker.Nack(ctx, lease.Token, cfg.retryAfter())
+		return
+	}
+
+	// Load the authoritative task from the shared store. A tombstoned/missing
+	// chunk is a safe skip (tombstone safety, §8.7.3 / §6.6): Ack so the job is
+	// not redelivered for a chunk that no longer exists.
+	task, _, err := cfg.Fetcher.ChunkTaskByID(ctx, job.ChunkID)
+	if err != nil {
+		if errors.Is(err, model.ErrNotFound) {
+			cfg.logf("embedqueue: chunk %d not found / tombstoned; acking (no-op)", job.ChunkID)
+			_ = cfg.Broker.Ack(ctx, lease.Token)
+			return
+		}
+		cfg.logf("embedqueue: fetch chunk %d: %v; redelivering", job.ChunkID, err)
+		_ = cfg.Broker.Nack(ctx, lease.Token, cfg.retryAfter())
+		return
+	}
+
+	if _, err := emb.EmbedAndIndex(ctx, indexKind, []model.ChunkTask{task}); err != nil {
+		// EmbedAndIndex already records embedding_status=error for permanent
+		// failures (SPEC §5.3); Nack lets the broker redeliver up to its limit and
+		// then dead-letter, mirroring the in-process retry/dead-letter behavior.
+		cfg.logf("embedqueue: embed chunk %d (%s): %v; redelivering", job.ChunkID, indexKind, err)
+		_ = cfg.Broker.Nack(ctx, lease.Token, cfg.retryAfter())
+		return
+	}
+	if err := cfg.Broker.Ack(ctx, lease.Token); err != nil {
+		cfg.logf("embedqueue: ack chunk %d: %v", job.ChunkID, err)
+	}
+}
+
+// sleepCtx waits for d or ctx cancellation, returning ctx.Err() on cancel.
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}

--- a/internal/index/embedding_worker.go
+++ b/internal/index/embedding_worker.go
@@ -648,6 +648,24 @@ func (w *EmbeddingWorker) RunOnce(ctx context.Context, indexKind string) (int, e
 	if len(tasks) == 0 {
 		return 0, nil
 	}
+	return w.EmbedAndIndex(ctx, indexKind, tasks)
+}
+
+// EmbedAndIndex embeds the supplied chunk tasks for indexKind, upserts their
+// vectors into the index, and marks them embedded (or failed) in the source —
+// the shared embed→index→mark step extracted from RunOnce so a distributed
+// embed-worker (SPEC §8.7) can reuse the exact same path on jobs it leases from
+// a broker instead of polling NextPending. Writes are idempotent because the
+// index upserts by chunk_id (SPEC §8.7.3), so re-running on an already-embedded
+// chunk overwrites the same vector and re-sets the same terminal status — no
+// duplicate vectors. Returns the number of chunks successfully indexed.
+func (w *EmbeddingWorker) EmbedAndIndex(ctx context.Context, indexKind string, tasks []model.ChunkTask) (int, error) {
+	if err := w.validate(); err != nil {
+		return 0, err
+	}
+	if len(tasks) == 0 {
+		return 0, nil
+	}
 	// sanity-check tasks returned by the source.  they should already be
 	// consistent, but validating here guards against misbehaving or
 	// hand‑constructed implementations.

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -1261,6 +1261,83 @@ func (s *SQLiteStore) ChunkMediaSpanByID(ctx context.Context, chunkID int64) (re
 	return relPath, docType, spanFromRow(kind, start, end, extraJSON), nil
 }
 
+// ChunkTaskByID returns the full embedding task for a single LIVE chunk
+// (SPEC §5.3), with its text, span, modality, and media ref — everything a
+// distributed embed-worker (SPEC §8.7) needs to embed a leased job without the
+// coordinator relaying payload bytes. It returns model.ErrNotFound when the
+// chunk does not exist OR has been tombstoned (deleted=1): a worker treats that
+// as a safe skip, honoring the tombstone so a job cannot resurrect a deleted
+// chunk (SPEC §6.6, §8.7.3 tombstone safety). textHash is returned separately so
+// a worker can detect a job enqueued for a since-changed chunk.
+func (s *SQLiteStore) ChunkTaskByID(ctx context.Context, chunkID uint64) (task model.ChunkTask, textHash string, err error) {
+	if chunkID == 0 {
+		return model.ChunkTask{}, "", model.ErrNotFound
+	}
+	db, err := s.ensureDB(ctx)
+	if err != nil {
+		return model.ChunkTask{}, "", err
+	}
+	defer s.ReleaseDB()
+
+	row := db.QueryRowContext(ctx, `
+WITH the_chunk AS (
+  SELECT chunk_id, rel_path, doc_type, rep_type, text, text_hash, index_kind, modality, media_ref
+  FROM chunks
+  WHERE chunk_id = ? AND deleted = 0
+),
+ranked_spans AS (
+  SELECT s.chunk_id, s.span_kind, s.start, s."end", s.extra_json,
+         ROW_NUMBER() OVER (PARTITION BY s.chunk_id ORDER BY s.span_id) AS rn
+  FROM spans s
+  JOIN the_chunk tc ON tc.chunk_id = s.chunk_id
+)
+SELECT tc.chunk_id, tc.rel_path, tc.doc_type, tc.rep_type, tc.text, tc.text_hash, tc.index_kind, tc.modality, tc.media_ref,
+       COALESCE(sp.span_kind, ''), COALESCE(sp.start, 0), COALESCE(sp.end, 0), COALESCE(sp.extra_json, '')
+FROM the_chunk tc
+LEFT JOIN ranked_spans sp ON sp.chunk_id = tc.chunk_id AND sp.rn = 1`, int64(chunkID))
+
+	var (
+		cid       int64
+		relPath   string
+		docType   string
+		repType   string
+		text      string
+		thash     string
+		idxKind   string
+		modality  string
+		mediaRef  string
+		spanK     string
+		spanS     int
+		spanE     int
+		spanExtra string
+	)
+	if scanErr := row.Scan(&cid, &relPath, &docType, &repType, &text, &thash, &idxKind, &modality, &mediaRef,
+		&spanK, &spanS, &spanE, &spanExtra); scanErr != nil {
+		if errors.Is(scanErr, sql.ErrNoRows) {
+			return model.ChunkTask{}, "", model.ErrNotFound
+		}
+		return model.ChunkTask{}, "", scanErr
+	}
+	if cid <= 0 {
+		return model.ChunkTask{}, "", model.ErrNotFound
+	}
+	uid := uint64(cid)
+	span := spanFromRow(spanK, spanS, spanE, spanExtra)
+	t := model.NewChunkTask(uid, text, idxKind, model.ChunkMetadata{
+		ChunkID:  uid,
+		RelPath:  relPath,
+		DocType:  docType,
+		RepType:  repType,
+		Snippet:  snippet(text, 240),
+		Span:     span,
+		Modality: modality,
+		MediaRef: mediaRef,
+	})
+	t.Modality = modality
+	t.MediaRef = mediaRef
+	return t, thash, nil
+}
+
 func (s *SQLiteStore) MarkDocumentDeleted(ctx context.Context, relPath string) error {
 	normalizedPath, err := normalizeRelPath(relPath)
 	if err != nil {

--- a/tests/config/distributed_embed_config_test.go
+++ b/tests/config/distributed_embed_config_test.go
@@ -55,16 +55,23 @@ func TestDistributedEmbed_TierCAllowed(t *testing.T) {
 	}
 }
 
-// TestDistributedEmbed_ExternalBrokerRequiresURL pins that selecting an external
-// broker without a connection URL is rejected (the topology must be reachable).
-func TestDistributedEmbed_ExternalBrokerRequiresURL(t *testing.T) {
+// TestDistributedEmbed_UnsupportedBrokerRejected pins that an external broker
+// (e.g. nats) is rejected at validation, in sync with buildEmbedBroker which can
+// only construct the built-in memory/sqlite brokers — a value it cannot build
+// must not validate (even with a broker_url), or startup would fail later.
+func TestDistributedEmbed_UnsupportedBrokerRejected(t *testing.T) {
 	cfg := config.Default()
 	cfg.IndexBackend = "qdrant"
 	cfg.Qdrant.URL = "http://localhost:6334"
 	cfg.DistributedEmbed.Enabled = true
 	cfg.DistributedEmbed.Broker = "nats"
-	if err := cfg.Validate(); err == nil {
-		t.Fatal("external broker without broker_url must fail validation")
+	cfg.DistributedEmbed.BrokerURL = "nats://broker:4222"
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("an unsupported (external) broker must fail validation in this build")
+	}
+	if !strings.Contains(err.Error(), "not supported") {
+		t.Fatalf("error should explain the broker is unsupported, got: %v", err)
 	}
 }
 
@@ -106,6 +113,56 @@ func TestDistributedEmbed_FileRoundTrip(t *testing.T) {
 	if cfg.DistributedEmbed.BrokerURL != "nats://secret@broker:4222" {
 		t.Fatalf("broker url = %q, want env-resolved value (file value must be ignored)", cfg.DistributedEmbed.BrokerURL)
 	}
+}
+
+// TestDistributedEmbed_NestedYAMLSection pins that the nested YAML form
+// (distributed_embed: with child keys) is honored, not just the dotted/flat
+// aliases — distributed_embed must be a recognized map section.
+func TestDistributedEmbed_NestedYAMLSection(t *testing.T) {
+	tmp := t.TempDir()
+	path := tmp + "/.dir2mcp.yaml"
+	writeFile(t, path, ""+
+		"root_dir: ./repo\n"+
+		"index_backend: qdrant\n"+
+		"qdrant_url: http://localhost:6334\n"+
+		"distributed_embed:\n"+
+		"  enabled: true\n"+
+		"  broker: sqlite\n"+
+		"  max_attempts: 9\n")
+
+	t.Setenv("DIR2MCP_DISABLE_KEYCHAIN", "1")
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.DistributedEmbed.Enabled {
+		t.Fatal("nested distributed_embed.enabled was ignored")
+	}
+	if cfg.DistributedEmbed.Broker != "sqlite" {
+		t.Fatalf("broker = %q, want sqlite", cfg.DistributedEmbed.Broker)
+	}
+	if cfg.DistributedEmbed.MaxAttempts != 9 {
+		t.Fatalf("max_attempts = %d, want 9", cfg.DistributedEmbed.MaxAttempts)
+	}
+}
+
+// TestDistributedEmbed_MalformedEnvRejected pins that an invalid distributed-embed
+// env override is reported, not silently ignored, so automation cannot believe an
+// override applied when it did not.
+func TestDistributedEmbed_MalformedEnvRejected(t *testing.T) {
+	t.Setenv("DIR2MCP_DISABLE_KEYCHAIN", "1")
+	t.Run("max_attempts", func(t *testing.T) {
+		t.Setenv("DIR2MCP_DISTRIBUTED_EMBED_MAX_ATTEMPTS", "not-a-number")
+		if _, err := config.Load(""); err == nil {
+			t.Fatal("malformed DIR2MCP_DISTRIBUTED_EMBED_MAX_ATTEMPTS must fail Load")
+		}
+	})
+	t.Run("enabled", func(t *testing.T) {
+		t.Setenv("DIR2MCP_DISTRIBUTED_EMBED_ENABLED", "yepyep")
+		if _, err := config.Load(""); err == nil {
+			t.Fatal("malformed DIR2MCP_DISTRIBUTED_EMBED_ENABLED must fail Load")
+		}
+	})
 }
 
 // TestDistributedEmbed_SnapshotOmitsBrokerURL pins SPEC §16.1.1: the broker URL

--- a/tests/config/distributed_embed_config_test.go
+++ b/tests/config/distributed_embed_config_test.go
@@ -1,0 +1,134 @@
+package tests
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+)
+
+// TestDistributedEmbed_DefaultOff pins that distributed embedding is off by
+// default (SPEC §8.7.4): a fresh config validates without any Tier-C requirement,
+// so the local-first single-binary in-process loop runs unchanged (§1.2).
+func TestDistributedEmbed_DefaultOff(t *testing.T) {
+	cfg := config.Default()
+	if cfg.DistributedEmbed.Enabled {
+		t.Fatal("distributed embedding must default to OFF")
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("default config must validate with distributed mode off: %v", err)
+	}
+}
+
+// TestDistributedEmbed_RequiresTierC pins SPEC §8.7.4: enabling distributed mode
+// with an embedded (single-node) Tier-A/B backend is CONFIG_INVALID — a worker
+// pool requires a shared external Tier-C store.
+func TestDistributedEmbed_RequiresTierC(t *testing.T) {
+	for _, backend := range []string{"memory", "disk"} {
+		cfg := config.Default()
+		cfg.IndexBackend = backend
+		cfg.DistributedEmbed.Enabled = true
+		err := cfg.Validate()
+		if err == nil {
+			t.Fatalf("backend %q: enabling distributed mode on an embedded backend must fail validation", backend)
+		}
+		if !strings.Contains(err.Error(), "Tier C") {
+			t.Fatalf("backend %q: error should mention the Tier C requirement, got: %v", backend, err)
+		}
+	}
+}
+
+// TestDistributedEmbed_TierCAllowed pins that distributed mode validates with an
+// external Tier-C backend (qdrant), the one configuration where Tier C becomes a
+// prerequisite (SPEC §8.7.4).
+func TestDistributedEmbed_TierCAllowed(t *testing.T) {
+	cfg := config.Default()
+	cfg.IndexBackend = "qdrant"
+	cfg.Qdrant.URL = "http://localhost:6334"
+	cfg.DistributedEmbed.Enabled = true
+	cfg.DistributedEmbed.Broker = "sqlite"
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("distributed mode with qdrant must validate: %v", err)
+	}
+	if cfg.DistributedEmbed.Broker != "sqlite" {
+		t.Fatalf("broker normalized to %q, want sqlite", cfg.DistributedEmbed.Broker)
+	}
+}
+
+// TestDistributedEmbed_ExternalBrokerRequiresURL pins that selecting an external
+// broker without a connection URL is rejected (the topology must be reachable).
+func TestDistributedEmbed_ExternalBrokerRequiresURL(t *testing.T) {
+	cfg := config.Default()
+	cfg.IndexBackend = "qdrant"
+	cfg.Qdrant.URL = "http://localhost:6334"
+	cfg.DistributedEmbed.Enabled = true
+	cfg.DistributedEmbed.Broker = "nats"
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("external broker without broker_url must fail validation")
+	}
+}
+
+// TestDistributedEmbed_FileRoundTrip pins config round-trip: the non-secret knobs
+// load from a config file and the broker URL secret is NEVER read from disk
+// (SPEC §16.1.1) — it is resolved only from the environment.
+func TestDistributedEmbed_FileRoundTrip(t *testing.T) {
+	tmp := t.TempDir()
+	path := tmp + "/.dir2mcp.yaml"
+	writeFile(t, path, ""+
+		"root_dir: ./repo\n"+
+		"index_backend: qdrant\n"+
+		"qdrant_url: http://localhost:6334\n"+
+		"distributed_embed_enabled: true\n"+
+		"distributed_embed_broker: sqlite\n"+
+		"distributed_embed_sqlite_path: /tmp/q.db\n"+
+		"distributed_embed_max_attempts: 7\n"+
+		"distributed_embed_broker_url: file-supplied-should-be-ignored\n")
+
+	t.Setenv("DIR2MCP_DISABLE_KEYCHAIN", "1")
+	t.Setenv("DIR2MCP_DISTRIBUTED_EMBED_BROKER_URL", "nats://secret@broker:4222")
+
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.DistributedEmbed.Enabled {
+		t.Fatal("distributed_embed_enabled not loaded from file")
+	}
+	if cfg.DistributedEmbed.Broker != "sqlite" {
+		t.Fatalf("broker = %q, want sqlite", cfg.DistributedEmbed.Broker)
+	}
+	if cfg.DistributedEmbed.BrokerSQLitePath != "/tmp/q.db" {
+		t.Fatalf("sqlite path = %q", cfg.DistributedEmbed.BrokerSQLitePath)
+	}
+	if cfg.DistributedEmbed.MaxAttempts != 7 {
+		t.Fatalf("max attempts = %d, want 7", cfg.DistributedEmbed.MaxAttempts)
+	}
+	if cfg.DistributedEmbed.BrokerURL != "nats://secret@broker:4222" {
+		t.Fatalf("broker url = %q, want env-resolved value (file value must be ignored)", cfg.DistributedEmbed.BrokerURL)
+	}
+}
+
+// TestDistributedEmbed_SnapshotOmitsBrokerURL pins SPEC §16.1.1: the broker URL
+// secret is never written to the persisted snapshot, while the non-secret knobs
+// are.
+func TestDistributedEmbed_SnapshotOmitsBrokerURL(t *testing.T) {
+	cfg := config.Default()
+	cfg.StateDir = t.TempDir()
+	cfg.IndexBackend = "qdrant"
+	cfg.Qdrant.URL = "http://localhost:6334"
+	cfg.DistributedEmbed.Enabled = true
+	cfg.DistributedEmbed.Broker = "sqlite"
+	cfg.DistributedEmbed.BrokerURL = "nats://secret@broker:4222"
+
+	path, err := config.SaveEffectiveSnapshot(cfg, config.SecretSourceMetadata{})
+	if err != nil {
+		t.Fatalf("SaveEffectiveSnapshot: %v", err)
+	}
+	raw := readFileString(t, path)
+	if strings.Contains(raw, "secret@broker") || strings.Contains(raw, "broker_url") {
+		t.Fatalf("snapshot leaked the broker URL secret:\n%s", raw)
+	}
+	if !strings.Contains(raw, "distributed_embed_enabled: true") {
+		t.Fatalf("snapshot missing the enable flag:\n%s", raw)
+	}
+}

--- a/tests/embedqueue/broker_test.go
+++ b/tests/embedqueue/broker_test.go
@@ -199,3 +199,104 @@ func TestSQLiteBroker_Durable(t *testing.T) {
 		t.Fatalf("reopened lease chunk = %d, want 42", lease.Job.ChunkID)
 	}
 }
+
+// TestBroker_EnqueueDedupsLiveJob pins that enqueuing the same chunk_id+index_kind
+// while a job for it is still LIVE (pending/in-flight) is collapsed, so a
+// coordinator re-enqueuing the same still-pending head across ticks does not pile
+// up duplicate jobs (SPEC §8.7.3). A different chunk is not deduped, and once the
+// live job drains (ack) the chunk may be enqueued again. Runs against both default
+// broker impls.
+func TestBroker_EnqueueDedupsLiveJob(t *testing.T) {
+	for _, f := range brokerFactories() {
+		t.Run(f.name, func(t *testing.T) {
+			ctx := context.Background()
+			b := f.make(t)
+			defer func() { _ = b.Close() }()
+
+			for i := 0; i < 3; i++ {
+				if err := b.Enqueue(ctx, sampleJob(11)); err != nil {
+					t.Fatalf("Enqueue %d: %v", i, err)
+				}
+			}
+			st, err := b.Stats(ctx)
+			if err != nil {
+				t.Fatalf("Stats: %v", err)
+			}
+			if st.Pending != 1 {
+				t.Fatalf("Pending = %d, want 1 (duplicate live jobs must be deduped)", st.Pending)
+			}
+
+			// A different chunk is NOT deduped.
+			if err := b.Enqueue(ctx, sampleJob(12)); err != nil {
+				t.Fatalf("Enqueue other chunk: %v", err)
+			}
+			if st, _ = b.Stats(ctx); st.Pending != 2 {
+				t.Fatalf("Pending = %d, want 2 (distinct chunk must enqueue)", st.Pending)
+			}
+
+			// Drain chunk 11, then re-enqueuing it is allowed (no live job remains).
+			lease, err := b.Lease(ctx, time.Minute)
+			if err != nil {
+				t.Fatalf("Lease: %v", err)
+			}
+			if err := b.Ack(ctx, lease.Token); err != nil {
+				t.Fatalf("Ack: %v", err)
+			}
+			if err := b.Enqueue(ctx, sampleJob(lease.Job.ChunkID)); err != nil {
+				t.Fatalf("re-enqueue after drain: %v", err)
+			}
+		})
+	}
+}
+
+// TestSQLiteBroker_LeaseTokensUniqueAcrossInstances pins that lease tokens are
+// globally unique: when two broker instances share one DB file and the same job
+// row is re-leased after a lease expiry, the second lease gets a DIFFERENT token,
+// so a stale Ack from the first instance cannot delete the second instance's
+// current lease (SPEC §8.7.3).
+func TestSQLiteBroker_LeaseTokensUniqueAcrossInstances(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "queue.db")
+	base := time.Unix(1_700_000_000, 0)
+
+	b1, err := embedqueue.NewSQLiteBroker(ctx, path, 5)
+	if err != nil {
+		t.Fatalf("open b1: %v", err)
+	}
+	defer func() { _ = b1.Close() }()
+	b1.SetClock(func() time.Time { return base })
+
+	b2, err := embedqueue.NewSQLiteBroker(ctx, path, 5)
+	if err != nil {
+		t.Fatalf("open b2: %v", err)
+	}
+	defer func() { _ = b2.Close() }()
+	// b2's clock is far ahead, so it sees b1's lease as expired and reclaims it.
+	b2.SetClock(func() time.Time { return base.Add(time.Hour) })
+
+	if err := b1.Enqueue(ctx, sampleJob(7)); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	l1, err := b1.Lease(ctx, time.Minute) // deadline = base + 1m
+	if err != nil {
+		t.Fatalf("b1 Lease: %v", err)
+	}
+	l2, err := b2.Lease(ctx, time.Minute) // base+1h > deadline -> reclaim + re-lease same row
+	if err != nil {
+		t.Fatalf("b2 Lease (reclaim): %v", err)
+	}
+	if l1.Token == l2.Token {
+		t.Fatalf("lease tokens collided across instances for the same job row: %q", l1.Token)
+	}
+	// A stale Ack from b1 must NOT delete b2's now-current lease.
+	if err := b1.Ack(ctx, l1.Token); err != nil {
+		t.Fatalf("stale Ack: %v", err)
+	}
+	st, err := b2.Stats(ctx)
+	if err != nil {
+		t.Fatalf("Stats: %v", err)
+	}
+	if st.InFlight != 1 {
+		t.Fatalf("stale Ack removed the live lease: %+v", st)
+	}
+}

--- a/tests/embedqueue/broker_test.go
+++ b/tests/embedqueue/broker_test.go
@@ -1,0 +1,201 @@
+package embedqueue_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/embedqueue"
+)
+
+func sampleJob(chunkID uint64) embedqueue.Job {
+	return embedqueue.Job{
+		CorpusID:      "corpus-1",
+		Source:        "local",
+		ChunkID:       chunkID,
+		IndexKind:     "text",
+		EmbedIdentity: "mistral|mistral-embed||0|0|off",
+	}
+}
+
+// brokerFactory builds a fresh broker for the shared contract tests so the same
+// assertions run against both the in-process and the SQLite default impls.
+type brokerFactory struct {
+	name string
+	make func(t *testing.T) embedqueue.Broker
+	// clock lets a test drive lease expiry deterministically; nil means the
+	// broker uses the real clock.
+	setClock func(b embedqueue.Broker, now func() time.Time)
+}
+
+func brokerFactories() []brokerFactory {
+	return []brokerFactory{
+		{
+			name: "mem",
+			make: func(t *testing.T) embedqueue.Broker { return embedqueue.NewMemBroker(3) },
+			setClock: func(b embedqueue.Broker, now func() time.Time) {
+				b.(*embedqueue.MemBroker).SetClock(now)
+			},
+		},
+		{
+			name: "sqlite",
+			make: func(t *testing.T) embedqueue.Broker {
+				path := filepath.Join(t.TempDir(), "queue.db")
+				b, err := embedqueue.NewSQLiteBroker(context.Background(), path, 3)
+				if err != nil {
+					t.Fatalf("NewSQLiteBroker: %v", err)
+				}
+				t.Cleanup(func() { _ = b.Close() })
+				return b
+			},
+			setClock: func(b embedqueue.Broker, now func() time.Time) {
+				b.(*embedqueue.SQLiteBroker).SetClock(now)
+			},
+		},
+	}
+}
+
+// TestBroker_EnqueueLeaseAck pins the happy path (SPEC §8.7.3): a job is enqueued,
+// leased exactly once, acked, and then the queue is empty.
+func TestBroker_EnqueueLeaseAck(t *testing.T) {
+	for _, bf := range brokerFactories() {
+		t.Run(bf.name, func(t *testing.T) {
+			ctx := context.Background()
+			b := bf.make(t)
+
+			if err := b.Enqueue(ctx, sampleJob(7)); err != nil {
+				t.Fatalf("Enqueue: %v", err)
+			}
+			lease, err := b.Lease(ctx, time.Minute)
+			if err != nil {
+				t.Fatalf("Lease: %v", err)
+			}
+			if lease.Job.ChunkID != 7 {
+				t.Fatalf("leased chunk = %d, want 7", lease.Job.ChunkID)
+			}
+
+			// Second lease before ack must find nothing (job is in-flight/hidden).
+			if _, err := b.Lease(ctx, time.Minute); err != embedqueue.ErrNoJob {
+				t.Fatalf("second Lease err = %v, want ErrNoJob", err)
+			}
+			if err := b.Ack(ctx, lease.Token); err != nil {
+				t.Fatalf("Ack: %v", err)
+			}
+			st, err := b.Stats(ctx)
+			if err != nil {
+				t.Fatalf("Stats: %v", err)
+			}
+			if st.Pending != 0 || st.InFlight != 0 {
+				t.Fatalf("after ack stats = %+v, want empty", st)
+			}
+		})
+	}
+}
+
+// TestBroker_LeaseExpiryRedelivery pins lease expiry (SPEC §8.7.3): a leased job
+// not acked before its visibility deadline becomes re-claimable, so a crashed
+// worker cannot strand a chunk.
+func TestBroker_LeaseExpiryRedelivery(t *testing.T) {
+	for _, bf := range brokerFactories() {
+		t.Run(bf.name, func(t *testing.T) {
+			ctx := context.Background()
+			b := bf.make(t)
+			now := time.Unix(1_000, 0)
+			bf.setClock(b, func() time.Time { return now })
+
+			if err := b.Enqueue(ctx, sampleJob(9)); err != nil {
+				t.Fatalf("Enqueue: %v", err)
+			}
+			first, err := b.Lease(ctx, 10*time.Second)
+			if err != nil {
+				t.Fatalf("Lease: %v", err)
+			}
+
+			// Before the deadline the job stays hidden.
+			now = now.Add(5 * time.Second)
+			if _, err := b.Lease(ctx, 10*time.Second); err != embedqueue.ErrNoJob {
+				t.Fatalf("pre-expiry Lease err = %v, want ErrNoJob", err)
+			}
+
+			// After the deadline the abandoned lease is reclaimed and re-leasable.
+			now = now.Add(10 * time.Second)
+			second, err := b.Lease(ctx, 10*time.Second)
+			if err != nil {
+				t.Fatalf("post-expiry Lease: %v", err)
+			}
+			if second.Job.ChunkID != 9 {
+				t.Fatalf("reclaimed chunk = %d, want 9", second.Job.ChunkID)
+			}
+			if second.Token == first.Token {
+				t.Fatalf("redelivery reused the same token %q", second.Token)
+			}
+		})
+	}
+}
+
+// TestBroker_NackRedeliversThenDeadLetters pins redelivery + dead-lettering
+// (SPEC §8.7.3): a job nacked past maxAttempts is dead-lettered, not requeued.
+func TestBroker_NackRedeliversThenDeadLetters(t *testing.T) {
+	for _, bf := range brokerFactories() {
+		t.Run(bf.name, func(t *testing.T) {
+			ctx := context.Background()
+			b := bf.make(t) // maxAttempts = 3
+
+			if err := b.Enqueue(ctx, sampleJob(3)); err != nil {
+				t.Fatalf("Enqueue: %v", err)
+			}
+			// Lease+Nack three times; the 3rd nack (attempts==maxAttempts) dead-letters.
+			for i := 0; i < 3; i++ {
+				lease, err := b.Lease(ctx, time.Minute)
+				if err != nil {
+					t.Fatalf("Lease attempt %d: %v", i+1, err)
+				}
+				if err := b.Nack(ctx, lease.Token, 0); err != nil {
+					t.Fatalf("Nack attempt %d: %v", i+1, err)
+				}
+			}
+			if _, err := b.Lease(ctx, time.Minute); err != embedqueue.ErrNoJob {
+				t.Fatalf("after dead-letter Lease err = %v, want ErrNoJob", err)
+			}
+			st, err := b.Stats(ctx)
+			if err != nil {
+				t.Fatalf("Stats: %v", err)
+			}
+			if st.DeadLettered != 1 {
+				t.Fatalf("dead-lettered = %d, want 1 (stats=%+v)", st.DeadLettered, st)
+			}
+		})
+	}
+}
+
+// TestSQLiteBroker_Durable confirms the SQLite broker persists enqueued jobs
+// across a reopen (a coordinator restart does not lose the backlog).
+func TestSQLiteBroker_Durable(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "queue.db")
+
+	b1, err := embedqueue.NewSQLiteBroker(ctx, path, 5)
+	if err != nil {
+		t.Fatalf("open 1: %v", err)
+	}
+	if err := b1.Enqueue(ctx, sampleJob(42)); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if err := b1.Close(); err != nil {
+		t.Fatalf("close 1: %v", err)
+	}
+
+	b2, err := embedqueue.NewSQLiteBroker(ctx, path, 5)
+	if err != nil {
+		t.Fatalf("open 2: %v", err)
+	}
+	defer func() { _ = b2.Close() }()
+	lease, err := b2.Lease(ctx, time.Minute)
+	if err != nil {
+		t.Fatalf("Lease after reopen: %v", err)
+	}
+	if lease.Job.ChunkID != 42 {
+		t.Fatalf("reopened lease chunk = %d, want 42", lease.Job.ChunkID)
+	}
+}

--- a/tests/embedqueue/coordinator_test.go
+++ b/tests/embedqueue/coordinator_test.go
@@ -1,0 +1,90 @@
+package embedqueue_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/embedqueue"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// fakePendingSource hands out pending tasks once, then reports empty — modeling
+// the store transitioning chunks out of "pending" after they are embedded.
+type fakePendingSource struct {
+	mu       sync.Mutex
+	pending  []model.ChunkTask
+	returned bool
+}
+
+func (s *fakePendingSource) NextPending(_ context.Context, _ int, _ string) ([]model.ChunkTask, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.returned {
+		return nil, nil
+	}
+	s.returned = true
+	return s.pending, nil
+}
+
+// TestCoordinator_EnqueuePending pins the coordinator role (SPEC §8.7.1/§8.7.2):
+// it enqueues one job per pending chunk, bound to the corpus ref and the
+// enqueue-time embed identity.
+func TestCoordinator_EnqueuePending(t *testing.T) {
+	ctx := context.Background()
+	broker := embedqueue.NewMemBroker(3)
+	src := &fakePendingSource{pending: []model.ChunkTask{
+		model.NewChunkTask(1, "a", "text", model.ChunkMetadata{ChunkID: 1, RelPath: "a.txt"}),
+		model.NewChunkTask(2, "b", "code", model.ChunkMetadata{ChunkID: 2, RelPath: "b.go"}),
+	}}
+
+	coord := &embedqueue.Coordinator{
+		Source:        src,
+		Broker:        broker,
+		CorpusID:      "corpus-x",
+		SourceKind:    "local",
+		EmbedIdentity: testIdentity,
+	}
+
+	n, err := coord.EnqueuePending(ctx, "")
+	if err != nil {
+		t.Fatalf("EnqueuePending: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("enqueued = %d, want 2", n)
+	}
+
+	st, _ := broker.Stats(ctx)
+	if st.Pending != 2 {
+		t.Fatalf("queue pending = %d, want 2", st.Pending)
+	}
+
+	// Drain and confirm jobs carry the corpus ref, chunk identity, and the
+	// enqueue-time embed identity (SPEC §8.7.2).
+	seen := map[uint64]embedqueue.Job{}
+	for i := 0; i < 2; i++ {
+		lease, err := broker.Lease(ctx, 0)
+		if err != nil {
+			t.Fatalf("Lease %d: %v", i, err)
+		}
+		seen[lease.Job.ChunkID] = lease.Job
+	}
+	if j, ok := seen[1]; !ok || j.IndexKind != "text" || j.CorpusID != "corpus-x" || j.EmbedIdentity != testIdentity {
+		t.Fatalf("chunk 1 job wrong: %+v", j)
+	}
+	if j, ok := seen[2]; !ok || j.IndexKind != "code" {
+		t.Fatalf("chunk 2 job wrong: %+v", j)
+	}
+}
+
+// TestCoordinator_RequiresEmbedIdentity pins that the coordinator refuses to
+// enqueue jobs with no embed identity (SPEC §8.7.2 — every job carries one).
+func TestCoordinator_RequiresEmbedIdentity(t *testing.T) {
+	coord := &embedqueue.Coordinator{
+		Source: &fakePendingSource{},
+		Broker: embedqueue.NewMemBroker(3),
+	}
+	if _, err := coord.EnqueuePending(context.Background(), ""); err == nil {
+		t.Fatal("EnqueuePending with empty embed identity: want error, got nil")
+	}
+}

--- a/tests/embedqueue/worker_test.go
+++ b/tests/embedqueue/worker_test.go
@@ -124,25 +124,16 @@ func TestWorker_LeaseEmbedAck(t *testing.T) {
 	}
 }
 
-// TestWorker_IdempotentRedelivery pins idempotency (SPEC §8.7.3): a duplicate /
-// redelivered job for the same chunk_id is safe — the vector write is keyed by
-// chunk_id so re-running does not create a duplicate vector. With the real index
-// the second write overwrites the same vector; here we assert the worker drains
-// both deliveries without error and each is keyed by the same chunk_id.
+// TestWorker_IdempotentRedelivery pins idempotency (SPEC §8.7.3): re-processing
+// the same chunk_id is safe — the vector write is keyed by chunk_id so re-running
+// does not create a duplicate vector. The broker dedups LIVE jobs, so a duplicate
+// enqueue while one is still queued is collapsed; once the first delivery drains,
+// re-enqueuing the same chunk (a later coordinator pass / at-least-once
+// redelivery) is permitted and embeds chunk_id 8 again, idempotently.
 func TestWorker_IdempotentRedelivery(t *testing.T) {
-	ctx := context.Background()
 	broker := embedqueue.NewMemBroker(3)
 	fetch := &fakeFetcher{tasks: map[uint64]model.ChunkTask{8: textTask(8, "dup")}}
 	step := &fakeEmbedStep{}
-
-	// Enqueue the SAME chunk twice (at-least-once delivery / duplicate enqueue).
-	for i := 0; i < 2; i++ {
-		if err := broker.Enqueue(ctx, embedqueue.Job{
-			ChunkID: 8, IndexKind: "text", EmbedIdentity: testIdentity,
-		}); err != nil {
-			t.Fatalf("Enqueue %d: %v", i, err)
-		}
-	}
 
 	cfg := embedqueue.Config{
 		Broker:        broker,
@@ -151,10 +142,44 @@ func TestWorker_IdempotentRedelivery(t *testing.T) {
 		EmbedIdentity: testIdentity,
 		PollInterval:  2 * time.Millisecond,
 	}
-	runWorkerUntil(t, cfg, func() bool {
-		st, _ := broker.Stats(ctx)
-		return st.Pending == 0 && st.InFlight == 0 && len(step.writes()) >= 2
-	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	finished := make(chan struct{})
+	go func() { _ = embedqueue.Run(ctx, cfg); close(finished) }()
+
+	enqueue := func() {
+		if err := broker.Enqueue(context.Background(), embedqueue.Job{
+			ChunkID: 8, IndexKind: "text", EmbedIdentity: testIdentity,
+		}); err != nil {
+			t.Errorf("Enqueue: %v", err)
+		}
+	}
+	waitForWrites := func(n int) {
+		deadline := time.After(3 * time.Second)
+		for {
+			st, _ := broker.Stats(context.Background())
+			if st.Pending == 0 && st.InFlight == 0 && len(step.writes()) >= n {
+				return
+			}
+			select {
+			case <-deadline:
+				t.Fatalf("worker did not reach %d writes within 3s (have %d)", n, len(step.writes()))
+			case <-time.After(5 * time.Millisecond):
+			}
+		}
+	}
+
+	// First delivery embeds chunk 8 once and drains.
+	enqueue()
+	waitForWrites(1)
+	// Re-enqueue the SAME chunk after it drained — dedup permits this (the prior
+	// job was acked). The embed write is keyed by chunk_id, so re-processing
+	// produces no duplicate vector (the real index upserts).
+	enqueue()
+	waitForWrites(2)
+
+	cancel()
+	<-finished
 
 	for _, id := range step.writes() {
 		if id != 8 {

--- a/tests/embedqueue/worker_test.go
+++ b/tests/embedqueue/worker_test.go
@@ -1,0 +1,231 @@
+package embedqueue_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/embedqueue"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+const testIdentity = "mistral|mistral-embed||0|0|off"
+
+// fakeFetcher returns a stored task by chunk_id, or model.ErrNotFound to model a
+// tombstoned/missing chunk (SPEC §8.7.3 tombstone safety).
+type fakeFetcher struct {
+	mu      sync.Mutex
+	tasks   map[uint64]model.ChunkTask
+	missing map[uint64]bool
+	calls   int
+}
+
+func (f *fakeFetcher) ChunkTaskByID(_ context.Context, chunkID uint64) (model.ChunkTask, string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	if f.missing[chunkID] {
+		return model.ChunkTask{}, "", model.ErrNotFound
+	}
+	t, ok := f.tasks[chunkID]
+	if !ok {
+		return model.ChunkTask{}, "", model.ErrNotFound
+	}
+	return t, "hash-" + t.Text, nil
+}
+
+// fakeEmbedStep records every chunk it embeds. Idempotency is verified by
+// counting how many times each chunk_id is written (must be >=1 but each write
+// overwrites the same logical vector — there are no duplicate vectors because the
+// real index upserts by chunk_id; here we record the call sequence).
+type fakeEmbedStep struct {
+	mu      sync.Mutex
+	written []uint64
+}
+
+func (e *fakeEmbedStep) EmbedAndIndex(_ context.Context, _ string, tasks []model.ChunkTask) (int, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for _, t := range tasks {
+		e.written = append(e.written, t.Metadata.ChunkID)
+	}
+	return len(tasks), nil
+}
+
+func (e *fakeEmbedStep) writes() []uint64 {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([]uint64, len(e.written))
+	copy(out, e.written)
+	return out
+}
+
+func textTask(id uint64, text string) model.ChunkTask {
+	return model.NewChunkTask(id, text, "text", model.ChunkMetadata{ChunkID: id, RelPath: "a.txt"})
+}
+
+func runWorkerUntil(t *testing.T, cfg embedqueue.Config, done func() bool) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	finished := make(chan struct{})
+	go func() {
+		_ = embedqueue.Run(ctx, cfg)
+		close(finished)
+	}()
+	deadline := time.After(3 * time.Second)
+	for {
+		if done() {
+			cancel()
+			<-finished
+			return
+		}
+		select {
+		case <-deadline:
+			cancel()
+			<-finished
+			t.Fatal("worker did not reach the expected state within 3s")
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+}
+
+// TestWorker_LeaseEmbedAck pins the happy path (SPEC §8.7.1/§8.7.3): the worker
+// leases a job, reads the authoritative task, embeds it, and acks — the vector
+// lands and the queue drains.
+func TestWorker_LeaseEmbedAck(t *testing.T) {
+	ctx := context.Background()
+	broker := embedqueue.NewMemBroker(3)
+	fetch := &fakeFetcher{tasks: map[uint64]model.ChunkTask{5: textTask(5, "hello")}}
+	step := &fakeEmbedStep{}
+
+	if err := broker.Enqueue(ctx, embedqueue.Job{
+		ChunkID: 5, IndexKind: "text", EmbedIdentity: testIdentity,
+	}); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+
+	cfg := embedqueue.Config{
+		Broker:        broker,
+		Fetcher:       fetch,
+		Embedders:     map[string]embedqueue.Embedder{"text": step},
+		EmbedIdentity: testIdentity,
+		PollInterval:  2 * time.Millisecond,
+	}
+	runWorkerUntil(t, cfg, func() bool {
+		st, _ := broker.Stats(ctx)
+		return st.Pending == 0 && st.InFlight == 0 && len(step.writes()) >= 1
+	})
+
+	writes := step.writes()
+	if len(writes) != 1 || writes[0] != 5 {
+		t.Fatalf("writes = %v, want [5]", writes)
+	}
+}
+
+// TestWorker_IdempotentRedelivery pins idempotency (SPEC §8.7.3): a duplicate /
+// redelivered job for the same chunk_id is safe — the vector write is keyed by
+// chunk_id so re-running does not create a duplicate vector. With the real index
+// the second write overwrites the same vector; here we assert the worker drains
+// both deliveries without error and each is keyed by the same chunk_id.
+func TestWorker_IdempotentRedelivery(t *testing.T) {
+	ctx := context.Background()
+	broker := embedqueue.NewMemBroker(3)
+	fetch := &fakeFetcher{tasks: map[uint64]model.ChunkTask{8: textTask(8, "dup")}}
+	step := &fakeEmbedStep{}
+
+	// Enqueue the SAME chunk twice (at-least-once delivery / duplicate enqueue).
+	for i := 0; i < 2; i++ {
+		if err := broker.Enqueue(ctx, embedqueue.Job{
+			ChunkID: 8, IndexKind: "text", EmbedIdentity: testIdentity,
+		}); err != nil {
+			t.Fatalf("Enqueue %d: %v", i, err)
+		}
+	}
+
+	cfg := embedqueue.Config{
+		Broker:        broker,
+		Fetcher:       fetch,
+		Embedders:     map[string]embedqueue.Embedder{"text": step},
+		EmbedIdentity: testIdentity,
+		PollInterval:  2 * time.Millisecond,
+	}
+	runWorkerUntil(t, cfg, func() bool {
+		st, _ := broker.Stats(ctx)
+		return st.Pending == 0 && st.InFlight == 0 && len(step.writes()) >= 2
+	})
+
+	for _, id := range step.writes() {
+		if id != 8 {
+			t.Fatalf("write for unexpected chunk %d; every redelivery must key chunk_id 8", id)
+		}
+	}
+}
+
+// TestWorker_EmbedIdentityMismatchRejected pins per-job embed-identity
+// enforcement (SPEC §8.7.3/§6.4): a worker whose embed identity does not match
+// the job MUST NOT embed it — no vector is written, preserving the single-space
+// invariant. The mismatched job is redelivered until it dead-letters.
+func TestWorker_EmbedIdentityMismatchRejected(t *testing.T) {
+	ctx := context.Background()
+	broker := embedqueue.NewMemBroker(2)
+	fetch := &fakeFetcher{tasks: map[uint64]model.ChunkTask{4: textTask(4, "x")}}
+	step := &fakeEmbedStep{}
+
+	if err := broker.Enqueue(ctx, embedqueue.Job{
+		ChunkID: 4, IndexKind: "text",
+		EmbedIdentity: "gemini|gemini-embedding-001||3072|0|off", // different space
+	}); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+
+	cfg := embedqueue.Config{
+		Broker:        broker,
+		Fetcher:       fetch,
+		Embedders:     map[string]embedqueue.Embedder{"text": step},
+		EmbedIdentity: testIdentity, // worker is mistral
+		PollInterval:  1 * time.Millisecond,
+		RetryAfter:    1 * time.Millisecond,
+	}
+	runWorkerUntil(t, cfg, func() bool {
+		st, _ := broker.Stats(ctx)
+		return st.DeadLettered == 1
+	})
+
+	if got := step.writes(); len(got) != 0 {
+		t.Fatalf("worker embedded a mismatched-identity job: writes=%v", got)
+	}
+}
+
+// TestWorker_TombstonedChunkSkipped pins tombstone safety (SPEC §8.7.3/§6.6): a
+// job for a chunk that no longer exists (tombstoned ⇒ ChunkTaskByID returns
+// ErrNotFound) is acked as a no-op — never embedded, never redelivered forever.
+func TestWorker_TombstonedChunkSkipped(t *testing.T) {
+	ctx := context.Background()
+	broker := embedqueue.NewMemBroker(3)
+	fetch := &fakeFetcher{missing: map[uint64]bool{6: true}}
+	step := &fakeEmbedStep{}
+
+	if err := broker.Enqueue(ctx, embedqueue.Job{
+		ChunkID: 6, IndexKind: "text", EmbedIdentity: testIdentity,
+	}); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+
+	cfg := embedqueue.Config{
+		Broker:        broker,
+		Fetcher:       fetch,
+		Embedders:     map[string]embedqueue.Embedder{"text": step},
+		EmbedIdentity: testIdentity,
+		PollInterval:  1 * time.Millisecond,
+	}
+	runWorkerUntil(t, cfg, func() bool {
+		st, _ := broker.Stats(ctx)
+		return st.Pending == 0 && st.InFlight == 0 && st.DeadLettered == 0
+	})
+
+	if got := step.writes(); len(got) != 0 {
+		t.Fatalf("worker embedded a tombstoned chunk: writes=%v", got)
+	}
+}

--- a/tests/index/embed_and_index_test.go
+++ b/tests/index/embed_and_index_test.go
@@ -1,0 +1,81 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// TestEmbedAndIndex_MatchesRunOnce pins that the EmbedAndIndex step extracted for
+// the distributed embed-worker (SPEC §8.7) produces the same result as the
+// in-process RunOnce path: the vector is indexed and the chunk is marked
+// embedded. This is the "distributed-mode-off = existing behavior unchanged"
+// invariant at the shared-step level — both paths run identical embed/index/mark
+// logic.
+func TestEmbedAndIndex_MatchesRunOnce(t *testing.T) {
+	ctx := context.Background()
+	src := &fakeChunkSource{}
+	idx := index.NewHNSWIndex("")
+	emb := &fakeEmbedder{vectors: [][]float32{{0.6, 0.8}}}
+	worker := &index.EmbeddingWorker{
+		Source: src, Index: idx, Embedder: emb, BatchSize: 4,
+	}
+
+	task := model.NewChunkTask(11, "hello", "text", model.ChunkMetadata{ChunkID: 11, RelPath: "a.txt"})
+	n, err := worker.EmbedAndIndex(ctx, "text", []model.ChunkTask{task})
+	if err != nil {
+		t.Fatalf("EmbedAndIndex: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("indexed = %d, want 1", n)
+	}
+	if len(src.embedded) != 1 || src.embedded[0] != 11 {
+		t.Fatalf("embedded = %v, want [11]", src.embedded)
+	}
+
+	hits, err := idx.Search(ctx, []float32{0.6, 0.8}, 5, model.Filter{})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(hits) != 1 || hits[0].ChunkID != 11 {
+		t.Fatalf("hits = %+v, want exactly chunk 11", hits)
+	}
+}
+
+// TestEmbedAndIndex_IdempotentNoDuplicateVectors pins SPEC §8.7.3: re-running an
+// embedding job for the same chunk_id (at-least-once / redelivery) overwrites the
+// same vector — it does NOT create a duplicate. After embedding the same chunk
+// twice, a search returns exactly one hit for it.
+func TestEmbedAndIndex_IdempotentNoDuplicateVectors(t *testing.T) {
+	ctx := context.Background()
+	src := &fakeChunkSource{}
+	idx := index.NewHNSWIndex("")
+	emb := &fakeEmbedder{vectors: [][]float32{{1, 0}}}
+	worker := &index.EmbeddingWorker{
+		Source: src, Index: idx, Embedder: emb, BatchSize: 4,
+	}
+
+	task := model.NewChunkTask(21, "dup", "text", model.ChunkMetadata{ChunkID: 21, RelPath: "b.txt"})
+
+	for i := 0; i < 2; i++ {
+		if _, err := worker.EmbedAndIndex(ctx, "text", []model.ChunkTask{task}); err != nil {
+			t.Fatalf("EmbedAndIndex pass %d: %v", i+1, err)
+		}
+	}
+
+	hits, err := idx.Search(ctx, []float32{1, 0}, 10, model.Filter{})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	count := 0
+	for _, h := range hits {
+		if h.ChunkID == 21 {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("chunk 21 appears %d times after re-embed; want exactly 1 (no duplicate vectors)", count)
+	}
+}

--- a/tests/security/cli_boundary_test.go
+++ b/tests/security/cli_boundary_test.go
@@ -191,6 +191,7 @@ func TestRepoSplitBoundary_InternalCLIFileOwnership(t *testing.T) {
 		"support_bundle.go":         {},
 		"up.go":                     {},
 		"up_daemon.go":              {},
+		"up_distributed_embed.go":   {},
 	}
 
 	var unexpected []string

--- a/tests/store/chunk_task_by_id_test.go
+++ b/tests/store/chunk_task_by_id_test.go
@@ -1,0 +1,114 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// TestChunkTaskByID_RoundTrip pins that ChunkTaskByID (added for distributed
+// embed-workers, SPEC §8.7.4) returns the full live task for a chunk id, with its
+// text and text_hash, so a worker can embed a leased job without coordinator-
+// relayed bytes.
+func TestChunkTaskByID_RoundTrip(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	defer func() { _ = st.Close() }()
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	if err := st.UpsertChunkTask(ctx, model.NewChunkTask(55, "the chunk text", "text", model.ChunkMetadata{
+		ChunkID: 55, RelPath: "docs/a.md", DocType: "md", RepType: "raw_text",
+	})); err != nil {
+		t.Fatalf("UpsertChunkTask: %v", err)
+	}
+
+	task, _, err := st.ChunkTaskByID(ctx, 55)
+	if err != nil {
+		t.Fatalf("ChunkTaskByID: %v", err)
+	}
+	if task.Metadata.ChunkID != 55 || task.Text != "the chunk text" || task.IndexKind != "text" {
+		t.Fatalf("unexpected task: %+v", task)
+	}
+}
+
+// TestChunkTaskByID_MissingIsNotFound pins that an unknown chunk id is reported
+// as model.ErrNotFound (a worker treats it as a safe skip).
+func TestChunkTaskByID_MissingIsNotFound(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	defer func() { _ = st.Close() }()
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if _, _, err := st.ChunkTaskByID(ctx, 999); !errors.Is(err, model.ErrNotFound) {
+		t.Fatalf("missing chunk err = %v, want ErrNotFound", err)
+	}
+	if _, _, err := st.ChunkTaskByID(ctx, 0); !errors.Is(err, model.ErrNotFound) {
+		t.Fatalf("zero chunk err = %v, want ErrNotFound", err)
+	}
+}
+
+// TestChunkTaskByID_TombstonedIsNotFound pins tombstone safety (SPEC §8.7.3 /
+// §6.6): a chunk whose document was tombstoned (deleted=1) is reported as
+// ErrNotFound, so a leased job cannot resurrect a deleted chunk.
+func TestChunkTaskByID_TombstonedIsNotFound(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	defer func() { _ = st.Close() }()
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	const relPath = "docs/deleteme.md"
+	if err := st.UpsertDocument(ctx, model.Document{
+		RelPath: relPath, DocType: "md", SourceType: "local", Status: "ok",
+	}); err != nil {
+		t.Fatalf("UpsertDocument: %v", err)
+	}
+	doc, err := st.GetDocumentByPath(ctx, relPath)
+	if err != nil {
+		t.Fatalf("GetDocumentByPath: %v", err)
+	}
+
+	var chunkID int64
+	err = st.WithTx(ctx, func(tx model.RepresentationStore) error {
+		repID, rerr := tx.UpsertRepresentation(ctx, model.Representation{
+			DocID: doc.DocID, RepType: "raw_text", RepHash: "h1",
+		})
+		if rerr != nil {
+			return rerr
+		}
+		id, cerr := tx.InsertChunkWithSpans(ctx, model.Chunk{
+			RepID: repID, Ordinal: 0, Text: "doomed", TextHash: "th", IndexKind: "text",
+			EmbeddingStatus: "pending",
+		}, []model.Span{{Kind: "lines", StartLine: 1, EndLine: 1}})
+		chunkID = id
+		return cerr
+	})
+	if err != nil {
+		t.Fatalf("seed chunk: %v", err)
+	}
+
+	// Live before deletion, with its text_hash surfaced.
+	_, hash, err := st.ChunkTaskByID(ctx, uint64(chunkID))
+	if err != nil {
+		t.Fatalf("pre-delete ChunkTaskByID: %v", err)
+	}
+	if hash != "th" {
+		t.Fatalf("text_hash = %q, want th", hash)
+	}
+
+	if err := st.MarkDocumentDeleted(ctx, relPath); err != nil {
+		t.Fatalf("MarkDocumentDeleted: %v", err)
+	}
+
+	if _, _, err := st.ChunkTaskByID(ctx, uint64(chunkID)); !errors.Is(err, model.ErrNotFound) {
+		t.Fatalf("tombstoned chunk err = %v, want ErrNotFound", err)
+	}
+}


### PR DESCRIPTION
Closes #248.

Implements the optional **distributed embedding** contract (dirstral-spec **§8.7**, spec 0.21.0): a coordinator enqueues pending chunks and N stateless workers pull jobs, read corpus bytes directly via CorpusFS (§7.10), embed, and write vectors + status back to a shared store. Off by default — the in-process single-binary loop is unchanged when distributed mode is off.

## §8.7 contract
- **Roles (§8.7.1):** coordinator (control plane: discovery/chunk/store/serve + enqueue pending) vs embed-worker (compute plane: lease → read bytes → embed → write back). The single-binary default is the degenerate case (one process, in-process queue, no broker).
- **Job schema (§8.7.2):** `embedqueue.Job` carries the corpus ref (`CorpusID` + `Source`), chunk identity (`ChunkID` + `IndexKind`), payload identity (`TextHash`, or media `RelPath` + `Span`), and the **embed identity (§8.1.4)** the job was enqueued under. No bytes, no secrets — safe to serialize/log.
- **Idempotency/ordering/identity (§8.7.3):** vector writes are keyed by `chunk_id` (re-delivery = overwrite, never a duplicate vector); no global ordering; per-job embed-identity enforced (mismatch ⇒ reject, never mix vector spaces, §6.4); tombstone-safe (a tombstoned/missing chunk is acked as a no-op, §6.6).
- **Shared store + broker (§8.7.4):** distributed mode **requires an external Tier C store** (qdrant/pgvector) — validation rejects an embedded Tier A/B backend. Broker is implementation-defined.

## Queue interface + default impls
- `embedqueue.Broker` — enqueue / lease / ack / nack(redeliver) / dead-letter, with lease expiry (visibility timeout). External adapters (NATS/Redis/SQS) plug in behind it; documented, not added to the default build.
- **Defaults (dependency-free, pure-Go, CGO_ENABLED=0):** `MemBroker` (in-process) and `SQLiteBroker` (durable, reuses the existing `modernc.org/sqlite` driver). Both implement the full contract incl. lease-expiry reclaim and dead-lettering.

## Coordinator / worker wiring
- `Coordinator.EnqueuePending` drains chunks whose `embedding_status` is `pending` (§5.3) into jobs bound to the corpus ref + embed identity.
- `embedqueue.Run(ctx, cfg)` is the reusable worker run-loop (exported for follow-up #249's CLI subcommand — **not** added here). It leases jobs, loads the authoritative task from the shared store (`store.ChunkTaskByID`, tombstone-safe), enforces embed identity, and embeds by **reusing the in-process path**: `EmbeddingWorker.EmbedAndIndex` (extracted from `RunOnce`, no duplicated embed/media-load/index/mark logic).
- Opt-in config `distributed_embed.*` (enabled/broker/sqlite_path/broker_url/max_attempts): off/empty by default, snapshot round-trips the non-secret knobs, broker URL is a runtime-only secret resolved per §16.1.1 and **never persisted**. When enabled, `up` runs the in-process degenerate coordinator+worker topology; when off, behavior is byte-identical.

## Spec re-pin
First distributed-ingest PR to land §8.7, so the `dirstral-spec` submodule is re-pinned to **0.21.0** (`f75f72a`), folded into the first commit.

## Tests (external `tests/<pkg>` packages)
- `tests/embedqueue`: broker contract over mem+sqlite (enqueue→lease→ack; lease-expiry redelivery; nack→dead-letter; sqlite durability); worker (lease→embed→ack; idempotent redelivery; embed-identity mismatch rejected; tombstone skip); coordinator (enqueue pending + embed-identity required).
- `tests/store`: `ChunkTaskByID` round-trip / not-found / tombstone-safe.
- `tests/index`: `EmbedAndIndex` parity with `RunOnce` + idempotent (no duplicate vectors).
- `tests/config`: off-by-default; Tier-C-required; external-broker-needs-url; file round-trip (broker_url never read from disk); snapshot omits broker_url.

Store shape (§5), retrieval (§9), and MCP tools (§12–15) are unchanged — distributed mode changes only **where** embedding runs. `make check` is green.

DO NOT MERGE.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added distributed embedding support with broker configuration options (memory or SQLite-backed job queues)
  * Added distributed embedding configuration validation requiring external Tier-C vector store backends (qdrant, pgvector)

* **Tests**
  * Added comprehensive test coverage for distributed embedding configuration, broker behavior, coordinator logic, and worker processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->