### PR TITLE
fix(observability): reset per-run indexing counters each scan (#426)

### DIFF
--- a/internal/appstate/indexing_state.go
+++ b/internal/appstate/indexing_state.go
@@ -81,17 +81,25 @@ func (s *IndexingState) SetRunning(running bool) {
 // worker and preloaded from the store, so it reflects durable embed progress
 // rather than a single scan and must survive across rescans. jobID/mode/running
 // are lifecycle fields, not counters, and are left as-is.
+//
+// Snapshot() reads each counter independently without a lock, so a concurrent
+// status scrape can interleave with this reset. To keep the
+// indexed+skipped+errors <= scanned invariant intact for every observer, the
+// component counters are zeroed first and scanned is zeroed last: any snapshot
+// taken mid-reset then sees a still-large (or already-zero) scanned alongside
+// component counters that are only ever <= their pre-reset values, never the
+// reverse (scanned=0 while indexed still carries the previous run's total).
 func (s *IndexingState) ResetProgress() {
 	if s == nil {
 		return
 	}
-	s.scanned.Store(0)
 	s.indexed.Store(0)
 	s.skipped.Store(0)
 	s.deleted.Store(0)
 	s.representations.Store(0)
 	s.chunksTotal.Store(0)
 	s.errors.Store(0)
+	s.scanned.Store(0)
 }
 
 func (s *IndexingState) AddScanned(delta int64) {

--- a/internal/appstate/indexing_state.go
+++ b/internal/appstate/indexing_state.go
@@ -74,6 +74,26 @@ func (s *IndexingState) SetRunning(running bool) {
 	s.running.Store(running)
 }
 
+// ResetProgress zeroes the per-run progress counters that runScan owns so a new
+// scan reports the current corpus rather than an ever-growing sum of every scan
+// the daemon has performed (issue #426). It deliberately leaves embeddedOK
+// untouched: that counter is owned by the (separately running, resumable) embed
+// worker and preloaded from the store, so it reflects durable embed progress
+// rather than a single scan and must survive across rescans. jobID/mode/running
+// are lifecycle fields, not counters, and are left as-is.
+func (s *IndexingState) ResetProgress() {
+	if s == nil {
+		return
+	}
+	s.scanned.Store(0)
+	s.indexed.Store(0)
+	s.skipped.Store(0)
+	s.deleted.Store(0)
+	s.representations.Store(0)
+	s.chunksTotal.Store(0)
+	s.errors.Store(0)
+}
+
 func (s *IndexingState) AddScanned(delta int64) {
 	if s == nil {
 		return

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -889,6 +889,16 @@ func (s *Service) runScan(ctx context.Context) error {
 		return errors.New("ingest store is not configured")
 	}
 
+	// Reset the per-run progress counters so each scan reports the current corpus
+	// rather than accumulating across every scan the daemon performs (issue #426).
+	// Without this the 10-min safety rescan re-adds the whole corpus each time,
+	// `errors` never clears after a transient failure is repaired, and stale
+	// event-path increments carry forward. embeddedOK is intentionally preserved
+	// (owned by the embed worker, not this scan).
+	if s.indexingState != nil {
+		s.indexingState.ResetProgress()
+	}
+
 	discoverOpts := DiscoverOptionsFromConfig(s.cfg)
 	// Attach the optional directory-discovery scan cache (issue #267 item 5) for
 	// the local-filesystem backend only. It is opened for the duration of this
@@ -1252,9 +1262,16 @@ func (s *Service) processDocument(ctx context.Context, f DiscoveredFile, secretP
 		return err
 	}
 
+	// Count "indexed" only once the document is durably processed. A doc that is
+	// ok now but whose representation generation fails below must count solely as
+	// an error (runScan adds it), not as both indexed and error — otherwise the
+	// same doc is double-counted and indexed+skipped+errors exceeds scanned
+	// (issue #426). indexedPending tracks the ok case so it is credited at each
+	// point where no further rep work can fail this run.
+	indexedPending := false
 	switch doc.Status {
 	case "ok":
-		s.addIndexed(1)
+		indexedPending = true
 	case "skipped", "secret_excluded":
 		s.addSkipped(1)
 		s.markActiveSkipped()
@@ -1271,12 +1288,15 @@ func (s *Service) processDocument(ctx context.Context, f DiscoveredFile, secretP
 	// Archive containers: extract and ingest each member as its own document.
 	// The archive document itself remains "skipped" (no direct text content).
 	if doc.DocType == "archive" {
+		s.creditIndexed(indexedPending)
 		return s.handleArchiveDocument(ctx, f, secretPatterns, forceReindex, seen, needsProcessing)
 	}
 
 	if !needsProcessing || doc.Status != "ok" {
 		// No representation work performed this run (cache hit / unchanged content
 		// / non-ok status): record it as skipped for the batch manifest (§8.6.11).
+		// An ok cache hit is still a durably-indexed document, so credit it.
+		s.creditIndexed(indexedPending)
 		s.markActiveSkipped()
 		return nil
 	}
@@ -1290,7 +1310,19 @@ func (s *Service) processDocument(ctx context.Context, f DiscoveredFile, secretP
 		_ = s.store.UpsertDocument(ctx, doc)
 		return fmt.Errorf("generate representations: %w", err)
 	}
+	s.creditIndexed(indexedPending)
 	return nil
+}
+
+// creditIndexed bumps the run-progress "indexed" counter when the document was
+// durably processed (status ok). Kept as a helper so processDocument credits the
+// counter only at the exit points past which no representation work can still
+// fail — a doc that later errors during rep-gen must count solely as an error,
+// not as both indexed and error (issue #426).
+func (s *Service) creditIndexed(indexed bool) {
+	if indexed {
+		s.addIndexed(1)
+	}
 }
 
 // deriveDocument runs the derivation pass for a single asset under the two-phase

--- a/tests/appstate/indexing_state_test.go
+++ b/tests/appstate/indexing_state_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/dirstral/dir2mcp/internal/appstate"
@@ -44,6 +45,49 @@ func TestResetProgress_ZeroesRunCountersPreservesEmbedded(t *testing.T) {
 	if !got.Running {
 		t.Fatal("ResetProgress must preserve Running=true")
 	}
+}
+
+// TestResetProgress_SnapshotInvariantDuringConcurrentReset guards the counter
+// ordering in ResetProgress: because Snapshot() reads each field independently
+// without a lock, a status scrape can interleave with a reset. Zeroing the
+// component counters before scanned keeps the indexed+skipped+errors <= scanned
+// invariant true for every observer, so a snapshot taken mid-reset never sees
+// scanned=0 while indexed/skipped/errors still carry the previous run's totals.
+// Run with -race to also surface any unsynchronised access.
+func TestResetProgress_SnapshotInvariantDuringConcurrentReset(t *testing.T) {
+	s := appstate.NewIndexingState(appstate.ModeFull)
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				got := s.Snapshot()
+				if got.Indexed+got.Skipped+got.Errors > got.Scanned {
+					t.Errorf("invariant violated mid-reset: indexed(%d)+skipped(%d)+errors(%d) > scanned(%d)",
+						got.Indexed, got.Skipped, got.Errors, got.Scanned)
+					return
+				}
+			}
+		}
+	}()
+
+	for i := 0; i < 2000; i++ {
+		s.AddScanned(10)
+		s.AddIndexed(4)
+		s.AddSkipped(3)
+		s.AddErrors(2)
+		s.ResetProgress()
+	}
+
+	close(stop)
+	wg.Wait()
 }
 
 // TestResetProgress_NilReceiverIsSafe mirrors the nil-guard pattern used by the

--- a/tests/appstate/indexing_state_test.go
+++ b/tests/appstate/indexing_state_test.go
@@ -1,0 +1,55 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/appstate"
+)
+
+// TestResetProgress_ZeroesRunCountersPreservesEmbedded verifies that
+// ResetProgress clears the per-scan progress counters (issue #426) while
+// leaving embeddedOK — owned by the separately-running, resumable embed worker
+// and preloaded from the store — intact, and without disturbing the
+// jobID/mode/running lifecycle fields.
+func TestResetProgress_ZeroesRunCountersPreservesEmbedded(t *testing.T) {
+	s := appstate.NewIndexingState(appstate.ModeFull)
+	s.SetJobID("job_fixed")
+	s.SetRunning(true)
+
+	s.AddScanned(7)
+	s.AddIndexed(4)
+	s.AddSkipped(2)
+	s.AddDeleted(1)
+	s.AddRepresentations(9)
+	s.AddChunksTotal(11)
+	s.AddErrors(3)
+	s.AddEmbeddedOK(5)
+
+	s.ResetProgress()
+
+	got := s.Snapshot()
+	if got.Scanned != 0 || got.Indexed != 0 || got.Skipped != 0 || got.Deleted != 0 ||
+		got.Representations != 0 || got.ChunksTotal != 0 || got.Errors != 0 {
+		t.Fatalf("ResetProgress left run counters non-zero: %+v", got)
+	}
+	if got.EmbeddedOK != 5 {
+		t.Fatalf("ResetProgress must preserve EmbeddedOK: got %d want 5", got.EmbeddedOK)
+	}
+	if got.JobID != "job_fixed" {
+		t.Fatalf("ResetProgress must preserve JobID: got %q", got.JobID)
+	}
+	if got.Mode != appstate.ModeFull {
+		t.Fatalf("ResetProgress must preserve Mode: got %q", got.Mode)
+	}
+	if !got.Running {
+		t.Fatal("ResetProgress must preserve Running=true")
+	}
+}
+
+// TestResetProgress_NilReceiverIsSafe mirrors the nil-guard pattern used by the
+// other IndexingState mutators so a scan on a service with no wired-up state
+// does not panic.
+func TestResetProgress_NilReceiverIsSafe(t *testing.T) {
+	var s *appstate.IndexingState
+	s.ResetProgress()
+}

--- a/tests/ingest/service_test.go
+++ b/tests/ingest/service_test.go
@@ -62,6 +62,72 @@ func TestServiceRun_ProcessesFilesAndMarksMissingDeleted(t *testing.T) {
 	assertServiceRunDocStatuses(t, st)
 }
 
+// TestServiceRun_CountersResetPerScan guards issue #426: the run-progress
+// counters must reflect the current scan/corpus, not a monotonic sum of every
+// scan the daemon has performed. Two successive scans over an unchanged corpus
+// must therefore report the same steady-state totals instead of doubling.
+func TestServiceRun_CountersResetPerScan(t *testing.T) {
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, "keep.txt"), []byte("plain text"))
+	mustWriteFile(t, filepath.Join(root, "code", "main.go"), []byte("package main\n"))
+	mustWriteFile(t, filepath.Join(root, "archive.zip"), []byte("PK\x03\x04"))
+	mustWriteFile(t, filepath.Join(root, "secret.txt"), []byte("Authorization: Bearer abcdefgh.ijklmnop.qrstuvwx\n"))
+
+	st := newMemoryStore()
+	st.docs["gone.txt"] = model.Document{
+		RelPath:   "gone.txt",
+		DocType:   "text",
+		SizeBytes: 4,
+		MTimeUnix: 1,
+		Status:    "ok",
+	}
+
+	cfg := config.Default()
+	cfg.RootDir = root
+
+	indexState := appstate.NewIndexingState(appstate.ModeIncremental)
+	svc := mustNewIngestService(t, cfg, st)
+	svc.SetIndexingState(indexState)
+
+	if err := svc.Run(context.Background()); err != nil {
+		t.Fatalf("first Run failed: %v", err)
+	}
+	first := indexState.Snapshot()
+	// keep.txt + code/main.go index; archive.zip + secret.txt skip; gone.txt (in
+	// the store, absent on disk) is tombstoned.
+	if first.Scanned != 4 || first.Indexed != 2 || first.Skipped != 2 || first.Deleted != 1 || first.Errors != 0 {
+		t.Fatalf("first run counts unexpected: scanned=%d indexed=%d skipped=%d deleted=%d errors=%d",
+			first.Scanned, first.Indexed, first.Skipped, first.Deleted, first.Errors)
+	}
+
+	if err := svc.Run(context.Background()); err != nil {
+		t.Fatalf("second Run failed: %v", err)
+	}
+	second := indexState.Snapshot()
+	// Without the per-run reset these would be 8/4/4 (accumulated). gone.txt was
+	// already tombstoned, so the second scan sees no new deletions.
+	if second.Scanned != 4 {
+		t.Fatalf("second run Scanned=%d want=4 (counters accumulated across scans)", second.Scanned)
+	}
+	if second.Indexed != 2 {
+		t.Fatalf("second run Indexed=%d want=2 (counters accumulated across scans)", second.Indexed)
+	}
+	if second.Skipped != 2 {
+		t.Fatalf("second run Skipped=%d want=2 (counters accumulated across scans)", second.Skipped)
+	}
+	if second.Deleted != 0 {
+		t.Fatalf("second run Deleted=%d want=0", second.Deleted)
+	}
+	if second.Errors != 0 {
+		t.Fatalf("second run Errors=%d want=0", second.Errors)
+	}
+	// The indexed+skipped+errors <= scanned invariant must hold every run.
+	if second.Indexed+second.Skipped+second.Errors > second.Scanned {
+		t.Fatalf("invariant violated: indexed(%d)+skipped(%d)+errors(%d) > scanned(%d)",
+			second.Indexed, second.Skipped, second.Errors, second.Scanned)
+	}
+}
+
 func assertServiceRunSnapshotCounts(t *testing.T, snapshot appstate.IndexingSnapshot) {
 	t.Helper()
 	if snapshot.Scanned != 5 {
@@ -425,6 +491,41 @@ func TestServiceRun_RepGenerationFailureMarksDocAsError(t *testing.T) {
 	}
 	if len(st.reps) != 0 {
 		t.Fatalf("expected no representations after rollback, got %d", len(st.reps))
+	}
+}
+
+// TestServiceRun_RepGenerationFailureCountsErrorNotIndexed guards the
+// double-count half of issue #426: a document whose representation generation
+// fails must count solely as an error, never as both indexed and error, so the
+// indexed+skipped+errors <= scanned invariant holds.
+func TestServiceRun_RepGenerationFailureCountsErrorNotIndexed(t *testing.T) {
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, "fail.txt"), []byte("some valid text content\n"))
+
+	cfg := config.Default()
+	cfg.RootDir = root
+
+	inner := newMemoryStore()
+	st := &failingChunkMemoryStore{memoryStore: inner}
+
+	indexState := appstate.NewIndexingState(appstate.ModeIncremental)
+	svc := mustNewIngestService(t, cfg, st)
+	svc.SetIndexingState(indexState)
+
+	if err := svc.Run(context.Background()); err != nil {
+		t.Fatalf("Run returned unexpected error: %v", err)
+	}
+
+	snap := indexState.Snapshot()
+	if snap.Errors != 1 {
+		t.Fatalf("Errors=%d want=1", snap.Errors)
+	}
+	if snap.Indexed != 0 {
+		t.Fatalf("Indexed=%d want=0 (failed rep-gen must not also count as indexed)", snap.Indexed)
+	}
+	if snap.Indexed+snap.Skipped+snap.Errors > snap.Scanned {
+		t.Fatalf("invariant violated: indexed(%d)+skipped(%d)+errors(%d) > scanned(%d)",
+			snap.Indexed, snap.Skipped, snap.Errors, snap.Scanned)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes **issue #426** (part of #395): `IndexingState` run-progress counters were monotonic for the whole daemon lifetime yet surfaced as the authoritative `status` numbers, so they drifted unboundedly.

`internal/appstate/indexing_state.go` exposed only `Add*` (atomic, monotonic) with **no reset**, and `runScan` never reset them — it only `SetMode`/`SetRunning` and added into the counters each invocation. Because the watcher fires a full `runScan` every 10 min and `buildCorpusSnapshot` prefers these live counters, `status` grew without bound.

### Symptoms fixed
- `scanned`/`indexed`/`skipped` climbed far above the real corpus (every 10-min rescan re-added the whole corpus).
- **`errors` never decremented** — a single transient failure made `status` report `errors>0` permanently until restart, even after the document was repaired.
- **Double-count** — `indexed` was credited before `generateRepresentations`; if rep-gen then failed, `runScan` also added an error, so the same doc counted as both `indexed` and `error`, breaking the `indexed+skipped+errors <= scanned` invariant.

## Changes
- Add `IndexingState.ResetProgress()` that zeroes the per-run counters (scanned/indexed/skipped/deleted/representations/chunks_total/errors). `embeddedOK` is deliberately **preserved** — it is owned by the separately-running, resumable embed worker and preloaded from the store, so it reflects durable embed progress rather than a single scan.
- Call `ResetProgress()` at the start of each `runScan`, so `status` reflects the current corpus/run.
- Credit `indexed` only **after** representation generation succeeds (via a small `creditIndexed` helper), so a doc whose rep-gen fails counts solely as an error, restoring the `indexed+skipped+errors <= scanned` invariant.

## Contract
Preserves the status/stats JSON contract — field names and the `-1` "unavailable" sentinel are untouched (this only changes when the live counters are zeroed, not their shape or the computed-fallback branch).

## Tests
- `tests/appstate/indexing_state_test.go`: `ResetProgress` zeroes run counters, preserves `embeddedOK`/jobID/mode/running, and is nil-safe.
- `tests/ingest/service_test.go`:
  - `TestServiceRun_CountersResetPerScan` — two successive scans over an unchanged corpus report the same steady-state totals instead of doubling.
  - `TestServiceRun_RepGenerationFailureCountsErrorNotIndexed` — a failed rep-gen counts only as an error (not indexed), and the `indexed+skipped+errors <= scanned` invariant holds.

`make check` passes (CGO_ENABLED=0, golangci-lint v2.10.1, gocyclo <= 15).

Closes #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes the monotonic `IndexingState` counters bug (#426): `runScan` now calls `ResetProgress()` at the start of each scan, and `indexed` is credited only after `generateRepresentations` succeeds via a new `creditIndexed` helper, eliminating both the ever-growing-sum and the double-count-on-rep-gen-failure problems.

- `ResetProgress()` zeroes the seven per-scan counters (components first, `scanned` last) to preserve the `indexed+skipped+errors <= scanned` invariant for concurrent `Snapshot()` readers; `embeddedOK` is deliberately left intact as it is owned by the separately-running embed worker.
- The `indexedPending` / `creditIndexed` pattern in `processDocument` ensures a document whose rep-gen fails counts solely as an error, restoring the `indexed+skipped+errors <= scanned` invariant even on partial failures.
- Two new integration tests (`TestServiceRun_CountersResetPerScan`, `TestServiceRun_RepGenerationFailureCountsErrorNotIndexed`) and a dedicated `indexing_state_test.go` suite (including a `-race`-friendly concurrent invariant test) provide end-to-end coverage of both fixes.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped to resetting per-scan counters and deferring the indexed credit, with no API or schema contract changes.

The reset ordering (component counters before scanned) is correctly documented and validated by a concurrent invariant test. The creditIndexed pattern defers the indexed credit to successful rep-gen exit points only, and the S3 ETag fast-path (skipUnchangedRemoteDocument) correctly calls addIndexed directly because no rep-gen occurs there. Both fixes are independently tested at the integration level. No counter accumulates or double-counts across runs.

No files require special attention; the changes are self-contained within the indexing state and scan pipeline.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/appstate/indexing_state.go | Adds ResetProgress() that zeros per-scan counters in deliberate order (components before scanned) to preserve the indexed+skipped+errors <= scanned invariant for concurrent snapshot readers; embeddedOK is intentionally preserved. |
| internal/ingest/service.go | Calls ResetProgress() at the top of runScan and introduces the indexedPending/creditIndexed pattern so indexed is credited only after generateRepresentations succeeds, eliminating the double-count for rep-gen failures. |
| tests/appstate/indexing_state_test.go | New test file covering ResetProgress: zeroes run counters, preserves embeddedOK/jobID/mode/running, nil-receiver safety, and concurrent invariant validation with -race support. |
| tests/ingest/service_test.go | Adds two integration tests: one proving counters reset per scan (no accumulation across runs), another proving a rep-gen failure counts only as an error (not also as indexed). |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant W as Watcher / caller
    participant S as Service.runScan
    participant IS as IndexingState
    participant SP as scanPass
    participant PD as processDocument
    participant GR as generateRepresentations

    W->>S: Run() / Reindex()
    S->>IS: ResetProgress() zeros indexed/skipped/errors then scanned
    S->>SP: scanPass(passSingle, discovered)
    loop each DiscoveredFile
        SP->>IS: AddScanned(1)
        SP->>PD: processDocument(f)
        alt "doc.Status == ok"
            PD-->>PD: "indexedPending = true"
            PD->>GR: generateRepresentations()
            alt success
                GR-->>PD: nil
                PD->>IS: creditIndexed(true) AddIndexed(1)
                PD-->>SP: nil
            else failure
                GR-->>PD: error
                PD-->>SP: error (no creditIndexed)
                SP->>IS: AddErrors(1)
            end
        else skipped / secret_excluded
            PD->>IS: AddSkipped(1)
            PD-->>SP: nil
        end
    end
    Note over IS: embeddedOK untouched — embed worker owns it
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant W as Watcher / caller
    participant S as Service.runScan
    participant IS as IndexingState
    participant SP as scanPass
    participant PD as processDocument
    participant GR as generateRepresentations

    W->>S: Run() / Reindex()
    S->>IS: ResetProgress() zeros indexed/skipped/errors then scanned
    S->>SP: scanPass(passSingle, discovered)
    loop each DiscoveredFile
        SP->>IS: AddScanned(1)
        SP->>PD: processDocument(f)
        alt "doc.Status == ok"
            PD-->>PD: "indexedPending = true"
            PD->>GR: generateRepresentations()
            alt success
                GR-->>PD: nil
                PD->>IS: creditIndexed(true) AddIndexed(1)
                PD-->>SP: nil
            else failure
                GR-->>PD: error
                PD-->>SP: error (no creditIndexed)
                SP->>IS: AddErrors(1)
            end
        else skipped / secret_excluded
            PD->>IS: AddSkipped(1)
            PD-->>SP: nil
        end
    end
    Note over IS: embeddedOK untouched — embed worker owns it
```

</a>

<sub>Reviews (2): Last reviewed commit: ["review: address PR #482 comments"](https://github.com/dirstral/dir2mcp/commit/d8d3c8bd0fc11085deba44733bfdc61179927fd0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41247984)</sub>

<!-- /greptile_comment -->