### PR TITLE
docs: stop hardcoding a spec version in the pointer stubs (#422-adjacent)

### DIFF
--- a/README.md
+++ b/README.md
@@ -757,7 +757,7 @@ Normative docs are maintained in the [`dirstral-spec`](https://github.com/dirstr
 - [dirstral-spec/docs/SPEC.md](dirstral-spec/docs/SPEC.md) — normative behavior, schemas, and runtime contracts
 - [dirstral-spec/docs/ECOSYSTEM.md](dirstral-spec/docs/ECOSYSTEM.md) — ecosystem/market/discovery/payment context
 - [dirstral-spec/docs/x402-payment-adapter-spec.md](dirstral-spec/docs/x402-payment-adapter-spec.md) — facilitator adapter contract
-- dir2mcp implements spec version `0.16.x` ([versioning](dirstral-spec/spec/versioning.md))
+- [dirstral-spec/spec/versioning.md](dirstral-spec/spec/versioning.md) — spec versioning policy and the implementation **compatibility matrix** (the canonical record of which spec version dir2mcp targets; the vendored submodule carries the current spec version in its header)
 
 Operator guides (in-repo):
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -8,7 +8,12 @@ single source of truth and this copy can no longer drift.
 - In-tree (pinned submodule): [`dirstral-spec/docs/SPEC.md`](../dirstral-spec/docs/SPEC.md)
 - Upstream: <https://github.com/dirstral/dirstral-spec/blob/main/docs/SPEC.md>
 
-dir2mcp implements spec version `0.16.x` — see [`dirstral-spec/spec/versioning.md`](../dirstral-spec/spec/versioning.md).
+The spec version dir2mcp targets is recorded in the **compatibility matrix** in
+[`dirstral-spec/spec/versioning.md`](../dirstral-spec/spec/versioning.md) — the
+single source of truth — and the vendored spec's own current version is in that
+file's header. This stub intentionally **no longer hardcodes a version number**:
+the previous `0.16.x` claim had drifted from both the matrix and the vendored
+spec, which is exactly the duplication this submodule layout exists to prevent.
 
 If the `dirstral-spec/` directory is empty, fetch the submodule:
 


### PR DESCRIPTION
## Problem
`docs/SPEC.md` and `README.md` both asserted **"dir2mcp implements spec version `0.16.x`"** — a hardcoded number that had drifted out of agreement with:
- the **vendored spec** (now `0.22.0`, per `dirstral-spec/docs/SPEC.md` + `versioning.md` header), and
- the canonical **compatibility matrix** in `dirstral-spec/spec/versioning.md`, which records `dir2mcp` as `0.14.x (pending)`.

Three different numbers in three places — the classic drift the vendored-submodule layout exists to prevent.

## Fix
Both pointer stubs now **defer to the compatibility matrix** as the single source of truth instead of restating a version number. No number is duplicated in this repo anymore. The per-feature `spec 0.x.y` provenance comments scattered through `internal/` are accurate annotations and are left untouched.

## ⚠️ Deeper issue this surfaces (not fixed here — needs a maintainer call)
The matrix itself is stale: it lists `dir2mcp` as **`0.14.x (pending)`** with 0.15/0.16/0.17 marked "Planned / follow-up", yet the code already implements 0.15 (extractor availability — `decision.go`, `docling_probe.go`) and 0.16 (output quality gate / quarantine — `service.go`, `errcat.go`) features. Determining dir2mcp's true conformance target against the 0.22.0 spec and updating the matrix is a spec-side change (governance loop) and a maintainer decision (#422). This PR only removes the drifting duplicate; it deliberately does not guess the matrix value.

Docs-only; no code or behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Replaced the hardcoded spec version reference with a link to the canonical compatibility matrix.
  * Clarified where to find the current spec version target, reducing the chance of outdated version statements in the docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This docs-only PR removes hardcoded spec version numbers (`0.16.x`) from `README.md` and `docs/SPEC.md`, replacing them with pointers to the compatibility matrix in `dirstral-spec/spec/versioning.md` as the single source of truth. No code or behavior is changed.

- **README.md**: The inline version claim is replaced with a bullet linking to `versioning.md`, consistent with the other `dirstral-spec` bullet entries in that section.
- **docs/SPEC.md**: The single-line version assertion is replaced with a short paragraph explaining that the stub no longer hardcodes a version and why — including a back-reference to the old `0.16.x` value as historical context.

<h3>Confidence Score: 5/5</h3>

Docs-only change with no code or behavior impact; safe to merge.

Both files are pointer stubs with no runtime effect. The rewording is accurate, the links are consistent with the rest of the Documentation section, and no version number is asserted in a place that could drift again.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Replaces a hardcoded `0.16.x` spec version claim with a link to the compatibility matrix in `dirstral-spec/spec/versioning.md`; change is accurate and well-placed in the Documentation section. |
| docs/SPEC.md | Pointer stub updated to defer version information to the compatibility matrix; new prose is verbose for a stub but correct — it explains the rationale and still references `0.16.x` as historical context (clearly labelled as the old, drifted claim). |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Developer / Reader] --> B{Where is the spec version?}

    subgraph BEFORE["Before this PR"]
        B1[README.md] -->|hardcoded claim| V1["dir2mcp implements spec version 0.16.x"]
        B2[docs/SPEC.md] -->|hardcoded claim| V2["dir2mcp implements spec version 0.16.x"]
        B3[dirstral-spec/spec/versioning.md] -->|canonical matrix| V3["0.14.x (pending)"]
        V1 -.->|drift| V3
        V2 -.->|drift| V3
    end

    subgraph AFTER["After this PR"]
        C1[README.md] -->|link| M[dirstral-spec/spec/versioning.md]
        C2[docs/SPEC.md] -->|link| M
        M -->|canonical record| T["Compatibility matrix\n(single source of truth)"]
    end

    B --> BEFORE
    B --> AFTER
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Developer / Reader] --> B{Where is the spec version?}

    subgraph BEFORE["Before this PR"]
        B1[README.md] -->|hardcoded claim| V1["dir2mcp implements spec version 0.16.x"]
        B2[docs/SPEC.md] -->|hardcoded claim| V2["dir2mcp implements spec version 0.16.x"]
        B3[dirstral-spec/spec/versioning.md] -->|canonical matrix| V3["0.14.x (pending)"]
        V1 -.->|drift| V3
        V2 -.->|drift| V3
    end

    subgraph AFTER["After this PR"]
        C1[README.md] -->|link| M[dirstral-spec/spec/versioning.md]
        C2[docs/SPEC.md] -->|link| M
        M -->|canonical record| T["Compatibility matrix\n(single source of truth)"]
    end

    B --> BEFORE
    B --> AFTER
```

</a>

<sub>Reviews (1): Last reviewed commit: ["docs: stop hardcoding a spec version in ..."](https://github.com/dirstral/dir2mcp/commit/ee9198a8c79d756b0101a99e10d0d4215d30e751) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40800301)</sub>

<!-- /greptile_comment -->