### PR TITLE
fix(mcp): degrade empty/unknown span kind to schema-valid document variant (#397)

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2366,8 +2366,13 @@ func buildOpenFileSpan(span model.Span) map[string]interface{} {
 	case "region":
 		return buildRegionSpan(span)
 	default:
+		// An empty or unknown kind (e.g. a BM25 hit on a cache miss whose
+		// Span.Kind is "") matches none of the Span oneOf branches in the
+		// outputSchema, so echoing it (or "") makes strict MCP clients reject
+		// the whole tool result ("Failed to call tool", issue #397). Degrade to
+		// the schema-valid "document" variant, which requires only kind.
 		return map[string]interface{}{
-			"kind": kind,
+			"kind": "document",
 		}
 	}
 }

--- a/internal/mcp/tools_internal_test.go
+++ b/internal/mcp/tools_internal_test.go
@@ -150,6 +150,82 @@ func TestBinaryContentMessageForDocType(t *testing.T) {
 	}
 }
 
+// spanMatchesOneOf reports how many of the Span schema's oneOf branches the
+// given rendered span satisfies. A schema-valid span must match exactly one.
+// Each branch is a const-kind object with additionalProperties:false, so the
+// check is: kind const matches, every required key is present, and the span
+// emits no key the branch does not declare.
+func spanMatchesOneOf(t *testing.T, span map[string]interface{}) int {
+	t.Helper()
+	branches, ok := spanDefinitionSchema()["oneOf"].([]interface{})
+	if !ok {
+		t.Fatal("spanDefinitionSchema has no oneOf list")
+	}
+	matched := 0
+	for _, b := range branches {
+		branch, ok := b.(map[string]interface{})
+		if !ok {
+			t.Fatalf("oneOf branch is not an object: %T", b)
+		}
+		props, _ := branch["properties"].(map[string]interface{})
+		kindSchema, _ := props["kind"].(map[string]interface{})
+		if span["kind"] != kindSchema["const"] {
+			continue
+		}
+		ok = true
+		if reqs, hasReq := branch["required"].([]string); hasReq {
+			for _, r := range reqs {
+				if _, present := span[r]; !present {
+					ok = false
+					break
+				}
+			}
+		}
+		if ok {
+			for k := range span {
+				if _, declared := props[k]; !declared {
+					ok = false
+					break
+				}
+			}
+		}
+		if ok {
+			matched++
+		}
+	}
+	return matched
+}
+
+// TestBuildOpenFileSpan_EmptyAndUnknownKindFallback pins the fix for issue #397:
+// a span with an empty or unknown Kind (e.g. a BM25 hit on a cache miss whose
+// Span.Kind is "") must degrade to the schema-valid "document" variant rather
+// than echoing {"kind":""} (or {"kind":"<unknown>"}), which matches none of the
+// Span oneOf branches and makes a strict MCP client (Claude Desktop validates
+// structuredContent against outputSchema) reject the whole result with "Failed
+// to call tool".
+func TestBuildOpenFileSpan_EmptyAndUnknownKindFallback(t *testing.T) {
+	cases := []struct {
+		name string
+		kind string
+	}{
+		{name: "empty kind", kind: ""},
+		{name: "whitespace kind", kind: "   "},
+		{name: "unknown kind", kind: "bogus"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildOpenFileSpan(model.Span{Kind: tc.kind})
+			if got["kind"] != "document" || len(got) != 1 {
+				t.Fatalf("buildOpenFileSpan(kind=%q) = %+v, want {\"kind\":\"document\"}", tc.kind, got)
+			}
+			if n := spanMatchesOneOf(t, got); n != 1 {
+				t.Fatalf("rendered span %+v matched %d Span oneOf branches, want exactly 1", got, n)
+			}
+		})
+	}
+}
+
 func preview(s string) string {
 	if len(s) <= 40 {
 		return s

--- a/tests/mcp/region_span_test.go
+++ b/tests/mcp/region_span_test.go
@@ -63,6 +63,20 @@ func TestBuildOpenFileSpan_RegionDegrades(t *testing.T) {
 	}
 }
 
+// TestBuildOpenFileSpan_EmptyKindDegradesToDocument pins the fix for issue #397:
+// a span with an empty (or unknown) Kind — as produced by a BM25 hit on a cache
+// miss — must render as the schema-valid {"kind":"document"} variant, not as
+// {"kind":""}, which matches no Span oneOf branch and makes a strict MCP client
+// reject the whole tool result ("Failed to call tool").
+func TestBuildOpenFileSpan_EmptyKindDegradesToDocument(t *testing.T) {
+	for _, kind := range []string{"", "   ", "totally-unknown"} {
+		got := mcp.BuildOpenFileSpan(model.Span{Kind: kind})
+		if got["kind"] != "document" || len(got) != 1 {
+			t.Errorf("BuildOpenFileSpan(kind=%q) = %+v, want {kind:document}", kind, got)
+		}
+	}
+}
+
 // TestBuildOpenFileSpan_ScalarKindsUnchanged guards that adding region did not
 // disturb the existing kinds.
 func TestBuildOpenFileSpan_ScalarKindsUnchanged(t *testing.T) {


### PR DESCRIPTION
## Problem

`buildOpenFileSpan`'s `default:` branch echoed the raw `kind` for any value not in `{lines,page,time,region}` — **including the empty string**. A BM25 hit on a cache miss can carry an empty `Span.Kind` (see the `if cached.Span.Kind != ""` guard in `internal/retrieval/hybrid.go`), and `serializeHit` unconditionally emits a span for every hit, so the result contained `{"kind":""}`.

That object matches **none** of the 5 const-kind branches in the `Span` `oneOf` (`spanDefinitionSchema`), and `span` is `required` in the `Hit` schema, so it cannot be omitted. A strict MCP client (Claude Desktop validates `structuredContent` against `outputSchema`) rejects the whole tool result with "Failed to call tool" — the same #387 class of failure.

## Fix

In `buildOpenFileSpan`'s default branch, degrade an empty or unknown kind to the `document` variant — a valid `oneOf` branch requiring only `kind`. We no longer echo an arbitrary/empty kind.

## Tests

- `internal/mcp`: `TestBuildOpenFileSpan_EmptyAndUnknownKindFallback` asserts the `{"kind":"document"}` fallback for empty, whitespace, and unknown kinds, and validates the rendered span matches **exactly one** `Span` `oneOf` branch (structural check against `spanDefinitionSchema`).
- `tests/mcp`: `TestBuildOpenFileSpan_EmptyKindDegradesToDocument` mirrors the existing region-span tests for the external surface.

## Verification

- `gofmt`, `go build ./...`, `go vet ./...` clean
- `go test ./internal/mcp/... ./tests/mcp/...` pass
- `make check` passes (after `git submodule update --init`)
- gocyclo: changed function stays well under 15

Closes #397.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved span handling so empty, whitespace-only, or unrecognized span types now safely fall back to a valid `document` span.
  * Reduced the chance of client-side validation errors when opening files with unexpected span data.

* **Tests**
  * Added coverage for empty and unknown span type cases to verify the fallback behavior remains consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->