### PR TITLE
feat: self-hosted unified multimodal embedder (OmniEmbed/Qwen2.5-Omni via vLLM) (#334)

### DIFF
--- a/internal/config/providers.go
+++ b/internal/config/providers.go
@@ -79,6 +79,14 @@ func builtinProfiles() map[string]providerProfileYAML {
 		// builtinPrecedence (like `local`) so it never silently wins auto
 		// selection; reach it via stt_provider: whisper.
 		"whisper": {Kind: "whisper", BaseURL: "${WHISPER_BASE_URL}"},
+		// omniembed: self-hosted OpenAI-compatible UNIFIED MULTIMODAL embed
+		// (dir2mcp#334). Credential-less by default (no api_key); operators
+		// point base_url (and optionally api_key/embed models) via a
+		// providers: entry or the OMNIEMBED_BASE_URL env default. Excluded
+		// from builtinPrecedence (like `local`/`whisper`) so it never silently
+		// wins embed auto-selection; reach it via model.embed.provider:
+		// omniembed. Multimodal embedding is opt-in via model.embed.multimodal.
+		"omniembed": {Kind: "omniembed", BaseURL: "${OMNIEMBED_BASE_URL}"},
 	}
 }
 

--- a/internal/omniembed/client.go
+++ b/internal/omniembed/client.go
@@ -1,0 +1,356 @@
+// Package omniembed is a pure-Go client for a self-hosted, unified
+// multimodal embedding endpoint — the off-API multimodal path
+// (dir2mcp#334), extending the self-hosted-endpoint capability (#240) and
+// the GPU-VPS / dual-machine epic (#250) to multimodal embedding.
+//
+// It targets an OmniEmbed / Qwen2.5-Omni model (Tevatron/OmniEmbed-v0.1)
+// served behind an OpenAI-compatible POST {BaseURL}/v1/embeddings surface,
+// which vLLM exposes for embedding models. Text is sent as plain strings;
+// non-text media (images, audio, video, PDFs) are sent as RFC 2397 data
+// URIs in the same `input` array — the convention OpenAI-compatible
+// multimodal embedding servers accept — so a single request mixes
+// modalities into ONE shared vector space (the property OmniEmbed provides
+// and that SPEC 8.1.7 requires).
+//
+// The endpoint may be credential-less (a self-hosted box on a private
+// network): a Bearer token is sent only when an api_key is configured.
+//
+// This client never logs media bytes, the request body, or the API key.
+package omniembed
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+const (
+	defaultRequestTimeout = 120 * time.Second
+	defaultMaxRetries     = 3
+	defaultInitialBackoff = 250 * time.Millisecond
+	defaultMaxBackoff     = 2 * time.Second
+	defaultBatchSize      = 32
+	// defaultMaxItemBytes bounds a single media payload so callers avoid
+	// sending absurdly large blobs that fail upstream or time out. Media
+	// chunks are already reduced to one PDF page / one A-V window upstream
+	// (SPEC 8.1.7), so this is a defensive ceiling, not a tuning knob.
+	defaultMaxItemBytes = 50 * 1024 * 1024
+
+	// DefaultModel is a sensible fallback model name. Self-hosted servers
+	// frequently ignore the field or accept the served model alias, but
+	// operators SHOULD set an explicit model via the provider profile.
+	DefaultModel = "omniembed"
+)
+
+// Client speaks the OpenAI-compatible /v1/embeddings contract against a
+// self-hosted base URL serving a unified multimodal embedding model.
+//
+// Error codes:
+//   - OMNIEMBED_AUTH (non-retryable): upstream 401/403.
+//   - OMNIEMBED_RATE_LIMIT (retryable): upstream 429.
+//   - OMNIEMBED_FAILED (retryable for network/5xx, non-retryable otherwise).
+type Client struct {
+	BaseURL    string
+	APIKey     string
+	HTTPClient *http.Client
+
+	MaxRetries     int
+	InitialBackoff time.Duration
+	MaxBackoff     time.Duration
+	// BatchSize bounds how many inputs are sent per request. Values <= 0
+	// fall back to defaultBatchSize.
+	BatchSize int
+	// MaxItemBytes bounds a single media payload (bytes). Values <= 0 fall
+	// back to defaultMaxItemBytes.
+	MaxItemBytes int
+
+	// DefaultEmbedModel is sent as the `model` field. Empty falls back to
+	// the package DefaultModel constant.
+	DefaultEmbedModel string
+}
+
+// compile-time assertions that *Client implements the model contracts.
+var (
+	_ model.Embedder           = (*Client)(nil)
+	_ model.MultimodalEmbedder = (*Client)(nil)
+)
+
+// NewClient constructs a client with safe default retry/timeout settings.
+// apiKey may be empty for a credential-less self-hosted endpoint.
+func NewClient(baseURL, apiKey string) *Client {
+	return &Client{
+		BaseURL:           strings.TrimRight(strings.TrimSpace(baseURL), "/"),
+		APIKey:            strings.TrimSpace(apiKey),
+		HTTPClient:        &http.Client{Timeout: defaultRequestTimeout},
+		MaxRetries:        defaultMaxRetries,
+		InitialBackoff:    defaultInitialBackoff,
+		MaxBackoff:        defaultMaxBackoff,
+		BatchSize:         defaultBatchSize,
+		MaxItemBytes:      defaultMaxItemBytes,
+		DefaultEmbedModel: DefaultModel,
+	}
+}
+
+// embedRequest is the OpenAI-compatible embeddings request. Input carries
+// plain text strings and/or data-URI media strings in one array; the
+// server embeds every element into the same vector space.
+type embedRequest struct {
+	Model string   `json:"model"`
+	Input []string `json:"input"`
+}
+
+type embedResponse struct {
+	Data []struct {
+		Index     int       `json:"index"`
+		Embedding []float64 `json:"embedding"`
+	} `json:"data"`
+}
+
+// Embed implements model.Embedder. Self-hosted unified embeddings are
+// symmetric, so the input role is accepted and ignored (SPEC 8.1.5).
+// Inputs are sent in BatchSize-sized batches; each batch is retried with
+// bounded exponential backoff, and vectors are reordered to match input
+// order.
+func (c *Client) Embed(ctx context.Context, modelName string, _ model.EmbedRole, inputs []string) ([][]float32, error) {
+	if len(inputs) == 0 {
+		return [][]float32{}, nil
+	}
+	encoded := make([]string, len(inputs))
+	copy(encoded, inputs)
+	return c.embedAll(ctx, modelName, encoded)
+}
+
+// EmbedMedia implements model.MultimodalEmbedder. Each media item is
+// encoded as an RFC 2397 base64 data URI and sent in the SAME `input`
+// array Embed uses, so media vectors are comparable to text vectors (SPEC
+// 8.1.7). Role is accepted and ignored (symmetric model). Bytes are never
+// logged.
+func (c *Client) EmbedMedia(ctx context.Context, modelName string, _ model.EmbedRole, items []model.MediaInput) ([][]float32, error) {
+	if len(items) == 0 {
+		return [][]float32{}, nil
+	}
+	maxItem := c.MaxItemBytes
+	if maxItem <= 0 {
+		maxItem = defaultMaxItemBytes
+	}
+	encoded := make([]string, len(items))
+	for i, it := range items {
+		if len(it.Data) == 0 {
+			return nil, &model.ProviderError{Code: "OMNIEMBED_FAILED", Message: "media input is empty", Retryable: false}
+		}
+		if len(it.Data) > maxItem {
+			return nil, &model.ProviderError{
+				Code:      "OMNIEMBED_FAILED",
+				Message:   fmt.Sprintf("media input too large (%d bytes, limit %d)", len(it.Data), maxItem),
+				Retryable: false,
+			}
+		}
+		encoded[i] = dataURI(it.MimeType, it.Data)
+	}
+	return c.embedAll(ctx, modelName, encoded)
+}
+
+// dataURI builds an RFC 2397 base64 data URI for the media bytes. An empty
+// MIME type defaults to application/octet-stream so the URI stays
+// well-formed.
+func dataURI(mimeType string, data []byte) string {
+	mt := strings.TrimSpace(mimeType)
+	if mt == "" {
+		mt = "application/octet-stream"
+	}
+	return "data:" + mt + ";base64," + base64.StdEncoding.EncodeToString(data)
+}
+
+// embedAll resolves the model name, sends inputs in BatchSize-sized
+// batches (each retried), and concatenates vectors in input order.
+func (c *Client) embedAll(ctx context.Context, modelName string, inputs []string) ([][]float32, error) {
+	if strings.TrimSpace(c.BaseURL) == "" {
+		return nil, &model.ProviderError{Code: "OMNIEMBED_FAILED", Message: "missing omniembed base_url", Retryable: false}
+	}
+	modelName = strings.TrimSpace(modelName)
+	if modelName == "" {
+		modelName = strings.TrimSpace(c.DefaultEmbedModel)
+		if modelName == "" {
+			modelName = DefaultModel
+		}
+	}
+	batchSize := c.BatchSize
+	if batchSize <= 0 {
+		batchSize = defaultBatchSize
+	}
+	out := make([][]float32, 0, len(inputs))
+	for start := 0; start < len(inputs); start += batchSize {
+		end := start + batchSize
+		if end > len(inputs) {
+			end = len(inputs)
+		}
+		vectors, err := c.embedBatchWithRetry(ctx, modelName, inputs[start:end])
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, vectors...)
+	}
+	return out, nil
+}
+
+func (c *Client) embedBatchWithRetry(ctx context.Context, modelName string, inputs []string) ([][]float32, error) {
+	maxRetries := c.MaxRetries
+	if maxRetries < 0 {
+		maxRetries = 0
+	}
+	var lastErr error
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		if attempt > 0 {
+			if err := c.wait(ctx, c.backoffForAttempt(attempt-1)); err != nil {
+				return nil, err
+			}
+		}
+		vectors, err := c.embedBatch(ctx, modelName, inputs)
+		if err == nil {
+			return vectors, nil
+		}
+		lastErr = err
+		var pErr *model.ProviderError
+		if errors.As(err, &pErr) && !pErr.Retryable {
+			return nil, err
+		}
+	}
+	return nil, lastErr
+}
+
+func (c *Client) embedBatch(ctx context.Context, modelName string, inputs []string) ([][]float32, error) {
+	body, err := json.Marshal(embedRequest{Model: modelName, Input: inputs})
+	if err != nil {
+		return nil, &model.ProviderError{Code: "OMNIEMBED_FAILED", Message: "failed to marshal embedding request", Retryable: false, Cause: err}
+	}
+	resp, err := c.doJSON(ctx, "/v1/embeddings", body)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, httpError(resp)
+	}
+
+	var parsed embedResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil, &model.ProviderError{Code: "OMNIEMBED_FAILED", Message: "failed to decode embedding response", Retryable: false, StatusCode: resp.StatusCode, Cause: err}
+	}
+	return collectVectors(parsed, len(inputs), resp.StatusCode)
+}
+
+// collectVectors validates the response covers every input exactly once
+// and reorders vectors by the server-reported index to match input order.
+func collectVectors(parsed embedResponse, n, statusCode int) ([][]float32, error) {
+	fail := func(msg string) error {
+		return &model.ProviderError{Code: "OMNIEMBED_FAILED", Message: msg, Retryable: false, StatusCode: statusCode}
+	}
+	if len(parsed.Data) != n {
+		return nil, fail(fmt.Sprintf("embedding response size mismatch: got %d vectors for %d inputs", len(parsed.Data), n))
+	}
+	vectors := make([][]float32, n)
+	seen := make([]bool, n)
+	for _, item := range parsed.Data {
+		if item.Index < 0 || item.Index >= n {
+			return nil, fail(fmt.Sprintf("embedding response contains out-of-range index %d", item.Index))
+		}
+		if seen[item.Index] {
+			return nil, fail(fmt.Sprintf("embedding response contains duplicate index %d", item.Index))
+		}
+		vec := make([]float32, len(item.Embedding))
+		for i, v := range item.Embedding {
+			vec[i] = float32(v)
+		}
+		vectors[item.Index] = vec
+		seen[item.Index] = true
+	}
+	for i := range seen {
+		if !seen[i] {
+			return nil, fail(fmt.Sprintf("embedding response missing index %d", i))
+		}
+	}
+	return vectors, nil
+}
+
+func (c *Client) doJSON(ctx context.Context, path string, body []byte) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+path, bytes.NewReader(body))
+	if err != nil {
+		return nil, &model.ProviderError{Code: "OMNIEMBED_FAILED", Message: "failed to build request", Retryable: false, Cause: err}
+	}
+	// Bearer auth is optional: only set it for credentialed endpoints.
+	if key := strings.TrimSpace(c.APIKey); key != "" {
+		req.Header.Set("Authorization", "Bearer "+key)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	httpClient := c.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: defaultRequestTimeout}
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, &model.ProviderError{Code: "OMNIEMBED_FAILED", Message: "request failed", Retryable: true, Cause: err}
+	}
+	return resp, nil
+}
+
+func httpError(resp *http.Response) error {
+	bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	errMsg := strings.TrimSpace(string(bodyBytes))
+	if errMsg == "" {
+		errMsg = "upstream returned non-200 response"
+	}
+	switch {
+	case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
+		return &model.ProviderError{Code: "OMNIEMBED_AUTH", Message: errMsg, Retryable: false, StatusCode: resp.StatusCode}
+	case resp.StatusCode == http.StatusTooManyRequests:
+		return &model.ProviderError{Code: "OMNIEMBED_RATE_LIMIT", Message: errMsg, Retryable: true, StatusCode: resp.StatusCode}
+	case resp.StatusCode >= http.StatusInternalServerError:
+		return &model.ProviderError{Code: "OMNIEMBED_FAILED", Message: errMsg, Retryable: true, StatusCode: resp.StatusCode}
+	default:
+		return &model.ProviderError{Code: "OMNIEMBED_FAILED", Message: errMsg, Retryable: false, StatusCode: resp.StatusCode}
+	}
+}
+
+func (c *Client) backoffForAttempt(attempt int) time.Duration {
+	initial := c.InitialBackoff
+	if initial <= 0 {
+		initial = defaultInitialBackoff
+	}
+	maxBackoff := c.MaxBackoff
+	if maxBackoff <= 0 {
+		maxBackoff = defaultMaxBackoff
+	}
+	backoff := initial
+	for i := 0; i < attempt; i++ {
+		backoff *= 2
+		if backoff >= maxBackoff {
+			return maxBackoff
+		}
+	}
+	return backoff
+}
+
+func (c *Client) wait(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -28,6 +28,15 @@ const (
 	// Distinct from KindOpenAI so STT auto-selection and the matrix can
 	// treat it as statically STT-capable (Supported) and credential-optional.
 	KindWhisper Kind = "whisper"
+	// KindOmniEmbed is a self-hosted, OpenAI-compatible UNIFIED MULTIMODAL
+	// embedding endpoint (dir2mcp#334): POST {base_url}/v1/embeddings serving
+	// an OmniEmbed / Qwen2.5-Omni model (vLLM). Distinct from KindOpenAI
+	// because, unlike a plain OpenAI-compatible embed endpoint, it embeds
+	// text AND non-text media (images/audio/video/PDFs) into one shared
+	// vector space (SPEC 8.1.7), so the matrix marks it statically
+	// embed-capable and credential-optional, and the embed factory builds
+	// the multimodal-capable adapter for it.
+	KindOmniEmbed Kind = "omniembed"
 )
 
 // Capability is a model capability bound to a provider profile.
@@ -105,6 +114,15 @@ var matrix = map[Kind]map[Capability]Support{
 		// provider-dependent.
 		CapSTT:     Supported,
 		CapDiarize: Supported,
+	},
+	KindOmniEmbed: {
+		// Self-hosted OpenAI-compatible UNIFIED MULTIMODAL embed
+		// (dir2mcp#334). Statically embed-capable: the standard
+		// /v1/embeddings contract is fixed and the served model embeds text
+		// and media into one shared vector space (SPEC 8.1.7), so — like
+		// kind:whisper for STT — it is marked Supported rather than
+		// EndpointDependent.
+		CapEmbed: Supported,
 	},
 }
 

--- a/internal/providerfactory/factory.go
+++ b/internal/providerfactory/factory.go
@@ -19,6 +19,7 @@ import (
 	"github.com/dirstral/dir2mcp/internal/gemini"
 	"github.com/dirstral/dir2mcp/internal/mistral"
 	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/omniembed"
 	"github.com/dirstral/dir2mcp/internal/openai"
 	"github.com/dirstral/dir2mcp/internal/provider"
 	"github.com/dirstral/dir2mcp/internal/whisperapi"
@@ -51,41 +52,68 @@ func validateEmbedDim(p provider.Profile) error {
 	return nil
 }
 
-// multimodalEmbedModel is the only model that serves multimodal embeddings
-// today (SPEC 8.1.7).
-const multimodalEmbedModel = "gemini-embedding-2"
+// geminiMultimodalEmbedModel is the Gemini model that serves multimodal
+// embeddings (SPEC 8.1.7). The self-hosted OmniEmbed backend
+// (KindOmniEmbed) serves an operator-chosen model name instead, so its
+// model string is not pinned here.
+const geminiMultimodalEmbedModel = "gemini-embedding-2"
 
 // validateEmbedMultimodal enforces SPEC 8.1.7. The mode must be a known
 // value; `augment`/`replace` map every modality into one shared vector
-// space, so the ENTIRE binding — provider and BOTH the text and code model
-// axes — must resolve to the multimodal model on Gemini, else CONFIG_INVALID
-// (mixing incomparable vectors in one index is forbidden, §8.1.4).
+// space, so the ENTIRE binding — provider AND both the text and code model
+// axes — must resolve to a multimodal-capable backend with a single shared
+// model on both axes, else CONFIG_INVALID (mixing incomparable vectors in
+// one index is forbidden, §8.1.4). Two backends are multimodal-capable:
+// Gemini (pinned to geminiMultimodalEmbedModel) and the self-hosted
+// OmniEmbed endpoint (dir2mcp#334, operator-chosen model name).
 func validateEmbedMultimodal(p provider.Profile) error {
 	mode := provider.NormalizeEmbedMultimodal(p.EmbedMultimodal)
 	switch mode {
 	case "off":
 		return nil
 	case "augment", "replace":
-		// Trim the model fields to match provider.EmbedIdentity (which
-		// trims), so a value with incidental whitespace isn't rejected as
-		// CONFIG_INVALID when it is treated as equivalent for identity.
-		textModel := strings.TrimSpace(p.EmbedTextModel)
-		codeModel := strings.TrimSpace(p.EmbedCodeModel)
-		if p.Kind != provider.KindGemini ||
-			textModel != multimodalEmbedModel ||
-			codeModel != multimodalEmbedModel {
-			return fmt.Errorf("CONFIG_INVALID: embed.multimodal=%q requires provider=gemini with embed.text_model and embed.code_model both set to %q (got kind=%q text_model=%q code_model=%q)",
-				mode, multimodalEmbedModel, p.Kind, textModel, codeModel)
-		}
-		return nil
+		return validateMultimodalBinding(p, mode)
 	default:
 		return fmt.Errorf("CONFIG_INVALID: embed.multimodal=%q is invalid (expected off, augment, or replace)", mode)
 	}
 }
 
+// validateMultimodalBinding checks the single-shared-space constraint for an
+// augment/replace binding. It is split out of validateEmbedMultimodal to keep
+// cyclomatic complexity flat as more multimodal backends are added.
+func validateMultimodalBinding(p provider.Profile, mode string) error {
+	// Trim the model fields to match provider.EmbedIdentity (which trims),
+	// so incidental whitespace isn't rejected when it is identity-equivalent.
+	textModel := strings.TrimSpace(p.EmbedTextModel)
+	codeModel := strings.TrimSpace(p.EmbedCodeModel)
+	switch p.Kind {
+	case provider.KindGemini:
+		if textModel != geminiMultimodalEmbedModel || codeModel != geminiMultimodalEmbedModel {
+			return fmt.Errorf("CONFIG_INVALID: embed.multimodal=%q on provider kind=gemini requires embed.text_model and embed.code_model both set to %q (got text_model=%q code_model=%q)",
+				mode, geminiMultimodalEmbedModel, textModel, codeModel)
+		}
+		return nil
+	case provider.KindOmniEmbed:
+		// Self-hosted OmniEmbed serves one unified model whose name the
+		// operator chooses; the only invariant is that BOTH axes embed with
+		// the SAME non-empty model so the index never mixes vector spaces
+		// (§8.1.4). An empty model is allowed only when both are empty (the
+		// server's default model on both axes).
+		if textModel != codeModel {
+			return fmt.Errorf("CONFIG_INVALID: embed.multimodal=%q on provider kind=omniembed requires embed.text_model and embed.code_model to be the same model (got text_model=%q code_model=%q)",
+				mode, textModel, codeModel)
+		}
+		return nil
+	default:
+		return fmt.Errorf("CONFIG_INVALID: embed.multimodal=%q requires a multimodal-capable provider (gemini or omniembed); got kind=%q",
+			mode, p.Kind)
+	}
+}
+
 // Embedder builds a model.Embedder for the profile (kinds: openai,
-// mistral, cohere, gemini). The per-call model still comes from the
-// caller; Default*Model is only a fallback for empty model names.
+// cohere, gemini, omniembed). gemini and omniembed additionally satisfy
+// model.MultimodalEmbedder (SPEC 8.1.7). The per-call model still comes
+// from the caller; Default*Model is only a fallback for empty model names.
 //
 // The embedding output-dimension knob (EmbedTextDim/EmbedCodeDim, SPEC
 // 8.1.6) is only honored by Gemini today; requesting it on any other
@@ -119,6 +147,15 @@ func Embedder(p provider.Profile) (model.Embedder, error) {
 		return c, nil
 	case provider.KindCohere:
 		c := cohere.NewClient(p.BaseURL, p.APIKey)
+		if p.EmbedTextModel != "" {
+			c.DefaultEmbedModel = p.EmbedTextModel
+		}
+		return c, nil
+	case provider.KindOmniEmbed:
+		// Self-hosted unified multimodal embedder (dir2mcp#334). Returns a
+		// model.MultimodalEmbedder so the embedding worker can embed media
+		// chunks (SPEC 8.1.7) off-API. Credential-optional (private box).
+		c := omniembed.NewClient(p.BaseURL, p.APIKey)
 		if p.EmbedTextModel != "" {
 			c.DefaultEmbedModel = p.EmbedTextModel
 		}

--- a/tests/config/providers_config_test.go
+++ b/tests/config/providers_config_test.go
@@ -184,6 +184,70 @@ func TestProviders_EmbedMultimodalKnob(t *testing.T) {
 	}
 }
 
+// TestProviders_OmniEmbedSelfHosted pins dir2mcp#334: the built-in
+// omniembed profile (a) takes its base_url from ${OMNIEMBED_BASE_URL},
+// (b) is selectable via an explicit model.embed.provider binding for a
+// multimodal corpus, and (c) is EXCLUDED from auto-precedence so it never
+// silently wins embed selection (mirrors `whisper`/`local`).
+func TestProviders_OmniEmbedSelfHosted(t *testing.T) {
+	// Blank every credentialed embed-capable provider so an explicit
+	// omniembed binding is the only way embed resolves here.
+	for _, k := range []string{
+		"MISTRAL_API_KEY", "OPENAI_API_KEY", "OPENROUTER_API_KEY",
+		"GEMINI_API_KEY", "COHERE_API_KEY",
+	} {
+		t.Setenv(k, "")
+	}
+	t.Setenv("OMNIEMBED_BASE_URL", "http://gpu-vps:8000")
+
+	yaml := "version: 1\n" +
+		"model:\n" +
+		"  embed:\n" +
+		"    provider: omniembed\n" +
+		"    text_model: omniembed-v0.1\n" +
+		"    code_model: omniembed-v0.1\n" +
+		"    multimodal: replace\n"
+	r := loadCfg(t, yaml).Providers()
+
+	p, err := r.Resolve(provider.CapEmbed)
+	if err != nil {
+		t.Fatalf("resolve omniembed embed: %v", err)
+	}
+	if p.Kind != provider.KindOmniEmbed {
+		t.Fatalf("kind = %q, want omniembed", p.Kind)
+	}
+	if p.BaseURL != "http://gpu-vps:8000" {
+		t.Fatalf("base_url = %q, want ${OMNIEMBED_BASE_URL} expansion", p.BaseURL)
+	}
+	if !p.CredentialLess {
+		t.Fatal("omniembed builtin must be credential-less (no api_key)")
+	}
+	if p.EmbedMultimodal != "replace" {
+		t.Fatalf("multimodal = %q, want replace", p.EmbedMultimodal)
+	}
+	if !strings.HasSuffix(r.EmbedIdentity(), "|replace") {
+		t.Fatalf("embed identity %q must encode the multimodal mode", r.EmbedIdentity())
+	}
+}
+
+// TestProviders_OmniEmbedNotInAutoPrecedence pins that the credential-less
+// omniembed profile never wins embed auto-selection: with no real
+// credentials and no explicit binding, embed must fail (preflight surfaces
+// it) rather than silently fall through to omniembed.
+func TestProviders_OmniEmbedNotInAutoPrecedence(t *testing.T) {
+	for _, k := range []string{
+		"MISTRAL_API_KEY", "OPENAI_API_KEY", "OPENROUTER_API_KEY",
+		"GEMINI_API_KEY", "COHERE_API_KEY", "ANTHROPIC_API_KEY", "ELEVENLABS_API_KEY",
+	} {
+		t.Setenv(k, "")
+	}
+	t.Setenv("OMNIEMBED_BASE_URL", "http://gpu-vps:8000")
+	cfg := loadCfg(t, "version: 1\n")
+	if _, err := cfg.Providers().Resolve(provider.CapEmbed); err == nil {
+		t.Fatal("omniembed must not win embed auto-selection (excluded from precedence)")
+	}
+}
+
 func TestProviders_EnvVarRefs(t *testing.T) {
 	// Default config (no custom providers): built-in profiles reference
 	// the standard credential env vars.

--- a/tests/omniembed/client_test.go
+++ b/tests/omniembed/client_test.go
@@ -1,0 +1,290 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/omniembed"
+)
+
+// newClient builds an omniembed client with near-zero backoff so retry
+// tests stay fast.
+func newClient(url, apiKey string) *omniembed.Client {
+	c := omniembed.NewClient(url, apiKey)
+	c.InitialBackoff = time.Millisecond
+	c.MaxBackoff = time.Millisecond
+	return c
+}
+
+// embedReq is the OpenAI-compatible request shape the server receives.
+type embedReq struct {
+	Model string   `json:"model"`
+	Input []string `json:"input"`
+}
+
+// decodeReq parses the JSON embeddings request body.
+func decodeReq(t *testing.T, r *http.Request) embedReq {
+	t.Helper()
+	var req embedReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		t.Fatalf("decode request: %v", err)
+	}
+	return req
+}
+
+// embedResponseFor builds an OpenAI-compatible embeddings response where the
+// i-th input maps to a dim-length vector. Indices are returned out of order
+// to exercise the reorder-by-index logic.
+func embedResponseFor(n, dim int) map[string]any {
+	data := make([]map[string]any, 0, n)
+	for i := n - 1; i >= 0; i-- { // reverse order on purpose
+		vec := make([]float64, dim)
+		for d := range vec {
+			vec[d] = float64(i)*0.1 + float64(d)
+		}
+		data = append(data, map[string]any{"index": i, "embedding": vec})
+	}
+	return map[string]any{"data": data}
+}
+
+// TestEmbed_TextOpenAIShape verifies text embedding hits POST
+// /v1/embeddings with the OpenAI {model,input:[...]} shape and returns
+// dim-correct vectors in input order.
+func TestEmbed_TextOpenAIShape(t *testing.T) {
+	const dim = 8
+	var gotPath, gotModel string
+	var gotInput []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		req := decodeReq(t, r)
+		gotModel = req.Model
+		gotInput = req.Input
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(embedResponseFor(len(req.Input), dim))
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL, "")
+	c.DefaultEmbedModel = "omniembed-v0.1"
+
+	vecs, err := c.Embed(context.Background(), "", model.EmbedDocument, []string{"alpha", "beta", "gamma"})
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if gotPath != "/v1/embeddings" {
+		t.Errorf("path = %q, want /v1/embeddings", gotPath)
+	}
+	if gotModel != "omniembed-v0.1" {
+		t.Errorf("model = %q, want omniembed-v0.1 (default applied)", gotModel)
+	}
+	if len(gotInput) != 3 || gotInput[0] != "alpha" || gotInput[2] != "gamma" {
+		t.Errorf("input = %v, want [alpha beta gamma]", gotInput)
+	}
+	if len(vecs) != 3 {
+		t.Fatalf("got %d vectors, want 3", len(vecs))
+	}
+	for i, v := range vecs {
+		if len(v) != dim {
+			t.Errorf("vector %d dim = %d, want %d", i, len(v), dim)
+		}
+	}
+	// Reorder-by-index correctness: vec[i][0] == i*0.1.
+	if vecs[1][0] < 0.09 || vecs[1][0] > 0.11 {
+		t.Errorf("vector 1 not reordered to input order: %v", vecs[1])
+	}
+}
+
+// TestEmbedMedia_DataURIInput verifies media items are sent as base64
+// data URIs in the same input array, and that vectors are dim-correct.
+func TestEmbedMedia_DataURIInput(t *testing.T) {
+	const dim = 4
+	var gotInput []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		req := decodeReq(t, r)
+		gotInput = req.Input
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(embedResponseFor(len(req.Input), dim))
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL, "")
+	items := []model.MediaInput{
+		{MimeType: "image/png", Data: []byte("PNGBYTES")},
+		{MimeType: "audio/mp3", Data: []byte("MP3BYTES")},
+	}
+	vecs, err := c.EmbedMedia(context.Background(), "omniembed", model.EmbedDocument, items)
+	if err != nil {
+		t.Fatalf("EmbedMedia: %v", err)
+	}
+	if len(vecs) != 2 {
+		t.Fatalf("got %d vectors, want 2", len(vecs))
+	}
+	for i, v := range vecs {
+		if len(v) != dim {
+			t.Errorf("vector %d dim = %d, want %d", i, len(v), dim)
+		}
+	}
+	if len(gotInput) != 2 {
+		t.Fatalf("got %d inputs, want 2", len(gotInput))
+	}
+	if !strings.HasPrefix(gotInput[0], "data:image/png;base64,") {
+		t.Errorf("input[0] = %q, want image/png data URI", gotInput[0])
+	}
+	if !strings.HasPrefix(gotInput[1], "data:audio/mp3;base64,") {
+		t.Errorf("input[1] = %q, want audio/mp3 data URI", gotInput[1])
+	}
+	// Raw bytes must not appear verbatim (defense against accidental
+	// plaintext leakage); they are base64-encoded.
+	if strings.Contains(gotInput[0], "PNGBYTES") {
+		t.Errorf("input[0] leaked raw bytes: %q", gotInput[0])
+	}
+}
+
+// TestEmbedMedia_EmptyItemRejected verifies an empty media payload is a
+// non-retryable error and never reaches the network.
+func TestEmbedMedia_EmptyItemRejected(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL, "")
+	_, err := c.EmbedMedia(context.Background(), "omniembed", model.EmbedDocument,
+		[]model.MediaInput{{MimeType: "image/png", Data: nil}})
+	if err == nil {
+		t.Fatal("want error for empty media item, got nil")
+	}
+	if got := atomic.LoadInt32(&hits); got != 0 {
+		t.Errorf("server hit %d times, want 0 (validated before request)", got)
+	}
+}
+
+// TestEmbed_EmptyInputsNoCall verifies zero inputs short-circuit with no
+// HTTP call (mirrors Embedder contract for empty batches).
+func TestEmbed_EmptyInputsNoCall(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL, "")
+	vecs, err := c.Embed(context.Background(), "m", model.EmbedQuery, nil)
+	if err != nil {
+		t.Fatalf("Embed(empty): %v", err)
+	}
+	if len(vecs) != 0 {
+		t.Errorf("got %d vectors, want 0", len(vecs))
+	}
+	if got := atomic.LoadInt32(&hits); got != 0 {
+		t.Errorf("server hit %d times, want 0", got)
+	}
+}
+
+// TestEmbed_BearerOnlyWhenCredentialed verifies the Authorization header is
+// sent only when an api_key is configured (credential-optional self-hosted).
+func TestEmbed_BearerOnlyWhenCredentialed(t *testing.T) {
+	check := func(t *testing.T, apiKey, wantAuth string) {
+		t.Helper()
+		var gotAuth string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotAuth = r.Header.Get("Authorization")
+			req := decodeReq(t, r)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(embedResponseFor(len(req.Input), 2))
+		}))
+		defer srv.Close()
+		c := newClient(srv.URL, apiKey)
+		if _, err := c.Embed(context.Background(), "m", model.EmbedDocument, []string{"x"}); err != nil {
+			t.Fatalf("Embed: %v", err)
+		}
+		if gotAuth != wantAuth {
+			t.Errorf("Authorization = %q, want %q", gotAuth, wantAuth)
+		}
+	}
+	t.Run("credential-less", func(t *testing.T) { check(t, "", "") })
+	t.Run("credentialed", func(t *testing.T) { check(t, "sekret", "Bearer sekret") })
+}
+
+// TestEmbed_RetryOn5xx verifies a transient 5xx is retried and then
+// succeeds, while a 401 is a non-retryable OMNIEMBED_AUTH error.
+func TestEmbed_RetryOn5xx(t *testing.T) {
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&attempts, 1) == 1 {
+			http.Error(w, "overloaded", http.StatusServiceUnavailable)
+			return
+		}
+		req := decodeReq(t, r)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(embedResponseFor(len(req.Input), 3))
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL, "")
+	vecs, err := c.Embed(context.Background(), "m", model.EmbedDocument, []string{"x"})
+	if err != nil {
+		t.Fatalf("Embed after retry: %v", err)
+	}
+	if len(vecs) != 1 || len(vecs[0]) != 3 {
+		t.Errorf("unexpected vectors after retry: %v", vecs)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 2 {
+		t.Errorf("attempts = %d, want 2 (one retry)", got)
+	}
+}
+
+// TestEmbed_AuthErrorNotRetried verifies a 401 maps to a non-retryable
+// OMNIEMBED_AUTH ProviderError and is attempted exactly once.
+func TestEmbed_AuthErrorNotRetried(t *testing.T) {
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		http.Error(w, "nope", http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL, "k")
+	_, err := c.Embed(context.Background(), "m", model.EmbedDocument, []string{"x"})
+	if err == nil {
+		t.Fatal("want auth error, got nil")
+	}
+	var pErr *model.ProviderError
+	if !errors.As(err, &pErr) || pErr.Code != "OMNIEMBED_AUTH" {
+		t.Errorf("err = %v, want OMNIEMBED_AUTH ProviderError", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Errorf("attempts = %d, want 1 (auth not retried)", got)
+	}
+}
+
+// TestEmbed_SizeMismatch verifies a response with the wrong vector count is
+// a non-retryable failure.
+func TestEmbed_SizeMismatch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Return 1 vector for 2 inputs.
+		_ = json.NewEncoder(w).Encode(embedResponseFor(1, 4))
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL, "")
+	_, err := c.Embed(context.Background(), "m", model.EmbedDocument, []string{"a", "b"})
+	if err == nil {
+		t.Fatal("want size-mismatch error, got nil")
+	}
+	if !strings.Contains(err.Error(), "size mismatch") {
+		t.Errorf("err = %v, want size mismatch", err)
+	}
+}

--- a/tests/providerfactory/factory_test.go
+++ b/tests/providerfactory/factory_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/dirstral/dir2mcp/internal/gemini"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/omniembed"
 	"github.com/dirstral/dir2mcp/internal/openai"
 	"github.com/dirstral/dir2mcp/internal/provider"
 	"github.com/dirstral/dir2mcp/internal/providerfactory"
@@ -170,6 +172,53 @@ func TestEmbedder_Multimodal(t *testing.T) {
 		if _, err := providerfactory.Embedder(p); err == nil {
 			t.Errorf("bad multimodal config #%d must be CONFIG_INVALID, got nil", i)
 		}
+	}
+}
+
+// TestEmbedder_OmniEmbed pins dir2mcp#334: the self-hosted omniembed kind
+// builds a model.Embedder that also satisfies model.MultimodalEmbedder, so
+// the embedding worker can embed media chunks off-API (SPEC 8.1.7). It is
+// credential-optional (a bare base_url is enough).
+func TestEmbedder_OmniEmbed(t *testing.T) {
+	p := provider.Profile{
+		Name: "omniembed", Kind: provider.KindOmniEmbed,
+		BaseURL: "http://gpu-vps:8000", CredentialLess: true,
+		EmbedTextModel: "omniembed-v0.1",
+	}
+	e, err := providerfactory.Embedder(p)
+	if err != nil {
+		t.Fatalf("Embedder(omniembed) error: %v", err)
+	}
+	if _, ok := e.(*omniembed.Client); !ok {
+		t.Fatalf("Embedder(omniembed) = %T, want *omniembed.Client", e)
+	}
+	if _, ok := e.(model.MultimodalEmbedder); !ok {
+		t.Fatal("omniembed embedder must satisfy model.MultimodalEmbedder (SPEC 8.1.7)")
+	}
+}
+
+// TestEmbedder_OmniEmbedMultimodal pins dir2mcp#334: augment/replace is
+// valid on omniembed when both axes share one (operator-chosen) model, and
+// CONFIG_INVALID when the axes diverge — never mixing vector spaces (§8.1.4).
+func TestEmbedder_OmniEmbedMultimodal(t *testing.T) {
+	base := provider.Profile{
+		Name: "omniembed", Kind: provider.KindOmniEmbed,
+		BaseURL: "http://gpu-vps:8000", CredentialLess: true,
+	}
+	for _, mode := range []string{"augment", "replace"} {
+		p := base
+		p.EmbedTextModel, p.EmbedCodeModel = "omniembed-v0.1", "omniembed-v0.1"
+		p.EmbedMultimodal = mode
+		if _, err := providerfactory.Embedder(p); err != nil {
+			t.Errorf("mode %q with one shared omniembed model must be valid: %v", mode, err)
+		}
+	}
+	// Diverging models on the two axes is CONFIG_INVALID (incomparable spaces).
+	bad := base
+	bad.EmbedTextModel, bad.EmbedCodeModel = "omniembed-v0.1", "other-model"
+	bad.EmbedMultimodal = "augment"
+	if _, err := providerfactory.Embedder(bad); err == nil {
+		t.Error("omniembed multimodal with mismatched text/code models must be CONFIG_INVALID")
 	}
 }
 


### PR DESCRIPTION
Closes #334

## What

Adds a **self-hosted** unified multimodal embedding backend so multimodal embedding (`EmbedMedia`, SPEC §8.1.7) can run off-API, removing the Gemini lock-in on the multimodal axis. Extends the self-hosted-endpoint capability (#240) and the GPU-VPS / dual-machine epic (#250) to multimodal embedding.

## Backend shape

New `internal/omniembed` client targets an **OmniEmbed / Qwen2.5-Omni** model (Tevatron/OmniEmbed-v0.1) served behind an **OpenAI-compatible** `POST {base_url}/v1/embeddings` surface (vLLM):

- **Request:** standard `{ "model": ..., "input": [ ... ] }`. Text is sent as plain strings; non-text media (images, audio, video, PDFs) are sent as **RFC 2397 base64 data URIs** in the *same* `input` array — the convention OpenAI-compatible multimodal embedding servers accept — so all modalities land in **one shared vector space** (the property OmniEmbed provides and §8.1.7 requires).
- **Response:** standard `{ "data": [ { "index", "embedding" } ] }`; vectors are validated for completeness and reordered by `index` to match input order.
- Credential-**optional** Bearer auth (a private box may have no key), bounded exponential-backoff retries, per-item payload ceiling. Never logs media bytes, the request body, or the API key.
- Implements both `model.Embedder` and `model.MultimodalEmbedder` (compile-time asserted), so the existing embedding worker type-asserts and embeds media chunks unchanged.

## Selection (vs Gemini)

Mirrors the self-hosted whisper STT pattern (#240):

- New `provider.KindOmniEmbed` with matrix `CapEmbed: Supported` (statically capable, like `whisper` for STT).
- Builtin **credential-less** `omniembed` profile keyed off `${OMNIEMBED_BASE_URL}`, **excluded from auto-precedence** (like `local`/`whisper`) so it never silently wins embed selection. Reached via `model.embed.provider: omniembed`.
- `providerfactory.Embedder` builds the adapter; `validateEmbedMultimodal` now accepts **gemini OR omniembed** for `augment`/`replace`. Gemini stays pinned to `gemini-embedding-2`; omniembed requires the **same operator-chosen model on both the text and code axes** (the single-shared-space invariant, §8.1.4), else CONFIG_INVALID.

The Gemini path and the in-memory HNSW / Tier-C index are untouched.

## Identity handling

No change to the embed identity scheme (SPEC §8.1.4): provider name + text/code model + dims + multimodal mode. Switching to/from omniembed therefore re-derives vectors and never mixes vector spaces (verified by the existing `VerifyEmbedIdentity` path; covered by config tests asserting the identity encodes the multimodal mode).

## Gating

Ungated / additive: the §8.1.7 contract + embed identity already exist; no MCP tool or citation change. **Submodule pin unchanged.**

Spec note (non-blocking): SPEC §8.5 (self-hosted endpoints) currently describes self-hosted STT/OCR/embed; a one-line clarification that a self-hosted endpoint may also serve the §8.1.7 *multimodal* embed contract (OpenAI-compatible `/v1/embeddings` with data-URI media inputs) would make this case explicit. The code is additive and does not depend on it, so no spec PR / re-pin is required to merge.

## Tests (no creds / no network — httptest only)

- `tests/omniembed/client_test.go`: `TestEmbed_TextOpenAIShape`, `TestEmbedMedia_DataURIInput`, `TestEmbedMedia_EmptyItemRejected`, `TestEmbed_EmptyInputsNoCall`, `TestEmbed_BearerOnlyWhenCredentialed`, `TestEmbed_RetryOn5xx`, `TestEmbed_AuthErrorNotRetried`, `TestEmbed_SizeMismatch`.
- `tests/providerfactory/factory_test.go`: `TestEmbedder_OmniEmbed` (builds a `MultimodalEmbedder`), `TestEmbedder_OmniEmbedMultimodal` (one shared model OK; mismatched axes CONFIG_INVALID).
- `tests/config/providers_config_test.go`: `TestProviders_OmniEmbedSelfHosted` (`${OMNIEMBED_BASE_URL}` expansion, credential-less, identity), `TestProviders_OmniEmbedNotInAutoPrecedence` (never wins auto-selection).

`make check` is fully green locally (fmt/vet/lint/cyclo≤15/ineffassign/misspell/test/build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHuQEKSW3nzU1Pn7KXXBhj