### PR TITLE
fix(embedqueue): idempotent embedded_ok, concurrent-coordinator guard, enqueue-stall signal (#486)

### DIFF
--- a/internal/cli/embed_worker.go
+++ b/internal/cli/embed_worker.go
@@ -188,7 +188,9 @@ func (a *App) runEmbedWorkerLoop(ctx context.Context, cfg config.Config, global 
 	defer func() { _ = broker.Close() }()
 
 	logger := pickEmbedLogger(a.stderr, global.jsonOutput)
-	embedders := buildAxisEmbedders(chunkSource, textIx, codeIx, embedder, nil, (*appstate.IndexingState)(nil), textModel, codeModel, cfg.RootDir, corpusFS, logger)
+	// The standalone embed-worker (#249) has no local IndexingState, so it needs no
+	// embedded_ok guard (the count hook is inert without a state to increment).
+	embedders := buildAxisEmbedders(chunkSource, textIx, codeIx, embedder, nil, (*appstate.IndexingState)(nil), (*embedqueue.EmbeddedGuard)(nil), textModel, codeModel, cfg.RootDir, corpusFS, logger)
 	if len(embedders) == 0 {
 		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, "CONFIG_INVALID: no index axis configured for embed-worker")
 		return exitConfigInvalid

--- a/internal/cli/up_distributed_embed.go
+++ b/internal/cli/up_distributed_embed.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"path/filepath"
 	"sync"
-	"time"
 
 	"github.com/dirstral/dir2mcp/internal/appstate"
 	"github.com/dirstral/dir2mcp/internal/config"
@@ -69,17 +68,38 @@ func startDistributedEmbedding(
 		return errors.New("distributed embedding: embed identity could not be resolved")
 	}
 
+	// Single-coordinator guard (issue #435 C3): refuse to start a second
+	// coordinator for this corpus. The default broker is in-process and cannot
+	// dedup across processes, so two daemons on one corpus would otherwise both
+	// enqueue + double-embed the same chunks. The lock releases automatically if
+	// this process dies (OS drops the advisory flock).
+	coordLock, err := embedqueue.AcquireCoordinatorLock(filepath.Join(cfg.StateDir, "embed-coordinator.lock"))
+	if err != nil {
+		if errors.Is(err, embedqueue.ErrCoordinatorLocked) {
+			return errors.New("distributed embedding: another dir2mcp is already embedding this corpus (coordinator lock held); refusing to start a second coordinator")
+		}
+		return fmt.Errorf("distributed embedding: acquire coordinator lock: %w", err)
+	}
+
 	broker, err := buildEmbedBroker(ctx, cfg)
 	if err != nil {
+		_ = coordLock.Release()
 		return fmt.Errorf("distributed embedding: build broker: %w", err)
 	}
 
+	// Guard embedded_ok against redelivery double-counting (issue #435 C2): the
+	// per-upsert hook fires on every successful (re-)embed, so gate the COUNT to a
+	// chunk's first success. Shared across both axes' hooks.
+	embeddedGuard := embedqueue.NewEmbeddedGuard()
+
 	// Build a per-kind embedder reusing the in-process embedding path so the
 	// distributed worker shares all embed/media-load/index/mark logic.
-	embedders := buildAxisEmbedders(chunkSource, textIndex, codeIndex, embedder, ret, indexingState, textModel, codeModel, rootDir, corpusFS, logger)
+	embedders := buildAxisEmbedders(chunkSource, textIndex, codeIndex, embedder, ret, indexingState, embeddedGuard, textModel, codeModel, rootDir, corpusFS, logger)
 	if len(embedders) == 0 {
-		// Post-open abort: close the broker so its SQLite handle is not leaked.
+		// Post-open abort: close the broker and release the lock so its SQLite
+		// handle and the coordinator lock are not leaked.
 		_ = broker.Close()
+		_ = coordLock.Release()
 		return errors.New("distributed embedding: no index axis configured")
 	}
 
@@ -121,11 +141,13 @@ func startDistributedEmbedding(
 		}()
 	}
 
-	// Close the broker when the run context ends so its handle (e.g. a SQLite DB)
-	// is released on shutdown.
+	// Close the broker and release the coordinator lock when the run context ends
+	// so its handle (e.g. a SQLite DB) and the single-coordinator guard are
+	// released on shutdown.
 	spawn(func() {
 		<-ctx.Done()
 		_ = broker.Close()
+		_ = coordLock.Release()
 	})
 
 	// Coordinator: periodically enqueue chunks that are still pending. Each pass
@@ -148,29 +170,38 @@ func startDistributedEmbedding(
 // runCoordinatorLoop enqueues pending chunks on a fixed interval until ctx is
 // cancelled. Re-enqueuing is safe: already-embedded chunks are no longer pending,
 // and a duplicate job is idempotent at the embed layer (SPEC §8.7.3).
+//
+// It delegates the loop + stall detection to embedqueue.RunCoordinator (issue #435
+// C4). A transient enqueue error stays best-effort (logged + non-blocking errCh
+// send) so a blip never stalls the loop, but a SUSTAINED failure (StallThreshold
+// consecutive errors) escalates to a durable, non-droppable signal — a
+// context-aware BLOCKING errCh send — so a stalled coordinator surfaces as an
+// embed_error event instead of a silently-idle daemon.
 func runCoordinatorLoop(ctx context.Context, coord *embedqueue.Coordinator, errCh chan<- error, logger *log.Logger) {
-	ticker := time.NewTicker(2 * time.Second)
-	defer ticker.Stop()
-	for {
-		if _, err := coord.EnqueuePending(ctx, ""); err != nil &&
-			!errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+	embedqueue.RunCoordinator(ctx, coord, embedqueue.CoordinatorLoopOptions{
+		OnError: func(err error) {
 			if logger != nil {
 				logger.Printf("distributed embedding: enqueue pending: %v", err)
 			}
-			// Also surface it as a structured event (the human logger is discarded
-			// in JSON mode). Non-blocking: a transient enqueue error must not stall
-			// the loop if errCh is full.
+			// Non-blocking: a transient enqueue error must not stall the loop if
+			// errCh is momentarily full.
 			select {
 			case errCh <- fmt.Errorf("distributed embedding: enqueue pending: %w", err):
 			default:
 			}
-		}
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-		}
-	}
+		},
+		OnStall: func(consecutive int, err error) {
+			if logger != nil {
+				logger.Printf("distributed embedding: enqueue STALLED after %d consecutive failures: %v", consecutive, err)
+			}
+			// Durable escalation: block until the signal is consumed (or shutdown)
+			// so a sustained stall is never dropped by a full channel.
+			select {
+			case errCh <- fmt.Errorf("distributed embedding: enqueue stalled after %d consecutive failures: %w", consecutive, err):
+			case <-ctx.Done():
+			}
+		},
+	})
 }
 
 // newEmbedStep builds an index.EmbeddingWorker configured for one axis and
@@ -183,6 +214,7 @@ func newEmbedStep(
 	embedder model.Embedder,
 	ret *retrieval.Service,
 	indexingState *appstate.IndexingState,
+	embeddedGuard *embedqueue.EmbeddedGuard,
 	textModel, codeModel, rootDir string,
 	corpusFS corpusfs.CorpusFS,
 	logger *log.Logger,
@@ -202,10 +234,13 @@ func newEmbedStep(
 		BatchSize:    distributedEmbedBatchSize,
 		Logger:       logger,
 		OnIndexedChunk: func(label uint64, metadata model.ChunkMetadata) {
+			// Refreshing metadata is idempotent, so it runs on every (re-)embed.
 			if ret != nil {
 				ret.SetChunkMetadataForIndex(kind, label, metadata.ToSearchHit())
 			}
-			if indexingState != nil {
+			// The count is NOT idempotent, so gate it to a chunk's first successful
+			// embed — a redelivered/retried job re-fires this hook (issue #435 C2).
+			if indexingState != nil && embeddedGuard.First(kind, label) {
 				indexingState.AddEmbeddedOK(1)
 			}
 		},
@@ -224,16 +259,17 @@ func buildAxisEmbedders(
 	embedder model.Embedder,
 	ret *retrieval.Service,
 	indexingState *appstate.IndexingState,
+	embeddedGuard *embedqueue.EmbeddedGuard,
 	textModel, codeModel, rootDir string,
 	corpusFS corpusfs.CorpusFS,
 	logger *log.Logger,
 ) map[string]embedqueue.Embedder {
 	embedders := make(map[string]embedqueue.Embedder)
 	if textIndex != nil {
-		embedders["text"] = newEmbedStep(chunkSource, textIndex, embedder, ret, indexingState, textModel, codeModel, rootDir, corpusFS, logger, "text")
+		embedders["text"] = newEmbedStep(chunkSource, textIndex, embedder, ret, indexingState, embeddedGuard, textModel, codeModel, rootDir, corpusFS, logger, "text")
 	}
 	if codeIndex != nil {
-		embedders["code"] = newEmbedStep(chunkSource, codeIndex, embedder, ret, indexingState, textModel, codeModel, rootDir, corpusFS, logger, "code")
+		embedders["code"] = newEmbedStep(chunkSource, codeIndex, embedder, ret, indexingState, embeddedGuard, textModel, codeModel, rootDir, corpusFS, logger, "code")
 	}
 	return embedders
 }

--- a/internal/embedqueue/coordinator_lock.go
+++ b/internal/embedqueue/coordinator_lock.go
@@ -1,0 +1,28 @@
+package embedqueue
+
+import "errors"
+
+// ErrCoordinatorLocked is returned by AcquireCoordinatorLock when another live
+// process already holds the corpus's coordinator lock. The caller MUST refuse to
+// start a second coordinator for the corpus: two coordinators on one corpus each
+// enqueue the same pending chunks and (with the default in-process MemBroker,
+// which cannot dedup across processes) double-embed them (issue #435 C3).
+var ErrCoordinatorLocked = errors.New("embedqueue: coordinator already running for this corpus")
+
+// CoordinatorLock is a single-holder, cross-process advisory lock guarding a
+// corpus's embedding coordinator (issue #435 C3, "detect + refuse"). It is a guard
+// against the accidental double-`up` / restart-race case, NOT a full multi-node
+// leader election (that lands with the standalone-worker deployment, #249): it
+// only ensures at most one coordinator runs per corpus on a single host.
+//
+// The default broker is in-process (MemBroker), so two daemons against the same
+// corpus each get a PRIVATE queue and cannot coordinate through the broker at all;
+// only a host-level lock (this) or the shared SQLite broker can catch that. The
+// lock is taken on a file in the corpus state dir, so it also naturally releases
+// if the holder process dies (the OS drops the advisory lock).
+//
+// The concrete lock is OS-specific; see coordinator_lock_unix.go and
+// coordinator_lock_other.go.
+type CoordinatorLock struct {
+	platformLock
+}

--- a/internal/embedqueue/coordinator_lock_other.go
+++ b/internal/embedqueue/coordinator_lock_other.go
@@ -1,0 +1,17 @@
+//go:build !unix
+
+package embedqueue
+
+// platformLock is empty on platforms without flock; the guard degrades to a no-op.
+type platformLock struct{}
+
+// AcquireCoordinatorLock is a no-op on non-unix platforms: it always succeeds so
+// the single-binary default keeps working, forgoing the cross-process coordinator
+// guard (issue #435 C3) there. dir2mcp ships darwin/linux binaries, where the unix
+// flock implementation applies.
+func AcquireCoordinatorLock(_ string) (*CoordinatorLock, error) {
+	return &CoordinatorLock{}, nil
+}
+
+// Release is a no-op on non-unix platforms.
+func (l *CoordinatorLock) Release() error { return nil }

--- a/internal/embedqueue/coordinator_lock_unix.go
+++ b/internal/embedqueue/coordinator_lock_unix.go
@@ -1,0 +1,49 @@
+//go:build unix
+
+package embedqueue
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// platformLock holds the open lock file whose flock we own. Closing the file (or
+// the process exiting) releases the flock.
+type platformLock struct {
+	f *os.File
+}
+
+// AcquireCoordinatorLock takes an exclusive, non-blocking advisory (flock) lock on
+// lockPath, creating the file if absent. It returns ErrCoordinatorLocked when
+// another process already holds it — the caller must then refuse to start a
+// coordinator for this corpus (issue #435 C3). The returned lock is released by
+// Release (or when the process exits and the OS drops the flock).
+func AcquireCoordinatorLock(lockPath string) (*CoordinatorLock, error) {
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("embedqueue: open coordinator lock: %w", err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = f.Close()
+		if err == syscall.EWOULDBLOCK {
+			return nil, ErrCoordinatorLocked
+		}
+		return nil, fmt.Errorf("embedqueue: lock coordinator lock: %w", err)
+	}
+	return &CoordinatorLock{platformLock{f: f}}, nil
+}
+
+// Release drops the advisory lock and closes the lock file. It is safe to call
+// once; a nil or already-released lock is a no-op.
+func (l *CoordinatorLock) Release() error {
+	if l == nil || l.f == nil {
+		return nil
+	}
+	f := l.f
+	l.f = nil
+	// Unlock explicitly; closing the fd would release it too, but being explicit
+	// keeps the intent clear and drops the lock even if Close is deferred.
+	_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+	return f.Close()
+}

--- a/internal/embedqueue/coordinator_lock_unix.go
+++ b/internal/embedqueue/coordinator_lock_unix.go
@@ -26,7 +26,9 @@ func AcquireCoordinatorLock(lockPath string) (*CoordinatorLock, error) {
 	}
 	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
 		_ = f.Close()
-		if err == syscall.EWOULDBLOCK {
+		// flock reports "already held" as EAGAIN or EWOULDBLOCK; POSIX allows these
+		// to be distinct errnos on some Unix platforms, so treat both as locked.
+		if err == syscall.EAGAIN || err == syscall.EWOULDBLOCK {
 			return nil, ErrCoordinatorLocked
 		}
 		return nil, fmt.Errorf("embedqueue: lock coordinator lock: %w", err)

--- a/internal/embedqueue/coordinator_loop.go
+++ b/internal/embedqueue/coordinator_loop.go
@@ -1,0 +1,103 @@
+package embedqueue
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// Default tuning for RunCoordinator.
+const (
+	defaultCoordinatorInterval = 2 * time.Second
+	defaultStallThreshold      = 3
+)
+
+// CoordinatorLoopOptions configures RunCoordinator (SPEC §8.7.1; issue #435 C4).
+type CoordinatorLoopOptions struct {
+	// Interval is how often the loop re-enqueues the pending head. Non-positive
+	// defaults to 2s.
+	Interval time.Duration
+
+	// StallThreshold is the number of CONSECUTIVE EnqueuePending failures after
+	// which OnStall fires — the loop treats that many back-to-back failures as a
+	// sustained stall (broker read-only / disk full), not a transient blip.
+	// Non-positive defaults to 3.
+	StallThreshold int
+
+	// OnError, if set, is called on every enqueue failure (each tick). It is the
+	// per-failure, best-effort notification hook: the loop NEVER blocks on it, so a
+	// transient failure cannot stall the loop. Cancellation errors are not reported.
+	OnError func(err error)
+
+	// OnStall, if set, is called ONCE when the consecutive-failure count first
+	// reaches StallThreshold, and not again until a later enqueue succeeds (which
+	// resets the counter). It is the durable escalation signal for a sustained
+	// stall — unlike OnError it is expected to guarantee delivery (e.g. a blocking,
+	// context-aware channel send or a structured event), because otherwise
+	// embedding makes no progress while the daemon still looks healthy (issue #435
+	// C4). It receives the consecutive-failure count and the latest error.
+	OnStall func(consecutive int, err error)
+}
+
+func (o CoordinatorLoopOptions) interval() time.Duration {
+	if o.Interval <= 0 {
+		return defaultCoordinatorInterval
+	}
+	return o.Interval
+}
+
+func (o CoordinatorLoopOptions) stallThreshold() int {
+	if o.StallThreshold <= 0 {
+		return defaultStallThreshold
+	}
+	return o.StallThreshold
+}
+
+// RunCoordinator drives coord.EnqueuePending on a fixed interval until ctx is
+// cancelled (SPEC §8.7.1). Re-enqueuing is safe: an already-embedded chunk is no
+// longer pending, and a duplicate job is idempotent at the embed layer (§8.7.3).
+//
+// It owns the stall-detection the bare loop lacked (issue #435 C4): a transient
+// enqueue error is reported via OnError and the loop keeps ticking (a momentary
+// broker hiccup must not tear down embedding), but StallThreshold consecutive
+// failures fire OnStall exactly once so a sustained failure surfaces a durable
+// signal instead of a silently-idle daemon. A single success resets both the
+// counter and the armed OnStall.
+func RunCoordinator(ctx context.Context, coord *Coordinator, opts CoordinatorLoopOptions) {
+	ticker := time.NewTicker(opts.interval())
+	defer ticker.Stop()
+
+	threshold := opts.stallThreshold()
+	consecutive := 0
+	stallSignaled := false
+
+	for {
+		_, err := coord.EnqueuePending(ctx, "")
+		switch {
+		case err == nil:
+			// Progress: forget the failure streak and re-arm stall detection.
+			consecutive = 0
+			stallSignaled = false
+		case errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded):
+			// Shutdown, not a stall — return without signaling.
+			return
+		default:
+			consecutive++
+			if opts.OnError != nil {
+				opts.OnError(err)
+			}
+			if consecutive >= threshold && !stallSignaled {
+				stallSignaled = true
+				if opts.OnStall != nil {
+					opts.OnStall(consecutive, err)
+				}
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}

--- a/internal/embedqueue/coordinator_loop.go
+++ b/internal/embedqueue/coordinator_loop.go
@@ -69,6 +69,15 @@ func (o CoordinatorLoopOptions) stallThreshold() int {
 // signal instead of a silently-idle daemon. A single success resets both the
 // counter and the armed OnStall.
 func RunCoordinator(ctx context.Context, coord *Coordinator, opts CoordinatorLoopOptions) {
+	// Fail fast rather than panicking on coord.EnqueuePending: RunCoordinator is
+	// an exported reusable helper, so a nil coordinator is a caller bug that should
+	// surface as a clear signal, not a dereference panic.
+	if coord == nil {
+		if opts.OnError != nil {
+			opts.OnError(errors.New("RunCoordinator: nil coordinator"))
+		}
+		return
+	}
 	ticker := time.NewTicker(opts.interval())
 	defer ticker.Stop()
 

--- a/internal/embedqueue/coordinator_loop.go
+++ b/internal/embedqueue/coordinator_loop.go
@@ -25,8 +25,10 @@ type CoordinatorLoopOptions struct {
 	StallThreshold int
 
 	// OnError, if set, is called on every enqueue failure (each tick). It is the
-	// per-failure, best-effort notification hook: the loop NEVER blocks on it, so a
-	// transient failure cannot stall the loop. Cancellation errors are not reported.
+	// per-failure, best-effort notification hook. The loop invokes it SYNCHRONOUSLY
+	// on its own goroutine, so the callback MUST be fast/non-blocking (or at most
+	// context-bounded) — a callback that blocks indefinitely stalls the loop and
+	// prevents further re-enqueues. Cancellation errors are not reported.
 	OnError func(err error)
 
 	// OnStall, if set, is called ONCE when the consecutive-failure count first
@@ -35,7 +37,10 @@ type CoordinatorLoopOptions struct {
 	// stall — unlike OnError it is expected to guarantee delivery (e.g. a blocking,
 	// context-aware channel send or a structured event), because otherwise
 	// embedding makes no progress while the daemon still looks healthy (issue #435
-	// C4). It receives the consecutive-failure count and the latest error.
+	// C4). Like OnError it is invoked SYNCHRONOUSLY on the loop's goroutine, so it
+	// too must be fast/non-blocking or at most context-bounded (a context-aware
+	// blocking send is fine — it cannot outlive ctx). It receives the
+	// consecutive-failure count and the latest error.
 	OnStall func(consecutive int, err error)
 }
 

--- a/internal/embedqueue/embedded_guard.go
+++ b/internal/embedqueue/embedded_guard.go
@@ -1,0 +1,60 @@
+package embedqueue
+
+import "sync"
+
+// EmbeddedGuard makes the "count a chunk as embedded_ok" side effect fire at most
+// once per (index_kind, chunk_id), even when a job is redelivered and re-embedded
+// (SPEC §8.7.3; issue #435 C2).
+//
+// The distributed path enqueues at-least-once: a lease expiry or a transient Nack
+// redelivers an already-succeeded chunk, and the worker re-runs the exact
+// in-process embed step. Vector writes are idempotent (keyed by chunk_id), but the
+// step's per-upsert OnIndexedChunk hook fires on EVERY successful upsert, so a
+// naive AddEmbeddedOK(1) in that hook inflates embedded_ok past chunks_total on
+// redelivery. The guard gates the COUNT (not the embed) to the first success.
+//
+// It is safe for concurrent use by the per-axis (text/code) embed hooks. The
+// tracked set is bounded by the number of distinct embedded chunks, matching the
+// corpus size — the same working-set the in-process loop already holds in memory.
+type EmbeddedGuard struct {
+	mu   sync.Mutex
+	seen map[embeddedKey]struct{}
+}
+
+// embeddedKey identifies a single embedded vector axis: a chunk's stable id scoped
+// by its index kind, so the same chunk_id on the "text" and "code" axes is counted
+// independently (SPEC §6.1).
+type embeddedKey struct {
+	kind    string
+	chunkID uint64
+}
+
+// NewEmbeddedGuard returns a ready EmbeddedGuard.
+func NewEmbeddedGuard() *EmbeddedGuard {
+	return &EmbeddedGuard{seen: make(map[embeddedKey]struct{})}
+}
+
+// First reports whether this is the first successful embed observed for
+// (indexKind, chunkID). It returns true exactly once per pair; every later call
+// for the same pair returns false. A caller wires it into the embed-success hook
+// so the embedded_ok counter is incremented only on that first true, making the
+// count idempotent across redelivery/retry (issue #435 C2).
+//
+// A nil guard treats every call as first (true), so callers that never construct
+// one keep the pre-guard behavior instead of panicking.
+func (g *EmbeddedGuard) First(indexKind string, chunkID uint64) bool {
+	if g == nil {
+		return true
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.seen == nil {
+		g.seen = make(map[embeddedKey]struct{})
+	}
+	key := embeddedKey{kind: indexKind, chunkID: chunkID}
+	if _, dup := g.seen[key]; dup {
+		return false
+	}
+	g.seen[key] = struct{}{}
+	return true
+}

--- a/tests/embedqueue/coordinator_lock_unix_test.go
+++ b/tests/embedqueue/coordinator_lock_unix_test.go
@@ -1,0 +1,67 @@
+//go:build unix
+
+package embedqueue_test
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/embedqueue"
+)
+
+// These tests are unix-only: AcquireCoordinatorLock is backed by flock and only
+// enforces mutual exclusion under //go:build unix. On other platforms it is a
+// no-op that always succeeds, so the ErrCoordinatorLocked assertions below would
+// not hold — gate them to the same build tag as the implementation.
+
+// --- C3: single-coordinator lock (issue #435) ---
+
+// TestCoordinatorLock_DetectAndRefuse pins the detect-and-refuse guard: a second
+// acquisition of the same lock path is refused with ErrCoordinatorLocked, and the
+// path becomes acquirable again after the first holder releases.
+func TestCoordinatorLock_DetectAndRefuse(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "embed-coordinator.lock")
+
+	first, err := embedqueue.AcquireCoordinatorLock(path)
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+
+	if _, err := embedqueue.AcquireCoordinatorLock(path); !errors.Is(err, embedqueue.ErrCoordinatorLocked) {
+		t.Fatalf("second acquire while held: err = %v, want ErrCoordinatorLocked", err)
+	}
+
+	if err := first.Release(); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+
+	// After release the lock is free again.
+	second, err := embedqueue.AcquireCoordinatorLock(path)
+	if err != nil {
+		t.Fatalf("acquire after release: %v", err)
+	}
+	if err := second.Release(); err != nil {
+		t.Fatalf("release second: %v", err)
+	}
+}
+
+// TestCoordinatorLock_ReleaseIdempotent pins that Release is safe to call twice and
+// on a nil lock (defensive shutdown paths).
+func TestCoordinatorLock_ReleaseIdempotent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "embed-coordinator.lock")
+	l, err := embedqueue.AcquireCoordinatorLock(path)
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	if err := l.Release(); err != nil {
+		t.Fatalf("first release: %v", err)
+	}
+	if err := l.Release(); err != nil {
+		t.Fatalf("second release should be a no-op: %v", err)
+	}
+	var nilLock *embedqueue.CoordinatorLock
+	if err := nilLock.Release(); err != nil {
+		t.Fatalf("nil release should be a no-op: %v", err)
+	}
+}

--- a/tests/embedqueue/hardening_test.go
+++ b/tests/embedqueue/hardening_test.go
@@ -3,7 +3,6 @@ package embedqueue_test
 import (
 	"context"
 	"errors"
-	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -128,56 +127,9 @@ func TestEmbeddedGuard_ConcurrentFirstOnce(t *testing.T) {
 	}
 }
 
-// --- C3: single-coordinator lock (issue #435) ---
-
-// TestCoordinatorLock_DetectAndRefuse pins the detect-and-refuse guard: a second
-// acquisition of the same lock path is refused with ErrCoordinatorLocked, and the
-// path becomes acquirable again after the first holder releases.
-func TestCoordinatorLock_DetectAndRefuse(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "embed-coordinator.lock")
-
-	first, err := embedqueue.AcquireCoordinatorLock(path)
-	if err != nil {
-		t.Fatalf("first acquire: %v", err)
-	}
-
-	if _, err := embedqueue.AcquireCoordinatorLock(path); !errors.Is(err, embedqueue.ErrCoordinatorLocked) {
-		t.Fatalf("second acquire while held: err = %v, want ErrCoordinatorLocked", err)
-	}
-
-	if err := first.Release(); err != nil {
-		t.Fatalf("release: %v", err)
-	}
-
-	// After release the lock is free again.
-	second, err := embedqueue.AcquireCoordinatorLock(path)
-	if err != nil {
-		t.Fatalf("acquire after release: %v", err)
-	}
-	if err := second.Release(); err != nil {
-		t.Fatalf("release second: %v", err)
-	}
-}
-
-// TestCoordinatorLock_ReleaseIdempotent pins that Release is safe to call twice and
-// on a nil lock (defensive shutdown paths).
-func TestCoordinatorLock_ReleaseIdempotent(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "embed-coordinator.lock")
-	l, err := embedqueue.AcquireCoordinatorLock(path)
-	if err != nil {
-		t.Fatalf("acquire: %v", err)
-	}
-	if err := l.Release(); err != nil {
-		t.Fatalf("first release: %v", err)
-	}
-	if err := l.Release(); err != nil {
-		t.Fatalf("second release should be a no-op: %v", err)
-	}
-	var nilLock *embedqueue.CoordinatorLock
-	if err := nilLock.Release(); err != nil {
-		t.Fatalf("nil release should be a no-op: %v", err)
-	}
-}
+// The C3 single-coordinator-lock tests (TestCoordinatorLock_*) live in
+// coordinator_lock_unix_test.go: AcquireCoordinatorLock only enforces mutual
+// exclusion under //go:build unix, so those assertions are gated to that tag.
 
 // --- C4: enqueue-stall signal (issue #435) ---
 

--- a/tests/embedqueue/hardening_test.go
+++ b/tests/embedqueue/hardening_test.go
@@ -241,3 +241,15 @@ func TestRunCoordinator_StallResetsAfterSuccess(t *testing.T) {
 		t.Fatalf("OnStall fired %d times for a sub-threshold failure burst, want 0", got)
 	}
 }
+
+// TestRunCoordinator_NilCoordinator pins that the exported loop helper fails
+// fast (reports via OnError and returns) instead of panicking on a nil coord.
+func TestRunCoordinator_NilCoordinator(t *testing.T) {
+	var got error
+	embedqueue.RunCoordinator(context.Background(), nil, embedqueue.CoordinatorLoopOptions{
+		OnError: func(err error) { got = err },
+	})
+	if got == nil {
+		t.Fatal("nil coordinator: want OnError to receive an error, got nil")
+	}
+}

--- a/tests/embedqueue/hardening_test.go
+++ b/tests/embedqueue/hardening_test.go
@@ -40,7 +40,11 @@ func TestEmbeddedGuard_First(t *testing.T) {
 // so callers with no guard keep the pre-guard behavior instead of panicking.
 func TestEmbeddedGuard_NilReceiver(t *testing.T) {
 	var g *embedqueue.EmbeddedGuard
-	if !g.First("text", 1) || !g.First("text", 1) {
+	// A nil guard must never dedup: the SAME (kind, id) reported twice both
+	// return first=true (a real guard would return false on the second call).
+	first := g.First("text", 1)
+	again := g.First("text", 1)
+	if !first || !again {
 		t.Fatal("nil guard: every call should report first=true")
 	}
 }

--- a/tests/embedqueue/hardening_test.go
+++ b/tests/embedqueue/hardening_test.go
@@ -1,0 +1,287 @@
+package embedqueue_test
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/embedqueue"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// --- C2: embedded_ok double-count guard (issue #435) ---
+
+// TestEmbeddedGuard_First pins the guard's core contract: it returns true exactly
+// once per (index_kind, chunk_id) and false thereafter, and treats the two axes
+// (text/code) of one chunk_id independently.
+func TestEmbeddedGuard_First(t *testing.T) {
+	g := embedqueue.NewEmbeddedGuard()
+
+	if !g.First("text", 7) {
+		t.Fatal("first embed of (text,7): want true")
+	}
+	if g.First("text", 7) {
+		t.Fatal("redelivered embed of (text,7): want false")
+	}
+	// A different axis for the same chunk id is a distinct vector — counted once.
+	if !g.First("code", 7) {
+		t.Fatal("first embed of (code,7): want true")
+	}
+	if g.First("code", 7) {
+		t.Fatal("redelivered embed of (code,7): want false")
+	}
+}
+
+// TestEmbeddedGuard_NilReceiver pins that a nil guard degrades to "always first",
+// so callers with no guard keep the pre-guard behavior instead of panicking.
+func TestEmbeddedGuard_NilReceiver(t *testing.T) {
+	var g *embedqueue.EmbeddedGuard
+	if !g.First("text", 1) || !g.First("text", 1) {
+		t.Fatal("nil guard: every call should report first=true")
+	}
+}
+
+// TestEmbeddedGuard_RedeliveredJobCountsOnce is the end-to-end C2 assertion: a job
+// that is embedded, has its lease expire (redelivery), and is re-embedded must
+// count embedded_ok exactly ONCE. It drives a real MemBroker through the same
+// lease→embed→expire→re-lease→embed cycle the worker follows, with the count wired
+// through the guard exactly as the CLI wires it into the embed hook.
+func TestEmbeddedGuard_RedeliveredJobCountsOnce(t *testing.T) {
+	ctx := context.Background()
+	broker := embedqueue.NewMemBroker(5)
+
+	// Deterministic clock so we can force lease expiry.
+	now := time.Unix(1000, 0)
+	broker.SetClock(func() time.Time { return now })
+
+	if err := broker.Enqueue(ctx, embedqueue.Job{ChunkID: 42, IndexKind: "text", EmbedIdentity: testIdentity}); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+
+	guard := embedqueue.NewEmbeddedGuard()
+	var embeddedOK int64
+	// countEmbed mirrors the CLI's guarded OnIndexedChunk hook: the vector write is
+	// idempotent (fires every time) but the count is gated to the first success.
+	countEmbed := func(kind string, chunkID uint64) {
+		if guard.First(kind, chunkID) {
+			atomic.AddInt64(&embeddedOK, 1)
+		}
+	}
+
+	// First delivery: lease, embed (count once), then DO NOT ack — let it expire.
+	lease1, err := broker.Lease(ctx, time.Second)
+	if err != nil {
+		t.Fatalf("Lease 1: %v", err)
+	}
+	countEmbed(lease1.Job.IndexKind, lease1.Job.ChunkID)
+
+	// Advance past the lease deadline so the job is reclaimed and redelivered.
+	now = now.Add(2 * time.Second)
+
+	lease2, err := broker.Lease(ctx, time.Second)
+	if err != nil {
+		t.Fatalf("Lease 2 (redelivery): %v", err)
+	}
+	if lease2.Job.ChunkID != 42 {
+		t.Fatalf("redelivered chunk = %d, want 42", lease2.Job.ChunkID)
+	}
+	// Re-embed the redelivered job: the vector write would repeat, but the guarded
+	// count must NOT.
+	countEmbed(lease2.Job.IndexKind, lease2.Job.ChunkID)
+	if err := broker.Ack(ctx, lease2.Token); err != nil {
+		t.Fatalf("Ack: %v", err)
+	}
+
+	if got := atomic.LoadInt64(&embeddedOK); got != 1 {
+		t.Fatalf("embedded_ok = %d after redelivery, want 1 (C2 double-count)", got)
+	}
+}
+
+// TestEmbeddedGuard_ConcurrentFirstOnce pins that under concurrent hits for the
+// same pair the guard hands out exactly one true — the race-free property the
+// double-count fix relies on. Run with -race.
+func TestEmbeddedGuard_ConcurrentFirstOnce(t *testing.T) {
+	g := embedqueue.NewEmbeddedGuard()
+	const goroutines = 64
+	var trues int64
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			if g.First("text", 99) {
+				atomic.AddInt64(&trues, 1)
+			}
+		}()
+	}
+	wg.Wait()
+	if trues != 1 {
+		t.Fatalf("concurrent First returned true %d times, want exactly 1", trues)
+	}
+}
+
+// --- C3: single-coordinator lock (issue #435) ---
+
+// TestCoordinatorLock_DetectAndRefuse pins the detect-and-refuse guard: a second
+// acquisition of the same lock path is refused with ErrCoordinatorLocked, and the
+// path becomes acquirable again after the first holder releases.
+func TestCoordinatorLock_DetectAndRefuse(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "embed-coordinator.lock")
+
+	first, err := embedqueue.AcquireCoordinatorLock(path)
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+
+	if _, err := embedqueue.AcquireCoordinatorLock(path); !errors.Is(err, embedqueue.ErrCoordinatorLocked) {
+		t.Fatalf("second acquire while held: err = %v, want ErrCoordinatorLocked", err)
+	}
+
+	if err := first.Release(); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+
+	// After release the lock is free again.
+	second, err := embedqueue.AcquireCoordinatorLock(path)
+	if err != nil {
+		t.Fatalf("acquire after release: %v", err)
+	}
+	if err := second.Release(); err != nil {
+		t.Fatalf("release second: %v", err)
+	}
+}
+
+// TestCoordinatorLock_ReleaseIdempotent pins that Release is safe to call twice and
+// on a nil lock (defensive shutdown paths).
+func TestCoordinatorLock_ReleaseIdempotent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "embed-coordinator.lock")
+	l, err := embedqueue.AcquireCoordinatorLock(path)
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	if err := l.Release(); err != nil {
+		t.Fatalf("first release: %v", err)
+	}
+	if err := l.Release(); err != nil {
+		t.Fatalf("second release should be a no-op: %v", err)
+	}
+	var nilLock *embedqueue.CoordinatorLock
+	if err := nilLock.Release(); err != nil {
+		t.Fatalf("nil release should be a no-op: %v", err)
+	}
+}
+
+// --- C4: enqueue-stall signal (issue #435) ---
+
+// stallingSource fails NextPending every call, modeling a broker/store that is
+// persistently unreadable (read-only DB / disk full).
+type stallingSource struct{ calls int64 }
+
+func (s *stallingSource) NextPending(_ context.Context, _ int, _ string) ([]model.ChunkTask, error) {
+	atomic.AddInt64(&s.calls, 1)
+	return nil, errors.New("simulated persistent enqueue failure")
+}
+
+// TestRunCoordinator_StallSignal pins C4: a sustained enqueue failure fires OnStall
+// exactly once after StallThreshold consecutive failures, while OnError fires on
+// every failing tick — so a stalled coordinator surfaces a durable signal instead
+// of silently making no progress.
+func TestRunCoordinator_StallSignal(t *testing.T) {
+	coord := &embedqueue.Coordinator{
+		Source:        &stallingSource{},
+		Broker:        embedqueue.NewMemBroker(5),
+		EmbedIdentity: testIdentity,
+	}
+
+	var errorCalls, stallCalls int64
+	stalled := make(chan int, 1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		embedqueue.RunCoordinator(ctx, coord, embedqueue.CoordinatorLoopOptions{
+			Interval:       time.Millisecond,
+			StallThreshold: 3,
+			OnError:        func(error) { atomic.AddInt64(&errorCalls, 1) },
+			OnStall: func(consecutive int, _ error) {
+				atomic.AddInt64(&stallCalls, 1)
+				select {
+				case stalled <- consecutive:
+				default:
+				}
+			},
+		})
+		close(done)
+	}()
+
+	select {
+	case consecutive := <-stalled:
+		if consecutive < 3 {
+			t.Fatalf("OnStall consecutive = %d, want >= 3 (StallThreshold)", consecutive)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("OnStall never fired on a sustained enqueue failure")
+	}
+
+	// Let the loop tick a while longer to prove OnStall is not re-fired every tick.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	if got := atomic.LoadInt64(&stallCalls); got != 1 {
+		t.Fatalf("OnStall fired %d times, want exactly 1 until a success resets it", got)
+	}
+	if got := atomic.LoadInt64(&errorCalls); got < 3 {
+		t.Fatalf("OnError fired %d times, want >= 3 (once per failing tick)", got)
+	}
+}
+
+// recoveringSource fails until failUntil calls, then succeeds — modeling a stall
+// that clears. Once it succeeds it keeps returning empty (nothing pending).
+type recoveringSource struct {
+	mu        sync.Mutex
+	calls     int
+	failUntil int
+}
+
+func (s *recoveringSource) NextPending(_ context.Context, _ int, _ string) ([]model.ChunkTask, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls++
+	if s.calls <= s.failUntil {
+		return nil, errors.New("transient enqueue failure")
+	}
+	return nil, nil
+}
+
+// TestRunCoordinator_StallResetsAfterSuccess pins that a success re-arms stall
+// detection: if failures resume after a recovery the signal can fire again, so a
+// second sustained stall is not swallowed.
+func TestRunCoordinator_StallResetsAfterSuccess(t *testing.T) {
+	// Fewer failures than the threshold, then success: OnStall must NOT fire.
+	coord := &embedqueue.Coordinator{
+		Source:        &recoveringSource{failUntil: 2},
+		Broker:        embedqueue.NewMemBroker(5),
+		EmbedIdentity: testIdentity,
+	}
+
+	var stallCalls int64
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	embedqueue.RunCoordinator(ctx, coord, embedqueue.CoordinatorLoopOptions{
+		Interval:       time.Millisecond,
+		StallThreshold: 3,
+		OnStall:        func(int, error) { atomic.AddInt64(&stallCalls, 1) },
+	})
+
+	if got := atomic.LoadInt64(&stallCalls); got != 0 {
+		t.Fatalf("OnStall fired %d times for a sub-threshold failure burst, want 0", got)
+	}
+}


### PR DESCRIPTION
Closes #486 — the C2–C4 follow-up carved out of #435 (C1 batching already landed in #477). Scoped to `internal/embedqueue/` + `tests/embedqueue/`, with minimal wiring in `internal/cli/up_distributed_embed.go` (and its caller `embed_worker.go`). `internal/cli/up.go` is untouched.

## C2 — `embedded_ok` double-counts on redelivery
The distributed embed path is at-least-once: a lease expiry / transient Nack redelivers an already-succeeded chunk, and the worker re-runs the exact in-process embed step. Vector writes are idempotent (keyed by `chunk_id`), but the per-upsert `OnIndexedChunk` hook fires on **every** successful upsert, so `AddEmbeddedOK(1)` inflated `embedded_ok` past `chunks_total` on redelivery.

- New `EmbeddedGuard` (race-free first-seen set keyed by `(index_kind, chunk_id)`).
- The CLI embed hook now gates the **count** (not the embed) to a chunk's first success: metadata refresh still runs every time (idempotent), `AddEmbeddedOK(1)` runs once.

## C3 — no single-coordinator guard (default in-process broker double-embeds)
The default broker is in-process `MemBroker`, so two daemons on one corpus each get a **private** queue and cannot coordinate through the broker — both enqueue + double-embed.

- New `AcquireCoordinatorLock` — an OS advisory (`flock`) lock on a state-dir lock file (`embed-coordinator.lock`), `_unix` + `_other` build-tagged like the repo's existing daemon lock files.
- A second coordinator is refused with `ErrCoordinatorLocked`; the lock releases on shutdown and if the holder process dies.
- **Scope:** detect-and-refuse only (the minimal correct option). Full multi-node leader election is deferred to the standalone-worker deployment (#249) and noted in code.

## C4 — persistent enqueue failure stalled silently
The old loop logged to a logger discarded in JSON/daemon mode and did a best-effort `errCh` send (dropped when the channel is momentarily full), so a sustained failure made no progress while the daemon looked healthy.

- New `RunCoordinator` owns the ticker + consecutive-failure tracking. Transient errors stay best-effort via `OnError`; `StallThreshold` consecutive failures fire `OnStall` **once** (re-armed by any success).
- The CLI wires `OnStall` to a **durable, context-aware blocking** `errCh` send, so a sustained stall reliably surfaces as an `embed_error` NDJSON event.

## Tests (`tests/embedqueue/hardening_test.go`)
- Guard: first-once semantics, nil receiver, **redelivered job counts `embedded_ok` once** (drives a real `MemBroker` lease→embed→expire→re-lease→embed cycle), concurrent first-once (race).
- Lock: detect-and-refuse + re-acquire after release; idempotent/nil `Release`.
- Stall: `OnStall` fires once after threshold while `OnError` fires per tick; sub-threshold burst does not signal.

## Validation
`gofmt -l` clean · `go build ./...` · `go vet` · `make cyclo` (0 over 15) · `golangci-lint run ./internal/embedqueue/... ./internal/cli/...` (0 issues) · `go test` + `go test -race ./internal/embedqueue/... ./tests/embedqueue/...` all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safer embedding coordination so only one coordinator starts for a corpus at a time.
  * Improved worker behavior to better surface when embedding processing stalls instead of idling silently.

* **Bug Fixes**
  * Prevented duplicate “embedded” counts during retries or redeliveries.
  * Made lock release and startup failure handling more reliable.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->