### PR TITLE
retrieval: opt-in adaptive retrieval gating (retrieve-or-skip + adaptive-k) (#338)

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -824,6 +824,7 @@ func (a *App) buildRetrieverForAsk(ctx context.Context, cfg config.Config, st mo
 	askMetricsEmitter := newNDJSONEmitter(a.stderr, true)
 	a.configureQueryMetrics(ret, cfg, askMetricsEmitter.Emit)
 	ret.SetContextCompression(cfg.ContextCompressionEnabled, cfg.ContextCompressionTargetRatio)
+	ret.SetAdaptiveRetrieval(cfg.RetrievalAdaptiveEnabled, cfg.RetrievalAdaptiveKMin, cfg.RetrievalAdaptiveKMax)
 
 	if metadataStore, ok := st.(embeddedChunkLister); ok {
 		if _, err := preloadEmbeddedChunkMetadata(ctx, metadataStore, ret); err != nil && !errors.Is(err, model.ErrNotImplemented) {

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -81,6 +81,7 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 	ret.SetMinScore(cfg.RetrievalMinScore)
 	ret.SetRecencyHalfLife(cfg.RetrievalRecencyHalfLife)
 	ret.SetContextCompression(cfg.ContextCompressionEnabled, cfg.ContextCompressionTargetRatio)
+	ret.SetAdaptiveRetrieval(cfg.RetrievalAdaptiveEnabled, cfg.RetrievalAdaptiveKMin, cfg.RetrievalAdaptiveKMax)
 
 	// events are emitted to stdout only after we create the emitter; moving
 	// creation before the preload call lets us report failures from that

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1605,6 +1605,23 @@ func applyModelRAGFileParsed(cfg *Config, fc fileConfig) {
 	if fc.RetrievalMinScore != nil {
 		cfg.RetrievalMinScore = *fc.RetrievalMinScore
 	}
+	applyRetrievalTuningFileParsed(cfg, fc)
+	if fc.SessionInactivityTimeout != nil {
+		cfg.SessionInactivityTimeout = *fc.SessionInactivityTimeout
+	}
+	if fc.SessionMaxLifetime != nil {
+		cfg.SessionMaxLifetime = *fc.SessionMaxLifetime
+	}
+	if fc.HealthCheckInterval != nil {
+		cfg.HealthCheckInterval = *fc.HealthCheckInterval
+	}
+}
+
+// applyRetrievalTuningFileParsed overlays the opt-in retrieval-tuning file
+// fields (recency time-decay #323, context compression #335, and the adaptive
+// gate #338) onto cfg. Split out of applyModelRAGFileParsed to keep that
+// function within the gocyclo budget as tuning knobs are added.
+func applyRetrievalTuningFileParsed(cfg *Config, fc fileConfig) {
 	if fc.RetrievalRecencyHalfLife != nil {
 		cfg.RetrievalRecencyHalfLife = *fc.RetrievalRecencyHalfLife
 	}
@@ -1622,15 +1639,6 @@ func applyModelRAGFileParsed(cfg *Config, fc fileConfig) {
 	}
 	if fc.RetrievalAdaptiveKMax != nil {
 		cfg.RetrievalAdaptiveKMax = *fc.RetrievalAdaptiveKMax
-	}
-	if fc.SessionInactivityTimeout != nil {
-		cfg.SessionInactivityTimeout = *fc.SessionInactivityTimeout
-	}
-	if fc.SessionMaxLifetime != nil {
-		cfg.SessionMaxLifetime = *fc.SessionMaxLifetime
-	}
-	if fc.HealthCheckInterval != nil {
-		cfg.HealthCheckInterval = *fc.HealthCheckInterval
 	}
 }
 
@@ -2949,12 +2957,14 @@ func applyIngestEnvOverrides(cfg *Config, env map[string]string) {
 		{"DIR2MCP_INGEST_LATE_CHUNKING", &cfg.IngestLateChunking},
 		{"DIR2MCP_INGEST_WATCH", &cfg.IngestWatch},
 		{"DIR2MCP_RETRIEVAL_HYBRID_ENABLED", &cfg.RetrievalHybridEnabled},
+		{"DIR2MCP_RETRIEVAL_ADAPTIVE_ENABLED", &cfg.RetrievalAdaptiveEnabled},
 	} {
 		applyBoolEnvField(o.field, o.key, env)
 	}
 	if raw, ok := envLookup("DIR2MCP_INGEST_WATCH_DEBOUNCE", env); ok && strings.TrimSpace(raw) != "" {
 		applyDurationEnvField(cfg, raw, "DIR2MCP_INGEST_WATCH_DEBOUNCE", &cfg.IngestWatchDebounce)
 	}
+	applyRetrievalAdaptiveKEnv(cfg, env)
 }
 
 // applyBoolEnvField sets *field from env[key] when the variable is set, non-empty,
@@ -2966,19 +2976,23 @@ func applyBoolEnvField(field *bool, key string, env map[string]string) {
 			*field = parsed
 		}
 	}
-	if raw, ok := envLookup("DIR2MCP_RETRIEVAL_ADAPTIVE_ENABLED", env); ok && strings.TrimSpace(raw) != "" {
-		if parsed, err := strconv.ParseBool(strings.TrimSpace(raw)); err == nil {
-			cfg.RetrievalAdaptiveEnabled = parsed
-		}
-	}
-	if raw, ok := envLookup("DIR2MCP_RETRIEVAL_ADAPTIVE_K_MIN", env); ok && strings.TrimSpace(raw) != "" {
-		if parsed, err := strconv.Atoi(strings.TrimSpace(raw)); err == nil {
-			cfg.RetrievalAdaptiveKMin = parsed
-		}
-	}
-	if raw, ok := envLookup("DIR2MCP_RETRIEVAL_ADAPTIVE_K_MAX", env); ok && strings.TrimSpace(raw) != "" {
-		if parsed, err := strconv.Atoi(strings.TrimSpace(raw)); err == nil {
-			cfg.RetrievalAdaptiveKMax = parsed
+}
+
+// applyRetrievalAdaptiveKEnv applies the opt-in adaptive-gate k-bound int env
+// overrides (DIR2MCP_RETRIEVAL_ADAPTIVE_K_MIN / _K_MAX), each only when set and
+// non-empty. A table keeps the cyclomatic complexity flat as bounds are added.
+func applyRetrievalAdaptiveKEnv(cfg *Config, env map[string]string) {
+	for _, o := range []struct {
+		key   string
+		field *int
+	}{
+		{"DIR2MCP_RETRIEVAL_ADAPTIVE_K_MIN", &cfg.RetrievalAdaptiveKMin},
+		{"DIR2MCP_RETRIEVAL_ADAPTIVE_K_MAX", &cfg.RetrievalAdaptiveKMax},
+	} {
+		if raw, ok := envLookup(o.key, env); ok && strings.TrimSpace(raw) != "" {
+			if parsed, err := strconv.Atoi(strings.TrimSpace(raw)); err == nil {
+				*o.field = parsed
+			}
 		}
 	}
 }
@@ -3432,22 +3446,30 @@ func (c *Config) validateRetrievalNumericBounds() error {
 		c.ContextCompressionTargetRatio < 0 || c.ContextCompressionTargetRatio > 1 {
 		return fmt.Errorf("retrieval.context_compression.target_ratio must be in [0,1] (0 = default): %v", c.ContextCompressionTargetRatio)
 	}
-	// Adaptive-gate k bounds: negative values are meaningless and an inverted
-	// window (k_min > k_max) would make clamping ill-defined. Reject both at
-	// validation time (explicit, deterministic) rather than silently clamping.
-	// A bound of 0 is allowed and means "use the built-in default" at apply
-	// time, so it is not flagged here. Only checked when the gate is enabled so
-	// disabled deployments are never affected.
-	if c.RetrievalAdaptiveEnabled {
-		if c.RetrievalAdaptiveKMin < 0 {
-			return fmt.Errorf("retrieval.adaptive.k_min must be non-negative: %d", c.RetrievalAdaptiveKMin)
-		}
-		if c.RetrievalAdaptiveKMax < 0 {
-			return fmt.Errorf("retrieval.adaptive.k_max must be non-negative: %d", c.RetrievalAdaptiveKMax)
-		}
-		if c.RetrievalAdaptiveKMin > 0 && c.RetrievalAdaptiveKMax > 0 && c.RetrievalAdaptiveKMin > c.RetrievalAdaptiveKMax {
-			return fmt.Errorf("retrieval.adaptive.k_min (%d) must not exceed retrieval.adaptive.k_max (%d)", c.RetrievalAdaptiveKMin, c.RetrievalAdaptiveKMax)
-		}
+	if err := c.validateAdaptiveBounds(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateAdaptiveBounds enforces the adaptive-gate k window when the gate is
+// enabled: negative bounds are meaningless and an inverted window (k_min >
+// k_max) would make clamping ill-defined, so both are rejected explicitly
+// rather than silently clamped. A bound of 0 is allowed and means "use the
+// built-in default" at apply time. When the gate is disabled the bounds are
+// ignored, so a stale window never blocks startup.
+func (c *Config) validateAdaptiveBounds() error {
+	if !c.RetrievalAdaptiveEnabled {
+		return nil
+	}
+	if c.RetrievalAdaptiveKMin < 0 {
+		return fmt.Errorf("retrieval.adaptive.k_min must be non-negative: %d", c.RetrievalAdaptiveKMin)
+	}
+	if c.RetrievalAdaptiveKMax < 0 {
+		return fmt.Errorf("retrieval.adaptive.k_max must be non-negative: %d", c.RetrievalAdaptiveKMax)
+	}
+	if c.RetrievalAdaptiveKMin > 0 && c.RetrievalAdaptiveKMax > 0 && c.RetrievalAdaptiveKMin > c.RetrievalAdaptiveKMax {
+		return fmt.Errorf("retrieval.adaptive.k_min (%d) must not exceed retrieval.adaptive.k_max (%d)", c.RetrievalAdaptiveKMin, c.RetrievalAdaptiveKMax)
 	}
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -256,6 +256,22 @@ type Config struct {
 	// default (0.5). Values >1 or non-finite are CONFIG_INVALID. Ignored when
 	// ContextCompressionEnabled is false.
 	ContextCompressionTargetRatio float64
+	// RetrievalAdaptiveEnabled toggles the opt-in, training-free adaptive
+	// retrieval gate (config `retrieval.adaptive.enabled`). When false
+	// (default) Ask uses today's fixed-k behavior unchanged. When true a
+	// cheap, deterministic per-query heuristic decides whether retrieval is
+	// needed (skip trivial queries) and adjusts k within
+	// [RetrievalAdaptiveKMin, RetrievalAdaptiveKMax] (narrow easy queries,
+	// widen hard ones). It is config-only (NOT an MCP tool parameter): no tool
+	// input/output schema change, so it is ungated. See SPEC 9 (retrieval).
+	RetrievalAdaptiveEnabled bool
+	// RetrievalAdaptiveKMin / RetrievalAdaptiveKMax bound the dynamic k chosen
+	// by the adaptive gate when enabled. The gate never returns k outside
+	// [k_min, k_max]; the base k (rag.k_default or a caller-supplied k) is
+	// clamped into this window. 0 means "use the built-in default" (see
+	// defaultConfig). Ignored entirely when RetrievalAdaptiveEnabled is false.
+	RetrievalAdaptiveKMin int
+	RetrievalAdaptiveKMax int
 	// Rerank* configure the optional post-fusion rerank stage (SPEC
 	// 9.1.1). Reranking auto-activates when a provider credential is
 	// present. CohereAPIKey is a secret: env-sourced, never persisted
@@ -564,6 +580,9 @@ type fileConfig struct {
 	RetrievalRecencyHalfLife           *time.Duration
 	ContextCompressionEnabled          *bool
 	ContextCompressionTargetRatio      *float64
+	RetrievalAdaptiveEnabled           *bool
+	RetrievalAdaptiveKMin              *int
+	RetrievalAdaptiveKMax              *int
 	RerankEnabled                      *bool
 	RerankProvider                     *string
 	CohereAPIKey                       *string
@@ -684,6 +703,9 @@ type persistedConfig struct {
 	RetrievalRecencyHalfLife           time.Duration `yaml:"retrieval_recency_half_life"`
 	ContextCompressionEnabled          bool          `yaml:"context_compression_enabled"`
 	ContextCompressionTargetRatio      float64       `yaml:"context_compression_target_ratio"`
+	RetrievalAdaptiveEnabled           bool          `yaml:"retrieval_adaptive_enabled"`
+	RetrievalAdaptiveKMin              int           `yaml:"retrieval_adaptive_k_min"`
+	RetrievalAdaptiveKMax              int           `yaml:"retrieval_adaptive_k_max"`
 	RerankEnabled                      bool          `yaml:"rerank_enabled"`
 	RerankProvider                     string        `yaml:"rerank_provider"`
 	CohereBaseURL                      string        `yaml:"cohere_base_url"`
@@ -852,6 +874,14 @@ func Default() Config {
 		// ContextCompressionTargetRatio defaults to 0 (use the built-in 0.5
 		// keep-ratio); it only takes effect when compression is enabled.
 		ContextCompressionTargetRatio: 0,
+		// RetrievalAdaptiveEnabled defaults to false: the adaptive retrieval
+		// gate is opt-in, so behavior is today's fixed-k path unless enabled.
+		RetrievalAdaptiveEnabled: false,
+		// RetrievalAdaptiveKMin / RetrievalAdaptiveKMax bound the dynamic k the
+		// gate may choose. These defaults give the heuristic room to narrow easy
+		// queries and widen hard ones around the typical rag.k_default (10).
+		RetrievalAdaptiveKMin: 4,
+		RetrievalAdaptiveKMax: 30,
 		// RerankEnabled left nil: auto mode (activates iff a rerank
 		// provider credential is present). See rerankEnabledEffective.
 		RerankProvider:            "cohere",
@@ -970,6 +1000,9 @@ func buildPersistedConfig(cfg *Config) persistedConfig {
 		RetrievalRecencyHalfLife:           cfg.RetrievalRecencyHalfLife,
 		ContextCompressionEnabled:          cfg.ContextCompressionEnabled,
 		ContextCompressionTargetRatio:      cfg.ContextCompressionTargetRatio,
+		RetrievalAdaptiveEnabled:           cfg.RetrievalAdaptiveEnabled,
+		RetrievalAdaptiveKMin:              cfg.RetrievalAdaptiveKMin,
+		RetrievalAdaptiveKMax:              cfg.RetrievalAdaptiveKMax,
 		RerankEnabled:                      rerankEnabledEffective(cfg),
 		RerankProvider:                     cfg.RerankProvider,
 		CohereBaseURL:                      cfg.CohereBaseURL,
@@ -1581,6 +1614,15 @@ func applyModelRAGFileParsed(cfg *Config, fc fileConfig) {
 	if fc.ContextCompressionTargetRatio != nil {
 		cfg.ContextCompressionTargetRatio = *fc.ContextCompressionTargetRatio
 	}
+	if fc.RetrievalAdaptiveEnabled != nil {
+		cfg.RetrievalAdaptiveEnabled = *fc.RetrievalAdaptiveEnabled
+	}
+	if fc.RetrievalAdaptiveKMin != nil {
+		cfg.RetrievalAdaptiveKMin = *fc.RetrievalAdaptiveKMin
+	}
+	if fc.RetrievalAdaptiveKMax != nil {
+		cfg.RetrievalAdaptiveKMax = *fc.RetrievalAdaptiveKMax
+	}
 	if fc.SessionInactivityTimeout != nil {
 		cfg.SessionInactivityTimeout = *fc.SessionInactivityTimeout
 	}
@@ -1999,6 +2041,12 @@ var configKeyAliases = map[string]string{
 	"context_compression_enabled":             "retrieval.context_compression.enabled",
 	"context_compression":                     "retrieval.context_compression.enabled",
 	"context_compression_target_ratio":        "retrieval.context_compression.target_ratio",
+	"retrieval_adaptive_enabled":              "retrieval.adaptive.enabled",
+	"adaptive_enabled":                        "retrieval.adaptive.enabled",
+	"retrieval_adaptive_k_min":                "retrieval.adaptive.k_min",
+	"adaptive_k_min":                          "retrieval.adaptive.k_min",
+	"retrieval_adaptive_k_max":                "retrieval.adaptive.k_max",
+	"adaptive_k_max":                          "retrieval.adaptive.k_max",
 	"rerank_enabled":                          "rerank.enabled",
 	"rerank.cohere.api_key":                   "cohere_api_key",
 	"rerank.cohere.base_url":                  "cohere_base_url",
@@ -2108,7 +2156,7 @@ func canonicalizeConfigKey(key string) string {
 // (so child keys should be prefixed) rather than a scalar/list key.
 func isMapSectionKey(key string) bool {
 	switch key {
-	case "rag", "ingest", "ingest.docling", "stt", "stt.mistral", "stt.elevenlabs", "server", "server.tls", "secret_sources", "mistral", "docling", "security", "security.auth", "x402", "x402.route_policy", "x402.route_policy.tools_call", "chunking", "retrieval", "retrieval.hybrid", "retrieval.context_compression", "rerank", "rerank.cohere", "index", "dedup":
+	case "rag", "ingest", "ingest.docling", "stt", "stt.mistral", "stt.elevenlabs", "server", "server.tls", "secret_sources", "mistral", "docling", "security", "security.auth", "x402", "x402.route_policy", "x402.route_policy.tools_call", "chunking", "retrieval", "retrieval.hybrid", "retrieval.context_compression", "retrieval.adaptive", "rerank", "rerank.cohere", "index", "dedup":
 		return true
 	case "ingest.pdf", "ingest.images", "ingest.audio", "ingest.archives", "secrets", "index.qdrant":
 		return true
@@ -2177,13 +2225,14 @@ var boolFileScalarTargets = map[string]func(*fileConfig) **bool{
 	"media.trim_leading_silence": func(c *fileConfig) **bool {
 		return &c.MediaTrimLeadingSilence
 	},
-	"media.vad":                func(c *fileConfig) **bool { return &c.MediaVAD },
-	"media.diarize.enabled":    func(c *fileConfig) **bool { return &c.MediaDiarizeEnabled },
-	"media.batch.two_phase":    func(c *fileConfig) **bool { return &c.MediaBatchTwoPhase },
-	"media.batch.progress":     func(c *fileConfig) **bool { return &c.MediaBatchProgress },
-	"x402_tools_call_enabled":  func(c *fileConfig) **bool { return &c.X402ToolsCallEnabled },
-	"retrieval.hybrid.enabled": func(c *fileConfig) **bool { return &c.RetrievalHybridEnabled },
-	"dedup.retrieval":          func(c *fileConfig) **bool { return &c.DedupRetrieval },
+	"media.vad":                  func(c *fileConfig) **bool { return &c.MediaVAD },
+	"media.diarize.enabled":      func(c *fileConfig) **bool { return &c.MediaDiarizeEnabled },
+	"media.batch.two_phase":      func(c *fileConfig) **bool { return &c.MediaBatchTwoPhase },
+	"media.batch.progress":       func(c *fileConfig) **bool { return &c.MediaBatchProgress },
+	"x402_tools_call_enabled":    func(c *fileConfig) **bool { return &c.X402ToolsCallEnabled },
+	"retrieval.hybrid.enabled":   func(c *fileConfig) **bool { return &c.RetrievalHybridEnabled },
+	"retrieval.adaptive.enabled": func(c *fileConfig) **bool { return &c.RetrievalAdaptiveEnabled },
+	"dedup.retrieval":            func(c *fileConfig) **bool { return &c.DedupRetrieval },
 	"retrieval.context_compression.enabled": func(c *fileConfig) **bool {
 		return &c.ContextCompressionEnabled
 	},
@@ -2217,6 +2266,8 @@ var intFileScalarTargets = map[string]func(*fileConfig) **int{
 	"rate_limit_rps":             func(c *fileConfig) **int { return &c.RateLimitRPS },
 	"rate_limit_burst":           func(c *fileConfig) **int { return &c.RateLimitBurst },
 	"rag.k_default":              func(c *fileConfig) **int { return &c.RAGKDefault },
+	"retrieval.adaptive.k_min":   func(c *fileConfig) **int { return &c.RetrievalAdaptiveKMin },
+	"retrieval.adaptive.k_max":   func(c *fileConfig) **int { return &c.RetrievalAdaptiveKMax },
 	"rag.max_context_chars":      func(c *fileConfig) **int { return &c.RAGMaxContextChars },
 	"rag.oversample_factor":      func(c *fileConfig) **int { return &c.RAGOversampleFactor },
 	"chunking.max_tokens":        func(c *fileConfig) **int { return &c.ChunkingMaxTokens },
@@ -2256,6 +2307,8 @@ func setIntFileScalar(cfg *fileConfig, key, value string) error {
 // be negative. A negative value is rejected at config-parse time (explicit,
 // deterministic) rather than being silently clamped later.
 var nonNegativeIntKeys = map[string]bool{
+	"retrieval.adaptive.k_min":                true,
+	"retrieval.adaptive.k_max":                true,
 	"media.audio_window_sec":                  true,
 	"media.video_window_sec":                  true,
 	"media.clip.max_duration_ms":              true,
@@ -2594,6 +2647,9 @@ func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	writeScalar("retrieval_recency_half_life", cfg.RetrievalRecencyHalfLife.String())
 	writeBool("context_compression_enabled", cfg.ContextCompressionEnabled)
 	writeScalar("context_compression_target_ratio", strconv.FormatFloat(cfg.ContextCompressionTargetRatio, 'f', -1, 64))
+	writeBool("retrieval_adaptive_enabled", cfg.RetrievalAdaptiveEnabled)
+	writeInt("retrieval_adaptive_k_min", cfg.RetrievalAdaptiveKMin)
+	writeInt("retrieval_adaptive_k_max", cfg.RetrievalAdaptiveKMax)
 	writeBool("rerank_enabled", cfg.RerankEnabled)
 	writeScalar("rerank_provider", cfg.RerankProvider)
 	writeScalar("cohere_base_url", cfg.CohereBaseURL)
@@ -2908,6 +2964,21 @@ func applyBoolEnvField(field *bool, key string, env map[string]string) {
 	if raw, ok := envLookup(key, env); ok && strings.TrimSpace(raw) != "" {
 		if parsed, err := strconv.ParseBool(strings.TrimSpace(raw)); err == nil {
 			*field = parsed
+		}
+	}
+	if raw, ok := envLookup("DIR2MCP_RETRIEVAL_ADAPTIVE_ENABLED", env); ok && strings.TrimSpace(raw) != "" {
+		if parsed, err := strconv.ParseBool(strings.TrimSpace(raw)); err == nil {
+			cfg.RetrievalAdaptiveEnabled = parsed
+		}
+	}
+	if raw, ok := envLookup("DIR2MCP_RETRIEVAL_ADAPTIVE_K_MIN", env); ok && strings.TrimSpace(raw) != "" {
+		if parsed, err := strconv.Atoi(strings.TrimSpace(raw)); err == nil {
+			cfg.RetrievalAdaptiveKMin = parsed
+		}
+	}
+	if raw, ok := envLookup("DIR2MCP_RETRIEVAL_ADAPTIVE_K_MAX", env); ok && strings.TrimSpace(raw) != "" {
+		if parsed, err := strconv.Atoi(strings.TrimSpace(raw)); err == nil {
+			cfg.RetrievalAdaptiveKMax = parsed
 		}
 	}
 }
@@ -3360,6 +3431,23 @@ func (c *Config) validateRetrievalNumericBounds() error {
 	if math.IsNaN(c.ContextCompressionTargetRatio) || math.IsInf(c.ContextCompressionTargetRatio, 0) ||
 		c.ContextCompressionTargetRatio < 0 || c.ContextCompressionTargetRatio > 1 {
 		return fmt.Errorf("retrieval.context_compression.target_ratio must be in [0,1] (0 = default): %v", c.ContextCompressionTargetRatio)
+	}
+	// Adaptive-gate k bounds: negative values are meaningless and an inverted
+	// window (k_min > k_max) would make clamping ill-defined. Reject both at
+	// validation time (explicit, deterministic) rather than silently clamping.
+	// A bound of 0 is allowed and means "use the built-in default" at apply
+	// time, so it is not flagged here. Only checked when the gate is enabled so
+	// disabled deployments are never affected.
+	if c.RetrievalAdaptiveEnabled {
+		if c.RetrievalAdaptiveKMin < 0 {
+			return fmt.Errorf("retrieval.adaptive.k_min must be non-negative: %d", c.RetrievalAdaptiveKMin)
+		}
+		if c.RetrievalAdaptiveKMax < 0 {
+			return fmt.Errorf("retrieval.adaptive.k_max must be non-negative: %d", c.RetrievalAdaptiveKMax)
+		}
+		if c.RetrievalAdaptiveKMin > 0 && c.RetrievalAdaptiveKMax > 0 && c.RetrievalAdaptiveKMin > c.RetrievalAdaptiveKMax {
+			return fmt.Errorf("retrieval.adaptive.k_min (%d) must not exceed retrieval.adaptive.k_max (%d)", c.RetrievalAdaptiveKMin, c.RetrievalAdaptiveKMax)
+		}
 	}
 	return nil
 }

--- a/internal/retrieval/adaptive.go
+++ b/internal/retrieval/adaptive.go
@@ -86,79 +86,104 @@ var (
 // base <= 0 is treated as "unspecified" and replaced by the midpoint-ish base
 // before clamping; callers normally pass rag.k_default.
 func adaptiveGate(query string, base, kMin, kMax int) adaptiveDecision {
-	// Defensive normalization so the gate is correct even if bounds arrive
-	// unsanitized; the engine also clamps these at wiring time.
+	kMin, kMax = normalizeAdaptiveBounds(kMin, kMax)
+	if base <= 0 {
+		base = kMin + (kMax-kMin)/2
+	}
+
+	sig := computeQuerySignals(query)
+
+	// SKIP: empty queries, or short conversational filler with no information
+	// need. Avoids an embedding+search when there is nothing to retrieve.
+	if sig.tokens == 0 || isTrivialSkip(sig) {
+		return adaptiveDecision{Retrieve: false, K: 0, Class: "skip"}
+	}
+	// HARD: long or multi-clause/comparative queries widen k toward kMax.
+	if isHardQuery(sig) {
+		return adaptiveDecision{Retrieve: true, K: kMax, Class: "widen"}
+	}
+	// EASY: short single-clause questions narrow k toward kMin.
+	if isEasyQuery(sig) {
+		return adaptiveDecision{Retrieve: true, K: kMin, Class: "narrow"}
+	}
+	// DEFAULT: clamp the caller's base k into the configured window.
+	return adaptiveDecision{Retrieve: true, K: clampInt(base, kMin, kMax), Class: "default"}
+}
+
+// querySignals holds the cheap, local features the gate derives from a query.
+type querySignals struct {
+	tokens           int  // word-like token count
+	hasInterrogative bool // a question word is present
+	hasQuestionMark  bool // a literal '?' is present
+	codey            bool // looks code-oriented (LooksLikeCodeQuery)
+	hardConnectors   int  // count of multi-clause/comparative connectors
+	allTrivial       bool // every token is conversational filler
+}
+
+// computeQuerySignals extracts the gate's decision features from query in a
+// single pass over its tokens.
+func computeQuerySignals(query string) querySignals {
+	toks := adaptiveWordRe.FindAllString(strings.ToLower(query), -1)
+	sig := querySignals{
+		tokens:          len(toks),
+		hasQuestionMark: strings.Contains(query, "?"),
+		codey:           LooksLikeCodeQuery(query),
+		allTrivial:      len(toks) > 0,
+	}
+	for _, t := range toks {
+		if adaptiveInterrogatives[t] {
+			sig.hasInterrogative = true
+		}
+		if adaptiveHardConnectors[t] {
+			sig.hardConnectors++
+		}
+		if !adaptiveTrivialTokens[t] {
+			sig.allTrivial = false
+		}
+	}
+	return sig
+}
+
+// isTrivialSkip reports whether a query is short conversational filler with no
+// information need (≤3 filler-only tokens, no question/code signal).
+func isTrivialSkip(sig querySignals) bool {
+	return sig.tokens <= 3 && sig.allTrivial &&
+		!sig.hasInterrogative && !sig.hasQuestionMark && !sig.codey
+}
+
+// isHardQuery reports whether a query is long or multi-clause/comparative and so
+// benefits from a wider evidence pool.
+func isHardQuery(sig querySignals) bool {
+	return sig.tokens >= 16 || sig.hardConnectors >= 2 ||
+		(sig.hardConnectors >= 1 && sig.tokens >= 10)
+}
+
+// isEasyQuery reports whether a query is a short, single-clause question that
+// can be answered from a narrow evidence pool.
+func isEasyQuery(sig querySignals) bool {
+	return sig.tokens <= 6 && sig.hardConnectors == 0 &&
+		(sig.hasInterrogative || sig.hasQuestionMark)
+}
+
+// normalizeAdaptiveBounds repairs a possibly-unsanitized [kMin, kMax] window to
+// 1 <= kMin <= kMax so the gate never emits an out-of-range k.
+func normalizeAdaptiveBounds(kMin, kMax int) (int, int) {
 	if kMin < 1 {
 		kMin = 1
 	}
 	if kMax < kMin {
 		kMax = kMin
 	}
-	if base <= 0 {
-		base = kMin + (kMax-kMin)/2
-	}
+	return kMin, kMax
+}
 
-	tokens := adaptiveWordRe.FindAllString(strings.ToLower(query), -1)
-	n := len(tokens)
-
-	// Empty/whitespace-only query: nothing to act on. Skip retrieval rather
-	// than burn an embedding+search on no signal.
-	if n == 0 {
-		return adaptiveDecision{Retrieve: false, K: 0, Class: "skip"}
+// clampInt clamps v into [lo, hi] (assumes lo <= hi).
+func clampInt(v, lo, hi int) int {
+	if v < lo {
+		return lo
 	}
-
-	hasInterrogative := false
-	hardConnectors := 0
-	for _, t := range tokens {
-		if adaptiveInterrogatives[t] {
-			hasInterrogative = true
-		}
-		if adaptiveHardConnectors[t] {
-			hardConnectors++
-		}
+	if v > hi {
+		return hi
 	}
-	hasQuestionMark := strings.Contains(query, "?")
-	codey := LooksLikeCodeQuery(query)
-
-	// SKIP: only for short queries with no information need. A query qualifies
-	// when every token is conversational filler and there is no interrogative
-	// word, no question mark, and no code signal. Capped at 3 tokens so a real
-	// short question is never skipped.
-	if n <= 3 && !hasInterrogative && !hasQuestionMark && !codey {
-		allTrivial := true
-		for _, t := range tokens {
-			if !adaptiveTrivialTokens[t] {
-				allTrivial = false
-				break
-			}
-		}
-		if allTrivial {
-			return adaptiveDecision{Retrieve: false, K: 0, Class: "skip"}
-		}
-	}
-
-	// HARD: long queries or multi-clause/comparative ones widen k toward kMax.
-	// Two independent signals (length OR connectors/length combos) keep this
-	// robust without a trained model.
-	hard := n >= 16 || hardConnectors >= 2 || (hardConnectors >= 1 && n >= 10)
-	if hard {
-		return adaptiveDecision{Retrieve: true, K: kMax, Class: "widen"}
-	}
-
-	// EASY: a short, single-clause question narrows k toward kMin. Requires a
-	// question signal so we don't aggressively narrow ambiguous statements.
-	easy := n <= 6 && hardConnectors == 0 && (hasInterrogative || hasQuestionMark)
-	if easy {
-		return adaptiveDecision{Retrieve: true, K: kMin, Class: "narrow"}
-	}
-
-	// DEFAULT: clamp the caller's base k into the configured window.
-	k := base
-	if k < kMin {
-		k = kMin
-	}
-	if k > kMax {
-		k = kMax
-	}
-	return adaptiveDecision{Retrieve: true, K: k, Class: "default"}
+	return v
 }

--- a/internal/retrieval/adaptive.go
+++ b/internal/retrieval/adaptive.go
@@ -1,0 +1,164 @@
+package retrieval
+
+import (
+	"regexp"
+	"strings"
+)
+
+// adaptiveDecision is the verdict of the training-free retrieval gate for a
+// single query. It is intentionally small and value-typed so the gate stays a
+// pure function of its inputs (query text + bounds): identical input always
+// yields identical output, which makes the behavior deterministic and testable
+// without any model or network call.
+type adaptiveDecision struct {
+	// Retrieve reports whether retrieval should run at all. When false the
+	// caller should answer without retrieved context (the "skip" verdict for
+	// trivial, non-informational queries such as greetings).
+	Retrieve bool
+	// K is the effective number of hits to request when Retrieve is true. It is
+	// always within the configured [kMin, kMax] window. When Retrieve is false
+	// K is 0 and carries no meaning.
+	K int
+	// Class is a short, stable label for the chosen policy ("skip", "narrow",
+	// "default", "widen"). It exists for logging/observability only and is not
+	// part of any external contract.
+	Class string
+}
+
+var (
+	// adaptiveWordRe extracts word-like tokens (letters/digits across Unicode)
+	// so the gate's length/keyword signals ignore punctuation and whitespace.
+	adaptiveWordRe = regexp.MustCompile(`[\p{L}\p{N}]+`)
+
+	// adaptiveTrivialTokens are stand-alone conversational tokens that, when a
+	// query consists solely of them (plus punctuation), carry no information
+	// need and so warrant skipping retrieval entirely. Kept deliberately small
+	// and high-precision to avoid skipping real questions.
+	adaptiveTrivialTokens = map[string]bool{
+		"hi": true, "hello": true, "hey": true, "yo": true,
+		"thanks": true, "thank": true, "thx": true, "ty": true,
+		"ok": true, "okay": true, "k": true, "cool": true, "nice": true,
+		"yes": true, "no": true, "yep": true, "nope": true, "sure": true,
+		"bye": true, "goodbye": true, "cya": true,
+		"please": true, "sorry": true,
+	}
+
+	// adaptiveInterrogatives signal a genuine information need; their presence
+	// blocks the "skip" verdict even for short queries.
+	adaptiveInterrogatives = map[string]bool{
+		"who": true, "what": true, "when": true, "where": true, "why": true,
+		"how": true, "which": true, "whom": true, "whose": true,
+		"is": true, "are": true, "do": true, "does": true, "did": true,
+		"can": true, "could": true, "should": true, "would": true, "will": true,
+		"explain": true, "describe": true, "list": true, "summarize": true,
+		"define": true, "find": true, "show": true, "give": true, "tell": true,
+	}
+
+	// adaptiveHardConnectors signal a multi-part or comparative query that
+	// typically benefits from a wider evidence pool.
+	adaptiveHardConnectors = map[string]bool{
+		"and": true, "or": true, "vs": true, "versus": true,
+		"compare": true, "comparison": true, "difference": true,
+		"differences": true, "between": true, "relationship": true,
+		"tradeoff": true, "tradeoffs": true, "pros": true, "cons": true,
+		"because": true, "therefore": true,
+	}
+)
+
+// adaptiveGate is the core, training-free retrieval decision. Given the raw
+// query and the resolved bounds (kMin <= kMax, both > 0) and the base k the
+// caller would otherwise use, it returns whether to retrieve and, if so, a
+// dynamic k clamped into [kMin, kMax].
+//
+// The policy uses only cheap, local query signals (length, question-likeness,
+// code-likeness, multi-clause connectors) so it adds no latency and is fully
+// deterministic:
+//
+//   - skip:    a short query made up solely of conversational filler tokens
+//     (greetings/acknowledgements) with no interrogative — no information need,
+//     so retrieval is skipped.
+//   - narrow:  a short, single-clause question — bias k toward kMin to cut
+//     noise and cost on easy lookups.
+//   - widen:   a long or multi-clause/comparative query — bias k toward kMax to
+//     pull more evidence for harder asks.
+//   - default: everything else — keep the base k (clamped into the window).
+//
+// base <= 0 is treated as "unspecified" and replaced by the midpoint-ish base
+// before clamping; callers normally pass rag.k_default.
+func adaptiveGate(query string, base, kMin, kMax int) adaptiveDecision {
+	// Defensive normalization so the gate is correct even if bounds arrive
+	// unsanitized; the engine also clamps these at wiring time.
+	if kMin < 1 {
+		kMin = 1
+	}
+	if kMax < kMin {
+		kMax = kMin
+	}
+	if base <= 0 {
+		base = kMin + (kMax-kMin)/2
+	}
+
+	tokens := adaptiveWordRe.FindAllString(strings.ToLower(query), -1)
+	n := len(tokens)
+
+	// Empty/whitespace-only query: nothing to act on. Skip retrieval rather
+	// than burn an embedding+search on no signal.
+	if n == 0 {
+		return adaptiveDecision{Retrieve: false, K: 0, Class: "skip"}
+	}
+
+	hasInterrogative := false
+	hardConnectors := 0
+	for _, t := range tokens {
+		if adaptiveInterrogatives[t] {
+			hasInterrogative = true
+		}
+		if adaptiveHardConnectors[t] {
+			hardConnectors++
+		}
+	}
+	hasQuestionMark := strings.Contains(query, "?")
+	codey := LooksLikeCodeQuery(query)
+
+	// SKIP: only for short queries with no information need. A query qualifies
+	// when every token is conversational filler and there is no interrogative
+	// word, no question mark, and no code signal. Capped at 3 tokens so a real
+	// short question is never skipped.
+	if n <= 3 && !hasInterrogative && !hasQuestionMark && !codey {
+		allTrivial := true
+		for _, t := range tokens {
+			if !adaptiveTrivialTokens[t] {
+				allTrivial = false
+				break
+			}
+		}
+		if allTrivial {
+			return adaptiveDecision{Retrieve: false, K: 0, Class: "skip"}
+		}
+	}
+
+	// HARD: long queries or multi-clause/comparative ones widen k toward kMax.
+	// Two independent signals (length OR connectors/length combos) keep this
+	// robust without a trained model.
+	hard := n >= 16 || hardConnectors >= 2 || (hardConnectors >= 1 && n >= 10)
+	if hard {
+		return adaptiveDecision{Retrieve: true, K: kMax, Class: "widen"}
+	}
+
+	// EASY: a short, single-clause question narrows k toward kMin. Requires a
+	// question signal so we don't aggressively narrow ambiguous statements.
+	easy := n <= 6 && hardConnectors == 0 && (hasInterrogative || hasQuestionMark)
+	if easy {
+		return adaptiveDecision{Retrieve: true, K: kMin, Class: "narrow"}
+	}
+
+	// DEFAULT: clamp the caller's base k into the configured window.
+	k := base
+	if k < kMin {
+		k = kMin
+	}
+	if k > kMax {
+		k = kMax
+	}
+	return adaptiveDecision{Retrieve: true, K: k, Class: "default"}
+}

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -163,6 +163,18 @@ type Service struct {
 	// citations. Default disabled ⇒ raw snippets are sent unchanged. Wired from
 	// config.ContextCompression* via SetContextCompression at construction.
 	compressor contextCompressor
+	// adaptiveEnabled toggles the opt-in, training-free retrieval gate
+	// (config retrieval.adaptive.enabled). Default false ⇒ Ask uses today's
+	// fixed-k path. When true, Ask consults adaptiveGate to decide whether to
+	// retrieve and what k to use, bounded by [adaptiveKMin, adaptiveKMax].
+	// Config-only — never an MCP tool parameter. Wired via SetAdaptiveRetrieval.
+	adaptiveEnabled bool
+	// adaptiveKMin / adaptiveKMax bound the dynamic k chosen by the gate. They
+	// are sanitized at wiring time (SetAdaptiveRetrieval) to 1 <= min <= max so
+	// the gate never emits an out-of-range k. Ignored when adaptiveEnabled is
+	// false.
+	adaptiveKMin int
+	adaptiveKMax int
 }
 
 // compile-time assertion that Service implements model.Retriever.  This
@@ -398,6 +410,41 @@ func (s *Service) SetContextCompression(enabled bool, targetRatio float64) {
 	s.metaMu.Lock()
 	defer s.metaMu.Unlock()
 	s.compressor = newContextCompressor(enabled, targetRatio)
+}
+
+// adaptiveKFloor / adaptiveKCeil are the built-in fallbacks used when the
+// operator leaves a bound at 0 ("use the default"). They give the gate a sane
+// window around the typical rag.k_default without requiring explicit tuning.
+const (
+	adaptiveKFloor = 4
+	adaptiveKCeil  = 30
+)
+
+// SetAdaptiveRetrieval wires the opt-in adaptive retrieval gate (config
+// retrieval.adaptive.*). When enabled is false the service keeps today's
+// fixed-k behavior and kMin/kMax are ignored. When enabled, kMin/kMax bound the
+// dynamic k the gate may choose; a bound <= 0 falls back to the built-in
+// default (adaptiveKFloor / adaptiveKCeil), and an inverted window is corrected
+// to kMax = kMin so the gate always sees 1 <= min <= max. The engine wires this
+// from config at construction time, mirroring SetMinScore.
+func (s *Service) SetAdaptiveRetrieval(enabled bool, kMin, kMax int) {
+	if kMin <= 0 {
+		kMin = adaptiveKFloor
+	}
+	if kMax <= 0 {
+		kMax = adaptiveKCeil
+	}
+	if kMin < 1 {
+		kMin = 1
+	}
+	if kMax < kMin {
+		kMax = kMin
+	}
+	s.metaMu.Lock()
+	defer s.metaMu.Unlock()
+	s.adaptiveEnabled = enabled
+	s.adaptiveKMin = kMin
+	s.adaptiveKMax = kMax
 }
 
 // SetDocumentHashes installs the rel_path → content_hash map used to group
@@ -885,9 +932,38 @@ func (s *Service) Ask(ctx context.Context, question string, query model.SearchQu
 		defer func() { s.emitQueryMetrics("ask", sink, time.Since(askStart)) }()
 	}
 
-	hits, err := s.search(ctx, query)
-	if err != nil {
-		return model.AskResult{}, err
+	// Adaptive retrieval gate (config retrieval.adaptive.*, opt-in). When
+	// enabled, a cheap deterministic heuristic decides whether to retrieve at
+	// all and what k to use; when disabled this is a no-op so the fixed-k path
+	// below is unchanged. The gate uses the question text (the effective query)
+	// and never alters the MCP tool contract.
+	skipRetrieval := false
+	s.metaMu.RLock()
+	adaptiveEnabled := s.adaptiveEnabled
+	adaptiveKMin := s.adaptiveKMin
+	adaptiveKMax := s.adaptiveKMax
+	s.metaMu.RUnlock()
+	if adaptiveEnabled {
+		decision := adaptiveGate(query.Query, query.K, adaptiveKMin, adaptiveKMax)
+		s.logf("adaptive gate: class=%s retrieve=%t k=%d (q=%q)", decision.Class, decision.Retrieve, decision.K, truncateQuestion(query.Query))
+		if decision.Retrieve {
+			query.K = decision.K
+		} else {
+			skipRetrieval = true
+		}
+	}
+
+	var (
+		hits []model.SearchHit
+		err  error
+	)
+	if !skipRetrieval {
+		// s.search (not s.Search) keeps the #327 usage sink owned by this Ask,
+		// so the nested search does not emit its own query_metrics event.
+		hits, err = s.search(ctx, query)
+		if err != nil {
+			return model.AskResult{}, err
+		}
 	}
 
 	citations := make([]model.Citation, 0, len(hits))

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -945,7 +945,7 @@ func (s *Service) Ask(ctx context.Context, question string, query model.SearchQu
 	s.metaMu.RUnlock()
 	if adaptiveEnabled {
 		decision := adaptiveGate(query.Query, query.K, adaptiveKMin, adaptiveKMax)
-		s.logf("adaptive gate: class=%s retrieve=%t k=%d (q=%q)", decision.Class, decision.Retrieve, decision.K, truncateQuestion(query.Query))
+		s.logf("adaptive gate: class=%s retrieve=%t k=%d", decision.Class, decision.Retrieve, decision.K)
 		if decision.Retrieve {
 			query.K = decision.K
 		} else {

--- a/tests/config/retrieval_adaptive_config_test.go
+++ b/tests/config/retrieval_adaptive_config_test.go
@@ -1,0 +1,153 @@
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+)
+
+// TestRetrievalAdaptive_DefaultDisabled pins the opt-in default: the adaptive
+// gate is off and its k bounds carry the built-in window unless configured.
+func TestRetrievalAdaptive_DefaultDisabled(t *testing.T) {
+	cfg := config.Default()
+	if cfg.RetrievalAdaptiveEnabled {
+		t.Fatalf("retrieval.adaptive.enabled must default to false")
+	}
+	if cfg.RetrievalAdaptiveKMin != 4 {
+		t.Fatalf("retrieval.adaptive.k_min default = %d, want 4", cfg.RetrievalAdaptiveKMin)
+	}
+	if cfg.RetrievalAdaptiveKMax != 30 {
+		t.Fatalf("retrieval.adaptive.k_max default = %d, want 30", cfg.RetrievalAdaptiveKMax)
+	}
+}
+
+// TestRetrievalAdaptive_NestedYAMLRoundTrips pins the nested-mapping form onto
+// the Config fields.
+func TestRetrievalAdaptive_NestedYAMLRoundTrips(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+	writeFile(t, path, strings.Join([]string{
+		"retrieval:",
+		"  adaptive:",
+		"    enabled: true",
+		"    k_min: 3",
+		"    k_max: 25",
+		"",
+	}, "\n"))
+
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if !cfg.RetrievalAdaptiveEnabled {
+		t.Fatalf("nested retrieval.adaptive.enabled did not round-trip")
+	}
+	if cfg.RetrievalAdaptiveKMin != 3 || cfg.RetrievalAdaptiveKMax != 25 {
+		t.Fatalf("nested k bounds = (%d,%d), want (3,25)", cfg.RetrievalAdaptiveKMin, cfg.RetrievalAdaptiveKMax)
+	}
+}
+
+// TestRetrievalAdaptive_FlatAliasRoundTrips pins the flat snake_case aliases.
+func TestRetrievalAdaptive_FlatAliasRoundTrips(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+	writeFile(t, path, strings.Join([]string{
+		"retrieval_adaptive_enabled: true",
+		"retrieval_adaptive_k_min: 5",
+		"retrieval_adaptive_k_max: 20",
+		"",
+	}, "\n"))
+
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if !cfg.RetrievalAdaptiveEnabled || cfg.RetrievalAdaptiveKMin != 5 || cfg.RetrievalAdaptiveKMax != 20 {
+		t.Fatalf("flat aliases = (%t,%d,%d), want (true,5,20)", cfg.RetrievalAdaptiveEnabled, cfg.RetrievalAdaptiveKMin, cfg.RetrievalAdaptiveKMax)
+	}
+}
+
+// TestRetrievalAdaptive_SnapshotRoundTrips pins the persisted-snapshot
+// round-trip: the gate settings survive SaveEffectiveSnapshot -> YAML -> load.
+func TestRetrievalAdaptive_SnapshotRoundTrips(t *testing.T) {
+	cfg := config.Default()
+	cfg.StateDir = t.TempDir()
+	cfg.RetrievalAdaptiveEnabled = true
+	cfg.RetrievalAdaptiveKMin = 6
+	cfg.RetrievalAdaptiveKMax = 18
+
+	path, err := config.SaveEffectiveSnapshot(cfg, config.SecretSourceMetadata{})
+	if err != nil {
+		t.Fatalf("SaveEffectiveSnapshot: %v", err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	for _, want := range []string{
+		"retrieval_adaptive_enabled: true",
+		"retrieval_adaptive_k_min: 6",
+		"retrieval_adaptive_k_max: 18",
+	} {
+		if !strings.Contains(string(raw), want) {
+			t.Fatalf("snapshot must persist %q:\n%s", want, raw)
+		}
+	}
+
+	loaded, _, err := config.LoadEffectiveSnapshot(path)
+	if err != nil {
+		t.Fatalf("LoadEffectiveSnapshot: %v", err)
+	}
+	if !loaded.RetrievalAdaptiveEnabled || loaded.RetrievalAdaptiveKMin != 6 || loaded.RetrievalAdaptiveKMax != 18 {
+		t.Fatalf("loaded snapshot = (%t,%d,%d), want (true,6,18)", loaded.RetrievalAdaptiveEnabled, loaded.RetrievalAdaptiveKMin, loaded.RetrievalAdaptiveKMax)
+	}
+}
+
+// TestRetrievalAdaptive_RejectsNegativeKBound pins validation: a negative bound
+// is CONFIG_INVALID when the gate is enabled.
+func TestRetrievalAdaptive_RejectsNegativeKBound(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+	writeFile(t, path, strings.Join([]string{
+		"retrieval_adaptive_enabled: true",
+		"retrieval_adaptive_k_min: -1",
+		"",
+	}, "\n"))
+
+	// A negative integer is rejected at parse time for non-negative keys.
+	if _, err := config.LoadFile(path); err == nil {
+		t.Fatalf("LoadFile with negative k_min = nil error, want rejection")
+	}
+}
+
+// TestRetrievalAdaptive_RejectsInvertedWindow pins validation: k_min > k_max is
+// rejected when the gate is enabled, because clamping would be ill-defined.
+func TestRetrievalAdaptive_RejectsInvertedWindow(t *testing.T) {
+	cfg := config.Default()
+	cfg.RetrievalAdaptiveEnabled = true
+	cfg.RetrievalAdaptiveKMin = 20
+	cfg.RetrievalAdaptiveKMax = 5
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatalf("Validate with inverted window = nil error, want rejection")
+	}
+	if !strings.Contains(err.Error(), "retrieval.adaptive") {
+		t.Fatalf("error must mention retrieval.adaptive, got: %v", err)
+	}
+}
+
+// TestRetrievalAdaptive_DisabledSkipsBoundValidation pins that an inverted
+// window is tolerated while the gate is disabled (the bounds are ignored), so a
+// stale config never blocks startup.
+func TestRetrievalAdaptive_DisabledSkipsBoundValidation(t *testing.T) {
+	cfg := config.Default()
+	cfg.RetrievalAdaptiveEnabled = false
+	cfg.RetrievalAdaptiveKMin = 20
+	cfg.RetrievalAdaptiveKMax = 5
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate with disabled gate must ignore k bounds, got: %v", err)
+	}
+}

--- a/tests/retrieval/adaptive_gate_test.go
+++ b/tests/retrieval/adaptive_gate_test.go
@@ -1,0 +1,122 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
+)
+
+// newAdaptiveService builds a retrieval service whose index records the k it is
+// asked for (fakeRetrievalIndex.lastK). Overfetch is pinned to 1 so lastK is
+// exactly the effective k the gate chose (no multiplier to back out). The fake
+// index returns no hits, which is all these tests need: they assert on the k
+// requested and on whether the index was queried at all, not on results.
+func newAdaptiveService(t *testing.T) (*retrieval.Service, *fakeRetrievalIndex) {
+	t.Helper()
+	idx := &fakeRetrievalIndex{lastK: -1}
+	emb := &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{"mistral-embed": {1, 0}}}
+	svc := retrieval.NewService(nil, idx, emb, nil)
+	svc.SetOverfetchMultiplier(1)
+	return svc, idx
+}
+
+// askEffectiveK runs Ask and returns the k the index was asked for. A returned
+// value of -1 means the index was never queried (retrieval skipped).
+func askEffectiveK(t *testing.T, svc *retrieval.Service, idx *fakeRetrievalIndex, question string) int {
+	t.Helper()
+	idx.lastK = -1
+	if _, err := svc.Ask(context.Background(), question, model.SearchQuery{Index: "text"}); err != nil {
+		t.Fatalf("Ask(%q): %v", question, err)
+	}
+	return idx.lastK
+}
+
+// TestAdaptive_Disabled_UsesFixedK pins the default-off contract: with the gate
+// disabled, Ask uses the fixed default k (15) regardless of query shape — a
+// trivial greeting and a hard multi-clause question request the same k, and the
+// index is always queried.
+func TestAdaptive_Disabled_UsesFixedK(t *testing.T) {
+	svc, idx := newAdaptiveService(t)
+	// gate left unset (disabled by default).
+
+	if got := askEffectiveK(t, svc, idx, "hi"); got != 15 {
+		t.Fatalf("disabled gate: trivial query should use fixed k=15, got %d", got)
+	}
+	hard := "compare and contrast the performance and reliability tradeoffs between approach one and approach two in detail"
+	if got := askEffectiveK(t, svc, idx, hard); got != 15 {
+		t.Fatalf("disabled gate: hard query should use fixed k=15, got %d", got)
+	}
+}
+
+// TestAdaptive_Skip_TrivialQuery pins the skip verdict: an enabled gate must NOT
+// query the index for a pure conversational greeting (no information need).
+func TestAdaptive_Skip_TrivialQuery(t *testing.T) {
+	svc, idx := newAdaptiveService(t)
+	svc.SetAdaptiveRetrieval(true, 4, 30)
+
+	if got := askEffectiveK(t, svc, idx, "thanks"); got != -1 {
+		t.Fatalf("enabled gate: trivial query should skip retrieval (lastK -1), got %d", got)
+	}
+	// A real short question must NOT be skipped even when enabled.
+	if got := askEffectiveK(t, svc, idx, "what is x402?"); got == -1 {
+		t.Fatalf("enabled gate: a real question must not be skipped")
+	}
+}
+
+// TestAdaptive_Narrow_EasyQuery pins the narrow verdict: an enabled gate biases
+// k toward k_min for a short, single-clause question.
+func TestAdaptive_Narrow_EasyQuery(t *testing.T) {
+	svc, idx := newAdaptiveService(t)
+	svc.SetAdaptiveRetrieval(true, 4, 30)
+
+	got := askEffectiveK(t, svc, idx, "what is x402?")
+	if got != 4 {
+		t.Fatalf("enabled gate: easy question should narrow k to k_min=4, got %d", got)
+	}
+}
+
+// TestAdaptive_Widen_HardQuery pins the widen verdict: an enabled gate biases k
+// toward k_max for a long, multi-clause/comparative question.
+func TestAdaptive_Widen_HardQuery(t *testing.T) {
+	svc, idx := newAdaptiveService(t)
+	svc.SetAdaptiveRetrieval(true, 4, 30)
+
+	hard := "compare and contrast the performance and reliability tradeoffs between approach one and approach two in detail"
+	got := askEffectiveK(t, svc, idx, hard)
+	if got != 30 {
+		t.Fatalf("enabled gate: hard question should widen k to k_max=30, got %d", got)
+	}
+}
+
+// TestAdaptive_Default_ClampsBaseK pins the default verdict: a medium query that
+// is neither easy nor hard keeps the base k (here the Ask default of 15) clamped
+// into the configured window. With a window of [4,10] the base 15 clamps to 10.
+func TestAdaptive_Default_ClampsBaseK(t *testing.T) {
+	svc, idx := newAdaptiveService(t)
+	svc.SetAdaptiveRetrieval(true, 4, 10)
+
+	// A statement (no interrogative, no connectors, mid length) → default class.
+	got := askEffectiveK(t, svc, idx, "the indexing pipeline handles multimodal documents end to end")
+	if got != 10 {
+		t.Fatalf("enabled gate: default class should clamp base k into window (10), got %d", got)
+	}
+}
+
+// TestAdaptive_BoundsSanitized pins that SetAdaptiveRetrieval repairs an
+// unusable window: a 0 (use default) max and an inverted min/max never produce
+// an out-of-range or panicking k. With min=8 and max=0 (→ default 30), a hard
+// query widens to 30, not to 8.
+func TestAdaptive_BoundsSanitized(t *testing.T) {
+	svc, idx := newAdaptiveService(t)
+	svc.SetAdaptiveRetrieval(true, 8, 0)
+
+	hard := "compare and contrast the performance and reliability tradeoffs between approach one and approach two in detail"
+	if got := askEffectiveK(t, svc, idx, hard); got != 30 {
+		t.Fatalf("k_max=0 should fall back to built-in default 30, got %d", got)
+	}
+	if got := askEffectiveK(t, svc, idx, "what is x402?"); got != 8 {
+		t.Fatalf("easy query should narrow to k_min=8, got %d", got)
+	}
+}


### PR DESCRIPTION
Closes #338

## What

Adds an **opt-in, training-free** retrieval gate that decides *whether* to retrieve per query and *how much* evidence to pull, instead of always retrieving at a fixed k. Off by default, so behavior is unchanged unless explicitly enabled. Config-only — no MCP tool/citation contract change, so it is **ungated** (no spec re-pin).

## Config (`retrieval.adaptive.*`)

| key | default | meaning |
|---|---|---|
| `retrieval.adaptive.enabled` | `false` | opt-in toggle; off ⇒ today's fixed-k path |
| `retrieval.adaptive.k_min` | `4` | lower bound for dynamic k (`0` ⇒ built-in default 4) |
| `retrieval.adaptive.k_max` | `30` | upper bound for dynamic k (`0` ⇒ built-in default 30) |

Plumbed through the full `RetrievalMinScore` template: `Config` field, `fileConfig`/`persistedConfig`, defaults, apply, snapshot, flat+nested aliases, scalar-setter tables, map-section key, env overrides (`DIR2MCP_RETRIEVAL_ADAPTIVE_*`), and validation. Validation (only when enabled) rejects negative bounds and an inverted window; a disabled gate ignores its bounds so a stale config never blocks startup.

## Gate heuristic (deterministic, training-free)

`adaptiveGate(query, base, kMin, kMax)` uses only cheap local query signals — token count, interrogative words / `?`, code-likeness, and multi-clause/comparative connectors:

- **skip** — empty query, or ≤3 conversational-filler tokens with no question/code signal ⇒ Ask answers without retrieved context.
- **narrow** — short single-clause question (≤6 tokens, has interrogative/`?`, no connectors) ⇒ `k = k_min`.
- **widen** — long (≥16 tokens) or multi-clause/comparative ⇒ `k = k_max`.
- **default** — everything else ⇒ base k (rag.k_default) clamped into `[k_min, k_max]`.

Wired via `Service.SetAdaptiveRetrieval` (mirrors `SetMinScore`) and consulted in `Ask`; bounds are sanitized at wiring time so the gate never emits an out-of-range k.

## Tests (external `tests/<pkg>`, fakes only — no creds)

`tests/retrieval/adaptive_gate_test.go`:
- `TestAdaptive_Disabled_UsesFixedK`
- `TestAdaptive_Skip_TrivialQuery`
- `TestAdaptive_Narrow_EasyQuery`
- `TestAdaptive_Widen_HardQuery`
- `TestAdaptive_Default_ClampsBaseK`
- `TestAdaptive_BoundsSanitized`

`tests/config/retrieval_adaptive_config_test.go`:
- `TestRetrievalAdaptive_DefaultDisabled`
- `TestRetrievalAdaptive_NestedYAMLRoundTrips`
- `TestRetrievalAdaptive_FlatAliasRoundTrips`
- `TestRetrievalAdaptive_SnapshotRoundTrips`
- `TestRetrievalAdaptive_RejectsNegativeKBound`
- `TestRetrievalAdaptive_RejectsInvertedWindow`
- `TestRetrievalAdaptive_DisabledSkipsBoundValidation`

`make check` fully green (gocyclo ≤15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added adaptive retrieval configuration that intelligently optimizes document retrieval based on query characteristics. The feature automatically classifies queries and adjusts retrieval depth—skipping trivial queries, narrowing results for simple questions, and expanding for complex queries—improving performance and relevance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->