### PR TITLE
docs(readme): replace sunset Go Report Card badge with golangci-lint + Go Reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 <p align="center">
   <a href="https://github.com/Dirstral/dir2mcp/actions/workflows/go.yml"><img src="https://github.com/Dirstral/dir2mcp/actions/workflows/go.yml/badge.svg" alt="CI"></a>
   <a href="https://go.dev/"><img src="https://img.shields.io/badge/go-1.25+-00ADD8?logo=go" alt="Go 1.25+"></a>
-  <a href="https://goreportcard.com/report/github.com/Dirstral/dir2mcp"><img src="https://goreportcard.com/badge/github.com/Dirstral/dir2mcp" alt="Go Report Card"></a>
+  <a href="https://golangci-lint.run/"><img src="https://img.shields.io/badge/lint-golangci--lint-brightgreen?logo=go&logoColor=white" alt="golangci-lint"></a>
+  <a href="https://pkg.go.dev/github.com/dirstral/dir2mcp"><img src="https://pkg.go.dev/badge/github.com/dirstral/dir2mcp.svg" alt="Go Reference"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
 </p>
 
@@ -784,7 +785,7 @@ API notes:
   original `Ask` continues to exist as a thin wrapper for compatibility.
 
 `make check` includes `make lint`, which requires [`golangci-lint`](https://golangci-lint.run/welcome/install/) installed locally.
-`make cyclo` runs the cyclomatic-complexity gate used by CI. Go Report Card updates externally after the CI run; if the badge lags, refresh it from the goreportcard.com report page for this repository.
+`make cyclo` runs the cyclomatic-complexity gate used by CI. Code quality is enforced by `make lint` (golangci-lint, 0 issues) in CI — the README badge links to golangci-lint, the successor recommended by Go Report Card after it was sunset in 2026.
 
 Contributor and agent guides: [AGENTS.md](AGENTS.md) · [CLAUDE.md](CLAUDE.md)
 


### PR DESCRIPTION
Go Report Card has been permanently sunset — its report page now shows a retirement notice (no grade) and directs users to golangci-lint.

**Change:** replace the dead `goreportcard.com` badge with two working ones:
- **golangci-lint** (https://golangci-lint.run/) — the successor Go Report Card recommends, and the exact quality gate this repo enforces via `make lint` (0 issues in CI).
- **Go Reference** (pkg.go.dev) — live docs badge on the canonical lowercase module path `github.com/dirstral/dir2mcp` (the capital-D path 404s on pkg.go.dev/goreportcard since those are case-sensitive).

Also updates the stale maintenance note that referenced refreshing the goreportcard page.

Docs-only; both badge URLs verified to return 200 image/svg+xml.