### PR TITLE
cli: refuse reindex under a live daemon (#418)

### DIFF
--- a/internal/cli/reindex.go
+++ b/internal/cli/reindex.go
@@ -27,15 +27,21 @@ func (a *App) runReindex(ctx context.Context, global globalOptions, args []strin
 		return exitConfigInvalid
 	}
 
+	cfg, code := a.loadReindexConfig(global)
+	if code != exitSuccess {
+		return code
+	}
+	// Refuse before prompting/destroying anything: a reindex under a live
+	// daemon corrupts the shared index/state (issue #418).
+	if code := a.refuseReindexIfDaemonRunning(global, cfg); code != exitSuccess {
+		return code
+	}
+
 	if !a.confirmDestructive(global, "Re-index all documents?", "Discards the current index and rebuilds it from scratch (may re-run OCR/embeddings).") {
 		writeln(a.stderr, "reindex aborted")
 		return exitSuccess
 	}
 
-	cfg, code := a.loadReindexConfig(global)
-	if code != exitSuccess {
-		return code
-	}
 	st, code := a.prepareReindexStore(ctx, global, cfg)
 	if code != exitSuccess {
 		return code
@@ -73,6 +79,40 @@ func (a *App) loadReindexConfig(global globalOptions) (config.Config, int) {
 	}
 	cfg.StateDir = baseDir
 	return cfg, exitSuccess
+}
+
+// refuseReindexIfDaemonRunning blocks a reindex when a live `dir2mcp up`
+// daemon owns the same state dir. A reindex clears content hashes and
+// unlinks the on-disk vector index (see prepareReindexStore); doing that
+// under a running daemon means two concurrent sqlite writers and index
+// files removed out from under a process that still holds them open —
+// index/state corruption, with the daemon continuing to serve a freed,
+// stale index (issue #418). We reuse the exact pid-file + liveness check
+// `up` uses to detect an already-running instance (readPIDFile +
+// processIsAlive) rather than reimplementing pid logic, and refuse with
+// an actionable error instead of racing the daemon.
+//
+// Returns exitSuccess (reindex may proceed) when there is no pid file,
+// the pid file is unreadable/malformed, or it names a dead process — none
+// of which we can positively identify as a live daemon.
+func (a *App) refuseReindexIfDaemonRunning(global globalOptions, cfg config.Config) int {
+	pid, err := readPIDFile(pidFilePath(cfg.StateDir))
+	if err != nil {
+		// No pid file (the common case) or a malformed one: nothing we can
+		// confirm is a live daemon, so let the reindex proceed. `down`
+		// handles cleanup of a malformed pid file.
+		return exitSuccess
+	}
+	if !processIsAlive(pid) {
+		// Stale pid file from a daemon that crashed/exited without cleanup —
+		// safe to reindex.
+		return exitSuccess
+	}
+	writeCLIError(a.stderr, global.jsonOutput, exitGeneric,
+		fmt.Sprintf("dir2mcp is running for %s (pid %d); refusing to reindex under a live daemon", cfg.StateDir, pid),
+		"Stop it with `dir2mcp down` first, then re-run `dir2mcp reindex`.",
+	)
+	return exitGeneric
 }
 
 // prepareReindexStore creates the state directory, opens the store,

--- a/tests/cli/reindex_daemon_guard_test.go
+++ b/tests/cli/reindex_daemon_guard_test.go
@@ -1,0 +1,109 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/cli"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// TestReindex_RefusesWhenDaemonAlive verifies the issue #418 guard:
+// `reindex` must refuse — with a clear, actionable error and a non-zero
+// exit — when a live daemon owns the same state dir, and it must NOT
+// delete the on-disk index files before bailing out. Otherwise reindex
+// runs concurrent sqlite writers and unlinks index files the daemon
+// still holds open, corrupting the shared state.
+func TestReindex_RefusesWhenDaemonAlive(t *testing.T) {
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, ".dir2mcp")
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	// A pid file naming THIS (alive) process stands in for a live daemon.
+	pidPath := filepath.Join(stateDir, "server.pid")
+	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(os.Getpid())+"\n"), 0o600); err != nil {
+		t.Fatalf("write pid file: %v", err)
+	}
+	// A sentinel index file that prepareReindexStore would remove if the
+	// guard failed to fire.
+	indexFile := filepath.Join(stateDir, "vectors_text.v2.hnsw")
+	if err := os.WriteFile(indexFile, []byte("INDEX"), 0o600); err != nil {
+		t.Fatalf("seed index file: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	reindexCalled := false
+	app := cli.NewAppWithIOAndHooks(&stdout, &stderr, cli.RuntimeHooks{
+		NewIngestor: func(_ config.Config, _ model.Store) (model.Ingestor, error) {
+			reindexCalled = true
+			return reindexNoopIngestor{}, nil
+		},
+	})
+
+	var code int
+	withWorkingDir(t, tmp, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		code = app.RunWithContext(ctx, []string{"reindex"})
+	})
+
+	if code == 0 {
+		t.Fatalf("expected non-zero exit when daemon is alive; got 0 (stderr=%q)", stderr.String())
+	}
+	if reindexCalled {
+		t.Error("ingestor should not be constructed when reindex refuses")
+	}
+	errOut := stderr.String()
+	if !strings.Contains(errOut, "dir2mcp down") {
+		t.Errorf("error should tell the user to stop the daemon with `dir2mcp down`; got %q", errOut)
+	}
+	if _, err := os.Stat(indexFile); err != nil {
+		t.Errorf("index file must NOT be deleted when reindex refuses; stat err=%v", err)
+	}
+	if data, err := os.ReadFile(indexFile); err != nil || string(data) != "INDEX" {
+		t.Errorf("index file content changed; data=%q err=%v", string(data), err)
+	}
+}
+
+// TestReindex_ProceedsWithStalePidFile verifies the guard does not
+// false-positive on a stale pid file (a daemon that crashed without
+// cleanup): a pid that is not alive must let the reindex run.
+func TestReindex_ProceedsWithStalePidFile(t *testing.T) {
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, ".dir2mcp")
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	// A high pid that is almost certainly dead exercises the
+	// processIsAlive==false branch (stale pid file from a crashed daemon).
+	pidPath := filepath.Join(stateDir, "server.pid")
+	if err := os.WriteFile(pidPath, []byte("2147480000\n"), 0o600); err != nil {
+		t.Fatalf("write stale pid file: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIOAndHooks(&stdout, &stderr, cli.RuntimeHooks{
+		NewIngestor: func(_ config.Config, _ model.Store) (model.Ingestor, error) {
+			return reindexNoopIngestor{}, nil
+		},
+	})
+
+	var code int
+	withWorkingDir(t, tmp, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		code = app.RunWithContext(ctx, []string{"reindex"})
+	})
+
+	if code != 0 {
+		t.Fatalf("reindex should proceed with a stale pid file; exit=%d stderr=%q", code, stderr.String())
+	}
+}


### PR DESCRIPTION
## Summary

`internal/cli/reindex.go` `prepareReindexStore` opens the sqlite store and `os.Remove`s the HNSW/index files **without first checking whether a `dir2mcp up` daemon is live for the same state dir**. If a daemon is running, `dir2mcp reindex` runs concurrent sqlite writers AND unlinks index files the daemon still holds open → index/state corruption, with the daemon continuing to serve a freed, stale index.

This adds a guard at the very start of the reindex flow — **before** the confirmation prompt and any destructive operation — that detects a live daemon and refuses with a clear, actionable error (non-zero exit) telling the user to stop the daemon first with `dir2mcp down`.

## Implementation

- New `refuseReindexIfDaemonRunning` reuses the **exact** liveness mechanism `up`/`up_daemon.go` use — `readPIDFile(pidFilePath(stateDir))` + `processIsAlive` — rather than reimplementing any pid logic.
- A missing pid file (common case), a malformed pid file, or a stale pid file naming a dead process all let reindex proceed exactly as before (no false positives on a crashed daemon).
- Config load was hoisted above the confirmation prompt so the guard can refuse before asking the user to confirm a destructive action.

## Scope

Partially addresses #418 (reindex live-daemon guard). The other #418 items live in other files and are intentionally left for separate PRs:
- destructive-first ordering / staging-and-swap (`reindex.go` part 2) — deferred
- pid-reuse identity in `down`/`up` (`down.go`/`daemon.go`)
- stale `status` "running" reconciliation (`status.go`)

## Tests

`tests/cli/reindex_daemon_guard_test.go`:
- `TestReindex_RefusesWhenDaemonAlive` — live pid → non-zero exit, error mentions `dir2mcp down`, ingestor never constructed, and the seeded index file is **not** deleted.
- `TestReindex_ProceedsWithStalePidFile` — stale (dead) pid → reindex proceeds.

Full `make check` (incl. golangci-lint + gocyclo) passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)