### PR TITLE
fix(providers): unknown-kind CONFIG_INVALID + declared-order user precedence (#440 F7/F8)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3633,6 +3633,11 @@ func (c *Config) Validate() error {
 		c.validateIngestOnUnsupported,
 		c.validateIngestExtractor,
 		c.validateIndexBackend,
+		// Before the provider-resolving gates (STT/media): an unrecognized
+		// provider `kind:` must fail here with its own root-cause CONFIG_INVALID
+		// (naming the profile + bad kind) rather than surfacing downstream as a
+		// generic "no eligible provider" error (issue #440 F7).
+		c.validateProviderKinds,
 		c.validateMediaVariants,
 		// Before the media gates: validateMediaTranslate/validateMediaDiarize
 		// resolve the STT profile, so an unrecognized stt.provider must fail here

--- a/internal/config/providers.go
+++ b/internal/config/providers.go
@@ -53,6 +53,13 @@ type providersDoc struct {
 		Chat  capBindingYAML `yaml:"chat"`
 		OCR   capBindingYAML `yaml:"ocr"`
 	} `yaml:"model"`
+	// declOrder is the order the profile names appear in the `providers:`
+	// mapping. yaml.v3 decodes the mapping into a Go map, which loses key
+	// order, so declared order is recovered separately (see
+	// providerDeclOrder) and used to order user-only profiles in the
+	// auto-selection precedence (SPEC 8.1.3). Empty when there is no
+	// providers block or order recovery failed.
+	declOrder []string
 }
 
 // builtinProfiles ship per SPEC 8.1.1 so operators usually only supply a
@@ -101,7 +108,10 @@ func builtinProfiles() map[string]providerProfileYAML {
 
 // builtinPrecedence is the deterministic auto-selection order (SPEC
 // 8.1.3): Mistral first (historical default), then the rest. User-only
-// profiles are appended in declared order after these.
+// profiles are appended after these in the order they are declared in the
+// YAML `providers:` mapping (recovered by providerDeclOrder; issue #440 F8) —
+// or, if declared order cannot be recovered, in sorted name order for
+// determinism.
 //
 // `mistral-ocr` (kind: mistral — the Voxtral STT / Mistral-OCR path) precedes
 // `mistral` (kind: openai — the OpenAI-compatible chat/embed path). This
@@ -293,15 +303,53 @@ func parseProvidersDoc(raw []byte) (providersDoc, error) {
 	if err := yaml.Unmarshal(sub, &doc); err != nil {
 		return providersDoc{}, fmt.Errorf("parse providers/model config: %w", err)
 	}
+	doc.declOrder = providerDeclOrder(sub)
 	return doc, nil
+}
+
+// providerDeclOrder recovers the profile names in the order they are declared
+// in the `providers:` mapping (issue #440 F8). yaml.v3 decodes a mapping into a
+// Go map, which loses key order, so the declared order — the SPEC 8.1.3
+// precedence for user-only profiles — is recovered by walking the mapping
+// node's Content (keys sit at even indices). Returns nil when there is no
+// `providers:` block or the subtree cannot be node-decoded, in which case the
+// caller falls back to a deterministic sorted order.
+func providerDeclOrder(sub []byte) []string {
+	var root yaml.Node
+	if err := yaml.Unmarshal(sub, &root); err != nil || len(root.Content) == 0 {
+		return nil
+	}
+	top := root.Content[0]
+	if top.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(top.Content); i += 2 {
+		if top.Content[i].Value != "providers" {
+			continue
+		}
+		pmap := top.Content[i+1]
+		if pmap.Kind != yaml.MappingNode {
+			return nil
+		}
+		order := make([]string, 0, len(pmap.Content)/2)
+		for j := 0; j+1 < len(pmap.Content); j += 2 {
+			order = append(order, pmap.Content[j].Value)
+		}
+		return order
+	}
+	return nil
 }
 
 // mergeProfiles overlays user-declared profiles per-field over the
 // built-ins and returns the merged set plus the deterministic
-// precedence order (built-ins first, then user-only names in declared
-// order — Go map order is non-deterministic so user-only ordering falls
-// back to sorted names for stability).
-func mergeProfiles(base, user map[string]providerProfileYAML) (map[string]providerProfileYAML, []string) {
+// precedence order: built-ins first (builtinPrecedence), then user-only
+// names in declared order (SPEC 8.1.3). declOrder carries the order the
+// profiles appear in the YAML `providers:` mapping (recovered by
+// providerDeclOrder, since a decoded Go map loses key order); any user-only
+// profile not present in declOrder — the defensive path when order recovery
+// fails — is appended in sorted name order so the result is always
+// deterministic (issue #440 F8).
+func mergeProfiles(base, user map[string]providerProfileYAML, declOrder []string) (map[string]providerProfileYAML, []string) {
 	merged := base
 	for name, up := range user {
 		base, ok := merged[name]
@@ -348,21 +396,42 @@ func mergeProfiles(base, user map[string]providerProfileYAML) (map[string]provid
 		merged[name] = base
 	}
 	order := append([]string(nil), builtinPrecedence...)
+	return merged, append(order, userOnlyOrder(user, declOrder)...)
+}
+
+// userOnlyOrder returns the non-built-in profile names in auto-selection
+// precedence order (SPEC 8.1.3): first the names present in declOrder (the YAML
+// declaration order recovered by providerDeclOrder, de-duplicated), then any
+// user-only profile declOrder did not cover — the defensive path when order
+// recovery fails or is partial — in sorted name order so the result is always
+// deterministic regardless of Go map iteration (issue #440 F8).
+func userOnlyOrder(user map[string]providerProfileYAML, declOrder []string) []string {
+	builtins := builtinProfiles()
+	isUserOnly := func(name string) bool {
+		if _, ok := user[name]; !ok {
+			return false
+		}
+		_, isBuiltin := builtins[name]
+		return !isBuiltin
+	}
 	var extra []string
+	seen := make(map[string]struct{}, len(user))
+	for _, name := range declOrder {
+		if _, dup := seen[name]; dup || !isUserOnly(name) {
+			continue
+		}
+		seen[name] = struct{}{}
+		extra = append(extra, name)
+	}
+	var leftover []string
 	for name := range user {
-		if _, isBuiltin := builtinProfiles()[name]; !isBuiltin {
-			extra = append(extra, name)
+		if _, ok := seen[name]; ok || !isUserOnly(name) {
+			continue
 		}
+		leftover = append(leftover, name)
 	}
-	// stable order for user-only profiles
-	for i := 0; i < len(extra); i++ {
-		for j := i + 1; j < len(extra); j++ {
-			if extra[j] < extra[i] {
-				extra[i], extra[j] = extra[j], extra[i]
-			}
-		}
-	}
-	return merged, append(order, extra...)
+	sort.Strings(leftover)
+	return append(extra, leftover...)
 }
 
 // expandEnv resolves ${VAR} / $VAR references via getenv (SPEC 16.1.1
@@ -421,7 +490,7 @@ type ProviderResolution struct {
 
 // providersResolution builds the resolution from the parsed doc + env.
 func (d providersDoc) resolve(base map[string]providerProfileYAML, getenv func(string) string) ProviderResolution {
-	merged, order := mergeProfiles(base, d.Providers)
+	merged, order := mergeProfiles(base, d.Providers, d.declOrder)
 	byName := toProfiles(merged, getenv)
 	prec := make([]provider.Profile, 0, len(order))
 	for _, n := range order {
@@ -638,6 +707,33 @@ func (c *Config) validateMediaDiarize() error {
 	return nil
 }
 
+// validateProviderKinds fails fast (CONFIG_INVALID) when any resolved provider
+// profile declares an unrecognized `kind:` (issue #440 F7). An unknown/typo
+// kind has no row in the capability matrix (SPEC 8.1.2), so the profile is
+// silently un-selectable in `auto` and surfaces only as a generic
+// "no eligible provider" error far from its cause — a typo the operator cannot
+// act on. Validating here names the offending profile and the bad kind at
+// startup so the misconfiguration is actionable immediately. Profiles are
+// scanned in sorted order so the reported error is stable across runs (Go map
+// iteration is non-deterministic).
+func (c *Config) validateProviderKinds() error {
+	byName := c.Providers().ByName()
+	names := make([]string, 0, len(byName))
+	for name := range byName {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		p := byName[name]
+		if !provider.IsKnownKind(p.Kind) {
+			return fmt.Errorf(
+				"CONFIG_INVALID: provider profile %q declares unrecognized kind %q; use one of %s",
+				name, p.Kind, provider.KnownKindsString())
+		}
+	}
+	return nil
+}
+
 // readSnapshotEmbedIdentity returns the embed_identity recorded in the
 // effective snapshot for stateDir, or "" if there is no snapshot / no
 // recorded identity (a fresh index — VerifyEmbedIdentity treats that as
@@ -701,7 +797,7 @@ func (cfg Config) Providers() ProviderResolution {
 func (cfg Config) ProviderEnvVarRefs() []string {
 	base := builtinProfiles()
 	seedLegacy(base, cfg)
-	merged, _ := mergeProfiles(base, cfg.providersDoc.Providers)
+	merged, _ := mergeProfiles(base, cfg.providersDoc.Providers, cfg.providersDoc.declOrder)
 
 	seen := make(map[string]struct{})
 	var refs []string

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -48,6 +48,39 @@ const (
 	KindColBERT Kind = "colbert"
 )
 
+// knownKinds is the set of recognized provider kinds (SPEC 8.1.1), in a
+// stable order for deterministic error messages. A profile whose kind is not
+// in this set has no row in the capability matrix, so it is silently
+// un-selectable for every capability in auto selection and surfaces only as a
+// generic ErrNoProvider far from its cause (issue #440 F7).
+var knownKinds = []Kind{
+	KindOpenAI, KindMistral, KindAnthropic, KindGemini, KindCohere,
+	KindElevenLabs, KindWhisper, KindOmniEmbed, KindColBERT,
+}
+
+// IsKnownKind reports whether k is a recognized provider kind (SPEC 8.1.1).
+// A profile declaring an unrecognized/typo kind is un-selectable for every
+// capability; the config layer rejects it as CONFIG_INVALID at startup rather
+// than letting it surface as a downstream "no provider" error (issue #440 F7).
+func IsKnownKind(k Kind) bool {
+	for _, known := range knownKinds {
+		if k == known {
+			return true
+		}
+	}
+	return false
+}
+
+// KnownKindsString renders the recognized provider kinds as a comma-separated
+// list for actionable CONFIG_INVALID remediation (issue #440 F7).
+func KnownKindsString() string {
+	names := make([]string, len(knownKinds))
+	for i, k := range knownKinds {
+		names[i] = string(k)
+	}
+	return strings.Join(names, ", ")
+}
+
 // Capability is a model capability bound to a provider profile.
 type Capability string
 

--- a/tests/config/providers_config_test.go
+++ b/tests/config/providers_config_test.go
@@ -86,12 +86,7 @@ func TestProviders_BuiltinAutoSelectByCredential(t *testing.T) {
 func TestProviders_NoCredentialEmbedFails(t *testing.T) {
 	// Deterministic: blank any embed-capable provider key the host/CI
 	// may already export (Resolve reads process env via cfg.Providers).
-	for _, k := range []string{
-		"MISTRAL_API_KEY", "OPENAI_API_KEY", "OPENROUTER_API_KEY",
-		"GEMINI_API_KEY", "COHERE_API_KEY", "ANTHROPIC_API_KEY", "ELEVENLABS_API_KEY",
-	} {
-		t.Setenv(k, "")
-	}
+	blankBuiltinProviderCreds(t)
 	// No creds and no explicit binding: auto-select must NOT silently
 	// fall through to the credential-less `local` (it's excluded from
 	// auto precedence) — embed must fail so preflight surfaces it.
@@ -312,12 +307,7 @@ func TestProviders_OmniEmbedSelfHosted(t *testing.T) {
 // credentials and no explicit binding, embed must fail (preflight surfaces
 // it) rather than silently fall through to omniembed.
 func TestProviders_OmniEmbedNotInAutoPrecedence(t *testing.T) {
-	for _, k := range []string{
-		"MISTRAL_API_KEY", "OPENAI_API_KEY", "OPENROUTER_API_KEY",
-		"GEMINI_API_KEY", "COHERE_API_KEY", "ANTHROPIC_API_KEY", "ELEVENLABS_API_KEY",
-	} {
-		t.Setenv(k, "")
-	}
+	blankBuiltinProviderCreds(t)
 	t.Setenv("OMNIEMBED_BASE_URL", "http://gpu-vps:8000")
 	cfg := loadCfg(t, "version: 1\n")
 	if _, err := cfg.Providers().Resolve(provider.CapEmbed); err == nil {

--- a/tests/config/providers_edges_440_test.go
+++ b/tests/config/providers_edges_440_test.go
@@ -58,10 +58,11 @@ func TestProviders_KnownKindsLoadCleanly(t *testing.T) {
 	}
 }
 
-// blankBuiltinEmbedCreds clears every built-in embed-capable credential so a
+// blankBuiltinProviderCreds clears every built-in provider credential (embed + STT)
+// so a
 // user-only profile is the only eligible embed backend and thus wins auto
 // selection — exercising the user-only precedence path.
-func blankBuiltinEmbedCreds(t *testing.T) {
+func blankBuiltinProviderCreds(t *testing.T) {
 	t.Helper()
 	for _, k := range []string{
 		"MISTRAL_API_KEY", "OPENAI_API_KEY", "OPENROUTER_API_KEY",
@@ -79,7 +80,7 @@ func blankBuiltinEmbedCreds(t *testing.T) {
 // behavior, a consequence of Go map order being lost on decode — would have
 // picked alpha.
 func TestProviders_UserOnlyPrecedenceIsDeclaredOrder(t *testing.T) {
-	blankBuiltinEmbedCreds(t)
+	blankBuiltinProviderCreds(t)
 	yaml := "providers:\n" +
 		"  zeta:\n    kind: openai\n    base_url: http://zeta.local/v1\n    api_key: zk\n" +
 		"  alpha:\n    kind: openai\n    base_url: http://alpha.local/v1\n    api_key: ak\n"
@@ -98,7 +99,7 @@ func TestProviders_UserOnlyPrecedenceIsDeclaredOrder(t *testing.T) {
 // alpha. Together the two cases prove the winner tracks declaration order
 // rather than a fixed alphabetical sort.
 func TestProviders_UserOnlyPrecedenceReversed(t *testing.T) {
-	blankBuiltinEmbedCreds(t)
+	blankBuiltinProviderCreds(t)
 	yaml := "providers:\n" +
 		"  alpha:\n    kind: openai\n    base_url: http://alpha.local/v1\n    api_key: ak\n" +
 		"  zeta:\n    kind: openai\n    base_url: http://zeta.local/v1\n    api_key: zk\n"

--- a/tests/config/providers_edges_440_test.go
+++ b/tests/config/providers_edges_440_test.go
@@ -1,0 +1,113 @@
+package tests
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/provider"
+)
+
+// loadFileErr loads a config file and returns the (config, error) pair without
+// fataling, so a test can assert on a startup CONFIG_INVALID failure.
+func loadFileErr(t *testing.T, yaml string) (config.Config, error) {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), ".dir2mcp.yaml")
+	writeFile(t, p, yaml)
+	return config.LoadFile(p)
+}
+
+// TestProviders_UnknownKindIsConfigInvalid pins issue #440 F7: a provider
+// profile declaring an unrecognized/typo `kind:` must fail at startup with a
+// clear CONFIG_INVALID that names the offending profile and the bad kind —
+// rather than being silently un-selectable in `auto` and surfacing only as a
+// generic "no eligible provider" error far from its cause.
+func TestProviders_UnknownKindIsConfigInvalid(t *testing.T) {
+	_, err := loadFileErr(t, "providers:\n  mytypo:\n    kind: opnai\n    api_key: xk\n")
+	if err == nil {
+		t.Fatal("unknown provider kind must fail config validation")
+	}
+	msg := err.Error()
+	for _, want := range []string{"CONFIG_INVALID", "mytypo", "opnai"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("error %q must name the profile + bad kind (missing %q)", msg, want)
+		}
+	}
+}
+
+// TestProviders_UnknownKindOverridingBuiltinIsConfigInvalid pins that a typo
+// kind on an override of a BUILT-IN profile (not just a brand-new one) is also
+// rejected, naming that profile.
+func TestProviders_UnknownKindOverridingBuiltinIsConfigInvalid(t *testing.T) {
+	_, err := loadFileErr(t, "providers:\n  gemini:\n    kind: gemni\n")
+	if err == nil {
+		t.Fatal("unknown kind overriding a builtin must fail config validation")
+	}
+	if msg := err.Error(); !strings.Contains(msg, "gemini") || !strings.Contains(msg, "gemni") {
+		t.Fatalf("error %q must name the overridden builtin + bad kind", msg)
+	}
+}
+
+// TestProviders_KnownKindsLoadCleanly is the negative control: every built-in
+// profile carries a recognized kind, so a config with no exotic providers must
+// still load without tripping the F7 gate.
+func TestProviders_KnownKindsLoadCleanly(t *testing.T) {
+	if _, err := loadFileErr(t, "providers:\n  extra:\n    kind: openai\n    base_url: http://x.local/v1\n    api_key: k\n"); err != nil {
+		t.Fatalf("a config with only recognized kinds must load: %v", err)
+	}
+}
+
+// blankBuiltinEmbedCreds clears every built-in embed-capable credential so a
+// user-only profile is the only eligible embed backend and thus wins auto
+// selection — exercising the user-only precedence path.
+func blankBuiltinEmbedCreds(t *testing.T) {
+	t.Helper()
+	for _, k := range []string{
+		"MISTRAL_API_KEY", "OPENAI_API_KEY", "OPENROUTER_API_KEY",
+		"GEMINI_API_KEY", "COHERE_API_KEY", "ANTHROPIC_API_KEY", "ELEVENLABS_API_KEY",
+	} {
+		t.Setenv(k, "")
+	}
+}
+
+// TestProviders_UserOnlyPrecedenceIsDeclaredOrder pins issue #440 F8: user-only
+// profiles take precedence in the order they are DECLARED in the YAML
+// `providers:` mapping, not alphabetically. Two embed-capable user profiles are
+// declared in reverse-alphabetical order (zeta before alpha); auto embed must
+// resolve to the first declared (zeta). Alphabetical ordering — the prior
+// behavior, a consequence of Go map order being lost on decode — would have
+// picked alpha.
+func TestProviders_UserOnlyPrecedenceIsDeclaredOrder(t *testing.T) {
+	blankBuiltinEmbedCreds(t)
+	yaml := "providers:\n" +
+		"  zeta:\n    kind: openai\n    base_url: http://zeta.local/v1\n    api_key: zk\n" +
+		"  alpha:\n    kind: openai\n    base_url: http://alpha.local/v1\n    api_key: ak\n"
+	r := loadCfg(t, yaml).Providers()
+	p, err := r.Resolve(provider.CapEmbed)
+	if err != nil {
+		t.Fatalf("auto embed should resolve to a user-only profile: %v", err)
+	}
+	if p.Name != "zeta" {
+		t.Fatalf("auto embed = %q, want first-declared %q (precedence must be declared order, not alphabetical)", p.Name, "zeta")
+	}
+}
+
+// TestProviders_UserOnlyPrecedenceReversed is the mirror of the above: with the
+// declaration order flipped (alpha before zeta), auto embed must resolve to
+// alpha. Together the two cases prove the winner tracks declaration order
+// rather than a fixed alphabetical sort.
+func TestProviders_UserOnlyPrecedenceReversed(t *testing.T) {
+	blankBuiltinEmbedCreds(t)
+	yaml := "providers:\n" +
+		"  alpha:\n    kind: openai\n    base_url: http://alpha.local/v1\n    api_key: ak\n" +
+		"  zeta:\n    kind: openai\n    base_url: http://zeta.local/v1\n    api_key: zk\n"
+	r := loadCfg(t, yaml).Providers()
+	p, err := r.Resolve(provider.CapEmbed)
+	if err != nil {
+		t.Fatalf("auto embed should resolve to a user-only profile: %v", err)
+	}
+	if p.Name != "alpha" {
+		t.Fatalf("auto embed = %q, want first-declared %q", p.Name, "alpha")
+	}
+}

--- a/tests/provider/provider_test.go
+++ b/tests/provider/provider_test.go
@@ -188,3 +188,26 @@ func TestEmbedIdentity(t *testing.T) {
 func mustErr(_ provider.Profile, err error) error {
 	return err
 }
+
+// TestIsKnownKind pins issue #440 F7's building block: every kind in the
+// capability matrix is recognized, and a typo is not. An unrecognized kind is
+// what the config layer rejects as CONFIG_INVALID at startup.
+func TestIsKnownKind(t *testing.T) {
+	for _, k := range []provider.Kind{
+		provider.KindOpenAI, provider.KindMistral, provider.KindAnthropic,
+		provider.KindGemini, provider.KindCohere, provider.KindElevenLabs,
+		provider.KindWhisper, provider.KindOmniEmbed, provider.KindColBERT,
+	} {
+		if !provider.IsKnownKind(k) {
+			t.Errorf("IsKnownKind(%q) = false, want true", k)
+		}
+	}
+	for _, k := range []provider.Kind{"", "opnai", "gemni", "OpenAI"} {
+		if provider.IsKnownKind(k) {
+			t.Errorf("IsKnownKind(%q) = true, want false", k)
+		}
+	}
+	if provider.KnownKindsString() == "" {
+		t.Fatal("KnownKindsString must list the recognized kinds for remediation")
+	}
+}


### PR DESCRIPTION
Addresses #440 (F7 unknown-kind error, F8 profile precedence); F3 remains, spec-gated #560.

## F7 — unknown/typo `kind:` is now an actionable startup CONFIG_INVALID
An unrecognized/typo `kind:` on a provider profile has no row in the capability matrix (SPEC 8.1.2), so the profile was silently un-selectable in `auto` and surfaced only as a generic "no eligible provider" error far from its cause. New `validateProviderKinds` gate (run before the STT/media provider-resolving gates) fails `CONFIG_INVALID` naming the offending profile and the bad kind, with the recognized-kinds list as remediation. Backed by new `provider.IsKnownKind` / `provider.KnownKindsString` helpers.

## F8 — user-only profile precedence is now declared order (honest fix, not a doc patch)
User-only profile precedence was **alphabetical** (Go map order is lost on YAML decode) despite the code claiming "declared order". yaml.v3 *can* recover declared order via a node walk, so this preserves it: `providerDeclOrder` walks the `providers:` mapping node to capture key order, and `userOnlyOrder` orders user-only profiles by declaration. When order recovery fails/partial, it falls back to sorted names so precedence is always deterministic. Two mirrored behavioral tests (declare `zeta` before `alpha` -> `zeta` wins; reversed -> `alpha` wins) prove the winner tracks declaration order, not a fixed alphabetical sort.

## Scope / tests
- Scoped to F7 + F8 only; F1/F2/F4/F5/F6 already merged (#559/#592); F3 spec-gated (#560) untouched. No `dirstral-spec` re-pin.
- New black-box tests in `tests/config` (F7 unknown-kind CONFIG_INVALID naming the profile; F8 declared-order precedence both directions) and a `tests/provider` unit test for the kind helpers.
- `make check` passes (only the known worktree-only `TestSpecYAMLSecretPatterns_Compile_JWTAndBearer` submodule-absent failure, green in CI).