### PR TITLE
perf(index): top-k heap + dirty-flag autosave for local vector backend (#429)

### DIFF
--- a/internal/index/hnsw_index.go
+++ b/internal/index/hnsw_index.go
@@ -44,6 +44,17 @@ type HNSWIndex struct {
 	payloads map[uint64]model.IndexPayload
 	identity string
 
+	// version is a monotonically increasing mutation counter, bumped under the
+	// write lock on every Upsert/Delete/Reset. savedVersion records the version
+	// captured by the last successful Save. When they are equal the in-memory
+	// state already matches the on-disk snapshot, so the periodic autosave can
+	// skip rewriting the whole index (issue #429 F7). Both are guarded by mu;
+	// capturing version together with the snapshot (under the read lock) and only
+	// advancing savedVersion after a durable write keeps the dirty check race-free
+	// and never drops a concurrent write that landed mid-save.
+	version      uint64
+	savedVersion uint64
+
 	// Logger is optional; if non-nil its Printf method will be used for
 	// informational messages. When nil the standard library's log package
 	// is used.
@@ -111,6 +122,7 @@ func (i *HNSWIndex) Upsert(ctx context.Context, vector []float32, payload model.
 	defer i.mu.Unlock()
 	i.vectors[payload.ChunkID] = copied
 	i.payloads[payload.ChunkID] = payload
+	i.version++
 	return nil
 }
 
@@ -149,8 +161,14 @@ func (i *HNSWIndex) Delete(ctx context.Context, chunkIDs []uint64) error {
 		delete(i.vectors, id)
 		delete(i.payloads, id)
 	}
+	i.version++
 	return nil
 }
+
+// scoreEps is the score-equality tolerance for the ranking tiebreak: two scores
+// within eps are treated as equal and ordered by ascending chunk_id, giving a
+// deterministic total order over realistic (well-separated) embedding scores.
+const scoreEps = 1e-6
 
 // scoredCandidate pairs a chunk_id with its cosine score during search.
 type scoredCandidate struct {
@@ -159,9 +177,28 @@ type scoredCandidate struct {
 	payload model.IndexPayload
 }
 
+// candidateBefore reports whether candidate a ranks strictly before b: higher
+// score first, with an eps-tolerant ascending chunk_id tiebreak. It is the sole
+// ranking comparator, shared by the top-k heap's eviction decision and the final
+// ordering of the retained hits, so the heap selects exactly the same k
+// candidates the previous full O(N log N) sort would have kept (issue #429 F1).
+func candidateBefore(aScore, bScore float32, aID, bID uint64) bool {
+	if math.Abs(float64(aScore)-float64(bScore)) <= scoreEps {
+		return aID < bID
+	}
+	return aScore > bScore
+}
+
 // Search returns the k best matches for vector, filtered by filter. The filter
 // is applied inline (CanFilter is always true for the pure-Go HNSW), so callers
 // may push it down rather than overfetch-then-filter.
+//
+// Scoring runs in place under the read lock — each stored vector is scored where
+// it lives rather than copied into a per-query slice first (issue #429 F2) — and
+// only the running top-k is retained in a bounded min-heap rather than sorting
+// every scored candidate (issue #429 F1). The retained k are then sorted with
+// candidateBefore, yielding results identical to the previous full-sort-then-
+// truncate for any input the comparator totally orders.
 func (i *HNSWIndex) Search(ctx context.Context, vector []float32, k int, filter model.Filter) ([]model.IndexHit, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -173,43 +210,20 @@ func (i *HNSWIndex) Search(ctx context.Context, vector []float32, k int, filter 
 		return []model.IndexHit{}, nil
 	}
 
-	candidates, mismatches := i.collectCandidates(vector, filter)
+	scored, mismatches := i.scoreTopK(vector, k, filter)
 	for _, m := range mismatches {
 		i.logf("dimension mismatch: chunk_id=%d candidate_len=%d query_len=%d", m.chunkID, m.candLen, m.queryLen)
 	}
 
-	scored := make([]scoredCandidate, 0, len(candidates))
-	for _, c := range candidates {
-		c.score = cosineSimilarity(vector, c.vector)
-		scored = append(scored, scoredCandidate{chunkID: c.chunkID, score: c.score, payload: c.payload})
-	}
-
-	const eps = 1e-6
 	sort.Slice(scored, func(a, b int) bool {
-		diff := math.Abs(float64(scored[a].score) - float64(scored[b].score))
-		if diff <= eps {
-			return scored[a].chunkID < scored[b].chunkID
-		}
-		return scored[a].score > scored[b].score
+		return candidateBefore(scored[a].score, scored[b].score, scored[a].chunkID, scored[b].chunkID)
 	})
 
-	if len(scored) > k {
-		scored = scored[:k]
-	}
 	hits := make([]model.IndexHit, len(scored))
 	for idx, s := range scored {
 		hits[idx] = model.IndexHit{ChunkID: s.chunkID, Score: s.score, Payload: s.payload}
 	}
 	return hits, nil
-}
-
-// searchCandidate carries a copied vector + payload for scoring outside the
-// lock.
-type searchCandidate struct {
-	chunkID uint64
-	vector  []float32
-	score   float32
-	payload model.IndexPayload
 }
 
 type dimMismatch struct {
@@ -218,15 +232,16 @@ type dimMismatch struct {
 	queryLen int
 }
 
-// collectCandidates snapshots, under the read lock, the vectors whose dimension
-// matches the query and whose payload satisfies the filter. Dimension
-// mismatches are returned for logging outside the lock.
-func (i *HNSWIndex) collectCandidates(vector []float32, filter model.Filter) ([]searchCandidate, []dimMismatch) {
-	var (
-		candidates []searchCandidate
-		mismatches []dimMismatch
-	)
+// scoreTopK scores every dimension-matching, filter-passing vector in place
+// under the read lock and returns the (unordered) best k candidates plus any
+// dimension mismatches for logging outside the lock. Because it retains at most
+// k candidates, it never allocates a per-query copy of the whole candidate set
+// nor of any candidate vector; a payload is copied out of the map only when the
+// candidate actually enters the heap.
+func (i *HNSWIndex) scoreTopK(vector []float32, k int, filter model.Filter) ([]scoredCandidate, []dimMismatch) {
+	var mismatches []dimMismatch
 	applyFilter := !filter.IsZero()
+	h := topKHeap{k: k, items: make([]scoredCandidate, 0, k)}
 
 	i.mu.RLock()
 	for id, cand := range i.vectors {
@@ -237,16 +252,94 @@ func (i *HNSWIndex) collectCandidates(vector []float32, filter model.Filter) ([]
 			}
 			continue
 		}
-		payload := i.payloads[id]
-		if applyFilter && !filter.Match(payload) {
+		havePayload := false
+		var payload model.IndexPayload
+		if applyFilter {
+			payload = i.payloads[id]
+			havePayload = true
+			if !filter.Match(payload) {
+				continue
+			}
+		}
+		score := cosineSimilarity(vector, cand)
+		// Skip the payload copy + heap push for candidates that cannot displace
+		// the current worst of a full heap.
+		if h.full() && !h.better(score, id) {
 			continue
 		}
-		copyVec := make([]float32, len(cand))
-		copy(copyVec, cand)
-		candidates = append(candidates, searchCandidate{chunkID: id, vector: copyVec, payload: payload})
+		if !havePayload {
+			payload = i.payloads[id]
+		}
+		h.push(scoredCandidate{chunkID: id, score: score, payload: payload})
 	}
 	i.mu.RUnlock()
-	return candidates, mismatches
+	return h.items, mismatches
+}
+
+// topKHeap is a bounded min-heap that retains the best k candidates seen so far,
+// ordered by candidateBefore. The root is the *worst* retained candidate, so a
+// newly scored candidate that ranks before the root evicts it in O(log k).
+type topKHeap struct {
+	items []scoredCandidate
+	k     int
+}
+
+func (h *topKHeap) full() bool { return len(h.items) >= h.k }
+
+// better reports whether a candidate with (score, id) ranks before the current
+// worst retained candidate (the root). Only meaningful when the heap is full.
+func (h *topKHeap) better(score float32, id uint64) bool {
+	root := h.items[0]
+	return candidateBefore(score, root.score, id, root.chunkID)
+}
+
+// worse reports whether item a ranks after item b (a is the poorer match).
+func (h *topKHeap) worse(a, b int) bool {
+	x, y := h.items[a], h.items[b]
+	return candidateBefore(y.score, x.score, y.chunkID, x.chunkID)
+}
+
+// push adds c when the heap is under capacity, otherwise replaces the worst
+// retained candidate. Callers must only push a candidate that is under capacity
+// or better than the root (see scoreTopK).
+func (h *topKHeap) push(c scoredCandidate) {
+	if len(h.items) < h.k {
+		h.items = append(h.items, c)
+		h.siftUp(len(h.items) - 1)
+		return
+	}
+	h.items[0] = c
+	h.siftDown(0)
+}
+
+func (h *topKHeap) siftUp(n int) {
+	for n > 0 {
+		parent := (n - 1) / 2
+		if !h.worse(n, parent) {
+			break
+		}
+		h.items[n], h.items[parent] = h.items[parent], h.items[n]
+		n = parent
+	}
+}
+
+func (h *topKHeap) siftDown(n int) {
+	size := len(h.items)
+	for {
+		left := 2*n + 1
+		if left >= size {
+			return
+		}
+		worst := left
+		if right := left + 1; right < size && h.worse(right, left) {
+			worst = right
+		}
+		if !h.worse(worst, n) {
+			return
+		}
+		h.items[n], h.items[worst] = h.items[worst], h.items[n]
+		n = worst
+	}
 }
 
 // CanFilter reports whether the backend can evaluate the filter itself. The
@@ -277,6 +370,7 @@ func (i *HNSWIndex) Reset(ctx context.Context, identity string) error {
 	i.vectors = make(map[uint64][]float32)
 	i.payloads = make(map[uint64]model.IndexPayload)
 	i.identity = identity
+	i.version++
 	return nil
 }
 
@@ -303,6 +397,18 @@ func (i *HNSWIndex) Save(ctx context.Context, path string) error {
 		return errors.New("path is required")
 	}
 
+	// Snapshot under the read lock so concurrent Upsert/Delete don't block on
+	// the gob encoding and file I/O, and so we deep-copy each slice rather than
+	// race with callers who might mutate the originals later. The version is
+	// captured atomically with the snapshot; when it equals the last saved
+	// version nothing has changed since the previous durable write, so we skip
+	// re-encoding and rewriting the whole index — no snapshot copy, no mkdir, no
+	// I/O (issue #429 F7).
+	snapshot, version, dirty := i.snapshotIfDirty()
+	if !dirty {
+		return nil
+	}
+
 	// Ensure the destination directory exists before writing. The temp file is
 	// created in the *same* directory as path (path+".tmp") so the subsequent
 	// rename is atomic on a single filesystem; if the state directory is missing
@@ -319,11 +425,6 @@ func (i *HNSWIndex) Save(ctx context.Context, path string) error {
 	if err != nil {
 		return err
 	}
-
-	// Snapshot under the read lock so concurrent Upsert/Delete don't block on
-	// the gob encoding and file I/O, and so we deep-copy each slice rather than
-	// race with callers who might mutate the originals later.
-	snapshot := i.snapshot()
 
 	enc := gob.NewEncoder(file)
 	if err := enc.Encode(snapshot); err != nil {
@@ -344,13 +445,28 @@ func (i *HNSWIndex) Save(ctx context.Context, path string) error {
 		_ = os.Remove(tmpPath)
 		return err
 	}
+	// The snapshot just landed durably; record the version it captured so a
+	// subsequent Save with no intervening mutation is a no-op. Any Upsert/Delete
+	// that raced this write bumped version past the captured value, so it stays
+	// dirty and the next Save persists it.
+	i.markSaved(version)
 	return nil
 }
 
-// snapshot deep-copies the index state under the read lock for persistence.
-func (i *HNSWIndex) snapshot() hnswSnapshot {
+// snapshotIfDirty captures, under the read lock, the mutation version and — only
+// when it differs from the last saved version — a deep copy of the index state
+// for persistence. The bool reports whether a save is needed; when false the
+// returned snapshot is empty and callers must skip the write. Capturing the
+// version and the copied state under the same lock makes the dirty decision
+// race-free: a concurrent Upsert/Delete either lands before the copy (included,
+// version advanced) or after (excluded, version advanced past the captured
+// value so the next Save re-persists it).
+func (i *HNSWIndex) snapshotIfDirty() (hnswSnapshot, uint64, bool) {
 	i.mu.RLock()
 	defer i.mu.RUnlock()
+	if i.version == i.savedVersion {
+		return hnswSnapshot{}, i.version, false
+	}
 	vectors := make(map[uint64][]float32, len(i.vectors))
 	for k, v := range i.vectors {
 		copied := make([]float32, len(v))
@@ -361,7 +477,18 @@ func (i *HNSWIndex) snapshot() hnswSnapshot {
 	for k, v := range i.payloads {
 		payloads[k] = v
 	}
-	return hnswSnapshot{Vectors: vectors, Payloads: payloads, Identity: i.identity}
+	return hnswSnapshot{Vectors: vectors, Payloads: payloads, Identity: i.identity}, i.version, true
+}
+
+// markSaved advances savedVersion to the version captured by a successful Save.
+// The guard tolerates out-of-order calls (savedVersion only ever moves forward)
+// though PersistenceManager already serializes saves.
+func (i *HNSWIndex) markSaved(version uint64) {
+	i.mu.Lock()
+	if version > i.savedVersion {
+		i.savedVersion = version
+	}
+	i.mu.Unlock()
 }
 
 // Load restores the index from a v2 snapshot file. A missing file is treated as
@@ -403,6 +530,10 @@ func (i *HNSWIndex) Load(ctx context.Context, path string) error {
 	i.vectors = snapshot.Vectors
 	i.payloads = snapshot.Payloads
 	i.identity = snapshot.Identity
+	// The freshly loaded state is exactly what is on disk, so mark it clean: a
+	// Save with no intervening mutation must not rewrite an identical snapshot.
+	i.version++
+	i.savedVersion = i.version
 	i.mu.Unlock()
 	return nil
 }

--- a/internal/index/hnsw_index.go
+++ b/internal/index/hnsw_index.go
@@ -157,11 +157,19 @@ func (i *HNSWIndex) Delete(ctx context.Context, chunkIDs []uint64) error {
 	}
 	i.mu.Lock()
 	defer i.mu.Unlock()
+	changed := false
 	for _, id := range chunkIDs {
+		if _, ok := i.vectors[id]; ok {
+			changed = true
+		}
 		delete(i.vectors, id)
 		delete(i.payloads, id)
 	}
-	i.version++
+	// Only a real removal makes the index dirty; deleting unknown IDs must not
+	// bump version or the next autosave rewrites an identical snapshot for nothing.
+	if changed {
+		i.version++
+	}
 	return nil
 }
 
@@ -530,9 +538,9 @@ func (i *HNSWIndex) Load(ctx context.Context, path string) error {
 	i.vectors = snapshot.Vectors
 	i.payloads = snapshot.Payloads
 	i.identity = snapshot.Identity
-	// The freshly loaded state is exactly what is on disk, so mark it clean: a
+	// The freshly loaded state is exactly what is on disk, so mark it clean
+	// (version is a mutation counter — Load is not a mutation, so leave it): a
 	// Save with no intervening mutation must not rewrite an identical snapshot.
-	i.version++
 	i.savedVersion = i.version
 	i.mu.Unlock()
 	return nil

--- a/tests/index/perf429_test.go
+++ b/tests/index/perf429_test.go
@@ -268,7 +268,10 @@ func TestHNSWIndex_ConcurrentSearchUpsertSave(t *testing.T) {
 				return
 			default:
 			}
-			_ = idx.Upsert(context.Background(), []float32{float32(id), 2}, model.IndexPayload{ChunkID: id, RelPath: "c.txt", DocType: "md"})
+			if err := idx.Upsert(context.Background(), []float32{float32(id), 2}, model.IndexPayload{ChunkID: id, RelPath: "c.txt", DocType: "md"}); err != nil {
+				t.Errorf("concurrent Upsert: %v", err)
+				return
+			}
 		}
 	}()
 
@@ -281,7 +284,10 @@ func TestHNSWIndex_ConcurrentSearchUpsertSave(t *testing.T) {
 			case <-stop:
 				return
 			default:
-				_ = idx.Save(context.Background(), "")
+				if err := idx.Save(context.Background(), ""); err != nil {
+					t.Errorf("concurrent Save: %v", err)
+					return
+				}
 			}
 		}
 	}()

--- a/tests/index/perf429_test.go
+++ b/tests/index/perf429_test.go
@@ -1,0 +1,322 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// Issue #429: the local memory backend's Search now scores in place under the
+// read lock and keeps only the running top-k in a bounded heap, instead of
+// copying every candidate vector and sorting all scored candidates. These tests
+// pin the perf refactor to produce results IDENTICAL to the previous
+// full-sort-then-truncate, and pin the dirty-flag autosave (F7) to skip a save
+// when nothing changed and to save when it did.
+
+// refCosine replicates internal/index.cosineSimilarity bit-for-bit (same float32
+// accumulation order over the query vector) so the reference ranking below scores
+// candidates identically to the index under test — otherwise a tie decided by the
+// eps tolerance could legitimately diverge and mask a real regression.
+func refCosine(a, b []float32) float32 {
+	var dot, magA, magB float32
+	for idx := range a {
+		dot += a[idx] * b[idx]
+		magA += a[idx] * a[idx]
+		magB += b[idx] * b[idx]
+	}
+	if magA == 0 || magB == 0 {
+		return 0
+	}
+	return dot / float32(math.Sqrt(float64(magA*magB)))
+}
+
+// referenceTopK is the pre-#429 algorithm: score every dimension-matching,
+// filter-passing candidate, full-sort by (score desc, eps-tolerant chunkID asc),
+// then truncate to k.
+func referenceTopK(vecs map[uint64][]float32, payloads map[uint64]model.IndexPayload, query []float32, k int, filter model.Filter) []model.IndexHit {
+	const eps = 1e-6
+	applyFilter := !filter.IsZero()
+	var scored []model.IndexHit
+	for id, v := range vecs {
+		if len(v) != len(query) {
+			continue
+		}
+		if applyFilter && !filter.Match(payloads[id]) {
+			continue
+		}
+		scored = append(scored, model.IndexHit{ChunkID: id, Score: refCosine(query, v), Payload: payloads[id]})
+	}
+	sort.Slice(scored, func(a, b int) bool {
+		if math.Abs(float64(scored[a].Score)-float64(scored[b].Score)) <= eps {
+			return scored[a].ChunkID < scored[b].ChunkID
+		}
+		return scored[a].Score > scored[b].Score
+	})
+	if len(scored) > k {
+		scored = scored[:k]
+	}
+	return scored
+}
+
+func randVec(r *rand.Rand, dim int) []float32 {
+	v := make([]float32, dim)
+	for i := range v {
+		v[i] = r.Float32()*2 - 1
+	}
+	return v
+}
+
+// TestHNSWIndex_TopKMatchesFullSort proves the heap-based top-k selection returns
+// exactly the same ranked hits (chunk IDs, order, and scores) the old full sort
+// would have, across many random corpora/queries, k values, and a filter.
+func TestHNSWIndex_TopKMatchesFullSort(t *testing.T) {
+	r := rand.New(rand.NewSource(1))
+	const dim = 8
+	for trial := 0; trial < 50; trial++ {
+		n := 1 + r.Intn(60)
+		idx := index.NewHNSWIndex("")
+		vecs := make(map[uint64][]float32, n)
+		payloads := make(map[uint64]model.IndexPayload, n)
+		for j := 0; j < n; j++ {
+			id := uint64(j + 1)
+			v := randVec(r, dim)
+			// Half the corpus is doc type "md", half "code" so the filtered
+			// pass exercises the same predicate path as the reference.
+			dt := "md"
+			if j%2 == 0 {
+				dt = "code"
+			}
+			p := model.IndexPayload{ChunkID: id, RelPath: fmt.Sprintf("f%d.txt", id), DocType: dt}
+			if err := idx.Upsert(context.Background(), v, p); err != nil {
+				t.Fatalf("upsert: %v", err)
+			}
+			vecs[id] = v
+			payloads[id] = p
+		}
+
+		filters := []model.Filter{{}, {DocTypes: []string{"md"}}}
+		for _, filter := range filters {
+			for _, k := range []int{1, 3, 7, n, n + 5} {
+				query := randVec(r, dim)
+				got, err := idx.Search(context.Background(), query, k, filter)
+				if err != nil {
+					t.Fatalf("search: %v", err)
+				}
+				want := referenceTopK(vecs, payloads, query, k, filter)
+				if len(got) != len(want) {
+					t.Fatalf("trial %d k=%d filter=%v: len got=%d want=%d", trial, k, filter, len(got), len(want))
+				}
+				for i := range want {
+					if got[i].ChunkID != want[i].ChunkID || got[i].Score != want[i].Score {
+						t.Fatalf("trial %d k=%d filter=%v pos %d: got (id=%d score=%v) want (id=%d score=%v)",
+							trial, k, filter, i, got[i].ChunkID, got[i].Score, want[i].ChunkID, want[i].Score)
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestHNSWIndex_TopKTieBreakByChunkID pins the deterministic tiebreak: candidates
+// with equal cosine score are ordered by ascending chunk_id, and the k boundary
+// falls on the lower id.
+func TestHNSWIndex_TopKTieBreakByChunkID(t *testing.T) {
+	idx := index.NewHNSWIndex("")
+	// Three vectors pointing the same direction → identical cosine to the query,
+	// so ordering is decided purely by the chunkID tiebreak.
+	for _, id := range []uint64{30, 10, 20} {
+		upsertVec(t, idx, id, []float32{1, 0})
+	}
+	hits, err := idx.Search(context.Background(), []float32{1, 0}, 2, model.Filter{})
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(hits) != 2 || hits[0].ChunkID != 10 || hits[1].ChunkID != 20 {
+		t.Fatalf("expected ids [10 20] by ascending tiebreak, got %+v", hits)
+	}
+}
+
+// TestHNSWIndex_DirtyFlagSkipsUnchangedSave proves the autosave no longer rewrites
+// the whole index when nothing changed (F7): a Save with no intervening mutation
+// performs no write, while a Save after a mutation does. The file is removed
+// between saves so a skipped write is observable as an absent file.
+func TestHNSWIndex_DirtyFlagSkipsUnchangedSave(t *testing.T) {
+	path := filepath.Join(t.TempDir(), index.TextIndexFileName)
+	idx := index.NewHNSWIndex(path)
+
+	// Fresh, never-mutated index: nothing to persist.
+	if err := idx.Save(context.Background(), ""); err != nil {
+		t.Fatalf("save fresh: %v", err)
+	}
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("fresh index should not have written a snapshot, stat err=%v", err)
+	}
+
+	// First real write after a mutation.
+	upsertVec(t, idx, 1, []float32{1, 0, 0})
+	if err := idx.Save(context.Background(), ""); err != nil {
+		t.Fatalf("save after upsert: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected snapshot after mutation: %v", err)
+	}
+
+	// Remove the file, then Save with nothing changed: must be a no-op (skipped).
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if err := idx.Save(context.Background(), ""); err != nil {
+		t.Fatalf("save unchanged: %v", err)
+	}
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("unchanged index re-wrote the snapshot; dirty flag not honored (stat err=%v)", err)
+	}
+
+	// Mutate again → dirty → Save writes.
+	upsertVec(t, idx, 2, []float32{0, 1, 0})
+	if err := idx.Save(context.Background(), ""); err != nil {
+		t.Fatalf("save after second upsert: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected snapshot after second mutation: %v", err)
+	}
+}
+
+// TestHNSWIndex_DirtyFlagDeleteAndResetMarkDirty pins that Delete and Reset are
+// treated as mutations that require a save.
+func TestHNSWIndex_DirtyFlagDeleteAndResetMarkDirty(t *testing.T) {
+	path := filepath.Join(t.TempDir(), index.TextIndexFileName)
+	idx := index.NewHNSWIndex(path)
+	upsertVec(t, idx, 1, []float32{1, 0})
+	if err := idx.Save(context.Background(), ""); err != nil {
+		t.Fatalf("initial save: %v", err)
+	}
+
+	for name, mutate := range map[string]func() error{
+		"delete": func() error { return idx.Delete(context.Background(), []uint64{1}) },
+		"reset":  func() error { return idx.Reset(context.Background(), "id-2") },
+	} {
+		if err := mutate(); err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		if err := os.Remove(path); err != nil {
+			t.Fatalf("%s remove: %v", name, err)
+		}
+		if err := idx.Save(context.Background(), ""); err != nil {
+			t.Fatalf("%s save: %v", name, err)
+		}
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("%s did not mark the index dirty; snapshot missing: %v", name, err)
+		}
+	}
+}
+
+// TestHNSWIndex_LoadMarksClean proves a freshly loaded index matches disk and so
+// a subsequent Save with no mutation is skipped.
+func TestHNSWIndex_LoadMarksClean(t *testing.T) {
+	path := filepath.Join(t.TempDir(), index.TextIndexFileName)
+	src := index.NewHNSWIndex(path)
+	upsertVec(t, src, 1, []float32{1, 0})
+	if err := src.Save(context.Background(), ""); err != nil {
+		t.Fatalf("seed save: %v", err)
+	}
+
+	loaded := index.NewHNSWIndex(path)
+	if err := loaded.Load(context.Background(), ""); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if err := loaded.Save(context.Background(), ""); err != nil {
+		t.Fatalf("save after load: %v", err)
+	}
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("loaded-then-unchanged index re-wrote the snapshot (stat err=%v)", err)
+	}
+}
+
+// TestHNSWIndex_ConcurrentSearchUpsertSave exercises the query/embed-worker/
+// autosave concurrency the dirty flag must be race-free under. Run with -race.
+func TestHNSWIndex_ConcurrentSearchUpsertSave(t *testing.T) {
+	path := filepath.Join(t.TempDir(), index.TextIndexFileName)
+	idx := index.NewHNSWIndex(path)
+	for id := uint64(1); id <= 20; id++ {
+		upsertVec(t, idx, id, []float32{float32(id), 1})
+	}
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Writers (embed worker analogue).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for id := uint64(21); ; id++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			_ = idx.Upsert(context.Background(), []float32{float32(id), 2}, model.IndexPayload{ChunkID: id, RelPath: "c.txt", DocType: "md"})
+		}
+	}()
+
+	// Autosave analogue.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = idx.Save(context.Background(), "")
+			}
+		}
+	}()
+
+	// Readers.
+	for w := 0; w < 4; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 500; i++ {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				if _, err := idx.Search(context.Background(), []float32{1, 1}, 5, model.Filter{}); err != nil {
+					t.Errorf("search: %v", err)
+					return
+				}
+			}
+		}()
+	}
+
+	// Let the readers run to completion, then stop writers/saver.
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 2000; i++ {
+			if _, err := idx.Search(context.Background(), []float32{2, 1}, 3, model.Filter{}); err != nil {
+				t.Errorf("search: %v", err)
+				break
+			}
+		}
+		close(done)
+	}()
+	<-done
+	close(stop)
+	wg.Wait()
+}


### PR DESCRIPTION
Addresses #429 (the bounded, high-value cheap wins only — NOT the full real-ANN rearchitecture).

## What's done
The default in-memory `HNSWIndex` is an exact brute-force cosine scan. This PR keeps results **bit-identical** (exact scan, full recall — perf only) while removing three hot-path costs:

- **F1 — top-k heap.** `Search` now retains only the running best `k` in a bounded min-heap (`O(N) + O(N log k)`) instead of sorting *every* scored candidate (`O(N log N)`). A single shared comparator, `candidateBefore` (score desc, eps-tolerant ascending chunk_id tiebreak), drives both heap eviction and the final ordering, so the retained `k` are exactly what the old full-sort-then-truncate produced.
- **F2 — in-place scoring.** Candidates are scored where they live under the read lock; no per-query copy of each candidate vector (the old code `make+copy`'d every candidate before scoring). A payload struct is copied out of the map only when the candidate actually enters the heap.
- **F7 — dirty-flag autosave.** A monotonic mutation `version` (bumped under the write lock on Upsert/Delete/Reset) is compared to the last-saved version, captured **atomically with the snapshot** under the read lock. An unchanged index skips the entire snapshot deep-copy + mkdir + gob encode + fsync + rename. `savedVersion` advances only after a durable write, so an Upsert/Delete racing a save is never dropped (it stays dirty for the next save). `Load` marks the loaded state clean.

## Correctness preservation
`candidateBefore` is the *sole* ranking comparator, identical to the pre-existing sort's `less`. Heap-select-k then sort-those-k yields the same set and order as full-sort then truncate for any input the comparator totally orders (all realistic embedding score distributions). A property test scores a reference implementation (the pre-#429 algorithm, with a bit-for-bit copy of `cosineSimilarity`) over 50 random corpora × multiple `k` values × filtered/unfiltered and asserts identical chunk IDs, order, and scores.

## Tests (under `tests/`, per AGENTS.md)
`tests/index/perf429_test.go`:
- top-k output identical to full-sort reference (random corpora, k, filter)
- deterministic chunk_id tiebreak at the k boundary
- dirty-flag: skips write when unchanged, writes after Upsert/Delete/Reset, and after Load stays clean
- concurrent Search + Upsert + Save (race-sensitive)

## Validation
`gofmt` clean · `go build ./...` · `go vet` · `make cyclo` (≤15) · `golangci-lint run ./internal/index/... ./internal/cli/...` (0 issues) · `go test ./internal/index/... ./tests/index/...` · `go test -race ./internal/index/... ./tests/index/... ./tests/cli/...` all green.

## Scope
Only `internal/index/hnsw_index.go` + `tests/index/perf429_test.go` changed. The dirty flag lives in the index's `Save`, which the autosave `PersistenceManager` already calls, so `internal/cli/up.go` needed no change.

## Deferred (follow-up)
Shared metadata de-duplication (F4), cold-start rehydrate (F6), disk-backend fsync-per-chunk / per-tx inserts (F8/F9) + its compaction dirty-flag, `list_files` COUNT caching (F10), sqlite WAL reader pool (F11), and the real sub-linear ANN rearchitecture / `HNSW` rename + large-corpus guidance (F3/F1 deep). The disk backend (`diskindex`) keeps its current scan/compaction; the same heap + dirty-flag treatment there is a symmetric follow-up.