### PR TITLE
fix(ingest): withhold archive content_hash until members extracted (#502)

### DIFF
--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -1154,6 +1154,18 @@ func (s *Service) trySkipUnchangedRemoteDocument(ctx context.Context, f Discover
 	if !etagUnchanged(f, existing, forceReindex) {
 		return false, nil
 	}
+	// An empty recorded content_hash means the document was never durably
+	// finalized — a withheld #402/#502 done-marker left blank by a crash before
+	// the representation-commit (or, for an archive container, before member
+	// extraction completed). The ETag+size may match, but the object still needs
+	// processing, so do NOT take the fast-skip path: fall through to the full
+	// read/hash path which re-runs the withheld work. A fully-indexed document
+	// always carries a non-empty content_hash, so the normal S3 fast-path is
+	// unaffected. This is what makes the withhold gate effective for S3 archives
+	// (the ETag skip runs before the content_hash recompute).
+	if strings.TrimSpace(existing.ContentHash) == "" {
+		return false, nil
+	}
 	// A media object's own ETag does not reflect changes to an adjacent subtitle
 	// sidecar (.srt/.vtt/.ttml): buildDocumentWithContent folds the sidecar
 	// fingerprint into ContentHash, but the ETag fast-path runs before that
@@ -1613,7 +1625,8 @@ func (s *Service) readDocumentContent(ctx context.Context, relPath string) ([]by
 // markMissingAsDeleted does not tombstone them.
 func (s *Service) handleArchiveDocument(ctx context.Context, doc model.Document, f DiscoveredFile, secretPatterns []*regexp.Regexp, forceReindex bool, seen map[string]struct{}, needsProcessing bool, finalContentHash string) error {
 	if needsProcessing {
-		if err := s.processArchiveMembers(ctx, f, secretPatterns, forceReindex, seen); err != nil {
+		complete, err := s.processArchiveMembers(ctx, f, secretPatterns, forceReindex, seen)
+		if err != nil {
 			if !errors.Is(err, errUnsupportedArchiveFormat) {
 				// Context cancellation (shutdown mid-archive) and any other
 				// non-sentinel error must propagate WITHOUT persisting a durable
@@ -1655,11 +1668,23 @@ func (s *Service) handleArchiveDocument(ctx context.Context, doc model.Document,
 			s.addSkipped(-1)
 			return fmt.Errorf("process archive members %s: %w", f.RelPath, err)
 		}
-		// #502: member extraction completed — stamp the withheld content_hash done
-		// marker now. The initial upsert blanked it, so a crash anywhere between that
-		// upsert and this point leaves the container with an empty hash and the next
-		// scan re-extracts instead of skipping on a premature marker. The container
-		// persists as status="skipped", so finalize preserves that healthy status.
+		if !complete {
+			// #502 (member granularity): a member failed, or a localize/extraction
+			// failure left the archive "skipped". Extraction did not FULLY complete,
+			// so leave the container's content_hash withheld (blank, from the initial
+			// upsert) — the next incremental scan re-extracts and retries the failed
+			// members. The members that DID succeed this run are already ingested
+			// (#398 best-effort); the only consequence is a re-extraction next scan
+			// until every member is durably processed. Stamping the done marker here
+			// would permanently skip the failed members on subsequent scans.
+			return nil
+		}
+		// #502: member extraction FULLY completed — stamp the withheld content_hash
+		// done marker now. The initial upsert blanked it, so a crash anywhere between
+		// that upsert and this point leaves the container with an empty hash and the
+		// next scan re-extracts instead of skipping on a premature marker. The
+		// container persists as status="skipped", so finalize preserves that healthy
+		// status.
 		if err := s.finalizeContentHashForStatus(ctx, &doc, finalContentHash, "skipped"); err != nil {
 			return err
 		}
@@ -1690,15 +1715,31 @@ func (s *Service) archiveMaxTotalBytesEff() int64 {
 
 // processArchiveMembers extracts members from an archive and ingests each one
 // as an independent document. One bad member is logged and skipped without
-// aborting the rest.
-func (s *Service) processArchiveMembers(ctx context.Context, f DiscoveredFile, secretPatterns []*regexp.Regexp, forceReindex bool, seen map[string]struct{}) error {
+// aborting the rest (#398 best-effort).
+//
+// It returns complete=true only when extraction FULLY succeeded: the archive
+// localized, extracted without error, and every member was durably processed.
+// complete=false signals the caller to leave the container's content_hash
+// withheld (blank) so the next incremental scan re-extracts and retries — the
+// members that DID succeed this run are still ingested, but a container whose
+// members did not all land must not be stamped "done", or the failed members
+// would be permanently skipped on subsequent scans (the #502 crash window, at
+// member granularity). Tradeoff: a partially-failing archive is re-extracted on
+// every scan until all its members succeed (successful members are cheap cache
+// hits; only the failed ones do real work). A non-nil error is a hard per-archive
+// failure (unsupported format sentinel or context cancellation) the caller
+// persists/propagates separately; complete is meaningless when err != nil.
+func (s *Service) processArchiveMembers(ctx context.Context, f DiscoveredFile, secretPatterns []*regexp.Regexp, forceReindex bool, seen map[string]struct{}) (complete bool, err error) {
 	// Archive readers need a real filesystem path. Localize returns the in-root
 	// path for a local corpus (no-op cleanup) or a temp download for an object
 	// store, so this works uniformly across backends.
 	localPath, cleanup, err := s.corpusFS().Localize(ctx, f.RelPath)
 	if err != nil {
 		s.getLogger().Printf("archive localize %s: %v", f.RelPath, err)
-		return nil // localize failure is non-fatal; archive stays "skipped"
+		// localize failure is non-fatal but leaves extraction incomplete; the
+		// archive stays "skipped" and its content_hash must not be finalized so
+		// the next scan retries.
+		return false, nil
 	}
 	defer cleanup()
 	members, truncated, err := extractArchiveMembers(localPath, f.RelPath, s.archiveMaxMembersEff(), s.archiveMaxTotalBytesEff())
@@ -1709,10 +1750,12 @@ func (s *Service) processArchiveMembers(ctx context.Context, f DiscoveredFile, s
 			// known but unsearchable, with zero diagnostics. Return the error so the
 			// caller records the archive as status="error" and counts it, making the
 			// gap visible and retriable instead of vanishing.
-			return fmt.Errorf("unsupported archive format for %s: %w", f.RelPath, err)
+			return false, fmt.Errorf("unsupported archive format for %s: %w", f.RelPath, err)
 		}
 		s.getLogger().Printf("archive extract %s: %v", f.RelPath, err)
-		return nil // corrupt/other extraction failure is non-fatal; archive stays "skipped"
+		// corrupt/other extraction failure is non-fatal; archive stays "skipped"
+		// and its content_hash stays withheld so the next scan retries.
+		return false, nil
 	}
 	if truncated {
 		// #408 decompression-bomb guard: extraction stopped once the archive hit
@@ -1724,19 +1767,25 @@ func (s *Service) processArchiveMembers(ctx context.Context, f DiscoveredFile, s
 			f.RelPath, s.archiveMaxMembersEff(), s.archiveMaxTotalBytesEff(), len(members),
 		)
 	}
+	allMembersOK := true
 	for _, m := range members {
 		if err := ctx.Err(); err != nil {
-			return err
+			return false, err
 		}
 		if err := s.processDocumentFromContent(ctx, m.RelPath, m.Content, f.MTimeUnix, secretPatterns, forceReindex); err != nil {
 			s.getLogger().Printf("archive member %s: %v", m.RelPath, err)
-			// continue with next member
+			allMembersOK = false // extraction did not fully complete; retry next scan
+			// continue with next member (#398 best-effort)
 		}
 		if seen != nil {
 			seen[m.RelPath] = struct{}{}
 		}
 	}
-	return nil
+	// Truncation (#408) is a deliberate, deterministic cap — the dropped members
+	// can never be recovered by re-extraction, so it does NOT withhold the marker
+	// (that would re-extract on every scan forever with no benefit). Only genuine
+	// per-member failures leave the archive incomplete.
+	return allMembersOK, nil
 }
 
 // retainArchiveMembers adds all existing members of an unchanged archive to

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -1297,6 +1297,10 @@ func (s *Service) processDocument(ctx context.Context, f DiscoveredFile, secretP
 
 	needsProcessing := s.resolveNeedsProcessing(ctx, existingDoc, doc, forceReindex)
 	finalContentHash, willGenerateReps := withholdContentHash(&doc, needsProcessing)
+	// #502: also withhold the marker for an archive container this run will
+	// (re)extract; finalContentHash still carries the original hash for the deferred
+	// finalize (withholdContentHash captured it before this blank).
+	withholdArchiveContentHash(&doc, needsProcessing)
 
 	if err := s.store.UpsertDocument(ctx, doc); err != nil {
 		return fmt.Errorf("upsert document: %w", err)
@@ -1318,7 +1322,7 @@ func (s *Service) processDocument(ctx context.Context, f DiscoveredFile, secretP
 	// The archive document itself remains "skipped" (no direct text content).
 	if doc.DocType == "archive" {
 		s.creditIndexed(indexedPending)
-		return s.handleArchiveDocument(ctx, doc, f, secretPatterns, forceReindex, seen, needsProcessing)
+		return s.handleArchiveDocument(ctx, doc, f, secretPatterns, forceReindex, seen, needsProcessing, finalContentHash)
 	}
 
 	if !needsProcessing || doc.Status != "ok" {
@@ -1379,6 +1383,21 @@ func withholdContentHash(doc *model.Document, needsProcessing bool) (finalConten
 	return finalContentHash, willGenerateReps
 }
 
+// withholdArchiveContentHash withholds the content_hash done marker for an archive
+// container this run will (re)extract (#502). withholdContentHash does not cover
+// archives — they persist as status="skipped", not "ok" — but they still use
+// content_hash as the incremental gate for whether member extraction re-runs.
+// Blanking it here (and stamping it only after processArchiveMembers completes)
+// closes the same crash window #402/#485 closed for the representation-commit path,
+// on the archive-extraction path. It is a no-op for non-archives and for archives
+// this run will not re-extract. Kept separate from processDocument to hold that
+// method within the cyclomatic-complexity budget.
+func withholdArchiveContentHash(doc *model.Document, needsProcessing bool) {
+	if needsProcessing && doc.DocType == "archive" {
+		doc.ContentHash = ""
+	}
+}
+
 // finalizeIfGenerated stamps the withheld #402 done marker via finalizeContentHash
 // when this run generated representations for doc, and is a no-op otherwise. Split
 // out so processDocument/processDocumentFromContent stay within the cyclomatic
@@ -1410,6 +1429,16 @@ func (s *Service) finalizeIfGenerated(ctx context.Context, doc *model.Document, 
 // columns) after the #413 guard; not-found → recreate the row from doc (there is
 // no current row whose columns must be preserved); store error → propagate.
 func (s *Service) finalizeContentHash(ctx context.Context, doc *model.Document, contentHash string) error {
+	return s.finalizeContentHashForStatus(ctx, doc, contentHash, "ok")
+}
+
+// finalizeContentHashForStatus is finalizeContentHash generalized over the
+// document's healthy "done" status. The representation-commit path finalizes an
+// "ok" document; the archive-extraction path (#502) finalizes a container that
+// persists as status="skipped". healthyStatus is the status the freshly re-read
+// row must still be in for the withheld marker to be stamped — the #413 guard
+// that never resurrects an out-of-band status="error" into a done state.
+func (s *Service) finalizeContentHashForStatus(ctx context.Context, doc *model.Document, contentHash, healthyStatus string) error {
 	current, err := s.store.GetDocumentByPath(ctx, doc.RelPath)
 	if err != nil {
 		if !isNotFoundError(err) {
@@ -1424,9 +1453,10 @@ func (s *Service) finalizeContentHash(ctx context.Context, doc *model.Document, 
 		}
 		return nil
 	}
-	// #413 guard: a non-fatal per-representation failure may have persisted
-	// status="error" out-of-band; never resurrect it into a done state.
-	if current.Status != "ok" {
+	// #413 guard: a non-fatal per-representation failure (or archive-subtype
+	// failure) may have persisted a status other than the expected healthy one
+	// out-of-band; never resurrect it into a done state.
+	if current.Status != healthyStatus {
 		return nil
 	}
 	// Stamp the withheld done marker onto the re-read row so out-of-band writes
@@ -1581,7 +1611,7 @@ func (s *Service) readDocumentContent(ctx context.Context, relPath string) ([]by
 // content changed (or a full reindex was requested) it extracts and processes
 // the members; otherwise it retains the existing member paths in seen so that
 // markMissingAsDeleted does not tombstone them.
-func (s *Service) handleArchiveDocument(ctx context.Context, doc model.Document, f DiscoveredFile, secretPatterns []*regexp.Regexp, forceReindex bool, seen map[string]struct{}, needsProcessing bool) error {
+func (s *Service) handleArchiveDocument(ctx context.Context, doc model.Document, f DiscoveredFile, secretPatterns []*regexp.Regexp, forceReindex bool, seen map[string]struct{}, needsProcessing bool, finalContentHash string) error {
 	if needsProcessing {
 		if err := s.processArchiveMembers(ctx, f, secretPatterns, forceReindex, seen); err != nil {
 			if !errors.Is(err, errUnsupportedArchiveFormat) {
@@ -1624,6 +1654,14 @@ func (s *Service) handleArchiveDocument(ctx context.Context, doc model.Document,
 			// not double-counted as both skipped and error in CorpusStats (#398).
 			s.addSkipped(-1)
 			return fmt.Errorf("process archive members %s: %w", f.RelPath, err)
+		}
+		// #502: member extraction completed — stamp the withheld content_hash done
+		// marker now. The initial upsert blanked it, so a crash anywhere between that
+		// upsert and this point leaves the container with an empty hash and the next
+		// scan re-extracts instead of skipping on a premature marker. The container
+		// persists as status="skipped", so finalize preserves that healthy status.
+		if err := s.finalizeContentHashForStatus(ctx, &doc, finalContentHash, "skipped"); err != nil {
+			return err
 		}
 	} else if seen != nil {
 		// Archive content unchanged: retain existing members in seen.

--- a/tests/ingest/crash_consistency_test.go
+++ b/tests/ingest/crash_consistency_test.go
@@ -265,6 +265,65 @@ func TestProcessDocument_ArchiveExtractionFailureLeavesContentHashUnstamped(t *t
 	}
 }
 
+// TestProcessDocument_ArchiveMemberFailureLeavesContentHashUnstamped pins the
+// member-granularity half of the #502 fix: when a single archive member fails to
+// ingest (a stand-in for a crash mid-member), that member is logged and skipped
+// per #398 best-effort, but the CONTAINER's content_hash is NOT stamped — so the
+// next incremental scan re-extracts and retries the failed member instead of
+// permanently skipping it on a premature done marker. An all-success archive (see
+// TestProcessDocument_ArchiveWithholdsContentHashUntilMembersExtracted) DOES stamp
+// the marker; this asserts the failing-member counterpart withholds it.
+func TestProcessDocument_ArchiveMemberFailureLeavesContentHashUnstamped(t *testing.T) {
+	root := t.TempDir()
+	archiveData := buildZip(t, map[string]string{"notes.txt": "hello from a zip member whose commit will fail"})
+	if err := os.WriteFile(filepath.Join(root, "docs.zip"), archiveData, 0o600); err != nil {
+		t.Fatalf("write archive: %v", err)
+	}
+	wantHash := ingest.ComputeContentHash(archiveData)
+
+	// insertChunkErr makes the member's representation commit fail (a stand-in for a
+	// per-member crash/outage). The member is logged+skipped (#398 best-effort), so
+	// processDocument still succeeds, but the container must NOT be finalized.
+	st := &fakeIncrementalStore{reflectByPath: true, insertChunkErr: errors.New("simulated member commit crash")}
+	svc := mustNewIngestService(t, config.Config{RootDir: root}, st)
+	df := ingest.DiscoveredFile{RelPath: "docs.zip", SizeBytes: int64(len(archiveData))}
+
+	// Best-effort: a member failure is swallowed, so the run itself succeeds.
+	if err := svc.ProcessDocument(context.Background(), df, nil, false); err != nil {
+		t.Fatalf("processDocument failed: %v", err)
+	}
+
+	// Sanity: the failing member WAS attempted (so this is really the member-failure
+	// path, not an archive that produced no members).
+	if st.insertChunkCalls == 0 {
+		t.Fatalf("expected the member's representation commit to be attempted")
+	}
+
+	var last model.Document
+	found := false
+	for i, d := range st.upsertedDocs {
+		if d.RelPath != "docs.zip" {
+			continue
+		}
+		if d.ContentHash == wantHash {
+			t.Fatalf("upsert #%d stamped the container content_hash despite a failed member: %q", i, d.ContentHash)
+		}
+		last = d
+		found = true
+	}
+	if !found {
+		t.Fatalf("expected the archive container to be upserted")
+	}
+	// Terminal container row: blank hash so the next scan re-extracts and retries
+	// the failed member; status stays "skipped" (archive containers carry no text).
+	if last.ContentHash != "" {
+		t.Fatalf("terminal container content_hash = %q, want empty so the failed member is retried next scan", last.ContentHash)
+	}
+	if last.Status != "skipped" {
+		t.Fatalf("terminal container status = %q, want skipped", last.Status)
+	}
+}
+
 // TestNeedsReprocessing_EmptyHashResumesAfterInterruption is the restart half of
 // the #402 A1 story: a document left with an empty content_hash by an interrupted
 // run (the withheld-marker state) is always reprocessed on the next scan.

--- a/tests/ingest/crash_consistency_test.go
+++ b/tests/ingest/crash_consistency_test.go
@@ -5,10 +5,12 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/dirstral/dir2mcp/internal/config"
 	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/model"
 )
 
 // TestProcessDocument_WithholdsContentHashUntilRepsCommit pins the #402 A1 fix:
@@ -141,6 +143,125 @@ func TestProcessDocument_FinalizePreservesOutOfBandTitle(t *testing.T) {
 	}
 	if last.Title != wantTitle {
 		t.Fatalf("finalize reverted out-of-band title: got %q, want %q", last.Title, wantTitle)
+	}
+}
+
+// TestProcessDocument_ArchiveWithholdsContentHashUntilMembersExtracted pins the
+// #502 fix: an archive container's content_hash "done" marker is NOT written on
+// the initial upsert; it is stamped only AFTER processArchiveMembers has committed
+// every member. content_hash is the incremental gate for whether member extraction
+// re-runs, and archive containers persist as status="skipped" — so an ungraceful
+// crash between the initial upsert and completed extraction must leave the hash
+// blank and force re-extraction, not skip on a premature marker (the archive-path
+// analogue of the #402/#485 representation-commit crash window).
+func TestProcessDocument_ArchiveWithholdsContentHashUntilMembersExtracted(t *testing.T) {
+	root := t.TempDir()
+	archiveData := buildZip(t, map[string]string{"notes.txt": "hello from zip archive"})
+	if err := os.WriteFile(filepath.Join(root, "docs.zip"), archiveData, 0o600); err != nil {
+		t.Fatalf("write archive: %v", err)
+	}
+	wantHash := ingest.ComputeContentHash(archiveData)
+
+	// reflectByPath so the container's deferred finalize reads back the container
+	// row (status "skipped"), not whichever member was upserted last.
+	st := &fakeIncrementalStore{reflectByPath: true} // new document, needs extraction
+	svc := mustNewIngestService(t, config.Config{RootDir: root}, st)
+	df := ingest.DiscoveredFile{RelPath: "docs.zip", SizeBytes: int64(len(archiveData))}
+
+	if err := svc.ProcessDocument(context.Background(), df, nil, false); err != nil {
+		t.Fatalf("processDocument failed: %v", err)
+	}
+
+	var containerUpserts []model.Document
+	lastMemberIdx, containerStampIdx := -1, -1
+	for i, d := range st.upsertedDocs {
+		switch {
+		case d.RelPath == "docs.zip":
+			containerUpserts = append(containerUpserts, d)
+			if d.ContentHash == wantHash {
+				containerStampIdx = i
+			}
+		case strings.HasPrefix(d.RelPath, "docs.zip/"):
+			lastMemberIdx = i
+		}
+	}
+
+	if lastMemberIdx == -1 {
+		t.Fatalf("expected at least one archive member to be upserted; upserts=%v", st.upsertedDocs)
+	}
+	if len(containerUpserts) < 2 {
+		t.Fatalf("expected >=2 container upserts (withhold + finalize), got %d", len(containerUpserts))
+	}
+	// Initial container upsert must NOT carry the done marker.
+	if containerUpserts[0].ContentHash != "" {
+		t.Fatalf("initial archive upsert leaked content_hash before members extracted: %q", containerUpserts[0].ContentHash)
+	}
+	if containerUpserts[0].Status != "skipped" {
+		t.Fatalf("initial archive upsert status = %q, want skipped", containerUpserts[0].Status)
+	}
+	// The done marker must have been stamped, and strictly AFTER the members were
+	// committed — this ordering is the crash-safety invariant.
+	if containerStampIdx == -1 {
+		t.Fatalf("archive content_hash was never finalized; want %q stamped", wantHash)
+	}
+	if containerStampIdx < lastMemberIdx {
+		t.Fatalf("archive content_hash stamped (upsert #%d) BEFORE members committed (last member upsert #%d)", containerStampIdx, lastMemberIdx)
+	}
+	// Final container upsert carries the real hash and keeps status "skipped".
+	last := containerUpserts[len(containerUpserts)-1]
+	if last.ContentHash != wantHash {
+		t.Fatalf("finalize archive content_hash = %q, want %q", last.ContentHash, wantHash)
+	}
+	if last.Status != "skipped" {
+		t.Fatalf("finalize archive status = %q, want skipped", last.Status)
+	}
+}
+
+// TestProcessDocument_ArchiveExtractionFailureLeavesContentHashUnstamped pins the
+// retry half of the #502 fix: when member extraction does not complete, the
+// container's content_hash is never stamped, so the next scan re-extracts rather
+// than skipping on a matching-but-premature marker. An unextractable archive
+// (.7z — classified as an archive but unsupported by the stdlib extractor) stands
+// in for "extraction did not finish".
+func TestProcessDocument_ArchiveExtractionFailureLeavesContentHashUnstamped(t *testing.T) {
+	root := t.TempDir()
+	archiveData := []byte("this is not a real 7z archive; extraction will fail")
+	if err := os.WriteFile(filepath.Join(root, "data.7z"), archiveData, 0o600); err != nil {
+		t.Fatalf("write archive: %v", err)
+	}
+	wantHash := ingest.ComputeContentHash(archiveData)
+
+	st := &fakeIncrementalStore{reflectByPath: true}
+	svc := mustNewIngestService(t, config.Config{RootDir: root}, st)
+	df := ingest.DiscoveredFile{RelPath: "data.7z", SizeBytes: int64(len(archiveData))}
+
+	if err := svc.ProcessDocument(context.Background(), df, nil, false); err == nil {
+		t.Fatalf("expected processDocument to fail for an unextractable archive")
+	}
+
+	// No container upsert may carry the done marker — the members were never
+	// extracted, so the marker would falsely skip re-extraction on the next scan.
+	var last model.Document
+	found := false
+	for i, d := range st.upsertedDocs {
+		if d.RelPath != "data.7z" {
+			continue
+		}
+		if d.ContentHash == wantHash {
+			t.Fatalf("upsert #%d stamped content_hash despite failed extraction: %q", i, d.ContentHash)
+		}
+		last = d
+		found = true
+	}
+	if !found {
+		t.Fatalf("expected the archive container to be upserted")
+	}
+	// Terminal row: blank hash (reprocessed next scan) + error (#398 diagnostic).
+	if last.ContentHash != "" {
+		t.Fatalf("terminal archive content_hash = %q, want empty so it is reprocessed", last.ContentHash)
+	}
+	if last.Status != "error" {
+		t.Fatalf("terminal archive status = %q, want error", last.Status)
 	}
 }
 

--- a/tests/ingest/etag_incremental_test.go
+++ b/tests/ingest/etag_incremental_test.go
@@ -341,6 +341,47 @@ func TestRunScan_S3ETagErrorStatusForcesReprocess(t *testing.T) {
 	}
 }
 
+// TestRunScan_S3ETagEmptyContentHashForcesReRead confirms the #502 S3 half of the
+// fix: the remote (S3) ETag fast path runs BEFORE the content_hash recompute, so
+// an object whose recorded content_hash is empty (a withheld #402/#502 done-marker
+// left blank by a crash — e.g. an archive container whose members were not fully
+// extracted) must NOT be ETag-skipped even when its ETag+size match, or the
+// withhold gate would be defeated and the object never reprocessed. An empty
+// content_hash always means "not durably done", so the object is re-read.
+func TestRunScan_S3ETagEmptyContentHashForcesReRead(t *testing.T) {
+	fs := newFakeRemoteFS()
+	fs.add("doc.txt", "etag-stable", "body")
+
+	st := newRemoteScanStore()
+	st.seed(model.Document{
+		DocID:     1,
+		RelPath:   "doc.txt",
+		DocType:   "text",
+		SizeBytes: int64(len("body")),
+		// Empty content_hash: a crash left the withheld done-marker blank. ETag/size
+		// still match, and status is a healthy "skipped" — the only signal that this
+		// row was never finalized is the empty content_hash.
+		ContentHash: "",
+		ETag:        "etag-stable",
+		Status:      "skipped",
+	})
+
+	svc := mustNewIngestService(t, config.Config{RootDir: "/corpus"}, st)
+	svc.SetCorpusFS(fs)
+
+	if err := svc.Run(context.Background()); err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	// The empty content_hash must defeat the ETag fast-skip: the object is re-read.
+	if got := fs.openCount("doc.txt"); got == 0 {
+		t.Errorf("object with empty content_hash was ETag-skipped; it must be re-read (withhold gate)")
+	}
+	// After the re-read it is durably finalized with a non-empty content_hash.
+	if doc, _ := st.get("doc.txt"); doc.ContentHash != ingest.ComputeContentHash([]byte("body")) {
+		t.Errorf("content_hash not finalized after re-read: %q", doc.ContentHash)
+	}
+}
+
 // TestRunScan_S3ETagForceReindexBypassesSkip confirms that a forced reindex
 // re-reads even an object whose ETag is unchanged (the skip is incremental-only,
 // SPEC §7.8.3).

--- a/tests/ingest/incremental_test.go
+++ b/tests/ingest/incremental_test.go
@@ -37,6 +37,15 @@ type fakeIncrementalStore struct {
 	// document (instead of existingDoc) so tests can exercise the read-back the
 	// #402 content_hash finalize performs.
 	reflectUpserts bool
+
+	// reflectByPath makes GetDocumentByPath return the most recently upserted
+	// document whose RelPath matches the requested path (falling back to
+	// existingDoc when none matches). It is required by the #502 archive tests,
+	// where an archive container and its members are distinct rows: the
+	// container's deferred finalize must read back the container row (status
+	// "skipped"), not whichever member happened to be upserted last. It takes
+	// precedence over reflectUpserts when both are set.
+	reflectByPath bool
 }
 
 func (f *fakeIncrementalStore) Init(context.Context) error { return nil }
@@ -51,9 +60,17 @@ func (f *fakeIncrementalStore) UpsertDocument(_ context.Context, doc model.Docum
 	f.upsertedDocs = append(f.upsertedDocs, doc)
 	return nil
 }
-func (f *fakeIncrementalStore) GetDocumentByPath(_ context.Context, _ string) (model.Document, error) {
+func (f *fakeIncrementalStore) GetDocumentByPath(_ context.Context, relPath string) (model.Document, error) {
 	if f.existingErr != nil {
 		return model.Document{}, f.existingErr
+	}
+	if f.reflectByPath {
+		for i := len(f.upsertedDocs) - 1; i >= 0; i-- {
+			if f.upsertedDocs[i].RelPath == relPath {
+				return f.upsertedDocs[i], nil
+			}
+		}
+		return f.existingDoc, nil
 	}
 	if f.reflectUpserts && len(f.upsertedDocs) > 0 {
 		return f.upsertedDocs[len(f.upsertedDocs)-1], nil


### PR DESCRIPTION
Closes #502.

## Problem

`withholdContentHash` withholds the `content_hash` done-marker only for `doc.Status == "ok"` and explicitly excludes archives (`doc.DocType != "archive"`). But archive containers persist as `status="skipped"` and still use `content_hash` as the incremental gate for whether `processArchiveMembers` re-runs.

A crash after the initial `UpsertDocument` but before extraction completes stamps a matching `content_hash`, so the next scan sees an unchanged container, skips re-extraction, and permanently misses some members. This is the archive-extraction analogue of the representation/chunk crash window closed by #402 / PR #485.

## Fix (mirrors #485's withhold/finalize split)

- `withholdArchiveContentHash` blanks the container's `content_hash` on the initial upsert whenever this run will (re)extract members (`needsProcessing && DocType == "archive"`). Extracted into its own helper so `processDocument` stays within the cyclomatic-complexity budget.
- `handleArchiveDocument` stamps the withheld hash via a new `finalizeContentHashForStatus` **only after** `processArchiveMembers` completes successfully.
- `finalizeContentHash` is generalized over the document's healthy "done" status: the representation path finalizes an `ok` document; the archive path finalizes a container that persists as `skipped`. The #413 guard (never resurrect an out-of-band `error` into a done state) is preserved for both.
- On failed/partial extraction the hash stays blank so the next scan retries. #398 archive-subtype error handling (`errUnsupportedArchiveFormat` → `status="error"`) and the #398 skipped/error counters are unchanged.

## Tests (`tests/ingest`)

- `TestProcessDocument_ArchiveWithholdsContentHashUntilMembersExtracted`: the initial container upsert carries no `content_hash`; the marker is stamped strictly **after** every member is committed.
- `TestProcessDocument_ArchiveExtractionFailureLeavesContentHashUnstamped`: an unextractable archive never stamps the marker (blank hash + `error` status → retried).
- Both fail on `main` and pass with the fix. Adds an opt-in path-aware `GetDocumentByPath` mode (`reflectByPath`) to the fake store so the container's deferred finalize reads back the container row, not a member row; existing `reflectUpserts` behavior is untouched.

## Validation

`gofmt` clean; `go build ./...`; `go vet ./...`; `make cyclo` (≤15); `golangci-lint run` (0 issues); `go test ./internal/ingest/... ./tests/ingest/...` all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved archive processing so completion markers are written only after archive contents finish extracting.
  * Prevented failed archive extraction from leaving a completed-looking record behind, so affected items will be retried on the next scan.
  * Kept status values consistent during archive processing, avoiding misleading “done” states after interruptions.

* **Tests**
  * Added regression coverage for archive crash consistency and extraction failure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->