### PR TITLE
fix(ingest): preserve sub-second transcript timing; stop fabricating absent STT spans (#431)

### DIFF
--- a/internal/elevenlabs/client.go
+++ b/internal/elevenlabs/client.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/url"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
@@ -126,9 +125,9 @@ func parseTranscribeResult(parsed transcribeResponse) (string, bool) {
 			if startMS <= 0 {
 				startMS = int(segment.Start * 1000)
 			}
-			mm := (startMS / 1000) / 60
-			ss := (startMS / 1000) % 60
-			lines = append(lines, "["+pad2(mm)+":"+pad2(ss)+"] "+text)
+			// Preserve millisecond precision in the marker so distinct in-second
+			// segments do not collapse onto one timestamp (issue #431).
+			lines = append(lines, model.FormatTranscriptTimestamp(startMS)+" "+text)
 		}
 		if len(lines) > 0 {
 			return strings.Join(lines, "\n"), true
@@ -352,11 +351,4 @@ func mapProviderError(statusCode int, message string) error {
 	}
 
 	return pe
-}
-
-func pad2(n int) string {
-	if n < 10 {
-		return "0" + strconv.Itoa(n)
-	}
-	return strconv.Itoa(n)
 }

--- a/internal/ingest/represent.go
+++ b/internal/ingest/represent.go
@@ -27,11 +27,11 @@ import (
 // ([mm:ss.mmm]). The fraction preserves millisecond precision so distinct
 // in-second segments do not collapse onto one marker (issue #431); a bare
 // whole-second marker parses as .000, keeping backward compatibility.
-var transcriptTimestampBracketedRe = regexp.MustCompile(`^\s*\[(\d{1,2}):(\d{2})(?::(\d{2}))?(?:\.(\d{1,3}))?\]\s*(.*)$`)
+var transcriptTimestampBracketedRe = regexp.MustCompile(`^\s*\[(\d+):(\d{2})(?::(\d{2}))?(?:\.(\d{1,3}))?\]\s*(.*)$`)
 
 // transcriptTimestampBareRe matches the same timestamps as
 // transcriptTimestampBracketedRe but without the surrounding brackets.
-var transcriptTimestampBareRe = regexp.MustCompile(`^\s*(\d{1,2}):(\d{2})(?::(\d{2}))?(?:\.(\d{1,3}))?(?:\s+|$)(.*)$`)
+var transcriptTimestampBareRe = regexp.MustCompile(`^\s*(\d+):(\d{2})(?::(\d{2}))?(?:\.(\d{1,3}))?(?:\s+|$)(.*)$`)
 
 const (
 	// RepTypeRawText is the representation type for raw text content
@@ -1161,7 +1161,10 @@ func parseMMSSComponents(m []string) (minutes, seconds int, ok bool) {
 	if err != nil {
 		return 0, 0, false
 	}
-	if minutes < 0 || minutes > 59 || seconds < 0 || seconds > 59 {
+	// minutes here is the TOTAL minutes of an [mm:ss] marker (no hour field), so
+	// a transcript longer than an hour renders e.g. [75:30]; accept any
+	// non-negative minute count. Only seconds are bounded to a single unit.
+	if minutes < 0 || seconds < 0 || seconds > 59 {
 		return 0, 0, false
 	}
 	return minutes, seconds, true

--- a/internal/ingest/represent.go
+++ b/internal/ingest/represent.go
@@ -22,13 +22,16 @@ import (
 	"golang.org/x/text/transform"
 )
 
-// transcriptTimestampBracketedRe matches leading timestamps in [mm:ss] or
-// [hh:mm:ss] form.
-var transcriptTimestampBracketedRe = regexp.MustCompile(`^\s*\[(\d{1,2}):(\d{2})(?::(\d{2}))?\]\s*(.*)$`)
+// transcriptTimestampBracketedRe matches leading timestamps in [mm:ss],
+// [hh:mm:ss], or either form with an optional sub-second fraction of 1-3 digits
+// ([mm:ss.mmm]). The fraction preserves millisecond precision so distinct
+// in-second segments do not collapse onto one marker (issue #431); a bare
+// whole-second marker parses as .000, keeping backward compatibility.
+var transcriptTimestampBracketedRe = regexp.MustCompile(`^\s*\[(\d{1,2}):(\d{2})(?::(\d{2}))?(?:\.(\d{1,3}))?\]\s*(.*)$`)
 
-// transcriptTimestampBareRe matches leading timestamps in mm:ss or hh:mm:ss
-// form without brackets.
-var transcriptTimestampBareRe = regexp.MustCompile(`^\s*(\d{1,2}):(\d{2})(?::(\d{2}))?(?:\s+|$)(.*)$`)
+// transcriptTimestampBareRe matches the same timestamps as
+// transcriptTimestampBracketedRe but without the surrounding brackets.
+var transcriptTimestampBareRe = regexp.MustCompile(`^\s*(\d{1,2}):(\d{2})(?::(\d{2}))?(?:\.(\d{1,3}))?(?:\s+|$)(.*)$`)
 
 const (
 	// RepTypeRawText is the representation type for raw text content
@@ -970,6 +973,11 @@ func chunkTranscriptByTime(content string) []chunkSegment {
 	}
 	segments := make([]transcriptSegment, 0, len(lines))
 	var current *transcriptSegment
+	// sawTimestamp records whether ANY line carried a real [mm:ss] marker. When
+	// none did, every segment's startMS is a synthetic default and there are no
+	// real anchors to time against, so we must not fabricate spans (issue #431
+	// item d).
+	sawTimestamp := false
 
 	pushCurrent := func() {
 		if current == nil {
@@ -987,6 +995,7 @@ func chunkTranscriptByTime(content string) []chunkSegment {
 	for _, line := range lines {
 		startMS, text, ok := parseTranscriptTimestamp(line)
 		if ok {
+			sawTimestamp = true
 			pushCurrent()
 			current = &transcriptSegment{startMS: startMS, text: strings.TrimSpace(text)}
 			continue
@@ -1005,12 +1014,24 @@ func chunkTranscriptByTime(content string) []chunkSegment {
 	}
 	pushCurrent()
 
-	if len(segments) == 0 {
+	// No timestamp markers anywhere: the transcriber returned plain text with no
+	// real timing (e.g. a Gemini-style STT backend). Emit the chunks WITHOUT a
+	// time span rather than fabricating a char-weighted window that would present
+	// invented timestamps as real (issue #431 item d). This also covers the
+	// degenerate len(segments)==0 case, which by definition had no markers.
+	if !sawTimestamp {
 		trimmed := strings.TrimSpace(content)
 		if trimmed == "" {
 			return nil
 		}
-		return splitTranscriptSegmentWithTiming(trimmed, 0, estimateTranscriptDurationMS(trimmed))
+		if len(segments) == 0 {
+			return splitTranscriptSegmentWithoutTiming(trimmed)
+		}
+		out := make([]chunkSegment, 0, len(segments))
+		for i := range segments {
+			out = append(out, splitTranscriptSegmentWithoutTiming(segments[i].text)...)
+		}
+		return out
 	}
 
 	out := make([]chunkSegment, 0, len(segments))
@@ -1107,6 +1128,29 @@ func splitTranscriptSegmentWithTiming(text string, startMS, endMS int) []chunkSe
 	return out
 }
 
+// splitTranscriptSegmentWithoutTiming chunks text with the same size policy as
+// splitTranscriptSegmentWithTiming but leaves every chunk's Span zero-valued
+// (empty Kind), so no time bounds are attached. It is used when a transcript
+// carried no timestamp markers at all: timing is genuinely absent, and an
+// empty-Kind span makes the chunker persist the chunk with no span row (rather
+// than a fabricated one) and makes subtitle export skip it — honest omission
+// over invented timing (issue #431 item d).
+func splitTranscriptSegmentWithoutTiming(text string) []chunkSegment {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return nil
+	}
+	parts := chunkTextByChars(text, TranscriptChunkMaxChars, TranscriptChunkOverlapChars, TranscriptChunkMinChars)
+	if len(parts) == 0 {
+		return []chunkSegment{{Text: text}}
+	}
+	out := make([]chunkSegment, 0, len(parts))
+	for _, part := range parts {
+		out = append(out, chunkSegment{Text: part.Text})
+	}
+	return out
+}
+
 func parseMMSSComponents(m []string) (minutes, seconds int, ok bool) {
 	var err error
 	minutes, err = strconv.Atoi(m[1])
@@ -1150,10 +1194,10 @@ func parseTranscriptTimestamp(line string) (int, string, bool) {
 	}
 
 	m := transcriptTimestampBracketedRe.FindStringSubmatch(trimmed)
-	if len(m) != 5 {
+	if len(m) != 6 {
 		m = transcriptTimestampBareRe.FindStringSubmatch(trimmed)
 	}
-	if len(m) != 5 {
+	if len(m) != 6 {
 		return 0, "", false
 	}
 
@@ -1174,8 +1218,28 @@ func parseTranscriptTimestamp(line string) (int, string, bool) {
 		}
 	}
 
-	totalMS := ((hours * 3600) + (minutes * 60) + seconds) * 1000
-	return totalMS, strings.TrimSpace(m[4]), true
+	totalMS := ((hours*3600)+(minutes*60)+seconds)*1000 + fractionToMS(m[4])
+	return totalMS, strings.TrimSpace(m[5]), true
+}
+
+// fractionToMS converts the optional decimal-second fraction captured from a
+// transcript marker (1-3 digits, no leading dot) into milliseconds. The fraction
+// is a tenths/hundredths/thousandths value, so it is right-padded to three
+// digits: "5" -> 500, "05" -> 50, "250" -> 250. An empty fraction (a bare
+// whole-second "[mm:ss]" marker) yields 0, preserving backward-compatible
+// parsing of markers written before sub-second precision existed.
+func fractionToMS(frac string) int {
+	if frac == "" {
+		return 0
+	}
+	for len(frac) < 3 {
+		frac += "0"
+	}
+	ms, err := strconv.Atoi(frac)
+	if err != nil {
+		return 0
+	}
+	return ms
 }
 
 func chunkCodeByLines(content string, maxLines, overlapLines int) []chunkSegment {

--- a/internal/ingest/translate.go
+++ b/internal/ingest/translate.go
@@ -147,18 +147,28 @@ func splitTimestampMarker(line string) (marker, text string) {
 	return strings.TrimRight(trimmed[:idx], " \t"), body
 }
 
-// formatTimestampMarker renders a millisecond offset as a bracketed [mm:ss] or
-// [hh:mm:ss] marker, matching the transcript timestamp format.
+// formatTimestampMarker renders a millisecond offset as a bracketed [mm:ss] /
+// [hh:mm:ss] marker, or the [.mmm] sub-second form when the offset is not on a
+// whole second, matching the transcript timestamp format (issue #431). It is
+// only a fallback for the "body not locatable" branch of splitTimestampMarker;
+// the common path preserves the source marker verbatim.
 func formatTimestampMarker(ms int) string {
 	if ms < 0 {
 		ms = 0
 	}
 	totalSec := ms / 1000
+	frac := ms % 1000
 	h := totalSec / 3600
 	m := (totalSec % 3600) / 60
 	sec := totalSec % 60
+	var base string
 	if h > 0 {
-		return fmt.Sprintf("[%02d:%02d:%02d]", h, m, sec)
+		base = fmt.Sprintf("%02d:%02d:%02d", h, m, sec)
+	} else {
+		base = fmt.Sprintf("%02d:%02d", m, sec)
 	}
-	return fmt.Sprintf("[%02d:%02d]", m, sec)
+	if frac != 0 {
+		return fmt.Sprintf("[%s.%03d]", base, frac)
+	}
+	return "[" + base + "]"
 }

--- a/internal/mistral/client.go
+++ b/internal/mistral/client.go
@@ -11,7 +11,6 @@ import (
 	"mime/multipart"
 	"net/http"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
@@ -744,8 +743,10 @@ func (c *Client) buildTranscribeBody(relPath string, data []byte) ([]byte, *mult
 }
 
 // parseMistralTranscriptSegments converts timed segments in a transcription
-// response into timestamped lines.  Returns ("", false) when no non-empty
-// segments are present.
+// response into timestamped lines (`[mm:ss] text`, or `[mm:ss.mmm] text` when a
+// segment starts sub-second). Sub-second precision is preserved so distinct
+// in-second segments do not collapse onto one marker (issue #431). Returns
+// ("", false) when no non-empty segments are present.
 func parseMistralTranscriptSegments(parsed transcribeResponse) (string, bool) {
 	if len(parsed.Segments) == 0 {
 		return "", false
@@ -756,15 +757,21 @@ func parseMistralTranscriptSegments(parsed transcribeResponse) (string, bool) {
 		if text == "" {
 			continue
 		}
-		startSec := int(seg.Start)
-		mm := startSec / 60
-		ss := startSec % 60
-		lines = append(lines, "["+pad2(mm)+":"+pad2(ss)+"] "+text)
+		lines = append(lines, model.FormatTranscriptTimestamp(secondsToMS(seg.Start))+" "+text)
 	}
 	if len(lines) > 0 {
 		return strings.Join(lines, "\n"), true
 	}
 	return "", false
+}
+
+// secondsToMS converts fractional seconds to whole milliseconds, clamping
+// negative values to 0.
+func secondsToMS(sec float64) int {
+	if sec <= 0 {
+		return 0
+	}
+	return int(sec*1000 + 0.5)
 }
 
 func (c *Client) transcribeOnce(ctx context.Context, relPath string, data []byte) (string, error) {
@@ -843,13 +850,6 @@ func (c *Client) transcribeOnce(ctx context.Context, relPath string, data []byte
 		}
 	}
 	return text, nil
-}
-
-func pad2(n int) string {
-	if n < 10 {
-		return "0" + strconv.Itoa(n)
-	}
-	return strconv.Itoa(n)
 }
 
 func (c *Client) generateWithRetry(ctx context.Context, prompt string) (string, error) {

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -126,6 +126,32 @@ type WordSpan struct {
 	W string `json:"w"`
 }
 
+// FormatTranscriptTimestamp renders an absolute media offset (milliseconds) as
+// the leading per-segment marker that transcribers emit and the ingest chunker
+// consumes. It is the single source of truth for that wire format so every STT
+// backend stays byte-for-byte consistent (generic, provider-neutral).
+//
+// A whole-second offset renders as "[mm:ss]" (unchanged from the historical
+// format); a sub-second offset renders as "[mm:ss.mmm]" so that two segments
+// inside the same second do not collapse onto one marker and word/subtitle
+// timings keep their millisecond precision (issue #431 item c). Minutes are not
+// wrapped into an hours field, matching prior provider output; a negative offset
+// is clamped to zero. The companion parser (ingest.parseTranscriptTimestamp)
+// accepts both forms, treating a bare whole-second marker as ".000".
+func FormatTranscriptTimestamp(startMS int) string {
+	if startMS < 0 {
+		startMS = 0
+	}
+	totalSeconds := startMS / 1000
+	ms := startMS % 1000
+	mm := totalSeconds / 60
+	ss := totalSeconds % 60
+	if ms == 0 {
+		return fmt.Sprintf("[%02d:%02d]", mm, ss)
+	}
+	return fmt.Sprintf("[%02d:%02d.%03d]", mm, ss, ms)
+}
+
 // RegionSpan localizes a chunk to a rectangular area within a page range of a
 // structured document (dirstral-spec §5.4 "region" span kind). It is the
 // in-memory shape of the spans.extra_json blob for region spans.

--- a/internal/whisperapi/client.go
+++ b/internal/whisperapi/client.go
@@ -27,7 +27,6 @@ import (
 	"mime/multipart"
 	"net/http"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
@@ -368,9 +367,12 @@ func secondsToMS(sec float64) int {
 	return int(sec*1000 + 0.5)
 }
 
-// parseTranscriptSegments converts timed segments into `[mm:ss] text`
-// lines (the format chunkTranscriptByTime consumes). Returns ("", false)
-// when no non-empty segments are present (caller falls back to flat text).
+// parseTranscriptSegments converts timed segments into `[mm:ss] text` (or
+// `[mm:ss.mmm] text` when the segment starts sub-second) lines, the format
+// chunkTranscriptByTime consumes. Sub-second start times are preserved so
+// distinct in-second segments do not collapse onto one marker (issue #431).
+// Returns ("", false) when no non-empty segments are present (caller falls back
+// to flat text).
 func parseTranscriptSegments(parsed transcribeResponse) (string, bool) {
 	if len(parsed.Segments) == 0 {
 		return "", false
@@ -381,13 +383,7 @@ func parseTranscriptSegments(parsed transcribeResponse) (string, bool) {
 		if text == "" {
 			continue
 		}
-		startSec := int(seg.Start)
-		if startSec < 0 {
-			startSec = 0
-		}
-		mm := startSec / 60
-		ss := startSec % 60
-		lines = append(lines, "["+pad2(mm)+":"+pad2(ss)+"] "+text)
+		lines = append(lines, model.FormatTranscriptTimestamp(secondsToMS(seg.Start))+" "+text)
 	}
 	if len(lines) == 0 {
 		return "", false
@@ -444,11 +440,4 @@ func (c *Client) wait(ctx context.Context, d time.Duration) error {
 	case <-timer.C:
 		return nil
 	}
-}
-
-func pad2(n int) string {
-	if n < 10 {
-		return "0" + strconv.Itoa(n)
-	}
-	return strconv.Itoa(n)
 }

--- a/tests/elevenlabs/client_test.go
+++ b/tests/elevenlabs/client_test.go
@@ -187,7 +187,10 @@ func TestElevenLabsTranscribe_ReturnsTimestampedSegments(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Transcribe failed: %v", err)
 	}
-	if text != "[00:00] hello\n[00:02] world" {
+	// start=2.4s must keep its sub-second precision as [00:02.400] rather than
+	// flooring to [00:02] and losing 400 ms (issue #431 item c). A whole-second
+	// start (0) still renders as the bare [00:00].
+	if text != "[00:00] hello\n[00:02.400] world" {
 		t.Fatalf("unexpected transcript: %q", text)
 	}
 	assertTranscribeRequest(t, got)

--- a/tests/ingest/represent_test.go
+++ b/tests/ingest/represent_test.go
@@ -526,6 +526,11 @@ func TestFormatTranscriptTimestamp(t *testing.T) {
 		{5050, "[00:05.050]"},
 		{5005, "[00:05.005]"},
 		{5500, "[00:05.500]"},
+		// >1h transcripts (interviews): total minutes, no hour wrapping, must
+		// still round-trip (regression for the >59-minute parse rejection).
+		{3600000, "[60:00]"},
+		{3630500, "[60:30.500]"},
+		{7200000, "[120:00]"},
 	}
 	for _, tc := range cases {
 		got := model.FormatTranscriptTimestamp(tc.ms)

--- a/tests/ingest/represent_test.go
+++ b/tests/ingest/represent_test.go
@@ -452,18 +452,110 @@ func TestChunkTranscriptByTime_SplitsLongTimestampWindow(t *testing.T) {
 	}
 }
 
-func TestChunkTranscriptByTime_NoTimestampsStillGetsTimeSpans(t *testing.T) {
+// TestChunkTranscriptByTime_NoTimestampsOmitsTiming asserts that a transcript
+// with no [mm:ss] markers (e.g. a Gemini-style STT backend that returns plain
+// text without timing) is still chunked into text, but the chunks carry NO time
+// span rather than a fabricated char-weighted window. Presenting invented
+// timestamps as real is the bug fixed by issue #431 item d: honest omission
+// beats fabrication.
+func TestChunkTranscriptByTime_NoTimestampsOmitsTiming(t *testing.T) {
 	input := strings.Repeat("plain transcript text without timestamps ", 300)
 	chunks := ingest.ChunkTranscriptByTime(input)
 	if len(chunks) == 0 {
-		t.Fatal("expected fallback chunks")
+		t.Fatal("expected text chunks even without timing")
 	}
+	for i, ch := range chunks {
+		if strings.TrimSpace(ch.Text) == "" {
+			t.Fatalf("chunk %d has empty text", i)
+		}
+		if ch.Span.Kind != "" {
+			t.Fatalf("chunk %d expected no span kind (timing absent), got %+v", i, ch.Span)
+		}
+		if ch.Span.StartMS != 0 || ch.Span.EndMS != 0 {
+			t.Fatalf("chunk %d expected zero (unset) time bounds, got %+v", i, ch.Span)
+		}
+	}
+}
+
+// TestChunkTranscriptByTime_SubSecondSegmentsDoNotCollapse asserts that two
+// segments starting within the same whole second keep distinct, ordered start
+// times and non-collapsed spans once the marker carries millisecond precision
+// (issue #431 item c). Before the fix both markers floored to [00:05] and the
+// first span collapsed to a 1 ms sliver, mis-routing its words to the next span.
+func TestChunkTranscriptByTime_SubSecondSegmentsDoNotCollapse(t *testing.T) {
+	input := "[00:05.250] first segment here\n[00:05.750] second segment here\n[00:06.000] third segment here"
+	chunks := ingest.ChunkTranscriptByTime(input)
+	if len(chunks) != 3 {
+		t.Fatalf("expected 3 chunks, got %d: %+v", len(chunks), chunks)
+	}
+	wantStarts := []int{5250, 5750, 6000}
 	for i, ch := range chunks {
 		if ch.Span.Kind != "time" {
 			t.Fatalf("chunk %d expected time span, got %+v", i, ch.Span)
 		}
+		if ch.Span.StartMS != wantStarts[i] {
+			t.Fatalf("chunk %d StartMS = %d, want %d", i, ch.Span.StartMS, wantStarts[i])
+		}
 		if ch.Span.EndMS <= ch.Span.StartMS {
-			t.Fatalf("chunk %d expected positive duration, got %+v", i, ch.Span)
+			t.Fatalf("chunk %d span collapsed: %+v", i, ch.Span)
+		}
+	}
+	// The first two must not share a start (the same-second collapse bug).
+	if chunks[0].Span.StartMS == chunks[1].Span.StartMS {
+		t.Fatalf("sub-second segments collapsed to the same start: %d", chunks[0].Span.StartMS)
+	}
+	// The first segment's real end must reach the second's start (no 1 ms sliver).
+	if chunks[0].Span.EndMS != chunks[1].Span.StartMS {
+		t.Fatalf("chunk 0 EndMS = %d, want %d (adjacent to chunk 1 start)", chunks[0].Span.EndMS, chunks[1].Span.StartMS)
+	}
+}
+
+// TestFormatTranscriptTimestamp covers the shared marker formatter every STT
+// backend uses: whole seconds render as [mm:ss] (backward compatible) and
+// sub-second offsets render as [mm:ss.mmm], and both round-trip through the
+// chunker's parser to the original millisecond value (issue #431 item c).
+func TestFormatTranscriptTimestamp(t *testing.T) {
+	cases := []struct {
+		ms   int
+		want string
+	}{
+		{0, "[00:00]"},
+		{5000, "[00:05]"},
+		{65000, "[01:05]"},
+		{5250, "[00:05.250]"},
+		{5050, "[00:05.050]"},
+		{5005, "[00:05.005]"},
+		{5500, "[00:05.500]"},
+	}
+	for _, tc := range cases {
+		got := model.FormatTranscriptTimestamp(tc.ms)
+		if got != tc.want {
+			t.Fatalf("FormatTranscriptTimestamp(%d) = %q, want %q", tc.ms, got, tc.want)
+		}
+		// Round-trip: the marker must chunk to a time span starting at tc.ms.
+		chunks := ingest.ChunkTranscriptByTime(got + " word one two three")
+		if len(chunks) == 0 {
+			t.Fatalf("no chunks for marker %q", got)
+		}
+		if chunks[0].Span.Kind != "time" || chunks[0].Span.StartMS != tc.ms {
+			t.Fatalf("marker %q parsed to %+v, want time span StartMS=%d", got, chunks[0].Span, tc.ms)
+		}
+	}
+}
+
+// TestChunkTranscriptByTime_MultiLineNoTimestampsOmitsTiming asserts the
+// honest-omission path holds even when a no-timing transcript spans several
+// lines: every chunk is emitted with no span rather than an invented window
+// (issue #431 item d).
+func TestChunkTranscriptByTime_MultiLineNoTimestampsOmitsTiming(t *testing.T) {
+	input := "first line of speech\nsecond line of speech\nthird line of speech"
+	chunks := ingest.ChunkTranscriptByTime(input)
+	if len(chunks) == 0 {
+		t.Fatal("expected text chunks even without timing")
+	}
+	for i, ch := range chunks {
+		if ch.Span.Kind != "" {
+			t.Fatalf("chunk %d expected no span kind (timing absent), got %+v", i, ch.Span)
 		}
 	}
 }

--- a/tests/whisperapi/client_test.go
+++ b/tests/whisperapi/client_test.go
@@ -132,6 +132,36 @@ func TestTranscribeSegmentsFormatting(t *testing.T) {
 	}
 }
 
+// TestTranscribeSubSecondSegmentsKeepDistinctMarkers asserts that two segments
+// starting within the same whole second render as distinct [mm:ss.mmm] markers
+// instead of collapsing onto one floored [mm:ss] (issue #431 item c).
+func TestTranscribeSubSecondSegmentsKeepDistinctMarkers(t *testing.T) {
+	const subSecondSegments = `{
+	  "text": "first second",
+	  "language": "en",
+	  "duration": 10.0,
+	  "segments": [
+	    {"start": 5.25, "end": 5.6, "text": "first"},
+	    {"start": 5.75, "end": 6.0, "text": "second"}
+	  ]
+	}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, subSecondSegments)
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL, "secret-key")
+	out, err := c.Transcribe(context.Background(), "podcast/ep1.mp3", []byte("audiobytes"))
+	if err != nil {
+		t.Fatalf("Transcribe: %v", err)
+	}
+	want := "[00:05.250] first\n[00:05.750] second"
+	if out != want {
+		t.Fatalf("transcript = %q, want %q", out, want)
+	}
+}
+
 // TestVerboseJSONResponseFormat asserts response_format=verbose_json is
 // sent when configured.
 func TestVerboseJSONResponseFormat(t *testing.T) {


### PR DESCRIPTION
Follow-up to #526 (which fixed the sidecar binding + `ask_audio` mime). This addresses the two **deferred** transcript-timing items of #431.

## (c) Sub-second precision → no same-second collapse
All STT transcribers floored segment start times to whole seconds via the `[mm:ss]` marker, so two segments inside one second collapsed onto the same marker: they parsed to identical `startMS`, the first span squashed to a 1 ms sliver, and per-word timing was mis-attributed to the next span (subtitle export drifted up to ~1 s).

- New shared, provider-neutral formatter `model.FormatTranscriptTimestamp(startMS)`: whole seconds render `[mm:ss]` (unchanged); sub-second offsets render `[mm:ss.mmm]`.
- `internal/whisperapi`, `internal/mistral`, and `internal/elevenlabs` now emit through it (removing three copies of the flooring `pad2` logic).
- The ingest parser carries the fraction: `transcriptTimestamp*Re` accept an optional `.mmm`, and `parseTranscriptTimestamp` adds `fractionToMS`. A bare whole-second `[mm:ss]` marker parses as `.000` — **backward compatible**.
- Translation preserves the verbatim marker (it round-trips through the ms-aware parser); the rare `formatTimestampMarker` fallback is now ms-aware too.

## (d) Absent timing no longer fabricated
When a transcript carries **no** `[mm:ss]` markers at all (e.g. a Gemini-style STT backend that returns text only), `chunkTranscriptByTime` previously invented a char-weighted `[0, words×300ms]` window and presented it as real timing.

- The chunker now makes the *has real timing* vs *no timing* distinction explicit (`sawTimestamp`). When timing is genuinely absent it emits chunks with **no time span** (`splitTranscriptSegmentWithoutTiming`): the chunk persists with no span row and subtitle export skips it. **Honest omission over fabrication.**
- Generic across all STT backends — no provider- or locale-specific handling.

## Tests
- `tests/ingest`: sub-second segments stay distinct through the chunker; format↔parse round-trip; multi-line no-timing transcript yields spanless chunks. Updated the pre-existing test that asserted the old fabrication contract to assert honest omission.
- `tests/whisperapi` + `tests/elevenlabs`: sub-second starts render as distinct `[mm:ss.mmm]` markers.

## Validation
`gofmt`, `go build ./...`, `go vet ./...`, `make cyclo` (≤15), `golangci-lint run` (0 issues), and `go test ./...` all pass.

Scope note: does not touch `internal/cli`, `internal/retrieval`, `internal/mcp`, `internal/store`, or `internal/ingest/sidecar.go` (owned by #526 / a parallel change).