### PR TITLE
feat(subtitle): media.subtitles.scrub_phrases — excise leaked hallucination phrases

### DIFF
--- a/internal/cli/export.go
+++ b/internal/cli/export.go
@@ -93,9 +93,17 @@ func (a *App) runExport(ctx context.Context, global globalOptions, args []string
 		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("invalid media.subtitles.drop_phrases: %v", err))
 		return exitConfigInvalid
 	}
+	// The scrub set was already validated at config load, so a parse error here is
+	// unexpected; surface it rather than silently dropping the rules.
+	scrub, err := subtitle.NewDropSet(cfg.MediaSubtitlesScrubPhrases)
+	if err != nil {
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("invalid media.subtitles.scrub_phrases: %v", err))
+		return exitConfigInvalid
+	}
 	clean := subtitle.CleanOptions{
 		DropURLs:        cfg.MediaSubtitlesDropURLs,
 		Drop:            drop,
+		Scrub:           scrub,
 		CollapseRepeats: cfg.MediaSubtitlesCollapseRepeats,
 		Glossary:        glossary,
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -546,6 +546,15 @@ type Config struct {
 	// VTT/SRT export.
 	MediaSubtitlesDropPhrases []string
 
+	// MediaSubtitlesScrubPhrases is an optional list of regular expressions
+	// EXCISED from exported cue text (config `media.subtitles.scrub_phrases`).
+	// Unlike drop_phrases (a whole-cue verdict), a scrub removes just the matched
+	// phrase from a cue that also carries real speech — for a hallucinated phrase
+	// that leaked into the same cue as genuine words. Configure with the full
+	// contiguous phrase so legitimate mentions of a single word are untouched. A
+	// cue that scrubs to empty is dropped. Empty by default. Only affects VTT/SRT.
+	MediaSubtitlesScrubPhrases []string
+
 	// MediaTrimLeadingSilence opts IN to trimming leading silence from media
 	// transcripts (dir2mcp#258, config `media.trim_leading_silence`). When true
 	// and ffmpeg is available, the duration of dead air before the first speech
@@ -768,6 +777,7 @@ type fileConfig struct {
 	MediaSubtitlesSegmentation         *string
 	MediaSubtitlesGlossary             []string
 	MediaSubtitlesDropPhrases          []string
+	MediaSubtitlesScrubPhrases         []string
 	MediaSubtitlesCollapseRepeats      *int
 	MediaSubtitlesDropURLs             *bool
 	MediaTrimLeadingSilence            *bool
@@ -906,6 +916,7 @@ type persistedConfig struct {
 	MediaSubtitlesSegmentation         string        `yaml:"media_subtitles_segmentation"`
 	MediaSubtitlesGlossary             []string      `yaml:"media_subtitles_glossary"`
 	MediaSubtitlesDropPhrases          []string      `yaml:"media_subtitles_drop_phrases"`
+	MediaSubtitlesScrubPhrases         []string      `yaml:"media_subtitles_scrub_phrases"`
 	MediaSubtitlesCollapseRepeats      int           `yaml:"media_subtitles_collapse_repeats"`
 	MediaSubtitlesDropURLs             bool          `yaml:"media_subtitles_drop_urls"`
 	MediaTrimLeadingSilence            bool          `yaml:"media_trim_leading_silence"`
@@ -1134,6 +1145,7 @@ func Default() Config {
 		// disables), no URL drop.
 		MediaSubtitlesGlossary:        nil,
 		MediaSubtitlesDropPhrases:     nil,
+		MediaSubtitlesScrubPhrases:    nil,
 		MediaSubtitlesCollapseRepeats: 0,
 		MediaSubtitlesDropURLs:        false,
 		ServerTLSCertFile:             "",
@@ -1264,6 +1276,7 @@ func buildPersistedConfig(cfg *Config) persistedConfig {
 		MediaSubtitlesSegmentation:         cfg.MediaSubtitlesSegmentation,
 		MediaSubtitlesGlossary:             append([]string(nil), cfg.MediaSubtitlesGlossary...),
 		MediaSubtitlesDropPhrases:          append([]string(nil), cfg.MediaSubtitlesDropPhrases...),
+		MediaSubtitlesScrubPhrases:         append([]string(nil), cfg.MediaSubtitlesScrubPhrases...),
 		MediaSubtitlesCollapseRepeats:      cfg.MediaSubtitlesCollapseRepeats,
 		MediaSubtitlesDropURLs:             cfg.MediaSubtitlesDropURLs,
 		MediaTrimLeadingSilence:            cfg.MediaTrimLeadingSilence,
@@ -2097,6 +2110,9 @@ func applyMediaSubtitlesFileParsed(cfg *Config, fc fileConfig) {
 	if fc.MediaSubtitlesDropPhrases != nil {
 		cfg.MediaSubtitlesDropPhrases = normalizeStringSlice(fc.MediaSubtitlesDropPhrases)
 	}
+	if fc.MediaSubtitlesScrubPhrases != nil {
+		cfg.MediaSubtitlesScrubPhrases = normalizeStringSlice(fc.MediaSubtitlesScrubPhrases)
+	}
 	if fc.MediaSubtitlesCollapseRepeats != nil {
 		cfg.MediaSubtitlesCollapseRepeats = *fc.MediaSubtitlesCollapseRepeats
 	}
@@ -2408,6 +2424,7 @@ var configKeyAliases = map[string]string{
 	"media_subtitles_segmentation":            "media.subtitles.segmentation",
 	"media_subtitles_glossary":                "media.subtitles.glossary",
 	"media_subtitles_drop_phrases":            "media.subtitles.drop_phrases",
+	"media_subtitles_scrub_phrases":           "media.subtitles.scrub_phrases",
 	"media_subtitles_collapse_repeats":        "media.subtitles.collapse_repeats",
 	"media_subtitles_drop_urls":               "media.subtitles.drop_urls",
 	"media_trim_leading_silence":              "media.trim_leading_silence",
@@ -2921,6 +2938,8 @@ func setFileListValue(cfg *fileConfig, key, value string) {
 		appendValue(&cfg.MediaSubtitlesGlossary, value)
 	case "media.subtitles.drop_phrases":
 		appendValue(&cfg.MediaSubtitlesDropPhrases, value)
+	case "media.subtitles.scrub_phrases":
+		appendValue(&cfg.MediaSubtitlesScrubPhrases, value)
 	case "retrieval.cross_lingual.target_langs":
 		appendValue(&cfg.CrossLingualTargetLangs, value)
 	}
@@ -2931,7 +2950,7 @@ func setFileListValue(cfg *fileConfig, key, value string) {
 func isListConfigKey(key string) bool {
 	key = canonicalizeConfigKey(key)
 	switch key {
-	case "trusted_proxies", "path_excludes", "secret_patterns", "allowed_origins", "media.translate.target_langs", "media.filter_words", "media.subtitles.glossary", "media.subtitles.drop_phrases", "retrieval.cross_lingual.target_langs":
+	case "trusted_proxies", "path_excludes", "secret_patterns", "allowed_origins", "media.translate.target_langs", "media.filter_words", "media.subtitles.glossary", "media.subtitles.drop_phrases", "media.subtitles.scrub_phrases", "retrieval.cross_lingual.target_langs":
 		return true
 	default:
 		return false
@@ -3051,6 +3070,7 @@ func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	writeScalar("media_subtitles_segmentation", cfg.MediaSubtitlesSegmentation)
 	writeList("media_subtitles_glossary", cfg.MediaSubtitlesGlossary)
 	writeList("media_subtitles_drop_phrases", cfg.MediaSubtitlesDropPhrases)
+	writeList("media_subtitles_scrub_phrases", cfg.MediaSubtitlesScrubPhrases)
 	writeInt("media_subtitles_collapse_repeats", cfg.MediaSubtitlesCollapseRepeats)
 	writeBool("media_subtitles_drop_urls", cfg.MediaSubtitlesDropURLs)
 	writeBool("media_trim_leading_silence", cfg.MediaTrimLeadingSilence)
@@ -3791,6 +3811,9 @@ func (c *Config) validateMediaSubtitles() error {
 	// than at export time. subtitle.NewDropSet owns the pattern grammar.
 	if _, err := subtitle.NewDropSet(c.MediaSubtitlesDropPhrases); err != nil {
 		return fmt.Errorf("media.subtitles.drop_phrases: %w", err)
+	}
+	if _, err := subtitle.NewDropSet(c.MediaSubtitlesScrubPhrases); err != nil {
+		return fmt.Errorf("media.subtitles.scrub_phrases: %w", err)
 	}
 	return nil
 }

--- a/internal/subtitle/clean.go
+++ b/internal/subtitle/clean.go
@@ -191,6 +191,41 @@ func (d *DropSet) IsSpam(text string) bool {
 	return !dropResidualRE.MatchString(stripped)
 }
 
+// scrubSpaceRE collapses runs of spaces/tabs left behind after a phrase is
+// excised. It deliberately excludes '\n' so an intentional two-line wrap survives
+// the scrub (CleanCues runs after wrapping).
+var scrubSpaceRE = regexp.MustCompile(`[ \t]+`)
+
+// Scrub removes every configured phrase match from text and tidies the result.
+// Unlike IsSpam (a whole-cue verdict), Scrub is used when a hallucinated phrase is
+// glued to REAL speech in the same cue — it excises just the phrase and keeps the
+// sentence. It is a strict no-op when no phrase matches (so the vast majority of
+// cues, including their line-wrap newline, pass through byte-for-byte). Because a
+// Scrub set is configured with the FULL contiguous hallucination phrase (not a
+// word alternation), it never touches a legitimate mention of one of the words.
+func (d *DropSet) Scrub(text string) string {
+	if !d.Active() {
+		return text
+	}
+	matched := false
+	for _, re := range d.res {
+		if re.MatchString(text) {
+			text = re.ReplaceAllString(text, " ")
+			matched = true
+		}
+	}
+	if !matched {
+		return text
+	}
+	// Collapse only spaces/tabs (never the wrap newline), then strip connective
+	// punctuation orphaned at either end by the excision (a leading ", " or a
+	// dangling "—"), keeping sentence-final "." "!" "?" so the surviving sentence
+	// is not de-punctuated.
+	text = scrubSpaceRE.ReplaceAllString(text, " ")
+	text = strings.TrimSpace(text)
+	return strings.TrimSpace(strings.Trim(text, ",;:—- "))
+}
+
 // CleanOptions configures the export-time cue-cleaning pass (port of the pilot's
 // clean_srt.py). All fields are additive and off by default, so a zero
 // CleanOptions leaves cues unchanged. It is applied AFTER WordFilter on export,
@@ -202,6 +237,10 @@ type CleanOptions struct {
 	// Drop drops any cue composed entirely of configured hallucination phrases
 	// (whisper keyword-spam over non-speech). Nil/inactive = no drops.
 	Drop *DropSet
+	// Scrub excises configured hallucination phrases from cues that ALSO carry
+	// real speech (the phrase leaked into the same cue), keeping the sentence.
+	// Configure with the full contiguous phrase. Nil/inactive = no scrubbing.
+	Scrub *DropSet
 	// CollapseRepeats drops the Nth-and-later cue in a run of identical
 	// consecutive cues (a whisper repetition-collapse artifact), keeping the
 	// first N-1. A value < 2 disables the pass, so legitimate short repeats
@@ -214,7 +253,7 @@ type CleanOptions struct {
 // Active reports whether any cleaning is configured. When false, CleanCues
 // returns its input unchanged so the empty-config export path is a no-op.
 func (o CleanOptions) Active() bool {
-	return o.DropURLs || o.Drop.Active() || o.CollapseRepeats >= 2 || o.Glossary.Active()
+	return o.DropURLs || o.Drop.Active() || o.Scrub.Active() || o.CollapseRepeats >= 2 || o.Glossary.Active()
 }
 
 // urlCueRE matches a hallucinated URL / bare domain in cue text (whisper emits
@@ -252,6 +291,15 @@ func CleanCues(cues []Cue, opts CleanOptions) []Cue {
 		}
 		if opts.Drop.IsSpam(text) {
 			continue
+		}
+		// Excise a hallucinated phrase that leaked into an otherwise-real cue,
+		// then re-check for emptiness (a cue that was ALL phrase plus punctuation
+		// scrubs to nothing and is dropped).
+		if opts.Scrub.Active() {
+			text = opts.Scrub.Scrub(text)
+			if text == "" {
+				continue
+			}
 		}
 		// Repetition-collapse compares the pre-glossary text so a rewrite cannot
 		// mask a collapse run. The comparison anchor (runText) updates only when

--- a/tests/cli/export_clean_test.go
+++ b/tests/cli/export_clean_test.go
@@ -51,11 +51,12 @@ func seedCleanExportStore(t *testing.T, stateDir, relPath string) {
 			{"Letter signed by Ajubei", 0, 2000}, // glossary -> Adzhubei
 			{"No.", 2000, 3000},                  // run of 4 identical "No."
 			{"No.", 3000, 4000},
-			{"No.", 4000, 5000},                       // 3rd -> dropped (threshold 3)
-			{"No.", 5000, 6000},                       // 4th -> dropped
-			{"Subtitles by www.spam.com", 6000, 8000}, // URL -> dropped
-			{"Crimea, NATO.", 8000, 9000},             // phrase-only -> dropped by drop_phrases
-			{"Real closing line", 9000, 10000},
+			{"No.", 4000, 5000},                           // 3rd -> dropped (threshold 3)
+			{"No.", 5000, 6000},                           // 4th -> dropped
+			{"Subtitles by www.spam.com", 6000, 8000},     // URL -> dropped
+			{"Crimea, NATO.", 8000, 9000},                 // phrase-only -> dropped by drop_phrases
+			{"Crimea, NATO. Genuine words.", 9000, 10000}, // leaked phrase -> scrubbed, sentence kept
+			{"Real closing line", 10000, 11000},
 		}
 		for i, c := range chunks {
 			if _, err := tx.InsertChunkWithSpans(ctx,
@@ -85,6 +86,8 @@ func TestExportAppliesCueCleaning(t *testing.T) {
 		"      - Aju?bei=>Adzhubei",
 		"    drop_phrases:",
 		"      - Crimea|NATO",
+		"    scrub_phrases:",
+		"      - Crimea,?\\s*NATO\\.?",
 		"    collapse_repeats: 3",
 		"    drop_urls: true",
 	}, "\n") + "\n"
@@ -112,7 +115,10 @@ func TestExportAppliesCueCleaning(t *testing.T) {
 		t.Errorf("repetition-collapse: got %d 'No.' cues, want 2:\n%s", n, out)
 	}
 	if strings.Contains(out, "Crimea, NATO") {
-		t.Errorf("phrase-only cue not dropped by drop_phrases:\n%s", out)
+		t.Errorf("phrase not removed (drop_phrases + scrub_phrases):\n%s", out)
+	}
+	if !strings.Contains(out, "Genuine words.") {
+		t.Errorf("scrub_phrases dropped the whole leaked cue instead of keeping the sentence:\n%s", out)
 	}
 	if !strings.Contains(out, "Real closing line") {
 		t.Errorf("real closing cue missing:\n%s", out)

--- a/tests/config/media_subtitles_config_test.go
+++ b/tests/config/media_subtitles_config_test.go
@@ -110,6 +110,7 @@ func TestMediaSubtitles_RoundTrip(t *testing.T) {
 	cfg.MediaSubtitlesSegmentation = "broadcast"
 	cfg.MediaSubtitlesGlossary = []string{"Aju?bei=>Adzhubei"}
 	cfg.MediaSubtitlesDropPhrases = []string{"Донбасс|Крым|НАТО"}
+	cfg.MediaSubtitlesScrubPhrases = []string{`Крым,?\s*НАТО`}
 	cfg.MediaSubtitlesCollapseRepeats = 3
 	cfg.MediaSubtitlesDropURLs = true
 
@@ -135,6 +136,9 @@ func TestMediaSubtitles_RoundTrip(t *testing.T) {
 	if len(loaded.MediaSubtitlesDropPhrases) != 1 || loaded.MediaSubtitlesDropPhrases[0] != "Донбасс|Крым|НАТО" {
 		t.Fatalf("drop_phrases did not round-trip: %#v", loaded.MediaSubtitlesDropPhrases)
 	}
+	if len(loaded.MediaSubtitlesScrubPhrases) != 1 || loaded.MediaSubtitlesScrubPhrases[0] != `Крым,?\s*НАТО` {
+		t.Fatalf("scrub_phrases did not round-trip: %#v", loaded.MediaSubtitlesScrubPhrases)
+	}
 	if loaded.MediaSubtitlesCollapseRepeats != 3 {
 		t.Fatalf("collapse_repeats = %d, want 3", loaded.MediaSubtitlesCollapseRepeats)
 	}
@@ -152,6 +156,9 @@ func TestMediaSubtitlesCleaning_DefaultsOff(t *testing.T) {
 	}
 	if len(cfg.MediaSubtitlesDropPhrases) != 0 {
 		t.Fatalf("drop_phrases should default empty, got %#v", cfg.MediaSubtitlesDropPhrases)
+	}
+	if len(cfg.MediaSubtitlesScrubPhrases) != 0 {
+		t.Fatalf("scrub_phrases should default empty, got %#v", cfg.MediaSubtitlesScrubPhrases)
 	}
 	if cfg.MediaSubtitlesCollapseRepeats != 0 {
 		t.Fatalf("collapse_repeats should default 0, got %d", cfg.MediaSubtitlesCollapseRepeats)
@@ -179,6 +186,8 @@ func TestMediaSubtitlesCleaning_NestedYAMLApplies(t *testing.T) {
 		"      - Khruschev=>Khrushchev",
 		"    drop_phrases:",
 		"      - Донбасс|Крым|Украина|Иван|Плющ|НАТО",
+		"    scrub_phrases:",
+		"      - Донбасс.*НАТО",
 		"    collapse_repeats: 3",
 		"    drop_urls: true",
 	}, "\n")+"\n")
@@ -186,6 +195,9 @@ func TestMediaSubtitlesCleaning_NestedYAMLApplies(t *testing.T) {
 	cfg, err := config.LoadFile(path)
 	if err != nil {
 		t.Fatalf("LoadFile(nested cleaning): %v", err)
+	}
+	if len(cfg.MediaSubtitlesScrubPhrases) != 1 {
+		t.Fatalf("nested scrub_phrases not applied: %#v", cfg.MediaSubtitlesScrubPhrases)
 	}
 	if len(cfg.MediaSubtitlesGlossary) != 2 {
 		t.Fatalf("nested glossary not applied: %#v", cfg.MediaSubtitlesGlossary)
@@ -226,6 +238,12 @@ func TestMediaSubtitlesCleaning_RejectsBadConfig(t *testing.T) {
 	badDrop.MediaSubtitlesDropPhrases = []string{"a(b"}
 	if err := badDrop.Validate(); err == nil {
 		t.Fatalf("invalid drop_phrases regexp should be rejected")
+	}
+
+	badScrub := config.Default()
+	badScrub.MediaSubtitlesScrubPhrases = []string{"a(b"}
+	if err := badScrub.Validate(); err == nil {
+		t.Fatalf("invalid scrub_phrases regexp should be rejected")
 	}
 }
 

--- a/tests/subtitle/clean_test.go
+++ b/tests/subtitle/clean_test.go
@@ -154,6 +154,54 @@ func TestCleanCuesDropsPhrases(t *testing.T) {
 	}
 }
 
+// TestDropSetScrub pins the scrub semantics: a configured full phrase is excised
+// from a cue that also carries real speech, leaving the sentence tidy; a cue that
+// is ALL phrase scrubs to empty; and a legitimate mention that does not contain
+// the full phrase is untouched.
+func TestDropSetScrub(t *testing.T) {
+	// Full contiguous hallucination phrase (flexible punctuation/spacing).
+	d, err := subtitle.NewDropSet([]string{`Донбасс,?\s*Крым,?\s*Украина,?\s*Иван\s+Плющ,?\s*НАТО\.?`})
+	if err != nil {
+		t.Fatalf("NewDropSet: %v", err)
+	}
+	cases := map[string]string{
+		"Донбасс, Крым, Украина, Иван Плющ, НАТО. Реальный текст.": "Реальный текст.",
+		"Донбасс, Крым, Украина, Иван Плющ, НАТО.":                 "",                                        // all phrase -> empty
+		"покойный Иван Плющ, председатель Совета":                  "покойный Иван Плющ, председатель Совета", // real mention, no full phrase
+	}
+	for in, want := range cases {
+		if got := d.Scrub(in); got != want {
+			t.Errorf("Scrub(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestCleanCuesScrubsLeakedPhrase pins that CleanCues excises a leaked phrase from
+// a mixed cue, drops a cue that scrubs to empty, and re-indexes gap-free.
+func TestCleanCuesScrubsLeakedPhrase(t *testing.T) {
+	d, err := subtitle.NewDropSet([]string{`Крым,?\s*НАТО\.?`})
+	if err != nil {
+		t.Fatalf("NewDropSet: %v", err)
+	}
+	cues := []subtitle.Cue{
+		{Index: 1, StartMS: 0, EndMS: 1000, Text: "Крым, НАТО. Настоящая речь."},
+		{Index: 2, StartMS: 1000, EndMS: 2000, Text: "Крым, НАТО."},
+		{Index: 3, StartMS: 2000, EndMS: 3000, Text: "Ordinary line"},
+	}
+	got := subtitle.CleanCues(cues, subtitle.CleanOptions{Scrub: d})
+	if len(got) != 2 {
+		t.Fatalf("expected 2 surviving cues, got %d: %+v", len(got), got)
+	}
+	if got[0].Text != "Настоящая речь." || got[1].Text != "Ordinary line" {
+		t.Fatalf("wrong cues survived: %+v", got)
+	}
+	for i := range got {
+		if got[i].Index != i+1 {
+			t.Errorf("survivor %d has Index %d, want %d", i, got[i].Index, i+1)
+		}
+	}
+}
+
 // TestCleanCuesInactiveIsIdentity pins that a zero CleanOptions returns cues
 // unchanged (same order, same content), so the empty-config path is a no-op.
 func TestCleanCuesInactiveIsIdentity(t *testing.T) {


### PR DESCRIPTION
## What

`drop_phrases` (#539) removes cues that are **entirely** Whisper keyword-spam. But when broadcast segmentation splits the hallucination across a cue boundary, the phrase **leaks** into a cue that also holds real speech:

- `Донбасс, Крым, Украина, Иван Плющ, НАТО. <real sentence>`
- tail fragment: `Плющ, НАТО. <real sentence>`

A whole-cue drop would throw away the real speech. Stacks on #539.

## How

New `media.subtitles.scrub_phrases` (`[]regexp`). `DropSet.Scrub` excises just the matched phrase and keeps the sentence. It is:
- a **strict no-op when no phrase matches** — the vast majority of cues, including their two-line wrap newline, pass through byte-for-byte;
- collapses only spaces/tabs, **never the wrap newline** (CleanCues runs after wrapping);
- strips connective punctuation orphaned by the excision (a leading `, ` / dangling `—`) while keeping sentence-final `.` `!` `?`;
- drops a cue that scrubs to empty.

Configure with the **full contiguous phrase** so a legitimate lone mention (`покойный Иван Плющ, председатель`) is untouched. Verified on the pilot corpus: 6 leaked cues → 0, legitimate Ivan Plyushch mention preserved.

Full config plumbing mirrors `drop_phrases` (runtime field, fileConfig overlay, Default, Snapshot, nested-yaml apply, dotted-key alias + list-append + allowlist, serialize, fail-fast validate).

## Tests

`DropSet.Scrub` semantics (excise / drop-to-empty / real-mention-untouched), `CleanCues` scrub, config round-trip / nested / reject, end-to-end export scrub.

`gofmt`/`go vet` clean; `go build ./...` OK; subtitle/config/cli suites green.

Companion PR (broadcast segmentation, stacked on #533): #540 — hyphen detok, duration cap, optimal wrap.