### PR TITLE
feat(protocol,mcp,cli): stamp format_version in connection.json + stats (#468)

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -254,13 +254,17 @@ type connectionSession struct {
 }
 
 type connectionPayload struct {
-	Transport   string            `json:"transport"`
-	URL         string            `json:"url"`
-	Headers     map[string]string `json:"headers"`
-	Session     connectionSession `json:"session"`
-	Public      bool              `json:"public"`
-	TokenSource string            `json:"token_source"`
-	TokenFile   string            `json:"token_file,omitempty"`
+	// FormatVersion is the df-000 cross-version signal (SPEC §1.3/§4.3, #468); it
+	// MUST be present so a reader can reject an incompatible connection.json shape
+	// before connecting. First field to mirror the spec example.
+	FormatVersion string            `json:"format_version"`
+	Transport     string            `json:"transport"`
+	URL           string            `json:"url"`
+	Headers       map[string]string `json:"headers"`
+	Session       connectionSession `json:"session"`
+	Public        bool              `json:"public"`
+	TokenSource   string            `json:"token_source"`
+	TokenFile     string            `json:"token_file,omitempty"`
 }
 
 type ndjsonEvent struct {
@@ -1782,9 +1786,10 @@ func buildConnectionPayload(cfg config.Config, url string, auth authMaterial) co
 	}
 
 	return connectionPayload{
-		Transport: "mcp_streamable_http",
-		URL:       url,
-		Headers:   headers,
+		FormatVersion: protocol.FormatVersion,
+		Transport:     "mcp_streamable_http",
+		URL:           url,
+		Headers:       headers,
 		Session: connectionSession{
 			UsesMCPSessionID:     true,
 			HeaderName:           protocol.MCPSessionHeader,

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -387,8 +387,12 @@ func (s *Server) handleStatsTool(ctx context.Context, args map[string]interface{
 		"root":             retrievedStats.Root,
 		"state_dir":        retrievedStats.StateDir,
 		"protocol_version": retrievedStats.ProtocolVersion,
-		"doc_counts":       retrievedStats.DocCounts,
-		"total_docs":       retrievedStats.TotalDocs,
+		// format_version is the df-000 cross-version signal (SPEC §1.3/§15.6,
+		// #468): the payload-shape semver, SHOULD-level, independent of both the
+		// pinned protocol_version and the spec document version.
+		"format_version": protocol.FormatVersion,
+		"doc_counts":     retrievedStats.DocCounts,
+		"total_docs":     retrievedStats.TotalDocs,
 		// indicates whether the above counts originate from the underlying
 		// retriever.  when false the map will be zero-valued (not nil) and
 		// total_docs will be 0, so consumers must not assume those values
@@ -3523,6 +3527,9 @@ func statsOutputSchema() map[string]interface{} {
 			"root":             map[string]interface{}{"type": "string"},
 			"state_dir":        map[string]interface{}{"type": "string"},
 			"protocol_version": map[string]interface{}{"type": "string"},
+			// Optional additive (SHOULD, df-000 / stats.json, #468): payload-shape
+			// semver. Declared so it passes additionalProperties:false; not required.
+			"format_version": map[string]interface{}{"type": "string", "pattern": `^[0-9]+\.[0-9]+\.[0-9]+$`},
 			"doc_counts": map[string]interface{}{
 				"type":                 "object",
 				"additionalProperties": map[string]interface{}{"type": "integer"},

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -60,6 +60,15 @@ const (
 	MCPProtocolVersionHeader = "MCP-Protocol-Version"
 
 	ProtocolDefaultVersion = "2025-11-25"
+
+	// FormatVersion is the semver payload-shape signal dir2mcp stamps into the
+	// self-describing payloads it writes at a boundary (SPEC §1.3 / df-000,
+	// #468): connection.json (MUST) and the dir2mcp_stats output (SHOULD). It is
+	// an INDEPENDENT version of the payload shape — deliberately NOT the MCP
+	// protocolVersion (pinned, orthogonal) nor the spec document version — so a
+	// consumer can detect an incompatible payload and adapt or reject. Bump on a
+	// shape change per the df-000 additive/major rules.
+	FormatVersion = "0.1.0"
 )
 
 const (

--- a/tests/cli/up_command_test.go
+++ b/tests/cli/up_command_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/dirstral/dir2mcp/internal/config"
 	"github.com/dirstral/dir2mcp/internal/identity"
 	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/protocol"
 	"github.com/dirstral/dir2mcp/internal/store"
 )
 
@@ -59,11 +60,12 @@ func (f *fakeErrorStore) ListEmbeddedChunkMetadata(ctx context.Context, indexKin
 }
 
 type cliConnectionFile struct {
-	Transport string            `json:"transport"`
-	URL       string            `json:"url"`
-	Headers   map[string]string `json:"headers"`
-	Public    bool              `json:"public"`
-	Session   struct {
+	FormatVersion string            `json:"format_version"`
+	Transport     string            `json:"transport"`
+	URL           string            `json:"url"`
+	Headers       map[string]string `json:"headers"`
+	Public        bool              `json:"public"`
+	Session       struct {
 		UsesMCPSessionID     bool   `json:"uses_mcp_session_id"`
 		HeaderName           string `json:"header_name"`
 		AssignedOnInitialize bool   `json:"assigned_on_initialize"`
@@ -129,6 +131,10 @@ func readConnectionFile(t *testing.T, connectionPath string) cliConnectionFile {
 
 func assertConnectionFile(t *testing.T, connection cliConnectionFile) {
 	t.Helper()
+	// connection.json MUST carry the df-000 cross-version signal (#468).
+	if connection.FormatVersion != protocol.FormatVersion {
+		t.Fatalf("connection.json format_version: got %q want %q", connection.FormatVersion, protocol.FormatVersion)
+	}
 	if connection.Transport != "mcp_streamable_http" {
 		t.Fatalf("unexpected transport: %q", connection.Transport)
 	}

--- a/tests/mcp/stats_format_version_468_test.go
+++ b/tests/mcp/stats_format_version_468_test.go
@@ -1,0 +1,33 @@
+package tests
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/protocol"
+)
+
+// TestMCPStats_FormatVersion asserts the dir2mcp_stats output carries the df-000
+// cross-version signal (#468): a semver format_version, declared in the served
+// additionalProperties:false outputSchema and equal to protocol.FormatVersion.
+// It is the payload-shape version, independent of the pinned protocol_version.
+func TestMCPStats_FormatVersion(t *testing.T) {
+	cfg := config.Default()
+	cfg.StateDir = t.TempDir()
+	cfg.MCPPath = protocol.DefaultMCPPath
+	cfg.AuthMode = "none"
+
+	server := httptest.NewServer(mcp.NewServer(cfg, nil).Handler())
+	defer server.Close()
+
+	sc := callStatsTool(t, server.URL+cfg.MCPPath)
+	fv, ok := sc["format_version"].(string)
+	if !ok || fv == "" {
+		t.Fatalf("stats output missing format_version: %#v", sc["format_version"])
+	}
+	if fv != protocol.FormatVersion {
+		t.Fatalf("format_version = %q, want %q", fv, protocol.FormatVersion)
+	}
+}


### PR DESCRIPTION
## What

Completes the **#468 code follow-up** now that spec 0.34.0 ([dirstral-spec #42](https://github.com/dirstral/dirstral-spec/pull/42)) is merged — stamping the df-000 `format_version` cross-version signal into the payloads that carry it.

## Recon: two of four boundaries were already done ✅

The df-000 contract has four boundaries. Two were **already implemented** (verified in code, recon-first):
- **§5.6 SQLite `PRAGMA user_version` fence** — `checkSchemaVersion` refuses a newer-schema DB *before* WAL/migrations, `stampSchemaVersion`, floor-at-1 additive migrations (`sqlite_store.go`, #405). This was the risky one — already handled carefully.
- **§11.2 pinned `initialize` protocolVersion** — `server.go` advertises the pinned config value, not the client's echo (#404/#422).

So this PR adds only the **two remaining self-describing-payload fields:**

| Boundary | Rule | Change |
|---|---|---|
| `connection.json` | §4.3 **MUST** | `format_version` as the first field of `connectionPayload`, stamped in `buildConnectionPayload` |
| `dir2mcp_stats` output | §15.6 **SHOULD** | `format_version` in the served map + declared (semver `pattern`, **not required**) in the `additionalProperties:false` outputSchema so it stays spec-legal |

New `protocol.FormatVersion = "0.1.0"` — the semver **payload-shape** version, deliberately distinct from the pinned MCP `protocolVersion` and the spec document version (SPEC §1.3 / df-000).

Re-pins the `dirstral-spec` submodule to `8bbbbc1` (spec 0.34.0).

## Tests
- `connection.json` carries `format_version == protocol.FormatVersion`.
- MCP stats output: `format_version` present, semver, equals the constant.
- `make check` green.

Closes #468

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an explicit format version (`0.1.0`) to connection information, helping clients identify payload compatibility.
  - Added the same format version to statistics tool responses, with schema support for structured consumers.

- **Bug Fixes**
  - Improved cross-version compatibility signaling for connection and statistics payloads.

- **Tests**
  - Added coverage confirming the format version is present and consistent across supported outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->