### PR TITLE
ingest(docling): make docling actually usable in dir2mcp-full (#381)

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -58,8 +58,8 @@ const serverLogName = "server.log"
 
 // daemonReadinessHeadroom is the slack added on top of the document-extractor
 // probe ceiling to cover index load and the listener bind that follow the
-// probe before the child writes connection.json. 25s on top of the 20s probe
-// gives a 45s total readiness window.
+// probe before the child writes connection.json. 25s on top of the 90s probe
+// gives a 115s total readiness window.
 const daemonReadinessHeadroom = 25 * time.Second
 
 // daemonReadinessTimeout caps how long the parent will wait for the child
@@ -68,16 +68,16 @@ const daemonReadinessHeadroom = 25 * time.Second
 // The server itself binds within ~1s, but the child resolves the document
 // extractor during startup BEFORE it binds. On dir2mcp-full with the default
 // IngestExtractor="auto" and docling on PATH, that runs the docling
-// functional probe (`docling --version`, which imports torch) bounded by
-// ingest.doclingProbeTimeout (20s) on a cold first run. The readiness window
-// MUST therefore stay comfortably above that probe ceiling, otherwise a
+// functional probe (`docling --version`, which imports torch/transformers/cv2)
+// bounded by ingest.doclingProbeTimeout (90s) on a cold first run. The readiness
+// window MUST therefore stay comfortably above that probe ceiling, otherwise a
 // healthy-but-slow first run trips a false "not ready" while the child is
 // still warming up.
 //
 // We derive it from the probe ceiling (+ headroom) rather than hard-coding a
 // figure so the ordering invariant — readiness window > probe ceiling — can't
-// silently regress if the probe timeout is ever raised. Evaluates to 45s with
-// today's 20s probe. Do NOT lower the probe timeout to "fix" a slow start.
+// silently regress if the probe timeout is ever raised. Evaluates to 115s with
+// today's 90s probe. Do NOT lower the probe timeout to "fix" a slow start.
 var daemonReadinessTimeout = ingest.DoclingProbeTimeout() + daemonReadinessHeadroom
 
 // DaemonReadinessTimeout exposes the readiness window so external tests can

--- a/internal/ingest/docling_extractor.go
+++ b/internal/ingest/docling_extractor.go
@@ -32,7 +32,15 @@ const defaultDoclingCommand = "docling --to json --output {output} {input}"
 const doclingOutputPlaceholder = "{output}"
 
 const (
-	maxDoclingStdoutBytes = 100 * 1024 * 1024
+	// maxDoclingOutputBytes caps the docling extraction output we read back (the
+	// structured JSON file, the legacy stdout buffer, and the docling-serve
+	// response). docling's `--to json` DoclingDocument is verbose — a 920KB,
+	// few-hundred-page legal PDF produces ~100MB of JSON — so the old 100MB cap
+	// rejected large acts (e.g. the BVI Business Companies Act) with "output
+	// exceeded limit" and left them unindexed (issue #381). 1 GiB comfortably
+	// covers the largest legal PDFs while still bounding a pathological output.
+	// The read is one-time during indexing; query-time paths are unaffected.
+	maxDoclingOutputBytes = 1024 * 1024 * 1024
 	maxDoclingStderrBytes = 1 * 1024 * 1024
 )
 
@@ -84,11 +92,22 @@ func (w *limitedBuffer) Write(p []byte) (int, error) {
 
 // NewDoclingExtractor returns a document extractor backed by a local docling
 // CLI invocation. If commandTemplate is blank, a default `docling` command is
-// used. The template may include `{input}`; when omitted, input is appended.
+// used. The template may include `{input}` and `{output}`; when `{input}` is
+// omitted, input is appended.
+//
+// A bare binary path (a single token, e.g. the dir2mcp-full wrapper's
+// DIR2MCP_DOCLING_COMMAND, which is just `…/docling-venv/bin/docling`) is
+// underspecified: run as-is it becomes `docling <input>`, which writes Markdown
+// into the working directory and nothing to stdout — every extraction then fails
+// "empty output" and litters the corpus (issue #381). Expand it to the default
+// flags so docling writes structured JSON into the {output} temp dir we read back.
 func NewDoclingExtractor(commandTemplate string) *doclingExtractor {
 	tpl := strings.TrimSpace(commandTemplate)
-	if tpl == "" {
+	switch {
+	case tpl == "":
 		tpl = defaultDoclingCommand
+	case len(strings.Fields(tpl)) == 1:
+		tpl = tpl + " --to json --output " + doclingOutputPlaceholder + " {input}"
 	}
 	return &doclingExtractor{commandTemplate: tpl}
 }
@@ -171,7 +190,7 @@ func (d *doclingExtractor) runFileOutput(ctx context.Context, inputPath string) 
 		return "", fmt.Errorf("docling command failed: %s", msg)
 	}
 
-	out, err := readDoclingOutputDir(outDir, inputPath, maxDoclingStdoutBytes)
+	out, err := readDoclingOutputDir(outDir, inputPath, maxDoclingOutputBytes)
 	if err != nil {
 		return "", err
 	}
@@ -196,7 +215,7 @@ func (d *doclingExtractor) runStdout(ctx context.Context, inputPath string) (str
 	// sys.path and shadow the venv's pinned packages with a different version.
 	cmd.Env = SanitizeDoclingEnv(os.Environ())
 	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &limitedBuffer{buf: &stdout, limit: maxDoclingStdoutBytes}
+	cmd.Stdout = &limitedBuffer{buf: &stdout, limit: maxDoclingOutputBytes}
 	cmd.Stderr = &limitedBuffer{buf: &stderr, limit: maxDoclingStderrBytes}
 	if err := cmd.Run(); err != nil {
 		if errors.Is(err, errDoclingOutputTooLarge) {

--- a/internal/ingest/docling_probe.go
+++ b/internal/ingest/docling_probe.go
@@ -14,7 +14,16 @@ import (
 
 // doclingProbeTimeout bounds the docling functional check so a hung binary
 // cannot stall startup or `dir2mcp doctor`.
-const doclingProbeTimeout = 20 * time.Second
+//
+// It must clear docling's COLD `--version` time, which imports the whole
+// torch/transformers/cv2 stack: ~26s on a warm M-series Mac and slower on older
+// hardware / the first run after install. The old 20s ceiling timed out that
+// cold probe, so `ingest.extractor=auto` silently fell back to Mistral OCR even
+// though docling worked (issue #381). 90s is generous headroom for slow machines
+// while still bounding a genuinely hung binary. The probe result is memoized per
+// process, so only the first probe pays it; the daemon readiness window scales
+// off this value, so the readiness > probe ordering invariant still holds.
+const doclingProbeTimeout = 90 * time.Second
 
 // DoclingProbeTimeout exposes the docling functional-probe ceiling so other
 // packages (and tests) can keep dependent timeouts — notably the daemon

--- a/internal/ingest/docling_serve_extractor.go
+++ b/internal/ingest/docling_serve_extractor.go
@@ -106,12 +106,12 @@ func (d *doclingServeExtractor) convert(ctx context.Context, relPath string, dat
 
 	// Read one byte past the limit so an over-size response surfaces as a clear
 	// "too large" error rather than a confusing truncated-JSON decode failure.
-	payload, err := io.ReadAll(io.LimitReader(resp.Body, maxDoclingStdoutBytes+1))
+	payload, err := io.ReadAll(io.LimitReader(resp.Body, maxDoclingOutputBytes+1))
 	if err != nil {
 		return nil, fmt.Errorf("read docling-serve response: %w", err)
 	}
-	if len(payload) > maxDoclingStdoutBytes {
-		return nil, fmt.Errorf("docling-serve response exceeded %d bytes", maxDoclingStdoutBytes)
+	if len(payload) > maxDoclingOutputBytes {
+		return nil, fmt.Errorf("docling-serve response exceeded %d bytes", maxDoclingOutputBytes)
 	}
 	if resp.StatusCode != http.StatusOK {
 		// Deliberately do NOT echo the response body: this error is persisted as

--- a/tests/ingest/docling_extractor_test.go
+++ b/tests/ingest/docling_extractor_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -199,4 +201,36 @@ func unreachableDoclingServeURL(t *testing.T) string {
 	url := srv.URL
 	srv.Close()
 	return url
+}
+
+// TestDoclingExtractor_Extract_BareBinaryExpandsToFileOutput covers issue #381:
+// the dir2mcp-full wrapper sets DIR2MCP_DOCLING_COMMAND to a BARE docling binary
+// path (a single token, no flags). Run as-is that becomes `docling <input>`,
+// which writes Markdown to the CWD and nothing to stdout — every extraction then
+// fails "empty output" and litters the corpus. NewDoclingExtractor must expand a
+// single-token command to the default `--to json --output {output} {input}`
+// template and read the produced file. A fake single-token "docling" that writes
+// to the directory it is given via --output proves the expansion took effect.
+func TestDoclingExtractor_Extract_BareBinaryExpandsToFileOutput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping POSIX-only command test on Windows")
+	}
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "docling")
+	// Expanded argv: <fake> --to json --output <outdir> <input>
+	// => $4 is the output dir, $5 is the input file. Write a file into $4 so the
+	// file-output path (not the stdout path) is what returns the content.
+	script := "#!/bin/sh\nprintf 'expanded-and-file-output' > \"$4/result.txt\"\n"
+	if err := os.WriteFile(fake, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake docling: %v", err)
+	}
+
+	extractor := ingest.NewDoclingExtractor(fake) // single bare token
+	out, err := extractor.Extract(context.Background(), "sample.pdf", []byte("%PDF-1.4 fake"))
+	if err != nil {
+		t.Fatalf("extract failed (bare binary not expanded to file-output template?): %v", err)
+	}
+	if strings.TrimSpace(out) != "expanded-and-file-output" {
+		t.Fatalf("unexpected output: %q", out)
+	}
 }


### PR DESCRIPTION
End-to-end verification of docling on a real **dir2mcp-full 0.9.5** install (89 legal PDFs, `ingest.extractor=auto` — the default) found three issues that together made docling unusable, even after #371 (rt_detr_v2/cv2) and #376 (`--output -`). Each is fixed here.

## 1. Functional-probe timeout too short → silent Mistral fallback
`doclingProbeTimeout` was 20s, but cold `docling --version` imports the whole torch/transformers/cv2 stack and takes **~26s** (slower on older hardware / first run). The probe timed out → docling deemed "failed functional check" → `auto` **silently fell back to Mistral OCR**. So dad never actually got docling. → 20s → **90s** (memoized per process; daemon readiness window scales off it).

## 2. dir2mcp-full wrapper passes a BARE docling path
The formula wrapper sets `DIR2MCP_DOCLING_COMMAND=/…/docling-venv/bin/docling` (bare path). dir2mcp ran `docling <input>` — no `--to json --output {output}` — so docling wrote Markdown to the CWD + nothing to stdout → every doc failed "empty output" and littered the corpus with `dir2mcp-docling-*.md` (then indexed). → `NewDoclingExtractor` now **expands a single-token command** to the default `--to json --output {output} {input}` template.

## 3. Output cap (100MB) too small for large legal acts
docling `--to json` for big multi-hundred-page acts is ~100–120MB (BVI Business Companies Act = 117MB, VI Rules = 101MB, Sanctions order = 116MB). The 100MB `maxDoclingStdoutBytes` cap rejected them ("output exceeded limit") → unindexed (3 of 89). → renamed `maxDoclingOutputBytes`, raised to **1 GiB** (one-time read during indexing; query paths unaffected).

## Verification (real corpus, dir2mcp-full 0.9.5 + these fixes)
- Banner: `OCR: docling` (no more Mistral fallback)
- docling runs `--to json --output <tempdir> <input>` — **zero corpus pollution**
- **89/89** docs extract via docling, **0 errors**, fully embedded (7172 chunks)
- `search`/`ask` return cited answers — incl. the previously-failing **BVI Business Companies Act** ("memorandum complying with section 9…", 8 citations)
- Added a regression test for the bare-binary expansion; `make check` green.

Closes #381.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the allowed size for extracted docling results, helping larger outputs complete successfully.
  * Improved handling of simpler docling command setups so a bare binary path now expands into a working default command.
  * Raised the startup probe timeout for docling to reduce false failures on slower first runs.
  * Applied the same output size protections across both file-based and streamed result handling.
* **Tests**
  * Added coverage for the bare-binary command expansion flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->