### PR TITLE
fix(mcp): protocol conformance gaps (#404)

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -628,6 +628,16 @@ func (s *Server) storeSession(id string, authScope string) {
 	s.persistSession(id, si)
 }
 
+// forgetSession removes a session from the in-memory map and the persistence
+// store. It is used for explicit DELETE session termination so the id cannot be
+// replayed after the client tears the session down.
+func (s *Server) forgetSession(id string) {
+	s.sessionMu.Lock()
+	delete(s.sessions, id)
+	s.sessionMu.Unlock()
+	s.deletePersistedSession(id)
+}
+
 func (s *Server) runSessionCleanup(ctx context.Context) {
 	ticker := time.NewTicker(s.sessionSweepInterval())
 	defer ticker.Stop()

--- a/internal/mcp/transport_sdk.go
+++ b/internal/mcp/transport_sdk.go
@@ -139,7 +139,26 @@ func (t *SDKTransport) validateServeInputs(handler Handler) error {
 }
 
 func (t *SDKTransport) serveHTTPRequest(w http.ResponseWriter, req *http.Request, sdkHandler http.Handler) {
-	if !t.checkPreRequest(w, req) {
+	if !t.checkRateLimit(w, req) {
+		return
+	}
+	switch req.Method {
+	case http.MethodPost:
+		t.servePost(w, req, sdkHandler)
+	case http.MethodDelete:
+		// DELETE is the spec's explicit session-termination verb. GET
+		// (server->client SSE) is intentionally unsupported: this is a
+		// request/response RAG server that pushes no unsolicited
+		// notifications, so it 405s below with an accurate Allow header.
+		t.serveSessionTermination(w, req, sdkHandler)
+	default:
+		w.Header().Set("Allow", "POST, DELETE")
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+func (t *SDKTransport) servePost(w http.ResponseWriter, req *http.Request, sdkHandler http.Handler) {
+	if !t.checkPostPreRequest(w, req) {
 		return
 	}
 	body, ok := readSDKBody(w, req)
@@ -157,7 +176,7 @@ func (t *SDKTransport) serveHTTPRequest(w http.ResponseWriter, req *http.Request
 	t.dispatchSDKRequest(w, req, parsedReq, id, hasID, sdkHandler)
 }
 
-func (t *SDKTransport) checkPreRequest(w http.ResponseWriter, req *http.Request) bool {
+func (t *SDKTransport) checkRateLimit(w http.ResponseWriter, req *http.Request) bool {
 	if t.server.rateLimiter != nil {
 		if !t.server.rateLimiter.allow(realIP(req, t.server.rateLimiter)) {
 			w.Header().Set("Retry-After", "1")
@@ -165,11 +184,10 @@ func (t *SDKTransport) checkPreRequest(w http.ResponseWriter, req *http.Request)
 			return false
 		}
 	}
-	if req.Method != http.MethodPost {
-		w.Header().Set("Allow", http.MethodPost)
-		w.WriteHeader(http.StatusMethodNotAllowed)
-		return false
-	}
+	return true
+}
+
+func (t *SDKTransport) checkPostPreRequest(w http.ResponseWriter, req *http.Request) bool {
 	ct := req.Header.Get("Content-Type")
 	if !strings.HasPrefix(strings.ToLower(ct), "application/json") {
 		writeError(w, http.StatusUnsupportedMediaType, nil, -32600, "Content-Type must be application/json", "INVALID_FIELD", false)
@@ -181,10 +199,85 @@ func (t *SDKTransport) checkPreRequest(w http.ResponseWriter, req *http.Request)
 	if !t.server.allowOrigin(w, req) {
 		return false
 	}
-	if strings.TrimSpace(req.Header.Get("Accept")) == "" {
-		req.Header.Set("Accept", "application/json, text/event-stream")
-	}
+	negotiateAccept(req)
 	return true
+}
+
+// negotiateAccept guarantees the POST Accept header advertises BOTH
+// application/json and text/event-stream, which the streamable-HTTP SDK
+// requires (it 400s a POST that lists only one). A spec-conformant client that
+// sends exactly "Accept: application/json" — reasonable, since the server runs
+// JSONResponse — would otherwise be rejected, so a partial header is augmented
+// rather than only injected when absent (issue #404). Detection mirrors the
+// SDK's exact whole-token matching (not substring), so an unmatched token like
+// "application/json;q=0.9" is treated as missing and the canonical token is
+// appended, which the SDK then matches.
+func negotiateAccept(req *http.Request) {
+	const jsonType = "application/json"
+	const sseType = "text/event-stream"
+
+	values := req.Header.Values("Accept")
+	jsonOK, streamOK := acceptSatisfies(values)
+	if jsonOK && streamOK {
+		return
+	}
+	parts := make([]string, 0, 3)
+	if existing := strings.TrimSpace(strings.Join(values, ", ")); existing != "" {
+		parts = append(parts, existing)
+	}
+	if !jsonOK {
+		parts = append(parts, jsonType)
+	}
+	if !streamOK {
+		parts = append(parts, sseType)
+	}
+	req.Header.Set("Accept", strings.Join(parts, ", "))
+}
+
+// acceptSatisfies reports whether the Accept header values already advertise
+// application/json and text/event-stream using the same whole-token matching
+// the SDK applies, so negotiateAccept only appends what is genuinely missing.
+func acceptSatisfies(values []string) (jsonOK, streamOK bool) {
+	for _, tok := range strings.Split(strings.Join(values, ","), ",") {
+		switch strings.TrimSpace(tok) {
+		case "application/json", "application/*":
+			jsonOK = true
+		case "text/event-stream", "text/*":
+			streamOK = true
+		case "*/*":
+			jsonOK = true
+			streamOK = true
+		}
+	}
+	return jsonOK, streamOK
+}
+
+// serveSessionTermination handles the spec's DELETE session-termination verb.
+// It validates the session against our own store first (so an unknown/expired
+// session gets our canonical SESSION_NOT_FOUND contract), forwards to the SDK
+// to tear down its per-session state, then forgets our copy so the id cannot be
+// replayed. Both stores key off the same id minted during initialize.
+func (t *SDKTransport) serveSessionTermination(w http.ResponseWriter, req *http.Request, sdkHandler http.Handler) {
+	if ok, _ := t.server.authorize(w, req); !ok {
+		return
+	}
+	if !t.server.allowOrigin(w, req) {
+		return
+	}
+	sessionID := strings.TrimSpace(req.Header.Get(protocol.MCPSessionHeader))
+	if sessionID == "" {
+		writeError(w, http.StatusNotFound, nil, -32001, "session not found", protocol.ErrorCodeSessionNotFound, false)
+		return
+	}
+	if ok, reason := t.server.hasActiveSession(sessionID, time.Now()); !ok {
+		if reason != "" {
+			w.Header().Set(protocol.MCPSessionExpiredHeader, reason)
+		}
+		writeError(w, http.StatusNotFound, nil, -32001, "session not found", protocol.ErrorCodeSessionNotFound, false)
+		return
+	}
+	sdkHandler.ServeHTTP(w, req)
+	t.server.forgetSession(sessionID)
 }
 
 func readSDKBody(w http.ResponseWriter, req *http.Request) ([]byte, bool) {
@@ -227,6 +320,8 @@ func (t *SDKTransport) dispatchSDKRequest(w http.ResponseWriter, req *http.Reque
 		t.handleSDKInitialize(w, req, id, hasID, sdkHandler)
 	case protocol.RPCMethodNotificationsInitialized:
 		t.handleSDKNotificationsInitialized(w, id, hasID)
+	case protocol.RPCMethodNotificationsCancelled:
+		t.handleSDKNotificationsCancelled(w, req, id, hasID, sdkHandler)
 	case protocol.RPCMethodToolsList:
 		t.handleSDKToolsList(w, req, hasID, sdkHandler)
 	case protocol.RPCMethodToolsCall:
@@ -279,6 +374,26 @@ func (t *SDKTransport) handleSDKNotificationsInitialized(w http.ResponseWriter, 
 		return
 	}
 	writeResult(w, http.StatusOK, id, map[string]interface{}{})
+}
+
+// handleSDKNotificationsCancelled forwards a cancellation notification to the
+// SDK so it can cancel the context of the request it targets (matched by
+// requestId within the session). Previously this fell through to
+// handleSDKUnknownMethod and was 202'd without ever reaching the SDK, so a
+// client cancelling a long ask/transcribe could not stop the server from
+// continuing to spend provider quota (issue #404). Cancellation only reaches an
+// in-flight tool call on the SDK-dispatched path (the default, non-x402 path);
+// the x402 path routes tools/call outside the SDK, so a cancel there is a
+// well-formed 202 no-op rather than an interrupt.
+func (t *SDKTransport) handleSDKNotificationsCancelled(w http.ResponseWriter, req *http.Request, id interface{}, hasID bool, sdkHandler http.Handler) {
+	if hasID {
+		// notifications/cancelled is a notification; an id makes it malformed.
+		// Preserve the JSON-RPC error contract rather than forwarding a
+		// would-be request the SDK would treat differently.
+		writeError(w, http.StatusOK, id, -32600, "notifications/cancelled must not carry an id", "INVALID_FIELD", false)
+		return
+	}
+	sdkHandler.ServeHTTP(w, req)
 }
 
 func (t *SDKTransport) handleSDKToolsList(w http.ResponseWriter, req *http.Request, hasID bool, sdkHandler http.Handler) {

--- a/internal/mcp/transport_sdk.go
+++ b/internal/mcp/transport_sdk.go
@@ -276,8 +276,18 @@ func (t *SDKTransport) serveSessionTermination(w http.ResponseWriter, req *http.
 		writeError(w, http.StatusNotFound, nil, -32001, "session not found", protocol.ErrorCodeSessionNotFound, false)
 		return
 	}
-	sdkHandler.ServeHTTP(w, req)
-	t.server.forgetSession(sessionID)
+	// Buffer the SDK's DELETE response so we can inspect its status before
+	// deciding whether to forget our own record. Only a confirmed 204 (the
+	// spec's success status for session termination) means the SDK actually
+	// tore down its per-session state; on any non-success response
+	// (error/timeout/id mismatch) we leave our record intact so the client can
+	// retry, rather than bricking a still-live session and blocking retries.
+	rec := newBufferedResponseWriter()
+	sdkHandler.ServeHTTP(rec, req)
+	if rec.status == http.StatusNoContent {
+		t.server.forgetSession(sessionID)
+	}
+	copyBufferedResponse(w, rec)
 }
 
 func readSDKBody(w http.ResponseWriter, req *http.Request) ([]byte, bool) {

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -46,6 +46,7 @@ const (
 const (
 	RPCMethodInitialize               = "initialize"
 	RPCMethodNotificationsInitialized = "notifications/initialized"
+	RPCMethodNotificationsCancelled   = "notifications/cancelled"
 	RPCMethodToolsList                = "tools/list"
 	RPCMethodToolsCall                = "tools/call"
 )

--- a/tests/mcp/conformance_test.go
+++ b/tests/mcp/conformance_test.go
@@ -47,29 +47,6 @@ func startConformanceServer(t *testing.T) (baseURL string, stop func()) {
 	return "http://" + ln.Addr().String() + "/mcp", stop
 }
 
-// initSession performs an initialize handshake and returns the session id.
-func initSession(t *testing.T, client *http.Client, url string) string {
-	t.Helper()
-	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`))
-	if err != nil {
-		t.Fatalf("build initialize: %v", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	resp, err := client.Do(req)
-	if err != nil {
-		t.Fatalf("POST initialize: %v", err)
-	}
-	_ = resp.Body.Close()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		t.Fatalf("initialize status: %d", resp.StatusCode)
-	}
-	sessionID := strings.TrimSpace(resp.Header.Get("MCP-Session-Id"))
-	if sessionID == "" {
-		t.Fatal("expected MCP-Session-Id from initialize")
-	}
-	return sessionID
-}
-
 // TestSDKTransport_PartialAcceptNegotiated verifies that a client sending only
 // "Accept: application/json" (non-empty but partial) is accepted rather than
 // 400'd by the SDK's dual-type requirement (#404, gap 2).
@@ -106,7 +83,7 @@ func TestSDKTransport_DeleteTerminatesSession(t *testing.T) {
 	defer stop()
 
 	client := &http.Client{Timeout: 3 * time.Second}
-	sessionID := initSession(t, client, url)
+	sessionID := initializeSession(t, url)
 
 	delReq, err := http.NewRequest(http.MethodDelete, url, nil)
 	if err != nil {
@@ -194,7 +171,7 @@ func TestSDKTransport_CancelledNotificationForwarded(t *testing.T) {
 	defer stop()
 
 	client := &http.Client{Timeout: 3 * time.Second}
-	sessionID := initSession(t, client, url)
+	sessionID := initializeSession(t, url)
 
 	cancelReq, err := http.NewRequest(http.MethodPost, url, strings.NewReader(`{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":"42","reason":"user aborted"}}`))
 	if err != nil {
@@ -220,7 +197,7 @@ func TestSDKTransport_CancelledWithIDRejected(t *testing.T) {
 	defer stop()
 
 	client := &http.Client{Timeout: 3 * time.Second}
-	sessionID := initSession(t, client, url)
+	sessionID := initializeSession(t, url)
 
 	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(`{"jsonrpc":"2.0","id":9,"method":"notifications/cancelled","params":{"requestId":"42"}}`))
 	if err != nil {

--- a/tests/mcp/conformance_test.go
+++ b/tests/mcp/conformance_test.go
@@ -1,0 +1,243 @@
+package tests
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/mcp"
+)
+
+// startConformanceServer boots an SDKTransport on a loopback listener and
+// returns its base /mcp URL plus a stop func. It mirrors the setup used by the
+// other transport tests but is shared across the conformance cases below.
+func startConformanceServer(t *testing.T) (baseURL string, stop func()) {
+	t.Helper()
+	srv := mcp.NewServer(config.Config{MCPPath: "/mcp", AuthMode: "none"}, nil)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	tr := mcp.NewSDKTransport(srv, ln, "", "")
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- tr.Serve(ctx, srv.Handler())
+	}()
+
+	stop = func() {
+		cancel()
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Errorf("Serve returned unexpected error: %v", err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Error("timeout waiting for Serve to exit")
+		}
+		_ = ln.Close()
+	}
+	return "http://" + ln.Addr().String() + "/mcp", stop
+}
+
+// initSession performs an initialize handshake and returns the session id.
+func initSession(t *testing.T, client *http.Client, url string) string {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`))
+	if err != nil {
+		t.Fatalf("build initialize: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("POST initialize: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		t.Fatalf("initialize status: %d", resp.StatusCode)
+	}
+	sessionID := strings.TrimSpace(resp.Header.Get("MCP-Session-Id"))
+	if sessionID == "" {
+		t.Fatal("expected MCP-Session-Id from initialize")
+	}
+	return sessionID
+}
+
+// TestSDKTransport_PartialAcceptNegotiated verifies that a client sending only
+// "Accept: application/json" (non-empty but partial) is accepted rather than
+// 400'd by the SDK's dual-type requirement (#404, gap 2).
+func TestSDKTransport_PartialAcceptNegotiated(t *testing.T) {
+	url, stop := startConformanceServer(t)
+	defer stop()
+
+	client := &http.Client{Timeout: 3 * time.Second}
+
+	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json") // partial: missing text/event-stream
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("POST initialize: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("partial Accept should be negotiated to 200, got %d: %s", resp.StatusCode, string(body))
+	}
+	if strings.TrimSpace(resp.Header.Get("MCP-Session-Id")) == "" {
+		t.Fatal("expected session id despite partial Accept")
+	}
+}
+
+// TestSDKTransport_DeleteTerminatesSession verifies DELETE terminates the
+// session (204) and that the id is no longer usable afterward (#404, gap 3).
+func TestSDKTransport_DeleteTerminatesSession(t *testing.T) {
+	url, stop := startConformanceServer(t)
+	defer stop()
+
+	client := &http.Client{Timeout: 3 * time.Second}
+	sessionID := initSession(t, client, url)
+
+	delReq, err := http.NewRequest(http.MethodDelete, url, nil)
+	if err != nil {
+		t.Fatalf("build DELETE: %v", err)
+	}
+	delReq.Header.Set("MCP-Session-Id", sessionID)
+	delResp, err := client.Do(delReq)
+	if err != nil {
+		t.Fatalf("DELETE: %v", err)
+	}
+	_ = delResp.Body.Close()
+	if delResp.StatusCode != http.StatusNoContent {
+		t.Fatalf("expected 204 from DELETE, got %d", delResp.StatusCode)
+	}
+
+	// The terminated session id must no longer be accepted.
+	listReq, err := http.NewRequest(http.MethodPost, url, strings.NewReader(`{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}`))
+	if err != nil {
+		t.Fatalf("build tools/list: %v", err)
+	}
+	listReq.Header.Set("Content-Type", "application/json")
+	listReq.Header.Set("MCP-Session-Id", sessionID)
+	listResp, err := client.Do(listReq)
+	if err != nil {
+		t.Fatalf("tools/list after DELETE: %v", err)
+	}
+	_ = listResp.Body.Close()
+	if listResp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404 for terminated session, got %d", listResp.StatusCode)
+	}
+}
+
+// TestSDKTransport_DeleteUnknownSession verifies DELETE with a missing/unknown
+// session returns our canonical 404 SESSION_NOT_FOUND contract.
+func TestSDKTransport_DeleteUnknownSession(t *testing.T) {
+	url, stop := startConformanceServer(t)
+	defer stop()
+
+	client := &http.Client{Timeout: 3 * time.Second}
+
+	// No session header at all.
+	req, err := http.NewRequest(http.MethodDelete, url, nil)
+	if err != nil {
+		t.Fatalf("build DELETE: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404 for DELETE without session, got %d", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), "SESSION_NOT_FOUND") {
+		t.Fatalf("expected SESSION_NOT_FOUND contract, got %s", string(body))
+	}
+}
+
+// TestSDKTransport_GetUnsupported verifies GET is 405'd with an accurate Allow
+// header advertising the supported verbs (#404, gap 3).
+func TestSDKTransport_GetUnsupported(t *testing.T) {
+	url, stop := startConformanceServer(t)
+	defer stop()
+
+	client := &http.Client{Timeout: 3 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405 for GET, got %d", resp.StatusCode)
+	}
+	allow := resp.Header.Get("Allow")
+	if !strings.Contains(allow, "POST") || !strings.Contains(allow, "DELETE") {
+		t.Fatalf("expected Allow to advertise POST and DELETE, got %q", allow)
+	}
+}
+
+// TestSDKTransport_CancelledNotificationForwarded verifies notifications/cancelled
+// is accepted (202) rather than swallowed as an unknown method (#404, gap 1).
+func TestSDKTransport_CancelledNotificationForwarded(t *testing.T) {
+	url, stop := startConformanceServer(t)
+	defer stop()
+
+	client := &http.Client{Timeout: 3 * time.Second}
+	sessionID := initSession(t, client, url)
+
+	cancelReq, err := http.NewRequest(http.MethodPost, url, strings.NewReader(`{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":"42","reason":"user aborted"}}`))
+	if err != nil {
+		t.Fatalf("build cancelled: %v", err)
+	}
+	cancelReq.Header.Set("Content-Type", "application/json")
+	cancelReq.Header.Set("MCP-Session-Id", sessionID)
+	resp, err := client.Do(cancelReq)
+	if err != nil {
+		t.Fatalf("POST notifications/cancelled: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("expected 202 for cancellation notification, got %d", resp.StatusCode)
+	}
+}
+
+// TestSDKTransport_CancelledWithIDRejected verifies a malformed cancellation
+// carrying an id is rejected via the JSON-RPC error contract rather than
+// forwarded as a request.
+func TestSDKTransport_CancelledWithIDRejected(t *testing.T) {
+	url, stop := startConformanceServer(t)
+	defer stop()
+
+	client := &http.Client{Timeout: 3 * time.Second}
+	sessionID := initSession(t, client, url)
+
+	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(`{"jsonrpc":"2.0","id":9,"method":"notifications/cancelled","params":{"requestId":"42"}}`))
+	if err != nil {
+		t.Fatalf("build cancelled+id: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("MCP-Session-Id", sessionID)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("POST cancelled+id: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 JSON-RPC error envelope, got %d", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), "INVALID_FIELD") {
+		t.Fatalf("expected INVALID_FIELD error, got %s", string(body))
+	}
+}


### PR DESCRIPTION
Closes #404.

Scoped strictly to the streamable-HTTP SDK transport (`internal/mcp/`). Verified each sub-point against current `main` (none of #476–485 touched these paths) and fixed the concrete, well-defined ones.

## Fixed
- **Gap 1 — `notifications/cancelled` swallowed [MODERATE].** Added `RPCMethodNotificationsCancelled` and forward the notification to the SDK instead of falling through to the unknown-method 202. On the default (non-x402) path the SDK dispatches tool calls, so a cancel now reaches the in-flight request's context. The x402 path routes `tools/call` outside the SDK, so a cancel there is a well-formed 202 no-op (noted). A cancellation carrying an id is rejected via the existing JSON-RPC error contract.
- **Gap 2 — partial `Accept` → opaque 400 [LOW/MOD].** `negotiateAccept` now augments a partial `Accept` so it advertises **both** `application/json` and `text/event-stream`, instead of only injecting when the header is empty. Detection mirrors the SDK's exact whole-token matching (v1.4.1 `streamable.go`), so an unmatched token like `application/json;q=0.9` is treated as missing and the canonical token is appended. A client sending exactly `Accept: application/json` is no longer 400'd.
- **Gap 3 — GET/DELETE hard-405'd [LOW].** `DELETE` session-termination is now supported: validate the session (canonical `SESSION_NOT_FOUND` on miss), forward to the SDK (204 + session close), then forget our copy so the id can't be replayed. Unsupported verbs 405 with an accurate `Allow: POST, DELETE`. **GET server→client SSE remains unsupported by design** — this is a request/response RAG server that pushes no unsolicited notifications (full streaming semantics deferred, per issue framing).

## Deferred / left as-is
- **Gap 4 — dead legacy handlers [LOW, latent].** `handleInitialize` (no version negotiation) and `handleToolsList` (no pagination) are off the live SDK path (the SDK handles negotiation + pagination) and some internal tests drive them directly. Changing them risks those tests for a latent, correct-by-luck path, so they're intentionally unchanged.

## Tests
Added `tests/mcp/conformance_test.go`: partial-Accept negotiated to 200, DELETE terminates + id no longer usable, DELETE unknown session → 404 `SESSION_NOT_FOUND`, GET → 405 with `Allow`, cancelled notification → 202, cancelled-with-id → JSON-RPC `INVALID_FIELD`.

## Validation
`gofmt -l` clean; `go build ./...`; `go vet ./internal/mcp/...`; `make cyclo` (≤15) pass; `golangci-lint run ./internal/mcp/...` = 0 issues; `go test ./internal/mcp/... ./tests/mcp/...` pass.

## Files changed
`internal/mcp/transport_sdk.go`, `internal/mcp/server.go` (`forgetSession` helper), `internal/protocol/constants.go` (one-line constant — the file the issue explicitly names as missing it; not among the packages parallel agents are editing), `tests/mcp/conformance_test.go`.