### PR TITLE
fix(openai): bound chat completions with a default max_tokens (#500)

### DIFF
--- a/internal/ingest/translate.go
+++ b/internal/ingest/translate.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/dirstral/dir2mcp/internal/model"
 )
 
 // readOrComputeTranslation returns the source transcript translated into
@@ -88,6 +90,14 @@ func (s *Service) translateTranscriptText(ctx context.Context, sourceText, targe
 	return strings.Join(out, "\n"), nil
 }
 
+// translateLineMaxTokens caps a single translated transcript line. One source
+// segment maps to one short output line, so a tight bound is plenty here; it
+// keeps the #500 runaway path tight on chat backends that respect max_tokens
+// WITHOUT lowering the generous default that ask/annotate rely on. It is applied
+// only when the translator implements model.BoundedGenerator; otherwise the call
+// falls back to Generate (the provider's own default cap still bounds it).
+const translateLineMaxTokens = 512
+
 // translateLine translates a single line of transcript text into targetLang via
 // the chat Generator. Empty/whitespace input short-circuits to empty so the chat
 // provider is never called for a marker-only line. The prompt asks for the
@@ -98,6 +108,9 @@ func (s *Service) translateLine(ctx context.Context, text, targetLang string) (s
 		return "", nil
 	}
 	prompt := buildTranslatePrompt(text, targetLang)
+	if bg, ok := s.translator.(model.BoundedGenerator); ok {
+		return bg.GenerateWithMaxTokens(ctx, prompt, translateLineMaxTokens)
+	}
 	translated, err := s.translator.Generate(ctx, prompt)
 	if err != nil {
 		return "", err

--- a/internal/model/interfaces.go
+++ b/internal/model/interfaces.go
@@ -255,6 +255,19 @@ type Generator interface {
 	Generate(ctx context.Context, prompt string) (string, error)
 }
 
+// BoundedGenerator is an OPTIONAL capability a Generator MAY implement to cap a
+// single completion's output tokens for THIS call, without changing the
+// generous default the generator uses for unbounded callers (answer synthesis,
+// annotation). A caller with a known-short output (e.g. one translated
+// transcript line) type-asserts its Generator against this and, if satisfied,
+// passes a tight cap; a Generator that does not implement it falls back to
+// Generate and behaves exactly as before. A maxTokens <= 0 MUST behave like
+// Generate (use the generator's own default).
+type BoundedGenerator interface {
+	Generator
+	GenerateWithMaxTokens(ctx context.Context, prompt string, maxTokens int) (string, error)
+}
+
 // Reranked is one rescored candidate: Index is the position in the
 // documents slice passed to Rerank; RelevanceScore is the provider's
 // relevance (higher = better). Results are returned best-first.

--- a/internal/openai/client.go
+++ b/internal/openai/client.go
@@ -36,10 +36,19 @@ const (
 	defaultBaseURL           = "https://api.openai.com/v1"
 	defaultRequestTimeout    = 30 * time.Second
 	defaultGenerationTimeout = 120 * time.Second
-	defaultMaxRetries        = 3
-	defaultInitialBackoff    = 250 * time.Millisecond
-	defaultMaxBackoff        = 2 * time.Second
-	defaultBatchSize         = 64
+	// defaultGenerationMaxTokens bounds a single /chat/completions
+	// completion. Without a cap a misbehaving model (common with small,
+	// self-hosted/CPU chat backends) can generate far past the requested
+	// output — e.g. a subtitle-line translation that never stops — until the
+	// generation timeout fires and the whole file fails with OPENAI_FAILED
+	// (issue #500). A finite cap turns that unbounded runaway into a bounded
+	// request. It is generous enough for translations and typical answers;
+	// operators on very slow backends can lower it via Client.GenerationMaxTokens.
+	defaultGenerationMaxTokens = 1024
+	defaultMaxRetries          = 3
+	defaultInitialBackoff      = 250 * time.Millisecond
+	defaultMaxBackoff          = 2 * time.Second
+	defaultBatchSize           = 64
 
 	// DefaultEmbedModel / DefaultChatModel / DefaultSTTModel /
 	// DefaultTTSModel / DefaultTTSVoice are fallbacks used only when the
@@ -77,6 +86,10 @@ type Client struct {
 	MaxBackoff        time.Duration
 	BatchSize         int
 	GenerationTimeout time.Duration
+	// GenerationMaxTokens caps a single chat completion (max_tokens). <= 0
+	// falls back to defaultGenerationMaxTokens; it is never sent unbounded.
+	// See issue #500.
+	GenerationMaxTokens int
 	// DefaultEmbedModel/DefaultChatModel/DefaultSTTModel/DefaultTTSModel/
 	// DefaultTTSVoice are used when the corresponding call is made with
 	// an empty value.
@@ -105,19 +118,20 @@ func NewClient(baseURL, apiKey string) *Client {
 		baseURL = defaultBaseURL
 	}
 	return &Client{
-		BaseURL:           strings.TrimRight(baseURL, "/"),
-		APIKey:            apiKey,
-		HTTPClient:        &http.Client{Timeout: defaultRequestTimeout},
-		MaxRetries:        defaultMaxRetries,
-		InitialBackoff:    defaultInitialBackoff,
-		MaxBackoff:        defaultMaxBackoff,
-		BatchSize:         defaultBatchSize,
-		GenerationTimeout: defaultGenerationTimeout,
-		DefaultEmbedModel: DefaultEmbedModel,
-		DefaultChatModel:  DefaultChatModel,
-		DefaultSTTModel:   DefaultSTTModel,
-		DefaultTTSModel:   DefaultTTSModel,
-		DefaultTTSVoice:   DefaultTTSVoice,
+		BaseURL:             strings.TrimRight(baseURL, "/"),
+		APIKey:              apiKey,
+		HTTPClient:          &http.Client{Timeout: defaultRequestTimeout},
+		MaxRetries:          defaultMaxRetries,
+		InitialBackoff:      defaultInitialBackoff,
+		MaxBackoff:          defaultMaxBackoff,
+		BatchSize:           defaultBatchSize,
+		GenerationTimeout:   defaultGenerationTimeout,
+		GenerationMaxTokens: defaultGenerationMaxTokens,
+		DefaultEmbedModel:   DefaultEmbedModel,
+		DefaultChatModel:    DefaultChatModel,
+		DefaultSTTModel:     DefaultSTTModel,
+		DefaultTTSModel:     DefaultTTSModel,
+		DefaultTTSVoice:     DefaultTTSVoice,
 	}
 }
 
@@ -257,8 +271,9 @@ type generateMessage struct {
 }
 
 type generateRequest struct {
-	Model    string            `json:"model"`
-	Messages []generateMessage `json:"messages"`
+	Model     string            `json:"model"`
+	Messages  []generateMessage `json:"messages"`
+	MaxTokens int               `json:"max_tokens,omitempty"`
 }
 
 type generateResponse struct {
@@ -288,6 +303,10 @@ func (c *Client) Generate(ctx context.Context, prompt string) (string, error) {
 	if timeout <= 0 {
 		timeout = defaultGenerationTimeout
 	}
+	maxTokens := c.GenerationMaxTokens
+	if maxTokens <= 0 {
+		maxTokens = defaultGenerationMaxTokens
+	}
 
 	var lastErr error
 	for attempt := 0; attempt <= maxRetries; attempt++ {
@@ -296,7 +315,7 @@ func (c *Client) Generate(ctx context.Context, prompt string) (string, error) {
 				return "", err
 			}
 		}
-		text, err := c.generateOnce(ctx, chatModel, prompt, timeout)
+		text, err := c.generateOnce(ctx, chatModel, prompt, maxTokens, timeout)
 		if err == nil {
 			return text, nil
 		}
@@ -309,10 +328,11 @@ func (c *Client) Generate(ctx context.Context, prompt string) (string, error) {
 	return "", lastErr
 }
 
-func (c *Client) generateOnce(ctx context.Context, chatModel, prompt string, timeout time.Duration) (string, error) {
+func (c *Client) generateOnce(ctx context.Context, chatModel, prompt string, maxTokens int, timeout time.Duration) (string, error) {
 	body, err := json.Marshal(generateRequest{
-		Model:    chatModel,
-		Messages: []generateMessage{{Role: "user", Content: prompt}},
+		Model:     chatModel,
+		Messages:  []generateMessage{{Role: "user", Content: prompt}},
+		MaxTokens: maxTokens,
 	})
 	if err != nil {
 		return "", &model.ProviderError{Code: "OPENAI_FAILED", Message: "failed to marshal generation request", Retryable: false, Cause: err}

--- a/internal/openai/client.go
+++ b/internal/openai/client.go
@@ -42,9 +42,13 @@ const (
 	// output — e.g. a subtitle-line translation that never stops — until the
 	// generation timeout fires and the whole file fails with OPENAI_FAILED
 	// (issue #500). A finite cap turns that unbounded runaway into a bounded
-	// request. It is generous enough for translations and typical answers;
-	// operators on very slow backends can lower it via Client.GenerationMaxTokens.
-	defaultGenerationMaxTokens = 1024
+	// request. It matches the anthropic sibling's 4096 so it is generous enough
+	// for RAG answer synthesis and annotate JSON (a tighter cap silently
+	// truncated long answers and could corrupt annotate JSON → ANNOTATE_FAILED);
+	// short-output callers pass a per-call cap via GenerateWithMaxTokens instead
+	// of lowering this. Operators on very slow backends can lower it via
+	// Client.GenerationMaxTokens.
+	defaultGenerationMaxTokens = 4096
 	defaultMaxRetries          = 3
 	defaultInitialBackoff      = 250 * time.Millisecond
 	defaultMaxBackoff          = 2 * time.Second
@@ -102,9 +106,10 @@ type Client struct {
 
 // compile-time assertions that *Client implements the model contracts.
 var (
-	_ model.Embedder    = (*Client)(nil)
-	_ model.Generator   = (*Client)(nil)
-	_ model.Transcriber = (*Client)(nil)
+	_ model.Embedder         = (*Client)(nil)
+	_ model.Generator        = (*Client)(nil)
+	_ model.BoundedGenerator = (*Client)(nil)
+	_ model.Transcriber      = (*Client)(nil)
 )
 
 // NewClient constructs a client with safe default retry/timeout settings.
@@ -271,9 +276,11 @@ type generateMessage struct {
 }
 
 type generateRequest struct {
-	Model     string            `json:"model"`
-	Messages  []generateMessage `json:"messages"`
-	MaxTokens int               `json:"max_tokens,omitempty"`
+	Model    string            `json:"model"`
+	Messages []generateMessage `json:"messages"`
+	// MaxTokens is always > 0 after clamping (see generate), so it is always
+	// emitted — no omitempty — to keep every completion bounded (issue #500).
+	MaxTokens int `json:"max_tokens"`
 }
 
 type generateResponse struct {
@@ -285,8 +292,24 @@ type generateResponse struct {
 	Usage usage.OpenAIUsage `json:"usage"`
 }
 
-// Generate implements model.Generator via {base}/chat/completions.
+// Generate implements model.Generator via {base}/chat/completions. It uses
+// the client's generous default cap (GenerationMaxTokens, else
+// defaultGenerationMaxTokens) so answer synthesis and annotation are not
+// truncated.
 func (c *Client) Generate(ctx context.Context, prompt string) (string, error) {
+	return c.generate(ctx, prompt, 0)
+}
+
+// GenerateWithMaxTokens is like Generate but caps this single completion at
+// maxTokens (max_tokens). A maxTokens <= 0 falls back to the client default,
+// so it is safe to pass 0. It lets a caller with a known-short output (e.g. a
+// single translated transcript line) request a tight bound WITHOUT lowering the
+// generous default that ask/annotate rely on. It satisfies model.BoundedGenerator.
+func (c *Client) GenerateWithMaxTokens(ctx context.Context, prompt string, maxTokens int) (string, error) {
+	return c.generate(ctx, prompt, maxTokens)
+}
+
+func (c *Client) generate(ctx context.Context, prompt string, maxTokensOverride int) (string, error) {
 	if strings.TrimSpace(c.APIKey) == "" {
 		return "", &model.ProviderError{Code: "OPENAI_AUTH", Message: "missing OpenAI API key", Retryable: false}
 	}
@@ -303,7 +326,12 @@ func (c *Client) Generate(ctx context.Context, prompt string) (string, error) {
 	if timeout <= 0 {
 		timeout = defaultGenerationTimeout
 	}
-	maxTokens := c.GenerationMaxTokens
+	// Per-call override wins when positive; otherwise fall back to the client
+	// default, then the package default. The value sent is always > 0.
+	maxTokens := maxTokensOverride
+	if maxTokens <= 0 {
+		maxTokens = c.GenerationMaxTokens
+	}
 	if maxTokens <= 0 {
 		maxTokens = defaultGenerationMaxTokens
 	}

--- a/tests/ingest/transcript_translate_test.go
+++ b/tests/ingest/transcript_translate_test.go
@@ -343,3 +343,65 @@ func TestTranscriptTranslation_ValidationRejectsEmptyTargets(t *testing.T) {
 		t.Fatalf("translation off must be valid, got %v", err)
 	}
 }
+
+// boundedFakeTranslator implements model.BoundedGenerator and records the
+// per-call max-tokens cap it receives, so the translate path can be asserted to
+// request a tight bound (issue #500 / PR #501 review) instead of the generous
+// answer/annotate default.
+type boundedFakeTranslator struct {
+	mu           sync.Mutex
+	calls        int
+	lastMaxToken int
+}
+
+func (b *boundedFakeTranslator) Generate(_ context.Context, prompt string) (string, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.calls++
+	b.lastMaxToken = 0
+	parts := strings.Split(prompt, "\n\n")
+	return "translated:" + parts[len(parts)-1], nil
+}
+
+func (b *boundedFakeTranslator) GenerateWithMaxTokens(_ context.Context, prompt string, maxTokens int) (string, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.calls++
+	b.lastMaxToken = maxTokens
+	parts := strings.Split(prompt, "\n\n")
+	return "translated:" + parts[len(parts)-1], nil
+}
+
+func (b *boundedFakeTranslator) observed() (calls, lastMaxToken int) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.calls, b.lastMaxToken
+}
+
+// TestTranscriptTranslation_UsesTightPerCallCap verifies the translate call site
+// passes a tight per-call max-tokens cap (512) when the translator implements
+// model.BoundedGenerator, keeping the #500 runaway path bounded without lowering
+// the generous default that ask/annotate rely on.
+func TestTranscriptTranslation_UsesTightPerCallCap(t *testing.T) {
+	t.Parallel()
+	stateDir := t.TempDir()
+	st := &fakeIngestStore{}
+	svc := mustNewIngestService(t, config.Config{StateDir: stateDir}, st)
+	svc.SetTranscriber(&fakeTranscriber{text: "[00:00] intro\n[00:02] chapter one"})
+	tr := &boundedFakeTranslator{}
+	svc.SetTranscriptLanguage("de")
+	svc.SetTranslator(tr, "mistral", "mistral-small-2506", []string{"en"})
+
+	doc := model.Document{DocID: 11, RelPath: "audio/talk.mp3", DocType: "audio"}
+	if err := svc.GenerateTranscriptRepresentation(context.Background(), doc, []byte("audio")); err != nil {
+		t.Fatalf("GenerateTranscriptRepresentation: %v", err)
+	}
+
+	calls, lastMaxToken := tr.observed()
+	if calls == 0 {
+		t.Fatalf("expected the bounded translator to be called")
+	}
+	if lastMaxToken != 512 {
+		t.Fatalf("translate max_tokens cap = %d, want 512", lastMaxToken)
+	}
+}

--- a/tests/openai/client_test.go
+++ b/tests/openai/client_test.go
@@ -169,6 +169,48 @@ func TestGenerate_HappyPathAndStructuredContent(t *testing.T) {
 	}
 }
 
+// TestGenerate_SendsBoundedMaxTokens locks issue #500: the chat request
+// must always carry a finite max_tokens so a misbehaving/self-hosted model
+// cannot run away past the generation timeout and fail the whole file.
+// NewClient's default (1024) applies when the caller sets nothing; an
+// explicit GenerationMaxTokens overrides it.
+func TestGenerate_SendsBoundedMaxTokens(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		override int
+		want     float64
+	}{
+		{name: "default", override: 0, want: 1024},
+		{name: "override", override: 42, want: 42},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotBody map[string]any
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_ = json.NewDecoder(r.Body).Decode(&gotBody)
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"choices": []map[string]any{{"message": map[string]any{"content": "ok"}}},
+				})
+			}))
+			defer srv.Close()
+
+			c := newClient(srv.URL)
+			if tc.override != 0 {
+				c.GenerationMaxTokens = tc.override
+			}
+			if _, err := c.Generate(context.Background(), "hi"); err != nil {
+				t.Fatalf("generate: %v", err)
+			}
+			mt, ok := gotBody["max_tokens"]
+			if !ok {
+				t.Fatalf("request omitted max_tokens; body = %v", gotBody)
+			}
+			if got, _ := mt.(float64); got != tc.want {
+				t.Fatalf("max_tokens = %v, want %v", mt, tc.want)
+			}
+		})
+	}
+}
+
 // TestGenerate_UsesGenerationTimeoutNotDefault locks the fix for the
 // PR #191 review: NewClient always sets HTTPClient (30s), so the
 // per-call GenerationTimeout must still be applied. With a 50ms

--- a/tests/openai/client_test.go
+++ b/tests/openai/client_test.go
@@ -172,15 +172,16 @@ func TestGenerate_HappyPathAndStructuredContent(t *testing.T) {
 // TestGenerate_SendsBoundedMaxTokens locks issue #500: the chat request
 // must always carry a finite max_tokens so a misbehaving/self-hosted model
 // cannot run away past the generation timeout and fail the whole file.
-// NewClient's default (1024) applies when the caller sets nothing; an
-// explicit GenerationMaxTokens overrides it.
+// NewClient's default (4096, matching the anthropic sibling so answer
+// synthesis and annotate JSON are not truncated) applies when the caller sets
+// nothing; an explicit GenerationMaxTokens overrides it.
 func TestGenerate_SendsBoundedMaxTokens(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
 		override int
 		want     float64
 	}{
-		{name: "default", override: 0, want: 1024},
+		{name: "default", override: 0, want: 4096},
 		{name: "override", override: 42, want: 42},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -198,6 +199,46 @@ func TestGenerate_SendsBoundedMaxTokens(t *testing.T) {
 				c.GenerationMaxTokens = tc.override
 			}
 			if _, err := c.Generate(context.Background(), "hi"); err != nil {
+				t.Fatalf("generate: %v", err)
+			}
+			mt, ok := gotBody["max_tokens"]
+			if !ok {
+				t.Fatalf("request omitted max_tokens; body = %v", gotBody)
+			}
+			if got, _ := mt.(float64); got != tc.want {
+				t.Fatalf("max_tokens = %v, want %v", mt, tc.want)
+			}
+		})
+	}
+}
+
+// TestGenerateWithMaxTokens_PerCallCap locks the per-call seam: a caller with a
+// known-short output (e.g. one translated transcript line) can request a tight
+// cap for that call WITHOUT lowering the generous default that Generate
+// (ask/annotate) uses. A positive maxTokens is sent verbatim; a <= 0 maxTokens
+// falls back to the client default, so it behaves like Generate.
+func TestGenerateWithMaxTokens_PerCallCap(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		maxTokens int
+		want      float64
+	}{
+		{name: "tight cap", maxTokens: 512, want: 512},
+		{name: "zero falls back to default", maxTokens: 0, want: 4096},
+		{name: "negative falls back to default", maxTokens: -1, want: 4096},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotBody map[string]any
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_ = json.NewDecoder(r.Body).Decode(&gotBody)
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"choices": []map[string]any{{"message": map[string]any{"content": "ok"}}},
+				})
+			}))
+			defer srv.Close()
+
+			var bg model.BoundedGenerator = newClient(srv.URL)
+			if _, err := bg.GenerateWithMaxTokens(context.Background(), "hi", tc.maxTokens); err != nil {
 				t.Fatalf("generate: %v", err)
 			}
 			mt, ok := gotBody["max_tokens"]

--- a/tests/openai/client_test.go
+++ b/tests/openai/client_test.go
@@ -185,13 +185,7 @@ func TestGenerate_SendsBoundedMaxTokens(t *testing.T) {
 		{name: "override", override: 42, want: 42},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			var gotBody map[string]any
-			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				_ = json.NewDecoder(r.Body).Decode(&gotBody)
-				_ = json.NewEncoder(w).Encode(map[string]any{
-					"choices": []map[string]any{{"message": map[string]any{"content": "ok"}}},
-				})
-			}))
+			srv, bodyCh := captureBodyServer(t)
 			defer srv.Close()
 
 			c := newClient(srv.URL)
@@ -201,6 +195,7 @@ func TestGenerate_SendsBoundedMaxTokens(t *testing.T) {
 			if _, err := c.Generate(context.Background(), "hi"); err != nil {
 				t.Fatalf("generate: %v", err)
 			}
+			gotBody := <-bodyCh
 			mt, ok := gotBody["max_tokens"]
 			if !ok {
 				t.Fatalf("request omitted max_tokens; body = %v", gotBody)
@@ -228,19 +223,14 @@ func TestGenerateWithMaxTokens_PerCallCap(t *testing.T) {
 		{name: "negative falls back to default", maxTokens: -1, want: 4096},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			var gotBody map[string]any
-			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				_ = json.NewDecoder(r.Body).Decode(&gotBody)
-				_ = json.NewEncoder(w).Encode(map[string]any{
-					"choices": []map[string]any{{"message": map[string]any{"content": "ok"}}},
-				})
-			}))
+			srv, bodyCh := captureBodyServer(t)
 			defer srv.Close()
 
 			var bg model.BoundedGenerator = newClient(srv.URL)
 			if _, err := bg.GenerateWithMaxTokens(context.Background(), "hi", tc.maxTokens); err != nil {
 				t.Fatalf("generate: %v", err)
 			}
+			gotBody := <-bodyCh
 			mt, ok := gotBody["max_tokens"]
 			if !ok {
 				t.Fatalf("request omitted max_tokens; body = %v", gotBody)
@@ -371,4 +361,25 @@ func asProviderErr(err error, target **model.ProviderError) bool {
 		*target = pe
 	}
 	return ok && strings.HasPrefix(pe.Code, "OPENAI_")
+}
+
+// captureBodyServer returns a test server that decodes each request body and
+// hands it to the test goroutine over the returned channel (race-free under
+// -race, unlike writing a shared map from the handler goroutine), plus a canned
+// chat response. Decode errors fail the request explicitly.
+func captureBodyServer(t *testing.T) (*httptest.Server, <-chan map[string]any) {
+	t.Helper()
+	bodyCh := make(chan map[string]any, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		bodyCh <- body
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{{"message": map[string]any{"content": "ok"}}},
+		})
+	}))
+	return srv, bodyCh
 }


### PR DESCRIPTION
Fixes #500.

## Problem
The OpenAI-compatible `Generate` path (`internal/openai`) marshaled `/chat/completions` with only `model` + `messages` — **no `max_tokens`**. Against a fast cloud model this is invisible, but against a small self-hosted / CPU chat backend the model can generate far past the requested output — e.g. a subtitle-line translation that never stops — until `GenerationTimeout` fires and the file fails fatally with `OPENAI_FAILED`. That makes the fully-local / no-egress translation path (the "locally deployed LLMs" setup, #493) unusable on realistic local hardware, and one runaway cue fails the **whole file**.

Reproduced against Ollama `qwen2.5:3b-instruct` on CPU: a no-cap translate call ran **9m38s** before the client socket timed out; adding a `max_tokens` cap made each call return reliably (~30s) and the full 51-cue clip translated cleanly.

## Fix
- Add a client-level `GenerationMaxTokens` (default **1024**), mirroring the existing `GenerationTimeout` default pattern — a client-level default, not a new user-config field.
- Always emit `max_tokens` on the chat request; `<= 0` falls back to the default so it is **never sent unbounded**.
- Applies to every `model.Generator.Generate` caller — translation and query expansion (same class as #444).

A finite cap converts an unbounded runaway into a bounded request. 1024 is generous for translations and typical answers; operators on very slow backends can lower `Client.GenerationMaxTokens`.

## Tests
`tests/openai`: `TestGenerate_SendsBoundedMaxTokens` asserts the request carries `max_tokens` (default 1024, and an explicit override is honored). `go build ./...`, `go vet`, and the `openai` suites pass.

## Notes / follow-ups
- A per-call or per-config cap (e.g. a tighter `media_translate_max_tokens` for the translate path specifically, vs. `ask` answer synthesis) would be a natural refinement, but is out of scope here — this PR removes the unbounded-runaway failure with a single safe default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Ryjn9aKoXj4CQPP8BVrVW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bounded generation support so translation and text generation can cap output length per request, with sensible fallbacks when a cap isn’t provided or isn’t supported.

* **Bug Fixes**
  * Prevented unbounded chat completion generation by always sending a valid maximum token value in requests.

* **Tests**
  * Added coverage to verify translation uses the tighter per-line cap (512) when available.
  * Added OpenAI client tests to confirm `max_tokens` is always included and honors default/per-call override behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->