### PR TITLE
fix(store,config): exclude quarantined chunks from BM25 + broaden default secret patterns

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -919,6 +919,16 @@ func Default() Config {
 			`(?i)(?:authorization\s*[:=]\s*bearer\s+|(?:access|id|refresh)_token\s*[:=]\s*)[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}`,
 			`(?i)token\s*[:=]\s*[A-Za-z0-9_.-]{20,}`,
 			`sk_[a-z0-9]{32}|api_[A-Za-z0-9]{32}`,
+			// OpenAI/Mistral-style hyphenated secret keys, e.g. "sk-proj-..."
+			// and "sk-...". Case-sensitive lowercase "sk-" prefix; the {20,}
+			// run of key chars keeps this from matching ordinary hyphenated
+			// prose (issue #443).
+			`sk-[A-Za-z0-9-]{20,}`,
+			// Generic provider-key assignment, e.g. "MISTRAL_API_KEY=<32 alnum>",
+			// "COHERE_API_KEY: ...", "GEMINI_API_KEY=...". Requires an
+			// uppercase provider prefix plus a 16+ char non-whitespace value so
+			// it gates real credentials without flagging plain text (issue #443).
+			`[A-Z][A-Z0-9_]*API_KEY\s*[:=]\s*\S{16,}`,
 		},
 		ElevenLabsAPIKey:     "",
 		ElevenLabsBaseURL:    "",

--- a/internal/store/sqlite_bm25.go
+++ b/internal/store/sqlite_bm25.go
@@ -28,6 +28,11 @@ import (
 // a vector-only fallback (returning zero results when the vector index was
 // empty). We now scan into sql.NullFloat64 and order NULL-scored rows LAST so a
 // missing score degrades a single hit's rank rather than failing the query.
+//
+// Quarantine filter (#439, F1): chunks the quality gate quarantined carry
+// embedding_status='error'. They must not surface via the lexical/hybrid path,
+// so the WHERE clause excludes them (embedding_status != 'error'). 'pending'
+// chunks remain searchable lexically (they need no embedding to match BM25).
 func (s *SQLiteStore) SearchBM25(ctx context.Context, query string, k int, indexKind string) ([]model.SearchHit, error) {
 	query = strings.TrimSpace(query)
 	if query == "" {
@@ -54,7 +59,8 @@ func (s *SQLiteStore) SearchBM25(ctx context.Context, query string, k int, index
 	         FROM chunks_fts
 	         JOIN chunks c ON c.chunk_id = chunks_fts.rowid
 	         LEFT JOIN documents d ON d.rel_path = c.rel_path
-	         WHERE chunks_fts MATCH ? AND c.deleted = 0`
+	         WHERE chunks_fts MATCH ? AND c.deleted = 0
+	               AND c.embedding_status != 'error'`
 	if kind := strings.TrimSpace(indexKind); kind != "" {
 		stmt += ` AND c.index_kind = ?`
 		args = append(args, kind)

--- a/tests/config/secret_patterns_test.go
+++ b/tests/config/secret_patterns_test.go
@@ -1,0 +1,62 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+)
+
+// anyMatch reports whether any of the compiled default secret patterns matches s.
+func anyMatch(t *testing.T, patterns []string, s string) bool {
+	t.Helper()
+	res, err := ingest.CompileSecretPatterns(patterns)
+	if err != nil {
+		t.Fatalf("CompileSecretPatterns: %v", err)
+	}
+	for _, re := range res {
+		if re.MatchString(s) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestDefaultSecretPatterns_MatchProviderKeys is a regression guard for #443:
+// the default scan patterns must catch real provider key formats — OpenAI/Mistral
+// hyphenated "sk-..." keys and "PROVIDER_API_KEY=<value>" assignments — which the
+// previous "sk_"/"api_" patterns missed entirely.
+func TestDefaultSecretPatterns_MatchProviderKeys(t *testing.T) {
+	patterns := config.Default().SecretPatterns
+
+	secrets := []string{
+		"sk-proj-abcdEFGH1234ijklMNOP5678qrstUVWX",
+		"sk-abcdEFGH1234ijklMNOP5678qrstUVWXyz90",
+		"MISTRAL_API_KEY=abcdEFGHijkl1234mnop5678QRST9012",
+		"COHERE_API_KEY: 0123456789abcdefABCDEF9876543210",
+		"GEMINI_API_KEY=AIzaSyA0123456789abcdefghijKLMNOP",
+	}
+	for _, s := range secrets {
+		if !anyMatch(t, patterns, s) {
+			t.Errorf("default secret patterns should match credential %q but did not", s)
+		}
+	}
+}
+
+// TestDefaultSecretPatterns_NoProseFalsePositives ensures the broadened patterns
+// stay surgical: ordinary documentation prose must not trip the scanner.
+func TestDefaultSecretPatterns_NoProseFalsePositives(t *testing.T) {
+	patterns := config.Default().SecretPatterns
+
+	prose := []string{
+		"The quick brown fox jumps over the lazy dog near the river.",
+		"Please ask the on-call engineer to rotate the deployment next week.",
+		"Set your API key by editing the configuration file in the dashboard.",
+		"This sentence mentions sk and api but contains no real credentials.",
+	}
+	for _, s := range prose {
+		if anyMatch(t, patterns, s) {
+			t.Errorf("default secret patterns false-positived on prose %q", s)
+		}
+	}
+}

--- a/tests/store/sqlite_bm25_quarantine_test.go
+++ b/tests/store/sqlite_bm25_quarantine_test.go
@@ -1,0 +1,76 @@
+package tests
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// TestSQLiteStore_SearchBM25_ExcludesQuarantined is a regression guard for #439
+// (F1): chunks the quality gate quarantined (embedding_status='error') must not
+// be returned by the lexical/hybrid path, even though the FTS index still
+// contains their terms. An 'ok' chunk matching the same term must still surface.
+func TestSQLiteStore_SearchBM25_ExcludesQuarantined(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "meta.sqlite")
+	st := store.NewSQLiteStore(dbPath)
+	defer func() { _ = st.Close() }()
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	const (
+		okLabel         uint64 = 1
+		quarantineLabel uint64 = 2
+	)
+	chunks := []struct {
+		label uint64
+		text  string
+	}{
+		{okLabel, "reporting suspicious transactions to the regulator"},
+		{quarantineLabel, "reporting officer training and qualifications"},
+	}
+	for _, c := range chunks {
+		task := model.NewChunkTask(c.label, c.text, "text", model.ChunkMetadata{
+			ChunkID: c.label,
+			RelPath: "docs/case.md",
+			DocType: "md",
+			RepType: "raw_text",
+		})
+		if err := st.UpsertChunkTask(ctx, task); err != nil {
+			t.Fatalf("UpsertChunkTask(%d): %v", c.label, err)
+		}
+	}
+
+	// Mark one chunk embedded ('ok') and quarantine the other ('error').
+	if err := st.MarkEmbedded(ctx, []uint64{okLabel}); err != nil {
+		t.Fatalf("MarkEmbedded: %v", err)
+	}
+	if err := st.MarkFailed(ctx, []uint64{quarantineLabel}, "quality gate quarantine"); err != nil {
+		t.Fatalf("MarkFailed: %v", err)
+	}
+
+	ls, ok := interface{}(st).(model.LexicalSearcher)
+	if !ok {
+		t.Fatalf("SQLiteStore must implement model.LexicalSearcher")
+	}
+
+	hits, err := ls.SearchBM25(ctx, "reporting", 10, "text")
+	if err != nil {
+		t.Fatalf("SearchBM25: %v", err)
+	}
+	if len(hits) != 1 {
+		t.Fatalf("expected exactly the 'ok' chunk to match, got %d hits: %+v", len(hits), hits)
+	}
+	if hits[0].ChunkID != okLabel {
+		t.Errorf("expected ok chunk %d, got chunk %d", okLabel, hits[0].ChunkID)
+	}
+	for _, h := range hits {
+		if h.ChunkID == quarantineLabel {
+			t.Errorf("quarantined chunk %d (embedding_status='error') must not appear in BM25 results", quarantineLabel)
+		}
+	}
+}


### PR DESCRIPTION
Two small, disjoint fixes in one PR.

## #439 (F1): quarantined garbage still served via BM25/hybrid
`internal/store/sqlite_bm25.go` `SearchBM25` filtered only on `c.deleted = 0`, with no embedding-status guard. Chunks the quality gate quarantined (`embedding_status='error'`) were still returned by the lexical/hybrid path and cited.

Fix: add `AND c.embedding_status != 'error'` to the WHERE clause. Quarantined chunks are now excluded; `'pending'` chunks (which need no embedding to match lexically) remain searchable. The FTS trigger is unchanged — the WHERE filter is the surgical fix.

This is only the BM25-quarantine-leak part of #439. The issue also tracks other heuristic items, so this PR **partially addresses #439 (F1: BM25 quarantine filter)** rather than closing it.

## #443: default secret-scan misses real provider key formats
`internal/config/config.go` default `SecretPatterns` matched `sk_`/`api_` but not OpenAI/Mistral `sk-...` (hyphen, mixed case) or `PROVIDER_API_KEY=<value>` assignments.

Fix: add two patterns to the defaults:
- `sk-[A-Za-z0-9-]{20,}` — OpenAI/Mistral hyphenated keys (e.g. `sk-proj-...`)
- `[A-Z][A-Z0-9_]*API_KEY\s*[:=]\s*\S{16,}` — generic `MISTRAL/COHERE/GEMINI_API_KEY` assignments

Both compile under Go's RE2 engine and stay surgical enough to avoid flagging ordinary prose. The 64KB scan-sample bound is intentionally left untouched (separate concern).

## Tests
- `tests/store/sqlite_bm25_quarantine_test.go`: asserts an `embedding_status='error'` chunk is NOT returned by `SearchBM25` while an `'ok'` chunk matching the same term IS.
- `tests/config/secret_patterns_test.go`: asserts the new defaults match `sk-proj-...` and `MISTRAL_API_KEY=<32chars>` (plus Cohere/Gemini shapes) and do NOT match ordinary sentences.

`gofmt`, `go build ./...`, `go vet`, and the focused `internal/store` / `internal/config` / `tests/store` / `tests/config` suites all pass, as does `make check` (the lone failure was a pre-existing uninitialized `dirstral-spec` submodule, unrelated to this change).

Closes #443.

🤖 Generated with [Claude Code](https://claude.com/claude-code)