### PR TITLE
fix(status): reconcile stale "running" snapshot against daemon liveness

### DIFF
--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -58,15 +58,44 @@ func (a *App) runStatus(ctx context.Context, global globalOptions, args []string
 		source = "computed"
 	}
 
-	return a.renderStatusOutput(global, cfg.StateDir, snapshot, source)
+	// Reconcile a daemon-written "running" snapshot against process liveness.
+	// corpus.json is written by the daemon, so a daemon that recorded
+	// running=true and then crashed would otherwise leave status reporting
+	// indexing as "running" forever. If no live daemon owns this state dir, the
+	// snapshot is stale: report indexing as stopped instead (#418).
+	staleRunning := false
+	if snapshot.Indexing.Running && !daemonIsLive(cfg.StateDir) {
+		snapshot.Indexing.Running = false
+		staleRunning = true
+	}
+
+	return a.renderStatusOutput(global, cfg.StateDir, snapshot, source, staleRunning)
 }
 
-func (a *App) renderStatusOutput(global globalOptions, stateDir string, snapshot corpusSnapshot, source string) int {
+// daemonIsLive reports whether a live daemon process currently owns the given
+// state dir. It consults the pid file written by `dir2mcp up` and checks the
+// recorded pid for liveness. Returns false when the pid file is absent,
+// malformed, or names a process that is no longer running.
+func daemonIsLive(stateDir string) bool {
+	pid, err := readPIDFile(pidFilePath(stateDir))
+	if err != nil {
+		return false
+	}
+	return processIsAlive(pid)
+}
+
+func (a *App) renderStatusOutput(global globalOptions, stateDir string, snapshot corpusSnapshot, source string, staleRunning bool) int {
 	if global.jsonOutput {
 		payload := map[string]interface{}{
 			"source":    source,
 			"state_dir": stateDir,
 			"snapshot":  snapshot,
+		}
+		if staleRunning {
+			// Additive, optional field: signals that the snapshot recorded
+			// indexing as running but no live daemon was found, so running was
+			// reconciled to false. Absent in the common case (#418).
+			payload["stale_running"] = true
 		}
 		if err := emitJSON(a.stdout, payload); err != nil {
 			writeCLIError(a.stderr, true, exitGeneric, fmt.Sprintf("encode status json: %v", err))
@@ -86,8 +115,11 @@ func (a *App) renderStatusOutput(global globalOptions, stateDir string, snapshot
 	writeln(a.stdout)
 
 	runningLabel := s.dim("stopped")
-	if snapshot.Indexing.Running {
+	switch {
+	case snapshot.Indexing.Running:
 		runningLabel = s.Green.Render("running")
+	case staleRunning:
+		runningLabel = s.dim("stopped") + "  " + s.dim("(stale snapshot; daemon not running)")
 	}
 
 	writef(a.stdout, "  %s  %s  %s\n", s.sectionHeader("Indexing"), s.dim("mode="+snapshot.Indexing.Mode), runningLabel)

--- a/tests/cli/command_behavior_test.go
+++ b/tests/cli/command_behavior_test.go
@@ -135,6 +135,138 @@ func TestStatusReadsCorpusSnapshotHuman(t *testing.T) {
 	}
 }
 
+// runningCorpusJSON returns a corpus.json payload that records indexing as
+// currently running, used to exercise the stale-running reconciliation (#418).
+func runningCorpusJSON() string {
+	return `{
+  "ts": "2026-03-01T00:00:00Z",
+  "indexing": {"mode":"incremental","running":true,"scanned":1,"indexed":1,"skipped":0,"deleted":0,"representations":1,"chunks_total":1,"embedded_ok":1,"errors":0},
+  "doc_counts": {"code": 1},
+  "total_docs": 1,
+  "code_ratio": 1.0
+}`
+}
+
+// TestStatusStaleRunningReportsStopped covers the core #418 fix: corpus.json
+// recorded indexing as running, but no live daemon owns the state dir (no pid
+// file), so status must reconcile the snapshot to "stopped" instead of
+// reporting a stale, perpetual "running".
+func TestStatusStaleRunningReportsStopped(t *testing.T) {
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, ".dir2mcp")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "corpus.json"), []byte(runningCorpusJSON()), 0o644); err != nil {
+		t.Fatalf("write corpus.json: %v", err)
+	}
+	// Deliberately no server.pid: the daemon crashed/exited.
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	withWorkingDir(t, tmp, func() {
+		code := app.RunWithContext(context.Background(), []string{"status"})
+		if code != 0 {
+			t.Fatalf("unexpected exit code: %d stderr=%s", code, stderr.String())
+		}
+	})
+
+	out := stdout.String()
+	if !strings.Contains(out, "stopped") {
+		t.Fatalf("expected indexing reported stopped, got: %s", out)
+	}
+	if !strings.Contains(out, "stale snapshot") {
+		t.Fatalf("expected stale-snapshot note, got: %s", out)
+	}
+}
+
+// TestStatusStaleRunningJSONReconcilesRunningFalse asserts the JSON envelope
+// reports running=false and flags stale_running when the snapshot is stale.
+func TestStatusStaleRunningJSONReconcilesRunningFalse(t *testing.T) {
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, ".dir2mcp")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "corpus.json"), []byte(runningCorpusJSON()), 0o644); err != nil {
+		t.Fatalf("write corpus.json: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	withWorkingDir(t, tmp, func() {
+		code := app.RunWithContext(context.Background(), []string{"--json", "status"})
+		if code != 0 {
+			t.Fatalf("unexpected exit code: %d stderr=%s", code, stderr.String())
+		}
+	})
+
+	var payload struct {
+		StaleRunning bool `json:"stale_running"`
+		Snapshot     struct {
+			Indexing struct {
+				Running bool `json:"running"`
+			} `json:"indexing"`
+		} `json:"snapshot"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal status payload: %v\nraw=%s", err, stdout.String())
+	}
+	if payload.Snapshot.Indexing.Running {
+		t.Fatalf("expected indexing.running reconciled to false, got true: %s", stdout.String())
+	}
+	if !payload.StaleRunning {
+		t.Fatalf("expected stale_running=true in payload, got: %s", stdout.String())
+	}
+}
+
+// TestStatusLiveDaemonReportsRunning guards the normal case: when a live daemon
+// owns the state dir (pid file names a running process), a running snapshot is
+// reported as running, not reconciled away.
+func TestStatusLiveDaemonReportsRunning(t *testing.T) {
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, ".dir2mcp")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "corpus.json"), []byte(runningCorpusJSON()), 0o644); err != nil {
+		t.Fatalf("write corpus.json: %v", err)
+	}
+	// The test process itself is a guaranteed-live pid, standing in for a
+	// live daemon registered in server.pid.
+	pid := fmt.Sprintf("%d\n", os.Getpid())
+	if err := os.WriteFile(filepath.Join(stateDir, "server.pid"), []byte(pid), 0o644); err != nil {
+		t.Fatalf("write server.pid: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	withWorkingDir(t, tmp, func() {
+		code := app.RunWithContext(context.Background(), []string{"--json", "status"})
+		if code != 0 {
+			t.Fatalf("unexpected exit code: %d stderr=%s", code, stderr.String())
+		}
+	})
+
+	var payload struct {
+		StaleRunning bool `json:"stale_running"`
+		Snapshot     struct {
+			Indexing struct {
+				Running bool `json:"running"`
+			} `json:"indexing"`
+		} `json:"snapshot"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal status payload: %v\nraw=%s", err, stdout.String())
+	}
+	if !payload.Snapshot.Indexing.Running {
+		t.Fatalf("expected live daemon to report running=true, got: %s", stdout.String())
+	}
+	if payload.StaleRunning {
+		t.Fatalf("did not expect stale_running for a live daemon: %s", stdout.String())
+	}
+}
+
 func TestStatusJSONMode(t *testing.T) {
 	tmp := t.TempDir()
 	stateDir := filepath.Join(tmp, ".dir2mcp")


### PR DESCRIPTION
Addresses the status-stale-running part of #418 (reindex-guard in #457; pid-reuse deferred).

## Problem

`internal/cli/status.go` read `snapshot.Indexing.Running` straight from `corpus.json` (daemon-written) with no liveness cross-check. A daemon that wrote `running=true` and then crashed left `status` reporting indexing as "running" (green) forever — it never consulted the pid file.

## Fix

In the status command, reconcile the reported indexing-running state against daemon liveness using the existing pid-liveness mechanism (`pidFilePath` + `readPIDFile` + `processIsAlive`, reused — not reimplemented):

- If `corpus.json` says `running=true` but no live daemon process owns the state dir (pid file absent or process not alive), report indexing as **stopped** and note the snapshot is stale.
- The normal case (a live daemon writing `running=true`) still reports running.
- Output contract is stable: human output unchanged except a `(stale snapshot; daemon not running)` note; JSON `indexing.running` is reconciled to `false` with an additive, optional `stale_running` flag.

Scope kept to `internal/cli/status.go` plus tests.

## Tests

`tests/cli/command_behavior_test.go`:
- `TestStatusStaleRunningReportsStopped` — `running=true`, no pid file → reports stopped + stale note.
- `TestStatusStaleRunningJSONReconcilesRunningFalse` — JSON envelope reports `running=false`, `stale_running=true`.
- `TestStatusLiveDaemonReportsRunning` — live pid (test process) → still reports running, no stale flag.

`make check` passes (build, vet, golangci-lint, gocyclo -over 15 clean, misspell, full test suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `status` output to better detect when indexing appears running but no live process is actually using the state directory.
  * Added a clearer “stale snapshot” message in human-readable output for this case.
  * JSON status output now includes a `stale_running` field and reports the indexing state more accurately when the snapshot is outdated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->