### PR TITLE
fix(store,config): persistence + config gaps (#405)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3644,6 +3644,13 @@ func (c *Config) validateNumericBounds() error {
 	if c.ChunkingOverlapTokens < 0 {
 		return fmt.Errorf("chunking.overlap_tokens must be non-negative: %d", c.ChunkingOverlapTokens)
 	}
+	// Relational guard (#405): an overlap >= the window size produces chunks
+	// that never advance (or run backwards), so reject it. Only enforced when
+	// a window is explicitly set (max_tokens > 0); 0 means "unset, use the
+	// chunker default", where a nonzero overlap is not yet meaningful.
+	if c.ChunkingMaxTokens > 0 && c.ChunkingOverlapTokens >= c.ChunkingMaxTokens {
+		return fmt.Errorf("chunking.overlap_tokens (%d) must be less than chunking.max_tokens (%d)", c.ChunkingOverlapTokens, c.ChunkingMaxTokens)
+	}
 	if c.IngestMaxFileMB < 0 {
 		return fmt.Errorf("ingest.max_file_mb must be non-negative: %d", c.IngestMaxFileMB)
 	}

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -343,9 +343,19 @@ func openDB(ctx context.Context, path string) (*sql.DB, error) {
 	// WAL itself can fail with SQLITE_BUSY if another process holds the
 	// database lock; without busy_timeout already in effect, that PRAGMA
 	// returns immediately rather than waiting.
+	//
+	// foreign_keys=ON makes the ON DELETE CASCADE constraints declared on
+	// representations/chunks/spans actually fire (#405). SQLite defaults it
+	// OFF, which left those cascades inert — harmless while every delete path
+	// is a soft-delete (UPDATE deleted=1), but a footgun the moment a hard
+	// DELETE FROM documents is introduced (compaction/vacuum), which would
+	// silently orphan child rows. It MUST be set outside any transaction; the
+	// single-connection pool (SetMaxOpenConns(1)) makes this per-connection
+	// pragma stick for the life of the store handle.
 	for _, pragma := range []string{
 		`PRAGMA busy_timeout=5000;`,
 		`PRAGMA journal_mode=WAL;`,
+		`PRAGMA foreign_keys=ON;`,
 	} {
 		if _, err := db.ExecContext(ctx, pragma); err != nil {
 			_ = db.Close()
@@ -353,6 +363,47 @@ func openDB(ctx context.Context, path string) (*sql.DB, error) {
 		}
 	}
 	return db, nil
+}
+
+// schemaVersion is the persistence-layer schema revision this binary
+// understands, stamped into the database file header via PRAGMA user_version
+// (#405). It is a monotonic counter, NOT the product/release version.
+//
+// All migrations to date are additive and idempotent (CREATE ... IF NOT
+// EXISTS, ALTER TABLE ADD COLUMN with defaults), so upgrading or downgrading
+// across them is safe and the floor stays at 1. Bump this ONLY when
+// introducing a non-additive change (a NOT NULL column without a default, a
+// type/tokenizer change, a table rewrite) so that:
+//   - a newer DB opened by an older binary is refused rather than
+//     silently mixed-version corrupted (the downgrade tripwire below), and
+//   - the bump documents exactly which change is not backward compatible.
+const schemaVersion = 1
+
+// checkSchemaVersion reads PRAGMA user_version and refuses to proceed when the
+// database was written by a newer binary (dbVersion > schemaVersion). Older or
+// unstamped databases (user_version == 0, the SQLite default) are accepted and
+// upgraded in place by the additive migrations, then re-stamped by
+// stampSchemaVersion. This runs BEFORE any migration so a future DB is never
+// mutated by a binary that does not understand it.
+func checkSchemaVersion(ctx context.Context, db *sql.DB) error {
+	var dbVersion int64
+	if err := db.QueryRowContext(ctx, `PRAGMA user_version`).Scan(&dbVersion); err != nil {
+		return fmt.Errorf("read schema version: %w", err)
+	}
+	if dbVersion > schemaVersion {
+		return fmt.Errorf("database schema version %d is newer than this binary supports (%d); upgrade dir2mcp to open this corpus", dbVersion, schemaVersion)
+	}
+	return nil
+}
+
+// stampSchemaVersion records the current schemaVersion into the database file
+// header. PRAGMA user_version does not accept bound parameters, so the trusted
+// integer constant is formatted directly (never user input).
+func stampSchemaVersion(ctx context.Context, db *sql.DB) error {
+	if _, err := db.ExecContext(ctx, fmt.Sprintf(`PRAGMA user_version = %d`, schemaVersion)); err != nil {
+		return fmt.Errorf("stamp schema version: %w", err)
+	}
+	return nil
 }
 
 // applyAdditiveColumnMigrations runs ALTER TABLE ADD COLUMN statements that
@@ -444,6 +495,12 @@ func (s *SQLiteStore) initLocked(ctx context.Context) error {
 
 	db, err := openDB(ctx, s.path)
 	if err != nil {
+		return err
+	}
+
+	// Refuse a database written by a newer binary before touching it (#405).
+	if err := checkSchemaVersion(ctx, db); err != nil {
+		_ = db.Close()
 		return err
 	}
 
@@ -566,7 +623,7 @@ CREATE INDEX IF NOT EXISTS idx_mcp_payment_outcomes_updated ON mcp_payment_outco
 		_ = db.Close()
 		return err
 	}
-	if err := backfillFTSIfEmpty(ctx, db); err != nil {
+	if err := repairFTSIfDrifted(ctx, db); err != nil {
 		_ = db.Close()
 		return err
 	}
@@ -576,28 +633,49 @@ CREATE INDEX IF NOT EXISTS idx_mcp_payment_outcomes_updated ON mcp_payment_outco
 		return err
 	}
 
+	// Stamp the schema version last, once every migration/repair above
+	// succeeded, so a partially-migrated DB is never marked current (#405).
+	if err := stampSchemaVersion(ctx, db); err != nil {
+		_ = db.Close()
+		return err
+	}
+
 	s.db = db
 	return nil
 }
 
-// backfillFTSIfEmpty handles the upgrade path where chunks_fts is created
-// fresh against an existing chunks table. Without this, FTS searches on a
-// pre-existing index return zero hits until each chunk is reprocessed by
-// ingest. The 'rebuild' command re-derives FTS content from the
-// content='chunks' external-content reference.
-func backfillFTSIfEmpty(ctx context.Context, db *sql.DB) error {
-	var exists, chunkCount int64
-	err := db.QueryRowContext(ctx, `SELECT 1 FROM chunks_fts LIMIT 1`).Scan(&exists)
-	if err == nil {
-		return nil
-	}
-	if !errors.Is(err, sql.ErrNoRows) {
-		return fmt.Errorf("check chunks_fts empty: %w", err)
-	}
-	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM chunks WHERE deleted = 0`).Scan(&chunkCount); err != nil {
+// repairFTSIfDrifted rebuilds the chunks_fts external-content index whenever it
+// has drifted out of sync with the chunks table (#405). The chunks_ai/ad/au
+// triggers mirror EVERY chunk row (including soft-deleted ones, whose deleted
+// flag is a column update, not a row removal) into chunks_fts, so a healthy
+// index has exactly one FTS entry per chunk row.
+//
+// Drift is measured against the chunks_fts_docsize shadow table, NOT
+// `SELECT COUNT(*) FROM chunks_fts`: on an external-content FTS5 table a plain
+// COUNT proxies back to the content table (chunks), so it can never reveal a
+// missing index entry. chunks_fts_docsize holds one row per actually-indexed
+// document, so COUNT(chunks_fts_docsize) == COUNT(chunks) is the true
+// consistency invariant. (FTS5 always creates _docsize unless the index was
+// declared with columnsize=0, which chunks_fts is not.)
+//
+// This supersedes the earlier "rebuild only when fully empty" probe, which
+// missed PARTIAL drift: a crash mid-rebuild, or any future write path that
+// bypasses the triggers, leaves a partially-populated FTS that the emptiness
+// check waved through — silently losing lexical recall for the missing chunks
+// until an operator ran an explicit rebuild. Any count mismatch (empty OR
+// partial) triggers a full rebuild from the content='chunks' reference; the
+// rebuild re-indexes every chunk row, so the counts match afterward and
+// startup does not loop. Distinct from #373 (NULL bm25 score) and #439
+// (quarantine query-time filter): both of those leave the FTS row set intact.
+func repairFTSIfDrifted(ctx context.Context, db *sql.DB) error {
+	var chunkCount, indexedCount int64
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM chunks`).Scan(&chunkCount); err != nil {
 		return fmt.Errorf("count chunks: %w", err)
 	}
-	if chunkCount == 0 {
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM chunks_fts_docsize`).Scan(&indexedCount); err != nil {
+		return fmt.Errorf("count chunks_fts_docsize: %w", err)
+	}
+	if chunkCount == indexedCount {
 		return nil
 	}
 	if _, err := db.ExecContext(ctx, `INSERT INTO chunks_fts(chunks_fts) VALUES('rebuild')`); err != nil {

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -339,9 +339,26 @@ func openDB(ctx context.Context, path string) (*sql.DB, error) {
 		return nil, err
 	}
 	db.SetMaxOpenConns(1)
-	// Order matters: busy_timeout MUST come before journal_mode. Switching to
-	// WAL itself can fail with SQLITE_BUSY if another process holds the
-	// database lock; without busy_timeout already in effect, that PRAGMA
+	// busy_timeout is connection-local and non-persistent: setting it neither
+	// creates nor mutates any on-disk file. Set it first so the WAL switch below
+	// waits rather than returning SQLITE_BUSY immediately when another process
+	// holds the database lock.
+	if _, err := db.ExecContext(ctx, `PRAGMA busy_timeout=5000;`); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	// Reject a database written by a NEWER binary BEFORE any persistent mutation
+	// (#405). PRAGMA journal_mode=WAL below persistently creates/modifies the
+	// -wal file, so the downgrade tripwire MUST run first: a future-schema DB we
+	// do not understand must be left byte-for-byte untouched. Reading
+	// user_version is a pure read and does not create a -wal file.
+	if err := checkSchemaVersion(ctx, db); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	// Order matters: busy_timeout (set above) MUST come before journal_mode.
+	// Switching to WAL itself can fail with SQLITE_BUSY if another process holds
+	// the database lock; without busy_timeout already in effect, that PRAGMA
 	// returns immediately rather than waiting.
 	//
 	// foreign_keys=ON makes the ON DELETE CASCADE constraints declared on
@@ -353,7 +370,6 @@ func openDB(ctx context.Context, path string) (*sql.DB, error) {
 	// single-connection pool (SetMaxOpenConns(1)) makes this per-connection
 	// pragma stick for the life of the store handle.
 	for _, pragma := range []string{
-		`PRAGMA busy_timeout=5000;`,
 		`PRAGMA journal_mode=WAL;`,
 		`PRAGMA foreign_keys=ON;`,
 	} {
@@ -383,8 +399,9 @@ const schemaVersion = 1
 // database was written by a newer binary (dbVersion > schemaVersion). Older or
 // unstamped databases (user_version == 0, the SQLite default) are accepted and
 // upgraded in place by the additive migrations, then re-stamped by
-// stampSchemaVersion. This runs BEFORE any migration so a future DB is never
-// mutated by a binary that does not understand it.
+// stampSchemaVersion. openDB calls this BEFORE applying journal_mode=WAL (or any
+// other persistent pragma/migration) so a future-schema DB is never mutated —
+// not even its -wal file created — by a binary that does not understand it.
 func checkSchemaVersion(ctx context.Context, db *sql.DB) error {
 	var dbVersion int64
 	if err := db.QueryRowContext(ctx, `PRAGMA user_version`).Scan(&dbVersion); err != nil {
@@ -493,14 +510,10 @@ func (s *SQLiteStore) initLocked(ctx context.Context) error {
 		return fmt.Errorf("set database file permissions: %w", err)
 	}
 
+	// openDB refuses a database written by a newer binary before applying any
+	// persistent pragma (WAL), so a future-schema DB is rejected untouched (#405).
 	db, err := openDB(ctx, s.path)
 	if err != nil {
-		return err
-	}
-
-	// Refuse a database written by a newer binary before touching it (#405).
-	if err := checkSchemaVersion(ctx, db); err != nil {
-		_ = db.Close()
 		return err
 	}
 
@@ -669,11 +682,14 @@ CREATE INDEX IF NOT EXISTS idx_mcp_payment_outcomes_updated ON mcp_payment_outco
 // (quarantine query-time filter): both of those leave the FTS row set intact.
 func repairFTSIfDrifted(ctx context.Context, db *sql.DB) error {
 	var chunkCount, indexedCount int64
-	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM chunks`).Scan(&chunkCount); err != nil {
-		return fmt.Errorf("count chunks: %w", err)
-	}
-	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM chunks_fts_docsize`).Scan(&indexedCount); err != nil {
-		return fmt.Errorf("count chunks_fts_docsize: %w", err)
+	// Read both counts in ONE statement so they observe a single, consistent
+	// database snapshot. Two separate COUNT(*) queries can straddle a concurrent
+	// writer's commit and see different snapshots, reporting a spurious mismatch
+	// that triggers a needless (costly) full FTS rebuild.
+	if err := db.QueryRowContext(ctx, `SELECT
+		(SELECT COUNT(*) FROM chunks),
+		(SELECT COUNT(*) FROM chunks_fts_docsize)`).Scan(&chunkCount, &indexedCount); err != nil {
+		return fmt.Errorf("count chunks vs chunks_fts_docsize: %w", err)
 	}
 	if chunkCount == indexedCount {
 		return nil

--- a/tests/config/chunking_overlap_validation_test.go
+++ b/tests/config/chunking_overlap_validation_test.go
@@ -1,0 +1,49 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+)
+
+// TestChunkingOverlapMustBeLessThanMax pins the relational guard added for
+// #405: when a chunk window is explicitly set (max_tokens > 0), an overlap that
+// meets or exceeds it would never advance the window, so Validate must reject
+// it. A zero window means "unset, use the chunker default" and is left alone.
+func TestChunkingOverlapMustBeLessThanMax(t *testing.T) {
+	t.Run("overlap equal to max is rejected", func(t *testing.T) {
+		cfg := config.Default()
+		cfg.ChunkingMaxTokens = 200
+		cfg.ChunkingOverlapTokens = 200
+		if err := cfg.Validate(); err == nil {
+			t.Fatal("expected overlap == max to fail validation")
+		}
+	})
+
+	t.Run("overlap greater than max is rejected", func(t *testing.T) {
+		cfg := config.Default()
+		cfg.ChunkingMaxTokens = 200
+		cfg.ChunkingOverlapTokens = 250
+		if err := cfg.Validate(); err == nil {
+			t.Fatal("expected overlap > max to fail validation")
+		}
+	})
+
+	t.Run("overlap less than max is accepted", func(t *testing.T) {
+		cfg := config.Default()
+		cfg.ChunkingMaxTokens = 200
+		cfg.ChunkingOverlapTokens = 50
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("overlap < max must validate: %v", err)
+		}
+	})
+
+	t.Run("unset window with nonzero overlap is not gated by the relation", func(t *testing.T) {
+		cfg := config.Default()
+		cfg.ChunkingMaxTokens = 0
+		cfg.ChunkingOverlapTokens = 100
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("unset max_tokens must skip the overlap<max relation: %v", err)
+		}
+	})
+}

--- a/tests/store/persistence_hardening_test.go
+++ b/tests/store/persistence_hardening_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"context"
 	"database/sql"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -74,6 +75,47 @@ func TestSchemaVersionDowngradeGuard(t *testing.T) {
 	defer func() { _ = st2.Close() }()
 	if err := st2.Init(ctx); err == nil {
 		t.Fatal("expected Init to reject a database with a newer schema version")
+	}
+}
+
+// TestSchemaVersionRejectedBeforeWALCreated pins that the downgrade tripwire
+// runs BEFORE any persistent mutation: opening a newer-schema database must be
+// refused without so much as creating its -wal file. journal_mode=WAL, applied
+// by openDB, persistently creates/modifies the -wal file, so the user_version
+// check must precede it (#405).
+func TestSchemaVersionRejectedBeforeWALCreated(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "meta.sqlite")
+
+	// Build a minimal database stamped with a far-future schema version using a
+	// raw connection in the default (rollback) journal mode, so the fixture
+	// itself leaves no -wal file behind.
+	raw := openRaw(t, dbPath)
+	if _, err := raw.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS _touch(x)`); err != nil {
+		t.Fatalf("touch db: %v", err)
+	}
+	if _, err := raw.ExecContext(ctx, `PRAGMA user_version = 99999`); err != nil {
+		t.Fatalf("forge user_version: %v", err)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("close raw: %v", err)
+	}
+
+	walPath := dbPath + "-wal"
+	if _, err := os.Stat(walPath); !os.IsNotExist(err) {
+		t.Fatalf("precondition: -wal file should not exist yet (stat err=%v)", err)
+	}
+
+	// A fresh store must refuse the future database...
+	st := store.NewSQLiteStore(dbPath)
+	defer func() { _ = st.Close() }()
+	if err := st.Init(ctx); err == nil {
+		t.Fatal("expected Init to reject a database with a newer schema version")
+	}
+
+	// ...and must NOT have created a -wal file while doing so.
+	if _, err := os.Stat(walPath); !os.IsNotExist(err) {
+		t.Fatalf("Init must not create a -wal file when rejecting a newer-schema DB (stat err=%v)", err)
 	}
 }
 

--- a/tests/store/persistence_hardening_test.go
+++ b/tests/store/persistence_hardening_test.go
@@ -1,0 +1,223 @@
+package tests
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// openRaw opens a second, independent connection to the same sqlite file so a
+// test can inspect or perturb the database out-of-band from the store handle.
+// foreign_keys is a per-connection pragma, so callers that need cascades on
+// this connection must enable it themselves.
+func openRaw(t *testing.T, dbPath string) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open raw sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// TestSchemaVersionStamped pins that Init records a non-zero PRAGMA
+// user_version into the database file header (#405). Before this, openDB set
+// only busy_timeout+journal_mode and the schema carried no version floor, so a
+// future non-additive migration had no tripwire.
+func TestSchemaVersionStamped(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "meta.sqlite")
+	st := store.NewSQLiteStore(dbPath)
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	_ = st.Close()
+
+	// user_version lives in the file header, so any connection reads it back.
+	raw := openRaw(t, dbPath)
+	var v int64
+	if err := raw.QueryRowContext(ctx, `PRAGMA user_version`).Scan(&v); err != nil {
+		t.Fatalf("read user_version: %v", err)
+	}
+	if v < 1 {
+		t.Fatalf("expected user_version >= 1 after Init, got %d", v)
+	}
+}
+
+// TestSchemaVersionDowngradeGuard pins the tripwire: a database stamped with a
+// version newer than this binary understands must be refused rather than
+// migrated in place (#405).
+func TestSchemaVersionDowngradeGuard(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "meta.sqlite")
+
+	// Initialize normally, then forge a far-future schema version.
+	st := store.NewSQLiteStore(dbPath)
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	_ = st.Close()
+
+	raw := openRaw(t, dbPath)
+	if _, err := raw.ExecContext(ctx, `PRAGMA user_version = 99999`); err != nil {
+		t.Fatalf("forge user_version: %v", err)
+	}
+
+	// A fresh store must refuse to open the future database.
+	st2 := store.NewSQLiteStore(dbPath)
+	defer func() { _ = st2.Close() }()
+	if err := st2.Init(ctx); err == nil {
+		t.Fatal("expected Init to reject a database with a newer schema version")
+	}
+}
+
+// TestForeignKeyCascade pins that the declared ON DELETE CASCADE constraints
+// actually fire once foreign_keys is enforced (#405): a hard delete of a
+// document tears down its representations, chunks, and spans. The store never
+// hard-deletes documents itself (it soft-deletes), so this exercises the
+// constraint through a raw connection with foreign_keys ON — proving the
+// schema's cascades are correctly declared rather than misleading.
+func TestForeignKeyCascade(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "meta.sqlite")
+	st := store.NewSQLiteStore(dbPath)
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	if err := st.UpsertDocument(ctx, model.Document{
+		RelPath: "docs/case.md",
+		DocType: "md",
+		Status:  "ok",
+	}); err != nil {
+		t.Fatalf("UpsertDocument: %v", err)
+	}
+	doc, err := st.GetDocumentByPath(ctx, "docs/case.md")
+	if err != nil {
+		t.Fatalf("GetDocumentByPath: %v", err)
+	}
+	repID, err := st.UpsertRepresentation(ctx, model.Representation{
+		DocID:   doc.DocID,
+		RepType: "raw_text",
+		RepHash: "hash-1",
+	})
+	if err != nil {
+		t.Fatalf("UpsertRepresentation: %v", err)
+	}
+	if _, err := st.InsertChunkWithSpans(ctx, model.Chunk{
+		RepID:   repID,
+		Ordinal: 0,
+		Text:    "the quick brown fox",
+	}, []model.Span{{Kind: "lines", StartLine: 1, EndLine: 1}}); err != nil {
+		t.Fatalf("InsertChunkWithSpans: %v", err)
+	}
+	_ = st.Close()
+
+	// Hard-delete the document on a connection that enforces foreign keys.
+	raw := openRaw(t, dbPath)
+	if _, err := raw.ExecContext(ctx, `PRAGMA foreign_keys=ON`); err != nil {
+		t.Fatalf("enable foreign_keys: %v", err)
+	}
+	if _, err := raw.ExecContext(ctx, `DELETE FROM documents WHERE doc_id = ?`, doc.DocID); err != nil {
+		t.Fatalf("DELETE FROM documents: %v", err)
+	}
+
+	for _, tbl := range []struct {
+		name  string
+		query string
+	}{
+		{"representations", `SELECT COUNT(*) FROM representations`},
+		{"chunks", `SELECT COUNT(*) FROM chunks`},
+		{"spans", `SELECT COUNT(*) FROM spans`},
+	} {
+		var n int64
+		if err := raw.QueryRowContext(ctx, tbl.query).Scan(&n); err != nil {
+			t.Fatalf("count %s: %v", tbl.name, err)
+		}
+		if n != 0 {
+			t.Errorf("cascade left %d orphaned %s rows, want 0", n, tbl.name)
+		}
+	}
+}
+
+// TestFTSPartialDriftRepaired pins that a PARTIALLY-populated chunks_fts (the
+// crash-mid-rebuild / trigger-bypass case) is detected and rebuilt on the next
+// Init (#405). The prior "rebuild only when fully empty" probe waved partial
+// drift through, silently losing lexical recall for the missing chunks.
+func TestFTSPartialDriftRepaired(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "meta.sqlite")
+	st := store.NewSQLiteStore(dbPath)
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	chunks := []struct {
+		label uint64
+		text  string
+	}{
+		{1, "alpha reporting suspicious transactions"},
+		{2, "bravo drug trafficking penalties criminal conduct"},
+		{3, "charlie training qualifications reporting officer"},
+	}
+	for _, c := range chunks {
+		task := model.NewChunkTask(c.label, c.text, "text", model.ChunkMetadata{
+			ChunkID: c.label,
+			RelPath: "docs/case.md",
+			DocType: "md",
+			RepType: "raw_text",
+		})
+		if err := st.UpsertChunkTask(ctx, task); err != nil {
+			t.Fatalf("UpsertChunkTask(%d): %v", c.label, err)
+		}
+	}
+	_ = st.Close()
+
+	// Corrupt the FTS index: evict a single chunk's row via the external-content
+	// 'delete' command, leaving chunks_fts partially populated (2 of 3 rows).
+	raw := openRaw(t, dbPath)
+	if _, err := raw.ExecContext(ctx,
+		`INSERT INTO chunks_fts(chunks_fts, rowid, text) VALUES('delete', ?, ?)`,
+		int64(2), "bravo drug trafficking penalties criminal conduct",
+	); err != nil {
+		t.Fatalf("evict FTS row: %v", err)
+	}
+	// chunks_fts_docsize holds one row per actually-indexed document, so it
+	// reflects the eviction (2 of 3) — unlike COUNT(*) FROM chunks_fts, which
+	// proxies to the content table and would still read 3.
+	var indexedCount int64
+	if err := raw.QueryRowContext(ctx, `SELECT COUNT(*) FROM chunks_fts_docsize`).Scan(&indexedCount); err != nil {
+		t.Fatalf("count chunks_fts_docsize: %v", err)
+	}
+	if indexedCount != 2 {
+		t.Fatalf("setup: expected 2 indexed FTS rows after eviction, got %d", indexedCount)
+	}
+
+	// Reopening the store must detect the count drift and rebuild.
+	st2 := store.NewSQLiteStore(dbPath)
+	defer func() { _ = st2.Close() }()
+	if err := st2.Init(ctx); err != nil {
+		t.Fatalf("re-Init: %v", err)
+	}
+
+	ls, ok := interface{}(st2).(model.LexicalSearcher)
+	if !ok {
+		t.Fatalf("SQLiteStore must implement model.LexicalSearcher")
+	}
+	hits, err := ls.SearchBM25(ctx, "trafficking", 5, "text")
+	if err != nil {
+		t.Fatalf("SearchBM25: %v", err)
+	}
+	if len(hits) == 0 {
+		t.Fatal("evicted chunk not searchable after re-Init; partial FTS drift was not repaired")
+	}
+	if hits[0].ChunkID != 2 {
+		t.Errorf("expected repaired chunk 2 as top hit, got %d", hits[0].ChunkID)
+	}
+}


### PR DESCRIPTION
Addresses #405 (persistence + config robustness gaps). Scoped strictly to `internal/store/` and `internal/config/` plus tests. The two items whose consumers live outside this scope are noted as follow-ups below.

## Store

- **Schema version floor.** `openDB` previously stamped no version. Init now guards `PRAGMA user_version`: a DB written by a newer binary is refused (downgrade tripwire), older/unstamped DBs (user_version=0) are accepted, migrated additively, and re-stamped last (only after every migration/repair succeeds). `schemaVersion` starts at 1 — additive migrations to date are safe both directions; bump only on the first non-additive change.
- **Foreign keys enforced.** `PRAGMA foreign_keys=ON` is now set on every connection (alongside busy_timeout/journal_mode). The `ON DELETE CASCADE` constraints on representations/chunks/spans were inert (SQLite defaults FK off); a future hard `DELETE FROM documents` would have orphaned child rows. The single-connection pool makes this per-connection pragma stick. No existing hard-delete path is affected (all store deletes are soft-deletes; the only manual `DELETE` is spans-for-a-chunk, parent intact).
- **Partial FTS drift repair.** `backfillFTSIfEmpty` (rebuild only when *fully* empty) is replaced by `repairFTSIfDrifted`, which compares `COUNT(chunks)` against the `chunks_fts_docsize` shadow table and rebuilds on any mismatch. A plain `COUNT(*) FROM chunks_fts` proxies to the content table and can never reveal a missing entry, so it could not detect a crash-mid-rebuild / trigger-bypass partial index. Distinct from #373 (NULL bm25) and #439 (quarantine query-time filter) — neither touches the FTS row set. The `chunks_ai/ad/au` triggers are untouched.

## Config

- **`chunking.overlap_tokens` < `chunking.max_tokens`** relational validation added (only enforced when `max_tokens > 0`; 0 means "unset, use chunker default"). This is the in-scope half of the "chunking.* silently ignored" item.

## Deferred (out of this scope, other agents own the files)

- **Wiring `chunking.max_tokens`/`overlap_tokens` to a consumer.** The chunker hardcodes literals in `internal/ingest/represent.go` (owned elsewhere for this batch). This PR adds the relational guard; the actual wire-through belongs to an ingest-scoped change.
- **Re-running `Validate()` after flag overlay.** The flag-applied-after-Validate hole is in `internal/cli/up.go` (out of scope here); should call `Validate()` again after applying flags.

## Tests (under `tests/`)

- `tests/store/persistence_hardening_test.go`: user_version stamped, newer-version downgrade refused, FK cascade tears down rep/chunk/span, partial-FTS drift repaired (evicted chunk searchable again after re-Init).
- `tests/config/chunking_overlap_validation_test.go`: overlap ==/> max rejected, < max accepted, unset window skips the relation.

## Validation

`gofmt` clean, `go build ./...`, `go vet ./...`, `make cyclo` (≤15), `golangci-lint run ./internal/store/... ./internal/config/...` → 0 issues, and full `go test ./tests/... ./internal/...` all pass.