### PR TITLE
mcp: render snippets in search / search-only content text (#390)

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -818,7 +818,7 @@ func (s *Server) handleSearchTool(ctx context.Context, args map[string]interface
 		"hits": serializeSearchHits(hits), "indexing_complete": indexingComplete,
 	}
 	return toolCallResult{
-		Content:           []toolContentItem{{Type: "text", Text: fmt.Sprintf("found %d result(s)", len(hits))}},
+		Content:           []toolContentItem{{Type: "text", Text: renderSearchHitsText(hits, "result")}},
 		StructuredContent: structured,
 	}, nil
 }
@@ -1770,7 +1770,7 @@ func (s *Server) runSearchOnlyMode(ctx context.Context, question string, sq mode
 		"indexing_complete": indexingComplete,
 	}
 	return toolCallResult{
-		Content:           []toolContentItem{{Type: "text", Text: fmt.Sprintf("found %d supporting result(s)", len(hits))}},
+		Content:           []toolContentItem{{Type: "text", Text: renderSearchHitsText(hits, "supporting result")}},
 		StructuredContent: structured,
 	}, nil
 }
@@ -2578,6 +2578,34 @@ func serializeHit(h model.SearchHit) map[string]interface{} {
 		out["media_ref"] = mediaRef
 	}
 	return out
+}
+
+// renderSearchHitsText renders hits into a readable text block for a tool's
+// content payload. structuredContent carries the full machine-readable hits, but
+// a model that reads the content text (as Claude Desktop does) previously saw
+// only a bare count ("found N result(s)") with none of the matched text — so it
+// could not read or cite search results without a follow-up open_file, and
+// search-only mode looked like it "returned only counts". Each entry carries the
+// document (title + rel_path), score, and the snippet so the block is
+// self-sufficient. structuredContent is unchanged.
+func renderSearchHitsText(hits []model.SearchHit, noun string) string {
+	if len(hits) == 0 {
+		return fmt.Sprintf("found 0 %s(s)", noun)
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "found %d %s(s):", len(hits), noun)
+	for i, h := range hits {
+		loc := h.RelPath
+		if t := strings.TrimSpace(h.Title); t != "" {
+			loc = fmt.Sprintf("%s (%s)", t, h.RelPath)
+		}
+		snippet := strings.Join(strings.Fields(h.Snippet), " ")
+		if len(snippet) > 600 {
+			snippet = snippet[:600] + "…"
+		}
+		fmt.Fprintf(&b, "\n\n%d. %s — score %.3f\n%s", i+1, loc, h.Score, snippet)
+	}
+	return b.String()
 }
 
 func serializeSearchHits(hits []model.SearchHit) []map[string]interface{} {

--- a/internal/mcp/tools_internal_test.go
+++ b/internal/mcp/tools_internal_test.go
@@ -7,6 +7,25 @@ import (
 	"github.com/dirstral/dir2mcp/internal/model"
 )
 
+// TestRenderSearchHitsTextIncludesSnippets guards that the search / search-only
+// content text carries each hit's document and snippet, not just a count. A bare
+// "found N result(s)" (the old behavior) left a model that reads the content
+// block unable to see or cite the matches — it looked like search "returned only
+// counts" even though structuredContent had the data.
+func TestRenderSearchHitsTextIncludesSnippets(t *testing.T) {
+	out := renderSearchHitsText([]model.SearchHit{
+		{RelPath: "a.pdf", Title: "Act A", Score: 0.5, Snippet: "the operative clause text"},
+	}, "result")
+	for _, want := range []string{"found 1 result(s)", "Act A", "a.pdf", "the operative clause text"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("rendered search text missing %q:\n%s", want, out)
+		}
+	}
+	if got := renderSearchHitsText(nil, "result"); got != "found 0 result(s)" {
+		t.Errorf("empty hits: got %q, want %q", got, "found 0 result(s)")
+	}
+}
+
 // TestSerializeHitKeysDeclaredInSchema guards against serializer/outputSchema
 // drift on search/ask hits (issue #387). The hit object is
 // additionalProperties:false, so any key serializeHit emits that the schema does

--- a/scripts/release_smoke.py
+++ b/scripts/release_smoke.py
@@ -58,11 +58,16 @@ def is_texty(s):
 
 
 def _resolve_ref(ref, root):
+    # Fail closed: a typo'd ref ('#/definitions/Hti') must surface as an error,
+    # not silently resolve to {} (which would validate as success and skip the
+    # nested checks). Returns None when the ref is malformed or unresolvable.
+    if not isinstance(ref, str) or not ref.startswith("#/"):
+        return None
     node = root
     for part in ref.lstrip("#/").split("/"):
-        if not isinstance(node, dict):
-            return {}
-        node = node.get(part, {})
+        if not isinstance(node, dict) or part not in node:
+            return None
+        node = node[part]
     return node
 
 
@@ -76,7 +81,10 @@ def schema_errors(schema, inst, root, path="$"):
     if not isinstance(schema, dict):
         return []
     if "$ref" in schema:
-        return schema_errors(_resolve_ref(schema["$ref"], root), inst, root, path)
+        target = _resolve_ref(schema["$ref"], root)
+        if target is None:
+            return [f"{path}: unresolved $ref {schema['$ref']!r}"]
+        return schema_errors(target, inst, root, path)
     if "oneOf" in schema:
         matches = [s for s in schema["oneOf"] if not schema_errors(s, inst, root, path)]
         return [] if len(matches) == 1 else [f"{path}: matched {len(matches)} oneOf branches (want 1)"]
@@ -109,9 +117,16 @@ def schema_errors(schema, inst, root, path="$"):
             for i, v in enumerate(inst):
                 errs += schema_errors(items, v, root, f"{path}[{i}]")
         return errs
-    scal = {"string": str, "integer": int, "number": (int, float), "boolean": bool}
-    if t in scal and not isinstance(inst, scal[t]):
-        return [f"{path}: expected {t}"]
+    # bool is a subclass of int in Python, so guard integer/number explicitly —
+    # else True/False would pass where strict JSON Schema rejects them.
+    if t == "string" and not isinstance(inst, str):
+        return [f"{path}: expected string"]
+    if t == "integer" and (not isinstance(inst, int) or isinstance(inst, bool)):
+        return [f"{path}: expected integer"]
+    if t == "number" and (not isinstance(inst, (int, float)) or isinstance(inst, bool)):
+        return [f"{path}: expected number"]
+    if t == "boolean" and not isinstance(inst, bool):
+        return [f"{path}: expected boolean"]
     return []
 
 
@@ -246,13 +261,23 @@ def run_checks(client, questions):
         schemas = {}
         check("tools/list (for schema validation)", False, str(e)[:80])
 
+    # Returns True when the response is safe to read downstream — either the tool
+    # declares no outputSchema (so strict clients don't validate it either; stats
+    # is one) or its structuredContent conforms. Returns False (and records a
+    # FAIL) when a declared schema is present but the content is missing or
+    # non-conforming, so callers can skip interpreting an already-rejected result.
     def validate(tool, r):
-        sch, sc = schemas.get(tool), r.get("structuredContent")
-        if not sch or sc is None:
-            return
+        sch = schemas.get(tool)
+        if not sch:
+            return True
+        sc = r.get("structuredContent")
+        if sc is None:
+            check(f"{tool}: structuredContent present (schema declared)", False, "missing structuredContent")
+            return False
         errs = schema_errors(sch, sc, sch)
         check(f"{tool}: structuredContent conforms to outputSchema",
               not errs, "ok" if not errs else f"{len(errs)} err — {errs[0][:90]}")
+        return not errs
 
     r = client.call("dir2mcp_stats", {})
     validate("dir2mcp_stats", r)
@@ -266,7 +291,8 @@ def run_checks(client, questions):
         if r.get("isError"):
             check(f"ask: {q[:42]}…", False, "tool error")
             continue
-        validate("dir2mcp_ask", r)
+        if not validate("dir2mcp_ask", r):
+            continue  # schema already failed; don't read fields off a rejected result
         sc = r.get("structuredContent", {})
         ans = (sc.get("answer") or "").strip()
         cites = sc.get("citations") or []
@@ -278,7 +304,8 @@ def run_checks(client, questions):
     check("search: >=1 hit", len(hits) >= 1, f"hits={len(hits)}")
 
     lf = client.call("dir2mcp_list_files", {"glob": "*.pdf", "limit": 12})
-    validate("dir2mcp_list_files", lf)
+    if not validate("dir2mcp_list_files", lf):
+        return fails  # schema failed; the files list can't be trusted to drive open_file
     files = [f["rel_path"] for f in lf.get("structuredContent", {}).get("files", [])]
     if not files:
         check("open_file: a pdf exists to test", False)
@@ -293,7 +320,9 @@ def run_checks(client, questions):
         if of.get("isError"):
             last = "tool error"
             continue
-        validate("dir2mcp_open_file", of)
+        if not validate("dir2mcp_open_file", of):
+            last = "schema-nonconforming"
+            continue  # a rejected result is not a valid text page
         txt = (of.get("content") or [{}])[0].get("text", "")
         if is_texty(txt):
             opened = (rp, len(txt.strip()))

--- a/scripts/release_smoke.py
+++ b/scripts/release_smoke.py
@@ -57,6 +57,64 @@ def is_texty(s):
     return letters >= 0.6 * len(s)
 
 
+def _resolve_ref(ref, root):
+    node = root
+    for part in ref.lstrip("#/").split("/"):
+        if not isinstance(node, dict):
+            return {}
+        node = node.get(part, {})
+    return node
+
+
+def schema_errors(schema, inst, root, path="$"):
+    """Minimal JSON-Schema check for the subset the dir2mcp outputSchemas use
+    ($ref/oneOf/const/enum/object+additionalProperties+required/array/scalars).
+    Mirrors what a strict MCP client (Claude Desktop) does to structuredContent —
+    the check that would have caught #387 (a serialized field not declared in an
+    additionalProperties:false object). NOT a full validator; deliberately small
+    and dependency-free."""
+    if not isinstance(schema, dict):
+        return []
+    if "$ref" in schema:
+        return schema_errors(_resolve_ref(schema["$ref"], root), inst, root, path)
+    if "oneOf" in schema:
+        matches = [s for s in schema["oneOf"] if not schema_errors(s, inst, root, path)]
+        return [] if len(matches) == 1 else [f"{path}: matched {len(matches)} oneOf branches (want 1)"]
+    if "const" in schema:
+        return [] if inst == schema["const"] else [f"{path}: {inst!r} != const {schema['const']!r}"]
+    if "enum" in schema:
+        return [] if inst in schema["enum"] else [f"{path}: {inst!r} not in enum"]
+    t = schema.get("type")
+    if t == "object" or (t is None and "properties" in schema):
+        if not isinstance(inst, dict):
+            return [f"{path}: expected object"]
+        errs, props = [], schema.get("properties", {})
+        for req in schema.get("required", []):
+            if req not in inst:
+                errs.append(f"{path}.{req}: required property missing")
+        addl = schema.get("additionalProperties", True)
+        for k, v in inst.items():
+            if k in props:
+                errs += schema_errors(props[k], v, root, f"{path}.{k}")
+            elif addl is False:
+                errs.append(f"{path}.{k}: additional property not allowed by schema")
+            elif isinstance(addl, dict):
+                errs += schema_errors(addl, v, root, f"{path}.{k}")
+        return errs
+    if t == "array":
+        if not isinstance(inst, list):
+            return [f"{path}: expected array"]
+        items, errs = schema.get("items"), []
+        if items:
+            for i, v in enumerate(inst):
+                errs += schema_errors(items, v, root, f"{path}[{i}]")
+        return errs
+    scal = {"string": str, "integer": int, "number": (int, float), "boolean": bool}
+    if t in scal and not isinstance(inst, scal[t]):
+        return [f"{path}: expected {t}"]
+    return []
+
+
 class HTTPClient:
     """MCP over streamable-HTTP, directly to the daemon."""
 
@@ -93,6 +151,11 @@ class HTTPClient:
         d, _ = self._post({"jsonrpc": "2.0", "id": 99, "method": "tools/call",
                            "params": {"name": name, "arguments": args}})
         return _result_or_error(d)
+
+    def list_tools(self):
+        d, _ = self._post({"jsonrpc": "2.0", "id": 50, "method": "tools/list", "params": {}})
+        res = _result_or_error(d)
+        return {t["name"]: t.get("outputSchema") for t in (res.get("tools") or [])}
 
     def close(self):
         pass
@@ -151,6 +214,13 @@ class StdioClient:
         # returned a result; _result_or_error surfaces it as a tool error.
         return _result_or_error(self._read_until(rid, timeout=120))
 
+    def list_tools(self):
+        self._id += 1
+        rid = self._id
+        self._send({"jsonrpc": "2.0", "id": rid, "method": "tools/list", "params": {}})
+        res = _result_or_error(self._read_until(rid, timeout=60))
+        return {t["name"]: t.get("outputSchema") for t in (res.get("tools") or [])}
+
     def close(self):
         try:
             self.proc.terminate()
@@ -165,7 +235,27 @@ def run_checks(client, questions):
         if not ok:
             fails.append(name)
 
+    # Fetch each tool's declared outputSchema once. Strict MCP clients (Claude
+    # Desktop) validate structuredContent against it and reject the whole call on
+    # any mismatch — see #387, where a serialized hit field (modality) absent from
+    # an additionalProperties:false schema made search/ask fail with "Failed to
+    # call tool" while curl and this gate (which formerly didn't validate) passed.
+    try:
+        schemas = client.list_tools()
+    except Exception as e:
+        schemas = {}
+        check("tools/list (for schema validation)", False, str(e)[:80])
+
+    def validate(tool, r):
+        sch, sc = schemas.get(tool), r.get("structuredContent")
+        if not sch or sc is None:
+            return
+        errs = schema_errors(sch, sc, sch)
+        check(f"{tool}: structuredContent conforms to outputSchema",
+              not errs, "ok" if not errs else f"{len(errs)} err — {errs[0][:90]}")
+
     r = client.call("dir2mcp_stats", {})
+    validate("dir2mcp_stats", r)
     ix = r.get("structuredContent", {}).get("indexing", {})
     check("stats: indexing stopped", ix.get("running") is False, f"running={ix.get('running')}")
     check("stats: errors==0", ix.get("errors", -1) == 0, f"errors={ix.get('errors')}")
@@ -176,16 +266,19 @@ def run_checks(client, questions):
         if r.get("isError"):
             check(f"ask: {q[:42]}…", False, "tool error")
             continue
+        validate("dir2mcp_ask", r)
         sc = r.get("structuredContent", {})
         ans = (sc.get("answer") or "").strip()
         cites = sc.get("citations") or []
         check(f"ask: {q[:42]}…", bool(ans) and len(cites) >= 1, f"answer={len(ans)}c citations={len(cites)}")
 
     r = client.call("dir2mcp_search", {"query": "financial investigation agency powers", "k": 5})
+    validate("dir2mcp_search", r)
     hits = r.get("structuredContent", {}).get("hits", []) if not r.get("isError") else []
     check("search: >=1 hit", len(hits) >= 1, f"hits={len(hits)}")
 
     lf = client.call("dir2mcp_list_files", {"glob": "*.pdf", "limit": 12})
+    validate("dir2mcp_list_files", lf)
     files = [f["rel_path"] for f in lf.get("structuredContent", {}).get("files", [])]
     if not files:
         check("open_file: a pdf exists to test", False)
@@ -200,6 +293,7 @@ def run_checks(client, questions):
         if of.get("isError"):
             last = "tool error"
             continue
+        validate("dir2mcp_open_file", of)
         txt = (of.get("content") or [{}])[0].get("text", "")
         if is_texty(txt):
             opened = (rp, len(txt.strip()))


### PR DESCRIPTION
Closes #390.

## Why
`dir2mcp_search` (and `ask mode=search_only`) put only `found N result(s)` in the model-readable `content` block; the snippets were in `structuredContent` only. A model that reads the content block (Claude Desktop) saw a count with no text — *"search finds matches but returns only counts"* in the transcript — and couldn't cite without extra round-trips.

## What
- `renderSearchHitsText`: `found N result(s):` then per hit `Title (rel_path) — score X.XXX` + bounded, whitespace-collapsed snippet.
- Wired into both `handleSearchTool` and `runSearchOnlyMode`.
- `structuredContent` unchanged (contract preserved). Regression test added.

## Verified
Live daemon: search content now shows e.g. *"18. (1) An employee … report a suspicious activity … to a Reporting Officer"* and *"17. (1) A Reporting Officer shall make a report to the Agency …"* with doc + score — the text the model was missing. `make check` green.

Separate from #387 (which fixed `ask` returning at all). file_glob was verified working; the transcript's "intermittent/glob" lines were narrative carryover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)