### PR TITLE
feat(subtitle): export-time cue cleaning — glossary, repetition-collapse, URL drop

### DIFF
--- a/internal/cli/export.go
+++ b/internal/cli/export.go
@@ -79,7 +79,19 @@ func (a *App) runExport(ctx context.Context, global globalOptions, args []string
 	}
 
 	filter := subtitle.NewWordFilter(cfg.MediaFilterWords)
-	rendered, code := a.renderTranscriptExport(ctx, global, ts, opts, filter)
+	// The glossary was already validated at config load, so a parse error here is
+	// unexpected; surface it rather than silently dropping the glossary.
+	glossary, err := subtitle.NewGlossary(cfg.MediaSubtitlesGlossary)
+	if err != nil {
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("invalid media.subtitles.glossary: %v", err))
+		return exitConfigInvalid
+	}
+	clean := subtitle.CleanOptions{
+		DropURLs:        cfg.MediaSubtitlesDropURLs,
+		CollapseRepeats: cfg.MediaSubtitlesCollapseRepeats,
+		Glossary:        glossary,
+	}
+	rendered, code := a.renderTranscriptExport(ctx, global, ts, opts, filter, clean)
 	if code != exitSuccess {
 		return code
 	}
@@ -91,7 +103,7 @@ func (a *App) runExport(ctx context.Context, global globalOptions, args []string
 // from its chunks, and renders them in the requested format. It returns the
 // serialized document, or an exit code on error (no transcript, no chunks,
 // unknown language, store failure).
-func (a *App) renderTranscriptExport(ctx context.Context, global globalOptions, ts transcriptStore, opts exportOptions, filter *subtitle.WordFilter) (string, int) {
+func (a *App) renderTranscriptExport(ctx context.Context, global globalOptions, ts transcriptStore, opts exportOptions, filter *subtitle.WordFilter, clean subtitle.CleanOptions) (string, int) {
 	reps, err := ts.TranscriptRepresentations(ctx, opts.relPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -128,6 +140,10 @@ func (a *App) renderTranscriptExport(ctx context.Context, global globalOptions, 
 	// consistent with how ingest strips them before embedding. Cues empty after
 	// filtering are dropped. An empty config leaves cues unchanged.
 	cues = subtitle.FilterCues(cues, filter)
+	// Apply the configured cue-cleaning passes (media.subtitles.glossary /
+	// collapse_repeats / drop_urls) after word-filtering, so filter_words removal
+	// and this cleanup compose. An empty config leaves cues unchanged.
+	cues = subtitle.CleanCues(cues, clean)
 	if len(cues) == 0 {
 		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("document %q transcript has no time-coded cues to export", opts.relPath))
 		return "", exitGeneric

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/dirstral/dir2mcp/internal/secrets"
+	"github.com/dirstral/dir2mcp/internal/subtitle"
 	"github.com/dirstral/dir2mcp/internal/usage"
 )
 
@@ -487,6 +488,26 @@ type Config struct {
 	// the text subtitle output is still produced.
 	MediaSubtitlesSMILEnabled bool
 
+	// MediaSubtitlesGlossary is an optional list of editorial term replacements
+	// applied to exported VTT/SRT cue text (config `media.subtitles.glossary`).
+	// Each entry is "pattern=>replacement" where pattern is a case-insensitive,
+	// ASCII-word-bounded regular expression (e.g. "Aju?bei=>Adzhubei" to
+	// normalize a transliterated name). Unlike media.filter_words (which deletes
+	// phrases) this REWRITES text and never drops a cue. Empty by default = off.
+	MediaSubtitlesGlossary []string
+
+	// MediaSubtitlesCollapseRepeats drops the Nth-and-later cue in a run of
+	// identical consecutive cues on export (config
+	// `media.subtitles.collapse_repeats`), the whisper repetition-collapse
+	// artifact. A value < 2 disables the pass (the default 0 = off), so
+	// legitimate short repeats survive; a typical setting is 3.
+	MediaSubtitlesCollapseRepeats int
+
+	// MediaSubtitlesDropURLs opts IN to dropping exported cues whose text is a
+	// hallucinated URL / bare domain / credit line (config
+	// `media.subtitles.drop_urls`). OFF by default. Only affects VTT/SRT export.
+	MediaSubtitlesDropURLs bool
+
 	// MediaTrimLeadingSilence opts IN to trimming leading silence from media
 	// transcripts (dir2mcp#258, config `media.trim_leading_silence`). When true
 	// and ffmpeg is available, the duration of dead air before the first speech
@@ -693,6 +714,9 @@ type fileConfig struct {
 	MediaSubtitlesTTMLEnabled          *bool
 	MediaSubtitlesTTMLAlignToleranceMS *int
 	MediaSubtitlesSMILEnabled          *bool
+	MediaSubtitlesGlossary             []string
+	MediaSubtitlesCollapseRepeats      *int
+	MediaSubtitlesDropURLs             *bool
 	MediaTrimLeadingSilence            *bool
 	MediaSilenceThresholdDB            *float64
 	MediaVAD                           *bool
@@ -822,6 +846,9 @@ type persistedConfig struct {
 	MediaSubtitlesTTMLEnabled          bool          `yaml:"media_subtitles_ttml_enabled"`
 	MediaSubtitlesTTMLAlignToleranceMS int           `yaml:"media_subtitles_ttml_align_tolerance_ms"`
 	MediaSubtitlesSMILEnabled          bool          `yaml:"media_subtitles_smil_enabled"`
+	MediaSubtitlesGlossary             []string      `yaml:"media_subtitles_glossary"`
+	MediaSubtitlesCollapseRepeats      int           `yaml:"media_subtitles_collapse_repeats"`
+	MediaSubtitlesDropURLs             bool          `yaml:"media_subtitles_drop_urls"`
 	MediaTrimLeadingSilence            bool          `yaml:"media_trim_leading_silence"`
 	MediaSilenceThresholdDB            float64       `yaml:"media_silence_threshold_db"`
 	MediaVAD                           bool          `yaml:"media_vad"`
@@ -1036,8 +1063,13 @@ func Default() Config {
 		MediaSubtitlesTTMLEnabled:          false,
 		MediaSubtitlesTTMLAlignToleranceMS: DefaultMediaSubtitlesAlignToleranceMS,
 		MediaSubtitlesSMILEnabled:          false,
-		ServerTLSCertFile:                  "",
-		ServerTLSKeyFile:                   "",
+		// Export-time cue cleaning (clean_srt.py port) is OFF by default: no
+		// glossary rewrites, no repetition-collapse (< 2 disables), no URL drop.
+		MediaSubtitlesGlossary:        nil,
+		MediaSubtitlesCollapseRepeats: 0,
+		MediaSubtitlesDropURLs:        false,
+		ServerTLSCertFile:             "",
+		ServerTLSKeyFile:              "",
 		X402: X402Config{
 			Mode:             "off",
 			FacilitatorURL:   "",
@@ -1159,6 +1191,9 @@ func buildPersistedConfig(cfg *Config) persistedConfig {
 		MediaSubtitlesTTMLEnabled:          cfg.MediaSubtitlesTTMLEnabled,
 		MediaSubtitlesTTMLAlignToleranceMS: cfg.MediaSubtitlesTTMLAlignToleranceMS,
 		MediaSubtitlesSMILEnabled:          cfg.MediaSubtitlesSMILEnabled,
+		MediaSubtitlesGlossary:             append([]string(nil), cfg.MediaSubtitlesGlossary...),
+		MediaSubtitlesCollapseRepeats:      cfg.MediaSubtitlesCollapseRepeats,
+		MediaSubtitlesDropURLs:             cfg.MediaSubtitlesDropURLs,
 		MediaTrimLeadingSilence:            cfg.MediaTrimLeadingSilence,
 		MediaSilenceThresholdDB:            cfg.MediaSilenceThresholdDB,
 		MediaVAD:                           cfg.MediaVAD,
@@ -1953,6 +1988,15 @@ func applyMediaSubtitlesFileParsed(cfg *Config, fc fileConfig) {
 	if fc.MediaSubtitlesSMILEnabled != nil {
 		cfg.MediaSubtitlesSMILEnabled = *fc.MediaSubtitlesSMILEnabled
 	}
+	if fc.MediaSubtitlesGlossary != nil {
+		cfg.MediaSubtitlesGlossary = normalizeStringSlice(fc.MediaSubtitlesGlossary)
+	}
+	if fc.MediaSubtitlesCollapseRepeats != nil {
+		cfg.MediaSubtitlesCollapseRepeats = *fc.MediaSubtitlesCollapseRepeats
+	}
+	if fc.MediaSubtitlesDropURLs != nil {
+		cfg.MediaSubtitlesDropURLs = *fc.MediaSubtitlesDropURLs
+	}
 }
 
 // applyX402FileParsed copies the set x402 file fields onto cfg.X402.
@@ -2253,6 +2297,9 @@ var configKeyAliases = map[string]string{
 	"media_subtitles_ttml_enabled":            "media.subtitles.ttml.enabled",
 	"media_subtitles_ttml_align_tolerance_ms": "media.subtitles.ttml.align_tolerance_ms",
 	"media_subtitles_smil_enabled":            "media.subtitles.smil.enabled",
+	"media_subtitles_glossary":                "media.subtitles.glossary",
+	"media_subtitles_collapse_repeats":        "media.subtitles.collapse_repeats",
+	"media_subtitles_drop_urls":               "media.subtitles.drop_urls",
 	"media_trim_leading_silence":              "media.trim_leading_silence",
 	"media_silence_threshold_db":              "media.silence_threshold_db",
 	"media_vad":                               "media.vad",
@@ -2386,6 +2433,9 @@ var boolFileScalarTargets = map[string]func(*fileConfig) **bool{
 	"media.subtitles.smil.enabled": func(c *fileConfig) **bool {
 		return &c.MediaSubtitlesSMILEnabled
 	},
+	"media.subtitles.drop_urls": func(c *fileConfig) **bool {
+		return &c.MediaSubtitlesDropURLs
+	},
 	"media.trim_leading_silence": func(c *fileConfig) **bool {
 		return &c.MediaTrimLeadingSilence
 	},
@@ -2448,6 +2498,9 @@ var intFileScalarTargets = map[string]func(*fileConfig) **int{
 	"media.subtitles.ttml.align_tolerance_ms": func(c *fileConfig) **int {
 		return &c.MediaSubtitlesTTMLAlignToleranceMS
 	},
+	"media.subtitles.collapse_repeats": func(c *fileConfig) **int {
+		return &c.MediaSubtitlesCollapseRepeats
+	},
 	"distributed_embed_max_attempts": func(c *fileConfig) **int {
 		return &c.DistributedEmbedMaxAttempts
 	},
@@ -2481,6 +2534,7 @@ var nonNegativeIntKeys = map[string]bool{
 	"media.clip.max_duration_ms":              true,
 	"media.clip.max_bytes":                    true,
 	"media.subtitles.ttml.align_tolerance_ms": true,
+	"media.subtitles.collapse_repeats":        true,
 }
 
 // setFloatFileScalar parses value as a float64 and assigns it to the
@@ -2739,6 +2793,8 @@ func setFileListValue(cfg *fileConfig, key, value string) {
 		appendValue(&cfg.MediaTranslateTargetLangs, value)
 	case "media.filter_words":
 		appendValue(&cfg.MediaFilterWords, value)
+	case "media.subtitles.glossary":
+		appendValue(&cfg.MediaSubtitlesGlossary, value)
 	case "retrieval.cross_lingual.target_langs":
 		appendValue(&cfg.CrossLingualTargetLangs, value)
 	}
@@ -2749,7 +2805,7 @@ func setFileListValue(cfg *fileConfig, key, value string) {
 func isListConfigKey(key string) bool {
 	key = canonicalizeConfigKey(key)
 	switch key {
-	case "trusted_proxies", "path_excludes", "secret_patterns", "allowed_origins", "media.translate.target_langs", "media.filter_words", "retrieval.cross_lingual.target_langs":
+	case "trusted_proxies", "path_excludes", "secret_patterns", "allowed_origins", "media.translate.target_langs", "media.filter_words", "media.subtitles.glossary", "retrieval.cross_lingual.target_langs":
 		return true
 	default:
 		return false
@@ -2865,6 +2921,9 @@ func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	writeBool("media_subtitles_ttml_enabled", cfg.MediaSubtitlesTTMLEnabled)
 	writeInt("media_subtitles_ttml_align_tolerance_ms", cfg.MediaSubtitlesTTMLAlignToleranceMS)
 	writeBool("media_subtitles_smil_enabled", cfg.MediaSubtitlesSMILEnabled)
+	writeList("media_subtitles_glossary", cfg.MediaSubtitlesGlossary)
+	writeInt("media_subtitles_collapse_repeats", cfg.MediaSubtitlesCollapseRepeats)
+	writeBool("media_subtitles_drop_urls", cfg.MediaSubtitlesDropURLs)
 	writeBool("media_trim_leading_silence", cfg.MediaTrimLeadingSilence)
 	writeScalar("media_silence_threshold_db", strconv.FormatFloat(cfg.MediaSilenceThresholdDB, 'f', -1, 64))
 	writeBool("media_vad", cfg.MediaVAD)
@@ -3522,6 +3581,16 @@ func (c *Config) validateMediaSubtitles() error {
 	}
 	if c.MediaSubtitlesTTMLAlignToleranceMS == 0 {
 		c.MediaSubtitlesTTMLAlignToleranceMS = DefaultMediaSubtitlesAlignToleranceMS
+	}
+	if c.MediaSubtitlesCollapseRepeats < 0 {
+		return fmt.Errorf("media.subtitles.collapse_repeats must not be negative: %d",
+			c.MediaSubtitlesCollapseRepeats)
+	}
+	// Fail fast on a malformed glossary (bad "pattern=>replacement" entry or an
+	// invalid regexp) at config time rather than at export time. subtitle.NewGlossary
+	// is the single source of truth for the entry grammar.
+	if _, err := subtitle.NewGlossary(c.MediaSubtitlesGlossary); err != nil {
+		return fmt.Errorf("media.subtitles.glossary: %w", err)
 	}
 	return nil
 }

--- a/internal/subtitle/clean.go
+++ b/internal/subtitle/clean.go
@@ -48,7 +48,12 @@ func NewGlossary(entries []string) (*Glossary, error) {
 		if from == "" {
 			return nil, fmt.Errorf("glossary entry %q has an empty match pattern", e)
 		}
-		re, err := regexp.Compile(`(?i)\b` + from + `\b`)
+		// Wrap the pattern in a non-capturing group so the word boundaries anchor
+		// the WHOLE pattern: without it a top-level alternation ("Aju|Adju") would
+		// compile to \bAju|Adju\b, which RE2 reads as (\bAju)|(Adju\b) — each
+		// alternative keeping only one boundary — silently allowing partial-word
+		// rewrites and breaking the documented word-bounded guarantee.
+		re, err := regexp.Compile(`(?i)\b(?:` + from + `)\b`)
 		if err != nil {
 			return nil, fmt.Errorf("glossary entry %q: invalid match pattern: %w", e, err)
 		}

--- a/internal/subtitle/clean.go
+++ b/internal/subtitle/clean.go
@@ -204,13 +204,14 @@ func CleanCues(cues []Cue, opts CleanOptions) []Cue {
 			}
 		}
 		if opts.Glossary.Active() {
-			text = opts.Glossary.Apply(text)
-			// A glossary rule may empty a cue (an empty REPLACEMENT deletes text,
-			// e.g. "foo=>"). Drop the now-empty cue like the entry-time empty/URL
-			// passes do. This runs AFTER the collapse bookkeeping, which compares
-			// pre-glossary text, so dropping here never corrupts the run counter;
-			// survivors are still re-indexed gap-free below.
-			if strings.TrimSpace(text) == "" {
+			// Re-trim after the rewrite: a glossary rule may empty a cue (an empty
+			// REPLACEMENT deletes text, e.g. "foo=>") or leave stray leading/
+			// trailing whitespace. Trim it and drop a now-empty cue like the
+			// entry-time empty/URL passes do. This runs AFTER the collapse
+			// bookkeeping (which compares pre-glossary text), so dropping here
+			// never corrupts the run counter; survivors are re-indexed gap-free.
+			text = strings.TrimSpace(opts.Glossary.Apply(text))
+			if text == "" {
 				continue
 			}
 		}

--- a/internal/subtitle/clean.go
+++ b/internal/subtitle/clean.go
@@ -1,0 +1,151 @@
+package subtitle
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Glossary applies editorial term replacements to cue text: whole-word,
+// case-insensitive substitutions that fix correct-but-misspelled entities (for
+// example a transliteration "Ajubei" -> "Adzhubei"). Unlike WordFilter, which
+// DELETES configured phrases, a glossary REWRITES text and never drops a cue.
+// Rules come entirely from configuration (media.subtitles.glossary); an empty
+// glossary is a no-op. Each rule's match side is a regular expression (so a
+// single entry can absorb spelling variants, e.g. "Aju?bei"), wrapped in ASCII
+// word boundaries and matched case-insensitively.
+type Glossary struct {
+	rules []glossaryRule
+}
+
+type glossaryRule struct {
+	re   *regexp.Regexp
+	repl string
+}
+
+// glossarySep separates the match pattern from its replacement in a configured
+// glossary entry, e.g. "Aju?bei=>Adzhubei".
+const glossarySep = "=>"
+
+// NewGlossary compiles glossary entries of the form "pattern=>replacement".
+// Whitespace around the entry and each side is trimmed; blank entries are
+// skipped. The pattern is compiled as a case-insensitive, ASCII-word-bounded
+// regular expression, so an invalid pattern is a configuration error (returned
+// here) rather than a silent no-op. A nil/empty list yields an inactive glossary.
+func NewGlossary(entries []string) (*Glossary, error) {
+	g := &Glossary{}
+	for _, e := range entries {
+		e = strings.TrimSpace(e)
+		if e == "" {
+			continue
+		}
+		i := strings.Index(e, glossarySep)
+		if i < 0 {
+			return nil, fmt.Errorf("glossary entry %q must be of the form pattern%sreplacement", e, glossarySep)
+		}
+		from := strings.TrimSpace(e[:i])
+		to := strings.TrimSpace(e[i+len(glossarySep):])
+		if from == "" {
+			return nil, fmt.Errorf("glossary entry %q has an empty match pattern", e)
+		}
+		re, err := regexp.Compile(`(?i)\b` + from + `\b`)
+		if err != nil {
+			return nil, fmt.Errorf("glossary entry %q: invalid match pattern: %w", e, err)
+		}
+		g.rules = append(g.rules, glossaryRule{re: re, repl: to})
+	}
+	return g, nil
+}
+
+// Active reports whether the glossary has any rules to apply. When false, Apply
+// is the identity and callers can skip it.
+func (g *Glossary) Active() bool {
+	return g != nil && len(g.rules) > 0
+}
+
+// Apply rewrites text by each glossary rule in configuration order. Replacements
+// are literal (a '$' in a replacement is not treated as a capture reference), so
+// the replacement text appears verbatim. Rules are applied in order; an earlier
+// rewrite can feed a later rule, which is deterministic.
+func (g *Glossary) Apply(text string) string {
+	if !g.Active() {
+		return text
+	}
+	for _, r := range g.rules {
+		text = r.re.ReplaceAllLiteralString(text, r.repl)
+	}
+	return text
+}
+
+// CleanOptions configures the export-time cue-cleaning pass (port of the pilot's
+// clean_srt.py). All fields are additive and off by default, so a zero
+// CleanOptions leaves cues unchanged. It is applied AFTER WordFilter on export,
+// so filter_words removal and this cleanup compose.
+type CleanOptions struct {
+	// DropURLs drops any cue whose text looks like a hallucinated URL / domain /
+	// credit line (whisper emits these over silence or music).
+	DropURLs bool
+	// CollapseRepeats drops the Nth-and-later cue in a run of identical
+	// consecutive cues (a whisper repetition-collapse artifact), keeping the
+	// first N-1. A value < 2 disables the pass, so legitimate short repeats
+	// ("Yes." "Yes.") survive — only long identical runs are collapsed.
+	CollapseRepeats int
+	// Glossary applies editorial term replacements. Nil/inactive = no rewrites.
+	Glossary *Glossary
+}
+
+// Active reports whether any cleaning is configured. When false, CleanCues
+// returns its input unchanged so the empty-config export path is a no-op.
+func (o CleanOptions) Active() bool {
+	return o.DropURLs || o.CollapseRepeats >= 2 || o.Glossary.Active()
+}
+
+// urlCueRE matches a hallucinated URL / bare domain in cue text. It mirrors the
+// pilot's clean_srt URL rule: an http(s):// or www. prefix, or a token ending in
+// a common TLD. ASCII word boundaries are sufficient for URLs.
+var urlCueRE = regexp.MustCompile(`(?i)(https?://|www\.|\b\S+\.(com|org|net|ru|ua)\b)`)
+
+// CleanCues applies the configured cleanup passes to cues in order: drop empty
+// cues, drop URL/credit hallucinations, collapse identical-consecutive runs, and
+// rewrite text via the glossary. Surviving cues are re-indexed gap-free (as
+// FilterCues does). Timing is preserved verbatim. A zero/empty CleanOptions
+// returns cues unchanged.
+func CleanCues(cues []Cue, opts CleanOptions) []Cue {
+	if !opts.Active() {
+		return cues
+	}
+	out := make([]Cue, 0, len(cues))
+	var runText string
+	var runLen int
+	for _, cue := range cues {
+		text := strings.TrimSpace(cue.Text)
+		if text == "" {
+			continue
+		}
+		if opts.DropURLs && urlCueRE.MatchString(text) {
+			continue
+		}
+		// Repetition-collapse compares the pre-glossary text so a rewrite cannot
+		// mask a collapse run. The comparison anchor (runText) updates only when
+		// the text changes, so a run of K identical cues keeps the first
+		// CollapseRepeats-1 and drops the rest.
+		if opts.CollapseRepeats >= 2 {
+			if text == runText {
+				runLen++
+				if runLen >= opts.CollapseRepeats {
+					continue
+				}
+			} else {
+				runText = text
+				runLen = 1
+			}
+		}
+		if opts.Glossary.Active() {
+			text = opts.Glossary.Apply(text)
+		}
+		cue.Index = len(out) + 1
+		cue.Text = text
+		out = append(out, cue)
+	}
+	return out
+}

--- a/internal/subtitle/clean.go
+++ b/internal/subtitle/clean.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 )
 
 // Glossary applies editorial term replacements to cue text: whole-word,
@@ -12,8 +14,10 @@ import (
 // DELETES configured phrases, a glossary REWRITES text and never drops a cue.
 // Rules come entirely from configuration (media.subtitles.glossary); an empty
 // glossary is a no-op. Each rule's match side is a regular expression (so a
-// single entry can absorb spelling variants, e.g. "Aju?bei"), wrapped in ASCII
-// word boundaries and matched case-insensitively.
+// single entry can absorb spelling variants, e.g. "Aju?bei"), matched
+// case-insensitively and constrained to whole words. Word boundaries are
+// Unicode-aware (letter/digit/underscore in any script), so rules apply to
+// Cyrillic, CJK, etc. — not only ASCII/Latin transliterations.
 type Glossary struct {
 	rules []glossaryRule
 }
@@ -29,9 +33,11 @@ const glossarySep = "=>"
 
 // NewGlossary compiles glossary entries of the form "pattern=>replacement".
 // Whitespace around the entry and each side is trimmed; blank entries are
-// skipped. The pattern is compiled as a case-insensitive, ASCII-word-bounded
-// regular expression, so an invalid pattern is a configuration error (returned
-// here) rather than a silent no-op. A nil/empty list yields an inactive glossary.
+// skipped. The pattern is compiled case-insensitively, so an invalid pattern is a
+// configuration error (returned here) rather than a silent no-op. Whole-word
+// matching is enforced at apply time by Unicode-aware boundary checks (see Apply),
+// not by RE2's ASCII-only \b — otherwise glossary rules would silently fail on any
+// non-Latin script. A nil/empty list yields an inactive glossary.
 func NewGlossary(entries []string) (*Glossary, error) {
 	g := &Glossary{}
 	for _, e := range entries {
@@ -48,18 +54,62 @@ func NewGlossary(entries []string) (*Glossary, error) {
 		if from == "" {
 			return nil, fmt.Errorf("glossary entry %q has an empty match pattern", e)
 		}
-		// Wrap the pattern in a non-capturing group so the word boundaries anchor
-		// the WHOLE pattern: without it a top-level alternation ("Aju|Adju") would
-		// compile to \bAju|Adju\b, which RE2 reads as (\bAju)|(Adju\b) — each
-		// alternative keeping only one boundary — silently allowing partial-word
-		// rewrites and breaking the documented word-bounded guarantee.
-		re, err := regexp.Compile(`(?i)\b(?:` + from + `)\b`)
+		// Wrap the pattern in a non-capturing group so Apply's boundary check
+		// constrains the WHOLE pattern: without it a top-level alternation
+		// ("Aju|Adju") would bind the surrounding context to only one alternative
+		// and the boundary check would police just part of the match, silently
+		// allowing partial-word rewrites and breaking the whole-word guarantee.
+		re, err := regexp.Compile(`(?i)(?:` + from + `)`)
 		if err != nil {
 			return nil, fmt.Errorf("glossary entry %q: invalid match pattern: %w", e, err)
 		}
 		g.rules = append(g.rules, glossaryRule{re: re, repl: to})
 	}
 	return g, nil
+}
+
+// isWordRune reports whether r is a word constituent for whole-word matching:
+// any Unicode letter or digit, or underscore. This is the Unicode-aware analogue
+// of RE2's ASCII-only \w, so word boundaries hold across Cyrillic, CJK, etc.
+func isWordRune(r rune) bool {
+	return r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r)
+}
+
+// replaceWholeWord replaces every non-overlapping match of re in text with repl,
+// but only where the match is whole-word: the runes immediately flanking the
+// match must sit on a word boundary (a \b-equivalent transition between a word
+// and a non-word rune), evaluated with Unicode-aware wordness. Non-whole-word
+// matches (e.g. "Aju" inside "Ajubeyond") are left untouched. repl is inserted
+// verbatim (no capture-group expansion).
+func replaceWholeWord(re *regexp.Regexp, text, repl string) string {
+	locs := re.FindAllStringIndex(text, -1)
+	if len(locs) == 0 {
+		return text
+	}
+	var b strings.Builder
+	last := 0
+	for _, loc := range locs {
+		s, e := loc[0], loc[1]
+		leftOK := true
+		if s > 0 {
+			before, _ := utf8.DecodeLastRuneInString(text[:s])
+			first, _ := utf8.DecodeRuneInString(text[s:e])
+			leftOK = isWordRune(before) != isWordRune(first)
+		}
+		rightOK := true
+		if e < len(text) {
+			after, _ := utf8.DecodeRuneInString(text[e:])
+			lastR, _ := utf8.DecodeLastRuneInString(text[s:e])
+			rightOK = isWordRune(lastR) != isWordRune(after)
+		}
+		if leftOK && rightOK {
+			b.WriteString(text[last:s])
+			b.WriteString(repl)
+			last = e
+		}
+	}
+	b.WriteString(text[last:])
+	return b.String()
 }
 
 // Active reports whether the glossary has any rules to apply. When false, Apply
@@ -77,7 +127,7 @@ func (g *Glossary) Apply(text string) string {
 		return text
 	}
 	for _, r := range g.rules {
-		text = r.re.ReplaceAllLiteralString(text, r.repl)
+		text = replaceWholeWord(r.re, text, r.repl)
 	}
 	return text
 }
@@ -105,16 +155,24 @@ func (o CleanOptions) Active() bool {
 	return o.DropURLs || o.CollapseRepeats >= 2 || o.Glossary.Active()
 }
 
-// urlCueRE matches a hallucinated URL / bare domain in cue text. It mirrors the
-// pilot's clean_srt URL rule: an http(s):// or www. prefix, or a token ending in
-// a common TLD. ASCII word boundaries are sufficient for URLs.
-var urlCueRE = regexp.MustCompile(`(?i)(https?://|www\.|\b\S+\.(com|org|net|ru|ua)\b)`)
+// urlCueRE matches a hallucinated URL / bare domain in cue text (whisper emits
+// these over silence or music). It is deliberately locale-agnostic: an http(s)://
+// or www. prefix, or a hostname-shaped label ([\w-]+) followed by a generic
+// dotted TLD (\.[a-z]{2,24}) at an ASCII word boundary. Requiring a letter
+// immediately after the dot and a hostname-shaped label keeps ordinary prose with
+// periods out ("end. Next", "3.14", "Mr. Smith" — the dot is followed by a space
+// or digits, not a TLD), while catching any real domain (.io, .tv, .co, .de, .uk,
+// .gov, .info, …) without hardcoding country-specific ccTLDs. RE2 word boundaries
+// and \w are ASCII-only, which is fine here: real domains are ASCII, and prose in
+// any script (Cyrillic, CJK, …) whose only dots are sentence periods never has a
+// [\w-] label immediately abutting a letter-led TLD.
+var urlCueRE = regexp.MustCompile(`(?i)(https?://|www\.|\b[\w-]+\.[a-z]{2,24}\b)`)
 
 // CleanCues applies the configured cleanup passes to cues in order: drop empty
 // cues, drop URL/credit hallucinations, collapse identical-consecutive runs, and
-// rewrite text via the glossary. Surviving cues are re-indexed gap-free (as
-// FilterCues does). Timing is preserved verbatim. A zero/empty CleanOptions
-// returns cues unchanged.
+// rewrite text via the glossary (dropping any cue the rewrite empties). Surviving
+// cues are re-indexed gap-free (as FilterCues does). Timing is preserved verbatim.
+// A zero/empty CleanOptions returns cues unchanged.
 func CleanCues(cues []Cue, opts CleanOptions) []Cue {
 	if !opts.Active() {
 		return cues
@@ -147,6 +205,14 @@ func CleanCues(cues []Cue, opts CleanOptions) []Cue {
 		}
 		if opts.Glossary.Active() {
 			text = opts.Glossary.Apply(text)
+			// A glossary rule may empty a cue (an empty REPLACEMENT deletes text,
+			// e.g. "foo=>"). Drop the now-empty cue like the entry-time empty/URL
+			// passes do. This runs AFTER the collapse bookkeeping, which compares
+			// pre-glossary text, so dropping here never corrupts the run counter;
+			// survivors are still re-indexed gap-free below.
+			if strings.TrimSpace(text) == "" {
+				continue
+			}
 		}
 		cue.Index = len(out) + 1
 		cue.Text = text

--- a/tests/cli/export_clean_test.go
+++ b/tests/cli/export_clean_test.go
@@ -1,0 +1,141 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/cli"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// seedCleanExportStore seeds a transcript exercising every cue-cleaning pass: a
+// name to be rewritten by the glossary, a long identical run to collapse, a URL
+// hallucination to drop, and ordinary speech that must survive.
+func seedCleanExportStore(t *testing.T, stateDir, relPath string) {
+	t.Helper()
+	ctx := context.Background()
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	st := store.NewSQLiteStore(filepath.Join(stateDir, "meta.sqlite"))
+	defer func() { _ = st.Close() }()
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if err := st.UpsertDocument(ctx, model.Document{
+		RelPath: relPath, DocType: "audio", SourceType: "local", Status: "ok",
+	}); err != nil {
+		t.Fatalf("UpsertDocument: %v", err)
+	}
+	doc, err := st.GetDocumentByPath(ctx, relPath)
+	if err != nil {
+		t.Fatalf("GetDocumentByPath: %v", err)
+	}
+	err = st.WithTx(ctx, func(tx model.RepresentationStore) error {
+		repID, err := tx.UpsertRepresentation(ctx, model.Representation{
+			DocID: doc.DocID, RepType: "transcript", RepHash: "h1",
+		})
+		if err != nil {
+			return err
+		}
+		chunks := []struct {
+			text  string
+			start int
+			end   int
+		}{
+			{"Letter signed by Ajubei", 0, 2000}, // glossary -> Adzhubei
+			{"No.", 2000, 3000},                  // run of 4 identical "No."
+			{"No.", 3000, 4000},
+			{"No.", 4000, 5000},                       // 3rd -> dropped (threshold 3)
+			{"No.", 5000, 6000},                       // 4th -> dropped
+			{"Subtitles by www.spam.com", 6000, 8000}, // URL -> dropped
+			{"Real closing line", 8000, 10000},
+		}
+		for i, c := range chunks {
+			if _, err := tx.InsertChunkWithSpans(ctx,
+				model.Chunk{RepID: repID, Ordinal: i, Text: c.text, IndexKind: "text"},
+				[]model.Span{{Kind: "time", StartMS: c.start, EndMS: c.end}},
+			); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("seed transcript: %v", err)
+	}
+}
+
+// TestExportAppliesCueCleaning pins the end-to-end cleaning path: glossary
+// rewrite, repetition-collapse, and URL drop all applied via the export command
+// when media.subtitles.{glossary,collapse_repeats,drop_urls} are configured.
+func TestExportAppliesCueCleaning(t *testing.T) {
+	tmp := t.TempDir()
+	seedCleanExportStore(t, filepath.Join(tmp, ".dir2mcp"), "media/talk.mp3")
+	cfgYAML := strings.Join([]string{
+		"media:",
+		"  subtitles:",
+		"    glossary:",
+		"      - Aju?bei=>Adzhubei",
+		"    collapse_repeats: 3",
+		"    drop_urls: true",
+	}, "\n") + "\n"
+	if err := os.WriteFile(filepath.Join(tmp, ".dir2mcp.yaml"), []byte(cfgYAML), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	withWorkingDir(t, tmp, func() {
+		if code := app.RunWithContext(context.Background(),
+			[]string{"export", "--format", "srt", "media/talk.mp3"}); code != 0 {
+			t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
+		}
+	})
+	out := stdout.String()
+
+	if strings.Contains(out, "Ajubei") || !strings.Contains(out, "Adzhubei") {
+		t.Errorf("glossary rewrite not applied:\n%s", out)
+	}
+	if strings.Contains(strings.ToLower(out), "spam.com") {
+		t.Errorf("URL cue not dropped:\n%s", out)
+	}
+	if n := strings.Count(out, "No."); n != 2 {
+		t.Errorf("repetition-collapse: got %d 'No.' cues, want 2:\n%s", n, out)
+	}
+	if !strings.Contains(out, "Real closing line") {
+		t.Errorf("real closing cue missing:\n%s", out)
+	}
+}
+
+// TestExportNoCleaningConfigUnchanged pins that without cleaning config the
+// export is unaffected (all cues, including the would-be-cleaned ones, survive).
+func TestExportNoCleaningConfigUnchanged(t *testing.T) {
+	tmp := t.TempDir()
+	seedCleanExportStore(t, filepath.Join(tmp, ".dir2mcp"), "media/talk.mp3")
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	withWorkingDir(t, tmp, func() {
+		if code := app.RunWithContext(context.Background(),
+			[]string{"export", "--format", "srt", "media/talk.mp3"}); code != 0 {
+			t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
+		}
+	})
+	out := stdout.String()
+
+	if !strings.Contains(out, "Ajubei") {
+		t.Errorf("without config the name should be untouched:\n%s", out)
+	}
+	if !strings.Contains(strings.ToLower(out), "spam.com") {
+		t.Errorf("without config the URL cue should survive:\n%s", out)
+	}
+	if n := strings.Count(out, "No."); n != 4 {
+		t.Errorf("without config all 4 'No.' cues should survive, got %d:\n%s", n, out)
+	}
+}

--- a/tests/config/media_subtitles_config_test.go
+++ b/tests/config/media_subtitles_config_test.go
@@ -37,6 +37,9 @@ func TestMediaSubtitles_RoundTrip(t *testing.T) {
 	cfg.MediaSubtitlesTTMLEnabled = true
 	cfg.MediaSubtitlesSMILEnabled = true
 	cfg.MediaSubtitlesTTMLAlignToleranceMS = 1800
+	cfg.MediaSubtitlesGlossary = []string{"Aju?bei=>Adzhubei"}
+	cfg.MediaSubtitlesCollapseRepeats = 3
+	cfg.MediaSubtitlesDropURLs = true
 
 	if err := config.SaveFile(path, cfg); err != nil {
 		t.Fatalf("SaveFile: %v", err)
@@ -50,6 +53,87 @@ func TestMediaSubtitles_RoundTrip(t *testing.T) {
 	}
 	if loaded.MediaSubtitlesTTMLAlignToleranceMS != 1800 {
 		t.Fatalf("align tolerance = %d, want 1800", loaded.MediaSubtitlesTTMLAlignToleranceMS)
+	}
+	if len(loaded.MediaSubtitlesGlossary) != 1 || loaded.MediaSubtitlesGlossary[0] != "Aju?bei=>Adzhubei" {
+		t.Fatalf("glossary did not round-trip: %#v", loaded.MediaSubtitlesGlossary)
+	}
+	if loaded.MediaSubtitlesCollapseRepeats != 3 {
+		t.Fatalf("collapse_repeats = %d, want 3", loaded.MediaSubtitlesCollapseRepeats)
+	}
+	if !loaded.MediaSubtitlesDropURLs {
+		t.Fatalf("drop_urls did not round-trip")
+	}
+}
+
+// TestMediaSubtitlesCleaning_DefaultsOff pins that the cue-cleaning passes are
+// off by default (no glossary, no collapse, no URL drop).
+func TestMediaSubtitlesCleaning_DefaultsOff(t *testing.T) {
+	cfg := config.Default()
+	if len(cfg.MediaSubtitlesGlossary) != 0 {
+		t.Fatalf("glossary should default empty, got %#v", cfg.MediaSubtitlesGlossary)
+	}
+	if cfg.MediaSubtitlesCollapseRepeats != 0 {
+		t.Fatalf("collapse_repeats should default 0, got %d", cfg.MediaSubtitlesCollapseRepeats)
+	}
+	if cfg.MediaSubtitlesDropURLs {
+		t.Fatalf("drop_urls should default false")
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate default: %v", err)
+	}
+}
+
+// TestMediaSubtitlesCleaning_NestedYAMLApplies locks the nested
+// media.subtitles.{glossary,collapse_repeats,drop_urls} mapping keys.
+func TestMediaSubtitlesCleaning_NestedYAMLApplies(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+	writeFile(t, path, strings.Join([]string{
+		"root_dir: /tmp/repo",
+		"state_dir: /tmp/repo/.dir2mcp",
+		"media:",
+		"  subtitles:",
+		"    glossary:",
+		"      - Aju?bei=>Adzhubei",
+		"      - Khruschev=>Khrushchev",
+		"    collapse_repeats: 3",
+		"    drop_urls: true",
+	}, "\n")+"\n")
+
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile(nested cleaning): %v", err)
+	}
+	if len(cfg.MediaSubtitlesGlossary) != 2 {
+		t.Fatalf("nested glossary not applied: %#v", cfg.MediaSubtitlesGlossary)
+	}
+	if cfg.MediaSubtitlesCollapseRepeats != 3 {
+		t.Fatalf("nested collapse_repeats = %d, want 3", cfg.MediaSubtitlesCollapseRepeats)
+	}
+	if !cfg.MediaSubtitlesDropURLs {
+		t.Fatalf("nested drop_urls not applied")
+	}
+}
+
+// TestMediaSubtitlesCleaning_RejectsBadConfig pins fail-fast validation: a
+// malformed glossary entry and a negative collapse threshold are rejected.
+func TestMediaSubtitlesCleaning_RejectsBadConfig(t *testing.T) {
+	badGloss := config.Default()
+	badGloss.MediaSubtitlesGlossary = []string{"missing-arrow"}
+	if err := badGloss.Validate(); err == nil {
+		t.Fatalf("malformed glossary entry should be rejected")
+	}
+
+	badRe := config.Default()
+	badRe.MediaSubtitlesGlossary = []string{"a(b=>c"}
+	if err := badRe.Validate(); err == nil {
+		t.Fatalf("invalid glossary regexp should be rejected")
+	}
+
+	badN := config.Default()
+	badN.MediaSubtitlesCollapseRepeats = -1
+	if err := badN.Validate(); err == nil {
+		t.Fatalf("negative collapse_repeats should be rejected")
 	}
 }
 

--- a/tests/subtitle/clean_test.go
+++ b/tests/subtitle/clean_test.go
@@ -28,6 +28,28 @@ func TestGlossaryReplacesWholeWordCaseInsensitive(t *testing.T) {
 	}
 }
 
+// TestGlossaryAlternationStaysWordBounded pins that a top-level alternation in a
+// glossary pattern keeps BOTH word boundaries anchoring the whole pattern (the
+// pattern is wrapped in a non-capturing group), so it never rewrites partial
+// words like "Ajubeyond" or "xAdju".
+func TestGlossaryAlternationStaysWordBounded(t *testing.T) {
+	g, err := subtitle.NewGlossary([]string{"Aju|Adju=>Adzhubei"})
+	if err != nil {
+		t.Fatalf("NewGlossary: %v", err)
+	}
+	cases := map[string]string{
+		"met Aju today":       "met Adzhubei today",  // left alternative, whole word
+		"met Adju today":      "met Adzhubei today",  // right alternative, whole word
+		"Ajubeyond the fold":  "Ajubeyond the fold",  // left alt must not match a prefix
+		"saw xAdju in a note": "saw xAdju in a note", // right alt must not match a suffix
+	}
+	for in, want := range cases {
+		if got := g.Apply(in); got != want {
+			t.Errorf("Apply(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
 // TestGlossaryInactiveAndErrors pins that an empty glossary is a no-op and that
 // malformed entries are rejected at construction (so config can fail fast).
 func TestGlossaryInactiveAndErrors(t *testing.T) {

--- a/tests/subtitle/clean_test.go
+++ b/tests/subtitle/clean_test.go
@@ -1,0 +1,135 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/subtitle"
+)
+
+// TestGlossaryReplacesWholeWordCaseInsensitive pins that a glossary rule rewrites
+// matching whole words case-insensitively, absorbs regex spelling variants, and
+// leaves non-matching substrings alone.
+func TestGlossaryReplacesWholeWordCaseInsensitive(t *testing.T) {
+	g, err := subtitle.NewGlossary([]string{"Aju?bei=>Adzhubei", "Khruschev=>Khrushchev"})
+	if err != nil {
+		t.Fatalf("NewGlossary: %v", err)
+	}
+	cases := map[string]string{
+		"signed by Ajubei today":  "signed by Adzhubei today", // variant with 'u'
+		"signed by Ajbei today":   "signed by Adzhubei today", // variant without 'u'
+		"AJUBEI spoke":            "Adzhubei spoke",           // case-insensitive
+		"met Khruschev in Moscow": "met Khrushchev in Moscow",
+		"Ajubeivich is untouched": "Ajubeivich is untouched", // word-bounded: no partial rewrite
+	}
+	for in, want := range cases {
+		if got := g.Apply(in); got != want {
+			t.Errorf("Apply(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestGlossaryInactiveAndErrors pins that an empty glossary is a no-op and that
+// malformed entries are rejected at construction (so config can fail fast).
+func TestGlossaryInactiveAndErrors(t *testing.T) {
+	empty, err := subtitle.NewGlossary(nil)
+	if err != nil {
+		t.Fatalf("NewGlossary(nil): %v", err)
+	}
+	if empty.Active() {
+		t.Fatalf("nil glossary should be inactive")
+	}
+	if got := empty.Apply("unchanged"); got != "unchanged" {
+		t.Fatalf("inactive Apply changed text: %q", got)
+	}
+
+	if _, err := subtitle.NewGlossary([]string{"no-arrow-here"}); err == nil {
+		t.Fatalf("entry without separator should error")
+	}
+	if _, err := subtitle.NewGlossary([]string{"=>only-replacement"}); err == nil {
+		t.Fatalf("entry with empty pattern should error")
+	}
+	if _, err := subtitle.NewGlossary([]string{"a(b=>c"}); err == nil {
+		t.Fatalf("entry with invalid regexp should error")
+	}
+}
+
+// TestCleanCuesInactiveIsIdentity pins that a zero CleanOptions returns cues
+// unchanged (same order, same content), so the empty-config path is a no-op.
+func TestCleanCuesInactiveIsIdentity(t *testing.T) {
+	cues := []subtitle.Cue{
+		{Index: 1, StartMS: 0, EndMS: 1000, Text: "one"},
+		{Index: 2, StartMS: 1000, EndMS: 2000, Text: "two"},
+	}
+	got := subtitle.CleanCues(cues, subtitle.CleanOptions{})
+	if len(got) != 2 || got[0].Text != "one" || got[1].Text != "two" {
+		t.Fatalf("inactive CleanCues altered cues: %+v", got)
+	}
+}
+
+// TestCleanCuesDropsURLs pins that URL/domain/credit cues are dropped when
+// enabled, while ordinary speech survives.
+func TestCleanCuesDropsURLs(t *testing.T) {
+	cues := []subtitle.Cue{
+		{Index: 1, StartMS: 0, EndMS: 1000, Text: "Real speech here"},
+		{Index: 2, StartMS: 1000, EndMS: 2000, Text: "Subtitles by www.example.com"},
+		{Index: 3, StartMS: 2000, EndMS: 3000, Text: "visit https://foo.bar"},
+		{Index: 4, StartMS: 3000, EndMS: 4000, Text: "see amara.org for more"},
+		{Index: 5, StartMS: 4000, EndMS: 5000, Text: "More real speech"},
+	}
+	got := subtitle.CleanCues(cues, subtitle.CleanOptions{DropURLs: true})
+	if len(got) != 2 {
+		t.Fatalf("expected 2 surviving cues, got %d: %+v", len(got), got)
+	}
+	if got[0].Text != "Real speech here" || got[1].Text != "More real speech" {
+		t.Fatalf("wrong cues survived: %+v", got)
+	}
+	for i := range got {
+		if got[i].Index != i+1 {
+			t.Errorf("survivor %d has Index %d, want %d", i, got[i].Index, i+1)
+		}
+	}
+}
+
+// TestCleanCuesCollapseRepeats pins the repetition-collapse: a long identical run
+// keeps the first (threshold-1) cues and drops the rest, while a short repeat and
+// a distinct cue are preserved.
+func TestCleanCuesCollapseRepeats(t *testing.T) {
+	mk := func(texts ...string) []subtitle.Cue {
+		out := make([]subtitle.Cue, 0, len(texts))
+		for i, tx := range texts {
+			out = append(out, subtitle.Cue{Index: i + 1, StartMS: i * 1000, EndMS: (i + 1) * 1000, Text: tx})
+		}
+		return out
+	}
+	// Five identical "No." in a row, then a distinct cue, then two identical.
+	cues := mk("No.", "No.", "No.", "No.", "No.", "Yes.", "Ok.", "Ok.")
+	got := subtitle.CleanCues(cues, subtitle.CleanOptions{CollapseRepeats: 3})
+	var texts []string
+	for _, c := range got {
+		texts = append(texts, c.Text)
+	}
+	// Run of 5 "No." -> keep first 2; "Yes." kept; run of 2 "Ok." (< 3) both kept.
+	want := []string{"No.", "No.", "Yes.", "Ok.", "Ok."}
+	if len(texts) != len(want) {
+		t.Fatalf("collapse got %v, want %v", texts, want)
+	}
+	for i := range want {
+		if texts[i] != want[i] {
+			t.Fatalf("collapse got %v, want %v", texts, want)
+		}
+	}
+}
+
+// TestCleanCuesGlossaryRewrites pins that glossary rewrites are applied to
+// surviving cues after the drop/collapse passes.
+func TestCleanCuesGlossaryRewrites(t *testing.T) {
+	g, err := subtitle.NewGlossary([]string{"Ajubei=>Adzhubei"})
+	if err != nil {
+		t.Fatalf("NewGlossary: %v", err)
+	}
+	cues := []subtitle.Cue{{Index: 1, StartMS: 0, EndMS: 1000, Text: "letter from Ajubei"}}
+	got := subtitle.CleanCues(cues, subtitle.CleanOptions{Glossary: g})
+	if len(got) != 1 || got[0].Text != "letter from Adzhubei" {
+		t.Fatalf("glossary not applied in CleanCues: %+v", got)
+	}
+}

--- a/tests/subtitle/clean_test.go
+++ b/tests/subtitle/clean_test.go
@@ -155,3 +155,106 @@ func TestCleanCuesGlossaryRewrites(t *testing.T) {
 		t.Fatalf("glossary not applied in CleanCues: %+v", got)
 	}
 }
+
+// TestCleanCuesCollapseRepeatsNonASCII pins that repetition-collapse (an
+// exact-match pass) works over real Cyrillic AND CJK cue text, not just ASCII —
+// proving the pass is script-agnostic (the existing "No." case is Latin).
+func TestCleanCuesCollapseRepeatsNonASCII(t *testing.T) {
+	mk := func(texts ...string) []subtitle.Cue {
+		out := make([]subtitle.Cue, 0, len(texts))
+		for i, tx := range texts {
+			out = append(out, subtitle.Cue{Index: i + 1, StartMS: i * 1000, EndMS: (i + 1) * 1000, Text: tx})
+		}
+		return out
+	}
+	// Cyrillic "Да." repeated, a distinct Cyrillic cue, then CJK "はい。" repeated.
+	cues := mk("Да.", "Да.", "Да.", "Да.", "Нет.", "はい。", "はい。", "はい。")
+	got := subtitle.CleanCues(cues, subtitle.CleanOptions{CollapseRepeats: 2})
+	var texts []string
+	for _, c := range got {
+		texts = append(texts, c.Text)
+	}
+	// threshold 2: run of 4 "Да." -> keep 1; "Нет." kept; run of 3 "はい。" -> keep 1.
+	want := []string{"Да.", "Нет.", "はい。"}
+	if len(texts) != len(want) {
+		t.Fatalf("non-ASCII collapse got %v, want %v", texts, want)
+	}
+	for i := range want {
+		if texts[i] != want[i] {
+			t.Fatalf("non-ASCII collapse got %v, want %v", texts, want)
+		}
+	}
+	for i := range got {
+		if got[i].Index != i+1 {
+			t.Errorf("survivor %d has Index %d, want %d", i, got[i].Index, i+1)
+		}
+	}
+}
+
+// TestCleanCuesDropURLsNonASCIINoFalsePositive pins the locale-agnostic URL rule:
+// Cyrillic and CJK cues that merely contain a sentence period are NOT dropped (no
+// false positive), while a real URL embedded in a Cyrillic-context cue IS dropped.
+func TestCleanCuesDropURLsNonASCIINoFalsePositive(t *testing.T) {
+	cues := []subtitle.Cue{
+		{Index: 1, StartMS: 0, EndMS: 1000, Text: "Привет. Как дела"},               // Cyrillic w/ period -> keep
+		{Index: 2, StartMS: 1000, EndMS: 2000, Text: "こんにちは。元気ですか"},                 // CJK w/ period -> keep
+		{Index: 3, StartMS: 2000, EndMS: 3000, Text: "Смотрите на www.example.com"}, // real URL -> drop
+		{Index: 4, StartMS: 3000, EndMS: 4000, Text: "Подписи на site.tv"},          // bare domain -> drop
+		{Index: 5, StartMS: 4000, EndMS: 5000, Text: "Обычная речь"},                // plain Cyrillic -> keep
+	}
+	got := subtitle.CleanCues(cues, subtitle.CleanOptions{DropURLs: true})
+	var texts []string
+	for _, c := range got {
+		texts = append(texts, c.Text)
+	}
+	want := []string{"Привет. Как дела", "こんにちは。元気ですか", "Обычная речь"}
+	if len(texts) != len(want) {
+		t.Fatalf("non-ASCII URL drop got %v, want %v", texts, want)
+	}
+	for i := range want {
+		if texts[i] != want[i] {
+			t.Fatalf("non-ASCII URL drop got %v, want %v", texts, want)
+		}
+	}
+}
+
+// TestCleanCuesGlossaryNonASCII pins that a glossary rewrite works over non-ASCII
+// (Cyrillic) cue text, not just Latin transliterations.
+func TestCleanCuesGlossaryNonASCII(t *testing.T) {
+	g, err := subtitle.NewGlossary([]string{"Аджубей=>Аджубей (зять Хрущёва)"})
+	if err != nil {
+		t.Fatalf("NewGlossary: %v", err)
+	}
+	cues := []subtitle.Cue{{Index: 1, StartMS: 0, EndMS: 1000, Text: "письмо от Аджубей сегодня"}}
+	got := subtitle.CleanCues(cues, subtitle.CleanOptions{Glossary: g})
+	if len(got) != 1 || got[0].Text != "письмо от Аджубей (зять Хрущёва) сегодня" {
+		t.Fatalf("non-ASCII glossary not applied: %+v", got)
+	}
+}
+
+// TestCleanCuesGlossaryEmptiesCueDropped pins FIX 2: a glossary rule with an empty
+// replacement ("foo=>") that rewrites a cue entirely to empty/whitespace drops the
+// cue rather than exporting a blank one, and survivors stay re-indexed gap-free.
+func TestCleanCuesGlossaryEmptiesCueDropped(t *testing.T) {
+	g, err := subtitle.NewGlossary([]string{"noise=>"})
+	if err != nil {
+		t.Fatalf("NewGlossary: %v", err)
+	}
+	cues := []subtitle.Cue{
+		{Index: 1, StartMS: 0, EndMS: 1000, Text: "keep me"},
+		{Index: 2, StartMS: 1000, EndMS: 2000, Text: "noise"}, // -> "" after glossary -> dropped
+		{Index: 3, StartMS: 2000, EndMS: 3000, Text: "keep me too"},
+	}
+	got := subtitle.CleanCues(cues, subtitle.CleanOptions{Glossary: g})
+	if len(got) != 2 {
+		t.Fatalf("expected 2 surviving cues, got %d: %+v", len(got), got)
+	}
+	if got[0].Text != "keep me" || got[1].Text != "keep me too" {
+		t.Fatalf("wrong cues survived: %+v", got)
+	}
+	for i := range got {
+		if got[i].Index != i+1 {
+			t.Errorf("survivor %d has Index %d, want %d", i, got[i].Index, i+1)
+		}
+	}
+}


### PR DESCRIPTION
## What

Ports the pilot's `clean_srt.py` cue-hygiene passes into the dir2mcp Go export path as three **additive, opt-in** filters, applied on VTT/SRT export after `media.filter_words`. Complements the broadcast segmentation in #533 / #524.

| Config | Effect | Default |
|---|---|---|
| `media.subtitles.glossary: ["pattern=>replacement", …]` | Editorial term **replacement** — case-insensitive, ASCII-word-bounded regexp, so one entry absorbs spelling variants (`Aju?bei=>Adzhubei`). Distinct from `filter_words` (which deletes). | empty (off) |
| `media.subtitles.collapse_repeats: N` | Drop the Nth-and-later cue in a run of identical consecutive cues (whisper repetition-collapse artifact), keeping the first N-1. `< 2` disables. | `0` (off) |
| `media.subtitles.drop_urls: bool` | Drop cues that are hallucinated URLs / bare domains / credit lines. | `false` |

All default off → export is byte-identical unless configured.

## Design

- New `subtitle.Glossary` + `subtitle.CleanCues` live beside the existing `WordFilter`, run via `subtitle.CleanCues` in `renderTranscriptExport`.
- The glossary grammar is validated **at config load** (`subtitle.NewGlossary` is the single source of truth), so a malformed `pattern=>replacement` entry or bad regexp fails fast with `CONFIG_INVALID` rather than at export. `collapse_repeats` is guarded non-negative.
- Config plumbed at every `media.subtitles.*` site (runtime field, fileConfig, defaults, snapshot, apply, alias, accessor/list-append, serialize, validate).
- Scope: VTT/SRT export only (TTML/SMIL keep their own path), and export-only — ingest/embeddings are untouched.

## Tests

- Unit: `Glossary` (whole-word / case-insensitive / regex-variant / error cases) and `CleanCues` (URL drop, collapse run math, glossary, inactive no-op).
- Config: defaults-off, save/load round-trip, nested-YAML apply, fail-fast validation (bad glossary entry, invalid regexp, negative threshold).
- End-to-end: `export` command applies all three passes with config, and is a no-op without it.

## Checklist
- [x] `make check`-level gates pass locally (build, vet, golangci-lint 0 issues, gocyclo -over 15 clean, gofmt)
- [x] New behavior has test coverage
- [x] `coderabbit review` run via CLI against `main` — **no findings**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Ryjn9aKoXj4CQPP8BVrVW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional subtitle cleanup during export, including glossary-based text replacements, repeat collapsing, and URL/credit-line removal.
  * New subtitle export settings can now be saved and loaded in configuration.

* **Bug Fixes**
  * Export now fails fast when subtitle glossary settings are invalid, preventing broken exports.
  * Cleaned subtitle cues are re-numbered correctly after removals.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->
