### PR TITLE
feat(transcription): emit meta_json.words granularity flag (spec §8.6.9)

### DIFF
--- a/internal/ingest/derivation.go
+++ b/internal/ingest/derivation.go
@@ -82,17 +82,22 @@ func (s *Service) activeDiarizeIdentity() string {
 // active STT derivation identity (provider/model/language, §5.2/§8.6.7) so a
 // later STT model swap can be detected and the transcript re-derived. When
 // diarization is active it additionally records diarized + the diarize
-// provider/model (§8.6.8) so a diarize-backend swap re-derives too. Fields are
+// provider/model (§8.6.8) so a diarize-backend swap re-derives too. hasWords
+// sets the §8.6.9 `words` granularity flag when the transcript's segments carry
+// per-word timing. Fields are
 // omitted (omitempty) when unset, so a setup with no resolved STT identity still
 // produces valid meta_json (and an empty recorded identity that the gate treats
 // as "always passes").
-func (s *Service) sttTranscriptMetaJSON(speakers []Speaker, text string) (string, error) {
+func (s *Service) sttTranscriptMetaJSON(speakers []Speaker, text string, hasWords bool) (string, error) {
 	meta := transcriptMeta{
 		Source:     sttSource,
 		Language:   strings.TrimSpace(s.transcriptLanguage),
 		Timestamps: true,
-		Provider:   strings.TrimSpace(s.sttProvider),
-		Model:      strings.TrimSpace(s.sttModel),
+		// §8.6.9: declare word-level timing granularity when at least one segment
+		// carries a populated words array (omitempty ⇒ segment-only stays absent).
+		Words:    hasWords,
+		Provider: strings.TrimSpace(s.sttProvider),
+		Model:    strings.TrimSpace(s.sttModel),
 	}
 	// §8.8 precedence: an operator pin (media.language / per-provider
 	// stt_language, §16.2) is the "configured" language and always wins. With no

--- a/internal/ingest/represent.go
+++ b/internal/ingest/represent.go
@@ -1118,6 +1118,20 @@ func attachWordsToTimeSpans(segs []chunkSegment, words []model.TimedWord) {
 	}
 }
 
+// segmentsHaveWordTiming reports whether any transcript segment carries a
+// populated per-word timing array on its span (SPEC §8.6.9). It drives the
+// transcript-level meta_json `words` granularity flag: true iff at least one
+// segment has word-level timing attached, so a consumer can tell word timing is
+// available without inspecting every span. It never affects chunking.
+func segmentsHaveWordTiming(segs []chunkSegment) bool {
+	for i := range segs {
+		if len(segs[i].Span.Words) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // timeSpanIndexForWord returns the index of the time-spanned chunk that owns a
 // word starting at startMS, or -1 when no chunk does. A word inside [StartMS,
 // EndMS) belongs to that chunk; a word at/after the last time chunk's EndMS is

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -3144,7 +3144,7 @@ func (s *Service) generateTranscriptRepresentation(ctx context.Context, doc mode
 	// attribution that is actually present on the segments.
 	s.applyDiarization(ctx, doc, content, segments)
 
-	metaJSON, err := s.sttTranscriptMetaJSON(distinctSpeakers(segments), transcriptText)
+	metaJSON, err := s.sttTranscriptMetaJSON(distinctSpeakers(segments), transcriptText, segmentsHaveWordTiming(segments))
 	if err != nil {
 		return fmt.Errorf("marshal transcript meta: %w", err)
 	}
@@ -3380,6 +3380,9 @@ func (s *Service) translateOneTranscript(ctx context.Context, doc model.Document
 		TranslateProvider: s.translateProvider,
 		TranslateModel:    s.translateModel,
 		Timestamps:        true,
+		// §8.6.9: a whisper-translate pass carries per-word timings onto the
+		// translated segments; the chat engine leaves them empty (segment-only).
+		Words: segmentsHaveWordTiming(segments),
 	}
 	// A translated transcript's effective language is its TARGET language (SPEC
 	// §5.2/§8.8), which the operator chose (media.translate.target_langs, §16.2) —

--- a/internal/ingest/sidecar.go
+++ b/internal/ingest/sidecar.go
@@ -96,6 +96,16 @@ type transcriptMeta struct {
 	Timestamps         bool     `json:"timestamps"`
 	Format             string   `json:"format,omitempty"`
 
+	// Words records the transcript's finest CAPTURED timing granularity (SPEC
+	// §8.6.9): true iff at least one segment carries a populated extra_json.words
+	// array (per-word timing, §8.6.1). Omitted (omitempty) when no segment carries
+	// word timing, so a segment-only transcript's meta_json is unchanged. Per
+	// §8.6.9 a consumer MUST treat absent/false as "segment granularity only" and
+	// degrade gracefully — never error because word timing is missing. It is a
+	// discovery hint (a consumer can tell word timing is available without
+	// inspecting every span); it never changes chunking or citations (§8.6.9).
+	Words bool `json:"words,omitempty"`
+
 	// Provider / Model / ModelVersion record the STT derivation identity on a
 	// machine-transcribed transcript (Source == "stt", spec §5.2/§8.6.7): the
 	// resolved STT provider profile name, its model, and an optional model
@@ -431,6 +441,10 @@ func (s *Service) persistSidecarTranscript(ctx context.Context, doc model.Docume
 	if lang != "" {
 		meta.LanguageSource = langSourceDeclared
 	}
+	// §8.6.9: declare word-level granularity when a cue carried per-word timing
+	// (omitempty ⇒ a segment-only sidecar's meta_json is unchanged). Cue-based
+	// sidecars are usually segment-only, so this is normally false/absent.
+	meta.Words = segmentsHaveWordTiming(segments)
 	// A sidecar that carried <v> voice tags yields speaker-attributed segments
 	// (SPEC §8.6.8). Such a transcript is diarized WITHOUT a model, so it records
 	// diarized:true and the speakers set but NO diarize_provider/model (mirrors

--- a/tests/ingest/transcribe_test.go
+++ b/tests/ingest/transcribe_test.go
@@ -2,9 +2,11 @@ package tests
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -316,5 +318,49 @@ func TestGenerateTranscriptRepresentation_AttachesWordSpans(t *testing.T) {
 	wordsCache := filepath.Join(stateDir, "cache", "transcribe", ingest.ComputeContentHash(content)+".words.json")
 	if _, err := os.Stat(wordsCache); err != nil {
 		t.Fatalf("expected words sidecar cache at %s: %v", wordsCache, err)
+	}
+
+	// §8.6.9: a word-timed transcript declares word granularity via meta_json.words.
+	if got := transcriptMetaWordsFlag(t, st.reps[0].MetaJSON); got != true {
+		t.Errorf("meta_json.words = %v, want true for a word-timed transcript (meta=%s)", got, st.reps[0].MetaJSON)
+	}
+}
+
+// transcriptMetaWordsFlag decodes the §8.6.9 word-granularity flag from a
+// transcript representation's meta_json. A missing key decodes to false, which
+// §8.6.9 defines as "segment granularity only".
+func transcriptMetaWordsFlag(t *testing.T, metaJSON string) bool {
+	t.Helper()
+	var meta struct {
+		Words bool `json:"words"`
+	}
+	if err := json.Unmarshal([]byte(metaJSON), &meta); err != nil {
+		t.Fatalf("meta_json %q is not valid JSON: %v", metaJSON, err)
+	}
+	return meta.Words
+}
+
+// TestGenerateTranscriptRepresentation_SegmentOnlyOmitsWordsFlag asserts a
+// segment-only transcript (a plain, non-structured transcriber) records no
+// word-granularity flag, so meta_json.words is absent/false (§8.6.9).
+func TestGenerateTranscriptRepresentation_SegmentOnlyOmitsWordsFlag(t *testing.T) {
+	t.Parallel()
+	stateDir := t.TempDir()
+	st := &fakeIngestStore{}
+	svc := mustNewIngestService(t, config.Config{StateDir: stateDir}, st)
+	svc.SetTranscriber(&fakeTranscriber{text: "[00:00] intro\n[00:02] chapter one\n[00:05] chapter two"})
+
+	doc := model.Document{DocID: 89, RelPath: "audio/segment.mp3", DocType: "audio"}
+	if err := svc.GenerateTranscriptRepresentation(context.Background(), doc, []byte("segment-only-bytes")); err != nil {
+		t.Fatalf("GenerateTranscriptRepresentation failed: %v", err)
+	}
+	if len(st.reps) != 1 {
+		t.Fatalf("expected one transcript representation, got %d", len(st.reps))
+	}
+	if got := transcriptMetaWordsFlag(t, st.reps[0].MetaJSON); got != false {
+		t.Errorf("meta_json.words = %v, want false/absent for a segment-only transcript (meta=%s)", got, st.reps[0].MetaJSON)
+	}
+	if strings.Contains(st.reps[0].MetaJSON, `"words"`) {
+		t.Errorf("segment-only transcript must omit the words key, got %s", st.reps[0].MetaJSON)
 	}
 }


### PR DESCRIPTION
## Summary

Per SPEC **§8.6.9 (0.20.0)**, a transcript declares its finest captured timing granularity via a transcript-level `meta_json.words` flag: `words: true` iff at least one segment carries a populated `extra_json.words` array. dir2mcp already **captures and stores** per-word timing on segment spans (verbose_json → `{t,d,w}` → `attachWordsToTimeSpans`), but never surfaced the transcript-level flag — so a consumer couldn't tell word timing was available without inspecting every span.

This is a **conformance gap** (the spec defines the field; the code didn't emit it), not a spec change — no dirstral-spec PR needed.

## Changes

- Add `Words bool` (`json:"words,omitempty"`) to `transcriptMeta`.
- New helper `segmentsHaveWordTiming(segs)` — true iff any segment span carries a populated `Words` array.
- Set the flag from the persisted segments in all three transcript paths:
  - **STT** — `sttTranscriptMetaJSON` (new `hasWords` param)
  - **whisper-translate** — `translateOneTranscript`
  - **sidecar** — `persistSidecarTranscript`
- Graceful degradation preserved: `omitempty` means a segment-only transcript's `meta_json` is byte-unchanged, and absent/false means "segment granularity only" per §8.6.9. Never changes chunking or citations.

## Tests

- `TestGenerateTranscriptRepresentation_AttachesWordSpans` extended: asserts `meta_json.words == true` for a structured (word-timed) transcriber.
- `TestGenerateTranscriptRepresentation_SegmentOnlyOmitsWordsFlag`: asserts the `words` key is absent/false for a segment-only transcript.

## Verification

- `make lint` → 0 issues
- `go test ./internal/ingest/... ./tests/ingest/... ./tests/store/... ./tests/mcp/... ./tests/cli/...` → all pass

Closes #472

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recording word-level timing availability in transcript metadata and sidecar output.
  * Translated transcripts now preserve and surface word timing when present.

* **Bug Fixes**
  * Word timing flags are now omitted when unavailable, preventing false positives in transcript data.
  * Segment-only transcripts continue to work normally without requiring word-level details.

* **Tests**
  * Expanded coverage to verify word timing metadata is set correctly and omitted when expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->