### PR TITLE
mcp: recover panics in tool dispatch so they don't drop the connection (#356)

### DIFF
--- a/internal/mcp/tool_panic_recovery_test.go
+++ b/internal/mcp/tool_panic_recovery_test.go
@@ -1,0 +1,69 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+)
+
+// TestInvokeToolHandler_RecoversPanic verifies that a panicking tool handler is
+// converted into a clean INTERNAL_ERROR tool result rather than propagating the
+// panic out through net/http (which would drop the client connection and surface
+// as an opaque "Failed to call tool"). Regression for issue #356.
+func TestInvokeToolHandler_RecoversPanic(t *testing.T) {
+	s := &Server{}
+	tool := toolDefinition{
+		Name: "boom",
+		handler: func(context.Context, map[string]interface{}) (toolCallResult, *toolExecutionError) {
+			panic("synthetic handler panic")
+		},
+	}
+
+	var (
+		result  toolCallResult
+		toolErr *toolExecutionError
+	)
+	// The call itself must not panic.
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("invokeToolHandler propagated a panic instead of recovering: %v", r)
+			}
+		}()
+		result, toolErr = s.invokeToolHandler(context.Background(), tool, tool.Name, nil)
+	}()
+
+	if toolErr == nil {
+		t.Fatal("expected a tool execution error after a handler panic, got nil")
+	}
+	if toolErr.Code != "INTERNAL_ERROR" {
+		t.Fatalf("expected INTERNAL_ERROR code, got %q", toolErr.Code)
+	}
+	if toolErr.Retryable {
+		t.Fatal("a handler panic should be reported as non-retryable")
+	}
+	if len(result.Content) != 0 || result.StructuredContent != nil {
+		t.Fatalf("expected an empty result on panic, got %+v", result)
+	}
+}
+
+// TestInvokeToolHandler_PassThrough verifies the wrapper is transparent for a
+// normal (non-panicking) handler: its result and nil error are returned
+// unchanged.
+func TestInvokeToolHandler_PassThrough(t *testing.T) {
+	s := &Server{}
+	want := toolCallResult{Content: []toolContentItem{{Type: "text", Text: "ok"}}}
+	tool := toolDefinition{
+		Name: "fine",
+		handler: func(context.Context, map[string]interface{}) (toolCallResult, *toolExecutionError) {
+			return want, nil
+		},
+	}
+
+	result, toolErr := s.invokeToolHandler(context.Background(), tool, tool.Name, nil)
+	if toolErr != nil {
+		t.Fatalf("unexpected tool error: %+v", toolErr)
+	}
+	if len(result.Content) != 1 || result.Content[0].Text != "ok" {
+		t.Fatalf("result not passed through unchanged: %+v", result)
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -7,11 +7,13 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"log"
 	"math"
 	"net/http"
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime/debug"
 	"sort"
 	"strings"
 	"unicode/utf8"
@@ -246,12 +248,35 @@ func (s *Server) processToolsCall(ctx context.Context, rawParams json.RawMessage
 		}), http.StatusOK, nil
 	}
 
-	result, toolErr := tool.handler(ctx, params.Arguments)
+	result, toolErr := s.invokeToolHandler(ctx, tool, params.Name, params.Arguments)
 	if toolErr != nil {
 		return newToolErrorResult(*toolErr), http.StatusOK, nil
 	}
 
 	return result, http.StatusOK, nil
+}
+
+// invokeToolHandler runs a tool handler with panic recovery. A bug in any
+// handler is converted into a clean INTERNAL_ERROR tool result (and the stack is
+// logged) rather than propagating out through net/http, which would recover the
+// panic at the server level by abruptly closing the connection — surfacing on
+// the client as an opaque "Failed to call tool" with the stack written only to
+// stderr. Returning a normal tool-error result instead lets the model read and
+// report the failure, and the logged stack makes the underlying bug
+// diagnosable. See issue #356.
+func (s *Server) invokeToolHandler(ctx context.Context, tool toolDefinition, name string, args map[string]interface{}) (result toolCallResult, toolErr *toolExecutionError) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("mcp: tool %q handler panicked: %v\n%s", name, r, debug.Stack())
+			result = toolCallResult{}
+			toolErr = &toolExecutionError{
+				Code:      "INTERNAL_ERROR",
+				Message:   "internal error while executing tool",
+				Retryable: false,
+			}
+		}
+	}()
+	return tool.handler(ctx, args)
 }
 
 func parseToolsCallParams(raw json.RawMessage) (toolsCallParams, error) {


### PR DESCRIPTION
Closes #356.

## Problem

Field report (v0.8.0): intermittent **`Failed to call tool "dir2mcp_open_file"`** / **`dir2mcp_list_files`** in Claude Desktop on a ~89-PDF OCR corpus, while `search`/`ask` succeed. The captured `server.log` was empty.

"Failed to call tool" is a **transport-level** failure — a clean tool error (e.g. `OCR_NOT_READY`) is returned as a result the model reads, not this. The MCP tool dispatch had **no panic recovery** (`internal/mcp/tools.go`, and no `recover()` anywhere in `internal/mcp/`). When a handler panics, Go's `net/http` recovers it at the *server* level: it abruptly closes the connection (client → "Failed to call tool") and writes the stack to **stderr**, never to `server.log`. That matches every observation — the transport error, the empty log, and the process surviving (other queries keep working). The "5-minute spin" is the model retrying the dropped call.

## Fix

Wrap the handler dispatch in `defer/recover` (`invokeToolHandler`):
- convert a panic into a clean `INTERNAL_ERROR` tool result (HTTP 200, `isError`) so the model reads and reports it instead of losing the connection, and
- `log.Printf` the recovered value + `debug.Stack()` so the underlying bug is finally diagnosable wherever stderr is captured.

This both **mitigates the symptom** (no more dropped connection) and **surfaces the real panic** next time so the actual trigger can be fixed.

## Tests

- `TestInvokeToolHandler_RecoversPanic` — a panicking handler yields a non-retryable `INTERNAL_ERROR` result, no propagated panic.
- `TestInvokeToolHandler_PassThrough` — the wrapper is transparent for normal handlers.

## Follow-ups (not in this PR)

- The actual panic trigger in `open_file`/`list_files` on this corpus (this PR makes it loggable).
- Support bundle should capture the server's **stderr** (where these errors land), not just `server.log`.
- Verify the `chunks_total=0 / embedded_ok=0` status reporting for the `corpus_json`/memory path (likely cosmetic; `ask` returned real content).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced tool execution stability and error recovery to prevent system crashes when tools encounter unexpected issues. Tool failures are now gracefully handled with proper error responses instead of causing system failures, improving overall reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->