### PR TITLE
fix(cli): per-document `file_skip` NDJSON events + coverage remediation hints (#414)

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -112,6 +112,10 @@ type documentErrorNotifier interface {
 	SetOnDocumentError(fn func(relPath, docType, message string))
 }
 
+type documentSkipNotifier interface {
+	SetOnDocumentSkip(fn func(relPath, docType, reason string))
+}
+
 type contentHashResetter interface {
 	ClearDocumentContentHashes(ctx context.Context) error
 }

--- a/internal/cli/ndjson_events_test.go
+++ b/internal/cli/ndjson_events_test.go
@@ -149,34 +149,71 @@ func TestNewFileErrorEmitter_EmitsPerDocumentIdentity(t *testing.T) {
 	}
 }
 
-// errorNotifierStub records what wireIngestorHooks registers on it.
-type errorNotifierStub struct {
+// TestNewFileSkipEmitter_EmitsReasonAtWarnLevel covers the `file_skip` half of
+// the never-indexed partition: the event must name the file and carry a
+// `skip_reasons` enum value, at level=warn per SPEC §3.2.
+func TestNewFileSkipEmitter_EmitsReasonAtWarnLevel(t *testing.T) {
+	var buf bytes.Buffer
+	emitter := newNDJSONEmitter(&buf, true)
+
+	newFileSkipEmitter(emitter)("notes/report.odt", "document", model.SkipReasonUnsupportedFormat)
+
+	events := decodeNDJSON(t, buf.String())
+	fs, ok := events["file_skip"]
+	if !ok {
+		t.Fatalf("no file_skip event emitted; got %q", buf.String())
+	}
+	if got := fs["rel_path"]; got != "notes/report.odt" {
+		t.Errorf("rel_path = %v, want notes/report.odt", got)
+	}
+	if got := fs["doc_type"]; got != "document" {
+		t.Errorf("doc_type = %v, want document", got)
+	}
+	if got := fs["reason"]; got != model.SkipReasonUnsupportedFormat {
+		t.Errorf("reason = %v, want %v", got, model.SkipReasonUnsupportedFormat)
+	}
+	if got := fs["__level"]; got != "warn" {
+		t.Errorf("level = %v, want warn (SPEC §3.2 enum is info|warn|error)", got)
+	}
+}
+
+// notifierStub records what wireIngestorHooks registers on it.
+type notifierStub struct {
 	model.Ingestor
-	fn func(relPath, docType, message string)
+	errFn  func(relPath, docType, message string)
+	skipFn func(relPath, docType, reason string)
 }
 
-func (s *errorNotifierStub) SetOnDocumentError(fn func(relPath, docType, message string)) {
-	s.fn = fn
+func (s *notifierStub) SetOnDocumentError(fn func(relPath, docType, message string)) {
+	s.errFn = fn
 }
 
-func TestWireIngestorHooks_RegistersDocumentErrorCallback(t *testing.T) {
-	stub := &errorNotifierStub{}
-	called := false
-	wireIngestorHooks(stub, nil, nil, func(string, string, string) { called = true })
+func (s *notifierStub) SetOnDocumentSkip(fn func(relPath, docType, reason string)) {
+	s.skipFn = fn
+}
 
-	if stub.fn == nil {
-		t.Fatal("wireIngestorHooks did not register the document-error callback")
+func TestWireIngestorHooks_RegistersDocumentCallbacks(t *testing.T) {
+	stub := &notifierStub{}
+	errCalled, skipCalled := false, false
+	wireIngestorHooks(stub, ingestorHooks{
+		onDocError: func(string, string, string) { errCalled = true },
+		onDocSkip:  func(string, string, string) { skipCalled = true },
+	})
+
+	if stub.errFn == nil || stub.skipFn == nil {
+		t.Fatal("wireIngestorHooks did not register both document callbacks")
 	}
-	stub.fn("a.pdf", "pdf", "boom")
-	if !called {
-		t.Fatal("registered callback was not the one passed in")
+	stub.errFn("a.pdf", "pdf", "boom")
+	stub.skipFn("b.odt", "document", model.SkipReasonUnsupportedFormat)
+	if !errCalled || !skipCalled {
+		t.Fatalf("registered callbacks were not the ones passed in (err=%v skip=%v)", errCalled, skipCalled)
 	}
 }
 
-func TestWireIngestorHooks_NilCallbackIsNotRegistered(t *testing.T) {
-	stub := &errorNotifierStub{}
-	wireIngestorHooks(stub, nil, nil, nil)
-	if stub.fn != nil {
+func TestWireIngestorHooks_NilCallbacksAreNotRegistered(t *testing.T) {
+	stub := &notifierStub{}
+	wireIngestorHooks(stub, ingestorHooks{})
+	if stub.errFn != nil || stub.skipFn != nil {
 		t.Fatal("wireIngestorHooks registered a nil callback")
 	}
 }

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -233,8 +233,34 @@ func (a *App) renderCoverageBlock(s styles, snapshot corpusSnapshot) {
 	)
 	for _, reason := range reasons {
 		writef(a.stdout, "    %s\n", s.stat(reason, summary.Categories[reason]))
+		if hint := skipReasonHint(reason); hint != "" {
+			writef(a.stdout, "      %s\n", s.dim(hint))
+		}
 	}
 	writeln(a.stdout)
+}
+
+// skipReasonHint returns the remediation guidance for a skip reason — the
+// "here's what to install or configure" half of the honest-coverage report
+// (#414). It is empty for reasons that are working as intended (an archive
+// container, an ignored binary, an ignore-rule match): printing an action for
+// those would train operators to ignore the block.
+//
+// An unrecognized reason (a newer server, per the additive skip_reasons enum)
+// also returns empty rather than guessing.
+func skipReasonHint(reason string) string {
+	switch reason {
+	case model.SkipReasonUnsupportedFormat:
+		return "no active extraction engine reads these formats — install a richer extractor (e.g. the docling-enabled build) or set ingest.extractor"
+	case model.SkipReasonSizeCap:
+		return "larger than ingest.max_file_mb — raise the cap to include them"
+	case model.SkipReasonPathExcluded:
+		return "matched ingest.path_excludes — drop the pattern to include them"
+	case model.SkipReasonSecretExcluded:
+		return "matched a secret pattern and was withheld on purpose — review ingest.secret_patterns if this was unintended"
+	default:
+		return ""
+	}
 }
 
 // renderRecentFailuresBlock prints up to statusRecentFailuresLimit recent

--- a/internal/cli/status_coverage_test.go
+++ b/internal/cli/status_coverage_test.go
@@ -129,6 +129,53 @@ func TestRenderStatus_HealthyCorpusOmitsBlocks(t *testing.T) {
 
 // TestFormatSkipBreakdown merges the store's durable SkipSummary with the
 // in-run (non-persisted) path-exclude counts into one stable, sorted line.
+// TestRenderCoverageBlock_RemediationHints pins the "here's what to install or
+// configure" half of the honest-coverage report (#414): actionable reasons get
+// a hint, working-as-intended ones (archive) stay bare so the block does not
+// train operators to ignore it.
+func TestRenderCoverageBlock_RemediationHints(t *testing.T) {
+	snapshot := corpusSnapshot{
+		Timestamp: "2026-07-09T00:00:00Z",
+		Indexing: corpusIndexing{
+			Mode:    "incremental",
+			Skipped: 4,
+			SkipSummary: &model.SkipSummary{
+				Categories: map[string]int64{
+					model.SkipReasonUnsupportedFormat: 3,
+					model.SkipReasonArchive:           1,
+				},
+			},
+		},
+		DocCounts: map[string]int64{"text": 1},
+		TotalDocs: 1,
+	}
+
+	var out bytes.Buffer
+	app := &App{stdout: &out, stderr: &bytes.Buffer{}}
+	app.renderCoverageBlock(newStyles(&out, false), snapshot)
+
+	got := out.String()
+	if !strings.Contains(got, "ingest.extractor") {
+		t.Errorf("unsupported_format is actionable but printed no remediation hint:\n%s", got)
+	}
+	if strings.Contains(got, "archive —") {
+		t.Errorf("archive is working-as-intended and must print no hint:\n%s", got)
+	}
+}
+
+func TestSkipReasonHint_UnknownReasonYieldsNoGuess(t *testing.T) {
+	// The skip_reasons enum is additive: a newer server may report a reason this
+	// binary has never heard of. Render it bare rather than inventing advice.
+	if hint := skipReasonHint("some_future_reason"); hint != "" {
+		t.Fatalf("unknown reason produced a hint: %q", hint)
+	}
+	for _, benign := range []string{model.SkipReasonArchive, model.SkipReasonBinaryIgnored, model.SkipReasonIgnoreRule} {
+		if hint := skipReasonHint(benign); hint != "" {
+			t.Errorf("%s is working-as-intended but produced a hint: %q", benign, hint)
+		}
+	}
+}
+
 func TestFormatSkipBreakdown(t *testing.T) {
 	if got := formatSkipBreakdown(nil, nil); got != "" {
 		t.Errorf("empty breakdown = %q, want empty", got)

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -124,7 +124,12 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 		writeCLIError(a.stderr, opts.jsonOutput, exitConfigInvalid, fmt.Sprintf("initialize ingestor: %v", err))
 		return exitConfigInvalid
 	}
-	wireIngestorHooks(ing, indexingState, ret.EvictDocuments, newFileErrorEmitter(emitter))
+	wireIngestorHooks(ing, ingestorHooks{
+		indexingState: indexingState,
+		evict:         ret.EvictDocuments,
+		onDocError:    newFileErrorEmitter(emitter),
+		onDocSkip:     newFileSkipEmitter(emitter),
+	})
 	wireDerivationCacheIdentities(ret, ing)
 
 	corpusFS, err := buildCorpusFS(ctx, cfg)
@@ -1206,22 +1211,30 @@ func buildCorpusFS(ctx context.Context, cfg config.Config) (corpusfs.CorpusFS, e
 	})
 }
 
-// wireIngestorHooks connects the optional indexing-state, document-delete and
-// document-error notification interfaces on ing, if the concrete type supports
-// them. onDocError may be nil, in which case no per-document error callback is
-// registered.
-func wireIngestorHooks(ing model.Ingestor, indexingState *appstate.IndexingState, evict func([]string), onDocError func(relPath, docType, message string)) {
+// ingestorHooks carries the optional callbacks wireIngestorHooks registers on
+// an ingestor. Any field may be nil, in which case that hook is not registered.
+type ingestorHooks struct {
+	indexingState *appstate.IndexingState
+	evict         func([]string)
+	onDocError    func(relPath, docType, message string)
+	onDocSkip     func(relPath, docType, reason string)
+}
+
+// wireIngestorHooks connects the optional indexing-state, document-delete,
+// document-error and document-skip notification interfaces on ing, if the
+// concrete type supports them.
+func wireIngestorHooks(ing model.Ingestor, hooks ingestorHooks) {
 	if stateAware, ok := ing.(indexingStateAware); ok {
-		stateAware.SetIndexingState(indexingState)
+		stateAware.SetIndexingState(hooks.indexingState)
 	}
 	if notifier, ok := ing.(documentDeleteNotifier); ok {
-		notifier.SetOnDocumentsDeleted(evict)
+		notifier.SetOnDocumentsDeleted(hooks.evict)
 	}
-	if onDocError == nil {
-		return
+	if notifier, ok := ing.(documentErrorNotifier); ok && hooks.onDocError != nil {
+		notifier.SetOnDocumentError(hooks.onDocError)
 	}
-	if notifier, ok := ing.(documentErrorNotifier); ok {
-		notifier.SetOnDocumentError(onDocError)
+	if notifier, ok := ing.(documentSkipNotifier); ok && hooks.onDocSkip != nil {
+		notifier.SetOnDocumentSkip(hooks.onDocSkip)
 	}
 }
 
@@ -1236,6 +1249,21 @@ func newFileErrorEmitter(emitter *ndjsonEmitter) func(relPath, docType, message 
 			"rel_path": relPath,
 			"doc_type": docType,
 			"message":  message,
+		})
+	}
+}
+
+// newFileSkipEmitter returns the per-document skip callback handed to the
+// ingestor. It emits the spec-required `file_skip` event (SPEC §3.2) at
+// level=warn — the streaming counterpart of the durable `skip_reasons`
+// aggregate: the aggregate says what was not indexed in total, the event says
+// which file, as it happens. `reason` is a value of the `skip_reasons` enum.
+func newFileSkipEmitter(emitter *ndjsonEmitter) func(relPath, docType, reason string) {
+	return func(relPath, docType, reason string) {
+		emitter.Emit("warn", "file_skip", map[string]interface{}{
+			"rel_path": relPath,
+			"doc_type": docType,
+			"reason":   reason,
 		})
 	}
 }

--- a/internal/ingest/document_hooks_test.go
+++ b/internal/ingest/document_hooks_test.go
@@ -132,3 +132,93 @@ func TestNotifyDocumentError_NilCallbackIsNoop(t *testing.T) {
 	svc.SetOnDocumentError(nil)
 	svc.notifyDocumentError(model.Document{RelPath: "a.pdf"})
 }
+
+// --- file_skip (#414) ---
+
+// captureSkips registers a skip callback and returns the slice it appends to.
+func captureSkips(svc *Service) *[]string {
+	var got []string
+	svc.SetOnDocumentSkip(func(relPath, docType, reason string) {
+		got = append(got, relPath+"|"+docType+"|"+reason)
+	})
+	return &got
+}
+
+func TestNotifyDocumentSkip_CarriesReason(t *testing.T) {
+	svc := newDocErrorService(&docErrorStubStore{})
+	got := captureSkips(svc)
+
+	svc.notifyDocumentSkip(model.Document{
+		RelPath:    "notes/report.odt",
+		DocType:    "document",
+		Status:     "skipped",
+		SkipReason: model.SkipReasonUnsupportedFormat,
+	})
+
+	want := "notes/report.odt|document|" + model.SkipReasonUnsupportedFormat
+	if len(*got) != 1 || (*got)[0] != want {
+		t.Fatalf("skip events = %v, want [%s]", *got, want)
+	}
+}
+
+// A pre-#570 row has no skip_reason column value. The event must still name a
+// reason rather than emit an empty string, which would break the closed enum.
+func TestNotifyDocumentSkip_BlankReasonFallsBackToDocType(t *testing.T) {
+	svc := newDocErrorService(&docErrorStubStore{})
+	got := captureSkips(svc)
+
+	svc.notifyDocumentSkip(model.Document{RelPath: "a.zip", DocType: "archive", Status: "skipped"})
+	svc.notifyDocumentSkip(model.Document{RelPath: "a.bin", DocType: "binary_ignored", Status: "skipped"})
+	svc.notifyDocumentSkip(model.Document{RelPath: ".env", DocType: "ignore", Status: "skipped"})
+	svc.notifyDocumentSkip(model.Document{RelPath: "k.pem", DocType: "text", Status: "secret_excluded"})
+
+	want := []string{
+		"a.zip|archive|" + model.SkipReasonArchive,
+		"a.bin|binary_ignored|" + model.SkipReasonBinaryIgnored,
+		".env|ignore|" + model.SkipReasonIgnoreRule,
+		"k.pem|text|" + model.SkipReasonSecretExcluded,
+	}
+	if len(*got) != len(want) {
+		t.Fatalf("skip events = %v, want %v", *got, want)
+	}
+	for i := range want {
+		if (*got)[i] != want[i] {
+			t.Errorf("event[%d] = %q, want %q", i, (*got)[i], want[i])
+		}
+	}
+}
+
+// creditInitialStatus must NOT raise a file_skip for an archive container: the
+// container is credited as skipped up front but reverts to an error if member
+// extraction fails, and SPEC §3.2 forbids one document raising both events.
+// Its file_skip is deferred to handleArchiveDocumentAndNotify.
+func TestCreditInitialStatus_DefersArchiveSkipEvent(t *testing.T) {
+	svc := newDocErrorService(&docErrorStubStore{})
+	got := captureSkips(svc)
+
+	svc.creditInitialStatus(model.Document{RelPath: "bundle.zip", DocType: "archive", Status: "skipped", SkipReason: model.SkipReasonArchive})
+	if len(*got) != 0 {
+		t.Fatalf("archive container raised a premature file_skip: %v", *got)
+	}
+
+	svc.creditInitialStatus(model.Document{RelPath: "a.bin", DocType: "binary_ignored", Status: "skipped", SkipReason: model.SkipReasonBinaryIgnored})
+	if len(*got) != 1 {
+		t.Fatalf("non-archive skip did not raise file_skip: %v", *got)
+	}
+}
+
+func TestNotifyDocumentSkip_ContainsCallbackPanic(t *testing.T) {
+	svc := newDocErrorService(&docErrorStubStore{})
+	svc.SetOnDocumentSkip(func(string, string, string) { panic("consumer blew up") })
+
+	svc.notifyDocumentSkip(model.Document{RelPath: "a.zip", DocType: "archive", Status: "skipped"})
+}
+
+func TestNotifyDocumentSkip_NilCallbackIsNoop(t *testing.T) {
+	svc := newDocErrorService(&docErrorStubStore{})
+	svc.notifyDocumentSkip(model.Document{RelPath: "a.zip"})
+
+	svc.SetOnDocumentSkip(func(string, string, string) { t.Fatal("cleared callback was invoked") })
+	svc.SetOnDocumentSkip(nil)
+	svc.notifyDocumentSkip(model.Document{RelPath: "a.zip"})
+}

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -216,6 +216,13 @@ type Service struct {
 	// without it a failed document is only observable by polling the store.
 	onDocumentError   func(relPath, docType, message string)
 	onDocumentErrorMu sync.RWMutex
+
+	// optional callback invoked for every document this run leaves never-indexed
+	// (status "skipped"/"secret_excluded"). The CLI uses it to emit the
+	// spec-required per-document `file_skip` NDJSON event (SPEC §3.2, #414). It
+	// is the streaming counterpart of the durable skip_reasons aggregate.
+	onDocumentSkip   func(relPath, docType, reason string)
+	onDocumentSkipMu sync.RWMutex
 	// bounds the compatibility wrapper used by SetOnDocumentDeleted so large
 	// deletion batches do not spawn an unbounded number of goroutines.
 	onDocumentDeletedMaxConcurrency int
@@ -727,6 +734,18 @@ func (s *Service) SetOnDocumentError(fn func(relPath, docType, message string)) 
 	s.onDocumentErrorMu.Lock()
 	defer s.onDocumentErrorMu.Unlock()
 	s.onDocumentError = fn
+}
+
+// SetOnDocumentSkip registers a callback invoked once per document this run
+// leaves never-indexed. `reason` is a model.SkipReason* value. Passing nil
+// clears the callback.
+//
+// A document raises either this callback or SetOnDocumentError, never both:
+// the two partition the never-indexed set (SPEC §3.2).
+func (s *Service) SetOnDocumentSkip(fn func(relPath, docType, reason string)) {
+	s.onDocumentSkipMu.Lock()
+	defer s.onDocumentSkipMu.Unlock()
+	s.onDocumentSkip = fn
 }
 
 // DiscoverOptionsFromConfig resolves ingest discovery behavior from config.
@@ -1442,6 +1461,14 @@ func (s *Service) scanPass(ctx context.Context, pass processPass, discovered []D
 			if countCorpus {
 				s.addSkipped(1)
 				s.addRunSkipReason(model.SkipReasonPathExcluded)
+				// Path-excluded files are never persisted, so the stream event is
+				// the only per-document record of them anywhere.
+				s.notifyDocumentSkip(model.Document{
+					RelPath:    f.RelPath,
+					DocType:    ClassifyDocType(f.RelPath),
+					Status:     "skipped",
+					SkipReason: model.SkipReasonPathExcluded,
+				})
 			}
 			if outcome != nil {
 				outcome.markSkipped()
@@ -1599,6 +1626,7 @@ func (s *Service) skipUnchangedRemoteDocument(ctx context.Context, f DiscoveredF
 		s.addIndexed(1)
 	case "skipped", "secret_excluded":
 		s.addSkipped(1)
+		s.notifyDocumentSkip(existing)
 	}
 	// An unchanged archive still owns its previously-extracted members; retain
 	// them so they are not treated as deletions this run.
@@ -1741,7 +1769,7 @@ func (s *Service) processDocument(ctx context.Context, f DiscoveredFile, secretP
 	// The archive document itself remains "skipped" (no direct text content).
 	if doc.DocType == "archive" {
 		s.creditIndexed(indexedPending)
-		return s.handleArchiveDocument(ctx, doc, f, secretPatterns, forceReindex, seen, needsProcessing, finalContentHash)
+		return s.handleArchiveDocumentAndNotify(ctx, doc, f, secretPatterns, forceReindex, seen, needsProcessing, finalContentHash)
 	}
 
 	if !needsProcessing || doc.Status != "ok" {
@@ -1906,6 +1934,12 @@ func (s *Service) creditInitialStatus(doc model.Document) (indexedPending, termi
 			s.activeOutcome.markSkippedWithCode(manifestErrBinarySkipped)
 		} else {
 			s.markActiveSkipped()
+		}
+		// An archive container is credited as skipped here but is NOT terminal: it
+		// reverts to an error (and addSkipped(-1)) if member extraction fails, so
+		// its file_skip is deferred until handleArchiveDocument succeeds.
+		if doc.DocType != "archive" {
+			s.notifyDocumentSkip(doc)
 		}
 		return false, false
 	case "error":
@@ -2408,6 +2442,10 @@ func (s *Service) persistOversizeSkips(ctx context.Context, oversize map[string]
 		if err := s.store.UpsertDocument(ctx, doc); err != nil {
 			s.getLogger().Printf("discovery: persist size-cap skip row for %s: %v", relPath, err)
 		}
+		// Emitted here rather than at the OnOversize counter bump so the event and
+		// the persisted row stay one-to-one; the oversize map is keyed by relPath,
+		// so no document raises it twice.
+		s.notifyDocumentSkip(doc)
 	}
 }
 
@@ -3117,6 +3155,52 @@ func (s *Service) notifyDocumentError(doc model.Document) {
 		}
 	}()
 	fn(doc.RelPath, doc.DocType, doc.ErrorMessage)
+}
+
+// handleArchiveDocumentAndNotify extracts an archive container's members and,
+// only if that fully succeeded, raises the container's deferred `file_skip`.
+// On failure the container was re-persisted as an error and its skipped credit
+// withdrawn (addSkipped(-1)), so it must raise a `file_error` instead — the two
+// events partition the never-indexed set (SPEC §3.2).
+func (s *Service) handleArchiveDocumentAndNotify(ctx context.Context, doc model.Document, f DiscoveredFile, secretPatterns []*regexp.Regexp, forceReindex bool, seen map[string]struct{}, needsProcessing bool, finalContentHash string) error {
+	if err := s.handleArchiveDocument(ctx, doc, f, secretPatterns, forceReindex, seen, needsProcessing, finalContentHash); err != nil {
+		return err
+	}
+	s.notifyDocumentSkip(doc)
+	return nil
+}
+
+// notifyDocumentSkip invokes the registered per-document skip callback. It is
+// called only where the document's never-indexed status is final for this run,
+// never merely where the `skipped` counter is incremented: an archive container
+// is credited as skipped up front but reverts to an error if member extraction
+// fails (addSkipped(-1)), and the spec forbids one document raising both a
+// `file_skip` and a `file_error`.
+//
+// A blank SkipReason falls back to the doc_type mapping so pre-#570 rows, which
+// were persisted before the skip_reason column existed, still report a reason
+// rather than an empty string.
+func (s *Service) notifyDocumentSkip(doc model.Document) {
+	s.onDocumentSkipMu.RLock()
+	fn := s.onDocumentSkip
+	s.onDocumentSkipMu.RUnlock()
+	if fn == nil {
+		return
+	}
+	reason := doc.SkipReason
+	if strings.TrimSpace(reason) == "" {
+		if doc.Status == "secret_excluded" {
+			reason = model.SkipReasonSecretExcluded
+		} else {
+			reason = skipReasonForDocType(doc.DocType)
+		}
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			s.getLogger().Printf("onDocumentSkip panic for %s (%s)", doc.RelPath, safePanicValue(r))
+		}
+	}()
+	fn(doc.RelPath, doc.DocType, reason)
 }
 
 // persistTitleIfFound runs the title heuristic on the supplied text body and,


### PR DESCRIPTION
Gated submodule re-pin: `dirstral-spec` `e651c81` → `2dd24f2` (spec **0.30.0**, [dirstral-spec#37](https://github.com/dirstral/dirstral-spec/pull/37)), which adds `file_skip` to the NDJSON event enum. #581 already landed the two halves that needed no spec change (per-document `file_error`, periodic `scan_progress`/`embed_progress`). This completes #414.

## `file_skip`

Ingest gains `SetOnDocumentSkip`, mirroring the `SetOnDocumentError` hook from #581 — RWMutex-guarded, panic-contained, invoked once per document the run leaves never-indexed. The CLI emits `file_skip` at `level=warn` carrying `{rel_path, doc_type, reason}`, where `reason` is a value of the **existing** `skip_reasons` enum (no new vocabulary).

### The subtle part: emit on *terminal* status, not on the counter bump

The spec says the two events **partition** the never-indexed set — a document raises a `file_skip` or a `file_error`, never both. Naively emitting wherever `addSkipped(1)` fires breaks that:

> An **archive container** is credited as skipped up front. If member extraction then fails, ingest runs `addSkipped(-1)` and re-persists the container as an **error**.

So a document would raise a `file_skip` *and* a `file_error`, and the `file_skip` count would exceed terminal `indexing.skipped`. Instead the archive's event is deferred into a new `handleArchiveDocumentAndNotify` and fires only when extraction fully succeeds. Both spec invariants then hold: the events partition the set, and the `file_skip` count equals terminal `indexing.skipped`. `TestCreditInitialStatus_DefersArchiveSkipEvent` pins it.

The extraction also keeps `processDocument` inside the `gocyclo -over 15` budget — inlining the branch pushed it to 16.

### Emission sites — one per document credited to `indexing.skipped`

| Site | Covers |
|---|---|
| `creditInitialStatus` | every skipped/`secret_excluded` doc **except** archives |
| `handleArchiveDocumentAndNotify` | archive containers, deferred, on success only |
| `skipUnchangedRemoteDocument` | pre-existing skips re-counted on incremental runs |
| path-exclude branch | never persisted — the event is their **only** per-document record anywhere |
| `persistOversizeSkips` | emitted beside the row so event and row stay 1:1 |

A blank `SkipReason` — a pre-#570 row, written before the column existed — falls back to the `doc_type` mapping rather than emitting an empty string, which would violate the closed enum.

## Coverage remediation hints

`status`'s coverage block printed bare `reason=count` pairs. It now appends the *"what to install or configure"* guidance #414 asks for, but **only for reasons an operator can act on** (`unsupported_format`, `size_cap`, `path_excluded`, `secret_excluded`). Working-as-intended reasons (`archive`, `binary_ignored`, `ignore_rule`) and unrecognized reasons from a newer server stay bare — printing an action for those would train operators to ignore the block. Hints are provider-neutral (they name `ingest.extractor`, not a vendor).

## `doc_counts` — no code change, and that is the finding

#414 asserted that `doc_counts` overstates coverage because it lacks a status filter. **The count is correct; the spec text was wrong.** `bs-007` described `doc_counts` as grouping `status="ready"` documents — a status that does not exist (the enum is `ok | skipped | error`), and one that could not "overstate" anything. Fixed in dirstral-spec#37. Nothing to change here.

## Known gap, unchanged and out of scope

A **lenient** unsupported-format skip (`ingest.on_unsupported=lenient`) leaves the document `status="ok"` and only bumps an in-run counter, so it raises no `file_skip` and is invisible to a later `status` call. That is a pre-existing documented limitation (`service.go`), not a regression — worth its own issue if you want it closed.

Separately: several pre-existing `emitter.Emit` calls use `level: "warning"`, but the spec enum is `info|warn|error`. `file_skip` uses the conformant `warn`. Fixing the stragglers is a behavior change for existing consumers, so I left them.

## Verification

`go test ./...` all pass. `go vet`, `golangci-lint` (0 issues), `gocyclo -over 15`, `ineffassign`, `misspell`, `gofmt -l` on touched files: all clean.

New tests: `TestNotifyDocumentSkip_CarriesReason`, `_BlankReasonFallsBackToDocType`, `_ContainsCallbackPanic`, `_NilCallbackIsNoop`, `TestCreditInitialStatus_DefersArchiveSkipEvent`, `TestNewFileSkipEmitter_EmitsReasonAtWarnLevel`, `TestWireIngestorHooks_RegistersDocumentCallbacks`, `TestRenderCoverageBlock_RemediationHints`, `TestSkipReasonHint_UnknownReasonYieldsNoGuess`. `document_error_hook_test.go` → `document_hooks_test.go` now that it covers both hooks.

Closes #414