### PR TITLE
fix(index): wire honest late-chunking active-state + identity capture (#446)

### DIFF
--- a/internal/config/providers.go
+++ b/internal/config/providers.go
@@ -386,6 +386,11 @@ type ProviderResolution struct {
 	byName     map[string]provider.Profile
 	precedence []provider.Profile
 	doc        providersDoc
+	// lateChunking is the resolved ingest.late_chunking flag (issue #332/#446),
+	// stamped by Config.Providers so EmbedIdentity folds the late-chunking mode
+	// into the corpus-lifetime identity (SPEC 8.1.4). It is not a provider
+	// attribute, so it lives on the resolution rather than on a Profile.
+	lateChunking bool
 }
 
 // providersResolution builds the resolution from the parsed doc + env.
@@ -620,7 +625,7 @@ func (r ProviderResolution) EmbedIdentity() string {
 	if err != nil {
 		return ""
 	}
-	return provider.EmbedIdentity(p)
+	return provider.EmbedIdentity(p, r.lateChunking)
 }
 
 // Providers returns the provider resolution for cfg using os.Getenv for
@@ -629,7 +634,11 @@ func (r ProviderResolution) EmbedIdentity() string {
 func (cfg Config) Providers() ProviderResolution {
 	base := builtinProfiles()
 	seedLegacy(base, cfg)
-	return cfg.providersDoc.resolve(base, nil)
+	r := cfg.providersDoc.resolve(base, nil)
+	// Fold the resolved ingest.late_chunking flag onto the resolution so the
+	// embed identity captures the late-chunking mode (issue #332/#446).
+	r.lateChunking = cfg.IngestLateChunking
+	return r
 }
 
 // ProviderEnvVarRefs returns the distinct environment variable names

--- a/internal/index/embedding_worker.go
+++ b/internal/index/embedding_worker.go
@@ -42,12 +42,18 @@ type EmbeddingWorker struct {
 	OnIndexedChunk func(label uint64, metadata model.ChunkMetadata)
 
 	// LateChunking is the resolved value of config.IngestLateChunking (issue
-	// #332). When true AND the configured Embedder implements model.TokenEmbedder,
-	// the worker is on the late-chunking path (embed whole documents, mean-pool
-	// token vectors per chunk span). When the embedder lacks that capability — as
-	// every shipped provider does today — the worker logs the fallback once and
-	// embeds chunks the existing way. Default false: the worker behaves
-	// byte-for-byte as before. The pure embed/mean-pool step lives in
+	// #332). It records the operator's intent to use the late-chunking path
+	// (embed whole documents, mean-pool token vectors per chunk span) when the
+	// configured Embedder implements model.TokenEmbedder.
+	//
+	// NOT-YET-WIRED (issue #446): the production embed loop does not yet run the
+	// pooling path — the whole-doc-embed + per-chunk mean-pool needs per-document
+	// rune spans and the source document text, neither of which the per-chunk
+	// ChunkTasks the worker leases from NextPending carry today. Until that
+	// plumbing lands the worker embeds chunk-by-chunk regardless of this flag, so
+	// the one-time decision log (logLateChunkDecisionOnce) says so honestly and
+	// never claims the path is "active". Default false: the worker behaves
+	// byte-for-byte as before. The pure embed/mean-pool step already lives in
 	// internal/latechunk; the worker holds the resolved capability gate
 	// (latechunk.Decide) so the decision and any fallback are observable
 	// end-to-end.
@@ -1065,9 +1071,18 @@ func (w *EmbeddingWorker) LateChunkDecision() latechunk.Decision {
 // logLateChunkDecisionOnce emits a single informational line describing the
 // late-chunking decision the first time the worker runs with the feature
 // enabled, so an operator who turned on ingest.late_chunking can see whether it
-// actually engaged or silently fell back to chunk-then-embed (issue #332: never
-// fail silently). It is a no-op when late chunking is disabled (the default), so
+// actually engaged or fell back to chunk-then-embed (issue #332: never fail
+// silently). It is a no-op when late chunking is disabled (the default), so
 // stock runs log nothing new.
+//
+// Honesty note (issue #446): even when the capability gate is satisfied
+// (dec.Active — the embedder exposes token embeddings), the production embed
+// loop does NOT yet run the whole-doc-embed + mean-pool path, so the worker
+// still embeds chunk-then-embed. The log therefore MUST NOT claim the path is
+// "active" in that case (the previous message lied): it reports that the
+// capability is present but the pooling path is not yet wired, so the fallback
+// is in effect. When the token-pooling path is wired, restore an "enabled and
+// active" line here (and branch the embed loop on dec.Active).
 func (w *EmbeddingWorker) logLateChunkDecisionOnce() {
 	if !w.LateChunking || w.lateChunkLogged {
 		return
@@ -1075,7 +1090,7 @@ func (w *EmbeddingWorker) logLateChunkDecisionOnce() {
 	w.lateChunkLogged = true
 	dec := w.LateChunkDecision()
 	if dec.Active {
-		w.logf("late chunking: enabled and active (embedder %T exposes token embeddings)", w.Embedder)
+		w.logf("late chunking: enabled and embedder %T exposes token embeddings, but the token-pooling path is not yet wired (issue #446); still embedding chunk-then-embed", w.Embedder)
 		return
 	}
 	w.logf("late chunking: enabled but falling back to chunk-then-embed (%s; embedder %T)", dec.Fallback, w.Embedder)

--- a/internal/latechunk/latechunk.go
+++ b/internal/latechunk/latechunk.go
@@ -10,8 +10,16 @@
 // No shipped provider implements that today, so Decide returns a fallback in the
 // stock build and the pipeline keeps chunk-then-embed. This package contains the
 // pure, deterministic, credential-free logic (capability gate + mean-pool) so a
-// future self-hosted token-embedding backend plugs in without touching the
-// embedding worker, and so the behavior is unit-testable with a fake embedder.
+// future self-hosted token-embedding backend plugs in, and so the behavior is
+// unit-testable with a fake embedder.
+//
+// Wiring status (issue #446): this library is complete and tested, but the
+// embedding worker does NOT yet call EmbedDocument on the active path — doing so
+// needs the source document text and per-chunk rune spans that the worker's
+// per-chunk tasks do not carry today, so wiring it is more than a drop-in. Until
+// then the worker treats an Active decision as observability only (an honest
+// "not yet wired" log) and still embeds chunk-then-embed; it does not silently
+// claim the pooling path ran.
 package latechunk
 
 import (

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -259,18 +259,41 @@ func Select(precedence []Profile, byName map[string]Profile, cap Capability, exp
 
 // EmbedIdentity is the corpus-lifetime embed identity (SPEC 8.1.4):
 // provider name + text/code model + requested text/code output dimension
-// (8.1.6) + multimodal mode (8.1.7). It is recorded in the config
-// snapshot/index and compared on load. Role (8.1.5) is deliberately
-// excluded — it does not affect vector-space compatibility, but the
-// requested dimension and multimodal mode do.
-func EmbedIdentity(p Profile) string {
-	return fmt.Sprintf("%s|%s|%s|%d|%d|%s",
+// (8.1.6) + multimodal mode (8.1.7) + late-chunking mode (issue #332/#446).
+// It is recorded in the config snapshot/index and compared on load. Role
+// (8.1.5) is deliberately excluded — it does not affect vector-space
+// compatibility, but the requested dimension, multimodal mode, and
+// late-chunking mode do.
+//
+// lateChunking is the resolved value of ingest.late_chunking (config, not a
+// provider attribute). It enters the identity because late chunking, once its
+// pooling path is wired, produces context-pooled chunk vectors that are NOT
+// comparable to chunk-then-embed vectors — so building a corpus with the mode
+// on then off (or a distributed worker with a different setting) MUST re-derive
+// rather than silently mix vector spaces (SPEC 8.1.4). The gate is conservative:
+// it keys off the config flag, not the runtime TokenEmbedder capability (which
+// EmbedIdentity cannot observe), so toggling the flag re-derives even in a build
+// with no token-embedding provider — the safe direction.
+func EmbedIdentity(p Profile, lateChunking bool) string {
+	return fmt.Sprintf("%s|%s|%s|%d|%d|%s|%s",
 		strings.TrimSpace(p.Name),
 		strings.TrimSpace(p.EmbedTextModel),
 		strings.TrimSpace(p.EmbedCodeModel),
 		p.EmbedTextDim,
 		p.EmbedCodeDim,
-		NormalizeEmbedMultimodal(p.EmbedMultimodal))
+		NormalizeEmbedMultimodal(p.EmbedMultimodal),
+		normalizeLateChunking(lateChunking))
+}
+
+// normalizeLateChunking renders the late-chunking mode as the stable token
+// used in the embed identity: "on" when enabled, "off" otherwise. Keeping it a
+// named token (rather than a bare bool) leaves room for future pooling modes
+// without another identity-field migration.
+func normalizeLateChunking(on bool) string {
+	if on {
+		return "on"
+	}
+	return "off"
 }
 
 // NormalizeEmbedMultimodal lower-cases/trims the multimodal mode and maps
@@ -307,21 +330,24 @@ func VerifyEmbedIdentity(recorded, current string) error {
 }
 
 // normalizeEmbedIdentity upgrades a legacy recorded identity to the
-// current 6-field form before comparison, so upgrading an existing corpus
-// that used native dimensions and no multimodal mode does not force a
-// spurious reindex:
-//   - pre-8.1.6 (3 fields: provider|text|code) → append "|0|0|off"
-//   - pre-8.1.7 (5 fields: …|tdim|cdim)        → append "|off"
+// current 7-field form before comparison, so upgrading an existing corpus
+// that used native dimensions, no multimodal mode, and no late chunking does
+// not force a spurious reindex:
+//   - pre-8.1.6 (3 fields: provider|text|code)        → append "|0|0|off|off"
+//   - pre-8.1.7 (5 fields: …|tdim|cdim)               → append "|off|off"
+//   - pre-late-chunking (6 fields: …|multimodal, #446) → append "|off"
 //
-// Empty (fresh index) and already-6-field values are returned unchanged.
+// Empty (fresh index) and already-7-field values are returned unchanged.
 func normalizeEmbedIdentity(id string) string {
 	if id == "" {
 		return ""
 	}
 	switch strings.Count(id, "|") {
 	case 2:
-		return id + "|0|0|off"
+		return id + "|0|0|off|off"
 	case 4:
+		return id + "|off|off"
+	case 5:
 		return id + "|off"
 	default:
 		return id

--- a/tests/config/late_chunking_config_test.go
+++ b/tests/config/late_chunking_config_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/dirstral/dir2mcp/internal/config"
@@ -63,6 +64,41 @@ func TestLateChunking_NestedAndFlatKeys(t *testing.T) {
 				t.Fatalf("expected IngestLateChunking=true for %s yaml", tc.name)
 			}
 		})
+	}
+}
+
+// TestLateChunking_EntersEmbedIdentity pins issue #446 F2: the late-chunking
+// mode is folded into the corpus-lifetime embed identity (SPEC 8.1.4), so
+// building a corpus with ingest.late_chunking on then off (or a distributed
+// worker with a different setting) re-derives rather than silently mixing
+// context-pooled and chunk-then-embed vectors in one vector space.
+func TestLateChunking_EntersEmbedIdentity(t *testing.T) {
+	t.Setenv("MISTRAL_API_KEY", "mk")
+
+	off := loadCfg(t, "version: 1\n")
+	if off.IngestLateChunking {
+		t.Fatal("precondition: late chunking must default off")
+	}
+	offID := off.Providers().EmbedIdentity()
+	if !strings.HasSuffix(offID, "|off") {
+		t.Fatalf("identity %q must end with the off late-chunking token", offID)
+	}
+
+	on := loadCfg(t, "ingest:\n  late_chunking: true\n")
+	if !on.IngestLateChunking {
+		t.Fatal("precondition: late chunking must be enabled")
+	}
+	onID := on.Providers().EmbedIdentity()
+	if !strings.HasSuffix(onID, "|on") {
+		t.Fatalf("identity %q must end with the on late-chunking token", onID)
+	}
+	if onID == offID {
+		t.Fatalf("toggling late chunking must change the embed identity: %q == %q", onID, offID)
+	}
+	// The mode is the ONLY difference: strip the trailing token and the rest of
+	// the identity must be byte-identical, so nothing else drifted.
+	if strings.TrimSuffix(onID, "|on") != strings.TrimSuffix(offID, "|off") {
+		t.Fatalf("only the late-chunking token may differ: on=%q off=%q", onID, offID)
 	}
 }
 

--- a/tests/config/providers_config_test.go
+++ b/tests/config/providers_config_test.go
@@ -166,9 +166,10 @@ func TestProviders_UserOverrideAndCustomProfile(t *testing.T) {
 func TestProviders_EmbedIdentityStable(t *testing.T) {
 	t.Setenv("MISTRAL_API_KEY", "mk")
 	id := loadCfg(t, "version: 1\n").Providers().EmbedIdentity()
-	// provider|text_model|code_model|text_dim|code_dim|multimodal
-	// (SPEC 8.1.4/8.1.6/8.1.7); default Mistral: native dims, mode off.
-	if id != "mistral|mistral-embed|codestral-embed|0|0|off" {
+	// provider|text_model|code_model|text_dim|code_dim|multimodal|late_chunking
+	// (SPEC 8.1.4/8.1.6/8.1.7, issue #332/#446); default Mistral: native dims,
+	// multimodal + late_chunking off.
+	if id != "mistral|mistral-embed|codestral-embed|0|0|off|off" {
 		t.Fatalf("embed identity = %q", id)
 	}
 }
@@ -196,8 +197,8 @@ func TestProviders_EmbedDimensionKnob(t *testing.T) {
 		t.Fatalf("dims = text:%d code:%d, want 1536/768", p.EmbedTextDim, p.EmbedCodeDim)
 	}
 	id := r.EmbedIdentity()
-	if !strings.HasSuffix(id, "|1536|768|off") {
-		t.Fatalf("embed identity %q must encode requested dims (and off mode)", id)
+	if !strings.HasSuffix(id, "|1536|768|off|off") {
+		t.Fatalf("embed identity %q must encode requested dims (and off modes)", id)
 	}
 }
 
@@ -220,7 +221,7 @@ func TestProviders_EmbedMultimodalKnob(t *testing.T) {
 	if p.EmbedMultimodal != "augment" {
 		t.Fatalf("multimodal = %q, want augment", p.EmbedMultimodal)
 	}
-	if !strings.HasSuffix(r.EmbedIdentity(), "|augment") {
+	if !strings.HasSuffix(r.EmbedIdentity(), "|augment|off") {
 		t.Fatalf("embed identity %q must encode the multimodal mode", r.EmbedIdentity())
 	}
 }
@@ -266,7 +267,7 @@ func TestProviders_OmniEmbedSelfHosted(t *testing.T) {
 	if p.EmbedMultimodal != "replace" {
 		t.Fatalf("multimodal = %q, want replace", p.EmbedMultimodal)
 	}
-	if !strings.HasSuffix(r.EmbedIdentity(), "|replace") {
+	if !strings.HasSuffix(r.EmbedIdentity(), "|replace|off") {
 		t.Fatalf("embed identity %q must encode the multimodal mode", r.EmbedIdentity())
 	}
 }

--- a/tests/config/self_hosted_endpoints_test.go
+++ b/tests/config/self_hosted_endpoints_test.go
@@ -49,7 +49,7 @@ func TestSelfHosted_EmbedBaseURLResolves(t *testing.T) {
 	}
 	// The embed identity must encode the self-hosted profile + model so a
 	// change is corpus-lifetime / reindex-bound (SPEC §8.1.4 / §8.5).
-	if id := r.EmbedIdentity(); id != "gpu-embed|bge-m3||0|0|off" {
+	if id := r.EmbedIdentity(); id != "gpu-embed|bge-m3||0|0|off|off" {
 		t.Fatalf("embed identity = %q", id)
 	}
 }

--- a/tests/index/late_chunking_worker_test.go
+++ b/tests/index/late_chunking_worker_test.go
@@ -1,7 +1,10 @@
 package tests
 
 import (
+	"bytes"
 	"context"
+	"log"
+	"strings"
 	"testing"
 
 	"github.com/dirstral/dir2mcp/internal/index"
@@ -72,5 +75,84 @@ func TestWorker_LateChunkDecision_ActiveWithTokenEmbedder(t *testing.T) {
 	}
 	if dec.Embedder == nil {
 		t.Fatal("active decision must carry a non-nil token embedder")
+	}
+}
+
+// lcRecordingEmbedder implements both model.Embedder and model.TokenEmbedder and
+// records which path the worker actually drove, so a test can prove the
+// token-pooling path is deferred (issue #446): even when the capability gate is
+// satisfied (dec.Active), the worker must still call Embed (chunk-then-embed)
+// and must NOT call EmbedDocumentTokens.
+type lcRecordingEmbedder struct {
+	embedCalls int
+	tokenCalls int
+}
+
+func (e *lcRecordingEmbedder) Embed(_ context.Context, _ string, _ model.EmbedRole, inputs []string) ([][]float32, error) {
+	e.embedCalls++
+	out := make([][]float32, len(inputs))
+	for i := range inputs {
+		out[i] = []float32{1}
+	}
+	return out, nil
+}
+
+func (e *lcRecordingEmbedder) EmbedDocumentTokens(_ context.Context, _ string, _ model.EmbedRole, inputs []string) ([]model.TokenEmbedding, error) {
+	e.tokenCalls++
+	out := make([]model.TokenEmbedding, len(inputs))
+	for i := range inputs {
+		out[i] = model.TokenEmbedding{Vectors: [][]float32{{1}}, Offsets: []int{0}, Ends: []int{1}}
+	}
+	return out, nil
+}
+
+// TestWorker_LateChunkActive_StillEmbedsChunkThenEmbed_HonestLog pins issue #446
+// F1: when late chunking is enabled AND the embedder exposes token embeddings
+// (dec.Active), the production embed loop is NOT yet wired to the pooling path,
+// so the worker must still embed chunk-then-embed (call Embed, never
+// EmbedDocumentTokens) and the one-time decision log MUST be honest — it must
+// NOT claim the path is "active" (the previous log lied) and must disclose that
+// the pooling path is not yet wired.
+func TestWorker_LateChunkActive_StillEmbedsChunkThenEmbed_HonestLog(t *testing.T) {
+	emb := &lcRecordingEmbedder{}
+
+	// Precondition: the decision is Active (enabled + token embedder present).
+	if dec := (&index.EmbeddingWorker{Embedder: emb, LateChunking: true}).LateChunkDecision(); !dec.Active {
+		t.Fatal("precondition: decision must be active with a token embedder + late chunking on")
+	}
+
+	src := &fakeChunkSource{tasks: []model.ChunkTask{
+		model.NewChunkTask(1, "hello", "", model.ChunkMetadata{ChunkID: 1, RelPath: "a.txt", DocType: "text"}),
+	}}
+	var buf bytes.Buffer
+	worker := &index.EmbeddingWorker{
+		Source: src, Index: index.NewHNSWIndex(""), Embedder: emb,
+		BatchSize: 4, LateChunking: true, Logger: log.New(&buf, "", 0),
+	}
+
+	n, err := worker.RunOnce(context.Background(), "text")
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("indexed = %d, want 1", n)
+	}
+
+	// The pooling path is deferred (#446): the worker drives Embed, not the
+	// token-embedding path.
+	if emb.tokenCalls != 0 {
+		t.Fatalf("token-pooling path must not run yet (deferred): tokenCalls=%d", emb.tokenCalls)
+	}
+	if emb.embedCalls == 0 {
+		t.Fatal("worker must still embed chunk-then-embed via Embed")
+	}
+
+	// The one-time decision log must be honest about the deferred state.
+	logged := buf.String()
+	if strings.Contains(logged, "enabled and active") {
+		t.Fatalf("log must not claim late chunking is active while the pooling path is deferred: %q", logged)
+	}
+	if !strings.Contains(logged, "not yet wired") {
+		t.Fatalf("log must disclose the pooling path is not yet wired: %q", logged)
 	}
 }

--- a/tests/provider/provider_test.go
+++ b/tests/provider/provider_test.go
@@ -132,10 +132,11 @@ func TestSelectAutoPrecedence(t *testing.T) {
 
 func TestEmbedIdentity(t *testing.T) {
 	p := provider.Profile{Name: "mistral", EmbedTextModel: "mistral-embed", EmbedCodeModel: "codestral-embed"}
-	id := provider.EmbedIdentity(p)
-	// Identity is provider|text_model|code_model|text_dim|code_dim|multimodal
-	// (SPEC 8.1.4/8.1.6/8.1.7); unset dims record as 0, mode as off.
-	if id != "mistral|mistral-embed|codestral-embed|0|0|off" {
+	id := provider.EmbedIdentity(p, false)
+	// Identity is provider|text_model|code_model|text_dim|code_dim|multimodal|
+	// late_chunking (SPEC 8.1.4/8.1.6/8.1.7, issue #332/#446); unset dims record
+	// as 0, multimodal + late_chunking as off.
+	if id != "mistral|mistral-embed|codestral-embed|0|0|off|off" {
 		t.Fatalf("identity = %q", id)
 	}
 	if err := provider.VerifyEmbedIdentity("", id); err != nil {
@@ -148,30 +149,40 @@ func TestEmbedIdentity(t *testing.T) {
 	// A different requested output dimension is a distinct identity
 	// (reindex-bound, SPEC 8.1.6): same provider+models but dim 768 must
 	// not match the native (dim 0) identity.
-	native := provider.EmbedIdentity(provider.Profile{Name: "gemini", EmbedTextModel: "gemini-embedding-001"})
-	dimmed := provider.EmbedIdentity(provider.Profile{Name: "gemini", EmbedTextModel: "gemini-embedding-001", EmbedTextDim: 768})
+	native := provider.EmbedIdentity(provider.Profile{Name: "gemini", EmbedTextModel: "gemini-embedding-001"}, false)
+	dimmed := provider.EmbedIdentity(provider.Profile{Name: "gemini", EmbedTextModel: "gemini-embedding-001", EmbedTextDim: 768}, false)
 	if native == dimmed {
 		t.Fatalf("requested dimension must change embed identity: %q == %q", native, dimmed)
 	}
 	// A different multimodal mode is a distinct identity (reindex-bound,
 	// SPEC 8.1.7).
-	mm := provider.EmbedIdentity(provider.Profile{Name: "gemini", EmbedTextModel: "gemini-embedding-2", EmbedCodeModel: "gemini-embedding-2", EmbedMultimodal: "augment"})
-	if mm == provider.EmbedIdentity(provider.Profile{Name: "gemini", EmbedTextModel: "gemini-embedding-2", EmbedCodeModel: "gemini-embedding-2"}) {
+	mm := provider.EmbedIdentity(provider.Profile{Name: "gemini", EmbedTextModel: "gemini-embedding-2", EmbedCodeModel: "gemini-embedding-2", EmbedMultimodal: "augment"}, false)
+	if mm == provider.EmbedIdentity(provider.Profile{Name: "gemini", EmbedTextModel: "gemini-embedding-2", EmbedCodeModel: "gemini-embedding-2"}, false) {
 		t.Fatalf("multimodal mode must change embed identity")
+	}
+	// A different late-chunking mode is a distinct identity (reindex-bound,
+	// issue #332/#446): the same profile with the mode on must NOT match off.
+	if provider.EmbedIdentity(p, true) == provider.EmbedIdentity(p, false) {
+		t.Fatalf("late-chunking mode must change embed identity")
 	}
 	// Legacy identities must NOT force a spurious reindex against the
 	// equivalent current identity: a 3-field (pre-8.1.6) normalizes to
-	// "|0|0|off" and a 5-field (pre-8.1.7) to "|off".
+	// "|0|0|off|off", a 5-field (pre-8.1.7) to "|off|off", and a 6-field
+	// (pre-late-chunking, #446) to "|off".
 	legacy3 := "mistral|mistral-embed|codestral-embed"
-	if err := provider.VerifyEmbedIdentity(legacy3, "mistral|mistral-embed|codestral-embed|0|0|off"); err != nil {
+	if err := provider.VerifyEmbedIdentity(legacy3, "mistral|mistral-embed|codestral-embed|0|0|off|off"); err != nil {
 		t.Errorf("legacy 3-field identity must match native current: %v", err)
 	}
 	legacy5 := "mistral|mistral-embed|codestral-embed|0|0"
-	if err := provider.VerifyEmbedIdentity(legacy5, "mistral|mistral-embed|codestral-embed|0|0|off"); err != nil {
+	if err := provider.VerifyEmbedIdentity(legacy5, "mistral|mistral-embed|codestral-embed|0|0|off|off"); err != nil {
 		t.Errorf("legacy 5-field identity must match off-mode current: %v", err)
 	}
+	legacy6 := "mistral|mistral-embed|codestral-embed|0|0|off"
+	if err := provider.VerifyEmbedIdentity(legacy6, "mistral|mistral-embed|codestral-embed|0|0|off|off"); err != nil {
+		t.Errorf("legacy 6-field identity must match late-chunking-off current: %v", err)
+	}
 	// But a legacy identity vs a non-native dimension still mismatches.
-	_ = cfgErr(t, provider.VerifyEmbedIdentity(legacy3, "mistral|mistral-embed|codestral-embed|768|0|off"))
+	_ = cfgErr(t, provider.VerifyEmbedIdentity(legacy3, "mistral|mistral-embed|codestral-embed|768|0|off|off"))
 }
 
 func mustErr(_ provider.Profile, err error) error {


### PR DESCRIPTION
Addresses #446. (Not `Closes`: the F1 pooling-path wiring is intentionally deferred — see below — so the issue stays open for that follow-up.)

## Context
Late chunking (#332) is a stub. `internal/latechunk` (mean-pool + capability gate) is complete and unit-tested, but **no production caller ever branched on the decision** — the embed loop unconditionally calls `Embedder.Embed` (chunk-then-embed). That left two coupled defects.

## What this fixes
### F1 — the "active" log lied (HIGH)
The one-time decision log printed `"late chunking: enabled and active"` the moment any `model.TokenEmbedder` was registered, even though the pooling path never ran. Now, when the capability gate is satisfied (`dec.Active`), the worker logs that the **token-pooling path is not yet wired** and it is **still embedding chunk-then-embed**. It never claims "active" until the path is real.

### F2 — `EmbedIdentity` didn't capture the mode (MED, coupled)
`EmbedIdentity` (SPEC 8.1.4) gained a 7th field (`|on`/`|off`), threaded from the resolved `ingest.late_chunking` flag onto `ProviderResolution`. Toggling the mode now **re-derives** the corpus identity instead of silently mixing context-pooled and chunk-then-embed vectors in one space. Legacy 3/5/6-field identities **normalize forward** to the off token, so upgrading an existing corpus never forces a spurious reindex.

Also corrects the package/field docs that claimed a backend plugs in "without touching the embedding worker" (it does need a `dec.Active` branch).

## Deferred (kept honest, not lying)
Wiring the real pooling path (F1 proper) needs the source document text + per-chunk **rune spans**, neither of which the per-chunk `ChunkTask`s leased from `NextPending` carry today — and no shipped provider implements `TokenEmbedder` to exercise it. So the branch is deferred; the stub is now **honest** rather than misleading. F3 (L2-normalize the pooled mean) is coupled to that wiring and left with it. ColBERT is out of scope.

## Scope
Touched only `internal/index/embedding_worker.go` (log + docs), `internal/provider/provider.go` (identity), `internal/config/providers.go` (thread the one flag), `internal/latechunk/latechunk.go` (docs), plus tests. Did **not** touch `hnsw_index.go`, `reconcile.go`, or `internal/embedqueue`.

## Tests
- `tests/config/late_chunking_config_test.go`: identity encodes + toggles on the mode; only the trailing token differs.
- `tests/provider/provider_test.go`: 7-field identity; legacy 3/5/6-field normalize without spurious reindex; mode change is a distinct identity.
- `tests/index/late_chunking_worker_test.go`: with the gate active, the worker still calls `Embed` (never `EmbedDocumentTokens`) and logs honestly (no "active", discloses "not yet wired").

## Validation
`gofmt` clean; `go build ./...`; `go vet ./...`; `make cyclo` (≤15); `golangci-lint run` full → 0 issues; full `go test ./...` green.