### PR TITLE
fix(index): isolate embedding batch poison chunks via bisection (#399)

### DIFF
--- a/internal/index/embedding_worker.go
+++ b/internal/index/embedding_worker.go
@@ -708,22 +708,44 @@ func (w *EmbeddingWorker) EmbedAndIndex(ctx context.Context, indexKind string, t
 	if err != nil {
 		return 0, err
 	}
+	return w.embedIndexBatch(ctx, indexKind, modelName, validTasks, labels)
+}
 
+// embedIndexBatch embeds validTasks (aligned 1:1 with labels), upserts the
+// resulting vectors into the index, and marks the chunks embedded. It is the
+// recursive core of EmbedAndIndex.
+//
+// On a non-transient, non-fatal batch embed error it bisects the batch
+// (bisectEmbedBatch) so a single provider-rejected "poison" input — an
+// oversized / bad-encoding / over-token-limit chunk that 400s the whole HTTP
+// request, since openai/gemini/omniembed all embed by batch — is isolated and
+// marked failed while its healthy siblings still embed (issue #399). Previously
+// one bad chunk marked up to batch-size-1 healthy siblings embedding_failure.
+//
+// The classification contract from issue #412 is preserved: transient errors
+// (network hiccup, rate limit, cancellation) leave the chunks PENDING for a
+// later cycle and are never marked failed; ErrFatal is a local media/config
+// failure (not a provider input rejection) and keeps the existing whole-batch
+// behavior so genuine misconfiguration stays loud rather than degrading into a
+// silent per-chunk failure storm.
+func (w *EmbeddingWorker) embedIndexBatch(ctx context.Context, indexKind, modelName string, validTasks []model.ChunkTask, labels []uint64) (int, error) {
 	// Text chunks embed via Embed; media chunks (SPEC 8.1.7) embed via
 	// EmbedMedia. embedTasks returns vectors aligned 1:1 with validTasks.
 	vectors, err := w.embedTasks(ctx, modelName, validTasks)
 	if err != nil {
-		// distinguish between transient errors (which we want to retry later)
-		// and permanent failures for which the chunks should be marked as
-		// irrecoverable.  A transient error could be a network timeout,
-		// rate‑limit response, or context cancellation.  We intentionally keep
-		// the interface simple; by returning the error without marking the
-		// chunks as failed they will remain in the pending state and be
-		// re‑fetched on the next cycle.  Permanent errors fall through to the
-		// existing MarkFailed behaviour.
+		// A transient error could be a network timeout, rate-limit response, or
+		// context cancellation. Returning it without marking the chunks failed
+		// leaves them PENDING so they are re-fetched on the next cycle (#412).
 		if isTransientEmbedError(err) {
 			return 0, err
 		}
+		// Non-transient, multi-item, and not a local/config fatal: this is the
+		// poison-chunk case. Bisect the batch so only the offending input(s)
+		// fail instead of the whole HTTP batch (#399).
+		if len(validTasks) > 1 && !errors.Is(err, ErrFatal) {
+			return w.bisectEmbedBatch(ctx, indexKind, modelName, validTasks, labels, err)
+		}
+		// Single item, or a fatal batch error: mark failed (existing behavior).
 		category := string(store.ClassifyError(err))
 		reason := store.SanitizeReason(err.Error())
 		if mfErr := w.Source.MarkFailedWithCategory(ctx, labels, category, reason); mfErr != nil {
@@ -753,6 +775,34 @@ func (w *EmbeddingWorker) EmbedAndIndex(ctx context.Context, indexKind string, t
 	}
 
 	return len(labels), nil
+}
+
+// bisectEmbedBatch isolates the provider-rejected input(s) in a batch that
+// failed a non-transient, non-fatal embed by splitting it in half and
+// re-embedding each half through embedIndexBatch. Recursion narrows to the
+// individual poison chunk, which is marked failed (embedding_status=error)
+// while every healthy sibling still embeds and indexes (issue #399).
+//
+// Error precedence in the return value: a transient error surfacing from either
+// half means those chunks stayed PENDING, so it is propagated to make the run
+// loop back off and re-fetch them. An isolated non-transient failure is already
+// terminal (its chunk is marked failed) and need not propagate, so once the
+// poison is contained the batch reports success for the healthy remainder.
+// Returns the total number of chunks successfully indexed across both halves.
+func (w *EmbeddingWorker) bisectEmbedBatch(ctx context.Context, indexKind, modelName string, validTasks []model.ChunkTask, labels []uint64, batchErr error) (int, error) {
+	w.logf("embed batch of %d failed non-transiently (%s); bisecting to isolate poison chunk(s) so healthy siblings still embed [kind=%s]",
+		len(validTasks), store.SanitizeReason(batchErr.Error()), indexKind)
+	mid := len(validTasks) / 2
+	nLeft, errLeft := w.embedIndexBatch(ctx, indexKind, modelName, validTasks[:mid], labels[:mid])
+	nRight, errRight := w.embedIndexBatch(ctx, indexKind, modelName, validTasks[mid:], labels[mid:])
+	n := nLeft + nRight
+	if errLeft != nil && isTransientEmbedError(errLeft) {
+		return n, errLeft
+	}
+	if errRight != nil && isTransientEmbedError(errRight) {
+		return n, errRight
+	}
+	return n, nil
 }
 
 // Run starts a background loop that periodically calls RunOnce. A small

--- a/internal/index/embedding_worker.go
+++ b/internal/index/embedding_worker.go
@@ -739,26 +739,45 @@ func (w *EmbeddingWorker) embedIndexBatch(ctx context.Context, indexKind, modelN
 		if isTransientEmbedError(err) {
 			return 0, err
 		}
-		// Non-transient, multi-item, and not a local/config fatal: this is the
-		// poison-chunk case. Bisect the batch so only the offending input(s)
-		// fail instead of the whole HTTP batch (#399).
-		if len(validTasks) > 1 && !errors.Is(err, ErrFatal) {
+		// Non-transient, multi-item, not a local/config fatal, and not a
+		// corpus-wide auth rejection: this is the poison-chunk case. Bisect the
+		// batch so only the offending input(s) fail instead of the whole HTTP
+		// batch (#399). Auth failures (401/403) are excluded because they reject
+		// every input identically — bisecting them isolates nothing and instead
+		// explodes one batch into O(n) embed calls (1+2+4+…), hammering the
+		// provider and risking a rate-limit/lockout, so they keep the existing
+		// whole-batch failure behavior below.
+		if len(validTasks) > 1 && !errors.Is(err, ErrFatal) &&
+			store.ClassifyError(err) != store.ErrorCategoryAuth {
 			return w.bisectEmbedBatch(ctx, indexKind, modelName, validTasks, labels, err)
 		}
-		// Single item, or a fatal batch error: mark failed (existing behavior).
+		// Single item, a fatal batch error, or an auth batch: mark failed
+		// (existing behavior).
 		category := string(store.ClassifyError(err))
 		reason := store.SanitizeReason(err.Error())
 		if mfErr := w.Source.MarkFailedWithCategory(ctx, labels, category, reason); mfErr != nil {
 			w.logf("mark failed update error: %v (source error: %v) labels=%v", mfErr, err, labels)
 		}
-		return 0, err
+		// ErrFatal is a local media/config failure that must stay loud and stop
+		// the worker (issue #412), so propagate it unwrapped — a parent
+		// bisectEmbedBatch must NOT absorb it. Every other non-transient failure
+		// here has been terminally marked failed, so wrap it in the
+		// errChunkMarkedFailed sentinel: a parent bisection absorbs that (its
+		// healthy siblings still succeed) while the run loop can still tell it
+		// apart from a post-embed write failure that must propagate.
+		if errors.Is(err, ErrFatal) {
+			return 0, err
+		}
+		return 0, fmt.Errorf("%w: %w", errChunkMarkedFailed, err)
 	}
 	if len(vectors) != len(validTasks) {
 		reason := "embedding vector count mismatch"
 		if mfErr := w.Source.MarkFailedWithCategory(ctx, labels, string(store.ErrorCategoryEmbeddingFailure), reason); mfErr != nil {
 			w.logf("mark failed update error: %v (reason: %s) labels=%v", mfErr, reason, labels)
 		}
-		return 0, errors.New(reason)
+		// Terminally marked failed, so absorbable by a parent bisection (same
+		// contract as the embed-rejection case above).
+		return 0, fmt.Errorf("%w: %s", errChunkMarkedFailed, reason)
 	}
 
 	n, err := w.indexChunks(ctx, validTasks, labels, vectors)
@@ -783,11 +802,15 @@ func (w *EmbeddingWorker) embedIndexBatch(ctx context.Context, indexKind, modelN
 // individual poison chunk, which is marked failed (embedding_status=error)
 // while every healthy sibling still embeds and indexes (issue #399).
 //
-// Error precedence in the return value: a transient error surfacing from either
-// half means those chunks stayed PENDING, so it is propagated to make the run
-// loop back off and re-fetch them. An isolated non-transient failure is already
-// terminal (its chunk is marked failed) and need not propagate, so once the
-// poison is contained the batch reports success for the healthy remainder.
+// Error precedence in the return value (see mergeBisectErrors): only the
+// errChunkMarkedFailed sentinel is absorbed — an isolated poison chunk this
+// recursion already marked failed is terminal, so once it is contained the batch
+// reports success for the healthy remainder. Every other error propagates:
+// transient errors (those chunks stayed PENDING, so the run loop must back off
+// and re-fetch them), ErrFatal (a local media/config failure that must stop the
+// worker, issue #412 — and it wins over a sibling's transient error), and
+// post-embed write failures from indexChunks/markEmbeddedWithRetry (the run loop
+// must see them or the affected chunks re-embed in a tight loop).
 // Returns the total number of chunks successfully indexed across both halves.
 func (w *EmbeddingWorker) bisectEmbedBatch(ctx context.Context, indexKind, modelName string, validTasks []model.ChunkTask, labels []uint64, batchErr error) (int, error) {
 	w.logf("embed batch of %d failed non-transiently (%s); bisecting to isolate poison chunk(s) so healthy siblings still embed [kind=%s]",
@@ -795,14 +818,29 @@ func (w *EmbeddingWorker) bisectEmbedBatch(ctx context.Context, indexKind, model
 	mid := len(validTasks) / 2
 	nLeft, errLeft := w.embedIndexBatch(ctx, indexKind, modelName, validTasks[:mid], labels[:mid])
 	nRight, errRight := w.embedIndexBatch(ctx, indexKind, modelName, validTasks[mid:], labels[mid:])
-	n := nLeft + nRight
-	if errLeft != nil && isTransientEmbedError(errLeft) {
-		return n, errLeft
+	return nLeft + nRight, mergeBisectErrors(errLeft, errRight)
+}
+
+// mergeBisectErrors selects the error a bisection should surface to its caller.
+// The errChunkMarkedFailed sentinel (a poison chunk a recursion already marked
+// terminally failed) is absorbed so healthy siblings still report success. Of
+// the remaining errors ErrFatal takes precedence — a local media/config failure
+// must stop the worker (issue #412) even when a sibling half only saw a
+// transient error — otherwise the first non-absorbable error is returned.
+func mergeBisectErrors(errs ...error) error {
+	var first error
+	for _, e := range errs {
+		if e == nil || errors.Is(e, errChunkMarkedFailed) {
+			continue
+		}
+		if errors.Is(e, ErrFatal) {
+			return e
+		}
+		if first == nil {
+			first = e
+		}
 	}
-	if errRight != nil && isTransientEmbedError(errRight) {
-		return n, errRight
-	}
-	return n, nil
+	return first
 }
 
 // Run starts a background loop that periodically calls RunOnce. A small
@@ -909,6 +947,16 @@ var ErrFatal = errors.New("fatal")
 // fixes it. Recognized by isTransientEmbedError so it routes to the retry (keep
 // pending) path rather than MarkFailed.
 var errRetryableMediaRead = errors.New("retryable media read")
+
+// errChunkMarkedFailed marks a batch whose chunk(s) embedIndexBatch has already
+// moved to a terminal failed state (embedding_status=error) — the isolated
+// poison chunk from bisection (#399) or a vector-count-mismatch. It exists so
+// bisectEmbedBatch can absorb exactly this case (its healthy siblings still
+// succeed) while still propagating everything the run loop must act on: transient
+// errors, ErrFatal, and post-embed write failures from indexChunks /
+// markEmbeddedWithRetry. It is never returned for a transient error or for
+// ErrFatal (both propagate unwrapped), so absorbing it cannot swallow those.
+var errChunkMarkedFailed = errors.New("chunk marked failed")
 
 // isRetryable determines whether RunOnce should be retried when it returns
 // the provided error. The predicate is intentionally conservative; context

--- a/internal/retrieval/hybrid.go
+++ b/internal/retrieval/hybrid.go
@@ -111,6 +111,13 @@ func (s *Service) runHybridSearch(
 	}
 	ls, ok := store.(model.LexicalSearcher)
 	if !ok {
+		// Hybrid is enabled but the store cannot serve BM25 — this silently
+		// degrades retrieval to vector-only (the BM25-regression class, issue
+		// #399). Warn once so it is diagnosable instead of invisible, without
+		// flooding the log on every query.
+		s.hybridNoLexicalWarnOnce.Do(func() {
+			s.logf("hybrid: enabled but store %T does not implement LexicalSearcher; degrading to vector-only search", store)
+		})
 		return nil, false
 	}
 	bm25Hits, err := ls.SearchBM25(ctx, query, hybridCandidatePoolSize, indexKind)

--- a/internal/retrieval/hybrid.go
+++ b/internal/retrieval/hybrid.go
@@ -115,9 +115,9 @@ func (s *Service) runHybridSearch(
 		// degrades retrieval to vector-only (the BM25-regression class, issue
 		// #399). Warn once so it is diagnosable instead of invisible, without
 		// flooding the log on every query.
-		s.hybridNoLexicalWarnOnce.Do(func() {
+		if s.hybridNoLexicalWarned.CompareAndSwap(false, true) {
 			s.logf("hybrid: enabled but store %T does not implement LexicalSearcher; degrading to vector-only search", store)
-		})
+		}
 		return nil, false
 	}
 	bm25Hits, err := ls.SearchBM25(ctx, query, hybridCandidatePoolSize, indexKind)

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/dirstral/dir2mcp/internal/model"
@@ -108,11 +109,14 @@ type Service struct {
 	// true; the engine can disable it via SetHybridEnabled when the operator
 	// sets retrieval.hybrid.enabled=false.
 	hybridEnabled bool
-	// hybridNoLexicalWarnOnce guards a single warning when hybrid is enabled
-	// but the store does not satisfy model.LexicalSearcher, so a BM25-regression
-	// that silently drops hybrid to vector-only is visible in the logs exactly
-	// once rather than never (issue #399) — and not on every query.
-	hybridNoLexicalWarnOnce sync.Once
+	// hybridNoLexicalWarned guards a single warning when hybrid is enabled but
+	// the store does not satisfy model.LexicalSearcher, so a BM25-regression that
+	// silently drops hybrid to vector-only is visible in the logs exactly once
+	// rather than never (issue #399) — and not on every query. It is an
+	// atomic.Bool rather than a sync.Once so SetHybridEnabled(true) can reset it:
+	// a hot-reload that toggles hybrid off and back on re-arms the warning
+	// instead of staying silent for the lifetime of the Service.
+	hybridNoLexicalWarned atomic.Bool
 	// reranker, when set and rerankEnabled, re-scores the fused candidate
 	// pool before truncation to k (see SPEC 9.1.1). Fail-open: any error
 	// falls back to the pre-rerank order.
@@ -275,6 +279,12 @@ func (s *Service) SetHybridEnabled(enabled bool) {
 	s.metaMu.Lock()
 	defer s.metaMu.Unlock()
 	s.hybridEnabled = enabled
+	// Re-arm the "no LexicalSearcher" warning on each (re-)enable so that a
+	// hot-reload toggling hybrid off and back on surfaces the degradation again
+	// instead of staying silent because the warning already fired once.
+	if enabled {
+		s.hybridNoLexicalWarned.Store(false)
+	}
 }
 
 // SetReranker wires an optional rerank provider. modelName is the

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -108,6 +108,11 @@ type Service struct {
 	// true; the engine can disable it via SetHybridEnabled when the operator
 	// sets retrieval.hybrid.enabled=false.
 	hybridEnabled bool
+	// hybridNoLexicalWarnOnce guards a single warning when hybrid is enabled
+	// but the store does not satisfy model.LexicalSearcher, so a BM25-regression
+	// that silently drops hybrid to vector-only is visible in the logs exactly
+	// once rather than never (issue #399) — and not on every query.
+	hybridNoLexicalWarnOnce sync.Once
 	// reranker, when set and rerankEnabled, re-scores the fused candidate
 	// pool before truncation to k (see SPEC 9.1.1). Fail-open: any error
 	// falls back to the pre-rerank order.

--- a/tests/index/embed_poison_isolation_test.go
+++ b/tests/index/embed_poison_isolation_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -148,5 +149,113 @@ func TestEmbedAndIndex_TransientBatchLeavesAllPending(t *testing.T) {
 	}
 	if len(src.embedded) != 0 {
 		t.Fatalf("embedded = %v, want none", src.embedded)
+	}
+}
+
+// fatalText marks an input that embeds fatally when isolated (a local
+// media/config failure, index.ErrFatal) — as opposed to poisonText, which is a
+// provider input rejection. A multi-item batch containing it fails
+// non-transiently but non-fatally so the worker bisects; only the isolated
+// single input surfaces ErrFatal.
+const fatalText = "FATAL-local-config"
+
+type fatalOnIsolateEmbedder struct{ calls int }
+
+func (e *fatalOnIsolateEmbedder) Embed(_ context.Context, _ string, _ model.EmbedRole, inputs []string) ([][]float32, error) {
+	e.calls++
+	hasFatal := false
+	for _, in := range inputs {
+		if strings.Contains(in, fatalText) {
+			hasFatal = true
+		}
+	}
+	if hasFatal {
+		if len(inputs) == 1 {
+			// Isolated fatal input: local media/config failure must stay loud.
+			return nil, fmt.Errorf("%w: local media/config failure", index.ErrFatal)
+		}
+		// Multi-item batch containing it: non-transient, non-fatal → bisect.
+		return nil, errors.New("400 bad request")
+	}
+	out := make([][]float32, len(inputs))
+	for i := range inputs {
+		out[i] = []float32{1, 0}
+	}
+	return out, nil
+}
+
+// TestBisect_FatalErrorPropagates pins the #412 contract through the #399
+// bisection path: an ErrFatal surfacing in a bisected sub-batch must propagate
+// (so the run loop stops) rather than be swallowed as batch success.
+func TestBisect_FatalErrorPropagates(t *testing.T) {
+	ctx := context.Background()
+	src := &fakeChunkSource{}
+	idx := index.NewHNSWIndex("")
+	emb := &fatalOnIsolateEmbedder{}
+	worker := &index.EmbeddingWorker{Source: src, Index: idx, Embedder: emb, BatchSize: 8}
+
+	tasks := []model.ChunkTask{
+		textTask(1, "healthy one"),
+		textTask(2, fatalText),
+	}
+	_, err := worker.EmbedAndIndex(ctx, "text", tasks)
+	if !errors.Is(err, index.ErrFatal) {
+		t.Fatalf("err = %v, want ErrFatal to propagate out of bisection", err)
+	}
+}
+
+// authEmbedder always rejects with a 401 (a corpus-wide auth failure) and counts
+// its calls so a test can assert bisection did NOT fan out into O(n) calls.
+type authEmbedder struct{ calls int }
+
+func (e *authEmbedder) Embed(_ context.Context, _ string, _ model.EmbedRole, _ []string) ([][]float32, error) {
+	e.calls++
+	return nil, errors.New("401 unauthorized: invalid api key")
+}
+
+// TestAuthError_NotBisected pins that a corpus-wide auth rejection is not
+// bisected (that would explode one batch into O(n) embed calls without isolating
+// anything). It marks the whole batch failed in a single embed call.
+func TestAuthError_NotBisected(t *testing.T) {
+	ctx := context.Background()
+	src := &fakeChunkSource{}
+	idx := index.NewHNSWIndex("")
+	emb := &authEmbedder{}
+	worker := &index.EmbeddingWorker{Source: src, Index: idx, Embedder: emb, BatchSize: 8}
+
+	tasks := []model.ChunkTask{
+		textTask(1, "a"), textTask(2, "b"), textTask(3, "c"), textTask(4, "d"),
+	}
+	if _, err := worker.EmbedAndIndex(ctx, "text", tasks); err == nil {
+		t.Fatal("auth failure should surface an error, got nil")
+	}
+	if emb.calls != 1 {
+		t.Fatalf("embed calls = %d, want 1 (auth must not bisect into O(n) calls)", emb.calls)
+	}
+	if len(src.failedLabels) != 4 {
+		t.Fatalf("failed labels = %v, want all 4 marked failed (whole-batch behavior)", src.failedLabels)
+	}
+}
+
+// TestBisect_PostEmbedWriteErrorPropagates pins the greptile P1 finding: a
+// non-transient index/upsert (post-embed write) failure in a bisected sub-batch
+// must propagate so the run loop backs off — otherwise the chunks stay PENDING
+// while the batch reports success, causing a tight re-embed loop.
+func TestBisect_PostEmbedWriteErrorPropagates(t *testing.T) {
+	ctx := context.Background()
+	src := &fakeChunkSource{}
+	writeErr := errors.New("vector dimension mismatch")
+	emb := &poisonEmbedder{}
+	worker := &index.EmbeddingWorker{
+		Source: src, Index: &fakeUpsertIndex{upsertErr: writeErr}, Embedder: emb, BatchSize: 8,
+	}
+
+	tasks := []model.ChunkTask{
+		textTask(1, "healthy one"), // will embed then fail the index write
+		textTask(2, poisonText),    // isolated + marked failed by bisection
+	}
+	_, err := worker.EmbedAndIndex(ctx, "text", tasks)
+	if !errors.Is(err, writeErr) {
+		t.Fatalf("err = %v, want the post-embed write error to propagate out of bisection", err)
 	}
 }

--- a/tests/index/embed_poison_isolation_test.go
+++ b/tests/index/embed_poison_isolation_test.go
@@ -1,0 +1,152 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// poisonText is the sentinel input that the poisonEmbedder rejects. It models a
+// provider-side 400 (input over the model's max context / bad encoding) which
+// fails the whole HTTP batch — openai/gemini/omniembed all embed by batch.
+const poisonText = "POISON-oversized-input"
+
+// poisonEmbedder returns a non-transient error for any batch that contains
+// poisonText (mirroring a provider that 400s the entire request on one bad
+// input) and deterministic vectors otherwise. It records the number of Embed
+// calls so a test can confirm the worker bisected rather than one-shotting.
+type poisonEmbedder struct {
+	calls int
+}
+
+func (e *poisonEmbedder) Embed(_ context.Context, _ string, _ model.EmbedRole, inputs []string) ([][]float32, error) {
+	e.calls++
+	for _, in := range inputs {
+		if strings.Contains(in, poisonText) {
+			// Non-transient, non-fatal: the poison-chunk case from issue #399.
+			return nil, errors.New("400 bad request: input exceeds maximum context length")
+		}
+	}
+	out := make([][]float32, len(inputs))
+	for i := range inputs {
+		out[i] = []float32{1, 0}
+	}
+	return out, nil
+}
+
+func textTask(id uint64, text string) model.ChunkTask {
+	return model.NewChunkTask(id, text, "text", model.ChunkMetadata{ChunkID: id, RelPath: "doc.txt"})
+}
+
+// TestEmbedAndIndex_PoisonChunkIsolated pins issue #399 item 1: a single
+// provider-rejected "poison" input in a batch must not fail its healthy
+// siblings. The worker bisects the failing batch, isolates the bad chunk (marks
+// it embedding_status=error), and still embeds+indexes every other chunk.
+func TestEmbedAndIndex_PoisonChunkIsolated(t *testing.T) {
+	ctx := context.Background()
+	src := &fakeChunkSource{}
+	idx := index.NewHNSWIndex("")
+	emb := &poisonEmbedder{}
+	worker := &index.EmbeddingWorker{Source: src, Index: idx, Embedder: emb, BatchSize: 8}
+
+	tasks := []model.ChunkTask{
+		textTask(1, "healthy one"),
+		textTask(2, "healthy two"),
+		textTask(3, poisonText), // the poison chunk
+		textTask(4, "healthy four"),
+	}
+
+	n, err := worker.EmbedAndIndex(ctx, "text", tasks)
+	if err != nil {
+		t.Fatalf("EmbedAndIndex returned error after isolating poison chunk: %v", err)
+	}
+	if n != 3 {
+		t.Fatalf("indexed = %d, want 3 (all healthy siblings)", n)
+	}
+
+	wantEmbedded := map[uint64]bool{1: true, 2: true, 4: true}
+	if len(src.embedded) != 3 {
+		t.Fatalf("embedded labels = %v, want the 3 healthy chunks", src.embedded)
+	}
+	for _, l := range src.embedded {
+		if !wantEmbedded[l] {
+			t.Fatalf("embedded contains unexpected label %d (poison must not be embedded): %v", l, src.embedded)
+		}
+	}
+
+	if len(src.failedLabels) != 1 || src.failedLabels[0] != 3 {
+		t.Fatalf("failed labels = %v, want exactly [3] (only the poison chunk)", src.failedLabels)
+	}
+	if src.failedCategory == "" {
+		t.Fatalf("poison chunk should be marked failed with a classification category, got empty")
+	}
+	if emb.calls < 2 {
+		t.Fatalf("embed calls = %d, want >=2 (the worker must bisect, not one-shot)", emb.calls)
+	}
+}
+
+// TestEmbedAndIndex_AllPoisonMarksEachFailed pins that a batch where every input
+// is rejected marks each chunk failed individually (no healthy siblings lost,
+// none left silently pending) and reports no run-loop error to avoid needless
+// backoff once every chunk has reached a terminal state.
+func TestEmbedAndIndex_AllPoisonMarksEachFailed(t *testing.T) {
+	ctx := context.Background()
+	src := &fakeChunkSource{}
+	idx := index.NewHNSWIndex("")
+	worker := &index.EmbeddingWorker{Source: src, Index: idx, Embedder: &poisonEmbedder{}, BatchSize: 8}
+
+	tasks := []model.ChunkTask{
+		textTask(10, poisonText+"-a"),
+		textTask(11, poisonText+"-b"),
+	}
+	n, err := worker.EmbedAndIndex(ctx, "text", tasks)
+	if err != nil {
+		t.Fatalf("EmbedAndIndex error = %v, want nil (all chunks terminally marked failed)", err)
+	}
+	if n != 0 {
+		t.Fatalf("indexed = %d, want 0", n)
+	}
+	if len(src.failedLabels) != 2 {
+		t.Fatalf("failed labels = %v, want both chunks marked failed", src.failedLabels)
+	}
+	if len(src.embedded) != 0 {
+		t.Fatalf("embedded = %v, want none", src.embedded)
+	}
+}
+
+// transientBatchEmbedder always fails with a transient error, so no chunk should
+// ever be marked failed (issue #412 contract, preserved by the bisection path).
+type transientBatchEmbedder struct{}
+
+func (transientBatchEmbedder) Embed(_ context.Context, _ string, _ model.EmbedRole, _ []string) ([][]float32, error) {
+	return nil, errors.New("503 service unavailable")
+}
+
+// TestEmbedAndIndex_TransientBatchLeavesAllPending pins that the poison-isolation
+// path does not touch transient errors: a transient batch failure leaves every
+// chunk PENDING (no MarkFailed) and surfaces the error so the run loop retries.
+func TestEmbedAndIndex_TransientBatchLeavesAllPending(t *testing.T) {
+	ctx := context.Background()
+	src := &fakeChunkSource{}
+	idx := index.NewHNSWIndex("")
+	worker := &index.EmbeddingWorker{Source: src, Index: idx, Embedder: transientBatchEmbedder{}, BatchSize: 8}
+
+	tasks := []model.ChunkTask{textTask(20, "a"), textTask(21, "b"), textTask(22, "c")}
+	n, err := worker.EmbedAndIndex(ctx, "text", tasks)
+	if err == nil {
+		t.Fatal("expected a transient error to be surfaced for retry")
+	}
+	if n != 0 {
+		t.Fatalf("indexed = %d, want 0", n)
+	}
+	if len(src.failedLabels) != 0 {
+		t.Fatalf("failed labels = %v, want none (transient errors must not mark chunks failed)", src.failedLabels)
+	}
+	if len(src.embedded) != 0 {
+		t.Fatalf("embedded = %v, want none", src.embedded)
+	}
+}


### PR DESCRIPTION
## Addresses #399

Robustness gaps in the embedding / retrieval path where a recoverable condition
failed (or silently degraded) more than it should. This PR implements the
HIGH-priority poison-chunk item plus one cheap observability item; the remaining
items are deferred to focused follow-ups (see below).

### Item 1 [HIGH] — one poison chunk no longer fails its whole batch
`internal/index/embedding_worker.go`

Providers embed by HTTP batch (openai 64, gemini 64, omniembed 32) and a single
rejected input (oversized / bad encoding / over token limit) 400s the whole
request. The worker previously marked **all** labels in the batch
`embedding_failure` on a non-transient error, so one bad chunk took down up to
batch-size-1 healthy siblings.

`EmbedAndIndex` now delegates to a recursive `embedIndexBatch`: on a
non-transient, non-fatal, multi-item batch error it **bisects** the batch and
re-embeds each half, narrowing to the individual offending chunk — which is
marked `embedding_status=error` (retryable-vs-permanent classification preserved
from #412) — while every healthy sibling still embeds and indexes.

Contract preserved:
- **Transient** errors (network / rate-limit / cancellation, #412) still leave
  chunks PENDING and are never marked failed. A transient error from a bisected
  half takes precedence in the return value so still-pending chunks are retried.
- **ErrFatal** (a local media/config failure, not a provider input rejection)
  keeps its existing whole-batch behaviour so genuine misconfiguration stays
  loud rather than degrading into a silent per-chunk failure storm.
- The single-item path (used by the distributed embed-worker,
  `internal/embedqueue`) is unchanged — bisection only engages for multi-item
  in-process batches.

### Item 4 [LOW] — warn when hybrid silently degrades to vector-only
`internal/retrieval/hybrid.go`, `internal/retrieval/service.go`

When hybrid is enabled but the store does not satisfy `model.LexicalSearcher`,
retrieval silently dropped to vector-only (the BM25-regression class, invisible
at runtime). It now logs a warning **once** (sync.Once-guarded, so no per-query
flood) so the degradation is diagnosable.

### Tests
`tests/index/embed_poison_isolation_test.go`:
- one poison chunk in a 4-chunk batch → the 3 healthy chunks embed+index, only
  the poison chunk is marked failed (with a classification category), and the
  worker bisected (asserted via embed-call count).
- all-poison batch → each chunk marked failed individually, no run-loop error.
- transient batch error → all chunks left PENDING, none marked failed, error
  surfaced for retry.

### Deferred (separate follow-ups)
- **Item 2 [MED]** per-provider input token/size caps — needs per-provider
  limits modelled across the openai/gemini/omniembed clients; oversized inputs
  now degrade gracefully (isolated + marked error) via item 1 instead of failing
  the batch.
- **Item 3 [MED]** preflight probe-embed to catch present-but-invalid creds.
- **Item 5 [LOW]** rerank against full chunk text instead of the truncated BM25
  snippet.
- **Item 6 [LOW]** include native vector width in the HNSW `EmbedIdentity`.

### Checks
`make check`: lint (0 issues), `go vet`, gocyclo (≤15), ineffassign, misspell,
and the embedding/retrieval suites all pass. (One unrelated `tests/cli`
timeout — `TestUpCreatesSecretTokenAndConnectionFile`, "initialize metadata
store: context deadline exceeded" — was a load-induced flake under heavy
parallel test load; it passes in isolation.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHuQEKSW3nzU1Pn7KXXBhj

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two robustness gaps in the embedding/retrieval path. The core change in `embedding_worker.go` introduces a recursive bisection strategy so a single provider-rejected "poison" chunk (oversized input, bad encoding) no longer marks all batch-mates failed; the fix adds an `errChunkMarkedFailed` sentinel that is absorbed within bisection but remains opaque to the run loop so post-embed write errors still propagate correctly. A companion observability fix in `hybrid.go`/`service.go` surfaces a one-time warning when hybrid search silently degrades to vector-only.

- **`embedIndexBatch` + `bisectEmbedBatch`** — on non-transient, non-fatal, non-auth batch embed failure, the batch is split recursively until the offending item is isolated and marked `embedding_status=error`; every healthy sibling still embeds and indexes.
- **`errChunkMarkedFailed` sentinel** — distinguishes \"chunk already terminal (absorbable by bisection)\" from \"post-embed write failure (must propagate to run loop)\"; the previous thread's concern that `indexChunks`/`markEmbeddedWithRetry` errors were silently dropped is addressed and pinned by `TestBisect_PostEmbedWriteErrorPropagates`.
- **`hybridNoLexicalWarned atomic.Bool`** — replaces the unresetable `sync.Once` approach; `SetHybridEnabled(true)` resets the flag so a hot-reload cycle re-arms the degradation warning, addressing the previous thread's concern about the once staying spent.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the bisection logic is correct, the error propagation contracts are preserved, and the two issues raised in previous review rounds are both demonstrably fixed and test-pinned.

The `errChunkMarkedFailed` sentinel correctly separates terminal chunk failures (absorbed within bisection so healthy siblings still succeed) from post-embed write failures (propagated to the run loop so tight re-embed loops are avoided). `mergeBisectErrors` gives `ErrFatal` priority over any sibling transient error, transient errors surface unchanged, and the sentinel cannot wrap either of those two cases. The `atomic.Bool` reset in `SetHybridEnabled` correctly re-arms the degradation warning on hot-reload. All new code paths are covered by dedicated tests including an explicit regression test for the prior post-embed write error propagation concern.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/index/embedding_worker.go | Adds `embedIndexBatch`/`bisectEmbedBatch`/`mergeBisectErrors` and the `errChunkMarkedFailed` sentinel; both previous-thread P1s (post-embed write errors silently absorbed, no bisection) are addressed; transient/fatal error contracts preserved. |
| internal/retrieval/hybrid.go | Adds a `CompareAndSwap`-guarded one-time warning when the store does not implement `LexicalSearcher`; correctly reads `hybridNoLexicalWarned` after releasing `metaMu`, safe because the field is an `atomic.Bool`. |
| internal/retrieval/service.go | Adds `hybridNoLexicalWarned atomic.Bool`; `SetHybridEnabled(true)` resets it so hot-reload cycles re-arm the degradation warning; addresses previous-thread concern about `sync.Once` staying spent after toggle. |
| tests/index/embed_poison_isolation_test.go | Five new tests covering: healthy-sibling isolation, all-poison batch, transient-leaves-PENDING, ErrFatal propagation through bisection, and the previous-thread P1 (post-embed write error propagates). |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["EmbedAndIndex\n(batch of N chunks)"] --> B["embedIndexBatch"]
    B --> C{embedTasks}
    C -- "transient error" --> D["Return error\nChunks stay PENDING"]
    C -- "non-transient error\nlen>1, !ErrFatal, !auth" --> E["bisectEmbedBatch"]
    C -- "single item OR\nErrFatal OR auth" --> F["MarkFailedWithCategory\n(whole batch)"]
    F -- "ErrFatal" --> G["Return ErrFatal\n(worker stops)"]
    F -- "other" --> H["Return errChunkMarkedFailed\n(absorbed by parent bisection)"]
    E --> I["embedIndexBatch\n(left half)"]
    E --> J["embedIndexBatch\n(right half)"]
    I & J --> K["mergeBisectErrors"]
    K -- "errChunkMarkedFailed only" --> L["Return nil\nHealthy siblings indexed ✓"]
    K -- "ErrFatal present" --> G
    K -- "transient or write error" --> D
    C -- "success" --> M["indexChunks"]
    M -- "error" --> N["Return write error\n(propagates to run loop)"]
    M -- "success" --> O["markEmbeddedWithRetry"]
    O -- "error" --> N
    O -- "success" --> P["Return n, nil"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["EmbedAndIndex\n(batch of N chunks)"] --> B["embedIndexBatch"]
    B --> C{embedTasks}
    C -- "transient error" --> D["Return error\nChunks stay PENDING"]
    C -- "non-transient error\nlen>1, !ErrFatal, !auth" --> E["bisectEmbedBatch"]
    C -- "single item OR\nErrFatal OR auth" --> F["MarkFailedWithCategory\n(whole batch)"]
    F -- "ErrFatal" --> G["Return ErrFatal\n(worker stops)"]
    F -- "other" --> H["Return errChunkMarkedFailed\n(absorbed by parent bisection)"]
    E --> I["embedIndexBatch\n(left half)"]
    E --> J["embedIndexBatch\n(right half)"]
    I & J --> K["mergeBisectErrors"]
    K -- "errChunkMarkedFailed only" --> L["Return nil\nHealthy siblings indexed ✓"]
    K -- "ErrFatal present" --> G
    K -- "transient or write error" --> D
    C -- "success" --> M["indexChunks"]
    M -- "error" --> N["Return write error\n(propagates to run loop)"]
    M -- "success" --> O["markEmbeddedWithRetry"]
    O -- "error" --> N
    O -- "success" --> P["Return n, nil"]
```

</a>

<sub>Reviews (2): Last reviewed commit: ["review: address PR #478 comments"](https://github.com/dirstral/dir2mcp/commit/195c19d270ecc12562a8acd51faa90187980b814) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41247262)</sub>

<!-- /greptile_comment -->