### PR TITLE
docs: truthfulness batch (Homebrew trust, two-tracks footprint, no-egress recipe, stale env vars) + doctor egress check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,17 +2,20 @@
 # Do not commit real secrets.
 # Ensure your .env is listed in .gitignore to avoid committing secrets;
 # .env.example is intentionally allowed (see .gitignore).
+#
+# NOTE: this file configures CLOUD providers (Mistral, ElevenLabs) — corpus
+# content is sent to those third-party APIs. If your data must not leave the
+# host, do NOT set these keys; instead follow the "Fully local / no-egress
+# setup" recipe in the README (self-hosted providers in .dir2mcp.yaml) and
+# verify with `dir2mcp doctor` (its `egress` row must report no third-party
+# egress).
 
 # Mistral (required for embeddings, OCR, transcription, and generation)
 MISTRAL_API_KEY=your_mistral_api_key
-# Base URL of the Mistral API.  Most users should leave this at the
-# default `https://api.mistral.ai`.  Change it only for private deployments,
-# custom endpoints, or when proxying requests through another host.
-MISTRAL_BASE_URL=https://api.mistral.ai
-# Optional override for max encoded Mistral upload payload size (bytes).
-# Used for OCR payloads and also enforced for Mistral transcription uploads.
-# Increase this if large PDFs or audio files are rejected as too large.
-DIR2MCP_MISTRAL_MAX_OCR_PAYLOAD_BYTES=20971520
+# The Mistral base URL is NOT an environment variable (a MISTRAL_BASE_URL here
+# would be ignored). To proxy Mistral or point at a private/custom endpoint,
+# add a `providers:` entry with a `base_url` in .dir2mcp.yaml — see the
+# "Self-hosted / GPU-VPS provider endpoints" section of the README.
 
 # ElevenLabs (optional)
 # Text-to-Speech (TTS) and Speech-to-Text (STT) service.  Provide your
@@ -49,6 +52,11 @@ DIR2MCP_X402_FACILITATOR_TOKEN=
 # The bridge forwards ElevenLabs webhook calls to a running dir2mcp MCP
 # endpoint.  It can read the dir2mcp bearer token explicitly or from the
 # state directory token file when MCP_TOKEN is unset.
+# NOTE: `dir2mcp up` binds a RANDOM loopback port by default and prints its
+# actual MCP URL on startup — the :8087 below is only the bridge's built-in
+# fallback. Set MCP_URL to the URL your server actually printed, or pin a
+# fixed port with `dir2mcp up --listen 127.0.0.1:8087` (or `listen_addr:` in
+# .dir2mcp.yaml). When MCP_URL is unset the bridge reads $STATE_DIR/connection.json.
 MCP_URL=http://127.0.0.1:8087/mcp
 MCP_TOKEN=
 STATE_DIR=.dir2mcp

--- a/README.md
+++ b/README.md
@@ -37,8 +37,12 @@ Deploy any local directory as an MCP knowledge server with indexing, retrieval, 
 Install `dir2mcp` via Homebrew tap:
 
 ```bash
+brew tap dirstral/tap
+brew trust dirstral/tap      # required on Homebrew 6.x: third-party taps are untrusted by default
 brew install dirstral/tap/dir2mcp
 ```
+
+On Homebrew 6.x a freshly tapped third-party formula is refused until the tap is trusted, so `brew install dirstral/tap/dir2mcp` on a clean machine fails without the `brew trust` step above. (On older Homebrew the trust step is a harmless no-op.)
 
 Then verify:
 
@@ -50,12 +54,21 @@ dir2mcp version
 
 dir2mcp ships in two Homebrew formulas that install the **same binary** but differ in whether the [docling](https://github.com/docling-project/docling) structured-extraction runtime is bundled:
 
-| Track | Install | docling | Pick when |
-|---|---|---|---|
-| **Lean** (default) | `brew install dirstral/tap/dir2mcp` | **Not bundled** — bring your own | You already have `docling`, run a `docling-serve` container, extract via Mistral OCR, or index docling-free corpora |
-| **Full** | `brew install dirstral/tap/dir2mcp-full` | **Bundled** (docling runtime included) | You want local structured PDF/image extraction with zero extra setup |
+| Track | Install | docling | Footprint | Pick when |
+|---|---|---|---|---|
+| **Lean** (default) | `brew install dirstral/tap/dir2mcp` | **Not bundled** — bring your own | installs in ~seconds (only `libcap` + `bubblewrap`) | You already have `docling`, run a `docling-serve` container, extract via Mistral OCR, or index docling-free corpora |
+| **Full** | `brew install dirstral/tap/dir2mcp-full` | **Bundled** (docling runtime included) | ≈ 6.3 GB installed / ~3 min build | You want local structured PDF/image extraction with zero extra setup |
 
-The two formulas are mutually exclusive (Homebrew refuses to install both at once). Choose **full** for batteries-included local extraction; choose **lean** if you bring docling yourself, run docling-serve, or rely on Mistral OCR. Either way, extraction is configurable at runtime via `ingest.extractor` (see [Document extraction](#document-extraction-modes--fallback)). To move from lean to full (or to a shared docling-serve) in stages without a re-index flag day, see [Migration & rollout](#migration--rollout-adopting-docling-in-stages).
+The two formulas install the **same binary**, so they are mutually exclusive — both provide a `dir2mcp` runtime and Homebrew refuses to have both linked at once. To **switch tracks**, first unlink (or uninstall) the currently-installed one:
+
+```bash
+brew unlink dir2mcp        # or: brew uninstall dir2mcp
+brew install dirstral/tap/dir2mcp-full
+```
+
+**Full footprint:** the full formula bundles a Python 3.12 venv with docling, torch/torchvision, scipy, and shapely, pulling a large dependency chain (llvm, rust, python, openssl, …). Measured at ≈ 6.3 GB installed (~39k files) and ~3 min to build on Linux x86_64 (Homebrew 6.0.6); macOS and prebuilt-bottle installs will differ. The lean formula, by contrast, installs in seconds with only `libcap` + `bubblewrap`.
+
+Choose **full** for batteries-included local extraction; choose **lean** if you bring docling yourself, run docling-serve, or rely on Mistral OCR. Either way, extraction is configurable at runtime via `ingest.extractor` (see [Document extraction](#document-extraction-modes--fallback)). To move from lean to full (or to a shared docling-serve) in stages without a re-index flag day, see [Migration & rollout](#migration--rollout-adopting-docling-in-stages).
 
 ### Nix (macOS + Linux)
 
@@ -194,17 +207,19 @@ What it verifies:
 
 ### Tunnel setup (copy/paste)
 
+> **Port note:** `dir2mcp up` binds a **random** loopback port by default (`127.0.0.1:0`) and prints its actual MCP URL on startup — it is not `:8087`. Either substitute the printed port in the commands below, or pin a fixed port first with `dir2mcp up --listen 127.0.0.1:8087` (or `listen_addr: 127.0.0.1:8087` in `.dir2mcp.yaml`). The `:8087` below is a placeholder for whichever local port your server is actually listening on.
+
 Cloudflare quick tunnel (no account-required quick mode):
 
 ```bash
-cloudflared tunnel --url http://127.0.0.1:8087 --no-autoupdate
+cloudflared tunnel --url http://127.0.0.1:<PORT> --no-autoupdate
 ```
 
 ngrok (requires verified account + authtoken):
 
 ```bash
 ngrok config add-authtoken <YOUR_NGROK_TOKEN>
-ngrok http http://127.0.0.1:8087
+ngrok http http://127.0.0.1:<PORT>
 ```
 
 Get ngrok public URL from local API:
@@ -228,13 +243,18 @@ DIR2MCP_DEMO_TOKEN="$(cat .dir2mcp/secret.token)" \
 
 | Command | Description |
 |---|---|
-| `up` | Start the MCP server and begin indexing |
+| `up` | Start the MCP server and begin indexing (daemonizes by default) |
+| `down` | Stop the dir2mcp server running in this directory |
 | `status` | Show corpus and indexing state |
 | `ask "<question>"` | Legacy compatibility shim; prefer `dirstral-cli` for client UX |
 | `search "<query>"` | Legacy compatibility shim; prefer `dirstral-cli` for client UX |
 | `open-file <rel-path>` | Legacy compatibility shim; prefer `dirstral-cli` for client UX |
 | `list-files` | Legacy compatibility shim; prefer `dirstral-cli` for client UX |
 | `reindex` | Force full re-ingestion |
+| `embed-worker` | Run a standalone distributed embed worker (no MCP serving; requires a Tier-C store + broker) |
+| `export` | Render a transcript as VTT/SRT/TTML subtitles (`export --format vtt\|srt\|ttml <path>`) |
+| `bridge` | Run helper adapters (for example the ElevenLabs webhook bridge) |
+| `support-bundle` | Collect logs + config + status into a shareable `tar.gz` |
 | `config init` | Interactive setup wizard (on a TTY): prompts for provider API keys, where to store them (`.env.local` or the OS keychain), and a corpus profile, then writes/updates `.dir2mcp.yaml`. Non-interactive (`--non-interactive`/`--json`/`--quiet`/no TTY) just writes a baseline config. `dir2mcp up` also launches this wizard on first run when started interactively (a TTY, and not `--json`/`--non-interactive`/read-only) and no embedding provider resolves. |
 | `config print` | Print effective config |
 | `config set-secret <ENV_VAR>` | Store a provider credential in the OS keychain (encrypted at rest) instead of a plaintext `.env.local` |
@@ -242,7 +262,7 @@ DIR2MCP_DEMO_TOKEN="$(cat .dir2mcp/secret.token)" \
 | `config secrets` | Show which provider credentials are present in the keychain / environment (never prints values) |
 | `install <client>` | Install dir2mcp into a supported MCP client (e.g. `dir2mcp install claude`) |
 | `uninstall <client>` | Remove dir2mcp from a supported MCP client |
-| `doctor <client>` | Run client-integration diagnostics |
+| `doctor [<client>]` | With a client name, run client-integration diagnostics. With no argument, run a server-side preflight (config, provider resolution, an **egress** check reporting whether any resolved provider is a public/third-party host, extractor availability, indexing failures); add `--deep` to actively probe the embedding credential |
 | `print-config <client>` | Print the MCP-server JSON snippet a client expects |
 | `service install\|uninstall\|status` | Auto-start the daemon at login so the corpus survives a reboot (macOS launchd) |
 | `version` | Print version |
@@ -295,7 +315,7 @@ vary by deployment. The commonly used variables are:
 | `DIR2MCP_DOCLING_SERVE_URL` | No | HTTP endpoint of a running [docling-serve](https://github.com/docling-project/docling-serve) container (e.g. `http://127.0.0.1:5001`). Required when `ingest.extractor=docling-serve`; under `auto` it is used only when the docling CLI is not on `PATH` |
 | `DIR2MCP_INGEST_WATCH` | No | When `true`, a running `dir2mcp up` keeps a filesystem watcher live and incrementally indexes added/changed/deleted files (default: `false`) |
 | `DIR2MCP_INGEST_WATCH_DEBOUNCE` | No | Per-file debounce window for coalescing editor write bursts before re-indexing (default: `500ms`) |
-| `MISTRAL_BASE_URL` | No | Mistral base URL (default: `https://api.mistral.ai`) |
+| _(Mistral endpoint)_ | — | The Mistral base URL is **not** configurable via an environment variable. To proxy Mistral or point at a private/custom endpoint, add a `providers:` entry with a `base_url` (see [Self-hosted / GPU-VPS provider endpoints](#self-hosted--gpu-vps-provider-endpoints-embed--ocr--stt)) |
 | `DIR2MCP_AUTH_TOKEN` | No | Auth token override |
 | `DIR2MCP_SERVER_NAME` | No | Override the MCP server name (and suggested `claude mcp add` alias). Defaults to a unique `dir2mcp-<slug>-<6-hex>` derived from the indexed directory |
 | `DIR2MCP_SESSION_INACTIVITY_TIMEOUT` | No | Session inactivity timeout (default: `24h`) |
@@ -463,6 +483,41 @@ vs. flat `page` spans). Suggested phases:
 
 For a multi-host / GPU-VPS topology (self-hosted extractor + remote corpus), see
 [docs/dual-machine-deployment.md](docs/dual-machine-deployment.md).
+
+### Fully local / no-egress setup
+
+The default quickstart (and `.env.example`) configures **cloud** providers, so a corpus is processed by third-party APIs (Mistral for embeddings/OCR/STT/generation, ElevenLabs for voice). If your data must **not leave the host** (data-residency / compliance / on-prem archives), configure every capability against endpoints you run — dir2mcp treats a self-hosted provider as first-class (SPEC §8.5) and needs no cloud key.
+
+Provide **no** cloud credentials (do not set `MISTRAL_API_KEY`, `ELEVENLABS_API_KEY`, etc. — with none present, auto-selection has nothing cloud to pick) and bind each capability explicitly in `.dir2mcp.yaml`:
+
+```yaml
+# .dir2mcp.yaml — fully local, no egress
+providers:
+  local-llm:                              # OpenAI-compatible server you run
+    kind: openai                          #   (Ollama, vLLM, llama.cpp, LM Studio, TEI, …)
+    base_url: http://127.0.0.1:11434/v1   # e.g. Ollama's OpenAI-compatible endpoint
+    embed_text_model: nomic-embed-text
+    embed_code_model: nomic-embed-text
+    chat_model: llama3.1                  # answers + translation stay local
+  local-stt:                              # self-hosted Whisper/WhisperX
+    kind: whisper                         # base_url is the host ROOT (/v1/audio/transcriptions is appended)
+    base_url: http://127.0.0.1:9001
+    stt_model: large-v3
+model:
+  embed:
+    provider: local-llm                   # reindex-bound (the embed identity includes it)
+  chat:
+    provider: local-llm
+stt_provider: local-stt                   # STT uses the legacy selector
+ingest:
+  extractor: docling                      # local structured extraction; do NOT fall back to cloud OCR
+```
+
+Notes:
+- **Document extraction:** use local `docling` (the `dir2mcp-full` track bundles it) or a self-hosted [docling-serve](#docling-extraction-over-http-docling-serve). Avoid `extractor: auto`, whose last fallback is cloud Mistral OCR — pin `extractor: docling` (or `docling-serve`, or `off`) so no page image is ever uploaded. For a self-hosted OCR endpoint instead, bind `model.ocr.provider` to a `kind: mistral` `/v1/ocr` profile (see below).
+- **Verify, don't infer:** run `dir2mcp doctor` — its **egress** row must report `no third-party egress: all resolved providers target local/loopback or private/LAN endpoints`. If it names any public host, that capability is still leaving the machine.
+- A trusted-LAN endpoint may be **credential-less** (omit `api_key`); loopback, private-range, `.local`/`.internal`, and single-label LAN hosts all count as no-egress.
+- For a multi-machine topology (corpus over NFS/S3, a GPU box on the LAN, systemd units), see [docs/dual-machine-deployment.md](docs/dual-machine-deployment.md) and the self-hosted provider contract below.
 
 ### Self-hosted / GPU-VPS provider endpoints (embed / OCR / STT)
 

--- a/internal/cli/server_doctor.go
+++ b/internal/cli/server_doctor.go
@@ -6,6 +6,8 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -68,6 +70,7 @@ func (a *App) runServerDoctor(ctx context.Context, global globalOptions, args []
 		stateDirCheck(cfg.StateDir),
 		providerCheck(ctx, cfg, "embed", provider.CapEmbed, true, deep),
 		providerCheck(ctx, cfg, "chat", provider.CapChat, false, false),
+		egressCheck(cfg),
 		extractorCheck(cfg),
 		extractionCoverageCheck(ctx, a, cfg),
 		indexingFailureCheck(ctx, a, cfg),
@@ -552,6 +555,148 @@ func stuckPendingCheck(ctx context.Context, a *App, cfg config.Config) doctorChe
 	}
 	return doctorCheck{Name: name, Status: doctorStatusWarn, Detail: fmt.Sprintf(
 		"%d chunk(s) stuck pending embedding and no daemon is running to drain them; start it with `dir2mcp up` (or run `dir2mcp reindex`)", stats.EmbeddedPending)}
+}
+
+// egressCheck reports, per content-carrying capability (embed, chat, ocr,
+// stt), whether the resolved provider's effective endpoint is a public /
+// third-party host — meaning corpus content leaves this machine — or a
+// local/loopback/LAN endpoint (no egress). It exists so an operator with a
+// data-residency / on-prem requirement can VERIFY "nothing leaves the host"
+// from the resolved configuration instead of inferring it from the absence of
+// cloud base_urls (#493).
+//
+// The check is purely informational and never fails or warns: sending corpus
+// content to a cloud provider is the intended default for most users, not a
+// misconfiguration, so it stays at "ok" and puts the verdict in Detail. All
+// work is local config resolution and host classification — no network is
+// touched, so the row is cheap and always safe to run.
+//
+// A capability that does not resolve (not configured) is skipped: an
+// unconfigured provider sends nothing. When a resolved profile has no explicit
+// base_url, the effective host is the provider kind's built-in default (e.g.
+// kind: mistral -> api.mistral.ai), so a happy-path cloud setup is correctly
+// reported as egress even though its base_url is blank.
+func egressCheck(cfg config.Config) doctorCheck {
+	const name = "egress"
+	res := cfg.Providers()
+	// Ordered so the detail reads embed, chat, ocr, stt regardless of map
+	// iteration; each pair is a corpus-content-carrying capability.
+	caps := []struct {
+		label string
+		cap   provider.Capability
+	}{
+		{"embed", provider.CapEmbed},
+		{"chat", provider.CapChat},
+		{"ocr", provider.CapOCR},
+		{"stt", provider.CapSTT},
+	}
+
+	// Group public destinations by host so the same provider serving several
+	// capabilities renders once (e.g. "api.mistral.ai (embed, chat, ocr)").
+	byHost := map[string][]string{}
+	hostOrder := []string{}
+	resolvedAny := false
+	for _, c := range caps {
+		prof, err := res.Resolve(c.cap)
+		if err != nil {
+			continue // capability not configured -> nothing egresses for it
+		}
+		resolvedAny = true
+		host := effectiveProviderHost(prof)
+		if host == "" || hostIsLocal(host) {
+			continue // loopback / LAN / self-hosted, or no known endpoint
+		}
+		if _, seen := byHost[host]; !seen {
+			hostOrder = append(hostOrder, host)
+		}
+		byHost[host] = append(byHost[host], c.label)
+	}
+
+	if !resolvedAny {
+		return doctorCheck{Name: name, Status: doctorStatusOK, Detail: "no content providers resolved"}
+	}
+	if len(hostOrder) == 0 {
+		return doctorCheck{Name: name, Status: doctorStatusOK,
+			Detail: "no third-party egress: all resolved providers target local/loopback or private/LAN endpoints"}
+	}
+	sort.Strings(hostOrder)
+	parts := make([]string, 0, len(hostOrder))
+	for _, h := range hostOrder {
+		parts = append(parts, fmt.Sprintf("%s (%s)", h, strings.Join(byHost[h], ", ")))
+	}
+	return doctorCheck{Name: name, Status: doctorStatusOK, Detail: fmt.Sprintf(
+		"corpus content egresses to third-party host(s): %s. For an on-prem/no-egress setup, see the README 'Fully local / no-egress' recipe.",
+		strings.Join(parts, "; "))}
+}
+
+// kindDefaultHost maps a provider kind to the cloud host its client contacts
+// when a profile sets no explicit base_url. It mirrors the defaultBaseURL
+// constants in the per-provider clients (internal/{mistral,openai,anthropic,
+// gemini,cohere,elevenlabs}). Self-hosted-only kinds (whisper/omniembed/colbert
+// and the credential-less `local` openai profile) have no cloud default and are
+// intentionally absent, so a blank base_url on those resolves to no host.
+var kindDefaultHost = map[provider.Kind]string{
+	provider.KindMistral:    "api.mistral.ai",
+	provider.KindOpenAI:     "api.openai.com",
+	provider.KindAnthropic:  "api.anthropic.com",
+	provider.KindGemini:     "generativelanguage.googleapis.com",
+	provider.KindCohere:     "api.cohere.com",
+	provider.KindElevenLabs: "api.elevenlabs.io",
+}
+
+// effectiveProviderHost returns the hostname the resolved profile will actually
+// contact: the host of its explicit base_url when set, else the kind's built-in
+// cloud default. Returns "" when neither is known (a self-hosted kind whose
+// base_url was left unset — misconfigured, surfaced by other checks, not egress
+// to a known third party).
+func effectiveProviderHost(prof provider.Profile) string {
+	if raw := strings.TrimSpace(prof.BaseURL); raw != "" {
+		if h := hostFromBaseURL(raw); h != "" {
+			return h
+		}
+		return ""
+	}
+	return kindDefaultHost[prof.Kind]
+}
+
+// hostFromBaseURL extracts the lowercased hostname (no port) from a provider
+// base_url. It tolerates a scheme-less value (e.g. "gpu-vps:9001") by parsing
+// it as an authority.
+func hostFromBaseURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err == nil && u.Host != "" {
+		return strings.ToLower(u.Hostname())
+	}
+	// Scheme-less: reparse with a scheme so host/port split correctly.
+	if u2, err2 := url.Parse("http://" + raw); err2 == nil && u2.Host != "" {
+		return strings.ToLower(u2.Hostname())
+	}
+	return ""
+}
+
+// hostIsLocal reports whether host denotes a loopback, private/LAN, or
+// otherwise non-public endpoint — i.e. one that does not send corpus content
+// off the machine/network. A bare single-label hostname (no dot, e.g.
+// "gpu-vps") is treated as LAN. Public FQDNs and public IPs return false.
+func hostIsLocal(host string) bool {
+	host = strings.ToLower(strings.TrimSpace(host))
+	if host == "" {
+		return true
+	}
+	switch host {
+	case "localhost", "ip6-localhost", "ip6-loopback":
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsUnspecified()
+	}
+	for _, suffix := range []string{".local", ".localhost", ".internal", ".lan", ".intranet"} {
+		if strings.HasSuffix(host, suffix) {
+			return true
+		}
+	}
+	// A single-label hostname (no dot) is not a public FQDN; treat as LAN.
+	return !strings.Contains(host, ".")
 }
 
 // renderDoctorReport emits checks as either JSON (one object with an

--- a/internal/cli/server_doctor_egress_test.go
+++ b/internal/cli/server_doctor_egress_test.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/provider"
+)
+
+// TestHostIsLocal_Classification proves the egress check's host classifier
+// treats loopback, private/LAN, single-label, and known-internal hosts as
+// non-egress while public FQDNs and public IPs are egress.
+func TestHostIsLocal_Classification(t *testing.T) {
+	local := []string{
+		"localhost", "127.0.0.1", "127.5.6.7", "::1", "0.0.0.0",
+		"10.0.0.5", "172.16.4.9", "192.168.1.20", "169.254.10.1",
+		"gpu-vps", "gpu-vps.local", "models.internal", "box.lan",
+	}
+	for _, h := range local {
+		if !hostIsLocal(h) {
+			t.Errorf("hostIsLocal(%q) = false, want true (no egress)", h)
+		}
+	}
+	public := []string{
+		"api.mistral.ai", "api.openai.com", "generativelanguage.googleapis.com",
+		"8.8.8.8", "example.com", "sub.domain.example.org",
+	}
+	for _, h := range public {
+		if hostIsLocal(h) {
+			t.Errorf("hostIsLocal(%q) = true, want false (egress)", h)
+		}
+	}
+}
+
+// TestHostFromBaseURL covers scheme-ful and scheme-less base_urls, port
+// stripping, and case folding.
+func TestHostFromBaseURL(t *testing.T) {
+	cases := map[string]string{
+		"https://api.mistral.ai/v1":  "api.mistral.ai",
+		"http://127.0.0.1:11434/v1":  "127.0.0.1",
+		"http://GPU-VPS:9001":        "gpu-vps",
+		"gpu-vps:9001":               "gpu-vps",
+		"https://API.OpenAI.com/v1/": "api.openai.com",
+	}
+	for in, want := range cases {
+		if got := hostFromBaseURL(in); got != want {
+			t.Errorf("hostFromBaseURL(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestEffectiveProviderHost_KindDefaults proves a blank base_url resolves to
+// the kind's cloud default (so a happy-path cloud profile still counts as
+// egress) while a self-hosted-only kind with no base_url resolves to "".
+func TestEffectiveProviderHost_KindDefaults(t *testing.T) {
+	if got := effectiveProviderHost(provider.Profile{Kind: provider.KindMistral}); got != "api.mistral.ai" {
+		t.Errorf("mistral default host = %q, want api.mistral.ai", got)
+	}
+	if got := effectiveProviderHost(provider.Profile{Kind: provider.KindOpenAI, BaseURL: "http://gpu:8080/v1"}); got != "gpu" {
+		t.Errorf("explicit base_url host = %q, want gpu", got)
+	}
+	if got := effectiveProviderHost(provider.Profile{Kind: provider.KindWhisper}); got != "" {
+		t.Errorf("self-hosted kind with no base_url host = %q, want \"\"", got)
+	}
+}
+
+// TestKindDefaultHost_MirrorsClients guards against a provider kind gaining a
+// cloud default that the egress check forgets to classify. Every cloud kind in
+// the map must be non-empty.
+func TestKindDefaultHost_MirrorsClients(t *testing.T) {
+	for k, h := range kindDefaultHost {
+		if strings.TrimSpace(h) == "" {
+			t.Errorf("kindDefaultHost[%q] is empty", k)
+		}
+		if hostIsLocal(h) {
+			t.Errorf("kindDefaultHost[%q] = %q classified as local; a cloud default must be public", k, h)
+		}
+	}
+}

--- a/tests/security/cli_boundary_test.go
+++ b/tests/security/cli_boundary_test.go
@@ -193,6 +193,7 @@ func TestRepoSplitBoundary_InternalCLIFileOwnership(t *testing.T) {
 		"routing_decision.go":                    {},
 		"server_doctor.go":                       {},
 		"server_doctor_coverage_test.go":         {},
+		"server_doctor_egress_test.go":           {},
 		"server_log_tee_internal_test.go":        {},
 		"service.go":                             {},
 		"service_darwin.go":                      {},


### PR DESCRIPTION
Documentation-truthfulness batch. Docs / `.env.example` only, plus one small new `doctor` egress check (no spec change, no submodule re-pin). Every claim was verified against the actual code/release before writing.

## Issues

Closes #489, Closes #490, Closes #491, Closes #430, Closes #493

## What changed, per issue

### #489 — Homebrew trust (README install)
Install steps now `brew tap` + `brew trust dirstral/tap` + `brew install`. On Homebrew 6.x a freshly tapped third-party formula is refused until trusted, so the bare install fails on a clean machine. (Confirmed against tap issue dirstral/homebrew-tap#42 and the release runbook.)

### #490 — lean/full conflict (README two-tracks)
Documents that the two formulae install the **same binary** and conflict, with the `brew unlink` (or `brew uninstall`) switch procedure.

### #491 — full footprint (README two-tracks)
Adds a Footprint column + prose: full ≈ 6.3 GB installed (~39k files) / ~3 min build, bundling a Python 3.12 venv with docling + torch/torchvision/scipy/shapely; lean installs in seconds with only `libcap` + `bubblewrap`. Numbers are the measured Linux x86_64 / Homebrew 6.0.6 figures from dirstral/homebrew-tap#45, attributed to that platform (macOS / prebuilt bottles differ).

### #493 — fully-local / no-egress path (docs + doctor egress check) — **doctor check INCLUDED**
- New README **"Fully local / no-egress setup"** recipe: self-hosted embed/chat via a `kind: openai` endpoint you run, STT via `kind: whisper`, local docling for extraction, no cloud keys. Cross-linked from `.env.example`.
- New **`dir2mcp doctor` egress check**: resolves the content-carrying capabilities (embed/chat/ocr/stt) and reports whether any resolved provider endpoint is a public/third-party host, so operators can *verify* "nothing leaves the host" rather than infer it. Purely informational (never fails/warns), local-only (no network). A blank `base_url` resolves to the provider kind's cloud default, so a happy-path cloud config is correctly flagged as egress. Verified end-to-end against the built binary (cloud config → `api.mistral.ai (embed, chat, ocr, stt)`; local config → `no third-party egress`).

### #430 — stale env vars / tunnel ports / missing commands
- `MISTRAL_BASE_URL` and `DIR2MCP_MISTRAL_MAX_OCR_PAYLOAD_BYTES` are read by **no** production code (verified by grep of `internal/`+`cmd/` minus tests). Removed from `.env.example`; README now points at the real mechanism (a `providers:` `base_url` entry). `ELEVENLABS_BASE_URL`/`COHERE_BASE_URL`/`WHISPER_BASE_URL`/etc. **are** wired, so they were left intact.
- Tunnel examples no longer hardcode `:8087` — the default `up` listen is a random `127.0.0.1:0`; docs now tell users to use the printed URL or pin `--listen`/`listen_addr`. (The bridge's own `DefaultMCPURL` `:8087` fallback is a real constant and was kept, with a clarifying note.)
- README CLI table gains `down`, `embed-worker`, `export`, `bridge`, `support-bundle`, and documents the server-side `doctor`.

## Tests / checks
- New `internal/cli/server_doctor_egress_test.go`, registered in `tests/security/cli_boundary_test.go`.
- `make check` passes.
- `coderabbit review` run; the single finding (broaden the quoted no-egress wording) addressed by widening both the doctor message and the README quote in lockstep so they stay identical.

## Notes
- Overlap with PR #575 (README extraction section) avoided — edits are confined to the Homebrew / two-tracks / no-egress / CLI-table / env-var sections.