### PR TITLE
server: sticky ephemeral listen port across restarts (#368)

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -166,6 +168,45 @@ func (a *App) teeServerLog(stateDir string) func() {
 // connectionFilePath returns the canonical connection.json location.
 func connectionFilePath(stateDir string) string {
 	return filepath.Join(stateDir, connectionFileName)
+}
+
+// readPreviousListenPort returns the TCP port recorded in a prior run's
+// connection.json, or "" when none is recorded or it is unreadable. Used to make
+// the ephemeral listen port sticky across restarts (#368).
+func readPreviousListenPort(stateDir string) string {
+	raw, err := os.ReadFile(connectionFilePath(stateDir))
+	if err != nil {
+		return ""
+	}
+	var conn connectionPayload
+	if err := json.Unmarshal(raw, &conn); err != nil {
+		return ""
+	}
+	u, err := url.Parse(strings.TrimSpace(conn.URL))
+	if err != nil {
+		return ""
+	}
+	return u.Port()
+}
+
+// preferredListenAddr returns listenAddr unchanged unless it is the ephemeral
+// default (host:0), in which case it substitutes the port a previous run
+// recorded in connection.json so a restart/upgrade re-binds the SAME port and
+// the URL baked into the Claude client config keeps working (#368). Returns the
+// original ephemeral address when no prior port is recorded; callers should
+// retry with the original address if binding the sticky port fails (the port may
+// now be taken).
+func preferredListenAddr(listenAddr, stateDir string) string {
+	host, port, err := net.SplitHostPort(strings.TrimSpace(listenAddr))
+	if err != nil || port != "0" {
+		// Explicit port (operator pinned it) or unparseable: respect as-is.
+		return listenAddr
+	}
+	prev := readPreviousListenPort(stateDir)
+	if prev == "" || prev == "0" {
+		return listenAddr
+	}
+	return net.JoinHostPort(host, prev)
 }
 
 // rotateLogIfLarge renames an oversized log file to "<path>.1" so the

--- a/internal/cli/server_log_tee_internal_test.go
+++ b/internal/cli/server_log_tee_internal_test.go
@@ -2,12 +2,49 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
+
+// TestPreferredListenAddr verifies the sticky-port logic (#368): the ephemeral
+// default (host:0) is replaced with a prior run's recorded port so a restart
+// re-binds the same port and the baked-in Claude URL keeps working; an explicit
+// port is respected; and the ephemeral default is kept when nothing is recorded.
+func TestPreferredListenAddr(t *testing.T) {
+	t.Run("explicit port respected", func(t *testing.T) {
+		got := preferredListenAddr("127.0.0.1:8080", t.TempDir())
+		if got != "127.0.0.1:8080" {
+			t.Fatalf("explicit port should be respected, got %q", got)
+		}
+	})
+
+	t.Run("ephemeral with no prior connection stays ephemeral", func(t *testing.T) {
+		got := preferredListenAddr("127.0.0.1:0", t.TempDir())
+		if got != "127.0.0.1:0" {
+			t.Fatalf("want ephemeral 127.0.0.1:0 with no prior port, got %q", got)
+		}
+	})
+
+	t.Run("ephemeral reuses prior recorded port", func(t *testing.T) {
+		stateDir := t.TempDir()
+		raw, err := json.Marshal(connectionPayload{URL: "http://127.0.0.1:58210/mcp"})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(stateDir, connectionFileName), raw, 0o600); err != nil {
+			t.Fatalf("write connection.json: %v", err)
+		}
+		got := preferredListenAddr("127.0.0.1:0", stateDir)
+		if got != "127.0.0.1:58210" {
+			t.Fatalf("want sticky 127.0.0.1:58210 from prior connection.json, got %q", got)
+		}
+	})
+}
 
 // TestTeeServerLog_WritesToServerLogInForeground verifies that a foreground /
 // service launch (not the daemon child) mirrors the process logger to

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -137,10 +137,9 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 		"state_dir": cfg.StateDir,
 	})
 
-	ln, err := net.Listen("tcp", cfg.ListenAddr)
-	if err != nil {
-		writeCLIError(a.stderr, opts.jsonOutput, exitServerBindFailure, fmt.Sprintf("bind server: %v", err))
-		return exitServerBindFailure
+	ln, code := a.bindServerListener(cfg, opts.jsonOutput)
+	if code != exitSuccess {
+		return code
 	}
 	runCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -1050,6 +1049,27 @@ func startEmbeddingIfNotReadOnly(ctx context.Context, cfg config.Config, readOnl
 	}
 	startEmbeddingWorkers(ctx, chunkSource, textIx, codeIx, embedder, ret, indexingState, embedErrCh, embedLogger, embedModelText, embedModelCode, rootDir, corpusFS, cfg.IngestLateChunking)
 	return nil
+}
+
+// bindServerListener binds the MCP server's TCP listener. It prefers the port a
+// previous run recorded (via preferredListenAddr, #368) so a restart/upgrade
+// re-binds the same ephemeral port and the URL baked into the Claude client
+// config keeps working; if that port is now taken it falls back to a fresh
+// ephemeral port so startup still succeeds. Returns the listener and exitSuccess,
+// or (nil, exit code) after writing a CLI error. Extracted from runUp to keep it
+// under the gocyclo budget.
+func (a *App) bindServerListener(cfg config.Config, jsonOutput bool) (net.Listener, int) {
+	listenAddr := preferredListenAddr(cfg.ListenAddr, cfg.StateDir)
+	ln, err := net.Listen("tcp", listenAddr)
+	if err != nil && listenAddr != cfg.ListenAddr {
+		writef(a.stderr, "note: previous port (%s) unavailable, binding a new one (re-run `dir2mcp install claude` if Claude can't connect): %v\n", listenAddr, err)
+		ln, err = net.Listen("tcp", cfg.ListenAddr)
+	}
+	if err != nil {
+		writeCLIError(a.stderr, jsonOutput, exitServerBindFailure, fmt.Sprintf("bind server: %v", err))
+		return nil, exitServerBindFailure
+	}
+	return ln, exitSuccess
 }
 
 // printHumanConnectionIfVerbose prints the human-readable connection block


### PR DESCRIPTION
Closes #368.

## Problem

The MCP server binds `127.0.0.1:0` (ephemeral) and the Claude integration bakes the concrete URL into the `mcpServers` entry at `install claude` time. So **every daemon restart picked a new port and silently broke the client connection** — observed in field bundles as `connect ECONNREFUSED 127.0.0.1:<old-port>` / "Server disconnected" — until the user re-ran `dir2mcp install claude` and restarted Claude Desktop. It also made the natural `brew upgrade` → restart flow break the connection.

## Fix

`preferredListenAddr` reuses the port recorded in the previous run's `connection.json` when `listen_addr` is the ephemeral default (`host:0`), so a restart/upgrade re-binds the **same** port and the baked-in client URL keeps working. If that port is now taken, it falls back to a fresh ephemeral port (with a note pointing at `install claude`) so startup never fails. An explicitly configured port is respected unchanged. Bind logic moved into `bindServerListener` to keep `runUp` under the gocyclo budget.

## Tests
- `TestPreferredListenAddr`: explicit port respected; ephemeral stays ephemeral with no prior record; ephemeral reuses the prior recorded port.

## Notes
Best-effort and backward-compatible: with no prior `connection.json` (first run) behavior is unchanged. Pairs with the existing `install claude` flow — most restarts now "just work" without re-install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Daemon now preserves its listen port across restarts, ensuring consistent network accessibility and reducing configuration disruption.

* **Improvements**
  * Graceful fallback mechanism added: if the previously-used port becomes unavailable, the daemon automatically allocates a new port while maintaining stability.

* **Tests**
  * Added comprehensive test coverage for port preservation and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->