### PR TITLE
fix: retry transient embed/index errors (#412) and defer empty embed model to the provider adapter (#396)

### DIFF
--- a/internal/index/embedding_worker.go
+++ b/internal/index/embedding_worker.go
@@ -610,6 +610,15 @@ func (w *EmbeddingWorker) indexChunks(ctx context.Context, validTasks []model.Ch
 					w.logf("mark embedded warning: failed to mark %d chunks as embedded before index error: %v labels=%v", idx, err, labels[:idx])
 				}
 			}
+			// A transient index/upsert error (the vector store is momentarily
+			// unreachable — connection refused/reset, 503/529, EOF) must NOT
+			// permanently fail the chunk: leave it PENDING so the next cycle
+			// retries it, mirroring the embed-path behavior (issue #412).
+			// Without this guard a brief Qdrant/pgvector blip silently buried
+			// chunks in the error state corpus-wide.
+			if isTransientEmbedError(addErr) {
+				return idx, addErr
+			}
 			category := string(store.ClassifyError(addErr))
 			reason := store.SanitizeReason(addErr.Error())
 			if mfErr := w.Source.MarkFailedWithCategory(ctx, labels[idx:idx+1], category, reason); mfErr != nil {
@@ -891,6 +900,14 @@ func isTransientEmbedError(err error) bool {
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return true
 	}
+	// A bare EOF / unexpected-EOF (connection dropped mid-response) is a
+	// transient transport failure that a later cycle recovers from. Match it
+	// structurally (errors.Is) in addition to the keyword set below, since
+	// io.EOF survives wrapping (e.g. *model.ProviderError.Cause) where the
+	// string form may not.
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
 	// net.Error can indicate timeouts or temporary network failures.
 	var ne net.Error
 	if errors.As(err, &ne) {
@@ -906,30 +923,36 @@ func isTransientEmbedError(err error) bool {
 			return true
 		}
 	}
-	// some embedder implementations return textual hints for rate limits or
-	// timeouts; look for those substrings so the behaviour is still correct
-	// even if they don't implement the net.Error interface.
-	lower := strings.ToLower(err.Error())
-	if strings.Contains(lower, "rate limit") || strings.Contains(lower, "timeout") {
+	// Rate-limit responses are retryable after backoff. store.IsTransientError
+	// (below) classifies rate limits under their own category, not transient_net,
+	// so keep this check explicit here.
+	if strings.Contains(strings.ToLower(err.Error()), "rate limit") {
 		return true
 	}
-	return false
+	// Defer to the shared store classification so the worker's retry gate and
+	// the transient_net diagnostics label agree on exactly the same set of
+	// errors (issue #412): timeouts, connection refused/reset, DNS failures,
+	// 503/529, service unavailable, overloaded, EOF. A failure left PENDING
+	// here is the same class dir2mcp status/doctor report as transient_net.
+	return store.IsTransientError(err)
 }
 
+// modelForKind returns the configured embed model for the index axis, or ""
+// when none was resolved. An empty result is intentional: it tells the
+// provider ADAPTER to apply its own correct default (text-embedding-3-small
+// for OpenAI, embed-v4.0 for Cohere, gemini-embedding-001 for Gemini, etc.).
+// Previously this fell back to the Mistral model names ("mistral-embed" /
+// "codestral-embed"), which silently sent a Mistral model id to whatever
+// provider was actually active — so swapping the embed provider to OpenAI or
+// Cohere failed the whole corpus with an unknown-model error (issue #396). The
+// concrete model is supplied upstream from the resolved embed profile
+// (ModelForText/ModelForCode); only when that profile leaves it blank do we
+// defer to the adapter default.
 func (w *EmbeddingWorker) modelForKind(indexKind string) string {
-	kind := strings.ToLower(strings.TrimSpace(indexKind))
-	switch kind {
-	case "code":
-		if strings.TrimSpace(w.ModelForCode) != "" {
-			return w.ModelForCode
-		}
-		return "codestral-embed"
-	default:
-		if strings.TrimSpace(w.ModelForText) != "" {
-			return w.ModelForText
-		}
-		return "mistral-embed"
+	if strings.ToLower(strings.TrimSpace(indexKind)) == "code" {
+		return strings.TrimSpace(w.ModelForCode)
 	}
+	return strings.TrimSpace(w.ModelForText)
 }
 
 // LateChunkDecision resolves the late-chunking capability gate (issue #332) for

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -637,21 +637,33 @@ func truncateQuestion(q string) string {
 	return string(r[:max]) + "…"
 }
 
+// SetQueryEmbeddingModel records the text-axis model used to embed the QUERY.
+// It MUST resolve to the same model the corpus was embedded with — sending a
+// query through a different embedder/model than the index yields a vector in a
+// foreign space and garbage hits.
+//
+// An empty modelName is recorded as empty (clearing the historical
+// "mistral-embed" default), so the active provider adapter applies its OWN
+// default — the very same default the embed worker used for the corpus when its
+// profile left the model blank (modelForKind, issue #396). Previously this was
+// a no-op on empty, so switching the embed provider to OpenAI/Cohere left the
+// query pinned to "mistral-embed" and every search hit a wrong-provider model
+// error while indexing had succeeded. The resolved embed profile always
+// supplies a concrete model for providers that define one (e.g. Mistral), so
+// this only clears the default for providers that intentionally defer to their
+// adapter.
 func (s *Service) SetQueryEmbeddingModel(modelName string) {
-	if strings.TrimSpace(modelName) == "" {
-		return
-	}
 	s.metaMu.Lock()
-	s.textModel = modelName
+	s.textModel = strings.TrimSpace(modelName)
 	s.metaMu.Unlock()
 }
 
+// SetCodeEmbeddingModel records the code-axis query embed model. Empty clears
+// the historical "codestral-embed" default so the active provider adapter
+// applies its own default (issue #396); see SetQueryEmbeddingModel.
 func (s *Service) SetCodeEmbeddingModel(modelName string) {
-	if strings.TrimSpace(modelName) == "" {
-		return
-	}
 	s.metaMu.Lock()
-	s.codeModel = modelName
+	s.codeModel = strings.TrimSpace(modelName)
 	s.metaMu.Unlock()
 }
 

--- a/internal/store/errcat.go
+++ b/internal/store/errcat.go
@@ -61,6 +61,22 @@ type classifierRule struct {
 	keywords []string
 }
 
+// transientNetKeywords is the canonical keyword set for a transient,
+// retryable network/upstream failure. It is the single source of truth
+// shared by ClassifyError (which labels these transient_net) and
+// IsTransientError (which the embedding worker uses to decide whether to
+// leave a chunk PENDING for retry rather than permanently failing it,
+// issue #412), so the retry decision and the diagnostics label never
+// disagree. Beyond the classic socket/DNS failures it also covers the
+// transient upstream statuses providers return under load — 503 Service
+// Unavailable, 529 Overloaded (Anthropic), and a bare EOF / "connection
+// reset" mid-response — all of which a later cycle routinely recovers from.
+var transientNetKeywords = []string{
+	"timeout", "connection refused", "connection reset", "no such host",
+	"context deadline exceeded", "i/o timeout", "503", "529",
+	"service unavailable", "overloaded", "eof",
+}
+
 // classifierRules is the keyword-driven classification table consumed
 // by ClassifyError. Split out as a package var so the function below
 // stays under the cyclomatic-complexity budget and so new keywords
@@ -69,9 +85,26 @@ var classifierRules = []classifierRule{
 	{ErrorCategoryRateLimit, []string{"429", "rate limit", "rate-limit", "quota exceeded", "too many requests"}},
 	{ErrorCategoryPayloadTooLarge, []string{"413", "payload too large", "request entity too large", "file too large", "exceeds maximum size"}},
 	{ErrorCategoryAuth, []string{"401", "403", "unauthorized", "forbidden", "invalid api key", "authentication"}},
-	{ErrorCategoryTransientNet, []string{"timeout", "connection refused", "connection reset", "no such host", "context deadline exceeded", "i/o timeout"}},
+	{ErrorCategoryTransientNet, transientNetKeywords},
 	{ErrorCategoryParseError, []string{"parse", "decode", "ocr", "extract", "corrupt", "unsupported"}},
 	{ErrorCategoryEmbeddingFailure, []string{"embedding", "embed", "vector", "dimension"}},
+}
+
+// IsTransientError reports whether err is a transient, retryable failure:
+// a net.Error timeout, or a message matching the shared transient_net
+// keyword set (connection refused/reset, DNS, 503/529, service
+// unavailable, overloaded, EOF). It exists so the embedding worker's
+// retry gate (issue #412) and ClassifyError's transient_net label use the
+// exact same definition — a failure the worker leaves PENDING is the same
+// class the diagnostics surface reports as transient_net. nil ⇒ false.
+func IsTransientError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if isNetTransient(err) {
+		return true
+	}
+	return containsAny(strings.ToLower(err.Error()), transientNetKeywords)
 }
 
 // ClassifyError returns the ErrorCategory that best describes err.

--- a/internal/store/errcat_test.go
+++ b/internal/store/errcat_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"errors"
+	"io"
 	"net"
 	"strings"
 	"testing"
@@ -26,6 +27,9 @@ func TestClassifyError_KnownPatterns(t *testing.T) {
 		{"net-deadline", context.DeadlineExceeded, ErrorCategoryTransientNet},
 		{"net-text", errors.New("connection refused"), ErrorCategoryTransientNet},
 		{"net-timeout", &fakeTimeoutErr{}, ErrorCategoryTransientNet},
+		{"net-503", errors.New("embed failed: 503 service unavailable"), ErrorCategoryTransientNet},
+		{"net-529-overloaded", errors.New("upstream returned: overloaded"), ErrorCategoryTransientNet},
+		{"net-eof", errors.New("post /embeddings: unexpected EOF"), ErrorCategoryTransientNet},
 		{"parse", errors.New("ocr extract failed: corrupt PDF"), ErrorCategoryParseError},
 		{"embed", errors.New("vector dimension mismatch: got 1024 want 1536"), ErrorCategoryEmbeddingFailure},
 		{"unknown", errors.New("something else"), ErrorCategoryUnknown},
@@ -49,6 +53,37 @@ func (e *fakeTimeoutErr) Temporary() bool { return true }
 // the isNetTransient branch of the classifier is exercised.
 var _ net.Error = (*fakeTimeoutErr)(nil)
 var _ = time.Now // keep imports stable for follow-on tests
+
+// TestIsTransientError pins the shared retry gate (issue #412): the broadened
+// transient set — connection refused, 503, overloaded, EOF, net timeouts — must
+// be reported transient, while permanent failures (auth, dimension) must not.
+func TestIsTransientError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"connection-refused", errors.New("dial tcp: connect: connection refused"), true},
+		{"connection-reset", errors.New("read: connection reset by peer"), true},
+		{"no-such-host", errors.New("lookup api.example.com: no such host"), true},
+		{"http-503", errors.New("embed failed: 503 service unavailable"), true},
+		{"overloaded-529", errors.New("upstream returned: overloaded"), true},
+		{"eof", errors.New("post /embeddings: unexpected EOF"), true},
+		{"wrapped-io-eof", io.EOF, true},
+		{"net-timeout", &fakeTimeoutErr{}, true},
+		{"deadline", context.DeadlineExceeded, true},
+		{"auth-permanent", errors.New("401 unauthorized"), false},
+		{"dimension-permanent", errors.New("vector dimension mismatch"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsTransientError(tc.err); got != tc.want {
+				t.Errorf("IsTransientError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
 
 func TestSanitizeReason(t *testing.T) {
 	cases := []struct {

--- a/tests/index/embedding_worker_test.go
+++ b/tests/index/embedding_worker_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"os"
@@ -222,6 +223,9 @@ func (s *fakeChunkSource) MarkFailedWithCategory(_ context.Context, labels []uin
 type fakeEmbedder struct {
 	vectors [][]float32
 	err     error
+	// gotModel records the model name passed to the most recent Embed call so
+	// tests can assert on modelForKind's resolution (issue #396).
+	gotModel string
 }
 
 // testWorker provides a fake RunOnce sequence; it also implements the
@@ -245,12 +249,31 @@ func (w *testWorker) RunOnce(ctx context.Context, indexKind string) (int, error)
 	return 1, nil
 }
 
-func (e *fakeEmbedder) Embed(_ context.Context, _ string, _ model.EmbedRole, _ []string) ([][]float32, error) {
+func (e *fakeEmbedder) Embed(_ context.Context, modelName string, _ model.EmbedRole, _ []string) ([][]float32, error) {
+	e.gotModel = modelName
 	if e.err != nil {
 		return nil, e.err
 	}
 	return e.vectors, nil
 }
+
+// fakeUpsertIndex is a minimal model.Index whose Upsert returns a configurable
+// error, so tests can exercise the index-error path (issue #412) without a real
+// vector backend. All other methods are no-ops.
+type fakeUpsertIndex struct {
+	upsertErr error
+}
+
+func (f *fakeUpsertIndex) Upsert(_ context.Context, _ []float32, _ model.IndexPayload) error {
+	return f.upsertErr
+}
+func (f *fakeUpsertIndex) Delete(_ context.Context, _ []uint64) error { return nil }
+func (f *fakeUpsertIndex) Search(_ context.Context, _ []float32, _ int, _ model.Filter) ([]model.IndexHit, error) {
+	return nil, nil
+}
+func (f *fakeUpsertIndex) Identity(_ context.Context) (string, error) { return "", nil }
+func (f *fakeUpsertIndex) Reset(_ context.Context, _ string) error    { return nil }
+func (f *fakeUpsertIndex) Close() error                               { return nil }
 
 func TestEmbeddingWorker_RunOnce_Success(t *testing.T) {
 	source := &fakeChunkSource{
@@ -552,6 +575,139 @@ func TestEmbeddingWorker_RunOnce_MarkFailedLogging(t *testing.T) {
 	if !strings.Contains(logged, "mark failed update error") || !strings.Contains(logged, "db down") {
 		t.Fatalf("expected log message about mark failed error, got %q", logged)
 	}
+}
+
+// TestEmbeddingWorker_RunOnce_TransientEmbedErrorsLeavePending pins issue #412:
+// the broadened transient classifier (connection refused / 503 / overloaded /
+// EOF) must keep the chunk PENDING for retry rather than permanently failing it.
+func TestEmbeddingWorker_RunOnce_TransientEmbedErrorsLeavePending(t *testing.T) {
+	cases := []struct{ name, msg string }{
+		{"connection-refused", "dial tcp 10.0.0.1:443: connect: connection refused"},
+		{"http-503", "embedding request failed: 503 service unavailable"},
+		{"overloaded", "upstream returned error: overloaded"},
+		{"unexpected-eof", "post /v1/embeddings: unexpected EOF"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			source := &fakeChunkSource{
+				tasks: []model.ChunkTask{model.NewChunkTask(70, "x", "", model.ChunkMetadata{ChunkID: 70})},
+			}
+			embErr := errors.New(tc.msg)
+			worker := &index.EmbeddingWorker{
+				Source: source, Index: index.NewHNSWIndex(""),
+				Embedder: &fakeEmbedder{err: embErr}, BatchSize: 1,
+			}
+			n, err := worker.RunOnce(context.Background(), "text")
+			if !errors.Is(err, embErr) {
+				t.Fatalf("err = %v, want %v", err, embErr)
+			}
+			if n != 0 {
+				t.Fatalf("indexed = %d, want 0", n)
+			}
+			if len(source.failedLabels) != 0 {
+				t.Fatalf("transient %q must not mark failed, got %v", tc.msg, source.failedLabels)
+			}
+		})
+	}
+
+	// A wrapped io.EOF (structural match, where the string form may be lost)
+	// is also transient.
+	t.Run("wrapped-io-eof", func(t *testing.T) {
+		source := &fakeChunkSource{
+			tasks: []model.ChunkTask{model.NewChunkTask(71, "y", "", model.ChunkMetadata{ChunkID: 71})},
+		}
+		embErr := fmt.Errorf("embed batch failed: %w", io.EOF)
+		worker := &index.EmbeddingWorker{
+			Source: source, Index: index.NewHNSWIndex(""),
+			Embedder: &fakeEmbedder{err: embErr}, BatchSize: 1,
+		}
+		if _, err := worker.RunOnce(context.Background(), "text"); !errors.Is(err, embErr) {
+			t.Fatalf("err = %v, want %v", err, embErr)
+		}
+		if len(source.failedLabels) != 0 {
+			t.Fatalf("wrapped EOF must not mark failed, got %v", source.failedLabels)
+		}
+	})
+}
+
+// TestEmbeddingWorker_RunOnce_TransientIndexErrorLeavesPending pins issue #412
+// part 2: a transient vector-index Upsert error must NOT mark the chunk failed —
+// it stays pending so the next cycle retries once the store recovers.
+func TestEmbeddingWorker_RunOnce_TransientIndexErrorLeavesPending(t *testing.T) {
+	source := &fakeChunkSource{
+		tasks: []model.ChunkTask{model.NewChunkTask(80, "z", "", model.ChunkMetadata{ChunkID: 80})},
+	}
+	upErr := errors.New("upsert vector: 503 service unavailable")
+	worker := &index.EmbeddingWorker{
+		Source: source, Index: &fakeUpsertIndex{upsertErr: upErr},
+		Embedder: &fakeEmbedder{vectors: [][]float32{{1, 0}}}, BatchSize: 1,
+	}
+	n, err := worker.RunOnce(context.Background(), "text")
+	if !errors.Is(err, upErr) {
+		t.Fatalf("err = %v, want %v", err, upErr)
+	}
+	if n != 0 {
+		t.Fatalf("indexed = %d, want 0", n)
+	}
+	if len(source.failedLabels) != 0 {
+		t.Fatalf("transient index error must leave chunk pending, got failed %v", source.failedLabels)
+	}
+	if len(source.embedded) != 0 {
+		t.Fatalf("nothing should be marked embedded on a failed-only batch, got %v", source.embedded)
+	}
+}
+
+// TestEmbeddingWorker_RunOnce_PermanentIndexErrorMarksFailed is the regression
+// guard for the other side of the #412 guard: a NON-transient index error still
+// marks the chunk failed (so genuinely broken chunks are not retried forever).
+func TestEmbeddingWorker_RunOnce_PermanentIndexErrorMarksFailed(t *testing.T) {
+	source := &fakeChunkSource{
+		tasks: []model.ChunkTask{model.NewChunkTask(81, "z", "", model.ChunkMetadata{ChunkID: 81})},
+	}
+	upErr := errors.New("vector dimension mismatch")
+	worker := &index.EmbeddingWorker{
+		Source: source, Index: &fakeUpsertIndex{upsertErr: upErr},
+		Embedder: &fakeEmbedder{vectors: [][]float32{{1, 0}}}, BatchSize: 1,
+	}
+	if _, err := worker.RunOnce(context.Background(), "text"); !errors.Is(err, upErr) {
+		t.Fatalf("err = %v, want %v", err, upErr)
+	}
+	if len(source.failedLabels) != 1 || source.failedLabels[0] != 81 {
+		t.Fatalf("permanent index error must mark chunk failed, got %v", source.failedLabels)
+	}
+}
+
+// TestEmbeddingWorker_ModelForKind_EmptyDefersToAdapter pins issue #396: with no
+// configured embed model, the worker passes "" to the embedder so the provider
+// ADAPTER applies its own default — it must NOT fall back to a Mistral model id
+// (which would fail an OpenAI/Cohere/Gemini corpus).
+func TestEmbeddingWorker_ModelForKind_EmptyDefersToAdapter(t *testing.T) {
+	t.Run("text", func(t *testing.T) {
+		source := &fakeChunkSource{
+			tasks: []model.ChunkTask{model.NewChunkTask(90, "hi", "", model.ChunkMetadata{ChunkID: 90, DocType: "text"})},
+		}
+		emb := &fakeEmbedder{vectors: [][]float32{{1, 0}}} // ModelForText intentionally unset
+		worker := &index.EmbeddingWorker{Source: source, Index: index.NewHNSWIndex(""), Embedder: emb, BatchSize: 1}
+		if _, err := worker.RunOnce(context.Background(), "text"); err != nil {
+			t.Fatalf("RunOnce: %v", err)
+		}
+		if emb.gotModel != "" {
+			t.Fatalf("text embed model = %q, want empty (adapter default), not a mistral literal", emb.gotModel)
+		}
+	})
+	t.Run("code", func(t *testing.T) {
+		source := &fakeChunkSource{
+			tasks: []model.ChunkTask{model.NewChunkTask(91, "hi", "", model.ChunkMetadata{ChunkID: 91, DocType: "code"})},
+		}
+		emb := &fakeEmbedder{vectors: [][]float32{{1, 0}}} // ModelForCode intentionally unset
+		worker := &index.EmbeddingWorker{Source: source, Index: index.NewHNSWIndex(""), Embedder: emb, BatchSize: 1}
+		if _, err := worker.RunOnce(context.Background(), "code"); err != nil {
+			t.Fatalf("RunOnce: %v", err)
+		}
+		if emb.gotModel != "" {
+			t.Fatalf("code embed model = %q, want empty (adapter default), not a codestral literal", emb.gotModel)
+		}
+	})
 }
 
 func TestEmbeddingWorker_Run_FatalErrorStops(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes two silent embed-failure bugs that both flow through `internal/index/embedding_worker.go`, so they are fixed together.

### #412 — transient embed/index errors were marked permanently failed (never retried)

- **`isTransientEmbedError`** only matched `rate limit` / `timeout` / `net.Timeout`. It now also recognizes `connection refused`, `connection reset`, `no such host`, `503`, `529`, `service unavailable`, `overloaded`, and `EOF` (including a wrapped `io.EOF` via `errors.Is`). The transient-network keyword set is centralized in `internal/store/errcat.go` as `transientNetKeywords` and exposed through a new `store.IsTransientError`, so the worker's retry gate and the `transient_net` diagnostics label (`dir2mcp status`/`doctor`) classify exactly the same errors. A transient match leaves the chunk **PENDING** for retry (no `MarkFailed`), matching existing embed-path behavior.
- **The vector-index upsert path (`indexChunks`)** called `MarkFailedWithCategory` on *any* `Upsert` error with no transience check, so a brief Qdrant/pgvector blip could bury chunks in the error state corpus-wide. It now applies the same `isTransientEmbedError` guard and leaves transient upsert failures pending. Non-transient upsert errors still mark the chunk failed (regression-guarded).

### #396 — swapping the embed provider to OpenAI/Cohere silently failed the corpus

- **`modelForKind`** fell back to the hardcoded `mistral-embed` / `codestral-embed` ids when the model was empty — sending Mistral model names to whatever provider was actually active. It now returns `""` when unset so the provider **adapter** applies its own correct default. Verified all four adapters already default sanely on empty (`openai` → `text-embedding-3-small`, `cohere` → `embed-v4.0`, `gemini` → `gemini-embedding-001`, `omniembed` → its `DefaultModel`), so no profile changes were needed.
- **Query side:** `SetQueryEmbeddingModel` / `SetCodeEmbeddingModel` were no-ops on an empty model, so the query stayed pinned to the `mistral-embed`/`codestral-embed` default in `NewService` even when the corpus was embedded with a different provider. They now record the trimmed value (including empty), clearing the Mistral-era default so the active adapter resolves the same default the corpus was embedded with. The built-in Mistral profile always supplies a concrete model, so Mistral corpora are unaffected; the `NewService` defaults are retained for the existing retrieval tests.

### Tests
- `store.IsTransientError` + `ClassifyError` now cover `503` / `overloaded` (529) / `EOF` / connection-refused/reset and still reject permanent (auth/dimension) failures.
- Worker: transient embed errors (`connection refused`, `503`, `overloaded`, `unexpected EOF`, wrapped `io.EOF`) leave the chunk pending; a transient index `Upsert` error leaves it pending while a permanent one still marks it failed; `modelForKind` defers to the adapter (empty model) for both text and code axes.

### Validation
- `gofmt` clean; `go build ./...`; `go vet` clean; targeted suites (`internal/index`, `internal/store`, `internal/retrieval`, `tests/index|store|retrieval|config|provider|providerfactory|embedqueue`) all pass. The only `go test ./...` failure is the pre-existing `tests/security` case that requires the `dirstral-spec` submodule (not initialized in this worktree) — unrelated to this change. Modified functions remain under the gocyclo-15 budget.

Closes #412.
Closes #396.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
