### PR TITLE
test(eval): offline retrieval-quality eval + ablation harness (#322)

### DIFF
--- a/tests/eval/ablation_test.go
+++ b/tests/eval/ablation_test.go
@@ -43,7 +43,10 @@ func runAblation(t *testing.T, corpus evalCorpus) []configMetrics {
 	t.Helper()
 	rows := make([]configMetrics, 0, len(ablationMatrix()))
 	for _, cfg := range ablationMatrix() {
-		svc := corpus.buildService(cfg)
+		svc, err := corpus.buildService(cfg)
+		if err != nil {
+			t.Fatalf("buildService(%s): %v", cfg.name, err)
+		}
 		perQuery := make([]RankedMetrics, 0, len(corpus.queries))
 		var totalHits int
 		for _, q := range corpus.queries {

--- a/tests/eval/ablation_test.go
+++ b/tests/eval/ablation_test.go
@@ -1,0 +1,188 @@
+package tests
+
+import (
+	"testing"
+)
+
+// evalK is the retrieval cutoff used for recall@k / nDCG@k across the ablation.
+const evalK = 5
+
+// configMetrics holds one ablation row's macro-averaged metrics plus the mean
+// number of hits returned per query (a proxy for how aggressively a config
+// trims the candidate set — relevant for the precision-oriented knobs).
+type configMetrics struct {
+	cfg      knobConfig
+	mean     RankedMetrics
+	meanHits float64
+}
+
+// ablationMatrix is the set of configurations the harness measures. Each row
+// toggles one additional retrieval knob on top of a sensible base so its effect
+// is isolated:
+//   - vector-only:     dense retrieval only (baseline)
+//   - hybrid:          + BM25 lexical RRF fusion
+//   - hybrid+rerank:   + deterministic lexical reranker over the fused pool
+//   - hybrid+dedup:    + retrieval-time cross-file de-duplication (#265)
+//   - hybrid+langfilt: + per-language retrieval filter (#267 item 4)
+//   - vector+minscore: vector-only + server-side relevance floor (#305), where
+//     scores are interpretable cosine similarities
+func ablationMatrix() []knobConfig {
+	return []knobConfig{
+		{name: "vector-only", hybrid: false},
+		{name: "hybrid", hybrid: true},
+		{name: "hybrid+rerank", hybrid: true, rerank: true},
+		{name: "hybrid+dedup", hybrid: true, crossFileDD: true},
+		{name: "hybrid+langfilt", hybrid: true, useLangs: true},
+		{name: "vector+minscore", hybrid: false, minScore: 0.7},
+	}
+}
+
+// runAblation evaluates every config in the matrix over the labeled query set
+// and returns one configMetrics row per config, in matrix order.
+func runAblation(t *testing.T, corpus evalCorpus) []configMetrics {
+	t.Helper()
+	rows := make([]configMetrics, 0, len(ablationMatrix()))
+	for _, cfg := range ablationMatrix() {
+		svc := corpus.buildService(cfg)
+		perQuery := make([]RankedMetrics, 0, len(corpus.queries))
+		var totalHits int
+		for _, q := range corpus.queries {
+			retrieved, err := corpus.runQuery(svc, q, cfg, evalK)
+			if err != nil {
+				t.Fatalf("config %q query %q: %v", cfg.name, q.ID, err)
+			}
+			totalHits += len(retrieved)
+			perQuery = append(perQuery, Evaluate(retrieved, relevantSet(q.Relevant), evalK))
+		}
+		rows = append(rows, configMetrics{
+			cfg:      cfg,
+			mean:     MeanMetrics(perQuery),
+			meanHits: float64(totalHits) / float64(len(corpus.queries)),
+		})
+	}
+	return rows
+}
+
+func metricsFor(rows []configMetrics, name string) configMetrics {
+	for _, r := range rows {
+		if r.cfg.name == name {
+			return r
+		}
+	}
+	panic("config not found: " + name)
+}
+
+// TestAblationMatrix is the headline deliverable: it runs the full ablation over
+// the deterministic, creds-free fixture corpus, logs a metrics table per
+// configuration (recall@k / nDCG@k / MRR, plus mean hits), and asserts the
+// quality invariants each knob should uphold so a regression fails CI.
+func TestAblationMatrix(t *testing.T) {
+	corpus, err := loadCorpus("testdata")
+	if err != nil {
+		t.Fatalf("load fixtures: %v", err)
+	}
+	rows := runAblation(t, corpus)
+
+	t.Logf("retrieval ablation @k=%d over %d queries:", evalK, len(corpus.queries))
+	t.Logf("%-18s %8s %8s %8s %9s", "config", "recall", "nDCG", "MRR", "meanHits")
+	for _, r := range rows {
+		t.Logf("%-18s %8.4f %8.4f %8.4f %9.2f",
+			r.cfg.name, r.mean.RecallAtK, r.mean.NDCGAtK, r.mean.MRR, r.meanHits)
+	}
+
+	assertBaselineFindsEverything(t, rows)
+	assertHybridImprovesRanking(t, rows)
+	assertRerankImprovesRanking(t, rows)
+	assertDedupTrimsWithoutRecallLoss(t, rows)
+	assertLangFilterDoesNotHurtRecall(t, rows)
+	assertMinScoreTrimsWithoutRecallLoss(t, rows)
+}
+
+// assertBaselineFindsEverything: the corpus is built so every relevant doc is
+// retrievable in the top-k by the vector baseline (recall@k == 1).
+func assertBaselineFindsEverything(t *testing.T, rows []configMetrics) {
+	t.Helper()
+	base := metricsFor(rows, "vector-only")
+	if !almostEqual(base.mean.RecallAtK, 1.0) {
+		t.Fatalf("vector-only baseline must find every relevant doc in top-%d (recall=%.4f); fixtures drifted",
+			evalK, base.mean.RecallAtK)
+	}
+}
+
+// assertHybridImprovesRanking: BM25+vector RRF fusion lifts a doc the dense axis
+// ranks below an off-topic neighbor (q_photosynthesis), so hybrid's nDCG and MRR
+// strictly exceed the vector-only baseline.
+func assertHybridImprovesRanking(t *testing.T, rows []configMetrics) {
+	t.Helper()
+	base := metricsFor(rows, "vector-only")
+	hyb := metricsFor(rows, "hybrid")
+	if !(hyb.mean.MRR > base.mean.MRR) {
+		t.Fatalf("hybrid must improve MRR over vector-only: base=%.4f hybrid=%.4f", base.mean.MRR, hyb.mean.MRR)
+	}
+	if !(hyb.mean.NDCGAtK > base.mean.NDCGAtK) {
+		t.Fatalf("hybrid must improve nDCG over vector-only: base=%.4f hybrid=%.4f", base.mean.NDCGAtK, hyb.mean.NDCGAtK)
+	}
+}
+
+// assertRerankImprovesRanking: the deterministic lexical reranker is at least as
+// good as plain hybrid on ranking quality (it reorders the fused pool toward the
+// lexically-best candidate) and never regresses recall.
+func assertRerankImprovesRanking(t *testing.T, rows []configMetrics) {
+	t.Helper()
+	hyb := metricsFor(rows, "hybrid")
+	rr := metricsFor(rows, "hybrid+rerank")
+	if rr.mean.MRR < hyb.mean.MRR-eps {
+		t.Fatalf("rerank must not regress MRR vs hybrid: hybrid=%.4f rerank=%.4f", hyb.mean.MRR, rr.mean.MRR)
+	}
+	if rr.mean.RecallAtK < hyb.mean.RecallAtK-eps {
+		t.Fatalf("rerank must not regress recall vs hybrid: hybrid=%.4f rerank=%.4f", hyb.mean.RecallAtK, rr.mean.RecallAtK)
+	}
+}
+
+// assertDedupTrimsWithoutRecallLoss: cross-file dedup collapses the byte-
+// identical gardening alias, shrinking the mean hit count, while the canonical
+// relevant doc survives so recall/MRR are unchanged.
+func assertDedupTrimsWithoutRecallLoss(t *testing.T, rows []configMetrics) {
+	t.Helper()
+	hyb := metricsFor(rows, "hybrid")
+	dd := metricsFor(rows, "hybrid+dedup")
+	if !(dd.meanHits < hyb.meanHits) {
+		t.Fatalf("cross-file dedup must shrink the candidate set: hybrid=%.2f dedup=%.2f", hyb.meanHits, dd.meanHits)
+	}
+	if dd.mean.RecallAtK < hyb.mean.RecallAtK-eps {
+		t.Fatalf("cross-file dedup must not drop a canonical relevant doc: hybrid=%.4f dedup=%.4f",
+			hyb.mean.RecallAtK, dd.mean.RecallAtK)
+	}
+}
+
+// assertLangFilterDoesNotHurtRecall: the per-language filter excludes the
+// other-language gardening translations (trimming the set) but the labeled
+// relevant docs are all English, so recall is preserved.
+func assertLangFilterDoesNotHurtRecall(t *testing.T, rows []configMetrics) {
+	t.Helper()
+	hyb := metricsFor(rows, "hybrid")
+	lf := metricsFor(rows, "hybrid+langfilt")
+	if lf.mean.RecallAtK < hyb.mean.RecallAtK-eps {
+		t.Fatalf("language filter must not drop relevant in-language docs: hybrid=%.4f langfilt=%.4f",
+			hyb.mean.RecallAtK, lf.mean.RecallAtK)
+	}
+	if !(lf.meanHits <= hyb.meanHits) {
+		t.Fatalf("language filter must not grow the candidate set: hybrid=%.2f langfilt=%.2f", hyb.meanHits, lf.meanHits)
+	}
+}
+
+// assertMinScoreTrimsWithoutRecallLoss: a 0.7 relevance floor on the vector path
+// drops low-similarity noise (shrinking mean hits) while keeping every
+// high-similarity relevant doc, so recall@k stays at the baseline.
+func assertMinScoreTrimsWithoutRecallLoss(t *testing.T, rows []configMetrics) {
+	t.Helper()
+	base := metricsFor(rows, "vector-only")
+	ms := metricsFor(rows, "vector+minscore")
+	if !(ms.meanHits < base.meanHits) {
+		t.Fatalf("min_score floor must trim low-score noise: base=%.2f minscore=%.2f", base.meanHits, ms.meanHits)
+	}
+	if ms.mean.RecallAtK < base.mean.RecallAtK-eps {
+		t.Fatalf("min_score floor must not drop high-similarity relevant docs: base=%.4f minscore=%.4f",
+			base.mean.RecallAtK, ms.mean.RecallAtK)
+	}
+}

--- a/tests/eval/harness.go
+++ b/tests/eval/harness.go
@@ -315,7 +315,7 @@ type knobConfig struct {
 // or cross-file dedup is requested (both rely on optional store capabilities);
 // otherwise the store is nil so the vector-only path is exercised exactly as in
 // the existing retrieval tests.
-func (c evalCorpus) buildService(cfg knobConfig) *retrieval.Service {
+func (c evalCorpus) buildService(cfg knobConfig) (*retrieval.Service, error) {
 	idx := index.NewHNSWIndex("")
 	for _, d := range c.docs {
 		payload := model.IndexPayload{
@@ -324,9 +324,9 @@ func (c evalCorpus) buildService(cfg knobConfig) *retrieval.Service {
 			DocType:  d.DocType,
 			Language: d.Language,
 		}
-		// Upsert errors are impossible for well-formed fixtures (validated in
-		// loadCorpus); ignore to keep buildService allocation-free of *testing.T.
-		_ = idx.Upsert(context.Background(), normalizeVec(d.Vector), payload)
+		if err := idx.Upsert(context.Background(), normalizeVec(d.Vector), payload); err != nil {
+			return nil, fmt.Errorf("upsert fixture chunk %d (%s): %w", d.ChunkID, d.RelPath, err)
+		}
 	}
 
 	var store model.Store
@@ -342,9 +342,11 @@ func (c evalCorpus) buildService(cfg knobConfig) *retrieval.Service {
 	svc.SetHybridEnabled(cfg.hybrid)
 	svc.SetCrossFileDedupEnabled(cfg.crossFileDD)
 	if cfg.crossFileDD {
-		if hashes, err := newBM25Store(c.docs).ListDocumentHashes(context.Background()); err == nil {
-			svc.SetDocumentHashes(hashes)
+		hashes, err := newBM25Store(c.docs).ListDocumentHashes(context.Background())
+		if err != nil {
+			return nil, fmt.Errorf("list document hashes for dedup: %w", err)
 		}
+		svc.SetDocumentHashes(hashes)
 	}
 	svc.SetMinScore(cfg.minScore)
 	if cfg.rerank {
@@ -362,7 +364,7 @@ func (c evalCorpus) buildService(cfg knobConfig) *retrieval.Service {
 			Language: d.Language,
 		})
 	}
-	return svc
+	return svc, nil
 }
 
 // runQuery executes one labeled query against svc and returns the retrieved

--- a/tests/eval/harness.go
+++ b/tests/eval/harness.go
@@ -169,9 +169,9 @@ func newBM25Store(docs []evalDoc) *bm25Store {
 	return &bm25Store{docs: append([]evalDoc(nil), docs...)}
 }
 
-func (s *bm25Store) Init(context.Context) error                            { return nil }
-func (s *bm25Store) UpsertDocument(context.Context, model.Document) error  { return nil }
-func (s *bm25Store) Close() error                                          { return nil }
+func (s *bm25Store) Init(context.Context) error                           { return nil }
+func (s *bm25Store) UpsertDocument(context.Context, model.Document) error { return nil }
+func (s *bm25Store) Close() error                                         { return nil }
 func (s *bm25Store) GetDocumentByPath(context.Context, string) (model.Document, error) {
 	return model.Document{}, model.ErrNotImplemented
 }
@@ -238,7 +238,7 @@ func (s *bm25Store) SearchBM25(_ context.Context, query string, k int, _ string)
 
 func tokenize(s string) []string {
 	fields := strings.FieldsFunc(strings.ToLower(s), func(r rune) bool {
-		return !(r >= 'a' && r <= 'z') && !(r >= '0' && r <= '9')
+		return (r < 'a' || r > 'z') && (r < '0' || r > '9')
 	})
 	return fields
 }

--- a/tests/eval/harness.go
+++ b/tests/eval/harness.go
@@ -1,0 +1,393 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
+)
+
+// evalDoc is one labeled corpus document loaded from testdata/corpus.json.
+type evalDoc struct {
+	ChunkID     uint64    `json:"chunk_id"`
+	RelPath     string    `json:"rel_path"`
+	DocType     string    `json:"doc_type"`
+	Language    string    `json:"language"`
+	ContentHash string    `json:"content_hash"`
+	Vector      []float32 `json:"vector"`
+	Text        string    `json:"text"`
+}
+
+// evalQuery is one labeled query loaded from testdata/queries.json.
+type evalQuery struct {
+	ID        string    `json:"id"`
+	Text      string    `json:"text"`
+	Vector    []float32 `json:"vector"`
+	Languages []string  `json:"languages"`
+	Relevant  []string  `json:"relevant"`
+}
+
+type corpusFile struct {
+	Documents []evalDoc `json:"documents"`
+}
+
+type queriesFile struct {
+	Queries []evalQuery `json:"queries"`
+}
+
+// evalCorpus is the loaded, validated fixture: documents plus the query set.
+type evalCorpus struct {
+	docs    []evalDoc
+	queries []evalQuery
+}
+
+// loadCorpus reads and validates the labeled fixture corpus + query set from
+// the given testdata directory. It fails fast on malformed fixtures (duplicate
+// or zero chunk ids, mismatched vector dimensions, queries referencing unknown
+// rel_paths) so a broken fixture surfaces as a clear test failure rather than
+// silently skewing metrics.
+func loadCorpus(dir string) (evalCorpus, error) {
+	var corpus corpusFile
+	if err := readJSON(filepath.Join(dir, "corpus.json"), &corpus); err != nil {
+		return evalCorpus{}, err
+	}
+	var queries queriesFile
+	if err := readJSON(filepath.Join(dir, "queries.json"), &queries); err != nil {
+		return evalCorpus{}, err
+	}
+	if err := validateCorpus(corpus.Documents, queries.Queries); err != nil {
+		return evalCorpus{}, err
+	}
+	return evalCorpus{docs: corpus.Documents, queries: queries.Queries}, nil
+}
+
+func readJSON(path string, dst any) error {
+	data, err := os.ReadFile(path) //nolint:gosec // fixture path is test-controlled
+	if err != nil {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+	if err := json.Unmarshal(data, dst); err != nil {
+		return fmt.Errorf("parse %s: %w", path, err)
+	}
+	return nil
+}
+
+func validateCorpus(docs []evalDoc, queries []evalQuery) error {
+	if len(docs) == 0 {
+		return fmt.Errorf("corpus has no documents")
+	}
+	if len(queries) == 0 {
+		return fmt.Errorf("query set is empty")
+	}
+	dim := len(docs[0].Vector)
+	if dim == 0 {
+		return fmt.Errorf("document %q has an empty vector", docs[0].RelPath)
+	}
+	seenID := make(map[uint64]struct{}, len(docs))
+	relPaths := make(map[string]struct{}, len(docs))
+	for _, d := range docs {
+		if d.ChunkID == 0 {
+			return fmt.Errorf("document %q has chunk_id 0 (must be > 0)", d.RelPath)
+		}
+		if _, dup := seenID[d.ChunkID]; dup {
+			return fmt.Errorf("duplicate chunk_id %d", d.ChunkID)
+		}
+		seenID[d.ChunkID] = struct{}{}
+		if len(d.Vector) != dim {
+			return fmt.Errorf("document %q vector dim %d != %d", d.RelPath, len(d.Vector), dim)
+		}
+		relPaths[d.RelPath] = struct{}{}
+	}
+	for _, q := range queries {
+		if len(q.Vector) != dim {
+			return fmt.Errorf("query %q vector dim %d != %d", q.ID, len(q.Vector), dim)
+		}
+		if len(q.Relevant) == 0 {
+			return fmt.Errorf("query %q has no relevant documents", q.ID)
+		}
+		for _, rp := range q.Relevant {
+			if _, ok := relPaths[rp]; !ok {
+				return fmt.Errorf("query %q references unknown rel_path %q", q.ID, rp)
+			}
+		}
+	}
+	return nil
+}
+
+// dictEmbedder is a deterministic, creds-free embedder for the eval harness. It
+// returns the pre-registered vector for an exact query text, so retrieval is
+// fully reproducible in CI with no provider calls. Unknown texts fall back to a
+// zero-ish unit vector (which simply ranks nothing strongly) rather than
+// erroring, keeping the harness robust to typos in fixtures.
+type dictEmbedder struct {
+	byText map[string][]float32
+	dim    int
+}
+
+func newDictEmbedder(queries []evalQuery, dim int) *dictEmbedder {
+	m := make(map[string][]float32, len(queries))
+	for _, q := range queries {
+		m[q.Text] = normalizeVec(q.Vector)
+	}
+	return &dictEmbedder{byText: m, dim: dim}
+}
+
+func (e *dictEmbedder) Embed(_ context.Context, _ string, _ model.EmbedRole, texts []string) ([][]float32, error) {
+	out := make([][]float32, len(texts))
+	for i, t := range texts {
+		if v, ok := e.byText[t]; ok {
+			out[i] = append([]float32(nil), v...)
+			continue
+		}
+		fallback := make([]float32, e.dim)
+		if e.dim > 0 {
+			fallback[0] = 1
+		}
+		out[i] = fallback
+	}
+	return out, nil
+}
+
+// bm25Store is an in-memory model.Store that also implements LexicalSearcher
+// (so the hybrid knob actually engages without sqlite/FTS5 or any creds) and
+// DocumentHashLister (so cross-file dedup can group byte-identical aliases). Its
+// BM25 is a deterministic term-overlap scorer: enough to make the lexical axis
+// rank a document the dense axis ranks lower, exercising RRF fusion.
+type bm25Store struct {
+	docs []evalDoc
+}
+
+func newBM25Store(docs []evalDoc) *bm25Store {
+	return &bm25Store{docs: append([]evalDoc(nil), docs...)}
+}
+
+func (s *bm25Store) Init(context.Context) error                            { return nil }
+func (s *bm25Store) UpsertDocument(context.Context, model.Document) error  { return nil }
+func (s *bm25Store) Close() error                                          { return nil }
+func (s *bm25Store) GetDocumentByPath(context.Context, string) (model.Document, error) {
+	return model.Document{}, model.ErrNotImplemented
+}
+
+func (s *bm25Store) ListFiles(_ context.Context, _, _ string, _, _ int) ([]model.Document, int64, error) {
+	return nil, 0, nil
+}
+
+// ListDocumentHashes feeds retrieval-time cross-file dedup (SPEC §9.2).
+func (s *bm25Store) ListDocumentHashes(context.Context) ([]model.DocumentHash, error) {
+	out := make([]model.DocumentHash, 0, len(s.docs))
+	for _, d := range s.docs {
+		out = append(out, model.DocumentHash{RelPath: d.RelPath, ContentHash: d.ContentHash})
+	}
+	return out, nil
+}
+
+// SearchBM25 ranks documents by term-overlap count with the query, breaking
+// ties by chunk_id, and returns the top k. Higher score is better, matching the
+// production sqlite adapter's negated-bm25 convention.
+func (s *bm25Store) SearchBM25(_ context.Context, query string, k int, _ string) ([]model.SearchHit, error) {
+	qterms := tokenize(query)
+	if len(qterms) == 0 {
+		return nil, nil
+	}
+	type scored struct {
+		hit   model.SearchHit
+		score float64
+	}
+	ranked := make([]scored, 0, len(s.docs))
+	for _, d := range s.docs {
+		overlap := termOverlap(qterms, tokenize(d.Text))
+		if overlap == 0 {
+			continue
+		}
+		ranked = append(ranked, scored{
+			hit: model.SearchHit{
+				ChunkID:  d.ChunkID,
+				RelPath:  d.RelPath,
+				DocType:  d.DocType,
+				Snippet:  d.Text,
+				Span:     model.Span{Kind: "lines"},
+				Language: d.Language,
+				Score:    float64(overlap),
+			},
+			score: float64(overlap),
+		})
+	}
+	sort.SliceStable(ranked, func(i, j int) bool {
+		if ranked[i].score != ranked[j].score {
+			return ranked[i].score > ranked[j].score
+		}
+		return ranked[i].hit.ChunkID < ranked[j].hit.ChunkID
+	})
+	if k > 0 && len(ranked) > k {
+		ranked = ranked[:k]
+	}
+	out := make([]model.SearchHit, len(ranked))
+	for i, r := range ranked {
+		out[i] = r.hit
+	}
+	return out, nil
+}
+
+func tokenize(s string) []string {
+	fields := strings.FieldsFunc(strings.ToLower(s), func(r rune) bool {
+		return !(r >= 'a' && r <= 'z') && !(r >= '0' && r <= '9')
+	})
+	return fields
+}
+
+func termOverlap(a, b []string) int {
+	set := make(map[string]struct{}, len(b))
+	for _, t := range b {
+		set[t] = struct{}{}
+	}
+	seen := make(map[string]struct{}, len(a))
+	count := 0
+	for _, t := range a {
+		if _, dup := seen[t]; dup {
+			continue
+		}
+		seen[t] = struct{}{}
+		if _, ok := set[t]; ok {
+			count++
+		}
+	}
+	return count
+}
+
+func normalizeVec(v []float32) []float32 {
+	var sum float64
+	for _, x := range v {
+		sum += float64(x) * float64(x)
+	}
+	if sum == 0 {
+		return append([]float32(nil), v...)
+	}
+	norm := math.Sqrt(sum)
+	out := make([]float32, len(v))
+	for i, x := range v {
+		out[i] = float32(float64(x) / norm)
+	}
+	return out
+}
+
+// lexicalReranker is a deterministic, creds-free model.Reranker for the eval
+// harness. It rescores each candidate snippet by term overlap with the query
+// (the same signal the in-memory BM25 store uses), so the rerank knob is
+// genuinely exercised — and reproducibly — without any provider call. Ties keep
+// the incoming order via a stable sort, and the result is best-first.
+type lexicalReranker struct{}
+
+func (lexicalReranker) Rerank(_ context.Context, _, query string, documents []string, topN int) ([]model.Reranked, error) {
+	qterms := tokenize(query)
+	scored := make([]model.Reranked, len(documents))
+	for i, d := range documents {
+		scored[i] = model.Reranked{Index: i, RelevanceScore: float64(termOverlap(qterms, tokenize(d)))}
+	}
+	sort.SliceStable(scored, func(i, j int) bool {
+		return scored[i].RelevanceScore > scored[j].RelevanceScore
+	})
+	if topN > 0 && len(scored) > topN {
+		scored = scored[:topN]
+	}
+	return scored, nil
+}
+
+// knobConfig names which retrieval knobs an ablation row enables.
+type knobConfig struct {
+	name        string
+	hybrid      bool
+	rerank      bool
+	crossFileDD bool
+	minScore    float64 // 0 disables the floor
+	useLangs    bool    // pass each query's languages filter through to Search
+}
+
+// buildService constructs a retrieval.Service over the loaded corpus with the
+// knobs of cfg applied. The store is the in-memory BM25 store only when hybrid
+// or cross-file dedup is requested (both rely on optional store capabilities);
+// otherwise the store is nil so the vector-only path is exercised exactly as in
+// the existing retrieval tests.
+func (c evalCorpus) buildService(cfg knobConfig) *retrieval.Service {
+	idx := index.NewHNSWIndex("")
+	for _, d := range c.docs {
+		payload := model.IndexPayload{
+			ChunkID:  d.ChunkID,
+			RelPath:  d.RelPath,
+			DocType:  d.DocType,
+			Language: d.Language,
+		}
+		// Upsert errors are impossible for well-formed fixtures (validated in
+		// loadCorpus); ignore to keep buildService allocation-free of *testing.T.
+		_ = idx.Upsert(context.Background(), normalizeVec(d.Vector), payload)
+	}
+
+	var store model.Store
+	if cfg.hybrid || cfg.crossFileDD {
+		store = newBM25Store(c.docs)
+	}
+
+	dim := len(c.docs[0].Vector)
+	svc := retrieval.NewService(store, idx, newDictEmbedder(c.queries, dim), nil)
+
+	// hybridEnabled defaults to true in NewService; pin it explicitly both ways
+	// so the vector-only rows truly bypass RRF fusion.
+	svc.SetHybridEnabled(cfg.hybrid)
+	svc.SetCrossFileDedupEnabled(cfg.crossFileDD)
+	if cfg.crossFileDD {
+		if hashes, err := newBM25Store(c.docs).ListDocumentHashes(context.Background()); err == nil {
+			svc.SetDocumentHashes(hashes)
+		}
+	}
+	svc.SetMinScore(cfg.minScore)
+	if cfg.rerank {
+		svc.SetReranker(lexicalReranker{}, "eval-lexical", 0)
+		svc.SetRerankEnabled(true)
+	}
+
+	for _, d := range c.docs {
+		svc.SetChunkMetadata(d.ChunkID, model.SearchHit{
+			ChunkID:  d.ChunkID,
+			RelPath:  d.RelPath,
+			DocType:  d.DocType,
+			Snippet:  d.Text,
+			Span:     model.Span{Kind: "lines", StartLine: 1, EndLine: 1},
+			Language: d.Language,
+		})
+	}
+	return svc
+}
+
+// runQuery executes one labeled query against svc and returns the retrieved
+// rel_paths in rank order (deduplicated, preserving first occurrence) for
+// metric computation.
+func (c evalCorpus) runQuery(svc *retrieval.Service, q evalQuery, cfg knobConfig, k int) ([]string, error) {
+	sq := model.SearchQuery{Query: q.Text, K: k}
+	if cfg.useLangs && len(q.Languages) > 0 {
+		sq.Languages = append([]string(nil), q.Languages...)
+	}
+	hits, err := svc.Search(context.Background(), sq)
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[string]struct{}, len(hits))
+	out := make([]string, 0, len(hits))
+	for _, h := range hits {
+		if h.RelPath == "" {
+			continue
+		}
+		if _, dup := seen[h.RelPath]; dup {
+			continue
+		}
+		seen[h.RelPath] = struct{}{}
+		out = append(out, h.RelPath)
+	}
+	return out, nil
+}

--- a/tests/eval/metrics.go
+++ b/tests/eval/metrics.go
@@ -1,0 +1,155 @@
+// Package tests holds the offline retrieval-quality eval + ablation harness
+// (issue #322). It is an EXTERNAL test package (package name "tests", import
+// path tests/eval) so it exercises only the public retrieval.Service surface.
+//
+// This file defines the pure ranking-quality metrics — recall@k, nDCG@k, and
+// MRR — used by the ablation runner. They take a ranked list of retrieved
+// document keys and the set of relevant keys for a query, and are deliberately
+// free of any dir2mcp types so they can be unit-tested in isolation and reused
+// for any ranked-retrieval evaluation.
+package tests
+
+import (
+	"math"
+	"sort"
+)
+
+// RankedMetrics bundles the per-query ranking-quality scores computed over one
+// retrieved list at a given cutoff k.
+type RankedMetrics struct {
+	RecallAtK float64 // fraction of relevant items present in the top-k
+	NDCGAtK   float64 // normalized discounted cumulative gain over the top-k
+	MRR       float64 // reciprocal rank of the first relevant item (any depth)
+}
+
+// RecallAtK returns the fraction of the relevant set that appears within the
+// first k retrieved keys. It is 0 when there are no relevant items (an
+// undefined ratio is reported as 0 so it can be averaged) and clamps k to the
+// length of retrieved. Duplicate retrieved keys are counted once.
+func RecallAtK(retrieved []string, relevant map[string]struct{}, k int) float64 {
+	if len(relevant) == 0 {
+		return 0
+	}
+	if k < 0 {
+		k = 0
+	}
+	if k > len(retrieved) {
+		k = len(retrieved)
+	}
+	found := make(map[string]struct{}, k)
+	for i := 0; i < k; i++ {
+		key := retrieved[i]
+		if _, ok := relevant[key]; ok {
+			found[key] = struct{}{}
+		}
+	}
+	return float64(len(found)) / float64(len(relevant))
+}
+
+// MRR returns the reciprocal rank of the first relevant retrieved key (1-based
+// rank), or 0 when no relevant key is retrieved at any depth. The full
+// retrieved list is considered (no cutoff), matching the standard MRR
+// definition.
+func MRR(retrieved []string, relevant map[string]struct{}) float64 {
+	if len(relevant) == 0 {
+		return 0
+	}
+	for i, key := range retrieved {
+		if _, ok := relevant[key]; ok {
+			return 1.0 / float64(i+1)
+		}
+	}
+	return 0
+}
+
+// NDCGAtK returns the normalized discounted cumulative gain over the first k
+// retrieved keys, using binary relevance (gain 1 for a relevant key, 0
+// otherwise) and the standard log2(rank+1) discount. The ideal DCG normalizer
+// is computed from min(len(relevant), k) perfectly-ranked relevant items, so a
+// perfect ranking scores 1.0 even when there are more relevant items than k.
+// Returns 0 when there are no relevant items. Duplicate relevant keys already
+// credited earlier in the list are not double-counted.
+func NDCGAtK(retrieved []string, relevant map[string]struct{}, k int) float64 {
+	if len(relevant) == 0 {
+		return 0
+	}
+	if k < 0 {
+		k = 0
+	}
+	if k > len(retrieved) {
+		k = len(retrieved)
+	}
+	credited := make(map[string]struct{}, k)
+	dcg := 0.0
+	for i := 0; i < k; i++ {
+		key := retrieved[i]
+		if _, ok := relevant[key]; !ok {
+			continue
+		}
+		if _, dup := credited[key]; dup {
+			continue
+		}
+		credited[key] = struct{}{}
+		dcg += 1.0 / math.Log2(float64(i+2)) // rank is i+1, discount log2(rank+1)
+	}
+	idealHits := len(relevant)
+	if idealHits > k {
+		idealHits = k
+	}
+	idcg := 0.0
+	for i := 0; i < idealHits; i++ {
+		idcg += 1.0 / math.Log2(float64(i+2))
+	}
+	if idcg == 0 {
+		return 0
+	}
+	return dcg / idcg
+}
+
+// Evaluate computes all three ranking metrics for one retrieved list at cutoff
+// k against the relevant set.
+func Evaluate(retrieved []string, relevant map[string]struct{}, k int) RankedMetrics {
+	return RankedMetrics{
+		RecallAtK: RecallAtK(retrieved, relevant, k),
+		NDCGAtK:   NDCGAtK(retrieved, relevant, k),
+		MRR:       MRR(retrieved, relevant),
+	}
+}
+
+// MeanMetrics averages a slice of per-query RankedMetrics into a single macro
+// average (each query weighted equally). An empty input yields a zero value.
+func MeanMetrics(perQuery []RankedMetrics) RankedMetrics {
+	n := len(perQuery)
+	if n == 0 {
+		return RankedMetrics{}
+	}
+	var sum RankedMetrics
+	for _, m := range perQuery {
+		sum.RecallAtK += m.RecallAtK
+		sum.NDCGAtK += m.NDCGAtK
+		sum.MRR += m.MRR
+	}
+	div := float64(n)
+	return RankedMetrics{
+		RecallAtK: sum.RecallAtK / div,
+		NDCGAtK:   sum.NDCGAtK / div,
+		MRR:       sum.MRR / div,
+	}
+}
+
+// relevantSet builds a set from a slice of relevant keys, dropping empties.
+// Exposed via the harness for fixture loading; kept here next to the metrics it
+// feeds. Sorting the input first keeps construction deterministic for callers
+// that range over the result.
+func relevantSet(keys []string) map[string]struct{} {
+	sorted := append([]string(nil), keys...)
+	sort.Strings(sorted)
+	set := make(map[string]struct{}, len(sorted))
+	for _, k := range sorted {
+		if k == "" {
+			continue
+		}
+		set[k] = struct{}{}
+	}
+	return set
+}

--- a/tests/eval/metrics_test.go
+++ b/tests/eval/metrics_test.go
@@ -1,0 +1,128 @@
+package tests
+
+import (
+	"math"
+	"testing"
+)
+
+const eps = 1e-9
+
+func almostEqual(a, b float64) bool { return math.Abs(a-b) <= eps }
+
+func TestRecallAtK(t *testing.T) {
+	rel := relevantSet([]string{"a", "b", "c", "d"})
+	cases := []struct {
+		name      string
+		retrieved []string
+		k         int
+		want      float64
+	}{
+		{"all-in-top-k", []string{"a", "b", "c", "d"}, 4, 1.0},
+		{"half-in-top-k", []string{"a", "x", "b", "y"}, 4, 0.5},
+		{"cutoff-limits", []string{"a", "b", "c", "d"}, 2, 0.5},
+		{"none-relevant", []string{"x", "y", "z"}, 3, 0.0},
+		{"k-exceeds-len", []string{"a", "b"}, 99, 0.5},
+		{"dup-counted-once", []string{"a", "a", "b"}, 3, 0.5},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := RecallAtK(c.retrieved, rel, c.k)
+			if !almostEqual(got, c.want) {
+				t.Fatalf("RecallAtK=%v want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestRecallAtK_NoRelevantIsZero(t *testing.T) {
+	if got := RecallAtK([]string{"a"}, map[string]struct{}{}, 1); got != 0 {
+		t.Fatalf("empty relevant set must yield 0, got %v", got)
+	}
+}
+
+func TestMRR(t *testing.T) {
+	rel := relevantSet([]string{"a", "b"})
+	cases := []struct {
+		name      string
+		retrieved []string
+		want      float64
+	}{
+		{"first-position", []string{"a", "x", "y"}, 1.0},
+		{"second-position", []string{"x", "a", "y"}, 0.5},
+		{"third-position", []string{"x", "y", "b"}, 1.0 / 3.0},
+		{"none-found", []string{"x", "y", "z"}, 0.0},
+		{"first-relevant-wins", []string{"x", "b", "a"}, 0.5},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := MRR(c.retrieved, rel)
+			if !almostEqual(got, c.want) {
+				t.Fatalf("MRR=%v want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestNDCGAtK_PerfectRankingIsOne(t *testing.T) {
+	rel := relevantSet([]string{"a", "b", "c"})
+	got := NDCGAtK([]string{"a", "b", "c", "x"}, rel, 4)
+	if !almostEqual(got, 1.0) {
+		t.Fatalf("perfect ranking nDCG must be 1.0, got %v", got)
+	}
+}
+
+func TestNDCGAtK_OrderMatters(t *testing.T) {
+	rel := relevantSet([]string{"a"})
+	// Single relevant item: rank 1 -> 1.0; rank 2 -> 1/log2(3); rank 3 -> 1/log2(4)=0.5.
+	top := NDCGAtK([]string{"a", "x", "y"}, rel, 3)
+	mid := NDCGAtK([]string{"x", "a", "y"}, rel, 3)
+	low := NDCGAtK([]string{"x", "y", "a"}, rel, 3)
+	if !(top > mid && mid > low) {
+		t.Fatalf("nDCG must decrease as the relevant item sinks: top=%v mid=%v low=%v", top, mid, low)
+	}
+	if !almostEqual(top, 1.0) {
+		t.Fatalf("rank-1 single relevant must be 1.0, got %v", top)
+	}
+	if !almostEqual(low, 0.5) {
+		t.Fatalf("rank-3 single relevant must be 0.5, got %v", low)
+	}
+}
+
+func TestNDCGAtK_IdealNormalizerCappedAtK(t *testing.T) {
+	// 4 relevant items but k=2: a perfect top-2 must still score 1.0 because the
+	// ideal DCG is computed over min(len(relevant), k) items.
+	rel := relevantSet([]string{"a", "b", "c", "d"})
+	got := NDCGAtK([]string{"a", "b", "x", "y"}, rel, 2)
+	if !almostEqual(got, 1.0) {
+		t.Fatalf("perfect top-k with more relevant than k must be 1.0, got %v", got)
+	}
+}
+
+func TestNDCGAtK_NoRelevantIsZero(t *testing.T) {
+	if got := NDCGAtK([]string{"a"}, map[string]struct{}{}, 1); got != 0 {
+		t.Fatalf("empty relevant set must yield 0, got %v", got)
+	}
+}
+
+func TestNDCGAtK_DuplicateNotDoubleCounted(t *testing.T) {
+	rel := relevantSet([]string{"a"})
+	// "a" appears twice; only the first credit should count, so this equals the
+	// single-occurrence rank-1 score of 1.0.
+	got := NDCGAtK([]string{"a", "a"}, rel, 2)
+	if !almostEqual(got, 1.0) {
+		t.Fatalf("duplicate relevant must not exceed 1.0, got %v", got)
+	}
+}
+
+func TestMeanMetrics(t *testing.T) {
+	got := MeanMetrics([]RankedMetrics{
+		{RecallAtK: 1.0, NDCGAtK: 1.0, MRR: 1.0},
+		{RecallAtK: 0.0, NDCGAtK: 0.0, MRR: 0.0},
+	})
+	if !almostEqual(got.RecallAtK, 0.5) || !almostEqual(got.NDCGAtK, 0.5) || !almostEqual(got.MRR, 0.5) {
+		t.Fatalf("mean of {1,0} must be 0.5 across metrics, got %+v", got)
+	}
+	if zero := MeanMetrics(nil); zero != (RankedMetrics{}) {
+		t.Fatalf("mean of empty must be zero value, got %+v", zero)
+	}
+}

--- a/tests/eval/probe_test.go
+++ b/tests/eval/probe_test.go
@@ -1,0 +1,80 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// TestFixturesLoadAndValidate pins that the shipped testdata corpus + query set
+// parse and pass the harness's structural validation (unique non-zero chunk
+// ids, matching vector dimensions, queries referencing only known rel_paths).
+// A broken fixture fails here with a precise message rather than silently
+// skewing the ablation metrics.
+func TestFixturesLoadAndValidate(t *testing.T) {
+	corpus, err := loadCorpus("testdata")
+	if err != nil {
+		t.Fatalf("fixtures failed to load/validate: %v", err)
+	}
+	if len(corpus.docs) == 0 || len(corpus.queries) == 0 {
+		t.Fatalf("fixtures empty: docs=%d queries=%d", len(corpus.docs), len(corpus.queries))
+	}
+}
+
+// TestDictEmbedderIsDeterministic pins the creds-free embedder contract: the
+// same query text always yields the same vector, and an unknown text yields a
+// stable fallback (so a fixture typo degrades gracefully instead of panicking).
+func TestDictEmbedderIsDeterministic(t *testing.T) {
+	corpus, err := loadCorpus("testdata")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	emb := newDictEmbedder(corpus.queries, len(corpus.docs[0].Vector))
+	q := corpus.queries[0].Text
+	a, err := emb.Embed(context.Background(), "any-model", model.EmbedQuery, []string{q, q})
+	if err != nil {
+		t.Fatalf("embed: %v", err)
+	}
+	if len(a) != 2 {
+		t.Fatalf("expected one vector per text, got %d", len(a))
+	}
+	for i := range a[0] {
+		if a[0][i] != a[1][i] {
+			t.Fatalf("embedder is non-deterministic at dim %d: %v vs %v", i, a[0], a[1])
+		}
+	}
+	unknown, err := emb.Embed(context.Background(), "m", model.EmbedQuery, []string{"no such query text"})
+	if err != nil {
+		t.Fatalf("embed unknown: %v", err)
+	}
+	if len(unknown) != 1 || len(unknown[0]) != len(corpus.docs[0].Vector) {
+		t.Fatalf("unknown-text fallback must be a dim-correct vector, got %v", unknown)
+	}
+}
+
+// TestBM25StoreRanksByOverlap pins the in-memory lexical store used to engage
+// the hybrid knob without sqlite/FTS5: it ranks by query/document term overlap,
+// best-first, and skips zero-overlap documents.
+func TestBM25StoreRanksByOverlap(t *testing.T) {
+	corpus, err := loadCorpus("testdata")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	store := newBM25Store(corpus.docs)
+	hits, err := store.SearchBM25(context.Background(), "plants convert sunlight into energy through photosynthesis", 10, "")
+	if err != nil {
+		t.Fatalf("SearchBM25: %v", err)
+	}
+	if len(hits) == 0 {
+		t.Fatal("expected BM25 hits for a lexically-matching query")
+	}
+	if hits[0].RelPath != "misc/photosynthesis.md" {
+		t.Fatalf("expected photosynthesis doc to rank first lexically, got %q", hits[0].RelPath)
+	}
+	for i := 1; i < len(hits); i++ {
+		if hits[i].Score > hits[i-1].Score {
+			t.Fatalf("BM25 hits not sorted best-first at %d: %v", i, hits)
+		}
+	}
+}

--- a/tests/eval/testdata/corpus.json
+++ b/tests/eval/testdata/corpus.json
@@ -1,0 +1,77 @@
+{
+  "_comment": "General-purpose labeled eval corpus for the retrieval ablation harness (issue #322). Each document carries a deterministic 4-D embedding `vector` (the harness L2-normalizes it before indexing), the lexical `text` used by the in-memory BM25 store, an optional BCP-47 `language`, and a `content_hash` used by cross-file dedup. No broadcaster/domain-specific data. chunk_id must be unique and > 0. Vectors are hand-chosen so individual knobs measurably move the metrics (see queries.json).",
+  "documents": [
+    {
+      "chunk_id": 1,
+      "rel_path": "guides/gardening.md",
+      "doc_type": "md",
+      "language": "en",
+      "content_hash": "H_GARDEN",
+      "vector": [1.0, 0.0, 0.0, 0.0],
+      "text": "How to grow tomatoes and water plants in a home vegetable garden."
+    },
+    {
+      "chunk_id": 2,
+      "rel_path": "guides/gardening-copy.md",
+      "doc_type": "md",
+      "language": "en",
+      "content_hash": "H_GARDEN",
+      "vector": [0.999, 0.045, 0.0, 0.0],
+      "text": "How to grow tomatoes and water plants in a home vegetable garden."
+    },
+    {
+      "chunk_id": 3,
+      "rel_path": "guides/cooking.md",
+      "doc_type": "md",
+      "language": "en",
+      "content_hash": "H_COOK",
+      "vector": [0.0, 1.0, 0.0, 0.0],
+      "text": "A recipe for roasting tomatoes with olive oil and herbs in the oven."
+    },
+    {
+      "chunk_id": 4,
+      "rel_path": "notes/astronomy.md",
+      "doc_type": "md",
+      "language": "en",
+      "content_hash": "H_ASTRO",
+      "vector": [0.0, 0.0, 1.0, 0.0],
+      "text": "Observing planets and stars through a backyard telescope at night."
+    },
+    {
+      "chunk_id": 5,
+      "rel_path": "notes/finance.md",
+      "doc_type": "md",
+      "language": "en",
+      "content_hash": "H_FIN",
+      "vector": [0.5, 0.5, 0.5, 0.0],
+      "text": "Budgeting tips and how to track monthly household spending."
+    },
+    {
+      "chunk_id": 6,
+      "rel_path": "i18n/jardin.md",
+      "doc_type": "md",
+      "language": "es",
+      "content_hash": "H_JARDIN",
+      "vector": [0.9, 0.0, 0.0, 0.44],
+      "text": "Como cultivar tomates y regar las plantas en un huerto casero."
+    },
+    {
+      "chunk_id": 7,
+      "rel_path": "i18n/jardim.md",
+      "doc_type": "md",
+      "language": "pt-BR",
+      "content_hash": "H_JARDIM",
+      "vector": [0.88, 0.0, 0.0, 0.47],
+      "text": "Como cultivar tomates e regar as plantas em uma horta caseira."
+    },
+    {
+      "chunk_id": 8,
+      "rel_path": "misc/photosynthesis.md",
+      "doc_type": "md",
+      "language": "en",
+      "content_hash": "H_PHOTO",
+      "vector": [0.4, 0.55, 0.0, 0.0],
+      "text": "Plants convert sunlight into energy through the process of photosynthesis."
+    }
+  ]
+}

--- a/tests/eval/testdata/queries.json
+++ b/tests/eval/testdata/queries.json
@@ -1,0 +1,30 @@
+{
+  "_comment": "Labeled query set for the retrieval ablation harness (issue #322). `vector` is the deterministic query embedding the fake embedder returns for this query's text (harness L2-normalizes it); `text` drives the in-memory BM25 store. `relevant` lists the canonical rel_paths that should be retrieved (a byte-identical alias is intentionally NOT labeled relevant, so cross-file dedup trims it without hurting recall). `languages` (optional) is passed as the per-language retrieval filter. Designed so individual knobs move the metrics: q_photosynthesis ranks its target mid on the dense axis but top on the lexical axis (hybrid lift); q_gardening_en_only exercises the language filter; the gardening alias exercises cross-file dedup.",
+  "queries": [
+    {
+      "id": "q_gardening",
+      "text": "how to grow tomatoes and water plants in a garden",
+      "vector": [1.0, 0.0, 0.0, 0.0],
+      "relevant": ["guides/gardening.md"]
+    },
+    {
+      "id": "q_gardening_en_only",
+      "text": "how to grow tomatoes and water plants in a garden",
+      "vector": [1.0, 0.0, 0.0, 0.0],
+      "languages": ["en"],
+      "relevant": ["guides/gardening.md"]
+    },
+    {
+      "id": "q_photosynthesis",
+      "text": "plants convert sunlight into energy through photosynthesis",
+      "vector": [0.5, 0.5, 0.5, 0.0],
+      "relevant": ["misc/photosynthesis.md"]
+    },
+    {
+      "id": "q_telescope",
+      "text": "observing planets and stars through a telescope at night",
+      "vector": [0.0, 0.0, 1.0, 0.0],
+      "relevant": ["notes/astronomy.md"]
+    }
+  ]
+}


### PR DESCRIPTION
## What

Adds an **offline, deterministic, creds-free** retrieval-quality eval + ablation harness under `tests/eval`, so the growing set of retrieval knobs (hybrid RRF, rerank, cross-file dedup #265, per-language filter #267, `min_score` floor #305) can be measured and regressions caught in CI.

Internal tooling only — **no MCP tool/spec contract change, no submodule re-pin**. It exercises only the public `retrieval.Service` surface, reusing the existing fake-embedder / in-memory-index test pattern.

Closes #322.

## Pieces

- **Metrics** (`tests/eval/metrics.go`, pure + type-free): `RecallAtK`, `NDCGAtK` (binary relevance, log2 discount, ideal-DCG capped at k), `MRR`, plus `MeanMetrics` macro averaging. Unit-tested in `metrics_test.go`.
- **Labeled fixture corpus** (`tests/eval/testdata/corpus.json` + `queries.json`): 8 general-purpose docs (gardening/cooking/astronomy/finance/photosynthesis + es/pt translations + a byte-identical gardening alias) and 4 labeled queries. Each doc/query carries a deterministic embedding vector and lexical text; relevance is by canonical `rel_path`. No broadcaster/domain data.
- **Harness** (`tests/eval/harness.go`): a dictionary embedder (query text → fixed vector, no provider calls), an in-memory `model.Store` that also implements `LexicalSearcher` (term-overlap BM25, so the hybrid knob truly engages without sqlite/FTS5) and `DocumentHashLister` (for cross-file dedup), a deterministic lexical reranker, fixture loader+validator, and a per-config `Service` builder.
- **Ablation runner** (`tests/eval/ablation_test.go`): builds the matrix `{vector-only, hybrid, hybrid+rerank, hybrid+dedup, hybrid+langfilt, vector+minscore}`, runs the query set, logs a metrics table, and asserts each knob's invariant.

## Sample output (`go test ./tests/eval -run TestAblationMatrix -v`)

```
config               recall     nDCG      MRR  meanHits
vector-only          1.0000   0.9077   0.8750      5.00
hybrid               1.0000   1.0000   1.0000      5.00
hybrid+rerank        1.0000   1.0000   1.0000      5.00
hybrid+dedup         1.0000   1.0000   1.0000      4.00
hybrid+langfilt      1.0000   1.0000   1.0000      5.00
vector+minscore      1.0000   0.9077   0.8750      2.75
```

Hybrid (and rerank) lift the photosynthesis target from rank 2 → 1 (nDCG/MRR 0.91/0.88 → 1.0); cross-file dedup and the `min_score` floor trim the candidate set (meanHits 5.00 → 4.00 / 2.75) **without** dropping any relevant doc (recall stays 1.0). A future live-provider eval can be added behind `RUN_INTEGRATION_TESTS=1`.

## Determinism / no creds

Embeddings come from a fixed query→vector dictionary; BM25 is in-memory term overlap; the reranker is deterministic term overlap. No network, no API keys, no sqlite/FTS5 — runs identically in CI.

## Checks

- `make check` green (gofmt, vet, golangci-lint/staticcheck, gocyclo ≤15, ineffassign, misspell, full test suite, build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end retrieval evaluation harness that loads labeled fixture data, runs retrieval experiments, and validates fixture integrity with deterministic embedding and lexical retrieval.
  * Implemented offline ranking-quality metrics (Recall@K, MRR, NDCG@K) with thorough edge-case coverage.
  * Added harness probe tests to confirm deterministic embeddings, lexical ranking behavior, and fixture loading/validation.
  * Added an ablation test matrix that evaluates multiple retrieval configurations at `evalK` and enforces quality invariants across variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->