### PR TITLE
fix(ingest): consolidate format allowlists into one capability table + name uncovered formats in doctor (#395 Stage 1)

### DIFF
--- a/internal/cli/server_doctor.go
+++ b/internal/cli/server_doctor.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -247,17 +248,13 @@ func extractionCoverageCheck(ctx context.Context, a *App, cfg config.Config) doc
 		}
 	}
 
-	// (A) Extractable documents exist but no extractor will run: those
-	// documents produce no representation, no chunks, and never appear in any
-	// answer. This is a hard configuration dead-end, so it is an error.
+	// (A/A') Extractable documents exist: report either a hard dead-end (no
+	// extractor at all) or partial coverage (an active extractor that cannot read
+	// some present formats). Factored out to keep this function's branching under
+	// the complexity budget.
 	if extractable > 0 {
-		if d := ingest.DescribeDocumentExtractor(cfg); d.Name == "" {
-			detail := fmt.Sprintf(
-				"%d document(s) need extraction (pdf/image/document) but no extractor is available: %s. "+
-					"They produce no searchable text. Enable an extractor (set ingest.extractor to auto/docling/mistral, "+
-					"not off), then make one available (install docling or set MISTRAL_API_KEY), and run `dir2mcp reindex`.",
-				extractable, d.Reason)
-			return doctorCheck{Name: name, Status: doctorStatusError, Detail: detail}
+		if check, reported := extractionAvailabilityCheck(ctx, sqliteStore, cfg, name, extractable); reported {
+			return check
 		}
 	}
 
@@ -274,6 +271,108 @@ func extractionCoverageCheck(ctx context.Context, a *App, cfg config.Config) doc
 
 	return doctorCheck{Name: name, Status: doctorStatusOK, Detail: fmt.Sprintf(
 		"%d extractable doc(s); %d/%d chunks embedded", extractable, stats.EmbeddedOK, stats.ChunksTotal)}
+}
+
+// extractionAvailabilityCheck reports the extractor-coverage verdict for a
+// corpus that has extractable documents. It returns (check, true) when it has a
+// verdict to surface — either:
+//
+//	(A)  no extractor is available at all → a hard configuration dead-end (error); or
+//	(A') an extractor is active but cannot read some formats present in the corpus
+//	     → those documents are skipped with a non-fatal unsupported-format
+//	     diagnostic (#394), so partial coverage is a warning that NAMES the exact
+//	     uncovered extensions (within §7.7's "surface the reason" mandate) so the
+//	     remedy is actionable — "install docling / add a provider for .odt, .tiff"
+//	     (#395) — instead of an opaque failure count.
+//
+// It returns (_, false) when every extractable format is covered, letting the
+// caller fall through to the embedding checks.
+func extractionAvailabilityCheck(ctx context.Context, sqliteStore *store.SQLiteStore, cfg config.Config, name string, extractable int64) (doctorCheck, bool) {
+	decision := ingest.DescribeDocumentExtractorContext(ctx, cfg)
+	if decision.Name == "" {
+		detail := fmt.Sprintf(
+			"%d document(s) need extraction (pdf/image/document) but no extractor is available: %s. "+
+				"They produce no searchable text. Enable an extractor (set ingest.extractor to auto/docling/mistral, "+
+				"not off), then make one available (install docling or set MISTRAL_API_KEY), and run `dir2mcp reindex`.",
+			extractable, decision.Reason)
+		return doctorCheck{Name: name, Status: doctorStatusError, Detail: detail}, true
+	}
+	extCounts, err := sqliteStore.ExtractableExtensionCounts(ctx, "ok")
+	if err != nil {
+		return doctorCheck{Name: name, Status: doctorStatusError, Detail: err.Error()}, true
+	}
+	structured := extractorIsStructured(decision.Name)
+	uncovered, docs := uncoveredExtractableExtensions(extCounts, structured)
+	if len(uncovered) == 0 {
+		return doctorCheck{}, false
+	}
+	return doctorCheck{Name: name, Status: doctorStatusWarn, Detail: fmt.Sprintf(
+		"%d document(s) in %d format(s) are uncovered by the active extractor (%s): %s. "+
+			"They produce no searchable text (skipped with an unsupported-format error). %s",
+		docs, len(uncovered), decision.Name, strings.Join(uncovered, ", "),
+		uncoveredExtractionRemedy(uncovered, structured))}, true
+}
+
+// extractorIsStructured maps a resolved extractor name (ExtractorDecision.Name)
+// to the structured/flat distinction the ingest capability table uses: the
+// docling family (docling / docling-serve) emits a DoclingDocument and reads the
+// broader structured set; mistral-ocr is the flat path. It mirrors the
+// structuredExtractor type-assertion Service.extractorCanReadExt performs at
+// runtime, so the doctor's coverage verdict matches what indexing will actually
+// route.
+func extractorIsStructured(name string) bool {
+	switch strings.TrimSpace(name) {
+	case "docling", "docling-serve":
+		return true
+	default:
+		return false
+	}
+}
+
+// uncoveredExtractableExtensions returns the sorted, distinct extensions present
+// in extCounts that the active extraction engine cannot read, plus the total
+// document count they account for. It consults the SAME consolidated capability
+// table the indexing path routes on (ingest.ExtractorSupportsExt), so the doctor
+// names exactly the formats that will be skipped with an unsupported-format
+// diagnostic (#394/#395). `structured` selects the docling-family verdict; false
+// is the flat OCR path. Extension-less assets (bucketed under "") are ignored —
+// they carry no format to name.
+func uncoveredExtractableExtensions(extCounts map[string]int64, structured bool) (exts []string, docs int64) {
+	for ext, n := range extCounts {
+		if ext == "" {
+			continue
+		}
+		if ingest.ExtractorSupportsExt(structured, ext) {
+			continue
+		}
+		exts = append(exts, ext)
+		docs += n
+	}
+	sort.Strings(exts)
+	return exts, docs
+}
+
+// uncoveredExtractionRemedy tailors the remediation hint to the active engine.
+// On the flat OCR path, the OpenXML Office + tiff/bmp formats become readable by
+// installing docling, so it is named; the OpenDocument/RTF/.doc/gif/svg family is
+// read by neither engine today (content support is #393). On the structured
+// (docling) path, every uncovered format is in that neither-engine set, so
+// installing docling would not help and the hint says so.
+func uncoveredExtractionRemedy(uncovered []string, structured bool) string {
+	if structured {
+		return "docling cannot import these formats; they need a future pandoc-style extractor (#393) or pre-conversion to a supported format."
+	}
+	doclingWouldCover := false
+	for _, ext := range uncovered {
+		if ingest.ExtractorSupportsExt(true, ext) {
+			doclingWouldCover = true
+			break
+		}
+	}
+	if doclingWouldCover {
+		return "Install docling (or set ingest.extractor=docling) to cover the Office/tiff/bmp formats; the remaining OpenDocument/RTF/.doc/gif/svg formats need a future pandoc-style extractor (#393)."
+	}
+	return "These formats are read by no available extractor; they need a future pandoc-style extractor (#393) or pre-conversion to a supported format."
 }
 
 // indexingFailureCheck reads the store-level FailureSummary (set by

--- a/internal/cli/server_doctor_coverage_test.go
+++ b/internal/cli/server_doctor_coverage_test.go
@@ -1,0 +1,89 @@
+package cli
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestUncoveredExtractableExtensions_NamesSpecificFormats proves the coverage
+// diagnostic names the exact corpus extensions the active extractor cannot read
+// (#395), rather than only reporting a count. It exercises both engine kinds
+// against a fixture corpus and checks the returned extensions are sorted,
+// deduplicated to distinct formats, and the document tally sums the uncovered
+// counts.
+func TestUncoveredExtractableExtensions_NamesSpecificFormats(t *testing.T) {
+	// Fixture corpus: a mix the flat OCR path cannot read (.docx/.tiff/.odt),
+	// formats it can (.pdf/.png), and an extension-less asset that must be
+	// ignored (no format to name).
+	corpus := map[string]int64{
+		".pdf":  4,
+		".png":  2,
+		".docx": 3,
+		".tiff": 1,
+		".odt":  2,
+		"":      5,
+	}
+
+	// Flat OCR (mistral-ocr): reads only pdf/png here; docx/tiff/odt uncovered.
+	flatExts, flatDocs := uncoveredExtractableExtensions(corpus, false)
+	if want := []string{".docx", ".odt", ".tiff"}; !reflect.DeepEqual(flatExts, want) {
+		t.Errorf("flat uncovered exts = %v, want %v (sorted, distinct, no empty ext)", flatExts, want)
+	}
+	if flatDocs != 6 { // 3 docx + 1 tiff + 2 odt
+		t.Errorf("flat uncovered doc count = %d, want 6", flatDocs)
+	}
+
+	// Structured (docling): reads docx/tiff too; only the OpenDocument .odt
+	// remains uncovered.
+	structExts, structDocs := uncoveredExtractableExtensions(corpus, true)
+	if want := []string{".odt"}; !reflect.DeepEqual(structExts, want) {
+		t.Errorf("structured uncovered exts = %v, want %v", structExts, want)
+	}
+	if structDocs != 2 {
+		t.Errorf("structured uncovered doc count = %d, want 2", structDocs)
+	}
+}
+
+// TestUncoveredExtractableExtensions_FullCoverage confirms no false positive when
+// every extractable format is readable by the active engine.
+func TestUncoveredExtractableExtensions_FullCoverage(t *testing.T) {
+	corpus := map[string]int64{".pdf": 3, ".png": 1, ".jpg": 2}
+	if exts, docs := uncoveredExtractableExtensions(corpus, false); len(exts) != 0 || docs != 0 {
+		t.Errorf("fully-covered corpus reported uncovered exts=%v docs=%d, want none", exts, docs)
+	}
+}
+
+// TestExtractorIsStructured maps resolved extractor names to the structured/flat
+// distinction the capability table uses.
+func TestExtractorIsStructured(t *testing.T) {
+	for name, want := range map[string]bool{
+		"docling":       true,
+		"docling-serve": true,
+		"mistral-ocr":   false,
+		"":              false,
+		"unknown":       false,
+	} {
+		if got := extractorIsStructured(name); got != want {
+			t.Errorf("extractorIsStructured(%q) = %v, want %v", name, got, want)
+		}
+	}
+}
+
+// TestUncoveredExtractionRemedy_TailoredToEngine checks the remediation hint
+// points a flat-OCR user at docling for the docling-coverable formats, and tells
+// a docling user that docling cannot help with the neither-engine formats.
+func TestUncoveredExtractionRemedy_TailoredToEngine(t *testing.T) {
+	// Flat path with a docling-coverable format present → name docling.
+	if got := uncoveredExtractionRemedy([]string{".docx", ".odt"}, false); !strings.Contains(got, "docling") {
+		t.Errorf("flat remedy %q should recommend installing docling", got)
+	}
+	// Flat path where docling would not help either (neither-engine formats).
+	if got := uncoveredExtractionRemedy([]string{".gif", ".svg"}, false); strings.Contains(got, "Install docling") {
+		t.Errorf("flat remedy for neither-engine formats %q should not recommend docling", got)
+	}
+	// Structured path: docling is already active and cannot import these.
+	if got := uncoveredExtractionRemedy([]string{".odt"}, true); !strings.Contains(got, "cannot import") {
+		t.Errorf("structured remedy %q should say docling cannot import them", got)
+	}
+}

--- a/internal/ingest/capability.go
+++ b/internal/ingest/capability.go
@@ -1,0 +1,121 @@
+package ingest
+
+// This file is the single internal source of truth for which extraction engine
+// can read which file format. It consolidates the three format allowlists that
+// were previously scattered across the codebase (#395 Stage 1):
+//
+//   - ingest.extractorSupportsExt — the docling-structured vs flat-OCR split
+//     added by #394 (formerly a pair of inline switch statements here);
+//   - mistral.ocrMIMEType — the flat-OCR pdf/png/jpg/jpeg/webp allowlist (its
+//     supported-extension set MUST mirror flatOCRReadableExt below; the mirror
+//     is enforced by TestOCRMIMESetMatchesCapabilityTable);
+//   - docling's implicit supported set — the OpenXML Office + tiff/bmp raster
+//     formats it imports, minus the OpenDocument/RTF/legacy-.doc/gif/svg family
+//     it cannot.
+//
+// IMPORTANT (scope): this is a byte-identical refactor. The table reproduces the
+// EXACT verdicts the previous inline allowlists returned — it does NOT change
+// which engine handles which format, and it deliberately adds NO fallback or
+// per-format selection logic. Capability-aware per-format SELECTION (picking the
+// best available engine per format, strict/lenient degradation) is #395
+// Stages 2-3, which are spec-PR-first (SPEC §7.4.B currently defines extraction
+// as a single global cascade, not a provider capability) and OUT OF SCOPE here.
+// A per-engine fidelity/precedence column is intentionally deferred to that work
+// so nothing in this PR can consume it for routing.
+
+// extractionEngine is the coarse engine family the capability table distinguishes.
+// It matches the ONLY distinction extractorCanReadExt makes today: the flat
+// Mistral-OCR path vs the structured docling family (docling CLI / docling-serve,
+// the engines that emit a DoclingDocument). Bespoke/self-hosted OCR profiles ride
+// the flat path; a future pandoc extractor (#393) would be added as a new engine
+// here rather than as another scattered allowlist.
+type extractionEngine int
+
+const (
+	// engineFlatOCR is the flat Mistral-OCR / bespoke-OCR path: text only, no
+	// structure. It reads exactly flatOCRReadableExt.
+	engineFlatOCR extractionEngine = iota
+	// engineStructured is the docling family: it emits a DoclingDocument and
+	// imports every pdf/image/document format EXCEPT structuredUnreadableExt.
+	engineStructured
+)
+
+// flatOCRReadableExt is the exact set of extensions the flat OCR path can read —
+// identical to (and the authoritative mirror of) mistral.ocrMIMEType's keys.
+// Everything else routed to a flat-OCR extractor is rejected upstream (#394
+// defect 3), so it is skipped with a visible unsupported-format diagnostic
+// rather than handed to an engine that hard-errors on it.
+var flatOCRReadableExt = map[string]struct{}{
+	".pdf":  {},
+	".png":  {},
+	".jpg":  {},
+	".jpeg": {},
+	".webp": {},
+}
+
+// structuredUnreadableExt is the set of pdf/image/document formats the docling
+// family CANNOT import: the OpenDocument family (.odt/.odp/.ods), RTF, legacy
+// binary .doc, and gif/svg (#394 defects 2 & 3). docling reads every OTHER
+// extension routed to it (the shared pdf/png/jpg/jpeg/webp set, plus OpenXML
+// Office docx/pptx/xlsx and tiff/bmp raster images), so the structured verdict
+// is a denylist: supported unless listed here. Content support for these
+// unreadable formats is tracked in #393.
+var structuredUnreadableExt = map[string]struct{}{
+	".odt": {},
+	".odp": {},
+	".ods": {},
+	".rtf": {},
+	".doc": {},
+	".gif": {},
+	".svg": {},
+}
+
+// engineSupportsExt reports whether the given extraction engine can read ext.
+// It is the single lookup both extractorSupportsExt and the doctor coverage
+// diagnostic consult. ext is expected already lowercased with its leading dot
+// (as filepath.Ext returns for a lowercased path).
+//
+// The verdicts are byte-identical to the pre-consolidation inline allowlists:
+//   - flat OCR: an allowlist — true iff ext is in flatOCRReadableExt;
+//   - structured: a denylist — true unless ext is in structuredUnreadableExt,
+//     so unlisted extensions (e.g. .txt, .html) stay "supported", exactly as the
+//     old `default: return true` branch behaved.
+func engineSupportsExt(engine extractionEngine, ext string) bool {
+	switch engine {
+	case engineFlatOCR:
+		_, ok := flatOCRReadableExt[ext]
+		return ok
+	case engineStructured:
+		_, denied := structuredUnreadableExt[ext]
+		return !denied
+	default:
+		return false
+	}
+}
+
+// extractorSupportsExt reports whether the selected document extractor can
+// actually read the given file extension (#394), consulting the consolidated
+// capability table above. SPEC §7.4.B routes every pdf/image/document doc_type
+// to one configured extractor, but no single extractor reads every format in
+// those coarse buckets, so a format outside the active engine's set must be
+// skipped with a visible diagnostic rather than handed to an extractor that
+// fails silently or hard-errors on it.
+//
+// `structured` is true for the docling family (local CLI or docling-serve — the
+// engines that emit a DoclingDocument), false for the flat Mistral-OCR path.
+func extractorSupportsExt(structured bool, ext string) bool {
+	engine := engineFlatOCR
+	if structured {
+		engine = engineStructured
+	}
+	return engineSupportsExt(engine, ext)
+}
+
+// ExtractorSupportsExt is the exported wrapper over extractorSupportsExt so
+// out-of-package diagnostics (the doctor extraction-coverage check) can consult
+// the same single source of truth for which formats the active engine covers,
+// without duplicating the allowlist. `structured` mirrors extractorCanReadExt's
+// distinction: true for the docling family, false for the flat OCR path.
+func ExtractorSupportsExt(structured bool, ext string) bool {
+	return extractorSupportsExt(structured, ext)
+}

--- a/internal/ingest/extractor_routing_test.go
+++ b/internal/ingest/extractor_routing_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/dirstral/dir2mcp/internal/mistral"
 	"github.com/dirstral/dir2mcp/internal/model"
 )
 
@@ -25,44 +26,76 @@ func (structuredRoutingExtractor) ExtractStructured(context.Context, string, []b
 	return StructuredExtraction{}, nil
 }
 
-// TestExtractorSupportsExt pins the #394 capability split: the flat OCR path
-// reads exactly the ocrMIMEType allowlist, while docling additionally reads
-// OpenXML Office and tiff/bmp but not the OpenDocument/RTF/legacy-.doc family or
-// gif/svg.
+// extractorRoutingCases is the full #394/#395 fixture set. It is the regression
+// guard proving the consolidated capability table (internal/ingest/capability.go)
+// returns byte-identical verdicts to the pre-consolidation inline allowlists: the
+// flat OCR path reads exactly the ocrMIMEType allowlist, docling additionally
+// reads OpenXML Office and tiff/bmp but not the OpenDocument/RTF/legacy-.doc
+// family or gif/svg, and any unlisted extension (html, txt) stays "supported" on
+// the structured denylist path.
+var extractorRoutingCases = []struct {
+	ext        string
+	flat       bool // expected support on the flat OCR path
+	structured bool // expected support on the docling family
+}{
+	// Read by both engines.
+	{".pdf", true, true},
+	{".png", true, true},
+	{".jpg", true, true},
+	{".jpeg", true, true},
+	{".webp", true, true},
+	// docling-only: OpenXML Office + tiff/bmp raster images.
+	{".docx", false, true},
+	{".pptx", false, true},
+	{".xlsx", false, true},
+	{".tif", false, true},
+	{".tiff", false, true},
+	{".bmp", false, true},
+	// Read by neither engine (#394 defects 2 & 3; content support in #393).
+	{".odt", false, false},
+	{".odp", false, false},
+	{".ods", false, false},
+	{".rtf", false, false},
+	{".doc", false, false},
+	{".gif", false, false},
+	{".svg", false, false},
+	// Unlisted extensions: rejected on the flat allowlist, "supported" on the
+	// structured denylist (the old `default: return true` branch — e.g. html
+	// reaches docling; #394 defect 1).
+	{".html", false, true},
+	{".txt", false, true},
+}
+
+// TestExtractorSupportsExt pins the #394 capability split against the
+// consolidated table, and asserts the exported wrapper agrees with the
+// unexported form so out-of-package diagnostics see identical verdicts.
 func TestExtractorSupportsExt(t *testing.T) {
-	cases := []struct {
-		ext        string
-		flat       bool // expected support on the flat OCR path
-		structured bool // expected support on the docling family
-	}{
-		// Read by both engines.
-		{".pdf", true, true},
-		{".png", true, true},
-		{".jpg", true, true},
-		{".jpeg", true, true},
-		{".webp", true, true},
-		// docling-only: OpenXML Office + tiff/bmp raster images.
-		{".docx", false, true},
-		{".pptx", false, true},
-		{".xlsx", false, true},
-		{".tif", false, true},
-		{".tiff", false, true},
-		{".bmp", false, true},
-		// Read by neither engine (#394 defects 2 & 3; content support in #393).
-		{".odt", false, false},
-		{".odp", false, false},
-		{".ods", false, false},
-		{".rtf", false, false},
-		{".doc", false, false},
-		{".gif", false, false},
-		{".svg", false, false},
-	}
-	for _, tc := range cases {
+	for _, tc := range extractorRoutingCases {
 		if got := extractorSupportsExt(false, tc.ext); got != tc.flat {
 			t.Errorf("extractorSupportsExt(flat, %q) = %v, want %v", tc.ext, got, tc.flat)
 		}
 		if got := extractorSupportsExt(true, tc.ext); got != tc.structured {
 			t.Errorf("extractorSupportsExt(structured, %q) = %v, want %v", tc.ext, got, tc.structured)
+		}
+		if got := ExtractorSupportsExt(false, tc.ext); got != tc.flat {
+			t.Errorf("ExtractorSupportsExt(flat, %q) = %v, want %v", tc.ext, got, tc.flat)
+		}
+		if got := ExtractorSupportsExt(true, tc.ext); got != tc.structured {
+			t.Errorf("ExtractorSupportsExt(structured, %q) = %v, want %v", tc.ext, got, tc.structured)
+		}
+	}
+}
+
+// TestOCRMIMESetMatchesCapabilityTable guards the mirror between the flat-OCR
+// verdict in the consolidated capability table and mistral.ocrMIMEType's
+// supported-extension set (the two authoritative-but-cycle-separated allowlists
+// #395 Stage 1 consolidates). Any divergence — an extension one accepts and the
+// other rejects — would reintroduce the silent-routing class of bug and fails
+// here.
+func TestOCRMIMESetMatchesCapabilityTable(t *testing.T) {
+	for _, tc := range extractorRoutingCases {
+		if got := mistral.SupportsOCRExt(tc.ext); got != tc.flat {
+			t.Errorf("mistral.SupportsOCRExt(%q) = %v, but capability table flat verdict is %v; the OCR MIME set and the table have drifted", tc.ext, got, tc.flat)
 		}
 	}
 }

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -380,42 +380,6 @@ var errNoVideoRepresentation = errors.New(
 	"video produced no representation: no subtitle sidecar found, video is not transcribed (STT is audio-only), " +
 		"and multimodal keyframe embedding is off — enable embed_multimodal or provide a .vtt/.srt sidecar to make it searchable")
 
-// extractorSupportsExt reports whether the selected document extractor can
-// actually read the given file extension (#394). SPEC §7.4B routes every
-// pdf/image/document doc_type to one configured extractor, but no single
-// extractor reads every format in those coarse buckets, so a format outside the
-// active engine's set must be skipped with a visible diagnostic rather than
-// handed to an extractor that fails silently or hard-errors on it.
-//
-// `structured` is true for the docling family (local CLI or docling-serve — the
-// engines that emit a DoclingDocument), false for the flat Mistral-OCR path.
-//   - Flat OCR (Mistral) reads exactly the ocrMIMEType allowlist:
-//     pdf/png/jpg/jpeg/webp. Everything else routed to it (all Office/OpenDocument
-//     documents and the gif/bmp/tiff/svg images) is rejected upstream (#394
-//     defect 3).
-//   - docling additionally imports OpenXML Office (docx/pptx/xlsx) and tiff/bmp
-//     raster images, but does NOT import the OpenDocument family (.odt/.odp/.ods),
-//     RTF, legacy binary .doc, or gif/svg (#394 defects 2 & 3). Every other
-//     extension is left "supported" so nothing docling handles today regresses;
-//     content support for the unreadable formats is tracked in #393.
-func extractorSupportsExt(structured bool, ext string) bool {
-	switch ext {
-	case ".pdf", ".png", ".jpg", ".jpeg", ".webp":
-		// Read by both docling and Mistral OCR.
-		return true
-	}
-	if !structured {
-		return false
-	}
-	switch ext {
-	case ".odt", ".odp", ".ods", ".rtf", ".doc", ".gif", ".svg":
-		// Not imported by docling; content support tracked in #393.
-		return false
-	default:
-		return true
-	}
-}
-
 // extractorCanReadExt reports whether the currently-selected extractor can read
 // the asset's format. Docling-family extractors implement structuredExtractor;
 // the flat Mistral-OCR path does not.

--- a/internal/mistral/client.go
+++ b/internal/mistral/client.go
@@ -502,6 +502,15 @@ func (c *Client) extractWithRetry(ctx context.Context, relPath string, data []by
 // that extractWithRetry can invoke it repeatedly.
 // ocrMIMEType returns the MIME type for the given file extension, or ("", false)
 // if the extension is not supported for OCR.
+//
+// The set of extensions accepted here is the flat-OCR readable set and MUST stay
+// in lockstep with the consolidated capability table's flatOCRReadableExt
+// (internal/ingest/capability.go) — the single source of truth for extraction
+// routing (#395). mistral lives below ingest in the import graph and cannot
+// import it, so the mapping is duplicated here (it also owns the ext→MIME
+// strings, a mistral-specific concern); the two are kept from diverging by
+// ingest.TestOCRMIMESetMatchesCapabilityTable, which cross-checks this function
+// against the table.
 func ocrMIMEType(ext string) (string, bool) {
 	switch ext {
 	case ".pdf":
@@ -515,6 +524,17 @@ func ocrMIMEType(ext string) (string, bool) {
 	default:
 		return "", false
 	}
+}
+
+// SupportsOCRExt reports whether the flat Mistral-OCR path accepts the given
+// file extension, i.e. whether ocrMIMEType maps it to a MIME type. It exists so
+// the ingest capability table (the single source of truth for extraction
+// routing, #395) can cross-check that its flat-OCR extension set has not drifted
+// from this package's OCR allowlist, without exporting the ext→MIME mapping
+// itself. ext is expected lowercased with its leading dot.
+func SupportsOCRExt(ext string) bool {
+	_, ok := ocrMIMEType(ext)
+	return ok
 }
 
 // extractOCRText assembles the text content from an OCR response, preferring

--- a/internal/mistral/ocr_mime_test.go
+++ b/internal/mistral/ocr_mime_test.go
@@ -1,0 +1,40 @@
+package mistral
+
+import "testing"
+
+// TestOCRMIMEType_Unchanged pins the exact ext→MIME mapping the flat OCR path
+// accepts. It is the byte-identical guard for #395 Stage 1: consolidating the
+// scattered format allowlists must not change which extensions Mistral OCR reads
+// or the MIME value it sends upstream.
+func TestOCRMIMEType_Unchanged(t *testing.T) {
+	supported := map[string]string{
+		".pdf":  "application/pdf",
+		".png":  "image/png",
+		".jpg":  "image/jpeg",
+		".jpeg": "image/jpeg",
+		".webp": "image/webp",
+	}
+	for ext, wantMIME := range supported {
+		gotMIME, ok := ocrMIMEType(ext)
+		if !ok {
+			t.Errorf("ocrMIMEType(%q) reported unsupported, want %q", ext, wantMIME)
+			continue
+		}
+		if gotMIME != wantMIME {
+			t.Errorf("ocrMIMEType(%q) = %q, want %q", ext, gotMIME, wantMIME)
+		}
+		if !SupportsOCRExt(ext) {
+			t.Errorf("SupportsOCRExt(%q) = false, want true", ext)
+		}
+	}
+	// Formats routed to OCR but not readable by it (#394 defect 3) must stay
+	// rejected so they are skipped with a diagnostic, never sent upstream.
+	for _, ext := range []string{".docx", ".tiff", ".bmp", ".odt", ".rtf", ".doc", ".gif", ".svg", ".html", ".txt", ""} {
+		if mime, ok := ocrMIMEType(ext); ok {
+			t.Errorf("ocrMIMEType(%q) = (%q, true), want unsupported", ext, mime)
+		}
+		if SupportsOCRExt(ext) {
+			t.Errorf("SupportsOCRExt(%q) = true, want false", ext)
+		}
+	}
+}

--- a/internal/store/extractable_extensions_test.go
+++ b/internal/store/extractable_extensions_test.go
@@ -1,0 +1,52 @@
+package store
+
+import (
+	"context"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// TestExtractableExtensionCounts drives the store query that feeds the doctor
+// extraction-coverage diagnostic (#395): it must count only non-deleted,
+// index-eligible (status='ok') documents in the extractable pdf/image/document
+// buckets, keyed by lowercased extension, and ignore code/text/deleted/errored
+// rows.
+func TestExtractableExtensionCounts(t *testing.T) {
+	st := NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	defer func() { _ = st.Close() }()
+	ctx := context.Background()
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("init store: %v", err)
+	}
+
+	docs := []model.Document{
+		{RelPath: "a.PDF", DocType: "pdf", Status: "ok", ContentHash: "h1"},   // uppercase ext → normalized
+		{RelPath: "b.pdf", DocType: "pdf", Status: "ok", ContentHash: "h2"},   // second .pdf
+		{RelPath: "scan.tiff", DocType: "image", Status: "ok", ContentHash: "h3"},
+		{RelPath: "notes.odt", DocType: "document", Status: "ok", ContentHash: "h4"},
+		{RelPath: "main.go", DocType: "code", Status: "ok", ContentHash: "h5"},        // not extractable
+		{RelPath: "bad.docx", DocType: "document", Status: "error", ContentHash: "h6"}, // wrong status
+		{RelPath: "gone.pdf", DocType: "pdf", Status: "ok", Deleted: true, ContentHash: "h7"}, // deleted
+	}
+	for _, d := range docs {
+		if err := st.UpsertDocument(ctx, d); err != nil {
+			t.Fatalf("upsert %s: %v", d.RelPath, err)
+		}
+	}
+
+	got, err := st.ExtractableExtensionCounts(ctx, "ok")
+	if err != nil {
+		t.Fatalf("ExtractableExtensionCounts: %v", err)
+	}
+	want := map[string]int64{
+		".pdf":  2,
+		".tiff": 1,
+		".odt":  1,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ExtractableExtensionCounts = %v, want %v", got, want)
+	}
+}

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -105,6 +105,50 @@ func (s *SQLiteStore) ActiveDocCountsByStatus(ctx context.Context, status string
 	return counts, rows.Err()
 }
 
+// ExtractableExtensionCounts returns per-lowercased-extension counts of
+// non-deleted, index-eligible documents whose doc_type requires a document
+// extractor to become searchable (the pdf/image/document buckets). It powers the
+// doctor extraction-coverage diagnostic, which names the SPECIFIC corpus
+// extensions the active extractor cannot read (#395).
+//
+// The doc_type filter mirrors ingest.ShouldGenerateExtractedMarkdown's
+// extractable set (pdf/image/document); store sits below ingest in the import
+// graph and cannot import it, so the list is duplicated here. Rows with an empty
+// extension are bucketed under "" so the caller can still see uncovered
+// extension-less assets. When status is non-empty the count is restricted to
+// documents in that status (e.g. "ok" for index-eligible rows), matching
+// ActiveDocCountsByStatus.
+func (s *SQLiteStore) ExtractableExtensionCounts(ctx context.Context, status string) (map[string]int64, error) {
+	db, err := s.ensureDB(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer s.ReleaseDB()
+
+	query := `SELECT rel_path FROM documents WHERE deleted = 0 AND doc_type IN ('pdf','image','document')`
+	args := []any{}
+	if trimmed := strings.TrimSpace(status); trimmed != "" {
+		query = `SELECT rel_path FROM documents WHERE deleted = 0 AND doc_type IN ('pdf','image','document') AND status = ?`
+		args = append(args, trimmed)
+	}
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	counts := make(map[string]int64)
+	for rows.Next() {
+		var relPath string
+		if err := rows.Scan(&relPath); err != nil {
+			return nil, err
+		}
+		ext := strings.ToLower(filepath.Ext(strings.TrimSpace(relPath)))
+		counts[ext]++
+	}
+	return counts, rows.Err()
+}
+
 // activeDocCountsWith encapsulates the query logic previously found in
 // SQLiteStore.ActiveDocCounts.  It accepts any dbExecutor so callers can reuse
 // an existing *sql.DB or a *sql.Tx without having to open a handle again.

--- a/tests/security/cli_boundary_test.go
+++ b/tests/security/cli_boundary_test.go
@@ -191,6 +191,7 @@ func TestRepoSplitBoundary_InternalCLIFileOwnership(t *testing.T) {
 		"rerank_selection_test.go":               {},
 		"routing_decision.go":                    {},
 		"server_doctor.go":                       {},
+		"server_doctor_coverage_test.go":         {},
 		"server_log_tee_internal_test.go":        {},
 		"service.go":                             {},
 		"service_darwin.go":                      {},


### PR DESCRIPTION
## What

Stage 1 (spec-neutral) of #395: a **byte-identical routing refactor** plus a diagnostic-quality improvement. **No behavior/routing change, no spec PR.** The capability-aware per-format **selection** matrix and strict/lenient degradation (#395 Stages 2-3) are **spec-PR-first and deliberately out of scope** — SPEC §7.4.B defines extraction as a single global cascade ("extraction is not a provider capability"), so a per-format selection layer needs a `dirstral-spec` PR first.

### 1. One capability table (pure refactor, verdicts byte-identical)
The three scattered format allowlists are consolidated into a single internal source of truth, `internal/ingest/capability.go`:
- `internal/ingest/service.go` `extractorSupportsExt` — the docling-structured vs flat-OCR split (#394).
- `internal/mistral/client.go` `ocrMIMEType` — the pdf/png/jpg/jpeg/webp OCR set.
- docling's implicit supported set.

The table reproduces the **exact** prior verdicts: the flat-OCR allowlist (`pdf/png/jpg/jpeg/webp`) and the docling denylist (`.odt/.odp/.ods/.rtf/.doc/.gif/.svg`), with any unlisted extension staying "supported" on the structured path exactly as the old `default: return true` branch did. `extractorSupportsExt`/`extractorCanReadExt` now consult the table. **No engine-selection or fallback logic is added**; a per-engine fidelity/precedence column is deliberately deferred to Stage 2 so nothing here can consume it for routing.

`mistral.ocrMIMEType` is unchanged (it owns the mistral-specific ext→MIME strings and sits below `ingest` in the import graph, so it can't import the table). A new `mistral.SupportsOCRExt` lets an ingest test cross-check that the table's flat-OCR set has **not drifted** from the OCR allowlist — the mirror is CI-enforced.

### 2. Doctor names the specific uncovered formats
`extractionCoverageCheck` previously only fired when **no** extractor existed at all. It now, when an extractor **is** active, names the **specific uncovered extensions present in the corpus** (e.g. `.odt, .tiff are uncovered by the active extractor (mistral-ocr)`) with an engine-tailored remedy, backed by a new `store.ExtractableExtensionCounts` query. This is within §7.7's existing "surface the reason" mandate — a diagnostic improvement, not a new routing surface. The global "no extractor" banner is preserved.

## Tests
- `TestExtractorSupportsExt` extended to the full #394 fixture set (`.odt/.rtf/.doc`, `.tiff/.bmp`, `.gif/.svg`, `.html`, `.docx/.jpg/.pdf`) as a byte-identical regression guard, asserting both the unexported and exported forms.
- `TestOCRMIMESetMatchesCapabilityTable` — cross-checks the table's flat set against `mistral.SupportsOCRExt`.
- `TestOCRMIMEType_Unchanged` — pins the exact ext→MIME mapping.
- Doctor tests naming uncovered extensions for a fixture corpus (both engine kinds) + remedy tailoring.
- `TestExtractableExtensionCounts` — store query counts only non-deleted, `status='ok'`, extractable-bucket docs by lowercased ext.

## Verification
- `make lint` → 0 issues.
- `go test ./internal/ingest/... ./internal/mistral/... ./internal/cli/... ./internal/store/... ./tests/ingest/...` → pass.
- `go vet ./...` → clean. `gocyclo` on the changed `extractionCoverageCheck` = 14 (≤15).
- Routing is byte-identical: a chunk/format that resolved to engine X before resolves to X after (guarded by the extended fixture-set test).

Addresses #395 (Stage 1: spec-neutral consolidation + coverage diagnostic; Stages 2-3 per-format selection are spec-PR-first, deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)