### PR TITLE
fix(retrieval): decay before top-k, no negative-score inversion, page/regex edges (#427)

### DIFF
--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -31,7 +31,10 @@ var (
 	codeKeywordRe   = regexp.MustCompile(`\b(func|class|package|import|return|if|for|while|switch|case)\b`)
 	codePunctRe     = regexp.MustCompile(`[(){}\[\];]`)
 	fileExtensionRe = regexp.MustCompile(`\.(js|ts|py|go|java|rb|cpp|c|cs|html|css|json|yaml|yml)\b`)
-	timePrefixRe    = regexp.MustCompile(`^\s*\[?(\d{1,2}):(\d{2})(?::(\d{2}))?\]?\s*(.*)$`)
+	// The lead field allows up to 3 digits so single-field MM:SS transcripts
+	// past 99 minutes (e.g. "[100:30]") still parse for open_file time slicing
+	// (#427); with the optional third field present it is the HH of HH:MM:SS.
+	timePrefixRe = regexp.MustCompile(`^\s*\[?(\d{1,3}):(\d{2})(?::(\d{2}))?\]?\s*(.*)$`)
 )
 
 var defaultPathExcludes = []string{
@@ -1087,11 +1090,27 @@ func (s *Service) search(ctx context.Context, query model.SearchQuery) ([]model.
 		k = 15
 	}
 
+	// When recency decay is active it re-scores each hit by its source-document
+	// age and can reorder candidates — promoting a fresh, highly-relevant doc
+	// that pure relevance ranked at k+1..k+n. Retrieving only k would truncate
+	// those away before decay ever sees them (and, if decay then pushed some
+	// top-k hits below the floor, return fewer than k), so widen the retrieval
+	// pool to the fusion/rerank pool size, decay that wider pool, then truncate
+	// to the caller's k below (#427). With decay off, poolK == k so the pipeline
+	// is byte-identical to before.
+	poolK := k
+	s.metaMu.RLock()
+	decayActive := s.recencyHalfLife > 0
+	s.metaMu.RUnlock()
+	if decayActive && poolK < recencyDecayCandidatePool {
+		poolK = recencyDecayCandidatePool
+	}
+
 	// Cross-lingual query expansion (#325) wraps the HyDE/per-mode pipeline: when
 	// active it runs that pipeline once per query-language variant and RRF-fuses
 	// the result sets; when inactive it reduces to a single searchWithHyDE call,
 	// so the un-expanded path is unchanged.
-	hits, err := s.searchExpanded(ctx, query, k)
+	hits, err := s.searchExpanded(ctx, query, poolK)
 	if err != nil {
 		return nil, err
 	}
@@ -1105,6 +1124,10 @@ func (s *Service) search(ctx context.Context, query model.SearchQuery) ([]model.
 	// and the recency decay, using each hit's final authoritative Score.
 	// Config-only; default 0 ⇒ pass-through.
 	hits = s.applyMinScoreFloor(hits)
+	// Truncate to the caller's k only now — after decay reordering and the floor
+	// have run over the wider pool — so decay determines top-k membership and the
+	// floor can surface k+1..k+n survivors. A no-op when poolK == k (#427).
+	hits = truncateSearchHits(hits, k)
 	// Prune (and evict) any chunk the store has since tombstoned — the partial
 	// incremental-reindex staleness of issue #409. Done LAST, on the small final
 	// result set, so at most k store lookups run per query and deleted content is
@@ -1303,6 +1326,12 @@ func (s *Service) generateHyDEDocument(ctx context.Context, gen model.Generator,
 	return truncateHyDEAnswer(generated)
 }
 
+// recencyDecayCandidatePool is the widened retrieval pool size used when the
+// opt-in recency decay is active, so decay re-ranks a pool larger than the
+// caller's k before the final truncation (#427). Matches the fusion/rerank
+// candidate pool sizes so decay sees the same breadth of candidates.
+const recencyDecayCandidatePool = 50
+
 // applyRecencyDecay multiplies each hit's final authoritative Score by an
 // exponential time-decay exp(-ln2 * age / half_life), where age is the hit's
 // source document mtime relative to a fixed "now" captured once at the start of
@@ -1355,7 +1384,15 @@ func (s *Service) applyRecencyDecay(ctx context.Context, hits []model.SearchHit)
 			continue
 		}
 		factor := math.Exp(-math.Ln2 * ageSec / halfLifeSec)
-		out[i].Score *= factor
+		// Multiplicative decay (factor ∈ (0,1]) only lowers a POSITIVE score with
+		// age; applied to a negative score it moves it toward 0 — i.e. raises it —
+		// so an older doc would outrank a newer one (rank inversion, #427).
+		// Negative similarities are reachable (in-process cosine, pgvector,
+		// qdrant) and unfiltered when min_score=0. Only decay non-negative scores;
+		// a score <= 0 is left untouched so decay never inverts ordering.
+		if out[i].Score > 0 {
+			out[i].Score *= factor
+		}
 	}
 	sort.SliceStable(out, func(i, j int) bool {
 		if out[i].Score != out[j].Score {
@@ -3542,6 +3579,14 @@ func slicePage(content string, page int) (string, bool) {
 		page = 1
 	}
 	parts := strings.Split(content, "\f")
+	// A form-feed terminator on the final page yields a trailing empty segment
+	// (e.g. "p1\fp2\f" splits into 3 parts), which would otherwise present a
+	// phantom empty page beyond the last real one — open_file page=3 on a
+	// 2-page doc returning "" with ok=true. Drop it so the page count reflects
+	// real pages and an out-of-range index errors instead (#427).
+	if len(parts) > 1 && parts[len(parts)-1] == "" {
+		parts = parts[:len(parts)-1]
+	}
 	if len(parts) > 1 {
 		if page > len(parts) {
 			return "", false

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -3594,7 +3594,10 @@ func slicePage(content string, page int) (string, bool) {
 		return strings.Trim(parts[page-1], "\n"), true
 	}
 	if page == 1 {
-		return content, true
+		// parts[0], not content: a single-page doc ending in a form-feed splits to
+		// ["text", ""] and the trailing-empty drop above leaves ["text"], so
+		// returning content would re-attach the stripped \f (#427 review).
+		return parts[0], true
 	}
 	return "", false
 }

--- a/internal/retrieval/slice_regex_427_test.go
+++ b/internal/retrieval/slice_regex_427_test.go
@@ -1,0 +1,59 @@
+package retrieval
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSlicePage_NoPhantomTrailingPage pins #427: a form-feed-terminated document
+// ("p1\fp2\f") must expose exactly its real pages. The trailing empty segment
+// from strings.Split must not present a phantom page beyond the last, so an
+// out-of-range page index errors (ok=false) rather than returning "" with ok=true.
+func TestSlicePage_NoPhantomTrailingPage(t *testing.T) {
+	content := "page one\fpage two\f" // 2 real pages, terminating form-feed
+
+	if got, ok := slicePage(content, 1); !ok || got != "page one" {
+		t.Fatalf("page 1: got (%q,%v), want (%q,true)", got, ok, "page one")
+	}
+	if got, ok := slicePage(content, 2); !ok || got != "page two" {
+		t.Fatalf("page 2: got (%q,%v), want (%q,true)", got, ok, "page two")
+	}
+	// Page 3 is past the last real page: must be out-of-range, not a phantom.
+	if got, ok := slicePage(content, 3); ok || got != "" {
+		t.Fatalf("phantom page 3: got (%q,%v), want (\"\",false)", got, ok)
+	}
+}
+
+// TestTimePrefixRe_MinutesOver99 pins #427: single-field MM:SS transcript lines
+// past 99 minutes (e.g. "[100:30]", "[123:45]") must parse for open_file time
+// slicing; the lead field previously capped at 2 digits and silently dropped them.
+func TestTimePrefixRe_MinutesOver99(t *testing.T) {
+	cases := []struct {
+		line   string
+		wantMS int
+	}{
+		{"[100:30] hundred minutes", (100*60 + 30) * 1000},
+		{"[123:45] later still", (123*60 + 45) * 1000},
+		{"[09:05] under a hundred", (9*60 + 5) * 1000},
+		{"[01:02:03] hh:mm:ss still works", (1*3600 + 2*60 + 3) * 1000},
+	}
+	for _, tc := range cases {
+		m := timePrefixRe.FindStringSubmatch(tc.line)
+		if len(m) == 0 {
+			t.Fatalf("regex did not match %q", tc.line)
+		}
+		if got := parseTimestampMS(m[1], m[2], m[3]); got != tc.wantMS {
+			t.Fatalf("parseTimestampMS(%q) = %d, want %d", tc.line, got, tc.wantMS)
+		}
+	}
+
+	// End-to-end through sliceTime: a >=100-minute cue must be selectable.
+	transcript := "[00:10] intro\n[100:30] the hundred-minute mark\n[101:00] just after"
+	out, ok := sliceTime(transcript, 100*60*1000, 101*60*1000)
+	if !ok {
+		t.Fatalf("sliceTime returned ok=false; expected timestamps to be found")
+	}
+	if !strings.Contains(out, "[100:30] the hundred-minute mark") {
+		t.Fatalf("sliceTime output %q missing the >=100-minute cue", out)
+	}
+}

--- a/internal/retrieval/slice_regex_427_test.go
+++ b/internal/retrieval/slice_regex_427_test.go
@@ -24,6 +24,24 @@ func TestSlicePage_NoPhantomTrailingPage(t *testing.T) {
 	}
 }
 
+// TestSlicePage_SinglePageTrailingFormFeed pins the #427 review fix: a single-page
+// document ending in a form-feed must return the clean text, not re-attach the
+// stripped \f (the trailing-empty drop leaves one segment, so page 1 returns
+// parts[0], not the raw content).
+func TestSlicePage_SinglePageTrailingFormFeed(t *testing.T) {
+	if got, ok := slicePage("only page\f", 1); !ok || got != "only page" {
+		t.Fatalf("single page w/ trailing form-feed: got (%q,%v), want (%q,true)", got, ok, "only page")
+	}
+	// A plain single-page doc (no form-feed) is unchanged.
+	if got, ok := slicePage("just text", 1); !ok || got != "just text" {
+		t.Fatalf("plain single page: got (%q,%v), want (%q,true)", got, ok, "just text")
+	}
+	// Page 2 of a single-page doc is out of range.
+	if got, ok := slicePage("only page\f", 2); ok || got != "" {
+		t.Fatalf("single-page page 2: got (%q,%v), want (\"\",false)", got, ok)
+	}
+}
+
 // TestTimePrefixRe_MinutesOver99 pins #427: single-field MM:SS transcript lines
 // past 99 minutes (e.g. "[100:30]", "[123:45]") must parse for open_file time
 // slicing; the lead field previously capped at 2 digits and silently dropped them.

--- a/tests/retrieval/recency_decay_test.go
+++ b/tests/retrieval/recency_decay_test.go
@@ -177,3 +177,83 @@ func TestSearch_Recency_FutureDatedNotAmplified(t *testing.T) {
 		}
 	}
 }
+
+// buildRecencyService is a variant of newRecencyService that lets a test choose
+// each candidate's raw cosine (via its stored vector) so negative-similarity and
+// top-k-membership behaviors can be pinned. Query vector is {1,0}; a candidate
+// vector v yields cosine = v·{1,0}/|v|.
+func buildRecencyService(t *testing.T, halfLife time.Duration, mtimes map[string]int64, vecs map[uint64][]float32, paths map[uint64]string) *retrieval.Service {
+	t.Helper()
+	idx := index.NewHNSWIndex("")
+	for id, v := range vecs {
+		addVec(t, idx, id, v)
+	}
+	svc := retrieval.NewService(&fakeRecencyStore{mtimes: mtimes}, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+		"mistral-embed": {1, 0},
+	}}, nil)
+	for id, p := range paths {
+		svc.SetChunkMetadata(id, model.SearchHit{RelPath: p, Snippet: "alpha " + p})
+	}
+	svc.SetRecencyHalfLife(halfLife)
+	svc.SetNowFunc(func() time.Time { return recencyNow })
+	return svc
+}
+
+// TestSearch_Recency_NegativeScoreNoInversion pins #427 (finding 2): multiplicative
+// decay must not invert ordering for NEGATIVE scores. chunk 1 (raw -0.60, NEWER)
+// should outrank chunk 2 (raw -1.00, OLDER). The buggy `score *= factor` pushes the
+// old, very-negative chunk 2 toward 0 (≈ -0.0002), lifting it above chunk 1 — an
+// inversion. The fix leaves non-positive scores untouched, preserving pure order.
+func TestSearch_Recency_NegativeScoreNoInversion(t *testing.T) {
+	mtimes := map[string]int64{
+		"new.md": recencyNow.Unix(),                            // chunk 1: fresh
+		"old.md": recencyNow.Add(-365 * 24 * time.Hour).Unix(), // chunk 2: 365d old
+	}
+	svc := buildRecencyService(t, 30*24*time.Hour, mtimes,
+		map[uint64][]float32{
+			1: {-0.6, 0.8}, // cosine -0.60 (NEWER, less negative ⇒ should rank first)
+			2: {-1, 0},     // cosine -1.00 (OLDER, more negative)
+		},
+		map[uint64]string{1: "new.md", 2: "old.md"},
+	)
+	hits, err := svc.Search(context.Background(), model.SearchQuery{Query: "alpha", K: 10})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	got := recencyChunkIDs(hits)
+	want := []uint64{1, 2}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("negative-score decay must not invert: want %v, got %v", want, got)
+	}
+}
+
+// TestSearch_Recency_DecayAffectsTopKMembership pins #427 (finding 1): decay must
+// run over a wider pool BEFORE the final top-k truncation, so a fresh doc that pure
+// relevance ranks at k+1 can still surface. With K=1, chunk 1 (raw 1.00, 365d old)
+// is the sole pre-decay top-1; the newer chunk 2 (raw 0.60, fresh) sits at k+1.
+// Before the fix, decay ran after truncation and could never promote chunk 2, so
+// the result was [1]. After the fix, decay re-ranks the wider pool and chunk 2 wins.
+func TestSearch_Recency_DecayAffectsTopKMembership(t *testing.T) {
+	mtimes := map[string]int64{
+		"old.md": recencyNow.Add(-365 * 24 * time.Hour).Unix(),
+		"new.md": recencyNow.Unix(),
+	}
+	svc := buildRecencyService(t, 30*24*time.Hour, mtimes,
+		map[uint64][]float32{
+			1: {1, 0},     // cosine 1.00 (OLD) — pre-decay rank #1
+			2: {0.6, 0.8}, // cosine 0.60 (NEW) — pre-decay rank #2 (k+1 when K=1)
+		},
+		map[uint64]string{1: "old.md", 2: "new.md"},
+	)
+	hits, err := svc.Search(context.Background(), model.SearchQuery{Query: "alpha", K: 1})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	got := recencyChunkIDs(hits)
+	if len(got) != 1 {
+		t.Fatalf("K=1 must return exactly 1 hit, got %v", got)
+	}
+	if got[0] != 2 {
+		t.Fatalf("decay must promote the fresh k+1 doc into top-1: want [2], got %v", got)
+	}
+}

--- a/tests/retrieval/recency_decay_test.go
+++ b/tests/retrieval/recency_decay_test.go
@@ -44,20 +44,15 @@ var recencyNow = time.Date(2026, time.June, 19, 0, 0, 0, 0, time.UTC)
 // {1, 0}: chunk 1 (older) → 1.00, chunk 2 (newer) → 0.60. Without decay chunk 1
 // outranks chunk 2; with a half-life shorter than chunk 1's extra age the decay
 // must flip the order so the newer chunk 2 wins.
+// newRecencyService is the fixed two-doc specialisation used by most recency
+// tests: chunk 1 = cosine 1.00 (old.md), chunk 2 = cosine 0.60 (new.md). It
+// delegates to buildRecencyService to avoid duplicating the index/store/embedder
+// wiring.
 func newRecencyService(t *testing.T, halfLife time.Duration, mtimes map[string]int64) *retrieval.Service {
 	t.Helper()
-	idx := index.NewHNSWIndex("")
-	addVec(t, idx, 1, []float32{1, 0})     // cosine 1.00 (OLD doc)
-	addVec(t, idx, 2, []float32{0.6, 0.8}) // cosine 0.60 (NEW doc)
-
-	svc := retrieval.NewService(&fakeRecencyStore{mtimes: mtimes}, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
-		"mistral-embed": {1, 0},
-	}}, nil)
-	svc.SetChunkMetadata(1, model.SearchHit{RelPath: "old.md", Snippet: "alpha old"})
-	svc.SetChunkMetadata(2, model.SearchHit{RelPath: "new.md", Snippet: "alpha new"})
-	svc.SetRecencyHalfLife(halfLife)
-	svc.SetNowFunc(func() time.Time { return recencyNow })
-	return svc
+	return buildRecencyService(t, halfLife, mtimes,
+		map[uint64][]float32{1: {1, 0}, 2: {0.6, 0.8}},
+		map[uint64]string{1: "old.md", 2: "new.md"})
 }
 
 func searchRecency(t *testing.T, svc *retrieval.Service) []model.SearchHit {


### PR DESCRIPTION
Fixes the three (four sub-item) scoring/slicing edge bugs in #427. All are minimal and scoped; the recency-decay findings are opt-in (`retrieval.recency_half_life` defaults off) so the default retrieval path is unchanged.

## Fixes

### 1. Recency decay applied after top-k truncation (`service.go` `search()`)
`searchExpanded` already truncated to `k` before `applyRecencyDecay` ran, so a fresh, highly-relevant doc ranked at k+1 could never be surfaced, and decay pushing top-k hits below `min_score` could return fewer than k. Now, when decay is active, we widen the retrieval pool to the fusion/rerank candidate pool size (50), decay that wider pool, apply the floor, then truncate to the caller's `k`. With decay off, `poolK == k` and the pipeline is byte-identical to before.

### 2. Recency decay inverted ranking for negative scores (`applyRecencyDecay`)
`out[i].Score *= factor` (factor ∈ (0,1]) only lowers a positive score; for a negative score it moves toward 0 (raises it), so an older doc outranked a newer one. Negative similarities are reachable (in-process cosine, pgvector, qdrant) and unfiltered at the default `min_score=0`. Now only non-negative scores are decayed; `score <= 0` is left untouched, so decay never inverts ordering.

### 3. `slicePage` phantom trailing page on form-feed
`strings.Split(content, "\f")` on content ending in `\f` yielded a trailing empty segment, so a 2-page doc reported 3 parts and `open_file page=3` returned `""` with `ok=true`. The trailing empty segment is now dropped, so an out-of-range page errors (`ok=false`).

### 4. Transcript timestamp regex missed minutes ≥ 100
`timePrefixRe` capped the lead field at `\d{1,2}`, silently dropping single-field `MM:SS` cues past 99 minutes (`[100:30]`). The lead field now allows `\d{1,3}` (still the HH field when the optional third group is present).

## Tests
Each new test fails before the fix and passes after:
- `TestSearch_Recency_NegativeScoreNoInversion` — negative-score decay does not invert.
- `TestSearch_Recency_DecayAffectsTopKMembership` — decay promotes a fresh k+1 doc into top-1 (K=1).
- `TestSlicePage_NoPhantomTrailingPage` — page past the last real page errors, no phantom.
- `TestTimePrefixRe_MinutesOver99` — regex + `sliceTime` parse `[100:30]`/`[123:45]`.

## Verification
- `make lint`: 0 issues
- `go test ./internal/retrieval/... ./tests/retrieval/... ./tests/mcp/... ./tests/ingest/...`: all pass

Closes #427