### PR TITLE
fix(ingest): surface multi-track audio instead of silently dropping tracks (#567)

### DIFF
--- a/internal/avutil/avutil.go
+++ b/internal/avutil/avutil.go
@@ -93,7 +93,52 @@ type MediaInfo struct {
 	// audio-only media or when not reported.
 	Width  int
 	Height int
+	// AudioStreams enumerates every audio stream in the container in ffprobe
+	// order (issue #567). It is empty for media with no audio. AudioCodec mirrors
+	// the first entry's codec for backward compatibility; consumers that must
+	// account for additional tracks — multi-language dubs / a music-&-effects
+	// track in broadcast/proxy media — read this slice instead of only AudioCodec.
+	AudioStreams []AudioStream
 }
+
+// AudioStream describes a single audio stream discovered in a media container.
+// It is the per-track census used to detect multi-track media (issue #567): the
+// transcription path feeds only the first audio stream to STT, so a container
+// bundling an original mix, per-language dubs, and a music-&-effects track would
+// otherwise be transcribed from track 0 alone with no signal that the rest
+// existed. All fields are best-effort — any may be zero/empty when ffprobe does
+// not report it — and callers MUST fail open rather than treat a missing field
+// as an error.
+type AudioStream struct {
+	// Index is the absolute ffprobe stream index within the container (across all
+	// stream types), as reported by ffprobe. The position within
+	// MediaInfo.AudioStreams gives the audio-relative order instead (0 == the
+	// first audio stream, the one ffmpeg selects by default and the only one
+	// currently transcribed; it is what `-map 0:a:0` selects).
+	Index int
+	// CodecName is the stream's codec_name (e.g. "aac"), empty when unreported.
+	CodecName string
+	// Channels is the channel count (1 mono, 2 stereo, …), 0 when unreported.
+	Channels int
+	// Language is the declared language metadata tag (ffprobe stream tag
+	// `language`, e.g. "eng", "rus", "und"), empty when the container carries no
+	// per-track language tag. It is only the tag the container declares — never
+	// inferred or detected here — so it stays general-purpose (no hardcoded
+	// language assumptions).
+	Language string
+	// Title is the declared stream `title` tag (e.g. "Music & Effects",
+	// "Commentary") when present, empty otherwise. A common broadcast hint about a
+	// track's role.
+	Title string
+}
+
+// AudioStreamCount reports how many audio streams the probed media carries.
+func (m MediaInfo) AudioStreamCount() int { return len(m.AudioStreams) }
+
+// HasMultipleAudioStreams reports whether the media carries more than one audio
+// stream — the multi-track case where transcribing only the first audio stream
+// (the current behavior) silently drops the others (issue #567).
+func (m MediaInfo) HasMultipleAudioStreams() bool { return len(m.AudioStreams) > 1 }
 
 // HasVideo reports whether the probed media carries a video stream with usable
 // dimensions, the precondition for emitting video width/height in SMIL.
@@ -103,10 +148,16 @@ func (m MediaInfo) HasVideo() bool {
 
 // ffprobeStream is the per-stream shape decoded from ffprobe -show_streams JSON.
 type ffprobeStream struct {
+	Index     int    `json:"index"`
 	CodecType string `json:"codec_type"`
 	CodecName string `json:"codec_name"`
 	Width     int    `json:"width"`
 	Height    int    `json:"height"`
+	Channels  int    `json:"channels"`
+	Tags      struct {
+		Language string `json:"language"`
+		Title    string `json:"title"`
+	} `json:"tags"`
 }
 
 // ffprobeFormat is the container shape decoded from ffprobe -show_format JSON.
@@ -134,7 +185,7 @@ func ProbeMediaInfo(ctx context.Context, path string) (MediaInfo, error) {
 	}
 	cmd := exec.CommandContext(ctx, bin,
 		"-v", "error",
-		"-show_entries", "format=format_name,bit_rate:stream=codec_type,codec_name,width,height",
+		"-show_entries", "format=format_name,bit_rate:stream=index,codec_type,codec_name,width,height,channels:stream_tags=language,title",
 		"-of", "json",
 		"--", path,
 	)
@@ -150,7 +201,10 @@ func ProbeMediaInfo(ctx context.Context, path string) (MediaInfo, error) {
 // parseMediaInfo decodes ffprobe -of json output into a MediaInfo. It is split
 // out (and exported via ParseMediaInfo) so the JSON mapping can be unit-tested
 // from the tests/ tree against captured ffprobe output without the binary. The
-// first video and first audio stream win; later streams are ignored.
+// first video stream wins for the codec/dimension fields, and AudioCodec mirrors
+// the first audio stream, but every audio stream is enumerated into AudioStreams
+// (in ffprobe order) so multi-track media is no longer silently reduced to track
+// 0 (issue #567).
 func parseMediaInfo(raw []byte) (MediaInfo, error) {
 	var probed ffprobeOutput
 	if err := json.Unmarshal(raw, &probed); err != nil {
@@ -173,8 +227,16 @@ func parseMediaInfo(raw []byte) (MediaInfo, error) {
 				}
 			}
 		case "audio":
+			as := AudioStream{
+				Index:     s.Index,
+				CodecName: strings.TrimSpace(s.CodecName),
+				Channels:  s.Channels,
+				Language:  strings.TrimSpace(s.Tags.Language),
+				Title:     strings.TrimSpace(s.Tags.Title),
+			}
+			info.AudioStreams = append(info.AudioStreams, as)
 			if info.AudioCodec == "" {
-				info.AudioCodec = strings.TrimSpace(s.CodecName)
+				info.AudioCodec = as.CodecName
 			}
 		}
 	}

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -3929,17 +3929,19 @@ func (s *Service) generateTranscriptRepresentation(ctx context.Context, doc mode
 		return false, err
 	}
 
+	// Multi-track honesty (issue #567): the transcription above fed only the first
+	// audio stream (ffmpeg's default selection) to STT. If the container carries
+	// additional audio streams — per-language dubs, an M&E track — surface them so
+	// the selection is visible rather than silent. Fired BEFORE the empty-transcript
+	// early return so a non-dialogue first track (e.g. an M&E track yielding an empty
+	// transcript) still warns about the dropped dialogue tracks (optibot #596).
+	// Best-effort and non-fatal: it never affects the transcript that was produced.
+	s.warnMultiTrackAudio(ctx, doc)
+
 	transcriptText = strings.TrimSpace(transcriptText)
 	if transcriptText == "" {
 		return false, nil
 	}
-
-	// Multi-track honesty (issue #567): the transcription above fed only the first
-	// audio stream (ffmpeg's default selection) to STT. If the container carries
-	// additional audio streams — per-language dubs, an M&E track — surface them so
-	// the selection is visible rather than silent. Best-effort and non-fatal: it
-	// never affects the transcript that was already produced.
-	s.warnMultiTrackAudio(ctx, doc)
 
 	var duration time.Duration
 	if d, derr := s.probeDuration(ctx, doc); derr == nil {

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -175,6 +175,13 @@ type Service struct {
 	// avutil.ErrNoAudioStream) without requiring the ffmpeg binary.
 	ExtractAudioTrackFunc func(ctx context.Context, path string) ([]byte, error)
 
+	// ProbeMediaInfoFunc overrides the container/stream probe used to detect
+	// multi-track audio (issue #567). Defaults to avutil.ProbeMediaInfo (ffprobe)
+	// when nil; tests set it to supply a deterministic stream census without the
+	// ffprobe binary. It is best-effort: any error leaves the transcript untouched
+	// and simply suppresses the multi-track diagnostic.
+	ProbeMediaInfoFunc func(ctx context.Context, path string) (avutil.MediaInfo, error)
+
 	// ArchiveMaxMembers and ArchiveMaxTotalBytes bound archive fan-out to contain
 	// decompression bombs (#408): the number of members ingested per archive and
 	// the aggregate uncompressed bytes buffered. A value <= 0 uses the package
@@ -2864,6 +2871,69 @@ func (s *Service) probeDuration(ctx context.Context, doc model.Document) (time.D
 	return probe(ctx, localPath)
 }
 
+// warnMultiTrackAudio surfaces multi-track media so additional audio streams are
+// not silently dropped (issue #567). The transcription path feeds only the first
+// audio stream (ffmpeg's default selection) to STT; when the container carries
+// more than one audio stream — common in broadcast/proxy media that bundles an
+// original mix, per-language dubs, and a music-&-effects track — the other tracks
+// are neither transcribed nor indexed. This emits a single structured, greppable
+// warning naming every track (audio-relative index, codec, channels, declared
+// language/title — all non-sensitive metadata, never the media bytes) so the
+// selection is honest rather than silent.
+//
+// It is best-effort: media is resolved through the CorpusFS (Localize) and probed
+// via ProbeMediaInfoFunc (default avutil.ProbeMediaInfo). Any failure — ffprobe
+// absent, an undecodable input, a localize error — silently yields no diagnostic
+// and never affects the transcript that was already produced. The full per-track
+// transcription this diagnostic points at (transcribing each stream, or selecting
+// by language) is deferred to a data-model/spec change (issue #567).
+func (s *Service) warnMultiTrackAudio(ctx context.Context, doc model.Document) {
+	probe := s.ProbeMediaInfoFunc
+	if probe == nil {
+		probe = avutil.ProbeMediaInfo
+	}
+	localPath, cleanup, err := s.corpusFS().Localize(ctx, doc.RelPath)
+	if err != nil {
+		return
+	}
+	defer cleanup()
+	info, err := probe(ctx, localPath)
+	if err != nil {
+		return
+	}
+	if !info.HasMultipleAudioStreams() {
+		return
+	}
+	streams := info.AudioStreams
+	descs := make([]string, len(streams))
+	for i, a := range streams {
+		descs[i] = describeAudioStream(i, a)
+	}
+	s.getLogger().Printf("multi-track audio: %s carries %d audio streams; only the first (%s) was transcribed — %d additional track(s) are not indexed: %s (issue #567)",
+		doc.RelPath, len(streams), descs[0], len(streams)-1, strings.Join(descs[1:], ", "))
+}
+
+// describeAudioStream renders one audio stream as a compact, non-sensitive
+// descriptor for the multi-track diagnostic (issue #567). pos is the
+// audio-relative index (0 == first audio stream, what `-map 0:a:0` selects).
+// Fields absent in the probe are omitted so the descriptor stays terse.
+func describeAudioStream(pos int, a avutil.AudioStream) string {
+	parts := []string{fmt.Sprintf("a:%d", pos)}
+	if a.CodecName != "" {
+		parts = append(parts, a.CodecName)
+	}
+	if a.Channels > 0 {
+		parts = append(parts, fmt.Sprintf("%dch", a.Channels))
+	}
+	if a.Language != "" {
+		parts = append(parts, "lang="+a.Language)
+	}
+	if a.Title != "" {
+		parts = append(parts, "title="+a.Title)
+	}
+	return "[" + strings.Join(parts, " ") + "]"
+}
+
 // detectLeadingSilence resolves the leading-silence duration for doc's media
 // using the configured detector (DetectLeadingSilenceFunc, defaulting to
 // avutil.DetectLeadingSilence with the configured threshold). It is graceful by
@@ -3863,6 +3933,13 @@ func (s *Service) generateTranscriptRepresentation(ctx context.Context, doc mode
 	if transcriptText == "" {
 		return false, nil
 	}
+
+	// Multi-track honesty (issue #567): the transcription above fed only the first
+	// audio stream (ffmpeg's default selection) to STT. If the container carries
+	// additional audio streams — per-language dubs, an M&E track — surface them so
+	// the selection is visible rather than silent. Best-effort and non-fatal: it
+	// never affects the transcript that was already produced.
+	s.warnMultiTrackAudio(ctx, doc)
 
 	var duration time.Duration
 	if d, derr := s.probeDuration(ctx, doc); derr == nil {

--- a/tests/avutil/mediainfo_test.go
+++ b/tests/avutil/mediainfo_test.go
@@ -73,6 +73,72 @@ func TestParseMediaInfoPartial(t *testing.T) {
 	}
 }
 
+// TestParseMediaInfoMultiTrackAudio pins the issue #567 census: every audio
+// stream is enumerated (in ffprobe order) with its index/codec/channels and
+// declared language/title tags, while AudioCodec stays the first stream's codec
+// for backward compatibility. A single proxy MP4 carrying an original mix, a
+// per-language dub, and a music-&-effects track must report all three so the
+// dropped tracks are not silent.
+func TestParseMediaInfoMultiTrackAudio(t *testing.T) {
+	raw := []byte(`{
+	  "streams": [
+	    {"index":0,"codec_type":"video","codec_name":"h264","width":1280,"height":720},
+	    {"index":1,"codec_type":"audio","codec_name":"aac","channels":2,"tags":{"language":"eng","title":"Original"}},
+	    {"index":2,"codec_type":"audio","codec_name":"aac","channels":2,"tags":{"language":"rus"}},
+	    {"index":3,"codec_type":"audio","codec_name":"aac","channels":2,"tags":{"title":"Music & Effects"}}
+	  ],
+	  "format": {"format_name":"mov,mp4,m4a,3gp,3g2,mj2","bit_rate":"2000000"}
+	}`)
+	info, err := avutil.ParseMediaInfo(raw)
+	if err != nil {
+		t.Fatalf("ParseMediaInfo: %v", err)
+	}
+	if info.AudioCodec != "aac" {
+		t.Fatalf("AudioCodec = %q, want first stream's codec aac", info.AudioCodec)
+	}
+	if !info.HasMultipleAudioStreams() {
+		t.Fatalf("HasMultipleAudioStreams() = false, want true for 3 audio streams")
+	}
+	if got := info.AudioStreamCount(); got != 3 {
+		t.Fatalf("AudioStreamCount() = %d, want 3", got)
+	}
+	// Enumerated in ffprobe order with absolute stream index preserved.
+	if info.AudioStreams[0].Index != 1 || info.AudioStreams[0].Language != "eng" ||
+		info.AudioStreams[0].Channels != 2 || info.AudioStreams[0].Title != "Original" {
+		t.Errorf("stream[0] = %+v, want {Index:1 aac 2ch lang=eng title=Original}", info.AudioStreams[0])
+	}
+	if info.AudioStreams[1].Index != 2 || info.AudioStreams[1].Language != "rus" {
+		t.Errorf("stream[1] = %+v, want {Index:2 lang=rus}", info.AudioStreams[1])
+	}
+	if info.AudioStreams[2].Index != 3 || info.AudioStreams[2].Title != "Music & Effects" ||
+		info.AudioStreams[2].Language != "" {
+		t.Errorf("stream[2] = %+v, want {Index:3 title=\"Music & Effects\" no-lang}", info.AudioStreams[2])
+	}
+}
+
+// TestParseMediaInfoSingleTrackAudio pins that ordinary single-track media reports
+// exactly one audio stream and is not flagged as multi-track (issue #567), so the
+// diagnostic never fires for the common case.
+func TestParseMediaInfoSingleTrackAudio(t *testing.T) {
+	raw := []byte(`{
+	  "streams": [
+	    {"index":0,"codec_type":"video","codec_name":"h264","width":1920,"height":1080},
+	    {"index":1,"codec_type":"audio","codec_name":"aac","channels":2}
+	  ],
+	  "format": {"format_name":"mov,mp4","bit_rate":"1500000"}
+	}`)
+	info, err := avutil.ParseMediaInfo(raw)
+	if err != nil {
+		t.Fatalf("ParseMediaInfo: %v", err)
+	}
+	if info.HasMultipleAudioStreams() {
+		t.Fatalf("single audio track must not report multi-track")
+	}
+	if info.AudioStreamCount() != 1 || info.AudioStreams[0].CodecName != "aac" {
+		t.Fatalf("audio streams = %+v, want one aac stream", info.AudioStreams)
+	}
+}
+
 // TestProbeMediaInfoToolNotFound pins the fail-open contract: when ffprobe is
 // absent, ProbeMediaInfo returns ErrToolNotFound so callers omit SMIL. Skipped
 // when ffprobe IS installed (then there is no "not found" path to assert).

--- a/tests/ingest/multitrack_audio_567_test.go
+++ b/tests/ingest/multitrack_audio_567_test.go
@@ -87,6 +87,46 @@ func TestMultiTrackAudio_SurfacedNotSilent(t *testing.T) {
 	}
 }
 
+// TestMultiTrackAudio_EmptyFirstTrackStillWarns is the optibot #596 regression:
+// when the first (default-selected) audio stream is a no-dialogue track — an M&E
+// track — STT yields an empty transcript. The multi-track warning MUST still fire
+// so the dropped dialogue tracks are not silent, even though no transcript
+// representation is produced (the diagnostic is emitted before the empty-transcript
+// early return).
+func TestMultiTrackAudio_EmptyFirstTrackStillWarns(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "me_first.mp4"), "fake-multitrack-video-bytes")
+	st := newRealStore(t)
+
+	svc := mustNewIngestService(t, config.Config{RootDir: root, StateDir: t.TempDir(), STTProvider: "off"}, st)
+	svc.SetTranscriber(&capturingTranscriber{text: ""}) // M&E track 0 → empty transcript
+	svc.SetSTTIdentity("whisper", "whisper-large-v3")
+
+	var logBuf bytes.Buffer
+	svc.SetLogger(log.New(&logBuf, "", 0))
+	svc.ExtractAudioTrackFunc = func(_ context.Context, _ string) ([]byte, error) {
+		return []byte("fake-extracted-audio"), nil
+	}
+	svc.ProbeMediaInfoFunc = func(_ context.Context, _ string) (avutil.MediaInfo, error) {
+		return avutil.MediaInfo{
+			Container: "mov,mp4", VideoCodec: "h264", AudioCodec: "aac",
+			AudioStreams: []avutil.AudioStream{
+				{Index: 1, CodecName: "aac", Channels: 6, Title: "Music & Effects"},
+				{Index: 2, CodecName: "aac", Channels: 2, Language: "eng", Title: "Dialogue"},
+			},
+		}, nil
+	}
+
+	f := ingest.DiscoveredFile{RelPath: "me_first.mp4", SizeBytes: 10, MTimeUnix: time.Now().Unix()}
+	if err := svc.ProcessDocument(context.Background(), f, nil, false); err != nil {
+		t.Fatalf("ProcessDocument(me_first.mp4): %v", err)
+	}
+	if logs := logBuf.String(); !strings.Contains(logs, "multi-track audio") || !strings.Contains(logs, "lang=eng") {
+		t.Fatalf("empty first-track transcript suppressed the multi-track warning (#596); logs:\n%s", logs)
+	}
+}
+
 // TestSingleTrackAudio_NoMultiTrackWarning pins that ordinary single-track media
 // (the common case) is byte-for-byte unchanged: it transcribes normally and emits
 // no multi-track diagnostic, so #567's warning never becomes noise.

--- a/tests/ingest/multitrack_audio_567_test.go
+++ b/tests/ingest/multitrack_audio_567_test.go
@@ -1,0 +1,133 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/avutil"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+)
+
+// TestMultiTrackAudio_SurfacedNotSilent is the honest-coverage guard for issue
+// #567: a media file whose container carries more than one audio stream is still
+// transcribed from the first stream only, but the dropped tracks must no longer be
+// silent — a single structured warning naming every track has to be emitted so an
+// operator can see that per-language / M&E tracks were not indexed.
+//
+// The stream census is injected via ProbeMediaInfoFunc and the audio extraction is
+// stubbed via ExtractAudioTrackFunc, so neither ffprobe nor ffmpeg is required and
+// CI stays hermetic.
+func TestMultiTrackAudio_SurfacedNotSilent(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "proxy.mp4"), "fake-multitrack-video-bytes")
+	st := newRealStore(t)
+
+	svc := mustNewIngestService(t, config.Config{RootDir: root, StateDir: t.TempDir(), STTProvider: "off"}, st)
+	tr := &capturingTranscriber{text: "[00:00] hello\n[00:03] world"}
+	svc.SetTranscriber(tr)
+	svc.SetSTTIdentity("whisper", "whisper-large-v3")
+	svc.SetTranscriptLanguage("en")
+
+	var logBuf bytes.Buffer
+	svc.SetLogger(log.New(&logBuf, "", 0))
+
+	// Stub audio extraction so the video routes to STT without ffmpeg (#495 path).
+	svc.ExtractAudioTrackFunc = func(_ context.Context, _ string) ([]byte, error) {
+		return []byte("fake-extracted-audio"), nil
+	}
+	// Inject a three-track census: an original mix, a per-language dub, and a
+	// music-&-effects track — the exact shape #567 describes.
+	svc.ProbeMediaInfoFunc = func(_ context.Context, _ string) (avutil.MediaInfo, error) {
+		return avutil.MediaInfo{
+			Container:  "mov,mp4",
+			VideoCodec: "h264",
+			AudioCodec: "aac",
+			Width:      1280,
+			Height:     720,
+			AudioStreams: []avutil.AudioStream{
+				{Index: 1, CodecName: "aac", Channels: 2, Language: "eng", Title: "Original"},
+				{Index: 2, CodecName: "aac", Channels: 2, Language: "rus"},
+				{Index: 3, CodecName: "aac", Channels: 2, Title: "Music & Effects"},
+			},
+		}, nil
+	}
+
+	f := ingest.DiscoveredFile{RelPath: "proxy.mp4", SizeBytes: 10, MTimeUnix: time.Now().Unix()}
+	if err := svc.ProcessDocument(context.Background(), f, nil, false); err != nil {
+		t.Fatalf("ProcessDocument(proxy.mp4): %v", err)
+	}
+
+	// The transcript is still produced (from the first track) — multi-track media
+	// must not break transcription.
+	if tr.calls != 1 {
+		t.Fatalf("STT calls = %d, want 1 (the first audio stream must still be transcribed)", tr.calls)
+	}
+	meta := transcriptMetaFor(t, st, "proxy.mp4")
+	if strings.TrimSpace(meta) == "" {
+		t.Fatal("multi-track media produced no transcript representation")
+	}
+
+	logs := logBuf.String()
+	if !strings.Contains(logs, "multi-track audio") {
+		t.Fatalf("no multi-track diagnostic logged; dropped tracks are silent (#567). logs:\n%s", logs)
+	}
+	// The warning must name the count and the dropped tracks so the selection is
+	// visible, not a bare "there is more than one" line.
+	for _, want := range []string{"3 audio streams", "2 additional", "lang=rus", "Music & Effects"} {
+		if !strings.Contains(logs, want) {
+			t.Errorf("multi-track diagnostic missing %q; logs:\n%s", want, logs)
+		}
+	}
+}
+
+// TestSingleTrackAudio_NoMultiTrackWarning pins that ordinary single-track media
+// (the common case) is byte-for-byte unchanged: it transcribes normally and emits
+// no multi-track diagnostic, so #567's warning never becomes noise.
+func TestSingleTrackAudio_NoMultiTrackWarning(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "single.mp4"), "fake-single-track-video-bytes")
+	st := newRealStore(t)
+
+	svc := mustNewIngestService(t, config.Config{RootDir: root, StateDir: t.TempDir(), STTProvider: "off"}, st)
+	tr := &capturingTranscriber{text: "[00:00] only one track here"}
+	svc.SetTranscriber(tr)
+	svc.SetSTTIdentity("whisper", "whisper-large-v3")
+	svc.SetTranscriptLanguage("en")
+
+	var logBuf bytes.Buffer
+	svc.SetLogger(log.New(&logBuf, "", 0))
+
+	svc.ExtractAudioTrackFunc = func(_ context.Context, _ string) ([]byte, error) {
+		return []byte("fake-extracted-audio"), nil
+	}
+	svc.ProbeMediaInfoFunc = func(_ context.Context, _ string) (avutil.MediaInfo, error) {
+		return avutil.MediaInfo{
+			Container:    "mov,mp4",
+			VideoCodec:   "h264",
+			AudioCodec:   "aac",
+			Width:        1280,
+			Height:       720,
+			AudioStreams: []avutil.AudioStream{{Index: 1, CodecName: "aac", Channels: 2, Language: "eng"}},
+		}, nil
+	}
+
+	f := ingest.DiscoveredFile{RelPath: "single.mp4", SizeBytes: 10, MTimeUnix: time.Now().Unix()}
+	if err := svc.ProcessDocument(context.Background(), f, nil, false); err != nil {
+		t.Fatalf("ProcessDocument(single.mp4): %v", err)
+	}
+
+	if tr.calls != 1 {
+		t.Fatalf("STT calls = %d, want 1", tr.calls)
+	}
+	if strings.Contains(logBuf.String(), "multi-track audio") {
+		t.Errorf("single-track media emitted a multi-track diagnostic; want none. logs:\n%s", logBuf.String())
+	}
+}


### PR DESCRIPTION
## Summary

Addresses #567. Media containers commonly carry **several audio streams** — an original mix, per-language dubs, and a music-&-effects (M&E) track are routine in broadcast/proxy media. The transcription path feeds only the **first** audio stream (ffmpeg's default selection) to STT, so the other tracks were transcribed from track 0 alone with **no signal that they existed**. That can silently mean transcribing the wrong language, or an M&E track with no dialogue (empty/garbage transcript).

## Scope decision: honest coverage, not full per-track transcription

I took the **honest-coverage path** (the issue's explicit item 4: "at minimum, log when >1 audio stream exists"), **not** the full per-track fix, because the full fix is a data-model + spec change, not a contained in-model change:

- Persisting one `transcript` representation per stream requires a new `rep_type` keying scheme. The only existing multi-transcript mechanism is the language suffix (`transcript`, `transcript-en`, …) under `UNIQUE(doc_id, rep_type)`, and that namespace is **shared with the translation path** — a source track in French (`transcript-fr`) would collide with a French translation target (`transcript-fr`).
- Per-track **selection** (skip M&E/no-speech tracks by embedded language tag or per-track langdetect — issue items 2/3) is new capability + config + retrieval/citation surface.

Per the spec-governance loop, that belongs in a dirstral-spec PR first. This PR makes the drop **honest and visible** without half-building the model change.

## Changes

- **`internal/avutil`**: `MediaInfo` now enumerates **every** audio stream via `AudioStreams []AudioStream` (index, codec, channels, declared `language`/`title` tags), plus `AudioStreamCount()` / `HasMultipleAudioStreams()`. `AudioCodec` still mirrors the first stream (backward compatible). Language/title are only the **declared container tags** — never inferred — so it stays general-purpose (no hardcoded languages).
- **`internal/ingest`**: when a transcribed media doc's container carries >1 audio stream, a single structured, greppable warning names every track (audio-relative index, codec, channels, declared lang/title — all non-sensitive metadata, never the bytes) so the selection is visible. Best-effort and non-fatal: any probe failure (ffprobe absent, undecodable input) leaves the already-produced transcript untouched. `ProbeMediaInfoFunc` override mirrors `ProbeDurationFunc` for hermetic tests.

Example log line:
```
multi-track audio: proxy.mp4 carries 3 audio streams; only the first ([a:0 aac 2ch lang=eng title=Original]) was transcribed — 2 additional track(s) are not indexed: [a:1 aac 2ch lang=rus], [a:2 aac 2ch title=Music & Effects] (issue #567)
```

## Deferred full-fix plan (for a follow-up + dirstral-spec PR)

1. **Spec/keying**: introduce a per-track transcript `rep_type` namespace disjoint from the language/translation suffixes (e.g. `transcript#a1`, `transcript#a2` by audio-relative index), and extend the read-side `store.TranscriptRepresentations` query + `meta_json` to carry track identity (index, declared language, channels).
2. **Selection** (issue items 2/3): choose which track(s) to transcribe — by config, by embedded language tag, or by per-track langdetect — and skip M&E/no-speech tracks. `ffmpeg -map 0:a:<n>` selects a stream; `avutil.MediaInfo.AudioStreams` (added here) already enumerates the candidates.
3. **Retrieval/citation**: expose which track a transcript chunk came from so answers can cite the correct language track.

## Tests

- `tests/avutil`: parse coverage for multi-track (3 streams: original / dub / M&E) and single-track JSON.
- `tests/ingest`: a 3-track container is transcribed **and** surfaced (warning names count + dropped tracks), while single-track media is unchanged and emits **no** warning. No ffprobe/ffmpeg required (`ProbeMediaInfoFunc`/`ExtractAudioTrackFunc` stubs).

## Verification

`go build ./...`, `go test ./internal/avutil/... ./internal/ingest/... ./tests/ingest/... ./tests/avutil/...` all green. `make check` green except the known worktree-only `TestSpecYAMLSecretPatterns_Compile_JWTAndBearer` (dirstral-spec submodule not checked out in the worktree; passes in CI).