### PR TITLE
mcp: declare modality/media_ref in hit outputSchema — fixes 'Failed to call tool' for search/ask (#387)

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2709,6 +2709,14 @@ func hitDefinitionSchema() map[string]interface{} {
 			"score":    map[string]interface{}{"type": "number"},
 			"snippet":  map[string]interface{}{"type": "string"},
 			"span":     map[string]interface{}{"$ref": "#/definitions/Span"},
+			// modality and media_ref are emitted by serializeHit for media /
+			// multimodal chunks (SPEC 8.1.7). They MUST be declared here: the hit
+			// object is additionalProperties:false, so an undeclared field makes a
+			// strict MCP client (Claude Desktop validates structuredContent against
+			// outputSchema) reject the whole result with "Failed to call tool" —
+			// the search/ask failures on docling corpora (issue #387).
+			"modality":  map[string]interface{}{"type": "string"},
+			"media_ref": map[string]interface{}{"type": "string"},
 		},
 		"required": []string{"chunk_id", "rel_path", "score", "snippet", "span"},
 	}

--- a/internal/mcp/tools_internal_test.go
+++ b/internal/mcp/tools_internal_test.go
@@ -3,7 +3,36 @@ package mcp
 import (
 	"strings"
 	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
 )
+
+// TestSerializeHitKeysDeclaredInSchema guards against serializer/outputSchema
+// drift on search/ask hits (issue #387). The hit object is
+// additionalProperties:false, so any key serializeHit emits that the schema does
+// not declare makes a strict MCP client (Claude Desktop validates
+// structuredContent against outputSchema) reject the whole result with "Failed
+// to call tool". A media/multimodal hit exercises the conditional fields
+// (modality, media_ref) that were previously missing from the schema.
+func TestSerializeHitKeysDeclaredInSchema(t *testing.T) {
+	hit := model.SearchHit{
+		ChunkID: 1, RelPath: "a.pdf", Title: "A", DocType: "pdf", RepType: "extracted_markdown",
+		Score: 0.5, Snippet: "x",
+		Span:     model.Span{Kind: "region", Region: &model.RegionSpan{StartPage: 1, EndPage: 1}},
+		Modality: "text", MediaRef: "a.pdf",
+	}
+	out := serializeHit(hit)
+	props, ok := hitDefinitionSchema()["properties"].(map[string]interface{})
+	if !ok {
+		t.Fatal("hitDefinitionSchema has no properties map")
+	}
+	for k := range out {
+		if _, declared := props[k]; !declared {
+			t.Errorf("serializeHit emits %q but hitDefinitionSchema does not declare it "+
+				"(additionalProperties:false → strict MCP clients reject the result)", k)
+		}
+	}
+}
 
 // TestLooksLikeBinaryContent exercises the heuristic upgrade landed for
 // PR #180: NUL-byte detection alone misses binary formats (mp3 frames, some


### PR DESCRIPTION
## The actual cause of "Failed to call tool"
In Claude Desktop, `dir2mcp_search`/`dir2mcp_ask`/`open_file` failed **immediately** with **"Failed to call tool"** while `stats`/`list_files` worked — even though the daemon was healthy (direct curl → HTTP 200 with a full cited answer in ~3s; `make release-smoke` all-pass; the `mcp-remote` bridge log shows the full response coming back).

Strict MCP clients (Claude Desktop) **validate `structuredContent` against the tool's `outputSchema`** and reject the whole result on any violation. `hitDefinitionSchema` is `additionalProperties: false` and declares chunk_id, rel_path, title, doc_type, rep_type, score, snippet, span — but `serializeHit` also emits **`modality`** and **`media_ref`** (conditionally, SPEC 8.1.7). Those undeclared fields fail validation → "Failed to call tool". `stats`/`list_files` passed because their content matched their schemas; **curl and the smoke test never caught it because they don't validate against `outputSchema` — only the client does.** That's why the server looked perfectly healthy while Claude kept failing.

Confirmed live with `jsonschema` against the running daemon: every `ask`/`search` hit raised `Additional properties are not allowed ('modality' was unexpected)`. After the fix, `ask`, `search`, and `open_file` structuredContent **all validate**.

## Fix
- Declare `modality` + `media_ref` (string) in `hitDefinitionSchema`.
- Add `TestSerializeHitKeysDeclaredInSchema`: asserts every key `serializeHit` can emit is declared in the hit schema, so serializer/outputSchema drift can't recur.

`make check` green.

Closes #387.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Structured search/ask results now accept additional optional multimodal fields, reducing schema validation issues.
  * Result serialization now stays aligned with the declared schema, preventing unexpected output keys.

* **Tests**
  * Added coverage to ensure serialized hit data only includes fields allowed by the schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->