### PR TITLE
fix(providers): keep embed dims on override, un-shadow Voxtral in auto-STT, truthful transcribe provenance (#440)

### DIFF
--- a/internal/config/providers.go
+++ b/internal/config/providers.go
@@ -102,13 +102,26 @@ func builtinProfiles() map[string]providerProfileYAML {
 // builtinPrecedence is the deterministic auto-selection order (SPEC
 // 8.1.3): Mistral first (historical default), then the rest. User-only
 // profiles are appended in declared order after these.
+//
+// `mistral-ocr` (kind: mistral — the Voxtral STT / Mistral-OCR path) precedes
+// `mistral` (kind: openai — the OpenAI-compatible chat/embed path). This
+// ordering is what makes `stt_provider: auto` resolve to the intended Voxtral
+// backend: for STT, `mistral` is only EndpointDependent (an arbitrary
+// api.mistral.ai/v1 base URL is not guaranteed to serve /v1/audio/transcriptions)
+// while `mistral-ocr` is statically Supported, and 8.1.3 auto selection takes the
+// FIRST eligible+capable profile in precedence order. With `mistral` first, auto
+// STT silently bound the OpenAI-compat transcriber and never used the seeded
+// Voxtral model (issue #440 F4). `mistral-ocr` carries no embed/chat capability,
+// so ordering it ahead of `mistral` leaves embed/chat/ocr auto selection
+// unchanged — it is skipped for those and `mistral` still wins.
+//
 // `local` is intentionally excluded: it is credential-less and would
 // otherwise silently win auto-selection when no real credential is
 // set, masking a missing-credential misconfig (and pointing at a
 // localhost endpoint that is usually not running). It remains fully
 // usable via an explicit `model.<cap>.provider: local` binding.
 var builtinPrecedence = []string{
-	"mistral", "mistral-ocr", "openai", "gemini", "cohere",
+	"mistral-ocr", "mistral", "openai", "gemini", "cohere",
 	"anthropic", "elevenlabs", "openrouter",
 }
 
@@ -318,6 +331,19 @@ func mergeProfiles(base, user map[string]providerProfileYAML) (map[string]provid
 			if f.src != "" {
 				*f.dst = f.src
 			}
+		}
+		// Carry the per-axis requested embedding dimensions (SPEC 8.1.6,
+		// Matryoshka/MRL). These are ints, not strings, so they are merged
+		// separately: a non-zero override wins, zero leaves the built-in dim
+		// intact. Omitting them here silently dropped a `providers:` profile
+		// override of embed_text_dim/embed_code_dim (issue #440 F1), resetting
+		// the effective embedding dimension and recording dim=0 in the embed
+		// identity.
+		if up.EmbedTextDim != 0 {
+			base.EmbedTextDim = up.EmbedTextDim
+		}
+		if up.EmbedCodeDim != 0 {
+			base.EmbedCodeDim = up.EmbedCodeDim
 		}
 		merged[name] = base
 	}

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -854,6 +854,22 @@ func resolveSTTProfile(cfg config.Config) (provider.Profile, bool) {
 	return prof, true
 }
 
+// ResolveSTTProviderModel returns the resolved active STT provider profile name
+// and its STT model for cfg (SPEC 8.1.3), mirroring the exact selection
+// TranscriberFromConfigWithLanguage / resolveSTTProfile perform. It exists so the
+// MCP tool layer can report the transcriber ACTUALLY used as provenance instead
+// of a hardcoded "mistral"/"voxtral-mini-latest" pair (issue #440 F5): with
+// stt_provider=elevenlabs/whisper/gemini/auto the reported provider now matches
+// the backend that produced the transcript. ok=false when STT is off or no
+// STT-capable profile resolves, in which case the caller keeps its own fallback.
+func ResolveSTTProviderModel(cfg config.Config) (providerName, sttModel string, ok bool) {
+	prof, resolved := resolveSTTProfile(cfg)
+	if !resolved {
+		return "", "", false
+	}
+	return strings.TrimSpace(prof.Name), strings.TrimSpace(prof.STTModel), true
+}
+
 // translatorFromConfig resolves the chat-capability binding used to translate
 // transcripts (SPEC §8.6.2: "uses the chat capability unless a dedicated
 // binding is configured") and builds a model.Generator from it. A dedicated

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1112,10 +1112,11 @@ func (s *Server) handleTranscribeTool(ctx context.Context, args map[string]inter
 		}
 	}
 
+	sttProvider, sttModel := resolvedSTTProvenance(s.cfg)
 	structured := map[string]interface{}{
 		"rel_path":        relPath,
-		"provider":        defaultSTTProvider,
-		"model":           defaultSTTModel,
+		"provider":        sttProvider,
+		"model":           sttModel,
 		"indexed":         indexed,
 		"segments":        segments,
 		"transcribed":     transcribed,
@@ -1126,6 +1127,25 @@ func (s *Server) handleTranscribeTool(ctx context.Context, args map[string]inter
 		Content:           []toolContentItem{{Type: "text", Text: fmt.Sprintf("transcribed %s", relPath)}},
 		StructuredContent: structured,
 	}, nil
+}
+
+// resolvedSTTProvenance returns the provider name + model of the STT backend the
+// server is actually configured to use, so transcribe / transcribe_and_ask report
+// truthful provenance in their tool results instead of the hardcoded
+// mistral/voxtral-mini-latest constants (issue #440 F5): with an ElevenLabs,
+// Whisper, Gemini, or auto-resolved backend the emitted provider/model now match
+// the transcriber that produced the transcript. It falls back to the historical
+// defaults only when no STT profile resolves (STT off/unconfigured), a defensive
+// path a real transcription never reaches.
+func resolvedSTTProvenance(cfg config.Config) (providerName, sttModel string) {
+	name, mdl, ok := ingest.ResolveSTTProviderModel(cfg)
+	if !ok {
+		return defaultSTTProvider, defaultSTTModel
+	}
+	if strings.TrimSpace(mdl) == "" {
+		mdl = defaultSTTModel
+	}
+	return name, mdl
 }
 
 func parseAnnotateArgs(args map[string]interface{}) (relPath string, schemaJSON map[string]interface{}, indexFlattenedText bool, maxChars int, toolErr *toolExecutionError) {
@@ -1311,9 +1331,10 @@ func (s *Server) handleTranscribeAndAskTool(ctx context.Context, args map[string
 		return toolCallResult{}, mapSearchError(askErr)
 	}
 
+	sttProvider, sttModel := resolvedSTTProvenance(s.cfg)
 	structured := buildAskStructuredContent(askResult)
-	structured["transcript_provider"] = defaultSTTProvider
-	structured["transcript_model"] = defaultSTTModel
+	structured["transcript_provider"] = sttProvider
+	structured["transcript_model"] = sttModel
 	structured["transcribed"] = strings.TrimSpace(transcriptText) != ""
 	structured["transcribed_now"] = transcribedNow
 
@@ -3109,8 +3130,12 @@ func transcribeOutputSchema() map[string]interface{} {
 		"type":                 "object",
 		"additionalProperties": false,
 		"properties": map[string]interface{}{
-			"rel_path":        map[string]interface{}{"type": "string"},
-			"provider":        map[string]interface{}{"type": "string", "enum": []string{"mistral", "elevenlabs"}},
+			"rel_path": map[string]interface{}{"type": "string"},
+			// provider is the resolved STT profile name (issue #440 F5), which may be
+			// any STT-capable profile (mistral-ocr, elevenlabs, whisper, gemini, a
+			// user-declared profile, …), so it is an open string rather than a pinned
+			// enum that would exclude the very backends the field now reports truthfully.
+			"provider":        map[string]interface{}{"type": "string"},
 			"model":           map[string]interface{}{"type": "string"},
 			"indexed":         map[string]interface{}{"type": "boolean"},
 			"transcribed":     map[string]interface{}{"type": "boolean"},
@@ -3197,7 +3222,10 @@ func transcribeAndAskOutputSchema() map[string]interface{} {
 		return askOutputSchema()
 	}
 
-	properties["transcript_provider"] = map[string]interface{}{"type": "string", "enum": []string{"mistral", "elevenlabs"}}
+	// transcript_provider is the resolved STT profile name (issue #440 F5); like
+	// transcribe's `provider` it is an open string, not a pinned two-value enum,
+	// so whisper/gemini/user-profile backends are reported truthfully.
+	properties["transcript_provider"] = map[string]interface{}{"type": "string"}
 	properties["transcript_model"] = map[string]interface{}{"type": "string"}
 	properties["transcribed"] = map[string]interface{}{"type": "boolean"}
 	properties["transcribed_now"] = map[string]interface{}{"type": "boolean"}

--- a/tests/config/providers_config_test.go
+++ b/tests/config/providers_config_test.go
@@ -202,6 +202,41 @@ func TestProviders_EmbedDimensionKnob(t *testing.T) {
 	}
 }
 
+// TestProviders_ProfileOverrideKeepsEmbedDims pins issue #440 F1: overriding a
+// built-in profile via the `providers:` map with embed_text_dim/embed_code_dim
+// must carry those Matryoshka dims (SPEC 8.1.6) through mergeProfiles onto the
+// resolved profile and into the embed identity. Before the fix the int dim fields
+// were dropped on the override branch (only string models were merged), so the
+// override was silently ignored, the provider embedded at its native dimension,
+// and the embed identity recorded dim=0.
+func TestProviders_ProfileOverrideKeepsEmbedDims(t *testing.T) {
+	// Blank the higher-precedence embed creds so gemini is the resolved embed
+	// provider and the override target.
+	for _, k := range []string{"MISTRAL_API_KEY", "OPENAI_API_KEY", "OPENROUTER_API_KEY", "COHERE_API_KEY"} {
+		t.Setenv(k, "")
+	}
+	t.Setenv("GEMINI_API_KEY", "gk")
+	yaml := "version: 1\n" +
+		"providers:\n" +
+		"  gemini:\n" +
+		"    embed_text_dim: 768\n" +
+		"    embed_code_dim: 256\n"
+	r := loadCfg(t, yaml).Providers()
+	p, err := r.Resolve(provider.CapEmbed)
+	if err != nil {
+		t.Fatalf("resolve embed: %v", err)
+	}
+	if p.Name != "gemini" {
+		t.Fatalf("embed provider = %q, want gemini", p.Name)
+	}
+	if p.EmbedTextDim != 768 || p.EmbedCodeDim != 256 {
+		t.Fatalf("profile-override dims dropped: text:%d code:%d, want 768/256", p.EmbedTextDim, p.EmbedCodeDim)
+	}
+	if !strings.Contains(r.EmbedIdentity(), "|768|256|") {
+		t.Fatalf("embed identity %q must encode the overridden dims", r.EmbedIdentity())
+	}
+}
+
 // TestProviders_EmbedMultimodalKnob pins SPEC 8.1.7: model.embed.multimodal
 // parses, resolves onto the embed profile, and enters the embed identity.
 func TestProviders_EmbedMultimodalKnob(t *testing.T) {

--- a/tests/ingest/stt_provenance_440_test.go
+++ b/tests/ingest/stt_provenance_440_test.go
@@ -1,0 +1,52 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+)
+
+// TestSTTAuto_ResolvesVoxtralNotOpenAICompat pins issue #440 F4: with
+// stt_provider=auto and only MISTRAL_API_KEY present, STT auto-selection must
+// resolve the Voxtral-backed `mistral-ocr` profile (kind: mistral, statically
+// STT-Supported), NOT the OpenAI-compatible `mistral` chat/embed profile
+// (kind: openai, STT only EndpointDependent). Before the precedence reorder,
+// `mistral` sat ahead of `mistral-ocr` and shadowed it, binding the wrong
+// transcriber and never using the seeded Voxtral model.
+func TestSTTAuto_ResolvesVoxtralNotOpenAICompat(t *testing.T) {
+	t.Setenv("MISTRAL_API_KEY", "k")
+	t.Setenv("ELEVENLABS_API_KEY", "")
+	t.Setenv("GEMINI_API_KEY", "")
+	cfg := config.Default()
+	cfg.STTProvider = "auto"
+
+	name, model, ok := ingest.ResolveSTTProviderModel(cfg)
+	if !ok {
+		t.Fatal("expected an STT provider to resolve in auto mode with MISTRAL_API_KEY set")
+	}
+	if name != "mistral-ocr" {
+		t.Fatalf("auto STT resolved provider = %q, want mistral-ocr (Voxtral), not the openai-compat mistral profile", name)
+	}
+	if model != "voxtral-mini-latest" {
+		t.Fatalf("auto STT resolved model = %q, want voxtral-mini-latest", model)
+	}
+}
+
+// TestSTTExplicit_ProviderReportedTruthfully pins issue #440 F5: an explicitly
+// configured non-Mistral STT backend must be reported by its own resolved profile
+// name, not the hardcoded "mistral". Exercised via the same resolver the transcribe
+// tool result now uses for its provenance.
+func TestSTTExplicit_ProviderReportedTruthfully(t *testing.T) {
+	t.Setenv("ELEVENLABS_API_KEY", "ek")
+	cfg := config.Default()
+	cfg.STTProvider = "elevenlabs"
+
+	name, _, ok := ingest.ResolveSTTProviderModel(cfg)
+	if !ok {
+		t.Fatal("expected the explicit elevenlabs STT provider to resolve")
+	}
+	if name != "elevenlabs" {
+		t.Fatalf("explicit STT provider reported as %q, want elevenlabs (not hardcoded mistral)", name)
+	}
+}

--- a/tests/mcp/tools_test.go
+++ b/tests/mcp/tools_test.go
@@ -228,7 +228,11 @@ func TestMCPToolsCallTranscribe_Success(t *testing.T) {
 	if gotLanguage != "fr" {
 		t.Fatalf("expected language hint to be forwarded, got %q", gotLanguage)
 	}
-	if got := envelope.Result.StructuredContent["provider"]; got != "mistral" {
+	// The reported provider is the resolved STT profile name (issue #440 F5),
+	// which for the default/Mistral STT path is the Voxtral-backed `mistral-ocr`
+	// profile — matching the derivation provenance — not the old hardcoded
+	// "mistral" constant.
+	if got := envelope.Result.StructuredContent["provider"]; got != "mistral-ocr" {
 		t.Fatalf("unexpected provider: %#v", got)
 	}
 	if got, ok := envelope.Result.StructuredContent["transcribed"].(bool); !ok || !got {
@@ -492,7 +496,9 @@ func TestMCPToolsCallTranscribeAndAsk_Success(t *testing.T) {
 	if got := envelope.Result.StructuredContent["answer"]; got != "alpha answer" {
 		t.Fatalf("unexpected answer: %#v", got)
 	}
-	if got := envelope.Result.StructuredContent["transcript_provider"]; got != "mistral" {
+	// Resolved STT profile name (issue #440 F5): the Voxtral-backed `mistral-ocr`
+	// profile, not the old hardcoded "mistral" constant.
+	if got := envelope.Result.StructuredContent["transcript_provider"]; got != "mistral-ocr" {
 		t.Fatalf("unexpected transcript_provider: %#v", got)
 	}
 }


### PR DESCRIPTION
Addresses #440 — fixes three of the four scoped sub-bugs (F1, F4, F5). **F3 is deferred to a dirstral-spec PR** (rationale below).

## F1 — profile override drops embed dims
`mergeProfiles` copied `Kind`/`BaseURL`/`APIKey` + string model fields but not the int `EmbedTextDim`/`EmbedCodeDim` when overriding an existing profile, so `providers: {gemini: {embed_text_dim: 768}}` was silently ignored — the provider embedded at its native dim and the embed identity recorded dim=0. Now the per-axis Matryoshka dims (SPEC 8.1.6) are carried through the override branch.

## F4 — auto STT shadowed Voxtral
`stt_provider: auto` resolved the OpenAI-compat `mistral` profile (`kind: openai`, STT only *EndpointDependent*) instead of the intended Voxtral `mistral-ocr` profile (`kind: mistral`, statically STT-*Supported*), because `mistral` preceded `mistral-ocr` in `builtinPrecedence` and 8.1.3 auto takes the first eligible+capable profile. Reordered so `mistral-ocr` precedes `mistral`. `mistral-ocr` carries no embed/chat capability, so embed/chat/ocr auto selection is unchanged (it is skipped there and `mistral` still wins) — only STT auto changes, correctly.

## F5 — transcribe result hardcoded provider=mistral
`transcribe` / `transcribe_and_ask` tool results emitted `provider=mistral`, `model=voxtral-mini-latest` regardless of the STT backend actually used. Now they report the resolved STT profile identity via `ingest.ResolveSTTProviderModel` (matching the derivation provenance at `service.go`), and the two output-schema `provider` fields are widened from a two-value enum to an open string so whisper/gemini/user-profile backends are described truthfully.

## F3 — EmbedIdentity omits base_url — DEFERRED (needs a spec PR)
SPEC §8.1.4 normatively enumerates the embed identity as `provider | text_model | code_model | text_dim | code_dim | multimodal`; base_url is not among them. Adding it changes the recorded, distributed-worker-compared (§6.4) identity **format**, and — unlike `late_chunking`, which defaults `off` for every pre-existing corpus and thus migrates cleanly — there is **no universal default base_url**, so every deployed corpus's recorded identity (no base_url) would mismatch the current one and force a **spurious full reindex** (the exact harm F3 itself warns about). Per the spec-governance loop this requires a `dirstral-spec` PR first (to define base_url's inclusion/position and the legacy-corpus grandfathering/migration), then a gated re-pin here.

## Tests
- `TestProviders_ProfileOverrideKeepsEmbedDims` — override keeps dims + enters the embed identity.
- `TestSTTAuto_ResolvesVoxtralNotOpenAICompat` — auto STT resolves `mistral-ocr`/`voxtral-mini-latest`, not the openai-compat `mistral`.
- `TestSTTExplicit_ProviderReportedTruthfully` — explicit elevenlabs reported by its own name.
- Updated two mcp tool tests that pinned the old hardcoded `"mistral"` (now `"mistral-ocr"`).

`make lint` = 0 issues; `tests/{provider,config,ingest,mcp,providerfactory}` + `internal/ingest` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)