### PR TITLE
fix(store): tolerate NULL bm25 score in SearchBM25 (#373)

### DIFF
--- a/internal/store/sqlite_bm25.go
+++ b/internal/store/sqlite_bm25.go
@@ -2,7 +2,9 @@ package store
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/dirstral/dir2mcp/internal/model"
@@ -17,6 +19,15 @@ import (
 // better" semantics (matching the vector path) can sort consistently. Raw
 // FTS5 bm25() returns lower-is-better scores; we flip the sign at the
 // boundary. Rank order is preserved either way.
+//
+// Defensive NULL handling: on some external-content FTS5 indexes (observed in
+// the field with modernc.org/sqlite, see #373), bm25() can return NULL for
+// matched rows when the index lacks usable per-document term statistics.
+// Scanning a NULL into a plain float64 fails with "converting NULL to float64
+// is unsupported", which previously killed the entire lexical path and forced
+// a vector-only fallback (returning zero results when the vector index was
+// empty). We now scan into sql.NullFloat64 and order NULL-scored rows LAST so a
+// missing score degrades a single hit's rank rather than failing the query.
 func (s *SQLiteStore) SearchBM25(ctx context.Context, query string, k int, indexKind string) ([]model.SearchHit, error) {
 	query = strings.TrimSpace(query)
 	if query == "" {
@@ -48,7 +59,11 @@ func (s *SQLiteStore) SearchBM25(ctx context.Context, query string, k int, index
 		stmt += ` AND c.index_kind = ?`
 		args = append(args, kind)
 	}
-	stmt += ` ORDER BY score, c.chunk_id ASC LIMIT ?`
+	// `score IS NULL` sorts FALSE(0) before TRUE(1), so non-NULL (real) scores
+	// come first and any NULL-scored rows sink to the bottom of the lexical
+	// ranking. Without this guard SQLite's ASC ordering would float NULLs to the
+	// very top (best position), which is exactly backwards for a missing score.
+	stmt += ` ORDER BY score IS NULL, score, c.chunk_id ASC LIMIT ?`
 	args = append(args, k)
 
 	rows, err := db.QueryContext(ctx, stmt, args...)
@@ -67,7 +82,7 @@ func (s *SQLiteStore) SearchBM25(ctx context.Context, query string, k int, index
 			text     string
 			language string
 			title    string
-			score    float64
+			score    sql.NullFloat64
 		)
 		if err := rows.Scan(&chunkID, &relPath, &docType, &repType, &text, &language, &title, &score); err != nil {
 			return nil, err
@@ -75,13 +90,20 @@ func (s *SQLiteStore) SearchBM25(ctx context.Context, query string, k int, index
 		if chunkID <= 0 {
 			continue
 		}
+		// Negate so higher-is-better matches the vector path. A NULL bm25 score
+		// (no usable term statistics for this row) maps to the worst possible
+		// final score so it ranks last, consistent with the ORDER BY above.
+		hitScore := math.Inf(-1)
+		if score.Valid {
+			hitScore = -score.Float64
+		}
 		hits = append(hits, model.SearchHit{
 			ChunkID:  uint64(chunkID),
 			RelPath:  relPath,
 			Title:    title,
 			DocType:  docType,
 			RepType:  repType,
-			Score:    -score,
+			Score:    hitScore,
 			Snippet:  snippet(text, 240),
 			Span:     model.Span{Kind: "lines"},
 			Language: language,

--- a/tests/store/sqlite_bm25_test.go
+++ b/tests/store/sqlite_bm25_test.go
@@ -2,6 +2,8 @@ package tests
 
 import (
 	"context"
+	"database/sql"
+	"math"
 	"path/filepath"
 	"testing"
 
@@ -151,5 +153,137 @@ func TestSQLiteStore_SearchBM25_PopulatesTitle(t *testing.T) {
 				t.Errorf("untitled hit should have empty title, got %q", h.Title)
 			}
 		}
+	}
+}
+
+// TestSQLiteStore_SearchBM25_OrdersMatches is an end-to-end regression guard for
+// #373: on the production external-content chunks_fts schema, SearchBM25 must
+// return every matched row without error and rank them sensibly. It does not
+// itself force the NULL bm25() condition (modernc.org/sqlite computes a real
+// score for every in-process index), but it locks in that the lexical path
+// returns multiple matches in a stable, defined order — the behaviour the NULL
+// regression broke by erroring out the whole query.
+func TestSQLiteStore_SearchBM25_OrdersMatches(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "meta.sqlite")
+	st := store.NewSQLiteStore(dbPath)
+	defer func() { _ = st.Close() }()
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	chunks := []struct {
+		label uint64
+		text  string
+	}{
+		{1, "annual report covering financial results"},
+		{2, "another report about the weather report"},
+		{3, "a third report note here"},
+	}
+	for _, c := range chunks {
+		task := model.NewChunkTask(c.label, c.text, "text", model.ChunkMetadata{
+			ChunkID: c.label,
+			RelPath: "docs/case.md",
+			DocType: "md",
+			RepType: "raw_text",
+		})
+		if err := st.UpsertChunkTask(ctx, task); err != nil {
+			t.Fatalf("UpsertChunkTask(%d): %v", c.label, err)
+		}
+	}
+
+	ls, ok := interface{}(st).(model.LexicalSearcher)
+	if !ok {
+		t.Fatalf("SQLiteStore must implement model.LexicalSearcher")
+	}
+	hits, err := ls.SearchBM25(ctx, "report", 10, "text")
+	if err != nil {
+		t.Fatalf("SearchBM25: %v", err)
+	}
+	if len(hits) != 3 {
+		t.Fatalf("expected all 3 matched chunks, got %d", len(hits))
+	}
+	// Scores are higher-is-better after negation; ensure they are sorted
+	// descending and finite (no NULL placeholder leaked through).
+	for i := 1; i < len(hits); i++ {
+		if hits[i-1].Score < hits[i].Score {
+			t.Errorf("hits not sorted by descending score: %v then %v", hits[i-1].Score, hits[i].Score)
+		}
+		if math.IsInf(hits[i].Score, 0) {
+			t.Errorf("hit %d has non-finite score with a real bm25 index: %v", hits[i].ChunkID, hits[i].Score)
+		}
+	}
+}
+
+// TestSearchBM25_NullScoreContract pins the defensive contract added for #373.
+// On some external-content FTS5 indexes (observed in the field on persisted
+// corpora) bm25() returns NULL for matched rows, which made the old
+// `score float64` scan fail with "converting NULL to float64 is unsupported"
+// and collapsed the whole lexical path. modernc.org/sqlite never produces that
+// NULL for an in-process index, so this test exercises the exact scan + ORDER
+// BY shape SearchBM25 relies on against a table whose score column is literally
+// NULL, asserting (a) the sql.NullFloat64 scan does not error on NULL and
+// (b) NULL-scored rows sort LAST rather than jumping to the top.
+func TestSearchBM25_NullScoreContract(t *testing.T) {
+	// Driver "sqlite" is registered transitively via the internal/store import.
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	// Stand-in for the SearchBM25 result set: a real (non-NULL) bm25 score, plus
+	// a row whose score is NULL to mimic the broken index condition.
+	const setup = `
+CREATE TABLE hits(chunk_id INTEGER PRIMARY KEY, score REAL);
+INSERT INTO hits(chunk_id, score) VALUES (1, 1.5), (2, NULL), (3, 0.5);`
+	if _, err := db.Exec(setup); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	// Same ORDER BY clause SearchBM25 uses: NULL scores sink to the bottom, real
+	// scores ascend (lower raw bm25 is better), ties broken by chunk_id.
+	rows, err := db.Query(`SELECT chunk_id, score FROM hits ORDER BY score IS NULL, score, chunk_id ASC`)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	type result struct {
+		id    int64
+		score float64
+	}
+	var got []result
+	for rows.Next() {
+		var id int64
+		var score sql.NullFloat64
+		// This is the load-bearing assertion: scanning a NULL into NullFloat64
+		// must not error the way a plain float64 did.
+		if err := rows.Scan(&id, &score); err != nil {
+			t.Fatalf("scan (NULL must be tolerated): %v", err)
+		}
+		s := math.Inf(-1)
+		if score.Valid {
+			s = -score.Float64
+		}
+		got = append(got, result{id: id, score: s})
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows.Err: %v", err)
+	}
+
+	if len(got) != 3 {
+		t.Fatalf("expected 3 rows, got %d", len(got))
+	}
+	// Real scores first (chunk 3 has the better raw bm25 of 0.5, then chunk 1),
+	// NULL-scored chunk 2 ranked last.
+	wantOrder := []int64{3, 1, 2}
+	for i, w := range wantOrder {
+		if got[i].id != w {
+			t.Errorf("order[%d] = chunk %d, want chunk %d (full order: %+v)", i, got[i].id, w, got)
+		}
+	}
+	if !math.IsInf(got[2].score, -1) {
+		t.Errorf("NULL-scored row should map to -Inf (worst), got %v", got[2].score)
 	}
 }


### PR DESCRIPTION
## Problem

`internal/store/sqlite_bm25.go`'s `SearchBM25` selected `bm25(chunks_fts) AS score` and scanned it into a Go `float64`. On the corpus's external-content FTS5 table (`content='chunks'`), `bm25(chunks_fts)` returns **NULL** for some matched rows, so `rows.Scan(...&score)` failed with `converting NULL to float64 is unsupported`.

That error propagated out of `SearchBM25`, and `internal/retrieval/hybrid.go` deliberately swallows lexical errors and falls back to vector-only search. When the vector index was empty, the whole search then returned **0 results**.

## Root-cause investigation

I reproduced the production schema and every realistic population path (the `AFTER INSERT/UPDATE/DELETE` triggers, the `'rebuild'` backfill in `backfillFTSIfEmpty`, `INSERT OR REPLACE` upserts, orphaned external content, `columnsize=0`, contentless `content=''`, NULL/empty text) against `modernc.org/sqlite v1.32.0`. In every in-process case the driver either computes a valid (sometimes degenerate) bm25 score or hard-errors with `database disk image is malformed (267)` — it **never returns NULL**.

Conclusion: the NULL is a property of the user's *persisted on-disk* FTS index (most plausibly written by a different SQLite build/version with different fts5 shadow-table internals, then read back by modernc). It is not produced by dir2mcp's schema, triggers, or population code, so there is no low-risk code change that "fixes the writer". A blanket `INSERT INTO chunks_fts(chunks_fts) VALUES('rebuild')` on every `Init` would re-derive the entire FTS index on each startup — expensive and risky for large corpora — and the existing `backfillFTSIfEmpty` already rebuilds when the index is empty. Per the issue's guidance, the defensive scan alone is the correct resolution here.

## Fix (defensive scan + ordering)

- Scan the score into `sql.NullFloat64` so a NULL value no longer kills the query; matched rows are still returned.
- Order with `ORDER BY score IS NULL, score, c.chunk_id ASC` so NULL-scored rows sink to the bottom of the lexical ranking instead of floating to the top under SQLite's default ASC NULL-first ordering.
- A NULL score maps to the worst final score (`-Inf`) after the existing negation, preserving higher-is-better semantics. Downstream RRF fusion uses only rank order and overwrites `Score` with the RRF value, so the `-Inf` placeholder never reaches serialized output.

## Tests

Added to `tests/store/sqlite_bm25_test.go`:
- `TestSQLiteStore_SearchBM25_OrdersMatches` — end-to-end regression: the production external-content schema returns all matched rows in stable descending-score order with finite scores.
- `TestSearchBM25_NullScoreContract` — pins the NULL-tolerant scan + ORDER BY contract (NULL scans without error, NULL-scored rows sort last). Because modernc never emits NULL bm25 for an in-process index, the NULL condition is exercised against a synthetic score column using the exact ORDER BY/scan shape `SearchBM25` relies on.

`make check` passes locally (`CGO_ENABLED=0`).

Closes #373

🤖 Generated with [Claude Code](https://claude.com/claude-code)