### PR TITLE
fix(ingest): quality-gate quarantine sets documents.status=error + canonical code (#422 V2, §8.6.6)

### DIFF
--- a/internal/ingest/batch.go
+++ b/internal/ingest/batch.go
@@ -28,11 +28,14 @@ import (
 // Canonical §14.4 error codes recorded in a manifest record's `error_code`
 // field (§7.7). EXTRACT_FAILED is the generic representation/derivation failure;
 // TRANSCRIBE_FAILED is distinguished via the package's transcript-failure
-// sentinel. Finer classification (TRANSLATE_FAILED/OCR_FAILED) is a follow-up
-// alongside the two-phase pass split.
+// sentinel. OCR_FAILED / TRANSLATE_FAILED are the finer output-quality-gate
+// classifications (§8.6.6): a degenerate OCR/translation output rejected by the
+// gate records the matching code via qualityGateFailureCode (service.go).
 const (
 	manifestErrTranscribeFailed = "TRANSCRIBE_FAILED"
 	manifestErrExtractFailed    = "EXTRACT_FAILED"
+	manifestErrOCRFailed        = "OCR_FAILED"
+	manifestErrTranslateFailed  = "TRANSLATE_FAILED"
 )
 
 // manifestErrorCode maps a per-asset processing error to a canonical §14.4 code

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -238,10 +238,12 @@ type Service struct {
 	// document currently being processed as a non-fatal per-document error, so the
 	// scan loop must count it as exactly one error and NOT credit it as indexed
 	// (issue #426). Like activeOutcome it is per-document state: the scan loop is
-	// sequential (at most one asset in flight), and it is reset at the start of
-	// each representation-generation entry point (generateRepresentations and the
-	// two-phase deriveDocument) so a rejected representation is counted once even
-	// when a document produces several (transcript + per-language translations).
+	// sequential (at most one asset in flight). The authoritative reset is at
+	// processDocument entry so every document starts clean by construction on every
+	// path; generateRepresentations additionally resets it to re-scope the flag for
+	// sequential archive members (separate processDocumentFromContent calls under a
+	// single processDocument entry). A rejected representation is thus counted once
+	// even when a document produces several (transcript + per-language translations).
 	quarantinedThisDoc bool
 
 	// activePass selects which work the representation generators perform for the
@@ -1310,6 +1312,20 @@ func (s *Service) refreshDocID(ctx context.Context, doc *model.Document) error {
 }
 
 func (s *Service) processDocument(ctx context.Context, f DiscoveredFile, secretPatterns []*regexp.Regexp, forceReindex bool, seen map[string]struct{}) error {
+	// Authoritative per-document reset of the §8.6.6/#426 quality-gate quarantine
+	// flag. The scan loop is sequential (at most one asset in flight), so resetting
+	// here — at the VERY START, before any early-return branch (build error, remote
+	// skip, archive, cache-hit/skipped, non-ok status) — guarantees every document
+	// begins with a clean flag by construction, matching the per-doc reset pattern
+	// used for activeOutcome/indexedPending. Without this, a stale true from a prior
+	// quarantined document could persist across an early-return path that never
+	// reaches generateRepresentations/deriveDocument (which also reset the flag) and
+	// wrongly suppress this document's indexed credit. The resets inside
+	// generateRepresentations/deriveDocument are kept: they re-scope the flag for
+	// sequential archive members, which run as separate processDocumentFromContent
+	// calls under a single processDocument entry.
+	s.quarantinedThisDoc = false
+
 	// Two-phase derivation pass (SPEC §8.6.11): the transcription pass already did
 	// all document building, upserting, counting, and source-transcript work for
 	// this asset; the derivation pass runs ONLY translation (§8.6.2) and re-doing
@@ -1576,12 +1592,10 @@ func (s *Service) suppressIndexedCredit(nonFatalErrored bool) bool {
 // with no source transcript are recorded as skipped and produce nothing — keeping
 // the derivation pass's per-asset manifest/progress totals faithful (§8.6.11).
 func (s *Service) deriveDocument(ctx context.Context, f DiscoveredFile, secretPatterns []*regexp.Regexp) error {
-	// Reset the per-document quality-gate quarantine flag (§8.6.6 / #426) so a
-	// translation rejected in this derivation pass is counted once and cannot leak
-	// its dedup state into the next asset. The derivation pass does not credit the
-	// indexed counter (the transcription pass did), so it only needs the flag reset
-	// for correct per-document error accounting on the translation path.
-	s.quarantinedThisDoc = false
+	// The per-document quality-gate quarantine flag (§8.6.6 / #426) was already
+	// reset at processDocument entry (deriveDocument is reached only from there),
+	// so a translation rejected in this derivation pass is counted once and cannot
+	// leak its dedup state into the next asset without a redundant reset here.
 	// No translation configured, or the multimodal "replace" mode that stands in
 	// for STT→text (so no transcript exists to translate): nothing to derive. This
 	// matches the single-pass gates so the corpus-wide output is identical.
@@ -2900,10 +2914,16 @@ func (s *Service) screenOutputQuality(ctx context.Context, doc model.Document, k
 // It is idempotent per document: a document with several rejected representations
 // (e.g. a transcript plus per-language translations) counts once and keeps the
 // FIRST canonical code, while every rejected representation still quarantines its
-// own chunks via the returned decision. The document's content_hash stays
-// withheld (#402/#413): the row is now status=error, so finalizeContentHash's
-// guard leaves the done-marker unstamped and the document is retried next run
-// (re-screening the cached STT/OCR output, not the provider — bounded cost).
+// own chunks via the returned decision. The document's content_hash done-marker is
+// blanked before the error upsert (#402/#413): the row is now status=error AND
+// carries an empty hash, so the next incremental run re-derives it. Blanking is
+// required for the two-phase derivation path, where deriveDocument re-reads the doc
+// AFTER the transcription pass already stamped content_hash — without it a
+// translation-gate rejection would persist status=error yet keep the stamped hash,
+// so the unchanged-content gate would SKIP (never retry) the quarantined document.
+// On the single-phase path the hash is already withheld (withholdContentHash), so
+// blanking it again is a no-op; the two modes are now consistent. Retry re-screens
+// the cached STT/OCR/translation output, not the provider — a bounded cost.
 func (s *Service) recordQualityGateDocError(ctx context.Context, doc model.Document, kind string, reason quality.Reason) {
 	code := qualityGateFailureCode(kind)
 	// Content-free and deterministic (§8.6.6): the message is code + kind + the
@@ -2920,6 +2940,10 @@ func (s *Service) recordQualityGateDocError(ctx context.Context, doc model.Docum
 	}
 	s.quarantinedThisDoc = true
 	s.addErrors(1)
+	// Withhold the content_hash done-marker so the quarantined document is retried
+	// next run in BOTH single-phase and two-phase modes (#402/#413). doc is a value
+	// copy, so this affects only the persisted error row.
+	doc.ContentHash = ""
 	s.persistNonFatalDocError(ctx, doc, errors.New(msg), nil)
 }
 

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -234,6 +234,16 @@ type Service struct {
 	// batch run is active, making recordOutput a no-op on the hot path.
 	activeOutcome *assetOutcome
 
+	// quarantinedThisDoc records that the output quality gate (§8.6.6) marked the
+	// document currently being processed as a non-fatal per-document error, so the
+	// scan loop must count it as exactly one error and NOT credit it as indexed
+	// (issue #426). Like activeOutcome it is per-document state: the scan loop is
+	// sequential (at most one asset in flight), and it is reset at the start of
+	// each representation-generation entry point (generateRepresentations and the
+	// two-phase deriveDocument) so a rejected representation is counted once even
+	// when a document produces several (transcript + per-language translations).
+	quarantinedThisDoc bool
+
 	// activePass selects which work the representation generators perform for the
 	// asset currently being processed under the optional two-phase pass split
 	// (SPEC §8.6.11). runScan sets it around each per-asset call (the scan loop is
@@ -298,6 +308,18 @@ func (s *Service) markActiveSkipped() {
 		return
 	}
 	s.activeOutcome.markSkipped()
+}
+
+// markActiveErrored records a terminal error outcome — the canonical §14.4 code
+// and a content-free message — on the asset currently being processed under an
+// active batch run, for the run manifest (SPEC §8.6.11). The first code recorded
+// wins (markErrorIfUnset), so a specific inner failure is never clobbered by a
+// later one. No-op when no batch run is active.
+func (s *Service) markActiveErrored(code, message string) {
+	if s == nil {
+		return
+	}
+	s.activeOutcome.markErrorIfUnset(code, message)
 }
 
 // ErrTranscriptProviderFailure marks failures originating from the transcript
@@ -1375,13 +1397,11 @@ func (s *Service) processDocument(ctx context.Context, f DiscoveredFile, secretP
 	if err := s.finalizeIfGenerated(ctx, &doc, willGenerateReps, finalContentHash); err != nil {
 		return err
 	}
-	if nonFatalErrored {
-		// A non-fatal soft-error path (binary-content, video-no-representation, or
-		// a zero-representation provider failure) already persisted this document
-		// as status="error" and bumped the error counter itself. It must count
-		// solely as an error, so suppress the indexed credit — otherwise the same
-		// doc is counted as both indexed and error and indexed+skipped+errors
-		// exceeds scanned (issue #426).
+	if s.suppressIndexedCredit(nonFatalErrored) {
+		// A non-fatal soft-error path already persisted this document as
+		// status="error" and bumped the error counter itself, so it must count
+		// solely as an error, not also as indexed (otherwise indexed+skipped+errors
+		// exceeds scanned — issue #426).
 		indexedPending = false
 	}
 	s.creditIndexed(indexedPending)
@@ -1531,6 +1551,17 @@ func (s *Service) creditIndexed(indexed bool) {
 	}
 }
 
+// suppressIndexedCredit reports whether the document just processed must NOT be
+// credited as indexed because a non-fatal soft error already counted it as an
+// error (issue #426). Two sources: (1) nonFatalErrored — a rep-generation
+// soft-failure (binary-content, video-no-representation, or a zero-representation
+// provider failure) returned by generateRepresentations; (2) quarantinedThisDoc —
+// an output quality gate (§8.6.6) that rejected a generated OCR/transcript/
+// translation output. Either way the document counts solely as an error.
+func (s *Service) suppressIndexedCredit(nonFatalErrored bool) bool {
+	return nonFatalErrored || s.quarantinedThisDoc
+}
+
 // deriveDocument runs the derivation pass for a single asset under the two-phase
 // split (SPEC §8.6.11): it produces ONLY translated transcripts (§8.6.2) from the
 // already-persisted source transcript, reusing the cached transcript text so it
@@ -1545,6 +1576,12 @@ func (s *Service) creditIndexed(indexed bool) {
 // with no source transcript are recorded as skipped and produce nothing — keeping
 // the derivation pass's per-asset manifest/progress totals faithful (§8.6.11).
 func (s *Service) deriveDocument(ctx context.Context, f DiscoveredFile, secretPatterns []*regexp.Regexp) error {
+	// Reset the per-document quality-gate quarantine flag (§8.6.6 / #426) so a
+	// translation rejected in this derivation pass is counted once and cannot leak
+	// its dedup state into the next asset. The derivation pass does not credit the
+	// indexed counter (the transcription pass did), so it only needs the flag reset
+	// for correct per-document error accounting on the translation path.
+	s.quarantinedThisDoc = false
 	// No translation configured, or the multimodal "replace" mode that stands in
 	// for STT→text (so no transcript exists to translate): nothing to derive. This
 	// matches the single-pass gates so the corpus-wide output is identical.
@@ -2347,6 +2384,10 @@ func isEmbeddableAudio(relPath string) bool {
 // hard error: the caller MUST NOT then also credit the document as indexed, or it
 // would be double-counted as both indexed and error (issue #426).
 func (s *Service) generateRepresentations(ctx context.Context, doc model.Document, content []byte, secretPatterns []*regexp.Regexp, forceReindex bool) (bool, error) {
+	// Reset the per-document quality-gate quarantine flag (§8.6.6 / #426). The scan
+	// loop is sequential, so this scopes the flag to the document about to be
+	// processed even though it is Service-level state.
+	s.quarantinedThisDoc = false
 	if s.repGen == nil {
 		return false, nil
 	}
@@ -2582,7 +2623,7 @@ func (s *Service) generateOCRMarkdownRepresentation(ctx context.Context, doc mod
 
 	s.persistTitleIfFound(ctx, doc, ocrText)
 
-	decision := s.screenOutputQuality(doc.RelPath, "ocr", ocrText, quality.Context{
+	decision := s.screenOutputQuality(ctx, doc, qualityKindOCR, ocrText, quality.Context{
 		Modality: quality.ModalityOCR,
 	})
 
@@ -2626,7 +2667,7 @@ func (s *Service) persistStructuredRepresentation(ctx context.Context, doc model
 		s.persistTitleIfFound(ctx, doc, md)
 	}
 
-	decision := s.screenOutputQuality(doc.RelPath, "ocr", md, quality.Context{
+	decision := s.screenOutputQuality(ctx, doc, qualityKindOCR, md, quality.Context{
 		Modality: quality.ModalityOCR,
 	})
 
@@ -2775,12 +2816,42 @@ type quarantineDecision struct {
 	category   string
 }
 
+// Quality-gate screening kinds — the `kind` argument to screenOutputQuality.
+// They select the canonical §14.4 error code recorded when a degenerate output
+// is quarantined (§8.6.6). The literal values are also the diagnostic labels in
+// the quarantine log line.
+const (
+	qualityKindOCR         = "ocr"
+	qualityKindTranscript  = "transcript"
+	qualityKindTranslation = "transcript-translation"
+)
+
+// qualityGateFailureCode maps a screening kind to its canonical §14.4 error code
+// (§8.6.6): an OCR / transcript / translation output rejected by the gate is
+// OCR_FAILED / TRANSCRIBE_FAILED / TRANSLATE_FAILED respectively. An unknown kind
+// falls back to the generic EXTRACT_FAILED so the recorded code is always a valid
+// §14.4 constant.
+func qualityGateFailureCode(kind string) string {
+	switch kind {
+	case qualityKindOCR:
+		return manifestErrOCRFailed
+	case qualityKindTranscript:
+		return manifestErrTranscribeFailed
+	case qualityKindTranslation:
+		return manifestErrTranslateFailed
+	default:
+		return manifestErrExtractFailed
+	}
+}
+
 // screenOutputQuality runs the quality gate over generated text. It returns a
 // zero-value (non-quarantine) decision when the gate is disabled (nil) or the
 // verdict is clean, so callers can always insert via the returned decision. On
-// a failed gate it logs a content-free warning and returns the quarantine
-// values. relPath/kind are used only for the diagnostic log line.
-func (s *Service) screenOutputQuality(relPath, kind string, text string, qctx quality.Context) quarantineDecision {
+// a failed gate it logs a content-free warning, records the §8.6.6 per-document
+// error (documents.status=error + canonical §14.4 code, non-fatal), and returns
+// the chunk-level quarantine values. kind selects the canonical code and the
+// diagnostic label; doc identifies the document to mark.
+func (s *Service) screenOutputQuality(ctx context.Context, doc model.Document, kind, text string, qctx quality.Context) quarantineDecision {
 	if s.qualityGate == nil {
 		return quarantineDecision{}
 	}
@@ -2798,12 +2869,58 @@ func (s *Service) screenOutputQuality(relPath, kind string, text string, qctx qu
 	// Detail is already redacted/content-free; SanitizeReason bounds/normalizes
 	// it for persistence into chunks.embedding_error.
 	embErr := store.SanitizeReason(detail)
-	s.getLogger().Printf("quality gate quarantined %s output for %s: reason=%s", kind, relPath, reason)
+	s.getLogger().Printf("quality gate quarantined %s output for %s: reason=%s", kind, doc.RelPath, reason)
+	// §8.6.6: a failed output quality gate is a non-fatal per-document error — the
+	// document is marked status=error with the canonical §14.4 code while indexing
+	// continues. This is IN ADDITION to the chunk-level quarantine encoded in the
+	// returned decision (embedding_status=error), which keeps the degenerate text
+	// out of the embedding index.
+	s.recordQualityGateDocError(ctx, doc, kind, reason)
 	return quarantineDecision{
 		quarantine: true,
 		embErr:     embErr,
 		category:   string(store.ErrorCategoryQualityGate),
 	}
+}
+
+// recordQualityGateDocError persists the §8.6.6 per-document error for a
+// quality-gate quarantine and accounts for it exactly once (issue #426):
+//
+//   - it marks documents.status=error via persistNonFatalDocError with a
+//     content-free message that LEADS with the canonical §14.4 code, so the code
+//     is queryable through error_message / RecentFailures (§15.6) without a store
+//     schema change (the documents table has no error_code column, and §8.6.6 only
+//     requires the document be "marked status=error with the appropriate code");
+//   - it records the same canonical code on the active batch manifest outcome
+//     (§8.6.11), whose record carries a dedicated machine-readable error_code;
+//   - it increments the run error counter once and sets quarantinedThisDoc so the
+//     scan loop suppresses the indexed credit (the document counts as exactly one
+//     error, zero indexed — issue #426).
+//
+// It is idempotent per document: a document with several rejected representations
+// (e.g. a transcript plus per-language translations) counts once and keeps the
+// FIRST canonical code, while every rejected representation still quarantines its
+// own chunks via the returned decision. The document's content_hash stays
+// withheld (#402/#413): the row is now status=error, so finalizeContentHash's
+// guard leaves the done-marker unstamped and the document is retried next run
+// (re-screening the cached STT/OCR output, not the provider — bounded cost).
+func (s *Service) recordQualityGateDocError(ctx context.Context, doc model.Document, kind string, reason quality.Reason) {
+	code := qualityGateFailureCode(kind)
+	// Content-free and deterministic (§8.6.6): the message is code + kind + the
+	// enum reason only — no document text — so it carries no secrets. nil secret
+	// patterns are therefore safe (persistNonFatalDocError still redacts, a no-op
+	// here).
+	msg := fmt.Sprintf("%s: output quality gate rejected %s output (%s)", code, kind, reason)
+	// Manifest surface (§8.6.11): first canonical code wins, never clobbered.
+	s.markActiveErrored(code, msg)
+	if s.quarantinedThisDoc {
+		// This document already recorded its canonical per-document error and was
+		// counted; keep the first code and count it once (issue #426).
+		return
+	}
+	s.quarantinedThisDoc = true
+	s.addErrors(1)
+	s.persistNonFatalDocError(ctx, doc, errors.New(msg), nil)
 }
 
 // transcriptExpectedLanguage returns the active STT provider profile's language
@@ -2835,7 +2952,7 @@ func (s *Service) generateTranscriptRepresentation(ctx context.Context, doc mode
 	if d, derr := s.probeDuration(ctx, doc); derr == nil {
 		duration = d
 	}
-	decision := s.screenOutputQuality(doc.RelPath, "transcript", transcriptText, quality.Context{
+	decision := s.screenOutputQuality(ctx, doc, qualityKindTranscript, transcriptText, quality.Context{
 		Modality:         quality.ModalityTranscript,
 		ExpectedLanguage: s.transcriptExpectedLanguage(),
 		Duration:         duration,
@@ -3027,7 +3144,7 @@ func (s *Service) translateOneTranscript(ctx context.Context, doc model.Document
 	// quality gate exactly like an STT transcript (anti-hallucination). The
 	// expected language is the TARGET language: the gate's language detector
 	// should accept the translated text, not the source.
-	decision := s.screenOutputQuality(doc.RelPath, "transcript-translation", translated, quality.Context{
+	decision := s.screenOutputQuality(ctx, doc, qualityKindTranslation, translated, quality.Context{
 		Modality:         quality.ModalityTranscript,
 		ExpectedLanguage: targetLang,
 		Duration:         duration,

--- a/tests/ingest/quality_gate_doc_status_test.go
+++ b/tests/ingest/quality_gate_doc_status_test.go
@@ -1,0 +1,233 @@
+package tests
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/appstate"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// These tests cover the §8.6.6 DOCUMENT-level contract of the output quality
+// gate (issue #422 V2): a rejected OCR/transcript/translation output is a
+// non-fatal per-document error. The document MUST end status=error carrying the
+// canonical §14.4 code (OCR_FAILED / TRANSCRIBE_FAILED / TRANSLATE_FAILED), its
+// content_hash MUST stay withheld so it is retried (#402/#413), it MUST count as
+// exactly one error and zero indexed (#426), and its chunks MUST still be
+// quarantined (embedding_status=error, category quality_gate). The chunk-level
+// quarantine on its own is already covered by quality_gate_test.go; these tests
+// add the document/status/counter surface that was the gap.
+
+// qgService builds a service with the output quality gate enabled, backed by a
+// real on-disk store and a fresh run-progress counter, so a full ProcessDocument
+// exercises status persistence, content_hash withholding, and the indexed/error
+// counters end to end.
+func qgService(t *testing.T, root string, st *store.SQLiteStore) (*ingest.Service, *appstate.IndexingState) {
+	t.Helper()
+	cfg := config.Config{RootDir: root, StateDir: t.TempDir(), STTProvider: "off", QualityGatesEnabled: true}
+	svc := mustNewIngestService(t, cfg, st)
+	state := appstate.NewIndexingState(appstate.ModeIncremental)
+	svc.SetIndexingState(state)
+	return svc, state
+}
+
+// mustGetDoc reads a persisted document by rel_path, failing the test on error.
+func mustGetDoc(t *testing.T, st *store.SQLiteStore, relPath string) model.Document {
+	t.Helper()
+	doc, err := st.GetDocumentByPath(context.Background(), relPath)
+	if err != nil {
+		t.Fatalf("GetDocumentByPath(%s): %v", relPath, err)
+	}
+	return doc
+}
+
+// assertQuarantinedDoc bundles the shared §8.6.6/#402/#413/#426 assertions for a
+// document whose generated output was rejected by the quality gate.
+func assertQuarantinedDoc(t *testing.T, st *store.SQLiteStore, state *appstate.IndexingState, relPath, wantCode string) {
+	t.Helper()
+
+	doc := mustGetDoc(t, st, relPath)
+	if doc.Status != "error" {
+		t.Fatalf("%s: status = %q, want \"error\" (a rejected quality gate is a per-document error, §8.6.6)", relPath, doc.Status)
+	}
+	// The canonical §14.4 code leads the error_message so it is queryable through
+	// RecentFailures / error_message without a store schema change.
+	if !strings.HasPrefix(doc.ErrorMessage, wantCode) {
+		t.Fatalf("%s: error_message = %q, want it to lead with canonical code %q", relPath, doc.ErrorMessage, wantCode)
+	}
+	// #402/#413: the done-marker stays withheld so the document is retried.
+	if doc.ContentHash != "" {
+		t.Fatalf("%s: content_hash = %q, want \"\" (withheld so the doc is retried next run)", relPath, doc.ContentHash)
+	}
+
+	// #426: exactly one error, zero indexed.
+	snap := state.Snapshot()
+	if snap.Errors != 1 {
+		t.Fatalf("%s: run errors = %d, want 1", relPath, snap.Errors)
+	}
+	if snap.Indexed != 0 {
+		t.Fatalf("%s: run indexed = %d, want 0 (a quarantined doc counts solely as an error, #426)", relPath, snap.Indexed)
+	}
+
+	// The document persists as a failure surfaced by RecentFailures.
+	failures, err := st.RecentFailures(context.Background(), 20)
+	if err != nil {
+		t.Fatalf("RecentFailures: %v", err)
+	}
+	if !recentFailuresContain(failures, relPath) {
+		t.Fatalf("%s missing from RecentFailures: %+v", relPath, failures)
+	}
+
+	// The chunk-level quarantine still holds: the rejected chunks are recorded as
+	// quality_gate embedding failures.
+	stats, err := st.CorpusStats(context.Background())
+	if err != nil {
+		t.Fatalf("CorpusStats: %v", err)
+	}
+	if stats.FailureSummary == nil || stats.FailureSummary.Categories[string(store.ErrorCategoryQualityGate)] == 0 {
+		t.Fatalf("%s: expected quarantined chunks under FailureSummary category %q, got %+v",
+			relPath, store.ErrorCategoryQualityGate, stats.FailureSummary)
+	}
+}
+
+// TestQualityGate_DegenerateTranscript_MarksDocError is the transcript case:
+// a repetition-loop transcript (the classic STT hallucination) is rejected, so
+// the audio document ends status=error with TRANSCRIBE_FAILED, is retried
+// (withheld hash), and counts as one error / zero indexed.
+func TestQualityGate_DegenerateTranscript_MarksDocError(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "loop.mp3"), "fake-audio")
+	st := newRealStore(t)
+
+	svc, state := qgService(t, root, st)
+	svc.SetTranscriber(&fakeTranscriber{text: strings.Repeat("thank you ", 60)})
+	svc.SetSTTIdentity("whisper", "whisper-large-v3")
+	svc.SetTranscriptLanguage("en")
+
+	f := ingest.DiscoveredFile{RelPath: "loop.mp3", SizeBytes: 10, MTimeUnix: time.Now().Unix()}
+	if err := svc.ProcessDocument(context.Background(), f, nil, false); err != nil {
+		t.Fatalf("ProcessDocument hard-failed on a non-fatal quality-gate rejection: %v", err)
+	}
+
+	assertQuarantinedDoc(t, st, state, "loop.mp3", "TRANSCRIBE_FAILED")
+}
+
+// TestQualityGate_DegenerateOCR_MarksDocError is the OCR case: a repetition-loop
+// OCR extraction is rejected, so the visual document ends status=error with
+// OCR_FAILED.
+func TestQualityGate_DegenerateOCR_MarksDocError(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "scan.pdf"), "fake-pdf-bytes")
+	st := newRealStore(t)
+
+	svc, state := qgService(t, root, st)
+	svc.SetOCR(&fakeOCR{text: strings.Repeat("thank you ", 60)})
+
+	f := ingest.DiscoveredFile{RelPath: "scan.pdf", SizeBytes: 13, MTimeUnix: time.Now().Unix()}
+	if err := svc.ProcessDocument(context.Background(), f, nil, false); err != nil {
+		t.Fatalf("ProcessDocument hard-failed on a non-fatal quality-gate rejection: %v", err)
+	}
+
+	assertQuarantinedDoc(t, st, state, "scan.pdf", "OCR_FAILED")
+}
+
+// TestQualityGate_DegenerateTranslation_MarksDocError is the translation case: a
+// clean source transcript passes, but a degenerate translation output is
+// rejected, so the document ends status=error with TRANSLATE_FAILED (§8.6.6 —
+// a failed translation gate is a per-document error, distinct from a best-effort
+// translation provider failure which does not mark the doc).
+func TestQualityGate_DegenerateTranslation_MarksDocError(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "talk.mp3"), "fake-audio")
+	st := newRealStore(t)
+
+	svc, state := qgService(t, root, st)
+	svc.SetTranscriber(&fakeTranscriber{text: "[00:00] a clean source line\n[00:02] another clean line"})
+	svc.SetSTTIdentity("whisper", "whisper-large-v3")
+	svc.SetTranscriptLanguage("de")
+	svc.SetTranslator(degenerateTranslator{}, "mistral", "m", []string{"en"})
+
+	f := ingest.DiscoveredFile{RelPath: "talk.mp3", SizeBytes: 10, MTimeUnix: time.Now().Unix()}
+	if err := svc.ProcessDocument(context.Background(), f, nil, false); err != nil {
+		t.Fatalf("ProcessDocument hard-failed on a non-fatal quality-gate rejection: %v", err)
+	}
+
+	assertQuarantinedDoc(t, st, state, "talk.mp3", "TRANSLATE_FAILED")
+}
+
+// TestQualityGate_CleanTranscript_IndexedNoError is the passing companion: a
+// clean transcript is unaffected — the document indexes normally (status ok,
+// content_hash stamped, one indexed, zero errors).
+func TestQualityGate_CleanTranscript_IndexedNoError(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "clean.mp3"), "fake-audio")
+	st := newRealStore(t)
+
+	svc, state := qgService(t, root, st)
+	svc.SetTranscriber(&fakeTranscriber{text: "[00:00] welcome to the lecture today\n[00:02] we discuss several distinct topics in depth\n[00:05] including history geography and science across many regions"})
+	svc.SetSTTIdentity("whisper", "whisper-large-v3")
+	svc.SetTranscriptLanguage("en")
+
+	f := ingest.DiscoveredFile{RelPath: "clean.mp3", SizeBytes: 10, MTimeUnix: time.Now().Unix()}
+	if err := svc.ProcessDocument(context.Background(), f, nil, false); err != nil {
+		t.Fatalf("ProcessDocument: %v", err)
+	}
+
+	doc := mustGetDoc(t, st, "clean.mp3")
+	if doc.Status != "ok" {
+		t.Fatalf("clean.mp3: status = %q, want \"ok\"", doc.Status)
+	}
+	if doc.ContentHash == "" {
+		t.Fatal("clean.mp3: content_hash was withheld for a clean transcript (should be stamped/indexed)")
+	}
+	snap := state.Snapshot()
+	if snap.Indexed != 1 || snap.Errors != 0 {
+		t.Fatalf("clean.mp3: indexed=%d errors=%d, want indexed=1 errors=0", snap.Indexed, snap.Errors)
+	}
+}
+
+// TestQualityGate_Disabled_LeavesDocOK proves the master switch: with the gate
+// off (the default), even a degenerate transcript leaves the document status=ok
+// and indexed — the nil gate is a pure no-op with no document-status side effect.
+func TestQualityGate_Disabled_LeavesDocOK(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "loop.mp3"), "fake-audio")
+	st := newRealStore(t)
+
+	// QualityGatesEnabled defaults to false here.
+	cfg := config.Config{RootDir: root, StateDir: t.TempDir(), STTProvider: "off"}
+	svc := mustNewIngestService(t, cfg, st)
+	state := appstate.NewIndexingState(appstate.ModeIncremental)
+	svc.SetIndexingState(state)
+	svc.SetTranscriber(&fakeTranscriber{text: strings.Repeat("thank you ", 60)})
+	svc.SetSTTIdentity("whisper", "whisper-large-v3")
+	svc.SetTranscriptLanguage("en")
+
+	f := ingest.DiscoveredFile{RelPath: "loop.mp3", SizeBytes: 10, MTimeUnix: time.Now().Unix()}
+	if err := svc.ProcessDocument(context.Background(), f, nil, false); err != nil {
+		t.Fatalf("ProcessDocument: %v", err)
+	}
+
+	doc := mustGetDoc(t, st, "loop.mp3")
+	if doc.Status != "ok" {
+		t.Fatalf("gate off: status = %q, want \"ok\" (a nil gate must not change document status)", doc.Status)
+	}
+	if doc.ContentHash == "" {
+		t.Fatal("gate off: content_hash was withheld though the gate is disabled")
+	}
+	snap := state.Snapshot()
+	if snap.Errors != 0 {
+		t.Fatalf("gate off: run errors = %d, want 0 (nil gate is a no-op)", snap.Errors)
+	}
+}

--- a/tests/ingest/quality_gate_doc_status_test.go
+++ b/tests/ingest/quality_gate_doc_status_test.go
@@ -196,6 +196,135 @@ func TestQualityGate_CleanTranscript_IndexedNoError(t *testing.T) {
 	}
 }
 
+// TestQualityGate_QuarantineDoesNotSuppressLaterIndexedCredit pins the
+// per-document reset of the §8.6.6/#426 quarantine flag (the authoritative reset
+// now lives at processDocument entry). A quarantined document leaves the flag
+// true; a subsequent document that takes an early-return path (here an ok cache
+// hit) must still be credited as indexed — the stale flag from the prior document
+// must NOT leak in and suppress its indexed credit.
+func TestQualityGate_QuarantineDoesNotSuppressLaterIndexedCredit(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "clean.mp3"), "clean-audio")
+	writeFile(t, filepath.Join(root, "loop.mp3"), "loop-audio")
+	st := newRealStore(t)
+
+	svc, state := qgService(t, root, st)
+	svc.SetSTTIdentity("whisper", "whisper-large-v3")
+	svc.SetTranscriptLanguage("en")
+
+	cleanF := ingest.DiscoveredFile{RelPath: "clean.mp3", SizeBytes: 11, MTimeUnix: time.Now().Unix()}
+	loopF := ingest.DiscoveredFile{RelPath: "loop.mp3", SizeBytes: 10, MTimeUnix: time.Now().Unix()}
+
+	// 1) Index a clean audio document so it becomes a cache hit on a later scan.
+	svc.SetTranscriber(&fakeTranscriber{text: "[00:00] welcome to the lecture today\n[00:02] we discuss several distinct topics in depth\n[00:05] including history geography and science across many regions"})
+	if err := svc.ProcessDocument(ctx, cleanF, nil, false); err != nil {
+		t.Fatalf("ProcessDocument(clean.mp3): %v", err)
+	}
+	if snap := state.Snapshot(); snap.Indexed != 1 || snap.Errors != 0 {
+		t.Fatalf("after clean.mp3: indexed=%d errors=%d, want indexed=1 errors=0", snap.Indexed, snap.Errors)
+	}
+
+	// 2) A quarantined document sets quarantinedThisDoc=true and does not clear it.
+	svc.SetTranscriber(&fakeTranscriber{text: strings.Repeat("thank you ", 60)})
+	if err := svc.ProcessDocument(ctx, loopF, nil, false); err != nil {
+		t.Fatalf("ProcessDocument(loop.mp3) hard-failed on a non-fatal quality-gate rejection: %v", err)
+	}
+	if snap := state.Snapshot(); snap.Indexed != 1 || snap.Errors != 1 {
+		t.Fatalf("after loop.mp3: indexed=%d errors=%d, want indexed=1 errors=1", snap.Indexed, snap.Errors)
+	}
+
+	// 3) Re-process the clean document. It is now an ok cache hit — an early-return
+	// path that credits the indexed counter WITHOUT re-entering rep generation. The
+	// stale quarantine flag from loop.mp3 must not suppress this credit, and no new
+	// error may be recorded.
+	if err := svc.ProcessDocument(ctx, cleanF, nil, false); err != nil {
+		t.Fatalf("ProcessDocument(clean.mp3 cache hit): %v", err)
+	}
+	snap := state.Snapshot()
+	if snap.Indexed != 2 {
+		t.Fatalf("cache-hit after a quarantine: indexed=%d, want 2 (flag leaked and suppressed the indexed credit)", snap.Indexed)
+	}
+	if snap.Errors != 1 {
+		t.Fatalf("cache-hit after a quarantine: errors=%d, want 1 (no error may leak across documents)", snap.Errors)
+	}
+}
+
+// TestQualityGate_TranslationRejected_WithholdsHash_BothModes pins two coupled
+// invariants for a translation-gate quarantine across BOTH the single-phase and
+// the two-phase (transcription + derivation) pipelines:
+//
+//   - FIX 2 (#402/#413): each quarantined audio document ends status=error with an
+//     EMPTY content_hash, so the next incremental run retries it. In the two-phase
+//     path the derivation pass re-reads the doc after pass 1 already stamped the
+//     hash, so recordQualityGateDocError must blank it — otherwise the unchanged
+//     -content gate would skip (never retry) the quarantined doc.
+//   - FIX 1 (#426): with two audio documents, the per-document quarantine flag is
+//     reset per document, so BOTH translation rejections are counted (errors=2). A
+//     leaked flag would suppress the second document's error accounting.
+func TestQualityGate_TranslationRejected_WithholdsHash_BothModes(t *testing.T) {
+	t.Parallel()
+	for _, twoPhase := range []bool{false, true} {
+		twoPhase := twoPhase
+		name := "single-phase"
+		if twoPhase {
+			name = "two-phase"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			root := t.TempDir()
+			mustWriteFile(t, filepath.Join(root, "audio", "one.mp3"), []byte("fake-audio-one"))
+			mustWriteFile(t, filepath.Join(root, "audio", "two.mp3"), []byte("fake-audio-two"))
+			st := newRealStore(t)
+
+			cfg := config.Config{
+				RootDir:             root,
+				StateDir:            t.TempDir(),
+				STTProvider:         "off",
+				QualityGatesEnabled: true,
+				MediaBatchTwoPhase:  twoPhase,
+			}
+			svc := mustNewIngestService(t, cfg, st)
+			state := appstate.NewIndexingState(appstate.ModeIncremental)
+			svc.SetIndexingState(state)
+			// A clean source transcript (passes the gate) with a degenerate translation
+			// (rejected by the gate).
+			svc.SetTranscriber(&fakeTranscriber{text: "[00:00] a clean source line\n[00:02] another clean line"})
+			svc.SetSTTIdentity("whisper", "whisper-large-v3")
+			svc.SetTranscriptLanguage("de")
+			svc.SetTranslator(degenerateTranslator{}, "mistral", "m", []string{"en"})
+
+			if err := svc.Run(ctx); err != nil {
+				t.Fatalf("Run: %v", err)
+			}
+
+			for _, rel := range []string{"audio/one.mp3", "audio/two.mp3"} {
+				doc := mustGetDoc(t, st, rel)
+				if doc.Status != "error" {
+					t.Fatalf("%s (%s): status=%q, want \"error\"", rel, name, doc.Status)
+				}
+				if !strings.HasPrefix(doc.ErrorMessage, "TRANSLATE_FAILED") {
+					t.Fatalf("%s (%s): error_message=%q, want it to lead with TRANSLATE_FAILED", rel, name, doc.ErrorMessage)
+				}
+				// FIX 2: the done-marker is withheld so the doc is retried next run — the
+				// same behavior in single-phase and two-phase (removing the two-phase
+				// content_hash-inconsistency limitation).
+				if doc.ContentHash != "" {
+					t.Fatalf("%s (%s): content_hash=%q, want \"\" (withheld so the quality-gate quarantine is retried in %s mode)", rel, name, doc.ContentHash, name)
+				}
+			}
+
+			// FIX 1: both documents' translation rejections are counted — the flag did
+			// not leak from the first quarantined document into the second.
+			if snap := state.Snapshot(); snap.Errors != 2 {
+				t.Fatalf("%s: run errors=%d, want 2 (both translation rejections counted; a leaked quarantine flag would suppress the second)", name, snap.Errors)
+			}
+		})
+	}
+}
+
 // TestQualityGate_Disabled_LeavesDocOK proves the master switch: with the gate
 // off (the default), even a degenerate transcript leaves the document status=ok
 // and indexed — the nil gate is a pure no-op with no document-status side effect.


### PR DESCRIPTION
Implements §8.6.6 (already in the pinned spec — no spec change): a failed output quality gate now marks the document `status=error` with the canonical §14.4 code `TRANSCRIBE_FAILED` / `OCR_FAILED` / `TRANSLATE_FAILED`, non-fatal, indexing continues.

## The gap
`screenOutputQuality` previously only quarantined the representation's **chunks** (`embedding_status=error`). It left the **document** `status="ok"`, counted it as indexed, and stamped the `content_hash` done-marker — so a degenerate STT/OCR/translation output was recorded as fully indexed and never retried, violating §8.6.6 and the §14.4 code contract (batch.go's known-follow-up note).

## Change
- `kind → canonical code`: `ocr→OCR_FAILED`, `transcript→TRANSCRIBE_FAILED`, `transcript-translation→TRANSLATE_FAILED` (new `qualityGateFailureCode`; `OCR_FAILED`/`TRANSLATE_FAILED` consts added alongside the existing manifest codes).
- On a quarantine verdict, `screenOutputQuality` now records the per-document error via the existing `persistNonFatalDocError` path, counts it once (`addErrors(1)`), records the same code on the batch-manifest outcome (§8.6.11, which has a machine-readable `error_code`), and suppresses the indexed credit. The chunk-level quarantine is preserved.
- **Canonical code persistence:** the `documents` table has no `error_code` column and §8.6.6 only requires the doc be "marked status=error with the appropriate code", so the code **leads `documents.error_message`** — queryable via `RecentFailures` (§15.6) with **no store schema change**. The manifest surface additionally carries the code in its dedicated `error_code` field.

## Invariants preserved
- **#402/#413**: the quarantined doc's `content_hash` stays withheld (the row is now `status=error`), so `finalizeContentHash`'s guard leaves the done-marker unstamped → retried next run (re-screening the cached output, not the provider — bounded cost).
- **#426**: the doc counts as exactly **one error / zero indexed**; idempotent per document, so a transcript plus several rejected translations still count once and keep the first canonical code.
- **Determinism (§8.6.6)**: the recorded message is `code + kind + enum reason` only (content-free).
- **Gate off (nil gate)**: pure no-op, no document-status side effect.

## Tests (`tests/ingest`)
Degenerate transcript / OCR / translation each end `status=error` with the matching canonical code, withheld hash, 1 error / 0 indexed, chunks quarantined (via `FailureSummary`); a clean transcript indexes normally; the disabled gate leaves `status=ok`.

## Validation
`gofmt`, `go build ./...`, `go vet ./...`, `make cyclo` (≤15), `golangci-lint run` (0 issues), and `go test ./internal/ingest/... ./internal/store/... ./tests/ingest/... ./tests/store/... ./tests/eval/...` all pass; race detector clean on the quality-gate tests.

Closes #422