### PR TITLE
feat(mcp,status): surface watch_overflows in dir2mcp_stats.indexing (#591)

### DIFF
--- a/internal/appstate/indexing_state.go
+++ b/internal/appstate/indexing_state.go
@@ -25,6 +25,14 @@ type IndexingSnapshot struct {
 	EmbeddedOK      int64
 	Errors          int64
 	Unknown         int64
+	// WatchActive reports whether a filesystem watcher is running this process.
+	// When false (a one-shot index, or a platform/config without a watcher),
+	// WatchOverflows is meaningless and callers MUST omit the optional
+	// watch_overflows stats field rather than report 0 (spec bs-007 / SPEC §15.6,
+	// #591): absence means "unknown / not applicable", 0 means "watching, none
+	// dropped".
+	WatchActive    bool
+	WatchOverflows int64
 }
 
 type IndexingState struct {
@@ -40,6 +48,12 @@ type IndexingState struct {
 	chunksTotal     atomic.Int64
 	embeddedOK      atomic.Int64
 	errors          atomic.Int64
+
+	// watchActive/watchOverflows are process-lifetime watcher telemetry, not
+	// per-scan progress: ResetProgress leaves them untouched (like embeddedOK)
+	// so the overflow tally survives rescans.
+	watchActive    atomic.Bool
+	watchOverflows atomic.Int64
 }
 
 func NewIndexingState(mode string) *IndexingState {
@@ -158,6 +172,28 @@ func (s *IndexingState) AddErrors(delta int64) {
 	s.errors.Add(delta)
 }
 
+// MarkWatchActive records that a filesystem watcher is running this process, so
+// Snapshot reports watch_overflows (even 0) instead of omitting it. Idempotent;
+// call it once when the watch loop starts.
+func (s *IndexingState) MarkWatchActive() {
+	if s == nil {
+		return
+	}
+	s.watchActive.Store(true)
+}
+
+// AddWatchOverflow increments the process-lifetime count of fsnotify kernel
+// event-buffer overflows (dropped-event bursts reconciled by the safety rescan
+// rather than per-event). It also marks the watcher active: an overflow can only
+// be observed while watching.
+func (s *IndexingState) AddWatchOverflow(delta int64) {
+	if s == nil {
+		return
+	}
+	s.watchActive.Store(true)
+	s.watchOverflows.Add(delta)
+}
+
 func (s *IndexingState) Snapshot() IndexingSnapshot {
 	if s == nil {
 		return IndexingSnapshot{
@@ -178,6 +214,8 @@ func (s *IndexingState) Snapshot() IndexingSnapshot {
 		ChunksTotal:     s.chunksTotal.Load(),
 		EmbeddedOK:      s.embeddedOK.Load(),
 		Errors:          s.errors.Load(),
+		WatchActive:     s.watchActive.Load(),
+		WatchOverflows:  s.watchOverflows.Load(),
 	}
 }
 

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -325,6 +325,11 @@ type corpusIndexing struct {
 	// coverage, #414/#395). Travels straight through from CorpusStats; omitted
 	// from JSON when nothing was skipped.
 	SkipSummary *model.SkipSummary `json:"skip_summary,omitempty"`
+	// WatchOverflows is the process-lifetime count of fsnotify kernel
+	// event-buffer overflows (#591). It is a pointer so it is emitted (even as
+	// 0) only when a watcher is running and omitted otherwise — absence means
+	// "not applicable" (one-shot index), not zero (spec 0.33.0 / stats.json).
+	WatchOverflows *int64 `json:"watch_overflows,omitempty"`
 }
 
 // NewApp constructs an App wired to os.Stdout and os.Stderr.
@@ -1955,6 +1960,18 @@ func emitProgressEvents(emitter *ndjsonEmitter, idx corpusIndexing) {
 	})
 }
 
+// watchOverflowsField returns a pointer to the lifetime watch-overflow count
+// when a watcher is running, or nil otherwise so `status --json` omits the
+// optional watch_overflows field entirely (absence = "not applicable", not 0;
+// spec 0.33.0 / stats.json, #591).
+func watchOverflowsField(idx appstate.IndexingSnapshot) *int64 {
+	if !idx.WatchActive {
+		return nil
+	}
+	v := idx.WatchOverflows
+	return &v
+}
+
 // buildCorpusSnapshot collects corpus stats and assembles a corpusSnapshot,
 // preferring live indexing-state counters when available and otherwise
 // deriving them from the store, including the code/total doc ratio.
@@ -2016,6 +2033,10 @@ func buildCorpusSnapshot(ctx context.Context, st model.Store, indexingState *app
 			// `status` can render an honest not-indexed coverage block
 			// (#414). Omitted from JSON on corpora with nothing skipped.
 			SkipSummary: corpusStats.SkipSummary,
+			// watch_overflows is surfaced only when a watcher is running
+			// (#591); on the store-derived fallback (indexingState == nil)
+			// WatchActive is false, so it stays omitted.
+			WatchOverflows: watchOverflowsField(idx),
 		},
 		DocCounts: docCounts,
 		TotalDocs: totalDocs,

--- a/internal/ingest/watch.go
+++ b/internal/ingest/watch.go
@@ -122,6 +122,10 @@ func (w *fsWatchLoop) run(ctx context.Context) error {
 		default:
 		}
 	}
+	// A watcher is now running: let the stats surface report watch_overflows
+	// (even 0) rather than omitting it as "not applicable" (#591).
+	w.svc.indexingState.MarkWatchActive()
+
 	workerDone := make(chan struct{})
 	go w.worker(ctx, rescanReq, workerDone)
 
@@ -158,6 +162,7 @@ func (w *fsWatchLoop) run(ctx context.Context) error {
 			// immediate coalesced rescan so the missed changes reconcile promptly
 			// rather than waiting for the next tick.
 			if errors.Is(err, fsnotify.ErrEventOverflow) {
+				w.svc.indexingState.AddWatchOverflow(1)
 				w.svc.getLogger().Printf("watch: event overflow (kernel event buffer exceeded); some events dropped, requesting immediate rescan")
 				requestRescan()
 				continue

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -394,19 +394,28 @@ func (s *Server) handleStatsTool(ctx context.Context, args map[string]interface{
 		// total_docs will be 0, so consumers must not assume those values
 		// represent an empty corpus without this flag.
 		"doc_counts_available": statsFromRetriever,
-		"indexing": map[string]interface{}{
-			"job_id":          snapshot.JobID,
-			"running":         snapshot.Running,
-			"mode":            snapshot.Mode,
-			"scanned":         retrievedStats.Scanned,
-			"indexed":         retrievedStats.Indexed,
-			"skipped":         retrievedStats.Skipped,
-			"deleted":         retrievedStats.Deleted,
-			"representations": retrievedStats.Representations,
-			"chunks_total":    retrievedStats.ChunksTotal,
-			"embedded_ok":     retrievedStats.EmbeddedOK,
-			"errors":          retrievedStats.Errors,
-		},
+		"indexing": func() map[string]interface{} {
+			idx := map[string]interface{}{
+				"job_id":          snapshot.JobID,
+				"running":         snapshot.Running,
+				"mode":            snapshot.Mode,
+				"scanned":         retrievedStats.Scanned,
+				"indexed":         retrievedStats.Indexed,
+				"skipped":         retrievedStats.Skipped,
+				"deleted":         retrievedStats.Deleted,
+				"representations": retrievedStats.Representations,
+				"chunks_total":    retrievedStats.ChunksTotal,
+				"embedded_ok":     retrievedStats.EmbeddedOK,
+				"errors":          retrievedStats.Errors,
+			}
+			// Optional additive field (#591): only surface watch_overflows when a
+			// watcher is actually running, so absence reads as "not applicable"
+			// (one-shot index) rather than a misleading 0 (spec bs-007 / SPEC §15.6).
+			if snapshot.WatchActive {
+				idx["watch_overflows"] = snapshot.WatchOverflows
+			}
+			return idx
+		}(),
 		"models": map[string]interface{}{
 			"embed_text":   defaultEmbedTextModel,
 			"embed_code":   defaultEmbedCodeModel,
@@ -3535,6 +3544,11 @@ func statsOutputSchema() map[string]interface{} {
 					"chunks_total":    map[string]interface{}{"type": "integer"},
 					"embedded_ok":     map[string]interface{}{"type": "integer"},
 					"errors":          map[string]interface{}{"type": "integer"},
+					// Optional additive (spec 0.33.0 / stats.json, #591): fsnotify
+					// kernel event-buffer overflow count. Declared here so it passes
+					// the additionalProperties:false gate; not required (omitted when
+					// no watcher is running).
+					"watch_overflows": map[string]interface{}{"type": "integer", "minimum": 0},
 				},
 				"required": []string{"job_id", "running", "mode", "scanned", "indexed", "skipped", "deleted", "representations", "chunks_total", "embedded_ok", "errors"},
 			},

--- a/tests/appstate/indexing_state_test.go
+++ b/tests/appstate/indexing_state_test.go
@@ -47,6 +47,55 @@ func TestResetProgress_ZeroesRunCountersPreservesEmbedded(t *testing.T) {
 	}
 }
 
+// TestWatchOverflows_ActiveGateAndLifetimePreservation verifies the #591
+// watch_overflows telemetry: a fresh state reports the watcher inactive (so the
+// stats surface omits the field rather than reporting a misleading 0);
+// MarkWatchActive flips WatchActive without inventing an overflow; AddWatchOverflow
+// both marks active and accumulates; and ResetProgress preserves the lifetime
+// overflow tally (like EmbeddedOK) instead of zeroing it with the per-scan
+// counters.
+func TestWatchOverflows_ActiveGateAndLifetimePreservation(t *testing.T) {
+	s := appstate.NewIndexingState(appstate.ModeIncremental)
+
+	if got := s.Snapshot(); got.WatchActive || got.WatchOverflows != 0 {
+		t.Fatalf("fresh state must be watcher-inactive with 0 overflows: %+v", got)
+	}
+
+	s.MarkWatchActive()
+	if got := s.Snapshot(); !got.WatchActive || got.WatchOverflows != 0 {
+		t.Fatalf("after MarkWatchActive want active with 0 overflows: %+v", got)
+	}
+
+	s.AddWatchOverflow(1)
+	s.AddWatchOverflow(2)
+	if got := s.Snapshot(); !got.WatchActive || got.WatchOverflows != 3 {
+		t.Fatalf("after overflows want active with 3: %+v", got)
+	}
+
+	// The overflow tally is process-lifetime telemetry, not per-scan progress:
+	// a rescan's ResetProgress must leave it (and WatchActive) intact.
+	s.AddScanned(5)
+	s.ResetProgress()
+	got := s.Snapshot()
+	if got.Scanned != 0 {
+		t.Fatalf("ResetProgress must zero per-scan Scanned: got %d", got.Scanned)
+	}
+	if !got.WatchActive || got.WatchOverflows != 3 {
+		t.Fatalf("ResetProgress must preserve watcher telemetry: got active=%v overflows=%d want active=true overflows=3", got.WatchActive, got.WatchOverflows)
+	}
+}
+
+// TestAddWatchOverflow_MarksActive verifies an overflow observed before any
+// explicit MarkWatchActive still flips WatchActive — an overflow can only occur
+// while watching, so the field must surface.
+func TestAddWatchOverflow_MarksActive(t *testing.T) {
+	s := appstate.NewIndexingState(appstate.ModeIncremental)
+	s.AddWatchOverflow(1)
+	if got := s.Snapshot(); !got.WatchActive || got.WatchOverflows != 1 {
+		t.Fatalf("AddWatchOverflow must mark active: got %+v", got)
+	}
+}
+
 // TestResetProgress_SnapshotInvariantDuringConcurrentReset guards the counter
 // ordering in ResetProgress: because Snapshot() reads each field independently
 // without a lock, a status scrape can interleave with a reset. Zeroing the

--- a/tests/mcp/stats_watch_overflows_591_test.go
+++ b/tests/mcp/stats_watch_overflows_591_test.go
@@ -1,0 +1,67 @@
+package tests
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/appstate"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/protocol"
+)
+
+// TestMCPStats_WatchOverflowsSurfacedWhenWatching asserts the optional additive
+// watch_overflows field (spec 0.33.0 / stats.json, dir2mcp #591) is present in
+// dir2mcp_stats.indexing — and carries the lifetime overflow count — when a
+// filesystem watcher is running. The served outputSchema declares indexing with
+// additionalProperties:false, so surfacing this field is only spec-legal because
+// the schema now allows it (PR #590 had to strip it before the spec caught up).
+func TestMCPStats_WatchOverflowsSurfacedWhenWatching(t *testing.T) {
+	idx := appstate.NewIndexingState(appstate.ModeIncremental)
+	idx.MarkWatchActive()
+	idx.AddWatchOverflow(2)
+
+	sc := statsIndexingWithState(t, idx)
+	got, present := sc["watch_overflows"]
+	if !present {
+		t.Fatalf("watch_overflows must be present while watching: indexing=%#v", sc)
+	}
+	// JSON numbers decode to float64.
+	if n, ok := got.(float64); !ok || n != 2 {
+		t.Fatalf("watch_overflows want 2, got %#v", got)
+	}
+}
+
+// TestMCPStats_WatchOverflowsOmittedWhenNotWatching asserts the field is omitted
+// (not reported as 0) when no watcher is running — a one-shot index or the
+// store-derived fallback. Absence means "not applicable", not "watching, none
+// dropped" (spec: consumers MUST treat absence as unknown/NA, not zero).
+func TestMCPStats_WatchOverflowsOmittedWhenNotWatching(t *testing.T) {
+	idx := appstate.NewIndexingState(appstate.ModeIncremental)
+	// No MarkWatchActive / AddWatchOverflow: watcher inactive.
+
+	sc := statsIndexingWithState(t, idx)
+	if _, present := sc["watch_overflows"]; present {
+		t.Fatalf("watch_overflows must be omitted when not watching: indexing=%#v", sc)
+	}
+}
+
+// statsIndexingWithState spins up an MCP server whose indexing snapshot is the
+// given state, calls dir2mcp_stats, and returns the structured `indexing` map.
+func statsIndexingWithState(t *testing.T, idx *appstate.IndexingState) map[string]interface{} {
+	t.Helper()
+	cfg := config.Default()
+	cfg.StateDir = t.TempDir()
+	cfg.MCPPath = protocol.DefaultMCPPath
+	cfg.AuthMode = "none"
+
+	server := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithIndexingState(idx)).Handler())
+	defer server.Close()
+
+	sc := callStatsTool(t, server.URL+cfg.MCPPath)
+	indexing, ok := sc["indexing"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("indexing object missing: %#v", sc)
+	}
+	return indexing
+}


### PR DESCRIPTION
## What

Surfaces the optional additive `watch_overflows` integer in `dir2mcp_stats.indexing`, closing the spec-first → re-pin loop for #591.

Spec 0.33.0 ([dirstral-spec #41](https://github.com/dirstral/dirstral-spec/pull/41)) added `watch_overflows` to `stats.json`. PR #590 had to **strip** the field when it first tried to surface it, because the served `indexing` object is `additionalProperties: false` and the schema had not yet caught up (a strict-client drift). Now that the spec is merged, this re-pins the submodule and surfaces the counter cleanly.

## How

- **`appstate.IndexingState`** gains a process-lifetime `watchOverflows` atomic + a `watchActive` flag, with `AddWatchOverflow`/`MarkWatchActive`. Both are **lifetime telemetry** (like `embeddedOK`) — `ResetProgress` leaves them untouched so the tally survives rescans.
- **fsnotify watch loop** (`internal/ingest/watch.go`): marks the state active when the loop starts, and increments on `ErrEventOverflow` — the same burst-drop path that already requests an immediate safety rescan (#409).
- **Two output surfaces** emit `watch_overflows` only when a watcher is actually running:
  - the **MCP stats tool** — declared in the served `outputSchema` so it passes the `additionalProperties: false` gate;
  - **`status --json`** — pointer + `omitempty`.
- When no watcher runs (one-shot index, or the store-derived fallback), the field is **omitted** — absence means "not applicable", **not** a misleading `0` (spec: consumers MUST treat absence as unknown/NA, not zero).
- Re-pins `dirstral-spec` submodule to `337f7df` (spec 0.33.0).

## Tests

- `tests/appstate`: active-gate + overflow accumulation + lifetime-preservation across `ResetProgress`.
- `tests/mcp`: `watch_overflows` present (with the count) when watching; omitted when not.
- `make check` all-pass.

Closes #591