### PR TITLE
perf: bounded top-k, throttled autosave, dirty-flag disk save, single metadata map (#429)

### DIFF
--- a/internal/index/diskindex/diskindex.go
+++ b/internal/index/diskindex/diskindex.go
@@ -46,9 +46,11 @@ import (
 	"os"
 	"sort"
 	"sync"
+	"time"
 
 	"golang.org/x/exp/mmap"
 
+	"github.com/dirstral/dir2mcp/internal/index/topk"
 	"github.com/dirstral/dir2mcp/internal/model"
 )
 
@@ -97,6 +99,23 @@ type DiskIndex struct {
 	identity  string
 	appendEnd int64          // current end-of-file offset for the append log
 	reader    *mmap.ReaderAt // mmap view of the segment, nil until first read/Load
+
+	// version is a monotonically increasing mutation counter bumped under the
+	// write lock on every appended record (Upsert/Delete) and Reset. savedVersion
+	// records the version captured by the last successful Save; when they are equal
+	// the on-disk segment already reflects the in-memory state, so the periodic
+	// autosave skips the full compaction rewrite (issue #429 F7). All the fields
+	// below are guarded by mu.
+	version      uint64
+	savedVersion uint64
+
+	// autosaveThreshold / autosaveMaxInterval / lastSaveTime throttle the periodic
+	// autosave exactly as the memory backend does (issue #429 C-a): AutosaveTick
+	// compacts only once threshold mutations have accumulated or maxInterval has
+	// elapsed; the force path (Save) always compacts when dirty.
+	autosaveThreshold   uint64
+	autosaveMaxInterval time.Duration
+	lastSaveTime        time.Time
 }
 
 // compile-time assertions: DiskIndex satisfies the core contract and both
@@ -112,9 +131,33 @@ var (
 // which case Save/Load require an explicit path argument.
 func New(path string) *DiskIndex {
 	return &DiskIndex{
-		path:     path,
-		locators: make(map[uint64]locator),
+		path:                path,
+		locators:            make(map[uint64]locator),
+		autosaveThreshold:   defaultAutosaveThreshold,
+		autosaveMaxInterval: defaultAutosaveMaxInterval,
+		lastSaveTime:        time.Now(),
 	}
+}
+
+// defaultAutosaveThreshold / defaultAutosaveMaxInterval mirror
+// index.DefaultAutosaveThreshold / DefaultAutosaveMaxInterval; they are redefined
+// here (rather than imported) because internal/index imports this package, so the
+// dependency cannot run the other way (issue #429 C-a).
+const (
+	defaultAutosaveThreshold   = 50000
+	defaultAutosaveMaxInterval = 5 * time.Minute
+)
+
+// SetAutosavePolicy overrides the periodic-autosave throttle (issue #429 C-a),
+// mirroring HNSWIndex.SetAutosavePolicy: a tick compacts only once threshold
+// mutations have accumulated or maxInterval has elapsed since the last save.
+// threshold==0 disables delta-gating; maxInterval<=0 disables the time fallback.
+// The force path (Save/StopAndSave) always compacts when dirty.
+func (d *DiskIndex) SetAutosavePolicy(threshold uint64, maxInterval time.Duration) {
+	d.mu.Lock()
+	d.autosaveThreshold = threshold
+	d.autosaveMaxInterval = maxInterval
+	d.mu.Unlock()
 }
 
 // Upsert appends the vector+payload as the newest record and points the locator
@@ -199,6 +242,10 @@ func (d *DiskIndex) appendRecord(chunkID uint64, tombstone bool, vector []float3
 			payloadLen: uint32(len(payloadBytes)),
 		}
 	}
+	// A record landed durably: mark the index dirty so the next Save compacts it.
+	// Delete only calls this for ids it knows exist, so tombstones bump version
+	// only on a real removal — matching HNSWIndex's changed-only Delete accounting.
+	d.version++
 	// The mmap view is now stale (file grew); drop it so the next read re-maps.
 	return d.invalidateReaderLocked()
 }
@@ -255,44 +302,77 @@ func (d *DiskIndex) Search(ctx context.Context, vector []float32, k int, filter 
 		return []model.IndexHit{}, nil
 	}
 
+	cands, err := d.scoreTopK(reader, vector, k, filter)
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(cands, func(a, b int) bool {
+		return topk.Before(cands[a].Score, cands[b].Score, cands[a].ChunkID, cands[b].ChunkID)
+	})
+	hits := make([]model.IndexHit, len(cands))
+	for i, c := range cands {
+		hits[i] = model.IndexHit{ChunkID: c.ChunkID, Score: c.Score, Payload: c.Payload}
+	}
+	return hits, nil
+}
+
+// scoreTopK scans every dimension-matching locator, scoring each candidate into a
+// bounded top-k heap, and returns the (unordered) retained best k. Caller holds
+// the read lock and passes the live mmap reader. A single query-sized byte buffer
+// + float32 slice is reused across candidates, so the whole scan's vector-read
+// allocation is O(1) rather than one []byte+[]float32 per candidate (issue #429
+// F2); the scratch is never retained past a score, so reuse is safe.
+func (d *DiskIndex) scoreTopK(reader *mmap.ReaderAt, vector []float32, k int, filter model.Filter) ([]topk.Candidate, error) {
 	applyFilter := !filter.IsZero()
-	scored := make([]model.IndexHit, 0, len(d.locators))
+	h := topk.New(k)
+	vecBytes := make([]byte, len(vector)*4)
+	vecScratch := make([]float32, len(vector))
 	for id, loc := range d.locators {
 		if int(loc.vecLen) != len(vector) {
 			continue // dimension mismatch; skip like HNSW does
 		}
-		vec, payload, rerr := readRecordAt(reader, loc)
-		if rerr != nil {
-			return nil, rerr
+		if err := scoreCandidate(reader, id, loc, vector, vecBytes, vecScratch, applyFilter, filter, h); err != nil {
+			return nil, err
 		}
-		if applyFilter && !filter.Match(payload) {
-			continue
-		}
-		scored = append(scored, model.IndexHit{
-			ChunkID: id,
-			Score:   cosineSimilarity(vector, vec),
-			Payload: payload,
-		})
 	}
-
-	sortHits(scored)
-	if len(scored) > k {
-		scored = scored[:k]
-	}
-	return scored, nil
+	return h.Items(), nil
 }
 
-// sortHits orders hits best-first with a deterministic chunkID tiebreak,
-// matching HNSWIndex.Search.
-func sortHits(hits []model.IndexHit) {
-	const eps = 1e-6
-	sort.Slice(hits, func(a, b int) bool {
-		diff := math.Abs(float64(hits[a].Score) - float64(hits[b].Score))
-		if diff <= eps {
-			return hits[a].ChunkID < hits[b].ChunkID
+// scoreCandidate reads, filters, scores, and conditionally admits one candidate
+// to the heap. When filtering, the payload is decoded first so the predicate can
+// reject the candidate before it is scored; otherwise the (expensive gob) payload
+// decode is deferred and paid only for candidates that survive the heap guard —
+// the disk analogue of the memory backend's in-place scoring (issue #429 F1/F2).
+func scoreCandidate(reader *mmap.ReaderAt, id uint64, loc locator, vector []float32, vecBytes []byte, vecScratch []float32, applyFilter bool, filter model.Filter, h *topk.Heap) error {
+	var payload model.IndexPayload
+	havePayload := false
+	if applyFilter {
+		p, err := readPayloadAt(reader, loc)
+		if err != nil {
+			return err
 		}
-		return hits[a].Score > hits[b].Score
-	})
+		if !filter.Match(p) {
+			return nil
+		}
+		payload, havePayload = p, true
+	}
+	if _, err := reader.ReadAt(vecBytes, loc.offset+int64(recordHdrLen)); err != nil {
+		return err
+	}
+	fillFloat32s(vecScratch, vecBytes)
+	score := cosineSimilarity(vector, vecScratch)
+	if h.Full() && !h.Better(score, id) {
+		return nil
+	}
+	if !havePayload {
+		p, err := readPayloadAt(reader, loc)
+		if err != nil {
+			return err
+		}
+		payload = p
+	}
+	h.Push(topk.Candidate{ChunkID: id, Score: score, Payload: payload})
+	return nil
 }
 
 // CanFilter reports that the backend evaluates filters itself: Search applies
@@ -328,6 +408,7 @@ func (d *DiskIndex) Reset(ctx context.Context, identity string) error {
 	d.locators = make(map[uint64]locator)
 	d.identity = identity
 	d.appendEnd = 0
+	d.version++
 
 	if d.path == "" {
 		return nil
@@ -374,6 +455,16 @@ func (d *DiskIndex) Save(ctx context.Context, path string) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
+	// When nothing has changed since the last durable save, the on-disk segment
+	// already reflects our state: skip the whole-segment compaction rewrite (no
+	// temp file, no fsync, no rename) so an idle corpus's autosave is a no-op
+	// (issue #429 F7). Save holds the write lock throughout, so no mutation can
+	// race between this check and advancing savedVersion below.
+	if d.version == d.savedVersion {
+		return nil
+	}
+	captured := d.version
+
 	reader, err := d.readerLocked()
 	if err != nil {
 		return err
@@ -398,10 +489,50 @@ func (d *DiskIndex) Save(ctx context.Context, path string) error {
 	d.path = path
 	d.locators = newLocators
 	d.appendEnd = newEnd
+	// The compacted segment landed durably; record the version it captured so a
+	// subsequent Save with no intervening mutation is a no-op.
+	d.savedVersion = captured
+	d.lastSaveTime = time.Now()
 	if err := d.invalidateReaderLocked(); err != nil {
 		return err
 	}
 	return writeIdentitySidecar(identitySidecarPath(path), d.identity)
+}
+
+// AutosaveTick is the periodic-save entrypoint (issue #429 C-a): it compacts via
+// Save only when the index is dirty AND either the accumulated mutation delta has
+// reached autosaveThreshold or autosaveMaxInterval has elapsed since the last
+// save. Otherwise it is a no-op, so a long ingest no longer recompacts the whole
+// segment on every 15s tick. StopAndSave still calls the force path (Save), so
+// the throttled tail is always persisted at shutdown.
+func (d *DiskIndex) AutosaveTick(ctx context.Context, path string) error {
+	d.mu.RLock()
+	delta := d.version - d.savedVersion
+	threshold := d.autosaveThreshold
+	maxInterval := d.autosaveMaxInterval
+	sinceSave := time.Since(d.lastSaveTime)
+	d.mu.RUnlock()
+
+	if !shouldAutosave(delta, threshold, maxInterval, sinceSave) {
+		return nil
+	}
+	return d.Save(ctx, path)
+}
+
+// shouldAutosave decides whether a periodic autosave tick should compact now
+// (issue #429 C-a). It mirrors index.shouldAutosave exactly (the two backends
+// cannot share a helper without an import cycle): never save a clean index; save
+// immediately once delta reaches the threshold; below the threshold save only
+// after maxInterval has elapsed. A zero threshold saves on any dirty tick; a
+// non-positive maxInterval disables the time-based fallback.
+func shouldAutosave(delta, threshold uint64, maxInterval, sinceSave time.Duration) bool {
+	if delta == 0 {
+		return false
+	}
+	if threshold == 0 || delta >= threshold {
+		return true
+	}
+	return maxInterval > 0 && sinceSave >= maxInterval
 }
 
 // compactInto writes the header and every live record to out (buffered),
@@ -587,6 +718,20 @@ func writeRecord(w io.Writer, chunkID uint64, tombstone bool, vector []float32, 
 	return recordHdrLen + len(vecBytes) + len(payloadBytes), nil
 }
 
+// readPayloadAt reads and gob-decodes only the payload for a locator, without
+// touching the vector bytes. Search uses it for lazy payload materialisation:
+// the payload is decoded only for candidates that survive the top-k heap guard
+// (or up front when a filter must inspect it), not for every scanned record.
+func readPayloadAt(reader *mmap.ReaderAt, loc locator) (model.IndexPayload, error) {
+	vecBytesLen := int(loc.vecLen) * 4
+	buf := make([]byte, int(loc.payloadLen))
+	// The payload follows the record header and the vector bytes.
+	if _, err := reader.ReadAt(buf, loc.offset+int64(recordHdrLen)+int64(vecBytesLen)); err != nil {
+		return model.IndexPayload{}, err
+	}
+	return decodePayload(buf)
+}
+
 // readRecordAt reads the vector and payload for a locator from the mmap reader.
 func readRecordAt(reader *mmap.ReaderAt, loc locator) ([]float32, model.IndexPayload, error) {
 	vecBytesLen := int(loc.vecLen) * 4
@@ -724,10 +869,17 @@ func float32sToBytes(v []float32) []byte {
 
 func bytesToFloat32s(b []byte) []float32 {
 	out := make([]float32, len(b)/4)
-	for i := range out {
-		out[i] = math.Float32frombits(binary.LittleEndian.Uint32(b[i*4:]))
-	}
+	fillFloat32s(out, b)
 	return out
+}
+
+// fillFloat32s decodes little-endian float32s from b into the caller-provided
+// dst (no allocation). dst must be sized for b (len(b)/4 elements); Search reuses
+// a single query-sized dst across every candidate (issue #429 F2).
+func fillFloat32s(dst []float32, b []byte) {
+	for i := range dst {
+		dst[i] = math.Float32frombits(binary.LittleEndian.Uint32(b[i*4:]))
+	}
 }
 
 func cosineSimilarity(a, b []float32) float32 {

--- a/internal/index/hnsw_index.go
+++ b/internal/index/hnsw_index.go
@@ -11,7 +11,9 @@ import (
 	"sort"
 	"sync"
 	"sync/atomic"
+	"time"
 
+	"github.com/dirstral/dir2mcp/internal/index/topk"
 	"github.com/dirstral/dir2mcp/internal/model"
 )
 
@@ -22,6 +24,17 @@ import (
 const (
 	TextIndexFileName = "vectors_text.v2.hnsw"
 	CodeIndexFileName = "vectors_code.v2.hnsw"
+)
+
+// DefaultAutosaveThreshold / DefaultAutosaveMaxInterval are the default periodic
+// autosave throttle (issue #429 C-a): during ingest a full snapshot fires only
+// after this many accumulated mutations, or after this much wall-time since the
+// last save, rather than on every 15s tick. Shutdown durability is unaffected —
+// StopAndSave always forces a final save. These apply to both the memory and
+// disk backends (diskindex mirrors them).
+const (
+	DefaultAutosaveThreshold   = 50000
+	DefaultAutosaveMaxInterval = 5 * time.Minute
 )
 
 // LegacyIndexFileNames are the pre-#247 bare-map snapshot basenames. reindex
@@ -54,6 +67,19 @@ type HNSWIndex struct {
 	// and never drops a concurrent write that landed mid-save.
 	version      uint64
 	savedVersion uint64
+
+	// autosaveThreshold / autosaveMaxInterval throttle the *periodic* autosave
+	// (AutosaveTick) so a long ingest doesn't rewrite the whole snapshot on every
+	// 15s tick (issue #429 F7 / C-a). A tick persists only when the accumulated
+	// mutation delta (version-savedVersion) reaches the threshold OR the max
+	// interval has elapsed since the last durable save; the force path (Save, used
+	// by StopAndSave at shutdown) always persists when dirty. A zero threshold
+	// disables delta-gating (every dirty tick saves — the pre-C-a behavior).
+	// lastSaveTime is the wall-clock of the last successful Save. All three are
+	// guarded by mu.
+	autosaveThreshold   uint64
+	autosaveMaxInterval time.Duration
+	lastSaveTime        time.Time
 
 	// Logger is optional; if non-nil its Printf method will be used for
 	// informational messages. When nil the standard library's log package
@@ -96,10 +122,25 @@ type hnswSnapshot struct {
 // persist to the given file.
 func NewHNSWIndex(path string) *HNSWIndex {
 	return &HNSWIndex{
-		path:     path,
-		vectors:  make(map[uint64][]float32),
-		payloads: make(map[uint64]model.IndexPayload),
+		path:                path,
+		vectors:             make(map[uint64][]float32),
+		payloads:            make(map[uint64]model.IndexPayload),
+		autosaveThreshold:   DefaultAutosaveThreshold,
+		autosaveMaxInterval: DefaultAutosaveMaxInterval,
+		lastSaveTime:        time.Now(),
 	}
+}
+
+// SetAutosavePolicy overrides the periodic-autosave throttle (issue #429 C-a).
+// A tick persists only once threshold mutations have accumulated or maxInterval
+// has elapsed since the last save. threshold==0 disables delta-gating so every
+// dirty tick saves; maxInterval<=0 disables the time-based fallback. The force
+// path (Save/StopAndSave) is unaffected and always persists when dirty.
+func (i *HNSWIndex) SetAutosavePolicy(threshold uint64, maxInterval time.Duration) {
+	i.mu.Lock()
+	i.autosaveThreshold = threshold
+	i.autosaveMaxInterval = maxInterval
+	i.mu.Unlock()
 }
 
 // Upsert stores (or replaces) the vector and its payload, keyed by
@@ -173,30 +214,6 @@ func (i *HNSWIndex) Delete(ctx context.Context, chunkIDs []uint64) error {
 	return nil
 }
 
-// scoreEps is the score-equality tolerance for the ranking tiebreak: two scores
-// within eps are treated as equal and ordered by ascending chunk_id, giving a
-// deterministic total order over realistic (well-separated) embedding scores.
-const scoreEps = 1e-6
-
-// scoredCandidate pairs a chunk_id with its cosine score during search.
-type scoredCandidate struct {
-	chunkID uint64
-	score   float32
-	payload model.IndexPayload
-}
-
-// candidateBefore reports whether candidate a ranks strictly before b: higher
-// score first, with an eps-tolerant ascending chunk_id tiebreak. It is the sole
-// ranking comparator, shared by the top-k heap's eviction decision and the final
-// ordering of the retained hits, so the heap selects exactly the same k
-// candidates the previous full O(N log N) sort would have kept (issue #429 F1).
-func candidateBefore(aScore, bScore float32, aID, bID uint64) bool {
-	if math.Abs(float64(aScore)-float64(bScore)) <= scoreEps {
-		return aID < bID
-	}
-	return aScore > bScore
-}
-
 // Search returns the k best matches for vector, filtered by filter. The filter
 // is applied inline (CanFilter is always true for the pure-Go HNSW), so callers
 // may push it down rather than overfetch-then-filter.
@@ -224,12 +241,12 @@ func (i *HNSWIndex) Search(ctx context.Context, vector []float32, k int, filter 
 	}
 
 	sort.Slice(scored, func(a, b int) bool {
-		return candidateBefore(scored[a].score, scored[b].score, scored[a].chunkID, scored[b].chunkID)
+		return topk.Before(scored[a].Score, scored[b].Score, scored[a].ChunkID, scored[b].ChunkID)
 	})
 
 	hits := make([]model.IndexHit, len(scored))
 	for idx, s := range scored {
-		hits[idx] = model.IndexHit{ChunkID: s.chunkID, Score: s.score, Payload: s.payload}
+		hits[idx] = model.IndexHit{ChunkID: s.ChunkID, Score: s.Score, Payload: s.Payload}
 	}
 	return hits, nil
 }
@@ -246,10 +263,10 @@ type dimMismatch struct {
 // k candidates, it never allocates a per-query copy of the whole candidate set
 // nor of any candidate vector; a payload is copied out of the map only when the
 // candidate actually enters the heap.
-func (i *HNSWIndex) scoreTopK(vector []float32, k int, filter model.Filter) ([]scoredCandidate, []dimMismatch) {
+func (i *HNSWIndex) scoreTopK(vector []float32, k int, filter model.Filter) ([]topk.Candidate, []dimMismatch) {
 	var mismatches []dimMismatch
 	applyFilter := !filter.IsZero()
-	h := topKHeap{k: k, items: make([]scoredCandidate, 0, k)}
+	h := topk.New(k)
 
 	i.mu.RLock()
 	for id, cand := range i.vectors {
@@ -272,82 +289,16 @@ func (i *HNSWIndex) scoreTopK(vector []float32, k int, filter model.Filter) ([]s
 		score := cosineSimilarity(vector, cand)
 		// Skip the payload copy + heap push for candidates that cannot displace
 		// the current worst of a full heap.
-		if h.full() && !h.better(score, id) {
+		if h.Full() && !h.Better(score, id) {
 			continue
 		}
 		if !havePayload {
 			payload = i.payloads[id]
 		}
-		h.push(scoredCandidate{chunkID: id, score: score, payload: payload})
+		h.Push(topk.Candidate{ChunkID: id, Score: score, Payload: payload})
 	}
 	i.mu.RUnlock()
-	return h.items, mismatches
-}
-
-// topKHeap is a bounded min-heap that retains the best k candidates seen so far,
-// ordered by candidateBefore. The root is the *worst* retained candidate, so a
-// newly scored candidate that ranks before the root evicts it in O(log k).
-type topKHeap struct {
-	items []scoredCandidate
-	k     int
-}
-
-func (h *topKHeap) full() bool { return len(h.items) >= h.k }
-
-// better reports whether a candidate with (score, id) ranks before the current
-// worst retained candidate (the root). Only meaningful when the heap is full.
-func (h *topKHeap) better(score float32, id uint64) bool {
-	root := h.items[0]
-	return candidateBefore(score, root.score, id, root.chunkID)
-}
-
-// worse reports whether item a ranks after item b (a is the poorer match).
-func (h *topKHeap) worse(a, b int) bool {
-	x, y := h.items[a], h.items[b]
-	return candidateBefore(y.score, x.score, y.chunkID, x.chunkID)
-}
-
-// push adds c when the heap is under capacity, otherwise replaces the worst
-// retained candidate. Callers must only push a candidate that is under capacity
-// or better than the root (see scoreTopK).
-func (h *topKHeap) push(c scoredCandidate) {
-	if len(h.items) < h.k {
-		h.items = append(h.items, c)
-		h.siftUp(len(h.items) - 1)
-		return
-	}
-	h.items[0] = c
-	h.siftDown(0)
-}
-
-func (h *topKHeap) siftUp(n int) {
-	for n > 0 {
-		parent := (n - 1) / 2
-		if !h.worse(n, parent) {
-			break
-		}
-		h.items[n], h.items[parent] = h.items[parent], h.items[n]
-		n = parent
-	}
-}
-
-func (h *topKHeap) siftDown(n int) {
-	size := len(h.items)
-	for {
-		left := 2*n + 1
-		if left >= size {
-			return
-		}
-		worst := left
-		if right := left + 1; right < size && h.worse(right, left) {
-			worst = right
-		}
-		if !h.worse(worst, n) {
-			return
-		}
-		h.items[n], h.items[worst] = h.items[worst], h.items[n]
-		n = worst
-	}
+	return h.Items(), mismatches
 }
 
 // CanFilter reports whether the backend can evaluate the filter itself. The
@@ -496,7 +447,28 @@ func (i *HNSWIndex) markSaved(version uint64) {
 	if version > i.savedVersion {
 		i.savedVersion = version
 	}
+	i.lastSaveTime = time.Now()
 	i.mu.Unlock()
+}
+
+// AutosaveTick is the periodic-save entrypoint (issue #429 C-a): it delegates to
+// Save only when the index is dirty AND either the accumulated mutation delta has
+// reached autosaveThreshold or autosaveMaxInterval has elapsed since the last
+// save. Otherwise it is a no-op, so a long ingest no longer rewrites the whole
+// snapshot on every 15s tick. The force path (Save) still persists any dirty
+// state, so StopAndSave at shutdown never drops the throttled tail.
+func (i *HNSWIndex) AutosaveTick(ctx context.Context, path string) error {
+	i.mu.RLock()
+	delta := i.version - i.savedVersion
+	threshold := i.autosaveThreshold
+	maxInterval := i.autosaveMaxInterval
+	sinceSave := time.Since(i.lastSaveTime)
+	i.mu.RUnlock()
+
+	if !shouldAutosave(delta, threshold, maxInterval, sinceSave) {
+		return nil
+	}
+	return i.Save(ctx, path)
 }
 
 // Load restores the index from a v2 snapshot file. A missing file is treated as
@@ -548,6 +520,22 @@ func (i *HNSWIndex) Load(ctx context.Context, path string) error {
 
 func (i *HNSWIndex) Close() error {
 	return nil
+}
+
+// shouldAutosave decides whether a periodic autosave tick should persist now
+// (issue #429 C-a). It never saves a clean index (delta==0). When delta reaches
+// the threshold it saves immediately; below the threshold it saves only once the
+// max interval has elapsed since the last save. A zero threshold means "save on
+// any dirty tick" (delta-gating disabled); a non-positive maxInterval disables
+// the time-based fallback. Pure and shared with the disk backend's copy.
+func shouldAutosave(delta, threshold uint64, maxInterval, sinceSave time.Duration) bool {
+	if delta == 0 {
+		return false
+	}
+	if threshold == 0 || delta >= threshold {
+		return true
+	}
+	return maxInterval > 0 && sinceSave >= maxInterval
 }
 
 func cosineSimilarity(a, b []float32) float32 {

--- a/internal/index/persistence.go
+++ b/internal/index/persistence.go
@@ -94,6 +94,47 @@ func (m *PersistenceManager) LoadAll(ctx context.Context) error {
 	return nil
 }
 
+// AutosaveTicker is an optional capability (issue #429 C-a): an index that can
+// throttle its periodic autosave, skipping the full snapshot/compaction when the
+// accumulated mutations are below a threshold and the max interval has not
+// elapsed. The autosave ticker prefers it; StopAndSave/SaveAll always use the
+// force path (Save) so shutdown durability is unaffected. Backends that do not
+// implement it fall back to Save on every tick (the pre-C-a behavior).
+type AutosaveTicker interface {
+	AutosaveTick(ctx context.Context, path string) error
+}
+
+// autosaveTick is the periodic-save path invoked by the ticker goroutine. Unlike
+// SaveAll (the force path used by StopAndSave), it routes each index through its
+// AutosaveTicker capability when available, so a long ingest doesn't rewrite the
+// whole index on every tick (issue #429 C-a). It shares saveMu with SaveAll/Load
+// so saves never overlap.
+func (m *PersistenceManager) autosaveTick() error {
+	m.saveMu.Lock()
+	defer m.saveMu.Unlock()
+
+	var combined error
+	for _, idx := range m.indices {
+		if idx.Index == nil {
+			continue
+		}
+		p, ok := idx.Index.(model.Persistable)
+		if !ok {
+			continue
+		}
+		var err error
+		if t, ok := idx.Index.(AutosaveTicker); ok {
+			err = t.AutosaveTick(context.Background(), idx.Path)
+		} else {
+			err = p.Save(context.Background(), idx.Path)
+		}
+		if err != nil {
+			combined = errors.Join(combined, err)
+		}
+	}
+	return combined
+}
+
 func (m *PersistenceManager) SaveAll() error {
 	// protect against concurrent callers; the underlying model.Index
 	// implementations are not required to be goroutine‑safe so we serialize
@@ -177,7 +218,7 @@ func (m *PersistenceManager) Start(ctx context.Context) {
 			case <-runCtx.Done():
 				return
 			case <-ticker.C:
-				if err := m.SaveAll(); err != nil {
+				if err := m.autosaveTick(); err != nil {
 					m.emitError(err)
 				}
 			}

--- a/internal/index/topk/topk.go
+++ b/internal/index/topk/topk.go
@@ -67,8 +67,13 @@ func (h *Heap) Items() []Candidate { return h.items }
 func (h *Heap) Full() bool { return len(h.items) >= h.k }
 
 // Better reports whether a candidate with (score, id) ranks before the current
-// worst retained candidate (the root). Only meaningful when the heap is full.
+// worst retained candidate (the root). An empty heap (including a k=0 heap, for
+// which Full() is trivially true) has no worst element, so nothing is better than
+// it — return false rather than indexing items[0].
 func (h *Heap) Better(score float32, id uint64) bool {
+	if len(h.items) == 0 {
+		return false
+	}
 	root := h.items[0]
 	return Before(score, root.Score, id, root.ChunkID)
 }

--- a/internal/index/topk/topk.go
+++ b/internal/index/topk/topk.go
@@ -1,0 +1,126 @@
+// Package topk provides a bounded top-k selection heap shared by the local
+// vector backends (internal/index.HNSWIndex and internal/index/diskindex).
+//
+// Both backends previously scored every candidate and full-sorted the whole
+// scored set before truncating to k — O(N log N) per query with a per-candidate
+// allocation. This package replaces that with a bounded min-heap that retains
+// only the running best k, ordered by the single ranking comparator Before, so
+// each Search allocates O(k) not O(N) (issue #429 F1/F2). It lives in its own
+// leaf package because internal/index imports internal/index/diskindex, so the
+// shared code cannot live in either of those without an import cycle.
+package topk
+
+import (
+	"math"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// ScoreEps is the score-equality tolerance for the ranking tiebreak: two scores
+// within eps are treated as equal and ordered by ascending chunk_id, giving a
+// deterministic total order over realistic (well-separated) embedding scores.
+const ScoreEps = 1e-6
+
+// Candidate pairs a chunk_id with its cosine score during search, carrying the
+// payload so a retained hit can be materialised without a second lookup.
+type Candidate struct {
+	ChunkID uint64
+	Score   float32
+	Payload model.IndexPayload
+}
+
+// Before reports whether a candidate with (aScore, aID) ranks strictly before
+// one with (bScore, bID): higher score first, with an eps-tolerant ascending
+// chunk_id tiebreak. It is the sole ranking comparator, shared by the heap's
+// eviction decision and the caller's final ordering of the retained hits, so the
+// heap selects exactly the same k candidates the previous full O(N log N) sort
+// would have kept (issue #429 F1).
+func Before(aScore, bScore float32, aID, bID uint64) bool {
+	if math.Abs(float64(aScore)-float64(bScore)) <= ScoreEps {
+		return aID < bID
+	}
+	return aScore > bScore
+}
+
+// Heap is a bounded min-heap that retains the best k candidates seen so far,
+// ordered by Before. The root is the *worst* retained candidate, so a newly
+// scored candidate that ranks before the root evicts it in O(log k).
+type Heap struct {
+	items []Candidate
+	k     int
+}
+
+// New returns an empty Heap that retains at most k candidates. A non-positive k
+// yields a heap that accepts nothing.
+func New(k int) *Heap {
+	if k < 0 {
+		k = 0
+	}
+	return &Heap{k: k, items: make([]Candidate, 0, k)}
+}
+
+// Items returns the retained candidates in heap (unordered) order. Callers sort
+// them with Before to obtain the final best-first ranking.
+func (h *Heap) Items() []Candidate { return h.items }
+
+// Full reports whether the heap is at capacity.
+func (h *Heap) Full() bool { return len(h.items) >= h.k }
+
+// Better reports whether a candidate with (score, id) ranks before the current
+// worst retained candidate (the root). Only meaningful when the heap is full.
+func (h *Heap) Better(score float32, id uint64) bool {
+	root := h.items[0]
+	return Before(score, root.Score, id, root.ChunkID)
+}
+
+// worse reports whether item a ranks after item b (a is the poorer match).
+func (h *Heap) worse(a, b int) bool {
+	x, y := h.items[a], h.items[b]
+	return Before(y.Score, x.Score, y.ChunkID, x.ChunkID)
+}
+
+// Push adds c when the heap is under capacity, otherwise replaces the worst
+// retained candidate. Callers must only push a candidate that is under capacity
+// or better than the root (guard with Full/Better).
+func (h *Heap) Push(c Candidate) {
+	if h.k == 0 {
+		return
+	}
+	if len(h.items) < h.k {
+		h.items = append(h.items, c)
+		h.siftUp(len(h.items) - 1)
+		return
+	}
+	h.items[0] = c
+	h.siftDown(0)
+}
+
+func (h *Heap) siftUp(n int) {
+	for n > 0 {
+		parent := (n - 1) / 2
+		if !h.worse(n, parent) {
+			break
+		}
+		h.items[n], h.items[parent] = h.items[parent], h.items[n]
+		n = parent
+	}
+}
+
+func (h *Heap) siftDown(n int) {
+	size := len(h.items)
+	for {
+		left := 2*n + 1
+		if left >= size {
+			return
+		}
+		worst := left
+		if right := left + 1; right < size && h.worse(right, left) {
+			worst = right
+		}
+		if !h.worse(worst, n) {
+			return
+		}
+		h.items[n], h.items[worst] = h.items[worst], h.items[n]
+		n = worst
+	}
+}

--- a/internal/index/topk/topk_test.go
+++ b/internal/index/topk/topk_test.go
@@ -1,0 +1,62 @@
+package topk
+
+import (
+	"sort"
+	"testing"
+)
+
+// TestHeap_EmptyAndZeroKNoPanic pins the #429-review fix: Better must not index
+// items[0] on an empty heap. A k=0 heap is trivially Full() (0 >= 0), so a
+// Full()-guarded caller would otherwise call Better on empty items and panic.
+func TestHeap_EmptyAndZeroKNoPanic(t *testing.T) {
+	// k=0: Full() true, but the heap retains nothing and Better must be false.
+	z := New(0)
+	if !z.Full() {
+		t.Fatalf("k=0 heap should report Full()")
+	}
+	if z.Better(9.9, 1) {
+		t.Fatalf("k=0 heap: Better must be false, not panic")
+	}
+	z.Push(Candidate{ChunkID: 1, Score: 9.9})
+	if len(z.Items()) != 0 {
+		t.Fatalf("k=0 heap must retain nothing, got %d", len(z.Items()))
+	}
+
+	// Non-zero k but no pushes yet: Better on the empty heap must be false.
+	h := New(3)
+	if h.Full() {
+		t.Fatalf("empty k=3 heap should not be Full()")
+	}
+	if h.Better(1.0, 1) {
+		t.Fatalf("empty heap: Better must be false, not panic")
+	}
+}
+
+// TestHeap_RetainsBestK pins that the bounded heap keeps exactly the top-k by the
+// Before comparator, matching a reference full sort.
+func TestHeap_RetainsBestK(t *testing.T) {
+	in := []Candidate{
+		{ChunkID: 1, Score: 0.10}, {ChunkID: 2, Score: 0.90},
+		{ChunkID: 3, Score: 0.50}, {ChunkID: 4, Score: 0.70},
+		{ChunkID: 5, Score: 0.30},
+	}
+	h := New(3)
+	for _, c := range in {
+		if !h.Full() || h.Better(c.Score, c.ChunkID) {
+			h.Push(c)
+		}
+	}
+	got := append([]Candidate(nil), h.Items()...)
+	sort.Slice(got, func(i, j int) bool {
+		return Before(got[i].Score, got[j].Score, got[i].ChunkID, got[j].ChunkID)
+	})
+	want := []uint64{2, 4, 3} // top-3 by score
+	if len(got) != len(want) {
+		t.Fatalf("kept %d, want %d: %+v", len(got), len(want), got)
+	}
+	for i, id := range want {
+		if got[i].ChunkID != id {
+			t.Fatalf("rank %d = chunk %d, want %d (%+v)", i, got[i].ChunkID, id, got)
+		}
+	}
+}

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -152,8 +152,11 @@ type Service struct {
 	ragSystemPrompt     string
 	ragMaxContextChars  int
 	metaMu              sync.RWMutex
+	// chunkByLabel is the single in-memory chunk-metadata store keyed by chunk_id
+	// label. A chunk_id belongs to exactly one axis (text or code) in production,
+	// so the previous per-index split (chunkByIndex) held a redundant second copy
+	// of every SearchHit; it was collapsed into this one map (issue #429 F4/D1).
 	chunkByLabel        map[uint64]model.SearchHit
-	chunkByIndex        map[string]map[uint64]model.SearchHit
 	rootDir             string
 	stateDir            string
 	// ocrCacheIdentity / transcriptCacheIdentity are the ACTIVE OCR-extraction and
@@ -337,10 +340,6 @@ func NewService(store model.Store, index model.Index, embedder model.Embedder, g
 		ragSystemPrompt:     defaultRAGSystemPrompt,
 		ragMaxContextChars:  defaultRAGMaxContext,
 		chunkByLabel:        make(map[uint64]model.SearchHit),
-		chunkByIndex: map[string]map[uint64]model.SearchHit{
-			"text": make(map[uint64]model.SearchHit),
-			"code": make(map[uint64]model.SearchHit),
-		},
 		rootDir:             ".",
 		stateDir:            filepath.Join(".", ".dir2mcp"),
 		protocolVersion:     "2025-11-25",
@@ -903,8 +902,6 @@ func (s *Service) SetSecretPatterns(patterns []string) error {
 func (s *Service) SetChunkMetadata(label uint64, metadata model.SearchHit) {
 	s.metaMu.Lock()
 	s.chunkByLabel[label] = metadata
-	s.chunkByIndex["text"][label] = metadata
-	s.chunkByIndex["code"][label] = metadata
 	s.metaMu.Unlock()
 }
 
@@ -955,9 +952,6 @@ func (s *Service) EvictDocuments(relPaths []string) {
 	s.metaMu.Lock()
 	for _, label := range labelsToDelete {
 		delete(s.chunkByLabel, label)
-		for _, byIndex := range s.chunkByIndex {
-			delete(byIndex, label)
-		}
 	}
 	s.metaMu.Unlock()
 }
@@ -993,9 +987,6 @@ func (s *Service) EvictChunks(labels []uint64) {
 	codeIndex := s.codeIndex
 	for _, label := range labels {
 		delete(s.chunkByLabel, label)
-		for _, byIndex := range s.chunkByIndex {
-			delete(byIndex, label)
-		}
 	}
 	s.metaMu.Unlock()
 
@@ -1046,16 +1037,13 @@ func (s *Service) pruneTombstonedHits(ctx context.Context, hits []model.SearchHi
 	return live
 }
 
+// SetChunkMetadataForIndex registers a chunk's metadata. The indexName axis is
+// accepted for API compatibility but no longer selects a per-index store: a
+// chunk_id belongs to exactly one axis in production, so metadata is kept once in
+// chunkByLabel (issue #429 D1).
 func (s *Service) SetChunkMetadataForIndex(indexName string, label uint64, metadata model.SearchHit) {
-	kind := strings.ToLower(strings.TrimSpace(indexName))
-	if kind != "text" && kind != "code" {
-		s.SetChunkMetadata(label, metadata)
-		return
-	}
-
 	s.metaMu.Lock()
 	s.chunkByLabel[label] = metadata
-	s.chunkByIndex[kind][label] = metadata
 	s.metaMu.Unlock()
 }
 
@@ -2364,13 +2352,6 @@ func collectStoreStatsFallback(ctx context.Context, st model.Store) (docStatusCo
 
 func (s *Service) searchHitForLabel(indexName string, label uint64) model.SearchHit {
 	s.metaMu.RLock()
-	if byIndex, ok := s.chunkByIndex[indexName]; ok {
-		if meta, exists := byIndex[label]; exists {
-			s.metaMu.RUnlock()
-			meta.ChunkID = label
-			return meta
-		}
-	}
 	meta, ok := s.chunkByLabel[label]
 	s.metaMu.RUnlock()
 
@@ -2971,15 +2952,7 @@ func (s *Service) searchHitFromIndexHit(indexName string, h model.IndexHit) mode
 func (s *Service) hasInMemoryMetadata() bool {
 	s.metaMu.RLock()
 	defer s.metaMu.RUnlock()
-	if len(s.chunkByLabel) > 0 {
-		return true
-	}
-	for _, byIndex := range s.chunkByIndex {
-		if len(byIndex) > 0 {
-			return true
-		}
-	}
-	return false
+	return len(s.chunkByLabel) > 0
 }
 
 // collectFilteredHits walks one batch of index hits and appends matching hits to

--- a/tests/index/perf429_disk_test.go
+++ b/tests/index/perf429_disk_test.go
@@ -1,0 +1,296 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/index/diskindex"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// Issue #429: the on-disk backend's Search now scores with a bounded top-k heap
+// (reading each candidate vector into a single reused scratch buffer) instead of
+// appending every scored hit and full-sorting, and its Save is dirty-flagged so
+// an idle corpus's autosave stops recompacting the whole segment. The periodic
+// autosave (AutosaveTick) is throttled so a long ingest doesn't rewrite the
+// segment on every 15s tick. These tests pin all three, plus that search
+// allocations stay bounded as N grows.
+
+// TestDiskIndex_TopKMatchesFullSort proves the disk backend's heap-based top-k
+// returns exactly the ranked hits the previous full-sort-then-truncate produced,
+// across random corpora/queries, k values, and a filter. referenceTopK (perf429_
+// test.go) scores with refCosine, which matches diskindex.cosineSimilarity bit
+// for bit (same query-vector accumulation order), so ties resolve identically.
+func TestDiskIndex_TopKMatchesFullSort(t *testing.T) {
+	r := rand.New(rand.NewSource(7))
+	const dim = 8
+	for trial := 0; trial < 30; trial++ {
+		n := 1 + r.Intn(50)
+		dir := t.TempDir()
+		idx := diskindex.New(filepath.Join(dir, diskindex.SegmentFileName("text")))
+		vecs := make(map[uint64][]float32, n)
+		payloads := make(map[uint64]model.IndexPayload, n)
+		for j := 0; j < n; j++ {
+			id := uint64(j + 1)
+			v := randVec(r, dim)
+			// Force a cluster of exact ties every few ids so the eps-tolerant
+			// chunkID tiebreak (not just distinct scores) is exercised.
+			if j%7 == 0 {
+				v = []float32{1, 0, 0, 0, 0, 0, 0, 0}
+			}
+			dt := "md"
+			if j%2 == 0 {
+				dt = "code"
+			}
+			p := model.IndexPayload{ChunkID: id, RelPath: fmt.Sprintf("f%d.txt", id), DocType: dt}
+			mustUpsertDisk(t, idx, p, v)
+			vecs[id] = v
+			payloads[id] = p
+		}
+
+		filters := []model.Filter{{}, {DocTypes: []string{"md"}}}
+		for _, filter := range filters {
+			for _, k := range []int{1, 3, 7, n, n + 5} {
+				query := randVec(r, dim)
+				got, err := idx.Search(context.Background(), query, k, filter)
+				if err != nil {
+					t.Fatalf("search: %v", err)
+				}
+				want := referenceTopK(vecs, payloads, query, k, filter)
+				if len(got) != len(want) {
+					t.Fatalf("trial %d k=%d filter=%v: len got=%d want=%d", trial, k, filter, len(got), len(want))
+				}
+				for i := range want {
+					if got[i].ChunkID != want[i].ChunkID || got[i].Score != want[i].Score {
+						t.Fatalf("trial %d k=%d filter=%v pos %d: got (id=%d score=%v) want (id=%d score=%v)",
+							trial, k, filter, i, got[i].ChunkID, got[i].Score, want[i].ChunkID, want[i].Score)
+					}
+				}
+			}
+		}
+		_ = idx.Close()
+	}
+}
+
+// TestDiskIndex_TopKTieBreakByChunkID pins the disk backend's deterministic
+// tiebreak: equal-cosine candidates order by ascending chunk_id and the k
+// boundary falls on the lower id.
+func TestDiskIndex_TopKTieBreakByChunkID(t *testing.T) {
+	dir := t.TempDir()
+	idx := diskindex.New(filepath.Join(dir, diskindex.SegmentFileName("text")))
+	t.Cleanup(func() { _ = idx.Close() })
+	for _, id := range []uint64{30, 10, 20} {
+		mustUpsertDisk(t, idx, model.IndexPayload{ChunkID: id, RelPath: "f.txt", DocType: "md"}, []float32{1, 0})
+	}
+	hits, err := idx.Search(context.Background(), []float32{1, 0}, 2, model.Filter{})
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(hits) != 2 || hits[0].ChunkID != 10 || hits[1].ChunkID != 20 {
+		t.Fatalf("expected ids [10 20] by ascending tiebreak, got %+v", hits)
+	}
+}
+
+// TestDiskIndex_DirtyFlagSkipsUnchangedSave proves Save no longer recompacts the
+// whole segment when nothing changed (F7): a Save with no intervening mutation
+// leaves the segment file untouched (same inode — os.SameFile), while a Save
+// after an Upsert rewrites it (new inode from the atomic temp-file rename).
+func TestDiskIndex_DirtyFlagSkipsUnchangedSave(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, diskindex.SegmentFileName("text"))
+	idx := diskindex.New(path)
+	t.Cleanup(func() { _ = idx.Close() })
+
+	mustUpsertDisk(t, idx, model.IndexPayload{ChunkID: 1, RelPath: "f.txt", DocType: "md"}, []float32{1, 0})
+	if err := idx.Save(context.Background(), ""); err != nil {
+		t.Fatalf("first save: %v", err)
+	}
+	fi1, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat after first save: %v", err)
+	}
+
+	// Second Save with no mutation must be a no-op: the segment is not rewritten.
+	if err := idx.Save(context.Background(), ""); err != nil {
+		t.Fatalf("clean save: %v", err)
+	}
+	fi2, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat after clean save: %v", err)
+	}
+	if !os.SameFile(fi1, fi2) {
+		t.Fatalf("clean Save rewrote the segment; dirty flag not honored")
+	}
+
+	// A mutation makes it dirty → Save recompacts (new file).
+	mustUpsertDisk(t, idx, model.IndexPayload{ChunkID: 2, RelPath: "f.txt", DocType: "md"}, []float32{0, 1})
+	if err := idx.Save(context.Background(), ""); err != nil {
+		t.Fatalf("dirty save: %v", err)
+	}
+	fi3, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat after dirty save: %v", err)
+	}
+	if os.SameFile(fi2, fi3) {
+		t.Fatalf("dirty Save did not rewrite the segment")
+	}
+}
+
+// TestDiskIndex_AutosaveThrottled is the ingest-cliff regression guard (C-a): with
+// a per-upsert tick (the worst case — one autosave tick per mutation) the number
+// of real compactions is bounded by ceil(K/threshold), NOT one per tick. A real
+// compaction is observed as a segment-file inode change (Save renames a fresh
+// temp file into place; appends keep the same inode).
+func TestDiskIndex_AutosaveThrottled(t *testing.T) {
+	const (
+		k         = 25
+		threshold = 10
+	)
+	dir := t.TempDir()
+	path := filepath.Join(dir, diskindex.SegmentFileName("text"))
+	idx := diskindex.New(path)
+	t.Cleanup(func() { _ = idx.Close() })
+	// Large max interval so only the mutation threshold — never wall-time — can
+	// trigger a save within the test, making the bound tight and deterministic.
+	idx.SetAutosavePolicy(threshold, time.Hour)
+
+	saves := 0
+	var base os.FileInfo
+	for j := 1; j <= k; j++ {
+		mustUpsertDisk(t, idx, model.IndexPayload{ChunkID: uint64(j), RelPath: "f.txt", DocType: "md"}, []float32{float32(j), 1})
+		if err := idx.AutosaveTick(context.Background(), ""); err != nil {
+			t.Fatalf("autosave tick %d: %v", j, err)
+		}
+		cur, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat: %v", err)
+		}
+		if base == nil {
+			// First observation is the append-created log, not a compaction.
+			base = cur
+			continue
+		}
+		if !os.SameFile(base, cur) {
+			saves++
+			base = cur
+		}
+	}
+
+	maxSaves := (k + threshold - 1) / threshold // ceil(K/threshold)
+	if saves < 1 {
+		t.Fatalf("expected at least one throttled compaction over %d upserts, got 0", k)
+	}
+	if saves > maxSaves {
+		t.Fatalf("compactions=%d exceed ceil(K/threshold)=%d; throttle not bounding", saves, maxSaves)
+	}
+	if saves >= k {
+		t.Fatalf("compactions=%d ~ one-per-tick (%d ticks); autosave not throttled", saves, k)
+	}
+}
+
+// TestHNSWIndex_AutosaveThrottled is the memory-backend twin of the disk guard:
+// a per-upsert tick yields a bounded number of snapshots, not one per tick. The
+// memory snapshot file only exists after a real Save, so its first appearance and
+// each subsequent inode change count a save.
+func TestHNSWIndex_AutosaveThrottled(t *testing.T) {
+	const (
+		k         = 25
+		threshold = 10
+	)
+	path := filepath.Join(t.TempDir(), index.TextIndexFileName)
+	idx := index.NewHNSWIndex(path)
+	idx.SetAutosavePolicy(threshold, time.Hour)
+
+	saves := 0
+	var prev os.FileInfo
+	for j := 1; j <= k; j++ {
+		upsertVec(t, idx, uint64(j), []float32{float32(j), 1})
+		if err := idx.AutosaveTick(context.Background(), ""); err != nil {
+			t.Fatalf("autosave tick %d: %v", j, err)
+		}
+		cur, err := os.Stat(path)
+		if err != nil {
+			continue // no snapshot yet: this tick was throttled
+		}
+		if prev == nil || !os.SameFile(prev, cur) {
+			saves++
+			prev = cur
+		}
+	}
+
+	maxSaves := (k + threshold - 1) / threshold
+	if saves < 1 {
+		t.Fatalf("expected at least one throttled snapshot over %d upserts, got 0", k)
+	}
+	if saves > maxSaves {
+		t.Fatalf("snapshots=%d exceed ceil(K/threshold)=%d; throttle not bounding", saves, maxSaves)
+	}
+	if saves >= k {
+		t.Fatalf("snapshots=%d ~ one-per-tick (%d ticks); autosave not throttled", saves, k)
+	}
+}
+
+// TestSearch_AllocationsStayBounded guards issue #429 F1/F2: Search allocations
+// must stay O(k), not O(N). A 4x larger corpus must not roughly-4x the per-query
+// allocations. Skipped under -short so `make ci` stays fast.
+func TestSearch_AllocationsStayBounded(t *testing.T) {
+	if testing.Short() {
+		t.Skip("allocation guard is slow (builds a few thousand-vector corpora); skipped under -short")
+	}
+	const (
+		dim   = 16
+		small = 300
+		large = 1200 // 4x
+		k     = 10
+	)
+	r := rand.New(rand.NewSource(11))
+	query := randVec(r, dim)
+
+	memAllocs := func(n int) float64 {
+		idx := index.NewHNSWIndex("")
+		for j := 1; j <= n; j++ {
+			upsertVec(t, idx, uint64(j), randVec(r, dim))
+		}
+		return testing.AllocsPerRun(10, func() {
+			if _, err := idx.Search(context.Background(), query, k, model.Filter{}); err != nil {
+				t.Fatalf("mem search: %v", err)
+			}
+		})
+	}
+	diskAllocs := func(n int) float64 {
+		dir := t.TempDir()
+		idx := diskindex.New(filepath.Join(dir, diskindex.SegmentFileName("text")))
+		defer func() { _ = idx.Close() }()
+		for j := 1; j <= n; j++ {
+			mustUpsertDisk(t, idx, model.IndexPayload{ChunkID: uint64(j), RelPath: "f.txt", DocType: "md"}, randVec(r, dim))
+		}
+		return testing.AllocsPerRun(10, func() {
+			if _, err := idx.Search(context.Background(), query, k, model.Filter{}); err != nil {
+				t.Fatalf("disk search: %v", err)
+			}
+		})
+	}
+
+	for _, tc := range []struct {
+		name  string
+		alloc func(int) float64
+	}{
+		{"memory", memAllocs},
+		{"disk", diskAllocs},
+	} {
+		aSmall := tc.alloc(small)
+		aLarge := tc.alloc(large)
+		// O(N) would scale ~4x with the corpus; O(k) stays roughly flat. Allow a
+		// 2x slack for measurement noise and the constant hits-slice/sort work.
+		if aLarge > aSmall*2 {
+			t.Fatalf("%s: Search allocs scale with N (allocs %.0f@N=%d vs %.0f@N=%d, >2x); expected O(k)",
+				tc.name, aLarge, large, aSmall, small)
+		}
+	}
+}

--- a/tests/retrieval/perf429_metadata_test.go
+++ b/tests/retrieval/perf429_metadata_test.go
@@ -1,0 +1,50 @@
+package tests
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
+)
+
+// Issue #429 D1: the retrieval service previously kept a chunk's SearchHit
+// metadata in BOTH a per-label map and a redundant per-index (text/code) map,
+// resident twice. The per-index split was collapsed into the single chunkByLabel
+// store. This test pins that eviction still hides a tombstoned document's chunks
+// on the very next search after the collapse — the single map is the sole source
+// of truth, and dropping a label from it makes searchHitForLabel fall back to an
+// empty-RelPath stub that matchFilters discards.
+func TestSearch_SingleMetadataMapEvictionHidesTombstonedChunks(t *testing.T) {
+	idx := index.NewHNSWIndex("")
+	addVec(t, idx, 1, []float32{1, 0})
+	addVec(t, idx, 2, []float32{0.9, 0.1})
+
+	st := newLivenessStore()
+	svc := retrieval.NewService(st, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+		"mistral-embed": {1, 0},
+	}}, nil)
+	svc.SetHybridEnabled(false) // vector-only ranking; no BM25 store dependency
+
+	// Register both chunks via the per-index entry point (the axis argument is now
+	// ignored — metadata is stored once in chunkByLabel).
+	svc.SetChunkMetadataForIndex("text", 1, model.SearchHit{ChunkID: 1, RelPath: "keep.md", DocType: "md", Snippet: "kept content"})
+	svc.SetChunkMetadataForIndex("code", 2, model.SearchHit{ChunkID: 2, RelPath: "drop.md", DocType: "md", Snippet: "content to drop"})
+
+	got := searchChunkIDs(t, svc, "content")
+	if !slices.Contains(got, 1) || !slices.Contains(got, 2) {
+		t.Fatalf("expected both chunks searchable before eviction, got %v", got)
+	}
+
+	// Whole-document eviction: drop.md is tombstoned in the store.
+	svc.EvictDocuments([]string{"drop.md"})
+
+	got = searchChunkIDs(t, svc, "content")
+	if slices.Contains(got, 2) {
+		t.Fatalf("evicted document's chunk 2 still returned after eviction: %v", got)
+	}
+	if !slices.Contains(got, 1) {
+		t.Fatalf("live chunk 1 should still be returned after evicting a different document, got %v", got)
+	}
+}


### PR DESCRIPTION
Spec-neutral local vector-backend performance fixes from #429. **No dirstral-spec PR is needed** — result ordering (byte-stable), the `chunk_id` label, and the persisted embed identity / segment format are all preserved.

## Stages

**A — bounded top-k + in-place / lazy scoring (F1/F2).** The top-k min-heap is extracted into a new shared leaf package `internal/index/topk` (a leaf, not package `index`, because `internal/index` imports `internal/index/diskindex` — the shared code cannot live in either without an import cycle). Both the memory (`HNSWIndex`) and disk (`DiskIndex`) backends now select the running best `k` with the bounded heap instead of scoring every candidate and full-sorting all N. The disk `Search` reads each candidate vector into a single reused query-sized scratch buffer and defers the expensive gob payload decode to only the candidates that survive the heap guard — search is now O(N) time with **O(k)** allocations (guarded by a test).

**B — dirty-flag the disk autosave (F7).** `DiskIndex` gains `version`/`savedVersion`, bumped on every appended record and `Reset`. `Save` short-circuits the whole-segment compaction rewrite when nothing changed since the last durable save, so an idle corpus's autosave is a no-op. No segment-format change.

**C-a — throttle ingest-time full rewrites (the F7 ingest cliff, SAFE version).** A new optional `AutosaveTicker` capability lets an index throttle its *periodic* autosave: `AutosaveTick` snapshots/compacts only once the accumulated mutation delta reaches a threshold (default 50k) **or** a max interval (default 5m) has elapsed, instead of on every 15s tick during a long ingest. `StopAndSave` still uses the force path (`Save`) so shutdown durability is unchanged. Applies to both backends. (No append-journal / sidecar — that was the deferred C-b.)

**D1 — collapse triplicated chunk metadata (F4).** The retrieval service dropped the redundant per-index (`chunkByIndex`) second copy of every `SearchHit`; all reads/writes/eviction now route through the single `chunkByLabel` store. A `chunk_id` belongs to exactly one axis in production, so the split was pure duplication.

## Tests
- Disk `Search` byte-identical ranking vs a reference full-sort (incl. exact-score ties, with/without filter).
- Disk dirty-flag `Save`: no-mutation Save leaves the segment untouched (same inode); Save after an Upsert rewrites it.
- Throttled autosave (memory + disk): K per-upsert ticks produce a bounded snapshot count (≤ ceil(K/threshold)), not one-per-tick.
- Single metadata map: `EvictDocuments` still hides a tombstoned document's chunks on the next search.
- Allocation guard (skipped under `-short`): a 4×-larger corpus must not ~4× per-query Search allocations (O(k) not O(N)).

`make lint` = 0 issues, gocyclo ≤ 15, `go test ./internal/index/... ./internal/retrieval/... ./tests/index/... ./tests/retrieval/...` (incl. `-race`) all pass.

## Deferred (explicitly out of scope)
- The residual "HNSW is really brute-force" issue — no real ANN graph; still O(N)/query (just now O(N) time + O(k) allocs). F3 naming/guidance untouched.
- **C-b** append-journal for incremental durability (needs a new sidecar file + spec change).
- **D2** removing the retrieval-side metadata cache / eviction rewrite (riskier follow-up).
- Startup/concurrency items F6/F8–F11 (fsync-per-upsert, single sqlite conn, list_files COUNT).

Addresses #429.