### PR TITLE
feat(ingest,provider,config): honest STT language coverage (#566 Slice A)

### DIFF
--- a/internal/config/providers.go
+++ b/internal/config/providers.go
@@ -31,9 +31,15 @@ type providerProfileYAML struct {
 	OCRModel       string  `yaml:"ocr_model"`
 	STTModel       string  `yaml:"stt_model"`
 	STTLanguage    string  `yaml:"stt_language"`
-	TTSModel       string  `yaml:"tts_model"`
-	TTSVoice       string  `yaml:"tts_voice"`
-	RerankModel    string  `yaml:"rerank_model"`
+	// STTLanguages is the profile's OPTIONAL declared STT language coverage
+	// (SPEC §8.2.1, dir2mcp #566): a non-empty set of BCP-47 tags the model is
+	// known to transcribe well. Unset or empty = open/unknown (no coverage
+	// assertion); a declared, non-empty set drives the honest-coverage warning
+	// when the effective source language falls outside it.
+	STTLanguages []string `yaml:"stt_languages"`
+	TTSModel     string   `yaml:"tts_model"`
+	TTSVoice     string   `yaml:"tts_voice"`
+	RerankModel  string   `yaml:"rerank_model"`
 }
 
 type capBindingYAML struct {
@@ -393,6 +399,12 @@ func mergeProfiles(base, user map[string]providerProfileYAML, declOrder []string
 		if up.EmbedCodeDim != 0 {
 			base.EmbedCodeDim = up.EmbedCodeDim
 		}
+		// STTLanguages (declared STT coverage, #566) is a slice: a non-empty
+		// override replaces the built-in's set wholesale; an omitted/empty one
+		// leaves the base intact (matching the "unset => open/unknown" contract).
+		if len(up.STTLanguages) > 0 {
+			base.STTLanguages = append([]string(nil), up.STTLanguages...)
+		}
 		merged[name] = base
 	}
 	order := append([]string(nil), builtinPrecedence...)
@@ -468,6 +480,7 @@ func toProfiles(merged map[string]providerProfileYAML, getenv func(string) strin
 			OCRModel:       p.OCRModel,
 			STTModel:       p.STTModel,
 			STTLanguage:    p.STTLanguage,
+			STTLanguages:   append([]string(nil), p.STTLanguages...),
 			TTSModel:       p.TTSModel,
 			TTSVoice:       p.TTSVoice,
 			RerankModel:    p.RerankModel,

--- a/internal/ingest/derivation.go
+++ b/internal/ingest/derivation.go
@@ -117,9 +117,15 @@ func (s *Service) sttTranscriptMetaJSON(speakers []Speaker, text string, hasWord
 	// non-empty coverage set and the effective transcript language is outside it,
 	// record language_covered=false. Left absent (nil) when coverage is unknown
 	// (no declaration) or covered — absence means "no assertion", never "covered".
-	if declared, covered := provider.STTLanguageCoverageSet(s.sttLanguages, meta.Language); declared && !covered {
-		no := false
-		meta.LanguageCovered = &no
+	// The empty-language guard is redundant (STTLanguageCoverageSet already returns
+	// declared=false for a blank language, so an unknown language never records a
+	// false), but making it explicit keeps this site consistent with the
+	// construction-time check in resolveTranscriptIdentityFields.
+	if meta.Language != "" {
+		if declared, covered := provider.STTLanguageCoverageSet(s.sttLanguages, meta.Language); declared && !covered {
+			no := false
+			meta.LanguageCovered = &no
+		}
 	}
 	if s.diarizeActive {
 		// Record the diarize backend identity whenever diarization is active so a

--- a/internal/ingest/derivation.go
+++ b/internal/ingest/derivation.go
@@ -113,6 +113,14 @@ func (s *Service) sttTranscriptMetaJSON(speakers []Speaker, text string, hasWord
 		meta.LanguageSource = langSourceDetected
 		meta.LanguageConfidence = &conf
 	}
+	// Honest STT language coverage (SPEC §8.2.1, #566): when the model declares a
+	// non-empty coverage set and the effective transcript language is outside it,
+	// record language_covered=false. Left absent (nil) when coverage is unknown
+	// (no declaration) or covered — absence means "no assertion", never "covered".
+	if declared, covered := provider.STTLanguageCoverageSet(s.sttLanguages, meta.Language); declared && !covered {
+		no := false
+		meta.LanguageCovered = &no
+	}
 	if s.diarizeActive {
 		// Record the diarize backend identity whenever diarization is active so a
 		// backend/model swap re-derives the transcript (§8.6.7), even before any

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -98,6 +98,13 @@ type Service struct {
 	sttProvider string
 	sttModel    string
 
+	// sttLanguages is the resolved STT profile's DECLARED language coverage
+	// (SPEC §8.2.1, #566): a non-empty set asserts which BCP-47 languages the
+	// model transcribes well. Empty = open/unknown (no assertion). It drives the
+	// honest-coverage warning at construction and the transcript meta's
+	// language_covered flag; it is never part of the derivation identity.
+	sttLanguages []string
+
 	// diarizeActive reports whether speaker diarization is active for
 	// model-derived transcripts (SPEC §8.6.8): true only when diarization is
 	// enabled (tri-state) AND the active STT backend advertises CapDiarize.
@@ -731,6 +738,19 @@ func (s *Service) resolveTranscriptIdentityFields() {
 	}
 	s.sttProvider = strings.TrimSpace(prof.Name)
 	s.sttModel = strings.TrimSpace(prof.STTModel)
+	// Honest STT language coverage (SPEC §8.2.1, #566). When the profile declares
+	// a non-empty coverage set and the pinned source language falls outside it,
+	// warn once at construction so an operator sees "this model does not declare
+	// this language" instead of only a downstream quality-gate drop. Fail-open:
+	// transcription still runs; the §8.6.6 quality gate remains the backstop for
+	// degraded output. Unknown coverage (no declaration) makes no assertion.
+	s.sttLanguages = append([]string(nil), prof.STTLanguages...)
+	if lang := strings.TrimSpace(s.transcriptLanguage); lang != "" {
+		if declared, covered := provider.STTLanguageCoverage(prof, lang); declared && !covered {
+			s.getLogger().Printf("stt: language %q is outside %s's declared coverage %v; transcription will proceed but may be degraded (SPEC §8.2.1) — configure an STT provider that covers this language",
+				lang, s.sttProvider, prof.STTLanguages)
+		}
+	}
 	// Resolve the diarization binding (SPEC §8.6.8) from the SAME STT profile:
 	// diarization is active when enabled (tri-state) AND the backend advertises
 	// CapDiarize. The diarize derivation identity (§8.6.7) is the backend's

--- a/internal/ingest/sidecar.go
+++ b/internal/ingest/sidecar.go
@@ -93,8 +93,17 @@ type transcriptMeta struct {
 	// be re-applied as a filter at query time (§9.5). Omitted unless a detector
 	// produced it; a pointer so a genuine 0.0 is distinguishable from "absent".
 	LanguageConfidence *float64 `json:"language_confidence,omitempty"`
-	Timestamps         bool     `json:"timestamps"`
-	Format             string   `json:"format,omitempty"`
+	// LanguageCovered records honest STT language coverage (SPEC §8.2.1, #566).
+	// It is set ONLY to false, and ONLY when the selected STT model DECLARES a
+	// non-empty coverage set (a profile's stt_languages) and the effective
+	// transcript Language falls outside it — the "transcribed in a language this
+	// model does not declare" signal. It is a pointer with omitempty so it is
+	// absent (coverage unknown / no declaration / covered) rather than a
+	// misleading false: absence MUST be read as "no coverage assertion", never as
+	// "covered". Sidecar transcripts (authored, not model-derived) never set it.
+	LanguageCovered *bool  `json:"language_covered,omitempty"`
+	Timestamps      bool   `json:"timestamps"`
+	Format          string `json:"format,omitempty"`
 
 	// Words records the transcript's finest CAPTURED timing granularity (SPEC
 	// §8.6.9): true iff at least one segment carries a populated extra_json.words

--- a/internal/ingest/stt_coverage_566_test.go
+++ b/internal/ingest/stt_coverage_566_test.go
@@ -1,0 +1,38 @@
+package ingest
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSTTTranscriptMeta_LanguageCovered_566 verifies the honest-coverage flag on
+// a machine-transcribed transcript's meta_json (SPEC §8.2.1, #566):
+//   - a declared coverage set that excludes the effective language => language_covered:false
+//   - a declared set that includes it => the field is ABSENT (covered, no false)
+//   - no declaration => ABSENT (unknown, never a misleading false)
+//
+// The transcript language is pinned (transcriptLanguage) so the meta writer takes
+// the "configured" branch and never invokes the auto-detector.
+func TestSTTTranscriptMeta_LanguageCovered_566(t *testing.T) {
+	metaFor := func(lang string, coverage []string) string {
+		s := &Service{transcriptLanguage: lang, sttProvider: "whisper", sttModel: "large-v3", sttLanguages: coverage}
+		out, err := s.sttTranscriptMetaJSON(nil, "some transcript text", false)
+		if err != nil {
+			t.Fatalf("sttTranscriptMetaJSON: %v", err)
+		}
+		return out
+	}
+
+	// Declared, uncovered (the #566 Kyrgyz-on-a-ru/en model case).
+	if m := metaFor("kir", []string{"ru", "en"}); !strings.Contains(m, `"language_covered":false`) {
+		t.Fatalf("declared+uncovered must record language_covered:false, got %s", m)
+	}
+	// Declared and covered => flag absent (never true, never a false).
+	if m := metaFor("ru", []string{"ru", "en"}); strings.Contains(m, "language_covered") {
+		t.Fatalf("covered language must OMIT language_covered, got %s", m)
+	}
+	// No declaration => unknown => absent.
+	if m := metaFor("kir", nil); strings.Contains(m, "language_covered") {
+		t.Fatalf("undeclared coverage must OMIT language_covered, got %s", m)
+	}
+}

--- a/internal/ingest/stt_coverage_566_test.go
+++ b/internal/ingest/stt_coverage_566_test.go
@@ -35,4 +35,9 @@ func TestSTTTranscriptMeta_LanguageCovered_566(t *testing.T) {
 	if m := metaFor("kir", nil); strings.Contains(m, "language_covered") {
 		t.Fatalf("undeclared coverage must OMIT language_covered, got %s", m)
 	}
+	// Unknown language (no pin, no detection) WITH a declared set => absent, not a
+	// misleading false: a blank language is "unknown", not "outside coverage".
+	if m := metaFor("", []string{"ru", "en"}); strings.Contains(m, "language_covered") {
+		t.Fatalf("unknown language must OMIT language_covered even with a declared set, got %s", m)
+	}
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -216,6 +216,11 @@ type Profile struct {
 	OCRModel        string
 	STTModel        string
 	STTLanguage     string // optional STT language hint (e.g. ElevenLabs)
+	// STTLanguages is the profile's optional DECLARED STT language coverage
+	// (SPEC §8.2.1, #566): BCP-47 tags the model is known to transcribe well.
+	// Empty = open/unknown (no coverage assertion). A non-empty set drives the
+	// honest-coverage warning when the effective source language is outside it.
+	STTLanguages []string
 	// STTVAD requests a provider-side voice-activity-detection filter where
 	// supported (dir2mcp#258, config `media.vad`). For the self-hosted whisper
 	// provider this maps to the OpenAI-compatible `vad_filter` form field;
@@ -504,6 +509,44 @@ func normalizeLateChunking(on bool) string {
 		return "on"
 	}
 	return "off"
+}
+
+// STTLanguageCoverage reports whether an STT profile's declared language
+// coverage (SPEC §8.2.1, #566) asserts support for lang. It returns
+// (declared, covered): declared is false when the profile makes NO coverage
+// assertion (empty STTLanguages, or an empty/blank lang to test) — in which case
+// coverage is unknown and callers MUST NOT treat it as non-coverage; covered is
+// true iff a declared tag matches lang. Matching is on the BCP-47 primary
+// subtag, case-insensitive ("ru" covers "ru-RU" and vice versa), so a coverage
+// set of primary tags need not enumerate every region.
+func STTLanguageCoverage(p Profile, lang string) (declared, covered bool) {
+	return STTLanguageCoverageSet(p.STTLanguages, lang)
+}
+
+// STTLanguageCoverageSet is STTLanguageCoverage against a raw declared-coverage
+// slice, for callers that hold the set without the full Profile (e.g. the
+// transcript-meta writer).
+func STTLanguageCoverageSet(coverage []string, lang string) (declared, covered bool) {
+	lang = primarySubtag(lang)
+	if lang == "" || len(coverage) == 0 {
+		return false, false
+	}
+	for _, tag := range coverage {
+		if primarySubtag(tag) == lang {
+			return true, true
+		}
+	}
+	return true, false
+}
+
+// primarySubtag lower-cases a BCP-47 tag and returns its primary language
+// subtag (the part before the first '-'), trimmed. Empty input → "".
+func primarySubtag(tag string) string {
+	tag = strings.ToLower(strings.TrimSpace(tag))
+	if i := strings.IndexByte(tag, '-'); i >= 0 {
+		return tag[:i]
+	}
+	return tag
 }
 
 // NormalizeEmbedMultimodal lower-cases/trims the multimodal mode and maps

--- a/tests/provider/stt_coverage_566_test.go
+++ b/tests/provider/stt_coverage_566_test.go
@@ -1,0 +1,43 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/provider"
+)
+
+// TestSTTLanguageCoverage_566 pins the declared STT language-coverage helper
+// (SPEC §8.2.1, #566): an empty coverage set (or empty language) makes NO
+// assertion (declared=false); a non-empty set matches on the BCP-47 primary
+// subtag, case-insensitive, so region variants and casing don't defeat it.
+func TestSTTLanguageCoverage_566(t *testing.T) {
+	cases := []struct {
+		name         string
+		coverage     []string
+		lang         string
+		wantDeclared bool
+		wantCovered  bool
+	}{
+		{"no declaration => unknown", nil, "kir", false, false},
+		{"empty language => unknown", []string{"ru", "en"}, "", false, false},
+		{"covered exact", []string{"ru", "en"}, "ru", true, true},
+		{"covered primary-subtag vs region", []string{"ru"}, "ru-RU", true, true},
+		{"covered region-declared vs primary", []string{"en-US"}, "en", true, true},
+		{"covered case-insensitive", []string{"RU", "EN"}, "ru", true, true},
+		{"declared but uncovered (the #566 case)", []string{"ru", "en"}, "kir", true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			declared, covered := provider.STTLanguageCoverageSet(tc.coverage, tc.lang)
+			if declared != tc.wantDeclared || covered != tc.wantCovered {
+				t.Fatalf("STTLanguageCoverageSet(%v, %q) = (declared=%v, covered=%v), want (%v, %v)",
+					tc.coverage, tc.lang, declared, covered, tc.wantDeclared, tc.wantCovered)
+			}
+			// The Profile-based wrapper must agree.
+			pd, pc := provider.STTLanguageCoverage(provider.Profile{STTLanguages: tc.coverage}, tc.lang)
+			if pd != declared || pc != covered {
+				t.Fatalf("STTLanguageCoverage wrapper disagrees: (%v,%v) vs (%v,%v)", pd, pc, declared, covered)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Spec-first follow-up to [dirstral-spec #43](https://github.com/dirstral/dirstral-spec/pull/43) (SPEC §8.2.1) — **Slice A of #566**. Surfaces when an STT model is transcribing a language it doesn't cover, instead of letting coverage collapse silently.

A single STT model doesn't cover every language equally. On a low-resource language (Whisper on Kyrgyz: measured ~27% real coverage, wrong-language + repetition loops) the model doesn't error — it detects the nearest in-vocabulary language and emits mangled output; the §8.6.6 quality gate then drops it, hiding the cause.

## Scope: the declared-coverage + honest-coverage-floor half

Kept **domain-general** (no built-in model→language table; coverage is operator-declared and defaults to **open/unknown = today's behavior**):

- **New optional per-profile `stt_languages`** (BCP-47 declared coverage) on the provider profile + YAML, merged per-field (non-empty override replaces wholesale; empty = no assertion).
- **`provider.STTLanguageCoverage` / `…Set`**: BCP-47 primary-subtag, case-insensitive match (`ru` covers `ru-RU`); returns `(declared, covered)` so absence of a declaration is never read as non-coverage.
- **Honest-coverage floor:** when a profile declares a non-empty set and the pinned source language is outside it, the ingest Service **warns once** at construction and records **`language_covered:false`** on the machine-transcribed transcript's `meta_json`. Fail-open — transcription still runs; the quality gate stays the backstop. The flag is **absent** (never a misleading `false`) when coverage is unknown or the language is covered.

Re-pins `dirstral-spec` to `079540b` (spec 0.35.0).

## Tests
- Coverage matcher: exact / region-variant / case-insensitive / undeclared / declared-uncovered.
- Transcript meta: declared-uncovered → `language_covered:false`; covered / undeclared → field absent.
- `make check` green.

## Deferred to Slice B
`media.stt.language_providers` per-language **routing** to a covering model (a per-run selection change with a language-pin subtlety), a strict *skip-instead-of-transcribe* mode, and a `dir2mcp_stats` coverage aggregate.

Refs #566, #395.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring speech-to-text language coverage.
  * Transcript metadata now reports when the selected speech-to-text model does not cover the transcript language.
  * Language matching supports case-insensitive BCP-47 primary language tags and regional variants.
  * Added warnings when configured language coverage excludes the transcript language.

* **Tests**
  * Added coverage for declared, covered, uncovered, and unknown language scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->