### PR TITLE
ingest: rune-correct structured flush + bound code chunks by chars (#417)

### DIFF
--- a/internal/ingest/represent.go
+++ b/internal/ingest/represent.go
@@ -379,6 +379,15 @@ const (
 	structuredChunkMinChars     = 200
 )
 
+// Code chunking is primarily line-based, but a single window (or a single very
+// long line, e.g. a minified JS/CSS bundle) must still be bounded by characters
+// so it stays within the embedder's input limit. codeChunkMaxChars is a rune
+// budget, kept consistent with the structured/text chunkers.
+const (
+	codeChunkMaxChars     = structuredChunkMaxChars
+	codeChunkOverlapChars = structuredChunkOverlapChars
+)
+
 // chunkStructuredBlocks implements section/element-aware chunking over the
 // ordered blocks of a structured document (spec §7.5): consecutive blocks
 // sharing the same section breadcrumb are grouped, then split by size; tables
@@ -416,6 +425,7 @@ type structuredChunker struct {
 	out          []chunkSegment
 	buf          []docling.Block
 	bufText      strings.Builder
+	bufRunes     int
 	bufSection   []string
 }
 
@@ -442,10 +452,15 @@ func (c *structuredChunker) add(b docling.Block) {
 	}
 	if c.bufText.Len() > 0 {
 		c.bufText.WriteString("\n\n")
+		c.bufRunes += 2
 	}
 	c.bufText.WriteString(b.Text)
+	c.bufRunes += utf8.RuneCountInString(b.Text)
 	c.buf = append(c.buf, b)
-	if c.bufText.Len() >= c.maxChars {
+	// maxChars is a rune budget; compare against the accumulated rune count, not
+	// strings.Builder.Len() (bytes) — otherwise multibyte text (Cyrillic, CJK)
+	// flushes at a fraction of the intended size and over-fragments chunks.
+	if c.bufRunes >= c.maxChars {
 		c.flush()
 	}
 }
@@ -465,6 +480,7 @@ func (c *structuredChunker) flush() {
 	buffered := c.buf
 	c.buf = nil
 	c.bufText.Reset()
+	c.bufRunes = 0
 	c.bufSection = nil
 	if text == "" || len(buffered) == 0 {
 		return
@@ -1002,7 +1018,21 @@ func chunkCodeByLines(content string, maxLines, overlapLines int) []chunkSegment
 		if text == "" {
 			continue
 		}
-		out = append(out, chunkSegment{
+		out = appendCodeWindow(out, text, start, end)
+		if end == len(lines) {
+			break
+		}
+	}
+	return out
+}
+
+// appendCodeWindow emits a line-window's text as one chunk, or—when the window
+// exceeds the rune cap (e.g. a minified single-line bundle)—splits it further by
+// characters so no chunk overruns the embedder input limit. Sub-segment line
+// numbers are mapped back into the window's absolute [start+1, end] range.
+func appendCodeWindow(out []chunkSegment, text string, start, end int) []chunkSegment {
+	if utf8.RuneCountInString(text) <= codeChunkMaxChars {
+		return append(out, chunkSegment{
 			Text: text,
 			Span: model.Span{
 				Kind:      "lines",
@@ -1010,9 +1040,16 @@ func chunkCodeByLines(content string, maxLines, overlapLines int) []chunkSegment
 				EndLine:   end,
 			},
 		})
-		if end == len(lines) {
-			break
-		}
+	}
+	for _, sub := range chunkTextByChars(text, codeChunkMaxChars, codeChunkOverlapChars, 1) {
+		out = append(out, chunkSegment{
+			Text: sub.Text,
+			Span: model.Span{
+				Kind:      "lines",
+				StartLine: start + sub.Span.StartLine,
+				EndLine:   start + sub.Span.EndLine,
+			},
+		})
 	}
 	return out
 }

--- a/tests/ingest/represent_test.go
+++ b/tests/ingest/represent_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/dirstral/dir2mcp/internal/ingest"
 	"github.com/dirstral/dir2mcp/internal/model"
@@ -279,6 +280,47 @@ func TestChunkCodeByLines(t *testing.T) {
 	}
 	if chunks[1].Span.StartLine != 171 {
 		t.Fatalf("expected overlap start line 171, got %d", chunks[1].Span.StartLine)
+	}
+}
+
+// TestChunkCodeByLines_MinifiedSingleLineSplitByChars pins that a minified
+// single-long-line bundle (no newlines) is bounded by characters rather than
+// emitted as one giant chunk that would exceed the embedder input limit.
+func TestChunkCodeByLines_MinifiedSingleLineSplitByChars(t *testing.T) {
+	const maxCodeChars = 2500
+	// One physical line, ~6000 runes, well over the per-chunk char cap.
+	content := strings.Repeat("a", 6000)
+	chunks := ingest.ChunkCodeByLines(content, 200, 30)
+	if len(chunks) < 2 {
+		t.Fatalf("expected the oversize single line to split into multiple chunks, got %d", len(chunks))
+	}
+	for i, c := range chunks {
+		if c.Span.Kind != "lines" {
+			t.Errorf("chunk %d span kind = %q, want lines", i, c.Span.Kind)
+		}
+		if c.Span.StartLine != 1 || c.Span.EndLine != 1 {
+			t.Errorf("chunk %d span = %+v, want single-line [1,1]", i, c.Span)
+		}
+		if n := utf8.RuneCountInString(c.Text); n > maxCodeChars {
+			t.Errorf("chunk %d has %d runes, exceeds cap %d", i, n, maxCodeChars)
+		}
+	}
+}
+
+// TestChunkCodeByLines_LongLineWithinWindowSplit pins that an oversize line
+// inside a multi-line window is still split by characters, with every chunk
+// staying under the cap.
+func TestChunkCodeByLines_LongLineWithinWindowSplit(t *testing.T) {
+	const maxCodeChars = 2500
+	content := "short header\n" + strings.Repeat("b", 8000) + "\nshort footer"
+	chunks := ingest.ChunkCodeByLines(content, 200, 30)
+	if len(chunks) < 2 {
+		t.Fatalf("expected oversize window to split, got %d chunks", len(chunks))
+	}
+	for i, c := range chunks {
+		if n := utf8.RuneCountInString(c.Text); n > maxCodeChars {
+			t.Errorf("chunk %d has %d runes, exceeds cap %d", i, n, maxCodeChars)
+		}
 	}
 }
 

--- a/tests/ingest/structured_chunk_test.go
+++ b/tests/ingest/structured_chunk_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/dirstral/dir2mcp/internal/ingest"
 	"github.com/dirstral/dir2mcp/internal/ingest/docling"
@@ -95,6 +96,80 @@ func TestChunkStructuredBlocks_PageSpanFallback(t *testing.T) {
 	}
 	if segs[0].Span.Kind != "page" || segs[0].Span.Page != 4 {
 		t.Errorf("span = %+v, want page span on page 4", segs[0].Span)
+	}
+}
+
+// TestChunkStructuredBlocks_MultibyteFlushUsesRunesNotBytes pins the F6 fix:
+// the structured chunker's flush trigger is a RUNE budget (maxChars=2500), not a
+// byte length. A run of same-section Cyrillic blocks totalling well under 2500
+// runes — but well over 2500 *bytes* (2 bytes/rune) — must group into a single
+// chunk, not fragment because strings.Builder.Len() (bytes) tripped the flush.
+func TestChunkStructuredBlocks_MultibyteFlushUsesRunesNotBytes(t *testing.T) {
+	// 10 blocks × 200 Cyrillic runes = 2000 runes (~4000 bytes) plus joiners,
+	// still < 2500 runes but > 2500 bytes.
+	const blockCount = 10
+	const runesPerBlock = 200
+	blocks := make([]docling.Block, 0, blockCount)
+	for i := 0; i < blockCount; i++ {
+		blocks = append(blocks, docling.Block{
+			Label:   "paragraph",
+			Text:    strings.Repeat("я", runesPerBlock),
+			Page:    1,
+			BBox:    bbox(1),
+			Section: []string{"Раздел"},
+		})
+	}
+
+	segs := ingest.ChunkStructuredBlocks(blocks)
+	if len(segs) != 1 {
+		t.Fatalf("expected the multibyte same-section run to group into 1 chunk, got %d", len(segs))
+	}
+	// The single chunk should carry roughly the full rune budget's worth of text,
+	// proving the flush did NOT fire early on byte length.
+	if n := utf8.RuneCountInString(segs[0].Text); n < 2000 {
+		t.Fatalf("grouped chunk has only %d runes, want ~2000+ (early byte-based flush?)", n)
+	}
+	if n := utf8.RuneCountInString(segs[0].Text); n > 2500 {
+		t.Fatalf("grouped chunk has %d runes, exceeds the 2500 rune budget", n)
+	}
+}
+
+// TestChunkStructuredBlocks_MultibyteFlushesAtRuneBudget pins that once a
+// same-section multibyte run exceeds the 2500-rune budget it does split — but at
+// the rune budget, yielding chunks near 2500 runes rather than ~1250 (the byte
+// bug would split a 2-byte/rune script at half the intended size).
+func TestChunkStructuredBlocks_MultibyteFlushesAtRuneBudget(t *testing.T) {
+	const blockCount = 30
+	const runesPerBlock = 200 // 30×200 = 6000 runes total
+	blocks := make([]docling.Block, 0, blockCount)
+	for i := 0; i < blockCount; i++ {
+		blocks = append(blocks, docling.Block{
+			Label:   "paragraph",
+			Text:    strings.Repeat("я", runesPerBlock),
+			Page:    1,
+			BBox:    bbox(1),
+			Section: []string{"Раздел"},
+		})
+	}
+
+	segs := ingest.ChunkStructuredBlocks(blocks)
+	if len(segs) < 2 {
+		t.Fatalf("expected a 6000-rune run to split, got %d chunks", len(segs))
+	}
+	var largest int
+	for _, s := range segs {
+		n := utf8.RuneCountInString(s.Text)
+		if n > 2500 {
+			t.Fatalf("chunk has %d runes, exceeds the 2500 rune budget", n)
+		}
+		if n > largest {
+			largest = n
+		}
+	}
+	// With correct rune accounting at least one chunk approaches the budget; the
+	// byte bug would cap every chunk near ~1250 runes.
+	if largest < 1500 {
+		t.Fatalf("largest chunk only %d runes; flush appears byte-based, not rune-based", largest)
 	}
 }
 


### PR DESCRIPTION
Addresses the rune-flush (F6) + code-chunk-oversize (F3) parts of #417 (charset/language/rerank-pool parts deferred).

## What

Two surgical chunking fixes in `internal/ingest/represent.go`.

### FIX F6 — structured flush byte-vs-rune (the TV-Rain Russian bug)
`structuredChunker.add` compared `strings.Builder.Len()` (BYTES) against `maxChars` (a RUNE budget, `structuredChunkMaxChars=2500`). For multibyte scripts (Cyrillic ~2 B/rune, CJK ~3 B/rune) the flush fired at roughly half/third the intended size, over-fragmenting structured docs into many small, weaker-embedding chunks. Now tracks an explicit rune counter (`bufRunes`) and triggers the flush at `maxChars` **runes**.

### FIX F3 — code chunking line-only oversize
`chunkCodeByLines` (docType `code`) split purely by line count (`maxLines=200`) with no char/token cap, so a minified `.js`/`.css` or single-line bundle became ONE chunk = the whole file, blowing past the embedder input limit (silent reject or truncation). Each line-window is now bounded by a rune cap (`codeChunkMaxChars=2500`, consistent with the text/structured chunkers); oversize windows and single very long lines are split via the rune-correct `chunkTextByChars`, with sub-segment line numbers mapped back into the window's absolute `[start+1, end]` range. No infinite loop; rune-correct throughout.

## Tests
- `TestChunkStructuredBlocks_MultibyteFlushUsesRunesNotBytes` / `_FlushesAtRuneBudget`: a same-section Cyrillic run that is under 2500 runes but over 2500 bytes groups into a single chunk; a larger run splits at the rune budget (chunks approach 2500, not ~1250).
- `TestChunkCodeByLines_MinifiedSingleLineSplitByChars` / `_LongLineWithinWindowSplit`: a minified single-long-line input yields multiple chunks, each under the cap.

## Scope
Only `internal/ingest/represent.go` and its tests. The charset-detection, language-tagging, and rerank-pool-truncation parts of #417 are intentionally left out.

`make check` passes locally (incl. golangci-lint + gocyclo; new helper stays under 15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)