### PR TITLE
fix(cli): synchronize ndjson emitter + atomic connection.json write (#436)

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -16,6 +16,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -245,7 +246,12 @@ type ndjsonEvent struct {
 
 type ndjsonEmitter struct {
 	enabled bool
-	out     io.Writer
+	// mu serializes writes to out. A single emitter is the shared sink for
+	// concurrent ask/search query_metrics events and the corpus writer;
+	// without synchronization their lines (which can exceed PIPE_BUF) may
+	// interleave and corrupt server.log.
+	mu  sync.Mutex
+	out io.Writer
 }
 
 type cliErrorPayload struct {
@@ -1709,7 +1715,55 @@ func writeConnectionFile(path string, payload connectionPayload) error {
 	// readable by other accounts) those are credential-adjacent. The
 	// state directory is 0o700 already, but defending in depth keeps a
 	// permissive parent directory from leaking the file's contents.
-	return os.WriteFile(path, content, 0o600)
+	//
+	// Write atomically (temp file + fsync + rename) so a concurrent reader
+	// — readiness poll, support bundle, or claude_cmd — never observes a
+	// truncated/partial file the way an in-place os.WriteFile(O_TRUNC) can.
+	return atomicWriteFile(path, content, 0o600)
+}
+
+// atomicWriteFile writes data to path atomically: it writes to a sibling
+// temp file in the same directory, fsyncs it, chmods it to mode, then
+// renames it over path (with a Windows remove-and-retry fallback). The
+// rename guarantees a concurrent reader sees either the old or the new file,
+// never a partial one. A per-write temp name keeps concurrent writers from
+// stomping each other's temp file.
+func atomicWriteFile(path string, data []byte, mode os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmpFile, err := os.CreateTemp(dir, filepath.Base(path)+".tmp.")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	tmp := tmpFile.Name()
+
+	if _, err := tmpFile.Write(data); err != nil {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmp)
+		return fmt.Errorf("write temp file: %w", err)
+	}
+	if err := tmpFile.Sync(); err != nil {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmp)
+		return fmt.Errorf("sync temp file: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("close temp file: %w", err)
+	}
+	if err := os.Chmod(tmp, mode); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("chmod temp file: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		// os.Rename fails on Windows when the destination already exists.
+		// Remove the existing file and retry once to support Windows.
+		_ = os.Remove(path)
+		if err2 := os.Rename(tmp, path); err2 != nil {
+			_ = os.Remove(tmp)
+			return fmt.Errorf("rename temp file: %w", err2)
+		}
+	}
+	return nil
 }
 
 // newNDJSONEmitter constructs an ndjsonEmitter that writes events to out
@@ -1772,44 +1826,15 @@ func writeCorpusSnapshot(ctx context.Context, stateDir string, st model.Store, i
 		return err
 	}
 
-	path := filepath.Join(stateDir, "corpus.json")
-	// Use a per-write temporary file so concurrent snapshot writers don't
-	// stomp each other's tmp file and trigger spurious ENOENT on rename.
-	tmpFile, err := os.CreateTemp(stateDir, "corpus.json.tmp.")
-	if err != nil {
-		return fmt.Errorf("create temp corpus snapshot: %w", err)
-	}
-	tmp := tmpFile.Name()
-
 	raw, err := json.MarshalIndent(snapshot, "", "  ")
 	if err != nil {
-		_ = tmpFile.Close()
-		_ = os.Remove(tmp)
 		return fmt.Errorf("marshal corpus snapshot: %w", err)
 	}
 
-	if _, err := tmpFile.Write(raw); err != nil {
-		_ = tmpFile.Close()
-		_ = os.Remove(tmp)
-		return fmt.Errorf("write temp corpus snapshot: %w", err)
-	}
-	if err := tmpFile.Close(); err != nil {
-		_ = os.Remove(tmp)
-		return fmt.Errorf("close temp corpus snapshot: %w", err)
-	}
 	// Match previous file mode (0o644) used with os.WriteFile.
-	if err := os.Chmod(tmp, 0o644); err != nil {
-		_ = os.Remove(tmp)
-		return fmt.Errorf("chmod temp corpus snapshot: %w", err)
-	}
-	if err := os.Rename(tmp, path); err != nil {
-		// os.Rename fails on Windows when the destination already exists.
-		// Remove the existing file and retry once to support Windows.
-		_ = os.Remove(path)
-		if err2 := os.Rename(tmp, path); err2 != nil {
-			_ = os.Remove(tmp)
-			return fmt.Errorf("rename corpus snapshot: %w", err2)
-		}
+	path := filepath.Join(stateDir, "corpus.json")
+	if err := atomicWriteFile(path, raw, 0o644); err != nil {
+		return fmt.Errorf("write corpus snapshot: %w", err)
 	}
 	return nil
 }
@@ -2078,6 +2103,8 @@ func (e *ndjsonEmitter) Emit(level, event string, data interface{}) {
 	if err != nil {
 		return
 	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
 	_, _ = fmt.Fprintln(e.out, string(encoded))
 }
 

--- a/internal/cli/corpus_writer_test.go
+++ b/internal/cli/corpus_writer_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -9,6 +10,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -273,4 +275,192 @@ func readCorpusFileMaybe(t *testing.T, path string) (corpusSnapshot, error) {
 		return corpusSnapshot{}, err
 	}
 	return snap, nil
+}
+
+// syncBuffer is a bytes.Buffer guarded by its own mutex so the test harness can
+// inspect emitter output without racing the emitter's writes. The emitter must
+// still serialize its own writes; this only protects the test's reads.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) Bytes() []byte {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return append([]byte(nil), b.buf.Bytes()...)
+}
+
+// TestNDJSONEmitter_ConcurrentEmitNoInterleave asserts that many goroutines
+// sharing a single emitter produce non-interleaved, individually-valid JSON
+// lines. Each event carries a payload large enough to exceed PIPE_BUF so that
+// an unsynchronized fmt.Fprintln would interleave; the mutex in Emit prevents
+// it. Run with -race to also catch the data race on e.out.
+func TestNDJSONEmitter_ConcurrentEmitNoInterleave(t *testing.T) {
+	t.Parallel()
+
+	var out syncBuffer
+	emitter := newNDJSONEmitter(&out, true)
+
+	const goroutines = 32
+	const perGoroutine = 50
+	// Payload comfortably larger than the 512-byte POSIX PIPE_BUF minimum so a
+	// non-atomic write would tear.
+	payload := strings.Repeat("x", 2048)
+
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < perGoroutine; i++ {
+				emitter.Emit("info", "query_metrics", map[string]any{
+					"goroutine": id,
+					"seq":       i,
+					"blob":      payload,
+				})
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	lines := 0
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var ev ndjsonEvent
+		if err := json.Unmarshal(line, &ev); err != nil {
+			t.Fatalf("corrupt/interleaved NDJSON line %d: %v\nline: %q", lines, err, string(line))
+		}
+		if ev.Event != "query_metrics" {
+			t.Fatalf("unexpected event on line %d: %q", lines, ev.Event)
+		}
+		lines++
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan emitter output: %v", err)
+	}
+	if want := goroutines * perGoroutine; lines != want {
+		t.Fatalf("expected %d non-interleaved lines, got %d", want, lines)
+	}
+}
+
+// TestWriteConnectionFile_AtomicNoTempLeftover asserts that a successful write
+// leaves a complete, valid file with its 0o600 mode preserved and no leftover
+// temp files in the directory.
+func TestWriteConnectionFile_AtomicNoTempLeftover(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "connection.json")
+	payload := connectionPayload{
+		Transport:   "http",
+		URL:         "http://127.0.0.1:8080/mcp",
+		Headers:     map[string]string{"Authorization": "Bearer redacted"},
+		TokenSource: "file",
+		TokenFile:   filepath.Join(dir, "token"),
+	}
+
+	if err := writeConnectionFile(path, payload); err != nil {
+		t.Fatalf("writeConnectionFile: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat connection.json: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("expected connection.json mode 0o600, got %o", got)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read connection.json: %v", err)
+	}
+	var got connectionPayload
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("connection.json is not valid JSON: %v", err)
+	}
+	if got.URL != payload.URL || got.TokenFile != payload.TokenFile {
+		t.Fatalf("round-trip mismatch: got %+v want %+v", got, payload)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".tmp.") {
+			t.Fatalf("leftover temp file after atomic write: %q", e.Name())
+		}
+	}
+}
+
+// TestWriteConnectionFile_ConcurrentReadNeverPartial hammers writeConnectionFile
+// from one goroutine while another repeatedly reads the file; because the write
+// is atomic (temp + rename) the reader must always see either no file or a
+// complete, valid JSON document — never a truncated one.
+func TestWriteConnectionFile_ConcurrentReadNeverPartial(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "connection.json")
+	payload := connectionPayload{
+		Transport: "http",
+		URL:       "http://127.0.0.1:8080/mcp",
+		Headers:   map[string]string{"Authorization": "Bearer " + strings.Repeat("a", 4096)},
+	}
+
+	const writes = 200
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < writes; i++ {
+			if err := writeConnectionFile(path, payload); err != nil {
+				t.Errorf("writeConnectionFile: %v", err)
+				return
+			}
+		}
+		close(done)
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				if os.IsNotExist(err) {
+					continue
+				}
+				t.Errorf("read connection.json: %v", err)
+				return
+			}
+			var got connectionPayload
+			if err := json.Unmarshal(raw, &got); err != nil {
+				t.Errorf("reader saw partial/corrupt connection.json: %v\nbytes=%d", err, len(raw))
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
 }


### PR DESCRIPTION
Addresses the emitter-race + connection.json-atomicity parts of #436 (bundle-redaction + snapshot-staleness deferred).

## Changes (internal/cli/app.go only)

### FIX 1 — unsynchronized NDJSON emitter (M1)
`ndjsonEmitter.Emit` wrote to the shared `e.out` (server.log) with a bare `fmt.Fprintln` and no lock, while a single emitter is the shared sink for concurrent ask/search `query_metrics` events *and* the corpus writer. Those lines can exceed `PIPE_BUF`, so concurrent unsynchronized writes could interleave and corrupt lines. Added a `sync.Mutex` to the struct and lock around the only write site.

### FIX 2 — connection.json non-atomic write (D3)
`writeConnectionFile` used `os.WriteFile` (`O_CREATE|O_TRUNC`), so a concurrent reader (readiness poll, support bundle, `claude_cmd`) could observe a truncated/partial file. It now writes atomically via a sibling temp file + `fsync` + rename, preserving the existing `0o600` mode. Factored the temp+sync+rename logic into a shared `atomicWriteFile` helper and routed `writeCorpusSnapshot` through it too (de-duplicating its previously-inline implementation).

## Tests (internal/cli/corpus_writer_test.go)
- `TestNDJSONEmitter_ConcurrentEmitNoInterleave`: 32 goroutines × 50 emits of >PIPE_BUF payloads through one emitter; asserts every output line is individually-valid JSON and the exact expected count (no interleaving). Passes under `-race`.
- `TestWriteConnectionFile_AtomicNoTempLeftover`: success leaves a complete valid file at mode `0o600` and no `.tmp.` leftovers.
- `TestWriteConnectionFile_ConcurrentReadNeverPartial`: a reader hammering the file during 200 rewrites only ever sees a complete, valid JSON document (or no file).

New tests were placed in the already-allowlisted `corpus_writer_test.go` to keep the `internal/cli` file-ownership boundary test green without touching `tests/security`.

`make check` passes locally (vet, golangci-lint, gocyclo -over 15, misspell, full test suite incl. `-race`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)