### PR TITLE
fix(retrieval): apply min_score floor on normalized scores (#411)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3981,13 +3981,21 @@ func (c *Config) validateMediaSTTNumericBounds() error {
 	return nil
 }
 
-func (c *Config) validateRetrievalNumericBounds() error {
-	// retrieval.min_score is a relevance floor applied to MIN-MAX NORMALIZED
-	// scores in [0,1] (#411); 0 disables it. A negative floor would never drop
-	// anything, and a floor > 1 would silently drop EVERY hit, so both are
-	// rejected explicitly.
+// validateMinScore validates retrieval.min_score. The floor is applied to
+// MIN-MAX NORMALIZED scores in [0,1] (#411); 0 disables it. A negative floor
+// would never drop anything, and a floor > 1 would silently drop EVERY hit, so
+// both are rejected explicitly. Split out to keep validateRetrievalNumericBounds
+// under the cyclomatic-complexity budget.
+func (c *Config) validateMinScore() error {
 	if c.RetrievalMinScore < 0 || c.RetrievalMinScore > 1 || math.IsNaN(c.RetrievalMinScore) || math.IsInf(c.RetrievalMinScore, 0) {
 		return fmt.Errorf("retrieval.min_score must be in [0,1] (normalized relevance; 0 disables the floor): %v", c.RetrievalMinScore)
+	}
+	return nil
+}
+
+func (c *Config) validateRetrievalNumericBounds() error {
+	if err := c.validateMinScore(); err != nil {
+		return err
 	}
 	// retrieval.recency_half_life is a time-decay half-life; 0 disables it. A
 	// negative half-life would amplify rather than decay older content.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3982,10 +3982,12 @@ func (c *Config) validateMediaSTTNumericBounds() error {
 }
 
 func (c *Config) validateRetrievalNumericBounds() error {
-	// retrieval.min_score is a relevance floor; 0 disables it. A negative floor
-	// would never drop anything, so reject it explicitly.
-	if c.RetrievalMinScore < 0 || math.IsNaN(c.RetrievalMinScore) || math.IsInf(c.RetrievalMinScore, 0) {
-		return fmt.Errorf("retrieval.min_score must be a non-negative finite number: %v", c.RetrievalMinScore)
+	// retrieval.min_score is a relevance floor applied to MIN-MAX NORMALIZED
+	// scores in [0,1] (#411); 0 disables it. A negative floor would never drop
+	// anything, and a floor > 1 would silently drop EVERY hit, so both are
+	// rejected explicitly.
+	if c.RetrievalMinScore < 0 || c.RetrievalMinScore > 1 || math.IsNaN(c.RetrievalMinScore) || math.IsInf(c.RetrievalMinScore, 0) {
+		return fmt.Errorf("retrieval.min_score must be in [0,1] (normalized relevance; 0 disables the floor): %v", c.RetrievalMinScore)
 	}
 	// retrieval.recency_half_life is a time-decay half-life; 0 disables it. A
 	// negative half-life would amplify rather than decay older content.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -220,12 +220,18 @@ type Config struct {
 	// rerank/truncation. Default false (every candidate is returned as before).
 	DedupRetrieval bool
 	// RetrievalMinScore is a server-side relevance floor (config
-	// `retrieval.min_score`): candidate hits whose final (authoritative) score is
-	// strictly below this value are dropped after scoring/fusion/rerank and after
-	// dedup/truncation, before results reach the model. It is config-only (NOT an
-	// MCP tool parameter) so no tool input/output schema changes. Default 0 =
-	// disabled (no floor): behavior is unchanged unless configured, preserving the
-	// local-first, no-surprises default. Negative values are CONFIG_INVALID.
+	// `retrieval.min_score`): candidate hits whose score — MIN-MAX NORMALIZED to
+	// [0,1] over the result set — is strictly below this value are dropped after
+	// scoring/fusion/rerank and after dedup/truncation, before results reach the
+	// model. The floor is applied on the normalized score (a RELATIVE floor in
+	// [0,1]: 0 keeps everything, 1 keeps only the top hit) rather than the raw
+	// authoritative score, because raw scores are incommensurable across retrieval
+	// modes — cosine (~0..1) vs RRF (max ≈ 0.033) vs a provider rerank scale — so a
+	// single raw threshold would silently wipe out all hybrid/RRF results (#411).
+	// It is config-only (NOT an MCP tool parameter) so no tool input/output schema
+	// changes. Default 0 = disabled (no floor): behavior is unchanged unless
+	// configured, preserving the local-first, no-surprises default. Negative
+	// values are CONFIG_INVALID.
 	RetrievalMinScore float64
 	// CostPriceOverrides maps a model name to per-1K-token USD prices,
 	// overriding the built-in defaults used by the per-query query_metrics

--- a/internal/retrieval/min_score_floor_rrf_test.go
+++ b/internal/retrieval/min_score_floor_rrf_test.go
@@ -1,0 +1,116 @@
+package retrieval
+
+import (
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// floorSurvivors runs applyMinScoreFloor for the given floor over hits and
+// returns the surviving chunk IDs in order.
+func floorSurvivors(floor float64, hits []model.SearchHit) []uint64 {
+	svc := &Service{}
+	svc.SetMinScore(floor)
+	out := svc.applyMinScoreFloor(hits)
+	ids := make([]uint64, 0, len(out))
+	for _, h := range out {
+		ids = append(ids, h.ChunkID)
+	}
+	return ids
+}
+
+func eqIDs(a, b []uint64) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestApplyMinScoreFloor_RRFScaleNotWipedOut is the #411 regression: an RRF
+// (hybrid/HyDE/cross-lingual) result set has scores on the ~[0, 2/(rrfK+1)≈0.033]
+// scale, so a cosine-shaped floor (0.3–0.5) applied to the RAW score would drop
+// EVERY hit and return empty. With the normalized floor, a mid-range floor keeps
+// the genuinely-relevant top hits and only drops the genuinely-weak tail.
+func TestApplyMinScoreFloor_RRFScaleNotWipedOut(t *testing.T) {
+	// Real RRF fusion output: three chunks fused from two ranked lists. All
+	// scores are tiny (~0.02–0.033), well below any cosine-shaped floor.
+	primary := []model.SearchHit{{ChunkID: 1}, {ChunkID: 2}, {ChunkID: 3}}
+	secondary := []model.SearchHit{{ChunkID: 1}, {ChunkID: 2}, {ChunkID: 3}}
+	fused := fuseRRF(primary, secondary, 10)
+	if len(fused) != 3 {
+		t.Fatalf("setup: expected 3 fused hits, got %d", len(fused))
+	}
+	// Sanity: confirm we really are on the RRF scale, not cosine.
+	if fused[0].Score > 0.05 {
+		t.Fatalf("setup: expected RRF-scale scores (<=0.05), top=%v", fused[0].Score)
+	}
+
+	// A cosine-shaped floor of 0.5 must NOT wipe the whole set (the pre-fix bug).
+	// Chunk 1 is the strongest fused hit (normalized 1.0) and survives.
+	got := floorSurvivors(0.5, fused)
+	if len(got) == 0 {
+		t.Fatalf("floor 0.5 wiped out all RRF hits (#411 regression); got empty")
+	}
+	if got[0] != fused[0].ChunkID {
+		t.Fatalf("strongest fused hit must survive; want %d, got %v", fused[0].ChunkID, got)
+	}
+
+	// The floor still filters: floor 0 keeps everything; floor 1.0 keeps only the
+	// top-normalized hit(s); the weakest hit (normalized 0.0) drops for any floor>0.
+	if got := floorSurvivors(0, fused); len(got) != 3 {
+		t.Fatalf("floor 0 must pass through all RRF hits; got %v", got)
+	}
+	weakest := fused[len(fused)-1].ChunkID
+	for _, id := range floorSurvivors(0.01, fused) {
+		if id == weakest {
+			t.Fatalf("weakest normalized hit (chunk %d) must drop above floor 0; survived", weakest)
+		}
+	}
+}
+
+// TestApplyMinScoreFloor_Normalized pins the normalized RELATIVE semantics on a
+// hand-built score set spanning both scales, independent of any retrieval mode.
+func TestApplyMinScoreFloor_Normalized(t *testing.T) {
+	// Scores {1.0, 0.5, 0.0} → min-max normalized {1.0, 0.5, 0.0} (denom 1.0, so
+	// the normalized values are exact and boundary comparisons are fp-stable).
+	hits := []model.SearchHit{
+		{ChunkID: 1, Score: 1.0},
+		{ChunkID: 2, Score: 0.5},
+		{ChunkID: 3, Score: 0.0},
+	}
+	cases := []struct {
+		floor float64
+		want  []uint64
+	}{
+		{0, []uint64{1, 2, 3}},       // disabled: pass-through
+		{0.4, []uint64{1, 2}},        // keeps top two (norm 1.0, 0.5), drops norm 0.0
+		{0.5, []uint64{1, 2}},        // boundary: norm == floor is KEPT (strict <)
+		{0.6, []uint64{1}},           // only the top survives
+		{1.5, []uint64{}},            // above every normalized score → empty
+	}
+	for _, tc := range cases {
+		got := floorSurvivors(tc.floor, hits)
+		if !eqIDs(got, tc.want) {
+			t.Fatalf("floor %v: want %v, got %v", tc.floor, tc.want, got)
+		}
+	}
+}
+
+// TestApplyMinScoreFloor_UniformSetNotWiped pins that an all-equal-score set
+// (denominator 0) is never wiped by a floor — normalizedRelevance maps it to
+// all-1, so every hit survives any floor <= 1. Without this guard a floor would
+// drop every hit of a tied set.
+func TestApplyMinScoreFloor_UniformSetNotWiped(t *testing.T) {
+	hits := []model.SearchHit{
+		{ChunkID: 1, Score: 0.03},
+		{ChunkID: 2, Score: 0.03},
+	}
+	if got := floorSurvivors(0.9, hits); len(got) != 2 {
+		t.Fatalf("uniform-score set must not be wiped by a floor; got %v", got)
+	}
+}

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -182,10 +182,12 @@ type Service struct {
 	// grouping for that path (entries are never collapsed together).
 	groupKeyByRelPath map[string]string
 	// minScore is a server-side relevance floor (config retrieval.min_score):
-	// hits whose final (authoritative) Score is strictly below it are dropped
-	// from Search results, after scoring/fusion/rerank/dedup/truncation. It is
-	// config-only (never an MCP tool parameter). Default 0 ⇒ disabled
-	// (pass-through). Wired from config.RetrievalMinScore at construction.
+	// hits whose score — MIN-MAX NORMALIZED to [0,1] over the result set, so the
+	// floor is scale-free across cosine/RRF/rerank modes (#411) — is strictly
+	// below it are dropped from Search results, after
+	// scoring/fusion/rerank/dedup/truncation. It is config-only (never an MCP tool
+	// parameter). Default 0 ⇒ disabled (pass-through). Wired from
+	// config.RetrievalMinScore at construction. See applyMinScoreFloor.
 	minScore float64
 	// genModel is the resolved chat/generation model name, used only to label
 	// and price the generate stage in per-query metrics (issue #327). Empty
@@ -459,10 +461,13 @@ func (s *Service) SetCrossFileDedupEnabled(enabled bool) {
 }
 
 // SetMinScore wires the server-side relevance floor (config retrieval.min_score).
-// Hits whose final authoritative Score is strictly below floor are dropped from
-// Search results, after scoring/fusion/rerank and after dedup/truncation. A
-// floor <= 0 disables the cutoff (pass-through). The engine wires this from
-// config.RetrievalMinScore at construction time, mirroring SetCrossFileDedupEnabled.
+// Hits whose min-max-normalized [0,1] score is strictly below floor are dropped
+// from Search results, after scoring/fusion/rerank and after dedup/truncation
+// (the floor is applied on the normalized score, not the raw authoritative one,
+// so it is scale-free across cosine/RRF/rerank modes — see applyMinScoreFloor,
+// #411). A floor <= 0 disables the cutoff (pass-through). The engine wires this
+// from config.RetrievalMinScore at construction time, mirroring
+// SetCrossFileDedupEnabled.
 func (s *Service) SetMinScore(floor float64) {
 	s.metaMu.Lock()
 	defer s.metaMu.Unlock()
@@ -1369,12 +1374,27 @@ func (s *Service) applyRecencyDecay(ctx context.Context, hits []model.SearchHit)
 	return out
 }
 
-// applyMinScoreFloor drops hits whose final authoritative Score is strictly
-// below the configured relevance floor (config retrieval.min_score). A floor
-// <= 0 disables the cutoff and returns hits unchanged (pass-through), preserving
-// the slice identity so callers see no allocation when unconfigured. Order is
-// preserved. This runs as the very last retrieval step so the comparison uses
-// the post-rerank score (or, when rerank is off, the fused score).
+// applyMinScoreFloor drops hits whose relevance falls strictly below the
+// configured relevance floor (config retrieval.min_score). A floor <= 0 disables
+// the cutoff and returns hits unchanged (pass-through), preserving the slice
+// identity so callers see no allocation when unconfigured. Order is preserved.
+// This runs as the very last retrieval step, so the comparison sees the fully
+// resolved result set (post scoring/fusion/rerank/dedup/recency).
+//
+// The floor is compared against each hit's score MIN-MAX NORMALIZED to [0,1]
+// over the result set — NOT the raw authoritative Score — because that raw score
+// lives on an incommensurable scale per retrieval mode (#411): pure-vector is
+// cosine similarity (~0..1); hybrid / HyDE-fuse / cross-lingual is an RRF score
+// whose theoretical max is 2/(rrfK+1) ≈ 0.033; rerank is a provider-specific
+// scale. Worse, the hybrid path falls back to raw cosine hits when BM25 returns
+// nothing, so the same corpus/config can emit RRF-scaled scores for one query
+// and cosine-scaled for the next. A raw `Score < floor` comparison therefore has
+// no consistent meaning: a cosine-shaped floor (0.3–0.5) silently drops EVERY
+// RRF hit and returns empty. Normalizing per result set makes the floor
+// scale-free and mode-agnostic: it is a RELATIVE floor in [0,1] where 0 keeps
+// everything, 1 keeps only the top-scoring hit(s), and a degenerate all-equal
+// set is never wiped (normalizedRelevance maps it to all-1). The reported Score
+// field is left UNCHANGED (unnormalized), preserving the tool/citation contract.
 func (s *Service) applyMinScoreFloor(hits []model.SearchHit) []model.SearchHit {
 	s.metaMu.RLock()
 	floor := s.minScore
@@ -1382,9 +1402,10 @@ func (s *Service) applyMinScoreFloor(hits []model.SearchHit) []model.SearchHit {
 	if floor <= 0 || len(hits) == 0 {
 		return hits
 	}
+	rel := normalizedRelevance(hits)
 	out := make([]model.SearchHit, 0, len(hits))
-	for _, h := range hits {
-		if h.Score < floor {
+	for i, h := range hits {
+		if rel[i] < floor {
 			continue
 		}
 		out = append(out, h)

--- a/tests/config/retrieval_min_score_config_test.go
+++ b/tests/config/retrieval_min_score_config_test.go
@@ -123,3 +123,28 @@ func TestRetrievalMinScore_ValidateRejectsNegativeProgrammatic(t *testing.T) {
 		t.Fatalf("Validate with negative RetrievalMinScore = nil error, want rejection")
 	}
 }
+
+// TestRetrievalMinScore_RejectsAboveOne pins that a floor > 1 is CONFIG_INVALID:
+// since #411 the floor is compared against MIN-MAX NORMALIZED scores in [0,1], so
+// any value above 1 would silently drop every hit — a misconfiguration.
+func TestRetrievalMinScore_RejectsAboveOne(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+	writeFile(t, path, "retrieval_min_score: 1.5\n")
+	if _, err := config.LoadFile(path); err == nil {
+		t.Fatalf("LoadFile with retrieval_min_score > 1 = nil error, want rejection")
+	} else if !strings.Contains(err.Error(), "retrieval.min_score") {
+		t.Fatalf("error must mention retrieval.min_score, got: %v", err)
+	}
+
+	// Programmatic guard too, and the boundary 1.0 stays valid.
+	cfg := config.Default()
+	cfg.RetrievalMinScore = 1.5
+	if err := cfg.Validate(); err == nil {
+		t.Fatalf("Validate with RetrievalMinScore=1.5 = nil error, want rejection")
+	}
+	cfg.RetrievalMinScore = 1.0
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("RetrievalMinScore=1.0 must be valid (keep only the top hit), got: %v", err)
+	}
+}

--- a/tests/eval/ablation_test.go
+++ b/tests/eval/ablation_test.go
@@ -51,8 +51,9 @@ func countCrossFileDupes(relPaths []string, hashByRelPath map[string]string) int
 //   - hybrid+rerank:   + deterministic lexical reranker over the fused pool
 //   - hybrid+dedup:    + retrieval-time cross-file de-duplication (#265)
 //   - hybrid+langfilt: + per-language retrieval filter (#267 item 4)
-//   - vector+minscore: vector-only + server-side relevance floor (#305), where
-//     scores are interpretable cosine similarities
+//   - vector+minscore: vector-only + server-side relevance floor (#305), applied
+//     on the result set's min-max normalized [0,1] scores (#411), so a modest
+//     relative floor trims the low-relevance tail without dropping strong hits
 func ablationMatrix() []knobConfig {
 	return []knobConfig{
 		{name: "vector-only", hybrid: false},
@@ -60,7 +61,7 @@ func ablationMatrix() []knobConfig {
 		{name: "hybrid+rerank", hybrid: true, rerank: true},
 		{name: "hybrid+dedup", hybrid: true, crossFileDD: true},
 		{name: "hybrid+langfilt", hybrid: true, useLangs: true},
-		{name: "vector+minscore", hybrid: false, minScore: 0.7},
+		{name: "vector+minscore", hybrid: false, minScore: 0.1},
 	}
 }
 
@@ -236,9 +237,10 @@ func assertLangFilterDoesNotHurtRecall(t *testing.T, rows []configMetrics) {
 	}
 }
 
-// assertMinScoreTrimsWithoutRecallLoss: a 0.7 relevance floor on the vector path
-// drops low-similarity noise (shrinking mean hits) while keeping every
-// high-similarity relevant doc, so recall@k stays at the baseline.
+// assertMinScoreTrimsWithoutRecallLoss: a modest normalized relevance floor
+// (0.1, applied on the result set's min-max normalized [0,1] scores, #411) on the
+// vector path drops the low-relevance tail (shrinking mean hits) while keeping
+// every high-similarity relevant doc, so recall@k stays at the baseline.
 func assertMinScoreTrimsWithoutRecallLoss(t *testing.T, rows []configMetrics) {
 	t.Helper()
 	base := metricsFor(rows, "vector-only")

--- a/tests/retrieval/min_score_floor_test.go
+++ b/tests/retrieval/min_score_floor_test.go
@@ -14,13 +14,15 @@ import (
 // similarity) with the server-side relevance floor configured.
 //
 // The three candidates have deterministic cosine scores against the query
-// vector {1, 0}: chunk 1 → 1.00, chunk 2 → 0.60, chunk 3 → 0.28.
+// vector {1, 0}: chunk 1 → 1.00, chunk 2 → 0.50, chunk 3 → 0.00. Because the
+// floor is applied on the result set's MIN-MAX normalized [0,1] scores (#411,
+// scale-free across cosine/RRF/rerank), these map to normalized {1.0, 0.5, 0.0}.
 func newMinScoreFloorService(t *testing.T, floor float64) *retrieval.Service {
 	t.Helper()
 	idx := index.NewHNSWIndex("")
-	addVec(t, idx, 1, []float32{1, 0})       // cosine 1.00
-	addVec(t, idx, 2, []float32{0.6, 0.8})   // cosine 0.60 (unit vector)
-	addVec(t, idx, 3, []float32{0.28, 0.96}) // cosine 0.28 (unit vector)
+	addVec(t, idx, 1, []float32{1, 0})           // cosine 1.00 → normalized 1.0
+	addVec(t, idx, 2, []float32{0.5, 0.8660254}) // cosine 0.50 → normalized 0.5 (unit vector)
+	addVec(t, idx, 3, []float32{0, 1})           // cosine 0.00 → normalized 0.0
 
 	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
 		"mistral-embed": {1, 0},
@@ -46,10 +48,10 @@ func searchFloorChunkIDs(t *testing.T, svc *retrieval.Service) []uint64 {
 }
 
 // TestSearch_MinScoreFloor_DropsSubThresholdHits pins the core behavior: with a
-// floor of 0.5, the two strong hits (scores 1.00 and 0.60) survive and the weak
-// hit (0.28) is dropped before results reach the model.
+// floor of 0.3, the two strong hits (normalized 1.0 and 0.5) survive and the weak
+// hit (normalized 0.0) is dropped before results reach the model.
 func TestSearch_MinScoreFloor_DropsSubThresholdHits(t *testing.T) {
-	svc := newMinScoreFloorService(t, 0.5)
+	svc := newMinScoreFloorService(t, 0.3)
 	got := searchFloorChunkIDs(t, svc)
 	want := []uint64{1, 2}
 	if len(got) != len(want) {
@@ -84,10 +86,11 @@ func TestSearch_MinScoreFloor_NegativeIsPassThrough(t *testing.T) {
 }
 
 // TestSearch_MinScoreFloor_BoundaryKeepsEqual pins the cutoff semantics: a hit
-// whose score equals the floor is KEPT (strict less-than drops). With floor
-// 0.60, chunks 1 (1.00) and 2 (0.60, equal) survive; chunk 3 (0.28) is dropped.
+// whose normalized score equals the floor is KEPT (strict less-than drops). With
+// floor 0.50, chunks 1 (norm 1.0) and 2 (norm 0.5, equal) survive; chunk 3 (norm
+// 0.0) is dropped.
 func TestSearch_MinScoreFloor_BoundaryKeepsEqual(t *testing.T) {
-	svc := newMinScoreFloorService(t, 0.6)
+	svc := newMinScoreFloorService(t, 0.5)
 	got := searchFloorChunkIDs(t, svc)
 	want := []uint64{1, 2}
 	if len(got) != len(want) {
@@ -101,8 +104,8 @@ func TestSearch_MinScoreFloor_BoundaryKeepsEqual(t *testing.T) {
 }
 
 // TestSearch_MinScoreFloor_DropsAllWhenAboveEveryScore pins that an aggressive
-// floor above every candidate's score yields zero hits (the floor may legitimately
-// return fewer than k — even zero — hits).
+// floor above every candidate's normalized score (max is 1.0) yields zero hits
+// (the floor may legitimately return fewer than k — even zero — hits).
 func TestSearch_MinScoreFloor_DropsAllWhenAboveEveryScore(t *testing.T) {
 	svc := newMinScoreFloorService(t, 1.5)
 	got := searchFloorChunkIDs(t, svc)


### PR DESCRIPTION
## Problem (#411)

`internal/retrieval/service.go` `applyMinScoreFloor` compared each hit's raw authoritative `Score` against `retrieval.min_score`, but that score is on an **incommensurable scale per retrieval mode**:

- pure-vector → cosine similarity (~0..1)
- hybrid / HyDE-fuse / cross-lingual → **RRF score**, theoretical max `2/(rrfK+1) ≈ 0.033`
- rerank → provider-specific scale

The hybrid path also falls back to raw cosine hits when BM25 returns nothing (`hybrid.go:130`), so the *same corpus/config* emits RRF-scaled scores for one query and cosine-scaled for the next. A single raw threshold therefore had no consistent meaning: a cosine-shaped floor (0.3–0.5) **silently dropped every hybrid/RRF hit and returned an empty answer with no error**. This also blocked the #403 default-abstention proposal.

## Fix

Apply the floor against each result set's scores **min-max normalized to [0,1]** (reusing the existing `normalizedRelevance` helper), not the raw score. The floor becomes a scale-free **relative** floor: `0` keeps everything, `1` keeps only the top hit, and a degenerate all-equal set is never wiped. The reported `Score` field is left unchanged, so the tool/citation contract is preserved (config-only knob, no schema change).

Doc comments on `RetrievalMinScore`, `minScore`, and `SetMinScore` updated to the normalized semantics.

## Tests

- New in-package regression (`min_score_floor_rrf_test.go`): a real `fuseRRF` result set (scores ~0.02–0.033) is **not** wiped by a cosine-shaped floor of 0.5 — the strongest fused hit survives — while a floor still drops the weakest normalized hit; plus a normalized-boundary table and a uniform-set-not-wiped guard.
- Existing vector-path floor tests (`tests/retrieval/min_score_floor_test.go`) retuned to normalized `{1.0, 0.5, 0.0}` fixture.
- Eval ablation (`tests/eval/ablation_test.go`) `vector+minscore` floor retuned from the absolute-cosine 0.7 to a modest relative 0.1.

`make lint` = 0 issues. `go test ./internal/retrieval/... ./tests/retrieval/... ./tests/eval/... ./tests/mcp/... ./tests/config/...` all pass.

Closes #411