### PR TITLE
retrieval: opt-in HyDE query transform (#333)

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,6 +607,23 @@ An optional **recency time-decay** boosts newer content for dated corpora (news,
     recency_half_life: 0   # 0/empty disables; e.g. 720h halves a 30-day-old hit's score
   ```
 
+### HyDE query transform (optional)
+
+**HyDE** (Hypothetical Document Embeddings) generates a short hypothetical answer to the query, embeds *that*, and retrieves with it — often improving recall for terse or keyword-style queries by closing the query↔document style gap. It is **server-side and config-only** (not an MCP tool parameter), so it changes no tool input/output schema.
+
+- **Default off**: behavior is unchanged unless you enable it. Enabling it adds one generation call per search to produce the hypothetical answer.
+- **Graceful degradation**: a generation failure (or no configured generator) falls back to the raw query — HyDE is an optimization, never a hard dependency.
+- **Modes**:
+  - `fuse` (default): RRF-fuses the hypothetical-document hits with the raw-query hits.
+  - `replace`: retrieves with the hypothetical-document embedding alone.
+
+  ```yaml
+  retrieval:
+    hyde:
+      enabled: false   # set true to opt in
+      mode: fuse       # fuse (default) | replace
+  ```
+
 ### Auth token behavior
 
 `dir2mcp` bearer auth can come from:

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -826,6 +826,7 @@ func (a *App) buildRetrieverForAsk(ctx context.Context, cfg config.Config, st mo
 	ret.SetContextCompression(cfg.ContextCompressionEnabled, cfg.ContextCompressionTargetRatio)
 	ret.SetAdaptiveRetrieval(cfg.RetrievalAdaptiveEnabled, cfg.RetrievalAdaptiveKMin, cfg.RetrievalAdaptiveKMax)
 	ret.SetMMR(cfg.RetrievalMMREnabled, cfg.RetrievalMMRLambda)
+	ret.SetHyDE(cfg.RetrievalHyDEEnabled, cfg.RetrievalHyDEMode)
 
 	if metadataStore, ok := st.(embeddedChunkLister); ok {
 		if _, err := preloadEmbeddedChunkMetadata(ctx, metadataStore, ret); err != nil && !errors.Is(err, model.ErrNotImplemented) {

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -83,6 +83,7 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 	ret.SetContextCompression(cfg.ContextCompressionEnabled, cfg.ContextCompressionTargetRatio)
 	ret.SetAdaptiveRetrieval(cfg.RetrievalAdaptiveEnabled, cfg.RetrievalAdaptiveKMin, cfg.RetrievalAdaptiveKMax)
 	ret.SetMMR(cfg.RetrievalMMREnabled, cfg.RetrievalMMRLambda)
+	ret.SetHyDE(cfg.RetrievalHyDEEnabled, cfg.RetrievalHyDEMode)
 
 	// events are emitted to stdout only after we create the emitter; moving
 	// creation before the preload call lets us report failures from that

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3550,7 +3550,7 @@ func (c *Config) validateRetrievalNumericBounds() error {
 		math.IsNaN(c.RetrievalMMRLambda) || math.IsInf(c.RetrievalMMRLambda, 0) {
 		return fmt.Errorf("retrieval.mmr.lambda must be within [0,1]: %v", c.RetrievalMMRLambda)
 	}
-	if err := c.validateHyDEMode(); err != nil {
+	if err := c.normalizeHyDEMode(); err != nil {
 		return err
 	}
 	if err := c.validateAdaptiveBounds(); err != nil {
@@ -3559,12 +3559,14 @@ func (c *Config) validateRetrievalNumericBounds() error {
 	return nil
 }
 
-// validateHyDEMode normalizes retrieval.hyde.mode (empty ⇒ "fuse") and rejects
-// any value other than "fuse"/"replace" so a typo fails at config time
-// (explicit, deterministic) rather than silently behaving like "fuse" at query
-// time. It runs regardless of RetrievalHyDEEnabled so a stale/misspelled mode is
-// caught even when HyDE is currently off.
-func (c *Config) validateHyDEMode() error {
+// normalizeHyDEMode normalizes retrieval.hyde.mode in place: empty becomes
+// "fuse" (the default) and a recognized value is lowercased; any other value is
+// CONFIG_INVALID so a typo fails at config time (explicit, deterministic) rather
+// than silently behaving like "fuse" at query time. It runs regardless of
+// RetrievalHyDEEnabled so a stale/misspelled mode is caught even when HyDE is
+// currently off. Extracted to keep validateRetrievalNumericBounds under the
+// cyclomatic budget.
+func (c *Config) normalizeHyDEMode() error {
 	switch mode := strings.ToLower(strings.TrimSpace(c.RetrievalHyDEMode)); mode {
 	case "":
 		c.RetrievalHyDEMode = HyDEModeFuse

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,15 @@ import (
 
 const DefaultProtocolVersion = "2025-11-25"
 
+// HyDE (Hypothetical Document Embeddings) query-transform modes
+// (config `retrieval.hyde.mode`). HyDEModeFuse RRF-fuses the
+// hypothetical-document hits with the raw-query hits; HyDEModeReplace uses the
+// hypothetical-document embedding alone. HyDEModeFuse is the default.
+const (
+	HyDEModeFuse    = "fuse"
+	HyDEModeReplace = "replace"
+)
+
 const EffectiveConfigSnapshotFile = ".dir2mcp.yaml.snapshot"
 
 // DefaultMediaClipMaxDurationMS / DefaultMediaClipMaxBytes are the built-in
@@ -287,6 +296,21 @@ type Config struct {
 	// is only consulted when RetrievalMMREnabled is true. Values outside [0,1]
 	// (or NaN/Inf) are CONFIG_INVALID.
 	RetrievalMMRLambda float64
+	// RetrievalHyDEEnabled toggles the opt-in HyDE (Hypothetical Document
+	// Embeddings) query transform (config `retrieval.hyde.enabled`). When true,
+	// Search generates a short hypothetical answer to the query via the
+	// configured generator, embeds that text, and retrieves with it. It is
+	// config-only (NOT an MCP tool parameter) so no tool input/output schema
+	// changes. Default false ⇒ unchanged behavior (raw query only). A generation
+	// failure degrades gracefully back to the raw query (never fatal). See
+	// Gao et al., "Precise Zero-Shot Dense Retrieval without Relevance Labels".
+	RetrievalHyDEEnabled bool
+	// RetrievalHyDEMode selects how the HyDE-variant results combine with the
+	// raw-query results (config `retrieval.hyde.mode`): "fuse" (default) RRF-fuses
+	// the hypothetical-document hits with the raw-query hits; "replace" uses the
+	// hypothetical-document embedding alone. Ignored when RetrievalHyDEEnabled is
+	// false. An empty value normalizes to "fuse".
+	RetrievalHyDEMode string
 	// Rerank* configure the optional post-fusion rerank stage (SPEC
 	// 9.1.1). Reranking auto-activates when a provider credential is
 	// present. CohereAPIKey is a secret: env-sourced, never persisted
@@ -600,6 +624,8 @@ type fileConfig struct {
 	RetrievalAdaptiveKMax              *int
 	RetrievalMMREnabled                *bool
 	RetrievalMMRLambda                 *float64
+	RetrievalHyDEEnabled               *bool
+	RetrievalHyDEMode                  *string
 	RerankEnabled                      *bool
 	RerankProvider                     *string
 	CohereAPIKey                       *string
@@ -725,6 +751,8 @@ type persistedConfig struct {
 	RetrievalAdaptiveKMax              int           `yaml:"retrieval_adaptive_k_max"`
 	RetrievalMMREnabled                bool          `yaml:"retrieval_mmr_enabled"`
 	RetrievalMMRLambda                 float64       `yaml:"retrieval_mmr_lambda"`
+	RetrievalHyDEEnabled               bool          `yaml:"retrieval_hyde_enabled"`
+	RetrievalHyDEMode                  string        `yaml:"retrieval_hyde_mode"`
 	RerankEnabled                      bool          `yaml:"rerank_enabled"`
 	RerankProvider                     string        `yaml:"rerank_provider"`
 	CohereBaseURL                      string        `yaml:"cohere_base_url"`
@@ -906,6 +934,12 @@ func Default() Config {
 		// default so an enabled-but-unspecified config behaves predictably.
 		RetrievalMMREnabled: false,
 		RetrievalMMRLambda:  0.5,
+		// RetrievalHyDEEnabled defaults to false: the HyDE query transform is
+		// off unless explicitly enabled, so default behavior is unchanged.
+		RetrievalHyDEEnabled: false,
+		// RetrievalHyDEMode defaults to "fuse": when HyDE is enabled the
+		// hypothetical-document hits are RRF-fused with the raw-query hits.
+		RetrievalHyDEMode: HyDEModeFuse,
 		// RerankEnabled left nil: auto mode (activates iff a rerank
 		// provider credential is present). See rerankEnabledEffective.
 		RerankProvider:            "cohere",
@@ -1029,6 +1063,8 @@ func buildPersistedConfig(cfg *Config) persistedConfig {
 		RetrievalAdaptiveKMax:              cfg.RetrievalAdaptiveKMax,
 		RetrievalMMREnabled:                cfg.RetrievalMMREnabled,
 		RetrievalMMRLambda:                 cfg.RetrievalMMRLambda,
+		RetrievalHyDEEnabled:               cfg.RetrievalHyDEEnabled,
+		RetrievalHyDEMode:                  cfg.RetrievalHyDEMode,
 		RerankEnabled:                      rerankEnabledEffective(cfg),
 		RerankProvider:                     cfg.RerankProvider,
 		CohereBaseURL:                      cfg.CohereBaseURL,
@@ -1645,9 +1681,9 @@ func applyModelRAGFileParsed(cfg *Config, fc fileConfig) {
 
 // applyRetrievalTuningFileParsed overlays the opt-in retrieval-tuning file
 // fields (recency time-decay #323, context compression #335, the adaptive
-// gate #338, and MMR diversity #340) onto cfg. Split out of
-// applyModelRAGFileParsed to keep that function within the gocyclo budget as
-// tuning knobs are added.
+// gate #338, MMR diversity #340, and the HyDE query transform #333) onto cfg.
+// Split out of applyModelRAGFileParsed to keep that function within the gocyclo
+// budget as tuning knobs are added.
 func applyRetrievalTuningFileParsed(cfg *Config, fc fileConfig) {
 	if fc.RetrievalRecencyHalfLife != nil {
 		cfg.RetrievalRecencyHalfLife = *fc.RetrievalRecencyHalfLife
@@ -1672,6 +1708,12 @@ func applyRetrievalTuningFileParsed(cfg *Config, fc fileConfig) {
 	}
 	if fc.RetrievalMMRLambda != nil {
 		cfg.RetrievalMMRLambda = *fc.RetrievalMMRLambda
+	}
+	if fc.RetrievalHyDEEnabled != nil {
+		cfg.RetrievalHyDEEnabled = *fc.RetrievalHyDEEnabled
+	}
+	if fc.RetrievalHyDEMode != nil {
+		cfg.RetrievalHyDEMode = *fc.RetrievalHyDEMode
 	}
 }
 
@@ -2092,6 +2134,10 @@ var configKeyAliases = map[string]string{
 	"mmr_enabled":                             "retrieval.mmr.enabled",
 	"retrieval_mmr_lambda":                    "retrieval.mmr.lambda",
 	"mmr_lambda":                              "retrieval.mmr.lambda",
+	"retrieval_hyde_enabled":                  "retrieval.hyde.enabled",
+	"hyde_enabled":                            "retrieval.hyde.enabled",
+	"retrieval_hyde_mode":                     "retrieval.hyde.mode",
+	"hyde_mode":                               "retrieval.hyde.mode",
 	"rerank_enabled":                          "rerank.enabled",
 	"rerank.cohere.api_key":                   "cohere_api_key",
 	"rerank.cohere.base_url":                  "cohere_base_url",
@@ -2201,7 +2247,7 @@ func canonicalizeConfigKey(key string) string {
 // (so child keys should be prefixed) rather than a scalar/list key.
 func isMapSectionKey(key string) bool {
 	switch key {
-	case "rag", "ingest", "ingest.docling", "stt", "stt.mistral", "stt.elevenlabs", "server", "server.tls", "secret_sources", "mistral", "docling", "security", "security.auth", "x402", "x402.route_policy", "x402.route_policy.tools_call", "chunking", "retrieval", "retrieval.hybrid", "retrieval.context_compression", "retrieval.adaptive", "retrieval.mmr", "rerank", "rerank.cohere", "index", "dedup":
+	case "rag", "ingest", "ingest.docling", "stt", "stt.mistral", "stt.elevenlabs", "server", "server.tls", "secret_sources", "mistral", "docling", "security", "security.auth", "x402", "x402.route_policy", "x402.route_policy.tools_call", "chunking", "retrieval", "retrieval.hybrid", "retrieval.context_compression", "retrieval.adaptive", "retrieval.mmr", "retrieval.hyde", "rerank", "rerank.cohere", "index", "dedup":
 		return true
 	case "ingest.pdf", "ingest.images", "ingest.audio", "ingest.archives", "secrets", "index.qdrant":
 		return true
@@ -2278,6 +2324,7 @@ var boolFileScalarTargets = map[string]func(*fileConfig) **bool{
 	"retrieval.hybrid.enabled":   func(c *fileConfig) **bool { return &c.RetrievalHybridEnabled },
 	"retrieval.adaptive.enabled": func(c *fileConfig) **bool { return &c.RetrievalAdaptiveEnabled },
 	"retrieval.mmr.enabled":      func(c *fileConfig) **bool { return &c.RetrievalMMREnabled },
+	"retrieval.hyde.enabled":     func(c *fileConfig) **bool { return &c.RetrievalHyDEEnabled },
 	"dedup.retrieval":            func(c *fileConfig) **bool { return &c.DedupRetrieval },
 	"retrieval.context_compression.enabled": func(c *fileConfig) **bool {
 		return &c.ContextCompressionEnabled
@@ -2529,6 +2576,8 @@ func setModelStringFileScalar(cfg *fileConfig, key, value string) {
 		cfg.RAGSystemPrompt = strPtr(value)
 	case "chunking.strategy":
 		cfg.ChunkingStrategy = strPtr(value)
+	case "retrieval.hyde.mode":
+		cfg.RetrievalHyDEMode = strPtr(value)
 	}
 }
 
@@ -2700,6 +2749,8 @@ func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	writeInt("retrieval_adaptive_k_max", cfg.RetrievalAdaptiveKMax)
 	writeBool("retrieval_mmr_enabled", cfg.RetrievalMMREnabled)
 	writeScalar("retrieval_mmr_lambda", strconv.FormatFloat(cfg.RetrievalMMRLambda, 'f', -1, 64))
+	writeBool("retrieval_hyde_enabled", cfg.RetrievalHyDEEnabled)
+	writeScalar("retrieval_hyde_mode", cfg.RetrievalHyDEMode)
 	writeBool("rerank_enabled", cfg.RerankEnabled)
 	writeScalar("rerank_provider", cfg.RerankProvider)
 	writeScalar("cohere_base_url", cfg.CohereBaseURL)
@@ -3499,8 +3550,28 @@ func (c *Config) validateRetrievalNumericBounds() error {
 		math.IsNaN(c.RetrievalMMRLambda) || math.IsInf(c.RetrievalMMRLambda, 0) {
 		return fmt.Errorf("retrieval.mmr.lambda must be within [0,1]: %v", c.RetrievalMMRLambda)
 	}
+	if err := c.validateHyDEMode(); err != nil {
+		return err
+	}
 	if err := c.validateAdaptiveBounds(); err != nil {
 		return err
+	}
+	return nil
+}
+
+// validateHyDEMode normalizes retrieval.hyde.mode (empty ⇒ "fuse") and rejects
+// any value other than "fuse"/"replace" so a typo fails at config time
+// (explicit, deterministic) rather than silently behaving like "fuse" at query
+// time. It runs regardless of RetrievalHyDEEnabled so a stale/misspelled mode is
+// caught even when HyDE is currently off.
+func (c *Config) validateHyDEMode() error {
+	switch mode := strings.ToLower(strings.TrimSpace(c.RetrievalHyDEMode)); mode {
+	case "":
+		c.RetrievalHyDEMode = HyDEModeFuse
+	case HyDEModeFuse, HyDEModeReplace:
+		c.RetrievalHyDEMode = mode
+	default:
+		return fmt.Errorf("retrieval.hyde.mode must be one of %q, %q: %q", HyDEModeFuse, HyDEModeReplace, c.RetrievalHyDEMode)
 	}
 	return nil
 }

--- a/internal/retrieval/hyde.go
+++ b/internal/retrieval/hyde.go
@@ -1,0 +1,50 @@
+package retrieval
+
+import "strings"
+
+// HyDE (Hypothetical Document Embeddings) query-transform modes. These mirror
+// the config values config.HyDEModeFuse / config.HyDEModeReplace; the retrieval
+// package keeps its own copies so it does not import the config package.
+//
+//   - hydeModeFuse:    RRF-fuse the hypothetical-document hits with the
+//     raw-query hits (the default; improves recall while keeping the raw
+//     query's precision).
+//   - hydeModeReplace: retrieve with the hypothetical-document embedding alone.
+const (
+	hydeModeFuse    = "fuse"
+	hydeModeReplace = "replace"
+)
+
+// hydeMaxAnswerChars bounds the hypothetical answer used for retrieval. A short
+// passage is enough to close the query↔document style gap (HyDE, Gao et al.);
+// trimming keeps the follow-up embedding call cheap and bounded.
+const hydeMaxAnswerChars = 1000
+
+// buildHyDEPrompt builds the instruction that asks the generator for a concise
+// hypothetical answer to the query. The generated text is embedded and used as
+// the retrieval vector (the HyDE transform); it is never shown to the end user,
+// so the prompt optimizes for a focused, document-style passage rather than a
+// conversational reply. The query is embedded verbatim — callers pass an already
+// trimmed, non-empty query.
+func buildHyDEPrompt(query string) string {
+	var b strings.Builder
+	b.WriteString("Write a short, factual passage (2-4 sentences) that directly answers ")
+	b.WriteString("the question below, as it might appear in a reference document. ")
+	b.WriteString("Do not add preamble, caveats, or citations; output only the passage.\n\n")
+	b.WriteString("Question: ")
+	b.WriteString(query)
+	b.WriteString("\n\nPassage:")
+	return b.String()
+}
+
+// truncateHyDEAnswer bounds a generated hypothetical answer to hydeMaxAnswerChars
+// runes so an over-long generation does not bloat the embedding request. Returns
+// the trimmed answer unchanged when already within the bound.
+func truncateHyDEAnswer(answer string) string {
+	answer = strings.TrimSpace(answer)
+	r := []rune(answer)
+	if len(r) <= hydeMaxAnswerChars {
+		return answer
+	}
+	return strings.TrimSpace(string(r[:hydeMaxAnswerChars]))
+}

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -942,7 +942,7 @@ func (s *Service) generateHyDEDocument(ctx context.Context, gen model.Generator,
 	prompt := buildHyDEPrompt(queryText)
 	generated, err := gen.Generate(ctx, prompt)
 	if err != nil {
-		s.logf("hyde: generation failed for query %q, falling back to raw query: %v", truncateQuestion(queryText), err)
+		s.logf("hyde: generation failed, falling back to raw query: %v", err)
 		return ""
 	}
 	return truncateHyDEAnswer(generated)

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -185,6 +185,17 @@ type Service struct {
 	// retrieval.mmr.lambda): 1 = pure relevance, 0 = pure diversity. Only
 	// consulted when mmrEnabled. Wired from config.RetrievalMMRLambda.
 	mmrLambda float64
+	// hydeEnabled toggles the opt-in HyDE (Hypothetical Document Embeddings)
+	// query transform (config retrieval.hyde.enabled). When true and a
+	// generator is configured, Search generates a short hypothetical answer to
+	// the query, embeds it, and retrieves with that text. Config-only (never an
+	// MCP tool parameter). Default false ⇒ unchanged behavior. Wired from
+	// config.RetrievalHyDEEnabled at construction.
+	hydeEnabled bool
+	// hydeMode selects how the HyDE-variant hits combine with the raw-query hits
+	// ("fuse" = RRF-fuse the two; "replace" = use the hypothetical-document hits
+	// alone). Default "fuse". Wired from config.RetrievalHyDEMode.
+	hydeMode string
 }
 
 // compile-time assertion that Service implements model.Retriever.  This
@@ -228,6 +239,7 @@ func NewService(store model.Store, index model.Index, embedder model.Embedder, g
 		secretPatterns:      compiledPatterns,
 		hybridEnabled:       true,
 		rerankCandidatePool: defaultRerankCandidatePool,
+		hydeMode:            hydeModeFuse,
 	}
 }
 
@@ -476,6 +488,25 @@ func (s *Service) SetMMR(enabled bool, lambda float64) {
 	defer s.metaMu.Unlock()
 	s.mmrEnabled = enabled
 	s.mmrLambda = lambda
+}
+
+// SetHyDE wires the opt-in HyDE (Hypothetical Document Embeddings) query
+// transform (config retrieval.hyde.enabled / retrieval.hyde.mode). When enabled
+// and a generator is configured, Search generates a short hypothetical answer to
+// the query, embeds it, and retrieves with that text — fused with the raw-query
+// results (mode "fuse", the default) or used alone (mode "replace"). An empty or
+// unrecognized mode normalizes to "fuse". A generation failure degrades
+// gracefully to the raw query (never fatal). Config-only; the engine wires this
+// from config at construction time, mirroring SetMinScore.
+func (s *Service) SetHyDE(enabled bool, mode string) {
+	mode = strings.ToLower(strings.TrimSpace(mode))
+	if mode != hydeModeReplace {
+		mode = hydeModeFuse
+	}
+	s.metaMu.Lock()
+	defer s.metaMu.Unlock()
+	s.hydeEnabled = enabled
+	s.hydeMode = mode
 }
 
 // SetDocumentHashes installs the rel_path → content_hash map used to group
@@ -795,42 +826,12 @@ func (s *Service) Search(ctx context.Context, query model.SearchQuery) ([]model.
 }
 
 func (s *Service) search(ctx context.Context, query model.SearchQuery) ([]model.SearchHit, error) {
-	s.metaMu.RLock()
-	textModel := s.textModel
-	codeModel := s.codeModel
-	textIndex := s.textIndex
-	codeIndex := s.codeIndex
-	s.metaMu.RUnlock()
-
 	k := query.K
 	if k <= 0 {
 		k = 15
 	}
 
-	mode := strings.ToLower(strings.TrimSpace(query.Index))
-	if mode == "" {
-		mode = "auto"
-	}
-	var (
-		hits []model.SearchHit
-		err  error
-	)
-	switch mode {
-	case "text":
-		hits, err = s.searchSingleIndex(ctx, query.Query, k, textModel, textIndex, "text", query, true)
-	case "code":
-		hits, err = s.searchSingleIndex(ctx, query.Query, k, codeModel, codeIndex, "code", query, true)
-	case "both":
-		hits, err = s.searchBothIndices(ctx, query.Query, k, textModel, codeModel, textIndex, codeIndex, query)
-	case "auto":
-		if looksLikeCodeQuery(query.Query) {
-			hits, err = s.searchSingleIndex(ctx, query.Query, k, codeModel, codeIndex, "code", query, true)
-		} else {
-			hits, err = s.searchSingleIndex(ctx, query.Query, k, textModel, textIndex, "text", query, true)
-		}
-	default:
-		hits, err = s.searchSingleIndex(ctx, query.Query, k, textModel, textIndex, "text", query, true)
-	}
+	hits, err := s.searchWithHyDE(ctx, query, k)
 	if err != nil {
 		return nil, err
 	}
@@ -839,11 +840,112 @@ func (s *Service) search(ctx context.Context, query model.SearchQuery) ([]model.
 	// decayed score and newer content survives a tie. Config-only; default 0 ⇒
 	// pass-through (no allocation, no lookups).
 	hits = s.applyRecencyDecay(ctx, hits)
-	// Apply the server-side relevance floor LAST: after scoring/fusion/rerank
-	// (the per-mode searches above), after their dedup/truncation, and after the
-	// recency decay, using each hit's final authoritative Score. Config-only;
-	// default 0 ⇒ pass-through.
+	// Apply the server-side relevance floor LAST: after scoring/fusion/rerank,
+	// the optional HyDE fusion, their dedup/truncation, and the recency decay,
+	// using each hit's final authoritative Score. Config-only; default 0 ⇒
+	// pass-through.
 	return s.applyMinScoreFloor(hits), nil
+}
+
+// searchByMode runs the index-mode dispatch (text/code/both/auto) for one query
+// text, returning up to k ranked hits. It is the shared retrieval primitive used
+// by both the raw query and — when the HyDE transform is enabled — the
+// hypothetical-document variant, so the two go through identical
+// fusion/rerank/dedup logic. allowRerank is forwarded to the single-index path
+// (the "both" path reranks internally on its merged pool regardless).
+func (s *Service) searchByMode(ctx context.Context, queryText string, k int, query model.SearchQuery, allowRerank bool) ([]model.SearchHit, error) {
+	s.metaMu.RLock()
+	textModel := s.textModel
+	codeModel := s.codeModel
+	textIndex := s.textIndex
+	codeIndex := s.codeIndex
+	s.metaMu.RUnlock()
+
+	mode := strings.ToLower(strings.TrimSpace(query.Index))
+	if mode == "" {
+		mode = "auto"
+	}
+	switch mode {
+	case "text":
+		return s.searchSingleIndex(ctx, queryText, k, textModel, textIndex, "text", query, allowRerank)
+	case "code":
+		return s.searchSingleIndex(ctx, queryText, k, codeModel, codeIndex, "code", query, allowRerank)
+	case "both":
+		return s.searchBothIndices(ctx, queryText, k, textModel, codeModel, textIndex, codeIndex, query)
+	case "auto":
+		if looksLikeCodeQuery(queryText) {
+			return s.searchSingleIndex(ctx, queryText, k, codeModel, codeIndex, "code", query, allowRerank)
+		}
+		return s.searchSingleIndex(ctx, queryText, k, textModel, textIndex, "text", query, allowRerank)
+	default:
+		return s.searchSingleIndex(ctx, queryText, k, textModel, textIndex, "text", query, allowRerank)
+	}
+}
+
+// searchWithHyDE runs retrieval for the query, applying the opt-in HyDE
+// (Hypothetical Document Embeddings) transform when enabled. With HyDE off it is
+// exactly searchByMode for the raw query (unchanged behavior). With HyDE on it
+// generates a short hypothetical answer, retrieves with that text, and either
+// RRF-fuses those hits with the raw-query hits (mode "fuse") or returns them
+// alone (mode "replace"). Generation failures, an empty hypothesis, or a missing
+// generator degrade gracefully to the raw-query results — HyDE is an
+// optimization, never a hard dependency.
+func (s *Service) searchWithHyDE(ctx context.Context, query model.SearchQuery, k int) ([]model.SearchHit, error) {
+	s.metaMu.RLock()
+	enabled := s.hydeEnabled
+	mode := s.hydeMode
+	gen := s.gen
+	s.metaMu.RUnlock()
+
+	if !enabled || gen == nil {
+		return s.searchByMode(ctx, query.Query, k, query, true)
+	}
+
+	hypothesis := s.generateHyDEDocument(ctx, gen, query.Query)
+	if hypothesis == "" {
+		// Graceful fallback: generation failed or produced nothing usable.
+		return s.searchByMode(ctx, query.Query, k, query, true)
+	}
+
+	if mode == hydeModeReplace {
+		// Use the hypothetical-document hits alone.
+		return s.searchByMode(ctx, hypothesis, k, query, true)
+	}
+
+	// Mode "fuse": retrieve both variants with rerank deferred so RRF fuses the
+	// raw candidate orderings, then rerank/truncate the fused pool once.
+	rawHits, err := s.searchByMode(ctx, query.Query, hybridCandidatePoolSize, query, false)
+	if err != nil {
+		return nil, err
+	}
+	hydeHits, err := s.searchByMode(ctx, hypothesis, hybridCandidatePoolSize, query, false)
+	if err != nil {
+		// A HyDE-variant retrieval error must not fail the whole request: fall
+		// back to the raw-query hits we already have.
+		s.logf("hyde: variant retrieval failed, falling back to raw query: %v", err)
+		return s.rerankPool(ctx, query.Query, rawHits, k), nil
+	}
+	fused := fuseRRF(rawHits, hydeHits, hybridCandidatePoolSize)
+	return s.rerankPool(ctx, query.Query, fused, k), nil
+}
+
+// generateHyDEDocument asks the generator for a concise hypothetical answer to
+// the query, used as the retrieval text for the HyDE transform. It returns the
+// trimmed generated text, or "" when generation fails or yields nothing — the
+// caller then falls back to the raw query. The question is not logged verbatim
+// (it may carry sensitive data); only a truncated form is logged on error.
+func (s *Service) generateHyDEDocument(ctx context.Context, gen model.Generator, queryText string) string {
+	queryText = strings.TrimSpace(queryText)
+	if queryText == "" {
+		return ""
+	}
+	prompt := buildHyDEPrompt(queryText)
+	generated, err := gen.Generate(ctx, prompt)
+	if err != nil {
+		s.logf("hyde: generation failed for query %q, falling back to raw query: %v", truncateQuestion(queryText), err)
+		return ""
+	}
+	return truncateHyDEAnswer(generated)
 }
 
 // applyRecencyDecay multiplies each hit's final authoritative Score by an

--- a/tests/config/retrieval_hyde_config_test.go
+++ b/tests/config/retrieval_hyde_config_test.go
@@ -1,0 +1,161 @@
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+)
+
+// TestRetrievalHyDE_DefaultDisabled pins the local-first default: the HyDE query
+// transform is off and the mode defaults to "fuse" unless explicitly configured.
+func TestRetrievalHyDE_DefaultDisabled(t *testing.T) {
+	cfg := config.Default()
+	if cfg.RetrievalHyDEEnabled {
+		t.Fatalf("retrieval.hyde.enabled must default to false, got true")
+	}
+	if cfg.RetrievalHyDEMode != config.HyDEModeFuse {
+		t.Fatalf("retrieval.hyde.mode must default to %q, got %q", config.HyDEModeFuse, cfg.RetrievalHyDEMode)
+	}
+}
+
+// TestRetrievalHyDE_NestedYAMLRoundTrips pins the nested-mapping form
+// (retrieval: \n  hyde: \n    enabled: true \n    mode: replace).
+func TestRetrievalHyDE_NestedYAMLRoundTrips(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+	writeFile(t, path, strings.Join([]string{
+		"retrieval:",
+		"  hyde:",
+		"    enabled: true",
+		"    mode: replace",
+		"",
+	}, "\n"))
+
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if !cfg.RetrievalHyDEEnabled {
+		t.Fatalf("nested retrieval.hyde.enabled = false, want true")
+	}
+	if cfg.RetrievalHyDEMode != config.HyDEModeReplace {
+		t.Fatalf("nested retrieval.hyde.mode = %q, want %q", cfg.RetrievalHyDEMode, config.HyDEModeReplace)
+	}
+}
+
+// TestRetrievalHyDE_FlatAliasRoundTrips pins the flat snake_case aliases
+// (retrieval_hyde_enabled / retrieval_hyde_mode).
+func TestRetrievalHyDE_FlatAliasRoundTrips(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+	writeFile(t, path, strings.Join([]string{
+		"retrieval_hyde_enabled: true",
+		"retrieval_hyde_mode: fuse",
+		"",
+	}, "\n"))
+
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if !cfg.RetrievalHyDEEnabled {
+		t.Fatalf("flat retrieval_hyde_enabled = false, want true")
+	}
+	if cfg.RetrievalHyDEMode != config.HyDEModeFuse {
+		t.Fatalf("flat retrieval_hyde_mode = %q, want %q", cfg.RetrievalHyDEMode, config.HyDEModeFuse)
+	}
+}
+
+// TestRetrievalHyDE_SnapshotRoundTrips pins the persisted-snapshot round-trip:
+// the enable flag and mode survive SaveEffectiveSnapshot -> YAML -> load.
+func TestRetrievalHyDE_SnapshotRoundTrips(t *testing.T) {
+	cfg := config.Default()
+	cfg.StateDir = t.TempDir()
+	cfg.RetrievalHyDEEnabled = true
+	cfg.RetrievalHyDEMode = config.HyDEModeReplace
+
+	path, err := config.SaveEffectiveSnapshot(cfg, config.SecretSourceMetadata{})
+	if err != nil {
+		t.Fatalf("SaveEffectiveSnapshot: %v", err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !strings.Contains(string(raw), "retrieval_hyde_enabled: true") {
+		t.Fatalf("snapshot must persist retrieval_hyde_enabled: true:\n%s", raw)
+	}
+	if !strings.Contains(string(raw), "retrieval_hyde_mode: replace") {
+		t.Fatalf("snapshot must persist retrieval_hyde_mode: replace:\n%s", raw)
+	}
+
+	loaded, _, err := config.LoadEffectiveSnapshot(path)
+	if err != nil {
+		t.Fatalf("LoadEffectiveSnapshot: %v", err)
+	}
+	if !loaded.RetrievalHyDEEnabled || loaded.RetrievalHyDEMode != config.HyDEModeReplace {
+		t.Fatalf("loaded snapshot must carry enabled=true mode=replace, got enabled=%v mode=%q",
+			loaded.RetrievalHyDEEnabled, loaded.RetrievalHyDEMode)
+	}
+}
+
+// TestRetrievalHyDE_EmptyModeNormalizesToFuse pins that an empty mode normalizes
+// to "fuse" during validation rather than failing or behaving undefined.
+func TestRetrievalHyDE_EmptyModeNormalizesToFuse(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+	writeFile(t, path, "retrieval_hyde_enabled: true\n")
+
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if cfg.RetrievalHyDEMode != config.HyDEModeFuse {
+		t.Fatalf("empty retrieval.hyde.mode must normalize to %q, got %q", config.HyDEModeFuse, cfg.RetrievalHyDEMode)
+	}
+}
+
+// TestRetrievalHyDE_RejectsUnknownMode pins validation: an unrecognized mode is
+// CONFIG_INVALID so a typo fails loudly at config time.
+func TestRetrievalHyDE_RejectsUnknownMode(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+	writeFile(t, path, "retrieval_hyde_mode: bogus\n")
+
+	_, err := config.LoadFile(path)
+	if err == nil {
+		t.Fatalf("LoadFile with retrieval_hyde_mode=bogus = nil error, want rejection")
+	}
+	if !strings.Contains(err.Error(), "retrieval.hyde.mode") {
+		t.Fatalf("error must mention retrieval.hyde.mode, got: %v", err)
+	}
+}
+
+// TestRetrievalHyDE_ValidateRejectsUnknownModeProgrammatic pins that Validate()
+// rejects an unknown mode injected programmatically (not via the file parser).
+func TestRetrievalHyDE_ValidateRejectsUnknownModeProgrammatic(t *testing.T) {
+	cfg := config.Default()
+	cfg.RetrievalHyDEMode = "nonsense"
+	if err := cfg.Validate(); err == nil {
+		t.Fatalf("Validate with bogus RetrievalHyDEMode = nil error, want rejection")
+	}
+}
+
+// TestRetrievalHyDE_ModeCaseInsensitive pins that mode values are normalized
+// case-insensitively (e.g. "REPLACE" -> "replace").
+func TestRetrievalHyDE_ModeCaseInsensitive(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+	writeFile(t, path, "retrieval_hyde_mode: REPLACE\n")
+
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if cfg.RetrievalHyDEMode != config.HyDEModeReplace {
+		t.Fatalf("REPLACE must normalize to %q, got %q", config.HyDEModeReplace, cfg.RetrievalHyDEMode)
+	}
+}

--- a/tests/retrieval/hyde_test.go
+++ b/tests/retrieval/hyde_test.go
@@ -1,0 +1,189 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
+)
+
+// textDispatchEmbedder returns a different query vector depending on the input
+// text, so the HyDE transform (which embeds a generated hypothetical answer) can
+// be steered to different chunks than the raw query. Any text containing the
+// "hyde" marker embeds toward chunk 2; everything else embeds toward chunk 1.
+type textDispatchEmbedder struct {
+	rawVec  []float32
+	hydeVec []float32
+}
+
+func (e *textDispatchEmbedder) Embed(_ context.Context, _ string, _ model.EmbedRole, texts []string) ([][]float32, error) {
+	res := make([][]float32, len(texts))
+	for i, txt := range texts {
+		vec := e.rawVec
+		if strings.Contains(strings.ToLower(txt), "hyde-doc") {
+			vec = e.hydeVec
+		}
+		clone := make([]float32, len(vec))
+		copy(clone, vec)
+		res[i] = clone
+	}
+	return res, nil
+}
+
+// recordingGenerator returns a fixed hypothetical document (carrying the
+// "hyde-doc" marker so textDispatchEmbedder routes it to chunk 2) and records
+// the prompt it was asked to generate from.
+type recordingGenerator struct {
+	out        string
+	err        error
+	calls      int
+	lastPrompt string
+}
+
+func (g *recordingGenerator) Generate(_ context.Context, prompt string) (string, error) {
+	g.calls++
+	g.lastPrompt = prompt
+	if g.err != nil {
+		return "", g.err
+	}
+	return g.out, nil
+}
+
+// newHyDEService builds a vector-only retrieval service (nil store ⇒ no hybrid
+// fusion) over two well-separated chunks. The raw query embeds to {1,0} (chunk
+// 1); the generated hypothetical document embeds to {0,1} (chunk 2).
+func newHyDEService(t *testing.T, gen model.Generator) *retrieval.Service {
+	t.Helper()
+	idx := index.NewHNSWIndex("")
+	addVec(t, idx, 1, []float32{1, 0})
+	addVec(t, idx, 2, []float32{0, 1})
+
+	emb := &textDispatchEmbedder{rawVec: []float32{1, 0}, hydeVec: []float32{0, 1}}
+	svc := retrieval.NewService(nil, idx, emb, gen)
+	svc.SetChunkMetadata(1, model.SearchHit{RelPath: "raw.md", Snippet: "raw"})
+	svc.SetChunkMetadata(2, model.SearchHit{RelPath: "hyde.md", Snippet: "hyde"})
+	return svc
+}
+
+func hydeSearchIDs(t *testing.T, svc *retrieval.Service) []uint64 {
+	t.Helper()
+	hits, err := svc.Search(context.Background(), model.SearchQuery{Query: "terse keyword", Index: "text", K: 10})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	ids := make([]uint64, 0, len(hits))
+	for _, h := range hits {
+		ids = append(ids, h.ChunkID)
+	}
+	return ids
+}
+
+func containsID(ids []uint64, want uint64) bool {
+	for _, id := range ids {
+		if id == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestSearch_HyDE_Disabled_IsRawQueryOnly pins the default-off behavior: with
+// HyDE never enabled the generator is not called and only the raw-query chunk
+// (1) is returned, ranked first.
+func TestSearch_HyDE_Disabled_IsRawQueryOnly(t *testing.T) {
+	gen := &recordingGenerator{out: "hyde-doc answer"}
+	svc := newHyDEService(t, gen)
+
+	got := hydeSearchIDs(t, svc)
+	if len(got) == 0 || got[0] != 1 {
+		t.Fatalf("disabled HyDE must rank the raw-query chunk first; got %v", got)
+	}
+	if gen.calls != 0 {
+		t.Fatalf("disabled HyDE must not call the generator; calls=%d", gen.calls)
+	}
+}
+
+// TestSearch_HyDE_Fuse_IncludesHypotheticalDocHits pins the fuse mode: the
+// hypothetical-document chunk (2), unreachable by the raw query alone, surfaces
+// alongside the raw-query chunk (1) via RRF fusion.
+func TestSearch_HyDE_Fuse_IncludesHypotheticalDocHits(t *testing.T) {
+	gen := &recordingGenerator{out: "this is a hyde-doc hypothetical passage"}
+	svc := newHyDEService(t, gen)
+	svc.SetHyDE(true, "fuse")
+
+	got := hydeSearchIDs(t, svc)
+	if gen.calls != 1 {
+		t.Fatalf("HyDE fuse must call the generator exactly once; calls=%d", gen.calls)
+	}
+	if !containsID(got, 1) {
+		t.Fatalf("fuse must keep the raw-query chunk (1); got %v", got)
+	}
+	if !containsID(got, 2) {
+		t.Fatalf("fuse must include the hypothetical-doc chunk (2); got %v", got)
+	}
+	if !strings.Contains(gen.lastPrompt, "terse keyword") {
+		t.Fatalf("HyDE prompt must embed the raw query; got %q", gen.lastPrompt)
+	}
+}
+
+// TestSearch_HyDE_Replace_UsesHypotheticalDocAlone pins the replace mode:
+// retrieval uses the hypothetical embedding alone, so the hypothetical-document
+// chunk (2) ranks first (the small 2-chunk corpus still returns both via
+// overfetch, but ordering reflects the embedding actually searched with).
+func TestSearch_HyDE_Replace_UsesHypotheticalDocAlone(t *testing.T) {
+	gen := &recordingGenerator{out: "hyde-doc replacement passage"}
+	svc := newHyDEService(t, gen)
+	svc.SetHyDE(true, "replace")
+
+	got := hydeSearchIDs(t, svc)
+	if len(got) == 0 || got[0] != 2 {
+		t.Fatalf("replace must rank the hypothetical-doc chunk (2) first; got %v", got)
+	}
+}
+
+// TestSearch_HyDE_GenerationFailure_FallsBackToRawQuery pins graceful
+// degradation: when the generator errors, Search must not fail and must fall
+// back to the raw-query ranking (chunk 1 first), as if HyDE were off.
+func TestSearch_HyDE_GenerationFailure_FallsBackToRawQuery(t *testing.T) {
+	gen := &recordingGenerator{err: errors.New("generation boom")}
+	svc := newHyDEService(t, gen)
+	svc.SetHyDE(true, "fuse")
+
+	hits, err := svc.Search(context.Background(), model.SearchQuery{Query: "terse keyword", Index: "text", K: 10})
+	if err != nil {
+		t.Fatalf("generation failure must not fail Search: %v", err)
+	}
+	if len(hits) == 0 || hits[0].ChunkID != 1 {
+		t.Fatalf("fallback must rank the raw-query chunk (1) first; got %v", hits)
+	}
+}
+
+// TestSearch_HyDE_EmptyGeneration_FallsBackToRawQuery pins that a generator
+// returning only whitespace is treated like a failure: the raw-query ranking
+// (chunk 1 first) is used, not the hypothetical embedding.
+func TestSearch_HyDE_EmptyGeneration_FallsBackToRawQuery(t *testing.T) {
+	gen := &recordingGenerator{out: "   \n  "}
+	svc := newHyDEService(t, gen)
+	svc.SetHyDE(true, "replace")
+
+	got := hydeSearchIDs(t, svc)
+	if len(got) == 0 || got[0] != 1 {
+		t.Fatalf("empty generation must fall back to raw-query ranking (chunk 1 first); got %v", got)
+	}
+}
+
+// TestSearch_HyDE_NilGenerator_IsRawQueryOnly pins that enabling HyDE without a
+// configured generator is a safe no-op (raw-query ranking), not a panic.
+func TestSearch_HyDE_NilGenerator_IsRawQueryOnly(t *testing.T) {
+	svc := newHyDEService(t, nil)
+	svc.SetHyDE(true, "fuse")
+
+	got := hydeSearchIDs(t, svc)
+	if len(got) == 0 || got[0] != 1 {
+		t.Fatalf("nil generator must fall back to raw-query ranking (chunk 1 first); got %v", got)
+	}
+}


### PR DESCRIPTION
## Summary

Adds an **opt-in, server-side HyDE** (Hypothetical Document Embeddings) query transform. When enabled, `Search` generates a short hypothetical answer to the query via the configured generator, embeds *that* text, and retrieves with it — either RRF-fused with the raw-query results (`fuse`, default) or used alone (`replace`). Closes #333.

This is **config-only** ⇒ ungated: no MCP tool/citation contract change, no spec change, no submodule re-pin. Off by default ⇒ behavior is unchanged unless explicitly enabled.

## Config

```yaml
retrieval:
  hyde:
    enabled: false   # opt in
    mode: fuse       # fuse (default) | replace
```

- Flat aliases: `retrieval_hyde_enabled`, `hyde_enabled`, `retrieval_hyde_mode`, `hyde_mode`.
- Empty mode normalizes to `fuse`; an unknown mode is `CONFIG_INVALID`.
- Full field + fileConfig + persistedConfig + Default + apply + alias + isMapSectionKey + validation + snapshot round-trip, modeled on the existing `retrieval.min_score` knob.

## How it works

- `retrieval/hyde.go`: HyDE prompt builder + mode constants + answer truncation.
- `Service.searchWithHyDE` wraps the existing mode-dispatch (`searchByMode`, extracted from `Search`). With HyDE on it generates a hypothetical doc, retrieves both variants with rerank deferred, **reuses the existing `fuseRRF`** to fuse the two candidate orderings, then reranks/truncates the fused pool once.
- **Graceful degradation**: a generation failure, an empty hypothesis, a missing generator, or a HyDE-variant retrieval error all fall back to the raw query — never fatal. The question is never logged verbatim.
- Wired in both server (`internal/cli/up.go`) and ask (`internal/cli/app.go`) paths via `Service.SetHyDE`, mirroring `SetMinScore`.

Factored standalone on `main` (does not depend on the unmerged cross-lingual PR #344), but kept cleanly separable so the two transforms can converge into a shared family later.

## Tests

- `tests/retrieval/hyde_test.go`: `TestSearch_HyDE_Disabled_IsRawQueryOnly`, `TestSearch_HyDE_Fuse_IncludesHypotheticalDocHits`, `TestSearch_HyDE_Replace_UsesHypotheticalDocAlone`, `TestSearch_HyDE_GenerationFailure_FallsBackToRawQuery`, `TestSearch_HyDE_EmptyGeneration_FallsBackToRawQuery`, `TestSearch_HyDE_NilGenerator_IsRawQueryOnly`.
- `tests/config/retrieval_hyde_config_test.go`: default-off, nested + flat-alias round-trips, snapshot round-trip, empty-mode normalization, unknown-mode rejection (file + programmatic), case-insensitivity.

`make check` is fully green (gocyclo ≤15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHuQEKSW3nzU1Pn7KXXBhj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional HyDE (Hypothetical Document Embeddings) query transformation for retrieval. When enabled, generates a hypothetical answer to improve search results. Operates in two modes: "fuse" (default) combines hypothetical-document hits with raw-query hits; "replace" uses hypothetical embeddings alone. Gracefully falls back to raw-query results if generation fails or no generator is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->