### PR TITLE
security(cli): redact support-bundle server.log + gate corpus content (#436 S1)

### DIFF
--- a/internal/cli/support_bundle.go
+++ b/internal/cli/support_bundle.go
@@ -37,8 +37,9 @@ const supportLogTailBytes int64 = 2 * 1024 * 1024 // 2 MB
 // — the effective config snapshot only carries `secret_sources:`
 // metadata (where each credential came from), not the credentials
 // themselves; server.log and the client bridge logs are run through the
-// secret redactor; and list-files.json redacts corpus paths/titles/error
-// messages unless the operator opts in with --include-content.
+// secret redactor; and list-files.json (plus status.json's failure samples)
+// redact corpus paths/titles/error messages unless the operator opts in with
+// --include-content.
 func (a *App) runSupportBundle(ctx context.Context, global globalOptions, args []string) int {
 	fs := flag.NewFlagSet("support-bundle", flag.ContinueOnError)
 	// Route flag-parse output through writeCLIError so JSON callers get
@@ -90,9 +91,12 @@ func (a *App) runSupportBundle(ctx context.Context, global globalOptions, args [
 
 	if !global.quiet {
 		_, _ = fmt.Fprintf(a.stdout, "Wrote support bundle to %s\n", destPath)
-		for _, w := range warnings {
-			_, _ = fmt.Fprintf(a.stderr, "warning: %v\n", w)
-		}
+	}
+	// Warnings — including the --include-content privacy-consent notice — are
+	// diagnostics on stderr. --quiet suppresses non-error output, but a consent
+	// warning must never be silently dropped, so it survives quiet mode.
+	for _, w := range warnings {
+		_, _ = fmt.Fprintf(a.stderr, "warning: %v\n", w)
 	}
 	return exitSuccess
 }
@@ -137,14 +141,14 @@ func collectSupportArtifacts(ctx context.Context, a *App, cfg config.Config, inc
 	}
 	add("server.log", logBytes, logErr)
 
-	statusBytes, statusErr := marshalStatusJSON(ctx, a, cfg)
+	statusBytes, statusErr := marshalStatusJSON(ctx, a, cfg, includeContent)
 	add("status.json", statusBytes, statusErr)
 
 	listBytes, listErr := marshalListFilesJSON(ctx, a, cfg, includeContent)
 	add("list-files.json", listBytes, listErr)
 	if listErr == nil && includeContent {
 		warnings = append(warnings, errors.New(
-			"list-files.json: --include-content embedded corpus paths/titles/error messages; review the bundle before sharing it"))
+			"list-files.json/status.json: --include-content may include corpus paths/titles/error messages; review the bundle before sharing it"))
 	}
 
 	routingBytes, routingErr := marshalRoutingJSON(cfg)
@@ -208,8 +212,11 @@ func readLogTail(path string, maxBytes int64) ([]byte, error) {
 
 // marshalStatusJSON computes the same payload `dir2mcp status --json`
 // would emit. Falls back to a placeholder when no state is present so
-// the bundle still records "we tried and found nothing".
-func marshalStatusJSON(ctx context.Context, a *App, cfg config.Config) ([]byte, error) {
+// the bundle still records "we tried and found nothing". The snapshot's
+// FailureSummary.Samples carry raw {rel_path, message} pairs that can echo
+// corpus content, so they are redacted the same way list-files.json is
+// unless the operator opts in with --include-content.
+func marshalStatusJSON(ctx context.Context, a *App, cfg config.Config, includeContent bool) ([]byte, error) {
 	snapshotPath := filepath.Join(cfg.StateDir, "corpus.json")
 	snapshot, err := readCorpusSnapshot(snapshotPath)
 	source := "corpus_json"
@@ -233,11 +240,37 @@ func marshalStatusJSON(ctx context.Context, a *App, cfg config.Config) ([]byte, 
 		}
 		source = "computed"
 	}
+	snapshot.Indexing.FailureSummary = redactFailureSamples(snapshot.Indexing.FailureSummary, includeContent)
 	return json.MarshalIndent(map[string]interface{}{
 		"source":    source,
 		"state_dir": cfg.StateDir,
 		"snapshot":  snapshot,
 	}, "", "  ")
+}
+
+// redactFailureSamples returns a copy of the failure summary whose sample
+// fields are handled exactly like list-files.json: rel_path becomes an
+// extension-only placeholder and the free-text message is dropped by default,
+// while --include-content restores the raw values run through the secret
+// redactor. The Categories aggregate is a fixed error-category enum with no
+// corpus content, so it is preserved either way. A copy is returned so the
+// underlying snapshot (which may be shared with the store) is never mutated.
+func redactFailureSamples(fs *model.FailureSummary, includeContent bool) *model.FailureSummary {
+	if fs == nil {
+		return nil
+	}
+	out := &model.FailureSummary{Categories: fs.Categories}
+	if len(fs.Samples) > 0 {
+		out.Samples = make([]model.FailureSample, len(fs.Samples))
+		for i, s := range fs.Samples {
+			out.Samples[i] = model.FailureSample{
+				RelPath:  listFileRelPath(s.RelPath, includeContent),
+				Category: s.Category,
+				Message:  redactContentField(s.Message, includeContent),
+			}
+		}
+	}
+	return out
 }
 
 // supportBundleFileRow is the per-document shape emitted in the bundle's
@@ -318,10 +351,29 @@ func listFileRelPath(relPath string, includeContent bool) string {
 	if includeContent {
 		return redactBundleSecrets(relPath)
 	}
-	if ext := filepath.Ext(relPath); ext != "" {
+	if ext := redactedExtension(relPath); ext != "" {
 		return "[redacted]" + ext
 	}
 	return "[redacted]"
+}
+
+// compoundExtensions are multi-part suffixes whose full form (not just the last
+// segment filepath.Ext returns) can drive extractor/OCR routing. Preserving the
+// whole suffix keeps the routing signal — e.g. .tar.gz instead of a misleading
+// .gz — while still disclosing only the extension, never the basename.
+var compoundExtensions = []string{".tar.gz", ".tar.bz2", ".tar.xz", ".tar.zst"}
+
+// redactedExtension returns the routing-relevant extension of relPath: a known
+// compound suffix when present (case-insensitive match, original casing kept),
+// otherwise the single trailing extension from filepath.Ext.
+func redactedExtension(relPath string) string {
+	lower := strings.ToLower(relPath)
+	for _, ce := range compoundExtensions {
+		if strings.HasSuffix(lower, ce) {
+			return relPath[len(relPath)-len(ce):]
+		}
+	}
+	return filepath.Ext(relPath)
 }
 
 // redactContentField returns a corpus-content string (title, error message) for

--- a/internal/cli/support_bundle.go
+++ b/internal/cli/support_bundle.go
@@ -36,7 +36,9 @@ const supportLogTailBytes int64 = 2 * 1024 * 1024 // 2 MB
 // diagnosing install/indexing problems. No secret values are included
 // — the effective config snapshot only carries `secret_sources:`
 // metadata (where each credential came from), not the credentials
-// themselves.
+// themselves; server.log and the client bridge logs are run through the
+// secret redactor; and list-files.json redacts corpus paths/titles/error
+// messages unless the operator opts in with --include-content.
 func (a *App) runSupportBundle(ctx context.Context, global globalOptions, args []string) int {
 	fs := flag.NewFlagSet("support-bundle", flag.ContinueOnError)
 	// Route flag-parse output through writeCLIError so JSON callers get
@@ -44,6 +46,8 @@ func (a *App) runSupportBundle(ctx context.Context, global globalOptions, args [
 	// flag package's prose mixed with our JSON envelope.
 	fs.SetOutput(io.Discard)
 	output := fs.String("output", "", "destination tar.gz path (default: ./dir2mcp-support-<timestamp>.tar.gz)")
+	includeContent := fs.Bool("include-content", false,
+		"include corpus paths/titles/extraction error messages in list-files.json (may disclose corpus content — review the bundle before sharing)")
 	if err := fs.Parse(args); err != nil {
 		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("support-bundle: %v", err))
 		return exitConfigInvalid
@@ -68,7 +72,7 @@ func (a *App) runSupportBundle(ctx context.Context, global globalOptions, args [
 		destPath = filepath.Join(".", fmt.Sprintf("dir2mcp-support-%s.tar.gz", time.Now().UTC().Format("20060102-150405")))
 	}
 
-	files, warnings := collectSupportArtifacts(ctx, a, cfg)
+	files, warnings := collectSupportArtifacts(ctx, a, cfg, *includeContent)
 
 	if err := writeSupportBundle(destPath, files); err != nil {
 		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("write support bundle: %v", err))
@@ -106,7 +110,7 @@ type supportFile struct {
 // Missing or unreadable sources are recorded as warnings rather than
 // fatal errors so the bundle is always produced even when the daemon
 // is down or the index is empty.
-func collectSupportArtifacts(ctx context.Context, a *App, cfg config.Config) ([]supportFile, []error) {
+func collectSupportArtifacts(ctx context.Context, a *App, cfg config.Config, includeContent bool) ([]supportFile, []error) {
 	var files []supportFile
 	var warnings []error
 
@@ -124,14 +128,24 @@ func collectSupportArtifacts(ctx context.Context, a *App, cfg config.Config) ([]
 	cfgBytes, cfgErr := readFileBest(config.EffectiveSnapshotPath(cfg.StateDir))
 	add("config.snapshot.yaml", cfgBytes, cfgErr)
 
+	// server.log is redirected daemon stdout/stderr and can carry query text,
+	// answer snippets, and bearer tokens. Redact it exactly like the client
+	// bridge logs before it enters the shareable bundle.
 	logBytes, logErr := readLogTail(serverLogPath(cfg.StateDir), supportLogTailBytes)
+	if logErr == nil && len(logBytes) > 0 {
+		logBytes = []byte(redactBundleSecrets(string(logBytes)))
+	}
 	add("server.log", logBytes, logErr)
 
 	statusBytes, statusErr := marshalStatusJSON(ctx, a, cfg)
 	add("status.json", statusBytes, statusErr)
 
-	listBytes, listErr := marshalListFilesJSON(ctx, a, cfg)
+	listBytes, listErr := marshalListFilesJSON(ctx, a, cfg, includeContent)
 	add("list-files.json", listBytes, listErr)
+	if listErr == nil && includeContent {
+		warnings = append(warnings, errors.New(
+			"list-files.json: --include-content embedded corpus paths/titles/error messages; review the bundle before sharing it"))
+	}
 
 	routingBytes, routingErr := marshalRoutingJSON(cfg)
 	add("routing.json", routingBytes, routingErr)
@@ -242,13 +256,22 @@ type supportBundleFileRow struct {
 	Status       string `json:"status"`
 	Deleted      bool   `json:"deleted"`
 	ErrorMessage string `json:"error_message,omitempty"`
+	// HasError preserves the per-document failure signal in the default
+	// (content-excluded) bundle, where the free-text error_message — which can
+	// echo file content — is dropped. Present only when content is excluded.
+	HasError bool `json:"has_error,omitempty"`
 }
 
-// marshalListFilesJSON dumps the per-document list with extraction-error
-// messages included so maintainers can tell from the bundle alone *why*
-// a document failed, not just *that* it did. Reads directly from the
-// sqlite store so it works without the daemon running.
-func marshalListFilesJSON(ctx context.Context, a *App, cfg config.Config) ([]byte, error) {
+// marshalListFilesJSON dumps the per-document list. By default the
+// content-bearing fields — rel_path, title and the free-text extraction
+// error_message — are redacted so the bundle never discloses the full corpus
+// inventory or content fragments without the operator's explicit consent; the
+// per-document doc_type/status/size skeleton (including a has_error flag) is
+// still emitted so a maintainer can triage extraction failures. Passing
+// includeContent (the `--include-content` flag) restores the raw fields, still
+// run through the secret redactor so credentials never leak either way. Reads
+// directly from the sqlite store so it works without the daemon running.
+func marshalListFilesJSON(ctx context.Context, a *App, cfg config.Config, includeContent bool) ([]byte, error) {
 	metaPath := filepath.Join(cfg.StateDir, "meta.sqlite")
 	if _, err := os.Stat(metaPath); err != nil {
 		return json.MarshalIndent(map[string]interface{}{
@@ -268,21 +291,47 @@ func marshalListFilesJSON(ctx context.Context, a *App, cfg config.Config) ([]byt
 	rows := make([]supportBundleFileRow, 0, len(docs))
 	for _, d := range docs {
 		rows = append(rows, supportBundleFileRow{
-			RelPath:      d.RelPath,
+			RelPath:      listFileRelPath(d.RelPath, includeContent),
 			DocType:      d.DocType,
 			SourceType:   d.SourceType,
-			Title:        d.Title,
+			Title:        redactContentField(d.Title, includeContent),
 			SizeBytes:    d.SizeBytes,
 			MTimeUnix:    d.MTimeUnix,
 			Status:       d.Status,
 			Deleted:      d.Deleted,
-			ErrorMessage: d.ErrorMessage,
+			ErrorMessage: redactContentField(d.ErrorMessage, includeContent),
+			HasError:     !includeContent && d.ErrorMessage != "",
 		})
 	}
 	return json.MarshalIndent(map[string]interface{}{
-		"files": rows,
-		"total": total,
+		"content_included": includeContent,
+		"files":            rows,
+		"total":            total,
 	}, "", "  ")
+}
+
+// listFileRelPath returns the document path for the bundle. With includeContent
+// it is the raw path run through the secret redactor; otherwise the path is
+// replaced with a placeholder that keeps only the file extension (needed to
+// diagnose extractor/OCR routing) and discloses no directory names or basenames.
+func listFileRelPath(relPath string, includeContent bool) string {
+	if includeContent {
+		return redactBundleSecrets(relPath)
+	}
+	if ext := filepath.Ext(relPath); ext != "" {
+		return "[redacted]" + ext
+	}
+	return "[redacted]"
+}
+
+// redactContentField returns a corpus-content string (title, error message) for
+// the bundle: the secret-redacted value when the operator opted into content,
+// and the empty string otherwise so the field is omitted entirely.
+func redactContentField(value string, includeContent bool) string {
+	if includeContent {
+		return redactBundleSecrets(value)
+	}
+	return ""
 }
 
 // marshalRoutingJSON dumps the provider/extractor routing decisions

--- a/internal/cli/support_bundle.go
+++ b/internal/cli/support_bundle.go
@@ -146,7 +146,7 @@ func collectSupportArtifacts(ctx context.Context, a *App, cfg config.Config, inc
 
 	listBytes, listErr := marshalListFilesJSON(ctx, a, cfg, includeContent)
 	add("list-files.json", listBytes, listErr)
-	if listErr == nil && includeContent {
+	if includeContent {
 		warnings = append(warnings, errors.New(
 			"list-files.json/status.json: --include-content may include corpus paths/titles/error messages; review the bundle before sharing it"))
 	}
@@ -259,7 +259,13 @@ func redactFailureSamples(fs *model.FailureSummary, includeContent bool) *model.
 	if fs == nil {
 		return nil
 	}
-	out := &model.FailureSummary{Categories: fs.Categories}
+	out := &model.FailureSummary{}
+	if fs.Categories != nil {
+		out.Categories = make(map[string]int64, len(fs.Categories))
+		for k, v := range fs.Categories {
+			out.Categories[k] = v
+		}
+	}
 	if len(fs.Samples) > 0 {
 		out.Samples = make([]model.FailureSample, len(fs.Samples))
 		for i, s := range fs.Samples {

--- a/internal/cli/support_bundle.go
+++ b/internal/cli/support_bundle.go
@@ -48,7 +48,7 @@ func (a *App) runSupportBundle(ctx context.Context, global globalOptions, args [
 	fs.SetOutput(io.Discard)
 	output := fs.String("output", "", "destination tar.gz path (default: ./dir2mcp-support-<timestamp>.tar.gz)")
 	includeContent := fs.Bool("include-content", false,
-		"include corpus paths/titles/extraction error messages in list-files.json (may disclose corpus content — review the bundle before sharing)")
+		"include corpus paths/titles/extraction error messages in list-files.json and status.json failure samples (may disclose corpus content — review the bundle before sharing)")
 	if err := fs.Parse(args); err != nil {
 		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("support-bundle: %v", err))
 		return exitConfigInvalid
@@ -250,8 +250,9 @@ func marshalStatusJSON(ctx context.Context, a *App, cfg config.Config, includeCo
 
 // redactFailureSamples returns a copy of the failure summary whose sample
 // fields are handled exactly like list-files.json: rel_path becomes an
-// extension-only placeholder and the free-text message is dropped by default,
-// while --include-content restores the raw values run through the secret
+// extension-only placeholder and the free-text message is blanked (set to the
+// empty string, not omitted) by default, while --include-content restores the
+// raw values run through the secret
 // redactor. The Categories aggregate is a fixed error-category enum with no
 // corpus content, so it is preserved either way. A copy is returned so the
 // underlying snapshot (which may be shared with the store) is never mutated.

--- a/tests/cli/support_bundle_test.go
+++ b/tests/cli/support_bundle_test.go
@@ -83,7 +83,10 @@ func TestSupportBundle_AssemblesDiagnosticsArchive(t *testing.T) {
 // failed (status="error") but never *why* — the upstream extraction
 // error was logged to server.log only. Now the bundle carries
 // documents.error_message so maintainers can triage a failed corpus
-// from the bundle alone.
+// from the bundle alone. Because rel_path/error_message can echo corpus
+// content, they are only emitted when the operator opts in with
+// --include-content (see TestSupportBundle_ListFilesRedactsContentByDefault
+// for the privacy-preserving default).
 func TestSupportBundle_ListFilesIncludesErrorMessage(t *testing.T) {
 	tmp := t.TempDir()
 	stateDir := filepath.Join(tmp, ".dir2mcp")
@@ -113,9 +116,12 @@ func TestSupportBundle_ListFilesIncludesErrorMessage(t *testing.T) {
 	testutil.WithWorkingDir(t, tmp, func() {
 		var stdout, stderr bytes.Buffer
 		app := cli.NewAppWithIO(&stdout, &stderr)
-		code := app.Run([]string{"support-bundle", "--output", bundlePath})
+		code := app.Run([]string{"support-bundle", "--include-content", "--output", bundlePath})
 		if code != 0 {
 			t.Fatalf("support-bundle exit=%d stderr=%q", code, stderr.String())
+		}
+		if !strings.Contains(stderr.String(), "review the bundle before sharing") {
+			t.Errorf("--include-content should warn about corpus content, stderr=%q", stderr.String())
 		}
 	})
 
@@ -175,6 +181,145 @@ func TestSupportBundle_JSONFlagParseError(t *testing.T) {
 			t.Errorf("stdout contained raw flag-package text: %q", stdout.String())
 		}
 	})
+}
+
+// TestSupportBundle_ListFilesRedactsContentByDefault pins the #436 S1 fix:
+// without --include-content the bundle must NOT disclose the corpus inventory
+// (rel_path/title) or free-text extraction errors (which can echo file
+// content), while still keeping the diagnostic skeleton (doc_type, status, and
+// a has_error flag) so a maintainer can triage failures.
+func TestSupportBundle_ListFilesRedactsContentByDefault(t *testing.T) {
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, ".dir2mcp")
+	t.Setenv("MISTRAL_API_KEY", "test-key")
+	t.Setenv("PATH", t.TempDir())
+
+	ctx := context.Background()
+	st := store.NewSQLiteStore(filepath.Join(stateDir, "meta.sqlite"))
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("init store: %v", err)
+	}
+	const secretPath = "clients/acme-merger-2026/board-minutes.pdf"
+	const secretTitle = "Project Bluebird acquisition terms"
+	const secretError = "extraction failed near text 'confidential: layoff list'"
+	if err := st.UpsertDocument(ctx, model.Document{
+		RelPath:      secretPath,
+		DocType:      "pdf",
+		Title:        secretTitle,
+		SizeBytes:    4096,
+		Status:       "error",
+		ErrorMessage: secretError,
+	}); err != nil {
+		t.Fatalf("upsert doc: %v", err)
+	}
+	_ = st.Close()
+
+	bundlePath := filepath.Join(tmp, "bundle.tar.gz")
+	testutil.WithWorkingDir(t, tmp, func() {
+		var stdout, stderr bytes.Buffer
+		app := cli.NewAppWithIO(&stdout, &stderr)
+		code := app.Run([]string{"support-bundle", "--output", bundlePath})
+		if code != 0 {
+			t.Fatalf("support-bundle exit=%d stderr=%q", code, stderr.String())
+		}
+		if strings.Contains(stderr.String(), "review the bundle before sharing") {
+			t.Errorf("default bundle should not emit the include-content warning, stderr=%q", stderr.String())
+		}
+	})
+
+	entries := extractTarGz(t, bundlePath)
+	// No corpus content anywhere in the bundle by default.
+	assertNoLeak(t, entries, []string{
+		secretPath, secretTitle, secretError, "board-minutes", "Bluebird", "layoff",
+	})
+
+	listBody := entries["list-files.json"]
+	var listed struct {
+		ContentIncluded bool `json:"content_included"`
+		Files           []struct {
+			RelPath      string `json:"rel_path"`
+			DocType      string `json:"doc_type"`
+			Title        string `json:"title"`
+			Status       string `json:"status"`
+			ErrorMessage string `json:"error_message"`
+			HasError     bool   `json:"has_error"`
+		} `json:"files"`
+	}
+	if err := json.Unmarshal(listBody, &listed); err != nil {
+		t.Fatalf("decode list-files.json: %v body=%s", err, listBody)
+	}
+	if listed.ContentIncluded {
+		t.Errorf("content_included = true, want false by default")
+	}
+	if len(listed.Files) != 1 {
+		t.Fatalf("want 1 file row, got %d: %s", len(listed.Files), listBody)
+	}
+	row := listed.Files[0]
+	// Skeleton preserved for diagnostics...
+	if row.DocType != "pdf" || row.Status != "error" || !row.HasError {
+		t.Errorf("diagnostic skeleton lost: %+v", row)
+	}
+	// ...but extension-only placeholder path, no title, no error text.
+	if row.RelPath != "[redacted].pdf" {
+		t.Errorf("rel_path = %q, want extension-only placeholder", row.RelPath)
+	}
+	if row.Title != "" || row.ErrorMessage != "" {
+		t.Errorf("title/error_message should be empty by default: %+v", row)
+	}
+}
+
+// TestSupportBundle_ServerLogRedacted pins that server.log — redirected daemon
+// stdout/stderr that can carry bearer tokens and query text — is run through the
+// secret redactor before it enters the shareable bundle (previously it was
+// bundled raw while client logs and daemon.json were already redacted).
+func TestSupportBundle_ServerLogRedacted(t *testing.T) {
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, ".dir2mcp")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	t.Setenv("MISTRAL_API_KEY", "test-key")
+	t.Setenv("PATH", t.TempDir())
+
+	const token = "sk-supersecret-abc123XYZ"
+	logLine := "2026-07-01 handling request Authorization: Bearer " + token + "\n"
+	if err := os.WriteFile(filepath.Join(stateDir, "server.log"), []byte(logLine), 0o600); err != nil {
+		t.Fatalf("write server.log: %v", err)
+	}
+
+	bundlePath := filepath.Join(tmp, "bundle.tar.gz")
+	testutil.WithWorkingDir(t, tmp, func() {
+		var stdout, stderr bytes.Buffer
+		app := cli.NewAppWithIO(&stdout, &stderr)
+		code := app.Run([]string{"support-bundle", "--output", bundlePath})
+		if code != 0 {
+			t.Fatalf("support-bundle exit=%d stderr=%q", code, stderr.String())
+		}
+	})
+
+	entries := extractTarGz(t, bundlePath)
+	serverLog, ok := entries["server.log"]
+	if !ok {
+		t.Fatalf("bundle missing server.log")
+	}
+	if bytes.Contains(serverLog, []byte(token)) {
+		t.Fatalf("server.log leaked bearer token: %s", serverLog)
+	}
+	if !bytes.Contains(serverLog, []byte("[REDACTED]")) {
+		t.Errorf("server.log should carry redaction marker, got: %s", serverLog)
+	}
+}
+
+// assertNoLeak fails if any bundle entry contains any of the sensitive strings.
+func assertNoLeak(t *testing.T, entries map[string][]byte, secrets []string) {
+	t.Helper()
+	for name, body := range entries {
+		for _, secret := range secrets {
+			if bytes.Contains(body, []byte(secret)) {
+				t.Fatalf("entry %q leaked corpus content %q", name, secret)
+			}
+		}
+	}
 }
 
 func assertOCRDiagnostic(t *testing.T, raw []byte) {

--- a/tests/cli/support_bundle_test.go
+++ b/tests/cli/support_bundle_test.go
@@ -310,6 +310,195 @@ func TestSupportBundle_ServerLogRedacted(t *testing.T) {
 	}
 }
 
+// TestSupportBundle_RedactedPathKeepsCompoundExtension pins that the
+// extension-only placeholder retains multi-part suffixes like .tar.gz (the
+// routing signal a maintainer needs) instead of the misleading .gz that
+// filepath.Ext alone would yield — while still disclosing no basename.
+func TestSupportBundle_RedactedPathKeepsCompoundExtension(t *testing.T) {
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, ".dir2mcp")
+	t.Setenv("MISTRAL_API_KEY", "test-key")
+	t.Setenv("PATH", t.TempDir())
+
+	ctx := context.Background()
+	st := store.NewSQLiteStore(filepath.Join(stateDir, "meta.sqlite"))
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("init store: %v", err)
+	}
+	if err := st.UpsertDocument(ctx, model.Document{
+		RelPath:   "backups/nightly.tar.gz",
+		DocType:   "archive",
+		SizeBytes: 1024,
+		Status:    "indexed",
+	}); err != nil {
+		t.Fatalf("upsert doc: %v", err)
+	}
+	_ = st.Close()
+
+	bundlePath := filepath.Join(tmp, "bundle.tar.gz")
+	testutil.WithWorkingDir(t, tmp, func() {
+		var stdout, stderr bytes.Buffer
+		app := cli.NewAppWithIO(&stdout, &stderr)
+		code := app.Run([]string{"support-bundle", "--output", bundlePath})
+		if code != 0 {
+			t.Fatalf("support-bundle exit=%d stderr=%q", code, stderr.String())
+		}
+	})
+
+	entries := extractTarGz(t, bundlePath)
+	// Basename must not leak even though the compound suffix is retained.
+	assertNoLeak(t, entries, []string{"nightly", "backups"})
+
+	var listed struct {
+		Files []struct {
+			RelPath string `json:"rel_path"`
+		} `json:"files"`
+	}
+	if err := json.Unmarshal(entries["list-files.json"], &listed); err != nil {
+		t.Fatalf("decode list-files.json: %v", err)
+	}
+	if len(listed.Files) != 1 {
+		t.Fatalf("want 1 file row, got %d: %s", len(listed.Files), entries["list-files.json"])
+	}
+	if listed.Files[0].RelPath != "[redacted].tar.gz" {
+		t.Errorf("rel_path = %q, want [redacted].tar.gz", listed.Files[0].RelPath)
+	}
+}
+
+// TestSupportBundle_StatusFailureSamplesRedactedByDefault pins that status.json
+// — which embeds the corpus snapshot including FailureSummary.Samples — never
+// discloses the raw {rel_path, message} pairs of failed chunks without
+// --include-content. The category aggregate (a fixed enum) is still kept so a
+// maintainer can triage embedding failures.
+func TestSupportBundle_StatusFailureSamplesRedactedByDefault(t *testing.T) {
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, ".dir2mcp")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	t.Setenv("MISTRAL_API_KEY", "test-key")
+	t.Setenv("PATH", t.TempDir())
+
+	const secretPath = "clients/acme-merger-2026/board-minutes.pdf"
+	const secretMessage = "embed failed near 'confidential: layoff list'"
+	// Seed corpus.json directly with a failure sample so the snapshot read path
+	// (source=corpus_json) carries the sensitive fields into status.json.
+	corpusJSON := `{
+  "ts": "2026-07-01T00:00:00Z",
+  "indexing": {
+    "mode": "idle",
+    "errors": 1,
+    "failure_summary": {
+      "categories": {"payload_too_large": 1},
+      "samples": [
+        {"rel_path": "` + secretPath + `", "category": "payload_too_large", "message": "` + secretMessage + `"}
+      ]
+    }
+  },
+  "doc_counts": {},
+  "total_docs": 1
+}`
+	if err := os.WriteFile(filepath.Join(stateDir, "corpus.json"), []byte(corpusJSON), 0o600); err != nil {
+		t.Fatalf("write corpus.json: %v", err)
+	}
+
+	bundlePath := filepath.Join(tmp, "bundle.tar.gz")
+	testutil.WithWorkingDir(t, tmp, func() {
+		var stdout, stderr bytes.Buffer
+		app := cli.NewAppWithIO(&stdout, &stderr)
+		code := app.Run([]string{"support-bundle", "--output", bundlePath})
+		if code != 0 {
+			t.Fatalf("support-bundle exit=%d stderr=%q", code, stderr.String())
+		}
+	})
+
+	entries := extractTarGz(t, bundlePath)
+	// No raw failure-sample content anywhere in the bundle by default.
+	assertNoLeak(t, entries, []string{
+		secretPath, secretMessage, "board-minutes", "layoff",
+	})
+
+	var status struct {
+		Snapshot struct {
+			Indexing struct {
+				FailureSummary struct {
+					Categories map[string]int64 `json:"categories"`
+					Samples    []struct {
+						RelPath  string `json:"rel_path"`
+						Category string `json:"category"`
+						Message  string `json:"message"`
+					} `json:"samples"`
+				} `json:"failure_summary"`
+			} `json:"indexing"`
+		} `json:"snapshot"`
+	}
+	if err := json.Unmarshal(entries["status.json"], &status); err != nil {
+		t.Fatalf("decode status.json: %v body=%s", err, entries["status.json"])
+	}
+	samples := status.Snapshot.Indexing.FailureSummary.Samples
+	if len(samples) != 1 {
+		t.Fatalf("want 1 failure sample, got %d: %s", len(samples), entries["status.json"])
+	}
+	s := samples[0]
+	// Category (a fixed enum) is preserved for triage...
+	if s.Category != "payload_too_large" {
+		t.Errorf("category = %q, want payload_too_large", s.Category)
+	}
+	if status.Snapshot.Indexing.FailureSummary.Categories["payload_too_large"] != 1 {
+		t.Errorf("categories aggregate lost: %+v", status.Snapshot.Indexing.FailureSummary.Categories)
+	}
+	// ...but rel_path is an extension-only placeholder and message is dropped.
+	if s.RelPath != "[redacted].pdf" {
+		t.Errorf("rel_path = %q, want extension-only placeholder", s.RelPath)
+	}
+	if s.Message != "" {
+		t.Errorf("message = %q, want empty by default", s.Message)
+	}
+}
+
+// TestSupportBundle_QuietPreservesIncludeContentWarning pins that --quiet does
+// not silently swallow the --include-content privacy-consent warning: quiet
+// suppresses the "Wrote support bundle" progress line on stdout but the consent
+// notice must still reach stderr.
+func TestSupportBundle_QuietPreservesIncludeContentWarning(t *testing.T) {
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, ".dir2mcp")
+	t.Setenv("MISTRAL_API_KEY", "test-key")
+	t.Setenv("PATH", t.TempDir())
+
+	ctx := context.Background()
+	st := store.NewSQLiteStore(filepath.Join(stateDir, "meta.sqlite"))
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("init store: %v", err)
+	}
+	if err := st.UpsertDocument(ctx, model.Document{
+		RelPath:      "doomed.pdf",
+		DocType:      "pdf",
+		SizeBytes:    1234,
+		Status:       "error",
+		ErrorMessage: "docling extraction failed",
+	}); err != nil {
+		t.Fatalf("upsert error doc: %v", err)
+	}
+	_ = st.Close()
+
+	bundlePath := filepath.Join(tmp, "bundle.tar.gz")
+	testutil.WithWorkingDir(t, tmp, func() {
+		var stdout, stderr bytes.Buffer
+		app := cli.NewAppWithIO(&stdout, &stderr)
+		code := app.Run([]string{"--quiet", "support-bundle", "--include-content", "--output", bundlePath})
+		if code != 0 {
+			t.Fatalf("support-bundle exit=%d stderr=%q", code, stderr.String())
+		}
+		if strings.Contains(stdout.String(), "Wrote support bundle to") {
+			t.Errorf("--quiet should suppress the progress line, stdout=%q", stdout.String())
+		}
+		if !strings.Contains(stderr.String(), "review the bundle before sharing") {
+			t.Errorf("--quiet must not drop the include-content consent warning, stderr=%q", stderr.String())
+		}
+	})
+}
+
 // assertNoLeak fails if any bundle entry contains any of the sensitive strings.
 func assertNoLeak(t *testing.T, entries map[string][]byte, secrets []string) {
 	t.Helper()


### PR DESCRIPTION
## What

Closes the **S1 bundle-redaction** disclosure surface of #436 in `internal/cli/support_bundle.go`. The support bundle previously shipped two corpus/secret leaks raw:

- **`server.log` added un-redacted.** `redactBundleSecrets` was applied to the client bridge logs and `daemon.json` but *not* to `server.log` — the redirected daemon stdout/stderr, which can carry bearer tokens, query text and answer snippets.
- **`list-files.json` embedded the full corpus inventory.** Every document's `rel_path`, `title` and free-text `error_message` were written via `ListFiles(...,0,0)` with no redaction or consent — disclosing the corpus inventory and content fragments to whoever receives the bundle.

## Fix

- Run `server.log` through `redactBundleSecrets` before bundling (same treatment client logs already get).
- Redact the content-bearing `list-files.json` fields **by default**: `rel_path` becomes an extension-only placeholder (`[redacted].pdf`, preserving the extractor/OCR routing signal), `title`/`error_message` are dropped, and a `has_error` flag + top-level `content_included:false` are added so a maintainer can still triage extraction failures from the skeleton.
- Add a `--include-content` flag that restores the raw fields (still run through the secret redactor so credentials never leak either way) and prints a "review the bundle before sharing" warning.

Bundle structure/usefulness is preserved; secrets are masked in every mode.

## Tests

- `TestSupportBundle_ListFilesRedactsContentByDefault` — no corpus content anywhere in the default bundle; skeleton (doc_type/status/has_error) retained.
- `TestSupportBundle_ServerLogRedacted` — a bearer token in `server.log` is masked.
- `TestSupportBundle_ListFilesIncludesErrorMessage` — updated to opt in via `--include-content` and assert the consent warning.

`make check` passes (CGO_ENABLED=0, golangci-lint, gocyclo ≤15).

## Scope

Addresses #436 (S1 bundle redaction). The emitter-race (M1) and `connection.json` atomicity (D3) parts were already fixed in #458. The snapshot-staleness parts (S3/D1) are **not** covered here — left for a separate change — so this does not close #436.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes the S1 bundle-redaction disclosure surface from #436 by redacting `server.log` through the existing secret redactor before bundling, and gating all corpus-inventory fields (`rel_path`, `title`, `error_message`, and `FailureSummary.Samples`) behind a new `--include-content` opt-in flag with a consent warning. The two previously flagged issues — the quiet-mode consent-warning drop and the single-extension truncation on `.tar.gz` paths — are both resolved here.

- **`server.log` redaction**: `redactBundleSecrets` is now applied to the server log tail before it enters the archive, matching the treatment already applied to client bridge logs and `daemon.json`.
- **Corpus inventory gating**: `list-files.json` and `status.json` failure samples default to extension-only `[redacted].<ext>` paths, empty title/error fields, and a `has_error` signal; `--include-content` restores raw values (still secret-redacted) and emits a consent warning that survives `--quiet` mode.
- **Compound extension support**: A `redactedExtension` helper checks a curated `compoundExtensions` list (`.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tar.zst`) before falling back to `filepath.Ext`, preserving the full routing-relevant suffix without leaking the basename.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the redaction logic is correct and conservative, previously flagged gaps are fully addressed, and the new behaviour is comprehensively pinned by five integration tests.

All three fix surfaces (server.log redaction, corpus inventory gating, quiet-mode warning preservation) are implemented correctly and independently verified by new tests. The compound-extension helper closes the previously flagged routing-signal degradation for .tar.gz files. No regressions in the test suite are visible from the diff; the assertNoLeak helper scans every bundle entry for sensitive substrings, making the correctness guarantee strong.

No files require special attention. Both changed files are in good shape.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/cli/support_bundle.go | Adds server.log redaction, --include-content flag with gated corpus fields and consent warning (preserved in quiet mode), and compound-extension-aware path placeholder. Logic is sound and consistent across list-files.json and status.json failure samples. |
| tests/cli/support_bundle_test.go | Five new end-to-end tests pin every redaction contract: default content exclusion, server.log token masking, compound extension retention, status.json failure-sample redaction, and quiet-mode consent warning preservation. Coverage is comprehensive. |


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[runSupportBundle] --> B{--include-content?}
    B -->|false| C[collectSupportArtifacts includeContent=false]
    B -->|true| D[collectSupportArtifacts includeContent=true]
    C --> E[server.log - redactBundleSecrets]
    D --> E
    E --> F[status.json - redactFailureSamples]
    F --> G{includeContent?}
    G -->|false| H[rel_path to redacted.ext / message to empty]
    G -->|true| I[rel_path and message through redactBundleSecrets]
    C --> J[list-files.json - marshalListFilesJSON]
    D --> J
    J --> K{includeContent?}
    K -->|false| L[rel_path to redacted.ext / title+error omitted / has_error preserved]
    K -->|true| M[all fields through redactBundleSecrets / has_error omitted]
    D --> N[Append consent warning]
    C --> O[writeSupportBundle]
    N --> O
    O --> P{global.jsonOutput?}
    P -->|true| Q[emitJSON with warnings array]
    P -->|false| R{global.quiet?}
    R -->|false| S[Print progress to stdout]
    R -->|true| T[Suppress progress line]
    S --> U[Print all warnings to stderr]
    T --> U
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[runSupportBundle] --> B{--include-content?}
    B -->|false| C[collectSupportArtifacts includeContent=false]
    B -->|true| D[collectSupportArtifacts includeContent=true]
    C --> E[server.log - redactBundleSecrets]
    D --> E
    E --> F[status.json - redactFailureSamples]
    F --> G{includeContent?}
    G -->|false| H[rel_path to redacted.ext / message to empty]
    G -->|true| I[rel_path and message through redactBundleSecrets]
    C --> J[list-files.json - marshalListFilesJSON]
    D --> J
    J --> K{includeContent?}
    K -->|false| L[rel_path to redacted.ext / title+error omitted / has_error preserved]
    K -->|true| M[all fields through redactBundleSecrets / has_error omitted]
    D --> N[Append consent warning]
    C --> O[writeSupportBundle]
    N --> O
    O --> P{global.jsonOutput?}
    P -->|true| Q[emitJSON with warnings array]
    P -->|false| R{global.quiet?}
    R -->|false| S[Print progress to stdout]
    R -->|true| T[Suppress progress line]
    S --> U[Print all warnings to stderr]
    T --> U
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/cli/support_bundle.go`, line 91-96 ([link](https://github.com/dirstral/dir2mcp/blob/b9cd6c02c1d73125cda16b43bc83ad4896a60699/internal/cli/support_bundle.go#L91-L96)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Consent warning silently dropped in `--quiet` mode**

   When `--quiet` and `--include-content` are both passed, the `warnings` loop is skipped entirely (line 93: `if !global.quiet`), so the "review the bundle before sharing it" message is never printed. Quiet mode is exactly the context where bundles are most likely to be produced by a script and then auto-uploaded or forwarded — i.e., the scenario where the consent reminder matters most. JSON mode (`--json`) correctly includes the warning in the structured response, but non-JSON quiet mode does not, leaving a silent gap in the consent mechanism the PR description treats as a key part of the fix.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["docs(support-bundle): clarify --include-..."](https://github.com/dirstral/dir2mcp/commit/f766618e99252364bcdf5f2979a390993e8fd850) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41247966)</sub>

<!-- /greptile_comment -->