### PR TITLE
ci(release): install Nix + pass nix token so GoReleaser publishes the flake

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,16 @@ jobs:
             exit 1
           fi
 
+      # GoReleaser's nix publisher needs `nix-hash` on PATH to compute the
+      # source hash for the generated flake; without Nix it skips the nix pipe
+      # ("nix-hash is not available"). Install Nix before the release step so the
+      # flake is published to dirstral/nix-user-repository.
+      - name: Install Nix
+        uses: cachix/install-nix-action@v30
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
       - name: GoReleaser release
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -61,6 +71,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+          # Required by the `nix:` publisher in .goreleaser.yaml to push the
+          # generated flake to dirstral/nix-user-repository.
+          NIX_USER_REPOSITORY_GITHUB_TOKEN: ${{ secrets.NIX_USER_REPOSITORY_GITHUB_TOKEN }}
 
       # GoReleaser auto-bumps the lean dir2mcp.rb but cannot regenerate
       # dir2mcp-full.rb (it carries hand-written docling install logic).


### PR DESCRIPTION
## Problem
The v0.8.0 release succeeded but **skipped the Nix publish** — `dirstral/nix-user-repository` got nothing. Release log:
```
nixpkgs • pipe skipped or partially skipped   reason=nix-hash is not available
```
Two gaps in `release.yml`:
1. **Nix isn't installed** on the runner, so GoReleaser's nix publisher can't compute the source hash (`nix-hash`).
2. The GoReleaser step **never passed `NIX_USER_REPOSITORY_GITHUB_TOKEN`** to its env, so even with `nix-hash` the push would have no credential.

## Fix
- Add an **Install Nix** step (cachix/install-nix-action@v30) before the GoReleaser step.
- Pass **`NIX_USER_REPOSITORY_GITHUB_TOKEN`** (now set as a repo secret) into the GoReleaser step env.

## Effect
Future releases publish the generated flake to `dirstral/nix-user-repository`. Homebrew + GitHub-release steps are unchanged.

## Note on v0.8.0
v0.8.0's NUR entry is not backfilled (the workflow file is read from the tag commit, which predates this fix). The **primary path is unaffected**: `nix run github:dirstral/dir2mcp` builds from the hand-written flake on `main` (shipped in #276). To populate the NUR with a real version, the next release (after this merges) does it.

Part of the #272 Nix rollout.