### PR TITLE
fix(ingest,cli): wire chunking.* config through the chunker; re-validate after flag overlay (#405)

### DIFF
--- a/internal/cli/reindex.go
+++ b/internal/cli/reindex.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/dirstral/dir2mcp/internal/config"
 	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/ingest"
 	"github.com/dirstral/dir2mcp/internal/model"
 )
 
@@ -112,6 +113,9 @@ func (a *App) loadReindexConfig(global globalOptions) (config.Config, int) {
 		baseDir = ".dir2mcp"
 	}
 	cfg.StateDir = baseDir
+	// A full rebuild re-chunks the whole corpus, so it must honour chunking.*
+	// too (#405). loadConfigWithGlobalOptions already validated the config.
+	ingest.ConfigureChunking(cfg.ChunkingMaxTokens, cfg.ChunkingOverlapTokens)
 	return cfg, exitSuccess
 }
 

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -393,6 +393,13 @@ func (a *App) resolveX402Token(cfg *config.Config, opts upOptions) (source strin
 // validateUpConfig runs all post-override config validations (public mode,
 // MCP path prefix, x402, root/state directories).
 func (a *App) validateUpConfig(cfg *config.Config, opts upOptions) int {
+	// Re-validate AFTER the CLI flag overlay (#405). Load() validated the
+	// on-disk config, but applyUpFlagOverrides may have set values Load never
+	// saw, so without this a flag could smuggle an invalid value past validation.
+	if err := cfg.Validate(); err != nil {
+		writeCLIError(a.stderr, opts.jsonOutput, exitConfigInvalid, fmt.Sprintf("CONFIG_INVALID: %v", err))
+		return exitConfigInvalid
+	}
 	if cfg.Public || opts.public {
 		if code := a.applyPublicMode(cfg, opts); code != exitSuccess {
 			return code
@@ -1308,6 +1315,10 @@ func (a *App) prepareUpConfig(opts upOptions) (config.Config, authMaterial, stri
 	if code := a.validateUpConfig(&cfg, opts); code != exitSuccess {
 		return config.Config{}, authMaterial{}, "", "", false, code
 	}
+	// Apply the validated chunking.* budgets to the chunker before ingestion
+	// begins (#405): the chunker reads process-level effective sizes, so this
+	// must run before any document is chunked.
+	ingest.ConfigureChunking(cfg.ChunkingMaxTokens, cfg.ChunkingOverlapTokens)
 	nonInteractiveMode := upNonInteractiveMode(opts)
 	if code := a.checkMistralAPIKey(&cfg, opts, nonInteractiveMode); code != exitSuccess {
 		return config.Config{}, authMaterial{}, "", "", false, code

--- a/internal/ingest/represent.go
+++ b/internal/ingest/represent.go
@@ -627,6 +627,16 @@ func ConfigureChunking(maxTokens, overlapTokens int) {
 	if minChars >= maxChars {
 		minChars = maxChars - 1
 	}
+	// Clamp overlap below the window so the raw-text path (chunkRawTextByDocType,
+	// which passes these effective vars straight to chunkTextByChars without
+	// normalizeTextChunkParams) can never receive overlap >= max — that would
+	// stall/loop chunking. Defense-in-depth even though Validate() rejects it.
+	if overlapChars < 0 {
+		overlapChars = 0
+	}
+	if overlapChars >= maxChars {
+		overlapChars = maxChars - 1
+	}
 	effectiveTextChunkMaxChars = maxChars
 	effectiveTextChunkOverlapChars = overlapChars
 	effectiveTextChunkMinChars = minChars
@@ -1457,6 +1467,18 @@ func chunkTextByChars(content string, maxChars, overlapChars, minChars int) []ch
 // ChunkTextByChars splits text content using the same policy as ingestion.
 func ChunkTextByChars(content string, maxChars, overlapChars, minChars int) []ChunkSegment {
 	raw := chunkTextByChars(content, maxChars, overlapChars, minChars)
+	out := make([]ChunkSegment, 0, len(raw))
+	for _, seg := range raw {
+		out = append(out, ChunkSegment(seg))
+	}
+	return out
+}
+
+// ChunkRawText is an exported wrapper over chunkRawTextByDocType (which uses the
+// process-level effective chunk sizes set by ConfigureChunking) so tests in the
+// tests/ tree can exercise the raw-text path directly.
+func ChunkRawText(docType, content string) []ChunkSegment {
+	raw := chunkRawTextByDocType(docType, content)
 	out := make([]ChunkSegment, 0, len(raw))
 	for _, seg := range raw {
 		out = append(out, ChunkSegment(seg))

--- a/internal/ingest/represent.go
+++ b/internal/ingest/represent.go
@@ -546,7 +546,7 @@ func chunkRawTextByDocType(docType, content string) []chunkSegment {
 	if docType == "code" {
 		return chunkCodeByLines(content, 200, 30)
 	}
-	return chunkTextByChars(content, 2500, 250, 200)
+	return chunkTextByChars(content, effectiveTextChunkMaxChars, effectiveTextChunkOverlapChars, effectiveTextChunkMinChars)
 }
 
 func chunkOCRByPages(content string) []chunkSegment {
@@ -570,12 +570,67 @@ func chunkOCRByPages(content string) []chunkSegment {
 
 // Structured-document chunking parameters (spec §7.5 size constraints). They
 // mirror the raw-text defaults so structured and plain text chunk at a
-// comparable granularity.
+// comparable granularity. These are the historical defaults used when no
+// chunking.* config is set; ConfigureChunking may override the effective values
+// below.
 const (
 	structuredChunkMaxChars     = 2500
 	structuredChunkOverlapChars = 250
 	structuredChunkMinChars     = 200
 )
+
+// approxCharsPerToken converts a chunking.*_tokens budget (config is expressed
+// in tokens) into the chunker's rune budget. It is a deliberately rough
+// heuristic (~4 characters per token for typical prose): the goal is that
+// changing chunking.max_tokens moves chunk sizes proportionally, not exact
+// tokenizer parity.
+const approxCharsPerToken = 4
+
+// Effective text/structured chunk sizing (rune budgets). They default to the
+// historical hardcoded values above, so a corpus with no chunking.* config
+// chunks byte-identically to before. ConfigureChunking overrides them from
+// chunking.max_tokens / chunking.overlap_tokens when those are set. The text and
+// structured chunkers share one window so plain and structured documents chunk
+// at a comparable granularity (read by chunkRawTextByDocType and
+// newStructuredChunker).
+var (
+	effectiveTextChunkMaxChars     = structuredChunkMaxChars
+	effectiveTextChunkOverlapChars = structuredChunkOverlapChars
+	effectiveTextChunkMinChars     = structuredChunkMinChars
+)
+
+// ConfigureChunking applies chunking.max_tokens / chunking.overlap_tokens to the
+// text and structured chunkers. Token budgets are converted to rune budgets via
+// approxCharsPerToken. When maxTokens <= 0 (unset) the historical defaults are
+// restored, so existing corpora chunk exactly as before and the call is
+// idempotent. Callers overlay already-validated config here at startup, before
+// ingestion begins; it is not safe to call concurrently with active chunking.
+func ConfigureChunking(maxTokens, overlapTokens int) {
+	if maxTokens <= 0 {
+		effectiveTextChunkMaxChars = structuredChunkMaxChars
+		effectiveTextChunkOverlapChars = structuredChunkOverlapChars
+		effectiveTextChunkMinChars = structuredChunkMinChars
+		return
+	}
+	maxChars := maxTokens * approxCharsPerToken
+	overlapChars := 0
+	if overlapTokens > 0 {
+		overlapChars = overlapTokens * approxCharsPerToken
+	}
+	// Scale the minimum-chunk floor to the configured window (preserving the
+	// default min:max proportion) so a small window does not drop every
+	// non-terminal chunk, and never let it reach the window size.
+	minChars := maxChars * structuredChunkMinChars / structuredChunkMaxChars
+	if minChars < 1 {
+		minChars = 1
+	}
+	if minChars >= maxChars {
+		minChars = maxChars - 1
+	}
+	effectiveTextChunkMaxChars = maxChars
+	effectiveTextChunkOverlapChars = overlapChars
+	effectiveTextChunkMinChars = minChars
+}
 
 // Code chunking is primarily line-based, but a single window (or a single very
 // long line, e.g. a minified JS/CSS bundle) must still be bounded by characters
@@ -629,7 +684,7 @@ type structuredChunker struct {
 
 func newStructuredChunker() *structuredChunker {
 	maxChars, overlapChars, minChars := normalizeTextChunkParams(
-		structuredChunkMaxChars, structuredChunkOverlapChars, structuredChunkMinChars)
+		effectiveTextChunkMaxChars, effectiveTextChunkOverlapChars, effectiveTextChunkMinChars)
 	return &structuredChunker{
 		maxChars:     maxChars,
 		overlapChars: overlapChars,

--- a/tests/cli/up_chunking_config_test.go
+++ b/tests/cli/up_chunking_config_test.go
@@ -1,0 +1,52 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/cli"
+)
+
+// TestUpRejectsInvalidChunkingConfig pins the config-validation half of #405 on
+// the `up` command surface: an invalid chunking window (overlap_tokens >=
+// max_tokens never advances the chunker) must stop startup with a config-invalid
+// exit, not be silently accepted. `up` now re-runs cfg.Validate() AFTER the CLI
+// flag overlay so a flag-supplied value cannot slip past validation either; this
+// exercises the same validation gate end-to-end through the command.
+func TestUpRejectsInvalidChunkingConfig(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("MISTRAL_API_KEY", "")
+	t.Setenv("DIR2MCP_AUTH_TOKEN", "")
+
+	cfgPath := filepath.Join(tmp, ".dir2mcp.yaml")
+	if err := os.WriteFile(cfgPath, []byte(strings.Join([]string{
+		"root_dir: .",
+		"state_dir: .dir2mcp",
+		"chunking_max_tokens: 200",
+		"chunking_overlap_tokens: 200", // overlap == max: rejected by Validate (#405)
+		"",
+	}, "\n")), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+
+	withWorkingDir(t, tmp, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		code := app.RunWithContext(ctx, []string{"--non-interactive", "up", "--read-only"})
+		if code != 2 {
+			t.Fatalf("expected exit 2 for invalid chunking config, got %d stderr=%s", code, stderr.String())
+		}
+	})
+
+	if !strings.Contains(stderr.String(), "chunking.overlap_tokens") {
+		t.Fatalf("expected chunking.overlap_tokens validation error, got: %s", stderr.String())
+	}
+}

--- a/tests/ingest/chunking_config_test.go
+++ b/tests/ingest/chunking_config_test.go
@@ -1,0 +1,65 @@
+package tests
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/ingest/docling"
+)
+
+// approxCharsPerToken mirrors the ingest package's token->rune conversion factor
+// used by ConfigureChunking. Kept in sync with internal/ingest/represent.go.
+const approxCharsPerToken = 4
+
+// TestConfigureChunking_MaxTokensCapsChunkSize pins the remaining half of #405:
+// chunking.max_tokens / chunking.overlap_tokens must actually reach the chunker
+// (they were silently ignored — the sizes were hardcoded). A smaller configured
+// window must produce smaller, more numerous chunks, every one within the
+// configured cap, while an unset window reproduces the historical default sizes.
+func TestConfigureChunking_MaxTokensCapsChunkSize(t *testing.T) {
+	// The chunker reads process-level effective sizes; restore the defaults so
+	// this test does not perturb any sibling test sharing the same binary.
+	defer ingest.ConfigureChunking(0, 0)
+
+	long := strings.Repeat("alpha beta gamma delta ", 3000) // ~69k runes
+	block := docling.Block{Label: docling.LabelParagraph, Text: long, Page: 1}
+
+	// Unset window (chunking.max_tokens = 0): historical default sizing.
+	ingest.ConfigureChunking(0, 0)
+	defaultSegs := ingest.ChunkStructuredBlocks([]docling.Block{block})
+	if len(defaultSegs) == 0 {
+		t.Fatal("default chunking produced no segments")
+	}
+
+	// A small explicit window: 100 tokens ~= 400 runes.
+	const maxTokens = 100
+	const overlapTokens = 20
+	ingest.ConfigureChunking(maxTokens, overlapTokens)
+	smallSegs := ingest.ChunkStructuredBlocks([]docling.Block{block})
+	if len(smallSegs) == 0 {
+		t.Fatal("configured chunking produced no segments")
+	}
+
+	capRunes := maxTokens * approxCharsPerToken
+	for i, s := range smallSegs {
+		if n := utf8.RuneCountInString(s.Text); n > capRunes {
+			t.Errorf("chunk %d has %d runes, exceeds configured cap %d runes", i, n, capRunes)
+		}
+	}
+
+	// The smaller window must fragment the same text into more chunks than the
+	// default — proof the config took effect rather than being ignored.
+	if len(smallSegs) <= len(defaultSegs) {
+		t.Errorf("configured max_tokens=%d did not shrink chunks: small=%d default=%d",
+			maxTokens, len(smallSegs), len(defaultSegs))
+	}
+
+	// Sanity: with no content lost, resetting to defaults restores the default
+	// sizing (idempotent), so a re-run matches the first default run.
+	ingest.ConfigureChunking(0, 0)
+	if got := len(ingest.ChunkStructuredBlocks([]docling.Block{block})); got != len(defaultSegs) {
+		t.Errorf("resetting chunking to defaults not idempotent: %d != %d", got, len(defaultSegs))
+	}
+}

--- a/tests/ingest/chunking_config_test.go
+++ b/tests/ingest/chunking_config_test.go
@@ -63,3 +63,25 @@ func TestConfigureChunking_MaxTokensCapsChunkSize(t *testing.T) {
 		t.Errorf("resetting chunking to defaults not idempotent: %d != %d", got, len(defaultSegs))
 	}
 }
+
+// TestConfigureChunking_ClampsOverlapForRawText pins that an overlap >= the
+// window (e.g. from a direct ConfigureChunking call that bypasses Validate) is
+// clamped, so the raw-text path can't stall: chunking must terminate and emit
+// bounded chunks. Regression for #405/#532 review.
+func TestConfigureChunking_ClampsOverlapForRawText(t *testing.T) {
+	defer ingest.ConfigureChunking(0, 0)
+	// overlap (1000 tokens) far exceeds the window (10 tokens); without the clamp
+	// chunkTextByChars would never advance.
+	ingest.ConfigureChunking(10, 1000)
+	long := strings.Repeat("alpha beta gamma delta ", 500)
+	segs := ingest.ChunkRawText("text", long)
+	if len(segs) == 0 {
+		t.Fatal("clamped raw-text chunking produced no segments")
+	}
+	capRunes := 10 * approxCharsPerToken
+	for i, s := range segs {
+		if n := utf8.RuneCountInString(s.Text); n > capRunes {
+			t.Errorf("chunk %d has %d runes, exceeds cap %d", i, n, capRunes)
+		}
+	}
+}


### PR DESCRIPTION
Completes #405 (persistence half landed in #506). Two config-wiring remainders.

## (a) `chunking.max_tokens` / `chunking.overlap_tokens` were silently ignored
The text and structured chunkers in `internal/ingest/represent.go` hardcoded their rune budgets (`2500/250/200`), so these config fields had no effect.

- Added process-level **effective chunk sizes** initialized to the historical default literals, plus `ConfigureChunking(maxTokens, overlapTokens)`.
- Token budgets convert to the chunker's rune budget via a documented `approxCharsPerToken = 4` heuristic; the min-chunk floor scales with the window (keeping the default `min:max` proportion) so a small window never drops non-terminal chunks.
- The text and structured chunkers share one effective window (they already shared defaults), so `chunkRawTextByDocType` and `newStructuredChunker` both read it.
- **When `max_tokens` is unset (0), the defaults are restored exactly** — existing corpora chunk byte-identically. No behavior change; the ablation/eval gate is unchanged.
- `up` (`prepareUpConfig`) and `reindex` (`loadReindexConfig`) apply the validated config before ingestion. `reindex` is included because a full rebuild re-chunks the whole corpus and would otherwise reintroduce the same silent drop.

The relational `overlap < max` validation was already added in #506; `internal/config/config.go` needed no change (verified).

## (b) Flags bypassed `Validate()`
`config.Load()` validates the on-disk config (incl. env overrides), but `up`'s CLI flag overlay (`applyUpFlagOverrides`) runs *after* Load and `validateUpConfig` never re-ran the full `Validate()`. `validateUpConfig` now calls `cfg.Validate()` first (after the overlay) and returns the config-invalid exit path on error.

Note: no shipping `up` flag currently maps to a `Validate()`-checked field, so this is defense-in-depth — it closes the code-path gap so a future/added flag can't smuggle an invalid value past validation. `reindex` does not overlay flags (only Load, which validates), so it needs no re-validate.

## Tests (under `tests/`, not `internal/`)
- `tests/ingest/chunking_config_test.go`: a custom `chunking.max_tokens` shrinks and caps chunks (every chunk within the configured rune cap; more chunks than the default window; reset-to-default is idempotent).
- `tests/cli/up_chunking_config_test.go`: `up` refuses to start on an invalid chunking window (`overlap == max`) with exit 2 + the chunking validation error.

## Validation (in-worktree)
`gofmt -l` clean; `go build ./...`; `go vet`; `make cyclo` (0 over 15); `golangci-lint run` (0 issues); targeted `internal/{ingest,config,cli}` + `tests/{ingest,config,cli,eval}` suites all green; **ablation gate unchanged**.