### PR TITLE
fix(retrieval): consistent BCP-47 language-tag validation (#441 items 2.2/2.3)

### DIFF
--- a/internal/model/langtag.go
+++ b/internal/model/langtag.go
@@ -31,41 +31,73 @@ func LanguagePrimarySubtag(tag string) string {
 // IsValidLanguageTag reports whether tag is a syntactically valid BCP-47
 // language tag for the purpose of the per-language retrieval filter (§9.5). The
 // check is deliberately lenient — it accepts the common forms an operator or
-// client sends (`en`, `EN`, `pt-BR`, `zh-Hant`, `und`) and rejects only clearly
-// malformed values — because §9.5 requires that an *unrecognized or malformed*
-// tag be reported as INVALID_FIELD, while a syntactically valid tag that simply
-// matches nothing is NOT an error.
+// client sends (`en`, `EN`, `pt-BR`, `zh-Hant`, `und`, and the locale form
+// `en_US`) and rejects only clearly malformed values — because §9.5 requires
+// that an *unrecognized or malformed* tag be reported as INVALID_FIELD, while a
+// syntactically valid tag that simply matches nothing is NOT an error.
 //
-// Validity rule: the tag is one or more '-'-separated subtags, each composed
-// solely of ASCII letters/digits, each 1..8 chars, with a non-empty primary
-// subtag of letters only (1..8). A trailing/leading/double hyphen, an empty
-// subtag, or any non-alphanumeric/non-hyphen rune is invalid. An empty/blank tag
-// is invalid (callers strip empties before validating; an explicit empty string
-// in the array is a client error).
+// Validity rule: the tag is one or more subtags separated by `-` OR `_` (the
+// `_` locale form is accepted as an alias for `-`, so `en_US` and `en-US` are
+// equivalent — this keeps validation consistent with LanguagePrimarySubtag,
+// which already treats `_` as a separator when honoring a stored representation
+// tag, issue #441 item 2.2). Each subtag is composed solely of ASCII
+// letters/digits and is 1..8 chars. The primary subtag (first) must be letters
+// only and at least 2 chars — a real language code is never numeric and never a
+// single letter (a lone `x`/`a` is a BCP-47 singleton/grandfathered prefix, not
+// a filterable language, issue #441 item 2.3). A trailing/leading/double
+// separator, an empty subtag, or any non-alphanumeric/non-separator rune is
+// invalid. An empty/blank tag is invalid (callers strip empties before
+// validating; an explicit empty string in the array is a client error).
 func IsValidLanguageTag(tag string) bool {
-	t := strings.TrimSpace(tag)
+	t := canonicalizeLanguageSeparators(strings.TrimSpace(tag))
 	if t == "" {
 		return false
 	}
-	subtags := strings.Split(t, "-")
-	for idx, sub := range subtags {
-		if len(sub) < 1 || len(sub) > 8 {
+	for idx, sub := range strings.Split(t, "-") {
+		if !isValidLanguageSubtag(sub, idx == 0) {
 			return false
-		}
-		for _, r := range sub {
-			isLetter := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
-			isDigit := r >= '0' && r <= '9'
-			if !isLetter && !isDigit {
-				return false
-			}
-			// The primary subtag (first) must be letters only — a language code is
-			// never numeric (e.g. "1" or "123" is not a language).
-			if idx == 0 && isDigit {
-				return false
-			}
 		}
 	}
 	return true
+}
+
+// isValidLanguageSubtag validates a single BCP-47 subtag under the lenient §9.5
+// rule (see IsValidLanguageTag). primary marks the first subtag, which carries
+// the stricter constraints: letters only and at least 2 chars (a real language
+// code is never numeric and never a single letter).
+func isValidLanguageSubtag(sub string, primary bool) bool {
+	if len(sub) < 1 || len(sub) > 8 {
+		return false
+	}
+	if primary && len(sub) < 2 {
+		return false
+	}
+	for _, r := range sub {
+		isLetter := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
+		isDigit := r >= '0' && r <= '9'
+		if !isLetter && !isDigit {
+			return false
+		}
+		// The primary subtag must be letters only — a language code is never
+		// numeric (e.g. "1" or "123" is not a language).
+		if primary && isDigit {
+			return false
+		}
+	}
+	return true
+}
+
+// canonicalizeLanguageSeparators maps the `_` locale separator to the BCP-47 `-`
+// separator so the underscore form (`en_US`) and the hyphen form (`en-US`) are
+// treated identically across validation (IsValidLanguageTag) and strict matching
+// (languageTagMatchesStrict). LanguagePrimarySubtag already collapses `_`/`-`
+// when extracting the primary subtag, so this keeps the filter side consistent
+// with the stored-representation side (issue #441 item 2.2).
+func canonicalizeLanguageSeparators(s string) string {
+	if strings.IndexByte(s, '_') < 0 {
+		return s
+	}
+	return strings.ReplaceAll(s, "_", "-")
 }
 
 // LanguageMatch selects the §9.5 matching mode for the per-language retrieval
@@ -175,14 +207,18 @@ func LanguageMatchesAnyMode(recordedTag string, requested []string, mode string)
 // suffix, compared case-insensitively. recorded is assumed already lower-cased
 // and trimmed by the caller; requested is canonicalized here.
 func languageTagMatchesStrict(requested, recorded string) bool {
-	req := strings.ToLower(strings.TrimSpace(requested))
-	if req == "" || recorded == "" {
+	// Canonicalize the `_` locale separator to `-` on both sides so `en_US`
+	// filters like `en-US` under strict matching (issue #441 item 2.2). recorded
+	// is already lower-cased/trimmed by the caller but may still carry `_`.
+	req := canonicalizeLanguageSeparators(strings.ToLower(strings.TrimSpace(requested)))
+	rec := canonicalizeLanguageSeparators(recorded)
+	if req == "" || rec == "" {
 		return false
 	}
-	if recorded == req {
+	if rec == req {
 		return true
 	}
 	// Recorded extends the request with additional subtags: the boundary after
 	// the request MUST be a subtag separator so `pt-br` never matches `pt-brz`.
-	return strings.HasPrefix(recorded, req+"-")
+	return strings.HasPrefix(rec, req+"-")
 }

--- a/tests/model/langtag_test.go
+++ b/tests/model/langtag_test.go
@@ -32,16 +32,66 @@ func TestLanguagePrimarySubtag(t *testing.T) {
 // INVALID_FIELD (§9.5/§14): common tags are valid; clearly malformed values are
 // rejected.
 func TestIsValidLanguageTag(t *testing.T) {
-	valid := []string{"en", "EN", "pt-BR", "zh-Hant", "und", "es", "de-DE-1996"}
+	valid := []string{
+		"en", "EN", "pt-BR", "zh-Hant", "und", "es", "de-DE-1996",
+		// The `_` locale form is accepted as an alias for `-` (issue #441 item
+		// 2.2): a filter is no longer rejected for a form that stored content is
+		// honored under (LanguagePrimarySubtag already collapses `_`).
+		"en_US", "pt_BR",
+	}
 	for _, tag := range valid {
 		if !model.IsValidLanguageTag(tag) {
 			t.Errorf("IsValidLanguageTag(%q) = false, want true", tag)
 		}
 	}
-	invalid := []string{"", "   ", "not a tag!", "@@@", "en-", "-en", "en--US", "123", "en-US-"}
+	invalid := []string{
+		"", "   ", "not a tag!", "@@@", "en-", "-en", "en--US", "123", "en-US-",
+		// A single-letter primary subtag is a BCP-47 singleton/grandfathered
+		// prefix, not a filterable language (issue #441 item 2.3).
+		"x", "a", "x-klingon", "en_", "_en",
+	}
 	for _, tag := range invalid {
 		if model.IsValidLanguageTag(tag) {
 			t.Errorf("IsValidLanguageTag(%q) = true, want false", tag)
+		}
+	}
+}
+
+// TestLanguageTagValidationConsistency pins the #441 item 2.2 fix: a filter tag
+// is accepted by IsValidLanguageTag exactly when stored content in the same form
+// is honored by LanguagePrimarySubtag. Before the fix, `en_US` yielded a stored
+// primary subtag ("en") yet was rejected as a client filter — an asymmetry that
+// silently dropped a legitimate filter.
+func TestLanguageTagValidationConsistency(t *testing.T) {
+	for _, tag := range []string{"en_US", "en-US", "pt_BR", "zh_Hant"} {
+		primary := model.LanguagePrimarySubtag(tag)
+		if primary == "" {
+			t.Fatalf("LanguagePrimarySubtag(%q) unexpectedly empty", tag)
+		}
+		if !model.IsValidLanguageTag(tag) {
+			t.Errorf("stored form %q yields primary %q but IsValidLanguageTag rejects the same filter (asymmetry, #441 2.2)", tag, primary)
+		}
+	}
+}
+
+// TestLanguageMatchesAnyMode_StrictUnderscore confirms the `_` locale form
+// filters identically to the `-` form under strict matching (issue #441 item
+// 2.2): `en_US` narrows exactly like `en-US`.
+func TestLanguageMatchesAnyMode_StrictUnderscore(t *testing.T) {
+	cases := []struct {
+		recorded  string
+		requested string
+		want      bool
+	}{
+		{"en-US", "en_US", true},  // underscore request matches hyphen recorded
+		{"en_US", "en-US", true},  // hyphen request matches underscore recorded
+		{"en-GB", "en_US", false}, // still narrows region
+		{"en", "en_US", false},    // bare en excluded by en_US request
+	}
+	for _, tc := range cases {
+		got := model.LanguageMatchesAnyMode(tc.recorded, []string{tc.requested}, model.LanguageMatchStrict)
+		if got != tc.want {
+			t.Errorf("strict match(recorded=%q, req=%q) = %v, want %v", tc.recorded, tc.requested, got, tc.want)
 		}
 	}
 }


### PR DESCRIPTION
Part of #441 (which is part of #395). Part of a parallel backlog wave.

## Recon: most of #441 already landed
Before writing any code I confirmed against `main` that the bulk of #441 is already fixed and merged:
- **1.1 / 1.2 / 1.3** (`file_glob` vs `list_files` glob divergence, missing `**`, case-sensitivity) — fixed by **#557** (`model.MatchGlob`/`CompileGlob` now drive both surfaces).
- **2.1** (languages filter never narrows region/script) — fixed by **#578** (opt-in `language_match: "strict"`, RFC 4647 Basic Filtering, spec-backed by SPEC §9.5).
- **3.1 / 3.2** (bilingual alignment mis-pairing) — fixed by **#557** (overlap-aware pairing).

The issue stayed **open** only because those PRs never carried a `Closes #441` keyword and two LOW-priority validation-consistency items remained. This PR closes those.

## What changed (the genuinely-remaining items)
`internal/model/langtag.go` — the §9.5 per-language filter validated a client `languages` tag inconsistently with how stored representation tags are honored:

- **2.2 — underscore asymmetry.** `IsValidLanguageTag` rejected the `_` locale form (`en_US`), while `LanguagePrimarySubtag` already collapses `_`/`-` when extracting a stored tag's primary subtag. So a client filter was rejected for a form that stored content is matched under — the filter was silently dropped. Underscore is now canonicalized to `-` before validation (`canonicalizeLanguageSeparators`) and in the strict-match path, so `en_US` filters identically to `en-US`.
- **2.3 — single-letter primary subtag.** A lone `x` / `a` wrongly validated. Those are BCP-47 singleton / grandfathered prefixes, not filterable languages; the primary subtag now requires at least 2 letters.

The per-subtag check was extracted into `isValidLanguageSubtag` to keep `gocyclo` under the 15 threshold.

**No spec change / spec-neutral.** SPEC §9.5 mandates `INVALID_FIELD` for a *malformed* tag and leaves the well-formedness rule to the implementation ("rejects only clearly malformed values"). This only tightens/aligns which forms count as malformed; it does not change the primary/strict matching contract. No submodule re-pin.

Note: `IsValidLanguageTag` is also consumed by ingest's `isKnownLanguageTag` (§8.6.4 sidecar binding), which additionally gates on `language.ParseBase`. The single-letter change is a no-op there (already rejected by `ParseBase`); the underscore change makes a `movie.en_US.srt`-style sidecar bind as `en` — strictly more correct and still ISO-gated.

## Tests
`tests/model/langtag_test.go`:
- `en_US` / `pt_BR` now valid; `x`, `a`, `x-klingon`, `en_`, `_en` now invalid.
- `TestLanguageTagValidationConsistency` — a filter is accepted iff stored content in the same form yields a primary subtag (closes the 2.2 asymmetry).
- `TestLanguageMatchesAnyMode_StrictUnderscore` — `en_US` narrows identically to `en-US` under strict mode.

`make check` = green (0 lint issues, gocyclo clean, all suites pass).

## Deferred
Nothing outstanding on #441 beyond this — 1.x/2.1/3.x already merged (#557/#578), and this PR covers 2.2/2.3. This makes #441 fully closable.