### PR TITLE
feat(config,ingest): language-coverage-aware STT routing (#566 Slice B)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -700,6 +700,19 @@ type Config struct {
 	// can set this true to restore strict script-mismatch enforcement.
 	MediaSTTLanguageStrict bool
 
+	// MediaSTTLanguageProviders routes transcription by the pinned source
+	// language (config `media.stt.language_providers`, SPEC §8.2.1, #566): a map
+	// from a BCP-47 primary language subtag to the NAME of an STT-capable provider
+	// profile. When the resolved SOURCE-LANGUAGE pin matches a key, that profile
+	// transcribes, OVERRIDING the default STT provider; empty/unset preserves the
+	// single-provider behaviour. Routing is PIN-BASED and per-run: langdetect is
+	// text-based and cannot know an audio file's language before transcription, so
+	// the route keys off the configured language pin (resolved once), never
+	// per-item auto-detection — with no pin there is nothing to route on. Keys are
+	// normalized to the BCP-47 primary subtag (lower-cased) at load; a mapped name
+	// that is absent or not STT-capable is rejected as CONFIG_INVALID at startup.
+	MediaSTTLanguageProviders map[string]string
+
 	// MediaBatchTwoPhase / MediaBatchProgress / MediaBatchManifest configure the
 	// optional batch-ergonomics surface for large-archive media ingests (SPEC
 	// §8.6.11; config block `media.batch`). All default OFF/empty so behavior is
@@ -1763,6 +1776,18 @@ func applyFileOverrides(cfg *Config, path string) error {
 		cfg.MediaTranslateGlossary = glossary
 	}
 
+	// Optional media.stt.language_providers nested map (SPEC §8.2.1, #566). It is
+	// a map of BCP-47 language -> STT provider profile name, so it is decoded from
+	// the media: subtree with yaml.v3 rather than the bespoke flat parser above
+	// (which is scalar/list-only). Absent block ⇒ nil (no routing), no error.
+	langProviders, err := parseMediaSTTLanguageProviders(raw)
+	if err != nil {
+		return fmt.Errorf("config file %s: %w", path, err)
+	}
+	if len(langProviders) > 0 {
+		cfg.MediaSTTLanguageProviders = langProviders
+	}
+
 	return nil
 }
 
@@ -2657,7 +2682,14 @@ func isMapSectionKey(key string) bool {
 	// prefixes their child keys into the glossary namespace (e.g.
 	// media.translate.glossary.<lang>.<term>) instead of leaking a source term like
 	// "engine" up to a real media.translate.<key> and corrupting config (#574).
-	if key == "media.translate.glossary" || strings.HasPrefix(key, "media.translate.glossary.") {
+	//
+	// media.stt.language_providers is likewise a nested lang->profile map decoded
+	// separately (parseMediaSTTLanguageProviders, #566); treat it and its language
+	// sub-entries as a section so children prefix into that namespace
+	// (media.stt.language_providers.<lang>) — a guaranteed no-op — instead of
+	// leaking a language code up to a real media.stt.<key>.
+	if key == "media.translate.glossary" || strings.HasPrefix(key, "media.translate.glossary.") ||
+		key == "media.stt.language_providers" || strings.HasPrefix(key, "media.stt.language_providers.") {
 		return true
 	}
 	switch key {
@@ -3755,6 +3787,10 @@ func (c *Config) Validate() error {
 		// with its own root-cause CONFIG_INVALID rather than surfacing as a
 		// misleading "requires STT provider to be kind:whisper" (optibot #592).
 		c.validateSTTProvider,
+		// After validateSTTProvider (so an unrecognized default selector fails with
+		// its own root cause first): reject a language_providers route that names an
+		// unknown or non-STT-capable profile (SPEC §8.2.1, #566) as CONFIG_INVALID.
+		c.validateSTTLanguageProviders,
 		c.validateMediaTranslate,
 		c.validateMediaSubtitles,
 		c.validateMediaDiarize,

--- a/internal/config/providers.go
+++ b/internal/config/providers.go
@@ -843,6 +843,7 @@ func (c Config) RouteSTTProfile(def provider.Profile) (provider.Profile, error) 
 	if !ok {
 		return def, nil
 	}
+	mapped = strings.TrimSpace(mapped) // defensive: values are trimmed at parse, but never route to a blank name
 	routed, err := c.Providers().ResolveExplicit(provider.CapSTT, mapped, true)
 	if err != nil {
 		return provider.Profile{}, err

--- a/internal/config/providers.go
+++ b/internal/config/providers.go
@@ -435,6 +435,61 @@ func parseCarbonConfig(raw []byte) (CarbonConfig, error) {
 	return cfg, nil
 }
 
+// mediaSTTLanguageProvidersDoc is the yaml shape of the optional
+// media.stt.language_providers nested map (SPEC §8.2.1, #566):
+//
+//	media:
+//	  stt:
+//	    language_providers:
+//	      ru: whisper-ru
+//	      en: whisper
+//
+// Unknown sibling keys under media/stt are ignored (yaml.v3 default), so this
+// coexists with the flat parser that reads the scalar media.stt.* fields.
+type mediaSTTLanguageProvidersDoc struct {
+	Media struct {
+		STT struct {
+			LanguageProviders map[string]string `yaml:"language_providers"`
+		} `yaml:"stt"`
+	} `yaml:"media"`
+}
+
+// parseMediaSTTLanguageProviders decodes the optional media.stt.language_providers
+// map into a route table keyed by the BCP-47 PRIMARY language subtag (SPEC §8.2.1,
+// #566), so a "ru" route matches a "ru-RU" pin and vice versa — the same matching
+// rule the honest-coverage check uses. Absent block ⇒ nil, no error. Two keys that
+// collapse to the same primary subtag but name DIFFERENT profiles are rejected
+// (ambiguous route), so lookup is deterministic.
+func parseMediaSTTLanguageProviders(raw []byte) (map[string]string, error) {
+	sub := extractTopLevelSubtree(raw, "media")
+	if len(sub) == 0 {
+		return nil, nil
+	}
+	var doc mediaSTTLanguageProvidersDoc
+	if err := yaml.Unmarshal(sub, &doc); err != nil {
+		return nil, fmt.Errorf("parse media.stt.language_providers config: %w", err)
+	}
+	in := doc.Media.STT.LanguageProviders
+	if len(in) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]string, len(in))
+	for lang, name := range in {
+		key := provider.PrimarySubtag(lang)
+		name = strings.TrimSpace(name)
+		if key == "" {
+			continue
+		}
+		if existing, dup := out[key]; dup && existing != name {
+			return nil, fmt.Errorf(
+				"CONFIG_INVALID: media.stt.language_providers has conflicting routes for language %q (%q vs %q)",
+				key, existing, name)
+		}
+		out[key] = name
+	}
+	return out, nil
+}
+
 func parseProvidersDoc(raw []byte) (providersDoc, error) {
 	var doc providersDoc
 	sub := extractProvidersSubtree(raw)
@@ -763,6 +818,39 @@ func resolveSTTProfileForCapability(cfg Config) (provider.Profile, bool) {
 	return prof, true
 }
 
+// RouteSTTProfile applies media.stt.language_providers language-based routing
+// (SPEC §8.2.1, #566) to an already-resolved DEFAULT STT profile. Routing is
+// PIN-BASED and per-run: langdetect is text-based and cannot know an audio file's
+// language before transcription, so the route keys off the profile's configured
+// source-language pin (def.STTLanguage), resolved once — never per-item
+// auto-detection. When that pin matches a language_providers entry (BCP-47
+// primary-subtag match), the mapped STT-capable profile is re-resolved (required)
+// and REPLACES the default, carrying the source-language pin onto it so the routed
+// backend still transcribes the right language AND the honest-coverage check (§8.2.1
+// Slice A) runs against the ROUTED profile's declared coverage. With no pin, no
+// route table, or no matching route, def is returned unchanged (single-provider
+// behaviour). It is the single routing point shared by the ingest transcriber build
+// and the expected-language / derivation-identity resolver, so the routed profile
+// propagates consistently. A route to an unknown or non-STT-capable profile is
+// rejected as CONFIG_INVALID at startup (validateSTTLanguageProviders), so the only
+// error here is a routed profile whose credential is unset.
+func (c Config) RouteSTTProfile(def provider.Profile) (provider.Profile, error) {
+	pin := strings.TrimSpace(def.STTLanguage)
+	if pin == "" || len(c.MediaSTTLanguageProviders) == 0 {
+		return def, nil
+	}
+	mapped, ok := c.MediaSTTLanguageProviders[provider.PrimarySubtag(pin)]
+	if !ok {
+		return def, nil
+	}
+	routed, err := c.Providers().ResolveExplicit(provider.CapSTT, mapped, true)
+	if err != nil {
+		return provider.Profile{}, err
+	}
+	routed.STTLanguage = pin
+	return routed, nil
+}
+
 // sttSelectorProfile is the SINGLE mapping from a normalized legacy stt.provider
 // selector (SPEC 8.1.3) to the built-in provider profile that serves it. It is
 // shared by every STT resolver — ingest transcription
@@ -877,6 +965,46 @@ func (c *Config) validateProviderKinds() error {
 			return fmt.Errorf(
 				"CONFIG_INVALID: provider profile %q declares unrecognized kind %q; use one of %s",
 				name, p.Kind, provider.KnownKindsString())
+		}
+	}
+	return nil
+}
+
+// validateSTTLanguageProviders fails fast (CONFIG_INVALID) when a
+// media.stt.language_providers route (SPEC §8.2.1, #566) names a profile that
+// does not exist or is not STT-capable (per the capability matrix, SPEC 8.1.2).
+// This is static validation: a route to a missing/incapable backend can never
+// transcribe, so it must be caught at startup naming the offending language and
+// profile rather than surfacing far downstream. Credential eligibility is NOT
+// checked here (a credential-less endpoint is valid; a missing api_key is a
+// runtime/preflight concern), matching how explicit provider bindings are gated.
+// EndpointDependent kinds (e.g. kind:openai audio) are permitted, consistent with
+// the matrix. Routes are scanned in sorted language order so the error is stable.
+func (c *Config) validateSTTLanguageProviders() error {
+	if len(c.MediaSTTLanguageProviders) == 0 {
+		return nil
+	}
+	byName := c.Providers().ByName()
+	langs := make([]string, 0, len(c.MediaSTTLanguageProviders))
+	for lang := range c.MediaSTTLanguageProviders {
+		langs = append(langs, lang)
+	}
+	sort.Strings(langs)
+	for _, lang := range langs {
+		name := strings.TrimSpace(c.MediaSTTLanguageProviders[lang])
+		if name == "" {
+			return fmt.Errorf(
+				"CONFIG_INVALID: media.stt.language_providers[%q] has no provider profile name", lang)
+		}
+		prof, ok := byName[name]
+		if !ok {
+			return fmt.Errorf(
+				"CONFIG_INVALID: media.stt.language_providers[%q] names unknown provider profile %q", lang, name)
+		}
+		if provider.Can(prof.Kind, provider.CapSTT) == provider.Unsupported {
+			return fmt.Errorf(
+				"CONFIG_INVALID: media.stt.language_providers[%q] provider %q (kind %q) is not speech-to-text capable; route to an STT-capable profile or remove the entry",
+				lang, name, prof.Kind)
 		}
 	}
 	return nil

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -949,6 +949,18 @@ func TranscriberFromConfigWithLanguage(cfg config.Config, language string) (mode
 		if langOverride != "" {
 			prof.STTLanguage = langOverride
 		}
+		// Language-based routing (SPEC §8.2.1, #566): if the effective source-language
+		// pin (the profile's configured STTLanguage, or the per-request override folded
+		// in above) maps to a provider profile via media.stt.language_providers, that
+		// profile REPLACES the default so the ACTUAL transcriber matches the backend
+		// resolveSTTProfile reports. Routing is pin-based and per-run — it keys off the
+		// configured pin, never per-item auto-detection — so an empty pin leaves the
+		// default untouched. RouteSTTProfile carries the pin onto the routed profile.
+		routed, rerr := cfg.RouteSTTProfile(prof)
+		if rerr != nil {
+			return nil, fmt.Errorf("stt provider %q: %w", sel, rerr)
+		}
+		prof = routed
 		// media.vad (dir2mcp#258) is a global toggle, applied onto whichever STT
 		// profile resolves; providers without VAD support ignore it.
 		prof.STTVAD = cfg.MediaVAD
@@ -1036,6 +1048,30 @@ func sttExpectedLanguage(cfg config.Config) string {
 // expected-language hint and the STT derivation identity recorded on transcript
 // representations (§8.6.7), so both observe the exact same profile.
 func resolveSTTProfile(cfg config.Config) (provider.Profile, bool) {
+	prof, ok := resolveDefaultSTTProfile(cfg)
+	if !ok {
+		return provider.Profile{}, false
+	}
+	// Language-based routing (SPEC §8.2.1, #566): if the resolved source-language
+	// pin maps to a provider profile via media.stt.language_providers, that profile
+	// REPLACES the default here too, so the expected-language hint, the STT
+	// derivation identity, and the honest-coverage check all observe the SAME
+	// backend that TranscriberFromConfigWithLanguage builds. A routed profile whose
+	// credential is unset resolves as STT-off on this path (ok=false), mirroring the
+	// default-profile eligibility handling above.
+	routed, err := cfg.RouteSTTProfile(prof)
+	if err != nil {
+		return provider.Profile{}, false
+	}
+	return routed, true
+}
+
+// resolveDefaultSTTProfile resolves the DEFAULT (un-routed) STT provider profile
+// from the legacy stt.provider selector (SPEC 8.1.3). It is the pre-routing half
+// of resolveSTTProfile, split out so both the routed resolver and the router
+// (which needs the resolved pin) share one selection path. ok=false when STT is
+// off, when no STT-capable profile resolves, or when the selector is unrecognised.
+func resolveDefaultSTTProfile(cfg config.Config) (provider.Profile, bool) {
 	sel := strings.ToLower(strings.TrimSpace(cfg.STTProvider))
 	if sel == "" {
 		sel = transcriberProviderAuto

--- a/internal/ingest/stt_routing_566_test.go
+++ b/internal/ingest/stt_routing_566_test.go
@@ -7,13 +7,15 @@ import (
 	"testing"
 
 	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/whisperapi"
 )
 
 // routingConfig loads a config whose DEFAULT whisper STT profile is pinned to
 // language "ru" and declares coverage [en] only (so "ru" is UNCOVERED on the
-// default), plus a route target `whisper-ru` that declares coverage [ru, en]. The
-// caller sets media.stt.language_providers to toggle routing on/off.
-func routingConfig(t *testing.T, route bool) config.Config {
+// default), plus a route target `whisper-ru` that declares coverage [ru, en] and
+// a distinct model/endpoint. routeKey adds `media.stt.language_providers[routeKey]
+// = whisper-ru`; "" installs no route table at all.
+func routingConfig(t *testing.T, routeKey string) config.Config {
 	t.Helper()
 	yaml := "" +
 		"providers:\n" +
@@ -27,8 +29,8 @@ func routingConfig(t *testing.T, route bool) config.Config {
 		"    base_url: http://gpu:9002/v1\n" +
 		"    stt_model: large-v3\n" +
 		"    stt_languages: [ru, en]\n"
-	if route {
-		yaml += "media:\n  stt:\n    language_providers:\n      ru: whisper-ru\n"
+	if routeKey != "" {
+		yaml += "media:\n  stt:\n    language_providers:\n      " + routeKey + ": whisper-ru\n"
 	}
 	path := filepath.Join(t.TempDir(), ".dir2mcp.yaml")
 	if err := os.WriteFile(path, []byte(yaml), 0o600); err != nil {
@@ -46,46 +48,54 @@ func routingConfig(t *testing.T, route bool) config.Config {
 // TestSTTRouting_PinnedLanguageSelectsMappedProfile pins the routing mechanism
 // (SPEC §8.2.1, #566): when the resolved source-language pin matches a
 // media.stt.language_providers entry, the mapped profile REPLACES the default STT
-// provider on the reported-provider path, and a language with no entry keeps the
-// default. Routing is pin-based, so the reported provider is the one that will
-// actually transcribe.
+// provider on the reported-provider path; a pin with no matching entry keeps the
+// default — including when OTHER routes exist.
 func TestSTTRouting_PinnedLanguageSelectsMappedProfile(t *testing.T) {
 	// Routed: pin "ru" -> whisper-ru replaces the default whisper profile.
-	name, model, ok := ResolveSTTProviderModel(routingConfig(t, true))
+	name, model, ok := ResolveSTTProviderModel(routingConfig(t, "ru"))
 	if !ok {
 		t.Fatal("expected an STT profile to resolve with routing on")
 	}
-	if name != "whisper-ru" {
-		t.Fatalf("routed STT provider = %q, want whisper-ru (the mapped profile)", name)
-	}
-	if model != "large-v3" {
-		t.Fatalf("routed STT model = %q, want large-v3 (the mapped profile's model)", model)
+	if name != "whisper-ru" || model != "large-v3" {
+		t.Fatalf("routed STT = %q/%q, want whisper-ru/large-v3 (the mapped profile)", name, model)
 	}
 
-	// Not routed: same pin, no route table -> the default whisper profile is kept.
-	name, model, ok = ResolveSTTProviderModel(routingConfig(t, false))
-	if !ok {
-		t.Fatal("expected an STT profile to resolve with routing off")
+	// No route table at all -> the default whisper profile is kept.
+	assertDefaultKept := func(t *testing.T, cfg config.Config, label string) {
+		name, model, ok := ResolveSTTProviderModel(cfg)
+		if !ok {
+			t.Fatalf("%s: expected an STT profile to resolve", label)
+		}
+		if name != "whisper" || model != "base" {
+			t.Fatalf("%s: STT = %q/%q, want the default whisper/base", label, name, model)
+		}
 	}
-	if name != "whisper" {
-		t.Fatalf("unrouted STT provider = %q, want the default whisper profile", name)
-	}
-	if model != "base" {
-		t.Fatalf("unrouted STT model = %q, want base (the default profile's model)", model)
-	}
+	assertDefaultKept(t, routingConfig(t, ""), "no route table")
+	// Routes EXIST but the pin ("ru") matches none of them ("en" only) -> default
+	// kept. This proves the miss path, which an empty table does not exercise.
+	assertDefaultKept(t, routingConfig(t, "en"), "non-matching route present")
 }
 
 // TestSTTRouting_TranscriberBuildUsesRoutedProfile confirms the ACTUAL transcriber
-// build path also honours the route (both the reported profile and the built
-// transcriber share the routing resolution), so a routed config builds a
-// transcriber rather than diverging from the reported provider.
+// build path honours the route: the built transcriber must be the ROUTED
+// whisper-ru client (model large-v3, endpoint gpu:9002), not the default whisper
+// (model base, gpu:9001). Both profiles build a valid *whisperapi.Client, so a
+// mere non-nil check would not detect a build path that ignored routing — assert
+// the route-specific model + base_url.
 func TestSTTRouting_TranscriberBuildUsesRoutedProfile(t *testing.T) {
-	tr, err := TranscriberFromConfig(routingConfig(t, true))
+	tr, err := TranscriberFromConfig(routingConfig(t, "ru"))
 	if err != nil {
 		t.Fatalf("build routed transcriber: %v", err)
 	}
-	if tr == nil {
-		t.Fatal("expected a non-nil transcriber for a routed whisper profile")
+	wc, ok := tr.(*whisperapi.Client)
+	if !ok {
+		t.Fatalf("expected a *whisperapi.Client, got %T", tr)
+	}
+	if wc.DefaultModel != "large-v3" {
+		t.Fatalf("built transcriber model = %q, want large-v3 (routed whisper-ru); routing did not reach the build path", wc.DefaultModel)
+	}
+	if wc.BaseURL != "http://gpu:9002/v1" {
+		t.Fatalf("built transcriber base_url = %q, want http://gpu:9002/v1 (routed whisper-ru)", wc.BaseURL)
 	}
 }
 
@@ -96,8 +106,8 @@ func TestSTTRouting_TranscriberBuildUsesRoutedProfile(t *testing.T) {
 // makes the ROUTED profile cover the language, so the honest-coverage flag is NOT
 // emitted — the coverage check runs against the routed profile, not the default.
 func TestSTTRouting_CoveredRouteSuppressesHonestCoverageWarning(t *testing.T) {
-	metaFor := func(route bool) (prov, lang, meta string, coverage []string) {
-		s := &Service{cfg: routingConfig(t, route)}
+	metaFor := func(routeKey string) (prov, lang, meta string, coverage []string) {
+		s := &Service{cfg: routingConfig(t, routeKey)}
 		s.resolveTranscriptIdentityFields()
 		m, err := s.sttTranscriptMetaJSON(nil, "some transcript text", false)
 		if err != nil {
@@ -108,7 +118,7 @@ func TestSTTRouting_CoveredRouteSuppressesHonestCoverageWarning(t *testing.T) {
 
 	// Control: no routing -> default whisper (coverage [en]) with pin ru is
 	// uncovered, so meta carries language_covered:false.
-	prov, lang, m, cov := metaFor(false)
+	prov, lang, m, cov := metaFor("")
 	if prov != "whisper" || lang != "ru" {
 		t.Fatalf("unrouted identity = provider %q lang %q, want whisper/ru; coverage %v", prov, lang, cov)
 	}
@@ -117,7 +127,7 @@ func TestSTTRouting_CoveredRouteSuppressesHonestCoverageWarning(t *testing.T) {
 	}
 
 	// Routed: whisper-ru covers ru, so the pin is covered and the flag is absent.
-	prov, lang, m, cov = metaFor(true)
+	prov, lang, m, cov = metaFor("ru")
 	if prov != "whisper-ru" || lang != "ru" {
 		t.Fatalf("routed identity = provider %q lang %q, want whisper-ru/ru; coverage %v", prov, lang, cov)
 	}

--- a/internal/ingest/stt_routing_566_test.go
+++ b/internal/ingest/stt_routing_566_test.go
@@ -1,0 +1,127 @@
+package ingest
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+)
+
+// routingConfig loads a config whose DEFAULT whisper STT profile is pinned to
+// language "ru" and declares coverage [en] only (so "ru" is UNCOVERED on the
+// default), plus a route target `whisper-ru` that declares coverage [ru, en]. The
+// caller sets media.stt.language_providers to toggle routing on/off.
+func routingConfig(t *testing.T, route bool) config.Config {
+	t.Helper()
+	yaml := "" +
+		"providers:\n" +
+		"  whisper:\n" +
+		"    base_url: http://gpu:9001/v1\n" +
+		"    stt_model: base\n" +
+		"    stt_language: ru\n" +
+		"    stt_languages: [en]\n" +
+		"  whisper-ru:\n" +
+		"    kind: whisper\n" +
+		"    base_url: http://gpu:9002/v1\n" +
+		"    stt_model: large-v3\n" +
+		"    stt_languages: [ru, en]\n"
+	if route {
+		yaml += "media:\n  stt:\n    language_providers:\n      ru: whisper-ru\n"
+	}
+	path := filepath.Join(t.TempDir(), ".dir2mcp.yaml")
+	if err := os.WriteFile(path, []byte(yaml), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	// The default STT profile is the (overridden) built-in whisper, pinned to ru.
+	cfg.STTProvider = "whisper"
+	return cfg
+}
+
+// TestSTTRouting_PinnedLanguageSelectsMappedProfile pins the routing mechanism
+// (SPEC §8.2.1, #566): when the resolved source-language pin matches a
+// media.stt.language_providers entry, the mapped profile REPLACES the default STT
+// provider on the reported-provider path, and a language with no entry keeps the
+// default. Routing is pin-based, so the reported provider is the one that will
+// actually transcribe.
+func TestSTTRouting_PinnedLanguageSelectsMappedProfile(t *testing.T) {
+	// Routed: pin "ru" -> whisper-ru replaces the default whisper profile.
+	name, model, ok := ResolveSTTProviderModel(routingConfig(t, true))
+	if !ok {
+		t.Fatal("expected an STT profile to resolve with routing on")
+	}
+	if name != "whisper-ru" {
+		t.Fatalf("routed STT provider = %q, want whisper-ru (the mapped profile)", name)
+	}
+	if model != "large-v3" {
+		t.Fatalf("routed STT model = %q, want large-v3 (the mapped profile's model)", model)
+	}
+
+	// Not routed: same pin, no route table -> the default whisper profile is kept.
+	name, model, ok = ResolveSTTProviderModel(routingConfig(t, false))
+	if !ok {
+		t.Fatal("expected an STT profile to resolve with routing off")
+	}
+	if name != "whisper" {
+		t.Fatalf("unrouted STT provider = %q, want the default whisper profile", name)
+	}
+	if model != "base" {
+		t.Fatalf("unrouted STT model = %q, want base (the default profile's model)", model)
+	}
+}
+
+// TestSTTRouting_TranscriberBuildUsesRoutedProfile confirms the ACTUAL transcriber
+// build path also honours the route (both the reported profile and the built
+// transcriber share the routing resolution), so a routed config builds a
+// transcriber rather than diverging from the reported provider.
+func TestSTTRouting_TranscriberBuildUsesRoutedProfile(t *testing.T) {
+	tr, err := TranscriberFromConfig(routingConfig(t, true))
+	if err != nil {
+		t.Fatalf("build routed transcriber: %v", err)
+	}
+	if tr == nil {
+		t.Fatal("expected a non-nil transcriber for a routed whisper profile")
+	}
+}
+
+// TestSTTRouting_CoveredRouteSuppressesHonestCoverageWarning pins the Slice-A
+// floor interaction (SPEC §8.2.1, #566): the default profile declares [en] only,
+// so the pinned "ru" is UNCOVERED and the transcript meta records
+// language_covered:false. Routing "ru" to whisper-ru (which declares [ru, en])
+// makes the ROUTED profile cover the language, so the honest-coverage flag is NOT
+// emitted — the coverage check runs against the routed profile, not the default.
+func TestSTTRouting_CoveredRouteSuppressesHonestCoverageWarning(t *testing.T) {
+	metaFor := func(route bool) (prov, lang, meta string, coverage []string) {
+		s := &Service{cfg: routingConfig(t, route)}
+		s.resolveTranscriptIdentityFields()
+		m, err := s.sttTranscriptMetaJSON(nil, "some transcript text", false)
+		if err != nil {
+			t.Fatalf("sttTranscriptMetaJSON: %v", err)
+		}
+		return s.sttProvider, s.transcriptLanguage, m, s.sttLanguages
+	}
+
+	// Control: no routing -> default whisper (coverage [en]) with pin ru is
+	// uncovered, so meta carries language_covered:false.
+	prov, lang, m, cov := metaFor(false)
+	if prov != "whisper" || lang != "ru" {
+		t.Fatalf("unrouted identity = provider %q lang %q, want whisper/ru; coverage %v", prov, lang, cov)
+	}
+	if !strings.Contains(m, `"language_covered":false`) {
+		t.Fatalf("unrouted (uncovered) transcript must record language_covered:false, got %s", m)
+	}
+
+	// Routed: whisper-ru covers ru, so the pin is covered and the flag is absent.
+	prov, lang, m, cov = metaFor(true)
+	if prov != "whisper-ru" || lang != "ru" {
+		t.Fatalf("routed identity = provider %q lang %q, want whisper-ru/ru; coverage %v", prov, lang, cov)
+	}
+	if strings.Contains(m, "language_covered") {
+		t.Fatalf("routed+covered transcript must OMIT language_covered, got %s", m)
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -539,6 +539,13 @@ func STTLanguageCoverageSet(coverage []string, lang string) (declared, covered b
 	return true, false
 }
 
+// PrimarySubtag lower-cases a BCP-47 tag and returns its primary language
+// subtag (the part before the first '-'), trimmed. Empty input → "". Exported
+// so the config layer normalizes media.stt.language_providers keys with the SAME
+// BCP-47 primary-subtag rule the coverage check uses (SPEC §8.2.1, #566), so a
+// "ru" route matches a "ru-RU" pin and vice versa.
+func PrimarySubtag(tag string) string { return primarySubtag(tag) }
+
 // primarySubtag lower-cases a BCP-47 tag and returns its primary language
 // subtag (the part before the first '-'), trimmed. Empty input → "".
 func primarySubtag(tag string) string {

--- a/tests/config/media_stt_language_providers_config_test.go
+++ b/tests/config/media_stt_language_providers_config_test.go
@@ -1,0 +1,136 @@
+package tests
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+)
+
+// TestMediaSTTLanguageProviders_Default confirms the routing table is empty by
+// default, so behaviour is unchanged (single-provider STT) when unset (#566).
+func TestMediaSTTLanguageProviders_Default(t *testing.T) {
+	if got := config.Default().MediaSTTLanguageProviders; len(got) != 0 {
+		t.Fatalf("media.stt.language_providers default = %v, want empty", got)
+	}
+}
+
+// TestMediaSTTLanguageProviders_ParsesNestedYAML confirms the nested lang->profile
+// map decodes and its keys normalize to the BCP-47 primary subtag (SPEC §8.2.1,
+// #566): "en-US" collapses to "en" so a "ru-RU" pin matches a "ru" route.
+func TestMediaSTTLanguageProviders_ParsesNestedYAML(t *testing.T) {
+	yaml := "" +
+		"providers:\n" +
+		"  whisper-ru:\n" +
+		"    kind: whisper\n" +
+		"    stt_model: large-v3\n" +
+		"    stt_languages: [ru, en]\n" +
+		"media:\n" +
+		"  stt:\n" +
+		"    language_providers:\n" +
+		"      ru: whisper-ru\n" +
+		"      en-US: whisper-ru\n"
+
+	cfg := loadCfg(t, yaml)
+	got := cfg.MediaSTTLanguageProviders
+	if len(got) != 2 {
+		t.Fatalf("language_providers = %v, want 2 entries", got)
+	}
+	if got["ru"] != "whisper-ru" {
+		t.Errorf("language_providers[ru] = %q, want whisper-ru", got["ru"])
+	}
+	if got["en"] != "whisper-ru" {
+		t.Errorf("language_providers[en] (from en-US) = %q, want whisper-ru", got["en"])
+	}
+}
+
+// TestMediaSTTLanguageProviders_UnknownProfileRejected pins the CONFIG_INVALID
+// static-validation rule (SPEC §8.2.1, #566): a route naming a profile that does
+// not exist must fail at startup, not silently at first transcription.
+func TestMediaSTTLanguageProviders_UnknownProfileRejected(t *testing.T) {
+	yaml := "" +
+		"media:\n" +
+		"  stt:\n" +
+		"    language_providers:\n" +
+		"      ru: no-such-profile\n"
+
+	path := filepath.Join(t.TempDir(), ".dir2mcp.yaml")
+	writeFile(t, path, yaml)
+	_, err := config.LoadFile(path)
+	if err == nil {
+		t.Fatal("expected CONFIG_INVALID for a route to an unknown provider profile")
+	}
+	if !strings.Contains(err.Error(), "CONFIG_INVALID") || !strings.Contains(err.Error(), "no-such-profile") {
+		t.Fatalf("expected a CONFIG_INVALID unknown-profile error, got: %v", err)
+	}
+}
+
+// TestMediaSTTLanguageProviders_NonSTTProfileRejected pins the second half of the
+// CONFIG_INVALID rule: a route to a profile that exists but is not STT-capable per
+// the capability matrix (SPEC 8.1.2) is rejected. A kind:anthropic profile serves
+// only chat, so it can never transcribe.
+func TestMediaSTTLanguageProviders_NonSTTProfileRejected(t *testing.T) {
+	yaml := "" +
+		"providers:\n" +
+		"  chat-only:\n" +
+		"    kind: anthropic\n" +
+		"    chat_model: claude-x\n" +
+		"media:\n" +
+		"  stt:\n" +
+		"    language_providers:\n" +
+		"      ru: chat-only\n"
+
+	path := filepath.Join(t.TempDir(), ".dir2mcp.yaml")
+	writeFile(t, path, yaml)
+	_, err := config.LoadFile(path)
+	if err == nil {
+		t.Fatal("expected CONFIG_INVALID for a route to a non-STT-capable profile")
+	}
+	if !strings.Contains(err.Error(), "CONFIG_INVALID") || !strings.Contains(err.Error(), "not speech-to-text capable") {
+		t.Fatalf("expected a CONFIG_INVALID non-STT-capable error, got: %v", err)
+	}
+}
+
+// TestMediaSTTLanguageProviders_ConflictingRoutesRejected confirms two keys that
+// collapse to the same primary subtag but name DIFFERENT profiles are rejected at
+// parse time, so route lookup stays deterministic.
+func TestMediaSTTLanguageProviders_ConflictingRoutesRejected(t *testing.T) {
+	yaml := "" +
+		"providers:\n" +
+		"  whisper-a:\n    kind: whisper\n    stt_model: a\n" +
+		"  whisper-b:\n    kind: whisper\n    stt_model: b\n" +
+		"media:\n" +
+		"  stt:\n" +
+		"    language_providers:\n" +
+		"      ru: whisper-a\n" +
+		"      ru-RU: whisper-b\n"
+
+	path := filepath.Join(t.TempDir(), ".dir2mcp.yaml")
+	writeFile(t, path, yaml)
+	_, err := config.LoadFile(path)
+	if err == nil {
+		t.Fatal("expected an error for conflicting routes on the same primary subtag")
+	}
+	if !strings.Contains(err.Error(), "conflicting routes") {
+		t.Fatalf("expected a conflicting-routes error, got: %v", err)
+	}
+}
+
+// TestMediaSTTLanguageProviders_ValidRoutePassesValidation guards against
+// over-rejection: a route to an existing STT-capable profile must load cleanly.
+func TestMediaSTTLanguageProviders_ValidRoutePassesValidation(t *testing.T) {
+	yaml := "" +
+		"providers:\n" +
+		"  whisper-ru:\n    kind: whisper\n    stt_model: large-v3\n    stt_languages: [ru]\n" +
+		"media:\n" +
+		"  stt:\n" +
+		"    language_providers:\n" +
+		"      ru: whisper-ru\n"
+
+	path := filepath.Join(t.TempDir(), ".dir2mcp.yaml")
+	writeFile(t, path, yaml)
+	if _, err := config.LoadFile(path); err != nil {
+		t.Fatalf("valid language_providers route should load, got: %v", err)
+	}
+}


### PR DESCRIPTION
## What

Implements the **routing half** of #566 (SPEC §8.2.1), building on Slice A (declared coverage + honest-coverage floor, PR #602).

Adds `media.stt.language_providers`: a map from a BCP-47 language to the name of an STT-capable provider profile. When the resolved **source-language pin** matches a key, that profile transcribes, **overriding the default STT provider**. Empty/unset preserves today's single-provider behaviour.

## How

Routing is **pin-based and per-run**, by design: `internal/langdetect` is text-based and cannot know an audio file's language *before* transcription, so routing keys off the configured language pin (the resolved STT profile's `STTLanguage`), resolved once at construction — not per-item auto-detection. With no pin there is nothing to route on, so the default is kept.

- `Config.RouteSTTProfile` is the **single routing point**. Given an already-resolved DEFAULT profile it looks up the pin (BCP-47 primary-subtag match, consistent with the Slice-A coverage rule), re-resolves the mapped profile via `ResolveExplicit(CapSTT, …)`, and carries the source-language pin onto it.
- Applied at **both** STT-resolution sites so the reported profile and the ACTUAL transcriber never diverge:
  - `ingest.resolveSTTProfile` — feeds the expected-language hint, the STT derivation identity, and the honest-coverage check.
  - `ingest.TranscriberFromConfigWithLanguage` — the transcriber build path (has its own resolution; wired through the same router).
- **Floor interaction:** because routing swaps the resolved profile, the Slice-A honest-coverage check now runs against the ROUTED profile's declared coverage. Routing a language to a covering provider therefore suppresses the `language_covered:false` warning.
- **Validation:** `validateSTTLanguageProviders` rejects a route to an unknown or non-STT-capable profile as `CONFIG_INVALID` at startup (capability matrix, SPEC 8.1.2); conflicting keys that collapse to the same primary subtag are rejected at parse time so lookup stays deterministic.
- The nested map is decoded from the `media:` subtree with yaml.v3 (the flat parser is scalar/list-only); keys normalize to the BCP-47 primary subtag.

## Tests

- **Routing:** a pinned language with a `language_providers` entry selects the mapped profile (asserted via the reported provider *and* the built transcriber); a language with no entry keeps the default.
- **Validation:** routes to unknown / non-STT-capable / conflicting profiles → `CONFIG_INVALID`; a valid route loads cleanly; nested-YAML parse + primary-subtag key normalization.
- **Floor interaction:** a routed, covered language omits `language_covered` (vs. the uncovered default which records `language_covered:false`).

`make check` passes locally. The `dirstral-spec` submodule pin is unchanged.

Refs #566