### PR TITLE
fix(retrieval,ingest): evict tombstoned chunks on partial reindex; watcher follows symlinks (#409)

### DIFF
--- a/internal/ingest/watch.go
+++ b/internal/ingest/watch.go
@@ -64,7 +64,7 @@ func (s *Service) Watch(ctx context.Context) error {
 	}
 	defer func() { _ = watcher.Close() }()
 
-	if err := s.addWatchDirs(watcher, absRoot); err != nil {
+	if err := s.addWatchDirs(watcher, absRoot, DiscoverOptionsFromConfig(s.cfg).FollowSymlinks); err != nil {
 		// A failure to register some dirs is non-fatal — the safety rescan
 		// still catches changes there. Log and continue.
 		s.getLogger().Printf("watch: registering directories: %v", err)
@@ -198,6 +198,23 @@ func (w *fsWatchLoop) handleEvent(ev fsnotify.Event) {
 // immediately rather than at the next safety rescan. It only walks the
 // directory tree (no document I/O), so it stays cheap on the event loop.
 func (w *fsWatchLoop) registerNewTree(absDir string) {
+	addDir := func(path string) {
+		if err := w.watcher.Add(path); err != nil {
+			w.svc.getLogger().Printf("watch: add %s: %v", path, err)
+		}
+	}
+	// Regular files already present in the new tree are armed for indexing;
+	// discovery filters are applied later in process().
+	armFile := func(path string) { w.arm(path, false) }
+
+	// With symlink following on, descend symlinked subdirectories too so the
+	// watch coverage matches the discovery walker (internal/corpusfs/local.go),
+	// which follows them when IngestFollowSymlinks is set. The default (off) path
+	// keeps the historical WalkDir behavior byte-for-byte.
+	if w.opts.FollowSymlinks {
+		walkWatchTree(absDir, resolvedRoot(w.absRoot), map[string]struct{}{}, addDir, armFile)
+		return
+	}
 	_ = filepath.WalkDir(absDir, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return nil
@@ -206,14 +223,10 @@ func (w *fsWatchLoop) registerNewTree(absDir string) {
 			if path != absDir && shouldSkipDirectory(d.Name()) {
 				return filepath.SkipDir
 			}
-			if err := w.watcher.Add(path); err != nil {
-				w.svc.getLogger().Printf("watch: add %s: %v", path, err)
-			}
+			addDir(path)
 			return nil
 		}
-		// Regular file already present in the new tree — arm it for indexing.
-		// Discovery filters are applied later in process().
-		w.arm(path, false)
+		armFile(path)
 		return nil
 	})
 }
@@ -347,8 +360,22 @@ func matchesGitignoreForFile(absRoot, relPath string) (bool, error) {
 // fsnotify is not recursive, so each directory must be added individually. A
 // single unwatchable directory does not abort registration of its siblings;
 // per-directory failures are aggregated and returned.
-func (s *Service) addWatchDirs(watcher *fsnotify.Watcher, absRoot string) error {
+func (s *Service) addWatchDirs(watcher *fsnotify.Watcher, absRoot string, followSymlinks bool) error {
 	var errs []error
+	add := func(path string) {
+		if addErr := watcher.Add(path); addErr != nil {
+			errs = append(errs, fmt.Errorf("watch %s: %w", path, addErr))
+		}
+	}
+	// When symlink following is enabled, register watches on symlinked
+	// subdirectories too, matching the discovery walker (internal/corpusfs/local.go)
+	// so an fsnotify-driven edit under a symlinked tree is observed rather than
+	// waiting for the 10-minute safety rescan (issue #409). Cycles terminate via
+	// the resolved-path visited set. The default (off) path is unchanged.
+	if followSymlinks {
+		walkWatchTree(absRoot, resolvedRoot(absRoot), map[string]struct{}{}, add, nil)
+		return errors.Join(errs...)
+	}
 	_ = filepath.WalkDir(absRoot, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return nil // skip unreadable entries; safety rescan still covers them
@@ -359,12 +386,94 @@ func (s *Service) addWatchDirs(watcher *fsnotify.Watcher, absRoot string) error 
 		if path != absRoot && shouldSkipDirectory(d.Name()) {
 			return filepath.SkipDir
 		}
-		if addErr := watcher.Add(path); addErr != nil {
-			errs = append(errs, fmt.Errorf("watch %s: %w", path, addErr))
-		}
+		add(path)
 		return nil
 	})
 	return errors.Join(errs...)
+}
+
+// resolvedRoot resolves absRoot to its canonical path for use as the containment
+// anchor of a symlink-following watch walk. A resolve failure falls back to the
+// lexical (cleaned) root so the walk still proceeds.
+func resolvedRoot(absRoot string) string {
+	if r, err := filepath.EvalSymlinks(absRoot); err == nil {
+		return filepath.Clean(r)
+	}
+	return filepath.Clean(absRoot)
+}
+
+// withinResolvedRoot reports whether candidate resolves inside rootResolved,
+// mirroring the discovery walker's isWithinRoot containment check
+// (internal/corpusfs/local.go): the watcher follows a symlink only when its
+// target stays inside the corpus, so it never watches (or indexes) content the
+// initial scan would not.
+func withinResolvedRoot(rootResolved, candidate string) bool {
+	rel, err := filepath.Rel(rootResolved, filepath.Clean(candidate))
+	if err != nil {
+		return false
+	}
+	if rel == "." {
+		return true
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel)
+}
+
+// walkWatchTree recursively visits absDir, invoking onDir for every non-skipped
+// directory and onFile (when non-nil) for every regular file, descending into
+// symlinked directories too. It is used only on the symlink-following watch
+// path and mirrors the discovery walker (internal/corpusfs/local.go): the
+// visited set holds resolved (EvalSymlinks) directory paths already entered so a
+// symlink cycle terminates AND a target reachable via both its real and a
+// symlinked name is walked once (under whichever name is seen first); a
+// symlinked directory is followed only when its target stays within rootResolved.
+// onDir/onFile receive the lexical path (through the symlink) so emitted fsnotify
+// events map back to a path under the watched root.
+func walkWatchTree(absDir, rootResolved string, visited map[string]struct{}, onDir func(string), onFile func(string)) {
+	resolved := resolvedRoot(absDir)
+	if !withinResolvedRoot(rootResolved, resolved) {
+		return
+	}
+	if _, seen := visited[resolved]; seen {
+		return
+	}
+	visited[resolved] = struct{}{}
+
+	onDir(absDir)
+
+	entries, err := os.ReadDir(absDir)
+	if err != nil {
+		return // unreadable dir; safety rescan still covers it
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		child := filepath.Join(absDir, name)
+		switch {
+		case entry.IsDir():
+			if shouldSkipDirectory(name) {
+				continue
+			}
+			walkWatchTree(child, rootResolved, visited, onDir, onFile)
+		case entry.Type()&os.ModeSymlink != 0:
+			// Resolve the link to decide dir-vs-file; descend symlinked dirs
+			// (containment is enforced on entry) and arm symlinked regular files.
+			target, statErr := os.Stat(child)
+			if statErr != nil {
+				continue
+			}
+			if target.IsDir() {
+				if shouldSkipDirectory(name) {
+					continue
+				}
+				walkWatchTree(child, rootResolved, visited, onDir, onFile)
+			} else if onFile != nil && target.Mode().IsRegular() {
+				onFile(child)
+			}
+		default:
+			if onFile != nil {
+				onFile(child)
+			}
+		}
+	}
 }
 
 // processDelete tombstones a single removed path and evicts it from retrieval,

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -925,6 +925,88 @@ func (s *Service) EvictDocuments(relPaths []string) {
 	s.metaMu.Unlock()
 }
 
+// chunkLivenessChecker is an optional store capability: it resolves a chunk by
+// id and returns model.ErrNotFound when that chunk has been tombstoned (or never
+// existed). The shipped *store.SQLiteStore satisfies it via ChunkTaskByID, whose
+// query selects only deleted=0 rows. Retrieval type-asserts against it (mirroring
+// the LexicalSearcher / DocumentHashLister optional-capability pattern) to prune
+// chunks a partial incremental reindex soft-deleted via SoftDeleteChunksFromOrdinal
+// but for which no whole-document eviction ever fired (issue #409). Stores that do
+// not implement it skip the liveness pass entirely, so behavior is unchanged.
+type chunkLivenessChecker interface {
+	ChunkTaskByID(ctx context.Context, chunkID uint64) (model.ChunkTask, string, error)
+}
+
+// EvictChunks removes the given chunk labels from the in-memory retrieval
+// metadata and drops their vectors from the text and code indexes. It is the
+// chunk-granularity analogue of EvictDocuments: an in-place edit that shrinks a
+// document tombstones its trailing chunks via SoftDeleteChunksFromOrdinal without
+// a whole-document delete, so those labels are never pruned by EvictDocuments and
+// would keep resolving to their stale snippet/vector until the daemon restarts
+// (issue #409). It is safe for concurrent use with search — the metadata maps are
+// guarded by metaMu and each index owns its own lock. Unknown labels are ignored.
+func (s *Service) EvictChunks(labels []uint64) {
+	if len(labels) == 0 {
+		return
+	}
+	s.metaMu.Lock()
+	textIndex := s.textIndex
+	codeIndex := s.codeIndex
+	for _, label := range labels {
+		delete(s.chunkByLabel, label)
+		for _, byIndex := range s.chunkByIndex {
+			delete(byIndex, label)
+		}
+	}
+	s.metaMu.Unlock()
+
+	// Also drop the vectors so the ANN scan stops returning the tombstoned labels
+	// as candidates. Delete ignores unknown ids, so issuing to both indexes is
+	// safe regardless of which one held a given label. A fresh context is used so
+	// the eviction still completes if the triggering query's context was canceled.
+	if textIndex != nil {
+		_ = textIndex.Delete(context.Background(), labels)
+	}
+	if codeIndex != nil {
+		_ = codeIndex.Delete(context.Background(), labels)
+	}
+}
+
+// pruneTombstonedHits drops (and evicts) hits whose chunk was soft-deleted in the
+// store since it was indexed — the partial incremental-reindex staleness of issue
+// #409, where SoftDeleteChunksFromOrdinal tombstones trailing chunks with no
+// whole-document eviction to prune them from the in-memory index. Each hit's
+// liveness is validated against the store (ChunkTaskByID returns model.ErrNotFound
+// for a tombstoned chunk); tombstoned labels are removed from the retrieval maps
+// and indexes via EvictChunks so subsequent searches never resurface them without
+// a restart. The pass is fail-open: a store that does not implement the liveness
+// capability, a zero label, or any non-ErrNotFound lookup error leaves the hit in
+// place, so a transient store error can never drop otherwise-valid results.
+func (s *Service) pruneTombstonedHits(ctx context.Context, hits []model.SearchHit) []model.SearchHit {
+	if len(hits) == 0 {
+		return hits
+	}
+	checker, ok := s.store.(chunkLivenessChecker)
+	if !ok {
+		return hits
+	}
+	var evict []uint64
+	live := hits[:0]
+	for _, hit := range hits {
+		if hit.ChunkID != 0 {
+			if _, _, err := checker.ChunkTaskByID(ctx, hit.ChunkID); errors.Is(err, model.ErrNotFound) {
+				evict = append(evict, hit.ChunkID)
+				continue
+			}
+		}
+		live = append(live, hit)
+	}
+	if len(evict) > 0 {
+		s.EvictChunks(evict)
+	}
+	return live
+}
+
 func (s *Service) SetChunkMetadataForIndex(indexName string, label uint64, metadata model.SearchHit) {
 	kind := strings.ToLower(strings.TrimSpace(indexName))
 	if kind != "text" && kind != "code" {
@@ -1018,11 +1100,16 @@ func (s *Service) search(ctx context.Context, query model.SearchQuery) ([]model.
 	// decayed score and newer content survives a tie. Config-only; default 0 ⇒
 	// pass-through (no allocation, no lookups).
 	hits = s.applyRecencyDecay(ctx, hits)
-	// Apply the server-side relevance floor LAST: after scoring/fusion/rerank,
+	// Apply the server-side relevance floor: after scoring/fusion/rerank,
 	// the optional HyDE fusion, any cross-lingual fusion, their dedup/truncation,
 	// and the recency decay, using each hit's final authoritative Score.
 	// Config-only; default 0 ⇒ pass-through.
-	return s.applyMinScoreFloor(hits), nil
+	hits = s.applyMinScoreFloor(hits)
+	// Prune (and evict) any chunk the store has since tombstoned — the partial
+	// incremental-reindex staleness of issue #409. Done LAST, on the small final
+	// result set, so at most k store lookups run per query and deleted content is
+	// never returned (nor cited) even before the next restart.
+	return s.pruneTombstonedHits(ctx, hits), nil
 }
 
 // searchByMode runs the index-mode dispatch (text/code/both/auto) for one query

--- a/tests/ingest/watch_test.go
+++ b/tests/ingest/watch_test.go
@@ -170,6 +170,65 @@ func TestWatch_IndexesFileInNewSubdir(t *testing.T) {
 	waitForPaths(t, st, "nested/deep.txt", true)
 }
 
+// TestWatch_FollowsSymlinkedDir verifies that with ingest.follow_symlinks on,
+// the watcher registers a watch on a symlinked directory tree (matching the
+// discovery walker) so an edit behind the symlink produces an event rather than
+// waiting for the 10-minute safety rescan (issue #409). Without the fix,
+// addWatchDirs's plain WalkDir never descends the symlink, so a file created
+// behind it is not reindexed under the symlinked path within the poll window.
+//
+// The link name ("aaa_link") sorts before the real target ("zzz_data"), so —
+// mirroring the discovery walker's visited-by-resolved-path dedup — the tree is
+// indexed and watched under the symlinked path; that is exactly the path a plain
+// WalkDir watcher would leave unwatched.
+func TestWatch_FollowsSymlinkedDir(t *testing.T) {
+	requireWatchIntegration(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	root := t.TempDir()
+
+	// A real directory inside the watched root, plus a symlink (sorting first)
+	// pointing at it. Symlink targets must stay within root to be followed,
+	// matching discovery's containment check.
+	realDir := filepath.Join(root, "zzz_data")
+	if err := os.Mkdir(realDir, 0o755); err != nil {
+		t.Fatalf("mkdir realDir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(realDir, "seed.txt"), []byte("seed"), 0o600); err != nil {
+		t.Fatalf("write seed: %v", err)
+	}
+	if err := os.Symlink(realDir, filepath.Join(root, "aaa_link")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("store init: %v", err)
+	}
+
+	cfg := config.Default()
+	cfg.RootDir = root
+	cfg.IngestFollowSymlinks = true
+	cfg.IngestWatchDebounce = 20 * time.Millisecond
+	svc := mustNewIngestService(t, cfg, st)
+
+	if err := svc.Run(ctx); err != nil {
+		t.Fatalf("initial Run: %v", err)
+	}
+	// The initial scan follows the symlink first (alphabetical) and indexes the
+	// seed file under the symlinked path.
+	waitForPaths(t, st, "aaa_link/seed.txt", true)
+
+	startWatcher(t, ctx, svc)
+
+	// Create a NEW file behind the symlink after the watcher started. Only a
+	// watch registered on the symlinked directory reindexes it under that path.
+	if err := os.WriteFile(filepath.Join(realDir, "added.txt"), []byte("new"), 0o600); err != nil {
+		t.Fatalf("write added: %v", err)
+	}
+	waitForPaths(t, st, "aaa_link/added.txt", true)
+}
+
 // TestWatch_IndexesFilesInMovedInTree verifies that a directory tree created
 // with nested children already present (e.g. mkdir -p a/b + a file) is picked
 // up: the watcher must register the whole new subtree and index existing files.

--- a/tests/retrieval/tombstone_evict_test.go
+++ b/tests/retrieval/tombstone_evict_test.go
@@ -1,0 +1,147 @@
+package tests
+
+import (
+	"context"
+	"slices"
+	"sync"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
+)
+
+// livenessStore is a minimal model.Store that also implements the retrieval
+// chunk-liveness capability (ChunkTaskByID): a chunk is live unless its id is in
+// the tombstoned set, in which case the lookup returns model.ErrNotFound — the
+// same signal *store.SQLiteStore emits for a chunk soft-deleted by a partial
+// incremental reindex (SoftDeleteChunksFromOrdinal). Safe for concurrent use.
+type livenessStore struct {
+	mu         sync.Mutex
+	tombstoned map[uint64]bool
+}
+
+func newLivenessStore() *livenessStore {
+	return &livenessStore{tombstoned: map[uint64]bool{}}
+}
+
+func (s *livenessStore) tombstone(id uint64) {
+	s.mu.Lock()
+	s.tombstoned[id] = true
+	s.mu.Unlock()
+}
+
+func (s *livenessStore) revive(id uint64) {
+	s.mu.Lock()
+	delete(s.tombstoned, id)
+	s.mu.Unlock()
+}
+
+func (s *livenessStore) ChunkTaskByID(_ context.Context, chunkID uint64) (model.ChunkTask, string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if chunkID == 0 || s.tombstoned[chunkID] {
+		return model.ChunkTask{}, "", model.ErrNotFound
+	}
+	return model.ChunkTask{Label: chunkID, Metadata: model.ChunkMetadata{ChunkID: chunkID}}, "", nil
+}
+
+func (s *livenessStore) Init(context.Context) error                           { return nil }
+func (s *livenessStore) UpsertDocument(context.Context, model.Document) error { return nil }
+func (s *livenessStore) GetDocumentByPath(context.Context, string) (model.Document, error) {
+	return model.Document{}, model.ErrNotFound
+}
+func (s *livenessStore) ListFiles(context.Context, string, string, int, int) ([]model.Document, int64, error) {
+	return nil, 0, nil
+}
+func (s *livenessStore) Close() error { return nil }
+
+// TestSearch_EvictsTombstonedChunksAfterPartialReindex pins issue #409 item (a):
+// an in-place edit that shrinks a document tombstones its trailing chunks via
+// SoftDeleteChunksFromOrdinal with no whole-document eviction. Retrieval must
+// stop returning that content on the very next search — without a restart — and
+// evict the label/vector from the in-memory index so it never resurfaces.
+func TestSearch_EvictsTombstonedChunksAfterPartialReindex(t *testing.T) {
+	idx := index.NewHNSWIndex("")
+	// Two chunks of one document; chunk 2 is the trailing chunk a later edit removes.
+	addVec(t, idx, 1, []float32{1, 0})
+	addVec(t, idx, 2, []float32{0.9, 0.1})
+
+	st := newLivenessStore()
+	svc := retrieval.NewService(st, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+		"mistral-embed": {1, 0},
+	}}, nil)
+	svc.SetHybridEnabled(false) // vector-only: deterministic ranking, no BM25 store dependency
+	svc.SetChunkMetadata(1, model.SearchHit{ChunkID: 1, RelPath: "doc.md", DocType: "md", Snippet: "kept content"})
+	svc.SetChunkMetadata(2, model.SearchHit{ChunkID: 2, RelPath: "doc.md", DocType: "md", Snippet: "deleted trailing content"})
+
+	// Before the edit both chunks are searchable.
+	got := searchChunkIDs(t, svc, "content")
+	if !slices.Contains(got, 2) {
+		t.Fatalf("expected chunk 2 present before deletion, got %v", got)
+	}
+
+	// Partial reindex: chunk 2 is soft-deleted (SoftDeleteChunksFromOrdinal).
+	st.tombstone(2)
+
+	// The first search after the edit must already exclude the deleted content.
+	got = searchChunkIDs(t, svc, "content")
+	if slices.Contains(got, 2) {
+		t.Fatalf("deleted chunk 2 still returned after incremental edit (no restart): %v", got)
+	}
+	if !slices.Contains(got, 1) {
+		t.Fatalf("live chunk 1 should still be returned, got %v", got)
+	}
+
+	// Prove the eviction was durable (label + vector dropped from the index),
+	// not merely a per-query filter: even if the store reports chunk 2 live
+	// again, it must stay absent because its vector was deleted from the index.
+	st.revive(2)
+	got = searchChunkIDs(t, svc, "content")
+	if slices.Contains(got, 2) {
+		t.Fatalf("evicted chunk 2 reappeared; expected it dropped from the in-memory index, got %v", got)
+	}
+}
+
+// TestSearch_TombstoneEvictionRaceSafe exercises the eviction path concurrently
+// with searches (run under -race): the tombstone prune writes chunkByLabel and
+// the indexes while other goroutines read them, so any missing lock surfaces as
+// a data race. Correctness is also asserted — no search may ever return the
+// tombstoned chunk.
+func TestSearch_TombstoneEvictionRaceSafe(t *testing.T) {
+	idx := index.NewHNSWIndex("")
+	addVec(t, idx, 1, []float32{1, 0})
+	addVec(t, idx, 2, []float32{0.9, 0.1})
+
+	st := newLivenessStore()
+	svc := retrieval.NewService(st, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+		"mistral-embed": {1, 0},
+	}}, nil)
+	svc.SetHybridEnabled(false)
+	svc.SetChunkMetadata(1, model.SearchHit{ChunkID: 1, RelPath: "doc.md", DocType: "md", Snippet: "kept content"})
+	svc.SetChunkMetadata(2, model.SearchHit{ChunkID: 2, RelPath: "doc.md", DocType: "md", Snippet: "deleted content"})
+
+	st.tombstone(2)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 25; j++ {
+				hits, err := svc.Search(context.Background(), model.SearchQuery{Query: "content", K: 10})
+				if err != nil {
+					t.Errorf("Search: %v", err)
+					return
+				}
+				for _, h := range hits {
+					if h.ChunkID == 2 {
+						t.Errorf("tombstoned chunk 2 returned under concurrency")
+						return
+					}
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
Addresses #409 (items 1 and 3; the MEDIUM partial-reindex staleness and the conditional symlink-watcher gap). Items 2/4/5 are noted below.

## (1) Partial-content edit leaves deleted chunks searchable until restart
An in-place edit that shrinks a document tombstones its trailing chunks via `SoftDeleteChunksFromOrdinal`, but eviction was wired only for whole-document deletes (`EvictDocuments`). The tombstoned chunks are never re-embedded, so their stale labels/vectors kept resolving to deleted content in vector/hybrid `search` and `ask` — with citations to text no longer present — until daemon restart.

**Fix (in `internal/retrieval`):** the final result set's liveness is validated against the store (`ChunkTaskByID` selects `deleted=0` only, returning `ErrNotFound` for a tombstoned chunk) and any tombstoned chunk is dropped and evicted from `chunkByLabel`/`chunkByIndex` and the text/code indexes via the new `EvictChunks` (the chunk-granularity analogue of `EvictDocuments`). Properties:
- Runs once per top-level query on the small final hit set → at most `k` store lookups.
- **Fail-open**: a store without the liveness capability (type assertion), a zero label, or any non-`ErrNotFound` lookup error leaves hits untouched, so a transient DB error never drops valid results. Fake-store unit tests are unaffected.
- **Race-safe**: `metaMu` guards the maps; each index owns its own lock. Covered by a concurrent `-race` test.
- Deleted content is excluded on the very next search (no restart), and the vector is removed so it never resurfaces.

This is the retrieval-side reconcile the issue offers ("have `searchHitForLabel` validate the resolved chunk's `deleted=0`/freshness against the store"), extended to also evict so the fix is durable within the session.

## (3) Watcher never watches symlinked directories even when `follow_symlinks=true`
`addWatchDirs`/`registerNewTree` used `filepath.WalkDir`, which never descends symlinked directories, while the discovery walker DOES follow them. So with the opt-in on, edits behind a symlinked subtree produced no events until the 10-minute safety rescan.

**Fix (in `internal/ingest/watch.go`, watch code only):** the watcher now honors `follow_symlinks` via a symlink-following walk that mirrors the discovery walker (`internal/corpusfs/local.go`): within-root containment, plus a resolved-path visited set that both terminates symlink cycles and dedups a target reachable via its real and symlinked names (walked once, under the first-seen name — matching discovery). The default (off) path keeps the historical `WalkDir` behavior byte-for-byte.

## Notes / out of scope
- Item 2 (transient stale window on modify until re-embed) shares the same root but concerns unchanged-ordinal chunks whose OLD vector is served until re-embed; not addressed here (self-heals when embedding is healthy).
- Items 4 (delete→recreate flap) and 5 (fsnotify overflow metric) are LOW and untouched.
- Left strictly within the eviction + watcher surface: `represent.go`, ingest sidecar code, `store`, `cli`, and `config` are unchanged (a parallel change owns the ingest-sidecar surface, #431).

## Tests
- `tests/retrieval/tombstone_evict_test.go`: after an incremental trailing-chunk delete a search no longer returns the deleted content (no restart) and the label/vector is evicted (proven by reviving the store row and confirming it stays gone); plus a concurrent `-race` eviction-path test.
- `tests/ingest/watch_test.go`: `TestWatch_FollowsSymlinkedDir` — a file created behind a symlinked dir is reindexed under the symlinked path when `follow_symlinks` is on (integration-gated, like the other watcher tests).

## Validation
`gofmt -l` clean, `go build ./...`, `go vet ./...`, `make cyclo` (≤15), `golangci-lint run` (0 issues), and the required suites (`internal/retrieval`, `internal/ingest`, `tests/{retrieval,index,ingest,eval}` — ablation gate green) all pass, including `-race` on the eviction path.