### PR TITLE
fix(ingest): stop mis-routing unreadable formats to an extractor that fails silently (#394)

### DIFF
--- a/internal/ingest/extractor_routing_test.go
+++ b/internal/ingest/extractor_routing_test.go
@@ -1,0 +1,127 @@
+package ingest
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// flatRoutingExtractor is a model.DocumentExtractor that emits flat text only
+// (like Mistral OCR) — it does NOT implement structuredExtractor, so
+// extractorCanReadExt treats it as the flat path.
+type flatRoutingExtractor struct{}
+
+func (flatRoutingExtractor) Extract(context.Context, string, []byte) (string, error) {
+	return "", nil
+}
+
+// structuredRoutingExtractor additionally implements structuredExtractor, so
+// extractorCanReadExt treats it as the docling family.
+type structuredRoutingExtractor struct{ flatRoutingExtractor }
+
+func (structuredRoutingExtractor) ExtractStructured(context.Context, string, []byte) (StructuredExtraction, error) {
+	return StructuredExtraction{}, nil
+}
+
+// TestExtractorSupportsExt pins the #394 capability split: the flat OCR path
+// reads exactly the ocrMIMEType allowlist, while docling additionally reads
+// OpenXML Office and tiff/bmp but not the OpenDocument/RTF/legacy-.doc family or
+// gif/svg.
+func TestExtractorSupportsExt(t *testing.T) {
+	cases := []struct {
+		ext        string
+		flat       bool // expected support on the flat OCR path
+		structured bool // expected support on the docling family
+	}{
+		// Read by both engines.
+		{".pdf", true, true},
+		{".png", true, true},
+		{".jpg", true, true},
+		{".jpeg", true, true},
+		{".webp", true, true},
+		// docling-only: OpenXML Office + tiff/bmp raster images.
+		{".docx", false, true},
+		{".pptx", false, true},
+		{".xlsx", false, true},
+		{".tif", false, true},
+		{".tiff", false, true},
+		{".bmp", false, true},
+		// Read by neither engine (#394 defects 2 & 3; content support in #393).
+		{".odt", false, false},
+		{".odp", false, false},
+		{".ods", false, false},
+		{".rtf", false, false},
+		{".doc", false, false},
+		{".gif", false, false},
+		{".svg", false, false},
+	}
+	for _, tc := range cases {
+		if got := extractorSupportsExt(false, tc.ext); got != tc.flat {
+			t.Errorf("extractorSupportsExt(flat, %q) = %v, want %v", tc.ext, got, tc.flat)
+		}
+		if got := extractorSupportsExt(true, tc.ext); got != tc.structured {
+			t.Errorf("extractorSupportsExt(structured, %q) = %v, want %v", tc.ext, got, tc.structured)
+		}
+	}
+}
+
+// TestExtractorCanReadExt confirms the doc-level dispatch honors the active
+// extractor kind: a docling-family extractor can read a docx an OCR-only
+// extractor cannot, while both reject a .odt.
+func TestExtractorCanReadExt(t *testing.T) {
+	flat := &Service{extractor: flatRoutingExtractor{}}
+	structured := &Service{extractor: structuredRoutingExtractor{}}
+	none := &Service{}
+
+	if flat.extractorCanReadExt("report.docx") {
+		t.Error("flat OCR extractor must not claim to read .docx")
+	}
+	if !structured.extractorCanReadExt("report.docx") {
+		t.Error("docling-family extractor must read .docx")
+	}
+	if structured.extractorCanReadExt("notes.odt") {
+		t.Error("docling-family extractor must not claim to read .odt")
+	}
+	if flat.extractorCanReadExt("scan.pdf") != true {
+		t.Error("both extractor kinds must read .pdf")
+	}
+	if none.extractorCanReadExt("scan.pdf") {
+		t.Error("a nil extractor can read nothing")
+	}
+}
+
+// TestExtractorLabel checks the diagnostic label reflects the structured/flat
+// split used for routing.
+func TestExtractorLabel(t *testing.T) {
+	if got := (&Service{extractor: structuredRoutingExtractor{}}).extractorLabel(); got != "docling" {
+		t.Errorf("structured extractorLabel = %q, want docling", got)
+	}
+	if got := (&Service{extractor: flatRoutingExtractor{}}).extractorLabel(); got == "docling" {
+		t.Errorf("flat extractorLabel = %q, want a non-docling label", got)
+	}
+}
+
+// TestUnsupportedExtractionErr checks the diagnostic names the offending
+// extension and the active extractor so the failure is actionable.
+func TestUnsupportedExtractionErr(t *testing.T) {
+	err := unsupportedExtractionErr("dir/deck.odp", "docling")
+	if err == nil {
+		t.Fatal("expected a non-nil diagnostic")
+	}
+	msg := err.Error()
+	for _, want := range []string{"unsupported format", ".odp", "docling"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("diagnostic %q missing %q", msg, want)
+		}
+	}
+	// The classification code stays the generic §14.4 EXTRACT_FAILED (no new
+	// spec-level code introduced).
+	if got := manifestErrorCode(err); got != manifestErrExtractFailed {
+		t.Errorf("manifestErrorCode = %q, want %q", got, manifestErrExtractFailed)
+	}
+}
+
+var _ model.DocumentExtractor = flatRoutingExtractor{}
+var _ model.DocumentExtractor = structuredRoutingExtractor{}

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -368,6 +368,78 @@ var errNoVideoRepresentation = errors.New(
 	"video produced no representation: no subtitle sidecar found, video is not transcribed (STT is audio-only), " +
 		"and multimodal keyframe embedding is off — enable embed_multimodal or provide a .vtt/.srt sidecar to make it searchable")
 
+// extractorSupportsExt reports whether the selected document extractor can
+// actually read the given file extension (#394). SPEC §7.4B routes every
+// pdf/image/document doc_type to one configured extractor, but no single
+// extractor reads every format in those coarse buckets, so a format outside the
+// active engine's set must be skipped with a visible diagnostic rather than
+// handed to an extractor that fails silently or hard-errors on it.
+//
+// `structured` is true for the docling family (local CLI or docling-serve — the
+// engines that emit a DoclingDocument), false for the flat Mistral-OCR path.
+//   - Flat OCR (Mistral) reads exactly the ocrMIMEType allowlist:
+//     pdf/png/jpg/jpeg/webp. Everything else routed to it (all Office/OpenDocument
+//     documents and the gif/bmp/tiff/svg images) is rejected upstream (#394
+//     defect 3).
+//   - docling additionally imports OpenXML Office (docx/pptx/xlsx) and tiff/bmp
+//     raster images, but does NOT import the OpenDocument family (.odt/.odp/.ods),
+//     RTF, legacy binary .doc, or gif/svg (#394 defects 2 & 3). Every other
+//     extension is left "supported" so nothing docling handles today regresses;
+//     content support for the unreadable formats is tracked in #393.
+func extractorSupportsExt(structured bool, ext string) bool {
+	switch ext {
+	case ".pdf", ".png", ".jpg", ".jpeg", ".webp":
+		// Read by both docling and Mistral OCR.
+		return true
+	}
+	if !structured {
+		return false
+	}
+	switch ext {
+	case ".odt", ".odp", ".ods", ".rtf", ".doc", ".gif", ".svg":
+		// Not imported by docling; content support tracked in #393.
+		return false
+	default:
+		return true
+	}
+}
+
+// extractorCanReadExt reports whether the currently-selected extractor can read
+// the asset's format. Docling-family extractors implement structuredExtractor;
+// the flat Mistral-OCR path does not.
+func (s *Service) extractorCanReadExt(relPath string) bool {
+	if s.extractor == nil {
+		return false
+	}
+	_, structured := s.extractor.(structuredExtractor)
+	ext := strings.ToLower(filepath.Ext(strings.TrimSpace(relPath)))
+	return extractorSupportsExt(structured, ext)
+}
+
+// extractorLabel is a short human name for the active extractor, used in the
+// #394 unsupported-format diagnostic. It reflects the same structured/flat split
+// extractorCanReadExt uses, not the concrete provider profile name.
+func (s *Service) extractorLabel() string {
+	if _, structured := s.extractor.(structuredExtractor); structured {
+		return "docling"
+	}
+	return "the OCR provider"
+}
+
+// unsupportedExtractionErr builds the durable, non-fatal diagnostic for a
+// pdf/image/document asset whose format the active extractor cannot read (#394).
+// Before #394 such a format was handed to the extractor anyway, which either
+// failed silently (docling → empty output → a silent empty rep) or hard-errored
+// (Mistral OCR → "unsupported file extension"); it is now skipped with this
+// clear message instead. Content support for the unreadable formats is #393.
+func unsupportedExtractionErr(relPath, extractor string) error {
+	ext := strings.ToLower(filepath.Ext(strings.TrimSpace(relPath)))
+	return fmt.Errorf(
+		"unsupported format for extraction: the active extractor (%s) cannot read %s files; "+
+			"install a capable extractor or convert the file to a supported format (tracked in #393)",
+		extractor, ext)
+}
+
 type documentDeleteMarker interface {
 	MarkDocumentDeleted(ctx context.Context, relPath string) error
 }
@@ -2292,26 +2364,41 @@ func (s *Service) addRepresentations(delta int64) {
 // `augment` keeps OCR and adds the media chunks. It returns whether any media
 // chunks were produced so the caller can apply the same `replace`-skips-text
 // rule to the audio transcript path.
-func (s *Service) generateExtractedAndMediaRepresentations(ctx context.Context, doc model.Document, content []byte) (bool, error) {
+func (s *Service) generateExtractedAndMediaRepresentations(ctx context.Context, doc model.Document, content []byte, secretPatterns []*regexp.Regexp) (mediaProduced, nonFatalErrored bool, err error) {
 	// A non-empty span set means media chunks will be produced. In `replace` we
 	// then skip OCR; in `augment` OCR is kept alongside.
 	spans := s.mediaSpansFor(ctx, doc, content)
-	mediaProduced := len(spans) > 0
+	mediaProduced = len(spans) > 0
 	skipOCR := s.embedMultimodal == "replace" && mediaProduced
 
 	if ShouldGenerateExtractedMarkdown(doc.DocType) && s.extractor != nil && !skipOCR {
-		if err := s.generateOCRMarkdownRepresentation(ctx, doc, content); err != nil {
-			return false, err
+		if s.extractorCanReadExt(doc.RelPath) {
+			if err := s.generateOCRMarkdownRepresentation(ctx, doc, content); err != nil {
+				return false, false, err
+			}
+			s.addRepresentations(1)
+		} else if !mediaProduced {
+			// #394: the active extractor cannot read this format. Rather than hand
+			// it to an extractor that fails silently (docling → empty) or hard-errors
+			// (Mistral OCR → "unsupported file extension"), record a clear, non-fatal
+			// unsupported-format diagnostic so the unsearchable asset is durably
+			// visible (status="error" / RecentFailures) and the run continues. Skipped
+			// only when direct multimodal embedding is not also making the doc
+			// searchable; content support for these formats is #393.
+			cause := unsupportedExtractionErr(doc.RelPath, s.extractorLabel())
+			s.getLogger().Printf("skipping extraction for %s (%s): %v", doc.RelPath, doc.DocType, cause)
+			s.addErrors(1)
+			s.persistNonFatalDocError(ctx, doc, cause, secretPatterns)
+			nonFatalErrored = true
 		}
-		s.addRepresentations(1)
 	}
 	if mediaProduced {
 		if err := s.repGen.GenerateMediaChunks(ctx, doc, computeRepHash(content), spans); err != nil {
-			return false, err
+			return false, false, err
 		}
 		s.addRepresentations(1)
 	}
-	return mediaProduced, nil
+	return mediaProduced, nonFatalErrored, nil
 }
 
 // Default media-window lengths for direct audio/video embedding (SPEC 8.1.7).
@@ -2577,9 +2664,16 @@ func (s *Service) generateRepresentations(ctx context.Context, doc model.Documen
 		return false, nil
 	}
 
-	mediaProduced, err := s.generateExtractedAndMediaRepresentations(ctx, doc, content)
+	mediaProduced, nonFatalErrored, err := s.generateExtractedAndMediaRepresentations(ctx, doc, content, secretPatterns)
 	if err != nil {
 		return false, err
+	}
+	if nonFatalErrored {
+		// #394: the extractor path persisted the document as status="error" (an
+		// unsupported format) and counted it as an error itself. A pdf/image/document
+		// asset has no transcript path, so return the soft-error signal now — the
+		// caller must not also credit it as indexed (issue #426).
+		return true, nil
 	}
 	// In `replace`, direct media embedding stands in for STT→text, so skip the
 	// transcript when audio media chunks were produced (SPEC 8.1.7). `augment`

--- a/tests/ingest/extractor_routing_394_test.go
+++ b/tests/ingest/extractor_routing_394_test.go
@@ -1,0 +1,72 @@
+package tests
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// processWithFlatExtractor writes name into a fresh root, ingests it through a
+// service whose document extractor is the flat (OCR-only) fakeExtractor, and
+// returns the persisted document. fakeExtractor does not implement
+// structuredExtractor, so it mirrors the Mistral-OCR routing path.
+func processWithFlatExtractor(t *testing.T, name string) model.Document {
+	t.Helper()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, name), "irrelevant bytes")
+	st := newRealStore(t)
+	svc := mustNewIngestService(t, config.Config{RootDir: root, StateDir: t.TempDir()}, st)
+	// A flat extractor that would happily return text if asked — proving the doc
+	// is skipped by the routing gate, not by the extractor failing.
+	svc.SetDocumentExtractor(&fakeExtractor{text: "should never be extracted"})
+
+	f := ingest.DiscoveredFile{RelPath: name, SizeBytes: 16, MTimeUnix: time.Now().Unix()}
+	if err := svc.ProcessDocument(context.Background(), f, nil, false); err != nil {
+		t.Fatalf("ProcessDocument(%s): %v", name, err)
+	}
+	return documentByPath(t, st, name)
+}
+
+// TestUnsupportedDocument_SurfacesDiagnostic is the #394 defect-2 guard: an .odt
+// (doc_type=document) routed to an extractor that cannot import it must surface a
+// clear unsupported-format diagnostic — not a silent empty representation, and
+// not an alarming generic provider failure.
+func TestUnsupportedDocument_SurfacesDiagnostic(t *testing.T) {
+	doc := processWithFlatExtractor(t, "notes.odt")
+	if doc.Status != "error" {
+		t.Fatalf("unsupported .odt status = %q, want \"error\" (a silent empty rep is the #394 bug)", doc.Status)
+	}
+	if !strings.Contains(strings.ToLower(doc.ErrorMessage), "unsupported format") {
+		t.Errorf("error_message = %q, want it to name the unsupported format", doc.ErrorMessage)
+	}
+}
+
+// TestUnsupportedImage_SurfacesDiagnostic is the #394 defect-3 guard: a .gif
+// (doc_type=image) is outside the OCR provider's allowlist and covered by no
+// extractor. It must surface the same visible unsupported-format diagnostic
+// instead of being silently rejected.
+func TestUnsupportedImage_SurfacesDiagnostic(t *testing.T) {
+	doc := processWithFlatExtractor(t, "diagram.gif")
+	if doc.Status != "error" {
+		t.Fatalf("unsupported .gif status = %q, want \"error\" (silent OCR rejection is the #394 bug)", doc.Status)
+	}
+	if !strings.Contains(strings.ToLower(doc.ErrorMessage), "unsupported format") {
+		t.Errorf("error_message = %q, want it to name the unsupported format", doc.ErrorMessage)
+	}
+}
+
+// TestSupportedImage_StillExtracted guards against over-reach: a .png the OCR
+// provider CAN read must still be extracted normally, not swept up by the #394
+// routing gate.
+func TestSupportedImage_StillExtracted(t *testing.T) {
+	doc := processWithFlatExtractor(t, "scan.png")
+	if doc.Status != "ok" {
+		t.Fatalf("supported .png status = %q, want \"ok\" (the routing gate must not block a readable format)", doc.Status)
+	}
+}


### PR DESCRIPTION
## What

Fixes the routing-correctness half of #394: formats routed to an extractor that cannot read them, and formats silently rejected with no signal.

SPEC §7.4B routes every `pdf`/`image`/`document` doc_type to one configured extractor, but no single extractor reads every format in those coarse buckets:

- **Mistral OCR** reads only `pdf/png/jpg/jpeg/webp` (mirrors `ocrMIMEType`).
- **docling** additionally reads OpenXML Office (`docx/pptx/xlsx`) and `tiff/bmp` images, but **not** the OpenDocument family (`.odt/.odp/.ods`), RTF, legacy binary `.doc`, or `gif/svg`.

Before this change, a format outside the active engine's set was handed to the extractor anyway, which either **failed silently** (docling → empty output → a silent empty representation) or **hard-errored** (Mistral OCR → "unsupported file extension"). Either way the asset became unsearchable with no clear signal.

## Change

A narrow, engine-aware capability gate in the extractor path (`generateExtractedAndMediaRepresentations`): before extraction, `extractorCanReadExt` checks whether the active extractor (docling-family vs flat OCR, distinguished by the existing `structuredExtractor` assertion) can actually read the asset's extension.

A format the extractor cannot read is **skipped with a clear, non-fatal unsupported-format diagnostic** (`status="error"` + `RecentFailures`, run continues) — the same visibility precedent as the #398 unsupported-archive / sidecar-less-video / binary-parquet paths — instead of a silent empty rep or an alarming generic provider failure. Direct multimodal embedding (when enabled) still covers the asset, so the diagnostic only fires when nothing else makes it searchable. The soft-error suppresses indexed credit (issue #426 invariant).

Formats the extractor already handles (`pdf`, `png/jpg/webp`, docling's `docx/pptx/xlsx`, `tiff/bmp`) are unaffected — no regression.

## Deliberately out of scope

- **Defect 1 (HTML → docling):** SPEC §7.4A routes `html` to `raw_text`, so routing it through a structured extractor is a behavior change that needs a `dirstral-spec` PR first (spec governance loop). HTML is **not** silently rejected today — it is indexed as `raw_text` — so there is no silent-failure to fix here. Deferred to the spec loop / #395.
- **Content support** for the unreadable formats (odt/rtf/etc. via a new extractor) is #393.
- The full capability-aware per-format **provider selection** redesign is #395; this PR only stops mis-routing a single already-selected extractor and surfaces a reason.

## Tests

- `internal/ingest/extractor_routing_test.go`: unit coverage for the capability table (`extractorSupportsExt`), the doc-level dispatch (`extractorCanReadExt`), the diagnostic message, and its §14.4 classification (stays `EXTRACT_FAILED`, no new spec-level code).
- `tests/ingest/extractor_routing_394_test.go`: end-to-end — an `.odt` and a `.gif` surface a visible unsupported-format diagnostic (not a silent empty rep), while a supported `.png` is still extracted normally.

`make lint` = 0 issues; `go test ./internal/ingest/... ./tests/ingest/...` all pass.

Closes #394