### PR TITLE
fix(whisperapi): normalize base_url trailing /v1 to avoid /v1/v1 404 (#496)

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,8 +473,8 @@ providers:
     base_url: http://gpu-vps:8080/v1
     embed_text_model: bge-m3
   whisper:                   # self-hosted STT (POST {base_url}/v1/audio/transcriptions)
-    kind: whisper
-    base_url: http://gpu-vps:9001/v1
+    kind: whisper            # base_url is the host ROOT; /v1/audio/transcriptions is appended
+    base_url: http://gpu-vps:9001
     stt_model: large-v3
   gpu-ocr:                   # self-hosted bespoke OCR (POST {base_url}/v1/ocr)
     kind: mistral            # base_url is the host ROOT; /v1/ocr is appended
@@ -489,7 +489,7 @@ stt_provider: whisper        # STT uses the legacy selector
 ```
 
 - **Capability mapping** (which route serves each capability, spec §8.5): embed → `POST {base_url}/v1/embeddings`; chat → `/v1/chat/completions`; STT → `/v1/audio/transcriptions` (endpoint-dependent, validated at first use). **OCR has no OpenAI analog** — bind it only to a `kind: mistral` `/v1/ocr` endpoint (or use [docling-serve](#docling-extraction-over-http-docling-serve)); binding `model.ocr.provider` to a `kind: openai` profile is rejected as `CONFIG_INVALID`.
-- **`base_url` shape differs by kind:** a `kind: openai` `base_url` already includes `/v1`; a `kind: mistral` OCR `base_url` is the **host root** (the client appends `/v1/ocr`).
+- **`base_url` shape differs by kind:** a `kind: openai` `base_url` already includes `/v1`; a `kind: mistral` OCR `base_url` and a `kind: whisper` STT `base_url` are the **host root** (the client appends `/v1/ocr` and `/v1/audio/transcriptions` respectively). The whisper client tolerates a stray trailing `/v1` and will not double it.
 - No shipped self-hosted defaults — you must declare the profile and bind it explicitly; nothing silently auto-selects a self-hosted endpoint.
 - For a full GPU-VPS topology (corpus over NFS/S3, vector backend, systemd), see [docs/dual-machine-deployment.md](docs/dual-machine-deployment.md).
 

--- a/internal/whisperapi/client.go
+++ b/internal/whisperapi/client.go
@@ -327,6 +327,21 @@ func (c *Client) task() string {
 	return TaskTranscribe
 }
 
+// transcriptionURL builds the OpenAI-compatible transcription endpoint from a
+// base URL, tolerating both accepted base_url shapes: the host root
+// (http://host:9001) and a base already ending in /v1 (http://host:9001/v1, as
+// some READMEs suggested). Both resolve to exactly one
+// /v1/audio/transcriptions path, so a stray trailing /v1 no longer doubles into
+// a 404 (dir2mcp#496).
+func transcriptionURL(baseURL string) string {
+	base := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	// Strip a single trailing /v1 segment so we never emit /v1/v1/... .
+	if trimmed := strings.TrimSuffix(base, "/v1"); trimmed != base {
+		base = trimmed
+	}
+	return base + "/v1/audio/transcriptions"
+}
+
 func (c *Client) transcribeOnce(ctx context.Context, relPath string, data []byte) (model.TranscriptResult, error) {
 	if strings.TrimSpace(c.BaseURL) == "" {
 		return model.TranscriptResult{}, &model.ProviderError{Code: "WHISPER_FAILED", Message: "missing whisper base_url", Retryable: false}
@@ -336,7 +351,7 @@ func (c *Client) transcribeOnce(ctx context.Context, relPath string, data []byte
 		return model.TranscriptResult{}, err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+"/v1/audio/transcriptions", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, transcriptionURL(c.BaseURL), bytes.NewReader(body))
 	if err != nil {
 		return model.TranscriptResult{}, &model.ProviderError{Code: "WHISPER_FAILED", Message: "failed to build transcription request", Retryable: false, Cause: err}
 	}

--- a/tests/whisperapi/client_test.go
+++ b/tests/whisperapi/client_test.go
@@ -617,3 +617,38 @@ func TestTranscribeStructuredWordsAbsent(t *testing.T) {
 func TestClientImplementsStructuredTranscriber(t *testing.T) {
 	var _ model.StructuredTranscriber = whisperapi.NewClient("http://x", "")
 }
+
+// TestBaseURLNormalizationSingleV1 asserts that whatever base_url shape an
+// operator configures — host root, a trailing slash, or a stray trailing /v1
+// (as an old README example suggested) — the client posts to exactly one
+// /v1/audio/transcriptions path and never doubles into /v1/v1/... 404 (#496).
+func TestBaseURLNormalizationSingleV1(t *testing.T) {
+	cases := []struct {
+		name       string
+		baseSuffix string // appended to the httptest server URL
+	}{
+		{name: "host root", baseSuffix: ""},
+		{name: "trailing slash", baseSuffix: "/"},
+		{name: "trailing /v1", baseSuffix: "/v1"},
+		{name: "trailing /v1/", baseSuffix: "/v1/"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotPath string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, jsonSegments)
+			}))
+			defer srv.Close()
+
+			c := newClient(srv.URL+tc.baseSuffix, "")
+			if _, err := c.Transcribe(context.Background(), "a/b.mp3", []byte("audiobytes")); err != nil {
+				t.Fatalf("Transcribe: %v", err)
+			}
+			if gotPath != "/v1/audio/transcriptions" {
+				t.Fatalf("request path = %q, want /v1/audio/transcriptions", gotPath)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
`kind: whisper` posts to `{base_url}/v1/audio/transcriptions`. A base_url ending in `/v1` (as the README example showed) doubled the path to `/v1/v1/audio/transcriptions` → 404 (`WHISPER_FAILED: {"detail":"Not Found"}`).

## Changes
- `internal/whisperapi/client.go`: new `transcriptionURL` helper trims a single trailing `/v1` (and trailing slashes) before appending `/v1/audio/transcriptions`, so host-root and `/v1` base_urls both resolve to exactly one path. Bare base_url behavior unchanged.
- `README.md`: whisper example now uses the host root; documents the per-kind base_url shape and that the whisper client tolerates a stray trailing `/v1`.
- `tests/whisperapi/client_test.go`: table test covering host root, trailing `/`, trailing `/v1`, and `/v1/` — all assert a single `/v1/audio/transcriptions`.

## Verify
- `make lint`: 0 issues
- `go test ./internal/whisperapi/... ./tests/whisperapi/...`: pass

Closes #496

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Whisper transcription request handling so base URLs are normalized correctly, preventing doubled `/v1` paths and ensuring requests reach the right endpoint.
  * The client now tolerates base URLs with extra slashes or a trailing `/v1` without breaking transcription calls.

* **Documentation**
  * Updated the README example for self-hosted GPU-VPS setups to show the recommended base URL format.
  * Clarified the accepted base URL shape for Whisper providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->