### PR TITLE
fix(embed): restore embed worker — ChunkSource signature drift disabled embedding corpus-wide (#364)

### DIFF
--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -29,6 +29,7 @@ import (
 	"github.com/dirstral/dir2mcp/internal/providerfactory"
 	"github.com/dirstral/dir2mcp/internal/retrieval"
 	"github.com/dirstral/dir2mcp/internal/setupwizard"
+	"github.com/dirstral/dir2mcp/internal/store"
 )
 
 func (a *App) runUp(ctx context.Context, opts upOptions) int {
@@ -818,6 +819,13 @@ func preloadEmbeddedChunkMetadata(ctx context.Context, source embeddedChunkListe
 	}
 	return total, nil
 }
+
+// Compile-time guard: the concrete store handed to startEmbeddingIfNotReadOnly
+// MUST satisfy index.ChunkSource, otherwise the runtime `st.(index.ChunkSource)`
+// assertion there fails silently and the embed worker never starts (issue #364).
+// A signature drift on any ChunkSource method (e.g. MarkFailedWithCategory) now
+// breaks the build instead of disabling embedding corpus-wide at runtime.
+var _ index.ChunkSource = (*store.SQLiteStore)(nil)
 
 func startEmbeddingWorkers(
 	ctx context.Context,

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -2141,8 +2141,14 @@ func (s *SQLiteStore) MarkFailed(ctx context.Context, labels []uint64, reason st
 // stored alongside the existing free-text reason so the original
 // message stays available for debugging while aggregations operate on
 // the enum.
-func (s *SQLiteStore) MarkFailedWithCategory(ctx context.Context, labels []uint64, category ErrorCategory, reason string) error {
-	return s.markEmbeddingStatus(ctx, labels, "error", reason, string(category))
+// category is the string form of an ErrorCategory: the index.ChunkSource
+// interface deliberately declares it as a plain string so the embed worker
+// (package index) need not depend on this package's ErrorCategory type. The
+// parameter MUST stay `string` — typing it as ErrorCategory silently breaks the
+// `store.(index.ChunkSource)` assertion in startEmbeddingIfNotReadOnly, which
+// disables the embed worker corpus-wide with no error (issue #364).
+func (s *SQLiteStore) MarkFailedWithCategory(ctx context.Context, labels []uint64, category, reason string) error {
+	return s.markEmbeddingStatus(ctx, labels, "error", reason, category)
 }
 
 func (s *SQLiteStore) UpsertMCPSession(ctx context.Context, sessionID string, created, lastSeen time.Time, authScope string) error {


### PR DESCRIPTION
## Summary

The embed worker has been **silently disabled for every corpus on 0.9.x**, so embeddings never populate and every \`search\`/\`ask\` returns zero results. This surfaces to users as **"Failed to call tool dir2mcp_open_file"** — a downstream symptom: with no retrieval grounding, the model falls back to guessing file paths and \`open_file\` returns \`FILE_NOT_FOUND\`.

### Root cause

A type-signature drift between the interface and its only implementation:

\`\`\`
index.ChunkSource.MarkFailedWithCategory(…, category string,        reason string)   ← interface
SQLiteStore.MarkFailedWithCategory   (…, category ErrorCategory, reason string)  ← impl
\`\`\`

Go interface satisfaction is *exact* — \`ErrorCategory\` (a \`type ErrorCategory string\`) does **not** satisfy a \`string\` parameter. So the runtime assertion \`st.(index.ChunkSource)\` in \`startEmbeddingIfNotReadOnly\` returns \`ok=false\` and the function returns **without starting any embed worker** — no error, no log. Introduced in #210 (structured error categories).

The compiler confirms it:

\`\`\`
*store.SQLiteStore does not implement index.ChunkSource (wrong type for method MarkFailedWithCategory)
  have MarkFailedWithCategory(context.Context, []uint64, store.ErrorCategory, string) error
  want MarkFailedWithCategory(context.Context, []uint64, string, string) error
\`\`\`

### Fix

- Make \`SQLiteStore.MarkFailedWithCategory\` take \`category string\`, matching the interface's documented intent (the comment on the interface method already says category is "the string form of store.ErrorCategory so … implementations don't need to depend on the store package's type"). All callers already pass strings.
- Add a **compile-time guard** \`var _ index.ChunkSource = (*store.SQLiteStore)(nil)\` so any future ChunkSource signature drift breaks the build instead of silently disabling embedding at runtime.

### Verification

Reproduced on a real 89-PDF corpus that was stuck at \`embedded_ok\` ≈ 0:
- **Before:** no \`embed worker started\` log; \`search\` → \`found 0 result(s)\`; \`ask\` → "No relevant context found".
- **After:** \`embed worker started [kind=text]\`, chunks drain **21 → 2850 embedded** (errors=0), \`search\` returns hits, \`ask\` returns a properly cited answer.
- \`go vet\` + store/cli/index/tests all pass.

Closes #364.

## Follow-ups (filed separately)
Found while diagnosing — tracked as their own issues: docling broken in the \`dir2mcp-full\` formula (transformers too old for \`rt_detr_v2\`), insufficient docling functional check, BM25 \`bm25()\` NULL scan error, embed-worker logs discarded in daemon mode, and the HNSW save \`rename\` filename mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build-time safety checks to catch potential runtime failures earlier in the development process.
  * Simplified internal method interfaces for better code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->