### PR TITLE
fix(mcp): route on-demand annotation of born-digital docs through pandoc (#585)

### DIFF
--- a/internal/ingest/capability.go
+++ b/internal/ingest/capability.go
@@ -29,8 +29,8 @@ import "strings"
 // It matches the ONLY distinction extractorCanReadExt makes today: the flat
 // Mistral-OCR path vs the structured docling family (docling CLI / docling-serve,
 // the engines that emit a DoclingDocument). Bespoke/self-hosted OCR profiles ride
-// the flat path; a future pandoc extractor (#393) would be added as a new engine
-// here rather than as another scattered allowlist.
+// the flat path; the pandoc extractor (#393) is modeled as a distinct engine
+// here (enginePandoc, below) rather than as another scattered allowlist.
 type extractionEngine int
 
 const (

--- a/internal/ingest/extractor_routing_test.go
+++ b/internal/ingest/extractor_routing_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/dirstral/dir2mcp/internal/config"
 	"github.com/dirstral/dir2mcp/internal/mistral"
 	"github.com/dirstral/dir2mcp/internal/model"
 )
@@ -296,5 +297,25 @@ func TestActiveExtractionAvailability(t *testing.T) {
 	pe := NewPandocExtractor("")
 	if got := (&Service{extractor: pe, pandocExtractor: pe}).activeExtractionAvailability(); got.structured || got.flatOCR || !got.pandoc {
 		t.Errorf("pandoc-primary availability = %+v, want {pandoc} only", got)
+	}
+}
+
+// TestExtractorCanReadExt_PandocOnlyPrimaryNil is the regression for the optibot
+// blocker on #585/#587: the index-time readability guard must be routing-aware —
+// when pandoc is the only active engine (primary s.extractor nil, s.pandocExtractor
+// set), a pandoc-routed born-digital format is still readable, and a format no
+// engine covers is not. Mirrors CanExtractSourceText so the index and annotation
+// paths agree.
+func TestExtractorCanReadExt_PandocOnlyPrimaryNil(t *testing.T) {
+	s := &Service{cfg: config.Config{IngestExtractor: "auto"}, pandocExtractor: NewPandocExtractor("")}
+	if !s.extractorCanReadExt("report.odt") {
+		t.Error("pandoc-only (nil primary): .odt must be readable via the pandoc route")
+	}
+	if s.extractorCanReadExt("scan.pdf") {
+		t.Error("pandoc-only (nil primary): .pdf reads by no active engine and must not be readable")
+	}
+	// No engine at all → not readable.
+	if (&Service{cfg: config.Config{IngestExtractor: "auto"}}).extractorCanReadExt("report.odt") {
+		t.Error("no extractor: .odt must not be readable")
 	}
 }

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -484,7 +484,12 @@ func (s *Service) routeExtractionExt(ext string) extractionRoute {
 // extract the format (structured or flat OCR); a format that must degrade — or
 // that routes to the raw_text baseline (html) — is not "readable" on this path.
 func (s *Service) extractorCanReadExt(relPath string) bool {
-	if s.extractor == nil {
+	// Routing-aware, mirroring CanExtractSourceText: pandoc (T2, #393) can be the
+	// only active extraction engine (primary s.extractor nil, s.pandocExtractor
+	// set), so gate on whether ANY engine is active rather than on the primary
+	// alone — otherwise a pandoc-routed born-digital format would be wrongly
+	// treated as unreadable at index time.
+	if s.extractor == nil && s.pandocExtractor == nil {
 		return false
 	}
 	ext := strings.ToLower(filepath.Ext(strings.TrimSpace(relPath)))
@@ -2683,7 +2688,7 @@ func (s *Service) generateExtractedAndMediaRepresentations(ctx context.Context, 
 	mediaProduced = len(spans) > 0
 	skipOCR := s.embedMultimodal == "replace" && mediaProduced
 
-	if ShouldGenerateExtractedMarkdown(doc.DocType) && s.extractor != nil && !skipOCR {
+	if ShouldGenerateExtractedMarkdown(doc.DocType) && (s.extractor != nil || s.pandocExtractor != nil) && !skipOCR {
 		if s.extractorCanReadExt(doc.RelPath) {
 			if err := s.generateOCRMarkdownRepresentation(ctx, doc, content); err != nil {
 				return false, false, err

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -3601,6 +3601,24 @@ func (s *Service) readOrComputePandoc(ctx context.Context, doc model.Document, c
 	return string(mdBytes), nil
 }
 
+// pandocCachePath returns the cache file readOrComputePandoc writes for content.
+// The pandoc cache is keyed by content hash alone (pandoc is a single
+// deterministic engine with no model concept), so no active-extractor key is
+// mixed in as PurgeOCRCache does.
+func (s *Service) pandocCachePath(content []byte) string {
+	return filepath.Join(s.cfg.StateDir, "cache", "pandoc", computeContentHash(content)+".md")
+}
+
+// PurgePandocCache removes the pandoc cache entry for content, mirroring
+// PurgeOCRCache for the pandoc engine (#393). Callers that gate the returned
+// Markdown (e.g. the MCP secret-pattern gate, #407) use it so a refused result is
+// never left persisted in {StateDir}/cache/pandoc. Missing files are ignored.
+func (s *Service) PurgePandocCache(content []byte) {
+	if err := os.Remove(s.pandocCachePath(content)); err != nil && !errors.Is(err, os.ErrNotExist) {
+		s.getLogger().Printf("purge pandoc cache: %v", err)
+	}
+}
+
 // pandocExtractionMetaJSON builds the per-document extracted_markdown meta_json for
 // a pandoc extraction: provider "pandoc" (no model concept) plus a best-effort
 // detected language (§8.8). It is separate from extractionMetaJSON because that
@@ -4349,6 +4367,56 @@ func (s *Service) readOrComputeOCR(ctx context.Context, doc model.Document, cont
 // ReadOrComputeOCR exposes OCR cache lookup/computation for tests.
 func (s *Service) ReadOrComputeOCR(ctx context.Context, doc model.Document, content []byte) (string, error) {
 	return s.readOrComputeOCR(ctx, doc, content)
+}
+
+// CanExtractSourceText reports whether an active extraction engine produces
+// source text for doc's format on the on-demand annotation path — i.e. the
+// per-format route (§7.4.B.1) is a real engine (structured, pandoc, or flat OCR)
+// and the engine that route needs is wired. It is the single routing-aware guard
+// the MCP layer consults so it does not re-implement selectExtractionRoute. A
+// pandoc-routed born-digital format is covered when pandoc is active even if the
+// primary extractor is nil.
+func (s *Service) CanExtractSourceText(doc model.Document) bool {
+	ext := strings.ToLower(filepath.Ext(strings.TrimSpace(doc.RelPath)))
+	switch s.routeExtractionExt(ext) {
+	case routePandoc:
+		return s.pandocExtractor != nil
+	case routeStructured, routeFlatOCR:
+		return s.extractor != nil
+	default:
+		return false
+	}
+}
+
+// ExtractSourceText returns the plain extracted Markdown for doc's content,
+// routing born-digital office/markup/ebook formats through the pandoc engine
+// (T2, #393) and every other format through the primary OCR/extractor. It is the
+// on-demand annotation source path's single entry point, mirroring how
+// generateOCRMarkdownRepresentation routes at index time, so the MCP layer does
+// not duplicate the routing decision. Callers must have set the primary
+// extractor (SetDocumentExtractor) and activated pandoc (ActivatePandocEngine),
+// and should guard with CanExtractSourceText first. The computed text is written
+// to the corresponding cache (OCR or pandoc); PurgeExtractionCache removes it.
+func (s *Service) ExtractSourceText(ctx context.Context, doc model.Document, content []byte) (string, error) {
+	ext := strings.ToLower(filepath.Ext(strings.TrimSpace(doc.RelPath)))
+	if s.pandocExtractor != nil && s.routeExtractionExt(ext) == routePandoc {
+		return s.readOrComputePandoc(ctx, doc, content)
+	}
+	return s.readOrComputeOCR(ctx, doc, content)
+}
+
+// PurgeExtractionCache removes the cache entry ExtractSourceText wrote for doc's
+// content, routing to the pandoc cache for pandoc-routed born-digital formats and
+// the OCR cache otherwise. The MCP secret-pattern gate (#407) uses it so a refused
+// extraction is never left persisted on disk, regardless of which engine produced
+// it.
+func (s *Service) PurgeExtractionCache(doc model.Document, content []byte) {
+	ext := strings.ToLower(filepath.Ext(strings.TrimSpace(doc.RelPath)))
+	if s.pandocExtractor != nil && s.routeExtractionExt(ext) == routePandoc {
+		s.PurgePandocCache(content)
+		return
+	}
+	s.PurgeOCRCache(content)
 }
 
 // PurgeOCRCache removes the OCR cache entry for the given content, using the

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2268,28 +2268,36 @@ func (s *Server) sourceTextForAnnotation(ctx context.Context, doc model.Document
 		if err != nil {
 			return "", "", annotationReadError(err)
 		}
-		extractor := ingest.DocumentExtractorFromConfigContext(ctx, s.cfg)
-		if extractor == nil {
-			return "", "", &toolExecutionError{
-				Code:      "CONFIG_INVALID",
-				Message:   "document extraction is not configured (install docling, set DIR2MCP_DOCLING_COMMAND, or set MISTRAL_API_KEY)",
-				Retryable: false,
-			}
-		}
 		ing, err := ingest.NewService(s.cfg, s.store)
 		if err != nil {
 			return "", "", &toolExecutionError{Code: "CONFIG_INVALID", Message: err.Error(), Retryable: false}
 		}
-		ing.SetDocumentExtractor(extractor)
-		text, ocrErr := ing.ReadOrComputeOCR(ctx, doc, content)
+		// Wire the primary extractor (docling/mistral) if one is configured, then
+		// activate the capability-gated pandoc engine (T2, #393) so born-digital
+		// office/markup/ebook formats route through it — mirroring how indexing's
+		// generateOCRMarkdownRepresentation routes. The primary extractor may be nil
+		// for a pandoc-only format (e.g. .odt with no docling/OCR), so the config
+		// guard is per-format via CanExtractSourceText rather than a bare nil check.
+		if extractor := ingest.DocumentExtractorFromConfigContext(ctx, s.cfg); extractor != nil {
+			ing.SetDocumentExtractor(extractor)
+		}
+		ing.ActivatePandocEngine(s.cfg)
+		if !ing.CanExtractSourceText(doc) {
+			return "", "", &toolExecutionError{
+				Code:      "CONFIG_INVALID",
+				Message:   "document extraction is not configured (install docling or pandoc, set DIR2MCP_DOCLING_COMMAND, or set MISTRAL_API_KEY)",
+				Retryable: false,
+			}
+		}
+		text, ocrErr := ing.ExtractSourceText(ctx, doc, content)
 		if ocrErr != nil {
 			return "", "", s.mapToolErrorFromProvider("ANNOTATE_FAILED", ocrErr)
 		}
-		// Gate the OCR text (issue #407). ReadOrComputeOCR already wrote it to the
-		// OCR cache, so purge that entry on a match (same extractor key) rather
-		// than leaving the refused secret persisted on disk.
+		// Gate the extracted text (issue #407). ExtractSourceText already wrote it to
+		// the OCR or pandoc cache, so purge the matching entry on a match rather than
+		// leaving the refused secret persisted on disk.
 		if gate := s.refuseIfSecretContent(text); gate != nil {
-			ing.PurgeOCRCache(content)
+			ing.PurgeExtractionCache(doc, content)
 			return "", "", gate
 		}
 		return text, ingest.RepTypeOCRMarkdown, nil

--- a/tests/mcp/annotate_pandoc_test.go
+++ b/tests/mcp/annotate_pandoc_test.go
@@ -1,0 +1,133 @@
+package tests
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/mcp"
+)
+
+// writeStubPandoc writes an executable shell script that echoes fixed Markdown to
+// stdout, standing in for the pandoc binary on the annotation path. Its basename
+// is deliberately NOT "pandoc" so the engine's `--version` functional probe is
+// skipped (a custom ingest.pandoc.command wrapper is trusted as-is), letting the
+// stub activate as the pandoc engine without a real pandoc install.
+func writeStubPandoc(t *testing.T, markdown string) string {
+	t.Helper()
+	dir := t.TempDir()
+	script := filepath.Join(dir, "stubpandoc.sh")
+	// The extractor invokes `<script> <tmpfile> -t gfm`; ignore the args and emit
+	// the fixed Markdown so the on-demand annotation source is deterministic.
+	body := "#!/bin/sh\ncat <<'PANDOC_EOF'\n" + markdown + "\nPANDOC_EOF\n"
+	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+		t.Fatalf("write stub pandoc: %v", err)
+	}
+	return script
+}
+
+// TestMCPToolsCallAnnotate_ODTRoutesThroughPandoc is the regression for #585: a
+// born-digital .odt document annotated on demand must have its source text
+// produced by the capability-activated pandoc engine (T2, #393), not the primary
+// docling/mistral extractor. The stubbed pandoc emits a distinctive marker; the
+// annotation prompt sent to the model must contain it, proving the source text
+// came from pandoc rather than an extraction error/empty text.
+func TestMCPToolsCallAnnotate_ODTRoutesThroughPandoc(t *testing.T) {
+	const marker = "PANDOC_ODT_SOURCE_MARKER extracted body text"
+	cfg, st, _ := setupMCPToolStore(t, "report.odt", "document", []byte("PK\x03\x04 fake odt bytes"))
+
+	var mu sync.Mutex
+	var lastPrompt string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat/completions" {
+			http.NotFound(w, r)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		_ = r.Body.Close()
+		mu.Lock()
+		lastPrompt = string(body)
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"choices":[{"message":{"content":"{\"summary\":\"ok\"}"}}]}`)
+	}))
+	defer upstream.Close()
+
+	cfg = withMistralUpstream(t, cfg, "mistral", upstream.URL)
+	// withMistralUpstream reloads config from a fresh file (defaults: extractor
+	// auto); point the pandoc engine at the stub so .odt activates+routes through it.
+	cfg.IngestPandocCommand = writeStubPandoc(t, marker)
+
+	server := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st)).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":85,"method":"tools/call","params":{"name":"dir2mcp_annotate","arguments":{"rel_path":"report.odt","schema_json":{"type":"object","properties":{"summary":{"type":"string"}}}}}}`)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d want=%d body=%s", resp.StatusCode, http.StatusOK, string(payload))
+	}
+
+	mu.Lock()
+	prompt := lastPrompt
+	mu.Unlock()
+	if prompt == "" {
+		t.Fatal("model was never called: annotation source text was not produced (pandoc route not taken)")
+	}
+	if !strings.Contains(prompt, marker) {
+		t.Fatalf("annotation prompt did not contain the pandoc-extracted marker %q; got prompt body: %s", marker, prompt)
+	}
+
+	// The pandoc extraction was cached (not refused), so a cache entry remains.
+	if entries := pandocCacheEntries(t, cfg.StateDir); len(entries) == 0 {
+		t.Fatal("expected a pandoc cache entry after a successful .odt annotation")
+	}
+}
+
+// TestMCPToolsCallAnnotate_ODTPandocSecretGatePurgesCache covers the #407
+// secret-gate on the pandoc annotation path: when the pandoc-extracted text
+// matches a secret pattern the tool must refuse (FORBIDDEN) AND the refused
+// extraction must not be left persisted in the pandoc cache.
+func TestMCPToolsCallAnnotate_ODTPandocSecretGatePurgesCache(t *testing.T) {
+	const secret = "AKIA_PANDOC_SECRET_TOKEN"
+	cfg, st, _ := setupMCPToolStore(t, "report.odt", "document", []byte("PK\x03\x04 fake odt bytes"))
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The secret gate refuses before any model call; fail loudly if reached.
+		t.Errorf("model must not be called when the source text is refused")
+		http.NotFound(w, r)
+	}))
+	defer upstream.Close()
+
+	cfg = withMistralUpstream(t, cfg, "mistral", upstream.URL)
+	cfg.IngestPandocCommand = writeStubPandoc(t, "clearance note: "+secret)
+	cfg.SecretPatterns = []string{"AKIA_[A-Z_]+"}
+
+	server := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st)).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, `{"jsonrpc":"2.0","id":86,"method":"tools/call","params":{"name":"dir2mcp_annotate","arguments":{"rel_path":"report.odt","schema_json":{"type":"object","properties":{"summary":{"type":"string"}}}}}}`)
+	defer func() { _ = resp.Body.Close() }()
+	assertToolCallErrorCode(t, resp, "FORBIDDEN")
+
+	if entries := pandocCacheEntries(t, cfg.StateDir); len(entries) != 0 {
+		t.Fatalf("refused pandoc extraction left cache entries behind: %v", entries)
+	}
+}
+
+// pandocCacheEntries lists the .md files in the pandoc cache dir for stateDir.
+func pandocCacheEntries(t *testing.T, stateDir string) []string {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(stateDir, "cache", "pandoc", "*.md"))
+	if err != nil {
+		t.Fatalf("glob pandoc cache: %v", err)
+	}
+	return matches
+}


### PR DESCRIPTION
Closes #585.

## Problem
`internal/mcp/tools.go` `sourceTextForAnnotation` (the `pdf|image|document` branch) built an ingest Service, set the primary extractor, and called `ing.ReadOrComputeOCR(...)` directly. `ReadOrComputeOCR` always uses the primary docling/mistral extractor and never routes through pandoc. So annotating a born-digital `.odt`/`.rtf`/`.epub` document — which **indexing** already covers via the capability-activated pandoc engine (#393) — yielded an extraction error or empty text on the on-demand annotation path. Not a regression, but an inconsistency: a document dir2mcp indexed via pandoc couldn't be annotated on demand.

## Fix
Make the annotation source path route-aware, mirroring index-time `generateOCRMarkdownRepresentation`, while keeping the routing decision inside `internal/ingest` (the MCP layer does not re-implement `selectExtractionRoute`).

**`internal/ingest/service.go`** — new exported `*Service` methods:
- `CanExtractSourceText(doc)` — per-format config guard. Structured/flat-OCR routes need the primary extractor; a pandoc-routed born-digital format needs only pandoc (a nil primary is fine).
- `ExtractSourceText(ctx, doc, content)` — routes pandoc-routed formats to `readOrComputePandoc`, everything else to `readOrComputeOCR`.
- `PurgeExtractionCache(doc, content)` + `PurgePandocCache(content)` — route-aware cache purge so a secret-refused pandoc extraction is not left persisted on disk (#407), mirroring `PurgeOCRCache`.

**`internal/mcp/tools.go`** — `sourceTextForAnnotation` now: sets the primary extractor when one is configured, calls `ActivatePandocEngine(cfg)`, guards with `CanExtractSourceText` (preserving the `CONFIG_INVALID` "extraction not configured" behavior when no engine covers the format), extracts via `ExtractSourceText`, and purges via `PurgeExtractionCache` on a secret-gate match.

**`internal/ingest/capability.go`** — refresh a stale "future pandoc extractor (#393)" type comment now that the engine ships. The `uncoveredExtractionRemedy` doctor advisory strings the issue also flagged (`.gif/.svg/.ods/.odp/.doc`) were already updated when #393 landed — verified, no change needed.

## Tests (`tests/mcp`, black-box)
- Annotating a `.odt` routes through a stubbed `ingest.pandoc.command` (a temp `chmod +x` script echoing Markdown); the pandoc-extracted marker reaches the model prompt, proving the source text came from pandoc.
- A secret-matching pandoc extraction is refused (`FORBIDDEN`) and its pandoc cache entry is purged (no `.md` left in `cache/pandoc`).

## Verification
- `go build ./...`, `go vet ./...`, `golangci-lint run` clean.
- `go test ./internal/mcp/... ./internal/ingest/... ./tests/mcp/... ./tests/ingest/... ./internal/cli/...` all pass.
- `make check` green (gofmt's re-touch of 3 pre-existing unrelated files reverted to keep the diff scope-clean; gofmt is not a CI gate).

Part of a parallel backlog wave (#395 spec-first tier follow-ups); do not merge without the usual review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)