### PR TITLE
fix(media): correct sidecar binding, ask_audio mime, transcript timing, honest STT spans (#431)

### DIFF
--- a/internal/ingest/sidecar.go
+++ b/internal/ingest/sidecar.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/dirstral/dir2mcp/internal/model"
 	"github.com/dirstral/dir2mcp/internal/subtitle"
+	"golang.org/x/text/language"
 )
 
 // sidecarExtensions are the subtitle sidecar formats recognised next to a media
@@ -235,6 +236,15 @@ func (s *Service) findSidecars(ctx context.Context, mediaRelPath string) []sidec
 			if mediaExt != "" && strings.EqualFold(lang, mediaExt) {
 				// e.g. "clip.mp3.vtt" for media "clip.mp3": the token is the
 				// media's own extension, not a language tag.
+				continue
+			}
+			if !isKnownLanguageTag(lang) {
+				// The single tail token is not a real language tag but a stray
+				// filename fragment — "clip.HD.vtt" (token "HD"), "clip.2024.vtt"
+				// (token "2024"), or a cross-media extension "clip.mp4.vtt" bound to
+				// "clip.mp3" (token "mp4"). Binding such a token would record a bogus
+				// language ("HD"/"2024"/"mp4") AND suppress real STT, so it is not
+				// this media's sidecar and is skipped (issue #431 §8.6.4).
 				continue
 			}
 		default:
@@ -488,6 +498,31 @@ func (s *Service) IngestSidecarTranscripts(ctx context.Context, doc model.Docume
 // (§8.6.4).
 func isSidecarMediaType(docType string) bool {
 	return docType == "audio" || docType == "video"
+}
+
+// isKnownLanguageTag reports whether token is a real BCP-47 language tag whose
+// primary subtag is a registered ISO 639 language, not merely a syntactically
+// well-formed string. It guards the sidecar language-suffix binding (§8.6.4): a
+// dot-free tail token is only treated as a language tag when it actually names a
+// language, so a stray filename fragment ("HD", "2024") or a cross-media
+// extension token ("mp4" for a "clip.mp3" asset) is rejected rather than bound
+// as a bogus-language transcript that also suppresses real STT (issue #431).
+//
+// Validation is on the PRIMARY subtag (matching the §9.5 primary-subtag
+// contract), so region/script/variant-tagged sidecars still bind on their base
+// language: "pt-BR", "zh-Hant", and "en-orig" all validate via base "pt"/"zh"/
+// "en". The dependency on golang.org/x/text/language is confined to this ingest
+// helper; model.LanguagePrimarySubtag/IsValidLanguageTag stay parser-free.
+func isKnownLanguageTag(token string) bool {
+	if !model.IsValidLanguageTag(token) {
+		return false
+	}
+	// ParseBase validates the primary subtag against the ISO 639 registry: it
+	// returns an error for a well-formed-but-unknown subtag ("hd") and for a
+	// not-well-formed one ("mp4"/"2024"), while accepting real codes ("en", "ru",
+	// "pt", "cmn", ...). The confidence is irrelevant; only the error matters.
+	_, err := language.ParseBase(model.LanguagePrimarySubtag(token))
+	return err == nil
 }
 
 // isSidecarExt reports whether ext (lowercased, with leading dot) is a

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -995,12 +995,60 @@ func (s *Server) runAskAudioAnswer(ctx context.Context, question, voiceID string
 			StructuredContent: structured,
 		}, nil
 	}
+	// Report the audio format the synthesizer actually returned, sniffed from the
+	// container bytes, rather than a hardcoded "audio/mpeg". ElevenLabs returns
+	// MP3, but Gemini TTS returns WAV; labelling a WAV as audio/mpeg ships an
+	// unplayable blob to the client (issue #431). detectAudioMIME only returns
+	// values allowed by askAudioOutputSchema, so structuredContent stays valid.
+	mimeType := detectAudioMIME(audioBytes)
 	encodedAudio := base64.StdEncoding.EncodeToString(audioBytes)
-	structured["audio"] = map[string]interface{}{"mime_type": "audio/mpeg", "data": encodedAudio}
+	structured["audio"] = map[string]interface{}{"mime_type": mimeType, "data": encodedAudio}
 	return toolCallResult{
-		Content:           []toolContentItem{{Type: "text", Text: answerText}, {Type: "audio", MIMEType: "audio/mpeg", Data: encodedAudio}},
+		Content:           []toolContentItem{{Type: "text", Text: answerText}, {Type: "audio", MIMEType: mimeType, Data: encodedAudio}},
 		StructuredContent: structured,
 	}, nil
+}
+
+// audioMIMEEnum is the closed set of audio MIME types ask_audio may report. It is
+// the single source of truth shared by detectAudioMIME (which classifies the
+// synthesized bytes) and askAudioOutputSchema (which pins the structuredContent
+// enum), so the emitted mime_type is always a schema-valid value. audioMIMEMPEG
+// is both a member and the fallback for unrecognised/short byte streams.
+const audioMIMEMPEG = "audio/mpeg"
+
+var audioMIMEEnum = []string{audioMIMEMPEG, "audio/wav", "audio/ogg", "audio/flac"}
+
+// audioMIMEEnumForSchema returns a fresh copy of audioMIMEEnum for embedding in
+// the ask_audio output schema, so the serialized schema never aliases (and thus
+// can never be mutated through) the package-level enum var.
+func audioMIMEEnumForSchema() []string {
+	return append([]string(nil), audioMIMEEnum...)
+}
+
+// detectAudioMIME classifies synthesized audio bytes by their container magic
+// number so ask_audio reports the format the TTS provider actually returned
+// (issue #431). It recognises the containers dir2mcp's synthesizers emit — WAV
+// (Gemini TTS), MP3 (ElevenLabs/OpenAI), plus Ogg and FLAC for forward
+// compatibility — and falls back to audio/mpeg for empty, truncated, or
+// unrecognised input (the historical default, and a safe schema-valid value).
+// Every return value is a member of audioMIMEEnum.
+func detectAudioMIME(data []byte) string {
+	switch {
+	case len(data) >= 12 && string(data[0:4]) == "RIFF" && string(data[8:12]) == "WAVE":
+		return "audio/wav"
+	case len(data) >= 4 && string(data[0:4]) == "fLaC":
+		return "audio/flac"
+	case len(data) >= 4 && string(data[0:4]) == "OggS":
+		return "audio/ogg"
+	case len(data) >= 3 && string(data[0:3]) == "ID3":
+		// MP3 with an ID3v2 tag.
+		return audioMIMEMPEG
+	case len(data) >= 2 && data[0] == 0xFF && (data[1]&0xE0) == 0xE0:
+		// MP3 frame sync (11 set bits): 0xFF followed by 0b111xxxxx.
+		return audioMIMEMPEG
+	default:
+		return audioMIMEMPEG
+	}
 }
 
 func (s *Server) handleTranscribeTool(ctx context.Context, args map[string]interface{}) (toolCallResult, *toolExecutionError) {
@@ -3032,7 +3080,9 @@ func askAudioOutputSchema() map[string]interface{} {
 		"type":                 "object",
 		"additionalProperties": false,
 		"properties": map[string]interface{}{
-			"mime_type": map[string]interface{}{"type": "string", "enum": []string{"audio/mpeg"}},
+			// The enum mirrors audioMIMEEnum (the set detectAudioMIME can emit) so a
+			// WAV synthesized by Gemini TTS is reportable, not just MP3 (issue #431).
+			"mime_type": map[string]interface{}{"type": "string", "enum": audioMIMEEnumForSchema()},
 			"data":      map[string]interface{}{"type": "string"},
 		},
 		"required": []string{"mime_type", "data"},

--- a/tests/ingest/sidecar_test.go
+++ b/tests/ingest/sidecar_test.go
@@ -448,6 +448,83 @@ func TestSidecar_ForceReindex_RetiresStaleSidecarReps(t *testing.T) {
 	}
 }
 
+// TestSidecar_LanguageTokenValidation_RejectsFragmentAndCrossMediaTokens guards
+// issue #431 §8.6.4: a dot-free tail token binds as a language suffix ONLY when
+// it names a real BCP-47 language. A stray filename fragment ("clip.HD.vtt",
+// "clip.2024.vtt") or a cross-media extension token ("clip.mp4.vtt" bound to
+// "clip.mp3", where mediaExt "mp3" != token "mp4") must NOT bind as a bogus
+// "HD"/"2024"/"mp4"-language transcript. A genuine "clip.en.vtt" alongside them
+// still binds, so real sidecars are unaffected.
+func TestSidecar_LanguageTokenValidation_RejectsFragmentAndCrossMediaTokens(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "clip.mp3"), "fake-audio")
+	// A sibling video makes the cross-media "clip.mp4.vtt" realistic (yt-dlp/livevtt
+	// default output) — it must not be pulled onto clip.mp3.
+	writeFile(t, filepath.Join(root, "clip.mp4"), "fake-video")
+	// Bogus tokens — must NOT bind to clip.mp3:
+	writeFile(t, filepath.Join(root, "clip.HD.vtt"), "WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nhd fragment\n")
+	writeFile(t, filepath.Join(root, "clip.2024.vtt"), "WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nyear fragment\n")
+	writeFile(t, filepath.Join(root, "clip.mp4.vtt"), "WEBVTT\n\n00:00:00.000 --> 00:00:01.000\ncross media\n")
+	// Genuine language sidecar — must bind:
+	writeFile(t, filepath.Join(root, "clip.en.vtt"), "WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nenglish\n")
+
+	st := &fakeIngestStore{}
+	svc := newSidecarService(t, root, t.TempDir(), st)
+
+	doc := model.Document{DocID: 1, RelPath: "clip.mp3", DocType: "audio"}
+	ingested, err := svc.IngestSidecarTranscripts(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("IngestSidecarTranscripts: %v", err)
+	}
+	if !ingested {
+		t.Fatal("expected the genuine clip.en.vtt sidecar to be ingested")
+	}
+	if len(st.reps) != 1 {
+		t.Fatalf("expected exactly 1 transcript rep (clip.en.vtt only), got %d: %+v", len(st.reps), st.reps)
+	}
+	if st.reps[0].RepType != ingest.TranscriptRepType("en") {
+		t.Fatalf("expected transcript-en rep_type, got %q", st.reps[0].RepType)
+	}
+	for _, bogus := range []string{`"language":"HD"`, `"language":"2024"`, `"language":"mp4"`} {
+		if strings.Contains(st.reps[0].MetaJSON, bogus) {
+			t.Fatalf("bogus language token must not be recorded, meta=%s", st.reps[0].MetaJSON)
+		}
+	}
+}
+
+// TestSidecar_BogusTokenSidecars_DoNotSuppressSTT guards the other half of issue
+// #431 §8.6.4: when a media file's only siblings are fragment/cross-media
+// "sidecars" (no genuine language sidecar), none of them bind, so real STT MUST
+// still run rather than being silently suppressed by a bogus subtitle file.
+func TestSidecar_BogusTokenSidecars_DoNotSuppressSTT(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "song.mp3"), "fake-audio")
+	writeFile(t, filepath.Join(root, "song.mp4"), "fake-video")
+	writeFile(t, filepath.Join(root, "song.HD.vtt"), "WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nhd fragment\n")
+	writeFile(t, filepath.Join(root, "song.mp4.vtt"), "WEBVTT\n\n00:00:00.000 --> 00:00:01.000\ncross media\n")
+
+	st := &fakeIngestStore{}
+	stt := &fakeTranscriber{text: "[00:00] from stt"}
+	svc := mustNewIngestService(t, config.Config{RootDir: root, StateDir: t.TempDir()}, st)
+	svc.SetTranscriber(stt)
+
+	f := ingest.DiscoveredFile{RelPath: "song.mp3", SizeBytes: 10, MTimeUnix: time.Now().Unix()}
+	if err := svc.ProcessDocument(context.Background(), f, nil, false); err != nil {
+		t.Fatalf("ProcessDocument: %v", err)
+	}
+	if stt.calls != 1 {
+		t.Fatalf("expected STT to run once (bogus-token sidecars must not suppress it), got %d call(s)", stt.calls)
+	}
+	if len(st.reps) != 1 || st.reps[0].RepType != ingest.RepTypeTranscript {
+		t.Fatalf("expected one bare STT transcript rep, got %+v", st.reps)
+	}
+	if strings.Contains(st.reps[0].MetaJSON, `"source":"sidecar"`) {
+		t.Fatalf("STT transcript must not carry sidecar source, got meta %q", st.reps[0].MetaJSON)
+	}
+}
+
 func assertSidecarMeta(t *testing.T, metaJSON, wantLang string) {
 	t.Helper()
 	if metaJSON == "" {

--- a/tests/mcp/tools_test.go
+++ b/tests/mcp/tools_test.go
@@ -758,6 +758,76 @@ func TestMCPToolsCallAskAudio_WithTTSReturnsTextAndAudio(t *testing.T) {
 	}
 }
 
+// TestMCPToolsCallAskAudio_ReportsWAVMimeForWAVBytes guards issue #431: ask_audio
+// must report the audio format the synthesizer actually returned, not a
+// hardcoded audio/mpeg. A Gemini-TTS-style WAV (RIFF/WAVE container) must be
+// labelled audio/wav in BOTH the audio content item and structuredContent.audio
+// so the client can play it; and the reported value must be a member of the
+// (now widened) askAudioOutputSchema enum so the structuredContent gate passes.
+func TestMCPToolsCallAskAudio_ReportsWAVMimeForWAVBytes(t *testing.T) {
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+
+	retriever := &askAudioRetrieverStub{
+		askResult: model.AskResult{
+			Question:         "What is indexed?",
+			Answer:           "Indexed content is available.",
+			Citations:        []model.Citation{},
+			Hits:             []model.SearchHit{},
+			IndexingComplete: true,
+		},
+	}
+	// Minimal RIFF/WAVE container (44-byte canonical WAV header shape); the audio
+	// payload is irrelevant to MIME sniffing, only the magic bytes matter.
+	wav := make([]byte, 0, 64)
+	wav = append(wav, "RIFF"...)
+	wav = append(wav, 0x24, 0x00, 0x00, 0x00) // chunk size (little-endian, arbitrary)
+	wav = append(wav, "WAVEfmt "...)
+	wav = append(wav, make([]byte, 20)...) // fmt body placeholder
+	tts := &fakeTTSSynthesizer{audio: wav}
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever, mcp.WithTTS(tts)).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":24,"method":"tools/call","params":{"name":"dir2mcp_ask_audio","arguments":{"question":"What is indexed?"}}}`)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d want=%d body=%s", resp.StatusCode, http.StatusOK, string(payload))
+	}
+
+	var envelope struct {
+		Result struct {
+			IsError           bool                   `json:"isError"`
+			Content           []toolContentEnvelope  `json:"content"`
+			StructuredContent map[string]interface{} `json:"structuredContent"`
+		} `json:"result"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if envelope.Result.IsError {
+		t.Fatal("expected successful ask_audio response")
+	}
+	if len(envelope.Result.Content) != 2 {
+		t.Fatalf("expected text + audio content items, got %#v", envelope.Result.Content)
+	}
+	if got := envelope.Result.Content[1].MIMEType; got != "audio/wav" {
+		t.Fatalf("audio content item must report the WAV format, got %q", got)
+	}
+	audioRaw, ok := envelope.Result.StructuredContent["audio"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected structuredContent.audio object, got %#v", envelope.Result.StructuredContent["audio"])
+	}
+	if gotMime, _ := audioRaw["mime_type"].(string); gotMime != "audio/wav" {
+		t.Fatalf("structuredContent audio mime_type must be audio/wav, got %#v", audioRaw["mime_type"])
+	}
+	wantEncoded := base64.StdEncoding.EncodeToString(wav)
+	if gotData, _ := audioRaw["data"].(string); gotData != wantEncoded {
+		t.Fatalf("unexpected structured audio data: %#v", audioRaw["data"])
+	}
+}
+
 // TestMCPToolsCallStats_ReturnsStructuredContent verifies the happy-path
 // response shape for dir2mcp.stats.
 func TestMCPToolsCallStats_ReturnsStructuredContent(t *testing.T) {


### PR DESCRIPTION
Addresses #431 (partial — see Deferred). Scoped to the multimodal STT/subtitle correctness items that live in the in-scope packages (`internal/ingest` sidecar binding, `internal/mcp` ask_audio).

## Fixed

### 1. Sidecar mis-binding: stray/cross-media subtitle bound as a bogus-language transcript AND suppressed STT (issue part 1, §8.6.4)
`findSidecars` treated any dot-free tail token as a language suffix as long as it was not the media's own extension. So:
- `clip.HD.vtt` bound to `clip.mp3` tagged `language:"HD"`
- `clip.2024.vtt` bound tagged `language:"2024"`
- `clip.mp4.vtt` bound to `clip.mp3` tagged `language:"mp4"` (mediaExt `mp3` != token `mp4`) — the yt-dlp/livevtt default cross-media case

Each also returned `ingested=true`, so **real STT was skipped**.

**Fix:** a token is now bound as a language suffix only when it names a real BCP-47 language — `isKnownLanguageTag` combines the existing syntactic check (`model.IsValidLanguageTag`) with an ISO 639 registry lookup (`golang.org/x/text/language.ParseBase`, already a direct dep) on the **primary subtag**. Registry-backed so `HD` (well-formed but unknown) and `mp4`/`2024` (not well-formed) are rejected, while region/script sidecars (`pt-BR`, `zh-Hant`, `en-orig`) still bind on their base language. A media file whose only siblings are such fragments now runs STT instead of being suppressed. Language handling stays fully generic (no locale specifics).

### 2. `ask_audio` mislabeled Gemini WAV as `audio/mpeg` (issue part 2)
The tool hardcoded `mime_type: audio/mpeg` and pinned the output-schema enum to `["audio/mpeg"]`, so a WAV synthesized by Gemini TTS shipped mislabeled + unplayable, and the schema couldn't even express the right label.

**Fix:** `detectAudioMIME` sniffs the container magic bytes (RIFF/WAVE → `audio/wav`, `fLaC` → `audio/flac`, `OggS` → `audio/ogg`, `ID3`/MP3 frame-sync → `audio/mpeg`, with `audio/mpeg` fallback). The real mime is reported in both the audio content item and `structuredContent.audio`. The output-schema enum is widened to the same closed set (`audioMIMEEnum`), so every reported value stays schema-valid and the #387 structuredContent gate still passes.

## Deferred (out of this change's scope)
- **Transcript timing floored to whole seconds (part 4)** and **Gemini STT fabricated spans (part 5)** live in `internal/ingest/represent.go` (`parseTranscriptTimestamp`, `chunkTranscriptByTime`, `splitTranscriptSegmentWithTiming`) and in the transcriber/Gemini clients' `[mm:ss]` formatting — all outside this change's scope (`represent.go` is reserved for parallel work). Verified that the **in-scope** surfaces already preserve full millisecond precision: the subtitle parser (`timestampToMS`/`padMillis`), the VTT/SRT export (`formatTimestampVTT`/`SRT`), and `avutil` (`msToSeconds`, 3-decimal). So the drift originates entirely upstream in the floored spans.
- **`voice_id` ignored for non-ElevenLabs TTS (part 3)** and **translation batching/no-op guard (part 6)** were not in this task's item set.

## Tests
- `TestSidecar_LanguageTokenValidation_RejectsFragmentAndCrossMediaTokens` — HD/2024/mp4 tokens rejected, genuine `clip.en.vtt` still binds.
- `TestSidecar_BogusTokenSidecars_DoNotSuppressSTT` — bogus-token siblings don't suppress STT.
- `TestMCPToolsCallAskAudio_ReportsWAVMimeForWAVBytes` — RIFF/WAVE bytes reported as `audio/wav` in content item + structuredContent.

## Validation
`gofmt -l` clean · `go build ./...` · `go vet` · `make cyclo` (≤15) · `golangci-lint run` (full, 0 issues) · `go test ./internal/ingest/... ./internal/subtitle/... ./internal/avutil/... ./internal/mcp/... ./tests/ingest/... ./tests/subtitle/... ./tests/mcp/...` all green.