### PR TITLE
feat: per-query cost + latency observability for ask/search (#327)

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -31,6 +31,7 @@ import (
 	"github.com/dirstral/dir2mcp/internal/providerfactory"
 	"github.com/dirstral/dir2mcp/internal/retrieval"
 	"github.com/dirstral/dir2mcp/internal/store"
+	"github.com/dirstral/dir2mcp/internal/usage"
 )
 
 const (
@@ -654,6 +655,29 @@ func (a *App) resolveModelClients(cfg config.Config) (model.Embedder, model.Gene
 	return embedder, gen, textModel, codeModel
 }
 
+// resolveChatModel returns the resolved chat/generation model name, used only
+// to label and price the generate stage in per-query metrics (issue #327).
+// Returns "" when no chat provider resolves.
+func (a *App) resolveChatModel(cfg config.Config) string {
+	cp, err := cfg.Providers().Resolve(provider.CapChat)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(cp.ChatModel)
+}
+
+// configureQueryMetrics wires per-query cost/latency observability onto the
+// retrieval service (issue #327): a structured query_metrics emitter, the
+// configured price table, and the resolved generation model label. Additive
+// and always-on; it never alters tool results. Shared by `up` and `ask`.
+func (a *App) configureQueryMetrics(ret *retrieval.Service, cfg config.Config, emit func(level, event string, data interface{})) {
+	if emit == nil {
+		return
+	}
+	ret.SetGenerationModel(a.resolveChatModel(cfg))
+	ret.SetMetricsEmitter(emit, usage.NewPriceTable(cfg.CostPriceOverrides))
+}
+
 // configureReranker wires the optional Cohere rerank stage onto the
 // retrieval service through the resolver (SPEC 8.1.3). cfg.RerankEnabled
 // is a tri-state override:
@@ -755,6 +779,12 @@ func (a *App) buildRetrieverForAsk(ctx context.Context, cfg config.Config, st mo
 	ret.SetOversampleFactor(cfg.RAGOversampleFactor)
 	a.configureReranker(ret, cfg)
 	ret.SetMinScore(cfg.RetrievalMinScore)
+
+	// Per-query cost/latency observability (issue #327). The ask CLI writes its
+	// result (often JSON) to stdout, so route the query_metrics event to stderr
+	// to avoid contaminating that output; it never alters the result itself.
+	askMetricsEmitter := newNDJSONEmitter(a.stderr, true)
+	a.configureQueryMetrics(ret, cfg, askMetricsEmitter.Emit)
 
 	if metadataStore, ok := st.(embeddedChunkLister); ok {
 		if _, err := preloadEmbeddedChunkMetadata(ctx, metadataStore, ret); err != nil && !errors.Is(err, model.ErrNotImplemented) {

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -85,6 +85,11 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 	// bootstrap step as structured events (see dirstral-spec/docs/SPEC.md for NDJSON schema).
 	emitter := newNDJSONEmitter(a.stdout, opts.jsonOutput)
 
+	// Wire per-query cost/latency observability (issue #327): always-on,
+	// additive, never alters tool results. Emits one query_metrics event per
+	// ask/search via the structured emitter plus a concise log line.
+	a.configureQueryMetrics(ret, cfg, emitter.Emit)
+
 	// Load the cross-file dedup hash map AFTER the emitter exists so a load
 	// failure is reported as a structured NDJSON warning event (machine-parseable
 	// in JSON/automation flows), consistent with other bootstrap steps.

--- a/internal/cohere/client.go
+++ b/internal/cohere/client.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/usage"
 )
 
 const (
@@ -327,6 +328,29 @@ type chatResponse struct {
 			Text string `json:"text"`
 		} `json:"content"`
 	} `json:"message"`
+	// Cohere v2 reports token usage nested under usage.tokens (input/output).
+	Usage struct {
+		Tokens struct {
+			InputTokens  int64 `json:"input_tokens"`
+			OutputTokens int64 `json:"output_tokens"`
+		} `json:"tokens"`
+	} `json:"usage"`
+}
+
+// tokenUsage normalizes the nested Cohere usage into the shared Usage shape,
+// returning ok=false when no counts were present.
+func (r chatResponse) tokenUsage() (usage.Usage, bool) {
+	in := r.Usage.Tokens.InputTokens
+	out := r.Usage.Tokens.OutputTokens
+	if in == 0 && out == 0 {
+		return usage.Usage{}, false
+	}
+	return usage.Usage{
+		PromptTokens:     in,
+		CompletionTokens: out,
+		TotalTokens:      in + out,
+		Reported:         true,
+	}, true
 }
 
 // Generate implements model.Generator via Cohere's v2 /v2/chat endpoint.
@@ -367,6 +391,9 @@ func (c *Client) generateOnce(ctx context.Context, chatModel, prompt string, tim
 	var parsed chatResponse
 	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
 		return "", &model.ProviderError{Code: "COHERE_FAILED", Message: "failed to decode generation response", Retryable: false, StatusCode: resp.StatusCode, Cause: err}
+	}
+	if u, ok := parsed.tokenUsage(); ok {
+		usage.Report(ctx, usage.StageGenerate, u)
 	}
 	var b strings.Builder
 	for _, p := range parsed.Message.Content {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/dirstral/dir2mcp/internal/secrets"
+	"github.com/dirstral/dir2mcp/internal/usage"
 )
 
 const DefaultProtocolVersion = "2025-11-25"
@@ -215,6 +216,12 @@ type Config struct {
 	// disabled (no floor): behavior is unchanged unless configured, preserving the
 	// local-first, no-surprises default. Negative values are CONFIG_INVALID.
 	RetrievalMinScore float64
+	// CostPriceOverrides maps a model name to per-1K-token USD prices,
+	// overriding the built-in defaults used by the per-query query_metrics
+	// event (issue #327). Parsed from the optional top-level `cost.prices:`
+	// YAML block. nil/empty ⇒ built-in defaults only. Observability-only:
+	// never affects retrieval or tool results.
+	CostPriceOverrides map[string]usage.ModelPrice
 	// Rerank* configure the optional post-fusion rerank stage (SPEC
 	// 9.1.1). Reranking auto-activates when a provider credential is
 	// present. CohereAPIKey is a secret: env-sourced, never persisted
@@ -1258,6 +1265,15 @@ func applyFileOverrides(cfg *Config, path string) error {
 		return fmt.Errorf("config file %s: %w", path, err)
 	}
 	cfg.providersDoc = doc
+
+	// Optional cost.prices overrides for per-query metrics (issue #327).
+	prices, err := parseCostPriceOverrides(raw)
+	if err != nil {
+		return fmt.Errorf("config file %s: %w", path, err)
+	}
+	if len(prices) > 0 {
+		cfg.CostPriceOverrides = prices
+	}
 
 	return nil
 }

--- a/internal/config/providers.go
+++ b/internal/config/providers.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/dirstral/dir2mcp/internal/provider"
+	"github.com/dirstral/dir2mcp/internal/usage"
 	"gopkg.in/yaml.v3"
 )
 
@@ -122,6 +123,71 @@ func extractProvidersSubtree(raw []byte) []byte {
 		return nil
 	}
 	return []byte(strings.Join(out, "\n"))
+}
+
+// extractTopLevelSubtree returns only the named top-level block (its key line
+// plus the indented/blank/comment continuation), mirroring
+// extractProvidersSubtree so a single block can be yaml.v3-parsed in isolation
+// without the bespoke flat parser. Returns nil when the key is absent.
+func extractTopLevelSubtree(raw []byte, want string) []byte {
+	var out []string
+	capturing := false
+	for _, line := range strings.Split(string(raw), "\n") {
+		trimmedLeft := strings.TrimLeft(line, " \t")
+		indented := line != trimmedLeft
+		blank := strings.TrimSpace(line) == ""
+		comment := strings.HasPrefix(trimmedLeft, "#")
+		topKey := !indented && !blank && !comment && strings.Contains(trimmedLeft, ":")
+
+		if topKey {
+			key := strings.TrimSpace(strings.SplitN(trimmedLeft, ":", 2)[0])
+			capturing = key == want
+		}
+		if capturing {
+			out = append(out, line)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return []byte(strings.Join(out, "\n"))
+}
+
+// costDoc is the yaml shape of the optional top-level `cost:` block:
+//
+//	cost:
+//	  prices:
+//	    my-model:
+//	      input_per_1k: 0.0005
+//	      output_per_1k: 0.0015
+type costDoc struct {
+	Cost struct {
+		Prices map[string]struct {
+			InputPer1K  float64 `yaml:"input_per_1k"`
+			OutputPer1K float64 `yaml:"output_per_1k"`
+		} `yaml:"prices"`
+	} `yaml:"cost"`
+}
+
+// parseCostPriceOverrides decodes the optional cost.prices block into a price
+// override map for per-query metrics (issue #327). Absent block ⇒ nil, no error.
+func parseCostPriceOverrides(raw []byte) (map[string]usage.ModelPrice, error) {
+	sub := extractTopLevelSubtree(raw, "cost")
+	if len(sub) == 0 {
+		return nil, nil
+	}
+	var doc costDoc
+	if err := yaml.Unmarshal(sub, &doc); err != nil {
+		return nil, fmt.Errorf("parse cost.prices config: %w", err)
+	}
+	if len(doc.Cost.Prices) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]usage.ModelPrice, len(doc.Cost.Prices))
+	for name, p := range doc.Cost.Prices {
+		out[name] = usage.ModelPrice{InputPer1K: p.InputPer1K, OutputPer1K: p.OutputPer1K}
+	}
+	return out, nil
 }
 
 func parseProvidersDoc(raw []byte) (providersDoc, error) {

--- a/internal/gemini/client.go
+++ b/internal/gemini/client.go
@@ -39,6 +39,7 @@ import (
 	"time"
 
 	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/usage"
 )
 
 const (
@@ -403,6 +404,7 @@ type generateResponse struct {
 			Content json.RawMessage `json:"content"`
 		} `json:"message"`
 	} `json:"choices"`
+	Usage usage.OpenAIUsage `json:"usage"`
 }
 
 // Generate implements model.Generator via {base}/chat/completions.
@@ -467,6 +469,9 @@ func (c *Client) generateOnce(ctx context.Context, chatModel, prompt string, tim
 	var parsed generateResponse
 	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
 		return "", &model.ProviderError{Code: "GEMINI_FAILED", Message: "failed to decode generation response", Retryable: false, StatusCode: resp.StatusCode, Cause: err}
+	}
+	if !parsed.Usage.Empty() {
+		usage.Report(ctx, usage.StageGenerate, parsed.Usage.ToUsage())
 	}
 	if len(parsed.Choices) == 0 {
 		return "", &model.ProviderError{Code: "GEMINI_FAILED", Message: "generation response had no choices", Retryable: false, StatusCode: resp.StatusCode}

--- a/internal/mistral/client.go
+++ b/internal/mistral/client.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/usage"
 )
 
 const (
@@ -176,7 +177,8 @@ type embedDataItem struct {
 }
 
 type embedResponse struct {
-	Data []embedDataItem `json:"data"`
+	Data  []embedDataItem   `json:"data"`
+	Usage usage.OpenAIUsage `json:"usage"`
 }
 
 type ocrRequest struct {
@@ -225,6 +227,7 @@ type generateResponse struct {
 			Content interface{} `json:"content"`
 		} `json:"message"`
 	} `json:"choices"`
+	Usage usage.OpenAIUsage `json:"usage"`
 }
 
 func (c *Client) embedBatchWithRetry(ctx context.Context, modelName string, inputs []string) ([][]float32, error) {
@@ -315,6 +318,10 @@ func (c *Client) embedBatch(ctx context.Context, modelName string, inputs []stri
 			StatusCode: resp.StatusCode,
 			Cause:      err,
 		}
+	}
+
+	if !parsed.Usage.Empty() {
+		usage.Report(ctx, usage.StageEmbed, parsed.Usage.ToUsage())
 	}
 
 	if len(parsed.Data) != len(inputs) {
@@ -928,6 +935,9 @@ func (c *Client) generateOnce(ctx context.Context, prompt string) (string, error
 			Retryable: false,
 			Cause:     err,
 		}
+	}
+	if !parsed.Usage.Empty() {
+		usage.Report(ctx, usage.StageGenerate, parsed.Usage.ToUsage())
 	}
 	if len(parsed.Choices) == 0 {
 		return "", &model.ProviderError{

--- a/internal/mistral/client.go
+++ b/internal/mistral/client.go
@@ -230,6 +230,15 @@ type generateResponse struct {
 	Usage usage.OpenAIUsage `json:"usage"`
 }
 
+// reportUsage forwards a provider-reported usage object to the per-query sink
+// when present (issue #327). A missing usage object leaves the stage unknown
+// (not zero). Inert when no sink is attached to ctx.
+func reportUsage(ctx context.Context, stage usage.Stage, u usage.OpenAIUsage) {
+	if !u.Empty() {
+		usage.Report(ctx, stage, u.ToUsage())
+	}
+}
+
 func (c *Client) embedBatchWithRetry(ctx context.Context, modelName string, inputs []string) ([][]float32, error) {
 	maxRetries := c.MaxRetries
 	if maxRetries < 0 {
@@ -320,9 +329,7 @@ func (c *Client) embedBatch(ctx context.Context, modelName string, inputs []stri
 		}
 	}
 
-	if !parsed.Usage.Empty() {
-		usage.Report(ctx, usage.StageEmbed, parsed.Usage.ToUsage())
-	}
+	reportUsage(ctx, usage.StageEmbed, parsed.Usage)
 
 	if len(parsed.Data) != len(inputs) {
 		return nil, &model.ProviderError{
@@ -936,9 +943,7 @@ func (c *Client) generateOnce(ctx context.Context, prompt string) (string, error
 			Cause:     err,
 		}
 	}
-	if !parsed.Usage.Empty() {
-		usage.Report(ctx, usage.StageGenerate, parsed.Usage.ToUsage())
-	}
+	reportUsage(ctx, usage.StageGenerate, parsed.Usage)
 	if len(parsed.Choices) == 0 {
 		return "", &model.ProviderError{
 			Code:      "MISTRAL_FAILED",

--- a/internal/openai/client.go
+++ b/internal/openai/client.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/usage"
 )
 
 const (
@@ -120,6 +121,7 @@ type embedResponse struct {
 		Index     int       `json:"index"`
 		Embedding []float64 `json:"embedding"`
 	} `json:"data"`
+	Usage usage.OpenAIUsage `json:"usage"`
 }
 
 // Embed implements model.Embedder. OpenAI embeddings are symmetric, so
@@ -204,6 +206,9 @@ func (c *Client) embedBatch(ctx context.Context, modelName string, inputs []stri
 	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
 		return nil, &model.ProviderError{Code: "OPENAI_FAILED", Message: "failed to decode embedding response", Retryable: false, StatusCode: resp.StatusCode, Cause: err}
 	}
+	if !parsed.Usage.Empty() {
+		usage.Report(ctx, usage.StageEmbed, parsed.Usage.ToUsage())
+	}
 	if len(parsed.Data) != len(inputs) {
 		return nil, &model.ProviderError{Code: "OPENAI_FAILED", Message: fmt.Sprintf("embedding response size mismatch: got %d vectors for %d inputs", len(parsed.Data), len(inputs)), Retryable: false, StatusCode: resp.StatusCode}
 	}
@@ -248,6 +253,7 @@ type generateResponse struct {
 			Content json.RawMessage `json:"content"`
 		} `json:"message"`
 	} `json:"choices"`
+	Usage usage.OpenAIUsage `json:"usage"`
 }
 
 // Generate implements model.Generator via {base}/chat/completions.
@@ -309,6 +315,9 @@ func (c *Client) generateOnce(ctx context.Context, chatModel, prompt string, tim
 	var parsed generateResponse
 	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
 		return "", &model.ProviderError{Code: "OPENAI_FAILED", Message: "failed to decode generation response", Retryable: false, StatusCode: resp.StatusCode, Cause: err}
+	}
+	if !parsed.Usage.Empty() {
+		usage.Report(ctx, usage.StageGenerate, parsed.Usage.ToUsage())
 	}
 	if len(parsed.Choices) == 0 {
 		return "", &model.ProviderError{Code: "OPENAI_FAILED", Message: "generation response had no choices", Retryable: false, StatusCode: resp.StatusCode}

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -17,8 +17,10 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/usage"
 )
 
 var (
@@ -129,6 +131,17 @@ type Service struct {
 	// config-only (never an MCP tool parameter). Default 0 ⇒ disabled
 	// (pass-through). Wired from config.RetrievalMinScore at construction.
 	minScore float64
+	// genModel is the resolved chat/generation model name, used only to label
+	// and price the generate stage in per-query metrics (issue #327). Empty
+	// when no generator is configured. Never affects retrieval behavior.
+	genModel string
+	// priceTable maps model names to approximate USD prices for the
+	// query_metrics event (issue #327). nil ⇒ cost is always omitted.
+	priceTable *usage.PriceTable
+	// metricsEmit, when set, receives one structured query_metrics event per
+	// Ask/Search (issue #327). nil ⇒ metrics collection is skipped entirely
+	// (zero overhead). It never alters tool results.
+	metricsEmit func(level, event string, data interface{})
 }
 
 // compile-time assertion that Service implements model.Retriever.  This
@@ -205,6 +218,87 @@ func (s *Service) SetRerankEnabled(enabled bool) {
 	s.metaMu.Lock()
 	defer s.metaMu.Unlock()
 	s.rerankEnabled = enabled
+}
+
+// SetGenerationModel records the resolved chat/generation model name used to
+// label and price the generate stage in per-query metrics (issue #327). It has
+// no effect on retrieval or generation behavior.
+func (s *Service) SetGenerationModel(modelName string) {
+	s.metaMu.Lock()
+	defer s.metaMu.Unlock()
+	s.genModel = strings.TrimSpace(modelName)
+}
+
+// SetMetricsEmitter wires per-query cost/latency observability (issue #327).
+// emit receives a single structured `query_metrics` event per Ask/Search;
+// prices maps model names to USD costs (nil ⇒ cost omitted). Passing a nil
+// emit disables metrics collection entirely. Metrics never change tool results.
+func (s *Service) SetMetricsEmitter(emit func(level, event string, data interface{}), prices *usage.PriceTable) {
+	s.metaMu.Lock()
+	defer s.metaMu.Unlock()
+	s.metricsEmit = emit
+	s.priceTable = prices
+}
+
+// metricsEnabled reports whether a metrics emitter is wired.
+func (s *Service) metricsEnabled() bool {
+	s.metaMu.RLock()
+	defer s.metaMu.RUnlock()
+	return s.metricsEmit != nil
+}
+
+// emitQueryMetrics builds a query_metrics event from the per-query sink and
+// surfaces it via the structured emitter plus a concise log line. It records
+// per-stage latency (always) and token usage + cost (where the provider
+// reported usage and the model is priced). It records counts/costs/latency
+// only — never prompts, documents, or keys. A nil sink or unset emitter is a
+// no-op. This is observability only; it never affects tool results (#327).
+func (s *Service) emitQueryMetrics(op string, sink *usage.Sink, total time.Duration) {
+	if sink == nil {
+		return
+	}
+	s.metaMu.RLock()
+	emit := s.metricsEmit
+	prices := s.priceTable
+	textModel := s.textModel
+	codeModel := s.codeModel
+	rerankModel := s.rerankModel
+	genModel := s.genModel
+	s.metaMu.RUnlock()
+	if emit == nil {
+		return
+	}
+
+	qm := usage.NewQueryMetrics(op, prices)
+
+	// Embed: prefer the text model label; fall back to code model. Embedding is
+	// symmetric across the two for pricing purposes here.
+	embedModel := textModel
+	if embedModel == "" {
+		embedModel = codeModel
+	}
+	if lat := sink.Latency(usage.StageEmbed); lat > 0 || hasStageUsage(sink, usage.StageEmbed) {
+		u, reported := sink.Stage(usage.StageEmbed)
+		qm.RecordStage(usage.StageEmbed, embedModel, lat, u, reported)
+	}
+	if lat := sink.Latency(usage.StageRerank); lat > 0 {
+		u, reported := sink.Stage(usage.StageRerank)
+		qm.RecordStage(usage.StageRerank, rerankModel, lat, u, reported)
+	}
+	if lat := sink.Latency(usage.StageGenerate); lat > 0 || hasStageUsage(sink, usage.StageGenerate) {
+		u, reported := sink.Stage(usage.StageGenerate)
+		qm.RecordStage(usage.StageGenerate, genModel, lat, u, reported)
+	}
+	qm.SetTotalLatency(total)
+
+	emit("info", "query_metrics", qm.Event())
+	s.logf("%s", qm.LogLine())
+}
+
+// hasStageUsage reports whether the sink recorded provider usage for a stage.
+func hasStageUsage(sink *usage.Sink, stage usage.Stage) bool {
+	_, ok := sink.Stage(stage)
+	return ok
 }
 
 // SetCrossFileDedupEnabled toggles retrieval-time cross-file de-duplication
@@ -528,6 +622,22 @@ func (s *Service) SetOverfetchMultiplier(m int) {
 }
 
 func (s *Service) Search(ctx context.Context, query model.SearchQuery) ([]model.SearchHit, error) {
+	// When metrics are enabled, attach a per-query usage sink and emit one
+	// query_metrics event for the search. When Ask calls Search internally it
+	// installs its own sink first; we detect that and skip double-emitting so a
+	// single `ask` produces exactly one event (issue #327).
+	if s.metricsEnabled() && usage.SinkFrom(ctx) == nil {
+		sink := usage.NewSink()
+		ctx = usage.WithSink(ctx, sink)
+		start := time.Now()
+		hits, err := s.search(ctx, query)
+		s.emitQueryMetrics("search", sink, time.Since(start))
+		return hits, err
+	}
+	return s.search(ctx, query)
+}
+
+func (s *Service) search(ctx context.Context, query model.SearchQuery) ([]model.SearchHit, error) {
 	s.metaMu.RLock()
 	textModel := s.textModel
 	codeModel := s.codeModel
@@ -609,7 +719,22 @@ func (s *Service) Ask(ctx context.Context, question string, query model.SearchQu
 		query.K = 15
 	}
 
-	hits, err := s.Search(ctx, query)
+	// Install a per-query usage sink so embed/rerank/generate token usage and
+	// latency for this ask are accumulated and emitted as a single
+	// query_metrics event. Calling s.search (not s.Search) keeps the sink
+	// owned here, so the nested search does not emit its own event (#327).
+	var (
+		sink     *usage.Sink
+		askStart time.Time
+	)
+	if s.metricsEnabled() {
+		sink = usage.NewSink()
+		ctx = usage.WithSink(ctx, sink)
+		askStart = time.Now()
+		defer func() { s.emitQueryMetrics("ask", sink, time.Since(askStart)) }()
+	}
+
+	hits, err := s.search(ctx, query)
 	if err != nil {
 		return model.AskResult{}, err
 	}
@@ -631,7 +756,12 @@ func (s *Service) Ask(ctx context.Context, question string, query model.SearchQu
 		maxContextChars := s.ragMaxContextChars
 		s.metaMu.RUnlock()
 		prompt := buildRAGPrompt(question, hits, systemPrompt, maxContextChars)
-		generated, genErr := s.gen.Generate(ctx, prompt)
+		var generated string
+		genErr := usage.TimeStage(ctx, usage.StageGenerate, func() error {
+			var gErr error
+			generated, gErr = s.gen.Generate(ctx, prompt)
+			return gErr
+		})
 		if genErr != nil {
 			// log the error so callers have visibility; fall back to the
 			// precomputed answer when generation fails.  avoid recording the
@@ -1275,7 +1405,12 @@ func (s *Service) searchSingleIndex(ctx context.Context, query string, k int, mo
 		// error rather than letting the nil dereference panic later.
 		return nil, ErrMissingEmbedder
 	}
-	vectors, err := s.embedder.Embed(ctx, modelName, model.EmbedQuery, []string{query})
+	var vectors [][]float32
+	err := usage.TimeStage(ctx, usage.StageEmbed, func() error {
+		var embErr error
+		vectors, embErr = s.embedder.Embed(ctx, modelName, model.EmbedQuery, []string{query})
+		return embErr
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -1471,7 +1606,12 @@ func (s *Service) rerankPool(ctx context.Context, query string, hits []model.Sea
 	for i, h := range cand {
 		docs[i] = h.Snippet
 	}
-	results, err := rr.Rerank(ctx, rmodel, query, docs, k)
+	var results []model.Reranked
+	err := usage.TimeStage(ctx, usage.StageRerank, func() error {
+		var rerr error
+		results, rerr = rr.Rerank(ctx, rmodel, query, docs, k)
+		return rerr
+	})
 	if err != nil || len(results) == 0 {
 		if err != nil {
 			s.logf("rerank: provider error, falling back to fused order: %v", err)

--- a/internal/usage/metrics.go
+++ b/internal/usage/metrics.go
@@ -1,0 +1,158 @@
+package usage
+
+import (
+	"fmt"
+	"math"
+	"strings"
+	"time"
+)
+
+// stageMetric is the per-stage breakdown surfaced in the query_metrics event.
+// Cost is a pointer so an unknown-model (no price) stage OMITS cost rather than
+// reporting a misleading 0.0.
+type stageMetric struct {
+	LatencyMS        int64    `json:"latency_ms"`
+	Model            string   `json:"model,omitempty"`
+	PromptTokens     int64    `json:"prompt_tokens,omitempty"`
+	CompletionTokens int64    `json:"completion_tokens,omitempty"`
+	TotalTokens      int64    `json:"total_tokens,omitempty"`
+	TokensReported   bool     `json:"tokens_reported"`
+	CostUSD          *float64 `json:"cost_usd,omitempty"`
+}
+
+// QueryMetrics accumulates per-query latency and (where available) token usage
+// across stages, then renders a single structured event payload. It is not
+// safe for concurrent stage registration; the retrieval service drives stages
+// sequentially.
+type QueryMetrics struct {
+	op     string // "ask" or "search"
+	prices *PriceTable
+	stages map[Stage]*stageMetric
+	order  []Stage
+	total  time.Duration
+}
+
+// NewQueryMetrics starts metrics collection for an operation ("ask"/"search")
+// using prices for cost mapping. A nil prices table still records tokens and
+// latency; cost is simply always omitted.
+func NewQueryMetrics(op string, prices *PriceTable) *QueryMetrics {
+	return &QueryMetrics{
+		op:     op,
+		prices: prices,
+		stages: make(map[Stage]*stageMetric),
+	}
+}
+
+// RecordStage registers a stage's wall-clock latency, model name, and the
+// usage observed for it (typically pulled from a Sink). Calling it more than
+// once for the same stage accumulates latency and tokens.
+func (m *QueryMetrics) RecordStage(stage Stage, model string, latency time.Duration, u Usage, reported bool) {
+	if m == nil {
+		return
+	}
+	sm, ok := m.stages[stage]
+	if !ok {
+		sm = &stageMetric{}
+		m.stages[stage] = sm
+		m.order = append(m.order, stage)
+	}
+	sm.LatencyMS += latency.Milliseconds()
+	if model != "" {
+		sm.Model = model
+	}
+	if reported {
+		sm.PromptTokens += u.PromptTokens
+		sm.CompletionTokens += u.CompletionTokens
+		if u.TotalTokens > 0 {
+			sm.TotalTokens += u.TotalTokens
+		} else {
+			sm.TotalTokens += u.PromptTokens + u.CompletionTokens
+		}
+		sm.TokensReported = true
+	}
+}
+
+// SetTotalLatency records the overall wall-clock time for the query, which may
+// exceed the sum of stages (it includes index search, fusion, dedup, etc.).
+func (m *QueryMetrics) SetTotalLatency(d time.Duration) {
+	if m != nil {
+		m.total = d
+	}
+}
+
+// finalize computes each stage's cost (when its model is priced) and returns
+// the aggregate totals: known cost, whether any stage had a known cost, and
+// total tokens across stages.
+func (m *QueryMetrics) finalize() (totalCost float64, costKnown bool, totalTokens int64) {
+	for _, stage := range m.order {
+		sm := m.stages[stage]
+		if sm.TokensReported {
+			totalTokens += sm.TotalTokens
+		}
+		if sm.TokensReported && sm.Model != "" {
+			cost, ok := m.prices.Cost(sm.Model, Usage{
+				PromptTokens:     sm.PromptTokens,
+				CompletionTokens: sm.CompletionTokens,
+			})
+			if ok {
+				rounded := roundUSD(cost)
+				sm.CostUSD = &rounded
+				totalCost += cost
+				costKnown = true
+			}
+		}
+	}
+	return totalCost, costKnown, totalTokens
+}
+
+// Event renders the structured payload for the query_metrics NDJSON event.
+// It contains ONLY counts, costs, and latency — never prompts, documents, or
+// keys. cost_usd (per-stage and total) is omitted entirely when no priced
+// model contributed, so unknown models never fabricate a cost.
+func (m *QueryMetrics) Event() map[string]interface{} {
+	totalCost, costKnown, totalTokens := m.finalize()
+
+	stages := make(map[string]interface{}, len(m.order))
+	for _, stage := range m.order {
+		stages[string(stage)] = m.stages[stage]
+	}
+
+	payload := map[string]interface{}{
+		"op":           m.op,
+		"latency_ms":   m.total.Milliseconds(),
+		"total_tokens": totalTokens,
+		"stages":       stages,
+	}
+	if costKnown {
+		payload["cost_usd"] = roundUSD(totalCost)
+	}
+	return payload
+}
+
+// LogLine renders a concise, human-readable one-liner for stderr logs. It
+// mirrors Event but never includes raw payloads.
+func (m *QueryMetrics) LogLine() string {
+	totalCost, costKnown, totalTokens := m.finalize()
+	var b strings.Builder
+	fmt.Fprintf(&b, "query_metrics op=%s latency_ms=%d tokens=%d", m.op, m.total.Milliseconds(), totalTokens)
+	if costKnown {
+		fmt.Fprintf(&b, " cost_usd=%.6f", roundUSD(totalCost))
+	} else {
+		b.WriteString(" cost_usd=unknown")
+	}
+	for _, stage := range m.order {
+		sm := m.stages[stage]
+		fmt.Fprintf(&b, " %s[%dms", stage, sm.LatencyMS)
+		if sm.TokensReported {
+			fmt.Fprintf(&b, ",tok=%d", sm.TotalTokens)
+		}
+		b.WriteString("]")
+	}
+	return b.String()
+}
+
+// roundUSD rounds to 6 decimal places (micro-dollar) for stable, readable
+// output without floating-point noise.
+func roundUSD(v float64) float64 {
+	return math.Round(v*1e6) / 1e6
+}

--- a/internal/usage/price.go
+++ b/internal/usage/price.go
@@ -1,0 +1,106 @@
+package usage
+
+import "strings"
+
+// ModelPrice is the per-1K-token USD price for a model. Either field may be
+// zero (e.g. embedding models have no output price). Prices are approximate
+// and operator-overridable; they exist for relative budgeting, not billing.
+type ModelPrice struct {
+	// InputPer1K is USD per 1,000 prompt/input tokens.
+	InputPer1K float64
+	// OutputPer1K is USD per 1,000 completion/output tokens.
+	OutputPer1K float64
+}
+
+// PriceTable maps a model name to its price. Lookup is case-insensitive and
+// trims surrounding whitespace. An unknown model yields ok=false so callers can
+// OMIT cost rather than fabricate a number (issue #327 requirement).
+type PriceTable struct {
+	prices map[string]ModelPrice
+}
+
+// DefaultPriceTable returns a built-in table with sensible approximate USD
+// prices (per 1K tokens) for common dir2mcp providers, current as of mid-2026.
+// These are starting points; operators override via config (NewPriceTable /
+// Merge). Unknown models are intentionally absent so their cost is omitted.
+func DefaultPriceTable() *PriceTable {
+	return &PriceTable{prices: map[string]ModelPrice{
+		// Mistral (chat)
+		"mistral-small-2506": {InputPer1K: 0.0001, OutputPer1K: 0.0003},
+		"mistral-small":      {InputPer1K: 0.0001, OutputPer1K: 0.0003},
+		"mistral-large":      {InputPer1K: 0.002, OutputPer1K: 0.006},
+		"mistral-medium":     {InputPer1K: 0.0004, OutputPer1K: 0.002},
+		// Mistral (embed)
+		"mistral-embed":   {InputPer1K: 0.0001},
+		"codestral-embed": {InputPer1K: 0.00015},
+		// OpenAI (chat)
+		"gpt-4o":      {InputPer1K: 0.0025, OutputPer1K: 0.01},
+		"gpt-4o-mini": {InputPer1K: 0.00015, OutputPer1K: 0.0006},
+		// OpenAI (embed)
+		"text-embedding-3-small": {InputPer1K: 0.00002},
+		"text-embedding-3-large": {InputPer1K: 0.00013},
+		// Gemini (chat)
+		"gemini-2.5-flash": {InputPer1K: 0.0003, OutputPer1K: 0.0025},
+		"gemini-2.5-pro":   {InputPer1K: 0.00125, OutputPer1K: 0.01},
+		// Gemini (embed)
+		"gemini-embedding-001": {InputPer1K: 0.00015},
+		// Cohere (rerank: priced per search, not tokens; left out so cost is
+		// omitted rather than mis-stated)
+		"command-r":      {InputPer1K: 0.00015, OutputPer1K: 0.0006},
+		"command-r-plus": {InputPer1K: 0.0025, OutputPer1K: 0.01},
+	}}
+}
+
+// NewPriceTable builds a table from the default table merged with operator
+// overrides. Override entries replace defaults by (case-insensitive) model
+// name; new entries are added. A nil/empty overrides map yields the defaults.
+func NewPriceTable(overrides map[string]ModelPrice) *PriceTable {
+	t := DefaultPriceTable()
+	t.Merge(overrides)
+	return t
+}
+
+// Merge applies operator overrides onto the table in place. Keys are
+// normalized (trimmed, lower-cased). Existing entries are replaced.
+func (t *PriceTable) Merge(overrides map[string]ModelPrice) {
+	if t == nil || len(overrides) == 0 {
+		return
+	}
+	if t.prices == nil {
+		t.prices = make(map[string]ModelPrice, len(overrides))
+	}
+	for name, p := range overrides {
+		key := normalizeModel(name)
+		if key == "" {
+			continue
+		}
+		t.prices[key] = p
+	}
+}
+
+// Lookup returns the price for model and whether it is known. Unknown models
+// return ok=false; callers MUST omit cost in that case.
+func (t *PriceTable) Lookup(model string) (ModelPrice, bool) {
+	if t == nil {
+		return ModelPrice{}, false
+	}
+	p, ok := t.prices[normalizeModel(model)]
+	return p, ok
+}
+
+// Cost returns the USD cost for the given token usage under model's price, and
+// whether a price was known. When the model is unknown, ok=false and cost is 0
+// (callers omit it). A known model with zero usage yields cost 0, ok=true.
+func (t *PriceTable) Cost(model string, u Usage) (float64, bool) {
+	p, ok := t.Lookup(model)
+	if !ok {
+		return 0, false
+	}
+	cost := (float64(u.PromptTokens)/1000.0)*p.InputPer1K +
+		(float64(u.CompletionTokens)/1000.0)*p.OutputPer1K
+	return cost, true
+}
+
+func normalizeModel(name string) string {
+	return strings.ToLower(strings.TrimSpace(name))
+}

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -12,6 +12,7 @@ package usage
 import (
 	"context"
 	"sync"
+	"time"
 )
 
 // Stage identifies one provider-backed phase of a query.
@@ -56,19 +57,54 @@ func (u *Usage) add(other Usage) {
 	u.Reported = true
 }
 
-// Sink is a thread-safe, per-query accumulator of provider token usage keyed
-// by stage. It is attached to a context so provider clients can report usage
-// without any change to the model interfaces. A nil Sink (the default) makes
-// Report a no-op, so providers behave exactly as before when observability is
-// not wired.
+// Sink is a thread-safe, per-query accumulator of provider token usage and
+// per-stage wall-clock latency, keyed by stage. It is attached to a context so
+// provider clients can report usage without any change to the model
+// interfaces, and so the retrieval service can record stage latency near each
+// provider call. A nil Sink (the default) makes all methods no-ops, so the
+// system behaves exactly as before when observability is not wired.
 type Sink struct {
-	mu      sync.Mutex
-	byStage map[Stage]Usage
+	mu        sync.Mutex
+	byStage   map[Stage]Usage
+	latencies map[Stage]time.Duration
 }
 
 // NewSink returns an empty Sink ready for concurrent use.
 func NewSink() *Sink {
-	return &Sink{byStage: make(map[Stage]Usage)}
+	return &Sink{
+		byStage:   make(map[Stage]Usage),
+		latencies: make(map[Stage]time.Duration),
+	}
+}
+
+// AddLatency accumulates wall-clock latency for a stage. Safe on a nil Sink.
+func (s *Sink) AddLatency(stage Stage, d time.Duration) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.latencies[stage] += d
+}
+
+// Latency returns the accumulated latency recorded for a stage.
+func (s *Sink) Latency(stage Stage) time.Duration {
+	if s == nil {
+		return 0
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.latencies[stage]
+}
+
+// TimeStage runs fn, recording its wall-clock duration against stage. The
+// stage is recorded even when fn returns an error so a failed provider call
+// still contributes latency. Safe on a nil Sink (fn still runs).
+func (s *Sink) TimeStage(stage Stage, fn func() error) error {
+	start := time.Now()
+	err := fn()
+	s.AddLatency(stage, time.Since(start))
+	return err
 }
 
 // Report records usage for a stage. Safe to call concurrently and on a nil
@@ -126,4 +162,11 @@ func SinkFrom(ctx context.Context) *Sink {
 // call sites a single line and inert when no sink is attached.
 func Report(ctx context.Context, stage Stage, u Usage) {
 	SinkFrom(ctx).Report(stage, u)
+}
+
+// TimeStage runs fn, recording its wall-clock duration against stage on the
+// Sink attached to ctx (if any). Inert (but still runs fn) when no sink is
+// attached.
+func TimeStage(ctx context.Context, stage Stage, fn func() error) error {
+	return SinkFrom(ctx).TimeStage(stage, fn)
 }

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -1,0 +1,129 @@
+// Package usage provides per-query cost and latency observability primitives
+// for dir2mcp (issue #327). It is purely additive: it never alters tool
+// results or provider behavior. Providers OPTIONALLY report token usage into a
+// context-attached Sink; the retrieval service times each stage, maps tokens
+// to an approximate USD cost via a configurable price table, and emits a
+// single structured `query_metrics` event.
+//
+// Privacy: this package records only counts, costs, and latency. It never
+// stores prompts, documents, queries, API keys, or any raw payload.
+package usage
+
+import (
+	"context"
+	"sync"
+)
+
+// Stage identifies one provider-backed phase of a query.
+type Stage string
+
+const (
+	// StageEmbed is query embedding (search + ask).
+	StageEmbed Stage = "embed"
+	// StageRerank is the optional cross-encoder rerank phase.
+	StageRerank Stage = "rerank"
+	// StageGenerate is RAG answer generation (ask only).
+	StageGenerate Stage = "generate"
+)
+
+// Usage holds token counts reported by a provider for a single call. A
+// provider that does not report usage contributes nothing (all zero). Counts
+// are additive across multiple calls within the same stage.
+type Usage struct {
+	// PromptTokens counts input/prompt tokens (a.k.a. input tokens).
+	PromptTokens int64
+	// CompletionTokens counts generated/output tokens. Always 0 for
+	// embed/rerank stages.
+	CompletionTokens int64
+	// TotalTokens is the provider-reported total when present; otherwise it is
+	// derived as PromptTokens+CompletionTokens by add.
+	TotalTokens int64
+	// Reported is true once at least one provider call reported usage for this
+	// stage. When false, token counts are unknown (not "zero cost").
+	Reported bool
+}
+
+// add merges other into u, deriving TotalTokens when a provider only reported
+// the prompt/completion split.
+func (u *Usage) add(other Usage) {
+	u.PromptTokens += other.PromptTokens
+	u.CompletionTokens += other.CompletionTokens
+	if other.TotalTokens > 0 {
+		u.TotalTokens += other.TotalTokens
+	} else {
+		u.TotalTokens += other.PromptTokens + other.CompletionTokens
+	}
+	u.Reported = true
+}
+
+// Sink is a thread-safe, per-query accumulator of provider token usage keyed
+// by stage. It is attached to a context so provider clients can report usage
+// without any change to the model interfaces. A nil Sink (the default) makes
+// Report a no-op, so providers behave exactly as before when observability is
+// not wired.
+type Sink struct {
+	mu      sync.Mutex
+	byStage map[Stage]Usage
+}
+
+// NewSink returns an empty Sink ready for concurrent use.
+func NewSink() *Sink {
+	return &Sink{byStage: make(map[Stage]Usage)}
+}
+
+// Report records usage for a stage. Safe to call concurrently and on a nil
+// Sink (no-op). Zero-valued usage is still recorded as "reported" so the
+// distinction between "provider reported 0 tokens" and "no usage available"
+// is preserved.
+func (s *Sink) Report(stage Stage, u Usage) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cur := s.byStage[stage]
+	cur.add(u)
+	s.byStage[stage] = cur
+}
+
+// Stage returns the accumulated usage for a stage and whether any provider
+// reported usage for it.
+func (s *Sink) Stage(stage Stage) (Usage, bool) {
+	if s == nil {
+		return Usage{}, false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	u, ok := s.byStage[stage]
+	return u, ok && u.Reported
+}
+
+type sinkKey struct{}
+
+// WithSink returns a context carrying sink so provider clients can report
+// usage for the in-flight query. Passing a nil sink returns ctx unchanged.
+func WithSink(ctx context.Context, sink *Sink) context.Context {
+	if sink == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, sinkKey{}, sink)
+}
+
+// SinkFrom extracts the Sink attached to ctx, or nil when none is present.
+// Provider clients call this; a nil result makes all reporting a no-op.
+func SinkFrom(ctx context.Context) *Sink {
+	if ctx == nil {
+		return nil
+	}
+	if s, ok := ctx.Value(sinkKey{}).(*Sink); ok {
+		return s
+	}
+	return nil
+}
+
+// Report is a convenience that extracts the Sink from ctx (if any) and records
+// usage for stage. It is the entry point provider clients use, keeping their
+// call sites a single line and inert when no sink is attached.
+func Report(ctx context.Context, stage Stage, u Usage) {
+	SinkFrom(ctx).Report(stage, u)
+}

--- a/internal/usage/wire.go
+++ b/internal/usage/wire.go
@@ -1,0 +1,63 @@
+package usage
+
+// OpenAIUsage mirrors the `usage` object returned by OpenAI-compatible APIs
+// (OpenAI, Mistral, Cohere v2, many local servers). Providers embed it in
+// their response structs and call ToUsage to feed a Sink. All fields are
+// optional; absent fields decode to 0.
+type OpenAIUsage struct {
+	PromptTokens     int64 `json:"prompt_tokens"`
+	CompletionTokens int64 `json:"completion_tokens"`
+	TotalTokens      int64 `json:"total_tokens"`
+	// InputTokens/OutputTokens are the newer field names some APIs use.
+	InputTokens  int64 `json:"input_tokens"`
+	OutputTokens int64 `json:"output_tokens"`
+}
+
+// Empty reports whether no token counts were present at all.
+func (u OpenAIUsage) Empty() bool {
+	return u.PromptTokens == 0 && u.CompletionTokens == 0 && u.TotalTokens == 0 &&
+		u.InputTokens == 0 && u.OutputTokens == 0
+}
+
+// ToUsage converts the wire shape into a Usage, normalizing the prompt/input
+// and completion/output aliases. Reported is set true so the caller records it
+// as "provider reported usage" even when the counts happen to be zero.
+func (u OpenAIUsage) ToUsage() Usage {
+	prompt := u.PromptTokens
+	if prompt == 0 {
+		prompt = u.InputTokens
+	}
+	completion := u.CompletionTokens
+	if completion == 0 {
+		completion = u.OutputTokens
+	}
+	return Usage{
+		PromptTokens:     prompt,
+		CompletionTokens: completion,
+		TotalTokens:      u.TotalTokens,
+		Reported:         true,
+	}
+}
+
+// GeminiUsage mirrors the `usageMetadata` object returned by the Gemini
+// generateContent API.
+type GeminiUsage struct {
+	PromptTokenCount     int64 `json:"promptTokenCount"`
+	CandidatesTokenCount int64 `json:"candidatesTokenCount"`
+	TotalTokenCount      int64 `json:"totalTokenCount"`
+}
+
+// Empty reports whether no token counts were present.
+func (u GeminiUsage) Empty() bool {
+	return u.PromptTokenCount == 0 && u.CandidatesTokenCount == 0 && u.TotalTokenCount == 0
+}
+
+// ToUsage converts Gemini's usageMetadata into a Usage.
+func (u GeminiUsage) ToUsage() Usage {
+	return Usage{
+		PromptTokens:     u.PromptTokenCount,
+		CompletionTokens: u.CandidatesTokenCount,
+		TotalTokens:      u.TotalTokenCount,
+		Reported:         true,
+	}
+}

--- a/tests/config/cost_price_config_test.go
+++ b/tests/config/cost_price_config_test.go
@@ -1,0 +1,43 @@
+package tests
+
+import (
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+)
+
+// TestCostPrices_DefaultEmpty verifies no overrides are present by default.
+func TestCostPrices_DefaultEmpty(t *testing.T) {
+	cfg := config.Default()
+	if len(cfg.CostPriceOverrides) != 0 {
+		t.Fatalf("cost price overrides must default to empty, got %v", cfg.CostPriceOverrides)
+	}
+}
+
+// TestCostPrices_YAMLRoundTrips pins the cost.prices block parsing for #327.
+func TestCostPrices_YAMLRoundTrips(t *testing.T) {
+	tmp := t.TempDir()
+	path := tmp + "/.dir2mcp.yaml"
+	writeFile(t, path, strings.Join([]string{
+		"cost:",
+		"  prices:",
+		"    my-chat-model:",
+		"      input_per_1k: 0.0005",
+		"      output_per_1k: 0.0015",
+		"",
+	}, "\n"))
+
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	p, ok := cfg.CostPriceOverrides["my-chat-model"]
+	if !ok {
+		t.Fatalf("expected cost override for my-chat-model, got %v", cfg.CostPriceOverrides)
+	}
+	if math.Abs(p.InputPer1K-0.0005) > 1e-12 || math.Abs(p.OutputPer1K-0.0015) > 1e-12 {
+		t.Fatalf("price mismatch: %+v", p)
+	}
+}

--- a/tests/mistral/client_usage_test.go
+++ b/tests/mistral/client_usage_test.go
@@ -1,0 +1,97 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/mistral"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/usage"
+)
+
+// TestGenerate_ReportsTokenUsage verifies the Mistral generate path parses the
+// OpenAI-style `usage` object and reports it into a context-attached sink.
+func TestGenerate_ReportsTokenUsage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{
+				{"message": map[string]any{"content": "hi"}},
+			},
+			"usage": map[string]any{
+				"prompt_tokens":     123,
+				"completion_tokens": 45,
+				"total_tokens":      168,
+			},
+		})
+	}))
+	defer server.Close()
+
+	sink := usage.NewSink()
+	ctx := usage.WithSink(context.Background(), sink)
+	client := mistral.NewClient(server.URL, "test-key")
+	if _, err := client.Generate(ctx, "prompt"); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	u, ok := sink.Stage(usage.StageGenerate)
+	if !ok {
+		t.Fatal("expected generate usage to be reported")
+	}
+	if u.PromptTokens != 123 || u.CompletionTokens != 45 || u.TotalTokens != 168 {
+		t.Fatalf("usage mismatch: %+v", u)
+	}
+}
+
+// TestEmbed_ReportsTokenUsage verifies the embed path reports prompt-token usage.
+func TestEmbed_ReportsTokenUsage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{
+				{"index": 0, "embedding": []float64{0.1, 0.2}},
+			},
+			"usage": map[string]any{"prompt_tokens": 7, "total_tokens": 7},
+		})
+	}))
+	defer server.Close()
+
+	sink := usage.NewSink()
+	ctx := usage.WithSink(context.Background(), sink)
+	client := mistral.NewClient(server.URL, "test-key")
+	if _, err := client.Embed(ctx, "mistral-embed", model.EmbedQuery, []string{"q"}); err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+
+	u, ok := sink.Stage(usage.StageEmbed)
+	if !ok {
+		t.Fatal("expected embed usage to be reported")
+	}
+	if u.PromptTokens != 7 {
+		t.Fatalf("embed prompt tokens=%d, want 7", u.PromptTokens)
+	}
+}
+
+// TestGenerate_NoUsageNoReport verifies that a response without a usage object
+// leaves the sink empty (unknown, not zero) and Generate still succeeds.
+func TestGenerate_NoUsageNoReport(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{
+				{"message": map[string]any{"content": "hi"}},
+			},
+		})
+	}))
+	defer server.Close()
+
+	sink := usage.NewSink()
+	ctx := usage.WithSink(context.Background(), sink)
+	client := mistral.NewClient(server.URL, "test-key")
+	if _, err := client.Generate(ctx, "prompt"); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if _, ok := sink.Stage(usage.StageGenerate); ok {
+		t.Fatal("no usage object => stage must remain unknown")
+	}
+}

--- a/tests/retrieval/query_metrics_test.go
+++ b/tests/retrieval/query_metrics_test.go
@@ -1,0 +1,209 @@
+package tests
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
+	"github.com/dirstral/dir2mcp/internal/usage"
+)
+
+// usageReportingEmbedder reports a fixed embed-stage token usage into the
+// context sink (mirroring a real provider) while returning deterministic
+// vectors so retrieval results stay stable.
+type usageReportingEmbedder struct {
+	*fakeRetrievalEmbedder
+	prompt int64
+}
+
+func (e *usageReportingEmbedder) Embed(ctx context.Context, modelName string, role model.EmbedRole, texts []string) ([][]float32, error) {
+	usage.Report(ctx, usage.StageEmbed, usage.Usage{PromptTokens: e.prompt, Reported: true})
+	return e.fakeRetrievalEmbedder.Embed(ctx, modelName, role, texts)
+}
+
+// usageReportingGenerator reports generate-stage token usage into the sink.
+type usageReportingGenerator struct {
+	out                   string
+	promptTok, completTok int64
+}
+
+func (g *usageReportingGenerator) Generate(ctx context.Context, _ string) (string, error) {
+	usage.Report(ctx, usage.StageGenerate, usage.Usage{
+		PromptTokens:     g.promptTok,
+		CompletionTokens: g.completTok,
+		Reported:         true,
+	})
+	return g.out, nil
+}
+
+type capturedEvent struct {
+	level string
+	event string
+	data  interface{}
+}
+
+type eventCapture struct {
+	mu     sync.Mutex
+	events []capturedEvent
+}
+
+func (c *eventCapture) emit(level, event string, data interface{}) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.events = append(c.events, capturedEvent{level, event, data})
+}
+
+func (c *eventCapture) queryMetrics() []map[string]interface{} {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var out []map[string]interface{}
+	for _, e := range c.events {
+		if e.event == "query_metrics" {
+			if m, ok := e.data.(map[string]interface{}); ok {
+				out = append(out, m)
+			}
+		}
+	}
+	return out
+}
+
+func metricsTestService(t *testing.T, gen model.Generator, cap *eventCapture) *retrieval.Service {
+	t.Helper()
+	idx := index.NewHNSWIndex("")
+	for id, vec := range map[uint64][]float32{1: {1, 0}, 2: {0.9, 0.1}, 3: {0.8, 0.2}} {
+		addVec(t, idx, id, vec)
+	}
+	emb := &usageReportingEmbedder{
+		fakeRetrievalEmbedder: &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+			"mistral-embed": {1, 0},
+		}},
+		prompt: 42,
+	}
+	svc := retrieval.NewService(nil, idx, emb, gen)
+	svc.SetChunkMetadata(1, model.SearchHit{ChunkID: 1, RelPath: "a.md", DocType: "md", Snippet: "alpha"})
+	svc.SetChunkMetadata(2, model.SearchHit{ChunkID: 2, RelPath: "b.md", DocType: "md", Snippet: "beta"})
+	svc.SetChunkMetadata(3, model.SearchHit{ChunkID: 3, RelPath: "c.md", DocType: "md", Snippet: "gamma"})
+	svc.SetGenerationModel("mistral-small-2506")
+	svc.SetMetricsEmitter(cap.emit, usage.DefaultPriceTable())
+	return svc
+}
+
+func TestQueryMetrics_SearchEmitsSingleEventWithFields(t *testing.T) {
+	cap := &eventCapture{}
+	svc := metricsTestService(t, nil, cap)
+
+	hits, err := svc.Search(context.Background(), model.SearchQuery{Query: "alpha", K: 3, Index: "text"})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(hits) == 0 {
+		t.Fatal("expected hits")
+	}
+
+	evs := cap.queryMetrics()
+	if len(evs) != 1 {
+		t.Fatalf("expected exactly 1 query_metrics event, got %d", len(evs))
+	}
+	ev := evs[0]
+	if ev["op"] != "search" {
+		t.Fatalf("op=%v, want search", ev["op"])
+	}
+	if _, ok := ev["latency_ms"].(int64); !ok {
+		t.Fatalf("latency_ms missing/wrong type: %v", ev["latency_ms"])
+	}
+	if ev["total_tokens"].(int64) != 42 {
+		t.Fatalf("total_tokens=%v, want 42 (embed)", ev["total_tokens"])
+	}
+	stages, ok := ev["stages"].(map[string]interface{})
+	if !ok || stages["embed"] == nil {
+		t.Fatalf("expected embed stage breakdown, got %v", ev["stages"])
+	}
+}
+
+func TestQueryMetrics_AskEmitsSingleEventNotTwo(t *testing.T) {
+	cap := &eventCapture{}
+	gen := &usageReportingGenerator{out: "answer [a.md]", promptTok: 200, completTok: 80}
+	svc := metricsTestService(t, gen, cap)
+
+	res, err := svc.Ask(context.Background(), "what is alpha?", model.SearchQuery{Query: "alpha", K: 3, Index: "text"})
+	if err != nil {
+		t.Fatalf("Ask: %v", err)
+	}
+	if res.Answer == "" {
+		t.Fatal("expected an answer")
+	}
+
+	evs := cap.queryMetrics()
+	if len(evs) != 1 {
+		t.Fatalf("ask must emit exactly 1 query_metrics event (no nested search event), got %d", len(evs))
+	}
+	ev := evs[0]
+	if ev["op"] != "ask" {
+		t.Fatalf("op=%v, want ask", ev["op"])
+	}
+	// embed(42) + generate(200+80) = 322
+	if ev["total_tokens"].(int64) != 322 {
+		t.Fatalf("total_tokens=%v, want 322", ev["total_tokens"])
+	}
+	cost, ok := ev["cost_usd"].(float64)
+	if !ok {
+		t.Fatalf("cost_usd should be present (mistral-embed + mistral-small-2506 priced): %v", ev["cost_usd"])
+	}
+	if cost <= 0 {
+		t.Fatalf("cost_usd should be positive, got %v", cost)
+	}
+}
+
+func TestQueryMetrics_ResultsUnchangedWithMetrics(t *testing.T) {
+	// Same service/query with and without the metrics emitter must produce
+	// identical hits: observability is additive and must not alter results.
+	build := func(withMetrics bool) []model.SearchHit {
+		idx := index.NewHNSWIndex("")
+		for id, vec := range map[uint64][]float32{1: {1, 0}, 2: {0.9, 0.1}, 3: {0.8, 0.2}} {
+			addVec(t, idx, id, vec)
+		}
+		svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+			"mistral-embed": {1, 0},
+		}}, nil)
+		svc.SetChunkMetadata(1, model.SearchHit{ChunkID: 1, RelPath: "a.md", DocType: "md", Snippet: "alpha"})
+		svc.SetChunkMetadata(2, model.SearchHit{ChunkID: 2, RelPath: "b.md", DocType: "md", Snippet: "beta"})
+		svc.SetChunkMetadata(3, model.SearchHit{ChunkID: 3, RelPath: "c.md", DocType: "md", Snippet: "gamma"})
+		if withMetrics {
+			svc.SetMetricsEmitter((&eventCapture{}).emit, usage.DefaultPriceTable())
+		}
+		hits, err := svc.Search(context.Background(), model.SearchQuery{Query: "alpha", K: 3, Index: "text"})
+		if err != nil {
+			t.Fatalf("Search: %v", err)
+		}
+		return hits
+	}
+
+	with := build(true)
+	without := build(false)
+	if len(with) != len(without) {
+		t.Fatalf("hit count differs: with=%d without=%d", len(with), len(without))
+	}
+	for i := range with {
+		if with[i].ChunkID != without[i].ChunkID || with[i].Score != without[i].Score {
+			t.Fatalf("hit %d differs: with=%+v without=%+v", i, with[i], without[i])
+		}
+	}
+}
+
+func TestQueryMetrics_DisabledEmitsNothing(t *testing.T) {
+	idx := index.NewHNSWIndex("")
+	addVec(t, idx, 1, []float32{1, 0})
+	svc := retrieval.NewService(nil, idx, &usageReportingEmbedder{
+		fakeRetrievalEmbedder: &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{"mistral-embed": {1, 0}}},
+		prompt:                42,
+	}, nil)
+	svc.SetChunkMetadata(1, model.SearchHit{ChunkID: 1, RelPath: "a.md", DocType: "md", Snippet: "alpha"})
+	// No SetMetricsEmitter call: metrics disabled.
+	if _, err := svc.Search(context.Background(), model.SearchQuery{Query: "alpha", K: 1, Index: "text"}); err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	// Nothing to assert beyond no panic / no emitter invoked; reaching here is success.
+}

--- a/tests/usage/metrics_test.go
+++ b/tests/usage/metrics_test.go
@@ -1,0 +1,126 @@
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/usage"
+)
+
+func TestSink_ReportAndStage(t *testing.T) {
+	s := usage.NewSink()
+	s.Report(usage.StageGenerate, usage.Usage{PromptTokens: 100, CompletionTokens: 50, Reported: true})
+	s.Report(usage.StageGenerate, usage.Usage{PromptTokens: 10, CompletionTokens: 5, Reported: true})
+
+	u, ok := s.Stage(usage.StageGenerate)
+	if !ok {
+		t.Fatal("expected generate usage to be reported")
+	}
+	if u.PromptTokens != 110 || u.CompletionTokens != 55 {
+		t.Fatalf("accumulation wrong: %+v", u)
+	}
+	if u.TotalTokens != 165 {
+		t.Fatalf("derived total wrong: %d, want 165", u.TotalTokens)
+	}
+}
+
+func TestSink_UnreportedStage(t *testing.T) {
+	s := usage.NewSink()
+	if _, ok := s.Stage(usage.StageEmbed); ok {
+		t.Fatal("stage with no report must be unknown (ok=false)")
+	}
+}
+
+func TestSink_NilIsNoOp(t *testing.T) {
+	var s *usage.Sink
+	s.Report(usage.StageEmbed, usage.Usage{PromptTokens: 1})
+	s.AddLatency(usage.StageEmbed, time.Second)
+	if _, ok := s.Stage(usage.StageEmbed); ok {
+		t.Fatal("nil sink must report nothing")
+	}
+}
+
+func TestSink_ContextRoundTrip(t *testing.T) {
+	s := usage.NewSink()
+	ctx := usage.WithSink(context.Background(), s)
+	usage.Report(ctx, usage.StageEmbed, usage.Usage{PromptTokens: 7, Reported: true})
+	u, ok := s.Stage(usage.StageEmbed)
+	if !ok || u.PromptTokens != 7 {
+		t.Fatalf("context-attached report failed: ok=%v %+v", ok, u)
+	}
+}
+
+func TestSink_TimeStageRecordsLatency(t *testing.T) {
+	s := usage.NewSink()
+	err := s.TimeStage(usage.StageRerank, func() error {
+		time.Sleep(2 * time.Millisecond)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if s.Latency(usage.StageRerank) <= 0 {
+		t.Fatal("expected positive recorded latency")
+	}
+}
+
+func TestQueryMetrics_EventKnownModelHasCost(t *testing.T) {
+	pt := usage.NewPriceTable(map[string]usage.ModelPrice{
+		"chat-x": {InputPer1K: 0.001, OutputPer1K: 0.002},
+	})
+	qm := usage.NewQueryMetrics("ask", pt)
+	qm.RecordStage(usage.StageGenerate, "chat-x", 30*time.Millisecond,
+		usage.Usage{PromptTokens: 1000, CompletionTokens: 500}, true)
+	qm.SetTotalLatency(50 * time.Millisecond)
+
+	ev := qm.Event()
+	if ev["op"] != "ask" {
+		t.Fatalf("op=%v, want ask", ev["op"])
+	}
+	if ev["latency_ms"].(int64) != 50 {
+		t.Fatalf("latency_ms=%v, want 50", ev["latency_ms"])
+	}
+	if ev["total_tokens"].(int64) != 1500 {
+		t.Fatalf("total_tokens=%v, want 1500", ev["total_tokens"])
+	}
+	cost, ok := ev["cost_usd"].(float64)
+	if !ok {
+		t.Fatalf("cost_usd missing for known model: %v", ev["cost_usd"])
+	}
+	if !approxEqual(cost, 0.002) {
+		t.Fatalf("cost_usd=%v, want 0.002", cost)
+	}
+	stages, ok := ev["stages"].(map[string]interface{})
+	if !ok || stages["generate"] == nil {
+		t.Fatalf("expected generate stage breakdown, got %v", ev["stages"])
+	}
+}
+
+func TestQueryMetrics_EventUnknownModelOmitsCost(t *testing.T) {
+	qm := usage.NewQueryMetrics("ask", usage.DefaultPriceTable())
+	qm.RecordStage(usage.StageGenerate, "unknown-model-zzz", 10*time.Millisecond,
+		usage.Usage{PromptTokens: 1000, CompletionTokens: 1000}, true)
+	ev := qm.Event()
+	if _, present := ev["cost_usd"]; present {
+		t.Fatalf("cost_usd must be omitted for unknown model, got %v", ev["cost_usd"])
+	}
+	// tokens and latency must still be present.
+	if ev["total_tokens"].(int64) != 2000 {
+		t.Fatalf("total_tokens=%v, want 2000", ev["total_tokens"])
+	}
+}
+
+func TestQueryMetrics_LatencyOnlyStageNoTokens(t *testing.T) {
+	qm := usage.NewQueryMetrics("search", usage.DefaultPriceTable())
+	// rerank stage with latency but no reported tokens (e.g. Cohere rerank).
+	qm.RecordStage(usage.StageRerank, "rerank-v3", 5*time.Millisecond, usage.Usage{}, false)
+	qm.SetTotalLatency(8 * time.Millisecond)
+	ev := qm.Event()
+	if ev["total_tokens"].(int64) != 0 {
+		t.Fatalf("expected 0 tokens, got %v", ev["total_tokens"])
+	}
+	if _, present := ev["cost_usd"]; present {
+		t.Fatal("no priced tokens => cost_usd omitted")
+	}
+}

--- a/tests/usage/price_test.go
+++ b/tests/usage/price_test.go
@@ -1,0 +1,76 @@
+package tests
+
+import (
+	"math"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/usage"
+)
+
+func approxEqual(a, b float64) bool {
+	return math.Abs(a-b) < 1e-9
+}
+
+func TestPriceTable_KnownModelCost(t *testing.T) {
+	pt := usage.NewPriceTable(map[string]usage.ModelPrice{
+		"test-chat": {InputPer1K: 0.001, OutputPer1K: 0.002},
+	})
+	cost, ok := pt.Cost("test-chat", usage.Usage{PromptTokens: 1000, CompletionTokens: 500})
+	if !ok {
+		t.Fatal("expected known model to yield a cost")
+	}
+	// 1000/1000*0.001 + 500/1000*0.002 = 0.001 + 0.001 = 0.002
+	if !approxEqual(cost, 0.002) {
+		t.Fatalf("cost=%v, want 0.002", cost)
+	}
+}
+
+func TestPriceTable_UnknownModelOmitsCost(t *testing.T) {
+	pt := usage.DefaultPriceTable()
+	cost, ok := pt.Cost("totally-made-up-model-xyz", usage.Usage{PromptTokens: 9999, CompletionTokens: 9999})
+	if ok {
+		t.Fatalf("unknown model must omit cost, got ok=true cost=%v", cost)
+	}
+	if cost != 0 {
+		t.Fatalf("unknown-model cost must be 0 (omitted), got %v", cost)
+	}
+}
+
+func TestPriceTable_CaseInsensitiveLookup(t *testing.T) {
+	pt := usage.NewPriceTable(map[string]usage.ModelPrice{
+		"  Mixed-Case-Model ": {InputPer1K: 0.01},
+	})
+	if _, ok := pt.Lookup("mixed-case-model"); !ok {
+		t.Fatal("lookup should be case-insensitive and whitespace-trimmed")
+	}
+}
+
+func TestPriceTable_OverridesReplaceDefaults(t *testing.T) {
+	// mistral-small-2506 exists in the default table; override it.
+	pt := usage.NewPriceTable(map[string]usage.ModelPrice{
+		"mistral-small-2506": {InputPer1K: 1.0, OutputPer1K: 1.0},
+	})
+	cost, ok := pt.Cost("mistral-small-2506", usage.Usage{PromptTokens: 1000})
+	if !ok {
+		t.Fatal("expected overridden model to be priced")
+	}
+	if !approxEqual(cost, 1.0) {
+		t.Fatalf("override not applied: cost=%v, want 1.0", cost)
+	}
+}
+
+func TestPriceTable_DefaultsCoverCommonModels(t *testing.T) {
+	pt := usage.DefaultPriceTable()
+	for _, m := range []string{"mistral-small-2506", "mistral-embed", "gpt-4o-mini", "gemini-2.5-flash"} {
+		if _, ok := pt.Lookup(m); !ok {
+			t.Errorf("default table missing common model %q", m)
+		}
+	}
+}
+
+func TestPriceTable_NilTableOmitsCost(t *testing.T) {
+	var pt *usage.PriceTable
+	if _, ok := pt.Cost("mistral-small-2506", usage.Usage{PromptTokens: 1000}); ok {
+		t.Fatal("nil price table must omit cost")
+	}
+}


### PR DESCRIPTION
## Summary

Adds per-query cost and latency observability for `ask` and `search` across all providers (Mistral/OpenAI/Gemini/Cohere). Closes #327.

Each query now accumulates **token usage** (where the provider reports it) and **wall-clock latency** for the embed / rerank / generate stages, maps tokens to an approximate USD cost via a configurable per-model price table, and emits a single structured `query_metrics` NDJSON event plus a concise log line.

**Additive and ungated** (per the issue): always-on, never changes tool results, citations, or any MCP tool input/output schema. A spec'd response field is the deferred follow-up.

## What was added

- **`internal/usage`** — the observability core:
  - `Sink`: a context-attached, thread-safe per-query accumulator of token usage + per-stage latency. Inert (no-op) when no sink is in context, so providers behave exactly as before.
  - `PriceTable`: per-model USD prices (per 1K tokens) with built-in defaults; **unknown models omit cost** rather than fabricate one. Overridable via config.
  - `QueryMetrics`: renders the `query_metrics` event and the log line. Counts/costs/latency only — never prompts, documents, or keys.
- **Provider usage parsing** — embed/generate (and Cohere chat) responses now parse the provider `usage` object and report it into the context sink. Inert without a sink.
- **`internal/retrieval`** — `Ask`/`Search` install a per-query sink, time each stage, and emit one event. `Ask` owns the sink so a nested search does not double-emit.
- **CLI wiring** — `up` emits to the stdout NDJSON stream; `ask` emits to stderr (to keep result output clean). Optional `cost.prices:` config block overrides default prices.

## Provider token-usage coverage

| Provider | embed | generate | rerank |
|---|---|---|---|
| Mistral | yes (`usage`) | yes (`usage`) | n/a |
| OpenAI | yes (`usage`) | yes (`usage`) | n/a |
| Gemini | no (native batch-embed has no usage) | yes (OpenAI-compat `usage`) | n/a |
| Cohere | — | yes (nested `usage.tokens`) | no token usage upstream (latency only) |

Where usage is unavailable, the stage records **latency only** and cost is omitted (never zeroed/fabricated).

## Event schema (`query_metrics`)

```json
{
  "op": "ask",
  "latency_ms": 812,
  "total_tokens": 1532,
  "cost_usd": 0.000412,
  "stages": {
    "embed":    {"latency_ms": 41, "model": "mistral-embed", "prompt_tokens": 42, "total_tokens": 42, "tokens_reported": true, "cost_usd": 0.000004},
    "rerank":   {"latency_ms": 120, "model": "rerank-v3", "tokens_reported": false},
    "generate": {"latency_ms": 650, "model": "mistral-small-2506", "prompt_tokens": 1200, "completion_tokens": 290, "total_tokens": 1490, "tokens_reported": true, "cost_usd": 0.000408}
  }
}
```

`cost_usd` (per-stage and total) is **omitted entirely** when no priced model contributed.

## Tests

- `tests/usage`: price mapping incl. unknown-model omission, case-insensitivity, overrides, nil-table; Sink accumulation / context round-trip / `TimeStage`; event shape (cost present/omitted, tokens, stage breakdown).
- `tests/retrieval`: search emits exactly one event; ask emits exactly one (no nested double-emit); results identical with/without metrics; disabled emits nothing.
- `tests/mistral`: embed + generate parse and report usage; missing `usage` leaves the stage unknown.
- `tests/config`: `cost.prices` block parses into overrides.

`make check` is fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)