### PR TITLE
fix(ingest): emit distinct TRANSLATE_FAILED / OCR_FAILED codes (#473, §14.4)

### DIFF
--- a/internal/ingest/batch.go
+++ b/internal/ingest/batch.go
@@ -26,11 +26,13 @@ import (
 // unconfigured, so a default ingest is byte-identical to today.
 
 // Canonical §14.4 error codes recorded in a manifest record's `error_code`
-// field (§7.7). EXTRACT_FAILED is the generic representation/derivation failure;
-// TRANSCRIBE_FAILED is distinguished via the package's transcript-failure
-// sentinel. OCR_FAILED / TRANSLATE_FAILED are the finer output-quality-gate
-// classifications (§8.6.6): a degenerate OCR/translation output rejected by the
-// gate records the matching code via qualityGateFailureCode (service.go).
+// field (§7.7). EXTRACT_FAILED is the generic representation/derivation failure.
+// TRANSCRIBE_FAILED / OCR_FAILED / TRANSLATE_FAILED are distinguished via the
+// package's provider-failure sentinels (ErrTranscriptProviderFailure /
+// ErrOCRProviderFailure / ErrTranslateProviderFailure) in manifestErrorCode, and
+// ALSO cover the degenerate-output quality-gate sub-case (§8.6.6): an OCR /
+// transcript / translation output rejected by the gate records the matching code
+// via qualityGateFailureCode (service.go).
 const (
 	manifestErrTranscribeFailed = "TRANSCRIBE_FAILED"
 	manifestErrExtractFailed    = "EXTRACT_FAILED"
@@ -39,13 +41,22 @@ const (
 )
 
 // manifestErrorCode maps a per-asset processing error to a canonical §14.4 code
-// for the run manifest. It distinguishes a transcript-provider failure; any other
-// representation/derivation failure is recorded as the generic EXTRACT_FAILED.
+// for the run manifest. It distinguishes translation, OCR, and transcript
+// provider failures via their sentinels (TRANSLATE_FAILED / OCR_FAILED /
+// TRANSCRIBE_FAILED); any other representation/derivation failure is recorded as
+// the generic EXTRACT_FAILED. Translate is matched first because a Whisper-engine
+// translation failure is a translation failure, not a transcription one.
 func manifestErrorCode(err error) string {
-	if errors.Is(err, ErrTranscriptProviderFailure) {
+	switch {
+	case errors.Is(err, ErrTranslateProviderFailure):
+		return manifestErrTranslateFailed
+	case errors.Is(err, ErrOCRProviderFailure):
+		return manifestErrOCRFailed
+	case errors.Is(err, ErrTranscriptProviderFailure):
 		return manifestErrTranscribeFailed
+	default:
+		return manifestErrExtractFailed
 	}
-	return manifestErrExtractFailed
 }
 
 // batchManifestStatus is a terminal per-asset outcome (SPEC §8.6.11).

--- a/internal/ingest/errcode_test.go
+++ b/internal/ingest/errcode_test.go
@@ -1,0 +1,111 @@
+package ingest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// TestManifestErrorCode pins the §14.4 classification: translation, OCR, and
+// transcript provider failures each map to their distinct canonical code, and
+// any other failure falls back to the generic EXTRACT_FAILED. The sentinels are
+// matched through fmt.Errorf %w wrapping (as the real failure sites wrap them).
+func TestManifestErrorCode(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "translate provider failure -> TRANSLATE_FAILED",
+			err:  fmt.Errorf("%w: translate transcript into %q: %w", ErrTranslateProviderFailure, "en", errors.New("chat down")),
+			want: manifestErrTranslateFailed,
+		},
+		{
+			name: "ocr provider failure -> OCR_FAILED",
+			err:  fmt.Errorf("%w: document extract %s: %w", ErrOCRProviderFailure, "scan.pdf", errors.New("ocr down")),
+			want: manifestErrOCRFailed,
+		},
+		{
+			name: "transcript provider failure -> TRANSCRIBE_FAILED",
+			err:  fmt.Errorf("%w: transcribe %s: %w", ErrTranscriptProviderFailure, "talk.mp3", errors.New("stt down")),
+			want: manifestErrTranscribeFailed,
+		},
+		{
+			name: "other failure -> EXTRACT_FAILED",
+			err:  errors.New("some generic derivation failure"),
+			want: manifestErrExtractFailed,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := manifestErrorCode(tc.err); got != tc.want {
+				t.Fatalf("manifestErrorCode = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// failingExtractor is a model.DocumentExtractor whose Extract always errors,
+// simulating an OCR provider/transport failure.
+type failingExtractor struct{}
+
+func (failingExtractor) Extract(_ context.Context, _ string, _ []byte) (string, error) {
+	return "", errors.New("ocr provider unavailable")
+}
+
+// TestReadOrComputeOCR_ProviderFailureTaggedOCRFailed proves the OCR compute path
+// tags a provider/transport failure with ErrOCRProviderFailure, so the run
+// manifest classifies it OCR_FAILED (§14.4) rather than the generic
+// EXTRACT_FAILED.
+func TestReadOrComputeOCR_ProviderFailureTaggedOCRFailed(t *testing.T) {
+	s := &Service{
+		cfg:       config.Config{StateDir: t.TempDir()},
+		extractor: failingExtractor{},
+	}
+	_, err := s.readOrComputeOCR(context.Background(), model.Document{RelPath: "scan.pdf"}, []byte("bytes"))
+	if err == nil {
+		t.Fatal("expected an OCR provider failure, got nil")
+	}
+	if !errors.Is(err, ErrOCRProviderFailure) {
+		t.Fatalf("error not tagged ErrOCRProviderFailure: %v", err)
+	}
+	if got := manifestErrorCode(err); got != manifestErrOCRFailed {
+		t.Fatalf("manifestErrorCode = %q, want %q", got, manifestErrOCRFailed)
+	}
+}
+
+// failingGenerator is a model.Generator whose Generate always errors, simulating
+// a chat translation provider failure.
+type failingGenerator struct{}
+
+func (failingGenerator) Generate(_ context.Context, _ string) (string, error) {
+	return "", errors.New("chat provider unavailable")
+}
+
+// TestTranslateOneTranscript_ProviderFailureTaggedTranslateFailed proves the
+// translation path tags a provider/transport failure with
+// ErrTranslateProviderFailure, so the run manifest classifies it TRANSLATE_FAILED
+// (§14.4) — distinct from the transcript's TRANSCRIBE_FAILED.
+func TestTranslateOneTranscript_ProviderFailureTaggedTranslateFailed(t *testing.T) {
+	s := &Service{
+		cfg:        config.Config{StateDir: t.TempDir()},
+		translator: failingGenerator{},
+	}
+	doc := model.Document{RelPath: "audio/talk.mp3", DocType: "audio"}
+	err := s.translateOneTranscript(context.Background(), doc, []byte("audio"), "[00:00] hallo", "de", "en", time.Second, 0)
+	if err == nil {
+		t.Fatal("expected a translation provider failure, got nil")
+	}
+	if !errors.Is(err, ErrTranslateProviderFailure) {
+		t.Fatalf("error not tagged ErrTranslateProviderFailure: %v", err)
+	}
+	if got := manifestErrorCode(err); got != manifestErrTranslateFailed {
+		t.Fatalf("manifestErrorCode = %q, want %q", got, manifestErrTranslateFailed)
+	}
+}

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -338,6 +338,19 @@ func (s *Service) markActiveErrored(code, message string) {
 // provider call itself (as opposed to persistence/cache write failures).
 var ErrTranscriptProviderFailure = errors.New("transcript provider failure")
 
+// ErrOCRProviderFailure marks failures originating from the OCR/document
+// extraction provider call itself (as opposed to persistence/cache write
+// failures). It is classified as the canonical §14.4 OCR_FAILED code on the run
+// manifest (manifestErrorCode), distinct from the generic EXTRACT_FAILED.
+var ErrOCRProviderFailure = errors.New("ocr provider failure")
+
+// ErrTranslateProviderFailure marks failures originating from the translation
+// provider call itself — either the chat engine or Whisper's native translate
+// task (as opposed to persistence/cache write failures). It is classified as the
+// canonical §14.4 TRANSLATE_FAILED code on the run manifest (manifestErrorCode),
+// distinct from the transcript's TRANSCRIBE_FAILED.
+var ErrTranslateProviderFailure = errors.New("translation provider failure")
+
 // errBinaryOnRawTextPath marks a document that classified into a text-oriented
 // doc type (SPEC §7.4) but whose bytes are binary — most notably a .parquet file,
 // which classifies as "data". Indexing it as raw text would normalize the binary
@@ -1719,6 +1732,12 @@ func (s *Service) deriveDocument(ctx context.Context, f DiscoveredFile, secretPa
 	if err := s.deriveTranscriptTranslations(ctx, doc, content); err != nil {
 		s.getLogger().Printf("two-phase derivation translation skipped for %s: %v", f.RelPath, err)
 		s.addErrors(1)
+		// §8.6.11/§14.4: record the canonical translation-failure code
+		// (TRANSLATE_FAILED for a provider failure) on the derivation-pass manifest
+		// record; the source transcript (persisted in the transcription pass) stays
+		// searchable, so documents.status is untouched. No-op with no batch run.
+		code := manifestErrorCode(err)
+		s.markActiveErrored(code, code+": transcript translation failed")
 	}
 	return nil
 }
@@ -3136,6 +3155,14 @@ func (s *Service) generateTranscriptRepresentation(ctx context.Context, doc mode
 	if err := s.translateTranscriptRepresentations(ctx, doc, content, transcriptText, duration, trimOffsetMS); err != nil {
 		s.getLogger().Printf("transcript translation skipped for %s: %v", doc.RelPath, err)
 		s.addErrors(1)
+		// §8.6.11/§14.4: record the canonical translation-failure code
+		// (TRANSLATE_FAILED for a provider failure) on the run manifest so the
+		// manifest faithfully reports the failed derivation. The source transcript
+		// was already persisted and stays searchable, so documents.status is left
+		// "ok" (best-effort translation, #426). This is a manifest-only signal and
+		// a no-op when no batch run is active.
+		code := manifestErrorCode(err)
+		s.markActiveErrored(code, code+": transcript translation failed")
 	}
 	return nil
 }
@@ -3256,7 +3283,10 @@ func (s *Service) translateOneTranscript(ctx context.Context, doc model.Document
 		translated, err = s.readOrComputeTranslation(ctx, content, sourceText, targetLang)
 	}
 	if err != nil {
-		return fmt.Errorf("translate transcript for %s into %q: %w", doc.RelPath, targetLang, err)
+		// §14.4: a translation provider/transport failure (chat OR whisper engine)
+		// is classified TRANSLATE_FAILED — distinct from the transcript's
+		// TRANSCRIBE_FAILED — when recorded on the run manifest (manifestErrorCode).
+		return fmt.Errorf("%w: translate transcript for %s into %q: %w", ErrTranslateProviderFailure, doc.RelPath, targetLang, err)
 	}
 	translated = strings.TrimSpace(translated)
 	if translated == "" {
@@ -3555,7 +3585,10 @@ func (s *Service) readOrComputeOCR(ctx context.Context, doc model.Document, cont
 	// (cache miss), not for cache hits.
 	ocrText, err := s.extractor.Extract(ctx, doc.RelPath, content)
 	if err != nil {
-		return "", fmt.Errorf("document extract %s: %w", doc.RelPath, err)
+		// §14.4: a provider/transport OCR failure is classified OCR_FAILED (not the
+		// generic EXTRACT_FAILED) once it reaches the run manifest via
+		// manifestErrorCode.
+		return "", fmt.Errorf("%w: document extract %s: %w", ErrOCRProviderFailure, doc.RelPath, err)
 	}
 
 	ocrBytes := []byte(strings.ReplaceAll(strings.ReplaceAll(ocrText, "\r\n", "\n"), "\r", "\n"))

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -3758,7 +3758,11 @@ func (s *Service) readOrComputeWhisperTranslation(ctx context.Context, doc model
 
 	translated, words, err := s.translateStructuredWindowed(ctx, doc, content)
 	if err != nil {
-		return "", nil, fmt.Errorf("%w: whisper-translate %s: %w", ErrTranscriptProviderFailure, doc.RelPath, err)
+		// A whisper-translate decode is a TRANSLATION failure (§14.4 TRANSLATE_FAILED),
+		// not a transcript one — tag it with the translate sentinel directly so the
+		// error chain is unambiguous (previously it carried ErrTranscriptProviderFailure
+		// and relied on manifestErrorCode's ordering to still classify it correctly).
+		return "", nil, fmt.Errorf("%w: whisper-translate %s: %w", ErrTranslateProviderFailure, doc.RelPath, err)
 	}
 	translatedBytes := []byte(strings.ReplaceAll(strings.ReplaceAll(translated, "\r\n", "\n"), "\r", "\n"))
 	if err := os.WriteFile(cachePath, translatedBytes, 0o644); err != nil {


### PR DESCRIPTION
## What & why

Spec **§14.4** defines distinct `TRANSLATE_FAILED` and `OCR_FAILED` error codes, and the run manifest (§8.6.11) advertises them. But **provider/transport** failures on those paths were mis-classified: OCR extract failures collapsed into the generic `EXTRACT_FAILED`, and Whisper-translate failures were wrongly tagged with the transcript sentinel (→ `TRANSCRIBE_FAILED`). Only the degenerate-output quality-gate sub-case emitted the finer codes.

This is **conformance to the pinned spec** (codes already exist in `dirstral-spec/docs/SPEC.md` §14.4) — no spec PR required.

## Changes

- Add `ErrOCRProviderFailure` / `ErrTranslateProviderFailure` sentinels next to the existing `ErrTranscriptProviderFailure`.
- Tag OCR extract failures (`readOrComputeOCR`) and translation-compute failures (`translateOneTranscript`, both chat and Whisper engines) with the matching sentinel; drop the mis-applied transcript sentinel from the Whisper-translate path.
- `manifestErrorCode` classifies all three sentinels → `TRANSCRIBE_FAILED` / `OCR_FAILED` / `TRANSLATE_FAILED` (translate matched first so a Whisper-engine translation failure isn't read as a transcription failure); everything else stays `EXTRACT_FAILED`.
- Record the canonical translate-failure code on the run manifest at the best-effort translation swallow points (single-pass and two-phase). `documents.status` stays `ok` — the source transcript remains searchable (preserves the #426 best-effort-translation invariant and `TestTranscriptTranslation_FailureIsNonFatal`).

The structured error shape (Code/Message/Retryable/Cause) is preserved; only the classification is corrected.

## Tests

`internal/ingest/errcode_test.go`:
- `TestManifestErrorCode` — table asserts the four-way mapping.
- `TestReadOrComputeOCR_ProviderFailureTaggedOCRFailed` — a failing extractor yields `OCR_FAILED`.
- `TestTranslateOneTranscript_ProviderFailureTaggedTranslateFailed` — a failing translator yields `TRANSLATE_FAILED`.

`make lint` → 0 issues. `go test ./internal/ingest ./tests/ingest ./tests/mcp` all green.

Closes #473

🤖 Generated with [Claude Code](https://claude.com/claude-code)
