### PR TITLE
fix(ingest): apply subtitle drop_phrases/scrub_phrases before embedding (#545)

### DIFF
--- a/internal/ingest/represent.go
+++ b/internal/ingest/represent.go
@@ -980,6 +980,42 @@ func applyWordFilterToSegments(segs []chunkSegment, filter *subtitle.WordFilter)
 	return out
 }
 
+// applyDropScrubToSegments applies the configured subtitle drop/scrub cleaning
+// (config media.subtitles.drop_phrases / scrub_phrases) to each chunk segment's
+// text at INGEST, before embedding — mirroring applyWordFilterToSegments for
+// media.filter_words, so the same phrases that are stripped from the exported
+// sidecar are also stripped from what gets chunked and embedded (issue #545).
+// A segment whose text is composed ENTIRELY of drop phrases (DropSet.IsSpam) is
+// dropped, so whisper keyword-spam over non-speech is never embedded; a segment
+// carrying a leaked phrase glued to real speech is scrubbed (DropSet.Scrub) and
+// kept, and dropped only if the scrub empties it. Both sets are the exact same
+// subtitle primitives the export path invokes (subtitle.CleanCues →
+// DropSet.IsSpam/Scrub) built from the same config keys, so the index and the
+// exported sidecar agree cue-for-cue. Nil/inactive sets return segs unchanged,
+// so the empty-config path is a byte-for-byte no-op. Drop is applied before
+// scrub (matching CleanCues ordering); spans (timing) are preserved verbatim on
+// surviving segments.
+func applyDropScrubToSegments(segs []chunkSegment, drop, scrub *subtitle.DropSet) []chunkSegment {
+	if !drop.Active() && !scrub.Active() {
+		return segs
+	}
+	out := make([]chunkSegment, 0, len(segs))
+	for _, seg := range segs {
+		if drop.IsSpam(seg.Text) {
+			continue
+		}
+		if scrub.Active() {
+			scrubbed := scrub.Scrub(seg.Text)
+			if strings.TrimSpace(scrubbed) == "" {
+				continue
+			}
+			seg.Text = scrubbed
+		}
+		out = append(out, seg)
+	}
+	return out
+}
+
 // shiftTranscriptSpans subtracts offsetMS from every "time" span's bounds and
 // from every attached word timestamp, clamping at 0 (dir2mcp#258 leading-silence
 // trim). It mutates segs in place and is deterministic for a given input. A
@@ -1561,6 +1597,24 @@ func ChunkTranscriptByTimeWithWordsFiltered(content string, words []model.TimedW
 	raw := chunkTranscriptByTimeWithWordsFiltered(content, words, filter)
 	out := make([]ChunkSegment, 0, len(raw))
 	for _, seg := range raw {
+		out = append(out, ChunkSegment(seg))
+	}
+	return out
+}
+
+// ApplyDropScrubToSegments is the exported counterpart of
+// applyDropScrubToSegments, exposed for tests in the tests/ tree. It applies the
+// configured subtitle drop/scrub cleaning to chunk segments exactly as the ingest
+// path does after chunking (before persistence/embedding). Nil/inactive sets
+// return the input unchanged.
+func ApplyDropScrubToSegments(segs []ChunkSegment, drop, scrub *subtitle.DropSet) []ChunkSegment {
+	raw := make([]chunkSegment, len(segs))
+	for i, seg := range segs {
+		raw[i] = chunkSegment(seg)
+	}
+	cleaned := applyDropScrubToSegments(raw, drop, scrub)
+	out := make([]ChunkSegment, 0, len(cleaned))
+	for _, seg := range cleaned {
 		out = append(out, ChunkSegment(seg))
 	}
 	return out

--- a/internal/ingest/represent.go
+++ b/internal/ingest/represent.go
@@ -1010,10 +1010,47 @@ func applyDropScrubToSegments(segs []chunkSegment, drop, scrub *subtitle.DropSet
 				continue
 			}
 			seg.Text = scrubbed
+			// Excise the scrubbed words from the per-word timings too: Span.Words is
+			// later rebuilt into broadcast cues / other word-level consumers, so
+			// leaving the removed phrase's words here would re-introduce the spam the
+			// scrub just removed from Text.
+			seg.Span.Words = filterWordSpansToText(seg.Span.Words, scrubbed)
 		}
 		out = append(out, seg)
 	}
 	return out
+}
+
+// filterWordSpansToText drops per-word timings whose token is no longer present
+// in text, so a scrubbed segment's Span.Words carries only its surviving words.
+// Matching is a case-insensitive multiset over whitespace tokens with surrounding
+// punctuation trimmed, so a word kept N times in text keeps N of its timings (and
+// a word removed by the scrub, absent from text, keeps none). Empty input is
+// returned unchanged.
+func filterWordSpansToText(words []model.WordSpan, text string) []model.WordSpan {
+	if len(words) == 0 {
+		return words
+	}
+	counts := make(map[string]int)
+	for _, tok := range strings.Fields(text) {
+		counts[normalizeWordToken(tok)]++
+	}
+	out := make([]model.WordSpan, 0, len(words))
+	for _, w := range words {
+		key := normalizeWordToken(w.W)
+		if key != "" && counts[key] > 0 {
+			counts[key]--
+			out = append(out, w)
+		}
+	}
+	return out
+}
+
+// normalizeWordToken lowercases a token and trims surrounding punctuation so a
+// whisper word token ("Aju?bei,") compares equal to its occurrence in rebuilt
+// segment text.
+func normalizeWordToken(s string) string {
+	return strings.ToLower(strings.Trim(strings.TrimSpace(s), ".,!?;:…»«()[]{}\"'“”‘’-—"))
 }
 
 // shiftTranscriptSpans subtracts offsetMS from every "time" span's bounds and

--- a/internal/ingest/represent.go
+++ b/internal/ingest/represent.go
@@ -1009,12 +1009,20 @@ func applyDropScrubToSegments(segs []chunkSegment, drop, scrub *subtitle.DropSet
 			if strings.TrimSpace(scrubbed) == "" {
 				continue
 			}
-			seg.Text = scrubbed
-			// Excise the scrubbed words from the per-word timings too: Span.Words is
-			// later rebuilt into broadcast cues / other word-level consumers, so
-			// leaving the removed phrase's words here would re-introduce the spam the
-			// scrub just removed from Text.
-			seg.Span.Words = filterWordSpansToText(seg.Span.Words, scrubbed)
+			// Only touch a segment the scrub actually changed. filterWordSpansToText
+			// is an approximate multiset token match, so re-running it on an
+			// UNCHANGED segment risks silently dropping a word timing on any
+			// tokenization/punctuation mismatch (numerals, contractions) — for every
+			// segment when scrub_phrases is set, not just scrubbed ones. An unchanged
+			// segment keeps its Text and Span.Words verbatim.
+			if scrubbed != seg.Text {
+				seg.Text = scrubbed
+				// Excise the scrubbed words from the per-word timings too: Span.Words is
+				// later rebuilt into broadcast cues / other word-level consumers, so
+				// leaving the removed phrase's words here would re-introduce the spam the
+				// scrub just removed from Text.
+				seg.Span.Words = filterWordSpansToText(seg.Span.Words, scrubbed)
+			}
 		}
 		out = append(out, seg)
 	}

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -3299,6 +3299,31 @@ func (s *Service) translateOneTranscript(ctx context.Context, doc model.Document
 		Duration:         duration,
 	})
 
+	// Chunk the translated text with the same word-aware transcript chunker as the
+	// source path so its time spans line up with the source segments (the
+	// translation preserves each segment's verbatim [mm:ss] marker) AND carry the
+	// whisper-translate per-word timings, enabling broadcast segmentation of the
+	// English track. translatedWords is nil for the chat engine, leaving that path
+	// chunk-only as before.
+	segments := chunkTranscriptByTimeWithWordsFiltered(translated, translatedWords, s.captionWordFilter())
+	// Strip configured subtitle drop/scrub phrases from the translated chunk text
+	// before embedding (issue #545), consistent with the source transcript path.
+	dropSet, scrubSet := s.captionDropScrub()
+	segments = applyDropScrubToSegments(segments, dropSet, scrubSet)
+	// Bail BEFORE creating the representation when the translation was fully
+	// stripped (drop/scrub emptied every segment): otherwise we would leave a
+	// dangling rep row with no chunks and inflate the representation count. The
+	// source transcript path bails before UpsertRepresentation for the same reason.
+	if len(segments) == 0 {
+		return nil
+	}
+	// Apply the same leading-silence trim offset as the source transcript so the
+	// translated time windows stay aligned with the source (dir2mcp#258). A zero
+	// offset (trim disabled / no silence detected) is a no-op.
+	if trimOffsetMS > 0 {
+		shiftTranscriptSpans(segments, trimOffsetMS)
+	}
+
 	meta := transcriptMeta{
 		Source:            translationSource,
 		Language:          targetLang,
@@ -3334,26 +3359,6 @@ func (s *Service) translateOneTranscript(ctx context.Context, doc model.Document
 	}
 	s.addRepresentations(1)
 
-	// Chunk the translated text with the same word-aware transcript chunker as the
-	// source path so its time spans line up with the source segments (the
-	// translation preserves each segment's verbatim [mm:ss] marker) AND carry the
-	// whisper-translate per-word timings, enabling broadcast segmentation of the
-	// English track. translatedWords is nil for the chat engine, leaving that path
-	// chunk-only as before.
-	segments := chunkTranscriptByTimeWithWordsFiltered(translated, translatedWords, s.captionWordFilter())
-	// Strip configured subtitle drop/scrub phrases from the translated chunk text
-	// before embedding (issue #545), consistent with the source transcript path.
-	dropSet, scrubSet := s.captionDropScrub()
-	segments = applyDropScrubToSegments(segments, dropSet, scrubSet)
-	if len(segments) == 0 {
-		return nil
-	}
-	// Apply the same leading-silence trim offset as the source transcript so the
-	// translated time windows stay aligned with the source (dir2mcp#258). A zero
-	// offset (trim disabled / no silence detected) is a no-op.
-	if trimOffsetMS > 0 {
-		shiftTranscriptSpans(segments, trimOffsetMS)
-	}
 	if err := s.repGen.upsertChunksForRepresentation(ctx, repID, "text", segments, decision); err != nil {
 		return fmt.Errorf("persist translated transcript chunks: %w", err)
 	}

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -702,6 +702,27 @@ func (s *Service) captionWordFilter() *subtitle.WordFilter {
 	return subtitle.NewWordFilter(s.cfg.MediaFilterWords)
 }
 
+// captionDropScrub builds the shared subtitle drop/scrub sets from
+// media.subtitles.drop_phrases / scrub_phrases (issue #545). The same sets clean
+// STT transcript chunks and sidecar-cue chunks before embedding, mirroring how
+// the export path (subtitle.CleanCues) cleans the exported sidecar — so a
+// wholly-spam chunk is never indexed and a chunk with a leaked phrase is embedded
+// scrubbed, keeping the index and sidecar in agreement. Empty config yields
+// inactive (nil) sets, which the cleaning treats as a no-op. The patterns were
+// already validated at config load (config.Validate → subtitle.NewDropSet), so a
+// compile error here is unexpected; it is logged and treated as no cleaning
+// (nil set) rather than failing ingestion.
+func (s *Service) captionDropScrub() (drop, scrub *subtitle.DropSet) {
+	var err error
+	if drop, err = subtitle.NewDropSet(s.cfg.MediaSubtitlesDropPhrases); err != nil {
+		s.getLogger().Printf("media.subtitles.drop_phrases invalid at ingest, ignoring: %v", err)
+	}
+	if scrub, err = subtitle.NewDropSet(s.cfg.MediaSubtitlesScrubPhrases); err != nil {
+		s.getLogger().Printf("media.subtitles.scrub_phrases invalid at ingest, ignoring: %v", err)
+	}
+	return drop, scrub
+}
+
 func sttExpectedLanguage(cfg config.Config) string {
 	prof, ok := resolveSTTProfile(cfg)
 	if !ok {
@@ -3068,6 +3089,11 @@ func (s *Service) generateTranscriptRepresentation(ctx context.Context, doc mode
 	})
 
 	segments := chunkTranscriptByTimeWithWordsFiltered(transcriptText, words, s.captionWordFilter())
+	// Strip configured subtitle drop/scrub phrases from the chunk text BEFORE
+	// embedding (issue #545), so whisper keyword-spam never pollutes the index —
+	// the same cleaning the export path applies to the sidecar. Off by default.
+	dropSet, scrubSet := s.captionDropScrub()
+	segments = applyDropScrubToSegments(segments, dropSet, scrubSet)
 	if len(segments) == 0 {
 		return nil
 	}
@@ -3315,6 +3341,10 @@ func (s *Service) translateOneTranscript(ctx context.Context, doc model.Document
 	// English track. translatedWords is nil for the chat engine, leaving that path
 	// chunk-only as before.
 	segments := chunkTranscriptByTimeWithWordsFiltered(translated, translatedWords, s.captionWordFilter())
+	// Strip configured subtitle drop/scrub phrases from the translated chunk text
+	// before embedding (issue #545), consistent with the source transcript path.
+	dropSet, scrubSet := s.captionDropScrub()
+	segments = applyDropScrubToSegments(segments, dropSet, scrubSet)
 	if len(segments) == 0 {
 		return nil
 	}

--- a/internal/ingest/sidecar.go
+++ b/internal/ingest/sidecar.go
@@ -331,9 +331,15 @@ func (s *Service) ingestSidecarTranscripts(ctx context.Context, doc model.Docume
 	}
 	sort.Strings(langs)
 
+	// Build the drop/scrub sets once for all languages; they are config-derived
+	// and language-independent. They strip configured subtitle drop/scrub phrases
+	// from the chunk text before embedding (issue #545), the same cleaning the
+	// export path applies to the sidecar. Off by default (inactive sets = no-op).
+	dropSet, scrubSet := s.captionDropScrub()
 	ingested := false
 	for _, lang := range langs {
 		segments := chunkSubtitleCuesFiltered(groups[lang], s.captionWordFilter())
+		segments = applyDropScrubToSegments(segments, dropSet, scrubSet)
 		if len(segments) == 0 {
 			continue
 		}

--- a/tests/ingest/drop_scrub_test.go
+++ b/tests/ingest/drop_scrub_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/model"
 	"github.com/dirstral/dir2mcp/internal/subtitle"
 )
 
@@ -113,6 +114,34 @@ func TestScrubExcisesLeakedPhrase(t *testing.T) {
 	// dropped: the real lines plus the scrubbed mixed line remain.
 	if len(got) != len(base)-1 {
 		t.Fatalf("expected the pure-spam line dropped after scrub: got %d, base %d", len(got), len(base))
+	}
+}
+
+// TestScrubFiltersWordTimings pins that scrubbing a leaked phrase also excises
+// the phrase's per-word timings from Span.Words — otherwise a downstream
+// word-level consumer (broadcast re-segmentation) would rebuild the scrubbed
+// spam from the leftover word timings, re-introducing what the scrub removed.
+func TestScrubFiltersWordTimings(t *testing.T) {
+	words := []model.TimedWord{
+		{Word: "hello", StartMS: 0, EndMS: 400},
+		{Word: "Крым", StartMS: 500, EndMS: 900}, // leaked spam token between real speech
+		{Word: "world", StartMS: 1000, EndMS: 1400},
+	}
+	base := ingest.ChunkTranscriptByTimeWithWords("[00:00] hello Крым world", words)
+	got := ingest.ApplyDropScrubToSegments(base, mustDropSet(t, nil), mustDropSet(t, []string{"Крым"}))
+
+	var toks []string
+	for _, seg := range got {
+		for _, w := range seg.Span.Words {
+			toks = append(toks, w.W)
+			if strings.Contains(w.W, "Крым") {
+				t.Fatalf("scrubbed word leaked into Span.Words: %v", toks)
+			}
+		}
+	}
+	// The real words keep their timings; only the scrubbed token is gone.
+	if len(toks) != 2 {
+		t.Fatalf("expected 2 surviving word timings (hello, world), got %v", toks)
 	}
 }
 

--- a/tests/ingest/drop_scrub_test.go
+++ b/tests/ingest/drop_scrub_test.go
@@ -145,6 +145,31 @@ func TestScrubFiltersWordTimings(t *testing.T) {
 	}
 }
 
+// TestScrubLeavesUnchangedSegmentWordsVerbatim pins that a segment the scrub
+// does NOT alter keeps its Span.Words exactly — the approximate word-timing
+// filter must run only on segments actually scrubbed, never on unmatched ones
+// (where a tokenization mismatch on numerals/punctuation could silently drop a
+// timing corpus-wide when scrub_phrases is set).
+func TestScrubLeavesUnchangedSegmentWordsVerbatim(t *testing.T) {
+	// Tricky tokens (a numeral, a contraction) that approximate matching could
+	// mishandle — but this line contains no scrub phrase, so it must be untouched.
+	words := []model.TimedWord{
+		{Word: "we've", StartMS: 0, EndMS: 300},
+		{Word: "got", StartMS: 300, EndMS: 600},
+		{Word: "1,200", StartMS: 600, EndMS: 900},
+		{Word: "cases", StartMS: 900, EndMS: 1200},
+	}
+	base := ingest.ChunkTranscriptByTimeWithWords("[00:00] we've got 1,200 cases", words)
+	got := ingest.ApplyDropScrubToSegments(base, mustDropSet(t, nil), mustDropSet(t, []string{"breaking news"}))
+
+	if len(got) != 1 {
+		t.Fatalf("expected 1 segment, got %d", len(got))
+	}
+	if len(got[0].Span.Words) != 4 {
+		t.Fatalf("unscrubbed segment must keep all 4 word timings verbatim, got %d: %+v", len(got[0].Span.Words), got[0].Span.Words)
+	}
+}
+
 // TestDropScrubConsistentIngestAndExport pins that the same DropSet, applied to
 // the same source, strips the same phrase at ingest (chunk segments) and at
 // export (CleanCues) — the index and the exported sidecar agree cue-for-cue.

--- a/tests/ingest/drop_scrub_test.go
+++ b/tests/ingest/drop_scrub_test.go
@@ -1,0 +1,176 @@
+package tests
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/subtitle"
+)
+
+// mustDropSet builds a subtitle.DropSet from configured patterns, failing the
+// test on a compile error (the patterns here are always valid).
+func mustDropSet(t *testing.T, patterns []string) *subtitle.DropSet {
+	t.Helper()
+	d, err := subtitle.NewDropSet(patterns)
+	if err != nil {
+		t.Fatalf("NewDropSet(%v): %v", patterns, err)
+	}
+	return d
+}
+
+// spamPhrases is the whisper keyword-spam vocabulary used across these tests.
+var spamPhrases = []string{"Донбасс", "Крым", "Украина", "НАТО"}
+
+// dropFixture is a time-stamped transcript whose middle line is pure keyword-spam
+// (a whisper hallucination over non-speech); the surrounding lines are real
+// speech that never mentions the spam words, so a drop pass leaves them clean.
+const dropFixture = "[00:00] Welcome to the broadcast\n" +
+	"[00:02] Донбасс, Крым, Украина, НАТО\n" +
+	"[00:05] Сегодня обсуждаем экономику региона"
+
+// scrubFixture pairs a real line with a mixed line where a leaked spam phrase is
+// glued to real speech, plus a wholly-spam line that scrubs to nothing.
+const scrubFixture = "[00:00] Welcome to the broadcast\n" +
+	"[00:02] Сегодня обсуждаем Донбасс, Крым, Украина, НАТО экономику\n" +
+	"[00:05] Донбасс, Крым, Украина, НАТО"
+
+// TestDropScrubEmptyConfigUnchanged pins that empty/inactive drop and scrub sets
+// leave the ingest chunk segments byte-for-byte identical to the unfiltered
+// chunker, so the off-by-default path changes nothing at ingest.
+func TestDropScrubEmptyConfigUnchanged(t *testing.T) {
+	base := ingest.ChunkTranscriptByTime(scrubFixture)
+	empties := [][]string{nil, {}, {"  "}}
+	for _, drop := range empties {
+		for _, scrub := range empties {
+			got := ingest.ApplyDropScrubToSegments(base, mustDropSet(t, drop), mustDropSet(t, scrub))
+			if !reflect.DeepEqual(got, base) {
+				t.Fatalf("empty drop/scrub changed chunks:\n got %#v\nwant %#v", got, base)
+			}
+		}
+	}
+	// Nil DropSet pointers are also a no-op.
+	if got := ingest.ApplyDropScrubToSegments(base, nil, nil); !reflect.DeepEqual(got, base) {
+		t.Fatalf("nil drop/scrub changed chunks:\n got %#v\nwant %#v", got, base)
+	}
+}
+
+// TestDropSpamSegmentNeverEmbedded pins that a chunk composed entirely of
+// configured drop phrases is removed at ingest, so pure keyword-spam never
+// reaches the stored/embedded chunks, while real-speech chunks survive with
+// their time spans intact.
+func TestDropSpamSegmentNeverEmbedded(t *testing.T) {
+	base := ingest.ChunkTranscriptByTime(dropFixture)
+	got := ingest.ApplyDropScrubToSegments(base, mustDropSet(t, spamPhrases), mustDropSet(t, nil))
+	if len(got) == 0 {
+		t.Fatal("expected surviving chunks, got none")
+	}
+
+	joined := joinSegText(got)
+	// Every spam word from the dropped pure-spam line is gone from the index.
+	for _, w := range spamPhrases {
+		if strings.Contains(joined, w) {
+			t.Fatalf("drop phrase %q leaked into ingest chunks: %q", w, joined)
+		}
+	}
+	// Both real-speech lines survive.
+	if !strings.Contains(joined, "Welcome to the broadcast") {
+		t.Fatalf("expected welcome line to survive: %q", joined)
+	}
+	if !strings.Contains(joined, "экономику региона") {
+		t.Fatalf("expected real content line to survive: %q", joined)
+	}
+	// Exactly the one pure-spam chunk was removed.
+	if len(got) != len(base)-1 {
+		t.Fatalf("expected exactly one chunk dropped: got %d, base %d", len(got), len(base))
+	}
+	for _, seg := range got {
+		if seg.Span.Kind != "time" {
+			t.Fatalf("surviving chunk lost its time span: %#v", seg.Span)
+		}
+	}
+}
+
+// TestScrubExcisesLeakedPhrase pins that a leaked spam phrase glued to real
+// speech is excised at ingest (so the phrase is never embedded) while the
+// sentence is kept, and that a wholly-spam chunk that scrubs to empty is dropped.
+func TestScrubExcisesLeakedPhrase(t *testing.T) {
+	base := ingest.ChunkTranscriptByTime(scrubFixture)
+	scrub := mustDropSet(t, []string{"Донбасс, Крым, Украина, НАТО"})
+
+	got := ingest.ApplyDropScrubToSegments(base, mustDropSet(t, nil), scrub)
+	joined := joinSegText(got)
+
+	if strings.Contains(joined, "Донбасс, Крым, Украина, НАТО") {
+		t.Fatalf("scrubbed phrase leaked into ingest chunks: %q", joined)
+	}
+	// The surrounding real speech of the mixed line is kept.
+	if !strings.Contains(joined, "Сегодня обсуждаем") || !strings.Contains(joined, "экономику") {
+		t.Fatalf("scrub removed real speech: %q", joined)
+	}
+	// The wholly-spam line (scrubFixture's third line) scrubs to empty and is
+	// dropped: the real lines plus the scrubbed mixed line remain.
+	if len(got) != len(base)-1 {
+		t.Fatalf("expected the pure-spam line dropped after scrub: got %d, base %d", len(got), len(base))
+	}
+}
+
+// TestDropScrubConsistentIngestAndExport pins that the same DropSet, applied to
+// the same source, strips the same phrase at ingest (chunk segments) and at
+// export (CleanCues) — the index and the exported sidecar agree cue-for-cue.
+func TestDropScrubConsistentIngestAndExport(t *testing.T) {
+	const text = "[00:00] keep this real line\n[00:02] Крым, НАТО"
+	drop := mustDropSet(t, []string{"Крым", "НАТО"})
+
+	// Ingest side: chunk, then apply the drop cleaning as the service does.
+	ingestSegs := ingest.ApplyDropScrubToSegments(ingest.ChunkTranscriptByTime(text), drop, mustDropSet(t, nil))
+
+	// Export side: build cues from the SAME chunks and clean on export.
+	rawSegs := ingest.ChunkTranscriptByTime(text)
+	chunks := make([]subtitle.TranscriptChunk, 0, len(rawSegs))
+	for _, s := range rawSegs {
+		chunks = append(chunks, subtitle.TranscriptChunk{Text: s.Text, Span: s.Span})
+	}
+	exportCues := subtitle.CleanCues(subtitle.BuildCues(chunks), subtitle.CleanOptions{Drop: drop})
+
+	ingestJoined := joinSegText(ingestSegs)
+	var exportJoined strings.Builder
+	for _, c := range exportCues {
+		exportJoined.WriteString(c.Text)
+		exportJoined.WriteString(" ")
+	}
+
+	if strings.Contains(ingestJoined, "НАТО") {
+		t.Fatalf("drop phrase leaked at ingest: %q", ingestJoined)
+	}
+	if strings.Contains(exportJoined.String(), "НАТО") {
+		t.Fatalf("drop phrase leaked at export: %q", exportJoined.String())
+	}
+	if !strings.Contains(ingestJoined, "keep this real line") {
+		t.Fatalf("ingest dropped real content: %q", ingestJoined)
+	}
+	if !strings.Contains(exportJoined.String(), "keep this real line") {
+		t.Fatalf("export dropped real content: %q", exportJoined.String())
+	}
+}
+
+// TestDropScrubSidecarCues pins the sidecar-cue ingest path: a merged chunk with
+// a leaked spam phrase is scrubbed while the real reporting is kept.
+func TestDropScrubSidecarCues(t *testing.T) {
+	cues := []subtitle.Cue{
+		{Index: 1, StartMS: 0, EndMS: 1000, Text: "Real reporting here"},
+		{Index: 2, StartMS: 1000, EndMS: 2000, Text: "Крым, НАТО"},
+	}
+	segs := ingest.ChunkSubtitleCues(cues)
+	scrub := mustDropSet(t, []string{"Крым, НАТО"})
+
+	got := ingest.ApplyDropScrubToSegments(segs, mustDropSet(t, nil), scrub)
+	joined := joinSegText(got)
+	if strings.Contains(joined, "Крым, НАТО") {
+		t.Fatalf("scrubbed phrase leaked into sidecar chunks: %q", joined)
+	}
+	if !strings.Contains(joined, "Real reporting here") {
+		t.Fatalf("expected real cue to survive: %q", joined)
+	}
+}

--- a/tests/ingest/whisper_translate_test.go
+++ b/tests/ingest/whisper_translate_test.go
@@ -252,6 +252,42 @@ func TestWhisperTranslate_RoutesThroughQualityGate(t *testing.T) {
 	}
 }
 
+// TestWhisperTranslate_FullyScrubbedCreatesNoDanglingRep pins the #545 review
+// fix: when drop/scrub strips a translation to nothing, NO translated
+// representation row is created (and the representation count is not inflated).
+// The empty-segment check now runs before UpsertRepresentation, matching the
+// source transcript path, so a fully-spam translation leaves no dangling rep.
+func TestWhisperTranslate_FullyScrubbedCreatesNoDanglingRep(t *testing.T) {
+	t.Parallel()
+	stateDir := t.TempDir()
+	st := &fakeIngestStore{}
+	svc := mustNewIngestService(t, config.Config{
+		StateDir:                  stateDir,
+		MediaSubtitlesDropPhrases: []string{"subscribe now"},
+	}, st)
+	svc.SetTranscriber(&fakeTranscriber{text: "[00:00] привет"})
+	svc.SetTranscriptLanguage("ru")
+	// The entire translated line is spam the drop set removes, so every translated
+	// segment is dropped and the translation collapses to empty.
+	svc.SetTranslateTranscriber(
+		&fakeTranscriber{text: "[00:00] subscribe now"},
+		"whisper", "large-v3", []string{"en"})
+
+	doc := model.Document{DocID: 31, RelPath: "audio/clip.mp3", DocType: "audio"}
+	if err := svc.GenerateTranscriptRepresentation(context.Background(), doc, []byte("audio")); err != nil {
+		t.Fatalf("GenerateTranscriptRepresentation: %v", err)
+	}
+
+	for _, r := range st.reps {
+		if r.RepType == ingest.TranscriptRepType("en") {
+			t.Fatalf("fully-scrubbed translation created a dangling %q rep: %+v", ingest.TranscriptRepType("en"), r)
+		}
+	}
+	if len(st.reps) != 1 {
+		t.Fatalf("expected only the source transcript rep (no dangling translated rep), got %d: %+v", len(st.reps), st.reps)
+	}
+}
+
 // TestWhisperTranslate_AppliesFilterWords pins that media.filter_words is applied
 // to the translated English track (#538 routed the translate path through the
 // filtered chunker, matching the source track). A pure-boilerplate translated


### PR DESCRIPTION
## Problem

`media.subtitles.drop_phrases` / `scrub_phrases` (via `subtitle.DropSet`) previously cleaned **only the exported SRT/VTT sidecar** — `subtitle.CleanCues` is called solely from `internal/cli/export.go`. The same whisper keyword-spam cues (e.g. `"Донбасс, Крым, Украина, НАТО"`, ~35% of cues on some RFE/RL originals) were still chunked and **embedded into the retrieval index**, so `search` / `ask` / citations kept surfacing hallucinated spam. This is inconsistent with `media.filter_words`, already applied at ingest before embedding.

## Change

Mirror the `filter_words` precedent (`applyWordFilterToSegments`) and run the configured `DropSet` over transcript chunk segments at ingest, before embedding:

- `applyDropScrubToSegments` (internal/ingest/represent.go): applies `DropSet.IsSpam` (drop a wholly-spam chunk) and `DropSet.Scrub` (excise a leaked phrase, keep the real speech, drop only if it empties) to chunk text — reusing the **exact same** `subtitle` primitives the export path calls, so the index and the sidecar agree cue-for-cue.
- `Service.captionDropScrub` builds the sets from the same config keys (validated at config load); wired into all three ingest chunk paths: STT transcript, translated transcript, and sidecar cues.
- **Off by default:** empty phrase lists yield inactive sets and a byte-for-byte no-op, so existing corpora are unchanged until reindexed.

Spec-neutral (follows the `filter_words` precedent; SPEC §8.6.6 sanctions checks-before-index).

## Reindex note

Existing corpora indexed before this lands keep the spam until reindexed.

## Tests

New `tests/ingest/drop_scrub_test.go`: empty-config no-op (incl. nil sets), pure-spam chunk dropped, leaked phrase scrubbed while real speech kept, wholly-spam chunk scrubbed-to-empty dropped, ingest⇄export cue-for-cue consistency, and the sidecar-cue path. `make lint` clean (0 issues); `go test ./internal/ingest/... ./tests/ingest/... ./internal/subtitle/... ./tests/subtitle/...` all pass.

Closes #545

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subtitle transcript ingest now supports configured caption “drop” and “scrub” rules to remove spammy lines and redact leaked phrases for both original and translated transcripts.
  * Sidecar subtitle imports now apply the same drop/scrub cleaning for consistent caption content.

* **Bug Fixes**
  * Prevents fully scrubbed translated transcripts from creating empty/dangling stored representations.
  * When scrub removes phrases, matching per-word timings are also removed so cleaned captions don’t resurface redacted content.

* **Tests**
  * Added regression coverage for nil/empty configs, spam dropping, scrubbing behavior, timing cleanup, ingest/export consistency, and sidecar cue handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->