### PR TITLE
service/supervision: crash-only respawn, Linux systemd backend, service-aware down (#434)

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -91,6 +91,13 @@ type App struct {
 	newRetriever func(config.Config, model.Store) model.Retriever
 
 	cachedStyles map[bool]*styles
+
+	// serverGracefulStop is set once the long-running server (up
+	// --foreground / a supervised service) has begun serving, so a
+	// subsequent signal-triggered shutdown is recognized as a normal,
+	// successful termination rather than an interrupted command. See
+	// resolveProcessExitCode (#434).
+	serverGracefulStop bool
 }
 
 type indexingStateAware interface {
@@ -398,7 +405,19 @@ func (a *App) Run(args []string) int {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 	code := a.RunWithContext(ctx, args)
-	if errors.Is(ctx.Err(), context.Canceled) && code == exitSuccess {
+	return resolveProcessExitCode(ctx.Err(), code, a.serverGracefulStop)
+}
+
+// resolveProcessExitCode maps a clean (exitSuccess) return that coincided
+// with a context cancellation to the interrupt exit code — EXCEPT when the
+// cancellation gracefully stopped the long-running server (up --foreground
+// or a supervised launchd/systemd service). A signal-triggered stop of the
+// server is a normal, successful termination and must exit 0, so launchd
+// (KeepAlive SuccessfulExit=false) and systemd (Restart=on-failure) do not
+// mistake a user- or supervisor-requested `down` for a crash and respawn it
+// (#434). A crash still returns its non-zero code untouched.
+func resolveProcessExitCode(ctxErr error, code int, serverGracefulStop bool) int {
+	if errors.Is(ctxErr, context.Canceled) && code == exitSuccess && !serverGracefulStop {
 		return exitSignalInterrupt
 	}
 	return code

--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"os"
 	"strings"
+
+	"github.com/dirstral/dir2mcp/internal/config"
 )
 
 // runDown stops the dir2mcp daemon registered for the current state
@@ -84,16 +86,17 @@ func (a *App) runDown(ctx context.Context, global globalOptions, args []string) 
 	// just stopped will be respawned at next login/boot. Inform the operator
 	// (do NOT auto-uninstall) so `down` in a teardown script isn't mistaken
 	// for a permanent stop (#434).
-	writeDownInfo(a.stdout, global.jsonOutput, cfg.StateDir, pid, true, "stopped", a.corpusServiceManaged(global))
+	writeDownInfo(a.stdout, global.jsonOutput, cfg.StateDir, pid, true, "stopped", a.corpusServiceManaged(cfg))
 	return exitSuccess
 }
 
 // corpusServiceManaged reports whether a launchd/systemd unit is installed
 // for the current corpus. Best-effort: any resolution/backend error (e.g. an
 // unsupported platform) yields false so the informational note is simply
-// omitted and `down` never fails over it.
-func (a *App) corpusServiceManaged(global globalOptions) bool {
-	sc, _, err := a.resolveServiceContext(global, "")
+// omitted and `down` never fails over it. Takes the already-loaded config so it
+// doesn't reload it.
+func (a *App) corpusServiceManaged(cfg config.Config) bool {
+	sc, err := serviceContextFromConfig(cfg, "")
 	if err != nil {
 		return false
 	}

--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -40,18 +40,18 @@ func (a *App) runDown(ctx context.Context, global globalOptions, args []string) 
 	pid, ownership := classifyPIDFile(pidPath)
 	switch ownership {
 	case pidNoFile:
-		writeDownInfo(a.stdout, global.jsonOutput, cfg.StateDir, 0, false, "no_pid_file")
+		writeDownInfo(a.stdout, global.jsonOutput, cfg.StateDir, 0, false, "no_pid_file", false)
 		return exitSuccess
 	case pidMalformed:
 		// Malformed pid file is suspicious — surface and continue cleanup so
 		// `down` always leaves a clean state behind.
 		writef(a.stderr, "warning: pid file %s is malformed; removing it\n", pidPath)
 		_ = removePIDFile(pidPath)
-		writeDownInfo(a.stdout, global.jsonOutput, cfg.StateDir, 0, false, "malformed_pid_file")
+		writeDownInfo(a.stdout, global.jsonOutput, cfg.StateDir, 0, false, "malformed_pid_file", false)
 		return exitSuccess
 	case pidDead:
 		_ = removePIDFile(pidPath)
-		writeDownInfo(a.stdout, global.jsonOutput, cfg.StateDir, pid, false, "stale_pid")
+		writeDownInfo(a.stdout, global.jsonOutput, cfg.StateDir, pid, false, "stale_pid", false)
 		return exitSuccess
 	case pidRecycled:
 		// The recorded pid is alive but its start-time token no longer matches:
@@ -60,7 +60,7 @@ func (a *App) runDown(ctx context.Context, global globalOptions, args []string) 
 		// (issue #418) — so clean up the stale pid file and stop, killing
 		// nothing.
 		_ = removePIDFile(pidPath)
-		writeDownInfo(a.stdout, global.jsonOutput, cfg.StateDir, pid, false, "recycled_pid")
+		writeDownInfo(a.stdout, global.jsonOutput, cfg.StateDir, pid, false, "recycled_pid", false)
 		return exitSuccess
 	}
 
@@ -80,26 +80,54 @@ func (a *App) runDown(ctx context.Context, global globalOptions, args []string) 
 	if err := os.Remove(connPath); err != nil && !errors.Is(err, os.ErrNotExist) {
 		writef(a.stderr, "warning: remove %s: %v\n", connPath, err)
 	}
-	writeDownInfo(a.stdout, global.jsonOutput, cfg.StateDir, pid, true, "stopped")
+	// If this corpus is also under launchd/systemd supervision, the daemon we
+	// just stopped will be respawned at next login/boot. Inform the operator
+	// (do NOT auto-uninstall) so `down` in a teardown script isn't mistaken
+	// for a permanent stop (#434).
+	writeDownInfo(a.stdout, global.jsonOutput, cfg.StateDir, pid, true, "stopped", a.corpusServiceManaged(global))
 	return exitSuccess
+}
+
+// corpusServiceManaged reports whether a launchd/systemd unit is installed
+// for the current corpus. Best-effort: any resolution/backend error (e.g. an
+// unsupported platform) yields false so the informational note is simply
+// omitted and `down` never fails over it.
+func (a *App) corpusServiceManaged(global globalOptions) bool {
+	sc, _, err := a.resolveServiceContext(global, "")
+	if err != nil {
+		return false
+	}
+	mgr, err := newServiceManager()
+	if err != nil {
+		return false
+	}
+	state, err := mgr.status(sc.label)
+	if err != nil {
+		return false
+	}
+	return state.Installed
 }
 
 // writeDownInfo emits the user-facing result of `down`. JSON mode emits a
 // structured object so scripts can branch on the outcome; humans get a
 // short prose line.
-func writeDownInfo(stdout io.Writer, jsonMode bool, stateDir string, pid int, stopped bool, reason string) {
+func writeDownInfo(stdout io.Writer, jsonMode bool, stateDir string, pid int, stopped bool, reason string, serviceManaged bool) {
 	if jsonMode {
 		_ = emitJSON(stdout, map[string]interface{}{
-			"state_dir": stateDir,
-			"pid":       pid,
-			"stopped":   stopped,
-			"reason":    reason,
+			"state_dir":       stateDir,
+			"pid":             pid,
+			"stopped":         stopped,
+			"reason":          reason,
+			"service_managed": serviceManaged,
 		})
 		return
 	}
 	switch reason {
 	case "stopped":
 		writef(stdout, "stopped dir2mcp daemon (pid %d) for %s\n", pid, stateDir)
+		if serviceManaged {
+			writeln(stdout, "note: this corpus is service-managed; it will restart at next login/boot — run `dir2mcp service uninstall` to remove permanently")
+		}
 	case "stale_pid":
 		writef(stdout, "no dir2mcp daemon was running for %s (cleared stale pid %d)\n", stateDir, pid)
 	case "recycled_pid":

--- a/internal/cli/down_internal_test.go
+++ b/internal/cli/down_internal_test.go
@@ -1,0 +1,61 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestWriteDownInfo_ServiceManagedNote pins the #434 down-vs-service
+// contract: after a successful stop of a service-managed corpus, `down`
+// appends an informational note (prose) and sets service_managed=true in the
+// JSON payload — but never auto-uninstalls and keeps exit 0. When the corpus
+// is not service-managed the note is absent and the field is false.
+func TestWriteDownInfo_ServiceManagedNote(t *testing.T) {
+	const note = "service-managed"
+
+	// Text mode, service-managed: the note must appear on a "stopped" result.
+	var managed bytes.Buffer
+	writeDownInfo(&managed, false, "/corpus/.dir2mcp", 4242, true, "stopped", true)
+	if !strings.Contains(managed.String(), note) {
+		t.Errorf("expected a service-managed note, got %q", managed.String())
+	}
+	if !strings.Contains(managed.String(), "service uninstall") {
+		t.Errorf("note should point at `service uninstall`, got %q", managed.String())
+	}
+
+	// Text mode, not service-managed: no note.
+	var plain bytes.Buffer
+	writeDownInfo(&plain, false, "/corpus/.dir2mcp", 4242, true, "stopped", false)
+	if strings.Contains(plain.String(), note) {
+		t.Errorf("did not expect a service-managed note, got %q", plain.String())
+	}
+
+	// A non-stop result (stale pid) must never carry the note even if the flag
+	// were somehow set, because nothing was actually stopped.
+	var stale bytes.Buffer
+	writeDownInfo(&stale, false, "/corpus/.dir2mcp", 4242, false, "stale_pid", true)
+	if strings.Contains(stale.String(), note) {
+		t.Errorf("stale-pid result should not carry a stop note, got %q", stale.String())
+	}
+
+	// JSON mode carries service_managed in the payload (both values).
+	for _, want := range []bool{true, false} {
+		var buf bytes.Buffer
+		writeDownInfo(&buf, true, "/corpus/.dir2mcp", 4242, true, "stopped", want)
+		var payload struct {
+			Stopped        bool `json:"stopped"`
+			ServiceManaged bool `json:"service_managed"`
+		}
+		if err := json.Unmarshal(buf.Bytes(), &payload); err != nil {
+			t.Fatalf("decode down JSON: %v raw=%s", err, buf.String())
+		}
+		if payload.ServiceManaged != want {
+			t.Errorf("service_managed = %v, want %v", payload.ServiceManaged, want)
+		}
+		if !payload.Stopped {
+			t.Errorf("stopped should be true")
+		}
+	}
+}

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -118,6 +118,17 @@ func (a *App) resolveServiceContext(global globalOptions, nameOverride string) (
 	if err != nil {
 		return serviceContext{}, config.Config{}, fmt.Errorf("load config: %w", err)
 	}
+	sc, err := serviceContextFromConfig(cfg, nameOverride)
+	if err != nil {
+		return serviceContext{}, config.Config{}, err
+	}
+	return sc, cfg, nil
+}
+
+// serviceContextFromConfig derives the service context from an already-loaded
+// config, so callers holding a config (e.g. `down`) don't pay a redundant
+// config reload. nameOverride is assumed pre-validated by the caller.
+func serviceContextFromConfig(cfg config.Config, nameOverride string) (serviceContext, error) {
 	name := resolveClaudeServerName(&cfg, nameOverride)
 	abs, err := filepath.Abs(cfg.RootDir)
 	if err != nil {
@@ -132,7 +143,7 @@ func (a *App) resolveServiceContext(global globalOptions, nameOverride string) (
 	}
 	bin, err := os.Executable()
 	if err != nil {
-		return serviceContext{}, config.Config{}, fmt.Errorf("locate dir2mcp executable: %w", err)
+		return serviceContext{}, fmt.Errorf("locate dir2mcp executable: %w", err)
 	}
 	return serviceContext{
 		label:      serviceLabel(name),
@@ -141,7 +152,7 @@ func (a *App) resolveServiceContext(global globalOptions, nameOverride string) (
 		stateDir:   stateDir,
 		binaryPath: bin,
 		logPath:    filepath.Join(stateDir, "service.log"),
-	}, cfg, nil
+	}, nil
 }
 
 // runServiceInstall handles `dir2mcp service install`.
@@ -525,8 +536,12 @@ func renderSystemdExecStart(spec serviceSpec) string {
 	quoted := make([]string, 0, len(tokens))
 	for _, tok := range tokens {
 		esc := iniEscape(tok)
-		if strings.ContainsAny(esc, " \t") {
-			esc = "\"" + esc + "\""
+		// Quote a token containing whitespace or a double quote. Within a
+		// double-quoted token systemd processes \" and \\ escapes, so escape any
+		// embedded quote (iniEscape already doubled backslashes) — otherwise a
+		// path containing " would break out of the quoting and split the command.
+		if strings.ContainsAny(esc, " \t\"") {
+			esc = "\"" + strings.ReplaceAll(esc, `"`, `\"`) + "\""
 		}
 		quoted = append(quoted, esc)
 	}
@@ -539,7 +554,12 @@ func renderSystemdExecStart(spec serviceSpec) string {
 // value containing a carriage return or newline would break the single-line
 // key=value format and is rejected upstream (rejectMultilineSpec); iniEscape
 // assumes that guard has already run.
+// iniEscape makes a value safe to place after `Key=` in a systemd unit. It
+// doubles backslashes first — a value ending in `\` would otherwise act as a
+// line-continuation, and systemd unescapes `\\`→`\` — then doubles `%` (the
+// specifier char). Newlines are rejected upstream by the install path.
 func iniEscape(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
 	return strings.ReplaceAll(s, "%", "%%")
 }
 

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -493,7 +493,12 @@ func renderSystemdUnit(spec serviceSpec) string {
 
 	var b strings.Builder
 	b.WriteString("[Unit]\n")
-	b.WriteString("Description=" + iniEscape("dir2mcp knowledge server ("+spec.Label+")") + "\n\n")
+	b.WriteString("Description=" + iniEscape("dir2mcp knowledge server ("+spec.Label+")") + "\n")
+	// Start-rate limits are UNIT-level directives — systemd ignores them under
+	// [Service] — so a crash-looping unit is capped at 5 starts per 300s and then
+	// held failed instead of hot-looping forever.
+	b.WriteString("StartLimitIntervalSec=300\n")
+	b.WriteString("StartLimitBurst=5\n\n")
 
 	b.WriteString("[Service]\n")
 	b.WriteString("Type=simple\n")
@@ -505,9 +510,7 @@ func renderSystemdUnit(spec serviceSpec) string {
 	b.WriteString("StandardOutput=append:" + iniEscape(spec.LogPath) + "\n")
 	b.WriteString("StandardError=append:" + iniEscape(spec.LogPath) + "\n")
 	b.WriteString("Restart=on-failure\n")
-	b.WriteString("RestartSec=30\n")
-	b.WriteString("StartLimitIntervalSec=300\n")
-	b.WriteString("StartLimitBurst=5\n\n")
+	b.WriteString("RestartSec=30\n\n")
 
 	b.WriteString("[Install]\n")
 	b.WriteString("WantedBy=default.target\n")

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -445,7 +445,16 @@ func renderLaunchdPlist(spec serviceSpec) string {
 	writePlistString(&b, "StandardOutPath", spec.LogPath)
 	writePlistString(&b, "StandardErrorPath", spec.LogPath)
 	b.WriteString("  <key>RunAtLoad</key>\n  <true/>\n")
-	b.WriteString("  <key>KeepAlive</key>\n  <true/>\n")
+	// KeepAlive as a dict with SuccessfulExit=false: launchd respawns the
+	// daemon only after a NON-ZERO (crash) exit, never after a graceful stop
+	// (exit 0). This makes `dir2mcp down` (which SIGTERMs the daemon into a
+	// clean exit 0) durably stop a service-managed daemon, and stops the boot
+	// crash-loop when a misconfigured daemon is stopped gracefully (#434).
+	b.WriteString("  <key>KeepAlive</key>\n  <dict>\n    <key>SuccessfulExit</key>\n    <false/>\n  </dict>\n")
+	// Widen launchd's default 10s respawn throttle so a daemon that crashes
+	// deterministically at boot (e.g. a missing credential) backs off instead
+	// of hot-looping.
+	b.WriteString("  <key>ThrottleInterval</key>\n  <integer>30</integer>\n")
 	writePlistString(&b, "ProcessType", "Background")
 	b.WriteString("</dict>\n</plist>\n")
 	return b.String()
@@ -465,4 +474,81 @@ func writePlistString(b *strings.Builder, key, value string) {
 // paths (& < >) cannot corrupt the plist document.
 func xmlEscape(b *strings.Builder, s string) {
 	_ = xml.EscapeText(b, []byte(s))
+}
+
+// renderSystemdUnit builds a systemd user-service unit (INI) for spec.
+// Like renderLaunchdPlist it lives in the shared (untagged) file so its
+// output is unit-tested on every platform; only the systemctl invocation
+// is linux-gated.
+//
+// The crash-loop-safe supervision block is the systemd analog of the
+// launchd KeepAlive{SuccessfulExit=false}+ThrottleInterval pair: Restart
+// only on a non-zero/crash exit (a graceful `down` exits 0), backed off by
+// RestartSec and bounded by StartLimit* so a deterministically-failing
+// config eventually gives up instead of hot-looping. EnvironmentFile points
+// at the corpus .env.local (leading `-` = optional) so the booted daemon
+// resolves provider credentials the same way the launchd service does.
+func renderSystemdUnit(spec serviceSpec) string {
+	envFile := filepath.Join(spec.WorkingDir, ".env.local")
+
+	var b strings.Builder
+	b.WriteString("[Unit]\n")
+	b.WriteString("Description=" + iniEscape("dir2mcp knowledge server ("+spec.Label+")") + "\n\n")
+
+	b.WriteString("[Service]\n")
+	b.WriteString("Type=simple\n")
+	b.WriteString("WorkingDirectory=" + iniEscape(spec.WorkingDir) + "\n")
+	b.WriteString("ExecStart=" + renderSystemdExecStart(spec) + "\n")
+	// Leading `-` marks the file optional: the unit still starts when the
+	// operator configured credentials via .dir2mcp.yaml instead.
+	b.WriteString("EnvironmentFile=-" + iniEscape(envFile) + "\n")
+	b.WriteString("StandardOutput=append:" + iniEscape(spec.LogPath) + "\n")
+	b.WriteString("StandardError=append:" + iniEscape(spec.LogPath) + "\n")
+	b.WriteString("Restart=on-failure\n")
+	b.WriteString("RestartSec=30\n")
+	b.WriteString("StartLimitIntervalSec=300\n")
+	b.WriteString("StartLimitBurst=5\n\n")
+
+	b.WriteString("[Install]\n")
+	b.WriteString("WantedBy=default.target\n")
+	return b.String()
+}
+
+// renderSystemdExecStart joins the binary and its args into an ExecStart
+// value, quoting any token containing whitespace so systemd parses it as a
+// single argument. Each token is INI-escaped first.
+func renderSystemdExecStart(spec serviceSpec) string {
+	tokens := append([]string{spec.BinaryPath}, spec.Args...)
+	quoted := make([]string, 0, len(tokens))
+	for _, tok := range tokens {
+		esc := iniEscape(tok)
+		if strings.ContainsAny(esc, " \t") {
+			esc = "\"" + esc + "\""
+		}
+		quoted = append(quoted, esc)
+	}
+	return strings.Join(quoted, " ")
+}
+
+// iniEscape makes s safe to embed in a systemd unit value. systemd treats a
+// literal `%` as the start of a specifier, so it must be doubled. This is the
+// INI analog of the plist's XML escaping (xmlEscape does NOT apply here). A
+// value containing a carriage return or newline would break the single-line
+// key=value format and is rejected upstream (rejectMultilineSpec); iniEscape
+// assumes that guard has already run.
+func iniEscape(s string) string {
+	return strings.ReplaceAll(s, "%", "%%")
+}
+
+// rejectMultilineSpec fails when any spec field that becomes a systemd unit
+// value contains a carriage return or newline, which would break the INI
+// key=value line format (the same guard persistCredentialsFromEnv applies to
+// dotenv values). Returns nil when every value is single-line.
+func rejectMultilineSpec(spec serviceSpec) error {
+	for _, v := range append([]string{spec.Label, spec.BinaryPath, spec.WorkingDir, spec.LogPath}, spec.Args...) {
+		if strings.ContainsAny(v, "\r\n") {
+			return fmt.Errorf("service value %q contains a newline, which is not allowed in a systemd unit", v)
+		}
+	}
+	return nil
 }

--- a/internal/cli/service_linux.go
+++ b/internal/cli/service_linux.go
@@ -1,0 +1,124 @@
+//go:build linux
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// systemdManager supervises a per-corpus dir2mcp daemon as a systemd user
+// service. runCmd is injectable so the daemon-reload/enable/status sequence
+// can be unit-tested without touching a real systemd. It mirrors the macOS
+// launchdManager structure.
+type systemdManager struct {
+	home   string
+	runCmd func(name string, args ...string) (string, error)
+}
+
+// newServiceManager returns the Linux systemd user-service backend.
+func newServiceManager() (serviceManager, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolve home dir: %w", err)
+	}
+	return &systemdManager{
+		home: home,
+		runCmd: func(name string, args ...string) (string, error) {
+			out, err := exec.Command(name, args...).CombinedOutput()
+			return string(out), err
+		},
+	}, nil
+}
+
+// backendName identifies this manager in CLI output.
+func (m *systemdManager) backendName() string { return "systemd" }
+
+// unitPath returns the canonical user-unit path for label. filepath.Base
+// clamps any residual path separators so the unit cannot escape the systemd
+// user directory even if upstream validation is somehow bypassed.
+func (m *systemdManager) unitPath(label string) string {
+	return filepath.Join(m.home, ".config", "systemd", "user", filepath.Base(label)+".service")
+}
+
+// install writes the user unit, reloads the daemon, and enables+starts it.
+func (m *systemdManager) install(spec serviceSpec) (string, error) {
+	if err := rejectMultilineSpec(spec); err != nil {
+		return "", err
+	}
+	unit := m.unitPath(spec.Label)
+	if err := os.MkdirAll(filepath.Dir(unit), 0o755); err != nil {
+		return "", fmt.Errorf("create systemd user dir: %w", err)
+	}
+	if err := os.WriteFile(unit, []byte(renderSystemdUnit(spec)), 0o644); err != nil {
+		return unit, fmt.Errorf("write unit %s: %w", unit, err)
+	}
+	if out, err := m.runCmd("systemctl", "--user", "daemon-reload"); err != nil {
+		return unit, fmt.Errorf("systemctl daemon-reload: %w: %s", err, strings.TrimSpace(out))
+	}
+	if out, err := m.runCmd("systemctl", "--user", "enable", "--now", filepath.Base(unit)); err != nil {
+		return unit, fmt.Errorf("systemctl enable --now: %w: %s", err, strings.TrimSpace(out))
+	}
+	return unit, nil
+}
+
+// uninstall disables+stops the unit, removes the file, and reloads the
+// daemon. Idempotent: removed=false when the unit file was already absent.
+func (m *systemdManager) uninstall(label string) (string, bool, error) {
+	unit := m.unitPath(label)
+	// Best-effort disable+stop (ignore the error when the unit is not loaded),
+	// then remove the file so it won't re-enable at next login.
+	_, _ = m.runCmd("systemctl", "--user", "disable", "--now", filepath.Base(unit))
+	_, err := os.Stat(unit)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return unit, false, nil
+		}
+		return unit, false, fmt.Errorf("stat unit %s: %w", unit, err)
+	}
+	if err := os.Remove(unit); err != nil {
+		return unit, false, fmt.Errorf("remove unit %s: %w", unit, err)
+	}
+	if out, err := m.runCmd("systemctl", "--user", "daemon-reload"); err != nil {
+		return unit, true, fmt.Errorf("systemctl daemon-reload: %w: %s", err, strings.TrimSpace(out))
+	}
+	return unit, true, nil
+}
+
+// status reports whether the unit is installed (file on disk / enabled) and
+// running (active). is-active/is-enabled exit non-zero for the normal
+// inactive/disabled states, so their errors are best-effort ignored and the
+// verdict is read from stdout ("active"/"enabled"/...); the on-disk unit file
+// is the authoritative installed signal.
+func (m *systemdManager) status(label string) (serviceState, error) {
+	unit := m.unitPath(label)
+	state := serviceState{UnitPath: unit}
+	if _, err := os.Stat(unit); err == nil {
+		state.Installed = true
+	} else if !os.IsNotExist(err) {
+		return state, fmt.Errorf("stat unit %s: %w", unit, err)
+	}
+
+	base := filepath.Base(unit)
+	activeOut, _ := m.runCmd("systemctl", "--user", "is-active", base)
+	state.Running = strings.TrimSpace(activeOut) == "active"
+
+	enabledOut, _ := m.runCmd("systemctl", "--user", "is-enabled", base)
+	enabled := strings.TrimSpace(enabledOut)
+	if enabled == "enabled" || enabled == "static" || enabled == "linked" {
+		state.Installed = true
+	}
+
+	switch {
+	case state.Running:
+		state.Detail = "running"
+	case state.Installed:
+		state.Detail = "installed, not running"
+	default:
+		state.Detail = "not installed"
+	}
+	return state, nil
+}

--- a/internal/cli/service_linux_test.go
+++ b/internal/cli/service_linux_test.go
@@ -1,0 +1,216 @@
+//go:build linux
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type recordedCmd struct {
+	name string
+	args []string
+}
+
+func newFakeSystemd(t *testing.T, output string, runErr error) (*systemdManager, *[]recordedCmd) {
+	t.Helper()
+	home := t.TempDir()
+	calls := &[]recordedCmd{}
+	mgr := &systemdManager{
+		home: home,
+		runCmd: func(name string, args ...string) (string, error) {
+			*calls = append(*calls, recordedCmd{name: name, args: args})
+			return output, runErr
+		},
+	}
+	return mgr, calls
+}
+
+// argLine joins a recorded command back into a single string for sequence
+// assertions.
+func argLine(c recordedCmd) string {
+	return c.name + " " + strings.Join(c.args, " ")
+}
+
+func TestSystemdManager_InstallWritesUnitAndEnables(t *testing.T) {
+	mgr, calls := newFakeSystemd(t, "", nil)
+	spec := serviceSpec{
+		Label:      "com.dirstral.dir2mcp-demo-abc123",
+		BinaryPath: "/usr/local/bin/dir2mcp",
+		WorkingDir: "/srv/corpus",
+		Args:       []string{"up", "--foreground"},
+		LogPath:    "/srv/corpus/.dir2mcp/service.log",
+	}
+
+	unit, err := mgr.install(spec)
+	if err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	wantPath := filepath.Join(mgr.home, ".config", "systemd", "user", spec.Label+".service")
+	if unit != wantPath {
+		t.Errorf("unit path = %q, want %q", unit, wantPath)
+	}
+	fi, statErr := os.Stat(wantPath)
+	if statErr != nil {
+		t.Fatalf("unit not written: %v", statErr)
+	}
+	if fi.Mode().Perm() != 0o644 {
+		t.Errorf("unit perms = %v, want 0644", fi.Mode().Perm())
+	}
+	body, _ := os.ReadFile(wantPath)
+	if !strings.Contains(string(body), "Restart=on-failure") {
+		t.Errorf("unit missing supervision block:\n%s", body)
+	}
+
+	want := []string{
+		"systemctl --user daemon-reload",
+		"systemctl --user enable --now com.dirstral.dir2mcp-demo-abc123.service",
+	}
+	if len(*calls) != len(want) {
+		t.Fatalf("got %d systemctl calls, want %d: %+v", len(*calls), len(want), *calls)
+	}
+	for i, w := range want {
+		if got := argLine((*calls)[i]); got != w {
+			t.Errorf("call %d = %q, want %q", i, got, w)
+		}
+	}
+}
+
+func TestSystemdManager_InstallSurfacesEnableFailure(t *testing.T) {
+	mgr, _ := newFakeSystemd(t, "Failed to enable unit", fmt.Errorf("exit status 1"))
+	_, err := mgr.install(serviceSpec{Label: "com.dirstral.x", BinaryPath: "/bin/dir2mcp", WorkingDir: "/x", LogPath: "/x/l.log"})
+	if err == nil {
+		t.Fatal("expected enable/daemon-reload failure to surface")
+	}
+}
+
+func TestSystemdManager_InstallRejectsNewlineValue(t *testing.T) {
+	mgr, calls := newFakeSystemd(t, "", nil)
+	_, err := mgr.install(serviceSpec{Label: "com.dirstral.x\ninjected=1", BinaryPath: "/bin/dir2mcp", WorkingDir: "/x", LogPath: "/x/l.log"})
+	if err == nil {
+		t.Fatal("expected a newline-in-value rejection")
+	}
+	if len(*calls) != 0 {
+		t.Errorf("no systemctl call should run when the spec is rejected, got %+v", *calls)
+	}
+}
+
+func TestSystemdManager_UninstallRemovesUnit(t *testing.T) {
+	mgr, calls := newFakeSystemd(t, "", nil)
+	label := "com.dirstral.dir2mcp-demo-abc123"
+	unit := mgr.unitPath(label)
+	if err := os.MkdirAll(filepath.Dir(unit), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(unit, []byte("[Unit]\n"), 0o644); err != nil {
+		t.Fatalf("seed unit: %v", err)
+	}
+
+	_, removed, err := mgr.uninstall(label)
+	if err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+	if !removed {
+		t.Error("expected removed=true for an existing unit")
+	}
+	if _, statErr := os.Stat(unit); !os.IsNotExist(statErr) {
+		t.Errorf("unit still present after uninstall: %v", statErr)
+	}
+	want := []string{
+		"systemctl --user disable --now com.dirstral.dir2mcp-demo-abc123.service",
+		"systemctl --user daemon-reload",
+	}
+	if len(*calls) != len(want) {
+		t.Fatalf("got %d calls, want %d: %+v", len(*calls), len(want), *calls)
+	}
+	for i, w := range want {
+		if got := argLine((*calls)[i]); got != w {
+			t.Errorf("call %d = %q, want %q", i, got, w)
+		}
+	}
+}
+
+func TestSystemdManager_UninstallAbsentIsIdempotent(t *testing.T) {
+	mgr, calls := newFakeSystemd(t, "", nil)
+	_, removed, err := mgr.uninstall("com.dirstral.not-installed")
+	if err != nil {
+		t.Fatalf("uninstall absent: %v", err)
+	}
+	if removed {
+		t.Error("expected removed=false when no unit exists")
+	}
+	// Only the best-effort disable ran; no file to remove, no reload needed.
+	if len(*calls) != 1 || argLine((*calls)[0]) != "systemctl --user disable --now com.dirstral.not-installed.service" {
+		t.Errorf("expected a single disable call, got %+v", *calls)
+	}
+}
+
+func TestSystemdManager_StatusReportsRunning(t *testing.T) {
+	// is-active -> "active", is-enabled -> "enabled".
+	outputs := []string{"active\n", "enabled\n"}
+	var i int
+	mgr := &systemdManager{
+		home: t.TempDir(),
+		runCmd: func(_ string, _ ...string) (string, error) {
+			o := outputs[i]
+			i++
+			return o, nil
+		},
+	}
+	label := "com.dirstral.dir2mcp-demo-abc123"
+	unit := mgr.unitPath(label)
+	if err := os.MkdirAll(filepath.Dir(unit), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(unit, []byte("[Unit]\n"), 0o644); err != nil {
+		t.Fatalf("seed unit: %v", err)
+	}
+
+	state, err := mgr.status(label)
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if !state.Installed || !state.Running {
+		t.Errorf("expected installed+running, got %+v", state)
+	}
+}
+
+func TestSystemdManager_StatusReportsNotInstalled(t *testing.T) {
+	// is-active exits non-zero with "inactive"; is-enabled with "not-found".
+	outputs := []string{"inactive\n", "not-found\n"}
+	var i int
+	mgr := &systemdManager{
+		home: t.TempDir(),
+		runCmd: func(_ string, _ ...string) (string, error) {
+			o := outputs[i]
+			i++
+			return o, fmt.Errorf("exit status 1")
+		},
+	}
+	state, err := mgr.status("com.dirstral.absent")
+	if err != nil {
+		t.Fatalf("status should not error for an absent unit: %v", err)
+	}
+	if state.Installed || state.Running {
+		t.Errorf("expected absent unit, got %+v", state)
+	}
+	if state.Detail != "not installed" {
+		t.Errorf("detail = %q, want \"not installed\"", state.Detail)
+	}
+}
+
+func TestSystemdManager_UnitPathClampsTraversal(t *testing.T) {
+	mgr, _ := newFakeSystemd(t, "", nil)
+	got := mgr.unitPath("../../etc/evil")
+	wantDir := filepath.Join(mgr.home, ".config", "systemd", "user")
+	if filepath.Dir(got) != wantDir {
+		t.Errorf("unitPath escaped user dir: %q (want parent %s)", got, wantDir)
+	}
+	if filepath.Base(got) != "evil.service" {
+		t.Errorf("expected clamped basename evil.service, got %q", filepath.Base(got))
+	}
+}

--- a/internal/cli/service_other.go
+++ b/internal/cli/service_other.go
@@ -1,4 +1,4 @@
-//go:build !darwin
+//go:build !darwin && !linux
 
 package cli
 
@@ -7,9 +7,9 @@ import (
 	"runtime"
 )
 
-// newServiceManager reports that login auto-start is not yet wired for
-// this platform. macOS (launchd) is supported today; a Linux systemd
-// user-unit backend is a planned follow-up.
+// newServiceManager reports that login auto-start is not wired for this
+// platform. macOS (launchd) and Linux (systemd user units) are supported;
+// this stub covers every other GOOS.
 func newServiceManager() (serviceManager, error) {
-	return nil, fmt.Errorf("dir2mcp service is not yet supported on %s (macOS/launchd only for now)", runtime.GOOS)
+	return nil, fmt.Errorf("dir2mcp service is not supported on %s (macOS/launchd and Linux/systemd only)", runtime.GOOS)
 }

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -107,6 +107,18 @@ func TestRenderSystemdUnit(t *testing.T) {
 		}
 	}
 
+	// Start-rate limits are [Unit]-level directives; systemd ignores them under
+	// [Service]. Assert they appear before the [Service] header so the crash-loop
+	// cap actually applies.
+	if svc := strings.Index(out, "[Service]"); svc >= 0 {
+		if lim := strings.Index(out, "StartLimitIntervalSec="); lim < 0 || lim > svc {
+			t.Errorf("StartLimitIntervalSec must be in [Unit] (before [Service]):\n%s", out)
+		}
+		if burst := strings.Index(out, "StartLimitBurst="); burst < 0 || burst > svc {
+			t.Errorf("StartLimitBurst must be in [Unit] (before [Service]):\n%s", out)
+		}
+	}
+
 	// EnvironmentFile points at the corpus .env.local and is optional (leading
 	// `-`), with % doubled to %%.
 	if !strings.Contains(out, "EnvironmentFile=-/srv/corpus 50%%/.env.local") {

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -149,6 +149,31 @@ func TestRenderSystemdUnit(t *testing.T) {
 	}
 }
 
+// TestIniEscapeBackslash pins that a value ending in `\` is doubled so systemd
+// does not read it as a line-continuation into the next directive.
+func TestIniEscapeBackslash(t *testing.T) {
+	if got := iniEscape(`/srv/corpus\`); got != `/srv/corpus\\` {
+		t.Errorf("trailing backslash not doubled: %q", got)
+	}
+	if got := iniEscape(`a\b%c`); got != `a\\b%%c` {
+		t.Errorf("backslash+percent escaping wrong: %q", got)
+	}
+}
+
+// TestRenderSystemdExecStart_EmbeddedQuote pins that a token containing a double
+// quote is quoted AND its embedded quote escaped, so it can't break out of the
+// quoting and split the command line.
+func TestRenderSystemdExecStart_EmbeddedQuote(t *testing.T) {
+	spec := serviceSpec{
+		BinaryPath: "/usr/local/bin/dir2mcp",
+		Args:       []string{"up", `--config`, `/srv/a"b/c.yaml`},
+	}
+	got := renderSystemdExecStart(spec)
+	if !strings.Contains(got, `"/srv/a\"b/c.yaml"`) {
+		t.Errorf("embedded quote not escaped+quoted: %q", got)
+	}
+}
+
 // TestRejectMultilineSpec pins the newline guard: a value with \r or \n must
 // be rejected (it would break the INI key=value line format), the same
 // protection persistCredentialsFromEnv applies to dotenv values.

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -48,6 +48,21 @@ func TestRenderLaunchdPlist(t *testing.T) {
 		}
 	}
 
+	// KeepAlive must be a dict with SuccessfulExit=false (respawn on crash
+	// only, not on a graceful exit-0 stop), not an unconditional <true/>.
+	// Guard on the substring order so KeepAlive is followed by the dict.
+	keepAliveDict := "<key>KeepAlive</key>\n  <dict>\n    <key>SuccessfulExit</key>\n    <false/>\n  </dict>"
+	if !strings.Contains(out, keepAliveDict) {
+		t.Errorf("plist KeepAlive is not a SuccessfulExit=false dict:\n%s", out)
+	}
+	if strings.Contains(out, "<key>KeepAlive</key>\n  <true/>") {
+		t.Errorf("plist still uses unconditional KeepAlive <true/>:\n%s", out)
+	}
+	// ThrottleInterval widens the default 10s respawn backoff.
+	if !strings.Contains(out, "<key>ThrottleInterval</key>\n  <integer>30</integer>") {
+		t.Errorf("plist missing ThrottleInterval=30:\n%s", out)
+	}
+
 	// WorkingDirectory carries an ampersand: it must be XML-escaped so
 	// the plist stays well-formed.
 	if !strings.Contains(out, "legal &amp; co") {
@@ -58,6 +73,114 @@ func TestRenderLaunchdPlist(t *testing.T) {
 	}
 	if !strings.HasPrefix(out, "<?xml") {
 		t.Errorf("plist missing XML header: %q", out[:min(20, len(out))])
+	}
+}
+
+// TestRenderSystemdUnit pins the systemd user-unit contract: the
+// crash-loop-safe supervision block (Restart=on-failure + backoff +
+// StartLimit), the optional .env.local EnvironmentFile, append: log
+// redirection, and the INI-specific escaping (%→%%, space-quoted ExecStart)
+// that is the analog of the plist XML escaping. Unit-tested on every platform.
+func TestRenderSystemdUnit(t *testing.T) {
+	spec := serviceSpec{
+		Label:      "com.dirstral.dir2mcp-demo-abc123",
+		BinaryPath: "/usr/local/bin/dir2mcp",
+		WorkingDir: "/srv/corpus 50%",
+		Args:       []string{"up", "--foreground", "--config", "/srv/my config.yaml"},
+		LogPath:    "/srv/corpus 50%/.dir2mcp/service.log",
+	}
+	out := renderSystemdUnit(spec)
+
+	for _, want := range []string{
+		"[Unit]",
+		"[Service]",
+		"Type=simple",
+		"[Install]",
+		"WantedBy=default.target",
+		"Restart=on-failure",
+		"RestartSec=30",
+		"StartLimitIntervalSec=300",
+		"StartLimitBurst=5",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("systemd unit missing %q\n---\n%s", want, out)
+		}
+	}
+
+	// EnvironmentFile points at the corpus .env.local and is optional (leading
+	// `-`), with % doubled to %%.
+	if !strings.Contains(out, "EnvironmentFile=-/srv/corpus 50%%/.env.local") {
+		t.Errorf("systemd unit missing optional .env.local EnvironmentFile with %%%% escape:\n%s", out)
+	}
+
+	// Log redirection must use append: so the log survives restarts.
+	if !strings.Contains(out, "StandardOutput=append:/srv/corpus 50%%/.dir2mcp/service.log") {
+		t.Errorf("systemd unit StandardOutput not append:-redirected/escaped:\n%s", out)
+	}
+	if !strings.Contains(out, "StandardError=append:/srv/corpus 50%%/.dir2mcp/service.log") {
+		t.Errorf("systemd unit StandardError not append:-redirected/escaped:\n%s", out)
+	}
+
+	// WorkingDirectory: literal % doubled.
+	if !strings.Contains(out, "WorkingDirectory=/srv/corpus 50%%") {
+		t.Errorf("systemd unit WorkingDirectory not %%-escaped:\n%s", out)
+	}
+
+	// ExecStart: binary + args, with the space-containing token quoted.
+	if !strings.Contains(out, `ExecStart=/usr/local/bin/dir2mcp up --foreground --config "/srv/my config.yaml"`) {
+		t.Errorf("systemd unit ExecStart not space-quoted:\n%s", out)
+	}
+
+	// A raw single-% must never survive (would be a systemd specifier).
+	if strings.Contains(strings.ReplaceAll(out, "%%", ""), "%") {
+		t.Errorf("systemd unit contains an unescaped single %%:\n%s", out)
+	}
+}
+
+// TestRejectMultilineSpec pins the newline guard: a value with \r or \n must
+// be rejected (it would break the INI key=value line format), the same
+// protection persistCredentialsFromEnv applies to dotenv values.
+func TestRejectMultilineSpec(t *testing.T) {
+	ok := serviceSpec{Label: "com.dirstral.x", BinaryPath: "/bin/dir2mcp", WorkingDir: "/x", Args: []string{"up"}, LogPath: "/x/l.log"}
+	if err := rejectMultilineSpec(ok); err != nil {
+		t.Errorf("clean spec rejected: %v", err)
+	}
+	for _, bad := range []serviceSpec{
+		{Label: "com.dirstral.x\n", BinaryPath: "/bin/dir2mcp", WorkingDir: "/x"},
+		{Label: "com.dirstral.x", BinaryPath: "/bin/dir2\rmcp", WorkingDir: "/x"},
+		{Label: "com.dirstral.x", BinaryPath: "/bin/dir2mcp", WorkingDir: "/x", Args: []string{"up\n--foreground"}},
+		{Label: "com.dirstral.x", BinaryPath: "/bin/dir2mcp", WorkingDir: "/x", LogPath: "/x/l\n.log"},
+	} {
+		if err := rejectMultilineSpec(bad); err == nil {
+			t.Errorf("expected rejection for spec with newline: %+v", bad)
+		}
+	}
+}
+
+// TestResolveProcessExitCode pins the #434 exit-code contract: a
+// signal-triggered graceful stop of the long-running server exits 0 (so
+// launchd/systemd don't treat a `down` as a crash and respawn), while an
+// interactive command interrupted mid-flight still reports the interrupt code
+// and any crash keeps its own non-zero code.
+func TestResolveProcessExitCode(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		ctxErr      error
+		code        int
+		gracefulSrv bool
+		want        int
+	}{
+		{"server graceful SIGTERM exits 0", context.Canceled, exitSuccess, true, exitSuccess},
+		{"interactive interrupt maps to signal code", context.Canceled, exitSuccess, false, exitSignalInterrupt},
+		{"server crash keeps its non-zero code", context.Canceled, exitGeneric, true, exitGeneric},
+		{"clean exit without cancel unchanged", nil, exitSuccess, false, exitSuccess},
+		{"deadline (not cancel) unchanged", context.DeadlineExceeded, exitSuccess, false, exitSuccess},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolveProcessExitCode(tc.ctxErr, tc.code, tc.gracefulSrv); got != tc.want {
+				t.Errorf("resolveProcessExitCode(%v,%d,%v)=%d, want %d", tc.ctxErr, tc.code, tc.gracefulSrv, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -245,6 +245,12 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 	startIngestWorker(runCtx, opts.readOnly, ing, indexingState, ingestErrCh)
 	startWatchWorker(runCtx, opts.readOnly, cfg.IngestWatch, ing, logSink, &bgWG)
 
+	// The server is now serving. A signal-triggered shutdown from here on is
+	// a normal, successful termination (a supervisor/`down`-requested stop),
+	// not an interrupted command — so it must exit 0, not exitSignalInterrupt.
+	// See resolveProcessExitCode (#434).
+	a.serverGracefulStop = true
+
 	return a.runEventLoop(runCtx, cancel, &cfg, st, indexingState, emitter, serverErrCh, ingestErrCh, embedErrCh, stdinQuitCh, logSink)
 }
 

--- a/internal/cli/up_graceful_stop_test.go
+++ b/internal/cli/up_graceful_stop_test.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestUp_GracefulCancelExitsZero pins the #434 precondition the launchd
+// KeepAlive{SuccessfulExit=false} and systemd Restart=on-failure contracts
+// depend on: a SIGTERM-triggered graceful stop of `up --foreground` (the
+// supervised service target) must exit 0, not the interrupt code — otherwise
+// a `dir2mcp down` (which SIGTERMs the daemon) would look like a crash and the
+// supervisor would respawn it.
+//
+// The signal is modeled by cancelling the run context (exactly what
+// signal.NotifyContext does on SIGTERM). The test asserts both halves of the
+// chain: runUp marks the stop graceful, and resolveProcessExitCode then keeps
+// the exit at 0.
+func TestUp_GracefulCancelExitsZero(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("MISTRAL_API_KEY", "test-key")
+	t.Setenv("DIR2MCP_AUTH_TOKEN", "test-token")
+	// Skip the network embed-preflight probe so the daemon reaches the serving
+	// loop without valid live credentials (mirrors the tests/cli TestMain).
+	t.Setenv("DIR2MCP_SKIP_EMBED_PROBE", "1")
+	t.Chdir(tmp)
+
+	stateDir := filepath.Join(tmp, ".dir2mcp")
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+
+	app := NewAppWithIO(io.Discard, io.Discard)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	codeCh := make(chan int, 1)
+	go func() {
+		codeCh <- app.RunWithContext(ctx, []string{"up", "--foreground", "--listen", "127.0.0.1:0"})
+	}()
+
+	// Wait until the daemon is serving (connection.json published), then stop
+	// it the way a signal would.
+	connPath := connectionFilePath(stateDir)
+	deadline := time.Now().Add(15 * time.Second)
+	for {
+		if _, err := os.Stat(connPath); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			cancel()
+			<-codeCh
+			t.Fatal("daemon never became ready (connection.json not written)")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	cancel()
+
+	var code int
+	select {
+	case code = <-codeCh:
+	case <-time.After(15 * time.Second):
+		t.Fatal("up did not exit after context cancellation")
+	}
+
+	if code != exitSuccess {
+		t.Fatalf("graceful stop returned code %d from the serve loop, want %d", code, exitSuccess)
+	}
+	if !app.serverGracefulStop {
+		t.Fatal("serverGracefulStop not set; a signal stop would be misread as an interrupt")
+	}
+	// The Run() wrapper maps a cancelled clean exit; with the graceful flag it
+	// must stay 0 so the supervisor does not treat `down` as a crash.
+	if got := resolveProcessExitCode(context.Canceled, code, app.serverGracefulStop); got != exitSuccess {
+		t.Fatalf("graceful SIGTERM exit code = %d, want %d", got, exitSuccess)
+	}
+}

--- a/tests/security/cli_boundary_test.go
+++ b/tests/security/cli_boundary_test.go
@@ -173,6 +173,7 @@ func TestRepoSplitBoundary_InternalCLIFileOwnership(t *testing.T) {
 		"daemon_other.go":                        {},
 		"daemon_unix.go":                         {},
 		"down.go":                                {},
+		"down_internal_test.go":                  {},
 		"embed_options_test.go":                  {},
 		"embed_preflight_probe_internal_test.go": {},
 		"embed_worker.go":                        {},
@@ -195,6 +196,8 @@ func TestRepoSplitBoundary_InternalCLIFileOwnership(t *testing.T) {
 		"service.go":                             {},
 		"service_darwin.go":                      {},
 		"service_darwin_test.go":                 {},
+		"service_linux.go":                       {},
+		"service_linux_test.go":                  {},
 		"service_other.go":                       {},
 		"service_test.go":                        {},
 		"status.go":                              {},
@@ -206,6 +209,7 @@ func TestRepoSplitBoundary_InternalCLIFileOwnership(t *testing.T) {
 		"up.go":                                  {},
 		"up_daemon.go":                           {},
 		"up_distributed_embed.go":                {},
+		"up_graceful_stop_test.go":               {},
 	}
 
 	var unexpected []string


### PR DESCRIPTION
Addresses #434 — the remaining spec-neutral service/supervision items after PR #522 (which already landed the `up --foreground` single-instance guard, the standalone `embed-worker` broker guard, and `doctor --deep`). Service/supervision is not spec-governed, so no dirstral-spec PR is required.

## A. launchd crash-only KeepAlive + graceful-stop exits 0
- **Precondition fix (found during recon):** a SIGTERM-triggered graceful stop of `up --foreground` previously exited `exitSignalInterrupt` (6), not 0, because `Run()` remapped any clean exit after a context cancel. With `KeepAlive{SuccessfulExit:false}` that would look like a crash and respawn forever. `runUp` now marks the serving phase graceful and `resolveProcessExitCode` keeps a signal-stop of the server at exit 0 — while still reporting an interrupted interactive command as `INTERRUPTED` and propagating real crash codes untouched.
- `renderLaunchdPlist`: `KeepAlive <true/>` → `KeepAlive <dict><key>SuccessfulExit</key><false/></dict>` (respawn only on a non-zero/crash exit), plus `ThrottleInterval=30` to widen the respawn backoff. This makes `down` durably stop a service-managed daemon and ends the boot crash-loop on a graceful stop.

## B. Linux systemd backend
- New `internal/cli/service_linux.go` (`//go:build linux`): `systemdManager` implementing `serviceManager`, mirroring `launchdManager` with an injectable `runCmd` for hermetic tests. Unit at `~/.config/systemd/user/<label>.service`; install = write + `daemon-reload` + `enable --now`; uninstall = `disable --now` + remove + reload (idempotent); status via `is-active`/`is-enabled` + on-disk unit.
- Shared, untagged `renderSystemdUnit` next to `renderLaunchdPlist` (unit-tested on every platform): crash-loop-safe supervision (`Restart=on-failure`, `RestartSec=30`, `StartLimitIntervalSec=300`, `StartLimitBurst=5`) — the systemd analog of KeepAlive+ThrottleInterval — an optional `EnvironmentFile=-<workdir>/.env.local`, and `append:` log redirection. INI escaping (the analog of the plist XML escaping): newline values rejected, literal `%`→`%%`, space-containing ExecStart tokens quoted.
- `service_other.go` build tag narrowed to `!darwin && !linux` (stub for truly-unsupported platforms).

## C. down-vs-service informational contract
- After a successful pid stop, `down` resolves the service backend and, if a unit is installed, appends an informational note ("this corpus is service-managed; it will restart at next login/boot — run `dir2mcp service uninstall` to remove permanently") and sets `service_managed` in the JSON payload. Best-effort; never auto-uninstalls; exit stays 0.

## Not done
- Optional probe-helper unification (`probeEmbedder` hard-fail vs `probeEmbedProvider` fail-open + `DIR2MCP_SKIP_EMBED_PROBE`) intentionally skipped: their semantics differ and unifying risks changing the fail-open behavior — out of scope for this PR.

## Tests
- `renderLaunchdPlist`: KeepAlive SuccessfulExit=false dict + ThrottleInterval, no unconditional `<true/>`.
- `resolveProcessExitCode` table + a live `up --foreground` cancel test asserting graceful stop exits 0 and sets the graceful flag.
- `renderSystemdUnit` cross-platform table (supervision block, optional `.env.local`, `append:`, `%`→`%%`, space-quoted ExecStart) + `rejectMultilineSpec`.
- `systemdManager` (linux-tagged, fake runCmd): exact `systemctl --user` install/uninstall/status sequences, 0644 unit written+removed, idempotent uninstall, newline rejection, path-traversal clamp.
- `writeDownInfo`: note present/absent + `service_managed` JSON field.

## Verification
- `make lint` = 0 issues (darwin and `GOOS=linux`).
- `go test ./internal/cli/... ./tests/cli/...` pass; `go build`/`go vet` clean on darwin, linux, windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `up` now exits cleanly when the server stops gracefully, even if the command was interrupted.
  * `down` now shows whether a service-managed corpus may restart automatically, and JSON output includes that status.
  * Service auto-start support now works on Linux as a user service, alongside macOS.

* **Bug Fixes**
  * Improved exit handling so crashes, interrupts, and successful stops are reported more accurately.
  * Better service supervision helps prevent rapid restart loops after repeated failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->