### PR TITLE
test(store): guard BM25/hybrid quarantine exclusion across the embed→quarantine lifecycle (#439)

### DIFF
--- a/tests/store/sqlite_bm25_quarantine_test.go
+++ b/tests/store/sqlite_bm25_quarantine_test.go
@@ -74,3 +74,84 @@ func TestSQLiteStore_SearchBM25_ExcludesQuarantined(t *testing.T) {
 		}
 	}
 }
+
+// TestSQLiteStore_SearchBM25_ExcludesQuarantinedAfterEmbedding is the lifecycle
+// regression for #439 (F1): the realistic quarantine path is a chunk that was
+// embedded (embedding_status='ok', already live and searchable, its FTS row
+// present) and is *later* re-screened and quarantined via MarkFailed. Because
+// the chunks_ai/au triggers keep every chunk's terms in chunks_fts regardless
+// of status — and MUST, so the #405/#506 drift check
+// (COUNT(chunks_fts_docsize) == COUNT(chunks)) stays valid — the row survives
+// the ok->error transition. It is the query-time WHERE filter, not the trigger,
+// that has to exclude it. This test proves that: both chunks surface while
+// healthy, then only the still-'ok' chunk surfaces once its sibling flips to
+// 'error'. (The sibling test above covers a chunk quarantined before it was
+// ever embedded.)
+func TestSQLiteStore_SearchBM25_ExcludesQuarantinedAfterEmbedding(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "meta.sqlite")
+	st := store.NewSQLiteStore(dbPath)
+	defer func() { _ = st.Close() }()
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	const (
+		healthyLabel    uint64 = 1
+		quarantineLabel uint64 = 2
+	)
+	chunks := []struct {
+		label uint64
+		text  string
+	}{
+		{healthyLabel, "reporting suspicious transactions to the regulator"},
+		{quarantineLabel, "reporting officer training and qualifications"},
+	}
+	for _, c := range chunks {
+		task := model.NewChunkTask(c.label, c.text, "text", model.ChunkMetadata{
+			ChunkID: c.label,
+			RelPath: "docs/case.md",
+			DocType: "md",
+			RepType: "raw_text",
+		})
+		if err := st.UpsertChunkTask(ctx, task); err != nil {
+			t.Fatalf("UpsertChunkTask(%d): %v", c.label, err)
+		}
+	}
+
+	ls, ok := interface{}(st).(model.LexicalSearcher)
+	if !ok {
+		t.Fatalf("SQLiteStore must implement model.LexicalSearcher")
+	}
+
+	// Both chunks are embedded and healthy: both are live and must match.
+	if err := st.MarkEmbedded(ctx, []uint64{healthyLabel, quarantineLabel}); err != nil {
+		t.Fatalf("MarkEmbedded: %v", err)
+	}
+	before, err := ls.SearchBM25(ctx, "reporting", 10, "text")
+	if err != nil {
+		t.Fatalf("SearchBM25 (pre-quarantine): %v", err)
+	}
+	if len(before) != 2 {
+		t.Fatalf("expected both 'ok' chunks to match before quarantine, got %d hits: %+v", len(before), before)
+	}
+
+	// Re-screen quarantines one chunk: ok -> error. Its FTS row is untouched by
+	// the status update, so only the WHERE filter can keep it out of results.
+	if err := st.MarkFailed(ctx, []uint64{quarantineLabel}, "quality gate quarantine"); err != nil {
+		t.Fatalf("MarkFailed: %v", err)
+	}
+	after, err := ls.SearchBM25(ctx, "reporting", 10, "text")
+	if err != nil {
+		t.Fatalf("SearchBM25 (post-quarantine): %v", err)
+	}
+	if len(after) != 1 {
+		t.Fatalf("expected only the still-'ok' chunk after quarantine, got %d hits: %+v", len(after), after)
+	}
+	if after[0].ChunkID != healthyLabel {
+		t.Errorf("expected healthy chunk %d, got chunk %d", healthyLabel, after[0].ChunkID)
+	}
+	if after[0].ChunkID == quarantineLabel {
+		t.Errorf("chunk %d quarantined after embedding (embedding_status='error') must not appear in BM25 results", quarantineLabel)
+	}
+}


### PR DESCRIPTION
Addresses the **store-side** half of #439 (F1): quarantined chunks (`embedding_status='error'`) must not surface via BM25/hybrid or be cited in `ask`.

## Verification of the primary bug (F1)
The production fix already landed in **#448** (in `main`): `SearchBM25` now filters `AND c.embedding_status != 'error'`, so quarantined chunks are excluded from the lexical path (and `'pending'` chunks stay lexically searchable). Confirmed complete and correct against current code:

- Every quarantine/failure path funnels through `markEmbeddingStatus(..., "error", ...)` (`MarkFailed` / `MarkFailedWithCategory`), so `!= 'error'` is the full predicate. `embedding_status` is `NOT NULL DEFAULT 'pending'`, so there is no NULL edge case.
- **Hybrid** delegates the entire exclusion decision to `SearchBM25`: `runHybridSearch` (hybrid.go:123) calls `ls.SearchBM25(...)` and trusts the returned hits (only re-attaching cached metadata). Quarantined chunks are never embedded, so they never appear on the vector side either. `SearchBM25` is therefore the single load-bearing guard for both `search` and hybrid `ask`.
- The FTS trigger correctly stays **unconditional**. Making `chunks_ai`/`chunks_au` skip quarantined chunks would break the #405/#506 drift invariant (`COUNT(chunks_fts_docsize) == COUNT(chunks)`), forcing a full FTS rebuild on every startup. The query-time filter is the right layer.

## What this PR adds
A **lifecycle regression test**. The existing test only covers a chunk quarantined *before* it was ever embedded. This adds the realistic path: a chunk that was embedded (live in `chunks_fts`, searchable) and is *later* re-screened and quarantined via `MarkFailed` (ok→error, FTS row persists). It asserts both chunks match while healthy, then only the still-`ok` chunk matches after its sibling flips to `error` — proving the query-time `WHERE` filter, not the trigger, does the work.

## Deferred (out of scope — separate change)
F2–F7 are heuristic misfires in `internal/quality` / ingest / config, not the store: whole-representation granularity (F2), pinned-STT-language quarantining legit other-language transcripts (F3), CJK/no-space repetition blindness (F4), music/ambient density gate (F5), printable-ASCII gibberish (F6), and per-threshold config knobs (F7). Tracked separately; kept general-purpose (no Russian/CJK-specific defaults).

## Validation
`gofmt -l` clean · `go build ./...` · `go vet` · `make cyclo` (≤15) · `golangci-lint run` (0 issues) · `go test ./internal/store/... ./tests/store/... ./tests/retrieval/...` all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search results now correctly exclude quarantined items after a status change, even if older search records still exist.
* **Tests**
  * Added regression coverage to verify BM25 search behavior across the item lifecycle and prevent this issue from returning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->