### PR TITLE
server: mirror logs to <state_dir>/server.log in every launch mode (#360)

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -126,6 +128,39 @@ func pidFilePath(stateDir string) string {
 // serverLogPath returns the canonical daemon log file location.
 func serverLogPath(stateDir string) string {
 	return filepath.Join(stateDir, serverLogName)
+}
+
+// teeServerLog mirrors the process-global logger to <state_dir>/server.log so
+// recovered-panic stacks and log.Printf output reach the support bundle in
+// EVERY launch mode — not just the double-fork daemon, whose stdout/stderr the
+// parent already redirects to that file (issue #360). It is a no-op in the
+// daemon child (its stderr is already the file, so teeing would double-write)
+// and returns a restore func (or nil) so the global-logger mutation is bounded
+// to the server's lifetime — important so it never leaks across tests. The tee
+// is additive: existing destinations (terminal in the foreground, the service
+// manager under launchd/systemd) keep receiving logs.
+func (a *App) teeServerLog(stateDir string) func() {
+	if isRunningAsDaemonChild() {
+		return nil
+	}
+	logPath := serverLogPath(stateDir)
+	if err := rotateLogIfLarge(logPath); err != nil {
+		// Non-fatal: a failed rotation just means we keep appending.
+		writef(a.stderr, "warning: rotate %s: %v\n", logPath, err)
+	}
+	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		// Best-effort: if we can't open the log file, leave logging as-is
+		// rather than failing server startup.
+		writef(a.stderr, "warning: open server log %s: %v\n", logPath, err)
+		return nil
+	}
+	prev := log.Writer()
+	log.SetOutput(io.MultiWriter(prev, f))
+	return func() {
+		log.SetOutput(prev)
+		_ = f.Close()
+	}
 }
 
 // connectionFilePath returns the canonical connection.json location.

--- a/internal/cli/server_log_tee_internal_test.go
+++ b/internal/cli/server_log_tee_internal_test.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"bytes"
+	"io"
+	"log"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestTeeServerLog_WritesToServerLogInForeground verifies that a foreground /
+// service launch (not the daemon child) mirrors the process logger to
+// <state_dir>/server.log, and that restore() bounds the global-logger mutation
+// so it never leaks past the server's lifetime. Regression for issue #360.
+func TestTeeServerLog_WritesToServerLogInForeground(t *testing.T) {
+	t.Setenv(daemonChildEnv, "") // ensure not treated as a daemon child
+	stateDir := t.TempDir()
+	app := NewAppWithIO(io.Discard, &bytes.Buffer{})
+
+	restore := app.teeServerLog(stateDir)
+	if restore == nil {
+		t.Fatal("expected tee to be active in a non-daemon-child (foreground) run")
+	}
+	const marker = "diag-marker-360-foreground"
+	log.Printf("%s", marker)
+	restore()
+
+	data, err := os.ReadFile(serverLogPath(stateDir))
+	if err != nil {
+		t.Fatalf("read server.log: %v", err)
+	}
+	if !strings.Contains(string(data), marker) {
+		t.Fatalf("server.log missing the logged marker; got %q", data)
+	}
+
+	// After restore the logger must no longer write to the (now closed) file.
+	log.Printf("post-restore-should-not-appear")
+	after, err := os.ReadFile(serverLogPath(stateDir))
+	if err != nil {
+		t.Fatalf("re-read server.log: %v", err)
+	}
+	if strings.Contains(string(after), "post-restore-should-not-appear") {
+		t.Fatal("logger still writing to server.log after restore() — global mutation leaked")
+	}
+}
+
+// TestTeeServerLog_NoopInDaemonChild verifies the tee is a no-op in the daemon
+// child, whose stderr the parent already redirects to server.log — teeing again
+// would double-write every line.
+func TestTeeServerLog_NoopInDaemonChild(t *testing.T) {
+	t.Setenv(daemonChildEnv, strings.Repeat("a", 64)) // looks like a daemon child
+	app := NewAppWithIO(io.Discard, &bytes.Buffer{})
+	if restore := app.teeServerLog(t.TempDir()); restore != nil {
+		restore()
+		t.Fatal("teeServerLog must be a no-op in the daemon child (stderr already → server.log)")
+	}
+}

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -55,6 +55,15 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 		return code
 	}
 
+	// Mirror the process logger to <state_dir>/server.log for foreground/service
+	// launches too (the daemon child already redirects stderr there). This keeps
+	// recovered-panic stacks and log output reachable in the support bundle
+	// regardless of how the server was started (issue #360). Bounded to this
+	// call so it never leaks into other code paths/tests.
+	if restoreLog := a.teeServerLog(cfg.StateDir); restoreLog != nil {
+		defer restoreLog()
+	}
+
 	st, textBuilt, codeBuilt, code := a.initStoreAndIndices(ctx, &cfg, opts.jsonOutput)
 	if code != exitSuccess {
 		return code

--- a/tests/security/cli_boundary_test.go
+++ b/tests/security/cli_boundary_test.go
@@ -185,6 +185,7 @@ func TestRepoSplitBoundary_InternalCLIFileOwnership(t *testing.T) {
 		"rerank_selection_test.go":        {},
 		"routing_decision.go":             {},
 		"server_doctor.go":                {},
+		"server_log_tee_internal_test.go": {},
 		"service.go":                      {},
 		"service_darwin.go":               {},
 		"service_darwin_test.go":          {},


### PR DESCRIPTION
Closes #360. Completes the diagnosability arc from #356/#357/#358/#359.

## Problem

Only the double-fork daemon redirects the server's stdout+stderr → `server.log` (`up_daemon.go`). Foreground / service-manager launches (`up --foreground`, under launchd/systemd) send stderr elsewhere, so recovered-panic stacks (from #357) and `log.Printf` output never reach the support bundle's `server.log`.

## Change

`teeServerLog(stateDir)` mirrors the process-global logger to `<state_dir>/server.log` on in-process startup (`runUp`):
- **No-op in the daemon child** (its stderr is already that file — teeing would double-write each line), guarded by `isRunningAsDaemonChild()`.
- **Additive**: wraps the current logger via `io.MultiWriter`, so the terminal (foreground) or service manager keeps receiving logs.
- **Bounded**: returns a restore func (`defer`red in `runUp`) that re-points the logger and closes the file, so the global-logger mutation never leaks past the server's lifetime — important for test isolation (the concern that deferred this from #359).
- Reuses `rotateLogIfLarge` + `O_APPEND`, mirroring the daemon path; best-effort (a log-open failure warns and leaves logging as-is rather than failing startup).

## Tests

- `TestTeeServerLog_WritesToServerLogInForeground`: a non-daemon-child run writes the marker to `server.log`, and after `restore()` the logger no longer writes to the (closed) file (mutation bounded).
- `TestTeeServerLog_NoopInDaemonChild`: returns nil in the daemon child.
- Allowlisted the new internal test in the repo-split boundary check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Server output is now automatically logged to a file with built-in log rotation when the file exceeds size limits. Logging is properly scoped to server execution.

* **Tests**
  * Added comprehensive tests validating server log output behavior.

* **Chores**
  * Updated test boundary configuration for new internal test file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->