### PR TITLE
store: enforce document status invariants (#425)

### DIFF
--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -1776,7 +1776,7 @@ func (s *SQLiteStore) CorpusStats(ctx context.Context) (model.CorpusStats, error
 		SELECT
 			COUNT(*) AS scanned,
 			COALESCE(SUM(CASE WHEN deleted = 0 AND status = 'ok' THEN 1 ELSE 0 END), 0) AS indexed,
-			COALESCE(SUM(CASE WHEN deleted = 0 AND status = 'skipped' THEN 1 ELSE 0 END), 0) AS skipped,
+			COALESCE(SUM(CASE WHEN deleted = 0 AND status IN ('skipped', 'secret_excluded') THEN 1 ELSE 0 END), 0) AS skipped,
 			COALESCE(SUM(CASE WHEN deleted = 1 THEN 1 ELSE 0 END), 0) AS deleted,
 			COALESCE(SUM(CASE WHEN deleted = 0 AND status = 'error' THEN 1 ELSE 0 END), 0) AS errors
 		FROM documents`,
@@ -1818,10 +1818,19 @@ func (s *SQLiteStore) NextPending(ctx context.Context, limit int, indexKind stri
 	}
 
 	args := []any{"pending"}
+	// Skip chunks whose parent document is errored or tombstoned: a doc whose
+	// status is 'error' (e.g. a later representation failed after an earlier
+	// rep's chunks committed) or is deleted must not keep live embeddable
+	// chunks that the embed worker re-embeds every cycle. Documents are keyed
+	// by rel_path, which chunks denormalize, so a LEFT JOIN on it predicates
+	// the parent's lifecycle at candidate selection. The NULL guard preserves a
+	// chunk with no document row (e.g. UpsertChunkTask seeds a bare chunk).
 	query := `WITH filtered_chunks AS (
 	            SELECT c.chunk_id, c.rel_path, c.doc_type, c.rep_type, c.text, c.index_kind, c.modality, c.media_ref, c.language
 	            FROM chunks c
+	            LEFT JOIN documents d ON d.rel_path = c.rel_path
 	            WHERE c.embedding_status = ? AND c.deleted = 0 AND c.chunk_id > 0
+	              AND (d.rel_path IS NULL OR (d.deleted = 0 AND d.status != 'error'))
 	          ),
 	          ranked_spans AS (
 	            SELECT s.chunk_id, s.span_kind, s.start, s."end", s.extra_json,
@@ -2503,6 +2512,13 @@ func normalizeStatus(status string) string {
 		return "skipped"
 	case "error":
 		return "error"
+	case "secret_excluded":
+		// A document withheld because it contains secrets is not "ok": it has
+		// zero searchable chunks and must persist faithfully so it stays
+		// visible as an audit signal (and is counted as skipped, not indexed).
+		return "secret_excluded"
+	case "pending":
+		return "pending"
 	default:
 		return "ok"
 	}

--- a/tests/store/document_status_invariants_test.go
+++ b/tests/store/document_status_invariants_test.go
@@ -1,0 +1,133 @@
+package tests
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// seedDocWithPendingChunk creates a document at relPath with the given status and
+// a single live, pending text chunk hung off a fresh representation. It returns
+// the chunk id so callers can assert NextPending visibility.
+func seedDocWithPendingChunk(ctx context.Context, t *testing.T, st *store.SQLiteStore, relPath, status string) int64 {
+	t.Helper()
+	if err := st.UpsertDocument(ctx, model.Document{
+		RelPath: relPath, DocType: "md", SourceType: "filesystem", Status: status,
+	}); err != nil {
+		t.Fatalf("UpsertDocument(%s, %s): %v", relPath, status, err)
+	}
+	doc, err := st.GetDocumentByPath(ctx, relPath)
+	if err != nil {
+		t.Fatalf("GetDocumentByPath(%s): %v", relPath, err)
+	}
+
+	var chunkID int64
+	err = st.WithTx(ctx, func(tx model.RepresentationStore) error {
+		repID, rerr := tx.UpsertRepresentation(ctx, model.Representation{
+			DocID: doc.DocID, RepType: "raw_text", RepHash: "h-" + relPath,
+		})
+		if rerr != nil {
+			return rerr
+		}
+		id, cerr := tx.InsertChunkWithSpans(ctx, model.Chunk{
+			RepID: repID, Ordinal: 0, Text: "body of " + relPath, TextHash: "th-" + relPath,
+			IndexKind: "text", EmbeddingStatus: "pending",
+		}, []model.Span{{Kind: "lines", StartLine: 1, EndLine: 1}})
+		chunkID = id
+		return cerr
+	})
+	if err != nil {
+		t.Fatalf("seed chunk for %s: %v", relPath, err)
+	}
+	return chunkID
+}
+
+// TestDocumentStatus_SecretExcludedRoundTrips pins issue #425 invariant 1: a
+// document withheld because it contains secrets is persisted faithfully as
+// "secret_excluded" (not collapsed to "ok" by normalizeStatus) and is counted as
+// skipped, not indexed, so the audit signal survives.
+func TestDocumentStatus_SecretExcludedRoundTrips(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	defer func() { _ = st.Close() }()
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	const relPath = "secrets/leaked.env"
+	if err := st.UpsertDocument(ctx, model.Document{
+		RelPath: relPath, DocType: "env", SourceType: "filesystem", Status: "secret_excluded",
+	}); err != nil {
+		t.Fatalf("UpsertDocument: %v", err)
+	}
+
+	doc, err := st.GetDocumentByPath(ctx, relPath)
+	if err != nil {
+		t.Fatalf("GetDocumentByPath: %v", err)
+	}
+	if doc.Status != "secret_excluded" {
+		t.Fatalf("status = %q, want secret_excluded (must not collapse to ok)", doc.Status)
+	}
+
+	// Add an ordinary indexed doc so we can tell indexed/skipped apart.
+	if err := st.UpsertDocument(ctx, model.Document{
+		RelPath: "docs/ok.md", DocType: "md", SourceType: "filesystem", Status: "ok",
+	}); err != nil {
+		t.Fatalf("UpsertDocument(ok): %v", err)
+	}
+
+	stats, err := st.CorpusStats(ctx)
+	if err != nil {
+		t.Fatalf("CorpusStats: %v", err)
+	}
+	if stats.Indexed != 1 {
+		t.Fatalf("Indexed = %d, want 1 (secret_excluded must not be indexed)", stats.Indexed)
+	}
+	if stats.Skipped != 1 {
+		t.Fatalf("Skipped = %d, want 1 (secret_excluded must count as skipped)", stats.Skipped)
+	}
+}
+
+// TestNextPending_SkipsErroredAndDeletedParents pins issue #425 invariant 2:
+// NextPending must not hand out chunks whose parent document is status='error'
+// or tombstoned, while chunks of an 'ok' document remain visible.
+func TestNextPending_SkipsErroredAndDeletedParents(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	defer func() { _ = st.Close() }()
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	okChunk := seedDocWithPendingChunk(ctx, t, st, "docs/ok.md", "ok")
+	_ = seedDocWithPendingChunk(ctx, t, st, "docs/broken.md", "error")
+	deletedChunk := seedDocWithPendingChunk(ctx, t, st, "docs/gone.md", "ok")
+	if err := st.MarkDocumentDeleted(ctx, "docs/gone.md"); err != nil {
+		t.Fatalf("MarkDocumentDeleted: %v", err)
+	}
+
+	tasks, err := st.NextPending(ctx, 100, "text")
+	if err != nil {
+		t.Fatalf("NextPending: %v", err)
+	}
+
+	got := make(map[int64]bool, len(tasks))
+	for _, task := range tasks {
+		got[int64(task.Label)] = true
+	}
+
+	if !got[okChunk] {
+		t.Fatalf("ok document's chunk %d missing from NextPending: %#v", okChunk, tasks)
+	}
+	for _, task := range tasks {
+		if task.Metadata.RelPath == "docs/broken.md" {
+			t.Fatalf("errored document's chunk leaked into NextPending: %#v", task)
+		}
+	}
+	if got[deletedChunk] {
+		t.Fatalf("tombstoned document's chunk %d leaked into NextPending", deletedChunk)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes two document status-invariant violations in `internal/store/sqlite_store.go` that let withheld/failed documents masquerade as healthy indexed content.

### 1. `normalizeStatus` collapsed unknown statuses to `ok`
It only recognized `skipped`/`error`; everything else (including `secret_excluded`, set by ingest when a file is withheld for containing secrets) was rewritten to `ok`. The doc was then persisted as an indexed `ok` document with zero chunks — counted as indexed, audit signal lost.

- Recognize `secret_excluded` and `pending` so they round-trip faithfully.
- Count `secret_excluded` as **skipped** (not indexed) in `CorpusStats` (`status IN ('skipped','secret_excluded')`).

### 2. `NextPending` ignored the parent document's lifecycle
It selected pending chunks with no parent-document check, so a document that later went `status='error'` (a representation failed *after* an earlier rep's chunks committed) kept **live embeddable/searchable chunks** that the embed worker re-embedded every cycle.

- `LEFT JOIN documents ON rel_path` and skip chunks whose parent is `status='error'` or tombstoned (`deleted=1`).
- A `d.rel_path IS NULL` guard preserves bare chunks with no document row (e.g. `UpsertChunkTask`-seeded chunks), so existing behavior is not regressed.

### Tests
New `tests/store/document_status_invariants_test.go`:
- (a) a doc upserted with `status='secret_excluded'` round-trips as `secret_excluded` (not `ok`) and is counted as skipped, not indexed.
- (b) chunks of a `status='error'` document (and a tombstoned document) are NOT returned by `NextPending`, while an `ok` document's chunk IS.

Full `make check` passes (gofmt, vet, golangci-lint, gocyclo, ineffassign, misspell, tests, build). Only `internal/store/sqlite_store.go` and the new test file changed.

Closes #425.

🤖 Generated with [Claude Code](https://claude.com/claude-code)