### PR TITLE
test+ci: docling adapter contract & provider-selection matrix (#145)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -81,3 +81,27 @@ jobs:
 
       - name: Run inspector smoke test
         run: make inspector-smoke
+
+  # Named, fast-failing coverage for the docling adapter contract and the
+  # provider-selection / fallback decision matrix (#145). These cases also run
+  # under `make check` (the `checks` job); this job runs them in isolation so an
+  # adapter-protocol regression or a broken fallback path is surfaced as its own
+  # red check rather than buried in the full suite. It needs no docling binary,
+  # no docling-serve container, and no network (deterministic fakes/seams only).
+  docling-contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Docling adapter contract + provider-selection matrix
+        run: >-
+          go test -v ./tests/ingest/
+          -run 'Docling|DescribeDocumentExtractor|DocumentExtractorFromConfig|DescribeAndBuild'

--- a/tests/ingest/docling_parity_test.go
+++ b/tests/ingest/docling_parity_test.go
@@ -1,0 +1,57 @@
+package tests
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/ingest/docling"
+)
+
+// TestDoclingAdapter_ServeAndLocalParity pins that the two structured-extraction
+// adapters — the local CLI path (docling package: Parse -> Linearize ->
+// RenderMarkdown, which the CLI extractor runs on `--to json` output) and the
+// docling-serve HTTP path — produce the IDENTICAL structured contract for the
+// same DoclingDocument. Without this, the two install tracks (lean docling-serve
+// vs full local docling, the #145 brew tracks) could silently diverge. Runs in
+// CI with no docling binary and no container.
+func TestDoclingAdapter_ServeAndLocalParity(t *testing.T) {
+	fixture := loadDoclingSample(t)
+
+	// Local CLI path: the docling package is exactly what NewDoclingExtractor
+	// runs on the command's JSON output.
+	doc, err := docling.Parse(fixture)
+	if err != nil {
+		t.Fatalf("local Parse: %v", err)
+	}
+	localBlocks := doc.Linearize()
+	localTitle := doc.Title()
+	localMarkdown := docling.RenderMarkdown(localBlocks)
+
+	// docling-serve path: same fixture returned as document.json_content.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":"success","document":{"json_content":`+string(fixture)+`}}`)
+	}))
+	defer srv.Close()
+
+	res, err := ingest.NewDoclingServeExtractor(srv.URL).
+		ExtractStructured(context.Background(), "report.pdf", fixture)
+	if err != nil {
+		t.Fatalf("serve ExtractStructured: %v", err)
+	}
+
+	if res.Title != localTitle {
+		t.Errorf("title diverges: serve=%q local=%q", res.Title, localTitle)
+	}
+	if res.Markdown != localMarkdown {
+		t.Errorf("markdown diverges between serve and local:\n--- serve ---\n%s\n--- local ---\n%s", res.Markdown, localMarkdown)
+	}
+	if !reflect.DeepEqual(res.Blocks, localBlocks) {
+		t.Errorf("blocks diverge between serve and local:\nserve=%+v\nlocal=%+v", res.Blocks, localBlocks)
+	}
+}

--- a/tests/ingest/docling_provider_matrix_test.go
+++ b/tests/ingest/docling_provider_matrix_test.go
@@ -1,0 +1,102 @@
+package tests
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+)
+
+// These cases pin the provider-selection / fallback decision matrix that #145
+// asks CI to validate, using only deterministic seams (no docling binary, no
+// network, no real Mistral key). Endpoint-reachability and functional-check
+// permutations are covered in docling_extractor_test.go and
+// docling_functional_check_test.go; this file pins the mode-dispatch and the
+// "off" / "no provider at all" edges that those suites do not.
+
+// TestDescribeDocumentExtractor_OffDisables pins that ingest.extractor=off
+// disables extraction outright, even when a Mistral credential is present — the
+// explicit kill switch must win over any auto-detected provider.
+func TestDescribeDocumentExtractor_OffDisables(t *testing.T) {
+	t.Setenv("MISTRAL_API_KEY", "fake-key")
+	d := ingest.DescribeDocumentExtractor(config.Config{IngestExtractor: "off"})
+	if d.Name != "" || d.Source != "disabled" {
+		t.Fatalf("off should disable extraction: name=%q source=%q (%s)", d.Name, d.Source, d.Reason)
+	}
+}
+
+// TestDocumentExtractorFromConfig_OffYieldsNoExtractor pins that the kill switch
+// is honoured by the builder too (lockstep with DescribeDocumentExtractor), so
+// no extractor is constructed when extraction is turned off.
+func TestDocumentExtractorFromConfig_OffYieldsNoExtractor(t *testing.T) {
+	t.Setenv("MISTRAL_API_KEY", "fake-key")
+	if ex := ingest.DocumentExtractorFromConfig(config.Config{IngestExtractor: "off"}); ex != nil {
+		t.Fatal("ingest.extractor=off must yield no extractor")
+	}
+}
+
+// TestDescribeDocumentExtractor_MistralExplicitNoCredentialDisabled pins that
+// explicitly requesting Mistral OCR with no credential disables extraction with
+// an explanatory reason — it must NOT silently fall through to another engine.
+func TestDescribeDocumentExtractor_MistralExplicitNoCredentialDisabled(t *testing.T) {
+	t.Setenv("MISTRAL_API_KEY", "")
+	d := ingest.DescribeDocumentExtractor(config.Config{IngestExtractor: "mistral"})
+	if d.Name != "" || d.Source != "disabled" {
+		t.Fatalf("explicit mistral without credential should be disabled: name=%q source=%q (%s)", d.Name, d.Source, d.Reason)
+	}
+}
+
+// TestDescribeDocumentExtractor_AutoNoProvidersDisabled pins the bottom of the
+// auto cascade: no docling CLI, no serve URL, and no Mistral credential leaves
+// no extractor available (rather than failing every document at ingest time).
+func TestDescribeDocumentExtractor_AutoNoProvidersDisabled(t *testing.T) {
+	if _, err := exec.LookPath("docling"); err == nil {
+		t.Skip("docling CLI present on PATH; auto would select it")
+	}
+	t.Setenv("MISTRAL_API_KEY", "")
+	d := ingest.DescribeDocumentExtractor(config.Config{IngestExtractor: "auto"})
+	if d.Name != "" || d.Source != "disabled" {
+		t.Fatalf("auto with no providers should be disabled: name=%q source=%q (%s)", d.Name, d.Source, d.Reason)
+	}
+}
+
+// TestDescribeDocumentExtractor_UnknownModeFallsToAuto pins that an unrecognised
+// ingest.extractor value is treated as auto (forward-compatible default) rather
+// than hard-failing config load.
+func TestDescribeDocumentExtractor_UnknownModeFallsToAuto(t *testing.T) {
+	if _, err := exec.LookPath("docling"); err == nil {
+		t.Skip("docling CLI present on PATH; auto would select it")
+	}
+	t.Setenv("MISTRAL_API_KEY", "fake-key")
+	d := ingest.DescribeDocumentExtractor(config.Config{IngestExtractor: "totally-unknown-mode"})
+	// With no docling but a Mistral credential, the auto cascade falls back to
+	// Mistral OCR — proving the unknown mode routed through the auto branch.
+	if d.Name != "mistral-ocr" || d.Source != "fallback" {
+		t.Fatalf("unknown mode should route through auto: name=%q source=%q (%s)", d.Name, d.Source, d.Reason)
+	}
+}
+
+// TestDescribeAndBuild_Lockstep is a light cross-check that the diagnostic
+// describe path and the builder agree on availability across the representative
+// modes (#145: the banner must reflect what the runtime actually runs). For
+// "disabled" decisions the builder must return nil; for selected ones it must
+// return a non-nil extractor.
+func TestDescribeAndBuild_Lockstep(t *testing.T) {
+	t.Setenv("MISTRAL_API_KEY", "")
+	cases := []config.Config{
+		{IngestExtractor: "off"},
+		{IngestExtractor: "mistral"},       // no credential -> disabled
+		{IngestExtractor: "docling-serve"}, // no URL -> disabled
+	}
+	for _, cfg := range cases {
+		d := ingest.DescribeDocumentExtractor(cfg)
+		ex := ingest.DocumentExtractorFromConfig(cfg)
+		if d.Source == "disabled" && ex != nil {
+			t.Errorf("mode %q: describe=disabled but builder returned an extractor", cfg.IngestExtractor)
+		}
+		if d.Source != "disabled" && ex == nil {
+			t.Errorf("mode %q: describe=%s/%s but builder returned nil", cfg.IngestExtractor, d.Name, d.Source)
+		}
+	}
+}

--- a/tests/ingest/docling_version_skew_test.go
+++ b/tests/ingest/docling_version_skew_test.go
@@ -1,0 +1,209 @@
+package tests
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/ingest/docling"
+)
+
+// The docling DoclingDocument schema evolves across releases; the adapter is
+// built to tolerate that drift (unknown top-level fields ignored, `cref` and
+// `$ref` reference aliases, label aliases, unknown labels degrading to
+// paragraph) so a docling upgrade does not silently break extraction. These
+// tests pin that version-skew contract directly against the parser/linearizer,
+// with no docling binary, so CI catches adapter-protocol regressions (#145).
+
+// TestDoclingParse_RejectsMalformedJSON pins the contract that drives the flat
+// fallback: malformed JSON yields an error (the caller then returns the raw
+// command output verbatim rather than fabricating structure).
+func TestDoclingParse_RejectsMalformedJSON(t *testing.T) {
+	if _, err := docling.Parse([]byte("{not valid json")); err == nil {
+		t.Fatal("Parse(malformed) = nil error, want a parse error so the caller can fall back to flat extraction")
+	}
+}
+
+// TestDoclingParse_RejectsEmptyBody pins that a structurally-empty document
+// (no body, or a body with no children) is rejected, so non-DoclingDocument
+// output (e.g. a plain-Markdown custom command) is not misread as structured.
+func TestDoclingParse_RejectsEmptyBody(t *testing.T) {
+	cases := map[string]string{
+		"no body":            `{"schema_name":"DoclingDocument","version":"1.2.0"}`,
+		"body no children":   `{"schema_name":"DoclingDocument","version":"1.2.0","body":{"self_ref":"#/body","children":[]}}`,
+		"flat markdown text": "# Just markdown\n\nnot json at all",
+	}
+	for name, in := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := docling.Parse([]byte(in)); err == nil {
+				t.Errorf("Parse(%q) = nil error, want rejection so the caller falls back to flat extraction", name)
+			}
+		})
+	}
+}
+
+// TestDoclingParse_ToleratesUnknownTopLevelFields pins forward-compat: a future
+// docling release that adds top-level fields the adapter does not model must
+// still parse and linearize cleanly (unknown fields ignored, not fatal).
+func TestDoclingParse_ToleratesUnknownTopLevelFields(t *testing.T) {
+	in := `{
+	  "schema_name": "DoclingDocument",
+	  "version": "9.9.0-future",
+	  "name": "Forward Compat",
+	  "some_new_field": {"nested": [1, 2, 3]},
+	  "key_value_items": [],
+	  "body": {"self_ref": "#/body", "children": [{"$ref": "#/texts/0"}]},
+	  "texts": [
+	    {"self_ref": "#/texts/0", "label": "paragraph", "text": "Survives schema drift.",
+	     "unknown_per_text_field": true}
+	  ]
+	}`
+	doc, err := docling.Parse([]byte(in))
+	if err != nil {
+		t.Fatalf("Parse with unknown fields: %v", err)
+	}
+	if doc.Version != "9.9.0-future" {
+		t.Errorf("Version = %q, want it retained for drift guards", doc.Version)
+	}
+	blocks := doc.Linearize()
+	if _, ok := findBlock(blocks, docling.LabelParagraph, "Survives schema drift."); !ok {
+		t.Errorf("paragraph lost when unknown fields are present: %+v", blocks)
+	}
+}
+
+// TestDoclingLinearize_AcceptsCrefReferenceAlias pins that the adapter follows
+// the `cref` reference key as well as `$ref`. Docling has emitted both across
+// versions; a release that switches keys must not drop body content.
+func TestDoclingLinearize_AcceptsCrefReferenceAlias(t *testing.T) {
+	in := `{
+	  "schema_name": "DoclingDocument", "version": "1.0.0", "name": "Cref Doc",
+	  "body": {"self_ref": "#/body", "children": [{"cref": "#/texts/0"}]},
+	  "texts": [
+	    {"self_ref": "#/texts/0", "label": "paragraph", "text": "Reached via cref."}
+	  ]
+	}`
+	doc, err := docling.Parse([]byte(in))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	blocks := doc.Linearize()
+	if _, ok := findBlock(blocks, docling.LabelParagraph, "Reached via cref."); !ok {
+		t.Errorf("cref reference not followed; body content dropped: %+v", blocks)
+	}
+}
+
+// TestDoclingLinearize_LabelAliasesAndDegradation pins the label-normalization
+// contract: known aliases (`subtitle-level-1` -> section_header) map onto the
+// spec label set, and an unknown/future label degrades to paragraph so its text
+// is still indexed rather than discarded.
+func TestDoclingLinearize_LabelAliasesAndDegradation(t *testing.T) {
+	in := `{
+	  "schema_name": "DoclingDocument", "version": "1.0.0", "name": "Labels",
+	  "body": {"self_ref": "#/body", "children": [
+	    {"$ref": "#/texts/0"}, {"$ref": "#/texts/1"}, {"$ref": "#/texts/2"}
+	  ]},
+	  "texts": [
+	    {"self_ref": "#/texts/0", "label": "subtitle-level-1", "level": 1, "text": "Legacy Heading"},
+	    {"self_ref": "#/texts/1", "label": "footnote", "text": "Unknown label body."},
+	    {"self_ref": "#/texts/2", "label": "TITLE", "text": "Mixed Case Title"}
+	  ]
+	}`
+	doc, err := docling.Parse([]byte(in))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	blocks := doc.Linearize()
+
+	if _, ok := findBlock(blocks, docling.LabelSectionHeader, "Legacy Heading"); !ok {
+		t.Error("subtitle-level-1 should normalize to section_header")
+	}
+	// An unknown label must still surface its text, under the paragraph label.
+	if _, ok := findBlock(blocks, docling.LabelParagraph, "Unknown label body."); !ok {
+		t.Error("unknown label should degrade to paragraph (text retained, not dropped)")
+	}
+	// Label matching is case-insensitive, so "TITLE" is a title.
+	if _, ok := findBlock(blocks, docling.LabelTitle, "Mixed Case Title"); !ok {
+		t.Error("upper-case TITLE should normalize to the title label")
+	}
+}
+
+// TestDoclingLinearize_OrigFallbackWhenTextEmpty pins that an element carrying
+// only `orig` (some docling enrichments populate orig, not text) still yields a
+// block, so its content is not lost.
+func TestDoclingLinearize_OrigFallbackWhenTextEmpty(t *testing.T) {
+	in := `{
+	  "schema_name": "DoclingDocument", "version": "1.0.0", "name": "Orig",
+	  "body": {"self_ref": "#/body", "children": [{"$ref": "#/texts/0"}]},
+	  "texts": [
+	    {"self_ref": "#/texts/0", "label": "paragraph", "text": "", "orig": "From orig only."}
+	  ]
+	}`
+	doc, err := docling.Parse([]byte(in))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	blocks := doc.Linearize()
+	if _, ok := findBlock(blocks, docling.LabelParagraph, "From orig only."); !ok {
+		t.Errorf("orig fallback lost: %+v", blocks)
+	}
+}
+
+// TestDoclingLinearize_BottomLeftBBoxNormalizedToTopLeft pins the provenance
+// normalization contract (spec §5.4): a BOTTOMLEFT-origin bbox is flipped to
+// TOPLEFT when the page height is known, with the origin recorded as TOPLEFT.
+// This is what keeps region citations accurate regardless of docling's stored
+// coordinate convention.
+func TestDoclingLinearize_BottomLeftBBoxNormalizedToTopLeft(t *testing.T) {
+	in := `{
+	  "schema_name": "DoclingDocument", "version": "1.0.0", "name": "BBox",
+	  "pages": {"1": {"size": {"width": 612, "height": 792}, "page_no": 1}},
+	  "body": {"self_ref": "#/body", "children": [{"$ref": "#/texts/0"}]},
+	  "texts": [
+	    {"self_ref": "#/texts/0", "label": "paragraph", "text": "Bottom-left box.",
+	     "prov": [{"page_no": 1, "bbox": {"l": 72, "t": 100, "r": 540, "b": 60, "coord_origin": "BOTTOMLEFT"}}]}
+	  ]
+	}`
+	doc, err := docling.Parse([]byte(in))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	b, ok := findBlock(doc.Linearize(), docling.LabelParagraph, "Bottom-left box.")
+	if !ok || b.BBox == nil {
+		t.Fatalf("expected a paragraph block with a bbox, got %+v ok=%v", b, ok)
+	}
+	if b.BBox.CoordOrigin != "TOPLEFT" {
+		t.Errorf("coord_origin = %q, want TOPLEFT after normalization", b.BBox.CoordOrigin)
+	}
+	// height=792, BOTTOMLEFT t=100 b=60 -> TOPLEFT top = 792-100 = 692, bottom = 792-60 = 732.
+	if b.BBox.T != 692 || b.BBox.B != 732 {
+		t.Errorf("normalized bbox T/B = %v/%v, want 692/732", b.BBox.T, b.BBox.B)
+	}
+	if b.BBox.T > b.BBox.B {
+		t.Errorf("normalized bbox must satisfy T<=B, got T=%v B=%v", b.BBox.T, b.BBox.B)
+	}
+}
+
+// TestDoclingRenderMarkdown_EscapesTablePipes pins that cell text containing a
+// pipe is escaped so it cannot break the Markdown table column layout (a common
+// source of corrupted structured output on real documents).
+func TestDoclingRenderMarkdown_EscapesTablePipes(t *testing.T) {
+	in := `{
+	  "schema_name": "DoclingDocument", "version": "1.0.0", "name": "Pipes",
+	  "body": {"self_ref": "#/body", "children": [{"$ref": "#/tables/0"}]},
+	  "tables": [
+	    {"self_ref": "#/tables/0", "label": "table", "data": {
+	      "num_rows": 2, "num_cols": 1, "table_cells": [
+	        {"text": "Header", "start_row_offset_idx": 0, "end_row_offset_idx": 1, "start_col_offset_idx": 0, "end_col_offset_idx": 1, "column_header": true},
+	        {"text": "a|b", "start_row_offset_idx": 1, "end_row_offset_idx": 2, "start_col_offset_idx": 0, "end_col_offset_idx": 1}
+	      ]
+	    }}
+	  ]
+	}`
+	doc, err := docling.Parse([]byte(in))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	md := docling.RenderMarkdown(doc.Linearize())
+	if !strings.Contains(md, `a\|b`) {
+		t.Errorf("table cell pipe not escaped, layout would break:\n%s", md)
+	}
+}


### PR DESCRIPTION
## Summary

Fills the remaining **core-repo** scope of #145: deterministic CI coverage for the docling adapter contract and the provider-selection / fallback decision matrix. All additions run in CI with **no docling binary, no docling-serve container, and no network** (existing fakes/seams only).

Per the issue's own progress comments, the brew install-track matrix (lean `dir2mcp` vs full `dir2mcp-full`) and the macOS Intel + Apple-Silicon runner lanes already shipped in `Dirstral/homebrew-tap`; the open core-repo items were the adapter goldens and explicit provider-selection/fallback assertions. This PR addresses those.

## What was already covered (left untouched)
- Golden DoclingDocument contract (`docling_contract_test.go` + `testdata/docling_sample.json`): parse → linearize → render, plus the docling-serve httptest golden.
- docling-serve adapter mechanics (`docling_serve_extractor_test.go`): convert endpoint/path, `to_formats=json`, file upload, non-200 + missing-`json_content` errors (no response-body leak), URL sanitization, `/health` probe.
- Provider selection permutations involving endpoint reachability and the functional-check cascade (`docling_extractor_test.go`, `docling_functional_check_test.go`): explicit/auto docling & docling-serve, broken-docling skip/fallback, serve-unreachable fallback.
- Env sanitization (`docling_env_test.go`); self-hosted OCR binding (`self_hosted_ocr_test.go`).
- The contract tests already execute in CI via `make check` → `go test ./...`.

## What this PR adds
**`tests/ingest/docling_version_skew_test.go`** — adapter protocol / version-skew contract directly against the parser/linearizer:
- `TestDoclingParse_RejectsMalformedJSON`, `TestDoclingParse_RejectsEmptyBody` — the flat-fallback seam (malformed JSON / empty body must error so the caller returns raw output).
- `TestDoclingParse_ToleratesUnknownTopLevelFields` — forward-compat: unknown top-level/per-element fields ignored; version retained.
- `TestDoclingLinearize_AcceptsCrefReferenceAlias` — `cref` reference alias followed as well as `$ref`.
- `TestDoclingLinearize_LabelAliasesAndDegradation` — `subtitle-level-1`→section_header, unknown label→paragraph (text retained), case-insensitive labels.
- `TestDoclingLinearize_OrigFallbackWhenTextEmpty` — `orig`-only elements still emit.
- `TestDoclingLinearize_BottomLeftBBoxNormalizedToTopLeft` — BOTTOMLEFT→TOPLEFT bbox normalization (region-citation accuracy).
- `TestDoclingRenderMarkdown_EscapesTablePipes` — table cell pipes escaped so layout can't break.

**`tests/ingest/docling_parity_test.go`** — `TestDoclingAdapter_ServeAndLocalParity`: the same DoclingDocument yields **identical** title/markdown/blocks through the local-CLI pipeline and the docling-serve adapter, so the two install tracks can't silently diverge.

**`tests/ingest/docling_provider_matrix_test.go`** — provider-selection matrix edges not covered elsewhere:
- `TestDescribeDocumentExtractor_OffDisables` + `TestDocumentExtractorFromConfig_OffYieldsNoExtractor` — `ingest.extractor=off` kill switch wins over a present credential.
- `TestDescribeDocumentExtractor_MistralExplicitNoCredentialDisabled` — explicit mistral w/o credential disables (no silent fall-through).
- `TestDescribeDocumentExtractor_AutoNoProvidersDisabled` — bottom of the auto cascade.
- `TestDescribeDocumentExtractor_UnknownModeFallsToAuto` — unknown mode routes through auto.
- `TestDescribeAndBuild_Lockstep` — describe path and builder agree on availability.

## CI workflow change
**`.github/workflows/go.yml`**: new `docling-contract` job that runs the docling adapter-contract + provider-selection tests in isolation (`go test ./tests/ingest -run 'Docling|DescribeDocumentExtractor|DocumentExtractorFromConfig|DescribeAndBuild'`). They also run under `make check`; the dedicated job makes #145's "CI catches adapter protocol regressions / verifies fallback" a discrete, fast-failing red check. YAML validated locally (parses; `docling-contract` job present).

## Verification
- `golangci-lint cache clean` then `make check` — fully green (fmt, vet, lint, cyclo, ineffassign, misspell, all tests, build).
- New tests pass; integration-only structured-extract tests remain gated behind `RUN_INTEGRATION_TESTS=1`.

## Remaining (cross-repo — cannot be validated in this sandbox)
The **brew install smoke for `dir2mcp` vs `dir2mcp-full`** and the **macOS Intel + Apple-Silicon runner matrix** live in `Dirstral/homebrew-tap` (per the issue, already shipped/green there; Intel full-lane restoration tracked in #149). They require real CI runners + Homebrew and are out of scope for this repo.

**Part of #145** — leaving the issue open for the cross-repo brew/multi-arch tracking.