### PR TITLE
fix(provider): include normalized embed base_url in the corpus-lifetime embed identity (#560, #440 F3)

### DIFF
--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -122,17 +122,20 @@ func (a *App) runConfig(ctx context.Context, global globalOptions, args []string
 			return exitSuccess
 		}
 		embedProvider, embedReady := "none", false
+		embedBaseURL := ""
 		if ep, perr := cfg.Providers().Resolve(provider.CapEmbed); perr == nil {
 			embedProvider, embedReady = ep.Name, true
+			embedBaseURL = provider.NormalizeEmbedBaseURL(ep)
 		}
 		writef(
 			a.stdout,
-			"root=%s state_dir=%s listen=%s mcp_path=%s embed_provider=%s embed_ready=%t\n",
+			"root=%s state_dir=%s listen=%s mcp_path=%s embed_provider=%s embed_base_url=%s embed_ready=%t\n",
 			cfg.RootDir,
 			cfg.StateDir,
 			cfg.ListenAddr,
 			cfg.MCPPath,
 			embedProvider,
+			embedBaseURL,
 			embedReady,
 		)
 	default:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1437,7 +1437,9 @@ func SaveEffectiveSnapshot(cfg Config, sources SecretSourceMetadata) (string, er
 		return "", fmt.Errorf("marshal snapshot yaml: %w", err)
 	}
 	raw = appendSnapshotSecretSourceMetadata(raw, sources)
-	raw = appendSnapshotEmbedIdentity(raw, cfg.Providers().EmbedIdentity())
+	providers := cfg.Providers()
+	raw = appendSnapshotEmbedIdentity(raw, providers.EmbedIdentity())
+	raw = appendSnapshotEmbedBaseURL(raw, providers.EmbedBaseURL())
 	if len(raw) == 0 || raw[len(raw)-1] != '\n' {
 		raw = append(raw, '\n')
 	}
@@ -1494,6 +1496,25 @@ func appendSnapshotEmbedIdentity(raw []byte, id string) []byte {
 		raw = append(raw, '\n')
 	}
 	return append(raw, []byte("embed_identity: "+id+"\n")...)
+}
+
+// appendSnapshotEmbedBaseURL records the normalized embed base_url (SPEC 8.1.4
+// / §6.4 `embed_base_url`) alongside the composite embed identity so the
+// endpoint that pins the vector space is legible without parsing the identity.
+// It is the SAME normalized value already folded into embed_identity's 2nd
+// field; a canonical/default/native-surface endpoint normalizes to "" and the
+// line is omitted (nothing to disambiguate). A top-level scalar — ignored by
+// the flat config parser and the providers:/model: yaml subtree decode on
+// reload.
+func appendSnapshotEmbedBaseURL(raw []byte, baseURL string) []byte {
+	baseURL = strings.TrimSpace(baseURL)
+	if baseURL == "" {
+		return raw
+	}
+	if len(raw) > 0 && raw[len(raw)-1] != '\n' {
+		raw = append(raw, '\n')
+	}
+	return append(raw, []byte("embed_base_url: "+baseURL+"\n")...)
 }
 
 // appendSnapshotSecretSourceMetadata appends a `secret_sources:` block

--- a/internal/config/providers.go
+++ b/internal/config/providers.go
@@ -775,6 +775,19 @@ func (r ProviderResolution) EmbedIdentity() string {
 	return provider.EmbedIdentity(p, r.lateChunking)
 }
 
+// EmbedBaseURL is the normalized embed base_url component of the corpus-lifetime
+// identity (SPEC 8.1.4 / §6.4 `embed_base_url`), or "" if embed cannot be
+// resolved OR the endpoint is a native surface / canonical/default (rule 1/2).
+// It is persisted alongside the recorded identity so operators can read the
+// endpoint that pins the vector space without parsing the composite identity.
+func (r ProviderResolution) EmbedBaseURL() string {
+	p, err := r.Resolve(provider.CapEmbed)
+	if err != nil {
+		return ""
+	}
+	return provider.NormalizeEmbedBaseURL(p)
+}
+
 // Providers returns the provider resolution for cfg using os.Getenv for
 // credential expansion (SPEC §8.1). The CLI wiring (C2-iii) calls
 // Resolve per capability and builds the adapter via providerfactory.

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -10,6 +10,7 @@ package provider
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"strings"
 )
@@ -337,25 +338,28 @@ func EmbedIdentity(p Profile, lateChunking bool) string {
 		normalizeLateChunking(lateChunking))
 }
 
-// canonicalEmbedBaseURLs maps an embed-capable provider kind to the set of
-// base_urls that ship as a built-in / hosted default for that kind. An
-// effective base_url equal to one of these (after canonicalization) is
-// canonical and normalizes to "" (SPEC 8.1.4 rule 2), so an existing
-// hosted-default corpus is not forced to reindex. Native-surface kinds
-// (gemini, cohere) never consult this table — their base_url is not meaningful
-// (rule 1). Self-hosted kinds (omniembed) ship no canonical default, so any
-// configured endpoint is meaningful.
+// canonicalEmbedBaseURLByBuiltin maps a built-in embed profile NAME to the
+// base_url it ships with, so an effective base_url equal to *that profile's own*
+// shipped default canonicalizes to "" (SPEC 8.1.4 rule 2: "equals the built-in
+// profile's shipped canonical base_url **for that provider**"). Matching is
+// per-profile, NOT kind-wide: all four entries are `kind: openai`, but a profile
+// is canonical only at its own endpoint. A `mistral` profile pointed at
+// api.openai.com is therefore a non-canonical override that keeps a distinct,
+// non-empty base_url component — a kind-wide set would instead collapse both to
+// "" and let vectors from two different backends silently share one index (the
+// exact mis-bind 8.1.4 exists to prevent). Native-surface kinds (gemini, cohere)
+// never consult this table (rule 1); self-hosted kinds (omniembed) and any
+// operator-named custom profile ship no canonical default, so any configured
+// endpoint is meaningful.
 //
-// MUST stay in sync with config.builtinProfiles: these are the openai-kind
-// built-ins' shipped base URLs plus the OpenAI wire default (the `openai`
-// built-in ships no base_url; its client defaults to api.openai.com/v1).
-var canonicalEmbedBaseURLs = map[Kind][]string{
-	KindOpenAI: {
-		"https://api.openai.com/v1",    // openai built-in (client default for an empty base_url)
-		"https://api.mistral.ai/v1",    // mistral built-in (the DEFAULT embed provider)
-		"https://openrouter.ai/api/v1", // openrouter built-in
-		"http://localhost:11434/v1",    // local built-in (credential-less)
-	},
+// MUST stay in sync with config.builtinProfiles. The `openai` built-in ships no
+// base_url; its client defaults to the OpenAI wire endpoint, recorded here so an
+// explicit api.openai.com on an `openai` profile also collapses to "".
+var canonicalEmbedBaseURLByBuiltin = map[string]string{
+	"openai":     "https://api.openai.com/v1",    // client default for an empty base_url
+	"mistral":    "https://api.mistral.ai/v1",    // the DEFAULT embed provider
+	"openrouter": "https://openrouter.ai/api/v1", //
+	"local":      "http://localhost:11434/v1",    // credential-less
 }
 
 // NormalizeEmbedBaseURL renders the profile's embed base_url as the stable
@@ -369,15 +373,16 @@ func NormalizeEmbedBaseURL(p Profile) string { return normalizeEmbedBaseURL(p) }
 //   - Rule 1 (not meaningful): a kind whose embed endpoint is a single
 //     canonical provider surface (native gemini / cohere) → "". base_url does
 //     not participate.
-//   - Rule 2 (canonical/default): an unset base_url, or one equal to the
-//     built-in/hosted default for the kind (canonicalEmbedBaseURLs), → "".
-//     Only an operator-overridden, non-canonical endpoint yields a non-empty
-//     component.
+//   - Rule 2 (canonical/default): an unset base_url, or one equal to *this
+//     profile's own* built-in shipped default (canonicalEmbedBaseURLByBuiltin,
+//     matched by profile name), → "". Only an operator-overridden, non-canonical
+//     endpoint — including a built-in profile pointed at a *different* vendor's
+//     host — yields a non-empty component.
 //   - Rule 3 (canonicalization, non-empty case): canonicalizeEmbedBaseURL.
 //
 // "" is a first-class value (not "unknown"): an index built before this rule
 // recorded no base_url and MUST stay valid against any provider that also
-// normalizes to "" — so no hosted-default corpus spuriously reindexes.
+// normalizes to "" — so no default-endpoint corpus spuriously reindexes.
 func normalizeEmbedBaseURL(p Profile) string {
 	switch p.Kind {
 	case KindGemini, KindCohere:
@@ -388,9 +393,12 @@ func normalizeEmbedBaseURL(p Profile) string {
 		return "" // Rule 2: unset → canonical/default.
 	}
 	norm := canonicalizeEmbedBaseURL(raw)
-	for _, c := range canonicalEmbedBaseURLs[p.Kind] {
-		if norm == canonicalizeEmbedBaseURL(c) {
-			return "" // Rule 2: equals a built-in/hosted default.
+	// Rule 2: collapse to "" only when the endpoint equals THIS profile's own
+	// shipped default (per-profile, not kind-wide) — so a built-in pointed at a
+	// foreign host stays distinct and cannot mix vector spaces.
+	if def, ok := canonicalEmbedBaseURLByBuiltin[strings.TrimSpace(p.Name)]; ok {
+		if norm == canonicalizeEmbedBaseURL(def) {
+			return ""
 		}
 	}
 	return norm
@@ -412,7 +420,13 @@ func canonicalizeEmbedBaseURL(raw string) string {
 	}
 	u, err := url.Parse(raw)
 	if err != nil || u.Host == "" {
-		return raw
+		// Not an absolute URL (e.g. an unexpanded ${VAR}, or a value url.Parse
+		// rejects). Return a sanitized form rather than the raw string: it must
+		// never carry a "|" (the embed-identity field delimiter — a leaked "|"
+		// would corrupt normalizeEmbedIdentity's field count), a control
+		// character, or a userinfo credential (this value flows into the recorded
+		// identity, the config snapshot, and CLI output).
+		return sanitizeOpaqueBaseURL(raw)
 	}
 	u.Scheme = strings.ToLower(u.Scheme)
 	u.User = nil    // drop userinfo (never record/log a credential)
@@ -423,26 +437,62 @@ func canonicalizeEmbedBaseURL(raw string) string {
 	if (u.Scheme == "http" && port == "80") || (u.Scheme == "https" && port == "443") {
 		port = ""
 	}
-	if port != "" {
-		u.Host = host + ":" + port
-	} else {
+	// net.JoinHostPort brackets an IPv6 literal ("fe80::1" → "[fe80::1]:443");
+	// a bare host-only IPv6 literal needs the brackets too (u.Hostname() strips
+	// them). Manual host+":"+port would mis-serialize both.
+	switch {
+	case port != "":
+		u.Host = net.JoinHostPort(host, port)
+	case strings.Contains(host, ":"):
+		u.Host = "[" + host + "]"
+	default:
 		u.Host = host
 	}
-	// Collapse duplicate slashes and strip trailing slashes, preserving the
-	// leading slash and the remaining path segments.
-	if u.Path != "" {
-		for strings.Contains(u.Path, "//") {
-			u.Path = strings.ReplaceAll(u.Path, "//", "/")
+	// Collapse duplicate slashes and strip trailing slashes on the ESCAPED path,
+	// so a genuine "/" separator is normalized while a percent-encoded slash
+	// (%2F) — a distinct, non-separator path byte — is preserved rather than
+	// silently folded into a separator (which would let two different endpoints
+	// canonicalize to one identity).
+	if esc := u.EscapedPath(); esc != "" {
+		for strings.Contains(esc, "//") {
+			esc = strings.ReplaceAll(esc, "//", "/")
 		}
-		if u.Path != "/" {
-			u.Path = strings.TrimRight(u.Path, "/")
+		if esc != "/" {
+			esc = strings.TrimRight(esc, "/")
 		} else {
-			u.Path = ""
+			esc = ""
+		}
+		// Set Path (decoded) and RawPath (encoded) consistently so String()
+		// re-emits the preserved encoding.
+		u.RawPath = esc
+		if dec, derr := url.PathUnescape(esc); derr == nil {
+			u.Path = dec
+		} else {
+			u.Path = esc
 		}
 	}
-	u.RawPath = "" // force canonical re-encoding of Path in String()
 	u.Opaque = ""
 	return u.String()
+}
+
+// sanitizeOpaqueBaseURL renders a base_url that does not parse as an absolute URL
+// into a value safe to record as an embed-identity component: it drops a
+// userinfo credential prefix (…@ before the first path slash) and strips the
+// identity delimiter "|" and control characters. It deliberately does not try to
+// "fix" the value — an unexpanded ${VAR} passes through minus those hazards — so
+// the comparison in normalizeEmbedBaseURL stays deterministic.
+func sanitizeOpaqueBaseURL(raw string) string {
+	if at := strings.IndexByte(raw, '@'); at >= 0 {
+		if slash := strings.IndexByte(raw, '/'); slash < 0 || at < slash {
+			raw = raw[at+1:] // drop a leading user[:pass]@ credential
+		}
+	}
+	return strings.Map(func(r rune) rune {
+		if r == '|' || r < 0x20 || r == 0x7f {
+			return -1
+		}
+		return r
+	}, raw)
 }
 
 // normalizeLateChunking renders the late-chunking mode as the stable token

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -10,6 +10,7 @@ package provider
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 )
 
@@ -298,12 +299,22 @@ func Select(precedence []Profile, byName map[string]Profile, cap Capability, exp
 }
 
 // EmbedIdentity is the corpus-lifetime embed identity (SPEC 8.1.4):
-// provider name + text/code model + requested text/code output dimension
-// (8.1.6) + multimodal mode (8.1.7) + late-chunking mode (issue #332/#446).
-// It is recorded in the config snapshot/index and compared on load. Role
-// (8.1.5) is deliberately excluded — it does not affect vector-space
-// compatibility, but the requested dimension, multimodal mode, and
-// late-chunking mode do.
+// provider name + normalized embed base_url + text/code model + requested
+// text/code output dimension (8.1.6) + multimodal mode (8.1.7) + late-chunking
+// mode (issue #332/#446). It is recorded in the config snapshot/index and
+// compared on load. Role (8.1.5) is deliberately excluded — it does not affect
+// vector-space compatibility, but the base_url, requested dimension, multimodal
+// mode, and late-chunking mode do.
+//
+// The normalized base_url (2nd field, SPEC 8.1.4 order
+// provider|base_url|text_model|…) disambiguates two same-kind/same-model
+// profiles that point at DIFFERENT endpoints (issue #560/#440 F3): without it
+// they collapse to one identity and their vectors silently mix in one index.
+// It enters in NORMALIZED form (normalizeEmbedBaseURL): a not-meaningful kind
+// (native gemini/cohere) or a canonical/default/unset endpoint normalizes to
+// "" so that an existing hosted-default corpus — and any index built before
+// this rule — does NOT spuriously reindex; only an operator-overridden,
+// non-canonical endpoint yields a non-empty component.
 //
 // lateChunking is the resolved value of ingest.late_chunking (config, not a
 // provider attribute). It enters the identity because late chunking, once its
@@ -315,14 +326,123 @@ func Select(precedence []Profile, byName map[string]Profile, cap Capability, exp
 // EmbedIdentity cannot observe), so toggling the flag re-derives even in a build
 // with no token-embedding provider — the safe direction.
 func EmbedIdentity(p Profile, lateChunking bool) string {
-	return fmt.Sprintf("%s|%s|%s|%d|%d|%s|%s",
+	return fmt.Sprintf("%s|%s|%s|%s|%d|%d|%s|%s",
 		strings.TrimSpace(p.Name),
+		normalizeEmbedBaseURL(p),
 		strings.TrimSpace(p.EmbedTextModel),
 		strings.TrimSpace(p.EmbedCodeModel),
 		p.EmbedTextDim,
 		p.EmbedCodeDim,
 		NormalizeEmbedMultimodal(p.EmbedMultimodal),
 		normalizeLateChunking(lateChunking))
+}
+
+// canonicalEmbedBaseURLs maps an embed-capable provider kind to the set of
+// base_urls that ship as a built-in / hosted default for that kind. An
+// effective base_url equal to one of these (after canonicalization) is
+// canonical and normalizes to "" (SPEC 8.1.4 rule 2), so an existing
+// hosted-default corpus is not forced to reindex. Native-surface kinds
+// (gemini, cohere) never consult this table — their base_url is not meaningful
+// (rule 1). Self-hosted kinds (omniembed) ship no canonical default, so any
+// configured endpoint is meaningful.
+//
+// MUST stay in sync with config.builtinProfiles: these are the openai-kind
+// built-ins' shipped base URLs plus the OpenAI wire default (the `openai`
+// built-in ships no base_url; its client defaults to api.openai.com/v1).
+var canonicalEmbedBaseURLs = map[Kind][]string{
+	KindOpenAI: {
+		"https://api.openai.com/v1",    // openai built-in (client default for an empty base_url)
+		"https://api.mistral.ai/v1",    // mistral built-in (the DEFAULT embed provider)
+		"https://openrouter.ai/api/v1", // openrouter built-in
+		"http://localhost:11434/v1",    // local built-in (credential-less)
+	},
+}
+
+// NormalizeEmbedBaseURL renders the profile's embed base_url as the stable
+// component used in the embed identity (SPEC 8.1.4). See normalizeEmbedBaseURL;
+// exported so the config layer can persist the same normalized value alongside
+// the recorded identity (§6.4).
+func NormalizeEmbedBaseURL(p Profile) string { return normalizeEmbedBaseURL(p) }
+
+// normalizeEmbedBaseURL implements the SPEC 8.1.4 base_url normalization:
+//
+//   - Rule 1 (not meaningful): a kind whose embed endpoint is a single
+//     canonical provider surface (native gemini / cohere) → "". base_url does
+//     not participate.
+//   - Rule 2 (canonical/default): an unset base_url, or one equal to the
+//     built-in/hosted default for the kind (canonicalEmbedBaseURLs), → "".
+//     Only an operator-overridden, non-canonical endpoint yields a non-empty
+//     component.
+//   - Rule 3 (canonicalization, non-empty case): canonicalizeEmbedBaseURL.
+//
+// "" is a first-class value (not "unknown"): an index built before this rule
+// recorded no base_url and MUST stay valid against any provider that also
+// normalizes to "" — so no hosted-default corpus spuriously reindexes.
+func normalizeEmbedBaseURL(p Profile) string {
+	switch p.Kind {
+	case KindGemini, KindCohere:
+		return "" // Rule 1: native single-surface embed.
+	}
+	raw := strings.TrimSpace(p.BaseURL)
+	if raw == "" {
+		return "" // Rule 2: unset → canonical/default.
+	}
+	norm := canonicalizeEmbedBaseURL(raw)
+	for _, c := range canonicalEmbedBaseURLs[p.Kind] {
+		if norm == canonicalizeEmbedBaseURL(c) {
+			return "" // Rule 2: equals a built-in/hosted default.
+		}
+	}
+	return norm
+}
+
+// canonicalizeEmbedBaseURL applies SPEC 8.1.4 rule 3 so endpoints that differ
+// only cosmetically compare equal: lowercase scheme+host, drop the default
+// port (80/http, 443/https), drop userinfo/query/fragment, strip trailing and
+// collapse duplicate path slashes while PRESERVING the remaining path (e.g.
+// /v1), and apply canonical percent-encoding. Path case is preserved (only the
+// host is lowercased). Dropping userinfo also keeps credentials out of the
+// recorded identity / any log line. An input that does not parse as an
+// absolute URL (e.g. an unexpanded ${VAR}) is returned trimmed so the
+// comparison stays deterministic.
+func canonicalizeEmbedBaseURL(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return raw
+	}
+	u.Scheme = strings.ToLower(u.Scheme)
+	u.User = nil    // drop userinfo (never record/log a credential)
+	u.RawQuery = "" // drop query
+	u.Fragment = "" // drop fragment
+	host := strings.ToLower(u.Hostname())
+	port := u.Port()
+	if (u.Scheme == "http" && port == "80") || (u.Scheme == "https" && port == "443") {
+		port = ""
+	}
+	if port != "" {
+		u.Host = host + ":" + port
+	} else {
+		u.Host = host
+	}
+	// Collapse duplicate slashes and strip trailing slashes, preserving the
+	// leading slash and the remaining path segments.
+	if u.Path != "" {
+		for strings.Contains(u.Path, "//") {
+			u.Path = strings.ReplaceAll(u.Path, "//", "/")
+		}
+		if u.Path != "/" {
+			u.Path = strings.TrimRight(u.Path, "/")
+		} else {
+			u.Path = ""
+		}
+	}
+	u.RawPath = "" // force canonical re-encoding of Path in String()
+	u.Opaque = ""
+	return u.String()
 }
 
 // normalizeLateChunking renders the late-chunking mode as the stable token
@@ -369,27 +489,49 @@ func VerifyEmbedIdentity(recorded, current string) error {
 	}
 }
 
-// normalizeEmbedIdentity upgrades a legacy recorded identity to the
-// current 7-field form before comparison, so upgrading an existing corpus
-// that used native dimensions, no multimodal mode, and no late chunking does
-// not force a spurious reindex:
-//   - pre-8.1.6 (3 fields: provider|text|code)        → append "|0|0|off|off"
-//   - pre-8.1.7 (5 fields: …|tdim|cdim)               → append "|off|off"
-//   - pre-late-chunking (6 fields: …|multimodal, #446) → append "|off"
+// normalizeEmbedIdentity upgrades a legacy recorded identity to the current
+// 8-field form (provider|base_url|text|code|tdim|cdim|multimodal|late-chunking)
+// before comparison, so upgrading an existing corpus that used native
+// dimensions, no multimodal mode, no late chunking, and a hosted-default
+// endpoint does not force a spurious reindex.
 //
-// Empty (fresh index) and already-7-field values are returned unchanged.
+// EVERY pre-base_url form gains an EMPTY base_url component inserted at
+// position 2 (issue #560/#440 F3) — an index built before the base_url rule
+// recorded no endpoint, which is identity-equal to any current profile whose
+// base_url normalizes to "" (all built-in/hosted-default deployments):
+//   - pre-8.1.6 (3 fields: provider|text|code)             → insert "" + append "|0|0|off|off"
+//   - pre-8.1.7 (5 fields: …|tdim|cdim)                    → insert "" + append "|off|off"
+//   - pre-late-chunking (6 fields: …|multimodal, #446)     → insert "" + append "|off"
+//   - pre-base_url (7 fields: …|multimodal|late-chunking)  → insert "" only
+//
+// Empty (fresh index) and already-8-field values are returned unchanged. A
+// base_url component never contains "|" (canonicalizeEmbedBaseURL drops query/
+// fragment and percent-encodes the path), so field counting is unambiguous.
 func normalizeEmbedIdentity(id string) string {
 	if id == "" {
 		return ""
 	}
-	switch strings.Count(id, "|") {
-	case 2:
-		return id + "|0|0|off|off"
-	case 4:
-		return id + "|off|off"
-	case 5:
-		return id + "|off"
-	default:
+	parts := strings.Split(id, "|")
+	switch len(parts) {
+	case 3: // pre-8.1.6
+		return insertEmbedBaseURLField(parts) + "|0|0|off|off"
+	case 5: // pre-8.1.7
+		return insertEmbedBaseURLField(parts) + "|off|off"
+	case 6: // pre-late-chunking
+		return insertEmbedBaseURLField(parts) + "|off"
+	case 7: // pre-base_url (had the late-chunking field, no base_url)
+		return insertEmbedBaseURLField(parts)
+	default: // already 8 fields (current), or an unrecognized shape → unchanged
 		return id
 	}
+}
+
+// insertEmbedBaseURLField inserts an empty base_url component immediately after
+// the provider name (position 2), the slot base_url now occupies in the embed
+// identity (SPEC 8.1.4 order provider|base_url|…).
+func insertEmbedBaseURLField(parts []string) string {
+	out := make([]string, 0, len(parts)+1)
+	out = append(out, parts[0], "")
+	out = append(out, parts[1:]...)
+	return strings.Join(out, "|")
 }

--- a/tests/config/embed_identity_test.go
+++ b/tests/config/embed_identity_test.go
@@ -30,9 +30,18 @@ func TestEmbedIdentity_SnapshotRecordsAndVerifies(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read snapshot: %v", err)
 	}
-	want := "embed_identity: mistral|mistral-embed|codestral-embed"
+	// The default embed provider is the `mistral` built-in (kind openai, base
+	// https://api.mistral.ai/v1) — its base_url is canonical, so the 2nd
+	// identity field (base_url, SPEC 8.1.4 / issue #560) normalizes to "" and
+	// an existing hosted-default corpus does NOT spuriously reindex.
+	want := "embed_identity: mistral||mistral-embed|codestral-embed"
 	if !strings.Contains(string(raw), want) {
 		t.Fatalf("snapshot missing %q:\n%s", want, raw)
+	}
+	// A canonical/default endpoint has nothing to disambiguate, so the discrete
+	// embed_base_url line is omitted (only an operator-overridden endpoint records it).
+	if strings.Contains(string(raw), "embed_base_url:") {
+		t.Fatalf("canonical default must not record embed_base_url:\n%s", raw)
 	}
 
 	// Same identity -> passes.
@@ -48,5 +57,57 @@ func TestEmbedIdentity_SnapshotRecordsAndVerifies(t *testing.T) {
 	err = changed.VerifyEmbedIdentity(dir)
 	if err == nil || !strings.Contains(err.Error(), "CONFIG_INVALID") {
 		t.Fatalf("changed embed identity must be refused, got: %v", err)
+	}
+}
+
+// TestEmbedIdentity_CustomBaseURL_RecordsAndReindexes pins the SPEC 8.1.4
+// base_url rule end-to-end (issue #560/#440 F3): an operator-overridden,
+// non-canonical embed endpoint is recorded (both as embed_base_url and inside
+// embed_identity) and a corpus built on one endpoint refuses to serve on a
+// different one — the two vector spaces must not silently mix.
+func TestEmbedIdentity_CustomBaseURL_RecordsAndReindexes(t *testing.T) {
+	dir := t.TempDir()
+
+	embedAt := func(base string) config.Config {
+		cfg := loadCfg(t, ""+
+			"providers:\n"+
+			"  gpu-embed:\n"+
+			"    kind: openai\n"+
+			"    base_url: "+base+"\n"+
+			"    embed_text_model: bge-m3\n"+
+			"model:\n"+
+			"  embed:\n"+
+			"    provider: gpu-embed\n")
+		cfg.StateDir = dir
+		return cfg
+	}
+
+	// Build a corpus on custom endpoint A and snapshot it.
+	cfgA := embedAt("http://gpu-vps-a:8080/v1/")
+	if _, err := config.SaveEffectiveSnapshot(cfgA, config.SecretSourceMetadata{}); err != nil {
+		t.Fatalf("SaveEffectiveSnapshot: %v", err)
+	}
+	raw, err := os.ReadFile(config.EffectiveSnapshotPath(dir))
+	if err != nil {
+		t.Fatalf("read snapshot: %v", err)
+	}
+	// The non-canonical endpoint is recorded discretely (canonicalized: the
+	// trailing slash is stripped) and folded into the identity's 2nd field.
+	if !strings.Contains(string(raw), "embed_base_url: http://gpu-vps-a:8080/v1\n") {
+		t.Fatalf("snapshot missing discrete embed_base_url:\n%s", raw)
+	}
+	if !strings.Contains(string(raw), "embed_identity: gpu-embed|http://gpu-vps-a:8080/v1|bge-m3|") {
+		t.Fatalf("snapshot embed_identity missing base_url field:\n%s", raw)
+	}
+
+	// Same endpoint reloads without a spurious reindex.
+	if err := cfgA.VerifyEmbedIdentity(dir); err != nil {
+		t.Fatalf("same custom endpoint must pass: %v", err)
+	}
+	// A DIFFERENT custom endpoint is refused (CONFIG_INVALID): the index's
+	// vectors are pinned to endpoint A's vector space.
+	err = embedAt("http://gpu-vps-b:8080/v1").VerifyEmbedIdentity(dir)
+	if err == nil || !strings.Contains(err.Error(), "CONFIG_INVALID") {
+		t.Fatalf("different custom endpoint must be refused, got: %v", err)
 	}
 }

--- a/tests/config/providers_config_test.go
+++ b/tests/config/providers_config_test.go
@@ -161,10 +161,11 @@ func TestProviders_UserOverrideAndCustomProfile(t *testing.T) {
 func TestProviders_EmbedIdentityStable(t *testing.T) {
 	t.Setenv("MISTRAL_API_KEY", "mk")
 	id := loadCfg(t, "version: 1\n").Providers().EmbedIdentity()
-	// provider|text_model|code_model|text_dim|code_dim|multimodal|late_chunking
-	// (SPEC 8.1.4/8.1.6/8.1.7, issue #332/#446); default Mistral: native dims,
-	// multimodal + late_chunking off.
-	if id != "mistral|mistral-embed|codestral-embed|0|0|off|off" {
+	// provider|base_url|text_model|code_model|text_dim|code_dim|multimodal|
+	// late_chunking (SPEC 8.1.4/8.1.6/8.1.7, issue #332/#446/#560); default
+	// Mistral: canonical base_url normalizes to "", native dims, multimodal +
+	// late_chunking off.
+	if id != "mistral||mistral-embed|codestral-embed|0|0|off|off" {
 		t.Fatalf("embed identity = %q", id)
 	}
 }

--- a/tests/config/self_hosted_endpoints_test.go
+++ b/tests/config/self_hosted_endpoints_test.go
@@ -47,9 +47,10 @@ func TestSelfHosted_EmbedBaseURLResolves(t *testing.T) {
 	if p.EmbedTextModel != "bge-m3" {
 		t.Fatalf("embed text model = %q, want bge-m3", p.EmbedTextModel)
 	}
-	// The embed identity must encode the self-hosted profile + model so a
-	// change is corpus-lifetime / reindex-bound (SPEC §8.1.4 / §8.5).
-	if id := r.EmbedIdentity(); id != "gpu-embed|bge-m3||0|0|off|off" {
+	// The embed identity must encode the self-hosted profile + custom base_url
+	// + model so a change to any is corpus-lifetime / reindex-bound (SPEC
+	// §8.1.4 / §8.5 / issue #560): the non-canonical endpoint is the 2nd field.
+	if id := r.EmbedIdentity(); id != "gpu-embed|http://gpu-vps:8080/v1|bge-m3||0|0|off|off" {
 		t.Fatalf("embed identity = %q", id)
 	}
 }

--- a/tests/provider/provider_test.go
+++ b/tests/provider/provider_test.go
@@ -215,41 +215,19 @@ func TestEmbedIdentity_BaseURL(t *testing.T) {
 	// Rule 2 — canonical/default → "": a built-in profile AT ITS OWN shipped
 	// endpoint (matched by profile name), plus an unset base_url, normalize to
 	// "". The name must be the built-in's name: the collapse is per-profile, not
-	// kind-wide (see the foreign-host regression below).
-	for name, base := range map[string]string{
-		"openai":     "", // unset → client wire default
-		"openai/v1":  "https://api.openai.com/v1",
-		"mistral":    "https://api.mistral.ai/v1",
-		"openrouter": "https://openrouter.ai/api/v1",
-		"local":      "http://localhost:11434/v1",
+	// kind-wide (see TestEmbedIdentity_PerProfileCanonical).
+	for _, tc := range []struct{ name, base string }{
+		{"openai", ""},                          // unset → client wire default
+		{"openai", "https://api.openai.com/v1"}, // explicit wire default
+		{"mistral", "https://api.mistral.ai/v1"},
+		{"openrouter", "https://openrouter.ai/api/v1"},
+		{"local", "http://localhost:11434/v1"},
 	} {
-		// map value keys by a display label; derive the built-in name from it.
-		builtin := name
-		if i := strings.IndexByte(name, '/'); i >= 0 {
-			builtin = name[:i]
-		}
-		p := provider.Profile{Name: builtin, Kind: provider.KindOpenAI, BaseURL: base,
+		p := provider.Profile{Name: tc.name, Kind: provider.KindOpenAI, BaseURL: tc.base,
 			EmbedTextModel: "text-embedding-3-small"}
 		if got := baseURLOf(p); got != "" {
-			t.Errorf("%s: a built-in at its own default must normalize to \"\", got %q", name, got)
+			t.Errorf("%s @ %q: a built-in at its own default must normalize to \"\", got %q", tc.name, tc.base, got)
 		}
-	}
-
-	// Rule 2 regression (#560 / CodeRabbit): the collapse is PER-PROFILE, not
-	// kind-wide. A built-in `mistral` profile pointed at a *different* listed
-	// vendor's host (api.openai.com) is a non-canonical override — it must NOT
-	// collapse to "" and must produce a DIFFERENT identity from the same-named,
-	// same-model profile at its real default, or vectors from two backends could
-	// silently share one index.
-	mistralReal := provider.Profile{Name: "mistral", Kind: provider.KindOpenAI,
-		BaseURL: "https://api.mistral.ai/v1", EmbedTextModel: "text-embedding-3-small"}
-	mistralAtOpenAI := provider.Profile{Name: "mistral", Kind: provider.KindOpenAI,
-		BaseURL: "https://api.openai.com/v1", EmbedTextModel: "text-embedding-3-small"}
-	if got := baseURLOf(mistralAtOpenAI); got == "" {
-		t.Errorf("a mistral profile pointed at api.openai.com must NOT collapse to \"\" (kind-wide mixing bug)")
-	}
-	if provider.EmbedIdentity(mistralReal, false) == provider.EmbedIdentity(mistralAtOpenAI, false) {
-		t.Errorf("mistral@mistral and mistral@openai must have distinct identities")
 	}
 
 	// Rule 1 — not meaningful: native gemini/cohere normalize to "" regardless
@@ -309,6 +287,28 @@ func TestEmbedIdentity_BaseURL(t *testing.T) {
 	legacyHosted := "mistral|mistral-embed|codestral-embed|0|0|off|off" // pre-base_url 7-field
 	if err := provider.VerifyEmbedIdentity(legacyHosted, hostedCurrent); err != nil {
 		t.Errorf("pre-base_url hosted-default identity must not reindex: %v", err)
+	}
+}
+
+// TestEmbedIdentity_PerProfileCanonical is the #560 / CodeRabbit regression: the
+// Rule-2 collapse to "" is PER-PROFILE, not kind-wide. A built-in `mistral`
+// profile pointed at a *different* listed vendor's host (api.openai.com) is a
+// non-canonical override — it must NOT collapse to "" and must produce a
+// DIFFERENT identity from the same-named, same-model profile at its real
+// default, or vectors from two backends could silently share one index.
+func TestEmbedIdentity_PerProfileCanonical(t *testing.T) {
+	baseURLOf := func(p provider.Profile) string {
+		return strings.Split(provider.EmbedIdentity(p, false), "|")[1]
+	}
+	mistralReal := provider.Profile{Name: "mistral", Kind: provider.KindOpenAI,
+		BaseURL: "https://api.mistral.ai/v1", EmbedTextModel: "text-embedding-3-small"}
+	mistralAtOpenAI := provider.Profile{Name: "mistral", Kind: provider.KindOpenAI,
+		BaseURL: "https://api.openai.com/v1", EmbedTextModel: "text-embedding-3-small"}
+	if got := baseURLOf(mistralAtOpenAI); got == "" {
+		t.Errorf("a mistral profile pointed at api.openai.com must NOT collapse to \"\" (kind-wide mixing bug)")
+	}
+	if provider.EmbedIdentity(mistralReal, false) == provider.EmbedIdentity(mistralAtOpenAI, false) {
+		t.Errorf("mistral@mistral and mistral@openai must have distinct identities")
 	}
 }
 

--- a/tests/provider/provider_test.go
+++ b/tests/provider/provider_test.go
@@ -212,19 +212,44 @@ func TestEmbedIdentity_BaseURL(t *testing.T) {
 		return parts[1]
 	}
 
-	// Rule 2 — canonical/default → "": kind:openai at the OpenAI wire default,
-	// the default mistral endpoint, and an unset base_url all normalize to "".
+	// Rule 2 — canonical/default → "": a built-in profile AT ITS OWN shipped
+	// endpoint (matched by profile name), plus an unset base_url, normalize to
+	// "". The name must be the built-in's name: the collapse is per-profile, not
+	// kind-wide (see the foreign-host regression below).
 	for name, base := range map[string]string{
-		"unset":            "",
-		"openai-canonical": "https://api.openai.com/v1",
-		"mistral-default":  "https://api.mistral.ai/v1",
-		"openrouter":       "https://openrouter.ai/api/v1",
+		"openai":     "", // unset → client wire default
+		"openai/v1":  "https://api.openai.com/v1",
+		"mistral":    "https://api.mistral.ai/v1",
+		"openrouter": "https://openrouter.ai/api/v1",
+		"local":      "http://localhost:11434/v1",
 	} {
-		p := provider.Profile{Name: name, Kind: provider.KindOpenAI, BaseURL: base,
+		// map value keys by a display label; derive the built-in name from it.
+		builtin := name
+		if i := strings.IndexByte(name, '/'); i >= 0 {
+			builtin = name[:i]
+		}
+		p := provider.Profile{Name: builtin, Kind: provider.KindOpenAI, BaseURL: base,
 			EmbedTextModel: "text-embedding-3-small"}
 		if got := baseURLOf(p); got != "" {
-			t.Errorf("%s: canonical/default base_url must normalize to \"\", got %q", name, got)
+			t.Errorf("%s: a built-in at its own default must normalize to \"\", got %q", name, got)
 		}
+	}
+
+	// Rule 2 regression (#560 / CodeRabbit): the collapse is PER-PROFILE, not
+	// kind-wide. A built-in `mistral` profile pointed at a *different* listed
+	// vendor's host (api.openai.com) is a non-canonical override — it must NOT
+	// collapse to "" and must produce a DIFFERENT identity from the same-named,
+	// same-model profile at its real default, or vectors from two backends could
+	// silently share one index.
+	mistralReal := provider.Profile{Name: "mistral", Kind: provider.KindOpenAI,
+		BaseURL: "https://api.mistral.ai/v1", EmbedTextModel: "text-embedding-3-small"}
+	mistralAtOpenAI := provider.Profile{Name: "mistral", Kind: provider.KindOpenAI,
+		BaseURL: "https://api.openai.com/v1", EmbedTextModel: "text-embedding-3-small"}
+	if got := baseURLOf(mistralAtOpenAI); got == "" {
+		t.Errorf("a mistral profile pointed at api.openai.com must NOT collapse to \"\" (kind-wide mixing bug)")
+	}
+	if provider.EmbedIdentity(mistralReal, false) == provider.EmbedIdentity(mistralAtOpenAI, false) {
+		t.Errorf("mistral@mistral and mistral@openai must have distinct identities")
 	}
 
 	// Rule 1 — not meaningful: native gemini/cohere normalize to "" regardless
@@ -284,6 +309,55 @@ func TestEmbedIdentity_BaseURL(t *testing.T) {
 	legacyHosted := "mistral|mistral-embed|codestral-embed|0|0|off|off" // pre-base_url 7-field
 	if err := provider.VerifyEmbedIdentity(legacyHosted, hostedCurrent); err != nil {
 		t.Errorf("pre-base_url hosted-default identity must not reindex: %v", err)
+	}
+}
+
+// TestEmbedBaseURL_CanonicalizationRobustness pins the CodeRabbit review fixes on
+// canonicalizeEmbedBaseURL: an IPv6 literal stays bracketed, a percent-encoded
+// slash is preserved (not folded into a path separator), and a value that does
+// not parse as an absolute URL can never leak the "|" identity delimiter, a
+// control character, or a userinfo credential into the recorded component.
+func TestEmbedBaseURL_CanonicalizationRobustness(t *testing.T) {
+	// A non-built-in profile name records the canonicalized base_url verbatim
+	// (no Rule-2 collapse), so we observe canonicalizeEmbedBaseURL directly.
+	norm := func(base string) string {
+		return provider.NormalizeEmbedBaseURL(provider.Profile{
+			Name: "custom", Kind: provider.KindOpenAI, CredentialLess: true, BaseURL: base})
+	}
+
+	// IPv6 literal: brackets preserved, default port dropped, non-default kept.
+	if got := norm("https://[2001:db8::1]:443/v1"); got != "https://[2001:db8::1]/v1" {
+		t.Errorf("IPv6 default-port: got %q", got)
+	}
+	if got := norm("https://[2001:db8::1]:8443/v1"); got != "https://[2001:db8::1]:8443/v1" {
+		t.Errorf("IPv6 custom-port: got %q", got)
+	}
+
+	// Percent-encoded slash is a distinct path byte, not a separator: it must
+	// survive canonicalization (else /a%2Fb and /a/b would collapse to one id).
+	if got := norm("https://h.internal/a%2Fb/v1"); !strings.Contains(got, "%2F") && !strings.Contains(got, "%2f") {
+		t.Errorf("encoded slash must be preserved, got %q", got)
+	}
+
+	// Fallback (unparseable/relative): never emit "|" (would corrupt the
+	// 8-field identity), control chars, or a userinfo credential.
+	for _, base := range []string{"${EMBED_URL}|inject", "user:secret@${EMBED_URL}", "raw\x01ctl"} {
+		got := norm(base)
+		if strings.Contains(got, "|") {
+			t.Errorf("fallback must strip the | delimiter: %q → %q", base, got)
+		}
+		if strings.ContainsAny(got, "\x00\x01\x1f\x7f") {
+			t.Errorf("fallback must strip control chars: %q → %q", base, got)
+		}
+	}
+	if got := norm("user:secret@${EMBED_URL}"); strings.Contains(got, "secret") {
+		t.Errorf("fallback must drop a userinfo credential: got %q", got)
+	}
+	// The delimiter guarantee holds end-to-end: the identity keeps exactly 8 fields.
+	id := provider.EmbedIdentity(provider.Profile{Name: "custom", Kind: provider.KindOpenAI,
+		CredentialLess: true, BaseURL: "${EMBED_URL}|x", EmbedTextModel: "m"}, false)
+	if n := strings.Count(id, "|"); n != 7 {
+		t.Errorf("identity must have 8 fields (7 pipes), got %d: %q", n, id)
 	}
 }
 

--- a/tests/provider/provider_test.go
+++ b/tests/provider/provider_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/dirstral/dir2mcp/internal/provider"
@@ -133,10 +134,11 @@ func TestSelectAutoPrecedence(t *testing.T) {
 func TestEmbedIdentity(t *testing.T) {
 	p := provider.Profile{Name: "mistral", EmbedTextModel: "mistral-embed", EmbedCodeModel: "codestral-embed"}
 	id := provider.EmbedIdentity(p, false)
-	// Identity is provider|text_model|code_model|text_dim|code_dim|multimodal|
-	// late_chunking (SPEC 8.1.4/8.1.6/8.1.7, issue #332/#446); unset dims record
-	// as 0, multimodal + late_chunking as off.
-	if id != "mistral|mistral-embed|codestral-embed|0|0|off|off" {
+	// Identity is provider|base_url|text_model|code_model|text_dim|code_dim|
+	// multimodal|late_chunking (SPEC 8.1.4/8.1.6/8.1.7, issue #332/#446/#560);
+	// an unset/canonical base_url records as "", unset dims as 0, multimodal +
+	// late_chunking as off.
+	if id != "mistral||mistral-embed|codestral-embed|0|0|off|off" {
 		t.Fatalf("identity = %q", id)
 	}
 	if err := provider.VerifyEmbedIdentity("", id); err != nil {
@@ -166,23 +168,123 @@ func TestEmbedIdentity(t *testing.T) {
 		t.Fatalf("late-chunking mode must change embed identity")
 	}
 	// Legacy identities must NOT force a spurious reindex against the
-	// equivalent current identity: a 3-field (pre-8.1.6) normalizes to
-	// "|0|0|off|off", a 5-field (pre-8.1.7) to "|off|off", and a 6-field
-	// (pre-late-chunking, #446) to "|off".
+	// equivalent current identity. Every pre-base_url form (issue #560) gains
+	// an EMPTY base_url component at position 2, so an existing hosted-default
+	// corpus (whose current base_url normalizes to "") stays valid: a 3-field
+	// (pre-8.1.6) normalizes to "||…|0|0|off|off", a 5-field (pre-8.1.7) to
+	// "||…|off|off", a 6-field (pre-late-chunking, #446) to "||…|off", and a
+	// 7-field (pre-base_url, #560) gains only the empty base_url. The current
+	// side is the 8-field form.
+	current := "mistral||mistral-embed|codestral-embed|0|0|off|off"
 	legacy3 := "mistral|mistral-embed|codestral-embed"
-	if err := provider.VerifyEmbedIdentity(legacy3, "mistral|mistral-embed|codestral-embed|0|0|off|off"); err != nil {
+	if err := provider.VerifyEmbedIdentity(legacy3, current); err != nil {
 		t.Errorf("legacy 3-field identity must match native current: %v", err)
 	}
 	legacy5 := "mistral|mistral-embed|codestral-embed|0|0"
-	if err := provider.VerifyEmbedIdentity(legacy5, "mistral|mistral-embed|codestral-embed|0|0|off|off"); err != nil {
+	if err := provider.VerifyEmbedIdentity(legacy5, current); err != nil {
 		t.Errorf("legacy 5-field identity must match off-mode current: %v", err)
 	}
 	legacy6 := "mistral|mistral-embed|codestral-embed|0|0|off"
-	if err := provider.VerifyEmbedIdentity(legacy6, "mistral|mistral-embed|codestral-embed|0|0|off|off"); err != nil {
+	if err := provider.VerifyEmbedIdentity(legacy6, current); err != nil {
 		t.Errorf("legacy 6-field identity must match late-chunking-off current: %v", err)
 	}
+	// pre-base_url 7-field form (had the late-chunking field, no base_url).
+	legacy7 := "mistral|mistral-embed|codestral-embed|0|0|off|off"
+	if err := provider.VerifyEmbedIdentity(legacy7, current); err != nil {
+		t.Errorf("legacy 7-field (pre-base_url) identity must match current: %v", err)
+	}
 	// But a legacy identity vs a non-native dimension still mismatches.
-	_ = cfgErr(t, provider.VerifyEmbedIdentity(legacy3, "mistral|mistral-embed|codestral-embed|768|0|off|off"))
+	_ = cfgErr(t, provider.VerifyEmbedIdentity(legacy3, "mistral||mistral-embed|codestral-embed|768|0|off|off"))
+}
+
+// TestEmbedIdentity_BaseURL exercises the SPEC 8.1.4 base_url component of the
+// embed identity (issue #560/#440 F3): two same-kind/same-model profiles at
+// DIFFERENT endpoints must NOT collapse to one identity, while a canonical /
+// default / native-surface endpoint normalizes to "" so no hosted-default
+// corpus spuriously reindexes.
+func TestEmbedIdentity_BaseURL(t *testing.T) {
+	// baseURLOf extracts the 2nd identity field (the normalized base_url).
+	baseURLOf := func(p provider.Profile) string {
+		parts := strings.Split(provider.EmbedIdentity(p, false), "|")
+		if len(parts) < 2 {
+			t.Fatalf("identity has no base_url field: %q", provider.EmbedIdentity(p, false))
+		}
+		return parts[1]
+	}
+
+	// Rule 2 — canonical/default → "": kind:openai at the OpenAI wire default,
+	// the default mistral endpoint, and an unset base_url all normalize to "".
+	for name, base := range map[string]string{
+		"unset":            "",
+		"openai-canonical": "https://api.openai.com/v1",
+		"mistral-default":  "https://api.mistral.ai/v1",
+		"openrouter":       "https://openrouter.ai/api/v1",
+	} {
+		p := provider.Profile{Name: name, Kind: provider.KindOpenAI, BaseURL: base,
+			EmbedTextModel: "text-embedding-3-small"}
+		if got := baseURLOf(p); got != "" {
+			t.Errorf("%s: canonical/default base_url must normalize to \"\", got %q", name, got)
+		}
+	}
+
+	// Rule 1 — not meaningful: native gemini/cohere normalize to "" regardless
+	// of any configured base_url (single canonical provider surface).
+	for _, k := range []provider.Kind{provider.KindGemini, provider.KindCohere} {
+		p := provider.Profile{Name: string(k), Kind: k, BaseURL: "https://custom.example.com/v9",
+			EmbedTextModel: "m"}
+		if got := baseURLOf(p); got != "" {
+			t.Errorf("kind %s: base_url must not participate (rule 1), got %q", k, got)
+		}
+	}
+
+	// A custom (non-canonical) endpoint yields a non-empty component, and two
+	// kind:openai profiles at DIFFERENT custom endpoints produce DIFFERENT
+	// identities (the #560 bug: without base_url they collapse and mix vectors).
+	a := provider.Profile{Name: "vllm", Kind: provider.KindOpenAI, CredentialLess: true,
+		BaseURL: "https://vllm-a.internal/v1", EmbedTextModel: "bge-m3"}
+	b := provider.Profile{Name: "vllm", Kind: provider.KindOpenAI, CredentialLess: true,
+		BaseURL: "https://vllm-b.internal/v1", EmbedTextModel: "bge-m3"}
+	if baseURLOf(a) == "" || baseURLOf(b) == "" {
+		t.Fatalf("custom endpoints must yield a non-empty base_url component: %q %q", baseURLOf(a), baseURLOf(b))
+	}
+	idA, idB := provider.EmbedIdentity(a, false), provider.EmbedIdentity(b, false)
+	if idA == idB {
+		t.Fatalf("two kind:openai profiles at different custom endpoints must differ: %q", idA)
+	}
+	// A corpus built on custom endpoint A must refuse to serve on endpoint B.
+	_ = cfgErr(t, provider.VerifyEmbedIdentity(idA, idB))
+	// …and match itself (no spurious reindex on the same custom endpoint).
+	if err := provider.VerifyEmbedIdentity(idA, idA); err != nil {
+		t.Errorf("same custom endpoint must pass: %v", err)
+	}
+
+	// Rule 3 — URL canonicalization: trailing slash, default port, uppercase
+	// host, userinfo, and duplicate slashes all normalize to one value.
+	canon := baseURLOf(a) // "https://vllm-a.internal/v1"
+	for _, variant := range []string{
+		"https://vllm-a.internal/v1/",
+		"https://vllm-a.internal:443/v1",
+		"https://VLLM-A.INTERNAL/v1",
+		"https://user:secret@vllm-a.internal/v1", // userinfo dropped (never recorded/logged)
+		"https://vllm-a.internal//v1",
+		"https://vllm-a.internal/v1?x=1#frag",
+	} {
+		p := provider.Profile{Name: "vllm", Kind: provider.KindOpenAI, CredentialLess: true,
+			BaseURL: variant, EmbedTextModel: "bge-m3"}
+		if got := baseURLOf(p); got != canon {
+			t.Errorf("canonicalization: %q normalized to %q, want %q", variant, got, canon)
+		}
+	}
+
+	// A pre-base_url legacy identity (recorded on a hosted default, no base_url)
+	// stays valid against the current hosted-default identity — no spurious
+	// reindex — but mismatches a corpus pinned to a custom endpoint.
+	hostedCurrent := provider.EmbedIdentity(provider.Profile{Name: "mistral", Kind: provider.KindOpenAI,
+		BaseURL: "https://api.mistral.ai/v1", EmbedTextModel: "mistral-embed", EmbedCodeModel: "codestral-embed"}, false)
+	legacyHosted := "mistral|mistral-embed|codestral-embed|0|0|off|off" // pre-base_url 7-field
+	if err := provider.VerifyEmbedIdentity(legacyHosted, hostedCurrent); err != nil {
+		t.Errorf("pre-base_url hosted-default identity must not reindex: %v", err)
+	}
 }
 
 func mustErr(_ provider.Profile, err error) error {


### PR DESCRIPTION
## Summary

Two providers of the same kind/model at **different** `base_url`s collapsed to one `EmbedIdentity`, so their vectors could silently mix in a single index (forbidden by SPEC §8.1.4). This adds the normalized `base_url` as the **2nd** identity field, matching the spec order `provider | base_url | text_model | code_model | text_dim | code_dim | multimodal | late_chunking`.

The spec is **already** normative on this (§8.1.4), so the `dirstral-spec` submodule is **untouched** — pure code conformance.

Closes #560. Also resolves #440 sub-bug **F3**.

## `base_url` normalization (`normalizeEmbedBaseURL`)

- **Rule 1 — not meaningful:** native single-surface kinds (`gemini`, `cohere`) → `""` (base_url does not participate).
- **Rule 2 — canonical/default:** an unset `base_url`, or one equal to a built-in/hosted default for the kind, → `""`. The canonical set (`canonicalEmbedBaseURLs`) mirrors `config.builtinProfiles`: `https://api.openai.com/v1` (openai wire default), the default `mistral` `https://api.mistral.ai/v1`, openrouter, and local. Only an operator-**overridden**, non-canonical endpoint yields a non-empty component.
- **Rule 3 — canonicalization:** lowercase scheme+host, drop default port (80/443), drop userinfo/query/fragment, strip trailing + collapse duplicate path slashes (preserving `/v1`), canonical percent-encoding. (Dropping userinfo also keeps credentials out of the recorded identity and any log line.)

## No spurious reindex (the risky part)

`""` is a **first-class** value, not "unknown". An index built before this rule recorded no `base_url`; it must stay valid against any provider that also normalizes to `""` (every built-in/hosted-default deployment). `normalizeEmbedIdentity` now **inserts an empty `base_url` at position 2** for every pre-base_url recorded form and appends the trailing fields by age:

| recorded form | fields | upgraded to (8-field current) |
|---|---|---|
| pre-8.1.6 `provider\|text\|code` | 3 | `provider\|\|text\|code\|0\|0\|off\|off` |
| pre-8.1.7 `…\|tdim\|cdim` | 5 | insert `""` + `\|off\|off` |
| pre-late-chunking `…\|multimodal` | 6 | insert `""` + `\|off` |
| pre-base_url `…\|multimodal\|late_chunking` | 7 | insert `""` only |
| current | 8 | unchanged |

So an existing hosted-default corpus (e.g. default Mistral, whose `api.mistral.ai/v1` normalizes to `""`) compares **equal** and does **not** reindex. Only a corpus on a custom endpoint sees a one-time `CONFIG_INVALID`/reindex on first reload.

## Persistence

Records the normalized value discretely as `embed_base_url` in the effective snapshot and `config print`, alongside the composite `embed_identity` (SPEC §6.4 / §8.1.4). The line is omitted when it normalizes to `""` (nothing to disambiguate).

## Tests

- **No spurious reindex:** pre-base_url legacy identities (3/5/6/7-field) verify OK against the current hosted-default identity; the default-Mistral snapshot records `mistral||mistral-embed|…` with no `embed_base_url` line.
- **Custom endpoint triggers reindex:** two `kind: openai` profiles at different custom `base_url`s produce different identities; a corpus built on endpoint A refuses to serve on B (`CONFIG_INVALID`) end-to-end.
- **Canonical/default → `""`:** `kind: openai` at `https://api.openai.com/v1` (and unset), the default mistral endpoint, openrouter.
- **Not-meaningful kinds:** gemini/cohere → `""` regardless of configured `base_url`.
- **URL canonicalization:** trailing slash / `:443` / uppercase host / userinfo / duplicate slashes / query+fragment all normalize equal.

## Verification

- `go build ./...` and the provider/config/cli/embedqueue/index/ingest suites pass.
- `make check` is all-pass except the expected worktree-only `TestSpecYAMLSecretPatterns_Compile_JWTAndBearer` (submodule not checked out in the worktree; green in CI).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `config print` and saved effective snapshots now include the resolved `embed_base_url` when embedding is available.
  * Embedding configuration identities now incorporate a normalized `base_url`, improving differentiation between distinct self-hosted endpoints.
* **Bug Fixes**
  * Backward compatibility is maintained for older saved embed identity formats.
  * Canonical/default endpoints avoid recording unnecessary `embed_base_url` details.
* **Tests**
  * Expanded coverage for identity/version compatibility, endpoint overrides, and base URL canonicalization robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->