### PR TITLE
feat: honest-coverage skip-reason surface in status/reindex (#414)

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -306,6 +306,10 @@ type corpusIndexing struct {
 	Errors          int64                 `json:"errors"`
 	Unknown         int64                 `json:"unknown"`
 	FailureSummary  *model.FailureSummary `json:"failure_summary,omitempty"`
+	// SkipSummary groups never-indexed documents by skip_reason (honest
+	// coverage, #414/#395). Travels straight through from CorpusStats; omitted
+	// from JSON when nothing was skipped.
+	SkipSummary *model.SkipSummary `json:"skip_summary,omitempty"`
 }
 
 // NewApp constructs an App wired to os.Stdout and os.Stderr.
@@ -1932,6 +1936,10 @@ func buildCorpusSnapshot(ctx context.Context, st model.Store, indexingState *app
 			// when no failures have been recorded (omitempty on the
 			// struct tag).
 			FailureSummary: corpusStats.FailureSummary,
+			// SkipSummary likewise travels through from CorpusStats so
+			// `status` can render an honest not-indexed coverage block
+			// (#414). Omitted from JSON on corpora with nothing skipped.
+			SkipSummary: corpusStats.SkipSummary,
 		},
 		DocCounts: docCounts,
 		TotalDocs: totalDocs,

--- a/internal/cli/reindex.go
+++ b/internal/cli/reindex.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -75,7 +76,14 @@ func (a *App) runReindex(ctx context.Context, global globalOptions, args []strin
 	// (rollback). Closing first prevents a persist-on-close from clobbering a
 	// rolled-back index.
 	if reindexErr == nil && !global.quiet && !global.jsonOutput {
-		printReindexFinalSummary(a.stderr, ctx, st)
+		// Path-excluded drops persist no document row, so they are not in the
+		// store's SkipSummary; pull the ingestor's in-run per-reason counts (if it
+		// exposes them) to merge into the printed breakdown (#414).
+		var inRunSkips map[string]int64
+		if src, ok := ing.(skipReasonCounter); ok {
+			inRunSkips = src.SkipReasonCounts()
+		}
+		printReindexFinalSummary(a.stderr, ctx, st, inRunSkips)
 	}
 	// Resolve the content-hash snapshot while the store (meta.sqlite) is still
 	// open: discard it on a durable rebuild, restore it on any failure so the
@@ -365,13 +373,55 @@ func printReindexProgressLine(out io.Writer, ctx context.Context, st model.Store
 // user knows the run finished and what the final counts are. Same
 // CorpusStats source as the progress poller; silent when stats are
 // unavailable.
-func printReindexFinalSummary(out io.Writer, ctx context.Context, st model.Store) {
+func printReindexFinalSummary(out io.Writer, ctx context.Context, st model.Store, inRunSkips map[string]int64) {
 	stats, ok := corpusStatsForReindex(ctx, st)
 	if !ok {
 		return
 	}
 	_, _ = fmt.Fprintf(out, "[reindex] done: scanned=%d indexed=%d skipped=%d errors=%d chunks=%d embedded=%d\n",
 		stats.Scanned, stats.Indexed, stats.Skipped, stats.Errors, stats.ChunksTotal, stats.EmbeddedOK)
+	if breakdown := formatSkipBreakdown(stats.SkipSummary, inRunSkips); breakdown != "" {
+		// Honest-coverage breakdown of *why* files were skipped (#414): the durable
+		// per-reason counts from the store plus this run's non-persisted
+		// path-excludes. Printed only when something was skipped.
+		_, _ = fmt.Fprintf(out, "[reindex] not indexed: %s\n", breakdown)
+	}
+}
+
+// skipReasonCounter is the optional ingestor capability exposing in-run,
+// non-persisted per-reason skip counts (path-excludes). The reindex summary
+// merges these with the store's durable SkipSummary.
+type skipReasonCounter interface {
+	SkipReasonCounts() map[string]int64
+}
+
+// formatSkipBreakdown renders a stable "reason=N reason=N" line from the
+// store's durable SkipSummary categories merged with this run's non-persisted
+// in-run counts (path-excludes). Returns "" when nothing was skipped. Counts
+// for a reason present in both sources are summed.
+func formatSkipBreakdown(summary *model.SkipSummary, inRun map[string]int64) string {
+	merged := map[string]int64{}
+	if summary != nil {
+		for reason, n := range summary.Categories {
+			merged[reason] += n
+		}
+	}
+	for reason, n := range inRun {
+		merged[reason] += n
+	}
+	if len(merged) == 0 {
+		return ""
+	}
+	reasons := make([]string, 0, len(merged))
+	for reason := range merged {
+		reasons = append(reasons, reason)
+	}
+	sort.Strings(reasons)
+	parts := make([]string, 0, len(reasons))
+	for _, reason := range reasons {
+		parts = append(parts, fmt.Sprintf("%s=%d", reason, merged[reason]))
+	}
+	return strings.Join(parts, " ")
 }
 
 // corpusStatsForReindex pulls CorpusStats from the SQLite-backed

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
+	"github.com/dirstral/dir2mcp/internal/config"
 	"github.com/dirstral/dir2mcp/internal/model"
 )
 
@@ -69,7 +71,64 @@ func (a *App) runStatus(ctx context.Context, global globalOptions, args []string
 		staleRunning = true
 	}
 
-	return a.renderStatusOutput(global, cfg.StateDir, snapshot, source, staleRunning)
+	// Load recent per-document ingest failures (rel_path + reason) so status can
+	// show *which* files failed and why, not just errors=N (#414 part 2). This is
+	// a live store read, best-effort: any miss leaves the block unrendered.
+	recentFailures := a.loadRecentFailuresForStatus(ctx, cfg, statusRecentFailuresLimit)
+
+	return a.renderStatusOutput(global, cfg.StateDir, snapshot, source, staleRunning, recentFailures)
+}
+
+// statusRecentFailuresLimit bounds how many recent failures `status` renders —
+// enough to triage without flooding the terminal on a badly-broken corpus.
+const statusRecentFailuresLimit = 10
+
+// loadRecentFailuresForStatus reads the most recent status='error' documents
+// from the store, best-effort. It opens a short-lived read handle (WAL allows a
+// concurrent reader alongside a live daemon) and returns nil on any miss — an
+// absent store, an unsupported backend, or a transient query error — so status
+// never fails because the diagnostic side query did.
+func (a *App) loadRecentFailuresForStatus(ctx context.Context, cfg config.Config, limit int) []model.Document {
+	metaPath := filepath.Join(cfg.StateDir, "meta.sqlite")
+	if _, err := os.Stat(metaPath); err != nil {
+		return nil
+	}
+	st := a.storeForConfig(cfg)
+	defer func() { _ = st.Close() }()
+	if err := st.Init(ctx); err != nil && !errors.Is(err, model.ErrNotImplemented) {
+		return nil
+	}
+	type recentFailuresLister interface {
+		RecentFailures(ctx context.Context, limit int) ([]model.Document, error)
+	}
+	rf, ok := st.(recentFailuresLister)
+	if !ok {
+		return nil
+	}
+	docs, err := rf.RecentFailures(ctx, limit)
+	if err != nil {
+		return nil
+	}
+	return docs
+}
+
+// statusErrorMessageRedactors is a compact safety net of high-confidence
+// credential patterns scrubbed from a failure message before it is printed by
+// `status`, mirroring the MCP stats surface (internal/mcp redactStatsErrorMessage).
+var statusErrorMessageRedactors = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)\b(sk|pk|rk)[-_](live|test|prod)?[-_]?[A-Za-z0-9]{16,}`),
+	regexp.MustCompile(`(?i)\b(AKIA|ASIA)[A-Z0-9]{16}\b`),
+	regexp.MustCompile(`eyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-.]{10,}\.[A-Za-z0-9_\-]{5,}`),
+	regexp.MustCompile(`(?i)(authorization|api[_-]?key|token|secret|password|passwd)\s*[:=]\s*\S+`),
+}
+
+// redactStatusErrorMessage scrubs high-confidence credentials from a failure
+// message before display. Returns msg unchanged when nothing matches.
+func redactStatusErrorMessage(msg string) string {
+	for _, rx := range statusErrorMessageRedactors {
+		msg = rx.ReplaceAllString(msg, "[REDACTED]")
+	}
+	return msg
 }
 
 // daemonIsLive reports whether a live daemon that is actually OURS currently
@@ -84,12 +143,19 @@ func daemonIsLive(stateDir string) bool {
 	return ownership == pidLive
 }
 
-func (a *App) renderStatusOutput(global globalOptions, stateDir string, snapshot corpusSnapshot, source string, staleRunning bool) int {
+func (a *App) renderStatusOutput(global globalOptions, stateDir string, snapshot corpusSnapshot, source string, staleRunning bool, recentFailures []model.Document) int {
 	if global.jsonOutput {
 		payload := map[string]interface{}{
 			"source":    source,
 			"state_dir": stateDir,
 			"snapshot":  snapshot,
+		}
+		if rf := recentFailuresJSON(recentFailures); len(rf) > 0 {
+			// Additive, optional field: the per-document failure list (rel_path,
+			// doc_type, redacted reason) surfaced alongside errors=N so --json
+			// consumers see *what* failed, not just a count (#414). Omitted when
+			// there are no failures.
+			payload["recent_failures"] = rf
 		}
 		if staleRunning {
 			// Additive, optional field: signals that the snapshot recorded
@@ -144,6 +210,9 @@ func (a *App) renderStatusOutput(global globalOptions, stateDir string, snapshot
 	writeln(a.stdout)
 	writeln(a.stdout)
 
+	a.renderCoverageBlock(s, snapshot)
+	a.renderRecentFailuresBlock(s, recentFailures)
+
 	writef(a.stdout, "  %s  %s  %s\n",
 		s.sectionHeader("Documents"),
 		s.stat("total", snapshot.TotalDocs),
@@ -161,4 +230,71 @@ func (a *App) renderStatusOutput(global globalOptions, stateDir string, snapshot
 	}
 	writeln(a.stdout)
 	return exitSuccess
+}
+
+// renderCoverageBlock prints an honest "Coverage / not-indexed" section that
+// breaks the skipped total down by reason (#414): "3 files unsupported_format,
+// 1 secret_excluded, …". No-op when nothing was skipped so healthy corpora keep
+// the terminal clean. Reasons are printed in a stable sorted order.
+func (a *App) renderCoverageBlock(s styles, snapshot corpusSnapshot) {
+	summary := snapshot.Indexing.SkipSummary
+	if summary == nil || len(summary.Categories) == 0 {
+		return
+	}
+	reasons := make([]string, 0, len(summary.Categories))
+	for reason := range summary.Categories {
+		reasons = append(reasons, reason)
+	}
+	sort.Strings(reasons)
+	writef(a.stdout, "  %s  %s\n",
+		s.sectionHeader("Coverage"),
+		s.dim("not indexed — what was skipped & why"),
+	)
+	for _, reason := range reasons {
+		writef(a.stdout, "    %s\n", s.stat(reason, summary.Categories[reason]))
+	}
+	writeln(a.stdout)
+}
+
+// renderRecentFailuresBlock prints up to statusRecentFailuresLimit recent
+// per-document ingest failures with rel_path and a redacted reason (#414 part
+// 2), so `status` surfaces *which* files failed rather than only errors=N.
+// No-op when there are none.
+func (a *App) renderRecentFailuresBlock(s styles, recentFailures []model.Document) {
+	if len(recentFailures) == 0 {
+		return
+	}
+	writef(a.stdout, "  %s  %s\n",
+		s.sectionHeader("Recent failures"),
+		s.dim(fmt.Sprintf("%d shown", len(recentFailures))),
+	)
+	for _, d := range recentFailures {
+		msg := redactStatusErrorMessage(strings.TrimSpace(d.ErrorMessage))
+		if msg == "" {
+			writef(a.stdout, "    %s\n", s.Red.Render(d.RelPath))
+			continue
+		}
+		writef(a.stdout, "    %s  %s\n", s.Red.Render(d.RelPath), s.dim(msg))
+	}
+	writeln(a.stdout)
+}
+
+// recentFailuresJSON projects the recent-failure documents into the additive
+// `recent_failures` array emitted by `status --json`: rel_path, doc_type,
+// mtime_unix, and a redacted error_message. Returns nil for an empty input so
+// the caller omits the field entirely on a healthy corpus.
+func recentFailuresJSON(recentFailures []model.Document) []map[string]interface{} {
+	if len(recentFailures) == 0 {
+		return nil
+	}
+	out := make([]map[string]interface{}, 0, len(recentFailures))
+	for _, d := range recentFailures {
+		out = append(out, map[string]interface{}{
+			"rel_path":      d.RelPath,
+			"doc_type":      d.DocType,
+			"mtime_unix":    d.MTimeUnix,
+			"error_message": redactStatusErrorMessage(d.ErrorMessage),
+		})
+	}
+	return out
 }

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strings"
 
 	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/ingest"
 	"github.com/dirstral/dir2mcp/internal/model"
 )
 
@@ -110,25 +110,6 @@ func (a *App) loadRecentFailuresForStatus(ctx context.Context, cfg config.Config
 		return nil
 	}
 	return docs
-}
-
-// statusErrorMessageRedactors is a compact safety net of high-confidence
-// credential patterns scrubbed from a failure message before it is printed by
-// `status`, mirroring the MCP stats surface (internal/mcp redactStatsErrorMessage).
-var statusErrorMessageRedactors = []*regexp.Regexp{
-	regexp.MustCompile(`(?i)\b(sk|pk|rk)[-_](live|test|prod)?[-_]?[A-Za-z0-9]{16,}`),
-	regexp.MustCompile(`(?i)\b(AKIA|ASIA)[A-Z0-9]{16}\b`),
-	regexp.MustCompile(`eyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-.]{10,}\.[A-Za-z0-9_\-]{5,}`),
-	regexp.MustCompile(`(?i)(authorization|api[_-]?key|token|secret|password|passwd)\s*[:=]\s*\S+`),
-}
-
-// redactStatusErrorMessage scrubs high-confidence credentials from a failure
-// message before display. Returns msg unchanged when nothing matches.
-func redactStatusErrorMessage(msg string) string {
-	for _, rx := range statusErrorMessageRedactors {
-		msg = rx.ReplaceAllString(msg, "[REDACTED]")
-	}
-	return msg
 }
 
 // daemonIsLive reports whether a live daemon that is actually OURS currently
@@ -269,7 +250,7 @@ func (a *App) renderRecentFailuresBlock(s styles, recentFailures []model.Documen
 		s.dim(fmt.Sprintf("%d shown", len(recentFailures))),
 	)
 	for _, d := range recentFailures {
-		msg := redactStatusErrorMessage(strings.TrimSpace(d.ErrorMessage))
+		msg := ingest.RedactCredentialsForDisplay(strings.TrimSpace(d.ErrorMessage))
 		if msg == "" {
 			writef(a.stdout, "    %s\n", s.Red.Render(d.RelPath))
 			continue
@@ -293,7 +274,7 @@ func recentFailuresJSON(recentFailures []model.Document) []map[string]interface{
 			"rel_path":      d.RelPath,
 			"doc_type":      d.DocType,
 			"mtime_unix":    d.MTimeUnix,
-			"error_message": redactStatusErrorMessage(d.ErrorMessage),
+			"error_message": ingest.RedactCredentialsForDisplay(d.ErrorMessage),
 		})
 	}
 	return out

--- a/internal/cli/status_coverage_test.go
+++ b/internal/cli/status_coverage_test.go
@@ -1,0 +1,149 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+func skipSnapshot() corpusSnapshot {
+	return corpusSnapshot{
+		Timestamp: "2026-07-07T00:00:00Z",
+		Indexing: corpusIndexing{
+			Mode:    "incremental",
+			Skipped: 3,
+			SkipSummary: &model.SkipSummary{
+				Categories: map[string]int64{
+					model.SkipReasonArchive:    2,
+					model.SkipReasonIgnoreRule: 1,
+				},
+			},
+		},
+		DocCounts: map[string]int64{"text": 1},
+		TotalDocs: 1,
+	}
+}
+
+func failuresFixture() []model.Document {
+	return []model.Document{
+		{RelPath: "broken.pdf", DocType: "pdf", MTimeUnix: 1, ErrorMessage: "docling crashed on page 3"},
+		// A message carrying a credential must be redacted before display.
+		{RelPath: "auth.log", DocType: "text", MTimeUnix: 2, ErrorMessage: "auth failed password=hunter2supersecret"},
+	}
+}
+
+// TestRenderStatus_TextCoverageAndFailures verifies the text status output
+// renders the honest-coverage block (per-reason skip breakdown) and the recent
+// failures block, and that credentials in a failure message are redacted (#414).
+func TestRenderStatus_TextCoverageAndFailures(t *testing.T) {
+	var out bytes.Buffer
+	app := NewAppWithIO(&out, &bytes.Buffer{})
+
+	code := app.renderStatusOutput(globalOptions{}, "/state", skipSnapshot(), "computed", false, failuresFixture())
+	if code != exitSuccess {
+		t.Fatalf("renderStatusOutput code = %d, want %d", code, exitSuccess)
+	}
+	got := out.String()
+
+	for _, want := range []string{"Coverage", "archive", "ignore_rule", "Recent failures", "broken.pdf", "auth.log"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("status text missing %q\n---\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "hunter2supersecret") {
+		t.Errorf("status text leaked a credential from a failure message:\n%s", got)
+	}
+	if !strings.Contains(got, "[REDACTED]") {
+		t.Errorf("status text did not redact the credential:\n%s", got)
+	}
+}
+
+// TestRenderStatus_JSONIncludesSkipSummaryAndFailures verifies --json carries
+// the skip_summary inside the snapshot and an additive recent_failures array
+// with redacted messages.
+func TestRenderStatus_JSONIncludesSkipSummaryAndFailures(t *testing.T) {
+	var out bytes.Buffer
+	app := NewAppWithIO(&out, &bytes.Buffer{})
+
+	code := app.renderStatusOutput(globalOptions{jsonOutput: true}, "/state", skipSnapshot(), "computed", false, failuresFixture())
+	if code != exitSuccess {
+		t.Fatalf("renderStatusOutput code = %d, want %d", code, exitSuccess)
+	}
+
+	var payload struct {
+		Snapshot struct {
+			Indexing struct {
+				SkipSummary *model.SkipSummary `json:"skip_summary"`
+			} `json:"indexing"`
+		} `json:"snapshot"`
+		RecentFailures []map[string]interface{} `json:"recent_failures"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal status json: %v\n%s", err, out.String())
+	}
+	if payload.Snapshot.Indexing.SkipSummary == nil {
+		t.Fatalf("snapshot.indexing.skip_summary missing:\n%s", out.String())
+	}
+	if payload.Snapshot.Indexing.SkipSummary.Categories[model.SkipReasonArchive] != 2 {
+		t.Errorf("skip_summary archive count = %d, want 2", payload.Snapshot.Indexing.SkipSummary.Categories[model.SkipReasonArchive])
+	}
+	if len(payload.RecentFailures) != 2 {
+		t.Fatalf("recent_failures len = %d, want 2:\n%s", len(payload.RecentFailures), out.String())
+	}
+	if msg, _ := payload.RecentFailures[1]["error_message"].(string); strings.Contains(msg, "hunter2supersecret") {
+		t.Errorf("recent_failures json leaked a credential: %q", msg)
+	}
+}
+
+// TestRenderStatus_HealthyCorpusOmitsBlocks verifies a corpus with nothing
+// skipped and no failures renders neither the Coverage nor the Recent failures
+// block, and emits no recent_failures field in JSON.
+func TestRenderStatus_HealthyCorpusOmitsBlocks(t *testing.T) {
+	healthy := corpusSnapshot{
+		Timestamp: "2026-07-07T00:00:00Z",
+		Indexing:  corpusIndexing{Mode: "incremental"},
+		DocCounts: map[string]int64{"text": 1},
+		TotalDocs: 1,
+	}
+
+	var textOut bytes.Buffer
+	app := NewAppWithIO(&textOut, &bytes.Buffer{})
+	app.renderStatusOutput(globalOptions{}, "/state", healthy, "computed", false, nil)
+	if s := textOut.String(); strings.Contains(s, "Coverage") || strings.Contains(s, "Recent failures") {
+		t.Errorf("healthy corpus rendered a skip/failure block:\n%s", s)
+	}
+
+	var jsonOut bytes.Buffer
+	app2 := NewAppWithIO(&jsonOut, &bytes.Buffer{})
+	app2.renderStatusOutput(globalOptions{jsonOutput: true}, "/state", healthy, "computed", false, nil)
+	if strings.Contains(jsonOut.String(), "recent_failures") {
+		t.Errorf("healthy corpus emitted recent_failures in json:\n%s", jsonOut.String())
+	}
+	if strings.Contains(jsonOut.String(), "skip_summary") {
+		t.Errorf("healthy corpus emitted skip_summary in json:\n%s", jsonOut.String())
+	}
+}
+
+// TestFormatSkipBreakdown merges the store's durable SkipSummary with the
+// in-run (non-persisted) path-exclude counts into one stable, sorted line.
+func TestFormatSkipBreakdown(t *testing.T) {
+	if got := formatSkipBreakdown(nil, nil); got != "" {
+		t.Errorf("empty breakdown = %q, want empty", got)
+	}
+	summary := &model.SkipSummary{Categories: map[string]int64{
+		model.SkipReasonArchive: 2,
+		model.SkipReasonSizeCap: 1,
+	}}
+	inRun := map[string]int64{
+		model.SkipReasonPathExcluded: 5,
+		model.SkipReasonArchive:      1, // summed with the durable count
+	}
+	got := formatSkipBreakdown(summary, inRun)
+	want := "archive=3 path_excluded=5 size_cap=1"
+	if got != want {
+		t.Errorf("formatSkipBreakdown = %q, want %q", got, want)
+	}
+}

--- a/internal/ingest/exclude.go
+++ b/internal/ingest/exclude.go
@@ -65,6 +65,58 @@ func RedactSecretsInMessage(msg string, patterns []*regexp.Regexp) string {
 	return out
 }
 
+// highConfidenceCredentialRedactors is the shared safety net of high-confidence
+// credential SHAPES — unambiguous token forms scrubbed from a failure message
+// before it is shown on any diagnostic surface. It is the common base used by
+// both RedactHighConfidenceCredentials (MCP recent_failures) and
+// RedactCredentialsForDisplay (CLI `status`), so the two surfaces cannot drift.
+// It deliberately contains only unambiguous shapes — never a generic
+// `keyword: value` form — so a redaction here never hides the actionable part of
+// an error (SPEC §15.6 recent_failures actionability).
+var highConfidenceCredentialRedactors = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)bearer\s+[A-Za-z0-9._\-+/=]{20,}`),                              // Bearer token
+	regexp.MustCompile(`\b(?:AKIA|ASIA)[0-9A-Z]{16}\b`),                                     // AWS access key (long-term / temporary)
+	regexp.MustCompile(`(?i)\b(?:sk|pk|rk)[-_][A-Za-z0-9_\-]{16,}`),                         // Stripe / OpenAI (sk-proj-…) / Anthropic-style key
+	regexp.MustCompile(`\bgh[pousr]_[A-Za-z0-9_]{20,}`),                                     // GitHub PAT / OAuth
+	regexp.MustCompile(`\bxox[baprs]-[A-Za-z0-9-]{10,}`),                                    // Slack
+	regexp.MustCompile(`eyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-.]{10,}\.[A-Za-z0-9_\-]{5,}`), // JWT
+}
+
+// displayKeyValueRedactor additionally scrubs generic `keyword: value` /
+// `keyword=value` credential assignments. It is applied ONLY on the CLI display
+// surface (RedactCredentialsForDisplay), where redacting `password=hunter2` in
+// the operator's terminal is worth the small risk of also masking a benign
+// `token: expired` — a tradeoff the MCP recent_failures surface deliberately
+// does not make (it feeds a client that needs the actionable failure text).
+var displayKeyValueRedactor = regexp.MustCompile(`(?i)(authorization|api[_-]?key|token|secret|password|passwd)\s*[:=]\s*\S+`)
+
+func applyRedactors(msg string, redactors []*regexp.Regexp) string {
+	if msg == "" {
+		return msg
+	}
+	for _, rx := range redactors {
+		msg = rx.ReplaceAllString(msg, "[REDACTED]")
+	}
+	return msg
+}
+
+// RedactHighConfidenceCredentials replaces any substring matching a
+// high-confidence credential shape with "[REDACTED]". Used by the MCP
+// recent_failures surface (SPEC §15.6 "error_message MUST NOT contain secrets").
+// Returns msg unchanged when nothing matches.
+func RedactHighConfidenceCredentials(msg string) string {
+	return applyRedactors(msg, highConfidenceCredentialRedactors)
+}
+
+// RedactCredentialsForDisplay applies the high-confidence redactors plus the
+// generic `keyword: value` redactor. Used by the CLI `status` coverage report,
+// a human-facing surface that can afford more aggressive scrubbing than the
+// MCP tool output. Returns msg unchanged when nothing matches.
+func RedactCredentialsForDisplay(msg string) string {
+	msg = applyRedactors(msg, highConfidenceCredentialRedactors)
+	return applyRedactors(msg, []*regexp.Regexp{displayKeyValueRedactor})
+}
+
 func matchesAnyPathExclude(relPath string, globs []string) bool {
 	return MatchesAnyPathExclude(relPath, globs)
 }

--- a/internal/ingest/redact_test.go
+++ b/internal/ingest/redact_test.go
@@ -1,0 +1,69 @@
+package ingest
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRedactHighConfidenceCredentials pins the single shared redactor used by
+// both the MCP recent_failures surface and the CLI `status` coverage report
+// (#414 review consolidation). It must cover every high-confidence shape from
+// both former redactors, and must NOT over-redact benign prose (the generic
+// `keyword: value` shape was deliberately left out to preserve §15.6
+// actionability).
+func TestRedactHighConfidenceCredentials(t *testing.T) {
+	redacted := []struct {
+		name string
+		in   string
+	}{
+		{"bearer", "auth failed: Bearer abcdefghijklmnopqrstuvwxyz0123456789"},
+		{"aws-akia", "creds AKIA1234567890ABCDEF rejected"},
+		{"aws-asia", "temp creds ASIA1234567890ABCDEF rejected"},
+		{"stripe-sk-live", "key sk_live_0123456789ABCDEFghij bad"},
+		{"openai-sk", "key sk-proj-0123456789ABCDEFghij bad"},
+		{"github-pat", "token ghp_0123456789abcdefABCDEF0123 denied"},
+		{"slack", "hook xoxb-0123456789-abcdefABCDEF expired"},
+		{"jwt", "jwt eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.abcdef bad"},
+	}
+	for _, c := range redacted {
+		got := RedactHighConfidenceCredentials(c.in)
+		if !strings.Contains(got, "[REDACTED]") {
+			t.Errorf("%s: expected redaction, got %q", c.name, got)
+		}
+	}
+
+	// The high-confidence base must NOT redact generic `keyword value` prose (no
+	// `:`/`=` assignment) — that preserves §15.6 actionability on the MCP surface.
+	keep := []string{
+		"the token expired 3 hours ago",
+		"password authentication failed for user alice",
+		"connection refused after 3 retries",
+	}
+	for _, msg := range keep {
+		if got := RedactHighConfidenceCredentials(msg); got != msg {
+			t.Errorf("base over-redacted benign message %q -> %q", msg, got)
+		}
+	}
+
+	if got := RedactHighConfidenceCredentials(""); got != "" {
+		t.Errorf("empty input should return empty, got %q", got)
+	}
+}
+
+// TestRedactCredentialsForDisplay pins that the CLI display variant additionally
+// scrubs generic `keyword=value` credential assignments (a real terminal leak),
+// while the MCP high-confidence base leaves them for actionability.
+func TestRedactCredentialsForDisplay(t *testing.T) {
+	leak := "auth failed password=hunter2supersecret"
+	if got := RedactCredentialsForDisplay(leak); strings.Contains(got, "hunter2supersecret") {
+		t.Errorf("display variant leaked credential: %q", got)
+	}
+	// Same input on the base (MCP) surface is intentionally left actionable.
+	if got := RedactHighConfidenceCredentials(leak); !strings.Contains(got, "hunter2supersecret") {
+		t.Errorf("base unexpectedly redacted generic keyword=value: %q", got)
+	}
+	// The display variant still inherits every high-confidence shape.
+	if got := RedactCredentialsForDisplay("key ghp_0123456789abcdefABCDEF0123 denied"); !strings.Contains(got, "[REDACTED]") {
+		t.Errorf("display variant missed a high-confidence shape: %q", got)
+	}
+}

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -266,6 +266,17 @@ type Service struct {
 	// transcript. The split changes ordering and reporting only, never the final
 	// representations/chunks/embeddings/citations.
 	activePass processPass
+
+	// runSkipReasons counts path-excluded drops by skip_reason for the CURRENT
+	// scan only. Path-excludes can be numerous (a broad glob can drop thousands
+	// of files), so — unlike archive/secret/size-cap skips — they are NOT
+	// persisted as documents rows; they live here for the run and are surfaced
+	// via SkipReasonCounts() merged into the reindex summary. This makes them a
+	// best-effort, in-process signal: the count is NOT durable across a restart
+	// and is not visible to a separate `status` process reading the store.
+	// Reset at the start of each runScan.
+	runSkipReasons   map[string]int64
+	runSkipReasonsMu sync.Mutex
 }
 
 // processPass is the per-asset work selector for the optional two-phase pass
@@ -1183,6 +1194,11 @@ func (s *Service) runScan(ctx context.Context) error {
 	if s.indexingState != nil {
 		s.indexingState.ResetProgress()
 	}
+	// Reset the in-run per-reason skip counter so each scan reports only its own
+	// path-excluded drops (these are not persisted; see runSkipReasons).
+	s.runSkipReasonsMu.Lock()
+	s.runSkipReasons = nil
+	s.runSkipReasonsMu.Unlock()
 
 	discoverOpts := DiscoverOptionsFromConfig(s.cfg)
 	// Attach the optional directory-discovery scan cache (issue #267 item 5) for
@@ -1206,9 +1222,16 @@ func (s *Service) runScan(ctx context.Context) error {
 		capBytes = corpusfs.DefaultMaxFileSizeBytes()
 	}
 	capMB := float64(capBytes) / (1024 * 1024)
+	// Persist a minimal skipped row for each size-capped file (skip_reason=
+	// size_cap) so the honest-coverage aggregate (CorpusStats.SkipSummary)
+	// reports *why* it was not indexed, not just that skipped>0 (#414/#497).
+	// Collected here and upserted after `seen` is built so those rows are
+	// registered as seen and markMissingAsDeleted does not tombstone them.
+	oversize := make(map[string]int64)
 	discoverOpts.OnOversize = func(relPath string, size int64) {
 		s.addScanned(1)
 		s.addSkipped(1)
+		oversize[relPath] = size
 		s.getLogger().Printf(
 			"discovery: skipping %s (%d bytes) — exceeds ingest.max_file_mb cap (%.0f MB); raise ingest.max_file_mb to include it",
 			relPath, size, capMB,
@@ -1251,6 +1274,10 @@ func (s *Service) runScan(ctx context.Context) error {
 	}()
 
 	seen := make(map[string]struct{}, len(discovered))
+
+	// Register size-capped drops as durable skipped rows before the pass(es)
+	// run so they survive markMissingAsDeleted and feed the coverage aggregate.
+	s.persistOversizeSkips(ctx, oversize, seen)
 
 	// Optional two-phase pass split (SPEC §8.6.11): run media ingest as two ordered
 	// passes over the corpus — a transcription pass (STT/sidecar → source
@@ -1311,6 +1338,7 @@ func (s *Service) scanPass(ctx context.Context, pass processPass, discovered []D
 		if matchesAnyPathExclude(f.RelPath, s.cfg.PathExcludes) {
 			if countCorpus {
 				s.addSkipped(1)
+				s.addRunSkipReason(model.SkipReasonPathExcluded)
 			}
 			if outcome != nil {
 				outcome.markSkipped()
@@ -2145,10 +2173,12 @@ func (s *Service) processDocumentFromContent(ctx context.Context, relPath string
 	}
 	if skipExtraction {
 		doc.Status = "skipped"
+		doc.SkipReason = skipReasonForDocType(docType)
 	}
 
 	if !skipExtraction && hasSecretMatch(contentSample(content), secretPatterns) {
 		doc.Status = "secret_excluded"
+		doc.SkipReason = model.SkipReasonSecretExcluded
 	}
 
 	existingDoc, err := s.store.GetDocumentByPath(ctx, relPath)
@@ -2236,14 +2266,55 @@ func (s *Service) buildDocumentWithContent(ctx context.Context, f DiscoveredFile
 	// enter the pipeline.
 	if docType == "archive" || docType == "binary_ignored" || docType == "ignore" {
 		doc.Status = "skipped"
+		doc.SkipReason = skipReasonForDocType(docType)
 		return doc, content, nil
 	}
 
 	if hasSecretMatch(contentSample(content), secretPatterns) {
 		doc.Status = "secret_excluded"
+		doc.SkipReason = model.SkipReasonSecretExcluded
 	}
 
 	return doc, content, nil
+}
+
+// persistOversizeSkips upserts a minimal skipped document row for each file
+// dropped at discovery for exceeding the ingest size cap (#497), stamping
+// skip_reason=size_cap so CorpusStats.SkipSummary can report it. Each path is
+// also registered in seen so markMissingAsDeleted (which runs after the scan)
+// does not tombstone the freshly-persisted row. Best-effort per path: a failed
+// upsert is logged and skipped rather than aborting the whole scan.
+func (s *Service) persistOversizeSkips(ctx context.Context, oversize map[string]int64, seen map[string]struct{}) {
+	for relPath, size := range oversize {
+		seen[relPath] = struct{}{}
+		doc := model.Document{
+			RelPath:    relPath,
+			DocType:    ClassifyDocType(relPath),
+			SizeBytes:  size,
+			Status:     "skipped",
+			SkipReason: model.SkipReasonSizeCap,
+		}
+		if err := s.store.UpsertDocument(ctx, doc); err != nil {
+			s.getLogger().Printf("discovery: persist size-cap skip row for %s: %v", relPath, err)
+		}
+	}
+}
+
+// skipReasonForDocType maps a never-ingested doc_type classification to its
+// stable model.SkipReason. It is the single source of truth for the
+// doc_type→skip_reason mapping so the top-level scan and archive-member paths
+// agree. An unrecognized type falls back to unsupported_format.
+func skipReasonForDocType(docType string) string {
+	switch docType {
+	case "archive":
+		return model.SkipReasonArchive
+	case "binary_ignored":
+		return model.SkipReasonBinaryIgnored
+	case "ignore":
+		return model.SkipReasonIgnoreRule
+	default:
+		return model.SkipReasonUnsupportedFormat
+	}
 }
 
 func contentSample(content []byte) []byte {
@@ -2352,6 +2423,35 @@ func (s *Service) addSkipped(delta int64) {
 	if s.indexingState != nil {
 		s.indexingState.AddSkipped(delta)
 	}
+}
+
+// addRunSkipReason increments the in-run, non-persisted per-reason skip counter
+// (currently only path-excludes). Safe for concurrent callers, though the scan
+// loop is sequential today.
+func (s *Service) addRunSkipReason(reason string) {
+	s.runSkipReasonsMu.Lock()
+	defer s.runSkipReasonsMu.Unlock()
+	if s.runSkipReasons == nil {
+		s.runSkipReasons = map[string]int64{}
+	}
+	s.runSkipReasons[reason]++
+}
+
+// SkipReasonCounts returns a copy of the in-run per-reason skip counts recorded
+// during the most recent scan (path-excludes). These are NOT persisted, so they
+// reflect only work this process performed; a fresh `status` process reading the
+// store will not see them. Returns nil when nothing was recorded.
+func (s *Service) SkipReasonCounts() map[string]int64 {
+	s.runSkipReasonsMu.Lock()
+	defer s.runSkipReasonsMu.Unlock()
+	if len(s.runSkipReasons) == 0 {
+		return nil
+	}
+	out := make(map[string]int64, len(s.runSkipReasons))
+	for k, v := range s.runSkipReasons {
+		out[k] = v
+	}
+	return out
 }
 
 func (s *Service) addDeleted(delta int64) {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -13,7 +13,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"regexp"
 	"runtime/debug"
 	"sort"
 	"strings"
@@ -472,33 +471,14 @@ func (s *Server) handleStatsTool(ctx context.Context, args map[string]interface{
 // (SPEC §15.6 "Implementations SHOULD cap at 20 entries by default").
 const statsRecentFailuresLimit = 20
 
-// statsErrorMessageRedactors is a small safety net of common credential
-// shapes applied at the MCP boundary before emitting recent_failures.
-// The write-side already runs the operator's configured
-// `secret_patterns` against err.Error() (see ingest.RedactSecretsInMessage,
-// PR #212) — this is belt-and-suspenders for the cases where the
-// operator hasn't configured any patterns or where a non-SQLite store
-// backend persists raw text. SPEC §15.6: "error_message MUST NOT
-// contain secrets". Kept tight (high-confidence shapes only) to avoid
-// false positives that would hide the actionable failure description.
-var statsErrorMessageRedactors = []*regexp.Regexp{
-	regexp.MustCompile(`(?i)bearer\s+[A-Za-z0-9._\-+/=]{20,}`),
-	regexp.MustCompile(`AKIA[0-9A-Z]{16}`),                                                 // AWS access key
-	regexp.MustCompile(`sk-[A-Za-z0-9_\-]{20,}`),                                           // OpenAI / Mistral / Anthropic style
-	regexp.MustCompile(`gh[pousr]_[A-Za-z0-9_]{20,}`),                                      // GitHub PAT / OAuth
-	regexp.MustCompile(`xox[baprs]-[A-Za-z0-9-]{10,}`),                                     // Slack
-	regexp.MustCompile(`eyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-.]{10,}\.[A-Za-z0-9_\-]{5,}`), // JWT
-}
-
-// redactStatsErrorMessage runs the high-confidence credential
-// redactors over msg, replacing each match with the literal
-// "[REDACTED]". Returns msg unchanged when no pattern matches.
-func redactStatsErrorMessage(msg string) string {
-	for _, rx := range statsErrorMessageRedactors {
-		msg = rx.ReplaceAllString(msg, "[REDACTED]")
-	}
-	return msg
-}
+// Credential redaction for recent_failures error_message (SPEC §15.6
+// "error_message MUST NOT contain secrets") is the shared
+// ingest.RedactHighConfidenceCredentials — the same high-confidence safety net
+// the CLI `status` coverage report uses, so the two surfaces cannot drift. The
+// write-side already runs the operator's configured `secret_patterns` against
+// err.Error() (ingest.RedactSecretsInMessage, PR #212); this is
+// belt-and-suspenders for when no patterns are configured or a non-SQLite store
+// persisted raw text.
 
 // loadRecentFailuresForStats returns the per-doc projection emitted in
 // dir2mcp_stats's optional recent_failures array: rel_path, doc_type,
@@ -536,7 +516,7 @@ func loadRecentFailuresForStats(ctx context.Context, st model.Store) []map[strin
 			"rel_path":      d.RelPath,
 			"doc_type":      d.DocType,
 			"mtime_unix":    d.MTimeUnix,
-			"error_message": redactStatsErrorMessage(d.ErrorMessage),
+			"error_message": ingest.RedactHighConfidenceCredentials(d.ErrorMessage),
 		})
 	}
 	return out

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -41,7 +41,46 @@ type Document struct {
 	// output (that schema is fixed by SPEC §15.5 with
 	// additionalProperties:false); it is a diagnostic-bundle field.
 	ErrorMessage string
+	// SkipReason is the stable classification of *why* a document was
+	// recorded as skipped (never indexed) rather than ingested — one of
+	// the SkipReason* constants below. Empty for ingested ("ok") and
+	// errored documents; populated only on status="skipped" /
+	// "secret_excluded" rows. Aggregated into CorpusStats.SkipSummary so
+	// `status`/`reindex` can report honest coverage ("what wasn't indexed
+	// & why", #414/#395). It is a plain string (mirroring
+	// FailureSummary.Categories) so the model package does not depend on
+	// internal/store.
+	SkipReason string
 }
+
+// SkipReason* enumerate the stable reasons a discovered file is recorded as
+// skipped (never indexed) rather than ingested or errored. Persisted in
+// documents.skip_reason and grouped by CorpusStats.SkipSummary. Kept as plain
+// string constants so callers across packages share one vocabulary without an
+// import cycle back to internal/store.
+const (
+	// SkipReasonUnsupportedFormat: the file's format has no configured
+	// extractor/OCR/transcriber path (e.g. .odt/.rtf without a reader).
+	SkipReasonUnsupportedFormat = "unsupported_format"
+	// SkipReasonBinaryIgnored: a binary artifact classified as non-textual
+	// and deliberately not ingested.
+	SkipReasonBinaryIgnored = "binary_ignored"
+	// SkipReasonArchive: an archive container persisted as a skipped row; its
+	// members are extracted separately and are not directly indexable.
+	SkipReasonArchive = "archive"
+	// SkipReasonIgnoreRule: a file matched a built-in ignore classification
+	// (e.g. .env variants) and was excluded from the pipeline.
+	SkipReasonIgnoreRule = "ignore_rule"
+	// SkipReasonSecretExcluded: content matched a secret pattern, so the file
+	// was excluded from ingestion (status="secret_excluded").
+	SkipReasonSecretExcluded = "secret_excluded"
+	// SkipReasonPathExcluded: the rel_path matched a configured path-exclude
+	// glob and was dropped at scan time (no durable row is persisted).
+	SkipReasonPathExcluded = "path_excluded"
+	// SkipReasonSizeCap: the file exceeded ingest.max_file_mb and was dropped
+	// at discovery.
+	SkipReasonSizeCap = "size_cap"
+)
 
 type Representation struct {
 	RepID       int64
@@ -507,6 +546,30 @@ type CorpusStats struct {
 	// so existing consumers continue to see a flat shape on healthy
 	// corpora.
 	FailureSummary *FailureSummary `json:"failure_summary,omitempty"`
+	// SkipSummary groups documents that were recorded as skipped (never
+	// indexed) by their SkipReason ("archive", "secret_excluded",
+	// "unsupported_format", …) plus a small sample of representative
+	// {rel_path, reason} pairs. It is the honest-coverage surface (#414/#395):
+	// "what wasn't indexed & why". Omitted from JSON when nothing was skipped
+	// so healthy corpora keep a flat shape. Only durably-persisted skip rows
+	// contribute here; discovery-time drops that persist no row (path-excludes)
+	// are surfaced separately by the in-run reindex summary.
+	SkipSummary *SkipSummary `json:"skip_summary,omitempty"`
+}
+
+// SkipSummary aggregates skipped (never-indexed) documents for honest-coverage
+// reporting. Categories is keyed by the string form of model.SkipReason* (kept
+// as plain map[string]int64 so the model package needs no store dependency).
+type SkipSummary struct {
+	Categories map[string]int64 `json:"categories"`
+	Samples    []SkipSample     `json:"samples,omitempty"`
+}
+
+// SkipSample is one representative skipped document: enough to see which files
+// a given reason applies to without dumping the whole documents table.
+type SkipSample struct {
+	RelPath string `json:"rel_path"`
+	Reason  string `json:"reason"`
 }
 
 // FailureSummary aggregates chunk embedding errors for diagnostics.

--- a/internal/store/skip_summary.go
+++ b/internal/store/skip_summary.go
@@ -1,0 +1,97 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// skipSummaryMaxSamples bounds how many representative skipped documents we
+// surface to status / reindex / support-bundle consumers. Small on purpose:
+// the diagnostic value comes from spotting *which* reason dominates coverage
+// gaps, not from dumping every skipped rel_path.
+const skipSummaryMaxSamples = 10
+
+// loadSkipSummary aggregates never-indexed (skipped) documents by skip_reason
+// and collects up to maxSamples representative {rel_path, reason} rows. It is
+// the durable half of the honest-coverage surface (#414/#395): only documents
+// persisted with status IN ('skipped','secret_excluded') contribute — the
+// same lifecycle set CorpusStats counts as Skipped. Returns nil when nothing
+// was skipped so CorpusStats.SkipSummary stays omitted from the JSON.
+func loadSkipSummary(ctx context.Context, db *sql.DB, maxSamples int) (*model.SkipSummary, error) {
+	categories, err := loadSkipCategories(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	if len(categories) == 0 {
+		return nil, nil
+	}
+	samples, err := loadSkipSamples(ctx, db, maxSamples)
+	if err != nil {
+		return nil, err
+	}
+	return &model.SkipSummary{Categories: categories, Samples: samples}, nil
+}
+
+// loadSkipCategories returns a count of skipped documents per skip_reason. An
+// empty reason (rows persisted before the column existed, or a skip site that
+// left it unset) is normalized to "unknown" so consumers don't have to.
+func loadSkipCategories(ctx context.Context, db *sql.DB) (map[string]int64, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT COALESCE(NULLIF(skip_reason, ''), 'unknown') AS reason, COUNT(*) AS n
+		FROM documents
+		WHERE deleted = 0 AND status IN ('skipped', 'secret_excluded')
+		GROUP BY reason
+		ORDER BY n DESC`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := map[string]int64{}
+	for rows.Next() {
+		var reason string
+		var count int64
+		if err := rows.Scan(&reason, &count); err != nil {
+			return nil, err
+		}
+		out[reason] = count
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// loadSkipSamples returns up to maxSamples skipped documents with rel_path /
+// reason. Ordered by reason then rel_path so the sample distribution favours
+// coverage across reasons rather than dumping the first N of one type.
+func loadSkipSamples(ctx context.Context, db *sql.DB, maxSamples int) ([]model.SkipSample, error) {
+	if maxSamples <= 0 {
+		return nil, nil
+	}
+	rows, err := db.QueryContext(ctx, `
+		SELECT rel_path, COALESCE(NULLIF(skip_reason, ''), 'unknown') AS reason
+		FROM documents
+		WHERE deleted = 0 AND status IN ('skipped', 'secret_excluded')
+		ORDER BY reason, rel_path
+		LIMIT ?`, maxSamples)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := make([]model.SkipSample, 0, maxSamples)
+	for rows.Next() {
+		var sample model.SkipSample
+		if err := rows.Scan(&sample.RelPath, &sample.Reason); err != nil {
+			return nil, err
+		}
+		out = append(out, sample)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -478,6 +478,14 @@ func applyAdditiveColumnMigrations(ctx context.Context, db *sql.DB) error {
 		// specific filter, so a corpus indexed before any language was recorded
 		// simply has empty values here (no migration of existing rows needed, §9.5).
 		`ALTER TABLE chunks ADD COLUMN language TEXT NOT NULL DEFAULT ''`,
+		// skip_reason records *why* a document was recorded as skipped (never
+		// indexed) rather than ingested — one of the model.SkipReason* strings
+		// ("archive", "binary_ignored", "ignore_rule", "secret_excluded",
+		// "unsupported_format", …). Empty for ingested ("ok") and errored rows.
+		// Aggregated into CorpusStats.SkipSummary so status/reindex can report
+		// honest coverage ("what wasn't indexed & why", #414/#395). Existing rows
+		// default to '' (unknown reason), which the aggregate normalizes.
+		`ALTER TABLE documents ADD COLUMN skip_reason TEXT NOT NULL DEFAULT ''`,
 	}
 	for _, stmt := range migrations {
 		if _, err := db.ExecContext(ctx, stmt); err != nil && !isDuplicateColumnError(err) {
@@ -529,7 +537,8 @@ CREATE TABLE IF NOT EXISTS documents (
   etag TEXT NOT NULL DEFAULT '',
   sidecar_fingerprint TEXT NOT NULL DEFAULT '',
   status TEXT NOT NULL DEFAULT 'ok',
-  deleted INTEGER NOT NULL DEFAULT 0
+  deleted INTEGER NOT NULL DEFAULT 0,
+  skip_reason TEXT NOT NULL DEFAULT ''
 );
 
 CREATE TABLE IF NOT EXISTS representations (
@@ -726,8 +735,8 @@ func (s *SQLiteStore) UpsertDocument(ctx context.Context, doc model.Document) er
 	// such two-phase write, so the always-replace semantics are correct.
 	_, err = db.ExecContext(
 		ctx,
-		`INSERT INTO documents(rel_path, doc_type, source_type, size_bytes, mtime_unix, content_hash, etag, sidecar_fingerprint, status, deleted, title, error_message)
-		 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`INSERT INTO documents(rel_path, doc_type, source_type, size_bytes, mtime_unix, content_hash, etag, sidecar_fingerprint, status, deleted, title, error_message, skip_reason)
+		 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		 ON CONFLICT(rel_path) DO UPDATE SET
 		   doc_type=excluded.doc_type,
 		   source_type=excluded.source_type,
@@ -739,7 +748,8 @@ func (s *SQLiteStore) UpsertDocument(ctx context.Context, doc model.Document) er
 		   status=excluded.status,
 		   deleted=excluded.deleted,
 		   title=CASE WHEN excluded.title <> '' THEN excluded.title ELSE documents.title END,
-		   error_message=excluded.error_message`,
+		   error_message=excluded.error_message,
+		   skip_reason=excluded.skip_reason`,
 		relPath,
 		normalizeDocType(doc.DocType),
 		normalizeSourceType(doc.SourceType),
@@ -752,6 +762,7 @@ func (s *SQLiteStore) UpsertDocument(ctx context.Context, doc model.Document) er
 		boolToInt(doc.Deleted),
 		strings.TrimSpace(doc.Title),
 		sanitizeDocErrorMessage(doc.ErrorMessage),
+		strings.TrimSpace(doc.SkipReason),
 	)
 	return err
 }
@@ -1738,7 +1749,7 @@ func (s *SQLiteStore) GetDocumentByPath(ctx context.Context, relPath string) (mo
 	var deleted int
 	row := db.QueryRowContext(
 		ctx,
-		`SELECT doc_id, rel_path, doc_type, source_type, size_bytes, mtime_unix, content_hash, etag, sidecar_fingerprint, status, deleted, title, error_message
+		`SELECT doc_id, rel_path, doc_type, source_type, size_bytes, mtime_unix, content_hash, etag, sidecar_fingerprint, status, deleted, title, error_message, skip_reason
 		 FROM documents WHERE rel_path = ?`,
 		normalizedPath,
 	)
@@ -1756,6 +1767,7 @@ func (s *SQLiteStore) GetDocumentByPath(ctx context.Context, relPath string) (mo
 		&deleted,
 		&doc.Title,
 		&doc.ErrorMessage,
+		&doc.SkipReason,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return model.Document{}, os.ErrNotExist
@@ -1783,7 +1795,7 @@ func (s *SQLiteStore) ListFiles(ctx context.Context, prefix, glob string, limit,
 	normalizedPrefix := model.NormalizePathPrefix(prefix)
 	trimmedGlob := strings.TrimSpace(glob)
 
-	selectCols := `SELECT doc_id, rel_path, doc_type, source_type, size_bytes, mtime_unix, content_hash, etag, sidecar_fingerprint, status, deleted, title, error_message FROM documents`
+	selectCols := `SELECT doc_id, rel_path, doc_type, source_type, size_bytes, mtime_unix, content_hash, etag, sidecar_fingerprint, status, deleted, title, error_message, skip_reason FROM documents`
 	where := []string{"deleted = 0"}
 	prefixArgs := make([]any, 0, 1)
 	if normalizedPrefix != "" {
@@ -1897,6 +1909,7 @@ func scanListFilesRow(rows *sql.Rows) (model.Document, error) {
 		&deleted,
 		&doc.Title,
 		&doc.ErrorMessage,
+		&doc.SkipReason,
 	); err != nil {
 		return model.Document{}, err
 	}
@@ -1926,7 +1939,7 @@ func (s *SQLiteStore) RecentFailures(ctx context.Context, limit int) ([]model.Do
 
 	rows, err := db.QueryContext(
 		ctx,
-		`SELECT doc_id, rel_path, doc_type, source_type, size_bytes, mtime_unix, content_hash, etag, sidecar_fingerprint, status, deleted, title, error_message
+		`SELECT doc_id, rel_path, doc_type, source_type, size_bytes, mtime_unix, content_hash, etag, sidecar_fingerprint, status, deleted, title, error_message, skip_reason
 		 FROM documents
 		 WHERE status = 'error' AND deleted = 0
 		 ORDER BY mtime_unix DESC, rel_path ASC
@@ -1956,6 +1969,7 @@ func (s *SQLiteStore) RecentFailures(ctx context.Context, limit int) ([]model.Do
 			&deleted,
 			&doc.Title,
 			&doc.ErrorMessage,
+			&doc.SkipReason,
 		); err != nil {
 			return nil, err
 		}
@@ -2039,6 +2053,12 @@ func (s *SQLiteStore) CorpusStats(ctx context.Context) (model.CorpusStats, error
 		return model.CorpusStats{}, err
 	}
 	stats.FailureSummary = summary
+
+	skipSummary, err := loadSkipSummary(ctx, db, skipSummaryMaxSamples)
+	if err != nil {
+		return model.CorpusStats{}, err
+	}
+	stats.SkipSummary = skipSummary
 
 	return stats, nil
 }

--- a/tests/ingest/skip_reason_coverage_test.go
+++ b/tests/ingest/skip_reason_coverage_test.go
@@ -1,0 +1,145 @@
+package tests
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/appstate"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// TestSkipReasonCoverage is the honest-coverage regression guard for #414: a
+// corpus mixing every skip class must record a stable, distinguishable
+// skip_reason on each persisted row, the CorpusStats.SkipSummary aggregate must
+// group them, and the numerous path-excluded drop (which persists no row) must
+// surface via the ingestor's in-run per-reason counter instead.
+func TestSkipReasonCoverage(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+
+	// An ingestable file (indexed, no skip_reason).
+	writeCorpusFile(t, root, "notes.txt", []byte("just some plain prose that indexes fine"))
+	// An archive container -> skip_reason=archive.
+	writeCorpusFile(t, root, "bundle.zip", emptyZip(t))
+	// A .env file -> classified "ignore" -> skip_reason=ignore_rule.
+	writeCorpusFile(t, root, ".env", []byte("HARMLESS=1\n"))
+	// A file whose content matches a secret pattern -> skip_reason=secret_excluded.
+	writeCorpusFile(t, root, "creds.txt", []byte("value TOPSECRETTOKEN here"))
+	// An over-cap file dropped at discovery -> skip_reason=size_cap.
+	writeCorpusFile(t, root, "big.bin", bytes.Repeat([]byte("x"), 2*1024*1024))
+	// A path-excluded file -> counted in-run, NOT persisted.
+	writeCorpusFile(t, root, filepath.Join("skipdir", "ignored.txt"), []byte("excluded by glob"))
+
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("store init: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+
+	cfg := config.Default()
+	cfg.RootDir = root
+	cfg.STTProvider = "off"
+	cfg.IngestMaxFileMB = 1 // the 2 MiB file must be dropped
+	cfg.SecretPatterns = []string{"TOPSECRETTOKEN"}
+	cfg.PathExcludes = []string{"skipdir/**"}
+
+	svc := mustNewIngestService(t, cfg, st)
+	svc.SetIndexingState(appstate.NewIndexingState(appstate.ModeIncremental))
+	if err := svc.Run(ctx); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Each persisted skip row carries its stable reason.
+	assertSkipReason(t, ctx, st, "bundle.zip", "skipped", model.SkipReasonArchive)
+	assertSkipReason(t, ctx, st, ".env", "skipped", model.SkipReasonIgnoreRule)
+	assertSkipReason(t, ctx, st, "creds.txt", "secret_excluded", model.SkipReasonSecretExcluded)
+	assertSkipReason(t, ctx, st, "big.bin", "skipped", model.SkipReasonSizeCap)
+
+	// The ingestable file is NOT skipped and carries no skip_reason.
+	if doc, err := st.GetDocumentByPath(ctx, "notes.txt"); err != nil {
+		t.Fatalf("GetDocumentByPath(notes.txt): %v", err)
+	} else if doc.SkipReason != "" {
+		t.Errorf("notes.txt skip_reason = %q, want empty", doc.SkipReason)
+	}
+
+	// The path-excluded file persists no row.
+	if _, err := st.GetDocumentByPath(ctx, "skipdir/ignored.txt"); err == nil {
+		t.Errorf("skipdir/ignored.txt should not have a persisted row (path-excluded)")
+	}
+
+	// The durable aggregate groups the persisted skips.
+	stats, err := st.CorpusStats(ctx)
+	if err != nil {
+		t.Fatalf("CorpusStats: %v", err)
+	}
+	if stats.SkipSummary == nil {
+		t.Fatalf("SkipSummary = nil, want populated")
+	}
+	for reason, want := range map[string]int64{
+		model.SkipReasonArchive:        1,
+		model.SkipReasonIgnoreRule:     1,
+		model.SkipReasonSecretExcluded: 1,
+		model.SkipReasonSizeCap:        1,
+	} {
+		if got := stats.SkipSummary.Categories[reason]; got != want {
+			t.Errorf("SkipSummary.Categories[%q] = %d, want %d (full=%+v)", reason, got, want, stats.SkipSummary.Categories)
+		}
+	}
+	// path_excluded is NOT durable, so it must not appear in the store aggregate.
+	if got := stats.SkipSummary.Categories[model.SkipReasonPathExcluded]; got != 0 {
+		t.Errorf("SkipSummary should not contain path_excluded (non-persisted), got %d", got)
+	}
+
+	// The in-run counter surfaces the path-excluded drop.
+	inRun := svc.SkipReasonCounts()
+	if inRun[model.SkipReasonPathExcluded] != 1 {
+		t.Errorf("SkipReasonCounts()[path_excluded] = %d, want 1 (full=%+v)", inRun[model.SkipReasonPathExcluded], inRun)
+	}
+
+	// No file in this corpus should have errored.
+	if stats.Errors != 0 {
+		t.Errorf("CorpusStats.Errors = %d, want 0", stats.Errors)
+	}
+}
+
+func assertSkipReason(t *testing.T, ctx context.Context, st *store.SQLiteStore, relPath, wantStatus, wantReason string) {
+	t.Helper()
+	doc, err := st.GetDocumentByPath(ctx, relPath)
+	if err != nil {
+		t.Fatalf("GetDocumentByPath(%s): %v", relPath, err)
+	}
+	if doc.Status != wantStatus {
+		t.Errorf("%s status = %q, want %q", relPath, doc.Status, wantStatus)
+	}
+	if doc.SkipReason != wantReason {
+		t.Errorf("%s skip_reason = %q, want %q", relPath, doc.SkipReason, wantReason)
+	}
+}
+
+func writeCorpusFile(t *testing.T, root, rel string, content []byte) {
+	t.Helper()
+	full := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatalf("mkdir for %s: %v", rel, err)
+	}
+	if err := os.WriteFile(full, content, 0o600); err != nil {
+		t.Fatalf("write %s: %v", rel, err)
+	}
+}
+
+// emptyZip returns the bytes of a valid, empty zip archive.
+func emptyZip(t *testing.T) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	if err := zw.Close(); err != nil {
+		t.Fatalf("close zip: %v", err)
+	}
+	return buf.Bytes()
+}

--- a/tests/security/cli_boundary_test.go
+++ b/tests/security/cli_boundary_test.go
@@ -198,6 +198,7 @@ func TestRepoSplitBoundary_InternalCLIFileOwnership(t *testing.T) {
 		"service_other.go":                       {},
 		"service_test.go":                        {},
 		"status.go":                              {},
+		"status_coverage_test.go":                {},
 		"style.go":                               {},
 		"support_bundle.go":                      {},
 		"support_bundle_internal_test.go":        {},

--- a/tests/store/skip_reason_roundtrip_test.go
+++ b/tests/store/skip_reason_roundtrip_test.go
@@ -1,0 +1,139 @@
+package tests
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// TestSQLiteStore_SkipReasonRoundtrip pins the persistence of the additive
+// documents.skip_reason column (#414): it round-trips through both
+// GetDocumentByPath and ListFiles, and re-opening the same database file (which
+// re-runs the additive migration) is a no-op rather than an error, proving the
+// migration is idempotent.
+func TestSQLiteStore_SkipReasonRoundtrip(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "meta.sqlite")
+
+	st := store.NewSQLiteStore(dbPath)
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	doc := model.Document{
+		RelPath:    "vendor/lib.zip",
+		DocType:    "archive",
+		SizeBytes:  4096,
+		MTimeUnix:  1_700_000_000,
+		Status:     "skipped",
+		SkipReason: model.SkipReasonArchive,
+	}
+	if err := st.UpsertDocument(ctx, doc); err != nil {
+		t.Fatalf("UpsertDocument: %v", err)
+	}
+
+	got, err := st.GetDocumentByPath(ctx, doc.RelPath)
+	if err != nil {
+		t.Fatalf("GetDocumentByPath: %v", err)
+	}
+	if got.SkipReason != model.SkipReasonArchive {
+		t.Errorf("GetDocumentByPath skip_reason = %q, want %q", got.SkipReason, model.SkipReasonArchive)
+	}
+
+	docs, _, err := st.ListFiles(ctx, "", "", 10, 0)
+	if err != nil {
+		t.Fatalf("ListFiles: %v", err)
+	}
+	found := false
+	for _, d := range docs {
+		if d.RelPath == doc.RelPath {
+			found = true
+			if d.SkipReason != model.SkipReasonArchive {
+				t.Errorf("ListFiles skip_reason = %q, want %q", d.SkipReason, model.SkipReasonArchive)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("ListFiles missing %s", doc.RelPath)
+	}
+
+	// Re-opening the same file re-runs applyAdditiveColumnMigrations, which must
+	// treat the already-present skip_reason column as a no-op (idempotent).
+	if err := st.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	st2 := store.NewSQLiteStore(dbPath)
+	if err := st2.Init(ctx); err != nil {
+		t.Fatalf("re-Init (migration idempotency): %v", err)
+	}
+	defer func() { _ = st2.Close() }()
+	got2, err := st2.GetDocumentByPath(ctx, doc.RelPath)
+	if err != nil {
+		t.Fatalf("GetDocumentByPath after reopen: %v", err)
+	}
+	if got2.SkipReason != model.SkipReasonArchive {
+		t.Errorf("skip_reason lost across reopen: %q", got2.SkipReason)
+	}
+}
+
+// TestSQLiteStore_SkipSummary verifies CorpusStats().SkipSummary aggregates
+// never-indexed rows by skip_reason across both the 'skipped' and
+// 'secret_excluded' lifecycle statuses, and is nil on a corpus with nothing
+// skipped so the JSON stays flat.
+func TestSQLiteStore_SkipSummary(t *testing.T) {
+	ctx := context.Background()
+	st := newTempSQLiteStore(t, ctx)
+	defer func() { _ = st.Close() }()
+
+	// Nil when nothing has been skipped.
+	stats, err := st.CorpusStats(ctx)
+	if err != nil {
+		t.Fatalf("CorpusStats (empty): %v", err)
+	}
+	if stats.SkipSummary != nil {
+		t.Errorf("SkipSummary = %+v, want nil on empty corpus", stats.SkipSummary)
+	}
+
+	rows := []model.Document{
+		{RelPath: "a.zip", DocType: "archive", Status: "skipped", SkipReason: model.SkipReasonArchive},
+		{RelPath: "b.zip", DocType: "archive", Status: "skipped", SkipReason: model.SkipReasonArchive},
+		{RelPath: ".env", DocType: "ignore", Status: "skipped", SkipReason: model.SkipReasonIgnoreRule},
+		{RelPath: "creds.txt", DocType: "text", Status: "secret_excluded", SkipReason: model.SkipReasonSecretExcluded},
+		// An ingested doc and an errored doc must NOT contribute to SkipSummary.
+		{RelPath: "ok.txt", DocType: "text", Status: "ok"},
+		{RelPath: "broken.pdf", DocType: "pdf", Status: "error", ErrorMessage: "boom"},
+	}
+	for _, d := range rows {
+		if err := st.UpsertDocument(ctx, d); err != nil {
+			t.Fatalf("UpsertDocument(%s): %v", d.RelPath, err)
+		}
+	}
+
+	stats, err = st.CorpusStats(ctx)
+	if err != nil {
+		t.Fatalf("CorpusStats: %v", err)
+	}
+	if stats.SkipSummary == nil {
+		t.Fatalf("SkipSummary = nil, want populated")
+	}
+	want := map[string]int64{
+		model.SkipReasonArchive:        2,
+		model.SkipReasonIgnoreRule:     1,
+		model.SkipReasonSecretExcluded: 1,
+	}
+	for reason, n := range want {
+		if got := stats.SkipSummary.Categories[reason]; got != n {
+			t.Errorf("SkipSummary.Categories[%q] = %d, want %d", reason, got, n)
+		}
+	}
+	// The ok/error rows must not leak a category into the skip aggregate.
+	if _, ok := stats.SkipSummary.Categories[""]; ok {
+		t.Errorf("SkipSummary leaked an empty-reason category from ok/error rows: %+v", stats.SkipSummary.Categories)
+	}
+	if len(stats.SkipSummary.Samples) == 0 {
+		t.Errorf("SkipSummary.Samples empty, want representative rows")
+	}
+}


### PR DESCRIPTION
## Summary

Implements the spec-neutral honest-coverage (skip-reason) work for #414: dir2mcp now records *why* a document was not indexed and surfaces it in `status`/`reindex`, closing both halves of the issue (skip-reason coverage **and** `recent_failures` in CLI status).

This is CLI/store/ingest-internal only. The §15.6-gated MCP `dir2mcp_stats.skip_reasons` field is **deferred** to a separate spec PR — the MCP tool output schema is untouched here (the stats tool builds its response as an explicit hand-built map, so the new `skip_summary` model field does not leak into it).

## A. Skip-reason enum + column (model + store)
- New `model.SkipReason*` constants (`unsupported_format, binary_ignored, archive, ignore_rule, secret_excluded, path_excluded, size_cap`) as plain strings (no store dependency, mirroring `FailureSummary.Categories`) + a `SkipReason` field on `model.Document`.
- Additive, idempotent `documents.skip_reason` migration; threaded through `UpsertDocument` and **every** documents projection/scan (`GetDocumentByPath`, `ListFiles`, `RecentFailures`) + the CREATE TABLE.

## B. Discovery-time drops
- Size-cap (#497): persists a minimal `status='skipped', skip_reason='size_cap'` row, registered as seen so `markMissingAsDeleted` won't tombstone it.
- Path-excludes (potentially numerous): an **in-run, non-persisted** per-reason counter on the service (`SkipReasonCounts()`), documented as not durable across a restart and invisible to a separate `status` process.

## C. Aggregate
- `CorpusStats.SkipSummary` (parallel to `FailureSummary`): nil-safe, `omitempty`, `Categories map[string]int64` + bounded `Samples`, sourced from a new `loadSkipSummary` over `status IN ('skipped','secret_excluded')`.

## D. CLI surfacing
- `status`: a **Coverage / not-indexed** block (per-reason breakdown) and a **Recent failures** block (rel_path + credential-redacted message), both guarded behind non-empty data and carried through `corpus.json` / `status --json` (`skip_summary` in the snapshot, additive `recent_failures` array).
- `reindex`: final summary appends a per-reason breakdown merging the durable `SkipSummary` with the in-run path-exclude counts.
- The status `DocCounts` overstatement is intentionally left as a separate behavior-change concern.

## Tests
- store: skip_reason round-trips (Get/ListFiles), migration idempotency across reopen, `SkipSummary` groups skipped+secret_excluded and is nil when none.
- ingest: an end-to-end corpus (archive + `.env` + secret file + oversized + path-excluded + an ingestable file) asserting each row's skip_reason, the aggregate, the in-run path-exclude count, and `errors=0`.
- cli: text + json render Coverage and Recent failures with redaction; healthy corpus omits both blocks; `formatSkipBreakdown` merge/sort.

## Verification
- `make lint` → 0 issues; `make cyclo` (gocyclo -over 15) → clean.
- `go test ./internal/store/... ./internal/ingest/... ./internal/cli/... ./tests/cli/... ./tests/store/... ./tests/ingest/...` + `go vet ./...` + mcp suites all pass.

Addresses #414 (MCP `skip_reasons` field deferred to a §15.6 spec PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)