### PR TITLE
fix(store,ingest): crash-safe done/embedded bookkeeping (#402)

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -106,7 +106,7 @@ type contentHashResetter interface {
 }
 
 type embeddedChunkLister interface {
-	ListEmbeddedChunkMetadata(ctx context.Context, indexKind string, limit, offset int) ([]model.ChunkTask, error)
+	ListEmbeddedChunkMetadata(ctx context.Context, indexKind string, limit int, afterChunkID int64) ([]model.ChunkTask, error)
 }
 
 type activeDocCountStore interface {

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -189,6 +189,14 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 		cancel()
 		bgWG.Wait()
 	}()
+	// Startup reconciliation (#402 A2): re-pend chunks sqlite counts embedded but
+	// whose vectors were lost to an ungraceful crash before the in-memory index's
+	// periodic snapshot. Must run before the embed worker so the re-pended chunks
+	// are picked up this session. No-op for durable backends and in read-only mode.
+	// Writes go through the synchronized logSink, not raw a.stderr: persistence
+	// autosave (started above) and the embed workers already write logSink
+	// concurrently, so a raw-stderr write here would race that shared sink (#419).
+	reconcileEmbeddedVectorsAtStartup(runCtx, opts.readOnly, st, textIx, codeIx, emitter, logSink)
 
 	embedErrCh := make(chan error, 4)
 	if err := startEmbeddingIfNotReadOnly(runCtx, cfg, opts.readOnly, st, textIx, codeIx, embedder, ret, indexingState, embedErrCh, logSink, opts.jsonOutput, etm, ecm, cfg.RootDir, corpusFS, emitter, &bgWG); err != nil {
@@ -854,9 +862,9 @@ func preloadEmbeddedChunkMetadata(ctx context.Context, source embeddedChunkListe
 	total := 0
 	kinds := []string{"text", "code"}
 	for _, kind := range kinds {
-		offset := 0
+		var afterChunkID int64
 		for {
-			tasks, err := source.ListEmbeddedChunkMetadata(ctx, kind, pageSize, offset)
+			tasks, err := source.ListEmbeddedChunkMetadata(ctx, kind, pageSize, afterChunkID)
 			if err != nil {
 				if errors.Is(err, model.ErrNotImplemented) {
 					break
@@ -874,7 +882,9 @@ func preloadEmbeddedChunkMetadata(ctx context.Context, source embeddedChunkListe
 			if len(tasks) < pageSize {
 				break
 			}
-			offset += len(tasks)
+			// Keyset seek: pages are ordered by chunk_id ascending, so carry the
+			// last chunk_id forward instead of an OFFSET that rescans skipped rows.
+			afterChunkID = int64(tasks[len(tasks)-1].Metadata.ChunkID)
 		}
 	}
 	return total, nil
@@ -895,6 +905,12 @@ var _ index.ChunkSource = (*store.SQLiteStore)(nil)
 // #364 failure mode one layer up). A signature drift on any RepresentationStore
 // method now breaks the build instead of silently dropping every document.
 var _ model.RepresentationStore = (*store.SQLiteStore)(nil)
+
+// Compile-time guard: the store MUST also satisfy index.EmbeddedVectorSource so
+// the runtime `st.(index.EmbeddedVectorSource)` assertion in
+// reconcileEmbeddedVectorsAtStartup keeps working — a signature drift would
+// otherwise silently disable the #402 A2 crash-recovery reconciliation.
+var _ index.EmbeddedVectorSource = (*store.SQLiteStore)(nil)
 
 func startEmbeddingWorkers(
 	ctx context.Context,
@@ -1117,6 +1133,54 @@ func (a *App) stopPersistenceWithLog(persistence *index.PersistenceManager) {
 	defer stopCancel()
 	if stopErr := persistence.StopAndSave(stopCtx); stopErr != nil && !errors.Is(stopErr, context.Canceled) {
 		writef(a.stderr, "final index save warning: %v\n", stopErr)
+	}
+}
+
+// reconcileEmbeddedVectorsAtStartup re-pends embedded chunks whose vectors are
+// missing from a crash-recovered vector index (issue #402 A2), for both the text
+// and code kinds. It is a no-op when the store does not expose the reconciliation
+// surface or the backend is durable (index.ReconcileEmbeddedVectors handles the
+// latter). Failures are logged, never fatal: a reconciliation error leaves the
+// corpus no worse off than before, so it must not block server startup.
+func reconcileEmbeddedVectorsAtStartup(ctx context.Context, readOnly bool, st model.Store, textIx, codeIx model.Index, emitter *ndjsonEmitter, stderr io.Writer) {
+	if readOnly {
+		return
+	}
+	source, ok := st.(index.EmbeddedVectorSource)
+	if !ok {
+		return
+	}
+	kinds := []struct {
+		name string
+		ix   model.Index
+	}{
+		{index.KindText, textIx},
+		{index.KindCode, codeIx},
+	}
+	total := 0
+	for _, k := range kinds {
+		n, err := index.ReconcileEmbeddedVectors(ctx, source, k.ix, k.name)
+		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				// Clean shutdown mid-reconciliation: expected, not worth a warning.
+				return
+			}
+			writef(stderr, "warning: embedded-vector reconciliation (%s) failed: %v\n", k.name, err)
+			if emitter != nil {
+				emitter.Emit("warning", "embedded_vector_reconcile_failed", map[string]interface{}{
+					"kind":    k.name,
+					"message": err.Error(),
+				})
+			}
+			continue
+		}
+		total += n
+	}
+	if total > 0 && emitter != nil {
+		emitter.Emit("info", "embedded_vectors_repended", map[string]interface{}{
+			"count":   total,
+			"message": "re-pending embedded chunks whose vectors were missing after an ungraceful shutdown",
+		})
 	}
 }
 

--- a/internal/index/hnsw_index.go
+++ b/internal/index/hnsw_index.go
@@ -114,6 +114,26 @@ func (i *HNSWIndex) Upsert(ctx context.Context, vector []float32, payload model.
 	return nil
 }
 
+// HasVectors reports, for each requested chunk ID, whether a vector is currently
+// present in the index. It implements VectorPresence (issue #402 A2): the
+// in-memory HNSW's durability is the periodic snapshot (~15s autosave), so an
+// ungraceful crash between MarkEmbedded and the next SaveAll silently drops
+// vectors that sqlite still counts embedded. Startup reconciliation calls this
+// to re-pend those chunks. A nil/empty request returns an empty map.
+func (i *HNSWIndex) HasVectors(ctx context.Context, chunkIDs []uint64) (map[uint64]bool, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	present := make(map[uint64]bool, len(chunkIDs))
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	for _, id := range chunkIDs {
+		_, ok := i.vectors[id]
+		present[id] = ok
+	}
+	return present, nil
+}
+
 // Delete removes the vectors and payloads for the given chunk IDs. Unknown IDs
 // are ignored.
 func (i *HNSWIndex) Delete(ctx context.Context, chunkIDs []uint64) error {

--- a/internal/index/reconcile.go
+++ b/internal/index/reconcile.go
@@ -1,0 +1,100 @@
+package index
+
+import (
+	"context"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// VectorPresence is an optional capability implemented by index backends whose
+// durability is NOT per-write — specifically the in-memory HNSW, whose vectors
+// only reach disk via the periodic snapshot (issue #402 A2). It reports which of
+// the given chunk IDs currently have a vector in the index so a startup
+// reconciliation can re-pend embedded chunks whose vectors were lost to an
+// ungraceful crash (SIGKILL/OOM/power loss) before the snapshot ran.
+//
+// Durable backends (disk, qdrant, pgvector) deliberately do NOT implement it:
+// their writes are individually durable and they rebuild from a durable store on
+// load, so there is nothing to reconcile. ReconcileEmbeddedVectors treats a
+// backend that does not implement VectorPresence as a no-op.
+type VectorPresence interface {
+	HasVectors(ctx context.Context, chunkIDs []uint64) (map[uint64]bool, error)
+}
+
+// EmbeddedVectorSource is the metadata-store surface ReconcileEmbeddedVectors
+// needs: it enumerates the chunks sqlite records as embedded and re-pends the
+// ones whose vector is missing. The shipped *store.SQLiteStore satisfies it.
+type EmbeddedVectorSource interface {
+	// ListEmbeddedChunkMetadata pages through chunks whose embedding_status is
+	// "ok" (embedded) for the given index kind using keyset (seek) pagination:
+	// afterChunkID is an exclusive lower bound on the ascending chunk_id key (pass
+	// 0 to start); the caller carries the last-seen chunk_id forward for the next
+	// page.
+	ListEmbeddedChunkMetadata(ctx context.Context, indexKind string, limit int, afterChunkID int64) ([]model.ChunkTask, error)
+	// RependEmbeddedChunks resets the given chunks' embedding_status to
+	// "pending" so the embed worker re-embeds them.
+	RependEmbeddedChunks(ctx context.Context, labels []uint64) error
+}
+
+// reconcilePageSize bounds each ListEmbeddedChunkMetadata page so the read scan
+// never materializes the whole embedded set at once.
+const reconcilePageSize = 500
+
+// ReconcileEmbeddedVectors re-pends chunks that sqlite records as embedded but
+// whose vector is absent from ix, and returns the number re-pended (issue #402
+// A2). It is a no-op — returning (0, nil) — when ix does not implement
+// VectorPresence (durable backends need no reconciliation).
+//
+// The read scan is kept strictly read-only (missing IDs are accumulated, not
+// re-pended, while paging) so keyset pagination walks a stable "ok" set; the
+// re-pend write happens once at the end. This avoids the pagination hazard of
+// mutating the very rows the pages are drawn from.
+//
+// Pages are fetched by keyset (seek) rather than OFFSET: each page seeks past the
+// last chunk_id seen, so every row is scanned once instead of OFFSET's quadratic
+// rescan-and-discard of skipped rows on large embedded sets.
+func ReconcileEmbeddedVectors(ctx context.Context, source EmbeddedVectorSource, ix model.Index, kind string) (int, error) {
+	presence, ok := ix.(VectorPresence)
+	if !ok {
+		return 0, nil
+	}
+
+	var missing []uint64
+	var afterChunkID int64
+	for {
+		chunks, err := source.ListEmbeddedChunkMetadata(ctx, kind, reconcilePageSize, afterChunkID)
+		if err != nil {
+			return 0, err
+		}
+		if len(chunks) == 0 {
+			break
+		}
+		ids := make([]uint64, len(chunks))
+		for i, c := range chunks {
+			ids[i] = c.Label
+		}
+		present, err := presence.HasVectors(ctx, ids)
+		if err != nil {
+			return 0, err
+		}
+		for _, id := range ids {
+			if id != 0 && !present[id] {
+				missing = append(missing, id)
+			}
+		}
+		if len(chunks) < reconcilePageSize {
+			break
+		}
+		// Seek past the last chunk_id in this page (rows are ordered by chunk_id
+		// ascending, so the final Label is the greatest key seen so far).
+		afterChunkID = int64(chunks[len(chunks)-1].Label)
+	}
+
+	if len(missing) == 0 {
+		return 0, nil
+	}
+	if err := source.RependEmbeddedChunks(ctx, missing); err != nil {
+		return 0, err
+	}
+	return len(missing), nil
+}

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -1282,6 +1282,8 @@ func (s *Service) processDocument(ctx context.Context, f DiscoveredFile, secretP
 	}
 
 	needsProcessing := s.resolveNeedsProcessing(ctx, existingDoc, doc, forceReindex)
+	finalContentHash, willGenerateReps := withholdContentHash(&doc, needsProcessing)
+
 	if err := s.store.UpsertDocument(ctx, doc); err != nil {
 		return fmt.Errorf("upsert document: %w", err)
 	}
@@ -1324,6 +1326,13 @@ func (s *Service) processDocument(ctx context.Context, f DiscoveredFile, secretP
 		_ = s.store.UpsertDocument(ctx, doc)
 		return fmt.Errorf("generate representations: %w", err)
 	}
+	// Representations committed: stamp the withheld #402 done marker now that the
+	// chunks are durably written. finalizeContentHash re-reads the row, so a
+	// document a soft-error path persisted as status="error" is left unmarked and
+	// retried next run rather than recorded as fully indexed.
+	if err := s.finalizeIfGenerated(ctx, &doc, willGenerateReps, finalContentHash); err != nil {
+		return err
+	}
 	if nonFatalErrored {
 		// A non-fatal soft-error path (binary-content, video-no-representation, or
 		// a zero-representation provider failure) already persisted this document
@@ -1334,6 +1343,84 @@ func (s *Service) processDocument(ctx context.Context, f DiscoveredFile, secretP
 		indexedPending = false
 	}
 	s.creditIndexed(indexedPending)
+	return nil
+}
+
+// withholdContentHash implements the #402 done-marker withholding. A document's
+// content_hash is the incremental "done" marker — resolveNeedsProcessing treats a
+// stored hash equal to the freshly computed one as "already indexed, skip".
+// Committing that marker in the doc upsert *before* the representations/chunks
+// are durably written means an ungraceful death (SIGKILL/OOM/power loss) in that
+// gap leaves an ok document carrying the done marker but zero chunks —
+// permanently invisible to search/ask and never reprocessed. When this run will
+// (re)generate representations, blank the marker on the initial upsert so it is
+// stamped only after the reps commit (see finalizeContentHash); it returns the
+// original hash to finalize with and whether withholding applied.
+func withholdContentHash(doc *model.Document, needsProcessing bool) (finalContentHash string, willGenerateReps bool) {
+	willGenerateReps = needsProcessing && doc.Status == "ok" && doc.DocType != "archive"
+	finalContentHash = doc.ContentHash
+	if willGenerateReps {
+		doc.ContentHash = ""
+	}
+	return finalContentHash, willGenerateReps
+}
+
+// finalizeIfGenerated stamps the withheld #402 done marker via finalizeContentHash
+// when this run generated representations for doc, and is a no-op otherwise. Split
+// out so processDocument/processDocumentFromContent stay within the cyclomatic
+// complexity limit.
+func (s *Service) finalizeIfGenerated(ctx context.Context, doc *model.Document, willGenerateReps bool, contentHash string) error {
+	if !willGenerateReps {
+		return nil
+	}
+	return s.finalizeContentHash(ctx, doc, contentHash)
+}
+
+// finalizeContentHash stamps the withheld content_hash "done" marker only after a
+// document's representations/chunks are durably committed (#402). It re-reads the
+// current row first for two reasons:
+//
+//   - #413: it never overwrites an out-of-band status="error" that a non-fatal
+//     per-representation failure may have persisted while generateRepresentations
+//     still returned nil (e.g. a transcript provider outage). Such a document keeps
+//     an empty content_hash and is retried on the next incremental run rather than
+//     being falsely recorded as fully indexed.
+//   - It upserts the re-read row rather than the by-value doc, so out-of-band
+//     column writes made during representation generation — notably the title
+//     (persistTitle/persistTitleIfFound writes documents.title on a separate
+//     upsert against the DB row, invisible to this function's by-value doc) —
+//     survive. Only the withheld content_hash comes from this finalize step; every
+//     other column is taken from the freshly re-read row.
+//
+// Paths are explicit: found → upsert the re-read row (preserving out-of-band
+// columns) after the #413 guard; not-found → recreate the row from doc (there is
+// no current row whose columns must be preserved); store error → propagate.
+func (s *Service) finalizeContentHash(ctx context.Context, doc *model.Document, contentHash string) error {
+	current, err := s.store.GetDocumentByPath(ctx, doc.RelPath)
+	if err != nil {
+		if !isNotFoundError(err) {
+			return fmt.Errorf("fetch document before finalizing content hash: %w", err)
+		}
+		// Not found: the initial upsert's row is gone (deleted mid-run) or never
+		// landed. There are no out-of-band columns to preserve, so deliberately
+		// recreate the row from doc with the withheld hash stamped on.
+		doc.ContentHash = contentHash
+		if err := s.store.UpsertDocument(ctx, *doc); err != nil {
+			return fmt.Errorf("finalize document content hash: %w", err)
+		}
+		return nil
+	}
+	// #413 guard: a non-fatal per-representation failure may have persisted
+	// status="error" out-of-band; never resurrect it into a done state.
+	if current.Status != "ok" {
+		return nil
+	}
+	// Stamp the withheld done marker onto the re-read row so out-of-band writes
+	// (e.g. title) survive, then upsert that row rather than the by-value doc.
+	current.ContentHash = contentHash
+	if err := s.store.UpsertDocument(ctx, current); err != nil {
+		return fmt.Errorf("finalize document content hash: %w", err)
+	}
 	return nil
 }
 
@@ -1646,6 +1733,11 @@ func (s *Service) processDocumentFromContent(ctx context.Context, relPath string
 	}
 	needsProcessing := s.resolveNeedsProcessing(ctx, existingDoc, doc, forceReindex)
 
+	// Withhold the content_hash done marker until representations commit so an
+	// ungraceful crash mid-ingest cannot leave an ok archive member with zero
+	// chunks that is never reprocessed (#402; see withholdContentHash).
+	finalContentHash, willGenerateReps := withholdContentHash(&doc, needsProcessing)
+
 	if err := s.store.UpsertDocument(ctx, doc); err != nil {
 		return fmt.Errorf("upsert document: %w", err)
 	}
@@ -1669,6 +1761,10 @@ func (s *Service) processDocumentFromContent(ctx context.Context, relPath string
 		doc.ErrorMessage = RedactSecretsInMessage(err.Error(), secretPatterns)
 		_ = s.store.UpsertDocument(ctx, doc)
 		return fmt.Errorf("generate representations: %w", err)
+	}
+	// Stamp the withheld #402 done marker now the archive member's reps commit.
+	if err := s.finalizeIfGenerated(ctx, &doc, willGenerateReps, finalContentHash); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -1923,7 +1923,13 @@ func (s *SQLiteStore) ChunkModalityPresence(ctx context.Context, relPath string)
 	return m == 1, t == 1, nil
 }
 
-func (s *SQLiteStore) ListEmbeddedChunkMetadata(ctx context.Context, indexKind string, limit, offset int) ([]model.ChunkTask, error) {
+// ListEmbeddedChunkMetadata pages through embedded ("ok") chunks using keyset
+// (seek) pagination: afterChunkID is an exclusive lower bound on chunk_id (pass 0
+// to start), and callers carry the last chunk_id of each page forward as the next
+// afterChunkID. Rows are ordered by chunk_id ascending, so this walks each row
+// exactly once — unlike OFFSET, which rescans and discards skipped rows every
+// page (quadratic on large embedded sets).
+func (s *SQLiteStore) ListEmbeddedChunkMetadata(ctx context.Context, indexKind string, limit int, afterChunkID int64) ([]model.ChunkTask, error) {
 	db, err := s.ensureDB(ctx)
 	if err != nil {
 		return nil, err
@@ -1932,15 +1938,15 @@ func (s *SQLiteStore) ListEmbeddedChunkMetadata(ctx context.Context, indexKind s
 	if limit <= 0 {
 		limit = 500
 	}
-	if offset < 0 {
-		offset = 0
+	if afterChunkID < 0 {
+		afterChunkID = 0
 	}
 
-	args := []any{"ok"}
+	args := []any{"ok", afterChunkID}
 	query := `WITH filtered_chunks AS (
 	            SELECT c.chunk_id, c.rel_path, c.doc_type, c.rep_type, c.text, c.index_kind, c.modality, c.media_ref, c.language
 	            FROM chunks c
-	            WHERE c.embedding_status = ? AND c.deleted = 0 AND c.chunk_id > 0
+	            WHERE c.embedding_status = ? AND c.deleted = 0 AND c.chunk_id > ?
 	          ),
 	          ranked_spans AS (
 	            SELECT s.chunk_id, s.span_kind, s.start, s."end", s.extra_json,
@@ -1958,8 +1964,8 @@ func (s *SQLiteStore) ListEmbeddedChunkMetadata(ctx context.Context, indexKind s
 		query += ` WHERE fc.index_kind = ?`
 		args = append(args, indexKind)
 	}
-	args = append(args, limit, offset)
-	query += ` ORDER BY fc.chunk_id LIMIT ? OFFSET ?`
+	args = append(args, limit)
+	query += ` ORDER BY fc.chunk_id LIMIT ?`
 
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -2134,6 +2140,15 @@ func SpanFromRow(kind string, start, end int, extraJSON string) model.Span {
 
 func (s *SQLiteStore) MarkEmbedded(ctx context.Context, labels []uint64) error {
 	return s.markEmbeddingStatus(ctx, labels, "ok", "", "")
+}
+
+// RependEmbeddedChunks resets the given chunks' embedding_status back to
+// "pending" (clearing any stale error/category) so the embed worker re-embeds
+// them via NextPending. It is used by startup reconciliation (issue #402 A2)
+// when an embedded chunk's vector is missing from a crash-recovered in-memory
+// index, restoring recall that would otherwise be silently lost.
+func (s *SQLiteStore) RependEmbeddedChunks(ctx context.Context, labels []uint64) error {
+	return s.markEmbeddingStatus(ctx, labels, "pending", "", "")
 }
 
 // MarkFailed retains its original signature for callers that have not

--- a/tests/cli/up_command_test.go
+++ b/tests/cli/up_command_test.go
@@ -54,7 +54,7 @@ func (f *fakeErrorStore) Close() error { return nil }
 
 // implement embeddedChunkLister so preloadEmbeddedChunkMetadata will hit our
 // injected failure.
-func (f *fakeErrorStore) ListEmbeddedChunkMetadata(ctx context.Context, indexKind string, limit, offset int) ([]model.ChunkTask, error) {
+func (f *fakeErrorStore) ListEmbeddedChunkMetadata(ctx context.Context, indexKind string, limit int, afterChunkID int64) ([]model.ChunkTask, error) {
 	return nil, f.err
 }
 

--- a/tests/index/reconcile_test.go
+++ b/tests/index/reconcile_test.go
@@ -1,0 +1,136 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// fakeEmbeddedSource records the embedded chunks per kind and the labels
+// re-pended by reconciliation. It paginates over the recorded set so
+// ReconcileEmbeddedVectors exercises its paging loop.
+type fakeEmbeddedSource struct {
+	byKind   map[string][]uint64
+	repended []uint64
+	listErr  error
+	repErr   error
+}
+
+func (f *fakeEmbeddedSource) ListEmbeddedChunkMetadata(_ context.Context, kind string, limit int, afterChunkID int64) ([]model.ChunkTask, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	// Mirror the store's keyset semantics: return Labels strictly greater than
+	// afterChunkID, ordered ascending, capped at limit.
+	ids := append([]uint64(nil), f.byKind[kind]...)
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	out := make([]model.ChunkTask, 0, limit)
+	for _, id := range ids {
+		if int64(id) <= afterChunkID {
+			continue
+		}
+		out = append(out, model.ChunkTask{Label: id, IndexKind: kind})
+		if len(out) == limit {
+			break
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeEmbeddedSource) RependEmbeddedChunks(_ context.Context, labels []uint64) error {
+	if f.repErr != nil {
+		return f.repErr
+	}
+	f.repended = append(f.repended, labels...)
+	return nil
+}
+
+// stubIndex is a minimal model.Index that deliberately does NOT implement
+// index.VectorPresence, standing in for a durable backend.
+type stubIndex struct{ model.Index }
+
+func mustUpsertChunk(t *testing.T, ix *index.HNSWIndex, id uint64) {
+	t.Helper()
+	if err := ix.Upsert(context.Background(), []float32{1, 0, 0}, model.IndexPayload{ChunkID: id}); err != nil {
+		t.Fatalf("upsert %d: %v", id, err)
+	}
+}
+
+// TestReconcileEmbeddedVectors_RependsMissing pins the #402 A2 fix: chunks that
+// sqlite records embedded but whose vectors are absent from a crash-recovered
+// in-memory index are re-pended so the embed worker re-embeds them.
+func TestReconcileEmbeddedVectors_RependsMissing(t *testing.T) {
+	ix := index.NewHNSWIndex("")
+	// Chunks 1 and 2 have vectors; chunk 3 was "embedded" per sqlite but its
+	// vector was lost to a crash before the snapshot.
+	mustUpsertChunk(t, ix, 1)
+	mustUpsertChunk(t, ix, 2)
+
+	src := &fakeEmbeddedSource{byKind: map[string][]uint64{index.KindText: {1, 2, 3}}}
+
+	n, err := index.ReconcileEmbeddedVectors(context.Background(), src, ix, index.KindText)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("re-pended count = %d, want 1", n)
+	}
+	if len(src.repended) != 1 || src.repended[0] != 3 {
+		t.Fatalf("re-pended labels = %v, want [3]", src.repended)
+	}
+}
+
+// TestReconcileEmbeddedVectors_AllPresentNoop verifies no re-pend happens when
+// every embedded chunk's vector is present.
+func TestReconcileEmbeddedVectors_AllPresentNoop(t *testing.T) {
+	ix := index.NewHNSWIndex("")
+	mustUpsertChunk(t, ix, 10)
+	mustUpsertChunk(t, ix, 11)
+	src := &fakeEmbeddedSource{byKind: map[string][]uint64{index.KindText: {10, 11}}}
+
+	n, err := index.ReconcileEmbeddedVectors(context.Background(), src, ix, index.KindText)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if n != 0 || len(src.repended) != 0 {
+		t.Fatalf("expected no re-pend, got n=%d repended=%v", n, src.repended)
+	}
+}
+
+// TestReconcileEmbeddedVectors_DurableBackendNoop verifies that a backend which
+// does not implement VectorPresence (durable: disk/qdrant/pgvector) is skipped
+// entirely — the store is never consulted.
+func TestReconcileEmbeddedVectors_DurableBackendNoop(t *testing.T) {
+	src := &fakeEmbeddedSource{
+		byKind:  map[string][]uint64{index.KindText: {1, 2, 3}},
+		listErr: errors.New("store must not be consulted for a durable backend"),
+	}
+	n, err := index.ReconcileEmbeddedVectors(context.Background(), src, stubIndex{}, index.KindText)
+	if err != nil {
+		t.Fatalf("reconcile durable: %v", err)
+	}
+	if n != 0 || len(src.repended) != 0 {
+		t.Fatalf("expected durable backend no-op, got n=%d repended=%v", n, src.repended)
+	}
+}
+
+// TestHNSWHasVectors_ReportsPresence pins the membership primitive used by
+// reconciliation.
+func TestHNSWHasVectors_ReportsPresence(t *testing.T) {
+	ix := index.NewHNSWIndex("")
+	mustUpsertChunk(t, ix, 7)
+	present, err := ix.HasVectors(context.Background(), []uint64{7, 8})
+	if err != nil {
+		t.Fatalf("HasVectors: %v", err)
+	}
+	if !present[7] {
+		t.Fatalf("chunk 7 should be present")
+	}
+	if present[8] {
+		t.Fatalf("chunk 8 should be absent")
+	}
+}

--- a/tests/ingest/crash_consistency_test.go
+++ b/tests/ingest/crash_consistency_test.go
@@ -1,0 +1,157 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+)
+
+// TestProcessDocument_WithholdsContentHashUntilRepsCommit pins the #402 A1 fix:
+// the content_hash "done" marker is NOT written on the initial document upsert;
+// it is stamped only after the representations/chunks are committed. This is what
+// makes an ungraceful crash mid-ingest recoverable — the incremental gate keys
+// off content_hash, so a document that never reached the finalize step is
+// reprocessed on restart instead of being silently skipped with zero chunks.
+func TestProcessDocument_WithholdsContentHashUntilRepsCommit(t *testing.T) {
+	root := t.TempDir()
+	absPath := filepath.Join(root, "note.txt")
+	content := "hello world, this is indexable text"
+	if err := os.WriteFile(absPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	wantHash := ingest.ComputeContentHash([]byte(content))
+
+	st := &fakeIncrementalStore{reflectUpserts: true} // new document, needs processing
+	svc := mustNewIngestService(t, config.Config{RootDir: root}, st)
+	df := ingest.DiscoveredFile{AbsPath: absPath, RelPath: "note.txt", SizeBytes: int64(len(content))}
+
+	if err := svc.ProcessDocument(context.Background(), df, nil, false); err != nil {
+		t.Fatalf("processDocument failed: %v", err)
+	}
+
+	if len(st.upsertedDocs) < 2 {
+		t.Fatalf("expected at least two document upserts (withhold + finalize), got %d", len(st.upsertedDocs))
+	}
+	// First upsert must NOT carry the done marker.
+	if st.upsertedDocs[0].ContentHash != "" {
+		t.Fatalf("initial upsert leaked the content_hash done marker: %q", st.upsertedDocs[0].ContentHash)
+	}
+	if st.upsertedDocs[0].Status != "ok" {
+		t.Fatalf("initial upsert status = %q, want ok", st.upsertedDocs[0].Status)
+	}
+	// Reps/chunks must have been committed before the finalize upsert.
+	if st.insertChunkCalls == 0 {
+		t.Fatalf("expected chunks to be committed")
+	}
+	// Final upsert stamps the real hash.
+	last := st.upsertedDocs[len(st.upsertedDocs)-1]
+	if last.ContentHash != wantHash {
+		t.Fatalf("finalize upsert content_hash = %q, want %q", last.ContentHash, wantHash)
+	}
+}
+
+// TestProcessDocument_CrashDuringRepsNeverMarksDone pins that a failure while
+// committing representations (a stand-in for a SIGKILL/OOM in that window) never
+// leaves the content_hash done marker set. The document must end up
+// reprocessable (empty hash, error status), not falsely "indexed" (#402 A1).
+func TestProcessDocument_CrashDuringRepsNeverMarksDone(t *testing.T) {
+	root := t.TempDir()
+	absPath := filepath.Join(root, "note.txt")
+	content := "content that would produce at least one chunk"
+	if err := os.WriteFile(absPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	wantHash := ingest.ComputeContentHash([]byte(content))
+
+	st := &fakeIncrementalStore{insertChunkErr: errors.New("simulated crash committing chunks")}
+	svc := mustNewIngestService(t, config.Config{RootDir: root}, st)
+	df := ingest.DiscoveredFile{AbsPath: absPath, RelPath: "note.txt", SizeBytes: int64(len(content))}
+
+	if err := svc.ProcessDocument(context.Background(), df, nil, false); err == nil {
+		t.Fatalf("expected processDocument to fail when chunk commit fails")
+	}
+
+	// The done marker must never have been written for this document.
+	for i, d := range st.upsertedDocs {
+		if d.ContentHash == wantHash {
+			t.Fatalf("upsert #%d wrote the content_hash done marker despite the crash: %q", i, d.ContentHash)
+		}
+	}
+	// The persisted terminal state must force reprocessing on the next scan.
+	last := st.upsertedDocs[len(st.upsertedDocs)-1]
+	if last.ContentHash != "" {
+		t.Fatalf("terminal content_hash = %q, want empty so the doc is reprocessed", last.ContentHash)
+	}
+	if last.Status != "error" {
+		t.Fatalf("terminal status = %q, want error", last.Status)
+	}
+}
+
+// TestProcessDocument_FinalizePreservesOutOfBandTitle pins the finalizeContentHash
+// regression (#402 follow-up): the title is written out-of-band to the DB row by
+// persistTitleIfFound DURING representation generation, invisible to the by-value
+// doc that finalizeContentHash carries. When finalize stamps the withheld
+// content_hash it must upsert the re-read row (title intact), not the by-value doc
+// — otherwise the freshly-written title is reverted. This asserts the terminal row
+// carries BOTH the extracted title AND the finalized content_hash.
+func TestProcessDocument_FinalizePreservesOutOfBandTitle(t *testing.T) {
+	root := t.TempDir()
+	absPath := filepath.Join(root, "note.txt")
+	// A markdown H1 makes ExtractTitle yield a title, so persistTitleIfFound writes
+	// documents.title out-of-band during representation generation.
+	content := "# Regression Title\n\nsome indexable body text goes here"
+	if err := os.WriteFile(absPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	wantHash := ingest.ComputeContentHash([]byte(content))
+	const wantTitle = "Regression Title"
+
+	// reflectUpserts makes GetDocumentByPath return the most recent upsert, so the
+	// out-of-band title write is visible to the finalize read-back — exactly the
+	// real store's behavior.
+	st := &fakeIncrementalStore{reflectUpserts: true}
+	svc := mustNewIngestService(t, config.Config{RootDir: root}, st)
+	df := ingest.DiscoveredFile{AbsPath: absPath, RelPath: "note.txt", SizeBytes: int64(len(content))}
+
+	if err := svc.ProcessDocument(context.Background(), df, nil, false); err != nil {
+		t.Fatalf("processDocument failed: %v", err)
+	}
+
+	// Sanity: the title was in fact written out-of-band before finalize ran.
+	sawTitle := false
+	for _, d := range st.upsertedDocs {
+		if d.Title == wantTitle {
+			sawTitle = true
+			break
+		}
+	}
+	if !sawTitle {
+		t.Fatalf("expected persistTitleIfFound to write title %q out-of-band; upserts=%d", wantTitle, len(st.upsertedDocs))
+	}
+
+	// The terminal row must carry BOTH the out-of-band title AND the finalized hash.
+	last := st.upsertedDocs[len(st.upsertedDocs)-1]
+	if last.ContentHash != wantHash {
+		t.Fatalf("finalize upsert content_hash = %q, want %q", last.ContentHash, wantHash)
+	}
+	if last.Title != wantTitle {
+		t.Fatalf("finalize reverted out-of-band title: got %q, want %q", last.Title, wantTitle)
+	}
+}
+
+// TestNeedsReprocessing_EmptyHashResumesAfterInterruption is the restart half of
+// the #402 A1 story: a document left with an empty content_hash by an interrupted
+// run (the withheld-marker state) is always reprocessed on the next scan.
+func TestNeedsReprocessing_EmptyHashResumesAfterInterruption(t *testing.T) {
+	if !ingest.NeedsReprocessing("", "any-new-hash", false) {
+		t.Fatalf("a document with an empty (withheld) content_hash must be reprocessed on restart")
+	}
+	if ingest.NeedsReprocessing("h", "h", false) {
+		t.Fatalf("an unchanged, fully-indexed document must not be reprocessed")
+	}
+}

--- a/tests/ingest/incremental_test.go
+++ b/tests/ingest/incremental_test.go
@@ -28,6 +28,15 @@ type fakeIncrementalStore struct {
 	lastInsertedChunk model.Chunk
 	insertedChunks    []model.Chunk
 	insertedSpans     [][]model.Span
+
+	// insertChunkErr, when non-nil, is returned by InsertChunkWithSpans to
+	// simulate an ungraceful failure/crash mid-representation-commit (#402).
+	insertChunkErr error
+
+	// reflectUpserts makes GetDocumentByPath return the most recently upserted
+	// document (instead of existingDoc) so tests can exercise the read-back the
+	// #402 content_hash finalize performs.
+	reflectUpserts bool
 }
 
 func (f *fakeIncrementalStore) Init(context.Context) error { return nil }
@@ -46,6 +55,9 @@ func (f *fakeIncrementalStore) GetDocumentByPath(_ context.Context, _ string) (m
 	if f.existingErr != nil {
 		return model.Document{}, f.existingErr
 	}
+	if f.reflectUpserts && len(f.upsertedDocs) > 0 {
+		return f.upsertedDocs[len(f.upsertedDocs)-1], nil
+	}
 	return f.existingDoc, nil
 }
 func (f *fakeIncrementalStore) UpsertRepresentation(_ context.Context, rep model.Representation) (int64, error) {
@@ -57,6 +69,9 @@ func (f *fakeIncrementalStore) UpsertRepresentation(_ context.Context, rep model
 }
 func (f *fakeIncrementalStore) InsertChunkWithSpans(_ context.Context, chunk model.Chunk, spans []model.Span) (int64, error) {
 	f.insertChunkCalls++
+	if f.insertChunkErr != nil {
+		return 0, f.insertChunkErr
+	}
 	// record
 	f.lastInsertedChunk = chunk
 	f.insertedChunks = append(f.insertedChunks, chunk)


### PR DESCRIPTION
## Summary

Fixes the #402 crash-consistency class: an ungraceful death (SIGKILL/OOM/power loss) during indexing left **premature completion markers** committed *before* their durable artifact, and there was **no startup reconciliation** — so an interrupted corpus looked fully indexed on restart and was silently, permanently under-indexed (both symptoms reported `errors=0, embedded_ok>0`, so the release-smoke gate never caught them).

### A1 — zero-chunk "ok" document after a crash mid-ingest
`processDocument`/`processDocumentFromContent` committed the document's `content_hash` (the incremental "done" marker `NeedsReprocessing` keys off) in its **own** upsert **before** the representations/chunks were written. A crash in that gap left an `ok` document with the marker set but zero chunks — invisible to search/ask and never reprocessed.

**Fix:** withhold the `content_hash` marker on the initial upsert whenever a run will (re)generate representations (`withholdContentHash`) and stamp it only **after** the reps/chunks durably commit (`finalizeContentHash`). An interrupted run leaves an empty hash → the next scan reprocesses the document. `finalizeContentHash` re-reads the row first so it never clobbers an out-of-band `status="error"` written by a non-fatal per-representation failure (#413).

### A2 — default `memory` index loses embedded vectors on crash
The in-memory HNSW backend's only durability is the ~15s autosave. A crash between `MarkEmbedded` and the next snapshot dropped vectors that sqlite still counted embedded, with no reconciliation — so those chunks were never re-embedded (silent recall loss).

**Fix:** on startup, before the embed worker starts, reconcile sqlite's embedded chunks against the vectors actually present in the loaded index and re-pend the missing ones (`index.ReconcileEmbeddedVectors` + `HNSWIndex.HasVectors` + `SQLiteStore.RependEmbeddedChunks`). Durable backends (disk/qdrant/pgvector) don't implement the `VectorPresence` capability and are skipped; read-only mode is a no-op. The read scan is kept strictly read-only (missing IDs accumulated, re-pended once at the end) so OFFSET pagination walks a stable set.

## Contracts preserved
- Document status counts unchanged (status is still written `ok` immediately; only the `content_hash` marker is deferred).
- `NeedsReprocessing` / store / status contracts unchanged; new store method is additive.
- Compile-time guards added so a signature drift can't silently disable the reconciliation (mirrors the #364 `ChunkSource` guard).

## Tests
- `tests/ingest/crash_consistency_test.go`: marker withheld until reps commit; a failure mid-rep-commit **never** writes the done marker (ends `error` + empty hash → retried); empty-hash resumes on restart.
- `tests/index/reconcile_test.go`: re-pend missing, all-present no-op, durable-backend no-op, `HasVectors`.

## Verification
`make check` passes (CGO_ENABLED=0, golangci-lint v2.10.1 clean, gocyclo ≤15 — `processDocument`/`processDocumentFromContent` refactored via extracted helpers to stay under budget).

Closes #402

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes the #402 crash-consistency class across two independent failure modes: a premature `content_hash` "done" marker committed before representations were durable (A1), and in-memory HNSW vectors silently dropped between `MarkEmbedded` and the next autosave snapshot (A2).

- **A1 fix** (`internal/ingest/service.go`): `withholdContentHash` blanks the `content_hash` field on the initial `UpsertDocument` call and `finalizeContentHash` stamps it only after `generateRepresentations` commits durably — re-reading the DB row first so out-of-band title writes survive and any interleaved `status="error"` from a non-fatal per-rep failure is preserved rather than overwritten.
- **A2 fix** (`internal/index/reconcile.go`, `internal/cli/up.go`): startup reconciliation walks all SQLite-embedded chunks via keyset pagination, calls `HasVectors` on the HNSW index, and re-pends any whose vector is absent; the reconciliation runs synchronously before the embed worker starts so re-pended chunks are picked up in the same session, and durable backends (disk/qdrant/pgvector) skip it entirely via the `VectorPresence` capability gate.
- **Keyset migration** (`internal/store/sqlite_store.go`, `internal/cli/up.go`): `ListEmbeddedChunkMetadata` and `preloadEmbeddedChunkMetadata` both switch from `OFFSET` to `chunk_id > afterChunkID` seek-based pagination, eliminating the O(N²) rescan on large embedded sets.

<h3>Confidence Score: 5/5</h3>

Safe to merge — both crash-consistency fixes are correctly scoped, sequenced, and tested.

The withheld-marker approach in A1 is correct end-to-end: the initial upsert carries an empty hash, generateRepresentations failure leaves it empty so the document is retried, and finalizeContentHash re-reads the row before stamping so neither an out-of-band error status nor an out-of-band title write can be lost. The A2 reconciliation runs synchronously before the embed worker, reads the index under an RLock compatible with the autosave goroutine, and commits a single re-pend write only after the full scan completes. The keyset migration is mechanically correct — LIMIT is applied after the index_kind filter, and the cursor advances by the last chunk_id seen. All four new behaviours have direct unit-test coverage.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/ingest/service.go | Adds withholdContentHash/generateRepsAndFinalize/finalizeContentHash helpers for A1 fix; marker is zeroed before the initial upsert and stamped only after reps commit, error path correctly leaves ContentHash="" so the document is retried. |
| internal/index/reconcile.go | New file adding VectorPresence/EmbeddedVectorSource interfaces and ReconcileEmbeddedVectors; paging is read-only during accumulation to keep the keyset cursor stable, re-pend is a single write at the end, durable-backend no-op path is clean. |
| internal/index/hnsw_index.go | Adds HasVectors using a RLock on the vectors map — correct and non-blocking alongside the autosave goroutine's write lock. |
| internal/store/sqlite_store.go | ListEmbeddedChunkMetadata migrated from OFFSET to keyset (chunk_id > afterChunkID); RependEmbeddedChunks added. SQL structure and LIMIT application are correct. |
| internal/cli/up.go | Reconciliation inserted synchronously after persistence.Start but before startEmbeddingIfNotReadOnly — correct ordering ensures re-pended chunks are picked up by the embed worker in the same session. |
| internal/cli/app.go | Interface signature updated and compile-time guard added for EmbeddedVectorSource; mirrors existing ChunkSource guard pattern from #364. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant S as ingest.Service
    participant DB as SQLiteStore
    participant R as generateRepresentations
    participant F as finalizeContentHash

    Note over S,F: A1 — processDocument / processDocumentFromContent
    S->>S: "withholdContentHash(&doc) — doc.ContentHash="""
    S->>DB: UpsertDocument(doc) — marker withheld
    S->>R: generateRepresentations(doc, content)
    alt reps succeed
        R-->>S: nil
        S->>F: "finalizeContentHash(&doc, realHash)"
        F->>DB: GetDocumentByPath (re-read row)
        alt "current.Status == ok"
            F->>DB: "UpsertDocument(current + ContentHash=realHash)"
        else status changed out-of-band
            F-->>S: nil — marker stays withheld, retried next scan
        end
    else reps fail
        R-->>S: error
        S->>DB: "UpsertDocument(Status=error, ContentHash="")"
        Note over DB: empty hash → reprocessed on next scan
    end

    Note over S,DB: A2 — startup reconciliation (before embed worker)
    participant ST as SQLiteStore
    participant IX as HNSWIndex
    participant W as EmbedWorker

    S->>ST: ListEmbeddedChunkMetadata(kind, limit, afterChunkID)
    ST-->>S: ChunkTask page
    S->>IX: HasVectors(chunkIDs)
    IX-->>S: present map
    S->>S: accumulate missing IDs (read-only during paging)
    S->>ST: RependEmbeddedChunks(missing)
    Note over W: started after reconciliation completes
    W->>ST: NextPending — picks up re-pended chunks
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant S as ingest.Service
    participant DB as SQLiteStore
    participant R as generateRepresentations
    participant F as finalizeContentHash

    Note over S,F: A1 — processDocument / processDocumentFromContent
    S->>S: "withholdContentHash(&doc) — doc.ContentHash="""
    S->>DB: UpsertDocument(doc) — marker withheld
    S->>R: generateRepresentations(doc, content)
    alt reps succeed
        R-->>S: nil
        S->>F: "finalizeContentHash(&doc, realHash)"
        F->>DB: GetDocumentByPath (re-read row)
        alt "current.Status == ok"
            F->>DB: "UpsertDocument(current + ContentHash=realHash)"
        else status changed out-of-band
            F-->>S: nil — marker stays withheld, retried next scan
        end
    else reps fail
        R-->>S: error
        S->>DB: "UpsertDocument(Status=error, ContentHash="")"
        Note over DB: empty hash → reprocessed on next scan
    end

    Note over S,DB: A2 — startup reconciliation (before embed worker)
    participant ST as SQLiteStore
    participant IX as HNSWIndex
    participant W as EmbedWorker

    S->>ST: ListEmbeddedChunkMetadata(kind, limit, afterChunkID)
    ST-->>S: ChunkTask page
    S->>IX: HasVectors(chunkIDs)
    IX-->>S: present map
    S->>S: accumulate missing IDs (read-only during paging)
    S->>ST: RependEmbeddedChunks(missing)
    Note over W: started after reconciliation completes
    W->>ST: NextPending — picks up re-pended chunks
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix(ingest): preserve out-of-band Title ..."](https://github.com/dirstral/dir2mcp/commit/07d4e7ee3000f4db356be71f628c6277d6c8e175) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41249470)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic startup reconciliation to re-queue missing embedded vectors after unexpected crashes.
  * Added vector presence reporting to the HNSW index to support reliable reconciliation.
* **Bug Fixes**
  * Switched embedded-chunk metadata scanning to keyset pagination to reduce missed/duplicated processing.
  * Improved ingest “done marker” handling so content hashes are only finalized after durable commits, with safeguards against incorrect status resurrection.
* **Tests**
  * Added/updated regression tests covering crash consistency, vector reconciliation, and pagination/incremental ingest behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->