### PR TITLE
ingest: extend §8.8 language detection to OCR + transcript (completes #471)

### DIFF
--- a/internal/ingest/derivation.go
+++ b/internal/ingest/derivation.go
@@ -6,8 +6,21 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/dirstral/dir2mcp/internal/langdetect"
 	"github.com/dirstral/dir2mcp/internal/provider"
 )
+
+// detectLanguage runs best-effort representation language auto-detection on text
+// when enabled (SPEC §8.8), returning the BCP-47 primary subtag and confidence,
+// or ("", 0, false) when detection is disabled or the result is unknown/below
+// the confidence floor. Detection never fails the caller; unknown is a
+// first-class, non-error state.
+func (s *Service) detectLanguage(text string) (tag string, confidence float64, ok bool) {
+	if s == nil || !s.cfg.LanguageDetectionEnabled {
+		return "", 0, false
+	}
+	return langdetect.Detect(text, langdetect.DefaultMinConfidence)
+}
 
 // Representation provenance and identity-driven re-derivation (spec §8.6.7).
 //
@@ -72,7 +85,7 @@ func (s *Service) activeDiarizeIdentity() string {
 // omitted (omitempty) when unset, so a setup with no resolved STT identity still
 // produces valid meta_json (and an empty recorded identity that the gate treats
 // as "always passes").
-func (s *Service) sttTranscriptMetaJSON(speakers []Speaker) (string, error) {
+func (s *Service) sttTranscriptMetaJSON(speakers []Speaker, text string) (string, error) {
 	meta := transcriptMeta{
 		Source:     sttSource,
 		Language:   strings.TrimSpace(s.transcriptLanguage),
@@ -80,14 +93,18 @@ func (s *Service) sttTranscriptMetaJSON(speakers []Speaker) (string, error) {
 		Provider:   strings.TrimSpace(s.sttProvider),
 		Model:      strings.TrimSpace(s.sttModel),
 	}
-	// transcriptLanguage is an operator pin (media.language / per-provider
-	// stt_language, SPEC §16.2), so when present it is the effective language with
-	// provenance "configured" — the top of the §8.8 precedence. When unset the STT
-	// path records no language (unknown): dir2mcp's transcribers do not currently
-	// report a detected language, and §8.8 forbids assuming a default, so the
-	// representation stays unknown until a detector that reports one is wired.
+	// §8.8 precedence: an operator pin (media.language / per-provider
+	// stt_language, §16.2) is the "configured" language and always wins. With no
+	// pin, fall back to best-effort auto-detection on the transcript text
+	// ("detected"). A detected language is recorded as the effective language but
+	// is deliberately excluded from the derivation identity (see
+	// transcriptIdentityFromMeta): a pure detector change must not re-transcribe.
 	if meta.Language != "" {
 		meta.LanguageSource = langSourceConfigured
+	} else if tag, conf, ok := s.detectLanguage(text); ok {
+		meta.Language = tag
+		meta.LanguageSource = langSourceDetected
+		meta.LanguageConfidence = &conf
 	}
 	if s.diarizeActive {
 		// Record the diarize backend identity whenever diarization is active so a
@@ -371,8 +388,17 @@ func transcriptIdentityFromMeta(metaJSON string) (string, bool) {
 	if strings.TrimSpace(meta.Provider) == "" && strings.TrimSpace(meta.Model) == "" {
 		return "", false
 	}
+	// A detected language (§8.8) is best-effort metadata, NOT part of the
+	// derivation identity: a detector change must not force re-transcription. The
+	// active identity (activeTranscriptIdentity) is built from the configured pin
+	// only, so exclude a detected language here to keep the two comparable. A
+	// configured/declared language remains part of the identity.
+	identityLang := meta.Language
+	if strings.TrimSpace(meta.LanguageSource) == langSourceDetected {
+		identityLang = ""
+	}
 	sttIdentity := derivationIdentity(string(provider.CapSTT),
-		meta.Provider, meta.Model, meta.ModelVersion, meta.Language)
+		meta.Provider, meta.Model, meta.ModelVersion, identityLang)
 	// Fold the recorded diarize identity (§8.6.8) into the transcript identity so
 	// a diarize provider/model change is detected as stale. Only model-derived
 	// diarization records a provider/model; a sidecar-supplied <v> attribution

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -2117,7 +2117,7 @@ func (s *Service) generateOCRMarkdownRepresentation(ctx context.Context, doc mod
 		DocID:       doc.DocID,
 		RepType:     RepTypeExtractedMarkdown,
 		RepHash:     computeRepHash([]byte(ocrText)),
-		MetaJSON:    s.extractionMetaJSON(),
+		MetaJSON:    s.extractionMetaJSON(ocrText),
 		CreatedUnix: time.Now().Unix(),
 		Deleted:     false,
 	}
@@ -2161,7 +2161,7 @@ func (s *Service) persistStructuredRepresentation(ctx context.Context, doc model
 		DocID:       doc.DocID,
 		RepType:     RepTypeExtractedMarkdown,
 		RepHash:     computeRepHash([]byte(md)),
-		MetaJSON:    s.extractionMetaJSON(),
+		MetaJSON:    s.extractionMetaJSON(md),
 		CreatedUnix: time.Now().Unix(),
 		Deleted:     false,
 	}
@@ -2223,7 +2223,7 @@ func (s *Service) persistTitle(ctx context.Context, doc model.Document, title st
 	}
 }
 
-func (s *Service) extractionMetaJSON() string {
+func (s *Service) extractionMetaJSON(text string) string {
 	if s == nil || s.extractor == nil {
 		return ""
 	}
@@ -2243,6 +2243,17 @@ func (s *Service) extractionMetaJSON() string {
 		// provider/model already set from extractorProviderModel.
 	default:
 		meta["type"] = fmt.Sprintf("%T", s.extractor)
+	}
+	// §8.8: with no operator pin or provider-declared language, record a
+	// best-effort detected language for the extracted text. Stored as strings
+	// only (no confidence) so the map[string]string round-trips through
+	// ocrIdentityFromMeta, which ignores language entirely — detection never
+	// affects the OCR derivation identity.
+	if _, has := meta["language"]; !has {
+		if tag, _, ok := s.detectLanguage(text); ok {
+			meta["language"] = tag
+			meta["language_source"] = langSourceDetected
+		}
 	}
 	encoded, err := json.Marshal(meta)
 	if err != nil {
@@ -2368,7 +2379,7 @@ func (s *Service) generateTranscriptRepresentation(ctx context.Context, doc mode
 	// attribution that is actually present on the segments.
 	s.applyDiarization(ctx, doc, content, segments)
 
-	metaJSON, err := s.sttTranscriptMetaJSON(distinctSpeakers(segments))
+	metaJSON, err := s.sttTranscriptMetaJSON(distinctSpeakers(segments), transcriptText)
 	if err != nil {
 		return fmt.Errorf("marshal transcript meta: %w", err)
 	}

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -2244,11 +2244,13 @@ func (s *Service) extractionMetaJSON(text string) string {
 	default:
 		meta["type"] = fmt.Sprintf("%T", s.extractor)
 	}
-	// §8.8: with no operator pin or provider-declared language, record a
-	// best-effort detected language for the extracted text. Stored as strings
-	// only (no confidence) so the map[string]string round-trips through
-	// ocrIdentityFromMeta, which ignores language entirely — detection never
-	// affects the OCR derivation identity.
+	// §8.8: record a best-effort detected language for the extracted text. No
+	// extractor reports a language today, so the meta["language"] guard is
+	// forward-compatible: if a future extractor records a provider-declared
+	// language ("declared", which outranks "detected"), the guard preserves it.
+	// Stored as strings only (no confidence) so the map[string]string round-trips
+	// through ocrIdentityFromMeta, which ignores language entirely — detection
+	// never affects the OCR derivation identity.
 	if _, has := meta["language"]; !has {
 		if tag, _, ok := s.detectLanguage(text); ok {
 			meta["language"] = tag

--- a/tests/ingest/language_detection_test.go
+++ b/tests/ingest/language_detection_test.go
@@ -15,7 +15,7 @@ import (
 
 // sttServiceWithDetection mirrors sttService (derivation_identity_test.go) but
 // turns on §8.8 best-effort language auto-detection.
-func sttServiceWithDetection(t *testing.T, root, stateDir string, st model.Store, sttModel, language string, tr *fakeTranscriber) *ingest.Service {
+func sttServiceWithDetection(t *testing.T, root, stateDir string, st model.Store, provider, sttModel, language string, tr *fakeTranscriber) *ingest.Service {
 	t.Helper()
 	svc := mustNewIngestService(t, config.Config{
 		RootDir:                  root,
@@ -24,7 +24,7 @@ func sttServiceWithDetection(t *testing.T, root, stateDir string, st model.Store
 		LanguageDetectionEnabled: true,
 	}, st)
 	svc.SetTranscriber(tr)
-	svc.SetSTTIdentity("whisper", sttModel)
+	svc.SetSTTIdentity(provider, sttModel)
 	svc.SetTranscriptLanguage(language)
 	return svc
 }
@@ -33,6 +33,49 @@ func sttServiceWithDetection(t *testing.T, root, stateDir string, st model.Store
 // carries) long enough for trigram detection.
 const englishTranscript = "[00:00] The committee reviewed the annual report in detail, and several members raised concerns about the regional budget allocations before the proposal was finally approved by a clear majority."
 
+// fakeExtractor is a stub model.DocumentExtractor returning canned markdown.
+type fakeExtractor struct{ text string }
+
+func (f *fakeExtractor) Extract(_ context.Context, _ string, _ []byte) (string, error) {
+	return f.text, nil
+}
+
+const englishExtracted = "The committee reviewed the annual report in detail and several members raised concerns about the regional budget allocations before approving the proposal."
+
+// TestOCRLanguageDetected_WhenNoPin: an extracted_markdown (OCR) representation
+// records a best-effort detected language (§8.8 `detected`) with no pin.
+func TestOCRLanguageDetected_WhenNoPin(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "doc.pdf"), "fake-pdf-bytes")
+	st := newRealStore(t)
+	svc := mustNewIngestService(t, config.Config{
+		RootDir:                  root,
+		StateDir:                 t.TempDir(),
+		LanguageDetectionEnabled: true,
+	}, st)
+	svc.SetDocumentExtractor(&fakeExtractor{text: englishExtracted})
+
+	f := ingest.DiscoveredFile{RelPath: "doc.pdf", SizeBytes: 14, MTimeUnix: time.Now().Unix()}
+	if err := svc.ProcessDocument(context.Background(), f, nil, false); err != nil {
+		t.Fatalf("ProcessDocument: %v", err)
+	}
+	meta, err := st.RepresentationMetaByType(context.Background(), "doc.pdf", ingest.RepTypeExtractedMarkdown)
+	if err != nil {
+		t.Fatalf("RepresentationMetaByType: %v", err)
+	}
+	var p map[string]any
+	if err := json.Unmarshal([]byte(meta), &p); err != nil {
+		t.Fatalf("meta not json (%q): %v", meta, err)
+	}
+	if p["language"] != "en" {
+		t.Errorf("language = %v, want en (meta=%q)", p["language"], meta)
+	}
+	if p["language_source"] != "detected" {
+		t.Errorf("language_source = %v, want detected", p["language_source"])
+	}
+}
+
 // TestTranscriptLanguageDetected_WhenNoPin: with no operator pin, the STT
 // transcript records a best-effort detected language (§8.8 `detected`).
 func TestTranscriptLanguageDetected_WhenNoPin(t *testing.T) {
@@ -40,7 +83,7 @@ func TestTranscriptLanguageDetected_WhenNoPin(t *testing.T) {
 	root := t.TempDir()
 	writeFile(t, filepath.Join(root, "talk.mp3"), "fake-audio")
 	st := newRealStore(t)
-	svc := sttServiceWithDetection(t, root, t.TempDir(), st, "whisper-large-v3", "", &fakeTranscriber{text: englishTranscript})
+	svc := sttServiceWithDetection(t, root, t.TempDir(), st, "whisper", "whisper-large-v3", "", &fakeTranscriber{text: englishTranscript})
 
 	f := ingest.DiscoveredFile{RelPath: "talk.mp3", SizeBytes: 10, MTimeUnix: time.Now().Unix()}
 	if err := svc.ProcessDocument(context.Background(), f, nil, false); err != nil {
@@ -66,7 +109,7 @@ func TestTranscriptPin_NotOverriddenByDetection(t *testing.T) {
 	writeFile(t, filepath.Join(root, "talk.mp3"), "fake-audio")
 	st := newRealStore(t)
 	// English audio, but the operator pinned French — the pin must win.
-	svc := sttServiceWithDetection(t, root, t.TempDir(), st, "whisper-large-v3", "fr", &fakeTranscriber{text: englishTranscript})
+	svc := sttServiceWithDetection(t, root, t.TempDir(), st, "whisper", "whisper-large-v3", "fr", &fakeTranscriber{text: englishTranscript})
 
 	f := ingest.DiscoveredFile{RelPath: "talk.mp3", SizeBytes: 10, MTimeUnix: time.Now().Unix()}
 	if err := svc.ProcessDocument(context.Background(), f, nil, false); err != nil {
@@ -98,7 +141,7 @@ func TestTranscriptDetectedLanguage_DoesNotForceReDerivation(t *testing.T) {
 	f := ingest.DiscoveredFile{RelPath: "talk.mp3", SizeBytes: 10, MTimeUnix: time.Now().Unix()}
 
 	tr1 := &fakeTranscriber{text: englishTranscript}
-	svc1 := sttServiceWithDetection(t, root, stateDir, st, "whisper-large-v3", "", tr1)
+	svc1 := sttServiceWithDetection(t, root, stateDir, st, "whisper", "whisper-large-v3", "", tr1)
 	if err := svc1.ProcessDocument(context.Background(), f, nil, false); err != nil {
 		t.Fatalf("scan1: %v", err)
 	}
@@ -111,7 +154,7 @@ func TestTranscriptDetectedLanguage_DoesNotForceReDerivation(t *testing.T) {
 
 	// Same model + same content: identity must match → no re-transcription.
 	tr2 := &fakeTranscriber{text: englishTranscript}
-	svc2 := sttServiceWithDetection(t, root, stateDir, st, "whisper-large-v3", "", tr2)
+	svc2 := sttServiceWithDetection(t, root, stateDir, st, "whisper", "whisper-large-v3", "", tr2)
 	if err := svc2.ProcessDocument(context.Background(), f, nil, false); err != nil {
 		t.Fatalf("scan2: %v", err)
 	}

--- a/tests/ingest/language_detection_test.go
+++ b/tests/ingest/language_detection_test.go
@@ -1,0 +1,121 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// sttServiceWithDetection mirrors sttService (derivation_identity_test.go) but
+// turns on §8.8 best-effort language auto-detection.
+func sttServiceWithDetection(t *testing.T, root, stateDir string, st model.Store, sttModel, language string, tr *fakeTranscriber) *ingest.Service {
+	t.Helper()
+	svc := mustNewIngestService(t, config.Config{
+		RootDir:                  root,
+		StateDir:                 stateDir,
+		STTProvider:              "off",
+		LanguageDetectionEnabled: true,
+	}, st)
+	svc.SetTranscriber(tr)
+	svc.SetSTTIdentity("whisper", sttModel)
+	svc.SetTranscriptLanguage(language)
+	return svc
+}
+
+// A clearly-English transcript (with a leading timestamp, as a real transcript
+// carries) long enough for trigram detection.
+const englishTranscript = "[00:00] The committee reviewed the annual report in detail, and several members raised concerns about the regional budget allocations before the proposal was finally approved by a clear majority."
+
+// TestTranscriptLanguageDetected_WhenNoPin: with no operator pin, the STT
+// transcript records a best-effort detected language (§8.8 `detected`).
+func TestTranscriptLanguageDetected_WhenNoPin(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "talk.mp3"), "fake-audio")
+	st := newRealStore(t)
+	svc := sttServiceWithDetection(t, root, t.TempDir(), st, "whisper-large-v3", "", &fakeTranscriber{text: englishTranscript})
+
+	f := ingest.DiscoveredFile{RelPath: "talk.mp3", SizeBytes: 10, MTimeUnix: time.Now().Unix()}
+	if err := svc.ProcessDocument(context.Background(), f, nil, false); err != nil {
+		t.Fatalf("ProcessDocument: %v", err)
+	}
+	var p map[string]any
+	if err := json.Unmarshal([]byte(transcriptMetaFor(t, st, "talk.mp3")), &p); err != nil {
+		t.Fatalf("meta not json: %v", err)
+	}
+	if p["language"] != "en" {
+		t.Errorf("language = %v, want en", p["language"])
+	}
+	if p["language_source"] != "detected" {
+		t.Errorf("language_source = %v, want detected", p["language_source"])
+	}
+}
+
+// TestTranscriptPin_NotOverriddenByDetection: an operator pin (configured) wins
+// over detection even when the audio is in a different language (§8.8 precedence).
+func TestTranscriptPin_NotOverriddenByDetection(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "talk.mp3"), "fake-audio")
+	st := newRealStore(t)
+	// English audio, but the operator pinned French — the pin must win.
+	svc := sttServiceWithDetection(t, root, t.TempDir(), st, "whisper-large-v3", "fr", &fakeTranscriber{text: englishTranscript})
+
+	f := ingest.DiscoveredFile{RelPath: "talk.mp3", SizeBytes: 10, MTimeUnix: time.Now().Unix()}
+	if err := svc.ProcessDocument(context.Background(), f, nil, false); err != nil {
+		t.Fatalf("ProcessDocument: %v", err)
+	}
+	var p map[string]any
+	if err := json.Unmarshal([]byte(transcriptMetaFor(t, st, "talk.mp3")), &p); err != nil {
+		t.Fatalf("meta not json: %v", err)
+	}
+	if p["language"] != "fr" {
+		t.Errorf("language = %v, want fr (pin must win over detection)", p["language"])
+	}
+	if p["language_source"] != "configured" {
+		t.Errorf("language_source = %v, want configured", p["language_source"])
+	}
+}
+
+// TestTranscriptDetectedLanguage_DoesNotForceReDerivation is the critical guard
+// for the §8.8 decoupling: a detected language is NOT part of the derivation
+// identity, so re-scanning with the same STT model must NOT re-transcribe. Without
+// the decoupling, the recorded identity (language=en) would differ from the active
+// identity (no pin), spuriously re-transcribing the whole corpus.
+func TestTranscriptDetectedLanguage_DoesNotForceReDerivation(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "talk.mp3"), "fake-audio")
+	st := newRealStore(t)
+	stateDir := t.TempDir()
+	f := ingest.DiscoveredFile{RelPath: "talk.mp3", SizeBytes: 10, MTimeUnix: time.Now().Unix()}
+
+	tr1 := &fakeTranscriber{text: englishTranscript}
+	svc1 := sttServiceWithDetection(t, root, stateDir, st, "whisper-large-v3", "", tr1)
+	if err := svc1.ProcessDocument(context.Background(), f, nil, false); err != nil {
+		t.Fatalf("scan1: %v", err)
+	}
+	if tr1.calls != 1 {
+		t.Fatalf("scan1 STT calls = %d, want 1", tr1.calls)
+	}
+	if meta := transcriptMetaFor(t, st, "talk.mp3"); !strings.Contains(meta, `"language_source":"detected"`) {
+		t.Fatalf("scan1 expected a detected language, got meta=%q", meta)
+	}
+
+	// Same model + same content: identity must match → no re-transcription.
+	tr2 := &fakeTranscriber{text: englishTranscript}
+	svc2 := sttServiceWithDetection(t, root, stateDir, st, "whisper-large-v3", "", tr2)
+	if err := svc2.ProcessDocument(context.Background(), f, nil, false); err != nil {
+		t.Fatalf("scan2: %v", err)
+	}
+	if tr2.calls != 0 {
+		t.Fatalf("scan2 STT calls = %d, want 0 (a detected language must NOT be part of the derivation identity)", tr2.calls)
+	}
+}


### PR DESCRIPTION
**Stacked on #474** (base is its branch; GitHub will retarget to `main` once #474 merges). Completes §8.8 by covering the two remaining derived representations.

## What
- **Transcript** (`sttTranscriptMetaJSON`): with no operator pin, detect the language from the transcript text → `language_source=detected`.
- **OCR** (`extractionMetaJSON`): with no recorded/declared language, detect from the extracted text. Stored as strings only (no confidence) so the `map[string]string` meta still round-trips through `ocrIdentityFromMeta`.
- Shared `Service.detectLanguage` helper, gated on `LanguageDetectionEnabled`.
- Honors the §8.8 precedence: **configured > declared > detected**.

## The load-bearing part: derivation-identity decoupling
A transcript's meta `language` doubles as part of its **derivation identity** (§8.6.7). Writing a *detected* language there naively would make the recorded identity (`language=en`) differ from the active identity (built from the pin only, here empty) → **spurious re-transcription of the whole corpus**. Fix: `transcriptIdentityFromMeta` now treats `language_source=detected` as **identity-neutral** (uses `""` for the identity language). OCR needed no change — `ocrIdentityFromMeta` already excludes language.

## Tests (tests/ingest, external — via the existing `fakeTranscriber` harness)
- detection records `language=en` / `source=detected` with no pin;
- a configured pin **wins** over detection (precedence);
- **the critical guard:** a detected-language transcript is **not** re-transcribed on re-scan with the same model (`tr.calls==0`) — proves identity-neutrality (without the decoupling this would re-transcribe).
- `make check` passes.

OCR detection has no dedicated integration test (no fake-extractor harness exists in the suite); it reuses the same detector + `detectLanguage` helper covered by the raw_text (#474) and transcript tests, and is identity-safe by construction.

Closes #471 (together with #474).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added best-effort automatic language detection for extracted text and transcripts when no language is manually set.
  * Language metadata can now include a detected language, its source, and confidence details.

* **Bug Fixes**
  * Detected language no longer overrides a manually configured language.
  * Changes in language detection won’t trigger unnecessary re-processing of existing transcripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes §8.8 language detection by extending it to the two remaining derived representations: STT transcripts (`sttTranscriptMetaJSON`) and OCR/structured extractions (`extractionMetaJSON`). The implementation shares a new `Service.detectLanguage` helper that is gated on `LanguageDetectionEnabled`, and carefully decouples detected-language metadata from the derivation identity to prevent spurious re-transcription.

- **`derivation.go`**: Adds the `detectLanguage` helper, adds a `text string` parameter to `sttTranscriptMetaJSON`, and teaches `transcriptIdentityFromMeta` to treat `language_source=detected` as identity-neutral (zeroing `identityLang`) so a detector change never forces re-transcription.
- **`service.go`**: Adds a `text string` parameter to `extractionMetaJSON` and appends `language`/`language_source` to the OCR `map[string]string` meta (no confidence, to preserve the round-trip through `ocrIdentityFromMeta` which already ignores language entirely).
- **`language_detection_test.go`**: Adds four integration tests covering: OCR detection, transcript detection, pin-wins-over-detection, and the critical re-derivation guard (`tr2.calls == 0`).

<h3>Confidence Score: 5/5</h3>

Safe to merge. The derivation-identity decoupling is correctly implemented for both paths and verified by the re-derivation guard test.

The core correctness property — that a detected language stored in meta does not cause transcriptIdentityFromMeta to diverge from activeTranscriptIdentity — is implemented correctly and validated by TestTranscriptDetectedLanguage_DoesNotForceReDerivation. The OCR path is safe by construction since ocrIdentityFromMeta already ignores language fields. No regressions introduced in the identity or caching logic.

No files require special attention. All three changed files are straightforward and the change surface is narrow.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/ingest/derivation.go | Adds detectLanguage helper and extends sttTranscriptMetaJSON to detect language from transcript text; correctly zeroes identityLang when language_source=detected in transcriptIdentityFromMeta to prevent spurious re-transcription. |
| internal/ingest/service.go | Threads text parameter into extractionMetaJSON; records best-effort detected language in OCR meta as strings only (no confidence), which is safe since ocrIdentityFromMeta already ignores language fields entirely. |
| tests/ingest/language_detection_test.go | Well-structured tests covering detection, pin precedence, and the identity-neutrality guard for transcripts; fakeExtractor correctly implements model.DocumentExtractor for the OCR smoke test. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[sttTranscriptMetaJSON / extractionMetaJSON] --> B{Operator pin set?}
    B -- Yes --> C[language_source = configured\nIdentity includes language]
    B -- No --> D{LanguageDetectionEnabled?}
    D -- No --> E[No language recorded]
    D -- Yes --> F[langdetect.Detect text]
    F --> G{Confidence >= floor?}
    G -- No --> E
    G -- Yes --> H[language_source = detected]
    H --> I{Transcript path?}
    I -- Yes --> J[transcriptIdentityFromMeta\nidentityLang empty for detected\nmatches activeTranscriptIdentity]
    I -- No, OCR --> K[ocrIdentityFromMeta\nignores language entirely]
    style C fill:#c8e6c9
    style J fill:#c8e6c9
    style K fill:#c8e6c9
    style E fill:#fff9c4
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[sttTranscriptMetaJSON / extractionMetaJSON] --> B{Operator pin set?}
    B -- Yes --> C[language_source = configured\nIdentity includes language]
    B -- No --> D{LanguageDetectionEnabled?}
    D -- No --> E[No language recorded]
    D -- Yes --> F[langdetect.Detect text]
    F --> G{Confidence >= floor?}
    G -- No --> E
    G -- Yes --> H[language_source = detected]
    H --> I{Transcript path?}
    I -- Yes --> J[transcriptIdentityFromMeta\nidentityLang empty for detected\nmatches activeTranscriptIdentity]
    I -- No, OCR --> K[ocrIdentityFromMeta\nignores language entirely]
    style C fill:#c8e6c9
    style J fill:#c8e6c9
    style K fill:#c8e6c9
    style E fill:#fff9c4
```

</a>

<sub>Reviews (3): Last reviewed commit: ["langdetect: address PR #475 review comme..."](https://github.com/dirstral/dir2mcp/commit/79e30741f99f20f5fa4a4106b8d74691428cd6d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40866273)</sub>

<!-- /greptile_comment -->