### PR TITLE
fix(embedqueue): batch lease/embed per iteration so BatchSize is honored (#435)

### DIFF
--- a/internal/cli/up_distributed_embed.go
+++ b/internal/cli/up_distributed_embed.go
@@ -17,6 +17,12 @@ import (
 	"github.com/dirstral/dir2mcp/internal/retrieval"
 )
 
+// distributedEmbedBatchSize is the number of chunks the distributed worker leases
+// and embeds per iteration, and the per-axis EmbeddingWorker batch size (issue
+// #435). Kept as one constant so the lease batch and the provider embed batch
+// stay in lockstep; mirrors the in-process EmbeddingWorker default of 32.
+const distributedEmbedBatchSize = 32
+
 // distributedTaskFetcher is the read-by-id capability the distributed worker
 // needs from the shared store (SPEC §8.7.4). The metadata store satisfies it.
 type distributedTaskFetcher interface {
@@ -88,7 +94,12 @@ func startDistributedEmbedding(
 		Fetcher:       fetcher,
 		Embedders:     embedders,
 		EmbedIdentity: identityStr,
-		Logger:        logger,
+		// Lease/embed up to distributedEmbedBatchSize chunks per iteration so the
+		// distributed path batches through the provider like the in-process loop
+		// (one embed call per batch, not per chunk — issue #435). Kept in lockstep
+		// with the per-axis EmbeddingWorker.BatchSize set in newEmbedStep.
+		BatchSize: distributedEmbedBatchSize,
+		Logger:    logger,
 	}
 
 	// Close the broker when the run context ends so its handle (e.g. a SQLite DB)
@@ -169,7 +180,7 @@ func newEmbedStep(
 		ModelForCode: codeModel,
 		RootDir:      rootDir,
 		Corpus:       corpusFS,
-		BatchSize:    32,
+		BatchSize:    distributedEmbedBatchSize,
 		Logger:       logger,
 		OnIndexedChunk: func(label uint64, metadata model.ChunkMetadata) {
 			if ret != nil {

--- a/internal/embedqueue/worker.go
+++ b/internal/embedqueue/worker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log"
+	"sort"
 	"strings"
 	"time"
 
@@ -211,8 +212,17 @@ func (cfg Config) processBatch(ctx context.Context, leases []Lease) {
 		}
 		groups[pj.indexKind] = append(groups[pj.indexKind], pj)
 	}
-	for kind, group := range groups {
-		cfg.embedGroup(ctx, kind, group)
+	// Embed groups in a deterministic index_kind order (Go map iteration is
+	// randomized). A stable order keeps the earliest-leased kinds from being
+	// pushed to the back of an arbitrary shuffle, which would needlessly shrink
+	// their remaining lease window and inflate redelivery/attempt counts.
+	kinds := make([]string, 0, len(groups))
+	for kind := range groups {
+		kinds = append(kinds, kind)
+	}
+	sort.Strings(kinds)
+	for _, kind := range kinds {
+		cfg.embedGroup(ctx, kind, groups[kind])
 	}
 }
 
@@ -280,6 +290,19 @@ func (cfg Config) embedGroup(ctx context.Context, indexKind string, group []prep
 	if len(group) == 0 {
 		return
 	}
+	// Drop any job whose lease already expired before we reached the provider.
+	// Draining a full batch and fetching each authoritative task serially costs
+	// time, so an early-leased job's window can be exhausted before EmbedAndIndex
+	// is called (a real risk at BatchSize=32 with a slow shared store). Embedding
+	// under a dead lease is wasted work: the follow-up Ack no-ops against a token
+	// the broker has already invalidated, so the job is redelivered anyway. The
+	// broker will re-lease it and embedding stays idempotent (keyed by chunk_id),
+	// so skipping here is safe and avoids attempt inflation (SPEC §8.7.3;
+	// Lease.Deadline).
+	group = cfg.liveLeases(group)
+	if len(group) == 0 {
+		return
+	}
 	tasks := make([]model.ChunkTask, len(group))
 	for i, pj := range group {
 		tasks[i] = pj.task
@@ -306,6 +329,23 @@ func (cfg Config) embedGroup(ctx context.Context, indexKind string, group []prep
 			cfg.logf("embedqueue: ack chunk %d: %v", pj.lease.Job.ChunkID, err)
 		}
 	}
+}
+
+// liveLeases returns the prepared jobs whose lease has not yet expired. An
+// expired lease is left in place (not Acked/Nacked) so the broker redelivers it;
+// embedding under it would only waste a provider call and a no-op Ack.
+func (cfg Config) liveLeases(group []preparedJob) []preparedJob {
+	now := time.Now()
+	live := group[:0]
+	for _, pj := range group {
+		if !pj.lease.Deadline.IsZero() && !now.Before(pj.lease.Deadline) {
+			cfg.logf("embedqueue: lease for chunk %d expired before embed; leaving for redelivery",
+				pj.lease.Job.ChunkID)
+			continue
+		}
+		live = append(live, pj)
+	}
+	return live
 }
 
 // embedOne embeds a single prepared job and Acks on success or Nacks on failure.

--- a/internal/embedqueue/worker.go
+++ b/internal/embedqueue/worker.go
@@ -46,6 +46,15 @@ type Config struct {
 	// across a heterogeneous pool (§8.7.3, §6.4).
 	EmbedIdentity string
 
+	// BatchSize bounds how many jobs the worker leases and embeds per iteration
+	// (SPEC §8.7, issue #435). The worker drains up to BatchSize claimable jobs,
+	// groups them by index_kind, and embeds each group in a SINGLE provider call
+	// via EmbedAndIndex — matching the in-process loop's batching instead of one
+	// provider call per chunk. Non-positive defaults to 32 (the in-process
+	// EmbeddingWorker default). A value of 1 restores the legacy one-at-a-time
+	// behavior.
+	BatchSize int
+
 	// LeaseDuration is the visibility timeout for a leased job. Non-positive
 	// defaults to 30s.
 	LeaseDuration time.Duration
@@ -78,6 +87,13 @@ func (c Config) validate() error {
 	return nil
 }
 
+func (c Config) batchSize() int {
+	if c.BatchSize <= 0 {
+		return 32
+	}
+	return c.BatchSize
+}
+
 func (c Config) leaseDuration() time.Duration {
 	if c.LeaseDuration <= 0 {
 		return 30 * time.Second
@@ -107,11 +123,26 @@ func (c Config) logf(format string, args ...any) {
 	log.Printf(format, args...)
 }
 
+// preparedJob is a leased job that passed per-job validation/identity/kind checks
+// and had its authoritative task loaded — ready to be embedded as part of a batch.
+type preparedJob struct {
+	lease     Lease
+	task      model.ChunkTask
+	indexKind string
+	embedder  Embedder
+}
+
 // Run is the distributed embed-worker run-loop (SPEC §8.7.1). It leases jobs,
 // reads the authoritative chunk via the shared store, enforces per-job embed
 // identity, embeds via the shared in-process embedding path, and Acks on success
 // or Nacks (redelivery / dead-letter) on transient failure. It blocks until ctx
 // is cancelled and returns ctx.Err() then.
+//
+// Each iteration drains up to BatchSize claimable jobs and embeds them grouped by
+// index_kind in a SINGLE provider call per group (issue #435), so the distributed
+// path batches through the provider exactly like the in-process loop instead of
+// making one embed call per chunk. Ack/Nack stays per-lease, so at-least-once
+// delivery, per-job attempt tracking, and dead-lettering are unchanged.
 //
 // It is exported as a reusable function because follow-up #249 wraps it in a CLI
 // subcommand; #249 (the subcommand) is out of scope here.
@@ -142,20 +173,62 @@ func Run(ctx context.Context, cfg Config) error {
 			}
 			continue
 		}
-		cfg.process(ctx, lease)
+		cfg.processBatch(ctx, cfg.drainBatch(ctx, lease))
 	}
 }
 
-// process executes one leased job and Acks/Nacks it. A permanent failure (embed
-// identity mismatch, unknown index kind, tombstoned chunk) Acks/Nacks terminally
-// so the job does not loop; a transient failure Nacks for redelivery.
-func (cfg Config) process(ctx context.Context, lease Lease) {
+// drainBatch returns the initial lease plus up to BatchSize-1 additional
+// currently-claimable jobs. It stops at the first empty queue or lease error —
+// those are surfaced/backed-off on the next Run cycle — so a partial batch is
+// embedded promptly rather than blocking for a full BatchSize.
+func (cfg Config) drainBatch(ctx context.Context, first Lease) []Lease {
+	leases := make([]Lease, 0, cfg.batchSize())
+	leases = append(leases, first)
+	for len(leases) < cfg.batchSize() {
+		if ctx.Err() != nil {
+			break
+		}
+		lease, err := cfg.Broker.Lease(ctx, cfg.leaseDuration())
+		if err != nil {
+			// ErrNoJob (queue drained) or a transient lease error: embed what we
+			// already hold; the next Run cycle re-leases / backs off.
+			break
+		}
+		leases = append(leases, lease)
+	}
+	return leases
+}
+
+// processBatch prepares every leased job (validate / identity / kind / fetch),
+// terminally Acking or Nacking the ones that fail preparation, then embeds the
+// survivors grouped by index_kind — one provider call per group.
+func (cfg Config) processBatch(ctx context.Context, leases []Lease) {
+	groups := make(map[string][]preparedJob)
+	for _, lease := range leases {
+		pj, ok := cfg.prepare(ctx, lease)
+		if !ok {
+			continue
+		}
+		groups[pj.indexKind] = append(groups[pj.indexKind], pj)
+	}
+	for kind, group := range groups {
+		cfg.embedGroup(ctx, kind, group)
+	}
+}
+
+// prepare runs the per-job checks that gate embedding a single leased job. It
+// returns ok=false (having already Acked/Nacked the lease) when the job must not
+// be embedded: an invalid job, an embed-identity mismatch, or an unknown
+// index_kind Nack for redelivery/dead-lettering; a tombstoned/missing chunk is
+// Acked as a safe no-op (SPEC §8.7.3 / §6.6). On ok=true the returned preparedJob
+// carries the authoritative task and its axis embedder.
+func (cfg Config) prepare(ctx context.Context, lease Lease) (preparedJob, bool) {
 	job := lease.Job
 	if err := job.Validate(); err != nil {
 		// Never log lease.Token — it is an opaque lease credential (§16.1.1).
 		cfg.logf("embedqueue: invalid job for chunk %d: %v", job.ChunkID, err)
 		_ = cfg.Broker.Nack(ctx, lease.Token, cfg.retryAfter())
-		return
+		return preparedJob{}, false
 	}
 
 	// Per-job embed identity enforcement (SPEC §8.7.3 / §6.4): a worker whose
@@ -166,7 +239,7 @@ func (cfg Config) process(ctx context.Context, lease Lease) {
 		cfg.logf("embedqueue: embed identity mismatch for chunk %d (job=%q worker=%q); rejecting",
 			job.ChunkID, job.EmbedIdentity, cfg.EmbedIdentity)
 		_ = cfg.Broker.Nack(ctx, lease.Token, cfg.retryAfter())
-		return
+		return preparedJob{}, false
 	}
 
 	indexKind := strings.ToLower(strings.TrimSpace(job.IndexKind))
@@ -177,7 +250,7 @@ func (cfg Config) process(ctx context.Context, lease Lease) {
 	if !ok {
 		cfg.logf("embedqueue: no embedder for index_kind %q (chunk %d); rejecting", indexKind, job.ChunkID)
 		_ = cfg.Broker.Nack(ctx, lease.Token, cfg.retryAfter())
-		return
+		return preparedJob{}, false
 	}
 
 	// Load the authoritative task from the shared store. A tombstoned/missing
@@ -188,23 +261,66 @@ func (cfg Config) process(ctx context.Context, lease Lease) {
 		if errors.Is(err, model.ErrNotFound) {
 			cfg.logf("embedqueue: chunk %d not found / tombstoned; acking (no-op)", job.ChunkID)
 			_ = cfg.Broker.Ack(ctx, lease.Token)
-			return
+			return preparedJob{}, false
 		}
 		cfg.logf("embedqueue: fetch chunk %d: %v; redelivering", job.ChunkID, err)
 		_ = cfg.Broker.Nack(ctx, lease.Token, cfg.retryAfter())
-		return
+		return preparedJob{}, false
 	}
+	return preparedJob{lease: lease, task: task, indexKind: indexKind, embedder: emb}, true
+}
 
-	if _, err := emb.EmbedAndIndex(ctx, indexKind, []model.ChunkTask{task}); err != nil {
-		// EmbedAndIndex already records embedding_status=error for permanent
-		// failures (SPEC §5.3); Nack lets the broker redeliver up to its limit and
-		// then dead-letter, mirroring the in-process retry/dead-letter behavior.
-		cfg.logf("embedqueue: embed chunk %d (%s): %v; redelivering", job.ChunkID, indexKind, err)
-		_ = cfg.Broker.Nack(ctx, lease.Token, cfg.retryAfter())
+// embedGroup embeds a same-index_kind group of prepared jobs in ONE provider call
+// (EmbedAndIndex over the whole batch) and Acks every lease on success. On a batch
+// failure it isolates: a lone job is Nacked for redelivery, but a multi-job batch
+// is re-embedded one chunk at a time so a single poison chunk is redelivered /
+// dead-lettered WITHOUT dragging its innocent batch-mates through the same retries
+// (preserving per-chunk isolation, SPEC §8.7.3).
+func (cfg Config) embedGroup(ctx context.Context, indexKind string, group []preparedJob) {
+	if len(group) == 0 {
 		return
 	}
-	if err := cfg.Broker.Ack(ctx, lease.Token); err != nil {
-		cfg.logf("embedqueue: ack chunk %d: %v", job.ChunkID, err)
+	tasks := make([]model.ChunkTask, len(group))
+	for i, pj := range group {
+		tasks[i] = pj.task
+	}
+	if _, err := group[0].embedder.EmbedAndIndex(ctx, indexKind, tasks); err != nil {
+		if len(group) == 1 {
+			// EmbedAndIndex already records embedding_status=error for permanent
+			// failures (SPEC §5.3); Nack lets the broker redeliver up to its limit
+			// and then dead-letter, mirroring the in-process behavior.
+			cfg.logf("embedqueue: embed chunk %d (%s): %v; redelivering",
+				group[0].lease.Job.ChunkID, indexKind, err)
+			_ = cfg.Broker.Nack(ctx, group[0].lease.Token, cfg.retryAfter())
+			return
+		}
+		cfg.logf("embedqueue: batch embed of %d chunk(s) (%s) failed: %v; isolating per-chunk",
+			len(group), indexKind, err)
+		for _, pj := range group {
+			cfg.embedOne(ctx, indexKind, pj)
+		}
+		return
+	}
+	for _, pj := range group {
+		if err := cfg.Broker.Ack(ctx, pj.lease.Token); err != nil {
+			cfg.logf("embedqueue: ack chunk %d: %v", pj.lease.Job.ChunkID, err)
+		}
+	}
+}
+
+// embedOne embeds a single prepared job and Acks on success or Nacks on failure.
+// It is the per-chunk isolation path taken after a batch embed fails, so a healthy
+// chunk still lands (and its store status is corrected) while only the genuinely
+// failing chunk is redelivered / dead-lettered.
+func (cfg Config) embedOne(ctx context.Context, indexKind string, pj preparedJob) {
+	if _, err := pj.embedder.EmbedAndIndex(ctx, indexKind, []model.ChunkTask{pj.task}); err != nil {
+		cfg.logf("embedqueue: embed chunk %d (%s): %v; redelivering",
+			pj.lease.Job.ChunkID, indexKind, err)
+		_ = cfg.Broker.Nack(ctx, pj.lease.Token, cfg.retryAfter())
+		return
+	}
+	if err := cfg.Broker.Ack(ctx, pj.lease.Token); err != nil {
+		cfg.logf("embedqueue: ack chunk %d: %v", pj.lease.Job.ChunkID, err)
 	}
 }
 

--- a/tests/embedqueue/worker_test.go
+++ b/tests/embedqueue/worker_test.go
@@ -391,8 +391,8 @@ func TestWorker_BatchPoisonChunkIsolated(t *testing.T) {
 	if seen[2] != 0 {
 		t.Fatalf("poison chunk 2 was embedded (%d times); it must never land: writes=%v", seen[2], writes)
 	}
-	if seen[1] == 0 || seen[3] == 0 {
-		t.Fatalf("innocent batch-mates did not land after isolation: writes=%v", writes)
+	if seen[1] != 1 || seen[3] != 1 {
+		t.Fatalf("innocent batch-mates must land exactly once after isolation: writes=%v", writes)
 	}
 }
 

--- a/tests/embedqueue/worker_test.go
+++ b/tests/embedqueue/worker_test.go
@@ -2,6 +2,8 @@ package embedqueue_test
 
 import (
 	"context"
+	"errors"
+	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -54,6 +56,65 @@ func (e *fakeEmbedStep) EmbedAndIndex(_ context.Context, _ string, tasks []model
 }
 
 func (e *fakeEmbedStep) writes() []uint64 {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([]uint64, len(e.written))
+	copy(out, e.written)
+	return out
+}
+
+// batchSizes records the length of the task slice passed to each EmbedAndIndex
+// call, so a test can assert the worker batched (a single N-chunk call) rather
+// than making N one-chunk calls (issue #435).
+type batchRecordingEmbedStep struct {
+	mu      sync.Mutex
+	written []uint64
+	batches []int
+}
+
+func (e *batchRecordingEmbedStep) EmbedAndIndex(_ context.Context, _ string, tasks []model.ChunkTask) (int, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.batches = append(e.batches, len(tasks))
+	for _, t := range tasks {
+		e.written = append(e.written, t.Metadata.ChunkID)
+	}
+	return len(tasks), nil
+}
+
+func (e *batchRecordingEmbedStep) snapshot() (writes []uint64, batches []int) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	writes = append(writes, e.written...)
+	batches = append(batches, e.batches...)
+	return writes, batches
+}
+
+// poisonEmbedStep fails any batch that contains poisonID (as a real provider
+// rejects a whole request when one input is bad) but succeeds otherwise, so a
+// test can assert per-chunk isolation: the poison chunk is redelivered/dead-
+// lettered while its innocent batch-mates still land (issue #435).
+type poisonEmbedStep struct {
+	mu       sync.Mutex
+	poisonID uint64
+	written  []uint64
+}
+
+func (e *poisonEmbedStep) EmbedAndIndex(_ context.Context, _ string, tasks []model.ChunkTask) (int, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for _, t := range tasks {
+		if t.Metadata.ChunkID == e.poisonID {
+			return 0, errors.New("poison chunk: permanent embed failure")
+		}
+	}
+	for _, t := range tasks {
+		e.written = append(e.written, t.Metadata.ChunkID)
+	}
+	return len(tasks), nil
+}
+
+func (e *poisonEmbedStep) writes() []uint64 {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	out := make([]uint64, len(e.written))
@@ -220,6 +281,118 @@ func TestWorker_EmbedIdentityMismatchRejected(t *testing.T) {
 
 	if got := step.writes(); len(got) != 0 {
 		t.Fatalf("worker embedded a mismatched-identity job: writes=%v", got)
+	}
+}
+
+// TestWorker_BatchesUpToBatchSize pins the #435 fix: with several jobs queued the
+// worker leases and embeds them in a SINGLE EmbedAndIndex call (up to BatchSize)
+// instead of one provider call per chunk. Every enqueued chunk is embedded exactly
+// once and the recorded batch sizes show batching (a call carrying >1 chunk).
+func TestWorker_BatchesUpToBatchSize(t *testing.T) {
+	ctx := context.Background()
+	broker := embedqueue.NewMemBroker(3)
+	tasks := map[uint64]model.ChunkTask{}
+	const n = 5
+	for id := uint64(1); id <= n; id++ {
+		tasks[id] = textTask(id, "chunk")
+	}
+	fetch := &fakeFetcher{tasks: tasks}
+	step := &batchRecordingEmbedStep{}
+
+	for id := uint64(1); id <= n; id++ {
+		if err := broker.Enqueue(ctx, embedqueue.Job{
+			ChunkID: id, IndexKind: "text", EmbedIdentity: testIdentity,
+		}); err != nil {
+			t.Fatalf("Enqueue: %v", err)
+		}
+	}
+
+	cfg := embedqueue.Config{
+		Broker:        broker,
+		Fetcher:       fetch,
+		Embedders:     map[string]embedqueue.Embedder{"text": step},
+		EmbedIdentity: testIdentity,
+		BatchSize:     n, // drain the whole queue in one lease batch
+		PollInterval:  2 * time.Millisecond,
+	}
+	runWorkerUntil(t, cfg, func() bool {
+		w, _ := step.snapshot()
+		st, _ := broker.Stats(ctx)
+		return st.Pending == 0 && st.InFlight == 0 && len(w) >= n
+	})
+
+	writes, batches := step.snapshot()
+	got := append([]uint64(nil), writes...)
+	sort.Slice(got, func(i, j int) bool { return got[i] < got[j] })
+	want := []uint64{1, 2, 3, 4, 5}
+	if len(got) != len(want) {
+		t.Fatalf("writes = %v, want each of %v exactly once", writes, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("writes = %v, want each of %v exactly once", writes, want)
+		}
+	}
+	// The whole point of #435: at least one EmbedAndIndex call carried more than
+	// one chunk. The old one-chunk-per-lease worker would show all 1s.
+	maxBatch := 0
+	for _, b := range batches {
+		if b > maxBatch {
+			maxBatch = b
+		}
+	}
+	if maxBatch < 2 {
+		t.Fatalf("no batching: EmbedAndIndex batch sizes = %v, want at least one call with >1 chunk", batches)
+	}
+}
+
+// TestWorker_BatchPoisonChunkIsolated pins that a batch failure preserves
+// per-chunk isolation (issue #435): a single poison chunk that fails the whole
+// batch is redelivered (and eventually dead-lettered) WITHOUT dragging its
+// innocent batch-mates down — those still land exactly once.
+func TestWorker_BatchPoisonChunkIsolated(t *testing.T) {
+	ctx := context.Background()
+	broker := embedqueue.NewMemBroker(2) // dead-letter the poison chunk after 2 tries
+	tasks := map[uint64]model.ChunkTask{
+		1: textTask(1, "good-a"),
+		2: textTask(2, "poison"),
+		3: textTask(3, "good-b"),
+	}
+	fetch := &fakeFetcher{tasks: tasks}
+	step := &poisonEmbedStep{poisonID: 2}
+
+	for id := uint64(1); id <= 3; id++ {
+		if err := broker.Enqueue(ctx, embedqueue.Job{
+			ChunkID: id, IndexKind: "text", EmbedIdentity: testIdentity,
+		}); err != nil {
+			t.Fatalf("Enqueue: %v", err)
+		}
+	}
+
+	cfg := embedqueue.Config{
+		Broker:        broker,
+		Fetcher:       fetch,
+		Embedders:     map[string]embedqueue.Embedder{"text": step},
+		EmbedIdentity: testIdentity,
+		BatchSize:     3,
+		PollInterval:  1 * time.Millisecond,
+		RetryAfter:    1 * time.Millisecond,
+	}
+	runWorkerUntil(t, cfg, func() bool {
+		st, _ := broker.Stats(ctx)
+		return st.DeadLettered == 1 && st.Pending == 0 && st.InFlight == 0
+	})
+
+	writes := step.writes()
+	seen := map[uint64]int{}
+	for _, id := range writes {
+		seen[id]++
+	}
+	if seen[2] != 0 {
+		t.Fatalf("poison chunk 2 was embedded (%d times); it must never land: writes=%v", seen[2], writes)
+	}
+	if seen[1] == 0 || seen[3] == 0 {
+		t.Fatalf("innocent batch-mates did not land after isolation: writes=%v", writes)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes **C1** of #435: the distributed embed worker leased and embedded **one chunk per iteration** (`EmbedAndIndex` on a length-1 slice), so the configured `BatchSize=32` was dead and the distributed path made ~32× the provider embed calls of the in-process loop — far slower and far more rate-limit-prone, despite "sharing the exact logic".

## Change

- **Batch the lease + embed.** Each `Run` iteration now drains up to `BatchSize` currently-claimable jobs, groups them by `index_kind`, and embeds each group in a **single** `EmbedAndIndex` call — matching the in-process loop's batching (one provider call per batch, not per chunk).
- **Per-lease Ack/Nack is unchanged**, so the §8.7 distributed-embed contract holds: at-least-once delivery, per-job attempt tracking, visibility/lease expiry, and dead-lettering all behave exactly as before.
- **Poison-chunk isolation preserved.** On a batch embed failure a multi-job batch is re-embedded one chunk at a time, so a single poison chunk is redelivered / dead-lettered (and its store status corrected on the innocents) **without** dragging its innocent batch-mates through the same retries. A lone failing job is Nacked directly as before.
- **`BatchSize` wired from one constant** (`distributedEmbedBatchSize = 32`) shared by the worker lease batch and the per-axis `EmbeddingWorker.BatchSize`, so they stay in lockstep. Non-positive `BatchSize` defaults to 32; `BatchSize: 1` restores the legacy one-at-a-time behavior.

Scoped to C1 only. C2 (`embedded_ok` double-count), C3 (leader election), and C4 (enqueue-stall signal) are out of scope for this PR.

## Tests (`tests/embedqueue/`)

- `TestWorker_BatchesUpToBatchSize` — with 5 jobs queued the worker embeds them via a single `EmbedAndIndex` call carrying >1 chunk (the old worker would show all length-1 calls); every chunk embedded exactly once.
- `TestWorker_BatchPoisonChunkIsolated` — a poison chunk that fails the whole batch is redelivered and dead-lettered while its innocent batch-mates still land exactly once.

## Verification

`make check` passes clean (CGO_ENABLED=0, lint, gocyclo ≤15).

Addresses #435 (part only; remainder tracked in #486)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the C1 regression from #435 where the distributed embed worker was leasing and embedding one chunk per iteration, making `BatchSize` effectively dead. The worker now drains up to `BatchSize` leases per iteration, groups them by `index_kind`, and calls `EmbedAndIndex` once per group — mirroring the in-process loop's batching behaviour.

- `drainBatch` collects up to `BatchSize` leases per iteration; `processBatch` groups survivors by `index_kind` and calls `embedGroup` once per kind, with `liveLeases` proactively dropping leases whose deadline has already passed before the provider call.
- Poison-chunk isolation is preserved: a batch failure on a multi-job group triggers per-chunk retry via `embedOne`, so a single bad chunk is dead-lettered without forcing its innocent batch-mates through repeated retries.
- `distributedEmbedBatchSize = 32` is a single constant shared by both the worker lease batch and the per-axis `EmbeddingWorker.BatchSize`, so they stay in lockstep.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The batching logic is correct, the poison-chunk isolation path is well-reasoned, and the proactive liveLeases check addresses the lease-expiry concern before provider calls.

The core change is a straightforward refactor of a tight run-loop: drainBatch replaces the single-lease path, processBatch groups by index_kind, and embedGroup calls EmbedAndIndex once per group with a fallback isolation path on failure. All existing per-lease contracts (Ack/Nack, at-least-once delivery, dead-lettering) are preserved verbatim. The new tests pin both the batching contract and the poison isolation contract with exact-count assertions. No correctness issues were found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/embedqueue/worker.go | Core fix: drainBatch + processBatch + embedGroup replace the old single-job process loop; liveLeases proactively drops expired leases before provider calls; poison isolation correctly falls through to per-chunk embedOne. Logic and contracts are sound. |
| internal/cli/up_distributed_embed.go | Adds distributedEmbedBatchSize = 32 constant; wires it into both Config.BatchSize and EmbeddingWorker.BatchSize to keep them in lockstep. Clean, minimal change. |
| tests/embedqueue/worker_test.go | Adds batchRecordingEmbedStep and poisonEmbedStep fakes; TestWorker_BatchesUpToBatchSize checks batching correctness (exactly-once embed + at least one multi-chunk call); TestWorker_BatchPoisonChunkIsolated verifies innocents land exactly once and poison is dead-lettered. Assertions are tight. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Run loop - Broker.Lease first] --> B[drainBatch\ncollect up to BatchSize leases]
    B --> C[processBatch\nprepare each lease]
    C --> D{prepare ok?}
    D -- Ack/Nack terminal --> E[Skip]
    D -- ok --> F[group by index_kind]
    F --> G[sort.Strings for determinism]
    G --> H[embedGroup per kind]
    H --> I[liveLeases\ndrop expired leases]
    I --> J{len group == 0?}
    J -- yes --> K[Return - broker redelivers]
    J -- no --> L[EmbedAndIndex whole group]
    L --> M{error?}
    M -- nil --> N[Ack all leases]
    M -- err, len==1 --> O[Nack single lease]
    M -- err, len>1 --> P[Isolation path\nembedOne per job]
    P --> Q{embedOne error?}
    Q -- nil --> R[Ack lease]
    Q -- err --> S[Nack lease]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Run loop - Broker.Lease first] --> B[drainBatch\ncollect up to BatchSize leases]
    B --> C[processBatch\nprepare each lease]
    C --> D{prepare ok?}
    D -- Ack/Nack terminal --> E[Skip]
    D -- ok --> F[group by index_kind]
    F --> G[sort.Strings for determinism]
    G --> H[embedGroup per kind]
    H --> I[liveLeases\ndrop expired leases]
    I --> J{len group == 0?}
    J -- yes --> K[Return - broker redelivers]
    J -- no --> L[EmbedAndIndex whole group]
    L --> M{error?}
    M -- nil --> N[Ack all leases]
    M -- err, len==1 --> O[Nack single lease]
    M -- err, len>1 --> P[Isolation path\nembedOne per job]
    P --> Q{embedOne error?}
    Q -- nil --> R[Ack lease]
    Q -- err --> S[Nack lease]
```

</a>

<sub>Reviews (2): Last reviewed commit: ["review: address PR #477 comments"](https://github.com/dirstral/dir2mcp/commit/080a400f25ab8a02fdbb825a80223f8ab4e6e292) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41246108)</sub>

<!-- /greptile_comment -->