### PR TITLE
feat(retrieval,mcp): date/time-range filter facet on search & ask (#326)

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -16,6 +16,7 @@ import (
 	"runtime/debug"
 	"sort"
 	"strings"
+	"time"
 	"unicode/utf8"
 
 	"github.com/dirstral/dir2mcp/internal/avutil"
@@ -749,7 +750,7 @@ func isResolvableSourceWithRoot(doc model.Document, rootAbs, rootReal string) bo
 
 func (s *Server) handleSearchTool(ctx context.Context, args map[string]interface{}) (toolCallResult, *toolExecutionError) {
 	if err := assertNoUnknownArguments(args, map[string]struct{}{
-		"query": {}, "k": {}, "index": {}, "path_prefix": {}, "file_glob": {}, "doc_types": {}, "speaker": {}, "languages": {}, "language_match": {},
+		"query": {}, "k": {}, "index": {}, "path_prefix": {}, "file_glob": {}, "doc_types": {}, "speaker": {}, "languages": {}, "language_match": {}, "date_from": {}, "date_to": {},
 	}); err != nil {
 		return toolCallResult{}, &toolExecutionError{Code: "INVALID_FIELD", Message: err.Error(), Retryable: false}
 	}
@@ -784,11 +785,15 @@ func (s *Server) handleSearchTool(ctx context.Context, args map[string]interface
 	if toolErr != nil {
 		return toolCallResult{}, toolErr
 	}
+	dateFrom, dateTo, toolErr := parseDateWindow(args)
+	if toolErr != nil {
+		return toolCallResult{}, toolErr
+	}
 	if s.retriever == nil {
 		return toolCallResult{}, &toolExecutionError{Code: protocol.ErrorCodeIndexNotReady, Message: "retriever not configured", Retryable: false}
 	}
 	sq := model.SearchQuery{
-		Query: query, K: k, Index: indexName, PathPrefix: pathPrefix, FileGlob: fileGlob, DocTypes: docTypes, Speaker: speaker, Languages: languages, LanguageMatch: languageMatch,
+		Query: query, K: k, Index: indexName, PathPrefix: pathPrefix, FileGlob: fileGlob, DocTypes: docTypes, Speaker: speaker, Languages: languages, LanguageMatch: languageMatch, DateFrom: dateFrom, DateTo: dateTo,
 	}
 	// index_used MUST be the index the query was actually routed to (SPEC §15.2),
 	// not the requested name. Prefer AxisSearcher so the reported axis is read back
@@ -855,7 +860,7 @@ func normalizeIndexAxis(axis string) string {
 
 func (s *Server) handleAskTool(ctx context.Context, args map[string]interface{}) (toolCallResult, *toolExecutionError) {
 	if err := assertNoUnknownArguments(args, map[string]struct{}{
-		"question": {}, "k": {}, "mode": {}, "index": {}, "path_prefix": {}, "file_glob": {}, "doc_types": {}, "languages": {}, "language_match": {},
+		"question": {}, "k": {}, "mode": {}, "index": {}, "path_prefix": {}, "file_glob": {}, "doc_types": {}, "languages": {}, "language_match": {}, "date_from": {}, "date_to": {},
 	}); err != nil {
 		return toolCallResult{}, &toolExecutionError{Code: "INVALID_FIELD", Message: err.Error(), Retryable: false}
 	}
@@ -890,10 +895,14 @@ func (s *Server) handleAskTool(ctx context.Context, args map[string]interface{})
 	if toolErr != nil {
 		return toolCallResult{}, toolErr
 	}
+	dateFrom, dateTo, toolErr := parseDateWindow(args)
+	if toolErr != nil {
+		return toolCallResult{}, toolErr
+	}
 	if s.retriever == nil {
 		return toolCallResult{}, &toolExecutionError{Code: protocol.ErrorCodeIndexNotReady, Message: "retriever not configured", Retryable: false}
 	}
-	sq := model.SearchQuery{Query: question, K: k, Index: indexName, PathPrefix: pathPrefix, FileGlob: fileGlob, DocTypes: docTypes, Languages: languages, LanguageMatch: languageMatch}
+	sq := model.SearchQuery{Query: question, K: k, Index: indexName, PathPrefix: pathPrefix, FileGlob: fileGlob, DocTypes: docTypes, Languages: languages, LanguageMatch: languageMatch, DateFrom: dateFrom, DateTo: dateTo}
 	if mode == "search_only" {
 		return s.runSearchOnlyMode(ctx, question, sq)
 	}
@@ -1852,6 +1861,69 @@ func parseLanguageMatchArg(args map[string]interface{}) (string, *toolExecutionE
 		}
 	}
 	return mode, nil
+}
+
+// parseDateBound parses an optional document-date window bound (SPEC §9.6). The
+// value may be an RFC 3339 timestamp (2026-04-01T00:00:00Z) or a bare YYYY-MM-DD
+// date interpreted in UTC. An absent or empty value yields (0, nil) — an open
+// bound. A bare date resolves to the start of that UTC day (00:00:00Z), or, when
+// endOfDay is set, to the last whole second of that day (23:59:59Z) so a bare
+// date_to bound is inclusive of the entire named day. A value that parses as
+// neither form is an INVALID_FIELD error (df-008). The returned value is Unix
+// seconds.
+func parseDateBound(args map[string]interface{}, key string, endOfDay bool) (int64, *toolExecutionError) {
+	raw, ok := args[key]
+	if !ok {
+		return 0, nil
+	}
+	value, ok := raw.(string)
+	if !ok {
+		return 0, &toolExecutionError{Code: "INVALID_FIELD", Message: fmt.Sprintf("%s must be a string", key), Retryable: false}
+	}
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, nil
+	}
+	if t, err := time.Parse(time.RFC3339, value); err == nil {
+		return t.Unix(), nil
+	}
+	if t, err := time.Parse("2006-01-02", value); err == nil {
+		if endOfDay {
+			// Inclusive upper bound: the last whole second of the named UTC day.
+			t = t.Add(24*time.Hour - time.Second)
+		}
+		return t.Unix(), nil
+	}
+	return 0, &toolExecutionError{
+		Code:      "INVALID_FIELD",
+		Message:   fmt.Sprintf("%s must be an RFC 3339 timestamp or a YYYY-MM-DD date, got %q", key, value),
+		Retryable: false,
+	}
+}
+
+// parseDateWindow parses the optional date_from/date_to arguments into an
+// inclusive [from, to] window in Unix seconds (SPEC §9.6). Absent bounds are 0
+// (open on that side). date_from anchors to the start of its day and date_to to
+// the end of its day (see parseDateBound). An inverted window (from after to) is
+// an INVALID_FIELD error (df-008); a window that simply matches nothing is left
+// to retrieval to return as an empty result, not an error.
+func parseDateWindow(args map[string]interface{}) (dateFrom, dateTo int64, toolErr *toolExecutionError) {
+	dateFrom, toolErr = parseDateBound(args, "date_from", false)
+	if toolErr != nil {
+		return 0, 0, toolErr
+	}
+	dateTo, toolErr = parseDateBound(args, "date_to", true)
+	if toolErr != nil {
+		return 0, 0, toolErr
+	}
+	if dateFrom > 0 && dateTo > 0 && dateFrom > dateTo {
+		return 0, 0, &toolExecutionError{
+			Code:      "INVALID_FIELD",
+			Message:   "date_from must not be after date_to",
+			Retryable: false,
+		}
+	}
+	return dateFrom, dateTo, nil
 }
 
 // mapSearchError converts a search/ask error into a toolExecutionError.
@@ -3037,6 +3109,14 @@ func searchInputSchema() map[string]interface{} {
 				"default":     "primary",
 				"description": "Optional (SPEC §9.5): matching mode for languages. 'primary' (default) matches on the BCP-47 primary subtag (pt-BR matches pt); 'strict' opts into RFC 4647 region/script narrowing (pt-BR matches pt-BR/pt-BR-… but not bare pt or pt-PT).",
 			},
+			"date_from": map[string]interface{}{
+				"type":        "string",
+				"description": "Optional (SPEC §9.6): restrict hits to documents whose date (mtime) is on or after this bound (inclusive). Accepts an RFC 3339 timestamp (2026-04-01T00:00:00Z) or a bare YYYY-MM-DD date (start of that UTC day). Absent = open lower bound.",
+			},
+			"date_to": map[string]interface{}{
+				"type":        "string",
+				"description": "Optional (SPEC §9.6): restrict hits to documents whose date (mtime) is on or before this bound (inclusive). Accepts an RFC 3339 timestamp or a bare YYYY-MM-DD date (end of that UTC day, 23:59:59Z). Absent = open upper bound.",
+			},
 		},
 		"required": []string{"query"},
 	}
@@ -3080,6 +3160,14 @@ func askInputSchema() map[string]interface{} {
 				"enum":        []string{"primary", "strict"},
 				"default":     "primary",
 				"description": "Optional (SPEC §9.5): matching mode for languages. 'primary' (default) matches on the BCP-47 primary subtag (pt-BR matches pt); 'strict' opts into RFC 4647 region/script narrowing (pt-BR matches pt-BR/pt-BR-… but not bare pt or pt-PT).",
+			},
+			"date_from": map[string]interface{}{
+				"type":        "string",
+				"description": "Optional (SPEC §9.6): restrict retrieved contexts to documents whose date (mtime) is on or after this bound (inclusive). Accepts an RFC 3339 timestamp (2026-04-01T00:00:00Z) or a bare YYYY-MM-DD date (start of that UTC day). Absent = open lower bound.",
+			},
+			"date_to": map[string]interface{}{
+				"type":        "string",
+				"description": "Optional (SPEC §9.6): restrict retrieved contexts to documents whose date (mtime) is on or before this bound (inclusive). Accepts an RFC 3339 timestamp or a bare YYYY-MM-DD date (end of that UTC day, 23:59:59Z). Absent = open upper bound.",
 			},
 		},
 		"required": []string{"question"},

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -432,6 +432,14 @@ type SearchQuery struct {
 	// default ("" ⇒ LanguageMatchPrimary) or opt-in region/script narrowing
 	// (LanguageMatchStrict). Inert unless Languages is non-empty.
 	LanguageMatch string
+	// DateFrom / DateTo optionally restrict hits to a document-date window (SPEC
+	// §9.6), compared against each candidate's source-document calendar anchor
+	// (mtime_unix). Both are Unix seconds and both bounds are inclusive; 0 means
+	// open on that side (absent bound). A candidate with an unknown mtime (0)
+	// never matches a window that sets either bound. Both-zero disables the
+	// filter (unchanged behavior). Callers validate DateFrom <= DateTo upstream.
+	DateFrom int64
+	DateTo   int64
 }
 
 type SearchHit struct {
@@ -455,6 +463,12 @@ type SearchHit struct {
 	// is NOT serialized into the tool result (the §9.2 hit structure is
 	// unchanged); empty means unknown.
 	Language string
+	// MTimeUnix is the source document's calendar anchor (its modification time,
+	// Unix seconds), denormalized onto the hit so the date/time-range retrieval
+	// filter (SPEC §9.6) can predicate on candidates without a store lookup —
+	// mirroring Language above. It is internal to retrieval and is NOT serialized
+	// into the tool result (the §9.2 hit structure is unchanged); 0 means unknown.
+	MTimeUnix int64
 }
 
 type ChunkMetadata struct {
@@ -471,6 +485,10 @@ type ChunkMetadata struct {
 	// representation (SPEC §5.2/§8.8), denormalized from representation meta_json
 	// at chunk insert so retrieval can apply the per-language filter (§9.5).
 	Language string
+	// MTimeUnix is the source document's calendar anchor (its modification time,
+	// Unix seconds), carried alongside the chunk so ToSearchHit can surface it to
+	// the date/time-range retrieval filter (SPEC §9.6). 0 means unknown.
+	MTimeUnix int64
 }
 
 // ToSearchHit converts the lightweight chunk metadata back into a full
@@ -478,16 +496,17 @@ type ChunkMetadata struct {
 // SearchHit values but chunk tasks only need a subset of fields.
 func (m ChunkMetadata) ToSearchHit() SearchHit {
 	return SearchHit{
-		ChunkID:  m.ChunkID,
-		RelPath:  m.RelPath,
-		Title:    m.Title,
-		DocType:  m.DocType,
-		RepType:  m.RepType,
-		Snippet:  m.Snippet,
-		Span:     m.Span,
-		Modality: m.Modality,
-		MediaRef: m.MediaRef,
-		Language: m.Language,
+		ChunkID:   m.ChunkID,
+		RelPath:   m.RelPath,
+		Title:     m.Title,
+		DocType:   m.DocType,
+		RepType:   m.RepType,
+		Snippet:   m.Snippet,
+		Span:      m.Span,
+		Modality:  m.Modality,
+		MediaRef:  m.MediaRef,
+		Language:  m.Language,
+		MTimeUnix: m.MTimeUnix,
 	}
 }
 

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -3552,17 +3552,8 @@ func matchFilters(hit model.SearchHit, query model.SearchQuery) bool {
 		}
 	}
 
-	if len(query.DocTypes) > 0 {
-		docTypeMatch := false
-		for _, docType := range query.DocTypes {
-			if strings.EqualFold(strings.TrimSpace(docType), strings.TrimSpace(hit.DocType)) {
-				docTypeMatch = true
-				break
-			}
-		}
-		if !docTypeMatch {
-			return false
-		}
+	if !docTypeMatches(query.DocTypes, hit.DocType) {
+		return false
 	}
 
 	// Optional speaker filter (SPEC §8.6.8/§15.2): restrict to time-spanned
@@ -3591,6 +3582,54 @@ func matchFilters(hit model.SearchHit, query model.SearchQuery) bool {
 		}
 	}
 
+	// Optional document-date window (SPEC §9.6): restrict to candidates whose
+	// source document's calendar anchor (mtime_unix) falls within the inclusive
+	// [date_from, date_to] window. Applied here at candidate selection — before
+	// cross-file de-dup, reranking, and truncation to k — so it only removes
+	// out-of-window candidates and never reorders or changes the result/citation
+	// structure, and k still counts only in-window hits.
+	if !withinDateWindow(hit.MTimeUnix, query.DateFrom, query.DateTo) {
+		return false
+	}
+
+	return true
+}
+
+// docTypeMatches reports whether hitDocType is a member of the requested doc-type
+// set (case-insensitive, trimmed). An empty set disables the predicate (a no-op
+// match), mirroring the other additive filters.
+func docTypeMatches(docTypes []string, hitDocType string) bool {
+	if len(docTypes) == 0 {
+		return true
+	}
+	for _, docType := range docTypes {
+		if strings.EqualFold(strings.TrimSpace(docType), strings.TrimSpace(hitDocType)) {
+			return true
+		}
+	}
+	return false
+}
+
+// withinDateWindow reports whether a candidate's document date (mtime, in Unix
+// seconds) falls within the inclusive [from, to] window (SPEC §9.6). Each bound is
+// optional: 0 means open on that side, and a both-open window matches every
+// candidate (the additive, off-by-default no-op). A candidate with an unknown
+// mtime (0) never matches a window that sets either bound — mirroring the
+// unknown-language rule (§8.8/§9.5) that an absent anchor never satisfies a
+// specific filter.
+func withinDateWindow(mtime, from, to int64) bool {
+	if from == 0 && to == 0 {
+		return true
+	}
+	if mtime <= 0 {
+		return false
+	}
+	if from != 0 && mtime < from {
+		return false
+	}
+	if to != 0 && mtime > to {
+		return false
+	}
 	return true
 }
 

--- a/internal/store/sqlite_bm25.go
+++ b/internal/store/sqlite_bm25.go
@@ -54,7 +54,7 @@ func (s *SQLiteStore) SearchBM25(ctx context.Context, query string, k int, index
 
 	args := []any{matchExpr}
 	stmt := `SELECT c.chunk_id, c.rel_path, c.doc_type, c.rep_type, c.text, c.language,
-	                COALESCE(d.title, ''),
+	                COALESCE(d.title, ''), COALESCE(d.mtime_unix, 0),
 	                bm25(chunks_fts) AS score
 	         FROM chunks_fts
 	         JOIN chunks c ON c.chunk_id = chunks_fts.rowid
@@ -81,16 +81,17 @@ func (s *SQLiteStore) SearchBM25(ctx context.Context, query string, k int, index
 	hits := make([]model.SearchHit, 0, k)
 	for rows.Next() {
 		var (
-			chunkID  int64
-			relPath  string
-			docType  string
-			repType  string
-			text     string
-			language string
-			title    string
-			score    sql.NullFloat64
+			chunkID   int64
+			relPath   string
+			docType   string
+			repType   string
+			text      string
+			language  string
+			title     string
+			mtimeUnix int64
+			score     sql.NullFloat64
 		)
-		if err := rows.Scan(&chunkID, &relPath, &docType, &repType, &text, &language, &title, &score); err != nil {
+		if err := rows.Scan(&chunkID, &relPath, &docType, &repType, &text, &language, &title, &mtimeUnix, &score); err != nil {
 			return nil, err
 		}
 		if chunkID <= 0 {
@@ -104,15 +105,16 @@ func (s *SQLiteStore) SearchBM25(ctx context.Context, query string, k int, index
 			hitScore = -score.Float64
 		}
 		hits = append(hits, model.SearchHit{
-			ChunkID:  uint64(chunkID),
-			RelPath:  relPath,
-			Title:    title,
-			DocType:  docType,
-			RepType:  repType,
-			Score:    hitScore,
-			Snippet:  snippet(text, 240),
-			Span:     model.Span{Kind: "lines"},
-			Language: language,
+			ChunkID:   uint64(chunkID),
+			RelPath:   relPath,
+			Title:     title,
+			DocType:   docType,
+			RepType:   repType,
+			Score:     hitScore,
+			Snippet:   snippet(text, 240),
+			Span:      model.Span{Kind: "lines"},
+			Language:  language,
+			MTimeUnix: mtimeUnix,
 		})
 	}
 	if err := rows.Err(); err != nil {

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -1727,9 +1727,10 @@ ranked_spans AS (
   JOIN the_chunk tc ON tc.chunk_id = s.chunk_id
 )
 SELECT tc.chunk_id, tc.rel_path, tc.doc_type, tc.rep_type, tc.text, tc.text_hash, tc.index_kind, tc.modality, tc.media_ref, tc.language,
-       COALESCE(sp.span_kind, ''), COALESCE(sp.start, 0), COALESCE(sp.end, 0), COALESCE(sp.extra_json, '')
+       COALESCE(sp.span_kind, ''), COALESCE(sp.start, 0), COALESCE(sp.end, 0), COALESCE(sp.extra_json, ''), COALESCE(d.mtime_unix, 0)
 FROM the_chunk tc
-LEFT JOIN ranked_spans sp ON sp.chunk_id = tc.chunk_id AND sp.rn = 1`, int64(chunkID))
+LEFT JOIN ranked_spans sp ON sp.chunk_id = tc.chunk_id AND sp.rn = 1
+LEFT JOIN documents d ON d.rel_path = tc.rel_path`, int64(chunkID))
 
 	var (
 		cid       int64
@@ -1746,9 +1747,10 @@ LEFT JOIN ranked_spans sp ON sp.chunk_id = tc.chunk_id AND sp.rn = 1`, int64(chu
 		spanS     int
 		spanE     int
 		spanExtra string
+		mtimeUnix int64
 	)
 	if scanErr := row.Scan(&cid, &relPath, &docType, &repType, &text, &thash, &idxKind, &modality, &mediaRef, &language,
-		&spanK, &spanS, &spanE, &spanExtra); scanErr != nil {
+		&spanK, &spanS, &spanE, &spanExtra, &mtimeUnix); scanErr != nil {
 		if errors.Is(scanErr, sql.ErrNoRows) {
 			return model.ChunkTask{}, "", model.ErrNotFound
 		}
@@ -1760,15 +1762,16 @@ LEFT JOIN ranked_spans sp ON sp.chunk_id = tc.chunk_id AND sp.rn = 1`, int64(chu
 	uid := uint64(cid)
 	span := spanFromRow(spanK, spanS, spanE, spanExtra)
 	t := model.NewChunkTask(uid, text, idxKind, model.ChunkMetadata{
-		ChunkID:  uid,
-		RelPath:  relPath,
-		DocType:  docType,
-		RepType:  repType,
-		Snippet:  snippet(text, 240),
-		Span:     span,
-		Modality: modality,
-		MediaRef: mediaRef,
-		Language: language,
+		ChunkID:   uid,
+		RelPath:   relPath,
+		DocType:   docType,
+		RepType:   repType,
+		Snippet:   snippet(text, 240),
+		Span:      span,
+		Modality:  modality,
+		MediaRef:  mediaRef,
+		Language:  language,
+		MTimeUnix: mtimeUnix,
 	})
 	t.Modality = modality
 	t.MediaRef = mediaRef
@@ -2213,7 +2216,8 @@ func (s *SQLiteStore) NextPending(ctx context.Context, limit int, indexKind stri
 	// the parent's lifecycle at candidate selection. The NULL guard preserves a
 	// chunk with no document row (e.g. UpsertChunkTask seeds a bare chunk).
 	query := `WITH filtered_chunks AS (
-	            SELECT c.chunk_id, c.rel_path, c.doc_type, c.rep_type, c.text, c.index_kind, c.modality, c.media_ref, c.language
+	            SELECT c.chunk_id, c.rel_path, c.doc_type, c.rep_type, c.text, c.index_kind, c.modality, c.media_ref, c.language,
+	                   COALESCE(d.mtime_unix, 0) AS mtime_unix
 	            FROM chunks c
 	            LEFT JOIN documents d ON d.rel_path = c.rel_path
 	            WHERE c.embedding_status = ? AND c.deleted = 0 AND c.chunk_id > 0
@@ -2226,7 +2230,7 @@ func (s *SQLiteStore) NextPending(ctx context.Context, limit int, indexKind stri
 	            JOIN filtered_chunks fc ON fc.chunk_id = s.chunk_id
 	          )
 	          SELECT fc.chunk_id, fc.rel_path, fc.doc_type, fc.rep_type, fc.text, fc.index_kind, fc.modality, fc.media_ref, fc.language,
-	                 COALESCE(sp.span_kind, ''), COALESCE(sp.start, 0), COALESCE(sp.end, 0), COALESCE(sp.extra_json, '')
+	                 COALESCE(sp.span_kind, ''), COALESCE(sp.start, 0), COALESCE(sp.end, 0), COALESCE(sp.extra_json, ''), fc.mtime_unix
 	          FROM filtered_chunks fc
 	          LEFT JOIN ranked_spans sp ON sp.chunk_id = fc.chunk_id AND sp.rn = 1`
 	if strings.TrimSpace(indexKind) != "" {
@@ -2258,8 +2262,9 @@ func (s *SQLiteStore) NextPending(ctx context.Context, limit int, indexKind stri
 			spanS     int
 			spanE     int
 			spanExtra string
+			mtimeUnix int64
 		)
-		if err := rows.Scan(&chunkID, &relPath, &docType, &repType, &text, &idxKind, &modality, &mediaRef, &language, &spanK, &spanS, &spanE, &spanExtra); err != nil {
+		if err := rows.Scan(&chunkID, &relPath, &docType, &repType, &text, &idxKind, &modality, &mediaRef, &language, &spanK, &spanS, &spanE, &spanExtra, &mtimeUnix); err != nil {
 			return nil, err
 		}
 		if chunkID <= 0 {
@@ -2268,15 +2273,16 @@ func (s *SQLiteStore) NextPending(ctx context.Context, limit int, indexKind stri
 		uid := uint64(chunkID)
 		span := spanFromRow(spanK, spanS, spanE, spanExtra)
 		task := model.NewChunkTask(uid, text, idxKind, model.ChunkMetadata{
-			ChunkID:  uid,
-			RelPath:  relPath,
-			DocType:  docType,
-			RepType:  repType,
-			Snippet:  snippet(text, 240),
-			Span:     span,
-			Modality: modality,
-			MediaRef: mediaRef,
-			Language: language,
+			ChunkID:   uid,
+			RelPath:   relPath,
+			DocType:   docType,
+			RepType:   repType,
+			Snippet:   snippet(text, 240),
+			Span:      span,
+			Modality:  modality,
+			MediaRef:  mediaRef,
+			Language:  language,
+			MTimeUnix: mtimeUnix,
 		})
 		task.Modality = modality
 		task.MediaRef = mediaRef
@@ -2343,7 +2349,7 @@ func (s *SQLiteStore) ListEmbeddedChunkMetadata(ctx context.Context, indexKind s
 	          )
 	          SELECT fc.chunk_id, fc.rel_path, fc.doc_type, fc.rep_type, fc.text, fc.index_kind,
 	                 COALESCE(sp.span_kind, ''), COALESCE(sp.start, 0), COALESCE(sp.end, 0), COALESCE(sp.extra_json, ''),
-	                 COALESCE(d.title, ''), fc.modality, fc.media_ref, fc.language
+	                 COALESCE(d.title, ''), fc.modality, fc.media_ref, fc.language, COALESCE(d.mtime_unix, 0)
 	          FROM filtered_chunks fc
 	          LEFT JOIN ranked_spans sp ON sp.chunk_id = fc.chunk_id AND sp.rn = 1
 	          LEFT JOIN documents d ON d.rel_path = fc.rel_path`
@@ -2377,8 +2383,9 @@ func (s *SQLiteStore) ListEmbeddedChunkMetadata(ctx context.Context, indexKind s
 			modality  string
 			mediaRef  string
 			language  string
+			mtimeUnix int64
 		)
-		if err := rows.Scan(&chunkID, &relPath, &docType, &repType, &text, &kind, &spanK, &spanS, &spanE, &spanExtra, &title, &modality, &mediaRef, &language); err != nil {
+		if err := rows.Scan(&chunkID, &relPath, &docType, &repType, &text, &kind, &spanK, &spanS, &spanE, &spanExtra, &title, &modality, &mediaRef, &language, &mtimeUnix); err != nil {
 			return nil, err
 		}
 		if chunkID <= 0 {
@@ -2393,16 +2400,17 @@ func (s *SQLiteStore) ListEmbeddedChunkMetadata(ctx context.Context, indexKind s
 			Modality:  modality,
 			MediaRef:  mediaRef,
 			Metadata: model.ChunkMetadata{
-				ChunkID:  uid,
-				RelPath:  relPath,
-				Title:    title,
-				DocType:  docType,
-				RepType:  repType,
-				Snippet:  snippet(text, 240),
-				Span:     span,
-				Modality: modality,
-				MediaRef: mediaRef,
-				Language: language,
+				ChunkID:   uid,
+				RelPath:   relPath,
+				Title:     title,
+				DocType:   docType,
+				RepType:   repType,
+				Snippet:   snippet(text, 240),
+				Span:      span,
+				Modality:  modality,
+				MediaRef:  mediaRef,
+				Language:  language,
+				MTimeUnix: mtimeUnix,
 			},
 		})
 	}

--- a/tests/mcp/search_date_test.go
+++ b/tests/mcp/search_date_test.go
@@ -1,0 +1,268 @@
+package tests
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// TestMCPSearch_DateWindowPassedThrough verifies dir2mcp_search accepts the
+// optional date_from/date_to bounds (SPEC §9.6) and forwards them to the
+// retriever's SearchQuery as inclusive Unix-second bounds: a bare date_from
+// anchors to the start of its UTC day, and a bare date_to to the last whole
+// second of its day (end-of-day inclusivity).
+func TestMCPSearch_DateWindowPassedThrough(t *testing.T) {
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+
+	var gotFrom, gotTo int64
+	retriever := &askAudioRetrieverStub{
+		indexingComplete: true,
+		OnSearch: func(q model.SearchQuery) ([]model.SearchHit, error) {
+			gotFrom, gotTo = q.DateFrom, q.DateTo
+			return []model.SearchHit{}, nil
+		},
+	}
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"dir2mcp_search","arguments":{"query":"q","date_from":"2026-04-01","date_to":"2026-04-30"}}}`)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d body=%s", resp.StatusCode, string(payload))
+	}
+
+	wantFrom := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC).Unix()
+	wantTo := time.Date(2026, 4, 30, 23, 59, 59, 0, time.UTC).Unix()
+	if gotFrom != wantFrom {
+		t.Errorf("bare date_from must anchor to start of UTC day: got %d want %d", gotFrom, wantFrom)
+	}
+	if gotTo != wantTo {
+		t.Errorf("bare date_to must be inclusive to end of UTC day: got %d want %d", gotTo, wantTo)
+	}
+}
+
+// TestMCPSearch_DateWindowRFC3339PassedThrough verifies an RFC 3339 timestamp is
+// forwarded verbatim as its Unix second (SPEC §9.6).
+func TestMCPSearch_DateWindowRFC3339PassedThrough(t *testing.T) {
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+
+	var gotFrom, gotTo int64
+	retriever := &askAudioRetrieverStub{
+		indexingComplete: true,
+		OnSearch: func(q model.SearchQuery) ([]model.SearchHit, error) {
+			gotFrom, gotTo = q.DateFrom, q.DateTo
+			return []model.SearchHit{}, nil
+		},
+	}
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"dir2mcp_search","arguments":{"query":"q","date_from":"2026-04-01T12:30:00Z","date_to":"2026-04-01T18:00:00Z"}}}`)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d body=%s", resp.StatusCode, string(payload))
+	}
+
+	wantFrom := time.Date(2026, 4, 1, 12, 30, 0, 0, time.UTC).Unix()
+	wantTo := time.Date(2026, 4, 1, 18, 0, 0, 0, time.UTC).Unix()
+	if gotFrom != wantFrom || gotTo != wantTo {
+		t.Fatalf("RFC 3339 bounds not forwarded: got from=%d to=%d want from=%d to=%d", gotFrom, gotTo, wantFrom, wantTo)
+	}
+}
+
+// TestMCPSearch_DateWindowAbsentIsNoFilter verifies that omitting date_from/date_to
+// leaves both bounds at 0 (open on both sides, behaviour unchanged, SPEC §9.6).
+func TestMCPSearch_DateWindowAbsentIsNoFilter(t *testing.T) {
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+
+	gotFrom, gotTo := int64(-1), int64(-1)
+	retriever := &askAudioRetrieverStub{
+		indexingComplete: true,
+		OnSearch: func(q model.SearchQuery) ([]model.SearchHit, error) {
+			gotFrom, gotTo = q.DateFrom, q.DateTo
+			return []model.SearchHit{}, nil
+		},
+	}
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"dir2mcp_search","arguments":{"query":"q"}}}`)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d body=%s", resp.StatusCode, string(payload))
+	}
+	if gotFrom != 0 || gotTo != 0 {
+		t.Fatalf("absent date window must leave both bounds 0, got from=%d to=%d", gotFrom, gotTo)
+	}
+}
+
+// TestMCPSearch_MalformedDateIsInvalidField verifies a value that is neither an
+// RFC 3339 timestamp nor a bare YYYY-MM-DD date is INVALID_FIELD (df-008), and the
+// retriever is never called.
+func TestMCPSearch_MalformedDateIsInvalidField(t *testing.T) {
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+	retriever := &askAudioRetrieverStub{indexingComplete: true}
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"dir2mcp_search","arguments":{"query":"q","date_from":"last tuesday"}}}`)
+	defer func() { _ = resp.Body.Close() }()
+
+	body, _ := io.ReadAll(resp.Body)
+	if got := string(body); !containsCanonicalCode(got, "INVALID_FIELD") {
+		t.Fatalf("malformed date_from must yield INVALID_FIELD, body=%s", got)
+	}
+	if retriever.searchCalled.Load() {
+		t.Fatal("retriever.Search must not be called when date_from is malformed")
+	}
+}
+
+// TestMCPSearch_InvertedDateWindowIsInvalidField verifies date_from after date_to
+// is INVALID_FIELD (df-008), not a silently-empty result.
+func TestMCPSearch_InvertedDateWindowIsInvalidField(t *testing.T) {
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+	retriever := &askAudioRetrieverStub{indexingComplete: true}
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"dir2mcp_search","arguments":{"query":"q","date_from":"2026-05-01","date_to":"2026-04-01"}}}`)
+	defer func() { _ = resp.Body.Close() }()
+
+	body, _ := io.ReadAll(resp.Body)
+	if got := string(body); !containsCanonicalCode(got, "INVALID_FIELD") {
+		t.Fatalf("inverted date window must yield INVALID_FIELD, body=%s", got)
+	}
+	if retriever.searchCalled.Load() {
+		t.Fatal("retriever.Search must not be called for an inverted date window")
+	}
+}
+
+// TestMCPAsk_DateWindowPassedThrough verifies dir2mcp_ask forwards date_from/date_to
+// to Ask's query (SPEC §9.6/§15.3).
+func TestMCPAsk_DateWindowPassedThrough(t *testing.T) {
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+
+	var gotFrom, gotTo int64
+	retriever := &askAudioRetrieverStub{
+		indexingComplete: true,
+		askResult:        model.AskResult{Answer: "ok"},
+		OnAskQuery:       func(q model.SearchQuery) { gotFrom, gotTo = q.DateFrom, q.DateTo },
+	}
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"dir2mcp_ask","arguments":{"question":"q","date_from":"2026-04-01"}}}`)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d body=%s", resp.StatusCode, string(payload))
+	}
+	wantFrom := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC).Unix()
+	if gotFrom != wantFrom || gotTo != 0 {
+		t.Fatalf("ask date window not forwarded, got from=%d to=%d want from=%d to=0", gotFrom, gotTo, wantFrom)
+	}
+}
+
+// TestMCPAsk_MalformedDateIsInvalidField mirrors the search malformed case for ask.
+func TestMCPAsk_MalformedDateIsInvalidField(t *testing.T) {
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+	retriever := &askAudioRetrieverStub{indexingComplete: true, askResult: model.AskResult{Answer: "ok"}}
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"dir2mcp_ask","arguments":{"question":"q","date_to":"04/30/2026"}}}`)
+	defer func() { _ = resp.Body.Close() }()
+
+	body, _ := io.ReadAll(resp.Body)
+	if got := string(body); !containsCanonicalCode(got, "INVALID_FIELD") {
+		t.Fatalf("malformed date_to on ask must yield INVALID_FIELD, body=%s", got)
+	}
+	if retriever.askCalled.Load() {
+		t.Fatal("retriever.Ask must not be called when date_to is malformed")
+	}
+}
+
+// TestMCPTools_SchemaAdvertisesDateWindow confirms both the search and ask tool
+// input schemas expose the optional date_from/date_to string bounds (SPEC §9.6).
+func TestMCPTools_SchemaAdvertisesDateWindow(t *testing.T) {
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+	retriever := &askAudioRetrieverStub{indexingComplete: true}
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d body=%s", resp.StatusCode, string(payload))
+	}
+
+	var envelope struct {
+		Result struct {
+			Tools []struct {
+				Name        string                 `json:"name"`
+				InputSchema map[string]interface{} `json:"inputSchema"`
+			} `json:"tools"`
+		} `json:"result"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	want := map[string]bool{"dir2mcp_search": false, "dir2mcp_ask": false}
+	for _, tool := range envelope.Result.Tools {
+		if _, ok := want[tool.Name]; !ok {
+			continue
+		}
+		props, _ := tool.InputSchema["properties"].(map[string]interface{})
+		for _, key := range []string{"date_from", "date_to"} {
+			bound, ok := props[key].(map[string]interface{})
+			if !ok {
+				t.Errorf("%s input schema missing optional %s bound, props=%v", tool.Name, key, props)
+				continue
+			}
+			if bound["type"] != "string" {
+				t.Errorf("%s %s must be a string, got %#v", tool.Name, key, bound["type"])
+			}
+		}
+		want[tool.Name] = true
+	}
+	for name, found := range want {
+		if !found {
+			t.Errorf("%s tool not advertised with a date window filter", name)
+		}
+	}
+}

--- a/tests/retrieval/date_filter_test.go
+++ b/tests/retrieval/date_filter_test.go
@@ -1,0 +1,202 @@
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
+)
+
+// unixDay returns the Unix seconds at 00:00:00Z of the given UTC calendar date,
+// the calendar anchor a document with that mtime would carry (SPEC §9.6).
+func unixDay(year int, month time.Month, day int) int64 {
+	return time.Date(year, month, day, 0, 0, 0, 0, time.UTC).Unix()
+}
+
+// newDateService builds a vector-only retrieval service over idx and registers
+// in-memory chunk metadata carrying each hit's MTimeUnix, mirroring the
+// production warm/on-index path so matchFilters sees the document-date anchor
+// (SPEC §9.6). It reuses addVec/fakeRetrievalEmbedder from the language tests.
+func newDateService(t *testing.T, idx *index.HNSWIndex, meta map[uint64]model.SearchHit) *retrieval.Service {
+	t.Helper()
+	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+		"mistral-embed": {1, 0},
+	}}, nil)
+	for id, hit := range meta {
+		svc.SetChunkMetadata(id, hit)
+	}
+	return svc
+}
+
+// dateCorpus builds a three-document corpus with mtimes on 2026-03-15,
+// 2026-04-15, and 2026-05-15 plus one document with an unknown (0) mtime.
+func dateCorpus(t *testing.T) *retrieval.Service {
+	t.Helper()
+	idx := index.NewHNSWIndex("")
+	addVec(t, idx, 1, []float32{1, 0})
+	addVec(t, idx, 2, []float32{0.97, 0.03})
+	addVec(t, idx, 3, []float32{0.94, 0.06})
+	addVec(t, idx, 4, []float32{0.91, 0.09})
+	return newDateService(t, idx, map[uint64]model.SearchHit{
+		1: {RelPath: "mar.txt", DocType: "text", Snippet: "march", MTimeUnix: unixDay(2026, 3, 15), Span: model.Span{Kind: "lines", StartLine: 1, EndLine: 1}},
+		2: {RelPath: "apr.txt", DocType: "text", Snippet: "april", MTimeUnix: unixDay(2026, 4, 15), Span: model.Span{Kind: "lines", StartLine: 1, EndLine: 1}},
+		3: {RelPath: "may.txt", DocType: "text", Snippet: "may", MTimeUnix: unixDay(2026, 5, 15), Span: model.Span{Kind: "lines", StartLine: 1, EndLine: 1}},
+		4: {RelPath: "unknown.txt", DocType: "text", Snippet: "undated", MTimeUnix: 0, Span: model.Span{Kind: "lines", StartLine: 1, EndLine: 1}},
+	})
+}
+
+func dateSearchIDs(t *testing.T, svc *retrieval.Service, q model.SearchQuery) []uint64 {
+	t.Helper()
+	hits, err := svc.Search(context.Background(), q)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	ids := make([]uint64, 0, len(hits))
+	for _, h := range hits {
+		ids = append(ids, h.ChunkID)
+	}
+	return ids
+}
+
+func hasID(ids []uint64, want uint64) bool {
+	for _, id := range ids {
+		if id == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestSearch_DateFilter_BothBoundsRestrictsToWindow pins SPEC §9.6: a closed
+// [date_from, date_to] window keeps only documents whose mtime is inside it,
+// inclusively, and excludes those outside and the unknown-mtime document.
+func TestSearch_DateFilter_BothBoundsRestrictsToWindow(t *testing.T) {
+	svc := dateCorpus(t)
+	// [2026-04-01, 2026-04-30] contains only the apr.txt doc (2026-04-15).
+	got := dateSearchIDs(t, svc, model.SearchQuery{
+		Query:    "x",
+		K:        10,
+		DateFrom: unixDay(2026, 4, 1),
+		DateTo:   time.Date(2026, 4, 30, 23, 59, 59, 0, time.UTC).Unix(),
+	})
+	if len(got) != 1 || got[0] != 2 {
+		t.Fatalf("window [Apr 1, Apr 30] must yield only apr.txt (id 2), got %v", got)
+	}
+}
+
+// TestSearch_DateFilter_InclusiveBounds pins §9.6 inclusivity: a document whose
+// mtime falls exactly on either bound is kept.
+func TestSearch_DateFilter_InclusiveBounds(t *testing.T) {
+	svc := dateCorpus(t)
+	// Bounds land exactly on the mar (from) and may (to) anchors.
+	got := dateSearchIDs(t, svc, model.SearchQuery{
+		Query:    "x",
+		K:        10,
+		DateFrom: unixDay(2026, 3, 15),
+		DateTo:   unixDay(2026, 5, 15),
+	})
+	if len(got) != 3 {
+		t.Fatalf("inclusive bounds on the mar/may anchors must keep all three dated docs, got %d: %v", len(got), got)
+	}
+	if hasID(got, 4) {
+		t.Fatalf("unknown-mtime doc must never match a bounded window, got %v", got)
+	}
+}
+
+// TestSearch_DateFilter_OpenLowerBound pins §9.6: an absent date_from leaves the
+// lower side open, so only date_to constrains.
+func TestSearch_DateFilter_OpenLowerBound(t *testing.T) {
+	svc := dateCorpus(t)
+	// Only date_to = end of April: mar and apr survive, may is excluded.
+	got := dateSearchIDs(t, svc, model.SearchQuery{
+		Query:  "x",
+		K:      10,
+		DateTo: time.Date(2026, 4, 30, 23, 59, 59, 0, time.UTC).Unix(),
+	})
+	if len(got) != 2 || !hasID(got, 1) || !hasID(got, 2) {
+		t.Fatalf("open-lower window (≤ Apr 30) must keep mar+apr only, got %v", got)
+	}
+}
+
+// TestSearch_DateFilter_OpenUpperBound pins §9.6: an absent date_to leaves the
+// upper side open, so only date_from constrains.
+func TestSearch_DateFilter_OpenUpperBound(t *testing.T) {
+	svc := dateCorpus(t)
+	// Only date_from = start of April: apr and may survive, mar is excluded.
+	got := dateSearchIDs(t, svc, model.SearchQuery{
+		Query:    "x",
+		K:        10,
+		DateFrom: unixDay(2026, 4, 1),
+	})
+	if len(got) != 2 || !hasID(got, 2) || !hasID(got, 3) {
+		t.Fatalf("open-upper window (≥ Apr 1) must keep apr+may only, got %v", got)
+	}
+}
+
+// TestSearch_DateFilter_BothOpenIsNoFilter pins §9.6: with both bounds absent the
+// filter is a no-op — every candidate is returned, including the unknown-mtime doc.
+func TestSearch_DateFilter_BothOpenIsNoFilter(t *testing.T) {
+	svc := dateCorpus(t)
+	got := dateSearchIDs(t, svc, model.SearchQuery{Query: "x", K: 10})
+	if len(got) != 4 {
+		t.Fatalf("no date window must return all four docs (unknown mtime included), got %d: %v", len(got), got)
+	}
+}
+
+// TestSearch_DateFilter_UnknownMtimeExcludedWhenBoundSet pins §9.6: a document
+// with an unknown (0) mtime never matches a window that sets either bound, but is
+// returned unchanged when no bound is set (mirrors the unknown-language rule).
+func TestSearch_DateFilter_UnknownMtimeExcludedWhenBoundSet(t *testing.T) {
+	svc := dateCorpus(t)
+
+	// A lower bound alone still excludes the unknown-mtime doc.
+	lower := dateSearchIDs(t, svc, model.SearchQuery{Query: "x", K: 10, DateFrom: unixDay(2026, 1, 1)})
+	if hasID(lower, 4) {
+		t.Fatalf("unknown-mtime doc must be excluded when date_from is set, got %v", lower)
+	}
+	// An upper bound alone likewise excludes it.
+	upper := dateSearchIDs(t, svc, model.SearchQuery{Query: "x", K: 10, DateTo: unixDay(2026, 12, 31)})
+	if hasID(upper, 4) {
+		t.Fatalf("unknown-mtime doc must be excluded when date_to is set, got %v", upper)
+	}
+}
+
+// TestSearch_DateFilter_NoMatchIsEmptyNotError pins §9.6: a valid window that
+// matches nothing in the corpus returns an empty hit list, not an error.
+func TestSearch_DateFilter_NoMatchIsEmptyNotError(t *testing.T) {
+	svc := dateCorpus(t)
+	hits, err := svc.Search(context.Background(), model.SearchQuery{
+		Query:    "x",
+		K:        10,
+		DateFrom: unixDay(2027, 1, 1),
+		DateTo:   unixDay(2027, 12, 31),
+	})
+	if err != nil {
+		t.Fatalf("a no-match date window must not error: %v", err)
+	}
+	if len(hits) != 0 {
+		t.Fatalf("a no-match date window must return an empty hit list, got %d", len(hits))
+	}
+}
+
+// TestSearch_DateFilter_KCountsOnlyInWindow pins §9.6: the window is applied at
+// candidate selection, so k counts only in-window hits — a k=1 request over a
+// window that admits a single doc returns that doc, even when a nearer-by-score
+// out-of-window doc exists.
+func TestSearch_DateFilter_KCountsOnlyInWindow(t *testing.T) {
+	svc := dateCorpus(t)
+	// mar.txt has the highest score (vector {1,0}) but is out of the April window;
+	// k=1 must still surface apr.txt rather than returning the out-of-window mar.
+	got := dateSearchIDs(t, svc, model.SearchQuery{
+		Query:    "x",
+		K:        1,
+		DateFrom: unixDay(2026, 4, 1),
+		DateTo:   time.Date(2026, 4, 30, 23, 59, 59, 0, time.UTC).Unix(),
+	})
+	if len(got) != 1 || got[0] != 2 {
+		t.Fatalf("k=1 over the April window must return apr.txt (id 2), got %v", got)
+	}
+}

--- a/tests/store/chunk_mtime_metadata_test.go
+++ b/tests/store/chunk_mtime_metadata_test.go
@@ -1,0 +1,119 @@
+package tests
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// TestChunkMetadata_MTimeDenormalizedFromDocument pins the SPEC §9.6 denorm: the
+// source document's calendar anchor (mtime_unix) is surfaced onto the chunk
+// metadata every metadata-loading query returns — NextPending (live embed),
+// ChunkTaskByID (distributed embed), and ListEmbeddedChunkMetadata (warm reload)
+// — so the date/time-range retrieval filter can predicate on candidates without
+// a per-hit store lookup, mirroring the per-language (§9.5) denorm.
+func TestChunkMetadata_MTimeDenormalizedFromDocument(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	defer func() { _ = st.Close() }()
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	const relPath = "docs/dated.md"
+	wantMTime := time.Date(2026, 4, 15, 9, 30, 0, 0, time.UTC).Unix()
+	if err := st.UpsertDocument(ctx, model.Document{
+		RelPath: relPath, DocType: "md", SourceType: "local", Status: "ok", MTimeUnix: wantMTime,
+	}); err != nil {
+		t.Fatalf("UpsertDocument: %v", err)
+	}
+	doc, err := st.GetDocumentByPath(ctx, relPath)
+	if err != nil {
+		t.Fatalf("GetDocumentByPath: %v", err)
+	}
+
+	pendingID, embeddedID := seedDatedRepChunks(t, st, doc.DocID)
+
+	// NextPending (live embed path → OnIndexedChunk → chunkByLabel).
+	pending, err := st.NextPending(ctx, 100, "")
+	if err != nil {
+		t.Fatalf("NextPending: %v", err)
+	}
+	if len(pending) == 0 {
+		t.Fatal("expected at least one pending chunk")
+	}
+	assertTasksMTime(t, "NextPending", pending, wantMTime)
+
+	// ChunkTaskByID (distributed embed lease path).
+	task, _, err := st.ChunkTaskByID(ctx, uint64(pendingID))
+	if err != nil {
+		t.Fatalf("ChunkTaskByID: %v", err)
+	}
+	assertTasksMTime(t, "ChunkTaskByID", []model.ChunkTask{task}, wantMTime)
+
+	// ListEmbeddedChunkMetadata (warm-reload path → chunkByLabel after restart).
+	embedded, err := st.ListEmbeddedChunkMetadata(ctx, "text", 100, 0)
+	if err != nil {
+		t.Fatalf("ListEmbeddedChunkMetadata: %v", err)
+	}
+	assertTasksMTime(t, "ListEmbeddedChunkMetadata", embedded, wantMTime)
+	if !containsChunk(embedded, uint64(embeddedID)) {
+		t.Fatalf("embedded chunk %d not returned by ListEmbeddedChunkMetadata", embeddedID)
+	}
+}
+
+// seedDatedRepChunks inserts one pending and one embedded ("ok") chunk under a new
+// representation of docID, returning their chunk ids.
+func seedDatedRepChunks(t *testing.T, st *store.SQLiteStore, docID int64) (pendingID, embeddedID int64) {
+	t.Helper()
+	ctx := context.Background()
+	err := st.WithTx(ctx, func(tx model.RepresentationStore) error {
+		repID, rerr := tx.UpsertRepresentation(ctx, model.Representation{
+			DocID: docID, RepType: "raw_text", RepHash: "h1",
+		})
+		if rerr != nil {
+			return rerr
+		}
+		id, cerr := tx.InsertChunkWithSpans(ctx, model.Chunk{
+			RepID: repID, Ordinal: 0, Text: "pending chunk", TextHash: "p1", IndexKind: "text",
+			EmbeddingStatus: "pending",
+		}, []model.Span{{Kind: "lines", StartLine: 1, EndLine: 1}})
+		if cerr != nil {
+			return cerr
+		}
+		pendingID = id
+		embeddedID, cerr = tx.InsertChunkWithSpans(ctx, model.Chunk{
+			RepID: repID, Ordinal: 1, Text: "embedded chunk", TextHash: "e1", IndexKind: "text",
+			EmbeddingStatus: "ok",
+		}, []model.Span{{Kind: "lines", StartLine: 2, EndLine: 2}})
+		return cerr
+	})
+	if err != nil {
+		t.Fatalf("seed chunks: %v", err)
+	}
+	return pendingID, embeddedID
+}
+
+// assertTasksMTime fails unless every task carries the expected document mtime.
+func assertTasksMTime(t *testing.T, from string, tasks []model.ChunkTask, want int64) {
+	t.Helper()
+	for _, tk := range tasks {
+		if tk.Metadata.MTimeUnix != want {
+			t.Fatalf("%s chunk %d mtime = %d, want %d", from, tk.Metadata.ChunkID, tk.Metadata.MTimeUnix, want)
+		}
+	}
+}
+
+// containsChunk reports whether tasks include a chunk with the given id.
+func containsChunk(tasks []model.ChunkTask, id uint64) bool {
+	for _, tk := range tasks {
+		if tk.Metadata.ChunkID == id {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Closes #326

Adds optional `date_from`/`date_to` inputs to `dir2mcp_search` and `dir2mcp_ask` that restrict results to a **document-date window**. The spec is already merged and pinned on `main` (dirstral-spec §9.6, bs-007 0.4.0); this PR implements to it. The submodule is untouched.

## Semantics (§9.6)
- **Value**: an RFC 3339 timestamp (`2026-04-01T00:00:00Z`) **or** a bare `YYYY-MM-DD` date (interpreted UTC). A bare `date_from` anchors to start-of-day (`00:00:00Z`); a bare `date_to` to end-of-day (`23:59:59Z`). Both bounds **inclusive**.
- **Anchor**: the document's `mtime_unix` (its calendar anchor). Media time spans are intra-document offsets and are not used.
- **Conjunctive** with the other filters and applied **at candidate selection** (`matchFilters`), so `k` counts only in-window hits.
- **Errors**: a malformed value, or `date_from > date_to`, is `INVALID_FIELD` (df-008); a window matching nothing is an **empty result, not an error**.
- **Additive / off-by-default**: an absent bound is open on that side; callers that never send them are byte-for-byte unchanged.

## Design (mirrors the §9.5 language filter — `SearchHit` + `matchFilters`)
- `MTimeUnix int64` is denormalized onto `model.SearchHit` (and `model.ChunkMetadata`, copied in `ToSearchHit`) and populated **wherever a hit's `Language` is**: the store's chunk-metadata queries (`NextPending`, `ChunkTaskByID`, `ListEmbeddedChunkMetadata` — each joins `documents`) and the BM25 path. The pure `matchFilters` predicate then checks the window with **no per-hit store lookup**.
- **Unknown mtime (0)** with a bound set → excluded, mirroring the unknown-language rule.
- The window is intentionally **not** pushed into `model.Filter`/backend pushdown: `IndexPayload` carries no mtime, so a pushed-down date filter would wrongly exclude every candidate. It is evaluated in Go over the overfetched pool instead — correctness-preserving, `k`-counting intact. `matchFilters` was refactored (doc-type + date extracted into small helpers) to stay under the cyclomatic-complexity gate.

## Tests
- **tests/retrieval** (`date_filter_test.go`): window in/out, open-lower, open-upper, both-open no-op, inclusive bounds, unknown-mtime excluded when a bound is set, no-match-is-empty, and k-counts-only-in-window.
- **tests/mcp** (`search_date_test.go`): RFC 3339 + bare-date pass-through, end-of-day inclusivity, malformed → `INVALID_FIELD`, inverted window → `INVALID_FIELD`, absent = no filter, and schema advertises the bounds (search + ask).
- **tests/store** (`chunk_mtime_metadata_test.go`): mtime propagation through all three metadata queries end-to-end against a real SQLite store.

## Verification
`go build ./...` and the targeted suites pass. `make check` is all-green except the known worktree-only `TestSpecYAMLSecretPatterns_Compile_JWTAndBearer` failure (the `dirstral-spec` submodule isn't checked out in the worktree; CI has it). Diff is scope-clean (the 3 unrelated pre-existing gofmt-noise files reverted).

## Deferred
`dir2mcp_ask_audio` does not wire `date_from`/`date_to`, matching its pre-existing gap for `languages`/`language_match` (it inherits the ask input schema but its handler allowlist omits them).