### PR TITLE
feat(subtitle): media.subtitles.drop_phrases — drop hallucinated keyword-spam cues

### DIFF
--- a/internal/cli/export.go
+++ b/internal/cli/export.go
@@ -86,8 +86,16 @@ func (a *App) runExport(ctx context.Context, global globalOptions, args []string
 		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("invalid media.subtitles.glossary: %v", err))
 		return exitConfigInvalid
 	}
+	// The drop set was already validated at config load, so a parse error here is
+	// unexpected; surface it rather than silently dropping the rules.
+	drop, err := subtitle.NewDropSet(cfg.MediaSubtitlesDropPhrases)
+	if err != nil {
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("invalid media.subtitles.drop_phrases: %v", err))
+		return exitConfigInvalid
+	}
 	clean := subtitle.CleanOptions{
 		DropURLs:        cfg.MediaSubtitlesDropURLs,
+		Drop:            drop,
 		CollapseRepeats: cfg.MediaSubtitlesCollapseRepeats,
 		Glossary:        glossary,
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -527,6 +527,15 @@ type Config struct {
 	// `media.subtitles.drop_urls`). OFF by default. Only affects VTT/SRT export.
 	MediaSubtitlesDropURLs bool
 
+	// MediaSubtitlesDropPhrases is an optional list of regular expressions; an
+	// exported cue whose text is composed ENTIRELY of matches (plus punctuation)
+	// is dropped (config `media.subtitles.drop_phrases`). This removes whisper
+	// keyword-spam hallucinated over silence/music/B-roll that survives the
+	// URL-drop and consecutive-identical collapse passes, without harming real
+	// speech that merely mentions one of the words. Empty by default. Only affects
+	// VTT/SRT export.
+	MediaSubtitlesDropPhrases []string
+
 	// MediaTrimLeadingSilence opts IN to trimming leading silence from media
 	// transcripts (dir2mcp#258, config `media.trim_leading_silence`). When true
 	// and ffmpeg is available, the duration of dead air before the first speech
@@ -747,6 +756,7 @@ type fileConfig struct {
 	MediaSubtitlesTTMLAlignToleranceMS *int
 	MediaSubtitlesSMILEnabled          *bool
 	MediaSubtitlesGlossary             []string
+	MediaSubtitlesDropPhrases          []string
 	MediaSubtitlesCollapseRepeats      *int
 	MediaSubtitlesDropURLs             *bool
 	MediaTrimLeadingSilence            *bool
@@ -883,6 +893,7 @@ type persistedConfig struct {
 	MediaSubtitlesTTMLAlignToleranceMS int           `yaml:"media_subtitles_ttml_align_tolerance_ms"`
 	MediaSubtitlesSMILEnabled          bool          `yaml:"media_subtitles_smil_enabled"`
 	MediaSubtitlesGlossary             []string      `yaml:"media_subtitles_glossary"`
+	MediaSubtitlesDropPhrases          []string      `yaml:"media_subtitles_drop_phrases"`
 	MediaSubtitlesCollapseRepeats      int           `yaml:"media_subtitles_collapse_repeats"`
 	MediaSubtitlesDropURLs             bool          `yaml:"media_subtitles_drop_urls"`
 	MediaTrimLeadingSilence            bool          `yaml:"media_trim_leading_silence"`
@@ -1106,8 +1117,10 @@ func Default() Config {
 		MediaSubtitlesTTMLAlignToleranceMS: DefaultMediaSubtitlesAlignToleranceMS,
 		MediaSubtitlesSMILEnabled:          false,
 		// Export-time cue cleaning (clean_srt.py port) is OFF by default: no
-		// glossary rewrites, no repetition-collapse (< 2 disables), no URL drop.
+		// glossary rewrites, no phrase drops, no repetition-collapse (< 2
+		// disables), no URL drop.
 		MediaSubtitlesGlossary:        nil,
+		MediaSubtitlesDropPhrases:     nil,
 		MediaSubtitlesCollapseRepeats: 0,
 		MediaSubtitlesDropURLs:        false,
 		ServerTLSCertFile:             "",
@@ -1236,6 +1249,7 @@ func buildPersistedConfig(cfg *Config) persistedConfig {
 		MediaSubtitlesTTMLAlignToleranceMS: cfg.MediaSubtitlesTTMLAlignToleranceMS,
 		MediaSubtitlesSMILEnabled:          cfg.MediaSubtitlesSMILEnabled,
 		MediaSubtitlesGlossary:             append([]string(nil), cfg.MediaSubtitlesGlossary...),
+		MediaSubtitlesDropPhrases:          append([]string(nil), cfg.MediaSubtitlesDropPhrases...),
 		MediaSubtitlesCollapseRepeats:      cfg.MediaSubtitlesCollapseRepeats,
 		MediaSubtitlesDropURLs:             cfg.MediaSubtitlesDropURLs,
 		MediaTrimLeadingSilence:            cfg.MediaTrimLeadingSilence,
@@ -2063,6 +2077,9 @@ func applyMediaSubtitlesFileParsed(cfg *Config, fc fileConfig) {
 	if fc.MediaSubtitlesGlossary != nil {
 		cfg.MediaSubtitlesGlossary = normalizeStringSlice(fc.MediaSubtitlesGlossary)
 	}
+	if fc.MediaSubtitlesDropPhrases != nil {
+		cfg.MediaSubtitlesDropPhrases = normalizeStringSlice(fc.MediaSubtitlesDropPhrases)
+	}
 	if fc.MediaSubtitlesCollapseRepeats != nil {
 		cfg.MediaSubtitlesCollapseRepeats = *fc.MediaSubtitlesCollapseRepeats
 	}
@@ -2372,6 +2389,7 @@ var configKeyAliases = map[string]string{
 	"media_subtitles_ttml_align_tolerance_ms": "media.subtitles.ttml.align_tolerance_ms",
 	"media_subtitles_smil_enabled":            "media.subtitles.smil.enabled",
 	"media_subtitles_glossary":                "media.subtitles.glossary",
+	"media_subtitles_drop_phrases":            "media.subtitles.drop_phrases",
 	"media_subtitles_collapse_repeats":        "media.subtitles.collapse_repeats",
 	"media_subtitles_drop_urls":               "media.subtitles.drop_urls",
 	"media_trim_leading_silence":              "media.trim_leading_silence",
@@ -2881,6 +2899,8 @@ func setFileListValue(cfg *fileConfig, key, value string) {
 		appendValue(&cfg.MediaFilterWords, value)
 	case "media.subtitles.glossary":
 		appendValue(&cfg.MediaSubtitlesGlossary, value)
+	case "media.subtitles.drop_phrases":
+		appendValue(&cfg.MediaSubtitlesDropPhrases, value)
 	case "retrieval.cross_lingual.target_langs":
 		appendValue(&cfg.CrossLingualTargetLangs, value)
 	}
@@ -2891,7 +2911,7 @@ func setFileListValue(cfg *fileConfig, key, value string) {
 func isListConfigKey(key string) bool {
 	key = canonicalizeConfigKey(key)
 	switch key {
-	case "trusted_proxies", "path_excludes", "secret_patterns", "allowed_origins", "media.translate.target_langs", "media.filter_words", "media.subtitles.glossary", "retrieval.cross_lingual.target_langs":
+	case "trusted_proxies", "path_excludes", "secret_patterns", "allowed_origins", "media.translate.target_langs", "media.filter_words", "media.subtitles.glossary", "media.subtitles.drop_phrases", "retrieval.cross_lingual.target_langs":
 		return true
 	default:
 		return false
@@ -3009,6 +3029,7 @@ func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	writeInt("media_subtitles_ttml_align_tolerance_ms", cfg.MediaSubtitlesTTMLAlignToleranceMS)
 	writeBool("media_subtitles_smil_enabled", cfg.MediaSubtitlesSMILEnabled)
 	writeList("media_subtitles_glossary", cfg.MediaSubtitlesGlossary)
+	writeList("media_subtitles_drop_phrases", cfg.MediaSubtitlesDropPhrases)
 	writeInt("media_subtitles_collapse_repeats", cfg.MediaSubtitlesCollapseRepeats)
 	writeBool("media_subtitles_drop_urls", cfg.MediaSubtitlesDropURLs)
 	writeBool("media_trim_leading_silence", cfg.MediaTrimLeadingSilence)
@@ -3733,6 +3754,11 @@ func (c *Config) validateMediaSubtitles() error {
 	// is the single source of truth for the entry grammar.
 	if _, err := subtitle.NewGlossary(c.MediaSubtitlesGlossary); err != nil {
 		return fmt.Errorf("media.subtitles.glossary: %w", err)
+	}
+	// Fail fast on a malformed drop phrase (invalid regexp) at config time rather
+	// than at export time. subtitle.NewDropSet owns the pattern grammar.
+	if _, err := subtitle.NewDropSet(c.MediaSubtitlesDropPhrases); err != nil {
+		return fmt.Errorf("media.subtitles.drop_phrases: %w", err)
 	}
 	return nil
 }

--- a/internal/subtitle/clean.go
+++ b/internal/subtitle/clean.go
@@ -132,6 +132,65 @@ func (g *Glossary) Apply(text string) string {
 	return text
 }
 
+// DropSet drops a whole cue when its text is composed ENTIRELY of configured
+// hallucination phrases (plus punctuation/whitespace). Whisper spams a fixed
+// phrase over silence/music/B-roll — e.g. "Донбасс, Крым, Украина, НАТО" — and
+// broadcast segmentation fragments it across cue boundaries, so neither the
+// URL-drop nor the consecutive-identical CollapseRepeats pass catches it. A drop
+// rule removes such cues WITHOUT harming real speech that merely mentions one of
+// the words: a cue survives as long as any non-phrase letters/digits remain
+// after the phrase matches are stripped (so "Крым сегодня" is kept, "Крым, НАТО"
+// is dropped). Rules come entirely from configuration
+// (media.subtitles.drop_phrases); an empty set is a no-op. Each entry is a
+// case-insensitive regular expression matched anywhere in the cue.
+type DropSet struct {
+	res []*regexp.Regexp
+}
+
+// dropResidualRE matches any letter or digit; a cue with none remaining after
+// phrase-stripping is treated as pure hallucination and dropped.
+var dropResidualRE = regexp.MustCompile(`[\p{L}\p{N}]`)
+
+// NewDropSet compiles drop-phrase patterns. Whitespace around each entry is
+// trimmed and blank entries are skipped. Each pattern is compiled
+// case-insensitively, so an invalid pattern is a configuration error (returned
+// here) rather than a silent no-op. A nil/empty list yields an inactive set.
+func NewDropSet(entries []string) (*DropSet, error) {
+	d := &DropSet{}
+	for _, e := range entries {
+		e = strings.TrimSpace(e)
+		if e == "" {
+			continue
+		}
+		re, err := regexp.Compile(`(?i)` + e)
+		if err != nil {
+			return nil, fmt.Errorf("drop phrase %q: invalid pattern: %w", e, err)
+		}
+		d.res = append(d.res, re)
+	}
+	return d, nil
+}
+
+// Active reports whether the set has any rules. When false, IsSpam is always
+// false and callers can skip it.
+func (d *DropSet) Active() bool {
+	return d != nil && len(d.res) > 0
+}
+
+// IsSpam reports whether text is composed entirely of configured drop phrases:
+// removing every phrase match leaves no letters or digits behind. An inactive
+// set never reports spam.
+func (d *DropSet) IsSpam(text string) bool {
+	if !d.Active() {
+		return false
+	}
+	stripped := text
+	for _, re := range d.res {
+		stripped = re.ReplaceAllString(stripped, " ")
+	}
+	return !dropResidualRE.MatchString(stripped)
+}
+
 // CleanOptions configures the export-time cue-cleaning pass (port of the pilot's
 // clean_srt.py). All fields are additive and off by default, so a zero
 // CleanOptions leaves cues unchanged. It is applied AFTER WordFilter on export,
@@ -140,6 +199,9 @@ type CleanOptions struct {
 	// DropURLs drops any cue whose text looks like a hallucinated URL / domain /
 	// credit line (whisper emits these over silence or music).
 	DropURLs bool
+	// Drop drops any cue composed entirely of configured hallucination phrases
+	// (whisper keyword-spam over non-speech). Nil/inactive = no drops.
+	Drop *DropSet
 	// CollapseRepeats drops the Nth-and-later cue in a run of identical
 	// consecutive cues (a whisper repetition-collapse artifact), keeping the
 	// first N-1. A value < 2 disables the pass, so legitimate short repeats
@@ -152,7 +214,7 @@ type CleanOptions struct {
 // Active reports whether any cleaning is configured. When false, CleanCues
 // returns its input unchanged so the empty-config export path is a no-op.
 func (o CleanOptions) Active() bool {
-	return o.DropURLs || o.CollapseRepeats >= 2 || o.Glossary.Active()
+	return o.DropURLs || o.Drop.Active() || o.CollapseRepeats >= 2 || o.Glossary.Active()
 }
 
 // urlCueRE matches a hallucinated URL / bare domain in cue text (whisper emits
@@ -186,6 +248,9 @@ func CleanCues(cues []Cue, opts CleanOptions) []Cue {
 			continue
 		}
 		if opts.DropURLs && urlCueRE.MatchString(text) {
+			continue
+		}
+		if opts.Drop.IsSpam(text) {
 			continue
 		}
 		// Repetition-collapse compares the pre-glossary text so a rewrite cannot

--- a/tests/cli/export_clean_test.go
+++ b/tests/cli/export_clean_test.go
@@ -54,7 +54,8 @@ func seedCleanExportStore(t *testing.T, stateDir, relPath string) {
 			{"No.", 4000, 5000},                       // 3rd -> dropped (threshold 3)
 			{"No.", 5000, 6000},                       // 4th -> dropped
 			{"Subtitles by www.spam.com", 6000, 8000}, // URL -> dropped
-			{"Real closing line", 8000, 10000},
+			{"Crimea, NATO.", 8000, 9000},             // phrase-only -> dropped by drop_phrases
+			{"Real closing line", 9000, 10000},
 		}
 		for i, c := range chunks {
 			if _, err := tx.InsertChunkWithSpans(ctx,
@@ -82,6 +83,8 @@ func TestExportAppliesCueCleaning(t *testing.T) {
 		"  subtitles:",
 		"    glossary:",
 		"      - Aju?bei=>Adzhubei",
+		"    drop_phrases:",
+		"      - Crimea|NATO",
 		"    collapse_repeats: 3",
 		"    drop_urls: true",
 	}, "\n") + "\n"
@@ -107,6 +110,9 @@ func TestExportAppliesCueCleaning(t *testing.T) {
 	}
 	if n := strings.Count(out, "No."); n != 2 {
 		t.Errorf("repetition-collapse: got %d 'No.' cues, want 2:\n%s", n, out)
+	}
+	if strings.Contains(out, "Crimea, NATO") {
+		t.Errorf("phrase-only cue not dropped by drop_phrases:\n%s", out)
 	}
 	if !strings.Contains(out, "Real closing line") {
 		t.Errorf("real closing cue missing:\n%s", out)
@@ -137,5 +143,8 @@ func TestExportNoCleaningConfigUnchanged(t *testing.T) {
 	}
 	if n := strings.Count(out, "No."); n != 4 {
 		t.Errorf("without config all 4 'No.' cues should survive, got %d:\n%s", n, out)
+	}
+	if !strings.Contains(out, "Crimea, NATO") {
+		t.Errorf("without config the phrase-only cue should survive:\n%s", out)
 	}
 }

--- a/tests/config/media_subtitles_config_test.go
+++ b/tests/config/media_subtitles_config_test.go
@@ -38,6 +38,7 @@ func TestMediaSubtitles_RoundTrip(t *testing.T) {
 	cfg.MediaSubtitlesSMILEnabled = true
 	cfg.MediaSubtitlesTTMLAlignToleranceMS = 1800
 	cfg.MediaSubtitlesGlossary = []string{"Aju?bei=>Adzhubei"}
+	cfg.MediaSubtitlesDropPhrases = []string{"Донбасс|Крым|НАТО"}
 	cfg.MediaSubtitlesCollapseRepeats = 3
 	cfg.MediaSubtitlesDropURLs = true
 
@@ -57,6 +58,9 @@ func TestMediaSubtitles_RoundTrip(t *testing.T) {
 	if len(loaded.MediaSubtitlesGlossary) != 1 || loaded.MediaSubtitlesGlossary[0] != "Aju?bei=>Adzhubei" {
 		t.Fatalf("glossary did not round-trip: %#v", loaded.MediaSubtitlesGlossary)
 	}
+	if len(loaded.MediaSubtitlesDropPhrases) != 1 || loaded.MediaSubtitlesDropPhrases[0] != "Донбасс|Крым|НАТО" {
+		t.Fatalf("drop_phrases did not round-trip: %#v", loaded.MediaSubtitlesDropPhrases)
+	}
 	if loaded.MediaSubtitlesCollapseRepeats != 3 {
 		t.Fatalf("collapse_repeats = %d, want 3", loaded.MediaSubtitlesCollapseRepeats)
 	}
@@ -71,6 +75,9 @@ func TestMediaSubtitlesCleaning_DefaultsOff(t *testing.T) {
 	cfg := config.Default()
 	if len(cfg.MediaSubtitlesGlossary) != 0 {
 		t.Fatalf("glossary should default empty, got %#v", cfg.MediaSubtitlesGlossary)
+	}
+	if len(cfg.MediaSubtitlesDropPhrases) != 0 {
+		t.Fatalf("drop_phrases should default empty, got %#v", cfg.MediaSubtitlesDropPhrases)
 	}
 	if cfg.MediaSubtitlesCollapseRepeats != 0 {
 		t.Fatalf("collapse_repeats should default 0, got %d", cfg.MediaSubtitlesCollapseRepeats)
@@ -96,6 +103,8 @@ func TestMediaSubtitlesCleaning_NestedYAMLApplies(t *testing.T) {
 		"    glossary:",
 		"      - Aju?bei=>Adzhubei",
 		"      - Khruschev=>Khrushchev",
+		"    drop_phrases:",
+		"      - Донбасс|Крым|Украина|Иван|Плющ|НАТО",
 		"    collapse_repeats: 3",
 		"    drop_urls: true",
 	}, "\n")+"\n")
@@ -106,6 +115,9 @@ func TestMediaSubtitlesCleaning_NestedYAMLApplies(t *testing.T) {
 	}
 	if len(cfg.MediaSubtitlesGlossary) != 2 {
 		t.Fatalf("nested glossary not applied: %#v", cfg.MediaSubtitlesGlossary)
+	}
+	if len(cfg.MediaSubtitlesDropPhrases) != 1 {
+		t.Fatalf("nested drop_phrases not applied: %#v", cfg.MediaSubtitlesDropPhrases)
 	}
 	if cfg.MediaSubtitlesCollapseRepeats != 3 {
 		t.Fatalf("nested collapse_repeats = %d, want 3", cfg.MediaSubtitlesCollapseRepeats)
@@ -134,6 +146,12 @@ func TestMediaSubtitlesCleaning_RejectsBadConfig(t *testing.T) {
 	badN.MediaSubtitlesCollapseRepeats = -1
 	if err := badN.Validate(); err == nil {
 		t.Fatalf("negative collapse_repeats should be rejected")
+	}
+
+	badDrop := config.Default()
+	badDrop.MediaSubtitlesDropPhrases = []string{"a(b"}
+	if err := badDrop.Validate(); err == nil {
+		t.Fatalf("invalid drop_phrases regexp should be rejected")
 	}
 }
 

--- a/tests/subtitle/clean_test.go
+++ b/tests/subtitle/clean_test.go
@@ -75,6 +75,85 @@ func TestGlossaryInactiveAndErrors(t *testing.T) {
 	}
 }
 
+// TestDropSetSpamDetection pins the drop-phrase semantics: a cue composed
+// ENTIRELY of configured phrases (plus punctuation) is spam, while a cue that
+// also carries real words survives, and an inactive set never flags spam.
+func TestDropSetSpamDetection(t *testing.T) {
+	d, err := subtitle.NewDropSet([]string{"Донбасс|Крым|Украина|Иван|Плющ|НАТО"})
+	if err != nil {
+		t.Fatalf("NewDropSet: %v", err)
+	}
+	if !d.Active() {
+		t.Fatalf("drop set with one rule should be active")
+	}
+	spam := []string{
+		"Донбасс, Крым, Украина, Иван Плющ, НАТО.",
+		"НАТО.",
+		"Крым, НАТО",
+		"украина", // case-insensitive
+	}
+	for _, s := range spam {
+		if !d.IsSpam(s) {
+			t.Errorf("IsSpam(%q) = false, want true", s)
+		}
+	}
+	keep := []string{
+		"Крым сегодня, нет Крыма.", // real words remain
+		"Что дальше будет, никто не знает.",
+		"Иван Плющ был депутатом.", // "был депутатом" survives
+	}
+	for _, s := range keep {
+		if d.IsSpam(s) {
+			t.Errorf("IsSpam(%q) = true, want false", s)
+		}
+	}
+}
+
+// TestDropSetInactiveAndErrors pins that an empty set is inactive (never spam)
+// and that an invalid regexp is rejected at construction.
+func TestDropSetInactiveAndErrors(t *testing.T) {
+	empty, err := subtitle.NewDropSet(nil)
+	if err != nil {
+		t.Fatalf("NewDropSet(nil): %v", err)
+	}
+	if empty.Active() {
+		t.Fatalf("nil drop set should be inactive")
+	}
+	if empty.IsSpam("НАТО.") {
+		t.Fatalf("inactive drop set flagged spam")
+	}
+	if _, err := subtitle.NewDropSet([]string{"a(b"}); err == nil {
+		t.Fatalf("invalid regexp should error")
+	}
+}
+
+// TestCleanCuesDropsPhrases pins that CleanCues drops phrase-only cues while
+// keeping cues that mix a phrase word with real speech, and re-indexes gap-free.
+func TestCleanCuesDropsPhrases(t *testing.T) {
+	d, err := subtitle.NewDropSet([]string{"Крым|НАТО"})
+	if err != nil {
+		t.Fatalf("NewDropSet: %v", err)
+	}
+	cues := []subtitle.Cue{
+		{Index: 1, StartMS: 0, EndMS: 1000, Text: "Крым, НАТО."},
+		{Index: 2, StartMS: 1000, EndMS: 2000, Text: "Крым сегодня наш дом."},
+		{Index: 3, StartMS: 2000, EndMS: 3000, Text: "НАТО"},
+		{Index: 4, StartMS: 3000, EndMS: 4000, Text: "Real speech here"},
+	}
+	got := subtitle.CleanCues(cues, subtitle.CleanOptions{Drop: d})
+	if len(got) != 2 {
+		t.Fatalf("expected 2 surviving cues, got %d: %+v", len(got), got)
+	}
+	if got[0].Text != "Крым сегодня наш дом." || got[1].Text != "Real speech here" {
+		t.Fatalf("wrong cues survived: %+v", got)
+	}
+	for i := range got {
+		if got[i].Index != i+1 {
+			t.Errorf("survivor %d has Index %d, want %d", i, got[i].Index, i+1)
+		}
+	}
+}
+
 // TestCleanCuesInactiveIsIdentity pins that a zero CleanOptions returns cues
 // unchanged (same order, same content), so the empty-config path is a no-op.
 func TestCleanCuesInactiveIsIdentity(t *testing.T) {


### PR DESCRIPTION
## What

Adds an export-time cue-cleaning pass, `media.subtitles.drop_phrases`, that drops a cue whose text is composed **entirely** of configured phrase matches (plus punctuation). Any real word beyond the phrase keeps the cue — so `"Крым сегодня"` survives while `"Крым, НАТО"` is dropped.

Stacks on #534 (glossary / collapse / URL-drop); `DropSet` sits alongside `Glossary` in `clean.go`.

## Why

On real RFE/RL interview audio, Whisper's **transcribe** pass hallucinates a fixed keyword phrase over silence / music / B-roll (e.g. `"Донбасс, Крым, Украина, Иван Плющ, НАТО"`) and repeats it. Measured spam share of two originals: **~35%** (166/474 cues) and **~36%** (71/197). `collapse_repeats` can't catch it — broadcast segmentation fragments the phrase across cue boundaries so consecutive cues aren't identical — and the glossary only rewrites, never drops. The translate (EN) pass doesn't hallucinate the same way, so this is transcribe-track-specific.

## How

- `subtitle.DropSet` (`NewDropSet` / `Active` / `IsSpam`): a cue is spam iff stripping every configured phrase match leaves no letters/digits behind. Wired into `CleanOptions` / `CleanCues` after `DropURLs`, before `CollapseRepeats`.
- `config media.subtitles.drop_phrases` (`[]string` of regexps): full plumbing mirroring `media.subtitles.glossary` — runtime field, fileConfig overlay, `Default`, `Snapshot`, nested-YAML apply, dotted-key alias + list-append + section allowlist, serialize, fail-fast regex validation.

## Tests

- `DropSet` semantics (spam vs. real-word survival, inactive no-op, invalid-regex reject)
- `CleanCues` drop + gap-free re-index
- config round-trip / nested-YAML / bad-regex reject
- end-to-end `export` drop path

`gofmt` + `go vet` clean; `go build ./...` OK; subtitle/config suites green.

## Checklist

- [x] `coderabbit review` run — no findings in this diff (reviewed as part of the integration superset; the 6 findings it surfaced are all in `internal/ingest/service.go` and `internal/quality/detectors.go`, which belong to the #509/#515 translate work, not this change)
- [x] New behavior has test coverage
- [x] No unrelated files changed