### PR TITLE
fix(ingest): stop pinned STT language from quarantining other-language transcripts (#439 F3)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -629,6 +629,24 @@ type Config struct {
 	MediaSTTMaxPayloadMB      int
 	MediaSTTRequestTimeoutSec int
 
+	// MediaSTTLanguageStrict controls whether a corpus-pinned STT language
+	// (config `media.stt.language` / a provider profile's language) is treated
+	// by the output quality gate as ground truth about content, and therefore
+	// enforced by its language/script-mismatch detector (config
+	// `media.stt.language_strict`, dir2mcp#439 F3).
+	//
+	// A pinned STT language is a provider HINT that biases transcription; it is
+	// NOT a per-file guarantee about content. Feeding it to the quality gate as
+	// the expected language quarantines legitimate other-language clips (e.g. an
+	// English interview in a corpus pinned to `ru` transcribes to ~100%
+	// off-script and is discarded). That contradicts the general-purpose,
+	// auto-detect mandate, so the default is false: a pinned language never
+	// drives quarantine, and the language detector self-skips for transcripts
+	// (degenerate output is still caught by the repetition/gibberish/density
+	// detectors). Operators who have verified a genuinely single-language corpus
+	// can set this true to restore strict script-mismatch enforcement.
+	MediaSTTLanguageStrict bool
+
 	// MediaBatchTwoPhase / MediaBatchProgress / MediaBatchManifest configure the
 	// optional batch-ergonomics surface for large-archive media ingests (SPEC
 	// §8.6.11; config block `media.batch`). All default OFF/empty so behavior is
@@ -796,6 +814,7 @@ type fileConfig struct {
 	MediaClipMaxBytes                  *int
 	MediaSTTMaxPayloadMB               *int
 	MediaSTTRequestTimeoutSec          *int
+	MediaSTTLanguageStrict             *bool
 	ElevenLabsAPIKey                   *string
 	ServerTLSCertFile                  *string
 	ServerTLSKeyFile                   *string
@@ -934,6 +953,7 @@ type persistedConfig struct {
 	MediaClipMaxBytes                  int           `yaml:"media_clip_max_bytes"`
 	MediaSTTMaxPayloadMB               int           `yaml:"media_stt_max_payload_mb"`
 	MediaSTTRequestTimeoutSec          int           `yaml:"media_stt_request_timeout_sec"`
+	MediaSTTLanguageStrict             bool          `yaml:"media_stt_language_strict"`
 	MediaBatchTwoPhase                 bool          `yaml:"media_batch_two_phase"`
 	MediaBatchProgress                 bool          `yaml:"media_batch_progress"`
 	MediaBatchManifest                 string        `yaml:"media_batch_manifest"`
@@ -1134,6 +1154,9 @@ func Default() Config {
 		// 0 = use the whisper client's built-in caps (#510, #511).
 		MediaSTTMaxPayloadMB:      0,
 		MediaSTTRequestTimeoutSec: 0,
+		// A pinned STT language is a provider hint, not per-file ground truth, so
+		// it does not drive quality-gate quarantine by default (dir2mcp#439 F3).
+		MediaSTTLanguageStrict:    false,
 		MediaVariantsGroup:        false,
 		MediaVariantsSelect:       "best",
 		MediaTranslateEnabled:     false,
@@ -1295,6 +1318,7 @@ func buildPersistedConfig(cfg *Config) persistedConfig {
 		MediaClipMaxBytes:                  cfg.MediaClipMaxBytes,
 		MediaSTTMaxPayloadMB:               cfg.MediaSTTMaxPayloadMB,
 		MediaSTTRequestTimeoutSec:          cfg.MediaSTTRequestTimeoutSec,
+		MediaSTTLanguageStrict:             cfg.MediaSTTLanguageStrict,
 		ServerTLSCertFile:                  cfg.ServerTLSCertFile,
 		ServerTLSKeyFile:                   cfg.ServerTLSKeyFile,
 		X402Mode:                           cfg.X402.Mode,
@@ -2092,6 +2116,9 @@ func applyMediaSTTFileParsed(cfg *Config, fc fileConfig) {
 	if fc.MediaSTTRequestTimeoutSec != nil {
 		cfg.MediaSTTRequestTimeoutSec = *fc.MediaSTTRequestTimeoutSec
 	}
+	if fc.MediaSTTLanguageStrict != nil {
+		cfg.MediaSTTLanguageStrict = *fc.MediaSTTLanguageStrict
+	}
 }
 
 // applyMediaSubtitlesFileParsed copies the set media.subtitles.* file fields
@@ -2443,6 +2470,7 @@ var configKeyAliases = map[string]string{
 	"media_clip_max_bytes":                    "media.clip.max_bytes",
 	"media_stt_max_payload_mb":                "media.stt.max_payload_mb",
 	"media_stt_request_timeout_sec":           "media.stt.request_timeout_sec",
+	"media_stt_language_strict":               "media.stt.language_strict",
 	"stt_provider":                            "stt.provider",
 	"stt_mistral_model":                       "stt.mistral.model",
 	"stt_elevenlabs_model":                    "stt.elevenlabs.model",
@@ -2562,6 +2590,7 @@ var boolFileScalarTargets = map[string]func(*fileConfig) **bool{
 	"media_sidecars_disabled":    func(c *fileConfig) **bool { return &c.MediaSidecarsDisabled },
 	"media.variants.group":       func(c *fileConfig) **bool { return &c.MediaVariantsGroup },
 	"media.translate.enabled":    func(c *fileConfig) **bool { return &c.MediaTranslateEnabled },
+	"media.stt.language_strict":  func(c *fileConfig) **bool { return &c.MediaSTTLanguageStrict },
 	"media.subtitles.ttml.enabled": func(c *fileConfig) **bool {
 		return &c.MediaSubtitlesTTMLEnabled
 	},
@@ -2676,6 +2705,7 @@ var nonNegativeIntKeys = map[string]bool{
 	"media.clip.max_bytes":                    true,
 	"media.stt.max_payload_mb":                true,
 	"media.stt.request_timeout_sec":           true,
+	"media.stt.language_strict":               true,
 	"media.subtitles.ttml.align_tolerance_ms": true,
 	"media.subtitles.collapse_repeats":        true,
 }
@@ -3095,6 +3125,7 @@ func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	writeInt("media_clip_max_bytes", cfg.MediaClipMaxBytes)
 	writeInt("media_stt_max_payload_mb", cfg.MediaSTTMaxPayloadMB)
 	writeInt("media_stt_request_timeout_sec", cfg.MediaSTTRequestTimeoutSec)
+	writeBool("media_stt_language_strict", cfg.MediaSTTLanguageStrict)
 	writeBool("media_batch_two_phase", cfg.MediaBatchTwoPhase)
 	writeBool("media_batch_progress", cfg.MediaBatchProgress)
 	writeScalar("media_batch_manifest", cfg.MediaBatchManifest)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2705,7 +2705,6 @@ var nonNegativeIntKeys = map[string]bool{
 	"media.clip.max_bytes":                    true,
 	"media.stt.max_payload_mb":                true,
 	"media.stt.request_timeout_sec":           true,
-	"media.stt.language_strict":               true,
 	"media.subtitles.ttml.align_tolerance_ms": true,
 	"media.subtitles.collapse_repeats":        true,
 }

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -3297,13 +3297,27 @@ func (s *Service) recordQualityGateDocError(ctx context.Context, doc model.Docum
 	s.persistNonFatalDocError(ctx, doc, errors.New(msg), nil)
 }
 
-// transcriptExpectedLanguage returns the active STT provider profile's language
-// tag used to drive the quality gate's language detector, or "" when none is
-// configured (in which case the language gate self-skips). The value is
-// resolved from the same provider profile the transcriber uses (SPEC 8.1.3),
-// not the legacy ElevenLabs-only field, so provider-profile setups (e.g.
-// Mistral) supply the correct expected language.
+// transcriptExpectedLanguage returns the language tag the quality gate's
+// language/script-mismatch detector should treat as expected for a transcript,
+// or "" when the detector should self-skip.
+//
+// A corpus-pinned STT language (s.transcriptLanguage, resolved from the active
+// provider profile per SPEC 8.1.3) is a provider HINT that biases
+// transcription; it is NOT a per-file guarantee about content. Feeding it to
+// the gate as ground truth quarantines legitimate other-language clips — e.g.
+// an English interview in a corpus pinned to `ru` transcribes to ~100%
+// off-script and is discarded (dir2mcp#439 F3), contradicting the
+// general-purpose auto-detect mandate. So by default (MediaSTTLanguageStrict
+// false) a pinned language does NOT drive quarantine and this returns "": the
+// language detector self-skips while the repetition/gibberish/density detectors
+// still catch degenerate output. Operators who have verified a genuinely
+// single-language corpus can set media.stt.language_strict:true to restore
+// strict enforcement. When STT language is auto (unpinned) s.transcriptLanguage
+// is already "", so the flag is a no-op and behaviour is unchanged.
 func (s *Service) transcriptExpectedLanguage() string {
+	if !s.cfg.MediaSTTLanguageStrict {
+		return ""
+	}
 	return s.transcriptLanguage
 }
 

--- a/tests/config/media_stt_limits_config_test.go
+++ b/tests/config/media_stt_limits_config_test.go
@@ -78,6 +78,65 @@ func TestMediaSTTLimits_ParsesFlatAndNestedYAML(t *testing.T) {
 	}
 }
 
+// TestMediaSTTLanguageStrict_DefaultsFalse confirms the pinned-STT-language
+// quality-gate enforcement toggle defaults to false, so a corpus-pinned STT
+// language never drives quarantine out of the box (dir2mcp#439 F3).
+func TestMediaSTTLanguageStrict_DefaultsFalse(t *testing.T) {
+	cfg := config.Default()
+	if cfg.MediaSTTLanguageStrict {
+		t.Errorf("media.stt.language_strict default = true, want false")
+	}
+}
+
+// TestMediaSTTLanguageStrict_RoundTripsThroughSaveLoad exercises the bool
+// plumbing (setBoolFileScalar, writeBool) for the toggle.
+func TestMediaSTTLanguageStrict_RoundTripsThroughSaveLoad(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+
+	cfg := config.Default()
+	cfg.RootDir = "/tmp/repo"
+	cfg.StateDir = "/tmp/repo/.dir2mcp"
+	cfg.MediaSTTLanguageStrict = true
+	if err := config.SaveFile(path, cfg); err != nil {
+		t.Fatalf("SaveFile: %v", err)
+	}
+	loaded, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if !loaded.MediaSTTLanguageStrict {
+		t.Errorf("media.stt.language_strict did not round-trip: got false, want true")
+	}
+}
+
+// TestMediaSTTLanguageStrict_ParsesFlatAndNestedYAML confirms both the flat key
+// (media_stt_language_strict) and the nested block (media: stt: language_strict)
+// apply through the loader.
+func TestMediaSTTLanguageStrict_ParsesFlatAndNestedYAML(t *testing.T) {
+	base := []string{
+		"root_dir: /tmp/repo",
+		"state_dir: /tmp/repo/.dir2mcp",
+	}
+	flat := append(append([]string(nil), base...), "media_stt_language_strict: true")
+	nested := append(append([]string(nil), base...),
+		"media:", "  stt:", "    language_strict: true")
+
+	for name, lines := range map[string][]string{"flat": flat, "nested": nested} {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), ".dir2mcp.yaml")
+			writeFile(t, path, strings.Join(lines, "\n")+"\n")
+			cfg, err := config.LoadFile(path)
+			if err != nil {
+				t.Fatalf("LoadFile(%s media.stt.language_strict): %v", name, err)
+			}
+			if !cfg.MediaSTTLanguageStrict {
+				t.Errorf("%s media.stt.language_strict = false, want true", name)
+			}
+		})
+	}
+}
+
 // TestMediaSTTLimits_NegativeRejected confirms negative values are CONFIG_INVALID.
 func TestMediaSTTLimits_NegativeRejected(t *testing.T) {
 	for _, tc := range []struct {

--- a/tests/ingest/quality_gate_test.go
+++ b/tests/ingest/quality_gate_test.go
@@ -109,6 +109,82 @@ func TestQualityGate_DisabledViaSetter(t *testing.T) {
 	}
 }
 
+// englishClipTranscript is a clean, legitimate English transcript (Latin
+// script) used by the pinned-language tests. It trips no degeneracy detector on
+// its own; the only quarantine signal it can raise is a language/script mismatch
+// against a pinned non-Latin STT language.
+const englishClipTranscript = "[00:00] welcome to the interview today\n" +
+	"[00:02] we discuss several distinct topics in depth\n" +
+	"[00:05] including history geography and science across many regions"
+
+// TestQualityGate_PinnedLanguageDoesNotQuarantineOtherLanguage pins dir2mcp#439
+// F3: a corpus pinned to a non-Latin STT language (`ru`) must NOT quarantine a
+// legitimate English clip by default. media.stt.language_strict defaults false,
+// so the pinned language is treated as a provider hint (not per-file ground
+// truth) and the quality gate's language detector self-skips — the English clip
+// is embedded normally instead of being discarded as ~100% off-script.
+func TestQualityGate_PinnedLanguageDoesNotQuarantineOtherLanguage(t *testing.T) {
+	t.Parallel()
+	stateDir := t.TempDir()
+	st := &fakeIngestStore{}
+	// MediaSTTLanguageStrict defaults to false (unset here).
+	svc := mustNewIngestService(t, config.Config{StateDir: stateDir, QualityGatesEnabled: true}, st)
+	svc.SetTranscriptLanguage("ru") // operator pinned Russian
+	svc.SetTranscriber(&fakeTranscriber{text: englishClipTranscript})
+
+	doc := model.Document{DocID: 105, RelPath: "audio/english_clip.mp3", DocType: "audio"}
+	if err := svc.GenerateTranscriptRepresentation(context.Background(), doc, []byte("audio-bytes")); err != nil {
+		t.Fatalf("GenerateTranscriptRepresentation failed: %v", err)
+	}
+
+	if len(st.chunks) == 0 {
+		t.Fatal("expected transcript chunks to be persisted, got none")
+	}
+	for i, c := range st.chunks {
+		if c.EmbeddingStatus != "pending" {
+			t.Fatalf("chunk %d: pinned-language footgun — legit English clip quarantined (status=%q); "+
+				"a pinned STT language must not drive quarantine by default", i, c.EmbeddingStatus)
+		}
+		if c.ErrorCategory != "" {
+			t.Fatalf("chunk %d: expected no error_category, got %q", i, c.ErrorCategory)
+		}
+	}
+}
+
+// TestQualityGate_PinnedLanguageStrictQuarantinesOffScript is the opt-in
+// companion: with media.stt.language_strict:true an operator asserts a genuinely
+// single-language corpus, so the pinned language IS enforced and an off-script
+// (English) transcript is quarantined as a language mismatch.
+func TestQualityGate_PinnedLanguageStrictQuarantinesOffScript(t *testing.T) {
+	t.Parallel()
+	stateDir := t.TempDir()
+	st := &fakeIngestStore{}
+	svc := mustNewIngestService(t, config.Config{
+		StateDir:               stateDir,
+		QualityGatesEnabled:    true,
+		MediaSTTLanguageStrict: true,
+	}, st)
+	svc.SetTranscriptLanguage("ru")
+	svc.SetTranscriber(&fakeTranscriber{text: englishClipTranscript})
+
+	doc := model.Document{DocID: 106, RelPath: "audio/english_strict.mp3", DocType: "audio"}
+	if err := svc.GenerateTranscriptRepresentation(context.Background(), doc, []byte("audio-bytes")); err != nil {
+		t.Fatalf("GenerateTranscriptRepresentation failed: %v", err)
+	}
+
+	if len(st.chunks) == 0 {
+		t.Fatal("expected transcript chunks to be persisted (quarantined), got none")
+	}
+	for i, c := range st.chunks {
+		if c.EmbeddingStatus != "error" {
+			t.Fatalf("chunk %d: strict mode should quarantine off-script transcript, got status=%q", i, c.EmbeddingStatus)
+		}
+		if c.ErrorCategory != string(store.ErrorCategoryQualityGate) {
+			t.Fatalf("chunk %d: expected error_category=%q, got %q", i, store.ErrorCategoryQualityGate, c.ErrorCategory)
+		}
+	}
+}
+
 // TestQualityGate_QuarantinesDegenerateOCR exercises the OCR flat path: a
 // degenerate OCR result is quarantined identically to the transcript path.
 func TestQualityGate_QuarantinesDegenerateOCR(t *testing.T) {


### PR DESCRIPTION
## #439 — remaining language-heuristic footgun (F3)

Most of #439 already landed on `main`; this PR closes the last open residual.

### Already fixed (context)
- **F1 — quarantined chunks served via BM25/hybrid + cited in `ask`:** fixed by #448 (`SearchBM25` carries `AND c.embedding_status != 'error'`; hybrid + citations inherit it) and regression-tested by #512 (`tests/store/sqlite_bm25_quarantine_test.go`).
- **F4/F5/F6 — CJK repetition, music density, printable-ASCII gibberish:** fixed by #531 (script-agnostic autocorrelation repetition, opt-in duration density floor, symbol-density + vowel-floor gibberish).

### Fixed here — F3: pinned STT language quarantines legitimate other-language transcripts
A corpus-pinned STT language (`media.stt.language` / a provider profile's language) is a **provider hint** that biases transcription — not a per-file guarantee about content. `internal/ingest` passed it to the output quality gate as the expected language, so the language/script-mismatch detector quarantined legitimate other-language clips: pinning `language: ru` discarded any English interview/song as ~100% off-script. That contradicts the general-purpose, auto-detect mandate and directly hit mixed-language pilots.

**Change:** the gate now treats a pinned STT language as ground truth only when the new `media.stt.language_strict` flag is set (**default `false`**).
- Default: a pinned language no longer drives quarantine; the language detector self-skips for transcripts. Degenerate output is still caught by the repetition / gibberish / density detectors.
- Opt-in `media.stt.language_strict: true`: operators who have verified a genuinely single-language corpus restore strict script-mismatch enforcement.
- Auto (unpinned) STT is unaffected — the expected language was already empty, so the flag is a no-op.

This also surfaces the **first quality-gate tuning knob** through `internal/config` (flat `media_stt_language_strict` + nested `media.stt.language_strict`, full save/load round-trip), so an operator hitting a false positive has a targeted control instead of only the master on/off switch.

### Spec governance
Bug fix / implementation change — **no dirstral-spec PR required.** The output quality gate is entirely internal (`internal/quality`); it has no normative text in `dirstral-spec/docs`. The pinned-vs-detected-language provenance is an ingest/config judgement call, not a change to any spec-defined contract.

### Tests
- `tests/ingest/quality_gate_test.go`: pinned `ru` + English clip → **not** quarantined by default (F3 regression); same setup with `language_strict:true` → quarantined as a language mismatch.
- `tests/config/media_stt_limits_config_test.go`: default `false`, save/load round-trip, flat + nested YAML parsing.
- `make check` passes (the sole failure in a fresh worktree was the uninitialised `dirstral-spec` submodule; green after `git submodule update --init`).

### Deferred (non-blocking)
- **F7 — exhaustive per-threshold config surfacing:** the remaining detector thresholds are not yet all exposed via `internal/config`. This is a tuning enhancement, not a correctness bug: the two false-positive sources F7 was meant to mitigate (F3 language, F5 density) are now both off/controllable by default, and this PR adds the first knob. Tracked as a follow-up rather than expanded here to keep the change scoped.
- **F2 — per-page/per-chunk screening granularity:** out of scope for this PR (whole-representation granularity); not among the residuals the maintainer kept #439 open for.

Closes #439
