### PR TITLE
fix(providers): query-side effective embed model + unified STT selector (#440 F2/F6)

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -695,7 +695,12 @@ func (a *App) resolveModelClients(cfg config.Config) (model.Embedder, model.Gene
 	if ep, err := r.Resolve(provider.CapEmbed); err == nil {
 		if e, ferr := providerfactory.Embedder(ep); ferr == nil {
 			embedder = e
-			textModel, codeModel = ep.EmbedTextModel, ep.EmbedCodeModel
+			// Resolve the CONCRETE embed models the adapter will send (kind
+			// default when the profile leaves them blank) so the ingest worker
+			// and the query-side retrieval embedder use byte-identical model ids
+			// instead of each independently relying on the adapter default while
+			// retrieval keeps a stale mistral-embed fallback (issue #440 F2).
+			textModel, codeModel = providerfactory.EffectiveEmbedModels(ep)
 		}
 	}
 	var gen model.Generator

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3626,47 +3626,27 @@ func applyX402RouteEnvOverrides(cfg *Config, env map[string]string) {
 // ValidateX402, this method operates on a pointer receiver so that it can
 // modify the receiver in-place.
 func (c *Config) Validate() error {
-	if err := c.validateIngestOnUnsupported(); err != nil {
-		return err
-	}
-	if err := c.validateIngestExtractor(); err != nil {
-		return err
-	}
-
-	if err := c.validateIndexBackend(); err != nil {
-		return err
-	}
-
-	if err := c.validateMediaVariants(); err != nil {
-		return err
-	}
-
-	if err := c.validateMediaTranslate(); err != nil {
-		return err
-	}
-
-	if err := c.validateMediaSubtitles(); err != nil {
-		return err
-	}
-
-	if err := c.validateMediaDiarize(); err != nil {
-		return err
-	}
-
-	if err := c.validateNumericBounds(); err != nil {
-		return err
-	}
-	if err := c.validateSource(); err != nil {
-		return err
-	}
-	if err := c.validateDistributedEmbed(); err != nil {
-		return err
-	}
-	if err := c.validateMediaBatch(); err != nil {
-		return err
-	}
-	if err := c.validateCrossLingual(); err != nil {
-		return err
+	// Ordered validation gates. Run in sequence; the first failure short-circuits
+	// (a loop rather than a straight-line if-chain so this stays under the
+	// cyclomatic-complexity budget as gates are added).
+	for _, validate := range []func() error{
+		c.validateIngestOnUnsupported,
+		c.validateIngestExtractor,
+		c.validateIndexBackend,
+		c.validateMediaVariants,
+		c.validateMediaTranslate,
+		c.validateMediaSubtitles,
+		c.validateMediaDiarize,
+		c.validateSTTProvider,
+		c.validateNumericBounds,
+		c.validateSource,
+		c.validateDistributedEmbed,
+		c.validateMediaBatch,
+		c.validateCrossLingual,
+	} {
+		if err := validate(); err != nil {
+			return err
+		}
 	}
 	c.applyValidationDefaults()
 	if c.SessionMaxLifetime > 0 && c.SessionMaxLifetime < c.SessionInactivityTimeout {
@@ -3674,6 +3654,27 @@ func (c *Config) Validate() error {
 			c.SessionMaxLifetime, c.SessionInactivityTimeout)
 	}
 	return nil
+}
+
+// validateSTTProvider fails fast (CONFIG_INVALID) when stt.provider names a
+// selector no STT resolver can map (issue #440 F6). Empty/`auto` and the off
+// aliases are valid; every other value must map to a built-in profile via
+// STTSelectorProfile. Without this gate an unknown or unmappable selector (a
+// typo, or a backend the selector table forgot) silently disabled STT on the
+// expected-language, derivation-identity, and diarization-gating paths while
+// erroring only at first transcription — a divergence surfaced far from its
+// cause. Validating here makes the misconfiguration fail at startup, uniformly.
+func (c *Config) validateSTTProvider() error {
+	sel := strings.ToLower(strings.TrimSpace(c.STTProvider))
+	switch sel {
+	case "", "auto", "off", "none", "disabled":
+		return nil
+	}
+	if _, ok := STTSelectorProfile(sel); ok {
+		return nil
+	}
+	return fmt.Errorf("CONFIG_INVALID: stt.provider %q is not a recognized speech-to-text backend; "+
+		"use one of auto, mistral, elevenlabs, whisper, openai, gemini, or off", c.STTProvider)
 }
 
 // validateMediaBatch enforces the media.batch (SPEC §8.6.11) invariants. All

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3634,10 +3634,14 @@ func (c *Config) Validate() error {
 		c.validateIngestExtractor,
 		c.validateIndexBackend,
 		c.validateMediaVariants,
+		// Before the media gates: validateMediaTranslate/validateMediaDiarize
+		// resolve the STT profile, so an unrecognized stt.provider must fail here
+		// with its own root-cause CONFIG_INVALID rather than surfacing as a
+		// misleading "requires STT provider to be kind:whisper" (optibot #592).
+		c.validateSTTProvider,
 		c.validateMediaTranslate,
 		c.validateMediaSubtitles,
 		c.validateMediaDiarize,
-		c.validateSTTProvider,
 		c.validateNumericBounds,
 		c.validateSource,
 		c.validateDistributedEmbed,

--- a/internal/config/providers.go
+++ b/internal/config/providers.go
@@ -529,19 +529,14 @@ func resolveSTTProfileForCapability(cfg Config) (provider.Profile, bool) {
 		return provider.Profile{}, false
 	}
 	r := cfg.Providers()
-	explicitBySelector := map[string]string{
-		"mistral":    "mistral-ocr",
-		"elevenlabs": "elevenlabs",
-		"whisper":    "whisper",
-	}
 	var (
 		prof provider.Profile
 		err  error
 	)
 	if sel == "auto" {
 		prof, err = r.Resolve(provider.CapSTT)
-	} else if explicit, ok := explicitBySelector[sel]; ok {
-		prof, err = r.ResolveExplicit(provider.CapSTT, explicit, true)
+	} else if profileName, ok := STTSelectorProfile(sel); ok {
+		prof, err = r.ResolveExplicit(provider.CapSTT, profileName, true)
 	} else {
 		return provider.Profile{}, false
 	}
@@ -549,6 +544,36 @@ func resolveSTTProfileForCapability(cfg Config) (provider.Profile, bool) {
 		return provider.Profile{}, false
 	}
 	return prof, true
+}
+
+// sttSelectorProfile is the SINGLE mapping from a normalized legacy stt.provider
+// selector (SPEC 8.1.3) to the built-in provider profile that serves it. It is
+// shared by every STT resolver — ingest transcription
+// (ingest.TranscriberFromConfigWithLanguage), the expected-language/derivation
+// resolver (ingest.resolveSTTProfile), and config-time diarization/translate
+// validation (resolveSTTProfileForCapability) — so an explicit selector resolves
+// to the SAME backend on every path (issue #440 F6). Before unification, these
+// tables diverged: only mistral/elevenlabs/whisper were mapped, so an explicit
+// `openai`/`gemini` selector errored loudly at first transcription while
+// silently resolving STT-OFF for expected-language, derivation identity, and
+// diarization gating — even though providerfactory.Transcriber builds those
+// kinds. The special `auto` selector and the off aliases are handled by callers,
+// not this table.
+var sttSelectorProfile = map[string]string{
+	"mistral":    "mistral-ocr", // Voxtral STT (kind: mistral)
+	"elevenlabs": "elevenlabs",
+	"whisper":    "whisper",
+	"openai":     "openai",
+	"gemini":     "gemini",
+}
+
+// STTSelectorProfile resolves a normalized (lower-cased, trimmed) legacy
+// stt.provider selector to the built-in profile name that serves it. known is
+// false for an unrecognized selector; `auto` and the off aliases are NOT in the
+// table (callers handle them before consulting it). See sttSelectorProfile.
+func STTSelectorProfile(sel string) (profileName string, known bool) {
+	name, ok := sttSelectorProfile[sel]
+	return name, ok
 }
 
 // diarizeStateForProfile resolves the effective diarization activation for the

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -43,11 +43,12 @@ const (
 
 	defaultOnDocumentDeletedMaxConcurrency = 8
 
-	transcriberProviderAuto       = "auto"
-	transcriberProviderMistral    = "mistral"
-	transcriberProviderElevenLabs = "elevenlabs"
-	transcriberProviderWhisper    = "whisper"
-	transcriberProviderOff        = "off"
+	// transcriberProviderAuto/Off are the two selectors handled directly by the
+	// STT resolvers; every other explicit selector (mistral/elevenlabs/whisper/
+	// openai/gemini) maps to a built-in profile via config.STTSelectorProfile,
+	// the single shared selector->profile table (issue #440 F6).
+	transcriberProviderAuto = "auto"
+	transcriberProviderOff  = "off"
 )
 
 type Service struct {
@@ -916,28 +917,26 @@ func TranscriberFromConfigWithLanguage(cfg config.Config, language string) (mode
 		}
 		return tr, nil
 	}
-	switch sel {
-	case transcriberProviderMistral:
-		prof, err := r.ResolveExplicit(provider.CapSTT, "mistral-ocr", true)
-		return build(prof, err)
-	case transcriberProviderElevenLabs:
-		prof, err := r.ResolveExplicit(provider.CapSTT, "elevenlabs", true)
-		return build(prof, err)
-	case transcriberProviderWhisper:
-		// Self-hosted OpenAI-compatible STT (dir2mcp#240). The profile is
-		// credential-less, so selection succeeds even without an api_key;
-		// a missing base_url surfaces as a provider error at first use.
-		prof, err := r.ResolveExplicit(provider.CapSTT, "whisper", true)
-		return build(prof, err)
-	case transcriberProviderAuto:
+	if sel == transcriberProviderAuto {
 		prof, err := r.Resolve(provider.CapSTT)
 		if errors.Is(err, provider.ErrNoProvider) {
 			return nil, nil // nothing eligible -> STT off
 		}
 		return build(prof, err)
-	default:
+	}
+	// Shared selector->profile table (issue #440 F6): mistral -> mistral-ocr
+	// (Voxtral), elevenlabs, whisper (self-hosted, credential-less — a missing
+	// base_url surfaces as a provider error at first use), openai, gemini. Every
+	// mapped kind is buildable by providerfactory.Transcriber, so an explicit
+	// selector reaches the same backend the resolver validated. An unmapped
+	// selector is rejected here and, in a normal startup, already at
+	// config.Validate (validateSTTProvider).
+	profileName, known := config.STTSelectorProfile(sel)
+	if !known {
 		return nil, fmt.Errorf("unsupported transcriber provider %q", sel)
 	}
+	prof, err := r.ResolveExplicit(provider.CapSTT, profileName, true)
+	return build(prof, err)
 }
 
 // sttExpectedLanguage resolves the active STT provider profile's language tag
@@ -1004,16 +1003,14 @@ func resolveSTTProfile(cfg config.Config) (provider.Profile, bool) {
 		prof provider.Profile
 		err  error
 	)
-	switch sel {
-	case transcriberProviderMistral:
-		prof, err = r.ResolveExplicit(provider.CapSTT, "mistral-ocr", true)
-	case transcriberProviderElevenLabs:
-		prof, err = r.ResolveExplicit(provider.CapSTT, "elevenlabs", true)
-	case transcriberProviderWhisper:
-		prof, err = r.ResolveExplicit(provider.CapSTT, "whisper", true)
-	case transcriberProviderAuto:
+	if sel == transcriberProviderAuto {
 		prof, err = r.Resolve(provider.CapSTT)
-	default:
+	} else if profileName, known := config.STTSelectorProfile(sel); known {
+		// Shared selector->profile table (issue #440 F6): mistral/elevenlabs/
+		// whisper/openai/gemini all resolve here, matching the factory's support,
+		// instead of silently falling through to STT-off on this path.
+		prof, err = r.ResolveExplicit(provider.CapSTT, profileName, true)
+	} else {
 		return provider.Profile{}, false
 	}
 	if err != nil {

--- a/internal/providerfactory/factory.go
+++ b/internal/providerfactory/factory.go
@@ -175,6 +175,60 @@ func Embedder(p provider.Profile) (model.Embedder, error) {
 	}
 }
 
+// EffectiveEmbedModels returns the concrete text/code embed model ids an
+// Embedder built from p (see Embedder) will actually send on the wire,
+// resolving each empty profile field to the same adapter kind default the
+// client applies internally. Built-in profiles like `openai`/`cohere`/`local`/
+// `omniembed` ship WITHOUT an embed_text_model (SPEC 8.1.1), so their profile
+// fields are empty and the adapter substitutes its own default
+// (text-embedding-3-small for OpenAI, embed-v4.0 for Cohere, etc.).
+//
+// This is the single resolution point the CLI uses so the ingest embed worker
+// and the query-side retrieval embedder are handed BYTE-IDENTICAL model ids
+// (issue #440 F2). Previously each side passed the empty profile field and
+// relied on the adapter default independently, while retrieval also carried a
+// hardcoded "mistral-embed"/"codestral-embed" fallback — an ASYMMETRIC default
+// that, if ever reached, embeds the query in a foreign vector space from the
+// corpus and returns garbage hits. Resolving the concrete model here removes
+// the asymmetry by construction and gives per-query metrics a truthful model
+// label instead of an empty string.
+//
+// Note: EmbedIdentity (SPEC 8.1.4) is intentionally derived from the RAW
+// profile field, not this resolved value, so making the effective model
+// explicit here never flips a recorded identity or forces a spurious reindex.
+func EffectiveEmbedModels(p provider.Profile) (text, code string) {
+	def := kindDefaultEmbedModel(p.Kind)
+	text = strings.TrimSpace(p.EmbedTextModel)
+	if text == "" {
+		text = def
+	}
+	code = strings.TrimSpace(p.EmbedCodeModel)
+	if code == "" {
+		code = def
+	}
+	return text, code
+}
+
+// kindDefaultEmbedModel returns the embed model an adapter of kind k substitutes
+// when the profile leaves the model blank, mirroring the per-kind fallbacks in
+// Embedder and each client's Embed. Kinds with no embed capability (or none with
+// a defined default) return "" — the effective model is then just whatever the
+// profile carries.
+func kindDefaultEmbedModel(k provider.Kind) string {
+	switch k {
+	case provider.KindOpenAI:
+		return openai.DefaultEmbedModel
+	case provider.KindCohere:
+		return cohere.DefaultEmbedModel
+	case provider.KindGemini:
+		return gemini.DefaultEmbedModel
+	case provider.KindOmniEmbed:
+		return omniembed.DefaultModel
+	default:
+		return ""
+	}
+}
+
 // Generator builds a model.Generator (kinds: openai, gemini, cohere,
 // anthropic).
 func Generator(p provider.Profile) (model.Generator, error) {

--- a/tests/ingest/stt_selector_440_test.go
+++ b/tests/ingest/stt_selector_440_test.go
@@ -1,0 +1,91 @@
+package tests
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+)
+
+// TestSTTExplicit_GeminiResolvesProfile pins issue #440 F6: an explicit
+// stt_provider=gemini must resolve the built-in `gemini` profile (which
+// providerfactory.Transcriber supports) instead of silently resolving STT-off.
+// Before unifying the selector tables, `gemini`/`openai` were mapped by NEITHER
+// resolveSTTProfile NOR the diarization-gating resolver, so the provider was
+// reported as absent while transcription would have errored loudly at first use.
+func TestSTTExplicit_GeminiResolvesProfile(t *testing.T) {
+	t.Setenv("GEMINI_API_KEY", "gk")
+	cfg := config.Default()
+	cfg.STTProvider = "gemini"
+
+	name, _, ok := ingest.ResolveSTTProviderModel(cfg)
+	if !ok {
+		t.Fatal("expected explicit stt_provider=gemini to resolve an STT profile, not silently resolve STT-off")
+	}
+	if name != "gemini" {
+		t.Fatalf("explicit gemini STT resolved profile = %q, want gemini", name)
+	}
+
+	tr, err := ingest.TranscriberFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("build gemini transcriber: unexpected error %v", err)
+	}
+	if tr == nil {
+		t.Fatal("expected a non-nil gemini transcriber for an explicit stt_provider=gemini selector")
+	}
+}
+
+// TestSTTExplicit_OpenAIResolvesProfile pins issue #440 F6 for the OpenAI STT
+// selector: kind:openai STT is EndpointDependent (validated at first use), but
+// an explicit selector must still resolve the `openai` profile and build a
+// transcriber rather than resolve STT-off.
+func TestSTTExplicit_OpenAIResolvesProfile(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "ok")
+	cfg := config.Default()
+	cfg.STTProvider = "openai"
+
+	name, _, ok := ingest.ResolveSTTProviderModel(cfg)
+	if !ok {
+		t.Fatal("expected explicit stt_provider=openai to resolve an STT profile, not silently resolve STT-off")
+	}
+	if name != "openai" {
+		t.Fatalf("explicit openai STT resolved profile = %q, want openai", name)
+	}
+
+	tr, err := ingest.TranscriberFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("build openai transcriber: unexpected error %v", err)
+	}
+	if tr == nil {
+		t.Fatal("expected a non-nil openai transcriber for an explicit stt_provider=openai selector")
+	}
+}
+
+// TestSTTSelector_UnknownFailsValidateFast pins issue #440 F6: an unknown /
+// unmappable stt.provider selector must fail fast at startup with CONFIG_INVALID
+// rather than silently disabling STT on the resolver paths.
+func TestSTTSelector_UnknownFailsValidateFast(t *testing.T) {
+	cfg := config.Default()
+	cfg.STTProvider = "definitely-not-a-backend"
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected cfg.Validate() to reject an unknown stt.provider selector")
+	}
+	if !strings.Contains(err.Error(), "CONFIG_INVALID") || !strings.Contains(err.Error(), "stt.provider") {
+		t.Fatalf("expected a CONFIG_INVALID stt.provider error, got: %v", err)
+	}
+}
+
+// TestSTTSelector_KnownAndOffPassValidate guards against over-rejection: every
+// recognized selector (plus auto/off/empty) must pass config validation.
+func TestSTTSelector_KnownAndOffPassValidate(t *testing.T) {
+	for _, sel := range []string{"", "auto", "off", "none", "disabled", "mistral", "elevenlabs", "whisper", "openai", "gemini", "GEMINI"} {
+		cfg := config.Default()
+		cfg.STTProvider = sel
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("stt.provider=%q should pass validation, got: %v", sel, err)
+		}
+	}
+}

--- a/tests/providerfactory/effective_embed_models_440_test.go
+++ b/tests/providerfactory/effective_embed_models_440_test.go
@@ -1,0 +1,75 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/cohere"
+	"github.com/dirstral/dir2mcp/internal/gemini"
+	"github.com/dirstral/dir2mcp/internal/omniembed"
+	"github.com/dirstral/dir2mcp/internal/openai"
+	"github.com/dirstral/dir2mcp/internal/provider"
+	"github.com/dirstral/dir2mcp/internal/providerfactory"
+)
+
+// TestEffectiveEmbedModels_EmptyProfileResolvesKindDefault pins issue #440 F2:
+// built-in embed profiles (openai/cohere/local/omniembed) ship WITHOUT an
+// embed_text_model, so the profile fields are empty. The ingest embed worker and
+// the query-side retrieval embedder must both send the SAME concrete model — the
+// adapter kind default — not an empty string on one side and a stale
+// "mistral-embed" fallback on the other (which would embed the query in a foreign
+// vector space from the corpus). EffectiveEmbedModels is the single resolution
+// point both sides derive from, so this asserts it returns exactly the model each
+// adapter substitutes internally when the profile leaves it blank.
+func TestEffectiveEmbedModels_EmptyProfileResolvesKindDefault(t *testing.T) {
+	cases := []struct {
+		name     string
+		kind     provider.Kind
+		wantText string
+		wantCode string
+	}{
+		{"openai", provider.KindOpenAI, openai.DefaultEmbedModel, openai.DefaultEmbedModel},
+		{"cohere", provider.KindCohere, cohere.DefaultEmbedModel, cohere.DefaultEmbedModel},
+		{"omniembed", provider.KindOmniEmbed, omniembed.DefaultModel, omniembed.DefaultModel},
+		{"gemini", provider.KindGemini, gemini.DefaultEmbedModel, gemini.DefaultEmbedModel},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// An empty-model built-in profile: only Kind set (openai/local both
+			// use kind:openai — the local profile is exactly this shape).
+			p := provider.Profile{Name: tc.name, Kind: tc.kind}
+			text, code := providerfactory.EffectiveEmbedModels(p)
+			if text != tc.wantText {
+				t.Errorf("effective embed text model = %q, want %q (adapter kind default)", text, tc.wantText)
+			}
+			if code != tc.wantCode {
+				t.Errorf("effective embed code model = %q, want %q (adapter kind default)", code, tc.wantCode)
+			}
+			if text == "" {
+				t.Error("effective embed text model is empty; the query side would fall back to the stale mistral-embed default and diverge from ingest (#440 F2)")
+			}
+			if text == "mistral-embed" {
+				t.Errorf("effective embed model resolved to the Mistral default %q for kind %q; that is the asymmetric wrong-provider bug #440 F2 fixes", text, tc.kind)
+			}
+		})
+	}
+}
+
+// TestEffectiveEmbedModels_ExplicitProfileWins confirms a profile that DOES carry
+// an embed model (e.g. the built-in mistral profile: kind:openai +
+// mistral-embed/codestral-embed) is returned verbatim, so unifying on the kind
+// default never overrides an operator's explicit model.
+func TestEffectiveEmbedModels_ExplicitProfileWins(t *testing.T) {
+	p := provider.Profile{
+		Name:           "mistral",
+		Kind:           provider.KindOpenAI,
+		EmbedTextModel: "mistral-embed",
+		EmbedCodeModel: "codestral-embed",
+	}
+	text, code := providerfactory.EffectiveEmbedModels(p)
+	if text != "mistral-embed" {
+		t.Errorf("effective embed text model = %q, want mistral-embed (explicit profile field)", text)
+	}
+	if code != "codestral-embed" {
+		t.Errorf("effective embed code model = %q, want codestral-embed (explicit profile field)", code)
+	}
+}


### PR DESCRIPTION
## Summary

Addresses **#440 (F2 query-side embed model divergence, F6 STT selector unification)**; **F3 remains, spec-gated #560**. F1/F4/F5 already landed in #559 and are untouched here. Part of a parallel backlog wave.

### F2 [HIGH] Query-side embed model diverges from ingest for empty-model built-in profiles
Built-in `openai`/`cohere`/`local`/`omniembed` embed profiles ship without an `embed_text_model`, so the profile field is empty. Ingest and the query-side retrieval embedder each passed that empty field and relied on the adapter default *independently*, while retrieval also carried a hardcoded `mistral-embed`/`codestral-embed` fallback — an **asymmetric default** that, if ever reached, embeds the query in a foreign vector space from the corpus and returns garbage hits.

**Fix:** new `providerfactory.EffectiveEmbedModels(p)` resolves the concrete model an adapter of the profile's kind actually sends (the kind default — `text-embedding-3-small` for OpenAI, `embed-v4.0` for Cohere, etc. — when the field is blank). `resolveModelClients` now hands that **byte-identical** value to both the ingest embed worker and `SetQueryEmbeddingModel`, so the two can never diverge, and per-query metrics get a truthful model label instead of an empty string.

`EmbedIdentity` (SPEC 8.1.4) is intentionally still derived from the **raw** profile field, so making the effective model explicit never flips a recorded identity or forces a spurious reindex (that's F3 territory, out of scope).

### F6 [MED] Unknown/unmapped STT selector → divergent resolvers, silent STT-off
An explicit `stt_provider: gemini`/`openai` (both buildable by `providerfactory.Transcriber`) resolved through three divergent tables that mapped only `mistral`/`elevenlabs`/`whisper`: it errored loudly at first transcription but **silently resolved STT-off** for expected-language, derivation identity, and diarization gating. Unknown selectors had no startup validation.

**Fix:** a single shared `config.STTSelectorProfile` table backs all three resolvers (`ingest.TranscriberFromConfigWithLanguage`, `ingest.resolveSTTProfile`, `config.resolveSTTProfileForCapability`), so `mistral`/`elevenlabs`/`whisper`/`openai`/`gemini` resolve consistently everywhere. `config.Validate` now rejects an unknown/unmappable selector with `CONFIG_INVALID` at startup rather than silently disabling STT. Kept general-purpose (no vendor-specific hacks).

## Tests
- `tests/providerfactory/effective_embed_models_440_test.go`: effective embed model == the adapter kind default for empty built-in profiles (openai/cohere/omniembed/gemini), and an explicit profile model (mistral → mistral-embed/codestral-embed) is returned verbatim.
- `tests/ingest/stt_selector_440_test.go`: explicit `gemini`/`openai` resolve their profiles and build a transcriber; an unknown selector fails `Validate` with `CONFIG_INVALID`; all known selectors plus `auto`/`off`/empty pass.

Both broken behaviors were reproduced against `main` before fixing (gemini selector: `ResolveSTTProviderModel` ok=false + `unsupported transcriber provider "gemini"` at build; unknown selector: `Validate()` returned nil).

## Notes
- `Config.Validate`'s straight-line if-chain was refactored to a loop over validators to stay under the cyclomatic-complexity budget after adding the STT gate; behavior (order + short-circuit) is unchanged.
- `make check` is all-pass except the pre-existing, unrelated `TestSpecYAMLSecretPatterns_Compile_JWTAndBearer`, which requires the `dirstral-spec` submodule (not checked out in this worktree; green in CI).
