### PR TITLE
fix(latechunk): L2-normalize pooled document vectors; report #446 wiring status

### DIFF
--- a/internal/latechunk/latechunk.go
+++ b/internal/latechunk/latechunk.go
@@ -26,6 +26,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 
 	"github.com/dirstral/dir2mcp/internal/model"
 )
@@ -174,6 +175,19 @@ func MeanPoolSpans(tok model.TokenEmbedding, spans []Span) (vectors [][]float32,
 // fallbackIdx slice lists span indices that no token overlapped (nil vector at
 // that index); a runtime token-embed failure returns a FallbackEmbedError-tagged
 // error so the caller embeds the whole document the old way. dec MUST be Active.
+//
+// Each returned chunk vector is L2-normalized to unit length (issue #446 F3): the
+// pooled arithmetic mean of contextual token vectors has no fixed norm, and while
+// that is harmless under cosine similarity (which normalizes internally, as the
+// default HNSW index does), a vector store configured for raw inner/dot-product
+// distance (a Qdrant/pgvector deployment MAY be) assumes unit-norm vectors. The
+// query side already produces provider-normalized embeddings via Embed, so
+// normalizing here keeps the late-chunked corpus vectors comparable to queries in
+// that space too. Pooling stays in MeanPoolSpan/MeanPoolSpans as a pure arithmetic
+// mean (that is the documented, unit-tested contract); normalization is applied
+// only here, on the index-bound document path. A degenerate zero-magnitude pooled
+// vector is returned unchanged (it cannot be normalized and, being all-zero, is an
+// upstream token-embedding anomaly rather than something this step should mask).
 func EmbedDocument(ctx context.Context, dec Decision, modelName string, docText string, spans []Span) (vectors [][]float32, fallbackIdx []int, err error) {
 	if !dec.Active || dec.Embedder == nil {
 		return nil, nil, fmt.Errorf("latechunk: EmbedDocument called with inactive decision (%s)", dec.Fallback)
@@ -185,7 +199,34 @@ func EmbedDocument(ctx context.Context, dec Decision, modelName string, docText 
 	if len(toks) != 1 {
 		return nil, nil, fmt.Errorf("%s: token-embedder returned %d results for 1 input", FallbackEmbedError, len(toks))
 	}
-	return MeanPoolSpans(toks[0], spans)
+	vectors, fallbackIdx, err = MeanPoolSpans(toks[0], spans)
+	if err != nil {
+		return nil, nil, err
+	}
+	for i := range vectors {
+		// nil vectors are per-span fallbacks (no token overlapped); leave them nil
+		// so the caller still sees which spans to embed the old way.
+		if vectors[i] != nil {
+			l2NormalizeInPlace(vectors[i])
+		}
+	}
+	return vectors, fallbackIdx, nil
+}
+
+// l2NormalizeInPlace scales v to unit L2 norm in place. A zero-magnitude vector
+// (no direction to preserve) is left unchanged rather than dividing by zero.
+func l2NormalizeInPlace(v []float32) {
+	var sumSq float64
+	for _, x := range v {
+		sumSq += float64(x) * float64(x)
+	}
+	if sumSq == 0 {
+		return
+	}
+	inv := float32(1 / math.Sqrt(sumSq))
+	for i := range v {
+		v[i] *= inv
+	}
 }
 
 // IsEmbedFallback reports whether err is a runtime token-embed failure from

--- a/tests/latechunk/latechunk_test.go
+++ b/tests/latechunk/latechunk_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"context"
 	"errors"
+	"math"
 	"testing"
 
 	"github.com/dirstral/dir2mcp/internal/latechunk"
@@ -201,8 +202,20 @@ func TestDecide_NilEmbedderFallsBack(t *testing.T) {
 	}
 }
 
+// l2Norm returns the Euclidean norm of v.
+func l2Norm(v []float32) float64 {
+	var sumSq float64
+	for _, x := range v {
+		sumSq += float64(x) * float64(x)
+	}
+	return math.Sqrt(sumSq)
+}
+
 // TestEmbedDocument_PoolsPerSpan exercises the full active path: embed the whole
-// document once via the fake token embedder, then mean-pool per chunk span.
+// document once via the fake token embedder, then mean-pool per chunk span. The
+// index-bound document path L2-normalizes each pooled vector (issue #446 F3), so
+// the expected vectors are the unit-normalized means (pooling itself, tested via
+// MeanPoolSpan above, stays a pure arithmetic mean).
 func TestEmbedDocument_PoolsPerSpan(t *testing.T) {
 	dec := latechunk.Decide(true, fakeTokenEmbedder{tok: fourTokenDoc()})
 	spans := []latechunk.Span{{Start: 0, End: 4}, {Start: 4, End: 8}}
@@ -213,13 +226,37 @@ func TestEmbedDocument_PoolsPerSpan(t *testing.T) {
 	if len(fallbackIdx) != 0 {
 		t.Fatalf("unexpected per-span fallbacks: %v", fallbackIdx)
 	}
-	if want := []float32{0.5, 0.5, 0}; !vecsAlmostEqual(vecs[0], want) {
+	// span [0,4): mean of (1,0,0),(0,1,0) = (0.5,0.5,0), normalized to unit norm.
+	if want := normalize([]float32{0.5, 0.5, 0}); !vecsAlmostEqual(vecs[0], want) {
 		t.Fatalf("span 0 = %v, want %v", vecs[0], want)
 	}
-	// span [4,8) overlaps tok2 (0,0,1) and tok3 (1,1,1): mean = (0.5,0.5,1).
-	if want := []float32{0.5, 0.5, 1}; !vecsAlmostEqual(vecs[1], want) {
+	// span [4,8) overlaps tok2 (0,0,1) and tok3 (1,1,1): mean = (0.5,0.5,1),
+	// normalized to unit norm.
+	if want := normalize([]float32{0.5, 0.5, 1}); !vecsAlmostEqual(vecs[1], want) {
 		t.Fatalf("span 1 = %v, want %v", vecs[1], want)
 	}
+	// Both index-bound vectors must be unit-norm so an inner/dot-product backend
+	// (which assumes unit vectors) compares them correctly against normalized
+	// query embeddings.
+	for i, v := range vecs {
+		if n := l2Norm(v); n < 1-1e-6 || n > 1+1e-6 {
+			t.Fatalf("vec %d not unit-norm: |%v| = %v", i, v, n)
+		}
+	}
+}
+
+// normalize returns a unit-L2-norm copy of v (test helper mirroring the
+// normalization EmbedDocument applies on the index-bound path).
+func normalize(v []float32) []float32 {
+	n := l2Norm(v)
+	if n == 0 {
+		return v
+	}
+	out := make([]float32, len(v))
+	for i, x := range v {
+		out[i] = float32(float64(x) / n)
+	}
+	return out
 }
 
 // TestEmbedDocument_RuntimeErrorIsFallback verifies a runtime token-embed


### PR DESCRIPTION
## Addresses #446

Issue #446 has three parts. Recon on `main` found **parts 2 and 3 are already fixed** (PR #521 / commit `fddc9e6`, "honest late-chunking active-state + identity capture"):

- **Part 2 — the "active" log lied:** already honest. It now logs that late chunking is enabled but "the token-pooling path is not yet wired (issue #446); still embedding chunk-then-embed", and a test in `tests/index/late_chunking_worker_test.go` pins that.
- **Part 3 — EmbedIdentity didn't capture the mode:** already captured. `provider.EmbedIdentity` is now a 7-field identity including `normalizeLateChunking(on/off)`, with `normalizeEmbedIdentity` back-compat migration and coverage in `tests/provider/provider_test.go`. Toggling `ingest.late_chunking` re-derives the identity → forces reindex.

This PR ships the one remaining safe, spec-neutral item:

### Part F3 — L2-normalize pooled document vectors (this PR)

`latechunk.EmbedDocument` mean-pools contextual token vectors per chunk span. An arithmetic mean has no fixed norm — harmless under cosine similarity (the default HNSW index normalizes internally), but a vector store configured for raw inner/dot-product distance (a Qdrant/pgvector deployment MAY be) assumes unit-norm vectors, and the query side already emits provider-normalized embeddings via `Embed`. This normalizes each **index-bound** pooled vector to unit L2 length so a late-chunked corpus stays comparable to queries in both spaces.

- Pooling stays a pure arithmetic mean in `MeanPoolSpan`/`MeanPoolSpans` (the documented, unit-tested contract); normalization is applied only on the `EmbedDocument` index-bound path.
- Per-span fallback (`nil`) vectors are left `nil`; a degenerate zero-magnitude vector is returned unchanged (no divide-by-zero).
- Test updated + a unit-norm assertion added.

## Deferred — Part 1 (actual wiring)

Actually running the whole-doc-embed + per-chunk mean-pool path in the embed loop is **not a drop-in** and is deferred:

- The leased `ChunkTask`s (and the store) carry neither the source-document text nor per-chunk **rune** spans — text chunks persist only `"lines"` spans (`chunkTextByChars` discards the rune offsets), and no whole-representation text is stored. `latechunk.EmbedDocument` needs both.
- Wiring therefore requires a schema migration (representation full-text + per-chunk rune offsets), ingest-chunker changes, a new store fetch, and worker document-grouping — a **storage/behavior change** gated by the spec-governance loop (EmbedIdentity fields are SPEC §8.1.4-governed).
- It is entirely latent: no shipped provider implements `TokenEmbedder`, so it cannot be validated end-to-end today. It should land with the first token-embedding provider so the pooled path is exercised in an integration test. A partial/batch-local wiring would silently mix context-pooled and independently-embedded vectors within one corpus (the §8.1.4 "MUST NOT silently mix vector spaces" invariant), so half-measures are not shipped.

`make lint` = 0 issues. `go test ./tests/latechunk/... ./tests/index/... ./tests/provider/... ./internal/retrieval/...` all pass.