### PR TITLE
fix(retrieval,store): BM25 cache-miss span + region-span page (#403 F6/F7)

### DIFF
--- a/internal/retrieval/searchhit_fallback_597_test.go
+++ b/internal/retrieval/searchhit_fallback_597_test.go
@@ -1,0 +1,20 @@
+package retrieval
+
+import "testing"
+
+// TestSearchHitForLabel_CacheMissReturnsZeroSpan pins the optibot #597 fix: the
+// metadata-cache-miss fallback must return a ZERO span (empty Kind), not the
+// degenerate Span{Kind:"lines"} placeholder — otherwise hybrid.go's
+// `cached.Span.Kind != ""` guard treats the miss as a real span and skips
+// overwriting it with a properly resolved one, re-introducing the F6 (#403)
+// lines-0-0 citation on the hybrid/vector path.
+func TestSearchHitForLabel_CacheMissReturnsZeroSpan(t *testing.T) {
+	s := &Service{}
+	hit := s.searchHitForLabel("text", 12345)
+	if hit.Span.Kind != "" {
+		t.Errorf("cache-miss span Kind = %q, want \"\" (no degenerate placeholder that clobbers a resolved span)", hit.Span.Kind)
+	}
+	if hit.ChunkID != 12345 {
+		t.Errorf("cache-miss ChunkID = %d, want 12345 (label preserved)", hit.ChunkID)
+	}
+}

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -3784,7 +3784,16 @@ func (s *Service) sliceFromMetadata(relPath string, requested model.Span) (strin
 				// range, not a plain page span. Without this, open_file page=N on
 				// a docling-extracted PDF found no metadata match and fell through
 				// to reading raw PDF bytes -> DOC_TYPE_UNSUPPORTED (issue #383).
-				matches = append(matches, candidate{page: span.Region.StartPage, text: hit.Snippet})
+				//
+				// The region covers the requested page, so attribute the slice to
+				// the page the caller actually asked about — NOT the region's
+				// primary (start) page. A multi-page region's cited text can sit on
+				// a later page than its primary, and localizing it to the primary
+				// page mis-reports where the text is (issue #403 F7). StartPage is
+				// kept as the secondary sort key so, when several chunks answer one
+				// page, they order by document reading order (and a plain page span,
+				// start 0, leads a region that merely spans into that page).
+				matches = append(matches, candidate{page: requested.Page, start: span.Region.StartPage, text: hit.Snippet})
 			}
 		case "time":
 			if !strings.EqualFold(span.Kind, "time") {

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -2366,7 +2366,12 @@ func (s *Service) searchHitForLabel(indexName string, label uint64) model.Search
 		DocType: "unknown",
 		RepType: "unknown",
 		Snippet: "",
-		Span:    model.Span{Kind: "lines"},
+		// Cache-miss fallback: a ZERO span (empty Kind), not the degenerate
+		// Span{Kind:"lines"} placeholder — the same F6 (#403) fix applied in the
+		// BM25 path. A non-empty Kind here would make hybrid.go's `cached.Span.Kind
+		// != ""` guard treat this miss as a real span and skip overwriting it with a
+		// properly resolved one (optibot #597).
+		Span: model.Span{},
 	}
 }
 

--- a/internal/store/sqlite_bm25.go
+++ b/internal/store/sqlite_bm25.go
@@ -53,12 +53,22 @@ func (s *SQLiteStore) SearchBM25(ctx context.Context, query string, k int, index
 	defer s.ReleaseDB()
 
 	args := []any{matchExpr}
+	// Resolve each hit's real span from the spans table (LEFT JOIN, 1:1 with a
+	// chunk) so a BM25 hit carries a genuine line/page/time/region span instead
+	// of the degenerate `lines 0-0` placeholder it used to hardcode (issue #403
+	// F6). Doing it here — at the query boundary — makes the span correct
+	// regardless of whether the hybrid metadata cache happens to be warm; the
+	// old code only re-attached a real span on a cache HIT, so a cache miss
+	// (reindex/eviction window) leaked a citation pointing at non-existent line 0.
 	stmt := `SELECT c.chunk_id, c.rel_path, c.doc_type, c.rep_type, c.text, c.language,
 	                COALESCE(d.title, ''), COALESCE(d.mtime_unix, 0),
+	                COALESCE(sp.span_kind, ''), COALESCE(sp.start, 0), COALESCE(sp.end, 0),
+	                COALESCE(sp.extra_json, ''),
 	                bm25(chunks_fts) AS score
 	         FROM chunks_fts
 	         JOIN chunks c ON c.chunk_id = chunks_fts.rowid
 	         LEFT JOIN documents d ON d.rel_path = c.rel_path
+	         LEFT JOIN spans sp ON sp.chunk_id = c.chunk_id
 	         WHERE chunks_fts MATCH ? AND c.deleted = 0
 	               AND c.embedding_status != 'error'`
 	if kind := strings.TrimSpace(indexKind); kind != "" {
@@ -89,14 +99,24 @@ func (s *SQLiteStore) SearchBM25(ctx context.Context, query string, k int, index
 			language  string
 			title     string
 			mtimeUnix int64
+			spanKind  string
+			spanStart int
+			spanEnd   int
+			spanExtra string
 			score     sql.NullFloat64
 		)
-		if err := rows.Scan(&chunkID, &relPath, &docType, &repType, &text, &language, &title, &mtimeUnix, &score); err != nil {
+		if err := rows.Scan(&chunkID, &relPath, &docType, &repType, &text, &language, &title, &mtimeUnix,
+			&spanKind, &spanStart, &spanEnd, &spanExtra, &score); err != nil {
 			return nil, err
 		}
 		if chunkID <= 0 {
 			continue
 		}
+		// Reconstruct the persisted span. A chunk with no span row (or an
+		// unusable one) reduces to an empty span rather than a misleading
+		// `lines 0-0`: bmSpan omits the degenerate lines placeholder so the
+		// downstream citation carries no line range instead of line 0 (#403 F6).
+		span := bmSpan(spanFromRow(spanKind, spanStart, spanEnd, spanExtra))
 		// Negate so higher-is-better matches the vector path. A NULL bm25 score
 		// (no usable term statistics for this row) maps to the worst possible
 		// final score so it ranks last, consistent with the ORDER BY above.
@@ -112,7 +132,7 @@ func (s *SQLiteStore) SearchBM25(ctx context.Context, query string, k int, index
 			RepType:   repType,
 			Score:     hitScore,
 			Snippet:   snippet(text, 240),
-			Span:      model.Span{Kind: "lines"},
+			Span:      span,
 			Language:  language,
 			MTimeUnix: mtimeUnix,
 		})
@@ -121,6 +141,23 @@ func (s *SQLiteStore) SearchBM25(ctx context.Context, query string, k int, index
 		return nil, err
 	}
 	return hits, nil
+}
+
+// bmSpan drops a degenerate "lines" span — kind "lines" with a non-positive or
+// inverted line range — down to the empty span (issue #403 F6). spanFromRow
+// falls back to `Span{Kind:"lines"}` (start/end 0) whenever a stored span is
+// missing or unusable; surfacing that as a BM25 hit's span produces a citation
+// pointing at line 0, which no client can resolve. Returning the zero Span
+// instead makes the hit carry no line range at all (the honest "unknown
+// location" state), which downstream serializers render as the schema-valid
+// document-level span rather than a phantom `lines 0-0`. Real spans of every
+// kind (valid lines, page, time, region) pass through unchanged.
+func bmSpan(span model.Span) model.Span {
+	if strings.EqualFold(strings.TrimSpace(span.Kind), "lines") &&
+		(span.StartLine <= 0 || span.EndLine < span.StartLine) {
+		return model.Span{}
+	}
+	return span
 }
 
 // sanitizeFTSQuery escapes user input for safe use as the right-hand side of

--- a/internal/store/sqlite_bm25.go
+++ b/internal/store/sqlite_bm25.go
@@ -68,7 +68,13 @@ func (s *SQLiteStore) SearchBM25(ctx context.Context, query string, k int, index
 	         FROM chunks_fts
 	         JOIN chunks c ON c.chunk_id = chunks_fts.rowid
 	         LEFT JOIN documents d ON d.rel_path = c.rel_path
-	         LEFT JOIN spans sp ON sp.chunk_id = c.chunk_id
+	         -- One span row per chunk. The spans table has no UNIQUE(chunk_id) — a
+	         -- chunk MAY carry multiple span rows (InsertChunkWithSpans accepts a
+	         -- slice), so a bare LEFT JOIN would fan out and count a chunk's BM25
+	         -- score N times, consuming the LIMIT with duplicates (optibot #597).
+	         -- GROUP BY collapses to a single (primary) span per chunk.
+	         LEFT JOIN (SELECT chunk_id, span_kind, start, "end", extra_json
+	                    FROM spans GROUP BY chunk_id) sp ON sp.chunk_id = c.chunk_id
 	         WHERE chunks_fts MATCH ? AND c.deleted = 0
 	               AND c.embedding_status != 'error'`
 	if kind := strings.TrimSpace(indexKind); kind != "" {

--- a/tests/retrieval/open_file_region_page_403_test.go
+++ b/tests/retrieval/open_file_region_page_403_test.go
@@ -1,0 +1,68 @@
+package tests
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
+)
+
+// TestOpenFile_RegionPage_AttributedToRequestedPage pins issue #403 F7: an
+// open_file page=N read that resolves a structured (docling) region chunk must
+// attribute the slice to the page the caller asked about — a page the region
+// genuinely covers — not to the region's primary (start) page. A multi-page
+// region's cited text can sit on a later page than its primary, so localizing
+// the read to the primary page mis-reports where the text is.
+//
+// The attribution is observed through slice ordering: matches sort by page and
+// then by document reading order. Before the fix a region spanning pages 1..N
+// was attributed to page 1, so it sorted ahead of a page-N-native chunk for a
+// page=N read (it looked like earlier-page content). After the fix both localize
+// to page N and the page-native span (sort key 0) leads the region that merely
+// spans into that page.
+func TestOpenFile_RegionPage_AttributedToRequestedPage(t *testing.T) {
+	svc := retrieval.NewService(nil, nil, nil, nil)
+	root := t.TempDir()
+	svc.SetRootDir(root)
+	svc.SetStateDir(filepath.Join(root, ".dir2mcp"))
+
+	const relPath = "report.pdf"
+	// A region chunk whose primary page is 1 but which spans through page 5.
+	svc.SetChunkMetadata(1, model.SearchHit{
+		RelPath: relPath,
+		Snippet: "region-spanning-1-to-5",
+		Span: model.Span{Kind: "region", Region: &model.RegionSpan{
+			StartPage: 1, EndPage: 5,
+			BBox: &model.BBox{Page: 1, L: 1, T: 2, R: 3, B: 4, CoordOrigin: "TOPLEFT"},
+		}},
+	})
+	// A chunk whose span is exactly page 5.
+	svc.SetChunkMetadata(2, model.SearchHit{
+		RelPath: relPath,
+		Snippet: "page-5-native",
+		Span:    model.Span{Kind: "page", Page: 5},
+	})
+
+	out, err := svc.OpenFile(context.Background(), relPath, model.Span{Kind: "page", Page: 5}, 20000)
+	if err != nil {
+		t.Fatalf("OpenFile page=5: %v", err)
+	}
+
+	// Both the page-5-native chunk and the region that covers page 5 are returned.
+	if !strings.Contains(out, "page-5-native") {
+		t.Fatalf("page-5-native chunk missing from page=5 read: %q", out)
+	}
+	if !strings.Contains(out, "region-spanning-1-to-5") {
+		t.Fatalf("region covering page 5 missing from page=5 read: %q", out)
+	}
+
+	// The region is now localized to the requested page 5 (not its primary page
+	// 1), so the page-5-native span leads it. Before the fix the region was
+	// attributed to page 1 and sorted first.
+	if got := strings.Index(out, "page-5-native"); got == -1 || got > strings.Index(out, "region-spanning-1-to-5") {
+		t.Fatalf("expected page-5-native content before the spanning region (region localized to primary page 1?); got %q", out)
+	}
+}

--- a/tests/store/sqlite_bm25_span_403_test.go
+++ b/tests/store/sqlite_bm25_span_403_test.go
@@ -1,0 +1,113 @@
+package tests
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// TestSQLiteStore_SearchBM25_ResolvesRealLineSpan pins issue #403 F6: a BM25 hit
+// must carry the chunk's persisted line span, not the degenerate `lines 0-0`
+// placeholder the query used to hardcode. Before the fix SearchBM25 always set
+// Span{Kind:"lines"} with zero lines, and the hybrid path only re-attached a
+// real span on a metadata-cache HIT — so a cache miss surfaced a citation
+// pointing at non-existent line 0. Resolving the span from the spans table at
+// the query boundary makes it correct regardless of cache warmth.
+func TestSQLiteStore_SearchBM25_ResolvesRealLineSpan(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	defer func() { _ = st.Close() }()
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	const relPath = "docs/lease.md"
+	if err := st.UpsertDocument(ctx, model.Document{
+		RelPath: relPath, DocType: "md", SourceType: "local", Status: "ok",
+	}); err != nil {
+		t.Fatalf("UpsertDocument: %v", err)
+	}
+	doc, err := st.GetDocumentByPath(ctx, relPath)
+	if err != nil {
+		t.Fatalf("GetDocumentByPath: %v", err)
+	}
+	err = st.WithTx(ctx, func(tx model.RepresentationStore) error {
+		repID, err := tx.UpsertRepresentation(ctx, model.Representation{
+			DocID: doc.DocID, RepType: "raw_text", RepHash: "h-lease",
+		})
+		if err != nil {
+			return err
+		}
+		ch := model.Chunk{RepID: repID, Ordinal: 0, Text: "termination notice period is thirty days", IndexKind: "text"}
+		_, err = tx.InsertChunkWithSpans(ctx, ch, []model.Span{{Kind: "lines", StartLine: 12, EndLine: 18}})
+		return err
+	})
+	if err != nil {
+		t.Fatalf("seed chunk with span: %v", err)
+	}
+
+	ls, ok := interface{}(st).(model.LexicalSearcher)
+	if !ok {
+		t.Fatalf("SQLiteStore must implement model.LexicalSearcher")
+	}
+	hits, err := ls.SearchBM25(ctx, "termination notice", 5, "text")
+	if err != nil {
+		t.Fatalf("SearchBM25: %v", err)
+	}
+	if len(hits) == 0 {
+		t.Fatalf("expected a BM25 hit for the seeded chunk")
+	}
+	span := hits[0].Span
+	if span.Kind != "lines" || span.StartLine != 12 || span.EndLine != 18 {
+		t.Fatalf("BM25 hit span = %+v, want lines 12-18 (regression: degenerate lines 0-0)", span)
+	}
+}
+
+// TestSQLiteStore_SearchBM25_OmitsSpanWhenNoneStored pins the other half of
+// issue #403 F6: a chunk with no persisted span row (e.g. a plain lexical chunk
+// written without provenance) must yield an *empty* span, not a misleading
+// `lines 0-0`. An empty span is the honest "unknown location" state that
+// downstream serializers render as a document-level span; line 0 is a phantom
+// citation no client can resolve.
+func TestSQLiteStore_SearchBM25_OmitsSpanWhenNoneStored(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	defer func() { _ = st.Close() }()
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	// UpsertChunkTask writes the chunk row (and populates chunks_fts) but no
+	// span row, so the LEFT JOIN in SearchBM25 finds no provenance.
+	task := model.NewChunkTask(1, "quarterly revenue exceeded projections", "text", model.ChunkMetadata{
+		ChunkID: 1,
+		RelPath: "docs/report.md",
+		DocType: "md",
+		RepType: "raw_text",
+	})
+	if err := st.UpsertChunkTask(ctx, task); err != nil {
+		t.Fatalf("UpsertChunkTask: %v", err)
+	}
+
+	ls, ok := interface{}(st).(model.LexicalSearcher)
+	if !ok {
+		t.Fatalf("SQLiteStore must implement model.LexicalSearcher")
+	}
+	hits, err := ls.SearchBM25(ctx, "quarterly revenue", 5, "text")
+	if err != nil {
+		t.Fatalf("SearchBM25: %v", err)
+	}
+	if len(hits) == 0 {
+		t.Fatalf("expected a BM25 hit for the spanless chunk")
+	}
+	span := hits[0].Span
+	if span.Kind != "" {
+		t.Fatalf("spanless BM25 hit span = %+v, want empty span (regression: degenerate lines 0-0)", span)
+	}
+	if span.StartLine != 0 || span.EndLine != 0 {
+		t.Fatalf("empty span must carry no line range, got start=%d end=%d", span.StartLine, span.EndLine)
+	}
+}


### PR DESCRIPTION
Addresses #403 (F6 BM25 cache-miss span, F7 region-span page); F2/F4/F5 remain, behavior/spec-gated.

## F6 — BM25-only cache-miss → degenerate `lines 0-0` span
`SearchBM25` hardcoded `Span{Kind:"lines"}` with zero lines; the hybrid path only re-attached the real span on a metadata-cache **hit** (`hybrid.go` `cached.Span.Kind != ""`). On a cache **miss** (reindex/eviction window) the citation pointed at non-existent line 0.

Fix: resolve each hit's span from the `spans` table via a `LEFT JOIN` at the query boundary (`spanFromRow`), so the span is correct — line / page / time / region — regardless of cache warmth. A chunk with no usable span row reduces to an **empty** span (the honest "unknown location", rendered downstream as a document-level span) instead of a misleading `lines 0-0` (`bmSpan` guard).

## F7 — region-span read localizes to the primary page
`open_file page=N` on a structured (docling) region chunk attributed the returned slice to the region's **primary (start) page** (`sliceFromMetadata`), even though a multi-page region's cited text can sit on a later page. Fix: attribute the slice to the **requested page** the region actually covers; keep the region start page as a secondary sort key (document reading order; a plain page span leads a region that merely spans into that page).

## Tests
- `tests/store/sqlite_bm25_span_403_test.go` — BM25 hit resolves the real line span; a spanless chunk yields an empty span (not `lines 0-0`).
- `tests/retrieval/open_file_region_page_403_test.go` — region covering page N is localized to N, ordered after page-N-native content. Verified failing pre-fix.

## Scope / deferred
- F2 (Sources force-append), F4 (default abstention), F5 (match-centered window) are behavior/policy or spec-gated — untouched.
- The deeper F7 goal of pointing a region citation at the exact page of the matched sentence needs per-block page provenance in the region-span **contract** (spec-gated) and is deferred; the read-side page attribution here is the contained correctness fix.
- `Citation`/`Span` structured field names (df-005/df-006) preserved; no submodule re-pin.

`make check` passes except the known worktree-only `TestSpecYAMLSecretPatterns_Compile_JWTAndBearer` (submodule not checked out; green in CI).