### PR TITLE
ingest: best-effort raw_text language auto-detection (spec §8.8)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/dirstral/dir2mcp
 go 1.25.0
 
 require (
+	github.com/abadojack/whatlanggo v1.0.1
 	github.com/aws/aws-sdk-go-v2 v1.42.0
 	github.com/aws/aws-sdk-go-v2/config v1.32.12
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.12

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
+github.com/abadojack/whatlanggo v1.0.1 h1:19N6YogDnf71CTHm3Mp2qhYfkRdyvbgwWdd2EPxJRG4=
+github.com/abadojack/whatlanggo v1.0.1/go.mod h1:66WiQbSbJBIlOZMsvbKe5m6pzQovxCH9B/K8tQB2uoc=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aws/aws-sdk-go-v2 v1.42.0 h1:XvXMJTkFQtpBKIWZnmr9ZEOc2InWM2yldjXEJ/bymhA=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -400,6 +400,17 @@ type Config struct {
 	// once it has been quiet for this long.
 	IngestWatchDebounce time.Duration
 
+	// LanguageDetectionEnabled turns on best-effort representation language
+	// auto-detection (SPEC §8.8, config `language_detection_enabled`). On by
+	// default: for a plain-text (raw_text) representation with no operator pin
+	// (configured) and no source-asserted language (declared), the language is
+	// detected from its text and recorded with language_source="detected".
+	// Detection is best-effort and never fails ingestion; below-floor/unknown
+	// results simply leave the language unset (a first-class state). Set false to
+	// record no detected language. (The confidence floor is a fixed default,
+	// langdetect.DefaultMinConfidence; making it configurable is a follow-up.)
+	LanguageDetectionEnabled bool
+
 	STTProvider               string
 	STTMistralModel           string
 	STTElevenLabsModel        string
@@ -672,6 +683,7 @@ type fileConfig struct {
 	STTElevenLabsModel                 *string
 	STTElevenLabsLanguageCode          *string
 	QualityGatesEnabled                *bool
+	LanguageDetectionEnabled           *bool
 	MediaSidecarsDisabled              *bool
 	MediaVariantsGroup                 *bool
 	MediaVariantsSelect                *string
@@ -800,6 +812,7 @@ type persistedConfig struct {
 	STTElevenLabsModel                 string        `yaml:"stt_elevenlabs_model"`
 	STTElevenLabsLanguageCode          string        `yaml:"stt_elevenlabs_language_code"`
 	QualityGatesEnabled                bool          `yaml:"quality_gates_enabled"`
+	LanguageDetectionEnabled           bool          `yaml:"language_detection_enabled"`
 	MediaSidecarsDisabled              bool          `yaml:"media_sidecars_disabled"`
 	MediaVariantsGroup                 bool          `yaml:"media_variants_group"`
 	MediaVariantsSelect                string        `yaml:"media_variants_select"`
@@ -1000,6 +1013,7 @@ func Default() Config {
 		STTElevenLabsModel:        "scribe_v1",
 		STTElevenLabsLanguageCode: "",
 		QualityGatesEnabled:       true,
+		LanguageDetectionEnabled:  true,
 		MediaClipMaxDurationMS:    DefaultMediaClipMaxDurationMS,
 		MediaClipMaxBytes:         DefaultMediaClipMaxBytes,
 		MediaVariantsGroup:        false,
@@ -1125,6 +1139,7 @@ func buildPersistedConfig(cfg *Config) persistedConfig {
 		STTElevenLabsModel:                 cfg.STTElevenLabsModel,
 		STTElevenLabsLanguageCode:          cfg.STTElevenLabsLanguageCode,
 		QualityGatesEnabled:                cfg.QualityGatesEnabled,
+		LanguageDetectionEnabled:           cfg.LanguageDetectionEnabled,
 		MediaSidecarsDisabled:              cfg.MediaSidecarsDisabled,
 		MediaVariantsGroup:                 cfg.MediaVariantsGroup,
 		MediaVariantsSelect:                cfg.MediaVariantsSelect,
@@ -1842,6 +1857,9 @@ func applySTTFileParsed(cfg *Config, fc fileConfig) {
 	if fc.QualityGatesEnabled != nil {
 		cfg.QualityGatesEnabled = *fc.QualityGatesEnabled
 	}
+	if fc.LanguageDetectionEnabled != nil {
+		cfg.LanguageDetectionEnabled = *fc.LanguageDetectionEnabled
+	}
 	applyMediaFileParsed(cfg, fc)
 }
 
@@ -2340,17 +2358,18 @@ func setFileScalarValue(cfg *fileConfig, key, value string) error {
 // from a table (rather than a switch) keeps its cyclomatic complexity flat as
 // more boolean keys are added.
 var boolFileScalarTargets = map[string]func(*fileConfig) **bool{
-	"public":                  func(c *fileConfig) **bool { return &c.Public },
-	"rag.generate_answer":     func(c *fileConfig) **bool { return &c.RAGGenerateAnswer },
-	"ingest.gitignore":        func(c *fileConfig) **bool { return &c.IngestGitignore },
-	"ingest.follow_symlinks":  func(c *fileConfig) **bool { return &c.IngestFollowSymlinks },
-	"ingest.scan_cache":       func(c *fileConfig) **bool { return &c.IngestScanCache },
-	"ingest.late_chunking":    func(c *fileConfig) **bool { return &c.IngestLateChunking },
-	"ingest.watch":            func(c *fileConfig) **bool { return &c.IngestWatch },
-	"quality_gates_enabled":   func(c *fileConfig) **bool { return &c.QualityGatesEnabled },
-	"media_sidecars_disabled": func(c *fileConfig) **bool { return &c.MediaSidecarsDisabled },
-	"media.variants.group":    func(c *fileConfig) **bool { return &c.MediaVariantsGroup },
-	"media.translate.enabled": func(c *fileConfig) **bool { return &c.MediaTranslateEnabled },
+	"public":                     func(c *fileConfig) **bool { return &c.Public },
+	"rag.generate_answer":        func(c *fileConfig) **bool { return &c.RAGGenerateAnswer },
+	"ingest.gitignore":           func(c *fileConfig) **bool { return &c.IngestGitignore },
+	"ingest.follow_symlinks":     func(c *fileConfig) **bool { return &c.IngestFollowSymlinks },
+	"ingest.scan_cache":          func(c *fileConfig) **bool { return &c.IngestScanCache },
+	"ingest.late_chunking":       func(c *fileConfig) **bool { return &c.IngestLateChunking },
+	"ingest.watch":               func(c *fileConfig) **bool { return &c.IngestWatch },
+	"quality_gates_enabled":      func(c *fileConfig) **bool { return &c.QualityGatesEnabled },
+	"language_detection_enabled": func(c *fileConfig) **bool { return &c.LanguageDetectionEnabled },
+	"media_sidecars_disabled":    func(c *fileConfig) **bool { return &c.MediaSidecarsDisabled },
+	"media.variants.group":       func(c *fileConfig) **bool { return &c.MediaVariantsGroup },
+	"media.translate.enabled":    func(c *fileConfig) **bool { return &c.MediaTranslateEnabled },
 	"media.subtitles.ttml.enabled": func(c *fileConfig) **bool {
 		return &c.MediaSubtitlesTTMLEnabled
 	},
@@ -2826,6 +2845,7 @@ func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	writeScalar("stt_elevenlabs_model", cfg.STTElevenLabsModel)
 	writeScalar("stt_elevenlabs_language_code", cfg.STTElevenLabsLanguageCode)
 	writeBool("quality_gates_enabled", cfg.QualityGatesEnabled)
+	writeBool("language_detection_enabled", cfg.LanguageDetectionEnabled)
 	writeBool("media_sidecars_disabled", cfg.MediaSidecarsDisabled)
 	writeBool("media_variants_group", cfg.MediaVariantsGroup)
 	writeScalar("media_variants_select", cfg.MediaVariantsSelect)

--- a/internal/ingest/represent.go
+++ b/internal/ingest/represent.go
@@ -3,6 +3,7 @@ package ingest
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"regexp"
@@ -13,6 +14,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/dirstral/dir2mcp/internal/ingest/docling"
+	"github.com/dirstral/dir2mcp/internal/langdetect"
 	"github.com/dirstral/dir2mcp/internal/model"
 	"github.com/dirstral/dir2mcp/internal/subtitle"
 )
@@ -59,6 +61,51 @@ func TranscriptRepType(language string) string {
 // RepresentationGenerator handles creation of representations from documents
 type RepresentationGenerator struct {
 	store model.RepresentationStore
+	// langDetectEnabled turns on best-effort language auto-detection for
+	// raw_text representations (SPEC §8.8). Default false; the Service enables it
+	// from config. A raw_text rep has no operator pin or source declaration, so
+	// detection is the only language signal (recorded as language_source=detected).
+	langDetectEnabled bool
+}
+
+// SetLanguageDetection enables or disables best-effort raw_text language
+// auto-detection (SPEC §8.8). Off by default so callers that do not opt in keep
+// the prior behavior (no recorded language).
+func (rg *RepresentationGenerator) SetLanguageDetection(enabled bool) {
+	rg.langDetectEnabled = enabled
+}
+
+// detectedLanguageMeta is the meta_json recorded on a raw_text representation
+// whose language was auto-detected (SPEC §5.2/§8.8). All fields omitempty so a
+// no-detection rep serializes to "{}" / is left empty by the caller.
+type detectedLanguageMeta struct {
+	Language           string  `json:"language,omitempty"`
+	LanguageSource     string  `json:"language_source,omitempty"`
+	LanguageConfidence float64 `json:"language_confidence,omitempty"`
+}
+
+// rawTextLanguageMeta returns the meta_json for a raw_text representation when
+// language detection is enabled and succeeds, else "" (unknown — a first-class,
+// non-error state). Detection never fails ingestion. The detected tag is NOT
+// part of any derivation identity (raw_text has none; its rep_hash is content
+// only), so a detector change can refresh the language without re-embedding.
+func (rg *RepresentationGenerator) rawTextLanguageMeta(text string) string {
+	if !rg.langDetectEnabled {
+		return ""
+	}
+	tag, confidence, ok := langdetect.Detect(text, langdetect.DefaultMinConfidence)
+	if !ok {
+		return ""
+	}
+	encoded, err := json.Marshal(detectedLanguageMeta{
+		Language:           tag,
+		LanguageSource:     langSourceDetected,
+		LanguageConfidence: confidence,
+	})
+	if err != nil {
+		return ""
+	}
+	return string(encoded)
 }
 
 // RepresentationGenerator handles creation of representations from documents.
@@ -138,6 +185,7 @@ func (rg *RepresentationGenerator) GenerateRawTextFromContent(ctx context.Contex
 		DocID:       doc.DocID,
 		RepType:     RepTypeRawText,
 		RepHash:     repHash,
+		MetaJSON:    rg.rawTextLanguageMeta(string(normalizedContent)),
 		CreatedUnix: time.Now().Unix(),
 		Deleted:     false,
 	}

--- a/internal/ingest/represent.go
+++ b/internal/ingest/represent.go
@@ -76,8 +76,9 @@ func (rg *RepresentationGenerator) SetLanguageDetection(enabled bool) {
 }
 
 // detectedLanguageMeta is the meta_json recorded on a raw_text representation
-// whose language was auto-detected (SPEC §5.2/§8.8). All fields omitempty so a
-// no-detection rep serializes to "{}" / is left empty by the caller.
+// whose language was auto-detected (SPEC §5.2/§8.8). It is marshaled only on the
+// detection-succeeded path; when detection is disabled or yields unknown,
+// rawTextLanguageMeta returns "" directly and this struct is never built.
 type detectedLanguageMeta struct {
 	Language           string  `json:"language,omitempty"`
 	LanguageSource     string  `json:"language_source,omitempty"`

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -326,6 +326,8 @@ func NewService(cfg config.Config, store model.Store) (*Service, error) {
 	svc.transcriber = transcriber
 	if rs, ok := store.(model.RepresentationStore); ok {
 		svc.repGen = NewRepresentationGenerator(rs)
+		// Best-effort raw_text language auto-detection (SPEC §8.8), on by default.
+		svc.repGen.SetLanguageDetection(cfg.LanguageDetectionEnabled)
 	}
 	// Construct the output quality gate from config (spec 0.16.0). When the
 	// master switch is on we use the package defaults (per-threshold config is

--- a/internal/ingest/sidecar.go
+++ b/internal/ingest/sidecar.go
@@ -40,12 +40,13 @@ const translationSource = "translation"
 // They record which signal won the §8.8 precedence (configured > declared >
 // detected) for a representation's effective language.
 //
-// The third precedence rank, "detected" (a best-effort auto-detector's result),
-// is part of the §8.8 contract but is intentionally NOT emitted yet: dir2mcp's
-// transcribers do not currently report a detected language and §8.8 forbids
-// assuming a default, so a representation with no pin and no declaration stays
-// unknown. The "detected" value will be wired here when a detector that reports
-// a language becomes available; recording it now would be dead code.
+// The third precedence rank, "detected" (a best-effort auto-detector's result,
+// langSourceDetected), is emitted for plain-text (raw_text) representations via
+// the langdetect detector (SPEC §8.8). It is recorded only when neither a pin
+// (configured) nor a source declaration (declared) is present. Transcript and
+// OCR detection is a follow-up: their meta language doubles as part of the
+// derivation identity (§8.6.7), so recording a detected language there without
+// decoupling it from that identity would force spurious re-derivation.
 const (
 	// langSourceConfigured: the language was pinned by an operator (e.g.
 	// media.language / a per-provider stt_language). It always wins (§8.8).
@@ -53,6 +54,9 @@ const (
 	// langSourceDeclared: the language was asserted by the source itself (a
 	// sidecar's language suffix §8.6.4, a track/document language tag).
 	langSourceDeclared = "declared"
+	// langSourceDetected: a best-effort auto-detector determined the language
+	// (§8.8). Lowest precedence — recorded only when no pin/declaration exists.
+	langSourceDetected = "detected"
 )
 
 // sidecarFile is a discovered subtitle sidecar for a media document: its corpus

--- a/internal/langdetect/langdetect.go
+++ b/internal/langdetect/langdetect.go
@@ -1,0 +1,69 @@
+// Package langdetect provides a pure-Go, deterministic best-effort language
+// detector used to record a representation's language (SPEC §8.8). It wraps the
+// trigram detector github.com/abadojack/whatlanggo and maps its result to a
+// BCP-47 primary subtag (ISO 639-1). Detection is best-effort and MUST NOT make
+// ingestion fail: callers treat a not-ok result as "unknown language", a
+// first-class non-error state.
+package langdetect
+
+import (
+	"unicode"
+
+	"github.com/abadojack/whatlanggo"
+)
+
+// minLetters is the minimum number of letter runes the input must contain before
+// detection is attempted. Trigram detection on very short or punctuation/number
+// heavy text is unreliable and tends to produce confident-looking garbage, so we
+// decline (unknown) rather than record a spurious language (§8.8 graceful
+// degradation).
+const minLetters = 20
+
+// DefaultMinConfidence is the default confidence floor (SPEC §8.8): a detected
+// language below this is discarded (left unknown) rather than recorded. The
+// floor is spec-optional (MAY); exposing it as a config knob is a follow-up.
+const DefaultMinConfidence = 0.65
+
+// Detect returns the BCP-47 primary subtag (ISO 639-1, e.g. "en", "fr") of the
+// dominant language in text together with the detector's confidence in [0,1].
+//
+// ok is false — meaning "unknown language", a first-class non-error state
+// (SPEC §8.8) — when any of the following hold:
+//   - text has too little letter content to detect reliably (< minLetters);
+//   - the detector cannot map its result to an ISO 639-1 primary subtag;
+//   - the confidence is below minConfidence (the optional confidence floor).
+//
+// A non-positive minConfidence disables the floor (any detected tag passes).
+// Detection is deterministic for identical input + detector, so the recorded
+// language is stable across re-indexing (§8.8 stability), and the detected tag
+// is never folded into a representation's derivation identity by callers.
+func Detect(text string, minConfidence float64) (tag string, confidence float64, ok bool) {
+	if countLetters(text) < minLetters {
+		return "", 0, false
+	}
+	info := whatlanggo.Detect(text)
+	tag = info.Lang.Iso6391()
+	if tag == "" {
+		// The detector returned no language it can express as an ISO 639-1
+		// primary subtag: treat as unknown.
+		return "", 0, false
+	}
+	if minConfidence > 0 && info.Confidence < minConfidence {
+		// Below the configured floor: decline to record a low-confidence guess.
+		return "", info.Confidence, false
+	}
+	return tag, info.Confidence, true
+}
+
+// countLetters returns the number of Unicode letter runes in s. Letters (not raw
+// length) gauge whether there is enough linguistic signal to detect, so a string
+// dominated by digits/punctuation/whitespace is correctly judged too sparse.
+func countLetters(s string) int {
+	n := 0
+	for _, r := range s {
+		if unicode.IsLetter(r) {
+			n++
+		}
+	}
+	return n
+}

--- a/internal/langdetect/langdetect.go
+++ b/internal/langdetect/langdetect.go
@@ -8,6 +8,7 @@ package langdetect
 
 import (
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/abadojack/whatlanggo"
 )
@@ -18,6 +19,11 @@ import (
 // decline (unknown) rather than record a spurious language (§8.8 graceful
 // degradation).
 const minLetters = 20
+
+// maxDetectBytes caps how much input is fed to the detector. Trigram detection
+// is reliable from a few hundred characters, so scanning a multi-megabyte
+// document adds latency without improving accuracy; we detect on a prefix.
+const maxDetectBytes = 4096
 
 // DefaultMinConfidence is the default confidence floor (SPEC §8.8): a detected
 // language below this is discarded (left unknown) rather than recorded. The
@@ -38,6 +44,14 @@ const DefaultMinConfidence = 0.65
 // language is stable across re-indexing (§8.8 stability), and the detected tag
 // is never folded into a representation's derivation identity by callers.
 func Detect(text string, minConfidence float64) (tag string, confidence float64, ok bool) {
+	if len(text) > maxDetectBytes {
+		text = text[:maxDetectBytes]
+		// The byte cap may split a trailing multi-byte rune; trim back to a
+		// well-formed boundary (detection tolerates it, but keep input clean).
+		for len(text) > 0 && !utf8.ValidString(text) {
+			text = text[:len(text)-1]
+		}
+	}
 	if countLetters(text) < minLetters {
 		return "", 0, false
 	}

--- a/internal/langdetect/langdetect_test.go
+++ b/internal/langdetect/langdetect_test.go
@@ -1,0 +1,54 @@
+package langdetect
+
+import "testing"
+
+// Clear, monolingual sentences long enough for trigram detection.
+var knownText = map[string]string{
+	"en": "The quick brown fox jumps over the lazy dog and then runs across the open field every single morning before the sun rises.",
+	"fr": "Le renard brun et rapide saute par-dessus le chien paresseux puis court à travers le champ ouvert chaque matin avant le lever du soleil.",
+	"de": "Der schnelle braune Fuchs springt über den faulen Hund und läuft dann jeden Morgen über das offene Feld bevor die Sonne aufgeht.",
+	"es": "El rápido zorro marrón salta sobre el perro perezoso y luego corre por el campo abierto todas las mañanas antes de que salga el sol.",
+}
+
+func TestDetect_KnownLanguages(t *testing.T) {
+	// Use floor 0 here: this asserts the language MAPPING, not the floor.
+	for want, text := range knownText {
+		tag, conf, ok := Detect(text, 0)
+		if !ok {
+			t.Errorf("Detect(%s sample) ok=false, want %q", want, want)
+			continue
+		}
+		if tag != want {
+			t.Errorf("Detect(%s sample) = %q (conf %.2f), want %q", want, tag, conf, want)
+		}
+	}
+}
+
+func TestDetect_ShortOrLowSignalIsUnknown(t *testing.T) {
+	for _, text := range []string{"", "   ", "hi", "a b c", "12345 !!! @@@ ---", "42 + 7 = 49"} {
+		if tag, _, ok := Detect(text, DefaultMinConfidence); ok {
+			t.Errorf("Detect(%q) ok=true (tag=%q), want unknown (too little letter signal)", text, tag)
+		}
+	}
+}
+
+func TestDetect_ConfidenceFloor(t *testing.T) {
+	text := knownText["en"]
+	// An impossible floor rejects everything (left unknown).
+	if _, _, ok := Detect(text, 1.01); ok {
+		t.Error("Detect with floor 1.01 should reject every result")
+	}
+	// A zero floor accepts a clearly-detectable language.
+	if _, _, ok := Detect(text, 0); !ok {
+		t.Error("Detect with floor 0 should accept a clear language")
+	}
+}
+
+func TestDetect_Deterministic(t *testing.T) {
+	text := knownText["de"]
+	t1, c1, ok1 := Detect(text, DefaultMinConfidence)
+	t2, c2, ok2 := Detect(text, DefaultMinConfidence)
+	if t1 != t2 || c1 != c2 || ok1 != ok2 {
+		t.Errorf("Detect not deterministic: (%q,%v,%v) vs (%q,%v,%v)", t1, c1, ok1, t2, c2, ok2)
+	}
+}

--- a/tests/ingest/represent_test.go
+++ b/tests/ingest/represent_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -209,6 +210,53 @@ func TestGenerateRawTextFromContentPrefersGivenBytes(t *testing.T) {
 	}
 	if st.reps[0].RepHash != hash {
 		t.Fatalf("representation hash %q does not match provided content hash %q", st.reps[0].RepHash, hash)
+	}
+}
+
+func TestGenerateRawText_DetectsLanguageWhenEnabled(t *testing.T) {
+	st := &fakeRepStore{failAfter: -1}
+	rg := ingest.NewRepresentationGenerator(st)
+	rg.SetLanguageDetection(true)
+	doc := model.Document{DocID: 1, RelPath: "notes.txt", DocType: "text"}
+	content := []byte("The annual report describes how the committee carefully reviewed every application and then approved the budget for the coming financial year across all of the regional offices.")
+	if err := rg.GenerateRawTextFromContent(context.Background(), doc, content); err != nil {
+		t.Fatalf("GenerateRawTextFromContent failed: %v", err)
+	}
+	if len(st.reps) == 0 {
+		t.Fatal("no representation recorded")
+	}
+	var meta struct {
+		Language       string  `json:"language"`
+		LanguageSource string  `json:"language_source"`
+		Confidence     float64 `json:"language_confidence"`
+	}
+	if err := json.Unmarshal([]byte(st.reps[0].MetaJSON), &meta); err != nil {
+		t.Fatalf("meta_json %q is not valid JSON: %v", st.reps[0].MetaJSON, err)
+	}
+	if meta.Language != "en" {
+		t.Errorf("detected language = %q, want en (meta=%q)", meta.Language, st.reps[0].MetaJSON)
+	}
+	if meta.LanguageSource != "detected" {
+		t.Errorf("language_source = %q, want detected", meta.LanguageSource)
+	}
+	if meta.Confidence <= 0 {
+		t.Errorf("language_confidence = %v, want > 0", meta.Confidence)
+	}
+}
+
+func TestGenerateRawText_NoLanguageWhenDetectionDisabled(t *testing.T) {
+	st := &fakeRepStore{failAfter: -1}
+	rg := ingest.NewRepresentationGenerator(st) // detection off by default
+	doc := model.Document{DocID: 1, RelPath: "notes.txt", DocType: "text"}
+	content := []byte("The annual report describes how the committee reviewed every application and approved the budget for the coming financial year.")
+	if err := rg.GenerateRawTextFromContent(context.Background(), doc, content); err != nil {
+		t.Fatalf("GenerateRawTextFromContent failed: %v", err)
+	}
+	if len(st.reps) == 0 {
+		t.Fatal("no representation recorded")
+	}
+	if strings.TrimSpace(st.reps[0].MetaJSON) != "" {
+		t.Errorf("detection disabled should record no meta_json, got %q", st.reps[0].MetaJSON)
 	}
 }
 

--- a/tests/langdetect/langdetect_test.go
+++ b/tests/langdetect/langdetect_test.go
@@ -1,6 +1,11 @@
-package langdetect
+package langdetect_test
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/langdetect"
+)
 
 // Clear, monolingual sentences long enough for trigram detection.
 var knownText = map[string]string{
@@ -13,7 +18,7 @@ var knownText = map[string]string{
 func TestDetect_KnownLanguages(t *testing.T) {
 	// Use floor 0 here: this asserts the language MAPPING, not the floor.
 	for want, text := range knownText {
-		tag, conf, ok := Detect(text, 0)
+		tag, conf, ok := langdetect.Detect(text, 0)
 		if !ok {
 			t.Errorf("Detect(%s sample) ok=false, want %q", want, want)
 			continue
@@ -26,7 +31,7 @@ func TestDetect_KnownLanguages(t *testing.T) {
 
 func TestDetect_ShortOrLowSignalIsUnknown(t *testing.T) {
 	for _, text := range []string{"", "   ", "hi", "a b c", "12345 !!! @@@ ---", "42 + 7 = 49"} {
-		if tag, _, ok := Detect(text, DefaultMinConfidence); ok {
+		if tag, _, ok := langdetect.Detect(text, langdetect.DefaultMinConfidence); ok {
 			t.Errorf("Detect(%q) ok=true (tag=%q), want unknown (too little letter signal)", text, tag)
 		}
 	}
@@ -35,20 +40,36 @@ func TestDetect_ShortOrLowSignalIsUnknown(t *testing.T) {
 func TestDetect_ConfidenceFloor(t *testing.T) {
 	text := knownText["en"]
 	// An impossible floor rejects everything (left unknown).
-	if _, _, ok := Detect(text, 1.01); ok {
+	if _, _, ok := langdetect.Detect(text, 1.01); ok {
 		t.Error("Detect with floor 1.01 should reject every result")
 	}
 	// A zero floor accepts a clearly-detectable language.
-	if _, _, ok := Detect(text, 0); !ok {
+	if _, _, ok := langdetect.Detect(text, 0); !ok {
 		t.Error("Detect with floor 0 should accept a clear language")
 	}
 }
 
 func TestDetect_Deterministic(t *testing.T) {
 	text := knownText["de"]
-	t1, c1, ok1 := Detect(text, DefaultMinConfidence)
-	t2, c2, ok2 := Detect(text, DefaultMinConfidence)
+	t1, c1, ok1 := langdetect.Detect(text, langdetect.DefaultMinConfidence)
+	t2, c2, ok2 := langdetect.Detect(text, langdetect.DefaultMinConfidence)
 	if t1 != t2 || c1 != c2 || ok1 != ok2 {
 		t.Errorf("Detect not deterministic: (%q,%v,%v) vs (%q,%v,%v)", t1, c1, ok1, t2, c2, ok2)
+	}
+}
+
+func TestDetect_TruncatesLongInputButStillDetects(t *testing.T) {
+	// A large natural-English document (well over the detector's internal prefix
+	// cap) must still detect correctly. Uses a varied multi-sentence block (not a
+	// repeated short phrase, which is degenerate and scores low confidence).
+	block := "The committee reviewed the annual report in detail. " +
+		"Several members raised concerns about the regional budget allocations. " +
+		"After a long discussion, the proposal was approved by a clear majority. " +
+		"The findings will be published next quarter alongside the audit summary. " +
+		"Stakeholders across every office welcomed the transparent new process. "
+	big := strings.Repeat(block, 50) // ~14 KB, far exceeds the internal cap
+	tag, _, ok := langdetect.Detect(big, langdetect.DefaultMinConfidence)
+	if !ok || tag != "en" {
+		t.Errorf("Detect(large en doc) = (%q, ok=%v), want en/true", tag, ok)
 	}
 }


### PR DESCRIPTION
Implements spec **§8.8** on-by-default language auto-detection for **raw_text** representations — the primary gap behind #471 (a per-language filter that matches nothing on un-pinned, sidecar-less corpora, since plain-text reps recorded no language).

## What
- **`internal/langdetect`** — a pure-Go (`CGO_ENABLED=0`), deterministic detector wrapping `whatlanggo`. Maps to a BCP-47 primary subtag (ISO 639-1) with a confidence floor (`DefaultMinConfidence` 0.65) and a min-letter guard. Too little signal / below floor → **unknown**, a first-class non-error state (never fails ingestion).
- **`RepresentationGenerator`** records `{language, language_source:"detected", language_confidence}` on a raw_text rep's `meta_json` when detection is enabled and succeeds. `meta_json.language` already denormalizes to `chunk.language` (`store.languageFromRepMeta`), so the **§9.5 per-language filter now matches detected-language docs with no schema change**.
- **Config** — `language_detection_enabled` (**on by default**, mirrors `quality_gates_enabled`). The floor is a fixed default for now (making it configurable is a follow-up).
- `rep_hash` is **content-only**, so a detected language never forces re-embedding — satisfies §8.8's "not part of derivation identity."

## Scope (and why)
**raw_text only** (covers code/text/md/data/html — the bulk of a typical corpus). OCR (`extracted_markdown`) and transcript detection are a **deliberate follow-up**: their meta `language` doubles as part of the **derivation identity** (§8.6.7, `transcriptIdentityFromMeta`), so writing a *detected* language there without first decoupling it from that identity (e.g. treat `language_source=detected` as identity-neutral) would trigger **spurious re-derivation/re-embedding**. Doing that safely is its own change.

## Tests
- Detector unit tests: en/fr/de/es mapping, short/low-signal → unknown, confidence floor, determinism.
- Ingest integration: an English doc records `language=en` / `source=detected`; detection-off records no meta.
- **`make check` passes** (fmt, vet, golangci-lint v2.10.1, gocyclo ≤15, ineffassign, misspell, full test suite, build).

Part of #471 (raw_text); OCR + transcript detection tracked as the remaining follow-up described above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional language detection for ingested text, with detected language details recorded when available.
  * Added a new configuration setting to turn language detection on or off.

* **Bug Fixes**
  * Improved handling of short or low-signal text so language metadata is only added when detection is confident.
  * Ensured language detection is consistent and works reliably on longer text inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements spec §8.8 best-effort language auto-detection for `raw_text` representations, closing the gap that caused the §9.5 per-language filter to miss un-pinned plain-text documents.

- **`internal/langdetect`** wraps `whatlanggo` with a 4 096-byte input cap, a 20-letter minimum guard, and a 0.65 confidence floor; results map to BCP-47 primary subtags (ISO 639-1). Too-little-signal and below-floor outcomes return `ok=false` — "unknown language" is a first-class non-error state that never fails ingestion.
- **`RepresentationGenerator`** gains `rawTextLanguageMeta`, which writes `{language, language_source:"detected", language_confidence}` into `meta_json` on the `raw_text` rep; the existing `languageFromRepMeta` → `chunk.language` denormalization makes §9.5 filtering work with no schema change.
- **Config** adds `language_detection_enabled` (default `true`) wired through the full config pipeline; OCR and transcript detection are deferred as a follow-up because their `meta_json.language` is part of the derivation identity.

<h3>Confidence Score: 5/5</h3>

Safe to merge — detection is best-effort and gated behind a config flag that defaults to on, with no schema changes and no ingestion-failure path.

The detection path is fully isolated: whatlanggo only processes the first 4 096 bytes, the minLetters guard and 0.65 confidence floor prevent spurious tags, and a failed detection simply leaves meta_json empty (the pre-existing behavior). The upsert SQL already updates meta_json unconditionally, so the language column in chunks is kept in sync within the same transaction. Config wiring covers all pipeline sites. Tests validate the happy path, the disabled path, short inputs, confidence-floor rejection, determinism, and truncation on oversized input.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/langdetect/langdetect.go | New package implementing pure-Go language detection using whatlanggo; correctly handles truncation to 4 096 bytes, minimum-letter guard, confidence floor, and the unknown-language non-error state. |
| internal/ingest/represent.go | Wires rawTextLanguageMeta into GenerateRawTextFromContent; two separate string(normalizedContent) conversions allocate the full content twice — convert once and reuse instead. |
| internal/ingest/service.go | Correctly wires cfg.LanguageDetectionEnabled into repGen.SetLanguageDetection() right after the RepresentationStore check. |
| internal/ingest/sidecar.go | Adds langSourceDetected constant and updates the comment block to reflect that §8.8 detection is now implemented for raw_text; comment accurately describes the OCR/transcript follow-up scope. |
| internal/config/config.go | Adds LanguageDetectionEnabled field throughout the config pipeline (struct, fileConfig, persistedConfig, defaults, apply, marshal, boolFileScalarTargets map) — all plumbing sites present, default is true. |
| tests/langdetect/langdetect_test.go | Tests cover known-language mapping, short/low-signal unknown case, confidence-floor behaviour, determinism, and truncation; placed in tests/ per AGENTS.md. |
| tests/ingest/represent_test.go | Two new tests verify language metadata is recorded when detection is on (language=en, source=detected, confidence>0) and absent when off; both use realistic multi-sentence English content above the minLetters threshold. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant S as Service
    participant RG as RepresentationGenerator
    participant LD as langdetect.Detect
    participant ST as SQLiteStore

    S->>RG: GenerateRawTextFromContent(doc, content)
    RG->>RG: normalizeUTF8(content)
    RG->>RG: computeRepHash(normalizedContent)
    alt langDetectEnabled
        RG->>LD: "Detect(text, DefaultMinConfidence=0.65)"
        LD->>LD: truncate to 4096 bytes
        LD->>LD: "countLetters >= 20?"
        LD->>LD: whatlanggo.Detect → Iso6391()
        LD-->>RG: tag, confidence, ok
        alt "ok == true"
            RG->>RG: "marshal {language, language_source, language_confidence}"
            RG-->>RG: "MetaJSON = JSON string"
        else "ok == false"
            RG-->>RG: "MetaJSON = empty"
        end
    else detection disabled
        RG-->>RG: "MetaJSON = empty"
    end
    RG->>ST: UpsertRepresentation(rep with MetaJSON)
    ST->>ST: INSERT ON CONFLICT DO UPDATE meta_json
    ST-->>RG: repID
    RG->>ST: InsertChunkWithSpans(chunk)
    ST->>ST: lookupChunkDocContext → languageFromRepMeta(meta_json)
    ST->>ST: INSERT chunk with language column
    ST-->>RG: chunkID
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant S as Service
    participant RG as RepresentationGenerator
    participant LD as langdetect.Detect
    participant ST as SQLiteStore

    S->>RG: GenerateRawTextFromContent(doc, content)
    RG->>RG: normalizeUTF8(content)
    RG->>RG: computeRepHash(normalizedContent)
    alt langDetectEnabled
        RG->>LD: "Detect(text, DefaultMinConfidence=0.65)"
        LD->>LD: truncate to 4096 bytes
        LD->>LD: "countLetters >= 20?"
        LD->>LD: whatlanggo.Detect → Iso6391()
        LD-->>RG: tag, confidence, ok
        alt "ok == true"
            RG->>RG: "marshal {language, language_source, language_confidence}"
            RG-->>RG: "MetaJSON = JSON string"
        else "ok == false"
            RG-->>RG: "MetaJSON = empty"
        end
    else detection disabled
        RG-->>RG: "MetaJSON = empty"
    end
    RG->>ST: UpsertRepresentation(rep with MetaJSON)
    ST->>ST: INSERT ON CONFLICT DO UPDATE meta_json
    ST-->>RG: repID
    RG->>ST: InsertChunkWithSpans(chunk)
    ST->>ST: lookupChunkDocContext → languageFromRepMeta(meta_json)
    ST->>ST: INSERT chunk with language column
    ST-->>RG: chunkID
```

</a>

<sub>Reviews (2): Last reviewed commit: ["langdetect: address PR #474 review comme..."](https://github.com/dirstral/dir2mcp/commit/4a5cef2f8532cef0fa344a5dd6f72f0c0dbb12d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40827017)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/danbi/github/dirstral/dir2mcp/-/custom-context?memory=305618d2-ac9c-4fc4-8f8a-2a644513be8d))

<!-- /greptile_comment -->