### PR TITLE
docling: real titles + open_file page=N on docling PDFs (#383)

### DIFF
--- a/internal/ingest/docling/docling_test.go
+++ b/internal/ingest/docling/docling_test.go
@@ -145,6 +145,23 @@ func TestTitle(t *testing.T) {
 	}
 }
 
+// TestTitle_NoTitleElementReturnsEmpty pins issue #383: with no title-labeled
+// element, Title() must return "" and NOT fall back to the document name (which
+// is the temp input filename dir2mcp feeds docling), so the ingest service's
+// content-based title heuristic supplies the title instead.
+func TestTitle_NoTitleElementReturnsEmpty(t *testing.T) {
+	doc := &Document{
+		Name: "dir2mcp-docling-12345",
+		Texts: []*textItem{
+			{Label: LabelSectionHeader, Text: "Some Heading"},
+			{Label: "text", Text: "body text"},
+		},
+	}
+	if got := doc.Title(); got != "" {
+		t.Errorf("Title() = %q, want \"\" (no title element must not fall back to Name)", got)
+	}
+}
+
 func TestTableRendersAtomicallyWithCaption(t *testing.T) {
 	doc, _ := Parse([]byte(sampleDoc))
 	blocks := doc.Linearize()

--- a/internal/ingest/docling/linearize.go
+++ b/internal/ingest/docling/linearize.go
@@ -69,7 +69,14 @@ func normalizeLabel(raw string) string {
 }
 
 // Title returns the document title from the first title-labeled text element,
-// falling back to the document name. Empty when neither is present.
+// or "" when the document has no title element.
+//
+// It deliberately does NOT fall back to the document name: docling derives that
+// name from the input filename, and dir2mcp feeds docling a temp file, so the
+// fallback surfaced the temp filename (e.g. "dir2mcp-docling-1234") as the
+// document title (issue #383). Returning "" instead lets the ingest service run
+// its content-based title heuristic (ExtractTitle) — the same path Mistral OCR
+// uses — yielding a real title like the document's heading.
 func (d *Document) Title() string {
 	for _, t := range d.Texts {
 		if t != nil && normalizeLabel(t.Label) == LabelTitle {
@@ -78,7 +85,7 @@ func (d *Document) Title() string {
 			}
 		}
 	}
-	return strings.TrimSpace(d.Name)
+	return ""
 }
 
 // headingFrame tracks one open section in the breadcrumb stack.

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -1906,6 +1906,19 @@ func mediaPageKey(relPath string, page int) string {
 	return relPath + "\x00" + strconv.Itoa(page)
 }
 
+// regionCoversPage reports whether a structured-extraction region span spans the
+// given 1-based page. EndPage falls back to StartPage for single-page regions.
+func regionCoversPage(region *model.RegionSpan, page int) bool {
+	if region == nil || region.StartPage <= 0 || page <= 0 {
+		return false
+	}
+	end := region.EndPage
+	if end < region.StartPage {
+		end = region.StartPage
+	}
+	return page >= region.StartPage && page <= end
+}
+
 // dedupMediaCandidates implements the SPEC 8.1.7 page-image dedup: drop a media
 // page-image candidate for (rel_path, page) only when a text/region candidate
 // for that same page survives, so a page is not double-counted. It runs BEFORE
@@ -2973,6 +2986,12 @@ func (s *Service) sliceFromMetadata(relPath string, requested model.Span) (strin
 		case "page":
 			if strings.EqualFold(span.Kind, "page") && span.Page == requested.Page {
 				matches = append(matches, candidate{page: span.Page, text: hit.Snippet})
+			} else if strings.EqualFold(span.Kind, "region") && regionCoversPage(span.Region, requested.Page) {
+				// Structured (docling) chunks carry a region span with a page
+				// range, not a plain page span. Without this, open_file page=N on
+				// a docling-extracted PDF found no metadata match and fell through
+				// to reading raw PDF bytes -> DOC_TYPE_UNSUPPORTED (issue #383).
+				matches = append(matches, candidate{page: span.Region.StartPage, text: hit.Snippet})
 			}
 		case "time":
 			if !strings.EqualFold(span.Kind, "time") {

--- a/internal/retrieval/service_test.go
+++ b/internal/retrieval/service_test.go
@@ -660,3 +660,29 @@ func TestAsk_AppendsOnlyMissingAttributions(t *testing.T) {
 		t.Fatalf("expected only one [docs/a.md] tag, got %q", got.Answer)
 	}
 }
+
+// TestRegionCoversPage pins issue #383: open_file page=N on a docling-extracted
+// PDF must match the chunk's region span (page range), not just plain page spans.
+func TestRegionCoversPage(t *testing.T) {
+	cases := []struct {
+		name   string
+		region *model.RegionSpan
+		page   int
+		want   bool
+	}{
+		{"nil region", nil, 1, false},
+		{"start of range", &model.RegionSpan{StartPage: 4, EndPage: 5}, 4, true},
+		{"end of range", &model.RegionSpan{StartPage: 4, EndPage: 5}, 5, true},
+		{"above range", &model.RegionSpan{StartPage: 4, EndPage: 5}, 6, false},
+		{"below range", &model.RegionSpan{StartPage: 4, EndPage: 5}, 3, false},
+		{"single page (EndPage 0)", &model.RegionSpan{StartPage: 7}, 7, true},
+		{"single page miss", &model.RegionSpan{StartPage: 7}, 8, false},
+		{"unset start", &model.RegionSpan{StartPage: 0}, 1, false},
+		{"zero page request", &model.RegionSpan{StartPage: 4, EndPage: 5}, 0, false},
+	}
+	for _, c := range cases {
+		if got := regionCoversPage(c.region, c.page); got != c.want {
+			t.Errorf("%s: regionCoversPage(%+v, %d) = %v, want %v", c.name, c.region, c.page, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Two docling quality bugs found verifying the stas-legal corpus on 0.9.6 — both visibly degrade Claude's docling experience (it can't identify documents and can't open pages, which is the flailing seen in the field transcripts).

## 1. Doc titles show as `dir2mcp-docling-<random>`
`docling.Document.Title()` fell back to the DoclingDocument **name**, which docling derives from the input filename — and dir2mcp feeds it a temp file (`dir2mcp-docling-*`). So every document's title became e.g. `dir2mcp-docling-1122486701`, surfaced in `list_files` and search hits. The model then can't recognize documents and guesses wrong `rel_path`s.

**Fix:** `Title()` returns `""` when there's no real title element (instead of the name); the ingest service then runs its content-based heuristic (`ExtractTitle`) — the same path Mistral OCR uses — yielding a real title (the document heading).

## 2. `open_file page=N` → `DOC_TYPE_UNSUPPORTED` on docling PDFs
`sliceFromMetadata`'s `page` case only matched plain `page` spans, but docling chunks carry a **region** span (page range in `Region.StartPage/EndPage`). Page reads found no metadata match → fell through to reading raw PDF bytes → `looksLikeBinaryContent` → `DOC_TYPE_UNSUPPORTED` (even with `page=N` passed).

**Fix:** the page lookup now also matches region spans covering the requested page (`regionCoversPage`).

## Verification
- **Live:** `open_file page=1` on `No.19of2003-FinancialInvestigationAgencyAct2003.pdf` now returns the page text ("FINANCIAL INVESTIGATION AGENCY ACT, 2003 / ARRANGEMENT OF SECTIONS / …") — previously `DOC_TYPE_UNSUPPORTED`.
- Title fix routes to the content heuristic; regression tests added for both (`Title()`→"" with no title element; `regionCoversPage`). `make check` green.

Titles correct on the next (re)index; the open_file fix is effective immediately on the fixed binary.

Closes #383.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Title detection now returns an empty value when no title is present, instead of using a fallback name.
  * Page selection for extracted content now more reliably matches page-based results, including single-page sections and boundary cases.

* **Tests**
  * Added coverage for missing titles and page-region matching to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->