### PR TITLE
fix(cli): foreground single-instance guard, standalone-worker broker guard, doctor probes (#434)

### DIFF
--- a/internal/cli/client_cmds.go
+++ b/internal/cli/client_cmds.go
@@ -91,7 +91,10 @@ func (a *App) runUninstall(_ context.Context, global globalOptions, args []strin
 // install healthy?", the client flavour answers "is this client wired
 // up correctly?".
 func (a *App) runDoctor(ctx context.Context, global globalOptions, args []string) int {
-	if len(args) == 0 {
+	// No positional, or a leading flag (e.g. `doctor --deep`): the
+	// daemon-side preflight. A client name never starts with '-', so
+	// flags unambiguously belong to the server flavour.
+	if len(args) == 0 || strings.HasPrefix(args[0], "-") {
 		return a.runServerDoctor(ctx, global, args)
 	}
 	client, rest, ok := extractClient(a, global.jsonOutput, "doctor", args)

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -331,7 +331,9 @@ func (a *App) emitSetupVerification(global globalOptions) {
 		{"embed", provider.CapEmbed},
 		{"chat", provider.CapChat},
 	} {
-		chk := providerCheck(cfg, c.label, c.cap, false)
+		// deep=false: setup verification only checks resolvability/construction,
+		// never touches the network (probing belongs to `doctor --deep`).
+		chk := providerCheck(context.Background(), cfg, c.label, c.cap, false, false)
 		switch chk.Status {
 		case doctorStatusOK:
 			writef(a.stdout, "%s %s provider ready (%s)\n", s.Success.Render("✓"), c.label, chk.Detail)

--- a/internal/cli/embed_worker.go
+++ b/internal/cli/embed_worker.go
@@ -97,10 +97,13 @@ func (a *App) loadEmbedWorkerConfig(global globalOptions) (config.Config, int) {
 //   - the index backend MUST be a shared Tier-C store (qdrant/pgvector), since
 //     the embedded Tier-A/B backends are single-node and unshareable (§8.7.4);
 //   - the embed identity MUST resolve, so the worker can reject jobs from a
-//     different vector space rather than mis-write (§8.1.4, §8.7.3).
+//     different vector space rather than mis-write (§8.1.4, §8.7.3);
+//   - the broker MUST be cross-process (sqlite/external), NOT the in-process
+//     "memory" default — a MemBroker is a process-local queue, so a standalone
+//     worker on it creates its OWN empty queue, never sees the daemon's jobs,
+//     and silently no-ops while printing "pulling jobs" (#434).
 //
-// The broker is validated when it is constructed (buildEmbedBroker); its URL is
-// a runtime-only secret (§16.1.1) and is never logged here.
+// The broker URL is a runtime-only secret (§16.1.1) and is never logged here.
 func (a *App) requireDistributedPrereqs(cfg config.Config, global globalOptions) int {
 	if !cfg.DistributedEmbed.Enabled {
 		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid,
@@ -113,6 +116,12 @@ func (a *App) requireDistributedPrereqs(cfg config.Config, global globalOptions)
 		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid,
 			fmt.Sprintf("CONFIG_INVALID: embed-worker requires a shared Tier-C vector store; index.backend=%q is single-node", cfg.IndexBackend),
 			"Set index.backend=qdrant or index.backend=pgvector — a worker pool must write to a store reachable by all participants (SPEC §8.7.4).")
+		return exitConfigInvalid
+	}
+	if broker := strings.ToLower(strings.TrimSpace(cfg.DistributedEmbed.Broker)); broker == "" || broker == "memory" {
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid,
+			fmt.Sprintf("CONFIG_INVALID: embed-worker cannot use the in-process %q broker; its job queue is process-local, so a standalone worker never sees the daemon's jobs and would silently do nothing", embedWorkerBrokerLabel(cfg)),
+			"Set distributed_embed.broker=sqlite (a queue db shared with the daemon) or an external broker so the worker and daemon share one queue (SPEC §8.7.4).")
 		return exitConfigInvalid
 	}
 	if strings.TrimSpace(cfg.Providers().EmbedIdentity()) == "" {

--- a/internal/cli/server_doctor.go
+++ b/internal/cli/server_doctor.go
@@ -3,11 +3,13 @@ package cli
 import (
 	"context"
 	"errors"
+	"flag"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/dirstral/dir2mcp/internal/config"
 	"github.com/dirstral/dir2mcp/internal/ingest"
@@ -36,16 +38,20 @@ const (
 
 // runServerDoctor produces a daemon-side preflight report covering
 // config loadability, state-dir writability, provider resolution for
-// each capability the server uses, extractor availability, and recent
-// indexing-failure aggregation. It does NOT contact remote providers
-// — keeping the command fast and side-effect-free was deliberately
-// preferred over deeper "ping" checks that would slow it down and
-// could fail for transient unrelated reasons.
+// each capability the server uses, extractor availability, daemon
+// liveness/port drift, a stuck-pending-embedding backlog, and recent
+// indexing-failure aggregation.
+//
+// By default it does NOT contact remote providers — keeping the command
+// fast and side-effect-free was deliberately preferred over "ping"
+// checks that could fail for transient unrelated reasons. The opt-in
+// --deep flag activates a single cheap probe embed so a present-but-
+// invalid/expired credential fails loudly instead of passing as ok (a
+// constructed-but-never-called client cannot detect bad creds — #434).
 func (a *App) runServerDoctor(ctx context.Context, global globalOptions, args []string) int {
-	if len(args) > 0 {
-		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid,
-			fmt.Sprintf("dir2mcp doctor (server-side) does not accept arguments: %s", strings.Join(args, " ")))
-		return exitConfigInvalid
+	deep, code := parseDoctorFlags(a, global, args)
+	if code != exitSuccess {
+		return code
 	}
 
 	cfg, cfgErr := loadConfigWithGlobalOptions(global)
@@ -59,13 +65,34 @@ func (a *App) runServerDoctor(ctx context.Context, global globalOptions, args []
 
 	checks = append(checks,
 		stateDirCheck(cfg.StateDir),
-		providerCheck(cfg, "embed", provider.CapEmbed, true),
-		providerCheck(cfg, "chat", provider.CapChat, false),
+		providerCheck(ctx, cfg, "embed", provider.CapEmbed, true, deep),
+		providerCheck(ctx, cfg, "chat", provider.CapChat, false, false),
 		extractorCheck(cfg),
 		extractionCoverageCheck(ctx, a, cfg),
 		indexingFailureCheck(ctx, a, cfg),
+		daemonLivenessCheck(cfg),
+		stuckPendingCheck(ctx, a, cfg),
 	)
 	return a.renderDoctorReport(global, checks)
+}
+
+// parseDoctorFlags parses the server-side doctor flags. Only --deep is
+// accepted; positional arguments are rejected (a client name would have
+// been routed to the client-side doctor before reaching here).
+func parseDoctorFlags(a *App, global globalOptions, args []string) (deep bool, code int) {
+	fs := flag.NewFlagSet("doctor", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	deepFlag := fs.Bool("deep", false, "actively probe providers (a cheap embed call) instead of only constructing clients")
+	if err := fs.Parse(args); err != nil {
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("invalid doctor flags: %v", err))
+		return false, exitConfigInvalid
+	}
+	if fs.NArg() > 0 {
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid,
+			fmt.Sprintf("dir2mcp doctor (server-side) does not accept arguments: %s", strings.Join(fs.Args(), " ")))
+		return false, exitConfigInvalid
+	}
+	return *deepFlag, exitSuccess
 }
 
 // configCheck reports whether the layered config loaded cleanly.
@@ -100,7 +127,14 @@ func stateDirCheck(stateDir string) doctorCheck {
 // check fails fast on a configured-but-unusable profile. required
 // distinguishes capabilities that must be present (embed) from those
 // that degrade gracefully when absent (chat).
-func providerCheck(cfg config.Config, label string, cap provider.Capability, required bool) doctorCheck {
+//
+// When deep is set (only for the embed capability, via `doctor --deep`)
+// the built embedder is exercised with a single cheap probe embed so a
+// present-but-invalid/expired credential surfaces as an error instead
+// of passing as ok — constructing a client never touches the network,
+// so it cannot detect bad creds (#434). The probe error is a provider
+// error (status code + code, never the key/URL), so it is safe to show.
+func providerCheck(ctx context.Context, cfg config.Config, label string, cap provider.Capability, required, deep bool) doctorCheck {
 	prof, err := cfg.Providers().Resolve(cap)
 	if err != nil {
 		status := doctorStatusError
@@ -114,12 +148,32 @@ func providerCheck(cfg config.Config, label string, cap provider.Capability, req
 		return doctorCheck{Name: "provider." + label, Status: status, Detail: err.Error()}
 	}
 	if cap == provider.CapEmbed {
-		if _, ferr := providerfactory.Embedder(prof); ferr != nil {
+		emb, ferr := providerfactory.Embedder(prof)
+		if ferr != nil {
 			return doctorCheck{Name: "provider." + label, Status: doctorStatusError,
 				Detail: fmt.Sprintf("profile %q unusable: %v", prof.Name, ferr)}
 		}
+		if deep {
+			if perr := probeEmbedder(ctx, emb, prof); perr != nil {
+				return doctorCheck{Name: "provider." + label, Status: doctorStatusError,
+					Detail: fmt.Sprintf("profile %q failed live probe (credential invalid/expired or endpoint unreachable): %v", prof.Name, perr)}
+			}
+			return doctorCheck{Name: "provider." + label, Status: doctorStatusOK, Detail: prof.Name + " (probe ok)"}
+		}
 	}
 	return doctorCheck{Name: "provider." + label, Status: doctorStatusOK, Detail: prof.Name}
+}
+
+// probeEmbedder issues one bounded, throwaway query-role embed so the
+// doctor can distinguish a working credential from a present-but-bad
+// one. The input is a fixed non-sensitive string and the result is
+// discarded; only the error matters. A short timeout keeps `doctor
+// --deep` responsive even when the endpoint hangs.
+func probeEmbedder(ctx context.Context, emb model.Embedder, prof provider.Profile) error {
+	pctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	_, err := emb.Embed(pctx, prof.EmbedTextModel, model.EmbedQuery, []string{"dir2mcp doctor probe"})
+	return err
 }
 
 // extractorCheck delegates to ingest.DescribeDocumentExtractor so the
@@ -320,6 +374,85 @@ func summarizeFailureCategories(categories map[string]int64) string {
 		parts = append(parts, fmt.Sprintf("%s=%d", e.category, e.count))
 	}
 	return strings.Join(parts, ", ")
+}
+
+// daemonProcess reports the pid recorded for this state dir and whether
+// that process is currently alive. A missing/unreadable pid file yields
+// (0, false). Used by both the liveness and stuck-pending checks.
+func daemonProcess(stateDir string) (pid int, alive bool) {
+	p, err := readPIDFile(pidFilePath(stateDir))
+	if err != nil {
+		return 0, false
+	}
+	return p, processIsAlive(p)
+}
+
+// daemonLivenessCheck reports whether a daemon is registered/alive for
+// this state dir and whether its recorded listen port is still
+// resolvable. It catches the port-drift class (#434): a daemon killed
+// with SIGKILL or stopped by the service manager can leave a stale pid
+// file or a connection.json pointing at a dead port, so clients hold a
+// URL that no longer serves. All checks are local file reads — no
+// network — so the row is cheap and always safe to run.
+func daemonLivenessCheck(cfg config.Config) doctorCheck {
+	const name = "daemon_liveness"
+	pid, err := readPIDFile(pidFilePath(cfg.StateDir))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return doctorCheck{Name: name, Status: doctorStatusOK, Detail: "no daemon registered (not running)"}
+		}
+		return doctorCheck{Name: name, Status: doctorStatusWarn, Detail: fmt.Sprintf("pid file unreadable: %v", err)}
+	}
+	if !processIsAlive(pid) {
+		return doctorCheck{Name: name, Status: doctorStatusWarn, Detail: fmt.Sprintf(
+			"stale pid file: pid %d is not running; a prior daemon exited without cleanup — run `dir2mcp down` to clear it", pid)}
+	}
+	port := readPreviousListenPort(cfg.StateDir)
+	if port == "" {
+		return doctorCheck{Name: name, Status: doctorStatusWarn, Detail: fmt.Sprintf(
+			"daemon running (pid %d) but connection.json is missing/unreadable; clients may hold a stale URL", pid)}
+	}
+	return doctorCheck{Name: name, Status: doctorStatusOK, Detail: fmt.Sprintf("daemon running (pid %d) on port %s", pid, port)}
+}
+
+// stuckPendingCheck surfaces a pending-embedding backlog that nothing is
+// draining. The existing extraction_coverage row only fires at
+// EmbeddedOK==0; a corpus with 40/100 chunks embedded and no running
+// daemon previously passed as ok even though the remaining 60 were stuck
+// forever (#434). This warns when chunks remain pending AND no daemon is
+// alive to embed them; while a daemon is running, a backlog is normal
+// mid-index and stays ok.
+func stuckPendingCheck(ctx context.Context, a *App, cfg config.Config) doctorCheck {
+	const name = "pending_backlog"
+	metaPath := filepath.Join(cfg.StateDir, "meta.sqlite")
+	if _, err := os.Stat(metaPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return doctorCheck{Name: name, Status: doctorStatusOK, Detail: "no index yet"}
+		}
+		return doctorCheck{Name: name, Status: doctorStatusError, Detail: fmt.Sprintf("stat %s: %v", metaPath, err)}
+	}
+	st := a.storeForConfig(cfg)
+	defer func() { _ = st.Close() }()
+	sqliteStore, ok := st.(*store.SQLiteStore)
+	if !ok {
+		return doctorCheck{Name: name, Status: doctorStatusWarn, Detail: "store is not SQLite-backed; pending aggregation unavailable"}
+	}
+	if err := sqliteStore.Init(ctx); err != nil && !errors.Is(err, model.ErrNotImplemented) {
+		return doctorCheck{Name: name, Status: doctorStatusError, Detail: fmt.Sprintf("initialize store: %v", err)}
+	}
+	stats, err := sqliteStore.CorpusStats(ctx)
+	if err != nil {
+		return doctorCheck{Name: name, Status: doctorStatusError, Detail: err.Error()}
+	}
+	if stats.EmbeddedPending == 0 {
+		return doctorCheck{Name: name, Status: doctorStatusOK, Detail: "0 chunks pending embedding"}
+	}
+	if _, alive := daemonProcess(cfg.StateDir); alive {
+		return doctorCheck{Name: name, Status: doctorStatusOK, Detail: fmt.Sprintf(
+			"%d chunk(s) pending; a daemon is running and draining them", stats.EmbeddedPending)}
+	}
+	return doctorCheck{Name: name, Status: doctorStatusWarn, Detail: fmt.Sprintf(
+		"%d chunk(s) stuck pending embedding and no daemon is running to drain them; start it with `dir2mcp up` (or run `dir2mcp reindex`)", stats.EmbeddedPending)}
 }
 
 // renderDoctorReport emits checks as either JSON (one object with an

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -77,11 +77,8 @@ func (a *App) runStatus(ctx context.Context, global globalOptions, args []string
 // recorded pid for liveness. Returns false when the pid file is absent,
 // malformed, or names a process that is no longer running.
 func daemonIsLive(stateDir string) bool {
-	pid, err := readPIDFile(pidFilePath(stateDir))
-	if err != nil {
-		return false
-	}
-	return processIsAlive(pid)
+	_, alive := daemonProcess(stateDir)
+	return alive
 }
 
 func (a *App) renderStatusOutput(global globalOptions, stateDir string, snapshot corpusSnapshot, source string, staleRunning bool) int {

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -1429,14 +1429,29 @@ func (a *App) setupServerSingleInstance(stateDir string, opts upOptions, cancel 
 	}
 	release, err := acquireSingleInstanceLock(stateDir)
 	if err != nil {
-		writeCLIError(a.stderr, opts.jsonOutput, exitGeneric,
-			err.Error(),
-			"Another dir2mcp server is already running for this state directory; check with `dir2mcp status` or stop it with `dir2mcp down`.",
-		)
+		// Only the genuine already-running/locked case gets the "another
+		// server is running" hint. Environmental failures (e.g. no
+		// permission to create or write the pid file) surface their real
+		// error unadorned so the hint does not mislead (#434).
+		if errors.Is(err, errAlreadyRunning) {
+			writeCLIError(a.stderr, opts.jsonOutput, exitGeneric,
+				err.Error(),
+				"Another dir2mcp server is already running for this state directory; check with `dir2mcp status` or stop it with `dir2mcp down`.",
+			)
+		} else {
+			writeCLIError(a.stderr, opts.jsonOutput, exitGeneric, err.Error())
+		}
 		return cleanup, exitGeneric
 	}
 	return release, exitSuccess
 }
+
+// errAlreadyRunning marks the single-instance lock failure caused by a
+// live server already owning the state dir (or winning the O_EXCL race),
+// as distinct from environmental failures (permission creating/writing
+// the pid file). The caller checks it with errors.Is so only the genuine
+// already-running case gets the "another server is running" hint.
+var errAlreadyRunning = errors.New("dir2mcp is already running")
 
 // acquireSingleInstanceLock claims the per-state-dir pid file so at most
 // one server process ever writes a given corpus's sqlite + index. It
@@ -1452,8 +1467,18 @@ func acquireSingleInstanceLock(stateDir string) (release func(), err error) {
 	// we must refuse.
 	if existing, rerr := readPIDFile(pidPath); rerr == nil {
 		if processIsAlive(existing) {
-			return nil, fmt.Errorf("dir2mcp is already running for %s (pid %d)", stateDir, existing)
+			return nil, fmt.Errorf("%w for %s (pid %d)", errAlreadyRunning, stateDir, existing)
 		}
+		_ = removePIDFile(pidPath)
+	} else if !errors.Is(rerr, os.ErrNotExist) {
+		// The pid file exists but is empty/corrupt/unparseable
+		// (readPIDFile errored with something other than "not exist").
+		// Its content names no live process, so treat it as a dead owner
+		// and clear it — otherwise a single malformed pid file would
+		// permanently brick startup: the O_EXCL claim below would fail
+		// and every run would report a bogus "already running" (#434). A
+		// live owner is never removed here because a live owner yields a
+		// parseable pid (the rerr == nil branch above), not an error.
 		_ = removePIDFile(pidPath)
 	}
 	if cerr := claimPIDFile(pidPath, os.Getpid()); cerr != nil {
@@ -1461,9 +1486,9 @@ func acquireSingleInstanceLock(stateDir string) (release func(), err error) {
 			// Lost the race between the stale check and the claim: another
 			// starter won. Surface its pid when we can still read it.
 			if existing, rerr := readPIDFile(pidPath); rerr == nil {
-				return nil, fmt.Errorf("dir2mcp is already running for %s (pid %d)", stateDir, existing)
+				return nil, fmt.Errorf("%w for %s (pid %d)", errAlreadyRunning, stateDir, existing)
 			}
-			return nil, fmt.Errorf("dir2mcp is already running for %s (pid file %s already claimed)", stateDir, pidPath)
+			return nil, fmt.Errorf("%w for %s (pid file %s already claimed)", errAlreadyRunning, stateDir, pidPath)
 		}
 		return nil, fmt.Errorf("claim pid file %s: %w", pidPath, cerr)
 	}

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -154,7 +154,7 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 	defer cancel()
 	defer func() { _ = ln.Close() }()
 
-	cleanupPIDFile, code := a.setupDaemonChildIfApplicable(cfg.StateDir, opts, cancel)
+	cleanupPIDFile, code := a.setupServerSingleInstance(cfg.StateDir, opts, cancel)
 	if code != exitSuccess {
 		return code
 	}
@@ -1403,36 +1403,71 @@ func (a *App) publishConnection(cfg config.Config, mcpURL string, auth authMater
 	return connection, exitSuccess
 }
 
-// setupDaemonChildIfApplicable performs the two daemon-child-only
-// preconditions that have to happen BEFORE writing connection.json: the
-// SIGTERM handler install and the O_EXCL pid-file claim. The handler is
-// installed first so a SIGTERM that arrives during the window between
-// here and the event loop is converted into a graceful cancel rather
-// than killing the child abruptly. The pid-file claim must come before
-// connection.json so a second daemon racing for the same state dir
-// loses deterministically and exits before touching anything else.
+// setupServerSingleInstance performs the preconditions that must happen
+// BEFORE writing connection.json: the daemon-child SIGTERM handler and,
+// in EVERY run mode, the single-instance pid-file lock. The handler is
+// installed first (daemon child only) so a SIGTERM in the window between
+// here and the event loop becomes a graceful cancel. The pid lock must
+// come before connection.json so a second server racing for the same
+// state dir loses deterministically and exits before touching anything.
 //
-// Returns the deferred cleanup closure (a no-op when not running as
-// daemon child) and an exit code; runUp returns immediately when the
-// code is non-zero (the helper has already written the error).
+// Crucially the lock is taken for foreground/service (`up --foreground`,
+// the launchd/systemd target) too, not just the double-fork daemon child
+// — two processes holding the same meta.sqlite + HNSW index files with
+// divergent in-memory state corrupt the index (#434). The daemon child
+// relies on its parent having reconciled a stale pid file first; the
+// foreground/service path has no parent, so acquireSingleInstanceLock
+// reconciles a dead owner itself before its O_EXCL claim.
 //
-// Extracted from runUp to keep that function under the
-// cyclomatic-complexity budget after PR #174's daemon-child setup grew.
-func (a *App) setupDaemonChildIfApplicable(stateDir string, opts upOptions, cancel context.CancelFunc) (cleanup func(), code int) {
+// Returns the deferred cleanup closure (removes the pid file on exit)
+// and an exit code; runUp returns immediately when the code is non-zero
+// (the helper has already written the error).
+func (a *App) setupServerSingleInstance(stateDir string, opts upOptions, cancel context.CancelFunc) (cleanup func(), code int) {
 	cleanup = func() {}
-	if !isRunningAsDaemonChild() {
-		return cleanup, exitSuccess
+	if isRunningAsDaemonChild() {
+		installDaemonChildSignalHandler(cancel)
 	}
-	installDaemonChildSignalHandler(cancel)
-	pidPath := pidFilePath(stateDir)
-	if err := claimPIDFile(pidPath, os.Getpid()); err != nil {
+	release, err := acquireSingleInstanceLock(stateDir)
+	if err != nil {
 		writeCLIError(a.stderr, opts.jsonOutput, exitGeneric,
-			fmt.Sprintf("claim pid file %s: %v", pidPath, err),
-			"another dir2mcp daemon is already running for this state directory; check with `dir2mcp status` or stop it with `dir2mcp down`.",
+			err.Error(),
+			"Another dir2mcp server is already running for this state directory; check with `dir2mcp status` or stop it with `dir2mcp down`.",
 		)
 		return cleanup, exitGeneric
 	}
-	return func() { _ = removePIDFile(pidPath) }, exitSuccess
+	return release, exitSuccess
+}
+
+// acquireSingleInstanceLock claims the per-state-dir pid file so at most
+// one server process ever writes a given corpus's sqlite + index. It
+// reconciles a stale pid file (owner process dead) so a clean restart is
+// not blocked by a crash, then claims with O_EXCL so two live starters
+// racing the same directory cannot both win. A live owner — or losing
+// the O_EXCL race — returns an "already running" error the caller
+// surfaces; the returned release removes the pid file on shutdown.
+func acquireSingleInstanceLock(stateDir string) (release func(), err error) {
+	pidPath := pidFilePath(stateDir)
+	// Reconcile a stale pid file whose owner is gone so the O_EXCL claim
+	// below has a clear field; a LIVE owner means a second writer, which
+	// we must refuse.
+	if existing, rerr := readPIDFile(pidPath); rerr == nil {
+		if processIsAlive(existing) {
+			return nil, fmt.Errorf("dir2mcp is already running for %s (pid %d)", stateDir, existing)
+		}
+		_ = removePIDFile(pidPath)
+	}
+	if cerr := claimPIDFile(pidPath, os.Getpid()); cerr != nil {
+		if errors.Is(cerr, os.ErrExist) {
+			// Lost the race between the stale check and the claim: another
+			// starter won. Surface its pid when we can still read it.
+			if existing, rerr := readPIDFile(pidPath); rerr == nil {
+				return nil, fmt.Errorf("dir2mcp is already running for %s (pid %d)", stateDir, existing)
+			}
+			return nil, fmt.Errorf("dir2mcp is already running for %s (pid file %s already claimed)", stateDir, pidPath)
+		}
+		return nil, fmt.Errorf("claim pid file %s: %w", pidPath, cerr)
+	}
+	return func() { _ = removePIDFile(pidPath) }, nil
 }
 
 // installInteractionForUp picks the right termination interaction for

--- a/tests/cli/service_worker_doctor_434_test.go
+++ b/tests/cli/service_worker_doctor_434_test.go
@@ -1,0 +1,224 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/cli"
+)
+
+// TestForegroundRefusesSecondInstance pins the #434 fix: `up --foreground`
+// (the launchd/systemd service target) must take the single-instance pid
+// lock, not just the double-fork daemon child. Two writers on the same
+// meta.sqlite + HNSW index files corrupt the index, so a foreground start
+// that finds a live owner must refuse and exit non-zero.
+//
+// The test pre-plants a pid file pointing at the (live) test process, then
+// starts `up --foreground`; the guard must bail before serving.
+func TestForegroundRefusesSecondInstance(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("MISTRAL_API_KEY", "test-key")
+	t.Setenv("DIR2MCP_AUTH_TOKEN", "test-token")
+
+	stateDir := filepath.Join(tmp, ".dir2mcp")
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	// A pid file whose owner is alive (this test process) simulates an already
+	// running server for the same corpus.
+	if err := os.WriteFile(filepath.Join(stateDir, "server.pid"), []byte(fmt.Sprintf("%d\n", os.Getpid())), 0o600); err != nil {
+		t.Fatalf("write pid file: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	withWorkingDir(t, tmp, func() {
+		// Generous timeout: if the guard is broken the server would serve until
+		// this fires (and exit 0), so a fast non-zero return is the pass signal.
+		ctx, cancel := context.WithTimeout(context.Background(), raceScaled(10*time.Second))
+		defer cancel()
+		code := app.RunWithContext(ctx, []string{"up", "--foreground", "--listen", "127.0.0.1:0"})
+		if code == 0 {
+			t.Fatalf("foreground up succeeded despite a live pid file; single-instance guard not applied. stderr=%s", stderr.String())
+		}
+	})
+	if !strings.Contains(stderr.String(), "already running") {
+		t.Fatalf("expected an 'already running' refusal, got stderr=%s", stderr.String())
+	}
+}
+
+// TestForegroundCleansStalePidAndStarts verifies the guard reconciles a
+// stale pid file (owner dead) rather than blocking a legitimate restart.
+// A pid that is not alive must be removed and the foreground server must
+// then acquire the lock and run until the context ends.
+func TestForegroundCleansStalePidAndStarts(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("MISTRAL_API_KEY", "test-key")
+	t.Setenv("DIR2MCP_AUTH_TOKEN", "test-token")
+
+	stateDir := filepath.Join(tmp, ".dir2mcp")
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	// PID 2^31-1 is (practically) never a live process, so the guard should
+	// treat this pid file as stale, remove it, and proceed.
+	if err := os.WriteFile(filepath.Join(stateDir, "server.pid"), []byte("2147483647\n"), 0o600); err != nil {
+		t.Fatalf("write stale pid file: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	withWorkingDir(t, tmp, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), raceScaled(2*time.Second))
+		defer cancel()
+		code := app.RunWithContext(ctx, []string{"up", "--foreground", "--listen", "127.0.0.1:0"})
+		if code != 0 {
+			t.Fatalf("foreground up refused to start over a stale pid file: code=%d stderr=%s", code, stderr.String())
+		}
+	})
+	if strings.Contains(stderr.String(), "already running") {
+		t.Fatalf("stale pid file was treated as a live instance: %s", stderr.String())
+	}
+}
+
+// TestEmbedWorkerRejectsInProcessMemoryBroker pins the #434 fix: the
+// standalone embed-worker must refuse the in-process "memory" broker,
+// whose queue is process-local, so the worker would create its own empty
+// queue, never see the daemon's jobs, and silently no-op. All other
+// distributed prerequisites are satisfied so the broker check is what
+// fails.
+func TestEmbedWorkerRejectsInProcessMemoryBroker(t *testing.T) {
+	tmp := t.TempDir()
+	// Distributed on + a shared Tier-C backend (qdrant) so we get past those
+	// prerequisites; the broker is left unset, defaulting to the in-process
+	// memory broker that the standalone worker must reject.
+	writeWorkerConfig(t, tmp, "root_dir: .\nstate_dir: .dir2mcp\n"+
+		"index_backend: qdrant\nqdrant_url: http://127.0.0.1:6334\n"+
+		"distributed_embed_enabled: true\n")
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	withWorkingDir(t, tmp, func() {
+		code := app.RunWithContext(context.Background(), []string{"--json", "embed-worker"})
+		if code != 2 {
+			t.Fatalf("unexpected exit code: got=%d want=2 stderr=%s", code, stderr.String())
+		}
+	})
+
+	payload := decodeCLIError(t, stderr.Bytes())
+	if payload.Error.Code != "CONFIG_INVALID" || payload.ExitCode != 2 {
+		t.Fatalf("unexpected payload: %+v", payload)
+	}
+	msg := strings.ToLower(payload.Error.Message)
+	if !strings.Contains(msg, "in-process") || !strings.Contains(msg, "memory") || !strings.Contains(msg, "broker") {
+		t.Fatalf("expected an in-process/memory broker rejection, got: %q", payload.Error.Message)
+	}
+}
+
+// TestDoctorDeepProbeFailsOnBadCreds pins the #434 fix: `doctor --deep`
+// must actively probe the embedding provider so a present-but-invalid
+// credential fails instead of passing as ok (construct-only never touches
+// the network). The provider points at a local endpoint returning 401.
+func TestDoctorDeepProbeFailsOnBadCreds(t *testing.T) {
+	// Local OpenAI-compatible endpoint that rejects every embed request, as a
+	// bad/expired key would.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":{"message":"invalid api key"}}`))
+	}))
+	defer srv.Close()
+
+	tmp := t.TempDir()
+	writeWorkerConfig(t, tmp, ""+
+		"root_dir: .\nstate_dir: .dir2mcp\n"+
+		"providers:\n"+
+		"  probe:\n"+
+		"    kind: openai\n"+
+		"    base_url: "+srv.URL+"/v1\n"+
+		"    embed_text_model: probe-model\n"+
+		"model:\n"+
+		"  embed:\n"+
+		"    provider: probe\n")
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	withWorkingDir(t, tmp, func() {
+		code := app.RunWithContext(context.Background(), []string{"--json", "doctor", "--deep"})
+		if code == 0 {
+			t.Fatalf("doctor --deep passed with an unauthorized embed endpoint; probe not run. stdout=%s", stdout.String())
+		}
+	})
+
+	var report struct {
+		OK     bool `json:"ok"`
+		Checks []struct {
+			Name   string `json:"name"`
+			Status string `json:"status"`
+			Detail string `json:"detail"`
+		} `json:"checks"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("decode doctor JSON: %v body=%q", err, stdout.String())
+	}
+	var embed *struct {
+		Name   string `json:"name"`
+		Status string `json:"status"`
+		Detail string `json:"detail"`
+	}
+	for i := range report.Checks {
+		if report.Checks[i].Name == "provider.embed" {
+			embed = &report.Checks[i]
+		}
+	}
+	if embed == nil {
+		t.Fatalf("doctor report missing provider.embed check: %+v", report.Checks)
+	}
+	if embed.Status != "error" {
+		t.Fatalf("provider.embed status = %q, want error (probe hit a 401); detail=%q", embed.Status, embed.Detail)
+	}
+	if !strings.Contains(embed.Detail, "probe") {
+		t.Fatalf("provider.embed detail = %q, want a probe-failure explanation", embed.Detail)
+	}
+}
+
+// TestDoctorWithoutDeepDoesNotProbe verifies the default (non-deep) doctor
+// stays construct-only: the same bad-credential endpoint must NOT be probed,
+// so provider.embed resolves ok and no network call is made.
+func TestDoctorWithoutDeepDoesNotProbe(t *testing.T) {
+	probed := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		probed = true
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	tmp := t.TempDir()
+	writeWorkerConfig(t, tmp, ""+
+		"root_dir: .\nstate_dir: .dir2mcp\n"+
+		"providers:\n"+
+		"  probe:\n"+
+		"    kind: openai\n"+
+		"    base_url: "+srv.URL+"/v1\n"+
+		"    embed_text_model: probe-model\n"+
+		"model:\n"+
+		"  embed:\n"+
+		"    provider: probe\n")
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	withWorkingDir(t, tmp, func() {
+		_ = app.RunWithContext(context.Background(), []string{"--json", "doctor"})
+	})
+	if probed {
+		t.Fatalf("default doctor probed the provider endpoint; probing must be gated behind --deep. stderr=%s", stderr.String())
+	}
+}

--- a/tests/cli/service_worker_doctor_434_test.go
+++ b/tests/cli/service_worker_doctor_434_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -87,6 +88,42 @@ func TestForegroundCleansStalePidAndStarts(t *testing.T) {
 	})
 	if strings.Contains(stderr.String(), "already running") {
 		t.Fatalf("stale pid file was treated as a live instance: %s", stderr.String())
+	}
+}
+
+// TestForegroundClearsMalformedPidAndStarts verifies the guard recovers
+// from a corrupt/unparseable pid file rather than letting it permanently
+// brick startup. A malformed pid file names no live process, so the guard
+// must treat it as a dead owner, remove it, claim the lock, and run — not
+// report a bogus "already running" (#434). Without the fix the O_EXCL
+// claim over the still-present malformed file fails and every start bails.
+func TestForegroundClearsMalformedPidAndStarts(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("MISTRAL_API_KEY", "test-key")
+	t.Setenv("DIR2MCP_AUTH_TOKEN", "test-token")
+
+	stateDir := filepath.Join(tmp, ".dir2mcp")
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	// Garbage that readPIDFile cannot parse into a pid. The guard must not
+	// mistake an unparseable file for a live owner.
+	if err := os.WriteFile(filepath.Join(stateDir, "server.pid"), []byte("not-a-pid\n"), 0o600); err != nil {
+		t.Fatalf("write malformed pid file: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	withWorkingDir(t, tmp, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), raceScaled(2*time.Second))
+		defer cancel()
+		code := app.RunWithContext(ctx, []string{"up", "--foreground", "--listen", "127.0.0.1:0"})
+		if code != 0 {
+			t.Fatalf("foreground up refused to start over a malformed pid file: code=%d stderr=%s", code, stderr.String())
+		}
+	})
+	if strings.Contains(stderr.String(), "already running") {
+		t.Fatalf("malformed pid file was treated as a live instance: %s", stderr.String())
 	}
 }
 
@@ -194,9 +231,9 @@ func TestDoctorDeepProbeFailsOnBadCreds(t *testing.T) {
 // stays construct-only: the same bad-credential endpoint must NOT be probed,
 // so provider.embed resolves ok and no network call is made.
 func TestDoctorWithoutDeepDoesNotProbe(t *testing.T) {
-	probed := false
+	var probed atomic.Bool
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		probed = true
+		probed.Store(true)
 		w.WriteHeader(http.StatusUnauthorized)
 	}))
 	defer srv.Close()
@@ -218,7 +255,7 @@ func TestDoctorWithoutDeepDoesNotProbe(t *testing.T) {
 	withWorkingDir(t, tmp, func() {
 		_ = app.RunWithContext(context.Background(), []string{"--json", "doctor"})
 	})
-	if probed {
+	if probed.Load() {
 		t.Fatalf("default doctor probed the provider endpoint; probing must be gated behind --deep. stderr=%s", stderr.String())
 	}
 }


### PR DESCRIPTION
Addresses #434 (operational-machinery gaps in service / embed-worker / doctor). Items 1, 2, 4 fixed; supervision items (3, 5 — down-vs-service teardown, Linux systemd, KeepAlive crash-loop) deferred as larger follow-ups.

## 1 [HIGH] `--foreground`/service mode single-instance guard (fixed)
`up --foreground` (the launchd/systemd target) took **no** pid lock — only the double-fork daemon child did. Two processes on the same `meta.sqlite` + HNSW index = double-writer corruption, default-reachable via `service install`.

- Single-instance pid lock now taken in **all** run modes via `acquireSingleInstanceLock`, called from `setupServerSingleInstance` (renamed from `setupDaemonChildIfApplicable`).
- The daemon child relied on its parent reconciling a stale pid file; the foreground/service path has no parent, so the new helper reconciles a **dead** owner itself (removes the stale file) before its `O_EXCL` claim. A **live** owner — or losing the `O_EXCL` race — refuses with a clear "already running" error.
- Daemon parent/child flow unchanged (parent still returns before this path; child still installs the SIGTERM handler).

## 2 [HIGH-for-feature] Standalone `embed-worker` memory-broker no-op (fixed)
`buildEmbedBroker` returns an in-process `MemBroker` for the default/`memory` broker; a standalone worker on it creates its own process-local queue, never sees the daemon's jobs, and prints "pulling jobs" while doing nothing.

- `requireDistributedPrereqs` now rejects the `memory` (and unset) broker for the standalone worker with a remediable `CONFIG_INVALID`, directing the operator to `broker=sqlite`/external (a queue shared with the daemon).

## 4 [MED] `doctor` false-OK on bad creds (fixed)
Doctor only *constructed* the embedder (no network call), so a present-but-invalid/expired key passed as `ok`.

- New opt-in `doctor --deep` flag runs a single cheap throwaway embed probe; a 401/unreachable endpoint now reports `provider.embed = error`. Default doctor stays construct-only (fast, no network).
- New `daemon_liveness` check: reads the pid file + `connection.json` to surface a stale pid / port drift (dead owner, missing connection file).
- New `pending_backlog` check: warns when chunks are stuck pending embedding and no daemon is running to drain them (the old `EmbeddedOK==0`-only check missed 40/100-pending corpora).
- No secrets in output — the probe uses a fixed non-sensitive input and provider errors carry only a code/status.

## Deferred (noted, not in scope of this PR)
- **Item 3**: `dir2mcp down` can't stop a service-managed foreground daemon (resolves only via `server.pid`). Note: foreground now *writes* a pid file, so `down` partially works, but the full teardown contract is out of scope (`down.go` untouched).
- **Item 5**: Linux systemd backend + `KeepAlive={SuccessfulExit:false}`/backoff — larger supervision work.

## Tests (tests/cli/service_worker_doctor_434_test.go)
- foreground refuses a second instance on a live pid file; and cleans a stale pid file and starts.
- standalone worker rejects the in-process memory broker.
- `doctor --deep` reports embed failure against a 401 endpoint; default doctor does **not** probe.

## Validation
`gofmt -l internal/ tests/` clean; `go build ./...`; `go vet ./...`; `make cyclo` (≤15); `golangci-lint run` — 0 issues; `go test ./internal/cli/... ./tests/cli/... ./tests/security/...` all pass.