### PR TITLE
fix(cli): eliminate data races on the shared stderr log sink (#419)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -47,6 +47,23 @@ jobs:
       - name: Check
         run: make check
 
+  race:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      # The race detector requires cgo; the rest of CI runs CGO_ENABLED=0.
+      - name: Run tests under the race detector
+        run: make test-race
+
   conformance:
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ build-elevenlabs-bridge:
 up: build
 	./dir2mcp up
 
-.PHONY: all clean clean-all help fmt vet lint cyclo ineffassign misspell test check ci benchmark inspector-smoke conformance
+.PHONY: all clean clean-all help fmt vet lint cyclo ineffassign misspell test test-race check ci benchmark inspector-smoke conformance
 
 all: check
 
@@ -42,6 +42,7 @@ help:
 	@echo "  ineffassign - run ineffassign over the whole tree"
 	@echo "  misspell    - run misspell over the whole tree"
 	@echo "  test   - run go test"
+	@echo "  test-race - run go test -race on the concurrency-sensitive packages (needs CGO)"
 	@echo "  check  - fmt + vet + lint + cyclo + ineffassign + misspell + test + build"
 	@echo "  ci     - vet + cyclo + ineffassign + misspell + test (CI-safe default)"
 	@echo "  build-elevenlabs-bridge - build the ElevenLabs webhook bridge binary"
@@ -73,6 +74,13 @@ misspell:
 
 test:
 	go test ./...
+
+# test-race exercises the goroutine-heavy embed/index/watch/store paths under the
+# race detector so concurrency regressions (issue #419) are caught. It needs the
+# C toolchain (CGO_ENABLED=1); it is a separate target rather than folded into
+# `check` because `check`/`ci` run with CGO_ENABLED=0.
+test-race:
+	CGO_ENABLED=1 go test -race ./internal/cli/... ./internal/index/... ./tests/cli ./tests/index ./tests/store
 
 test-release-tools:
 	cd scripts && python3 -m unittest discover -p 'test_*.py'

--- a/internal/cli/server_log_tee_internal_test.go
+++ b/internal/cli/server_log_tee_internal_test.go
@@ -205,6 +205,7 @@ func TestStartEmbeddingIfNotReadOnly_NoChunkSourceLogsWarning(t *testing.T) {
 		"", "", "",          // embedModelText, embedModelCode, rootDir
 		nil, // corpusFS
 		emitter,
+		nil, // wg: no workers start on this path (store lacks ChunkSource)
 	)
 	if err != nil {
 		t.Fatalf("startEmbeddingIfNotReadOnly returned error: %v", err)

--- a/internal/cli/syncwriter.go
+++ b/internal/cli/syncwriter.go
@@ -1,0 +1,34 @@
+package cli
+
+import (
+	"io"
+	"sync"
+)
+
+// syncWriter serializes concurrent writes to an underlying io.Writer with a
+// mutex. The server runs several long-lived goroutines (embed workers, the
+// corpus writer, the watch worker) plus the main event loop, and they all log
+// diagnostics to the same process stderr sink. A *log.Logger guards its own
+// Output calls, but direct writef(stderr, ...) writes bypass that lock, so two
+// goroutines writing to one unsynchronized sink (e.g. a bytes.Buffer in tests)
+// is a data race (issue #419). Routing every concurrent-phase writer through a
+// single syncWriter gives them one shared lock.
+type syncWriter struct {
+	mu sync.Mutex
+	w  io.Writer
+}
+
+// newSyncWriter wraps w so concurrent Write calls are serialized. If w is
+// already a *syncWriter it is returned unchanged to avoid nesting locks.
+func newSyncWriter(w io.Writer) *syncWriter {
+	if sw, ok := w.(*syncWriter); ok {
+		return sw
+	}
+	return &syncWriter{w: w}
+}
+
+func (s *syncWriter) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.w.Write(p)
+}

--- a/internal/cli/syncwriter.go
+++ b/internal/cli/syncwriter.go
@@ -5,29 +5,35 @@ import (
 	"sync"
 )
 
-// syncWriter serializes concurrent writes to an underlying io.Writer with a
+// SyncWriter serializes concurrent writes to an underlying io.Writer with a
 // mutex. The server runs several long-lived goroutines (embed workers, the
 // corpus writer, the watch worker) plus the main event loop, and they all log
 // diagnostics to the same process stderr sink. A *log.Logger guards its own
 // Output calls, but direct writef(stderr, ...) writes bypass that lock, so two
 // goroutines writing to one unsynchronized sink (e.g. a bytes.Buffer in tests)
 // is a data race (issue #419). Routing every concurrent-phase writer through a
-// single syncWriter gives them one shared lock.
-type syncWriter struct {
+// single SyncWriter gives them one shared lock.
+//
+// It is exported (with NewSyncWriter) only so the concurrency regression guard
+// can live in tests/ per AGENTS.md rather than as an internal *_test.go file;
+// there is no external consumer (internal/cli is not importable outside the
+// module).
+type SyncWriter struct {
 	mu sync.Mutex
 	w  io.Writer
 }
 
-// newSyncWriter wraps w so concurrent Write calls are serialized. If w is
-// already a *syncWriter it is returned unchanged to avoid nesting locks.
-func newSyncWriter(w io.Writer) *syncWriter {
-	if sw, ok := w.(*syncWriter); ok {
+// NewSyncWriter wraps w so concurrent Write calls are serialized. If w is
+// already a *SyncWriter it is returned unchanged to avoid nesting locks.
+func NewSyncWriter(w io.Writer) *SyncWriter {
+	if sw, ok := w.(*SyncWriter); ok {
 		return sw
 	}
-	return &syncWriter{w: w}
+	return &SyncWriter{w: w}
 }
 
-func (s *syncWriter) Write(p []byte) (int, error) {
+// Write serializes concurrent writes to the wrapped io.Writer under a mutex.
+func (s *SyncWriter) Write(p []byte) (int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.w.Write(p)

--- a/internal/cli/syncwriter_test.go
+++ b/internal/cli/syncwriter_test.go
@@ -1,0 +1,49 @@
+package cli
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+)
+
+// TestSyncWriterSerializesConcurrentWrites is the focused regression guard for
+// issue #419: many goroutines writing to one shared sink (here a bytes.Buffer,
+// as in the CLI tests) must not race or lose bytes. Run under `go test -race`
+// this fails if syncWriter drops its mutex; even without -race the byte count
+// assertion catches a torn Buffer.grow.
+func TestSyncWriterSerializesConcurrentWrites(t *testing.T) {
+	var buf bytes.Buffer
+	w := newSyncWriter(&buf)
+
+	const goroutines, perGoroutine = 8, 250
+	line := []byte("embed worker started [kind=text]\n")
+
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perGoroutine; i++ {
+				if _, err := w.Write(line); err != nil {
+					t.Errorf("write: %v", err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got, want := bytes.Count(buf.Bytes(), []byte("\n")), goroutines*perGoroutine; got != want {
+		t.Fatalf("lost writes under concurrency: got %d lines, want %d", got, want)
+	}
+}
+
+// TestNewSyncWriterDoesNotDoubleWrap keeps nested locking from creeping in when
+// an already-synchronized sink is wrapped again (e.g. both the embed logger and
+// the event loop route through the shared sink).
+func TestNewSyncWriterDoesNotDoubleWrap(t *testing.T) {
+	inner := newSyncWriter(&bytes.Buffer{})
+	if got := newSyncWriter(inner); got != inner {
+		t.Fatalf("newSyncWriter double-wrapped an existing *syncWriter: got %p, want %p", got, inner)
+	}
+}

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -158,7 +158,7 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 	// persistence autosave callback, and the event loop). Without it, direct
 	// writef(stderr, ...) writes race the embed worker's *log.Logger writes on the
 	// same underlying sink (a bytes.Buffer under `go test -race`) — issue #419.
-	logSink := newSyncWriter(a.stderr)
+	logSink := NewSyncWriter(a.stderr)
 
 	persistence := index.NewPersistenceManager(
 		[]index.IndexedFile{
@@ -171,18 +171,20 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 	persistence.Start(runCtx)
 	defer a.stopPersistenceWithLog(persistence)
 
-	// Drain the embed workers before runUp returns. They are the goroutines whose
+	// Drain every long-lived background goroutine before runUp returns: the embed
+	// workers (or, in distributed mode, the coordinator/worker/broker-closer), the
+	// corpus writer, and the watch worker. These are the goroutines whose
 	// unconditional startup/progress logging outlives the call otherwise, racing a
 	// caller that reads the sink after return (issue #419); waiting also stops them
 	// from touching the store/indices the deferred Close calls below tear down.
-	var embedWG sync.WaitGroup
+	var bgWG sync.WaitGroup
 	defer func() {
 		cancel()
-		embedWG.Wait()
+		bgWG.Wait()
 	}()
 
 	embedErrCh := make(chan error, 4)
-	if err := startEmbeddingIfNotReadOnly(runCtx, cfg, opts.readOnly, st, textIx, codeIx, embedder, ret, indexingState, embedErrCh, logSink, opts.jsonOutput, etm, ecm, cfg.RootDir, corpusFS, emitter, &embedWG); err != nil {
+	if err := startEmbeddingIfNotReadOnly(runCtx, cfg, opts.readOnly, st, textIx, codeIx, embedder, ret, indexingState, embedErrCh, logSink, opts.jsonOutput, etm, ecm, cfg.RootDir, corpusFS, emitter, &bgWG); err != nil {
 		// A distributed-embedding setup failure is fatal: refuse to run a server
 		// that would silently never drain its pending queue.
 		writeCLIError(logSink, opts.jsonOutput, exitConfigInvalid, fmt.Sprintf("start embedding: %v", err))
@@ -216,9 +218,16 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 	stdinQuitCh := a.installInteractionForUp(cancel, cfg, connection, auth, opts, nonInteractiveMode)
 
 	ingestErrCh := make(chan error, 1)
-	go runCorpusWriter(runCtx, cfg.StateDir, st, indexingState, logSink, emitter)
+	// Track the corpus writer on bgWG so the deferred drain waits for it to stop
+	// before st.Close() runs; otherwise writeCorpusSnapshot can query a closed
+	// store, and its logging can race a caller reading the sink after return (#419).
+	bgWG.Add(1)
+	go func() {
+		defer bgWG.Done()
+		runCorpusWriter(runCtx, cfg.StateDir, st, indexingState, logSink, emitter)
+	}()
 	startIngestWorker(runCtx, opts.readOnly, ing, indexingState, ingestErrCh)
-	startWatchWorker(runCtx, opts.readOnly, cfg.IngestWatch, ing, logSink)
+	startWatchWorker(runCtx, opts.readOnly, cfg.IngestWatch, ing, logSink, &bgWG)
 
 	return a.runEventLoop(runCtx, cancel, &cfg, st, indexingState, emitter, serverErrCh, ingestErrCh, embedErrCh, stdinQuitCh, logSink)
 }
@@ -737,7 +746,7 @@ type watchable interface {
 // the server.
 func startWatchWorker(runCtx context.Context, readOnly, enabled bool, ing interface {
 	Run(context.Context) error
-}, stderr io.Writer) {
+}, stderr io.Writer, wg *sync.WaitGroup) {
 	if !enabled {
 		return
 	}
@@ -751,7 +760,16 @@ func startWatchWorker(runCtx context.Context, readOnly, enabled bool, ing interf
 	if !ok {
 		return
 	}
+	// Register on the drain group so the deferred cancel()+Wait() in runUp waits
+	// for this goroutine to exit before returning; its Watch error logging would
+	// otherwise race a caller reading the shared sink after return (issue #419).
+	if wg != nil {
+		wg.Add(1)
+	}
 	go func() {
+		if wg != nil {
+			defer wg.Done()
+		}
 		if err := w.Watch(runCtx); err != nil && runCtx.Err() == nil {
 			_, _ = fmt.Fprintf(stderr, "watch: %v\n", err)
 		}
@@ -1107,7 +1125,7 @@ func startEmbeddingIfNotReadOnly(ctx context.Context, cfg config.Config, readOnl
 		return nil
 	}
 	if cfg.DistributedEmbed.Enabled {
-		return startDistributedEmbedding(ctx, cfg, st, chunkSource, textIx, codeIx, embedder, ret, indexingState, embedErrCh, embedLogger, embedModelText, embedModelCode, rootDir, corpusFS)
+		return startDistributedEmbedding(ctx, cfg, st, chunkSource, textIx, codeIx, embedder, ret, indexingState, embedErrCh, embedLogger, embedModelText, embedModelCode, rootDir, corpusFS, wg)
 	}
 	startEmbeddingWorkers(ctx, chunkSource, textIx, codeIx, embedder, ret, indexingState, embedErrCh, embedLogger, embedModelText, embedModelCode, rootDir, corpusFS, cfg.IngestLateChunking, wg)
 	return nil

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/charmbracelet/huh"
@@ -152,22 +153,39 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 	}
 	defer cleanupPIDFile()
 
+	// One mutex-guarded sink shared by every goroutine that logs to stderr during
+	// the concurrent phase (embed workers, corpus writer, watch worker, the
+	// persistence autosave callback, and the event loop). Without it, direct
+	// writef(stderr, ...) writes race the embed worker's *log.Logger writes on the
+	// same underlying sink (a bytes.Buffer under `go test -race`) — issue #419.
+	logSink := newSyncWriter(a.stderr)
+
 	persistence := index.NewPersistenceManager(
 		[]index.IndexedFile{
 			{Path: textIndexPath, Index: textIx},
 			{Path: codeIndexPath, Index: codeIx},
 		},
 		15*time.Second,
-		func(saveErr error) { writef(a.stderr, "index autosave warning: %v\n", saveErr) },
+		func(saveErr error) { writef(logSink, "index autosave warning: %v\n", saveErr) },
 	)
 	persistence.Start(runCtx)
 	defer a.stopPersistenceWithLog(persistence)
 
+	// Drain the embed workers before runUp returns. They are the goroutines whose
+	// unconditional startup/progress logging outlives the call otherwise, racing a
+	// caller that reads the sink after return (issue #419); waiting also stops them
+	// from touching the store/indices the deferred Close calls below tear down.
+	var embedWG sync.WaitGroup
+	defer func() {
+		cancel()
+		embedWG.Wait()
+	}()
+
 	embedErrCh := make(chan error, 4)
-	if err := startEmbeddingIfNotReadOnly(runCtx, cfg, opts.readOnly, st, textIx, codeIx, embedder, ret, indexingState, embedErrCh, a.stderr, opts.jsonOutput, etm, ecm, cfg.RootDir, corpusFS, emitter); err != nil {
+	if err := startEmbeddingIfNotReadOnly(runCtx, cfg, opts.readOnly, st, textIx, codeIx, embedder, ret, indexingState, embedErrCh, logSink, opts.jsonOutput, etm, ecm, cfg.RootDir, corpusFS, emitter, &embedWG); err != nil {
 		// A distributed-embedding setup failure is fatal: refuse to run a server
 		// that would silently never drain its pending queue.
-		writeCLIError(a.stderr, opts.jsonOutput, exitConfigInvalid, fmt.Sprintf("start embedding: %v", err))
+		writeCLIError(logSink, opts.jsonOutput, exitConfigInvalid, fmt.Sprintf("start embedding: %v", err))
 		return exitConfigInvalid
 	}
 
@@ -198,11 +216,11 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 	stdinQuitCh := a.installInteractionForUp(cancel, cfg, connection, auth, opts, nonInteractiveMode)
 
 	ingestErrCh := make(chan error, 1)
-	go runCorpusWriter(runCtx, cfg.StateDir, st, indexingState, a.stderr, emitter)
+	go runCorpusWriter(runCtx, cfg.StateDir, st, indexingState, logSink, emitter)
 	startIngestWorker(runCtx, opts.readOnly, ing, indexingState, ingestErrCh)
-	startWatchWorker(runCtx, opts.readOnly, cfg.IngestWatch, ing, a.stderr)
+	startWatchWorker(runCtx, opts.readOnly, cfg.IngestWatch, ing, logSink)
 
-	return a.runEventLoop(runCtx, cancel, &cfg, st, indexingState, emitter, serverErrCh, ingestErrCh, embedErrCh, stdinQuitCh)
+	return a.runEventLoop(runCtx, cancel, &cfg, st, indexingState, emitter, serverErrCh, ingestErrCh, embedErrCh, stdinQuitCh, logSink)
 }
 
 // applyTLSConfig resolves TLS cert/key from opts and cfg, validates them, and
@@ -753,6 +771,7 @@ func (a *App) runEventLoop(
 	ingestErrCh chan error,
 	embedErrCh <-chan error,
 	stdinQuitCh <-chan struct{},
+	logSink io.Writer,
 ) int {
 	for {
 		select {
@@ -763,7 +782,7 @@ func (a *App) runEventLoop(
 			return exitSuccess
 		case serverErr := <-serverErrCh:
 			if serverErr != nil {
-				writeCLIError(a.stderr, emitter.enabled, exitGeneric, fmt.Sprintf("server failed: %v", serverErr))
+				writeCLIError(logSink, emitter.enabled, exitGeneric, fmt.Sprintf("server failed: %v", serverErr))
 				emitter.Emit("error", "fatal", map[string]interface{}{
 					"code":    "SERVER_FAILURE",
 					"message": serverErr.Error(),
@@ -774,14 +793,14 @@ func (a *App) runEventLoop(
 		case ingestErr, ok := <-ingestErrCh:
 			if !ok {
 				ingestErrCh = nil
-				_ = writeCorpusSnapshot(runCtx, cfg.StateDir, st, indexingState, a.stderr, emitter)
+				_ = writeCorpusSnapshot(runCtx, cfg.StateDir, st, indexingState, logSink, emitter)
 				continue
 			}
 			if ingestErr == nil {
-				_ = writeCorpusSnapshot(runCtx, cfg.StateDir, st, indexingState, a.stderr, emitter)
+				_ = writeCorpusSnapshot(runCtx, cfg.StateDir, st, indexingState, logSink, emitter)
 				continue
 			}
-			writeCLIError(a.stderr, emitter.enabled, exitIngestionFatal, fmt.Sprintf("ingestion failed: %v", ingestErr))
+			writeCLIError(logSink, emitter.enabled, exitIngestionFatal, fmt.Sprintf("ingestion failed: %v", ingestErr))
 			emitter.Emit("error", "file_error", map[string]interface{}{
 				"message": ingestErr.Error(),
 			})
@@ -794,7 +813,7 @@ func (a *App) runEventLoop(
 			if embedErr == nil {
 				continue
 			}
-			writeCLIError(a.stderr, emitter.enabled, exitGeneric, fmt.Sprintf("embedding worker warning: %v", embedErr))
+			writeCLIError(logSink, emitter.enabled, exitGeneric, fmt.Sprintf("embedding worker warning: %v", embedErr))
 			emitter.Emit("error", "embed_error", map[string]interface{}{
 				"message": embedErr.Error(),
 			})
@@ -856,6 +875,7 @@ func startEmbeddingWorkers(
 	textModel, codeModel, rootDir string,
 	corpusFS corpusfs.CorpusFS,
 	lateChunking bool,
+	wg *sync.WaitGroup,
 ) {
 	if st == nil || embedder == nil {
 		return
@@ -887,7 +907,13 @@ func startEmbeddingWorkers(
 			},
 		}
 
+		if wg != nil {
+			wg.Add(1)
+		}
 		go func() {
+			if wg != nil {
+				defer wg.Done()
+			}
 			err := worker.Run(ctx, 750*time.Millisecond, workerKind)
 			if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 				return
@@ -1059,7 +1085,7 @@ func (a *App) stopPersistenceWithLog(persistence *index.PersistenceManager) {
 // It returns an error only for a distributed-mode SETUP failure (broker cannot be
 // built, store lacks ChunkTaskByID, no embed identity), which the caller treats as
 // fatal — the historical in-process path never errors here.
-func startEmbeddingIfNotReadOnly(ctx context.Context, cfg config.Config, readOnly bool, st model.Store, textIx, codeIx model.Index, embedder model.Embedder, ret *retrieval.Service, indexingState *appstate.IndexingState, embedErrCh chan error, stderr io.Writer, jsonOutput bool, embedModelText, embedModelCode, rootDir string, corpusFS corpusfs.CorpusFS, emitter *ndjsonEmitter) error {
+func startEmbeddingIfNotReadOnly(ctx context.Context, cfg config.Config, readOnly bool, st model.Store, textIx, codeIx model.Index, embedder model.Embedder, ret *retrieval.Service, indexingState *appstate.IndexingState, embedErrCh chan error, stderr io.Writer, jsonOutput bool, embedModelText, embedModelCode, rootDir string, corpusFS corpusfs.CorpusFS, emitter *ndjsonEmitter, wg *sync.WaitGroup) error {
 	if readOnly {
 		return nil
 	}
@@ -1083,7 +1109,7 @@ func startEmbeddingIfNotReadOnly(ctx context.Context, cfg config.Config, readOnl
 	if cfg.DistributedEmbed.Enabled {
 		return startDistributedEmbedding(ctx, cfg, st, chunkSource, textIx, codeIx, embedder, ret, indexingState, embedErrCh, embedLogger, embedModelText, embedModelCode, rootDir, corpusFS)
 	}
-	startEmbeddingWorkers(ctx, chunkSource, textIx, codeIx, embedder, ret, indexingState, embedErrCh, embedLogger, embedModelText, embedModelCode, rootDir, corpusFS, cfg.IngestLateChunking)
+	startEmbeddingWorkers(ctx, chunkSource, textIx, codeIx, embedder, ret, indexingState, embedErrCh, embedLogger, embedModelText, embedModelCode, rootDir, corpusFS, cfg.IngestLateChunking, wg)
 	return nil
 }
 

--- a/internal/cli/up_distributed_embed.go
+++ b/internal/cli/up_distributed_embed.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/dirstral/dir2mcp/internal/appstate"
@@ -47,6 +48,7 @@ func startDistributedEmbedding(
 	logger *log.Logger,
 	textModel, codeModel, rootDir string,
 	corpusFS corpusfs.CorpusFS,
+	wg *sync.WaitGroup,
 ) error {
 	// Setup failures are returned (not sent to errCh) so the caller can FAIL FAST:
 	// a server that cannot start its embedding topology would otherwise run
@@ -91,27 +93,44 @@ func startDistributedEmbedding(
 		Logger:        logger,
 	}
 
+	// Register every goroutine below on the caller's drain group so runUp's
+	// deferred cancel()+Wait() blocks until they exit before it closes the
+	// store/indices and returns — otherwise their logging (via logger → the shared
+	// sink) can race a caller reading that sink after return, and the worker can
+	// touch the store after Close (issue #419).
+	spawn := func(fn func()) {
+		if wg != nil {
+			wg.Add(1)
+		}
+		go func() {
+			if wg != nil {
+				defer wg.Done()
+			}
+			fn()
+		}()
+	}
+
 	// Close the broker when the run context ends so its handle (e.g. a SQLite DB)
 	// is released on shutdown.
-	go func() {
+	spawn(func() {
 		<-ctx.Done()
 		_ = broker.Close()
-	}()
+	})
 
 	// Coordinator: periodically enqueue chunks that are still pending. Each pass
 	// enqueues the current pending head; the ticker drives the full drain as the
 	// head clears and picks up chunks added later (incremental ingest), with no
 	// global ordering requirement (SPEC §8.7.3).
-	go runCoordinatorLoop(ctx, coord, errCh, logger)
+	spawn(func() { runCoordinatorLoop(ctx, coord, errCh, logger) })
 
 	// Worker: drain the queue. Errors are surfaced on errCh (cancellation is not
 	// an error), mirroring startEmbeddingWorkers.
-	go func() {
+	spawn(func() {
 		if rerr := embedqueue.Run(ctx, workerCfg); rerr != nil &&
 			!errors.Is(rerr, context.Canceled) && !errors.Is(rerr, context.DeadlineExceeded) {
 			errCh <- fmt.Errorf("distributed embed worker: %w", rerr)
 		}
-	}()
+	})
 	return nil
 }
 

--- a/tests/cli/racetimeout_norace.go
+++ b/tests/cli/racetimeout_norace.go
@@ -1,0 +1,9 @@
+//go:build !race
+
+package tests
+
+import "time"
+
+// raceScaled is the identity outside `-race` builds; see the race-tagged variant
+// for why deadlines are expanded when the race detector is enabled.
+func raceScaled(d time.Duration) time.Duration { return d }

--- a/tests/cli/racetimeout_race.go
+++ b/tests/cli/racetimeout_race.go
@@ -1,0 +1,12 @@
+//go:build race
+
+package tests
+
+import "time"
+
+// raceScaled expands a fixed test deadline when the binary is built with the
+// race detector. `-race` slows the CGO sqlite store-init/query paths roughly an
+// order of magnitude, so deadlines that are generous in a normal build would
+// otherwise expire under load and produce spurious "context deadline exceeded"
+// failures that have nothing to do with a data race (issue #419).
+func raceScaled(d time.Duration) time.Duration { return d * 10 }

--- a/tests/cli/syncwriter_test.go
+++ b/tests/cli/syncwriter_test.go
@@ -1,19 +1,21 @@
-package cli
+package tests
 
 import (
 	"bytes"
 	"sync"
 	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/cli"
 )
 
 // TestSyncWriterSerializesConcurrentWrites is the focused regression guard for
 // issue #419: many goroutines writing to one shared sink (here a bytes.Buffer,
 // as in the CLI tests) must not race or lose bytes. Run under `go test -race`
-// this fails if syncWriter drops its mutex; even without -race the byte count
+// this fails if SyncWriter drops its mutex; even without -race the byte count
 // assertion catches a torn Buffer.grow.
 func TestSyncWriterSerializesConcurrentWrites(t *testing.T) {
 	var buf bytes.Buffer
-	w := newSyncWriter(&buf)
+	w := cli.NewSyncWriter(&buf)
 
 	const goroutines, perGoroutine = 8, 250
 	line := []byte("embed worker started [kind=text]\n")
@@ -42,8 +44,8 @@ func TestSyncWriterSerializesConcurrentWrites(t *testing.T) {
 // an already-synchronized sink is wrapped again (e.g. both the embed logger and
 // the event loop route through the shared sink).
 func TestNewSyncWriterDoesNotDoubleWrap(t *testing.T) {
-	inner := newSyncWriter(&bytes.Buffer{})
-	if got := newSyncWriter(inner); got != inner {
-		t.Fatalf("newSyncWriter double-wrapped an existing *syncWriter: got %p, want %p", got, inner)
+	inner := cli.NewSyncWriter(&bytes.Buffer{})
+	if got := cli.NewSyncWriter(inner); got != inner {
+		t.Fatalf("NewSyncWriter double-wrapped an existing *SyncWriter: got %p, want %p", got, inner)
 	}
 }

--- a/tests/cli/up_command_test.go
+++ b/tests/cli/up_command_test.go
@@ -82,7 +82,7 @@ func TestUpCreatesSecretTokenAndConnectionFile(t *testing.T) {
 	app := cli.NewAppWithIO(&stdout, &stderr)
 
 	withWorkingDir(t, tmp, func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), raceScaled(2*time.Second))
 		defer cancel()
 		code := app.RunWithContext(ctx, []string{"up", "--listen", "127.0.0.1:0"})
 		if code != 0 {
@@ -168,7 +168,7 @@ func TestUpBannerPrintsRegistrationHintWithUniqueName(t *testing.T) {
 	app := cli.NewAppWithIO(&stdout, &stderr)
 
 	withWorkingDir(t, tmp, func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), raceScaled(2*time.Second))
 		defer cancel()
 		code := app.RunWithContext(ctx, []string{"up", "--listen", "127.0.0.1:0"})
 		if code != 0 {
@@ -221,7 +221,7 @@ func TestUpSupportsGlobalDirAndStateDirFlags(t *testing.T) {
 	app := cli.NewAppWithIO(&stdout, &stderr)
 
 	withWorkingDir(t, tmp, func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), raceScaled(2*time.Second))
 		defer cancel()
 
 		code := app.RunWithContext(ctx, []string{
@@ -305,7 +305,7 @@ func TestUpTLSConnectionURLUsesHTTPS(t *testing.T) {
 	app := cli.NewAppWithIO(&stdout, &stderr)
 
 	withWorkingDir(t, tmp, func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), raceScaled(2*time.Second))
 		defer cancel()
 
 		code := app.RunWithContext(ctx, []string{
@@ -344,7 +344,7 @@ func TestUpWarnsAboutFacilitatorTokenConflict(t *testing.T) {
 	app := cli.NewAppWithIO(&stdout, &stderr)
 
 	withWorkingDir(t, tmp, func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), raceScaled(2*time.Second))
 		defer cancel()
 
 		code := app.RunWithContext(ctx, []string{
@@ -510,7 +510,7 @@ func TestReindexPassesConfigToNewIngestor(t *testing.T) {
 	})
 
 	withWorkingDir(t, tmp, func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), raceScaled(2*time.Second))
 		defer cancel()
 		code := app.RunWithContext(ctx, []string{"reindex"})
 		if code != 0 {
@@ -564,7 +564,7 @@ func TestReindexClearsContentHashesBeforeRun(t *testing.T) {
 	})
 
 	withWorkingDir(t, tmp, func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), raceScaled(2*time.Second))
 		defer cancel()
 		code := app.RunWithContext(ctx, []string{"reindex"})
 		if code != 0 {
@@ -609,7 +609,7 @@ func TestUpJSONConnectionEventIncludesTokenSourceForFileAuth(t *testing.T) {
 	app := cli.NewAppWithIO(&stdout, &stderr)
 
 	withWorkingDir(t, tmp, func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), raceScaled(2*time.Second))
 		defer cancel()
 
 		code := app.RunWithContext(ctx, []string{
@@ -681,7 +681,7 @@ func TestUpJSONPreloadErrorEmitsWarningEvent(t *testing.T) {
 	})
 
 	withWorkingDir(t, tmp, func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), raceScaled(2*time.Second))
 		defer cancel()
 
 		code := app.RunWithContext(ctx, []string{"up", "--json", "--listen", "127.0.0.1:0"})
@@ -798,7 +798,7 @@ func TestUpDefaultListenStaysLoopbackWhenNotPublic(t *testing.T) {
 	app := cli.NewAppWithIO(&stdout, &stderr)
 
 	withWorkingDir(t, tmp, func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), raceScaled(2*time.Second))
 		defer cancel()
 		code := app.RunWithContext(ctx, []string{"up"})
 		if code != 0 {
@@ -826,7 +826,7 @@ func TestUpPublicWithoutListenBindsAllInterfaces(t *testing.T) {
 	app := cli.NewAppWithIO(&stdout, &stderr)
 
 	withWorkingDir(t, tmp, func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), raceScaled(2*time.Second))
 		defer cancel()
 		code := app.RunWithContext(ctx, []string{"up", "--public"})
 		if code != 0 {
@@ -898,7 +898,7 @@ func TestUpPublicAuthNoneAllowedWithForceInsecure(t *testing.T) {
 	app := cli.NewAppWithIO(&stdout, &stderr)
 
 	withWorkingDir(t, tmp, func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), raceScaled(2*time.Second))
 		defer cancel()
 		code := app.RunWithContext(ctx, []string{"up", "--public", "--auth", "none", "--force-insecure", "--json"})
 		if code != 0 {
@@ -949,7 +949,7 @@ func TestUpX402OnAllowsMissingFields(t *testing.T) {
 	app := cli.NewAppWithIO(&stdout, &stderr)
 
 	withWorkingDir(t, tmp, func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), raceScaled(2*time.Second))
 		defer cancel()
 
 		code := app.RunWithContext(ctx, []string{
@@ -997,7 +997,7 @@ func TestUpPublicRespectsExplicitListen(t *testing.T) {
 	app := cli.NewAppWithIO(&stdout, &stderr)
 
 	withWorkingDir(t, tmp, func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), raceScaled(2*time.Second))
 		defer cancel()
 		code := app.RunWithContext(ctx, []string{"up", "--public", "--listen", "127.0.0.1:0"})
 		if code != 0 {
@@ -1025,7 +1025,7 @@ func TestUpPublicNDJSONServerStartedIncludesPublicField(t *testing.T) {
 	app := cli.NewAppWithIO(&stdout, &stderr)
 
 	withWorkingDir(t, tmp, func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), raceScaled(2*time.Second))
 		defer cancel()
 		code := app.RunWithContext(ctx, []string{"up", "--public", "--json", "--read-only"})
 		if code != 0 {

--- a/tests/security/cli_boundary_test.go
+++ b/tests/security/cli_boundary_test.go
@@ -195,6 +195,8 @@ func TestRepoSplitBoundary_InternalCLIFileOwnership(t *testing.T) {
 		"style.go":                        {},
 		"support_bundle.go":               {},
 		"support_bundle_internal_test.go": {},
+		"syncwriter.go":                   {},
+		"syncwriter_test.go":              {},
 		"up.go":                           {},
 		"up_daemon.go":                    {},
 		"up_distributed_embed.go":         {},

--- a/tests/store/racetimeout_norace.go
+++ b/tests/store/racetimeout_norace.go
@@ -1,0 +1,8 @@
+//go:build !race
+
+package tests
+
+import "time"
+
+// raceScaled is the identity outside `-race` builds; see the race-tagged variant.
+func raceScaled(d time.Duration) time.Duration { return d }

--- a/tests/store/racetimeout_race.go
+++ b/tests/store/racetimeout_race.go
@@ -1,0 +1,12 @@
+//go:build race
+
+package tests
+
+import "time"
+
+// raceScaled expands a fixed test deadline when the binary is built with the
+// race detector. `-race` slows the CGO sqlite paths (and WAL lock contention)
+// roughly an order of magnitude, so a deadline that is ample normally would
+// otherwise expire and produce a spurious "context deadline exceeded" failure
+// unrelated to any data race (issue #419).
+func raceScaled(d time.Duration) time.Duration { return d * 10 }

--- a/tests/store/sqlite_store_test.go
+++ b/tests/store/sqlite_store_test.go
@@ -754,7 +754,7 @@ func TestSQLiteStore_CorpusStats_Empty(t *testing.T) {
 }
 
 func TestSQLiteStoreConcurrentReadWriteWithWAL(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), raceScaled(5*time.Second))
 	defer cancel()
 
 	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))


### PR DESCRIPTION
## Summary

`CGO_ENABLED=1 go test -race ./...` reported **3 `WARNING: DATA RACE`** in `tests/cli` (issue #419). The embed-worker `*log.Logger` wrote to the process stderr sink — a `bytes.Buffer` under `-race` — while the test read it, because the detached embed workers outlived `runUp`, and several goroutines (embed workers, corpus writer, watch worker, event loop, persistence callback) wrote to that one sink with no shared lock.

## Fixes

- **Mutex-guarded sink**: new `syncWriter` (an `io.Writer` guarding writes with a `sync.Mutex`). `runUp` wraps stderr once and routes every concurrent-phase writer through the shared instance, so their writes serialize.
- **Drain embed workers before return**: `startEmbeddingWorkers` now registers each goroutine on a `sync.WaitGroup`; `runUp` cancels and waits for it before returning. This stops the workers' unconditional startup/progress logging from racing a caller that reads the sink after return, and also prevents workers from touching the store/indices the deferred `Close` calls tear down.

## CI / regression coverage

- `make test-race` target + a `race` CI job in `.github/workflows/go.yml` — `make check`/`ci` run `CGO_ENABLED=0` and never exercised `-race`, so these regressions shipped unobserved.
- Focused `syncWriter` concurrency unit test.
- The race detector slows CGO sqlite ~10x, so the deadline-bounded `up`/store tests were expiring under `-race` for reasons unrelated to any data race. A build-tagged `raceScaled()` helper (`//go:build race`) expands those fixed deadlines only under `-race`; normal builds are unchanged.

## Verification

Before (`CGO_ENABLED=1 go test -race ./tests/cli ./tests/store`): 3 DATA RACE warnings, `tests/cli` + `tests/store` FAIL.

After (`make test-race` scope):
```
ok  github.com/dirstral/dir2mcp/internal/cli   7.795s
ok  github.com/dirstral/dir2mcp/tests/cli      347.257s
ok  github.com/dirstral/dir2mcp/tests/index    6.827s
ok  github.com/dirstral/dir2mcp/tests/store    30.330s
```
0 data races. `make check` (CGO_ENABLED=0, lint v2.10.1, gocyclo ≤15) passes.

Closes #419

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR eliminates three data races (issue #419) in the `up` command's concurrent phase by introducing a mutex-guarded `SyncWriter` sink and a `sync.WaitGroup` drain for all background goroutines before `runUp` returns.

- **`SyncWriter`**: wraps `a.stderr` once in `runUp`; every concurrent writer (embed workers, corpus writer, watch worker, event loop, autosave callback) routes through this single shared lock, preventing torn writes to the underlying `bytes.Buffer` under `-race`.
- **`bgWG` drain**: embed workers (local and distributed), the corpus writer, and the watch worker are all registered on a `WaitGroup` whose deferred `cancel()+Wait()` fires in LIFO order before `st.Close()` / index `Close()`, preventing use-after-close and post-return log writes that race test readers.
- **Race-CI coverage**: a new `make test-race` / `.github/workflows/go.yml race` job runs the goroutine-heavy packages under `CGO_ENABLED=1 go test -race`; `raceScaled()` build-tag helpers expand fixed deadlines 10× only under `-race` to absorb CGO sqlite overhead.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the concurrency fix is mechanically sound and the new race-detector CI job validates it end-to-end.

The SyncWriter and bgWG drain are correctly wired: wg.Add always precedes goroutine launch, the deferred drain executes in LIFO order before any store/index Close calls, and startIngestWorker (correctly omitted from bgWG) communicates only through a channel with no direct stderr writes. The distributed-embedding path now passes wg all the way through spawn, covering the gap that existed before this PR.

tests/security/cli_boundary_test.go has a ghost allowlist entry for syncwriter_test.go under internal/cli/ — the file lives in tests/cli/ and the entry should be removed.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/cli/up.go | All concurrent-phase writers routed through logSink; bgWG drain deferred correctly (LIFO order ensures goroutines exit before store/index Close calls); startIngestWorker correctly omitted (channel-only, no stderr writes). |
| internal/cli/syncwriter.go | New mutex-guarded io.Writer wrapper; correct double-wrap prevention; exported only for tests/ compliance. |
| internal/cli/up_distributed_embed.go | spawn helper correctly calls wg.Add before the goroutine starts and wg.Done inside; all three distributed goroutines (broker-closer, coordinator, worker) now tracked. |
| tests/security/cli_boundary_test.go | Adds syncwriter.go correctly, but also adds syncwriter_test.go which doesn't exist in internal/cli — ghost allowlist entry. |
| tests/cli/syncwriter_test.go | Focused concurrency regression guard for issue #419; correctly placed in tests/ per AGENTS.md; double-wrap and byte-count assertions are sound. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant runUp
    participant logSink as SyncWriter(logSink)
    participant embedWorkers as Embed Workers
    participant corpusWriter as Corpus Writer
    participant watchWorker as Watch Worker
    participant bgWG as bgWG (WaitGroup)

    runUp->>logSink: NewSyncWriter(a.stderr)
    runUp->>bgWG: register embed workers via startEmbeddingIfNotReadOnly
    runUp->>bgWG: bgWG.Add(1) — corpus writer
    runUp->>bgWG: bgWG.Add(1) — watch worker

    par concurrent writes (serialized by logSink)
        embedWorkers->>logSink: logger.Printf(...)
        corpusWriter->>logSink: writef(logSink, ...)
        watchWorker->>logSink: fmt.Fprintf(logSink, ...)
    end

    runUp->>runUp: runEventLoop returns
    Note over runUp: deferred bgWG drain (LIFO, runs first)
    runUp->>bgWG: cancel() → context cancelled
    embedWorkers-->>bgWG: bgWG.Done()
    corpusWriter-->>bgWG: bgWG.Done()
    watchWorker-->>bgWG: bgWG.Done()
    runUp->>bgWG: bgWG.Wait() returns
    Note over runUp: then st.Close() / index.Close() run safely
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant runUp
    participant logSink as SyncWriter(logSink)
    participant embedWorkers as Embed Workers
    participant corpusWriter as Corpus Writer
    participant watchWorker as Watch Worker
    participant bgWG as bgWG (WaitGroup)

    runUp->>logSink: NewSyncWriter(a.stderr)
    runUp->>bgWG: register embed workers via startEmbeddingIfNotReadOnly
    runUp->>bgWG: bgWG.Add(1) — corpus writer
    runUp->>bgWG: bgWG.Add(1) — watch worker

    par concurrent writes (serialized by logSink)
        embedWorkers->>logSink: logger.Printf(...)
        corpusWriter->>logSink: writef(logSink, ...)
        watchWorker->>logSink: fmt.Fprintf(logSink, ...)
    end

    runUp->>runUp: runEventLoop returns
    Note over runUp: deferred bgWG drain (LIFO, runs first)
    runUp->>bgWG: cancel() → context cancelled
    embedWorkers-->>bgWG: bgWG.Done()
    corpusWriter-->>bgWG: bgWG.Done()
    watchWorker-->>bgWG: bgWG.Done()
    runUp->>bgWG: bgWG.Wait() returns
    Note over runUp: then st.Close() / index.Close() run safely
```

</a>

<sub>Reviews (2): Last reviewed commit: ["review: address PR #484 comments"](https://github.com/dirstral/dir2mcp/commit/c025cb5c0fbe1494bf38fc2244a09b25d7fc6b23) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41248859)</sub>

<!-- /greptile_comment -->