### PR TITLE
fix(x402): enforce facilitator verify/settle verdicts (#400)

### DIFF
--- a/internal/mcp/payment.go
+++ b/internal/mcp/payment.go
@@ -111,6 +111,13 @@ func (s *Server) handleToolsCallRequest(ctx context.Context, w http.ResponseWrit
 		s.handlePaymentFailure(w, id, "verify", err, executionKey)
 		return
 	}
+	// The facilitator returns HTTP 200 with {"isValid":false} for a rejected
+	// payment, which surfaces here as a nil Go error. Inspect the verdict and
+	// fail closed so an invalid payment never reaches the gated tool.
+	if !paymentVerdictTrue(verifyResponse, "isValid") {
+		s.rejectInvalidPayment(w, id, verifyResponse, executionKey)
+		return
+	}
 	s.emitPaymentEvent("info", "payment_verified", safePaymentResponseFields(verifyResponse))
 	s.appendPaymentLog("payment_verified", safePaymentResponseFields(verifyResponse))
 
@@ -145,6 +152,13 @@ func (s *Server) handleToolsCallRequest(ctx context.Context, w http.ResponseWrit
 		s.handlePaymentFailure(w, id, "settle", err, executionKey)
 		return
 	}
+	// As with verify, the facilitator returns HTTP 200 with {"success":false}
+	// for a failed settlement (nil Go error). Do not mark the outcome settled
+	// or emit a PAYMENT-RESPONSE for an unsettled payment.
+	if !paymentVerdictTrue(settleResponse, "success") {
+		s.rejectFailedSettlement(w, id, settleResponse, executionKey)
+		return
+	}
 
 	// update the cached outcome; if the entry was pruned we need to
 	// reconstruct and persist the successful state before replaying it.
@@ -162,6 +176,87 @@ func (s *Server) handleToolsCallRequest(ctx context.Context, w http.ResponseWrit
 
 	s.emitPaymentEvent("info", "payment_settled", safePaymentResponseFields(settleResponse))
 	s.appendPaymentLog("payment_settled", safePaymentResponseFields(settleResponse))
+}
+
+// paymentVerdictTrue reports whether the facilitator response body carries the
+// named boolean verdict field set to true ("isValid" for verify, "success" for
+// settle). A missing, malformed, or non-true field is treated as false so the
+// payment gate fails closed: the facilitator returns HTTP 200 with
+// isValid=false / success=false for a rejected payment, which surfaces as a nil
+// Go error and must not be mistaken for a successful payment.
+func paymentVerdictTrue(raw json.RawMessage, field string) bool {
+	var parsed map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return false
+	}
+	v, ok := parsed[field]
+	if !ok {
+		return false
+	}
+	var b bool
+	if err := json.Unmarshal(v, &b); err != nil {
+		return false
+	}
+	return b
+}
+
+// paymentStringField extracts a string field from a facilitator response body,
+// returning "" when the field is absent or not a string.
+func paymentStringField(raw json.RawMessage, field string) string {
+	var parsed map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return ""
+	}
+	v, ok := parsed[field]
+	if !ok {
+		return ""
+	}
+	var str string
+	if err := json.Unmarshal(v, &str); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(str)
+}
+
+// rejectInvalidPayment handles a facilitator verify that returned a non-true
+// verdict (isValid=false) without a transport error. It records the verdict and
+// responds with a PAYMENT_INVALID challenge instead of executing the tool.
+func (s *Server) rejectInvalidPayment(w http.ResponseWriter, id interface{}, verifyResponse json.RawMessage, executionKey string) {
+	fields := safePaymentResponseFields(verifyResponse)
+	s.emitPaymentEvent("info", "payment_invalid", fields)
+	s.appendPaymentLog("payment_invalid", fields)
+	message := "payment verification rejected"
+	if reason := paymentStringField(verifyResponse, "invalidReason"); reason != "" {
+		message += ": " + reason
+	}
+	s.handlePaymentFailure(w, id, "verify", &x402.FacilitatorError{
+		Operation:  "verify",
+		StatusCode: http.StatusPaymentRequired,
+		Code:       x402.CodePaymentInvalid,
+		Message:    message,
+		Retryable:  false,
+	}, executionKey)
+}
+
+// rejectFailedSettlement handles a facilitator settle that returned a non-true
+// verdict (success=false) without a transport error. The gated tool has already
+// executed, but the payment did not settle, so the outcome is not marked
+// settled and no successful PAYMENT-RESPONSE is emitted.
+func (s *Server) rejectFailedSettlement(w http.ResponseWriter, id interface{}, settleResponse json.RawMessage, executionKey string) {
+	fields := safePaymentResponseFields(settleResponse)
+	s.emitPaymentEvent("error", "payment_settlement_failed", fields)
+	s.appendPaymentLog("payment_settlement_failed", fields)
+	message := "payment settlement failed"
+	if reason := paymentStringField(settleResponse, "errorReason"); reason != "" {
+		message += ": " + reason
+	}
+	s.handlePaymentFailure(w, id, "settle", &x402.FacilitatorError{
+		Operation:  "settle",
+		StatusCode: http.StatusPaymentRequired,
+		Code:       x402.CodePaymentSettlementFailed,
+		Message:    message,
+		Retryable:  false,
+	}, executionKey)
 }
 
 func (s *Server) handlePaymentFailure(w http.ResponseWriter, id interface{}, operation string, err error, executionKey string) {
@@ -247,6 +342,10 @@ func (s *Server) replayCachedPaymentOutcomeIfAny(ctx context.Context, w http.Res
 	settleResponse, settleErr := s.x402Client.Settle(ctx, paymentSignature, s.x402Requirement)
 	if settleErr != nil {
 		s.handlePaymentFailure(w, id, "settle", settleErr, executionKey)
+		return true
+	}
+	if !paymentVerdictTrue(settleResponse, "success") {
+		s.rejectFailedSettlement(w, id, settleResponse, executionKey)
 		return true
 	}
 	// original outcome loaded above; keep a copy in case the cache entry
@@ -651,7 +750,7 @@ func (s *Server) appendPaymentLog(event string, data map[string]interface{}) {
 // response, including only explicitly allowed fields to avoid recording
 // unexpected or sensitive fields that the facilitator may add in future.
 func safePaymentResponseFields(raw json.RawMessage) map[string]interface{} {
-	allowed := []string{"ok", "txHash", "status", "network", "amount"}
+	allowed := []string{"ok", "txHash", "status", "network", "amount", "isValid", "success", "invalidReason"}
 	var parsed map[string]interface{}
 	if err := json.Unmarshal(raw, &parsed); err != nil {
 		return map[string]interface{}{}

--- a/tests/mcp/x402_test.go
+++ b/tests/mcp/x402_test.go
@@ -160,6 +160,82 @@ func TestX402ToolsCall_VerifyInvalidReturns402WithChallenge(t *testing.T) {
 	}
 }
 
+// TestX402ToolsCall_VerifyVerdictFalseAt200Returns402 covers the security
+// regression in issue #400: a facilitator that returns HTTP 200 with
+// {"isValid":false} (no Go error) must NOT execute the gated tool. The server
+// must reject the call with a 402 PAYMENT_INVALID challenge and never settle.
+func TestX402ToolsCall_VerifyVerdictFalseAt200Returns402(t *testing.T) {
+	t.Parallel()
+	fac := newFacilitatorStub(t)
+	fac.verifyStatus = http.StatusOK // 200 OK, but verdict says invalid
+	fac.verifyBody = `{"isValid":false,"invalidReason":"insufficient_funds"}`
+	facServer := httptest.NewServer(fac)
+	defer facServer.Close()
+
+	cfg := x402EnabledTestConfig("https://resource.example.com")
+	cfg.AuthMode = "none"
+	cfg.X402.FacilitatorURL = facServer.URL
+
+	retriever := &countingSearchRetriever{}
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPCWithHeaders(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":401,"method":"tools/call","params":{"name":"dir2mcp_search","arguments":{"query":"foo"}}}`, map[string]string{
+		"PAYMENT-SIGNATURE": "forged-payment-signature",
+	})
+	defer func() { _ = resp.Body.Close() }()
+
+	assertRPCErrorCodeAndRetryable(t, resp, http.StatusPaymentRequired, "PAYMENT_INVALID", false)
+	if strings.TrimSpace(resp.Header.Get("PAYMENT-REQUIRED")) == "" {
+		t.Fatal("expected PAYMENT-REQUIRED header on rejected (isValid=false) verify")
+	}
+	if retriever.searchCalls.Load() != 0 {
+		t.Fatalf("gated tool executed for an invalid payment: search calls=%d want=0", retriever.searchCalls.Load())
+	}
+	if fac.settleCalls.Load() != 0 {
+		t.Fatalf("settle calls=%d want=0 (must not settle an invalid payment)", fac.settleCalls.Load())
+	}
+}
+
+// TestX402ToolsCall_SettleVerdictFalseAt200Returns402 covers the settle half of
+// issue #400: a facilitator that returns HTTP 200 with {"success":false} (no Go
+// error) must not be reported as a successful settlement. The tool runs (settle
+// happens after execution) but the response must be a 402 with no
+// PAYMENT-RESPONSE header.
+func TestX402ToolsCall_SettleVerdictFalseAt200Returns402(t *testing.T) {
+	t.Parallel()
+	fac := newFacilitatorStub(t)
+	fac.verifyStatus = http.StatusOK
+	fac.verifyBody = `{"ok":true,"isValid":true,"payer":"payer-1"}`
+	fac.settleStatus = http.StatusOK // 200 OK, but verdict says failure
+	fac.settleBody = `{"success":false,"errorReason":"settlement_rejected"}`
+	facServer := httptest.NewServer(fac)
+	defer facServer.Close()
+
+	cfg := x402EnabledTestConfig("https://resource.example.com")
+	cfg.AuthMode = "none"
+	cfg.X402.FacilitatorURL = facServer.URL
+
+	retriever := &countingSearchRetriever{}
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPCWithHeaders(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":402,"method":"tools/call","params":{"name":"dir2mcp_search","arguments":{"query":"foo"}}}`, map[string]string{
+		"PAYMENT-SIGNATURE": "unsettleable-payment-signature",
+	})
+	defer func() { _ = resp.Body.Close() }()
+
+	assertRPCErrorCodeAndRetryable(t, resp, http.StatusPaymentRequired, "PAYMENT_SETTLEMENT_FAILED", false)
+	if strings.TrimSpace(resp.Header.Get("PAYMENT-RESPONSE")) != "" {
+		t.Fatal("expected no PAYMENT-RESPONSE header when settlement verdict is success=false")
+	}
+	if fac.settleCalls.Load() != 1 {
+		t.Fatalf("settle calls=%d want=1", fac.settleCalls.Load())
+	}
+}
+
 func TestX402ToolsCall_ToolErrorDoesNotSettle(t *testing.T) {
 	t.Parallel()
 	fac := newFacilitatorStub(t)


### PR DESCRIPTION
## Summary

`internal/mcp/payment.go` gated `tools/call` on x402 payment, but only checked the **Go `error`** returned by `FacilitatorClient.Verify` / `Settle`. The x402 facilitator returns **HTTP 200** with `{"isValid":false}` (verify) or `{"success":false}` (settle) for a *rejected* payment — which the SDK surfaces as a **nil error**. The verdict was only passed to `safePaymentResponseFields` for logging and never enforced, so a forged/invalid `PAYMENT-SIGNATURE` executed the gated tool for free in **both `on` and `required` modes**.

## Fix

- After a non-error `Verify`, inspect the verdict: `isValid != true` → reject with a `402 PAYMENT_INVALID` challenge and **do not** call `processToolsCall`.
- After a non-error `Settle`, inspect the verdict: `success != true` → `402 PAYMENT_SETTLEMENT_FAILED`; the outcome is **not** marked settled and **no** `PAYMENT-RESPONSE` header is emitted. Same check is applied on the cached settle-retry path.
- The verdict parse **fails closed**: a missing/malformed/non-true field is treated as not-valid.
- Added `isValid`, `success`, `invalidReason` to the `safePaymentResponseFields` audit-log allowlist so the verdict is recorded.

## Tests

- `TestX402ToolsCall_VerifyVerdictFalseAt200Returns402`: facilitator returns `200` + `{"isValid":false}` (no Go error) → asserts the gated tool does **not** execute, response is `402 PAYMENT_INVALID` with a `PAYMENT-REQUIRED` header, and settle is never called. Verified to fail without the fix (returns `200` with the tool result).
- `TestX402ToolsCall_SettleVerdictFalseAt200Returns402`: facilitator returns `200` + `{"success":false}` → asserts `402 PAYMENT_SETTLEMENT_FAILED` and no `PAYMENT-RESPONSE` header.

`go build`, `go vet`, `gofmt`, `make check`, and the targeted x402 suites all pass. No function exceeds gocyclo 15.

Closes #400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Payment-gated actions now fail safely when verification or settlement returns an invalid result, even if the request itself succeeded.
  * Cached payment outcomes are no longer treated as settled unless settlement is confirmed.
  * Response logging now preserves additional payment verdict details for troubleshooting.

* **Tests**
  * Added regression coverage for failed payment verification and failed settlement responses to ensure gated actions are blocked correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->