### PR TITLE
embedqueue: respect maxAttempts on lease-reclaim + set broker DB pragmas (#433)

### DIFF
--- a/internal/embedqueue/membroker.go
+++ b/internal/embedqueue/membroker.go
@@ -115,12 +115,19 @@ func (b *MemBroker) Lease(_ context.Context, visibility time.Duration) (Lease, e
 
 // reclaimExpiredLocked moves in-flight jobs whose lease deadline has passed back
 // to pending so a crashed/abandoned worker cannot strand a chunk (SPEC §8.7.3
-// lease expiry). Caller holds b.mu.
+// lease expiry). A job whose lease expires after it has already exhausted
+// maxAttempts is dead-lettered instead of redelivered, mirroring Nack's gate, so
+// a chunk that reliably kills/hangs the worker before it can Ack/Nack cannot be
+// re-leased forever. Caller holds b.mu.
 func (b *MemBroker) reclaimExpiredLocked(now time.Time) {
 	for token, mj := range b.inflight {
 		if now.After(mj.deadline) {
 			delete(b.inflight, token)
 			mj.token = ""
+			if mj.attempts >= b.maxAttempts {
+				b.deadLetter = append(b.deadLetter, mj)
+				continue
+			}
 			b.pending = append(b.pending, mj)
 		}
 	}

--- a/internal/embedqueue/sqlitebroker.go
+++ b/internal/embedqueue/sqlitebroker.go
@@ -37,6 +37,20 @@ func NewSQLiteBroker(ctx context.Context, path string, maxAttempts int) (*SQLite
 	if err != nil {
 		return nil, fmt.Errorf("embedqueue: open sqlite broker: %w", err)
 	}
+	// Order matters: busy_timeout MUST come before journal_mode (mirrors
+	// internal/store/sqlite_store.go). Under the multi-worker pool the
+	// reclaim-write-first Lease otherwise hits "database is locked" immediately
+	// instead of waiting; WAL further reduces read/write blocking across
+	// connections and processes.
+	for _, pragma := range []string{
+		`PRAGMA busy_timeout=5000;`,
+		`PRAGMA journal_mode=WAL;`,
+	} {
+		if _, err := db.ExecContext(ctx, pragma); err != nil {
+			_ = db.Close()
+			return nil, fmt.Errorf("embedqueue: configure sqlite broker: %w", err)
+		}
+	}
 	b, err := newSQLiteBroker(ctx, db, true, maxAttempts)
 	if err != nil {
 		_ = db.Close()
@@ -143,6 +157,34 @@ WHERE NOT EXISTS (
 	return nil
 }
 
+// execer is the subset of *sql.DB / *sql.Tx that reclaimExpired needs, so the
+// same reclaim runs both inside Lease's transaction and on Stats's bare handle.
+type execer interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+}
+
+// reclaimExpired moves in-flight jobs whose lease deadline has passed back to
+// pending so a crashed/abandoned worker cannot strand a chunk (SPEC §8.7.3 lease
+// expiry). A job whose lease expires after it has already exhausted maxAttempts
+// is dead-lettered instead of redelivered, mirroring Nack's gate, so a chunk that
+// reliably kills/hangs the worker before it can Ack/Nack cannot be re-leased
+// forever. The dead-letter UPDATE runs first so attempts-exhausted rows are not
+// caught by the requeue UPDATE.
+func (b *SQLiteBroker) reclaimExpired(ctx context.Context, q execer, nowNS int64) error {
+	if _, err := q.ExecContext(ctx,
+		`UPDATE embed_jobs SET state='dead', token=NULL, deadline_ns=0
+		   WHERE state='inflight' AND deadline_ns < ? AND attempts >= ?`,
+		nowNS, b.maxAttempts); err != nil {
+		return fmt.Errorf("embedqueue: reclaim dead-letter: %w", err)
+	}
+	if _, err := q.ExecContext(ctx,
+		`UPDATE embed_jobs SET state='pending', token=NULL, deadline_ns=0
+		   WHERE state='inflight' AND deadline_ns < ?`, nowNS); err != nil {
+		return fmt.Errorf("embedqueue: reclaim: %w", err)
+	}
+	return nil
+}
+
 // Lease reclaims expired leases, then atomically claims the oldest claimable
 // pending job.
 func (b *SQLiteBroker) Lease(ctx context.Context, visibility time.Duration) (Lease, error) {
@@ -158,10 +200,8 @@ func (b *SQLiteBroker) Lease(ctx context.Context, visibility time.Duration) (Lea
 	defer func() { _ = tx.Rollback() }()
 
 	// Reclaim expired in-flight leases (SPEC §8.7.3 lease expiry).
-	if _, err := tx.ExecContext(ctx,
-		`UPDATE embed_jobs SET state='pending', token=NULL, deadline_ns=0
-		   WHERE state='inflight' AND deadline_ns < ?`, nowNS); err != nil {
-		return Lease{}, fmt.Errorf("embedqueue: lease reclaim: %w", err)
+	if err := b.reclaimExpired(ctx, tx, nowNS); err != nil {
+		return Lease{}, err
 	}
 
 	var (
@@ -253,10 +293,8 @@ func (b *SQLiteBroker) Nack(ctx context.Context, token string, retryAfter time.D
 // are accurate.
 func (b *SQLiteBroker) Stats(ctx context.Context) (Stats, error) {
 	nowNS := b.now().UnixNano()
-	if _, err := b.db.ExecContext(ctx,
-		`UPDATE embed_jobs SET state='pending', token=NULL, deadline_ns=0
-		   WHERE state='inflight' AND deadline_ns < ?`, nowNS); err != nil {
-		return Stats{}, fmt.Errorf("embedqueue: stats reclaim: %w", err)
+	if err := b.reclaimExpired(ctx, b.db, nowNS); err != nil {
+		return Stats{}, err
 	}
 	var s Stats
 	row := b.db.QueryRowContext(ctx, `

--- a/internal/embedqueue/sqlitebroker_pragma_test.go
+++ b/internal/embedqueue/sqlitebroker_pragma_test.go
@@ -1,0 +1,40 @@
+package embedqueue
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+// TestSQLiteBroker_PragmasConfigured pins F5 (issue #433): when the broker opens
+// its own DB it configures the connection with busy_timeout then journal_mode=WAL
+// (same order/values as internal/store/sqlite_store.go) so the reclaim-write-first
+// Lease waits on contention under the multi-worker pool instead of failing
+// immediately with "database is locked". This is a white-box test because
+// busy_timeout is connection-local and only observable on the broker's own handle.
+func TestSQLiteBroker_PragmasConfigured(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "queue.db")
+
+	b, err := NewSQLiteBroker(ctx, path, 5)
+	if err != nil {
+		t.Fatalf("NewSQLiteBroker: %v", err)
+	}
+	defer func() { _ = b.Close() }()
+
+	var busyTimeout int
+	if err := b.db.QueryRowContext(ctx, `PRAGMA busy_timeout`).Scan(&busyTimeout); err != nil {
+		t.Fatalf("query busy_timeout: %v", err)
+	}
+	if busyTimeout != 5000 {
+		t.Fatalf("busy_timeout = %d, want 5000", busyTimeout)
+	}
+
+	var journalMode string
+	if err := b.db.QueryRowContext(ctx, `PRAGMA journal_mode`).Scan(&journalMode); err != nil {
+		t.Fatalf("query journal_mode: %v", err)
+	}
+	if journalMode != "wal" {
+		t.Fatalf("journal_mode = %q, want \"wal\"", journalMode)
+	}
+}

--- a/tests/embedqueue/broker_test.go
+++ b/tests/embedqueue/broker_test.go
@@ -169,6 +169,53 @@ func TestBroker_NackRedeliversThenDeadLetters(t *testing.T) {
 	}
 }
 
+// TestBroker_ReclaimDeadLettersAfterMaxAttempts pins F1 (issue #433): the
+// lease-reclaim path must respect maxAttempts. A chunk whose embedding reliably
+// kills/hangs the worker dies before it can Ack/Nack, so each lease simply
+// expires and is reclaimed. Reclaim redelivers only up to maxAttempts; once
+// attempts are exhausted the next reclaim dead-letters the job instead of
+// re-leasing it forever. Runs against both default broker impls.
+func TestBroker_ReclaimDeadLettersAfterMaxAttempts(t *testing.T) {
+	for _, bf := range brokerFactories() {
+		t.Run(bf.name, func(t *testing.T) {
+			ctx := context.Background()
+			b := bf.make(t) // maxAttempts = 3
+			now := time.Unix(2_000, 0)
+			bf.setClock(b, func() time.Time { return now })
+
+			if err := b.Enqueue(ctx, sampleJob(5)); err != nil {
+				t.Fatalf("Enqueue: %v", err)
+			}
+
+			// Lease the job maxAttempts times, letting each lease expire without an
+			// Ack/Nack so the next Lease reclaims and redelivers it (the crash-loop).
+			for i := 0; i < 3; i++ {
+				lease, err := b.Lease(ctx, 10*time.Second)
+				if err != nil {
+					t.Fatalf("Lease attempt %d: %v", i+1, err)
+				}
+				if lease.Job.ChunkID != 5 {
+					t.Fatalf("attempt %d leased chunk %d, want 5", i+1, lease.Job.ChunkID)
+				}
+				now = now.Add(11 * time.Second) // let the lease expire
+			}
+
+			// attempts == maxAttempts and the lease has expired: reclaim must
+			// dead-letter the job, not redeliver it.
+			if _, err := b.Lease(ctx, 10*time.Second); err != embedqueue.ErrNoJob {
+				t.Fatalf("post-exhaustion Lease err = %v, want ErrNoJob (job must be dead-lettered)", err)
+			}
+			st, err := b.Stats(ctx)
+			if err != nil {
+				t.Fatalf("Stats: %v", err)
+			}
+			if st.DeadLettered != 1 || st.Pending != 0 || st.InFlight != 0 {
+				t.Fatalf("after reclaim stats = %+v, want DeadLettered=1 only", st)
+			}
+		})
+	}
+}
+
 // TestSQLiteBroker_Durable confirms the SQLite broker persists enqueued jobs
 // across a reopen (a coordinator restart does not lose the backlog).
 func TestSQLiteBroker_Durable(t *testing.T) {


### PR DESCRIPTION
Addresses the reclaim-attempts (F1) + SQLiteBroker-pragmas (F5) parts of #433 (dead-letter write-back F2/F3 deferred)

## F1 [HIGH] — reclaim path ignored `attempts` → poison task redelivered forever
The `maxAttempts`→dead-letter gate existed only in `Nack`. The lease-reclaim path moved an expired in-flight job straight back to `pending` with no attempts check, so a chunk whose embedding reliably kills/hangs the worker (dying before Ack/Nack) was re-leased forever in an infinite crash loop. Reclaim now mirrors `Nack`'s gate: a lease that expires after exhausting `maxAttempts` is dead-lettered instead of redelivered. `MemBroker` (`reclaimExpiredLocked`) and `SQLiteBroker` (new shared `reclaimExpired` helper, used by both `Lease` and `Stats`) are kept consistent.

## F5 [MED] — SQLiteBroker opened its DB with no busy_timeout/WAL → SQLITE_BUSY storms
`NewSQLiteBroker` now sets `busy_timeout=5000` then `journal_mode=WAL` (same order/values as `internal/store/sqlite_store.go`), so the reclaim-write-first `Lease` waits on contention under the multi-worker pool instead of failing immediately with `database is locked`.

## Scope
Touches only `internal/embedqueue/` (membroker.go, sqlitebroker.go) + tests. The dead-letter-write-back-to-chunk-status (F2) and surface-the-DLQ (F3) parts need cross-package store interaction and are deferred to a separate PR.

## Tests
- Reclaim dead-letters a job once it reaches `maxAttempts` and its lease expires (not redelivered to pending) — both `MemBroker` and `SQLiteBroker`.
- The broker DB reports `busy_timeout=5000` and `journal_mode=wal` after construction.

`make check` passes locally (gofmt, vet, golangci-lint, gocyclo, ineffassign, misspell, tests, build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)