### PR TITLE
feat(ingest): content-addressed translation cache (#267 item 2)

### DIFF
--- a/internal/ingest/derivation.go
+++ b/internal/ingest/derivation.go
@@ -256,6 +256,60 @@ func (s *Service) OCRCacheKey(content []byte) string {
 	return s.ocrCacheKey(content)
 }
 
+// activeTranslateIdentity is the translation derivation identity of the
+// currently configured translator for a given target language, in the canonical
+// derivationIdentity form (capability=translate, §8.6.2/§8.6.7). The target
+// language is folded as the identity's language field so a different target lands
+// on a different identity (and cache key). Empty when no translate provider/model
+// is resolved, so the historical bytes+text-only key is preserved for the
+// no-translate path.
+func (s *Service) activeTranslateIdentity(targetLang string) string {
+	if strings.TrimSpace(s.translateProvider) == "" && strings.TrimSpace(s.translateModel) == "" {
+		return ""
+	}
+	return derivationIdentity(string(provider.CapTranslate),
+		s.translateProvider, s.translateModel, "", targetLang)
+}
+
+// translateCacheKey returns the on-disk translation cache filename stem for the
+// given source media bytes, source transcript text, and target language. It folds
+// the canonical translate derivation identity (provider/model/target-language)
+// into the key (SPEC §8.6.7), exactly mirroring transcriptCacheKey/ocrCacheKey,
+// so the same source in two corpora derives the translation once (cross-corpus
+// reuse) while a provider, model, or target-language change MISSES the cache and
+// never returns another derivation's bytes.
+//
+// The SOURCE TRANSCRIPT TEXT is folded in addition to the media bytes because the
+// translation is of that text: if an upstream STT/model swap changes the source
+// transcript, the cached translation of the OLD text is stale and must miss. When
+// no translate provider/model is resolved the historical bytes+text-only key is
+// preserved.
+func (s *Service) translateCacheKey(content []byte, sourceText, targetLang string) string {
+	parts := []string{
+		computeContentHash(content),
+		computeContentHash([]byte(sourceText)),
+	}
+	if identity := s.activeTranslateIdentity(targetLang); identity != "" {
+		parts = append(parts, identity)
+	} else {
+		// Preserve the historical behaviour of keying on the lower-cased target
+		// language even with no resolved provider/model identity, so two distinct
+		// targets never collide on the no-identity path.
+		parts = append(parts, strings.ToLower(strings.TrimSpace(targetLang)))
+	}
+	combined := strings.Join(parts, "\x00")
+	return computeContentHash([]byte(combined))
+}
+
+// TranslateCacheKey exposes translateCacheKey for tests in the tests/ tree, so
+// the provider/model/target-language → cache-key binding (SPEC §8.6.7) can be
+// asserted directly — in particular that a provider, model, or target-language
+// change yields a distinct key (no cross-identity bleed) while the same identity
+// over the same source yields a stable key (cross-corpus reuse).
+func (s *Service) TranslateCacheKey(content []byte, sourceText, targetLang string) string {
+	return s.translateCacheKey(content, sourceText, targetLang)
+}
+
 // derivationIdentity builds the canonical, order-stable derivation-identity
 // string from the structured fields the spec defines (§8.6.7:
 // {capability, provider, model, version, language}). It is intentionally NOT an

--- a/internal/ingest/translate.go
+++ b/internal/ingest/translate.go
@@ -21,20 +21,18 @@ func (s *Service) readOrComputeTranslation(ctx context.Context, content []byte, 
 		return "", fmt.Errorf("create translate cache dir: %w", err)
 	}
 
-	// Key the cache on the full translation identity, not just the source media
-	// bytes: the same media re-translated after the source transcript text, the
-	// chat provider, or the model changes must NOT return stale text (the rep's
-	// meta_json records the new provider/model, so a stale body would be
-	// mislabeled). The TranscriptLangSuffix is retained on the filename so cache
-	// files stay human-identifiable by language.
-	cacheIdentity := strings.Join([]string{
-		computeContentHash(content),
-		computeContentHash([]byte(sourceText)),
-		strings.TrimSpace(s.translateProvider),
-		strings.TrimSpace(s.translateModel),
-		strings.ToLower(strings.TrimSpace(targetLang)),
-	}, "\x00")
-	base := computeContentHash([]byte(cacheIdentity)) + TranscriptLangSuffix(targetLang)
+	// Key the cache on the canonical translate derivation identity, not just the
+	// source media bytes (SPEC §8.6.7): the same media re-translated after the
+	// source transcript text, the translate provider, the model, or the TARGET
+	// LANGUAGE changes must NOT return stale text (the rep's meta_json records the
+	// new provider/model, so a stale body would be mislabeled). translateCacheKey
+	// folds {content, source-text, capability=translate|provider|model|target-lang}
+	// via the same derivationIdentity scheme as transcriptCacheKey/ocrCacheKey, so
+	// the same source in two corpora derives once (cross-corpus reuse) while an
+	// identity change misses without reading another derivation's bytes. The
+	// TranscriptLangSuffix is retained on the filename so cache files stay
+	// human-identifiable by language.
+	base := s.translateCacheKey(content, sourceText, targetLang) + TranscriptLangSuffix(targetLang)
 	cachePath := filepath.Join(cacheDir, base+".txt")
 	if cached, err := os.ReadFile(cachePath); err == nil {
 		return string(cached), nil

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -46,6 +46,15 @@ const (
 	// it. Binding diarization to a backend that lacks the capability is rejected
 	// as CONFIG_INVALID, consistent with the capability matrix (8.1.2).
 	CapDiarize Capability = "diarize"
+	// CapTranslate is transcript translation (SPEC §8.6.2). It is not a distinct
+	// provider capability in the matrix — translation runs on a chat provider
+	// (CapChat) — but it is a distinct DERIVATION kind: a translated transcript's
+	// provenance and content-addressed cache key fold {translate, provider, model,
+	// target-language} so a provider/model/target-language change re-derives and
+	// never reads another derivation's cached bytes (§8.6.7). It is defined here so
+	// translation reuses the one canonical derivationIdentity scheme rather than a
+	// parallel ad-hoc one.
+	CapTranslate Capability = "translate"
 )
 
 // Support is a capability-matrix cell state.

--- a/tests/ingest/translate_cache_test.go
+++ b/tests/ingest/translate_cache_test.go
@@ -1,0 +1,159 @@
+package tests
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// translation cache tests (issue #267 item 2): the content-addressed artifact
+// cache pattern (transcript/OCR) is extended to translation outputs so the same
+// source file in two corpora derives the translation once (cross-corpus reuse),
+// while a provider/model/target-language change MISSES the cache and never reads
+// another derivation's cached bytes.
+
+// TestTranslateCacheKey_SameIdentityStable locks cross-corpus reuse: the same
+// source content + source text + translate identity (provider/model/target-lang)
+// always yields the SAME cache key, even across two distinct Service instances
+// (two corpora / two runs). A stable key is what lets a second corpus read the
+// first corpus's cached translation instead of re-calling the chat provider.
+func TestTranslateCacheKey_SameIdentityStable(t *testing.T) {
+	t.Parallel()
+	content := []byte("identical-audio-bytes")
+	sourceText := "[00:00] one line"
+
+	newSvc := func() *ingest.Service {
+		st := &fakeIngestStore{}
+		s := mustNewIngestService(t, config.Config{StateDir: t.TempDir()}, st)
+		s.SetTranslator(&fakeTranslator{}, "mistral", "mistral-small-2506", []string{"en"})
+		return s
+	}
+
+	corpusA := newSvc()
+	corpusB := newSvc()
+
+	keyA := corpusA.TranslateCacheKey(content, sourceText, "en")
+	keyB := corpusB.TranslateCacheKey(content, sourceText, "en")
+
+	if keyA != keyB {
+		t.Fatalf("same source+identity must yield a stable cache key across corpora: %q != %q", keyA, keyB)
+	}
+}
+
+// TestTranslateCacheKey_IdentityChangeMisses locks the no-cross-identity-bleed
+// guarantee: a provider, model, or target-language change MUST land on a distinct
+// cache key, so the new derivation never reads the previous one's cached bytes.
+func TestTranslateCacheKey_IdentityChangeMisses(t *testing.T) {
+	t.Parallel()
+	content := []byte("audio-bytes")
+	sourceText := "[00:00] one line"
+
+	newSvc := func(prov, modelName string) *ingest.Service {
+		st := &fakeIngestStore{}
+		s := mustNewIngestService(t, config.Config{StateDir: t.TempDir()}, st)
+		s.SetTranslator(&fakeTranslator{}, prov, modelName, []string{"en", "fr"})
+		return s
+	}
+
+	base := newSvc("mistral", "m1")
+	baseKey := base.TranslateCacheKey(content, sourceText, "en")
+
+	// Same provider/model/target as base -> same key (sanity for the diffs below).
+	if again := newSvc("mistral", "m1").TranslateCacheKey(content, sourceText, "en"); again != baseKey {
+		t.Fatalf("identical identity must be stable: %q != %q", again, baseKey)
+	}
+
+	// Provider change must miss.
+	if k := newSvc("openai", "m1").TranslateCacheKey(content, sourceText, "en"); k == baseKey {
+		t.Fatalf("provider change must yield a distinct cache key (got %q for both)", k)
+	}
+	// Model change must miss.
+	if k := newSvc("mistral", "m2").TranslateCacheKey(content, sourceText, "en"); k == baseKey {
+		t.Fatalf("model change must yield a distinct cache key (got %q for both)", k)
+	}
+	// Target-language change must miss.
+	if k := base.TranslateCacheKey(content, sourceText, "fr"); k == baseKey {
+		t.Fatalf("target-language change must yield a distinct cache key (got %q for both)", k)
+	}
+	// Source-transcript-text change must miss (translation is of that text; an
+	// upstream STT swap changing the source text must not reuse the old body).
+	if k := base.TranslateCacheKey(content, "[00:00] DIFFERENT text", "en"); k == baseKey {
+		t.Fatalf("source-text change must yield a distinct cache key (got %q for both)", k)
+	}
+}
+
+// TestTranslateCacheKey_NoIdentityPathSeparatesTargets locks the disabled/absent
+// identity path: with no resolved translate provider/model, the key falls back to
+// {content, source-text, target-language} and two distinct targets still never
+// collide, and the no-identity key differs from an identity-folded key.
+func TestTranslateCacheKey_NoIdentityPathSeparatesTargets(t *testing.T) {
+	t.Parallel()
+	content := []byte("audio-bytes")
+	sourceText := "[00:00] one line"
+
+	// No SetTranslator -> empty translate identity -> bytes+text(+target) key.
+	none := mustNewIngestService(t, config.Config{StateDir: t.TempDir()}, &fakeIngestStore{})
+
+	kEn := none.TranslateCacheKey(content, sourceText, "en")
+	kFr := none.TranslateCacheKey(content, sourceText, "fr")
+	if kEn == kFr {
+		t.Fatalf("no-identity path must still separate distinct targets (got %q for both)", kEn)
+	}
+
+	// An identity-folded key for the same source+target must differ from the
+	// no-identity key (the identity is folded in).
+	with := mustNewIngestService(t, config.Config{StateDir: t.TempDir()}, &fakeIngestStore{})
+	with.SetTranslator(&fakeTranslator{}, "mistral", "m1", []string{"en"})
+	if k := with.TranslateCacheKey(content, sourceText, "en"); k == kEn {
+		t.Fatalf("identity-folded key must differ from no-identity key (got %q for both)", k)
+	}
+}
+
+// TestTranslation_CrossCorpusReuse is the end-to-end analogue of the cache-key
+// test: a translation computed by one corpus is reused (no chat-provider call) by
+// a SECOND corpus pointed at the SAME stateDir + same source content + same
+// translate identity — the cross-corpus "derive once" guarantee of #267 item 2.
+func TestTranslation_CrossCorpusReuse(t *testing.T) {
+	t.Parallel()
+	stateDir := t.TempDir()
+	content := []byte("audio-bytes")
+
+	run := func(tr *fakeTranslator) {
+		s := mustNewIngestService(t, config.Config{StateDir: stateDir}, &fakeIngestStore{})
+		s.SetTranscriber(&fakeTranscriber{text: "[00:00] one line"})
+		s.SetTranscriptLanguage("de")
+		s.SetTranslator(tr, "mistral", "m1", []string{"en"})
+		doc := model.Document{DocID: 3, RelPath: "audio/clip.mp3", DocType: "audio"}
+		if err := s.GenerateTranscriptRepresentation(context.Background(), doc, content); err != nil {
+			t.Fatalf("GenerateTranscriptRepresentation: %v", err)
+		}
+	}
+
+	first := &fakeTranslator{}
+	run(first)
+	if first.callCount() == 0 {
+		t.Fatalf("expected translator called on the first corpus run")
+	}
+
+	// A different corpus (fresh Service, same stateDir) over the same source must
+	// read the cached translation: zero chat-provider calls.
+	second := &fakeTranslator{}
+	run(second)
+	if second.callCount() != 0 {
+		t.Fatalf("expected cross-corpus cache reuse (0 translator calls), got %d", second.callCount())
+	}
+
+	// The cache file the second run reused must exist on disk under cache/translate.
+	probe := mustNewIngestService(t, config.Config{StateDir: stateDir}, &fakeIngestStore{})
+	probe.SetTranslator(&fakeTranslator{}, "mistral", "m1", []string{"en"})
+	cachePath := filepath.Join(stateDir, "cache", "translate",
+		probe.TranslateCacheKey(content, "[00:00] one line", "en")+ingest.TranscriptLangSuffix("en")+".txt")
+	if _, err := os.Stat(cachePath); err != nil {
+		t.Fatalf("expected translation cache file at %s: %v", cachePath, err)
+	}
+}


### PR DESCRIPTION
## Summary

Part of #267 (item 2). Implements **only** item 2 of #267 — the content-addressed artifact cache — and does **not** close the issue.

Item 2 asked that the transcript cache pattern (content_hash + identity) extend to OCR, translation, and embeddings so the same input file in two corpora derives each artifact once (cross-corpus reuse), reusing the existing derivation-identity scheme rather than a parallel one.

### What was already covered (recon)

- **Transcripts** — `cache/transcribe`, keyed by `transcriptCacheKey` folding the STT identity.
- **OCR** — `cache/ocr`, keyed by `ocrCacheKey` folding the OCR identity (incl. the provider-only fix).
- **Structured/docling** — `cache/docling`, keyed by `ocrCacheKey`.
- **Translation** — `cache/translate` (added in #293) was already content-addressed, but it hand-rolled its cache key via a manual `strings.Join` of provider/model/target-lang — a *parallel* scheme, the exact thing item 2 says to avoid.
- **Embeddings** — scoped **out**: embeddings are not a file artifact. They are tracked by the chunk `embedding_status` + the vector store, with cross-run/corpus identity handled by the embed-identity machinery (`VerifyEmbedIdentity`, SPEC §8.1.4). They do not fit the file-cache pattern, so there is nothing to add here.

### What this PR changes (translation)

The remaining gap was translation using an ad-hoc key. This PR brings it onto the one canonical `derivationIdentity` scheme, exactly mirroring transcript/OCR:

- Add `provider.CapTranslate` — translation is a distinct *derivation* kind (it runs on a chat provider but its provenance/identity is its own).
- Add `Service.activeTranslateIdentity(targetLang)` folding `{translate, provider, model, target-language}` via the shared `derivationIdentity` helper.
- Add `Service.translateCacheKey(content, sourceText, targetLang)` mirroring `transcriptCacheKey`/`ocrCacheKey`, plus a `TranslateCacheKey` test seam (like `OCRCacheKey`).
- `readOrComputeTranslation` now keys on `translateCacheKey`.

### Cache-key / identity handling

The key folds `{content-hash, source-text-hash, derivationIdentity(translate, provider, model, "", target-language)}`. Consequences, all test-locked:

- Same source + identity → **stable key across corpora** (cross-corpus reuse / derive once).
- A **provider, model, or target-language** change → **distinct key** (cache miss, never reads another derivation's bytes).
- A **source-transcript-text** change (e.g. upstream STT swap) → distinct key, so a stale translation of the old text never resurfaces.
- No resolved translate provider/model → historical bytes+text+target-language key preserved (disabled/absent path still separates targets).

No tool / citation / persisted contract changed; this is an internal efficiency improvement. No submodule re-pin.

## Tests (external `tests/ingest` package)

- `TestTranslateCacheKey_SameIdentityStable` — cross-corpus stable key.
- `TestTranslateCacheKey_IdentityChangeMisses` — provider/model/target-lang/source-text change each misses.
- `TestTranslateCacheKey_NoIdentityPathSeparatesTargets` — disabled/absent identity path.
- `TestTranslation_CrossCorpusReuse` — end-to-end: a second corpus over the same stateDir + source reuses the cache (0 chat-provider calls).

`make check` passes fully green (fmt + vet + lint + cyclo + ineffassign + misspell + test + build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)