### PR TITLE
feat(retrieval): opt-in recency / time-decay score boosting (#323)

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,6 +596,17 @@ An optional **relevance floor** drops low-similarity candidate hits before they 
     min_score: 0.0   # 0 disables; e.g. 0.4 drops hits scoring below 0.4
   ```
 
+An optional **recency time-decay** boosts newer content for dated corpora (news, logs, changelogs, meeting notes). It is **server-side and config-only** — not an MCP tool parameter, so it changes no tool input/output schema.
+
+- When configured, each hit's final score is multiplied by an exponential decay `exp(-ln2 * age / half_life)`, where `age` is the hit's source-document mtime relative to a fixed "now" captured at query start. The decay is applied just **before** the relevance floor; re-scored hits are re-sorted deterministically.
+- A hit whose date cannot be resolved is **never boosted nor penalized**, and a future-dated hit (clock skew) is clamped so it cannot be amplified above its raw score.
+- **Default empty/`0` = disabled** (pass-through): behavior is unchanged unless you configure it. A negative half-life is rejected as invalid config.
+
+  ```yaml
+  retrieval:
+    recency_half_life: 0   # 0/empty disables; e.g. 720h halves a 30-day-old hit's score
+  ```
+
 ### Auth token behavior
 
 `dir2mcp` bearer auth can come from:

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -816,6 +816,7 @@ func (a *App) buildRetrieverForAsk(ctx context.Context, cfg config.Config, st mo
 	ret.SetOversampleFactor(cfg.RAGOversampleFactor)
 	a.configureReranker(ret, cfg)
 	ret.SetMinScore(cfg.RetrievalMinScore)
+	ret.SetRecencyHalfLife(cfg.RetrievalRecencyHalfLife)
 
 	// Per-query cost/latency observability (issue #327). The ask CLI writes its
 	// result (often JSON) to stdout, so route the query_metrics event to stderr

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -79,6 +79,7 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 	a.configureReranker(ret, cfg)
 	ret.SetCrossFileDedupEnabled(cfg.DedupRetrieval)
 	ret.SetMinScore(cfg.RetrievalMinScore)
+	ret.SetRecencyHalfLife(cfg.RetrievalRecencyHalfLife)
 
 	// events are emitted to stdout only after we create the emitter; moving
 	// creation before the preload call lets us report failures from that

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -227,6 +227,18 @@ type Config struct {
 	// `carbon:` YAML block. Disabled by default. Observability-only: never
 	// affects retrieval or tool results, and records only counts/estimates.
 	Carbon CarbonConfig
+	// RetrievalRecencyHalfLife is an OPT-IN server-side time-decay half-life
+	// (config `retrieval.recency_half_life`): when > 0, each candidate hit's
+	// final (authoritative) score is multiplied by an exponential decay
+	// `exp(-ln2 * age / half_life)`, where age is the hit's source document
+	// mtime relative to a fixed "now" captured at query start. Newer content
+	// therefore ranks higher in dated corpora; a hit with no resolvable date is
+	// never boosted nor penalized. The decay is applied after scoring/fusion/
+	// rerank and just before the relevance floor. It is config-only (NOT an MCP
+	// tool parameter) so no tool input/output schema changes. Default 0 =
+	// disabled (no decay): behavior is unchanged unless configured. Negative
+	// values are CONFIG_INVALID.
+	RetrievalRecencyHalfLife time.Duration
 	// Rerank* configure the optional post-fusion rerank stage (SPEC
 	// 9.1.1). Reranking auto-activates when a provider credential is
 	// present. CohereAPIKey is a secret: env-sourced, never persisted
@@ -532,6 +544,7 @@ type fileConfig struct {
 	RetrievalHybridEnabled             *bool
 	DedupRetrieval                     *bool
 	RetrievalMinScore                  *float64
+	RetrievalRecencyHalfLife           *time.Duration
 	RerankEnabled                      *bool
 	RerankProvider                     *string
 	CohereAPIKey                       *string
@@ -649,6 +662,7 @@ type persistedConfig struct {
 	RetrievalHybridEnabled             bool          `yaml:"retrieval_hybrid_enabled"`
 	DedupRetrieval                     bool          `yaml:"dedup_retrieval"`
 	RetrievalMinScore                  float64       `yaml:"retrieval_min_score"`
+	RetrievalRecencyHalfLife           time.Duration `yaml:"retrieval_recency_half_life"`
 	RerankEnabled                      bool          `yaml:"rerank_enabled"`
 	RerankProvider                     string        `yaml:"rerank_provider"`
 	CohereBaseURL                      string        `yaml:"cohere_base_url"`
@@ -808,6 +822,9 @@ func Default() Config {
 		// RetrievalMinScore defaults to 0 (disabled): no relevance floor is
 		// applied unless explicitly configured.
 		RetrievalMinScore: 0,
+		// RetrievalRecencyHalfLife defaults to 0 (disabled): no time-decay is
+		// applied unless explicitly configured.
+		RetrievalRecencyHalfLife: 0,
 		// RerankEnabled left nil: auto mode (activates iff a rerank
 		// provider credential is present). See rerankEnabledEffective.
 		RerankProvider:            "cohere",
@@ -923,6 +940,7 @@ func buildPersistedConfig(cfg *Config) persistedConfig {
 		RetrievalHybridEnabled:             cfg.RetrievalHybridEnabled,
 		DedupRetrieval:                     cfg.DedupRetrieval,
 		RetrievalMinScore:                  cfg.RetrievalMinScore,
+		RetrievalRecencyHalfLife:           cfg.RetrievalRecencyHalfLife,
 		RerankEnabled:                      rerankEnabledEffective(cfg),
 		RerankProvider:                     cfg.RerankProvider,
 		CohereBaseURL:                      cfg.CohereBaseURL,
@@ -1525,6 +1543,9 @@ func applyModelRAGFileParsed(cfg *Config, fc fileConfig) {
 	if fc.RetrievalMinScore != nil {
 		cfg.RetrievalMinScore = *fc.RetrievalMinScore
 	}
+	if fc.RetrievalRecencyHalfLife != nil {
+		cfg.RetrievalRecencyHalfLife = *fc.RetrievalRecencyHalfLife
+	}
 	if fc.SessionInactivityTimeout != nil {
 		cfg.SessionInactivityTimeout = *fc.SessionInactivityTimeout
 	}
@@ -1938,6 +1959,8 @@ var configKeyAliases = map[string]string{
 	"dedup_retrieval":                         "dedup.retrieval",
 	"retrieval_min_score":                     "retrieval.min_score",
 	"min_score":                               "retrieval.min_score",
+	"retrieval_recency_half_life":             "retrieval.recency_half_life",
+	"recency_half_life":                       "retrieval.recency_half_life",
 	"rerank_enabled":                          "rerank.enabled",
 	"rerank.cohere.api_key":                   "cohere_api_key",
 	"rerank.cohere.base_url":                  "cohere_base_url",
@@ -2237,6 +2260,8 @@ func setDurationFileScalar(cfg *fileConfig, key, value string) error {
 		target = &cfg.HealthCheckInterval
 	case "ingest.watch_debounce":
 		target = &cfg.IngestWatchDebounce
+	case "retrieval.recency_half_life":
+		target = &cfg.RetrievalRecencyHalfLife
 	default:
 		return nil
 	}
@@ -2523,6 +2548,7 @@ func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	writeBool("retrieval_hybrid_enabled", cfg.RetrievalHybridEnabled)
 	writeBool("dedup_retrieval", cfg.DedupRetrieval)
 	writeScalar("retrieval_min_score", strconv.FormatFloat(cfg.RetrievalMinScore, 'f', -1, 64))
+	writeScalar("retrieval_recency_half_life", cfg.RetrievalRecencyHalfLife.String())
 	writeBool("rerank_enabled", cfg.RerankEnabled)
 	writeScalar("rerank_provider", cfg.RerankProvider)
 	writeScalar("cohere_base_url", cfg.CohereBaseURL)
@@ -3268,6 +3294,12 @@ func (c *Config) validateNumericBounds() error {
 	// validation rather than silently corrupting the floor comparison.
 	if c.RetrievalMinScore < 0 || math.IsNaN(c.RetrievalMinScore) || math.IsInf(c.RetrievalMinScore, 0) {
 		return fmt.Errorf("retrieval.min_score must be a non-negative finite number: %v", c.RetrievalMinScore)
+	}
+	// retrieval.recency_half_life is a time-decay half-life; 0 disables it. A
+	// negative half-life is meaningless (it would amplify rather than decay older
+	// content) so reject it explicitly, mirroring the min_score guard.
+	if c.RetrievalRecencyHalfLife < 0 {
+		return fmt.Errorf("retrieval.recency_half_life must be non-negative: %v", c.RetrievalRecencyHalfLife)
 	}
 	return nil
 }

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -145,6 +145,19 @@ type Service struct {
 	// Ask/Search (issue #327). nil ⇒ metrics collection is skipped entirely
 	// (zero overhead). It never alters tool results.
 	metricsEmit func(level, event string, data interface{})
+	// recencyHalfLife is an opt-in server-side time-decay half-life (config
+	// retrieval.recency_half_life): when > 0, each hit's final authoritative
+	// Score is multiplied by exp(-ln2 * age / half_life) where age is the hit's
+	// source document mtime relative to a fixed "now" captured at query start.
+	// Newer content therefore ranks higher; a hit with no resolvable date is
+	// neither boosted nor penalized. Applied after scoring/fusion/rerank and just
+	// before the min_score floor. Config-only (never an MCP tool parameter).
+	// Default 0 ⇒ disabled (pass-through). Wired from
+	// config.RetrievalRecencyHalfLife at construction.
+	recencyHalfLife time.Duration
+	// nowFn returns the reference instant for recency decay; overridable in
+	// tests for determinism. Defaults to time.Now.
+	nowFn func() time.Time
 }
 
 // compile-time assertion that Service implements model.Retriever.  This
@@ -332,6 +345,39 @@ func (s *Service) SetMinScore(floor float64) {
 	s.metaMu.Lock()
 	defer s.metaMu.Unlock()
 	s.minScore = floor
+}
+
+// SetRecencyHalfLife wires the opt-in server-side time-decay (config
+// retrieval.recency_half_life). When halfLife > 0, each hit's final
+// authoritative Score is multiplied by exp(-ln2 * age / half_life) using the
+// hit's source document mtime relative to a fixed "now" captured at query
+// start, after scoring/fusion/rerank and just before the min_score floor. A
+// halfLife <= 0 disables the decay (pass-through). The engine wires this from
+// config.RetrievalRecencyHalfLife at construction time, mirroring SetMinScore.
+func (s *Service) SetRecencyHalfLife(halfLife time.Duration) {
+	s.metaMu.Lock()
+	defer s.metaMu.Unlock()
+	s.recencyHalfLife = halfLife
+}
+
+// SetNowFunc overrides the reference clock used by recency decay. Intended for
+// deterministic tests; passing nil restores time.Now.
+func (s *Service) SetNowFunc(fn func() time.Time) {
+	s.metaMu.Lock()
+	defer s.metaMu.Unlock()
+	s.nowFn = fn
+}
+
+// now returns the reference instant for recency decay, defaulting to time.Now
+// when no override is installed.
+func (s *Service) now() time.Time {
+	s.metaMu.RLock()
+	fn := s.nowFn
+	s.metaMu.RUnlock()
+	if fn == nil {
+		return time.Now()
+	}
+	return fn()
 }
 
 // SetDocumentHashes installs the rel_path → content_hash map used to group
@@ -690,10 +736,82 @@ func (s *Service) search(ctx context.Context, query model.SearchQuery) ([]model.
 	if err != nil {
 		return nil, err
 	}
+	// Apply the opt-in recency time-decay just BEFORE the relevance floor: it
+	// re-scores each hit by its source-document age, so the floor compares the
+	// decayed score and newer content survives a tie. Config-only; default 0 ⇒
+	// pass-through (no allocation, no lookups).
+	hits = s.applyRecencyDecay(ctx, hits)
 	// Apply the server-side relevance floor LAST: after scoring/fusion/rerank
-	// (the per-mode searches above) and after their dedup/truncation, using each
-	// hit's final authoritative Score. Config-only; default 0 ⇒ pass-through.
+	// (the per-mode searches above), after their dedup/truncation, and after the
+	// recency decay, using each hit's final authoritative Score. Config-only;
+	// default 0 ⇒ pass-through.
 	return s.applyMinScoreFloor(hits), nil
+}
+
+// applyRecencyDecay multiplies each hit's final authoritative Score by an
+// exponential time-decay exp(-ln2 * age / half_life), where age is the hit's
+// source document mtime relative to a fixed "now" captured once at the start of
+// this call (so a single Search is deterministic regardless of wall-clock drift
+// across hits). A half-life <= 0 disables the decay and returns hits unchanged
+// (pass-through), preserving slice identity so callers see no allocation when
+// unconfigured. A hit whose source date cannot be resolved (unknown rel_path,
+// store error, or mtime <= 0) is left untouched — never boosted, never
+// penalized. A future-dated hit (age < 0) is clamped to age 0 (factor 1) so a
+// skewed mtime can never amplify a score above its undecayed value. Because the
+// re-scoring can reorder candidates, hits are re-sorted best-first with a
+// stable, deterministic tiebreak (rel_path then chunk id) so output ordering is
+// reproducible.
+func (s *Service) applyRecencyDecay(ctx context.Context, hits []model.SearchHit) []model.SearchHit {
+	s.metaMu.RLock()
+	halfLife := s.recencyHalfLife
+	store := s.store
+	s.metaMu.RUnlock()
+	if halfLife <= 0 || len(hits) == 0 || store == nil {
+		return hits
+	}
+	now := s.now()
+	halfLifeSec := halfLife.Seconds()
+	// Cache document lookups by rel_path: many hits can share one source
+	// document, and a single Search should stat each document at most once.
+	mtimeByPath := make(map[string]int64, len(hits))
+	resolveMtime := func(relPath string) int64 {
+		if relPath == "" {
+			return 0
+		}
+		if mt, ok := mtimeByPath[relPath]; ok {
+			return mt
+		}
+		var mt int64
+		if doc, err := store.GetDocumentByPath(ctx, relPath); err == nil {
+			mt = doc.MTimeUnix
+		}
+		mtimeByPath[relPath] = mt
+		return mt
+	}
+	out := make([]model.SearchHit, len(hits))
+	copy(out, hits)
+	for i := range out {
+		mtime := resolveMtime(out[i].RelPath)
+		if mtime <= 0 {
+			continue
+		}
+		ageSec := now.Sub(time.Unix(mtime, 0)).Seconds()
+		if ageSec <= 0 {
+			continue
+		}
+		factor := math.Exp(-math.Ln2 * ageSec / halfLifeSec)
+		out[i].Score *= factor
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Score != out[j].Score {
+			return out[i].Score > out[j].Score
+		}
+		if out[i].RelPath != out[j].RelPath {
+			return out[i].RelPath < out[j].RelPath
+		}
+		return out[i].ChunkID < out[j].ChunkID
+	})
+	return out
 }
 
 // applyMinScoreFloor drops hits whose final authoritative Score is strictly

--- a/tests/config/retrieval_recency_half_life_config_test.go
+++ b/tests/config/retrieval_recency_half_life_config_test.go
@@ -1,0 +1,124 @@
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+)
+
+// TestRetrievalRecencyHalfLife_DefaultDisabled pins the local-first default: the
+// time-decay is 0 (disabled) unless explicitly configured.
+func TestRetrievalRecencyHalfLife_DefaultDisabled(t *testing.T) {
+	cfg := config.Default()
+	if cfg.RetrievalRecencyHalfLife != 0 {
+		t.Fatalf("retrieval.recency_half_life must default to 0 (disabled), got %v", cfg.RetrievalRecencyHalfLife)
+	}
+}
+
+// TestRetrievalRecencyHalfLife_NestedYAMLRoundTrips pins the nested-mapping form
+// (retrieval: \n  recency_half_life: 720h) onto Config.RetrievalRecencyHalfLife.
+func TestRetrievalRecencyHalfLife_NestedYAMLRoundTrips(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+	writeFile(t, path, strings.Join([]string{
+		"retrieval:",
+		"  recency_half_life: 720h",
+		"",
+	}, "\n"))
+
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if cfg.RetrievalRecencyHalfLife != 720*time.Hour {
+		t.Fatalf("nested retrieval.recency_half_life = %v, want 720h", cfg.RetrievalRecencyHalfLife)
+	}
+}
+
+// TestRetrievalRecencyHalfLife_FlatAliasRoundTrips pins the flat snake_case
+// alias (retrieval_recency_half_life -> retrieval.recency_half_life).
+func TestRetrievalRecencyHalfLife_FlatAliasRoundTrips(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+	writeFile(t, path, "retrieval_recency_half_life: 48h\n")
+
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if cfg.RetrievalRecencyHalfLife != 48*time.Hour {
+		t.Fatalf("flat retrieval_recency_half_life = %v, want 48h", cfg.RetrievalRecencyHalfLife)
+	}
+}
+
+// TestRetrievalRecencyHalfLife_SnapshotRoundTrips pins the persisted-snapshot
+// round-trip: the half-life survives SaveEffectiveSnapshot -> YAML -> load.
+func TestRetrievalRecencyHalfLife_SnapshotRoundTrips(t *testing.T) {
+	cfg := config.Default()
+	cfg.StateDir = t.TempDir()
+	cfg.RetrievalRecencyHalfLife = 168 * time.Hour
+
+	path, err := config.SaveEffectiveSnapshot(cfg, config.SecretSourceMetadata{})
+	if err != nil {
+		t.Fatalf("SaveEffectiveSnapshot: %v", err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !strings.Contains(string(raw), "retrieval_recency_half_life: 168h") {
+		t.Fatalf("snapshot must persist retrieval_recency_half_life: 168h:\n%s", raw)
+	}
+
+	loaded, _, err := config.LoadEffectiveSnapshot(path)
+	if err != nil {
+		t.Fatalf("LoadEffectiveSnapshot: %v", err)
+	}
+	if loaded.RetrievalRecencyHalfLife != 168*time.Hour {
+		t.Fatalf("loaded snapshot must carry RetrievalRecencyHalfLife=168h, got %v", loaded.RetrievalRecencyHalfLife)
+	}
+}
+
+// TestRetrievalRecencyHalfLife_RejectsUnparseable asserts a non-duration value
+// is rejected at config-parse time rather than silently ignored.
+func TestRetrievalRecencyHalfLife_RejectsUnparseable(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+	writeFile(t, path, "retrieval_recency_half_life: not-a-duration\n")
+
+	if _, err := config.LoadFile(path); err == nil {
+		t.Fatalf("LoadFile with unparseable retrieval_recency_half_life = nil error, want rejection")
+	}
+}
+
+// TestRetrievalRecencyHalfLife_RejectsNegative pins validation: a negative
+// half-life is CONFIG_INVALID (it would amplify rather than decay older content,
+// so it is a misconfiguration).
+func TestRetrievalRecencyHalfLife_RejectsNegative(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+	writeFile(t, path, "retrieval_recency_half_life: -1h\n")
+
+	_, err := config.LoadFile(path)
+	if err == nil {
+		t.Fatalf("LoadFile with negative retrieval_recency_half_life = nil error, want rejection")
+	}
+	if !strings.Contains(err.Error(), "retrieval.recency_half_life") {
+		t.Fatalf("error must mention retrieval.recency_half_life, got: %v", err)
+	}
+}
+
+// TestRetrievalRecencyHalfLife_ValidateRejectsNegativeProgrammatic pins that the
+// Validate() guard rejects a negative half-life injected programmatically (not
+// via the file parser), so the decay can never run with a bad half-life.
+func TestRetrievalRecencyHalfLife_ValidateRejectsNegativeProgrammatic(t *testing.T) {
+	cfg := config.Default()
+	cfg.RetrievalRecencyHalfLife = -time.Hour
+	if err := cfg.Validate(); err == nil {
+		t.Fatalf("Validate with negative RetrievalRecencyHalfLife = nil error, want rejection")
+	}
+}

--- a/tests/retrieval/recency_decay_test.go
+++ b/tests/retrieval/recency_decay_test.go
@@ -18,7 +18,7 @@ type fakeRecencyStore struct {
 	mtimes map[string]int64
 }
 
-func (f *fakeRecencyStore) Init(context.Context) error                       { return nil }
+func (f *fakeRecencyStore) Init(context.Context) error                           { return nil }
 func (f *fakeRecencyStore) UpsertDocument(context.Context, model.Document) error { return nil }
 func (f *fakeRecencyStore) GetDocumentByPath(_ context.Context, relPath string) (model.Document, error) {
 	mt, ok := f.mtimes[relPath]

--- a/tests/retrieval/recency_decay_test.go
+++ b/tests/retrieval/recency_decay_test.go
@@ -1,0 +1,179 @@
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
+)
+
+// fakeRecencyStore is a minimal model.Store that resolves a document's mtime by
+// rel_path so the recency time-decay (config retrieval.recency_half_life) can be
+// exercised without sqlite or credentials. A rel_path absent from mtimes
+// resolves to ErrNotImplemented, modelling an undated hit.
+type fakeRecencyStore struct {
+	mtimes map[string]int64
+}
+
+func (f *fakeRecencyStore) Init(context.Context) error                       { return nil }
+func (f *fakeRecencyStore) UpsertDocument(context.Context, model.Document) error { return nil }
+func (f *fakeRecencyStore) GetDocumentByPath(_ context.Context, relPath string) (model.Document, error) {
+	mt, ok := f.mtimes[relPath]
+	if !ok {
+		return model.Document{}, model.ErrNotImplemented
+	}
+	return model.Document{RelPath: relPath, MTimeUnix: mt}, nil
+}
+func (f *fakeRecencyStore) ListFiles(context.Context, string, string, int, int) ([]model.Document, int64, error) {
+	return nil, 0, nil
+}
+func (f *fakeRecencyStore) Close() error { return nil }
+
+// recencyNow is the fixed reference instant captured by the service at query
+// start, so age computations are deterministic regardless of wall clock.
+var recencyNow = time.Date(2026, time.June, 19, 0, 0, 0, 0, time.UTC)
+
+// newRecencyService builds a vector-only retrieval service (the fake store does
+// not implement LexicalSearcher so fusion stays off and each hit's Score is the
+// raw cosine similarity) backed by a store that dates each candidate document.
+//
+// The two candidates have deterministic cosine scores against the query vector
+// {1, 0}: chunk 1 (older) → 1.00, chunk 2 (newer) → 0.60. Without decay chunk 1
+// outranks chunk 2; with a half-life shorter than chunk 1's extra age the decay
+// must flip the order so the newer chunk 2 wins.
+func newRecencyService(t *testing.T, halfLife time.Duration, mtimes map[string]int64) *retrieval.Service {
+	t.Helper()
+	idx := index.NewHNSWIndex("")
+	addVec(t, idx, 1, []float32{1, 0})     // cosine 1.00 (OLD doc)
+	addVec(t, idx, 2, []float32{0.6, 0.8}) // cosine 0.60 (NEW doc)
+
+	svc := retrieval.NewService(&fakeRecencyStore{mtimes: mtimes}, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+		"mistral-embed": {1, 0},
+	}}, nil)
+	svc.SetChunkMetadata(1, model.SearchHit{RelPath: "old.md", Snippet: "alpha old"})
+	svc.SetChunkMetadata(2, model.SearchHit{RelPath: "new.md", Snippet: "alpha new"})
+	svc.SetRecencyHalfLife(halfLife)
+	svc.SetNowFunc(func() time.Time { return recencyNow })
+	return svc
+}
+
+func searchRecency(t *testing.T, svc *retrieval.Service) []model.SearchHit {
+	t.Helper()
+	hits, err := svc.Search(context.Background(), model.SearchQuery{Query: "alpha", K: 10})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	return hits
+}
+
+func recencyChunkIDs(hits []model.SearchHit) []uint64 {
+	ids := make([]uint64, 0, len(hits))
+	for _, h := range hits {
+		ids = append(ids, h.ChunkID)
+	}
+	return ids
+}
+
+// TestSearch_Recency_NewerOutranksOlder pins the core behavior: chunk 1 is 365
+// days old (raw score 1.00) and chunk 2 is fresh (raw score 0.60). With a
+// 30-day half-life the old chunk decays by exp(-ln2*365/30) ≈ 2.2e-4 to ~0.0002
+// while the fresh chunk keeps ~0.60, so the newer chunk 2 now ranks first.
+func TestSearch_Recency_NewerOutranksOlder(t *testing.T) {
+	mtimes := map[string]int64{
+		"old.md": recencyNow.Add(-365 * 24 * time.Hour).Unix(),
+		"new.md": recencyNow.Unix(),
+	}
+	svc := newRecencyService(t, 30*24*time.Hour, mtimes)
+	got := recencyChunkIDs(searchRecency(t, svc))
+	want := []uint64{2, 1}
+	if len(got) != len(want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("decay must rank newer first: want %v, got %v", want, got)
+		}
+	}
+}
+
+// TestSearch_Recency_DisabledIsUnchanged pins the default-off behavior: with a
+// zero half-life no decay is applied, so the raw cosine order (chunk 1 then
+// chunk 2) is preserved even though chunk 1 is far older.
+func TestSearch_Recency_DisabledIsUnchanged(t *testing.T) {
+	mtimes := map[string]int64{
+		"old.md": recencyNow.Add(-365 * 24 * time.Hour).Unix(),
+		"new.md": recencyNow.Unix(),
+	}
+	svc := newRecencyService(t, 0, mtimes)
+	got := recencyChunkIDs(searchRecency(t, svc))
+	want := []uint64{1, 2}
+	if len(got) != len(want) {
+		t.Fatalf("half-life=0 must preserve raw order; want %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("half-life=0 must be pass-through: want %v, got %v", want, got)
+		}
+	}
+}
+
+// TestSearch_Recency_UndatedHitUnaffected pins that a hit whose source document
+// has no resolvable date is neither boosted nor penalized: only the dated old
+// chunk decays. Here chunk 1 (old, dated) decays below chunk 2 (undated, raw
+// 0.60 kept), so the undated chunk ends up first purely because the dated one
+// lost score — the undated hit's own score is untouched.
+func TestSearch_Recency_UndatedHitUnaffected(t *testing.T) {
+	// Only old.md is dated; new.md is absent ⇒ undated ⇒ no decay.
+	mtimes := map[string]int64{
+		"old.md": recencyNow.Add(-365 * 24 * time.Hour).Unix(),
+	}
+	svc := newRecencyService(t, 30*24*time.Hour, mtimes)
+	hits := searchRecency(t, svc)
+	if len(hits) != 2 {
+		t.Fatalf("expected 2 hits, got %d", len(hits))
+	}
+	byID := map[uint64]float64{}
+	for _, h := range hits {
+		byID[h.ChunkID] = h.Score
+	}
+	// Undated chunk 2 keeps its raw cosine (~0.60) exactly.
+	if got := byID[2]; got < 0.5999 || got > 0.6001 {
+		t.Fatalf("undated hit score must be unchanged (~0.60), got %v", got)
+	}
+	// Dated chunk 1 decayed well below its raw 1.00.
+	if got := byID[1]; got >= 0.5 {
+		t.Fatalf("dated old hit should have decayed below 0.5, got %v", got)
+	}
+}
+
+// TestSearch_Recency_FutureDatedNotAmplified pins that a hit whose mtime is in
+// the future (clock skew) is clamped to age 0 (factor 1) rather than amplified:
+// its score stays at the raw cosine, never above it. Chunk 1 is future-dated
+// (raw 1.00) and chunk 2 is fresh (raw 0.60); the order is unchanged and chunk
+// 1's score is not pushed above 1.00.
+func TestSearch_Recency_FutureDatedNotAmplified(t *testing.T) {
+	mtimes := map[string]int64{
+		"old.md": recencyNow.Add(48 * time.Hour).Unix(), // future-dated
+		"new.md": recencyNow.Unix(),
+	}
+	svc := newRecencyService(t, 30*24*time.Hour, mtimes)
+	hits := searchRecency(t, svc)
+	got := recencyChunkIDs(hits)
+	want := []uint64{1, 2}
+	if len(got) != len(want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("future-dated hit must keep raw order: want %v, got %v", want, got)
+		}
+	}
+	for _, h := range hits {
+		if h.ChunkID == 1 && h.Score > 1.0001 {
+			t.Fatalf("future-dated hit must not be amplified above raw 1.00, got %v", h.Score)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds an **opt-in, server-side time-decay** so newer content ranks higher in dated corpora (news, logs, changelogs, meeting notes). Config-only ⇒ **ungated**: no MCP tool/citation schema change, no spec PR, no submodule re-pin. Plumbed exactly like the `retrieval.min_score` relevance floor (#305).

Closes #323

## Behavior

- New config knob `retrieval.recency_half_life` (a duration; `0`/empty = disabled = unchanged behavior). Validation rejects negative values (parse-time and `Validate()`).
- When `> 0`, each hit's final authoritative score is multiplied by `exp(-ln2 * age / half_life)`, where `age` is the hit's **source-document mtime** (`documents.mtime_unix`, resolved via `store.GetDocumentByPath`) relative to a fixed `now` captured once at query start (deterministic).
- Applied **after** scoring/fusion/rerank and **just before** the `min_score` floor; re-scored hits are re-sorted best-first with a deterministic tiebreak (rel_path, then chunk id).
- A hit with **no resolvable date** is never boosted nor penalized; a **future-dated** hit (clock skew) is clamped to age 0 (factor 1) so it can't be amplified above its raw score.
- Wired from config in both CLI bootstraps (`up.go`, `app.go`) via a new `SetRecencyHalfLife` setter, mirroring `SetMinScore`.

## Why document mtime

`SearchHit` carries no absolute date; transcript `Span` time fields are intra-file offsets, not calendar dates. The per-document `mtime_unix` already persisted in the store is the best available per-hit absolute date and is general-purpose (no fixed time semantics).

## Tests (no creds; fake-embedder / in-mem harness)

- `tests/retrieval/recency_decay_test.go`: newer outranks older with decay on; disabled (0) unchanged; undated hit's score untouched; future-dated not amplified.
- `tests/config/retrieval_recency_half_life_config_test.go`: default-off; nested + flat-alias load; snapshot round-trip; unparseable rejected; negative rejected at parse-time and via `Validate()`.

`make check` is fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)