### PR TITLE
fix(retrieval): open_file cache lookup uses ingest's identity-aware key (#488)

### DIFF
--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -130,6 +130,17 @@ type Service struct {
 	chunkByIndex        map[string]map[uint64]model.SearchHit
 	rootDir             string
 	stateDir            string
+	// ocrCacheIdentity / transcriptCacheIdentity are the ACTIVE OCR-extraction and
+	// STT(+diarize) derivation identities (SPEC §8.6.7) of the ingest pipeline,
+	// plumbed in via SetDerivationCacheIdentities so open_file's OCR/transcript
+	// cache LOOKUP keys the cache the SAME identity-aware way ingest's writer does
+	// (internal/ingest/derivation.go ocrCacheKey/transcriptCacheKey). Without them
+	// retrieval keyed on the source bytes alone and missed every entry ingest wrote
+	// on a docling/mistral/STT corpus (issue #488). An empty identity selects the
+	// historical bytes-only key — exactly what ingest writes when no
+	// extractor/transcriber is configured — so the no-OCR path is unchanged.
+	ocrCacheIdentity        string
+	transcriptCacheIdentity string
 	// corpusFS, when non-nil, routes open_file raw-text reads and OCR/transcript
 	// source-byte hashing through the corpus filesystem abstraction instead of the
 	// local filesystem. It is injected only for object-store backends (S3) so a
@@ -758,6 +769,23 @@ func (s *Service) SetStateDir(stateDir string) {
 	}
 	s.metaMu.Lock()
 	s.stateDir = stateDir
+	s.metaMu.Unlock()
+}
+
+// SetDerivationCacheIdentities plumbs the ingest pipeline's ACTIVE OCR and
+// transcript derivation identities (SPEC §8.6.7) into open_file's OCR/transcript
+// cache lookup so a docling/mistral/STT corpus's cached text is FOUND instead of
+// missed (issue #488). Pass ingest's active OCR identity (Service.activeOCRIdentity)
+// as ocrIdentity and its active transcript identity (activeTranscriptIdentity,
+// which already folds diarize) as transcriptIdentity. An empty string selects the
+// bytes-only key ingest writes when the respective extractor/transcriber is not
+// configured, preserving the pre-#488 no-OCR behavior. Passing the ACTIVE identity
+// (not a store-recorded one, which can carry a differing model_version) is what
+// keeps this lookup byte-identical to ingest's writer.
+func (s *Service) SetDerivationCacheIdentities(ocrIdentity, transcriptIdentity string) {
+	s.metaMu.Lock()
+	s.ocrCacheIdentity = ocrIdentity
+	s.transcriptCacheIdentity = transcriptIdentity
 	s.metaMu.Unlock()
 }
 
@@ -1534,11 +1562,13 @@ func (s *Service) readSourceBytes(ctx context.Context, corpusFS corpusfs.CorpusF
 }
 
 // hashSourceBytes computes the sha256 hex digest of the corpus document at
-// relPath — the key under which ingest stored the document's OCR/transcript
-// cache entry. It streams the source bytes through the CorpusFS Open seam when a
-// backend is injected (so an S3 object is hashed without a local copy) and
-// otherwise reads the local resolved path, rejecting a directory target with the
-// same DOC_TYPE_UNSUPPORTED mapping the raw-text path uses.
+// relPath — the BASE content hash ingest folds (with the derivation identity)
+// into the OCR/transcript cache key. It streams the source bytes through the
+// CorpusFS Open seam when a backend is injected (so an S3 object is hashed
+// without a local copy) and otherwise reads the local resolved path, rejecting a
+// directory target with the same DOC_TYPE_UNSUPPORTED mapping the raw-text path
+// uses. It is the fallback for ocrCacheKeyForOpen: a store that can report the
+// already-known base hash (ocrSourceHashProvider) skips this full object GET.
 func (s *Service) hashSourceBytes(ctx context.Context, corpusFS corpusfs.CorpusFS, resolvedAbs, relPath string) (string, error) {
 	var reader io.Reader
 	if corpusFS != nil {
@@ -1578,23 +1608,25 @@ func (s *Service) hashSourceBytes(ctx context.Context, corpusFS corpusfs.CorpusF
 // openFileFromOCRCache reads the precomputed OCR (or transcript) representation
 // for a binary document. The cache layout mirrors what
 // internal/ingest.Service.readOrComputeOCR / readOrComputeTranscript write:
-// <stateDir>/cache/ocr/<sha256-of-source-bytes>.md for OCR, and
-// <stateDir>/cache/transcribe/<sha256-of-source-bytes>*.txt for transcripts.
-// When no cache file exists (e.g. ingest is still running), the function
-// returns model.ErrOCRNotReady so callers can surface an actionable error
-// rather than fall back to raw bytes.
+// <stateDir>/cache/ocr/<key>.md for OCR, and
+// <stateDir>/cache/transcribe/<key>*.txt for transcripts. The <key> is the
+// identity-aware key ingest wrote — sha256(sha256(bytes)+"\x00"+identity) with the
+// active OCR/transcript derivation identity folded in (SPEC §8.6.7) — NOT a
+// bytes-only hash; see ocrCacheKeyForOpen. When no cache file exists (e.g. ingest
+// is still running), the function returns model.ErrOCRNotReady so callers can
+// surface an actionable error rather than fall back to raw bytes.
 func (s *Service) openFileFromOCRCache(ctx context.Context, corpusFS corpusfs.CorpusFS, stateDir, resolvedAbs, relPath string, secretPatterns []*regexp.Regexp, maxChars int) (string, bool, error) {
 	stateDir = strings.TrimSpace(stateDir)
 	if stateDir == "" {
 		stateDir = filepath.Join(".", ".dir2mcp")
 	}
 
-	hashHex, err := s.hashSourceBytes(ctx, corpusFS, resolvedAbs, relPath)
+	cacheKey, err := s.ocrCacheKeyForOpen(ctx, corpusFS, resolvedAbs, relPath)
 	if err != nil {
 		return "", false, err
 	}
 
-	candidates := openFileOCRCacheCandidates(stateDir, hashHex, relPath)
+	candidates := openFileOCRCacheCandidates(stateDir, cacheKey, relPath)
 	for _, candidate := range candidates {
 		data, readErr := os.ReadFile(candidate)
 		if readErr != nil {
@@ -1614,20 +1646,21 @@ func (s *Service) openFileFromOCRCache(ctx context.Context, corpusFS corpusfs.Co
 }
 
 // openFileOCRCacheCandidates returns the set of cache paths to consult, in
-// preference order, for a given source document. Audio transcripts are stored
+// preference order, for a given source document. cacheKey is the identity-aware
+// filename stem ingest wrote (ocrCacheKeyForOpen). Audio transcripts are stored
 // with an optional language suffix (or none), so we glob for any matching
 // file. PDFs use a single .md path.
-func openFileOCRCacheCandidates(stateDir, hashHex, relPath string) []string {
+func openFileOCRCacheCandidates(stateDir, cacheKey, relPath string) []string {
 	ext := strings.ToLower(filepath.Ext(relPath))
 	switch {
 	case ext == ".pdf" || isImageExt(ext):
 		// PDF and image extraction both write extracted markdown to cache/ocr.
-		return []string{filepath.Join(stateDir, "cache", "ocr", hashHex+".md")}
+		return []string{filepath.Join(stateDir, "cache", "ocr", cacheKey+".md")}
 	case isAudioExt(ext):
-		// transcripts are written as <hash>[<-lang>].txt; default-language
+		// transcripts are written as <key>[<-lang>].txt; default-language
 		// transcripts have no suffix, so the unsuffixed file is preferred.
-		out := []string{filepath.Join(stateDir, "cache", "transcribe", hashHex+".txt")}
-		matches, err := filepath.Glob(filepath.Join(stateDir, "cache", "transcribe", hashHex+"-*.txt"))
+		out := []string{filepath.Join(stateDir, "cache", "transcribe", cacheKey+".txt")}
+		matches, err := filepath.Glob(filepath.Join(stateDir, "cache", "transcribe", cacheKey+"-*.txt"))
 		if err == nil {
 			sort.Strings(matches)
 			out = append(out, matches...)
@@ -1636,6 +1669,91 @@ func openFileOCRCacheCandidates(stateDir, hashHex, relPath string) []string {
 	default:
 		return nil
 	}
+}
+
+// ocrSourceHashProvider is the OPTIONAL store capability that returns the EXACT
+// base content hash ingest folded into an OCR/transcript cache key — the
+// sha256-hex over the document's raw source bytes (ingest.ComputeContentHash),
+// NOT the sidecar-folded content_hash the store persists for the incremental gate
+// (§7.6). When a store can supply it, open_file derives the identity-aware cache
+// key WITHOUT a full object GET (issue #488 perf). A store that does not implement
+// it, or returns ok=false, transparently falls back to streaming+hashing the
+// source bytes, so correctness never depends on this optimization.
+type ocrSourceHashProvider interface {
+	OCRSourceContentHash(ctx context.Context, relPath string) (hash string, ok bool, err error)
+}
+
+// ocrCacheKeyForOpen derives the on-disk OCR/transcript cache filename stem for
+// relPath, reproducing the identity-aware key ingest wrote (SPEC §8.6.7). It
+// folds the ACTIVE OCR (pdf/image) or transcript (audio) derivation identity into
+// the base content hash exactly as internal/ingest.Service.ocrCacheKey /
+// transcriptCacheKey do, so open_file lands on ingest's cache entry instead of
+// missing every identity-scoped entry (issue #488). The base content hash is
+// taken from the store when it can report the already-known value (skipping a full
+// object GET); otherwise it is computed by streaming the source bytes.
+func (s *Service) ocrCacheKeyForOpen(ctx context.Context, corpusFS corpusfs.CorpusFS, resolvedAbs, relPath string) (string, error) {
+	s.metaMu.RLock()
+	ocrIdentity := s.ocrCacheIdentity
+	transcriptIdentity := s.transcriptCacheIdentity
+	store := s.store
+	s.metaMu.RUnlock()
+
+	identity := cacheIdentityForExt(relPath, ocrIdentity, transcriptIdentity)
+
+	contentHash, err := s.sourceContentHash(ctx, corpusFS, store, resolvedAbs, relPath)
+	if err != nil {
+		return "", err
+	}
+	return foldDerivationCacheKey(contentHash, identity), nil
+}
+
+// sourceContentHash returns the base content hash for relPath, preferring the
+// store's already-known value (ocrSourceHashProvider) so the identity-aware key
+// can be derived WITHOUT a full object GET (#488 perf). A store that lacks the
+// capability, reports ok=false, or errors falls back to streaming+hashing the
+// bytes — the optimization is best-effort and never changes the resulting key.
+func (s *Service) sourceContentHash(ctx context.Context, corpusFS corpusfs.CorpusFS, store model.Store, resolvedAbs, relPath string) (string, error) {
+	if provider, ok := store.(ocrSourceHashProvider); ok {
+		if hash, ok, err := provider.OCRSourceContentHash(ctx, relPath); err != nil {
+			s.logf("open_file: source-hash lookup for %q failed, hashing bytes: %v", relPath, err)
+		} else if ok && hash != "" {
+			return hash, nil
+		}
+	}
+	return s.hashSourceBytes(ctx, corpusFS, resolvedAbs, relPath)
+}
+
+// cacheIdentityForExt selects which active derivation identity governs relPath's
+// cache key: the OCR-extraction identity for PDF/image documents and the
+// transcript identity for audio, matching ingest's per-representation keying.
+// Any other extension (no OCR/transcript representation) folds in no identity.
+func cacheIdentityForExt(relPath, ocrIdentity, transcriptIdentity string) string {
+	ext := strings.ToLower(filepath.Ext(strings.TrimSpace(relPath)))
+	switch {
+	case ext == ".pdf" || isImageExt(ext):
+		return ocrIdentity
+	case isAudioExt(ext):
+		return transcriptIdentity
+	default:
+		return ""
+	}
+}
+
+// foldDerivationCacheKey reproduces the identity-folding in
+// internal/ingest.Service.ocrCacheKey / transcriptCacheKey
+// (internal/ingest/derivation.go): with a non-empty active derivation identity it
+// returns sha256-hex(contentHash + "\x00" + identity), folding the OCR/STT
+// provider+model identity into the key so open_file lands on the same cache entry
+// ingest wrote (SPEC §8.6.7). An empty identity — no extractor/transcriber
+// configured, or an unwired retriever — preserves the historical bytes-only key,
+// which is exactly what ingest writes in that case.
+func foldDerivationCacheKey(contentHash, identity string) string {
+	if identity == "" {
+		return contentHash
+	}
+	combined := strings.Join([]string{contentHash, identity}, "\x00")
+	sum := sha256.Sum256([]byte(combined))
+	return hex.EncodeToString(sum[:])
 }
 
 func (s *Service) openFileFromMetadata(normalizedRel string, span model.Span, maxChars int, secretPatterns []*regexp.Regexp, kind string) (content string, truncated bool, handled bool, err error) {

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -783,6 +783,13 @@ func (s *Service) SetStateDir(stateDir string) {
 // (not a store-recorded one, which can carry a differing model_version) is what
 // keeps this lookup byte-identical to ingest's writer.
 func (s *Service) SetDerivationCacheIdentities(ocrIdentity, transcriptIdentity string) {
+	// Trim to stay byte-identical to ingest's canonical identity, whose fields are
+	// each TrimSpace'd by derivationIdentity (internal/ingest/derivation.go); any
+	// stray leading/trailing whitespace here would silently force a cache miss.
+	// Trimming ingest's already-trimmed output is a no-op, matching sibling setters
+	// (SetStateDir/SetProtocolVersion).
+	ocrIdentity = strings.TrimSpace(ocrIdentity)
+	transcriptIdentity = strings.TrimSpace(transcriptIdentity)
 	s.metaMu.Lock()
 	s.ocrCacheIdentity = ocrIdentity
 	s.transcriptCacheIdentity = transcriptIdentity
@@ -1716,11 +1723,35 @@ func (s *Service) sourceContentHash(ctx context.Context, corpusFS corpusfs.Corpu
 	if provider, ok := store.(ocrSourceHashProvider); ok {
 		if hash, ok, err := provider.OCRSourceContentHash(ctx, relPath); err != nil {
 			s.logf("open_file: source-hash lookup for %q failed, hashing bytes: %v", relPath, err)
-		} else if ok && hash != "" {
+		} else if ok && isSHA256Hex(hash) {
 			return hash, nil
+		} else if ok && hash != "" {
+			// The store reported a value that is not a canonical sha256 hex digest
+			// (wrong length / non-hex / uppercase). Trusting it would fold a bogus
+			// base hash into the cache key, deterministically missing the entry
+			// ingest wrote and regressing open_file to OCR_NOT_READY. Fall back to
+			// hashing the bytes so the key stays byte-identical to ingest's.
+			s.logf("open_file: store source-hash for %q is not sha256-hex, hashing bytes", relPath)
 		}
 	}
 	return s.hashSourceBytes(ctx, corpusFS, resolvedAbs, relPath)
+}
+
+// isSHA256Hex reports whether s is exactly 64 lowercase hexadecimal characters —
+// the canonical form of a sha256 digest ingest folds into the derivation cache
+// key. A store-provided base hash MUST pass this before it is trusted; anything
+// else falls back to hashing the source bytes so the key stays byte-identical.
+func isSHA256Hex(s string) bool {
+	if len(s) != 64 {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
 }
 
 // cacheIdentityForExt selects which active derivation identity governs relPath's

--- a/tests/retrieval/open_file_ocr_cache_key_test.go
+++ b/tests/retrieval/open_file_ocr_cache_key_test.go
@@ -25,10 +25,12 @@ import (
 // files below are written at ingest's REAL key (ing.OCRCacheKey /
 // ing.ReadOrComputeTranscript), so a hit proves the two keys agree.
 
-// fakeKeyStore is a minimal model.Store. When baseHash is non-empty it also
-// implements the optional ocrSourceHashProvider capability (OCRSourceContentHash),
-// letting open_file derive the identity-aware key WITHOUT a full object GET (the
-// #488 perf path).
+// fakeKeyStore is a minimal model.Store that always implements the optional
+// ocrSourceHashProvider capability (OCRSourceContentHash is defined below). It
+// returns ok=true — supplying baseHash — only when baseHash is non-empty, letting
+// open_file derive the identity-aware key WITHOUT a full object GET (the #488 perf
+// path); with an empty baseHash it reports ok=false so open_file falls back to
+// hashing the bytes.
 type fakeKeyStore struct {
 	baseHash string
 }
@@ -43,7 +45,10 @@ func (f *fakeKeyStore) ListFiles(context.Context, string, string, int, int) ([]m
 }
 func (f *fakeKeyStore) Close() error { return nil }
 
-// OCRSourceContentHash is present only when baseHash is set (the perf capability).
+// OCRSourceContentHash is ALWAYS defined, so *fakeKeyStore always satisfies the
+// optional ocrSourceHashProvider capability. It signals whether a base hash is
+// actually available via its ok return (false when baseHash is unset), not by the
+// method's presence.
 func (f *fakeKeyStore) OCRSourceContentHash(_ context.Context, _ string) (string, bool, error) {
 	if f.baseHash == "" {
 		return "", false, nil
@@ -263,6 +268,87 @@ func TestOpenFile_OCRCacheKey_SkipsObjectGETWhenStoreHasHash(t *testing.T) {
 	}
 	if fs.opens != 0 {
 		t.Fatalf("expected zero object GETs when the store supplies the base hash, got %d", fs.opens)
+	}
+}
+
+// TestOpenFile_OCRCacheKey_WhitespacePaddedIdentityHits locks the FIX-1 trim:
+// SetDerivationCacheIdentities must TrimSpace its args so a caller that passes a
+// whitespace-padded identity still reconstructs ingest's byte-identical key and
+// HITS the cache, instead of silently missing on the stray whitespace.
+func TestOpenFile_OCRCacheKey_WhitespacePaddedIdentityHits(t *testing.T) {
+	root := t.TempDir()
+	stateDir := filepath.Join(root, ".dir2mcp")
+
+	pdfBytes := []byte("%PDF-1.4 whitespace body")
+	fs := &fakeCorpusFS{objects: map[string][]byte{"docs/w.pdf": pdfBytes}}
+
+	ocrText := "# Padded identity OCR text"
+	cacheDir := filepath.Join(stateDir, "cache", "ocr")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatalf("mkdir ocr cache: %v", err)
+	}
+	key := ingestOCRCacheKey(t, stateDir, pdfBytes)
+	if err := os.WriteFile(filepath.Join(cacheDir, key+".md"), []byte(ocrText), 0o644); err != nil {
+		t.Fatalf("write ocr cache: %v", err)
+	}
+
+	svc := retrieval.NewService(nil, nil, nil, nil)
+	svc.SetRootDir(root)
+	svc.SetStateDir(stateDir)
+	svc.SetCorpusFS(fs)
+	// Same active OCR identity as the hit case, but padded with leading/trailing
+	// whitespace — the setter must trim it to stay byte-identical to ingest's key.
+	svc.SetDerivationCacheIdentities("  ocr|docling|||\n", "\t")
+
+	out, err := svc.OpenFile(context.Background(), "docs/w.pdf", model.Span{}, 20000)
+	if err != nil {
+		t.Fatalf("OpenFile with whitespace-padded identity returned err: %v", err)
+	}
+	if out != ocrText {
+		t.Fatalf("expected cached OCR text with padded identity, got %q", out)
+	}
+}
+
+// TestOpenFile_OCRCacheKey_MalformedStoreHashFallsBack locks the FIX-2 validation:
+// a store that reports a non-sha256 base hash (wrong shape) must NOT be trusted —
+// open_file falls back to hashing the source bytes (a real object GET) and still
+// reconstructs ingest's key and HITS, instead of folding the bogus hash and
+// regressing to OCR_NOT_READY.
+func TestOpenFile_OCRCacheKey_MalformedStoreHashFallsBack(t *testing.T) {
+	root := t.TempDir()
+	stateDir := filepath.Join(root, ".dir2mcp")
+
+	pdfBytes := []byte("%PDF-1.4 malformed-hash body")
+	fs := &countingCorpusFS{objects: map[string][]byte{"docs/m.pdf": pdfBytes}}
+
+	ocrText := "# Fallback OCR text"
+	cacheDir := filepath.Join(stateDir, "cache", "ocr")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatalf("mkdir ocr cache: %v", err)
+	}
+	key := ingestOCRCacheKey(t, stateDir, pdfBytes)
+	if err := os.WriteFile(filepath.Join(cacheDir, key+".md"), []byte(ocrText), 0o644); err != nil {
+		t.Fatalf("write ocr cache: %v", err)
+	}
+
+	// The store reports a bogus, non-sha256 base hash: open_file must reject its
+	// shape and hash the bytes instead.
+	store := &fakeKeyStore{baseHash: "not-a-valid-sha256-hash"}
+	svc := retrieval.NewService(store, nil, nil, nil)
+	svc.SetRootDir(root)
+	svc.SetStateDir(stateDir)
+	svc.SetCorpusFS(fs)
+	svc.SetDerivationCacheIdentities("ocr|docling|||", "")
+
+	out, err := svc.OpenFile(context.Background(), "docs/m.pdf", model.Span{}, 20000)
+	if err != nil {
+		t.Fatalf("OpenFile (malformed store-hash fallback) returned err: %v", err)
+	}
+	if out != ocrText {
+		t.Fatalf("expected cached OCR text via byte-hash fallback, got %q", out)
+	}
+	if fs.opens == 0 {
+		t.Fatalf("expected a byte-hashing object GET when the store hash is malformed, got %d", fs.opens)
 	}
 }
 

--- a/tests/retrieval/open_file_ocr_cache_key_test.go
+++ b/tests/retrieval/open_file_ocr_cache_key_test.go
@@ -1,0 +1,276 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/corpusfs"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
+)
+
+// These tests lock the fix for issue #488: open_file's OCR/transcript cache
+// lookup must key the cache the SAME identity-aware way ingest's writer does
+// (SPEC §8.6.7). Ingest folds the active OCR/STT derivation identity into the
+// cache key (ingest.Service.ocrCacheKey / transcriptCacheKey); retrieval used to
+// key on the source bytes alone, so on every real docling/mistral/STT corpus the
+// lookup MISSED the entry ingest wrote and returned OCR_NOT_READY. The cache
+// files below are written at ingest's REAL key (ing.OCRCacheKey /
+// ing.ReadOrComputeTranscript), so a hit proves the two keys agree.
+
+// fakeKeyStore is a minimal model.Store. When baseHash is non-empty it also
+// implements the optional ocrSourceHashProvider capability (OCRSourceContentHash),
+// letting open_file derive the identity-aware key WITHOUT a full object GET (the
+// #488 perf path).
+type fakeKeyStore struct {
+	baseHash string
+}
+
+func (f *fakeKeyStore) Init(context.Context) error                           { return nil }
+func (f *fakeKeyStore) UpsertDocument(context.Context, model.Document) error { return nil }
+func (f *fakeKeyStore) GetDocumentByPath(context.Context, string) (model.Document, error) {
+	return model.Document{}, nil
+}
+func (f *fakeKeyStore) ListFiles(context.Context, string, string, int, int) ([]model.Document, int64, error) {
+	return nil, 0, nil
+}
+func (f *fakeKeyStore) Close() error { return nil }
+
+// OCRSourceContentHash is present only when baseHash is set (the perf capability).
+func (f *fakeKeyStore) OCRSourceContentHash(_ context.Context, _ string) (string, bool, error) {
+	if f.baseHash == "" {
+		return "", false, nil
+	}
+	return f.baseHash, true, nil
+}
+
+// countingCorpusFS wraps an object map and counts Open calls, so a test can
+// assert open_file skipped the full object GET.
+type countingCorpusFS struct {
+	objects map[string][]byte
+	opens   int
+}
+
+func (c *countingCorpusFS) Open(ctx context.Context, relPath string) (io.ReadSeekCloser, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	c.opens++
+	data, ok := c.objects[relPath]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	return readSeekCloser{bytes.NewReader(data)}, nil
+}
+
+func (c *countingCorpusFS) Walk(context.Context, string, corpusfs.Options) ([]corpusfs.DiscoveredFile, error) {
+	return nil, errors.New("countingCorpusFS: Walk not implemented")
+}
+
+func (c *countingCorpusFS) Localize(context.Context, string) (string, func(), error) {
+	return "", func() {}, errors.New("countingCorpusFS: Localize not implemented")
+}
+
+// ingestOCRCacheKey builds an ingest.Service with the docling extractor and
+// returns the on-disk OCR cache key it would write for content — the
+// authoritative, identity-aware key retrieval must reproduce.
+func ingestOCRCacheKey(t *testing.T, stateDir string, content []byte) string {
+	t.Helper()
+	cfg := config.Config{RootDir: t.TempDir(), StateDir: stateDir, STTProvider: "off"}
+	ing, err := ingest.NewService(cfg, &fakeKeyStore{})
+	if err != nil {
+		t.Fatalf("ingest.NewService: %v", err)
+	}
+	ing.SetDocumentExtractor(ingest.NewDoclingExtractor("docling"))
+	return ing.OCRCacheKey(content)
+}
+
+// TestOpenFile_OCRCacheKey_IdentityAwareHit is the core #488 parity case: a PDF's
+// OCR text, written by ingest at its identity-folded key, is FOUND by open_file
+// once the active OCR identity is plumbed in — and is MISSED with the old
+// bytes-only key (no identity), reproducing the bug.
+func TestOpenFile_OCRCacheKey_IdentityAwareHit(t *testing.T) {
+	root := t.TempDir()
+	stateDir := filepath.Join(root, ".dir2mcp")
+
+	pdfBytes := []byte("%PDF-1.4 identity-aware body")
+	fs := &fakeCorpusFS{objects: map[string][]byte{"docs/a.pdf": pdfBytes}}
+
+	ocrText := "# Extracted\n\nARRANGEMENT OF SECTIONS\n\n1. Short title."
+	cacheDir := filepath.Join(stateDir, "cache", "ocr")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatalf("mkdir ocr cache: %v", err)
+	}
+	key := ingestOCRCacheKey(t, stateDir, pdfBytes)
+	if err := os.WriteFile(filepath.Join(cacheDir, key+".md"), []byte(ocrText), 0o644); err != nil {
+		t.Fatalf("write ocr cache: %v", err)
+	}
+
+	// Without the active identity, retrieval keys on the bytes alone and MISSES
+	// the identity-folded entry ingest wrote — the pre-fix bug.
+	miss := retrieval.NewService(nil, nil, nil, nil)
+	miss.SetRootDir(root)
+	miss.SetStateDir(stateDir)
+	miss.SetCorpusFS(fs)
+	if _, err := miss.OpenFile(context.Background(), "docs/a.pdf", model.Span{}, 20000); !errors.Is(err, model.ErrOCRNotReady) {
+		t.Fatalf("bytes-only lookup should miss the identity-folded entry, got err=%v", err)
+	}
+
+	// With the active OCR identity plumbed in (docling ⇒ provider-only identity,
+	// SPEC §8.6.7), retrieval reconstructs ingest's key and HITS.
+	svc := retrieval.NewService(nil, nil, nil, nil)
+	svc.SetRootDir(root)
+	svc.SetStateDir(stateDir)
+	svc.SetCorpusFS(fs)
+	svc.SetDerivationCacheIdentities("ocr|docling|||", "")
+
+	out, err := svc.OpenFile(context.Background(), "docs/a.pdf", model.Span{}, 20000)
+	if err != nil {
+		t.Fatalf("OpenFile with active OCR identity returned err: %v", err)
+	}
+	if out != ocrText {
+		t.Fatalf("expected cached OCR text, got %q", out)
+	}
+}
+
+// TestOpenFile_OCRCacheKey_DifferentIdentityMisses locks the no-cross-identity
+// bleed: an entry written under one OCR identity must NOT be returned when a
+// different identity is active (a model/provider swap the re-ingest gate treats
+// as stale).
+func TestOpenFile_OCRCacheKey_DifferentIdentityMisses(t *testing.T) {
+	root := t.TempDir()
+	stateDir := filepath.Join(root, ".dir2mcp")
+
+	pdfBytes := []byte("%PDF-1.4 mismatch body")
+	fs := &fakeCorpusFS{objects: map[string][]byte{"docs/b.pdf": pdfBytes}}
+
+	cacheDir := filepath.Join(stateDir, "cache", "ocr")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatalf("mkdir ocr cache: %v", err)
+	}
+	key := ingestOCRCacheKey(t, stateDir, pdfBytes)
+	if err := os.WriteFile(filepath.Join(cacheDir, key+".md"), []byte("# docling output"), 0o644); err != nil {
+		t.Fatalf("write ocr cache: %v", err)
+	}
+
+	svc := retrieval.NewService(nil, nil, nil, nil)
+	svc.SetRootDir(root)
+	svc.SetStateDir(stateDir)
+	svc.SetCorpusFS(fs)
+	// A DIFFERENT active identity (mistral, not docling) must not read docling's
+	// cached output.
+	svc.SetDerivationCacheIdentities("ocr|mistral|pixtral||", "")
+
+	if _, err := svc.OpenFile(context.Background(), "docs/b.pdf", model.Span{}, 20000); !errors.Is(err, model.ErrOCRNotReady) {
+		t.Fatalf("different-identity lookup must miss, got err=%v", err)
+	}
+}
+
+// TestOpenFile_TranscriptCacheKey_IdentityAwareHit is the transcript analogue:
+// ingest transcribes an audio file, writing the transcript at its STT
+// identity-folded key (incl. the language suffix); open_file returns it once the
+// active transcript identity is plumbed in.
+func TestOpenFile_TranscriptCacheKey_IdentityAwareHit(t *testing.T) {
+	root := t.TempDir()
+	stateDir := filepath.Join(root, ".dir2mcp")
+
+	audioBytes := []byte("fake-audio-bytes")
+	fs := &fakeCorpusFS{objects: map[string][]byte{"media/talk.mp3": audioBytes}}
+
+	const transcript = "[00:00] hello from the cached transcript"
+
+	// Drive the real ingest transcript pipeline so the cache file lands at
+	// ingest's authoritative identity-aware key.
+	cfg := config.Config{RootDir: root, StateDir: stateDir, STTProvider: "off"}
+	ing, err := ingest.NewService(cfg, &fakeKeyStore{})
+	if err != nil {
+		t.Fatalf("ingest.NewService: %v", err)
+	}
+	ing.SetTranscriber(&fakeTranscriber{text: transcript})
+	ing.SetSTTIdentity("whisper", "whisper-large-v3")
+	ing.SetTranscriptLanguage("en")
+	doc := model.Document{RelPath: "media/talk.mp3"}
+	if _, err := ing.ReadOrComputeTranscript(context.Background(), doc, audioBytes, "en"); err != nil {
+		t.Fatalf("ReadOrComputeTranscript: %v", err)
+	}
+
+	svc := retrieval.NewService(nil, nil, nil, nil)
+	svc.SetRootDir(root)
+	svc.SetStateDir(stateDir)
+	svc.SetCorpusFS(fs)
+	svc.SetDerivationCacheIdentities("", "stt|whisper|whisper-large-v3||en")
+
+	out, err := svc.OpenFile(context.Background(), "media/talk.mp3", model.Span{}, 20000)
+	if err != nil {
+		t.Fatalf("OpenFile with active transcript identity returned err: %v", err)
+	}
+	if out != transcript {
+		t.Fatalf("expected cached transcript, got %q", out)
+	}
+
+	// A different STT identity must miss the cached transcript.
+	miss := retrieval.NewService(nil, nil, nil, nil)
+	miss.SetRootDir(root)
+	miss.SetStateDir(stateDir)
+	miss.SetCorpusFS(fs)
+	miss.SetDerivationCacheIdentities("", "stt|whisper|whisper-large-v2||en")
+	if _, err := miss.OpenFile(context.Background(), "media/talk.mp3", model.Span{}, 20000); !errors.Is(err, model.ErrOCRNotReady) {
+		t.Fatalf("different STT identity must miss, got err=%v", err)
+	}
+}
+
+// TestOpenFile_OCRCacheKey_SkipsObjectGETWhenStoreHasHash locks the #488 perf
+// path: when the store can report the base content hash (ocrSourceHashProvider),
+// open_file derives the identity-aware key WITHOUT streaming the object — zero
+// CorpusFS Open calls — and still returns the cached text.
+func TestOpenFile_OCRCacheKey_SkipsObjectGETWhenStoreHasHash(t *testing.T) {
+	root := t.TempDir()
+	stateDir := filepath.Join(root, ".dir2mcp")
+
+	pdfBytes := []byte("%PDF-1.4 perf body")
+	fs := &countingCorpusFS{objects: map[string][]byte{"docs/c.pdf": pdfBytes}}
+
+	ocrText := "# No-GET OCR text"
+	cacheDir := filepath.Join(stateDir, "cache", "ocr")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatalf("mkdir ocr cache: %v", err)
+	}
+	key := ingestOCRCacheKey(t, stateDir, pdfBytes)
+	if err := os.WriteFile(filepath.Join(cacheDir, key+".md"), []byte(ocrText), 0o644); err != nil {
+		t.Fatalf("write ocr cache: %v", err)
+	}
+
+	store := &fakeKeyStore{baseHash: ingest.ComputeContentHash(pdfBytes)}
+	svc := retrieval.NewService(store, nil, nil, nil)
+	svc.SetRootDir(root)
+	svc.SetStateDir(stateDir)
+	svc.SetCorpusFS(fs)
+	svc.SetDerivationCacheIdentities("ocr|docling|||", "")
+
+	out, err := svc.OpenFile(context.Background(), "docs/c.pdf", model.Span{}, 20000)
+	if err != nil {
+		t.Fatalf("OpenFile (store-hash path) returned err: %v", err)
+	}
+	if out != ocrText {
+		t.Fatalf("expected cached OCR text, got %q", out)
+	}
+	if fs.opens != 0 {
+		t.Fatalf("expected zero object GETs when the store supplies the base hash, got %d", fs.opens)
+	}
+}
+
+// fakeTranscriber is a minimal model.Transcriber returning a fixed transcript.
+type fakeTranscriber struct {
+	text string
+}
+
+func (f *fakeTranscriber) Transcribe(context.Context, string, []byte) (string, error) {
+	return f.text, nil
+}


### PR DESCRIPTION
Closes #488

## Problem
`open_file`'s OCR/transcript cache lookup keyed the cache on a **bytes-only** `sha256(source-bytes)`, but ingest writes those entries under an **identity-folded** key (SPEC §8.6.7):

```
sha256( sha256(bytes) + "\x00" + activeOCR/TranscriptIdentity )
```

The bytes-only key is only ever written when **no** extractor/STT is configured. So on every real docling/mistral/STT corpus (local *and* S3), retrieval's bytes-only lookup **missed the entry ingest wrote and returned `OCR_NOT_READY`** — plus a full object GET per call just to hash the bytes. Pre-existing, orthogonal to #479 (verified identical in the pre-#479 tree); it went unnoticed because the release-smoke gate exercises only `page=`/`time=` spans, not the OCR-cache text sub-path.

## Fix (scoped to `internal/retrieval/service.go`)
- **Correctness — key parity with ingest.** New `SetDerivationCacheIdentities(ocrIdentity, transcriptIdentity)` plumbs the ingest pipeline's **active** OCR and transcript derivation identities into open_file's lookup. `ocrCacheKeyForOpen` folds them into the key **exactly** as `ingest.Service.ocrCacheKey` / `transcriptCacheKey` do (shared `\x00`-joined sha256 form), so the lookup lands on ingest's entry. Passing the **active** identity (not a store-recorded one, which can carry a differing `model_version`) is what keeps the two byte-identical. An empty identity preserves the historical **bytes-only** key — exactly what ingest writes with no extractor/transcriber — so the no-OCR and local/NFS paths are unchanged.
- **Perf — no redundant object GET.** When the store can report the already-known base content hash (optional `ocrSourceHashProvider` capability), the identity-aware key is derived **without** streaming the object. A store that lacks the capability, returns `ok=false`, or errors transparently falls back to streaming+hashing the bytes, so correctness never depends on the optimization.

## Tests (`tests/retrieval/open_file_ocr_cache_key_test.go`)
Drive ingest's **real** writers so a hit proves retrieval's reconstructed key matches ingest's:
- OCR (docling, provider-only identity): entry written at `ing.OCRCacheKey(content)` is **found**; with no identity (bytes-only) it **misses** — reproducing the bug.
- Different OCR identity (mistral) correctly **misses** docling's entry.
- Transcript: `ing.ReadOrComputeTranscript` writes at the STT identity-folded key (incl. language suffix); open_file **finds** it with the matching transcript identity, **misses** with a different one.
- Perf: when the store supplies the base hash, open_file returns the cached text with **zero** CorpusFS `Open` calls.

## Note on wiring
This PR lands the mechanism + parity tests in the retriever. Connecting the setter to the live engine (passing ingest's active identities at construction in `internal/cli`) is a one-line follow-up in the broader retrieval wave (#409/#422), deliberately kept out of this narrowly-scoped cache-key PR. Until wired, the identities default empty ⇒ pre-existing bytes-only behavior (no regression).

## Validation
`gofmt -l` clean · `go build ./...` · `go vet ./...` · `make cyclo` (≤15) · `golangci-lint run` (0 issues) · `go test ./internal/retrieval/... ./tests/retrieval/...` all pass.