### PR TITLE
feat(whisper): make STT payload cap + request timeout configurable (#510, #511)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3672,11 +3672,8 @@ func (c *Config) validateNumericBounds() error {
 	if c.IngestWatchDebounce < 0 {
 		return fmt.Errorf("ingest.watch_debounce must be non-negative: %v", c.IngestWatchDebounce)
 	}
-	if c.MediaSTTMaxPayloadMB < 0 {
-		return fmt.Errorf("media.stt.max_payload_mb must be non-negative (0 = client default): %d", c.MediaSTTMaxPayloadMB)
-	}
-	if c.MediaSTTRequestTimeoutSec < 0 {
-		return fmt.Errorf("media.stt.request_timeout_sec must be non-negative (0 = client default): %d", c.MediaSTTRequestTimeoutSec)
+	if err := c.validateMediaSTTNumericBounds(); err != nil {
+		return err
 	}
 	if c.RAGMaxContextChars < 0 {
 		return fmt.Errorf("rag.max_context_chars must be non-negative: %d", c.RAGMaxContextChars)
@@ -3709,6 +3706,19 @@ func (c *Config) validateNumericBounds() error {
 // NaN/Inf are also rejected at parse time, but are re-guarded here so a
 // programmatically-injected value still fails validation rather than silently
 // corrupting behavior.
+// validateMediaSTTNumericBounds checks the media.stt.* numeric config fields.
+// Split from validateNumericBounds to keep it under the cyclomatic-complexity
+// budget; behaviour is unchanged.
+func (c *Config) validateMediaSTTNumericBounds() error {
+	if c.MediaSTTMaxPayloadMB < 0 {
+		return fmt.Errorf("media.stt.max_payload_mb must be non-negative (0 = client default): %d", c.MediaSTTMaxPayloadMB)
+	}
+	if c.MediaSTTRequestTimeoutSec < 0 {
+		return fmt.Errorf("media.stt.request_timeout_sec must be non-negative (0 = client default): %d", c.MediaSTTRequestTimeoutSec)
+	}
+	return nil
+}
+
 func (c *Config) validateRetrievalNumericBounds() error {
 	// retrieval.min_score is a relevance floor; 0 disables it. A negative floor
 	// would never drop anything, so reject it explicitly.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1936,12 +1936,7 @@ func applyMediaFileParsed(cfg *Config, fc fileConfig) {
 	if fc.MediaVideoWindowSec != nil {
 		cfg.MediaVideoWindowSec = *fc.MediaVideoWindowSec
 	}
-	if fc.MediaSTTMaxPayloadMB != nil {
-		cfg.MediaSTTMaxPayloadMB = *fc.MediaSTTMaxPayloadMB
-	}
-	if fc.MediaSTTRequestTimeoutSec != nil {
-		cfg.MediaSTTRequestTimeoutSec = *fc.MediaSTTRequestTimeoutSec
-	}
+	applyMediaSTTFileParsed(cfg, fc)
 	if fc.MediaClipMaxDurationMS != nil {
 		cfg.MediaClipMaxDurationMS = *fc.MediaClipMaxDurationMS
 	}
@@ -1963,6 +1958,18 @@ func applyMediaBatchFileParsed(cfg *Config, fc fileConfig) {
 	}
 	if fc.MediaBatchManifest != nil {
 		cfg.MediaBatchManifest = strings.TrimSpace(*fc.MediaBatchManifest)
+	}
+}
+
+// applyMediaSTTFileParsed copies the set media.stt.* file fields (#510, #511)
+// onto cfg. Split out of applyMediaFileParsed so that function stays under the
+// cyclomatic-complexity budget.
+func applyMediaSTTFileParsed(cfg *Config, fc fileConfig) {
+	if fc.MediaSTTMaxPayloadMB != nil {
+		cfg.MediaSTTMaxPayloadMB = *fc.MediaSTTMaxPayloadMB
+	}
+	if fc.MediaSTTRequestTimeoutSec != nil {
+		cfg.MediaSTTRequestTimeoutSec = *fc.MediaSTTRequestTimeoutSec
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -544,6 +544,17 @@ type Config struct {
 	MediaClipMaxDurationMS int
 	MediaClipMaxBytes      int
 
+	// MediaSTTMaxPayloadMB / MediaSTTRequestTimeoutSec tune the self-hosted
+	// whisper STT client's request limits (config `media.stt.max_payload_mb` /
+	// `media.stt.request_timeout_sec`), applied onto whichever whisper STT profile
+	// resolves. The whisper client's built-in caps (50 MB payload, 120 s request
+	// timeout) are too small for long-form media — a 30-min mono file exceeds the
+	// payload cap and takes longer than 120 s to transcribe — so these let an
+	// operator raise them (dir2mcp#510, #511). 0 (default) means "use the client's
+	// built-in default"; negative is CONFIG_INVALID.
+	MediaSTTMaxPayloadMB      int
+	MediaSTTRequestTimeoutSec int
+
 	// MediaBatchTwoPhase / MediaBatchProgress / MediaBatchManifest configure the
 	// optional batch-ergonomics surface for large-archive media ingests (SPEC
 	// §8.6.11; config block `media.batch`). All default OFF/empty so behavior is
@@ -701,6 +712,8 @@ type fileConfig struct {
 	MediaVideoWindowSec                *int
 	MediaClipMaxDurationMS             *int
 	MediaClipMaxBytes                  *int
+	MediaSTTMaxPayloadMB               *int
+	MediaSTTRequestTimeoutSec          *int
 	ElevenLabsAPIKey                   *string
 	ServerTLSCertFile                  *string
 	ServerTLSKeyFile                   *string
@@ -829,6 +842,8 @@ type persistedConfig struct {
 	MediaVideoWindowSec                int           `yaml:"media_video_window_sec"`
 	MediaClipMaxDurationMS             int           `yaml:"media_clip_max_duration_ms"`
 	MediaClipMaxBytes                  int           `yaml:"media_clip_max_bytes"`
+	MediaSTTMaxPayloadMB               int           `yaml:"media_stt_max_payload_mb"`
+	MediaSTTRequestTimeoutSec          int           `yaml:"media_stt_request_timeout_sec"`
 	MediaBatchTwoPhase                 bool          `yaml:"media_batch_two_phase"`
 	MediaBatchProgress                 bool          `yaml:"media_batch_progress"`
 	MediaBatchManifest                 string        `yaml:"media_batch_manifest"`
@@ -1026,6 +1041,9 @@ func Default() Config {
 		LanguageDetectionEnabled:  true,
 		MediaClipMaxDurationMS:    DefaultMediaClipMaxDurationMS,
 		MediaClipMaxBytes:         DefaultMediaClipMaxBytes,
+		// 0 = use the whisper client's built-in caps (#510, #511).
+		MediaSTTMaxPayloadMB:      0,
+		MediaSTTRequestTimeoutSec: 0,
 		MediaVariantsGroup:        false,
 		MediaVariantsSelect:       "best",
 		MediaTranslateEnabled:     false,
@@ -1167,6 +1185,8 @@ func buildPersistedConfig(cfg *Config) persistedConfig {
 		MediaVideoWindowSec:                cfg.MediaVideoWindowSec,
 		MediaClipMaxDurationMS:             cfg.MediaClipMaxDurationMS,
 		MediaClipMaxBytes:                  cfg.MediaClipMaxBytes,
+		MediaSTTMaxPayloadMB:               cfg.MediaSTTMaxPayloadMB,
+		MediaSTTRequestTimeoutSec:          cfg.MediaSTTRequestTimeoutSec,
 		ServerTLSCertFile:                  cfg.ServerTLSCertFile,
 		ServerTLSKeyFile:                   cfg.ServerTLSKeyFile,
 		X402Mode:                           cfg.X402.Mode,
@@ -1916,6 +1936,12 @@ func applyMediaFileParsed(cfg *Config, fc fileConfig) {
 	if fc.MediaVideoWindowSec != nil {
 		cfg.MediaVideoWindowSec = *fc.MediaVideoWindowSec
 	}
+	if fc.MediaSTTMaxPayloadMB != nil {
+		cfg.MediaSTTMaxPayloadMB = *fc.MediaSTTMaxPayloadMB
+	}
+	if fc.MediaSTTRequestTimeoutSec != nil {
+		cfg.MediaSTTRequestTimeoutSec = *fc.MediaSTTRequestTimeoutSec
+	}
 	if fc.MediaClipMaxDurationMS != nil {
 		cfg.MediaClipMaxDurationMS = *fc.MediaClipMaxDurationMS
 	}
@@ -2261,6 +2287,8 @@ var configKeyAliases = map[string]string{
 	"media_video_window_sec":                  "media.video_window_sec",
 	"media_clip_max_duration_ms":              "media.clip.max_duration_ms",
 	"media_clip_max_bytes":                    "media.clip.max_bytes",
+	"media_stt_max_payload_mb":                "media.stt.max_payload_mb",
+	"media_stt_request_timeout_sec":           "media.stt.request_timeout_sec",
 	"stt_provider":                            "stt.provider",
 	"stt_mistral_model":                       "stt.mistral.model",
 	"stt_elevenlabs_model":                    "stt.elevenlabs.model",
@@ -2325,7 +2353,7 @@ func isMapSectionKey(key string) bool {
 		return true
 	case "source", "source.s3":
 		return true
-	case "media", "media.variants", "media.translate", "media.clip", "media.diarize", "media.batch":
+	case "media", "media.variants", "media.translate", "media.clip", "media.stt", "media.diarize", "media.batch":
 		return true
 	case "media.subtitles", "media.subtitles.ttml", "media.subtitles.smil":
 		return true
@@ -2445,6 +2473,10 @@ var intFileScalarTargets = map[string]func(*fileConfig) **int{
 	"media.video_window_sec":     func(c *fileConfig) **int { return &c.MediaVideoWindowSec },
 	"media.clip.max_duration_ms": func(c *fileConfig) **int { return &c.MediaClipMaxDurationMS },
 	"media.clip.max_bytes":       func(c *fileConfig) **int { return &c.MediaClipMaxBytes },
+	"media.stt.max_payload_mb":   func(c *fileConfig) **int { return &c.MediaSTTMaxPayloadMB },
+	"media.stt.request_timeout_sec": func(c *fileConfig) **int {
+		return &c.MediaSTTRequestTimeoutSec
+	},
 	"media.subtitles.ttml.align_tolerance_ms": func(c *fileConfig) **int {
 		return &c.MediaSubtitlesTTMLAlignToleranceMS
 	},
@@ -2480,6 +2512,8 @@ var nonNegativeIntKeys = map[string]bool{
 	"media.video_window_sec":                  true,
 	"media.clip.max_duration_ms":              true,
 	"media.clip.max_bytes":                    true,
+	"media.stt.max_payload_mb":                true,
+	"media.stt.request_timeout_sec":           true,
 	"media.subtitles.ttml.align_tolerance_ms": true,
 }
 
@@ -2878,6 +2912,8 @@ func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	writeInt("media_video_window_sec", cfg.MediaVideoWindowSec)
 	writeInt("media_clip_max_duration_ms", cfg.MediaClipMaxDurationMS)
 	writeInt("media_clip_max_bytes", cfg.MediaClipMaxBytes)
+	writeInt("media_stt_max_payload_mb", cfg.MediaSTTMaxPayloadMB)
+	writeInt("media_stt_request_timeout_sec", cfg.MediaSTTRequestTimeoutSec)
 	writeBool("media_batch_two_phase", cfg.MediaBatchTwoPhase)
 	writeBool("media_batch_progress", cfg.MediaBatchProgress)
 	writeScalar("media_batch_manifest", cfg.MediaBatchManifest)
@@ -3628,6 +3664,12 @@ func (c *Config) validateNumericBounds() error {
 	}
 	if c.IngestWatchDebounce < 0 {
 		return fmt.Errorf("ingest.watch_debounce must be non-negative: %v", c.IngestWatchDebounce)
+	}
+	if c.MediaSTTMaxPayloadMB < 0 {
+		return fmt.Errorf("media.stt.max_payload_mb must be non-negative (0 = client default): %d", c.MediaSTTMaxPayloadMB)
+	}
+	if c.MediaSTTRequestTimeoutSec < 0 {
+		return fmt.Errorf("media.stt.request_timeout_sec must be non-negative (0 = client default): %d", c.MediaSTTRequestTimeoutSec)
 	}
 	if c.RAGMaxContextChars < 0 {
 		return fmt.Errorf("rag.max_context_chars must be non-negative: %d", c.RAGMaxContextChars)

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -568,6 +568,10 @@ func TranscriberFromConfigWithLanguage(cfg config.Config, language string) (mode
 		// media.vad (dir2mcp#258) is a global toggle, applied onto whichever STT
 		// profile resolves; providers without VAD support ignore it.
 		prof.STTVAD = cfg.MediaVAD
+		// media.stt.* request limits (dir2mcp#510/#511), likewise applied onto the
+		// resolved STT profile; 0 leaves the whisper client's built-in defaults.
+		prof.STTMaxPayloadMB = cfg.MediaSTTMaxPayloadMB
+		prof.STTRequestTimeoutSec = cfg.MediaSTTRequestTimeoutSec
 		tr, berr := buildTranscriber(prof)
 		if berr != nil {
 			return nil, fmt.Errorf("stt provider %q: %w", sel, berr)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -186,10 +186,17 @@ type Profile struct {
 	// provider this maps to the OpenAI-compatible `vad_filter` form field;
 	// providers without VAD support ignore it. It is not part of the STT
 	// identity, so toggling it is not reindex-bound.
-	STTVAD      bool
-	TTSModel    string
-	TTSVoice    string // TTS voice id/name (e.g. ElevenLabs voice, OpenAI voice)
-	RerankModel string
+	STTVAD bool
+	// STTMaxPayloadMB / STTRequestTimeoutSec tune the self-hosted whisper client's
+	// request limits (config `media.stt.max_payload_mb` / `media.stt.request_timeout_sec`,
+	// dir2mcp#510/#511). 0 means "use the client's built-in default". Like STTVAD
+	// these are operational knobs, not part of the STT identity, so changing them
+	// is not reindex-bound.
+	STTMaxPayloadMB      int
+	STTRequestTimeoutSec int
+	TTSModel             string
+	TTSVoice             string // TTS voice id/name (e.g. ElevenLabs voice, OpenAI voice)
+	RerankModel          string
 }
 
 // Eligible reports whether the profile may be selected/preflighted

--- a/internal/providerfactory/factory.go
+++ b/internal/providerfactory/factory.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/dirstral/dir2mcp/internal/anthropic"
 	"github.com/dirstral/dir2mcp/internal/cohere"
@@ -251,6 +252,7 @@ func Transcriber(p provider.Profile) (model.Transcriber, error) {
 			c.DefaultLanguage = lang
 		}
 		c.VADFilter = p.STTVAD
+		applyWhisperLimits(c, p)
 		return c, nil
 	case provider.KindMistral:
 		c := mistral.NewClient(p.BaseURL, p.APIKey)
@@ -280,6 +282,20 @@ func Transcriber(p provider.Profile) (model.Transcriber, error) {
 		return c, nil
 	default:
 		return nil, unsupported(p, provider.CapSTT)
+	}
+}
+
+// applyWhisperLimits overrides the whisper client's built-in request caps from
+// the resolved profile when set (>0). The defaults (50 MB payload, 120 s
+// timeout) are too small for long-form media, so an operator can raise them via
+// media.stt.max_payload_mb / media.stt.request_timeout_sec (dir2mcp#510/#511). A
+// zero value leaves the client's default in place.
+func applyWhisperLimits(c *whisperapi.Client, p provider.Profile) {
+	if p.STTMaxPayloadMB > 0 {
+		c.MaxPayloadBytes = p.STTMaxPayloadMB * 1024 * 1024
+	}
+	if p.STTRequestTimeoutSec > 0 && c.HTTPClient != nil {
+		c.HTTPClient.Timeout = time.Duration(p.STTRequestTimeoutSec) * time.Second
 	}
 }
 

--- a/internal/providerfactory/factory.go
+++ b/internal/providerfactory/factory.go
@@ -11,6 +11,7 @@ package providerfactory
 import (
 	"context"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -292,11 +293,32 @@ func Transcriber(p provider.Profile) (model.Transcriber, error) {
 // zero value leaves the client's default in place.
 func applyWhisperLimits(c *whisperapi.Client, p provider.Profile) {
 	if p.STTMaxPayloadMB > 0 {
-		c.MaxPayloadBytes = p.STTMaxPayloadMB * 1024 * 1024
+		c.MaxPayloadBytes = mbToBytes(p.STTMaxPayloadMB)
 	}
 	if p.STTRequestTimeoutSec > 0 && c.HTTPClient != nil {
-		c.HTTPClient.Timeout = time.Duration(p.STTRequestTimeoutSec) * time.Second
+		c.HTTPClient.Timeout = secToDuration(p.STTRequestTimeoutSec)
 	}
+}
+
+// mbToBytes converts a megabyte count to bytes, clamping to math.MaxInt
+// instead of silently wrapping to a negative/smaller value when the
+// multiplication would overflow int (32-bit builds or very large configs).
+func mbToBytes(mb int) int {
+	const bytesPerMB = 1024 * 1024
+	if mb > math.MaxInt/bytesPerMB {
+		return math.MaxInt
+	}
+	return mb * bytesPerMB
+}
+
+// secToDuration converts a second count to a time.Duration, clamping to the
+// maximum representable duration (math.MaxInt64 ns) instead of wrapping to a
+// small/negative value when the nanosecond multiplication would overflow int64.
+func secToDuration(sec int) time.Duration {
+	if int64(sec) > math.MaxInt64/int64(time.Second) {
+		return time.Duration(math.MaxInt64)
+	}
+	return time.Duration(sec) * time.Second
 }
 
 // newElevenLabs builds an ElevenLabs client carrying the profile's

--- a/tests/config/media_stt_limits_config_test.go
+++ b/tests/config/media_stt_limits_config_test.go
@@ -1,0 +1,98 @@
+package tests
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+)
+
+// TestMediaSTTLimits_DefaultsAreZero confirms the STT request-limit knobs default
+// to 0 (= use the whisper client's built-in caps), so behavior is unchanged when
+// unset (dir2mcp#510/#511).
+func TestMediaSTTLimits_DefaultsAreZero(t *testing.T) {
+	cfg := config.Default()
+	if cfg.MediaSTTMaxPayloadMB != 0 {
+		t.Errorf("media.stt.max_payload_mb default = %d, want 0", cfg.MediaSTTMaxPayloadMB)
+	}
+	if cfg.MediaSTTRequestTimeoutSec != 0 {
+		t.Errorf("media.stt.request_timeout_sec default = %d, want 0", cfg.MediaSTTRequestTimeoutSec)
+	}
+}
+
+// TestMediaSTTLimits_RoundTripsThroughSaveLoad exercises the int plumbing
+// (setIntFileScalar/intPtr, writeInt) for the two scalars.
+func TestMediaSTTLimits_RoundTripsThroughSaveLoad(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+
+	cfg := config.Default()
+	cfg.RootDir = "/tmp/repo"
+	cfg.StateDir = "/tmp/repo/.dir2mcp"
+	cfg.MediaSTTMaxPayloadMB = 250
+	cfg.MediaSTTRequestTimeoutSec = 3600
+	if err := config.SaveFile(path, cfg); err != nil {
+		t.Fatalf("SaveFile: %v", err)
+	}
+	loaded, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if loaded.MediaSTTMaxPayloadMB != 250 {
+		t.Errorf("max_payload_mb did not round-trip: got %d, want 250", loaded.MediaSTTMaxPayloadMB)
+	}
+	if loaded.MediaSTTRequestTimeoutSec != 3600 {
+		t.Errorf("request_timeout_sec did not round-trip: got %d, want 3600", loaded.MediaSTTRequestTimeoutSec)
+	}
+}
+
+// TestMediaSTTLimits_ParsesFlatAndNestedYAML confirms both the flat keys
+// (media_stt_*) and the nested block (media: stt: ...) apply through the loader.
+func TestMediaSTTLimits_ParsesFlatAndNestedYAML(t *testing.T) {
+	base := []string{
+		"root_dir: /tmp/repo",
+		"state_dir: /tmp/repo/.dir2mcp",
+	}
+	flat := append(append([]string(nil), base...),
+		"media_stt_max_payload_mb: 300",
+		"media_stt_request_timeout_sec: 900")
+	nested := append(append([]string(nil), base...),
+		"media:", "  stt:", "    max_payload_mb: 300", "    request_timeout_sec: 900")
+
+	for name, lines := range map[string][]string{"flat": flat, "nested": nested} {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), ".dir2mcp.yaml")
+			writeFile(t, path, strings.Join(lines, "\n")+"\n")
+			cfg, err := config.LoadFile(path)
+			if err != nil {
+				t.Fatalf("LoadFile(%s media.stt): %v", name, err)
+			}
+			if cfg.MediaSTTMaxPayloadMB != 300 {
+				t.Errorf("%s max_payload_mb = %d, want 300", name, cfg.MediaSTTMaxPayloadMB)
+			}
+			if cfg.MediaSTTRequestTimeoutSec != 900 {
+				t.Errorf("%s request_timeout_sec = %d, want 900", name, cfg.MediaSTTRequestTimeoutSec)
+			}
+		})
+	}
+}
+
+// TestMediaSTTLimits_NegativeRejected confirms negative values are CONFIG_INVALID.
+func TestMediaSTTLimits_NegativeRejected(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		set  func(*config.Config)
+	}{
+		{"negative payload", func(c *config.Config) { c.MediaSTTMaxPayloadMB = -1 }},
+		{"negative timeout", func(c *config.Config) { c.MediaSTTRequestTimeoutSec = -5 }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.Default()
+			tc.set(&cfg)
+			if err := cfg.Validate(); err == nil {
+				t.Fatalf("expected an error for %s", tc.name)
+			}
+		})
+	}
+}

--- a/tests/providerfactory/factory_test.go
+++ b/tests/providerfactory/factory_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"testing"
+	"time"
 
 	"github.com/dirstral/dir2mcp/internal/colbertrerank"
 	"github.com/dirstral/dir2mcp/internal/gemini"
@@ -10,6 +11,7 @@ import (
 	"github.com/dirstral/dir2mcp/internal/openai"
 	"github.com/dirstral/dir2mcp/internal/provider"
 	"github.com/dirstral/dir2mcp/internal/providerfactory"
+	"github.com/dirstral/dir2mcp/internal/whisperapi"
 )
 
 func prof(k provider.Kind) provider.Profile {
@@ -64,6 +66,50 @@ func TestTranscriber(t *testing.T) {
 			t.Errorf("Transcriber(%s) must error (not STT-capable)", k)
 		}
 	}
+}
+
+// TestWhisperTranscriberLimits asserts the whisper client honors the profile's
+// STT request-limit overrides (dir2mcp#510/#511): a positive STTMaxPayloadMB /
+// STTRequestTimeoutSec raises the client caps, and zero leaves the built-in
+// defaults untouched.
+func TestWhisperTranscriberLimits(t *testing.T) {
+	defClient := whisperapi.NewClient("http://x", "")
+	defPayload := defClient.MaxPayloadBytes
+	defTimeout := defClient.HTTPClient.Timeout
+
+	t.Run("overrides applied", func(t *testing.T) {
+		p := prof(provider.KindWhisper)
+		p.STTMaxPayloadMB = 200
+		p.STTRequestTimeoutSec = 1800
+		tr, err := providerfactory.Transcriber(p)
+		if err != nil {
+			t.Fatalf("Transcriber(whisper): %v", err)
+		}
+		c, ok := tr.(*whisperapi.Client)
+		if !ok {
+			t.Fatalf("whisper Transcriber is %T, want *whisperapi.Client", tr)
+		}
+		if want := 200 * 1024 * 1024; c.MaxPayloadBytes != want {
+			t.Errorf("MaxPayloadBytes = %d, want %d", c.MaxPayloadBytes, want)
+		}
+		if want := 1800 * time.Second; c.HTTPClient.Timeout != want {
+			t.Errorf("HTTPClient.Timeout = %v, want %v", c.HTTPClient.Timeout, want)
+		}
+	})
+
+	t.Run("zero leaves defaults", func(t *testing.T) {
+		tr, err := providerfactory.Transcriber(prof(provider.KindWhisper))
+		if err != nil {
+			t.Fatalf("Transcriber(whisper): %v", err)
+		}
+		c := tr.(*whisperapi.Client)
+		if c.MaxPayloadBytes != defPayload {
+			t.Errorf("MaxPayloadBytes = %d, want default %d", c.MaxPayloadBytes, defPayload)
+		}
+		if c.HTTPClient.Timeout != defTimeout {
+			t.Errorf("HTTPClient.Timeout = %v, want default %v", c.HTTPClient.Timeout, defTimeout)
+		}
+	})
 }
 
 func TestTTS(t *testing.T) {

--- a/tests/providerfactory/factory_test.go
+++ b/tests/providerfactory/factory_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -97,12 +98,37 @@ func TestWhisperTranscriberLimits(t *testing.T) {
 		}
 	})
 
+	t.Run("huge values clamp rather than wrap", func(t *testing.T) {
+		p := prof(provider.KindWhisper)
+		// Values large enough that mb*1MB (int) and sec*1e9ns (int64)
+		// would overflow and wrap to a negative/smaller value.
+		p.STTMaxPayloadMB = math.MaxInt
+		p.STTRequestTimeoutSec = math.MaxInt
+		tr, err := providerfactory.Transcriber(p)
+		if err != nil {
+			t.Fatalf("Transcriber(whisper): %v", err)
+		}
+		c, ok := tr.(*whisperapi.Client)
+		if !ok {
+			t.Fatalf("whisper Transcriber is %T, want *whisperapi.Client", tr)
+		}
+		if c.MaxPayloadBytes < defPayload {
+			t.Errorf("MaxPayloadBytes wrapped/shrank on overflow: got %d, want >= default %d", c.MaxPayloadBytes, defPayload)
+		}
+		if c.HTTPClient.Timeout < defTimeout {
+			t.Errorf("HTTPClient.Timeout wrapped/shrank on overflow: got %v, want >= default %v", c.HTTPClient.Timeout, defTimeout)
+		}
+	})
+
 	t.Run("zero leaves defaults", func(t *testing.T) {
 		tr, err := providerfactory.Transcriber(prof(provider.KindWhisper))
 		if err != nil {
 			t.Fatalf("Transcriber(whisper): %v", err)
 		}
-		c := tr.(*whisperapi.Client)
+		c, ok := tr.(*whisperapi.Client)
+		if !ok {
+			t.Fatalf("whisper Transcriber is %T, want *whisperapi.Client", tr)
+		}
 		if c.MaxPayloadBytes != defPayload {
 			t.Errorf("MaxPayloadBytes = %d, want default %d", c.MaxPayloadBytes, defPayload)
 		}


### PR DESCRIPTION
## What

The whisper STT client hardcodes a **50 MB payload cap** and a **120 s request timeout** with no operator override. Both are too small for long-form media — dir2mcp's core STT use case:

- a 30-min mono file is ~58 MB → rejected client-side before sending (#510)
- transcribing it takes >120 s → the client aborts mid-request while the server returns 200 (#511)

## How

Two global media knobs, applied onto whichever whisper STT profile resolves (mirroring the existing `media.vad` → `STTVAD` pattern):

| config key | effect |
|---|---|
| `media.stt.max_payload_mb` | `whisperapi.Client.MaxPayloadBytes` |
| `media.stt.request_timeout_sec` | `whisperapi.Client.HTTPClient.Timeout` |

`0` (default) keeps the client's built-in caps → **behavior unchanged unless set**. Negative is `CONFIG_INVALID`. Plumbed through `provider.Profile` (`STTMaxPayloadMB` / `STTRequestTimeoutSec`) and applied in `providerfactory` for the whisper kind.

## Testing

- `tests/providerfactory`: whisper client honors the overrides; zero leaves the built-in defaults.
- `tests/config`: defaults are 0; flat + nested YAML parse; save/load round-trip; negative rejected.
- Verified end-to-end: with the timeout raised, a 30-min interview transcribes through dir2mcp (previously failed at 120 s); with the payload cap raised, the 58 MB WAV is accepted (previously rejected).

Fixes #510. Fixes #511.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Ryjn9aKoXj4CQPP8BVrVW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable self-hosted Whisper transcription limits: maximum request payload size and request timeout.
  * Settings support both flat and nested YAML formats and persist through save/load.

* **Bug Fixes**
  * Validation now rejects negative values for the new transcription limits.
  * Whisper transcription now applies the configured limits per profile; zero values keep Whisper’s built-in defaults, and extreme values are safely clamped.

* **Tests**
  * Added coverage for defaults, persistence, YAML compatibility, validation, and Whisper client limit enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->