### PR TITLE
fix(providers): allow credential-less kind:openai on a custom base_url (#498)

### DIFF
--- a/internal/openai/client.go
+++ b/internal/openai/client.go
@@ -10,6 +10,14 @@
 // callers can depend on model.Embedder / model.Generator without taking
 // a hard dependency on this package.
 //
+// A custom (non-default) base_url is treated as a self-hosted / local
+// OpenAI-compatible endpoint (Ollama/vLLM/LM Studio, SPEC §8.5) and MAY be
+// credential-less: when no api_key is configured against such a base_url the
+// client does NOT fail with OPENAI_AUTH and sends no Bearer header, mirroring
+// the credential-optional whisper/omniembed/colbert self-hosted clients. A
+// missing key against the public OpenAI cloud endpoint (the default base_url)
+// is still a hard OPENAI_AUTH error.
+//
 // OpenAI embeddings are symmetric, so the model.EmbedRole is accepted
 // and intentionally ignored (SPEC 8.1.5) — observable behavior MUST NOT
 // differ by role for this provider.
@@ -140,6 +148,30 @@ func NewClient(baseURL, apiKey string) *Client {
 	}
 }
 
+// missingRequiredKey reports whether an empty api_key is a hard error for
+// this client. A missing key is only fatal against the public OpenAI cloud
+// endpoint (the default base_url, or an unset base that falls back to it); a
+// custom base_url points at a self-hosted / local OpenAI-compatible endpoint
+// on a trusted network, which is credential-less by design (SPEC §8.5) and is
+// called with no Bearer header. When this returns false the caller proceeds
+// credential-less rather than returning OPENAI_AUTH.
+func (c *Client) missingRequiredKey() bool {
+	if strings.TrimSpace(c.APIKey) != "" {
+		return false
+	}
+	base := strings.TrimRight(strings.TrimSpace(c.BaseURL), "/")
+	return base == "" || base == defaultBaseURL
+}
+
+// setAuthHeader sets the Bearer Authorization header only when an api_key is
+// configured, so a credential-less local endpoint receives no auth header
+// (mirrors the whisper/omniembed/colbert self-hosted clients).
+func (c *Client) setAuthHeader(req *http.Request) {
+	if key := strings.TrimSpace(c.APIKey); key != "" {
+		req.Header.Set("Authorization", "Bearer "+key)
+	}
+}
+
 type embedRequest struct {
 	Model string   `json:"model"`
 	Input []string `json:"input"`
@@ -158,7 +190,7 @@ type embedResponse struct {
 // in BatchSize-sized batches; each batch is retried with bounded
 // exponential backoff, and vectors are reordered to match input order.
 func (c *Client) Embed(ctx context.Context, modelName string, _ model.EmbedRole, inputs []string) ([][]float32, error) {
-	if strings.TrimSpace(c.APIKey) == "" {
+	if c.missingRequiredKey() {
 		return nil, &model.ProviderError{Code: "OPENAI_AUTH", Message: "missing OpenAI API key", Retryable: false}
 	}
 	modelName = strings.TrimSpace(modelName)
@@ -310,7 +342,7 @@ func (c *Client) GenerateWithMaxTokens(ctx context.Context, prompt string, maxTo
 }
 
 func (c *Client) generate(ctx context.Context, prompt string, maxTokensOverride int) (string, error) {
-	if strings.TrimSpace(c.APIKey) == "" {
+	if c.missingRequiredKey() {
 		return "", &model.ProviderError{Code: "OPENAI_AUTH", Message: "missing OpenAI API key", Retryable: false}
 	}
 	chatModel := strings.TrimSpace(c.DefaultChatModel)
@@ -431,7 +463,7 @@ type transcriptionResponse struct {
 // SPEC 8.1.2 ³: a compatible base lacking audio surfaces a provider
 // error here, never CONFIG_INVALID.
 func (c *Client) Transcribe(ctx context.Context, relPath string, data []byte) (string, error) {
-	if strings.TrimSpace(c.APIKey) == "" {
+	if c.missingRequiredKey() {
 		return "", &model.ProviderError{Code: "OPENAI_AUTH", Message: "missing OpenAI API key", Retryable: false}
 	}
 	if len(data) == 0 {
@@ -474,7 +506,7 @@ func (c *Client) transcribeOnce(ctx context.Context, relPath string, data []byte
 	if err != nil {
 		return "", &model.ProviderError{Code: "OPENAI_FAILED", Message: "failed to build transcription request", Retryable: false, Cause: err}
 	}
-	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	c.setAuthHeader(req)
 	req.Header.Set("Content-Type", w.FormDataContentType())
 	resp, err := clientWithTimeout(c.HTTPClient, timeout).Do(req)
 	if err != nil {
@@ -505,7 +537,7 @@ type speechRequest struct {
 // shape) via {base}/audio/speech, returning raw audio bytes. TTS is
 // fail-open per SPEC 8.3 — callers proceed without audio on error.
 func (c *Client) Synthesize(ctx context.Context, text string) ([]byte, error) {
-	if strings.TrimSpace(c.APIKey) == "" {
+	if c.missingRequiredKey() {
 		return nil, &model.ProviderError{Code: "OPENAI_AUTH", Message: "missing OpenAI API key", Retryable: false}
 	}
 	if strings.TrimSpace(text) == "" {
@@ -581,7 +613,7 @@ func (c *Client) doJSON(ctx context.Context, path string, body []byte, timeout t
 	if err != nil {
 		return nil, &model.ProviderError{Code: "OPENAI_FAILED", Message: "failed to build request", Retryable: false, Cause: err}
 	}
-	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	c.setAuthHeader(req)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 

--- a/tests/openai/client_test.go
+++ b/tests/openai/client_test.go
@@ -105,12 +105,56 @@ func TestEndpointPathJoinPreservesVersion(t *testing.T) {
 	}
 }
 
+// TestEmbed_MissingKeyIsNonRetryableAuth pins the cloud contract: a missing
+// api_key against the DEFAULT (public OpenAI) base_url is a hard OPENAI_AUTH
+// error, before any HTTP call. An empty base_url falls back to the cloud
+// default, so this exercises the credential-required path. The credential-less
+// local path (a custom base_url) is covered by TestCredentialLessLocalEndpoint.
 func TestEmbed_MissingKeyIsNonRetryableAuth(t *testing.T) {
-	c := openai.NewClient("http://127.0.0.1:0", "")
+	c := openai.NewClient("", "") // empty base -> public OpenAI cloud default
 	_, err := c.Embed(context.Background(), "m", model.EmbedQuery, []string{"x"})
 	var pe *model.ProviderError
 	if !asProviderErr(err, &pe) || pe.Code != "OPENAI_AUTH" || pe.Retryable {
 		t.Fatalf("want non-retryable OPENAI_AUTH, got %v", err)
+	}
+}
+
+// TestCredentialLessLocalEndpoint pins issue #498 / SPEC §8.5: a kind:openai
+// profile pointed at a CUSTOM (self-hosted / local) base_url with NO api_key is
+// credential-less — it must NOT fail with OPENAI_AUTH, and it must send NO
+// Authorization header (a trusted-network endpoint requires no key). This
+// mirrors the credential-optional whisper/omniembed/colbert self-hosted clients.
+func TestCredentialLessLocalEndpoint(t *testing.T) {
+	var sawAuth atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "" {
+			sawAuth.Store(true)
+		}
+		switch r.URL.Path {
+		case "/v1/embeddings":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": []map[string]any{{"index": 0, "embedding": []float64{1, 2}}},
+			})
+		case "/v1/chat/completions":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"choices": []map[string]any{{"message": map[string]any{"content": "ok"}}},
+			})
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	// Custom base_url + empty api_key: the local endpoint is credential-less.
+	c := openai.NewClient(srv.URL+"/v1", "")
+	if _, err := c.Embed(context.Background(), "bge-m3", model.EmbedDocument, []string{"x"}); err != nil {
+		t.Fatalf("credential-less local embed must succeed, got %v", err)
+	}
+	if _, err := c.Generate(context.Background(), "hi"); err != nil {
+		t.Fatalf("credential-less local generate must succeed, got %v", err)
+	}
+	if sawAuth.Load() {
+		t.Fatal("credential-less local endpoint must receive NO Authorization header")
 	}
 }
 
@@ -336,7 +380,10 @@ func TestTranscribeAndSynthesize(t *testing.T) {
 }
 
 func TestAudioMissingKeyAndEmptyInput(t *testing.T) {
-	nokey := openai.NewClient("http://127.0.0.1:0", "")
+	// Missing key against the DEFAULT (public OpenAI) base is a hard OPENAI_AUTH
+	// error before any HTTP call (empty base -> cloud default). A custom base is
+	// credential-less (covered by TestCredentialLessLocalEndpoint).
+	nokey := openai.NewClient("", "")
 	if _, err := nokey.Transcribe(context.Background(), "a.wav", []byte("x")); err == nil {
 		t.Error("Transcribe missing key must error")
 	}


### PR DESCRIPTION
## Summary

A `kind: openai` provider pointed at a **trusted local** endpoint (Ollama/vLLM/LM Studio) failed with `OPENAI_AUTH: missing OpenAI API key` unless an `api_key` was set — even though the README and SPEC §8.5 state a trusted-network endpoint "may be **credential-less** (no `api_key`)".

The provider *selection* layer already treated a no-`api_key` profile as credential-less/eligible (`provider.Eligible`), but the `internal/openai` client itself hard-rejected an empty key and always sent a `Bearer` header, so the capability call failed at runtime.

## Fix

Scope the allowance to a **custom (non-default) base_url**, which identifies a self-hosted / local OpenAI-compatible endpoint:

- A missing key against the **public OpenAI cloud** endpoint (the default `base_url`, or an unset base that falls back to it) is still a hard `OPENAI_AUTH` error — the cloud contract is unchanged.
- Against a **custom `base_url`**, the client proceeds credential-less and sends **no `Authorization` header**, mirroring the credential-optional whisper/omniembed/colbert self-hosted clients.

Applies uniformly to embed, chat, STT, and TTS via a shared `missingRequiredKey`/`setAuthHeader` pair.

## Tests

- New `TestCredentialLessLocalEndpoint`: custom base_url + empty key embeds/generates successfully and sends no auth header.
- Retargeted the missing-key embed/audio tests to the default cloud base to pin the unchanged credential-required contract.
- `make lint`: 0 issues. Relevant provider/openai/providerfactory suites pass.

Closes #498