### PR TITLE
feat(retrieval): cross-lingual query expansion (RRF fusion) (#325)

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -827,6 +827,7 @@ func (a *App) buildRetrieverForAsk(ctx context.Context, cfg config.Config, st mo
 	ret.SetAdaptiveRetrieval(cfg.RetrievalAdaptiveEnabled, cfg.RetrievalAdaptiveKMin, cfg.RetrievalAdaptiveKMax)
 	ret.SetMMR(cfg.RetrievalMMREnabled, cfg.RetrievalMMRLambda)
 	ret.SetHyDE(cfg.RetrievalHyDEEnabled, cfg.RetrievalHyDEMode)
+	a.configureCrossLingual(ret, cfg, st, generator)
 
 	if metadataStore, ok := st.(embeddedChunkLister); ok {
 		if _, err := preloadEmbeddedChunkMetadata(ctx, metadataStore, ret); err != nil && !errors.Is(err, model.ErrNotImplemented) {

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -84,6 +84,7 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 	ret.SetAdaptiveRetrieval(cfg.RetrievalAdaptiveEnabled, cfg.RetrievalAdaptiveKMin, cfg.RetrievalAdaptiveKMax)
 	ret.SetMMR(cfg.RetrievalMMREnabled, cfg.RetrievalMMRLambda)
 	ret.SetHyDE(cfg.RetrievalHyDEEnabled, cfg.RetrievalHyDEMode)
+	a.configureCrossLingual(ret, cfg, st, generator)
 
 	// events are emitted to stdout only after we create the emitter; moving
 	// creation before the preload call lets us report failures from that
@@ -908,6 +909,32 @@ func (a *App) loadCrossFileDedupHashes(ctx context.Context, cfg config.Config, s
 		return
 	}
 	ret.SetDocumentHashes(hashes)
+}
+
+// configureCrossLingual wires server-side cross-lingual query expansion (#325)
+// onto the retrieval service. It reuses the chat generator as the translate
+// primitive (SPEC §8.6.2 uses the chat capability for translation) and, for the
+// "auto" target set, registers a corpus-languages provider backed by the store's
+// optional model.CorpusLanguageLister (resolving to the corpus's detected
+// languages, #267). It is a no-op for behavior when disabled in config — the
+// service then leaves search unchanged regardless of the wiring. Mirrors how
+// SetMinScore / SetCrossFileDedupEnabled are wired from config; config-only, so
+// no MCP tool-schema change.
+func (a *App) configureCrossLingual(ret *retrieval.Service, cfg config.Config, st model.Store, translator model.Generator) {
+	if ret == nil {
+		return
+	}
+	ret.SetCrossLingual(cfg.CrossLingualEnabled, cfg.CrossLingualTargetLangs, translator)
+	if lister, ok := st.(model.CorpusLanguageLister); ok && lister != nil {
+		ret.SetCorpusLanguagesProvider(func() []string {
+			langs, err := lister.ListCorpusLanguages(context.Background())
+			if err != nil {
+				writef(a.stderr, "warning: list corpus languages for cross-lingual expansion: %v\n", err)
+				return nil
+			}
+			return langs
+		})
+	}
 }
 
 // initIndexingState creates a new IndexingState and optionally preloads

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -911,6 +911,11 @@ func (a *App) loadCrossFileDedupHashes(ctx context.Context, cfg config.Config, s
 	ret.SetDocumentHashes(hashes)
 }
 
+// corpusLanguagesLookupTimeout bounds the query-time store lookup that resolves
+// the "auto" cross-lingual target set, so a slow/blocked backend degrades to no
+// auto targets rather than hanging retrieval.
+const corpusLanguagesLookupTimeout = 2 * time.Second
+
 // configureCrossLingual wires server-side cross-lingual query expansion (#325)
 // onto the retrieval service. It reuses the chat generator as the translate
 // primitive (SPEC §8.6.2 uses the chat capability for translation) and, for the
@@ -927,9 +932,16 @@ func (a *App) configureCrossLingual(ret *retrieval.Service, cfg config.Config, s
 	ret.SetCrossLingual(cfg.CrossLingualEnabled, cfg.CrossLingualTargetLangs, translator)
 	if lister, ok := st.(model.CorpusLanguageLister); ok && lister != nil {
 		ret.SetCorpusLanguagesProvider(func() []string {
-			langs, err := lister.ListCorpusLanguages(context.Background())
+			// Bound the store lookup: this runs on the query-time retrieval path,
+			// so a slow/blocked backend must not hang retrieval indefinitely.
+			ctx, cancel := context.WithTimeout(context.Background(), corpusLanguagesLookupTimeout)
+			defer cancel()
+			langs, err := lister.ListCorpusLanguages(ctx)
 			if err != nil {
-				writef(a.stderr, "warning: list corpus languages for cross-lingual expansion: %v\n", err)
+				// Avoid logging the raw backend error: it can carry sensitive
+				// connection details. The expansion degrades gracefully (no auto
+				// targets) on failure.
+				writef(a.stderr, "warning: list corpus languages for cross-lingual expansion failed\n")
 				return nil
 			}
 			return langs

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3449,6 +3449,16 @@ func (c *Config) validateCrossLingual() error {
 						"(use \"auto\" or BCP-47 letters/digits/hyphen, e.g. \"en\" or \"pt-br\")", lang)
 				}
 			}
+			// Reject structurally malformed tags (e.g. "-", "en-", "en--us"): a
+			// leading/trailing/empty subtag is character-class-safe but has no
+			// primary subtag, so it would be silently dropped at target resolution.
+			// Failing here keeps misconfiguration explicit rather than silent.
+			for _, sub := range strings.Split(l, "-") {
+				if sub == "" {
+					return fmt.Errorf("retrieval.cross_lingual.target_langs contains a malformed language tag %q "+
+						"(empty subtag; use \"auto\" or BCP-47 tags like \"en\" or \"pt-br\")", lang)
+				}
+			}
 		}
 		if _, dup := seen[l]; dup {
 			continue

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -311,6 +311,23 @@ type Config struct {
 	// hypothetical-document embedding alone. Ignored when RetrievalHyDEEnabled is
 	// false. An empty value normalizes to "fuse".
 	RetrievalHyDEMode string
+	// CrossLingualEnabled enables server-side cross-lingual query expansion
+	// (config `retrieval.cross_lingual.enabled`): when true and a translator is
+	// available, the query is translated into the corpus's other languages, each
+	// variant is retrieved independently, and the per-language result sets are
+	// RRF-fused (reusing the hybrid fusion machinery) so an EN query surfaces RU
+	// content (and vice versa). Config-only (NOT an MCP tool parameter) so no
+	// tool input/output schema changes. Default false = disabled: search behavior
+	// is unchanged unless configured. A translation failure for one language is
+	// skipped, never fatal.
+	CrossLingualEnabled bool
+	// CrossLingualTargetLangs lists the language tag(s) the query is expanded
+	// into (config `retrieval.cross_lingual.target_langs`). The sentinel "auto"
+	// (the default when the list is empty) means "the corpus's detected languages"
+	// (#267) resolved at startup; an explicit list pins the targets. The detected
+	// query language is skipped (no self-translation). Has no built-in fixed
+	// language pair (general-purpose).
+	CrossLingualTargetLangs []string
 	// Rerank* configure the optional post-fusion rerank stage (SPEC
 	// 9.1.1). Reranking auto-activates when a provider credential is
 	// present. CohereAPIKey is a secret: env-sourced, never persisted
@@ -626,6 +643,8 @@ type fileConfig struct {
 	RetrievalMMRLambda                 *float64
 	RetrievalHyDEEnabled               *bool
 	RetrievalHyDEMode                  *string
+	CrossLingualEnabled                *bool
+	CrossLingualTargetLangs            []string
 	RerankEnabled                      *bool
 	RerankProvider                     *string
 	CohereAPIKey                       *string
@@ -753,6 +772,8 @@ type persistedConfig struct {
 	RetrievalMMRLambda                 float64       `yaml:"retrieval_mmr_lambda"`
 	RetrievalHyDEEnabled               bool          `yaml:"retrieval_hyde_enabled"`
 	RetrievalHyDEMode                  string        `yaml:"retrieval_hyde_mode"`
+	CrossLingualEnabled                bool          `yaml:"cross_lingual_enabled"`
+	CrossLingualTargetLangs            []string      `yaml:"cross_lingual_target_langs"`
 	RerankEnabled                      bool          `yaml:"rerank_enabled"`
 	RerankProvider                     string        `yaml:"rerank_provider"`
 	CohereBaseURL                      string        `yaml:"cohere_base_url"`
@@ -940,6 +961,11 @@ func Default() Config {
 		// RetrievalHyDEMode defaults to "fuse": when HyDE is enabled the
 		// hypothetical-document hits are RRF-fused with the raw-query hits.
 		RetrievalHyDEMode: HyDEModeFuse,
+		// CrossLingualEnabled defaults to false (disabled): cross-lingual query
+		// expansion is off unless explicitly enabled. The target-langs list is
+		// left empty, which means "auto" (the corpus's detected languages).
+		CrossLingualEnabled:     false,
+		CrossLingualTargetLangs: nil,
 		// RerankEnabled left nil: auto mode (activates iff a rerank
 		// provider credential is present). See rerankEnabledEffective.
 		RerankProvider:            "cohere",
@@ -1065,6 +1091,8 @@ func buildPersistedConfig(cfg *Config) persistedConfig {
 		RetrievalMMRLambda:                 cfg.RetrievalMMRLambda,
 		RetrievalHyDEEnabled:               cfg.RetrievalHyDEEnabled,
 		RetrievalHyDEMode:                  cfg.RetrievalHyDEMode,
+		CrossLingualEnabled:                cfg.CrossLingualEnabled,
+		CrossLingualTargetLangs:            append([]string(nil), cfg.CrossLingualTargetLangs...),
 		RerankEnabled:                      rerankEnabledEffective(cfg),
 		RerankProvider:                     cfg.RerankProvider,
 		CohereBaseURL:                      cfg.CohereBaseURL,
@@ -1681,9 +1709,10 @@ func applyModelRAGFileParsed(cfg *Config, fc fileConfig) {
 
 // applyRetrievalTuningFileParsed overlays the opt-in retrieval-tuning file
 // fields (recency time-decay #323, context compression #335, the adaptive
-// gate #338, MMR diversity #340, and the HyDE query transform #333) onto cfg.
-// Split out of applyModelRAGFileParsed to keep that function within the gocyclo
-// budget as tuning knobs are added.
+// gate #338, MMR diversity #340, the HyDE query transform #333, and
+// cross-lingual query expansion #325) onto cfg. Split out of
+// applyModelRAGFileParsed to keep that function within the gocyclo budget as
+// tuning knobs are added.
 func applyRetrievalTuningFileParsed(cfg *Config, fc fileConfig) {
 	if fc.RetrievalRecencyHalfLife != nil {
 		cfg.RetrievalRecencyHalfLife = *fc.RetrievalRecencyHalfLife
@@ -1714,6 +1743,12 @@ func applyRetrievalTuningFileParsed(cfg *Config, fc fileConfig) {
 	}
 	if fc.RetrievalHyDEMode != nil {
 		cfg.RetrievalHyDEMode = *fc.RetrievalHyDEMode
+	}
+	if fc.CrossLingualEnabled != nil {
+		cfg.CrossLingualEnabled = *fc.CrossLingualEnabled
+	}
+	if fc.CrossLingualTargetLangs != nil {
+		cfg.CrossLingualTargetLangs = normalizeStringSlice(fc.CrossLingualTargetLangs)
 	}
 }
 
@@ -2138,6 +2173,9 @@ var configKeyAliases = map[string]string{
 	"hyde_enabled":                            "retrieval.hyde.enabled",
 	"retrieval_hyde_mode":                     "retrieval.hyde.mode",
 	"hyde_mode":                               "retrieval.hyde.mode",
+	"cross_lingual_enabled":                   "retrieval.cross_lingual.enabled",
+	"cross_lingual":                           "retrieval.cross_lingual.enabled",
+	"cross_lingual_target_langs":              "retrieval.cross_lingual.target_langs",
 	"rerank_enabled":                          "rerank.enabled",
 	"rerank.cohere.api_key":                   "cohere_api_key",
 	"rerank.cohere.base_url":                  "cohere_base_url",
@@ -2247,7 +2285,7 @@ func canonicalizeConfigKey(key string) string {
 // (so child keys should be prefixed) rather than a scalar/list key.
 func isMapSectionKey(key string) bool {
 	switch key {
-	case "rag", "ingest", "ingest.docling", "stt", "stt.mistral", "stt.elevenlabs", "server", "server.tls", "secret_sources", "mistral", "docling", "security", "security.auth", "x402", "x402.route_policy", "x402.route_policy.tools_call", "chunking", "retrieval", "retrieval.hybrid", "retrieval.context_compression", "retrieval.adaptive", "retrieval.mmr", "retrieval.hyde", "rerank", "rerank.cohere", "index", "dedup":
+	case "rag", "ingest", "ingest.docling", "stt", "stt.mistral", "stt.elevenlabs", "server", "server.tls", "secret_sources", "mistral", "docling", "security", "security.auth", "x402", "x402.route_policy", "x402.route_policy.tools_call", "chunking", "retrieval", "retrieval.hybrid", "retrieval.context_compression", "retrieval.adaptive", "retrieval.mmr", "retrieval.hyde", "retrieval.cross_lingual", "rerank", "rerank.cohere", "index", "dedup":
 		return true
 	case "ingest.pdf", "ingest.images", "ingest.audio", "ingest.archives", "secrets", "index.qdrant":
 		return true
@@ -2316,16 +2354,17 @@ var boolFileScalarTargets = map[string]func(*fileConfig) **bool{
 	"media.trim_leading_silence": func(c *fileConfig) **bool {
 		return &c.MediaTrimLeadingSilence
 	},
-	"media.vad":                  func(c *fileConfig) **bool { return &c.MediaVAD },
-	"media.diarize.enabled":      func(c *fileConfig) **bool { return &c.MediaDiarizeEnabled },
-	"media.batch.two_phase":      func(c *fileConfig) **bool { return &c.MediaBatchTwoPhase },
-	"media.batch.progress":       func(c *fileConfig) **bool { return &c.MediaBatchProgress },
-	"x402_tools_call_enabled":    func(c *fileConfig) **bool { return &c.X402ToolsCallEnabled },
-	"retrieval.hybrid.enabled":   func(c *fileConfig) **bool { return &c.RetrievalHybridEnabled },
-	"retrieval.adaptive.enabled": func(c *fileConfig) **bool { return &c.RetrievalAdaptiveEnabled },
-	"retrieval.mmr.enabled":      func(c *fileConfig) **bool { return &c.RetrievalMMREnabled },
-	"retrieval.hyde.enabled":     func(c *fileConfig) **bool { return &c.RetrievalHyDEEnabled },
-	"dedup.retrieval":            func(c *fileConfig) **bool { return &c.DedupRetrieval },
+	"media.vad":                       func(c *fileConfig) **bool { return &c.MediaVAD },
+	"media.diarize.enabled":           func(c *fileConfig) **bool { return &c.MediaDiarizeEnabled },
+	"media.batch.two_phase":           func(c *fileConfig) **bool { return &c.MediaBatchTwoPhase },
+	"media.batch.progress":            func(c *fileConfig) **bool { return &c.MediaBatchProgress },
+	"x402_tools_call_enabled":         func(c *fileConfig) **bool { return &c.X402ToolsCallEnabled },
+	"retrieval.hybrid.enabled":        func(c *fileConfig) **bool { return &c.RetrievalHybridEnabled },
+	"retrieval.adaptive.enabled":      func(c *fileConfig) **bool { return &c.RetrievalAdaptiveEnabled },
+	"retrieval.mmr.enabled":           func(c *fileConfig) **bool { return &c.RetrievalMMREnabled },
+	"retrieval.hyde.enabled":          func(c *fileConfig) **bool { return &c.RetrievalHyDEEnabled },
+	"retrieval.cross_lingual.enabled": func(c *fileConfig) **bool { return &c.CrossLingualEnabled },
+	"dedup.retrieval":                 func(c *fileConfig) **bool { return &c.DedupRetrieval },
 	"retrieval.context_compression.enabled": func(c *fileConfig) **bool {
 		return &c.ContextCompressionEnabled
 	},
@@ -2665,6 +2704,8 @@ func setFileListValue(cfg *fileConfig, key, value string) {
 		appendValue(&cfg.MediaTranslateTargetLangs, value)
 	case "media.filter_words":
 		appendValue(&cfg.MediaFilterWords, value)
+	case "retrieval.cross_lingual.target_langs":
+		appendValue(&cfg.CrossLingualTargetLangs, value)
 	}
 }
 
@@ -2673,7 +2714,7 @@ func setFileListValue(cfg *fileConfig, key, value string) {
 func isListConfigKey(key string) bool {
 	key = canonicalizeConfigKey(key)
 	switch key {
-	case "trusted_proxies", "path_excludes", "secret_patterns", "allowed_origins", "media.translate.target_langs", "media.filter_words":
+	case "trusted_proxies", "path_excludes", "secret_patterns", "allowed_origins", "media.translate.target_langs", "media.filter_words", "retrieval.cross_lingual.target_langs":
 		return true
 	default:
 		return false
@@ -2751,6 +2792,8 @@ func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	writeScalar("retrieval_mmr_lambda", strconv.FormatFloat(cfg.RetrievalMMRLambda, 'f', -1, 64))
 	writeBool("retrieval_hyde_enabled", cfg.RetrievalHyDEEnabled)
 	writeScalar("retrieval_hyde_mode", cfg.RetrievalHyDEMode)
+	writeBool("cross_lingual_enabled", cfg.CrossLingualEnabled)
+	writeList("cross_lingual_target_langs", cfg.CrossLingualTargetLangs)
 	writeBool("rerank_enabled", cfg.RerankEnabled)
 	writeScalar("rerank_provider", cfg.RerankProvider)
 	writeScalar("cohere_base_url", cfg.CohereBaseURL)
@@ -3292,6 +3335,9 @@ func (c *Config) Validate() error {
 	if err := c.validateMediaBatch(); err != nil {
 		return err
 	}
+	if err := c.validateCrossLingual(); err != nil {
+		return err
+	}
 	c.applyValidationDefaults()
 	if c.SessionMaxLifetime > 0 && c.SessionMaxLifetime < c.SessionInactivityTimeout {
 		return fmt.Errorf("session_max_lifetime (%v) must be >= session_inactivity_timeout (%v)",
@@ -3370,6 +3416,51 @@ func (c *Config) validateMediaTranslate() error {
 			"media.translate.target_langs (no default target language)")
 	}
 	c.MediaTranslateTargetLangs = out
+	return nil
+}
+
+// crossLingualAutoSentinel is the target-langs value meaning "expand into the
+// corpus's detected languages (#267)" rather than an explicit pinned list. It is
+// resolved at startup against the live corpus, so it is accepted by validation
+// even though it is not a BCP-47 tag.
+const crossLingualAutoSentinel = "auto"
+
+// validateCrossLingual enforces the cross-lingual query-expansion config
+// invariants (#325). The feature is opt-in and off by default. The target-langs
+// list is normalized (trimmed, lower-cased, de-duplicated). An empty list is
+// valid and means "auto" (the corpus's detected languages, resolved at startup).
+// An explicit list may contain the "auto" sentinel and/or BCP-47 tags; any other
+// tag must use the cache-safe BCP-47 alphabet (letters/digits/hyphen), matching
+// validateMediaTranslate. Validation runs regardless of the enable flag so a
+// saved-but-disabled list round-trips and re-enabling restores it.
+func (c *Config) validateCrossLingual() error {
+	seen := make(map[string]struct{}, len(c.CrossLingualTargetLangs))
+	out := make([]string, 0, len(c.CrossLingualTargetLangs))
+	for _, lang := range c.CrossLingualTargetLangs {
+		l := strings.ToLower(strings.TrimSpace(lang))
+		if l == "" {
+			continue
+		}
+		if l != crossLingualAutoSentinel {
+			for _, r := range l {
+				safe := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-'
+				if !safe {
+					return fmt.Errorf("retrieval.cross_lingual.target_langs contains an invalid language tag %q "+
+						"(use \"auto\" or BCP-47 letters/digits/hyphen, e.g. \"en\" or \"pt-br\")", lang)
+				}
+			}
+		}
+		if _, dup := seen[l]; dup {
+			continue
+		}
+		seen[l] = struct{}{}
+		out = append(out, l)
+	}
+	if len(out) == 0 {
+		c.CrossLingualTargetLangs = nil
+	} else {
+		c.CrossLingualTargetLangs = out
+	}
 	return nil
 }
 

--- a/internal/model/interfaces.go
+++ b/internal/model/interfaces.go
@@ -43,6 +43,18 @@ type DocumentHashLister interface {
 	ListDocumentHashes(ctx context.Context) ([]DocumentHash, error)
 }
 
+// CorpusLanguageLister is an optional capability stores may implement so the
+// retrieval service can resolve the "auto" cross-lingual query-expansion target
+// set (#325) to the corpus's detected languages (#267). It returns the distinct
+// non-empty effective languages recorded across non-deleted chunks (SPEC
+// §5.2/§8.8), as BCP-47 tags. The retrieval service type-asserts against this
+// interface, mirroring DocumentHashLister/LexicalSearcher; stores that do not
+// implement it simply yield no auto targets and cross-lingual expansion is a
+// no-op unless an explicit target list is configured.
+type CorpusLanguageLister interface {
+	ListCorpusLanguages(ctx context.Context) ([]string, error)
+}
+
 // Index is the core vector-store contract every backend must satisfy (issue
 // #247). The in-memory HNSW is the conforming default; external/on-disk
 // backends (Qdrant #268, pgvector #269, on-disk #246) implement the same

--- a/internal/retrieval/crosslingual.go
+++ b/internal/retrieval/crosslingual.go
@@ -1,0 +1,243 @@
+package retrieval
+
+import (
+	"context"
+	"strings"
+	"unicode"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// crossLingualAutoSentinel mirrors config.crossLingualAutoSentinel: the
+// target-langs value meaning "expand into the corpus's detected languages
+// (#267)" rather than an explicit pinned list. Duplicated here to avoid a
+// retrieval→config dependency for a single constant.
+const crossLingualAutoSentinel = "auto"
+
+// crossLingualMaxVariants caps how many translated query variants a single
+// search may issue, bounding the added embed/retrieval cost (and translator
+// calls) regardless of how many languages the corpus records. The original
+// query is always retrieved in addition to the variants.
+const crossLingualMaxVariants = 8
+
+// searchExpanded runs the HyDE/per-mode retrieval pipeline for the original
+// query and, when cross-lingual query expansion (#325) is active, the per-mode
+// pipeline for each translated query variant, then RRF-fuses the per-language
+// result sets via the shared fusion primitive. When expansion is inactive
+// (disabled, no translator, or no resolvable target languages) it is exactly one
+// searchWithHyDE call on the original query, so the un-expanded path is
+// unchanged.
+//
+// Expansion is best-effort and never fails the search on translation trouble: a
+// target language whose translation errors (or returns blank, or equals the
+// original query) is simply skipped. Only the BASE query's retrieval error
+// propagates; a variant's retrieval error is logged and that variant dropped, so
+// a flaky variant degrades recall rather than breaking the search.
+func (s *Service) searchExpanded(ctx context.Context, query model.SearchQuery, k int) ([]model.SearchHit, error) {
+	// The base (original-language) query runs through the full HyDE/per-mode
+	// pipeline, so with cross-lingual expansion disabled this is byte-identical to
+	// a plain searchWithHyDE call.
+	base, err := s.searchWithHyDE(ctx, query, k)
+	if err != nil {
+		return nil, err
+	}
+
+	variants := s.crossLingualQueryVariants(ctx, query.Query)
+	if len(variants) == 0 {
+		return base, nil
+	}
+
+	lists := make([][]model.SearchHit, 0, len(variants)+1)
+	lists = append(lists, base)
+	for _, v := range variants {
+		// Translated variants reuse the original query's filters/mode (so routing
+		// and predicates match) but retrieve on the variant text. They go through
+		// searchByMode (not searchWithHyDE) to bound the added cost to retrieval —
+		// no extra generation per variant.
+		hits, verr := s.searchByMode(ctx, v, k, query, true)
+		if verr != nil {
+			// A variant retrieval failure degrades gracefully: log and skip it
+			// rather than failing the whole (cross-lingual) search.
+			s.logf("cross-lingual: retrieval for a translated query variant failed, skipping: %v", verr)
+			continue
+		}
+		lists = append(lists, hits)
+	}
+	if len(lists) == 1 {
+		// Every variant dropped out: fall back to the un-fused base result so the
+		// outcome matches a plain search rather than re-fusing a single list.
+		return base, nil
+	}
+	return fuseRRFMulti(lists, k), nil
+}
+
+// crossLingualQueryVariants returns the translated query strings to additionally
+// retrieve for, one per resolved target language, when cross-lingual expansion
+// is active. It returns nil (no expansion) when the feature is disabled, no
+// translator is wired, the query is blank, or no target languages resolve. The
+// detected query language is skipped (no self-translation), as is any target
+// whose translation fails, returns blank, or is unchanged from the input.
+func (s *Service) crossLingualQueryVariants(ctx context.Context, queryStr string) []string {
+	s.metaMu.RLock()
+	enabled := s.crossLingualEnabled
+	translator := s.crossLingualTranslator
+	configured := append([]string(nil), s.crossLingualTargetLangs...)
+	corpusFn := s.crossLingualCorpusLangsFn
+	s.metaMu.RUnlock()
+
+	q := strings.TrimSpace(queryStr)
+	if !enabled || translator == nil || q == "" {
+		return nil
+	}
+
+	targets := resolveCrossLingualTargets(configured, corpusFn, detectQueryLanguage(q))
+	if len(targets) == 0 {
+		return nil
+	}
+
+	variants := make([]string, 0, len(targets))
+	for _, lang := range targets {
+		translated, terr := translator.Generate(ctx, buildCrossLingualPrompt(q, lang))
+		if terr != nil {
+			// A per-language translation failure degrades gracefully (skip it),
+			// never fails the search (#325).
+			s.logf("cross-lingual: translating query into %q failed, skipping: %v", lang, terr)
+			continue
+		}
+		t := strings.TrimSpace(translated)
+		if t == "" || strings.EqualFold(t, q) {
+			continue
+		}
+		variants = append(variants, t)
+	}
+	return variants
+}
+
+// resolveCrossLingualTargets resolves the effective set of target languages to
+// expand a query into. An empty configured list, or one containing the "auto"
+// sentinel, contributes the corpus's detected languages (via corpusFn, #267);
+// other configured entries are taken literally. The detected query language is
+// excluded (matched on primary subtag) so the query is never re-translated into
+// its own language. Results are primary-subtag-deduplicated, order-preserving
+// (configured-explicit first, then corpus-detected), and capped at
+// crossLingualMaxVariants.
+func resolveCrossLingualTargets(configured []string, corpusFn func() []string, queryLang string) []string {
+	queryPrimary := model.LanguagePrimarySubtag(queryLang)
+
+	var corpus []string
+	corpusLoaded := false
+	loadCorpus := func() []string {
+		if !corpusLoaded {
+			corpusLoaded = true
+			if corpusFn != nil {
+				corpus = corpusFn()
+			}
+		}
+		return corpus
+	}
+
+	// "auto" mode: an empty configured list means auto.
+	wantAuto := len(configured) == 0
+	candidates := make([]string, 0, len(configured)+4)
+	for _, c := range configured {
+		l := strings.ToLower(strings.TrimSpace(c))
+		if l == "" {
+			continue
+		}
+		if l == crossLingualAutoSentinel {
+			wantAuto = true
+			continue
+		}
+		candidates = append(candidates, l)
+	}
+	if wantAuto {
+		for _, c := range loadCorpus() {
+			if l := strings.ToLower(strings.TrimSpace(c)); l != "" {
+				candidates = append(candidates, l)
+			}
+		}
+	}
+
+	out := make([]string, 0, len(candidates))
+	seen := make(map[string]struct{}, len(candidates))
+	for _, c := range candidates {
+		primary := model.LanguagePrimarySubtag(c)
+		if primary == "" {
+			continue
+		}
+		// Skip the query's own language (no self-translation).
+		if queryPrimary != "" && primary == queryPrimary {
+			continue
+		}
+		if _, dup := seen[primary]; dup {
+			continue
+		}
+		seen[primary] = struct{}{}
+		out = append(out, c)
+		if len(out) >= crossLingualMaxVariants {
+			break
+		}
+	}
+	return out
+}
+
+// buildCrossLingualPrompt builds a deterministic, general-purpose prompt that
+// translates a SEARCH QUERY into targetLang. It mirrors the ingest translate
+// prompt's contract (target-only, return the translation alone) but frames the
+// input as a query so the model keeps it terse and search-appropriate rather
+// than expanding it into prose.
+func buildCrossLingualPrompt(query, targetLang string) string {
+	var b strings.Builder
+	b.WriteString("Translate the following search query into ")
+	b.WriteString(targetLang)
+	b.WriteString(". Preserve the meaning and keep it concise, as a search query. ")
+	b.WriteString("Return only the translated query, with no preamble, quotes, or explanation.\n\n")
+	b.WriteString(query)
+	return b.String()
+}
+
+// detectQueryLanguage returns a best-effort BCP-47 primary subtag for the
+// dominant script of the query, used ONLY to skip self-translation (translating
+// a query into the language it is already in). It is intentionally a coarse,
+// dependency-free script heuristic — not a full language identifier — covering
+// the scripts dir2mcp's multilingual corpora most commonly mix (e.g. Latin vs
+// Cyrillic). When the dominant script does not map to a single language (most
+// notably Latin, shared by many languages) it returns "" so NO target is
+// skipped — i.e. the query is expanded into every target, which is the safe
+// recall-preserving default. The mapping never claims a specific language for an
+// ambiguous script.
+func detectQueryLanguage(query string) string {
+	counts := map[string]int{}
+	for _, r := range query {
+		if !unicode.IsLetter(r) {
+			continue
+		}
+		switch {
+		case unicode.Is(unicode.Cyrillic, r):
+			counts["ru"]++
+		case unicode.Is(unicode.Han, r):
+			counts["zh"]++
+		case unicode.Is(unicode.Hiragana, r), unicode.Is(unicode.Katakana, r):
+			counts["ja"]++
+		case unicode.Is(unicode.Hangul, r):
+			counts["ko"]++
+		case unicode.Is(unicode.Greek, r):
+			counts["el"]++
+		case unicode.Is(unicode.Arabic, r):
+			counts["ar"]++
+		case unicode.Is(unicode.Hebrew, r):
+			counts["he"]++
+		default:
+			// Latin and other shared scripts are ambiguous: do not attribute a
+			// language, so no target is skipped on their account.
+		}
+	}
+	best := ""
+	bestN := 0
+	for lang, n := range counts {
+		if n > bestN {
+			best, bestN = lang, n
+		}
+	}
+	return best
+}

--- a/internal/retrieval/crosslingual.go
+++ b/internal/retrieval/crosslingual.go
@@ -96,6 +96,10 @@ func (s *Service) crossLingualQueryVariants(ctx context.Context, queryStr string
 	}
 
 	variants := make([]string, 0, len(targets))
+	// Dedup translated variants: distinct target languages can yield the same
+	// translation (or one equal to the query), and retrieving/fusing a duplicate
+	// would double-count its evidence and skew the RRF ranking.
+	seenVariants := make(map[string]struct{}, len(targets))
 	for _, lang := range targets {
 		translated, terr := translator.Generate(ctx, buildCrossLingualPrompt(q, lang))
 		if terr != nil {
@@ -108,6 +112,11 @@ func (s *Service) crossLingualQueryVariants(ctx context.Context, queryStr string
 		if t == "" || strings.EqualFold(t, q) {
 			continue
 		}
+		key := strings.ToLower(t)
+		if _, dup := seenVariants[key]; dup {
+			continue
+		}
+		seenVariants[key] = struct{}{}
 		variants = append(variants, t)
 	}
 	return variants
@@ -215,8 +224,6 @@ func detectQueryLanguage(query string) string {
 		switch {
 		case unicode.Is(unicode.Cyrillic, r):
 			counts["ru"]++
-		case unicode.Is(unicode.Han, r):
-			counts["zh"]++
 		case unicode.Is(unicode.Hiragana, r), unicode.Is(unicode.Katakana, r):
 			counts["ja"]++
 		case unicode.Is(unicode.Hangul, r):
@@ -228,8 +235,12 @@ func detectQueryLanguage(query string) string {
 		case unicode.Is(unicode.Hebrew, r):
 			counts["he"]++
 		default:
-			// Latin and other shared scripts are ambiguous: do not attribute a
-			// language, so no target is skipped on their account.
+			// Latin, Han, and other shared scripts are ambiguous: do not attribute
+			// a language, so no target is skipped on their account. Han in
+			// particular is shared by Chinese and Japanese (and historically
+			// Korean), so mapping it to a single language would wrongly suppress a
+			// target variant; a genuine self-translation is still caught later by
+			// the query-equality check.
 		}
 	}
 	best := ""

--- a/internal/retrieval/hybrid.go
+++ b/internal/retrieval/hybrid.go
@@ -28,6 +28,20 @@ const hybridCandidatePoolSize = 50
 // expose slightly different snippets for the same chunk; we prefer the
 // vector path as the canonical source.
 func fuseRRF(primary, secondary []model.SearchHit, k int) []model.SearchHit {
+	return fuseRRFMulti([][]model.SearchHit{primary, secondary}, k)
+}
+
+// fuseRRFMulti combines any number of ranked SearchHit lists into a single
+// ranked list using reciprocal-rank fusion — the n-ary generalization of
+// fuseRRF. A chunk appearing in a list at rank r contributes 1/(rrfK+r); a
+// chunk appearing in several lists sums its per-list contributions, so a chunk
+// surfaced by multiple lists (e.g. retrieved for multiple language variants in
+// cross-lingual expansion, #325) is boosted. The metadata of the FIRST list a
+// chunk appears in is preserved (lists are processed in argument order), output
+// is sorted best-first with a deterministic chunk_id tiebreak, and truncated to
+// k. Empty lists are skipped. This is the shared fusion primitive for both
+// hybrid BM25+vector fusion and cross-lingual per-variant fusion.
+func fuseRRFMulti(lists [][]model.SearchHit, k int) []model.SearchHit {
 	if k <= 0 {
 		k = 10
 	}
@@ -35,7 +49,11 @@ func fuseRRF(primary, secondary []model.SearchHit, k int) []model.SearchHit {
 		hit   model.SearchHit
 		score float64
 	}
-	bag := make(map[uint64]*fused, len(primary)+len(secondary))
+	total := 0
+	for _, l := range lists {
+		total += len(l)
+	}
+	bag := make(map[uint64]*fused, total)
 
 	contribute := func(hit model.SearchHit, rank int) {
 		entry, ok := bag[hit.ChunkID]
@@ -46,11 +64,10 @@ func fuseRRF(primary, secondary []model.SearchHit, k int) []model.SearchHit {
 		entry.score += 1.0 / float64(rrfK+rank)
 	}
 
-	for i, h := range primary {
-		contribute(h, i+1)
-	}
-	for i, h := range secondary {
-		contribute(h, i+1)
+	for _, list := range lists {
+		for i, h := range list {
+			contribute(h, i+1)
+		}
 	}
 
 	out := make([]model.SearchHit, 0, len(bag))

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -196,6 +196,27 @@ type Service struct {
 	// ("fuse" = RRF-fuse the two; "replace" = use the hypothetical-document hits
 	// alone). Default "fuse". Wired from config.RetrievalHyDEMode.
 	hydeMode string
+	// crossLingualEnabled toggles server-side cross-lingual query expansion
+	// (#325): when true and crossLingualTranslator is set, Search translates the
+	// query into each resolved target language, retrieves per variant, and
+	// RRF-fuses the per-language result sets. Default false ⇒ unchanged behavior.
+	// Wired from config.CrossLingualEnabled at construction.
+	crossLingualEnabled bool
+	// crossLingualTargetLangs is the configured target-language list
+	// (config retrieval.cross_lingual.target_langs). Empty, or the "auto"
+	// sentinel, resolves to the corpus's detected languages via
+	// crossLingualCorpusLangsFn at query time. Tags are lower-cased.
+	crossLingualTargetLangs []string
+	// crossLingualTranslator is the reusable translate primitive (the chat
+	// Generator, SPEC §8.6.2). When nil, cross-lingual expansion is inert even if
+	// enabled (it degrades to the un-expanded search). Wired from the same
+	// translatorFromConfig binding the ingest pipeline uses.
+	crossLingualTranslator model.Generator
+	// crossLingualCorpusLangsFn returns the corpus's detected languages (#267)
+	// for the "auto" target resolution. nil ⇒ auto resolves to no targets (the
+	// expansion is a no-op), so an explicit list is required to expand on a store
+	// that cannot enumerate languages.
+	crossLingualCorpusLangsFn func() []string
 }
 
 // compile-time assertion that Service implements model.Retriever.  This
@@ -507,6 +528,47 @@ func (s *Service) SetHyDE(enabled bool, mode string) {
 	defer s.metaMu.Unlock()
 	s.hydeEnabled = enabled
 	s.hydeMode = mode
+}
+
+// SetCrossLingual wires server-side cross-lingual query expansion (#325). When
+// enabled and translator is non-nil, Search translates the query into each
+// resolved target language, retrieves per variant, and RRF-fuses the result
+// sets so a query in one language surfaces content in the others. targetLangs is
+// the configured list (config retrieval.cross_lingual.target_langs); an empty
+// list or the "auto" sentinel resolves to the corpus's detected languages via
+// the provider registered with SetCorpusLanguagesProvider. Tags are lower-cased
+// and de-duplicated. Passing enabled=false or a nil translator leaves search
+// behavior unchanged. The engine wires this from config.CrossLingualEnabled /
+// config.CrossLingualTargetLangs at construction, mirroring SetMinScore.
+func (s *Service) SetCrossLingual(enabled bool, targetLangs []string, translator model.Generator) {
+	norm := make([]string, 0, len(targetLangs))
+	seen := make(map[string]struct{}, len(targetLangs))
+	for _, l := range targetLangs {
+		t := strings.ToLower(strings.TrimSpace(l))
+		if t == "" {
+			continue
+		}
+		if _, dup := seen[t]; dup {
+			continue
+		}
+		seen[t] = struct{}{}
+		norm = append(norm, t)
+	}
+	s.metaMu.Lock()
+	defer s.metaMu.Unlock()
+	s.crossLingualEnabled = enabled
+	s.crossLingualTargetLangs = norm
+	s.crossLingualTranslator = translator
+}
+
+// SetCorpusLanguagesProvider registers a callback returning the corpus's
+// detected languages (#267), used to resolve the "auto" cross-lingual target
+// set. Passing nil clears it (auto then resolves to no targets). The callback is
+// invoked at query time so it always reflects the live corpus.
+func (s *Service) SetCorpusLanguagesProvider(fn func() []string) {
+	s.metaMu.Lock()
+	defer s.metaMu.Unlock()
+	s.crossLingualCorpusLangsFn = fn
 }
 
 // SetDocumentHashes installs the rel_path → content_hash map used to group
@@ -831,7 +893,11 @@ func (s *Service) search(ctx context.Context, query model.SearchQuery) ([]model.
 		k = 15
 	}
 
-	hits, err := s.searchWithHyDE(ctx, query, k)
+	// Cross-lingual query expansion (#325) wraps the HyDE/per-mode pipeline: when
+	// active it runs that pipeline once per query-language variant and RRF-fuses
+	// the result sets; when inactive it reduces to a single searchWithHyDE call,
+	// so the un-expanded path is unchanged.
+	hits, err := s.searchExpanded(ctx, query, k)
 	if err != nil {
 		return nil, err
 	}
@@ -841,16 +907,16 @@ func (s *Service) search(ctx context.Context, query model.SearchQuery) ([]model.
 	// pass-through (no allocation, no lookups).
 	hits = s.applyRecencyDecay(ctx, hits)
 	// Apply the server-side relevance floor LAST: after scoring/fusion/rerank,
-	// the optional HyDE fusion, their dedup/truncation, and the recency decay,
-	// using each hit's final authoritative Score. Config-only; default 0 ⇒
-	// pass-through.
+	// the optional HyDE fusion, any cross-lingual fusion, their dedup/truncation,
+	// and the recency decay, using each hit's final authoritative Score.
+	// Config-only; default 0 ⇒ pass-through.
 	return s.applyMinScoreFloor(hits), nil
 }
 
 // searchByMode runs the index-mode dispatch (text/code/both/auto) for one query
 // text, returning up to k ranked hits. It is the shared retrieval primitive used
-// by both the raw query and — when the HyDE transform is enabled — the
-// hypothetical-document variant, so the two go through identical
+// by the raw query, the HyDE hypothetical-document variant (#333), and each
+// cross-lingual translated variant (#325), so all go through identical
 // fusion/rerank/dedup logic. allowRerank is forwarded to the single-index path
 // (the "both" path reranks internally on its merged pool regardless).
 func (s *Service) searchByMode(ctx context.Context, queryText string, k int, query model.SearchQuery, allowRerank bool) ([]model.SearchHit, error) {

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -861,6 +861,42 @@ func (s *SQLiteStore) ListDocumentHashes(ctx context.Context) ([]model.DocumentH
 	return hashes, nil
 }
 
+// ListCorpusLanguages returns the distinct non-empty effective languages
+// recorded across non-deleted chunks (SPEC §5.2/§8.8), as BCP-47 tags sorted
+// for determinism. It backs the "auto" cross-lingual query-expansion target
+// resolution (#325): the retrieval service expands a query into the corpus's
+// detected languages (#267). Chunks with no recorded language (unknown) are
+// excluded. Implements model.CorpusLanguageLister.
+func (s *SQLiteStore) ListCorpusLanguages(ctx context.Context) ([]string, error) {
+	db, err := s.ensureDB(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer s.ReleaseDB()
+
+	rows, err := db.QueryContext(ctx,
+		`SELECT DISTINCT language FROM chunks WHERE deleted = 0 AND TRIM(language) != '' ORDER BY language`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	langs := make([]string, 0)
+	for rows.Next() {
+		var lang string
+		if err := rows.Scan(&lang); err != nil {
+			return nil, err
+		}
+		if lang = strings.TrimSpace(lang); lang != "" {
+			langs = append(langs, lang)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return langs, nil
+}
+
 // WithTx begins a new database transaction and passes a transaction-bound
 // representation store to the supplied callback. If the callback returns an
 // error the transaction is rolled back; otherwise it is committed.  The

--- a/tests/config/cross_lingual_config_test.go
+++ b/tests/config/cross_lingual_config_test.go
@@ -1,0 +1,134 @@
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+)
+
+// TestCrossLingual_DefaultsDisabled pins the local-first, no-surprises default:
+// cross-lingual query expansion is off and has no target languages unless
+// explicitly configured.
+func TestCrossLingual_DefaultsDisabled(t *testing.T) {
+	cfg := config.Default()
+	if cfg.CrossLingualEnabled {
+		t.Fatalf("retrieval.cross_lingual.enabled must default to false")
+	}
+	if len(cfg.CrossLingualTargetLangs) != 0 {
+		t.Fatalf("retrieval.cross_lingual.target_langs must default to empty, got %#v", cfg.CrossLingualTargetLangs)
+	}
+}
+
+// TestCrossLingual_NestedYAMLRoundTrips pins the nested spec-style block onto
+// CrossLingualEnabled + CrossLingualTargetLangs.
+func TestCrossLingual_NestedYAMLRoundTrips(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+	writeFile(t, path, strings.Join([]string{
+		"retrieval:",
+		"  cross_lingual:",
+		"    enabled: true",
+		"    target_langs:",
+		"      - ru",
+		"      - en",
+		"",
+	}, "\n"))
+
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if !cfg.CrossLingualEnabled {
+		t.Fatalf("nested retrieval.cross_lingual.enabled not applied")
+	}
+	if !reflect.DeepEqual(cfg.CrossLingualTargetLangs, []string{"ru", "en"}) {
+		t.Fatalf("nested target_langs = %#v, want [ru en]", cfg.CrossLingualTargetLangs)
+	}
+}
+
+// TestCrossLingual_FlatAliasRoundTrips pins the flat snake_case aliases.
+func TestCrossLingual_FlatAliasRoundTrips(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+	writeFile(t, path, strings.Join([]string{
+		"cross_lingual_enabled: true",
+		"cross_lingual_target_langs:",
+		"  - auto",
+		"",
+	}, "\n"))
+
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if !cfg.CrossLingualEnabled {
+		t.Fatalf("flat cross_lingual_enabled not applied")
+	}
+	if !reflect.DeepEqual(cfg.CrossLingualTargetLangs, []string{"auto"}) {
+		t.Fatalf("flat cross_lingual_target_langs = %#v, want [auto]", cfg.CrossLingualTargetLangs)
+	}
+}
+
+// TestCrossLingual_AcceptsAutoSentinelAndExplicit pins that the "auto" sentinel
+// is accepted alongside BCP-47 tags and survives normalization (lower-cased,
+// de-duplicated).
+func TestCrossLingual_AcceptsAutoSentinelAndExplicit(t *testing.T) {
+	cfg := config.Default()
+	cfg.CrossLingualTargetLangs = []string{"AUTO", "RU", "ru", "pt-BR"}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate with valid target_langs = %v, want nil", err)
+	}
+	if !reflect.DeepEqual(cfg.CrossLingualTargetLangs, []string{"auto", "ru", "pt-br"}) {
+		t.Fatalf("target_langs not normalized/deduped: %#v", cfg.CrossLingualTargetLangs)
+	}
+}
+
+// TestCrossLingual_RejectsInvalidTag pins that a tag outside the cache-safe
+// BCP-47 alphabet (and not the "auto" sentinel) is CONFIG_INVALID.
+func TestCrossLingual_RejectsInvalidTag(t *testing.T) {
+	cfg := config.Default()
+	cfg.CrossLingualTargetLangs = []string{"en_us"} // underscore is not allowed
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatalf("Validate with invalid target_langs = nil error, want rejection")
+	}
+	if !strings.Contains(err.Error(), "retrieval.cross_lingual.target_langs") {
+		t.Fatalf("error must mention retrieval.cross_lingual.target_langs, got: %v", err)
+	}
+}
+
+// TestCrossLingual_SnapshotRoundTrips pins the persisted-snapshot round-trip for
+// both the enable flag and the target list.
+func TestCrossLingual_SnapshotRoundTrips(t *testing.T) {
+	cfg := config.Default()
+	cfg.StateDir = t.TempDir()
+	cfg.CrossLingualEnabled = true
+	cfg.CrossLingualTargetLangs = []string{"ru", "en"}
+
+	path, err := config.SaveEffectiveSnapshot(cfg, config.SecretSourceMetadata{})
+	if err != nil {
+		t.Fatalf("SaveEffectiveSnapshot: %v", err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !strings.Contains(string(raw), "cross_lingual_enabled: true") {
+		t.Fatalf("snapshot must persist cross_lingual_enabled: true:\n%s", raw)
+	}
+
+	loaded, _, err := config.LoadEffectiveSnapshot(path)
+	if err != nil {
+		t.Fatalf("LoadEffectiveSnapshot: %v", err)
+	}
+	if !loaded.CrossLingualEnabled {
+		t.Fatalf("loaded snapshot must carry CrossLingualEnabled=true")
+	}
+	if !reflect.DeepEqual(loaded.CrossLingualTargetLangs, []string{"ru", "en"}) {
+		t.Fatalf("loaded snapshot target_langs = %#v, want [ru en]", loaded.CrossLingualTargetLangs)
+	}
+}

--- a/tests/retrieval/cross_lingual_test.go
+++ b/tests/retrieval/cross_lingual_test.go
@@ -71,8 +71,8 @@ func (v *vectorRoutingIndex) Close() error                             { return 
 // translation fail (to exercise graceful degradation). callsByLang records how
 // many times each target language was requested.
 type fakeTranslator struct {
-	byLang     map[string]string
-	errForLang map[string]error
+	byLang      map[string]string
+	errForLang  map[string]error
 	callsByLang map[string]int
 }
 

--- a/tests/retrieval/cross_lingual_test.go
+++ b/tests/retrieval/cross_lingual_test.go
@@ -1,0 +1,257 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
+)
+
+// queryAwareEmbedder maps a query string to a fixed vector so a translated
+// query variant retrieves a different chunk than the original. The first text
+// is treated as the query (the service embeds exactly one query string per
+// search). An unmapped query falls back to {1, 0}.
+type queryAwareEmbedder struct {
+	vecByQuery map[string][]float32
+}
+
+func (e *queryAwareEmbedder) Embed(_ context.Context, _ string, _ model.EmbedRole, texts []string) ([][]float32, error) {
+	out := make([][]float32, len(texts))
+	for i, t := range texts {
+		vec, ok := e.vecByQuery[strings.TrimSpace(t)]
+		if !ok {
+			vec = []float32{1, 0}
+		}
+		clone := make([]float32, len(vec))
+		copy(clone, vec)
+		out[i] = clone
+	}
+	return out, nil
+}
+
+// vectorRoutingIndex returns ONLY the labels mapped to the queried vector, so a
+// per-language query variant deterministically retrieves a disjoint result set.
+// Routing is keyed on the first vector component: 1 ⇒ EN labels, 0 ⇒ RU labels.
+// Unlike a real ANN index it does not surface orthogonal candidates, which keeps
+// the cross-lingual fusion assertions unambiguous (the base query alone never
+// returns the other language's doc).
+type vectorRoutingIndex struct {
+	enLabels []uint64
+	ruLabels []uint64
+}
+
+func (v *vectorRoutingIndex) Upsert(context.Context, []float32, model.IndexPayload) error {
+	return nil
+}
+func (v *vectorRoutingIndex) Delete(context.Context, []uint64) error { return nil }
+func (v *vectorRoutingIndex) Search(_ context.Context, vec []float32, k int, _ model.Filter) ([]model.IndexHit, error) {
+	labels := v.ruLabels
+	if len(vec) > 0 && vec[0] >= 0.5 {
+		labels = v.enLabels
+	}
+	out := make([]model.IndexHit, 0, len(labels))
+	for i, l := range labels {
+		if i >= k {
+			break
+		}
+		out = append(out, model.IndexHit{ChunkID: l, Score: 1.0})
+	}
+	return out, nil
+}
+func (v *vectorRoutingIndex) Identity(context.Context) (string, error) { return "", nil }
+func (v *vectorRoutingIndex) Reset(context.Context, string) error      { return nil }
+func (v *vectorRoutingIndex) Close() error                             { return nil }
+
+// fakeTranslator is a model.Generator that returns a canned translation keyed by
+// the target language embedded in the prompt, simulating the chat translate
+// primitive without credentials. errForLang, when set for a language, makes that
+// translation fail (to exercise graceful degradation). callsByLang records how
+// many times each target language was requested.
+type fakeTranslator struct {
+	byLang     map[string]string
+	errForLang map[string]error
+	callsByLang map[string]int
+}
+
+func (f *fakeTranslator) Generate(_ context.Context, prompt string) (string, error) {
+	lang := ""
+	for l := range f.byLang {
+		if strings.Contains(prompt, " into "+l+".") {
+			lang = l
+			break
+		}
+	}
+	if lang == "" {
+		for l := range f.errForLang {
+			if strings.Contains(prompt, " into "+l+".") {
+				lang = l
+				break
+			}
+		}
+	}
+	if f.callsByLang == nil {
+		f.callsByLang = map[string]int{}
+	}
+	f.callsByLang[lang]++
+	if err, ok := f.errForLang[lang]; ok {
+		return "", err
+	}
+	return f.byLang[lang], nil
+}
+
+func searchRelPaths(t *testing.T, svc *retrieval.Service, q model.SearchQuery) []string {
+	t.Helper()
+	hits, err := svc.Search(context.Background(), q)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	out := make([]string, 0, len(hits))
+	for _, h := range hits {
+		out = append(out, h.RelPath)
+	}
+	return out
+}
+
+func containsPath(paths []string, want string) bool {
+	for _, p := range paths {
+		if p == want {
+			return true
+		}
+	}
+	return false
+}
+
+// newCrossLingualService builds a vector-only service with two chunks that match
+// disjoint query vectors: the EN query vector {1, 0} surfaces the EN doc, and the
+// translated RU query vector {0, 1} surfaces the RU doc. The fake translator maps
+// the EN query to its RU form.
+func newCrossLingualService(t *testing.T) *retrieval.Service {
+	t.Helper()
+	idx := &vectorRoutingIndex{enLabels: []uint64{1}, ruLabels: []uint64{2}}
+
+	emb := &queryAwareEmbedder{vecByQuery: map[string][]float32{
+		"sanctions": {1, 0}, // original EN query
+		"санкции":   {0, 1}, // RU translation of the query
+	}}
+	svc := retrieval.NewService(nil, idx, emb, nil)
+	svc.SetChunkMetadata(1, model.SearchHit{ChunkID: 1, RelPath: "en.md", DocType: "md", Snippet: "english", Language: "en"})
+	svc.SetChunkMetadata(2, model.SearchHit{ChunkID: 2, RelPath: "ru.md", DocType: "md", Snippet: "russian", Language: "ru"})
+	svc.SetCorpusLanguagesProvider(func() []string { return []string{"en", "ru"} })
+	return svc
+}
+
+// TestCrossLingual_FusesMultiLanguageHits is the core behavior: an EN query with
+// cross-lingual expansion enabled (auto targets) surfaces BOTH the EN doc (from
+// the original query) and the RU doc (from the translated variant), fused via RRF.
+func TestCrossLingual_FusesMultiLanguageHits(t *testing.T) {
+	tr := &fakeTranslator{byLang: map[string]string{"ru": "санкции"}}
+	svc := newCrossLingualService(t)
+	svc.SetCrossLingual(true, nil /* auto */, tr)
+
+	paths := searchRelPaths(t, svc, model.SearchQuery{Query: "sanctions", K: 10})
+	if !containsPath(paths, "en.md") {
+		t.Fatalf("expected en.md (original query hit) in results, got %v", paths)
+	}
+	if !containsPath(paths, "ru.md") {
+		t.Fatalf("expected ru.md (cross-lingual variant hit) in results, got %v", paths)
+	}
+}
+
+// TestCrossLingual_ExplicitTargetLangs pins that an explicit target list (not
+// "auto") drives the same fusion without needing a corpus-languages provider.
+func TestCrossLingual_ExplicitTargetLangs(t *testing.T) {
+	tr := &fakeTranslator{byLang: map[string]string{"ru": "санкции"}}
+	idx := &vectorRoutingIndex{enLabels: []uint64{1}, ruLabels: []uint64{2}}
+	emb := &queryAwareEmbedder{vecByQuery: map[string][]float32{
+		"sanctions": {1, 0},
+		"санкции":   {0, 1},
+	}}
+	svc := retrieval.NewService(nil, idx, emb, nil)
+	svc.SetChunkMetadata(1, model.SearchHit{ChunkID: 1, RelPath: "en.md", DocType: "md", Snippet: "english", Language: "en"})
+	svc.SetChunkMetadata(2, model.SearchHit{ChunkID: 2, RelPath: "ru.md", DocType: "md", Snippet: "russian", Language: "ru"})
+	// No corpus-languages provider registered: explicit list must still work.
+	svc.SetCrossLingual(true, []string{"ru"}, tr)
+
+	paths := searchRelPaths(t, svc, model.SearchQuery{Query: "sanctions", K: 10})
+	if !containsPath(paths, "en.md") || !containsPath(paths, "ru.md") {
+		t.Fatalf("expected both en.md and ru.md with explicit target_langs, got %v", paths)
+	}
+}
+
+// TestCrossLingual_DisabledIsUnchanged pins that with the feature off, the search
+// returns only the original-query hit and never calls the translator.
+func TestCrossLingual_DisabledIsUnchanged(t *testing.T) {
+	tr := &fakeTranslator{byLang: map[string]string{"ru": "санкции"}}
+	svc := newCrossLingualService(t)
+	// Cross-lingual not enabled.
+
+	paths := searchRelPaths(t, svc, model.SearchQuery{Query: "sanctions", K: 10})
+	if containsPath(paths, "ru.md") {
+		t.Fatalf("disabled cross-lingual must not surface ru.md, got %v", paths)
+	}
+	if !containsPath(paths, "en.md") {
+		t.Fatalf("expected en.md from the original query, got %v", paths)
+	}
+	if len(tr.callsByLang) != 0 {
+		t.Fatalf("translator must not be called when cross-lingual is disabled, got %v", tr.callsByLang)
+	}
+}
+
+// TestCrossLingual_FailingTranslationSkipped pins graceful degradation: when the
+// translation for a target language errors, that variant is skipped (not fatal),
+// and the search still returns the original-query hit.
+func TestCrossLingual_FailingTranslationSkipped(t *testing.T) {
+	tr := &fakeTranslator{
+		byLang:     map[string]string{},
+		errForLang: map[string]error{"ru": errors.New("translate boom")},
+	}
+	svc := newCrossLingualService(t)
+	svc.SetCrossLingual(true, nil, tr)
+
+	paths := searchRelPaths(t, svc, model.SearchQuery{Query: "sanctions", K: 10})
+	if !containsPath(paths, "en.md") {
+		t.Fatalf("a failing translation must not fail the search; expected en.md, got %v", paths)
+	}
+	if containsPath(paths, "ru.md") {
+		t.Fatalf("the failed RU variant must be skipped, got %v", paths)
+	}
+	if tr.callsByLang["ru"] == 0 {
+		t.Fatalf("expected an attempted RU translation, got %v", tr.callsByLang)
+	}
+}
+
+// TestCrossLingual_SkipsQueryLanguage pins that the detected query language (here
+// Cyrillic ⇒ ru) is never re-translated: with a RU query and auto targets
+// {en, ru}, only EN is requested.
+func TestCrossLingual_SkipsQueryLanguage(t *testing.T) {
+	tr := &fakeTranslator{byLang: map[string]string{"en": "sanctions", "ru": "санкции"}}
+	svc := newCrossLingualService(t)
+	svc.SetCrossLingual(true, nil, tr)
+
+	// RU query: detectQueryLanguage(Cyrillic) ⇒ ru, so ru is skipped.
+	_ = searchRelPaths(t, svc, model.SearchQuery{Query: "санкции", K: 10})
+	if tr.callsByLang["ru"] != 0 {
+		t.Fatalf("must not translate a RU query into RU (self-translation), got %v", tr.callsByLang)
+	}
+	if tr.callsByLang["en"] == 0 {
+		t.Fatalf("expected the RU query to be translated into EN, got %v", tr.callsByLang)
+	}
+}
+
+// TestCrossLingual_NilTranslatorIsInert pins that enabling the feature without a
+// translator leaves search unchanged (no panic, no expansion).
+func TestCrossLingual_NilTranslatorIsInert(t *testing.T) {
+	svc := newCrossLingualService(t)
+	svc.SetCrossLingual(true, []string{"ru"}, nil)
+
+	paths := searchRelPaths(t, svc, model.SearchQuery{Query: "sanctions", K: 10})
+	if containsPath(paths, "ru.md") {
+		t.Fatalf("nil translator must not expand the query, got %v", paths)
+	}
+	if !containsPath(paths, "en.md") {
+		t.Fatalf("expected en.md from the original query, got %v", paths)
+	}
+}

--- a/tests/store/list_corpus_languages_test.go
+++ b/tests/store/list_corpus_languages_test.go
@@ -1,0 +1,86 @@
+package tests
+
+import (
+	"context"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// insertChunkWithLanguage upserts a document + representation (carrying the given
+// effective language in its meta_json) + one chunk, so the chunk's denormalized
+// language column (SPEC §5.2/§8.8) is populated. Returns nothing; fatals on error.
+func insertChunkWithLanguage(t *testing.T, st *store.SQLiteStore, relPath, language string) {
+	t.Helper()
+	ctx := context.Background()
+	if err := st.UpsertDocument(ctx, model.Document{RelPath: relPath, DocType: "md"}); err != nil {
+		t.Fatalf("upsert document %q: %v", relPath, err)
+	}
+	doc, err := st.GetDocumentByPath(ctx, relPath)
+	if err != nil {
+		t.Fatalf("get document %q: %v", relPath, err)
+	}
+	meta := `{"language":"` + language + `"}`
+	repID, err := st.UpsertRepresentation(ctx, model.Representation{
+		DocID:    doc.DocID,
+		RepType:  "raw_text",
+		RepHash:  relPath + "-h",
+		MetaJSON: meta,
+	})
+	if err != nil {
+		t.Fatalf("upsert representation %q: %v", relPath, err)
+	}
+	if _, err := st.InsertChunkWithSpans(ctx, model.Chunk{
+		RepID:     repID,
+		Ordinal:   0,
+		Text:      "body of " + relPath,
+		IndexKind: "text",
+	}, nil); err != nil {
+		t.Fatalf("insert chunk %q: %v", relPath, err)
+	}
+}
+
+// TestListCorpusLanguages_DistinctSorted pins the "auto" cross-lingual target
+// resolution backend (#325): the distinct non-empty effective languages recorded
+// across non-deleted chunks are returned, sorted and de-duplicated.
+func TestListCorpusLanguages_DistinctSorted(t *testing.T) {
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "langs.sqlite"))
+	if err := st.Init(context.Background()); err != nil {
+		t.Fatalf("store init: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	insertChunkWithLanguage(t, st, "a.md", "ru")
+	insertChunkWithLanguage(t, st, "b.md", "en")
+	insertChunkWithLanguage(t, st, "c.md", "ru") // duplicate language
+	insertChunkWithLanguage(t, st, "d.md", "")   // unknown language: excluded
+
+	langs, err := st.ListCorpusLanguages(context.Background())
+	if err != nil {
+		t.Fatalf("ListCorpusLanguages: %v", err)
+	}
+	if !reflect.DeepEqual(langs, []string{"en", "ru"}) {
+		t.Fatalf("ListCorpusLanguages = %#v, want [en ru]", langs)
+	}
+}
+
+// TestListCorpusLanguages_EmptyCorpus pins that an empty corpus yields no
+// languages (so "auto" cross-lingual expansion is a no-op).
+func TestListCorpusLanguages_EmptyCorpus(t *testing.T) {
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "empty.sqlite"))
+	if err := st.Init(context.Background()); err != nil {
+		t.Fatalf("store init: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	langs, err := st.ListCorpusLanguages(context.Background())
+	if err != nil {
+		t.Fatalf("ListCorpusLanguages: %v", err)
+	}
+	if len(langs) != 0 {
+		t.Fatalf("expected no languages for empty corpus, got %#v", langs)
+	}
+}


### PR DESCRIPTION
Closes #325

## What

Opt-in, server-side **cross-lingual query expansion**: when enabled, dir2mcp translates the search query into the corpus's other languages (reusing the existing translator), retrieves for each variant, and **RRF-fuses** the per-language result sets — so an EN query surfaces RU content (and vice versa). General-purpose: no fixed language pair.

Config-only ⇒ **ungated**: no MCP tool-schema change, no citation-contract change, no spec re-pin. Off by default = byte-identical to prior behavior.

## Config knob

- `retrieval.cross_lingual.enabled` (bool, default `false`) — flat alias `cross_lingual_enabled` / `cross_lingual`.
- `retrieval.cross_lingual.target_langs` (list) — flat alias `cross_lingual_target_langs`. Empty or the `auto` sentinel ⇒ the corpus's detected languages (#267); an explicit BCP-47 list pins targets. Validated/normalized (lower-cased, de-duped; `auto` accepted; cache-unsafe tags rejected). Round-trips through nested + flat YAML and the effective snapshot.

## How variants are generated + fused

- The chat `model.Generator` (the same translate primitive ingest uses, SPEC §8.6.2) translates the query into each resolved target language.
- The detected query language (coarse, dependency-free Unicode-script heuristic; ambiguous scripts like Latin map to nothing so no target is wrongly skipped) is **not** re-translated.
- Each variant runs the full per-mode retrieval pipeline (`searchByMode`), and the original + variant result sets are fused with `fuseRRFMulti` — the n-ary generalization of the existing hybrid `fuseRRF`, so a chunk surfaced by multiple variants is boosted.
- **Graceful degradation**: a per-language translation failure (or blank/identical output) is skipped, never fatal; a variant's retrieval error is logged and dropped. With expansion inactive (disabled / nil translator / no targets) it reduces to a single un-fused search.
- `auto` resolution is backed by a new optional store capability `model.CorpusLanguageLister` (`SQLiteStore.ListCorpusLanguages`, distinct non-empty chunk languages), mirroring `DocumentHashLister`.
- Wired from CLI bootstrap (`up` + `ask`) like `min_score` / cross-file-dedup.

## Tests

- `tests/retrieval/cross_lingual_test.go`: `TestCrossLingual_FusesMultiLanguageHits`, `TestCrossLingual_ExplicitTargetLangs`, `TestCrossLingual_DisabledIsUnchanged`, `TestCrossLingual_FailingTranslationSkipped`, `TestCrossLingual_SkipsQueryLanguage`, `TestCrossLingual_NilTranslatorIsInert` (fake translator/embedder, no creds).
- `tests/config/cross_lingual_config_test.go`: defaults, nested + flat YAML, `auto` + normalization, invalid-tag rejection, snapshot round-trip.
- `tests/store/list_corpus_languages_test.go`: `TestListCorpusLanguages_DistinctSorted`, `TestListCorpusLanguages_EmptyCorpus`.

`make lint` = 0 issues. `make check` is green except `tests/security` which requires the `dirstral-spec` submodule (uninitialized in this worktree; unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHuQEKSW3nzU1Pn7KXXBhj


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cross-lingual query expansion that automatically translates queries to multiple languages and retrieves results across them
  * Configuration options to enable/disable cross-lingual expansion and specify target languages or use automatic corpus language detection
  * Results from multiple languages are intelligently fused and ranked together

<!-- end of auto-generated comment: release notes by coderabbit.ai -->