### PR TITLE
feat(rerank): self-hosted ColBERT late-interaction reranker backend (#337)

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -684,8 +684,42 @@ func (a *App) configureQueryMetrics(ret *retrieval.Service, cfg config.Config, e
 	))
 }
 
-// configureReranker wires the optional Cohere rerank stage onto the
-// retrieval service through the resolver (SPEC 8.1.3). cfg.RerankEnabled
+// rerankSelectorProfiles maps a non-default rerank.provider selector onto
+// the built-in provider profile that serves it. `cohere` (and the empty
+// selector) take the auto-resolution path instead and are intentionally
+// absent. `colbert` is the self-hosted late-interaction backend
+// (dir2mcp#337); it is reached by an explicit selector, like the whisper
+// STT path, so it never wins rerank auto-selection over hosted cohere.
+var rerankSelectorProfiles = map[string]string{
+	"colbert": "colbert",
+}
+
+// resolveRerankProfile resolves the rerank provider profile for the legacy
+// flat rerank.provider selector (SPEC 8.1.3). An empty selector or `cohere`
+// uses auto-resolution; a known self-hosted selector (e.g. `colbert`)
+// resolves its named profile explicitly. ok=false means "no rerank backend"
+// (an unknown selector, or no eligible profile) — the caller fails open.
+func resolveRerankProfile(cfg config.Config, asked bool) (provider.Profile, error, bool) {
+	r := cfg.Providers()
+	sel := strings.ToLower(strings.TrimSpace(cfg.RerankProvider))
+	switch sel {
+	case "", "cohere":
+		p, err := r.Resolve(provider.CapRerank)
+		return p, err, true
+	default:
+		name, known := rerankSelectorProfiles[sel]
+		if !known {
+			return provider.Profile{}, nil, false
+		}
+		p, err := r.ResolveExplicit(provider.CapRerank, name, asked)
+		return p, err, true
+	}
+}
+
+// configureReranker wires the optional rerank stage onto the retrieval
+// service through the resolver (SPEC 8.1.3). The backend is either the
+// hosted Cohere cross-encoder or a self-hosted late-interaction (ColBERT)
+// endpoint (dir2mcp#337), selected by rerank.provider. cfg.RerankEnabled
 // is a tri-state override:
 //
 //	nil    -> auto: on iff a rerank provider resolves
@@ -700,18 +734,15 @@ func (a *App) configureReranker(ret *retrieval.Service, cfg config.Config) {
 	}
 	asked := explicit && *cfg.RerankEnabled
 
-	// Honor the legacy flat rerank_provider during the transition: a
-	// non-cohere value preserves the prior "unsupported provider
-	// disables rerank" behavior (only cohere serves rerank — SPEC
-	// 8.1.2).
-	if rpName := strings.ToLower(strings.TrimSpace(cfg.RerankProvider)); rpName != "" && rpName != "cohere" {
+	rp, err, ok := resolveRerankProfile(cfg, asked)
+	if !ok {
+		// Unrecognised rerank.provider selector: preserve the prior
+		// "unsupported provider disables rerank" behavior.
 		if asked {
 			writef(a.stderr, "warning: rerank.provider %q unsupported; reranking disabled\n", cfg.RerankProvider)
 		}
 		return
 	}
-
-	rp, err := cfg.Providers().Resolve(provider.CapRerank)
 	if err != nil {
 		// No eligible rerank provider (or an invalid explicit binding).
 		// Auto mode stays silent; only warn when explicitly asked.

--- a/internal/cli/rerank_selection_test.go
+++ b/internal/cli/rerank_selection_test.go
@@ -1,0 +1,73 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/provider"
+)
+
+// TestResolveRerankProfile_ColBERTSelector verifies rerank.provider=colbert
+// routes to the built-in self-hosted ColBERT profile (dir2mcp#337), as an
+// alternative to the hosted cohere path.
+func TestResolveRerankProfile_ColBERTSelector(t *testing.T) {
+	t.Setenv("COLBERT_BASE_URL", "http://colbert.internal:9000")
+	cfg := config.Default()
+	cfg.RerankProvider = "colbert"
+
+	p, err, ok := resolveRerankProfile(cfg, true)
+	if !ok {
+		t.Fatal("colbert selector must be recognised")
+	}
+	if err != nil {
+		t.Fatalf("resolve error: %v", err)
+	}
+	if p.Kind != provider.KindColBERT {
+		t.Fatalf("kind = %q, want colbert", p.Kind)
+	}
+	if p.BaseURL != "http://colbert.internal:9000" {
+		t.Fatalf("base_url = %q, want env-expanded value", p.BaseURL)
+	}
+}
+
+// TestResolveRerankProfile_CohereSelectorUsesAuto verifies the default
+// cohere selector takes the auto-resolution path: with a credential it
+// resolves cohere, without one it stays unresolved (rerank off) — unchanged
+// pre-#337 behavior.
+func TestResolveRerankProfile_CohereSelectorUsesAuto(t *testing.T) {
+	cfg := config.Default() // RerankProvider defaults to "cohere"
+
+	t.Run("with credential resolves cohere", func(t *testing.T) {
+		t.Setenv("COHERE_API_KEY", "k")
+		p, err, ok := resolveRerankProfile(cfg, true)
+		if !ok || err != nil {
+			t.Fatalf("want ok cohere resolve, got ok=%v err=%v", ok, err)
+		}
+		if p.Kind != provider.KindCohere {
+			t.Fatalf("kind = %q, want cohere", p.Kind)
+		}
+	})
+
+	t.Run("without credential stays unresolved", func(t *testing.T) {
+		t.Setenv("COHERE_API_KEY", "")
+		_, err, ok := resolveRerankProfile(cfg, true)
+		if !ok {
+			t.Fatal("cohere selector must still take the (recognised) auto path")
+		}
+		if err == nil {
+			t.Fatal("auto cohere without credential must not resolve")
+		}
+	})
+}
+
+// TestResolveRerankProfile_UnknownSelectorInert verifies an unrecognised
+// rerank.provider value is reported as not-ok, so configureReranker leaves
+// reranking off (preserving the prior "unsupported provider disables
+// rerank" behavior).
+func TestResolveRerankProfile_UnknownSelectorInert(t *testing.T) {
+	cfg := config.Default()
+	cfg.RerankProvider = "totally-unknown"
+	if _, _, ok := resolveRerankProfile(cfg, true); ok {
+		t.Fatal("unknown rerank.provider selector must be inert (ok=false)")
+	}
+}

--- a/internal/colbertrerank/client.go
+++ b/internal/colbertrerank/client.go
@@ -1,0 +1,246 @@
+// Package colbertrerank is a pure-Go client for a self-hosted
+// late-interaction / multi-vector (ColBERT-style) reranking endpoint
+// (dir2mcp#337).
+//
+// It targets a portable JSON rerank contract — POST {BaseURL}/rerank with
+// a query plus the candidate documents, returning a relevance score per
+// document — that common self-hosted late-interaction servers expose
+// (ColBERTv2/PLAID, Jina-ColBERT-v2, GTE-ModernColBERT shims). The wire
+// shape deliberately mirrors the Cohere /v2/rerank request/response
+// (model/query/documents -> results[].{index,relevance_score}) so the same
+// retrieval seam (model.Reranker) drives either backend unchanged.
+//
+// The endpoint may be credential-less (a self-hosted box on a private
+// network): a Bearer token is sent only when an api_key is configured —
+// the same self-hosted shape as internal/whisperapi for STT.
+//
+// Reranking in dir2mcp is fail-open: callers treat any error from this
+// client as "skip rerank, keep the fused order" (see internal/retrieval).
+// The client never logs document text or secrets; HTTP errors carry only a
+// status-derived message (CLAUDE.md: no raw sensitive payloads).
+package colbertrerank
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+const (
+	defaultRequestTimeout = 30 * time.Second
+	defaultMaxRetries     = 3
+	defaultInitialBackoff = 250 * time.Millisecond
+	defaultMaxBackoff     = 2 * time.Second
+
+	// DefaultModel is a sensible fallback model name. Self-hosted servers
+	// frequently ignore the field or serve a single fixed checkpoint, but
+	// operators SHOULD set an explicit model via the provider profile.
+	DefaultModel = "colbert"
+)
+
+// Client speaks a JSON late-interaction rerank contract against a
+// self-hosted base URL.
+//
+// Error codes (carried on *model.ProviderError):
+//   - COLBERT_AUTH (non-retryable): upstream 401/403.
+//   - COLBERT_RATE_LIMIT (retryable): upstream 429.
+//   - COLBERT_FAILED (retryable for network/5xx, non-retryable otherwise).
+type Client struct {
+	BaseURL    string
+	APIKey     string
+	HTTPClient *http.Client
+
+	MaxRetries     int
+	InitialBackoff time.Duration
+	MaxBackoff     time.Duration
+
+	// DefaultModel is sent as the request `model` field when Rerank is
+	// called with an empty modelName. Empty falls back to the package
+	// DefaultModel constant.
+	DefaultModel string
+}
+
+// compile-time assertion that *Client implements the rerank contract.
+var _ model.Reranker = (*Client)(nil)
+
+// NewClient constructs a client with safe default retry/timeout settings.
+// apiKey may be empty for a credential-less self-hosted endpoint.
+func NewClient(baseURL, apiKey string) *Client {
+	return &Client{
+		BaseURL:        strings.TrimRight(strings.TrimSpace(baseURL), "/"),
+		APIKey:         strings.TrimSpace(apiKey),
+		HTTPClient:     &http.Client{Timeout: defaultRequestTimeout},
+		MaxRetries:     defaultMaxRetries,
+		InitialBackoff: defaultInitialBackoff,
+		MaxBackoff:     defaultMaxBackoff,
+		DefaultModel:   DefaultModel,
+	}
+}
+
+type rerankRequest struct {
+	Model     string   `json:"model"`
+	Query     string   `json:"query"`
+	Documents []string `json:"documents"`
+	TopN      int      `json:"top_n,omitempty"`
+}
+
+type rerankResponse struct {
+	Results []struct {
+		Index          int     `json:"index"`
+		RelevanceScore float64 `json:"relevance_score"`
+	} `json:"results"`
+}
+
+// Rerank re-scores documents against query via the self-hosted late-interaction
+// endpoint and returns results ordered best-first. topN <= 0 requests all
+// documents back. An empty documents slice short-circuits to an empty result
+// without an API call. A credential-less endpoint is allowed (no api_key); only
+// a missing base_url is a hard error.
+func (c *Client) Rerank(ctx context.Context, modelName, query string, documents []string, topN int) ([]model.Reranked, error) {
+	if len(documents) == 0 {
+		return nil, nil
+	}
+	if strings.TrimSpace(c.BaseURL) == "" {
+		return nil, &model.ProviderError{Code: "COLBERT_FAILED", Message: "missing colbert base_url", Retryable: false}
+	}
+	if strings.TrimSpace(modelName) == "" {
+		modelName = strings.TrimSpace(c.DefaultModel)
+		if modelName == "" {
+			modelName = DefaultModel
+		}
+	}
+	return c.rerankWithRetry(ctx, modelName, query, documents, topN)
+}
+
+func (c *Client) rerankWithRetry(ctx context.Context, modelName, query string, documents []string, topN int) ([]model.Reranked, error) {
+	maxAttempts := c.MaxRetries + 1
+	if maxAttempts <= 0 {
+		maxAttempts = 1
+	}
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		out, err := c.rerankOnce(ctx, modelName, query, documents, topN)
+		if err == nil {
+			return out, nil
+		}
+		lastErr = err
+
+		var providerErr *model.ProviderError
+		if !errors.As(err, &providerErr) || !providerErr.Retryable || attempt == maxAttempts-1 {
+			return nil, err
+		}
+		if waitErr := c.wait(ctx, c.backoffForAttempt(attempt)); waitErr != nil {
+			return nil, waitErr
+		}
+	}
+	return nil, lastErr
+}
+
+func (c *Client) rerankOnce(ctx context.Context, modelName, query string, documents []string, topN int) ([]model.Reranked, error) {
+	payload := rerankRequest{Model: modelName, Query: query, Documents: documents}
+	if topN > 0 {
+		payload.TopN = topN
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, &model.ProviderError{Code: "COLBERT_FAILED", Message: "failed to marshal rerank request", Retryable: false, Cause: err}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+"/rerank", bytes.NewReader(body))
+	if err != nil {
+		return nil, &model.ProviderError{Code: "COLBERT_FAILED", Message: "failed to build rerank request", Retryable: false, Cause: err}
+	}
+	// Bearer auth is optional: only set it for credentialed endpoints.
+	if key := strings.TrimSpace(c.APIKey); key != "" {
+		req.Header.Set("Authorization", "Bearer "+key)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	httpClient := c.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: defaultRequestTimeout}
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, &model.ProviderError{Code: "COLBERT_FAILED", Message: "rerank request failed", Retryable: true, Cause: err}
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, httpError(resp)
+	}
+
+	var parsed rerankResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil, &model.ProviderError{Code: "COLBERT_FAILED", Message: "failed to decode rerank response", Retryable: false, StatusCode: resp.StatusCode, Cause: err}
+	}
+
+	out := make([]model.Reranked, 0, len(parsed.Results))
+	for _, r := range parsed.Results {
+		if r.Index < 0 || r.Index >= len(documents) {
+			return nil, &model.ProviderError{Code: "COLBERT_FAILED", Message: fmt.Sprintf("rerank response contains out-of-range index %d", r.Index), Retryable: false, StatusCode: resp.StatusCode}
+		}
+		out = append(out, model.Reranked{Index: r.Index, RelevanceScore: r.RelevanceScore})
+	}
+	return out, nil
+}
+
+// httpError maps an upstream non-200 onto a typed *model.ProviderError. The
+// raw upstream body is drained (bounded) but never surfaced: it can echo
+// prompt/document content (CLAUDE.md: no raw sensitive payloads in errors).
+// The HTTP status is sufficient and machine-parseable via StatusCode.
+func httpError(resp *http.Response) error {
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+	switch {
+	case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
+		return &model.ProviderError{Code: "COLBERT_AUTH", Message: fmt.Sprintf("colbert rerank rejected (HTTP %d)", resp.StatusCode), Retryable: false, StatusCode: resp.StatusCode}
+	case resp.StatusCode == http.StatusTooManyRequests:
+		return &model.ProviderError{Code: "COLBERT_RATE_LIMIT", Message: "colbert rerank rate limited (HTTP 429)", Retryable: true, StatusCode: resp.StatusCode}
+	case resp.StatusCode >= http.StatusInternalServerError:
+		return &model.ProviderError{Code: "COLBERT_FAILED", Message: fmt.Sprintf("colbert upstream error (HTTP %d)", resp.StatusCode), Retryable: true, StatusCode: resp.StatusCode}
+	default:
+		return &model.ProviderError{Code: "COLBERT_FAILED", Message: fmt.Sprintf("colbert rerank failed (HTTP %d)", resp.StatusCode), Retryable: false, StatusCode: resp.StatusCode}
+	}
+}
+
+func (c *Client) backoffForAttempt(attempt int) time.Duration {
+	initial := c.InitialBackoff
+	if initial <= 0 {
+		initial = defaultInitialBackoff
+	}
+	maxBackoff := c.MaxBackoff
+	if maxBackoff <= 0 {
+		maxBackoff = defaultMaxBackoff
+	}
+	backoff := initial
+	for i := 0; i < attempt; i++ {
+		backoff *= 2
+		if backoff >= maxBackoff {
+			return maxBackoff
+		}
+	}
+	return backoff
+}
+
+func (c *Client) wait(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/internal/config/providers.go
+++ b/internal/config/providers.go
@@ -88,6 +88,14 @@ func builtinProfiles() map[string]providerProfileYAML {
 		// wins embed auto-selection; reach it via model.embed.provider:
 		// omniembed. Multimodal embedding is opt-in via model.embed.multimodal.
 		"omniembed": {Kind: "omniembed", BaseURL: "${OMNIEMBED_BASE_URL}"},
+		// colbert: self-hosted late-interaction / multi-vector reranker
+		// (dir2mcp#337). Credential-less by default (no api_key); operators
+		// point base_url (and optionally set api_key/rerank_model) via a
+		// providers: entry or the COLBERT_BASE_URL env default. Excluded from
+		// builtinPrecedence (like `local`/`whisper`) so it never silently wins
+		// rerank auto-selection over the hosted cohere path; reach it via
+		// rerank.provider: colbert.
+		"colbert": {Kind: "colbert", BaseURL: "${COLBERT_BASE_URL}"},
 	}
 }
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -37,6 +37,15 @@ const (
 	// embed-capable and credential-optional, and the embed factory builds
 	// the multimodal-capable adapter for it.
 	KindOmniEmbed Kind = "omniembed"
+	// KindColBERT is a self-hosted late-interaction / multi-vector
+	// (ColBERT-style) reranking endpoint (dir2mcp#337): POST
+	// {base_url}/rerank with a query + candidate documents, returning a
+	// relevance score per document. Distinct from KindCohere so rerank
+	// selection and the matrix can treat it as statically rerank-capable
+	// (Supported) and credential-optional — the same self-hosted shape as
+	// KindWhisper for STT. It pairs with self-hosted embeddings (#334) for a
+	// fully-offline high-precision retrieval pipeline.
+	KindColBERT Kind = "colbert"
 )
 
 // Capability is a model capability bound to a provider profile.
@@ -123,6 +132,14 @@ var matrix = map[Kind]map[Capability]Support{
 		// kind:whisper for STT — it is marked Supported rather than
 		// EndpointDependent.
 		CapEmbed: Supported,
+	},
+	KindColBERT: {
+		// Self-hosted late-interaction (ColBERT-style) reranker (dir2mcp#337).
+		// Statically rerank-capable: the self-hosted endpoint speaks a fixed
+		// JSON rerank contract (query + documents -> per-document score), so
+		// like KindWhisper for STT we mark it Supported and credential-optional
+		// (a box on a private network needs no api_key).
+		CapRerank: Supported,
 	},
 }
 

--- a/internal/providerfactory/factory.go
+++ b/internal/providerfactory/factory.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/dirstral/dir2mcp/internal/anthropic"
 	"github.com/dirstral/dir2mcp/internal/cohere"
+	"github.com/dirstral/dir2mcp/internal/colbertrerank"
 	"github.com/dirstral/dir2mcp/internal/elevenlabs"
 	"github.com/dirstral/dir2mcp/internal/gemini"
 	"github.com/dirstral/dir2mcp/internal/mistral"
@@ -327,14 +328,26 @@ func TTS(p provider.Profile) (TTSSynthesizer, error) {
 	}
 }
 
-// Reranker builds a model.Reranker (only `cohere`).
+// Reranker builds a model.Reranker for rerank-capable kinds: `cohere`
+// (hosted cross-encoder, SPEC 8.1.2) and `colbert` (self-hosted
+// late-interaction / multi-vector endpoint, dir2mcp#337). The colbert
+// client is credential-optional (a self-hosted box on a private network),
+// mirroring the whisper STT path.
 func Reranker(p provider.Profile) (model.Reranker, error) {
-	if p.Kind != provider.KindCohere {
+	switch p.Kind {
+	case provider.KindCohere:
+		c := cohere.NewClient(p.BaseURL, p.APIKey)
+		if p.RerankModel != "" {
+			c.DefaultModel = p.RerankModel
+		}
+		return c, nil
+	case provider.KindColBERT:
+		c := colbertrerank.NewClient(p.BaseURL, p.APIKey)
+		if p.RerankModel != "" {
+			c.DefaultModel = p.RerankModel
+		}
+		return c, nil
+	default:
 		return nil, unsupported(p, provider.CapRerank)
 	}
-	c := cohere.NewClient(p.BaseURL, p.APIKey)
-	if p.RerankModel != "" {
-		c.DefaultModel = p.RerankModel
-	}
-	return c, nil
 }

--- a/tests/colbertrerank/client_test.go
+++ b/tests/colbertrerank/client_test.go
@@ -1,0 +1,200 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/colbertrerank"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+type rerankBody struct {
+	Model     string   `json:"model"`
+	Query     string   `json:"query"`
+	Documents []string `json:"documents"`
+	TopN      int      `json:"top_n"`
+}
+
+func newClient(url, apiKey string) *colbertrerank.Client {
+	c := colbertrerank.NewClient(url, apiKey)
+	c.InitialBackoff = time.Millisecond
+	c.MaxBackoff = 2 * time.Millisecond
+	return c
+}
+
+// TestRerank_ReordersByReturnedScores verifies the client targets POST
+// /rerank, sends the query+documents body, and returns results in the exact
+// (best-first) provider order — the candidate-pool reordering contract.
+func TestRerank_ReordersByReturnedScores(t *testing.T) {
+	var gotAuth, gotPath string
+	var body rerankBody
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotPath = r.URL.Path
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &body)
+		w.Header().Set("Content-Type", "application/json")
+		// Deliberately out of input order; the client must preserve the
+		// provider's best-first ordering.
+		_, _ = w.Write([]byte(`{"results":[{"index":2,"relevance_score":0.91},{"index":0,"relevance_score":0.40}]}`))
+	}))
+	defer srv.Close()
+
+	res, err := newClient(srv.URL, "test-key").Rerank(context.Background(), "colbert-v2", "q", []string{"a", "b", "c"}, 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotPath != "/rerank" {
+		t.Fatalf("path = %q, want /rerank", gotPath)
+	}
+	if gotAuth != "Bearer test-key" {
+		t.Fatalf("auth = %q, want Bearer test-key", gotAuth)
+	}
+	if body.Model != "colbert-v2" || body.Query != "q" || len(body.Documents) != 3 || body.TopN != 2 {
+		t.Fatalf("unexpected request body: %+v", body)
+	}
+	if len(res) != 2 || res[0].Index != 2 || res[1].Index != 0 {
+		t.Fatalf("provider order not preserved: %+v", res)
+	}
+	if res[0].RelevanceScore != 0.91 {
+		t.Fatalf("score not parsed: %+v", res[0])
+	}
+}
+
+// TestRerank_CredentialLessOmitsAuthHeader verifies a self-hosted box on a
+// private network works without an api_key and that NO Authorization header
+// is sent in that case.
+func TestRerank_CredentialLessOmitsAuthHeader(t *testing.T) {
+	var hadAuth bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, hadAuth = r.Header["Authorization"]
+		_, _ = w.Write([]byte(`{"results":[{"index":0,"relevance_score":0.5}]}`))
+	}))
+	defer srv.Close()
+
+	res, err := newClient(srv.URL, "").Rerank(context.Background(), "", "q", []string{"a"}, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if hadAuth {
+		t.Fatalf("credential-less client must not send an Authorization header")
+	}
+	if len(res) != 1 || res[0].Index != 0 {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+}
+
+// TestRerank_DefaultModelWhenEmpty verifies an empty model name falls back
+// to the package default in the request body.
+func TestRerank_DefaultModelWhenEmpty(t *testing.T) {
+	var body rerankBody
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &body)
+		_, _ = w.Write([]byte(`{"results":[]}`))
+	}))
+	defer srv.Close()
+
+	if _, err := newClient(srv.URL, "").Rerank(context.Background(), "", "q", []string{"a"}, 0); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if body.Model != colbertrerank.DefaultModel {
+		t.Fatalf("model = %q, want default %q", body.Model, colbertrerank.DefaultModel)
+	}
+}
+
+// TestRerank_EmptyDocumentsShortCircuits verifies an empty candidate pool
+// never touches the network.
+func TestRerank_EmptyDocumentsShortCircuits(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("endpoint must not be called for empty documents")
+	}))
+	defer srv.Close()
+	res, err := newClient(srv.URL, "").Rerank(context.Background(), "", "q", nil, 0)
+	if err != nil || res != nil {
+		t.Fatalf("want (nil,nil), got (%v,%v)", res, err)
+	}
+}
+
+// TestRerank_MissingBaseURLIsNonRetryable verifies an unconfigured endpoint
+// (no base_url) fails fast and non-retryably so the retrieval seam can fail
+// open without network access.
+func TestRerank_MissingBaseURLIsNonRetryable(t *testing.T) {
+	_, err := colbertrerank.NewClient("", "").Rerank(context.Background(), "", "q", []string{"a"}, 0)
+	assertProviderError(t, err, "COLBERT_FAILED", false)
+}
+
+// TestRerank_HTTPErrorsMapToTypedCodes verifies upstream status codes map to
+// the documented error codes/retryability, and that the raw upstream body is
+// never echoed into the error message (no doc text / secret leakage).
+func TestRerank_HTTPErrorsMapToTypedCodes(t *testing.T) {
+	cases := []struct {
+		name      string
+		status    int
+		code      string
+		retryable bool
+	}{
+		{"unauthorized", http.StatusUnauthorized, "COLBERT_AUTH", false},
+		{"forbidden", http.StatusForbidden, "COLBERT_AUTH", false},
+		{"rate_limited", http.StatusTooManyRequests, "COLBERT_RATE_LIMIT", true},
+		{"server_error", http.StatusInternalServerError, "COLBERT_FAILED", true},
+		{"bad_request", http.StatusBadRequest, "COLBERT_FAILED", false},
+	}
+	const secret = "SECRET-DOC-TEXT-should-not-leak"
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(secret))
+			}))
+			defer srv.Close()
+			c := newClient(srv.URL, "k")
+			c.MaxRetries = 0 // keep retryable cases from looping in the test
+			_, err := c.Rerank(context.Background(), "", "q", []string{"a"}, 0)
+			assertProviderError(t, err, tc.code, tc.retryable)
+			var pErr *model.ProviderError
+			if errors.As(err, &pErr) && strings.Contains(pErr.Message, secret) {
+				t.Fatalf("error message leaked upstream body: %q", pErr.Message)
+			}
+		})
+	}
+}
+
+// TestRerank_OutOfRangeIndexRejected verifies a malformed response (index
+// outside the documents slice) is a non-retryable failure rather than a
+// silent out-of-bounds, so the seam falls open to the fused order.
+func TestRerank_OutOfRangeIndexRejected(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"results":[{"index":5,"relevance_score":0.9}]}`))
+	}))
+	defer srv.Close()
+	_, err := newClient(srv.URL, "k").Rerank(context.Background(), "", "q", []string{"a", "b"}, 0)
+	assertProviderError(t, err, "COLBERT_FAILED", false)
+}
+
+func assertProviderError(t *testing.T, err error, wantCode string, wantRetryable bool) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected error %s, got nil", wantCode)
+	}
+	var pErr *model.ProviderError
+	if !errors.As(err, &pErr) {
+		t.Fatalf("error is not *model.ProviderError: %v", err)
+	}
+	if pErr.Code != wantCode {
+		t.Fatalf("code = %q, want %q (msg=%q)", pErr.Code, wantCode, pErr.Message)
+	}
+	if pErr.Retryable != wantRetryable {
+		t.Fatalf("retryable = %v, want %v", pErr.Retryable, wantRetryable)
+	}
+	if strings.TrimSpace(pErr.Message) == "" {
+		t.Fatalf("provider error message is empty")
+	}
+}

--- a/tests/config/providers_config_test.go
+++ b/tests/config/providers_config_test.go
@@ -20,6 +20,47 @@ func loadCfg(t *testing.T, yaml string) config.Config {
 	return cfg
 }
 
+// TestProviders_ColBERTRerankProfileResolves verifies the built-in
+// self-hosted ColBERT reranker profile (dir2mcp#337) resolves explicitly,
+// is credential-less (eligible without an api_key), and is rerank-capable.
+// It is excluded from auto-precedence, so auto rerank resolution never
+// silently picks it over the hosted cohere path.
+func TestProviders_ColBERTRerankProfileResolves(t *testing.T) {
+	t.Setenv("COLBERT_BASE_URL", "http://colbert.internal:9000")
+	r := loadCfg(t, "version: 1\n").Providers()
+
+	p, err := r.ResolveExplicit(provider.CapRerank, "colbert", true)
+	if err != nil {
+		t.Fatalf("ResolveExplicit(rerank, colbert) error: %v", err)
+	}
+	if p.Kind != provider.KindColBERT {
+		t.Fatalf("kind = %q, want colbert", p.Kind)
+	}
+	if p.BaseURL != "http://colbert.internal:9000" {
+		t.Fatalf("base_url = %q, want env-expanded value", p.BaseURL)
+	}
+	if !p.Eligible() {
+		t.Fatal("colbert profile must be credential-less (eligible without api_key)")
+	}
+	if provider.Can(provider.KindColBERT, provider.CapRerank) != provider.Supported {
+		t.Fatal("colbert must be statically rerank-capable")
+	}
+}
+
+// TestProviders_ColBERTNotAutoSelectedForRerank verifies that, with no
+// rerank credential, auto rerank resolution still does NOT pick the
+// credential-less colbert profile (it is excluded from precedence) — auto
+// stays off, exactly as it did before #337.
+func TestProviders_ColBERTNotAutoSelectedForRerank(t *testing.T) {
+	for _, k := range []string{"COHERE_API_KEY", "COLBERT_BASE_URL"} {
+		t.Setenv(k, "")
+	}
+	r := loadCfg(t, "version: 1\n").Providers()
+	if _, err := r.Resolve(provider.CapRerank); err == nil {
+		t.Fatal("auto rerank must not silently select the colbert profile")
+	}
+}
+
 func TestProviders_BuiltinAutoSelectByCredential(t *testing.T) {
 	t.Setenv("MISTRAL_API_KEY", "mk")
 	cfg := loadCfg(t, "rag:\n  generate_answer: true\n")

--- a/tests/providerfactory/factory_test.go
+++ b/tests/providerfactory/factory_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"testing"
 
+	"github.com/dirstral/dir2mcp/internal/colbertrerank"
 	"github.com/dirstral/dir2mcp/internal/gemini"
 	"github.com/dirstral/dir2mcp/internal/model"
 	"github.com/dirstral/dir2mcp/internal/omniembed"
@@ -79,13 +80,32 @@ func TestTTS(t *testing.T) {
 }
 
 func TestReranker(t *testing.T) {
-	if r, err := providerfactory.Reranker(prof(provider.KindCohere)); err != nil || r == nil {
-		t.Fatalf("Reranker(cohere) = %v, %v", r, err)
+	for _, k := range []provider.Kind{provider.KindCohere, provider.KindColBERT} {
+		if r, err := providerfactory.Reranker(prof(k)); err != nil || r == nil {
+			t.Fatalf("Reranker(%s) = %v, %v", k, r, err)
+		}
 	}
 	for _, k := range []provider.Kind{provider.KindOpenAI, provider.KindMistral, provider.KindGemini, provider.KindAnthropic, provider.KindElevenLabs} {
 		if _, err := providerfactory.Reranker(prof(k)); err == nil {
 			t.Errorf("Reranker(%s) must error", k)
 		}
+	}
+}
+
+// TestReranker_ColBERTModelPropagates verifies the profile's rerank_model
+// overrides the colbert client's default (parity with the cohere path).
+func TestReranker_ColBERTModelPropagates(t *testing.T) {
+	p := provider.Profile{Name: "colbert", Kind: provider.KindColBERT, BaseURL: "http://localhost:9000", RerankModel: "gte-moderncolbert"}
+	r, err := providerfactory.Reranker(p)
+	if err != nil || r == nil {
+		t.Fatalf("Reranker(colbert) = %v, %v", r, err)
+	}
+	c, ok := r.(*colbertrerank.Client)
+	if !ok {
+		t.Fatalf("expected *colbertrerank.Client, got %T", r)
+	}
+	if c.DefaultModel != "gte-moderncolbert" {
+		t.Fatalf("rerank_model not propagated: %q", c.DefaultModel)
 	}
 }
 

--- a/tests/security/cli_boundary_test.go
+++ b/tests/security/cli_boundary_test.go
@@ -182,6 +182,7 @@ func TestRepoSplitBoundary_InternalCLIFileOwnership(t *testing.T) {
 		"registration_hint.go":      {},
 		"registration_hint_test.go": {},
 		"remote_commands.go":        {},
+		"rerank_selection_test.go":  {},
 		"routing_decision.go":       {},
 		"server_doctor.go":          {},
 		"service.go":                {},


### PR DESCRIPTION
Closes #337

## What

Adds an optional **self-hosted late-interaction / multi-vector (ColBERT-style) reranker** behind the existing rerank seam, as an alternative/complement to the hosted Cohere reranker. It pairs with self-hosted embeddings (#334) for a fully-offline high-precision retrieval pipeline.

Config-only / additive backend ⇒ **ungated**: no MCP tool, citation, or spec change; no submodule re-pin.

## How it works

- **New adapter `internal/colbertrerank`** — a pure-Go `model.Reranker` speaking a portable JSON rerank contract:
  - Request: `POST {base_url}/rerank` with `{"model","query","documents":[...],"top_n"}`
  - Response: `{"results":[{"index","relevance_score"}, ...]}` (best-first)
  - The wire shape deliberately mirrors Cohere's `/v2/rerank` so the same seam drives either backend.
  - **Credential-optional** (Bearer sent only when `api_key` is set — a private-network box needs none), bounded exponential retry, fail-open. Never logs document text or raw upstream bodies.
- **`provider.KindColBERT`** added to the capability matrix as `CapRerank: Supported` (credential-optional) — the same self-hosted shape as `KindWhisper` for STT.
- **`providerfactory.Reranker`** now builds the colbert client for `KindColBERT` (cohere path unchanged).
- **Built-in `colbert` profile** (`kind: colbert`, `base_url: ${COLBERT_BASE_URL}`), credential-less and **excluded from auto-precedence** so it never silently wins rerank auto-selection over hosted Cohere.

## Selection (vs Cohere)

`configureReranker` resolves the rerank profile from the `rerank.provider` selector:
- `cohere` / empty → auto-resolution (unchanged pre-#337 behavior)
- `colbert` → explicit resolution of the `colbert` profile (like the `stt.provider: whisper` path)
- unknown selector → inert (rerank stays off)

The retrieval candidate-pool, ordering, fail-open, and no-rerank paths are unchanged.

## Tests

- `tests/colbertrerank` — stub `httptest` server: targets `/rerank`, reorders candidates by returned scores, omits auth when credential-less, defaults the model, short-circuits empty pools, maps HTTP status → typed codes without leaking the upstream body, rejects out-of-range indices.
- `tests/providerfactory` — `KindColBERT` builds a reranker; `rerank_model` propagates.
- `tests/config` — built-in colbert profile resolves explicitly, is credential-less + rerank-capable, and is not auto-selected.
- `internal/cli` — `resolveRerankProfile` routing (colbert / cohere-auto / unknown-inert).

No network or credentials required; no doc text or secrets asserted/logged.

`make check` is fully green locally (gocyclo ≤ 15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHuQEKSW3nzU1Pn7KXXBhj