### PR TITLE
retrieval: opt-in MMR diversity reranking (#340)

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -825,6 +825,7 @@ func (a *App) buildRetrieverForAsk(ctx context.Context, cfg config.Config, st mo
 	a.configureQueryMetrics(ret, cfg, askMetricsEmitter.Emit)
 	ret.SetContextCompression(cfg.ContextCompressionEnabled, cfg.ContextCompressionTargetRatio)
 	ret.SetAdaptiveRetrieval(cfg.RetrievalAdaptiveEnabled, cfg.RetrievalAdaptiveKMin, cfg.RetrievalAdaptiveKMax)
+	ret.SetMMR(cfg.RetrievalMMREnabled, cfg.RetrievalMMRLambda)
 
 	if metadataStore, ok := st.(embeddedChunkLister); ok {
 		if _, err := preloadEmbeddedChunkMetadata(ctx, metadataStore, ret); err != nil && !errors.Is(err, model.ErrNotImplemented) {

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -82,6 +82,7 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 	ret.SetRecencyHalfLife(cfg.RetrievalRecencyHalfLife)
 	ret.SetContextCompression(cfg.ContextCompressionEnabled, cfg.ContextCompressionTargetRatio)
 	ret.SetAdaptiveRetrieval(cfg.RetrievalAdaptiveEnabled, cfg.RetrievalAdaptiveKMin, cfg.RetrievalAdaptiveKMax)
+	ret.SetMMR(cfg.RetrievalMMREnabled, cfg.RetrievalMMRLambda)
 
 	// events are emitted to stdout only after we create the emitter; moving
 	// creation before the preload call lets us report failures from that

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -272,6 +272,21 @@ type Config struct {
 	// defaultConfig). Ignored entirely when RetrievalAdaptiveEnabled is false.
 	RetrievalAdaptiveKMin int
 	RetrievalAdaptiveKMax int
+	// RetrievalMMREnabled toggles Maximal Marginal Relevance (MMR) diversity
+	// re-ordering (config `retrieval.mmr.enabled`). When true, the final
+	// candidate pool is re-ordered before truncation to trade some relevance for
+	// coverage/diversity, iteratively picking the candidate that maximizes
+	// `lambda*relevance - (1-lambda)*maxSimToAlreadyPicked`. It composes with
+	// dedup (SPEC 9.2) and rerank (SPEC 9.1.1) and is config-only (NOT an MCP
+	// tool parameter). Default false ⇒ pass-through (candidate order unchanged),
+	// preserving the local-first, no-surprises default.
+	RetrievalMMREnabled bool
+	// RetrievalMMRLambda is the MMR relevance-vs-diversity trade-off
+	// (config `retrieval.mmr.lambda`) in [0,1]: 1.0 = pure relevance (no
+	// diversity penalty), 0.0 = pure diversity. Default 0.5 balances the two. It
+	// is only consulted when RetrievalMMREnabled is true. Values outside [0,1]
+	// (or NaN/Inf) are CONFIG_INVALID.
+	RetrievalMMRLambda float64
 	// Rerank* configure the optional post-fusion rerank stage (SPEC
 	// 9.1.1). Reranking auto-activates when a provider credential is
 	// present. CohereAPIKey is a secret: env-sourced, never persisted
@@ -583,6 +598,8 @@ type fileConfig struct {
 	RetrievalAdaptiveEnabled           *bool
 	RetrievalAdaptiveKMin              *int
 	RetrievalAdaptiveKMax              *int
+	RetrievalMMREnabled                *bool
+	RetrievalMMRLambda                 *float64
 	RerankEnabled                      *bool
 	RerankProvider                     *string
 	CohereAPIKey                       *string
@@ -706,6 +723,8 @@ type persistedConfig struct {
 	RetrievalAdaptiveEnabled           bool          `yaml:"retrieval_adaptive_enabled"`
 	RetrievalAdaptiveKMin              int           `yaml:"retrieval_adaptive_k_min"`
 	RetrievalAdaptiveKMax              int           `yaml:"retrieval_adaptive_k_max"`
+	RetrievalMMREnabled                bool          `yaml:"retrieval_mmr_enabled"`
+	RetrievalMMRLambda                 float64       `yaml:"retrieval_mmr_lambda"`
 	RerankEnabled                      bool          `yaml:"rerank_enabled"`
 	RerankProvider                     string        `yaml:"rerank_provider"`
 	CohereBaseURL                      string        `yaml:"cohere_base_url"`
@@ -882,6 +901,11 @@ func Default() Config {
 		// queries and widen hard ones around the typical rag.k_default (10).
 		RetrievalAdaptiveKMin: 4,
 		RetrievalAdaptiveKMax: 30,
+		// MMR diversity re-ordering defaults to OFF (issue #340): candidate order
+		// is unchanged unless explicitly enabled. Lambda carries its balanced 0.5
+		// default so an enabled-but-unspecified config behaves predictably.
+		RetrievalMMREnabled: false,
+		RetrievalMMRLambda:  0.5,
 		// RerankEnabled left nil: auto mode (activates iff a rerank
 		// provider credential is present). See rerankEnabledEffective.
 		RerankProvider:            "cohere",
@@ -1003,6 +1027,8 @@ func buildPersistedConfig(cfg *Config) persistedConfig {
 		RetrievalAdaptiveEnabled:           cfg.RetrievalAdaptiveEnabled,
 		RetrievalAdaptiveKMin:              cfg.RetrievalAdaptiveKMin,
 		RetrievalAdaptiveKMax:              cfg.RetrievalAdaptiveKMax,
+		RetrievalMMREnabled:                cfg.RetrievalMMREnabled,
+		RetrievalMMRLambda:                 cfg.RetrievalMMRLambda,
 		RerankEnabled:                      rerankEnabledEffective(cfg),
 		RerankProvider:                     cfg.RerankProvider,
 		CohereBaseURL:                      cfg.CohereBaseURL,
@@ -1618,9 +1644,10 @@ func applyModelRAGFileParsed(cfg *Config, fc fileConfig) {
 }
 
 // applyRetrievalTuningFileParsed overlays the opt-in retrieval-tuning file
-// fields (recency time-decay #323, context compression #335, and the adaptive
-// gate #338) onto cfg. Split out of applyModelRAGFileParsed to keep that
-// function within the gocyclo budget as tuning knobs are added.
+// fields (recency time-decay #323, context compression #335, the adaptive
+// gate #338, and MMR diversity #340) onto cfg. Split out of
+// applyModelRAGFileParsed to keep that function within the gocyclo budget as
+// tuning knobs are added.
 func applyRetrievalTuningFileParsed(cfg *Config, fc fileConfig) {
 	if fc.RetrievalRecencyHalfLife != nil {
 		cfg.RetrievalRecencyHalfLife = *fc.RetrievalRecencyHalfLife
@@ -1639,6 +1666,12 @@ func applyRetrievalTuningFileParsed(cfg *Config, fc fileConfig) {
 	}
 	if fc.RetrievalAdaptiveKMax != nil {
 		cfg.RetrievalAdaptiveKMax = *fc.RetrievalAdaptiveKMax
+	}
+	if fc.RetrievalMMREnabled != nil {
+		cfg.RetrievalMMREnabled = *fc.RetrievalMMREnabled
+	}
+	if fc.RetrievalMMRLambda != nil {
+		cfg.RetrievalMMRLambda = *fc.RetrievalMMRLambda
 	}
 }
 
@@ -2055,6 +2088,10 @@ var configKeyAliases = map[string]string{
 	"adaptive_k_min":                          "retrieval.adaptive.k_min",
 	"retrieval_adaptive_k_max":                "retrieval.adaptive.k_max",
 	"adaptive_k_max":                          "retrieval.adaptive.k_max",
+	"retrieval_mmr_enabled":                   "retrieval.mmr.enabled",
+	"mmr_enabled":                             "retrieval.mmr.enabled",
+	"retrieval_mmr_lambda":                    "retrieval.mmr.lambda",
+	"mmr_lambda":                              "retrieval.mmr.lambda",
 	"rerank_enabled":                          "rerank.enabled",
 	"rerank.cohere.api_key":                   "cohere_api_key",
 	"rerank.cohere.base_url":                  "cohere_base_url",
@@ -2164,7 +2201,7 @@ func canonicalizeConfigKey(key string) string {
 // (so child keys should be prefixed) rather than a scalar/list key.
 func isMapSectionKey(key string) bool {
 	switch key {
-	case "rag", "ingest", "ingest.docling", "stt", "stt.mistral", "stt.elevenlabs", "server", "server.tls", "secret_sources", "mistral", "docling", "security", "security.auth", "x402", "x402.route_policy", "x402.route_policy.tools_call", "chunking", "retrieval", "retrieval.hybrid", "retrieval.context_compression", "retrieval.adaptive", "rerank", "rerank.cohere", "index", "dedup":
+	case "rag", "ingest", "ingest.docling", "stt", "stt.mistral", "stt.elevenlabs", "server", "server.tls", "secret_sources", "mistral", "docling", "security", "security.auth", "x402", "x402.route_policy", "x402.route_policy.tools_call", "chunking", "retrieval", "retrieval.hybrid", "retrieval.context_compression", "retrieval.adaptive", "retrieval.mmr", "rerank", "rerank.cohere", "index", "dedup":
 		return true
 	case "ingest.pdf", "ingest.images", "ingest.audio", "ingest.archives", "secrets", "index.qdrant":
 		return true
@@ -2240,6 +2277,7 @@ var boolFileScalarTargets = map[string]func(*fileConfig) **bool{
 	"x402_tools_call_enabled":    func(c *fileConfig) **bool { return &c.X402ToolsCallEnabled },
 	"retrieval.hybrid.enabled":   func(c *fileConfig) **bool { return &c.RetrievalHybridEnabled },
 	"retrieval.adaptive.enabled": func(c *fileConfig) **bool { return &c.RetrievalAdaptiveEnabled },
+	"retrieval.mmr.enabled":      func(c *fileConfig) **bool { return &c.RetrievalMMREnabled },
 	"dedup.retrieval":            func(c *fileConfig) **bool { return &c.DedupRetrieval },
 	"retrieval.context_compression.enabled": func(c *fileConfig) **bool {
 		return &c.ContextCompressionEnabled
@@ -2336,6 +2374,8 @@ func setFloatFileScalar(cfg *fileConfig, key, value string) error {
 		target = &cfg.RetrievalMinScore
 	case "retrieval.context_compression.target_ratio":
 		target = &cfg.ContextCompressionTargetRatio
+	case "retrieval.mmr.lambda":
+		target = &cfg.RetrievalMMRLambda
 	default:
 		return nil
 	}
@@ -2658,6 +2698,8 @@ func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	writeBool("retrieval_adaptive_enabled", cfg.RetrievalAdaptiveEnabled)
 	writeInt("retrieval_adaptive_k_min", cfg.RetrievalAdaptiveKMin)
 	writeInt("retrieval_adaptive_k_max", cfg.RetrievalAdaptiveKMax)
+	writeBool("retrieval_mmr_enabled", cfg.RetrievalMMREnabled)
+	writeScalar("retrieval_mmr_lambda", strconv.FormatFloat(cfg.RetrievalMMRLambda, 'f', -1, 64))
 	writeBool("rerank_enabled", cfg.RerankEnabled)
 	writeScalar("rerank_provider", cfg.RerankProvider)
 	writeScalar("cohere_base_url", cfg.CohereBaseURL)
@@ -3425,10 +3467,11 @@ func (c *Config) validateNumericBounds() error {
 
 // validateRetrievalNumericBounds validates the retrieval-tuning numeric knobs —
 // the min_score relevance floor (#305), the recency time-decay half-life (#323),
-// and the context-compression keep-ratio (#335) — extracted from
-// validateNumericBounds to keep it within the gocyclo budget. NaN/Inf are also
-// rejected at parse time, but are re-guarded here so a programmatically-injected
-// value still fails validation rather than silently corrupting behavior.
+// the context-compression keep-ratio (#335), and the MMR lambda (#340) —
+// extracted from validateNumericBounds to keep it within the gocyclo budget.
+// NaN/Inf are also rejected at parse time, but are re-guarded here so a
+// programmatically-injected value still fails validation rather than silently
+// corrupting behavior.
 func (c *Config) validateRetrievalNumericBounds() error {
 	// retrieval.min_score is a relevance floor; 0 disables it. A negative floor
 	// would never drop anything, so reject it explicitly.
@@ -3445,6 +3488,16 @@ func (c *Config) validateRetrievalNumericBounds() error {
 	if math.IsNaN(c.ContextCompressionTargetRatio) || math.IsInf(c.ContextCompressionTargetRatio, 0) ||
 		c.ContextCompressionTargetRatio < 0 || c.ContextCompressionTargetRatio > 1 {
 		return fmt.Errorf("retrieval.context_compression.target_ratio must be in [0,1] (0 = default): %v", c.ContextCompressionTargetRatio)
+	}
+	// retrieval.mmr.lambda is the MMR relevance-vs-diversity trade-off and MUST
+	// lie in [0,1]. Validate unconditionally (even when MMR is disabled) so a
+	// malformed value is rejected deterministically at config time rather than
+	// lying dormant until the knob is flipped on. NaN/Inf are already rejected at
+	// parse time in setFloatFileScalar, but guard here too for values injected
+	// programmatically (not via the file parser).
+	if c.RetrievalMMRLambda < 0 || c.RetrievalMMRLambda > 1 ||
+		math.IsNaN(c.RetrievalMMRLambda) || math.IsInf(c.RetrievalMMRLambda, 0) {
+		return fmt.Errorf("retrieval.mmr.lambda must be within [0,1]: %v", c.RetrievalMMRLambda)
 	}
 	if err := c.validateAdaptiveBounds(); err != nil {
 		return err

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -1950,11 +1950,19 @@ func applyMMR(hits []model.SearchHit, lambda float64) []model.SearchHit {
 	for range hits {
 		best := -1
 		var bestScore float64
+		// The first selection has no diversity penalty (maxSim is 0 for every
+		// candidate), so seed it by pure relevance. Applying the full objective
+		// here would make every candidate tie at 0 when lambda=0 and fall back to
+		// the ChunkID tiebreak instead of picking the most relevant hit.
+		firstPick := len(selected) == 0
 		for i := 0; i < n; i++ {
 			if chosen[i] {
 				continue
 			}
-			score := lambda*rel[i] - (1-lambda)*maxSim[i]
+			score := rel[i]
+			if !firstPick {
+				score = lambda*rel[i] - (1-lambda)*maxSim[i]
+			}
 			if best == -1 || score > bestScore ||
 				(score == bestScore && hits[i].ChunkID < hits[best].ChunkID) {
 				best = i

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -175,6 +175,16 @@ type Service struct {
 	// false.
 	adaptiveKMin int
 	adaptiveKMax int
+	// mmrEnabled toggles Maximal Marginal Relevance diversity re-ordering
+	// (config retrieval.mmr.enabled, issue #340). When true, the final candidate
+	// pool is re-ordered before truncation to k to trade some relevance for
+	// coverage/diversity. Default false ⇒ pass-through (order unchanged). Wired
+	// from config.RetrievalMMREnabled at construction.
+	mmrEnabled bool
+	// mmrLambda is the MMR relevance-vs-diversity trade-off in [0,1] (config
+	// retrieval.mmr.lambda): 1 = pure relevance, 0 = pure diversity. Only
+	// consulted when mmrEnabled. Wired from config.RetrievalMMRLambda.
+	mmrLambda float64
 }
 
 // compile-time assertion that Service implements model.Retriever.  This
@@ -445,6 +455,27 @@ func (s *Service) SetAdaptiveRetrieval(enabled bool, kMin, kMax int) {
 	s.adaptiveEnabled = enabled
 	s.adaptiveKMin = kMin
 	s.adaptiveKMax = kMax
+}
+
+// SetMMR wires the optional Maximal Marginal Relevance diversity re-ordering
+// (config retrieval.mmr.enabled / retrieval.mmr.lambda, issue #340). When
+// enabled, the final candidate pool is re-ordered before truncation to k to
+// trade some relevance for coverage/diversity. lambda is the relevance-vs-
+// diversity trade-off in [0,1]; values outside the range are clamped (the
+// config layer already rejects them, this is a defensive guard). Disabled ⇒
+// candidate order is unchanged (pass-through). The engine wires this from
+// config at construction time, mirroring SetMinScore.
+func (s *Service) SetMMR(enabled bool, lambda float64) {
+	if lambda < 0 {
+		lambda = 0
+	}
+	if lambda > 1 {
+		lambda = 1
+	}
+	s.metaMu.Lock()
+	defer s.metaMu.Unlock()
+	s.mmrEnabled = enabled
+	s.mmrLambda = lambda
 }
 
 // SetDocumentHashes installs the rel_path → content_hash map used to group
@@ -1818,7 +1849,7 @@ func (s *Service) rerankPool(ctx context.Context, query string, hits []model.Sea
 	s.metaMu.RUnlock()
 
 	if !enabled || rr == nil || len(hits) <= 1 {
-		return truncateSearchHits(hits, k)
+		return s.diversifyAndTruncate(hits, k)
 	}
 	if pool <= 0 {
 		pool = defaultRerankCandidatePool
@@ -1847,13 +1878,13 @@ func (s *Service) rerankPool(ctx context.Context, query string, hits []model.Sea
 		if err != nil {
 			s.logf("rerank: provider error, falling back to fused order: %v", err)
 		}
-		return truncateSearchHits(fused, k)
+		return s.diversifyAndTruncate(fused, k)
 	}
 	out := make([]model.SearchHit, 0, len(fused))
 	for _, r := range results {
 		if r.Index < 0 || r.Index >= len(cand) {
 			s.logf("rerank: out-of-range index %d, falling back to fused order", r.Index)
-			return truncateSearchHits(fused, k)
+			return s.diversifyAndTruncate(fused, k)
 		}
 		h := cand[r.Index]
 		h.Score = r.RelevanceScore
@@ -1870,7 +1901,157 @@ func (s *Service) rerankPool(ctx context.Context, query string, hits []model.Sea
 	if len(fused) > len(cand) {
 		out = append(out, fused[len(cand):]...)
 	}
-	return truncateSearchHits(out, k)
+	return s.diversifyAndTruncate(out, k)
+}
+
+// diversifyAndTruncate applies the optional MMR diversity re-ordering (issue
+// #340) to the final candidate pool and then truncates to k. When MMR is
+// disabled it is exactly truncateSearchHits(hits, k) — the candidate order is
+// unchanged and no allocation beyond the truncation slice occurs. It runs as
+// the last reordering step (after scoring/fusion/rerank and dedup), so the
+// relevance signal it consumes is each hit's final authoritative Score.
+func (s *Service) diversifyAndTruncate(hits []model.SearchHit, k int) []model.SearchHit {
+	s.metaMu.RLock()
+	enabled := s.mmrEnabled
+	lambda := s.mmrLambda
+	s.metaMu.RUnlock()
+	if !enabled || len(hits) <= 1 {
+		return truncateSearchHits(hits, k)
+	}
+	return truncateSearchHits(applyMMR(hits, lambda), k)
+}
+
+// applyMMR re-orders hits by Maximal Marginal Relevance: starting from the
+// most-relevant candidate, it iteratively selects the candidate maximizing
+//
+//	lambda*relevance(c) - (1-lambda)*maxSim(c, alreadySelected)
+//
+// where relevance is the pool-normalized final Score in [0,1] and sim is a
+// deterministic term-overlap (Jaccard) similarity over hit snippets — SearchHit
+// carries no embedding vector, so snippet overlap is the available diversity
+// signal. lambda=1 reduces to pure relevance ordering; lambda=0 to pure
+// diversity. Ties (equal MMR objective) break on lower ChunkID so the result is
+// deterministic. The input slice is not mutated; a re-ordered copy is returned.
+func applyMMR(hits []model.SearchHit, lambda float64) []model.SearchHit {
+	n := len(hits)
+	rel := normalizedRelevance(hits)
+	tokens := make([]map[string]struct{}, n)
+	for i := range hits {
+		tokens[i] = tokenizeSnippet(hits[i].Snippet)
+	}
+
+	selected := make([]model.SearchHit, 0, n)
+	chosen := make([]bool, n)
+	// maxSim[i] tracks the highest similarity of candidate i to any
+	// already-selected hit, updated incrementally as selections are made so the
+	// loop is O(n^2) overall rather than O(n^3).
+	maxSim := make([]float64, n)
+
+	for range hits {
+		best := -1
+		var bestScore float64
+		for i := 0; i < n; i++ {
+			if chosen[i] {
+				continue
+			}
+			score := lambda*rel[i] - (1-lambda)*maxSim[i]
+			if best == -1 || score > bestScore ||
+				(score == bestScore && hits[i].ChunkID < hits[best].ChunkID) {
+				best = i
+				bestScore = score
+			}
+		}
+		chosen[best] = true
+		selected = append(selected, hits[best])
+		// Update each remaining candidate's running max similarity against the
+		// newly selected hit.
+		for i := 0; i < n; i++ {
+			if chosen[i] {
+				continue
+			}
+			if sim := jaccardSimilarity(tokens[i], tokens[best]); sim > maxSim[i] {
+				maxSim[i] = sim
+			}
+		}
+	}
+	return selected
+}
+
+// normalizedRelevance maps each hit's Score onto [0,1] via min-max scaling over
+// the pool so the MMR relevance term is commensurate with the [0,1] similarity
+// penalty regardless of the underlying score magnitude (cosine, RRF, or rerank
+// score). A degenerate pool (all-equal scores) maps to all-1, so MMR then
+// orders purely by the diversity penalty.
+func normalizedRelevance(hits []model.SearchHit) []float64 {
+	rel := make([]float64, len(hits))
+	if len(hits) == 0 {
+		return rel
+	}
+	minScore := math.Inf(1)
+	maxScore := math.Inf(-1)
+	for _, h := range hits {
+		if h.Score < minScore {
+			minScore = h.Score
+		}
+		if h.Score > maxScore {
+			maxScore = h.Score
+		}
+	}
+	denom := maxScore - minScore
+	if denom <= 0 {
+		for i := range rel {
+			rel[i] = 1
+		}
+		return rel
+	}
+	for i, h := range hits {
+		rel[i] = (h.Score - minScore) / denom
+	}
+	return rel
+}
+
+// mmrTokenRe splits a snippet into lowercase alphanumeric word tokens for the
+// term-overlap diversity signal. Compiled once at package load.
+var mmrTokenRe = regexp.MustCompile(`[\p{L}\p{N}]+`)
+
+// tokenizeSnippet lowercases and splits a snippet into a set of word tokens used
+// for the term-overlap diversity signal. Returns an empty (non-nil) set for an
+// empty snippet.
+func tokenizeSnippet(snippet string) map[string]struct{} {
+	set := make(map[string]struct{})
+	for _, tok := range mmrTokenRe.FindAllString(strings.ToLower(snippet), -1) {
+		set[tok] = struct{}{}
+	}
+	return set
+}
+
+// jaccardSimilarity returns |a∩b| / |a∪b| for two token sets, in [0,1]. Two
+// empty sets are defined as maximally similar (1.0): snippet-less hits (e.g.
+// media-only) are treated as near-duplicates of each other so MMR spreads them
+// out rather than clustering them.
+func jaccardSimilarity(a, b map[string]struct{}) float64 {
+	if len(a) == 0 && len(b) == 0 {
+		return 1
+	}
+	if len(a) == 0 || len(b) == 0 {
+		return 0
+	}
+	// Intersect over the smaller set to keep the scan tight.
+	small, large := a, b
+	if len(large) < len(small) {
+		small, large = large, small
+	}
+	inter := 0
+	for tok := range small {
+		if _, ok := large[tok]; ok {
+			inter++
+		}
+	}
+	union := len(a) + len(b) - inter
+	if union == 0 {
+		return 0
+	}
+	return float64(inter) / float64(union)
 }
 
 func truncateSearchHits(hits []model.SearchHit, k int) []model.SearchHit {

--- a/tests/config/retrieval_mmr_config_test.go
+++ b/tests/config/retrieval_mmr_config_test.go
@@ -1,0 +1,161 @@
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+)
+
+// TestRetrievalMMR_Defaults pins the local-first defaults: MMR is OFF and the
+// lambda trade-off defaults to a balanced 0.5.
+func TestRetrievalMMR_Defaults(t *testing.T) {
+	cfg := config.Default()
+	if cfg.RetrievalMMREnabled {
+		t.Fatalf("retrieval.mmr.enabled must default to false")
+	}
+	if cfg.RetrievalMMRLambda != 0.5 {
+		t.Fatalf("retrieval.mmr.lambda must default to 0.5, got %v", cfg.RetrievalMMRLambda)
+	}
+}
+
+// TestRetrievalMMR_NestedYAMLRoundTrips pins the nested-mapping form onto
+// Config.RetrievalMMREnabled / RetrievalMMRLambda.
+func TestRetrievalMMR_NestedYAMLRoundTrips(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+	writeFile(t, path, strings.Join([]string{
+		"retrieval:",
+		"  mmr:",
+		"    enabled: true",
+		"    lambda: 0.7",
+		"",
+	}, "\n"))
+
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if !cfg.RetrievalMMREnabled {
+		t.Fatalf("nested retrieval.mmr.enabled = false, want true")
+	}
+	if cfg.RetrievalMMRLambda != 0.7 {
+		t.Fatalf("nested retrieval.mmr.lambda = %v, want 0.7", cfg.RetrievalMMRLambda)
+	}
+}
+
+// TestRetrievalMMR_FlatAliasRoundTrips pins the flat snake_case aliases
+// (retrieval_mmr_enabled / retrieval_mmr_lambda).
+func TestRetrievalMMR_FlatAliasRoundTrips(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+	writeFile(t, path, strings.Join([]string{
+		"retrieval_mmr_enabled: true",
+		"retrieval_mmr_lambda: 0.3",
+		"",
+	}, "\n"))
+
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if !cfg.RetrievalMMREnabled {
+		t.Fatalf("flat retrieval_mmr_enabled = false, want true")
+	}
+	if cfg.RetrievalMMRLambda != 0.3 {
+		t.Fatalf("flat retrieval_mmr_lambda = %v, want 0.3", cfg.RetrievalMMRLambda)
+	}
+}
+
+// TestRetrievalMMR_SnapshotRoundTrips pins the persisted-snapshot round-trip:
+// both knobs survive SaveEffectiveSnapshot -> YAML -> load.
+func TestRetrievalMMR_SnapshotRoundTrips(t *testing.T) {
+	cfg := config.Default()
+	cfg.StateDir = t.TempDir()
+	cfg.RetrievalMMREnabled = true
+	cfg.RetrievalMMRLambda = 0.8
+
+	path, err := config.SaveEffectiveSnapshot(cfg, config.SecretSourceMetadata{})
+	if err != nil {
+		t.Fatalf("SaveEffectiveSnapshot: %v", err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !strings.Contains(string(raw), "retrieval_mmr_enabled: true") {
+		t.Fatalf("snapshot must persist retrieval_mmr_enabled: true:\n%s", raw)
+	}
+	if !strings.Contains(string(raw), "retrieval_mmr_lambda: 0.8") {
+		t.Fatalf("snapshot must persist retrieval_mmr_lambda: 0.8:\n%s", raw)
+	}
+
+	loaded, _, err := config.LoadEffectiveSnapshot(path)
+	if err != nil {
+		t.Fatalf("LoadEffectiveSnapshot: %v", err)
+	}
+	if !loaded.RetrievalMMREnabled || loaded.RetrievalMMRLambda != 0.8 {
+		t.Fatalf("loaded snapshot must carry enabled=true lambda=0.8, got enabled=%v lambda=%v",
+			loaded.RetrievalMMREnabled, loaded.RetrievalMMRLambda)
+	}
+}
+
+// TestRetrievalMMR_RejectsLambdaOutOfRange pins range validation: a lambda
+// outside [0,1] is CONFIG_INVALID.
+func TestRetrievalMMR_RejectsLambdaOutOfRange(t *testing.T) {
+	for _, bad := range []string{"-0.1", "1.5", "2"} {
+		tmp := t.TempDir()
+		path := filepath.Join(tmp, ".dir2mcp.yaml")
+		writeFile(t, path, "retrieval_mmr_lambda: "+bad+"\n")
+
+		_, err := config.LoadFile(path)
+		if err == nil {
+			t.Errorf("LoadFile with retrieval_mmr_lambda=%q = nil error, want rejection", bad)
+			continue
+		}
+		if !strings.Contains(err.Error(), "retrieval.mmr.lambda") {
+			t.Errorf("error must mention retrieval.mmr.lambda, got: %v", err)
+		}
+	}
+}
+
+// TestRetrievalMMR_AcceptsLambdaBoundaries pins that the inclusive endpoints 0
+// and 1 are valid (pure diversity / pure relevance).
+func TestRetrievalMMR_AcceptsLambdaBoundaries(t *testing.T) {
+	for _, good := range []string{"0", "1", "0.0", "1.0"} {
+		tmp := t.TempDir()
+		path := filepath.Join(tmp, ".dir2mcp.yaml")
+		writeFile(t, path, "retrieval_mmr_lambda: "+good+"\n")
+
+		if _, err := config.LoadFile(path); err != nil {
+			t.Errorf("LoadFile with retrieval_mmr_lambda=%q = %v, want accepted", good, err)
+		}
+	}
+}
+
+// TestRetrievalMMR_RejectsNonFinite asserts NaN/Inf strings (which
+// strconv.ParseFloat accepts) are rejected at config-parse time.
+func TestRetrievalMMR_RejectsNonFinite(t *testing.T) {
+	for _, bad := range []string{"NaN", "Inf", "+Inf", "-Inf", "Infinity"} {
+		tmp := t.TempDir()
+		path := filepath.Join(tmp, ".dir2mcp.yaml")
+		writeFile(t, path, "retrieval_mmr_lambda: "+bad+"\n")
+
+		if _, err := config.LoadFile(path); err == nil {
+			t.Errorf("LoadFile with retrieval_mmr_lambda=%q = nil error, want rejection", bad)
+		}
+	}
+}
+
+// TestRetrievalMMR_ValidateRejectsOutOfRangeProgrammatic pins that the
+// Validate() guard rejects an out-of-range lambda injected programmatically
+// (not via the file parser).
+func TestRetrievalMMR_ValidateRejectsOutOfRangeProgrammatic(t *testing.T) {
+	cfg := config.Default()
+	cfg.RetrievalMMRLambda = 1.7
+	if err := cfg.Validate(); err == nil {
+		t.Fatalf("Validate with RetrievalMMRLambda=1.7 = nil error, want rejection")
+	}
+}

--- a/tests/retrieval/mmr_diversity_test.go
+++ b/tests/retrieval/mmr_diversity_test.go
@@ -1,0 +1,140 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
+)
+
+// newMMRService builds a vector-only retrieval service (nil store keeps hybrid
+// fusion from engaging, so each hit's Score is the raw cosine similarity) with
+// three candidates whose cosine scores against the query vector {1, 0} are:
+//
+//	chunk 1 → 1.00, snippet "alpha apple fruit"        (most relevant)
+//	chunk 2 → ~0.92, snippet "alpha apple fruit"       (near-duplicate of 1)
+//	chunk 3 → 0.80,  snippet "zebra ocean mountain"    (diverse, less relevant)
+//
+// Pure relevance order is [1, 2, 3]. MMR with a balanced lambda demotes the
+// near-duplicate (chunk 2) below the diverse hit (chunk 3): [1, 3, 2].
+func newMMRService(t *testing.T, enabled bool, lambda float64) *retrieval.Service {
+	t.Helper()
+	idx := index.NewHNSWIndex("")
+	addVec(t, idx, 1, []float32{1, 0})       // cosine 1.00
+	addVec(t, idx, 2, []float32{0.92, 0.39}) // cosine ~0.92
+	addVec(t, idx, 3, []float32{0.80, 0.60}) // cosine 0.80 (unit vector)
+
+	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+		"mistral-embed": {1, 0},
+	}}, nil)
+	svc.SetChunkMetadata(1, model.SearchHit{RelPath: "a.md", Snippet: "alpha apple fruit"})
+	svc.SetChunkMetadata(2, model.SearchHit{RelPath: "b.md", Snippet: "alpha apple fruit"})
+	svc.SetChunkMetadata(3, model.SearchHit{RelPath: "c.md", Snippet: "zebra ocean mountain"})
+	svc.SetMMR(enabled, lambda)
+	return svc
+}
+
+func mmrSearchChunkIDs(t *testing.T, svc *retrieval.Service, k int) []uint64 {
+	t.Helper()
+	hits, err := svc.Search(context.Background(), model.SearchQuery{Query: "alpha", K: k})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	ids := make([]uint64, 0, len(hits))
+	for _, h := range hits {
+		ids = append(ids, h.ChunkID)
+	}
+	return ids
+}
+
+func assertOrder(t *testing.T, got, want []uint64) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("order length mismatch: want %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("order mismatch: want %v, got %v", want, got)
+		}
+	}
+}
+
+// TestSearch_MMR_DemotesNearDuplicate pins the core behavior: with MMR enabled
+// and a balanced lambda, the near-duplicate (chunk 2) is demoted below the
+// diverse hit (chunk 3), surfacing distinct evidence higher.
+func TestSearch_MMR_DemotesNearDuplicate(t *testing.T) {
+	svc := newMMRService(t, true, 0.5)
+	got := mmrSearchChunkIDs(t, svc, 10)
+	assertOrder(t, got, []uint64{1, 3, 2})
+}
+
+// TestSearch_MMR_DisabledKeepsRelevanceOrder pins the default-off behavior:
+// with MMR disabled the candidate order is the unchanged pure-relevance order.
+func TestSearch_MMR_DisabledKeepsRelevanceOrder(t *testing.T) {
+	svc := newMMRService(t, false, 0.5)
+	got := mmrSearchChunkIDs(t, svc, 10)
+	assertOrder(t, got, []uint64{1, 2, 3})
+}
+
+// TestSearch_MMR_LambdaOneIsPureRelevance pins that lambda=1 disables the
+// diversity penalty entirely, so MMR reproduces the pure-relevance order even
+// when enabled.
+func TestSearch_MMR_LambdaOneIsPureRelevance(t *testing.T) {
+	svc := newMMRService(t, true, 1.0)
+	got := mmrSearchChunkIDs(t, svc, 10)
+	assertOrder(t, got, []uint64{1, 2, 3})
+}
+
+// TestSearch_MMR_LambdaZeroPrefersDiversity pins the opposite extreme: lambda=0
+// ignores relevance, so after the (relevance-seeded) first pick the most
+// dissimilar candidate is preferred. Chunk 1 is selected first (highest
+// relevance, no prior selections), then chunk 3 (sim 0 to chunk 1) beats chunk
+// 2 (sim 1 to chunk 1).
+func TestSearch_MMR_LambdaZeroPrefersDiversity(t *testing.T) {
+	svc := newMMRService(t, true, 0)
+	got := mmrSearchChunkIDs(t, svc, 10)
+	assertOrder(t, got, []uint64{1, 3, 2})
+}
+
+// TestSearch_MMR_ComposesWithRerank pins that MMR runs as the LAST reordering
+// step, after the rerank stage and before the final truncation: the reranker
+// scores the pool in pure-relevance order (best-first 1,2,3) and MMR then
+// diversifies it to [1, 3, 2], demoting the near-duplicate. This exercises the
+// rerankPool path (the universal final step) rather than the rerank-disabled
+// fast path covered by the other cases.
+func TestSearch_MMR_ComposesWithRerank(t *testing.T) {
+	idx := index.NewHNSWIndex("")
+	addVec(t, idx, 1, []float32{1, 0})
+	addVec(t, idx, 2, []float32{0.92, 0.39})
+	addVec(t, idx, 3, []float32{0.80, 0.60})
+	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+		"mistral-embed": {1, 0},
+	}}, nil)
+	svc.SetChunkMetadata(1, model.SearchHit{ChunkID: 1, RelPath: "a.md", Snippet: "alpha apple fruit"})
+	svc.SetChunkMetadata(2, model.SearchHit{ChunkID: 2, RelPath: "b.md", Snippet: "alpha apple fruit"})
+	svc.SetChunkMetadata(3, model.SearchHit{ChunkID: 3, RelPath: "c.md", Snippet: "zebra ocean mountain"})
+	// Identity rerank (best-first 1,2,3) with descending scores: the post-rerank
+	// order is the pure-relevance order MMR then diversifies.
+	svc.SetReranker(&fakeReranker{order: []int{0, 1, 2}}, "", 0)
+	svc.SetRerankEnabled(true)
+	svc.SetMMR(true, 0.5)
+
+	got := mmrSearchChunkIDs(t, svc, 10)
+	assertOrder(t, got, []uint64{1, 3, 2})
+}
+
+// TestSearch_MMR_SingleHitIsStable pins that a single-candidate pool is returned
+// unchanged regardless of MMR (no reordering is possible / meaningful).
+func TestSearch_MMR_SingleHitIsStable(t *testing.T) {
+	idx := index.NewHNSWIndex("")
+	addVec(t, idx, 7, []float32{1, 0})
+	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+		"mistral-embed": {1, 0},
+	}}, nil)
+	svc.SetChunkMetadata(7, model.SearchHit{RelPath: "x.md", Snippet: "solo"})
+	svc.SetMMR(true, 0.5)
+	got := mmrSearchChunkIDs(t, svc, 10)
+	assertOrder(t, got, []uint64{7})
+}

--- a/tests/retrieval/mmr_diversity_test.go
+++ b/tests/retrieval/mmr_diversity_test.go
@@ -98,6 +98,29 @@ func TestSearch_MMR_LambdaZeroPrefersDiversity(t *testing.T) {
 	assertOrder(t, got, []uint64{1, 3, 2})
 }
 
+// TestSearch_MMR_LambdaZeroSeedsByRelevanceNotChunkID locks in that the FIRST
+// MMR pick is relevance-seeded even when lambda=0. The most relevant hit here is
+// chunk 5 (cosine 1.00) while the lowest ChunkID is chunk 1 (cosine 0.80, a
+// diverse snippet). If the first selection applied the full objective it would
+// tie all candidates at 0 (maxSim=0, lambda=0) and the ChunkID tiebreak would
+// wrongly seed with chunk 1. The relevance-seeded pick selects chunk 5 first;
+// then chunk 1 (sim 0 to chunk 5) beats the near-duplicate chunk 2 (sim 1).
+func TestSearch_MMR_LambdaZeroSeedsByRelevanceNotChunkID(t *testing.T) {
+	idx := index.NewHNSWIndex("")
+	addVec(t, idx, 1, []float32{0.80, 0.60}) // cosine 0.80, lowest ChunkID
+	addVec(t, idx, 2, []float32{0.92, 0.39}) // cosine ~0.92, near-duplicate of 5
+	addVec(t, idx, 5, []float32{1, 0})       // cosine 1.00, most relevant
+	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+		"mistral-embed": {1, 0},
+	}}, nil)
+	svc.SetChunkMetadata(1, model.SearchHit{RelPath: "a.md", Snippet: "zebra ocean mountain"})
+	svc.SetChunkMetadata(2, model.SearchHit{RelPath: "b.md", Snippet: "alpha apple fruit"})
+	svc.SetChunkMetadata(5, model.SearchHit{RelPath: "c.md", Snippet: "alpha apple fruit"})
+	svc.SetMMR(true, 0)
+	got := mmrSearchChunkIDs(t, svc, 10)
+	assertOrder(t, got, []uint64{5, 1, 2})
+}
+
 // TestSearch_MMR_ComposesWithRerank pins that MMR runs as the LAST reordering
 // step, after the rerank stage and before the final truncation: the reranker
 // scores the pool in pure-relevance order (best-first 1,2,3) and MMR then


### PR DESCRIPTION
## Summary
Adds an opt-in **Maximal Marginal Relevance (MMR)** re-ordering that trades some relevance for diversity/coverage on broad/exploratory queries. Off by default ⇒ candidate order is unchanged. Config-only — no MCP tool/citation contract change, no spec/submodule re-pin.

Closes #340

## Config (ungated)
- `retrieval.mmr.enabled` (bool, default `false`)
- `retrieval.mmr.lambda` (float in `[0,1]`, default `0.5`) — relevance-vs-diversity trade-off; `1` = pure relevance, `0` = pure diversity.

Both knobs are wired through the standard plumbing: `Config` / `fileConfig` / `persistedConfig` / `Default` / apply / flat+nested aliases / `isMapSectionKey` (`retrieval.mmr`) / snapshot writer / range validation. Lambda is range-validated (`[0,1]`, finite) at parse time and in `Validate()`.

## Behavior
MMR runs as the **last reordering step**, inside `rerankPool` (the universal final step for single-index and `index=both`), so it composes with cross-file dedup (SPEC 9.2) and rerank (SPEC 9.1.1) and runs **before truncation to k**.

Algorithm: iteratively pick the candidate maximizing

```
lambda*relevance(c) - (1-lambda)*maxSim(c, alreadySelected)
```

- **Relevance** = pool min-max-normalized final authoritative `Score` (so lambda is meaningful regardless of cosine/RRF/rerank magnitude).
- **Similarity** = deterministic **Jaccard term-overlap over hit snippets**. `SearchHit` carries no embedding vector, so snippet term-overlap is the available diversity signal (the spec'd fallback).
- Deterministic tie-breaks on lower `ChunkID`.

Disabled or single-hit pool ⇒ exactly the previous `truncateSearchHits` (no reordering, no extra allocation).

## Tests (external `tests/`, fakes only — no creds)
Retrieval (`tests/retrieval/mmr_diversity_test.go`):
- `TestSearch_MMR_DemotesNearDuplicate` — enabled MMR demotes a near-duplicate, surfaces the diverse hit (`[1,3,2]`).
- `TestSearch_MMR_DisabledKeepsRelevanceOrder` — default off = unchanged order.
- `TestSearch_MMR_LambdaOneIsPureRelevance` — lambda=1 ≈ pure relevance.
- `TestSearch_MMR_LambdaZeroPrefersDiversity` — lambda=0 prefers diversity.
- `TestSearch_MMR_ComposesWithRerank` — runs after the rerank stage.
- `TestSearch_MMR_SingleHitIsStable`.

Config (`tests/config/retrieval_mmr_config_test.go`):
- defaults; nested + flat-alias round-trips; snapshot round-trip; lambda out-of-range + non-finite rejection (parse and programmatic); inclusive `[0,1]` boundaries.

## Checks
`golangci-lint` clean, `go vet`, gocyclo ≤15 (extracted `validateRetrievalNumericBounds`), full `make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Maximal Marginal Relevance (MMR) support for retrieval result diversity re-ordering.
  * New configuration options to enable MMR and adjust diversity weighting parameters.

* **Tests**
  * Added comprehensive test coverage for MMR configuration, validation, and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->