### PR TITLE
mcp: route SDK transport tool calls through panic-recovery guard (#401)

### DIFF
--- a/internal/mcp/tool_panic_recovery_test.go
+++ b/internal/mcp/tool_panic_recovery_test.go
@@ -105,14 +105,14 @@ func TestSDKTransport_RecoversPanic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("server connect: %v", err)
 	}
-	defer serverSession.Close()
+	defer func() { _ = serverSession.Close() }()
 
 	client := sdkmcp.NewClient(&sdkmcp.Implementation{Name: "test-client", Version: "v0"}, nil)
 	clientSession, err := client.Connect(ctx, clientTransport, nil)
 	if err != nil {
 		t.Fatalf("client connect: %v", err)
 	}
-	defer clientSession.Close()
+	defer func() { _ = clientSession.Close() }()
 
 	// The call must return a normal (in-band) error result, not a transport
 	// error or a crashed daemon.

--- a/internal/mcp/tool_panic_recovery_test.go
+++ b/internal/mcp/tool_panic_recovery_test.go
@@ -2,7 +2,12 @@ package mcp
 
 import (
 	"context"
+	"strings"
 	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/protocol"
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // TestInvokeToolHandler_RecoversPanic verifies that a panicking tool handler is
@@ -65,5 +70,71 @@ func TestInvokeToolHandler_PassThrough(t *testing.T) {
 	}
 	if len(result.Content) != 1 || result.Content[0].Text != "ok" {
 		t.Fatalf("result not passed through unchanged: %+v", result)
+	}
+}
+
+// TestSDKTransport_RecoversPanic drives the *production* SDK transport closure
+// (buildSDKServer's AddTool handler) end-to-end: the go-sdk runs tool handlers in
+// a background goroutine with no recover of its own, so a panic that escapes the
+// closure crashes the whole daemon. Before the fix the closure called
+// td.handler directly, bypassing invokeToolHandler's recover guard on the default
+// (x402-off) path. This asserts a panicking handler now returns a clean isError
+// tool result instead of taking down the process. Regression for issue #401.
+func TestSDKTransport_RecoversPanic(t *testing.T) {
+	ctx := context.Background()
+
+	s := &Server{
+		cfg: config.Config{ServerName: "test"},
+		tools: map[string]toolDefinition{
+			protocol.ToolNameSearch: {
+				Name:         protocol.ToolNameSearch,
+				Description:  "panicking tool for test",
+				InputSchema:  map[string]interface{}{"type": "object"},
+				OutputSchema: map[string]interface{}{"type": "object"},
+				handler: func(context.Context, map[string]interface{}) (toolCallResult, *toolExecutionError) {
+					panic("synthetic handler panic via SDK transport")
+				},
+			},
+		},
+	}
+
+	sdkServer := s.buildSDKServer()
+
+	clientTransport, serverTransport := sdkmcp.NewInMemoryTransports()
+	serverSession, err := sdkServer.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	defer serverSession.Close()
+
+	client := sdkmcp.NewClient(&sdkmcp.Implementation{Name: "test-client", Version: "v0"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	defer clientSession.Close()
+
+	// The call must return a normal (in-band) error result, not a transport
+	// error or a crashed daemon.
+	res, err := clientSession.CallTool(ctx, &sdkmcp.CallToolParams{
+		Name:      protocol.ToolNameSearch,
+		Arguments: map[string]interface{}{},
+	})
+	if err != nil {
+		t.Fatalf("CallTool returned a transport error (handler panic not recovered): %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected an isError tool result after a handler panic, got %+v", res)
+	}
+
+	var text string
+	for _, c := range res.Content {
+		if tc, ok := c.(*sdkmcp.TextContent); ok {
+			text = tc.Text
+			break
+		}
+	}
+	if want := "INTERNAL_ERROR"; !strings.Contains(text, want) {
+		t.Fatalf("expected error result to mention %q, got %q", want, text)
 	}
 }

--- a/internal/mcp/transport_sdk.go
+++ b/internal/mcp/transport_sdk.go
@@ -397,7 +397,7 @@ func (s *Server) buildSDKServer() *sdkmcp.Server {
 					return nil, fmt.Errorf("invalid tool arguments: %w", err)
 				}
 			}
-			res, toolErr := td.handler(ctx, args)
+			res, toolErr := s.invokeToolHandler(ctx, td, td.Name, args)
 			if toolErr != nil {
 				res = newToolErrorResult(*toolErr)
 			}


### PR DESCRIPTION
## Problem

A panic in any MCP tool handler crashed the entire daemon on the default (x402-off) path.

The go-sdk runs tool handlers in a background goroutine with no `recover()` of its own. The SDK transport closure in `buildSDKServer` (`internal/mcp/transport_sdk.go`) called `td.handler(ctx, args)` **directly**, bypassing `invokeToolHandler` (`internal/mcp/tools.go`) which holds the `recover()` guard added for #356/#357. Only the x402-enabled path routed through `invokeToolHandler`, so the default path was unprotected and a single handler panic took down the process.

## Fix

- In the `buildSDKServer` `AddTool` closure, call `s.invokeToolHandler(ctx, td, td.Name, args)` instead of `td.handler(ctx, args)`. The `toolErr → newToolErrorResult` and `convertToolCallResult` handling stays equivalent, so a panicking handler now yields a clean `INTERNAL_ERROR` isError tool result on every transport path.
- Add `TestSDKTransport_RecoversPanic`, which drives the **production** SDK transport end-to-end (`buildSDKServer` + in-memory client/server sessions) against a panicking handler and asserts the call returns an isError result rather than crashing the process. The existing tests only covered `invokeToolHandler` directly.

## Verification

- `go build ./...`, `go vet ./...` clean
- `make fmt vet cyclo ineffassign misspell` clean (gocyclo under 15)
- `go test ./internal/mcp/... ./tests/mcp/...` passes

Closes #401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)