### PR TITLE
fix(retrieval): route open_file/OCR reads through CorpusFS for S3 corpora (#432)

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -844,6 +844,16 @@ func (a *App) buildRetrieverForAsk(ctx context.Context, cfg config.Config, st mo
 		}
 	}
 
+	// Route open_file / OCR reads through the corpus filesystem for object-store
+	// backends so the ask CLI can read S3-backed documents too (#432). A build
+	// failure is non-fatal here: local/NFS corpora do not need it and search/ask
+	// citations never touch the corpus FS, so ask still functions.
+	if sourceIsRemote(cfg) {
+		if corpusFS, fsErr := buildCorpusFS(ctx, cfg); fsErr == nil {
+			ret.SetCorpusFS(corpusFS)
+		}
+	}
+
 	cleanup := func() {
 		_ = textIx.Close()
 		_ = codeIx.Close()

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -851,6 +851,14 @@ func (a *App) buildRetrieverForAsk(ctx context.Context, cfg config.Config, st mo
 	if sourceIsRemote(cfg) {
 		if corpusFS, fsErr := buildCorpusFS(ctx, cfg); fsErr == nil {
 			ret.SetCorpusFS(corpusFS)
+		} else {
+			// Non-fatal (search/ask never touch the corpus FS), but emit a
+			// structured warning so the operator knows open_file text/OCR reads
+			// will fall through to the local path and fail on this S3 corpus
+			// even though search/ask still work (#432).
+			askMetricsEmitter.Emit("warning", "corpus_fs_unavailable", map[string]interface{}{
+				"error": fsErr.Error(),
+			})
 		}
 	}
 

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -133,6 +133,13 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 	if setter, ok := ing.(corpusFSSetter); ok {
 		setter.SetCorpusFS(corpusFS)
 	}
+	// Route retrieval-time reads (open_file raw text / OCR / transcript) through
+	// the corpus filesystem for object-store backends so open_file works on an S3
+	// corpus (#432). Local/NFS corpora keep the historical local read path (their
+	// resolved-path + symlink-containment behavior) untouched.
+	if sourceIsRemote(cfg) {
+		ret.SetCorpusFS(corpusFS)
+	}
 
 	emitter.Emit("info", "index_loaded", map[string]interface{}{
 		"state_dir": cfg.StateDir,
@@ -1009,6 +1016,15 @@ func initIndexingState(ctx context.Context, st model.Store, ret *retrieval.Servi
 // configured backend (local/nfs/s3) drives discovery and reads.
 type corpusFSSetter interface {
 	SetCorpusFS(fsys corpusfs.CorpusFS)
+}
+
+// sourceIsRemote reports whether the configured corpus source is an object-store
+// backend (currently S3) rather than a local/NFS filesystem. Retrieval-time
+// reads are routed through the corpus filesystem only for remote backends; local
+// and NFS corpora keep the historical local-filesystem read path. Kind matching
+// mirrors corpusfs.New (case-insensitive; empty normalizes to local).
+func sourceIsRemote(cfg config.Config) bool {
+	return strings.EqualFold(strings.TrimSpace(cfg.Source.Kind), "s3")
 }
 
 // buildCorpusFS constructs the corpus filesystem selected by cfg.Source

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/dirstral/dir2mcp/internal/corpusfs"
 	"github.com/dirstral/dir2mcp/internal/model"
 	"github.com/dirstral/dir2mcp/internal/usage"
 )
@@ -99,8 +100,14 @@ type Service struct {
 	chunkByIndex        map[string]map[uint64]model.SearchHit
 	rootDir             string
 	stateDir            string
-	protocolVersion     string
-	pathExcludes        []string
+	// corpusFS, when non-nil, routes open_file raw-text reads and OCR/transcript
+	// source-byte hashing through the corpus filesystem abstraction instead of the
+	// local filesystem. It is injected only for object-store backends (S3) so a
+	// remote corpus returns content instead of failing on a missing local path
+	// (#432); nil preserves the historical local-filesystem read path exactly.
+	corpusFS        corpusfs.CorpusFS
+	protocolVersion string
+	pathExcludes    []string
 	// cached compiled regexps for exclude patterns; keys are normalized patterns
 	excludeRegexps map[string]*regexp.Regexp
 	secretPatterns []*regexp.Regexp
@@ -683,6 +690,20 @@ func (s *Service) SetRootDir(root string) {
 	}
 	s.metaMu.Lock()
 	s.rootDir = root
+	s.metaMu.Unlock()
+}
+
+// SetCorpusFS injects the corpus filesystem backend used for retrieval-time
+// reads (open_file raw text and OCR/transcript source-byte hashing). When nil
+// (the default) reads resolve against the local filesystem exactly as before,
+// so local/NFS corpora are unaffected. Object-store backends (S3) inject a
+// CorpusFS so open_file reads route through its Open seam and return content
+// instead of failing on a missing local path (#432). The cache the OCR/
+// transcript text lives in is always local under the state dir and is read
+// directly regardless of backend.
+func (s *Service) SetCorpusFS(fsys corpusfs.CorpusFS) {
+	s.metaMu.Lock()
+	s.corpusFS = fsys
 	s.metaMu.Unlock()
 }
 
@@ -1296,6 +1317,7 @@ func (s *Service) openFile(ctx context.Context, relPath string, span model.Span,
 	s.metaMu.RLock()
 	rootDir := s.rootDir
 	stateDir := s.stateDir
+	corpusFS := s.corpusFS
 	pathExcludes := append([]string(nil), s.pathExcludes...)
 	secretPatterns := append([]*regexp.Regexp(nil), s.secretPatterns...)
 	s.metaMu.RUnlock()
@@ -1322,9 +1344,18 @@ func (s *Service) openFile(ctx context.Context, relPath string, span model.Span,
 		return content, truncated, err
 	}
 
-	resolvedAbs, err := resolveSymlinkInRoot(targetAbs, realRoot, pathExcludes, s)
-	if err != nil {
-		return "", false, err
+	// Symlink resolution and in-root containment are local-filesystem concerns.
+	// For an object-store backend (corpusFS set) there is no local path to
+	// EvalSymlinks — containment is enforced by the CorpusFS itself against the
+	// rel path — so skip it and let the read helpers route through the backend
+	// (#432). resolveFilePath above already rejected traversal/absolute/excluded
+	// rel paths for both backends.
+	resolvedAbs := targetAbs
+	if corpusFS == nil {
+		resolvedAbs, err = resolveSymlinkInRoot(targetAbs, realRoot, pathExcludes, s)
+		if err != nil {
+			return "", false, err
+		}
 	}
 
 	// For binary documents (PDF, audio) with no explicit span — OR with a
@@ -1336,14 +1367,14 @@ func (s *Service) openFile(ctx context.Context, relPath string, span model.Span,
 	// (issue #364; see also #177). Text-native types (md, txt, code, html) keep
 	// the existing default of returning file bytes with line slicing.
 	if isBinaryDocType(normalizedRel) && (kind == "" || kind == "lines") {
-		content, truncated, err := s.openFileFromOCRCache(stateDir, resolvedAbs, normalizedRel, secretPatterns, maxChars)
+		content, truncated, err := s.openFileFromOCRCache(ctx, corpusFS, stateDir, resolvedAbs, normalizedRel, secretPatterns, maxChars)
 		if err != nil {
 			return "", false, err
 		}
 		return content, truncated, nil
 	}
 
-	return s.openFileFromResolvedPath(resolvedAbs, secretPatterns, kind, span, maxChars)
+	return s.openFileFromResolvedPath(ctx, corpusFS, resolvedAbs, normalizedRel, secretPatterns, kind, span, maxChars)
 }
 
 // chunkModalityChecker is the optional store capability used to classify a
@@ -1425,6 +1456,81 @@ func isBinaryDocType(relPath string) bool {
 	return ext == ".pdf" || isImageExt(ext) || isAudioExt(ext)
 }
 
+// readSourceBytes returns the full byte content of the corpus document at
+// relPath. When a CorpusFS backend is injected (object stores such as S3) the
+// read routes through its Open seam — the same seam the media/embedding paths
+// use — so remote corpora return content instead of failing on a missing local
+// path (#432). With no backend it preserves the historical local read exactly:
+// a directory target maps to the actionable DOC_TYPE_UNSUPPORTED rather than an
+// opaque OS error, then readFileBounded returns the bytes. The bool mirrors
+// readFileBounded's truncation flag (always false here since the read is
+// unbounded; open_file applies its own maxChars downstream).
+func (s *Service) readSourceBytes(ctx context.Context, corpusFS corpusfs.CorpusFS, resolvedAbs, relPath string) ([]byte, bool, error) {
+	if corpusFS != nil {
+		rc, err := corpusFS.Open(ctx, relPath)
+		if err != nil {
+			return nil, false, err
+		}
+		defer func() { _ = rc.Close() }()
+		data, readErr := io.ReadAll(rc)
+		if readErr != nil {
+			return nil, false, readErr
+		}
+		return data, false, nil
+	}
+
+	info, err := os.Stat(resolvedAbs)
+	if err != nil {
+		return nil, false, err
+	}
+	if info.IsDir() {
+		return nil, false, model.ErrDocTypeUnsupported
+	}
+	return readFileBounded(resolvedAbs, 0)
+}
+
+// hashSourceBytes computes the sha256 hex digest of the corpus document at
+// relPath — the key under which ingest stored the document's OCR/transcript
+// cache entry. It streams the source bytes through the CorpusFS Open seam when a
+// backend is injected (so an S3 object is hashed without a local copy) and
+// otherwise reads the local resolved path, rejecting a directory target with the
+// same DOC_TYPE_UNSUPPORTED mapping the raw-text path uses.
+func (s *Service) hashSourceBytes(ctx context.Context, corpusFS corpusfs.CorpusFS, resolvedAbs, relPath string) (string, error) {
+	var reader io.Reader
+	if corpusFS != nil {
+		rc, err := corpusFS.Open(ctx, relPath)
+		if err != nil {
+			return "", err
+		}
+		defer func() { _ = rc.Close() }()
+		reader = rc
+	} else {
+		// Reject directories explicitly, mirroring readSourceBytes. Without this
+		// guard os.Open succeeds on a directory and io.Copy on a directory file
+		// descriptor surfaces as an opaque OS error that the MCP layer would map to
+		// INTERNAL_ERROR; DOC_TYPE_UNSUPPORTED is the correct, actionable mapping.
+		info, err := os.Stat(resolvedAbs)
+		if err != nil {
+			return "", err
+		}
+		if info.IsDir() {
+			return "", model.ErrDocTypeUnsupported
+		}
+		sourceFile, err := os.Open(resolvedAbs)
+		if err != nil {
+			return "", err
+		}
+		defer func() { _ = sourceFile.Close() }()
+		reader = sourceFile
+	}
+
+	hasher := sha256.New()
+	if _, err := io.Copy(hasher, reader); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
 // openFileFromOCRCache reads the precomputed OCR (or transcript) representation
 // for a binary document. The cache layout mirrors what
 // internal/ingest.Service.readOrComputeOCR / readOrComputeTranscript write:
@@ -1433,35 +1539,16 @@ func isBinaryDocType(relPath string) bool {
 // When no cache file exists (e.g. ingest is still running), the function
 // returns model.ErrOCRNotReady so callers can surface an actionable error
 // rather than fall back to raw bytes.
-func (s *Service) openFileFromOCRCache(stateDir, resolvedAbs, relPath string, secretPatterns []*regexp.Regexp, maxChars int) (string, bool, error) {
+func (s *Service) openFileFromOCRCache(ctx context.Context, corpusFS corpusfs.CorpusFS, stateDir, resolvedAbs, relPath string, secretPatterns []*regexp.Regexp, maxChars int) (string, bool, error) {
 	stateDir = strings.TrimSpace(stateDir)
 	if stateDir == "" {
 		stateDir = filepath.Join(".", ".dir2mcp")
 	}
 
-	// Reject directories explicitly, mirroring openFileFromResolvedPath. Without
-	// this guard os.Open succeeds on a directory and io.Copy on a directory file
-	// descriptor surfaces as an opaque OS error that the MCP layer would map to
-	// INTERNAL_ERROR; DOC_TYPE_UNSUPPORTED is the correct, actionable mapping.
-	info, err := os.Stat(resolvedAbs)
+	hashHex, err := s.hashSourceBytes(ctx, corpusFS, resolvedAbs, relPath)
 	if err != nil {
 		return "", false, err
 	}
-	if info.IsDir() {
-		return "", false, model.ErrDocTypeUnsupported
-	}
-
-	sourceFile, err := os.Open(resolvedAbs)
-	if err != nil {
-		return "", false, err
-	}
-	defer func() { _ = sourceFile.Close() }()
-
-	hasher := sha256.New()
-	if _, err := io.Copy(hasher, sourceFile); err != nil {
-		return "", false, err
-	}
-	hashHex := hex.EncodeToString(hasher.Sum(nil))
 
 	candidates := openFileOCRCacheCandidates(stateDir, hashHex, relPath)
 	for _, candidate := range candidates {
@@ -1524,16 +1611,8 @@ func (s *Service) openFileFromMetadata(normalizedRel string, span model.Span, ma
 	return out, truncated, true, nil
 }
 
-func (s *Service) openFileFromResolvedPath(resolvedAbs string, secretPatterns []*regexp.Regexp, kind string, span model.Span, maxChars int) (string, bool, error) {
-	info, err := os.Stat(resolvedAbs)
-	if err != nil {
-		return "", false, err
-	}
-	if info.IsDir() {
-		return "", false, model.ErrDocTypeUnsupported
-	}
-
-	raw, readTruncated, err := readFileBounded(resolvedAbs, 0)
+func (s *Service) openFileFromResolvedPath(ctx context.Context, corpusFS corpusfs.CorpusFS, resolvedAbs, relPath string, secretPatterns []*regexp.Regexp, kind string, span model.Span, maxChars int) (string, bool, error) {
+	raw, readTruncated, err := s.readSourceBytes(ctx, corpusFS, resolvedAbs, relPath)
 	if err != nil {
 		return "", false, err
 	}

--- a/tests/retrieval/open_file_corpusfs_test.go
+++ b/tests/retrieval/open_file_corpusfs_test.go
@@ -1,0 +1,143 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/corpusfs"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
+)
+
+// fakeCorpusFS is an in-memory corpusfs.CorpusFS whose objects live only in a
+// map — never on the local filesystem. It stands in for an object-store backend
+// (S3) so open_file's read path can be exercised without any local source file,
+// which is exactly the condition that broke S3 corpora (#432): retrieval used to
+// resolve against the local FS and fail because the bytes are remote.
+type fakeCorpusFS struct {
+	objects map[string][]byte
+}
+
+// readSeekCloser adapts a *bytes.Reader (which has no Close) to the
+// io.ReadSeekCloser the CorpusFS.Open contract returns.
+type readSeekCloser struct {
+	*bytes.Reader
+}
+
+func (readSeekCloser) Close() error { return nil }
+
+func (f *fakeCorpusFS) Open(ctx context.Context, relPath string) (io.ReadSeekCloser, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	data, ok := f.objects[relPath]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	return readSeekCloser{bytes.NewReader(data)}, nil
+}
+
+func (f *fakeCorpusFS) Walk(context.Context, string, corpusfs.Options) ([]corpusfs.DiscoveredFile, error) {
+	return nil, errors.New("fakeCorpusFS: Walk not implemented")
+}
+
+func (f *fakeCorpusFS) Localize(context.Context, string) (string, func(), error) {
+	return "", func() {}, errors.New("fakeCorpusFS: Localize not implemented")
+}
+
+// TestOpenFile_CorpusFS_TextReturnsContent verifies that open_file on a text
+// document served by a CorpusFS backend returns the object's bytes even though
+// no local file exists under RootDir — the S3 raw-text read path (#432).
+func TestOpenFile_CorpusFS_TextReturnsContent(t *testing.T) {
+	// RootDir points at an empty temp dir: there is deliberately NO local file,
+	// so a regression to the local-FS read path would fail with not-found.
+	root := t.TempDir()
+	stateDir := filepath.Join(root, ".dir2mcp")
+
+	body := "# Remote Doc\n\nServed from the object store, not the local disk."
+	fs := &fakeCorpusFS{objects: map[string][]byte{"docs/remote.md": []byte(body)}}
+
+	svc := retrieval.NewService(nil, nil, nil, nil)
+	svc.SetRootDir(root)
+	svc.SetStateDir(stateDir)
+	svc.SetCorpusFS(fs)
+
+	out, err := svc.OpenFile(context.Background(), "docs/remote.md", model.Span{}, 20000)
+	if err != nil {
+		t.Fatalf("OpenFile over CorpusFS returned err: %v", err)
+	}
+	if out != body {
+		t.Fatalf("expected full remote body, got %q", out)
+	}
+}
+
+// TestOpenFile_CorpusFS_PDFReturnsOCRMarkdown verifies that open_file on a
+// binary document (PDF) with no span reads the local OCR cache keyed by the
+// sha256 of the object's bytes, where those bytes are hashed by STREAMING them
+// through the CorpusFS Open seam (not os.Open of a local path). This is the
+// OCR/transcript read path that was silently broken on S3 (#432): os.Stat of the
+// non-existent local path failed before the (present) cache could be consulted.
+func TestOpenFile_CorpusFS_PDFReturnsOCRMarkdown(t *testing.T) {
+	root := t.TempDir()
+	stateDir := filepath.Join(root, ".dir2mcp")
+
+	pdfBytes := []byte("%PDF-1.4\r%\xe2\xe3\xcf\xd3\r\n1 0 obj<</Type/Catalog>>endobj\n%%EOF")
+	fs := &fakeCorpusFS{objects: map[string][]byte{"docs/remote.pdf": pdfBytes}}
+
+	ocrText := "# Remote OCR\n\nARRANGEMENT OF SECTIONS\n\n1. Short title."
+	cacheDir := filepath.Join(stateDir, "cache", "ocr")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatalf("mkdir ocr cache: %v", err)
+	}
+	sum := sha256.Sum256(pdfBytes)
+	cachePath := filepath.Join(cacheDir, hex.EncodeToString(sum[:])+".md")
+	if err := os.WriteFile(cachePath, []byte(ocrText), 0o644); err != nil {
+		t.Fatalf("write ocr cache: %v", err)
+	}
+
+	svc := retrieval.NewService(nil, nil, nil, nil)
+	svc.SetRootDir(root)
+	svc.SetStateDir(stateDir)
+	svc.SetCorpusFS(fs)
+
+	out, err := svc.OpenFile(context.Background(), "docs/remote.pdf", model.Span{}, 20000)
+	if err != nil {
+		t.Fatalf("OpenFile no-span on remote pdf returned err: %v", err)
+	}
+	if strings.HasPrefix(out, "%PDF") {
+		t.Fatalf("expected OCR markdown, got raw PDF bytes: %q", out[:min(80, len(out))])
+	}
+	if !strings.Contains(out, "ARRANGEMENT OF SECTIONS") {
+		t.Fatalf("expected OCR markdown content, got %q", out)
+	}
+}
+
+// TestOpenFile_CorpusFS_PDFNoCacheReturnsOCRNotReady verifies that when the OCR
+// cache has not been written yet (ingest still running), the CorpusFS read path
+// preserves the retryable ErrOCRNotReady contract rather than leaking a
+// backend read error.
+func TestOpenFile_CorpusFS_PDFNoCacheReturnsOCRNotReady(t *testing.T) {
+	root := t.TempDir()
+	stateDir := filepath.Join(root, ".dir2mcp")
+
+	pdfBytes := []byte("%PDF-1.4 no-cache")
+	fs := &fakeCorpusFS{objects: map[string][]byte{"docs/pending.pdf": pdfBytes}}
+
+	svc := retrieval.NewService(nil, nil, nil, nil)
+	svc.SetRootDir(root)
+	svc.SetStateDir(stateDir)
+	svc.SetCorpusFS(fs)
+
+	_, err := svc.OpenFile(context.Background(), "docs/pending.pdf", model.Span{}, 200)
+	if !errors.Is(err, model.ErrOCRNotReady) {
+		t.Fatalf("expected ErrOCRNotReady, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

`source.kind=s3` is a shipped feature, but the retrieval surface was never taught about `corpusfs`. `open_file`'s raw-text and OCR/transcript read paths resolved against the **local** filesystem (`os.Stat`/`os.Open` + `EvalSymlinks` on a `RootDir`-relative path), while for an S3 corpus `RootDir` is left at `"."` and the source bytes live remotely. Result on an S3-ingested corpus:

- `open_file` on a **text** doc → `os.Open(filepath.Join(".", rel))` → not-found.
- `open_file` on a **PDF/image/audio** with no span (the OCR/transcript text path) → `os.Stat` fails **before** the local OCR cache (which *does* exist) is consulted.

Only metadata-served `page=`/`time=` spans and search/ask citations worked (they never touch the FS), so the release-smoke gate's `open_file page=1` passed while text/OCR `open_file` was silently broken (issue #432, part 1).

## Fix

Route retrieval reads through the `CorpusFS` `Open` seam — the same abstraction the media/embedding paths use:

- Add `Service.corpusFS` + `SetCorpusFS`. **nil (local/NFS) preserves the historical local read path byte-for-byte** — resolved-path, symlink containment, and directory-target guard. When set (object stores) reads route through `CorpusFS.Open`.
- `readSourceBytes` / `hashSourceBytes` stream the object's bytes through the backend for raw-text reads and for the sha256 that keys the **local** OCR/transcript cache, so a remote source is hashed without a local copy. The cache itself is always local under the state dir and read directly regardless of backend.
- Skip local symlink resolution when a backend is injected (containment is the CorpusFS's job against the rel path; traversal/absolute/excluded rel paths are already rejected upstream for both backends).
- Wire the S3 backend into the retrieval service in `up` (daemon) and the `ask` CLI, **gated to remote sources** so local/NFS behavior is untouched.

## Contract preserved

Span kinds, `DOC_TYPE_UNSUPPORTED` for directory targets, and the retryable `OCR_NOT_READY` when the cache is not yet written are all unchanged.

## Scope

Addresses **part 1 (HIGH)** of #432 — the broken retrieval read path. Parts 2-4 (gitignore no-op on S3 discovery, nil Content-Length streaming fallback, region/endpoint validation) are ingest/discovery-side concerns and are out of scope for this retrieval-focused PR.

## Tests

New `tests/retrieval/open_file_corpusfs_test.go`: `open_file` over a CorpusFS-abstracted source (in-memory fake, **no local source file present**) returns content for text, returns OCR markdown for a PDF (bytes hashed via the backend to key the local cache), and preserves `ErrOCRNotReady` when the cache is absent.

`make check` passes (gofmt/vet/golangci-lint v2.10.1 `0 issues`/gocyclo ≤15/misspell/ineffassign). The full `go test ./...` is green; two unrelated `up`-command tests flaked on `initialize metadata store: context deadline exceeded` under full-suite parallel load and pass in isolation.

Addresses #432 (part only; remainder tracked in #487)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Routes `open_file` raw-text and OCR/transcript reads through `CorpusFS.Open` for object-store (S3) corpora, fixing a silent broken path where retrieval tried to `os.Open` a local path that doesn't exist for remotely-stored documents.

- Adds `Service.corpusFS` field + `SetCorpusFS`; nil preserves the historical local-FS path (symlink resolution + containment) byte-for-byte, so local and NFS corpora are unaffected.
- Extracts `readSourceBytes` / `hashSourceBytes` helpers that dispatch on the nil/set corpusFS — the CorpusFS path streams the object for both raw-text reads and the sha256 that keys the local OCR/transcript cache.
- Wires the S3 backend into both the `up` daemon (fatal on failure) and the `ask` CLI (non-fatal, emits a structured warning), gated to `sourceIsRemote` so the local read path is never changed.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is narrowly scoped to the S3 read path, the nil-corpusFS guard keeps every existing local/NFS code path unchanged, and three dedicated tests exercise each branch without requiring a local source file.

The change introduces two new code branches (CorpusFS and local) and both are exercised by the new test suite. The local fallback path is mechanically identical to the code it replaced — same stat, same dir guard, same readFileBounded(0) — so regressions on existing deployments are not plausible. The previously noted concerns (non-fatal app.go failure and per-call S3 download for hash computation) are already tracked in prior review threads and do not affect correctness for the cases this PR targets.

No files require special attention beyond what is already in prior review threads.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/retrieval/service.go | Core of the fix: adds corpusFS field + SetCorpusFS, splits OCR-hash and raw-read helpers into readSourceBytes/hashSourceBytes that dispatch on nil-vs-set corpusFS, updates openFileFromOCRCache and openFileFromResolvedPath signatures. Local-FS path is preserved byte-for-byte when corpusFS is nil. |
| internal/cli/up.go | Adds sourceIsRemote helper and wires ret.SetCorpusFS after corpusFS is built (fatal on failure); guard keeps local/NFS corpora on the historical read path. |
| internal/cli/app.go | Wires corpusFS into the ask CLI retriever non-fatally; buildCorpusFS failure emits a structured warning but leaves corpusFS nil on the service so text/OCR open_file still fails silently on that corpus — intentional degradation already flagged in prior review thread. |
| tests/retrieval/open_file_corpusfs_test.go | Three focused tests (text, PDF OCR hit, PDF OCR miss) using an in-memory fakeCorpusFS with no local source file; verifies each code path introduced by the fix. Follows existing test conventions under tests/. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[openFile called] --> B{span kind?}
    B -- page/time --> C[openFileFromMetadata\nreturns span slice]
    B -- lines/empty --> D{isBinaryDocType?}
    D -- yes --> E[openFileFromOCRCache]
    D -- no --> F[openFileFromResolvedPath]

    E --> G[hashSourceBytes]
    G --> H{corpusFS nil?}
    H -- nil --> I[os.Stat + os.Open\nlocal resolvedAbs]
    H -- set --> J[corpusFS.Open relPath\nstream sha256]
    I --> K[sha256 hash]
    J --> K
    K --> L[read local OCR cache\ncache/ocr/HASH.md]
    L --> M{cache hit?}
    M -- yes --> N[return OCR markdown]
    M -- no --> O[return ErrOCRNotReady]

    F --> P[readSourceBytes]
    P --> Q{corpusFS nil?}
    Q -- nil --> R[os.Stat + readFileBounded\nlocal resolvedAbs]
    Q -- set --> S[corpusFS.Open relPath\nio.ReadAll]
    R --> T[slice/truncate → return content]
    S --> T
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[openFile called] --> B{span kind?}
    B -- page/time --> C[openFileFromMetadata\nreturns span slice]
    B -- lines/empty --> D{isBinaryDocType?}
    D -- yes --> E[openFileFromOCRCache]
    D -- no --> F[openFileFromResolvedPath]

    E --> G[hashSourceBytes]
    G --> H{corpusFS nil?}
    H -- nil --> I[os.Stat + os.Open\nlocal resolvedAbs]
    H -- set --> J[corpusFS.Open relPath\nstream sha256]
    I --> K[sha256 hash]
    J --> K
    K --> L[read local OCR cache\ncache/ocr/HASH.md]
    L --> M{cache hit?}
    M -- yes --> N[return OCR markdown]
    M -- no --> O[return ErrOCRNotReady]

    F --> P[readSourceBytes]
    P --> Q{corpusFS nil?}
    Q -- nil --> R[os.Stat + readFileBounded\nlocal resolvedAbs]
    Q -- set --> S[corpusFS.Open relPath\nio.ReadAll]
    R --> T[slice/truncate → return content]
    S --> T
```

</a>

<sub>Reviews (2): Last reviewed commit: ["review: address PR #479 comments"](https://github.com/dirstral/dir2mcp/commit/5e35f159445f863559e96e149df1e6842dd41414) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41247295)</sub>

<!-- /greptile_comment -->