### PR TITLE
observability: opt-in energy / carbon footprint estimate (#328)

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -676,6 +676,12 @@ func (a *App) configureQueryMetrics(ret *retrieval.Service, cfg config.Config, e
 	}
 	ret.SetGenerationModel(a.resolveChatModel(cfg))
 	ret.SetMetricsEmitter(emit, usage.NewPriceTable(cfg.CostPriceOverrides))
+	// Opt-in energy/CO2e estimate (issue #328); off unless carbon.enabled.
+	ret.SetCarbonModel(usage.NewCarbonModel(
+		cfg.Carbon.Enabled,
+		cfg.Carbon.EnergyOverrides,
+		cfg.Carbon.GridGramsCO2ePerWh,
+	))
 }
 
 // configureReranker wires the optional Cohere rerank stage onto the

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -222,6 +222,11 @@ type Config struct {
 	// YAML block. nil/empty ⇒ built-in defaults only. Observability-only:
 	// never affects retrieval or tool results.
 	CostPriceOverrides map[string]usage.ModelPrice
+	// Carbon configures the OPT-IN, approximate energy/CO2e estimate surfaced in
+	// the query_metrics event (issue #328). Parsed from the optional top-level
+	// `carbon:` YAML block. Disabled by default. Observability-only: never
+	// affects retrieval or tool results, and records only counts/estimates.
+	Carbon CarbonConfig
 	// Rerank* configure the optional post-fusion rerank stage (SPEC
 	// 9.1.1). Reranking auto-activates when a provider credential is
 	// present. CohereAPIKey is a secret: env-sourced, never persisted
@@ -1274,6 +1279,13 @@ func applyFileOverrides(cfg *Config, path string) error {
 	if len(prices) > 0 {
 		cfg.CostPriceOverrides = prices
 	}
+
+	// Optional carbon: block for the opt-in energy/CO2e estimate (issue #328).
+	carbon, err := parseCarbonConfig(raw)
+	if err != nil {
+		return fmt.Errorf("config file %s: %w", path, err)
+	}
+	cfg.Carbon = carbon
 
 	return nil
 }

--- a/internal/config/providers.go
+++ b/internal/config/providers.go
@@ -198,6 +198,71 @@ func parseCostPriceOverrides(raw []byte) (map[string]usage.ModelPrice, error) {
 	return out, nil
 }
 
+// carbonDoc is the yaml shape of the optional top-level `carbon:` block for the
+// opt-in energy/CO2e estimate (issue #328):
+//
+//	carbon:
+//	  enabled: true
+//	  grid_g_co2e_per_wh: 0.35   # optional; omit/<=0 to skip the CO2e estimate
+//	  energy:                     # optional per-model Wh/1K-token overrides
+//	    my-model:
+//	      wh_per_1k: 0.5
+//
+// gridSet distinguishes "operator set 0/negative" from "unset" so the loader
+// can apply the built-in default grid factor only when the key is absent.
+type carbonDoc struct {
+	Carbon struct {
+		Enabled        bool     `yaml:"enabled"`
+		GridGCO2ePerWh *float64 `yaml:"grid_g_co2e_per_wh"`
+		Energy         map[string]struct {
+			WhPer1K float64 `yaml:"wh_per_1k"`
+		} `yaml:"energy"`
+	} `yaml:"carbon"`
+}
+
+// CarbonConfig is the resolved, opt-in energy/carbon estimate configuration
+// (issue #328). Disabled by default; all factors operator-overridable.
+type CarbonConfig struct {
+	// Enabled gates the entire estimate. Off by default.
+	Enabled bool
+	// EnergyOverrides maps a model name to a Wh-per-1K-token factor, overriding
+	// the built-in defaults. nil/empty ⇒ built-in defaults only.
+	EnergyOverrides map[string]usage.EnergyFactor
+	// GridGramsCO2ePerWh is the grid carbon-intensity factor in gCO2e/Wh. When
+	// the key is absent it defaults to usage.DefaultGridIntensityGramsPerWh; a
+	// value <= 0 disables the CO2e estimate (Wh is still surfaced).
+	GridGramsCO2ePerWh float64
+}
+
+// parseCarbonConfig decodes the optional top-level `carbon:` block (issue #328).
+// Absent block ⇒ zero value (disabled), no error. When present, an unset grid
+// factor falls back to the built-in default so an enabled-but-minimal config
+// still produces a CO2e estimate.
+func parseCarbonConfig(raw []byte) (CarbonConfig, error) {
+	var cfg CarbonConfig
+	sub := extractTopLevelSubtree(raw, "carbon")
+	if len(sub) == 0 {
+		return cfg, nil
+	}
+	var doc carbonDoc
+	if err := yaml.Unmarshal(sub, &doc); err != nil {
+		return cfg, fmt.Errorf("parse carbon config: %w", err)
+	}
+	cfg.Enabled = doc.Carbon.Enabled
+	if doc.Carbon.GridGCO2ePerWh != nil {
+		cfg.GridGramsCO2ePerWh = *doc.Carbon.GridGCO2ePerWh
+	} else {
+		cfg.GridGramsCO2ePerWh = usage.DefaultGridIntensityGramsPerWh
+	}
+	if len(doc.Carbon.Energy) > 0 {
+		cfg.EnergyOverrides = make(map[string]usage.EnergyFactor, len(doc.Carbon.Energy))
+		for name, f := range doc.Carbon.Energy {
+			cfg.EnergyOverrides[name] = usage.EnergyFactor{WhPer1K: f.WhPer1K}
+		}
+	}
+	return cfg, nil
+}
+
 func parseProvidersDoc(raw []byte) (providersDoc, error) {
 	var doc providersDoc
 	sub := extractProvidersSubtree(raw)

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -138,6 +138,9 @@ type Service struct {
 	// priceTable maps model names to approximate USD prices for the
 	// query_metrics event (issue #327). nil ⇒ cost is always omitted.
 	priceTable *usage.PriceTable
+	// carbon supplies the OPT-IN, approximate energy/CO2e estimate for the
+	// query_metrics event (issue #328). nil/disabled ⇒ no energy/CO2e fields.
+	carbon *usage.CarbonModel
 	// metricsEmit, when set, receives one structured query_metrics event per
 	// Ask/Search (issue #327). nil ⇒ metrics collection is skipped entirely
 	// (zero overhead). It never alters tool results.
@@ -240,6 +243,15 @@ func (s *Service) SetMetricsEmitter(emit func(level, event string, data interfac
 	s.priceTable = prices
 }
 
+// SetCarbonModel wires the OPT-IN energy/CO2e estimate (issue #328) onto the
+// query_metrics event. A nil or disabled model omits all energy/CO2e fields,
+// leaving cost/latency unchanged. Observability only; never affects results.
+func (s *Service) SetCarbonModel(carbon *usage.CarbonModel) {
+	s.metaMu.Lock()
+	defer s.metaMu.Unlock()
+	s.carbon = carbon
+}
+
 // metricsEnabled reports whether a metrics emitter is wired.
 func (s *Service) metricsEnabled() bool {
 	s.metaMu.RLock()
@@ -260,6 +272,7 @@ func (s *Service) emitQueryMetrics(op string, sink *usage.Sink, total time.Durat
 	s.metaMu.RLock()
 	emit := s.metricsEmit
 	prices := s.priceTable
+	carbon := s.carbon
 	textModel := s.textModel
 	codeModel := s.codeModel
 	rerankModel := s.rerankModel
@@ -269,7 +282,7 @@ func (s *Service) emitQueryMetrics(op string, sink *usage.Sink, total time.Durat
 		return
 	}
 
-	qm := usage.NewQueryMetrics(op, prices)
+	qm := usage.NewQueryMetricsWithCarbon(op, prices, carbon)
 
 	// Embed: prefer the text model label; fall back to code model. Embedding is
 	// symmetric across the two for pricing purposes here.

--- a/internal/usage/energy.go
+++ b/internal/usage/energy.go
@@ -1,0 +1,173 @@
+package usage
+
+// Energy / carbon footprint estimation (issue #328).
+//
+// This is an OPT-IN, deliberately APPROXIMATE estimate. It multiplies the
+// already-captured token counts by a configurable per-model energy factor
+// (Wh per 1,000 tokens) to produce watt-hours, and optionally multiplies that
+// by a grid carbon-intensity factor (gCO2e per Wh) to produce grams of CO2e.
+//
+// It is NOT a measurement. Real energy use depends on hardware, batching,
+// utilization, datacenter PUE, and grid mix — none of which dir2mcp can
+// observe. The numbers exist as a relative sustainability signal, clearly
+// labelled an estimate, with every factor operator-overridable. When a model
+// has no known factor the estimate is OMITTED (never fabricated as 0), exactly
+// like the cost path.
+//
+// Privacy: like the rest of this package, only counts and derived estimates
+// are recorded — never prompts, documents, queries, or keys.
+
+// DefaultGridIntensityGramsPerWh is the default grid carbon-intensity factor in
+// grams of CO2e per watt-hour, used when carbon estimation is enabled but no
+// grid factor is configured. ~0.4 kgCO2e/kWh = 0.4 gCO2e/Wh is a rough global
+// average electricity intensity (mid-2020s). Operators should override it with
+// a value for their region / energy contract for a meaningful estimate.
+const DefaultGridIntensityGramsPerWh = 0.4
+
+// EnergyFactor is the approximate electricity drawn by a model per 1,000
+// tokens, in watt-hours. A single factor is applied to total tokens
+// (prompt+completion); the prompt/completion split is not modeled because the
+// per-token energy difference is dwarfed by the estimate's overall uncertainty.
+type EnergyFactor struct {
+	// WhPer1K is watt-hours consumed per 1,000 tokens processed. Approximate
+	// and operator-overridable.
+	WhPer1K float64
+}
+
+// EnergyTable maps a model name to its approximate energy factor. Lookup is
+// case-insensitive and whitespace-trimmed (it reuses normalizeModel). An
+// unknown model yields ok=false so callers OMIT the estimate rather than
+// fabricate a number — mirroring PriceTable (issue #328).
+type EnergyTable struct {
+	factors map[string]EnergyFactor
+}
+
+// DefaultEnergyTable returns a built-in table with rough Wh-per-1K-token
+// factors for common dir2mcp models. These are order-of-magnitude starting
+// points drawn from public LLM-inference energy estimates (mid-2020s); they are
+// NOT vendor-published figures. Small embedding models draw far less than large
+// chat models. Operators override via config (carbon.energy / NewEnergyTable).
+// Unknown models are intentionally absent so their estimate is omitted.
+func DefaultEnergyTable() *EnergyTable {
+	return &EnergyTable{factors: map[string]EnergyFactor{
+		// Mistral (chat)
+		"mistral-small-2506": {WhPer1K: 0.30},
+		"mistral-small":      {WhPer1K: 0.30},
+		"mistral-medium":     {WhPer1K: 0.60},
+		"mistral-large":      {WhPer1K: 1.20},
+		// Mistral (embed)
+		"mistral-embed":   {WhPer1K: 0.02},
+		"codestral-embed": {WhPer1K: 0.02},
+		// OpenAI (chat)
+		"gpt-4o":      {WhPer1K: 1.00},
+		"gpt-4o-mini": {WhPer1K: 0.20},
+		// OpenAI (embed)
+		"text-embedding-3-small": {WhPer1K: 0.01},
+		"text-embedding-3-large": {WhPer1K: 0.02},
+		// Gemini (chat)
+		"gemini-2.5-flash": {WhPer1K: 0.20},
+		"gemini-2.5-pro":   {WhPer1K: 1.00},
+		// Gemini (embed)
+		"gemini-embedding-001": {WhPer1K: 0.02},
+		// Cohere (chat)
+		"command-r":      {WhPer1K: 0.30},
+		"command-r-plus": {WhPer1K: 1.00},
+	}}
+}
+
+// NewEnergyTable builds a table from the default table merged with operator
+// overrides. Override entries replace defaults by (case-insensitive) model
+// name; new entries are added. A nil/empty overrides map yields the defaults.
+func NewEnergyTable(overrides map[string]EnergyFactor) *EnergyTable {
+	t := DefaultEnergyTable()
+	t.Merge(overrides)
+	return t
+}
+
+// Merge applies operator overrides onto the table in place. Keys are
+// normalized (trimmed, lower-cased). Existing entries are replaced.
+func (t *EnergyTable) Merge(overrides map[string]EnergyFactor) {
+	if t == nil || len(overrides) == 0 {
+		return
+	}
+	if t.factors == nil {
+		t.factors = make(map[string]EnergyFactor, len(overrides))
+	}
+	for name, f := range overrides {
+		key := normalizeModel(name)
+		if key == "" {
+			continue
+		}
+		t.factors[key] = f
+	}
+}
+
+// Lookup returns the energy factor for model and whether it is known. Unknown
+// models return ok=false; callers MUST omit the estimate in that case.
+func (t *EnergyTable) Lookup(model string) (EnergyFactor, bool) {
+	if t == nil {
+		return EnergyFactor{}, false
+	}
+	f, ok := t.factors[normalizeModel(model)]
+	return f, ok
+}
+
+// EnergyWh returns the estimated watt-hours for totalTokens under model's
+// factor, and whether a factor was known. Unknown model ⇒ ok=false, wh=0
+// (callers omit it). A known model with zero tokens yields wh=0, ok=true.
+func (t *EnergyTable) EnergyWh(model string, totalTokens int64) (float64, bool) {
+	f, ok := t.Lookup(model)
+	if !ok {
+		return 0, false
+	}
+	return (float64(totalTokens) / 1000.0) * f.WhPer1K, true
+}
+
+// CarbonModel pairs an energy table with a grid carbon-intensity factor and the
+// opt-in toggle. It is the single object the retrieval service consults to
+// estimate energy/CO2e for a query. A nil/disabled model omits all estimates.
+type CarbonModel struct {
+	enabled bool
+	energy  *EnergyTable
+	// gridGramsPerWh is grams of CO2e per watt-hour. When <= 0 the CO2e
+	// estimate is omitted but the Wh estimate is still surfaced.
+	gridGramsPerWh float64
+}
+
+// NewCarbonModel builds a CarbonModel. When enabled is false the returned model
+// reports Enabled()==false and produces no estimates. energyOverrides are
+// merged onto the default energy table. gridGramsPerWh <= 0 disables the CO2e
+// estimate (Wh is still produced). Pass a negative grid value to mean "unset";
+// callers wanting the built-in default should pass DefaultGridIntensityGramsPerWh.
+func NewCarbonModel(enabled bool, energyOverrides map[string]EnergyFactor, gridGramsPerWh float64) *CarbonModel {
+	return &CarbonModel{
+		enabled:        enabled,
+		energy:         NewEnergyTable(energyOverrides),
+		gridGramsPerWh: gridGramsPerWh,
+	}
+}
+
+// Enabled reports whether carbon estimation is on. A nil model is disabled.
+func (c *CarbonModel) Enabled() bool {
+	return c != nil && c.enabled
+}
+
+// EstimateWh returns the estimated watt-hours for totalTokens under model, and
+// whether an estimate is available (enabled AND model known). A disabled model
+// always returns ok=false.
+func (c *CarbonModel) EstimateWh(model string, totalTokens int64) (float64, bool) {
+	if !c.Enabled() {
+		return 0, false
+	}
+	return c.energy.EnergyWh(model, totalTokens)
+}
+
+// EstimateCO2eGrams converts a watt-hour estimate into grams of CO2e using the
+// configured grid intensity, returning ok=false when carbon estimation is
+// disabled or no positive grid factor is configured.
+func (c *CarbonModel) EstimateCO2eGrams(wh float64) (float64, bool) {
+	if !c.Enabled() || c.gridGramsPerWh <= 0 {
+		return 0, false
+	}
+	return wh * c.gridGramsPerWh, true
+}

--- a/internal/usage/metrics.go
+++ b/internal/usage/metrics.go
@@ -8,8 +8,8 @@ import (
 )
 
 // stageMetric is the per-stage breakdown surfaced in the query_metrics event.
-// Cost is a pointer so an unknown-model (no price) stage OMITS cost rather than
-// reporting a misleading 0.0.
+// Cost/EnergyWh/CO2eG are pointers so an unknown-model (no price / no energy
+// factor) stage OMITS them rather than reporting a misleading 0.0.
 type stageMetric struct {
 	LatencyMS        int64    `json:"latency_ms"`
 	Model            string   `json:"model,omitempty"`
@@ -18,6 +18,11 @@ type stageMetric struct {
 	TotalTokens      int64    `json:"total_tokens,omitempty"`
 	TokensReported   bool     `json:"tokens_reported"`
 	CostUSD          *float64 `json:"cost_usd,omitempty"`
+	// EnergyWh / CO2eG are OPT-IN approximate estimates (issue #328), present
+	// only when carbon estimation is enabled and the stage's model has a known
+	// energy factor. CO2eG additionally requires a positive grid factor.
+	EnergyWh *float64 `json:"energy_wh,omitempty"`
+	CO2eG    *float64 `json:"co2e_g,omitempty"`
 }
 
 // QueryMetrics accumulates per-query latency and (where available) token usage
@@ -27,6 +32,7 @@ type stageMetric struct {
 type QueryMetrics struct {
 	op     string // "ask" or "search"
 	prices *PriceTable
+	carbon *CarbonModel
 	stages map[Stage]*stageMetric
 	order  []Stage
 	total  time.Duration
@@ -34,11 +40,20 @@ type QueryMetrics struct {
 
 // NewQueryMetrics starts metrics collection for an operation ("ask"/"search")
 // using prices for cost mapping. A nil prices table still records tokens and
-// latency; cost is simply always omitted.
+// latency; cost is simply always omitted. Carbon estimation is off; use
+// NewQueryMetricsWithCarbon to enable the opt-in energy/CO2e estimate (#328).
 func NewQueryMetrics(op string, prices *PriceTable) *QueryMetrics {
+	return NewQueryMetricsWithCarbon(op, prices, nil)
+}
+
+// NewQueryMetricsWithCarbon is NewQueryMetrics plus an optional CarbonModel for
+// the opt-in energy/CO2e estimate (issue #328). A nil or disabled carbon model
+// omits all energy/CO2e fields, leaving cost/latency unchanged.
+func NewQueryMetricsWithCarbon(op string, prices *PriceTable, carbon *CarbonModel) *QueryMetrics {
 	return &QueryMetrics{
 		op:     op,
 		prices: prices,
+		carbon: carbon,
 		stages: make(map[Stage]*stageMetric),
 	}
 }
@@ -80,29 +95,66 @@ func (m *QueryMetrics) SetTotalLatency(d time.Duration) {
 	}
 }
 
-// finalize computes each stage's cost (when its model is priced) and returns
-// the aggregate totals: known cost, whether any stage had a known cost, and
-// total tokens across stages.
-func (m *QueryMetrics) finalize() (totalCost float64, costKnown bool, totalTokens int64) {
+// finalized holds the aggregate totals computed once per render so Event and
+// LogLine stay consistent without recomputing.
+type finalized struct {
+	totalCost   float64
+	costKnown   bool
+	totalTokens int64
+	totalWh     float64
+	energyKnown bool
+	totalCO2eG  float64
+	co2eKnown   bool
+	carbonOn    bool
+}
+
+// finalize computes each stage's cost (when its model is priced) and, when
+// carbon estimation is enabled, its energy/CO2e estimate (when its model has a
+// known factor), populating the per-stage pointers and returning the aggregate
+// totals. Unknown models omit the respective field rather than fabricating 0.
+func (m *QueryMetrics) finalize() finalized {
+	f := finalized{carbonOn: m.carbon.Enabled()}
 	for _, stage := range m.order {
 		sm := m.stages[stage]
 		if sm.TokensReported {
-			totalTokens += sm.TotalTokens
+			f.totalTokens += sm.TotalTokens
 		}
 		if sm.TokensReported && sm.Model != "" {
-			cost, ok := m.prices.Cost(sm.Model, Usage{
+			if cost, ok := m.prices.Cost(sm.Model, Usage{
 				PromptTokens:     sm.PromptTokens,
 				CompletionTokens: sm.CompletionTokens,
-			})
-			if ok {
+			}); ok {
 				rounded := roundUSD(cost)
 				sm.CostUSD = &rounded
-				totalCost += cost
-				costKnown = true
+				f.totalCost += cost
+				f.costKnown = true
+			}
+			if f.carbonOn {
+				m.finalizeStageCarbon(sm, &f)
 			}
 		}
 	}
-	return totalCost, costKnown, totalTokens
+	return f
+}
+
+// finalizeStageCarbon estimates and records a single stage's energy/CO2e,
+// updating the running totals. Caller guarantees carbon is enabled and the
+// stage reported tokens for a named model.
+func (m *QueryMetrics) finalizeStageCarbon(sm *stageMetric, f *finalized) {
+	wh, ok := m.carbon.EstimateWh(sm.Model, sm.TotalTokens)
+	if !ok {
+		return
+	}
+	roundedWh := roundEnergy(wh)
+	sm.EnergyWh = &roundedWh
+	f.totalWh += wh
+	f.energyKnown = true
+	if co2e, ok := m.carbon.EstimateCO2eGrams(wh); ok {
+		roundedCO2e := roundEnergy(co2e)
+		sm.CO2eG = &roundedCO2e
+		f.totalCO2eG += co2e
+		f.co2eKnown = true
+	}
 }
 
 // Event renders the structured payload for the query_metrics NDJSON event.
@@ -110,7 +162,7 @@ func (m *QueryMetrics) finalize() (totalCost float64, costKnown bool, totalToken
 // keys. cost_usd (per-stage and total) is omitted entirely when no priced
 // model contributed, so unknown models never fabricate a cost.
 func (m *QueryMetrics) Event() map[string]interface{} {
-	totalCost, costKnown, totalTokens := m.finalize()
+	f := m.finalize()
 
 	stages := make(map[string]interface{}, len(m.order))
 	for _, stage := range m.order {
@@ -120,11 +172,22 @@ func (m *QueryMetrics) Event() map[string]interface{} {
 	payload := map[string]interface{}{
 		"op":           m.op,
 		"latency_ms":   m.total.Milliseconds(),
-		"total_tokens": totalTokens,
+		"total_tokens": f.totalTokens,
 		"stages":       stages,
 	}
-	if costKnown {
-		payload["cost_usd"] = roundUSD(totalCost)
+	if f.costKnown {
+		payload["cost_usd"] = roundUSD(f.totalCost)
+	}
+	// Energy/CO2e are OPT-IN, approximate estimates (issue #328). They are
+	// surfaced only when enabled and at least one stage had a known factor, and
+	// are explicitly flagged with energy_estimate=true so consumers never mistake
+	// them for measurements.
+	if f.energyKnown {
+		payload["energy_wh"] = roundEnergy(f.totalWh)
+		payload["energy_estimate"] = true
+	}
+	if f.co2eKnown {
+		payload["co2e_g"] = roundEnergy(f.totalCO2eG)
 	}
 	return payload
 }
@@ -132,13 +195,23 @@ func (m *QueryMetrics) Event() map[string]interface{} {
 // LogLine renders a concise, human-readable one-liner for stderr logs. It
 // mirrors Event but never includes raw payloads.
 func (m *QueryMetrics) LogLine() string {
-	totalCost, costKnown, totalTokens := m.finalize()
+	f := m.finalize()
 	var b strings.Builder
-	fmt.Fprintf(&b, "query_metrics op=%s latency_ms=%d tokens=%d", m.op, m.total.Milliseconds(), totalTokens)
-	if costKnown {
-		fmt.Fprintf(&b, " cost_usd=%.6f", roundUSD(totalCost))
+	fmt.Fprintf(&b, "query_metrics op=%s latency_ms=%d tokens=%d", m.op, m.total.Milliseconds(), f.totalTokens)
+	if f.costKnown {
+		fmt.Fprintf(&b, " cost_usd=%.6f", roundUSD(f.totalCost))
 	} else {
 		b.WriteString(" cost_usd=unknown")
+	}
+	if f.carbonOn {
+		if f.energyKnown {
+			fmt.Fprintf(&b, " energy_wh~%.4f", roundEnergy(f.totalWh))
+		} else {
+			b.WriteString(" energy_wh=unknown")
+		}
+		if f.co2eKnown {
+			fmt.Fprintf(&b, " co2e_g~%.4f", roundEnergy(f.totalCO2eG))
+		}
 	}
 	for _, stage := range m.order {
 		sm := m.stages[stage]
@@ -155,4 +228,11 @@ func (m *QueryMetrics) LogLine() string {
 // output without floating-point noise.
 func roundUSD(v float64) float64 {
 	return math.Round(v*1e6) / 1e6
+}
+
+// roundEnergy rounds Wh / gCO2e estimates to 4 decimals for stable, readable
+// output. The estimate's inherent uncertainty far exceeds this precision; the
+// rounding only removes floating-point noise.
+func roundEnergy(v float64) float64 {
+	return math.Round(v*1e4) / 1e4
 }

--- a/tests/config/carbon_config_test.go
+++ b/tests/config/carbon_config_test.go
@@ -1,0 +1,92 @@
+package tests
+
+import (
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/usage"
+)
+
+// TestCarbon_DefaultDisabled verifies the opt-in contract: off by default (#328).
+func TestCarbon_DefaultDisabled(t *testing.T) {
+	cfg := config.Default()
+	if cfg.Carbon.Enabled {
+		t.Fatal("carbon estimate must default to disabled")
+	}
+	if len(cfg.Carbon.EnergyOverrides) != 0 {
+		t.Fatalf("energy overrides must default to empty, got %v", cfg.Carbon.EnergyOverrides)
+	}
+}
+
+// TestCarbon_AbsentBlockDisabled: no carbon: block ⇒ disabled, no error.
+func TestCarbon_AbsentBlockDisabled(t *testing.T) {
+	tmp := t.TempDir()
+	path := tmp + "/.dir2mcp.yaml"
+	writeFile(t, path, "server:\n  port: 8080\n")
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if cfg.Carbon.Enabled {
+		t.Fatal("absent carbon block must leave estimate disabled")
+	}
+}
+
+// TestCarbon_YAMLRoundTrips pins the carbon: block parsing for #328.
+func TestCarbon_YAMLRoundTrips(t *testing.T) {
+	tmp := t.TempDir()
+	path := tmp + "/.dir2mcp.yaml"
+	writeFile(t, path, strings.Join([]string{
+		"carbon:",
+		"  enabled: true",
+		"  grid_g_co2e_per_wh: 0.35",
+		"  energy:",
+		"    my-chat-model:",
+		"      wh_per_1k: 0.75",
+		"",
+	}, "\n"))
+
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if !cfg.Carbon.Enabled {
+		t.Fatal("expected carbon enabled")
+	}
+	if math.Abs(cfg.Carbon.GridGramsCO2ePerWh-0.35) > 1e-12 {
+		t.Fatalf("grid factor mismatch: %v", cfg.Carbon.GridGramsCO2ePerWh)
+	}
+	f, ok := cfg.Carbon.EnergyOverrides["my-chat-model"]
+	if !ok {
+		t.Fatalf("expected energy override for my-chat-model, got %v", cfg.Carbon.EnergyOverrides)
+	}
+	if math.Abs(f.WhPer1K-0.75) > 1e-12 {
+		t.Fatalf("wh_per_1k mismatch: %+v", f)
+	}
+}
+
+// TestCarbon_DefaultGridWhenOmitted: enabled with no grid key ⇒ built-in default
+// so a minimal config still yields a CO2e estimate.
+func TestCarbon_DefaultGridWhenOmitted(t *testing.T) {
+	tmp := t.TempDir()
+	path := tmp + "/.dir2mcp.yaml"
+	writeFile(t, path, strings.Join([]string{
+		"carbon:",
+		"  enabled: true",
+		"",
+	}, "\n"))
+
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if !cfg.Carbon.Enabled {
+		t.Fatal("expected carbon enabled")
+	}
+	if math.Abs(cfg.Carbon.GridGramsCO2ePerWh-usage.DefaultGridIntensityGramsPerWh) > 1e-12 {
+		t.Fatalf("grid factor should default to %v, got %v",
+			usage.DefaultGridIntensityGramsPerWh, cfg.Carbon.GridGramsCO2ePerWh)
+	}
+}

--- a/tests/usage/energy_test.go
+++ b/tests/usage/energy_test.go
@@ -1,0 +1,187 @@
+package tests
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/usage"
+)
+
+// TestEnergyTable_KnownModelWh verifies the Wh estimate for a known model.
+func TestEnergyTable_KnownModelWh(t *testing.T) {
+	et := usage.NewEnergyTable(map[string]usage.EnergyFactor{
+		"test-chat": {WhPer1K: 0.5},
+	})
+	wh, ok := et.EnergyWh("test-chat", 2000)
+	if !ok {
+		t.Fatal("expected known model to yield an energy estimate")
+	}
+	// 2000/1000 * 0.5 = 1.0 Wh
+	if !approxEqual(wh, 1.0) {
+		t.Fatalf("wh=%v, want 1.0", wh)
+	}
+}
+
+// TestEnergyTable_UnknownModelOmits ensures unknown models never fabricate Wh.
+func TestEnergyTable_UnknownModelOmits(t *testing.T) {
+	et := usage.DefaultEnergyTable()
+	wh, ok := et.EnergyWh("totally-made-up-model-xyz", 9999)
+	if ok {
+		t.Fatalf("unknown model must omit estimate, got ok=true wh=%v", wh)
+	}
+	if wh != 0 {
+		t.Fatalf("unknown-model wh must be 0 (omitted), got %v", wh)
+	}
+}
+
+// TestEnergyTable_OverridesReplaceDefaults checks operator overrides win.
+func TestEnergyTable_OverridesReplaceDefaults(t *testing.T) {
+	et := usage.NewEnergyTable(map[string]usage.EnergyFactor{
+		"mistral-small-2506": {WhPer1K: 9.0},
+	})
+	wh, ok := et.EnergyWh("mistral-small-2506", 1000)
+	if !ok {
+		t.Fatal("expected overridden model to be known")
+	}
+	if !approxEqual(wh, 9.0) {
+		t.Fatalf("override not applied: wh=%v, want 9.0", wh)
+	}
+}
+
+// TestEnergyTable_NilOmits guards the nil-table path.
+func TestEnergyTable_NilOmits(t *testing.T) {
+	var et *usage.EnergyTable
+	if _, ok := et.EnergyWh("mistral-small-2506", 1000); ok {
+		t.Fatal("nil energy table must omit estimate")
+	}
+}
+
+// TestCarbonModel_DisabledProducesNothing verifies the off-by-default contract.
+func TestCarbonModel_DisabledProducesNothing(t *testing.T) {
+	c := usage.NewCarbonModel(false, nil, usage.DefaultGridIntensityGramsPerWh)
+	if c.Enabled() {
+		t.Fatal("carbon model must be disabled")
+	}
+	if _, ok := c.EstimateWh("mistral-small-2506", 1000); ok {
+		t.Fatal("disabled carbon model must not estimate Wh")
+	}
+}
+
+// TestCarbonModel_NilDisabled guards the nil receiver.
+func TestCarbonModel_NilDisabled(t *testing.T) {
+	var c *usage.CarbonModel
+	if c.Enabled() {
+		t.Fatal("nil carbon model must be disabled")
+	}
+	if _, ok := c.EstimateWh("mistral-small-2506", 1000); ok {
+		t.Fatal("nil carbon model must not estimate Wh")
+	}
+}
+
+// TestCarbonModel_WhAndCO2e checks the full Wh -> gCO2e math for a known model.
+func TestCarbonModel_WhAndCO2e(t *testing.T) {
+	c := usage.NewCarbonModel(true, map[string]usage.EnergyFactor{
+		"chat-x": {WhPer1K: 1.0},
+	}, 0.4)
+	wh, ok := c.EstimateWh("chat-x", 5000)
+	if !ok {
+		t.Fatal("expected Wh estimate for known model")
+	}
+	// 5000/1000 * 1.0 = 5.0 Wh
+	if !approxEqual(wh, 5.0) {
+		t.Fatalf("wh=%v, want 5.0", wh)
+	}
+	co2e, ok := c.EstimateCO2eGrams(wh)
+	if !ok {
+		t.Fatal("expected CO2e estimate with positive grid factor")
+	}
+	// 5.0 Wh * 0.4 gCO2e/Wh = 2.0 g
+	if !approxEqual(co2e, 2.0) {
+		t.Fatalf("co2e=%v, want 2.0", co2e)
+	}
+}
+
+// TestCarbonModel_NonPositiveGridOmitsCO2e: Wh is surfaced, CO2e is omitted.
+func TestCarbonModel_NonPositiveGridOmitsCO2e(t *testing.T) {
+	c := usage.NewCarbonModel(true, map[string]usage.EnergyFactor{
+		"chat-x": {WhPer1K: 1.0},
+	}, 0)
+	wh, ok := c.EstimateWh("chat-x", 1000)
+	if !ok || !approxEqual(wh, 1.0) {
+		t.Fatalf("expected Wh=1.0, got ok=%v wh=%v", ok, wh)
+	}
+	if _, ok := c.EstimateCO2eGrams(wh); ok {
+		t.Fatal("non-positive grid factor must omit CO2e")
+	}
+}
+
+// TestQueryMetrics_CarbonEnabledKnownModel exercises the emitter end-to-end:
+// energy_wh + co2e_g present and flagged as an estimate.
+func TestQueryMetrics_CarbonEnabledKnownModel(t *testing.T) {
+	carbon := usage.NewCarbonModel(true, map[string]usage.EnergyFactor{
+		"chat-x": {WhPer1K: 1.0},
+	}, 0.4)
+	qm := usage.NewQueryMetricsWithCarbon("ask", usage.DefaultPriceTable(), carbon)
+	qm.RecordStage(usage.StageGenerate, "chat-x", 30*time.Millisecond,
+		usage.Usage{PromptTokens: 1000, CompletionTokens: 1000}, true)
+	qm.SetTotalLatency(40 * time.Millisecond)
+
+	ev := qm.Event()
+	wh, ok := ev["energy_wh"].(float64)
+	if !ok {
+		t.Fatalf("energy_wh missing: %v", ev["energy_wh"])
+	}
+	// 2000 tokens * 1.0 Wh/1K = 2.0 Wh
+	if !approxEqual(wh, 2.0) {
+		t.Fatalf("energy_wh=%v, want 2.0", wh)
+	}
+	if est, _ := ev["energy_estimate"].(bool); !est {
+		t.Fatal("energy_estimate flag must be true when energy is surfaced")
+	}
+	co2e, ok := ev["co2e_g"].(float64)
+	if !ok {
+		t.Fatalf("co2e_g missing: %v", ev["co2e_g"])
+	}
+	// 2.0 Wh * 0.4 = 0.8 g
+	if !approxEqual(co2e, 0.8) {
+		t.Fatalf("co2e_g=%v, want 0.8", co2e)
+	}
+}
+
+// TestQueryMetrics_CarbonDisabledOmitsFields: with carbon off, no energy fields
+// appear (cost/latency unchanged).
+func TestQueryMetrics_CarbonDisabledOmitsFields(t *testing.T) {
+	qm := usage.NewQueryMetrics("ask", usage.DefaultPriceTable())
+	qm.RecordStage(usage.StageGenerate, "mistral-small-2506", 10*time.Millisecond,
+		usage.Usage{PromptTokens: 1000, CompletionTokens: 1000}, true)
+	ev := qm.Event()
+	if _, present := ev["energy_wh"]; present {
+		t.Fatalf("energy_wh must be absent when carbon disabled, got %v", ev["energy_wh"])
+	}
+	if _, present := ev["co2e_g"]; present {
+		t.Fatalf("co2e_g must be absent when carbon disabled, got %v", ev["co2e_g"])
+	}
+	if _, present := ev["energy_estimate"]; present {
+		t.Fatal("energy_estimate flag must be absent when carbon disabled")
+	}
+}
+
+// TestQueryMetrics_CarbonUnknownModelOmits: enabled but unknown model ⇒ no
+// fabricated estimate.
+func TestQueryMetrics_CarbonUnknownModelOmits(t *testing.T) {
+	carbon := usage.NewCarbonModel(true, nil, 0.4)
+	qm := usage.NewQueryMetricsWithCarbon("ask", usage.DefaultPriceTable(), carbon)
+	qm.RecordStage(usage.StageGenerate, "unknown-model-zzz", 10*time.Millisecond,
+		usage.Usage{PromptTokens: 1000, CompletionTokens: 1000}, true)
+	ev := qm.Event()
+	if _, present := ev["energy_wh"]; present {
+		t.Fatalf("energy_wh must be omitted for unknown model, got %v", ev["energy_wh"])
+	}
+	if _, present := ev["co2e_g"]; present {
+		t.Fatalf("co2e_g must be omitted for unknown model, got %v", ev["co2e_g"])
+	}
+	// tokens still present.
+	if ev["total_tokens"].(int64) != 2000 {
+		t.Fatalf("total_tokens=%v, want 2000", ev["total_tokens"])
+	}
+}


### PR DESCRIPTION
Closes #328

Stacks on #345 (cost/latency observability). **Base is \`feat/cost-latency-observability-327\`, NOT main**, so this reviews as a clean diff on top of #345.

## What

Adds an **opt-in, approximate** energy / CO2e estimate per query, surfaced through the same structured \`query_metrics\` emitter introduced by #345. Off by default; clearly labelled an estimate; every factor operator-overridable.

## Model

- \`internal/usage/energy.go\`:
  - \`EnergyTable\` — Wh per 1,000 tokens, per model, with sensible (order-of-magnitude) defaults for common dir2mcp models; case-insensitive lookup; unknown model ⇒ estimate **omitted**, never fabricated.
  - \`CarbonModel\` — pairs the energy table with a grid carbon-intensity factor (gCO2e/Wh) + the enable toggle. \`EstimateWh\` / \`EstimateCO2eGrams\`.
  - \`DefaultGridIntensityGramsPerWh = 0.4\` (rough global avg; override per region).
- \`QueryMetrics\` (\`metrics.go\`): \`NewQueryMetricsWithCarbon\` adds per-stage + total \`energy_wh\` / \`co2e_g\`, flagged \`energy_estimate=true\`. Cost/latency unchanged. Estimate applied to total tokens (the prompt/completion split is well below the estimate's uncertainty). A non-positive grid factor surfaces Wh but omits CO2e.

## Config

Optional top-level \`carbon:\` block (mirrors \`cost.prices\`), disabled by default:

\`\`\`yaml
carbon:
  enabled: true
  grid_g_co2e_per_wh: 0.35   # optional; omit -> built-in default; <=0 -> skip CO2e
  energy:                     # optional per-model Wh/1K-token overrides
    my-model:
      wh_per_1k: 0.5
\`\`\`

Parsed into \`config.Config.Carbon\` and wired through \`retrieval.Service.SetCarbonModel\` from the CLI (\`up\` + \`ask\`).

## Privacy / scope

Records only counts and derived estimates — never prompts, documents, queries, or keys. No MCP tool / citation contract change. No spec re-pin. Ingest/embed-run emission is left to a follow-up: #345 only wired query-time (search/ask) emission, and that path already covers the embed stage.

## Tests

- \`tests/usage/energy_test.go\`: \`TestEnergyTable_KnownModelWh\`, \`TestEnergyTable_UnknownModelOmits\`, \`TestEnergyTable_OverridesReplaceDefaults\`, \`TestEnergyTable_NilOmits\`, \`TestCarbonModel_DisabledProducesNothing\`, \`TestCarbonModel_NilDisabled\`, \`TestCarbonModel_WhAndCO2e\`, \`TestCarbonModel_NonPositiveGridOmitsCO2e\`, \`TestQueryMetrics_CarbonEnabledKnownModel\`, \`TestQueryMetrics_CarbonDisabledOmitsFields\`, \`TestQueryMetrics_CarbonUnknownModelOmits\`.
- \`tests/config/carbon_config_test.go\`: \`TestCarbon_DefaultDisabled\`, \`TestCarbon_AbsentBlockDisabled\`, \`TestCarbon_YAMLRoundTrips\`, \`TestCarbon_DefaultGridWhenOmitted\`.

\`make check\` green (lint/vet/cyclo/ineffassign/misspell/tests). gocyclo ≤15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHuQEKSW3nzU1Pn7KXXBhj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional carbon and energy estimation in query metrics, configurable via YAML with support for per-model energy overrides and grid carbon intensity settings.

* **Tests**
  * Added comprehensive tests for carbon configuration parsing and energy/carbon estimation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->