### PR TITLE
ingest(docling): read output from a temp dir, not stdout (#376)

### DIFF
--- a/internal/ingest/docling_extractor.go
+++ b/internal/ingest/docling_extractor.go
@@ -18,7 +18,18 @@ import (
 // page/bbox provenance (spec 0.9.0 §7.4.B). When a custom docling_command
 // emits flat Markdown instead, Extract transparently falls back to treating
 // the output as Markdown.
-const defaultDoclingCommand = "docling --to json --output - {input}"
+//
+// `{output}` is substituted with a fresh per-call temp directory and the
+// produced file is read back from it. docling does NOT stream to stdout —
+// `--output -` writes a file named `-` in the working directory and leaves
+// stdout empty (issue #376), which silently failed every extraction. A template
+// that omits `{output}` keeps the legacy stdout-reading path (e.g. a custom
+// `cat {input}` or a wrapper that genuinely prints to stdout).
+const defaultDoclingCommand = "docling --to json --output {output} {input}"
+
+// doclingOutputPlaceholder marks where a per-call temp output directory is
+// substituted into the command template.
+const doclingOutputPlaceholder = "{output}"
 
 const (
 	maxDoclingStdoutBytes = 100 * 1024 * 1024
@@ -101,7 +112,9 @@ type structuredExtractor interface {
 }
 
 // run executes the configured docling command against data and returns the
-// trimmed stdout.
+// trimmed extraction output. When the template contains {output} (the default),
+// docling writes into a per-call temp directory and run reads the produced file
+// back; otherwise the legacy stdout-reading path is used.
 func (d *doclingExtractor) run(ctx context.Context, relPath string, data []byte) (string, error) {
 	ext := filepath.Ext(relPath)
 	if ext == "" {
@@ -123,7 +136,56 @@ func (d *doclingExtractor) run(ctx context.Context, relPath string, data []byte)
 		return "", fmt.Errorf("close temp doc file: %w", err)
 	}
 
-	args, err := buildDoclingCommandArgs(d.commandTemplate, tmpPath)
+	if strings.Contains(d.commandTemplate, doclingOutputPlaceholder) {
+		return d.runFileOutput(ctx, tmpPath)
+	}
+	return d.runStdout(ctx, tmpPath)
+}
+
+// runFileOutput runs docling with {output} pointed at a fresh temp directory and
+// returns the contents of the single file docling writes there (issue #376).
+// The output dir is isolated from the corpus so docling's artifacts can never be
+// re-ingested, and is removed when the call returns.
+func (d *doclingExtractor) runFileOutput(ctx context.Context, inputPath string) (string, error) {
+	outDir, err := os.MkdirTemp("", "dir2mcp-docling-out-*")
+	if err != nil {
+		return "", fmt.Errorf("create docling output dir: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(outDir) }()
+
+	args, err := buildDoclingCommandArgs(d.commandTemplate, inputPath, outDir)
+	if err != nil {
+		return "", err
+	}
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	cmd.Env = SanitizeDoclingEnv(os.Environ())
+	// docling logs progress to stdout/stderr; the real output is the file in
+	// outDir, so stdout is discarded and only stderr is captured for diagnostics.
+	var stderr bytes.Buffer
+	cmd.Stderr = &limitedBuffer{buf: &stderr, limit: maxDoclingStderrBytes}
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return "", fmt.Errorf("docling command failed: %s", msg)
+	}
+
+	out, err := readDoclingOutputDir(outDir, inputPath, maxDoclingStdoutBytes)
+	if err != nil {
+		return "", err
+	}
+	out = strings.TrimSpace(out)
+	if out == "" {
+		return "", fmt.Errorf("docling command produced empty output")
+	}
+	return out, nil
+}
+
+// runStdout is the legacy path for command templates without {output}: it reads
+// the extraction from the command's stdout (e.g. a custom `cat {input}` wrapper).
+func (d *doclingExtractor) runStdout(ctx context.Context, inputPath string) (string, error) {
+	args, err := buildDoclingCommandArgs(d.commandTemplate, inputPath, "")
 	if err != nil {
 		return "", err
 	}
@@ -152,6 +214,47 @@ func (d *doclingExtractor) run(ctx context.Context, relPath string, data []byte)
 		return "", fmt.Errorf("docling command produced empty output")
 	}
 	return out, nil
+}
+
+// readDoclingOutputDir returns the contents of the file docling wrote into
+// outDir. docling names the output after the input stem (`<stem>.json`/`.md`),
+// so when several files are present the one matching the input stem is preferred;
+// a single file is used directly. A file larger than limit is rejected rather
+// than partially read.
+func readDoclingOutputDir(outDir, inputPath string, limit int) (string, error) {
+	entries, err := os.ReadDir(outDir)
+	if err != nil {
+		return "", fmt.Errorf("read docling output dir: %w", err)
+	}
+	files := make([]os.DirEntry, 0, len(entries))
+	for _, e := range entries {
+		if e.Type().IsRegular() {
+			files = append(files, e)
+		}
+	}
+	if len(files) == 0 {
+		return "", nil
+	}
+
+	chosen := files[0]
+	if len(files) > 1 {
+		stem := strings.TrimSuffix(filepath.Base(inputPath), filepath.Ext(inputPath))
+		for _, f := range files {
+			if strings.TrimSuffix(f.Name(), filepath.Ext(f.Name())) == stem {
+				chosen = f
+				break
+			}
+		}
+	}
+
+	if info, ierr := chosen.Info(); ierr == nil && limit > 0 && info.Size() > int64(limit) {
+		return "", fmt.Errorf("docling command output exceeded limit")
+	}
+	data, err := os.ReadFile(filepath.Join(outDir, chosen.Name()))
+	if err != nil {
+		return "", fmt.Errorf("read docling output file: %w", err)
+	}
+	return string(data), nil
 }
 
 // Extract returns Markdown suitable for chunking/indexing. When the command
@@ -205,7 +308,7 @@ func (d *doclingExtractor) ExtractStructured(ctx context.Context, relPath string
 	}, nil
 }
 
-func buildDoclingCommandArgs(template, inputPath string) ([]string, error) {
+func buildDoclingCommandArgs(template, inputPath, outputDir string) ([]string, error) {
 	parts := strings.Fields(strings.TrimSpace(template))
 	if len(parts) == 0 {
 		return nil, fmt.Errorf("docling command is empty")
@@ -215,6 +318,9 @@ func buildDoclingCommandArgs(template, inputPath string) ([]string, error) {
 		if strings.Contains(parts[i], "{input}") {
 			parts[i] = strings.ReplaceAll(parts[i], "{input}", inputPath)
 			replaced = true
+		}
+		if strings.Contains(parts[i], doclingOutputPlaceholder) {
+			parts[i] = strings.ReplaceAll(parts[i], doclingOutputPlaceholder, outputDir)
 		}
 	}
 	if !replaced {

--- a/tests/ingest/docling_extractor_test.go
+++ b/tests/ingest/docling_extractor_test.go
@@ -27,6 +27,40 @@ func TestDoclingExtractor_Extract_UsesConfiguredCommand(t *testing.T) {
 	}
 }
 
+// TestDoclingExtractor_Extract_FileOutputPath covers the {output} path (issue
+// #376): docling does not stream to stdout — it writes a file into the directory
+// given to --output. A template containing {output} must therefore run the
+// command, then read the produced file back, rather than reading stdout. `cp
+// {input} {output}` simulates docling: cp into a directory keeps the input
+// basename, so the extractor reads that file's contents.
+func TestDoclingExtractor_Extract_FileOutputPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping POSIX-only command test on Windows")
+	}
+	extractor := ingest.NewDoclingExtractor("cp {input} {output}")
+	out, err := extractor.Extract(context.Background(), "sample.md", []byte("hello from file output"))
+	if err != nil {
+		t.Fatalf("extract failed: %v", err)
+	}
+	if strings.TrimSpace(out) != "hello from file output" {
+		t.Fatalf("unexpected output: %q", out)
+	}
+}
+
+// TestDoclingExtractor_Extract_FileOutputEmpty verifies that a {output} command
+// which writes nothing surfaces the empty-output error (issue #376) instead of
+// silently succeeding — `true` runs successfully but leaves the output dir empty.
+func TestDoclingExtractor_Extract_FileOutputEmpty(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping POSIX-only command test on Windows")
+	}
+	extractor := ingest.NewDoclingExtractor("true {input} {output}")
+	_, err := extractor.Extract(context.Background(), "sample.md", []byte("data"))
+	if err == nil || !strings.Contains(err.Error(), "empty output") {
+		t.Fatalf("expected empty-output error, got: %v", err)
+	}
+}
+
 func TestDocumentExtractorFromConfig_PrefersDoclingCommand(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping POSIX-only command test on Windows")


### PR DESCRIPTION
## Problem
docling 2.92.0 does **not** stream to stdout. The default command `docling --to json --output - {input}` reads stdout, but `--output -` writes a file (a directory literally named `-`) in the working directory and leaves stdout empty. Result, once docling actually loads (after #371):
- every document fails with `docling command produced empty output` (status=error, corpus never extracts/embeds), and
- docling's output artifacts (`dir2mcp-docling-*.md`, a `-/<name>.json`) land in the **corpus root** and get indexed (RAG answers from docling temp files).

Found while verifying #371 end-to-end on a real corpus.

## Fix
- Route docling output to a fresh per-call temp directory via a new `{output}` placeholder; read the produced file back instead of stdout.
- Default command is now `docling --to json --output {output} {input}`.
- The temp output dir is isolated from the corpus and `RemoveAll`'d after the call, so artifacts can never be re-ingested.
- Templates **without** `{output}` keep the legacy stdout path (preserves custom wrappers like `cat {input}`).

## Verification
- **Real docling** (dir2mcp-full 0.9.4_1): `reindex` extracts a PDF to structured markdown — `docling_reps=1, errors=0`, chunk text is real content, and **no artifacts left in the corpus root**.
- New unit tests: file-output path (`cp {input} {output}`) and empty-output detection (`true …`). Existing stdout-path test (`cat {input}`) still passes.
- `make check` green.

## Follow-up
#372 (make the formula/CI smoke actually convert a PDF) would have caught both this and the original rt_detr_v2 break — still worth doing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)