### PR TITLE
feat(ingest): two-phase ingest pass split (#260)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2989,18 +2989,14 @@ func (c *Config) Validate() error {
 	return nil
 }
 
-// validateMediaBatch enforces the media.batch (SPEC §8.6.11) invariants. The
-// JSONL run manifest and side-channel progress are implemented; the two-phase
-// pass split (media.batch.two_phase) is NOT yet implemented, so enabling it is
-// rejected up front rather than silently behaving as single-pass — an honest
-// error beats a no-op flag. (The single-pass path already produces the same
-// representations/chunks/citations, so manifest + progress are fully usable
-// today.)
+// validateMediaBatch enforces the media.batch (SPEC §8.6.11) invariants. All
+// three features — the two-phase pass split (media.batch.two_phase), the JSONL
+// run manifest, and side-channel progress — are implemented. The two-phase split
+// is observably equivalent to single-pass for the resulting
+// representations/chunks/embeddings/citations (it reorders work into a
+// transcription pass then a derivation pass, never changing output), so it has no
+// config interdependencies to reject here; it is a self-contained ordering toggle.
 func (c *Config) validateMediaBatch() error {
-	if c.MediaBatchTwoPhase {
-		return fmt.Errorf("media.batch.two_phase is not yet implemented; " +
-			"use media.batch.manifest and media.batch.progress (single-pass) for now")
-	}
 	return nil
 }
 

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -219,6 +219,51 @@ type Service struct {
 	// generators stamp produced outputs onto it via recordOutput. Nil when no
 	// batch run is active, making recordOutput a no-op on the hot path.
 	activeOutcome *assetOutcome
+
+	// activePass selects which work the representation generators perform for the
+	// asset currently being processed under the optional two-phase pass split
+	// (SPEC §8.6.11). runScan sets it around each per-asset call (the scan loop is
+	// sequential). passSingle (the zero value) is the default single-pass pipeline
+	// — byte-identical to before the split existed. passTranscription produces
+	// every representation EXCEPT translated transcripts; passDerivation produces
+	// ONLY translated transcripts from the already-computed (cached) source
+	// transcript. The split changes ordering and reporting only, never the final
+	// representations/chunks/embeddings/citations.
+	activePass processPass
+}
+
+// processPass is the per-asset work selector for the optional two-phase pass
+// split (SPEC §8.6.11). The two ordered passes together produce exactly the same
+// representations as a single pass; each pass is independently resumable via the
+// existing identity/cache state (§7.6/§8.6.7).
+type processPass int
+
+const (
+	// passSingle runs the full per-document pipeline (transcription THEN
+	// derivation) in one go. It is the default and is observably identical to the
+	// pipeline before the two-phase split was introduced.
+	passSingle processPass = iota
+	// passTranscription runs every representation step EXCEPT translated
+	// transcripts: raw text, OCR/extracted markdown, direct media chunks, and the
+	// source (STT/sidecar) transcript with its chunks.
+	passTranscription
+	// passDerivation runs ONLY the derivation step (translation §8.6.2) for media
+	// documents, reusing the cached source transcript so it never re-transcribes.
+	passDerivation
+)
+
+// passLabel maps a pass to its manifest/progress label (SPEC §8.6.11). The
+// single pass carries no label so its manifest records stay identical to the
+// pre-split single-pass output.
+func (p processPass) label() string {
+	switch p {
+	case passTranscription:
+		return "transcription"
+	case passDerivation:
+		return "derivation"
+	default:
+		return ""
+	}
 }
 
 // recordContentHash stamps the resolved content_hash (§7.6) onto the asset
@@ -886,16 +931,60 @@ func (s *Service) runScan(ctx context.Context) error {
 	defer func() {
 		s.batch.close()
 		s.batch = nil
+		s.activePass = passSingle
 	}()
-	s.batch.startPass("", len(discovered))
 
 	seen := make(map[string]struct{}, len(discovered))
+
+	// Optional two-phase pass split (SPEC §8.6.11): run media ingest as two ordered
+	// passes over the corpus — a transcription pass (STT/sidecar → source
+	// transcript, plus all non-media representations) followed by a derivation pass
+	// (translation §8.6.2). It is observably equivalent to single-pass for the
+	// resulting representations/chunks/embeddings/citations (it changes ordering and
+	// reporting only), and each pass is independently resumable via the existing
+	// identity/cache state (§7.6/§8.6.7) so an interrupted transcription pass does
+	// not force re-transcription of completed assets. Default (off) is the single
+	// pass below, byte-identical to before the split existed.
+	if s.cfg.MediaBatchTwoPhase {
+		if err := s.scanPass(ctx, passTranscription, discovered, compiledSecrets, forceReindex, seen); err != nil {
+			return err
+		}
+		if err := s.scanPass(ctx, passDerivation, discovered, compiledSecrets, forceReindex, seen); err != nil {
+			return err
+		}
+		return s.markMissingAsDeleted(ctx, existing, seen)
+	}
+
+	if err := s.scanPass(ctx, passSingle, discovered, compiledSecrets, forceReindex, seen); err != nil {
+		return err
+	}
+	return s.markMissingAsDeleted(ctx, existing, seen)
+}
+
+// scanPass processes every discovered asset once under the given pass (SPEC
+// §8.6.11). passSingle runs the full pipeline; passTranscription and
+// passDerivation are the two ordered halves of the two-phase split. The same
+// per-asset processing is reused across all three passes — only the work each
+// representation generator performs differs, governed by s.activePass. The seen
+// set is shared across passes so markMissingAsDeleted sees the union of assets
+// observed in either pass.
+func (s *Service) scanPass(ctx context.Context, pass processPass, discovered []DiscoveredFile, compiledSecrets []*regexp.Regexp, forceReindex bool, seen map[string]struct{}) error {
+	s.activePass = pass
+	s.batch.startPass(pass.label(), len(discovered))
+
 	for _, f := range discovered {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
 
-		s.addScanned(1)
+		// Scan/skip counters reflect the corpus, not the pass: count them only on the
+		// first (or only) pass so a two-phase run reports the same totals as
+		// single-pass. The derivation pass reuses the same per-asset processing but
+		// must not double-count.
+		countCorpus := pass != passDerivation
+		if countCorpus {
+			s.addScanned(1)
+		}
 
 		var outcome *assetOutcome
 		if s.batch != nil {
@@ -904,7 +993,9 @@ func (s *Service) runScan(ctx context.Context) error {
 		}
 
 		if matchesAnyPathExclude(f.RelPath, s.cfg.PathExcludes) {
-			s.addSkipped(1)
+			if countCorpus {
+				s.addSkipped(1)
+			}
 			if outcome != nil {
 				outcome.markSkipped()
 				s.batch.finalize(outcome)
@@ -925,7 +1016,9 @@ func (s *Service) runScan(ctx context.Context) error {
 		}
 
 		if err != nil {
-			s.addErrors(1)
+			if countCorpus {
+				s.addErrors(1)
+			}
 			// record that we saw the file even if processing failed so
 			// markMissingAsDeleted does not treat it as removed
 			seen[f.RelPath] = struct{}{}
@@ -933,8 +1026,7 @@ func (s *Service) runScan(ctx context.Context) error {
 		}
 		seen[f.RelPath] = struct{}{}
 	}
-
-	return s.markMissingAsDeleted(ctx, existing, seen)
+	return nil
 }
 
 // recordAssetOutputs records the rep_types persisted for a successfully-processed
@@ -1118,6 +1210,16 @@ func (s *Service) refreshDocID(ctx context.Context, doc *model.Document) error {
 }
 
 func (s *Service) processDocument(ctx context.Context, f DiscoveredFile, secretPatterns []*regexp.Regexp, forceReindex bool, seen map[string]struct{}) error {
+	// Two-phase derivation pass (SPEC §8.6.11): the transcription pass already did
+	// all document building, upserting, counting, and source-transcript work for
+	// this asset; the derivation pass runs ONLY translation (§8.6.2) and re-doing
+	// the full document pipeline here would either double-count or be gated out by
+	// the unchanged-content check (the document is identical to what the
+	// transcription pass just wrote). Route to the lean derivation-only path.
+	if s.activePass == passDerivation {
+		return s.deriveDocument(ctx, f, secretPatterns)
+	}
+
 	// Remote (S3) incremental fast path (SPEC §7.8.3, #245): when the object's
 	// ETag+size match the recorded document, the body is unchanged, so skip the
 	// full GET + content_hash recompute entirely. No-op for local/NFS corpora
@@ -1187,6 +1289,106 @@ func (s *Service) processDocument(ctx context.Context, f DiscoveredFile, secretP
 		return fmt.Errorf("generate representations: %w", err)
 	}
 	return nil
+}
+
+// deriveDocument runs the derivation pass for a single asset under the two-phase
+// split (SPEC §8.6.11): it produces ONLY translated transcripts (§8.6.2) from the
+// already-persisted source transcript, reusing the cached transcript text so it
+// never re-transcribes — which is what makes the derivation pass independently
+// resumable (§7.6/§8.6.7). All document building, upserting, counting, and
+// source-transcript work was already done by the transcription pass.
+//
+// It mirrors the gating of the single-pass translation step exactly so the final
+// set of representations is observably identical: translation applies only to a
+// model-derived (STT) transcript of an audio document, and only when translation
+// is configured. Non-media documents, sidecar-transcript documents, and assets
+// with no source transcript are recorded as skipped and produce nothing — keeping
+// the derivation pass's per-asset manifest/progress totals faithful (§8.6.11).
+func (s *Service) deriveDocument(ctx context.Context, f DiscoveredFile, secretPatterns []*regexp.Regexp) error {
+	// No translation configured, or the multimodal "replace" mode that stands in
+	// for STT→text (so no transcript exists to translate): nothing to derive. This
+	// matches the single-pass gates so the corpus-wide output is identical.
+	if s.translator == nil || len(s.translateTargetLangs) == 0 {
+		s.markActiveSkipped()
+		return nil
+	}
+
+	docType := ClassifyDocType(f.RelPath)
+	if docType != "audio" || s.transcriber == nil {
+		s.markActiveSkipped()
+		return nil
+	}
+
+	doc, err := s.store.GetDocumentByPath(ctx, f.RelPath)
+	if isUnexpectedStoreErr(err) {
+		return fmt.Errorf("get existing document: %w", err)
+	}
+	// A document the transcription pass did not record as a healthy media asset has
+	// no source transcript to translate; skip it.
+	if isNotFoundError(err) || doc.Status != "ok" {
+		s.markActiveSkipped()
+		return nil
+	}
+	s.recordContentHash(doc.ContentHash)
+
+	content, err := s.readDocumentContent(ctx, f.RelPath)
+	if err != nil {
+		// A read failure in the derivation pass must not fail the run: the source
+		// transcript already exists. Record skipped and move on.
+		s.getLogger().Printf("two-phase derivation: read %s: %v (skipping translation)", f.RelPath, err)
+		s.markActiveSkipped()
+		return nil
+	}
+
+	if err := s.deriveTranscriptTranslations(ctx, doc, content); err != nil {
+		s.getLogger().Printf("two-phase derivation translation skipped for %s: %v", f.RelPath, err)
+		s.addErrors(1)
+	}
+	return nil
+}
+
+// deriveTranscriptTranslations recomputes the source transcript (a cache hit, so
+// no re-transcription) and translates it, reusing the SAME derivation logic and
+// trim/alignment as the single-pass path so the resulting translated transcript
+// representations and chunks are byte-identical to single-pass (SPEC §8.6.11).
+func (s *Service) deriveTranscriptTranslations(ctx context.Context, doc model.Document, content []byte) error {
+	transcriptText, _, err := s.readOrComputeTranscriptWithWords(ctx, doc, content, "")
+	if err != nil {
+		return err
+	}
+	transcriptText = strings.TrimSpace(transcriptText)
+	if transcriptText == "" {
+		return nil
+	}
+
+	var duration time.Duration
+	if d, derr := s.probeDuration(ctx, doc); derr == nil {
+		duration = d
+	}
+
+	// Recompute the same leading-silence trim offset the transcription pass applied
+	// to the source transcript so translated time windows stay aligned (dir2mcp#258
+	// / SPEC §8.6.2). Detection is deterministic for an unchanged asset.
+	trimOffsetMS := 0
+	if s.cfg.MediaTrimLeadingSilence {
+		if offset := s.detectLeadingSilence(ctx, doc); offset > 0 {
+			trimOffsetMS = int(offset.Milliseconds())
+		}
+	}
+	return s.translateTranscriptRepresentations(ctx, doc, content, transcriptText, duration, trimOffsetMS)
+}
+
+// readDocumentContent reads an asset's bytes through the corpus filesystem,
+// localizing remote (object-store) objects as needed. Used by the two-phase
+// derivation pass, which needs the source bytes only to key the per-language
+// translation cache.
+func (s *Service) readDocumentContent(ctx context.Context, relPath string) ([]byte, error) {
+	rc, err := s.corpusFS().Open(ctx, relPath)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rc.Close() }()
+	return io.ReadAll(rc)
 }
 
 // handleArchiveDocument handles an archive-type document: if the archive
@@ -2208,6 +2410,15 @@ func (s *Service) generateTranscriptRepresentation(ctx context.Context, doc mode
 	// Translation is a best-effort enrichment: any failure (chat provider error,
 	// translated-rep persistence) is logged and counted but NOT propagated, so a
 	// failed translation never marks the source transcript's document as errored.
+	//
+	// Under the two-phase split (SPEC §8.6.11) translation is the derivation pass's
+	// job and runs in a later corpus-wide pass (see deriveDocument), so the
+	// transcription pass stops here after persisting the source transcript. The
+	// final set of representations is identical either way — only the ordering
+	// differs. In single-pass mode (the default) it runs inline as before.
+	if s.activePass == passTranscription {
+		return nil
+	}
 	if err := s.translateTranscriptRepresentations(ctx, doc, content, transcriptText, duration, trimOffsetMS); err != nil {
 		s.getLogger().Printf("transcript translation skipped for %s: %v", doc.RelPath, err)
 		s.addErrors(1)

--- a/tests/config/media_batch_config_test.go
+++ b/tests/config/media_batch_config_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/dirstral/dir2mcp/internal/config"
@@ -45,18 +44,15 @@ func TestMediaBatch_NestedYAMLApplies(t *testing.T) {
 	}
 }
 
-// TestMediaBatch_TwoPhaseRejected pins that enabling the not-yet-implemented
-// two-phase pass split is rejected up front rather than silently behaving as
-// single-pass.
-func TestMediaBatch_TwoPhaseRejected(t *testing.T) {
+// TestMediaBatch_TwoPhaseAccepted pins that enabling the two-phase pass split
+// (SPEC §8.6.11) validates: it is a self-contained ordering toggle with no config
+// interdependencies, observably equivalent to single-pass for the resulting
+// representations/chunks/embeddings/citations.
+func TestMediaBatch_TwoPhaseAccepted(t *testing.T) {
 	cfg := config.Default()
 	cfg.MediaBatchTwoPhase = true
-	err := cfg.Validate()
-	if err == nil {
-		t.Fatal("media.batch.two_phase=true must fail validation (not yet implemented)")
-	}
-	if !strings.Contains(err.Error(), "two_phase") {
-		t.Fatalf("error should name two_phase, got: %v", err)
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("media.batch.two_phase=true must validate: %v", err)
 	}
 }
 

--- a/tests/ingest/two_phase_test.go
+++ b/tests/ingest/two_phase_test.go
@@ -1,0 +1,299 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// repSnapshot is a deterministic, store-independent fingerprint of one
+// representation and its chunks. It is the unit of comparison for the two-phase
+// vs single-pass equivalence property (SPEC §8.6.11): two passes must produce the
+// SAME representations/chunks as a single pass.
+type repSnapshot struct {
+	RepType string
+	Meta    string
+	Chunks  []chunkSnapshot
+}
+
+type chunkSnapshot struct {
+	Ordinal   int
+	Text      string
+	TextHash  string
+	IndexKind string
+}
+
+// snapshotDoc collects every active transcript representation for a document plus
+// each representation's ordered chunks into a deterministic slice, so two runs can
+// be compared for byte-equivalence of their derived output.
+func snapshotDoc(t *testing.T, st *store.SQLiteStore, relPath string) []repSnapshot {
+	t.Helper()
+	ctx := context.Background()
+	reps, err := st.TranscriptRepresentations(ctx, relPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatalf("TranscriptRepresentations(%s): %v", relPath, err)
+	}
+	out := make([]repSnapshot, 0, len(reps))
+	for _, r := range reps {
+		chunks, err := st.GetChunksByRepID(ctx, r.RepID)
+		if err != nil {
+			t.Fatalf("GetChunksByRepID(%d): %v", r.RepID, err)
+		}
+		cs := make([]chunkSnapshot, 0, len(chunks))
+		for _, c := range chunks {
+			cs = append(cs, chunkSnapshot{
+				Ordinal:   c.Ordinal,
+				Text:      c.Text,
+				TextHash:  c.TextHash,
+				IndexKind: c.IndexKind,
+			})
+		}
+		sort.Slice(cs, func(i, j int) bool { return cs[i].Ordinal < cs[j].Ordinal })
+		out = append(out, repSnapshot{
+			// rep_type is encoded in meta_json (language + source); use the normalized
+			// meta as the stable rep identity so source/translated reps are
+			// distinguishable without an extra store accessor.
+			RepType: repTypeFromMeta(r.MetaJSON),
+			Meta:    normalizeMeta(t, r.MetaJSON),
+			Chunks:  cs,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].RepType < out[j].RepType })
+	return out
+}
+
+// repTypeFromMeta derives a stable rep identity label from a transcript rep's
+// meta_json (source + language), independent of the store's internal rep_type
+// column. It is used only to order/compare snapshots deterministically.
+func repTypeFromMeta(metaJSON string) string {
+	var m map[string]any
+	if err := json.Unmarshal([]byte(metaJSON), &m); err != nil {
+		return metaJSON
+	}
+	source, _ := m["source"].(string)
+	lang, _ := m["language"].(string)
+	return fmt.Sprintf("%s/%s", source, lang)
+}
+
+// normalizeMeta re-marshals meta_json with sorted keys so two semantically-equal
+// metas compare equal regardless of field order.
+func normalizeMeta(t *testing.T, metaJSON string) string {
+	t.Helper()
+	if strings.TrimSpace(metaJSON) == "" {
+		return ""
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(metaJSON), &m); err != nil {
+		t.Fatalf("meta_json not valid json (%q): %v", metaJSON, err)
+	}
+	out, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("re-marshal meta: %v", err)
+	}
+	return string(out)
+}
+
+// twoPhaseHarness builds an identical corpus + service for an equivalence run and
+// returns the corpus rel paths plus the store for snapshotting.
+type twoPhaseHarness struct {
+	root     string
+	stateDir string
+	store    *store.SQLiteStore
+	svc      *ingest.Service
+	relPaths []string
+}
+
+// newTwoPhaseHarness writes a fixed corpus (two text files + two audio files) and
+// wires a service with a deterministic STT identity, fake transcriber, and fake
+// translator (target "en"; source language "de"). twoPhase selects the pass mode.
+// A fresh translator instance is returned so callers can assert call counts.
+func newTwoPhaseHarness(t *testing.T, twoPhase bool) (*twoPhaseHarness, *fakeTranslator) {
+	t.Helper()
+	root := t.TempDir()
+	stateDir := t.TempDir()
+
+	rel := []string{"notes/a.txt", "notes/b.txt", "audio/one.mp3", "audio/two.mp3"}
+	mustWriteFile(t, filepath.Join(root, "notes", "a.txt"), []byte("alpha text body"))
+	mustWriteFile(t, filepath.Join(root, "notes", "b.txt"), []byte("beta text body"))
+	mustWriteFile(t, filepath.Join(root, "audio", "one.mp3"), []byte("fake-audio-one"))
+	mustWriteFile(t, filepath.Join(root, "audio", "two.mp3"), []byte("fake-audio-two"))
+
+	st := store.NewSQLiteStore(filepath.Join(stateDir, "meta.sqlite"))
+	if err := st.Init(context.Background()); err != nil {
+		t.Fatalf("store init: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	cfg := config.Config{
+		RootDir:            root,
+		StateDir:           stateDir,
+		STTProvider:        "off",
+		MediaBatchTwoPhase: twoPhase,
+	}
+	svc := mustNewIngestService(t, cfg, st)
+	svc.SetTranscriber(&fakeTranscriber{text: "[00:00] intro line\n[00:02] second line\n[00:05] third line"})
+	svc.SetSTTIdentity("whisper", "whisper-large-v3")
+	svc.SetTranscriptLanguage("de")
+	tr := &fakeTranslator{}
+	svc.SetTranslator(tr, "mistral", "mistral-small-2506", []string{"en"})
+
+	return &twoPhaseHarness{root: root, stateDir: stateDir, store: st, svc: svc, relPaths: rel}, tr
+}
+
+// TestTwoPhase_EquivalentToSinglePass is the core property test (SPEC §8.6.11):
+// running media ingest as two ordered passes (transcription then derivation) MUST
+// produce the SAME representations and chunks as a single pass over the same
+// corpus. Only ordering/reporting differ — never the derived output.
+func TestTwoPhase_EquivalentToSinglePass(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	single, _ := newTwoPhaseHarness(t, false)
+	if err := single.svc.Run(ctx); err != nil {
+		t.Fatalf("single-pass Run: %v", err)
+	}
+
+	two, _ := newTwoPhaseHarness(t, true)
+	if err := two.svc.Run(ctx); err != nil {
+		t.Fatalf("two-phase Run: %v", err)
+	}
+
+	for _, rel := range single.relPaths {
+		got := snapshotDoc(t, two.store, rel)
+		want := snapshotDoc(t, single.store, rel)
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("two-phase output for %s differs from single-pass.\n two-phase: %#v\n single  : %#v", rel, got, want)
+		}
+	}
+
+	// Sanity: the audio docs must actually have produced BOTH a source and a
+	// translated transcript, otherwise the equivalence above is vacuous.
+	for _, rel := range []string{"audio/one.mp3", "audio/two.mp3"} {
+		snap := snapshotDoc(t, single.store, rel)
+		if len(snap) != 2 {
+			t.Fatalf("expected source + translated transcript for %s, got %d: %#v", rel, len(snap), snap)
+		}
+	}
+}
+
+// TestTwoPhase_DerivationDoesNotRetranscribe pins the resumability property (SPEC
+// §8.6.11 / §7.6/§8.6.7): the derivation pass reuses the cached source transcript
+// and never re-invokes the transcriber. With two audio files, the transcriber is
+// called exactly once per file across BOTH passes — the derivation pass adds zero
+// transcribe calls.
+func TestTwoPhase_DerivationDoesNotRetranscribe(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	h, _ := newTwoPhaseHarness(t, true)
+	tr := &fakeTranscriber{text: "[00:00] one\n[00:02] two"}
+	h.svc.SetTranscriber(tr)
+
+	if err := h.svc.Run(ctx); err != nil {
+		t.Fatalf("two-phase Run: %v", err)
+	}
+
+	// Two audio assets -> the transcription pass transcribes each once; the
+	// derivation pass hits the transcript cache and must NOT transcribe again.
+	if tr.calls != 2 {
+		t.Fatalf("expected exactly 2 transcribe calls (one per audio asset, none in derivation pass), got %d", tr.calls)
+	}
+}
+
+// TestTwoPhase_ManifestRecordsCarryPass pins that, under the two-phase split, each
+// manifest record (SPEC §8.6.11) carries the correct `pass` label: the
+// transcription pass records carry "transcription" and the derivation pass records
+// carry "derivation", with every asset appearing in both passes.
+func TestTwoPhase_ManifestRecordsCarryPass(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	h, _ := newTwoPhaseHarness(t, true)
+	manifestPath := filepath.Join(h.stateDir, "run.jsonl")
+	// Rebuild the service with the manifest enabled (newTwoPhaseHarness leaves it
+	// off); reuse the same corpus/store so the run is otherwise identical.
+	cfg := config.Config{
+		RootDir:            h.root,
+		StateDir:           h.stateDir,
+		STTProvider:        "off",
+		MediaBatchTwoPhase: true,
+		MediaBatchManifest: manifestPath,
+		MediaBatchProgress: true,
+	}
+	svc := mustNewIngestService(t, cfg, h.store)
+	svc.SetTranscriber(&fakeTranscriber{text: "[00:00] intro line\n[00:02] second line"})
+	svc.SetSTTIdentity("whisper", "whisper-large-v3")
+	svc.SetTranscriptLanguage("de")
+	svc.SetTranslator(&fakeTranslator{}, "mistral", "m", []string{"en"})
+
+	if err := svc.Run(ctx); err != nil {
+		t.Fatalf("two-phase Run with manifest: %v", err)
+	}
+
+	recs := readManifest(t, manifestPath)
+	// 4 assets x 2 passes = 8 records.
+	if len(recs) != 8 {
+		t.Fatalf("want 8 manifest records (4 assets x 2 passes), got %d: %+v", len(recs), recs)
+	}
+	passCounts := map[string]int{}
+	for _, r := range recs {
+		p, _ := r["pass"].(string)
+		passCounts[p]++
+	}
+	if passCounts["transcription"] != 4 {
+		t.Fatalf("want 4 transcription-pass records, got %d (%v)", passCounts["transcription"], passCounts)
+	}
+	if passCounts["derivation"] != 4 {
+		t.Fatalf("want 4 derivation-pass records, got %d (%v)", passCounts["derivation"], passCounts)
+	}
+}
+
+// TestTwoPhase_DisabledIsSinglePassManifest pins that with two-phase OFF (the
+// default), manifest records carry NO pass label — byte-identical to the
+// pre-split single-pass manifest.
+func TestTwoPhase_DisabledIsSinglePassManifest(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	h, _ := newTwoPhaseHarness(t, false)
+	manifestPath := filepath.Join(h.stateDir, "run.jsonl")
+	cfg := config.Config{
+		RootDir:            h.root,
+		StateDir:           h.stateDir,
+		STTProvider:        "off",
+		MediaBatchManifest: manifestPath,
+		MediaBatchProgress: true,
+	}
+	svc := mustNewIngestService(t, cfg, h.store)
+	svc.SetTranscriber(&fakeTranscriber{text: "[00:00] intro line"})
+	svc.SetSTTIdentity("whisper", "whisper-large-v3")
+	svc.SetTranscriptLanguage("de")
+	svc.SetTranslator(&fakeTranslator{}, "mistral", "m", []string{"en"})
+
+	if err := svc.Run(ctx); err != nil {
+		t.Fatalf("single-pass Run with manifest: %v", err)
+	}
+
+	recs := readManifest(t, manifestPath)
+	if len(recs) != 4 {
+		t.Fatalf("want 4 single-pass manifest records (one per asset), got %d", len(recs))
+	}
+	for _, r := range recs {
+		if p, ok := r["pass"]; ok && p != "" {
+			t.Fatalf("single-pass manifest record must not carry a pass label, got %v", p)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Implements the remaining part of #260 — the **two-phase pass split** (SPEC §8.6.11). PR #315 already delivered `media.batch` config, the JSONL run manifest, and progress reporting; `two_phase=true` was rejected at config validation as not-yet-implemented. This PR implements it and removes that rejection.

Two-phase mode is **opt-in** (`media.batch.two_phase`, off by default). When enabled, media ingest runs as **two ordered passes** over the corpus:

1. **transcription pass** — STT/sidecar → source transcript, plus every non-media representation (raw text, OCR/extracted markdown, direct media chunks);
2. **derivation pass** — translation (§8.6.2) of the source transcript.

It is **observably equivalent** to single-pass for the resulting representations/chunks/embeddings/citations — only ordering and reporting differ. Each pass is independently **resumable** via the existing identity/cache state (§7.6/§8.6.7): the derivation pass reuses the cached source transcript and never re-transcribes.

## Seam

`runScan` now iterates the corpus once (`passSingle`, default) or twice (`passTranscription` then `passDerivation`) via an extracted `scanPass` helper. A `processPass` value on the service (`s.activePass`, set per-asset like the existing `activeOutcome`) governs what the representation generators do:

- transcription pass: `generateTranscriptRepresentation` stops after persisting the source transcript, skipping the inline translation call;
- derivation pass: `processDocument` routes to a lean `deriveDocument` that skips all document rebuild/upsert/counting (already done in pass 1) and recomputes the cached source transcript (cache hit, no re-transcribe) to drive only the translation step.

This reuses the existing per-document translation logic (`translateTranscriptRepresentations`) so the derived output is byte-identical to single-pass.

## Non-media documents

Text/OCR/image/PDF/archive documents have no translation derivation, so they are fully processed in the **transcription pass** and are no-ops (recorded `skipped`) in the **derivation pass**. Corpus-level scan counters are credited only on the transcription/single pass to avoid double-counting; the manifest faithfully records every asset in both passes.

## Determinism & resumability

Asset order within each pass is the discovery order (deterministic). The transcript cache key (bytes + STT identity) makes the derivation pass a cache hit, so an interrupted transcription pass does not force re-transcription of completed assets.

## Tests (external package, `tests/ingest`)

- `TestTwoPhase_EquivalentToSinglePass` — **key property**: two-phase produces the same transcript representations and chunks as single-pass over an identical corpus (with a sanity check that audio docs really produced source + translated reps).
- `TestTwoPhase_DerivationDoesNotRetranscribe` — resumability: transcriber called exactly once per audio asset across both passes.
- `TestTwoPhase_ManifestRecordsCarryPass` — manifest records carry the correct `transcription`/`derivation` pass label.
- `TestTwoPhase_DisabledIsSinglePassManifest` — default (off) is single-pass with no pass label.
- Config test updated: `two_phase=true` now validates instead of being rejected.

`make check` is fully green (fmt/vet/lint/gocyclo/tests/build).

No MCP tool schema changes; no submodule re-pin (implements already-pinned §8.6.11 at 0.21.0).

Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)
