### PR TITLE
fix(subtitle): escape VTT/SRT cue text and voice names (#438)

### DIFF
--- a/internal/subtitle/subtitle.go
+++ b/internal/subtitle/subtitle.go
@@ -7,11 +7,53 @@ package subtitle
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 
 	"github.com/dirstral/dir2mcp/internal/model"
 )
+
+// blankLineRE matches an interior run of blank lines (a newline, optional
+// whitespace, and one or more further newlines). Such a run terminates a cue
+// block early in both WebVTT and SRT, so renderers collapse it to a single
+// newline to keep cue boundaries intact.
+var blankLineRE = regexp.MustCompile(`\n[ \t]*\n+`)
+
+// collapseBlankLines replaces any interior run of blank lines with a single
+// newline so ordinary transcript text (which may contain paragraph breaks)
+// cannot prematurely terminate a cue block.
+func collapseBlankLines(text string) string {
+	return blankLineRE.ReplaceAllString(text, "\n")
+}
+
+// vttCueTextReplacer escapes the characters that are special in WebVTT cue
+// payloads. Escaping '>' also neutralises the "-->" timing arrow (it becomes
+// "--&gt;"), so a cue line can never be misread as a timing line.
+var vttCueTextReplacer = strings.NewReplacer(
+	"&", "&amp;",
+	"<", "&lt;",
+	">", "&gt;",
+)
+
+// escapeVTTText makes arbitrary transcript text safe as a WebVTT cue payload:
+// it collapses interior blank lines, escapes '&'/'<'/'>', and (via the '>'
+// escape) neutralises any "-->" so the text cannot break the cue structure.
+func escapeVTTText(text string) string {
+	return vttCueTextReplacer.Replace(collapseBlankLines(text))
+}
+
+// srtCueTextReplacer neutralises the "-->" timing arrow in SRT cue text. SRT
+// has no markup escaping, so a literal "-->" on its own line could be parsed as
+// a timing line; replacing it with "-→" keeps the text readable and unambiguous.
+var srtCueTextReplacer = strings.NewReplacer("-->", "-→")
+
+// neutralizeSRTText makes arbitrary transcript text safe as an SRT cue payload:
+// it collapses interior blank lines (which would end the cue block early) and
+// neutralises any "-->" timing arrow.
+func neutralizeSRTText(text string) string {
+	return srtCueTextReplacer.Replace(collapseBlankLines(text))
+}
 
 // Cue is a single subtitle entry: a [StartMS, EndMS] time window and the text
 // shown during it. Index is the 1-based sequence number used by SRT (WebVTT
@@ -122,22 +164,32 @@ func RenderVTT(cues []Cue) string {
 			b.WriteString(speaker)
 			b.WriteByte('>')
 		}
-		b.WriteString(text)
+		b.WriteString(escapeVTTText(text))
 		b.WriteString("\n\n")
 	}
 	return b.String()
 }
 
-// sanitizeVoiceName makes a speaker name safe to embed in a WebVTT <v Name> tag:
-// it trims whitespace and strips '<' and '>' so the name cannot terminate the
-// tag or inject markup. Returns "" for an empty/blank name so the caller omits
-// the voice tag entirely.
+// voiceNameReplacer makes a speaker name safe to embed in a WebVTT <v Name>
+// tag: it strips '<'/'>' (which would terminate the tag or inject markup),
+// escapes '&' (a bare ampersand is an invalid entity in the tag), and replaces
+// CR/LF with a space (a newline would leave the <v ...> tag unterminated).
+var voiceNameReplacer = strings.NewReplacer(
+	"<", "",
+	">", "",
+	"&", "&amp;",
+	"\r", " ",
+	"\n", " ",
+)
+
+// sanitizeVoiceName makes a speaker name safe to embed in a WebVTT <v Name> tag.
+// Returns "" for an empty/blank name so the caller omits the voice tag entirely.
 func sanitizeVoiceName(name string) string {
 	name = strings.TrimSpace(name)
 	if name == "" {
 		return ""
 	}
-	return strings.TrimSpace(strings.NewReplacer("<", "", ">", "").Replace(name))
+	return strings.TrimSpace(voiceNameReplacer.Replace(name))
 }
 
 // RenderSRT serializes cues as a SubRip (SRT) document: a 1-based index line,
@@ -159,7 +211,7 @@ func RenderSRT(cues []Cue) string {
 		b.WriteString(" --> ")
 		b.WriteString(formatTimestampSRT(cue.EndMS))
 		b.WriteByte('\n')
-		b.WriteString(text)
+		b.WriteString(neutralizeSRTText(text))
 		b.WriteString("\n\n")
 	}
 	return b.String()

--- a/tests/subtitle/subtitle_test.go
+++ b/tests/subtitle/subtitle_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/dirstral/dir2mcp/internal/model"
@@ -155,5 +156,98 @@ func TestParseTTML_ReturnsCuesInDocumentTimeOrder(t *testing.T) {
 		if c.Index != i+1 {
 			t.Fatalf("cue %d: expected 1-based index %d, got %d", i, i+1, c.Index)
 		}
+	}
+}
+
+// hostileCues exercises cue text and a speaker name that, if emitted raw, would
+// produce malformed/unplayable subtitles: a literal '&', a '<', a "-->" timing
+// arrow, an interior blank line, and a speaker name carrying '&' and a newline.
+func hostileCues() []subtitle.Cue {
+	return []subtitle.Cue{{
+		Index:   1,
+		StartMS: 0,
+		EndMS:   1000,
+		Text:    "Tom & Jerry <fast>\n\n--> over there",
+		Speaker: "Tom & Jerry\nNarrator",
+	}}
+}
+
+// TestRenderVTT_EscapesHostileText asserts that ordinary-but-hostile transcript
+// text is escaped into a well-formed WebVTT cue payload: '&'/'<' are escaped,
+// no raw "-->" survives in the payload (it would be read as a timing line), and
+// the interior blank line is collapsed so the cue is not terminated early.
+func TestRenderVTT_EscapesHostileText(t *testing.T) {
+	got := subtitle.RenderVTT(hostileCues())
+
+	// Split header from the single cue block.
+	if !strings.HasPrefix(got, "WEBVTT\n\n") {
+		t.Fatalf("missing WEBVTT header: %q", got)
+	}
+	body := strings.TrimPrefix(got, "WEBVTT\n\n")
+	lines := strings.Split(strings.TrimRight(body, "\n"), "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected timing + payload lines, got %q", got)
+	}
+	timing, payload := lines[0], strings.Join(lines[1:], "\n")
+
+	if timing != "00:00:00.000 --> 00:00:01.000" {
+		t.Errorf("timing line = %q, want canonical arrow", timing)
+	}
+	// Voice tag escaped: '&' -> "&amp;", newline -> space, tag terminated by '>'.
+	wantVoice := "<v Tom &amp; Jerry Narrator>"
+	if !strings.HasPrefix(payload, wantVoice) {
+		t.Fatalf("voice tag = %q, want prefix %q", payload, wantVoice)
+	}
+	cueText := strings.TrimPrefix(payload, wantVoice)
+
+	if strings.Contains(cueText, "\n\n") {
+		t.Errorf("cue text contains interior blank line (premature cue end): %q", cueText)
+	}
+	if strings.Contains(cueText, "-->") {
+		t.Errorf("cue text contains raw '-->' (mistakable for a timing line): %q", cueText)
+	}
+	// Drop well-formed entities, then assert no raw '&' or '<' remain.
+	entities := strings.NewReplacer("&amp;", "", "&lt;", "", "&gt;", "")
+	residual := entities.Replace(cueText)
+	if strings.Contains(residual, "&") {
+		t.Errorf("cue text contains raw '&' outside an entity: %q", cueText)
+	}
+	if strings.Contains(residual, "<") {
+		t.Errorf("cue text contains raw '<': %q", cueText)
+	}
+}
+
+// TestRenderSRT_NeutralizesHostileText asserts SRT cue text cannot break the
+// block structure: a literal "-->" is neutralised (so it is not parsed as a
+// timing line) and an interior blank line is collapsed (so the cue block is not
+// terminated early, which would desync every following cue).
+func TestRenderSRT_NeutralizesHostileText(t *testing.T) {
+	got := subtitle.RenderSRT(hostileCues())
+
+	lines := strings.Split(strings.TrimRight(got, "\n"), "\n")
+	// Expect: "1", timing line, then payload lines — and no blank line within.
+	if len(lines) < 3 {
+		t.Fatalf("expected index + timing + payload, got %q", got)
+	}
+	if lines[0] != "1" {
+		t.Errorf("index line = %q, want \"1\"", lines[0])
+	}
+	if lines[1] != "00:00:00,000 --> 00:00:01,000" {
+		t.Errorf("timing line = %q, want canonical arrow", lines[1])
+	}
+	payload := strings.Join(lines[2:], "\n")
+	// strings.Split on the trailing-trimmed doc must yield no empty interior
+	// line: an empty element here is a premature blank line that ends the cue.
+	for i, ln := range lines {
+		if ln == "" {
+			t.Errorf("SRT line %d is blank (premature cue end / desync): %q", i, got)
+		}
+	}
+	if strings.Contains(payload, "-->") {
+		t.Errorf("payload contains raw '-->' (mistakable for a timing line): %q", payload)
+	}
+	// SRT is not markup, so '&' and '<' are left intact (only '-->' is unsafe).
+	if !strings.Contains(payload, "Tom & Jerry") || !strings.Contains(payload, "<fast>") {
+		t.Errorf("SRT payload unexpectedly altered non-arrow text: %q", payload)
 	}
 }


### PR DESCRIPTION
## Problem

`internal/subtitle` emitted cue text and voice names **unescaped**, so ordinary transcript text produced malformed/unplayable subtitles:

- **WebVTT cue text** was written raw (`b.WriteString(text)`). A bare `&` or `<` is invalid in a cue payload, an internal blank line terminates the cue early, and a literal `-->` is read as a timing line.
- **WebVTT voice name** (`sanitizeVoiceName`) stripped only `<`/`>`, so a bare `&` was an invalid entity and a `\n` in a `SpeakerLabel` left the `<v ...>` tag unterminated.
- **SRT cue text** broke if it contained `-->` (parsed as a timing line) or an internal blank line (ends the cue block early and desyncs every following cue).

TTML is already correctly escaped via `xml.EscapeText` and is left untouched.

## Fix

- **VTT cue text:** escape `&`→`&amp;`, `<`→`&lt;`, `>`→`&gt;` (the `>` escape also neutralises `-->` → `--&gt;`), and collapse interior blank lines.
- **VTT voice name:** additionally escape `&` and replace CR/LF with a space.
- **SRT cue text:** neutralise `-->` (→ `-→`) and collapse interior blank lines.

## Tests

Added `TestRenderVTT_EscapesHostileText` and `TestRenderSRT_NeutralizesHostileText` (mirroring `tests/subtitle/subtitle_test.go`) with cue text containing `&`, `<`, `-->`, and an internal blank line, plus a speaker name with `&` and a newline, asserting the rendered VTT/SRT is well-formed (no raw `<`/`&` in cue text, no stray `-->` in payload, no premature blank line).

## Verification

`gofmt` clean, `go build ./...`, `go vet ./...`, and `go test ./internal/subtitle/... ./tests/subtitle/... ./tests/cli/...` all pass. `make check` passes except one pre-existing, unrelated failure (uninitialized `dirstral-spec` submodule in the worktree).

Closes #438.

🤖 Generated with [Claude Code](https://claude.com/claude-code)