### PR TITLE
ingest: persist status=error when a provider failure yields zero reps (#413)

### DIFF
--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -1279,7 +1279,7 @@ func (s *Service) processDocument(ctx context.Context, f DiscoveredFile, secretP
 		return nil
 	}
 
-	if err := s.generateRepresentations(ctx, doc, content, forceReindex); err != nil {
+	if err := s.generateRepresentations(ctx, doc, content, secretPatterns, forceReindex); err != nil {
 		// Persist error status so the next incremental run retries this document
 		// and operators can identify it via status queries.  Silence the upsert
 		// error since the original rep error is the more actionable signal.
@@ -1526,7 +1526,7 @@ func (s *Service) processDocumentFromContent(ctx context.Context, relPath string
 	if !needsProcessing || doc.Status != "ok" {
 		return nil
 	}
-	if err := s.generateRepresentations(ctx, doc, content, forceReindex); err != nil {
+	if err := s.generateRepresentations(ctx, doc, content, secretPatterns, forceReindex); err != nil {
 		// Persist error status so the next incremental run retries this document
 		// and operators can identify it via status queries.  Silence the upsert
 		// error since the original rep error is the more actionable signal.
@@ -1934,7 +1934,7 @@ func isEmbeddableAudio(relPath string) bool {
 	}
 }
 
-func (s *Service) generateRepresentations(ctx context.Context, doc model.Document, content []byte, forceReindex bool) error {
+func (s *Service) generateRepresentations(ctx context.Context, doc model.Document, content []byte, secretPatterns []*regexp.Regexp, forceReindex bool) error {
 	if s.repGen == nil {
 		return nil
 	}
@@ -1968,7 +1968,7 @@ func (s *Service) generateRepresentations(ctx context.Context, doc model.Documen
 		return nil
 	}
 
-	return s.generateTranscriptOrSidecar(ctx, doc, content, forceReindex)
+	return s.generateTranscriptOrSidecar(ctx, doc, content, secretPatterns, forceReindex, mediaProduced)
 }
 
 // generateTranscriptOrSidecar resolves a media document's transcript. Subtitle
@@ -1977,7 +1977,7 @@ func (s *Service) generateRepresentations(ctx context.Context, doc model.Documen
 // transcript is authoritative. `--force`/reindex overrides the gate, retiring
 // any stale sidecar transcripts and re-running STT. Sidecar ingestion bypasses
 // the quality gate (authored, not model-derived; §8.6.6/§8.6.7).
-func (s *Service) generateTranscriptOrSidecar(ctx context.Context, doc model.Document, content []byte, forceReindex bool) error {
+func (s *Service) generateTranscriptOrSidecar(ctx context.Context, doc model.Document, content []byte, secretPatterns []*regexp.Regexp, forceReindex, mediaProduced bool) error {
 	if !forceReindex {
 		ingested, err := s.ingestSidecarTranscripts(ctx, doc)
 		if err != nil {
@@ -1999,6 +1999,20 @@ func (s *Service) generateTranscriptOrSidecar(ctx context.Context, doc model.Doc
 		if errors.Is(err, ErrTranscriptProviderFailure) {
 			s.getLogger().Printf("transcription skipped for %s: %v", doc.RelPath, err)
 			s.addErrors(1)
+			// #413: a genuine provider failure that left the document with no
+			// representation of its own (no media chunks under multimodal
+			// `augment`) must not stay status="ok" — that hid the unsearchable
+			// audio from CorpusStats.Errors / RecentFailures / FailureSummary and
+			// reported errors=0 after a restart. Persist it as status="error" so
+			// the failure is durably visible and is retried on the next
+			// incremental run, while STILL returning nil so the batch continues. A
+			// document that DID produce media chunks stays "ok": it remains
+			// searchable, so it is not a zero-representation failure. Legitimately
+			// empty media never reaches here — an empty transcript returns nil
+			// without ErrTranscriptProviderFailure.
+			if !mediaProduced {
+				s.persistNonFatalDocError(ctx, doc, err, secretPatterns)
+			}
 			return nil
 		}
 		return err
@@ -2033,6 +2047,23 @@ func (s *Service) retireStaleSidecarTranscripts(ctx context.Context, doc model.D
 		s.getLogger().Printf("retired %d stale sidecar transcript(s) for %s before STT reindex", n, doc.RelPath)
 	}
 	return nil
+}
+
+// persistNonFatalDocError records a per-document failure that must NOT abort the
+// batch run (the caller still returns nil) by re-upserting the document as
+// status="error" with a redacted message. Without it, a document that produced
+// zero representations because of a genuine provider failure would stay
+// status="ok" and be invisible to CorpusStats.Errors / RecentFailures /
+// FailureSummary — silently unsearchable, with errors=0 reported after a restart
+// (#413). The upsert error is logged and swallowed because the original failure
+// is the more actionable signal, mirroring the generateRepresentations error
+// path. The live error counter is incremented separately by the caller.
+func (s *Service) persistNonFatalDocError(ctx context.Context, doc model.Document, cause error, secretPatterns []*regexp.Regexp) {
+	doc.Status = "error"
+	doc.ErrorMessage = RedactSecretsInMessage(cause.Error(), secretPatterns)
+	if err := s.store.UpsertDocument(ctx, doc); err != nil {
+		s.getLogger().Printf("persist error status for %s: %v", doc.RelPath, err)
+	}
 }
 
 // persistTitleIfFound runs the title heuristic on the supplied text body and,

--- a/tests/ingest/service_test.go
+++ b/tests/ingest/service_test.go
@@ -598,8 +598,16 @@ func TestServiceRun_AudioTranscriberFailure_DoesNotFailRun(t *testing.T) {
 	if !ok {
 		t.Fatal("expected audio document to be upserted")
 	}
-	if doc.Status != "ok" {
-		t.Fatalf("expected audio document status to remain ok, got %q", doc.Status)
+	// #413: a genuine provider failure that produced zero representations must be
+	// persisted as status="error" with a descriptive message — not silently left
+	// status="ok", which hid the unsearchable audio from CorpusStats.Errors /
+	// RecentFailures and reported errors=0 after a restart. The run itself still
+	// must not fail (asserted above).
+	if doc.Status != "error" {
+		t.Fatalf("expected audio document status to be persisted as error, got %q", doc.Status)
+	}
+	if doc.ErrorMessage == "" {
+		t.Fatal("expected a descriptive error_message on the failed audio document")
 	}
 }
 

--- a/tests/ingest/zero_rep_failure_test.go
+++ b/tests/ingest/zero_rep_failure_test.go
@@ -1,0 +1,78 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// TestProcessDocument_TranscriptProviderFailure_PersistsErrorStatus is the
+// regression guard for #413: an audio document whose transcription fails with a
+// genuine provider failure produces zero representations, yet the previous code
+// left it status="ok" — invisible to CorpusStats.Errors / RecentFailures and
+// reporting errors=0 after a restart (the audio was silently unsearchable). The
+// failure must now be persisted as status="error" (with an error_message) and
+// surface in RecentFailures / CorpusStats.Errors, while the ingest run itself
+// still does NOT hard-fail (the batch continues).
+func TestProcessDocument_TranscriptProviderFailure_PersistsErrorStatus(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "talk.mp3"), "fake-audio")
+	st := newRealStore(t)
+
+	svc := sttService(t, root, t.TempDir(), st, "whisper", "whisper-large-v3", "en",
+		&fakeTranscriber{err: errors.New("provider down")})
+
+	f := ingest.DiscoveredFile{RelPath: "talk.mp3", SizeBytes: 10, MTimeUnix: time.Now().Unix()}
+
+	// A per-document transcript provider failure must not hard-fail the run.
+	if err := svc.ProcessDocument(context.Background(), f, nil, false); err != nil {
+		t.Fatalf("ProcessDocument hard-failed on a per-document transcript provider failure: %v", err)
+	}
+
+	// The document is persisted as status="error" with a descriptive message
+	// rather than being silently left status="ok".
+	doc, err := st.GetDocumentByPath(context.Background(), "talk.mp3")
+	if err != nil {
+		t.Fatalf("GetDocumentByPath: %v", err)
+	}
+	if doc.Status != "error" {
+		t.Fatalf("doc status = %q, want \"error\" (a zero-representation provider failure must not stay ok)", doc.Status)
+	}
+	if doc.ErrorMessage == "" {
+		t.Fatal("doc error_message is empty; the failure carries no descriptive message")
+	}
+
+	// It surfaces in RecentFailures (newest-first, status='error').
+	failures, err := st.RecentFailures(context.Background(), 20)
+	if err != nil {
+		t.Fatalf("RecentFailures: %v", err)
+	}
+	if !recentFailuresContain(failures, "talk.mp3") {
+		t.Fatalf("talk.mp3 missing from RecentFailures: %+v", failures)
+	}
+
+	// And CorpusStats.Errors — the persisted count that survives a restart —
+	// includes it (the bug reported errors=0 here).
+	stats, err := st.CorpusStats(context.Background())
+	if err != nil {
+		t.Fatalf("CorpusStats: %v", err)
+	}
+	if stats.Errors < 1 {
+		t.Fatalf("CorpusStats.Errors = %d, want >= 1", stats.Errors)
+	}
+}
+
+func recentFailuresContain(docs []model.Document, relPath string) bool {
+	for _, d := range docs {
+		if d.RelPath == relPath {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Problem

On `ErrTranscriptProviderFailure`, `generateTranscriptOrSidecar` logged, called `addErrors(1)`, and `return nil` — leaving the audio document `status="ok"` with no transcript and **never persisting it as an error**. The failure was therefore invisible to:

- `CorpusStats.Errors` (counts `status='error'` rows)
- `RecentFailures`
- `FailureSummary`

So a transcription provider failure left the audio **silently unsearchable**, and the corpus reported `errors=0` after a daemon restart (the live counter is in-memory only).

## Fix

When a genuine (non-transient) provider failure leaves a document with **zero representations**, persist it as `status="error"` with a redacted `error_message` before `return nil`:

- New `persistNonFatalDocError` helper re-upserts the document as `status="error"` (logging+swallowing the upsert error, mirroring the existing `generateRepresentations` error path). The live `addErrors(1)` counter is kept.
- The persist is gated on `!mediaProduced`: a document that DID produce multimodal media chunks stays `"ok"` (still searchable — not a zero-representation failure). `secretPatterns` and `mediaProduced` are threaded through `generateRepresentations` / `generateTranscriptOrSidecar`.
- **Legitimately empty media is unaffected**: an empty transcript returns `nil` *without* the `ErrTranscriptProviderFailure` sentinel, so it never marks an error.
- The batch is **still not hard-failed** — the run continues (`return nil`), only the persisted status/visibility changes. The failed doc is now also retried on the next incremental run (`resolveNeedsProcessing` retries `status='error'`).

Scope: `internal/ingest/service.go` plus tests.

## Tests

- New `tests/ingest/zero_rep_failure_test.go`: an audio doc whose transcription fails with `ErrTranscriptProviderFailure` is persisted `status='error'` (+ `error_message`) and surfaces in `RecentFailures` and `CorpusStats.Errors`, while `ProcessDocument` does not hard-fail. (real SQLite store, end to end)
- Updated `TestServiceRun_AudioTranscriberFailure_DoesNotFailRun`: it previously asserted the document status *remained* `"ok"` — that encoded the exact #413 bug. It now asserts `status="error"` + non-empty `error_message`, keeping the "run does not fail" guarantee.

`make check` passes locally (build, vet, golangci-lint, gocyclo <15, full test suite, python tests).

Closes #413.

🤖 Generated with [Claude Code](https://claude.com/claude-code)