### PR TITLE
feat(retrieval): evidence-guided context compression before generation (#335)

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -823,6 +823,7 @@ func (a *App) buildRetrieverForAsk(ctx context.Context, cfg config.Config, st mo
 	// to avoid contaminating that output; it never alters the result itself.
 	askMetricsEmitter := newNDJSONEmitter(a.stderr, true)
 	a.configureQueryMetrics(ret, cfg, askMetricsEmitter.Emit)
+	ret.SetContextCompression(cfg.ContextCompressionEnabled, cfg.ContextCompressionTargetRatio)
 
 	if metadataStore, ok := st.(embeddedChunkLister); ok {
 		if _, err := preloadEmbeddedChunkMetadata(ctx, metadataStore, ret); err != nil && !errors.Is(err, model.ErrNotImplemented) {

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -80,6 +80,7 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 	ret.SetCrossFileDedupEnabled(cfg.DedupRetrieval)
 	ret.SetMinScore(cfg.RetrievalMinScore)
 	ret.SetRecencyHalfLife(cfg.RetrievalRecencyHalfLife)
+	ret.SetContextCompression(cfg.ContextCompressionEnabled, cfg.ContextCompressionTargetRatio)
 
 	// events are emitted to stdout only after we create the emitter; moving
 	// creation before the preload call lets us report failures from that

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2108,7 +2108,7 @@ func canonicalizeConfigKey(key string) string {
 // (so child keys should be prefixed) rather than a scalar/list key.
 func isMapSectionKey(key string) bool {
 	switch key {
-	case "rag", "ingest", "ingest.docling", "stt", "stt.mistral", "stt.elevenlabs", "server", "server.tls", "secret_sources", "mistral", "docling", "security", "security.auth", "x402", "x402.route_policy", "x402.route_policy.tools_call", "chunking", "retrieval", "retrieval.hybrid", "rerank", "rerank.cohere", "index", "dedup":
+	case "rag", "ingest", "ingest.docling", "stt", "stt.mistral", "stt.elevenlabs", "server", "server.tls", "secret_sources", "mistral", "docling", "security", "security.auth", "x402", "x402.route_policy", "x402.route_policy.tools_call", "chunking", "retrieval", "retrieval.hybrid", "retrieval.context_compression", "rerank", "rerank.cohere", "index", "dedup":
 		return true
 	case "ingest.pdf", "ingest.images", "ingest.audio", "ingest.archives", "secrets", "index.qdrant":
 		return true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -239,6 +239,23 @@ type Config struct {
 	// disabled (no decay): behavior is unchanged unless configured. Negative
 	// values are CONFIG_INVALID.
 	RetrievalRecencyHalfLife time.Duration
+	// ContextCompressionEnabled toggles evidence-guided context compression
+	// (config `retrieval.context_compression.enabled`): when true, the Ask path
+	// compresses the per-hit text that is sent to the generator — keeping only
+	// query-relevant sentences and dropping redundant ones — to cut prompt
+	// tokens and fit more evidence inside `rag.max_context_chars`. It is
+	// config-only (NOT an MCP tool parameter) so no tool input/output schema
+	// changes. It compresses ONLY the model-facing context: citations and the
+	// returned hits/snippets are never altered, so citation fidelity is
+	// preserved. Default false ⇒ unchanged behavior (raw snippets are sent).
+	ContextCompressionEnabled bool
+	// ContextCompressionTargetRatio bounds how aggressively a hit's text is
+	// compressed: the keeper keeps at most this fraction of the hit's original
+	// rune length (rounded up), always retaining at least the single most
+	// query-relevant sentence. Valid range (0,1]; 0 selects the built-in
+	// default (0.5). Values >1 or non-finite are CONFIG_INVALID. Ignored when
+	// ContextCompressionEnabled is false.
+	ContextCompressionTargetRatio float64
 	// Rerank* configure the optional post-fusion rerank stage (SPEC
 	// 9.1.1). Reranking auto-activates when a provider credential is
 	// present. CohereAPIKey is a secret: env-sourced, never persisted
@@ -545,6 +562,8 @@ type fileConfig struct {
 	DedupRetrieval                     *bool
 	RetrievalMinScore                  *float64
 	RetrievalRecencyHalfLife           *time.Duration
+	ContextCompressionEnabled          *bool
+	ContextCompressionTargetRatio      *float64
 	RerankEnabled                      *bool
 	RerankProvider                     *string
 	CohereAPIKey                       *string
@@ -663,6 +682,8 @@ type persistedConfig struct {
 	DedupRetrieval                     bool          `yaml:"dedup_retrieval"`
 	RetrievalMinScore                  float64       `yaml:"retrieval_min_score"`
 	RetrievalRecencyHalfLife           time.Duration `yaml:"retrieval_recency_half_life"`
+	ContextCompressionEnabled          bool          `yaml:"context_compression_enabled"`
+	ContextCompressionTargetRatio      float64       `yaml:"context_compression_target_ratio"`
 	RerankEnabled                      bool          `yaml:"rerank_enabled"`
 	RerankProvider                     string        `yaml:"rerank_provider"`
 	CohereBaseURL                      string        `yaml:"cohere_base_url"`
@@ -825,6 +846,12 @@ func Default() Config {
 		// RetrievalRecencyHalfLife defaults to 0 (disabled): no time-decay is
 		// applied unless explicitly configured.
 		RetrievalRecencyHalfLife: 0,
+		// ContextCompressionEnabled defaults to false: the Ask path sends raw
+		// snippets unchanged unless compression is explicitly enabled.
+		ContextCompressionEnabled: false,
+		// ContextCompressionTargetRatio defaults to 0 (use the built-in 0.5
+		// keep-ratio); it only takes effect when compression is enabled.
+		ContextCompressionTargetRatio: 0,
 		// RerankEnabled left nil: auto mode (activates iff a rerank
 		// provider credential is present). See rerankEnabledEffective.
 		RerankProvider:            "cohere",
@@ -941,6 +968,8 @@ func buildPersistedConfig(cfg *Config) persistedConfig {
 		DedupRetrieval:                     cfg.DedupRetrieval,
 		RetrievalMinScore:                  cfg.RetrievalMinScore,
 		RetrievalRecencyHalfLife:           cfg.RetrievalRecencyHalfLife,
+		ContextCompressionEnabled:          cfg.ContextCompressionEnabled,
+		ContextCompressionTargetRatio:      cfg.ContextCompressionTargetRatio,
 		RerankEnabled:                      rerankEnabledEffective(cfg),
 		RerankProvider:                     cfg.RerankProvider,
 		CohereBaseURL:                      cfg.CohereBaseURL,
@@ -1546,6 +1575,12 @@ func applyModelRAGFileParsed(cfg *Config, fc fileConfig) {
 	if fc.RetrievalRecencyHalfLife != nil {
 		cfg.RetrievalRecencyHalfLife = *fc.RetrievalRecencyHalfLife
 	}
+	if fc.ContextCompressionEnabled != nil {
+		cfg.ContextCompressionEnabled = *fc.ContextCompressionEnabled
+	}
+	if fc.ContextCompressionTargetRatio != nil {
+		cfg.ContextCompressionTargetRatio = *fc.ContextCompressionTargetRatio
+	}
 	if fc.SessionInactivityTimeout != nil {
 		cfg.SessionInactivityTimeout = *fc.SessionInactivityTimeout
 	}
@@ -1961,6 +1996,9 @@ var configKeyAliases = map[string]string{
 	"min_score":                               "retrieval.min_score",
 	"retrieval_recency_half_life":             "retrieval.recency_half_life",
 	"recency_half_life":                       "retrieval.recency_half_life",
+	"context_compression_enabled":             "retrieval.context_compression.enabled",
+	"context_compression":                     "retrieval.context_compression.enabled",
+	"context_compression_target_ratio":        "retrieval.context_compression.target_ratio",
 	"rerank_enabled":                          "rerank.enabled",
 	"rerank.cohere.api_key":                   "cohere_api_key",
 	"rerank.cohere.base_url":                  "cohere_base_url",
@@ -2146,7 +2184,10 @@ var boolFileScalarTargets = map[string]func(*fileConfig) **bool{
 	"x402_tools_call_enabled":  func(c *fileConfig) **bool { return &c.X402ToolsCallEnabled },
 	"retrieval.hybrid.enabled": func(c *fileConfig) **bool { return &c.RetrievalHybridEnabled },
 	"dedup.retrieval":          func(c *fileConfig) **bool { return &c.DedupRetrieval },
-	"rerank.enabled":           func(c *fileConfig) **bool { return &c.RerankEnabled },
+	"retrieval.context_compression.enabled": func(c *fileConfig) **bool {
+		return &c.ContextCompressionEnabled
+	},
+	"rerank.enabled": func(c *fileConfig) **bool { return &c.RerankEnabled },
 	"distributed_embed_enabled": func(c *fileConfig) **bool {
 		return &c.DistributedEmbedEnabled
 	},
@@ -2232,6 +2273,8 @@ func setFloatFileScalar(cfg *fileConfig, key, value string) error {
 		target = &cfg.MediaSilenceThresholdDB
 	case "retrieval.min_score":
 		target = &cfg.RetrievalMinScore
+	case "retrieval.context_compression.target_ratio":
+		target = &cfg.ContextCompressionTargetRatio
 	default:
 		return nil
 	}
@@ -2549,6 +2592,8 @@ func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	writeBool("dedup_retrieval", cfg.DedupRetrieval)
 	writeScalar("retrieval_min_score", strconv.FormatFloat(cfg.RetrievalMinScore, 'f', -1, 64))
 	writeScalar("retrieval_recency_half_life", cfg.RetrievalRecencyHalfLife.String())
+	writeBool("context_compression_enabled", cfg.ContextCompressionEnabled)
+	writeScalar("context_compression_target_ratio", strconv.FormatFloat(cfg.ContextCompressionTargetRatio, 'f', -1, 64))
 	writeBool("rerank_enabled", cfg.RerankEnabled)
 	writeScalar("rerank_provider", cfg.RerankProvider)
 	writeScalar("cohere_base_url", cfg.CohereBaseURL)
@@ -3287,19 +3332,34 @@ func (c *Config) validateNumericBounds() error {
 	if c.IngestMaxFileMB < 0 {
 		return fmt.Errorf("ingest.max_file_mb must be non-negative: %d", c.IngestMaxFileMB)
 	}
-	// retrieval.min_score is a relevance floor; 0 disables it. A negative floor is
-	// meaningless (it would never drop anything) so reject it explicitly. NaN/Inf
-	// are already rejected at parse time in setFloatFileScalar, but guard here too
-	// so a value injected programmatically (not via the file parser) still fails
-	// validation rather than silently corrupting the floor comparison.
+	if err := c.validateRetrievalNumericBounds(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateRetrievalNumericBounds validates the retrieval-tuning numeric knobs —
+// the min_score relevance floor (#305), the recency time-decay half-life (#323),
+// and the context-compression keep-ratio (#335) — extracted from
+// validateNumericBounds to keep it within the gocyclo budget. NaN/Inf are also
+// rejected at parse time, but are re-guarded here so a programmatically-injected
+// value still fails validation rather than silently corrupting behavior.
+func (c *Config) validateRetrievalNumericBounds() error {
+	// retrieval.min_score is a relevance floor; 0 disables it. A negative floor
+	// would never drop anything, so reject it explicitly.
 	if c.RetrievalMinScore < 0 || math.IsNaN(c.RetrievalMinScore) || math.IsInf(c.RetrievalMinScore, 0) {
 		return fmt.Errorf("retrieval.min_score must be a non-negative finite number: %v", c.RetrievalMinScore)
 	}
 	// retrieval.recency_half_life is a time-decay half-life; 0 disables it. A
-	// negative half-life is meaningless (it would amplify rather than decay older
-	// content) so reject it explicitly, mirroring the min_score guard.
+	// negative half-life would amplify rather than decay older content.
 	if c.RetrievalRecencyHalfLife < 0 {
 		return fmt.Errorf("retrieval.recency_half_life must be non-negative: %v", c.RetrievalRecencyHalfLife)
+	}
+	// retrieval.context_compression.target_ratio is a keep-fraction in (0,1];
+	// 0 selects the built-in default at the retrieval layer.
+	if math.IsNaN(c.ContextCompressionTargetRatio) || math.IsInf(c.ContextCompressionTargetRatio, 0) ||
+		c.ContextCompressionTargetRatio < 0 || c.ContextCompressionTargetRatio > 1 {
+		return fmt.Errorf("retrieval.context_compression.target_ratio must be in [0,1] (0 = default): %v", c.ContextCompressionTargetRatio)
 	}
 	return nil
 }

--- a/internal/retrieval/compress.go
+++ b/internal/retrieval/compress.go
@@ -1,0 +1,234 @@
+package retrieval
+
+import (
+	"sort"
+	"strings"
+	"unicode"
+)
+
+// Evidence-guided context compression (issue #335).
+//
+// This is a deterministic, dependency-free compression pass applied ONLY to the
+// per-hit text that is assembled into the RAG prompt sent to the generator. It
+// never touches the SearchHit values themselves, the returned citations, or the
+// hit snippets surfaced to callers — so citation fidelity is fully preserved.
+//
+// The pass is inspired by evidentiality-guided compression (ECoRAG) and prompt
+// compression (LLMLingua), reduced to two cheap, deterministic heuristics:
+//
+//  1. query-relevance sentence filtering: rank a chunk's sentences by lexical
+//     overlap with the query and keep the most relevant ones up to a budget;
+//  2. redundancy dedup: drop a candidate sentence whose token set is nearly a
+//     subset of an already-kept sentence.
+//
+// Kept sentences are re-emitted in their ORIGINAL order so the surviving text
+// stays readable and faithful to the source ordering.
+
+const (
+	// defaultCompressionTargetRatio is the keep-fraction used when the operator
+	// enables compression without specifying a ratio (config 0 ⇒ default).
+	defaultCompressionTargetRatio = 0.5
+	// redundancyOverlapThreshold is the token-set containment above which a
+	// candidate sentence is considered redundant with an already-kept one.
+	redundancyOverlapThreshold = 0.9
+	// minSentenceRunes guards against compressing already-tiny text: snippets at
+	// or below this rune length are returned unchanged (compression cannot
+	// meaningfully help and risks dropping the only evidence).
+	minSentenceRunes = 80
+)
+
+// contextCompressor holds the resolved compression policy. The zero value with
+// enabled=false is a pass-through. It is safe for concurrent use (immutable
+// after construction).
+type contextCompressor struct {
+	enabled     bool
+	targetRatio float64
+}
+
+// newContextCompressor resolves an enable flag and a raw target ratio into a
+// usable policy. A ratio outside (0,1] falls back to the built-in default; this
+// mirrors the config-layer validation but keeps the retrieval layer robust to
+// programmatic construction.
+func newContextCompressor(enabled bool, targetRatio float64) contextCompressor {
+	if targetRatio <= 0 || targetRatio > 1 {
+		targetRatio = defaultCompressionTargetRatio
+	}
+	return contextCompressor{enabled: enabled, targetRatio: targetRatio}
+}
+
+// compressSnippet returns an evidence-filtered version of text relevant to
+// query. When compression is disabled, the input is too short to benefit, or no
+// query terms are available, the original text is returned unchanged. The result
+// is never longer than the input and never empty when the input is non-empty.
+func (c contextCompressor) compressSnippet(query, text string) string {
+	if !c.enabled {
+		return text
+	}
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" {
+		return text
+	}
+	if len([]rune(trimmed)) <= minSentenceRunes {
+		return text
+	}
+
+	sentences := splitSentences(trimmed)
+	if len(sentences) <= 1 {
+		return text
+	}
+
+	queryTerms := tokenSet(query)
+	if len(queryTerms) == 0 {
+		// Without query signal we cannot rank by relevance; leave the text as is
+		// rather than guessing (graceful no-op).
+		return text
+	}
+
+	type scored struct {
+		idx    int
+		text   string
+		tokens map[string]struct{}
+		score  float64
+	}
+	ranked := make([]scored, 0, len(sentences))
+	for i, s := range sentences {
+		toks := tokenSet(s)
+		ranked = append(ranked, scored{
+			idx:    i,
+			text:   s,
+			tokens: toks,
+			score:  overlapScore(queryTerms, toks),
+		})
+	}
+
+	// Rank by descending relevance; ties keep original order for determinism.
+	sort.SliceStable(ranked, func(i, j int) bool {
+		if ranked[i].score == ranked[j].score {
+			return ranked[i].idx < ranked[j].idx
+		}
+		return ranked[i].score > ranked[j].score
+	})
+
+	budget := int(float64(len([]rune(trimmed)))*c.targetRatio + 0.999)
+	if budget < 1 {
+		budget = 1
+	}
+
+	keptIdx := make([]int, 0, len(ranked))
+	keptTokens := make([]map[string]struct{}, 0, len(ranked))
+	used := 0
+	for _, cand := range ranked {
+		// Always keep the single most relevant sentence (first in ranked order)
+		// so compression never drops all evidence, even if it overruns budget.
+		mostRelevant := len(keptIdx) == 0
+		if !mostRelevant {
+			if used >= budget {
+				break
+			}
+			if isRedundant(cand.tokens, keptTokens) {
+				continue
+			}
+		}
+		keptIdx = append(keptIdx, cand.idx)
+		keptTokens = append(keptTokens, cand.tokens)
+		used += len([]rune(cand.text)) + 1 // +1 for the joining space
+	}
+
+	// Re-emit kept sentences in original order for readability/fidelity.
+	sort.Ints(keptIdx)
+	parts := make([]string, 0, len(keptIdx))
+	for _, idx := range keptIdx {
+		parts = append(parts, sentences[idx])
+	}
+	out := strings.Join(parts, " ")
+	if strings.TrimSpace(out) == "" {
+		// Defensive: never return empty for non-empty input.
+		return text
+	}
+	return out
+}
+
+// isRedundant reports whether cand's token set is mostly contained in any
+// already-kept sentence's token set (containment >= redundancyOverlapThreshold).
+func isRedundant(cand map[string]struct{}, kept []map[string]struct{}) bool {
+	if len(cand) == 0 {
+		return false
+	}
+	for _, k := range kept {
+		if containment(cand, k) >= redundancyOverlapThreshold {
+			return true
+		}
+	}
+	return false
+}
+
+// containment returns the fraction of a's tokens that also appear in b.
+func containment(a, b map[string]struct{}) float64 {
+	if len(a) == 0 {
+		return 0
+	}
+	hits := 0
+	for t := range a {
+		if _, ok := b[t]; ok {
+			hits++
+		}
+	}
+	return float64(hits) / float64(len(a))
+}
+
+// overlapScore returns the fraction of a sentence's tokens that are query terms.
+// Normalizing by sentence length avoids favoring long sentences purely for
+// containing more tokens.
+func overlapScore(query, sentence map[string]struct{}) float64 {
+	if len(sentence) == 0 {
+		return 0
+	}
+	hits := 0
+	for t := range sentence {
+		if _, ok := query[t]; ok {
+			hits++
+		}
+	}
+	return float64(hits) / float64(len(sentence))
+}
+
+// tokenSet lowercases s and returns the set of word tokens (letters/digits),
+// dropping single-character tokens which carry little signal.
+func tokenSet(s string) map[string]struct{} {
+	fields := strings.FieldsFunc(strings.ToLower(s), func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsNumber(r)
+	})
+	set := make(map[string]struct{}, len(fields))
+	for _, f := range fields {
+		if len([]rune(f)) <= 1 {
+			continue
+		}
+		set[f] = struct{}{}
+	}
+	return set
+}
+
+// splitSentences breaks text into sentences on terminal punctuation (. ! ?) and
+// newlines. It keeps the punctuation with the sentence and trims surrounding
+// whitespace. Empty fragments are dropped. This is intentionally simple and
+// deterministic rather than linguistically perfect.
+func splitSentences(text string) []string {
+	var sentences []string
+	var b strings.Builder
+	flush := func() {
+		s := strings.TrimSpace(b.String())
+		if s != "" {
+			sentences = append(sentences, s)
+		}
+		b.Reset()
+	}
+	for _, r := range text {
+		b.WriteRune(r)
+		switch r {
+		case '.', '!', '?', '\n':
+			flush()
+		}
+	}
+	flush()
+	return sentences
+}

--- a/internal/retrieval/compress.go
+++ b/internal/retrieval/compress.go
@@ -57,6 +57,15 @@ func newContextCompressor(enabled bool, targetRatio float64) contextCompressor {
 	return contextCompressor{enabled: enabled, targetRatio: targetRatio}
 }
 
+// scoredSentence pairs a sentence with its original position, token set, and
+// query-relevance score.
+type scoredSentence struct {
+	idx    int
+	text   string
+	tokens map[string]struct{}
+	score  float64
+}
+
 // compressSnippet returns an evidence-filtered version of text relevant to
 // query. When compression is disabled, the input is too short to benefit, or no
 // query terms are available, the original text is returned unchanged. The result
@@ -66,18 +75,13 @@ func (c contextCompressor) compressSnippet(query, text string) string {
 		return text
 	}
 	trimmed := strings.TrimSpace(text)
-	if trimmed == "" {
+	if trimmed == "" || len([]rune(trimmed)) <= minSentenceRunes {
 		return text
 	}
-	if len([]rune(trimmed)) <= minSentenceRunes {
-		return text
-	}
-
 	sentences := splitSentences(trimmed)
 	if len(sentences) <= 1 {
 		return text
 	}
-
 	queryTerms := tokenSet(query)
 	if len(queryTerms) == 0 {
 		// Without query signal we cannot rank by relevance; leave the text as is
@@ -85,63 +89,9 @@ func (c contextCompressor) compressSnippet(query, text string) string {
 		return text
 	}
 
-	type scored struct {
-		idx    int
-		text   string
-		tokens map[string]struct{}
-		score  float64
-	}
-	ranked := make([]scored, 0, len(sentences))
-	for i, s := range sentences {
-		toks := tokenSet(s)
-		ranked = append(ranked, scored{
-			idx:    i,
-			text:   s,
-			tokens: toks,
-			score:  overlapScore(queryTerms, toks),
-		})
-	}
-
-	// Rank by descending relevance; ties keep original order for determinism.
-	sort.SliceStable(ranked, func(i, j int) bool {
-		if ranked[i].score == ranked[j].score {
-			return ranked[i].idx < ranked[j].idx
-		}
-		return ranked[i].score > ranked[j].score
-	})
-
-	budget := int(float64(len([]rune(trimmed)))*c.targetRatio + 0.999)
-	if budget < 1 {
-		budget = 1
-	}
-
-	keptIdx := make([]int, 0, len(ranked))
-	keptTokens := make([]map[string]struct{}, 0, len(ranked))
-	used := 0
-	for _, cand := range ranked {
-		// Always keep the single most relevant sentence (first in ranked order)
-		// so compression never drops all evidence, even if it overruns budget.
-		mostRelevant := len(keptIdx) == 0
-		if !mostRelevant {
-			// Beyond the guaranteed most-relevant sentence, only keep sentences
-			// that carry at least some query signal. Pure filler (score 0) is
-			// dropped even if budget remains — that is the whole point of
-			// evidence-guided compression. ranked is score-descending, so once
-			// we hit a zero-score candidate every remaining one is also zero.
-			if cand.score <= 0 {
-				break
-			}
-			if used >= budget {
-				break
-			}
-			if isRedundant(cand.tokens, keptTokens) {
-				continue
-			}
-		}
-		keptIdx = append(keptIdx, cand.idx)
-		keptTokens = append(keptTokens, cand.tokens)
-		used += len([]rune(cand.text)) + 1 // +1 for the joining space
-	}
+	ranked := rankSentences(sentences, queryTerms)
+	budget := c.budgetRunes(trimmed)
+	keptIdx := selectKeptSentences(ranked, budget)
 
 	// Re-emit kept sentences in original order for readability/fidelity.
 	sort.Ints(keptIdx)
@@ -155,6 +105,64 @@ func (c contextCompressor) compressSnippet(query, text string) string {
 		return text
 	}
 	return out
+}
+
+// budgetRunes returns the rune budget for kept sentences (ceil of ratio * len),
+// always at least 1.
+func (c contextCompressor) budgetRunes(trimmed string) int {
+	budget := int(float64(len([]rune(trimmed)))*c.targetRatio + 0.999)
+	if budget < 1 {
+		budget = 1
+	}
+	return budget
+}
+
+// rankSentences scores each sentence by query-relevance and returns them sorted
+// descending; ties keep original order for determinism.
+func rankSentences(sentences []string, queryTerms map[string]struct{}) []scoredSentence {
+	ranked := make([]scoredSentence, 0, len(sentences))
+	for i, s := range sentences {
+		toks := tokenSet(s)
+		ranked = append(ranked, scoredSentence{
+			idx:    i,
+			text:   s,
+			tokens: toks,
+			score:  overlapScore(queryTerms, toks),
+		})
+	}
+	sort.SliceStable(ranked, func(i, j int) bool {
+		if ranked[i].score == ranked[j].score {
+			return ranked[i].idx < ranked[j].idx
+		}
+		return ranked[i].score > ranked[j].score
+	})
+	return ranked
+}
+
+// selectKeptSentences walks the score-descending ranking and returns the
+// original indices to keep. It always keeps the single most relevant sentence
+// (so evidence is never fully dropped); beyond that it keeps only sentences with
+// query signal, within the rune budget, that are not redundant with a kept one.
+func selectKeptSentences(ranked []scoredSentence, budget int) []int {
+	keptIdx := make([]int, 0, len(ranked))
+	keptTokens := make([]map[string]struct{}, 0, len(ranked))
+	used := 0
+	for _, cand := range ranked {
+		if len(keptIdx) > 0 {
+			// ranked is score-descending: once a zero-score candidate appears,
+			// every remaining one is filler too, so stop.
+			if cand.score <= 0 || used >= budget {
+				break
+			}
+			if isRedundant(cand.tokens, keptTokens) {
+				continue
+			}
+		}
+		keptIdx = append(keptIdx, cand.idx)
+		keptTokens = append(keptTokens, cand.tokens)
+		used += len([]rune(cand.text)) + 1 // +1 for the joining space
+	}
+	return keptIdx
 }
 
 // isRedundant reports whether cand's token set is mostly contained in any

--- a/internal/retrieval/compress.go
+++ b/internal/retrieval/compress.go
@@ -28,9 +28,10 @@ const (
 	// defaultCompressionTargetRatio is the keep-fraction used when the operator
 	// enables compression without specifying a ratio (config 0 ⇒ default).
 	defaultCompressionTargetRatio = 0.5
-	// redundancyOverlapThreshold is the token-set containment above which a
-	// candidate sentence is considered redundant with an already-kept one.
-	redundancyOverlapThreshold = 0.9
+	// redundancyOverlapThreshold is the token-set containment at or above which
+	// a candidate sentence is considered redundant with an already-kept one
+	// (i.e. most of its words already appear in a kept sentence).
+	redundancyOverlapThreshold = 0.8
 	// minSentenceRunes guards against compressing already-tiny text: snippets at
 	// or below this rune length are returned unchanged (compression cannot
 	// meaningfully help and risks dropping the only evidence).
@@ -122,6 +123,14 @@ func (c contextCompressor) compressSnippet(query, text string) string {
 		// so compression never drops all evidence, even if it overruns budget.
 		mostRelevant := len(keptIdx) == 0
 		if !mostRelevant {
+			// Beyond the guaranteed most-relevant sentence, only keep sentences
+			// that carry at least some query signal. Pure filler (score 0) is
+			// dropped even if budget remains — that is the whole point of
+			// evidence-guided compression. ranked is score-descending, so once
+			// we hit a zero-score candidate every remaining one is also zero.
+			if cand.score <= 0 {
+				break
+			}
 			if used >= budget {
 				break
 			}

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -158,6 +158,11 @@ type Service struct {
 	// nowFn returns the reference instant for recency decay; overridable in
 	// tests for determinism. Defaults to time.Now.
 	nowFn func() time.Time
+	// compressor applies evidence-guided context compression (issue #335) to the
+	// per-hit text assembled into the RAG prompt — NEVER to the returned hits or
+	// citations. Default disabled ⇒ raw snippets are sent unchanged. Wired from
+	// config.ContextCompression* via SetContextCompression at construction.
+	compressor contextCompressor
 }
 
 // compile-time assertion that Service implements model.Retriever.  This
@@ -378,6 +383,21 @@ func (s *Service) now() time.Time {
 		return time.Now()
 	}
 	return fn()
+}
+
+// SetContextCompression wires evidence-guided context compression (issue #335).
+// When enabled, the Ask path compresses the per-hit text sent to the generator —
+// keeping query-relevant, non-redundant sentences up to targetRatio of each
+// hit's original length — to cut prompt tokens and fit more evidence. It affects
+// ONLY the model-facing prompt: returned hits, snippets, and citations are never
+// altered, preserving citation fidelity. A targetRatio outside (0,1] selects the
+// built-in default. Disabled ⇒ raw snippets are sent unchanged (pass-through).
+// The engine wires this from config.ContextCompression* at construction time,
+// mirroring SetMinScore.
+func (s *Service) SetContextCompression(enabled bool, targetRatio float64) {
+	s.metaMu.Lock()
+	defer s.metaMu.Unlock()
+	s.compressor = newContextCompressor(enabled, targetRatio)
 }
 
 // SetDocumentHashes installs the rel_path → content_hash map used to group
@@ -885,8 +905,12 @@ func (s *Service) Ask(ctx context.Context, question string, query model.SearchQu
 		s.metaMu.RLock()
 		systemPrompt := s.ragSystemPrompt
 		maxContextChars := s.ragMaxContextChars
+		compressor := s.compressor
 		s.metaMu.RUnlock()
-		prompt := buildRAGPrompt(question, hits, systemPrompt, maxContextChars)
+		// buildRAGPrompt compresses only the model-facing snippet text; the
+		// `hits` and `citations` built above are never mutated, so cited spans
+		// remain byte-for-byte identical to what was retrieved.
+		prompt := buildRAGPrompt(question, hits, systemPrompt, maxContextChars, compressor)
 		var generated string
 		genErr := usage.TimeStage(ctx, usage.StageGenerate, func() error {
 			var gErr error
@@ -2104,7 +2128,7 @@ func buildFallbackAnswer(question string, hits []model.SearchHit) string {
 	return strings.Join(lines, "\n")
 }
 
-func buildRAGPrompt(question string, hits []model.SearchHit, systemPrompt string, maxContextChars int) string {
+func buildRAGPrompt(question string, hits []model.SearchHit, systemPrompt string, maxContextChars int, compressor contextCompressor) string {
 	systemPrompt = strings.TrimSpace(systemPrompt)
 	if systemPrompt == "" {
 		systemPrompt = defaultRAGSystemPrompt
@@ -2140,7 +2164,11 @@ func buildRAGPrompt(question string, hits []model.SearchHit, systemPrompt string
 			line += " (" + title + ")"
 		}
 		line += " "
-		snippet := truncateSnippet(strings.TrimSpace(h.Snippet), 300)
+		// Evidence-guided compression (issue #335) reshapes ONLY this local
+		// copy of the snippet that flows into the prompt; h.Snippet and the
+		// caller's citations are untouched. Disabled compressor ⇒ identity.
+		modelText := compressor.compressSnippet(question, strings.TrimSpace(h.Snippet))
+		snippet := truncateSnippet(modelText, 300)
 		switch {
 		case snippet != "":
 			// Available text (incl. an augment media hit's OCR/transcript)

--- a/packaging/macports/textproc/dir2mcp/work
+++ b/packaging/macports/textproc/dir2mcp/work
@@ -1,0 +1,1 @@
+/opt/local/var/macports/build/dir2mcp-f9357715/work

--- a/tests/config/context_compression_config_test.go
+++ b/tests/config/context_compression_config_test.go
@@ -1,0 +1,162 @@
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+)
+
+// TestContextCompression_DefaultDisabled pins the local-first default: context
+// compression is off and the target ratio is 0 (meaning "use the built-in
+// default") unless explicitly configured.
+func TestContextCompression_DefaultDisabled(t *testing.T) {
+	cfg := config.Default()
+	if cfg.ContextCompressionEnabled {
+		t.Fatalf("context compression must default to disabled")
+	}
+	if cfg.ContextCompressionTargetRatio != 0 {
+		t.Fatalf("context_compression.target_ratio must default to 0, got %v", cfg.ContextCompressionTargetRatio)
+	}
+}
+
+// TestContextCompression_NestedYAMLRoundTrips pins the nested-mapping form onto
+// the Config fields.
+func TestContextCompression_NestedYAMLRoundTrips(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+	writeFile(t, path, strings.Join([]string{
+		"retrieval:",
+		"  context_compression:",
+		"    enabled: true",
+		"    target_ratio: 0.4",
+		"",
+	}, "\n"))
+
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if !cfg.ContextCompressionEnabled {
+		t.Fatalf("nested retrieval.context_compression.enabled must parse to true")
+	}
+	if cfg.ContextCompressionTargetRatio != 0.4 {
+		t.Fatalf("nested target_ratio = %v, want 0.4", cfg.ContextCompressionTargetRatio)
+	}
+}
+
+// TestContextCompression_FlatAliasRoundTrips pins the flat snake_case aliases.
+func TestContextCompression_FlatAliasRoundTrips(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+	writeFile(t, path, strings.Join([]string{
+		"context_compression_enabled: true",
+		"context_compression_target_ratio: 0.6",
+		"",
+	}, "\n"))
+
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if !cfg.ContextCompressionEnabled {
+		t.Fatalf("flat context_compression_enabled must parse to true")
+	}
+	if cfg.ContextCompressionTargetRatio != 0.6 {
+		t.Fatalf("flat context_compression_target_ratio = %v, want 0.6", cfg.ContextCompressionTargetRatio)
+	}
+}
+
+// TestContextCompression_ShortAliasEnables pins the convenience alias
+// `context_compression: true` onto the enable flag.
+func TestContextCompression_ShortAliasEnables(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+	writeFile(t, path, "context_compression: true\n")
+
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if !cfg.ContextCompressionEnabled {
+		t.Fatalf("context_compression: true must enable compression")
+	}
+}
+
+// TestContextCompression_SnapshotRoundTrips pins the persisted-snapshot
+// round-trip: both knobs survive SaveEffectiveSnapshot -> YAML -> load.
+func TestContextCompression_SnapshotRoundTrips(t *testing.T) {
+	cfg := config.Default()
+	cfg.StateDir = t.TempDir()
+	cfg.ContextCompressionEnabled = true
+	cfg.ContextCompressionTargetRatio = 0.35
+
+	path, err := config.SaveEffectiveSnapshot(cfg, config.SecretSourceMetadata{})
+	if err != nil {
+		t.Fatalf("SaveEffectiveSnapshot: %v", err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !strings.Contains(string(raw), "context_compression_enabled: true") {
+		t.Fatalf("snapshot must persist context_compression_enabled: true:\n%s", raw)
+	}
+	if !strings.Contains(string(raw), "context_compression_target_ratio: 0.35") {
+		t.Fatalf("snapshot must persist context_compression_target_ratio: 0.35:\n%s", raw)
+	}
+
+	loaded, _, err := config.LoadEffectiveSnapshot(path)
+	if err != nil {
+		t.Fatalf("LoadEffectiveSnapshot: %v", err)
+	}
+	if !loaded.ContextCompressionEnabled || loaded.ContextCompressionTargetRatio != 0.35 {
+		t.Fatalf("loaded snapshot mismatch: enabled=%v ratio=%v",
+			loaded.ContextCompressionEnabled, loaded.ContextCompressionTargetRatio)
+	}
+}
+
+// TestContextCompression_RejectsRatioOutOfRange pins validation: a ratio above 1
+// or below 0 is CONFIG_INVALID.
+func TestContextCompression_RejectsRatioOutOfRange(t *testing.T) {
+	for _, bad := range []string{"1.5", "-0.2"} {
+		tmp := t.TempDir()
+		path := filepath.Join(tmp, ".dir2mcp.yaml")
+		writeFile(t, path, "context_compression_target_ratio: "+bad+"\n")
+
+		_, err := config.LoadFile(path)
+		if err == nil {
+			t.Errorf("LoadFile with target_ratio=%q = nil error, want rejection", bad)
+			continue
+		}
+		if !strings.Contains(err.Error(), "context_compression.target_ratio") {
+			t.Errorf("error for %q must mention context_compression.target_ratio, got: %v", bad, err)
+		}
+	}
+}
+
+// TestContextCompression_RejectsNonFiniteRatio pins that NaN/Inf strings (which
+// strconv.ParseFloat accepts) are rejected at parse time.
+func TestContextCompression_RejectsNonFiniteRatio(t *testing.T) {
+	for _, bad := range []string{"NaN", "Inf", "+Inf", "-Inf", "Infinity"} {
+		tmp := t.TempDir()
+		path := filepath.Join(tmp, ".dir2mcp.yaml")
+		writeFile(t, path, "context_compression_target_ratio: "+bad+"\n")
+
+		if _, err := config.LoadFile(path); err == nil {
+			t.Errorf("LoadFile with target_ratio=%q = nil error, want rejection", bad)
+		}
+	}
+}
+
+// TestContextCompression_ValidateRejectsRatioProgrammatic pins that Validate()
+// rejects an out-of-range ratio injected programmatically (not via the parser).
+func TestContextCompression_ValidateRejectsRatioProgrammatic(t *testing.T) {
+	cfg := config.Default()
+	cfg.ContextCompressionTargetRatio = 2
+	if err := cfg.Validate(); err == nil {
+		t.Fatalf("Validate with out-of-range ratio = nil error, want rejection")
+	}
+}

--- a/tests/retrieval/context_compression_test.go
+++ b/tests/retrieval/context_compression_test.go
@@ -1,0 +1,184 @@
+package tests
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
+)
+
+// compressionSnippet is a multi-sentence chunk where exactly one sentence is
+// on-topic for the query "payment gating", the rest are off-topic filler or
+// redundant restatements. An evidence-guided compressor should keep the
+// on-topic sentence and drop the noise; with compression off the whole snippet
+// is sent verbatim.
+const compressionSnippet = "The x402 adapter implements payment gating via an HTTP 402 challenge. " +
+	"The office cafeteria serves lunch between noon and two in the afternoon every weekday. " +
+	"Quarterly planning meetings are scheduled in the large conference room on the third floor. " +
+	"The annual company picnic was rained out last summer and rescheduled twice afterwards. " +
+	"Birthday celebrations happen in the kitchen area near the coffee machines on Fridays."
+
+// newCompressionService builds a single-hit vector service whose lone chunk
+// carries compressionSnippet. The generator records the prompt it is handed so
+// tests can assert on the exact model-facing context.
+func newCompressionService(t *testing.T, gen *fakeGenerator) *retrieval.Service {
+	t.Helper()
+	idx := index.NewHNSWIndex("")
+	addVec(t, idx, 1, []float32{1, 0})
+	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+		"mistral-embed": {1, 0},
+	}}, gen)
+	svc.SetChunkMetadata(1, model.SearchHit{
+		ChunkID: 1,
+		RelPath: "docs/x402.md",
+		Title:   "x402 adapter",
+		Snippet: compressionSnippet,
+		Span:    model.Span{StartLine: 7, EndLine: 42},
+	})
+	return svc
+}
+
+func askCompression(t *testing.T, svc *retrieval.Service) model.AskResult {
+	t.Helper()
+	res, err := svc.Ask(context.Background(), "payment gating", model.SearchQuery{Query: "payment gating", K: 5})
+	if err != nil {
+		t.Fatalf("Ask: %v", err)
+	}
+	return res
+}
+
+// TestAsk_ContextCompression_ShrinksModelContext pins the core win: when
+// compression is enabled the prompt handed to the generator is strictly shorter
+// than the raw-snippet prompt, AND the kept content still contains the on-topic
+// evidence ("payment gating") while the off-topic filler ("cafeteria") is gone.
+func TestAsk_ContextCompression_ShrinksModelContext(t *testing.T) {
+	rawGen := &fakeGenerator{out: "answer [docs/x402.md]"}
+	rawSvc := newCompressionService(t, rawGen)
+	rawSvc.SetContextCompression(false, 0)
+	_ = askCompression(t, rawSvc)
+
+	compGen := &fakeGenerator{out: "answer [docs/x402.md]"}
+	compSvc := newCompressionService(t, compGen)
+	compSvc.SetContextCompression(true, 0)
+	_ = askCompression(t, compSvc)
+
+	if compGen.lastPrompt == "" || rawGen.lastPrompt == "" {
+		t.Fatalf("expected both prompts to be captured")
+	}
+	if len(compGen.lastPrompt) >= len(rawGen.lastPrompt) {
+		t.Fatalf("compressed prompt (%d) must be shorter than raw prompt (%d)",
+			len(compGen.lastPrompt), len(rawGen.lastPrompt))
+	}
+	if !strings.Contains(compGen.lastPrompt, "payment gating") {
+		t.Fatalf("compressed prompt must retain the on-topic evidence; got:\n%s", compGen.lastPrompt)
+	}
+	if strings.Contains(compGen.lastPrompt, "cafeteria") {
+		t.Fatalf("compressed prompt must drop off-topic filler; got:\n%s", compGen.lastPrompt)
+	}
+}
+
+// TestAsk_ContextCompression_PreservesCitations pins citation fidelity: whether
+// compression is on or off, the returned citations and hit snippet are
+// byte-for-byte identical, because compression only reshapes the prompt copy.
+func TestAsk_ContextCompression_PreservesCitations(t *testing.T) {
+	rawSvc := newCompressionService(t, &fakeGenerator{out: "a [docs/x402.md]"})
+	rawSvc.SetContextCompression(false, 0)
+	rawRes := askCompression(t, rawSvc)
+
+	compSvc := newCompressionService(t, &fakeGenerator{out: "a [docs/x402.md]"})
+	compSvc.SetContextCompression(true, 0)
+	compRes := askCompression(t, compSvc)
+
+	if len(rawRes.Citations) != 1 || len(compRes.Citations) != 1 {
+		t.Fatalf("expected exactly one citation each; raw=%d comp=%d",
+			len(rawRes.Citations), len(compRes.Citations))
+	}
+	rc, cc := rawRes.Citations[0], compRes.Citations[0]
+	if rc.ChunkID != cc.ChunkID || rc.RelPath != cc.RelPath || rc.Title != cc.Title ||
+		rc.Span.StartLine != cc.Span.StartLine || rc.Span.EndLine != cc.Span.EndLine {
+		t.Fatalf("citations diverged under compression:\nraw=%+v\ncomp=%+v", rc, cc)
+	}
+	if cc.Span.StartLine != 7 || cc.Span.EndLine != 42 {
+		t.Fatalf("cited span was altered: %+v", cc.Span)
+	}
+	// The returned hit snippet must remain the full, uncompressed source text.
+	if len(compRes.Hits) != 1 || compRes.Hits[0].Snippet != compressionSnippet {
+		t.Fatalf("returned hit snippet must be the original uncompressed text; got %q",
+			compRes.Hits[0].Snippet)
+	}
+}
+
+// TestAsk_ContextCompression_DisabledIsUnchanged pins the default-off behavior:
+// with compression disabled the prompt contains the full snippet verbatim,
+// including the filler the compressor would otherwise drop.
+func TestAsk_ContextCompression_DisabledIsUnchanged(t *testing.T) {
+	gen := &fakeGenerator{out: "answer [docs/x402.md]"}
+	svc := newCompressionService(t, gen)
+	svc.SetContextCompression(false, 0)
+	_ = askCompression(t, svc)
+
+	if !strings.Contains(gen.lastPrompt, "cafeteria") {
+		t.Fatalf("disabled compression must send the full snippet; got:\n%s", gen.lastPrompt)
+	}
+}
+
+// TestAsk_ContextCompression_DropsRedundantSentences pins the redundancy-dedup
+// path: two query-relevant sentences that restate the same evidence collapse to
+// one in the model-facing context, so the prompt is shorter than raw while the
+// evidence survives once.
+func TestAsk_ContextCompression_DropsRedundantSentences(t *testing.T) {
+	idx := index.NewHNSWIndex("")
+	addVec(t, idx, 1, []float32{1, 0})
+	// Two near-identical relevant sentences plus filler. The duplicate should be
+	// dropped by the redundancy filter.
+	snippet := "The payment gating module validates every incoming request token. " +
+		"The payment gating module validates each incoming request token carefully. " +
+		"Unrelated trivia about the weather and the office plants filled the page."
+	gen := &fakeGenerator{out: "a [r.md]"}
+	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+		"mistral-embed": {1, 0},
+	}}, gen)
+	svc.SetChunkMetadata(1, model.SearchHit{ChunkID: 1, RelPath: "r.md", Snippet: snippet})
+	svc.SetContextCompression(true, 1) // ratio 1 so budget is not the limiter
+
+	if _, err := svc.Ask(context.Background(), "payment gating request token",
+		model.SearchQuery{Query: "payment gating request token", K: 5}); err != nil {
+		t.Fatalf("Ask: %v", err)
+	}
+	occurrences := strings.Count(gen.lastPrompt, "payment gating module validates")
+	if occurrences != 1 {
+		t.Fatalf("redundant relevant sentence should collapse to one; found %d in:\n%s",
+			occurrences, gen.lastPrompt)
+	}
+	if strings.Contains(gen.lastPrompt, "weather") {
+		t.Fatalf("off-topic filler should be dropped; got:\n%s", gen.lastPrompt)
+	}
+}
+
+// TestAsk_ContextCompression_NeverEmptyForTinySnippet pins graceful behavior on
+// inputs too short to compress: the prompt still carries the snippet text and
+// the citation is intact.
+func TestAsk_ContextCompression_NeverEmptyForTinySnippet(t *testing.T) {
+	idx := index.NewHNSWIndex("")
+	addVec(t, idx, 1, []float32{1, 0})
+	gen := &fakeGenerator{out: "a [t.md]"}
+	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+		"mistral-embed": {1, 0},
+	}}, gen)
+	svc.SetChunkMetadata(1, model.SearchHit{ChunkID: 1, RelPath: "t.md", Snippet: "short evidence here"})
+	svc.SetContextCompression(true, 0.1)
+
+	res, err := svc.Ask(context.Background(), "evidence", model.SearchQuery{Query: "evidence", K: 5})
+	if err != nil {
+		t.Fatalf("Ask: %v", err)
+	}
+	if !strings.Contains(gen.lastPrompt, "short evidence here") {
+		t.Fatalf("tiny snippet must pass through unchanged; got:\n%s", gen.lastPrompt)
+	}
+	if len(res.Citations) != 1 || res.Citations[0].RelPath != "t.md" {
+		t.Fatalf("citation must be intact for tiny snippet; got %+v", res.Citations)
+	}
+}


### PR DESCRIPTION
Closes #335

## What

Adds an **opt-in** compression stage between retrieval and generation that keeps only evidence-bearing content in the **model-facing** prompt — cutting prompt tokens and fitting more evidence inside `rag.max_context_chars`. Inspired by ECoRAG (evidentiality-guided compression) and LLMLingua (prompt compression), reduced to two cheap, deterministic heuristics: query-relevance sentence filtering + redundancy dedup.

Config-only ⇒ **ungated**: no MCP tool/citation contract change, no spec re-pin.

## Where it sits in the Ask path

`Service.Ask` builds `citations` and the returned `Hits` from the raw search hits **first**, then calls `buildRAGPrompt(question, hits, systemPrompt, maxContextChars, compressor)`. Compression runs only inside `buildRAGPrompt`, on a **local copy** of each hit's snippet (`compressor.compressSnippet(...)`) just before the existing 300-rune snippet cap and `rag.max_context_chars` budgeting. The same wiring template as `SetMinScore` is followed (`SetContextCompression`, wired in `internal/cli/up.go` and `internal/cli/app.go`).

## How cited spans are protected

`SearchHit` values are never mutated — compression reshapes only the prompt-local snippet string. `citations` (chunk id / rel_path / title / span) and `AskResult.Hits` (including each hit's full `Snippet`) are built from the untouched hits, so cited spans/snippets are byte-for-byte identical with vs without compression. A test asserts exactly this.

## Config knobs (off by default)

- `retrieval.context_compression.enabled` (bool; aliases `context_compression_enabled`, short `context_compression`) — default false ⇒ unchanged behavior.
- `retrieval.context_compression.target_ratio` (float in [0,1], 0 = built-in default 0.5; alias `context_compression_target_ratio`) — keep-fraction ceiling per hit; the single most relevant sentence is always retained. Out-of-range / non-finite ⇒ CONFIG_INVALID.

Full config plumbing: field + fileConfig + persistedConfig + Default + apply + nested/flat aliases + bool/float dispatch + snapshot + validation, plus registering `retrieval.context_compression` as a YAML map section.

## Tests (fakes only, no creds)

Retrieval (`tests/retrieval/context_compression_test.go`):
- `TestAsk_ContextCompression_ShrinksModelContext`
- `TestAsk_ContextCompression_PreservesCitations`
- `TestAsk_ContextCompression_DisabledIsUnchanged`
- `TestAsk_ContextCompression_DropsRedundantSentences`
- `TestAsk_ContextCompression_NeverEmptyForTinySnippet`

Config (`tests/config/context_compression_config_test.go`):
- `TestContextCompression_DefaultDisabled`
- `TestContextCompression_NestedYAMLRoundTrips`
- `TestContextCompression_FlatAliasRoundTrips`
- `TestContextCompression_ShortAliasEnables`
- `TestContextCompression_SnapshotRoundTrips`
- `TestContextCompression_RejectsRatioOutOfRange`
- `TestContextCompression_RejectsNonFiniteRatio`
- `TestContextCompression_ValidateRejectsRatioProgrammatic`

`make check` is fully green (lint 0 issues, gocyclo ≤15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHuQEKSW3nzU1Pn7KXXBhj