### PR TITLE
fix(quality): script-agnostic repetition/gibberish detection; don't quarantine sparse audio (#439)

### DIFF
--- a/internal/quality/config.go
+++ b/internal/quality/config.go
@@ -4,6 +4,12 @@ package quality
 // generally start from [DefaultConfig] and disable detectors selectively,
 // because [Config.WithDefaults] fills only unset thresholds and does not
 // force Enabled flags on.
+//
+// Every threshold is exposed as a per-detector knob so a caller can tune the
+// gate for its corpus (e.g. a speech-dense corpus may enable the duration
+// density floor, while a music/podcast corpus leaves it off). Wiring these
+// knobs from the user-facing config file lives outside this package; the gate
+// only accepts an already-resolved Config.
 type Config struct {
 	Empty      EmptyConfig
 	Repetition RepetitionConfig
@@ -18,18 +24,48 @@ type EmptyConfig struct {
 	MinChars int
 }
 
-// RepetitionConfig configures the repetition-loop detector.
+// RepetitionConfig configures the repetition-loop detector. Detection is
+// script-agnostic: it measures how much of the (whitespace-normalized) rune
+// stream is explained by a single short repeating period, so it catches
+// space-delimited loops ("thank you thank you …") and space-free CJK loops
+// ("感谢观看感谢观看 …") uniformly.
 type RepetitionConfig struct {
-	Enabled           bool
-	NGram             int
+	Enabled bool
+	// MaxRepeatFraction is the largest share of the content that may be
+	// explained by a single dominant repeating period before the gate trips.
 	MaxRepeatFraction float64
-	MinWords          int
+	// MaxPeriod bounds the longest repeating unit (in runes) considered. It
+	// keeps detection O(runes × MaxPeriod) on long inputs.
+	MaxPeriod int
+	// MinRunes is the minimum normalized rune length required before the
+	// detector inspects the content; shorter inputs are skipped as too small
+	// to judge. This replaces whitespace word counting, which was blind to
+	// scripts without word boundaries.
+	MinRunes int
 }
 
-// GibberishConfig configures the gibberish (non-printable) detector.
+// GibberishConfig configures the gibberish/coherence detector. Beyond the
+// non-printable-rune check it applies two script-agnostic coherence signals:
+// an "other character" (symbol/box-drawing) density ceiling and, for
+// alphabetic scripts that distinguish vowels, a vowel floor that catches
+// printable-ASCII consonant mash.
 type GibberishConfig struct {
-	Enabled                 bool
+	Enabled bool
+	// MaxNonPrintableFraction is the ceiling on replacement/control/private-use
+	// runes (corrupted decoding).
 	MaxNonPrintableFraction float64
+	// MaxOtherFraction is the ceiling on the fraction of visible runes that are
+	// neither letters, digits, nor punctuation (symbol soup). Natural prose in
+	// any script sits well below this.
+	MaxOtherFraction float64
+	// MinVowelFraction is the floor on the vowel share among vowel-bearing
+	// alphabetic letters (Latin/Cyrillic/Greek). Consonant mash falls below it;
+	// it is set low so heavily accented real languages stay clear.
+	MinVowelFraction float64
+	// MinVowelSampleLetters is the minimum number of vowel-bearing letters
+	// required before the vowel floor is applied, so short fragments are not
+	// misjudged.
+	MinVowelSampleLetters int
 }
 
 // LanguageConfig configures the language/script-mismatch detector.
@@ -38,12 +74,35 @@ type LanguageConfig struct {
 	MaxOffScriptFraction float64
 }
 
-// DensityConfig configures the low-text-density detector.
+// DensityConfig configures the low-text-density detector. The duration-based
+// floor (MinCharsPerMinute) is disabled by default: a sparse transcript is a
+// legitimate outcome for music or long silences, so density alone is not
+// treated as a failure. The segment-ratio check remains the clearer signal of
+// dropped content and stays on by default. Operators who know a corpus is
+// speech-dense can set MinCharsPerMinute > 0 to re-enable the floor.
 type DensityConfig struct {
 	Enabled           bool
 	MinCharsPerMinute float64
 	MinSegmentRatio   float64
 }
+
+// Default threshold values, exported as named constants so the reasoning
+// behind each is documented in one place.
+const (
+	defaultEmptyMinChars = 1
+
+	defaultRepetitionMaxFraction = 0.50
+	defaultRepetitionMaxPeriod   = 64
+	defaultRepetitionMinRunes    = 24
+
+	defaultGibberishMaxNonPrintable = 0.20
+	defaultGibberishMaxOther        = 0.40
+	defaultGibberishMinVowel        = 0.08
+	defaultGibberishMinVowelSample  = 16
+	defaultLanguageMaxOffScript     = 0.50
+	defaultDensityMinSegmentRatio   = 1.0 / 3.0
+	defaultDensityMinCharsPerMinute = 0.0 // 0 => duration floor disabled.
+)
 
 // DefaultConfig returns the recommended configuration with every detector
 // enabled and conservative thresholds.
@@ -51,26 +110,29 @@ func DefaultConfig() Config {
 	return Config{
 		Empty: EmptyConfig{
 			Enabled:  true,
-			MinChars: 1,
+			MinChars: defaultEmptyMinChars,
 		},
 		Repetition: RepetitionConfig{
 			Enabled:           true,
-			NGram:             3,
-			MaxRepeatFraction: 0.30,
-			MinWords:          30,
+			MaxRepeatFraction: defaultRepetitionMaxFraction,
+			MaxPeriod:         defaultRepetitionMaxPeriod,
+			MinRunes:          defaultRepetitionMinRunes,
 		},
 		Gibberish: GibberishConfig{
 			Enabled:                 true,
-			MaxNonPrintableFraction: 0.20,
+			MaxNonPrintableFraction: defaultGibberishMaxNonPrintable,
+			MaxOtherFraction:        defaultGibberishMaxOther,
+			MinVowelFraction:        defaultGibberishMinVowel,
+			MinVowelSampleLetters:   defaultGibberishMinVowelSample,
 		},
 		Language: LanguageConfig{
 			Enabled:              true,
-			MaxOffScriptFraction: 0.50,
+			MaxOffScriptFraction: defaultLanguageMaxOffScript,
 		},
 		Density: DensityConfig{
 			Enabled:           true,
-			MinCharsPerMinute: 30,
-			MinSegmentRatio:   1.0 / 3.0,
+			MinCharsPerMinute: defaultDensityMinCharsPerMinute,
+			MinSegmentRatio:   defaultDensityMinSegmentRatio,
 		},
 	}
 }
@@ -79,6 +141,9 @@ func DefaultConfig() Config {
 // threshold filled in from [DefaultConfig]. Enabled flags are preserved
 // exactly as set; callers should start from DefaultConfig and disable
 // detectors selectively, since WithDefaults does not force Enabled=true.
+//
+// MinCharsPerMinute is intentionally not filled: 0 is a meaningful value
+// (duration floor disabled) rather than "unset".
 func (c Config) WithDefaults() Config {
 	d := DefaultConfig()
 
@@ -86,27 +151,33 @@ func (c Config) WithDefaults() Config {
 		c.Empty.MinChars = d.Empty.MinChars
 	}
 
-	if c.Repetition.NGram <= 0 {
-		c.Repetition.NGram = d.Repetition.NGram
-	}
 	if c.Repetition.MaxRepeatFraction <= 0 {
 		c.Repetition.MaxRepeatFraction = d.Repetition.MaxRepeatFraction
 	}
-	if c.Repetition.MinWords <= 0 {
-		c.Repetition.MinWords = d.Repetition.MinWords
+	if c.Repetition.MaxPeriod <= 0 {
+		c.Repetition.MaxPeriod = d.Repetition.MaxPeriod
+	}
+	if c.Repetition.MinRunes <= 0 {
+		c.Repetition.MinRunes = d.Repetition.MinRunes
 	}
 
 	if c.Gibberish.MaxNonPrintableFraction <= 0 {
 		c.Gibberish.MaxNonPrintableFraction = d.Gibberish.MaxNonPrintableFraction
+	}
+	if c.Gibberish.MaxOtherFraction <= 0 {
+		c.Gibberish.MaxOtherFraction = d.Gibberish.MaxOtherFraction
+	}
+	if c.Gibberish.MinVowelFraction <= 0 {
+		c.Gibberish.MinVowelFraction = d.Gibberish.MinVowelFraction
+	}
+	if c.Gibberish.MinVowelSampleLetters <= 0 {
+		c.Gibberish.MinVowelSampleLetters = d.Gibberish.MinVowelSampleLetters
 	}
 
 	if c.Language.MaxOffScriptFraction <= 0 {
 		c.Language.MaxOffScriptFraction = d.Language.MaxOffScriptFraction
 	}
 
-	if c.Density.MinCharsPerMinute <= 0 {
-		c.Density.MinCharsPerMinute = d.Density.MinCharsPerMinute
-	}
 	if c.Density.MinSegmentRatio <= 0 {
 		c.Density.MinSegmentRatio = d.Density.MinSegmentRatio
 	}

--- a/internal/quality/detectors.go
+++ b/internal/quality/detectors.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"unicode"
 	"unicode/utf8"
+
+	"golang.org/x/text/unicode/norm"
 )
 
 // emptyDetector flags output that is effectively empty after trimming
@@ -28,82 +30,179 @@ func (d emptyDetector) Inspect(text string, _ Context) *Finding {
 	return nil
 }
 
-// repetitionDetector flags output dominated by a single repeated word
-// n-gram, the classic STT "thank you for watching" hallucination loop.
+// repetitionDetector flags output dominated by a single short repeating unit,
+// the classic STT "thank you for watching" hallucination loop. It is
+// script-agnostic: instead of counting whitespace-delimited words (which is
+// blind to scripts without word boundaries, such as a looping CJK phrase), it
+// measures the largest share of the normalized rune stream that a single
+// repeating period explains. A period-p loop makes rune r[i] equal r[i+p]
+// almost everywhere; natural language has no such dominant period at any lag.
 type repetitionDetector struct {
-	n        int
-	maxFrac  float64
-	minWords int
+	maxFrac   float64
+	maxPeriod int
+	minRunes  int
 }
 
 func (repetitionDetector) Name() string { return "repetition" }
 
 func (d repetitionDetector) Inspect(text string, _ Context) *Finding {
-	words := strings.Fields(strings.ToLower(text))
-	if len(words) < d.minWords || len(words) < d.n {
+	rs := normalizeRunes(text)
+	n := len(rs)
+	if n < d.minRunes {
 		return nil
 	}
-	counts := make(map[string]int)
-	total := 0
-	topCount := 0
-	for i := 0; i+d.n <= len(words); i++ {
-		gram := strings.Join(words[i:i+d.n], " ")
-		counts[gram]++
-		total++
-		if counts[gram] > topCount {
-			topCount = counts[gram]
+	// Only consider periods whose repeated span covers at least half the text,
+	// so a genuine dominant loop qualifies while short high-lag windows cannot
+	// inflate the fraction by chance.
+	maxLag := d.maxPeriod
+	if maxLag > n/2 {
+		maxLag = n / 2
+	}
+	if maxLag < 1 {
+		return nil
+	}
+	bestFrac := 0.0
+	bestLag := 0
+	for p := 1; p <= maxLag; p++ {
+		overlap := n - p
+		matches := 0
+		for i := 0; i < overlap; i++ {
+			if rs[i] == rs[i+p] {
+				matches++
+			}
+		}
+		frac := float64(matches) / float64(overlap)
+		if frac > bestFrac {
+			bestFrac = frac
+			bestLag = p
 		}
 	}
-	if total == 0 {
-		return nil
-	}
-	frac := float64(topCount) / float64(total)
-	if frac > d.maxFrac {
+	if bestFrac > d.maxFrac {
 		// Detail is intentionally content-free: report only the repetition
-		// metrics, never the repeated phrase itself (which is raw input text).
+		// metrics (the period length and coverage), never the repeated text.
 		return &Finding{
 			Reason: ReasonRepetitionLoop,
-			Detail: fmt.Sprintf("top %d-gram repeats %d/%d (%.0f%%)",
-				d.n, topCount, total, frac*100),
-			Score: frac,
+			Detail: fmt.Sprintf("dominant period %d runes covers %.0f%% of content",
+				bestLag, bestFrac*100),
+			Score: bestFrac,
 		}
 	}
 	return nil
 }
 
-// gibberishDetector flags output with too high a fraction of replacement,
-// control, or private-use runes, a signal of corrupted decoding.
+// normalizeRunes lowercases text and collapses every run of whitespace into a
+// single space, returning the result as a rune slice. This makes repetition
+// detection insensitive to spacing and case while preserving the character
+// sequence that a loop repeats, in any script.
+func normalizeRunes(text string) []rune {
+	rs := make([]rune, 0, len(text))
+	prevSpace := false
+	for _, r := range strings.ToLower(text) {
+		if unicode.IsSpace(r) {
+			if !prevSpace && len(rs) > 0 {
+				rs = append(rs, ' ')
+			}
+			prevSpace = true
+			continue
+		}
+		rs = append(rs, r)
+		prevSpace = false
+	}
+	// Drop a trailing collapsed space, if any.
+	if len(rs) > 0 && rs[len(rs)-1] == ' ' {
+		rs = rs[:len(rs)-1]
+	}
+	return rs
+}
+
+// gibberishDetector flags incoherent output using three script-agnostic
+// signals, in order of confidence:
+//
+//  1. non-printable runes (replacement/control/private-use) — corrupted
+//     decoding;
+//  2. symbol density — a high fraction of visible runes that are neither
+//     letters, digits, nor punctuation (printable-ASCII symbol soup);
+//  3. vowel deficiency — among vowel-bearing alphabetic letters
+//     (Latin/Cyrillic/Greek), a vowel share below a low floor (consonant
+//     mash such as "qwrtplkjhg"). This signal self-skips for scripts without a
+//     vowel/consonant distinction (Han, Arabic, Hebrew, …) and for samples too
+//     small to judge, so legitimate multilingual text is never flagged.
 type gibberishDetector struct {
 	maxNonPrintable float64
+	maxOther        float64
+	minVowel        float64
+	minVowelSample  int
 }
 
 func (gibberishDetector) Name() string { return "gibberish" }
 
-func (d gibberishDetector) Inspect(text string, _ Context) *Finding {
-	total := 0
-	bad := 0
+// coherenceStats tallies, over the visible (non-whitespace) runes of some
+// text, the counts each gibberish signal needs.
+type coherenceStats struct {
+	visible     int // all non-whitespace runes
+	bad         int // replacement/control/private-use runes
+	other       int // visible runes that are not letter, digit, or punctuation
+	vowelScript int // letters in a vowel-bearing script (Latin/Cyrillic/Greek)
+	vowels      int // vowels among vowelScript letters
+}
+
+// classify folds a single visible rune into the stats.
+func (s *coherenceStats) classify(r rune) {
+	s.visible++
+	switch {
+	case r == utf8.RuneError || r == '�' ||
+		unicode.Is(unicode.C, r) || unicode.Is(unicode.Co, r):
+		s.bad++
+	case unicode.IsLetter(r):
+		if isVowelBearingLetter(r) {
+			s.vowelScript++
+			if isVowel(r) {
+				s.vowels++
+			}
+		}
+	case unicode.IsDigit(r) || unicode.IsPunct(r):
+		// Digits and punctuation are ordinary in prose; ignore.
+	default:
+		s.other++
+	}
+}
+
+func gatherCoherenceStats(text string) coherenceStats {
+	var s coherenceStats
 	for _, r := range text {
 		if unicode.IsSpace(r) {
 			continue
 		}
-		total++
-		if r == utf8.RuneError || r == '�' ||
-			unicode.Is(unicode.C, r) || unicode.Is(unicode.Co, r) {
-			bad++
-		}
+		s.classify(r)
 	}
-	if total == 0 {
+	return s
+}
+
+func (d gibberishDetector) Inspect(text string, _ Context) *Finding {
+	s := gatherCoherenceStats(text)
+	if s.visible == 0 {
 		return nil
 	}
-	frac := float64(bad) / float64(total)
-	if frac > d.maxNonPrintable {
-		return &Finding{
-			Reason: ReasonGibberish,
-			Detail: fmt.Sprintf("%d/%d non-printable runes (%.0f%%)", bad, total, frac*100),
-			Score:  frac,
+
+	if f := float64(s.bad) / float64(s.visible); f > d.maxNonPrintable {
+		return gibberishFinding(fmt.Sprintf("%d/%d non-printable runes (%.0f%%)", s.bad, s.visible, f*100), f)
+	}
+	if f := float64(s.other) / float64(s.visible); f > d.maxOther {
+		return gibberishFinding(fmt.Sprintf("%d/%d non-language symbols (%.0f%%)", s.other, s.visible, f*100), f)
+	}
+	if s.vowelScript >= d.minVowelSample {
+		if f := float64(s.vowels) / float64(s.vowelScript); f < d.minVowel {
+			return gibberishFinding(fmt.Sprintf("%d/%d vowels among alphabetic letters (%.0f%%)",
+				s.vowels, s.vowelScript, f*100), 1-f)
 		}
 	}
 	return nil
+}
+
+// gibberishFinding builds a ReasonGibberish finding from an already
+// content-free detail string and score.
+func gibberishFinding(detail string, score float64) *Finding {
+	return &Finding{Reason: ReasonGibberish, Detail: detail, Score: score}
 }
 
 // languageDetector flags output whose script does not match the expected
@@ -148,7 +247,11 @@ func (d languageDetector) Inspect(text string, ctx Context) *Finding {
 }
 
 // densityDetector flags output that is implausibly sparse relative to the
-// source media duration or the number of source segments.
+// number of source segments (a clear signal of dropped content). The
+// duration-based floor is opt-in: a low chars-per-minute rate is a legitimate
+// outcome for music or long silences, so it is applied only when
+// minCharsPerMinute is configured above zero, and never quarantines sparse
+// audio on its own by default.
 type densityDetector struct {
 	minCharsPerMinute float64
 	minSegmentRatio   float64
@@ -159,7 +262,7 @@ func (densityDetector) Name() string { return "density" }
 func (d densityDetector) Inspect(text string, ctx Context) *Finding {
 	chars := float64(utf8.RuneCountInString(strings.TrimSpace(text)))
 
-	if ctx.Duration > 0 {
+	if d.minCharsPerMinute > 0 && ctx.Duration > 0 {
 		minutes := ctx.Duration.Minutes()
 		cpm := chars / minutes
 		if cpm < d.minCharsPerMinute {
@@ -283,6 +386,52 @@ var languageScript = map[string]script{
 	"zh": scriptHan,
 	"ko": scriptHangul,
 	"hi": scriptDevanagari,
+}
+
+// baseVowels holds the lowercase base (diacritic-stripped) vowel letters for
+// the alphabetic scripts that distinguish vowels from consonants: Latin,
+// Greek, and Cyrillic. Accented forms fold to these bases via [foldBase], so
+// the set stays small yet covers heavily accented languages.
+var baseVowels = func() map[rune]struct{} {
+	m := make(map[rune]struct{})
+	for _, r := range "aeiou" + "αεηιουω" + "аеиоуыэюяіїєў" {
+		m[r] = struct{}{}
+	}
+	return m
+}()
+
+// isVowelBearingLetter reports whether r belongs to an alphabetic script that
+// distinguishes vowels from consonants. Scripts without that distinction
+// (Han, Kana, Arabic, Hebrew, Devanagari, …) return false so the vowel-floor
+// signal self-skips for them.
+func isVowelBearingLetter(r rune) bool {
+	switch scriptOf(r) {
+	case scriptLatin, scriptCyrillic, scriptGreek:
+		return true
+	default:
+		return false
+	}
+}
+
+// isVowel reports whether r is a vowel in its script, tolerating diacritics
+// (e.g. "é", "ü", "ậ", "ή"). ASCII letters take a fast path.
+func isVowel(r rune) bool {
+	lr := unicode.ToLower(r)
+	if lr < utf8.RuneSelf {
+		_, ok := baseVowels[lr]
+		return ok
+	}
+	_, ok := baseVowels[foldBase(lr)]
+	return ok
+}
+
+// foldBase returns the base letter of r with combining diacritics removed, by
+// taking the first rune of its canonical (NFD) decomposition.
+func foldBase(r rune) rune {
+	for _, b := range norm.NFD.String(string(r)) {
+		return b
+	}
+	return r
 }
 
 // scriptForLanguage returns the dominant script for a language tag, or

--- a/internal/quality/quality.go
+++ b/internal/quality/quality.go
@@ -98,25 +98,30 @@ type Gate struct {
 }
 
 // New builds a Gate from cfg. Defaults are filled via [Config.WithDefaults],
-// and detectors are appended in severity order (empty, repetition,
-// gibberish, language, density). Each detector is included only if its
-// corresponding Enabled flag is set.
+// and detectors are appended in severity order (empty, gibberish, repetition,
+// language, density). Gibberish precedes repetition so that corrupted output
+// (e.g. a run of replacement characters, which is also trivially "repetitive")
+// is reported as its root cause rather than as a repetition loop. Each detector
+// is included only if its corresponding Enabled flag is set.
 func New(cfg Config) *Gate {
 	cfg = cfg.WithDefaults()
 	g := &Gate{}
 	if cfg.Empty.Enabled {
 		g.detectors = append(g.detectors, emptyDetector{minChars: cfg.Empty.MinChars})
 	}
-	if cfg.Repetition.Enabled {
-		g.detectors = append(g.detectors, repetitionDetector{
-			n:        cfg.Repetition.NGram,
-			maxFrac:  cfg.Repetition.MaxRepeatFraction,
-			minWords: cfg.Repetition.MinWords,
-		})
-	}
 	if cfg.Gibberish.Enabled {
 		g.detectors = append(g.detectors, gibberishDetector{
 			maxNonPrintable: cfg.Gibberish.MaxNonPrintableFraction,
+			maxOther:        cfg.Gibberish.MaxOtherFraction,
+			minVowel:        cfg.Gibberish.MinVowelFraction,
+			minVowelSample:  cfg.Gibberish.MinVowelSampleLetters,
+		})
+	}
+	if cfg.Repetition.Enabled {
+		g.detectors = append(g.detectors, repetitionDetector{
+			maxFrac:   cfg.Repetition.MaxRepeatFraction,
+			maxPeriod: cfg.Repetition.MaxPeriod,
+			minRunes:  cfg.Repetition.MinRunes,
 		})
 	}
 	if cfg.Language.Enabled {

--- a/tests/quality/quality_test.go
+++ b/tests/quality/quality_test.go
@@ -16,17 +16,39 @@ const cleanTranscript = "Welcome back to the show. Today we are talking about " 
 	"printed books and will walk us through several rare examples from the " +
 	"fifteenth century before we open the floor to questions from listeners."
 
-// repetitionLoop is a degenerate STT hallucination loop. A four-word phrase
-// only reaches roughly a quarter of all trigrams, which sits under the
-// default 0.30 threshold, so we use a two-word phrase whose top trigram
-// dominates the output (~50%). See the deviation note in the PR body.
+// repetitionLoop is a degenerate space-delimited STT hallucination loop: a
+// short phrase repeated until it dominates the whole output.
 var repetitionLoop = strings.Repeat("thank you ", 60)
+
+// cjkRepetitionLoop is the same failure mode in a script without whitespace
+// word boundaries (a looping "thanks for watching"). A whitespace-tokenized
+// detector is blind to it; a script-agnostic one is not.
+var cjkRepetitionLoop = strings.Repeat("感谢观看", 40)
 
 // cyrillicText is a short run of Cyrillic letters.
 const cyrillicText = "Привет, это пример текста на русском языке для проверки."
 
-// gibberishText is dominated by the Unicode replacement character.
+// sparseMusicTranscript is a legitimately sparse transcript (music with long
+// instrumental stretches). It is well under any reasonable chars-per-minute
+// floor but is valid content, not a failure.
+const sparseMusicTranscript = "[Music]\n" +
+	"We are the champions, my friends.\n" +
+	"[Music]\n" +
+	"And we'll keep on fighting till the end.\n" +
+	"[Music]"
+
+// gibberishText is dominated by the Unicode replacement character (corrupted
+// decoding).
 var gibberishText = strings.Repeat("�", 50) + " ok"
+
+// asciiGibberish is printable-ASCII non-language garbage: a consonant mash
+// with no vowels. It decodes cleanly, so the non-printable check passes it;
+// the coherence check must catch it.
+const asciiGibberish = "kzrtbqxwvlmnpdfghjklzxcvbnmqwrtpsdgfhbcgjklmnpqrstvwxzkgbrmntpl"
+
+// symbolSoup is printable-ASCII garbage made mostly of symbols rather than
+// letters.
+const symbolSoup = "^=~^=~<>|^=~<>|^=` `^~<>|=^~ ^=<>|~^=<>|`^~=<>|^=~<>`|^=~<>"
 
 func TestGate_Evaluate(t *testing.T) {
 	gate := quality.New(quality.DefaultConfig())
@@ -45,8 +67,15 @@ func TestGate_Evaluate(t *testing.T) {
 			wantOK: true,
 		},
 		{
-			name:       "repetition loop",
+			name:       "space-delimited repetition loop",
 			text:       repetitionLoop,
+			ctx:        quality.Context{Modality: quality.ModalityTranscript},
+			wantOK:     false,
+			wantReason: quality.ReasonRepetitionLoop,
+		},
+		{
+			name:       "cjk repetition loop",
+			text:       cjkRepetitionLoop,
 			ctx:        quality.Context{Modality: quality.ModalityTranscript},
 			wantOK:     false,
 			wantReason: quality.ReasonRepetitionLoop,
@@ -85,11 +114,10 @@ func TestGate_Evaluate(t *testing.T) {
 			wantOK: true,
 		},
 		{
-			name:       "tiny text over long duration",
-			text:       "Okay.",
-			ctx:        quality.Context{Modality: quality.ModalityTranscript, Duration: 60 * time.Minute},
-			wantOK:     false,
-			wantReason: quality.ReasonLowDensity,
+			name:   "sparse music transcript over long duration passes",
+			text:   sparseMusicTranscript,
+			ctx:    quality.Context{Modality: quality.ModalityTranscript, Duration: 60 * time.Minute},
+			wantOK: true,
 		},
 		{
 			name:       "too few segments",
@@ -101,6 +129,20 @@ func TestGate_Evaluate(t *testing.T) {
 		{
 			name:       "gibberish ocr output",
 			text:       gibberishText,
+			ctx:        quality.Context{Modality: quality.ModalityOCR},
+			wantOK:     false,
+			wantReason: quality.ReasonGibberish,
+		},
+		{
+			name:       "printable ascii consonant mash",
+			text:       asciiGibberish,
+			ctx:        quality.Context{Modality: quality.ModalityTranscript},
+			wantOK:     false,
+			wantReason: quality.ReasonGibberish,
+		},
+		{
+			name:       "printable ascii symbol soup",
+			text:       symbolSoup,
 			ctx:        quality.Context{Modality: quality.ModalityOCR},
 			wantOK:     false,
 			wantReason: quality.ReasonGibberish,
@@ -150,6 +192,29 @@ func TestRepetition_ShortTextSkipped(t *testing.T) {
 	}
 }
 
+// TestDensity_DurationFloorOptIn documents that the duration-based density
+// floor is disabled by default (sparse audio passes) but can be re-enabled
+// per corpus via config, at which point the same sparse transcript trips.
+func TestDensity_DurationFloorOptIn(t *testing.T) {
+	ctx := quality.Context{Modality: quality.ModalityTranscript, Duration: 60 * time.Minute}
+
+	def := quality.New(quality.DefaultConfig())
+	if v := def.Evaluate(sparseMusicTranscript, ctx); !v.OK() {
+		t.Fatalf("default gate should not quarantine sparse audio; findings=%+v", v.Findings)
+	}
+
+	cfg := quality.DefaultConfig()
+	cfg.Density.MinCharsPerMinute = 30
+	strict := quality.New(cfg)
+	v := strict.Evaluate(sparseMusicTranscript, ctx)
+	if v.OK() {
+		t.Fatal("gate with duration floor enabled should quarantine sparse audio")
+	}
+	if p := v.Primary(); p == nil || p.Reason != quality.ReasonLowDensity {
+		t.Fatalf("expected ReasonLowDensity, got %+v", v.Findings)
+	}
+}
+
 func TestConfig_WithDefaults_FillsThresholds(t *testing.T) {
 	got := quality.Config{}.WithDefaults()
 	want := quality.DefaultConfig()
@@ -157,27 +222,35 @@ func TestConfig_WithDefaults_FillsThresholds(t *testing.T) {
 	if got.Empty.MinChars != want.Empty.MinChars {
 		t.Errorf("Empty.MinChars = %d, want %d", got.Empty.MinChars, want.Empty.MinChars)
 	}
-	if got.Repetition.NGram != want.Repetition.NGram {
-		t.Errorf("Repetition.NGram = %d, want %d", got.Repetition.NGram, want.Repetition.NGram)
-	}
 	if got.Repetition.MaxRepeatFraction != want.Repetition.MaxRepeatFraction {
 		t.Errorf("Repetition.MaxRepeatFraction = %v, want %v",
 			got.Repetition.MaxRepeatFraction, want.Repetition.MaxRepeatFraction)
 	}
-	if got.Repetition.MinWords != want.Repetition.MinWords {
-		t.Errorf("Repetition.MinWords = %d, want %d", got.Repetition.MinWords, want.Repetition.MinWords)
+	if got.Repetition.MaxPeriod != want.Repetition.MaxPeriod {
+		t.Errorf("Repetition.MaxPeriod = %d, want %d", got.Repetition.MaxPeriod, want.Repetition.MaxPeriod)
+	}
+	if got.Repetition.MinRunes != want.Repetition.MinRunes {
+		t.Errorf("Repetition.MinRunes = %d, want %d", got.Repetition.MinRunes, want.Repetition.MinRunes)
 	}
 	if got.Gibberish.MaxNonPrintableFraction != want.Gibberish.MaxNonPrintableFraction {
 		t.Errorf("Gibberish.MaxNonPrintableFraction = %v, want %v",
 			got.Gibberish.MaxNonPrintableFraction, want.Gibberish.MaxNonPrintableFraction)
 	}
+	if got.Gibberish.MaxOtherFraction != want.Gibberish.MaxOtherFraction {
+		t.Errorf("Gibberish.MaxOtherFraction = %v, want %v",
+			got.Gibberish.MaxOtherFraction, want.Gibberish.MaxOtherFraction)
+	}
+	if got.Gibberish.MinVowelFraction != want.Gibberish.MinVowelFraction {
+		t.Errorf("Gibberish.MinVowelFraction = %v, want %v",
+			got.Gibberish.MinVowelFraction, want.Gibberish.MinVowelFraction)
+	}
+	if got.Gibberish.MinVowelSampleLetters != want.Gibberish.MinVowelSampleLetters {
+		t.Errorf("Gibberish.MinVowelSampleLetters = %d, want %d",
+			got.Gibberish.MinVowelSampleLetters, want.Gibberish.MinVowelSampleLetters)
+	}
 	if got.Language.MaxOffScriptFraction != want.Language.MaxOffScriptFraction {
 		t.Errorf("Language.MaxOffScriptFraction = %v, want %v",
 			got.Language.MaxOffScriptFraction, want.Language.MaxOffScriptFraction)
-	}
-	if got.Density.MinCharsPerMinute != want.Density.MinCharsPerMinute {
-		t.Errorf("Density.MinCharsPerMinute = %v, want %v",
-			got.Density.MinCharsPerMinute, want.Density.MinCharsPerMinute)
 	}
 	if got.Density.MinSegmentRatio != want.Density.MinSegmentRatio {
 		t.Errorf("Density.MinSegmentRatio = %v, want %v",


### PR DESCRIPTION
Completes the heuristic half of #439. The store-side BM25 quarantine leak (quarantined chunks served via BM25/hybrid and cited in `ask`) was already fixed in #448/#512; this PR fixes the quality-gate heuristic misfires. **All changes are confined to `internal/quality/` and its tests** — no `store`/`retrieval`/`ingest`/`config`/`cli` edits.

## Heuristics fixed

### Repetition detector — was whitespace-tokenized, blind to CJK
Replaced word n-grams (which treated a space-free "感谢观看…" loop as a single token and skipped it) with a **script-agnostic autocorrelation** over the whitespace-normalized rune stream: the largest share of content explained by a single short repeating period. Catches space-delimited ("thank you…") and CJK loops uniformly. The metric is period- and length-invariant, so natural language (low autocorrelation at every lag) is not flagged at any length.

### Density gate — was killing sparse/music audio
The duration-based chars-per-minute floor is now **opt-in (disabled by default)**. A sparse transcript is a legitimate outcome for music or long silences, so low density alone no longer quarantines. The **segment-ratio check** (output segments vs. source STT segments) — a clearer signal of genuinely dropped content — stays on by default. Operators who know a corpus is speech-dense can re-enable the floor via config.

### Gibberish detector — missed printable-ASCII garbage
Kept the non-printable-rune check and added two script-agnostic coherence signals: a **symbol-density ceiling** (printable-ASCII symbol soup) and a **vowel floor** over vowel-bearing alphabetic scripts (consonant mash). The vowel signal self-skips for scripts without a vowel/consonant distinction (Han, Kana, Arabic, Hebrew, Devanagari) and for short samples, so legitimate multilingual text is never flagged. Diacritics fold to base vowels via NFD, so accented languages stay clear. Gibberish now runs before repetition so corrupted output is reported as its root cause.

### Per-threshold config
Every threshold is now a per-detector knob on the existing `quality.Config` struct: `MaxPeriod`, `MinRunes`, `MaxOtherFraction`, `MinVowelFraction`, `MinVowelSampleLetters`, and the opt-in `MinCharsPerMinute`.

## Deferred (out of scope for `internal/quality` alone)
- **Wiring the new knobs from the user config file** — the `internal/config` package is out of scope for this PR. The tunable struct lives in `quality`; a follow-up can surface it in `internal/config`.
- **Pinned-STT-language quarantine** — the language detector behaves correctly for its input; the misfire is that `internal/ingest` passes a pinned STT provider language as `ExpectedLanguage` even for other-language audio (`transcriptLanguage = sttExpectedLanguage(cfg)`). Fixing the provenance belongs in `ingest`/`config`, out of scope here.

## General-purpose
No locale/language-specific special-casing. Every heuristic is derived from Unicode script/category properties (autocorrelation, symbol category, vowel-bearing scripts) and improves CJK/Cyrillic/Latin/music uniformly.

## Validation
`gofmt -l`, `go build ./...`, `go vet ./...`, `make cyclo` (≤15), full `golangci-lint run` (0 issues), and `go test ./internal/quality/... ./tests/quality/...` all pass. Ingest test suites still pass.