### PR TITLE
ingest: exclude dir2mcp's own support bundle from the corpus (#366)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -906,6 +906,12 @@ func Default() Config {
 			"**/*.pem",
 			"**/*.key",
 			"**/id_rsa",
+			// dir2mcp's own support bundles: `support-bundle` writes
+			// dir2mcp-support-<ts>.tar.gz into the working dir, and deep archive
+			// ingestion would otherwise unpack and index its logs/config —
+			// poisoning the knowledge corpus with dir2mcp's own diagnostics
+			// (issue #366). Excluding the archive also skips its extraction.
+			"**/dir2mcp-support-*.tar.gz",
 		},
 		SecretPatterns: []string{
 			`AKIA[0-9A-Z]{16}`,

--- a/tests/ingest/ingest_test.go
+++ b/tests/ingest/ingest_test.go
@@ -331,6 +331,7 @@ func TestMatchesAnyPathExclude(t *testing.T) {
 		"**/node_modules/**",
 		"**/*.pem",
 		"**/.env",
+		"**/dir2mcp-support-*.tar.gz",
 	}
 
 	tests := []struct {
@@ -366,6 +367,25 @@ func TestMatchesAnyPathExclude(t *testing.T) {
 		{
 			name:     "normal file",
 			relPath:  "src/main.go",
+			expected: false,
+		},
+		{
+			// dir2mcp's own support bundle must never be ingested (#366):
+			// `support-bundle` drops it in the corpus root and deep archive
+			// ingestion would otherwise unpack and index its logs/config.
+			name:     "support bundle at corpus root",
+			relPath:  "dir2mcp-support-20260622-165429.tar.gz",
+			expected: true,
+		},
+		{
+			name:     "support bundle in a subdirectory",
+			relPath:  "reports/dir2mcp-support-20260101-000000.tar.gz",
+			expected: true,
+		},
+		{
+			// A user's own archive must NOT be swept up by the pattern.
+			name:     "unrelated archive is not excluded",
+			relPath:  "data/corpus-archive.tar.gz",
 			expected: false,
 		},
 	}


### PR DESCRIPTION
Closes #366.

## Problem (field report, v0.9.1)

On a legal-PDF knowledge corpus, RAG answers came predominantly from **log/yaml/json files**, not the PDFs. Root cause: `dir2mcp support-bundle` writes `dir2mcp-support-<ts>.tar.gz` into the working dir (the corpus root), and with `ingest.archives_mode: deep` the next index pass **unpacked and indexed its contents** — `mcp.log`, `server.log`, `config.snapshot.yaml`, `status.json`, etc. The bundle's own `list-files.json` shows them indexed under the archive's virtual path. Those plain-text diagnostics keyword-match readily (and contain echoed OCR'd legal text + dir2mcp metadata), so they dominate retrieval. A diagnostic the user generated poisoned their own corpus — worse each time they bundled to report it.

## Fix

Add `**/dir2mcp-support-*.tar.gz` to default `path_excludes`. Excludes apply at discovery, so this skips the archive **and** its deep extraction. The pattern is specific to dir2mcp's bundle name, so a user's own `*.tar.gz` archives are unaffected.

## Tests
- `TestMatchesAnyPathExclude`: support bundle excluded at corpus root and in a subdir; an unrelated `*.tar.gz` is NOT excluded.

## User remediation (existing corpora)
Delete any `dir2mcp-support-*.tar.gz` from the corpus directory and re-index.

## Context
Found alongside #364 (the embedding gap) while diagnosing the same field report — this one explains "RAG sources from log files"; #364/#365 explain the empty semantic index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)