### PR TITLE
feat(ingest,config): terminology-aware translation glossary (#574)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -519,6 +519,18 @@ type Config struct {
 	// (config `media.translate.context_lines`, issue #573). 0 means no margin.
 	// Only consulted for engine="chat".
 	MediaTranslateContextLines int
+	// MediaTranslateGlossary is OPTIONAL terminology guidance for the CHAT
+	// translate engine (config `media.translate.glossary`, SPEC §8.6.2, issue
+	// #574): a mapping keyed per BCP-47 TARGET language of source term/phrase →
+	// preferred rendering, injected into BOTH the per-line and windowed translate
+	// prompts as GUIDANCE (not a hard constraint) so proper nouns, domain terms,
+	// and preferred spellings render consistently AND inflect correctly (the model
+	// adapts morphology, unlike a find/replace). Only the entries for the CURRENT
+	// target language are injected. Empty/unset = no guidance (historical
+	// behaviour). It is DISTINCT from media.subtitles.glossary (an export-time
+	// regex find/replace on rendered cues). Domain-general: no built-in terms; the
+	// map is entirely operator-provided.
+	MediaTranslateGlossary map[string]map[string]string
 	// MediaFilterWords is an optional, general-purpose list of boilerplate /
 	// credits / watermark phrases stripped from transcript and subtitle text
 	// (config `media.filter_words`). Matching is case-insensitive substring
@@ -1739,6 +1751,18 @@ func applyFileOverrides(cfg *Config, path string) error {
 	}
 	cfg.Carbon = carbon
 
+	// Optional media.translate.glossary nested map (SPEC §8.6.2, issue #574).
+	// It is a per-target-language map-of-maps, so it is decoded from the media:
+	// subtree with yaml.v3 rather than the bespoke flat parser above (which is
+	// scalar/list-only). Absent block ⇒ nil (no guidance), no error.
+	glossary, err := parseMediaTranslateGlossary(raw)
+	if err != nil {
+		return fmt.Errorf("config file %s: %w", path, err)
+	}
+	if len(glossary) > 0 {
+		cfg.MediaTranslateGlossary = glossary
+	}
+
 	return nil
 }
 
@@ -2627,6 +2651,15 @@ func canonicalizeConfigKey(key string) string {
 // isMapSectionKey reports whether key names a nested mapping section
 // (so child keys should be prefixed) rather than a scalar/list key.
 func isMapSectionKey(key string) bool {
+	// media.translate.glossary is a nested per-target-language map-of-maps decoded
+	// separately with yaml.v3 (parseMediaTranslateGlossary); treat the glossary key
+	// AND every language sub-mapping under it as a section so the flat parser
+	// prefixes their child keys into the glossary namespace (e.g.
+	// media.translate.glossary.<lang>.<term>) instead of leaking a source term like
+	// "engine" up to a real media.translate.<key> and corrupting config (#574).
+	if key == "media.translate.glossary" || strings.HasPrefix(key, "media.translate.glossary.") {
+		return true
+	}
 	switch key {
 	case "rag", "ingest", "ingest.docling", "ingest.pandoc", "stt", "stt.mistral", "stt.elevenlabs", "server", "server.tls", "secret_sources", "mistral", "docling", "pandoc", "security", "security.auth", "x402", "x402.route_policy", "x402.route_policy.tools_call", "chunking", "retrieval", "retrieval.hybrid", "retrieval.context_compression", "retrieval.adaptive", "retrieval.mmr", "retrieval.hyde", "retrieval.cross_lingual", "rerank", "rerank.cohere", "index", "dedup":
 		return true

--- a/internal/config/providers.go
+++ b/internal/config/providers.go
@@ -224,7 +224,7 @@ func parseMediaTranslateGlossary(raw []byte) (map[string]map[string]string, erro
 	if err := yaml.Unmarshal(sub, &doc); err != nil {
 		return nil, fmt.Errorf("parse media.translate.glossary config: %w", err)
 	}
-	return normalizeTranslateGlossary(doc.Glossary), nil
+	return normalizeTranslateGlossary(doc.Glossary)
 }
 
 // normalizeTranslateGlossary lower-cases each target-language key (matching the
@@ -233,23 +233,38 @@ func parseMediaTranslateGlossary(raw []byte) (map[string]map[string]string, erro
 // rendering CASE is preserved (only the language tag is folded). Returns nil when
 // nothing survives so an empty/whitespace-only glossary is indistinguishable from
 // unset (today's no-guidance behaviour).
-func normalizeTranslateGlossary(in map[string]map[string]string) map[string]map[string]string {
+//
+// Two raw keys that collide after normalization ("es" and " ES " → "es"; " term "
+// and "term" → "term") are a config error, not a silent last-writer-wins overwrite
+// (which would be nondeterministic under Go map iteration): return CONFIG_INVALID
+// so the operator disambiguates.
+func normalizeTranslateGlossary(in map[string]map[string]string) (map[string]map[string]string, error) {
 	if len(in) == 0 {
-		return nil
+		return nil, nil
 	}
 	out := make(map[string]map[string]string, len(in))
+	langSeen := make(map[string]string, len(in)) // normalized lang → first raw key
 	for lang, terms := range in {
 		l := strings.ToLower(strings.TrimSpace(lang))
 		if l == "" || len(terms) == 0 {
 			continue
 		}
+		if prev, dup := langSeen[l]; dup {
+			return nil, fmt.Errorf("CONFIG_INVALID: media.translate.glossary target languages %q and %q both normalize to %q", prev, lang, l)
+		}
+		langSeen[l] = lang
 		m := make(map[string]string, len(terms))
+		srcSeen := make(map[string]string, len(terms)) // trimmed source term → first raw key
 		for src, rendering := range terms {
 			s := strings.TrimSpace(src)
 			r := strings.TrimSpace(rendering)
 			if s == "" || r == "" {
 				continue
 			}
+			if prev, dup := srcSeen[s]; dup {
+				return nil, fmt.Errorf("CONFIG_INVALID: media.translate.glossary[%q] source terms %q and %q both normalize to %q", l, prev, src, s)
+			}
+			srcSeen[s] = src
 			m[s] = r
 		}
 		if len(m) > 0 {
@@ -257,9 +272,9 @@ func normalizeTranslateGlossary(in map[string]map[string]string) map[string]map[
 		}
 	}
 	if len(out) == 0 {
-		return nil
+		return nil, nil
 	}
-	return out
+	return out, nil
 }
 
 // extractMediaTranslateGlossarySubtree returns the `glossary:` block nested under

--- a/internal/config/providers.go
+++ b/internal/config/providers.go
@@ -198,6 +198,126 @@ func extractTopLevelSubtree(raw []byte, want string) []byte {
 	return []byte(strings.Join(out, "\n"))
 }
 
+// parseMediaTranslateGlossary decodes the OPTIONAL, per-target-language
+// `media.translate.glossary` nested map (SPEC §8.6.2, issue #574):
+//
+//	media:
+//	  translate:
+//	    glossary:
+//	      es:
+//	        "United Nations": "Naciones Unidas"
+//
+// It is a map-of-maps, so — unlike the scalar/list `media.*` keys handled by the
+// bespoke flat parser — it is decoded with yaml.v3 from the glossary block
+// extracted in isolation (extractMediaTranslateGlossarySubtree), never exposing
+// unrelated `media:` scalars to a strict YAML decode. Language keys are
+// lower-cased to match the normalized target_langs used at lookup time; blank
+// languages/terms/renderings are dropped. Absent block ⇒ nil (no guidance).
+func parseMediaTranslateGlossary(raw []byte) (map[string]map[string]string, error) {
+	sub := extractMediaTranslateGlossarySubtree(raw)
+	if len(sub) == 0 {
+		return nil, nil
+	}
+	var doc struct {
+		Glossary map[string]map[string]string `yaml:"glossary"`
+	}
+	if err := yaml.Unmarshal(sub, &doc); err != nil {
+		return nil, fmt.Errorf("parse media.translate.glossary config: %w", err)
+	}
+	return normalizeTranslateGlossary(doc.Glossary), nil
+}
+
+// normalizeTranslateGlossary lower-cases each target-language key (matching the
+// normalized media.translate.target_langs used at lookup), trims each source
+// term and rendering, and drops blank languages/terms/renderings. Source-term and
+// rendering CASE is preserved (only the language tag is folded). Returns nil when
+// nothing survives so an empty/whitespace-only glossary is indistinguishable from
+// unset (today's no-guidance behaviour).
+func normalizeTranslateGlossary(in map[string]map[string]string) map[string]map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]map[string]string, len(in))
+	for lang, terms := range in {
+		l := strings.ToLower(strings.TrimSpace(lang))
+		if l == "" || len(terms) == 0 {
+			continue
+		}
+		m := make(map[string]string, len(terms))
+		for src, rendering := range terms {
+			s := strings.TrimSpace(src)
+			r := strings.TrimSpace(rendering)
+			if s == "" || r == "" {
+				continue
+			}
+			m[s] = r
+		}
+		if len(m) > 0 {
+			out[l] = m
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// extractMediaTranslateGlossarySubtree returns the `glossary:` block nested under
+// `media:` → `translate:` (its key line plus indented continuation), dedented to
+// column 0 so yaml.v3 can decode it in isolation, or nil when absent. It tracks
+// the media→translate→glossary nesting by indentation so it does NOT match the
+// unrelated, list-valued `media.subtitles.glossary` (§8.6.3).
+func extractMediaTranslateGlossarySubtree(raw []byte) []byte {
+	lines := strings.Split(string(raw), "\n")
+	start, base := findMediaTranslateGlossaryHeader(lines)
+	if start < 0 {
+		return nil
+	}
+	out := []string{lines[start][base:]} // dedented `glossary:` header
+	for _, line := range lines[start+1:] {
+		trimmed := strings.TrimLeft(line, " ")
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			out = append(out, "")
+			continue
+		}
+		if len(line)-len(trimmed) <= base {
+			break // dedented back to/above the header: end of the glossary block
+		}
+		out = append(out, line[base:]) // strip the header indent, keep relative nesting
+	}
+	return []byte(strings.Join(out, "\n"))
+}
+
+// findMediaTranslateGlossaryHeader locates the `glossary:` line nested exactly
+// under a top-level `media:` → `translate:` mapping, returning its line index and
+// leading-space indent (or -1 when absent). It walks an indentation stack of
+// (indent, key) frames so it matches only the translate glossary, never
+// media.subtitles.glossary.
+func findMediaTranslateGlossaryHeader(lines []string) (idx, indent int) {
+	type frame struct {
+		indent int
+		key    string
+	}
+	var stack []frame
+	for i, line := range lines {
+		trimmed := strings.TrimLeft(line, " ")
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		ind := len(line) - len(trimmed)
+		for len(stack) > 0 && stack[len(stack)-1].indent >= ind {
+			stack = stack[:len(stack)-1]
+		}
+		key := strings.TrimSpace(strings.SplitN(trimmed, ":", 2)[0])
+		stack = append(stack, frame{indent: ind, key: key})
+		if len(stack) == 3 && stack[0].indent == 0 &&
+			stack[0].key == "media" && stack[1].key == "translate" && stack[2].key == "glossary" {
+			return i, ind
+		}
+	}
+	return -1, -1
+}
+
 // costDoc is the yaml shape of the optional top-level `cost:` block:
 //
 //	cost:

--- a/internal/ingest/translate.go
+++ b/internal/ingest/translate.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -180,7 +181,7 @@ func (s *Service) translateWindow(ctx context.Context, cells []translateCell, or
 	before := order[max(0, start-marginM):start]
 	after := order[end:min(len(order), end+marginM)]
 
-	prompt := buildWindowTranslatePrompt(cells, before, targets, after, targetLang)
+	prompt := buildWindowTranslatePrompt(cells, before, targets, after, targetLang, s.translateGlossaryFor(targetLang))
 	raw, err := s.generateBounded(ctx, prompt, translateLineMaxTokens*len(targets))
 	if err != nil {
 		// A provider/transport failure is NOT a format mismatch: the provider is
@@ -270,19 +271,62 @@ func (s *Service) translateLine(ctx context.Context, text, targetLang string) (s
 	if text == "" {
 		return "", nil
 	}
-	return s.generateBounded(ctx, buildTranslatePrompt(text, targetLang), translateLineMaxTokens)
+	return s.generateBounded(ctx, buildTranslatePrompt(text, targetLang, s.translateGlossaryFor(targetLang)), translateLineMaxTokens)
+}
+
+// translateGlossaryFor returns the terminology-guidance entries (source term →
+// preferred rendering) configured for targetLang, or nil when no glossary applies
+// (SPEC §8.6.2, issue #574). Language tags are matched case-insensitively against
+// the normalized (lower-cased) glossary keys.
+func (s *Service) translateGlossaryFor(targetLang string) map[string]string {
+	if len(s.cfg.MediaTranslateGlossary) == 0 {
+		return nil
+	}
+	return s.cfg.MediaTranslateGlossary[strings.ToLower(strings.TrimSpace(targetLang))]
+}
+
+// writeGlossaryGuidance appends a deterministic terminology-guidance line for the
+// current target language's glossary entries (SPEC §8.6.2, issue #574). It is
+// GUIDANCE, not a hard constraint — the model is asked to PREFER these renderings
+// but adapt them for grammar. Entries are emitted in sorted source-term order so
+// the prompt is byte-for-byte deterministic (Go map iteration order is
+// randomized). No-op when glossary is empty, preserving today's prompt exactly.
+func writeGlossaryGuidance(b *strings.Builder, glossary map[string]string) {
+	if len(glossary) == 0 {
+		return
+	}
+	terms := make([]string, 0, len(glossary))
+	for src := range glossary {
+		terms = append(terms, src)
+	}
+	sort.Strings(terms)
+	b.WriteString("Prefer these renderings for the terms below, adapting only as grammar requires ")
+	b.WriteString("(case, inflection, agreement): ")
+	for i, src := range terms {
+		if i > 0 {
+			b.WriteString("; ")
+		}
+		b.WriteString(src)
+		b.WriteString(" => ")
+		b.WriteString(glossary[src])
+	}
+	b.WriteString(".\n")
 }
 
 // buildTranslatePrompt builds a deterministic, general-purpose translation
 // prompt. It pins the TARGET language only (the source language is auto-detected
 // by the model, matching SPEC §8.6.2's auto-detection default) and instructs the
-// model to return the translation alone so the output needs no post-parsing.
-func buildTranslatePrompt(text, targetLang string) string {
+// model to return the translation alone so the output needs no post-parsing. When
+// a non-empty glossary is supplied it injects per-target terminology guidance
+// (§8.6.2); an empty glossary reproduces the historical prompt verbatim.
+func buildTranslatePrompt(text, targetLang string, glossary map[string]string) string {
 	var b strings.Builder
 	b.WriteString("Translate the following text into ")
 	b.WriteString(targetLang)
 	b.WriteString(". Preserve meaning faithfully. Return only the translated text, ")
-	b.WriteString("with no preamble, quotes, or explanation.\n\n")
+	b.WriteString("with no preamble, quotes, or explanation.\n")
+	writeGlossaryGuidance(&b, glossary)
+	b.WriteString("\n")
 	b.WriteString(text)
 	return b.String()
 }
@@ -294,8 +338,10 @@ func buildTranslatePrompt(text, targetLang string) string {
 // referents, agreement, split sentences, and terminology WITHOUT re-translating
 // them. The strict "N: <translation>" response contract lets the caller verify a
 // 1:1 mapping and safe-degrade on any mismatch. It is language-agnostic (the
-// target language is pinned; the source is auto-detected).
-func buildWindowTranslatePrompt(cells []translateCell, before, targets, after []int, targetLang string) string {
+// target language is pinned; the source is auto-detected). A non-empty glossary
+// injects the same per-target terminology guidance as the per-line prompt
+// (§8.6.2, issue #574); an empty glossary reproduces the historical prompt.
+func buildWindowTranslatePrompt(cells []translateCell, before, targets, after []int, targetLang string, glossary map[string]string) string {
 	var b strings.Builder
 	b.WriteString("Translate each NUMBERED line below into ")
 	b.WriteString(targetLang)
@@ -307,6 +353,7 @@ func buildWindowTranslatePrompt(cells []translateCell, before, targets, after []
 	b.WriteString("with the SAME count and the SAME numbers in the SAME order. Do NOT add, drop, split, ")
 	b.WriteString("merge, renumber, or reorder lines, and never output the context lines. ")
 	b.WriteString("No preamble, quotes, or explanation.\n")
+	writeGlossaryGuidance(&b, glossary)
 
 	writeContext := func(heading string, idxs []int) {
 		if len(idxs) == 0 {

--- a/internal/ingest/translate_glossary_test.go
+++ b/internal/ingest/translate_glossary_test.go
@@ -1,0 +1,101 @@
+package ingest
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+)
+
+const glossaryGuidanceMarker = "Prefer these renderings for the terms below"
+
+// TestBuildTranslatePrompt_GlossaryInjectedDeterministic asserts the per-line
+// prompt (buildTranslatePrompt) injects the current target language's glossary as
+// guidance, in sorted source-term order (never Go map-iteration order), and still
+// carries the source text (SPEC §8.6.2, issue #574).
+func TestBuildTranslatePrompt_GlossaryInjectedDeterministic(t *testing.T) {
+	glossary := map[string]string{"Zephyr": "Zefiro", "Aegis": "Egida", "Mistral": "Mistral"}
+	got := buildTranslatePrompt("The Aegis holds.", "es", glossary)
+
+	if !strings.Contains(got, glossaryGuidanceMarker) {
+		t.Fatalf("glossary guidance missing:\n%s", got)
+	}
+	for _, want := range []string{"Aegis => Egida", "Mistral => Mistral", "Zephyr => Zefiro"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing glossary entry %q in:\n%s", want, got)
+		}
+	}
+	// Deterministic sorted order: Aegis < Mistral < Zephyr.
+	ai, mi, zi := strings.Index(got, "Aegis =>"), strings.Index(got, "Mistral =>"), strings.Index(got, "Zephyr =>")
+	if ai >= mi || mi >= zi {
+		t.Errorf("glossary entries not in sorted order (Aegis<Mistral<Zephyr): %d,%d,%d\n%s", ai, mi, zi, got)
+	}
+	if !strings.HasSuffix(got, "The Aegis holds.") {
+		t.Errorf("source text lost from prompt:\n%s", got)
+	}
+}
+
+// TestBuildTranslatePrompt_NoGlossaryUnchanged asserts an empty/nil glossary
+// injects nothing and reproduces the historical prompt (blank line before the
+// source text) byte-for-byte, so today's behaviour is preserved.
+func TestBuildTranslatePrompt_NoGlossaryUnchanged(t *testing.T) {
+	for _, g := range []map[string]string{nil, {}} {
+		got := buildTranslatePrompt("hello", "es", g)
+		if strings.Contains(got, glossaryGuidanceMarker) {
+			t.Errorf("guidance injected for empty glossary:\n%s", got)
+		}
+		if !strings.Contains(got, "explanation.\n\nhello") {
+			t.Errorf("empty-glossary prompt diverged from the historical form:\n%s", got)
+		}
+	}
+}
+
+// TestBuildWindowTranslatePrompt_Glossary asserts the windowed prompt
+// (buildWindowTranslatePrompt, #573/#599) injects the same guidance in sorted
+// order and omits it when the glossary is empty.
+func TestBuildWindowTranslatePrompt_Glossary(t *testing.T) {
+	cells := []translateCell{{body: "one", translatable: true}, {body: "two", translatable: true}}
+	targets := []int{0, 1}
+
+	withG := buildWindowTranslatePrompt(cells, nil, targets, nil, "de", map[string]string{"beta": "B", "alpha": "A"})
+	if !strings.Contains(withG, glossaryGuidanceMarker) {
+		t.Fatalf("glossary guidance missing from windowed prompt:\n%s", withG)
+	}
+	if ai, bi := strings.Index(withG, "alpha => A"), strings.Index(withG, "beta => B"); ai < 0 || ai >= bi {
+		t.Errorf("windowed glossary entries not in sorted order: %d,%d\n%s", ai, bi, withG)
+	}
+
+	withoutG := buildWindowTranslatePrompt(cells, nil, targets, nil, "de", nil)
+	if strings.Contains(withoutG, glossaryGuidanceMarker) {
+		t.Errorf("guidance injected for nil glossary in windowed prompt:\n%s", withoutG)
+	}
+}
+
+// TestTranslateGlossaryFor_CurrentTargetOnly asserts only the current target
+// language's entries are selected (never another language's), that the language
+// match is case-insensitive, and that an unconfigured target yields nil.
+func TestTranslateGlossaryFor_CurrentTargetOnly(t *testing.T) {
+	svc := &Service{cfg: config.Config{MediaTranslateGlossary: map[string]map[string]string{
+		"es": {"Sun": "Sol"},
+		"fr": {"Sun": "Soleil"},
+	}}}
+
+	if es := svc.translateGlossaryFor("es"); len(es) != 1 || es["Sun"] != "Sol" {
+		t.Fatalf("es glossary wrong: %#v", es)
+	}
+	if svc.translateGlossaryFor("ES") == nil {
+		t.Error("expected case-insensitive language match for \"ES\"")
+	}
+	if g := svc.translateGlossaryFor("de"); g != nil {
+		t.Errorf("expected nil for a target with no glossary, got %#v", g)
+	}
+
+	// The es prompt must show only the es rendering, never the fr one.
+	prompt := buildTranslatePrompt("The Sun", "es", svc.translateGlossaryFor("es"))
+	if !strings.Contains(prompt, "Sun => Sol") {
+		t.Errorf("es rendering missing:\n%s", prompt)
+	}
+	if strings.Contains(prompt, "Soleil") {
+		t.Errorf("fr rendering leaked into es prompt:\n%s", prompt)
+	}
+}

--- a/internal/ingest/translate_glossary_test.go
+++ b/internal/ingest/translate_glossary_test.go
@@ -39,13 +39,15 @@ func TestBuildTranslatePrompt_GlossaryInjectedDeterministic(t *testing.T) {
 // injects nothing and reproduces the historical prompt (blank line before the
 // source text) byte-for-byte, so today's behaviour is preserved.
 func TestBuildTranslatePrompt_NoGlossaryUnchanged(t *testing.T) {
+	// The exact pre-#574 prompt: the fixed instruction line, a blank line, then the
+	// source text — with NO glossary block. Compared in full so a change anywhere in
+	// the legacy prompt (not just the tail) fails the compat guarantee.
+	const historical = "Translate the following text into es. Preserve meaning faithfully. " +
+		"Return only the translated text, with no preamble, quotes, or explanation.\n\nhello"
 	for _, g := range []map[string]string{nil, {}} {
 		got := buildTranslatePrompt("hello", "es", g)
-		if strings.Contains(got, glossaryGuidanceMarker) {
-			t.Errorf("guidance injected for empty glossary:\n%s", got)
-		}
-		if !strings.Contains(got, "explanation.\n\nhello") {
-			t.Errorf("empty-glossary prompt diverged from the historical form:\n%s", got)
+		if got != historical {
+			t.Errorf("empty-glossary prompt diverged from the historical form byte-for-byte:\n got=%q\nwant=%q", got, historical)
 		}
 	}
 }
@@ -83,8 +85,8 @@ func TestTranslateGlossaryFor_CurrentTargetOnly(t *testing.T) {
 	if es := svc.translateGlossaryFor("es"); len(es) != 1 || es["Sun"] != "Sol" {
 		t.Fatalf("es glossary wrong: %#v", es)
 	}
-	if svc.translateGlossaryFor("ES") == nil {
-		t.Error("expected case-insensitive language match for \"ES\"")
+	if es := svc.translateGlossaryFor("ES"); es == nil || es["Sun"] != "Sol" {
+		t.Errorf("expected case-insensitive \"ES\" to resolve to the es map (Sun=>Sol), got %#v", es)
 	}
 	if g := svc.translateGlossaryFor("de"); g != nil {
 		t.Errorf("expected nil for a target with no glossary, got %#v", g)

--- a/tests/config/media_translate_glossary_config_test.go
+++ b/tests/config/media_translate_glossary_config_test.go
@@ -1,0 +1,149 @@
+package tests
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+)
+
+// TestMediaTranslateGlossary_NestedYAMLApplies locks the per-target-language,
+// map-of-maps `media.translate.glossary` parse (SPEC §8.6.2, issue #574): the
+// nested block is decoded with yaml.v3 (not the flat scalar/list parser) and the
+// language keys are lower-cased to match the normalized target_langs used at
+// lookup time.
+func TestMediaTranslateGlossary_NestedYAMLApplies(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+	writeFile(t, path, strings.Join([]string{
+		"root_dir: /tmp/repo",
+		"state_dir: /tmp/repo/.dir2mcp",
+		"media:",
+		"  translate:",
+		"    engine: chat",
+		"    glossary:",
+		"      es:",
+		`        "United Nations": "Naciones Unidas"`,
+		`        "Security Council": "Consejo de Seguridad"`,
+		"      FR:",
+		`        "United Nations": "Nations Unies"`,
+	}, "\n")+"\n")
+
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile(nested media.translate.glossary) = %v, want nil", err)
+	}
+	es := cfg.MediaTranslateGlossary["es"]
+	if es["United Nations"] != "Naciones Unidas" || es["Security Council"] != "Consejo de Seguridad" {
+		t.Errorf("es glossary not parsed: %#v", es)
+	}
+	// Language tag is folded to lower-case ("FR" -> "fr").
+	if fr := cfg.MediaTranslateGlossary["fr"]; fr["United Nations"] != "Nations Unies" {
+		t.Errorf("fr glossary (lower-cased key) not parsed: %#v", cfg.MediaTranslateGlossary)
+	}
+	// Only the two configured languages are present.
+	if len(cfg.MediaTranslateGlossary) != 2 {
+		t.Errorf("expected 2 language entries, got %d: %#v", len(cfg.MediaTranslateGlossary), cfg.MediaTranslateGlossary)
+	}
+}
+
+// TestMediaTranslateGlossary_DoesNotCorruptSiblingKeys guards the flat-parser
+// footgun: a glossary SOURCE TERM that happens to match a real media.translate
+// key (e.g. "engine") must NOT leak up and overwrite that sibling scalar. The
+// glossary block is namespaced away from the flat parser (isMapSectionKey) and
+// decoded separately, so the real engine value is preserved.
+func TestMediaTranslateGlossary_DoesNotCorruptSiblingKeys(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+	writeFile(t, path, strings.Join([]string{
+		"root_dir: /tmp/repo",
+		"state_dir: /tmp/repo/.dir2mcp",
+		"media:",
+		"  translate:",
+		"    engine: chat",
+		"    glossary:",
+		"      de:",
+		`        "engine": "Triebwerk"`,
+		`        "window_lines": "Zeilenfenster"`,
+	}, "\n")+"\n")
+
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile = %v, want nil", err)
+	}
+	if cfg.MediaTranslateEngine != "chat" {
+		t.Errorf("glossary source term corrupted media.translate.engine: got %q, want \"chat\"", cfg.MediaTranslateEngine)
+	}
+	if de := cfg.MediaTranslateGlossary["de"]; de["engine"] != "Triebwerk" {
+		t.Errorf("glossary entry keyed on a config-like term not preserved: %#v", de)
+	}
+}
+
+// TestMediaTranslateGlossary_AbsentIsNil confirms an absent/empty glossary leaves
+// the field nil (no guidance = today's behaviour), including when the block is
+// present but all entries are blank.
+func TestMediaTranslateGlossary_AbsentIsNil(t *testing.T) {
+	tmp := t.TempDir()
+	for name, body := range map[string]string{
+		"absent": strings.Join([]string{
+			"root_dir: /tmp/repo",
+			"state_dir: /tmp/repo/.dir2mcp",
+			"media:",
+			"  translate:",
+			"    engine: chat",
+		}, "\n") + "\n",
+		"blank_entries": strings.Join([]string{
+			"root_dir: /tmp/repo",
+			"state_dir: /tmp/repo/.dir2mcp",
+			"media:",
+			"  translate:",
+			"    glossary:",
+			"      es:",
+			`        "  ": "   "`,
+		}, "\n") + "\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(tmp, name+".yaml")
+			writeFile(t, path, body)
+			cfg, err := config.LoadFile(path)
+			if err != nil {
+				t.Fatalf("LoadFile = %v, want nil", err)
+			}
+			if cfg.MediaTranslateGlossary != nil {
+				t.Errorf("expected nil glossary, got %#v", cfg.MediaTranslateGlossary)
+			}
+		})
+	}
+}
+
+// TestMediaTranslateGlossary_NotConfusedWithSubtitlesGlossary asserts the nested
+// translate glossary and the unrelated, list-valued media.subtitles.glossary
+// (§8.6.3) coexist without cross-contamination.
+func TestMediaTranslateGlossary_NotConfusedWithSubtitlesGlossary(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+	writeFile(t, path, strings.Join([]string{
+		"root_dir: /tmp/repo",
+		"state_dir: /tmp/repo/.dir2mcp",
+		"media:",
+		"  subtitles:",
+		"    glossary:",
+		"      - \"Github => GitHub\"",
+		"  translate:",
+		"    glossary:",
+		"      es:",
+		`        "color": "colour"`,
+	}, "\n")+"\n")
+
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile = %v, want nil", err)
+	}
+	if len(cfg.MediaSubtitlesGlossary) != 1 || cfg.MediaSubtitlesGlossary[0] != "Github => GitHub" {
+		t.Errorf("subtitles.glossary (list) not parsed independently: %#v", cfg.MediaSubtitlesGlossary)
+	}
+	if cfg.MediaTranslateGlossary["es"]["color"] != "colour" {
+		t.Errorf("translate.glossary (map) not parsed independently: %#v", cfg.MediaTranslateGlossary)
+	}
+}

--- a/tests/config/media_translate_glossary_config_test.go
+++ b/tests/config/media_translate_glossary_config_test.go
@@ -147,3 +147,39 @@ func TestMediaTranslateGlossary_NotConfusedWithSubtitlesGlossary(t *testing.T) {
 		t.Errorf("translate.glossary (map) not parsed independently: %#v", cfg.MediaTranslateGlossary)
 	}
 }
+
+// TestMediaTranslateGlossary_RejectsNormalizedCollisions locks the CONFIG_INVALID
+// contract (#574 review): two glossary keys that collide only after normalization
+// — target languages that fold to the same lower-cased tag, or source terms that
+// trim to the same string — must be rejected, not silently last-writer-wins
+// (nondeterministic under Go map iteration).
+func TestMediaTranslateGlossary_RejectsNormalizedCollisions(t *testing.T) {
+	cases := map[string][]string{
+		"language collision (es / ' ES ')": {
+			"media:", "  translate:", "    glossary:",
+			"      es:", `        "Sun": "Sol"`,
+			`      " ES ":`, `        "Moon": "Luna"`,
+		},
+		"source-term collision (term / ' term ')": {
+			"media:", "  translate:", "    glossary:",
+			"      es:", `        "term": "A"`, `        " term ": "B"`,
+		},
+	}
+	for name, mediaLines := range cases {
+		t.Run(name, func(t *testing.T) {
+			tmp := t.TempDir()
+			path := filepath.Join(tmp, ".dir2mcp.yaml")
+			writeFile(t, path, strings.Join(append([]string{
+				"root_dir: /tmp/repo", "state_dir: /tmp/repo/.dir2mcp",
+			}, mediaLines...), "\n")+"\n")
+
+			_, err := config.LoadFile(path)
+			if err == nil {
+				t.Fatalf("expected a config error for %s, got nil", name)
+			}
+			if !strings.Contains(err.Error(), "CONFIG_INVALID") || !strings.Contains(err.Error(), "glossary") {
+				t.Fatalf("error should name CONFIG_INVALID + glossary, got: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds an optional, per-target-language **`media.translate.glossary`** — a mapping of source term/phrase → preferred rendering — injected into the chat translate **prompt** as guidance (SPEC §8.6.2, dirstral-spec #44).

- **Keyed per target language**: `glossary: { <bcp47-target>: { "<source term>": "<rendering>" } }`. Only the current target language's entries are injected.
- Applies to **both** prompt builders in `internal/ingest/translate.go`: the per-line `buildTranslatePrompt` and the windowed `buildWindowTranslatePrompt` (#573/#599).
- **Guidance, not a hard constraint** — the model is asked to *prefer* the renderings but adapt for grammar (case/inflection/agreement), so terms inflect correctly across surface forms (which a find/replace cannot).
- Entries are emitted in **sorted source-term order** so the prompt is byte-for-byte deterministic (never Go map-iteration order).
- **Empty/unset = today's behaviour** (the historical prompt is reproduced verbatim).
- **Distinct** from the export-time regex `media.subtitles.glossary` (§8.6.3) — untouched here.
- **Domain-general**: no built-in terms; entirely operator-provided.

## How

- **Config** (`internal/config/`): new `Config.MediaTranslateGlossary map[string]map[string]string`. Because it is a nested map-of-maps — unlike the scalar/list `media.*` keys handled by the bespoke flat parser — it is decoded with **yaml.v3** from the `glossary:` block extracted in isolation (`extractMediaTranslateGlossarySubtree` / `parseMediaTranslateGlossary`), mirroring the existing `carbon:`/`cost:` subtree-decode pattern and never exposing unrelated `media:` scalars to a strict decode. Language keys are lower-cased to match the normalized `target_langs` used at lookup; blank languages/terms/renderings are dropped.
- **Footgun guard**: `isMapSectionKey` now treats `media.translate.glossary` and its language sub-mappings as sections, so a glossary source term that matches a real key (e.g. `engine`) is namespaced away and can never leak up to corrupt `media.translate.*`.
- **Spec re-pin**: bumps the `dirstral-spec` submodule `079540b → 3dba703` (spec main), which adds §8.6.2 glossary; the previous pin predated it.

## Tests

- `internal/ingest/translate_glossary_test.go` (white-box): guidance injected + deterministic sorted ordering in **both** builders; absent for empty/nil and other-language glossaries; historical prompt preserved when empty; per-target selection (no cross-language leak; case-insensitive match; nil for unconfigured target).
- `tests/config/media_translate_glossary_config_test.go`: nested-YAML parse (incl. lower-cased lang keys), the sibling-key non-corruption guard, absent/blank → nil, and coexistence with the list-valued `media.subtitles.glossary`.

`make check` passes locally (unrelated gofmt-noise reverts applied).

Closes #574