### PR TITLE
fix(ingest): record lenient unsupported-format skip durably (#584)

### DIFF
--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -572,16 +572,19 @@ func (s *Service) SetOnUnsupported(mode string) {
 // read it and never lets the gap be silent:
 //
 //   - strict: a non-fatal per-document UNSUPPORTED_FORMAT error (§7.7) —
-//     documents.status=error, the error counter is bumped, and the caller is told
-//     (nonFatalErrored) not to also credit the document as indexed (#426).
-//   - lenient (default): skip-with-warning — no extracted_markdown is produced,
-//     the document keeps whatever other representations it has, and the gap is
-//     logged and recorded in the in-run skip counter so `status`/`reindex` and the
-//     honest coverage report (§7.7) name it. The document is still indexed.
+//     documents.status=error, the error counter is bumped, a file_error fires.
+//   - lenient (default): a **durable skip** (§7.4.B.2, #584) — documents.status=
+//     skipped with an unsupported-format skip_reason, the skipped counter is bumped,
+//     and a file_skip fires. The document is NOT indexed (it has no searchable
+//     representation), so the coverage report (§7.7) names it durably — after a
+//     restart, not just via an in-run counter — instead of leaving it status="ok"
+//     (an unsearchable document mislabeled as indexed, the gap #584 closed).
 //
-// It returns whether the strict path recorded a non-fatal error (so the caller
-// can propagate the #426 no-double-count signal).
-func (s *Service) degradeUnsupportedExtraction(ctx context.Context, doc model.Document, secretPatterns []*regexp.Regexp) (nonFatalErrored bool) {
+// In BOTH modes the returned suppressCredit is true: the caller must not also
+// credit the document as indexed (#426), because it is now recorded as either an
+// error or a skip. (The error-vs-skip counting is done here, not by the caller, so
+// returning true never double-counts.)
+func (s *Service) degradeUnsupportedExtraction(ctx context.Context, doc model.Document, secretPatterns []*regexp.Regexp) (suppressCredit bool) {
 	cause := unsupportedExtractionErr(doc.RelPath, s.extractorLabel())
 	if s.onUnsupported == onUnsupportedStrict {
 		s.getLogger().Printf("unsupported format (strict) for %s (%s): %v", doc.RelPath, doc.DocType, cause)
@@ -589,12 +592,14 @@ func (s *Service) degradeUnsupportedExtraction(ctx context.Context, doc model.Do
 		s.persistNonFatalDocError(ctx, doc, cause, secretPatterns)
 		return true
 	}
-	// lenient: honest skip, not an error. The document remains status="ok" with
-	// whatever other representations it has; the coverage report (§7.7) and the
-	// in-run skip counter name the uncovered format so it is never silent.
-	s.getLogger().Printf("unsupported format (lenient, skipped) for %s (%s): %v", doc.RelPath, doc.DocType, cause)
-	s.addRunSkipReason(model.SkipReasonUnsupportedFormat)
-	return false
+	// lenient: a durable, honest skip — not status="ok". This path is reached only
+	// when no active engine can read the format AND no media chunks were produced,
+	// so the document is genuinely unsearchable; record it as status="skipped" so
+	// the coverage aggregate (§7.7) and a file_skip name it durably (#584).
+	s.getLogger().Printf("unsupported format (lenient, durable skip) for %s (%s): %v", doc.RelPath, doc.DocType, cause)
+	s.addSkipped(1)
+	s.persistNonFatalDocSkip(ctx, doc, model.SkipReasonUnsupportedFormat)
+	return true
 }
 
 type documentDeleteMarker interface {
@@ -3000,10 +3005,11 @@ func (s *Service) generateRepresentations(ctx context.Context, doc model.Documen
 		return false, err
 	}
 	if nonFatalErrored {
-		// #394: the extractor path persisted the document as status="error" (an
-		// unsupported format) and counted it as an error itself. A pdf/image/document
-		// asset has no transcript path, so return the soft-error signal now — the
-		// caller must not also credit it as indexed (issue #426).
+		// #394/#584: the extractor degraded an unsupported format and already
+		// recorded it — as status="error" (strict) or a durable status="skipped"
+		// (lenient) — counting it as an error or a skip itself. A pdf/image/document
+		// asset has no transcript path, so propagate the suppress-credit signal now:
+		// the caller must not also credit it as indexed (issue #426).
 		return true, nil
 	}
 	// In `replace`, direct media embedding stands in for STT→text, so skip the
@@ -3207,6 +3213,27 @@ func (s *Service) persistNonFatalDocError(ctx context.Context, doc model.Documen
 		s.getLogger().Printf("persist error status for %s: %v", doc.RelPath, err)
 	}
 	s.notifyDocumentError(doc)
+}
+
+// persistNonFatalDocSkip records a lenient §7.4.B.2 unsupported-format degradation
+// as a DURABLE skip so the coverage gap survives the run that produced it (#584).
+// A document no active extractor can read AND that produced no other searchable
+// representation is recorded as documents.status="skipped" with the given
+// skip_reason, so CorpusStats.SkipSummary — which aggregates status="skipped" rows
+// — names it after a restart, not only via the in-run counter, and a file_skip
+// event fires. Without it the document stayed status="ok": an unsearchable
+// document mislabeled as indexed, invisible to the coverage report once its run
+// ended. The upsert error is logged and swallowed (mirroring persistNonFatalDocError);
+// the live skipped counter is incremented separately by the caller. The skip event
+// still fires even if the upsert failed — the stream event is the only signal a
+// `--json` consumer will see for it.
+func (s *Service) persistNonFatalDocSkip(ctx context.Context, doc model.Document, reason string) {
+	doc.Status = "skipped"
+	doc.SkipReason = reason
+	if err := s.store.UpsertDocument(ctx, doc); err != nil {
+		s.getLogger().Printf("persist skipped status for %s: %v", doc.RelPath, err)
+	}
+	s.notifyDocumentSkip(doc)
 }
 
 // notifyDocumentError invokes the registered per-document error callback with

--- a/tests/ingest/extractor_routing_394_test.go
+++ b/tests/ingest/extractor_routing_394_test.go
@@ -64,22 +64,44 @@ func TestUnsupportedImage_StrictSurfacesError(t *testing.T) {
 	}
 }
 
-// TestUnsupportedDocument_LenientSkipsHonestly is the #395 Stage 3 guard for the
-// lenient DEFAULT (ingest.on_unsupported=lenient): an unsupported .odt is NOT a
-// per-document error — the document is indexed with whatever representations it has
-// (none here) and the coverage gap is recorded in the in-run skip counter so
-// status/reindex and the honest coverage report name it (§7.4.B.2 / §7.7). The key
-// property versus the pre-#395 behavior is that it is honest, not silent: the skip
-// reason is counted rather than the format being handed to an engine that can't
-// read it.
+// TestUnsupportedDocument_LenientSkipsHonestly is the #584 guard for the lenient
+// DEFAULT (ingest.on_unsupported=lenient): an unsupported .odt with no searchable
+// representation is NOT a per-document error, and NOT left status="ok" (which
+// mislabeled an unsearchable document as indexed). It is recorded as a DURABLE
+// skip — status="skipped" with an unsupported-format skip_reason — so the coverage
+// gap survives the run that produced it and status/reindex name it after a restart
+// (§7.4.B.2 / §7.7). The document is re-read from the store here, so a persisted
+// skip proves the durability property.
 func TestUnsupportedDocument_LenientSkipsHonestly(t *testing.T) {
-	doc, svc := processWithFlatExtractor(t, "notes.odt", "") // empty = lenient default
-	if doc.Status == "error" {
-		t.Fatalf("unsupported .odt (lenient) status = %q, want a non-error status (lenient skips, not errors)", doc.Status)
+	doc, _ := processWithFlatExtractor(t, "notes.odt", "") // empty = lenient default
+	if doc.Status != "skipped" {
+		t.Fatalf("unsupported .odt (lenient) status = %q, want \"skipped\" (durable skip, not ok/error) (#584)", doc.Status)
 	}
-	counts := svc.SkipReasonCounts()
-	if counts[model.SkipReasonUnsupportedFormat] == 0 {
-		t.Errorf("lenient skip did not record an unsupported_format skip reason; counts=%v", counts)
+	if doc.SkipReason != model.SkipReasonUnsupportedFormat {
+		t.Errorf("skip_reason = %q, want %q so the coverage aggregate names it", doc.SkipReason, model.SkipReasonUnsupportedFormat)
+	}
+}
+
+// TestUnsupportedDocument_LenientFiresFileSkip is the streaming half of #584: a
+// lenient unsupported-format skip must emit a per-document file_skip event (via the
+// SetOnDocumentSkip hook) carrying the unsupported_format reason, so a `--json`
+// consumer learns the document was left uncovered — not only the durable status.
+func TestUnsupportedDocument_LenientFiresFileSkip(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "notes.odt"), "irrelevant bytes")
+	st := newRealStore(t)
+	svc := mustNewIngestService(t, config.Config{RootDir: root, StateDir: t.TempDir()}, st) // lenient default
+	svc.SetDocumentExtractor(&fakeExtractor{text: "should never be extracted"})
+
+	var gotPath, gotReason string
+	svc.SetOnDocumentSkip(func(relPath, _docType, reason string) { gotPath, gotReason = relPath, reason })
+
+	f := ingest.DiscoveredFile{RelPath: "notes.odt", SizeBytes: 16, MTimeUnix: time.Now().Unix()}
+	if err := svc.ProcessDocument(context.Background(), f, nil, false); err != nil {
+		t.Fatalf("ProcessDocument: %v", err)
+	}
+	if gotPath != "notes.odt" || gotReason != model.SkipReasonUnsupportedFormat {
+		t.Errorf("file_skip event = (%q, %q), want (\"notes.odt\", %q)", gotPath, gotReason, model.SkipReasonUnsupportedFormat)
 	}
 }
 


### PR DESCRIPTION
Closes #584. The honest-coverage capstone under the #395 umbrella. Gated on the now-merged dirstral-spec **#39** (SPEC 0.32.0 §7.4.B.2; re-pinned here `508b0c9` → `2510f5c`).

## The gap

Under `ingest.on_unsupported=lenient` (the **default**), a document that no active extractor can read **and** that produced no other searchable representation was left at durable `status=ok` — indistinguishable in the store from a genuinely indexed document. The only trace was an *in-run, non-persisted* skip counter (`addRunSkipReason`), so the coverage signal existed during the producing run and then **evaporated**: no `file_skip` on the stream, and `unsupported_format=0` in `status`/`reindex` after a restart or incremental re-run.

## The fix

`degradeUnsupportedExtraction`'s lenient branch now records a **durable skip** instead of leaving `status=ok`:
- new `persistNonFatalDocSkip` → `documents.status=skipped` + `skip_reason=unsupported_format`
- `addSkipped(1)` counts it toward `indexing.skipped`
- a per-document `file_skip` event fires (`notifyDocumentSkip`)
- returns the suppress-credit signal so the doc is **not** also credited as indexed (#426)

`CorpusStats.SkipSummary` aggregates `status=skipped` rows, so the gap is now named **durably** — after a restart — not only via the in-run counter. The error-vs-skip counting is done inside the function, so returning the suppress-credit bool never double-counts.

## Scope / invariants

- **Strict mode unchanged** (`status=error` + `file_error`).
- Preserves the `file_skip`/`file_error` partition (df-009): a lenient-unsupported doc now joins the skipped set, `#file_skip == indexing.skipped`.
- The not-indexed *outcome* is unchanged — the document was never searchable; it is now recorded honestly rather than mislabeled `status=ok`. A corpus re-indexed on this reclassifies such docs ok→skipped on their next pass.

## Tests

`TestUnsupportedDocument_LenientSkipsHonestly` updated to assert the durable `status=skipped` + `skip_reason` (re-read from the store, proving durability); new `TestUnsupportedDocument_LenientFiresFileSkip` asserts the `file_skip` event fires with the unsupported-format reason. Strict-path tests unchanged. `make check` green.

Note: this re-pin also carries dirstral-spec **#40** (the #326 date-filter spec); the #326 *code* is a separate follow-up PR.