### PR TITLE
fix(s3): apply gitignore, handle nil Content-Length, validate region/endpoint on discovery (#487)

### DIFF
--- a/internal/corpusfs/factory.go
+++ b/internal/corpusfs/factory.go
@@ -178,15 +178,28 @@ func validateS3SourceConfig(cfg Config) error {
 	}
 	u, err := url.Parse(endpoint)
 	if err != nil {
-		return fmt.Errorf("corpusfs: source.s3.endpoint is not a valid URL: %w", err)
+		// Never echo the raw endpoint: it may embed userinfo
+		// (http://user:pass@host), and a parse-failure error would leak those
+		// credentials into logs/startup output.
+		return errors.New("corpusfs: source.s3.endpoint is not a valid URL")
 	}
 	if u.Scheme != "http" && u.Scheme != "https" {
-		return fmt.Errorf("corpusfs: source.s3.endpoint must use http or https, got %q", endpoint)
+		return fmt.Errorf("corpusfs: source.s3.endpoint must use http or https, got %q", redactedEndpoint(u))
 	}
 	if u.Host == "" {
-		return fmt.Errorf("corpusfs: source.s3.endpoint must include a host, got %q", endpoint)
+		return errors.New("corpusfs: source.s3.endpoint must include a host")
 	}
 	return nil
+}
+
+// redactedEndpoint renders a parsed endpoint URL as scheme://host, dropping any
+// userinfo, path, or query so credentials embedded in the endpoint
+// (http://user:pass@host) never reach logs or error messages.
+func redactedEndpoint(u *url.URL) string {
+	if u.Host == "" {
+		return u.Scheme
+	}
+	return u.Scheme + "://" + u.Host
 }
 
 // presignerForClient returns a presignFunc backed by the SDK's PresignClient when

--- a/internal/corpusfs/factory.go
+++ b/internal/corpusfs/factory.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"path/filepath"
 	"strings"
 
@@ -136,8 +137,8 @@ func New(ctx context.Context, cfg Config) (CorpusFS, error) {
 // capability can hand ffmpeg a range-seekable URL (issue #243); a stub client (no
 // concrete *s3.Client) yields no presigner and MediaURL falls back to Localize.
 func newS3FromConfig(ctx context.Context, cfg Config) (CorpusFS, error) {
-	if strings.TrimSpace(cfg.S3Bucket) == "" {
-		return nil, errors.New("corpusfs: source kind s3 requires a bucket")
+	if err := validateS3SourceConfig(cfg); err != nil {
+		return nil, err
 	}
 	client, err := newS3Client(ctx, cfg)
 	if err != nil {
@@ -152,6 +153,40 @@ func newS3FromConfig(ctx context.Context, cfg Config) (CorpusFS, error) {
 		Prefix:   cfg.S3Prefix,
 		CacheDir: cacheDir,
 	}, presignerForClient(client))
+}
+
+// validateS3SourceConfig enforces the S3 corpus-source invariants before a
+// client is built so misconfiguration fails fast with a clear, actionable error
+// at startup rather than as an opaque endpoint-resolution failure on the first
+// ListObjects (issue #487). It requires a bucket; requires a region when no
+// custom endpoint is configured (AWS endpoint resolution needs one, and the SDK
+// otherwise fails deep in the request path); and, when a custom endpoint is set,
+// requires it to be a syntactically valid http(s) URL with a host.
+func validateS3SourceConfig(cfg Config) error {
+	if strings.TrimSpace(cfg.S3Bucket) == "" {
+		return errors.New("corpusfs: source kind s3 requires a bucket")
+	}
+	region := strings.TrimSpace(cfg.S3Region)
+	endpoint := strings.TrimSpace(cfg.S3Endpoint)
+	if endpoint == "" {
+		if region == "" {
+			return errors.New("corpusfs: source kind s3 requires a region " +
+				"(set source.s3.region, DIR2MCP_SOURCE_S3_REGION, or AWS_REGION) " +
+				"when no custom endpoint is configured")
+		}
+		return nil
+	}
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return fmt.Errorf("corpusfs: source.s3.endpoint is not a valid URL: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("corpusfs: source.s3.endpoint must use http or https, got %q", endpoint)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("corpusfs: source.s3.endpoint must include a host, got %q", endpoint)
+	}
+	return nil
 }
 
 // presignerForClient returns a presignFunc backed by the SDK's PresignClient when

--- a/internal/corpusfs/local.go
+++ b/internal/corpusfs/local.go
@@ -544,7 +544,14 @@ func parseGitIgnoreRules(absDir, relDir string) ([]gitIgnoreRule, error) {
 		}
 		return nil, fmt.Errorf("read %s: %w", gitIgnorePath, err)
 	}
+	return parseGitIgnoreContent(content, relDir), nil
+}
 
+// parseGitIgnoreContent parses the raw bytes of a .gitignore file into rules
+// anchored at relDir (the corpus-relative directory the .gitignore lives in). It
+// is the backend-agnostic core of gitignore parsing so both the local walker
+// (reading files) and the S3 walker (reading objects) apply identical semantics.
+func parseGitIgnoreContent(content []byte, relDir string) []gitIgnoreRule {
 	lines := strings.Split(strings.ReplaceAll(strings.ReplaceAll(string(content), "\r\n", "\n"), "\r", "\n"), "\n")
 	rules := make([]gitIgnoreRule, 0, len(lines))
 	for _, line := range lines {
@@ -580,7 +587,23 @@ func parseGitIgnoreRules(absDir, relDir string) ([]gitIgnoreRule, error) {
 		})
 	}
 
-	return rules, nil
+	return rules
+}
+
+// keyIgnoredByGitignore reports whether an object key (a corpus-relative slash
+// path to a regular file) is excluded by the gitignore rules. It mirrors the
+// local walker, which prunes an ignored directory before descending: a key is
+// ignored if any ancestor directory segment is ignored (a directory match, which
+// git treats as un-re-includable) or the file path itself matches. rules must
+// already be ordered root-first so gitignore's last-match-wins precedence holds.
+func keyIgnoredByGitignore(rel string, rules []gitIgnoreRule) bool {
+	segs := strings.Split(rel, "/")
+	for i := 1; i < len(segs); i++ {
+		if matchesGitIgnoreRules(rules, strings.Join(segs[:i], "/"), true) {
+			return true
+		}
+	}
+	return matchesGitIgnoreRules(rules, rel, false)
 }
 
 func matchesGitIgnoreRules(rules []gitIgnoreRule, relPath string, isDir bool) bool {

--- a/internal/corpusfs/s3.go
+++ b/internal/corpusfs/s3.go
@@ -265,9 +265,17 @@ func (s *S3FS) getGitIgnoreObject(ctx context.Context, rel string) ([]byte, erro
 		return nil, fmt.Errorf("corpusfs: get gitignore s3://%s/%s: %w", s.bucket, key, err)
 	}
 	defer func() { _ = out.Body.Close() }()
-	content, err := io.ReadAll(io.LimitReader(out.Body, maxGitIgnoreObjectBytes))
+	// Read one byte past the cap so a .gitignore larger than
+	// maxGitIgnoreObjectBytes can be detected. Applying a silently truncated
+	// rule set would drop trailing ignore rules and wrongly include files, so
+	// fail loudly rather than filter with partial rules.
+	content, err := io.ReadAll(io.LimitReader(out.Body, maxGitIgnoreObjectBytes+1))
 	if err != nil {
 		return nil, fmt.Errorf("corpusfs: read gitignore s3://%s/%s: %w", s.bucket, key, err)
+	}
+	if int64(len(content)) > maxGitIgnoreObjectBytes {
+		return nil, fmt.Errorf("corpusfs: gitignore s3://%s/%s exceeds %d-byte limit; "+
+			"refusing to apply truncated ignore rules", s.bucket, key, maxGitIgnoreObjectBytes)
 	}
 	return content, nil
 }

--- a/internal/corpusfs/s3.go
+++ b/internal/corpusfs/s3.go
@@ -138,18 +138,41 @@ func (s *S3FS) relForKey(key string) (string, bool) {
 
 // Walk lists objects under the prefix and converts them to DiscoveredFile,
 // honoring MaxSizeBytes and the default excluded directories (matched against
-// the relative key segments). The root argument is ignored: the configured
-// prefix is the corpus root. Results are sorted by RelPath.
+// the relative key segments). When opts.UseGitIgnore is set, the rules in any
+// discovered .gitignore objects are fetched and applied to the listed keys so
+// gitignore is honored on S3 exactly as it is on the local filesystem (issue
+// #487). The root argument is ignored: the configured prefix is the corpus root.
+// Results are sorted by RelPath.
 func (s *S3FS) Walk(ctx context.Context, _ string, opts Options) ([]DiscoveredFile, error) {
 	if opts.MaxSizeBytes <= 0 {
 		opts.MaxSizeBytes = defaultMaxFileSizeBytes
 	}
 
+	files, gitignoreRels, err := s.listObjects(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.UseGitIgnore && len(gitignoreRels) > 0 {
+		if files, err = s.filterGitIgnored(ctx, files, gitignoreRels); err != nil {
+			return nil, err
+		}
+	}
+
+	sort.Slice(files, func(i, j int) bool { return files[i].RelPath < files[j].RelPath })
+	return files, nil
+}
+
+// listObjects paginates the bucket listing, converting in-scope objects to
+// DiscoveredFile and (when gitignore is enabled) collecting the corpus-relative
+// paths of any .gitignore objects so their rules can be loaded afterward.
+func (s *S3FS) listObjects(ctx context.Context, opts Options) ([]DiscoveredFile, []string, error) {
 	files := make([]DiscoveredFile, 0, 256)
+	var gitignoreRels []string
 	var token *string
 	for {
 		if err := ctx.Err(); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		out, err := s.client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
 			Bucket:            aws.String(s.bucket),
@@ -157,14 +180,17 @@ func (s *S3FS) Walk(ctx context.Context, _ string, opts Options) ([]DiscoveredFi
 			ContinuationToken: token,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("corpusfs: list s3://%s/%s: %w", s.bucket, s.prefix, err)
+			return nil, nil, fmt.Errorf("corpusfs: list s3://%s/%s: %w", s.bucket, s.prefix, err)
 		}
 		for _, obj := range out.Contents {
-			f, ok := s.discoveredFromObject(obj, opts)
-			if !ok {
-				continue
+			if opts.UseGitIgnore {
+				if rel, ok := s.relForKey(aws.ToString(obj.Key)); ok && path.Base(rel) == ".gitignore" {
+					gitignoreRels = append(gitignoreRels, rel)
+				}
 			}
-			files = append(files, f)
+			if f, ok := s.discoveredFromObject(obj, opts); ok {
+				files = append(files, f)
+			}
 		}
 		if out.IsTruncated == nil || !*out.IsTruncated {
 			break
@@ -174,9 +200,76 @@ func (s *S3FS) Walk(ctx context.Context, _ string, opts Options) ([]DiscoveredFi
 			break
 		}
 	}
+	return files, gitignoreRels, nil
+}
 
-	sort.Slice(files, func(i, j int) bool { return files[i].RelPath < files[j].RelPath })
-	return files, nil
+// filterGitIgnored loads the rules from the discovered .gitignore objects and
+// drops the discovered files they exclude, in place.
+func (s *S3FS) filterGitIgnored(ctx context.Context, files []DiscoveredFile, gitignoreRels []string) ([]DiscoveredFile, error) {
+	rules, err := s.loadGitIgnoreRules(ctx, gitignoreRels)
+	if err != nil {
+		return nil, err
+	}
+	kept := files[:0]
+	for _, f := range files {
+		if keyIgnoredByGitignore(f.RelPath, rules) {
+			continue
+		}
+		kept = append(kept, f)
+	}
+	return kept, nil
+}
+
+// maxGitIgnoreObjectBytes bounds how many bytes are read from a .gitignore
+// object so a pathologically large key cannot exhaust memory during discovery.
+const maxGitIgnoreObjectBytes = 1 << 20 // 1 MiB
+
+// loadGitIgnoreRules fetches and parses the given .gitignore objects into a
+// single ordered rule set. The rels are sorted root-first (by directory depth,
+// then lexically) so shallower rules precede deeper ones — matching the local
+// walker's parent-first accumulation and gitignore's last-match-wins precedence.
+func (s *S3FS) loadGitIgnoreRules(ctx context.Context, rels []string) ([]gitIgnoreRule, error) {
+	ordered := append([]string(nil), rels...)
+	sort.Slice(ordered, func(i, j int) bool {
+		di, dj := strings.Count(ordered[i], "/"), strings.Count(ordered[j], "/")
+		if di != dj {
+			return di < dj
+		}
+		return ordered[i] < ordered[j]
+	})
+
+	var rules []gitIgnoreRule
+	for _, rel := range ordered {
+		content, err := s.getGitIgnoreObject(ctx, rel)
+		if err != nil {
+			return nil, err
+		}
+		relDir := path.Dir(rel)
+		if relDir == "." {
+			relDir = ""
+		}
+		rules = append(rules, parseGitIgnoreContent(content, relDir)...)
+	}
+	return rules, nil
+}
+
+// getGitIgnoreObject reads a single .gitignore object's bytes (bounded by
+// maxGitIgnoreObjectBytes) so its rules can be parsed.
+func (s *S3FS) getGitIgnoreObject(ctx context.Context, rel string) ([]byte, error) {
+	key := s.keyForRel(rel)
+	out, err := s.client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("corpusfs: get gitignore s3://%s/%s: %w", s.bucket, key, err)
+	}
+	defer func() { _ = out.Body.Close() }()
+	content, err := io.ReadAll(io.LimitReader(out.Body, maxGitIgnoreObjectBytes))
+	if err != nil {
+		return nil, fmt.Errorf("corpusfs: read gitignore s3://%s/%s: %w", s.bucket, key, err)
+	}
+	return content, nil
 }
 
 // discoveredFromObject converts a listed object into a DiscoveredFile, applying
@@ -244,6 +337,19 @@ func (s *S3FS) Open(ctx context.Context, relPath string) (io.ReadSeekCloser, err
 	})
 	if err != nil {
 		return nil, fmt.Errorf("corpusfs: head s3://%s/%s: %w", s.bucket, key, err)
+	}
+	// A HEAD that omits Content-Length (seen on some MinIO/R2/gateway setups)
+	// leaves the total size unknown. The range reader treats an unknown size as 0
+	// and returns io.EOF on the first Read, so io.ReadAll would yield empty
+	// content with no error — a silently truncated document. Fall back to a
+	// whole-object streaming GET so the bytes are actually read (issue #487).
+	if head.ContentLength == nil {
+		return &s3StreamReader{
+			ctx:    ctx,
+			client: s.client,
+			bucket: s.bucket,
+			key:    key,
+		}, nil
 	}
 	return &s3RangeReader{
 		ctx:    ctx,

--- a/internal/corpusfs/s3reader.go
+++ b/internal/corpusfs/s3reader.go
@@ -95,3 +95,94 @@ func (r *s3RangeReader) Close() error {
 	}
 	return nil
 }
+
+// s3StreamReader is an io.ReadSeekCloser over an S3 object whose total size is
+// unknown (a HEAD that omitted Content-Length). It streams a single whole-object
+// GET rather than issuing ranged reads, so sequential consumers (io.ReadAll of a
+// whole file) get the complete bytes instead of the silent-empty result a
+// size-0 range reader would produce. Seeks are limited to what a forward-only
+// stream can honor: querying the current position, a no-op seek to it, and
+// forward skips (by discarding bytes); backward seeks and SeekEnd fail because
+// the object cannot be rewound and its length is unknown.
+type s3StreamReader struct {
+	ctx    context.Context
+	client s3API
+	bucket string
+	key    string
+
+	offset int64
+	body   io.ReadCloser
+}
+
+// Read fulfills io.Reader, opening the whole-object GET body on demand.
+func (r *s3StreamReader) Read(p []byte) (int, error) {
+	if r.body == nil {
+		if err := r.open(); err != nil {
+			return 0, err
+		}
+	}
+	n, err := r.body.Read(p)
+	r.offset += int64(n)
+	return n, err
+}
+
+// open starts the whole-object (unranged) GET.
+func (r *s3StreamReader) open() error {
+	out, err := r.client.GetObject(r.ctx, &s3.GetObjectInput{
+		Bucket: aws.String(r.bucket),
+		Key:    aws.String(r.key),
+	})
+	if err != nil {
+		return fmt.Errorf("corpusfs: stream get s3://%s/%s: %w", r.bucket, r.key, err)
+	}
+	r.body = out.Body
+	return nil
+}
+
+// Seek fulfills io.Seeker within the limits of a forward-only stream: it resolves
+// the target absolute offset, treats a seek to the current position as a no-op
+// (so callers can query the position with Seek(0, io.SeekCurrent)), and services
+// a forward seek by discarding the intervening bytes. Backward seeks and seeks
+// relative to the (unknown) end are rejected.
+func (r *s3StreamReader) Seek(offset int64, whence int) (int64, error) {
+	var abs int64
+	switch whence {
+	case io.SeekStart:
+		abs = offset
+	case io.SeekCurrent:
+		abs = r.offset + offset
+	case io.SeekEnd:
+		return 0, errors.New("corpusfs: cannot seek relative to end of unknown-length s3 object")
+	default:
+		return 0, errors.New("corpusfs: invalid seek whence")
+	}
+	if abs < 0 {
+		return 0, errors.New("corpusfs: negative seek position")
+	}
+	if abs == r.offset {
+		return abs, nil
+	}
+	if abs < r.offset {
+		return 0, errors.New("corpusfs: cannot seek backward in a streaming s3 object")
+	}
+	if r.body == nil {
+		if err := r.open(); err != nil {
+			return 0, err
+		}
+	}
+	if _, err := io.CopyN(io.Discard, r.body, abs-r.offset); err != nil {
+		return 0, fmt.Errorf("corpusfs: forward seek s3://%s/%s: %w", r.bucket, r.key, err)
+	}
+	r.offset = abs
+	return abs, nil
+}
+
+// Close releases the open GET body, if any.
+func (r *s3StreamReader) Close() error {
+	if r.body != nil {
+		err := r.body.Close()
+		r.body = nil
+		return err
+	}
+	return nil
+}

--- a/internal/corpusfs/s3reader.go
+++ b/internal/corpusfs/s3reader.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -112,10 +113,14 @@ type s3StreamReader struct {
 
 	offset int64
 	body   io.ReadCloser
+	closed bool
 }
 
 // Read fulfills io.Reader, opening the whole-object GET body on demand.
 func (r *s3StreamReader) Read(p []byte) (int, error) {
+	if r.closed {
+		return 0, fs.ErrClosed
+	}
 	if r.body == nil {
 		if err := r.open(); err != nil {
 			return 0, err
@@ -145,6 +150,9 @@ func (r *s3StreamReader) open() error {
 // a forward seek by discarding the intervening bytes. Backward seeks and seeks
 // relative to the (unknown) end are rejected.
 func (r *s3StreamReader) Seek(offset int64, whence int) (int64, error) {
+	if r.closed {
+		return 0, fs.ErrClosed
+	}
 	var abs int64
 	switch whence {
 	case io.SeekStart:
@@ -177,8 +185,14 @@ func (r *s3StreamReader) Seek(offset int64, whence int) (int64, error) {
 	return abs, nil
 }
 
-// Close releases the open GET body, if any.
+// Close releases the open GET body, if any, and marks the reader closed so a
+// later Read/Seek cannot silently reopen the stream from offset 0 while r.offset
+// is non-zero (which would return corrupted data). Double-Close is a no-op.
 func (r *s3StreamReader) Close() error {
+	if r.closed {
+		return nil
+	}
+	r.closed = true
 	if r.body != nil {
 		err := r.body.Close()
 		r.body = nil

--- a/tests/corpusfs/s3_discovery_test.go
+++ b/tests/corpusfs/s3_discovery_test.go
@@ -1,0 +1,180 @@
+package tests
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+
+	"github.com/dirstral/dir2mcp/internal/corpusfs"
+)
+
+// TestS3FSWalk_HonorsGitIgnore pins issue #487 part 2: when UseGitIgnore is set,
+// the rules in discovered .gitignore objects are fetched and applied to S3 keys
+// exactly as the local walker applies them, so an operator relying on gitignore
+// to keep secrets/junk out of the corpus gets it honored on S3 too.
+func TestS3FSWalk_HonorsGitIgnore(t *testing.T) {
+	objs := map[string][]byte{
+		".gitignore":     []byte("*.log\nsecret/\n"),
+		"keep.txt":       []byte("keep"),
+		"app.log":        []byte("ignored by *.log"),
+		"secret/key.txt": []byte("ignored: under secret/ dir"),
+		"sub/.gitignore": []byte("local.tmp\n"),
+		"sub/keep.md":    []byte("keep"),
+		"sub/local.tmp":  []byte("ignored by sub/.gitignore"),
+		"sub/app.log":    []byte("ignored by root *.log (unanchored)"),
+	}
+	fsys, _ := newFakeS3FS(t, "", objs, "")
+
+	// With gitignore enabled the ignored keys drop out.
+	got, err := fsys.Walk(context.Background(), "", corpusfs.Options{UseGitIgnore: true})
+	if err != nil {
+		t.Fatalf("Walk(gitignore): %v", err)
+	}
+	rels := map[string]bool{}
+	for _, f := range got {
+		rels[f.RelPath] = true
+	}
+	// .gitignore files are regular files and stay discovered (LocalFS parity).
+	for _, want := range []string{"keep.txt", "sub/keep.md", ".gitignore", "sub/.gitignore"} {
+		if !rels[want] {
+			t.Fatalf("expected %q discovered, got %v", want, rels)
+		}
+	}
+	for _, bad := range []string{"app.log", "secret/key.txt", "sub/local.tmp", "sub/app.log"} {
+		if rels[bad] {
+			t.Fatalf("expected %q excluded by gitignore, but it was discovered", bad)
+		}
+	}
+
+	// Parity check: with gitignore disabled the same keys come back.
+	all, err := fsys.Walk(context.Background(), "", corpusfs.Options{})
+	if err != nil {
+		t.Fatalf("Walk(no-gitignore): %v", err)
+	}
+	if len(all) != len(objs) {
+		t.Fatalf("without gitignore expected all %d objects, got %d", len(objs), len(all))
+	}
+}
+
+// nilLenS3 wraps fakeS3 but reports a nil Content-Length from HeadObject, as some
+// MinIO/R2/gateway setups do.
+type nilLenS3 struct {
+	*fakeS3
+}
+
+func (n *nilLenS3) HeadObject(_ context.Context, in *s3.HeadObjectInput, _ ...func(*s3.Options)) (*s3.HeadObjectOutput, error) {
+	if _, ok := n.objects[aws.ToString(in.Key)]; !ok {
+		return nil, &s3types.NoSuchKey{}
+	}
+	return &s3.HeadObjectOutput{ContentLength: nil}, nil
+}
+
+// TestS3FSOpen_NilContentLengthStreams pins issue #487 part 3: an object whose
+// HEAD omits Content-Length must stream its full bytes rather than silently
+// returning an empty read (which a size-0 range reader would produce).
+func TestS3FSOpen_NilContentLengthStreams(t *testing.T) {
+	body := []byte("the quick brown fox jumps over the lazy dog")
+	objs := map[string][]byte{"corpus/doc.txt": body}
+	stub := &fakeS3{objects: objs}
+	fsys, err := corpusfs.NewS3FS(&nilLenS3{fakeS3: stub}, corpusfs.S3Config{Bucket: "bkt", Prefix: "corpus"})
+	if err != nil {
+		t.Fatalf("NewS3FS: %v", err)
+	}
+
+	rc, err := fsys.Open(context.Background(), "doc.txt")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = rc.Close() }()
+
+	// Seek(0, SeekCurrent) must report the current position without consuming.
+	if pos, err := rc.Seek(0, io.SeekCurrent); err != nil || pos != 0 {
+		t.Fatalf("Seek(0,Current) = (%d,%v), want (0,nil)", pos, err)
+	}
+
+	got, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if string(got) != string(body) {
+		t.Fatalf("nil-Content-Length read mismatch:\n got %q\nwant %q", got, body)
+	}
+
+	// A backward seek on a forward-only stream is a clear error, not a silent no-op.
+	if _, err := rc.Seek(0, io.SeekStart); err == nil {
+		t.Fatalf("expected backward Seek to error on a streaming object")
+	}
+}
+
+// TestNew_S3RegionEndpointValidation pins issue #487 part 4: an s3 source with no
+// region and no custom endpoint is rejected with a clear error before any client
+// is built, and a custom endpoint must be a valid http(s) URL with a host.
+func TestNew_S3RegionEndpointValidation(t *testing.T) {
+	restore := corpusfs.SetS3ClientBuilderForTest(func(_ context.Context, _ corpusfs.Config) (corpusfs.S3API, error) {
+		t.Fatal("client builder must not be called when config is invalid")
+		return nil, nil
+	})
+	defer restore()
+
+	cases := []struct {
+		name    string
+		cfg     corpusfs.Config
+		wantSub string
+	}{
+		{
+			name:    "no region and no endpoint",
+			cfg:     corpusfs.Config{Kind: "s3", S3Bucket: "b"},
+			wantSub: "region",
+		},
+		{
+			name:    "endpoint without scheme",
+			cfg:     corpusfs.Config{Kind: "s3", S3Bucket: "b", S3Endpoint: "minio:9000"},
+			wantSub: "http or https",
+		},
+		{
+			name:    "endpoint with non-http scheme",
+			cfg:     corpusfs.Config{Kind: "s3", S3Bucket: "b", S3Endpoint: "ftp://minio:9000"},
+			wantSub: "http or https",
+		},
+		{
+			name:    "endpoint without host",
+			cfg:     corpusfs.Config{Kind: "s3", S3Bucket: "b", S3Endpoint: "http://"},
+			wantSub: "host",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := corpusfs.New(context.Background(), tc.cfg)
+			if err == nil || !strings.Contains(err.Error(), tc.wantSub) {
+				t.Fatalf("New(%+v) err = %v, want substring %q", tc.cfg, err, tc.wantSub)
+			}
+		})
+	}
+}
+
+// TestNew_S3CustomEndpointNoRegionOK confirms a valid custom endpoint makes a
+// region optional (S3-compatible stores such as MinIO/R2 do not need one).
+func TestNew_S3CustomEndpointNoRegionOK(t *testing.T) {
+	restore := corpusfs.SetS3ClientBuilderForTest(func(_ context.Context, _ corpusfs.Config) (corpusfs.S3API, error) {
+		return &fakeS3{objects: map[string][]byte{}}, nil
+	})
+	defer restore()
+
+	fsys, err := corpusfs.New(context.Background(), corpusfs.Config{
+		Kind:       "s3",
+		StateDir:   t.TempDir(),
+		S3Bucket:   "b",
+		S3Endpoint: "http://localhost:9000",
+	})
+	if err != nil {
+		t.Fatalf("New(s3, custom endpoint, no region): %v", err)
+	}
+	if _, ok := fsys.(*corpusfs.S3FS); !ok {
+		t.Fatalf("New = %T, want *corpusfs.S3FS", fsys)
+	}
+}

--- a/tests/corpusfs/s3_discovery_test.go
+++ b/tests/corpusfs/s3_discovery_test.go
@@ -2,7 +2,9 @@ package tests
 
 import (
 	"context"
+	"errors"
 	"io"
+	"io/fs"
 	"strings"
 	"testing"
 
@@ -58,6 +60,81 @@ func TestS3FSWalk_HonorsGitIgnore(t *testing.T) {
 	}
 	if len(all) != len(objs) {
 		t.Fatalf("without gitignore expected all %d objects, got %d", len(objs), len(all))
+	}
+}
+
+// TestS3FSWalk_OversizedGitIgnoreErrors verifies that a .gitignore larger than
+// the read cap is rejected loudly rather than silently truncated: applying a
+// partial rule set would drop trailing ignore rules and wrongly include files.
+func TestS3FSWalk_OversizedGitIgnoreErrors(t *testing.T) {
+	// > 1 MiB of valid ignore rules so the reader's cap is exceeded.
+	big := strings.Repeat("*.log\n", 200000) // 1.2 MB
+	objs := map[string][]byte{
+		".gitignore": []byte(big),
+		"keep.txt":   []byte("keep"),
+		"app.log":    []byte("would be ignored if rules loaded"),
+	}
+	fsys, _ := newFakeS3FS(t, "", objs, "")
+
+	_, err := fsys.Walk(context.Background(), "", corpusfs.Options{UseGitIgnore: true})
+	if err == nil {
+		t.Fatalf("Walk with oversized .gitignore = nil error, want a truncation error")
+	}
+	if !strings.Contains(err.Error(), "truncated") && !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("Walk error = %v, want it to flag the oversized/truncated .gitignore", err)
+	}
+
+	// A within-cap .gitignore still loads and filters normally (control).
+	objs[".gitignore"] = []byte("*.log\n")
+	okFS, _ := newFakeS3FS(t, "", objs, "")
+	got, err := okFS.Walk(context.Background(), "", corpusfs.Options{UseGitIgnore: true})
+	if err != nil {
+		t.Fatalf("Walk with small .gitignore: %v", err)
+	}
+	for _, f := range got {
+		if f.RelPath == "app.log" {
+			t.Fatalf("app.log should be excluded by the small .gitignore, got %v", got)
+		}
+	}
+}
+
+// TestS3FSOpen_UseAfterCloseRejected verifies that a streaming reader rejects
+// Read/Seek after Close instead of silently reopening from offset 0 while its
+// logical offset is non-zero (which would return corrupted data). It also
+// confirms double-Close is safe.
+func TestS3FSOpen_UseAfterCloseRejected(t *testing.T) {
+	body := []byte("the quick brown fox jumps over the lazy dog")
+	objs := map[string][]byte{"corpus/doc.txt": body}
+	stub := &fakeS3{objects: objs}
+	fsys, err := corpusfs.NewS3FS(&nilLenS3{fakeS3: stub}, corpusfs.S3Config{Bucket: "bkt", Prefix: "corpus"})
+	if err != nil {
+		t.Fatalf("NewS3FS: %v", err)
+	}
+
+	rc, err := fsys.Open(context.Background(), "doc.txt")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	// Consume some bytes so the logical offset is non-zero before Close.
+	buf := make([]byte, 5)
+	if _, err := io.ReadFull(rc, buf); err != nil {
+		t.Fatalf("ReadFull: %v", err)
+	}
+
+	if err := rc.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	// Double-Close must be safe.
+	if err := rc.Close(); err != nil {
+		t.Fatalf("second Close = %v, want nil", err)
+	}
+
+	if _, err := rc.Read(make([]byte, 4)); !errors.Is(err, fs.ErrClosed) {
+		t.Fatalf("Read after Close = %v, want fs.ErrClosed", err)
+	}
+	if _, err := rc.Seek(0, io.SeekCurrent); !errors.Is(err, fs.ErrClosed) {
+		t.Fatalf("Seek after Close = %v, want fs.ErrClosed", err)
 	}
 }
 
@@ -154,6 +231,33 @@ func TestNew_S3RegionEndpointValidation(t *testing.T) {
 				t.Fatalf("New(%+v) err = %v, want substring %q", tc.cfg, err, tc.wantSub)
 			}
 		})
+	}
+}
+
+// TestNew_S3EndpointErrorRedactsUserinfo pins the security fix: a rejected
+// endpoint that embeds credentials (http://user:pass@host) must not leak the
+// userinfo into the returned error, which lands in logs/startup output.
+func TestNew_S3EndpointErrorRedactsUserinfo(t *testing.T) {
+	restore := corpusfs.SetS3ClientBuilderForTest(func(_ context.Context, _ corpusfs.Config) (corpusfs.S3API, error) {
+		t.Fatal("client builder must not be called when config is invalid")
+		return nil, nil
+	})
+	defer restore()
+
+	// Non-http scheme so validation rejects it, with secret userinfo embedded.
+	cfg := corpusfs.Config{Kind: "s3", S3Bucket: "b", S3Endpoint: "ftp://alice:hunter2@minio:9000"}
+	_, err := corpusfs.New(context.Background(), cfg)
+	if err == nil {
+		t.Fatalf("New(%+v) = nil error, want validation failure", cfg)
+	}
+	for _, secret := range []string{"hunter2", "alice:hunter2", "alice"} {
+		if strings.Contains(err.Error(), secret) {
+			t.Fatalf("endpoint error leaked userinfo %q: %v", secret, err)
+		}
+	}
+	// It should still be actionable: name the offending scheme.
+	if !strings.Contains(err.Error(), "http or https") {
+		t.Fatalf("endpoint error = %v, want it to flag the scheme requirement", err)
 	}
 }
 


### PR DESCRIPTION
Closes #487.

Discovery-side follow-up to #432 (the retrieval/open_file side landed in #479). Scoped to S3 discovery + `internal/corpusfs`; no changes to ingest represent/service/archive.

## Part 2 — `.gitignore` was a silent no-op on S3
`S3FS.Walk` never read `.gitignore` keys, so an operator relying on gitignore to keep secrets/junk out got it honored locally but silently ignored on S3. Walk now collects any `.gitignore` objects during listing, fetches and parses their rules (bounded read), and applies them to the listed keys. Semantics match the local walker:
- rules are ordered root-first (by directory depth) so gitignore's last-match-wins precedence holds;
- a key is excluded if any ancestor directory segment is ignored (git's un-re-includable-parent rule) or the file path itself matches;
- each `.gitignore`'s rules only apply within its own subtree (`baseRel`).

Parsing is shared via a new `parseGitIgnoreContent` extracted from the local `parseGitIgnoreRules`, so both backends apply byte-identical rule semantics.

## Part 3 — nil Content-Length streamed as a silent empty read
`Open` set `size` from `aws.ToInt64(head.ContentLength)`; a HEAD that omits Content-Length (some MinIO/R2/gateway setups) yielded size 0, so the range reader returned `io.EOF` immediately and `io.ReadAll` produced an empty-but-valid-looking document. `Open` now falls back to a whole-object streaming GET (`s3StreamReader`) when Content-Length is nil. The stream supports sequential reads, position queries, and forward skips; backward/SeekEnd error clearly rather than silently misbehaving.

## Part 4 — region/endpoint validation
The factory now validates the S3 source before building a client: a region is required when no custom endpoint is set (AWS endpoint resolution needs one), and a custom endpoint must be a syntactically valid http(s) URL with a host. Misconfiguration now fails fast at startup with a clear, actionable error instead of an opaque endpoint-resolution failure on the first ListObjects.

Not addressed here (out of this issue's concrete scope): the http-endpoint-with-static-creds warning and transient/permanent List-error mapping noted in #432's part 4 remain as-is; credentials are never logged.

## Tests (`tests/corpusfs/s3_discovery_test.go`)
- a gitignored key (via `*.log`, a `dir/` rule, and a nested `.gitignore`) is excluded from S3 discovery, and disabling gitignore restores parity;
- a nil-Content-Length object streams its full bytes (not empty) and rejects backward seeks;
- invalid region/endpoint configs error clearly (no region + no endpoint; endpoint without scheme / non-http scheme / no host), and a valid custom endpoint makes region optional.

## Validation (in worktree)
`gofmt -l` clean; `go build ./...`; `go vet ./...`; `make cyclo` (Walk refactored to stay ≤15); `golangci-lint run` full = 0 issues; `go test ./tests/corpusfs/... ./tests/ingest/... ./tests/config/...` green.