### PR TITLE
fix(cli): per-document file_error + periodic scan/embed progress on the NDJSON stream (#414 part 3)

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -108,6 +108,10 @@ type documentDeleteNotifier interface {
 	SetOnDocumentsDeleted(fn func(relPaths []string))
 }
 
+type documentErrorNotifier interface {
+	SetOnDocumentError(fn func(relPath, docType, message string))
+}
+
 type contentHashResetter interface {
 	ClearDocumentContentHashes(ctx context.Context) error
 }
@@ -1896,6 +1900,7 @@ func writeCorpusSnapshot(ctx context.Context, stateDir string, st model.Store, i
 	if err != nil {
 		return err
 	}
+	emitProgressEvents(emitter, snapshot.Indexing)
 
 	raw, err := json.MarshalIndent(snapshot, "", "  ")
 	if err != nil {
@@ -1908,6 +1913,32 @@ func writeCorpusSnapshot(ctx context.Context, stateDir string, st model.Store, i
 		return fmt.Errorf("write corpus snapshot: %w", err)
 	}
 	return nil
+}
+
+// emitProgressEvents emits the spec-required `scan_progress` and
+// `embed_progress` NDJSON events (SPEC §3.2) from a freshly built snapshot.
+// It is called on every corpus-writer tick, which is what makes the events
+// *periodic* — before #414 they were emitted exactly once at startup with
+// hardcoded zeros, so an operator tailing `--json` never saw indexing advance.
+//
+// Representations, ChunksTotal and EmbeddedOK carry the -1 "not derivable"
+// sentinel on the ListFiles-only fallback path; it is passed through verbatim
+// because the spec defines -1 as "unavailable", not as an error.
+func emitProgressEvents(emitter *ndjsonEmitter, idx corpusIndexing) {
+	emitter.Emit("info", "scan_progress", map[string]interface{}{
+		"scanned": idx.Scanned,
+		"indexed": idx.Indexed,
+		"skipped": idx.Skipped,
+		"deleted": idx.Deleted,
+		"reps":    idx.Representations,
+		"chunks":  idx.ChunksTotal,
+		"errors":  idx.Errors,
+	})
+	emitter.Emit("info", "embed_progress", map[string]interface{}{
+		"embedded": idx.EmbeddedOK,
+		"chunks":   idx.ChunksTotal,
+		"errors":   idx.Errors,
+	})
 }
 
 // buildCorpusSnapshot collects corpus stats and assembles a corpusSnapshot,
@@ -2165,7 +2196,7 @@ func reportUnexpectedDocStatuses(statusCounts map[string]int64, examples map[str
 // Emit writes a single timestamped NDJSON event line when the emitter is
 // enabled; encoding failures are silently dropped.
 func (e *ndjsonEmitter) Emit(level, event string, data interface{}) {
-	if !e.enabled {
+	if e == nil || !e.enabled {
 		return
 	}
 	entry := ndjsonEvent{

--- a/internal/cli/ndjson_events_test.go
+++ b/internal/cli/ndjson_events_test.go
@@ -1,0 +1,182 @@
+package cli
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// decodeNDJSON parses the emitter output into events keyed by event name.
+// Later occurrences win, which is what the periodic-progress assertions want:
+// they care about the most recent counter values on the stream.
+func decodeNDJSON(t *testing.T, raw string) map[string]map[string]interface{} {
+	t.Helper()
+	events := make(map[string]map[string]interface{})
+	scanner := bufio.NewScanner(strings.NewReader(raw))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var ev struct {
+			Level string                 `json:"level"`
+			Event string                 `json:"event"`
+			Data  map[string]interface{} `json:"data"`
+		}
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			t.Fatalf("unmarshal ndjson line %q: %v", line, err)
+		}
+		ev.Data["__level"] = ev.Level
+		events[ev.Event] = ev.Data
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan ndjson: %v", err)
+	}
+	return events
+}
+
+// TestEmitProgressEvents_CarriesLiveCounters is the regression guard for #414:
+// scan_progress/embed_progress must report the real indexing counters, not the
+// hardcoded zeros that were emitted once at startup.
+func TestEmitProgressEvents_CarriesLiveCounters(t *testing.T) {
+	var buf bytes.Buffer
+	emitter := newNDJSONEmitter(&buf, true)
+
+	emitProgressEvents(emitter, corpusIndexing{
+		Scanned:         412,
+		Indexed:         55,
+		Skipped:         340,
+		Deleted:         2,
+		Representations: 88,
+		ChunksTotal:     1480,
+		EmbeddedOK:      920,
+		Errors:          1,
+	})
+
+	events := decodeNDJSON(t, buf.String())
+
+	scan, ok := events["scan_progress"]
+	if !ok {
+		t.Fatalf("no scan_progress event emitted; got %v", buf.String())
+	}
+	for field, want := range map[string]float64{
+		"scanned": 412, "indexed": 55, "skipped": 340,
+		"deleted": 2, "reps": 88, "chunks": 1480, "errors": 1,
+	} {
+		if got, _ := scan[field].(float64); got != want {
+			t.Errorf("scan_progress[%s] = %v, want %v", field, scan[field], want)
+		}
+	}
+
+	embed, ok := events["embed_progress"]
+	if !ok {
+		t.Fatalf("no embed_progress event emitted; got %v", buf.String())
+	}
+	for field, want := range map[string]float64{
+		"embedded": 920, "chunks": 1480, "errors": 1,
+	} {
+		if got, _ := embed[field].(float64); got != want {
+			t.Errorf("embed_progress[%s] = %v, want %v", field, embed[field], want)
+		}
+	}
+}
+
+// TestEmitProgressEvents_PassesThroughUnavailableSentinel pins the spec rule
+// that -1 means "not derivable" (the ListFiles-only fallback) and MUST reach
+// the client verbatim rather than being clamped to 0 — a 0 would be read as
+// "nothing embedded", which is a different, wrong claim.
+func TestEmitProgressEvents_PassesThroughUnavailableSentinel(t *testing.T) {
+	var buf bytes.Buffer
+	emitter := newNDJSONEmitter(&buf, true)
+
+	emitProgressEvents(emitter, corpusIndexing{
+		Scanned:         10,
+		Representations: -1,
+		ChunksTotal:     -1,
+		EmbeddedOK:      -1,
+	})
+
+	events := decodeNDJSON(t, buf.String())
+	if got, _ := events["scan_progress"]["reps"].(float64); got != -1 {
+		t.Errorf("scan_progress[reps] = %v, want -1", events["scan_progress"]["reps"])
+	}
+	if got, _ := events["embed_progress"]["embedded"].(float64); got != -1 {
+		t.Errorf("embed_progress[embedded] = %v, want -1", events["embed_progress"]["embedded"])
+	}
+}
+
+func TestEmitProgressEvents_DisabledEmitterIsSilent(t *testing.T) {
+	var buf bytes.Buffer
+	emitProgressEvents(newNDJSONEmitter(&buf, false), corpusIndexing{Scanned: 1})
+	if buf.Len() != 0 {
+		t.Fatalf("disabled emitter wrote %q, want no output", buf.String())
+	}
+}
+
+func TestEmitProgressEvents_NilEmitterDoesNotPanic(t *testing.T) {
+	emitProgressEvents(nil, corpusIndexing{Scanned: 1})
+}
+
+// TestNewFileErrorEmitter_EmitsPerDocumentIdentity covers the other half of
+// #414 part 3: a non-fatal per-document failure must reach the stream with the
+// document identity attached, not just a bare message.
+func TestNewFileErrorEmitter_EmitsPerDocumentIdentity(t *testing.T) {
+	var buf bytes.Buffer
+	emitter := newNDJSONEmitter(&buf, true)
+
+	newFileErrorEmitter(emitter)("docs/broken.pdf", "pdf", "extract: encrypted document")
+
+	events := decodeNDJSON(t, buf.String())
+	fe, ok := events["file_error"]
+	if !ok {
+		t.Fatalf("no file_error event emitted; got %q", buf.String())
+	}
+	if got := fe["rel_path"]; got != "docs/broken.pdf" {
+		t.Errorf("rel_path = %v, want docs/broken.pdf", got)
+	}
+	if got := fe["doc_type"]; got != "pdf" {
+		t.Errorf("doc_type = %v, want pdf", got)
+	}
+	if got := fe["message"]; got != "extract: encrypted document" {
+		t.Errorf("message = %v, want the extract error", got)
+	}
+	if got := fe["__level"]; got != "error" {
+		t.Errorf("level = %v, want error", got)
+	}
+}
+
+// errorNotifierStub records what wireIngestorHooks registers on it.
+type errorNotifierStub struct {
+	model.Ingestor
+	fn func(relPath, docType, message string)
+}
+
+func (s *errorNotifierStub) SetOnDocumentError(fn func(relPath, docType, message string)) {
+	s.fn = fn
+}
+
+func TestWireIngestorHooks_RegistersDocumentErrorCallback(t *testing.T) {
+	stub := &errorNotifierStub{}
+	called := false
+	wireIngestorHooks(stub, nil, nil, func(string, string, string) { called = true })
+
+	if stub.fn == nil {
+		t.Fatal("wireIngestorHooks did not register the document-error callback")
+	}
+	stub.fn("a.pdf", "pdf", "boom")
+	if !called {
+		t.Fatal("registered callback was not the one passed in")
+	}
+}
+
+func TestWireIngestorHooks_NilCallbackIsNotRegistered(t *testing.T) {
+	stub := &errorNotifierStub{}
+	wireIngestorHooks(stub, nil, nil, nil)
+	if stub.fn != nil {
+		t.Fatal("wireIngestorHooks registered a nil callback")
+	}
+}

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -124,7 +124,7 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 		writeCLIError(a.stderr, opts.jsonOutput, exitConfigInvalid, fmt.Sprintf("initialize ingestor: %v", err))
 		return exitConfigInvalid
 	}
-	wireIngestorHooks(ing, indexingState, ret.EvictDocuments)
+	wireIngestorHooks(ing, indexingState, ret.EvictDocuments, newFileErrorEmitter(emitter))
 	wireDerivationCacheIdentities(ret, ing)
 
 	corpusFS, err := buildCorpusFS(ctx, cfg)
@@ -1206,14 +1206,37 @@ func buildCorpusFS(ctx context.Context, cfg config.Config) (corpusfs.CorpusFS, e
 	})
 }
 
-// wireIngestorHooks connects the optional indexing-state and document-delete
-// notification interfaces on ing, if the concrete type supports them.
-func wireIngestorHooks(ing model.Ingestor, indexingState *appstate.IndexingState, evict func([]string)) {
+// wireIngestorHooks connects the optional indexing-state, document-delete and
+// document-error notification interfaces on ing, if the concrete type supports
+// them. onDocError may be nil, in which case no per-document error callback is
+// registered.
+func wireIngestorHooks(ing model.Ingestor, indexingState *appstate.IndexingState, evict func([]string), onDocError func(relPath, docType, message string)) {
 	if stateAware, ok := ing.(indexingStateAware); ok {
 		stateAware.SetIndexingState(indexingState)
 	}
 	if notifier, ok := ing.(documentDeleteNotifier); ok {
 		notifier.SetOnDocumentsDeleted(evict)
+	}
+	if onDocError == nil {
+		return
+	}
+	if notifier, ok := ing.(documentErrorNotifier); ok {
+		notifier.SetOnDocumentError(onDocError)
+	}
+}
+
+// newFileErrorEmitter returns the per-document error callback handed to the
+// ingestor. It emits the spec-required non-fatal `file_error` event (SPEC §3.2)
+// carrying the document identity, so an operator tailing `--json` can see which
+// document failed and why. The message arrives already secret-redacted by
+// ingest.persistNonFatalDocError; it is passed through untouched.
+func newFileErrorEmitter(emitter *ndjsonEmitter) func(relPath, docType, message string) {
+	return func(relPath, docType, message string) {
+		emitter.Emit("error", "file_error", map[string]interface{}{
+			"rel_path": relPath,
+			"doc_type": docType,
+			"message":  message,
+		})
 	}
 }
 

--- a/internal/ingest/document_error_hook_test.go
+++ b/internal/ingest/document_error_hook_test.go
@@ -1,0 +1,134 @@
+package ingest
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log"
+	"regexp"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// docErrorStubStore is the minimal model.Store needed to drive
+// persistNonFatalDocError. upsertErr lets a test simulate a failing store.
+type docErrorStubStore struct {
+	mu        sync.Mutex
+	upserted  []model.Document
+	upsertErr error
+}
+
+func (s *docErrorStubStore) Init(context.Context) error { return nil }
+
+func (s *docErrorStubStore) UpsertDocument(_ context.Context, doc model.Document) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.upserted = append(s.upserted, doc)
+	return s.upsertErr
+}
+
+func (s *docErrorStubStore) GetDocumentByPath(context.Context, string) (model.Document, error) {
+	return model.Document{}, model.ErrNotImplemented
+}
+
+func (s *docErrorStubStore) ListFiles(context.Context, string, string, int, int) ([]model.Document, int64, error) {
+	return nil, 0, nil
+}
+
+func (s *docErrorStubStore) Close() error { return nil }
+
+func newDocErrorService(store model.Store) *Service {
+	return &Service{store: store, logger: log.New(io.Discard, "", 0)}
+}
+
+// TestPersistNonFatalDocError_NotifiesWithRedactedMessage is the security-
+// relevant assertion for #414: the per-document `file_error` stream event must
+// carry the redacted message, never the raw error text. A stream consumer is an
+// untrusted sink (server.log, a piped process), so a leaked credential here is
+// as bad as one in the store.
+func TestPersistNonFatalDocError_NotifiesWithRedactedMessage(t *testing.T) {
+	store := &docErrorStubStore{}
+	svc := newDocErrorService(store)
+
+	var (
+		gotRelPath string
+		gotDocType string
+		gotMessage string
+		calls      int
+	)
+	svc.SetOnDocumentError(func(relPath, docType, message string) {
+		calls++
+		gotRelPath, gotDocType, gotMessage = relPath, docType, message
+	})
+
+	secret := regexp.MustCompile(`s3cr3t-[a-z0-9]+`)
+	doc := model.Document{RelPath: "docs/broken.pdf", DocType: "pdf"}
+	cause := errors.New("ocr call failed: token s3cr3t-abc123 rejected")
+
+	svc.persistNonFatalDocError(context.Background(), doc, cause, []*regexp.Regexp{secret})
+
+	if calls != 1 {
+		t.Fatalf("callback invoked %d times, want exactly 1", calls)
+	}
+	if gotRelPath != "docs/broken.pdf" {
+		t.Errorf("relPath = %q, want docs/broken.pdf", gotRelPath)
+	}
+	if gotDocType != "pdf" {
+		t.Errorf("docType = %q, want pdf", gotDocType)
+	}
+	if strings.Contains(gotMessage, "s3cr3t-abc123") {
+		t.Fatalf("callback received an unredacted secret: %q", gotMessage)
+	}
+	if !strings.Contains(gotMessage, "ocr call failed") {
+		t.Errorf("callback lost the actionable error text: %q", gotMessage)
+	}
+
+	// The persisted document must carry the same redacted message.
+	if len(store.upserted) != 1 {
+		t.Fatalf("upserted %d docs, want 1", len(store.upserted))
+	}
+	if store.upserted[0].Status != "error" {
+		t.Errorf("persisted status = %q, want error", store.upserted[0].Status)
+	}
+	if store.upserted[0].ErrorMessage != gotMessage {
+		t.Errorf("persisted message %q != streamed message %q", store.upserted[0].ErrorMessage, gotMessage)
+	}
+}
+
+// TestPersistNonFatalDocError_NotifiesEvenWhenUpsertFails pins the deliberate
+// ordering choice: the document genuinely failed, so the operator tailing
+// `--json` must still learn about it even if we could not record it.
+func TestPersistNonFatalDocError_NotifiesEvenWhenUpsertFails(t *testing.T) {
+	store := &docErrorStubStore{upsertErr: errors.New("disk full")}
+	svc := newDocErrorService(store)
+
+	called := false
+	svc.SetOnDocumentError(func(string, string, string) { called = true })
+
+	svc.persistNonFatalDocError(context.Background(), model.Document{RelPath: "a.pdf"}, errors.New("boom"), nil)
+
+	if !called {
+		t.Fatal("callback was not invoked when the store upsert failed")
+	}
+}
+
+// TestNotifyDocumentError_ContainsCallbackPanic guards the ingest run against a
+// buggy stream consumer: a panicking callback must not abort indexing.
+func TestNotifyDocumentError_ContainsCallbackPanic(t *testing.T) {
+	svc := newDocErrorService(&docErrorStubStore{})
+	svc.SetOnDocumentError(func(string, string, string) { panic("consumer blew up") })
+
+	svc.notifyDocumentError(model.Document{RelPath: "a.pdf"}) // must not panic
+}
+
+func TestNotifyDocumentError_NilCallbackIsNoop(t *testing.T) {
+	svc := newDocErrorService(&docErrorStubStore{})
+	svc.notifyDocumentError(model.Document{RelPath: "a.pdf"})
+
+	svc.SetOnDocumentError(func(string, string, string) { t.Fatal("cleared callback was invoked") })
+	svc.SetOnDocumentError(nil)
+	svc.notifyDocumentError(model.Document{RelPath: "a.pdf"})
+}

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -209,6 +209,13 @@ type Service struct {
 	// service's in-memory maps so deleted files are no longer searchable.
 	onDocumentsDeleted   func(relPaths []string)
 	onDocumentsDeletedMu sync.RWMutex
+
+	// optional callback invoked for every non-fatal per-document failure, after
+	// the message has been secret-redacted. The CLI uses it to emit the
+	// spec-required per-document `file_error` NDJSON event (SPEC §3.2, #414);
+	// without it a failed document is only observable by polling the store.
+	onDocumentError   func(relPath, docType, message string)
+	onDocumentErrorMu sync.RWMutex
 	// bounds the compatibility wrapper used by SetOnDocumentDeleted so large
 	// deletion batches do not spawn an unbounded number of goroutines.
 	onDocumentDeletedMaxConcurrency int
@@ -710,6 +717,16 @@ func (s *Service) SetOnDocumentsDeleted(fn func(relPaths []string)) {
 	s.onDocumentsDeletedMu.Lock()
 	defer s.onDocumentsDeletedMu.Unlock()
 	s.onDocumentsDeleted = fn
+}
+
+// SetOnDocumentError registers a callback invoked once per non-fatal
+// per-document failure. The message passed to fn has already been
+// secret-redacted by persistNonFatalDocError; callers MUST NOT re-derive it
+// from the underlying error. Passing nil clears the callback.
+func (s *Service) SetOnDocumentError(fn func(relPath, docType, message string)) {
+	s.onDocumentErrorMu.Lock()
+	defer s.onDocumentErrorMu.Unlock()
+	s.onDocumentError = fn
 }
 
 // DiscoverOptionsFromConfig resolves ingest discovery behavior from config.
@@ -3079,6 +3096,27 @@ func (s *Service) persistNonFatalDocError(ctx context.Context, doc model.Documen
 	if err := s.store.UpsertDocument(ctx, doc); err != nil {
 		s.getLogger().Printf("persist error status for %s: %v", doc.RelPath, err)
 	}
+	s.notifyDocumentError(doc)
+}
+
+// notifyDocumentError invokes the registered per-document error callback with
+// the already-redacted message. It fires even when the upsert above failed: the
+// document did fail, and the stream event is the only signal an operator tailing
+// `--json` will ever see for it. A panicking callback is contained so a buggy
+// consumer cannot abort the ingest run.
+func (s *Service) notifyDocumentError(doc model.Document) {
+	s.onDocumentErrorMu.RLock()
+	fn := s.onDocumentError
+	s.onDocumentErrorMu.RUnlock()
+	if fn == nil {
+		return
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			s.getLogger().Printf("onDocumentError panic for %s (%s)", doc.RelPath, safePanicValue(r))
+		}
+	}()
+	fn(doc.RelPath, doc.DocType, doc.ErrorMessage)
 }
 
 // persistTitleIfFound runs the title heuristic on the supplied text body and,

--- a/tests/security/cli_boundary_test.go
+++ b/tests/security/cli_boundary_test.go
@@ -182,6 +182,7 @@ func TestRepoSplitBoundary_InternalCLIFileOwnership(t *testing.T) {
 		"export_reflow_internal_test.go":         {},
 		"export_ttml.go":                         {},
 		"flag_ordering_test.go":                  {},
+		"ndjson_events_test.go":                  {},
 		"pididentity_darwin.go":                  {},
 		"pididentity_linux.go":                   {},
 		"pididentity_other.go":                   {},


### PR DESCRIPTION
Recon on #414 found that two of its three parts were already delivered by #570, but **part 3 was entirely unimplemented** — no code behind it at all. This PR implements it.

## The bug is a spec-conformance violation, not a feature gap

`SPEC.md` §3.2 and `df-009-cli-output-contract.md` both list, as **required events for `up`**:

> * periodic `scan_progress` and `embed_progress`
> * `file_error` for per-document failures (non-fatal)

Neither held on `main`:

| Event | Spec says | `main` did |
|---|---|---|
| `file_error` | per-document, non-fatal | emitted **only** from `runEventLoop` when the *whole ingest run* returned a fatal error |
| `scan_progress` / `embed_progress` | periodic | emitted **once**, from `publishConnection`, with hardcoded zeros (`"skipped": 0`) |

So a single PDF that failed extraction produced no stream event, and an operator tailing `--json` never saw indexing advance past zero.

Because both event names are already in the spec's event enum, this needs **no spec change** — it is a conformance fix.

## What changed

**Per-document `file_error`.** `internal/ingest` gains `SetOnDocumentError`, following the existing `SetOnDocumentsDeleted` pattern (RWMutex-guarded, panic-contained so a buggy stream consumer cannot abort an ingest run). It fires from `persistNonFatalDocError`, the single choke point for all five per-document failure sites. The CLI wires it through `wireIngestorHooks` to an emitter that sends `{rel_path, doc_type, message}`.

Two deliberate choices worth reviewing:

- The callback receives the message **after** secret redaction. The NDJSON stream is an untrusted sink (`server.log`, a piped process), so a leaked credential there is as bad as one in the store. `TestPersistNonFatalDocError_NotifiesWithRedactedMessage` pins this.
- The callback fires **even when the status upsert fails**. The document genuinely failed, and if we could not record it, the stream event is the only signal the operator will ever get.

**Periodic progress.** Emitted from `writeCorpusSnapshot`, which the corpus writer already calls on a 5s tick while indexing runs, and which already holds both the live counters and the emitter. The `-1` "not derivable" sentinel (the ListFiles-only fallback path) is passed through verbatim rather than clamped to `0` — per spec, `-1` means *unavailable*, whereas `0` would assert "nothing embedded", a different and wrong claim.

The startup zero-valued emission in `publishConnection` is **retained**: `tests/cli/up_command_test.go` and `tests/up_command_test.go` assert the required events are present at startup.

Also hardens `ndjsonEmitter.Emit` against a nil receiver.

## Left alone, on purpose

`runEventLoop` still emits `file_error` alongside `fatal` on a whole-run ingest failure. That is arguably spec misuse (`file_error` is defined as non-fatal), but no test covers it and removing it is an observable behavior change for any existing consumer. Flagging it rather than folding it in — happy to remove in a follow-up if you agree.

## Not in this PR — blocked on spec

Two remaining #414 bullets need a `dirstral-spec` change first, per the governance loop:

1. **A per-file skip event.** `file_skip` is **not** in the spec's event enum, so emitting it would be a spec violation. Needs a spec PR to add it.
2. **`doc_counts` overstates coverage.** The code runs `GROUP BY doc_type WHERE deleted = 0` with no status filter, so a rejected `.odt` inflates the `document` count. But the spec text is self-contradictory here — `bs-007` line 199 says `doc_counts` "groups `status="ready"` documents by `doc_type` and so **overstates** coverage", which cannot both be true. Needs a spec clarification before the code can be changed in either direction.

Filing a `dirstral-spec` PR for both; the gated code re-pin follows.

## Verification

`go test ./...` all pass; `go vet`, `golangci-lint` (0 issues), `gocyclo -over 15`, `ineffassign`, `misspell`, `gofmt -l` on touched files all clean.

New tests: `internal/cli/ndjson_events_test.go` (live counters, `-1` sentinel pass-through, disabled/nil emitter, `file_error` identity, hook registration) and `internal/ingest/document_error_hook_test.go` (redaction, notify-on-upsert-failure, panic containment, nil-callback no-op). `ndjson_events_test.go` is registered in the `tests/security/cli_boundary_test.go` allowlist.

Part of #414. Does not close it — see "blocked on spec" above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured per-document error notifications in the CLI, including file path, document type, and message details.
  * Progress output now includes live indexing updates during snapshot writes.
* **Bug Fixes**
  * Preserves unavailable progress values instead of replacing them.
  * Prevents crashes when progress/error emitters are disabled or unset.
  * Ensures document error notifications are sent even if a document update fails.
* **Tests**
  * Added coverage for progress reporting, error events, nil handlers, and callback safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->