### PR TITLE
server: deterministic per-corpus listen port — stop the bridge URL drifting (#386)

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"crypto/sha256"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -202,11 +204,35 @@ func preferredListenAddr(listenAddr, stateDir string) string {
 		// Explicit port (operator pinned it) or unparseable: respect as-is.
 		return listenAddr
 	}
-	prev := readPreviousListenPort(stateDir)
-	if prev == "" || prev == "0" {
-		return listenAddr
+	// Prefer the port a previous run recorded in connection.json (#368).
+	if prev := readPreviousListenPort(stateDir); prev != "" && prev != "0" {
+		return net.JoinHostPort(host, prev)
 	}
-	return net.JoinHostPort(host, prev)
+	// No recorded port — e.g. a fresh corpus, or after `down`/`rm -rf .dir2mcp`
+	// (which the setup guide runs) removed connection.json. Derive a port that is
+	// deterministic for this corpus instead of letting :0 pick a fresh random one
+	// every time, so the URL baked into the client config stays valid across
+	// reinstalls and the bridge does not silently strand (#386).
+	if dp := deterministicPort(stateDir); dp != "" {
+		return net.JoinHostPort(host, dp)
+	}
+	return listenAddr
+}
+
+// deterministicPort maps a corpus's state directory to a stable port in the IANA
+// dynamic/private range (49152–65535) via a hash of its absolute path. The same
+// corpus binds the same port across restarts even with no prior connection.json;
+// distinct corpora almost always differ. bindServerListener still falls back to
+// an ephemeral port if this one is taken, so startup never fails. Returns "" when
+// the path can't be resolved (caller then keeps the ephemeral :0).
+func deterministicPort(stateDir string) string {
+	abs, err := filepath.Abs(strings.TrimSpace(stateDir))
+	if err != nil || abs == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(abs))
+	const base, span = 49152, 16384 // 49152..65535 inclusive
+	return strconv.Itoa(base + int(binary.BigEndian.Uint16(sum[:2]))%span)
 }
 
 // rotateLogIfLarge renames an oversized log file to "<path>.1" so the

--- a/internal/cli/server_log_tee_internal_test.go
+++ b/internal/cli/server_log_tee_internal_test.go
@@ -6,8 +6,10 @@ import (
 	"encoding/json"
 	"io"
 	"log"
+	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -46,10 +48,14 @@ func TestPreferredListenAddr(t *testing.T) {
 		}
 	})
 
-	t.Run("ephemeral with no prior connection stays ephemeral", func(t *testing.T) {
-		got := preferredListenAddr("127.0.0.1:0", t.TempDir())
-		if got != "127.0.0.1:0" {
-			t.Fatalf("want ephemeral 127.0.0.1:0 with no prior port, got %q", got)
+	t.Run("ephemeral with no prior connection uses a deterministic per-corpus port", func(t *testing.T) {
+		// No connection.json (fresh corpus, or after down/rm) must NOT drift to a
+		// fresh random port — it should bind a stable port derived from the state
+		// dir so the baked client URL keeps working across reinstalls (#386).
+		stateDir := t.TempDir()
+		want := net.JoinHostPort("127.0.0.1", deterministicPort(stateDir))
+		if got := preferredListenAddr("127.0.0.1:0", stateDir); got != want {
+			t.Fatalf("want deterministic %q, got %q", want, got)
 		}
 	})
 
@@ -67,6 +73,24 @@ func TestPreferredListenAddr(t *testing.T) {
 			t.Fatalf("want sticky 127.0.0.1:58210 from prior connection.json, got %q", got)
 		}
 	})
+}
+
+// TestDeterministicPort covers the per-corpus port derivation (#386): stable for
+// a given state dir, inside the IANA dynamic range, and corpus-specific so two
+// corpora almost never collide.
+func TestDeterministicPort(t *testing.T) {
+	a := t.TempDir()
+	p := deterministicPort(a)
+	if p == "" || p != deterministicPort(a) {
+		t.Fatalf("deterministicPort not stable for %q: %q", a, p)
+	}
+	n, err := strconv.Atoi(p)
+	if err != nil || n < 49152 || n > 65535 {
+		t.Fatalf("port %q outside dynamic range 49152-65535", p)
+	}
+	if other := deterministicPort(t.TempDir()); other == p {
+		t.Errorf("distinct corpora collided on port %q", p)
+	}
 }
 
 // TestTeeServerLog_WritesToServerLogInForeground verifies that a foreground /


### PR DESCRIPTION
## Why
Recurring **"Failed to call tool"** for *every* tool while the daemon is healthy = the `bunx mcp-remote` bridge baked into the client config points at a stale port. Root mechanism: `listen_addr` defaults to ephemeral `:0`; `preferredListenAddr` reuses the port recorded in `connection.json` (#368), but **`down` / `rm -rf .dir2mcp` deletes connection.json** (exactly what the setup guide tells users to run), so the next `up` has no record and `:0` picks a *fresh random* port → the baked URL goes stale with no signal but `ECONNREFUSED`.

## Fix
When `listen_addr` is `:0` **and** there is no recorded prior port, derive a **deterministic port from a hash of the corpus's absolute state-dir path** (IANA dynamic range 49152–65535). The same corpus then binds the same port across restarts/reinstalls, so the client URL stays valid.

Selection order (unchanged except the new default):
1. explicit pinned port (operator set `listen_addr: host:NNNN`) → respected
2. prior port recorded in `connection.json` (#368) → reused
3. **deterministic per-corpus port (new)** → the `:0` default
4. `bindServerListener` still falls back to an ephemeral port if the chosen one is taken → startup never fails

## Tests
`deterministicPort` is stable for a given state dir, inside the dynamic range, and corpus-specific; `preferredListenAddr` returns the deterministic port when there's no connection.json, still respects an explicit pin, and still reuses a recorded port. `make check` green.

No spec change: SPEC §4.3 governs `connection.json`'s format (unchanged here), not port *selection* — a local daemon impl detail.

Closes #386.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daemon startup so it uses a stable port for a given state directory when an ephemeral port is requested and no saved port is available.
  * This helps avoid changing ports unexpectedly between runs while still staying within the standard dynamic/private port range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->