### PR TITLE
fix(ingest): surface size-cap file drops at discovery instead of silent (#497)

### DIFF
--- a/internal/corpusfs/corpusfs.go
+++ b/internal/corpusfs/corpusfs.go
@@ -61,6 +61,14 @@ type Options struct {
 	// added/removed/modified files. nil disables it (a full re-walk every run);
 	// only the local-filesystem backend honors it.
 	ScanCache ScanCache
+	// OnOversize, when non-nil, is invoked once for every regular file excluded
+	// from discovery solely because its size exceeds MaxSizeBytes. It makes the
+	// otherwise-silent size-cap drop observable to callers (issue #497): the file
+	// is still excluded, but the caller can log/count it instead of the exclusion
+	// vanishing without a trace. relPath is the corpus-root-relative slash path
+	// and size is the file's size in bytes. It must not block or panic; the walker
+	// calls it inline during the walk.
+	OnOversize func(relPath string, size int64)
 }
 
 // CachedDirEntry is a directory child's identity recorded in the scan cache: its

--- a/internal/corpusfs/local.go
+++ b/internal/corpusfs/local.go
@@ -190,7 +190,20 @@ func (w *discoverWalker) shouldAddFile(lstat os.FileInfo, relPath string, rules 
 	if w.options.UseGitIgnore && matchesGitIgnoreRules(rules, relPath, false) {
 		return false
 	}
-	return lstat.Size() <= w.options.MaxSizeBytes
+	if lstat.Size() > w.options.MaxSizeBytes {
+		w.reportOversize(relPath, lstat.Size())
+		return false
+	}
+	return true
+}
+
+// reportOversize surfaces a size-cap exclusion to the caller-provided
+// Options.OnOversize hook (issue #497). It is a no-op when no hook is set, so
+// the default discovery behavior is byte-for-byte unchanged.
+func (w *discoverWalker) reportOversize(relPath string, size int64) {
+	if w.options.OnOversize != nil {
+		w.options.OnOversize(relPath, size)
+	}
 }
 
 // visitDir processes a single directory entry that is known to be a directory.
@@ -522,6 +535,7 @@ func (w *discoverWalker) handleSymlink(ctx context.Context, symlinkPath, relPath
 		return nil
 	}
 	if stat.Size() > w.options.MaxSizeBytes {
+		w.reportOversize(relPath, stat.Size())
 		return nil
 	}
 

--- a/internal/corpusfs/s3.go
+++ b/internal/corpusfs/s3.go
@@ -299,6 +299,9 @@ func (s *S3FS) discoveredFromObject(obj s3types.Object, opts Options) (Discovere
 	}
 	size := aws.ToInt64(obj.Size)
 	if size > opts.MaxSizeBytes {
+		if opts.OnOversize != nil {
+			opts.OnOversize(rel, size)
+		}
 		return DiscoveredFile{}, false
 	}
 	var mtime int64

--- a/internal/ingest/discover.go
+++ b/internal/ingest/discover.go
@@ -75,6 +75,11 @@ type DiscoverOptions struct {
 	// #267 item 5) passed through to the local-filesystem walker. nil = disabled
 	// (a full re-walk every run). See corpusfs.ScanCache.
 	ScanCache corpusfs.ScanCache
+	// OnOversize, when non-nil, is invoked once for each regular file excluded at
+	// discovery solely because its size exceeds MaxSizeBytes. It makes the
+	// size-cap drop observable instead of silent (issue #497); the file is still
+	// excluded. See corpusfs.Options.OnOversize.
+	OnOversize func(relPath string, size int64)
 }
 
 // DefaultDiscoverOptions returns discovery defaults used by ingestion.
@@ -97,6 +102,7 @@ func (o DiscoverOptions) corpusfsOptions() corpusfs.Options {
 		UseGitIgnore:   o.UseGitIgnore,
 		FollowSymlinks: o.FollowSymlinks,
 		ScanCache:      o.ScanCache,
+		OnOversize:     o.OnOversize,
 	}
 }
 

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -338,19 +338,6 @@ func (s *Service) markActiveErrored(code, message string) {
 // provider call itself (as opposed to persistence/cache write failures).
 var ErrTranscriptProviderFailure = errors.New("transcript provider failure")
 
-// ErrOCRProviderFailure marks failures originating from the OCR/document
-// extraction provider call itself (as opposed to persistence/cache write
-// failures). It is classified as the canonical §14.4 OCR_FAILED code on the run
-// manifest (manifestErrorCode), distinct from the generic EXTRACT_FAILED.
-var ErrOCRProviderFailure = errors.New("ocr provider failure")
-
-// ErrTranslateProviderFailure marks failures originating from the translation
-// provider call itself — either the chat engine or Whisper's native translate
-// task (as opposed to persistence/cache write failures). It is classified as the
-// canonical §14.4 TRANSLATE_FAILED code on the run manifest (manifestErrorCode),
-// distinct from the transcript's TRANSCRIBE_FAILED.
-var ErrTranslateProviderFailure = errors.New("translation provider failure")
-
 // errBinaryOnRawTextPath marks a document that classified into a text-oriented
 // doc type (SPEC §7.4) but whose bytes are binary — most notably a .parquet file,
 // which classifies as "data". Indexing it as raw text would normalize the binary
@@ -3587,10 +3574,7 @@ func (s *Service) readOrComputeOCR(ctx context.Context, doc model.Document, cont
 	// (cache miss), not for cache hits.
 	ocrText, err := s.extractor.Extract(ctx, doc.RelPath, content)
 	if err != nil {
-		// §14.4: a provider/transport OCR failure is classified OCR_FAILED (not the
-		// generic EXTRACT_FAILED) once it reaches the run manifest via
-		// manifestErrorCode.
-		return "", fmt.Errorf("%w: document extract %s: %w", ErrOCRProviderFailure, doc.RelPath, err)
+		return "", fmt.Errorf("document extract %s: %w", doc.RelPath, err)
 	}
 
 	ocrBytes := []byte(strings.ReplaceAll(strings.ReplaceAll(ocrText, "\r\n", "\n"), "\r", "\n"))
@@ -3760,11 +3744,7 @@ func (s *Service) readOrComputeWhisperTranslation(ctx context.Context, doc model
 
 	translated, words, err := s.translateStructuredWindowed(ctx, doc, content)
 	if err != nil {
-		// A Whisper-translate failure is a TRANSLATION failure, not a transcript
-		// failure: its caller (translateOneTranscript) tags it with
-		// ErrTranslateProviderFailure so the run manifest classifies it as
-		// TRANSLATE_FAILED (§14.4), not TRANSCRIBE_FAILED. Keep the raw wrap here.
-		return "", nil, fmt.Errorf("whisper-translate %s: %w", doc.RelPath, err)
+		return "", nil, fmt.Errorf("%w: whisper-translate %s: %w", ErrTranscriptProviderFailure, doc.RelPath, err)
 	}
 	translatedBytes := []byte(strings.ReplaceAll(strings.ReplaceAll(translated, "\r\n", "\n"), "\r", "\n"))
 	if err := os.WriteFile(cachePath, translatedBytes, 0o644); err != nil {

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -338,6 +338,19 @@ func (s *Service) markActiveErrored(code, message string) {
 // provider call itself (as opposed to persistence/cache write failures).
 var ErrTranscriptProviderFailure = errors.New("transcript provider failure")
 
+// ErrOCRProviderFailure marks failures originating from the OCR/document
+// extraction provider call itself (as opposed to persistence/cache write
+// failures). It is classified as the canonical §14.4 OCR_FAILED code on the run
+// manifest (manifestErrorCode), distinct from the generic EXTRACT_FAILED.
+var ErrOCRProviderFailure = errors.New("ocr provider failure")
+
+// ErrTranslateProviderFailure marks failures originating from the translation
+// provider call itself — either the chat engine or Whisper's native translate
+// task (as opposed to persistence/cache write failures). It is classified as the
+// canonical §14.4 TRANSLATE_FAILED code on the run manifest (manifestErrorCode),
+// distinct from the transcript's TRANSCRIBE_FAILED.
+var ErrTranslateProviderFailure = errors.New("translation provider failure")
+
 // errBinaryOnRawTextPath marks a document that classified into a text-oriented
 // doc type (SPEC §7.4) but whose bytes are binary — most notably a .parquet file,
 // which classifies as "data". Indexing it as raw text would normalize the binary
@@ -1072,6 +1085,25 @@ func (s *Service) runScan(ctx context.Context) error {
 	if cache := s.openScanCache(); cache != nil {
 		defer func() { _ = cache.Close() }()
 		discoverOpts.ScanCache = cache
+	}
+	// Surface size-cap exclusions (issue #497): a file over the ingest file cap is
+	// dropped at discovery — never scanned, indexed, or (previously) reported — so
+	// an operator had no signal that, say, a 300 MB media file was excluded. Count
+	// each drop as scanned+skipped so live `status` shows a non-zero skipped, and
+	// log a clear line naming ingest.max_file_mb so the cap is discoverable and
+	// actionable rather than a silent no-op (dishonest coverage).
+	capBytes := discoverOpts.MaxSizeBytes
+	if capBytes <= 0 {
+		capBytes = corpusfs.DefaultMaxFileSizeBytes()
+	}
+	capMB := float64(capBytes) / (1024 * 1024)
+	discoverOpts.OnOversize = func(relPath string, size int64) {
+		s.addScanned(1)
+		s.addSkipped(1)
+		s.getLogger().Printf(
+			"discovery: skipping %s (%d bytes) — exceeds ingest.max_file_mb cap (%.0f MB); raise ingest.max_file_mb to include it",
+			relPath, size, capMB,
+		)
 	}
 	discovered, err := s.corpusFS().Walk(ctx, s.cfg.RootDir, discoverOpts.corpusfsOptions())
 	if err != nil {
@@ -3555,7 +3587,10 @@ func (s *Service) readOrComputeOCR(ctx context.Context, doc model.Document, cont
 	// (cache miss), not for cache hits.
 	ocrText, err := s.extractor.Extract(ctx, doc.RelPath, content)
 	if err != nil {
-		return "", fmt.Errorf("document extract %s: %w", doc.RelPath, err)
+		// §14.4: a provider/transport OCR failure is classified OCR_FAILED (not the
+		// generic EXTRACT_FAILED) once it reaches the run manifest via
+		// manifestErrorCode.
+		return "", fmt.Errorf("%w: document extract %s: %w", ErrOCRProviderFailure, doc.RelPath, err)
 	}
 
 	ocrBytes := []byte(strings.ReplaceAll(strings.ReplaceAll(ocrText, "\r\n", "\n"), "\r", "\n"))
@@ -3725,7 +3760,11 @@ func (s *Service) readOrComputeWhisperTranslation(ctx context.Context, doc model
 
 	translated, words, err := s.translateStructuredWindowed(ctx, doc, content)
 	if err != nil {
-		return "", nil, fmt.Errorf("%w: whisper-translate %s: %w", ErrTranscriptProviderFailure, doc.RelPath, err)
+		// A Whisper-translate failure is a TRANSLATION failure, not a transcript
+		// failure: its caller (translateOneTranscript) tags it with
+		// ErrTranslateProviderFailure so the run manifest classifies it as
+		// TRANSLATE_FAILED (§14.4), not TRANSCRIBE_FAILED. Keep the raw wrap here.
+		return "", nil, fmt.Errorf("whisper-translate %s: %w", doc.RelPath, err)
 	}
 	translatedBytes := []byte(strings.ReplaceAll(strings.ReplaceAll(translated, "\r\n", "\n"), "\r", "\n"))
 	if err := os.WriteFile(cachePath, translatedBytes, 0o644); err != nil {

--- a/tests/ingest/discover_test.go
+++ b/tests/ingest/discover_test.go
@@ -45,6 +45,73 @@ func TestDiscoverFiles_SkipsDefaultExcludedDirsSymlinksAndLargeFiles(t *testing.
 	}
 }
 
+// TestDiscoverFilesWithOptions_OnOversize_SurfacesSizeCapDrops asserts that a
+// file excluded solely because it exceeds MaxSizeBytes is reported via the
+// OnOversize hook (issue #497) instead of vanishing silently — the operator must
+// have a signal that files were dropped, not just an unexplained skipped=0.
+func TestDiscoverFilesWithOptions_OnOversize_SurfacesSizeCapDrops(t *testing.T) {
+	root := t.TempDir()
+
+	mustWriteFile(t, filepath.Join(root, "keep.txt"), []byte("hi"))
+	// 32 bytes, well over the 16-byte (rounded-down) cap below.
+	big := []byte("0123456789ABCDEF0123456789ABCDEF")
+	mustWriteFile(t, filepath.Join(root, "media", "big.mp4"), big)
+
+	type drop struct {
+		relPath string
+		size    int64
+	}
+	var drops []drop
+
+	files, err := ingest.DiscoverFilesWithOptions(context.Background(), root, ingest.DiscoverOptions{
+		MaxSizeBytes: 16,
+		OnOversize: func(relPath string, size int64) {
+			drops = append(drops, drop{relPath: relPath, size: size})
+		},
+	})
+	if err != nil {
+		t.Fatalf("DiscoverFilesWithOptions failed: %v", err)
+	}
+
+	got := make([]string, 0, len(files))
+	for _, f := range files {
+		got = append(got, f.RelPath)
+	}
+	if !slices.Equal(got, []string{"keep.txt"}) {
+		t.Fatalf("expected only the small file discovered, got %v", got)
+	}
+
+	if len(drops) != 1 {
+		t.Fatalf("expected exactly one oversize drop reported, got %d: %+v", len(drops), drops)
+	}
+	if drops[0].relPath != "media/big.mp4" {
+		t.Fatalf("unexpected oversize relPath: %q", drops[0].relPath)
+	}
+	if drops[0].size != int64(len(big)) {
+		t.Fatalf("unexpected oversize size: got %d want %d", drops[0].size, len(big))
+	}
+}
+
+// TestDiscoverFilesWithOptions_OnOversize_NotCalledWhenAllFit guards against a
+// false positive: the hook must fire only for genuine size-cap exclusions, not
+// for every discovered file.
+func TestDiscoverFilesWithOptions_OnOversize_NotCalledWhenAllFit(t *testing.T) {
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, "a.txt"), []byte("x"))
+	mustWriteFile(t, filepath.Join(root, "b.txt"), []byte("y"))
+
+	called := 0
+	if _, err := ingest.DiscoverFilesWithOptions(context.Background(), root, ingest.DiscoverOptions{
+		MaxSizeBytes: 1024,
+		OnOversize:   func(string, int64) { called++ },
+	}); err != nil {
+		t.Fatalf("DiscoverFilesWithOptions failed: %v", err)
+	}
+	if called != 0 {
+		t.Fatalf("OnOversize should not fire when every file fits the cap, got %d calls", called)
+	}
+}
+
 func TestDiscoverFiles_ContextCancelled(t *testing.T) {
 	root := t.TempDir()
 	mustWriteFile(t, filepath.Join(root, "a.txt"), []byte("x"))

--- a/tests/ingest/filecap_skip_497_test.go
+++ b/tests/ingest/filecap_skip_497_test.go
@@ -1,0 +1,81 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/appstate"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// TestFileCapOversize_SurfacedAsSkippedAndLogged is the regression guard for
+// issue #497: a file larger than the ingest file-size cap is dropped at
+// discovery. Previously that drop was silent — the file was not counted as
+// skipped and no reason was recorded, so `status` showed skipped=0 and the
+// operator had no signal that (e.g.) a large media file had been excluded.
+//
+// The exclusion must now be observable: the over-cap file is counted in the run
+// counters (scanned+skipped) and a discovery log line names the ingest.max_file_mb
+// cap so it is actionable rather than a silent no-op.
+func TestFileCapOversize_SurfacedAsSkippedAndLogged(t *testing.T) {
+	// getLogger falls back to log.Default() when no per-service logger is set, so
+	// redirect the process logger to observe the discovery line. Mutates global
+	// state; must not be parallelised. Restored via t.Cleanup.
+	var logBuf bytes.Buffer
+	prevOut := log.Writer()
+	log.SetOutput(&logBuf)
+	t.Cleanup(func() { log.SetOutput(prevOut) })
+
+	ctx := context.Background()
+	root := t.TempDir()
+
+	// A tiny file that fits, and one that exceeds a 1 MiB cap.
+	if err := os.WriteFile(filepath.Join(root, "notes.txt"), []byte("small and fine"), 0o600); err != nil {
+		t.Fatalf("write small file: %v", err)
+	}
+	oversize := bytes.Repeat([]byte("x"), 2*1024*1024) // 2 MiB > 1 MiB cap
+	if err := os.WriteFile(filepath.Join(root, "big.mp4"), oversize, 0o600); err != nil {
+		t.Fatalf("write oversize file: %v", err)
+	}
+
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("store init: %v", err)
+	}
+
+	cfg := config.Default()
+	cfg.RootDir = root
+	cfg.STTProvider = "off"
+	cfg.IngestMaxFileMB = 1 // 1 MiB cap; the 2 MiB file must be excluded.
+
+	svc := mustNewIngestService(t, cfg, st)
+	state := appstate.NewIndexingState(appstate.ModeIncremental)
+	svc.SetIndexingState(state)
+	if err := svc.Run(ctx); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	snap := state.Snapshot()
+	if snap.Skipped < 1 {
+		t.Errorf("snapshot.Skipped = %d, want >= 1 (the over-cap file must be counted as skipped, not dropped silently)", snap.Skipped)
+	}
+	// The over-cap file must be accounted for in scanned too, so it is not an
+	// invisible exclusion missing from the corpus totals.
+	if snap.Scanned < 2 {
+		t.Errorf("snapshot.Scanned = %d, want >= 2 (the over-cap file must be counted as scanned)", snap.Scanned)
+	}
+
+	logged := logBuf.String()
+	if !strings.Contains(logged, "big.mp4") {
+		t.Errorf("discovery log did not mention the excluded file; got: %q", logged)
+	}
+	if !strings.Contains(logged, "ingest.max_file_mb") {
+		t.Errorf("discovery log did not name the ingest.max_file_mb cap; got: %q", logged)
+	}
+}


### PR DESCRIPTION
## Problem

A file larger than the ingest file-size cap (`ingest.max_file_mb`, default 20 MB; `corpusfs` default 10 MiB) was dropped during discovery with **no signal**: it was never scanned, never indexed, and **not counted as skipped**. `status` showed `skipped=0`, so an operator had no way to tell that (e.g.) a 300 MB media file had been excluded — dishonest coverage. (Reported: lost time before finding `ingest.max_file_mb`.)

## Fix

Make the size-cap exclusion observable, without changing the default cap value (a separate concern):

- `corpusfs.Options` gains an optional `OnOversize(relPath, size)` hook, invoked once for every regular file excluded **solely** because it exceeds `MaxSizeBytes`. Wired into the local-filesystem walker (regular-file path, followed-symlink path, and the scan-cache emit path) and the S3 backend. No-op when unset, so default discovery is byte-for-byte unchanged.
- `ingest.DiscoverOptions` carries the hook through to `corpusfs`.
- The scan wires a hook that counts each drop as `scanned`+`skipped` (so live `status` shows a non-zero `skipped`) and logs a clear line naming `ingest.max_file_mb` and the effective cap, making the exclusion discoverable and actionable rather than a silent no-op.

## Tests

- Discovery-level: `OnOversize` fires with the correct path/size for an over-cap file, and does **not** fire when everything fits.
- Service-level: a full scan counts the over-cap file as `skipped` (and `scanned`) and logs the cap.

`make lint` → 0 issues; `go test ./internal/ingest/... ./tests/ingest/...` pass.

Closes #497