### PR TITLE
fix(ingest): stop docling subprocess wedging indexing (#406)

### DIFF
--- a/internal/ingest/docling_extractor.go
+++ b/internal/ingest/docling_extractor.go
@@ -3,12 +3,12 @@ package ingest
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/dirstral/dir2mcp/internal/ingest/docling"
 )
@@ -44,7 +44,22 @@ const (
 	maxDoclingStderrBytes = 1 * 1024 * 1024
 )
 
-var errDoclingOutputTooLarge = errors.New("docling output exceeded configured limit")
+// doclingExtractTimeout bounds a single document's docling subprocess so one
+// pathological file can never wedge the whole indexer (issue #406). docling
+// streams tqdm/loguru progress for the lifetime of a slow extraction, so the
+// limit must sit comfortably above the slowest real document: large multi-
+// hundred-page legal PDFs (the corpus this protects) can take several minutes
+// on CPU-only hosts, so 15 minutes leaves generous headroom while still
+// guaranteeing forward progress. On expiry the document is marked failed
+// (retryable) instead of hanging indexing. It is a var (not a const) only so
+// tests can shorten it; production never reassigns it.
+var doclingExtractTimeout = 15 * time.Minute
+
+// doclingWaitDelay is a backstop after the context is cancelled (timeout or
+// shutdown): os/exec sends the kill signal, and if the child has not exited
+// within this grace period the I/O pipes are force-closed so cmd.Run() cannot
+// block indefinitely on a wedged subprocess that ignores cancellation.
+const doclingWaitDelay = 10 * time.Second
 
 // SanitizeDoclingEnv returns env (in os.Environ "KEY=VALUE" form) with the
 // Python path-injection variables removed and user site-packages disabled, so
@@ -78,17 +93,42 @@ type doclingExtractor struct {
 	commandTemplate string
 }
 
+// limitedBuffer caps how much it retains while still accepting every write.
+// Crucially it NEVER returns an error: when wired as cmd.Stdout/cmd.Stderr, a
+// Write that returns an error makes os/exec stop draining that pipe, so the
+// child blocks on a full pipe and cmd.Run() never returns — docling streams
+// verbose tqdm/loguru progress to stderr, so a large PDF can exceed the cap and
+// deadlock indexing (issue #406). Instead, once over the cap it discards the
+// overflow (no longer appending to buf) but reports the full length as written
+// so the pipe keeps draining. Callers detect over-cap output via Truncated()
+// after Run() returns.
 type limitedBuffer struct {
-	buf   *bytes.Buffer
-	limit int
+	buf       *bytes.Buffer
+	limit     int
+	truncated bool
 }
 
 func (w *limitedBuffer) Write(p []byte) (int, error) {
-	if w.limit > 0 && w.buf.Len()+len(p) > w.limit {
-		return 0, errDoclingOutputTooLarge
+	if w.limit <= 0 {
+		return w.buf.Write(p)
 	}
-	return w.buf.Write(p)
+	if remaining := w.limit - w.buf.Len(); remaining > 0 {
+		if len(p) <= remaining {
+			return w.buf.Write(p)
+		}
+		// Keep what fits, discard the rest, but acknowledge the whole write so
+		// os/exec keeps draining the pipe.
+		_, _ = w.buf.Write(p[:remaining])
+		w.truncated = true
+		return len(p), nil
+	}
+	// Already at/over the cap: discard but acknowledge to keep the pipe draining.
+	w.truncated = true
+	return len(p), nil
 }
+
+// Truncated reports whether any bytes were discarded because the cap was hit.
+func (w *limitedBuffer) Truncated() bool { return w.truncated }
 
 // NewDoclingExtractor returns a document extractor backed by a local docling
 // CLI invocation. If commandTemplate is blank, a default `docling` command is
@@ -176,13 +216,19 @@ func (d *doclingExtractor) runFileOutput(ctx context.Context, inputPath string) 
 	if err != nil {
 		return "", err
 	}
+	ctx, cancel := context.WithTimeout(ctx, doclingExtractTimeout)
+	defer cancel()
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	cmd.WaitDelay = doclingWaitDelay
 	cmd.Env = SanitizeDoclingEnv(os.Environ())
 	// docling logs progress to stdout/stderr; the real output is the file in
 	// outDir, so stdout is discarded and only stderr is captured for diagnostics.
 	var stderr bytes.Buffer
 	cmd.Stderr = &limitedBuffer{buf: &stderr, limit: maxDoclingStderrBytes}
 	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("docling command timed out after %s", doclingExtractTimeout)
+		}
 		msg := strings.TrimSpace(stderr.String())
 		if msg == "" {
 			msg = err.Error()
@@ -208,18 +254,22 @@ func (d *doclingExtractor) runStdout(ctx context.Context, inputPath string) (str
 	if err != nil {
 		return "", err
 	}
+	ctx, cancel := context.WithTimeout(ctx, doclingExtractTimeout)
+	defer cancel()
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	cmd.WaitDelay = doclingWaitDelay
 	// Run docling with a sanitized environment so it uses only its bundled
 	// venv. A stray PYTHONPATH/PYTHONHOME in the caller's shell (e.g. from a
 	// conda install) would otherwise be added to the venv interpreter's
 	// sys.path and shadow the venv's pinned packages with a different version.
 	cmd.Env = SanitizeDoclingEnv(os.Environ())
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &limitedBuffer{buf: &stdout, limit: maxDoclingOutputBytes}
+	stdoutBuf := &limitedBuffer{buf: &bytes.Buffer{}, limit: maxDoclingOutputBytes}
+	var stderr bytes.Buffer
+	cmd.Stdout = stdoutBuf
 	cmd.Stderr = &limitedBuffer{buf: &stderr, limit: maxDoclingStderrBytes}
 	if err := cmd.Run(); err != nil {
-		if errors.Is(err, errDoclingOutputTooLarge) {
-			return "", fmt.Errorf("docling command output exceeded limit")
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("docling command timed out after %s", doclingExtractTimeout)
 		}
 		msg := strings.TrimSpace(stderr.String())
 		if msg == "" {
@@ -228,7 +278,12 @@ func (d *doclingExtractor) runStdout(ctx context.Context, inputPath string) (str
 		return "", fmt.Errorf("docling command failed: %s", msg)
 	}
 
-	out := strings.TrimSpace(stdout.String())
+	// The buffer keeps draining past the cap (so the child never deadlocks on a
+	// full pipe); reject over-cap stdout here, after the command has exited.
+	if stdoutBuf.Truncated() {
+		return "", fmt.Errorf("docling command output exceeded limit")
+	}
+	out := strings.TrimSpace(stdoutBuf.buf.String())
 	if out == "" {
 		return "", fmt.Errorf("docling command produced empty output")
 	}

--- a/internal/ingest/docling_extractor_internal_test.go
+++ b/internal/ingest/docling_extractor_internal_test.go
@@ -1,0 +1,107 @@
+package ingest
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestLimitedBuffer_OverCapNeverErrors is the core regression guard for issue
+// #406: when wired as cmd.Stdout/cmd.Stderr, a Write that returns an error
+// makes os/exec stop draining the pipe and the child deadlocks on a full pipe.
+// Over-cap writes must therefore always report the full length and a nil error,
+// retain only up to the cap, and flag truncation.
+func TestLimitedBuffer_OverCapNeverErrors(t *testing.T) {
+	lb := &limitedBuffer{buf: &bytes.Buffer{}, limit: 8}
+
+	n, err := lb.Write([]byte("1234"))
+	if err != nil || n != 4 {
+		t.Fatalf("under-cap write: n=%d err=%v", n, err)
+	}
+	if lb.Truncated() {
+		t.Fatal("did not expect truncation under cap")
+	}
+
+	// Straddles the cap: 4 bytes already buffered, writing 8 more (total 12 > 8).
+	n, err = lb.Write([]byte("ABCDEFGH"))
+	if err != nil {
+		t.Fatalf("straddling write returned error (would deadlock os/exec): %v", err)
+	}
+	if n != 8 {
+		t.Fatalf("straddling write must report full length to keep pipe draining, got n=%d", n)
+	}
+	if !lb.Truncated() {
+		t.Fatal("expected truncation flag after exceeding cap")
+	}
+
+	// Fully past the cap: still accepted, still discarded.
+	n, err = lb.Write([]byte("xyz"))
+	if err != nil || n != 3 {
+		t.Fatalf("over-cap write: n=%d err=%v", n, err)
+	}
+
+	if got := lb.buf.Len(); got != 8 {
+		t.Fatalf("buffer retained %d bytes, want cap of 8", got)
+	}
+	if got := lb.buf.String(); got != "1234ABCD" {
+		t.Fatalf("retained content = %q, want %q", got, "1234ABCD")
+	}
+}
+
+// TestLimitedBuffer_ZeroLimitUnbounded confirms a non-positive limit disables
+// capping entirely (used where the buffer must keep everything).
+func TestLimitedBuffer_ZeroLimitUnbounded(t *testing.T) {
+	lb := &limitedBuffer{buf: &bytes.Buffer{}, limit: 0}
+	big := strings.Repeat("z", 10_000)
+	n, err := lb.Write([]byte(big))
+	if err != nil || n != len(big) {
+		t.Fatalf("unbounded write: n=%d err=%v", n, err)
+	}
+	if lb.Truncated() || lb.buf.Len() != len(big) {
+		t.Fatalf("unbounded buffer should retain all bytes, got len=%d truncated=%v", lb.buf.Len(), lb.Truncated())
+	}
+}
+
+// TestRunFileOutput_TimesOutOnHungCommand verifies the per-document timeout
+// (issue #406): a docling command that hangs forever is killed and surfaces a
+// timeout error instead of wedging the indexer. The fake command both sleeps
+// and floods stderr, exercising the deadlock fix and the timeout together.
+func TestRunFileOutput_TimesOutOnHungCommand(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping POSIX-only command test on Windows")
+	}
+	prev := doclingExtractTimeout
+	doclingExtractTimeout = 200 * time.Millisecond
+	t.Cleanup(func() { doclingExtractTimeout = prev })
+
+	// A fake "docling" that floods stderr (stressing the non-erroring
+	// limitedBuffer drain) and then hangs far longer than the timeout. The
+	// command-template splitter is whitespace-delimited, so the body lives in a
+	// script file rather than an inline `sh -c` argument.
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "docling")
+	// exec replaces the shell with sleep so killing the child closes the stderr
+	// pipe immediately (no orphaned process keeps it open).
+	script := "#!/bin/sh\nyes hangingprogress | head -c 5000000 >&2\nexec sleep 30\n"
+	if err := os.WriteFile(fake, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake docling: %v", err)
+	}
+	// {output} keeps the file-output path.
+	ext := NewDoclingExtractor(fake + " --output {output} {input}")
+
+	start := time.Now()
+	_, err := ext.Extract(context.Background(), "sample.pdf", []byte("%PDF-1.4 fake"))
+	elapsed := time.Since(start)
+
+	if err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("expected timeout error, got: %v", err)
+	}
+	if elapsed > 10*time.Second {
+		t.Fatalf("command was not killed promptly by the timeout (took %s)", elapsed)
+	}
+}


### PR DESCRIPTION
## Problem

The docling extractor (`internal/ingest/docling_extractor.go`) could **wedge the entire indexer** on large documents — exactly the large legal PDFs this corpus is built around. Two independent failure modes:

### 1. stderr-cap deadlock
`limitedBuffer.Write` returned an error (`errDoclingOutputTooLarge`) once the 1 MiB stderr cap was exceeded. `limitedBuffer` is wired as `cmd.Stderr`, and when a `Write` returns an error, Go's `os/exec` **stops draining that pipe**. docling then blocks writing to a full pipe and `cmd.Run()` never returns. Since docling streams verbose `tqdm`/`loguru` progress to stderr, a large PDF can easily exceed 1 MiB of stderr and hang indexing forever.

### 2. no per-document timeout
`runFileOutput`/`runStdout` ran `exec.CommandContext` with the long-lived ingest context — no per-extraction bound. A single hung/slow child blocked indexing indefinitely.

## Fix

1. **`limitedBuffer.Write` never errors.** It keeps accepting every write, discarding bytes once over the cap but always returning `(len(p), nil)` so the pipe keeps draining. Overflow is tracked via a new `Truncated()` method. The legacy stdout over-cap rejection (`runStdout`) now checks `Truncated()` **after** `cmd.Run()` returns instead of erroring mid-`Write`. The separate file-output size guard in `readDoclingOutputDir` is unchanged.
2. **Per-document timeout.** Both run paths wrap the context with `context.WithTimeout(ctx, doclingExtractTimeout)` where `doclingExtractTimeout = 15m` — generous headroom above the slowest real legal PDF on CPU-only hosts, while still guaranteeing forward progress. `cmd.WaitDelay = 10s` is a kill backstop so a wedged child that ignores cancellation can't block `Run()` indefinitely. On expiry a clear `"docling command timed out"` error marks the doc failed (retryable) rather than hanging the indexer.

## Tests

New `internal/ingest/docling_extractor_internal_test.go` (white-box, `limitedBuffer` is unexported):
- `TestLimitedBuffer_OverCapNeverErrors` — over-cap writes return no error, report full length, retain only up to the cap, and flag truncation (the deadlock guard).
- `TestLimitedBuffer_ZeroLimitUnbounded` — non-positive limit disables capping.
- `TestRunFileOutput_TimesOutOnHungCommand` — a fake docling that floods stderr then hangs is killed promptly and surfaces a timeout error (exercises both fixes together).

## Validation
- `gofmt`, `go build ./...`, `go vet ./...`, `make cyclo` (nothing over 15) — clean.
- `go test ./internal/ingest/... ./tests/ingest/...` — pass.
- `make ci` — only failure is the pre-existing, unrelated `tests/security` spec-pattern test that needs the `dirstral-spec` submodule checked out (not initialized in this worktree).

Closes #406.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
