### PR TITLE
fix(elevenlabsbridge): require inbound auth + guard non-loopback binds (#415)

### DIFF
--- a/internal/cli/bridge.go
+++ b/internal/cli/bridge.go
@@ -36,10 +36,20 @@ func (a *App) runBridgeElevenLabs(ctx context.Context, global globalOptions, arg
 		return parseCode
 	}
 
+	if err := elevenlabsbridge.ValidateListenSecurity(listen, cfg.InboundSecretConfigured(), cfg.ForceInsecure); err != nil {
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, err.Error())
+		return exitConfigInvalid
+	}
+
 	bridge, err := elevenlabsbridge.New(cfg)
 	if err != nil {
 		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, err.Error())
 		return exitGeneric
+	}
+
+	inboundAuth := "none"
+	if bridge.InboundAuthEnabled() {
+		inboundAuth = "secret"
 	}
 
 	if global.jsonOutput {
@@ -49,6 +59,7 @@ func (a *App) runBridgeElevenLabs(ctx context.Context, global globalOptions, arg
 			"mcp_url":      cfg.MCPURL,
 			"state_dir":    cfg.StateDir,
 			"token_source": bridge.TokenSource(),
+			"inbound_auth": inboundAuth,
 		}); err != nil {
 			writeCLIError(a.stderr, true, exitGeneric, fmt.Sprintf("encode bridge json: %v", err))
 			return exitGeneric
@@ -58,6 +69,7 @@ func (a *App) runBridgeElevenLabs(ctx context.Context, global globalOptions, arg
 		_, _ = fmt.Fprintf(a.stdout, "MCP_URL=%s\n", cfg.MCPURL)
 		_, _ = fmt.Fprintf(a.stdout, "STATE_DIR=%s\n", cfg.StateDir)
 		_, _ = fmt.Fprintf(a.stdout, "MCP token source=%s\n", bridge.TokenSource())
+		_, _ = fmt.Fprintf(a.stdout, "inbound auth=%s\n", inboundAuth)
 	}
 
 	if err := elevenlabsbridge.RunWithBridge(ctx, bridge, listen); err != nil && ctx.Err() == nil {
@@ -69,10 +81,11 @@ func (a *App) runBridgeElevenLabs(ctx context.Context, global globalOptions, arg
 
 func loadBridgeDefaultConfig(global globalOptions) (elevenlabsbridge.Config, error) {
 	env := map[string]string{
-		"MCP_URL":   os.Getenv("MCP_URL"),
-		"MCP_TOKEN": os.Getenv("MCP_TOKEN"),
-		"STATE_DIR": os.Getenv("STATE_DIR"),
-		"PORT":      os.Getenv("PORT"),
+		"MCP_URL":               os.Getenv("MCP_URL"),
+		"MCP_TOKEN":             os.Getenv("MCP_TOKEN"),
+		"STATE_DIR":             os.Getenv("STATE_DIR"),
+		"PORT":                  os.Getenv("PORT"),
+		"BRIDGE_INBOUND_SECRET": os.Getenv("BRIDGE_INBOUND_SECRET"),
 	}
 	if v := strings.TrimSpace(global.stateDir); v != "" {
 		env["STATE_DIR"] = v
@@ -88,6 +101,8 @@ func (a *App) parseBridgeElevenLabsFlags(global globalOptions, defaultCfg eleven
 	stateDir := fs.String("state-dir", defaultCfg.StateDir, "dir2mcp state directory")
 	port := fs.Int("port", defaultCfg.Port, "bridge listen port")
 	listenAddr := fs.String("listen", "", "override listen address (host:port)")
+	inboundSecret := fs.String("inbound-secret", defaultCfg.InboundSecret, "shared secret required from inbound callers (Authorization: Bearer <secret> or X-Bridge-Secret)")
+	forceInsecure := fs.Bool("force-insecure", false, "allow binding a non-loopback address without an inbound secret (unsafe)")
 	if err := fs.Parse(args); err != nil {
 		return elevenlabsbridge.Config{}, "", exitConfigInvalid
 	}
@@ -100,6 +115,8 @@ func (a *App) parseBridgeElevenLabsFlags(global globalOptions, defaultCfg eleven
 	cfg.MCPURL = strings.TrimSpace(*mcpURL)
 	cfg.MCPToken = strings.TrimSpace(*mcpToken)
 	cfg.StateDir = strings.TrimSpace(*stateDir)
+	cfg.InboundSecret = strings.TrimSpace(*inboundSecret)
+	cfg.ForceInsecure = *forceInsecure
 	portProvided := false
 	fs.Visit(func(f *flag.Flag) {
 		if f.Name == "port" {

--- a/internal/elevenlabsbridge/config.go
+++ b/internal/elevenlabsbridge/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -29,6 +30,22 @@ type Config struct {
 	MCPToken string
 	StateDir string
 	Port     int
+	// InboundSecret is the shared secret that inbound callers must present
+	// (via "Authorization: Bearer <secret>" or "X-Bridge-Secret: <secret>")
+	// on every protected route. When empty, inbound auth is disabled and the
+	// bridge refuses to bind to a non-loopback address unless ForceInsecure is
+	// set.
+	InboundSecret string
+	// ForceInsecure permits binding to a non-loopback address without an
+	// inbound secret. It mirrors the main server's --force-insecure escape
+	// hatch and is unsafe: anyone who can reach the socket can drive
+	// authenticated MCP calls against the private corpus.
+	ForceInsecure bool
+}
+
+// InboundSecretConfigured reports whether an inbound shared secret is set.
+func (cfg Config) InboundSecretConfigured() bool {
+	return strings.TrimSpace(cfg.InboundSecret) != ""
 }
 
 // DefaultConfig returns the bridge defaults used when env vars and flags are
@@ -53,6 +70,9 @@ func LoadConfigFromEnv(env map[string]string) (Config, error) {
 	}
 	if v := strings.TrimSpace(env["STATE_DIR"]); v != "" {
 		cfg.StateDir = v
+	}
+	if v := strings.TrimSpace(env["BRIDGE_INBOUND_SECRET"]); v != "" {
+		cfg.InboundSecret = v
 	}
 	if v := strings.TrimSpace(env["PORT"]); v != "" {
 		port, err := strconv.Atoi(v)
@@ -93,10 +113,11 @@ func LoadConfigFromEnv(env map[string]string) (Config, error) {
 // LoadConfigFromOSEnv resolves the bridge config from the current process env.
 func LoadConfigFromOSEnv() (Config, error) {
 	return LoadConfigFromEnv(map[string]string{
-		"MCP_URL":   os.Getenv("MCP_URL"),
-		"MCP_TOKEN": os.Getenv("MCP_TOKEN"),
-		"STATE_DIR": os.Getenv("STATE_DIR"),
-		"PORT":      os.Getenv("PORT"),
+		"MCP_URL":               os.Getenv("MCP_URL"),
+		"MCP_TOKEN":             os.Getenv("MCP_TOKEN"),
+		"STATE_DIR":             os.Getenv("STATE_DIR"),
+		"PORT":                  os.Getenv("PORT"),
+		"BRIDGE_INBOUND_SECRET": os.Getenv("BRIDGE_INBOUND_SECRET"),
 	})
 }
 
@@ -152,6 +173,57 @@ func readTokenFromFile(tokenPath string) (token, source, absPath string, err err
 // port. The bridge intentionally binds to loopback by default.
 func (cfg Config) EffectiveListenAddr() string {
 	return fmt.Sprintf("127.0.0.1:%d", cfg.Port)
+}
+
+// isLoopbackListenAddr reports whether listenAddr binds only to a loopback
+// interface. An empty host (e.g. ":8088") or a wildcard host (0.0.0.0, ::) is
+// treated as non-loopback because it is reachable from other hosts. Unparseable
+// addresses are treated as non-loopback (fail closed).
+func isLoopbackListenAddr(listenAddr string) bool {
+	addr := strings.TrimSpace(listenAddr)
+	if addr == "" {
+		return false
+	}
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		// No port present; treat the whole value as the host.
+		host = addr
+	}
+	host = strings.TrimSpace(host)
+	if host == "" {
+		// Empty host binds all interfaces.
+		return false
+	}
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	parsed := net.ParseIP(host)
+	if parsed == nil {
+		return false
+	}
+	if parsed.IsUnspecified() {
+		return false
+	}
+	return parsed.IsLoopback()
+}
+
+// ValidateListenSecurity enforces the non-loopback guard: binding to a
+// non-loopback address without an inbound secret is refused unless
+// forceInsecure is set. Loopback binds (local development) are always allowed.
+// It mirrors the main server's --public/--force-insecure contract.
+func ValidateListenSecurity(listenAddr string, hasInboundSecret, forceInsecure bool) error {
+	if hasInboundSecret || forceInsecure {
+		return nil
+	}
+	if isLoopbackListenAddr(listenAddr) {
+		return nil
+	}
+	return fmt.Errorf(
+		"refusing to bind elevenlabs bridge to non-loopback address %q without inbound auth: "+
+			"set BRIDGE_INBOUND_SECRET (or --inbound-secret) to require a shared secret, "+
+			"or pass --force-insecure to override (unsafe: exposes the private corpus to anonymous callers)",
+		strings.TrimSpace(listenAddr),
+	)
 }
 
 func readConnectionPayload(stateDir string) (connectionPayload, error) {

--- a/internal/elevenlabsbridge/server.go
+++ b/internal/elevenlabsbridge/server.go
@@ -2,6 +2,7 @@ package elevenlabsbridge
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,6 +13,8 @@ import (
 
 	"github.com/dirstral/dir2mcp/internal/protocol"
 )
+
+const inboundSecretHeader = "X-Bridge-Secret"
 
 const defaultAskK = 3
 const maxBridgeRequestBodyBytes int64 = 1 << 20
@@ -74,12 +77,79 @@ func (b *bridge) MCPURL() string {
 	return b.cfg.MCPURL
 }
 
+// InboundAuthEnabled reports whether protected routes require a shared secret.
+func (b *bridge) InboundAuthEnabled() bool {
+	if b == nil {
+		return false
+	}
+	return b.cfg.InboundSecretConfigured()
+}
+
 func (b *bridge) routes() {
+	// /health is intentionally unauthenticated: it returns no corpus data.
 	b.mux.HandleFunc("/health", b.handleHealth)
-	b.mux.HandleFunc("/ask", b.methodGuard(http.MethodPost, b.handleAsk))
-	b.mux.HandleFunc("/search", b.methodGuard(http.MethodPost, b.handleSearch))
-	b.mux.HandleFunc("/list_files", b.methodGuard(http.MethodGet, b.handleListFiles, http.MethodPost))
-	b.mux.HandleFunc("/stats", b.methodGuard(http.MethodGet, b.handleStats, http.MethodPost))
+	b.mux.HandleFunc("/ask", b.protected(http.MethodPost, b.handleAsk))
+	b.mux.HandleFunc("/search", b.protected(http.MethodPost, b.handleSearch))
+	b.mux.HandleFunc("/list_files", b.protected(http.MethodGet, b.handleListFiles, http.MethodPost))
+	b.mux.HandleFunc("/stats", b.protected(http.MethodGet, b.handleStats, http.MethodPost))
+}
+
+// protected wraps a handler with the inbound-auth check followed by the HTTP
+// method guard, so unauthenticated callers are rejected before any work runs.
+func (b *bridge) protected(allowed string, fn http.HandlerFunc, extra ...string) http.HandlerFunc {
+	return b.requireInboundAuth(b.methodGuard(allowed, fn, extra...))
+}
+
+// requireInboundAuth rejects requests that do not present the configured shared
+// secret. When no secret is configured the handler passes through; in that case
+// the non-loopback guard (ValidateListenSecurity) prevents the bridge from
+// starting on a publicly reachable address.
+func (b *bridge) requireInboundAuth(fn http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !b.cfg.InboundSecretConfigured() {
+			fn(w, r)
+			return
+		}
+		if !b.inboundSecretMatches(r) {
+			w.Header().Set("WWW-Authenticate", `Bearer realm="elevenlabs-bridge"`)
+			writeJSONError(w, http.StatusUnauthorized, "missing or invalid inbound credentials")
+			return
+		}
+		fn(w, r)
+	}
+}
+
+// inboundSecretMatches performs a constant-time comparison of the presented
+// credential against the configured secret. It accepts either an
+// "Authorization: Bearer <secret>" header or an "X-Bridge-Secret: <secret>"
+// header.
+func (b *bridge) inboundSecretMatches(r *http.Request) bool {
+	secret := strings.TrimSpace(b.cfg.InboundSecret)
+	if secret == "" {
+		return false
+	}
+	presented := strings.TrimSpace(r.Header.Get(inboundSecretHeader))
+	if presented == "" {
+		if auth := strings.TrimSpace(r.Header.Get("Authorization")); auth != "" {
+			if rest, ok := cutBearerPrefix(auth); ok {
+				presented = strings.TrimSpace(rest)
+			}
+		}
+	}
+	if presented == "" {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(presented), []byte(secret)) == 1
+}
+
+// cutBearerPrefix strips a case-insensitive "Bearer " prefix from an
+// Authorization header value.
+func cutBearerPrefix(value string) (string, bool) {
+	const prefix = "bearer "
+	if len(value) < len(prefix) || !strings.EqualFold(value[:len(prefix)], prefix) {
+		return "", false
+	}
+	return value[len(prefix):], true
 }
 
 func (b *bridge) methodGuard(allowed string, fn http.HandlerFunc, extra ...string) http.HandlerFunc {
@@ -266,6 +336,9 @@ func Run(ctx context.Context, cfg Config, listenAddr string) error {
 // RunWithBridge starts the bridge HTTP server with a pre-constructed bridge and
 // blocks until the context is canceled or the server fails to start.
 func RunWithBridge(ctx context.Context, b *bridge, listenAddr string) error {
+	if err := ValidateListenSecurity(listenAddr, b.cfg.InboundSecretConfigured(), b.cfg.ForceInsecure); err != nil {
+		return err
+	}
 	server := &http.Server{
 		Addr:              strings.TrimSpace(listenAddr),
 		Handler:           b.Handler(),

--- a/tests/elevenlabsbridge/bridge_test.go
+++ b/tests/elevenlabsbridge/bridge_test.go
@@ -2,7 +2,9 @@ package elevenlabsbridge_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -330,6 +332,179 @@ func assertAskRequestSequence(t *testing.T, requests []recordedMCPRequest) {
 	}
 	if requests[1].K != 7 {
 		t.Fatalf("k=%d", requests[1].K)
+	}
+}
+
+func TestInboundSecretRejectsUnauthenticated(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		requests []recordedMCPRequest
+	)
+	handlerErrCh := make(chan error, 8)
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handleMCPBackend(w, r, &mu, &requests, handlerErrCh)
+	}))
+	defer backend.Close()
+
+	cfg := elevenlabsbridge.DefaultConfig()
+	cfg.MCPURL = backend.URL
+	cfg.MCPToken = "bridge-token"
+	cfg.StateDir = t.TempDir()
+	cfg.InboundSecret = "top-secret"
+
+	bridge, err := elevenlabsbridge.New(cfg)
+	if err != nil {
+		t.Fatalf("new bridge: %v", err)
+	}
+	if !bridge.InboundAuthEnabled() {
+		t.Fatalf("expected inbound auth to be enabled")
+	}
+
+	srv := httptest.NewServer(bridge.Handler())
+	defer srv.Close()
+
+	askBody := `{"question":"what is alpha?","k":7}`
+
+	// No credential -> 401, and the backend must never be reached.
+	if got := postAsk(t, srv.URL, askBody, ""); got != http.StatusUnauthorized {
+		t.Fatalf("missing secret: status=%d want=%d", got, http.StatusUnauthorized)
+	}
+	// Wrong credential -> 401.
+	if got := postAskWithHeader(t, srv.URL, askBody, "X-Bridge-Secret", "wrong"); got != http.StatusUnauthorized {
+		t.Fatalf("wrong secret: status=%d want=%d", got, http.StatusUnauthorized)
+	}
+
+	mu.Lock()
+	if len(requests) != 0 {
+		mu.Unlock()
+		t.Fatalf("backend was reached by unauthenticated callers: %#v", requests)
+	}
+	mu.Unlock()
+
+	// Correct credential via X-Bridge-Secret -> 200.
+	if got := postAskWithHeader(t, srv.URL, askBody, "X-Bridge-Secret", "top-secret"); got != http.StatusOK {
+		t.Fatalf("valid X-Bridge-Secret: status=%d want=%d", got, http.StatusOK)
+	}
+	// Correct credential via Authorization: Bearer -> 200.
+	if got := postAsk(t, srv.URL, askBody, "Bearer top-secret"); got != http.StatusOK {
+		t.Fatalf("valid bearer: status=%d want=%d", got, http.StatusOK)
+	}
+
+	// /health stays unauthenticated.
+	healthResp, err := http.Get(srv.URL + "/health")
+	if err != nil {
+		t.Fatalf("get health: %v", err)
+	}
+	_ = healthResp.Body.Close()
+	if healthResp.StatusCode != http.StatusOK {
+		t.Fatalf("health status=%d want=%d", healthResp.StatusCode, http.StatusOK)
+	}
+
+	close(handlerErrCh)
+	for err := range handlerErrCh {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func postAsk(t *testing.T, baseURL, body, authorization string) int {
+	t.Helper()
+	return postAskWithHeader(t, baseURL, body, "Authorization", authorization)
+}
+
+func postAskWithHeader(t *testing.T, baseURL, body, headerName, headerValue string) int {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/ask", bytes.NewBufferString(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if headerValue != "" {
+		req.Header.Set(headerName, headerValue)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return resp.StatusCode
+}
+
+func TestValidateListenSecurity(t *testing.T) {
+	cases := []struct {
+		name          string
+		listen        string
+		hasSecret     bool
+		forceInsecure bool
+		wantErr       bool
+	}{
+		{name: "loopback no secret allowed", listen: "127.0.0.1:8088"},
+		{name: "loopback ipv6 allowed", listen: "[::1]:8088"},
+		{name: "localhost allowed", listen: "localhost:8088"},
+		{name: "wildcard no secret refused", listen: "0.0.0.0:8088", wantErr: true},
+		{name: "empty host refused", listen: ":8088", wantErr: true},
+		{name: "ipv6 wildcard refused", listen: "[::]:8088", wantErr: true},
+		{name: "public ip no secret refused", listen: "192.168.1.10:8088", wantErr: true},
+		{name: "public ip with secret allowed", listen: "0.0.0.0:8088", hasSecret: true},
+		{name: "public ip force insecure allowed", listen: "0.0.0.0:8088", forceInsecure: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := elevenlabsbridge.ValidateListenSecurity(tc.listen, tc.hasSecret, tc.forceInsecure)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error for %q (secret=%v force=%v)", tc.listen, tc.hasSecret, tc.forceInsecure)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error for %q: %v", tc.listen, err)
+			}
+		})
+	}
+}
+
+func TestRunWithBridgeRefusesNonLoopbackWithoutSecret(t *testing.T) {
+	cfg := elevenlabsbridge.DefaultConfig()
+	cfg.MCPURL = "http://127.0.0.1:1/mcp"
+	cfg.MCPToken = "token"
+	cfg.StateDir = t.TempDir()
+
+	bridge, err := elevenlabsbridge.New(cfg)
+	if err != nil {
+		t.Fatalf("new bridge: %v", err)
+	}
+
+	// Non-loopback without a secret must be refused before the server binds.
+	if err := elevenlabsbridge.RunWithBridge(context.Background(), bridge, "0.0.0.0:0"); err == nil {
+		t.Fatalf("expected RunWithBridge to refuse non-loopback bind without secret")
+	} else if !strings.Contains(err.Error(), "non-loopback") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunWithBridgeAllowsLoopbackWithoutSecret(t *testing.T) {
+	cfg := elevenlabsbridge.DefaultConfig()
+	cfg.MCPURL = "http://127.0.0.1:1/mcp"
+	cfg.MCPToken = "token"
+	cfg.StateDir = t.TempDir()
+
+	bridge, err := elevenlabsbridge.New(cfg)
+	if err != nil {
+		t.Fatalf("new bridge: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- elevenlabsbridge.RunWithBridge(ctx, bridge, "127.0.0.1:0")
+	}()
+
+	// The guard must not refuse a loopback bind: cancel and expect a clean
+	// context-cancellation rather than a security error.
+	cancel()
+	if err := <-errCh; err != nil && !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context cancellation, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Problem

The ElevenLabs bridge (`internal/elevenlabsbridge`) is a REST→MCP reverse proxy that holds the dir2mcp bearer token and made **authenticated** MCP calls on behalf of **any anonymous** caller (auth-laundering). The inbound routes `/ask`, `/search`, `/list_files`, `/stats` were guarded **only** by an HTTP method check — no `Authorization`, secret, HMAC, or signature on any route. `--listen` accepted any address (e.g. `0.0.0.0`) with no guard, and the documented ElevenLabs use case needs a publicly reachable URL. Result: anyone reaching the socket read the private corpus (data exfiltration) and drove unbounded LLM/embedding spend (cost-amplification DoS).

## Fix (two parts)

**1. Inbound authentication.** New shared-secret config field, set via `BRIDGE_INBOUND_SECRET` env or `--inbound-secret`. When configured, every protected route requires the secret presented as `Authorization: Bearer <secret>` or `X-Bridge-Secret: <secret>`, verified with `crypto/subtle.ConstantTimeCompare`. Missing/wrong credentials return `401`. `/health` stays unauthenticated (it returns no corpus data). Auth runs before the method guard and before any backend call.

**2. Non-loopback guard.** Mirrors the main server's `--public`/`--force-insecure` contract. Binding a non-loopback address (wildcard `0.0.0.0`/`::`, empty host, or a routable IP) **without** an inbound secret is refused with a clear, actionable error unless `--force-insecure` is set. Loopback binds (`127.0.0.1`, `::1`, `localhost`) with no secret stay allowed for local dev. Enforced both at the CLI (clean config error) and in `RunWithBridge` (defense-in-depth).

The CLI/JSON status now reports `inbound auth=secret|none`.

## Scope

Touches only `internal/elevenlabsbridge/{config.go,server.go}`, `internal/cli/bridge.go`, and `tests/elevenlabsbridge/bridge_test.go`.

## Tests

- Protected route returns `401` without the secret and `200` with the correct secret (both header forms); the backend is never reached by unauthenticated callers; `/health` stays open.
- `ValidateListenSecurity` table covering loopback/wildcard/empty-host/routable-IP × secret/force-insecure.
- `RunWithBridge` refuses a non-loopback bind without a secret and allows a loopback bind without one.

Full `make check` passes (gofmt, vet, golangci-lint, gocyclo, ineffassign, misspell, tests, build).

## Follow-up

The PREFERRED ElevenLabs webhook **HMAC** signature verification (HMAC-SHA256 over the raw body with a timestamp/replay window) is left as a follow-up; the constant-time shared-secret check fully closes the open hole and is a large improvement.

Addresses #415 (inbound auth + non-loopback guard; HMAC follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)