### PR TITLE
feat(ingest): pandoc extractor — capability-activated T2 born-digital engine (#393)

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -346,6 +346,11 @@ func NewAppWithIO(stdout, stderr io.Writer) *App {
 			if extractor := ingest.DocumentExtractorFromConfig(cfg); extractor != nil {
 				svc.SetDocumentExtractor(extractor)
 			}
+			// #393: activate the capability-activated pandoc engine (T2) after the
+			// primary extractor is wired. Under `auto` it runs alongside the primary;
+			// under the `pandoc` pin it reuses the primary instance. Kept out of
+			// NewService so it stays free of ambient-PATH probing.
+			svc.ActivatePandocEngine(cfg)
 			return svc, nil
 		},
 		// default store constructor uses sqlite in the configured state

--- a/internal/cli/server_doctor.go
+++ b/internal/cli/server_doctor.go
@@ -305,7 +305,13 @@ func extractionAvailabilityCheck(ctx context.Context, sqliteStore *store.SQLiteS
 		return doctorCheck{Name: name, Status: doctorStatusError, Detail: err.Error()}, true
 	}
 	structured := extractorIsStructured(decision.Name)
-	uncovered, docs := uncoveredExtractableExtensions(extCounts, structured)
+	// pandoc (T2, #393) can be a second active engine under `auto`, covering the
+	// born-digital formats docling cannot read (.odt/.rtf/.epub) and — when it is
+	// the primary — the OOXML/markup formats it reads. Fold its availability into
+	// the engine-aware coverage verdict so the doctor names exactly what indexing
+	// will skip.
+	pandocActive := ingest.PandocActive(cfg)
+	uncovered, docs := uncoveredExtractableExtensions(extCounts, cfg.IngestExtractor, structured, decision.Name == "mistral-ocr", pandocActive)
 	if len(uncovered) == 0 {
 		return doctorCheck{}, false
 	}
@@ -333,19 +339,20 @@ func extractorIsStructured(name string) bool {
 }
 
 // uncoveredExtractableExtensions returns the sorted, distinct extensions present
-// in extCounts that the active extraction engine cannot read, plus the total
-// document count they account for. It consults the SAME consolidated capability
-// table the indexing path routes on (ingest.ExtractorSupportsExt), so the doctor
-// names exactly the formats that will be skipped with an unsupported-format
-// diagnostic (#394/#395). `structured` selects the docling-family verdict; false
-// is the flat OCR path. Extension-less assets (bucketed under "") are ignored —
-// they carry no format to name.
-func uncoveredExtractableExtensions(extCounts map[string]int64, structured bool) (exts []string, docs int64) {
+// in extCounts that no active extraction engine can read, plus the total document
+// count they account for. It consults the SAME per-format router the indexing path
+// uses (ingest.ExtractionCovered → selectExtractionRoute), so the doctor names
+// exactly the formats that will be skipped with an unsupported-format diagnostic
+// (#394/#395) — including the pandoc (T2, #393) tier the coarse structured/flat
+// boolean cannot express. `structured`/`flatOCR`/`pandoc` are the active engines
+// derived from the extractor decision; `policy` is ingest.extractor. Extension-less
+// assets (bucketed under "") are ignored — they carry no format to name.
+func uncoveredExtractableExtensions(extCounts map[string]int64, policy string, structured, flatOCR, pandoc bool) (exts []string, docs int64) {
 	for ext, n := range extCounts {
 		if ext == "" {
 			continue
 		}
-		if ingest.ExtractorSupportsExt(structured, ext) {
+		if ingest.ExtractionCovered(policy, structured, flatOCR, pandoc, ext) {
 			continue
 		}
 		exts = append(exts, ext)

--- a/internal/cli/server_doctor.go
+++ b/internal/cli/server_doctor.go
@@ -319,7 +319,7 @@ func extractionAvailabilityCheck(ctx context.Context, sqliteStore *store.SQLiteS
 		"%d document(s) in %d format(s) are uncovered by the active extractor (%s): %s. "+
 			"They produce no searchable text (skipped with an unsupported-format error). %s",
 		docs, len(uncovered), decision.Name, strings.Join(uncovered, ", "),
-		uncoveredExtractionRemedy(uncovered, structured))}, true
+		uncoveredExtractionRemedy(uncovered, structured, pandocActive))}, true
 }
 
 // extractorIsStructured maps a resolved extractor name (ExtractorDecision.Name)
@@ -362,31 +362,42 @@ func uncoveredExtractableExtensions(extCounts map[string]int64, policy string, s
 	return exts, docs
 }
 
-// uncoveredExtractionRemedy tailors the remediation hint to the active engine.
-// On the flat OCR path, the OpenXML Office + tiff/bmp formats become readable by
-// installing docling, so it is named; the OpenDocument/RTF/.doc/gif/svg family is
-// read by neither engine today (content support is #393). On the structured
-// (docling) path, every uncovered format is in that neither-engine set, so
-// installing docling would not help and the hint says so.
-func uncoveredExtractionRemedy(uncovered []string, structured bool) string {
+// uncoveredExtractionRemedy tailors the remediation hint to the engines NOT yet
+// active. It names only engines that would actually help: docling for the
+// OpenXML-Office/tiff/bmp formats and pandoc (T2, #393) for the born-digital
+// OpenDocument/RTF/EPUB family. Formats no installable engine can read (e.g.
+// .gif/.svg/.odp/.ods/legacy .doc) get a pre-conversion hint. `structured`/`pandoc`
+// report which of those engines is already active, so an already-active engine is
+// never suggested.
+func uncoveredExtractionRemedy(uncovered []string, structured, pandoc bool) string {
 	// The §7.7 coverage report MUST, for each uncovered class, name the engine to
 	// add AND the ingest.on_unsupported knob that governs whether the gap is a
 	// warning (lenient, the default) or a per-document error (strict).
 	const onUnsupportedHint = " Or set ingest.on_unsupported: strict to fail instead of skip these documents."
-	if structured {
-		return "docling cannot import these formats; they need a future pandoc-style extractor (#393) or pre-conversion to a supported format." + onUnsupportedHint
-	}
-	doclingWouldCover := false
+
+	doclingWouldCover, pandocWouldCover := false, false
 	for _, ext := range uncovered {
-		if ingest.ExtractorSupportsExt(true, ext) {
+		if !structured && ingest.ExtractorSupportsExt(true, ext) {
 			doclingWouldCover = true
-			break
+		}
+		if !pandoc && ingest.PandocSupportsExt(ext) {
+			pandocWouldCover = true
 		}
 	}
+
+	var fixes []string
 	if doclingWouldCover {
-		return "Install docling (or set ingest.extractor=docling) to cover the Office/tiff/bmp formats; the remaining OpenDocument/RTF/.doc/gif/svg formats need a future pandoc-style extractor (#393)." + onUnsupportedHint
+		fixes = append(fixes, "install docling (or set ingest.extractor=docling) for the Office/tiff/bmp formats")
 	}
-	return "These formats are read by no available extractor; they need a future pandoc-style extractor (#393) or pre-conversion to a supported format." + onUnsupportedHint
+	if pandocWouldCover {
+		fixes = append(fixes, "install pandoc (#393) for the born-digital OpenDocument/RTF/EPUB formats")
+	}
+	if len(fixes) == 0 {
+		// Every engine that could help is already active (or none reads these):
+		// no installable extractor covers them.
+		return "These formats are read by no available extractor; pre-convert them to a supported format." + onUnsupportedHint
+	}
+	return "To cover them: " + strings.Join(fixes, "; ") + "; or pre-convert to a supported format." + onUnsupportedHint
 }
 
 // indexingFailureCheck reads the store-level FailureSummary (set by

--- a/internal/cli/server_doctor_coverage_test.go
+++ b/internal/cli/server_doctor_coverage_test.go
@@ -26,7 +26,7 @@ func TestUncoveredExtractableExtensions_NamesSpecificFormats(t *testing.T) {
 	}
 
 	// Flat OCR (mistral-ocr): reads only pdf/png here; docx/tiff/odt uncovered.
-	flatExts, flatDocs := uncoveredExtractableExtensions(corpus, false)
+	flatExts, flatDocs := uncoveredExtractableExtensions(corpus, "auto", false, true, false)
 	if want := []string{".docx", ".odt", ".tiff"}; !reflect.DeepEqual(flatExts, want) {
 		t.Errorf("flat uncovered exts = %v, want %v (sorted, distinct, no empty ext)", flatExts, want)
 	}
@@ -36,7 +36,7 @@ func TestUncoveredExtractableExtensions_NamesSpecificFormats(t *testing.T) {
 
 	// Structured (docling): reads docx/tiff too; only the OpenDocument .odt
 	// remains uncovered.
-	structExts, structDocs := uncoveredExtractableExtensions(corpus, true)
+	structExts, structDocs := uncoveredExtractableExtensions(corpus, "auto", true, false, false)
 	if want := []string{".odt"}; !reflect.DeepEqual(structExts, want) {
 		t.Errorf("structured uncovered exts = %v, want %v", structExts, want)
 	}
@@ -49,8 +49,37 @@ func TestUncoveredExtractableExtensions_NamesSpecificFormats(t *testing.T) {
 // every extractable format is readable by the active engine.
 func TestUncoveredExtractableExtensions_FullCoverage(t *testing.T) {
 	corpus := map[string]int64{".pdf": 3, ".png": 1, ".jpg": 2}
-	if exts, docs := uncoveredExtractableExtensions(corpus, false); len(exts) != 0 || docs != 0 {
+	if exts, docs := uncoveredExtractableExtensions(corpus, "auto", false, true, false); len(exts) != 0 || docs != 0 {
 		t.Errorf("fully-covered corpus reported uncovered exts=%v docs=%d, want none", exts, docs)
+	}
+}
+
+// TestUncoveredExtractableExtensions_PandocEngine confirms the engine-aware
+// coverage verdict folds in the pandoc (T2, #393) tier: under `auto` with docling
+// AND pandoc active, the born-digital .odt/.rtf docling cannot read are COVERED by
+// pandoc, while a pandoc-only corpus still reports .pdf uncovered (pandoc reads no
+// PDF/raster).
+func TestUncoveredExtractableExtensions_PandocEngine(t *testing.T) {
+	corpus := map[string]int64{".pdf": 2, ".docx": 1, ".odt": 3, ".rtf": 1, ".doc": 1}
+
+	// docling + pandoc active: pdf/docx via docling, odt/rtf via pandoc; only the
+	// legacy binary .doc (neither engine reads) remains uncovered.
+	exts, docs := uncoveredExtractableExtensions(corpus, "auto", true /*structured*/, false, true /*pandoc*/)
+	if want := []string{".doc"}; !reflect.DeepEqual(exts, want) {
+		t.Errorf("docling+pandoc uncovered = %v, want %v", exts, want)
+	}
+	if docs != 1 {
+		t.Errorf("docling+pandoc uncovered docs = %d, want 1", docs)
+	}
+
+	// pandoc-only (no docling/OCR): odt/rtf/docx covered by pandoc; pdf and legacy
+	// .doc are uncovered (pandoc reads neither).
+	exts2, docs2 := uncoveredExtractableExtensions(corpus, "auto", false, false, true /*pandoc*/)
+	if want := []string{".doc", ".pdf"}; !reflect.DeepEqual(exts2, want) {
+		t.Errorf("pandoc-only uncovered = %v, want %v", exts2, want)
+	}
+	if docs2 != 3 { // 2 pdf + 1 doc
+		t.Errorf("pandoc-only uncovered docs = %d, want 3", docs2)
 	}
 }
 

--- a/internal/cli/server_doctor_coverage_test.go
+++ b/internal/cli/server_doctor_coverage_test.go
@@ -100,19 +100,31 @@ func TestExtractorIsStructured(t *testing.T) {
 }
 
 // TestUncoveredExtractionRemedy_TailoredToEngine checks the remediation hint
-// points a flat-OCR user at docling for the docling-coverable formats, and tells
-// a docling user that docling cannot help with the neither-engine formats.
+// names only the engines that would actually help — docling for its OOXML/raster
+// formats, pandoc (#393) for the born-digital family — never an already-active
+// engine, and falls back to pre-conversion when no installable engine reads them.
 func TestUncoveredExtractionRemedy_TailoredToEngine(t *testing.T) {
-	// Flat path with a docling-coverable format present → name docling.
-	if got := uncoveredExtractionRemedy([]string{".docx", ".odt"}, false); !strings.Contains(got, "docling") {
-		t.Errorf("flat remedy %q should recommend installing docling", got)
+	// Flat path (no docling, no pandoc): .docx is docling-coverable and .odt is
+	// pandoc-coverable → recommend both, never the stale "future extractor" wording.
+	got := uncoveredExtractionRemedy([]string{".docx", ".odt"}, false, false)
+	if !strings.Contains(got, "docling") || !strings.Contains(got, "pandoc") {
+		t.Errorf("flat remedy %q should recommend installing docling and pandoc", got)
 	}
-	// Flat path where docling would not help either (neither-engine formats).
-	if got := uncoveredExtractionRemedy([]string{".gif", ".svg"}, false); strings.Contains(got, "Install docling") {
-		t.Errorf("flat remedy for neither-engine formats %q should not recommend docling", got)
+	if strings.Contains(got, "future") {
+		t.Errorf("remedy must not call pandoc a 'future' extractor now that #393 ships: %q", got)
 	}
-	// Structured path: docling is already active and cannot import these.
-	if got := uncoveredExtractionRemedy([]string{".odt"}, true); !strings.Contains(got, "cannot import") {
-		t.Errorf("structured remedy %q should say docling cannot import them", got)
+	// Neither-engine formats (no installable extractor reads them) → pre-convert,
+	// no docling/pandoc suggestion.
+	if got := uncoveredExtractionRemedy([]string{".gif", ".svg"}, false, false); strings.Contains(got, "docling") || strings.Contains(got, "pandoc") {
+		t.Errorf("neither-engine remedy %q should not recommend an extractor", got)
+	}
+	// docling active, pandoc not: an uncovered .odt is pandoc-coverable → suggest
+	// pandoc, and do NOT re-suggest the already-active docling.
+	if got := uncoveredExtractionRemedy([]string{".odt"}, true, false); !strings.Contains(got, "pandoc") || strings.Contains(got, "install docling") {
+		t.Errorf("docling-active remedy %q should recommend pandoc and not re-suggest docling", got)
+	}
+	// Both engines active: nothing installable helps → pre-convert only.
+	if got := uncoveredExtractionRemedy([]string{".odp", ".gif"}, true, true); strings.Contains(got, "install") {
+		t.Errorf("both-active remedy %q should only advise pre-conversion", got)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -191,9 +191,13 @@ type Config struct {
 	// ingest.extractor=docling-serve; under extractor=auto an empty value
 	// simply means the HTTP transport is not used (spec 0.10.0 §7.4.B).
 	IngestDoclingServeURL string
-	ElevenLabsAPIKey      string
-	ElevenLabsBaseURL     string
-	ElevenLabsTTSVoiceID  string
+	// IngestPandocCommand optionally configures a local pandoc CLI command
+	// (its first field is the binary) used for the capability-activated pandoc
+	// document extractor (#393). Empty resolves `pandoc` from PATH.
+	IngestPandocCommand  string
+	ElevenLabsAPIKey     string
+	ElevenLabsBaseURL    string
+	ElevenLabsTTSVoiceID string
 	// AllowedOrigins is always initialized with local defaults and then extended
 	// via env/CLI comma-separated origin lists.
 	AllowedOrigins []string
@@ -742,6 +746,7 @@ type fileConfig struct {
 	DoclingCommand  *string
 
 	IngestDoclingServeURL              *string
+	IngestPandocCommand                *string
 	ElevenLabsBaseURL                  *string
 	ElevenLabsTTSVoiceID               *string
 	AllowedOrigins                     []string
@@ -879,6 +884,7 @@ type persistedConfig struct {
 	SecretPatterns  []string `yaml:"secret_patterns"`
 	DoclingCommand  string   `yaml:"docling_command"`
 	DoclingServeURL string   `yaml:"docling_serve_url"`
+	PandocCommand   string   `yaml:"pandoc_command"`
 	// optional session timeouts expressed as YAML duration strings
 	SessionInactivityTimeout time.Duration `yaml:"session_inactivity_timeout"`
 	SessionMaxLifetime       time.Duration `yaml:"session_max_lifetime"`
@@ -1247,6 +1253,7 @@ func buildPersistedConfig(cfg *Config) persistedConfig {
 		SecretPatterns:                     append([]string(nil), cfg.SecretPatterns...),
 		DoclingCommand:                     cfg.DoclingCommand,
 		DoclingServeURL:                    cfg.IngestDoclingServeURL,
+		PandocCommand:                      cfg.IngestPandocCommand,
 		SessionInactivityTimeout:           cfg.SessionInactivityTimeout,
 		SessionMaxLifetime:                 cfg.SessionMaxLifetime,
 		HealthCheckInterval:                cfg.HealthCheckInterval,
@@ -1850,6 +1857,9 @@ func applyModelClientsFileParsed(cfg *Config, fc fileConfig) {
 	if fc.IngestDoclingServeURL != nil {
 		cfg.IngestDoclingServeURL = *fc.IngestDoclingServeURL
 	}
+	if fc.IngestPandocCommand != nil {
+		cfg.IngestPandocCommand = *fc.IngestPandocCommand
+	}
 	if fc.ElevenLabsBaseURL != nil {
 		cfg.ElevenLabsBaseURL = *fc.ElevenLabsBaseURL
 	}
@@ -2382,6 +2392,8 @@ var configKeyAliases = map[string]string{
 	"ingest.docling.command":                  "docling_command",
 	"docling.serve_url":                       "docling_serve_url",
 	"ingest.docling.serve_url":                "docling_serve_url",
+	"pandoc.command":                          "pandoc_command",
+	"ingest.pandoc.command":                   "pandoc_command",
 	"stt.elevenlabs.api_key":                  "elevenlabs_api_key",
 	"secrets.elevenlabs_api_key":              "elevenlabs_api_key",
 	"secrets.x402_facilitator_url":            "x402_facilitator_url",
@@ -2544,7 +2556,7 @@ func canonicalizeConfigKey(key string) string {
 // (so child keys should be prefixed) rather than a scalar/list key.
 func isMapSectionKey(key string) bool {
 	switch key {
-	case "rag", "ingest", "ingest.docling", "stt", "stt.mistral", "stt.elevenlabs", "server", "server.tls", "secret_sources", "mistral", "docling", "security", "security.auth", "x402", "x402.route_policy", "x402.route_policy.tools_call", "chunking", "retrieval", "retrieval.hybrid", "retrieval.context_compression", "retrieval.adaptive", "retrieval.mmr", "retrieval.hyde", "retrieval.cross_lingual", "rerank", "rerank.cohere", "index", "dedup":
+	case "rag", "ingest", "ingest.docling", "ingest.pandoc", "stt", "stt.mistral", "stt.elevenlabs", "server", "server.tls", "secret_sources", "mistral", "docling", "pandoc", "security", "security.auth", "x402", "x402.route_policy", "x402.route_policy.tools_call", "chunking", "retrieval", "retrieval.hybrid", "retrieval.context_compression", "retrieval.adaptive", "retrieval.mmr", "retrieval.hyde", "retrieval.cross_lingual", "rerank", "rerank.cohere", "index", "dedup":
 		return true
 	case "ingest.pdf", "ingest.images", "ingest.audio", "ingest.archives", "secrets", "index.qdrant":
 		return true
@@ -2887,6 +2899,8 @@ func setModelStringFileScalar(cfg *fileConfig, key, value string) {
 		cfg.DoclingCommand = strPtr(value)
 	case "docling_serve_url":
 		cfg.IngestDoclingServeURL = strPtr(value)
+	case "pandoc_command":
+		cfg.IngestPandocCommand = strPtr(value)
 	case "rag.system_prompt":
 		cfg.RAGSystemPrompt = strPtr(value)
 	case "chunking.strategy":
@@ -3065,6 +3079,7 @@ func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	writeList("secret_patterns", cfg.SecretPatterns)
 	writeScalar("docling_command", cfg.DoclingCommand)
 	writeScalar("docling_serve_url", cfg.DoclingServeURL)
+	writeScalar("pandoc_command", cfg.PandocCommand)
 	writeScalar("session_inactivity_timeout", cfg.SessionInactivityTimeout.String())
 	writeScalar("session_max_lifetime", cfg.SessionMaxLifetime.String())
 	writeScalar("health_check_interval", cfg.HealthCheckInterval.String())
@@ -3386,6 +3401,7 @@ func applyIngestEnvOverrides(cfg *Config, env map[string]string) {
 	}{
 		{"DIR2MCP_DOCLING_COMMAND", &cfg.DoclingCommand},
 		{"DIR2MCP_DOCLING_SERVE_URL", &cfg.IngestDoclingServeURL},
+		{"DIR2MCP_PANDOC_COMMAND", &cfg.IngestPandocCommand},
 		{"DIR2MCP_INGEST_EXTRACTOR", &cfg.IngestExtractor},
 		{"DIR2MCP_INGEST_ON_UNSUPPORTED", &cfg.IngestOnUnsupported},
 		{"DIR2MCP_INDEX_BACKEND", &cfg.IndexBackend},
@@ -3893,9 +3909,9 @@ func (c *Config) validateIngestExtractor() error {
 		extractorMode = Default().IngestExtractor
 	}
 	switch extractorMode {
-	case "auto", "docling", "docling-serve", "mistral", "off":
+	case "auto", "docling", "docling-serve", "pandoc", "mistral", "off":
 	default:
-		return fmt.Errorf("ingest.extractor must be one of auto, docling, docling-serve, mistral, off: %q", c.IngestExtractor)
+		return fmt.Errorf("ingest.extractor must be one of auto, docling, docling-serve, pandoc, mistral, off: %q", c.IngestExtractor)
 	}
 	c.IngestExtractor = extractorMode
 	return nil

--- a/internal/ingest/capability.go
+++ b/internal/ingest/capability.go
@@ -40,6 +40,11 @@ const (
 	// engineStructured is the docling family: it emits a DoclingDocument and
 	// imports every pdf/image/document format EXCEPT structuredUnreadableExt.
 	engineStructured
+	// enginePandoc is the capability-activated pandoc extractor (#393): the T2
+	// tier of the §7.4.B.1 fidelity matrix. It converts born-digital
+	// office/markup/ebook formats to Markdown and reads exactly pandocReadableExt.
+	// It reads NO pdf/raster input and produces NO page/bbox provenance.
+	enginePandoc
 )
 
 // flatOCRReadableExt is the exact set of extensions the flat OCR path can read —
@@ -63,13 +68,31 @@ var flatOCRReadableExt = map[string]struct{}{
 // is a denylist: supported unless listed here. Content support for these
 // unreadable formats is tracked in #393.
 var structuredUnreadableExt = map[string]struct{}{
-	".odt": {},
-	".odp": {},
-	".ods": {},
-	".rtf": {},
-	".doc": {},
-	".gif": {},
-	".svg": {},
+	".odt":  {},
+	".odp":  {},
+	".ods":  {},
+	".rtf":  {},
+	".doc":  {},
+	".epub": {}, // docling has no EPUB reader; pandoc (T2, #393) is its extraction engine.
+	".gif":  {},
+	".svg":  {},
+}
+
+// pandocReadableExt is the born-digital office/markup/ebook set the pandoc engine
+// (T2, #393) converts to Markdown — exactly the §7.4.B.1 matrix's pandoc ✅ cells.
+// It deliberately EXCLUDES formats pandoc cannot read as INPUT: .pptx and .xlsx
+// (pandoc has no PowerPoint/Excel reader — .pptx is writer-only, .xlsx has no
+// reader) and legacy binary .doc (pandoc reads OOXML .docx, not the old .doc).
+// Those stay with docling (T1) where supported, or degrade (§7.4.B.2). pandoc
+// reads NO pdf/raster input, so none of flatOCRReadableExt appears here.
+var pandocReadableExt = map[string]struct{}{
+	".docx":  {},
+	".odt":   {},
+	".rtf":   {},
+	".epub":  {},
+	".html":  {},
+	".htm":   {},
+	".xhtml": {},
 }
 
 // engineSupportsExt reports whether the given extraction engine can read ext.
@@ -90,6 +113,9 @@ func engineSupportsExt(engine extractionEngine, ext string) bool {
 	case engineStructured:
 		_, denied := structuredUnreadableExt[ext]
 		return !denied
+	case enginePandoc:
+		_, ok := pandocReadableExt[ext]
+		return ok
 	default:
 		return false
 	}
@@ -128,15 +154,14 @@ func ExtractorSupportsExt(structured bool, ext string) bool {
 // capability matrix and mandates "best-available per format" routing under
 // `ingest.extractor: auto`: for each classified document, select the ACTIVE
 // engine of lowest fidelity tier whose matrix cell for that format is ✅, falling
-// through the tier order (T1 docling → T2 pandoc[future #393] → T3 mistral OCR →
-// T4 raw_text). A format no active engine supports degrades per §7.4.B.2; html is
-// the one format whose T4 `raw_text` baseline (§7.4.A) is unconditional, so it is
-// never dropped. selectExtractionRoute below is that algorithm; the ingest
-// service consumes it (deriving which engines are active from the resolved
-// extractor) so routing is a single, spec-faithful decision rather than a coarse
-// doc_type switch. pandoc (T2) is declared in the matrix for completeness but is
-// never active until #393 ships, so it is not represented as an eligible engine
-// here.
+// through the tier order (T1 docling → T2 pandoc → T3 mistral OCR → T4 raw_text).
+// A format no active engine supports degrades per §7.4.B.2; html is the one format
+// whose T4 `raw_text` baseline (§7.4.A) is unconditional, so it is never dropped.
+// selectExtractionRoute below is that algorithm; the ingest service consumes it
+// (deriving which engines are active from the resolved extractors) so routing is a
+// single, spec-faithful decision rather than a coarse doc_type switch. pandoc (T2,
+// #393) is a capability-activated engine: active iff a functional pandoc resolves
+// and the policy permits it.
 
 // markupReadableExt is the markup (html) format class of the §7.4.B.1 matrix. It
 // is the only class with a `raw_text` (T4) ✅ cell, and per §7.4.A that baseline
@@ -169,6 +194,11 @@ const (
 	// routeStructured: the docling family (T1) — structured extracted_markdown
 	// with region spans (§7.4.B "Structured extraction").
 	routeStructured
+	// routePandoc: the pandoc engine (T2, #393) — flat extracted_markdown for
+	// born-digital office/markup/ebook formats. No page/bbox provenance (pandoc has
+	// no pages), so no region spans. Ordered by fidelity between the structured
+	// (T1) and flat-OCR (T3) tiers.
+	routePandoc
 	// routeFlatOCR: the mistral OCR engine (T3) — page-separated extracted_markdown
 	// (§7.4.B "Page-separated extraction").
 	routeFlatOCR
@@ -188,6 +218,9 @@ type extractionAvailability struct {
 	// flatOCR is true when the mistral OCR engine (the active `ocr` provider) is
 	// available.
 	flatOCR bool
+	// pandoc is true when the capability-activated pandoc engine (T2, #393) is
+	// active — a functional pandoc resolved and the policy permits it.
+	pandoc bool
 }
 
 // selectExtractionRoute implements SPEC §7.4.B.1's best-available per-format
@@ -200,6 +233,8 @@ type extractionAvailability struct {
 //   - `auto`: every engine is eligible (subject to availability).
 //   - `docling` / `docling-serve`: only the structured (docling family) engine is
 //     eligible — a pinned engine gets no cross-engine fallback (§7.4.B.1).
+//   - `pandoc`: only the pandoc (T2) engine is eligible — a pandoc pin gets no
+//     docling/mistral fallback, so a format pandoc cannot read degrades.
 //   - `mistral`: only the flat OCR engine is eligible.
 //   - `off`: no extraction engine is eligible; html still falls to its raw_text
 //     baseline, and pdf/image/document simply produce no extracted representation.
@@ -207,18 +242,45 @@ type extractionAvailability struct {
 // A format no eligible+active engine supports returns routeDegrade, EXCEPT markup
 // (html), whose raw_text baseline (§7.4.A) is unconditional and exempt from the
 // pin restriction so html is never dropped.
+// extractionPolicyAllows maps the normalized `ingest.extractor` policy to which
+// engine tiers are ELIGIBLE (subject to availability). A pin restricts eligibility
+// to its single engine — no cross-engine fallback (§7.4.B.1); `auto` allows all;
+// an unrecognized value allows none (html still reaches its raw_text baseline).
+// Split out of selectExtractionRoute to keep that function under the cyclomatic
+// budget.
+func extractionPolicyAllows(policy string) (structured, pandoc, flat bool) {
+	switch policy {
+	case "auto":
+		return true, true, true
+	case "docling", "docling-serve":
+		return true, false, false
+	case "pandoc":
+		return false, true, false
+	case "mistral":
+		return false, false, true
+	default:
+		return false, false, false
+	}
+}
+
 func selectExtractionRoute(policy string, avail extractionAvailability, ext string) extractionRoute {
 	policy = strings.ToLower(strings.TrimSpace(policy))
 	if policy == "" {
 		policy = "auto"
 	}
-	structuredAllowed := policy == "auto" || policy == "docling" || policy == "docling-serve"
-	flatAllowed := policy == "auto" || policy == "mistral"
+	structuredAllowed, pandocAllowed, flatAllowed := extractionPolicyAllows(policy)
 
 	// T1 docling (structured): reads every extraction format except the
 	// structured-unreadable denylist.
 	if structuredAllowed && avail.structured && engineSupportsExt(engineStructured, ext) {
 		return routeStructured
+	}
+	// T2 pandoc (#393): born-digital office/markup/ebook formats. Selected below
+	// docling and above mistral OCR — it covers the docling-unreadable born-digital
+	// family (.odt/.rtf/.epub) and, when docling is absent, the OOXML/markup formats
+	// it can read (.docx/.html).
+	if pandocAllowed && avail.pandoc && engineSupportsExt(enginePandoc, ext) {
+		return routePandoc
 	}
 	// T3 mistral OCR (flat): the pdf/png/jpg/jpeg/webp allowlist.
 	if flatAllowed && avail.flatOCR && engineSupportsExt(engineFlatOCR, ext) {
@@ -231,4 +293,24 @@ func selectExtractionRoute(policy string, avail extractionAvailability, ext stri
 		return routeRawText
 	}
 	return routeDegrade
+}
+
+// ExtractionCovered reports whether the active extraction engines produce searchable
+// extracted text for ext under the given `ingest.extractor` policy — i.e. the
+// per-format route is an actual extraction engine (structured/pandoc/flat OCR) and
+// not routeDegrade. It is the engine-aware coverage predicate the doctor's
+// extraction-coverage check consults so its verdict matches exactly what indexing
+// routes, including the pandoc (T2, #393) tier that the coarse structured/flat
+// boolean cannot express (a pandoc primary reads neither the docling nor the OCR
+// set). Callers pass which engines are active (derived from the resolved extractor
+// decision) plus pandoc availability. Extractable exts are pdf/image/document only,
+// so routeRawText (markup/html) never appears here.
+func ExtractionCovered(policy string, structured, flatOCR, pandoc bool, ext string) bool {
+	avail := extractionAvailability{structured: structured, flatOCR: flatOCR, pandoc: pandoc}
+	switch selectExtractionRoute(policy, avail, ext) {
+	case routeStructured, routePandoc, routeFlatOCR:
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/ingest/classify.go
+++ b/internal/ingest/classify.go
@@ -34,7 +34,7 @@ func classifyByExtension(ext string) string {
 		return "html"
 	case ".pdf":
 		return "pdf"
-	case ".doc", ".docx", ".ppt", ".pptx", ".xls", ".xlsx", ".odt", ".odp", ".ods", ".rtf":
+	case ".doc", ".docx", ".ppt", ".pptx", ".xls", ".xlsx", ".odt", ".odp", ".ods", ".rtf", ".epub":
 		return "document"
 	case ".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".tif", ".tiff", ".svg":
 		return "image"

--- a/internal/ingest/decision.go
+++ b/internal/ingest/decision.go
@@ -16,7 +16,7 @@ import (
 // the construction cost.
 type ExtractorDecision struct {
 	// Name is the selected extractor identifier: "docling",
-	// "docling-serve", "mistral-ocr", or "" when no extractor is available.
+	// "docling-serve", "pandoc", "mistral-ocr", or "" when no extractor is available.
 	Name string
 	// Source describes how the choice was made: "explicit" (user
 	// pinned via ingest.extractor), "auto" (auto-detected as the
@@ -63,13 +63,24 @@ func describeDocumentExtractor(ctx context.Context, cfg config.Config) Extractor
 		return describeExplicitDocling(ctx, cfg)
 	case "docling-serve":
 		return describeExplicitDoclingServe(ctx, cfg)
+	case "pandoc":
+		return describeExplicitPandoc(ctx, cfg)
 	case "mistral":
 		if mistralOCRAvailable(cfg) {
 			return ExtractorDecision{Name: "mistral-ocr", Source: "explicit"}
 		}
 		return ExtractorDecision{Source: "disabled", Reason: "ingest.extractor=mistral but the mistral-ocr provider has no credential"}
 	default: // auto
-		return describeAutoDocumentExtractor(ctx, cfg)
+		decision := describeAutoDocumentExtractor(ctx, cfg)
+		// pandoc (T2) is additive under auto, not the primary of the docling →
+		// docling-serve → mistral cascade. But when that cascade resolves to
+		// "disabled" (no docling/OCR) yet a functional pandoc IS available, pandoc
+		// is the only active engine, so it becomes the primary the banner and
+		// DocumentExtractorFromConfig build (born-digital formats stay covered).
+		if decision.Source == "disabled" && pandocAvailableContext(ctx, cfg) {
+			return ExtractorDecision{Name: "pandoc", Source: "auto", Reason: "no docling/OCR; pandoc covers born-digital formats"}
+		}
+		return decision
 	}
 }
 
@@ -99,6 +110,21 @@ func describeExplicitDocling(ctx context.Context, cfg config.Config) ExtractorDe
 		return ExtractorDecision{Source: "disabled", Reason: "ingest.extractor=docling but the docling command is present yet failed its functional check"}
 	}
 	return ExtractorDecision{Name: "docling", Source: "explicit", Reason: doclingResolvedReason(source)}
+}
+
+// describeExplicitPandoc resolves the pandoc CLI for ingest.extractor=pandoc.
+// Per spec §7.4 a capability-activated extractor is available only when it both
+// resolves AND passes a functional check; a present-but-broken pandoc disables
+// extraction (no silent fallback to another engine), mirroring explicit docling.
+func describeExplicitPandoc(ctx context.Context, cfg config.Config) ExtractorDecision {
+	bin, source, ok := resolvePandocBinary(cfg)
+	if !ok {
+		return ExtractorDecision{Source: "disabled", Reason: "ingest.extractor=pandoc but pandoc is unavailable"}
+	}
+	if err := pandocFunctionalCheck(ctx, bin); err != nil {
+		return ExtractorDecision{Source: "disabled", Reason: "ingest.extractor=pandoc but the pandoc command is present yet failed its functional check"}
+	}
+	return ExtractorDecision{Name: "pandoc", Source: "explicit", Reason: pandocResolvedReason(source)}
 }
 
 func describeAutoDocumentExtractor(ctx context.Context, cfg config.Config) ExtractorDecision {

--- a/internal/ingest/derivation.go
+++ b/internal/ingest/derivation.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/dirstral/dir2mcp/internal/config"
@@ -224,6 +225,32 @@ func (s *Service) activeOCRIdentity() string {
 	return derivationIdentity(string(provider.CapOCR), prov, modelName, "", "")
 }
 
+// activeOCRIdentityForPath is activeOCRIdentity resolved for a SPECIFIC document's
+// format. Under `ingest.extractor: auto` two extraction engines can be active at
+// once (docling + the capability-activated pandoc, #393), and a born-digital
+// document extracted by pandoc records provider "pandoc" in its meta_json — not
+// the primary engine's provider. So the staleness comparison must be against the
+// identity of the engine that WOULD extract THIS format (its per-format route),
+// not the global primary; otherwise every pandoc-extracted doc looks perpetually
+// stale under auto (recorded "pandoc" vs a primary "docling") and re-extracts on
+// every run. A format that routes to no extraction engine (degrade/raw_text) has
+// no active OCR identity, so the check self-skips (fail-open).
+func (s *Service) activeOCRIdentityForPath(relPath string) string {
+	ext := strings.ToLower(filepath.Ext(strings.TrimSpace(relPath)))
+	switch s.routeExtractionExt(ext) {
+	case routePandoc:
+		// pandoc has no model concept; mirror pandocExtractionMetaJSON (provider
+		// "pandoc", no model/version) so recorded == active for an unchanged doc.
+		return derivationIdentity(string(provider.CapOCR), "pandoc", "", "", "")
+	case routeStructured, routeFlatOCR:
+		// The primary extractor is the structured/flat engine for these routes, so
+		// its identity is the right one.
+		return s.activeOCRIdentity()
+	default:
+		return ""
+	}
+}
+
 // derivationIdentityStale reports whether a document whose content is unchanged
 // must nonetheless be reprocessed because a derived representation's recorded
 // derivation identity no longer matches the active model's identity (spec
@@ -280,10 +307,12 @@ func (s *Service) transcriptStale(ctx context.Context, reader representationMeta
 // by a different OCR/extraction model than the active one (§8.6.7). It self-skips
 // when no extractor is configured.
 func (s *Service) ocrStale(ctx context.Context, reader representationMetaReader, relPath string) bool {
-	if s.extractor == nil {
+	if s.extractor == nil && s.pandocExtractor == nil {
 		return false
 	}
-	active := s.activeOCRIdentity()
+	// Route-aware: under `auto`, a pandoc-extracted born-digital doc (#393) must be
+	// compared against the pandoc identity, not the primary engine's.
+	active := s.activeOCRIdentityForPath(relPath)
 	if active == "" {
 		return false
 	}

--- a/internal/ingest/derivation_pandoc_test.go
+++ b/internal/ingest/derivation_pandoc_test.go
@@ -1,0 +1,51 @@
+package ingest
+
+import (
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+)
+
+// TestActiveOCRIdentityForPath_PandocRouteUsesPandocIdentity is the regression for
+// the perpetual-staleness bug (#393): under `ingest.extractor: auto` two engines
+// can be active (docling primary + capability-activated pandoc). A born-digital
+// doc (.odt) is extracted by pandoc and records provider "pandoc" in its meta_json,
+// so the derivation-identity staleness check (ocrStale) MUST compare it against the
+// pandoc identity, not the primary docling's — otherwise recorded "pandoc" never
+// matches active "docling" and the doc re-extracts on every run.
+func TestActiveOCRIdentityForPath_PandocRouteUsesPandocIdentity(t *testing.T) {
+	s := &Service{
+		cfg:             config.Config{IngestExtractor: "auto"},
+		extractor:       NewDoclingExtractor("docling"), // structured primary (T1)
+		pandocExtractor: NewPandocExtractor("pandoc"),   // second engine (T2)
+	}
+
+	// .odt is docling-unreadable, so under auto it routes to pandoc: the active
+	// identity must equal what a stored pandoc extraction records.
+	wantPandoc, ok := ocrIdentityFromMeta(`{"provider":"pandoc"}`)
+	if !ok {
+		t.Fatal("ocrIdentityFromMeta rejected a pandoc meta_json")
+	}
+	gotODT := s.activeOCRIdentityForPath("report.odt")
+	if gotODT != wantPandoc {
+		t.Errorf("active OCR identity for .odt = %q, want the pandoc identity %q", gotODT, wantPandoc)
+	}
+
+	// The primary (docling) identity must NOT be what an .odt compares against —
+	// that mismatch was the bug.
+	if gotODT == s.activeOCRIdentity() {
+		t.Errorf("active OCR identity for .odt must not be the primary docling identity %q", s.activeOCRIdentity())
+	}
+
+	// A docling-readable format (.pdf) still resolves to the primary (docling)
+	// identity, unchanged by the pandoc wiring.
+	if gotPDF := s.activeOCRIdentityForPath("scan.pdf"); gotPDF != s.activeOCRIdentity() {
+		t.Errorf("active OCR identity for .pdf = %q, want the primary identity %q", gotPDF, s.activeOCRIdentity())
+	}
+
+	// A format no active engine can read (.doc: docling-denied, not pandoc-readable)
+	// has no active OCR identity, so the staleness check self-skips (fail-open).
+	if got := s.activeOCRIdentityForPath("legacy.doc"); got != "" {
+		t.Errorf("active OCR identity for uncovered .doc = %q, want empty", got)
+	}
+}

--- a/internal/ingest/extractor_routing_test.go
+++ b/internal/ingest/extractor_routing_test.go
@@ -51,8 +51,12 @@ var extractorRoutingCases = []struct {
 	{".tif", false, true},
 	{".tiff", false, true},
 	{".bmp", false, true},
-	// Read by neither engine (#394 defects 2 & 3; content support in #393).
+	// Read by neither the flat OCR nor the docling engine. Some are now covered by
+	// pandoc (T2, #393) — see TestSelectExtractionRoute_Pandoc — but the flat/
+	// structured verdicts here are unchanged. .epub is docling-unreadable (#393
+	// routes it to pandoc).
 	{".odt", false, false},
+	{".epub", false, false},
 	{".odp", false, false},
 	{".ods", false, false},
 	{".rtf", false, false},
@@ -217,6 +221,60 @@ func TestSelectExtractionRoute(t *testing.T) {
 	}
 }
 
+// TestSelectExtractionRoute_Pandoc is the #393 guard for the T2 pandoc tier: it
+// pins the fidelity-ordered choice for pandoc-readable born-digital formats across
+// the auto policy, the pandoc pin, and the docling pin (which must NOT borrow
+// pandoc).
+func TestSelectExtractionRoute_Pandoc(t *testing.T) {
+	doclingAndPandoc := extractionAvailability{structured: true, pandoc: true}
+	pandocOnly := extractionAvailability{pandoc: true}
+	doclingOnly := extractionAvailability{structured: true}
+
+	cases := []struct {
+		name   string
+		policy string
+		avail  extractionAvailability
+		ext    string
+		want   extractionRoute
+	}{
+		// auto, docling + pandoc both active: docling (T1) wins for what it reads;
+		// pandoc (T2) covers the docling-unreadable born-digital family.
+		{"auto docling+pandoc docx -> structured (T1 wins)", "auto", doclingAndPandoc, ".docx", routeStructured},
+		{"auto docling+pandoc odt -> pandoc (docling cannot import)", "auto", doclingAndPandoc, ".odt", routePandoc},
+		{"auto docling+pandoc rtf -> pandoc", "auto", doclingAndPandoc, ".rtf", routePandoc},
+		{"auto docling+pandoc epub -> pandoc (docling has no epub reader)", "auto", doclingAndPandoc, ".epub", routePandoc},
+		{"auto docling+pandoc pdf -> structured (pandoc reads no pdf)", "auto", doclingAndPandoc, ".pdf", routeStructured},
+		// auto, pandoc the only active engine: it reads the OOXML/born-digital it can.
+		{"auto pandoc-only docx -> pandoc", "auto", pandocOnly, ".docx", routePandoc},
+		{"auto pandoc-only odt -> pandoc", "auto", pandocOnly, ".odt", routePandoc},
+		{"auto pandoc-only pdf -> degrade (pandoc reads no pdf)", "auto", pandocOnly, ".pdf", routeDegrade},
+		{"auto pandoc-only pptx -> degrade (pandoc has no pptx reader)", "auto", pandocOnly, ".pptx", routeDegrade},
+		{"auto pandoc-only xlsx -> degrade (pandoc has no xlsx reader)", "auto", pandocOnly, ".xlsx", routeDegrade},
+		{"auto pandoc-only doc -> degrade (pandoc reads docx not legacy doc)", "auto", pandocOnly, ".doc", routeDegrade},
+		// pandoc pin: only pandoc eligible; pptx/xlsx/pdf/doc degrade.
+		{"pin pandoc odt -> pandoc", "pandoc", pandocOnly, ".odt", routePandoc},
+		{"pin pandoc docx -> pandoc", "pandoc", pandocOnly, ".docx", routePandoc},
+		{"pin pandoc pptx -> degrade", "pandoc", pandocOnly, ".pptx", routeDegrade},
+		{"pin pandoc pdf -> degrade", "pandoc", pandocOnly, ".pdf", routeDegrade},
+		// pandoc pin must not borrow docling even when docling is available.
+		{"pin pandoc + docling avail docx -> pandoc (no docling borrow)", "pandoc", doclingAndPandoc, ".docx", routePandoc},
+		{"pin pandoc + docling avail pdf -> degrade (pandoc reads no pdf, no docling borrow)", "pandoc", doclingAndPandoc, ".pdf", routeDegrade},
+		// docling pin must NOT route pandoc formats to pandoc.
+		{"pin docling odt -> degrade (no pandoc borrow)", "docling", doclingAndPandoc, ".odt", routeDegrade},
+		{"pin docling pptx -> structured (docling reads pptx)", "docling", doclingOnly, ".pptx", routeStructured},
+		// html markup boundary with pandoc: pandoc reads html when structured absent.
+		{"auto pandoc-only html -> pandoc", "auto", pandocOnly, ".html", routePandoc},
+		{"auto pandoc-only+nothing html still never dropped elsewhere", "auto", pandocOnly, ".htm", routePandoc},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := selectExtractionRoute(tc.policy, tc.avail, tc.ext); got != tc.want {
+				t.Errorf("selectExtractionRoute(%q, %+v, %q) = %d, want %d", tc.policy, tc.avail, tc.ext, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestActiveExtractionAvailability confirms availability is derived from the
 // resolved single extractor: a structured extractor reports structured-active, a
 // flat one reports flat-active, and no extractor reports nothing active.
@@ -229,5 +287,14 @@ func TestActiveExtractionAvailability(t *testing.T) {
 	}
 	if got := (&Service{}).activeExtractionAvailability(); got.structured || got.flatOCR {
 		t.Errorf("nil extractor availability = %+v, want zero", got)
+	}
+	// #393: pandoc as a SECOND engine alongside a structured primary.
+	if got := (&Service{extractor: structuredRoutingExtractor{}, pandocExtractor: NewPandocExtractor("")}).activeExtractionAvailability(); !got.structured || !got.pandoc || got.flatOCR {
+		t.Errorf("structured+pandoc availability = %+v, want {structured,pandoc}", got)
+	}
+	// pandoc as the PRIMARY (pin / auto-only-pandoc): not mislabeled flat/structured.
+	pe := NewPandocExtractor("")
+	if got := (&Service{extractor: pe, pandocExtractor: pe}).activeExtractionAvailability(); got.structured || got.flatOCR || !got.pandoc {
+		t.Errorf("pandoc-primary availability = %+v, want {pandoc} only", got)
 	}
 }

--- a/internal/ingest/pandoc_extractor.go
+++ b/internal/ingest/pandoc_extractor.go
@@ -1,0 +1,116 @@
+package ingest
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// pandocExtractTimeout bounds a single document's pandoc subprocess so one
+// pathological file can never wedge the indexer. Born-digital conversion is fast
+// (pandoc is a native binary with no model load), so 2 minutes is generous
+// headroom while still guaranteeing forward progress. It is a var (not a const)
+// only so tests can shorten it; production never reassigns it.
+var pandocExtractTimeout = 2 * time.Minute
+
+const (
+	// maxPandocOutputBytes caps the Markdown we read back from pandoc. Born-digital
+	// office/markup/ebook conversions are far smaller than docling's verbose JSON,
+	// so 256 MiB comfortably covers any real document while still bounding a
+	// pathological output.
+	maxPandocOutputBytes = 256 * 1024 * 1024
+	maxPandocStderrBytes = 1 * 1024 * 1024
+)
+
+// pandocWaitDelay is a backstop after the context is cancelled (timeout or
+// shutdown): os/exec sends the kill signal, and if the child has not exited within
+// this grace period the I/O pipes are force-closed so cmd.Run() cannot block
+// indefinitely on a wedged subprocess.
+const pandocWaitDelay = 10 * time.Second
+
+// pandocExtractor converts born-digital office/markup/ebook formats to Markdown
+// via a local pandoc CLI invocation (#393, the §7.4.B.1 T2 tier). It is a flat
+// extractor: it implements model.DocumentExtractor (Markdown out) and does NOT
+// implement structuredExtractor — pandoc emits no reading-order/section/page
+// provenance, so there are no region spans to carry.
+type pandocExtractor struct {
+	// command is the resolved pandoc command template (the first field is the
+	// binary). Empty means the `pandoc` binary is resolved from PATH per call.
+	command string
+}
+
+// NewPandocExtractor returns a document extractor backed by a local pandoc CLI
+// invocation. cmd is the configured ingest.pandoc.command (its first field is the
+// binary); a blank cmd resolves `pandoc` from PATH.
+func NewPandocExtractor(cmd string) *pandocExtractor {
+	return &pandocExtractor{command: strings.TrimSpace(cmd)}
+}
+
+// pandocBinary returns the executable to invoke: the first field of the configured
+// command, or the bare "pandoc" resolved from PATH.
+func (p *pandocExtractor) pandocBinary() string {
+	if fields := strings.Fields(p.command); len(fields) > 0 {
+		return fields[0]
+	}
+	return "pandoc"
+}
+
+// Extract writes data to a temp file (preserving the extension so pandoc can infer
+// the input format), runs `<pandoc> <tmpfile> -t gfm`, and returns the trimmed
+// GitHub-Flavored-Markdown pandoc streams to stdout. Output and stderr are capped;
+// the subprocess is bounded by pandocExtractTimeout. On failure it returns a
+// wrapped error whose message never includes the user-supplied command literally.
+func (p *pandocExtractor) Extract(ctx context.Context, relPath string, data []byte) (string, error) {
+	ext := filepath.Ext(relPath)
+	if ext == "" {
+		ext = ".bin"
+	}
+	tmpFile, err := os.CreateTemp("", "dir2mcp-pandoc-*"+ext)
+	if err != nil {
+		return "", fmt.Errorf("create temp doc file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+	if _, err := tmpFile.Write(data); err != nil {
+		_ = tmpFile.Close()
+		return "", fmt.Errorf("write temp doc file: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return "", fmt.Errorf("close temp doc file: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, pandocExtractTimeout)
+	defer cancel()
+	// pandoc streams Markdown to stdout by default; `-t gfm` selects
+	// GitHub-Flavored Markdown as the output format.
+	cmd := exec.CommandContext(ctx, p.pandocBinary(), tmpPath, "-t", "gfm")
+	cmd.WaitDelay = pandocWaitDelay
+	cmd.Env = os.Environ()
+	stdout := &limitedBuffer{buf: &bytes.Buffer{}, limit: maxPandocOutputBytes}
+	var stderr bytes.Buffer
+	cmd.Stdout = stdout
+	cmd.Stderr = &limitedBuffer{buf: &stderr, limit: maxPandocStderrBytes}
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("pandoc command timed out after %s", pandocExtractTimeout)
+		}
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return "", fmt.Errorf("pandoc command failed: %s", msg)
+	}
+	if stdout.Truncated() {
+		return "", fmt.Errorf("pandoc command output exceeded limit")
+	}
+	out := strings.TrimSpace(stdout.buf.String())
+	if out == "" {
+		return "", fmt.Errorf("pandoc command produced empty output")
+	}
+	return out, nil
+}

--- a/internal/ingest/pandoc_extractor_test.go
+++ b/internal/ingest/pandoc_extractor_test.go
@@ -1,0 +1,70 @@
+package ingest
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPandocExtractor_Extract_ReturnsStdoutMarkdown(t *testing.T) {
+	// A stub `pandoc` that ignores its args and echoes fixed Markdown to stdout,
+	// exactly as pandoc streams `-t gfm` output. No real pandoc binary required.
+	dir := t.TempDir()
+	stub := filepath.Join(dir, "pandoc")
+	if err := os.WriteFile(stub, []byte("#!/bin/sh\nprintf '# Title\\n\\nBody text.\\n'\n"), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	ex := NewPandocExtractor(stub)
+	out, err := ex.Extract(context.Background(), "notes.odt", []byte("irrelevant bytes"))
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if want := "# Title\n\nBody text."; out != want {
+		t.Errorf("Extract() = %q, want %q (trimmed stdout)", out, want)
+	}
+}
+
+func TestPandocExtractor_Extract_EmptyOutputIsError(t *testing.T) {
+	dir := t.TempDir()
+	stub := filepath.Join(dir, "pandoc")
+	if err := os.WriteFile(stub, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	if _, err := NewPandocExtractor(stub).Extract(context.Background(), "empty.odt", []byte("x")); err == nil {
+		t.Error("empty pandoc output must be an error, not a silent empty representation")
+	}
+}
+
+func TestPandocExtractor_Extract_NonZeroExitIsError(t *testing.T) {
+	dir := t.TempDir()
+	stub := filepath.Join(dir, "pandoc")
+	if err := os.WriteFile(stub, []byte("#!/bin/sh\necho 'boom' >&2\nexit 2\n"), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	_, err := NewPandocExtractor(stub).Extract(context.Background(), "bad.odt", []byte("x"))
+	if err == nil {
+		t.Fatal("a failing pandoc must return an error")
+	}
+	// The user-supplied command/path must never appear literally in the diagnostic.
+	if strings.Contains(err.Error(), stub) {
+		t.Errorf("error %q leaks the pandoc binary path", err.Error())
+	}
+}
+
+func TestPandocExtractor_Extract_TimesOut(t *testing.T) {
+	dir := t.TempDir()
+	stub := filepath.Join(dir, "pandoc")
+	if err := os.WriteFile(stub, []byte("#!/bin/sh\nsleep 5\n"), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	orig := pandocExtractTimeout
+	pandocExtractTimeout = 100 * time.Millisecond
+	defer func() { pandocExtractTimeout = orig }()
+	_, err := NewPandocExtractor(stub).Extract(context.Background(), "slow.odt", []byte("x"))
+	if err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Errorf("expected a timeout error, got %v", err)
+	}
+}

--- a/internal/ingest/pandoc_probe.go
+++ b/internal/ingest/pandoc_probe.go
@@ -90,7 +90,14 @@ func pandocFunctionalCheck(ctx context.Context, bin string) error {
 	// At most one probe per binary; concurrent callers for the same bin wait,
 	// callers for other bins proceed independently.
 	entry.once.Do(func() {
-		entry.err = runPandocVersionProbe(ctx, bin)
+		// Detach from the caller's context: this result is memoized process-wide, so
+		// a cancelled or expired REQUEST context must not permanently cache a healthy
+		// pandoc as unavailable for the rest of the process (CodeRabbit #586). The
+		// fixed pandocProbeTimeout is the only deadline; a genuinely hung binary is
+		// still bounded. ctx is retained on the signature for caller symmetry with
+		// doclingFunctionalCheck and to document the cancellable intent of the call.
+		_ = ctx
+		entry.err = runPandocVersionProbe(context.Background(), bin)
 	})
 	return entry.err
 }

--- a/internal/ingest/pandoc_probe.go
+++ b/internal/ingest/pandoc_probe.go
@@ -1,0 +1,165 @@
+package ingest
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+)
+
+// pandocProbeTimeout bounds the pandoc functional check so a hung binary cannot
+// stall startup or `dir2mcp doctor`. Unlike docling (which imports the whole
+// torch/transformers stack and needs a 90s cold-start ceiling), pandoc is a fast
+// native binary: `pandoc --version` returns in milliseconds, so a short 10s
+// timeout is generous headroom while still bounding a genuinely hung binary. The
+// probe result is memoized per process, so only the first probe pays it.
+const pandocProbeTimeout = 10 * time.Second
+
+// pandocProbeEntry memoizes one binary's functional-check result; the sync.Once
+// ensures the probe runs at most once per binary even under concurrent callers.
+type pandocProbeEntry struct {
+	once sync.Once
+	err  error
+}
+
+// pandocProbeEntries caches functional-check results per resolved binary for the
+// process lifetime (spec §7.4: cache the result for the run rather than probing
+// per document). A long-running daemon whose pandoc is installed mid-run picks up
+// the change on the next `dir2mcp up`.
+var (
+	pandocProbeMu      sync.Mutex
+	pandocProbeEntries = map[string]*pandocProbeEntry{}
+)
+
+// resolvePandocBinary returns the pandoc executable that would run for cfg, how it
+// was resolved ("command" from ingest.pandoc.command, or "path" from PATH), and
+// whether it resolved at all. The binary value itself is never surfaced in
+// diagnostics (a user command/path may be sensitive); callers map source to a
+// redacted reason via pandocResolvedReason.
+func resolvePandocBinary(cfg config.Config) (bin, source string, ok bool) {
+	if tpl := strings.TrimSpace(cfg.IngestPandocCommand); tpl != "" {
+		if fields := strings.Fields(tpl); len(fields) > 0 {
+			return fields[0], "command", true
+		}
+	}
+	if p, err := exec.LookPath("pandoc"); err == nil {
+		return p, "path", true
+	}
+	return "", "", false
+}
+
+// pandocResolvedReason maps a resolvePandocBinary source to the redacted reason
+// used in diagnostics. The literal command/path is never embedded (mirrors
+// doclingResolvedReason) so no user-supplied value flows into the banner or the
+// support bundle.
+func pandocResolvedReason(source string) string {
+	if source == "path" {
+		return "auto-detected on PATH"
+	}
+	return "configured pandoc command"
+}
+
+// pandocFunctionalCheck reports whether a resolved pandoc binary actually runs
+// (spec §7.4: a capability-activated engine is available only when it resolves
+// AND passes a lightweight functional check). A pandoc that resolves but crashes
+// on `--version` must be treated as unavailable rather than selected and then
+// failing every document.
+//
+// The check applies only to actual pandoc binaries (basename "pandoc"). A custom
+// ingest.pandoc.command may point at a wrapper that does not understand
+// --version, so such commands keep the prior "resolvable == available" behavior
+// and are not probed (mirrors doclingFunctionalCheck).
+func pandocFunctionalCheck(ctx context.Context, bin string) error {
+	if !looksLikePandoc(bin) {
+		return nil
+	}
+
+	pandocProbeMu.Lock()
+	entry, ok := pandocProbeEntries[bin]
+	if !ok {
+		entry = &pandocProbeEntry{}
+		pandocProbeEntries[bin] = entry
+	}
+	pandocProbeMu.Unlock()
+
+	// At most one probe per binary; concurrent callers for the same bin wait,
+	// callers for other bins proceed independently.
+	entry.once.Do(func() {
+		entry.err = runPandocVersionProbe(ctx, bin)
+	})
+	return entry.err
+}
+
+// looksLikePandoc reports whether bin's base name identifies the real pandoc CLI
+// (which supports `--version`).
+func looksLikePandoc(bin string) bool {
+	base := strings.ToLower(filepath.Base(strings.TrimSpace(bin)))
+	base = strings.TrimSuffix(base, ".exe")
+	return base == "pandoc"
+}
+
+// runPandocVersionProbe runs `<bin> --version` with a plain environment and a
+// bounded timeout, discarding output. pandoc is a self-contained native binary
+// and needs no environment sanitization (unlike docling's Python venv). A non-nil
+// return means the binary is present but non-functional.
+func runPandocVersionProbe(ctx context.Context, bin string) error {
+	pctx, cancel := context.WithTimeout(ctx, pandocProbeTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(pctx, bin, "--version")
+	cmd.Env = os.Environ()
+	return cmd.Run()
+}
+
+// pandocAvailable reports whether pandoc resolves for cfg AND passes its
+// functional check. It uses a background context; callers on hot paths that hold
+// a request context should use pandocAvailableContext so the probe is cancellable.
+func pandocAvailable(cfg config.Config) bool {
+	return pandocAvailableContext(context.Background(), cfg)
+}
+
+// pandocAvailableContext is pandocAvailable with a caller-provided context threaded
+// into the functional-check probe.
+func pandocAvailableContext(ctx context.Context, cfg config.Config) bool {
+	bin, _, ok := resolvePandocBinary(cfg)
+	if !ok {
+		return false
+	}
+	return pandocFunctionalCheck(ctx, bin) == nil
+}
+
+// pandocPolicyAllows reports whether the ingest.extractor policy permits pandoc as
+// an active engine: only `auto` (pandoc is an additive secondary engine) and the
+// explicit `pandoc` pin. Under any other pin (docling/docling-serve/mistral/off)
+// pandoc is not activated.
+func pandocPolicyAllows(policy string) bool {
+	p := strings.ToLower(strings.TrimSpace(policy))
+	return p == "" || p == "auto" || p == "pandoc"
+}
+
+// pandocEngineActive reports whether pandoc is an active extraction engine for
+// cfg: the policy permits it AND a functional pandoc resolves. It is the single
+// source of truth shared by NewService (which builds the extractor) and the
+// doctor coverage check (via PandocActive), so the availability the doctor reports
+// cannot drift from the engine indexing will actually run.
+func pandocEngineActive(cfg config.Config) bool {
+	return pandocPolicyAllows(cfg.IngestExtractor) && pandocAvailable(cfg)
+}
+
+// PandocActive is the exported wrapper over pandocEngineActive so out-of-package
+// diagnostics (the doctor extraction-coverage check) can report pandoc's covered
+// formats without duplicating the policy+availability logic.
+func PandocActive(cfg config.Config) bool {
+	return pandocEngineActive(cfg)
+}
+
+// PandocSupportsExt is the exported wrapper over the pandoc engine's readable set
+// so the doctor coverage check can report pandoc-covered formats. ext is expected
+// lowercased with its leading dot.
+func PandocSupportsExt(ext string) bool {
+	return engineSupportsExt(enginePandoc, ext)
+}

--- a/internal/ingest/pandoc_probe_test.go
+++ b/internal/ingest/pandoc_probe_test.go
@@ -1,0 +1,113 @@
+package ingest
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+)
+
+// writePandocStub writes an executable script named exactly `name` into a fresh
+// temp dir and returns its absolute path. body is the shell body (after the
+// shebang). Naming it "pandoc" makes looksLikePandoc true so the functional check
+// actually probes it; any other name is treated as a wrapper (not probed).
+func writePandocStub(t *testing.T, name, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte("#!/bin/sh\n"+body+"\n"), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	return p
+}
+
+func TestResolvePandocBinary_CommandBeatsPath(t *testing.T) {
+	stub := writePandocStub(t, "pandoc", "exit 0")
+	bin, source, ok := resolvePandocBinary(config.Config{IngestPandocCommand: stub + " --extra"})
+	if !ok || bin != stub || source != "command" {
+		t.Fatalf("resolvePandocBinary(command) = (%q,%q,%v), want (%q,command,true)", bin, source, ok, stub)
+	}
+	if got := pandocResolvedReason(source); got != "configured pandoc command" {
+		t.Errorf("reason = %q, want configured pandoc command", got)
+	}
+}
+
+func TestResolvePandocBinary_FallsBackToPath(t *testing.T) {
+	// Prepend a temp dir containing a `pandoc` to PATH so resolution is
+	// deterministic regardless of whether the host has a real pandoc.
+	stubDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(stubDir, "pandoc"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	bin, source, ok := resolvePandocBinary(config.Config{})
+	if !ok || source != "path" || filepath.Base(bin) != "pandoc" {
+		t.Fatalf("resolvePandocBinary(path) = (%q,%q,%v), want a PATH pandoc", bin, source, ok)
+	}
+	if got := pandocResolvedReason(source); got != "auto-detected on PATH" {
+		t.Errorf("reason = %q, want auto-detected on PATH", got)
+	}
+}
+
+func TestPandocFunctionalCheck_MemoizedOnce(t *testing.T) {
+	countFile := filepath.Join(t.TempDir(), "count")
+	// Each invocation appends a byte to countFile; a memoized probe runs it once.
+	stub := writePandocStub(t, "pandoc", "printf x >> "+countFile+"\nexit 0")
+	for i := 0; i < 3; i++ {
+		if err := pandocFunctionalCheck(context.Background(), stub); err != nil {
+			t.Fatalf("functional check err: %v", err)
+		}
+	}
+	data, err := os.ReadFile(countFile)
+	if err != nil {
+		t.Fatalf("read count: %v", err)
+	}
+	if len(data) != 1 {
+		t.Errorf("probe ran %d times, want exactly 1 (memoized)", len(data))
+	}
+}
+
+func TestPandocFunctionalCheck_NonFunctionalFails(t *testing.T) {
+	stub := writePandocStub(t, "pandoc", "exit 1")
+	if err := pandocFunctionalCheck(context.Background(), stub); err == nil {
+		t.Error("a pandoc that exits non-zero on --version must fail the functional check")
+	}
+	if pandocAvailable(config.Config{IngestPandocCommand: stub}) {
+		t.Error("a non-functional pandoc must report unavailable")
+	}
+}
+
+func TestPandocFunctionalCheck_WrapperNotProbed(t *testing.T) {
+	// A command whose basename is not "pandoc" is a wrapper: it is NOT probed, so
+	// even a non-zero-exiting binary keeps "resolvable == available".
+	wrapper := writePandocStub(t, "my-pandoc-wrapper", "exit 3")
+	if err := pandocFunctionalCheck(context.Background(), wrapper); err != nil {
+		t.Errorf("wrapper command must not be probed, got err %v", err)
+	}
+	if !pandocAvailable(config.Config{IngestPandocCommand: wrapper}) {
+		t.Error("a resolvable wrapper command must report available (not probed)")
+	}
+}
+
+func TestPandocEngineActive_PolicyGating(t *testing.T) {
+	stub := writePandocStub(t, "pandoc", "exit 0")
+	for _, tc := range []struct {
+		policy string
+		want   bool
+	}{
+		{"", true}, // empty defaults to auto
+		{"auto", true},
+		{"pandoc", true},
+		{"docling", false},
+		{"docling-serve", false},
+		{"mistral", false},
+		{"off", false},
+	} {
+		got := pandocEngineActive(config.Config{IngestExtractor: tc.policy, IngestPandocCommand: stub})
+		if got != tc.want {
+			t.Errorf("pandocEngineActive(policy=%q) = %v, want %v", tc.policy, got, tc.want)
+		}
+	}
+}

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -56,7 +56,13 @@ type Service struct {
 	indexingState *appstate.IndexingState
 	repGen        *RepresentationGenerator
 	extractor     model.DocumentExtractor
-	transcriber   model.Transcriber
+	// pandocExtractor is the capability-activated pandoc engine (T2, #393). Under
+	// `ingest.extractor: auto` it runs as a SECOND active engine alongside the
+	// primary s.extractor (e.g. docling handles .docx, pandoc handles .odt); under
+	// the `pandoc` pin it is also the primary. It is nil under any non-pandoc pin
+	// (docling/docling-serve/mistral/off) or when no functional pandoc resolves.
+	pandocExtractor *pandocExtractor
+	transcriber     model.Transcriber
 
 	// onUnsupported is the resolved §7.4.B.2 degradation mode for a format no
 	// active extraction engine supports (ingest.on_unsupported): "lenient"
@@ -413,20 +419,53 @@ var errNoVideoRepresentation = errors.New(
 		"and multimodal keyframe embedding is off — enable embed_multimodal or provide a .vtt/.srt sidecar to make it searchable")
 
 // activeExtractionAvailability derives which extraction engines are active for
-// this run (§7.4.B "Extractor availability") from the single resolved extractor.
-// The resolved extractor is already the best-available engine chosen by the
-// docling → docling-serve → mistral cascade (DescribeDocumentExtractor), so it is
-// either the structured docling family or the flat OCR path; deriving
-// availability from it keeps the per-format selection in lockstep with the engine
-// the service will actually run, with no second probe to drift from it.
+// this run (§7.4.B "Extractor availability") from the resolved extractors. The
+// primary s.extractor is the best-available engine chosen by the docling →
+// docling-serve → mistral cascade (DescribeDocumentExtractor) — structured
+// (docling family), flat OCR, or pandoc when it is the only engine. pandoc (T2,
+// #393) may additionally be active as a SECOND engine (s.pandocExtractor) under
+// `auto`. Deriving availability from the wired extractors keeps the per-format
+// selection in lockstep with the engines the service will actually run.
 func (s *Service) activeExtractionAvailability() extractionAvailability {
-	if s.extractor == nil {
-		return extractionAvailability{}
+	avail := extractionAvailability{}
+	switch s.extractor.(type) {
+	case nil:
+		// No primary extractor; only pandoc (if wired) may be active.
+	case *pandocExtractor:
+		// Primary is pandoc (the `pandoc` pin or the auto-only-pandoc case);
+		// avail.pandoc is set below from s.pandocExtractor.
+	default:
+		if _, structured := s.extractor.(structuredExtractor); structured {
+			avail.structured = true
+		} else {
+			avail.flatOCR = true
+		}
 	}
-	if _, structured := s.extractor.(structuredExtractor); structured {
-		return extractionAvailability{structured: true}
+	if s.pandocExtractor != nil {
+		avail.pandoc = true
 	}
-	return extractionAvailability{flatOCR: true}
+	return avail
+}
+
+// ActivatePandocEngine wires the capability-activated pandoc engine (T2, #393) as
+// an active extraction engine when cfg permits it (ingest.extractor auto or the
+// pandoc pin) AND a functional pandoc resolves. Under `auto` it runs as a second
+// engine alongside the primary s.extractor (e.g. docling handles .docx, pandoc
+// handles .odt); under the `pandoc` pin the primary IS pandoc, so this reuses that
+// same instance rather than building a second one. It is called by the CLI
+// ingestor wiring right after the primary extractor is set; NewService itself
+// stays free of any ambient-PATH probe so unit tests that inject a single
+// extractor are unaffected by whether a pandoc binary happens to be installed.
+func (s *Service) ActivatePandocEngine(cfg config.Config) {
+	if !pandocEngineActive(cfg) {
+		s.pandocExtractor = nil
+		return
+	}
+	if pe, ok := s.extractor.(*pandocExtractor); ok {
+		s.pandocExtractor = pe
+		return
+	}
+	s.pandocExtractor = NewPandocExtractor(cfg.IngestPandocCommand)
 }
 
 // routeExtractionExt resolves the capability-aware, per-format extraction route
@@ -450,7 +489,7 @@ func (s *Service) extractorCanReadExt(relPath string) bool {
 	}
 	ext := strings.ToLower(filepath.Ext(strings.TrimSpace(relPath)))
 	switch s.routeExtractionExt(ext) {
-	case routeStructured, routeFlatOCR:
+	case routeStructured, routePandoc, routeFlatOCR:
 		return true
 	default:
 		return false
@@ -461,8 +500,14 @@ func (s *Service) extractorCanReadExt(relPath string) bool {
 // #394 unsupported-format diagnostic. It reflects the same structured/flat split
 // extractorCanReadExt uses, not the concrete provider profile name.
 func (s *Service) extractorLabel() string {
+	if _, ok := s.extractor.(*pandocExtractor); ok {
+		return "pandoc"
+	}
 	if _, structured := s.extractor.(structuredExtractor); structured {
 		return "docling"
+	}
+	if s.extractor == nil && s.pandocExtractor != nil {
+		return "pandoc"
 	}
 	return "the OCR provider"
 }
@@ -812,6 +857,8 @@ func DocumentExtractorFromConfigContext(ctx context.Context, cfg config.Config) 
 		return NewDoclingExtractor(tpl)
 	case "docling-serve":
 		return NewDoclingServeExtractor(cfg.IngestDoclingServeURL)
+	case "pandoc":
+		return NewPandocExtractor(strings.TrimSpace(cfg.IngestPandocCommand))
 	case "mistral-ocr":
 		return mistralExtractor(cfg)
 	default:
@@ -3248,7 +3295,21 @@ func isNotFoundError(err error) bool {
 }
 
 func (s *Service) generateOCRMarkdownRepresentation(ctx context.Context, doc model.Document, content []byte) error {
-	if s.repGen == nil || s.extractor == nil {
+	if s.repGen == nil {
+		return nil
+	}
+
+	// #393: pandoc (T2) is a capability-activated engine for born-digital
+	// office/markup/ebook formats. Route the doc's format first; a pandoc route is
+	// served by the flat extracted_markdown path (no page/bbox provenance). This is
+	// checked before the s.extractor nil-guard so pandoc works when it is the only
+	// active engine (auto with no docling/OCR, or the pandoc pin).
+	ext := strings.ToLower(filepath.Ext(strings.TrimSpace(doc.RelPath)))
+	if s.pandocExtractor != nil && s.routeExtractionExt(ext) == routePandoc {
+		return s.generatePandocMarkdownRepresentation(ctx, doc, content)
+	}
+
+	if s.extractor == nil {
 		return nil
 	}
 
@@ -3401,6 +3462,9 @@ func (s *Service) extractionMetaJSON(text string) string {
 	switch ex := s.extractor.(type) {
 	case *doclingExtractor:
 		meta["command"] = strings.TrimSpace(ex.commandTemplate)
+	case *pandocExtractor:
+		// provider "pandoc" already set from extractorProviderModel; no user command
+		// is embedded (kept secret-free, unlike docling's command field).
 	case *doclingServeExtractor:
 		// Sanitized (scheme/host/path only): this is persisted per-document, so
 		// any userinfo/query in the URL must not become durable metadata.
@@ -3445,6 +3509,8 @@ func (s *Service) extractorProviderModel() (providerName string, modelName strin
 		return "docling", ""
 	case *doclingServeExtractor:
 		return "docling-serve", ""
+	case *pandocExtractor:
+		return "pandoc", ""
 	case *mistral.Client:
 		return "mistral", strings.TrimSpace(ex.DefaultOCRModel)
 	default:
@@ -3455,6 +3521,103 @@ func (s *Service) extractorProviderModel() (providerName string, modelName strin
 // GenerateOCRMarkdownRepresentation exposes OCR representation generation for tests.
 func (s *Service) GenerateOCRMarkdownRepresentation(ctx context.Context, doc model.Document, content []byte) error {
 	return s.generateOCRMarkdownRepresentation(ctx, doc, content)
+}
+
+// generatePandocMarkdownRepresentation produces the extracted_markdown
+// representation for a born-digital document via the pandoc engine (T2, #393). It
+// mirrors the flat branch of generateOCRMarkdownRepresentation but records
+// provider "pandoc" and, because pandoc emits no pages, chunks the Markdown by
+// lines WITHOUT fabricating page/bbox provenance.
+//
+// #393 follow-up: section-breadcrumb spans (a SHOULD progressive enhancement per
+// §7.4.B.1) are deferred — deriving them would require new Markdown-heading parsing
+// machinery, so this ships the flat extracted_markdown without breadcrumb spans.
+func (s *Service) generatePandocMarkdownRepresentation(ctx context.Context, doc model.Document, content []byte) error {
+	if s.repGen == nil || s.pandocExtractor == nil {
+		return nil
+	}
+	md, err := s.readOrComputePandoc(ctx, doc, content)
+	if err != nil {
+		return err
+	}
+	md = strings.TrimSpace(md)
+	if md == "" {
+		return nil
+	}
+
+	s.persistTitleIfFound(ctx, doc, md)
+
+	decision := s.screenOutputQuality(ctx, doc, qualityKindOCR, md, quality.Context{
+		Modality: quality.ModalityOCR,
+	})
+
+	rep := model.Representation{
+		DocID:       doc.DocID,
+		RepType:     RepTypeExtractedMarkdown,
+		RepHash:     computeRepHash([]byte(md)),
+		MetaJSON:    s.pandocExtractionMetaJSON(md),
+		CreatedUnix: time.Now().Unix(),
+		Deleted:     false,
+	}
+	repID, err := s.repGen.store.UpsertRepresentation(ctx, rep)
+	if err != nil {
+		return fmt.Errorf("upsert pandoc representation: %w", err)
+	}
+
+	segments := chunkRawTextByDocType(doc.DocType, md)
+	if len(segments) == 0 {
+		return nil
+	}
+	if err := s.repGen.upsertChunksForRepresentation(ctx, repID, "text", segments, decision); err != nil {
+		return fmt.Errorf("persist pandoc chunks: %w", err)
+	}
+	return nil
+}
+
+// readOrComputePandoc returns the pandoc-converted Markdown for content, caching
+// it under <state>/cache/pandoc keyed by content hash so re-indexing does not
+// re-run pandoc. pandoc is a single deterministic engine with no model concept, so
+// the bytes-only key is sufficient (its own cache dir isolates it from the OCR
+// cache). A pandoc failure is wrapped as ErrOCRProviderFailure so it classifies as
+// a retryable per-document OCR_FAILED in the run manifest (§14.4), mirroring
+// readOrComputeOCR.
+func (s *Service) readOrComputePandoc(ctx context.Context, doc model.Document, content []byte) (string, error) {
+	cacheDir := filepath.Join(s.cfg.StateDir, "cache", "pandoc")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		return "", fmt.Errorf("create pandoc cache dir: %w", err)
+	}
+	cachePath := filepath.Join(cacheDir, computeContentHash(content)+".md")
+	if cached, err := os.ReadFile(cachePath); err == nil {
+		return string(cached), nil
+	}
+	md, err := s.pandocExtractor.Extract(ctx, doc.RelPath, content)
+	if err != nil {
+		return "", fmt.Errorf("%w: pandoc extract %s: %w", ErrOCRProviderFailure, doc.RelPath, err)
+	}
+	mdBytes := []byte(strings.ReplaceAll(strings.ReplaceAll(md, "\r\n", "\n"), "\r", "\n"))
+	if err := os.WriteFile(cachePath, mdBytes, 0o644); err != nil {
+		return "", fmt.Errorf("write pandoc cache: %w", err)
+	}
+	return string(mdBytes), nil
+}
+
+// pandocExtractionMetaJSON builds the per-document extracted_markdown meta_json for
+// a pandoc extraction: provider "pandoc" (no model concept) plus a best-effort
+// detected language (§8.8). It is separate from extractionMetaJSON because that
+// switches on the PRIMARY s.extractor, which under `auto` is docling — so a pandoc
+// extraction must not be mislabeled with the primary's provider. No user-supplied
+// command is embedded, keeping diagnostics secret-free.
+func (s *Service) pandocExtractionMetaJSON(text string) string {
+	meta := map[string]string{"provider": "pandoc"}
+	if tag, _, ok := s.detectLanguage(text); ok {
+		meta["language"] = tag
+		meta["language_source"] = langSourceDetected
+	}
+	encoded, err := json.Marshal(meta)
+	if err != nil {
+		return ""
+	}
+	return string(encoded)
 }
 
 // quarantineDecision carries the result of screening generated output through

--- a/tests/config/pandoc_config_test.go
+++ b/tests/config/pandoc_config_test.go
@@ -1,0 +1,73 @@
+package tests
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+)
+
+// TestPandocExtractor_Accepted confirms ingest.extractor=pandoc is a valid value
+// (#393) and survives validation unchanged.
+func TestPandocExtractor_Accepted(t *testing.T) {
+	cfg := config.Default()
+	cfg.IngestExtractor = "pandoc"
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("ingest.extractor=pandoc should validate: %v", err)
+	}
+	if cfg.IngestExtractor != "pandoc" {
+		t.Fatalf("ingest.extractor normalized to %q, want pandoc", cfg.IngestExtractor)
+	}
+}
+
+// TestPandocCommand_NestedKeyLoads confirms the spec-style nested key
+// ingest.pandoc.command loads into IngestPandocCommand (mirroring
+// ingest.docling.command).
+func TestPandocCommand_NestedKeyLoads(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+	writeFile(t, path, "root_dir: ./repo\ningest:\n  pandoc:\n    command: /opt/pandoc {input}\n")
+
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile failed: %v", err)
+	}
+	if cfg.IngestPandocCommand != "/opt/pandoc {input}" {
+		t.Fatalf("loaded ingest.pandoc.command = %q, want /opt/pandoc {input}", cfg.IngestPandocCommand)
+	}
+}
+
+// TestPandocCommand_FlatRoundtrip verifies the flat pandoc_command key loads and
+// survives a SaveFile→LoadFile roundtrip.
+func TestPandocCommand_FlatRoundtrip(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+	writeFile(t, path, "root_dir: ./repo\npandoc_command: my-pandoc {input}\ningest_extractor: pandoc\n")
+
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile failed: %v", err)
+	}
+	if cfg.IngestPandocCommand != "my-pandoc {input}" {
+		t.Fatalf("loaded pandoc_command = %q, want my-pandoc {input}", cfg.IngestPandocCommand)
+	}
+	if cfg.IngestExtractor != "pandoc" {
+		t.Fatalf("loaded ingest_extractor = %q, want pandoc", cfg.IngestExtractor)
+	}
+
+	out := filepath.Join(tmp, "out.yaml")
+	if err := config.SaveFile(out, cfg); err != nil {
+		t.Fatalf("SaveFile failed: %v", err)
+	}
+	if text := readFileString(t, out); !strings.Contains(text, "pandoc_command: my-pandoc {input}") {
+		t.Fatalf("saved config missing pandoc_command:\n%s", text)
+	}
+	reloaded, err := config.LoadFile(out)
+	if err != nil {
+		t.Fatalf("reload failed: %v", err)
+	}
+	if reloaded.IngestPandocCommand != "my-pandoc {input}" {
+		t.Fatalf("roundtrip lost pandoc_command: %q", reloaded.IngestPandocCommand)
+	}
+}

--- a/tests/ingest/classify_test.go
+++ b/tests/ingest/classify_test.go
@@ -22,6 +22,8 @@ func TestClassifyDocType_Smoke(t *testing.T) {
 		{path: "slides.pptx", want: "document"},
 		{path: "sheet.xlsx", want: "document"},
 		{path: "report.docx", want: "document"},
+		{path: "book.epub", want: "document"},
+		{path: "notes.odt", want: "document"},
 		{path: "image.png", want: "image"},
 		{path: "audio.mp3", want: "audio"},
 		{path: "clip.mp4", want: "video"},

--- a/tests/ingest/pandoc_decision_test.go
+++ b/tests/ingest/pandoc_decision_test.go
@@ -1,0 +1,66 @@
+package tests
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+)
+
+// writePandocStub writes an executable script named exactly `name` and returns its
+// path. Naming it "pandoc" makes the functional check probe it.
+func writePandocStub(t *testing.T, name, body string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(p, []byte("#!/bin/sh\n"+body+"\n"), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	return p
+}
+
+// TestDescribeDocumentExtractor_PandocExplicitAvailable pins that ingest.extractor=
+// pandoc with a functional pandoc resolves to an explicit pandoc decision, and the
+// builder returns a non-nil extractor in lockstep.
+func TestDescribeDocumentExtractor_PandocExplicitAvailable(t *testing.T) {
+	stub := writePandocStub(t, "pandoc", "exit 0")
+	cfg := config.Config{IngestExtractor: "pandoc", IngestPandocCommand: stub}
+	d := ingest.DescribeDocumentExtractor(cfg)
+	if d.Name != "pandoc" || d.Source != "explicit" {
+		t.Fatalf("describe = %s/%s, want pandoc/explicit (reason %q)", d.Name, d.Source, d.Reason)
+	}
+	if ex := ingest.DocumentExtractorFromConfig(cfg); ex == nil {
+		t.Error("builder returned nil for an available pandoc pin")
+	}
+}
+
+// TestDescribeDocumentExtractor_PandocExplicitUnavailable pins that a present-but-
+// broken pandoc (non-zero --version) disables extraction — no silent fallback.
+func TestDescribeDocumentExtractor_PandocExplicitUnavailable(t *testing.T) {
+	stub := writePandocStub(t, "pandoc", "exit 1")
+	d := ingest.DescribeDocumentExtractor(config.Config{IngestExtractor: "pandoc", IngestPandocCommand: stub})
+	if d.Name != "" || d.Source != "disabled" {
+		t.Fatalf("describe = %s/%s, want disabled", d.Name, d.Source)
+	}
+}
+
+// TestDescribeDocumentExtractor_AutoOnlyPandoc pins that under auto, when no
+// docling/OCR is available but pandoc is, pandoc becomes the resolved primary so
+// born-digital formats stay covered.
+func TestDescribeDocumentExtractor_AutoOnlyPandoc(t *testing.T) {
+	if _, err := exec.LookPath("docling"); err == nil {
+		t.Skip("docling CLI present on PATH; auto would select it over pandoc")
+	}
+	t.Setenv("MISTRAL_API_KEY", "") // no OCR credential, so the cascade bottoms out
+	stub := writePandocStub(t, "pandoc", "exit 0")
+	cfg := config.Config{IngestExtractor: "auto", IngestPandocCommand: stub}
+	d := ingest.DescribeDocumentExtractor(cfg)
+	if d.Name != "pandoc" || d.Source != "auto" {
+		t.Fatalf("auto-only-pandoc describe = %s/%s, want pandoc/auto (reason %q)", d.Name, d.Source, d.Reason)
+	}
+	if ex := ingest.DocumentExtractorFromConfig(cfg); ex == nil {
+		t.Error("builder returned nil when pandoc is the only available auto engine")
+	}
+}


### PR DESCRIPTION
Closes #393. Last open child of the honest-coverage umbrella #395.

Adds **pandoc** as a capability-activated **T2** extraction engine (SPEC §7.4.B.1), gated by the now-merged spec **dirstral-spec#38** (re-pinned here: `2dd24f2` → `508b0c9`, spec 0.31.0).

## What it does

pandoc converts born-digital **office/markup/ebook** formats to Markdown. It runs as a **second active engine** under `ingest.extractor: auto` — docling (T1) handles `.docx`, pandoc (T2) handles the docling-unreadable `.odt/.rtf/.epub` — and can be pinned with `ingest.extractor: pandoc`. It is **capability-activated**: no enable flag; a working `pandoc` binary (PATH or `ingest.pandoc.command`) activates it, absence deactivates it. **No behavior change when pandoc is absent** (the default install).

Reader-only set: `.docx .odt .rtf .epub .html/.htm/.xhtml`. It deliberately does **not** claim `.pptx`/`.xlsx` (pandoc has no PowerPoint/Excel *reader*) or legacy binary `.doc` (docx-only) — those stay with docling (T1) or degrade per §7.4.B.2. No PDF/raster input. No page/`bbox` provenance (pandoc has no pages), so citations are section-granular.

## Key pieces

- **`capability.go`** — `enginePandoc` + `pandocReadableExt`; `routePandoc` between structured (T1) and flat-OCR (T3); `extractionAvailability.pandoc`; `selectExtractionRoute` + `extractionPolicyAllows`; engine-aware `ExtractionCovered` for the doctor. `.epub` → `structuredUnreadableExt` (docling has no epub reader) so it routes to pandoc.
- **`pandoc_probe.go` / `pandoc_extractor.go`** — resolve + memoized **10s** `--version` functional check (short — native binary, unlike docling's 90s torch import); flat `Extract` via `pandoc <file> -t gfm` (stdout, size/timeout caps, secret-free errors).
- **`service.go`** — `s.pandocExtractor` second engine; `ActivatePandocEngine`; route-aware availability/label/dispatch; `generatePandocMarkdownRepresentation` + `readOrComputePandoc` (own `cache/pandoc` content-hash key) + `pandocExtractionMetaJSON` (records provider `pandoc`, so a pandoc extraction isn't mislabeled with the primary under `auto`).
- **`derivation.go`** — `ocrStale` is now **route-aware** (`activeOCRIdentityForPath`): under `auto` a pandoc-extracted doc compares against the pandoc identity, not the primary docling's — without this, every born-digital doc looks perpetually stale (recorded `pandoc` vs active `docling`) and re-extracts on every run.
- **`classify.go`** — `.epub` → `document`. **`config.go`** — `ingest.pandoc.command` / `DIR2MCP_PANDOC_COMMAND`; `pandoc` accepted as an extractor value. **`app.go`** — `ActivatePandocEngine` after the primary is wired (kept out of `NewService` so unit tests injecting a single extractor stay PATH-independent). **`server_doctor.go`** — engine-aware coverage.

## Tests

Probe (resolve/memoize/non-functional/wrapper-not-probed), extractor (stubbed via `ingest.pandoc.command`), routing (`.docx`→pandoc, `.pptx`/`.xlsx`→structured-or-degrade, `.doc`→degrade, pins), classify (`.epub`), config round-trip, doctor coverage, and a derivation regression pinning the route-aware identity. `make check` green.

## Scope notes / follow-ups (deferred, not regressions)

- Section-breadcrumb spans are a SHOULD progressive enhancement per §7.4.B.1 — deferred (flat `extracted_markdown`, no fabricated page/bbox spans), marked with a `#393 follow-up:` comment.
- On-demand **annotation** of born-digital docs still uses the OCR-only path → tracked in **#585** (also notes stale doctor remediation wording).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Pandoc support for converting supported documents into Markdown.
  * Pandoc can be selected automatically or configured as the explicit extraction engine.
  * Added configurable Pandoc command settings through configuration files and environment variables.
  * Improved extraction coverage diagnostics for Pandoc-supported formats.
  * Added EPUB document classification and route-aware extraction caching.

* **Bug Fixes**
  * Fixed extraction staleness checks for documents processed through different extraction engines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->