### PR TITLE
fix(cli): wire ingest derivation identities into the retriever so open_file cache hits (#488)

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -828,6 +828,13 @@ func (a *App) buildRetrieverForAsk(ctx context.Context, cfg config.Config, st mo
 	ret.SetCodeIndex(codeIx)
 	ret.SetRootDir(cfg.RootDir)
 	ret.SetStateDir(cfg.StateDir)
+	// Plumb ingest's ACTIVE OCR/transcript derivation identities into open_file's
+	// cache lookup so it keys the OCR/transcript cache the SAME identity-aware way
+	// ingest's writer does (issue #488). The ask path is read-only and builds no
+	// ingest Service, so the identities are computed from the same cfg the ingestor
+	// would use (byte-identical to a Service's getters).
+	ocrIdentity, transcriptIdentity := ingest.ActiveDerivationIdentities(cfg)
+	ret.SetDerivationCacheIdentities(ocrIdentity, transcriptIdentity)
 	ret.SetProtocolVersion(cfg.ProtocolVersion)
 	ret.SetRAGSystemPrompt(cfg.RAGSystemPrompt)
 	ret.SetMaxContextChars(cfg.RAGMaxContextChars)

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -125,6 +125,7 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 		return exitConfigInvalid
 	}
 	wireIngestorHooks(ing, indexingState, ret.EvictDocuments)
+	wireDerivationCacheIdentities(ret, ing)
 
 	corpusFS, err := buildCorpusFS(ctx, cfg)
 	if err != nil {
@@ -1085,6 +1086,34 @@ func initIndexingState(ctx context.Context, st model.Store, ret *retrieval.Servi
 // configured backend (local/nfs/s3) drives discovery and reads.
 type corpusFSSetter interface {
 	SetCorpusFS(fsys corpusfs.CorpusFS)
+}
+
+// derivationCacheIdentityProvider is the subset of the ingest pipeline that
+// exposes its ACTIVE OCR/transcript derivation identities (SPEC §8.6.7). The
+// concrete *ingest.Service implements it. It is asserted on the live ingestor so
+// the retriever's open_file cache lookup can be keyed the SAME identity-aware way
+// ingest's writer keys the cache it wrote (issue #488) — using the ACTUAL active
+// extractor/STT binding the ingestor runs with, not just a config re-derivation.
+// A test ingestor that does not implement it simply leaves the retriever on the
+// historical bytes-only key.
+type derivationCacheIdentityProvider interface {
+	ActiveOCRIdentity() string
+	ActiveTranscriptIdentity() string
+}
+
+// wireDerivationCacheIdentities plumbs the live ingestor's ACTIVE OCR/transcript
+// derivation identities (SPEC §8.6.7) into open_file's cache lookup so it keys the
+// OCR/transcript cache the SAME identity-aware way ingest's writer does (issue
+// #488). Sourced from the live ingestor (not a config re-derivation) so it
+// reflects the exact extractor/STT binding this daemon writes cache entries with.
+// An ingestor that does not expose the identities (a test fake) leaves the
+// retriever on the historical bytes-only key.
+func wireDerivationCacheIdentities(ret *retrieval.Service, ing model.Ingestor) {
+	ids, ok := ing.(derivationCacheIdentityProvider)
+	if !ok {
+		return
+	}
+	ret.SetDerivationCacheIdentities(ids.ActiveOCRIdentity(), ids.ActiveTranscriptIdentity())
 }
 
 // sourceIsRemote reports whether the configured corpus source is an object-store

--- a/internal/ingest/derivation.go
+++ b/internal/ingest/derivation.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/dirstral/dir2mcp/internal/config"
 	"github.com/dirstral/dir2mcp/internal/langdetect"
 	"github.com/dirstral/dir2mcp/internal/provider"
 )
@@ -148,6 +149,62 @@ func joinTranscriptIdentity(sttIdentity, diarizeIdentity string) string {
 		return sttIdentity
 	}
 	return sttIdentity + "#" + diarizeIdentity
+}
+
+// ActiveOCRIdentity is the exported accessor for the OCR/extraction derivation
+// identity ingest folds into the OCR cache key it writes (ocrCacheKey). It is
+// byte-identical to that fold: empty when no extractor is configured (the
+// bytes-only key path), otherwise the canonical CapOCR identity. The retriever
+// plumbs this into open_file via SetDerivationCacheIdentities so the OCR cache
+// LOOKUP keys the cache the SAME identity-aware way ingest's writer does (issue
+// #488). It is a thin wrapper: the identity computation stays in activeOCRIdentity.
+func (s *Service) ActiveOCRIdentity() string {
+	return s.activeOCRIdentity()
+}
+
+// ActiveTranscriptIdentity is the exported accessor for the transcript
+// derivation identity ingest folds into the transcript cache key it writes
+// (transcriptCacheKey). It returns EXACTLY what that key folds, which is the
+// crucial detail for byte-identity: transcriptCacheKey uses the bytes-only key
+// (folds nothing) when neither an STT provider nor model is resolved, even though
+// the underlying activeTranscriptIdentity always renders a non-empty "stt|…"
+// string. This accessor therefore returns "" on that same no-STT guard so the
+// retriever's open_file lookup lands on ingest's bytes-only key instead of
+// folding a spurious identity and missing (issue #488). With STT configured it
+// returns the full canonical CapSTT(+diarize) identity, identical to what
+// transcriptCacheKey folds.
+func (s *Service) ActiveTranscriptIdentity() string {
+	// Mirror transcriptCacheKey's guard exactly (internal/ingest/derivation.go):
+	// no resolved STT provider+model ⇒ ingest writes the bytes-only key, so the
+	// retriever must fold no identity.
+	if strings.TrimSpace(s.sttProvider) == "" && strings.TrimSpace(s.sttModel) == "" {
+		return ""
+	}
+	return s.activeTranscriptIdentity()
+}
+
+// ActiveDerivationIdentities computes the ACTIVE OCR and transcript derivation
+// identities (SPEC §8.6.7) for cfg WITHOUT constructing a full ingest Service or
+// touching a store. It exists for retriever-only paths that have no ingest
+// Service to borrow the getters from — the read-only `ask` CLI — so open_file's
+// OCR/transcript cache lookup can still be keyed the identity-aware way ingest's
+// writer keys it (issue #488). The returned strings are byte-identical to
+// (*Service).ActiveOCRIdentity / ActiveTranscriptIdentity on a Service built from
+// the same cfg the way the CLI builds its ingestor (NewService + the config
+// extractor), because both resolve the transcript fields through the shared
+// resolveTranscriptIdentityFields and the extractor through DocumentExtractorFromConfig.
+// Prefer a live Service's getters when one exists on the path; use this only
+// where none does.
+func ActiveDerivationIdentities(cfg config.Config) (ocr, transcript string) {
+	s := &Service{cfg: cfg}
+	// The extractor is not resolved by NewService; the CLI ingestor wires it via
+	// SetDocumentExtractor(DocumentExtractorFromConfig(cfg)). Mirror that here so
+	// the OCR identity matches what ingest actually runs with.
+	if extractor := DocumentExtractorFromConfig(cfg); extractor != nil {
+		s.extractor = extractor
+	}
+	s.resolveTranscriptIdentityFields()
+	return s.ActiveOCRIdentity(), s.ActiveTranscriptIdentity()
 }
 
 // activeOCRIdentity is the OCR/extraction derivation identity of the currently

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -377,24 +377,7 @@ func NewService(cfg config.Config, store model.Store) (*Service, error) {
 	if cfg.QualityGatesEnabled {
 		svc.qualityGate = quality.New(quality.DefaultConfig())
 	}
-	svc.transcriptLanguage = sttExpectedLanguage(cfg)
-	// Resolve the STT derivation identity (SPEC §8.6.7) from the same profile the
-	// transcriber uses, so a recorded transcript identity can be compared against
-	// the active one to detect a model swap. Empty when STT is off.
-	if prof, ok := resolveSTTProfile(cfg); ok {
-		svc.sttProvider = strings.TrimSpace(prof.Name)
-		svc.sttModel = strings.TrimSpace(prof.STTModel)
-		// Resolve the diarization binding (SPEC §8.6.8) from the SAME STT profile:
-		// diarization is active when enabled (tri-state) AND the backend advertises
-		// CapDiarize. The diarize derivation identity (§8.6.7) is the backend's
-		// provider name + STT model, so a backend/model swap re-derives. When
-		// inactive the fields stay empty and the STT path is unchanged.
-		if config.DiarizationActive(cfg, prof) {
-			svc.diarizeActive = true
-			svc.diarizeProvider = strings.TrimSpace(prof.Name)
-			svc.diarizeModel = strings.TrimSpace(prof.STTModel)
-		}
-	}
+	svc.resolveTranscriptIdentityFields()
 	// Resolve the optional transcript-translation binding (SPEC §8.6.2). When
 	// translation is enabled we resolve the chat capability and build a
 	// generator; when off (default), or no chat provider resolves, the field
@@ -415,6 +398,35 @@ func NewService(cfg config.Config, store model.Store) (*Service, error) {
 		svc.embedMultimodal = provider.NormalizeEmbedMultimodal(ep.EmbedMultimodal)
 	}
 	return svc, nil
+}
+
+// resolveTranscriptIdentityFields populates the transcript derivation-identity
+// fields (transcript language, STT provider/model, and the diarize binding) on s
+// from s.cfg. It is the single source of truth for that resolution, shared by
+// NewService and ActiveDerivationIdentities so the transcript identity the
+// retriever reconstructs for open_file (issue #488) cannot drift from the one
+// ingest folds into the transcript cache key it writes (SPEC §8.6.7).
+func (s *Service) resolveTranscriptIdentityFields() {
+	s.transcriptLanguage = sttExpectedLanguage(s.cfg)
+	// Resolve the STT derivation identity (SPEC §8.6.7) from the same profile the
+	// transcriber uses, so a recorded transcript identity can be compared against
+	// the active one to detect a model swap. Empty when STT is off.
+	prof, ok := resolveSTTProfile(s.cfg)
+	if !ok {
+		return
+	}
+	s.sttProvider = strings.TrimSpace(prof.Name)
+	s.sttModel = strings.TrimSpace(prof.STTModel)
+	// Resolve the diarization binding (SPEC §8.6.8) from the SAME STT profile:
+	// diarization is active when enabled (tri-state) AND the backend advertises
+	// CapDiarize. The diarize derivation identity (§8.6.7) is the backend's
+	// provider name + STT model, so a backend/model swap re-derives. When
+	// inactive the fields stay empty and the STT path is unchanged.
+	if config.DiarizationActive(s.cfg, prof) {
+		s.diarizeActive = true
+		s.diarizeProvider = strings.TrimSpace(prof.Name)
+		s.diarizeModel = strings.TrimSpace(prof.STTModel)
+	}
 }
 
 // SetOnDocumentDeleted registers a compatibility wrapper for callers that still

--- a/tests/retrieval/open_file_cache_wiring_test.go
+++ b/tests/retrieval/open_file_cache_wiring_test.go
@@ -1,0 +1,175 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
+)
+
+// These tests lock the END-TO-END wiring for issue #488. #517 gave the retriever
+// SetDerivationCacheIdentities but left it UNCALLED, so open_file still defaulted
+// to the bytes-only cache key and missed every identity-aware entry ingest wrote.
+// The CLI now passes ingest's ACTIVE OCR/transcript identities into the retriever
+// at construction; these tests prove the identities the retriever receives —
+// straight from ingest's exported getters (ActiveOCRIdentity/ActiveTranscriptIdentity)
+// and the config helper (ActiveDerivationIdentities) — reconstruct the exact key
+// ingest's writer folded, so open_file HITS.
+
+// TestOpenFile_DerivationIdentityWiring_OCR is the core wiring case: an OCR entry
+// ingest wrote at its identity-folded key is FOUND by open_file when the identity
+// is sourced straight from ingest's ActiveOCRIdentity getter (the daemon path's
+// wiring), and MISSED with the pre-wiring bytes-only key.
+func TestOpenFile_DerivationIdentityWiring_OCR(t *testing.T) {
+	root := t.TempDir()
+	stateDir := filepath.Join(root, ".dir2mcp")
+
+	pdfBytes := []byte("%PDF-1.4 wiring body")
+	fs := &fakeCorpusFS{objects: map[string][]byte{"docs/a.pdf": pdfBytes}}
+
+	cfg := config.Config{RootDir: root, StateDir: stateDir, STTProvider: "off"}
+	ing, err := ingest.NewService(cfg, &fakeKeyStore{})
+	if err != nil {
+		t.Fatalf("ingest.NewService: %v", err)
+	}
+	ing.SetDocumentExtractor(ingest.NewDoclingExtractor("docling"))
+
+	// The exported getter must equal the identity that reconstructs ingest's key,
+	// and (STT off) the transcript getter must be empty so the retriever does not
+	// fold a spurious transcript identity for this OCR corpus.
+	if got := ing.ActiveOCRIdentity(); got != "ocr|docling|||" {
+		t.Fatalf("ActiveOCRIdentity = %q, want %q", got, "ocr|docling|||")
+	}
+	if got := ing.ActiveTranscriptIdentity(); got != "" {
+		t.Fatalf("ActiveTranscriptIdentity with STT off = %q, want empty", got)
+	}
+
+	// ingest writes the OCR cache at its identity-aware key.
+	ocrText := "# wired OCR text"
+	cacheDir := filepath.Join(stateDir, "cache", "ocr")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatalf("mkdir ocr cache: %v", err)
+	}
+	key := ing.OCRCacheKey(pdfBytes)
+	if err := os.WriteFile(filepath.Join(cacheDir, key+".md"), []byte(ocrText), 0o644); err != nil {
+		t.Fatalf("write ocr cache: %v", err)
+	}
+
+	// THE WIRING under test: identities come straight from ingest's getters, as the
+	// CLI now plumbs them into the retriever.
+	svc := retrieval.NewService(nil, nil, nil, nil)
+	svc.SetRootDir(root)
+	svc.SetStateDir(stateDir)
+	svc.SetCorpusFS(fs)
+	svc.SetDerivationCacheIdentities(ing.ActiveOCRIdentity(), ing.ActiveTranscriptIdentity())
+
+	out, err := svc.OpenFile(context.Background(), "docs/a.pdf", model.Span{}, 20000)
+	if err != nil {
+		t.Fatalf("OpenFile after wiring returned err: %v", err)
+	}
+	if out != ocrText {
+		t.Fatalf("expected cached OCR text, got %q", out)
+	}
+
+	// Sanity: an UNWIRED retriever (the pre-#488 default) keys on the bytes alone
+	// and MISSES the identity-folded entry ingest wrote.
+	miss := retrieval.NewService(nil, nil, nil, nil)
+	miss.SetRootDir(root)
+	miss.SetStateDir(stateDir)
+	miss.SetCorpusFS(fs)
+	if _, err := miss.OpenFile(context.Background(), "docs/a.pdf", model.Span{}, 20000); !errors.Is(err, model.ErrOCRNotReady) {
+		t.Fatalf("unwired (bytes-only) lookup should miss, got err=%v", err)
+	}
+}
+
+// TestOpenFile_DerivationIdentityWiring_Transcript is the transcript analogue:
+// a transcript ingest wrote at its STT identity-folded key is FOUND by open_file
+// when the identity is sourced from ingest's ActiveTranscriptIdentity getter.
+func TestOpenFile_DerivationIdentityWiring_Transcript(t *testing.T) {
+	root := t.TempDir()
+	stateDir := filepath.Join(root, ".dir2mcp")
+
+	audioBytes := []byte("fake-audio-bytes")
+	fs := &fakeCorpusFS{objects: map[string][]byte{"media/talk.mp3": audioBytes}}
+
+	const transcript = "[00:00] hello from the wired transcript"
+
+	cfg := config.Config{RootDir: root, StateDir: stateDir, STTProvider: "off"}
+	ing, err := ingest.NewService(cfg, &fakeKeyStore{})
+	if err != nil {
+		t.Fatalf("ingest.NewService: %v", err)
+	}
+	ing.SetTranscriber(&fakeTranscriber{text: transcript})
+	ing.SetSTTIdentity("whisper", "whisper-large-v3")
+	ing.SetTranscriptLanguage("en")
+
+	if got := ing.ActiveTranscriptIdentity(); got != "stt|whisper|whisper-large-v3||en" {
+		t.Fatalf("ActiveTranscriptIdentity = %q, want %q", got, "stt|whisper|whisper-large-v3||en")
+	}
+
+	doc := model.Document{RelPath: "media/talk.mp3"}
+	if _, err := ing.ReadOrComputeTranscript(context.Background(), doc, audioBytes, "en"); err != nil {
+		t.Fatalf("ReadOrComputeTranscript: %v", err)
+	}
+
+	svc := retrieval.NewService(nil, nil, nil, nil)
+	svc.SetRootDir(root)
+	svc.SetStateDir(stateDir)
+	svc.SetCorpusFS(fs)
+	svc.SetDerivationCacheIdentities(ing.ActiveOCRIdentity(), ing.ActiveTranscriptIdentity())
+
+	out, err := svc.OpenFile(context.Background(), "media/talk.mp3", model.Span{}, 20000)
+	if err != nil {
+		t.Fatalf("OpenFile after wiring returned err: %v", err)
+	}
+	if out != transcript {
+		t.Fatalf("expected cached transcript, got %q", out)
+	}
+
+	// Sanity: an unwired retriever misses the identity-folded transcript.
+	miss := retrieval.NewService(nil, nil, nil, nil)
+	miss.SetRootDir(root)
+	miss.SetStateDir(stateDir)
+	miss.SetCorpusFS(fs)
+	if _, err := miss.OpenFile(context.Background(), "media/talk.mp3", model.Span{}, 20000); !errors.Is(err, model.ErrOCRNotReady) {
+		t.Fatalf("unwired (bytes-only) transcript lookup should miss, got err=%v", err)
+	}
+}
+
+// TestActiveDerivationIdentities_MatchesServiceGetters locks the ask-path helper
+// to the exact recipe the CLI builds its ingestor with: for any cfg,
+// ingest.ActiveDerivationIdentities(cfg) must return byte-identical strings to a
+// full Service constructed from the same cfg (NewService + the config extractor).
+// The ask CLI has no ingest Service, so it relies on this helper being a faithful
+// stand-in — a drift here would silently reintroduce the #488 miss on `ask`.
+func TestActiveDerivationIdentities_MatchesServiceGetters(t *testing.T) {
+	root := t.TempDir()
+	stateDir := filepath.Join(root, ".dir2mcp")
+	cfg := config.Config{RootDir: root, StateDir: stateDir, STTProvider: "off"}
+
+	// Build a Service exactly as the CLI's default ingestor does: NewService plus
+	// the config-resolved document extractor.
+	recipe, err := ingest.NewService(cfg, &fakeKeyStore{})
+	if err != nil {
+		t.Fatalf("ingest.NewService: %v", err)
+	}
+	if ex := ingest.DocumentExtractorFromConfig(cfg); ex != nil {
+		recipe.SetDocumentExtractor(ex)
+	}
+	wantOCR := recipe.ActiveOCRIdentity()
+	wantTranscript := recipe.ActiveTranscriptIdentity()
+
+	gotOCR, gotTranscript := ingest.ActiveDerivationIdentities(cfg)
+	if gotOCR != wantOCR {
+		t.Fatalf("ActiveDerivationIdentities OCR = %q, want %q", gotOCR, wantOCR)
+	}
+	if gotTranscript != wantTranscript {
+		t.Fatalf("ActiveDerivationIdentities transcript = %q, want %q", gotTranscript, wantTranscript)
+	}
+}


### PR DESCRIPTION
Follow-up to #517: calls `SetDerivationCacheIdentities` at retriever construction so open_file's OCR/transcript cache lookup uses ingest's identity-aware key end-to-end. Closes the wiring gap #517 flagged.

## Problem

#517 added `retrieval.Service.SetDerivationCacheIdentities(ocrIdentity, transcriptIdentity)` and the retrieval-side identity-folding (`ocrCacheKeyForOpen`/`foldDerivationCacheKey`), but the setter was **never called**. So open_file kept defaulting to the old bytes-only cache key and missed every identity-scoped entry ingest writes on a docling/mistral/STT corpus (→ `OCR_NOT_READY`).

## Fix

- **Exported getters** on `*ingest.Service`:
  - `ActiveOCRIdentity()` — thin wrapper over `activeOCRIdentity()` (empty when no extractor, matching `ocrCacheKey`).
  - `ActiveTranscriptIdentity()` — returns exactly what `transcriptCacheKey` folds: it mirrors that key's no-STT guard and returns `""` when neither STT provider nor model is resolved (the underlying `activeTranscriptIdentity()` always renders a non-empty `stt|…` string, so a naive wrapper would fold a spurious identity and miss). This keeps the lookup byte-identical to ingest's writer.
- **Config helper** `ingest.ActiveDerivationIdentities(cfg) (ocr, transcript string)` for retriever-only paths with no ingest Service. It reuses the shared `resolveTranscriptIdentityFields` (extracted from `NewService`) and `DocumentExtractorFromConfig`, so it cannot drift from the Service getters.
- **Both retriever construction sites wired**:
  - `internal/cli/up.go` (daemon `up`): sources identities from the **live ingestor** via a `derivationCacheIdentityProvider` type assertion, so it reflects the exact extractor/STT binding the daemon writes cache entries with.
  - `internal/cli/app.go` (`buildRetrieverForAsk`): the ask path is read-only and builds no ingest Service, so it uses the config helper `ingest.ActiveDerivationIdentities(cfg)`.

## Acceptance

The identities passed to the retriever equal what ingest folds into the cache key it writes (byte-identical), preserving the open_file tool/error contract. The empty-identity path (no extractor/transcriber) preserves the historical bytes-only key.

## Tests

New end-to-end wiring tests in `tests/retrieval/open_file_cache_wiring_test.go`:
- OCR + transcript entries ingest wrote at their identity-folded keys are **found** by open_file when the identity comes straight from ingest's getters, and **missed** by an unwired (bytes-only) retriever.
- `ActiveDerivationIdentities(cfg)` is byte-identical to a Service built the CLI's way.

## Validation

`gofmt`, `go build ./...`, `go vet ./...`, `make cyclo` (≤15), `golangci-lint run` (0 issues), and `go test` over ingest/retrieval/cli (internal + tests) all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache matching for OCR and transcript lookups, so previously generated content is more reliably found in the ask flow.
  * Reduced missed results when opening files by using the same identity rules across related workflows.

* **Tests**
  * Added regression coverage for OCR and transcript cache wiring.
  * Added a check to ensure identity values stay consistent across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->