### PR TITLE
fix(cli): write Claude Desktop config atomically with 0600 perms

### DIFF
--- a/internal/cli/claude_cmd.go
+++ b/internal/cli/claude_cmd.go
@@ -403,13 +403,18 @@ func loadJSONFileOrEmpty(path string) (map[string]interface{}, error) {
 	return out, nil
 }
 
+// writeJSONFile serializes payload and writes it atomically with owner-only
+// (0600) permissions. Atomicity matters because this rewrites the user's whole
+// Claude Desktop config (containing *all* of their MCP servers): a truncate-in-
+// place write interrupted mid-stream would corrupt every entry, not just ours.
+// The 0600 mode keeps the embedded bearer token out of world-readable files.
 func writeJSONFile(path string, payload map[string]interface{}) error {
 	raw, err := json.MarshalIndent(payload, "", "  ")
 	if err != nil {
 		return err
 	}
 	raw = append(raw, '\n')
-	return os.WriteFile(path, raw, 0o644)
+	return writeFileAtomic(path, raw)
 }
 
 func jsonMarshalMap(v interface{}) (map[string]interface{}, error) {

--- a/internal/cli/export.go
+++ b/internal/cli/export.go
@@ -245,7 +245,8 @@ func transcriptRepLanguage(metaJSON string) string {
 }
 
 // writeFileAtomic writes data to path via a sibling temp file + rename so a
-// reader never observes a partially written subtitle document. The temp file is
+// reader never observes a partially written file and an interrupted write can
+// never truncate/corrupt an existing one. The temp file is created 0600 and
 // removed on any failure before the rename completes.
 func writeFileAtomic(path string, data []byte) error {
 	dir := filepath.Dir(path)
@@ -262,6 +263,13 @@ func writeFileAtomic(path string, data []byte) error {
 	cleanup := func() {
 		_ = tmp.Close()
 		_ = os.Remove(tmpName)
+	}
+	// Pin owner-only perms explicitly rather than relying on the implicit
+	// CreateTemp mode: some callers (e.g. the Claude config) embed a bearer
+	// token and must never land world-readable.
+	if err := tmp.Chmod(0o600); err != nil {
+		cleanup()
+		return err
 	}
 	if _, err := tmp.Write(data); err != nil {
 		cleanup()

--- a/tests/cli/claude_command_test.go
+++ b/tests/cli/claude_command_test.go
@@ -443,3 +443,98 @@ func TestClaudeUninstallIsIdempotentWhenEntryAbsent(t *testing.T) {
 		t.Errorf("expected informational stdout about nothing to remove, got: %q", got)
 	}
 }
+
+func TestClaudeInstallWritesConfigAtomically0600AndPreservesOtherServers(t *testing.T) {
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, "state")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state: %v", err)
+	}
+	tokenPath := filepath.Join(stateDir, "secret.token")
+	if err := os.WriteFile(tokenPath, []byte("supersecret\n"), 0o600); err != nil {
+		t.Fatalf("write token: %v", err)
+	}
+	connection := map[string]interface{}{
+		"transport":    "mcp_streamable_http",
+		"url":          "http://127.0.0.1:9882/mcp",
+		"headers":      map[string]string{"MCP-Protocol-Version": "2025-11-25"},
+		"public":       false,
+		"token_source": "secret.token",
+		"token_file":   tokenPath,
+	}
+	raw, _ := json.Marshal(connection)
+	if err := os.WriteFile(filepath.Join(stateDir, "connection.json"), raw, 0o644); err != nil {
+		t.Fatalf("write connection: %v", err)
+	}
+
+	// A pre-existing config carrying an UNRELATED MCP server from another tool;
+	// the install must not clobber it.
+	configDir := filepath.Join(tmp, "cfg")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("mkdir cfg: %v", err)
+	}
+	configPath := filepath.Join(configDir, "claude_desktop_config.json")
+	initial := map[string]interface{}{
+		"mcpServers": map[string]interface{}{
+			"some-other-tool": map[string]interface{}{
+				"command": "other",
+				"args":    []string{"--serve"},
+			},
+		},
+	}
+	initialRaw, _ := json.MarshalIndent(initial, "", "  ")
+	if err := os.WriteFile(configPath, initialRaw, 0o644); err != nil {
+		t.Fatalf("write initial config: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	code := app.RunWithContext(context.Background(), []string{
+		"--state-dir", stateDir,
+		"install", "claude",
+		"--name", "stas-legal-dir2mcp",
+		"--config-path", configPath,
+	})
+	if code != 0 {
+		t.Fatalf("unexpected exit code: %d stderr=%s", code, stderr.String())
+	}
+
+	// The token-bearing config must be owner-only.
+	info, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatalf("stat config: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("config perms = %o, want 0600 (it embeds a bearer token)", perm)
+	}
+
+	// Atomic writer must not leave a sibling temp file behind on success.
+	entries, err := os.ReadDir(configDir)
+	if err != nil {
+		t.Fatalf("readdir cfg: %v", err)
+	}
+	for _, e := range entries {
+		if e.Name() != filepath.Base(configPath) {
+			t.Errorf("unexpected leftover file in config dir: %q", e.Name())
+		}
+	}
+
+	updatedRaw, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read updated config: %v", err)
+	}
+	var updated map[string]interface{}
+	if err := json.Unmarshal(updatedRaw, &updated); err != nil {
+		t.Fatalf("unmarshal updated config: %v raw=%s", err, string(updatedRaw))
+	}
+	mcpServers, ok := updated["mcpServers"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("mcpServers missing after install: %+v", updated)
+	}
+	if _, ok := mcpServers["stas-legal-dir2mcp"]; !ok {
+		t.Errorf("named server not written: %+v", mcpServers)
+	}
+	if _, ok := mcpServers["some-other-tool"]; !ok {
+		t.Errorf("unrelated MCP server entry should be preserved: %+v", mcpServers)
+	}
+}

--- a/tests/cli/claude_command_test.go
+++ b/tests/cli/claude_command_test.go
@@ -444,9 +444,13 @@ func TestClaudeUninstallIsIdempotentWhenEntryAbsent(t *testing.T) {
 	}
 }
 
-func TestClaudeInstallWritesConfigAtomically0600AndPreservesOtherServers(t *testing.T) {
-	tmp := t.TempDir()
-	stateDir := filepath.Join(tmp, "state")
+// setupAtomicInstallFixture writes the state dir (token + connection.json) and a
+// pre-existing Claude config carrying an UNRELATED MCP server, returning the
+// state dir, the config path, and its parent dir. Extracted to keep the test
+// itself under the gocyclo budget.
+func setupAtomicInstallFixture(t *testing.T, tmp string) (stateDir, configDir, configPath string) {
+	t.Helper()
+	stateDir = filepath.Join(tmp, "state")
 	if err := os.MkdirAll(stateDir, 0o755); err != nil {
 		t.Fatalf("mkdir state: %v", err)
 	}
@@ -466,14 +470,11 @@ func TestClaudeInstallWritesConfigAtomically0600AndPreservesOtherServers(t *test
 	if err := os.WriteFile(filepath.Join(stateDir, "connection.json"), raw, 0o644); err != nil {
 		t.Fatalf("write connection: %v", err)
 	}
-
-	// A pre-existing config carrying an UNRELATED MCP server from another tool;
-	// the install must not clobber it.
-	configDir := filepath.Join(tmp, "cfg")
+	configDir = filepath.Join(tmp, "cfg")
 	if err := os.MkdirAll(configDir, 0o755); err != nil {
 		t.Fatalf("mkdir cfg: %v", err)
 	}
-	configPath := filepath.Join(configDir, "claude_desktop_config.json")
+	configPath = filepath.Join(configDir, "claude_desktop_config.json")
 	initial := map[string]interface{}{
 		"mcpServers": map[string]interface{}{
 			"some-other-tool": map[string]interface{}{
@@ -486,6 +487,12 @@ func TestClaudeInstallWritesConfigAtomically0600AndPreservesOtherServers(t *test
 	if err := os.WriteFile(configPath, initialRaw, 0o644); err != nil {
 		t.Fatalf("write initial config: %v", err)
 	}
+	return stateDir, configDir, configPath
+}
+
+func TestClaudeInstallWritesConfigAtomically0600AndPreservesOtherServers(t *testing.T) {
+	tmp := t.TempDir()
+	stateDir, configDir, configPath := setupAtomicInstallFixture(t, tmp)
 
 	var stdout, stderr bytes.Buffer
 	app := cli.NewAppWithIO(&stdout, &stderr)


### PR DESCRIPTION
## Problem (#410)

`install claude` / `uninstall claude` rewrite the user's entire `claude_desktop_config.json` — which holds **all** of their MCP servers, not just dir2mcp's. The rewrite went through `writeJSONFile`, which did a non-atomic `os.WriteFile(path, raw, 0o644)`:

- **Corruption risk:** truncate-in-place. An interrupted write (crash, Ctrl-C, full disk) corrupts every MCP server entry in the file, not just ours.
- **Token leak:** the config embeds the `Authorization: Bearer <token>` header, but `0644` left it world-readable.

## Fix

- Route `writeJSONFile` through the package's existing `writeFileAtomic` (sibling temp file + `fsync` + `rename`), so a reader/crash never observes a partial file and an interrupt can't truncate the existing one.
- Pin the temp file to `0600` explicitly (rather than relying on the implicit `os.CreateTemp` mode) so the token-bearing config never lands world-readable. This also applies to the export callers, which were already effectively `0600`.

## Test

Added `TestClaudeInstallWritesConfigAtomically0600AndPreservesOtherServers` in `tests/cli`, asserting the install path:
- writes the config `0600`,
- leaves no leftover temp file in the config dir on success,
- preserves an unrelated `mcpServers` entry from another tool.

## Verification

- `gofmt` clean, `go build ./...`, `go vet ./internal/cli/... ./tests/cli/...`
- `go test ./internal/cli/... ./tests/cli/...` green
- `golangci-lint run` on changed packages: 0 issues
- no functions over gocyclo 15

Scope note: this PR addresses the atomic-write + perms parts of #410. The `bunx`/`npx` and missing `-y` divergence (item 3) is intentionally deferred to keep this change focused.

Closes #410.

🤖 Generated with [Claude Code](https://claude.com/claude-code)