### PR TITLE
fix(ingest): windowed chat translation for cross-line context (#573)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,6 +49,18 @@ const (
 // cue is merged into that cue.
 const DefaultMediaSubtitlesAlignToleranceMS = 2500
 
+// DefaultMediaTranslateWindowLines / DefaultMediaTranslateContextLines are the
+// built-in chat translate-engine window sizes (issue #573): translate cues in
+// batches of DefaultMediaTranslateWindowLines, each carrying a read-only margin
+// of DefaultMediaTranslateContextLines cues on either side. The window is large
+// enough to give the model real cross-cue context (referents, split sentences,
+// terminology) while staying a bounded single request; the margin is deliberately
+// small so context stays cheap. Both are language-agnostic (general-purpose).
+const (
+	DefaultMediaTranslateWindowLines  = 16
+	DefaultMediaTranslateContextLines = 3
+)
+
 type SecretSourceMetadata struct {
 	ElevenLabsAPIKey     string
 	CohereAPIKey         string
@@ -488,6 +500,25 @@ type Config struct {
 	// accumulate. 0 (default) preserves the historical single-pass behavior. Only
 	// consulted for MediaTranslateEngine="whisper".
 	MediaTranslateWhisperWindowSec int
+	// MediaTranslateWindowLines sets how many consecutive transcript cues the
+	// chat translate engine sends to the model in ONE request (config
+	// `media.translate.window_lines`, issue #573). Translating cues in a window
+	// lets the model see neighbouring cues, so it can resolve pronouns/agreement,
+	// keep split sentences coherent, and hold terminology consistent — the blind
+	// per-cue path degraded quality, worst on low-resource languages. A strict
+	// numbered 1:1 request/response contract preserves the one-source-cue ↔
+	// one-output-line invariant chunkTranscriptByTime depends on; a malformed
+	// batch response falls back to per-line translation for that window (never a
+	// desync). 0 (unset) means the built-in default; <=1 restores the historical
+	// per-line behaviour (and, with window_lines<=1 and context_lines=0, keeps
+	// pre-windowing translate caches valid). Only consulted for engine="chat".
+	MediaTranslateWindowLines int
+	// MediaTranslateContextLines sets how many surrounding cues on EACH side of a
+	// window are supplied to the chat translate engine as READ-ONLY context —
+	// shown to the model to disambiguate but never re-translated or returned
+	// (config `media.translate.context_lines`, issue #573). 0 means no margin.
+	// Only consulted for engine="chat".
+	MediaTranslateContextLines int
 	// MediaFilterWords is an optional, general-purpose list of boilerplate /
 	// credits / watermark phrases stripped from transcript and subtitle text
 	// (config `media.filter_words`). Matching is case-insensitive substring
@@ -806,6 +837,8 @@ type fileConfig struct {
 	MediaTranslateTargetLangs          []string
 	MediaTranslateEngine               *string
 	MediaTranslateWhisperWindowSec     *int
+	MediaTranslateWindowLines          *int
+	MediaTranslateContextLines         *int
 	MediaFilterWords                   []string
 	MediaSubtitlesTTMLEnabled          *bool
 	MediaSubtitlesTTMLAlignToleranceMS *int
@@ -948,6 +981,8 @@ type persistedConfig struct {
 	MediaTranslateTargetLangs          []string      `yaml:"media_translate_target_langs"`
 	MediaTranslateEngine               string        `yaml:"media_translate_engine"`
 	MediaTranslateWhisperWindowSec     int           `yaml:"media_translate_whisper_window_sec"`
+	MediaTranslateWindowLines          int           `yaml:"media_translate_window_lines"`
+	MediaTranslateContextLines         int           `yaml:"media_translate_context_lines"`
 	MediaFilterWords                   []string      `yaml:"media_filter_words"`
 	MediaSubtitlesTTMLEnabled          bool          `yaml:"media_subtitles_ttml_enabled"`
 	MediaSubtitlesTTMLAlignToleranceMS int           `yaml:"media_subtitles_ttml_align_tolerance_ms"`
@@ -1177,6 +1212,12 @@ func Default() Config {
 		MediaTranslateEnabled:     false,
 		MediaTranslateTargetLangs: nil,
 		MediaTranslateEngine:      "chat",
+		// Cross-line context for the chat translate engine (issue #573): translate
+		// cues in windows of this many, each with a small read-only margin, so the
+		// model sees neighbouring cues. On by default (quality fix); the 1:1
+		// numbered contract + per-window fallback keep subtitle timing exact.
+		MediaTranslateWindowLines:  DefaultMediaTranslateWindowLines,
+		MediaTranslateContextLines: DefaultMediaTranslateContextLines,
 		// Bilingual subtitle export (SPEC §8.6.10) is OFF by default; the align
 		// tolerance carries its spec default so an enabled-but-unspecified config
 		// behaves predictably.
@@ -1315,6 +1356,8 @@ func buildPersistedConfig(cfg *Config) persistedConfig {
 		MediaTranslateTargetLangs:          append([]string(nil), cfg.MediaTranslateTargetLangs...),
 		MediaTranslateEngine:               cfg.MediaTranslateEngine,
 		MediaTranslateWhisperWindowSec:     cfg.MediaTranslateWhisperWindowSec,
+		MediaTranslateWindowLines:          cfg.MediaTranslateWindowLines,
+		MediaTranslateContextLines:         cfg.MediaTranslateContextLines,
 		MediaFilterWords:                   append([]string(nil), cfg.MediaFilterWords...),
 		MediaSubtitlesTTMLEnabled:          cfg.MediaSubtitlesTTMLEnabled,
 		MediaSubtitlesTTMLAlignToleranceMS: cfg.MediaSubtitlesTTMLAlignToleranceMS,
@@ -2073,6 +2116,12 @@ func applyMediaFileParsed(cfg *Config, fc fileConfig) {
 	if fc.MediaTranslateWhisperWindowSec != nil {
 		cfg.MediaTranslateWhisperWindowSec = *fc.MediaTranslateWhisperWindowSec
 	}
+	if fc.MediaTranslateWindowLines != nil {
+		cfg.MediaTranslateWindowLines = *fc.MediaTranslateWindowLines
+	}
+	if fc.MediaTranslateContextLines != nil {
+		cfg.MediaTranslateContextLines = *fc.MediaTranslateContextLines
+	}
 	if fc.MediaFilterWords != nil {
 		cfg.MediaFilterWords = normalizeStringSlice(fc.MediaFilterWords)
 	}
@@ -2476,6 +2525,8 @@ var configKeyAliases = map[string]string{
 	"media_translate_target_langs":            "media.translate.target_langs",
 	"media_translate_engine":                  "media.translate.engine",
 	"media_translate_whisper_window_sec":      "media.translate.whisper_window_sec",
+	"media_translate_window_lines":            "media.translate.window_lines",
+	"media_translate_context_lines":           "media.translate.context_lines",
 	"media_filter_words":                      "media.filter_words",
 	"filter_words":                            "media.filter_words",
 	"media_subtitles_ttml_enabled":            "media.subtitles.ttml.enabled",
@@ -2684,6 +2735,8 @@ var intFileScalarTargets = map[string]func(*fileConfig) **int{
 	"rerank.candidate_pool":              func(c *fileConfig) **int { return &c.RerankCandidatePool },
 	"media.audio_window_sec":             func(c *fileConfig) **int { return &c.MediaAudioWindowSec },
 	"media.translate.whisper_window_sec": func(c *fileConfig) **int { return &c.MediaTranslateWhisperWindowSec },
+	"media.translate.window_lines":       func(c *fileConfig) **int { return &c.MediaTranslateWindowLines },
+	"media.translate.context_lines":      func(c *fileConfig) **int { return &c.MediaTranslateContextLines },
 	"media.video_window_sec":             func(c *fileConfig) **int { return &c.MediaVideoWindowSec },
 	"media.clip.max_duration_ms":         func(c *fileConfig) **int { return &c.MediaClipMaxDurationMS },
 	"media.clip.max_bytes":               func(c *fileConfig) **int { return &c.MediaClipMaxBytes },
@@ -2727,6 +2780,8 @@ var nonNegativeIntKeys = map[string]bool{
 	"retrieval.adaptive.k_max":                true,
 	"media.audio_window_sec":                  true,
 	"media.translate.whisper_window_sec":      true,
+	"media.translate.window_lines":            true,
+	"media.translate.context_lines":           true,
 	"media.video_window_sec":                  true,
 	"media.clip.max_duration_ms":              true,
 	"media.clip.max_bytes":                    true,
@@ -3161,6 +3216,8 @@ func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	}
 	writeInt("media_audio_window_sec", cfg.MediaAudioWindowSec)
 	writeInt("media_translate_whisper_window_sec", cfg.MediaTranslateWhisperWindowSec)
+	writeInt("media_translate_window_lines", cfg.MediaTranslateWindowLines)
+	writeInt("media_translate_context_lines", cfg.MediaTranslateContextLines)
 	writeInt("media_video_window_sec", cfg.MediaVideoWindowSec)
 	writeInt("media_clip_max_duration_ms", cfg.MediaClipMaxDurationMS)
 	writeInt("media_clip_max_bytes", cfg.MediaClipMaxBytes)

--- a/internal/ingest/derivation.go
+++ b/internal/ingest/derivation.go
@@ -384,8 +384,14 @@ func (s *Service) activeTranslateIdentity(targetLang string) string {
 	if strings.TrimSpace(s.translateProvider) == "" && strings.TrimSpace(s.translateModel) == "" {
 		return ""
 	}
+	// Fold the chat translate window/margin shape into the identity's version
+	// field (issue #573): the windowed 1:1 batch prompt gives the model cross-cue
+	// context, so its output differs from the isolated per-line prompt and from a
+	// different window shape. A stale cached translation would be mislabeled by the
+	// rep's recorded provider/model, so a shape change MUST miss the cache. The
+	// historical per-line shape folds "" so pre-windowing caches stay valid.
 	return derivationIdentity(string(provider.CapTranslate),
-		s.translateProvider, s.translateModel, "", targetLang)
+		s.translateProvider, s.translateModel, s.translateWindowShape(), targetLang)
 }
 
 // translateCacheKey returns the on-disk translation cache filename stem for the

--- a/internal/ingest/translate.go
+++ b/internal/ingest/translate.go
@@ -5,8 +5,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 
+	"github.com/dirstral/dir2mcp/internal/config"
 	"github.com/dirstral/dir2mcp/internal/model"
 )
 
@@ -52,51 +55,205 @@ func (s *Service) readOrComputeTranslation(ctx context.Context, content []byte, 
 	return out, nil
 }
 
+// translateCell is one source transcript line decomposed into its verbatim
+// leading timestamp marker and spoken body, plus the translated body once
+// resolved. A cell is translatable when its body has non-whitespace text; empty
+// lines and marker-only lines pass through unchanged so the output keeps exactly
+// one line per source line (the anti-desync invariant chunkTranscriptByTime
+// relies on).
+type translateCell struct {
+	marker       string
+	body         string
+	translated   string
+	translatable bool
+}
+
 // translateTranscriptText translates a segment-formatted transcript into
 // targetLang while keeping it time-aligned to the source (SPEC §8.6.2): each
 // source line's leading [mm:ss] / mm:ss timestamp marker is preserved VERBATIM
 // and only the spoken text is translated, so chunkTranscriptByTime produces the
-// same time spans for the translated transcript as for the source. Lines are
-// translated segment-by-segment via the chat Generator; a line with no timestamp
-// marker is translated as-is (its leading-marker, if any, is empty).
+// same time spans for the translated transcript as for the source.
+//
+// Cues are translated in WINDOWS of translateWindowLines() consecutive cues per
+// chat call, each window carrying a read-only margin of translateContextLines()
+// surrounding cues, so the model sees neighbouring cues and can resolve
+// referents/agreement, keep split sentences coherent, and hold terminology
+// consistent (issue #573). A strict numbered 1:1 request/response contract lets
+// the batch be verified — exactly one output line per input cue, in order. On any
+// count/format mismatch the window safe-degrades to per-line translation, so a
+// malformed model response can never drop/merge/reorder cues and desync subtitle
+// timing. The historical per-line path is used directly when the effective window
+// is <=1 with no margin (an explicit opt-out that also keeps pre-windowing
+// translate caches valid — see translateWindowShape).
 func (s *Service) translateTranscriptText(ctx context.Context, sourceText, targetLang string) (string, error) {
 	lines := strings.Split(sourceText, "\n")
-	out := make([]string, 0, len(lines))
-	for _, line := range lines {
+	cells := make([]translateCell, len(lines))
+	var order []int // indices into cells that carry translatable text, in order
+	for i, line := range lines {
 		if strings.TrimSpace(line) == "" {
-			out = append(out, "")
-			continue
+			continue // zero-value cell: empty line passes through as ""
 		}
 		marker, body := splitTimestampMarker(line)
-		translatedBody, err := s.translateLine(ctx, body, targetLang)
-		if err != nil {
-			return "", err
-		}
-		// Collapse any internal newlines/whitespace runs the chat provider may
-		// have returned into single spaces, so one source segment stays exactly
-		// one output line — otherwise an extra line would desync the translated
-		// transcript's time spans from the source (chunkTranscriptByTime keys on
-		// per-line [mm:ss] markers).
-		translatedBody = strings.Join(strings.Fields(translatedBody), " ")
-		switch {
-		case marker == "":
-			out = append(out, translatedBody)
-		case translatedBody == "":
-			out = append(out, marker)
-		default:
-			out = append(out, marker+" "+translatedBody)
+		cells[i] = translateCell{marker: marker, body: body}
+		if strings.TrimSpace(body) != "" {
+			cells[i].translatable = true
+			order = append(order, i)
 		}
 	}
+
+	windowN := s.translateWindowLines()
+	marginM := s.translateContextLines()
+	if windowN <= 1 && marginM == 0 {
+		// Explicit opt-out: translate each cue in isolation (historical behaviour).
+		if err := s.translateCellsPerLine(ctx, cells, order, targetLang); err != nil {
+			return "", err
+		}
+	} else {
+		for start := 0; start < len(order); start += windowN {
+			end := min(start+windowN, len(order))
+			if err := s.translateWindow(ctx, cells, order, start, end, marginM, targetLang); err != nil {
+				return "", err
+			}
+		}
+	}
+
+	out := make([]string, len(cells))
+	for i := range cells {
+		if !cells[i].translatable {
+			// Empty line -> "" (zero-value marker); marker-only line -> marker.
+			out[i] = cells[i].marker
+			continue
+		}
+		out[i] = assembleTranslatedLine(cells[i].marker, cells[i].translated)
+	}
 	return strings.Join(out, "\n"), nil
+}
+
+// translateWindowLines resolves the effective chat-translate window size from
+// config: 0 (unset) means the built-in default; <1 is clamped to 1 (per-line).
+func (s *Service) translateWindowLines() int {
+	n := s.cfg.MediaTranslateWindowLines
+	switch {
+	case n == 0:
+		return config.DefaultMediaTranslateWindowLines
+	case n < 1:
+		return 1
+	default:
+		return n
+	}
+}
+
+// translateContextLines resolves the effective read-only context margin (cues on
+// each side of a window) from config; negative is clamped to 0.
+func (s *Service) translateContextLines() int {
+	if m := s.cfg.MediaTranslateContextLines; m > 0 {
+		return m
+	}
+	return 0
+}
+
+// translateWindowShape is the identity token folded into the translate derivation
+// identity (activeTranslateIdentity) so a change to the window/margin — which
+// materially changes the cross-line context the model sees and therefore its
+// output — invalidates cached translations (§8.6.7). The historical per-line path
+// (window<=1, margin==0) folds NOTHING, so pre-windowing caches stay valid for
+// that explicit opt-out. It is chat-engine only: the whisper engine keys its own
+// cache on the STT identity (readOrComputeWhisperTranslation) and never consults
+// this identity, so its cache is untouched.
+func (s *Service) translateWindowShape() string {
+	if s.translateEngine == "whisper" {
+		return ""
+	}
+	w, m := s.translateWindowLines(), s.translateContextLines()
+	if w <= 1 && m == 0 {
+		return ""
+	}
+	return fmt.Sprintf("cw%dc%d", w, m)
+}
+
+// translateWindow translates order[start:end] in a single numbered batch, giving
+// the model up to marginM read-only context cues on each side. It verifies the
+// model returned exactly one line per target in order; on any mismatch it falls
+// back to per-line translation for this window so timing can never desync.
+func (s *Service) translateWindow(ctx context.Context, cells []translateCell, order []int, start, end, marginM int, targetLang string) error {
+	targets := order[start:end]
+	before := order[max(0, start-marginM):start]
+	after := order[end:min(len(order), end+marginM)]
+
+	prompt := buildWindowTranslatePrompt(cells, before, targets, after, targetLang)
+	raw, err := s.generateBounded(ctx, prompt, translateLineMaxTokens*len(targets))
+	if err != nil {
+		// A provider/transport failure is NOT a format mismatch: the provider is
+		// down, so fanning out into per-line retries would just multiply the same
+		// error. Surface it and let translation abort as the per-line path did.
+		return err
+	}
+	parsed, ok := parseNumberedTranslations(raw, len(targets))
+	if !ok {
+		s.getLogger().Printf("transcript translation: windowed batch response did not return %d numbered lines 1:1; "+
+			"falling back to per-line translation for this window (subtitle timing preserved)", len(targets))
+		return s.translateCellsPerLine(ctx, cells, targets, targetLang)
+	}
+	for i, idx := range targets {
+		cells[idx].translated = collapseTranslatedLine(parsed[i])
+	}
+	return nil
+}
+
+// translateCellsPerLine translates each cell named by idxs one at a time (the
+// historical isolated path). It is also the safe-degrade fallback for a window
+// whose batch response was malformed. collapseTranslatedLine keeps one source cue
+// exactly one output line.
+func (s *Service) translateCellsPerLine(ctx context.Context, cells []translateCell, idxs []int, targetLang string) error {
+	for _, idx := range idxs {
+		translatedBody, err := s.translateLine(ctx, cells[idx].body, targetLang)
+		if err != nil {
+			return err
+		}
+		cells[idx].translated = collapseTranslatedLine(translatedBody)
+	}
+	return nil
+}
+
+// assembleTranslatedLine reattaches the verbatim timestamp marker to a translated
+// body, preserving the exact source formatting rules.
+func assembleTranslatedLine(marker, translatedBody string) string {
+	switch {
+	case marker == "":
+		return translatedBody
+	case translatedBody == "":
+		return marker
+	default:
+		return marker + " " + translatedBody
+	}
+}
+
+// collapseTranslatedLine collapses any internal newlines/whitespace runs a chat
+// provider may have returned into single spaces, so one source segment stays
+// exactly one output line — otherwise an extra line would desync the translated
+// transcript's time spans from the source (chunkTranscriptByTime keys on per-line
+// [mm:ss] markers).
+func collapseTranslatedLine(s string) string {
+	return strings.Join(strings.Fields(s), " ")
 }
 
 // translateLineMaxTokens caps a single translated transcript line. One source
 // segment maps to one short output line, so a tight bound is plenty here; it
 // keeps the #500 runaway path tight on chat backends that respect max_tokens
-// WITHOUT lowering the generous default that ask/annotate rely on. It is applied
-// only when the translator implements model.BoundedGenerator; otherwise the call
-// falls back to Generate (the provider's own default cap still bounds it).
+// WITHOUT lowering the generous default that ask/annotate rely on. For a windowed
+// batch the cap is scaled by the number of target cues. It is applied only when
+// the translator implements model.BoundedGenerator; otherwise the call falls back
+// to Generate (the provider's own default cap still bounds it).
 const translateLineMaxTokens = 512
+
+// generateBounded runs the translator with a per-call max-tokens cap when it
+// implements model.BoundedGenerator, else falls back to the plain Generator.
+func (s *Service) generateBounded(ctx context.Context, prompt string, maxTokens int) (string, error) {
+	if bg, ok := s.translator.(model.BoundedGenerator); ok {
+		return bg.GenerateWithMaxTokens(ctx, prompt, maxTokens)
+	}
+	return s.translator.Generate(ctx, prompt)
+}
 
 // translateLine translates a single line of transcript text into targetLang via
 // the chat Generator. Empty/whitespace input short-circuits to empty so the chat
@@ -107,15 +264,7 @@ func (s *Service) translateLine(ctx context.Context, text, targetLang string) (s
 	if text == "" {
 		return "", nil
 	}
-	prompt := buildTranslatePrompt(text, targetLang)
-	if bg, ok := s.translator.(model.BoundedGenerator); ok {
-		return bg.GenerateWithMaxTokens(ctx, prompt, translateLineMaxTokens)
-	}
-	translated, err := s.translator.Generate(ctx, prompt)
-	if err != nil {
-		return "", err
-	}
-	return translated, nil
+	return s.generateBounded(ctx, buildTranslatePrompt(text, targetLang), translateLineMaxTokens)
 }
 
 // buildTranslatePrompt builds a deterministic, general-purpose translation
@@ -130,6 +279,98 @@ func buildTranslatePrompt(text, targetLang string) string {
 	b.WriteString("with no preamble, quotes, or explanation.\n\n")
 	b.WriteString(text)
 	return b.String()
+}
+
+// buildWindowTranslatePrompt builds the numbered, general-purpose batch prompt
+// for a window of consecutive cues (issue #573). The `targets` cues are numbered
+// 1..N and are the ONLY lines the model translates and returns; the `before` /
+// `after` cues are supplied as read-only context so the model can resolve
+// referents, agreement, split sentences, and terminology WITHOUT re-translating
+// them. The strict "N: <translation>" response contract lets the caller verify a
+// 1:1 mapping and safe-degrade on any mismatch. It is language-agnostic (the
+// target language is pinned; the source is auto-detected).
+func buildWindowTranslatePrompt(cells []translateCell, before, targets, after []int, targetLang string) string {
+	var b strings.Builder
+	b.WriteString("Translate each NUMBERED line below into ")
+	b.WriteString(targetLang)
+	b.WriteString(". These are consecutive subtitle cues from one recording, so use the ")
+	b.WriteString("surrounding context lines only to resolve pronouns, gender/number agreement, ")
+	b.WriteString("sentences split across cues, and to keep terminology and named entities consistent. ")
+	b.WriteString("Preserve meaning faithfully.\n")
+	b.WriteString("Return EXACTLY one translated line per numbered input, in the form \"N: <translation>\", ")
+	b.WriteString("with the SAME count and the SAME numbers in the SAME order. Do NOT add, drop, split, ")
+	b.WriteString("merge, renumber, or reorder lines, and never output the context lines. ")
+	b.WriteString("No preamble, quotes, or explanation.\n")
+
+	writeContext := func(heading string, idxs []int) {
+		if len(idxs) == 0 {
+			return
+		}
+		b.WriteString("\n")
+		b.WriteString(heading)
+		b.WriteString("\n")
+		for _, idx := range idxs {
+			b.WriteString("- ")
+			b.WriteString(cells[idx].body)
+			b.WriteString("\n")
+		}
+	}
+
+	writeContext("Context before (do NOT translate or return):", before)
+	b.WriteString("\nLines to translate:\n")
+	for n, idx := range targets {
+		b.WriteString(strconv.Itoa(n + 1))
+		b.WriteString(": ")
+		b.WriteString(cells[idx].body)
+		b.WriteString("\n")
+	}
+	writeContext("Context after (do NOT translate or return):", after)
+	return b.String()
+}
+
+// numberedTranslationRE matches a "N: <text>" / "N. <text>" / "N) <text>"
+// response line, capturing the 1-based index and the translated text.
+var numberedTranslationRE = regexp.MustCompile(`^\s*(\d+)\s*[:.)]\s?(.*)$`)
+
+// parseNumberedTranslations parses a windowed batch response into exactly n
+// translations, indexed 0..n-1 by the model's 1-based numbering. It enforces the
+// strict 1:1 contract: every number 1..n must appear exactly once (no gaps, no
+// duplicates, no out-of-range numbers), or it returns ok=false so the caller
+// safe-degrades to per-line translation. Continuation lines (a wrapped
+// translation with no leading number) are appended to the current entry so a
+// model that hard-wraps a long line is tolerated without breaking the mapping.
+func parseNumberedTranslations(raw string, n int) ([]string, bool) {
+	if n <= 0 {
+		return nil, false
+	}
+	out := make([]string, n)
+	seen := make([]bool, n)
+	filled := 0
+	cur := -1
+	for _, line := range strings.Split(raw, "\n") {
+		if m := numberedTranslationRE.FindStringSubmatch(line); m != nil {
+			num, err := strconv.Atoi(m[1])
+			if err != nil || num < 1 || num > n {
+				return nil, false
+			}
+			idx := num - 1
+			if seen[idx] {
+				return nil, false // duplicate number: cannot trust the 1:1 mapping
+			}
+			seen[idx] = true
+			out[idx] = m[2]
+			filled++
+			cur = idx
+			continue
+		}
+		if cur >= 0 && strings.TrimSpace(line) != "" {
+			out[cur] += " " + line // continuation of a wrapped translation
+		}
+	}
+	if filled != n {
+		return nil, false
+	}
+	return out, true
 }
 
 // splitTimestampMarker splits a transcript line into its leading timestamp

--- a/internal/ingest/translate.go
+++ b/internal/ingest/translate.go
@@ -247,10 +247,16 @@ func collapseTranslatedLine(s string) string {
 const translateLineMaxTokens = 512
 
 // generateBounded runs the translator with a per-call max-tokens cap when it
-// implements model.BoundedGenerator, else falls back to the plain Generator.
+// implements model.BoundedGenerator, else falls back to the plain Generator. A
+// non-positive maxTokens also falls back to Generate — mirroring the
+// model.BoundedGenerator contract ("<= 0 means use default") and keeping this
+// aligned with retrieval.boundedGenerate, so a future zero-cap opt-out behaves
+// identically on both paths rather than silently passing 0 here.
 func (s *Service) generateBounded(ctx context.Context, prompt string, maxTokens int) (string, error) {
-	if bg, ok := s.translator.(model.BoundedGenerator); ok {
-		return bg.GenerateWithMaxTokens(ctx, prompt, maxTokens)
+	if maxTokens > 0 {
+		if bg, ok := s.translator.(model.BoundedGenerator); ok {
+			return bg.GenerateWithMaxTokens(ctx, prompt, maxTokens)
+		}
 	}
 	return s.translator.Generate(ctx, prompt)
 }

--- a/tests/config/media_translate_context_config_test.go
+++ b/tests/config/media_translate_context_config_test.go
@@ -1,0 +1,94 @@
+package tests
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+)
+
+// TestMediaTranslateContext_Defaults locks the built-in chat-translate window
+// defaults (issue #573): cues are translated in windows with a small read-only
+// margin by default so the model gets cross-line context.
+func TestMediaTranslateContext_Defaults(t *testing.T) {
+	cfg := config.Default()
+	if cfg.MediaTranslateWindowLines != config.DefaultMediaTranslateWindowLines {
+		t.Errorf("media.translate.window_lines default = %d, want %d",
+			cfg.MediaTranslateWindowLines, config.DefaultMediaTranslateWindowLines)
+	}
+	if cfg.MediaTranslateContextLines != config.DefaultMediaTranslateContextLines {
+		t.Errorf("media.translate.context_lines default = %d, want %d",
+			cfg.MediaTranslateContextLines, config.DefaultMediaTranslateContextLines)
+	}
+}
+
+// TestMediaTranslateContext_RoundTripsThroughSaveLoad exercises the int plumbing
+// (setIntFileScalar, writeInt) for the window/context scalars through save/load.
+func TestMediaTranslateContext_RoundTripsThroughSaveLoad(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+
+	cfg := config.Default()
+	cfg.RootDir = "/tmp/repo"
+	cfg.StateDir = "/tmp/repo/.dir2mcp"
+	cfg.MediaTranslateWindowLines = 24
+	cfg.MediaTranslateContextLines = 5
+	if err := config.SaveFile(path, cfg); err != nil {
+		t.Fatalf("SaveFile failed: %v", err)
+	}
+	loaded, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile failed: %v", err)
+	}
+	if loaded.MediaTranslateWindowLines != 24 {
+		t.Errorf("media.translate.window_lines did not round-trip: got %d, want 24", loaded.MediaTranslateWindowLines)
+	}
+	if loaded.MediaTranslateContextLines != 5 {
+		t.Errorf("media.translate.context_lines did not round-trip: got %d, want 5", loaded.MediaTranslateContextLines)
+	}
+}
+
+// TestMediaTranslateContext_NestedYAMLApplies locks the nested media: translate:
+// block for the new scalars.
+func TestMediaTranslateContext_NestedYAMLApplies(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+	writeFile(t, path, strings.Join([]string{
+		"root_dir: /tmp/repo",
+		"state_dir: /tmp/repo/.dir2mcp",
+		"media:",
+		"  translate:",
+		"    window_lines: 12",
+		"    context_lines: 2",
+	}, "\n")+"\n")
+
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile(nested media.translate) = %v, want nil", err)
+	}
+	if cfg.MediaTranslateWindowLines != 12 {
+		t.Errorf("nested media.translate.window_lines = %d, want 12", cfg.MediaTranslateWindowLines)
+	}
+	if cfg.MediaTranslateContextLines != 2 {
+		t.Errorf("nested media.translate.context_lines = %d, want 2", cfg.MediaTranslateContextLines)
+	}
+}
+
+// TestMediaTranslateContext_RejectsNegative asserts a negative window/context
+// value is rejected at config-parse time rather than silently clamped.
+func TestMediaTranslateContext_RejectsNegative(t *testing.T) {
+	for _, key := range []string{"media_translate_window_lines", "media_translate_context_lines"} {
+		tmp := t.TempDir()
+		path := filepath.Join(tmp, ".dir2mcp.yaml")
+		writeFile(t, path, strings.Join([]string{
+			"root_dir: /tmp/repo",
+			"state_dir: /tmp/repo/.dir2mcp",
+			key + ": -3",
+		}, "\n")+"\n")
+
+		if _, err := config.LoadFile(path); err == nil {
+			t.Errorf("LoadFile with %s=-3 = nil error, want rejection", key)
+		}
+	}
+}

--- a/tests/ingest/transcript_translate_test.go
+++ b/tests/ingest/transcript_translate_test.go
@@ -379,29 +379,63 @@ func (b *boundedFakeTranslator) observed() (calls, lastMaxToken int) {
 }
 
 // TestTranscriptTranslation_UsesTightPerCallCap verifies the translate call site
-// passes a tight per-call max-tokens cap (512) when the translator implements
+// passes a tight per-call max-tokens cap when the translator implements
 // model.BoundedGenerator, keeping the #500 runaway path bounded without lowering
-// the generous default that ask/annotate rely on.
+// the generous default that ask/annotate rely on. The windowed chat engine (#573)
+// sends N cues per batch, so the batch cap scales to 512*N; the explicit per-line
+// opt-out keeps the historical flat 512.
 func TestTranscriptTranslation_UsesTightPerCallCap(t *testing.T) {
 	t.Parallel()
-	stateDir := t.TempDir()
-	st := &fakeIngestStore{}
-	svc := mustNewIngestService(t, config.Config{StateDir: stateDir}, st)
-	svc.SetTranscriber(&fakeTranscriber{text: "[00:00] intro\n[00:02] chapter one"})
-	tr := &boundedFakeTranslator{}
-	svc.SetTranscriptLanguage("de")
-	svc.SetTranslator(tr, "mistral", "mistral-small-2506", []string{"en"})
 
-	doc := model.Document{DocID: 11, RelPath: "audio/talk.mp3", DocType: "audio"}
-	if err := svc.GenerateTranscriptRepresentation(context.Background(), doc, []byte("audio")); err != nil {
-		t.Fatalf("GenerateTranscriptRepresentation: %v", err)
-	}
+	// Default (windowed): both cues go in ONE batch, so the cap is 512*2 = 1024,
+	// a bound that scales with the number of target cues in the request.
+	t.Run("windowed batch scales the cap", func(t *testing.T) {
+		t.Parallel()
+		st := &fakeIngestStore{}
+		svc := mustNewIngestService(t, config.Config{StateDir: t.TempDir()}, st)
+		svc.SetTranscriber(&fakeTranscriber{text: "[00:00] intro\n[00:02] chapter one"})
+		tr := &boundedFakeTranslator{}
+		svc.SetTranscriptLanguage("de")
+		svc.SetTranslator(tr, "mistral", "mistral-small-2506", []string{"en"})
 
-	calls, lastMaxToken := tr.observed()
-	if calls == 0 {
-		t.Fatalf("expected the bounded translator to be called")
-	}
-	if lastMaxToken != 512 {
-		t.Fatalf("translate max_tokens cap = %d, want 512", lastMaxToken)
-	}
+		doc := model.Document{DocID: 11, RelPath: "audio/talk.mp3", DocType: "audio"}
+		if err := svc.GenerateTranscriptRepresentation(context.Background(), doc, []byte("audio")); err != nil {
+			t.Fatalf("GenerateTranscriptRepresentation: %v", err)
+		}
+		calls, lastMaxToken := tr.observed()
+		if calls == 0 {
+			t.Fatalf("expected the bounded translator to be called")
+		}
+		if lastMaxToken != 512*2 {
+			t.Fatalf("windowed translate max_tokens cap = %d, want %d (512 per target cue)", lastMaxToken, 512*2)
+		}
+	})
+
+	// Explicit per-line opt-out (window_lines=1, context_lines=0): each cue is a
+	// separate call capped at the flat 512, exactly as before windowing existed.
+	t.Run("per-line opt-out keeps flat 512", func(t *testing.T) {
+		t.Parallel()
+		st := &fakeIngestStore{}
+		svc := mustNewIngestService(t, config.Config{
+			StateDir:                   t.TempDir(),
+			MediaTranslateWindowLines:  1,
+			MediaTranslateContextLines: 0,
+		}, st)
+		svc.SetTranscriber(&fakeTranscriber{text: "[00:00] intro\n[00:02] chapter one"})
+		tr := &boundedFakeTranslator{}
+		svc.SetTranscriptLanguage("de")
+		svc.SetTranslator(tr, "mistral", "mistral-small-2506", []string{"en"})
+
+		doc := model.Document{DocID: 12, RelPath: "audio/talk2.mp3", DocType: "audio"}
+		if err := svc.GenerateTranscriptRepresentation(context.Background(), doc, []byte("audio")); err != nil {
+			t.Fatalf("GenerateTranscriptRepresentation: %v", err)
+		}
+		calls, lastMaxToken := tr.observed()
+		if calls == 0 {
+			t.Fatalf("expected the bounded translator to be called")
+		}
+		if lastMaxToken != 512 {
+			t.Fatalf("per-line translate max_tokens cap = %d, want 512", lastMaxToken)
+		}
+	})
 }

--- a/tests/ingest/translate_context_test.go
+++ b/tests/ingest/translate_context_test.go
@@ -1,0 +1,300 @@
+package tests
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// Cross-line translation context tests (issue #573): the chat translate engine
+// batches consecutive cues in a window (with a read-only margin) so the model can
+// resolve referents/agreement/split-sentences/terminology across cues, while a
+// strict numbered 1:1 request/response contract guarantees exactly one output cue
+// per input cue — a malformed response safe-degrades to per-line rather than
+// desyncing subtitle timing.
+
+// batchTargetLineRE matches a numbered target line ("N: <cue>") inside a windowed
+// translate prompt's "Lines to translate:" section.
+var batchTargetLineRE = regexp.MustCompile(`^(\d+):\s?(.*)$`)
+
+// contextAwareTranslator honours the windowed numbered 1:1 contract — it returns
+// exactly one translated line per numbered target and never translates the
+// read-only context margin — and records every prompt it received so the presence
+// of cross-line context can be asserted black-box. Per-line (opt-out / fallback)
+// prompts are translated as a single tagged line.
+type contextAwareTranslator struct {
+	mu         sync.Mutex
+	prompts    []string
+	batchCalls int
+	lineCalls  int
+}
+
+func (f *contextAwareTranslator) Generate(_ context.Context, prompt string) (string, error) {
+	f.mu.Lock()
+	f.prompts = append(f.prompts, prompt)
+	isBatch := strings.Contains(prompt, "Lines to translate:")
+	if isBatch {
+		f.batchCalls++
+	} else {
+		f.lineCalls++
+	}
+	f.mu.Unlock()
+
+	if !isBatch {
+		parts := strings.Split(prompt, "\n\n")
+		return "T[" + strings.TrimSpace(parts[len(parts)-1]) + "]", nil
+	}
+	// Echo exactly the numbered targets, translated; stop at the context margin.
+	var out []string
+	inTargets := false
+	for _, line := range strings.Split(prompt, "\n") {
+		if strings.HasPrefix(line, "Lines to translate:") {
+			inTargets = true
+			continue
+		}
+		if !inTargets {
+			continue
+		}
+		if strings.TrimSpace(line) == "" || strings.HasPrefix(line, "Context") {
+			break // reached the trailing context margin / end of targets
+		}
+		if m := batchTargetLineRE.FindStringSubmatch(line); m != nil {
+			out = append(out, m[1]+": T["+m[2]+"]")
+		}
+	}
+	return strings.Join(out, "\n"), nil
+}
+
+func (f *contextAwareTranslator) snapshot() (prompts []string, batchCalls, lineCalls int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.prompts...), f.batchCalls, f.lineCalls
+}
+
+// malformedBatchTranslator returns an UNPARSEABLE blob for a windowed batch (no
+// numbering) so the safe-degrade path is exercised, while translating a per-line
+// (fallback) prompt normally. It counts each path.
+type malformedBatchTranslator struct {
+	mu         sync.Mutex
+	batchCalls int
+	lineCalls  int
+}
+
+func (f *malformedBatchTranslator) Generate(_ context.Context, prompt string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if strings.Contains(prompt, "Lines to translate:") {
+		f.batchCalls++
+		return "here is the whole translation as one blob with no numbering at all", nil
+	}
+	f.lineCalls++
+	parts := strings.Split(prompt, "\n\n")
+	return "T[" + strings.TrimSpace(parts[len(parts)-1]) + "]", nil
+}
+
+func (f *malformedBatchTranslator) counts() (batch, line int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.batchCalls, f.lineCalls
+}
+
+// readTranslateCache reads the single translated-transcript cache file written
+// under <stateDir>/cache/translate. That file is the verbatim translated
+// transcript (markers + text), so it is the cleanest black-box surface for
+// asserting the 1:1 marker mapping.
+func readTranslateCache(t *testing.T, stateDir string) string {
+	t.Helper()
+	dir := filepath.Join(stateDir, "cache", "translate")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read translate cache dir: %v", err)
+	}
+	var found []string
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".txt") {
+			b, err := os.ReadFile(filepath.Join(dir, e.Name()))
+			if err != nil {
+				t.Fatalf("read translate cache file %s: %v", e.Name(), err)
+			}
+			found = append(found, string(b))
+		}
+	}
+	if len(found) != 1 {
+		t.Fatalf("expected exactly one translate cache .txt, got %d in %s", len(found), dir)
+	}
+	return found[0]
+}
+
+// splitWindowPromptSections splits a windowed translate prompt into its
+// context portion (everything outside the numbered target block) and the numbered
+// target block itself.
+func splitWindowPromptSections(prompt string) (ctx, targets string) {
+	const marker = "Lines to translate:\n"
+	i := strings.Index(prompt, marker)
+	if i < 0 {
+		return prompt, ""
+	}
+	rest := prompt[i+len(marker):]
+	if j := strings.Index(rest, "\nContext after"); j >= 0 {
+		return prompt[:i] + rest[j:], rest[:j]
+	}
+	return prompt[:i], rest
+}
+
+func countNumberedTargets(prompt string) int {
+	_, targets := splitWindowPromptSections(prompt)
+	n := 0
+	for _, line := range strings.Split(targets, "\n") {
+		if batchTargetLineRE.MatchString(line) {
+			n++
+		}
+	}
+	return n
+}
+
+// TestTranscriptTranslation_WindowedPreservesOneToOne is the anti-desync guard:
+// an N-cue transcript translated in a single window yields exactly N output cues
+// with the original [mm:ss] markers intact and in order.
+func TestTranscriptTranslation_WindowedPreservesOneToOne(t *testing.T) {
+	t.Parallel()
+	stateDir := t.TempDir()
+	st := &fakeIngestStore{}
+	svc := mustNewIngestService(t, config.Config{StateDir: stateDir}, st)
+	source := "[00:00] one\n[00:03] two\n[00:06] three\n[00:09] four\n[00:12] five"
+	svc.SetTranscriber(&fakeTranscriber{text: source})
+	svc.SetTranscriptLanguage("de")
+	tr := &contextAwareTranslator{}
+	svc.SetTranslator(tr, "mistral", "m", []string{"en"})
+
+	doc := model.Document{DocID: 1, RelPath: "audio/a.mp3", DocType: "audio"}
+	if err := svc.GenerateTranscriptRepresentation(context.Background(), doc, []byte("audio")); err != nil {
+		t.Fatalf("GenerateTranscriptRepresentation: %v", err)
+	}
+
+	got := readTranslateCache(t, stateDir)
+	want := "[00:00] T[one]\n[00:03] T[two]\n[00:06] T[three]\n[00:09] T[four]\n[00:12] T[five]"
+	if got != want {
+		t.Fatalf("windowed translation broke the 1:1 marker mapping:\n got: %q\nwant: %q", got, want)
+	}
+	// The default window (16) covers all 5 cues in one batch: exactly one batch
+	// call, and no per-line fallback (the contract was satisfied).
+	if _, batch, line := tr.snapshot(); batch != 1 || line != 0 {
+		t.Fatalf("expected exactly one windowed batch call and no per-line fallback, got batch=%d line=%d", batch, line)
+	}
+}
+
+// TestTranscriptTranslation_WindowedProvidesCrossLineContext proves the model is
+// actually given cross-cue context: a windowed batch prompt carries more than one
+// cue, and the surrounding-margin cue is supplied as READ-ONLY context (marked
+// "do NOT translate or return"), not as a target.
+func TestTranscriptTranslation_WindowedProvidesCrossLineContext(t *testing.T) {
+	t.Parallel()
+	stateDir := t.TempDir()
+	st := &fakeIngestStore{}
+	svc := mustNewIngestService(t, config.Config{
+		StateDir:                   stateDir,
+		MediaTranslateWindowLines:  2,
+		MediaTranslateContextLines: 1,
+	}, st)
+	source := "[00:00] alpha\n[00:03] bravo\n[00:06] charlie\n[00:09] delta"
+	svc.SetTranscriber(&fakeTranscriber{text: source})
+	svc.SetTranscriptLanguage("de")
+	tr := &contextAwareTranslator{}
+	svc.SetTranslator(tr, "mistral", "m", []string{"en"})
+
+	doc := model.Document{DocID: 2, RelPath: "audio/b.mp3", DocType: "audio"}
+	if err := svc.GenerateTranscriptRepresentation(context.Background(), doc, []byte("audio")); err != nil {
+		t.Fatalf("GenerateTranscriptRepresentation: %v", err)
+	}
+
+	prompts, batch, _ := tr.snapshot()
+	if batch == 0 {
+		t.Fatalf("expected windowed batch calls, got none")
+	}
+
+	// (a) At least one window prompt carries more than one target cue — the model
+	// sees neighbouring cues together, not one in isolation.
+	sawMultiCueWindow := false
+	for _, p := range prompts {
+		if countNumberedTargets(p) >= 2 {
+			sawMultiCueWindow = true
+			break
+		}
+	}
+	if !sawMultiCueWindow {
+		t.Fatalf("no batch prompt contained >1 target cue (no cross-line context); prompts=%v", prompts)
+	}
+
+	// (b) The neighbour cue is read-only context, not a target: the charlie/delta
+	// window must show 'bravo' in a "do NOT translate or return" context section
+	// while 'charlie' is a numbered target and 'bravo' is NOT.
+	sawContextOnlyMargin := false
+	for _, p := range prompts {
+		ctxSection, targetSection := splitWindowPromptSections(p)
+		if strings.Contains(ctxSection, "bravo") &&
+			strings.Contains(ctxSection, "do NOT translate or return") &&
+			strings.Contains(targetSection, "charlie") &&
+			!strings.Contains(targetSection, "bravo") {
+			sawContextOnlyMargin = true
+			break
+		}
+	}
+	if !sawContextOnlyMargin {
+		t.Fatalf("no prompt marked neighbour cue 'bravo' as read-only context for the charlie/delta window; prompts=%v", prompts)
+	}
+
+	// The 1:1 output is intact across BOTH windows.
+	got := readTranslateCache(t, stateDir)
+	want := "[00:00] T[alpha]\n[00:03] T[bravo]\n[00:06] T[charlie]\n[00:09] T[delta]"
+	if got != want {
+		t.Fatalf("windowed translation with a margin broke 1:1:\n got: %q\nwant: %q", got, want)
+	}
+}
+
+// TestTranscriptTranslation_MalformedBatchFallsBackTo1to1 is the safe-degrade
+// guard: when the model returns an unparseable batch response (wrong structure /
+// line count), the window falls back to per-line translation so the result still
+// has exactly one output cue per input cue with markers intact — never a desync.
+func TestTranscriptTranslation_MalformedBatchFallsBackTo1to1(t *testing.T) {
+	t.Parallel()
+	stateDir := t.TempDir()
+	st := &fakeIngestStore{}
+	svc := mustNewIngestService(t, config.Config{StateDir: stateDir}, st)
+	source := "[00:00] uno\n[00:03] dos\n[00:06] tres"
+	svc.SetTranscriber(&fakeTranscriber{text: source})
+	svc.SetTranscriptLanguage("de")
+	tr := &malformedBatchTranslator{}
+	svc.SetTranslator(tr, "mistral", "m", []string{"en"})
+
+	doc := model.Document{DocID: 3, RelPath: "audio/c.mp3", DocType: "audio"}
+	if err := svc.GenerateTranscriptRepresentation(context.Background(), doc, []byte("audio")); err != nil {
+		t.Fatalf("GenerateTranscriptRepresentation: %v", err)
+	}
+
+	got := readTranslateCache(t, stateDir)
+	want := "[00:00] T[uno]\n[00:03] T[dos]\n[00:06] T[tres]"
+	if got != want {
+		t.Fatalf("malformed batch response desynced the transcript:\n got: %q\nwant: %q", got, want)
+	}
+
+	batch, line := tr.counts()
+	if batch < 1 {
+		t.Fatalf("expected the windowed batch path to be attempted at least once, got %d", batch)
+	}
+	if line != 3 {
+		t.Fatalf("expected per-line fallback for all 3 cues after the malformed batch, got %d per-line calls", line)
+	}
+	// The translated transcript must chunk into the same 3 time spans as the
+	// source — the malformed response did not add/drop/merge a cue.
+	if got := ingest.ChunkTranscriptByTime(want); len(got) != 3 {
+		t.Fatalf("expected 3 time-aligned chunks from the fallback output, got %d", len(got))
+	}
+}


### PR DESCRIPTION
Closes #573

## Problem

The `media.translate.engine=chat` path translated transcript cues **one line at a time in complete isolation** — `buildTranslatePrompt` sent a single line, so the model never saw neighbouring cues. Because subtitle cues are short and frequently not self-contained (a sentence split across 2–3 timed cues, pronouns/agreement resolving against a prior cue, terminology that should stay consistent), this caused fragment mistranslation, referent/gender/number errors, and terminology drift — worst on low-resource languages and dense speech.

## The invariant preserved

One source cue ↔ exactly one output line, because `chunkTranscriptByTime` re-derives the translated transcript's time spans from the per-line `[mm:ss]` markers. Any batching that drops/merges/reorders lines (or changes the line count) desyncs subtitle timing. This fix keeps the 1:1 mapping exactly.

## Approach (issue's preferred "A": windowed batch with a structured 1:1 contract)

- **Windowed translation.** Cues are translated in windows of `media.translate.window_lines` consecutive cues per chat call (default **16**), each window carrying a read-only margin of `media.translate.context_lines` surrounding cues on each side (default **3**) that the model uses for context but is instructed **not** to translate or return.
- **Strict numbered 1:1 contract.** The target cues are numbered `1..N`; the model must return exactly one `N: <translation>` line per input, same count/order. `parseNumberedTranslations` verifies every number `1..N` appears exactly once (no gaps, duplicates, out-of-range, or wrong count).
- **Safe fallback (never a desync).** On **any** count/format mismatch the window falls back to the historical per-line translation and logs it, so a malformed model response can never desync timing. A provider/transport error surfaces as before (no per-line fan-out of a down provider).
- **Markers preserved verbatim.** The `[mm:ss]` markers are split off before the model sees the text and reattached deterministically; the model only ever rewrites the spoken text.
- **General-purpose.** No language-specific handling; glossary/terminology awareness (#574) is intentionally out of scope.

## Cache identity

The window/margin shape is folded into the translate derivation identity's `version` field (`activeTranslateIdentity`), so a shape change invalidates stale cached translations (a stale body would be mislabeled by the rep's recorded provider/model). The explicit per-line opt-out (`window_lines<=1`, `context_lines=0`) folds nothing, keeping pre-windowing caches valid. The `whisper` engine keys its own STT-identity cache and is unaffected.

## Tests

- `TestTranscriptTranslation_WindowedPreservesOneToOne` — anti-desync guard: an N-cue transcript yields exactly N output cues with the original `[mm:ss]` markers intact and in order.
- `TestTranscriptTranslation_WindowedProvidesCrossLineContext` — a windowed prompt carries >1 cue and the neighbour cue is supplied as read-only context (marked "do NOT translate or return"), not a target.
- `TestTranscriptTranslation_MalformedBatchFallsBackTo1to1` — a malformed batch response safe-degrades to per-line, keeping the correct 1:1 cue count with markers intact.
- Updated `TestTranscriptTranslation_UsesTightPerCallCap` for the scaled batch cap (`512·N`) plus a per-line opt-out sub-case that keeps the flat `512`.
- Config plumbing round-trip / nested-YAML / negative-rejection coverage for the two new keys.

`make check` passes (except the worktree-only `TestSpecYAMLSecretPatterns_Compile_JWTAndBearer`, which needs the `dirstral-spec` submodule checked out — green in CI).

Code-only quality fix: no tool/error contract or spec change; the `dirstral-spec` submodule is untouched.