### PR TITLE
Addresses the path-prefix pushdown (F1) + HNSW 2000-dim guard (F2) parts of #437 (qdrant-sentinel/DSN/NaN deferred)

### DIFF
--- a/internal/index/pgvectorindex/index.go
+++ b/internal/index/pgvectorindex/index.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"sync"
 
 	"github.com/jackc/pgx/v5"
@@ -97,7 +98,7 @@ type Index struct {
 
 	mu         sync.Mutex
 	dim        int  // 0 until known (config or first vector)
-	tableReady bool // vectors table + HNSW index created
+	tableReady bool // vectors table created (+ HNSW index when dim <= HNSWMaxDim)
 }
 
 // Open connects to Postgres, verifies pgvector is available, and ensures the
@@ -165,9 +166,10 @@ func (i *Index) ensureBaseSchema(ctx context.Context) error {
 	return nil
 }
 
-// ensureVectorsTable creates the dimensioned vectors table and its HNSW index
-// if not already created in this process. dim must be positive. It is
-// idempotent and safe under concurrent callers.
+// ensureVectorsTable creates the dimensioned vectors table and, when the
+// dimension is within pgvector's index limit (HNSWMaxDim), its HNSW index, if
+// not already created in this process. dim must be positive. It is idempotent
+// and safe under concurrent callers.
 func (i *Index) ensureVectorsTable(ctx context.Context, dim int) error {
 	i.mu.Lock()
 	defer i.mu.Unlock()
@@ -177,9 +179,17 @@ func (i *Index) ensureVectorsTable(ctx context.Context, dim int) error {
 	if dim <= 0 {
 		return fmt.Errorf("pgvector: embedding dimension must be positive, got %d", dim)
 	}
-	stmts := []string{
-		CreateTableSQL(i.schema, i.table, dim),
-		CreateHNSWIndexSQL(i.schema, i.table),
+	stmts := []string{CreateTableSQL(i.schema, i.table, dim)}
+	// pgvector's hnsw/ivfflat indexes are capped at HNSWMaxDim dimensions; above
+	// that, CREATE INDEX fails and would leave tableReady false and every Upsert
+	// re-failing corpus-wide (issue #437 F2). For high-dimensional models we skip
+	// the ANN index — the table still answers queries via exact search — and warn
+	// the operator rather than failing the backend.
+	if idxSQL, ok := CreateHNSWIndexSQL(i.schema, i.table, dim); ok {
+		stmts = append(stmts, idxSQL)
+	} else {
+		log.Printf("pgvector: ANN (HNSW) indexing disabled for table %q: embedding dimension %d exceeds pgvector's %d-dim index limit; falling back to exact (sequential-scan) search. For faster ANN search, use a smaller Matryoshka embedding dimension (<= %d).",
+			i.table, dim, HNSWMaxDim, HNSWMaxDim)
 	}
 	for _, s := range stmts {
 		if _, err := i.db.Exec(ctx, s); err != nil {

--- a/internal/index/pgvectorindex/sql.go
+++ b/internal/index/pgvectorindex/sql.go
@@ -103,15 +103,31 @@ func CreateTableSQL(schema, table string, dim int) string {
 )`, tbl, dim)
 }
 
+// HNSWMaxDim is pgvector's hard upper bound on the number of dimensions an
+// hnsw (or ivfflat) index can cover. Above this, "CREATE INDEX ... USING hnsw"
+// fails outright (e.g. gemini-embedding-001's native 3072 dims), so dir2mcp
+// skips ANN index creation and falls back to exact (sequential-scan) search
+// rather than leaving the backend permanently broken (issue #437 F2).
+const HNSWMaxDim = 2000
+
 // CreateHNSWIndexSQL returns the DDL to create the HNSW index on the embedding
-// column using cosine distance. The index name is derived from the table name
-// so repeated calls are idempotent.
-func CreateHNSWIndexSQL(schema, table string) string {
+// column using cosine distance, and ok=true. The index name is derived from the
+// table name so repeated calls are idempotent.
+//
+// When dim exceeds HNSWMaxDim, pgvector cannot build the index, so it returns
+// ok=false and an empty statement: the caller must SKIP index creation. The
+// table remains fully queryable without the index (pgvector falls back to an
+// exact sequential scan — slower, but correct), so a high-dimensional model
+// must never fail the whole backend.
+func CreateHNSWIndexSQL(schema, table string, dim int) (string, bool) {
+	if dim > HNSWMaxDim {
+		return "", false
+	}
 	idxName := quoteIdent(table + "_embedding_hnsw")
 	return fmt.Sprintf(
 		`CREATE INDEX IF NOT EXISTS %s ON %s USING hnsw (embedding vector_cosine_ops)`,
 		idxName, qualifiedTable(schema, table),
-	)
+	), true
 }
 
 // CreateIdentityTableSQL returns the DDL for the single-row identity table.
@@ -200,10 +216,22 @@ func BuildFilterPredicates(f model.Filter, startArg int) ([]string, []any) {
 		clauses = append(clauses, "btrim(rel_path) <> ''")
 	}
 	if f.PathPrefix != "" {
-		// rel_path LIKE prefix || '%' — escape LIKE metacharacters in the
-		// prefix so a literal % or _ in a path is matched verbatim.
-		ph := next(escapeLikePrefix(f.PathPrefix) + "%")
-		clauses = append(clauses, fmt.Sprintf("rel_path LIKE %s ESCAPE '\\'", ph))
+		// Normalize the prefix with the SAME NormalizePathPrefix that
+		// model.Filter.Match (via MatchesPathPrefix) applies, so the SQL
+		// pushdown and the authoritative Go-side recheck agree (issue #437 F1 /
+		// #286). Without this, a raw "./Docs"-style or trailing-slash prefix
+		// pushed verbatim diverges from the matcher and silently drops valid
+		// rows. A prefix that normalizes away (e.g. "." or "./") imposes no
+		// constraint and is skipped (matches everything), mirroring the matcher.
+		//
+		// Matching is case-INSENSITIVE — lower(rel_path) LIKE lower(prefix||'%')
+		// — to mirror MatchesPathPrefix's ASCII case-fold and the store's
+		// list_files LIKE. LIKE metacharacters in the literal prefix are escaped
+		// so a literal % or _ in a path is matched verbatim.
+		if normalized := model.NormalizePathPrefix(f.PathPrefix); normalized != "" {
+			ph := next(escapeLikePrefix(normalized) + "%")
+			clauses = append(clauses, fmt.Sprintf("lower(rel_path) LIKE lower(%s) ESCAPE '\\'", ph))
+		}
 	}
 	if len(f.DocTypes) > 0 {
 		// Case-insensitive set membership: lower(doc_type) = ANY(lowered set).

--- a/tests/pgvectorindex/querier_stub_test.go
+++ b/tests/pgvectorindex/querier_stub_test.go
@@ -93,6 +93,42 @@ func TestIndex_Upsert_StubQuerier(t *testing.T) {
 	}
 }
 
+// TestIndex_Upsert_HighDimSkipsHNSW verifies that a high-dimensional embedding
+// (> pgvector's 2000-dim index limit) still succeeds: the table is created and
+// the INSERT runs, but the CREATE INDEX ... USING hnsw DDL is SKIPPED so the
+// backend is not permanently broken (issue #437 F2).
+func TestIndex_Upsert_HighDimSkipsHNSW(t *testing.T) {
+	stub := &stubQuerier{}
+	ix := pgvectorindex.NewWithQuerier(stub, pgvectorindex.Config{}, false)
+
+	vec := make([]float32, 3072) // gemini-embedding-001 native dim
+	vec[0] = 0.5
+	if err := ix.Upsert(context.Background(), vec, model.IndexPayload{ChunkID: 1, RelPath: "a.md"}); err != nil {
+		t.Fatalf("Upsert at dim 3072 must not fail: %v", err)
+	}
+
+	var sawCreateTable, sawHNSW, sawInsert bool
+	for _, e := range stub.execs {
+		switch {
+		case strings.Contains(e.sql, "CREATE TABLE IF NOT EXISTS"):
+			sawCreateTable = true
+		case strings.Contains(e.sql, "USING hnsw"):
+			sawHNSW = true
+		case strings.Contains(e.sql, "ON CONFLICT (chunk_id) DO UPDATE"):
+			sawInsert = true
+		}
+	}
+	if !sawCreateTable {
+		t.Errorf("expected CREATE TABLE for high-dim upsert, execs: %+v", stub.execs)
+	}
+	if sawHNSW {
+		t.Errorf("HNSW index DDL must be SKIPPED above the 2000-dim limit, execs: %+v", stub.execs)
+	}
+	if !sawInsert {
+		t.Errorf("expected the INSERT to still run, execs: %+v", stub.execs)
+	}
+}
+
 // TestIndex_Upsert_RejectsBadInput mirrors the HNSW contract: empty vector and
 // zero chunk_id are errors.
 func TestIndex_Upsert_RejectsBadInput(t *testing.T) {

--- a/tests/pgvectorindex/sql_test.go
+++ b/tests/pgvectorindex/sql_test.go
@@ -33,15 +33,19 @@ func TestBuildFilterPredicates_ExcludeOrphans(t *testing.T) {
 	}
 }
 
-// TestBuildFilterPredicates_PathPrefix produces a LIKE prefix||'%' predicate
-// and escapes LIKE metacharacters in the literal prefix.
+// TestBuildFilterPredicates_PathPrefix produces a case-insensitive LIKE
+// prefix||'%' predicate over a NORMALIZED prefix and escapes LIKE
+// metacharacters in the literal prefix (issue #437 F1). NormalizePathPrefix
+// strips the trailing slash via path.Clean, so the trailing "/" is gone.
 func TestBuildFilterPredicates_PathPrefix(t *testing.T) {
 	clauses, args := pgvectorindex.BuildFilterPredicates(model.Filter{PathPrefix: "docs/50%_off/"}, 1)
 	if len(clauses) != 1 {
 		t.Fatalf("expected 1 clause, got %v", clauses)
 	}
-	if !strings.Contains(clauses[0], "rel_path LIKE $1 ESCAPE") {
-		t.Fatalf("expected LIKE $1 ESCAPE clause, got %q", clauses[0])
+	// The pushdown must be case-insensitive (lower() on both sides) to mirror
+	// model.MatchesPathPrefix's ASCII fold.
+	if !strings.Contains(clauses[0], "lower(rel_path) LIKE lower($1) ESCAPE") {
+		t.Fatalf("expected case-insensitive LIKE lower($1) ESCAPE clause, got %q", clauses[0])
 	}
 	if len(args) != 1 {
 		t.Fatalf("expected 1 arg, got %v", args)
@@ -51,10 +55,90 @@ func TestBuildFilterPredicates_PathPrefix(t *testing.T) {
 		t.Fatalf("expected string arg, got %T", args[0])
 	}
 	// The % and _ in the prefix must be escaped; the trailing % wildcard must
-	// remain unescaped.
-	want := `docs/50\%\_off/%`
+	// remain unescaped. The trailing path separator is removed by normalization.
+	want := `docs/50\%\_off%`
 	if got != want {
 		t.Fatalf("escaped prefix arg = %q, want %q", got, want)
+	}
+}
+
+// TestBuildFilterPredicates_PathPrefix_Normalized verifies the prefix is run
+// through model.NormalizePathPrefix so a "./docs"-style or differently-cased
+// input produces the SAME pushdown the Go-side model.Filter.Match recheck uses
+// (issue #437 F1 / #286). All variants must reduce to the same lowercased,
+// normalized argument so the backend never silently under-returns rows.
+func TestBuildFilterPredicates_PathPrefix_Normalized(t *testing.T) {
+	cases := []struct {
+		name   string
+		prefix string
+		want   string // expected LIKE argument (escaped, + trailing %)
+	}{
+		{"leading dot-slash", "./docs", `docs%`},
+		{"trailing slash", "docs/", `docs%`},
+		{"backslashes", `docs\sub`, `docs/sub%`},
+		{"redundant separators", "docs//sub/", `docs/sub%`},
+		{"mixed case preserved verbatim", "Docs", `Docs%`},
+		{"leading slash stripped", "/docs", `docs%`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			clauses, args := pgvectorindex.BuildFilterPredicates(model.Filter{PathPrefix: tc.prefix}, 1)
+			if len(clauses) != 1 {
+				t.Fatalf("expected 1 clause, got %v", clauses)
+			}
+			if !strings.Contains(clauses[0], "lower(rel_path) LIKE lower($1) ESCAPE") {
+				t.Fatalf("expected case-insensitive normalized LIKE clause, got %q", clauses[0])
+			}
+			if len(args) != 1 || args[0] != tc.want {
+				t.Fatalf("LIKE arg = %v, want %q", args, tc.want)
+			}
+		})
+	}
+}
+
+// TestBuildFilterPredicates_PathPrefix_NormalizesAway verifies a prefix that
+// reduces to "no prefix" (".", "./") imposes NO constraint, matching the
+// matcher (MatchesPathPrefix returns true for everything in that case).
+func TestBuildFilterPredicates_PathPrefix_NormalizesAway(t *testing.T) {
+	for _, p := range []string{".", "./", "  ", `.\`} {
+		clauses, args := pgvectorindex.BuildFilterPredicates(model.Filter{PathPrefix: p}, 1)
+		if len(clauses) != 0 || len(args) != 0 {
+			t.Fatalf("prefix %q should add no predicate, got clauses=%v args=%v", p, clauses, args)
+		}
+	}
+}
+
+// TestBuildFilterPredicates_PathPrefix_AgreesWithMatch is the cross-check that
+// the F1 fix exists to guarantee: every row the SQL pushdown is meant to keep
+// is exactly the set model.Filter.Match keeps. We assert agreement on the
+// hard cases (case-fold + form mismatch) by simulating the lowercased LIKE
+// prefix test in Go and comparing against model.Filter.Match.
+func TestBuildFilterPredicates_PathPrefix_AgreesWithMatch(t *testing.T) {
+	relPaths := []string{
+		"Docs/readme.md", "docs/readme.md", "DOCS/a/b.md",
+		"other/x.md", "docsy/x.md", "doc/x.md",
+	}
+	prefixes := []string{"docs", "Docs", "./docs/", `docs\`, "DOCS/"}
+	for _, prefix := range prefixes {
+		f := model.Filter{PathPrefix: prefix}
+		clauses, args := pgvectorindex.BuildFilterPredicates(f, 1)
+		// Recover the lowercased, normalized LIKE pattern (strip trailing %).
+		var pattern string
+		if len(args) == 1 {
+			pattern = strings.ToLower(strings.TrimSuffix(args[0].(string), "%"))
+		}
+		_ = clauses
+		for _, rp := range relPaths {
+			// Emulate "lower(rel_path) LIKE lower(prefix)||'%'": since the only
+			// metacharacters were escaped away in these prefixes, this is a plain
+			// case-insensitive prefix test.
+			sqlKeeps := pattern == "" || strings.HasPrefix(strings.ToLower(rp), pattern)
+			goKeeps := f.Match(model.IndexPayload{RelPath: rp})
+			if sqlKeeps != goKeeps {
+				t.Errorf("prefix %q rel %q: SQL pushdown keeps=%v but Filter.Match keeps=%v",
+					prefix, rp, sqlKeeps, goKeeps)
+			}
+		}
 	}
 }
 
@@ -318,10 +402,47 @@ func TestCreateTableSQL(t *testing.T) {
 	}
 }
 
-// TestCreateHNSWIndexSQL uses the cosine ops class.
+// TestCreateHNSWIndexSQL uses the cosine ops class for in-limit dimensions and
+// reports ok=true (issue #437 F2).
 func TestCreateHNSWIndexSQL(t *testing.T) {
-	sql := pgvectorindex.CreateHNSWIndexSQL("public", "vt")
+	sql, ok := pgvectorindex.CreateHNSWIndexSQL("public", "vt", 768)
+	if !ok {
+		t.Fatalf("expected ok=true for dim 768")
+	}
 	if !strings.Contains(sql, "USING hnsw (embedding vector_cosine_ops)") {
 		t.Fatalf("expected HNSW cosine index, got:\n%s", sql)
+	}
+}
+
+// TestCreateHNSWIndexSQL_DimGuard verifies the index is created at and below the
+// 2000-dim pgvector limit and SKIPPED (ok=false, empty SQL) above it, so a
+// high-dimensional model (e.g. gemini-embedding-001's 3072) falls back to exact
+// search instead of permanently breaking the backend (issue #437 F2).
+func TestCreateHNSWIndexSQL_DimGuard(t *testing.T) {
+	cases := []struct {
+		dim    int
+		wantOK bool
+	}{
+		{1, true},
+		{768, true},
+		{1536, true},
+		{2000, true},  // exactly the limit is still indexable
+		{2001, false}, // one over the limit
+		{3072, false}, // gemini-embedding-001 native dim
+	}
+	for _, tc := range cases {
+		sql, ok := pgvectorindex.CreateHNSWIndexSQL("public", "vt", tc.dim)
+		if ok != tc.wantOK {
+			t.Errorf("dim %d: ok = %v, want %v", tc.dim, ok, tc.wantOK)
+		}
+		if ok && !strings.Contains(sql, "USING hnsw") {
+			t.Errorf("dim %d: expected HNSW DDL, got:\n%s", tc.dim, sql)
+		}
+		if !ok && sql != "" {
+			t.Errorf("dim %d: expected empty SQL when skipped, got:\n%s", tc.dim, sql)
+		}
+	}
+	if pgvectorindex.HNSWMaxDim != 2000 {
+		t.Fatalf("HNSWMaxDim = %d, want 2000 (pgvector hnsw/ivfflat hard limit)", pgvectorindex.HNSWMaxDim)
 	}
 }


### PR DESCRIPTION
Fixes the two MED-HIGH parts of #437 in the pgvector backend. Scoped strictly to `internal/index/pgvectorindex/` (`sql.go`, `index.go`) + its tests. The smaller qdrant-sentinel / DSN-leak / NaN parts are intentionally left for a follow-up.

## F1 [MED-HIGH] — path_prefix pushdown diverged from `Filter.Match` -> silent under-return

`BuildFilterPredicates` pushed `rel_path LIKE 'prefix%' ESCAPE '\'` over the **raw** prefix. But:

- Postgres `LIKE` is case-**sensitive**, while `model.MatchesPathPrefix` is ASCII case-**insensitive**.
- The pushdown skipped normalization, while `Match` runs `NormalizePathPrefix` first (`./`-strip, `\`->`/`, `path.Clean`, leading-`/`-strip).

So a case- or form-mismatched prefix (e.g. `./Docs`, `docs/`, `DOCS/`) silently dropped valid rows that `Filter.Match` would keep.

**Fix:** normalize the prefix with the same `NormalizePathPrefix` and emit a case-insensitive `lower(rel_path) LIKE lower($n) ESCAPE '\'`. A prefix that normalizes away (`.`, `./`) imposes no constraint, mirroring the matcher. The backend pushdown and the authoritative Go-side recheck now agree (the lowercase LIKE can only over-return on non-ASCII folds, which the Go recheck removes — never under-return).

## F2 [MED-HIGH] — HNSW 2000-dim limit permanently broke high-dim models

`CreateHNSWIndexSQL` unconditionally created `USING hnsw (...)`. pgvector's hnsw/ivfflat indexes are capped at 2000 dims, so for `dim > 2000` (e.g. gemini-embedding-001 = 3072) `CREATE INDEX` failed, `tableReady` stayed false, and every `Upsert` re-failed corpus-wide.

**Fix:** `CreateHNSWIndexSQL` now takes the dimension and returns `ok=false` (empty SQL) above `HNSWMaxDim` (2000). `ensureVectorsTable` skips the index and logs a clear warning recommending a smaller Matryoshka dimension. The table stays fully queryable via exact (sequential-scan) search instead of breaking the backend. Dimension is threaded through from `ensureVectorsTable` where it is already known.

## Tests

- `BuildFilterPredicates` builds a case-insensitive predicate over a normalized prefix for `Docs` / `./docs` / `docs/` / backslash / leading-slash inputs, and emits no predicate when the prefix normalizes away.
- Cross-check: the SQL pushdown keeps exactly the rows `Filter.Match` keeps across case/form-mismatched prefixes.
- HNSW dim guard: created at/below 2000, skipped above; `HNSWMaxDim == 2000`.
- High-dim (3072) `Upsert` succeeds and skips the HNSW DDL while still running the INSERT.

`make check` passes fully (vet, golangci-lint, gocyclo<=15, misspell, all suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)