### PR TITLE
fix(retrieval): hybrid fuses a rerank-sized over-fetch pool; re-baseline ablation dedup invariant (#519)

### DIFF
--- a/internal/retrieval/hybrid.go
+++ b/internal/retrieval/hybrid.go
@@ -105,6 +105,7 @@ func (s *Service) runHybridSearch(
 	s.metaMu.RLock()
 	enabled := s.hybridEnabled
 	store := s.store
+	rerankPool := s.rerankCandidatePool
 	s.metaMu.RUnlock()
 	if !enabled {
 		return nil, false
@@ -145,5 +146,29 @@ func (s *Service) runHybridSearch(
 			bm25Hits[i].DocType = cached.DocType
 		}
 	}
-	return fuseRRF(vectorHits, bm25Hits, k), true
+	// Fuse into a candidate pool sized for the downstream rerank stage, not just
+	// the final k. Truncating fusion to k here would defeat the over-fetch pool
+	// (#519): the reranker (rerankPool) could then only reorder the top-k and
+	// never rescue a relevant chunk fused at rank k+1..pool. The caller truncates
+	// to k when rerank is disabled, so the wider pool is harmless there. This
+	// mirrors the HyDE path, which already fuses to hybridCandidatePoolSize.
+	return fuseRRF(vectorHits, bm25Hits, rerankFusionPoolSize(k, rerankPool)), true
+}
+
+// rerankFusionPoolSize returns how many fused candidates to keep before the
+// rerank stage: at least hybridCandidatePoolSize and the configured rerank
+// candidate pool (falling back to the default when unset), but never fewer than
+// the caller's k so a larger requested k is still honored.
+func rerankFusionPoolSize(k, rerankPool int) int {
+	pool := rerankPool
+	if pool <= 0 {
+		pool = defaultRerankCandidatePool
+	}
+	if pool < hybridCandidatePoolSize {
+		pool = hybridCandidatePoolSize
+	}
+	if k > pool {
+		return k
+	}
+	return pool
 }

--- a/internal/retrieval/hybrid_test.go
+++ b/internal/retrieval/hybrid_test.go
@@ -79,6 +79,34 @@ func TestFuseRRF_ZeroKDefaults(t *testing.T) {
 	}
 }
 
+// TestRerankFusionPoolSize pins the #519 rerank-pool fix: hybrid fusion keeps a
+// candidate pool sized for the downstream rerank stage (not truncated to the
+// final k), so the reranker can rescue a chunk fused below rank k.
+func TestRerankFusionPoolSize(t *testing.T) {
+	cases := []struct {
+		name       string
+		k          int
+		rerankPool int
+		want       int
+	}{
+		{"small k, default pool", 10, defaultRerankCandidatePool, defaultRerankCandidatePool},
+		{"pool unset falls back to default", 10, 0, defaultRerankCandidatePool},
+		{"k larger than pool is honored", 80, 50, 80},
+		{"pool below hybrid floor lifts to floor", 5, 20, hybridCandidatePoolSize},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := rerankFusionPoolSize(tc.k, tc.rerankPool); got != tc.want {
+				t.Fatalf("rerankFusionPoolSize(%d, %d) = %d, want %d", tc.k, tc.rerankPool, got, tc.want)
+			}
+			// The pool must never be smaller than k, or rerank cannot return k hits.
+			if got := rerankFusionPoolSize(tc.k, tc.rerankPool); got < tc.k {
+				t.Fatalf("pool %d < k %d", got, tc.k)
+			}
+		})
+	}
+}
+
 func scores(hits []model.SearchHit) []float64 {
 	out := make([]float64, len(hits))
 	for i, h := range hits {

--- a/tests/eval/ablation_test.go
+++ b/tests/eval/ablation_test.go
@@ -9,11 +9,38 @@ const evalK = 5
 
 // configMetrics holds one ablation row's macro-averaged metrics plus the mean
 // number of hits returned per query (a proxy for how aggressively a config
-// trims the candidate set — relevant for the precision-oriented knobs).
+// trims the candidate set — relevant for the precision-oriented knobs) and the
+// total number of cross-file duplicate hits (two returned rel_paths sharing a
+// content_hash) summed over the query set — the direct signal cross-file dedup
+// is supposed to drive to zero.
 type configMetrics struct {
-	cfg      knobConfig
-	mean     RankedMetrics
-	meanHits float64
+	cfg            knobConfig
+	mean           RankedMetrics
+	meanHits       float64
+	crossFileDupes int
+}
+
+// countCrossFileDupes counts how many returned rel_paths are cross-file
+// duplicates of an already-seen result — i.e. share a content_hash with a
+// higher-ranked hit. rel_paths with an unknown/empty content_hash are never
+// grouped (each is its own group), mirroring dedupCrossFileCandidates. The
+// return value is (# returned rel_paths − # distinct content groups), so 0 means
+// every source file appears at most once.
+func countCrossFileDupes(relPaths []string, hashByRelPath map[string]string) int {
+	seen := make(map[string]struct{}, len(relPaths))
+	dupes := 0
+	for _, rp := range relPaths {
+		key := hashByRelPath[rp]
+		if key == "" {
+			key = "\x00relpath\x00" + rp // unknown/empty hash: never grouped
+		}
+		if _, ok := seen[key]; ok {
+			dupes++
+			continue
+		}
+		seen[key] = struct{}{}
+	}
+	return dupes
 }
 
 // ablationMatrix is the set of configurations the harness measures. Each row
@@ -41,6 +68,10 @@ func ablationMatrix() []knobConfig {
 // and returns one configMetrics row per config, in matrix order.
 func runAblation(t *testing.T, corpus evalCorpus) []configMetrics {
 	t.Helper()
+	hashByRelPath := make(map[string]string, len(corpus.docs))
+	for _, d := range corpus.docs {
+		hashByRelPath[d.RelPath] = d.ContentHash
+	}
 	rows := make([]configMetrics, 0, len(ablationMatrix()))
 	for _, cfg := range ablationMatrix() {
 		svc, err := corpus.buildService(cfg)
@@ -48,19 +79,21 @@ func runAblation(t *testing.T, corpus evalCorpus) []configMetrics {
 			t.Fatalf("buildService(%s): %v", cfg.name, err)
 		}
 		perQuery := make([]RankedMetrics, 0, len(corpus.queries))
-		var totalHits int
+		var totalHits, dupes int
 		for _, q := range corpus.queries {
 			retrieved, err := corpus.runQuery(svc, q, cfg, evalK)
 			if err != nil {
 				t.Fatalf("config %q query %q: %v", cfg.name, q.ID, err)
 			}
 			totalHits += len(retrieved)
+			dupes += countCrossFileDupes(retrieved, hashByRelPath)
 			perQuery = append(perQuery, Evaluate(retrieved, relevantSet(q.Relevant), evalK))
 		}
 		rows = append(rows, configMetrics{
-			cfg:      cfg,
-			mean:     MeanMetrics(perQuery),
-			meanHits: float64(totalHits) / float64(len(corpus.queries)),
+			cfg:            cfg,
+			mean:           MeanMetrics(perQuery),
+			meanHits:       float64(totalHits) / float64(len(corpus.queries)),
+			crossFileDupes: dupes,
 		})
 	}
 	return rows
@@ -87,16 +120,16 @@ func TestAblationMatrix(t *testing.T) {
 	rows := runAblation(t, corpus)
 
 	t.Logf("retrieval ablation @k=%d over %d queries:", evalK, len(corpus.queries))
-	t.Logf("%-18s %8s %8s %8s %9s", "config", "recall", "nDCG", "MRR", "meanHits")
+	t.Logf("%-18s %8s %8s %8s %9s %9s", "config", "recall", "nDCG", "MRR", "meanHits", "xfileDup")
 	for _, r := range rows {
-		t.Logf("%-18s %8.4f %8.4f %8.4f %9.2f",
-			r.cfg.name, r.mean.RecallAtK, r.mean.NDCGAtK, r.mean.MRR, r.meanHits)
+		t.Logf("%-18s %8.4f %8.4f %8.4f %9.2f %9d",
+			r.cfg.name, r.mean.RecallAtK, r.mean.NDCGAtK, r.mean.MRR, r.meanHits, r.crossFileDupes)
 	}
 
 	assertBaselineFindsEverything(t, rows)
 	assertHybridImprovesRanking(t, rows)
 	assertRerankImprovesRanking(t, rows)
-	assertDedupTrimsWithoutRecallLoss(t, rows)
+	assertDedupRemovesCrossFileDuplicates(t, rows)
 	assertLangFilterDoesNotHurtRecall(t, rows)
 	assertMinScoreTrimsWithoutRecallLoss(t, rows)
 }
@@ -130,6 +163,14 @@ func assertHybridImprovesRanking(t *testing.T, rows []configMetrics) {
 // assertRerankImprovesRanking: the deterministic lexical reranker is at least as
 // good as plain hybrid on ranking quality (it reorders the fused pool toward the
 // lexically-best candidate) and never regresses recall.
+//
+// Since the #519 over-fetch fix, hybrid fusion keeps a rerank-sized candidate
+// pool instead of truncating to k, so the reranker now reorders the full
+// over-fetch pool (and can rescue a chunk fused at rank k+1..pool) rather than
+// only permuting the top-k. The invariant stays a no-regression FLOOR (rerank
+// must never do worse than plain hybrid): asserting a strict improvement would
+// over-fit this small fixture, and the floor already fails loudly if the wider
+// pool ever let rerank drop a relevant doc.
 func assertRerankImprovesRanking(t *testing.T, rows []configMetrics) {
 	t.Helper()
 	hyb := metricsFor(rows, "hybrid")
@@ -142,15 +183,36 @@ func assertRerankImprovesRanking(t *testing.T, rows []configMetrics) {
 	}
 }
 
-// assertDedupTrimsWithoutRecallLoss: cross-file dedup collapses the byte-
-// identical gardening alias, shrinking the mean hit count, while the canonical
-// relevant doc survives so recall/MRR are unchanged.
-func assertDedupTrimsWithoutRecallLoss(t *testing.T, rows []configMetrics) {
+// assertDedupRemovesCrossFileDuplicates: cross-file dedup collapses the byte-
+// identical gardening alias so no source file appears twice in the top-k, while
+// the canonical relevant doc survives so recall is unchanged.
+//
+// This assertion was re-baselined for the #519 over-fetch fix. Previously hybrid
+// fusion truncated to the final k, so cross-file dedup returned strictly FEWER
+// hits than plain hybrid (it dropped the alias without anything to backfill), and
+// the gate asserted `dedup.meanHits < hybrid.meanHits`. The over-fetch fix widens
+// the fused candidate pool to a rerank-sized set: dedup now removes the alias and
+// backfills to k with the next UNIQUE cross-file result, so both configs return k
+// hits and the old "fewer hits" invariant no longer holds (and was never the real
+// contract — it was a proxy). The correct, stronger property is asserted directly:
+//   - hybrid+dedup returns ZERO cross-file duplicates (every content_hash appears
+//     at most once in the deduped top-k) — the property dedup exists to guarantee;
+//   - plain hybrid DOES surface at least one cross-file duplicate, so the gate is
+//     non-vacuous and would genuinely fail if dedup ever stopped collapsing them;
+//   - recall is not reduced (the canonical relevant doc still survives).
+func assertDedupRemovesCrossFileDuplicates(t *testing.T, rows []configMetrics) {
 	t.Helper()
 	hyb := metricsFor(rows, "hybrid")
 	dd := metricsFor(rows, "hybrid+dedup")
-	if !(dd.meanHits < hyb.meanHits) {
-		t.Fatalf("cross-file dedup must shrink the candidate set: hybrid=%.2f dedup=%.2f", hyb.meanHits, dd.meanHits)
+	// Guard against a vacuous gate: without dedup the corpus/query set must
+	// actually surface a cross-file duplicate into the top-k, otherwise
+	// asserting dedup==0 proves nothing.
+	if hyb.crossFileDupes == 0 {
+		t.Fatalf("ablation fixtures must surface a cross-file duplicate without dedup (got 0); fixtures drifted")
+	}
+	if dd.crossFileDupes != 0 {
+		t.Fatalf("cross-file dedup must leave no duplicate source file in the top-k: hybrid=%d dedup=%d",
+			hyb.crossFileDupes, dd.crossFileDupes)
 	}
 	if dd.mean.RecallAtK < hyb.mean.RecallAtK-eps {
 		t.Fatalf("cross-file dedup must not drop a canonical relevant doc: hybrid=%.4f dedup=%.4f",


### PR DESCRIPTION
Closes #519.

## Problem
`runHybridSearch` fused RRF results to the final `k`, so when rerank/dedup was enabled the downstream stage could only reorder the top-k and could never rescue a relevant chunk fused at rank `k+1..pool` — defeating the over-fetch pool (the same class the HyDE path already avoids by fusing to `hybridCandidatePoolSize`).

## Pool change (`internal/retrieval/hybrid.go`)
Hybrid fusion now keeps a candidate pool sized for the downstream rerank stage via the new `rerankFusionPoolSize(k, s.rerankCandidatePool)`:
- floored at `hybridCandidatePoolSize`,
- backed by the configured rerank candidate pool (falls back to `defaultRerankCandidatePool` when unset),
- never below the caller's `k` (a larger requested `k` is still honored).

The caller (`searchSingleIndex`) still truncates to `k` when rerank is disabled, so the wider pool is harmless there — it only lets the reranker and cross-file/media dedup operate over the real over-fetch candidate set. Mirrors the HyDE path. `TestRerankFusionPoolSize` pins the sizing.

## Deliberate ablation re-baseline (`tests/eval/ablation_test.go`)
The wider pool changes hybrid candidate-set semantics. `hybrid+dedup` now removes the byte-identical gardening alias and **backfills to k with the next UNIQUE cross-file result** instead of returning fewer hits — so both `hybrid` and `hybrid+dedup` return `k` hits and the old invariant `assertDedupTrimsWithoutRecallLoss` ("dedup returns FEWER hits than hybrid") no longer holds. That was only ever a proxy for the real contract.

Replaced with `assertDedupRemovesCrossFileDuplicates`, asserting the genuinely-correct property:
- **`hybrid+dedup` returns ZERO cross-file duplicates** — each `content_hash` appears at most once in the deduped top-k (the property dedup exists to guarantee);
- **plain `hybrid` DOES surface at least one cross-file duplicate**, so the gate is non-vacuous and fails loudly if dedup ever stops collapsing them;
- **recall is not reduced** (the canonical relevant doc still survives).

To observe cross-file uniqueness, the harness gains a minimal metric: per config, `# returned rel_paths − # distinct content-hash groups`, summed over the query set (added to `configMetrics` + logged in the ablation table as `xfileDup`). A negative check (temporarily disabling dedup) confirms the gate fails (`dedup=4`) rather than being decorative. The rerank assertion keeps its no-regression floor with an added comment noting it now reorders the full over-fetch pool.

Observed ablation table after the fix: `hybrid` xfileDup=4, `hybrid+dedup` xfileDup=0, recall=1.0 across all rows.

## Validation
- `gofmt -l internal/ tests/` clean
- `go build ./...`, `go vet ./internal/retrieval/... ./tests/eval/...` clean
- `make cyclo` (≤15) clean
- `golangci-lint run` (full) — 0 issues
- `go test ./internal/retrieval/... ./tests/retrieval/... ./tests/eval/...` — all pass; ablation gate passes and fails when dedup is sabotaged