### PR TITLE
feat(ingest): capability-aware per-format extraction + HTML→docling routing (#395 Stages 2-3, #556)

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ For Homebrew and other installed workflows, you can persist this in `.dir2mcp.ya
 
 ```yaml
 ingest_extractor: auto
+ingest_on_unsupported: lenient   # lenient (default) | strict
 docling_command: docling --to json --output - {input}
 ```
 
@@ -356,6 +357,10 @@ PDFs and images are converted to text by an **extractor**, selected with `ingest
 | `off` | No extraction (PDFs/images contribute no extracted text). |
 
 Under `auto`, the fallback cascade is **docling CLI → docling-serve → Mistral OCR → disabled**. The chosen extractor is reported at startup and by `dir2mcp doctor` (e.g. `OCR: mistral-ocr (fallback; docling not found on PATH)`), so the active path is visible rather than inferred per document.
+
+**Best-available *per format* (§7.4.B.1).** Selection is capability-aware: for each format, `auto` picks the highest-fidelity *active* engine that can actually read it, so no document is silently handed to an engine that can't (e.g. `.docx`/`.tiff` go to docling but are never routed to Mistral OCR, which can't import them), and a higher-fidelity engine is never bypassed. HTML is a dual-path format: when a structured engine (docling) is active it is routed there to preserve headings/tables/links (`extracted_markdown` with structured spans); otherwise it falls back to flat `raw_text` — so HTML is never dropped and never regresses when docling is absent.
+
+**When no active engine covers a format** (`ingest.on_unsupported`, env `DIR2MCP_INGEST_ON_UNSUPPORTED`): `lenient` (default) skips the document with a warning and names the gap in the coverage report (`dir2mcp doctor`) — the backward-compatible, honest-not-silent outcome; `strict` records it as a non-fatal per-document `UNSUPPORTED_FORMAT` error (for CI / correctness-sensitive corpora). Either way the gap is surfaced, never silent.
 
 An extractor counts as *available* only when it can actually **run**, not merely when it is configured (spec 0.15.0 §7.4). The `docling` CLI is functional-checked (a quick `docling --version` probe, cached for the run); a binary that is present but broken — e.g. a venv with ABI-incompatible dependencies — is treated as **unavailable**, exactly as an unreachable `serve_url` makes `docling-serve` unavailable. Under `auto` a broken docling is skipped and the cascade continues; under explicit `docling` it disables extraction (no silent fallback). `dir2mcp doctor` reports the real state instead of a false "healthy".
 

--- a/internal/cli/server_doctor.go
+++ b/internal/cli/server_doctor.go
@@ -359,8 +359,12 @@ func uncoveredExtractableExtensions(extCounts map[string]int64, structured bool)
 // (docling) path, every uncovered format is in that neither-engine set, so
 // installing docling would not help and the hint says so.
 func uncoveredExtractionRemedy(uncovered []string, structured bool) string {
+	// The §7.7 coverage report MUST, for each uncovered class, name the engine to
+	// add AND the ingest.on_unsupported knob that governs whether the gap is a
+	// warning (lenient, the default) or a per-document error (strict).
+	const onUnsupportedHint = " Or set ingest.on_unsupported: strict to fail instead of skip these documents."
 	if structured {
-		return "docling cannot import these formats; they need a future pandoc-style extractor (#393) or pre-conversion to a supported format."
+		return "docling cannot import these formats; they need a future pandoc-style extractor (#393) or pre-conversion to a supported format." + onUnsupportedHint
 	}
 	doclingWouldCover := false
 	for _, ext := range uncovered {
@@ -370,9 +374,9 @@ func uncoveredExtractionRemedy(uncovered []string, structured bool) string {
 		}
 	}
 	if doclingWouldCover {
-		return "Install docling (or set ingest.extractor=docling) to cover the Office/tiff/bmp formats; the remaining OpenDocument/RTF/.doc/gif/svg formats need a future pandoc-style extractor (#393)."
+		return "Install docling (or set ingest.extractor=docling) to cover the Office/tiff/bmp formats; the remaining OpenDocument/RTF/.doc/gif/svg formats need a future pandoc-style extractor (#393)." + onUnsupportedHint
 	}
-	return "These formats are read by no available extractor; they need a future pandoc-style extractor (#393) or pre-conversion to a supported format."
+	return "These formats are read by no available extractor; they need a future pandoc-style extractor (#393) or pre-conversion to a supported format." + onUnsupportedHint
 }
 
 // indexingFailureCheck reads the store-level FailureSummary (set by

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -366,6 +366,11 @@ type Config struct {
 	IngestAudioMode      string
 	IngestArchivesMode   string
 	IngestExtractor      string
+	// IngestOnUnsupported is the §7.4.B.2 degradation mode for a format no active
+	// extraction engine can read: "lenient" (default) skips with a warning and
+	// names the gap in the honest coverage report, "strict" records a non-fatal
+	// per-document UNSUPPORTED_FORMAT error. Empty defaults to lenient.
+	IngestOnUnsupported string
 
 	// IndexBackend selects the vector index backend (issue #246): "memory"
 	// (default, the in-memory HNSW) or "disk" (the Tier-B pure-Go on-disk
@@ -758,6 +763,7 @@ type fileConfig struct {
 	IngestAudioMode                    *string
 	IngestArchivesMode                 *string
 	IngestExtractor                    *string
+	IngestOnUnsupported                *string
 	IndexBackend                       *string
 	IngestScanCache                    *bool
 	IngestLateChunking                 *bool
@@ -897,6 +903,7 @@ type persistedConfig struct {
 	IngestAudioMode                    string        `yaml:"ingest_audio_mode"`
 	IngestArchivesMode                 string        `yaml:"ingest_archives_mode"`
 	IngestExtractor                    string        `yaml:"ingest_extractor"`
+	IngestOnUnsupported                string        `yaml:"ingest_on_unsupported"`
 	IndexBackend                       string        `yaml:"index_backend"`
 	IngestScanCache                    bool          `yaml:"ingest_scan_cache"`
 	IngestLateChunking                 bool          `yaml:"ingest_late_chunking"`
@@ -1118,6 +1125,7 @@ func Default() Config {
 		IngestAudioMode:           "auto",
 		IngestArchivesMode:        "deep",
 		IngestExtractor:           "auto",
+		IngestOnUnsupported:       "lenient",
 		IndexBackend:              "memory",
 		IngestScanCache:           false,
 		IngestLateChunking:        false,
@@ -1257,6 +1265,7 @@ func buildPersistedConfig(cfg *Config) persistedConfig {
 		IngestAudioMode:                    cfg.IngestAudioMode,
 		IngestArchivesMode:                 cfg.IngestArchivesMode,
 		IngestExtractor:                    cfg.IngestExtractor,
+		IngestOnUnsupported:                cfg.IngestOnUnsupported,
 		IndexBackend:                       cfg.IndexBackend,
 		IngestScanCache:                    cfg.IngestScanCache,
 		IngestLateChunking:                 cfg.IngestLateChunking,
@@ -1960,6 +1969,9 @@ func applyIngestModesFileParsed(cfg *Config, fc fileConfig) {
 	if fc.IngestExtractor != nil {
 		cfg.IngestExtractor = *fc.IngestExtractor
 	}
+	if fc.IngestOnUnsupported != nil {
+		cfg.IngestOnUnsupported = *fc.IngestOnUnsupported
+	}
 	if fc.IndexBackend != nil {
 		cfg.IndexBackend = *fc.IndexBackend
 	}
@@ -2414,6 +2426,8 @@ var configKeyAliases = map[string]string{
 	"archives_mode":                           "ingest.archives.mode",
 	"ingest_extractor":                        "ingest.extractor",
 	"extractor":                               "ingest.extractor",
+	"ingest_on_unsupported":                   "ingest.on_unsupported",
+	"on_unsupported":                          "ingest.on_unsupported",
 	"index_backend":                           "index.backend",
 	"backend":                                 "index.backend",
 	"media_variants_group":                    "media.variants.group",
@@ -2866,6 +2880,8 @@ func setIngestStringFileScalar(cfg *fileConfig, key, value string) {
 		cfg.IngestArchivesMode = strPtr(value)
 	case "ingest.extractor":
 		cfg.IngestExtractor = strPtr(value)
+	case "ingest.on_unsupported":
+		cfg.IngestOnUnsupported = strPtr(value)
 	case "index.backend":
 		cfg.IndexBackend = strPtr(value)
 	case "stt.provider":
@@ -2876,6 +2892,15 @@ func setIngestStringFileScalar(cfg *fileConfig, key, value string) {
 		cfg.STTElevenLabsModel = strPtr(value)
 	case "stt.elevenlabs.language_code":
 		cfg.STTElevenLabsLanguageCode = strPtr(value)
+	default:
+		setMediaStringFileScalar(cfg, key, value)
+	}
+}
+
+// setMediaStringFileScalar assigns media.* string keys onto the fileConfig. Split
+// out of setIngestStringFileScalar so each stays within the cyclomatic budget.
+func setMediaStringFileScalar(cfg *fileConfig, key, value string) {
+	switch key {
 	case "media.variants.select":
 		cfg.MediaVariantsSelect = strPtr(value)
 	case "media.subtitles.segmentation":
@@ -3052,6 +3077,7 @@ func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	writeScalar("ingest_audio_mode", cfg.IngestAudioMode)
 	writeScalar("ingest_archives_mode", cfg.IngestArchivesMode)
 	writeScalar("ingest_extractor", cfg.IngestExtractor)
+	writeScalar("ingest_on_unsupported", cfg.IngestOnUnsupported)
 	writeScalar("index_backend", cfg.IndexBackend)
 	writeBool("ingest_scan_cache", cfg.IngestScanCache)
 	writeBool("ingest_late_chunking", cfg.IngestLateChunking)
@@ -3330,6 +3356,7 @@ func applyIngestEnvOverrides(cfg *Config, env map[string]string) {
 		{"DIR2MCP_DOCLING_COMMAND", &cfg.DoclingCommand},
 		{"DIR2MCP_DOCLING_SERVE_URL", &cfg.IngestDoclingServeURL},
 		{"DIR2MCP_INGEST_EXTRACTOR", &cfg.IngestExtractor},
+		{"DIR2MCP_INGEST_ON_UNSUPPORTED", &cfg.IngestOnUnsupported},
 		{"DIR2MCP_INDEX_BACKEND", &cfg.IndexBackend},
 	} {
 		if raw, ok := envLookup(o.key, env); ok && strings.TrimSpace(raw) != "" {
@@ -3552,6 +3579,9 @@ func applyX402RouteEnvOverrides(cfg *Config, env map[string]string) {
 // ValidateX402, this method operates on a pointer receiver so that it can
 // modify the receiver in-place.
 func (c *Config) Validate() error {
+	if err := c.validateIngestOnUnsupported(); err != nil {
+		return err
+	}
 	if err := c.validateIngestExtractor(); err != nil {
 		return err
 	}
@@ -3837,6 +3867,23 @@ func (c *Config) validateIngestExtractor() error {
 		return fmt.Errorf("ingest.extractor must be one of auto, docling, docling-serve, mistral, off: %q", c.IngestExtractor)
 	}
 	c.IngestExtractor = extractorMode
+	return nil
+}
+
+// validateIngestOnUnsupported normalizes IngestOnUnsupported (defaulting empty to
+// the lenient default) and rejects any value outside lenient/strict. It is the
+// §7.4.B.2 degradation-mode knob mirroring the tri-state opt-outs used elsewhere.
+func (c *Config) validateIngestOnUnsupported() error {
+	mode := strings.ToLower(strings.TrimSpace(c.IngestOnUnsupported))
+	if mode == "" {
+		mode = Default().IngestOnUnsupported
+	}
+	switch mode {
+	case "lenient", "strict":
+	default:
+		return fmt.Errorf("ingest.on_unsupported must be one of lenient, strict: %q", c.IngestOnUnsupported)
+	}
+	c.IngestOnUnsupported = mode
 	return nil
 }
 

--- a/internal/ingest/capability.go
+++ b/internal/ingest/capability.go
@@ -1,5 +1,7 @@
 package ingest
 
+import "strings"
+
 // This file is the single internal source of truth for which extraction engine
 // can read which file format. It consolidates the three format allowlists that
 // were previously scattered across the codebase (#395 Stage 1):
@@ -118,4 +120,115 @@ func extractorSupportsExt(structured bool, ext string) bool {
 // distinction: true for the docling family, false for the flat OCR path.
 func ExtractorSupportsExt(structured bool, ext string) bool {
 	return extractorSupportsExt(structured, ext)
+}
+
+// --- Capability-aware, per-format selection (#395 Stage 2 / #556) --------------
+//
+// SPEC §7.4.B.1 defines the extraction-engine registry as a fidelity-ordered
+// capability matrix and mandates "best-available per format" routing under
+// `ingest.extractor: auto`: for each classified document, select the ACTIVE
+// engine of lowest fidelity tier whose matrix cell for that format is ✅, falling
+// through the tier order (T1 docling → T2 pandoc[future #393] → T3 mistral OCR →
+// T4 raw_text). A format no active engine supports degrades per §7.4.B.2; html is
+// the one format whose T4 `raw_text` baseline (§7.4.A) is unconditional, so it is
+// never dropped. selectExtractionRoute below is that algorithm; the ingest
+// service consumes it (deriving which engines are active from the resolved
+// extractor) so routing is a single, spec-faithful decision rather than a coarse
+// doc_type switch. pandoc (T2) is declared in the matrix for completeness but is
+// never active until #393 ships, so it is not represented as an eligible engine
+// here.
+
+// markupReadableExt is the markup (html) format class of the §7.4.B.1 matrix. It
+// is the only class with a `raw_text` (T4) ✅ cell, and per §7.4.A that baseline
+// is guaranteed: html is never dropped even when no structured engine is active
+// and even when a single engine is pinned.
+var markupReadableExt = map[string]struct{}{
+	".html":  {},
+	".htm":   {},
+	".xhtml": {},
+}
+
+// isMarkupExt reports whether ext is a markup (html) extension eligible for the
+// unconditional §7.4.A raw_text baseline. ext is expected lowercased with its
+// leading dot.
+func isMarkupExt(ext string) bool {
+	_, ok := markupReadableExt[ext]
+	return ok
+}
+
+// extractionRoute is the pipeline action the per-format selection resolves for a
+// document's format (§7.4.B.1). The ingest service consumes it to decide how — or
+// whether — to produce an extracted_markdown representation.
+type extractionRoute int
+
+const (
+	// routeDegrade: no active engine supports the format (a coverage gap under
+	// `auto`, or a pinned engine that cannot read it). Handled per the §7.4.B.2
+	// strict/lenient degradation contract; never a silent empty representation.
+	routeDegrade extractionRoute = iota
+	// routeStructured: the docling family (T1) — structured extracted_markdown
+	// with region spans (§7.4.B "Structured extraction").
+	routeStructured
+	// routeFlatOCR: the mistral OCR engine (T3) — page-separated extracted_markdown
+	// (§7.4.B "Page-separated extraction").
+	routeFlatOCR
+	// routeRawText: the T4 raw_text baseline (§7.4.A). Applies only to markup
+	// (html) and is the guaranteed fallback so html is never dropped.
+	routeRawText
+)
+
+// extractionAvailability records which extraction engines are ACTIVE for the run
+// (§7.4.B "Extractor availability"). It is derived once from the resolved
+// extractor so the per-format selection can never drift from the engine the
+// service will actually run.
+type extractionAvailability struct {
+	// structured is true when the docling family (local CLI or docling-serve) is
+	// active — it resolved and passed its availability probe.
+	structured bool
+	// flatOCR is true when the mistral OCR engine (the active `ocr` provider) is
+	// available.
+	flatOCR bool
+}
+
+// selectExtractionRoute implements SPEC §7.4.B.1's best-available per-format
+// selection plus the §7.4.A markup boundary (#556). Given the `ingest.extractor`
+// policy, the set of active engines, and a lowercased file extension, it returns
+// the highest-fidelity ACTIVE engine that supports the format, falling through
+// the fidelity order. The selection is deterministic (a pure function of its
+// inputs) and, because availability is resolved once per run, cached for the run.
+//
+//   - `auto`: every engine is eligible (subject to availability).
+//   - `docling` / `docling-serve`: only the structured (docling family) engine is
+//     eligible — a pinned engine gets no cross-engine fallback (§7.4.B.1).
+//   - `mistral`: only the flat OCR engine is eligible.
+//   - `off`: no extraction engine is eligible; html still falls to its raw_text
+//     baseline, and pdf/image/document simply produce no extracted representation.
+//
+// A format no eligible+active engine supports returns routeDegrade, EXCEPT markup
+// (html), whose raw_text baseline (§7.4.A) is unconditional and exempt from the
+// pin restriction so html is never dropped.
+func selectExtractionRoute(policy string, avail extractionAvailability, ext string) extractionRoute {
+	policy = strings.ToLower(strings.TrimSpace(policy))
+	if policy == "" {
+		policy = "auto"
+	}
+	structuredAllowed := policy == "auto" || policy == "docling" || policy == "docling-serve"
+	flatAllowed := policy == "auto" || policy == "mistral"
+
+	// T1 docling (structured): reads every extraction format except the
+	// structured-unreadable denylist.
+	if structuredAllowed && avail.structured && engineSupportsExt(engineStructured, ext) {
+		return routeStructured
+	}
+	// T3 mistral OCR (flat): the pdf/png/jpg/jpeg/webp allowlist.
+	if flatAllowed && avail.flatOCR && engineSupportsExt(engineFlatOCR, ext) {
+		return routeFlatOCR
+	}
+	// T4 raw_text baseline: markup (html) only, always available and exempt from
+	// the pin restriction (§7.4.A: "raw_text remains the guaranteed baseline;
+	// HTML is never dropped, and behavior MUST NOT regress when docling is absent").
+	if isMarkupExt(ext) {
+		return routeRawText
+	}
+	return routeDegrade
 }

--- a/internal/ingest/extractor_routing_test.go
+++ b/internal/ingest/extractor_routing_test.go
@@ -158,3 +158,76 @@ func TestUnsupportedExtractionErr(t *testing.T) {
 
 var _ model.DocumentExtractor = flatRoutingExtractor{}
 var _ model.DocumentExtractor = structuredRoutingExtractor{}
+
+// TestSelectExtractionRoute is the #395 Stage 2 / #556 guard for the
+// capability-aware, per-format selection (SPEC §7.4.B.1 best-available + §7.4.A
+// markup boundary). It pins the fidelity-ordered choice for every combination of
+// policy, active engines, and format that the shipped engines can produce.
+func TestSelectExtractionRoute(t *testing.T) {
+	both := extractionAvailability{structured: true, flatOCR: true}
+	structuredOnly := extractionAvailability{structured: true}
+	flatOnly := extractionAvailability{flatOCR: true}
+	none := extractionAvailability{}
+
+	cases := []struct {
+		name   string
+		policy string
+		avail  extractionAvailability
+		ext    string
+		want   extractionRoute
+	}{
+		// auto: docling (T1) is preferred whenever active, for every format it reads.
+		{"auto both pdf -> structured (T1 wins)", "auto", both, ".pdf", routeStructured},
+		{"auto both docx -> structured", "auto", both, ".docx", routeStructured},
+		{"auto both tiff -> structured (mistral cannot)", "auto", both, ".tiff", routeStructured},
+		// auto: docling absent -> mistral (T3) for its allowlist, degrade otherwise.
+		{"auto flat pdf -> flat OCR", "auto", flatOnly, ".pdf", routeFlatOCR},
+		{"auto flat png -> flat OCR", "auto", flatOnly, ".png", routeFlatOCR},
+		{"auto flat docx -> degrade (mistral cannot read docx)", "auto", flatOnly, ".docx", routeDegrade},
+		{"auto flat tiff -> degrade", "auto", flatOnly, ".tiff", routeDegrade},
+		// auto: nothing active -> degrade (except html, see below).
+		{"auto none pdf -> degrade", "auto", none, ".pdf", routeDegrade},
+		// html markup boundary (#556 / §7.4.A):
+		{"auto structured html -> structured (promoted, #556)", "auto", structuredOnly, ".html", routeStructured},
+		{"auto structured htm -> structured", "auto", structuredOnly, ".htm", routeStructured},
+		{"auto flat html -> raw_text baseline (mistral cannot read html)", "auto", flatOnly, ".html", routeRawText},
+		{"auto none html -> raw_text baseline (never dropped)", "auto", none, ".html", routeRawText},
+		// pinned docling: only structured is eligible.
+		{"pin docling pdf -> structured", "docling", structuredOnly, ".pdf", routeStructured},
+		{"pin docling html -> structured", "docling", structuredOnly, ".html", routeStructured},
+		{"pin docling odt -> degrade (docling cannot import odt)", "docling", structuredOnly, ".odt", routeDegrade},
+		// pinned mistral: no cross-engine fallback; html still keeps its baseline.
+		{"pin mistral pdf -> flat OCR", "mistral", flatOnly, ".pdf", routeFlatOCR},
+		{"pin mistral docx -> degrade (no fallback to docling)", "mistral", both, ".docx", routeDegrade},
+		{"pin mistral html -> raw_text baseline (§7.4.A, never dropped)", "mistral", both, ".html", routeRawText},
+		// docling-serve is a structured transport: behaves like docling for selection.
+		{"pin docling-serve pdf -> structured", "docling-serve", structuredOnly, ".pdf", routeStructured},
+		// off: no extraction engine eligible; html still falls to its baseline.
+		{"off pdf -> degrade", "off", both, ".pdf", routeDegrade},
+		{"off html -> raw_text baseline", "off", both, ".html", routeRawText},
+		// empty policy defaults to auto.
+		{"empty policy defaults to auto", "", both, ".pdf", routeStructured},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := selectExtractionRoute(tc.policy, tc.avail, tc.ext); got != tc.want {
+				t.Errorf("selectExtractionRoute(%q, %+v, %q) = %d, want %d", tc.policy, tc.avail, tc.ext, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestActiveExtractionAvailability confirms availability is derived from the
+// resolved single extractor: a structured extractor reports structured-active, a
+// flat one reports flat-active, and no extractor reports nothing active.
+func TestActiveExtractionAvailability(t *testing.T) {
+	if got := (&Service{extractor: structuredRoutingExtractor{}}).activeExtractionAvailability(); !got.structured || got.flatOCR {
+		t.Errorf("structured extractor availability = %+v, want {structured:true}", got)
+	}
+	if got := (&Service{extractor: flatRoutingExtractor{}}).activeExtractionAvailability(); got.structured || !got.flatOCR {
+		t.Errorf("flat extractor availability = %+v, want {flatOCR:true}", got)
+	}
+	if got := (&Service{}).activeExtractionAvailability(); got.structured || got.flatOCR {
+		t.Errorf("nil extractor availability = %+v, want zero", got)
+	}
+}

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -58,6 +58,13 @@ type Service struct {
 	extractor     model.DocumentExtractor
 	transcriber   model.Transcriber
 
+	// onUnsupported is the resolved §7.4.B.2 degradation mode for a format no
+	// active extraction engine supports (ingest.on_unsupported): "lenient"
+	// (default) skips with a warning and surfaces the gap in the honest coverage
+	// report, while "strict" records a non-fatal per-document UNSUPPORTED_FORMAT
+	// error. Resolved once in NewService; empty is treated as lenient.
+	onUnsupported string
+
 	// fsys is the corpus filesystem abstraction used for discovery and byte
 	// reads. Nil means "use a local filesystem rooted at cfg.RootDir" — the
 	// default that preserves the historical local-corpus behavior. It is
@@ -391,16 +398,49 @@ var errNoVideoRepresentation = errors.New(
 	"video produced no representation: no subtitle sidecar found, video is not transcribed (STT is audio-only), " +
 		"and multimodal keyframe embedding is off — enable embed_multimodal or provide a .vtt/.srt sidecar to make it searchable")
 
+// activeExtractionAvailability derives which extraction engines are active for
+// this run (§7.4.B "Extractor availability") from the single resolved extractor.
+// The resolved extractor is already the best-available engine chosen by the
+// docling → docling-serve → mistral cascade (DescribeDocumentExtractor), so it is
+// either the structured docling family or the flat OCR path; deriving
+// availability from it keeps the per-format selection in lockstep with the engine
+// the service will actually run, with no second probe to drift from it.
+func (s *Service) activeExtractionAvailability() extractionAvailability {
+	if s.extractor == nil {
+		return extractionAvailability{}
+	}
+	if _, structured := s.extractor.(structuredExtractor); structured {
+		return extractionAvailability{structured: true}
+	}
+	return extractionAvailability{flatOCR: true}
+}
+
+// routeExtractionExt resolves the capability-aware, per-format extraction route
+// (§7.4.B.1 / §7.4.A) for a lowercased extension under the active
+// `ingest.extractor` policy and the currently-active engines. It is the single
+// routing decision both the extracted-markdown path and the html markup-boundary
+// (#556) consult.
+func (s *Service) routeExtractionExt(ext string) extractionRoute {
+	return selectExtractionRoute(s.cfg.IngestExtractor, s.activeExtractionAvailability(), ext)
+}
+
 // extractorCanReadExt reports whether the currently-selected extractor can read
-// the asset's format. Docling-family extractors implement structuredExtractor;
-// the flat Mistral-OCR path does not.
+// the asset's format for the extracted-markdown path (pdf/image/document),
+// consulting the per-format selection (§7.4.B.1) rather than a coarse
+// structured/flat switch. It is true only when the active engine is routed to
+// extract the format (structured or flat OCR); a format that must degrade — or
+// that routes to the raw_text baseline (html) — is not "readable" on this path.
 func (s *Service) extractorCanReadExt(relPath string) bool {
 	if s.extractor == nil {
 		return false
 	}
-	_, structured := s.extractor.(structuredExtractor)
 	ext := strings.ToLower(filepath.Ext(strings.TrimSpace(relPath)))
-	return extractorSupportsExt(structured, ext)
+	switch s.routeExtractionExt(ext) {
+	case routeStructured, routeFlatOCR:
+		return true
+	default:
+		return false
+	}
 }
 
 // extractorLabel is a short human name for the active extractor, used in the
@@ -425,6 +465,63 @@ func unsupportedExtractionErr(relPath, extractor string) error {
 		"unsupported format for extraction: the active extractor (%s) cannot read %s files; "+
 			"install a capable extractor or convert the file to a supported format (tracked in #393)",
 		extractor, ext)
+}
+
+// onUnsupportedStrict/Lenient are the §7.4.B.2 degradation modes.
+const (
+	onUnsupportedLenient = "lenient"
+	onUnsupportedStrict  = "strict"
+)
+
+// normalizeOnUnsupported maps the raw ingest.on_unsupported config value to the
+// resolved §7.4.B.2 mode. Only "strict" selects the strict contract; everything
+// else (including empty and any unrecognized value) is the lenient default, so a
+// service constructed from a bare config.Config degrades leniently — the
+// backward-compatible, not-indexed-but-honest outcome.
+func normalizeOnUnsupported(v string) string {
+	if strings.EqualFold(strings.TrimSpace(v), onUnsupportedStrict) {
+		return onUnsupportedStrict
+	}
+	return onUnsupportedLenient
+}
+
+// SetOnUnsupported overrides the resolved §7.4.B.2 degradation mode, primarily
+// for tests that need to exercise strict/lenient without threading a full config.
+// The value is normalized (only "strict" is strict; anything else is lenient).
+func (s *Service) SetOnUnsupported(mode string) {
+	s.onUnsupported = normalizeOnUnsupported(mode)
+}
+
+// degradeUnsupportedExtraction applies the §7.4.B.2 degradation contract to a
+// pdf/image/document asset whose format no active extraction engine can read,
+// and which produced no direct-embedding media chunks either (so it would
+// otherwise be unsearchable). It never hands the asset to an engine that cannot
+// read it and never lets the gap be silent:
+//
+//   - strict: a non-fatal per-document UNSUPPORTED_FORMAT error (§7.7) —
+//     documents.status=error, the error counter is bumped, and the caller is told
+//     (nonFatalErrored) not to also credit the document as indexed (#426).
+//   - lenient (default): skip-with-warning — no extracted_markdown is produced,
+//     the document keeps whatever other representations it has, and the gap is
+//     logged and recorded in the in-run skip counter so `status`/`reindex` and the
+//     honest coverage report (§7.7) name it. The document is still indexed.
+//
+// It returns whether the strict path recorded a non-fatal error (so the caller
+// can propagate the #426 no-double-count signal).
+func (s *Service) degradeUnsupportedExtraction(ctx context.Context, doc model.Document, secretPatterns []*regexp.Regexp) (nonFatalErrored bool) {
+	cause := unsupportedExtractionErr(doc.RelPath, s.extractorLabel())
+	if s.onUnsupported == onUnsupportedStrict {
+		s.getLogger().Printf("unsupported format (strict) for %s (%s): %v", doc.RelPath, doc.DocType, cause)
+		s.addErrors(1)
+		s.persistNonFatalDocError(ctx, doc, cause, secretPatterns)
+		return true
+	}
+	// lenient: honest skip, not an error. The document remains status="ok" with
+	// whatever other representations it has; the coverage report (§7.7) and the
+	// in-run skip counter name the uncovered format so it is never silent.
+	s.getLogger().Printf("unsupported format (lenient, skipped) for %s (%s): %v", doc.RelPath, doc.DocType, cause)
+	s.addRunSkipReason(model.SkipReasonUnsupportedFormat)
+	return false
 }
 
 type documentDeleteMarker interface {
@@ -455,6 +552,7 @@ func NewService(cfg config.Config, store model.Store) (*Service, error) {
 		store:                           store,
 		logger:                          log.Default(),
 		onDocumentDeletedMaxConcurrency: defaultOnDocumentDeletedMaxConcurrency,
+		onUnsupported:                   normalizeOnUnsupported(cfg.IngestOnUnsupported),
 	}
 	transcriber, err := TranscriberFromConfig(cfg)
 	if err != nil {
@@ -2490,18 +2588,13 @@ func (s *Service) generateExtractedAndMediaRepresentations(ctx context.Context, 
 			}
 			s.addRepresentations(1)
 		} else if !mediaProduced {
-			// #394: the active extractor cannot read this format. Rather than hand
-			// it to an extractor that fails silently (docling → empty) or hard-errors
-			// (Mistral OCR → "unsupported file extension"), record a clear, non-fatal
-			// unsupported-format diagnostic so the unsearchable asset is durably
-			// visible (status="error" / RecentFailures) and the run continues. Skipped
-			// only when direct multimodal embedding is not also making the doc
+			// #394/#395: the active extractor cannot read this format. Rather than
+			// hand it to an engine that fails silently (docling → empty) or hard-errors
+			// (Mistral OCR → "unsupported file extension"), degrade honestly per the
+			// §7.4.B.2 strict/lenient contract — never a silent empty representation.
+			// Skipped only when direct multimodal embedding is not also making the doc
 			// searchable; content support for these formats is #393.
-			cause := unsupportedExtractionErr(doc.RelPath, s.extractorLabel())
-			s.getLogger().Printf("skipping extraction for %s (%s): %v", doc.RelPath, doc.DocType, cause)
-			s.addErrors(1)
-			s.persistNonFatalDocError(ctx, doc, cause, secretPatterns)
-			nonFatalErrored = true
+			nonFatalErrored = s.degradeUnsupportedExtraction(ctx, doc, secretPatterns)
 		}
 	}
 	if mediaProduced {
@@ -2749,6 +2842,17 @@ func (s *Service) generateRepresentations(ctx context.Context, doc model.Documen
 		return false, nil
 	}
 
+	// #556 / §7.4.A markup boundary: html is a dual-path format. When a structured
+	// extraction engine (the docling family) is active and the per-format selection
+	// routes html to it, produce a structured extracted_markdown representation
+	// (headings/tables/links as region spans) instead of flat raw_text. When no
+	// structured HTML engine is active — extractor off/unavailable, or pinned to a
+	// non-structured engine — html falls back to the raw_text baseline below, so it
+	// is never dropped and does not regress when docling is absent.
+	if doc.DocType == "html" && s.htmlRoutesToStructured(doc.RelPath) {
+		return s.generateHTMLStructured(ctx, doc, content, secretPatterns)
+	}
+
 	if ShouldGenerateRawText(doc.DocType) {
 		// #398: a binary payload that classified into a text-oriented doc type
 		// (e.g. .parquet → "data") must not be run through the raw-text path, where
@@ -2796,6 +2900,61 @@ func (s *Service) generateRepresentations(ctx context.Context, doc model.Documen
 	}
 
 	return s.generateTranscriptOrSidecar(ctx, doc, content, secretPatterns, forceReindex, mediaProduced)
+}
+
+// htmlRoutesToStructured reports whether an html document should be promoted to
+// the structured extraction path (#556 / §7.4.A) instead of flat raw_text: true
+// only when the active extractor is a structured (docling family) engine AND the
+// per-format selection (§7.4.B.1) routes html to it. Every other case — no
+// extractor, docling unavailable, or a pinned flat engine — keeps the guaranteed
+// raw_text baseline, so html never regresses when docling is absent.
+func (s *Service) htmlRoutesToStructured(relPath string) bool {
+	if s.extractor == nil || s.repGen == nil {
+		return false
+	}
+	if _, structured := s.extractor.(structuredExtractor); !structured {
+		return false
+	}
+	ext := strings.ToLower(filepath.Ext(strings.TrimSpace(relPath)))
+	return s.routeExtractionExt(ext) == routeStructured
+}
+
+// generateHTMLStructured produces the structured extracted_markdown representation
+// for an html document via the active docling-family extractor (#556 / §7.4.A),
+// preserving heading/table structure as region spans (html carries no page/bbox,
+// so its region spans carry the section breadcrumb + label). It guarantees the
+// §7.4.A baseline: if structured extraction errors or yields no parseable
+// structure, it falls back to flat raw_text so html is never dropped. html has no
+// media/transcript path, so it returns immediately after the text representation;
+// the (nonFatalErrored, err) contract matches generateRepresentations.
+func (s *Service) generateHTMLStructured(ctx context.Context, doc model.Document, content []byte, secretPatterns []*regexp.Regexp) (bool, error) {
+	if se, ok := s.extractor.(structuredExtractor); ok {
+		res, err := s.readOrComputeStructured(ctx, doc, content, se)
+		switch {
+		case err == nil && len(res.Blocks) > 0:
+			if perr := s.persistStructuredRepresentation(ctx, doc, res); perr != nil {
+				return false, perr
+			}
+			s.addRepresentations(1)
+			return false, nil
+		case err != nil:
+			s.getLogger().Printf("html structured extraction failed for %s, falling back to raw_text baseline (§7.4.A): %v", doc.RelPath, err)
+		default:
+			s.getLogger().Printf("html structured extraction produced no structure for %s, using raw_text baseline (§7.4.A)", doc.RelPath)
+		}
+	}
+	// Baseline (§7.4.A): flat raw_text so html is never dropped.
+	if err := s.repGen.GenerateRawTextFromContent(ctx, doc, content); err != nil {
+		return false, err
+	}
+	s.addRepresentations(1)
+	const titleScanLimit = 4096
+	titleContent := content
+	if len(titleContent) > titleScanLimit {
+		titleContent = titleContent[:titleScanLimit]
+	}
+	s.persistTitleIfFound(ctx, doc, string(titleContent))
+	return false, nil
 }
 
 // generateTranscriptOrSidecar resolves a media document's transcript. Subtitle

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -2932,6 +2932,13 @@ func (s *Service) generateHTMLStructured(ctx context.Context, doc model.Document
 		res, err := s.readOrComputeStructured(ctx, doc, content, se)
 		switch {
 		case err == nil && len(res.Blocks) > 0:
+			if strings.TrimSpace(res.Markdown) == "" {
+				// Blocks but no markdown: nothing to persist. Fall through to the
+				// raw_text baseline rather than counting a phantom representation
+				// (would inflate coverage; §7.4.A guarantees html is never dropped).
+				s.getLogger().Printf("html structured extraction produced blocks but no markdown for %s, using raw_text baseline (§7.4.A)", doc.RelPath)
+				break
+			}
 			if perr := s.persistStructuredRepresentation(ctx, doc, res); perr != nil {
 				return false, perr
 			}

--- a/tests/config/on_unsupported_config_test.go
+++ b/tests/config/on_unsupported_config_test.go
@@ -1,0 +1,76 @@
+package tests
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+)
+
+// TestOnUnsupported_Default confirms ingest.on_unsupported defaults to the
+// lenient, backward-compatible degradation mode (§7.4.B.2).
+func TestOnUnsupported_Default(t *testing.T) {
+	if got := config.Default().IngestOnUnsupported; got != "lenient" {
+		t.Fatalf("default ingest.on_unsupported = %q, want lenient", got)
+	}
+}
+
+// TestOnUnsupported_Validation normalizes empty to lenient and rejects any value
+// outside lenient/strict.
+func TestOnUnsupported_Validation(t *testing.T) {
+	cfg := config.Default()
+	cfg.IngestOnUnsupported = ""
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("empty on_unsupported should validate: %v", err)
+	}
+	if cfg.IngestOnUnsupported != "lenient" {
+		t.Fatalf("empty on_unsupported should normalize to lenient, got %q", cfg.IngestOnUnsupported)
+	}
+
+	cfg = config.Default()
+	cfg.IngestOnUnsupported = "STRICT"
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("strict on_unsupported should validate: %v", err)
+	}
+	if cfg.IngestOnUnsupported != "strict" {
+		t.Fatalf("on_unsupported should normalize case to strict, got %q", cfg.IngestOnUnsupported)
+	}
+
+	cfg = config.Default()
+	cfg.IngestOnUnsupported = "loud"
+	if err := cfg.Validate(); err == nil {
+		t.Fatalf("expected error for unknown on_unsupported value, got nil")
+	}
+}
+
+// TestOnUnsupported_FileRoundtrip verifies the key loads from a config file and
+// survives a SaveFile→LoadFile roundtrip.
+func TestOnUnsupported_FileRoundtrip(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+	writeFile(t, path, "root_dir: ./repo\ningest_on_unsupported: strict\n")
+
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile failed: %v", err)
+	}
+	if cfg.IngestOnUnsupported != "strict" {
+		t.Fatalf("loaded ingest.on_unsupported = %q, want strict", cfg.IngestOnUnsupported)
+	}
+
+	out := filepath.Join(tmp, "out.yaml")
+	if err := config.SaveFile(out, cfg); err != nil {
+		t.Fatalf("SaveFile failed: %v", err)
+	}
+	if text := readFileString(t, out); !strings.Contains(text, "ingest_on_unsupported: strict") {
+		t.Fatalf("saved config missing ingest_on_unsupported:\n%s", text)
+	}
+	reloaded, err := config.LoadFile(out)
+	if err != nil {
+		t.Fatalf("reload failed: %v", err)
+	}
+	if reloaded.IngestOnUnsupported != "strict" {
+		t.Fatalf("roundtrip lost on_unsupported: %q", reloaded.IngestOnUnsupported)
+	}
+}

--- a/tests/ingest/extractor_routing_394_test.go
+++ b/tests/ingest/extractor_routing_394_test.go
@@ -13,59 +13,81 @@ import (
 )
 
 // processWithFlatExtractor writes name into a fresh root, ingests it through a
-// service whose document extractor is the flat (OCR-only) fakeExtractor, and
-// returns the persisted document. fakeExtractor does not implement
-// structuredExtractor, so it mirrors the Mistral-OCR routing path.
-func processWithFlatExtractor(t *testing.T, name string) model.Document {
+// service whose document extractor is the flat (OCR-only) fakeExtractor under the
+// given ingest.on_unsupported mode, and returns the persisted document plus the
+// service (so callers can read its in-run skip counts). fakeExtractor does not
+// implement structuredExtractor, so it mirrors the Mistral-OCR routing path. An
+// empty mode exercises the lenient default.
+func processWithFlatExtractor(t *testing.T, name, onUnsupported string) (model.Document, *ingest.Service) {
 	t.Helper()
 	root := t.TempDir()
 	writeFile(t, filepath.Join(root, name), "irrelevant bytes")
 	st := newRealStore(t)
-	svc := mustNewIngestService(t, config.Config{RootDir: root, StateDir: t.TempDir()}, st)
+	svc := mustNewIngestService(t, config.Config{RootDir: root, StateDir: t.TempDir(), IngestOnUnsupported: onUnsupported}, st)
 	// A flat extractor that would happily return text if asked — proving the doc
-	// is skipped by the routing gate, not by the extractor failing.
+	// is routed away by the capability-aware selection, not by the extractor
+	// failing.
 	svc.SetDocumentExtractor(&fakeExtractor{text: "should never be extracted"})
 
 	f := ingest.DiscoveredFile{RelPath: name, SizeBytes: 16, MTimeUnix: time.Now().Unix()}
 	if err := svc.ProcessDocument(context.Background(), f, nil, false); err != nil {
 		t.Fatalf("ProcessDocument(%s): %v", name, err)
 	}
-	return documentByPath(t, st, name)
+	return documentByPath(t, st, name), svc
 }
 
-// TestUnsupportedDocument_SurfacesDiagnostic is the #394 defect-2 guard: an .odt
-// (doc_type=document) routed to an extractor that cannot import it must surface a
-// clear unsupported-format diagnostic — not a silent empty representation, and
-// not an alarming generic provider failure.
-func TestUnsupportedDocument_SurfacesDiagnostic(t *testing.T) {
-	doc := processWithFlatExtractor(t, "notes.odt")
+// TestUnsupportedDocument_StrictSurfacesError is the #394 defect-2 guard under
+// ingest.on_unsupported=strict: an .odt (doc_type=document) routed to an extractor
+// that cannot import it is a non-fatal per-document error (§7.4.B.2) — not a silent
+// empty representation, and not an alarming generic provider failure.
+func TestUnsupportedDocument_StrictSurfacesError(t *testing.T) {
+	doc, _ := processWithFlatExtractor(t, "notes.odt", "strict")
 	if doc.Status != "error" {
-		t.Fatalf("unsupported .odt status = %q, want \"error\" (a silent empty rep is the #394 bug)", doc.Status)
+		t.Fatalf("unsupported .odt (strict) status = %q, want \"error\"", doc.Status)
 	}
 	if !strings.Contains(strings.ToLower(doc.ErrorMessage), "unsupported format") {
 		t.Errorf("error_message = %q, want it to name the unsupported format", doc.ErrorMessage)
 	}
 }
 
-// TestUnsupportedImage_SurfacesDiagnostic is the #394 defect-3 guard: a .gif
-// (doc_type=image) is outside the OCR provider's allowlist and covered by no
-// extractor. It must surface the same visible unsupported-format diagnostic
-// instead of being silently rejected.
-func TestUnsupportedImage_SurfacesDiagnostic(t *testing.T) {
-	doc := processWithFlatExtractor(t, "diagram.gif")
+// TestUnsupportedImage_StrictSurfacesError is the #394 defect-3 guard under strict:
+// a .gif (doc_type=image) is outside the OCR provider's allowlist and covered by no
+// extractor. It must surface the same visible unsupported-format error instead of
+// being silently rejected.
+func TestUnsupportedImage_StrictSurfacesError(t *testing.T) {
+	doc, _ := processWithFlatExtractor(t, "diagram.gif", "strict")
 	if doc.Status != "error" {
-		t.Fatalf("unsupported .gif status = %q, want \"error\" (silent OCR rejection is the #394 bug)", doc.Status)
+		t.Fatalf("unsupported .gif (strict) status = %q, want \"error\"", doc.Status)
 	}
 	if !strings.Contains(strings.ToLower(doc.ErrorMessage), "unsupported format") {
 		t.Errorf("error_message = %q, want it to name the unsupported format", doc.ErrorMessage)
+	}
+}
+
+// TestUnsupportedDocument_LenientSkipsHonestly is the #395 Stage 3 guard for the
+// lenient DEFAULT (ingest.on_unsupported=lenient): an unsupported .odt is NOT a
+// per-document error — the document is indexed with whatever representations it has
+// (none here) and the coverage gap is recorded in the in-run skip counter so
+// status/reindex and the honest coverage report name it (§7.4.B.2 / §7.7). The key
+// property versus the pre-#395 behavior is that it is honest, not silent: the skip
+// reason is counted rather than the format being handed to an engine that can't
+// read it.
+func TestUnsupportedDocument_LenientSkipsHonestly(t *testing.T) {
+	doc, svc := processWithFlatExtractor(t, "notes.odt", "") // empty = lenient default
+	if doc.Status == "error" {
+		t.Fatalf("unsupported .odt (lenient) status = %q, want a non-error status (lenient skips, not errors)", doc.Status)
+	}
+	counts := svc.SkipReasonCounts()
+	if counts[model.SkipReasonUnsupportedFormat] == 0 {
+		t.Errorf("lenient skip did not record an unsupported_format skip reason; counts=%v", counts)
 	}
 }
 
 // TestSupportedImage_StillExtracted guards against over-reach: a .png the OCR
-// provider CAN read must still be extracted normally, not swept up by the #394
-// routing gate.
+// provider CAN read must still be extracted normally, not swept up by the routing
+// gate, in either degradation mode.
 func TestSupportedImage_StillExtracted(t *testing.T) {
-	doc := processWithFlatExtractor(t, "scan.png")
+	doc, _ := processWithFlatExtractor(t, "scan.png", "")
 	if doc.Status != "ok" {
 		t.Fatalf("supported .png status = %q, want \"ok\" (the routing gate must not block a readable format)", doc.Status)
 	}

--- a/tests/ingest/html_routing_556_test.go
+++ b/tests/ingest/html_routing_556_test.go
@@ -1,0 +1,150 @@
+package tests
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/ingest/docling"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// fakeStructuredExtractor is a model.DocumentExtractor that also implements the
+// structured (docling-family) path, so the ingest service treats it as a
+// structured extractor. It returns a canned StructuredExtraction so an html
+// document can be exercised through the #556 structured route without a real
+// docling binary.
+type fakeStructuredExtractor struct {
+	res ingest.StructuredExtraction
+	err error
+}
+
+func (f *fakeStructuredExtractor) Extract(context.Context, string, []byte) (string, error) {
+	return f.res.Markdown, f.err
+}
+
+func (f *fakeStructuredExtractor) ExtractStructured(context.Context, string, []byte) (ingest.StructuredExtraction, error) {
+	return f.res, f.err
+}
+
+// repTypesFor lists the representation types persisted for relPath.
+func repTypesFor(t *testing.T, st *store.SQLiteStore, relPath string) map[string]bool {
+	t.Helper()
+	types, err := st.RepresentationTypesByPath(context.Background(), relPath)
+	if err != nil {
+		t.Fatalf("RepresentationTypesByPath(%s): %v", relPath, err)
+	}
+	set := make(map[string]bool, len(types))
+	for _, ty := range types {
+		set[ty] = true
+	}
+	return set
+}
+
+func ingestOne(t *testing.T, svc *ingest.Service, st *store.SQLiteStore, name, body string) map[string]bool {
+	t.Helper()
+	f := ingest.DiscoveredFile{RelPath: name, SizeBytes: int64(len(body)), MTimeUnix: time.Now().Unix()}
+	if err := svc.ProcessDocument(context.Background(), f, nil, false); err != nil {
+		t.Fatalf("ProcessDocument(%s): %v", name, err)
+	}
+	return repTypesFor(t, st, name)
+}
+
+const sampleHTML = "<html><head><title>Page Title</title></head><body><h1>Heading</h1><p>Body text.</p></body></html>"
+
+func newHTMLService(t *testing.T, st *store.SQLiteStore, root string) *ingest.Service {
+	t.Helper()
+	return mustNewIngestService(t, config.Config{RootDir: root, StateDir: t.TempDir()}, st)
+}
+
+// TestHTML_RoutesToStructured_WhenDoclingActive is the #556 core: when a
+// structured (docling family) extractor is active, an .html document is routed
+// through it, producing an extracted_markdown representation (structure preserved)
+// instead of flat raw_text (§7.4.A).
+func TestHTML_RoutesToStructured_WhenDoclingActive(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "page.html"), sampleHTML)
+	st := newRealStore(t)
+	svc := newHTMLService(t, st, root)
+	svc.SetDocumentExtractor(&fakeStructuredExtractor{res: ingest.StructuredExtraction{
+		Markdown: "# Heading\n\nBody text.",
+		Title:    "Page Title",
+		Blocks: []docling.Block{
+			{Label: "section_header", Level: 1, Section: nil, Text: "Heading"},
+			{Label: "paragraph", Section: []string{"Heading"}, Text: "Body text."},
+		},
+	}})
+
+	reps := ingestOne(t, svc, st, "page.html", sampleHTML)
+	if !reps[ingest.RepTypeExtractedMarkdown] {
+		t.Errorf("html with active docling did not produce extracted_markdown; reps=%v", reps)
+	}
+	if reps[ingest.RepTypeRawText] {
+		t.Errorf("html with active docling must not also produce raw_text (dual-path is one or the other); reps=%v", reps)
+	}
+	if doc := documentByPath(t, st, "page.html"); doc.Status != "ok" {
+		t.Errorf("html status = %q, want ok", doc.Status)
+	}
+}
+
+// TestHTML_FallsBackToRawText_WhenFlatExtractor pins the §7.4.A markup boundary:
+// with only a flat OCR extractor active (which cannot read html), html falls back
+// to the raw_text baseline — never dropped, never mis-routed to the flat engine.
+func TestHTML_FallsBackToRawText_WhenFlatExtractor(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "page.html"), sampleHTML)
+	st := newRealStore(t)
+	svc := newHTMLService(t, st, root)
+	svc.SetDocumentExtractor(&fakeExtractor{text: "should never be used for html"})
+
+	reps := ingestOne(t, svc, st, "page.html", sampleHTML)
+	if !reps[ingest.RepTypeRawText] {
+		t.Errorf("html with flat extractor did not fall back to raw_text; reps=%v", reps)
+	}
+	if reps[ingest.RepTypeExtractedMarkdown] {
+		t.Errorf("html must not produce extracted_markdown on the flat path; reps=%v", reps)
+	}
+}
+
+// TestHTML_FallsBackToRawText_WhenNoExtractor pins the no-regression guarantee:
+// with no extractor at all (the lean build), html is still indexed as raw_text
+// exactly as before docling routing existed.
+func TestHTML_FallsBackToRawText_WhenNoExtractor(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "page.html"), sampleHTML)
+	st := newRealStore(t)
+	svc := newHTMLService(t, st, root)
+	// No SetDocumentExtractor: the lean-build path.
+
+	reps := ingestOne(t, svc, st, "page.html", sampleHTML)
+	if !reps[ingest.RepTypeRawText] {
+		t.Errorf("html with no extractor did not produce raw_text; reps=%v", reps)
+	}
+	if reps[ingest.RepTypeExtractedMarkdown] {
+		t.Errorf("html with no extractor must not produce extracted_markdown; reps=%v", reps)
+	}
+}
+
+// TestHTML_FallsBackToRawText_WhenStructuredYieldsNothing guards the §7.4.A
+// baseline on a degraded structured extractor: an active docling family engine
+// that returns no parseable structure (or errors) must not drop the html — it
+// falls back to raw_text.
+func TestHTML_FallsBackToRawText_WhenStructuredYieldsNothing(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "page.html"), sampleHTML)
+	st := newRealStore(t)
+	svc := newHTMLService(t, st, root)
+	// Structured extractor active but yields zero blocks: baseline must apply.
+	svc.SetDocumentExtractor(&fakeStructuredExtractor{res: ingest.StructuredExtraction{}})
+
+	reps := ingestOne(t, svc, st, "page.html", sampleHTML)
+	if !reps[ingest.RepTypeRawText] {
+		t.Errorf("empty structured extraction did not fall back to raw_text; reps=%v", reps)
+	}
+	if reps[ingest.RepTypeExtractedMarkdown] {
+		t.Errorf("empty structured extraction must not persist an empty extracted_markdown; reps=%v", reps)
+	}
+}


### PR DESCRIPTION
## Summary

Implements the gated code side of the capability-aware, per-format extraction work. Re-pins the `dirstral-spec` submodule to **0.29.0** (spec PR #36 — capability-aware per-format extraction, already merged to spec `main`) and implements the newly-normative behavior.

Closes #556. Advances #395 (Stages 2-3; #395 is an umbrella issue, so referenced rather than fully closed — the pandoc engine #393 and its format coverage remain open).

## What changed

### Per-format best-available selection (#395 Stage 2 — SPEC §7.4.B.1)
- New `selectExtractionRoute(policy, availability, ext)` in `internal/ingest/capability.go`: the spec's fidelity-ordered best-available algorithm over the engine registry (T1 docling → T3 mistral OCR → T4 raw_text); pandoc (T2) is declared but inactive until #393.
- Availability is derived once from the resolved extractor (`activeExtractionAvailability`), so selection can never drift from the engine the service actually runs. A format is never routed to an engine that can't read it, and a higher-fidelity active engine is never bypassed. Deterministic, cached for the run.

### HTML → docling (#556 — SPEC §7.4.A markup boundary)
- `.html`/`.htm` are promoted to the structured docling path (`extracted_markdown` + `region` spans) when a structured engine is active and the selection routes them there.
- Falls back to the guaranteed `raw_text` (T4) baseline when no structured HTML engine is available (extractor off/unavailable, pinned to a flat engine, or docling absent) — HTML is never dropped and does **not** regress on the lean build.

### Graceful degradation + honest coverage (#395 Stage 3 — SPEC §7.4.B.2 / §7.7)
- New `ingest.on_unsupported` config knob (`lenient` default | `strict`), tri-state-shaped like the existing kill-switches:
  - **lenient**: skip-with-warning — the document is still indexed with whatever representations it has, and the gap is recorded in the in-run skip counter + named by the `dir2mcp doctor` coverage report. The backward-compatible, honest-not-silent outcome.
  - **strict**: a non-fatal per-document `UNSUPPORTED_FORMAT` error (for CI / correctness-sensitive corpora).
- Never a silent empty representation in either mode.

### Plumbing & docs
- Full config plumbing + validation for `ingest.on_unsupported` (file/env/flags/roundtrip).
- `dir2mcp doctor` coverage remedy now names the `on_unsupported` knob (§7.7).
- README document-extraction section updated (per-format selection, HTML routing, `on_unsupported`).

## Tests
- Unit: `selectExtractionRoute` across every policy × availability × format combination; `activeExtractionAvailability`.
- Integration (`tests/ingest`): HTML → structured when docling active; raw_text fallback for flat / no / empty-structured extractor (no-regression); strict vs lenient degradation for unsupported `.odt`/`.gif`; supported `.png` still extracted.
- Config: `ingest.on_unsupported` default / validation / file roundtrip.

`make check` passes clean. `coderabbit review`: no findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option to control how unsupported file formats are handled, with default and strict modes.
  * Improved extraction routing so supported content can use the best available extraction path, including better HTML handling.

* **Bug Fixes**
  * Unsupported files now either skip with a warning or surface a clear non-fatal error, depending on the selected mode.
  * Diagnostics now provide clearer guidance for resolving unsupported-format issues.

* **Documentation**
  * Updated setup and behavior docs with examples and clearer fallback rules for extraction modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->