### PR TITLE
ingest: harden ExtractTitle against shebangs, page headers, and front-matter (#442)

### DIFF
--- a/internal/ingest/title.go
+++ b/internal/ingest/title.go
@@ -19,10 +19,14 @@ const titleMaxLen = 200
 // beginning of a text/markdown/OCR body. Used to humanize citations whose
 // rel_path is opaque (e.g. Windows 8.3-truncated PDF filenames).
 //
-// Heuristic, in order of preference (markdown headings always win, even when
-// they appear after an earlier uppercase-line candidate):
-//  1. The first markdown heading line (`# Title`, `## Title`, ...).
-//  2. The first line that is mostly uppercase and looks title-like.
+// Heuristic, in order of preference (earlier wins):
+//  1. A `title:` key inside a leading YAML front-matter block (the author's
+//     explicitly declared title).
+//  2. The first markdown ATX heading line (`# Title`, `## Title`, ...) or a
+//     setext H1 (a line followed by a `=====` underline). Code-fenced lines are
+//     skipped so a `#` comment inside a fence is not mistaken for a heading.
+//  3. The first line that is mostly uppercase and looks title-like (not a
+//     digit-heavy page/running header or a colon-terminated label).
 //
 // Returns an empty string if no candidate is found. Callers should treat the
 // empty result as "no title available" and fall back to rel_path themselves.
@@ -31,20 +35,52 @@ func ExtractTitle(body string) string {
 		return ""
 	}
 	body = truncateOnRuneBoundary(body, titleScanLimit)
+	lines := strings.Split(body, "\n")
+
+	// 1. YAML front-matter title wins outright when declared.
+	if title, end, present := frontMatterTitle(lines); present {
+		if title != "" {
+			return title
+		}
+		// Front-matter block present but no title key: skip its lines so the
+		// body scan does not treat front-matter values as title candidates.
+		lines = lines[end:]
+	}
+
+	return titleFromBody(lines)
+}
+
+// titleFromBody scans the (post front-matter) lines for a markdown heading,
+// setext H1, or an uppercase-line fallback. Markdown headings win even when an
+// earlier uppercase-line candidate exists; the uppercase fallback is only
+// returned if no heading is found anywhere in the scanned window.
+func titleFromBody(lines []string) string {
 	var uppercaseFallback string
-	for _, raw := range strings.Split(body, "\n") {
+	var prev string // previous non-blank, non-fence line (for setext underline)
+	inFence := false
+	for _, raw := range lines {
 		line := strings.TrimSpace(raw)
-		if line == "" {
+		if isFenceDelimiter(line) {
+			inFence = !inFence
+			prev = ""
+			continue
+		}
+		if inFence || line == "" {
+			prev = ""
 			continue
 		}
 		if title := titleFromMarkdownHeading(line); title != "" {
 			return title
+		}
+		if prev != "" && isSetextUnderline(line) {
+			return clampTitle(prev)
 		}
 		if uppercaseFallback == "" {
 			if title := titleFromUppercaseLine(line); title != "" {
 				uppercaseFallback = title
 			}
 		}
+		prev = line
 	}
 	return uppercaseFallback
 }
@@ -65,12 +101,97 @@ func truncateOnRuneBoundary(s string, maxBytes int) string {
 	return s[:cut]
 }
 
+// frontMatterTitle parses a leading YAML front-matter block delimited by `---`
+// lines and returns its `title:` value. present is true only when a complete
+// block (opening and closing delimiter) is found; end is the index of the first
+// body line after the closing delimiter. A bare leading `---` with no closing
+// delimiter is treated as not-a-block (it may be a thematic break or setext
+// rule) so the body scan still runs over it.
+func frontMatterTitle(lines []string) (title string, end int, present bool) {
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
+		return "", 0, false
+	}
+	for i := 1; i < len(lines); i++ {
+		switch strings.TrimSpace(lines[i]) {
+		case "---", "...":
+			return title, i + 1, true
+		}
+		if title == "" {
+			if v, ok := frontMatterValue(lines[i], "title"); ok {
+				title = v
+			}
+		}
+	}
+	return "", 0, false
+}
+
+// frontMatterValue extracts the value of a `key:` mapping line (case-insensitive
+// key), stripping a single layer of matching surrounding quotes and clamping to
+// titleMaxLen. ok is false when the line is not the requested key or the value
+// is empty.
+func frontMatterValue(line, key string) (string, bool) {
+	trimmed := strings.TrimSpace(line)
+	prefix := key + ":"
+	if !strings.HasPrefix(strings.ToLower(trimmed), prefix) {
+		return "", false
+	}
+	val := strings.TrimSpace(trimmed[len(prefix):])
+	val = trimMatchingQuotes(val)
+	val = clampTitle(val)
+	if val == "" {
+		return "", false
+	}
+	return val, true
+}
+
+func trimMatchingQuotes(s string) string {
+	if len(s) >= 2 {
+		first, last := s[0], s[len(s)-1]
+		if (first == '"' && last == '"') || (first == '\'' && last == '\'') {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
+}
+
+// isFenceDelimiter reports whether a trimmed line opens or closes a fenced code
+// block (``` or ~~~, at least three of the same character, optionally with an
+// info string).
+func isFenceDelimiter(line string) bool {
+	return strings.HasPrefix(line, "```") || strings.HasPrefix(line, "~~~")
+}
+
+// isSetextUnderline reports whether a trimmed line is a setext H1 underline: a
+// non-empty run consisting solely of `=` characters.
+func isSetextUnderline(line string) bool {
+	if line == "" {
+		return false
+	}
+	for _, r := range line {
+		if r != '=' {
+			return false
+		}
+	}
+	return true
+}
+
+// titleFromMarkdownHeading returns the text of an ATX heading line. Per
+// CommonMark the opening run of 1-6 `#` must be followed by a space/tab (or end
+// of line); this rejects shebangs (`#!/usr/bin/env python`), hashtags
+// (`#nowplaying`), and `#`-prefixed code comments that are not headings.
 func titleFromMarkdownHeading(line string) string {
-	if !strings.HasPrefix(line, "#") {
+	hashes := 0
+	for hashes < len(line) && line[hashes] == '#' {
+		hashes++
+	}
+	if hashes == 0 || hashes > 6 {
 		return ""
 	}
-	stripped := strings.TrimLeft(line, "#")
-	stripped = strings.TrimSpace(stripped)
+	rest := line[hashes:]
+	if rest != "" && rest[0] != ' ' && rest[0] != '\t' {
+		return ""
+	}
+	stripped := strings.TrimSpace(rest)
 	if stripped == "" {
 		return ""
 	}
@@ -78,16 +199,20 @@ func titleFromMarkdownHeading(line string) string {
 }
 
 // titleFromUppercaseLine returns the line if it looks like an act/document
-// title: at least 3 letters, mostly uppercase, no trailing sentence punctuation.
+// title: at least 3 letters, mostly uppercase, not digit-heavy (a page or
+// running header such as `PAGE 1 OF 10` / `JANUARY 2026`), and not terminated
+// by sentence punctuation or a label colon (`ABSTRACT:`).
 func titleFromUppercaseLine(line string) string {
-	letters := 0
-	upper := 0
+	letters, upper, digits := 0, 0, 0
 	for _, r := range line {
-		if unicode.IsLetter(r) {
+		switch {
+		case unicode.IsLetter(r):
 			letters++
 			if unicode.IsUpper(r) {
 				upper++
 			}
+		case unicode.IsDigit(r):
+			digits++
 		}
 	}
 	if letters < 3 {
@@ -96,7 +221,13 @@ func titleFromUppercaseLine(line string) string {
 	if float64(upper)/float64(letters) < 0.7 {
 		return ""
 	}
-	if last := lastNonSpace(line); last == '.' {
+	// Digit-heavy lines are page numbers / running headers, not titles. A lone
+	// year embedded in a long title (e.g. "... ACT, 2021") stays under this bar.
+	if digits*2 >= letters {
+		return ""
+	}
+	switch lastNonSpace(line) {
+	case '.', ':':
 		return ""
 	}
 	return clampTitle(line)

--- a/internal/ingest/title_test.go
+++ b/internal/ingest/title_test.go
@@ -59,6 +59,71 @@ func TestExtractTitle(t *testing.T) {
 			want: "",
 		},
 		{
+			name: "#442: shebang is not a markdown heading",
+			body: "#!/usr/bin/env python\nprint('hello world')\n",
+			want: "",
+		},
+		{
+			name: "#442: hashtag is not a markdown heading",
+			body: "#nowplaying just vibing to some lo-fi beats\nmore lowercase body\n",
+			want: "",
+		},
+		{
+			name: "#442: YAML front-matter title wins outright",
+			body: "---\ntitle: The Real Title\n---\nCHAPTER ONE\n\nbody text\n",
+			want: "The Real Title",
+		},
+		{
+			name: "#442: front-matter title strips surrounding quotes",
+			body: "---\nauthor: Jane Doe\ntitle: \"Quoted Title\"\n---\nbody\n",
+			want: "Quoted Title",
+		},
+		{
+			name: "#442: front-matter without a title key falls through to heading",
+			body: "---\nauthor: Jane Doe\ndate: 2026-06-25\n---\n# Fallback Heading\n",
+			want: "Fallback Heading",
+		},
+		{
+			name: "#442: bare leading --- (no close) is not front-matter; heading still wins",
+			body: "---\n# Just A Heading\n",
+			want: "Just A Heading",
+		},
+		{
+			name: "#442: digit-heavy page header is not a title",
+			body: "PAGE 1 OF 10\n\nsome lowercase body that follows the header\n",
+			want: "",
+		},
+		{
+			name: "#442: month/year running header is not a title",
+			body: "JANUARY 2026\n\nsome lowercase body that follows the header\n",
+			want: "",
+		},
+		{
+			name: "#442: colon-terminated label is not a title",
+			body: "ABSTRACT:\nthis is the abstract body, all lowercase prose.\n",
+			want: "",
+		},
+		{
+			name: "#442: genuine all-caps title still works",
+			body: "MAIN TITLE\n\nsome lowercase body text\n",
+			want: "MAIN TITLE",
+		},
+		{
+			name: "#442: all-caps title with a trailing year still works",
+			body: "PROLIFERATION FINANCING (PROHIBITION) ACT, 2021\n\nbody\n",
+			want: "PROLIFERATION FINANCING (PROHIBITION) ACT, 2021",
+		},
+		{
+			name: "#442: # comment inside a code fence is not a heading",
+			body: "```python\n# this is a code comment, not a heading\nx = 1\n```\n\nMAIN TITLE\n",
+			want: "MAIN TITLE",
+		},
+		{
+			name: "#442: setext H1 underline is recognized",
+			body: "The Setext Title\n================\n\nbody text\n",
+			want: "The Setext Title",
+		},
+		{
 			name: "scan limit honored — late title is found if before limit",
 			body: padding(titleScanLimit-200) + "# Late Title Within Window",
 			want: "Late Title Within Window",


### PR DESCRIPTION
Addresses the title-extraction part of #442 (image-annotation part deferred).

Scoped to `internal/ingest/title.go` (+ its test). Fixes the `ExtractTitle` heuristic:

- **5.3 Shebang/hashtag are not headings.** ATX headings now require a space/tab after the 1-6 `#` run (CommonMark), so `#!/usr/bin/env python` and `#nowplaying` no longer become titles.
- **5.2 YAML front-matter title is honored.** A leading `---` front-matter block is parsed and its `title:` value becomes the highest-priority source (strips one layer of matching quotes). A block with no `title:` key is skipped so its values aren't mistaken for candidates.
- **5.1 Page headers / labels rejected.** The uppercase-line fallback now rejects digit-heavy running headers (`PAGE 1 OF 10`, `JANUARY 2026`) and colon-terminated labels (`ABSTRACT:`), in addition to the existing trailing-`.` rule.
- **5.4 Setext H1** (`Title` + `=====` underline) is recognized.
- Fenced code blocks are tracked so a `#` comment inside a fence is not treated as a heading.

Conservative: genuine all-caps titles (including ones with a trailing year, e.g. `... ACT, 2021`) and real `# Heading` lines still extract exactly as before. The existing #383 (docling-tempfile) and #417 (BOM) paths are untouched.

Adds regression tests covering: shebang/hashtag not a title; front-matter title used (and quote-stripped); front-matter without title falls through; `PAGE 1 OF 10` / `JANUARY 2026` / `ABSTRACT:` not titles; normal `# Heading` and `MAIN TITLE` still work; code-fence `#` comment ignored; setext H1.

`make check` passes locally (gofmt/vet/golangci-lint/gocyclo/tests/build).

The image-annotation part of #442 (`mcp/tools.go`, `ingest/service.go`) is intentionally out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)