### PR TITLE
perf(index): bounded-batch re-pend in startup reconciliation (#503)

### DIFF
--- a/internal/index/reconcile.go
+++ b/internal/index/reconcile.go
@@ -40,15 +40,33 @@ type EmbeddedVectorSource interface {
 // never materializes the whole embedded set at once.
 const reconcilePageSize = 500
 
+// reconcileRependBatch bounds how many confirmed-missing chunk IDs are buffered
+// before they are flushed to RependEmbeddedChunks. Without it a corpus whose
+// snapshot lost most/all vectors would buffer O(total embedded chunks) IDs before
+// the single end-of-scan re-pend (issue #503). Peak buffer is bounded to
+// reconcileRependBatch + reconcilePageSize (one whole page is appended before the
+// threshold is re-checked), i.e. a few thousand uint64s regardless of corpus size.
+const reconcileRependBatch = 1000
+
 // ReconcileEmbeddedVectors re-pends chunks that sqlite records as embedded but
 // whose vector is absent from ix, and returns the number re-pended (issue #402
 // A2). It is a no-op — returning (0, nil) — when ix does not implement
 // VectorPresence (durable backends need no reconciliation).
 //
-// The read scan is kept strictly read-only (missing IDs are accumulated, not
-// re-pended, while paging) so keyset pagination walks a stable "ok" set; the
-// re-pend write happens once at the end. This avoids the pagination hazard of
-// mutating the very rows the pages are drawn from.
+// Missing IDs are re-pended in bounded batches as the scan proceeds (issue #503)
+// rather than buffered whole and flushed once at the end, which caps peak memory
+// at reconcileRependBatch + reconcilePageSize IDs on very large corpora.
+//
+// Stable-set correctness (unchanged): reconciliation runs at startup before the
+// embed worker starts, so no concurrent embed can be finishing a vector mid-scan;
+// the only invariant to preserve is that a re-pend must not disturb the keyset
+// walk of the "ok" set. Batching is safe because a flush only ever re-pends IDs
+// confirmed missing by HasVectors during the read of an *already-completed* page,
+// so every flushed ID has chunk_id <= afterChunkID (the seek cursor for the next
+// fetch). Flipping those rows ok->pending therefore cannot alter any future page:
+// subsequent fetches select only chunk_id > afterChunkID, which excludes every
+// re-pended row. The scan still walks a stable "ok" set exactly as the prior
+// single end-of-scan re-pend did.
 //
 // Pages are fetched by keyset (seek) rather than OFFSET: each page seeks past the
 // last chunk_id seen, so every row is scanned once instead of OFFSET's quadratic
@@ -59,42 +77,76 @@ func ReconcileEmbeddedVectors(ctx context.Context, source EmbeddedVectorSource, 
 		return 0, nil
 	}
 
-	var missing []uint64
-	var afterChunkID int64
+	var (
+		missing      []uint64
+		repended     int
+		afterChunkID int64
+	)
+	// flush re-pends the buffered missing IDs and resets the buffer. Every ID in
+	// missing has chunk_id <= afterChunkID (drawn only from completed pages), so
+	// the write cannot perturb the keyset walk of the remaining "ok" set.
+	flush := func() error {
+		if len(missing) == 0 {
+			return nil
+		}
+		if err := source.RependEmbeddedChunks(ctx, missing); err != nil {
+			return err
+		}
+		repended += len(missing)
+		missing = missing[:0]
+		return nil
+	}
+
 	for {
 		chunks, err := source.ListEmbeddedChunkMetadata(ctx, kind, reconcilePageSize, afterChunkID)
 		if err != nil {
-			return 0, err
+			return repended, err
 		}
 		if len(chunks) == 0 {
 			break
 		}
-		ids := make([]uint64, len(chunks))
-		for i, c := range chunks {
-			ids[i] = c.Label
-		}
-		present, err := presence.HasVectors(ctx, ids)
+		pageMiss, err := pageMissing(ctx, presence, chunks)
 		if err != nil {
-			return 0, err
+			return repended, err
 		}
-		for _, id := range ids {
-			if id != 0 && !present[id] {
-				missing = append(missing, id)
-			}
-		}
+		missing = append(missing, pageMiss...)
 		if len(chunks) < reconcilePageSize {
 			break
 		}
 		// Seek past the last chunk_id in this page (rows are ordered by chunk_id
-		// ascending, so the final Label is the greatest key seen so far).
+		// ascending, so the final Label is the greatest key seen so far). Flush
+		// only after advancing the cursor keeps every buffered ID <= afterChunkID.
 		afterChunkID = int64(chunks[len(chunks)-1].Label)
+		if len(missing) >= reconcileRependBatch {
+			if err := flush(); err != nil {
+				return repended, err
+			}
+		}
 	}
 
-	if len(missing) == 0 {
-		return 0, nil
+	if err := flush(); err != nil {
+		return repended, err
 	}
-	if err := source.RependEmbeddedChunks(ctx, missing); err != nil {
-		return 0, err
+	return repended, nil
+}
+
+// pageMissing returns the chunk IDs in a single embedded page whose vectors are
+// absent from the index. Zero labels are skipped defensively. The caller passes a
+// non-empty page (the scan loop breaks on an empty page before calling this).
+func pageMissing(ctx context.Context, presence VectorPresence, chunks []model.ChunkTask) ([]uint64, error) {
+	ids := make([]uint64, len(chunks))
+	for i, c := range chunks {
+		ids[i] = c.Label
 	}
-	return len(missing), nil
+	present, err := presence.HasVectors(ctx, ids)
+	if err != nil {
+		return nil, err
+	}
+	missing := make([]uint64, 0, len(ids))
+	for _, id := range ids {
+		if id != 0 && !present[id] {
+			missing = append(missing, id)
+		}
+	}
+	return missing, nil
 }

--- a/internal/index/reconcile.go
+++ b/internal/index/reconcile.go
@@ -82,9 +82,10 @@ func ReconcileEmbeddedVectors(ctx context.Context, source EmbeddedVectorSource, 
 		repended     int
 		afterChunkID int64
 	)
-	// flush re-pends the buffered missing IDs and resets the buffer. Every ID in
-	// missing has chunk_id <= afterChunkID (drawn only from completed pages), so
-	// the write cannot perturb the keyset walk of the remaining "ok" set.
+	// flush re-pends the buffered missing IDs and resets the buffer. afterChunkID
+	// is advanced to a page's last chunk_id before that page's IDs can be flushed,
+	// so every buffered ID has chunk_id <= afterChunkID and the write cannot perturb
+	// the keyset walk of the remaining "ok" set.
 	flush := func() error {
 		if len(missing) == 0 {
 			return nil
@@ -110,13 +111,15 @@ func ReconcileEmbeddedVectors(ctx context.Context, source EmbeddedVectorSource, 
 			return repended, err
 		}
 		missing = append(missing, pageMiss...)
+		// Advance the cursor to the largest chunk_id read on THIS page BEFORE any
+		// flush (rows are ordered by chunk_id ascending, so the final Label is the
+		// greatest key seen so far). Advancing on every page — including the final
+		// short one — keeps every buffered ID at chunk_id <= afterChunkID, so the
+		// end-of-scan flush's invariant holds literally for the last page too.
+		afterChunkID = int64(chunks[len(chunks)-1].Label)
 		if len(chunks) < reconcilePageSize {
 			break
 		}
-		// Seek past the last chunk_id in this page (rows are ordered by chunk_id
-		// ascending, so the final Label is the greatest key seen so far). Flush
-		// only after advancing the cursor keeps every buffered ID <= afterChunkID.
-		afterChunkID = int64(chunks[len(chunks)-1].Label)
 		if len(missing) >= reconcileRependBatch {
 			if err := flush(); err != nil {
 				return repended, err

--- a/tests/index/reconcile_test.go
+++ b/tests/index/reconcile_test.go
@@ -20,11 +20,15 @@ type fakeEmbeddedSource struct {
 	// can assert re-pending is flushed in bounded batches (issue #503) rather than
 	// one terminal call.
 	rependBatches []int
-	listErr       error
-	repErr        error
+	// seeks records the afterChunkID cursor passed to each ListEmbeddedChunkMetadata
+	// call so tests can assert the keyset walk advances monotonically.
+	seeks   []int64
+	listErr error
+	repErr  error
 }
 
 func (f *fakeEmbeddedSource) ListEmbeddedChunkMetadata(_ context.Context, kind string, limit int, afterChunkID int64) ([]model.ChunkTask, error) {
+	f.seeks = append(f.seeks, afterChunkID)
 	if f.listErr != nil {
 		return nil, f.listErr
 	}
@@ -176,6 +180,14 @@ func TestReconcileEmbeddedVectors_RependsInBoundedBatches(t *testing.T) {
 	}
 	if sum != total {
 		t.Fatalf("batch sizes sum to %d, want %d: %v", sum, total, src.rependBatches)
+	}
+	// The keyset cursor is monotonic non-decreasing across pages — each fetch seeks
+	// strictly past the previous page's largest chunk_id, so no row is scanned twice
+	// and the flush invariant (buffered ID chunk_id <= afterChunkID) can hold.
+	for i := 1; i < len(src.seeks); i++ {
+		if src.seeks[i] <= src.seeks[i-1] {
+			t.Fatalf("seek cursor not monotonic at page %d: %v", i, src.seeks)
+		}
 	}
 	// Correctness preserved: the union of all batches is exactly the missing set.
 	got := append([]uint64(nil), src.repended...)

--- a/tests/index/reconcile_test.go
+++ b/tests/index/reconcile_test.go
@@ -16,8 +16,12 @@ import (
 type fakeEmbeddedSource struct {
 	byKind   map[string][]uint64
 	repended []uint64
-	listErr  error
-	repErr   error
+	// rependBatches records the size of each RependEmbeddedChunks call so tests
+	// can assert re-pending is flushed in bounded batches (issue #503) rather than
+	// one terminal call.
+	rependBatches []int
+	listErr       error
+	repErr        error
 }
 
 func (f *fakeEmbeddedSource) ListEmbeddedChunkMetadata(_ context.Context, kind string, limit int, afterChunkID int64) ([]model.ChunkTask, error) {
@@ -46,7 +50,22 @@ func (f *fakeEmbeddedSource) RependEmbeddedChunks(_ context.Context, labels []ui
 		return f.repErr
 	}
 	f.repended = append(f.repended, labels...)
+	f.rependBatches = append(f.rependBatches, len(labels))
 	return nil
+}
+
+// absentIndex is a model.Index that implements index.VectorPresence and reports
+// every chunk as missing, standing in for a snapshot that lost all its vectors.
+// It lets the batching test drive a large missing set without materializing a
+// real HNSW graph.
+type absentIndex struct{ model.Index }
+
+func (absentIndex) HasVectors(_ context.Context, chunkIDs []uint64) (map[uint64]bool, error) {
+	present := make(map[uint64]bool, len(chunkIDs))
+	for _, id := range chunkIDs {
+		present[id] = false
+	}
+	return present, nil
 }
 
 // stubIndex is a minimal model.Index that deliberately does NOT implement
@@ -115,6 +134,59 @@ func TestReconcileEmbeddedVectors_DurableBackendNoop(t *testing.T) {
 	}
 	if n != 0 || len(src.repended) != 0 {
 		t.Fatalf("expected durable backend no-op, got n=%d repended=%v", n, src.repended)
+	}
+}
+
+// TestReconcileEmbeddedVectors_RependsInBoundedBatches pins the #503 fix: a large
+// missing set is re-pended across multiple bounded batches as the scan proceeds
+// (not one terminal O(total) call), and the union of every batch equals the full
+// missing set — so bounding peak memory preserves correctness.
+func TestReconcileEmbeddedVectors_RependsInBoundedBatches(t *testing.T) {
+	// Enough embedded chunks — all reported missing — that the buffer crosses the
+	// re-pend batch threshold several times, forcing multiple flushes.
+	const total = 2500
+	want := make([]uint64, 0, total)
+	for id := uint64(1); id <= total; id++ {
+		want = append(want, id)
+	}
+	src := &fakeEmbeddedSource{byKind: map[string][]uint64{index.KindText: want}}
+
+	n, err := index.ReconcileEmbeddedVectors(context.Background(), src, absentIndex{}, index.KindText)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if n != total {
+		t.Fatalf("re-pended count = %d, want %d", n, total)
+	}
+	// Bounded batching: more than one flush, and no single flush carried the whole
+	// missing set (peak buffer is bounded well below total on a large corpus).
+	if len(src.rependBatches) < 2 {
+		t.Fatalf("expected re-pend to be flushed in multiple batches, got %d call(s): %v",
+			len(src.rependBatches), src.rependBatches)
+	}
+	sum := 0
+	for i, size := range src.rependBatches {
+		if size == 0 {
+			t.Fatalf("batch %d was empty: %v", i, src.rependBatches)
+		}
+		if size >= total {
+			t.Fatalf("batch %d size %d not bounded below total %d: %v", i, size, total, src.rependBatches)
+		}
+		sum += size
+	}
+	if sum != total {
+		t.Fatalf("batch sizes sum to %d, want %d: %v", sum, total, src.rependBatches)
+	}
+	// Correctness preserved: the union of all batches is exactly the missing set.
+	got := append([]uint64(nil), src.repended...)
+	sort.Slice(got, func(i, j int) bool { return got[i] < got[j] })
+	if len(got) != len(want) {
+		t.Fatalf("re-pended %d chunks, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("re-pended set diverges at %d: got %d want %d", i, got[i], want[i])
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #503.

## Problem
`ReconcileEmbeddedVectors` (startup embedded-vector reconciliation, `internal/index/reconcile.go`) accumulated **all** missing chunk IDs in memory and issued a **single** `RependEmbeddedChunks` at the very end of the scan. Worst case (a snapshot that lost most/all vectors after an ungraceful crash) is O(total embedded chunks) peak memory, and it delays every re-pend to the end of the full scan — problematic for very large corpora at startup. Carved from PR #485 review.

## Fix — bounded-batch re-pend as the scan proceeds
The buffer is flushed via `RependEmbeddedChunks` whenever it reaches `reconcileRependBatch` (1000), then the scan continues. Peak memory is bounded to `reconcileRependBatch + reconcilePageSize` IDs (one whole page is appended before the threshold is re-checked) — a few thousand `uint64`s regardless of corpus size — and re-pending happens incrementally instead of all at the end.

## Stable-set correctness is preserved
The prior design's guarantee was that the read scan does not mutate the very rows keyset pagination still needs to walk. Batching keeps that guarantee:

- Reconciliation runs at startup **before** the embed worker starts (`cmd/cli/up.go`: reconcile at line 199, embed worker at line 202), so no concurrent embed can be finishing a vector mid-scan.
- A flush only ever re-pends IDs **confirmed missing** by `HasVectors` during the read of an **already-completed** page, so every flushed ID has `chunk_id <= afterChunkID` (the seek cursor for the next fetch). The flush is issued only after the cursor has advanced past the whole page.
- Flipping those rows `ok -> pending` therefore cannot alter any future page: subsequent keyset fetches select only `chunk_id > afterChunkID`, which excludes every re-pended row.

So the scan walks the same stable "ok" set the single end-of-scan re-pend did — just with bounded memory. The choice (mid-scan batching, safe under keyset pagination) is documented in a comment on the function.

## Tests (`tests/index/reconcile_test.go`)
- New `TestReconcileEmbeddedVectors_RependsInBoundedBatches`: 2500 all-missing chunks are re-pended across **multiple** bounded batches (asserts >1 flush, no flush carries the whole set), and the union of all batches equals the full missing set (correctness preserved). Fake source now records per-call batch sizes; a lightweight all-absent index avoids materializing a real HNSW graph.
- Existing reconcile tests unchanged and still green.

## Validation (in worktree)
- `gofmt -l internal/ tests/`: clean
- `go build ./...`, `go vet ./internal/index/... ./tests/index/...`: clean
- `make cyclo` (>15): clean (extracted `pageMissing` helper to stay under the gate)
- `golangci-lint run` (full): 0 issues
- `go test ./internal/index/... ./tests/index/...` and `go test -race ./tests/index/...`: pass

Scope: only `internal/index/reconcile.go` and `tests/index/reconcile_test.go`.