### PR TITLE
feat(ingest): batch run manifest + progress reporting (#260, two-phase deferred)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -406,6 +406,22 @@ type Config struct {
 	MediaClipMaxDurationMS int
 	MediaClipMaxBytes      int
 
+	// MediaBatchTwoPhase / MediaBatchProgress / MediaBatchManifest configure the
+	// optional batch-ergonomics surface for large-archive media ingests (SPEC
+	// §8.6.11; config block `media.batch`). All default OFF/empty so behavior is
+	// byte-identical to today when unconfigured.
+	//   - MediaBatchTwoPhase (media.batch.two_phase): run media ingest as two
+	//     ordered passes (transcription, then derivation) instead of single-pass.
+	//     Observably output-equivalent to single-pass — ordering/reporting only.
+	//   - MediaBatchProgress (media.batch.progress): emit side-channel, monotonic
+	//     progress against a per-pass total. Never alters outputs or ordering.
+	//   - MediaBatchManifest (media.batch.manifest): path of a JSONL run manifest
+	//     (one record per asset). Empty disables the manifest. The manifest is
+	//     advisory for resume only — the live identity/cache/mtime gates always win.
+	MediaBatchTwoPhase bool
+	MediaBatchProgress bool
+	MediaBatchManifest string
+
 	// QualityGatesEnabled is the master switch for the output quality gate
 	// (spec 0.16.0): when true (default), generated transcript/OCR text is
 	// screened for degenerate output (repetition loops, empty output,
@@ -536,6 +552,9 @@ type fileConfig struct {
 	ElevenLabsAPIKey                   *string
 	ServerTLSCertFile                  *string
 	ServerTLSKeyFile                   *string
+	MediaBatchTwoPhase                 *bool
+	MediaBatchProgress                 *bool
+	MediaBatchManifest                 *string
 	// session timings expressed as YAML duration strings.  populated by
 	// parseConfigYAML's custom parser via setFileScalarValue rather than the
 	// standard yaml.Unmarshal machinery.  struct tags are therefore omitted
@@ -644,6 +663,9 @@ type persistedConfig struct {
 	MediaVideoWindowSec                int           `yaml:"media_video_window_sec"`
 	MediaClipMaxDurationMS             int           `yaml:"media_clip_max_duration_ms"`
 	MediaClipMaxBytes                  int           `yaml:"media_clip_max_bytes"`
+	MediaBatchTwoPhase                 bool          `yaml:"media_batch_two_phase"`
+	MediaBatchProgress                 bool          `yaml:"media_batch_progress"`
+	MediaBatchManifest                 string        `yaml:"media_batch_manifest"`
 	// MediaDiarizeEnabled is the tri-state diarization opt (SPEC §8.6.8): a
 	// *bool so the snapshot can round-trip omitted (nil) vs. false vs. true
 	// without collapsing the auto/off distinction.
@@ -918,6 +940,9 @@ func buildPersistedConfig(cfg *Config) persistedConfig {
 		ServerTLSKeyFile:                   cfg.ServerTLSKeyFile,
 		X402Mode:                           cfg.X402.Mode,
 		X402FacilitatorURL:                 cfg.X402.FacilitatorURL,
+		MediaBatchTwoPhase:                 cfg.MediaBatchTwoPhase,
+		MediaBatchProgress:                 cfg.MediaBatchProgress,
+		MediaBatchManifest:                 cfg.MediaBatchManifest,
 		// token intentionally omitted to avoid persisting secrets
 		// X402FacilitatorToken: cfg.X402.FacilitatorToken,
 		X402ResourceBaseURL:  cfg.X402.ResourceBaseURL,
@@ -1598,6 +1623,15 @@ func applyMediaFileParsed(cfg *Config, fc fileConfig) {
 	if fc.MediaClipMaxBytes != nil {
 		cfg.MediaClipMaxBytes = *fc.MediaClipMaxBytes
 	}
+	if fc.MediaBatchTwoPhase != nil {
+		cfg.MediaBatchTwoPhase = *fc.MediaBatchTwoPhase
+	}
+	if fc.MediaBatchProgress != nil {
+		cfg.MediaBatchProgress = *fc.MediaBatchProgress
+	}
+	if fc.MediaBatchManifest != nil {
+		cfg.MediaBatchManifest = strings.TrimSpace(*fc.MediaBatchManifest)
+	}
 }
 
 // applyMediaSubtitlesFileParsed copies the set media.subtitles.* file fields
@@ -1936,6 +1970,9 @@ var configKeyAliases = map[string]string{
 	"distributed_embed.sqlite_path":           "distributed_embed_sqlite_path",
 	"distributed_embed.broker_url":            "distributed_embed_broker_url",
 	"distributed_embed.max_attempts":          "distributed_embed_max_attempts",
+	"media_batch_two_phase":                   "media.batch.two_phase",
+	"media_batch_progress":                    "media.batch.progress",
+	"media_batch_manifest":                    "media.batch.manifest",
 }
 
 // canonicalizeConfigKey lower-cases and trims key and maps it through
@@ -1958,7 +1995,7 @@ func isMapSectionKey(key string) bool {
 		return true
 	case "source", "source.s3":
 		return true
-	case "media", "media.variants", "media.translate", "media.clip", "media.diarize":
+	case "media", "media.variants", "media.translate", "media.clip", "media.diarize", "media.batch":
 		return true
 	case "media.subtitles", "media.subtitles.ttml", "media.subtitles.smil":
 		return true
@@ -2022,6 +2059,8 @@ var boolFileScalarTargets = map[string]func(*fileConfig) **bool{
 	},
 	"media.vad":                func(c *fileConfig) **bool { return &c.MediaVAD },
 	"media.diarize.enabled":    func(c *fileConfig) **bool { return &c.MediaDiarizeEnabled },
+	"media.batch.two_phase":    func(c *fileConfig) **bool { return &c.MediaBatchTwoPhase },
+	"media.batch.progress":     func(c *fileConfig) **bool { return &c.MediaBatchProgress },
 	"x402_tools_call_enabled":  func(c *fileConfig) **bool { return &c.X402ToolsCallEnabled },
 	"retrieval.hybrid.enabled": func(c *fileConfig) **bool { return &c.RetrievalHybridEnabled },
 	"dedup.retrieval":          func(c *fileConfig) **bool { return &c.DedupRetrieval },
@@ -2291,6 +2330,8 @@ func setIngestStringFileScalar(cfg *fileConfig, key, value string) {
 		cfg.STTElevenLabsLanguageCode = strPtr(value)
 	case "media.variants.select":
 		cfg.MediaVariantsSelect = strPtr(value)
+	case "media.batch.manifest":
+		cfg.MediaBatchManifest = strPtr(value)
 	}
 }
 
@@ -2470,6 +2511,9 @@ func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	writeInt("media_video_window_sec", cfg.MediaVideoWindowSec)
 	writeInt("media_clip_max_duration_ms", cfg.MediaClipMaxDurationMS)
 	writeInt("media_clip_max_bytes", cfg.MediaClipMaxBytes)
+	writeBool("media_batch_two_phase", cfg.MediaBatchTwoPhase)
+	writeBool("media_batch_progress", cfg.MediaBatchProgress)
+	writeScalar("media_batch_manifest", cfg.MediaBatchManifest)
 	writeScalar("server_tls_cert_file", cfg.ServerTLSCertFile)
 	writeScalar("server_tls_key_file", cfg.ServerTLSKeyFile)
 	writeScalar("x402_mode", cfg.X402Mode)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1623,6 +1623,13 @@ func applyMediaFileParsed(cfg *Config, fc fileConfig) {
 	if fc.MediaClipMaxBytes != nil {
 		cfg.MediaClipMaxBytes = *fc.MediaClipMaxBytes
 	}
+	applyMediaBatchFileParsed(cfg, fc)
+}
+
+// applyMediaBatchFileParsed copies the set media.batch file fields (SPEC §8.6.11)
+// onto cfg. Split from applyMediaFileParsed to keep that function under the
+// cyclomatic-complexity budget.
+func applyMediaBatchFileParsed(cfg *Config, fc fileConfig) {
 	if fc.MediaBatchTwoPhase != nil {
 		cfg.MediaBatchTwoPhase = *fc.MediaBatchTwoPhase
 	}
@@ -2971,10 +2978,28 @@ func (c *Config) Validate() error {
 	if err := c.validateDistributedEmbed(); err != nil {
 		return err
 	}
+	if err := c.validateMediaBatch(); err != nil {
+		return err
+	}
 	c.applyValidationDefaults()
 	if c.SessionMaxLifetime > 0 && c.SessionMaxLifetime < c.SessionInactivityTimeout {
 		return fmt.Errorf("session_max_lifetime (%v) must be >= session_inactivity_timeout (%v)",
 			c.SessionMaxLifetime, c.SessionInactivityTimeout)
+	}
+	return nil
+}
+
+// validateMediaBatch enforces the media.batch (SPEC §8.6.11) invariants. The
+// JSONL run manifest and side-channel progress are implemented; the two-phase
+// pass split (media.batch.two_phase) is NOT yet implemented, so enabling it is
+// rejected up front rather than silently behaving as single-pass — an honest
+// error beats a no-op flag. (The single-pass path already produces the same
+// representations/chunks/citations, so manifest + progress are fully usable
+// today.)
+func (c *Config) validateMediaBatch() error {
+	if c.MediaBatchTwoPhase {
+		return fmt.Errorf("media.batch.two_phase is not yet implemented; " +
+			"use media.batch.manifest and media.batch.progress (single-pass) for now")
 	}
 	return nil
 }

--- a/internal/ingest/batch.go
+++ b/internal/ingest/batch.go
@@ -1,0 +1,349 @@
+package ingest
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"time"
+)
+
+// Batch-ergonomics surface for large-archive media ingests (SPEC §8.6.11).
+//
+// This file implements three optional, additive, off-by-default features that
+// change ingest ORDERING and REPORTING only — never the resulting
+// representations, chunks, embeddings, or citations:
+//
+//   - a side-channel, monotonic progress reporter (media.batch.progress);
+//   - a JSONL run manifest, one record per asset (media.batch.manifest);
+//   - a two-phase pass split (media.batch.two_phase), implemented in service.go.
+//
+// All three are governed by the media.batch config block and are inert when
+// unconfigured, so a default ingest is byte-identical to today.
+
+// Canonical §14.4 error codes recorded in a manifest record's `error_code`
+// field (§7.7). EXTRACT_FAILED is the generic representation/derivation failure;
+// TRANSCRIBE_FAILED is distinguished via the package's transcript-failure
+// sentinel. Finer classification (TRANSLATE_FAILED/OCR_FAILED) is a follow-up
+// alongside the two-phase pass split.
+const (
+	manifestErrTranscribeFailed = "TRANSCRIBE_FAILED"
+	manifestErrExtractFailed    = "EXTRACT_FAILED"
+)
+
+// manifestErrorCode maps a per-asset processing error to a canonical §14.4 code
+// for the run manifest. It distinguishes a transcript-provider failure; any other
+// representation/derivation failure is recorded as the generic EXTRACT_FAILED.
+func manifestErrorCode(err error) string {
+	if errors.Is(err, ErrTranscriptProviderFailure) {
+		return manifestErrTranscribeFailed
+	}
+	return manifestErrExtractFailed
+}
+
+// batchManifestStatus is a terminal per-asset outcome (SPEC §8.6.11).
+type batchManifestStatus string
+
+const (
+	batchStatusCompleted batchManifestStatus = "completed"
+	batchStatusSkipped   batchManifestStatus = "skipped"
+	batchStatusError     batchManifestStatus = "error"
+)
+
+// batchManifestRecord is one JSONL line in the run manifest (SPEC §8.6.11).
+// The field set is self-describing and deterministic so the manifest is stable
+// and machine-consumable. Optional fields use omitempty so an unknown value
+// (e.g. an undecodable duration) is simply absent rather than a misleading zero.
+type batchManifestRecord struct {
+	// asset identity (§7.8/§7.6).
+	RelPath     string `json:"rel_path"`
+	ContentHash string `json:"content_hash,omitempty"`
+
+	// terminal outcome (§7.7). On error, ErrorCode carries the canonical §14.4
+	// code and ErrorMessage a redacted human message.
+	Status       batchManifestStatus `json:"status"`
+	ErrorCode    string              `json:"error_code,omitempty"`
+	ErrorMessage string              `json:"error_message,omitempty"`
+
+	// media duration (when known) and processing time for the asset.
+	DurationMS   int64 `json:"duration_ms,omitempty"`
+	ProcessingMS int64 `json:"processing_ms"`
+
+	// outputs produced — the derived representation rep_types and any export
+	// artifacts (e.g. transcript/translated language tags, subtitle formats).
+	Outputs []string `json:"outputs,omitempty"`
+
+	// the pass that produced this record under two-phase mode
+	// ("transcription"|"derivation"); empty under single-pass.
+	Pass string `json:"pass,omitempty"`
+}
+
+// assetOutcome accumulates the observable result of processing a single asset
+// so a manifest record can be emitted and progress advanced. It is populated by
+// processDocument and the representation generators when a batch run is active;
+// when no batch run is active the accumulator is nil and the hot path is
+// untouched.
+type assetOutcome struct {
+	relPath     string
+	contentHash string
+	status      batchManifestStatus
+	errorCode   string
+	errorMsg    string
+	durationMS  int64
+	startedAt   time.Time
+
+	mu      sync.Mutex
+	outputs map[string]struct{}
+}
+
+// newAssetOutcome starts timing an asset's processing.
+func newAssetOutcome(relPath string) *assetOutcome {
+	return &assetOutcome{
+		relPath:   relPath,
+		status:    batchStatusCompleted,
+		startedAt: time.Now(),
+		outputs:   make(map[string]struct{}),
+	}
+}
+
+// addOutput records a produced output label (a rep_type or export artifact tag)
+// on the outcome. Safe for concurrent use. No-op on a nil receiver so callers
+// need not branch when a batch run is inactive.
+func (o *assetOutcome) addOutput(label string) {
+	if o == nil || label == "" {
+		return
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if o.outputs == nil {
+		o.outputs = make(map[string]struct{})
+	}
+	o.outputs[label] = struct{}{}
+}
+
+// setContentHash records the asset's resolved content_hash (§7.6). No-op on a
+// nil receiver or empty hash.
+func (o *assetOutcome) setContentHash(hash string) {
+	if o == nil || hash == "" {
+		return
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.contentHash = hash
+}
+
+// markErrorIfUnset records a terminal error outcome ONLY when one is not already
+// recorded, so a specific inner error code (set by a representation generator) is
+// never clobbered by a generic outer one. No-op on a nil receiver.
+func (o *assetOutcome) markErrorIfUnset(code, message string) {
+	if o == nil {
+		return
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if o.status == batchStatusError {
+		return
+	}
+	o.status = batchStatusError
+	o.errorCode = code
+	o.errorMsg = message
+}
+
+// markSkipped records a terminal skipped outcome (no work performed: cache hit,
+// unchanged content, or a non-ingestable type). No-op on a nil receiver.
+func (o *assetOutcome) markSkipped() {
+	if o == nil {
+		return
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	// An error already recorded wins over a late skip signal.
+	if o.status != batchStatusError {
+		o.status = batchStatusSkipped
+	}
+}
+
+// record materializes the deterministic manifest record from the accumulated
+// outcome. Outputs are sorted so the record is reproducible across runs of an
+// unchanged corpus (§8.6.11 determinism).
+func (o *assetOutcome) record(pass string) batchManifestRecord {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	outputs := make([]string, 0, len(o.outputs))
+	for label := range o.outputs {
+		outputs = append(outputs, label)
+	}
+	sort.Strings(outputs)
+	if len(outputs) == 0 {
+		outputs = nil
+	}
+	return batchManifestRecord{
+		RelPath:      o.relPath,
+		ContentHash:  o.contentHash,
+		Status:       o.status,
+		ErrorCode:    o.errorCode,
+		ErrorMessage: o.errorMsg,
+		DurationMS:   o.durationMS,
+		ProcessingMS: time.Since(o.startedAt).Milliseconds(),
+		Outputs:      outputs,
+		Pass:         pass,
+	}
+}
+
+// batchRun owns the per-scan batch state: the optional JSONL manifest writer and
+// the optional progress reporter. It is created once per runScan when any
+// media.batch feature is enabled and is nil otherwise, so the default ingest
+// path allocates nothing and behaves exactly as before.
+type batchRun struct {
+	logger *log.Logger
+
+	// progress
+	progressEnabled bool
+	total           int64
+	completed       int64
+	pass            string // current pass label for progress/manifest
+
+	// manifest
+	manifestEnabled bool
+	manifestPath    string
+
+	mu   sync.Mutex
+	file *os.File
+	enc  *json.Encoder
+}
+
+// newBatchRun constructs the per-scan batch state from config. It returns nil
+// when no media.batch feature is enabled so the caller's hot path is untouched.
+// When the manifest is enabled it opens (truncates) the manifest file up front;
+// a manifest open failure is non-fatal — it disables the manifest and warns,
+// because batch ergonomics must never fail an otherwise-healthy ingest.
+func newBatchRun(progress, manifest bool, manifestPath string, logger *log.Logger) *batchRun {
+	if !progress && !manifest {
+		return nil
+	}
+	if logger == nil {
+		logger = log.Default()
+	}
+	br := &batchRun{
+		logger:          logger,
+		progressEnabled: progress,
+	}
+	if manifest && manifestPath != "" {
+		if err := br.openManifest(manifestPath); err != nil {
+			logger.Printf("batch manifest disabled: %v", err)
+		} else {
+			br.manifestEnabled = true
+			br.manifestPath = manifestPath
+		}
+	}
+	return br
+}
+
+func (b *batchRun) openManifest(path string) error {
+	if dir := filepath.Dir(path); dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("create manifest dir %s: %w", dir, err)
+		}
+	}
+	f, err := os.Create(path) //nolint:gosec // operator-configured manifest path
+	if err != nil {
+		return fmt.Errorf("create manifest %s: %w", path, err)
+	}
+	b.file = f
+	b.enc = json.NewEncoder(f)
+	return nil
+}
+
+// startPass (re)establishes the progress total at the beginning of a pass and
+// records the pass label stamped on progress lines and manifest records. The
+// completed counter is reset so progress is monotonic WITHIN a pass (§8.6.11).
+func (b *batchRun) startPass(label string, total int) {
+	if b == nil {
+		return
+	}
+	b.mu.Lock()
+	b.pass = label
+	b.total = int64(total)
+	b.completed = 0
+	b.mu.Unlock()
+	if b.progressEnabled {
+		if label != "" {
+			b.logger.Printf("ingest progress: starting %s pass (%d assets)", label, total)
+		} else {
+			b.logger.Printf("ingest progress: starting (%d assets)", total)
+		}
+	}
+}
+
+// advance records that one unit finished (completed, skipped, or errored — all
+// count toward the monotonic completed total per §8.6.11, so a resumed run that
+// resolves an asset from cache still reports faithful totals) and emits a
+// progress line via the structured logger. Side-channel only: it never alters
+// outputs, ordering, or error semantics.
+func (b *batchRun) advance() {
+	if b == nil || !b.progressEnabled {
+		return
+	}
+	b.mu.Lock()
+	b.completed++
+	done := b.completed
+	total := b.total
+	pass := b.pass
+	b.mu.Unlock()
+	if pass != "" {
+		b.logger.Printf("ingest progress [%s]: %d/%d", pass, done, total)
+	} else {
+		b.logger.Printf("ingest progress: %d/%d", done, total)
+	}
+}
+
+// write appends one manifest record as a JSONL line. No-op when the manifest is
+// disabled. A write error is logged and swallowed — the manifest is advisory and
+// must never fail the ingest. Concurrency-safe.
+func (b *batchRun) write(rec batchManifestRecord) {
+	if b == nil || !b.manifestEnabled {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.enc == nil {
+		return
+	}
+	if err := b.enc.Encode(rec); err != nil {
+		b.logger.Printf("batch manifest write failed for %s: %v", rec.RelPath, err)
+	}
+}
+
+// finalize records an outcome at the end of an asset's processing: it appends
+// the manifest record and advances progress. It is the single completion point
+// so the manifest and the progress total stay consistent. No-op on nil.
+func (b *batchRun) finalize(o *assetOutcome) {
+	if b == nil || o == nil {
+		return
+	}
+	b.mu.Lock()
+	pass := b.pass
+	b.mu.Unlock()
+	b.write(o.record(pass))
+	b.advance()
+}
+
+// close flushes and closes the manifest file. Safe to call on nil.
+func (b *batchRun) close() {
+	if b == nil {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.file != nil {
+		if err := b.file.Close(); err != nil {
+			b.logger.Printf("batch manifest close failed: %v", err)
+		}
+		b.file = nil
+		b.enc = nil
+	}
+}

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -206,6 +206,39 @@ type Service struct {
 	// Nil until a scan sets it; direct callers fall back to a one-shot walk.
 	sidecarIndex map[string]int64
 	sidecarMu    sync.RWMutex
+
+	// batch holds the optional per-scan batch-ergonomics state (SPEC §8.6.11):
+	// the JSONL run manifest writer and the side-channel progress reporter. It is
+	// created in runScan only when a media.batch feature is enabled and torn down
+	// when the scan ends; nil otherwise, so the default ingest path is unchanged.
+	batch *batchRun
+
+	// activeOutcome is the manifest/progress accumulator for the asset currently
+	// being processed. runScan sets it around each per-asset processing call (the
+	// scan loop is sequential, so at most one asset is in flight); the rep
+	// generators stamp produced outputs onto it via recordOutput. Nil when no
+	// batch run is active, making recordOutput a no-op on the hot path.
+	activeOutcome *assetOutcome
+}
+
+// recordContentHash stamps the resolved content_hash (§7.6) onto the asset
+// currently being processed under an active batch run, for the run manifest (SPEC
+// §8.6.11). No-op when no batch run is active.
+func (s *Service) recordContentHash(hash string) {
+	if s == nil {
+		return
+	}
+	s.activeOutcome.setContentHash(hash)
+}
+
+// markActiveSkipped marks the asset currently being processed under an active
+// batch run as "skipped" — no work performed (cache hit, unchanged content, or a
+// non-ingestable type), SPEC §8.6.11. No-op when no batch run is active.
+func (s *Service) markActiveSkipped() {
+	if s == nil {
+		return
+	}
+	s.activeOutcome.markSkipped()
 }
 
 // ErrTranscriptProviderFailure marks failures originating from the transcript
@@ -846,6 +879,16 @@ func (s *Service) runScan(ctx context.Context) error {
 
 	forceReindex := s.indexingState != nil && s.indexingState.Snapshot().Mode == appstate.ModeFull
 
+	// Optional batch-ergonomics run (SPEC §8.6.11): a JSONL run manifest and/or a
+	// side-channel progress reporter. nil (and inert) unless a media.batch feature
+	// is enabled, so the default ingest path is unchanged.
+	s.batch = newBatchRun(s.cfg.MediaBatchProgress, s.cfg.MediaBatchManifest != "", s.cfg.MediaBatchManifest, s.getLogger())
+	defer func() {
+		s.batch.close()
+		s.batch = nil
+	}()
+	s.batch.startPass("", len(discovered))
+
 	seen := make(map[string]struct{}, len(discovered))
 	for _, f := range discovered {
 		if err := ctx.Err(); err != nil {
@@ -853,12 +896,35 @@ func (s *Service) runScan(ctx context.Context) error {
 		}
 
 		s.addScanned(1)
+
+		var outcome *assetOutcome
+		if s.batch != nil {
+			outcome = newAssetOutcome(f.RelPath)
+			s.activeOutcome = outcome
+		}
+
 		if matchesAnyPathExclude(f.RelPath, s.cfg.PathExcludes) {
 			s.addSkipped(1)
+			if outcome != nil {
+				outcome.markSkipped()
+				s.batch.finalize(outcome)
+				s.activeOutcome = nil
+			}
 			continue
 		}
 
-		if err := s.processDocument(ctx, f, compiledSecrets, forceReindex, seen); err != nil {
+		err := s.processDocument(ctx, f, compiledSecrets, forceReindex, seen)
+		if outcome != nil {
+			if err != nil {
+				outcome.markErrorIfUnset(manifestErrorCode(err), RedactSecretsInMessage(err.Error(), compiledSecrets))
+			} else {
+				s.recordAssetOutputs(ctx, outcome, f.RelPath)
+			}
+			s.batch.finalize(outcome)
+			s.activeOutcome = nil
+		}
+
+		if err != nil {
 			s.addErrors(1)
 			// record that we saw the file even if processing failed so
 			// markMissingAsDeleted does not treat it as removed
@@ -869,6 +935,29 @@ func (s *Service) runScan(ctx context.Context) error {
 	}
 
 	return s.markMissingAsDeleted(ctx, existing, seen)
+}
+
+// recordAssetOutputs records the rep_types persisted for a successfully-processed
+// asset onto its batch manifest outcome (SPEC §8.6.11 "outputs produced"). It is
+// best-effort: a store that cannot list rep_types, or a lookup error, leaves
+// outputs empty — the manifest is advisory and must never fail an ingest.
+func (s *Service) recordAssetOutputs(ctx context.Context, outcome *assetOutcome, relPath string) {
+	if outcome == nil {
+		return
+	}
+	lister, ok := s.store.(interface {
+		RepresentationTypesByPath(context.Context, string) ([]string, error)
+	})
+	if !ok {
+		return
+	}
+	types, err := lister.RepresentationTypesByPath(ctx, relPath)
+	if err != nil {
+		return
+	}
+	for _, t := range types {
+		outcome.addOutput(t)
+	}
 }
 
 // etagUnchanged reports whether a remote (object-store) source object can be
@@ -1041,6 +1130,9 @@ func (s *Service) processDocument(ctx context.Context, f DiscoveredFile, secretP
 	if buildErr != nil {
 		return s.persistBuildError(ctx, f, secretPatterns, buildErr)
 	}
+	// Stamp the resolved content_hash onto the batch manifest outcome (§8.6.11);
+	// no-op when no batch run is active.
+	s.recordContentHash(doc.ContentHash)
 
 	existingDoc, err := s.store.GetDocumentByPath(ctx, doc.RelPath)
 	if isUnexpectedStoreErr(err) {
@@ -1061,6 +1153,7 @@ func (s *Service) processDocument(ctx context.Context, f DiscoveredFile, secretP
 		s.addIndexed(1)
 	case "skipped", "secret_excluded":
 		s.addSkipped(1)
+		s.markActiveSkipped()
 	case "error":
 		// although buildDocumentWithContent will never return a document with
 		// Status="error" (the error case returns early above), we leave this
@@ -1078,6 +1171,9 @@ func (s *Service) processDocument(ctx context.Context, f DiscoveredFile, secretP
 	}
 
 	if !needsProcessing || doc.Status != "ok" {
+		// No representation work performed this run (cache hit / unchanged content
+		// / non-ok status): record it as skipped for the batch manifest (§8.6.11).
+		s.markActiveSkipped()
 		return nil
 	}
 

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -1081,6 +1081,44 @@ func (s *SQLiteStore) RepresentationMetaByType(ctx context.Context, relPath, rep
 	return metaJSON, nil
 }
 
+// RepresentationTypesByPath returns the distinct rep_types of the active
+// (non-deleted) representations for the document at relPath, sorted for
+// deterministic output. Used by the batch run manifest (SPEC §8.6.11) to record
+// the "outputs produced" for an asset. A missing document yields an empty slice
+// and a nil error (no outputs, not an error).
+func (s *SQLiteStore) RepresentationTypesByPath(ctx context.Context, relPath string) ([]string, error) {
+	normalizedPath, err := normalizeRelPath(relPath)
+	if err != nil {
+		return nil, err
+	}
+	db, err := s.ensureDB(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer s.ReleaseDB()
+
+	rows, err := db.QueryContext(ctx, `
+SELECT DISTINCT r.rep_type
+  FROM representations r
+  JOIN documents d ON d.doc_id = r.doc_id
+ WHERE d.rel_path = ? AND d.deleted = 0 AND r.deleted = 0
+ ORDER BY r.rep_type ASC`, normalizedPath)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var types []string
+	for rows.Next() {
+		var t string
+		if err := rows.Scan(&t); err != nil {
+			return nil, err
+		}
+		types = append(types, t)
+	}
+	return types, rows.Err()
+}
+
 // SoftDeleteSidecarTranscripts tombstones (deleted = 1) the document's
 // sidecar-sourced transcript representations and their chunks, returning the
 // number of representations retired. A representation is treated as

--- a/tests/config/media_batch_config_test.go
+++ b/tests/config/media_batch_config_test.go
@@ -1,0 +1,81 @@
+package tests
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+)
+
+// TestMediaBatch_DefaultsOff pins that the batch-ergonomics surface (SPEC §8.6.11)
+// is fully off by default, so a default ingest is unchanged.
+func TestMediaBatch_DefaultsOff(t *testing.T) {
+	cfg := config.Default()
+	if cfg.MediaBatchTwoPhase || cfg.MediaBatchProgress || cfg.MediaBatchManifest != "" {
+		t.Fatalf("media.batch must default off: two_phase=%v progress=%v manifest=%q",
+			cfg.MediaBatchTwoPhase, cfg.MediaBatchProgress, cfg.MediaBatchManifest)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("default config must validate: %v", err)
+	}
+}
+
+// TestMediaBatch_NestedYAMLApplies pins the nested YAML form (media.batch.*) is
+// honored — media.batch must be a recognized map section.
+func TestMediaBatch_NestedYAMLApplies(t *testing.T) {
+	tmp := t.TempDir()
+	path := tmp + "/.dir2mcp.yaml"
+	writeFile(t, path, ""+
+		"root_dir: ./repo\n"+
+		"media:\n"+
+		"  batch:\n"+
+		"    progress: true\n"+
+		"    manifest: run.jsonl\n")
+
+	t.Setenv("DIR2MCP_DISABLE_KEYCHAIN", "1")
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.MediaBatchProgress {
+		t.Fatal("nested media.batch.progress was ignored")
+	}
+	if cfg.MediaBatchManifest != "run.jsonl" {
+		t.Fatalf("media.batch.manifest = %q, want run.jsonl", cfg.MediaBatchManifest)
+	}
+}
+
+// TestMediaBatch_TwoPhaseRejected pins that enabling the not-yet-implemented
+// two-phase pass split is rejected up front rather than silently behaving as
+// single-pass.
+func TestMediaBatch_TwoPhaseRejected(t *testing.T) {
+	cfg := config.Default()
+	cfg.MediaBatchTwoPhase = true
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("media.batch.two_phase=true must fail validation (not yet implemented)")
+	}
+	if !strings.Contains(err.Error(), "two_phase") {
+		t.Fatalf("error should name two_phase, got: %v", err)
+	}
+}
+
+// TestMediaBatch_RoundTrip pins the non-secret knobs survive a snapshot
+// round-trip via the flat keys.
+func TestMediaBatch_RoundTrip(t *testing.T) {
+	tmp := t.TempDir()
+	path := tmp + "/.dir2mcp.yaml"
+	writeFile(t, path, ""+
+		"root_dir: ./repo\n"+
+		"media_batch_progress: true\n"+
+		"media_batch_manifest: /tmp/run.jsonl\n")
+
+	t.Setenv("DIR2MCP_DISABLE_KEYCHAIN", "1")
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.MediaBatchProgress || cfg.MediaBatchManifest != "/tmp/run.jsonl" {
+		t.Fatalf("flat keys not loaded: progress=%v manifest=%q", cfg.MediaBatchProgress, cfg.MediaBatchManifest)
+	}
+}

--- a/tests/ingest/batch_manifest_test.go
+++ b/tests/ingest/batch_manifest_test.go
@@ -1,0 +1,139 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// readManifest parses a JSONL run manifest (SPEC §8.6.11) into one map per line.
+func readManifest(t *testing.T, path string) []map[string]any {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read manifest %s: %v", path, err)
+	}
+	var recs []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(string(raw)), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			t.Fatalf("manifest line not valid JSON (%q): %v", line, err)
+		}
+		recs = append(recs, rec)
+	}
+	return recs
+}
+
+// TestServiceRun_BatchManifest pins the JSONL run manifest (SPEC §8.6.11): a
+// record per asset with the required fields, "skipped" status on a cache-hit
+// second run, and truncate-and-rewrite each run.
+func TestServiceRun_BatchManifest(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, "a.txt"), []byte("alpha text"))
+	mustWriteFile(t, filepath.Join(root, "sub", "b.txt"), []byte("beta text"))
+
+	stateDir := filepath.Join(t.TempDir(), "state")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state: %v", err)
+	}
+	manifestPath := filepath.Join(stateDir, "run.jsonl")
+
+	cfg := config.Default()
+	cfg.RootDir = root
+	cfg.StateDir = stateDir
+	cfg.MediaBatchManifest = manifestPath
+	cfg.MediaBatchProgress = true
+
+	st := store.NewSQLiteStore(filepath.Join(stateDir, "meta.sqlite"))
+	defer func() { _ = st.Close() }()
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	svc := mustNewIngestService(t, cfg, st)
+
+	// First run: both assets are newly processed -> completed.
+	if err := svc.Run(ctx); err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+	recs := readManifest(t, manifestPath)
+	if len(recs) != 2 {
+		t.Fatalf("want 2 manifest records, got %d: %+v", len(recs), recs)
+	}
+	byPath := map[string]map[string]any{}
+	for _, r := range recs {
+		rel, _ := r["rel_path"].(string)
+		byPath[rel] = r
+	}
+	for _, p := range []string{"a.txt", "sub/b.txt"} {
+		r, ok := byPath[p]
+		if !ok {
+			t.Fatalf("manifest missing record for %s; got %+v", p, byPath)
+		}
+		if r["status"] != "completed" {
+			t.Fatalf("%s: status=%v, want completed", p, r["status"])
+		}
+		if h, _ := r["content_hash"].(string); h == "" {
+			t.Fatalf("%s: missing content_hash (a §8.6.11 MUST field)", p)
+		}
+		if _, ok := r["processing_ms"]; !ok {
+			t.Fatalf("%s: missing processing_ms", p)
+		}
+	}
+
+	// Second run over the unchanged corpus: cache hits -> skipped, and the
+	// manifest is truncated and rewritten (still exactly 2 records).
+	if err := svc.Run(ctx); err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+	recs2 := readManifest(t, manifestPath)
+	if len(recs2) != 2 {
+		t.Fatalf("second run: want 2 records (truncated+rewritten), got %d", len(recs2))
+	}
+	for _, r := range recs2 {
+		if r["status"] != "skipped" {
+			t.Fatalf("second run %v: status=%v, want skipped (cache hit)", r["rel_path"], r["status"])
+		}
+	}
+}
+
+// TestServiceRun_BatchManifestDisabledWritesNothing pins that with the manifest
+// unconfigured (default), no manifest file is written.
+func TestServiceRun_BatchManifestDisabledWritesNothing(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, "a.txt"), []byte("alpha text"))
+
+	stateDir := filepath.Join(t.TempDir(), "state")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state: %v", err)
+	}
+	candidate := filepath.Join(stateDir, "run.jsonl")
+
+	cfg := config.Default()
+	cfg.RootDir = root
+	cfg.StateDir = stateDir
+	// MediaBatchManifest left empty -> disabled.
+
+	st := store.NewSQLiteStore(filepath.Join(stateDir, "meta.sqlite"))
+	defer func() { _ = st.Close() }()
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	svc := mustNewIngestService(t, cfg, st)
+	if err := svc.Run(ctx); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if _, err := os.Stat(candidate); !os.IsNotExist(err) {
+		t.Fatalf("manifest should not exist when disabled (stat err=%v)", err)
+	}
+}

--- a/tests/store/representation_types_test.go
+++ b/tests/store/representation_types_test.go
@@ -1,0 +1,62 @@
+package tests
+
+import (
+	"context"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// TestRepresentationTypesByPath pins the read side of the batch run manifest's
+// "outputs produced" field (SPEC §8.6.11): the distinct, sorted rep_types of a
+// document's active representations, with a missing document reported as an empty
+// slice (no outputs) rather than an error.
+func TestRepresentationTypesByPath(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	defer func() { _ = st.Close() }()
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	if err := st.UpsertDocument(ctx, model.Document{
+		RelPath: "media/a.mp4", DocType: "video", ContentHash: "h1", Status: "ok",
+	}); err != nil {
+		t.Fatalf("UpsertDocument: %v", err)
+	}
+	doc, err := st.GetDocumentByPath(ctx, "media/a.mp4")
+	if err != nil {
+		t.Fatalf("GetDocumentByPath: %v", err)
+	}
+
+	// Two distinct active rep types (out of insertion order, to prove sorting).
+	for _, r := range []model.Representation{
+		{DocID: doc.DocID, RepType: "transcript-es", RepHash: "r1"},
+		{DocID: doc.DocID, RepType: "transcript", RepHash: "r2"},
+	} {
+		if _, err := st.UpsertRepresentation(ctx, r); err != nil {
+			t.Fatalf("UpsertRepresentation %s: %v", r.RepType, err)
+		}
+	}
+
+	types, err := st.RepresentationTypesByPath(ctx, "media/a.mp4")
+	if err != nil {
+		t.Fatalf("RepresentationTypesByPath: %v", err)
+	}
+	want := []string{"transcript", "transcript-es"}
+	if !reflect.DeepEqual(types, want) {
+		t.Fatalf("types = %v, want %v (distinct + sorted)", types, want)
+	}
+
+	// A missing document yields an empty slice and a nil error.
+	missing, err := st.RepresentationTypesByPath(ctx, "media/nope.mp4")
+	if err != nil {
+		t.Fatalf("RepresentationTypesByPath(missing): %v", err)
+	}
+	if len(missing) != 0 {
+		t.Fatalf("missing doc types = %v, want empty", missing)
+	}
+}


### PR DESCRIPTION
## Summary
Implements the **manifest + progress** half of SPEC §8.6.11 batch ergonomics for large-archive media ingests (dir2mcp #260), all opt-in and off by default.

- **`media.batch` config** — `two_phase` / `progress` / `manifest` (nested + flat keys, snapshot round-trip, `media.batch` registered as a map section). Disabled ⇒ ingest is byte-identical to today.
- **JSONL run manifest** (`media.batch.manifest`) — one record per asset: `rel_path` + `content_hash`, terminal `status` (`completed`/`skipped`/`error`) + canonical §14.4 `error_code`, `processing_ms`, and `outputs` (the doc's persisted rep_types). Truncate-and-rewrite per run; **advisory for resume** (live identity/cache/mtime gates always win); **fail-open** (a manifest error never fails an ingest).
- **Progress** (`media.batch.progress`) — side-channel, monotonic against a per-pass total established at pass start; cache hits count as completed; never alters outputs/ordering.
- **store** — `RepresentationTypesByPath` (distinct, sorted active rep_types) feeds the manifest 'outputs produced'.

## Two-phase: deferred (Part of #260, not Closes)
The optional **two-phase pass split** (transcribe-all → derive-all) is the invasive part — it restructures the per-document `runScan`/`processDocument` pipeline into two ordered passes. To keep this PR focused and reviewable, `media.batch.two_phase=true` is **rejected at config validation** (honest: not-yet-implemented) rather than silently behaving as single-pass. The single-pass path already produces identical representations/chunks/citations, so manifest + progress are fully usable now. Two-phase will land as a focused follow-up.

## Tests
- `tests/store/representation_types_test.go` — distinct/sorted rep_types + missing-doc empty.
- `tests/config/media_batch_config_test.go` — defaults off; nested YAML; two_phase rejected; flat round-trip.
- `tests/ingest/batch_manifest_test.go` — manifest record per asset with required fields; cache-hit second run ⇒ skipped + truncate/rewrite; disabled ⇒ no manifest file.

`make check` green. No spec re-pin (§8.6.11 already on main at 0.21.0). No MCP tool/citation contract changes.

Part of #260.