### PR TITLE
feat: detected-language metadata + per-language retrieval filter (#267 item 4)

### DIFF
--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -784,14 +784,11 @@ func preloadEmbeddedChunkMetadata(ctx context.Context, source embeddedChunkListe
 				return total, err
 			}
 			for _, task := range tasks {
-				ret.SetChunkMetadataForIndex(kind, task.Metadata.ChunkID, model.SearchHit{
-					ChunkID: task.Metadata.ChunkID,
-					RelPath: task.Metadata.RelPath,
-					DocType: task.Metadata.DocType,
-					RepType: task.Metadata.RepType,
-					Snippet: task.Metadata.Snippet,
-					Span:    task.Metadata.Span,
-				})
+				// ToSearchHit carries every field the in-memory metadata needs,
+				// including the representation Language (SPEC §5.2/§8.8) so the
+				// per-language retrieval filter (§9.5) works against warm-loaded
+				// metadata after a restart, not just freshly-indexed chunks.
+				ret.SetChunkMetadataForIndex(kind, task.Metadata.ChunkID, task.Metadata.ToSearchHit())
 				total++
 			}
 			if len(tasks) < pageSize {

--- a/internal/index/embedding_worker.go
+++ b/internal/index/embedding_worker.go
@@ -559,8 +559,9 @@ func mediaMIMEType(relPath string) string {
 // diarized transcript's "time" span (SPEC §8.6.8) so a FilteringIndex can push
 // down a speaker filter without re-reading the span. They are empty on every
 // non-diarized transcript, so payloads are byte-identical to today. Language is
-// not carried on ChunkMetadata today and is left empty for backends to populate
-// when available.
+// the representation's effective BCP-47 language (SPEC §5.2/§8.8) so a
+// FilteringIndex can push down the per-language filter (§9.5); it is empty on a
+// representation that recorded no language (unknown), preserving prior payloads.
 func payloadFromTask(t model.ChunkTask) model.IndexPayload {
 	meta := t.Metadata
 	return model.IndexPayload{
@@ -577,6 +578,7 @@ func payloadFromTask(t model.ChunkTask) model.IndexPayload {
 		Snippet:      meta.Snippet,
 		Span:         meta.Span,
 		MediaRef:     meta.MediaRef,
+		Language:     meta.Language,
 	}
 }
 

--- a/internal/index/pgvectorindex/sql.go
+++ b/internal/index/pgvectorindex/sql.go
@@ -249,14 +249,15 @@ LIMIT %s`, q, qualifiedTable(schema, table), where, q, limitPH)
 }
 
 // CanFilterFilter reports whether every active predicate of the filter is
-// expressible in SQL. PathGlob and Speaker are the unsupported predicates; when
-// either is set the backend cannot push down and retrieval must filter in Go.
-// Speaker (diarized transcript filter, SPEC §8.6.8) is intentionally left to the
-// Go-side matchFilters re-check so speaker filtering stays on the single,
-// authoritative model.Filter.Match path. This is the pure decision function
-// behind the FilteringIndex.CanFilter method.
+// expressible in SQL. PathGlob, Speaker, and Languages are the unsupported
+// predicates; when any is set the backend cannot push down and retrieval must
+// filter in Go. Speaker (diarized transcript filter, SPEC §8.6.8) and Languages
+// (per-language retrieval filter, SPEC §9.5) are intentionally left to the
+// Go-side matchFilters re-check so they stay on the single, authoritative
+// model.Filter.Match path (the BCP-47 primary-subtag matching lives there).
+// This is the pure decision function behind the FilteringIndex.CanFilter method.
 func CanFilterFilter(f model.Filter) bool {
-	return f.PathGlob == "" && strings.TrimSpace(f.Speaker) == ""
+	return f.PathGlob == "" && strings.TrimSpace(f.Speaker) == "" && len(f.Languages) == 0
 }
 
 // MarshalPayload serialises the full IndexPayload (including the nested Span)

--- a/internal/index/qdrantindex/filter.go
+++ b/internal/index/qdrantindex/filter.go
@@ -40,6 +40,15 @@ func canFilter(filter model.Filter) bool {
 	if strings.TrimSpace(filter.Speaker) != "" {
 		return false
 	}
+	// Languages (per-language retrieval filter, SPEC §9.5) is likewise evaluated
+	// by the Go-side matchFilters re-check: BCP-47 primary-subtag matching has no
+	// faithful native Qdrant equivalent (keyword match is whole-value, so "en"
+	// would miss "en-US"). Decline push-down so it stays on the single,
+	// authoritative model.Filter.Match path. Declining is always safe
+	// (overfetch-then-filter).
+	if len(filter.Languages) != 0 {
+		return false
+	}
 	return true
 }
 

--- a/internal/ingest/derivation.go
+++ b/internal/ingest/derivation.go
@@ -80,6 +80,15 @@ func (s *Service) sttTranscriptMetaJSON(speakers []Speaker) (string, error) {
 		Provider:   strings.TrimSpace(s.sttProvider),
 		Model:      strings.TrimSpace(s.sttModel),
 	}
+	// transcriptLanguage is an operator pin (media.language / per-provider
+	// stt_language, SPEC §16.2), so when present it is the effective language with
+	// provenance "configured" — the top of the §8.8 precedence. When unset the STT
+	// path records no language (unknown): dir2mcp's transcribers do not currently
+	// report a detected language, and §8.8 forbids assuming a default, so the
+	// representation stays unknown until a detector that reports one is wired.
+	if meta.Language != "" {
+		meta.LanguageSource = langSourceConfigured
+	}
 	if s.diarizeActive {
 		// Record the diarize backend identity whenever diarization is active so a
 		// backend/model swap re-derives the transcript (§8.6.7), even before any

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -2553,6 +2553,14 @@ func (s *Service) translateOneTranscript(ctx context.Context, doc model.Document
 		TranslateModel:    s.translateModel,
 		Timestamps:        true,
 	}
+	// A translated transcript's effective language is its TARGET language (SPEC
+	// §5.2/§8.8), which the operator chose (media.translate.target_langs, §16.2) —
+	// an operator pin — so its provenance is "configured". It is recorded
+	// independently of the §8.8 source precedence and is the value the §9.5 filter
+	// matches (a request for the target language returns translations into it).
+	if strings.TrimSpace(meta.Language) != "" {
+		meta.LanguageSource = langSourceConfigured
+	}
 	metaJSON, err := json.Marshal(meta)
 	if err != nil {
 		return fmt.Errorf("marshal translated transcript meta: %w", err)

--- a/internal/ingest/sidecar.go
+++ b/internal/ingest/sidecar.go
@@ -398,13 +398,17 @@ func parseSidecar(sc sidecarFile, content string) map[string][]subtitle.Cue {
 // screened by the quality gate (§8.6.6/§8.6.7). meta_json records source=sidecar
 // and the language so retrieval and re-derivation treat it as authored.
 func (s *Service) persistSidecarTranscript(ctx context.Context, doc model.Document, lang string, cues []subtitle.Cue, segments []chunkSegment) error {
+	// Normalize once so the recorded language and its provenance are derived from
+	// the same value (no padded/non-canonical language stored alongside a trimmed
+	// provenance decision).
+	lang = strings.TrimSpace(lang)
 	meta := transcriptMeta{Source: sidecarSource, Language: lang, Timestamps: true}
 	// A sidecar's language is asserted by the source itself — the filename suffix
 	// (clip.en.vtt §8.6.4) or a TTML xml:lang — so its provenance is "declared"
 	// (SPEC §5.2/§8.8). An undifferentiated sidecar (clip.vtt) carries no language
 	// tag: lang is empty (unknown), so we leave language_source unset rather than
 	// asserting a declaration that was never made.
-	if strings.TrimSpace(lang) != "" {
+	if lang != "" {
 		meta.LanguageSource = langSourceDeclared
 	}
 	// A sidecar that carried <v> voice tags yields speaker-attributed segments

--- a/internal/ingest/sidecar.go
+++ b/internal/ingest/sidecar.go
@@ -36,6 +36,25 @@ const sttSource = "stt"
 // derivation identity and IS screened by the output quality gate.
 const translationSource = "translation"
 
+// language_source values for transcriptMeta.LanguageSource (SPEC §5.2/§8.8).
+// They record which signal won the §8.8 precedence (configured > declared >
+// detected) for a representation's effective language.
+//
+// The third precedence rank, "detected" (a best-effort auto-detector's result),
+// is part of the §8.8 contract but is intentionally NOT emitted yet: dir2mcp's
+// transcribers do not currently report a detected language and §8.8 forbids
+// assuming a default, so a representation with no pin and no declaration stays
+// unknown. The "detected" value will be wired here when a detector that reports
+// a language becomes available; recording it now would be dead code.
+const (
+	// langSourceConfigured: the language was pinned by an operator (e.g.
+	// media.language / a per-provider stt_language). It always wins (§8.8).
+	langSourceConfigured = "configured"
+	// langSourceDeclared: the language was asserted by the source itself (a
+	// sidecar's language suffix §8.6.4, a track/document language tag).
+	langSourceDeclared = "declared"
+)
+
 // sidecarFile is a discovered subtitle sidecar for a media document: its corpus
 // rel_path, the language tag parsed from the filename (empty when the sidecar is
 // undifferentiated, e.g. "clip.vtt"), the lowercased extension, and the sidecar
@@ -52,10 +71,25 @@ type sidecarFile struct {
 // the STT provider/model fields are omitted (omitempty) so the representation
 // carries no model derivation identity (§8.6.7).
 type transcriptMeta struct {
-	Source     string `json:"source,omitempty"`
-	Language   string `json:"language,omitempty"`
-	Timestamps bool   `json:"timestamps"`
-	Format     string `json:"format,omitempty"`
+	Source   string `json:"source,omitempty"`
+	Language string `json:"language,omitempty"`
+	// LanguageSource records how Language was obtained (SPEC §5.2/§8.8):
+	// "configured" (an operator pin, e.g. media.language / per-provider
+	// stt_language), "declared" (asserted by the source itself, e.g. a sidecar's
+	// language suffix or track tag), or "detected" (an auto-detector's best-effort
+	// result). Omitted (omitempty) when no language was recorded (unknown) or the
+	// provenance is unspecified, so meta_json is unchanged for a transcript that
+	// records no language. The recorded Language is the EFFECTIVE value resolved
+	// by §8.8 precedence (configured > declared > detected); LanguageSource names
+	// the signal that won.
+	LanguageSource string `json:"language_source,omitempty"`
+	// LanguageConfidence is a detector-reported confidence in [0,1] for an
+	// auto-"detected" Language (SPEC §5.2/§8.8). Informational only — it MUST NOT
+	// be re-applied as a filter at query time (§9.5). Omitted unless a detector
+	// produced it; a pointer so a genuine 0.0 is distinguishable from "absent".
+	LanguageConfidence *float64 `json:"language_confidence,omitempty"`
+	Timestamps         bool     `json:"timestamps"`
+	Format             string   `json:"format,omitempty"`
 
 	// Provider / Model / ModelVersion record the STT derivation identity on a
 	// machine-transcribed transcript (Source == "stt", spec §5.2/§8.6.7): the
@@ -365,6 +399,14 @@ func parseSidecar(sc sidecarFile, content string) map[string][]subtitle.Cue {
 // and the language so retrieval and re-derivation treat it as authored.
 func (s *Service) persistSidecarTranscript(ctx context.Context, doc model.Document, lang string, cues []subtitle.Cue, segments []chunkSegment) error {
 	meta := transcriptMeta{Source: sidecarSource, Language: lang, Timestamps: true}
+	// A sidecar's language is asserted by the source itself — the filename suffix
+	// (clip.en.vtt §8.6.4) or a TTML xml:lang — so its provenance is "declared"
+	// (SPEC §5.2/§8.8). An undifferentiated sidecar (clip.vtt) carries no language
+	// tag: lang is empty (unknown), so we leave language_source unset rather than
+	// asserting a declaration that was never made.
+	if strings.TrimSpace(lang) != "" {
+		meta.LanguageSource = langSourceDeclared
+	}
 	// A sidecar that carried <v> voice tags yields speaker-attributed segments
 	// (SPEC §8.6.8). Such a transcript is diarized WITHOUT a model, so it records
 	// diarized:true and the speakers set but NO diarize_provider/model (mirrors

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -734,7 +734,7 @@ func isResolvableSourceWithRoot(doc model.Document, rootAbs, rootReal string) bo
 
 func (s *Server) handleSearchTool(ctx context.Context, args map[string]interface{}) (toolCallResult, *toolExecutionError) {
 	if err := assertNoUnknownArguments(args, map[string]struct{}{
-		"query": {}, "k": {}, "index": {}, "path_prefix": {}, "file_glob": {}, "doc_types": {}, "speaker": {},
+		"query": {}, "k": {}, "index": {}, "path_prefix": {}, "file_glob": {}, "doc_types": {}, "speaker": {}, "languages": {},
 	}); err != nil {
 		return toolCallResult{}, &toolExecutionError{Code: "INVALID_FIELD", Message: err.Error(), Retryable: false}
 	}
@@ -761,11 +761,15 @@ func (s *Server) handleSearchTool(ctx context.Context, args map[string]interface
 	if err != nil {
 		return toolCallResult{}, &toolExecutionError{Code: "INVALID_FIELD", Message: err.Error(), Retryable: false}
 	}
+	languages, toolErr := parseLanguagesArg(args)
+	if toolErr != nil {
+		return toolCallResult{}, toolErr
+	}
 	if s.retriever == nil {
 		return toolCallResult{}, &toolExecutionError{Code: protocol.ErrorCodeIndexNotReady, Message: "retriever not configured", Retryable: false}
 	}
 	hits, searchErr := s.retriever.Search(ctx, model.SearchQuery{
-		Query: query, K: k, Index: indexName, PathPrefix: pathPrefix, FileGlob: fileGlob, DocTypes: docTypes, Speaker: speaker,
+		Query: query, K: k, Index: indexName, PathPrefix: pathPrefix, FileGlob: fileGlob, DocTypes: docTypes, Speaker: speaker, Languages: languages,
 	})
 	if searchErr != nil {
 		return toolCallResult{}, mapSearchError(searchErr)
@@ -793,7 +797,7 @@ func (s *Server) handleSearchTool(ctx context.Context, args map[string]interface
 
 func (s *Server) handleAskTool(ctx context.Context, args map[string]interface{}) (toolCallResult, *toolExecutionError) {
 	if err := assertNoUnknownArguments(args, map[string]struct{}{
-		"question": {}, "k": {}, "mode": {}, "index": {}, "path_prefix": {}, "file_glob": {}, "doc_types": {},
+		"question": {}, "k": {}, "mode": {}, "index": {}, "path_prefix": {}, "file_glob": {}, "doc_types": {}, "languages": {},
 	}); err != nil {
 		return toolCallResult{}, &toolExecutionError{Code: "INVALID_FIELD", Message: err.Error(), Retryable: false}
 	}
@@ -820,10 +824,14 @@ func (s *Server) handleAskTool(ctx context.Context, args map[string]interface{})
 	if toolErr != nil {
 		return toolCallResult{}, toolErr
 	}
+	languages, toolErr := parseLanguagesArg(args)
+	if toolErr != nil {
+		return toolCallResult{}, toolErr
+	}
 	if s.retriever == nil {
 		return toolCallResult{}, &toolExecutionError{Code: protocol.ErrorCodeIndexNotReady, Message: "retriever not configured", Retryable: false}
 	}
-	sq := model.SearchQuery{Query: question, K: k, Index: indexName, PathPrefix: pathPrefix, FileGlob: fileGlob, DocTypes: docTypes}
+	sq := model.SearchQuery{Query: question, K: k, Index: indexName, PathPrefix: pathPrefix, FileGlob: fileGlob, DocTypes: docTypes, Languages: languages}
 	if mode == "search_only" {
 		return s.runSearchOnlyMode(ctx, question, sq)
 	}
@@ -1654,6 +1662,34 @@ func parseSearchFilters(args map[string]interface{}) (pathPrefix, fileGlob strin
 		return "", "", nil, &toolExecutionError{Code: "INVALID_FIELD", Message: err.Error(), Retryable: false}
 	}
 	return pathPrefix, fileGlob, docTypes, nil
+}
+
+// parseLanguagesArg parses the optional per-language retrieval filter (SPEC
+// §9.5): an array of BCP-47 language tags. Absent or empty ⇒ nil (no filtering,
+// behaviour unchanged). Each entry must be a syntactically valid BCP-47 tag
+// (model.IsValidLanguageTag); a malformed tag is INVALID_FIELD (§9.5/§14). A
+// syntactically valid tag that simply matches nothing in the corpus is NOT an
+// error — that is handled downstream by returning an empty hit list. The parsed
+// tags are returned verbatim (trimmed); the retrieval filter normalizes to the
+// primary subtag for case-insensitive matching.
+func parseLanguagesArg(args map[string]interface{}) ([]string, *toolExecutionError) {
+	languages, err := parseOptionalStringSlice(args, "languages")
+	if err != nil {
+		return nil, &toolExecutionError{Code: "INVALID_FIELD", Message: err.Error(), Retryable: false}
+	}
+	if len(languages) == 0 {
+		return nil, nil
+	}
+	for _, tag := range languages {
+		if !model.IsValidLanguageTag(tag) {
+			return nil, &toolExecutionError{
+				Code:      "INVALID_FIELD",
+				Message:   fmt.Sprintf("languages contains an invalid BCP-47 language tag %q", tag),
+				Retryable: false,
+			}
+		}
+	}
+	return languages, nil
 }
 
 // mapSearchError converts a search/ask error into a toolExecutionError.
@@ -2672,6 +2708,11 @@ func searchInputSchema() map[string]interface{} {
 				"type":        "string",
 				"description": "Optional (SPEC §8.6.8): restrict time-spanned transcript hits to this speaker id. A corpus without diarized transcripts returns no speaker-filtered hits.",
 			},
+			"languages": map[string]interface{}{
+				"type":        "array",
+				"items":       map[string]interface{}{"type": "string"},
+				"description": "Optional (SPEC §9.5): restrict hits to representations recorded in any of these BCP-47 languages (case-insensitive primary-subtag match). Absent/empty = no filtering; unknown-language representations never match a specific filter.",
+			},
 		},
 		"required": []string{"query"},
 	}
@@ -2705,6 +2746,11 @@ func askInputSchema() map[string]interface{} {
 			"path_prefix": map[string]interface{}{"type": "string"},
 			"file_glob":   map[string]interface{}{"type": "string"},
 			"doc_types":   map[string]interface{}{"type": "array", "items": map[string]interface{}{"type": "string"}},
+			"languages": map[string]interface{}{
+				"type":        "array",
+				"items":       map[string]interface{}{"type": "string"},
+				"description": "Optional (SPEC §9.5): restrict retrieved contexts to representations recorded in any of these BCP-47 languages (case-insensitive primary-subtag match). Absent/empty = no filtering; unknown-language representations never match a specific filter.",
+			},
 		},
 		"required": []string{"question"},
 	}

--- a/internal/model/langtag.go
+++ b/internal/model/langtag.go
@@ -1,0 +1,96 @@
+package model
+
+import "strings"
+
+// Per-language retrieval filter helpers (SPEC §9.5) and representation language
+// recording (§5.2/§8.8). The matching contract is intentionally minimal and
+// dependency-free: a request matches a recorded representation language when
+// their BCP-47 **primary subtags** are equal, compared case-insensitively. We do
+// not pull in a full BCP-47 parser because §9.5 only mandates primary-subtag
+// matching ("Implementations MAY additionally honor an exact full-tag match but
+// MUST AT LEAST honor primary-subtag matching"). Region, script, and other
+// subtags never cause a match to be missed when the primary subtags agree.
+
+// LanguagePrimarySubtag returns the lower-cased BCP-47 primary subtag of a
+// language tag — the segment before the first '-' or '_' — trimmed of
+// surrounding whitespace. It returns "" for an empty/whitespace tag (which the
+// caller treats as "unknown language"). It is the canonical key used for both
+// recording a representation's effective language and matching it against a
+// requested filter tag (§9.5), so the two are always compared on the same axis.
+func LanguagePrimarySubtag(tag string) string {
+	t := strings.ToLower(strings.TrimSpace(tag))
+	if t == "" {
+		return ""
+	}
+	if i := strings.IndexAny(t, "-_"); i >= 0 {
+		return t[:i]
+	}
+	return t
+}
+
+// IsValidLanguageTag reports whether tag is a syntactically valid BCP-47
+// language tag for the purpose of the per-language retrieval filter (§9.5). The
+// check is deliberately lenient — it accepts the common forms an operator or
+// client sends (`en`, `EN`, `pt-BR`, `zh-Hant`, `und`) and rejects only clearly
+// malformed values — because §9.5 requires that an *unrecognized or malformed*
+// tag be reported as INVALID_FIELD, while a syntactically valid tag that simply
+// matches nothing is NOT an error.
+//
+// Validity rule: the tag is one or more '-'-separated subtags, each composed
+// solely of ASCII letters/digits, each 1..8 chars, with a non-empty primary
+// subtag of letters only (1..8). A trailing/leading/double hyphen, an empty
+// subtag, or any non-alphanumeric/non-hyphen rune is invalid. An empty/blank tag
+// is invalid (callers strip empties before validating; an explicit empty string
+// in the array is a client error).
+func IsValidLanguageTag(tag string) bool {
+	t := strings.TrimSpace(tag)
+	if t == "" {
+		return false
+	}
+	subtags := strings.Split(t, "-")
+	for idx, sub := range subtags {
+		if len(sub) < 1 || len(sub) > 8 {
+			return false
+		}
+		for _, r := range sub {
+			isLetter := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
+			isDigit := r >= '0' && r <= '9'
+			if !isLetter && !isDigit {
+				return false
+			}
+			// The primary subtag (first) must be letters only — a language code is
+			// never numeric (e.g. "1" or "123" is not a language).
+			if idx == 0 && isDigit {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// LanguageMatchesAny reports whether a representation's recorded effective
+// language (recordedTag, §5.2) matches any of the requested filter tags under
+// the §9.5 semantics: case-insensitive **primary-subtag** match, logical OR
+// across the requested set.
+//
+//   - An empty requested set means "no filter" and is handled by the caller, not
+//     here; LanguageMatchesAny is only consulted when a filter is active.
+//   - A representation with no recorded language (recordedTag == "" ⇒ unknown,
+//     §8.8) NEVER matches a specific filter — it returns false here, so it is
+//     excluded whenever the filter is non-empty.
+//   - Requested tags are assumed already validated (IsValidLanguageTag) by the
+//     MCP layer; an entry that reduces to an empty primary subtag matches
+//     nothing.
+func LanguageMatchesAny(recordedTag string, requested []string) bool {
+	recorded := LanguagePrimarySubtag(recordedTag)
+	if recorded == "" {
+		// Unknown language: never matches a specific filter (§9.5).
+		return false
+	}
+	for _, req := range requested {
+		if LanguagePrimarySubtag(req) == recorded {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -76,6 +76,15 @@ type Chunk struct {
 	// chunk; the embedding worker reads those bytes and embeds them
 	// directly. Empty for text chunks.
 	MediaRef string
+	// Language is the effective BCP-47 language of the chunk's source
+	// representation (SPEC §5.2/§8.8), denormalized onto the chunk so the
+	// per-language retrieval filter (§9.5) can predicate at candidate selection
+	// without re-reading representation meta_json. It is populated at chunk
+	// insert time from the representation's recorded meta language; empty means
+	// the representation recorded no language (unknown), which never matches a
+	// specific filter. Additive: a corpus indexed before any language was
+	// recorded simply has empty values here (no migration, §9.5).
+	Language string
 }
 
 type Span struct {
@@ -187,6 +196,7 @@ func (p IndexPayload) ToSearchHit() SearchHit {
 		Span:     span,
 		Modality: p.Modality,
 		MediaRef: p.MediaRef,
+		Language: p.Language,
 	}
 }
 
@@ -219,6 +229,12 @@ type Filter struct {
 	DocTypes       []string
 	ExcludeOrphans bool
 	Speaker        string
+	// Languages restricts candidates to representations whose recorded effective
+	// language (SPEC §5.2/§8.8) matches any requested BCP-47 tag on the
+	// primary-subtag axis, case-insensitively (logical OR, SPEC §9.5). Empty
+	// disables the predicate (no language filtering). A candidate with no
+	// recorded language (unknown) never matches a non-empty Languages filter.
+	Languages []string
 }
 
 // IsZero reports whether the filter has no active predicate.
@@ -227,7 +243,8 @@ func (f Filter) IsZero() bool {
 		f.PathGlob == "" &&
 		len(f.DocTypes) == 0 &&
 		!f.ExcludeOrphans &&
-		strings.TrimSpace(f.Speaker) == ""
+		strings.TrimSpace(f.Speaker) == "" &&
+		len(f.Languages) == 0
 }
 
 // Match reports whether the payload satisfies every active predicate. It
@@ -273,6 +290,16 @@ func (f Filter) Match(p IndexPayload) bool {
 			return false
 		}
 	}
+	// Languages restricts to representations recorded in any of the requested
+	// BCP-47 languages, matched on the primary subtag case-insensitively (SPEC
+	// §9.5). A payload with no recorded language (unknown, §8.8) never matches a
+	// non-empty filter, so a corpus indexed before any language was recorded
+	// returns nothing for a specific language filter. Empty filter is a no-op.
+	if len(f.Languages) > 0 {
+		if !LanguageMatchesAny(p.Language, f.Languages) {
+			return false
+		}
+	}
 	return true
 }
 
@@ -288,6 +315,11 @@ type SearchQuery struct {
 	// the filter; a corpus without diarized transcripts returns no
 	// speaker-filtered hits.
 	Speaker string
+	// Languages optionally restricts hits to representations recorded in any of
+	// these BCP-47 languages (SPEC §9.5/§15.2-3): case-insensitive primary-subtag
+	// match, logical OR. Absent/empty disables the filter (unchanged behavior).
+	// An unknown-language representation never matches a non-empty filter.
+	Languages []string
 }
 
 type SearchHit struct {
@@ -305,6 +337,12 @@ type SearchHit struct {
 	// retrieval dedup page-image candidates and mark media-only hits.
 	Modality string
 	MediaRef string
+	// Language is the effective BCP-47 language of the hit's source
+	// representation (SPEC §5.2/§8.8), carried so the per-language retrieval
+	// filter (§9.5) can predicate on candidates. It is internal to retrieval and
+	// is NOT serialized into the tool result (the §9.2 hit structure is
+	// unchanged); empty means unknown.
+	Language string
 }
 
 type ChunkMetadata struct {
@@ -317,6 +355,10 @@ type ChunkMetadata struct {
 	Span     Span
 	Modality string
 	MediaRef string
+	// Language is the effective BCP-47 language of the chunk's source
+	// representation (SPEC §5.2/§8.8), denormalized from representation meta_json
+	// at chunk insert so retrieval can apply the per-language filter (§9.5).
+	Language string
 }
 
 // ToSearchHit converts the lightweight chunk metadata back into a full
@@ -333,6 +375,7 @@ func (m ChunkMetadata) ToSearchHit() SearchHit {
 		Span:     m.Span,
 		Modality: m.Modality,
 		MediaRef: m.MediaRef,
+		Language: m.Language,
 	}
 }
 

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -1524,6 +1524,7 @@ func filterFromQuery(q model.SearchQuery) model.Filter {
 		PathGlob:   q.FileGlob,
 		DocTypes:   q.DocTypes,
 		Speaker:    q.Speaker,
+		Languages:  q.Languages,
 	}
 }
 
@@ -2070,6 +2071,19 @@ func matchFilters(hit model.SearchHit, query model.SearchQuery) bool {
 	// speaker-filtered hits. Empty filter is a no-op (behaviour unchanged).
 	if speaker := strings.TrimSpace(query.Speaker); speaker != "" {
 		if !strings.EqualFold(speaker, strings.TrimSpace(hit.Span.Speaker)) {
+			return false
+		}
+	}
+
+	// Optional per-language filter (SPEC §9.5/§15.2-3): restrict to candidates
+	// whose source representation recorded any of the requested BCP-47 languages,
+	// matched on the primary subtag case-insensitively (logical OR). Applied here
+	// at candidate selection — before cross-file de-dup, reranking, and truncation
+	// to k — so it only removes non-matching candidates and never reorders or
+	// changes the result/citation structure. A hit with no recorded language
+	// (unknown, §8.8) never matches a non-empty filter; an empty filter is a no-op.
+	if len(query.Languages) > 0 {
+		if !model.LanguageMatchesAny(hit.Language, query.Languages) {
 			return false
 		}
 	}

--- a/internal/store/sqlite_bm25.go
+++ b/internal/store/sqlite_bm25.go
@@ -37,7 +37,7 @@ func (s *SQLiteStore) SearchBM25(ctx context.Context, query string, k int, index
 	defer s.ReleaseDB()
 
 	args := []any{matchExpr}
-	stmt := `SELECT c.chunk_id, c.rel_path, c.doc_type, c.rep_type, c.text,
+	stmt := `SELECT c.chunk_id, c.rel_path, c.doc_type, c.rep_type, c.text, c.language,
 	                COALESCE(d.title, ''),
 	                bm25(chunks_fts) AS score
 	         FROM chunks_fts
@@ -60,29 +60,31 @@ func (s *SQLiteStore) SearchBM25(ctx context.Context, query string, k int, index
 	hits := make([]model.SearchHit, 0, k)
 	for rows.Next() {
 		var (
-			chunkID int64
-			relPath string
-			docType string
-			repType string
-			text    string
-			title   string
-			score   float64
+			chunkID  int64
+			relPath  string
+			docType  string
+			repType  string
+			text     string
+			language string
+			title    string
+			score    float64
 		)
-		if err := rows.Scan(&chunkID, &relPath, &docType, &repType, &text, &title, &score); err != nil {
+		if err := rows.Scan(&chunkID, &relPath, &docType, &repType, &text, &language, &title, &score); err != nil {
 			return nil, err
 		}
 		if chunkID <= 0 {
 			continue
 		}
 		hits = append(hits, model.SearchHit{
-			ChunkID: uint64(chunkID),
-			RelPath: relPath,
-			Title:   title,
-			DocType: docType,
-			RepType: repType,
-			Score:   -score,
-			Snippet: snippet(text, 240),
-			Span:    model.Span{Kind: "lines"},
+			ChunkID:  uint64(chunkID),
+			RelPath:  relPath,
+			Title:    title,
+			DocType:  docType,
+			RepType:  repType,
+			Score:    -score,
+			Snippet:  snippet(text, 240),
+			Span:     model.Span{Kind: "lines"},
+			Language: language,
 		})
 	}
 	if err := rows.Err(); err != nil {

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -191,24 +191,54 @@ func upsertRepresentationWith(ctx context.Context, exec dbExecutor, rep model.Re
 	return repID, nil
 }
 
-func lookupChunkDocContext(ctx context.Context, exec dbExecutor, repID int64) (relPath, docType, repType string, err error) {
+func lookupChunkDocContext(ctx context.Context, exec dbExecutor, repID int64) (relPath, docType, repType, language string, err error) {
+	var metaJSON string
 	err = exec.QueryRowContext(
 		ctx,
-		`SELECT d.rel_path, d.doc_type, r.rep_type
+		`SELECT d.rel_path, d.doc_type, r.rep_type, COALESCE(r.meta_json, '')
 		 FROM representations r
 		 JOIN documents d ON d.doc_id = r.doc_id
 		 WHERE r.rep_id = ?
 		 LIMIT 1`,
 		repID,
-	).Scan(&relPath, &docType, &repType)
-	return relPath, docType, repType, err
+	).Scan(&relPath, &docType, &repType, &metaJSON)
+	if err != nil {
+		return relPath, docType, repType, "", err
+	}
+	// Denormalize the representation's recorded effective language (SPEC §5.2/§8.8)
+	// onto the chunk so the per-language retrieval filter (§9.5) can predicate at
+	// candidate selection. The recorded `language` is already the resolved
+	// effective value (precedence applied at the ingest write per §8.8), so the
+	// store merely reads it; absent ⇒ unknown (empty), never an error.
+	return relPath, docType, repType, languageFromRepMeta(metaJSON), err
 }
 
-func insertChunkWithSpansWith(ctx context.Context, exec dbExecutor, chunk model.Chunk, spans []model.Span, relPath, docType, repType string) (int64, error) {
+// languageFromRepMeta extracts the effective BCP-47 language a representation
+// recorded in its meta_json (SPEC §5.2 `language`). It is intentionally tolerant:
+// a representation with no meta, unparseable meta, or no `language` field is
+// "unknown language" (returns ""), which never matches a specific per-language
+// filter (§9.5). The recorded value is returned verbatim (trimmed); §9.5
+// matching normalizes to the primary subtag, so both full-tag and primary-subtag
+// recordings filter correctly.
+func languageFromRepMeta(metaJSON string) string {
+	metaJSON = strings.TrimSpace(metaJSON)
+	if metaJSON == "" {
+		return ""
+	}
+	var meta struct {
+		Language string `json:"language"`
+	}
+	if err := json.Unmarshal([]byte(metaJSON), &meta); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(meta.Language)
+}
+
+func insertChunkWithSpansWith(ctx context.Context, exec dbExecutor, chunk model.Chunk, spans []model.Span, relPath, docType, repType, language string) (int64, error) {
 	_, err := exec.ExecContext(
 		ctx,
-		`INSERT INTO chunks(rep_id, ordinal, rel_path, doc_type, rep_type, text, text_hash, tokens_est, index_kind, modality, media_ref, embedding_status, embedding_error, error_category, deleted)
-		 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`INSERT INTO chunks(rep_id, ordinal, rel_path, doc_type, rep_type, text, text_hash, tokens_est, index_kind, modality, media_ref, language, embedding_status, embedding_error, error_category, deleted)
+		 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		 ON CONFLICT(rep_id, ordinal) DO UPDATE SET
 		   rel_path=excluded.rel_path,
 		   doc_type=excluded.doc_type,
@@ -219,6 +249,7 @@ func insertChunkWithSpansWith(ctx context.Context, exec dbExecutor, chunk model.
 		   index_kind=excluded.index_kind,
 		   modality=excluded.modality,
 		   media_ref=excluded.media_ref,
+		   language=excluded.language,
 		   embedding_status=excluded.embedding_status,
 		   embedding_error=excluded.embedding_error,
 		   error_category=excluded.error_category,
@@ -234,6 +265,7 @@ func insertChunkWithSpansWith(ctx context.Context, exec dbExecutor, chunk model.
 		normalizeIndexKind(chunk.IndexKind),
 		normalizeModality(chunk.Modality),
 		strings.TrimSpace(chunk.MediaRef),
+		strings.TrimSpace(language),
 		normalizeEmbeddingStatus(chunk.EmbeddingStatus),
 		strings.TrimSpace(chunk.EmbeddingError),
 		strings.TrimSpace(chunk.ErrorCategory),
@@ -369,6 +401,15 @@ func applyAdditiveColumnMigrations(ctx context.Context, db *sql.DB) error {
 		// §7.8.3, #298). Empty for local/NFS corpora, non-media docs, and media
 		// with no sidecar — preserving the historical fast-path behavior.
 		`ALTER TABLE documents ADD COLUMN sidecar_fingerprint TEXT NOT NULL DEFAULT ''`,
+		// language denormalizes the effective BCP-47 language of a chunk's source
+		// representation (SPEC §5.2/§8.8) onto the chunk so the per-language
+		// retrieval filter (§9.5) can predicate at candidate selection without a
+		// per-chunk representation meta_json lookup. Populated at chunk insert from
+		// the representation's recorded meta language; empty means the
+		// representation recorded no language (unknown) — which never matches a
+		// specific filter, so a corpus indexed before any language was recorded
+		// simply has empty values here (no migration of existing rows needed, §9.5).
+		`ALTER TABLE chunks ADD COLUMN language TEXT NOT NULL DEFAULT ''`,
 	}
 	for _, stmt := range migrations {
 		if _, err := db.ExecContext(ctx, stmt); err != nil && !isDuplicateColumnError(err) {
@@ -446,6 +487,7 @@ CREATE TABLE IF NOT EXISTS chunks (
   index_kind TEXT NOT NULL DEFAULT 'text',
   modality TEXT NOT NULL DEFAULT 'text',
   media_ref TEXT NOT NULL DEFAULT '',
+  language TEXT NOT NULL DEFAULT '',
   embedding_status TEXT NOT NULL DEFAULT 'pending',
   embedding_error TEXT NOT NULL DEFAULT '',
   error_category TEXT NOT NULL DEFAULT '',
@@ -731,11 +773,11 @@ func (s *SQLiteStore) InsertChunkWithSpans(ctx context.Context, chunk model.Chun
 		return 0, err
 	}
 	defer func() { _ = tx.Rollback() }()
-	relPath, docType, repType, err := lookupChunkDocContext(ctx, tx, chunk.RepID)
+	relPath, docType, repType, language, err := lookupChunkDocContext(ctx, tx, chunk.RepID)
 	if err != nil {
 		return 0, err
 	}
-	chunkID, err := insertChunkWithSpansWith(ctx, tx, chunk, spans, relPath, docType, repType)
+	chunkID, err := insertChunkWithSpansWith(ctx, tx, chunk, spans, relPath, docType, repType, language)
 	if err != nil {
 		return 0, err
 	}
@@ -870,11 +912,11 @@ func (t *txSQLiteStore) InsertChunkWithSpans(ctx context.Context, chunk model.Ch
 		return 0, err
 	}
 
-	relPath, docType, repType, err := lookupChunkDocContext(ctx, t.tx, chunk.RepID)
+	relPath, docType, repType, language, err := lookupChunkDocContext(ctx, t.tx, chunk.RepID)
 	if err != nil {
 		return 0, err
 	}
-	return insertChunkWithSpansWith(ctx, t.tx, chunk, spans, relPath, docType, repType)
+	return insertChunkWithSpansWith(ctx, t.tx, chunk, spans, relPath, docType, repType, language)
 }
 
 func (t *txSQLiteStore) SoftDeleteChunksFromOrdinal(ctx context.Context, repID int64, fromOrdinal int) error {
@@ -1319,7 +1361,7 @@ func (s *SQLiteStore) ChunkTaskByID(ctx context.Context, chunkID uint64) (task m
 
 	row := db.QueryRowContext(ctx, `
 WITH the_chunk AS (
-  SELECT chunk_id, rel_path, doc_type, rep_type, text, text_hash, index_kind, modality, media_ref
+  SELECT chunk_id, rel_path, doc_type, rep_type, text, text_hash, index_kind, modality, media_ref, language
   FROM chunks
   WHERE chunk_id = ? AND deleted = 0
 ),
@@ -1329,7 +1371,7 @@ ranked_spans AS (
   FROM spans s
   JOIN the_chunk tc ON tc.chunk_id = s.chunk_id
 )
-SELECT tc.chunk_id, tc.rel_path, tc.doc_type, tc.rep_type, tc.text, tc.text_hash, tc.index_kind, tc.modality, tc.media_ref,
+SELECT tc.chunk_id, tc.rel_path, tc.doc_type, tc.rep_type, tc.text, tc.text_hash, tc.index_kind, tc.modality, tc.media_ref, tc.language,
        COALESCE(sp.span_kind, ''), COALESCE(sp.start, 0), COALESCE(sp.end, 0), COALESCE(sp.extra_json, '')
 FROM the_chunk tc
 LEFT JOIN ranked_spans sp ON sp.chunk_id = tc.chunk_id AND sp.rn = 1`, int64(chunkID))
@@ -1344,12 +1386,13 @@ LEFT JOIN ranked_spans sp ON sp.chunk_id = tc.chunk_id AND sp.rn = 1`, int64(chu
 		idxKind   string
 		modality  string
 		mediaRef  string
+		language  string
 		spanK     string
 		spanS     int
 		spanE     int
 		spanExtra string
 	)
-	if scanErr := row.Scan(&cid, &relPath, &docType, &repType, &text, &thash, &idxKind, &modality, &mediaRef,
+	if scanErr := row.Scan(&cid, &relPath, &docType, &repType, &text, &thash, &idxKind, &modality, &mediaRef, &language,
 		&spanK, &spanS, &spanE, &spanExtra); scanErr != nil {
 		if errors.Is(scanErr, sql.ErrNoRows) {
 			return model.ChunkTask{}, "", model.ErrNotFound
@@ -1370,6 +1413,7 @@ LEFT JOIN ranked_spans sp ON sp.chunk_id = tc.chunk_id AND sp.rn = 1`, int64(chu
 		Span:     span,
 		Modality: modality,
 		MediaRef: mediaRef,
+		Language: language,
 	})
 	t.Modality = modality
 	t.MediaRef = mediaRef
@@ -1736,7 +1780,7 @@ func (s *SQLiteStore) NextPending(ctx context.Context, limit int, indexKind stri
 
 	args := []any{"pending"}
 	query := `WITH filtered_chunks AS (
-	            SELECT c.chunk_id, c.rel_path, c.doc_type, c.rep_type, c.text, c.index_kind, c.modality, c.media_ref
+	            SELECT c.chunk_id, c.rel_path, c.doc_type, c.rep_type, c.text, c.index_kind, c.modality, c.media_ref, c.language
 	            FROM chunks c
 	            WHERE c.embedding_status = ? AND c.deleted = 0 AND c.chunk_id > 0
 	          ),
@@ -1746,7 +1790,7 @@ func (s *SQLiteStore) NextPending(ctx context.Context, limit int, indexKind stri
 	            FROM spans s
 	            JOIN filtered_chunks fc ON fc.chunk_id = s.chunk_id
 	          )
-	          SELECT fc.chunk_id, fc.rel_path, fc.doc_type, fc.rep_type, fc.text, fc.index_kind, fc.modality, fc.media_ref,
+	          SELECT fc.chunk_id, fc.rel_path, fc.doc_type, fc.rep_type, fc.text, fc.index_kind, fc.modality, fc.media_ref, fc.language,
 	                 COALESCE(sp.span_kind, ''), COALESCE(sp.start, 0), COALESCE(sp.end, 0), COALESCE(sp.extra_json, '')
 	          FROM filtered_chunks fc
 	          LEFT JOIN ranked_spans sp ON sp.chunk_id = fc.chunk_id AND sp.rn = 1`
@@ -1774,12 +1818,13 @@ func (s *SQLiteStore) NextPending(ctx context.Context, limit int, indexKind stri
 			idxKind   string
 			modality  string
 			mediaRef  string
+			language  string
 			spanK     string
 			spanS     int
 			spanE     int
 			spanExtra string
 		)
-		if err := rows.Scan(&chunkID, &relPath, &docType, &repType, &text, &idxKind, &modality, &mediaRef, &spanK, &spanS, &spanE, &spanExtra); err != nil {
+		if err := rows.Scan(&chunkID, &relPath, &docType, &repType, &text, &idxKind, &modality, &mediaRef, &language, &spanK, &spanS, &spanE, &spanExtra); err != nil {
 			return nil, err
 		}
 		if chunkID <= 0 {
@@ -1796,6 +1841,7 @@ func (s *SQLiteStore) NextPending(ctx context.Context, limit int, indexKind stri
 			Span:     span,
 			Modality: modality,
 			MediaRef: mediaRef,
+			Language: language,
 		})
 		task.Modality = modality
 		task.MediaRef = mediaRef
@@ -1844,7 +1890,7 @@ func (s *SQLiteStore) ListEmbeddedChunkMetadata(ctx context.Context, indexKind s
 
 	args := []any{"ok"}
 	query := `WITH filtered_chunks AS (
-	            SELECT c.chunk_id, c.rel_path, c.doc_type, c.rep_type, c.text, c.index_kind, c.modality, c.media_ref
+	            SELECT c.chunk_id, c.rel_path, c.doc_type, c.rep_type, c.text, c.index_kind, c.modality, c.media_ref, c.language
 	            FROM chunks c
 	            WHERE c.embedding_status = ? AND c.deleted = 0 AND c.chunk_id > 0
 	          ),
@@ -1856,7 +1902,7 @@ func (s *SQLiteStore) ListEmbeddedChunkMetadata(ctx context.Context, indexKind s
 	          )
 	          SELECT fc.chunk_id, fc.rel_path, fc.doc_type, fc.rep_type, fc.text, fc.index_kind,
 	                 COALESCE(sp.span_kind, ''), COALESCE(sp.start, 0), COALESCE(sp.end, 0), COALESCE(sp.extra_json, ''),
-	                 COALESCE(d.title, ''), fc.modality, fc.media_ref
+	                 COALESCE(d.title, ''), fc.modality, fc.media_ref, fc.language
 	          FROM filtered_chunks fc
 	          LEFT JOIN ranked_spans sp ON sp.chunk_id = fc.chunk_id AND sp.rn = 1
 	          LEFT JOIN documents d ON d.rel_path = fc.rel_path`
@@ -1889,8 +1935,9 @@ func (s *SQLiteStore) ListEmbeddedChunkMetadata(ctx context.Context, indexKind s
 			title     string
 			modality  string
 			mediaRef  string
+			language  string
 		)
-		if err := rows.Scan(&chunkID, &relPath, &docType, &repType, &text, &kind, &spanK, &spanS, &spanE, &spanExtra, &title, &modality, &mediaRef); err != nil {
+		if err := rows.Scan(&chunkID, &relPath, &docType, &repType, &text, &kind, &spanK, &spanS, &spanE, &spanExtra, &title, &modality, &mediaRef, &language); err != nil {
 			return nil, err
 		}
 		if chunkID <= 0 {
@@ -1914,6 +1961,7 @@ func (s *SQLiteStore) ListEmbeddedChunkMetadata(ctx context.Context, indexKind s
 				Span:     span,
 				Modality: modality,
 				MediaRef: mediaRef,
+				Language: language,
 			},
 		})
 	}

--- a/tests/ingest/language_metadata_test.go
+++ b/tests/ingest/language_metadata_test.go
@@ -1,0 +1,131 @@
+package tests
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// TestLanguageMetadata_SidecarRecordsDeclaredSourceAndChunkLanguage pins the
+// detected-language metadata contract (SPEC §5.2/§8.8) plus the §9.5 denorm: a
+// per-language sidecar transcript records its effective language with
+// language_source="declared" (the filename suffix is a source-asserted
+// declaration), and that effective language is denormalized onto the persisted
+// chunk rows so the per-language retrieval filter can predicate on it.
+func TestLanguageMetadata_SidecarRecordsDeclaredSourceAndChunkLanguage(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "talk.mp3"), "fake-audio")
+	writeFile(t, filepath.Join(root, "talk.pt.vtt"),
+		"WEBVTT\n\n00:00:00.000 --> 00:00:02.000\nola mundo\n")
+
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	if err := st.Init(context.Background()); err != nil {
+		t.Fatalf("store init: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	svc := newSidecarService(t, root, t.TempDir(), st)
+
+	if err := st.UpsertDocument(context.Background(), model.Document{RelPath: "talk.mp3", DocType: "audio"}); err != nil {
+		t.Fatalf("upsert document: %v", err)
+	}
+	doc, err := st.GetDocumentByPath(context.Background(), "talk.mp3")
+	if err != nil {
+		t.Fatalf("get document: %v", err)
+	}
+	if _, err := svc.IngestSidecarTranscripts(context.Background(), doc); err != nil {
+		t.Fatalf("IngestSidecarTranscripts: %v", err)
+	}
+
+	// Representation meta_json records the effective language + declared source.
+	reps, err := st.TranscriptRepresentations(context.Background(), "talk.mp3")
+	if err != nil {
+		t.Fatalf("TranscriptRepresentations: %v", err)
+	}
+	if len(reps) != 1 {
+		t.Fatalf("expected one transcript representation, got %d", len(reps))
+	}
+	meta := reps[0].MetaJSON
+	if !strings.Contains(meta, `"language":"pt"`) {
+		t.Fatalf("expected language=pt in meta_json, got %s", meta)
+	}
+	if !strings.Contains(meta, `"language_source":"declared"`) {
+		t.Fatalf("expected language_source=declared in meta_json, got %s", meta)
+	}
+
+	// The effective language is denormalized onto the persisted chunk rows.
+	tasks, err := st.NextPending(context.Background(), 100, "")
+	if err != nil {
+		t.Fatalf("NextPending: %v", err)
+	}
+	if len(tasks) == 0 {
+		t.Fatal("expected at least one pending chunk for the sidecar transcript")
+	}
+	for _, task := range tasks {
+		if task.Metadata.Language != "pt" {
+			t.Fatalf("chunk %d must carry the representation language pt, got %q",
+				task.Metadata.ChunkID, task.Metadata.Language)
+		}
+	}
+}
+
+// TestLanguageMetadata_UndifferentiatedSidecarIsUnknown pins §8.8 graceful
+// degradation: an undifferentiated sidecar (clip.vtt, no language suffix)
+// records NO language (unknown) and NO language_source, and its chunks carry an
+// empty language — which never matches a specific §9.5 filter.
+func TestLanguageMetadata_UndifferentiatedSidecarIsUnknown(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "lecture.mp3"), "fake-audio")
+	writeFile(t, filepath.Join(root, "lecture.vtt"),
+		"WEBVTT\n\n00:00:00.000 --> 00:00:02.000\nIntro\n")
+
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	if err := st.Init(context.Background()); err != nil {
+		t.Fatalf("store init: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	svc := newSidecarService(t, root, t.TempDir(), st)
+
+	if err := st.UpsertDocument(context.Background(), model.Document{RelPath: "lecture.mp3", DocType: "audio"}); err != nil {
+		t.Fatalf("upsert document: %v", err)
+	}
+	doc, err := st.GetDocumentByPath(context.Background(), "lecture.mp3")
+	if err != nil {
+		t.Fatalf("get document: %v", err)
+	}
+	if _, err := svc.IngestSidecarTranscripts(context.Background(), doc); err != nil {
+		t.Fatalf("IngestSidecarTranscripts: %v", err)
+	}
+
+	reps, err := st.TranscriptRepresentations(context.Background(), "lecture.mp3")
+	if err != nil {
+		t.Fatalf("TranscriptRepresentations: %v", err)
+	}
+	if len(reps) != 1 {
+		t.Fatalf("expected one transcript representation, got %d", len(reps))
+	}
+	if strings.Contains(reps[0].MetaJSON, `"language"`) {
+		t.Fatalf("undifferentiated sidecar must record no language, got %s", reps[0].MetaJSON)
+	}
+	if strings.Contains(reps[0].MetaJSON, `"language_source"`) {
+		t.Fatalf("undifferentiated sidecar must record no language_source, got %s", reps[0].MetaJSON)
+	}
+
+	tasks, err := st.NextPending(context.Background(), 100, "")
+	if err != nil {
+		t.Fatalf("NextPending: %v", err)
+	}
+	if len(tasks) == 0 {
+		t.Fatal("expected at least one pending chunk")
+	}
+	for _, task := range tasks {
+		if task.Metadata.Language != "" {
+			t.Fatalf("unknown-language chunk must carry empty language, got %q", task.Metadata.Language)
+		}
+	}
+}

--- a/tests/mcp/search_languages_test.go
+++ b/tests/mcp/search_languages_test.go
@@ -1,0 +1,208 @@
+package tests
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// TestMCPSearch_LanguagesFilterPassedThrough verifies dir2mcp_search accepts the
+// optional languages filter (SPEC §9.5/§15.2) and forwards it verbatim to the
+// retriever's SearchQuery.
+func TestMCPSearch_LanguagesFilterPassedThrough(t *testing.T) {
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+
+	var got []string
+	retriever := &askAudioRetrieverStub{
+		indexingComplete: true,
+		OnSearch: func(q model.SearchQuery) ([]model.SearchHit, error) {
+			got = q.Languages
+			return []model.SearchHit{}, nil
+		},
+	}
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"dir2mcp_search","arguments":{"query":"q","languages":["pt-BR","es"]}}}`)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d body=%s", resp.StatusCode, string(payload))
+	}
+	if len(got) != 2 || got[0] != "pt-BR" || got[1] != "es" {
+		t.Fatalf("languages filter not forwarded to retriever, got %v want [pt-BR es]", got)
+	}
+}
+
+// TestMCPSearch_LanguagesAbsentIsNoFilter verifies that omitting languages leaves
+// SearchQuery.Languages empty (no filtering, behaviour unchanged, SPEC §9.5).
+func TestMCPSearch_LanguagesAbsentIsNoFilter(t *testing.T) {
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+
+	got := []string{"sentinel"}
+	retriever := &askAudioRetrieverStub{
+		indexingComplete: true,
+		OnSearch: func(q model.SearchQuery) ([]model.SearchHit, error) {
+			got = q.Languages
+			return []model.SearchHit{}, nil
+		},
+	}
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"dir2mcp_search","arguments":{"query":"q"}}}`)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d body=%s", resp.StatusCode, string(payload))
+	}
+	if len(got) != 0 {
+		t.Fatalf("absent languages filter must leave SearchQuery.Languages empty, got %v", got)
+	}
+}
+
+// TestMCPSearch_InvalidLanguageTagIsInvalidField verifies a syntactically invalid
+// BCP-47 tag is reported as INVALID_FIELD (SPEC §9.5/§14) — not silently ignored
+// and not a server error.
+func TestMCPSearch_InvalidLanguageTagIsInvalidField(t *testing.T) {
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+	retriever := &askAudioRetrieverStub{indexingComplete: true}
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"dir2mcp_search","arguments":{"query":"q","languages":["en","not a tag!"]}}}`)
+	defer func() { _ = resp.Body.Close() }()
+
+	body, _ := io.ReadAll(resp.Body)
+	if got := string(body); !containsCanonicalCode(got, "INVALID_FIELD") {
+		t.Fatalf("invalid BCP-47 tag must yield INVALID_FIELD, body=%s", got)
+	}
+	if retriever.searchCalled.Load() {
+		t.Fatal("retriever.Search must not be called when a language tag is invalid")
+	}
+}
+
+// TestMCPAsk_LanguagesFilterPassedThrough verifies dir2mcp_ask accepts the
+// optional languages filter (SPEC §9.5/§15.3) and forwards it to Ask's query.
+func TestMCPAsk_LanguagesFilterPassedThrough(t *testing.T) {
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+
+	var got []string
+	retriever := &askAudioRetrieverStub{
+		indexingComplete: true,
+		askResult:        model.AskResult{Answer: "ok"},
+		OnAskQuery:       func(q model.SearchQuery) { got = q.Languages },
+	}
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"dir2mcp_ask","arguments":{"question":"q","languages":["en"]}}}`)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d body=%s", resp.StatusCode, string(payload))
+	}
+	if len(got) != 1 || got[0] != "en" {
+		t.Fatalf("ask languages filter not forwarded, got %v want [en]", got)
+	}
+}
+
+// TestMCPAsk_InvalidLanguageTagIsInvalidField mirrors the search case for ask.
+func TestMCPAsk_InvalidLanguageTagIsInvalidField(t *testing.T) {
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+	retriever := &askAudioRetrieverStub{indexingComplete: true, askResult: model.AskResult{Answer: "ok"}}
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"dir2mcp_ask","arguments":{"question":"q","languages":["@@@"]}}}`)
+	defer func() { _ = resp.Body.Close() }()
+
+	body, _ := io.ReadAll(resp.Body)
+	if got := string(body); !containsCanonicalCode(got, "INVALID_FIELD") {
+		t.Fatalf("invalid BCP-47 tag on ask must yield INVALID_FIELD, body=%s", got)
+	}
+	if retriever.askCalled.Load() {
+		t.Fatal("retriever.Ask must not be called when a language tag is invalid")
+	}
+}
+
+// TestMCPTools_SchemaAdvertisesLanguages confirms both the search and ask tool
+// input schemas expose the optional languages array filter (SPEC §15.2/§15.3).
+func TestMCPTools_SchemaAdvertisesLanguages(t *testing.T) {
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+	retriever := &askAudioRetrieverStub{indexingComplete: true}
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d body=%s", resp.StatusCode, string(payload))
+	}
+
+	var envelope struct {
+		Result struct {
+			Tools []struct {
+				Name        string                 `json:"name"`
+				InputSchema map[string]interface{} `json:"inputSchema"`
+			} `json:"tools"`
+		} `json:"result"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	want := map[string]bool{"dir2mcp_search": false, "dir2mcp_ask": false}
+	for _, tool := range envelope.Result.Tools {
+		if _, ok := want[tool.Name]; !ok {
+			continue
+		}
+		props, _ := tool.InputSchema["properties"].(map[string]interface{})
+		langs, ok := props["languages"].(map[string]interface{})
+		if !ok {
+			t.Errorf("%s input schema missing optional languages filter, props=%v", tool.Name, props)
+			continue
+		}
+		if langs["type"] != "array" {
+			t.Errorf("%s languages must be an array, got %#v", tool.Name, langs["type"])
+		}
+		want[tool.Name] = true
+	}
+	for name, found := range want {
+		if !found {
+			t.Errorf("%s tool not advertised with a languages filter", name)
+		}
+	}
+}
+
+// containsCanonicalCode reports whether the JSON-RPC response body carries the
+// given canonical error code as a quoted JSON string (tolerating either an
+// inline data.code field or a tool-result error envelope).
+func containsCanonicalCode(body, code string) bool {
+	return strings.Contains(body, `"`+code+`"`)
+}

--- a/tests/mcp/tools_test.go
+++ b/tests/mcp/tools_test.go
@@ -2162,6 +2162,9 @@ type askAudioRetrieverStub struct {
 	// callback to compute a custom question string.
 	EchoQuestion bool
 	OnAsk        func(question string) string
+	// OnAskQuery, when set, is invoked with the full SearchQuery passed to Ask so
+	// a test can assert additive filters (e.g. Languages, SPEC §9.5) are forwarded.
+	OnAskQuery func(query model.SearchQuery)
 
 	// tracking for assertions (read from HTTP handler goroutines)
 	searchCalled atomic.Bool
@@ -2195,8 +2198,11 @@ func (s *askAudioRetrieverStub) Search(_ context.Context, q model.SearchQuery) (
 	return nil, model.ErrNotImplemented
 }
 
-func (s *askAudioRetrieverStub) Ask(_ context.Context, question string, _ model.SearchQuery) (model.AskResult, error) {
+func (s *askAudioRetrieverStub) Ask(_ context.Context, question string, q model.SearchQuery) (model.AskResult, error) {
 	s.askCalled.Store(true)
+	if s.OnAskQuery != nil {
+		s.OnAskQuery(q)
+	}
 	if s.askErr != nil {
 		return model.AskResult{}, s.askErr
 	}

--- a/tests/model/langtag_test.go
+++ b/tests/model/langtag_test.go
@@ -1,0 +1,95 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// TestLanguagePrimarySubtag pins the canonical primary-subtag normalization used
+// by the per-language retrieval filter (SPEC §9.5): lower-cased, segment before
+// the first '-' or '_', empty for a blank tag.
+func TestLanguagePrimarySubtag(t *testing.T) {
+	cases := map[string]string{
+		"en":      "en",
+		"EN":      "en",
+		"en-US":   "en",
+		"pt-BR":   "pt",
+		"zh-Hant": "zh",
+		"en_us":   "en",
+		"  fr  ":  "fr",
+		"":        "",
+		"   ":     "",
+	}
+	for in, want := range cases {
+		if got := model.LanguagePrimarySubtag(in); got != want {
+			t.Errorf("LanguagePrimarySubtag(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestIsValidLanguageTag pins the lenient BCP-47 validity check that decides
+// INVALID_FIELD (§9.5/§14): common tags are valid; clearly malformed values are
+// rejected.
+func TestIsValidLanguageTag(t *testing.T) {
+	valid := []string{"en", "EN", "pt-BR", "zh-Hant", "und", "es", "de-DE-1996"}
+	for _, tag := range valid {
+		if !model.IsValidLanguageTag(tag) {
+			t.Errorf("IsValidLanguageTag(%q) = false, want true", tag)
+		}
+	}
+	invalid := []string{"", "   ", "not a tag!", "@@@", "en-", "-en", "en--US", "123", "en-US-"}
+	for _, tag := range invalid {
+		if model.IsValidLanguageTag(tag) {
+			t.Errorf("IsValidLanguageTag(%q) = true, want false", tag)
+		}
+	}
+}
+
+// TestLanguageMatchesAny pins the §9.5 matching contract: primary-subtag,
+// case-insensitive, logical OR; unknown (empty recorded) never matches a
+// specific filter.
+func TestLanguageMatchesAny(t *testing.T) {
+	cases := []struct {
+		recorded  string
+		requested []string
+		want      bool
+	}{
+		{"en", []string{"en"}, true},
+		{"en-US", []string{"EN"}, true},
+		{"pt-BR", []string{"pt"}, true},
+		{"pt-BR", []string{"es", "pt"}, true}, // OR
+		{"en", []string{"pt", "es"}, false},
+		{"", []string{"en"}, false},    // unknown never matches a specific filter
+		{"en", []string{"und"}, false}, // und is not en
+		{"", []string{"und"}, false},   // unknown is not matched even by und here
+	}
+	for _, tc := range cases {
+		if got := model.LanguageMatchesAny(tc.recorded, tc.requested); got != tc.want {
+			t.Errorf("LanguageMatchesAny(%q, %v) = %v, want %v", tc.recorded, tc.requested, got, tc.want)
+		}
+	}
+}
+
+// TestFilterMatch_Languages exercises the predicate through model.Filter.Match,
+// the single authoritative path shared by the in-Go re-check and backend
+// pushdown (HNSW/disk), to ensure language filtering composes with the existing
+// predicates and that an unknown-language payload is excluded by a non-empty
+// filter but kept when the filter is empty.
+func TestFilterMatch_Languages(t *testing.T) {
+	en := model.IndexPayload{ChunkID: 1, RelPath: "a.txt", DocType: "text", Language: "en-GB"}
+	unknown := model.IndexPayload{ChunkID: 2, RelPath: "b.txt", DocType: "text", Language: ""}
+
+	specific := model.Filter{Languages: []string{"en"}}
+	if !specific.Match(en) {
+		t.Error("en-GB payload must match a [en] filter (primary subtag)")
+	}
+	if specific.Match(unknown) {
+		t.Error("unknown-language payload must NOT match a specific [en] filter")
+	}
+
+	empty := model.Filter{}
+	if !empty.Match(unknown) || !empty.Match(en) {
+		t.Error("an empty filter must match every payload (no language filtering)")
+	}
+}

--- a/tests/retrieval/language_filter_test.go
+++ b/tests/retrieval/language_filter_test.go
@@ -1,0 +1,153 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
+)
+
+// addVecLang upserts a vector whose payload carries the representation's recorded
+// effective language, mirroring what payloadFromTask stores in production so the
+// HNSW pushdown filter (model.Filter.Match over the payload) sees it.
+func addVecLang(t *testing.T, idx *index.HNSWIndex, id uint64, vec []float32, relPath, docType, language string) {
+	t.Helper()
+	payload := model.IndexPayload{ChunkID: id, RelPath: relPath, DocType: docType, Language: language}
+	if err := idx.Upsert(context.Background(), vec, payload); err != nil {
+		t.Fatalf("Upsert(%d): %v", id, err)
+	}
+}
+
+// newLangService builds a vector-only retrieval service over idx and registers
+// the in-memory chunk metadata (carrying Language) for each id, mirroring the
+// production warm/on-index path so matchFilters sees the recorded language.
+func newLangService(t *testing.T, idx *index.HNSWIndex, meta map[uint64]model.SearchHit) *retrieval.Service {
+	t.Helper()
+	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+		"mistral-embed": {1, 0},
+	}}, nil)
+	for id, hit := range meta {
+		svc.SetChunkMetadata(id, hit)
+	}
+	return svc
+}
+
+func langSearchIDs(t *testing.T, svc *retrieval.Service, q model.SearchQuery) []uint64 {
+	t.Helper()
+	hits, err := svc.Search(context.Background(), q)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	ids := make([]uint64, 0, len(hits))
+	for _, h := range hits {
+		ids = append(ids, h.ChunkID)
+	}
+	return ids
+}
+
+// TestSearch_LanguageFilter_RestrictsToRequested pins SPEC §9.5: a languages
+// filter restricts hits to representations recorded in any requested language
+// (logical OR), excluding other languages.
+func TestSearch_LanguageFilter_RestrictsToRequested(t *testing.T) {
+	idx := index.NewHNSWIndex("")
+	addVecLang(t, idx, 1, []float32{1, 0}, "en.txt", "text", "en")
+	addVecLang(t, idx, 2, []float32{0.96, 0.04}, "pt.txt", "text", "pt-BR")
+	addVecLang(t, idx, 3, []float32{0.92, 0.08}, "es.txt", "text", "es")
+	svc := newLangService(t, idx, map[uint64]model.SearchHit{
+		1: {RelPath: "en.txt", DocType: "text", Snippet: "english", Language: "en", Span: model.Span{Kind: "lines", StartLine: 1, EndLine: 1}},
+		2: {RelPath: "pt.txt", DocType: "text", Snippet: "portuguese", Language: "pt-BR", Span: model.Span{Kind: "lines", StartLine: 1, EndLine: 1}},
+		3: {RelPath: "es.txt", DocType: "text", Snippet: "spanish", Language: "es", Span: model.Span{Kind: "lines", StartLine: 1, EndLine: 1}},
+	})
+
+	got := langSearchIDs(t, svc, model.SearchQuery{Query: "x", K: 10, Languages: []string{"pt", "es"}})
+	if len(got) != 2 {
+		t.Fatalf("languages [pt es] should yield 2 hits, got %d: %v", len(got), got)
+	}
+	for _, id := range got {
+		if id == 1 {
+			t.Fatalf("english hit must be excluded by a [pt es] filter, got %v", got)
+		}
+	}
+}
+
+// TestSearch_LanguageFilter_PrimarySubtagCaseInsensitive pins §9.5: matching is
+// on the BCP-47 primary subtag, case-insensitively, so a request for "EN"
+// matches both "en" and "en-US".
+func TestSearch_LanguageFilter_PrimarySubtagCaseInsensitive(t *testing.T) {
+	idx := index.NewHNSWIndex("")
+	addVecLang(t, idx, 1, []float32{1, 0}, "a.txt", "text", "en")
+	addVecLang(t, idx, 2, []float32{0.96, 0.04}, "b.txt", "text", "en-US")
+	svc := newLangService(t, idx, map[uint64]model.SearchHit{
+		1: {RelPath: "a.txt", DocType: "text", Snippet: "x", Language: "en", Span: model.Span{Kind: "lines", StartLine: 1, EndLine: 1}},
+		2: {RelPath: "b.txt", DocType: "text", Snippet: "y", Language: "en-US", Span: model.Span{Kind: "lines", StartLine: 1, EndLine: 1}},
+	})
+
+	got := langSearchIDs(t, svc, model.SearchQuery{Query: "x", K: 10, Languages: []string{"EN"}})
+	if len(got) != 2 {
+		t.Fatalf("request EN should match en and en-US (primary subtag), got %d: %v", len(got), got)
+	}
+}
+
+// TestSearch_LanguageFilter_UnknownExcludedBySpecificFilterButUnaffectedWithout
+// pins §8.8/§9.5: an unknown-language representation never matches a specific
+// filter, but is returned unchanged when no filter is set.
+func TestSearch_LanguageFilter_UnknownExcludedBySpecificFilterButUnaffectedWithout(t *testing.T) {
+	idx := index.NewHNSWIndex("")
+	addVecLang(t, idx, 1, []float32{1, 0}, "en.txt", "text", "en")
+	addVecLang(t, idx, 2, []float32{0.96, 0.04}, "unknown.txt", "text", "") // no recorded language
+	svc := newLangService(t, idx, map[uint64]model.SearchHit{
+		1: {RelPath: "en.txt", DocType: "text", Snippet: "x", Language: "en", Span: model.Span{Kind: "lines", StartLine: 1, EndLine: 1}},
+		2: {RelPath: "unknown.txt", DocType: "text", Snippet: "y", Language: "", Span: model.Span{Kind: "lines", StartLine: 1, EndLine: 1}},
+	})
+
+	// Specific filter excludes the unknown-language hit.
+	filtered := langSearchIDs(t, svc, model.SearchQuery{Query: "x", K: 10, Languages: []string{"en"}})
+	if len(filtered) != 1 || filtered[0] != 1 {
+		t.Fatalf("a specific [en] filter must exclude the unknown-language hit, got %v", filtered)
+	}
+
+	// No filter: both hits returned (behaviour unchanged).
+	unfiltered := langSearchIDs(t, svc, model.SearchQuery{Query: "x", K: 10})
+	if len(unfiltered) != 2 {
+		t.Fatalf("absent filter must be a no-op; expected 2 hits, got %d: %v", len(unfiltered), unfiltered)
+	}
+}
+
+// TestSearch_LanguageFilter_AbsentIsUnchanged confirms an absent/empty filter
+// leaves results identical to no filter (additive, off by default, §9.5).
+func TestSearch_LanguageFilter_AbsentIsUnchanged(t *testing.T) {
+	idx := index.NewHNSWIndex("")
+	addVecLang(t, idx, 1, []float32{1, 0}, "en.txt", "text", "en")
+	addVecLang(t, idx, 2, []float32{0.96, 0.04}, "pt.txt", "text", "pt")
+	svc := newLangService(t, idx, map[uint64]model.SearchHit{
+		1: {RelPath: "en.txt", DocType: "text", Snippet: "x", Language: "en", Span: model.Span{Kind: "lines", StartLine: 1, EndLine: 1}},
+		2: {RelPath: "pt.txt", DocType: "text", Snippet: "y", Language: "pt", Span: model.Span{Kind: "lines", StartLine: 1, EndLine: 1}},
+	})
+
+	none := langSearchIDs(t, svc, model.SearchQuery{Query: "x", K: 10})
+	empty := langSearchIDs(t, svc, model.SearchQuery{Query: "x", K: 10, Languages: []string{}})
+	if len(none) != 2 || len(empty) != 2 {
+		t.Fatalf("absent vs empty languages must both be no-ops; none=%v empty=%v", none, empty)
+	}
+}
+
+// TestSearch_LanguageFilter_NoMatchIsEmptyNotError pins §9.5: a syntactically
+// valid tag that matches nothing in the corpus returns an empty hit list, not an
+// error.
+func TestSearch_LanguageFilter_NoMatchIsEmptyNotError(t *testing.T) {
+	idx := index.NewHNSWIndex("")
+	addVecLang(t, idx, 1, []float32{1, 0}, "en.txt", "text", "en")
+	svc := newLangService(t, idx, map[uint64]model.SearchHit{
+		1: {RelPath: "en.txt", DocType: "text", Snippet: "x", Language: "en", Span: model.Span{Kind: "lines", StartLine: 1, EndLine: 1}},
+	})
+
+	hits, err := svc.Search(context.Background(), model.SearchQuery{Query: "x", K: 10, Languages: []string{"ja"}})
+	if err != nil {
+		t.Fatalf("a no-match language filter must not error: %v", err)
+	}
+	if len(hits) != 0 {
+		t.Fatalf("a no-match language filter must return an empty hit list, got %d", len(hits))
+	}
+}


### PR DESCRIPTION
## Summary

Implements **issue #267 item 4** end-to-end against spec **0.22.0** (re-pinned in this PR): record each representation's effective language and add an optional per-language retrieval filter to `dir2mcp_search` / `dir2mcp_ask`.

Part of #267 (item 4). Items 1/2/3/5 already landed (#297, #312, #300, #308); the issue is already closed, so this uses "Part of" rather than "Closes".

## Detected-language metadata (SPEC §5.2/§8.8)

- `transcriptMeta` now records `language_source` (`configured` | `declared`) and optional `language_confidence` alongside the existing `language`.
- Precedence per §8.8 (configured > declared > detected):
  - STT / translated transcripts with an operator pin → `language` = pin, `language_source` = `configured`.
  - Per-language sidecars (`clip.en.vtt`, TTML `xml:lang`) → `language_source` = `declared`.
  - Undifferentiated sidecar / unpinned STT → **unknown** (no language, graceful degrade, never an error).
- Best-effort `detected` is intentionally **not** emitted yet: no detector primitive currently reports a language and §8.8 forbids assuming a default. The seam is documented for when a detector lands.

## Per-language retrieval filter (SPEC §9.5)

- Optional `languages: string[]` on `dir2mcp_search` (§15.2) and `dir2mcp_ask` (§15.3), matching the spec JSON schemas exactly.
- Semantics: case-insensitive **BCP-47 primary-subtag** match, logical **OR**, applied at **candidate selection** (before dedup/rerank/truncation). Absent/empty ⇒ unchanged behavior. Unknown-language representations never match a specific filter. Invalid BCP-47 tag ⇒ `INVALID_FIELD`. No result-structure or citation change. A valid tag that matches nothing ⇒ empty list (not an error).

## Data path

The effective language is denormalized onto chunks (additive `chunks.language` column — **no migration** of existing rows; empty = unknown) so the filter predicates at candidate selection without a per-chunk `meta_json` lookup. Plumbed through `ChunkMetadata` → `IndexPayload`/`SearchHit` → `Filter.Match`. HNSW/disk backends push the filter down via the payload; qdrant/pgvector decline push-down (BCP-47 subtag matching has no faithful native form) and defer to the single Go-side `Filter.Match`.

## Spec governance

Re-pins the `dirstral-spec` submodule to `b26728e` (0.22.0) in its own commit, per the gated re-pin loop.

## Tests

- `tests/model`: `TestLanguagePrimarySubtag`, `TestIsValidLanguageTag`, `TestLanguageMatchesAny`, `TestFilterMatch_Languages`
- `tests/retrieval`: `TestSearch_LanguageFilter_RestrictsToRequested`, `_PrimarySubtagCaseInsensitive`, `_UnknownExcludedBySpecificFilterButUnaffectedWithout`, `_AbsentIsUnchanged`, `_NoMatchIsEmptyNotError`
- `tests/mcp`: `TestMCPSearch_LanguagesFilterPassedThrough`, `_LanguagesAbsentIsNoFilter`, `_InvalidLanguageTagIsInvalidField`, `TestMCPAsk_LanguagesFilterPassedThrough`, `TestMCPAsk_InvalidLanguageTagIsInvalidField`, `TestMCPTools_SchemaAdvertisesLanguages`
- `tests/ingest`: `TestLanguageMetadata_SidecarRecordsDeclaredSourceAndChunkLanguage`, `TestLanguageMetadata_UndifferentiatedSidecarIsUnknown`

`make check` is fully green; MCP inspector-smoke + conformance pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHuQEKSW3nzU1Pn7KXXBhj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional per-language filtering for retrieval and search, driven by requested language tags.
  * Extended MCP `search` and `ask` tools with an optional `languages` argument to restrict results.
* **Enhancements**
  * Persisted transcript and chunk metadata now include effective language info, plus language provenance (configured vs declared) and optional detector confidence.
  * Search results now expose language metadata to support consistent filtering.
* **Bug Fixes**
  * Improved restart/warm-load behavior so language filtering remains correct after reloads.
* **Tests**
  * Added coverage for language-tag handling, retrieval filtering, MCP behavior, and persistence of language metadata.
* **Chores**
  * Updated the `dirstral-spec` subproject revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->