### PR TITLE
feat(export): optional bilingual TTML + SMIL packaging (off by default) (#255)

### DIFF
--- a/internal/avutil/avutil.go
+++ b/internal/avutil/avutil.go
@@ -12,6 +12,7 @@ package avutil
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	neturl "net/url"
@@ -65,6 +66,119 @@ func Duration(ctx context.Context, path string) (time.Duration, error) {
 		return 0, fmt.Errorf("ffprobe %q: non-positive duration %g", path, secs)
 	}
 	return time.Duration(secs * float64(time.Second)), nil
+}
+
+// MediaInfo holds the subset of ffprobe track metadata used to package a media
+// presentation (SPEC §8.6.10 SMIL). It is best-effort: any field may be zero/
+// empty when ffprobe does not report it, and callers MUST fail open (omit the
+// metadata-dependent output) rather than treat a missing field as an error.
+type MediaInfo struct {
+	// Container is the demuxer/format name reported by ffprobe (e.g. "mov,mp4,
+	// m4a,3gp,3g2,mj2"). Empty when unknown.
+	Container string
+	// VideoCodec / AudioCodec are the codec_name of the first video/audio stream
+	// (e.g. "h264", "aac"). Empty when the corresponding stream is absent.
+	VideoCodec string
+	AudioCodec string
+	// BitRateBPS is the overall container bit rate in bits per second, 0 when not
+	// reported.
+	BitRateBPS int
+	// Width / Height are the first video stream's pixel dimensions, 0 for
+	// audio-only media or when not reported.
+	Width  int
+	Height int
+}
+
+// HasVideo reports whether the probed media carries a video stream with usable
+// dimensions, the precondition for emitting video width/height in SMIL.
+func (m MediaInfo) HasVideo() bool {
+	return m.Width > 0 && m.Height > 0
+}
+
+// ffprobeStream is the per-stream shape decoded from ffprobe -show_streams JSON.
+type ffprobeStream struct {
+	CodecType string `json:"codec_type"`
+	CodecName string `json:"codec_name"`
+	Width     int    `json:"width"`
+	Height    int    `json:"height"`
+}
+
+// ffprobeFormat is the container shape decoded from ffprobe -show_format JSON.
+type ffprobeFormat struct {
+	FormatName string `json:"format_name"`
+	BitRate    string `json:"bit_rate"`
+}
+
+// ffprobeOutput is the top-level JSON ffprobe emits with -of json.
+type ffprobeOutput struct {
+	Streams []ffprobeStream `json:"streams"`
+	Format  ffprobeFormat   `json:"format"`
+}
+
+// ProbeMediaInfo probes container/codec/bitrate/dimension metadata for the media
+// at path via ffprobe's JSON output. It returns ErrToolNotFound when ffprobe is
+// not installed so callers can fail open (omit SMIL, keep text subtitles per
+// SPEC §8.6.10). A successful probe with some fields unreported yields a partial
+// MediaInfo rather than an error: SMIL packaging is best-effort. The probe is
+// deterministic for a given input.
+func ProbeMediaInfo(ctx context.Context, path string) (MediaInfo, error) {
+	bin, err := exec.LookPath("ffprobe")
+	if err != nil {
+		return MediaInfo{}, ErrToolNotFound
+	}
+	cmd := exec.CommandContext(ctx, bin,
+		"-v", "error",
+		"-show_entries", "format=format_name,bit_rate:stream=codec_type,codec_name,width,height",
+		"-of", "json",
+		"--", path,
+	)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return MediaInfo{}, fmt.Errorf("ffprobe %q: %w: %s", path, err, strings.TrimSpace(stderr.String()))
+	}
+	return parseMediaInfo(out.Bytes())
+}
+
+// parseMediaInfo decodes ffprobe -of json output into a MediaInfo. It is split
+// out (and exported via ParseMediaInfo) so the JSON mapping can be unit-tested
+// from the tests/ tree against captured ffprobe output without the binary. The
+// first video and first audio stream win; later streams are ignored.
+func parseMediaInfo(raw []byte) (MediaInfo, error) {
+	var probed ffprobeOutput
+	if err := json.Unmarshal(raw, &probed); err != nil {
+		return MediaInfo{}, fmt.Errorf("avutil: parse ffprobe json: %w", err)
+	}
+	info := MediaInfo{Container: strings.TrimSpace(probed.Format.FormatName)}
+	if br := strings.TrimSpace(probed.Format.BitRate); br != "" && br != "N/A" {
+		if n, err := strconv.Atoi(br); err == nil && n > 0 {
+			info.BitRateBPS = n
+		}
+	}
+	for _, s := range probed.Streams {
+		switch strings.ToLower(strings.TrimSpace(s.CodecType)) {
+		case "video":
+			if info.VideoCodec == "" {
+				info.VideoCodec = strings.TrimSpace(s.CodecName)
+				if s.Width > 0 && s.Height > 0 {
+					info.Width = s.Width
+					info.Height = s.Height
+				}
+			}
+		case "audio":
+			if info.AudioCodec == "" {
+				info.AudioCodec = strings.TrimSpace(s.CodecName)
+			}
+		}
+	}
+	return info, nil
+}
+
+// ParseMediaInfo is the exported counterpart of parseMediaInfo, exposed so tests
+// in the tests/ tree can verify ffprobe JSON decoding without the ffprobe binary.
+func ParseMediaInfo(ffprobeJSON []byte) (MediaInfo, error) {
+	return parseMediaInfo(ffprobeJSON)
 }
 
 // DefaultSilenceThresholdDB is the noise floor (in dBFS) below which audio is

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -535,7 +535,7 @@ func (a *App) printUsage() {
 		{"list-files", "legacy compatibility shim; prefer dirstral-cli for client UX"},
 		{"reindex", "force a full re-index of all documents"},
 		{"embed-worker", "run a standalone distributed embed worker (no MCP serving; requires Tier-C store + broker)"},
-		{"export", "render a transcript as VTT/SRT subtitles (export --format vtt|srt <path>)"},
+		{"export", "render a transcript as VTT/SRT/TTML subtitles (export --format vtt|srt|ttml <path>)"},
 		{"bridge", "run helper adapters (for example ElevenLabs webhooks)"},
 		{"config", "view or edit configuration"},
 		{"install", "install dir2mcp into a client (e.g. dir2mcp install claude)"},

--- a/internal/cli/export.go
+++ b/internal/cli/export.go
@@ -27,10 +27,14 @@ type transcriptStore interface {
 }
 
 type exportOptions struct {
-	format  string
-	lang    string
-	out     string
-	relPath string
+	format string
+	lang   string
+	// secondaryLang selects a second transcript language for bilingual TTML
+	// export (SPEC §8.6.10). Empty = monolingual. Only meaningful with
+	// --format ttml.
+	secondaryLang string
+	out           string
+	relPath       string
 }
 
 // runExport renders a document's stored transcript as a WebVTT or SRT subtitle
@@ -64,6 +68,14 @@ func (a *App) runExport(ctx context.Context, global globalOptions, args []string
 	if !ok {
 		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, "configured store does not support transcript export")
 		return exitGeneric
+	}
+
+	// TTML (and its companion SMIL) is the optional broadcast-packaging surface
+	// (SPEC §8.6.10), gated by config and OFF by default. It has its own
+	// resolve+render+emit path because it MAY select two transcript languages
+	// (bilingual) and MAY emit two sidecars (TTML + SMIL).
+	if opts.format == "ttml" {
+		return a.runTTMLExport(ctx, global, cfg, ts, opts)
 	}
 
 	filter := subtitle.NewWordFilter(cfg.MediaFilterWords)
@@ -152,20 +164,25 @@ func parseExportOptions(args []string) (exportOptions, error) {
 	opts := exportOptions{}
 	fs := flag.NewFlagSet("export", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
-	fs.StringVar(&opts.format, "format", "", "subtitle format: vtt|srt (required)")
+	fs.StringVar(&opts.format, "format", "", "subtitle format: vtt|srt|ttml (required)")
 	fs.StringVar(&opts.lang, "lang", "", "language code selecting which transcript to export (default: the document's transcript)")
-	fs.StringVar(&opts.out, "out", "", "output file path (default: stdout)")
+	fs.StringVar(&opts.secondaryLang, "secondary-lang", "", "second language code for bilingual TTML export (only with --format ttml)")
+	fs.StringVar(&opts.out, "out", "", "output file path (default: stdout). For ttml the companion .smil is written alongside")
 	if err := fs.Parse(args); err != nil {
 		return exportOptions{}, err
 	}
 
 	opts.format = strings.ToLower(strings.TrimSpace(opts.format))
 	switch opts.format {
-	case "vtt", "srt":
+	case "vtt", "srt", "ttml":
 	case "":
-		return exportOptions{}, errors.New("--format is required (vtt|srt)")
+		return exportOptions{}, errors.New("--format is required (vtt|srt|ttml)")
 	default:
-		return exportOptions{}, fmt.Errorf("unsupported format %q (want vtt|srt)", opts.format)
+		return exportOptions{}, fmt.Errorf("unsupported format %q (want vtt|srt|ttml)", opts.format)
+	}
+	opts.secondaryLang = strings.TrimSpace(opts.secondaryLang)
+	if opts.secondaryLang != "" && opts.format != "ttml" {
+		return exportOptions{}, errors.New("--secondary-lang is only valid with --format ttml")
 	}
 
 	rest := fs.Args()

--- a/internal/cli/export_ttml.go
+++ b/internal/cli/export_ttml.go
@@ -1,0 +1,161 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/dirstral/dir2mcp/internal/avutil"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/subtitle"
+)
+
+// runTTMLExport renders a document's transcript(s) as the optional broadcast
+// TTML packaging surface (SPEC §8.6.10) and, when enabled, a companion SMIL
+// document. It is reached only for --format ttml. The surface is gated by config
+// (media.subtitles.ttml.enabled) and OFF by default, so a disabled config never
+// reaches the render path. With one language it emits monolingual TTML; with a
+// --secondary-lang whose transcript exists it emits bilingual TTML aligned
+// within the configured tolerance. A requested language with no transcript is
+// reported as INVALID_FIELD. SMIL fails open: when probe metadata is
+// unavailable the SMIL is omitted but the TTML is still emitted.
+func (a *App) runTTMLExport(ctx context.Context, global globalOptions, cfg config.Config, ts transcriptStore, opts exportOptions) int {
+	if !cfg.MediaSubtitlesTTMLEnabled {
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid,
+			"TTML export is disabled (set media.subtitles.ttml.enabled to enable, SPEC §8.6.10)")
+		return exitConfigInvalid
+	}
+
+	filter := subtitle.NewWordFilter(cfg.MediaFilterWords)
+
+	primaryCues, code := a.resolveCues(ctx, global, ts, opts.relPath, opts.lang, filter)
+	if code != exitSuccess {
+		return code
+	}
+
+	var bilingual []subtitle.BilingualCue
+	if opts.secondaryLang != "" {
+		secondaryCues, scode := a.resolveCues(ctx, global, ts, opts.relPath, opts.secondaryLang, filter)
+		if scode != exitSuccess {
+			return scode
+		}
+		bilingual = subtitle.AlignBilingual(primaryCues, secondaryCues,
+			opts.lang, opts.secondaryLang, cfg.MediaSubtitlesTTMLAlignToleranceMS)
+	} else {
+		bilingual = subtitle.MonolingualBilingualCues(primaryCues, opts.lang)
+	}
+	if len(bilingual) == 0 {
+		writeCLIError(a.stderr, global.jsonOutput, exitGeneric,
+			fmt.Sprintf("document %q transcript has no time-coded cues to export", opts.relPath))
+		return exitGeneric
+	}
+
+	ttml := subtitle.RenderTTML(bilingual, opts.lang)
+	return a.emitTTMLExport(ctx, global, cfg, opts, ttml)
+}
+
+// resolveCues loads the transcript representation for lang, builds its cues, and
+// applies the configured word filter. A non-empty lang with no matching
+// transcript is reported as INVALID_FIELD (SPEC §8.6.10/§8.6.3). It returns the
+// cues, or an exit code on error.
+func (a *App) resolveCues(ctx context.Context, global globalOptions, ts transcriptStore, relPath, lang string, filter *subtitle.WordFilter) ([]subtitle.Cue, int) {
+	reps, err := ts.TranscriptRepresentations(ctx, relPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("no document found at %q", relPath))
+			return nil, exitGeneric
+		}
+		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("load transcript representations: %v", err))
+		return nil, exitGeneric
+	}
+	if len(reps) == 0 {
+		writeCLIError(a.stderr, global.jsonOutput, exitGeneric,
+			fmt.Sprintf("document %q has no transcript representation", relPath))
+		return nil, exitGeneric
+	}
+
+	rep, ok := selectTranscriptRep(reps, lang)
+	if !ok {
+		// A requested language with no transcript is a client field error, not a
+		// server failure (SPEC §8.6.10: "Requesting an export for a language with
+		// no transcript is INVALID_FIELD").
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid,
+			fmt.Sprintf("INVALID_FIELD: document %q has no transcript for language %q", relPath, lang))
+		return nil, exitConfigInvalid
+	}
+
+	rows, err := ts.TranscriptSpanChunks(ctx, rep.RepID)
+	if err != nil {
+		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("load transcript chunks: %v", err))
+		return nil, exitGeneric
+	}
+	chunks := make([]subtitle.TranscriptChunk, 0, len(rows))
+	for _, r := range rows {
+		chunks = append(chunks, subtitle.TranscriptChunk{Text: r.Text, Span: r.Span})
+	}
+	cues := subtitle.FilterCues(subtitle.BuildCues(chunks), filter)
+	return cues, exitSuccess
+}
+
+// emitTTMLExport writes the TTML document and, when SMIL is enabled and an --out
+// path is given, the companion SMIL sidecar alongside it. Without --out the TTML
+// is written to stdout and SMIL is not produced (a single stream has no sidecar
+// path to reference). SMIL fails open: a probe failure omits the SMIL but never
+// fails the TTML emission.
+func (a *App) emitTTMLExport(ctx context.Context, global globalOptions, cfg config.Config, opts exportOptions, ttml string) int {
+	if strings.TrimSpace(opts.out) == "" {
+		writef(a.stdout, "%s", ttml)
+		return exitSuccess
+	}
+	if err := writeFileAtomic(opts.out, []byte(ttml)); err != nil {
+		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("write %q: %v", opts.out, err))
+		return exitGeneric
+	}
+	if !global.quiet && !global.jsonOutput {
+		writef(a.stdout, "wrote %s\n", opts.out)
+	}
+
+	if cfg.MediaSubtitlesSMILEnabled {
+		a.emitSMILSidecar(ctx, global, cfg, opts)
+	}
+	return exitSuccess
+}
+
+// emitSMILSidecar probes the media and writes a SMIL packaging document next to
+// the TTML --out path (same base name, .smil extension). It fails open per SPEC
+// §8.6.10: when ffprobe is unavailable or the media cannot be probed, it logs a
+// note (non-fatal) and produces no SMIL rather than failing the export.
+func (a *App) emitSMILSidecar(ctx context.Context, global globalOptions, cfg config.Config, opts exportOptions) {
+	mediaPath := filepath.Join(cfg.RootDir, opts.relPath)
+	info, err := avutil.ProbeMediaInfo(ctx, mediaPath)
+	if err != nil {
+		// Fail open: omit SMIL, keep the TTML already written. Never echo raw
+		// ffprobe stderr at the user beyond a short note.
+		if !global.quiet && !global.jsonOutput {
+			writef(a.stdout, "skipping SMIL (media metadata unavailable): %v\n", err)
+		}
+		return
+	}
+
+	smilPath := strings.TrimSuffix(opts.out, filepath.Ext(opts.out)) + ".smil"
+	// A bilingual TTML carries both languages in one document, so it is referenced
+	// once with the primary language tag.
+	subs := []subtitle.SMILSubtitleRef{{Src: filepath.Base(opts.out), Lang: opts.lang}}
+	smil := subtitle.RenderSMIL(subtitle.SMILInput{
+		MediaSrc:  filepath.Base(mediaPath),
+		Info:      info,
+		Subtitles: subs,
+	})
+	if err := writeFileAtomic(smilPath, []byte(smil)); err != nil {
+		if !global.quiet && !global.jsonOutput {
+			writef(a.stdout, "skipping SMIL (write failed): %v\n", err)
+		}
+		return
+	}
+	if !global.quiet && !global.jsonOutput {
+		writef(a.stdout, "wrote %s\n", smilPath)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1571,15 +1571,7 @@ func applyMediaFileParsed(cfg *Config, fc fileConfig) {
 	if fc.MediaFilterWords != nil {
 		cfg.MediaFilterWords = normalizeStringSlice(fc.MediaFilterWords)
 	}
-	if fc.MediaSubtitlesTTMLEnabled != nil {
-		cfg.MediaSubtitlesTTMLEnabled = *fc.MediaSubtitlesTTMLEnabled
-	}
-	if fc.MediaSubtitlesTTMLAlignToleranceMS != nil {
-		cfg.MediaSubtitlesTTMLAlignToleranceMS = *fc.MediaSubtitlesTTMLAlignToleranceMS
-	}
-	if fc.MediaSubtitlesSMILEnabled != nil {
-		cfg.MediaSubtitlesSMILEnabled = *fc.MediaSubtitlesSMILEnabled
-	}
+	applyMediaSubtitlesFileParsed(cfg, fc)
 	if fc.MediaTrimLeadingSilence != nil {
 		cfg.MediaTrimLeadingSilence = *fc.MediaTrimLeadingSilence
 	}
@@ -1605,6 +1597,21 @@ func applyMediaFileParsed(cfg *Config, fc fileConfig) {
 	}
 	if fc.MediaClipMaxBytes != nil {
 		cfg.MediaClipMaxBytes = *fc.MediaClipMaxBytes
+	}
+}
+
+// applyMediaSubtitlesFileParsed copies the set media.subtitles.* file fields
+// (SPEC §8.6.10) onto cfg. Split out of applyMediaFileParsed so each apply
+// helper stays under the cyclomatic-complexity budget.
+func applyMediaSubtitlesFileParsed(cfg *Config, fc fileConfig) {
+	if fc.MediaSubtitlesTTMLEnabled != nil {
+		cfg.MediaSubtitlesTTMLEnabled = *fc.MediaSubtitlesTTMLEnabled
+	}
+	if fc.MediaSubtitlesTTMLAlignToleranceMS != nil {
+		cfg.MediaSubtitlesTTMLAlignToleranceMS = *fc.MediaSubtitlesTTMLAlignToleranceMS
+	}
+	if fc.MediaSubtitlesSMILEnabled != nil {
+		cfg.MediaSubtitlesSMILEnabled = *fc.MediaSubtitlesSMILEnabled
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1953,6 +1953,8 @@ func isMapSectionKey(key string) bool {
 		return true
 	case "media", "media.variants", "media.translate", "media.clip", "media.diarize":
 		return true
+	case "media.subtitles", "media.subtitles.ttml", "media.subtitles.smil":
+		return true
 	case "index.pgvector":
 		return true
 	case "distributed_embed":

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,12 @@ const (
 	DefaultMediaClipMaxBytes      = 26214400
 )
 
+// DefaultMediaSubtitlesAlignToleranceMS is the bilingual cross-language cue
+// alignment tolerance (SPEC §8.6.10, media.subtitles.ttml.align_tolerance_ms):
+// a secondary segment whose start is within this many milliseconds of a primary
+// cue is merged into that cue.
+const DefaultMediaSubtitlesAlignToleranceMS = 2500
+
 type SecretSourceMetadata struct {
 	ElevenLabsAPIKey     string
 	CohereAPIKey         string
@@ -318,6 +324,31 @@ type Config struct {
 	// carries no language- or domain-specific phrases.
 	MediaFilterWords []string
 
+	// MediaSubtitlesTTMLEnabled opts IN to the OPTIONAL bilingual broadcast
+	// subtitle-packaging surface (SPEC §8.6.10, config
+	// `media.subtitles.ttml.enabled`). OFF by default: VTT/SRT export (§8.6.3) is
+	// unaffected and no TTML/SMIL is produced. When enabled the `export` command
+	// can render TTML (monolingual, or bilingual when a secondary --lang transcript
+	// exists) and, when also enabled, a companion SMIL packaging document.
+	MediaSubtitlesTTMLEnabled bool
+
+	// MediaSubtitlesTTMLAlignToleranceMS is the cross-language cue alignment
+	// tolerance in milliseconds (SPEC §8.6.10, config
+	// `media.subtitles.ttml.align_tolerance_ms`, default 2500). A secondary-language
+	// segment whose start is within this tolerance of a primary cue is merged into
+	// that cue; otherwise it is emitted as its own secondary-only cue. Only consulted
+	// for bilingual TTML export. Zero/negative falls back to the default at
+	// validation time.
+	MediaSubtitlesTTMLAlignToleranceMS int
+
+	// MediaSubtitlesSMILEnabled opts IN to emitting a SMIL packaging document
+	// alongside TTML (SPEC §8.6.10, config `media.subtitles.smil.enabled`). OFF by
+	// default. Only consulted when MediaSubtitlesTTMLEnabled is true. SMIL carries
+	// the probed track metadata (container/codec, bitrate, video width/height) via
+	// ffprobe and fails open: when metadata is unavailable the SMIL is omitted and
+	// the text subtitle output is still produced.
+	MediaSubtitlesSMILEnabled bool
+
 	// MediaTrimLeadingSilence opts IN to trimming leading silence from media
 	// transcripts (dir2mcp#258, config `media.trim_leading_silence`). When true
 	// and ffmpeg is available, the duration of dead air before the first speech
@@ -447,61 +478,64 @@ type fileConfig struct {
 	SecretPatterns  []string
 	DoclingCommand  *string
 
-	IngestDoclingServeURL     *string
-	ElevenLabsBaseURL         *string
-	ElevenLabsTTSVoiceID      *string
-	AllowedOrigins            []string
-	RAGSystemPrompt           *string
-	RAGGenerateAnswer         *bool
-	RAGKDefault               *int
-	RAGMaxContextChars        *int
-	RAGOversampleFactor       *int
-	RetrievalHybridEnabled    *bool
-	DedupRetrieval            *bool
-	RetrievalMinScore         *float64
-	RerankEnabled             *bool
-	RerankProvider            *string
-	CohereAPIKey              *string
-	CohereBaseURL             *string
-	RerankModel               *string
-	RerankCandidatePool       *int
-	ChunkingStrategy          *string
-	ChunkingMaxTokens         *int
-	ChunkingOverlapTokens     *int
-	IngestGitignore           *bool
-	IngestFollowSymlinks      *bool
-	IngestMaxFileMB           *int
-	IngestPDFMode             *string
-	IngestImagesMode          *string
-	IngestAudioMode           *string
-	IngestArchivesMode        *string
-	IngestExtractor           *string
-	IndexBackend              *string
-	IngestScanCache           *bool
-	IngestWatch               *bool
-	IngestWatchDebounce       *time.Duration
-	STTProvider               *string
-	STTMistralModel           *string
-	STTElevenLabsModel        *string
-	STTElevenLabsLanguageCode *string
-	QualityGatesEnabled       *bool
-	MediaSidecarsDisabled     *bool
-	MediaVariantsGroup        *bool
-	MediaVariantsSelect       *string
-	MediaTranslateEnabled     *bool
-	MediaTranslateTargetLangs []string
-	MediaFilterWords          []string
-	MediaTrimLeadingSilence   *bool
-	MediaSilenceThresholdDB   *float64
-	MediaVAD                  *bool
-	MediaDiarizeEnabled       *bool
-	MediaAudioWindowSec       *int
-	MediaVideoWindowSec       *int
-	MediaClipMaxDurationMS    *int
-	MediaClipMaxBytes         *int
-	ElevenLabsAPIKey          *string
-	ServerTLSCertFile         *string
-	ServerTLSKeyFile          *string
+	IngestDoclingServeURL              *string
+	ElevenLabsBaseURL                  *string
+	ElevenLabsTTSVoiceID               *string
+	AllowedOrigins                     []string
+	RAGSystemPrompt                    *string
+	RAGGenerateAnswer                  *bool
+	RAGKDefault                        *int
+	RAGMaxContextChars                 *int
+	RAGOversampleFactor                *int
+	RetrievalHybridEnabled             *bool
+	DedupRetrieval                     *bool
+	RetrievalMinScore                  *float64
+	RerankEnabled                      *bool
+	RerankProvider                     *string
+	CohereAPIKey                       *string
+	CohereBaseURL                      *string
+	RerankModel                        *string
+	RerankCandidatePool                *int
+	ChunkingStrategy                   *string
+	ChunkingMaxTokens                  *int
+	ChunkingOverlapTokens              *int
+	IngestGitignore                    *bool
+	IngestFollowSymlinks               *bool
+	IngestMaxFileMB                    *int
+	IngestPDFMode                      *string
+	IngestImagesMode                   *string
+	IngestAudioMode                    *string
+	IngestArchivesMode                 *string
+	IngestExtractor                    *string
+	IndexBackend                       *string
+	IngestScanCache                    *bool
+	IngestWatch                        *bool
+	IngestWatchDebounce                *time.Duration
+	STTProvider                        *string
+	STTMistralModel                    *string
+	STTElevenLabsModel                 *string
+	STTElevenLabsLanguageCode          *string
+	QualityGatesEnabled                *bool
+	MediaSidecarsDisabled              *bool
+	MediaVariantsGroup                 *bool
+	MediaVariantsSelect                *string
+	MediaTranslateEnabled              *bool
+	MediaTranslateTargetLangs          []string
+	MediaFilterWords                   []string
+	MediaSubtitlesTTMLEnabled          *bool
+	MediaSubtitlesTTMLAlignToleranceMS *int
+	MediaSubtitlesSMILEnabled          *bool
+	MediaTrimLeadingSilence            *bool
+	MediaSilenceThresholdDB            *float64
+	MediaVAD                           *bool
+	MediaDiarizeEnabled                *bool
+	MediaAudioWindowSec                *int
+	MediaVideoWindowSec                *int
+	MediaClipMaxDurationMS             *int
+	MediaClipMaxBytes                  *int
+	ElevenLabsAPIKey                   *string
+	ServerTLSCertFile                  *string
+	ServerTLSKeyFile                   *string
 	// session timings expressed as YAML duration strings.  populated by
 	// parseConfigYAML's custom parser via setFileScalarValue rather than the
 	// standard yaml.Unmarshal machinery.  struct tags are therefore omitted
@@ -558,55 +592,58 @@ type persistedConfig struct {
 	SessionMaxLifetime       time.Duration `yaml:"session_max_lifetime"`
 	HealthCheckInterval      time.Duration `yaml:"health_check_interval"`
 
-	ElevenLabsBaseURL         string        `yaml:"elevenlabs_base_url"`
-	ElevenLabsTTSVoiceID      string        `yaml:"elevenlabs_tts_voice_id"`
-	AllowedOrigins            []string      `yaml:"allowed_origins"`
-	RAGSystemPrompt           string        `yaml:"rag_system_prompt"`
-	RAGGenerateAnswer         bool          `yaml:"rag_generate_answer"`
-	RAGKDefault               int           `yaml:"rag_k_default"`
-	RAGMaxContextChars        int           `yaml:"rag_max_context_chars"`
-	RAGOversampleFactor       int           `yaml:"rag_oversample_factor"`
-	RetrievalHybridEnabled    bool          `yaml:"retrieval_hybrid_enabled"`
-	DedupRetrieval            bool          `yaml:"dedup_retrieval"`
-	RetrievalMinScore         float64       `yaml:"retrieval_min_score"`
-	RerankEnabled             bool          `yaml:"rerank_enabled"`
-	RerankProvider            string        `yaml:"rerank_provider"`
-	CohereBaseURL             string        `yaml:"cohere_base_url"`
-	RerankModel               string        `yaml:"rerank_model"`
-	RerankCandidatePool       int           `yaml:"rerank_candidate_pool"`
-	ChunkingStrategy          string        `yaml:"chunking_strategy"`
-	ChunkingMaxTokens         int           `yaml:"chunking_max_tokens"`
-	ChunkingOverlapTokens     int           `yaml:"chunking_overlap_tokens"`
-	IngestGitignore           bool          `yaml:"ingest_gitignore"`
-	IngestFollowSymlinks      bool          `yaml:"ingest_follow_symlinks"`
-	IngestMaxFileMB           int           `yaml:"ingest_max_file_mb"`
-	IngestPDFMode             string        `yaml:"ingest_pdf_mode"`
-	IngestImagesMode          string        `yaml:"ingest_images_mode"`
-	IngestAudioMode           string        `yaml:"ingest_audio_mode"`
-	IngestArchivesMode        string        `yaml:"ingest_archives_mode"`
-	IngestExtractor           string        `yaml:"ingest_extractor"`
-	IndexBackend              string        `yaml:"index_backend"`
-	IngestScanCache           bool          `yaml:"ingest_scan_cache"`
-	IngestWatch               bool          `yaml:"ingest_watch"`
-	IngestWatchDebounce       time.Duration `yaml:"ingest_watch_debounce"`
-	STTProvider               string        `yaml:"stt_provider"`
-	STTMistralModel           string        `yaml:"stt_mistral_model"`
-	STTElevenLabsModel        string        `yaml:"stt_elevenlabs_model"`
-	STTElevenLabsLanguageCode string        `yaml:"stt_elevenlabs_language_code"`
-	QualityGatesEnabled       bool          `yaml:"quality_gates_enabled"`
-	MediaSidecarsDisabled     bool          `yaml:"media_sidecars_disabled"`
-	MediaVariantsGroup        bool          `yaml:"media_variants_group"`
-	MediaVariantsSelect       string        `yaml:"media_variants_select"`
-	MediaTranslateEnabled     bool          `yaml:"media_translate_enabled"`
-	MediaTranslateTargetLangs []string      `yaml:"media_translate_target_langs"`
-	MediaFilterWords          []string      `yaml:"media_filter_words"`
-	MediaTrimLeadingSilence   bool          `yaml:"media_trim_leading_silence"`
-	MediaSilenceThresholdDB   float64       `yaml:"media_silence_threshold_db"`
-	MediaVAD                  bool          `yaml:"media_vad"`
-	MediaAudioWindowSec       int           `yaml:"media_audio_window_sec"`
-	MediaVideoWindowSec       int           `yaml:"media_video_window_sec"`
-	MediaClipMaxDurationMS    int           `yaml:"media_clip_max_duration_ms"`
-	MediaClipMaxBytes         int           `yaml:"media_clip_max_bytes"`
+	ElevenLabsBaseURL                  string        `yaml:"elevenlabs_base_url"`
+	ElevenLabsTTSVoiceID               string        `yaml:"elevenlabs_tts_voice_id"`
+	AllowedOrigins                     []string      `yaml:"allowed_origins"`
+	RAGSystemPrompt                    string        `yaml:"rag_system_prompt"`
+	RAGGenerateAnswer                  bool          `yaml:"rag_generate_answer"`
+	RAGKDefault                        int           `yaml:"rag_k_default"`
+	RAGMaxContextChars                 int           `yaml:"rag_max_context_chars"`
+	RAGOversampleFactor                int           `yaml:"rag_oversample_factor"`
+	RetrievalHybridEnabled             bool          `yaml:"retrieval_hybrid_enabled"`
+	DedupRetrieval                     bool          `yaml:"dedup_retrieval"`
+	RetrievalMinScore                  float64       `yaml:"retrieval_min_score"`
+	RerankEnabled                      bool          `yaml:"rerank_enabled"`
+	RerankProvider                     string        `yaml:"rerank_provider"`
+	CohereBaseURL                      string        `yaml:"cohere_base_url"`
+	RerankModel                        string        `yaml:"rerank_model"`
+	RerankCandidatePool                int           `yaml:"rerank_candidate_pool"`
+	ChunkingStrategy                   string        `yaml:"chunking_strategy"`
+	ChunkingMaxTokens                  int           `yaml:"chunking_max_tokens"`
+	ChunkingOverlapTokens              int           `yaml:"chunking_overlap_tokens"`
+	IngestGitignore                    bool          `yaml:"ingest_gitignore"`
+	IngestFollowSymlinks               bool          `yaml:"ingest_follow_symlinks"`
+	IngestMaxFileMB                    int           `yaml:"ingest_max_file_mb"`
+	IngestPDFMode                      string        `yaml:"ingest_pdf_mode"`
+	IngestImagesMode                   string        `yaml:"ingest_images_mode"`
+	IngestAudioMode                    string        `yaml:"ingest_audio_mode"`
+	IngestArchivesMode                 string        `yaml:"ingest_archives_mode"`
+	IngestExtractor                    string        `yaml:"ingest_extractor"`
+	IndexBackend                       string        `yaml:"index_backend"`
+	IngestScanCache                    bool          `yaml:"ingest_scan_cache"`
+	IngestWatch                        bool          `yaml:"ingest_watch"`
+	IngestWatchDebounce                time.Duration `yaml:"ingest_watch_debounce"`
+	STTProvider                        string        `yaml:"stt_provider"`
+	STTMistralModel                    string        `yaml:"stt_mistral_model"`
+	STTElevenLabsModel                 string        `yaml:"stt_elevenlabs_model"`
+	STTElevenLabsLanguageCode          string        `yaml:"stt_elevenlabs_language_code"`
+	QualityGatesEnabled                bool          `yaml:"quality_gates_enabled"`
+	MediaSidecarsDisabled              bool          `yaml:"media_sidecars_disabled"`
+	MediaVariantsGroup                 bool          `yaml:"media_variants_group"`
+	MediaVariantsSelect                string        `yaml:"media_variants_select"`
+	MediaTranslateEnabled              bool          `yaml:"media_translate_enabled"`
+	MediaTranslateTargetLangs          []string      `yaml:"media_translate_target_langs"`
+	MediaFilterWords                   []string      `yaml:"media_filter_words"`
+	MediaSubtitlesTTMLEnabled          bool          `yaml:"media_subtitles_ttml_enabled"`
+	MediaSubtitlesTTMLAlignToleranceMS int           `yaml:"media_subtitles_ttml_align_tolerance_ms"`
+	MediaSubtitlesSMILEnabled          bool          `yaml:"media_subtitles_smil_enabled"`
+	MediaTrimLeadingSilence            bool          `yaml:"media_trim_leading_silence"`
+	MediaSilenceThresholdDB            float64       `yaml:"media_silence_threshold_db"`
+	MediaVAD                           bool          `yaml:"media_vad"`
+	MediaAudioWindowSec                int           `yaml:"media_audio_window_sec"`
+	MediaVideoWindowSec                int           `yaml:"media_video_window_sec"`
+	MediaClipMaxDurationMS             int           `yaml:"media_clip_max_duration_ms"`
+	MediaClipMaxBytes                  int           `yaml:"media_clip_max_bytes"`
 	// MediaDiarizeEnabled is the tri-state diarization opt (SPEC §8.6.8): a
 	// *bool so the snapshot can round-trip omitted (nil) vs. false vs. true
 	// without collapsing the auto/off distinction.
@@ -754,8 +791,14 @@ func Default() Config {
 		MediaVariantsSelect:       "best",
 		MediaTranslateEnabled:     false,
 		MediaTranslateTargetLangs: nil,
-		ServerTLSCertFile:         "",
-		ServerTLSKeyFile:          "",
+		// Bilingual subtitle export (SPEC §8.6.10) is OFF by default; the align
+		// tolerance carries its spec default so an enabled-but-unspecified config
+		// behaves predictably.
+		MediaSubtitlesTTMLEnabled:          false,
+		MediaSubtitlesTTMLAlignToleranceMS: DefaultMediaSubtitlesAlignToleranceMS,
+		MediaSubtitlesSMILEnabled:          false,
+		ServerTLSCertFile:                  "",
+		ServerTLSKeyFile:                   "",
 		X402: X402Config{
 			Mode:             "off",
 			FacilitatorURL:   "",
@@ -800,78 +843,81 @@ func buildPersistedConfig(cfg *Config) persistedConfig {
 	}
 
 	return persistedConfig{
-		RootDir:                   cfg.RootDir,
-		StateDir:                  cfg.StateDir,
-		ListenAddr:                cfg.ListenAddr,
-		MCPPath:                   cfg.MCPPath,
-		ProtocolVersion:           cfg.ProtocolVersion,
-		Public:                    cfg.Public,
-		AuthMode:                  cfg.AuthMode,
-		ServerName:                cfg.ServerName,
-		RateLimitRPS:              cfg.RateLimitRPS,
-		RateLimitBurst:            cfg.RateLimitBurst,
-		TrustedProxies:            append([]string(nil), cfg.TrustedProxies...),
-		PathExcludes:              append([]string(nil), cfg.PathExcludes...),
-		SecretPatterns:            append([]string(nil), cfg.SecretPatterns...),
-		DoclingCommand:            cfg.DoclingCommand,
-		DoclingServeURL:           cfg.IngestDoclingServeURL,
-		SessionInactivityTimeout:  cfg.SessionInactivityTimeout,
-		SessionMaxLifetime:        cfg.SessionMaxLifetime,
-		HealthCheckInterval:       cfg.HealthCheckInterval,
-		ElevenLabsBaseURL:         cfg.ElevenLabsBaseURL,
-		ElevenLabsTTSVoiceID:      cfg.ElevenLabsTTSVoiceID,
-		AllowedOrigins:            append([]string(nil), cfg.AllowedOrigins...),
-		RAGSystemPrompt:           cfg.RAGSystemPrompt,
-		RAGGenerateAnswer:         cfg.RAGGenerateAnswer,
-		RAGKDefault:               cfg.RAGKDefault,
-		RAGMaxContextChars:        cfg.RAGMaxContextChars,
-		RAGOversampleFactor:       cfg.RAGOversampleFactor,
-		RetrievalHybridEnabled:    cfg.RetrievalHybridEnabled,
-		DedupRetrieval:            cfg.DedupRetrieval,
-		RetrievalMinScore:         cfg.RetrievalMinScore,
-		RerankEnabled:             rerankEnabledEffective(cfg),
-		RerankProvider:            cfg.RerankProvider,
-		CohereBaseURL:             cfg.CohereBaseURL,
-		RerankModel:               cfg.RerankModel,
-		RerankCandidatePool:       cfg.RerankCandidatePool,
-		ChunkingStrategy:          cfg.ChunkingStrategy,
-		ChunkingMaxTokens:         cfg.ChunkingMaxTokens,
-		ChunkingOverlapTokens:     cfg.ChunkingOverlapTokens,
-		IngestGitignore:           cfg.IngestGitignore,
-		IngestFollowSymlinks:      cfg.IngestFollowSymlinks,
-		IngestMaxFileMB:           cfg.IngestMaxFileMB,
-		IngestPDFMode:             cfg.IngestPDFMode,
-		IngestImagesMode:          cfg.IngestImagesMode,
-		IngestAudioMode:           cfg.IngestAudioMode,
-		IngestArchivesMode:        cfg.IngestArchivesMode,
-		IngestExtractor:           cfg.IngestExtractor,
-		IndexBackend:              cfg.IndexBackend,
-		IngestScanCache:           cfg.IngestScanCache,
-		IngestWatch:               cfg.IngestWatch,
-		IngestWatchDebounce:       cfg.IngestWatchDebounce,
-		STTProvider:               cfg.STTProvider,
-		STTMistralModel:           cfg.STTMistralModel,
-		STTElevenLabsModel:        cfg.STTElevenLabsModel,
-		STTElevenLabsLanguageCode: cfg.STTElevenLabsLanguageCode,
-		QualityGatesEnabled:       cfg.QualityGatesEnabled,
-		MediaSidecarsDisabled:     cfg.MediaSidecarsDisabled,
-		MediaVariantsGroup:        cfg.MediaVariantsGroup,
-		MediaVariantsSelect:       cfg.MediaVariantsSelect,
-		MediaTranslateEnabled:     cfg.MediaTranslateEnabled,
-		MediaTranslateTargetLangs: append([]string(nil), cfg.MediaTranslateTargetLangs...),
-		MediaFilterWords:          append([]string(nil), cfg.MediaFilterWords...),
-		MediaTrimLeadingSilence:   cfg.MediaTrimLeadingSilence,
-		MediaSilenceThresholdDB:   cfg.MediaSilenceThresholdDB,
-		MediaVAD:                  cfg.MediaVAD,
-		MediaDiarizeEnabled:       copyBoolPtr(cfg.MediaDiarizeEnabled),
-		MediaAudioWindowSec:       cfg.MediaAudioWindowSec,
-		MediaVideoWindowSec:       cfg.MediaVideoWindowSec,
-		MediaClipMaxDurationMS:    cfg.MediaClipMaxDurationMS,
-		MediaClipMaxBytes:         cfg.MediaClipMaxBytes,
-		ServerTLSCertFile:         cfg.ServerTLSCertFile,
-		ServerTLSKeyFile:          cfg.ServerTLSKeyFile,
-		X402Mode:                  cfg.X402.Mode,
-		X402FacilitatorURL:        cfg.X402.FacilitatorURL,
+		RootDir:                            cfg.RootDir,
+		StateDir:                           cfg.StateDir,
+		ListenAddr:                         cfg.ListenAddr,
+		MCPPath:                            cfg.MCPPath,
+		ProtocolVersion:                    cfg.ProtocolVersion,
+		Public:                             cfg.Public,
+		AuthMode:                           cfg.AuthMode,
+		ServerName:                         cfg.ServerName,
+		RateLimitRPS:                       cfg.RateLimitRPS,
+		RateLimitBurst:                     cfg.RateLimitBurst,
+		TrustedProxies:                     append([]string(nil), cfg.TrustedProxies...),
+		PathExcludes:                       append([]string(nil), cfg.PathExcludes...),
+		SecretPatterns:                     append([]string(nil), cfg.SecretPatterns...),
+		DoclingCommand:                     cfg.DoclingCommand,
+		DoclingServeURL:                    cfg.IngestDoclingServeURL,
+		SessionInactivityTimeout:           cfg.SessionInactivityTimeout,
+		SessionMaxLifetime:                 cfg.SessionMaxLifetime,
+		HealthCheckInterval:                cfg.HealthCheckInterval,
+		ElevenLabsBaseURL:                  cfg.ElevenLabsBaseURL,
+		ElevenLabsTTSVoiceID:               cfg.ElevenLabsTTSVoiceID,
+		AllowedOrigins:                     append([]string(nil), cfg.AllowedOrigins...),
+		RAGSystemPrompt:                    cfg.RAGSystemPrompt,
+		RAGGenerateAnswer:                  cfg.RAGGenerateAnswer,
+		RAGKDefault:                        cfg.RAGKDefault,
+		RAGMaxContextChars:                 cfg.RAGMaxContextChars,
+		RAGOversampleFactor:                cfg.RAGOversampleFactor,
+		RetrievalHybridEnabled:             cfg.RetrievalHybridEnabled,
+		DedupRetrieval:                     cfg.DedupRetrieval,
+		RetrievalMinScore:                  cfg.RetrievalMinScore,
+		RerankEnabled:                      rerankEnabledEffective(cfg),
+		RerankProvider:                     cfg.RerankProvider,
+		CohereBaseURL:                      cfg.CohereBaseURL,
+		RerankModel:                        cfg.RerankModel,
+		RerankCandidatePool:                cfg.RerankCandidatePool,
+		ChunkingStrategy:                   cfg.ChunkingStrategy,
+		ChunkingMaxTokens:                  cfg.ChunkingMaxTokens,
+		ChunkingOverlapTokens:              cfg.ChunkingOverlapTokens,
+		IngestGitignore:                    cfg.IngestGitignore,
+		IngestFollowSymlinks:               cfg.IngestFollowSymlinks,
+		IngestMaxFileMB:                    cfg.IngestMaxFileMB,
+		IngestPDFMode:                      cfg.IngestPDFMode,
+		IngestImagesMode:                   cfg.IngestImagesMode,
+		IngestAudioMode:                    cfg.IngestAudioMode,
+		IngestArchivesMode:                 cfg.IngestArchivesMode,
+		IngestExtractor:                    cfg.IngestExtractor,
+		IndexBackend:                       cfg.IndexBackend,
+		IngestScanCache:                    cfg.IngestScanCache,
+		IngestWatch:                        cfg.IngestWatch,
+		IngestWatchDebounce:                cfg.IngestWatchDebounce,
+		STTProvider:                        cfg.STTProvider,
+		STTMistralModel:                    cfg.STTMistralModel,
+		STTElevenLabsModel:                 cfg.STTElevenLabsModel,
+		STTElevenLabsLanguageCode:          cfg.STTElevenLabsLanguageCode,
+		QualityGatesEnabled:                cfg.QualityGatesEnabled,
+		MediaSidecarsDisabled:              cfg.MediaSidecarsDisabled,
+		MediaVariantsGroup:                 cfg.MediaVariantsGroup,
+		MediaVariantsSelect:                cfg.MediaVariantsSelect,
+		MediaTranslateEnabled:              cfg.MediaTranslateEnabled,
+		MediaTranslateTargetLangs:          append([]string(nil), cfg.MediaTranslateTargetLangs...),
+		MediaFilterWords:                   append([]string(nil), cfg.MediaFilterWords...),
+		MediaSubtitlesTTMLEnabled:          cfg.MediaSubtitlesTTMLEnabled,
+		MediaSubtitlesTTMLAlignToleranceMS: cfg.MediaSubtitlesTTMLAlignToleranceMS,
+		MediaSubtitlesSMILEnabled:          cfg.MediaSubtitlesSMILEnabled,
+		MediaTrimLeadingSilence:            cfg.MediaTrimLeadingSilence,
+		MediaSilenceThresholdDB:            cfg.MediaSilenceThresholdDB,
+		MediaVAD:                           cfg.MediaVAD,
+		MediaDiarizeEnabled:                copyBoolPtr(cfg.MediaDiarizeEnabled),
+		MediaAudioWindowSec:                cfg.MediaAudioWindowSec,
+		MediaVideoWindowSec:                cfg.MediaVideoWindowSec,
+		MediaClipMaxDurationMS:             cfg.MediaClipMaxDurationMS,
+		MediaClipMaxBytes:                  cfg.MediaClipMaxBytes,
+		ServerTLSCertFile:                  cfg.ServerTLSCertFile,
+		ServerTLSKeyFile:                   cfg.ServerTLSKeyFile,
+		X402Mode:                           cfg.X402.Mode,
+		X402FacilitatorURL:                 cfg.X402.FacilitatorURL,
 		// token intentionally omitted to avoid persisting secrets
 		// X402FacilitatorToken: cfg.X402.FacilitatorToken,
 		X402ResourceBaseURL:  cfg.X402.ResourceBaseURL,
@@ -1525,6 +1571,15 @@ func applyMediaFileParsed(cfg *Config, fc fileConfig) {
 	if fc.MediaFilterWords != nil {
 		cfg.MediaFilterWords = normalizeStringSlice(fc.MediaFilterWords)
 	}
+	if fc.MediaSubtitlesTTMLEnabled != nil {
+		cfg.MediaSubtitlesTTMLEnabled = *fc.MediaSubtitlesTTMLEnabled
+	}
+	if fc.MediaSubtitlesTTMLAlignToleranceMS != nil {
+		cfg.MediaSubtitlesTTMLAlignToleranceMS = *fc.MediaSubtitlesTTMLAlignToleranceMS
+	}
+	if fc.MediaSubtitlesSMILEnabled != nil {
+		cfg.MediaSubtitlesSMILEnabled = *fc.MediaSubtitlesSMILEnabled
+	}
 	if fc.MediaTrimLeadingSilence != nil {
 		cfg.MediaTrimLeadingSilence = *fc.MediaTrimLeadingSilence
 	}
@@ -1755,122 +1810,125 @@ func nearestSectionPrefix(sectionByIndent map[int]string, indent int) string {
 // configKeyAliases maps legacy/alternate key spellings to their canonical form.
 // Keys not present in the map are returned unchanged by canonicalizeConfigKey.
 var configKeyAliases = map[string]string{
-	"server.listen":                        "listen_addr",
-	"server.mcp_path":                      "mcp_path",
-	"server.name":                          "server_name",
-	"server.protocol_version":              "protocol_version",
-	"server.public":                        "public",
-	"security.auth.mode":                   "auth_mode",
-	"security.allowed_origins":             "allowed_origins",
-	"security.path_excludes":               "path_excludes",
-	"security.secret_patterns":             "secret_patterns",
-	"docling.command":                      "docling_command",
-	"ingest.docling.command":               "docling_command",
-	"docling.serve_url":                    "docling_serve_url",
-	"ingest.docling.serve_url":             "docling_serve_url",
-	"stt.elevenlabs.api_key":               "elevenlabs_api_key",
-	"secrets.elevenlabs_api_key":           "elevenlabs_api_key",
-	"secrets.x402_facilitator_url":         "x402_facilitator_url",
-	"rag_generate_answer":                  "rag.generate_answer",
-	"generate_answer":                      "rag.generate_answer",
-	"rag_k_default":                        "rag.k_default",
-	"k_default":                            "rag.k_default",
-	"rag_system_prompt":                    "rag.system_prompt",
-	"system_prompt":                        "rag.system_prompt",
-	"rag_max_context_chars":                "rag.max_context_chars",
-	"max_context_chars":                    "rag.max_context_chars",
-	"rag_oversample_factor":                "rag.oversample_factor",
-	"oversample_factor":                    "rag.oversample_factor",
-	"retrieval_hybrid_enabled":             "retrieval.hybrid.enabled",
-	"hybrid_enabled":                       "retrieval.hybrid.enabled",
-	"dedup_retrieval":                      "dedup.retrieval",
-	"retrieval_min_score":                  "retrieval.min_score",
-	"min_score":                            "retrieval.min_score",
-	"rerank_enabled":                       "rerank.enabled",
-	"rerank.cohere.api_key":                "cohere_api_key",
-	"rerank.cohere.base_url":               "cohere_base_url",
-	"rerank.cohere.model":                  "rerank_model",
-	"rerank.provider":                      "rerank_provider",
-	"rerank.model":                         "rerank_model",
-	"rerank_candidate_pool":                "rerank.candidate_pool",
-	"chunking_strategy":                    "chunking.strategy",
-	"chunking_max_tokens":                  "chunking.max_tokens",
-	"chunking_overlap_tokens":              "chunking.overlap_tokens",
-	"ingest_gitignore":                     "ingest.gitignore",
-	"gitignore":                            "ingest.gitignore",
-	"ingest_follow_symlinks":               "ingest.follow_symlinks",
-	"follow_symlinks":                      "ingest.follow_symlinks",
-	"ingest_max_file_mb":                   "ingest.max_file_mb",
-	"max_file_mb":                          "ingest.max_file_mb",
-	"ingest_scan_cache":                    "ingest.scan_cache",
-	"scan_cache":                           "ingest.scan_cache",
-	"ingest_watch":                         "ingest.watch",
-	"ingest_watch_debounce":                "ingest.watch_debounce",
-	"ingest_pdf_mode":                      "ingest.pdf.mode",
-	"pdf_mode":                             "ingest.pdf.mode",
-	"ingest_images_mode":                   "ingest.images.mode",
-	"images_mode":                          "ingest.images.mode",
-	"ingest_audio_mode":                    "ingest.audio.mode",
-	"audio_mode":                           "ingest.audio.mode",
-	"ingest_archives_mode":                 "ingest.archives.mode",
-	"archives_mode":                        "ingest.archives.mode",
-	"ingest_extractor":                     "ingest.extractor",
-	"extractor":                            "ingest.extractor",
-	"index_backend":                        "index.backend",
-	"backend":                              "index.backend",
-	"media_variants_group":                 "media.variants.group",
-	"media_variants_select":                "media.variants.select",
-	"media_translate_enabled":              "media.translate.enabled",
-	"media_translate_target_langs":         "media.translate.target_langs",
-	"media_filter_words":                   "media.filter_words",
-	"filter_words":                         "media.filter_words",
-	"media_trim_leading_silence":           "media.trim_leading_silence",
-	"media_silence_threshold_db":           "media.silence_threshold_db",
-	"media_vad":                            "media.vad",
-	"media_diarize_enabled":                "media.diarize.enabled",
-	"media_audio_window_sec":               "media.audio_window_sec",
-	"media_video_window_sec":               "media.video_window_sec",
-	"media_clip_max_duration_ms":           "media.clip.max_duration_ms",
-	"media_clip_max_bytes":                 "media.clip.max_bytes",
-	"stt_provider":                         "stt.provider",
-	"stt_mistral_model":                    "stt.mistral.model",
-	"stt_elevenlabs_model":                 "stt.elevenlabs.model",
-	"stt_elevenlabs_language_code":         "stt.elevenlabs.language_code",
-	"elevenlabs_language_code":             "stt.elevenlabs.language_code",
-	"server_tls_cert_file":                 "server.tls.cert_file",
-	"tls_cert_file":                        "server.tls.cert_file",
-	"cert_file":                            "server.tls.cert_file",
-	"server.tls.cert":                      "server.tls.cert_file",
-	"server_tls_key_file":                  "server.tls.key_file",
-	"tls_key_file":                         "server.tls.key_file",
-	"key_file":                             "server.tls.key_file",
-	"server.tls.key":                       "server.tls.key_file",
-	"x402.mode":                            "x402_mode",
-	"x402.facilitator_url":                 "x402_facilitator_url",
-	"x402.resource_base_url":               "x402_resource_base_url",
-	"x402.facilitator_token":               "x402_facilitator_token",
-	"x402.route_policy.tools_call.enabled": "x402_tools_call_enabled",
-	"x402.route_policy.tools_call.price":   "x402_price_atomic",
-	"x402.route_policy.tools_call.network": "x402_network",
-	"x402.route_policy.tools_call.scheme":  "x402_scheme",
-	"x402.route_policy.tools_call.asset":   "x402_asset",
-	"x402.route_policy.tools_call.pay_to":  "x402_pay_to",
-	"source.kind":                          "source_kind",
-	"source.s3.bucket":                     "source_s3_bucket",
-	"source.s3.prefix":                     "source_s3_prefix",
-	"source.s3.region":                     "source_s3_region",
-	"source.s3.endpoint":                   "source_s3_endpoint",
-	"index.qdrant.url":                     "qdrant_url",
-	"index.qdrant.collection":              "qdrant_collection",
-	"index.qdrant.api_key":                 "qdrant_api_key",
-	"index.pgvector.dsn":                   "index_pgvector_dsn",
-	"index.pgvector.schema":                "index_pgvector_schema",
-	"index.pgvector.table":                 "index_pgvector_table",
-	"distributed_embed.enabled":            "distributed_embed_enabled",
-	"distributed_embed.broker":             "distributed_embed_broker",
-	"distributed_embed.sqlite_path":        "distributed_embed_sqlite_path",
-	"distributed_embed.broker_url":         "distributed_embed_broker_url",
-	"distributed_embed.max_attempts":       "distributed_embed_max_attempts",
+	"server.listen":                           "listen_addr",
+	"server.mcp_path":                         "mcp_path",
+	"server.name":                             "server_name",
+	"server.protocol_version":                 "protocol_version",
+	"server.public":                           "public",
+	"security.auth.mode":                      "auth_mode",
+	"security.allowed_origins":                "allowed_origins",
+	"security.path_excludes":                  "path_excludes",
+	"security.secret_patterns":                "secret_patterns",
+	"docling.command":                         "docling_command",
+	"ingest.docling.command":                  "docling_command",
+	"docling.serve_url":                       "docling_serve_url",
+	"ingest.docling.serve_url":                "docling_serve_url",
+	"stt.elevenlabs.api_key":                  "elevenlabs_api_key",
+	"secrets.elevenlabs_api_key":              "elevenlabs_api_key",
+	"secrets.x402_facilitator_url":            "x402_facilitator_url",
+	"rag_generate_answer":                     "rag.generate_answer",
+	"generate_answer":                         "rag.generate_answer",
+	"rag_k_default":                           "rag.k_default",
+	"k_default":                               "rag.k_default",
+	"rag_system_prompt":                       "rag.system_prompt",
+	"system_prompt":                           "rag.system_prompt",
+	"rag_max_context_chars":                   "rag.max_context_chars",
+	"max_context_chars":                       "rag.max_context_chars",
+	"rag_oversample_factor":                   "rag.oversample_factor",
+	"oversample_factor":                       "rag.oversample_factor",
+	"retrieval_hybrid_enabled":                "retrieval.hybrid.enabled",
+	"hybrid_enabled":                          "retrieval.hybrid.enabled",
+	"dedup_retrieval":                         "dedup.retrieval",
+	"retrieval_min_score":                     "retrieval.min_score",
+	"min_score":                               "retrieval.min_score",
+	"rerank_enabled":                          "rerank.enabled",
+	"rerank.cohere.api_key":                   "cohere_api_key",
+	"rerank.cohere.base_url":                  "cohere_base_url",
+	"rerank.cohere.model":                     "rerank_model",
+	"rerank.provider":                         "rerank_provider",
+	"rerank.model":                            "rerank_model",
+	"rerank_candidate_pool":                   "rerank.candidate_pool",
+	"chunking_strategy":                       "chunking.strategy",
+	"chunking_max_tokens":                     "chunking.max_tokens",
+	"chunking_overlap_tokens":                 "chunking.overlap_tokens",
+	"ingest_gitignore":                        "ingest.gitignore",
+	"gitignore":                               "ingest.gitignore",
+	"ingest_follow_symlinks":                  "ingest.follow_symlinks",
+	"follow_symlinks":                         "ingest.follow_symlinks",
+	"ingest_max_file_mb":                      "ingest.max_file_mb",
+	"max_file_mb":                             "ingest.max_file_mb",
+	"ingest_scan_cache":                       "ingest.scan_cache",
+	"scan_cache":                              "ingest.scan_cache",
+	"ingest_watch":                            "ingest.watch",
+	"ingest_watch_debounce":                   "ingest.watch_debounce",
+	"ingest_pdf_mode":                         "ingest.pdf.mode",
+	"pdf_mode":                                "ingest.pdf.mode",
+	"ingest_images_mode":                      "ingest.images.mode",
+	"images_mode":                             "ingest.images.mode",
+	"ingest_audio_mode":                       "ingest.audio.mode",
+	"audio_mode":                              "ingest.audio.mode",
+	"ingest_archives_mode":                    "ingest.archives.mode",
+	"archives_mode":                           "ingest.archives.mode",
+	"ingest_extractor":                        "ingest.extractor",
+	"extractor":                               "ingest.extractor",
+	"index_backend":                           "index.backend",
+	"backend":                                 "index.backend",
+	"media_variants_group":                    "media.variants.group",
+	"media_variants_select":                   "media.variants.select",
+	"media_translate_enabled":                 "media.translate.enabled",
+	"media_translate_target_langs":            "media.translate.target_langs",
+	"media_filter_words":                      "media.filter_words",
+	"filter_words":                            "media.filter_words",
+	"media_subtitles_ttml_enabled":            "media.subtitles.ttml.enabled",
+	"media_subtitles_ttml_align_tolerance_ms": "media.subtitles.ttml.align_tolerance_ms",
+	"media_subtitles_smil_enabled":            "media.subtitles.smil.enabled",
+	"media_trim_leading_silence":              "media.trim_leading_silence",
+	"media_silence_threshold_db":              "media.silence_threshold_db",
+	"media_vad":                               "media.vad",
+	"media_diarize_enabled":                   "media.diarize.enabled",
+	"media_audio_window_sec":                  "media.audio_window_sec",
+	"media_video_window_sec":                  "media.video_window_sec",
+	"media_clip_max_duration_ms":              "media.clip.max_duration_ms",
+	"media_clip_max_bytes":                    "media.clip.max_bytes",
+	"stt_provider":                            "stt.provider",
+	"stt_mistral_model":                       "stt.mistral.model",
+	"stt_elevenlabs_model":                    "stt.elevenlabs.model",
+	"stt_elevenlabs_language_code":            "stt.elevenlabs.language_code",
+	"elevenlabs_language_code":                "stt.elevenlabs.language_code",
+	"server_tls_cert_file":                    "server.tls.cert_file",
+	"tls_cert_file":                           "server.tls.cert_file",
+	"cert_file":                               "server.tls.cert_file",
+	"server.tls.cert":                         "server.tls.cert_file",
+	"server_tls_key_file":                     "server.tls.key_file",
+	"tls_key_file":                            "server.tls.key_file",
+	"key_file":                                "server.tls.key_file",
+	"server.tls.key":                          "server.tls.key_file",
+	"x402.mode":                               "x402_mode",
+	"x402.facilitator_url":                    "x402_facilitator_url",
+	"x402.resource_base_url":                  "x402_resource_base_url",
+	"x402.facilitator_token":                  "x402_facilitator_token",
+	"x402.route_policy.tools_call.enabled":    "x402_tools_call_enabled",
+	"x402.route_policy.tools_call.price":      "x402_price_atomic",
+	"x402.route_policy.tools_call.network":    "x402_network",
+	"x402.route_policy.tools_call.scheme":     "x402_scheme",
+	"x402.route_policy.tools_call.asset":      "x402_asset",
+	"x402.route_policy.tools_call.pay_to":     "x402_pay_to",
+	"source.kind":                             "source_kind",
+	"source.s3.bucket":                        "source_s3_bucket",
+	"source.s3.prefix":                        "source_s3_prefix",
+	"source.s3.region":                        "source_s3_region",
+	"source.s3.endpoint":                      "source_s3_endpoint",
+	"index.qdrant.url":                        "qdrant_url",
+	"index.qdrant.collection":                 "qdrant_collection",
+	"index.qdrant.api_key":                    "qdrant_api_key",
+	"index.pgvector.dsn":                      "index_pgvector_dsn",
+	"index.pgvector.schema":                   "index_pgvector_schema",
+	"index.pgvector.table":                    "index_pgvector_table",
+	"distributed_embed.enabled":               "distributed_embed_enabled",
+	"distributed_embed.broker":                "distributed_embed_broker",
+	"distributed_embed.sqlite_path":           "distributed_embed_sqlite_path",
+	"distributed_embed.broker_url":            "distributed_embed_broker_url",
+	"distributed_embed.max_attempts":          "distributed_embed_max_attempts",
 }
 
 // canonicalizeConfigKey lower-cases and trims key and maps it through
@@ -1944,6 +2002,12 @@ var boolFileScalarTargets = map[string]func(*fileConfig) **bool{
 	"media_sidecars_disabled": func(c *fileConfig) **bool { return &c.MediaSidecarsDisabled },
 	"media.variants.group":    func(c *fileConfig) **bool { return &c.MediaVariantsGroup },
 	"media.translate.enabled": func(c *fileConfig) **bool { return &c.MediaTranslateEnabled },
+	"media.subtitles.ttml.enabled": func(c *fileConfig) **bool {
+		return &c.MediaSubtitlesTTMLEnabled
+	},
+	"media.subtitles.smil.enabled": func(c *fileConfig) **bool {
+		return &c.MediaSubtitlesSMILEnabled
+	},
 	"media.trim_leading_silence": func(c *fileConfig) **bool {
 		return &c.MediaTrimLeadingSilence
 	},
@@ -1992,6 +2056,9 @@ var intFileScalarTargets = map[string]func(*fileConfig) **int{
 	"media.video_window_sec":     func(c *fileConfig) **int { return &c.MediaVideoWindowSec },
 	"media.clip.max_duration_ms": func(c *fileConfig) **int { return &c.MediaClipMaxDurationMS },
 	"media.clip.max_bytes":       func(c *fileConfig) **int { return &c.MediaClipMaxBytes },
+	"media.subtitles.ttml.align_tolerance_ms": func(c *fileConfig) **int {
+		return &c.MediaSubtitlesTTMLAlignToleranceMS
+	},
 	"distributed_embed_max_attempts": func(c *fileConfig) **int {
 		return &c.DistributedEmbedMaxAttempts
 	},
@@ -2018,10 +2085,11 @@ func setIntFileScalar(cfg *fileConfig, key, value string) error {
 // be negative. A negative value is rejected at config-parse time (explicit,
 // deterministic) rather than being silently clamped later.
 var nonNegativeIntKeys = map[string]bool{
-	"media.audio_window_sec":     true,
-	"media.video_window_sec":     true,
-	"media.clip.max_duration_ms": true,
-	"media.clip.max_bytes":       true,
+	"media.audio_window_sec":                  true,
+	"media.video_window_sec":                  true,
+	"media.clip.max_duration_ms":              true,
+	"media.clip.max_bytes":                    true,
+	"media.subtitles.ttml.align_tolerance_ms": true,
 }
 
 // setFloatFileScalar parses value as a float64 and assigns it to the
@@ -2377,6 +2445,9 @@ func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	writeBool("media_translate_enabled", cfg.MediaTranslateEnabled)
 	writeList("media_translate_target_langs", cfg.MediaTranslateTargetLangs)
 	writeList("media_filter_words", cfg.MediaFilterWords)
+	writeBool("media_subtitles_ttml_enabled", cfg.MediaSubtitlesTTMLEnabled)
+	writeInt("media_subtitles_ttml_align_tolerance_ms", cfg.MediaSubtitlesTTMLAlignToleranceMS)
+	writeBool("media_subtitles_smil_enabled", cfg.MediaSubtitlesSMILEnabled)
 	writeBool("media_trim_leading_silence", cfg.MediaTrimLeadingSilence)
 	writeScalar("media_silence_threshold_db", strconv.FormatFloat(cfg.MediaSilenceThresholdDB, 'f', -1, 64))
 	writeBool("media_vad", cfg.MediaVAD)
@@ -2830,6 +2901,10 @@ func (c *Config) Validate() error {
 		return err
 	}
 
+	if err := c.validateMediaSubtitles(); err != nil {
+		return err
+	}
+
 	if err := c.validateMediaDiarize(); err != nil {
 		return err
 	}
@@ -2910,6 +2985,22 @@ func (c *Config) validateMediaTranslate() error {
 			"media.translate.target_langs (no default target language)")
 	}
 	c.MediaTranslateTargetLangs = out
+	return nil
+}
+
+// validateMediaSubtitles enforces the optional bilingual subtitle-export config
+// invariants (SPEC §8.6.10): the surface is off by default and additive, so
+// nothing is validated against translation/STT state here. The align tolerance
+// has a spec default (2500 ms); a zero/omitted value is normalized to the
+// default and a negative value is rejected (a tolerance cannot be negative).
+func (c *Config) validateMediaSubtitles() error {
+	if c.MediaSubtitlesTTMLAlignToleranceMS < 0 {
+		return fmt.Errorf("media.subtitles.ttml.align_tolerance_ms must not be negative: %d",
+			c.MediaSubtitlesTTMLAlignToleranceMS)
+	}
+	if c.MediaSubtitlesTTMLAlignToleranceMS == 0 {
+		c.MediaSubtitlesTTMLAlignToleranceMS = DefaultMediaSubtitlesAlignToleranceMS
+	}
 	return nil
 }
 

--- a/internal/subtitle/bilingual.go
+++ b/internal/subtitle/bilingual.go
@@ -1,0 +1,236 @@
+package subtitle
+
+import (
+	"encoding/xml"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// BilingualCue is a TTML cue carrying one or two language-tagged text runs over
+// a single time region (SPEC §8.6.10). PrimaryText/PrimaryLang is always set;
+// SecondaryText/SecondaryLang are set when a secondary-language segment aligned
+// to this cue's time region within tolerance. Both runs map back to the SAME
+// transcript segment span — StartMS/EndMS — so a rendered cue stays traceable to
+// its chunk timing (§8.6.1).
+type BilingualCue struct {
+	StartMS int
+	EndMS   int
+
+	PrimaryLang string
+	PrimaryText string
+	Speaker     string
+
+	SecondaryLang string
+	SecondaryText string
+}
+
+// DefaultAlignToleranceMS mirrors the spec/config default
+// (media.subtitles.ttml.align_tolerance_ms, SPEC §8.6.10) so callers that do not
+// thread a configured tolerance still align deterministically.
+const DefaultAlignToleranceMS = 2500
+
+// AlignBilingual aligns secondary-language cues onto primary-language cues for
+// bilingual TTML export (SPEC §8.6.10). The primary cues define the cue set and
+// their time regions are authoritative; each secondary cue is merged into the
+// primary cue whose start is closest to the secondary's start within
+// toleranceMS. A secondary cue with no primary cue in tolerance is emitted as
+// its own secondary-only cue (never dropped). Alignment is deterministic: inputs
+// are sorted by (start,end), the nearest-start primary wins, ties break to the
+// earlier primary, and a primary already carrying a secondary run keeps its
+// first match so a later secondary falls through to its own cue.
+//
+// A non-positive toleranceMS falls back to DefaultAlignToleranceMS. Passing nil
+// secondary cues yields the primaries rendered as monolingual bilingual cues.
+func AlignBilingual(primary, secondary []Cue, primaryLang, secondaryLang string, toleranceMS int) []BilingualCue {
+	if toleranceMS <= 0 {
+		toleranceMS = DefaultAlignToleranceMS
+	}
+
+	prim := sortedByStart(primary)
+	sec := sortedByStart(secondary)
+
+	out := make([]BilingualCue, len(prim))
+	assigned := make([]bool, len(prim))
+	for i, p := range prim {
+		out[i] = BilingualCue{
+			StartMS:     p.StartMS,
+			EndMS:       p.EndMS,
+			PrimaryLang: primaryLang,
+			PrimaryText: strings.TrimSpace(p.Text),
+			Speaker:     strings.TrimSpace(p.Speaker),
+		}
+	}
+
+	var orphans []BilingualCue
+	for _, s := range sec {
+		idx := nearestPrimary(prim, assigned, s.StartMS, toleranceMS)
+		if idx < 0 {
+			// No primary within tolerance (or all candidates already carry a
+			// secondary run): emit the secondary as its own cue rather than drop
+			// it (SPEC §8.6.10).
+			orphans = append(orphans, BilingualCue{
+				StartMS:       s.StartMS,
+				EndMS:         s.EndMS,
+				PrimaryLang:   secondaryLang,
+				PrimaryText:   strings.TrimSpace(s.Text),
+				Speaker:       strings.TrimSpace(s.Speaker),
+				SecondaryLang: "",
+			})
+			continue
+		}
+		out[idx].SecondaryLang = secondaryLang
+		out[idx].SecondaryText = strings.TrimSpace(s.Text)
+		assigned[idx] = true
+	}
+
+	merged := append(out, orphans...)
+	sort.SliceStable(merged, func(i, j int) bool {
+		if merged[i].StartMS != merged[j].StartMS {
+			return merged[i].StartMS < merged[j].StartMS
+		}
+		return merged[i].EndMS < merged[j].EndMS
+	})
+	return merged
+}
+
+// nearestPrimary returns the index of the unassigned primary cue whose start is
+// closest to startMS within toleranceMS, or -1 when none qualifies. Ties (equal
+// distance) resolve to the earlier (lower-index) primary for determinism.
+func nearestPrimary(prim []Cue, assigned []bool, startMS, toleranceMS int) int {
+	best := -1
+	bestDelta := toleranceMS + 1
+	for i, p := range prim {
+		if assigned[i] {
+			continue
+		}
+		delta := startMS - p.StartMS
+		if delta < 0 {
+			delta = -delta
+		}
+		if delta <= toleranceMS && delta < bestDelta {
+			best = i
+			bestDelta = delta
+		}
+	}
+	return best
+}
+
+// sortedByStart returns a copy of cues ordered by (start, end) so alignment and
+// rendering are deterministic regardless of input order. Empty-text cues are
+// dropped (nothing to display).
+func sortedByStart(cues []Cue) []Cue {
+	out := make([]Cue, 0, len(cues))
+	for _, c := range cues {
+		if strings.TrimSpace(c.Text) == "" {
+			continue
+		}
+		out = append(out, c)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].StartMS != out[j].StartMS {
+			return out[i].StartMS < out[j].StartMS
+		}
+		return out[i].EndMS < out[j].EndMS
+	})
+	return out
+}
+
+// MonolingualBilingualCues wraps a single language's cues as BilingualCues with
+// no secondary run, the input shape for monolingual TTML export.
+func MonolingualBilingualCues(cues []Cue, lang string) []BilingualCue {
+	src := sortedByStart(cues)
+	out := make([]BilingualCue, 0, len(src))
+	for _, c := range src {
+		out = append(out, BilingualCue{
+			StartMS:     c.StartMS,
+			EndMS:       c.EndMS,
+			PrimaryLang: lang,
+			PrimaryText: strings.TrimSpace(c.Text),
+			Speaker:     strings.TrimSpace(c.Speaker),
+		})
+	}
+	return out
+}
+
+// RenderTTML serializes bilingual cues as a TTML (Timed Text Markup Language)
+// document. Each cue becomes a <p> with begin/end timing; its primary and (when
+// present) secondary text runs are emitted as language-tagged <span xml:lang>
+// children over the SAME time region (SPEC §8.6.10), so both languages remain
+// traceable to the cue's transcript span. Speaker markup is intentionally not
+// emitted here: TTML voice markup is optional (§8.6.8) and omitting it keeps the
+// text runs clean and the output portable (fail open).
+//
+// docLang is the document-level xml:lang (typically the primary language).
+// Rendering is deterministic for a given cue slice.
+func RenderTTML(cues []BilingualCue, docLang string) string {
+	var b strings.Builder
+	b.WriteString(`<?xml version="1.0" encoding="UTF-8"?>` + "\n")
+	b.WriteString(`<tt xmlns="http://www.w3.org/ns/ttml" xml:lang="`)
+	b.WriteString(escapeAttr(docLang))
+	b.WriteString("\">\n")
+	b.WriteString("  <body>\n")
+	b.WriteString("    <div>\n")
+	for _, c := range cues {
+		if strings.TrimSpace(c.PrimaryText) == "" && strings.TrimSpace(c.SecondaryText) == "" {
+			continue
+		}
+		fmt.Fprintf(&b, "      <p begin=%q end=%q>\n",
+			formatTimestampTTML(c.StartMS), formatTimestampTTML(c.EndMS))
+		writeTTMLRun(&b, c.PrimaryLang, c.PrimaryText)
+		if strings.TrimSpace(c.SecondaryText) != "" {
+			writeTTMLRun(&b, c.SecondaryLang, c.SecondaryText)
+		}
+		b.WriteString("      </p>\n")
+	}
+	b.WriteString("    </div>\n")
+	b.WriteString("  </body>\n")
+	b.WriteString("</tt>\n")
+	return b.String()
+}
+
+// writeTTMLRun writes one language-tagged text run as a <span xml:lang="..">
+// child. Newlines in the text become <br/> so multi-line cues render. Text and
+// the language tag are XML-escaped. A run with an empty language tag omits the
+// xml:lang attribute (the document-level lang applies).
+func writeTTMLRun(b *strings.Builder, lang, text string) {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return
+	}
+	if lang = strings.TrimSpace(lang); lang != "" {
+		fmt.Fprintf(b, "        <span xml:lang=%q>", lang)
+	} else {
+		b.WriteString("        <span>")
+	}
+	b.WriteString(escapeTTMLText(text))
+	b.WriteString("</span>\n")
+}
+
+// escapeTTMLText XML-escapes cue text and converts newlines to <br/> so a
+// multi-line cue renders correctly inside a <span>.
+func escapeTTMLText(s string) string {
+	lines := strings.Split(s, "\n")
+	for i, l := range lines {
+		lines[i] = escapeText(l)
+	}
+	return strings.Join(lines, "<br/>")
+}
+
+// escapeText XML-escapes character data.
+func escapeText(s string) string {
+	var b strings.Builder
+	_ = xml.EscapeText(&b, []byte(s))
+	return b.String()
+}
+
+// escapeAttr XML-escapes a value destined for a double-quoted attribute.
+func escapeAttr(s string) string {
+	return escapeText(s)
+}
+
+// formatTimestampTTML renders ms as a TTML clock-time "HH:MM:SS.mmm".
+func formatTimestampTTML(ms int) string {
+	h, m, s, msec := splitTimestamp(ms)
+	return fmt.Sprintf("%02d:%02d:%02d.%03d", h, m, s, msec)
+}

--- a/internal/subtitle/smil.go
+++ b/internal/subtitle/smil.go
@@ -1,0 +1,91 @@
+package subtitle
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/dirstral/dir2mcp/internal/avutil"
+)
+
+// SMILSubtitleRef names a companion subtitle document referenced by a SMIL
+// packaging file: the relative Src (e.g. "clip.ttml") and its Lang (BCP-47),
+// used for the <textstream> systemLanguage attribute.
+type SMILSubtitleRef struct {
+	Src  string
+	Lang string
+}
+
+// SMILInput is the data a SMIL packaging document is rendered from (SPEC
+// §8.6.10): the media reference plus probed track metadata and the companion
+// subtitle document(s). MediaSrc is the relative media reference; Info carries
+// the ffprobe-derived metadata (any field may be zero — see fail-open below).
+type SMILInput struct {
+	MediaSrc  string
+	Info      avutil.MediaInfo
+	Subtitles []SMILSubtitleRef
+}
+
+// RenderSMIL serializes a SMIL packaging document describing the media
+// presentation: the media reference plus probed container/codec/bitrate and
+// (for video) width/height, and references to the companion subtitle
+// document(s) (SPEC §8.6.10). Unknown metadata fields are simply omitted from
+// the output (a zero width/height omits the region size, an empty codec omits
+// the param) — this is the fail-open contract: a partial probe still yields a
+// valid SMIL, and a caller that could not probe at all should omit SMIL
+// entirely rather than call this with an empty MediaSrc.
+//
+// Rendering is deterministic for a given input.
+func RenderSMIL(in SMILInput) string {
+	var b strings.Builder
+	b.WriteString(`<?xml version="1.0" encoding="UTF-8"?>` + "\n")
+	b.WriteString(`<smil xmlns="http://www.w3.org/ns/SMIL" version="3.0">` + "\n")
+
+	b.WriteString("  <head>\n")
+	writeMeta(&b, "container", in.Info.Container)
+	writeMeta(&b, "videoCodec", in.Info.VideoCodec)
+	writeMeta(&b, "audioCodec", in.Info.AudioCodec)
+	if in.Info.BitRateBPS > 0 {
+		writeMeta(&b, "bitrate", strconv.Itoa(in.Info.BitRateBPS))
+	}
+	if in.Info.HasVideo() {
+		fmt.Fprintf(&b, "    <layout>\n      <root-layout width=%q height=%q/>\n    </layout>\n",
+			strconv.Itoa(in.Info.Width), strconv.Itoa(in.Info.Height))
+	}
+	b.WriteString("  </head>\n")
+
+	b.WriteString("  <body>\n")
+	b.WriteString("    <par>\n")
+	if in.Info.HasVideo() {
+		fmt.Fprintf(&b, "      <video src=%q width=%q height=%q/>\n",
+			escapeAttr(in.MediaSrc), strconv.Itoa(in.Info.Width), strconv.Itoa(in.Info.Height))
+	} else {
+		fmt.Fprintf(&b, "      <audio src=%q/>\n", escapeAttr(in.MediaSrc))
+	}
+	for _, sub := range in.Subtitles {
+		src := strings.TrimSpace(sub.Src)
+		if src == "" {
+			continue
+		}
+		if lang := strings.TrimSpace(sub.Lang); lang != "" {
+			fmt.Fprintf(&b, "      <textstream src=%q systemLanguage=%q/>\n",
+				escapeAttr(src), escapeAttr(lang))
+		} else {
+			fmt.Fprintf(&b, "      <textstream src=%q/>\n", escapeAttr(src))
+		}
+	}
+	b.WriteString("    </par>\n")
+	b.WriteString("  </body>\n")
+	b.WriteString("</smil>\n")
+	return b.String()
+}
+
+// writeMeta emits a SMIL <meta name=.. content=../> line, skipping empty values
+// so an unreported metadata field is simply absent (fail open).
+func writeMeta(b *strings.Builder, name, value string) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return
+	}
+	fmt.Fprintf(b, "    <meta name=%q content=%q/>\n", escapeAttr(name), escapeAttr(value))
+}

--- a/tests/avutil/mediainfo_test.go
+++ b/tests/avutil/mediainfo_test.go
@@ -1,0 +1,87 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/avutil"
+)
+
+// TestParseMediaInfoFull pins decoding of a complete ffprobe -of json payload:
+// container/bitrate from format, and the first video + first audio stream codecs
+// and the video dimensions.
+func TestParseMediaInfoFull(t *testing.T) {
+	raw := []byte(`{
+	  "streams": [
+	    {"codec_type":"video","codec_name":"h264","width":1920,"height":1080},
+	    {"codec_type":"audio","codec_name":"aac"}
+	  ],
+	  "format": {"format_name":"mov,mp4,m4a,3gp,3g2,mj2","bit_rate":"1500000"}
+	}`)
+	info, err := avutil.ParseMediaInfo(raw)
+	if err != nil {
+		t.Fatalf("ParseMediaInfo: %v", err)
+	}
+	if info.Container != "mov,mp4,m4a,3gp,3g2,mj2" {
+		t.Fatalf("container = %q", info.Container)
+	}
+	if info.VideoCodec != "h264" || info.AudioCodec != "aac" {
+		t.Fatalf("codecs = %q/%q", info.VideoCodec, info.AudioCodec)
+	}
+	if info.BitRateBPS != 1500000 {
+		t.Fatalf("bitrate = %d", info.BitRateBPS)
+	}
+	if info.Width != 1920 || info.Height != 1080 || !info.HasVideo() {
+		t.Fatalf("dimensions = %dx%d (hasVideo=%v)", info.Width, info.Height, info.HasVideo())
+	}
+}
+
+// TestParseMediaInfoAudioOnly pins that an audio-only payload yields no video
+// codec/dimensions and HasVideo() is false, so SMIL falls back to <audio>.
+func TestParseMediaInfoAudioOnly(t *testing.T) {
+	raw := []byte(`{
+	  "streams": [{"codec_type":"audio","codec_name":"mp3"}],
+	  "format": {"format_name":"mp3","bit_rate":"128000"}
+	}`)
+	info, err := avutil.ParseMediaInfo(raw)
+	if err != nil {
+		t.Fatalf("ParseMediaInfo: %v", err)
+	}
+	if info.HasVideo() {
+		t.Fatalf("audio-only must not report video")
+	}
+	if info.AudioCodec != "mp3" || info.BitRateBPS != 128000 {
+		t.Fatalf("audio info wrong: %+v", info)
+	}
+}
+
+// TestParseMediaInfoPartial pins fail-open decoding: a payload missing bitrate /
+// dimensions yields a partial MediaInfo (zero fields) rather than an error.
+func TestParseMediaInfoPartial(t *testing.T) {
+	raw := []byte(`{"streams":[{"codec_type":"video","codec_name":"vp9"}],"format":{"format_name":"webm","bit_rate":"N/A"}}`)
+	info, err := avutil.ParseMediaInfo(raw)
+	if err != nil {
+		t.Fatalf("ParseMediaInfo: %v", err)
+	}
+	if info.VideoCodec != "vp9" {
+		t.Fatalf("video codec = %q", info.VideoCodec)
+	}
+	if info.BitRateBPS != 0 || info.HasVideo() {
+		t.Fatalf("partial info should have zero bitrate/dimensions: %+v", info)
+	}
+}
+
+// TestProbeMediaInfoToolNotFound pins the fail-open contract: when ffprobe is
+// absent, ProbeMediaInfo returns ErrToolNotFound so callers omit SMIL. Skipped
+// when ffprobe IS installed (then there is no "not found" path to assert).
+func TestProbeMediaInfoToolNotFound(t *testing.T) {
+	if _, err := exec.LookPath("ffprobe"); err == nil {
+		t.Skip("ffprobe is installed; the not-found path is unobservable here")
+	}
+	_, err := avutil.ProbeMediaInfo(context.Background(), "/nonexistent/media.mp4")
+	if !errors.Is(err, avutil.ErrToolNotFound) {
+		t.Fatalf("expected ErrToolNotFound, got %v", err)
+	}
+}

--- a/tests/cli/export_ttml_test.go
+++ b/tests/cli/export_ttml_test.go
@@ -1,0 +1,231 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/cli"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// seedBilingualStore writes a sqlite store holding one document with two
+// transcript representations (primary + secondary language, keyed by meta_json),
+// each with two time-spanned chunks, so the bilingual TTML export path can
+// resolve both languages.
+func seedBilingualStore(t *testing.T, stateDir, relPath string) {
+	t.Helper()
+	ctx := context.Background()
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	st := store.NewSQLiteStore(filepath.Join(stateDir, "meta.sqlite"))
+	defer func() { _ = st.Close() }()
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if err := st.UpsertDocument(ctx, model.Document{
+		RelPath: relPath, DocType: "audio", SourceType: "local", Status: "ok",
+	}); err != nil {
+		t.Fatalf("UpsertDocument: %v", err)
+	}
+	doc, err := st.GetDocumentByPath(ctx, relPath)
+	if err != nil {
+		t.Fatalf("GetDocumentByPath: %v", err)
+	}
+
+	type langRep struct {
+		repType string
+		meta    string
+		hash    string
+		chunks  [][3]any // text, startMS, endMS
+	}
+	// Per-language transcripts coexist under distinct rep_types
+	// ("transcript-<lang>") per the store's UNIQUE(doc_id, rep_type) constraint
+	// (SPEC §8.6.2/§8.6.4); TranscriptRepresentations reads both bare and suffixed
+	// forms. This mirrors how the translation surface persists a translated
+	// transcript alongside the source.
+	reps := []langRep{
+		{"transcript-en", `{"language":"en"}`, "en1", [][3]any{{"Hello", 0, 2000}, {"World", 5000, 7000}}},
+		// French start offsets are within the default 2500 ms tolerance of the
+		// English cues, so they align onto the same time regions.
+		{"transcript-fr", `{"language":"fr"}`, "fr1", [][3]any{{"Bonjour", 200, 2100}, {"Monde", 5100, 7100}}},
+	}
+	err = st.WithTx(ctx, func(tx model.RepresentationStore) error {
+		for _, r := range reps {
+			repID, rerr := tx.UpsertRepresentation(ctx, model.Representation{
+				DocID: doc.DocID, RepType: r.repType, RepHash: r.hash, MetaJSON: r.meta,
+			})
+			if rerr != nil {
+				return rerr
+			}
+			for i, c := range r.chunks {
+				if _, cerr := tx.InsertChunkWithSpans(ctx,
+					model.Chunk{RepID: repID, Ordinal: i, Text: c[0].(string), IndexKind: "text"},
+					[]model.Span{{Kind: "time", StartMS: c[1].(int), EndMS: c[2].(int)}},
+				); cerr != nil {
+					return cerr
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("seed transcripts: %v", err)
+	}
+}
+
+// writeTTMLConfig writes a minimal config file enabling the TTML/SMIL surface,
+// returning its path for use via the --config global flag.
+func writeTTMLConfig(t *testing.T, dir string, smil bool) string {
+	t.Helper()
+	path := filepath.Join(dir, "dir2mcp.yaml")
+	lines := []string{
+		"media_subtitles_ttml_enabled: true",
+	}
+	if smil {
+		lines = append(lines, "media_subtitles_smil_enabled: true")
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}
+
+// TestExportTTMLDisabledByDefault pins that without enabling config, --format
+// ttml is rejected: the optional surface is OFF by default (SPEC §8.6.10) and
+// VTT/SRT behavior is unchanged.
+func TestExportTTMLDisabledByDefault(t *testing.T) {
+	tmp := t.TempDir()
+	seedExportStore(t, filepath.Join(tmp, ".dir2mcp"), "media/talk.mp3", `{"language":"en"}`)
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	withWorkingDir(t, tmp, func() {
+		code := app.RunWithContext(context.Background(),
+			[]string{"export", "--format", "ttml", "media/talk.mp3"})
+		if code == 0 {
+			t.Fatalf("ttml export must fail when disabled; stdout=%s", stdout.String())
+		}
+	})
+	if !strings.Contains(stderr.String(), "disabled") {
+		t.Fatalf("expected disabled error, got %q", stderr.String())
+	}
+	if strings.Contains(stdout.String(), "<tt") {
+		t.Fatalf("no TTML should be emitted when disabled")
+	}
+}
+
+// TestExportTTMLMonolingual pins that with the surface enabled, a single-language
+// TTML document is rendered to stdout.
+func TestExportTTMLMonolingual(t *testing.T) {
+	tmp := t.TempDir()
+	seedExportStore(t, filepath.Join(tmp, ".dir2mcp"), "media/talk.mp3", `{"language":"en"}`)
+	cfgPath := writeTTMLConfig(t, tmp, false)
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	withWorkingDir(t, tmp, func() {
+		code := app.RunWithContext(context.Background(),
+			[]string{"--config", cfgPath, "export", "--format", "ttml", "--lang", "en", "media/talk.mp3"})
+		if code != 0 {
+			t.Fatalf("ttml export exit = %d, stderr=%s", code, stderr.String())
+		}
+	})
+	out := stdout.String()
+	for _, want := range []string{`<tt `, `xml:lang="en"`, `First part`, `Second part`} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("monolingual TTML missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// TestExportTTMLBilingual pins bilingual TTML: both languages render over the
+// same <p> time regions, aligned within the default tolerance.
+func TestExportTTMLBilingual(t *testing.T) {
+	tmp := t.TempDir()
+	seedBilingualStore(t, filepath.Join(tmp, ".dir2mcp"), "media/talk.mp3")
+	cfgPath := writeTTMLConfig(t, tmp, false)
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	withWorkingDir(t, tmp, func() {
+		code := app.RunWithContext(context.Background(),
+			[]string{"--config", cfgPath, "export", "--format", "ttml",
+				"--lang", "en", "--secondary-lang", "fr", "media/talk.mp3"})
+		if code != 0 {
+			t.Fatalf("bilingual ttml exit = %d, stderr=%s", code, stderr.String())
+		}
+	})
+	out := stdout.String()
+	for _, want := range []string{
+		`<span xml:lang="en">Hello</span>`,
+		`<span xml:lang="fr">Bonjour</span>`,
+		`<span xml:lang="en">World</span>`,
+		`<span xml:lang="fr">Monde</span>`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("bilingual TTML missing %q in:\n%s", want, out)
+		}
+	}
+	// Both runs must sit under the same primary time region (single <p>).
+	if strings.Count(out, "<p ") != 2 {
+		t.Fatalf("expected 2 merged <p> cues, got %d:\n%s", strings.Count(out, "<p "), out)
+	}
+}
+
+// TestExportTTMLMissingLanguageInvalidField pins that requesting a language with
+// no transcript fails as INVALID_FIELD (SPEC §8.6.10), not a server error.
+func TestExportTTMLMissingLanguageInvalidField(t *testing.T) {
+	tmp := t.TempDir()
+	seedExportStore(t, filepath.Join(tmp, ".dir2mcp"), "media/talk.mp3", `{"language":"en"}`)
+	cfgPath := writeTTMLConfig(t, tmp, false)
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	withWorkingDir(t, tmp, func() {
+		code := app.RunWithContext(context.Background(),
+			[]string{"--config", cfgPath, "export", "--format", "ttml",
+				"--lang", "en", "--secondary-lang", "de", "media/talk.mp3"})
+		if code == 0 {
+			t.Fatalf("missing secondary language should fail; stdout=%s", stdout.String())
+		}
+	})
+	if !strings.Contains(stderr.String(), "INVALID_FIELD") {
+		t.Fatalf("expected INVALID_FIELD error, got %q", stderr.String())
+	}
+}
+
+// TestExportTTMLSMILFailsOpen pins the SMIL fail-open contract: with SMIL
+// enabled but the media file absent/unprobeable (or ffprobe missing), the TTML
+// is still written and the export succeeds; SMIL is simply omitted.
+func TestExportTTMLSMILFailsOpen(t *testing.T) {
+	tmp := t.TempDir()
+	seedExportStore(t, filepath.Join(tmp, ".dir2mcp"), "media/talk.mp3", `{"language":"en"}`)
+	cfgPath := writeTTMLConfig(t, tmp, true)
+	outPath := filepath.Join(tmp, "out", "talk.ttml")
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	withWorkingDir(t, tmp, func() {
+		// No media file at media/talk.mp3 exists on disk -> probe fails -> SMIL
+		// omitted, TTML still written, exit 0.
+		code := app.RunWithContext(context.Background(),
+			[]string{"--config", cfgPath, "export", "--format", "ttml",
+				"--lang", "en", "--out", outPath, "media/talk.mp3"})
+		if code != 0 {
+			t.Fatalf("export should fail open on missing media; exit=%d stderr=%s", code, stderr.String())
+		}
+	})
+	if _, err := os.ReadFile(outPath); err != nil {
+		t.Fatalf("TTML must still be written on SMIL fail-open: %v", err)
+	}
+	smilPath := strings.TrimSuffix(outPath, ".ttml") + ".smil"
+	if _, err := os.Stat(smilPath); err == nil {
+		t.Fatalf("SMIL must be omitted when media metadata is unavailable")
+	}
+}

--- a/tests/config/media_subtitles_config_test.go
+++ b/tests/config/media_subtitles_config_test.go
@@ -1,0 +1,112 @@
+package tests
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+)
+
+// TestMediaSubtitles_DefaultsOff confirms the optional bilingual subtitle export
+// surface (SPEC §8.6.10) is OFF by default and carries the spec default align
+// tolerance, so behavior is unchanged when nothing is configured.
+func TestMediaSubtitles_DefaultsOff(t *testing.T) {
+	cfg := config.Default()
+	if cfg.MediaSubtitlesTTMLEnabled {
+		t.Fatalf("media.subtitles.ttml.enabled must default to false")
+	}
+	if cfg.MediaSubtitlesSMILEnabled {
+		t.Fatalf("media.subtitles.smil.enabled must default to false")
+	}
+	if cfg.MediaSubtitlesTTMLAlignToleranceMS != config.DefaultMediaSubtitlesAlignToleranceMS {
+		t.Fatalf("align tolerance default = %d, want %d",
+			cfg.MediaSubtitlesTTMLAlignToleranceMS, config.DefaultMediaSubtitlesAlignToleranceMS)
+	}
+}
+
+// TestMediaSubtitles_RoundTrip pins SaveFile/LoadFile round-trip of the new
+// keys so the snapshot faithfully persists an enabled config.
+func TestMediaSubtitles_RoundTrip(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+
+	cfg := config.Default()
+	cfg.RootDir = "/tmp/repo"
+	cfg.StateDir = "/tmp/repo/.dir2mcp"
+	cfg.MediaSubtitlesTTMLEnabled = true
+	cfg.MediaSubtitlesSMILEnabled = true
+	cfg.MediaSubtitlesTTMLAlignToleranceMS = 1800
+
+	if err := config.SaveFile(path, cfg); err != nil {
+		t.Fatalf("SaveFile: %v", err)
+	}
+	loaded, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if !loaded.MediaSubtitlesTTMLEnabled || !loaded.MediaSubtitlesSMILEnabled {
+		t.Fatalf("enabled flags did not round-trip: %+v", loaded)
+	}
+	if loaded.MediaSubtitlesTTMLAlignToleranceMS != 1800 {
+		t.Fatalf("align tolerance = %d, want 1800", loaded.MediaSubtitlesTTMLAlignToleranceMS)
+	}
+}
+
+// TestMediaSubtitles_NestedYAMLApplies locks the nested media.subtitles.ttml /
+// media.subtitles.smil mapping so child keys are bound via the YAML scanner.
+func TestMediaSubtitles_NestedYAMLApplies(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+	writeFile(t, path, strings.Join([]string{
+		"root_dir: /tmp/repo",
+		"state_dir: /tmp/repo/.dir2mcp",
+		"media:",
+		"  subtitles:",
+		"    ttml:",
+		"      enabled: true",
+		"      align_tolerance_ms: 1200",
+		"    smil:",
+		"      enabled: true",
+	}, "\n")+"\n")
+
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile(nested media.subtitles): %v", err)
+	}
+	if !cfg.MediaSubtitlesTTMLEnabled || !cfg.MediaSubtitlesSMILEnabled {
+		t.Fatalf("nested enable flags not applied: %+v", cfg)
+	}
+	if cfg.MediaSubtitlesTTMLAlignToleranceMS != 1200 {
+		t.Fatalf("nested align_tolerance_ms = %d, want 1200", cfg.MediaSubtitlesTTMLAlignToleranceMS)
+	}
+}
+
+// TestMediaSubtitles_ZeroToleranceDefaults pins that an explicit 0 align
+// tolerance normalizes to the spec default at validation time.
+func TestMediaSubtitles_ZeroToleranceDefaults(t *testing.T) {
+	cfg := config.Default()
+	cfg.MediaSubtitlesTTMLAlignToleranceMS = 0
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if cfg.MediaSubtitlesTTMLAlignToleranceMS != config.DefaultMediaSubtitlesAlignToleranceMS {
+		t.Fatalf("zero tolerance should default, got %d", cfg.MediaSubtitlesTTMLAlignToleranceMS)
+	}
+}
+
+// TestMediaSubtitles_RejectsNegativeTolerance pins that a negative align
+// tolerance is rejected at config-parse time rather than silently accepted.
+func TestMediaSubtitles_RejectsNegativeTolerance(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+	writeFile(t, path, strings.Join([]string{
+		"root_dir: /tmp/repo",
+		"state_dir: /tmp/repo/.dir2mcp",
+		"media_subtitles_ttml_align_tolerance_ms: -1",
+	}, "\n")+"\n")
+
+	if _, err := config.LoadFile(path); err == nil {
+		t.Fatalf("negative align tolerance should be rejected")
+	}
+}

--- a/tests/security/cli_boundary_test.go
+++ b/tests/security/cli_boundary_test.go
@@ -176,6 +176,7 @@ func TestRepoSplitBoundary_InternalCLIFileOwnership(t *testing.T) {
 		"embed_options_test.go":     {},
 		"embed_worker.go":           {},
 		"export.go":                 {},
+		"export_ttml.go":            {},
 		"flag_ordering_test.go":     {},
 		"reindex.go":                {},
 		"registration_hint.go":      {},

--- a/tests/subtitle/bilingual_test.go
+++ b/tests/subtitle/bilingual_test.go
@@ -1,0 +1,149 @@
+package tests
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/avutil"
+	"github.com/dirstral/dir2mcp/internal/subtitle"
+)
+
+// TestAlignBilingualWithinTolerance pins that a secondary cue whose start is
+// within the alignment tolerance of a primary cue is merged into that primary
+// cue (same time region, two language runs), while a secondary cue outside
+// tolerance is emitted as its own secondary-only cue rather than dropped
+// (SPEC §8.6.10).
+func TestAlignBilingualWithinTolerance(t *testing.T) {
+	primary := []subtitle.Cue{
+		{StartMS: 0, EndMS: 2000, Text: "Hello"},
+		{StartMS: 5000, EndMS: 7000, Text: "World"},
+	}
+	secondary := []subtitle.Cue{
+		// 200 ms after the first primary start: within 2500 ms -> merged.
+		{StartMS: 200, EndMS: 2100, Text: "Bonjour"},
+		// 9000 ms: no primary within 2500 ms -> own secondary-only cue.
+		{StartMS: 9000, EndMS: 10000, Text: "Orphelin"},
+	}
+
+	got := subtitle.AlignBilingual(primary, secondary, "en", "fr", 2500)
+	if len(got) != 3 {
+		t.Fatalf("expected 3 cues (2 primary + 1 orphan), got %d: %+v", len(got), got)
+	}
+
+	// First cue carries both languages over the primary time region.
+	c0 := got[0]
+	if c0.StartMS != 0 || c0.EndMS != 2000 {
+		t.Fatalf("merged cue must keep primary time region [0,2000], got [%d,%d]", c0.StartMS, c0.EndMS)
+	}
+	if c0.PrimaryText != "Hello" || c0.PrimaryLang != "en" {
+		t.Fatalf("primary run wrong: %+v", c0)
+	}
+	if c0.SecondaryText != "Bonjour" || c0.SecondaryLang != "fr" {
+		t.Fatalf("secondary run not aligned to same region: %+v", c0)
+	}
+
+	// Second primary has no secondary in tolerance.
+	if got[1].SecondaryText != "" {
+		t.Fatalf("second primary should have no secondary run: %+v", got[1])
+	}
+
+	// Orphan secondary emitted as its own cue, not dropped.
+	last := got[2]
+	if last.StartMS != 9000 || last.PrimaryText != "Orphelin" || last.PrimaryLang != "fr" {
+		t.Fatalf("orphan secondary cue wrong: %+v", last)
+	}
+}
+
+// TestAlignBilingualDeterministic pins deterministic alignment: repeated runs
+// over identical inputs produce identical cue slices.
+func TestAlignBilingualDeterministic(t *testing.T) {
+	primary := []subtitle.Cue{
+		{StartMS: 1000, EndMS: 2000, Text: "A"},
+		{StartMS: 1100, EndMS: 2100, Text: "B"},
+	}
+	secondary := []subtitle.Cue{
+		{StartMS: 1050, EndMS: 2050, Text: "x"},
+		{StartMS: 1150, EndMS: 2150, Text: "y"},
+	}
+	first := subtitle.RenderTTML(subtitle.AlignBilingual(primary, secondary, "en", "fr", 2500), "en")
+	for i := 0; i < 5; i++ {
+		again := subtitle.RenderTTML(subtitle.AlignBilingual(primary, secondary, "en", "fr", 2500), "en")
+		if again != first {
+			t.Fatalf("alignment not deterministic on run %d", i)
+		}
+	}
+}
+
+// TestRenderTTMLBilingual pins that bilingual TTML emits language-tagged spans
+// over a single <p> time region, both traceable to the same cue.
+func TestRenderTTMLBilingual(t *testing.T) {
+	cues := []subtitle.BilingualCue{
+		{
+			StartMS: 0, EndMS: 1500,
+			PrimaryLang: "en", PrimaryText: "Hello",
+			SecondaryLang: "fr", SecondaryText: "Bonjour",
+		},
+	}
+	out := subtitle.RenderTTML(cues, "en")
+	for _, want := range []string{
+		`<tt xmlns="http://www.w3.org/ns/ttml" xml:lang="en">`,
+		`<p begin="00:00:00.000" end="00:00:01.500">`,
+		`<span xml:lang="en">Hello</span>`,
+		`<span xml:lang="fr">Bonjour</span>`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("TTML missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// TestRenderTTMLEscapesText pins XML escaping of cue text and newline -> <br/>.
+func TestRenderTTMLEscapesText(t *testing.T) {
+	cues := []subtitle.BilingualCue{
+		{StartMS: 0, EndMS: 1000, PrimaryLang: "en", PrimaryText: "a < b & c\nline2"},
+	}
+	out := subtitle.RenderTTML(cues, "en")
+	if !strings.Contains(out, "a &lt; b &amp; c<br/>line2") {
+		t.Fatalf("expected escaped text with <br/>, got:\n%s", out)
+	}
+}
+
+// TestRenderSMILMetadataAndFailOpen pins that SMIL carries probed codec/bitrate/
+// dimensions when present, and that a zero MediaInfo (the fail-open case after a
+// failed probe) still renders a valid audio-only SMIL with no width/height —
+// callers omit SMIL entirely on probe failure, but a partial probe must not
+// crash or emit bogus dimensions (SPEC §8.6.10).
+func TestRenderSMILMetadataAndFailOpen(t *testing.T) {
+	full := subtitle.RenderSMIL(subtitle.SMILInput{
+		MediaSrc: "clip.mp4",
+		Info: avutil.MediaInfo{
+			Container: "mov,mp4", VideoCodec: "h264", AudioCodec: "aac",
+			BitRateBPS: 800000, Width: 1280, Height: 720,
+		},
+		Subtitles: []subtitle.SMILSubtitleRef{{Src: "clip.ttml", Lang: "en"}},
+	})
+	for _, want := range []string{
+		`name="videoCodec" content="h264"`,
+		`name="bitrate" content="800000"`,
+		`<video src="clip.mp4" width="1280" height="720"/>`,
+		`<textstream src="clip.ttml" systemLanguage="en"/>`,
+	} {
+		if !strings.Contains(full, want) {
+			t.Fatalf("SMIL missing %q in:\n%s", want, full)
+		}
+	}
+
+	// Partial/empty MediaInfo: no dimensions, falls back to <audio>, no bogus
+	// width/height attributes.
+	partial := subtitle.RenderSMIL(subtitle.SMILInput{
+		MediaSrc:  "clip.mp4",
+		Info:      avutil.MediaInfo{},
+		Subtitles: []subtitle.SMILSubtitleRef{{Src: "clip.ttml", Lang: "en"}},
+	})
+	if strings.Contains(partial, "width=") || strings.Contains(partial, "<video") {
+		t.Fatalf("empty MediaInfo must not emit video/dimensions, got:\n%s", partial)
+	}
+	if !strings.Contains(partial, `<audio src="clip.mp4"/>`) {
+		t.Fatalf("empty MediaInfo should fall back to <audio>, got:\n%s", partial)
+	}
+}


### PR DESCRIPTION
Closes #255

Implements the optional broadcast subtitle-packaging surface defined in SPEC §8.6.10 (already pinned at spec 0.21.0 on main — no submodule re-pin). OFF by default and fully additive: with the config disabled, behavior is byte-identical to today and VTT/SRT export is unchanged.

## What changed

### Config (extended)
New off-by-default block (flat + nested YAML, snapshot round-trip, validation):
- `media.subtitles.ttml.enabled` (bool, default false)
- `media.subtitles.ttml.align_tolerance_ms` (int, default 2500; 0 normalizes to default, negative rejected)
- `media.subtitles.smil.enabled` (bool, default false)

### avutil (added)
- `ProbeMediaInfo` / `ParseMediaInfo` + `MediaInfo`: ffprobe JSON probe of container/codec/bitrate/width/height, following the existing `Duration` pattern. Returns `ErrToolNotFound` when ffprobe is absent so callers fail open.

### subtitle (added, extends existing ttml.go/subtitle.go)
- `AlignBilingual`: deterministic cross-language cue alignment within tolerance; a secondary segment within tolerance merges into the nearest primary cue over the SAME time region, an out-of-tolerance secondary becomes its own cue (never dropped).
- `RenderTTML`: monolingual or bilingual TTML with per-language `xml:lang` spans, XML-escaped, newline→`<br/>`.
- `RenderSMIL`: SMIL packaging from probed `MediaInfo` + companion subtitle refs; omits any unreported field (fail open), falls back to `<audio>` for audio-only media.

### cli/export (extended + new export_ttml.go)
- `--format ttml` (gated by config; rejected when disabled) and `--secondary-lang` for the bilingual case.
- Bilingual selects two `transcript-<lang>` representations and aligns; monolingual works regardless of translation.
- With `--out`, writes the `.ttml` and (when `smil.enabled`) a companion `.smil` sidecar. SMIL **fails open**: a missing/unprobeable media file or absent ffprobe omits the SMIL but still writes the TTML and exits 0.
- A requested language with no transcript ⇒ `INVALID_FIELD`.

## Translation dependency
Resolved using the existing translation representation model: per-language transcripts already coexist as distinct `transcript-<lang>` rep_types under `UNIQUE(doc_id, rep_type)`, and `store.TranscriptRepresentations` already surfaces both bare and suffixed forms. No new translation primitive was required; the monolingual path is independent of translation.

## Tests (external `tests/<pkg>` packages)
- `tests/subtitle`: `TestAlignBilingualWithinTolerance`, `TestAlignBilingualDeterministic`, `TestRenderTTMLBilingual`, `TestRenderTTMLEscapesText`, `TestRenderSMILMetadataAndFailOpen`
- `tests/avutil`: `TestParseMediaInfoFull`, `TestParseMediaInfoAudioOnly`, `TestParseMediaInfoPartial`, `TestProbeMediaInfoToolNotFound` (skips when ffprobe present)
- `tests/config`: `TestMediaSubtitles_DefaultsOff`, `_RoundTrip`, `_NestedYAMLApplies`, `_ZeroToleranceDefaults`, `_RejectsNegativeTolerance`
- `tests/cli`: `TestExportTTMLDisabledByDefault`, `TestExportTTMLMonolingual`, `TestExportTTMLBilingual`, `TestExportTTMLMissingLanguageInvalidField`, `TestExportTTMLSMILFailsOpen`

`make check` fully green (golangci-lint 0 issues, gocyclo ≤15). No MCP tool schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)