### PR TITLE
fix(filters): unify file_glob/list_files glob semantics; overlap-aware bilingual alignment (#441)

### DIFF
--- a/internal/model/glob.go
+++ b/internal/model/glob.go
@@ -1,0 +1,131 @@
+package model
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Canonical path-glob matcher shared by the search/ask `file_glob` filter and
+// the store's `list_files` glob (issue #441). Before this, `file_glob` used Go
+// `path.Match` (segment-aware `*`, no `**`, case-sensitive) while `list_files`
+// used SQLite `GLOB` (`*` crosses `/`, no special `**`, case-sensitive) — so the
+// SAME pattern returned DIFFERENT file sets and `**` was silently ignored on the
+// retrieval side. Both surfaces now compile the pattern here so they can never
+// drift, mirroring how NormalizePathPrefix already unified `path_prefix`.
+//
+// Semantics (one canonical dialect):
+//   - `*`  matches any run of characters WITHIN a single path segment (it does
+//     NOT cross `/`).
+//   - `**` matches across segments: `**/` matches zero or more leading segments
+//     (so `**/x` matches `x`, `a/x`, and `a/b/x`); a `**` not followed by `/`
+//     matches any characters including `/`.
+//   - `?`  matches exactly one character that is not `/`.
+//   - `\x` matches the literal character `x` (so a caller can match a path that
+//     itself contains a glob metacharacter — this is what escapeGlobLiteral
+//     relies on). A trailing backslash is an invalid pattern.
+//   - every other byte matches itself, with ASCII letters folded
+//     case-insensitively to agree with `path_prefix` (MatchesPathPrefix, which
+//     mirrors SQLite LIKE's ASCII-only case folding).
+//
+// Character classes (`[...]`) are NOT interpreted: `[` and `]` match literally,
+// matching the exclude-glob dialect this reuses and keeping escapeGlobLiteral's
+// escaping unambiguous.
+type CompiledGlob struct {
+	re *regexp.Regexp
+}
+
+// CompileGlob compiles a path glob into a matcher. It returns an error only for a
+// syntactically invalid pattern (currently: a trailing unescaped backslash).
+func CompileGlob(pattern string) (*CompiledGlob, error) {
+	src, err := globToRegexpSource(pattern)
+	if err != nil {
+		return nil, err
+	}
+	re, err := regexp.Compile(src)
+	if err != nil {
+		return nil, err
+	}
+	return &CompiledGlob{re: re}, nil
+}
+
+// Match reports whether relPath matches the compiled glob.
+func (g *CompiledGlob) Match(relPath string) bool {
+	if g == nil || g.re == nil {
+		return false
+	}
+	return g.re.MatchString(relPath)
+}
+
+// MatchGlob reports whether relPath matches pattern under the canonical dialect.
+// It is a convenience wrapper around CompileGlob for one-shot matches; hot paths
+// that reuse a pattern should CompileGlob once and reuse the result.
+func MatchGlob(pattern, relPath string) (bool, error) {
+	g, err := CompileGlob(pattern)
+	if err != nil {
+		return false, err
+	}
+	return g.Match(relPath), nil
+}
+
+// globToRegexpSource translates a canonical path glob into an anchored regular
+// expression source string.
+func globToRegexpSource(glob string) (string, error) {
+	var b strings.Builder
+	b.WriteString("^")
+	for i := 0; i < len(glob); {
+		c := glob[i]
+		switch c {
+		case '\\':
+			if i+1 >= len(glob) {
+				return "", fmt.Errorf("invalid glob %q: trailing backslash", glob)
+			}
+			writeGlobLiteral(&b, glob[i+1])
+			i += 2
+			continue
+		case '*':
+			if i+1 < len(glob) && glob[i+1] == '*' {
+				i += 2
+				if i < len(glob) && glob[i] == '/' {
+					i++
+					b.WriteString("(?:.*/)?")
+				} else {
+					b.WriteString(".*")
+				}
+				continue
+			}
+			b.WriteString(`[^/]*`)
+		case '?':
+			b.WriteString(`[^/]`)
+		default:
+			writeGlobLiteral(&b, c)
+		}
+		i++
+	}
+	b.WriteString("$")
+	return b.String(), nil
+}
+
+// writeGlobLiteral emits a single literal byte into the regexp source. ASCII
+// letters are folded case-insensitively as a two-element class ([Aa]) so matching
+// agrees with path_prefix's ASCII-only fold; regexp metacharacters are escaped;
+// all other bytes (including UTF-8 continuation bytes) are written verbatim.
+func writeGlobLiteral(b *strings.Builder, c byte) {
+	switch {
+	case c >= 'A' && c <= 'Z':
+		b.WriteByte('[')
+		b.WriteByte(c)
+		b.WriteByte(c + ('a' - 'A'))
+		b.WriteByte(']')
+	case c >= 'a' && c <= 'z':
+		b.WriteByte('[')
+		b.WriteByte(c - ('a' - 'A'))
+		b.WriteByte(c)
+		b.WriteByte(']')
+	default:
+		if strings.IndexByte(`.+()|[]{}^$\*?`, c) >= 0 {
+			b.WriteByte('\\')
+		}
+		b.WriteByte(c)
+	}
+}

--- a/internal/model/glob.go
+++ b/internal/model/glob.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
+	"sync/atomic"
 )
 
 // Canonical path-glob matcher shared by the search/ask `file_glob` filter and
@@ -57,11 +59,46 @@ func (g *CompiledGlob) Match(relPath string) bool {
 	return g.re.MatchString(relPath)
 }
 
-// MatchGlob reports whether relPath matches pattern under the canonical dialect.
-// It is a convenience wrapper around CompileGlob for one-shot matches; hot paths
-// that reuse a pattern should CompileGlob once and reuse the result.
-func MatchGlob(pattern, relPath string) (bool, error) {
+// globCache memoizes CompileGlob so a pattern reused across many candidate hits
+// in a query hot path (matchFilters / Filter.Match, issue #441) is compiled ONCE
+// rather than per candidate — regexp.Compile per hit is a real regression on a
+// widened candidate pool. Glob patterns are low-cardinality (operator config +
+// per-query filters); growth is bounded by globCacheMax so an unbounded stream of
+// distinct patterns can't grow the cache without limit (past the cap, compilation
+// still works, just uncached). Entries are immutable, so the sync.Map is safe.
+var (
+	globCache    sync.Map // pattern string -> globCacheEntry
+	globCacheLen atomic.Int64
+)
+
+const globCacheMax = 1024
+
+type globCacheEntry struct {
+	g   *CompiledGlob
+	err error
+}
+
+func compileGlobCached(pattern string) (*CompiledGlob, error) {
+	if v, ok := globCache.Load(pattern); ok {
+		e := v.(globCacheEntry)
+		return e.g, e.err
+	}
 	g, err := CompileGlob(pattern)
+	if globCacheLen.Load() < globCacheMax {
+		if _, loaded := globCache.LoadOrStore(pattern, globCacheEntry{g: g, err: err}); !loaded {
+			globCacheLen.Add(1)
+		}
+	}
+	return g, err
+}
+
+// MatchGlob reports whether relPath matches pattern under the canonical dialect.
+// Compilation is memoized (globCache), so calling it per candidate hit in a
+// filter hot path compiles the pattern only once. A caller with a single pattern
+// and many paths may still CompileGlob once and reuse the *CompiledGlob to skip
+// even the cache lookup.
+func MatchGlob(pattern, relPath string) (bool, error) {
+	g, err := compileGlobCached(pattern)
 	if err != nil {
 		return false, err
 	}

--- a/internal/model/glob_test.go
+++ b/internal/model/glob_test.go
@@ -1,0 +1,92 @@
+package model
+
+import "testing"
+
+// TestMatchGlob_CanonicalSemantics pins the one canonical path-glob dialect that
+// both the search/ask file_glob filter and the list_files glob now share
+// (issue #441): segment-aware `*`, recursive `**`, `?` = one non-slash char,
+// backslash escaping, and ASCII-case-insensitive literals.
+func TestMatchGlob_CanonicalSemantics(t *testing.T) {
+	cases := []struct {
+		pattern string
+		path    string
+		want    bool
+	}{
+		// `*` is segment-aware: it does NOT cross `/`.
+		{"*.pdf", "a.pdf", true},
+		{"*.pdf", "docs/a.pdf", false},
+		{"*.pdf", "docs/sub/a.pdf", false},
+		{"docs/*", "docs/a.pdf", true},
+		{"docs/*", "docs/sub/a.pdf", false},
+		{"docs/*.pdf", "docs/a.pdf", true},
+		{"docs/*.pdf", "docs/sub/a.pdf", false},
+
+		// `**` crosses segments.
+		{"**/*.pdf", "a.pdf", true},
+		{"**/*.pdf", "docs/a.pdf", true},
+		{"**/*.pdf", "docs/sub/a.pdf", true},
+		{"**", "a/b/c.pdf", true},
+		{"docs/**", "docs/sub/a.pdf", true},
+		{"docs/**/*.pdf", "docs/a.pdf", true},
+		{"docs/**/*.pdf", "docs/sub/deep/a.pdf", true},
+
+		// `?` matches exactly one non-slash char.
+		{"a?.txt", "ab.txt", true},
+		{"a?.txt", "a.txt", false},
+		{"a?.txt", "a/b.txt", false},
+
+		// ASCII case-insensitive (agrees with path_prefix).
+		{"DOCS/*", "docs/a.pdf", true},
+		{"docs/*", "DOCS/A.PDF", true},
+
+		// Backslash escapes a metacharacter to a literal (escapeGlobLiteral relies
+		// on this for open_file's exact-path match).
+		{`a\*b.txt`, "a*b.txt", true},
+		{`a\*b.txt`, "axb.txt", false},
+		{`file\?.txt`, "file?.txt", true},
+		{`file\?.txt`, "fileX.txt", false},
+	}
+	for _, c := range cases {
+		got, err := MatchGlob(c.pattern, c.path)
+		if err != nil {
+			t.Errorf("MatchGlob(%q,%q) unexpected error: %v", c.pattern, c.path, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("MatchGlob(%q,%q)=%v want %v", c.pattern, c.path, got, c.want)
+		}
+	}
+}
+
+// TestMatchGlob_TrailingBackslashInvalid pins that a trailing unescaped backslash
+// is reported as an invalid pattern.
+func TestMatchGlob_TrailingBackslashInvalid(t *testing.T) {
+	if _, err := MatchGlob(`docs\`, "docs"); err == nil {
+		t.Fatalf("expected error for trailing backslash pattern")
+	}
+}
+
+// TestFilterPathGlob_MatchesMatchGlob pins that the Filter.Match PathGlob
+// predicate (search/ask pushdown path) and the standalone MatchGlob used by
+// list_files agree on the same file set for representative patterns — the core
+// contract of issue #441 (file_glob and list_files must not diverge).
+func TestFilterPathGlob_MatchesMatchGlob(t *testing.T) {
+	patterns := []string{"*.pdf", "docs/*", "**/*.pdf", "docs/**", "DOCS/*"}
+	paths := []string{
+		"a.pdf", "b.txt", "docs/a.pdf", "docs/sub/a.pdf",
+		"docs/sub/deep/a.pdf", "src/main.go",
+	}
+	for _, pat := range patterns {
+		for _, p := range paths {
+			viaMatchGlob, err := MatchGlob(pat, p)
+			if err != nil {
+				t.Fatalf("MatchGlob(%q,%q): %v", pat, p, err)
+			}
+			viaFilter := Filter{PathGlob: pat}.Match(IndexPayload{RelPath: p})
+			if viaMatchGlob != viaFilter {
+				t.Errorf("divergence for pattern %q path %q: MatchGlob=%v Filter.Match=%v",
+					pat, p, viaMatchGlob, viaFilter)
+			}
+		}
+	}
+}

--- a/internal/model/glob_test.go
+++ b/internal/model/glob_test.go
@@ -1,6 +1,37 @@
 package model
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
+
+// TestMatchGlob_CompilationMemoized pins that MatchGlob memoizes compilation so a
+// pattern reused across candidate hits (matchFilters / Filter.Match hot path) is
+// compiled once, results stay correct on repeat, and many distinct patterns never
+// break matching (the cache is bounded, uncached past the cap).
+func TestMatchGlob_CompilationMemoized(t *testing.T) {
+	pat := "docs/**/*.memoize_probe_zzz.md"
+	if m, err := MatchGlob(pat, "docs/a/b/x.memoize_probe_zzz.md"); err != nil || !m {
+		t.Fatalf("MatchGlob = (%v,%v), want (true,nil)", m, err)
+	}
+	if _, ok := globCache.Load(pat); !ok {
+		t.Fatal("pattern not memoized after first MatchGlob")
+	}
+	for i := 0; i < 5; i++ {
+		if m, _ := MatchGlob(pat, "docs/x.memoize_probe_zzz.md"); !m {
+			t.Fatal("cached glob lost a valid match")
+		}
+		if m, _ := MatchGlob(pat, "nope.txt"); m {
+			t.Fatal("cached glob gained a spurious match")
+		}
+	}
+	// Past the cache cap, compilation still works (just uncached) and never panics.
+	for i := 0; i < globCacheMax+20; i++ {
+		if _, err := MatchGlob(fmt.Sprintf("d%d/*.x", i), "nope"); err != nil {
+			t.Fatalf("distinct pattern %d errored past cap: %v", i, err)
+		}
+	}
+}
 
 // TestMatchGlob_CanonicalSemantics pins the one canonical path-glob dialect that
 // both the search/ask file_glob filter and the list_files glob now share

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -3,7 +3,6 @@ package model
 import (
 	"encoding/json"
 	"fmt"
-	"path"
 	"strings"
 )
 
@@ -243,7 +242,9 @@ type IndexHit struct {
 //   - PathPrefix: keep only rel_paths with this prefix, normalized via
 //     NormalizePathPrefix and matched case-insensitively (ASCII) to agree with
 //     the store's list_files LIKE query (issue #286).
-//   - PathGlob:   keep only rel_paths matching this path.Match glob.
+//   - PathGlob:   keep only rel_paths matching this canonical path glob
+//     (MatchGlob: segment-aware `*`, recursive `**`, ASCII case-insensitive —
+//     the same matcher list_files uses, issue #441).
 //   - DocTypes:   keep only these doc types (case-insensitive).
 //   - ExcludeOrphans: drop chunks with an empty rel_path (orphaned/evicted).
 //   - Speaker: keep only time-spanned transcript chunks attributed to this
@@ -276,8 +277,9 @@ func (f Filter) IsZero() bool {
 // Match reports whether the payload satisfies every active predicate. It
 // reproduces the semantics of retrieval's matchFilters: an empty rel_path is
 // rejected when ExcludeOrphans is set; PathPrefix is normalized and matched via
-// MatchesPathPrefix (consistent with list_files); PathGlob uses path.Match;
-// DocTypes is a case-insensitive set membership.
+// MatchesPathPrefix (consistent with list_files); PathGlob uses the canonical
+// MatchGlob (also shared with list_files, issue #441); DocTypes is a
+// case-insensitive set membership.
 func (f Filter) Match(p IndexPayload) bool {
 	relPath := p.RelPath
 	if f.ExcludeOrphans && strings.TrimSpace(relPath) == "" {
@@ -289,7 +291,7 @@ func (f Filter) Match(p IndexPayload) bool {
 		return false
 	}
 	if f.PathGlob != "" {
-		matched, err := path.Match(f.PathGlob, relPath)
+		matched, err := MatchGlob(f.PathGlob, relPath)
 		if err != nil || !matched {
 			return false
 		}

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -10,7 +10,6 @@ import (
 	"log"
 	"math"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -3352,7 +3351,10 @@ func matchFilters(hit model.SearchHit, query model.SearchQuery) bool {
 	}
 
 	if query.FileGlob != "" {
-		matched, err := path.Match(query.FileGlob, hit.RelPath)
+		// Canonical glob (segment-aware `*`, recursive `**`, ASCII
+		// case-insensitive) shared with list_files so the same pattern selects the
+		// same files on both surfaces (issue #441).
+		matched, err := model.MatchGlob(query.FileGlob, hit.RelPath)
 		if err != nil || !matched {
 			return false
 		}

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -1781,21 +1781,76 @@ func (s *SQLiteStore) ListFiles(ctx context.Context, prefix, glob string, limit,
 	}
 
 	normalizedPrefix := model.NormalizePathPrefix(prefix)
+	trimmedGlob := strings.TrimSpace(glob)
 
-	query := `SELECT doc_id, rel_path, doc_type, source_type, size_bytes, mtime_unix, content_hash, etag, sidecar_fingerprint, status, deleted, title, error_message FROM documents`
+	selectCols := `SELECT doc_id, rel_path, doc_type, source_type, size_bytes, mtime_unix, content_hash, etag, sidecar_fingerprint, status, deleted, title, error_message FROM documents`
 	where := []string{"deleted = 0"}
-	args := make([]any, 0, 4)
+	prefixArgs := make([]any, 0, 1)
 	if normalizedPrefix != "" {
 		where = append(where, `rel_path LIKE ? ESCAPE '\'`)
-		args = append(args, escapeLike(normalizedPrefix)+"%")
+		prefixArgs = append(prefixArgs, escapeLike(normalizedPrefix)+"%")
 	}
-	if strings.TrimSpace(glob) != "" {
-		where = append(where, "rel_path GLOB ?")
-		args = append(args, glob)
+	whereClause := " WHERE " + strings.Join(where, " AND ")
+
+	// The `glob` filter uses the SAME canonical matcher as the search/ask
+	// `file_glob` filter (model.MatchGlob, issue #441): segment-aware `*`,
+	// recursive `**`, ASCII case-insensitive. SQLite `GLOB` cannot express those
+	// semantics (its `*` crosses `/` and it has no `**`), so when a glob is set we
+	// evaluate it in Go over the prefix-matched rows and paginate in Go. Without a
+	// glob the query keeps its efficient SQL LIMIT/OFFSET pagination unchanged.
+	if trimmedGlob == "" {
+		return s.listFilesSQLPaged(ctx, db, selectCols, whereClause, prefixArgs, limit, offset)
 	}
-	query += " WHERE " + strings.Join(where, " AND ")
-	query += " ORDER BY rel_path LIMIT ? OFFSET ?"
-	args = append(args, limit, offset)
+
+	matcher, err := model.CompileGlob(trimmedGlob)
+	if err != nil {
+		// A malformed glob matches nothing rather than erroring, mirroring the
+		// search/ask side; list_files with no match is not an error.
+		return []model.Document{}, 0, nil
+	}
+
+	query := selectCols + whereClause + " ORDER BY rel_path"
+	rows, err := db.QueryContext(ctx, query, prefixArgs...)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	matched := make([]model.Document, 0, limit)
+	var total int64
+	for rows.Next() {
+		doc, scanErr := scanListFilesRow(rows)
+		if scanErr != nil {
+			return nil, 0, scanErr
+		}
+		if !matcher.Match(doc.RelPath) {
+			continue
+		}
+		total++
+		// Only materialize the requested page; earlier rows advance offset and
+		// later rows only bump the total count.
+		if int64(offset) < total && int64(len(matched)) < int64(limit) {
+			matched = append(matched, doc)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, err
+	}
+
+	return matched, total, nil
+}
+
+// listFilesSQLPaged runs the glob-free ListFiles path: prefix filtering plus
+// SQL-side ORDER BY / LIMIT / OFFSET pagination and a matching COUNT.
+func (s *SQLiteStore) listFilesSQLPaged(
+	ctx context.Context,
+	db *sql.DB,
+	selectCols, whereClause string,
+	prefixArgs []any,
+	limit, offset int,
+) ([]model.Document, int64, error) {
+	query := selectCols + whereClause + " ORDER BY rel_path LIMIT ? OFFSET ?"
+	args := append(append([]any{}, prefixArgs...), limit, offset)
 
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -1805,26 +1860,10 @@ func (s *SQLiteStore) ListFiles(ctx context.Context, prefix, glob string, limit,
 
 	docs := make([]model.Document, 0, limit)
 	for rows.Next() {
-		var doc model.Document
-		var deleted int
-		if err := rows.Scan(
-			&doc.DocID,
-			&doc.RelPath,
-			&doc.DocType,
-			&doc.SourceType,
-			&doc.SizeBytes,
-			&doc.MTimeUnix,
-			&doc.ContentHash,
-			&doc.ETag,
-			&doc.SidecarFingerprint,
-			&doc.Status,
-			&deleted,
-			&doc.Title,
-			&doc.ErrorMessage,
-		); err != nil {
-			return nil, 0, err
+		doc, scanErr := scanListFilesRow(rows)
+		if scanErr != nil {
+			return nil, 0, scanErr
 		}
-		doc.Deleted = deleted == 1
 		docs = append(docs, doc)
 	}
 	if err := rows.Err(); err != nil {
@@ -1832,17 +1871,37 @@ func (s *SQLiteStore) ListFiles(ctx context.Context, prefix, glob string, limit,
 	}
 
 	var total int64
-	countQuery := "SELECT COUNT(*) FROM documents"
-	countArgs := make([]any, 0)
-	if len(where) > 0 {
-		countQuery += " WHERE " + strings.Join(where, " AND ")
-		countArgs = append(countArgs, args[:len(args)-2]...)
-	}
-	if err := db.QueryRowContext(ctx, countQuery, countArgs...).Scan(&total); err != nil {
+	countQuery := "SELECT COUNT(*) FROM documents" + whereClause
+	if err := db.QueryRowContext(ctx, countQuery, prefixArgs...).Scan(&total); err != nil {
 		return nil, 0, err
 	}
 
 	return docs, total, nil
+}
+
+// scanListFilesRow scans one documents row into a model.Document for ListFiles.
+func scanListFilesRow(rows *sql.Rows) (model.Document, error) {
+	var doc model.Document
+	var deleted int
+	if err := rows.Scan(
+		&doc.DocID,
+		&doc.RelPath,
+		&doc.DocType,
+		&doc.SourceType,
+		&doc.SizeBytes,
+		&doc.MTimeUnix,
+		&doc.ContentHash,
+		&doc.ETag,
+		&doc.SidecarFingerprint,
+		&doc.Status,
+		&deleted,
+		&doc.Title,
+		&doc.ErrorMessage,
+	); err != nil {
+		return model.Document{}, err
+	}
+	doc.Deleted = deleted == 1
+	return doc, nil
 }
 
 // RecentFailures returns up to limit documents that ended ingest with

--- a/internal/subtitle/bilingual.go
+++ b/internal/subtitle/bilingual.go
@@ -38,10 +38,10 @@ const DefaultAlignToleranceMS = 2500
 // the cue with the greatest temporal overlap is the correct pairing even when a
 // neighboring cue happens to start closer (issue #441). Only when a secondary
 // overlaps no unassigned primary does alignment fall back to the nearest primary
-// by inter-cue gap, and then only within toleranceMS. A secondary cue with no
+// by start distance, and then only within toleranceMS. A secondary cue with no
 // primary in range is emitted as its own secondary-only cue (never dropped).
 // Alignment is deterministic: inputs are sorted by (start,end); the greatest-
-// overlap (else nearest-gap) primary wins; ties break to the earlier primary;
+// overlap (else nearest-start) primary wins; ties break to the earlier primary;
 // and a primary already carrying a secondary run keeps its first match so a
 // later secondary falls through to its own cue.
 //

--- a/internal/subtitle/bilingual.go
+++ b/internal/subtitle/bilingual.go
@@ -33,12 +33,17 @@ const DefaultAlignToleranceMS = 2500
 // AlignBilingual aligns secondary-language cues onto primary-language cues for
 // bilingual TTML export (SPEC §8.6.10). The primary cues define the cue set and
 // their time regions are authoritative; each secondary cue is merged into the
-// primary cue whose start is closest to the secondary's start within
-// toleranceMS. A secondary cue with no primary cue in tolerance is emitted as
-// its own secondary-only cue (never dropped). Alignment is deterministic: inputs
-// are sorted by (start,end), the nearest-start primary wins, ties break to the
-// earlier primary, and a primary already carrying a secondary run keeps its
-// first match so a later secondary falls through to its own cue.
+// primary cue whose TIME REGION it overlaps most. Overlap — not start distance —
+// is the primary signal: a translation shares its source cue's time region, so
+// the cue with the greatest temporal overlap is the correct pairing even when a
+// neighboring cue happens to start closer (issue #441). Only when a secondary
+// overlaps no unassigned primary does alignment fall back to the nearest primary
+// by inter-cue gap, and then only within toleranceMS. A secondary cue with no
+// primary in range is emitted as its own secondary-only cue (never dropped).
+// Alignment is deterministic: inputs are sorted by (start,end); the greatest-
+// overlap (else nearest-gap) primary wins; ties break to the earlier primary;
+// and a primary already carrying a secondary run keeps its first match so a
+// later secondary falls through to its own cue.
 //
 // A non-positive toleranceMS falls back to DefaultAlignToleranceMS. Passing nil
 // secondary cues yields the primaries rendered as monolingual bilingual cues.
@@ -64,7 +69,7 @@ func AlignBilingual(primary, secondary []Cue, primaryLang, secondaryLang string,
 
 	var orphans []BilingualCue
 	for _, s := range sec {
-		idx := nearestPrimary(prim, assigned, s.StartMS, toleranceMS)
+		idx := bestPrimary(prim, assigned, s, toleranceMS)
 		if idx < 0 {
 			// No primary within tolerance (or all candidates already carry a
 			// secondary run): emit the secondary as its own cue rather than drop
@@ -94,26 +99,66 @@ func AlignBilingual(primary, secondary []Cue, primaryLang, secondaryLang string,
 	return merged
 }
 
-// nearestPrimary returns the index of the unassigned primary cue whose start is
-// closest to startMS within toleranceMS, or -1 when none qualifies. Ties (equal
-// distance) resolve to the earlier (lower-index) primary for determinism.
-func nearestPrimary(prim []Cue, assigned []bool, startMS, toleranceMS int) int {
-	best := -1
+// bestPrimary returns the index of the unassigned primary cue that best matches
+// secondary cue s, or -1 when none qualifies. Selection is overlap-first
+// (issue #441): the unassigned primary whose time region overlaps s the most
+// wins outright, since a translation shares its source cue's region regardless
+// of small start offsets — so a translation of a long cue is no longer stolen by
+// a short neighbor that merely starts nearer, and a secondary that clearly
+// overlaps one primary is not greedily mis-paired to an adjacent one within
+// tolerance. Overlapping candidates are NOT gated by toleranceMS: a shared time
+// region is a match however the starts line up. Only when s overlaps no
+// unassigned primary does it fall back to the nearest primary by START distance
+// within toleranceMS (the pre-existing tolerance contract, unchanged). Ties
+// (equal overlap, or equal start distance in the fallback) resolve to the
+// earlier (lower-index) primary for determinism.
+func bestPrimary(prim []Cue, assigned []bool, s Cue, toleranceMS int) int {
+	bestOverlap := 0
+	bestOverlapIdx := -1
 	bestDelta := toleranceMS + 1
+	bestDeltaIdx := -1
 	for i, p := range prim {
 		if assigned[i] {
 			continue
 		}
-		delta := startMS - p.StartMS
+		if ov := overlapMS(s, p); ov > 0 {
+			if ov > bestOverlap {
+				bestOverlap = ov
+				bestOverlapIdx = i
+			}
+			continue
+		}
+		delta := s.StartMS - p.StartMS
 		if delta < 0 {
 			delta = -delta
 		}
 		if delta <= toleranceMS && delta < bestDelta {
-			best = i
 			bestDelta = delta
+			bestDeltaIdx = i
 		}
 	}
-	return best
+	if bestOverlapIdx >= 0 {
+		return bestOverlapIdx
+	}
+	return bestDeltaIdx
+}
+
+// overlapMS returns the length in milliseconds of the temporal overlap between
+// two cues' [start,end] regions, or 0 when they do not overlap (touching regions
+// count as 0 overlap and fall through to the start-distance fallback).
+func overlapMS(a, b Cue) int {
+	lo := a.StartMS
+	if b.StartMS > lo {
+		lo = b.StartMS
+	}
+	hi := a.EndMS
+	if b.EndMS < hi {
+		hi = b.EndMS
+	}
+	if hi <= lo {
+		return 0
+	}
+	return hi - lo
 }
 
 // sortedByStart returns a copy of cues ordered by (start, end) so alignment and

--- a/tests/store/list_files_glob_test.go
+++ b/tests/store/list_files_glob_test.go
@@ -3,12 +3,39 @@ package tests
 import (
 	"context"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"testing"
 
 	"github.com/dirstral/dir2mcp/internal/model"
 	"github.com/dirstral/dir2mcp/internal/store"
 )
+
+// globCase pairs a glob with the paths list_files must return for it (drawn from
+// globTestRelPaths). Shared by the canonical-semantics test and the file_glob
+// agreement test (issue #441).
+type globCase struct {
+	glob string
+	want []string
+}
+
+var globTestRelPaths = []string{
+	"root.pdf",
+	"docs/guide.pdf",
+	"docs/notes.txt",
+	"docs/sub/deep.pdf",
+	"src/main.go",
+}
+
+var globTestCases = []globCase{
+	// `*` is segment-aware: `*.pdf` matches only root-level PDFs.
+	{"*.pdf", []string{"root.pdf"}},
+	// `docs/*` matches direct children of docs/, not nested.
+	{"docs/*", []string{"docs/guide.pdf", "docs/notes.txt"}},
+	// `**` recurses across segments.
+	{"**/*.pdf", []string{"docs/guide.pdf", "docs/sub/deep.pdf", "root.pdf"}},
+	{"docs/**", []string{"docs/guide.pdf", "docs/notes.txt", "docs/sub/deep.pdf"}},
+}
 
 // TestListFiles_GlobCanonicalSemantics pins that the list_files glob now uses the
 // SAME canonical matcher as the search/ask file_glob filter (issue #441): `*` is
@@ -23,14 +50,7 @@ func TestListFiles_GlobCanonicalSemantics(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = st.Close() })
 
-	relPaths := []string{
-		"root.pdf",
-		"docs/guide.pdf",
-		"docs/notes.txt",
-		"docs/sub/deep.pdf",
-		"src/main.go",
-	}
-	for _, rp := range relPaths {
+	for _, rp := range globTestRelPaths {
 		if err := st.UpsertDocument(ctx, model.Document{RelPath: rp, DocType: "text", Status: "ok"}); err != nil {
 			t.Fatalf("upsert %q: %v", rp, err)
 		}
@@ -52,40 +72,25 @@ func TestListFiles_GlobCanonicalSemantics(t *testing.T) {
 		return got
 	}
 
-	cases := []struct {
-		glob string
-		want []string
-	}{
-		// `*` is segment-aware: `*.pdf` matches only root-level PDFs.
-		{"*.pdf", []string{"root.pdf"}},
-		// `docs/*` matches direct children of docs/, not nested.
-		{"docs/*", []string{"docs/guide.pdf", "docs/notes.txt"}},
-		// `**` recurses across segments.
-		{"**/*.pdf", []string{"docs/guide.pdf", "docs/sub/deep.pdf", "root.pdf"}},
-		{"docs/**", []string{"docs/guide.pdf", "docs/notes.txt", "docs/sub/deep.pdf"}},
-	}
-	for _, c := range cases {
-		got := listGlob(c.glob)
-		sort.Strings(c.want)
-		if len(got) != len(c.want) {
-			t.Errorf("glob %q: got %v want %v", c.glob, got, c.want)
-			continue
-		}
-		for i := range got {
-			if got[i] != c.want[i] {
-				t.Errorf("glob %q: got %v want %v", c.glob, got, c.want)
-				break
-			}
+	for _, c := range globTestCases {
+		want := append([]string(nil), c.want...)
+		sort.Strings(want)
+		if got := listGlob(c.glob); !reflect.DeepEqual(got, want) {
+			t.Errorf("glob %q: got %v want %v", c.glob, got, want)
 		}
 	}
+}
 
-	// Cross-check: list_files and the file_glob matcher agree on every path.
-	for _, c := range cases {
+// TestListFiles_GlobMatchesFileGlob pins that the search/ask file_glob matcher
+// (model.MatchGlob) selects exactly the same paths list_files returns for each
+// canonical glob (issue #441) — the two surfaces must never diverge.
+func TestListFiles_GlobMatchesFileGlob(t *testing.T) {
+	for _, c := range globTestCases {
 		want := map[string]bool{}
 		for _, w := range c.want {
 			want[w] = true
 		}
-		for _, rp := range relPaths {
+		for _, rp := range globTestRelPaths {
 			viaFilter, err := model.MatchGlob(c.glob, rp)
 			if err != nil {
 				t.Fatalf("MatchGlob(%q,%q): %v", c.glob, rp, err)

--- a/tests/store/list_files_glob_test.go
+++ b/tests/store/list_files_glob_test.go
@@ -1,0 +1,130 @@
+package tests
+
+import (
+	"context"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// TestListFiles_GlobCanonicalSemantics pins that the list_files glob now uses the
+// SAME canonical matcher as the search/ask file_glob filter (issue #441): `*` is
+// segment-aware (does NOT cross `/`) and `**` is recursive. Previously list_files
+// used SQLite GLOB where `*` crossed `/`, so `*.pdf` and `docs/*` returned a
+// different file set than the identical file_glob on search/ask.
+func TestListFiles_GlobCanonicalSemantics(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("store init: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	relPaths := []string{
+		"root.pdf",
+		"docs/guide.pdf",
+		"docs/notes.txt",
+		"docs/sub/deep.pdf",
+		"src/main.go",
+	}
+	for _, rp := range relPaths {
+		if err := st.UpsertDocument(ctx, model.Document{RelPath: rp, DocType: "text", Status: "ok"}); err != nil {
+			t.Fatalf("upsert %q: %v", rp, err)
+		}
+	}
+
+	listGlob := func(glob string) []string {
+		docs, total, err := st.ListFiles(ctx, "", glob, 1000, 0)
+		if err != nil {
+			t.Fatalf("ListFiles(glob=%q): %v", glob, err)
+		}
+		got := make([]string, 0, len(docs))
+		for _, d := range docs {
+			got = append(got, d.RelPath)
+		}
+		sort.Strings(got)
+		if int64(len(got)) != total {
+			t.Fatalf("ListFiles(glob=%q): len(docs)=%d != total=%d", glob, len(got), total)
+		}
+		return got
+	}
+
+	cases := []struct {
+		glob string
+		want []string
+	}{
+		// `*` is segment-aware: `*.pdf` matches only root-level PDFs.
+		{"*.pdf", []string{"root.pdf"}},
+		// `docs/*` matches direct children of docs/, not nested.
+		{"docs/*", []string{"docs/guide.pdf", "docs/notes.txt"}},
+		// `**` recurses across segments.
+		{"**/*.pdf", []string{"docs/guide.pdf", "docs/sub/deep.pdf", "root.pdf"}},
+		{"docs/**", []string{"docs/guide.pdf", "docs/notes.txt", "docs/sub/deep.pdf"}},
+	}
+	for _, c := range cases {
+		got := listGlob(c.glob)
+		sort.Strings(c.want)
+		if len(got) != len(c.want) {
+			t.Errorf("glob %q: got %v want %v", c.glob, got, c.want)
+			continue
+		}
+		for i := range got {
+			if got[i] != c.want[i] {
+				t.Errorf("glob %q: got %v want %v", c.glob, got, c.want)
+				break
+			}
+		}
+	}
+
+	// Cross-check: list_files and the file_glob matcher agree on every path.
+	for _, c := range cases {
+		want := map[string]bool{}
+		for _, w := range c.want {
+			want[w] = true
+		}
+		for _, rp := range relPaths {
+			viaFilter, err := model.MatchGlob(c.glob, rp)
+			if err != nil {
+				t.Fatalf("MatchGlob(%q,%q): %v", c.glob, rp, err)
+			}
+			if viaFilter != want[rp] {
+				t.Errorf("divergence glob %q path %q: file_glob=%v list_files=%v", c.glob, rp, viaFilter, want[rp])
+			}
+		}
+	}
+}
+
+// TestListFiles_GlobPagination pins that Go-side glob pagination reports the full
+// matched total while returning only the requested page.
+func TestListFiles_GlobPagination(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("store init: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	for _, rp := range []string{"a.pdf", "b.pdf", "c.pdf", "d.txt"} {
+		if err := st.UpsertDocument(ctx, model.Document{RelPath: rp, DocType: "text", Status: "ok"}); err != nil {
+			t.Fatalf("upsert %q: %v", rp, err)
+		}
+	}
+
+	docs, total, err := st.ListFiles(ctx, "", "*.pdf", 2, 1)
+	if err != nil {
+		t.Fatalf("ListFiles: %v", err)
+	}
+	if total != 3 {
+		t.Errorf("total=%d want 3 (a,b,c .pdf)", total)
+	}
+	if len(docs) != 2 {
+		t.Fatalf("page len=%d want 2", len(docs))
+	}
+	// Ordered by rel_path, offset 1 -> b.pdf, c.pdf.
+	if docs[0].RelPath != "b.pdf" || docs[1].RelPath != "c.pdf" {
+		t.Errorf("page = %q,%q want b.pdf,c.pdf", docs[0].RelPath, docs[1].RelPath)
+	}
+}

--- a/tests/subtitle/bilingual_test.go
+++ b/tests/subtitle/bilingual_test.go
@@ -54,6 +54,63 @@ func TestAlignBilingualWithinTolerance(t *testing.T) {
 	}
 }
 
+// TestAlignBilingualOverlapWins pins the issue #441 fix: pairing is overlap-first,
+// so a secondary is merged into the primary whose TIME REGION it overlaps most —
+// not merely the primary whose start is nearest. A greedy start-only matcher with
+// a 2500 ms tolerance would mis-pair these; overlap-aware alignment does not.
+func TestAlignBilingualOverlapWins(t *testing.T) {
+	// Two adjacent primaries. The secondary starts 100 ms before P1 but sits
+	// squarely inside P1's region; a start-distance matcher within tolerance could
+	// steal it onto P0 (start distance 1900 ms < 2500 ms). Overlap must win.
+	primary := []subtitle.Cue{
+		{StartMS: 0, EndMS: 1800, Text: "P0"},
+		{StartMS: 2000, EndMS: 3800, Text: "P1"},
+	}
+	secondary := []subtitle.Cue{
+		{StartMS: 1900, EndMS: 3700, Text: "S1"},
+	}
+	got := subtitle.AlignBilingual(primary, secondary, "en", "fr", 2500)
+
+	var p1 *subtitle.BilingualCue
+	for i := range got {
+		if got[i].PrimaryText == "P1" {
+			p1 = &got[i]
+		}
+		if got[i].PrimaryText == "P0" && got[i].SecondaryText != "" {
+			t.Fatalf("secondary mis-paired onto P0 (start-nearest): %+v", got[i])
+		}
+	}
+	if p1 == nil {
+		t.Fatalf("P1 cue missing: %+v", got)
+	}
+	if p1.SecondaryText != "S1" || p1.SecondaryLang != "fr" {
+		t.Fatalf("secondary S1 should merge into P1 (max overlap), got %+v", *p1)
+	}
+}
+
+// TestAlignBilingualLongCueNotStolen pins fix 3.2: a translation of a long cue is
+// not stolen by a short neighbor that merely starts nearer. The secondary overlaps
+// the long primary heavily; the short primary starts closer but shares no region.
+func TestAlignBilingualLongCueNotStolen(t *testing.T) {
+	primary := []subtitle.Cue{
+		{StartMS: 1000, EndMS: 1200, Text: "SHORT"},
+		{StartMS: 1300, EndMS: 6000, Text: "LONG"},
+	}
+	secondary := []subtitle.Cue{
+		// Starts 500 ms after SHORT (nearest start) but overlaps LONG for ~4 s.
+		{StartMS: 1500, EndMS: 5800, Text: "T"},
+	}
+	got := subtitle.AlignBilingual(primary, secondary, "en", "fr", 2500)
+	for _, c := range got {
+		if c.PrimaryText == "SHORT" && c.SecondaryText != "" {
+			t.Fatalf("translation stolen by short neighbor: %+v", c)
+		}
+		if c.PrimaryText == "LONG" && c.SecondaryText != "T" {
+			t.Fatalf("translation should merge into LONG (max overlap), got %+v", c)
+		}
+	}
+}
+
 // TestAlignBilingualDeterministic pins deterministic alignment: repeated runs
 // over identical inputs produce identical cue slices.
 func TestAlignBilingualDeterministic(t *testing.T) {


### PR DESCRIPTION
Addresses #441 (part of #395). Fixes the glob-filter divergence, `**` support, case consistency, and bilingual mis-pairing; defers the spec-mandated language-filter item.

## What changed

### 1. `file_glob` and `list_files` glob now agree (issue 1.1/1.2/1.3)
Before: `file_glob` used Go `path.Match` (segment-aware `*`, **no `**`**, case-sensitive) while `list_files` used SQLite `GLOB` (`*` **crosses `/`**, no `**`, case-sensitive). The same pattern returned **different file sets** — e.g. `*.pdf` matched only root PDFs in search/ask but every PDF in `list_files` — and `**` was silently ignored on the retrieval side.

New: a single canonical matcher `model.MatchGlob` / `model.CompileGlob` (new `internal/model/glob.go`) drives **both** surfaces:
- `*` is segment-aware (does not cross `/`)
- `**` is recursive (`**/x` matches `x`, `a/x`, `a/b/x`)
- `?` = one non-`/` char
- `\x` escapes a metacharacter to a literal (preserves `escapeGlobLiteral`, so `open_file`'s exact-path match still works)
- ASCII **case-insensitive**, matching `path_prefix` (closes 1.3)

`matchFilters` (retrieval) and `Filter.Match` (pushdown) call it; `store.ListFiles` evaluates it in Go when a glob is set (and keeps efficient SQL `LIMIT/OFFSET` pagination when no glob is given). This mirrors how `NormalizePathPrefix` already unified `path_prefix`.

Behavior note: `list_files glob:"*.pdf"` now returns **root-only** PDFs (use `**/*.pdf` for recursive) — the intended consequence of making the two surfaces agree on the canonical dialect.

### 2. Bilingual alignment is overlap-aware (issue 3.1/3.2)
`AlignBilingual` paired each secondary cue to the nearest **start** within a 2500 ms tolerance, which mis-paired a translation onto the wrong adjacent cue and let a short neighbor steal a long cue's translation. Pairing is now **overlap-first**: the unassigned primary with the greatest time-region overlap wins outright (ungated by tolerance). The prior nearest-start-within-tolerance rule is kept only as the fallback for a secondary that overlaps no primary, so the existing orphan/tolerance contract is unchanged.

## Deferred (spec-touching)
The `languages` filter's over-matching (`en-US` also matches `en-GB`/`en`; `zh-Hant` matches `zh-Hans`) is **mandated** by SPEC §9.5: matching is primary-subtag only and *"Region, script, and other subtags MUST NOT cause a match to be missed when the primary subtags agree."* Narrowing by region/script contradicts a normative MUST, so it needs a `dirstral-spec` change first (spec governance loop) rather than a code-only fix. Left `IsValidLanguageTag` (2.2/2.3) untouched to keep this PR spec-neutral.

## Tests
- `internal/model/glob_test.go`: canonical semantics table (`*` vs `**`, `?`, escaping, case-fold, trailing-`\` error) + `Filter.Match` == `MatchGlob` agreement.
- `tests/store/list_files_glob_test.go`: `list_files` honors segment-aware `*` / recursive `**`, agrees with `file_glob` matcher, and paginates the matched total correctly.
- `tests/subtitle/bilingual_test.go`: overlap wins over nearest-start; long-cue translation not stolen by short neighbor.

`make lint` = 0 issues. `go test ./internal/... ./tests/...` (store, retrieval, mcp, subtitle, conformance, ingest, cli) all pass.