### PR TITLE
retrieval: embed-pending diagnostics + open_file PDF line-range OCR fallback (#364)

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -285,6 +285,7 @@ type corpusIndexing struct {
 	Representations int64                 `json:"representations"`
 	ChunksTotal     int64                 `json:"chunks_total"`
 	EmbeddedOK      int64                 `json:"embedded_ok"`
+	EmbeddedPending int64                 `json:"embedded_pending"`
 	Errors          int64                 `json:"errors"`
 	Unknown         int64                 `json:"unknown"`
 	FailureSummary  *model.FailureSummary `json:"failure_summary,omitempty"`
@@ -1857,6 +1858,11 @@ func buildCorpusSnapshot(ctx context.Context, st model.Store, indexingState *app
 			Representations: idx.Representations,
 			ChunksTotal:     idx.ChunksTotal,
 			EmbeddedOK:      idx.EmbeddedOK,
+			// embedded_pending is always a store-derived count (no live
+			// appstate counter tracks it), so source it straight from
+			// corpusStats rather than idx — correct in both the live-snapshot
+			// and computed-fallback branches above (#364).
+			EmbeddedPending: corpusStats.EmbeddedPending,
 			Errors:          idx.Errors,
 			Unknown:         idx.Unknown,
 			// FailureSummary travels straight through from the

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -97,10 +97,11 @@ func (a *App) renderStatusOutput(global globalOptions, stateDir string, snapshot
 		s.stat("skipped", snapshot.Indexing.Skipped),
 		s.stat("deleted", snapshot.Indexing.Deleted),
 	)
-	writef(a.stdout, "    %s  %s  %s  %s",
+	writef(a.stdout, "    %s  %s  %s  %s  %s",
 		s.stat("reps", snapshot.Indexing.Representations),
 		s.stat("chunks", snapshot.Indexing.ChunksTotal),
 		s.stat("embedded", snapshot.Indexing.EmbeddedOK),
+		s.stat("pending", snapshot.Indexing.EmbeddedPending),
 		s.stat("unknown", snapshot.Indexing.Unknown),
 	)
 	if snapshot.Indexing.Errors > 0 {

--- a/internal/index/embedding_worker.go
+++ b/internal/index/embedding_worker.go
@@ -771,6 +771,11 @@ func (w *EmbeddingWorker) Run(ctx context.Context, interval time.Duration, index
 	backoff := interval
 	const maxBackoff = 30 * time.Second
 
+	// One startup line so the support bundle / server.log shows the worker is
+	// actually running for this axis. Its ABSENCE on a corpus with pending
+	// chunks (embedded_pending>0) is itself the diagnosis. See issue #364.
+	w.logf("embed worker started [kind=%s, interval=%s]", indexKind, interval)
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -781,7 +786,14 @@ func (w *EmbeddingWorker) Run(ctx context.Context, interval time.Duration, index
 			if w.RunOnceFunc != nil {
 				runOnce = w.RunOnceFunc
 			}
-			_, err := runOnce(ctx, indexKind)
+			n, err := runOnce(ctx, indexKind)
+			if n > 0 {
+				// Progress is otherwise invisible: a corpus that never logs
+				// "embedded N" while embedded_pending stays high tells us the
+				// worker found nothing to do (filter/visibility) vs. embedded
+				// fine (which would show here).
+				w.logf("embedded %d chunk(s) [kind=%s]", n, indexKind)
+			}
 			if err != nil {
 				if isRetryable(err) {
 					w.logf("run once failed (retryable): %v; backing off %v", err, backoff)

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -463,8 +463,15 @@ type CorpusStats struct {
 	Representations int64            `json:"representations"`
 	ChunksTotal     int64            `json:"chunks_total"`
 	EmbeddedOK      int64            `json:"embedded_ok"`
-	Errors          int64            `json:"errors"`
-	Unknown         int64            `json:"unknown"`
+	// EmbeddedPending is the count of non-deleted chunks still awaiting
+	// embedding (embedding_status='pending'). Surfaced alongside EmbeddedOK so
+	// "chunks_total>0 but embedded_ok=0" is unambiguous: a large pending count
+	// with errors=0 means the embed worker hasn't drained the queue (semantic
+	// search is degraded to keyword-only until it does), vs. a real embed
+	// failure which shows under Errors/FailureSummary.
+	EmbeddedPending int64 `json:"embedded_pending"`
+	Errors          int64 `json:"errors"`
+	Unknown         int64 `json:"unknown"`
 	// FailureSummary groups chunk-level embedding failures by
 	// store.ErrorCategory ("rate_limit", "payload_too_large", etc.)
 	// plus a small sample of representative {rel_path, message}

--- a/internal/model/types_test.go
+++ b/internal/model/types_test.go
@@ -58,6 +58,7 @@ func TestStatsJSONFlattening(t *testing.T) {
 		"representations",
 		"chunks_total",
 		"embedded_ok",
+		"embedded_pending",
 		"errors",
 		"unknown",
 	}

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -1315,12 +1315,15 @@ func (s *Service) openFile(ctx context.Context, relPath string, span model.Span,
 		return "", false, err
 	}
 
-	// For binary documents (PDF, audio) with no explicit span, return the
-	// cached OCR/transcript markdown rather than the raw bytes. Without this,
-	// callers that don't pass page=N or start_ms/end_ms get an unusable text
-	// payload made of PDF stream bytes (see issue #177). Text-native types
-	// (md, txt, code, html) keep the existing default of returning file bytes.
-	if kind == "" && isBinaryDocType(normalizedRel) {
+	// For binary documents (PDF, audio) with no explicit span — OR with a
+	// line-range span, which is meaningless for OCR/transcript text — return the
+	// cached OCR/transcript markdown rather than the raw bytes. page=N / time
+	// spans were already served from metadata above. Without this, a caller that
+	// passes start_line/end_line on a PDF (a very natural thing for a model to
+	// try) gets bounced with DOC_TYPE_UNSUPPORTED instead of the text it wanted
+	// (issue #364; see also #177). Text-native types (md, txt, code, html) keep
+	// the existing default of returning file bytes with line slicing.
+	if isBinaryDocType(normalizedRel) && (kind == "" || kind == "lines") {
 		content, truncated, err := s.openFileFromOCRCache(stateDir, resolvedAbs, normalizedRel, secretPatterns, maxChars)
 		if err != nil {
 			return "", false, err

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -1735,6 +1735,7 @@ func applyCorpusStats(base model.Stats, corpus model.CorpusStats) model.Stats {
 	base.Representations = corpus.Representations
 	base.ChunksTotal = corpus.ChunksTotal
 	base.EmbeddedOK = corpus.EmbeddedOK
+	base.EmbeddedPending = corpus.EmbeddedPending
 	base.Errors = corpus.Errors
 	base.TotalDocs = corpus.TotalDocs
 	if len(corpus.DocCounts) == 0 {

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -1794,6 +1794,9 @@ func (s *SQLiteStore) CorpusStats(ctx context.Context) (model.CorpusStats, error
 	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM chunks WHERE deleted = 0 AND embedding_status = 'ok'`).Scan(&stats.EmbeddedOK); err != nil {
 		return model.CorpusStats{}, err
 	}
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM chunks WHERE deleted = 0 AND embedding_status = 'pending'`).Scan(&stats.EmbeddedPending); err != nil {
+		return model.CorpusStats{}, err
+	}
 
 	summary, err := loadFailureSummary(ctx, db, failureSummaryMaxSamples)
 	if err != nil {


### PR DESCRIPTION
Closes #364.

## Context

A v0.9.0 field-report bundle (now carrying client-logs from #359) on a 99-doc legal-PDF corpus showed `chunks_total: 2865` / `embedded_ok: 0` / `errors: 0` after indexing — i.e. the vector index is empty, so retrieval degrades to keyword-only → the "thin answers that cite section numbers without quoting" that kicked off this thread. The query embedder works (every ask/search logs `embed[...]`), so creds are fine.

Static analysis shows `startEmbeddingWorkers` and the `NextPending` filter both look correct, and there's **no logging**, so the runtime cause is unobservable from a bundle. Rather than speculatively rewrite the embed worker, this PR makes the failure observable so the next bundle pins it.

## Changes

**Embedding diagnostics**
- `model.CorpusStats.embedded_pending` — count of `embedding_status='pending'`, surfaced in `status`. `embedded_ok:0 / embedded_pending:2865 / errors:0` now unambiguously means "worker hasn't drained the queue" (semantic search degraded) vs. a real embed failure (which shows under `errors`/`failure_summary`).
- Embed worker logs a startup line per axis (`embed worker started [kind=text]`) and a per-batch `embedded N chunk(s)` progress line. Presence/absence in `server.log` distinguishes "never ran / found zero" from "embedded fine".

**open_file UX**
- A binary/PDF doc opened with a line-range span (`start_line/end_line`) now serves the cached OCR markdown instead of `DOC_TYPE_UNSUPPORTED`. `page=N`/`time` are still served from metadata. The model naturally tries line ranges on PDFs and was getting bounced (wasted round-trips, visible in the client logs).

## Tests
- Updated `TestStatsJSONFlattening` for the new `embedded_pending` field.
- `make check` green.

## Follow-up
The diagnostics are expected to let us root-cause and properly fix the embedding gap from your dad's next v0.9.1 support bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added pending embeddings metric to corpus statistics for better tracking of documents awaiting embedding.
  * Enhanced embedding worker logging with startup information and progress messages.

* **Bug Fixes**
  * Fixed line-range document requests on binary file types (PDFs, images, audio) to properly access cached content.

* **Tests**
  * Updated statistics validation tests to cover new pending embeddings metric.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->