### PR TITLE
cli: route embed-worker logs to server.log in daemon/JSON mode

### DIFF
--- a/internal/cli/server_log_tee_internal_test.go
+++ b/internal/cli/server_log_tee_internal_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"log"
@@ -9,7 +10,29 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/model"
 )
+
+// notChunkSourceStore is a minimal model.Store that deliberately does NOT
+// implement index.ChunkSource, used to exercise the assertion-failure path in
+// startEmbeddingIfNotReadOnly (issue #374). The shipped *store.SQLiteStore
+// always satisfies ChunkSource (guarded at compile time), so a fake is the only
+// way to drive the "embedding disabled" warning branch.
+type notChunkSourceStore struct{}
+
+func (notChunkSourceStore) Init(context.Context) error { return nil }
+func (notChunkSourceStore) UpsertDocument(context.Context, model.Document) error {
+	return nil
+}
+func (notChunkSourceStore) GetDocumentByPath(context.Context, string) (model.Document, error) {
+	return model.Document{}, nil
+}
+func (notChunkSourceStore) ListFiles(context.Context, string, string, int, int) ([]model.Document, int64, error) {
+	return nil, 0, nil
+}
+func (notChunkSourceStore) Close() error { return nil }
 
 // TestPreferredListenAddr verifies the sticky-port logic (#368): the ephemeral
 // default (host:0) is replaced with a prior run's recorded port so a restart
@@ -91,5 +114,89 @@ func TestTeeServerLog_NoopInDaemonChild(t *testing.T) {
 	if restore := app.teeServerLog(t.TempDir()); restore != nil {
 		restore()
 		t.Fatal("teeServerLog must be a no-op in the daemon child (stderr already → server.log)")
+	}
+}
+
+// TestPickEmbedLogger_JSONModeReachesServerLog verifies that in JSON/daemon mode
+// the embed-worker logger is NOT discarded (issue #374): it writes to the
+// process-global log destination, which teeServerLog has wired to server.log. A
+// discarded logger would make the issue-#364 "embed worker started" diagnostic —
+// whose absence is the diagnosis — impossible to ever observe in a real daemon.
+func TestPickEmbedLogger_JSONModeReachesServerLog(t *testing.T) {
+	t.Setenv(daemonChildEnv, "") // foreground tee path (daemon child wires stderr→file at the OS level)
+	stateDir := t.TempDir()
+	app := NewAppWithIO(io.Discard, &bytes.Buffer{})
+
+	restore := app.teeServerLog(stateDir)
+	if restore == nil {
+		t.Fatal("expected tee to be active so log.Writer() reaches server.log")
+	}
+	defer restore()
+
+	// stderr is intentionally a buffer we ignore: in JSON mode the embed logger
+	// must route to log.Writer() (→ server.log), not to stderr.
+	embedLogger := pickEmbedLogger(io.Discard, true /* jsonOutput */)
+	const marker = "embed worker started [kind=text]"
+	embedLogger.Printf("%s", marker)
+
+	data, err := os.ReadFile(serverLogPath(stateDir))
+	if err != nil {
+		t.Fatalf("read server.log: %v", err)
+	}
+	if !strings.Contains(string(data), marker) {
+		t.Fatalf("JSON-mode embed logger output missing from server.log (was it discarded?); got %q", data)
+	}
+}
+
+// TestStartEmbeddingIfNotReadOnly_NoChunkSourceLogsWarning verifies that when the
+// store does not satisfy index.ChunkSource, embedding is not silently disabled
+// (issue #374): a warning is written to server.log (via the embed logger →
+// log.Writer() tee) AND emitted as a structured NDJSON event.
+func TestStartEmbeddingIfNotReadOnly_NoChunkSourceLogsWarning(t *testing.T) {
+	t.Setenv(daemonChildEnv, "")
+	stateDir := t.TempDir()
+	var stdout bytes.Buffer
+	app := NewAppWithIO(&stdout, io.Discard)
+
+	restore := app.teeServerLog(stateDir)
+	if restore == nil {
+		t.Fatal("expected tee to be active so the embed logger reaches server.log")
+	}
+	defer restore()
+
+	emitter := newNDJSONEmitter(&stdout, true /* enabled */)
+
+	err := startEmbeddingIfNotReadOnly(
+		context.Background(),
+		config.Config{},
+		false, // readOnly: must be false to reach the ChunkSource assertion
+		notChunkSourceStore{},
+		nil, nil, // textIx, codeIx
+		nil,                 // embedder
+		nil,                 // ret
+		nil,                 // indexingState
+		make(chan error, 1), // embedErrCh
+		io.Discard,          // stderr
+		true,                // jsonOutput
+		"", "", "",          // embedModelText, embedModelCode, rootDir
+		nil, // corpusFS
+		emitter,
+	)
+	if err != nil {
+		t.Fatalf("startEmbeddingIfNotReadOnly returned error: %v", err)
+	}
+
+	// server.log got the human warning line.
+	logData, readErr := os.ReadFile(serverLogPath(stateDir))
+	if readErr != nil {
+		t.Fatalf("read server.log: %v", readErr)
+	}
+	if !strings.Contains(string(logData), "does not satisfy index.ChunkSource") {
+		t.Fatalf("server.log missing ChunkSource-disabled warning; got %q", logData)
+	}
+
+	// stdout got the structured NDJSON warning event.
+	if !strings.Contains(stdout.String(), "embedding_disabled_no_chunk_source") {
+		t.Fatalf("NDJSON warning event missing from stdout; got %q", stdout.String())
 	}
 }

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -164,7 +164,7 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 	defer a.stopPersistenceWithLog(persistence)
 
 	embedErrCh := make(chan error, 4)
-	if err := startEmbeddingIfNotReadOnly(runCtx, cfg, opts.readOnly, st, textIx, codeIx, embedder, ret, indexingState, embedErrCh, a.stderr, opts.jsonOutput, etm, ecm, cfg.RootDir, corpusFS); err != nil {
+	if err := startEmbeddingIfNotReadOnly(runCtx, cfg, opts.readOnly, st, textIx, codeIx, embedder, ret, indexingState, embedErrCh, a.stderr, opts.jsonOutput, etm, ecm, cfg.RootDir, corpusFS, emitter); err != nil {
 		// A distributed-embedding setup failure is fatal: refuse to run a server
 		// that would silently never drain its pending queue.
 		writeCLIError(a.stderr, opts.jsonOutput, exitConfigInvalid, fmt.Sprintf("start embedding: %v", err))
@@ -636,11 +636,27 @@ func buildMCPServerOptions(cfg *config.Config, st model.Store, indexingState *ap
 	return opts
 }
 
-// pickEmbedLogger returns a logger appropriate for the embed workers based on
-// whether JSON output mode is active (discard) or not (stderr).
+// pickEmbedLogger returns a logger for the embed workers.
+//
+// In human mode it writes to stderr (the operator's terminal). In JSON mode it
+// MUST NOT discard: the daemonized server child runs in JSON mode, and silently
+// dropping the worker's "embed worker started [kind=...]" startup line (issue
+// #364 added it precisely so its ABSENCE in server.log is the diagnosis) and the
+// per-batch "embedded N chunk(s)" progress would make those diagnostics
+// unreachable in a real daemon. Instead it writes to the process-global log
+// destination (log.Writer()), which is already wired to reach
+// <state_dir>/server.log in EVERY launch mode:
+//
+//   - daemon child: the parent redirects the child's stderr to server.log, and
+//     log.Writer() defaults to stderr (issue #360);
+//   - foreground/service: teeServerLog() has already swapped log.Writer() for a
+//     MultiWriter that includes the server.log file handle.
+//
+// Routing through that single destination (rather than opening server.log a
+// second time here) is what avoids double-writing the worker lines.
 func pickEmbedLogger(stderr io.Writer, jsonOutput bool) *log.Logger {
 	if jsonOutput {
-		return log.New(io.Discard, "", 0)
+		return log.New(log.Writer(), "", log.LstdFlags)
 	}
 	return log.New(stderr, "", log.LstdFlags)
 }
@@ -1043,15 +1059,27 @@ func (a *App) stopPersistenceWithLog(persistence *index.PersistenceManager) {
 // It returns an error only for a distributed-mode SETUP failure (broker cannot be
 // built, store lacks ChunkTaskByID, no embed identity), which the caller treats as
 // fatal — the historical in-process path never errors here.
-func startEmbeddingIfNotReadOnly(ctx context.Context, cfg config.Config, readOnly bool, st model.Store, textIx, codeIx model.Index, embedder model.Embedder, ret *retrieval.Service, indexingState *appstate.IndexingState, embedErrCh chan error, stderr io.Writer, jsonOutput bool, embedModelText, embedModelCode, rootDir string, corpusFS corpusfs.CorpusFS) error {
+func startEmbeddingIfNotReadOnly(ctx context.Context, cfg config.Config, readOnly bool, st model.Store, textIx, codeIx model.Index, embedder model.Embedder, ret *retrieval.Service, indexingState *appstate.IndexingState, embedErrCh chan error, stderr io.Writer, jsonOutput bool, embedModelText, embedModelCode, rootDir string, corpusFS corpusfs.CorpusFS, emitter *ndjsonEmitter) error {
 	if readOnly {
 		return nil
 	}
+	embedLogger := pickEmbedLogger(stderr, jsonOutput)
 	chunkSource, ok := st.(index.ChunkSource)
 	if !ok {
+		// The compile-time guard (var _ index.ChunkSource = (*store.SQLiteStore)(nil))
+		// keeps the shipped store satisfying ChunkSource, but a future/alternate
+		// backend that does not would otherwise disable embedding corpus-wide with
+		// no trace. Log loudly (to server.log via embedLogger) and emit a structured
+		// NDJSON warning so the silent-failure of issue #364 can never recur.
+		embedLogger.Printf("embedding disabled: store %T does not satisfy index.ChunkSource; pending chunks will never be embedded", st)
+		if emitter != nil {
+			emitter.Emit("warning", "embedding_disabled_no_chunk_source", map[string]interface{}{
+				"store_type": fmt.Sprintf("%T", st),
+				"message":    "store does not satisfy index.ChunkSource; embedding is disabled and pending chunks will never be embedded",
+			})
+		}
 		return nil
 	}
-	embedLogger := pickEmbedLogger(stderr, jsonOutput)
 	if cfg.DistributedEmbed.Enabled {
 		return startDistributedEmbedding(ctx, cfg, st, chunkSource, textIx, codeIx, embedder, ret, indexingState, embedErrCh, embedLogger, embedModelText, embedModelCode, rootDir, corpusFS)
 	}


### PR DESCRIPTION
## Problem

Two observability gaps hid the embed-worker bug from issue #364:

1. **`pickEmbedLogger` discarded embed-worker logs in JSON mode.** The daemonized server child runs in JSON mode, so the `embed worker started [kind=...]` startup line (added by #364 precisely so its *absence* in `server.log` is the diagnosis) and the per-batch `embedded N chunk(s)` progress were sent to `io.Discard` and never reached `<state_dir>/server.log`. The diagnostic could therefore never appear in a real daemon.
2. **`startEmbeddingIfNotReadOnly` returned silently** when `st.(index.ChunkSource)` failed — disabling embedding corpus-wide with no log line.

## Fix

1. In JSON mode, `pickEmbedLogger` now writes to the process-global log destination (`log.Writer()`) instead of discarding. That destination already reaches `server.log` in **every** launch mode:
   - **daemon child** — the parent redirects the child's stderr to `server.log`, and `log.Writer()` defaults to stderr (#360);
   - **foreground/service** — `teeServerLog()` has already swapped `log.Writer()` for a `MultiWriter` that includes the `server.log` file handle.

   Routing through that single destination (rather than re-opening `server.log` here) is what avoids double-writing the worker lines.
2. On the `ChunkSource`-not-satisfied path, `startEmbeddingIfNotReadOnly` now logs a loud warning to `server.log` (via the embed logger) **and** emits a structured NDJSON warning event (`embedding_disabled_no_chunk_source`) instead of returning silently.

## Tests

Appended to the existing `internal/cli/server_log_tee_internal_test.go` (no new `*_test.go` under `internal/`, per AGENTS.md):
- `TestPickEmbedLogger_JSONModeReachesServerLog` — asserts the JSON-mode embed logger output lands in `server.log` (not discarded).
- `TestStartEmbeddingIfNotReadOnly_NoChunkSourceLogsWarning` — asserts the `ChunkSource`-not-satisfied path writes a `server.log` warning and emits the NDJSON event.

`make check` passes (`CGO_ENABLED=0`).

Closes #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added test coverage for embedding logger behavior in JSON logging mode
  * Added regression tests for embedding startup behavior and warning messages

* **Improvements**
  * Enhanced visibility of embedding worker diagnostic logs in daemon mode
  * Improved warning messages when embedding is unavailable or cannot initialize

<!-- end of auto-generated comment: release notes by coderabbit.ai -->