### PR TITLE
fix(conformance): region-span §5.4 + five §14 canonical error codes (#422)

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -1027,8 +1027,20 @@ func exitCodeLabel(exitCode int) string {
 
 // writeCLIError writes an error to stderr, as a structured JSON payload when
 // jsonOutput is set (with a hand-rolled fallback if encoding fails) or as
-// plain text with optional hint lines otherwise.
+// plain text with optional hint lines otherwise. The JSON `code` field is
+// derived from the exit code via exitCodeLabel; callers needing a specific
+// canonical §14 code (e.g. BIND_FAILED, TLS_CONFIG_INVALID) use
+// writeCLIErrorWithCode instead.
 func writeCLIError(stderr io.Writer, jsonOutput bool, exitCode int, message string, hints ...string) {
+	writeCLIErrorWithCode(stderr, jsonOutput, exitCode, exitCodeLabel(exitCode), message, hints...)
+}
+
+// writeCLIErrorWithCode is writeCLIError with an explicit machine-readable
+// `code` for the JSON payload, decoupling the emitted error code from the
+// process exit code. It lets a failure keep its canonical §14 code (e.g. a bind
+// failure carries exit code exitServerBindFailure but code "BIND_FAILED") rather
+// than the coarser exit-code label. The plain-text path is unaffected.
+func writeCLIErrorWithCode(stderr io.Writer, jsonOutput bool, exitCode int, code, message string, hints ...string) {
 	if jsonOutput {
 		filteredHints := make([]string, 0, len(hints))
 		for _, hint := range hints {
@@ -1039,7 +1051,7 @@ func writeCLIError(stderr io.Writer, jsonOutput bool, exitCode int, message stri
 		}
 		payload := cliErrorPayload{
 			Error: cliError{
-				Code:    exitCodeLabel(exitCode),
+				Code:    code,
 				Message: strings.TrimSpace(message),
 				Hints:   filteredHints,
 			},
@@ -1059,7 +1071,7 @@ func writeCLIError(stderr io.Writer, jsonOutput bool, exitCode int, message stri
 			writef(
 				stderr,
 				"{\"error\":{\"code\":%q,\"message\":%s},\"exit_code\":%d}\n",
-				exitCodeLabel(exitCode),
+				code,
 				escapedMessage,
 				exitCode,
 			)

--- a/internal/cli/error_codes_test.go
+++ b/internal/cli/error_codes_test.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"net"
+	"path/filepath"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/protocol"
+)
+
+// decodeCLIErrorCode extracts the machine-readable `code` from a JSON CLI error
+// payload written to stderr.
+func decodeCLIErrorCode(t *testing.T, raw []byte) string {
+	t.Helper()
+	var payload struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("decode CLI error payload %q: %v", raw, err)
+	}
+	return payload.Error.Code
+}
+
+// TestBindServerListener_EmitsBindFailed proves a failed listener bind surfaces
+// the canonical §14.1 BIND_FAILED code (not the coarser exit-code label) in the
+// JSON error payload.
+func TestBindServerListener_EmitsBindFailed(t *testing.T) {
+	// Occupy a port so the subsequent bind on the same address fails.
+	occupied, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("occupy port: %v", err)
+	}
+	defer func() { _ = occupied.Close() }()
+
+	var stderr bytes.Buffer
+	a := &App{stderr: &stderr}
+	cfg := config.Default()
+	cfg.ListenAddr = occupied.Addr().String()
+	cfg.StateDir = t.TempDir() // no recorded preferred port → no fallback
+
+	ln, code := a.bindServerListener(cfg, true)
+	if ln != nil {
+		_ = ln.Close()
+		t.Fatal("expected bind to fail on an occupied port")
+	}
+	if code == exitSuccess {
+		t.Fatalf("expected a non-success exit code, got %d", code)
+	}
+	if got := decodeCLIErrorCode(t, stderr.Bytes()); got != protocol.ErrorCodeBindFailed {
+		t.Fatalf("error code = %q, want %q (body=%s)", got, protocol.ErrorCodeBindFailed, stderr.String())
+	}
+}
+
+// TestApplyTLSConfig_EmitsTLSConfigInvalid proves a TLS flag validation failure
+// surfaces the canonical §14.1 TLS_CONFIG_INVALID code, distinct from the
+// generic CONFIG_INVALID.
+func TestApplyTLSConfig_EmitsTLSConfigInvalid(t *testing.T) {
+	var stderr bytes.Buffer
+	a := &App{stderr: &stderr}
+	cfg := config.Default()
+
+	// Cert without key is an invalid TLS configuration.
+	opts := upOptions{tlsCert: filepath.Join(t.TempDir(), "cert.pem")}
+	opts.jsonOutput = true
+
+	_, _, code := a.applyTLSConfig(&cfg, opts)
+	if code == exitSuccess {
+		t.Fatal("expected TLS validation to fail")
+	}
+	if got := decodeCLIErrorCode(t, stderr.Bytes()); got != protocol.ErrorCodeTLSConfigInvalid {
+		t.Fatalf("error code = %q, want %q (body=%s)", got, protocol.ErrorCodeTLSConfigInvalid, stderr.String())
+	}
+}

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -260,7 +260,7 @@ func (a *App) applyTLSConfig(cfg *config.Config, opts upOptions) (tlsCertFile, t
 		tlsKeyFile = strings.TrimSpace(cfg.ServerTLSKeyFile)
 	}
 	if err := validateTLSFlags(tlsCertFile, tlsKeyFile); err != nil {
-		writeCLIError(a.stderr, opts.jsonOutput, exitConfigInvalid, fmt.Sprintf("CONFIG_INVALID: %v", err))
+		writeCLIErrorWithCode(a.stderr, opts.jsonOutput, exitConfigInvalid, protocol.ErrorCodeTLSConfigInvalid, fmt.Sprintf("TLS_CONFIG_INVALID: %v", err))
 		return "", "", exitConfigInvalid
 	}
 	cfg.ServerTLSCertFile = tlsCertFile
@@ -1320,7 +1320,7 @@ func (a *App) bindServerListener(cfg config.Config, jsonOutput bool) (net.Listen
 		ln, err = net.Listen("tcp", cfg.ListenAddr)
 	}
 	if err != nil {
-		writeCLIError(a.stderr, jsonOutput, exitServerBindFailure, fmt.Sprintf("bind server: %v", err))
+		writeCLIErrorWithCode(a.stderr, jsonOutput, exitServerBindFailure, protocol.ErrorCodeBindFailed, fmt.Sprintf("bind server: %v", err))
 		return nil, exitServerBindFailure
 	}
 	return ln, exitSuccess

--- a/internal/ingest/batch.go
+++ b/internal/ingest/batch.go
@@ -38,14 +38,20 @@ const (
 	manifestErrExtractFailed    = "EXTRACT_FAILED"
 	manifestErrOCRFailed        = "OCR_FAILED"
 	manifestErrTranslateFailed  = "TRANSLATE_FAILED"
+	// manifestErrFileTooLarge (§14.4) classifies an asset over the ingest size cap.
+	manifestErrFileTooLarge = "FILE_TOO_LARGE"
+	// manifestErrBinarySkipped (§14.4) is recorded on the skipped manifest entry
+	// for a non-textual binary asset dropped from ingestion.
+	manifestErrBinarySkipped = "BINARY_SKIPPED"
 )
 
 // manifestErrorCode maps a per-asset processing error to a canonical §14.4 code
-// for the run manifest. It distinguishes translation, OCR, and transcript
-// provider failures via their sentinels (TRANSLATE_FAILED / OCR_FAILED /
-// TRANSCRIBE_FAILED); any other representation/derivation failure is recorded as
-// the generic EXTRACT_FAILED. Translate is matched first because a Whisper-engine
-// translation failure is a translation failure, not a transcription one.
+// for the run manifest. It distinguishes translation, OCR, transcript provider
+// failures, and an over-cap file via their sentinels (TRANSLATE_FAILED /
+// OCR_FAILED / TRANSCRIBE_FAILED / FILE_TOO_LARGE); any other
+// representation/derivation failure is recorded as the generic EXTRACT_FAILED.
+// Translate is matched first because a Whisper-engine translation failure is a
+// translation failure, not a transcription one.
 func manifestErrorCode(err error) string {
 	switch {
 	case errors.Is(err, ErrTranslateProviderFailure):
@@ -54,6 +60,8 @@ func manifestErrorCode(err error) string {
 		return manifestErrOCRFailed
 	case errors.Is(err, ErrTranscriptProviderFailure):
 		return manifestErrTranscribeFailed
+	case errors.Is(err, ErrFileTooLarge):
+		return manifestErrFileTooLarge
 	default:
 		return manifestErrExtractFailed
 	}
@@ -179,6 +187,23 @@ func (o *assetOutcome) markSkipped() {
 	if o.status != batchStatusError {
 		o.status = batchStatusSkipped
 	}
+}
+
+// markSkippedWithCode records a terminal skipped outcome and stamps a canonical
+// §14.4 code on it (e.g. BINARY_SKIPPED), so a skip that carries a machine
+// classification surfaces in the run manifest's error_code. No-op on a nil
+// receiver; a recorded error still wins over a late skip.
+func (o *assetOutcome) markSkippedWithCode(code string) {
+	if o == nil {
+		return
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if o.status == batchStatusError {
+		return
+	}
+	o.status = batchStatusSkipped
+	o.errorCode = code
 }
 
 // record materializes the deterministic manifest record from the accumulated
@@ -344,6 +369,27 @@ func (b *batchRun) finalize(o *assetOutcome) {
 	b.mu.Unlock()
 	b.write(o.record(pass))
 	b.advance()
+}
+
+// recordSkippedWithCode writes a single skipped manifest record carrying a
+// canonical §14.4 code for an asset that never entered the per-asset processing
+// loop (e.g. a file dropped at discovery for exceeding the size cap, #497). It
+// is manifest-only and deliberately does NOT advance progress: the file was
+// never counted in a pass total, so advancing here would push the counter past
+// the total. No-op on nil or when the manifest is disabled.
+func (b *batchRun) recordSkippedWithCode(relPath, code string) {
+	if b == nil {
+		return
+	}
+	b.mu.Lock()
+	pass := b.pass
+	b.mu.Unlock()
+	b.write(batchManifestRecord{
+		RelPath:   relPath,
+		Status:    batchStatusSkipped,
+		ErrorCode: code,
+		Pass:      pass,
+	})
 }
 
 // close flushes and closes the manifest file. Safe to call on nil.

--- a/internal/ingest/errcode_test.go
+++ b/internal/ingest/errcode_test.go
@@ -51,6 +51,56 @@ func TestManifestErrorCode(t *testing.T) {
 	}
 }
 
+// TestManifestErrorCode_FileTooLarge proves an over-cap file error (wrapped
+// ErrFileTooLarge, as the size-check sites wrap it) maps to the canonical §14.4
+// FILE_TOO_LARGE code rather than the generic EXTRACT_FAILED.
+func TestManifestErrorCode_FileTooLarge(t *testing.T) {
+	err := fmt.Errorf("%w: file %s too large (%d bytes); limit %d", ErrFileTooLarge, "big.txt", 20_000_000, 10_485_760)
+	if got := manifestErrorCode(err); got != manifestErrFileTooLarge {
+		t.Fatalf("manifestErrorCode = %q, want %q", got, manifestErrFileTooLarge)
+	}
+}
+
+// TestGenerateRawTextFromContent_OversizeTaggedFileTooLarge proves the raw-text
+// size check wraps ErrFileTooLarge, so an oversize document is classified
+// FILE_TOO_LARGE on the run manifest.
+func TestGenerateRawTextFromContent_OversizeTaggedFileTooLarge(t *testing.T) {
+	rg := &RepresentationGenerator{} // size check runs before any store access
+	content := make([]byte, defaultMaxFileSizeBytes+1)
+	err := rg.GenerateRawTextFromContent(context.Background(), model.Document{RelPath: "big.txt"}, content)
+	if err == nil {
+		t.Fatal("expected an oversize error, got nil")
+	}
+	if !errors.Is(err, ErrFileTooLarge) {
+		t.Fatalf("error not tagged ErrFileTooLarge: %v", err)
+	}
+	if got := manifestErrorCode(err); got != manifestErrFileTooLarge {
+		t.Fatalf("manifestErrorCode = %q, want %q", got, manifestErrFileTooLarge)
+	}
+}
+
+// TestAssetOutcome_BinarySkippedCode proves a binary-skip records a skipped
+// manifest outcome carrying the canonical §14.4 BINARY_SKIPPED code, so a
+// non-textual binary is machine-visible in the run manifest.
+func TestAssetOutcome_BinarySkippedCode(t *testing.T) {
+	o := newAssetOutcome("blob.bin")
+	o.markSkippedWithCode(manifestErrBinarySkipped)
+	rec := o.record("")
+	if rec.Status != batchStatusSkipped {
+		t.Fatalf("status = %q, want %q", rec.Status, batchStatusSkipped)
+	}
+	if rec.ErrorCode != manifestErrBinarySkipped {
+		t.Fatalf("error_code = %q, want %q", rec.ErrorCode, manifestErrBinarySkipped)
+	}
+	// A recorded error must win over a later skip signal (no silent downgrade).
+	o2 := newAssetOutcome("blob.bin")
+	o2.markErrorIfUnset(manifestErrExtractFailed, "boom")
+	o2.markSkippedWithCode(manifestErrBinarySkipped)
+	if got := o2.record(""); got.Status != batchStatusError || got.ErrorCode != manifestErrExtractFailed {
+		t.Fatalf("error must win: status=%q code=%q", got.Status, got.ErrorCode)
+	}
+}
+
 // failingExtractor is a model.DocumentExtractor whose Extract always errors,
 // simulating an OCR provider/transport failure.
 type failingExtractor struct{}

--- a/internal/ingest/represent.go
+++ b/internal/ingest/represent.go
@@ -155,7 +155,7 @@ func (rg *RepresentationGenerator) GenerateRawText(ctx context.Context, doc mode
 		return fmt.Errorf("stat file %s: %w", doc.RelPath, err)
 	}
 	if info.Size() > defaultMaxFileSizeBytes {
-		return fmt.Errorf("file %s too large (%d bytes); limit %d", doc.RelPath, info.Size(), defaultMaxFileSizeBytes)
+		return fmt.Errorf("%w: file %s too large (%d bytes); limit %d", ErrFileTooLarge, doc.RelPath, info.Size(), defaultMaxFileSizeBytes)
 	}
 
 	// Read file content first so we can delegate to the new helper which
@@ -178,7 +178,7 @@ func (rg *RepresentationGenerator) GenerateRawTextFromContent(ctx context.Contex
 	// Guard against huge files to avoid OOM.  We mirror the same limit used by
 	// discovery since raw-text ingestion should follow the same policy.
 	if int64(len(content)) > defaultMaxFileSizeBytes {
-		return fmt.Errorf("file %s too large (%d bytes); limit %d", doc.RelPath, len(content), defaultMaxFileSizeBytes)
+		return fmt.Errorf("%w: file %s too large (%d bytes); limit %d", ErrFileTooLarge, doc.RelPath, len(content), defaultMaxFileSizeBytes)
 	}
 
 	// Validate and normalize UTF-8

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -244,6 +244,12 @@ type Service struct {
 	// batch run is active, making recordOutput a no-op on the hot path.
 	activeOutcome *assetOutcome
 
+	// pendingOversize accumulates files dropped at discovery for exceeding the
+	// ingest size cap (#497). They never become assets in the scan loop, so their
+	// canonical §14.4 FILE_TOO_LARGE manifest entries are emitted once, after the
+	// batch run is created. Populated by the OnOversize discovery callback.
+	pendingOversize []string
+
 	// quarantinedThisDoc records that the output quality gate (§8.6.6) marked the
 	// document currently being processed as a non-fatal per-document error, so the
 	// scan loop must count it as exactly one error and NOT credit it as indexed
@@ -350,6 +356,12 @@ var ErrOCRProviderFailure = errors.New("ocr provider failure")
 // canonical §14.4 TRANSLATE_FAILED code on the run manifest (manifestErrorCode),
 // distinct from the transcript's TRANSCRIBE_FAILED.
 var ErrTranslateProviderFailure = errors.New("translation provider failure")
+
+// ErrFileTooLarge marks a document rejected because its size exceeds the ingest
+// size cap (§14.4). Wrapped at the size-check sites so manifestErrorCode
+// classifies it as the canonical FILE_TOO_LARGE code rather than the generic
+// EXTRACT_FAILED.
+var ErrFileTooLarge = errors.New("file too large")
 
 // errBinaryOnRawTextPath marks a document that classified into a text-oriented
 // doc type (SPEC §7.4) but whose bytes are binary — most notably a .parquet file,
@@ -1206,9 +1218,13 @@ func (s *Service) runScan(ctx context.Context) error {
 		capBytes = corpusfs.DefaultMaxFileSizeBytes()
 	}
 	capMB := float64(capBytes) / (1024 * 1024)
+	s.pendingOversize = nil
 	discoverOpts.OnOversize = func(relPath string, size int64) {
 		s.addScanned(1)
 		s.addSkipped(1)
+		// Remember the drop so a FILE_TOO_LARGE manifest entry (§14.4) can be
+		// emitted once the batch run exists (discovery runs before it is created).
+		s.pendingOversize = append(s.pendingOversize, relPath)
 		s.getLogger().Printf(
 			"discovery: skipping %s (%d bytes) — exceeds ingest.max_file_mb cap (%.0f MB); raise ingest.max_file_mb to include it",
 			relPath, size, capMB,
@@ -1249,6 +1265,14 @@ func (s *Service) runScan(ctx context.Context) error {
 		s.batch = nil
 		s.activePass = passSingle
 	}()
+
+	// Emit a FILE_TOO_LARGE manifest entry (§14.4) for each file dropped at
+	// discovery for exceeding the ingest size cap (#497). These never enter the
+	// per-asset loop, so this is their only manifest producer. Manifest-only and
+	// no-op when the manifest is disabled.
+	for _, relPath := range s.pendingOversize {
+		s.batch.recordSkippedWithCode(relPath, manifestErrFileTooLarge)
+	}
 
 	seen := make(map[string]struct{}, len(discovered))
 
@@ -1767,7 +1791,15 @@ func (s *Service) creditInitialStatus(doc model.Document) (indexedPending, termi
 		return true, false
 	case "skipped", "secret_excluded":
 		s.addSkipped(1)
-		s.markActiveSkipped()
+		// A file skipped because it classified as a non-textual binary carries the
+		// canonical §14.4 BINARY_SKIPPED code on its manifest entry; every other
+		// skip (cache hit, unchanged content, ignore/archive type) stays a plain
+		// skip with no code.
+		if doc.DocType == "binary_ignored" {
+			s.activeOutcome.markSkippedWithCode(manifestErrBinarySkipped)
+		} else {
+			s.markActiveSkipped()
+		}
 		return false, false
 	case "error":
 		// although buildDocumentWithContent will never return a document with

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2635,7 +2635,7 @@ func buildRegionSpan(span model.Span) map[string]interface{} {
 			"t":            r.BBox.T,
 			"r":            r.BBox.R,
 			"b":            r.BBox.B,
-			"coord_origin": r.BBox.CoordOrigin,
+			"coord_origin": model.NormalizeCoordOrigin(r.BBox.CoordOrigin),
 		},
 		"section": section,
 	}
@@ -2933,7 +2933,7 @@ func spanDefinitionSchema() map[string]interface{} {
 							"t":            map[string]interface{}{"type": "number"},
 							"r":            map[string]interface{}{"type": "number"},
 							"b":            map[string]interface{}{"type": "number"},
-							"coord_origin": map[string]interface{}{"type": "string"},
+							"coord_origin": map[string]interface{}{"enum": []string{"TOPLEFT", "BOTTOMLEFT"}},
 						},
 						"required": []string{"page", "l", "t", "r", "b", "coord_origin"},
 					},

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -173,6 +173,41 @@ type BBox struct {
 	CoordOrigin string  `json:"coord_origin"`
 }
 
+// NormalizeCoordOrigin constrains a bbox coord_origin to the §5.4 enum
+// {TOPLEFT, BOTTOMLEFT}. Empty defaults to TOPLEFT (the spec's SHOULD-normalize
+// target) and any other unrecognized value is clamped to TOPLEFT, so an emitted
+// span always satisfies the published Span schema's enum constraint.
+func NormalizeCoordOrigin(origin string) string {
+	if strings.EqualFold(strings.TrimSpace(origin), "BOTTOMLEFT") {
+		return "BOTTOMLEFT"
+	}
+	return "TOPLEFT"
+}
+
+// NormalizeRegionLabel collapses a region span label to the §5.4 eight-value
+// enum {paragraph, section_header, list_item, table, caption, code, formula,
+// picture}. docling emits "title" (LabelTitle), which is outside the enum, so it
+// collapses to section_header; any other non-empty unknown collapses to the
+// neutral "paragraph". An empty label is left empty (the field is omitempty and
+// optional), so a label-less span keeps its shape. Only the stored/emitted label
+// is normalized — the internal LabelTitle used for document-title detection is
+// untouched.
+func NormalizeRegionLabel(label string) string {
+	trimmed := strings.TrimSpace(label)
+	if trimmed == "" {
+		return ""
+	}
+	switch strings.ToLower(trimmed) {
+	case "paragraph", "section_header", "list_item", "table",
+		"caption", "code", "formula", "picture":
+		return strings.ToLower(trimmed)
+	case "title":
+		return "section_header"
+	default:
+		return "paragraph"
+	}
+}
+
 // IndexPayload is the per-vector metadata an Index stores alongside the dense
 // vector (issue #247). It carries everything retrieval needs to materialise a
 // SearchHit and everything a Filter needs to predicate on, so an external or

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -32,6 +32,21 @@ const (
 	ErrorCodeRateLimitExceeded = "RATE_LIMIT_EXCEEDED"
 	// ErrorCodeRateLimited is kept as a compatibility alias.
 	ErrorCodeRateLimited = ErrorCodeRateLimitExceeded
+
+	// Canonical §14 codes for ingest/startup/index failures. Each names a
+	// specific, machine-recognizable failure so operators (and conformance
+	// clients) get a stable code rather than only free-text prose.
+	//
+	//   ErrorCodeFileTooLarge         §14.4 — asset exceeds the ingest size cap.
+	//   ErrorCodeBinarySkipped        §14.4 — asset skipped as non-textual binary.
+	//   ErrorCodeIndexVersionMismatch §14.3 — on-disk index format ≠ this binary's.
+	//   ErrorCodeBindFailed           §14.1 — the server could not bind its listener.
+	//   ErrorCodeTLSConfigInvalid     §14.1 — TLS cert/key flags failed validation.
+	ErrorCodeFileTooLarge         = "FILE_TOO_LARGE"
+	ErrorCodeBinarySkipped        = "BINARY_SKIPPED"
+	ErrorCodeIndexVersionMismatch = "INDEX_VERSION_MISMATCH"
+	ErrorCodeBindFailed           = "BIND_FAILED"
+	ErrorCodeTLSConfigInvalid     = "TLS_CONFIG_INVALID"
 )
 
 const (

--- a/internal/store/region_span_test.go
+++ b/internal/store/region_span_test.go
@@ -1,0 +1,175 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/protocol"
+)
+
+// decodeRegion round-trips the extra_json a region span flattens to so a test
+// can assert the normalized, persisted shape.
+func decodeRegion(t *testing.T, extraJSON string) model.RegionSpan {
+	t.Helper()
+	var r model.RegionSpan
+	if err := json.Unmarshal([]byte(extraJSON), &r); err != nil {
+		t.Fatalf("decode region extra_json %q: %v", extraJSON, err)
+	}
+	return r
+}
+
+// TestRegionSpanToRow_CoordOriginNormalized proves coord_origin is constrained
+// to the §5.4 enum at the persistence boundary: BOTTOMLEFT survives, an
+// out-of-enum value is clamped to TOPLEFT, and empty defaults to TOPLEFT.
+func TestRegionSpanToRow_CoordOriginNormalized(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"bottomleft preserved", "BOTTOMLEFT", "BOTTOMLEFT"},
+		{"lowercase bottomleft", "bottomleft", "BOTTOMLEFT"},
+		{"empty defaults topleft", "", "TOPLEFT"},
+		{"unknown clamped topleft", "CENTER", "TOPLEFT"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &model.RegionSpan{
+				StartPage: 2, EndPage: 2,
+				BBox: &model.BBox{Page: 2, L: 1, T: 2, R: 3, B: 4, CoordOrigin: tc.in},
+			}
+			kind, start, end, extra, err := regionSpanToRow(r)
+			if err != nil {
+				t.Fatalf("regionSpanToRow err = %v", err)
+			}
+			if kind != "region" || start != 2 || end != 2 {
+				t.Fatalf("kind/start/end = %q/%d/%d, want region/2/2", kind, start, end)
+			}
+			if got := decodeRegion(t, extra).BBox.CoordOrigin; got != tc.want {
+				t.Fatalf("coord_origin = %q, want %q", got, tc.want)
+			}
+			// The caller's span must not be mutated by normalization.
+			if r.BBox.CoordOrigin != tc.in {
+				t.Fatalf("caller bbox mutated: coord_origin = %q, want %q", r.BBox.CoordOrigin, tc.in)
+			}
+		})
+	}
+}
+
+// TestRegionSpanToRow_LabelNormalized proves the stored label is collapsed to
+// the §5.4 eight-value enum: docling's "title" → section_header, an unknown →
+// paragraph, an in-enum value is preserved, and an empty label stays empty.
+func TestRegionSpanToRow_LabelNormalized(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"title to section_header", "title", "section_header"},
+		{"unknown to paragraph", "footnote", "paragraph"},
+		{"in-enum preserved", "table", "table"},
+		{"empty stays empty", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &model.RegionSpan{
+				StartPage: 1, EndPage: 1,
+				BBox:  &model.BBox{Page: 1, CoordOrigin: "TOPLEFT"},
+				Label: tc.in,
+			}
+			_, _, _, extra, err := regionSpanToRow(r)
+			if err != nil {
+				t.Fatalf("regionSpanToRow err = %v", err)
+			}
+			if got := decodeRegion(t, extra).Label; got != tc.want {
+				t.Fatalf("label = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRegionSpanToRow_BBoxPageInvariant proves the §5.4 MUST — start_page ≤
+// bbox.page ≤ end_page — is validated (hard reject), not clamped.
+func TestRegionSpanToRow_BBoxPageInvariant(t *testing.T) {
+	cases := []struct {
+		name    string
+		bbox    int
+		start   int
+		end     int
+		wantErr bool
+	}{
+		{"in range single", 3, 3, 3, false},
+		{"in range multi", 4, 2, 6, false},
+		{"below start", 1, 2, 6, true},
+		{"above end", 7, 2, 6, true},
+		{"zero page below start", 0, 1, 3, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &model.RegionSpan{
+				StartPage: tc.start, EndPage: tc.end,
+				BBox: &model.BBox{Page: tc.bbox, CoordOrigin: "TOPLEFT"},
+			}
+			_, _, _, _, err := regionSpanToRow(r)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error for bbox.page %d outside [%d,%d], got nil", tc.bbox, tc.start, tc.end)
+				}
+				if !strings.Contains(err.Error(), "bbox.page") {
+					t.Fatalf("error %q does not mention bbox.page", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for bbox.page %d in [%d,%d]: %v", tc.bbox, tc.start, tc.end, err)
+			}
+		})
+	}
+}
+
+// TestCheckIndexFormatVersion_MatchAndMismatch proves the §14.3 gate opens a
+// current (v1) corpus without a false positive, but a corpus whose persisted
+// index_format_version was bumped to an incompatible value is refused with the
+// canonical INDEX_VERSION_MISMATCH code and retryable=false.
+func TestCheckIndexFormatVersion_MatchAndMismatch(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "meta.sqlite")
+
+	// Fresh v1 store opens clean (no false positive).
+	st := NewSQLiteStore(path)
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("init fresh store: %v", err)
+	}
+	// Bump the persisted index format to an incompatible value, then reopen.
+	if err := st.SetSetting(ctx, "index_format_version", "2"); err != nil {
+		t.Fatalf("bump index_format_version: %v", err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+
+	reopened := NewSQLiteStore(path)
+	err := reopened.Init(ctx)
+	if err == nil {
+		_ = reopened.Close()
+		t.Fatal("expected INDEX_VERSION_MISMATCH on reopen, got nil")
+	}
+	var mismatch *IndexVersionMismatchError
+	if !errors.As(err, &mismatch) {
+		t.Fatalf("error is not *IndexVersionMismatchError: %v", err)
+	}
+	if mismatch.Code() != protocol.ErrorCodeIndexVersionMismatch {
+		t.Fatalf("code = %q, want %q", mismatch.Code(), protocol.ErrorCodeIndexVersionMismatch)
+	}
+	if mismatch.Retryable() {
+		t.Fatal("index-version mismatch must not be retryable")
+	}
+	if mismatch.Persisted != "2" || mismatch.Expected != indexFormatVersion {
+		t.Fatalf("persisted/expected = %q/%q, want 2/%q", mismatch.Persisted, mismatch.Expected, indexFormatVersion)
+	}
+}

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/dirstral/dir2mcp/internal/mistral"
 	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/protocol"
 )
 
 const relPathErrorMessage = "rel_path must be a non-empty relative path without parent-traversal or absolute paths"
@@ -395,6 +396,60 @@ func openDB(ctx context.Context, path string) (*sql.DB, error) {
 //   - the bump documents exactly which change is not backward compatible.
 const schemaVersion = 1
 
+// indexFormatVersion is the on-disk index format this binary reads and writes.
+// It is persisted in settings under "index_format_version" on first init. Bump
+// ONLY on a non-backward-compatible index format change; a mismatch between the
+// persisted value and this constant surfaces the canonical §14.3
+// INDEX_VERSION_MISMATCH so an operator reindexes with a compatible binary
+// rather than reading a format this binary does not understand.
+const indexFormatVersion = "1"
+
+// IndexVersionMismatchError reports that a corpus's persisted
+// index_format_version does not match indexFormatVersion. It carries the
+// canonical §14.3 code and is NOT retryable — the corpus must be reindexed with
+// a compatible binary.
+type IndexVersionMismatchError struct {
+	Persisted string
+	Expected  string
+}
+
+func (e *IndexVersionMismatchError) Error() string {
+	return fmt.Sprintf(
+		"%s: corpus index_format_version %q does not match this binary's %q; reindex the corpus",
+		protocol.ErrorCodeIndexVersionMismatch, e.Persisted, e.Expected,
+	)
+}
+
+// Code returns the canonical §14.3 error code for this failure.
+func (e *IndexVersionMismatchError) Code() string { return protocol.ErrorCodeIndexVersionMismatch }
+
+// Retryable reports that an index-version mismatch is not retryable.
+func (e *IndexVersionMismatchError) Retryable() bool { return false }
+
+// checkIndexFormatVersion refuses to open a corpus whose persisted
+// index_format_version differs from indexFormatVersion (§14.3). It runs AFTER
+// bootstrapSettingsLocked, which inserts the current version for a fresh DB
+// (ON CONFLICT DO NOTHING), so an existing corpus keeps its recorded value: a
+// v1 corpus matches (no false positive), while a corpus stamped by a future,
+// incompatible binary is rejected rather than silently misread. A legacy DB
+// with the row absent, or an empty value, is treated as current.
+func checkIndexFormatVersion(ctx context.Context, db *sql.DB) error {
+	var persisted string
+	err := db.QueryRowContext(ctx,
+		`SELECT value FROM settings WHERE key = 'index_format_version' LIMIT 1`).Scan(&persisted)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read index_format_version: %w", err)
+	}
+	persisted = strings.TrimSpace(persisted)
+	if persisted == "" || persisted == indexFormatVersion {
+		return nil
+	}
+	return &IndexVersionMismatchError{Persisted: persisted, Expected: indexFormatVersion}
+}
+
 // checkSchemaVersion reads PRAGMA user_version and refuses to proceed when the
 // database was written by a newer binary (dbVersion > schemaVersion). Older or
 // unstamped databases (user_version == 0, the SQLite default) are accepted and
@@ -642,6 +697,14 @@ CREATE INDEX IF NOT EXISTS idx_mcp_payment_outcomes_updated ON mcp_payment_outco
 	}
 
 	if err := bootstrapSettingsLocked(ctx, db); err != nil {
+		_ = db.Close()
+		return err
+	}
+
+	// Refuse a corpus written in an incompatible index format (§14.3). Runs after
+	// bootstrap so a fresh DB carries the current version and only a genuine
+	// mismatch (a future/incompatible binary's stamp) is rejected.
+	if err := checkIndexFormatVersion(ctx, db); err != nil {
 		_ = db.Close()
 		return err
 	}
@@ -2716,7 +2779,7 @@ func bootstrapSettingsLocked(ctx context.Context, db *sql.DB) error {
 	defaults := map[string]string{
 		"schema_version":       "1",
 		"protocol_version":     "2025-11-25",
-		"index_format_version": "1",
+		"index_format_version": indexFormatVersion,
 		"embed_text_model":     "mistral-embed",
 		"embed_code_model":     "codestral-embed",
 		"ocr_model":            mistral.DefaultOCRModel,
@@ -2912,6 +2975,14 @@ func timeSpanExtraJSON(words []model.WordSpan, speaker, speakerLabel string) (st
 // regionSpanToRow validates and flattens a region span: the page range goes to
 // start/end and the bbox/section/label payload is marshaled to extra_json. A
 // region MUST carry a bbox and a valid page range (spec §5.4).
+//
+// It is the persistence boundary that enforces the §5.4 Span constraints so a
+// stored span always round-trips against the published Span schema (a strict
+// client would otherwise reject an out-of-enum value with "Failed to call
+// tool"): coord_origin is normalized to {TOPLEFT,BOTTOMLEFT}, label to the
+// eight-value enum, and the bbox.page ∈ [start_page,end_page] invariant (§5.4
+// MUST) is validated — hard-rejected, because a bbox on a page outside the
+// chunk's range is a provenance error, not something to silently clamp.
 func regionSpanToRow(r *model.RegionSpan) (kind string, start int, end int, extraJSON string, err error) {
 	if r == nil {
 		return "", 0, 0, "", errors.New("invalid region span: missing region payload")
@@ -2922,7 +2993,21 @@ func regionSpanToRow(r *model.RegionSpan) (kind string, start int, end int, extr
 	if r.BBox == nil {
 		return "", 0, 0, "", errors.New("invalid region span: missing bbox")
 	}
-	encoded, mErr := json.Marshal(r)
+	// §5.4 MUST: start_page ≤ bbox.page ≤ end_page (bbox.page is the primary page).
+	if r.BBox.Page < r.StartPage || r.BBox.Page > r.EndPage {
+		return "", 0, 0, "", fmt.Errorf(
+			"invalid region span: bbox.page %d outside page range [%d,%d]",
+			r.BBox.Page, r.StartPage, r.EndPage,
+		)
+	}
+	// Normalize coord_origin + label to their §5.4 enums on a copy so the stored
+	// extra_json conforms without mutating the caller's span.
+	normalized := *r
+	bbox := *r.BBox
+	bbox.CoordOrigin = model.NormalizeCoordOrigin(bbox.CoordOrigin)
+	normalized.BBox = &bbox
+	normalized.Label = model.NormalizeRegionLabel(r.Label)
+	encoded, mErr := json.Marshal(&normalized)
 	if mErr != nil {
 		return "", 0, 0, "", fmt.Errorf("marshal region span: %w", mErr)
 	}

--- a/tests/conformance/output_schema_conformance_test.go
+++ b/tests/conformance/output_schema_conformance_test.go
@@ -1,0 +1,124 @@
+package conformance
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// toolsListSchemas fetches tools/list and returns each tool's outputSchema as a
+// decoded generic tree keyed by tool name.
+func toolsListSchemas(t *testing.T) map[string]interface{} {
+	t.Helper()
+	cfg := defaultConfig()
+	srv := newServer(cfg)
+	defer srv.Close()
+
+	sid := initSession(t, srv.URL+cfg.MCPPath)
+	resp := sendRPC(t, srv.URL+cfg.MCPPath, sid, `{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}`, nil)
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("tools/list: status=%d want=200 body=%s", resp.StatusCode, body)
+	}
+
+	var envelope struct {
+		Result struct {
+			Tools []struct {
+				Name         string                 `json:"name"`
+				OutputSchema map[string]interface{} `json:"outputSchema"`
+			} `json:"tools"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		t.Fatalf("tools/list: decode: %v body=%s", err, body)
+	}
+	out := make(map[string]interface{}, len(envelope.Result.Tools))
+	for _, tool := range envelope.Result.Tools {
+		out[tool.Name] = tool.OutputSchema
+	}
+	return out
+}
+
+// findAllByKey walks a decoded JSON tree and returns every value found under the
+// given key at any depth.
+func findAllByKey(node interface{}, key string) []interface{} {
+	var found []interface{}
+	switch v := node.(type) {
+	case map[string]interface{}:
+		for k, child := range v {
+			if k == key {
+				found = append(found, child)
+			}
+			found = append(found, findAllByKey(child, key)...)
+		}
+	case []interface{}:
+		for _, child := range v {
+			found = append(found, findAllByKey(child, key)...)
+		}
+	}
+	return found
+}
+
+// hasConstRegion reports whether the tree contains a span variant whose kind is
+// the "region" const — i.e. the region span variant is advertised.
+func hasConstRegion(node interface{}) bool {
+	for _, kind := range findAllByKey(node, "kind") {
+		if m, ok := kind.(map[string]interface{}); ok {
+			if c, ok := m["const"].(string); ok && c == "region" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// TestOutputSchema_CoordOriginIsEnum asserts every bbox.coord_origin schema
+// advertised across all tool outputSchemas constrains the value to the §5.4
+// enum {TOPLEFT, BOTTOMLEFT} — not a bare {"type":"string"}, which a strict
+// client would accept before the published Span rejects an out-of-enum value.
+func TestOutputSchema_CoordOriginIsEnum(t *testing.T) {
+	t.Parallel()
+	schemas := toolsListSchemas(t)
+
+	nodes := findAllByKey(schemas, "coord_origin")
+	if len(nodes) == 0 {
+		t.Fatal("no coord_origin schema found in any tool outputSchema")
+	}
+	for _, node := range nodes {
+		m, ok := node.(map[string]interface{})
+		if !ok {
+			t.Fatalf("coord_origin schema is not an object: %#v", node)
+		}
+		if _, isString := m["type"]; isString {
+			t.Fatalf("coord_origin must be enum-constrained, got type-based schema: %#v", m)
+		}
+		enum, ok := m["enum"].([]interface{})
+		if !ok {
+			t.Fatalf("coord_origin missing enum: %#v", m)
+		}
+		got := map[string]bool{}
+		for _, e := range enum {
+			if s, ok := e.(string); ok {
+				got[s] = true
+			}
+		}
+		if len(enum) != 2 || !got["TOPLEFT"] || !got["BOTTOMLEFT"] {
+			t.Fatalf("coord_origin enum = %v, want exactly [TOPLEFT BOTTOMLEFT]", enum)
+		}
+	}
+}
+
+// TestOutputSchema_SearchAdvertisesRegionSpan asserts the search tool's
+// outputSchema advertises the region span variant (§15.1.1), so a client can
+// validate a region-provenance citation.
+func TestOutputSchema_SearchAdvertisesRegionSpan(t *testing.T) {
+	t.Parallel()
+	schemas := toolsListSchemas(t)
+	search, ok := schemas["dir2mcp_search"]
+	if !ok {
+		t.Fatal("dir2mcp_search not present in tools/list")
+	}
+	if !hasConstRegion(search) {
+		t.Fatal("search outputSchema does not advertise a region span variant")
+	}
+}

--- a/tests/security/cli_boundary_test.go
+++ b/tests/security/cli_boundary_test.go
@@ -176,6 +176,7 @@ func TestRepoSplitBoundary_InternalCLIFileOwnership(t *testing.T) {
 		"embed_options_test.go":                  {},
 		"embed_preflight_probe_internal_test.go": {},
 		"embed_worker.go":                        {},
+		"error_codes_test.go":                    {},
 		"export.go":                              {},
 		"export_reflow_internal_test.go":         {},
 		"export_ttml.go":                         {},


### PR DESCRIPTION
Addresses #422 — implements the remaining still-open spec-conformance items (V1/V2/V3 and the FORBIDDEN/OCR/TRANSLATE/TRANSCRIBE codes were already fixed and are untouched). All fixes are conformance to the pinned SPEC.md; no dirstral-spec PR needed.

## Region-span conformance (§5.4) — fixed at the store boundary + tool schema
- **coord_origin enum**: tool outputSchema now constrains `coord_origin` to `["TOPLEFT","BOTTOMLEFT"]` (was `{"type":"string"}`); `regionSpanToRow` normalizes the stored/emitted value (empty/unknown → `TOPLEFT`) via `model.NormalizeCoordOrigin`. `buildRegionSpan` normalizes on emit too.
- **label enum**: `model.NormalizeRegionLabel` collapses the stored label to the §5.4 eight-value enum — docling's `title` → `section_header`, any other unknown → `paragraph`. The internal `LabelTitle` used for document-title detection is left intact; only the persisted label is normalized.
- **bbox.page invariant (§5.4 MUST)**: `start_page ≤ bbox.page ≤ end_page` is now validated in `regionSpanToRow` and hard-rejected (a bbox off the chunk's page range is a provenance error, not clampable).

## Five unimplemented §14 canonical error codes — now have producers
- **FILE_TOO_LARGE (§14.4)**: new `ErrFileTooLarge` sentinel wrapped at the raw-text size checks → `manifestErrorCode` maps to `FILE_TOO_LARGE` (surfaces via `status=error`/`RecentFailures` + run manifest); the `OnOversize` discovery callback (#497) also records a `FILE_TOO_LARGE` manifest entry for files dropped at discovery.
- **BINARY_SKIPPED (§14.4)**: a file skipped as `binary_ignored` stamps `BINARY_SKIPPED` on its skipped run-manifest entry.
- **BIND_FAILED (§14.1)**: a failed `net.Listen` emits `BIND_FAILED` in the JSON error `code` (new `writeCLIErrorWithCode` decouples emitted code from exit-code label).
- **TLS_CONFIG_INVALID (§14.1)**: `validateTLSFlags` failures emit `TLS_CONFIG_INVALID`, distinct from generic `CONFIG_INVALID`.
- **INDEX_VERSION_MISMATCH (§14.3)**: on store open, a persisted `index_format_version` that differs from the binary's expected version is refused (non-retryable). Gated strictly — a fresh/v1 store matches with no false positive.

## Note on the §14.4 surfacing channel
`BINARY_SKIPPED` and the discovery-dropped `FILE_TOO_LARGE` entries are emitted through the **run manifest** `error_code` field — the same machine-readable §14.4 channel already used by `OCR_FAILED`/`TRANSLATE_FAILED`/`TRANSCRIBE_FAILED` (the `documents` table has no `error_code` column). The in-pipeline `FILE_TOO_LARGE` (over-cap represent) additionally lands `status=error`, so it also shows in `RecentFailures`.

## Tests
- `internal/store/region_span_test.go`: `regionSpanToRow` — BOTTOMLEFT preserved, out-of-enum coord_origin normalized, `title`→`section_header`, unknown→`paragraph`, bbox.page-out-of-range rejected; plus the INDEX_VERSION_MISMATCH open path (bumped version).
- `tests/conformance/output_schema_conformance_test.go`: asserts every advertised `coord_origin` is the two-value enum and search advertises the region span variant.
- `internal/ingest/errcode_test.go`: oversize → `FILE_TOO_LARGE`, binary skip → `BINARY_SKIPPED`, error-wins-over-skip.
- `internal/cli/error_codes_test.go`: `BIND_FAILED` (bind an occupied port), `TLS_CONFIG_INVALID` (cert without key).

`make lint` = 0 issues; `go test ./internal/... ./tests/...` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHuQEKSW3nzU1Pn7KXXBhj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Error messages now include more specific machine-readable codes for startup, TLS, bind, oversized file, and skipped-binary failures.
  * Region span metadata is now normalized to expected values before being stored or returned, improving consistency across tools and outputs.
  * Index files now carry a version check, allowing incompatible stores to be detected on open.

* **Bug Fixes**
  * Oversized files are now reported as “file too large” instead of a generic failure.
  * Invalid TLS settings and port bind issues now surface clearer error codes in CLI JSON output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->