### PR TITLE
fix(ingest): transcribe the audio track of video files (#495)

### DIFF
--- a/internal/avutil/avutil.go
+++ b/internal/avutil/avutil.go
@@ -29,6 +29,12 @@ import (
 // the text path) from a genuine decode error.
 var ErrToolNotFound = errors.New("avutil: required media tool not found on PATH")
 
+// ErrNoAudioStream indicates the media at the given path carries no audio stream,
+// so there is nothing to transcribe. Callers treat it as a graceful "no
+// transcript" (not a hard failure): a silent film or a screen recording with no
+// audio track simply produces no transcript representation (issue #495).
+var ErrNoAudioStream = errors.New("avutil: media has no audio stream")
+
 // msToSeconds formats a millisecond offset as a fractional-second string with
 // millisecond precision, the form ffmpeg's -ss/-to accept.
 func msToSeconds(ms int) string {
@@ -390,6 +396,70 @@ func ExtractSegmentURL(ctx context.Context, url, srcExt string, startMS, endMS i
 		return nil, fmt.Errorf("avutil: ExtractSegmentURL requires an http(s) URL, got %q", redactInput(url))
 	}
 	return extractSegment(ctx, url, srcExt, startMS, endMS)
+}
+
+// ExtractAudioTrack demuxes the audio stream of the media at a local filesystem
+// path and re-encodes it into a compact mono 16 kHz AAC (.m4a) clip suitable for
+// speech-to-text, returning the container bytes. The video stream is dropped
+// (-vn), so a video container (.mp4/.mov) yields an audio-only clip that STT
+// providers accept — the audio track of a video is transcribed exactly like a
+// standalone audio file (issue #495).
+//
+// Re-encoding (rather than a stream copy) makes the output codec/container
+// deterministic regardless of the source audio codec (aac, opus, ac3, …), and
+// mono 16 kHz mirrors the preprocessing speech models apply internally, keeping
+// the clip small enough for provider upload limits without hurting recognition.
+//
+// It returns ErrToolNotFound when ffprobe/ffmpeg are not installed and
+// ErrNoAudioStream when the media carries no audio track (nothing to transcribe).
+func ExtractAudioTrack(ctx context.Context, path string) ([]byte, error) {
+	// Probe first so a video with no audio track is reported as the distinct
+	// ErrNoAudioStream (a graceful "no transcript") instead of an opaque ffmpeg
+	// "does not contain any stream" failure. A probe error other than a missing
+	// tool is not fatal here: fall through and let ffmpeg surface the real error.
+	if info, err := ProbeMediaInfo(ctx, path); err != nil {
+		if errors.Is(err, ErrToolNotFound) {
+			return nil, ErrToolNotFound
+		}
+	} else if strings.TrimSpace(info.AudioCodec) == "" {
+		return nil, ErrNoAudioStream
+	}
+
+	bin, err := exec.LookPath("ffmpeg")
+	if err != nil {
+		return nil, ErrToolNotFound
+	}
+
+	tmpDir, err := os.MkdirTemp("", "dir2mcp-avaudio-")
+	if err != nil {
+		return nil, fmt.Errorf("avutil: temp dir: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+	outPath := filepath.Join(tmpDir, "audio.m4a")
+
+	cmd := exec.CommandContext(ctx, bin,
+		"-nostdin",
+		"-v", "error",
+		"-i", path,
+		"-vn",
+		"-ac", "1",
+		"-ar", "16000",
+		"-c:a", "aac",
+		"-y", outPath,
+	)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("ffmpeg extract audio %q: %w: %s", path, err, strings.TrimSpace(stderr.String()))
+	}
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		return nil, fmt.Errorf("avutil: read extracted audio: %w", err)
+	}
+	if len(data) == 0 {
+		return nil, fmt.Errorf("avutil: ffmpeg produced an empty audio track for %q", path)
+	}
+	return data, nil
 }
 
 // isHTTPURL reports whether s is an http or https URL, the only schemes ffmpeg

--- a/internal/avutil/extract_audio_integration_test.go
+++ b/internal/avutil/extract_audio_integration_test.go
@@ -1,0 +1,91 @@
+package avutil
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// synthClip renders a short clip at path using ffmpeg's lavfi sources. When
+// withAudio is false the clip carries only a video stream, so it exercises the
+// no-audio-track degradation path. It fails the test if ffmpeg cannot render.
+func synthClip(t *testing.T, path string, withAudio bool) {
+	t.Helper()
+	bin, err := exec.LookPath("ffmpeg")
+	if err != nil {
+		t.Fatalf("ffmpeg required to synthesize a test clip: %v", err)
+	}
+	args := []string{"-nostdin", "-v", "error", "-y",
+		"-f", "lavfi", "-i", "testsrc=duration=1:size=160x120:rate=15"}
+	if withAudio {
+		args = append(args, "-f", "lavfi", "-i", "sine=frequency=440:duration=1", "-shortest")
+	}
+	args = append(args, "-c:v", "libx264", "-pix_fmt", "yuv420p")
+	if withAudio {
+		args = append(args, "-c:a", "aac")
+	}
+	args = append(args, path)
+	cmd := exec.CommandContext(context.Background(), bin, args...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("synthesize clip %q: %v: %s", path, err, out)
+	}
+}
+
+// TestExtractAudioTrack_Integration exercises the real ffmpeg audio-extraction
+// path (issue #495): a video clip yields a non-empty audio-only clip that probes
+// as carrying an audio (and no video) stream, and a video with no audio stream
+// returns ErrNoAudioStream so callers degrade gracefully. Gated behind
+// RUN_INTEGRATION_TESTS and skipped when ffmpeg/ffprobe are absent.
+func TestExtractAudioTrack_Integration(t *testing.T) {
+	if os.Getenv("RUN_INTEGRATION_TESTS") == "" {
+		t.Skip("set RUN_INTEGRATION_TESTS=1 to run integration tests")
+	}
+	if _, err := exec.LookPath("ffmpeg"); err != nil {
+		t.Skip("ffmpeg not installed")
+	}
+	if _, err := exec.LookPath("ffprobe"); err != nil {
+		t.Skip("ffprobe not installed")
+	}
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	t.Run("video with audio yields an audio-only clip", func(t *testing.T) {
+		src := filepath.Join(dir, "clip.mp4")
+		synthClip(t, src, true)
+
+		audio, err := ExtractAudioTrack(ctx, src)
+		if err != nil {
+			t.Fatalf("ExtractAudioTrack: %v", err)
+		}
+		if len(audio) == 0 {
+			t.Fatal("ExtractAudioTrack returned empty audio")
+		}
+
+		out := filepath.Join(dir, "extracted.m4a")
+		if err := os.WriteFile(out, audio, 0o644); err != nil {
+			t.Fatalf("write extracted audio: %v", err)
+		}
+		info, err := ProbeMediaInfo(ctx, out)
+		if err != nil {
+			t.Fatalf("probe extracted audio: %v", err)
+		}
+		if info.AudioCodec == "" {
+			t.Errorf("extracted clip has no audio stream: %+v", info)
+		}
+		if info.VideoCodec != "" {
+			t.Errorf("extracted clip still carries a video stream (%q); -vn should have dropped it", info.VideoCodec)
+		}
+	})
+
+	t.Run("video with no audio returns ErrNoAudioStream", func(t *testing.T) {
+		src := filepath.Join(dir, "silent.mp4")
+		synthClip(t, src, false)
+
+		if _, err := ExtractAudioTrack(ctx, src); !errors.Is(err, ErrNoAudioStream) {
+			t.Fatalf("ExtractAudioTrack on a soundless video = %v, want ErrNoAudioStream", err)
+		}
+	})
+}

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -168,6 +168,12 @@ type Service struct {
 	// (0, err) is treated as "do not trim".
 	DetectLeadingSilenceFunc func(ctx context.Context, path string) (time.Duration, error)
 
+	// ExtractAudioTrackFunc overrides extraction of a video's audio track before it
+	// is transcribed (issue #495). Defaults to avutil.ExtractAudioTrack (ffmpeg)
+	// when nil; tests set it to supply deterministic audio bytes (or
+	// avutil.ErrNoAudioStream) without requiring the ffmpeg binary.
+	ExtractAudioTrackFunc func(ctx context.Context, path string) ([]byte, error)
+
 	// ArchiveMaxMembers and ArchiveMaxTotalBytes bound archive fan-out to contain
 	// decompression bombs (#408): the number of members ingested per archive and
 	// the aggregate uncompressed bytes buffered. A value <= 0 uses the package
@@ -410,13 +416,15 @@ var errBinaryOnRawTextPath = errors.New(
 	"binary content on the raw-text path; not indexed as text (e.g. Parquet or another binary file with a text-classified extension)")
 
 // errNoVideoRepresentation marks a video document that produced zero
-// representations: no subtitle sidecar (.vtt/.srt/.ttml) was found next to it,
-// video STT is not applied (transcription is audio-only), and multimodal
-// keyframe embedding is off. Such a video is known but unsearchable, so it is
-// surfaced as a durable non-fatal diagnostic instead of a silent no-op (#398).
+// representations: no subtitle sidecar (.vtt/.srt/.ttml) was found next to it, no
+// transcript was derived (speech-to-text is off/unconfigured, or the video has no
+// audio track to transcribe — issue #495), and multimodal keyframe embedding is
+// off. Such a video is known but unsearchable, so it is surfaced as a durable
+// non-fatal diagnostic instead of a silent no-op (#398).
 var errNoVideoRepresentation = errors.New(
-	"video produced no representation: no subtitle sidecar found, video is not transcribed (STT is audio-only), " +
-		"and multimodal keyframe embedding is off — enable embed_multimodal or provide a .vtt/.srt sidecar to make it searchable")
+	"video produced no representation: no subtitle sidecar found, no transcript was derived " +
+		"(speech-to-text is off/unconfigured or the video has no audio track), and multimodal keyframe embedding is off — " +
+		"configure a speech-to-text provider, enable embed_multimodal, or provide a .vtt/.srt sidecar to make it searchable")
 
 // activeExtractionAvailability derives which extraction engines are active for
 // this run (§7.4.B "Extractor availability") from the resolved extractors. The
@@ -2051,7 +2059,10 @@ func (s *Service) deriveDocument(ctx context.Context, f DiscoveredFile, secretPa
 	}
 
 	docType := ClassifyDocType(f.RelPath)
-	if docType != "audio" || s.transcriber == nil {
+	// Audio AND video carry model-derived transcripts (issue #495): a video's
+	// source transcript was produced from its extracted audio track in the
+	// transcription pass, so its translation is derived here exactly like audio.
+	if !isSidecarMediaType(docType) || s.transcriber == nil {
 		s.markActiveSkipped()
 		return nil
 	}
@@ -3090,51 +3101,63 @@ func (s *Service) generateTranscriptOrSidecar(ctx context.Context, doc model.Doc
 		return false, err
 	}
 
-	if doc.DocType != "audio" || s.transcriber == nil {
-		// #398: a video with no subtitle sidecar (handled above) and no multimodal
-		// keyframe chunks yields zero representations because transcription is
-		// audio-only. That was a silent no-op; record it as status="error" so the
-		// unsearchable video is durably visible (CorpusStats.Errors / RecentFailures)
-		// and retried once a sidecar is added or embed_multimodal is enabled. The run
-		// still continues (returns nil), mirroring the #413 provider-failure path.
-		if doc.DocType == "video" && !mediaProduced {
-			s.getLogger().Printf("no representation produced for video %s: %v", doc.RelPath, errNoVideoRepresentation)
-			s.addErrors(1)
-			s.persistNonFatalDocError(ctx, doc, errNoVideoRepresentation, secretPatterns)
-			return true, nil
-		}
-		return false, nil
-	}
-	if err := s.generateTranscriptRepresentation(ctx, doc, content); err != nil {
-		// Provider/transient failures should not fail the entire ingest run.
-		// Persistence/cache failures should still propagate.
-		if errors.Is(err, ErrTranscriptProviderFailure) {
-			s.getLogger().Printf("transcription skipped for %s: %v", doc.RelPath, err)
-			s.addErrors(1)
-			// #413: a genuine provider failure that left the document with no
-			// representation of its own (no media chunks under multimodal
-			// `augment`) must not stay status="ok" — that hid the unsearchable
-			// audio from CorpusStats.Errors / RecentFailures / FailureSummary and
-			// reported errors=0 after a restart. Persist it as status="error" so
-			// the failure is durably visible and is retried on the next
-			// incremental run, while STILL returning nil so the batch continues. A
-			// document that DID produce media chunks stays "ok": it remains
-			// searchable, so it is not a zero-representation failure. Legitimately
-			// empty media never reaches here — an empty transcript returns nil
-			// without ErrTranscriptProviderFailure.
-			if !mediaProduced {
-				s.persistNonFatalDocError(ctx, doc, err, secretPatterns)
-				// The document is now durably status="error" and already counted
-				// above; signal the caller not to also credit it as indexed
-				// (issue #426). A doc that DID produce media chunks stays "ok"
-				// and searchable, so it is still credited (returns false).
-				return true, nil
+	// Route audio AND video (issue #495) through the same STT transcript path when
+	// speech-to-text is configured. A video's audio track is extracted before it is
+	// handed to the provider (see transcribe); audio is fed directly. When STT is
+	// off (no transcriber) or the media yields no transcript, the no-representation
+	// check below still surfaces an unsearchable video (#398).
+	if isSidecarMediaType(doc.DocType) && s.transcriber != nil {
+		produced, err := s.generateTranscriptRepresentation(ctx, doc, content)
+		if err != nil {
+			// Provider/transient failures should not fail the entire ingest run.
+			// Persistence/cache failures should still propagate.
+			if errors.Is(err, ErrTranscriptProviderFailure) {
+				s.getLogger().Printf("transcription skipped for %s: %v", doc.RelPath, err)
+				s.addErrors(1)
+				// #413: a genuine provider failure that left the document with no
+				// representation of its own (no media chunks under multimodal
+				// `augment`) must not stay status="ok" — that hid the unsearchable
+				// audio/video from CorpusStats.Errors / RecentFailures /
+				// FailureSummary and reported errors=0 after a restart. Persist it as
+				// status="error" so the failure is durably visible and is retried on
+				// the next incremental run, while STILL returning nil so the batch
+				// continues. A document that DID produce media chunks stays "ok": it
+				// remains searchable, so it is not a zero-representation failure.
+				// Legitimately empty media never reaches here — an empty transcript
+				// returns (false, nil) without ErrTranscriptProviderFailure.
+				if !mediaProduced {
+					s.persistNonFatalDocError(ctx, doc, err, secretPatterns)
+					// The document is now durably status="error" and already counted
+					// above; signal the caller not to also credit it as indexed
+					// (issue #426). A doc that DID produce media chunks stays "ok"
+					// and searchable, so it is still credited (returns false).
+					return true, nil
+				}
+				return false, nil
 			}
+			return false, err
+		}
+		if produced {
+			s.addRepresentations(1)
 			return false, nil
 		}
-		return false, err
+		// produced == false: the transcript was empty (silence) or the video has no
+		// audio track to transcribe. Fall through so an otherwise unsearchable video
+		// is still surfaced by the no-representation check below (#398/#495).
 	}
-	s.addRepresentations(1)
+
+	// #398/#495: a video with no subtitle sidecar (handled above), no derived
+	// transcript, and no multimodal keyframe chunks yields zero representations —
+	// known but unsearchable. Record it as status="error" so it is durably visible
+	// (CorpusStats.Errors / RecentFailures) and retried once a sidecar is added,
+	// STT is configured, or embed_multimodal is enabled. The run still continues
+	// (returns nil), mirroring the #413 provider-failure path.
+	if doc.DocType == "video" && !mediaProduced {
+		s.getLogger().Printf("no representation produced for video %s: %v", doc.RelPath, errNoVideoRepresentation)
+		s.addErrors(1)
+		s.persistNonFatalDocError(ctx, doc, errNoVideoRepresentation, secretPatterns)
+		return true, nil
+	}
 	return false, nil
 }
 
@@ -3772,19 +3795,26 @@ func (s *Service) transcriptExpectedLanguage() string {
 	return s.transcriptLanguage
 }
 
-func (s *Service) generateTranscriptRepresentation(ctx context.Context, doc model.Document, content []byte) error {
+// generateTranscriptRepresentation transcribes a media document (audio, or a
+// video's extracted audio track — issue #495) and persists the source transcript
+// representation and its chunks. It returns (produced, err): produced is true only
+// when a transcript representation was actually persisted, so the caller can tell a
+// real transcript from a legitimately empty one (silence, or a video with no audio
+// track) and surface an otherwise-unsearchable video (#398). A returned err follows
+// the same contract as generateRepresentations.
+func (s *Service) generateTranscriptRepresentation(ctx context.Context, doc model.Document, content []byte) (bool, error) {
 	if s.repGen == nil || s.transcriber == nil {
-		return nil
+		return false, nil
 	}
 
 	transcriptText, words, err := s.readOrComputeTranscriptWithWords(ctx, doc, content, "")
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	transcriptText = strings.TrimSpace(transcriptText)
 	if transcriptText == "" {
-		return nil
+		return false, nil
 	}
 
 	var duration time.Duration
@@ -3804,7 +3834,7 @@ func (s *Service) generateTranscriptRepresentation(ctx context.Context, doc mode
 	dropSet, scrubSet := s.captionDropScrub()
 	segments = applyDropScrubToSegments(segments, dropSet, scrubSet)
 	if len(segments) == 0 {
-		return nil
+		return false, nil
 	}
 	// Optional model-driven speaker diarization (SPEC §8.6.8): when active and a
 	// diarizer is injected, attribute each segment to a speaker. This is metadata
@@ -3817,7 +3847,7 @@ func (s *Service) generateTranscriptRepresentation(ctx context.Context, doc mode
 
 	metaJSON, err := s.sttTranscriptMetaJSON(distinctSpeakers(segments), transcriptText, segmentsHaveWordTiming(segments))
 	if err != nil {
-		return fmt.Errorf("marshal transcript meta: %w", err)
+		return false, fmt.Errorf("marshal transcript meta: %w", err)
 	}
 	rep := model.Representation{
 		DocID:       doc.DocID,
@@ -3829,7 +3859,7 @@ func (s *Service) generateTranscriptRepresentation(ctx context.Context, doc mode
 	}
 	repID, err := s.repGen.store.UpsertRepresentation(ctx, rep)
 	if err != nil {
-		return fmt.Errorf("upsert transcript representation: %w", err)
+		return false, fmt.Errorf("upsert transcript representation: %w", err)
 	}
 
 	// Optional leading-silence trim (dir2mcp#258): when enabled, subtract the
@@ -3846,7 +3876,7 @@ func (s *Service) generateTranscriptRepresentation(ctx context.Context, doc mode
 		}
 	}
 	if err := s.repGen.upsertChunksForRepresentation(ctx, repID, "text", segments, decision); err != nil {
-		return fmt.Errorf("persist transcript chunks: %w", err)
+		return false, fmt.Errorf("persist transcript chunks: %w", err)
 	}
 
 	// Optional translation step (SPEC §8.6.2): after the source transcript
@@ -3866,7 +3896,7 @@ func (s *Service) generateTranscriptRepresentation(ctx context.Context, doc mode
 	// final set of representations is identical either way — only the ordering
 	// differs. In single-pass mode (the default) it runs inline as before.
 	if s.activePass == passTranscription {
-		return nil
+		return true, nil
 	}
 	if err := s.translateTranscriptRepresentations(ctx, doc, content, transcriptText, duration, trimOffsetMS); err != nil {
 		s.getLogger().Printf("transcript translation skipped for %s: %v", doc.RelPath, err)
@@ -3880,7 +3910,7 @@ func (s *Service) generateTranscriptRepresentation(ctx context.Context, doc mode
 		code := manifestErrorCode(err)
 		s.markActiveErrored(code, code+": transcript translation failed")
 	}
-	return nil
+	return true, nil
 }
 
 // applyDiarization stamps speaker attribution onto the transcript segments via
@@ -4090,7 +4120,8 @@ func (s *Service) translateOneTranscript(ctx context.Context, doc model.Document
 
 // GenerateTranscriptRepresentation exposes transcript generation for tests.
 func (s *Service) GenerateTranscriptRepresentation(ctx context.Context, doc model.Document, content []byte) error {
-	return s.generateTranscriptRepresentation(ctx, doc, content)
+	_, err := s.generateTranscriptRepresentation(ctx, doc, content)
+	return err
 }
 
 // StoreAnnotationRepresentations persists a structured annotation JSON payload
@@ -4551,8 +4582,61 @@ func (s *Service) translateStructured(ctx context.Context, doc model.Document, c
 // (word-timing) capability when available. Providers that do not implement
 // model.StructuredTranscriber return no words, leaving downstream behaviour
 // unchanged.
+//
+// A video document (issue #495) has no audio-only container that STT providers
+// accept directly, so its audio track is demuxed/re-encoded to a compact clip via
+// ffmpeg first and handed to the provider under an audio filename; audio documents
+// are passed through unchanged. A video with no audio track degrades to an empty
+// transcript (no error) so the caller records "no transcript" rather than failing.
 func (s *Service) transcribe(ctx context.Context, doc model.Document, content []byte) (string, []model.TimedWord, error) {
-	return s.transcribeWith(ctx, s.transcriber, doc.RelPath, content)
+	relPath := doc.RelPath
+	if doc.DocType == "video" {
+		audio, err := s.extractVideoAudioTrack(ctx, doc, content)
+		if err != nil {
+			if errors.Is(err, avutil.ErrNoAudioStream) {
+				s.getLogger().Printf("no audio track to transcribe in video %s; skipping STT", doc.RelPath)
+				return "", nil, nil
+			}
+			return "", nil, err
+		}
+		content = audio
+		relPath = videoAudioRelPath(doc.RelPath)
+	}
+	return s.transcribeWith(ctx, s.transcriber, relPath, content)
+}
+
+// extractVideoAudioTrack demuxes a video's audio track to a compact STT-ready
+// clip (issue #495). avutil slices by file path, so the in-memory bytes are staged
+// to a temp file (mirroring the windowed-translate path) before extraction. It
+// propagates avutil.ErrNoAudioStream so the caller can degrade a soundless video
+// gracefully, and avutil.ErrToolNotFound when ffmpeg is absent.
+func (s *Service) extractVideoAudioTrack(ctx context.Context, doc model.Document, content []byte) ([]byte, error) {
+	tmp, err := os.CreateTemp("", "dir2mcp-vaudio-*"+filepath.Ext(doc.RelPath))
+	if err != nil {
+		return nil, fmt.Errorf("stage video for audio extraction: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+	if _, err := tmp.Write(content); err != nil {
+		_ = tmp.Close()
+		return nil, fmt.Errorf("write staged video: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return nil, fmt.Errorf("flush staged video: %w", err)
+	}
+	extract := s.ExtractAudioTrackFunc
+	if extract == nil {
+		extract = avutil.ExtractAudioTrack
+	}
+	return extract(ctx, tmpPath)
+}
+
+// videoAudioRelPath rewrites a video's path to the extracted audio clip's filename
+// so the STT provider infers an audio MIME type from the extension rather than a
+// video container it would reject (issue #495). ExtractAudioTrack emits an m4a
+// (AAC) clip, so the suffix matches the actual bytes handed to the provider.
+func videoAudioRelPath(relPath string) string {
+	return strings.TrimSuffix(relPath, filepath.Ext(relPath)) + ".m4a"
 }
 
 // readCachedWords loads per-word timing from the sidecar cache file, returning

--- a/tests/ingest/video_transcript_495_test.go
+++ b/tests/ingest/video_transcript_495_test.go
@@ -1,0 +1,139 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/avutil"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+)
+
+// capturingTranscriber records the filename and bytes it is handed so a test can
+// assert that a video's EXTRACTED AUDIO — not the raw container — reaches STT
+// (issue #495).
+type capturingTranscriber struct {
+	text       string
+	gotRelPath string
+	gotBytes   []byte
+	calls      int
+}
+
+func (c *capturingTranscriber) Transcribe(_ context.Context, relPath string, data []byte) (string, error) {
+	c.calls++
+	c.gotRelPath = relPath
+	c.gotBytes = append([]byte(nil), data...)
+	return c.text, nil
+}
+
+// TestVideoTranscript_RoutedThroughSTT is the regression guard for issue #495: a
+// .mp4 video classified as doc_type "video" must be transcribed by extracting its
+// audio track and feeding it to the configured STT provider, exactly like an audio
+// file. Before the fix, only audio extensions were routed to STT, so a video was
+// ingested but silently produced no transcript.
+//
+// ffmpeg is stubbed via ExtractAudioTrackFunc so the routing is exercised without
+// the binary; the real audio extraction is covered by avutil.
+func TestVideoTranscript_RoutedThroughSTT(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "clip.mp4"), "fake-video-container-bytes")
+	st := newRealStore(t)
+
+	svc := mustNewIngestService(t, config.Config{RootDir: root, StateDir: t.TempDir(), STTProvider: "off"}, st)
+	tr := &capturingTranscriber{text: "[00:00] hello from the video\n[00:03] second line"}
+	svc.SetTranscriber(tr)
+	svc.SetSTTIdentity("whisper", "whisper-large-v3")
+	svc.SetTranscriptLanguage("en")
+
+	extractedAudio := []byte("fake-extracted-aac-audio")
+	svc.ExtractAudioTrackFunc = func(_ context.Context, path string) ([]byte, error) {
+		// avutil is handed the staged video temp file, whose extension is preserved
+		// so ffmpeg infers the source muxer.
+		if !strings.HasSuffix(path, ".mp4") {
+			t.Errorf("audio extraction handed %q, want a staged .mp4 path", path)
+		}
+		return extractedAudio, nil
+	}
+
+	f := ingest.DiscoveredFile{RelPath: "clip.mp4", SizeBytes: 10, MTimeUnix: time.Now().Unix()}
+	if err := svc.ProcessDocument(context.Background(), f, nil, false); err != nil {
+		t.Fatalf("ProcessDocument(clip.mp4): %v", err)
+	}
+
+	// Routed through STT exactly once, with the EXTRACTED AUDIO under an audio
+	// filename — not the raw .mp4 container the provider would reject.
+	if tr.calls != 1 {
+		t.Fatalf("STT calls = %d, want 1 (a video's audio track must be transcribed, #495)", tr.calls)
+	}
+	if string(tr.gotBytes) != string(extractedAudio) {
+		t.Errorf("STT received %q, want the extracted audio bytes %q (the raw container must not be sent)", tr.gotBytes, extractedAudio)
+	}
+	if filepath.Ext(tr.gotRelPath) != ".m4a" {
+		t.Errorf("STT received filename %q, want an audio (.m4a) extension so the provider infers an audio MIME type", tr.gotRelPath)
+	}
+
+	meta := transcriptMetaFor(t, st, "clip.mp4")
+	if strings.TrimSpace(meta) == "" {
+		t.Fatal("video produced no transcript representation (issue #495 routing gap)")
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(meta), &parsed); err != nil {
+		t.Fatalf("transcript meta is not valid json (%q): %v", meta, err)
+	}
+	if parsed["source"] != "stt" {
+		t.Errorf("transcript source = %v, want stt", parsed["source"])
+	}
+	if parsed["provider"] != "whisper" {
+		t.Errorf("transcript provider = %v, want whisper", parsed["provider"])
+	}
+
+	doc := documentByPath(t, st, "clip.mp4")
+	if doc.Status != "ok" {
+		t.Errorf("clip.mp4 status = %q, want ok (a transcribed video is searchable)", doc.Status)
+	}
+}
+
+// TestVideoTranscript_NoAudioTrack_DegradesGracefully asserts the honest
+// degradation path (#495): a video with no audio stream has nothing to transcribe,
+// so STT is not invoked and the run does not fail. With no transcript, no subtitle
+// sidecar, and multimodal keyframe embedding off, the soundless video is still
+// surfaced as a durable status="error" so it is not a silent no-op (#398).
+func TestVideoTranscript_NoAudioTrack_DegradesGracefully(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "silent.mp4"), "fake-video-no-audio")
+	st := newRealStore(t)
+
+	svc := mustNewIngestService(t, config.Config{RootDir: root, StateDir: t.TempDir(), STTProvider: "off"}, st)
+	tr := &capturingTranscriber{text: "unused"}
+	svc.SetTranscriber(tr)
+	svc.SetSTTIdentity("whisper", "whisper-large-v3")
+	svc.ExtractAudioTrackFunc = func(_ context.Context, _ string) ([]byte, error) {
+		return nil, avutil.ErrNoAudioStream
+	}
+
+	f := ingest.DiscoveredFile{RelPath: "silent.mp4", SizeBytes: 10, MTimeUnix: time.Now().Unix()}
+	if err := svc.ProcessDocument(context.Background(), f, nil, false); err != nil {
+		t.Fatalf("ProcessDocument(silent.mp4): %v (a soundless video must not fail the run)", err)
+	}
+
+	if tr.calls != 0 {
+		t.Errorf("STT calls = %d, want 0 (a video with no audio track has nothing to transcribe)", tr.calls)
+	}
+	if meta, err := st.RepresentationMetaByType(context.Background(), "silent.mp4", ingest.RepTypeTranscript); err == nil && strings.TrimSpace(meta) != "" {
+		t.Errorf("soundless video produced a transcript rep (%q); want none", meta)
+	}
+
+	doc := documentByPath(t, st, "silent.mp4")
+	if doc.Status != "error" {
+		t.Errorf("soundless video status = %q, want error (an unsearchable video must be durably visible, #398)", doc.Status)
+	}
+	if !strings.Contains(strings.ToLower(doc.ErrorMessage), "no representation") {
+		t.Errorf("error_message = %q, want it to explain the video produced no representation", doc.ErrorMessage)
+	}
+}


### PR DESCRIPTION
## Problem (#495)

`.mp4`/`.mov` files classify as doc_type `video`, but only audio extensions were routed to STT. A video was ingested and indexed, yet **never sent to the transcriber** — no transcript, no error, effectively unsearchable. The operator's only workaround was to pre-extract an audio track (`ffmpeg -vn`) per file.

## Fix

Route `video` through the same STT transcript path as `audio`, extracting the video's audio track first so **any** STT provider accepts it (not just ffmpeg-backed self-hosted whisper — Mistral/ElevenLabs reject video containers):

- **`avutil.ExtractAudioTrack`** demuxes and re-encodes a video's audio stream to a compact mono 16 kHz AAC (`.m4a`) clip via `ffmpeg -vn`. Re-encoding (not stream-copy) makes the output deterministic regardless of source codec (aac/opus/ac3/…). Returns `ErrToolNotFound` when ffmpeg is absent and `ErrNoAudioStream` when the media has no audio track.
- **`ingest.transcribe`** extracts a video's audio before handing it to the provider under an audio filename (so the provider infers an audio MIME type); audio docs are passed through unchanged. Extraction is injectable via `ExtractAudioTrackFunc`, mirroring the existing `ProbeDurationFunc`/`DetectLeadingSilenceFunc` test hooks.
- **`generateTranscriptOrSidecar`** and the **two-phase derivation** gate now route both audio and video (`isSidecarMediaType`) through STT, so video transcripts translate/derive downstream exactly like audio.

The STT cache key is still the original video bytes (extraction runs only on a cache miss), and the transcript representation/chunking path is doc-type-independent, so a video transcript behaves identically to an audio transcript.

## Honest, non-fatal degradation

- Video with **no audio track** (`ErrNoAudioStream`) → no transcript, STT not invoked, run continues. If there's also no sidecar and multimodal keyframe embedding is off, it's surfaced as a durable `status="error"` (#398) instead of a silent no-op.
- **ffmpeg absent** / provider failure → flows through the existing non-fatal transcript-failure path (durably visible, retried next scan).
- **STT off** → unchanged; a sidecar-less, keyframe-less video is still flagged unsearchable (#398).
- Keyframe/multimodal embedding for video is preserved (transcript is added alongside).

## Tests

- `tests/ingest/video_transcript_495_test.go` — black-box via `ProcessDocument`: a `.mp4` routes through STT and produces a transcript rep with `source=stt` (asserting the provider receives the **extracted audio** under a `.m4a` filename, not the raw container); a soundless video degrades gracefully to `status="error"` without invoking STT. Extractor is stubbed, so no ffmpeg is needed in CI.
- `internal/avutil/extract_audio_integration_test.go` — `RUN_INTEGRATION_TESTS`-gated, skipped when ffmpeg/ffprobe are absent: synthesizes clips and exercises the real ffmpeg extraction (audio-only output; `ErrNoAudioStream` for a video with no audio).

`make check` passes locally except one pre-existing, unrelated failure: `TestSpecYAMLSecretPatterns_Compile_JWTAndBearer` needs the `dirstral-spec` submodule (not checked out in this worktree) — no spec files were touched.

Part of a parallel backlog wave; do not merge without the usual review.

Closes #495.