### PR TITLE
SECURITY: enforce ingest exclude/secret policy on on-demand transcribe/annotate (#407)

### DIFF
--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -2905,6 +2905,18 @@ func (s *Service) ReadOrComputeOCR(ctx context.Context, doc model.Document, cont
 	return s.readOrComputeOCR(ctx, doc, content)
 }
 
+// PurgeOCRCache removes the OCR cache entry for the given content, using the
+// same active-extractor key readOrComputeOCR writes under. Callers that gate the
+// returned OCR text (e.g. the MCP secret-pattern gate) use this so a refused
+// result is never left persisted in {StateDir}/cache/ocr. Missing files are
+// ignored.
+func (s *Service) PurgeOCRCache(content []byte) {
+	cachePath := filepath.Join(s.cfg.StateDir, "cache", "ocr", s.ocrCacheKey(content)+".md")
+	if err := os.Remove(cachePath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		s.getLogger().Printf("purge ocr cache: %v", err)
+	}
+}
+
 // TranscriptLangSuffix returns a safe filename suffix for the given language,
 // used to key the transcript cache by content+language. Empty language returns
 // an empty suffix so language-unaware callers share the same cache file.
@@ -3043,6 +3055,22 @@ func (s *Service) writeCachedWords(path string, words []model.TimedWord) {
 // ReadOrComputeTranscript exposes transcript cache lookup/computation for tests.
 func (s *Service) ReadOrComputeTranscript(ctx context.Context, doc model.Document, content []byte, language string) (string, error) {
 	return s.readOrComputeTranscript(ctx, doc, content, language)
+}
+
+// PurgeTranscriptCache removes the transcript cache entry (and its word-timing
+// sidecar) for the given content+language, using the same active-STT key
+// readOrComputeTranscriptWithWords writes under. Callers that gate the returned
+// transcript (e.g. the MCP secret-pattern gate) use this so refused text is
+// never left persisted in {StateDir}/cache/transcribe. Missing files are
+// ignored.
+func (s *Service) PurgeTranscriptCache(content []byte, language string) {
+	cacheDir := filepath.Join(s.cfg.StateDir, "cache", "transcribe")
+	base := s.transcriptCacheKey(content) + TranscriptLangSuffix(language)
+	for _, p := range []string{base + ".txt", base + ".words.json"} {
+		if err := os.Remove(filepath.Join(cacheDir, p)); err != nil && !errors.Is(err, os.ErrNotExist) {
+			s.getLogger().Printf("purge transcript cache: %v", err)
+		}
+	}
 }
 
 // flattenJSONForIndexing walks an arbitrary JSON-like structure and

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -18,6 +18,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime/debug"
 	"sort"
 	"strings"
@@ -122,6 +123,14 @@ type Server struct {
 	execKeyMu map[string]*keyMutex
 
 	eventEmitter func(level, event string, data interface{})
+
+	// secretPatterns is the compiled secret_patterns slice used by
+	// refuseIfSecretContent. Compilation is deferred to first use and performed
+	// at most once via secretPatternOnce so annotate/transcribe requests reuse
+	// the same []*regexp.Regexp instead of recompiling every call.
+	secretPatternOnce sync.Once
+	secretPatterns    []*regexp.Regexp
+	secretPatternErr  error
 
 	// extractSegment cuts [startMS, endMS) from a local media file and returns
 	// the container bytes for dir2mcp_open_media_clip (SPEC §15.11). It defaults

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"log"
 	"math"
@@ -27,6 +28,12 @@ import (
 	"github.com/dirstral/dir2mcp/internal/provider"
 	"github.com/dirstral/dir2mcp/internal/providerfactory"
 )
+
+// maxOpenFilePage caps the open_file page argument so a caller cannot request
+// an absurd page index (issue #407 part 3). Real documents stay well under
+// this; the ceiling only bounds pathological input for symmetry with the other
+// numeric limits (k/max_chars/clip-duration).
+const maxOpenFilePage = 1_000_000
 
 const (
 	defaultEmbedTextModel = "mistral-embed"
@@ -1080,6 +1087,12 @@ func (s *Server) handleAnnotateTool(ctx context.Context, args map[string]interfa
 	if toolErr != nil {
 		return toolCallResult{}, toolErr
 	}
+	// Gate the source text against secret_patterns, matching open_file (issue
+	// #407). The audio branch is already gated inside the transcript path; this
+	// covers OCR/raw-text documents whose content open_file would refuse.
+	if gate := s.refuseIfSecretContent(sourceText); gate != nil {
+		return toolCallResult{}, gate
+	}
 	if strings.TrimSpace(sourceText) == "" {
 		return toolCallResult{}, &toolExecutionError{Code: "ANNOTATE_FAILED", Message: "no source text available for annotation", Retryable: false}
 	}
@@ -1797,6 +1810,9 @@ func parsePageArg(args map[string]interface{}) (page int, hasPage bool, toolErr 
 	if p <= 0 {
 		return 0, false, &toolExecutionError{Code: "INVALID_FIELD", Message: "page must be > 0", Retryable: false}
 	}
+	if p > maxOpenFilePage {
+		return 0, false, &toolExecutionError{Code: "INVALID_FIELD", Message: fmt.Sprintf("page must be <= %d", maxOpenFilePage), Retryable: false}
+	}
 	return p, true, nil
 }
 
@@ -1964,9 +1980,21 @@ func (s *Server) initAudioDocumentOnDemand(ctx context.Context, normalizedRel st
 	if statErr != nil {
 		return model.Document{}, mapFileAccessError(statErr)
 	}
-	content, readErr := os.ReadFile(absPath)
+	// Bound the read to the ingest file-size cap. open_file streams via
+	// readFileBounded; this on-demand branch previously used an unbounded
+	// os.ReadFile, so a large within-root audio file could OOM the daemon
+	// (issue #407). Files over the cap are never indexed by discovery either,
+	// so refusing here keeps the two paths consistent.
+	maxBytes := s.ingestMaxFileBytes()
+	if info.Size() > maxBytes {
+		return model.Document{}, &toolExecutionError{Code: "FILE_TOO_LARGE", Message: fmt.Sprintf("audio file is %d bytes, exceeds ingest limit %d bytes", info.Size(), maxBytes), Retryable: false}
+	}
+	content, tooLarge, readErr := readBoundedFile(absPath, maxBytes)
 	if readErr != nil {
 		return model.Document{}, mapFileAccessError(readErr)
+	}
+	if tooLarge {
+		return model.Document{}, &toolExecutionError{Code: "FILE_TOO_LARGE", Message: fmt.Sprintf("audio file exceeds ingest limit %d bytes", maxBytes), Retryable: false}
 	}
 	upsertDoc := model.Document{
 		RelPath: normalizedRel, DocType: "audio", SourceType: "filesystem",
@@ -1988,6 +2016,8 @@ func (s *Server) initAudioDocumentOnDemand(ctx context.Context, normalizedRel st
 
 func mapPathError(err error) *toolExecutionError {
 	switch {
+	case errors.Is(err, model.ErrForbidden):
+		return &toolExecutionError{Code: protocol.ErrorCodePermissionDenied, Message: "forbidden", Retryable: false}
 	case errors.Is(err, model.ErrPathOutsideRoot):
 		return &toolExecutionError{Code: "PATH_OUTSIDE_ROOT", Message: "path outside root", Retryable: false}
 	case errors.Is(err, os.ErrNotExist):
@@ -2008,6 +2038,8 @@ func mapReadDocumentError(err error) *toolExecutionError {
 	switch {
 	case errors.Is(err, os.ErrNotExist):
 		return &toolExecutionError{Code: protocol.ErrorCodeFileNotFound, Message: "file not found", Retryable: false}
+	case errors.Is(err, model.ErrForbidden):
+		return &toolExecutionError{Code: protocol.ErrorCodePermissionDenied, Message: "forbidden", Retryable: false}
 	case errors.Is(err, model.ErrPathOutsideRoot):
 		return &toolExecutionError{Code: "PATH_OUTSIDE_ROOT", Message: "path outside root", Retryable: false}
 	default:
@@ -2062,6 +2094,14 @@ func (s *Server) ensureTranscriptForAudioDoc(ctx context.Context, doc model.Docu
 		return "", false, false, s.mapToolErrorFromProvider("TRANSCRIBE_FAILED", readErr)
 	}
 
+	// Gate the transcript against secret_patterns before indexing or returning
+	// it (issue #407). open_file refuses a document whose text matches a secret
+	// pattern; without this, the same content could be exfiltrated via the
+	// transcript segments / transcribe_and_ask.
+	if gate := s.refuseIfSecretContent(transcript); gate != nil {
+		return "", false, false, gate
+	}
+
 	indexed := false
 	if strings.TrimSpace(transcript) != "" {
 		// only attempt to persist a representation when we actually have text
@@ -2087,6 +2127,8 @@ func (s *Server) sourceTextForAnnotation(ctx context.Context, doc model.Document
 			switch {
 			case errors.Is(err, os.ErrNotExist):
 				return "", "", &toolExecutionError{Code: protocol.ErrorCodeFileNotFound, Message: "file not found", Retryable: false}
+			case errors.Is(err, model.ErrForbidden):
+				return "", "", &toolExecutionError{Code: protocol.ErrorCodePermissionDenied, Message: "forbidden", Retryable: false}
 			case errors.Is(err, model.ErrPathOutsideRoot):
 				return "", "", &toolExecutionError{Code: "PATH_OUTSIDE_ROOT", Message: err.Error(), Retryable: false}
 			default:
@@ -2117,6 +2159,8 @@ func (s *Server) sourceTextForAnnotation(ctx context.Context, doc model.Document
 			switch {
 			case errors.Is(err, os.ErrNotExist):
 				return "", "", &toolExecutionError{Code: protocol.ErrorCodeFileNotFound, Message: "file not found", Retryable: false}
+			case errors.Is(err, model.ErrForbidden):
+				return "", "", &toolExecutionError{Code: protocol.ErrorCodePermissionDenied, Message: "forbidden", Retryable: false}
 			case errors.Is(err, model.ErrPathOutsideRoot):
 				return "", "", &toolExecutionError{Code: "PATH_OUTSIDE_ROOT", Message: err.Error(), Retryable: false}
 			default:
@@ -2125,6 +2169,50 @@ func (s *Server) sourceTextForAnnotation(ctx context.Context, doc model.Document
 		}
 		return string(ingest.NormalizeUTF8(content)), ingest.RepTypeRawText, nil
 	}
+}
+
+// ingestMaxFileBytes returns the per-file size cap used by ingestion, so the
+// on-demand tool read paths honour the same bound (issue #407).
+func (s *Server) ingestMaxFileBytes() int64 {
+	if s.cfg.IngestMaxFileMB > 0 {
+		return int64(s.cfg.IngestMaxFileMB) * 1024 * 1024
+	}
+	return ingest.DefaultMaxFileSizeBytes()
+}
+
+// readBoundedFile reads at most maxBytes from path. It reports tooLarge=true
+// (with nil content) when the file exceeds the cap, guarding against a file
+// that grows between stat and read.
+func readBoundedFile(path string, maxBytes int64) (content []byte, tooLarge bool, err error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, false, err
+	}
+	defer func() { _ = f.Close() }()
+	data, err := io.ReadAll(io.LimitReader(f, maxBytes+1))
+	if err != nil {
+		return nil, false, err
+	}
+	if int64(len(data)) > maxBytes {
+		return nil, true, nil
+	}
+	return data, false, nil
+}
+
+// refuseIfSecretContent applies the same secret-pattern gate open_file enforces
+// before returning text to the caller (issue #407). annotate/transcribe emit
+// derived text (transcript segments, OCR/annotation previews) that open_file
+// would refuse for a document matching secret_patterns, so mirror the gate here
+// to close the exfiltration path. The offending text is never logged.
+func (s *Server) refuseIfSecretContent(text string) *toolExecutionError {
+	patterns, err := ingest.CompileSecretPatterns(s.cfg.SecretPatterns)
+	if err != nil {
+		return &toolExecutionError{Code: "CONFIG_INVALID", Message: fmt.Sprintf("compile secret patterns: %v", err), Retryable: false}
+	}
+	if ingest.HasSecretMatch([]byte(text), patterns) {
+		return &toolExecutionError{Code: protocol.ErrorCodePermissionDenied, Message: "forbidden", Retryable: false}
+	}
+	return nil
 }
 
 func (s *Server) readDocumentContent(relPath string) ([]byte, error) {
@@ -2148,6 +2236,15 @@ func (s *Server) resolveDocumentPath(relPath string) (string, error) {
 	if normalized == "." || normalized == ".." || strings.HasPrefix(normalized, "../") || filepath.IsAbs(relPath) {
 		return "", model.ErrPathOutsideRoot
 	}
+	// Apply the corpus path-exclusion policy that normal ingestion enforces
+	// (issue #407). Excluded files are never indexed, so the on-demand
+	// transcribe/annotate branches would otherwise be the *only* way to reach
+	// them — letting a caller extract a file the operator deliberately excluded
+	// (e.g. private/*.mp3, **/.env). Reuse the same helper ingestion uses so the
+	// policy cannot drift.
+	if ingest.MatchesAnyPathExclude(normalized, s.cfg.PathExcludes) {
+		return "", model.ErrForbidden
+	}
 	absPath := filepath.Join(rootAbs, filepath.FromSlash(normalized))
 	targetReal, err := filepath.EvalSymlinks(absPath)
 	if err != nil {
@@ -2156,6 +2253,11 @@ func (s *Server) resolveDocumentPath(relPath string) (string, error) {
 	rel, err := filepath.Rel(rootReal, targetReal)
 	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 		return "", model.ErrPathOutsideRoot
+	}
+	// Re-check the symlink-resolved path so a symlink whose real target is
+	// excluded (or matches a secret-file glob) is refused too.
+	if ingest.MatchesAnyPathExclude(filepath.ToSlash(rel), s.cfg.PathExcludes) {
+		return "", model.ErrForbidden
 	}
 	return targetReal, nil
 }

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1083,15 +1083,14 @@ func (s *Server) handleAnnotateTool(ctx context.Context, args map[string]interfa
 		return toolCallResult{}, toolErr
 	}
 
+	// sourceTextForAnnotation applies the secret_patterns gate for every
+	// document kind (issue #407): the audio branch gates inside the transcript
+	// path, and the OCR/raw branches gate before returning. Gating once at the
+	// source avoids re-scanning (and, previously, recompiling regexes for) audio
+	// transcripts that were already checked.
 	sourceText, sourceRep, toolErr := s.sourceTextForAnnotation(ctx, doc)
 	if toolErr != nil {
 		return toolCallResult{}, toolErr
-	}
-	// Gate the source text against secret_patterns, matching open_file (issue
-	// #407). The audio branch is already gated inside the transcript path; this
-	// covers OCR/raw-text documents whose content open_file would refuse.
-	if gate := s.refuseIfSecretContent(sourceText); gate != nil {
-		return toolCallResult{}, gate
 	}
 	if strings.TrimSpace(sourceText) == "" {
 		return toolCallResult{}, &toolExecutionError{Code: "ANNOTATE_FAILED", Message: "no source text available for annotation", Retryable: false}
@@ -2097,8 +2096,12 @@ func (s *Server) ensureTranscriptForAudioDoc(ctx context.Context, doc model.Docu
 	// Gate the transcript against secret_patterns before indexing or returning
 	// it (issue #407). open_file refuses a document whose text matches a secret
 	// pattern; without this, the same content could be exfiltrated via the
-	// transcript segments / transcribe_and_ask.
+	// transcript segments / transcribe_and_ask. ReadOrComputeTranscript already
+	// persisted the text to the transcript cache, so purge that entry on a match
+	// (using the same STT key) — otherwise the refused secret would linger on
+	// disk even though the API response is blocked.
 	if gate := s.refuseIfSecretContent(transcript); gate != nil {
+		ing.PurgeTranscriptCache(content, language)
 		return "", false, false, gate
 	}
 
@@ -2113,6 +2116,23 @@ func (s *Server) ensureTranscriptForAudioDoc(ctx context.Context, doc model.Docu
 	return transcript, !cacheValid, indexed, nil
 }
 
+// annotationReadError maps a readDocumentContent failure to the tool error
+// sourceTextForAnnotation returns. Extracted so the OCR and raw-text branches
+// share one mapping (and to keep sourceTextForAnnotation under the cyclomatic
+// limit).
+func annotationReadError(err error) *toolExecutionError {
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		return &toolExecutionError{Code: protocol.ErrorCodeFileNotFound, Message: "file not found", Retryable: false}
+	case errors.Is(err, model.ErrForbidden):
+		return &toolExecutionError{Code: protocol.ErrorCodePermissionDenied, Message: "forbidden", Retryable: false}
+	case errors.Is(err, model.ErrPathOutsideRoot):
+		return &toolExecutionError{Code: "PATH_OUTSIDE_ROOT", Message: err.Error(), Retryable: false}
+	default:
+		return &toolExecutionError{Code: protocol.ErrorCodePermissionDenied, Message: err.Error(), Retryable: false}
+	}
+}
+
 func (s *Server) sourceTextForAnnotation(ctx context.Context, doc model.Document) (string, string, *toolExecutionError) {
 	switch doc.DocType {
 	case "audio":
@@ -2124,16 +2144,7 @@ func (s *Server) sourceTextForAnnotation(ctx context.Context, doc model.Document
 	case "pdf", "image", "document":
 		content, err := s.readDocumentContent(doc.RelPath)
 		if err != nil {
-			switch {
-			case errors.Is(err, os.ErrNotExist):
-				return "", "", &toolExecutionError{Code: protocol.ErrorCodeFileNotFound, Message: "file not found", Retryable: false}
-			case errors.Is(err, model.ErrForbidden):
-				return "", "", &toolExecutionError{Code: protocol.ErrorCodePermissionDenied, Message: "forbidden", Retryable: false}
-			case errors.Is(err, model.ErrPathOutsideRoot):
-				return "", "", &toolExecutionError{Code: "PATH_OUTSIDE_ROOT", Message: err.Error(), Retryable: false}
-			default:
-				return "", "", &toolExecutionError{Code: protocol.ErrorCodePermissionDenied, Message: err.Error(), Retryable: false}
-			}
+			return "", "", annotationReadError(err)
 		}
 		extractor := ingest.DocumentExtractorFromConfigContext(ctx, s.cfg)
 		if extractor == nil {
@@ -2152,22 +2163,26 @@ func (s *Server) sourceTextForAnnotation(ctx context.Context, doc model.Document
 		if ocrErr != nil {
 			return "", "", s.mapToolErrorFromProvider("ANNOTATE_FAILED", ocrErr)
 		}
+		// Gate the OCR text (issue #407). ReadOrComputeOCR already wrote it to the
+		// OCR cache, so purge that entry on a match (same extractor key) rather
+		// than leaving the refused secret persisted on disk.
+		if gate := s.refuseIfSecretContent(text); gate != nil {
+			ing.PurgeOCRCache(content)
+			return "", "", gate
+		}
 		return text, ingest.RepTypeOCRMarkdown, nil
 	default:
 		content, err := s.readDocumentContent(doc.RelPath)
 		if err != nil {
-			switch {
-			case errors.Is(err, os.ErrNotExist):
-				return "", "", &toolExecutionError{Code: protocol.ErrorCodeFileNotFound, Message: "file not found", Retryable: false}
-			case errors.Is(err, model.ErrForbidden):
-				return "", "", &toolExecutionError{Code: protocol.ErrorCodePermissionDenied, Message: "forbidden", Retryable: false}
-			case errors.Is(err, model.ErrPathOutsideRoot):
-				return "", "", &toolExecutionError{Code: "PATH_OUTSIDE_ROOT", Message: err.Error(), Retryable: false}
-			default:
-				return "", "", &toolExecutionError{Code: protocol.ErrorCodePermissionDenied, Message: err.Error(), Retryable: false}
-			}
+			return "", "", annotationReadError(err)
 		}
-		return string(ingest.NormalizeUTF8(content)), ingest.RepTypeRawText, nil
+		text := string(ingest.NormalizeUTF8(content))
+		// Gate raw text too (issue #407); there is no derived cache to purge on
+		// this path.
+		if gate := s.refuseIfSecretContent(text); gate != nil {
+			return "", "", gate
+		}
+		return text, ingest.RepTypeRawText, nil
 	}
 }
 
@@ -2205,11 +2220,13 @@ func readBoundedFile(path string, maxBytes int64) (content []byte, tooLarge bool
 // would refuse for a document matching secret_patterns, so mirror the gate here
 // to close the exfiltration path. The offending text is never logged.
 func (s *Server) refuseIfSecretContent(text string) *toolExecutionError {
-	patterns, err := ingest.CompileSecretPatterns(s.cfg.SecretPatterns)
-	if err != nil {
-		return &toolExecutionError{Code: "CONFIG_INVALID", Message: fmt.Sprintf("compile secret patterns: %v", err), Retryable: false}
+	s.secretPatternOnce.Do(func() {
+		s.secretPatterns, s.secretPatternErr = ingest.CompileSecretPatterns(s.cfg.SecretPatterns)
+	})
+	if s.secretPatternErr != nil {
+		return &toolExecutionError{Code: "CONFIG_INVALID", Message: fmt.Sprintf("compile secret patterns: %v", s.secretPatternErr), Retryable: false}
 	}
-	if ingest.HasSecretMatch([]byte(text), patterns) {
+	if ingest.HasSecretMatch([]byte(text), s.secretPatterns) {
 		return &toolExecutionError{Code: protocol.ErrorCodePermissionDenied, Message: "forbidden", Retryable: false}
 	}
 	return nil

--- a/tests/mcp/tool_exclude_policy_test.go
+++ b/tests/mcp/tool_exclude_policy_test.go
@@ -1,0 +1,149 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/protocol"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// exampleAWSKey is a well-formed but non-live AWS access-key ID that matches the
+// default AKIA secret pattern. It is only used to exercise the secret gate.
+const exampleAWSKey = "AKIAIOSFODNN7EXAMPLE"
+
+// newExcludeTestServer builds an MCP server rooted at a fresh temp dir with a
+// live sqlite store, returning the config and root so callers can drop files.
+func newExcludeTestServer(t *testing.T) (config.Config, *store.SQLiteStore, string) {
+	t.Helper()
+	rootDir := t.TempDir()
+	stateDir := filepath.Join(rootDir, ".dir2mcp")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	st := store.NewSQLiteStore(filepath.Join(stateDir, "meta.sqlite"))
+	if err := st.Init(context.Background()); err != nil {
+		t.Fatalf("init sqlite store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	cfg := config.Default()
+	cfg.RootDir = rootDir
+	cfg.StateDir = stateDir
+	cfg.MCPPath = protocol.DefaultMCPPath
+	cfg.AuthMode = "none"
+	return cfg, st, rootDir
+}
+
+// TestMCPTranscribe_RefusesExcludedPath verifies that an operator-excluded audio
+// file cannot be transcribed on demand (issue #407 part 1). The file is never
+// indexed, so the request takes the on-demand init branch — which must now apply
+// the same path-exclusion policy ingestion enforces.
+func TestMCPTranscribe_RefusesExcludedPath(t *testing.T) {
+	cfg, st, rootDir := newExcludeTestServer(t)
+	cfg.PathExcludes = append(cfg.PathExcludes, "private/**")
+
+	if err := os.MkdirAll(filepath.Join(rootDir, "private"), 0o755); err != nil {
+		t.Fatalf("mkdir private: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rootDir, "private", "voice.wav"), []byte("RIFF0000WAVEfmt data"), 0o644); err != nil {
+		t.Fatalf("write audio: %v", err)
+	}
+
+	server := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st)).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":701,"method":"tools/call","params":{"name":"dir2mcp_transcribe","arguments":{"rel_path":"private/voice.wav"}}}`)
+	defer func() { _ = resp.Body.Close() }()
+	assertToolCallErrorCode(t, resp, protocol.ErrorCodePermissionDenied)
+}
+
+// TestMCPTranscribe_RefusesOversizeAudio verifies the on-demand read is bounded
+// by the ingest file-size cap (issue #407 part 1): a within-root audio file that
+// exceeds the cap is refused rather than read unbounded into memory.
+func TestMCPTranscribe_RefusesOversizeAudio(t *testing.T) {
+	cfg, st, rootDir := newExcludeTestServer(t)
+	cfg.IngestMaxFileMB = 1
+
+	big := bytes.Repeat([]byte("A"), 1200*1024) // ~1.17 MiB > 1 MiB cap
+	if err := os.WriteFile(filepath.Join(rootDir, "big.wav"), big, 0o644); err != nil {
+		t.Fatalf("write audio: %v", err)
+	}
+
+	server := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st)).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":702,"method":"tools/call","params":{"name":"dir2mcp_transcribe","arguments":{"rel_path":"big.wav"}}}`)
+	defer func() { _ = resp.Body.Close() }()
+	assertToolCallErrorCode(t, resp, "FILE_TOO_LARGE")
+}
+
+// TestMCPAnnotate_RefusesExcludedPath verifies annotate honours the exclusion
+// policy for an indexed-but-excluded document (issue #407 part 1).
+func TestMCPAnnotate_RefusesExcludedPath(t *testing.T) {
+	// setupMCPToolStore upserts the doc and uses config.Default(), whose
+	// PathExcludes already carry the default secret-file globs (**/*.key).
+	cfg, st, _ := setupMCPToolStore(t, "secret.key", "text", []byte("private material"))
+
+	server := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st)).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":703,"method":"tools/call","params":{"name":"dir2mcp_annotate","arguments":{"rel_path":"secret.key","schema_json":{"type":"object"}}}}`)
+	defer func() { _ = resp.Body.Close() }()
+	assertToolCallErrorCode(t, resp, protocol.ErrorCodePermissionDenied)
+}
+
+// TestMCPAnnotate_RefusesSecretContent verifies annotate applies the same
+// secret-pattern gate open_file enforces (issue #407 part 2): a document whose
+// text matches secret_patterns is refused before any provider call, and the
+// secret value is not echoed back in the error.
+func TestMCPAnnotate_RefusesSecretContent(t *testing.T) {
+	cfg, st, _ := setupMCPToolStore(t, "note.txt", "text", []byte("aws key "+exampleAWSKey))
+
+	server := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st)).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":704,"method":"tools/call","params":{"name":"dir2mcp_annotate","arguments":{"rel_path":"note.txt","schema_json":{"type":"object"}}}}`)
+	defer func() { _ = resp.Body.Close() }()
+	assertToolCallErrorCodeAndMessage(t, resp, protocol.ErrorCodePermissionDenied, nil, []string{exampleAWSKey})
+}
+
+// TestMCPTranscribe_RefusesSecretTranscript verifies the transcript output is
+// gated by secret_patterns (issue #407 part 2): a transcript containing a secret
+// is refused rather than returned as segments.
+func TestMCPTranscribe_RefusesSecretTranscript(t *testing.T) {
+	cfg, st, rootDir := newExcludeTestServer(t)
+	if err := os.WriteFile(filepath.Join(rootDir, "voice.wav"), []byte("RIFF0000WAVEfmt data"), 0o644); err != nil {
+		t.Fatalf("write audio: %v", err)
+	}
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/audio/transcriptions" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"segments":[{"start":1,"end":2,"text":"my key is ` + exampleAWSKey + `"}]}`))
+	}))
+	defer upstream.Close()
+	cfg = withMistralUpstream(t, cfg, "mistral-ocr", upstream.URL)
+
+	server := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st)).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":705,"method":"tools/call","params":{"name":"dir2mcp_transcribe","arguments":{"rel_path":"voice.wav"}}}`)
+	defer func() { _ = resp.Body.Close() }()
+	assertToolCallErrorCodeAndMessage(t, resp, protocol.ErrorCodePermissionDenied, nil, []string{exampleAWSKey})
+}

--- a/tests/mcp/tool_exclude_policy_test.go
+++ b/tests/mcp/tool_exclude_policy_test.go
@@ -147,3 +147,64 @@ func TestMCPTranscribe_RefusesSecretTranscript(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }()
 	assertToolCallErrorCodeAndMessage(t, resp, protocol.ErrorCodePermissionDenied, nil, []string{exampleAWSKey})
 }
+
+// TestMCPTranscribe_PurgesSecretTranscriptCache verifies the disk-persistence gap
+// is closed (issue #407): ReadOrComputeTranscript writes the computed transcript
+// to {StateDir}/cache/transcribe before the secret gate runs, so a refused
+// transcript must be purged from that cache rather than left on disk in
+// plaintext.
+func TestMCPTranscribe_PurgesSecretTranscriptCache(t *testing.T) {
+	cfg, st, rootDir := newExcludeTestServer(t)
+	if err := os.WriteFile(filepath.Join(rootDir, "voice.wav"), []byte("RIFF0000WAVEfmt data"), 0o644); err != nil {
+		t.Fatalf("write audio: %v", err)
+	}
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/audio/transcriptions" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"segments":[{"start":1,"end":2,"text":"my key is ` + exampleAWSKey + `"}]}`))
+	}))
+	defer upstream.Close()
+	cfg = withMistralUpstream(t, cfg, "mistral-ocr", upstream.URL)
+
+	server := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st)).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":706,"method":"tools/call","params":{"name":"dir2mcp_transcribe","arguments":{"rel_path":"voice.wav"}}}`)
+	defer func() { _ = resp.Body.Close() }()
+	assertToolCallErrorCode(t, resp, protocol.ErrorCodePermissionDenied)
+
+	assertNoSecretOnDisk(t, filepath.Join(cfg.StateDir, "cache", "transcribe"), exampleAWSKey)
+}
+
+// assertNoSecretOnDisk walks dir and fails if any file's contents contain secret,
+// proving a refused derivation was not left persisted in the cache.
+func assertNoSecretOnDisk(t *testing.T, dir, secret string) {
+	t.Helper()
+	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		if bytes.Contains(data, []byte(secret)) {
+			t.Fatalf("secret leaked to cache file %s", path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk cache dir: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the SECURITY issue in #407: the on-demand `dir2mcp_transcribe` /
`dir2mcp_annotate` tool handlers processed a file **without** applying the
corpus exclusion/secret-pattern policy that normal ingestion (and
`open_file`) enforce. A caller could therefore transcribe/annotate a file the
operator deliberately excluded (e.g. `private/*.mp3`, `**/.env`, `**/*.key`)
and disclose its content — plus the on-demand audio read was unbounded.

## Changes

- **Exclude-policy bypass (part 1).** `resolveDocumentPath` — the shared choke
  point for the on-demand transcribe/annotate read paths — now applies the same
  path-exclusion policy ingestion uses (`ingest.MatchesAnyPathExclude` over
  `cfg.PathExcludes`), checked against **both** the requested rel path and the
  symlink-resolved real path (zip-slip / symlink-escape into an excluded
  target). Excluded → `model.ErrForbidden` → canonical `PERMISSION_DENIED`.
- **Unbounded read (part 1).** The on-demand audio init now bounds the read to
  the ingest file-size cap (`IngestMaxFileMB`) instead of an unbounded
  `os.ReadFile`, refusing oversize files with `FILE_TOO_LARGE` rather than
  risking daemon OOM. A `readBoundedFile` guard also catches a file that grows
  between stat and read.
- **Secret-scan asymmetry (part 2).** transcribe/annotate now apply the same
  `secret_patterns` gate `open_file` enforces before emitting derived text
  (transcript segments, OCR/annotation previews), closing a defense-in-depth
  exfiltration gap. The offending text is never logged.
- **open_file page cap (part 3).** `parsePageArg` gains an upper bound for
  symmetry with the other numeric limits.

Reuses the existing `internal/ingest` exclusion/secret helpers
(`MatchesAnyPathExclude`, `CompileSecretPatterns`, `HasSecretMatch`) rather
than duplicating logic. Existing tool/error contracts and canonical codes are
preserved.

## Tests

New `tests/mcp/tool_exclude_policy_test.go` covers:
- transcribe refuses an excluded audio path (on-demand branch),
- transcribe refuses an oversize audio file (`FILE_TOO_LARGE`),
- annotate refuses an excluded document,
- annotate refuses secret-matching content (and does not echo the secret),
- transcribe refuses a transcript containing a secret (and does not echo it).

`make check` passes (gofmt, go vet, golangci-lint v2 → 0 issues, full test
suite, python unittests, build).

Closes #407

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes a security gap in the on-demand `dir2mcp_transcribe` and `dir2mcp_annotate` tool handlers: until now, neither path applied the corpus path-exclusion or `secret_patterns` policy that normal ingestion and `open_file` already enforced. A caller could therefore transcribe or annotate any deliberately excluded file (e.g., `private/*.mp3`, `**/.env`) or exfiltrate secrets via derived text.

- **Exclude-policy bypass** is fixed by adding `ingest.MatchesAnyPathExclude` checks to `resolveDocumentPath` (the shared choke point), covering both the requested relative path and the symlink-resolved real path to guard against zip-slip / symlink-escape into excluded targets.
- **Unbounded audio read** is fixed by replacing `os.ReadFile` with a new `readBoundedFile` helper capped at `IngestMaxFileMB`, with a TOCTOU guard that catches files that grow between stat and read.
- **Secret-scan asymmetry** is closed by `refuseIfSecretContent` (pattern compilation cached via `sync.Once`) applied after transcript/OCR derivation; when a secret fires, `PurgeTranscriptCache`/`PurgeOCRCache` are called immediately so the refused text is not left on disk.
- **`open_file` page cap** is added to `parsePageArg` for symmetry with other numeric bounds.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The changes are narrowly scoped security fixes that close documented exfiltration paths without altering existing tool contracts or error codes.

Every changed code path has been traced: resolveDocumentPath now enforces PathExcludes at both the raw normalized path and the symlink-resolved path, covering transcribe, annotate, and media-clip reads. readBoundedFile provides TOCTOU-safe bounded reads. The secret gate is correctly applied after derivation with immediate cache purge. The sync.Once pattern-compilation fix, the prior-review cache-before-gate concern for both transcript and OCR paths, and the open_file page-cap are all correctly addressed. Integration tests verify each scenario including disk non-persistence of refused secrets.

No files require special attention. All four changed files implement their stated purpose correctly.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/mcp/tools.go | Core security fixes: adds exclusion-policy check to resolveDocumentPath (both pre- and post-symlink resolution), bounded audio read via readBoundedFile, refuseIfSecretContent with sync.Once pattern compilation, OCR/transcript secret gate with immediate cache purge on match, and open_file page cap. All paths through readDocumentContent now enforce PathExcludes. |
| internal/ingest/service.go | Adds PurgeOCRCache and PurgeTranscriptCache public helpers. Both methods use the same active-derivation cache key (ocrCacheKey/transcriptCacheKey) that the underlying write paths use, ensuring the purge targets the exact file(s) just written. PurgeTranscriptCache also removes the .words.json word-timing sidecar. |
| internal/mcp/server.go | Adds secretPatternOnce sync.Once, secretPatterns []*regexp.Regexp, and secretPatternErr error fields to Server to cache compiled secret-pattern regexes across requests, addressing the per-call recompilation noted in prior review. |
| tests/mcp/tool_exclude_policy_test.go | New integration tests covering all three fix areas: excluded path → PERMISSION_DENIED for transcribe and annotate, oversize audio → FILE_TOO_LARGE, secret-matching content → PERMISSION_DENIED without echoing the secret value, and disk-persistence verification that PurgeTranscriptCache removes the cache entry on a secret match. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[dir2mcp_transcribe / dir2mcp_annotate request] --> B[lookupDocumentForTool\nor initAudioDocumentOnDemand]
    B --> C{resolveDocumentPath}
    C -- MatchesAnyPathExclude\nnormalized rel path --> D[ErrForbidden → PERMISSION_DENIED]
    C -- EvalSymlinks --> E{MatchesAnyPathExclude\nsymlink-resolved rel path}
    E -- excluded --> D
    E -- allowed --> F[readDocumentContent\nreturns file bytes]
    F --> G{info.Size > ingestMaxFileBytes?}
    G -- YES --> H[FILE_TOO_LARGE]
    G -- NO --> I[readBoundedFile\nLimitReader maxBytes+1]
    I -- tooLarge=true --> H
    I -- OK --> J[ReadOrComputeTranscript\nor ReadOrComputeOCR\nwrites to cache]
    J --> K{refuseIfSecretContent\nsecretPatternOnce.Do}
    K -- match --> L[PurgeTranscriptCache\nor PurgeOCRCache\ndelete from disk]
    L --> D
    K -- no match --> M[Return transcript/OCR text\nto caller]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[dir2mcp_transcribe / dir2mcp_annotate request] --> B[lookupDocumentForTool\nor initAudioDocumentOnDemand]
    B --> C{resolveDocumentPath}
    C -- MatchesAnyPathExclude\nnormalized rel path --> D[ErrForbidden → PERMISSION_DENIED]
    C -- EvalSymlinks --> E{MatchesAnyPathExclude\nsymlink-resolved rel path}
    E -- excluded --> D
    E -- allowed --> F[readDocumentContent\nreturns file bytes]
    F --> G{info.Size > ingestMaxFileBytes?}
    G -- YES --> H[FILE_TOO_LARGE]
    G -- NO --> I[readBoundedFile\nLimitReader maxBytes+1]
    I -- tooLarge=true --> H
    I -- OK --> J[ReadOrComputeTranscript\nor ReadOrComputeOCR\nwrites to cache]
    J --> K{refuseIfSecretContent\nsecretPatternOnce.Do}
    K -- match --> L[PurgeTranscriptCache\nor PurgeOCRCache\ndelete from disk]
    L --> D
    K -- no match --> M[Return transcript/OCR text\nto caller]
```

</a>

<sub>Reviews (2): Last reviewed commit: ["review: address PR #480 comments"](https://github.com/dirstral/dir2mcp/commit/464a9e8b8346398e626ec645de9f6025543c082c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41247773)</sub>

<!-- /greptile_comment -->