### PR TITLE
Addresses the gemini-redirect-key-leak + success-body-OOM parts of #416 (Retry-After/jitter, plaintext-http, zero-vector deferred)

### DIFF
--- a/internal/elevenlabs/client.go
+++ b/internal/elevenlabs/client.go
@@ -21,6 +21,15 @@ const (
 	defaultBaseURL  = "https://api.elevenlabs.io"
 	defaultTimeout  = 30 * time.Second
 	defaultSTTModel = "scribe_v1"
+
+	// maxResponseBytes caps a JSON success response body (STT) so a malicious
+	// or buggy upstream (e.g. a gzip bomb behind a custom base_url) cannot
+	// drive unbounded memory use when we buffer it (issue #416).
+	maxResponseBytes = 64 << 20 // 64 MiB
+	// maxAudioResponseBytes caps a TTS audio body. Audio is legitimately
+	// larger than JSON, so it gets a higher ceiling while still bounding the
+	// read.
+	maxAudioResponseBytes = 256 << 20 // 256 MiB
 )
 
 type Client struct {
@@ -184,9 +193,9 @@ func (c *Client) Transcribe(ctx context.Context, relPath string, data []byte) (s
 		_ = resp.Body.Close()
 	}()
 
-	bodyBytes, err := io.ReadAll(resp.Body)
+	bodyBytes, err := readLimitedBody(resp, maxResponseBytes)
 	if err != nil {
-		return "", &model.ProviderError{Code: "ELEVENLABS_FAILED", Message: "failed to read STT response", Retryable: true, StatusCode: resp.StatusCode, Cause: err}
+		return "", err
 	}
 
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
@@ -285,15 +294,9 @@ func (c *Client) SynthesizeWithVoice(ctx context.Context, text, voiceID string) 
 		_ = resp.Body.Close()
 	}()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := readLimitedBody(resp, maxAudioResponseBytes)
 	if err != nil {
-		return nil, &model.ProviderError{
-			Code:       "ELEVENLABS_FAILED",
-			Message:    "failed to read TTS response",
-			Retryable:  true,
-			StatusCode: resp.StatusCode,
-			Cause:      err,
-		}
+		return nil, err
 	}
 
 	if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
@@ -305,6 +308,21 @@ func (c *Client) SynthesizeWithVoice(ctx context.Context, text, voiceID string) 
 		message = fmt.Sprintf("elevenlabs tts returned status %d", resp.StatusCode)
 	}
 	return nil, mapProviderError(resp.StatusCode, message)
+}
+
+// readLimitedBody buffers a response body under limit bytes, returning a clear
+// error rather than reading unbounded if the upstream sends more (issue #416).
+// It reads one byte past the cap to detect an over-limit body without
+// buffering the whole thing.
+func readLimitedBody(resp *http.Response, limit int64) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(resp.Body, limit+1))
+	if err != nil {
+		return nil, &model.ProviderError{Code: "ELEVENLABS_FAILED", Message: "failed to read response", Retryable: true, StatusCode: resp.StatusCode, Cause: err}
+	}
+	if int64(len(data)) > limit {
+		return nil, &model.ProviderError{Code: "ELEVENLABS_FAILED", Message: fmt.Sprintf("response exceeds %d-byte limit", limit), Retryable: false, StatusCode: resp.StatusCode}
+	}
+	return data, nil
 }
 
 func mapProviderError(statusCode int, message string) error {

--- a/internal/elevenlabs/limit_test.go
+++ b/internal/elevenlabs/limit_test.go
@@ -1,0 +1,37 @@
+package elevenlabs
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// TestReadLimitedBody_OverLimitErrors pins issue #416: a response body that
+// exceeds the cap is rejected with a clear, non-retryable provider error
+// instead of being buffered unbounded (OOM). A within-cap body is returned in
+// full.
+func TestReadLimitedBody_OverLimitErrors(t *testing.T) {
+	const n = 100
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(strings.Repeat("a", n)))}
+	if _, err := readLimitedBody(resp, 10); err == nil {
+		t.Fatal("over-limit body must error, got nil")
+	} else {
+		var pe *model.ProviderError
+		if !errors.As(err, &pe) || pe.Code != "ELEVENLABS_FAILED" || pe.Retryable {
+			t.Fatalf("want non-retryable ELEVENLABS_FAILED, got %v", err)
+		}
+	}
+
+	resp = &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(strings.Repeat("a", n)))}
+	got, err := readLimitedBody(resp, 1000)
+	if err != nil {
+		t.Fatalf("within-limit body must succeed, got %v", err)
+	}
+	if len(got) != n {
+		t.Fatalf("got %d bytes, want %d", len(got), n)
+	}
+}

--- a/internal/gemini/client.go
+++ b/internal/gemini/client.go
@@ -70,6 +70,13 @@ const (
 	// (signed 16-bit little-endian, mono); used to build the WAV header
 	// when the response mimeType omits an explicit rate.
 	geminiTTSSampleRate = 24000
+
+	// maxResponseBytes caps a success response body so a malicious or buggy
+	// upstream (e.g. a gzip bomb behind a compromised/custom base_url) cannot
+	// drive unbounded memory use when we buffer/decode the body (issue #416).
+	// Gemini returns even TTS audio inline (base64) inside the JSON response,
+	// so this single generous cap covers embeddings, chat, STT and TTS.
+	maxResponseBytes = 64 << 20 // 64 MiB
 )
 
 // Client is a Gemini adapter that speaks the OpenAI-compatible wire
@@ -316,8 +323,12 @@ func (c *Client) embedReqsNative(ctx context.Context, modelName string, dim int,
 		return nil, httpError(resp)
 	}
 
+	raw, err := readLimitedBody(resp, maxResponseBytes)
+	if err != nil {
+		return nil, err
+	}
 	var parsed geminiBatchEmbedResponse
-	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+	if err := json.Unmarshal(raw, &parsed); err != nil {
 		return nil, &model.ProviderError{Code: "GEMINI_FAILED", Message: "failed to decode embedding response", Retryable: false, StatusCode: resp.StatusCode, Cause: err}
 	}
 	if len(parsed.Embeddings) != len(reqs) {
@@ -466,8 +477,12 @@ func (c *Client) generateOnce(ctx context.Context, chatModel, prompt string, tim
 		return "", httpError(resp)
 	}
 
+	raw, err := readLimitedBody(resp, maxResponseBytes)
+	if err != nil {
+		return "", err
+	}
 	var parsed generateResponse
-	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+	if err := json.Unmarshal(raw, &parsed); err != nil {
 		return "", &model.ProviderError{Code: "GEMINI_FAILED", Message: "failed to decode generation response", Retryable: false, StatusCode: resp.StatusCode, Cause: err}
 	}
 	if !parsed.Usage.Empty() {
@@ -605,8 +620,12 @@ func (c *Client) transcribeOnce(ctx context.Context, relPath string, data []byte
 	if resp.StatusCode != http.StatusOK {
 		return "", httpError(resp)
 	}
+	raw, err := readLimitedBody(resp, maxResponseBytes)
+	if err != nil {
+		return "", err
+	}
 	var parsed geminiGenerateResponse
-	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+	if err := json.Unmarshal(raw, &parsed); err != nil {
 		return "", &model.ProviderError{Code: "GEMINI_FAILED", Message: "failed to decode transcription response", Retryable: false, StatusCode: resp.StatusCode, Cause: err}
 	}
 	text := strings.TrimSpace(firstCandidateText(parsed))
@@ -672,8 +691,12 @@ func (c *Client) Synthesize(ctx context.Context, text string) ([]byte, error) {
 		if resp.StatusCode != http.StatusOK {
 			return nil, httpError(resp)
 		}
+		raw, err := readLimitedBody(resp, maxResponseBytes)
+		if err != nil {
+			return nil, err
+		}
 		var parsed geminiGenerateResponse
-		if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		if err := json.Unmarshal(raw, &parsed); err != nil {
 			return nil, &model.ProviderError{Code: "GEMINI_FAILED", Message: "failed to decode tts response", Retryable: false, StatusCode: resp.StatusCode, Cause: err}
 		}
 		pcm, rate, perr := firstAudioPart(parsed)
@@ -837,11 +860,39 @@ func (c *Client) doJSON(ctx context.Context, path string, body []byte, timeout t
 // a shallow copy so connection pooling is preserved.
 func clientWithTimeout(base *http.Client, timeout time.Duration) *http.Client {
 	if base == nil {
-		return &http.Client{Timeout: timeout}
+		return &http.Client{Timeout: timeout, CheckRedirect: refuseRedirect}
 	}
 	cp := *base
 	cp.Timeout = timeout
+	cp.CheckRedirect = refuseRedirect
 	return &cp
+}
+
+// refuseRedirect stops the HTTP client from following any redirect. A direct
+// provider API call never legitimately needs one, and Go copies custom request
+// headers (here the x-goog-api-key key, which it does NOT strip cross-host the
+// way it strips Authorization/Cookie) onto the redirect target — so following a
+// 3xx from a compromised/misconfigured base_url would leak the Gemini key to an
+// attacker-controlled host (issue #416). Returning http.ErrUseLastResponse
+// halts at the 3xx response (surfaced as a non-2xx provider error) without ever
+// sending the key onward.
+func refuseRedirect(_ *http.Request, _ []*http.Request) error {
+	return http.ErrUseLastResponse
+}
+
+// readLimitedBody buffers a success response body under limit bytes, returning
+// a clear error rather than reading unbounded if the upstream sends more
+// (issue #416). It reads one byte past the cap to detect an over-limit body
+// without buffering the whole thing.
+func readLimitedBody(resp *http.Response, limit int64) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(resp.Body, limit+1))
+	if err != nil {
+		return nil, &model.ProviderError{Code: "GEMINI_FAILED", Message: "failed to read response", Retryable: true, StatusCode: resp.StatusCode, Cause: err}
+	}
+	if int64(len(data)) > limit {
+		return nil, &model.ProviderError{Code: "GEMINI_FAILED", Message: fmt.Sprintf("response exceeds %d-byte limit", limit), Retryable: false, StatusCode: resp.StatusCode}
+	}
+	return data, nil
 }
 
 func httpError(resp *http.Response) error {

--- a/internal/gemini/limit_test.go
+++ b/internal/gemini/limit_test.go
@@ -1,0 +1,37 @@
+package gemini
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// TestReadLimitedBody_OverLimitErrors pins issue #416: a success body that
+// exceeds the cap is rejected with a clear, non-retryable provider error
+// instead of being buffered unbounded (OOM). A within-cap body is returned in
+// full.
+func TestReadLimitedBody_OverLimitErrors(t *testing.T) {
+	const n = 100
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(strings.Repeat("a", n)))}
+	if _, err := readLimitedBody(resp, 10); err == nil {
+		t.Fatal("over-limit body must error, got nil")
+	} else {
+		var pe *model.ProviderError
+		if !errors.As(err, &pe) || pe.Code != "GEMINI_FAILED" || pe.Retryable {
+			t.Fatalf("want non-retryable GEMINI_FAILED, got %v", err)
+		}
+	}
+
+	resp = &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(strings.Repeat("a", n)))}
+	got, err := readLimitedBody(resp, 1000)
+	if err != nil {
+		t.Fatalf("within-limit body must succeed, got %v", err)
+	}
+	if len(got) != n {
+		t.Fatalf("got %d bytes, want %d", len(got), n)
+	}
+}

--- a/internal/mistral/client.go
+++ b/internal/mistral/client.go
@@ -44,6 +44,12 @@ const (
 	// DefaultTranscribeModel is the default model used for audio
 	// transcription requests.
 	DefaultTranscribeModel = "voxtral-mini-latest"
+
+	// maxResponseBytes caps a JSON success response body (embeddings, OCR,
+	// transcription, chat) so a malicious or buggy upstream (e.g. a gzip bomb
+	// behind a custom base_url) cannot drive unbounded memory use when we
+	// buffer or decode it (issue #416).
+	maxResponseBytes = 64 << 20 // 64 MiB
 )
 
 // Client provides Mistral API integrations.
@@ -318,8 +324,12 @@ func (c *Client) embedBatch(ctx context.Context, modelName string, inputs []stri
 		return nil, mistralHTTPError(resp)
 	}
 
+	raw, err := readLimitedBody(resp, maxResponseBytes)
+	if err != nil {
+		return nil, err
+	}
 	var parsed embedResponse
-	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+	if err := json.Unmarshal(raw, &parsed); err != nil {
 		return nil, &model.ProviderError{
 			Code:       "MISTRAL_FAILED",
 			Message:    "failed to decode embedding response",
@@ -331,33 +341,31 @@ func (c *Client) embedBatch(ctx context.Context, modelName string, inputs []stri
 
 	reportUsage(ctx, usage.StageEmbed, parsed.Usage)
 
-	if len(parsed.Data) != len(inputs) {
-		return nil, &model.ProviderError{
-			Code:       "MISTRAL_FAILED",
-			Message:    fmt.Sprintf("embedding response size mismatch: got %d vectors for %d inputs", len(parsed.Data), len(inputs)),
-			Retryable:  false,
-			StatusCode: resp.StatusCode,
-		}
+	vectors, err := collectEmbedVectors(parsed, len(inputs), resp.StatusCode)
+	if err != nil {
+		return nil, err
 	}
 
-	vectors := make([][]float32, len(inputs))
-	seen := make([]bool, len(inputs))
+	return vectors, nil
+}
+
+// collectEmbedVectors validates the response covers every input exactly once
+// and reorders vectors by the server-reported index to match input order.
+func collectEmbedVectors(parsed embedResponse, n, statusCode int) ([][]float32, error) {
+	fail := func(msg string) error {
+		return &model.ProviderError{Code: "MISTRAL_FAILED", Message: msg, Retryable: false, StatusCode: statusCode}
+	}
+	if len(parsed.Data) != n {
+		return nil, fail(fmt.Sprintf("embedding response size mismatch: got %d vectors for %d inputs", len(parsed.Data), n))
+	}
+	vectors := make([][]float32, n)
+	seen := make([]bool, n)
 	for _, item := range parsed.Data {
-		if item.Index < 0 || item.Index >= len(inputs) {
-			return nil, &model.ProviderError{
-				Code:       "MISTRAL_FAILED",
-				Message:    "embedding response contains invalid index",
-				Retryable:  false,
-				StatusCode: resp.StatusCode,
-			}
+		if item.Index < 0 || item.Index >= n {
+			return nil, fail("embedding response contains invalid index")
 		}
 		if seen[item.Index] {
-			return nil, &model.ProviderError{
-				Code:       "MISTRAL_FAILED",
-				Message:    fmt.Sprintf("embedding response contains duplicate index: %d", item.Index),
-				Retryable:  false,
-				StatusCode: resp.StatusCode,
-			}
+			return nil, fail(fmt.Sprintf("embedding response contains duplicate index: %d", item.Index))
 		}
 		vector := make([]float32, len(item.Embedding))
 		for i, val := range item.Embedding {
@@ -366,19 +374,27 @@ func (c *Client) embedBatch(ctx context.Context, modelName string, inputs []stri
 		vectors[item.Index] = vector
 		seen[item.Index] = true
 	}
-
 	for i := range seen {
 		if !seen[i] {
-			return nil, &model.ProviderError{
-				Code:       "MISTRAL_FAILED",
-				Message:    fmt.Sprintf("embedding response missing index: %d", i),
-				Retryable:  false,
-				StatusCode: resp.StatusCode,
-			}
+			return nil, fail(fmt.Sprintf("embedding response missing index: %d", i))
 		}
 	}
-
 	return vectors, nil
+}
+
+// readLimitedBody buffers a success response body under limit bytes, returning
+// a clear error rather than reading unbounded if the upstream sends more
+// (issue #416). It reads one byte past the cap to detect an over-limit body
+// without buffering the whole thing.
+func readLimitedBody(resp *http.Response, limit int64) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(resp.Body, limit+1))
+	if err != nil {
+		return nil, &model.ProviderError{Code: "MISTRAL_FAILED", Message: "failed to read response", Retryable: true, StatusCode: resp.StatusCode, Cause: err}
+	}
+	if int64(len(data)) > limit {
+		return nil, &model.ProviderError{Code: "MISTRAL_FAILED", Message: fmt.Sprintf("response exceeds %d-byte limit", limit), Retryable: false, StatusCode: resp.StatusCode}
+	}
+	return data, nil
 }
 
 // mistralHTTPError reads the response body and returns a *model.ProviderError
@@ -627,8 +643,12 @@ func (c *Client) extractOnce(ctx context.Context, relPath string, data []byte) (
 		return "", mistralHTTPError(resp)
 	}
 
+	raw, err := readLimitedBody(resp, maxResponseBytes)
+	if err != nil {
+		return "", err
+	}
 	var parsed ocrResponse
-	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+	if err := json.Unmarshal(raw, &parsed); err != nil {
 		return "", &model.ProviderError{
 			Code:      "MISTRAL_FAILED",
 			Message:   "failed to decode ocr response",
@@ -796,8 +816,12 @@ func (c *Client) transcribeOnce(ctx context.Context, relPath string, data []byte
 		return "", mistralHTTPError(resp)
 	}
 
+	raw, err := readLimitedBody(resp, maxResponseBytes)
+	if err != nil {
+		return "", err
+	}
 	var parsed transcribeResponse
-	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+	if err := json.Unmarshal(raw, &parsed); err != nil {
 		return "", &model.ProviderError{
 			Code:      "MISTRAL_FAILED",
 			Message:   "failed to decode transcription response",
@@ -934,8 +958,12 @@ func (c *Client) generateOnce(ctx context.Context, prompt string) (string, error
 		return "", mistralHTTPError(resp)
 	}
 
+	raw, err := readLimitedBody(resp, maxResponseBytes)
+	if err != nil {
+		return "", err
+	}
 	var parsed generateResponse
-	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+	if err := json.Unmarshal(raw, &parsed); err != nil {
 		return "", &model.ProviderError{
 			Code:      "MISTRAL_FAILED",
 			Message:   "failed to decode generation response",

--- a/internal/mistral/limit_test.go
+++ b/internal/mistral/limit_test.go
@@ -1,0 +1,37 @@
+package mistral
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// TestReadLimitedBody_OverLimitErrors pins issue #416: a success body that
+// exceeds the cap is rejected with a clear, non-retryable provider error
+// instead of being buffered unbounded (OOM). A within-cap body is returned in
+// full.
+func TestReadLimitedBody_OverLimitErrors(t *testing.T) {
+	const n = 100
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(strings.Repeat("a", n)))}
+	if _, err := readLimitedBody(resp, 10); err == nil {
+		t.Fatal("over-limit body must error, got nil")
+	} else {
+		var pe *model.ProviderError
+		if !errors.As(err, &pe) || pe.Code != "MISTRAL_FAILED" || pe.Retryable {
+			t.Fatalf("want non-retryable MISTRAL_FAILED, got %v", err)
+		}
+	}
+
+	resp = &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(strings.Repeat("a", n)))}
+	got, err := readLimitedBody(resp, 1000)
+	if err != nil {
+		t.Fatalf("within-limit body must succeed, got %v", err)
+	}
+	if len(got) != n {
+		t.Fatalf("got %d bytes, want %d", len(got), n)
+	}
+}

--- a/internal/omniembed/client.go
+++ b/internal/omniembed/client.go
@@ -49,6 +49,12 @@ const (
 	// frequently ignore the field or accept the served model alias, but
 	// operators SHOULD set an explicit model via the provider profile.
 	DefaultModel = "omniembed"
+
+	// maxResponseBytes caps a success response body so a malicious or buggy
+	// self-hosted endpoint (the omniembed base_url is operator-supplied and
+	// often unauthenticated) cannot drive unbounded memory use via a
+	// giant/gzip-bombed 200 response (issue #416).
+	maxResponseBytes = 64 << 20 // 64 MiB
 )
 
 // Client speaks the OpenAI-compatible /v1/embeddings contract against a
@@ -241,8 +247,12 @@ func (c *Client) embedBatch(ctx context.Context, modelName string, inputs []stri
 		return nil, httpError(resp)
 	}
 
+	raw, err := readLimitedBody(resp, maxResponseBytes)
+	if err != nil {
+		return nil, err
+	}
 	var parsed embedResponse
-	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+	if err := json.Unmarshal(raw, &parsed); err != nil {
 		return nil, &model.ProviderError{Code: "OMNIEMBED_FAILED", Message: "failed to decode embedding response", Retryable: false, StatusCode: resp.StatusCode, Cause: err}
 	}
 	return collectVectors(parsed, len(inputs), resp.StatusCode)
@@ -302,6 +312,21 @@ func (c *Client) doJSON(ctx context.Context, path string, body []byte) (*http.Re
 		return nil, &model.ProviderError{Code: "OMNIEMBED_FAILED", Message: "request failed", Retryable: true, Cause: err}
 	}
 	return resp, nil
+}
+
+// readLimitedBody buffers a success response body under maxResponseBytes,
+// returning a clear error rather than reading unbounded if the upstream sends
+// more (issue #416). It reads one byte past the cap to detect an over-limit
+// body without buffering the whole thing.
+func readLimitedBody(resp *http.Response, limit int64) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(resp.Body, limit+1))
+	if err != nil {
+		return nil, &model.ProviderError{Code: "OMNIEMBED_FAILED", Message: "failed to read response", Retryable: true, StatusCode: resp.StatusCode, Cause: err}
+	}
+	if int64(len(data)) > limit {
+		return nil, &model.ProviderError{Code: "OMNIEMBED_FAILED", Message: fmt.Sprintf("response exceeds %d-byte limit", limit), Retryable: false, StatusCode: resp.StatusCode}
+	}
+	return data, nil
 }
 
 func httpError(resp *http.Response) error {

--- a/internal/omniembed/limit_test.go
+++ b/internal/omniembed/limit_test.go
@@ -1,0 +1,38 @@
+package omniembed
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// TestReadLimitedBody_OverLimitErrors pins issue #416: a success body that
+// exceeds the cap is rejected with a clear, non-retryable provider error
+// instead of being buffered unbounded (OOM) — the OOM risk is highest for the
+// self-hosted, operator-supplied omniembed endpoint. A within-cap body is
+// returned in full.
+func TestReadLimitedBody_OverLimitErrors(t *testing.T) {
+	const n = 100
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(strings.Repeat("a", n)))}
+	if _, err := readLimitedBody(resp, 10); err == nil {
+		t.Fatal("over-limit body must error, got nil")
+	} else {
+		var pe *model.ProviderError
+		if !errors.As(err, &pe) || pe.Code != "OMNIEMBED_FAILED" || pe.Retryable {
+			t.Fatalf("want non-retryable OMNIEMBED_FAILED, got %v", err)
+		}
+	}
+
+	resp = &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(strings.Repeat("a", n)))}
+	got, err := readLimitedBody(resp, 1000)
+	if err != nil {
+		t.Fatalf("within-limit body must succeed, got %v", err)
+	}
+	if len(got) != n {
+		t.Fatalf("got %d bytes, want %d", len(got), n)
+	}
+}

--- a/internal/openai/client.go
+++ b/internal/openai/client.go
@@ -50,6 +50,16 @@ const (
 	DefaultSTTModel   = "whisper-1"
 	DefaultTTSModel   = "tts-1"
 	DefaultTTSVoice   = "alloy"
+
+	// maxResponseBytes caps a JSON success response body (embeddings, chat,
+	// transcription) so a malicious or buggy upstream (e.g. a gzip bomb behind
+	// a custom base_url) cannot drive unbounded memory use when we buffer or
+	// decode it (issue #416).
+	maxResponseBytes = 64 << 20 // 64 MiB
+	// maxAudioResponseBytes caps a TTS audio body. Audio is legitimately
+	// larger than JSON, so it gets a higher ceiling while still bounding the
+	// read.
+	maxAudioResponseBytes = 256 << 20 // 256 MiB
 )
 
 // Client is an OpenAI-compatible API adapter.
@@ -202,8 +212,12 @@ func (c *Client) embedBatch(ctx context.Context, modelName string, inputs []stri
 		return nil, httpError(resp)
 	}
 
+	raw, err := readLimitedBody(resp, maxResponseBytes)
+	if err != nil {
+		return nil, err
+	}
 	var parsed embedResponse
-	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+	if err := json.Unmarshal(raw, &parsed); err != nil {
 		return nil, &model.ProviderError{Code: "OPENAI_FAILED", Message: "failed to decode embedding response", Retryable: false, StatusCode: resp.StatusCode, Cause: err}
 	}
 	if !parsed.Usage.Empty() {
@@ -312,8 +326,12 @@ func (c *Client) generateOnce(ctx context.Context, chatModel, prompt string, tim
 		return "", httpError(resp)
 	}
 
+	raw, err := readLimitedBody(resp, maxResponseBytes)
+	if err != nil {
+		return "", err
+	}
 	var parsed generateResponse
-	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+	if err := json.Unmarshal(raw, &parsed); err != nil {
 		return "", &model.ProviderError{Code: "OPENAI_FAILED", Message: "failed to decode generation response", Retryable: false, StatusCode: resp.StatusCode, Cause: err}
 	}
 	if !parsed.Usage.Empty() {
@@ -418,8 +436,12 @@ func (c *Client) transcribeOnce(ctx context.Context, relPath string, data []byte
 	if resp.StatusCode != http.StatusOK {
 		return "", httpError(resp)
 	}
+	raw, err := readLimitedBody(resp, maxResponseBytes)
+	if err != nil {
+		return "", err
+	}
 	var parsed transcriptionResponse
-	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+	if err := json.Unmarshal(raw, &parsed); err != nil {
 		return "", &model.ProviderError{Code: "OPENAI_FAILED", Message: "failed to decode transcription response", Retryable: false, StatusCode: resp.StatusCode, Cause: err}
 	}
 	return strings.TrimSpace(parsed.Text), nil
@@ -466,9 +488,9 @@ func (c *Client) Synthesize(ctx context.Context, text string) ([]byte, error) {
 		if resp.StatusCode != http.StatusOK {
 			return nil, httpError(resp)
 		}
-		audio, rerr := io.ReadAll(resp.Body)
+		audio, rerr := readLimitedBody(resp, maxAudioResponseBytes)
 		if rerr != nil {
-			return nil, &model.ProviderError{Code: "OPENAI_FAILED", Message: "failed to read tts audio", Retryable: true, Cause: rerr}
+			return nil, rerr
 		}
 		if len(audio) == 0 {
 			return nil, &model.ProviderError{Code: "OPENAI_FAILED", Message: "tts returned no audio", Retryable: false, StatusCode: resp.StatusCode}
@@ -535,6 +557,21 @@ func clientWithTimeout(base *http.Client, timeout time.Duration) *http.Client {
 	cp := *base
 	cp.Timeout = timeout
 	return &cp
+}
+
+// readLimitedBody buffers a success response body under limit bytes, returning
+// a clear error rather than reading unbounded if the upstream sends more
+// (issue #416). It reads one byte past the cap to detect an over-limit body
+// without buffering the whole thing.
+func readLimitedBody(resp *http.Response, limit int64) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(resp.Body, limit+1))
+	if err != nil {
+		return nil, &model.ProviderError{Code: "OPENAI_FAILED", Message: "failed to read response", Retryable: true, StatusCode: resp.StatusCode, Cause: err}
+	}
+	if int64(len(data)) > limit {
+		return nil, &model.ProviderError{Code: "OPENAI_FAILED", Message: fmt.Sprintf("response exceeds %d-byte limit", limit), Retryable: false, StatusCode: resp.StatusCode}
+	}
+	return data, nil
 }
 
 func httpError(resp *http.Response) error {

--- a/internal/openai/limit_test.go
+++ b/internal/openai/limit_test.go
@@ -1,0 +1,37 @@
+package openai
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// TestReadLimitedBody_OverLimitErrors pins issue #416: a success body that
+// exceeds the cap is rejected with a clear, non-retryable provider error
+// instead of being buffered unbounded (OOM). A within-cap body is returned in
+// full.
+func TestReadLimitedBody_OverLimitErrors(t *testing.T) {
+	const n = 100
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(strings.Repeat("a", n)))}
+	if _, err := readLimitedBody(resp, 10); err == nil {
+		t.Fatal("over-limit body must error, got nil")
+	} else {
+		var pe *model.ProviderError
+		if !errors.As(err, &pe) || pe.Code != "OPENAI_FAILED" || pe.Retryable {
+			t.Fatalf("want non-retryable OPENAI_FAILED, got %v", err)
+		}
+	}
+
+	resp = &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(strings.Repeat("a", n)))}
+	got, err := readLimitedBody(resp, 1000)
+	if err != nil {
+		t.Fatalf("within-limit body must succeed, got %v", err)
+	}
+	if len(got) != n {
+		t.Fatalf("got %d bytes, want %d", len(got), n)
+	}
+}

--- a/tests/gemini/client_test.go
+++ b/tests/gemini/client_test.go
@@ -713,6 +713,41 @@ func TestAudioMissingKeyAndEmptyInput(t *testing.T) {
 	}
 }
 
+// TestRedirectIsRefusedAndKeyNotLeaked pins issue #416: the Gemini client must
+// NOT follow HTTP redirects. The key rides a custom header (x-goog-api-key),
+// and Go copies custom headers onto a redirect target (it only strips
+// Authorization/Cookie cross-host) — so a 3xx from a compromised or
+// misconfigured base_url would forward the API key to an attacker-controlled
+// host. The redirect target must never be contacted and the call must fail.
+func TestRedirectIsRefusedAndKeyNotLeaked(t *testing.T) {
+	var attackerHits int32
+	var leaked int32
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attackerHits, 1)
+		if r.Header.Get("x-goog-api-key") != "" {
+			atomic.StoreInt32(&leaked, 1)
+		}
+		_ = json.NewEncoder(w).Encode(embedRespFor(decodeNativeEmbed(t, r)))
+	}))
+	defer attacker.Close()
+
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, attacker.URL+r.URL.Path, http.StatusFound)
+	}))
+	defer redirector.Close()
+
+	c := newClient(redirector.URL)
+	if _, err := c.Embed(context.Background(), "gemini-embedding-001", model.EmbedDocument, []string{"x"}); err == nil {
+		t.Fatal("embed across a redirect must fail (redirect refused), got nil error")
+	}
+	if n := atomic.LoadInt32(&attackerHits); n != 0 {
+		t.Fatalf("redirect target was contacted %d time(s); the redirect must be refused", n)
+	}
+	if atomic.LoadInt32(&leaked) != 0 {
+		t.Fatal("x-goog-api-key was leaked to the redirect target")
+	}
+}
+
 // asProviderErr unwraps via errors.As (repo convention) so wrapped
 // provider errors are still recognized.
 func asProviderErr(err error, target **model.ProviderError) bool {


### PR DESCRIPTION
## Summary

Two of the security/robustness items from #416, scoped strictly to the provider HTTP clients (`internal/gemini`, `internal/openai`, `internal/omniembed`, `internal/mistral`, `internal/elevenlabs`). No retrieval/embedding/config code touched.

### FIX 1 — Gemini API key leaks across HTTP redirects (MED-HIGH, security)

`internal/gemini` authenticates with the custom `x-goog-api-key` header. Go follows redirects by default and copies custom headers onto the redirect target (it only strips `Authorization`/`Cookie` cross-host), so a malicious/compromised `base_url` or an injected `302` would forward the Gemini key to an attacker-controlled host.

Fix: set `CheckRedirect` on every Gemini HTTP client to **refuse** redirects (returns `http.ErrUseLastResponse`, surfaced as a non-2xx provider error). A direct provider API call never legitimately needs a redirect, so refusing is safe and the key is never sent onward. (Bearer-auth clients are not vulnerable — Go strips `Authorization` — so this hardening is applied to gemini, the affected client.)

### FIX 2 — no `io.LimitReader` on success bodies → gzip-bomb / huge-response OOM (MED)

Error bodies were already capped at 4096 bytes, but `200 OK` bodies were decoded/read **unbounded** (`json.NewDecoder(resp.Body)` / `io.ReadAll`) across all five clients. A malicious or buggy provider (especially a self-hosted omniembed or a custom `base_url`) could return a giant/gzip-bombed `200` and OOM the daemon.

Fix: every success-body read/decode now goes through `io.LimitReader` with a finite cap — **64 MiB** for JSON (embeddings/chat/OCR/STT), **256 MiB** for TTS audio (higher so legitimate large audio is not truncated). Exceeding the cap returns a clear, non-retryable provider error instead of buffering unbounded. Implemented as a small `readLimitedBody(resp, limit)` helper per client (reads one byte past the cap to detect overflow without buffering the whole body).

## Tests

- **gemini redirect**: a test server returning `302` to a second server — the client errors and the redirect target is never contacted, so the `x-goog-api-key` is never leaked.
- **over-limit body** (all five clients): the limited reader returns a non-retryable `*_FAILED` error on an over-cap body and returns within-cap bodies in full.
- Refactored `mistral.embedBatch` (extracted `collectEmbedVectors`) to keep `gocyclo` under 15.
- `make check` passes locally (fmt, vet, lint, cyclo, ineffassign, misspell, full test suite, release-tools, build).

## Deferred (still open in #416)

Retry-After/jitter, plaintext-http guard, and zero-vector handling are intentionally **not** in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)