### PR TITLE
chore(release): end-to-end MCP smoke gate before tagging releases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,14 +75,19 @@ run the gate against the running daemon:
 ```bash
 make build
 # point a daemon at a freshly-reindexed corpus on THIS binary, wait for pending=0, then:
-make release-smoke STATE_DIR=/path/to/corpus/.dir2mcp
+make release-smoke STATE_DIR=/path/to/corpus/.dir2mcp                  # server contract (HTTP)
+make release-smoke STATE_DIR=/path/to/corpus/.dir2mcp TRANSPORT=stdio  # full mcp-remote bridge
 ```
 
 It speaks MCP to the daemon and asserts: indexing stopped + `errors=0` +
 `embedded_ok>0`; each question returns a grounded answer **with citations**;
 `search` returns hits; `open_file page=1` returns text. Any failure exits
-non-zero — do not tag until it is all-pass. (Manual gate: needs a live daemon +
-the corpus's provider credentials, so it is not part of `make ci`.)
+non-zero — do not tag until it is all-pass. Run **both** transports:
+`TRANSPORT=http` (default) hits the daemon directly; `TRANSPORT=stdio` drives the
+same `bunx mcp-remote` bridge Claude Desktop uses, so it also catches
+client/bridge-layer regressions (the "Failed to call tool" class). (Manual gate:
+needs a live daemon + the corpus's provider credentials, so it is not part of
+`make ci`.)
 
 The release workflow will build binaries for `darwin/linux × amd64/arm64`, publish a GitHub release with checksums, and push updated formulas to `Dirstral/homebrew-tap` automatically.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,27 @@ git tag v0.1.0
 git push origin v0.1.0
 ```
 
+### Pre-release smoke gate (run before tagging)
+
+`make ci`/`make check` validate code, but they do NOT exercise the live
+retrieval surface (`ask`/`search`/`open_file`) end-to-end — the surface that
+broke repeatedly across v0.9.x (empty embeddings, broken docling, BM25 NULL,
+open_file page reads). Before tagging, build the candidate binary, (re)index a
+representative corpus with it, wait for indexing to finish (`pending=0`), then
+run the gate against the running daemon:
+
+```bash
+make build
+# point a daemon at a freshly-reindexed corpus on THIS binary, wait for pending=0, then:
+make release-smoke STATE_DIR=/path/to/corpus/.dir2mcp
+```
+
+It speaks MCP to the daemon and asserts: indexing stopped + `errors=0` +
+`embedded_ok>0`; each question returns a grounded answer **with citations**;
+`search` returns hits; `open_file page=1` returns text. Any failure exits
+non-zero — do not tag until it is all-pass. (Manual gate: needs a live daemon +
+the corpus's provider credentials, so it is not part of `make ci`.)
+
 The release workflow will build binaries for `darwin/linux × amd64/arm64`, publish a GitHub release with checksums, and push updated formulas to `Dirstral/homebrew-tap` automatically.
 
 Requires `HOMEBREW_TAP_GITHUB_TOKEN` to be set as a repository secret (a PAT with `repo` scope on `Dirstral/homebrew-tap`).

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,16 @@ SMOKE_CORPUS ?= tests/testdata/smoke-corpus
 inspector-smoke: build
 	bash scripts/inspector-smoke.sh ./dir2mcp "$(SMOKE_CORPUS)"
 
+# Pre-release end-to-end gate: speaks MCP to a RUNNING dir2mcp daemon and
+# exercises ask/search/open_file (the retrieval surface that broke across
+# v0.9.x). Point it at a freshly (re)indexed corpus on the candidate binary
+# BEFORE tagging a release; all checks must pass. Needs a live daemon + the
+# corpus's provider credentials, so it is a manual gate, not part of `make ci`.
+#   make release-smoke STATE_DIR=~/Downloads/stas-legal/.dir2mcp
+STATE_DIR ?= .dir2mcp
+release-smoke:
+	python3 scripts/release_smoke.py --state-dir "$(STATE_DIR)"
+
 clean:
 	rm -f dir2mcp coverage.out
 	# only purge the test cache so we don't evict the global build cache

--- a/Makefile
+++ b/Makefile
@@ -98,9 +98,13 @@ inspector-smoke: build
 # BEFORE tagging a release; all checks must pass. Needs a live daemon + the
 # corpus's provider credentials, so it is a manual gate, not part of `make ci`.
 #   make release-smoke STATE_DIR=~/Downloads/stas-legal/.dir2mcp
+# TRANSPORT=http (default) hits the daemon directly; TRANSPORT=stdio drives the
+# real `bunx mcp-remote` bridge Claude Desktop uses (catches client-layer bugs).
+# Run both before a release.
 STATE_DIR ?= .dir2mcp
+TRANSPORT ?= http
 release-smoke:
-	python3 scripts/release_smoke.py --state-dir "$(STATE_DIR)"
+	python3 scripts/release_smoke.py --state-dir "$(STATE_DIR)" --transport "$(TRANSPORT)"
 
 clean:
 	rm -f dir2mcp coverage.out

--- a/scripts/release_smoke.py
+++ b/scripts/release_smoke.py
@@ -25,14 +25,48 @@ import argparse, json, os, select, subprocess, sys, urllib.request
 PROTO = "2025-11-25"
 
 
+def _result_or_error(msg):
+    """Map a JSON-RPC response message to a tool result, surfacing protocol
+    errors as an isError result instead of silently collapsing them to {} (so a
+    handshake/auth failure produces a clear failure, not misleading downstream
+    FAILs)."""
+    if msg is None:
+        return {"isError": True, "content": [{"type": "text", "text": "no response (Failed to call tool)"}]}
+    if msg.get("error"):
+        e = msg["error"]
+        return {"isError": True, "content": [{"type": "text", "text": f"JSON-RPC error {e.get('code')}: {e.get('message')}"}]}
+    return msg.get("result", {})
+
+
+def _check_init(msg, transport):
+    """Fail fast with the real protocol/auth error from an initialize response."""
+    if msg is None:
+        raise RuntimeError(f"{transport}: no response to initialize (server/bridge unreachable?)")
+    if msg.get("error"):
+        e = msg["error"]
+        raise RuntimeError(f"{transport}: initialize failed — JSON-RPC error {e.get('code')}: {e.get('message')}")
+
+
+def is_texty(s):
+    """Heuristic: real extracted text (not raw bytes / empty). Legal prose is
+    mostly letters; binary payloads are not."""
+    s = (s or "").strip()
+    if len(s) < 20:
+        return False
+    letters = sum(c.isalpha() or c.isspace() for c in s)
+    return letters >= 0.6 * len(s)
+
+
 class HTTPClient:
     """MCP over streamable-HTTP, directly to the daemon."""
 
     def __init__(self, url, token):
         self.url, self.token, self.sid = url, token, None
-        self.sid = self._post({"jsonrpc": "2.0", "id": 1, "method": "initialize",
+        msg, sid = self._post({"jsonrpc": "2.0", "id": 1, "method": "initialize",
             "params": {"protocolVersion": PROTO, "capabilities": {},
-                       "clientInfo": {"name": "release-smoke", "version": "1"}}})[1]
+                       "clientInfo": {"name": "release-smoke", "version": "1"}}})
+        _check_init(msg, "http")
+        self.sid = sid
 
     def _post(self, body):
         req = urllib.request.Request(self.url, data=json.dumps(body).encode(), method="POST")
@@ -58,7 +92,7 @@ class HTTPClient:
     def call(self, name, args):
         d, _ = self._post({"jsonrpc": "2.0", "id": 99, "method": "tools/call",
                            "params": {"name": name, "arguments": args}})
-        return (d or {}).get("result", {})
+        return _result_or_error(d)
 
     def close(self):
         pass
@@ -80,8 +114,7 @@ class StdioClient:
                        "clientInfo": {"name": "release-smoke", "version": "1"}}})
         # bunx may cold-download mcp-remote, and the bridge handshakes with the
         # server before forwarding — allow a generous window for the first reply.
-        if self._read_until(1, timeout=90) is None:
-            raise RuntimeError("mcp-remote bridge did not complete initialize within 90s")
+        _check_init(self._read_until(1, timeout=90), "stdio")
         self._send({"jsonrpc": "2.0", "method": "notifications/initialized"})
 
     def _send(self, obj):
@@ -114,11 +147,9 @@ class StdioClient:
         rid = self._id
         self._send({"jsonrpc": "2.0", "id": rid, "method": "tools/call",
                     "params": {"name": name, "arguments": args}})
-        msg = self._read_until(rid, timeout=120)
-        if msg is None:
-            # the exact "Failed to call tool" class: bridge never returned a result
-            return {"isError": True, "content": [{"type": "text", "text": "bridge: no response (Failed to call tool)"}]}
-        return msg.get("result", {})
+        # A None here is the exact "Failed to call tool" class — the bridge never
+        # returned a result; _result_or_error surfaces it as a tool error.
+        return _result_or_error(self._read_until(rid, timeout=120))
 
     def close(self):
         try:
@@ -154,17 +185,29 @@ def run_checks(client, questions):
     hits = r.get("structuredContent", {}).get("hits", []) if not r.get("isError") else []
     check("search: >=1 hit", len(hits) >= 1, f"hits={len(hits)}")
 
-    lf = client.call("dir2mcp_list_files", {"glob": "*.pdf", "limit": 1})
-    files = lf.get("structuredContent", {}).get("files", [])
-    if files:
-        rp = files[0]["rel_path"]
-        of = client.call("dir2mcp_open_file", {"rel_path": rp, "page": 1})
-        txt = (of.get("content") or [{}])[0].get("text", "") if not of.get("isError") else ""
-        check(f"open_file page=1 ({rp[:30]}…)",
-              not of.get("isError") and len(txt.strip()) > 0,
-              "tool error" if of.get("isError") else f"{len(txt)}c")
-    else:
+    lf = client.call("dir2mcp_list_files", {"glob": "*.pdf", "limit": 12})
+    files = [f["rel_path"] for f in lf.get("structuredContent", {}).get("files", [])]
+    if not files:
         check("open_file: a pdf exists to test", False)
+        return fails
+    # Probe several PDFs rather than whichever sorts first: a single image-only
+    # cover page must not fail the gate, and the result must be real text (not raw
+    # bytes). Pass on the first page that yields printable text; fail only if none
+    # of the sampled PDFs do (which would mean open_file page reads are broken).
+    opened, last = None, ""
+    for rp in files:
+        of = client.call("dir2mcp_open_file", {"rel_path": rp, "page": 1})
+        if of.get("isError"):
+            last = "tool error"
+            continue
+        txt = (of.get("content") or [{}])[0].get("text", "")
+        if is_texty(txt):
+            opened = (rp, len(txt.strip()))
+            break
+        last = f"{len(txt.strip())}c not text-like"
+    check("open_file page=1 returns text",
+          opened is not None,
+          f"{opened[0][:30]}… {opened[1]}c" if opened else f"none of {len(files)} pdfs ({last})")
     return fails
 
 

--- a/scripts/release_smoke.py
+++ b/scripts/release_smoke.py
@@ -1,55 +1,181 @@
 #!/usr/bin/env python3
 """End-to-end MCP smoke test for a running dir2mcp instance.
 
-Speaks the MCP streamable-HTTP protocol to a live daemon and exercises the
-retrieval path the stas-legal guide's "Проверка" step covers — the exact
-surface that kept breaking (empty embeddings, broken docling, BM25 NULL).
+Exercises the retrieval path the stas-legal guide's verification step covers —
+the surface that kept breaking (empty embeddings, broken docling, BM25 NULL,
+open_file page reads). Two transports:
+
+  --transport http   (default) speaks MCP streamable-HTTP straight to the daemon
+                      (the server contract; deterministic, no extra deps).
+  --transport stdio  drives the SAME `bunx mcp-remote` bridge Claude Desktop
+                      uses, over stdio — catches client/bridge-layer regressions
+                      too.
 
 Gate (any failure -> exit 1):
   * stats: indexing stopped, errors==0, embedded_ok>0
   * ask (each question): non-empty answer AND >=1 citation, no tool error
   * search: >=1 hit
-  * open_file(real pdf, page=1): non-empty text, not a tool error
+  * open_file(real pdf, page=1): non-empty, non-binary text
 
-Usage: release_smoke.py [--state-dir DIR] [--question Q ...]
+Usage:
+  release_smoke.py [--state-dir DIR] [--transport http|stdio] [--bunx CMD] [--question Q ...]
 """
-import argparse, json, os, sys, urllib.request
+import argparse, json, os, select, subprocess, sys, urllib.request
 
-def _post(url, token, sid, body):
-    req = urllib.request.Request(url, data=json.dumps(body).encode(), method="POST")
-    req.add_header("Authorization", f"Bearer {token}")
-    req.add_header("Content-Type", "application/json")
-    req.add_header("MCP-Protocol-Version", "2025-11-25")
-    req.add_header("Accept", "application/json, text/event-stream")
-    if sid:
-        req.add_header("Mcp-Session-Id", sid)
-    resp = urllib.request.urlopen(req, timeout=120)
-    hdr_sid = resp.headers.get("Mcp-Session-Id")
-    out = None
-    for line in resp.read().decode().splitlines():
-        line = line.strip()
-        if line.startswith("data:"):
-            line = line[5:].strip()
-        if not line:
-            continue
+PROTO = "2025-11-25"
+
+
+class HTTPClient:
+    """MCP over streamable-HTTP, directly to the daemon."""
+
+    def __init__(self, url, token):
+        self.url, self.token, self.sid = url, token, None
+        self.sid = self._post({"jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": {"protocolVersion": PROTO, "capabilities": {},
+                       "clientInfo": {"name": "release-smoke", "version": "1"}}})[1]
+
+    def _post(self, body):
+        req = urllib.request.Request(self.url, data=json.dumps(body).encode(), method="POST")
+        req.add_header("Authorization", f"Bearer {self.token}")
+        req.add_header("Content-Type", "application/json")
+        req.add_header("MCP-Protocol-Version", PROTO)
+        req.add_header("Accept", "application/json, text/event-stream")
+        if self.sid:
+            req.add_header("Mcp-Session-Id", self.sid)
+        resp = urllib.request.urlopen(req, timeout=120)
+        out = None
+        for line in resp.read().decode().splitlines():
+            line = line.strip()
+            if line.startswith("data:"):
+                line = line[5:].strip()
+            if line:
+                try:
+                    out = json.loads(line)
+                except json.JSONDecodeError:
+                    pass
+        return out, resp.headers.get("Mcp-Session-Id")
+
+    def call(self, name, args):
+        d, _ = self._post({"jsonrpc": "2.0", "id": 99, "method": "tools/call",
+                           "params": {"name": name, "arguments": args}})
+        return (d or {}).get("result", {})
+
+    def close(self):
+        pass
+
+
+class StdioClient:
+    """MCP over the bunx mcp-remote bridge (the path Claude Desktop uses)."""
+
+    def __init__(self, url, token, bunx="bunx"):
+        self.proc = subprocess.Popen(
+            [bunx, "mcp-remote", url,
+             "--header", f"MCP-Protocol-Version:{PROTO}",
+             "--header", f"Authorization:Bearer {token}"],
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+            text=True, bufsize=1)
+        self._id = 1
+        self._send({"jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": {"protocolVersion": PROTO, "capabilities": {},
+                       "clientInfo": {"name": "release-smoke", "version": "1"}}})
+        # bunx may cold-download mcp-remote, and the bridge handshakes with the
+        # server before forwarding — allow a generous window for the first reply.
+        if self._read_until(1, timeout=90) is None:
+            raise RuntimeError("mcp-remote bridge did not complete initialize within 90s")
+        self._send({"jsonrpc": "2.0", "method": "notifications/initialized"})
+
+    def _send(self, obj):
+        self.proc.stdin.write(json.dumps(obj) + "\n")
+        self.proc.stdin.flush()
+
+    def _read_until(self, want_id, timeout=60):
+        import time
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            r, _, _ = select.select([self.proc.stdout], [], [], deadline - time.monotonic())
+            if not r:
+                continue
+            line = self.proc.stdout.readline()
+            if line == "":
+                return None  # bridge closed stdout
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                msg = json.loads(line)
+            except json.JSONDecodeError:
+                continue  # skip any non-JSON noise
+            if msg.get("id") == want_id:
+                return msg
+        return None
+
+    def call(self, name, args):
+        self._id += 1
+        rid = self._id
+        self._send({"jsonrpc": "2.0", "id": rid, "method": "tools/call",
+                    "params": {"name": name, "arguments": args}})
+        msg = self._read_until(rid, timeout=120)
+        if msg is None:
+            # the exact "Failed to call tool" class: bridge never returned a result
+            return {"isError": True, "content": [{"type": "text", "text": "bridge: no response (Failed to call tool)"}]}
+        return msg.get("result", {})
+
+    def close(self):
         try:
-            out = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-    return out, hdr_sid
+            self.proc.terminate()
+        except Exception:
+            pass
 
-def call(url, token, sid, name, args):
-    body = {"jsonrpc": "2.0", "id": 99, "method": "tools/call",
-            "params": {"name": name, "arguments": args}}
-    d, _ = _post(url, token, sid, body)
-    r = (d or {}).get("result", {})
-    return r
+
+def run_checks(client, questions):
+    fails = []
+    def check(name, ok, detail=""):
+        print(f"  [{'PASS' if ok else 'FAIL'}] {name}{(' — ' + detail) if detail else ''}")
+        if not ok:
+            fails.append(name)
+
+    r = client.call("dir2mcp_stats", {})
+    ix = r.get("structuredContent", {}).get("indexing", {})
+    check("stats: indexing stopped", ix.get("running") is False, f"running={ix.get('running')}")
+    check("stats: errors==0", ix.get("errors", -1) == 0, f"errors={ix.get('errors')}")
+    check("stats: embedded_ok>0", ix.get("embedded_ok", 0) > 0, f"embedded_ok={ix.get('embedded_ok')}")
+
+    for q in questions:
+        r = client.call("dir2mcp_ask", {"question": q, "k": 8})
+        if r.get("isError"):
+            check(f"ask: {q[:42]}…", False, "tool error")
+            continue
+        sc = r.get("structuredContent", {})
+        ans = (sc.get("answer") or "").strip()
+        cites = sc.get("citations") or []
+        check(f"ask: {q[:42]}…", bool(ans) and len(cites) >= 1, f"answer={len(ans)}c citations={len(cites)}")
+
+    r = client.call("dir2mcp_search", {"query": "financial investigation agency powers", "k": 5})
+    hits = r.get("structuredContent", {}).get("hits", []) if not r.get("isError") else []
+    check("search: >=1 hit", len(hits) >= 1, f"hits={len(hits)}")
+
+    lf = client.call("dir2mcp_list_files", {"glob": "*.pdf", "limit": 1})
+    files = lf.get("structuredContent", {}).get("files", [])
+    if files:
+        rp = files[0]["rel_path"]
+        of = client.call("dir2mcp_open_file", {"rel_path": rp, "page": 1})
+        txt = (of.get("content") or [{}])[0].get("text", "") if not of.get("isError") else ""
+        check(f"open_file page=1 ({rp[:30]}…)",
+              not of.get("isError") and len(txt.strip()) > 0,
+              "tool error" if of.get("isError") else f"{len(txt)}c")
+    else:
+        check("open_file: a pdf exists to test", False)
+    return fails
+
 
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--state-dir", default=".dir2mcp")
+    ap.add_argument("--transport", choices=["http", "stdio"], default="http")
+    ap.add_argument("--bunx", default="bunx", help="command that runs mcp-remote (stdio transport)")
     ap.add_argument("--question", action="append", default=[])
     a = ap.parse_args()
+
     conn = json.load(open(os.path.join(a.state_dir, "connection.json")))
     url = conn["url"]
     token = open(os.path.join(a.state_dir, "secret.token")).read().strip()
@@ -58,46 +184,16 @@ def main():
         "What entities are subject to BVI economic substance requirements?",
         "Under what circumstances must a financial institution file a suspicious transaction report in the BVI? Include the section number.",
     ]
-    _, sid = _post(url, token, None, {"jsonrpc":"2.0","id":1,"method":"initialize",
-        "params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"release-smoke","version":"1"}}})
-    fails = []
-    def check(name, ok, detail=""):
-        print(f"  [{'PASS' if ok else 'FAIL'}] {name}{(' — '+detail) if detail else ''}")
-        if not ok: fails.append(name)
 
-    print(f"dir2mcp release smoke @ {url}")
-    # 1. stats
-    r = call(url, token, sid, "dir2mcp_stats", {})
-    ix = r.get("structuredContent", {}).get("indexing", {})
-    check("stats: indexing stopped", ix.get("running") is False, f"running={ix.get('running')}")
-    check("stats: errors==0", ix.get("errors", -1) == 0, f"errors={ix.get('errors')}")
-    check("stats: embedded_ok>0", ix.get("embedded_ok", 0) > 0, f"embedded_ok={ix.get('embedded_ok')}")
-    # 2. ask
-    for q in questions:
-        r = call(url, token, sid, "dir2mcp_ask", {"question": q, "k": 8})
-        if r.get("isError"):
-            check(f"ask: {q[:42]}…", False, "tool error"); continue
-        sc = r.get("structuredContent", {})
-        ans = (sc.get("answer") or "").strip()
-        cites = sc.get("citations") or []
-        check(f"ask: {q[:42]}…", bool(ans) and len(cites) >= 1, f"answer={len(ans)}c citations={len(cites)}")
-    # 3. search
-    r = call(url, token, sid, "dir2mcp_search", {"query": "financial investigation agency powers", "k": 5})
-    hits = r.get("structuredContent", {}).get("hits", []) if not r.get("isError") else []
-    check("search: >=1 hit", len(hits) >= 1, f"hits={len(hits)}")
-    # 4. open_file (real pdf, page 1)
-    lf = call(url, token, sid, "dir2mcp_list_files", {"glob": "*.pdf", "limit": 1})
-    files = lf.get("structuredContent", {}).get("files", [])
-    if files:
-        rp = files[0]["rel_path"]
-        of = call(url, token, sid, "dir2mcp_open_file", {"rel_path": rp, "page": 1})
-        txt = (of.get("content") or [{}])[0].get("text", "") if not of.get("isError") else ""
-        check(f"open_file page=1 ({rp[:30]}…)", not of.get("isError") and len(txt.strip()) > 0, "tool error" if of.get("isError") else f"{len(txt)}c")
-    else:
-        check("open_file: a pdf exists to test", False)
-
+    print(f"dir2mcp release smoke @ {url}  (transport={a.transport})")
+    client = StdioClient(url, token, a.bunx) if a.transport == "stdio" else HTTPClient(url, token)
+    try:
+        fails = run_checks(client, questions)
+    finally:
+        client.close()
     print(f"\n{'✅ ALL PASS' if not fails else '❌ FAILED: ' + ', '.join(fails)}")
     sys.exit(1 if fails else 0)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/release_smoke.py
+++ b/scripts/release_smoke.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""End-to-end MCP smoke test for a running dir2mcp instance.
+
+Speaks the MCP streamable-HTTP protocol to a live daemon and exercises the
+retrieval path the stas-legal guide's "Проверка" step covers — the exact
+surface that kept breaking (empty embeddings, broken docling, BM25 NULL).
+
+Gate (any failure -> exit 1):
+  * stats: indexing stopped, errors==0, embedded_ok>0
+  * ask (each question): non-empty answer AND >=1 citation, no tool error
+  * search: >=1 hit
+  * open_file(real pdf, page=1): non-empty text, not a tool error
+
+Usage: release_smoke.py [--state-dir DIR] [--question Q ...]
+"""
+import argparse, json, os, sys, urllib.request
+
+def _post(url, token, sid, body):
+    req = urllib.request.Request(url, data=json.dumps(body).encode(), method="POST")
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Content-Type", "application/json")
+    req.add_header("MCP-Protocol-Version", "2025-11-25")
+    req.add_header("Accept", "application/json, text/event-stream")
+    if sid:
+        req.add_header("Mcp-Session-Id", sid)
+    resp = urllib.request.urlopen(req, timeout=120)
+    hdr_sid = resp.headers.get("Mcp-Session-Id")
+    out = None
+    for line in resp.read().decode().splitlines():
+        line = line.strip()
+        if line.startswith("data:"):
+            line = line[5:].strip()
+        if not line:
+            continue
+        try:
+            out = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+    return out, hdr_sid
+
+def call(url, token, sid, name, args):
+    body = {"jsonrpc": "2.0", "id": 99, "method": "tools/call",
+            "params": {"name": name, "arguments": args}}
+    d, _ = _post(url, token, sid, body)
+    r = (d or {}).get("result", {})
+    return r
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--state-dir", default=".dir2mcp")
+    ap.add_argument("--question", action="append", default=[])
+    a = ap.parse_args()
+    conn = json.load(open(os.path.join(a.state_dir, "connection.json")))
+    url = conn["url"]
+    token = open(os.path.join(a.state_dir, "secret.token")).read().strip()
+    questions = a.question or [
+        "What powers does the BVI Financial Investigation Agency have? Cite sections.",
+        "What entities are subject to BVI economic substance requirements?",
+        "Under what circumstances must a financial institution file a suspicious transaction report in the BVI? Include the section number.",
+    ]
+    _, sid = _post(url, token, None, {"jsonrpc":"2.0","id":1,"method":"initialize",
+        "params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"release-smoke","version":"1"}}})
+    fails = []
+    def check(name, ok, detail=""):
+        print(f"  [{'PASS' if ok else 'FAIL'}] {name}{(' — '+detail) if detail else ''}")
+        if not ok: fails.append(name)
+
+    print(f"dir2mcp release smoke @ {url}")
+    # 1. stats
+    r = call(url, token, sid, "dir2mcp_stats", {})
+    ix = r.get("structuredContent", {}).get("indexing", {})
+    check("stats: indexing stopped", ix.get("running") is False, f"running={ix.get('running')}")
+    check("stats: errors==0", ix.get("errors", -1) == 0, f"errors={ix.get('errors')}")
+    check("stats: embedded_ok>0", ix.get("embedded_ok", 0) > 0, f"embedded_ok={ix.get('embedded_ok')}")
+    # 2. ask
+    for q in questions:
+        r = call(url, token, sid, "dir2mcp_ask", {"question": q, "k": 8})
+        if r.get("isError"):
+            check(f"ask: {q[:42]}…", False, "tool error"); continue
+        sc = r.get("structuredContent", {})
+        ans = (sc.get("answer") or "").strip()
+        cites = sc.get("citations") or []
+        check(f"ask: {q[:42]}…", bool(ans) and len(cites) >= 1, f"answer={len(ans)}c citations={len(cites)}")
+    # 3. search
+    r = call(url, token, sid, "dir2mcp_search", {"query": "financial investigation agency powers", "k": 5})
+    hits = r.get("structuredContent", {}).get("hits", []) if not r.get("isError") else []
+    check("search: >=1 hit", len(hits) >= 1, f"hits={len(hits)}")
+    # 4. open_file (real pdf, page 1)
+    lf = call(url, token, sid, "dir2mcp_list_files", {"glob": "*.pdf", "limit": 1})
+    files = lf.get("structuredContent", {}).get("files", [])
+    if files:
+        rp = files[0]["rel_path"]
+        of = call(url, token, sid, "dir2mcp_open_file", {"rel_path": rp, "page": 1})
+        txt = (of.get("content") or [{}])[0].get("text", "") if not of.get("isError") else ""
+        check(f"open_file page=1 ({rp[:30]}…)", not of.get("isError") and len(txt.strip()) > 0, "tool error" if of.get("isError") else f"{len(txt)}c")
+    else:
+        check("open_file: a pdf exists to test", False)
+
+    print(f"\n{'✅ ALL PASS' if not fails else '❌ FAILED: ' + ', '.join(fails)}")
+    sys.exit(1 if fails else 0)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Why
`make check`/`make ci` validate code but never exercise the **live retrieval surface** (`ask`/`search`/`open_file`) — which broke repeatedly across v0.9.x and only surfaced when a human asked the Claude client:
- #364 empty embeddings, #376 docling `--output -`, #381 docling probe/bare-binary/cap, #373 BM25 NULL, #383 open_file page on docling PDFs.

Every one of those would have been caught by actually running the stas-legal guide's verification questions through an MCP client before shipping.

## What
`scripts/release_smoke.py` — speaks the MCP streamable-HTTP protocol to a **running** dir2mcp daemon and asserts:
- `stats`: indexing stopped, `errors==0`, `embedded_ok>0`
- `ask` (each question): non-empty answer **and ≥1 citation**, no tool error
- `search`: ≥1 hit
- `open_file(real pdf, page=1)`: non-empty, non-binary text

Exits non-zero on any failure. Questions are overridable via `--question`.

Wired as `make release-smoke STATE_DIR=…` and documented in CLAUDE.md's Releasing section as a **pre-tag gate**: build the candidate binary, reindex a representative corpus on it, wait for `pending=0`, then run the gate; don't tag unless all-pass. It needs a live daemon + provider creds, so it's a manual gate (not in `make ci`).

## Verification
- **Fails** on a 0.9.6 daemon (correctly catches the missing #383 open_file fix).
- **All-pass** on a v0.9.7 daemon against the stas-legal corpus (3 cited answers, 5 search hits, open_file page text).

`test-release-tools` only runs `test_*.py`, so this script is ignored there; `make check` stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new pre-release smoke check for live release candidates.
  * Release instructions now include a manual end-to-end validation flow before tagging.

* **Bug Fixes**
  * Added checks that verify indexing has finished, no errors occurred, search returns results, and file text extraction works as expected.
  * The smoke check now fails clearly if any live retrieval path does not behave correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->