### PR TITLE
docs: extend dual-machine deployment guide with distributed embedding (#241)

### DIFF
--- a/docs/dual-machine-deployment.md
+++ b/docs/dual-machine-deployment.md
@@ -54,13 +54,18 @@ Why this shape:
   page rendering) re-reads media. Putting the daemon next to where the corpus is
   read avoids pulling the same bytes across the wire twice. This matters most for
   **video**, which is large and, for time-window extraction, currently
-  materializes the whole object locally (see [§4 caveats](#4-caveats-and-current-limitations)).
+  materializes the whole object locally (see [§5 caveats](#5-caveats-and-current-limitations)).
 - **StateDir stays local — always.** Regardless of where the corpus lives, the
   state directory (SQLite metadata, the embedded vector index, and caches) is
   kept on the VPS's local disk. dir2mcp never writes its index or state back to
   the remote source; only the corpus *content* is remote. (`dirstral-spec/docs/SPEC.md`
   §7.8, §1.2.) When the corpus is on S3, the per-object download cache lives
   under `StateDir/corpus-cache`.
+
+The single-daemon shape above is the default and the recommended starting point.
+If embedding throughput becomes the bottleneck, you can optionally fan the embed
+work out across several worker processes on the VPS while keeping one daemon as the
+coordinator — see [§4 Optional: distributed embedding](#4-optional-distributed-embedding-coordinator--workers).
 
 ---
 
@@ -242,14 +247,124 @@ auth unless `--force-insecure` is explicitly set.
 
 ---
 
-## 4. Caveats and current limitations
+## 4. Optional: distributed embedding (coordinator + workers)
+
+Everything above runs embedding **inside the daemon process**. For a large corpus
+or a slow embed model, you can instead let the daemon act as a **coordinator** that
+enqueues embedding jobs onto a shared queue, and run one or more standalone
+**`dir2mcp embed-worker`** processes that lease jobs, embed, and write vectors
+directly to a shared store. This is opt-in (`distributed_embed.enabled: true`) and
+governed by `dirstral-spec/docs/SPEC.md` §8.7.
+
+This is a different axis from the single-machine "daemon on the GPU VPS" topology
+above — you only need it when one embedder cannot keep up. The corpus-read and
+StateDir rules from §1 still apply: corpus content is read where each worker runs,
+and each process keeps its own local StateDir.
+
+### 4.1 What this requires
+
+Distributed mode has two hard prerequisites, both enforced at config load /
+worker startup:
+
+- **A shared Tier-C vector store.** `distributed_embed.enabled: true` requires
+  `index.backend: qdrant` or `index.backend: pgvector`. The embedded Tier-A
+  (`memory`) and Tier-B (`disk`) backends are single-node and cannot be shared
+  across processes, so the daemon and `embed-worker` **reject** them with a
+  `CONFIG_INVALID`-style error at startup (SPEC §8.7.4). All coordinator and
+  worker processes must point at the **same** Tier-C collection/table.
+- **A broker** that holds the job queue (below).
+
+Every process — coordinator and all workers — must also share the **same embed
+identity** (provider / model / dims; see §5). They are embedding into one vector
+space, so their embed config must agree.
+
+### 4.2 Broker (job queue)
+
+Pick the broker with `distributed_embed.broker`. Only the two **built-in** brokers
+are shipped today; external broker adapters (Redis, NATS, etc.) are **not yet
+implemented** and are rejected with `unsupported distributed_embed.broker` if
+named:
+
+| `distributed_embed.broker` | Backing | Scope | When |
+|---|---|---|---|
+| `memory` (default) | in-process queue | single process only | Degenerate / testing; the queue lives inside one process and is not visible to separate worker processes. |
+| `sqlite` | a SQLite queue file | multi-process on one host | Persistent, pure-Go, file-backed queue. Workers on the **same host** share it via `distributed_embed.sqlite_path` (defaults to `<state_dir>/embed-queue.db`). |
+
+> The `memory` broker is in-process only, so it does **not** connect a separate
+> `embed-worker` to the coordinator. The `sqlite` broker shares a queue **file**,
+> which means coordinator and workers must run on the **same host** (or a host
+> where they all see the same path). A broker that fans work out across *different*
+> hosts needs an external broker adapter, which is on the SPEC §8.7 roadmap but not
+> shipped — so today's distributed topology scales workers **on the GPU VPS
+> itself**, not across machines.
+
+```yaml
+index:
+  backend: qdrant
+  qdrant:
+    url: http://localhost:6334
+    collection: my-corpus
+
+distributed_embed:
+  enabled: true
+  broker: sqlite                 # memory | sqlite (built-ins only)
+  sqlite_path: /var/lib/dir2mcp/embed-queue.db   # optional; defaults to <state_dir>/embed-queue.db
+  max_attempts: 5                # optional; redelivery bound before dead-lettering (default 5)
+```
+
+> The runtime-only broker connection string for a future external broker is read
+> **only** from the `DIR2MCP_DISTRIBUTED_EMBED_BROKER_URL` environment variable and
+> is never persisted to the config file. With only built-in brokers shipped today
+> it has no effect.
+
+### 4.3 Run the coordinator and the workers
+
+1. **Coordinator** — start the daemon as usual (`dir2mcp up …`) with
+   `distributed_embed.enabled: true`. It enumerates the corpus and enqueues embed
+   jobs onto the broker instead of embedding inline.
+2. **Workers** — on the same host, run one or more:
+
+   ```bash
+   dir2mcp embed-worker
+   ```
+
+   `embed-worker` serves no MCP traffic; it leases embed jobs, calls the (localhost)
+   embed server, and writes vectors to the shared Tier-C store. It uses the same
+   config file as the coordinator (same Tier-C store, same broker, same embed
+   identity). Optional tuning flags:
+
+   - `--lease-duration` — visibility timeout for a leased job (default `30s`).
+   - `--poll-interval` — wait after an empty queue before leasing again (default `500ms`).
+   - `--retry-after` — delay before a transiently-failed job is redelivered (default `2s`).
+
+Run as many `embed-worker` processes as your GPU(s) can feed. Because all workers
+write to the same Tier-C collection under the same embed identity, the result is a
+single coherent index.
+
+---
+
+## 5. Caveats and current limitations
 
 - **FUSE-over-S3 listing cost.** If you mount S3 as a filesystem (mountpoint-s3,
   goofys, etc.) instead of using `source.kind: s3`, directory listings over a
   large object tree can be slow and request-expensive, because a filesystem walk
   turns into many `LIST`/`HEAD` calls. Prefer the native `source.kind: s3`
   backend (a flat object listing) for large corpora; reserve FUSE for cases where
-  you specifically need a real mountpoint.
+  you specifically need a real mountpoint. The same listing cost applies to a deep
+  **NFS** tree. For a large local-filesystem-style backend (including NFS and FUSE
+  mounts) where most directories are unchanged between runs, you can opt into the
+  directory-discovery **scan cache** so an unchanged directory skips re-reading and
+  re-sorting its entries:
+
+  ```yaml
+  ingest:
+    scan_cache: true   # default OFF; opt-in. Local-filesystem backend only.
+  ```
+
+  The cache keys each directory on its own mtime plus its direct children's
+  name/size/mtime/mode, so a changed directory is still rescanned. It is only
+  consulted for the local-filesystem backend (not the native `source.kind: s3`
+  object listing).
 
 - **Video time-window reads currently download the whole object.** Range reads
   over S3 avoid whole-object downloads for plain byte-slice reads, but the
@@ -269,11 +384,12 @@ auth unless `--force-insecure` is explicitly set.
 
 ---
 
-## 5. Related docs
+## 6. Related docs
 
 - [`SPEC.md`](SPEC.md) — pointer to the canonical, normative spec (this guide's
   references resolve there): §6 (vector backends), §7.8 (remote corpus), §8.5
-  (self-hosted endpoints), §16.1.1 (credentials), §16.2 (config schema).
+  (self-hosted endpoints), §8.7 (distributed embedding), §16.1.1 (credentials),
+  §16.2 (config schema).
 - [`VISION.md`](VISION.md), [`ECOSYSTEM.md`](ECOSYSTEM.md) — product and ecosystem context.
 - [`x402-payment-adapter-spec.md`](x402-payment-adapter-spec.md) — request-gating
   adapter contract, if you gate the exposed MCP endpoint.

--- a/docs/dual-machine-deployment.md
+++ b/docs/dual-machine-deployment.md
@@ -11,6 +11,7 @@ referenced here, see the canonical spec in the `dirstral-spec` submodule:
 - Self-hosted / OpenAI-compatible provider endpoints — `dirstral-spec/docs/SPEC.md` §8.5
 - Remote corpus sources — `dirstral-spec/docs/SPEC.md` §7.8
 - Vector index backends and identity — `dirstral-spec/docs/SPEC.md` §6
+- Distributed embedding (coordinator + workers + broker) — `dirstral-spec/docs/SPEC.md` §8.7
 - Credential resolution (env → keychain → `.env.local`, never persisted) — `dirstral-spec/docs/SPEC.md` §16.1.1
 - Config schema (`source:`, `index:`, `providers:`, `model:`) — `dirstral-spec/docs/SPEC.md` §16.2
 


### PR DESCRIPTION
Closes #241.

## Summary

Extends the existing `docs/dual-machine-deployment.md` (created/expanded by the merged PR #288 during #240) into the full dual-machine deployment guide. No content was overwritten; the accurate single-daemon topology, provider/source/index config, and existing caveats are preserved and built on.

## What was added/expanded

- **Intro + Related docs**: link `dirstral-spec/docs/SPEC.md` §8.7 (distributed embedding).
- **§1 Topology**: forward-pointer to the optional distributed topology, framed as opt-in only when one embedder cannot keep up.
- **New §4 "Optional: distributed embedding (coordinator + workers)"**:
  - Hard prerequisites: a shared **Tier-C** store (`index.backend: qdrant`|`pgvector`; embedded `memory`/`disk` rejected at startup per SPEC §8.7.4) and a broker; shared embed identity across all processes.
  - Broker table: only built-in `memory` (in-process) and `sqlite` (same-host file-backed queue) are shipped; external broker adapters are **not yet implemented** and are rejected. Documents that today's distributed mode scales workers **on the VPS**, not across hosts.
  - The `dir2mcp embed-worker` subcommand and its tuning flags (`--lease-duration`, `--poll-interval`, `--retry-after`).
  - Coordinator + worker run steps; example `distributed_embed:` YAML block.
- **§5 Caveats** (renumbered from §4): extended the FUSE/large-tree listing caveat to also cover deep NFS trees and the opt-in directory-discovery **scan cache** (`ingest.scan_cache`, default off, local-filesystem backend only, from #267 item 5).

## Verified against the code (not paraphrased)

- Config (nested operator YAML form, `internal/config/config.go`): `distributed_embed.enabled` / `.broker` / `.sqlite_path` / `.max_attempts`; runtime-only `DIR2MCP_DISTRIBUTED_EMBED_BROKER_URL` (never persisted); `ingest.scan_cache`; `index.backend` Tier-C enforcement (SPEC §8.7.4).
- Broker built-ins `memory` / `sqlite` only; external adapters rejected (`internal/cli/up_distributed_embed.go`).
- `dir2mcp embed-worker` subcommand and flag defaults (30s / 500ms / 2s) (`internal/cli/embed_worker.go`).

## Checks

- `make check` is green (the docs misspell lint over docs/README passes). The one initial failure was the unrelated `tests/security` spec-pattern test needing the `dirstral-spec` submodule; resolved with `git submodule update --init dirstral-spec` (working-tree checkout only, no re-pin — tree is clean).

Docs only; no Go code changed; no submodule re-pin committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHuQEKSW3nzU1Pn7KXXBhj