### PR TITLE
feat(config,ingest): STT skip on uncovered language (#566 Slice C)

### DIFF
--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -258,6 +258,8 @@ func skipReasonHint(reason string) string {
 		return "matched ingest.path_excludes — drop the pattern to include them"
 	case model.SkipReasonSecretExcluded:
 		return "matched a secret pattern and was withheld on purpose — review ingest.secret_patterns if this was unintended"
+	case model.SkipReasonLanguageUncovered:
+		return "source language is outside the STT model's declared stt_languages coverage — route it via media.stt.language_providers to a model that covers it, or set media.stt.on_uncovered_language=warn to transcribe anyway"
 	default:
 		return ""
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -713,6 +713,18 @@ type Config struct {
 	// that is absent or not STT-capable is rejected as CONFIG_INVALID at startup.
 	MediaSTTLanguageProviders map[string]string
 
+	// MediaSTTOnUncoveredLanguage is the honest-coverage floor action (config
+	// `media.stt.on_uncovered_language`, SPEC §8.2.1, #566): what the daemon does
+	// when the resolved source language is outside the finally-selected STT model's
+	// declared stt_languages coverage. "warn" (default, fail-open) transcribes
+	// anyway and records the (language, model, covered=false) fact on the transcript
+	// meta_json so an operator sees it. "skip" (strict) records the item as
+	// documents.status="skipped" with skip_reason="language_uncovered" instead of
+	// transcribing to degraded output — no transcript representation is produced.
+	// The floor only applies when coverage is DECLARED (a non-empty stt_languages);
+	// unknown coverage never trips it under either mode.
+	MediaSTTOnUncoveredLanguage string
+
 	// MediaBatchTwoPhase / MediaBatchProgress / MediaBatchManifest configure the
 	// optional batch-ergonomics surface for large-archive media ingests (SPEC
 	// §8.6.11; config block `media.batch`). All default OFF/empty so behavior is
@@ -885,6 +897,7 @@ type fileConfig struct {
 	MediaSTTMaxPayloadMB               *int
 	MediaSTTRequestTimeoutSec          *int
 	MediaSTTLanguageStrict             *bool
+	MediaSTTOnUncoveredLanguage        *string
 	ElevenLabsAPIKey                   *string
 	ServerTLSCertFile                  *string
 	ServerTLSKeyFile                   *string
@@ -1028,6 +1041,7 @@ type persistedConfig struct {
 	MediaSTTMaxPayloadMB               int           `yaml:"media_stt_max_payload_mb"`
 	MediaSTTRequestTimeoutSec          int           `yaml:"media_stt_request_timeout_sec"`
 	MediaSTTLanguageStrict             bool          `yaml:"media_stt_language_strict"`
+	MediaSTTOnUncoveredLanguage        string        `yaml:"media_stt_on_uncovered_language"`
 	MediaBatchTwoPhase                 bool          `yaml:"media_batch_two_phase"`
 	MediaBatchProgress                 bool          `yaml:"media_batch_progress"`
 	MediaBatchManifest                 string        `yaml:"media_batch_manifest"`
@@ -1231,12 +1245,16 @@ func Default() Config {
 		MediaSTTRequestTimeoutSec: 0,
 		// A pinned STT language is a provider hint, not per-file ground truth, so
 		// it does not drive quality-gate quarantine by default (dir2mcp#439 F3).
-		MediaSTTLanguageStrict:    false,
-		MediaVariantsGroup:        false,
-		MediaVariantsSelect:       "best",
-		MediaTranslateEnabled:     false,
-		MediaTranslateTargetLangs: nil,
-		MediaTranslateEngine:      "chat",
+		MediaSTTLanguageStrict: false,
+		// Honest-coverage floor action (SPEC §8.2.1, #566): fail-open by default —
+		// transcribe an uncovered-language item anyway and record the fact — so
+		// behavior is unchanged unless an operator opts into strict skipping.
+		MediaSTTOnUncoveredLanguage: onUncoveredLanguageWarn,
+		MediaVariantsGroup:          false,
+		MediaVariantsSelect:         "best",
+		MediaTranslateEnabled:       false,
+		MediaTranslateTargetLangs:   nil,
+		MediaTranslateEngine:        "chat",
 		// Cross-line context for the chat translate engine (issue #573): translate
 		// cues in windows of this many, each with a small read-only margin, so the
 		// model sees neighbouring cues. On by default (quality fix); the 1:1
@@ -1404,6 +1422,7 @@ func buildPersistedConfig(cfg *Config) persistedConfig {
 		MediaSTTMaxPayloadMB:               cfg.MediaSTTMaxPayloadMB,
 		MediaSTTRequestTimeoutSec:          cfg.MediaSTTRequestTimeoutSec,
 		MediaSTTLanguageStrict:             cfg.MediaSTTLanguageStrict,
+		MediaSTTOnUncoveredLanguage:        cfg.MediaSTTOnUncoveredLanguage,
 		ServerTLSCertFile:                  cfg.ServerTLSCertFile,
 		ServerTLSKeyFile:                   cfg.ServerTLSKeyFile,
 		X402Mode:                           cfg.X402.Mode,
@@ -2261,6 +2280,9 @@ func applyMediaSTTFileParsed(cfg *Config, fc fileConfig) {
 	if fc.MediaSTTLanguageStrict != nil {
 		cfg.MediaSTTLanguageStrict = *fc.MediaSTTLanguageStrict
 	}
+	if fc.MediaSTTOnUncoveredLanguage != nil {
+		cfg.MediaSTTOnUncoveredLanguage = *fc.MediaSTTOnUncoveredLanguage
+	}
 }
 
 // applyMediaSubtitlesFileParsed copies the set media.subtitles.* file fields
@@ -2619,6 +2641,7 @@ var configKeyAliases = map[string]string{
 	"media_stt_max_payload_mb":                "media.stt.max_payload_mb",
 	"media_stt_request_timeout_sec":           "media.stt.request_timeout_sec",
 	"media_stt_language_strict":               "media.stt.language_strict",
+	"media_stt_on_uncovered_language":         "media.stt.on_uncovered_language",
 	"stt_provider":                            "stt.provider",
 	"stt_mistral_model":                       "stt.mistral.model",
 	"stt_elevenlabs_model":                    "stt.elevenlabs.model",
@@ -3092,6 +3115,8 @@ func setMediaStringFileScalar(cfg *fileConfig, key, value string) {
 		cfg.MediaSubtitlesSegmentation = strPtr(value)
 	case "media.translate.engine":
 		cfg.MediaTranslateEngine = strPtr(value)
+	case "media.stt.on_uncovered_language":
+		cfg.MediaSTTOnUncoveredLanguage = strPtr(value)
 	case "media.batch.manifest":
 		cfg.MediaBatchManifest = strPtr(value)
 	}
@@ -3310,6 +3335,7 @@ func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	writeInt("media_stt_max_payload_mb", cfg.MediaSTTMaxPayloadMB)
 	writeInt("media_stt_request_timeout_sec", cfg.MediaSTTRequestTimeoutSec)
 	writeBool("media_stt_language_strict", cfg.MediaSTTLanguageStrict)
+	writeScalar("media_stt_on_uncovered_language", cfg.MediaSTTOnUncoveredLanguage)
 	writeBool("media_batch_two_phase", cfg.MediaBatchTwoPhase)
 	writeBool("media_batch_progress", cfg.MediaBatchProgress)
 	writeScalar("media_batch_manifest", cfg.MediaBatchManifest)
@@ -3791,6 +3817,7 @@ func (c *Config) Validate() error {
 		// its own root cause first): reject a language_providers route that names an
 		// unknown or non-STT-capable profile (SPEC §8.2.1, #566) as CONFIG_INVALID.
 		c.validateSTTLanguageProviders,
+		c.validateMediaSTTOnUncoveredLanguage,
 		c.validateMediaTranslate,
 		c.validateMediaSubtitles,
 		c.validateMediaDiarize,
@@ -4088,6 +4115,35 @@ func (c *Config) validateIngestOnUnsupported() error {
 		return fmt.Errorf("ingest.on_unsupported must be one of lenient, strict: %q", c.IngestOnUnsupported)
 	}
 	c.IngestOnUnsupported = mode
+	return nil
+}
+
+// onUncoveredLanguageWarn / onUncoveredLanguageSkip are the two honest-coverage
+// floor actions for media.stt.on_uncovered_language (SPEC §8.2.1, #566). "warn"
+// (default, fail-open) transcribes an uncovered-language item anyway and records
+// the fact; "skip" (strict) records it as documents.status="skipped" with
+// skip_reason="language_uncovered" instead of transcribing to degraded output.
+const (
+	onUncoveredLanguageWarn = "warn"
+	onUncoveredLanguageSkip = "skip"
+)
+
+// validateMediaSTTOnUncoveredLanguage normalizes MediaSTTOnUncoveredLanguage
+// (defaulting empty to the fail-open "warn" default) and rejects any value
+// outside warn/skip (SPEC §8.2.1, #566). It mirrors validateIngestOnUnsupported:
+// a small closed string enum with a lenient default so a bare config validates
+// unchanged.
+func (c *Config) validateMediaSTTOnUncoveredLanguage() error {
+	action := strings.ToLower(strings.TrimSpace(c.MediaSTTOnUncoveredLanguage))
+	if action == "" {
+		action = Default().MediaSTTOnUncoveredLanguage
+	}
+	switch action {
+	case onUncoveredLanguageWarn, onUncoveredLanguageSkip:
+	default:
+		return fmt.Errorf("media.stt.on_uncovered_language must be one of warn, skip: %q", c.MediaSTTOnUncoveredLanguage)
+	}
+	c.MediaSTTOnUncoveredLanguage = action
 	return nil
 }
 

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -105,6 +105,13 @@ type Service struct {
 	// language_covered flag; it is never part of the derivation identity.
 	sttLanguages []string
 
+	// onUncoveredLanguage is the resolved media.stt.on_uncovered_language action
+	// (SPEC §8.2.1, #566): "warn" (default, fail-open) transcribes an
+	// uncovered-language item anyway and records the fact; "skip" records the item
+	// as documents.status="skipped" with skip_reason="language_uncovered" instead
+	// of transcribing to degraded output. Resolved once from config in NewService.
+	onUncoveredLanguage string
+
 	// diarizeActive reports whether speaker diarization is active for
 	// model-derived transcripts (SPEC §8.6.8): true only when diarization is
 	// enabled (tri-state) AND the active STT backend advertises CapDiarize.
@@ -579,6 +586,88 @@ func (s *Service) SetOnUnsupported(mode string) {
 	s.onUnsupported = normalizeOnUnsupported(mode)
 }
 
+// onUncoveredLanguageWarn / onUncoveredLanguageSkip are the resolved
+// media.stt.on_uncovered_language actions (SPEC §8.2.1, #566). "skip" suppresses
+// transcription for an uncovered source language; "warn" (and any other resolved
+// value) is the fail-open default: transcribe anyway.
+const (
+	onUncoveredLanguageWarn = "warn"
+	onUncoveredLanguageSkip = "skip"
+)
+
+// normalizeOnUncoveredLanguage maps the raw media.stt.on_uncovered_language config
+// value to the resolved §8.2.1 action. Only "skip" (case-insensitive) selects the
+// strict skip contract; everything else — including empty and any unrecognized
+// value — is the fail-open "warn" default, so a service constructed from a bare
+// config.Config transcribes as today (config.Validate rejects unknown values, but
+// a Service built directly from an unvalidated config must still degrade safely).
+func normalizeOnUncoveredLanguage(v string) string {
+	if strings.EqualFold(strings.TrimSpace(v), onUncoveredLanguageSkip) {
+		return onUncoveredLanguageSkip
+	}
+	return onUncoveredLanguageWarn
+}
+
+// SetOnUncoveredLanguage overrides the resolved §8.2.1 honest-coverage floor
+// action, primarily for tests that need to exercise warn/skip without threading a
+// full config. Only "skip" is strict; anything else is the fail-open warn default.
+func (s *Service) SetOnUncoveredLanguage(action string) {
+	s.onUncoveredLanguage = normalizeOnUncoveredLanguage(action)
+}
+
+// sttLanguageUncovered reports whether the pinned STT source language trips the
+// honest-coverage floor (SPEC §8.2.1): the finally-selected model declares a
+// non-empty stt_languages set and the pinned language is outside it. It keys off
+// the pinned source language (s.transcriptLanguage) and the routed profile's
+// declared coverage (s.sttLanguages) — the same inputs as the Slice A
+// construction-time warning — both resolved once in resolveTranscriptIdentityFields.
+// It deliberately uses only the configured pin, never per-item auto-detection:
+// langdetect is text-based and cannot know an item's language before it is
+// transcribed, so a skip-before-transcribe decision can only rest on the pin.
+// False when there is no pin or coverage is unknown (STTLanguageCoverageSet
+// returns declared=false for a blank language or an empty coverage set).
+func (s *Service) sttLanguageUncovered() bool {
+	lang := strings.TrimSpace(s.transcriptLanguage)
+	if lang == "" {
+		return false
+	}
+	declared, covered := provider.STTLanguageCoverageSet(s.sttLanguages, lang)
+	return declared && !covered
+}
+
+// skipUncoveredLanguageTranscript applies the SPEC §8.2.1 honest-coverage floor
+// SKIP action (#566) for a media item about to be transcribed. It returns
+// skip=false when transcription should proceed (warn mode, or a covered/unknown
+// language); the caller then transcribes as today. It returns skip=true when the
+// pinned source language is outside the selected STT model's declared coverage AND
+// media.stt.on_uncovered_language=skip, in which case transcription is NOT run:
+//
+//   - When the item produced no other searchable representation (mediaProduced=false)
+//     it is recorded as a durable status="skipped" with skip_reason="language_uncovered"
+//     and credited to the skipped counter, so the gap surfaces as honest not-indexed
+//     coverage in the skip_reasons aggregate instead of garbage the §8.6.6 quality gate
+//     silently drops. suppressCredit is true so the caller does not also credit it as
+//     indexed (#426).
+//   - When the item already produced media chunks (embed_multimodal=augment) it stays
+//     searchable via those, so it is NOT recorded as skipped — only the transcript is
+//     suppressed and suppressCredit is false (the document is still indexed).
+//
+// It is reached only after the sidecar attempt returned no sidecar transcript, so a
+// real subtitle track (not produced by the uncovered STT model) still wins.
+func (s *Service) skipUncoveredLanguageTranscript(ctx context.Context, doc model.Document, mediaProduced bool) (skip, suppressCredit bool) {
+	if s.onUncoveredLanguage != onUncoveredLanguageSkip || !s.sttLanguageUncovered() {
+		return false, false
+	}
+	s.getLogger().Printf("stt: skipping transcription of %s (%s) — source language %q is outside %s's declared coverage %v (media.stt.on_uncovered_language=skip, SPEC §8.2.1)",
+		doc.RelPath, doc.DocType, strings.TrimSpace(s.transcriptLanguage), s.sttProvider, s.sttLanguages)
+	if mediaProduced {
+		return true, false
+	}
+	s.addSkipped(1)
+	s.persistNonFatalDocSkip(ctx, doc, model.SkipReasonLanguageUncovered)
+	return true, true
+}
+
 // degradeUnsupportedExtraction applies the §7.4.B.2 degradation contract to a
 // pdf/image/document asset whose format no active extraction engine can read,
 // and which produced no direct-embedding media chunks either (so it would
@@ -645,6 +734,7 @@ func NewService(cfg config.Config, store model.Store) (*Service, error) {
 		logger:                          log.Default(),
 		onDocumentDeletedMaxConcurrency: defaultOnDocumentDeletedMaxConcurrency,
 		onUnsupported:                   normalizeOnUnsupported(cfg.IngestOnUnsupported),
+		onUncoveredLanguage:             normalizeOnUncoveredLanguage(cfg.MediaSTTOnUncoveredLanguage),
 	}
 	transcriber, err := TranscriberFromConfig(cfg)
 	if err != nil {
@@ -1268,6 +1358,15 @@ func (s *Service) SetTranscriptLanguage(language string) {
 func (s *Service) SetSTTIdentity(providerName, model string) {
 	s.sttProvider = strings.TrimSpace(providerName)
 	s.sttModel = strings.TrimSpace(model)
+}
+
+// SetSTTLanguages overrides the resolved STT profile's declared language coverage
+// (SPEC §8.2.1, #566) — the non-empty BCP-47 set that drives the honest-coverage
+// floor. It mirrors SetSTTIdentity for tests that need deterministic coverage
+// without resolving a real STT provider profile. A nil/empty set means
+// open/unknown (no coverage assertion), exactly as an undeclared profile.
+func (s *Service) SetSTTLanguages(languages []string) {
+	s.sttLanguages = append([]string(nil), languages...)
 }
 
 // SetDiarizer wires the optional model-driven diarization seam (SPEC §8.6.8) and
@@ -3241,6 +3340,14 @@ func (s *Service) generateTranscriptOrSidecar(ctx context.Context, doc model.Doc
 	// off (no transcriber) or the media yields no transcript, the no-representation
 	// check below still surfaces an unsearchable video (#398).
 	if isSidecarMediaType(doc.DocType) && s.transcriber != nil {
+		// Honest-coverage floor, skip action (SPEC §8.2.1, #566): when the selected
+		// STT model does not cover the pinned source language and
+		// media.stt.on_uncovered_language=skip, suppress transcription rather than
+		// emit degraded output. Handled in a helper so this function stays under the
+		// cyclomatic-complexity budget; see skipUncoveredLanguageTranscript.
+		if skip, suppressCredit := s.skipUncoveredLanguageTranscript(ctx, doc, mediaProduced); skip {
+			return suppressCredit, nil
+		}
 		produced, err := s.generateTranscriptRepresentation(ctx, doc, content)
 		if err != nil {
 			// Provider/transient failures should not fail the entire ingest run.

--- a/internal/ingest/stt_skip_uncovered_566_test.go
+++ b/internal/ingest/stt_skip_uncovered_566_test.go
@@ -1,0 +1,52 @@
+package ingest
+
+import "testing"
+
+// TestNormalizeOnUncoveredLanguage_566 pins the media.stt.on_uncovered_language
+// normalization (SPEC §8.2.1, #566): only "skip" (case-insensitive, trimmed)
+// selects the strict skip contract; everything else — including "warn", empty, and
+// any unrecognized value — is the fail-open "warn" default, so a Service built from
+// an unvalidated config always degrades safely (transcribe anyway).
+func TestNormalizeOnUncoveredLanguage_566(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"skip", onUncoveredLanguageSkip},
+		{"SKIP", onUncoveredLanguageSkip},
+		{"  skip  ", onUncoveredLanguageSkip},
+		{"warn", "warn"},
+		{"", "warn"},
+		{"nonsense", "warn"},
+	}
+	for _, c := range cases {
+		if got := normalizeOnUncoveredLanguage(c.in); got != c.want {
+			t.Errorf("normalizeOnUncoveredLanguage(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// TestSTTLanguageUncovered_566 pins the honest-coverage floor decision used by the
+// skip branch (SPEC §8.2.1, #566). It keys ONLY off the pinned source language and
+// the resolved profile's declared coverage — never per-item auto-detection — so it
+// trips exactly when a non-empty declared set excludes the pin.
+func TestSTTLanguageUncovered_566(t *testing.T) {
+	cases := []struct {
+		name     string
+		pin      string
+		coverage []string
+		want     bool
+	}{
+		{"declared+uncovered trips", "kir", []string{"ru", "en"}, true},
+		{"declared+covered does not trip", "ru", []string{"ru", "en"}, false},
+		{"undeclared (nil) never trips", "kir", nil, false},
+		{"empty declared set never trips", "kir", []string{}, false},
+		{"no pin never trips", "", []string{"ru", "en"}, false},
+		{"blank pin never trips", "   ", []string{"ru", "en"}, false},
+	}
+	for _, c := range cases {
+		s := &Service{transcriptLanguage: c.pin, sttLanguages: c.coverage}
+		if got := s.sttLanguageUncovered(); got != c.want {
+			t.Errorf("%s: sttLanguageUncovered(pin=%q, coverage=%v) = %v, want %v", c.name, c.pin, c.coverage, got, c.want)
+		}
+	}
+}

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -80,6 +80,11 @@ const (
 	// SkipReasonSizeCap: the file exceeded ingest.max_file_mb and was dropped
 	// at discovery.
 	SkipReasonSizeCap = "size_cap"
+	// SkipReasonLanguageUncovered: media whose resolved source language is outside
+	// the selected STT model's declared stt_languages coverage, skipped under
+	// media.stt.on_uncovered_language=skip (SPEC §8.2.1) instead of transcribed to
+	// degraded output. No transcript representation is produced.
+	SkipReasonLanguageUncovered = "language_uncovered"
 )
 
 type Representation struct {

--- a/tests/config/media_stt_on_uncovered_language_config_test.go
+++ b/tests/config/media_stt_on_uncovered_language_config_test.go
@@ -1,0 +1,98 @@
+package tests
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+)
+
+// TestMediaSTTOnUncoveredLanguage_Default confirms the honest-coverage floor
+// action defaults to the fail-open "warn" (SPEC §8.2.1, #566): behavior is
+// unchanged unless an operator opts into strict skipping.
+func TestMediaSTTOnUncoveredLanguage_Default(t *testing.T) {
+	if got := config.Default().MediaSTTOnUncoveredLanguage; got != "warn" {
+		t.Fatalf("default media.stt.on_uncovered_language = %q, want warn", got)
+	}
+}
+
+// TestMediaSTTOnUncoveredLanguage_Validation normalizes empty to warn, normalizes
+// case, accepts skip, and rejects any value outside warn/skip.
+func TestMediaSTTOnUncoveredLanguage_Validation(t *testing.T) {
+	cfg := config.Default()
+	cfg.MediaSTTOnUncoveredLanguage = ""
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("empty on_uncovered_language should validate: %v", err)
+	}
+	if cfg.MediaSTTOnUncoveredLanguage != "warn" {
+		t.Fatalf("empty on_uncovered_language should normalize to warn, got %q", cfg.MediaSTTOnUncoveredLanguage)
+	}
+
+	cfg = config.Default()
+	cfg.MediaSTTOnUncoveredLanguage = "SKIP"
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("skip on_uncovered_language should validate: %v", err)
+	}
+	if cfg.MediaSTTOnUncoveredLanguage != "skip" {
+		t.Fatalf("on_uncovered_language should normalize case to skip, got %q", cfg.MediaSTTOnUncoveredLanguage)
+	}
+
+	cfg = config.Default()
+	cfg.MediaSTTOnUncoveredLanguage = "drop"
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected an error for an unknown media.stt.on_uncovered_language value, got nil")
+	}
+}
+
+// TestMediaSTTOnUncoveredLanguage_ParsesFlatAndNestedYAML confirms both the flat
+// key (media_stt_on_uncovered_language) and the nested block
+// (media: stt: on_uncovered_language:) set the action through the YAML loader.
+func TestMediaSTTOnUncoveredLanguage_ParsesFlatAndNestedYAML(t *testing.T) {
+	base := []string{
+		"root_dir: /tmp/repo",
+		"state_dir: /tmp/repo/.dir2mcp",
+	}
+	flat := append(append([]string(nil), base...), "media_stt_on_uncovered_language: skip")
+	nested := append(append([]string(nil), base...),
+		"media:", "  stt:", "    on_uncovered_language: skip")
+
+	for name, lines := range map[string][]string{"flat": flat, "nested": nested} {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), ".dir2mcp.yaml")
+			writeFile(t, path, strings.Join(lines, "\n")+"\n")
+			cfg, err := config.LoadFile(path)
+			if err != nil {
+				t.Fatalf("LoadFile(%s media.stt.on_uncovered_language): %v", name, err)
+			}
+			if cfg.MediaSTTOnUncoveredLanguage != "skip" {
+				t.Fatalf("%s form did not set the action, got %q", name, cfg.MediaSTTOnUncoveredLanguage)
+			}
+		})
+	}
+}
+
+// TestMediaSTTOnUncoveredLanguage_RoundTripsThroughSaveLoad confirms the action
+// survives a save/load cycle.
+func TestMediaSTTOnUncoveredLanguage_RoundTripsThroughSaveLoad(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".dir2mcp.yaml")
+
+	cfg := config.Default()
+	cfg.RootDir = "/tmp/repo"
+	cfg.StateDir = "/tmp/repo/.dir2mcp"
+	cfg.MediaSTTOnUncoveredLanguage = "skip"
+	if err := config.SaveFile(path, cfg); err != nil {
+		t.Fatalf("SaveFile: %v", err)
+	}
+	if text := readFileString(t, path); !strings.Contains(text, "media_stt_on_uncovered_language: skip") {
+		t.Fatalf("saved config missing media_stt_on_uncovered_language:\n%s", text)
+	}
+	loaded, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if loaded.MediaSTTOnUncoveredLanguage != "skip" {
+		t.Fatalf("action did not round-trip, got %q", loaded.MediaSTTOnUncoveredLanguage)
+	}
+}

--- a/tests/ingest/stt_skip_uncovered_566_test.go
+++ b/tests/ingest/stt_skip_uncovered_566_test.go
@@ -1,0 +1,164 @@
+package tests
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/appstate"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// skipUncoveredService builds a media-ingesting service whose STT identity,
+// pinned source language, declared coverage, and honest-coverage floor action are
+// all set deterministically (no real provider), backed by a real on-disk store so
+// a full ProcessDocument exercises status persistence and the SkipSummary
+// aggregate end to end (SPEC §8.2.1, #566). The returned fakeTranscriber lets a
+// caller assert whether transcription was ATTEMPTED (calls) — the load-bearing
+// "did not transcribe" signal for the skip path.
+func skipUncoveredService(t *testing.T, root string, st *store.SQLiteStore, pinLang string, coverage []string, action string) (*ingest.Service, *appstate.IndexingState, *fakeTranscriber) {
+	t.Helper()
+	cfg := config.Config{RootDir: root, StateDir: t.TempDir(), STTProvider: "off"}
+	svc := mustNewIngestService(t, cfg, st)
+	state := appstate.NewIndexingState(appstate.ModeIncremental)
+	svc.SetIndexingState(state)
+	ft := &fakeTranscriber{text: "[00:00] a clean line of speech\n[00:02] another clean line of speech"}
+	svc.SetTranscriber(ft)
+	svc.SetSTTIdentity("whisper", "large-v3")
+	svc.SetTranscriptLanguage(pinLang)
+	svc.SetSTTLanguages(coverage)
+	svc.SetOnUncoveredLanguage(action)
+	return svc, state, ft
+}
+
+// TestSTTSkipUncovered_SkipRecordsDurableSkip is the core #566 skip case: the
+// pinned source language "kir" is outside the model's declared coverage [ru, en]
+// and media.stt.on_uncovered_language=skip, so the audio document is recorded as a
+// durable status="skipped" with skip_reason="language_uncovered" — no transcript
+// is produced and the transcriber is never invoked. The gap surfaces in the
+// SkipSummary honest-coverage aggregate rather than as garbage the quality gate
+// silently drops (SPEC §8.2.1).
+func TestSTTSkipUncovered_SkipRecordsDurableSkip(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "talk.mp3"), "fake-audio")
+	st := newRealStore(t)
+
+	svc, state, ft := skipUncoveredService(t, root, st, "kir", []string{"ru", "en"}, "skip")
+
+	f := ingest.DiscoveredFile{RelPath: "talk.mp3", SizeBytes: 10, MTimeUnix: time.Now().Unix()}
+	if err := svc.ProcessDocument(ctx, f, nil, false); err != nil {
+		t.Fatalf("ProcessDocument hard-failed on a non-fatal language-uncovered skip: %v", err)
+	}
+
+	doc := mustGetDoc(t, st, "talk.mp3")
+	if doc.Status != "skipped" {
+		t.Fatalf("talk.mp3: status = %q, want \"skipped\" (uncovered language under skip mode, §8.2.1)", doc.Status)
+	}
+	if doc.SkipReason != model.SkipReasonLanguageUncovered {
+		t.Fatalf("talk.mp3: skip_reason = %q, want %q", doc.SkipReason, model.SkipReasonLanguageUncovered)
+	}
+	// Load-bearing: transcription must NOT have been attempted (no degraded output).
+	if ft.calls != 0 {
+		t.Fatalf("talk.mp3: transcriber was invoked %d time(s), want 0 (skip must not transcribe)", ft.calls)
+	}
+	// The skipped counter is credited exactly once.
+	if snap := state.Snapshot(); snap.Skipped != 1 {
+		t.Fatalf("talk.mp3: run skipped = %d, want 1", snap.Skipped)
+	}
+	// The reason flows into the honest-coverage SkipSummary aggregate (SPEC §15.2).
+	stats, err := st.CorpusStats(ctx)
+	if err != nil {
+		t.Fatalf("CorpusStats: %v", err)
+	}
+	if stats.SkipSummary == nil || stats.SkipSummary.Categories[model.SkipReasonLanguageUncovered] != 1 {
+		t.Fatalf("expected SkipSummary category %q == 1, got %+v", model.SkipReasonLanguageUncovered, stats.SkipSummary)
+	}
+}
+
+// TestSTTSkipUncovered_WarnTranscribesAnyway is the fail-open default: the SAME
+// uncovered "kir"/[ru,en] pairing under media.stt.on_uncovered_language=warn (the
+// default) still transcribes — the item indexes normally and the transcriber IS
+// invoked. This proves the new skip branch is inert unless the operator opts into
+// skip; the Slice-A honest-coverage warning + meta flag remain the backstop.
+func TestSTTSkipUncovered_WarnTranscribesAnyway(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "talk.mp3"), "fake-audio")
+	st := newRealStore(t)
+
+	svc, _, ft := skipUncoveredService(t, root, st, "kir", []string{"ru", "en"}, "warn")
+
+	f := ingest.DiscoveredFile{RelPath: "talk.mp3", SizeBytes: 10, MTimeUnix: time.Now().Unix()}
+	if err := svc.ProcessDocument(ctx, f, nil, false); err != nil {
+		t.Fatalf("ProcessDocument: %v", err)
+	}
+
+	doc := mustGetDoc(t, st, "talk.mp3")
+	if doc.Status != "ok" {
+		t.Fatalf("talk.mp3 (warn): status = %q, want \"ok\" (warn transcribes anyway)", doc.Status)
+	}
+	if ft.calls == 0 {
+		t.Fatal("talk.mp3 (warn): transcriber was not invoked, want it to transcribe under the fail-open default")
+	}
+}
+
+// TestSTTSkipUncovered_CoveredLanguageTranscribesUnderSkip proves the floor is not
+// over-eager: even with media.stt.on_uncovered_language=skip, a pinned language
+// that IS in the declared coverage ("ru" in [ru, en]) transcribes normally — skip
+// only suppresses genuinely uncovered languages, never covered ones.
+func TestSTTSkipUncovered_CoveredLanguageTranscribesUnderSkip(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "talk.mp3"), "fake-audio")
+	st := newRealStore(t)
+
+	svc, _, ft := skipUncoveredService(t, root, st, "ru", []string{"ru", "en"}, "skip")
+
+	f := ingest.DiscoveredFile{RelPath: "talk.mp3", SizeBytes: 10, MTimeUnix: time.Now().Unix()}
+	if err := svc.ProcessDocument(ctx, f, nil, false); err != nil {
+		t.Fatalf("ProcessDocument: %v", err)
+	}
+
+	doc := mustGetDoc(t, st, "talk.mp3")
+	if doc.Status != "ok" {
+		t.Fatalf("talk.mp3 (covered+skip): status = %q, want \"ok\" (covered language must transcribe)", doc.Status)
+	}
+	if ft.calls == 0 {
+		t.Fatal("talk.mp3 (covered+skip): transcriber was not invoked, want it to transcribe a covered language")
+	}
+}
+
+// TestSTTSkipUncovered_UnknownCoverageTranscribesUnderSkip proves absence of a
+// declared coverage set is not evidence of non-coverage: with skip mode but NO
+// declared stt_languages (open/unknown), the floor does not apply and the item
+// transcribes — an empty coverage set never floors every language (SPEC §8.2.1).
+func TestSTTSkipUncovered_UnknownCoverageTranscribesUnderSkip(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "talk.mp3"), "fake-audio")
+	st := newRealStore(t)
+
+	svc, _, ft := skipUncoveredService(t, root, st, "kir", nil, "skip")
+
+	f := ingest.DiscoveredFile{RelPath: "talk.mp3", SizeBytes: 10, MTimeUnix: time.Now().Unix()}
+	if err := svc.ProcessDocument(ctx, f, nil, false); err != nil {
+		t.Fatalf("ProcessDocument: %v", err)
+	}
+
+	doc := mustGetDoc(t, st, "talk.mp3")
+	if doc.Status != "ok" {
+		t.Fatalf("talk.mp3 (unknown coverage+skip): status = %q, want \"ok\" (unknown coverage never floors)", doc.Status)
+	}
+	if ft.calls == 0 {
+		t.Fatal("talk.mp3 (unknown coverage+skip): transcriber was not invoked, want it to transcribe")
+	}
+}


### PR DESCRIPTION
## Summary

Closes #566 (final slice). Adds `media.stt.on_uncovered_language` (`warn` | `skip`, default `warn`) implementing the honest-coverage floor **action** of SPEC §8.2.1. Slices A (#602) and B (#604) already landed the honest-coverage detection + language-aware routing; this adds the config-driven strict-skip branch and the `language_uncovered` skip_reason.

When the pinned source language is outside the finally-selected STT model's declared `stt_languages` coverage:

- **`warn`** (default, fail-open): transcribe anyway and record the `(language, model, covered=false)` fact — unchanged Slice A behavior.
- **`skip`** (strict): record the media item as `documents.status="skipped"` with `skip_reason="language_uncovered"` and do **not** transcribe. The gap surfaces as honest not-indexed coverage in the `skip_reasons` aggregate instead of garbage the §8.6.6 quality gate silently drops. No transcript representation is produced.

The skip decision keys off the pinned source language and the routed profile's declared coverage — the same inputs as the Slice A construction-time warning. `langdetect` is text-based and cannot know an item's language before it is transcribed, so a skip-before-transcribe decision can only rest on the configured pin (no pin ⇒ no skip). A document that already produced media chunks (`embed_multimodal=augment`) stays searchable via those, so its transcript is suppressed rather than the document being recorded as skipped. The new reason flows into the durable `SkipSummary` aggregate (SQL group-by, no allowlist) and carries a `status` remediation hint.

Re-pins `dirstral-spec` to `55151bd` (SPEC §8.2.1 `on_uncovered_language` + the `language_uncovered` skip_reason enum entry — spec merged first per the governance loop).

## Files

- `internal/config/config.go` — new `MediaSTTOnUncoveredLanguage` field + full parse/merge/persist/validate wiring (mirrors `media.stt.language_strict` / `media.translate.engine`); rejects unknown values.
- `internal/model/types.go` — `SkipReasonLanguageUncovered` constant.
- `internal/ingest/service.go` — resolve action in `NewService`; skip branch in `generateTranscriptOrSidecar`; `sttLanguageUncovered()` + `normalizeOnUncoveredLanguage()` helpers; `SetOnUncoveredLanguage` / `SetSTTLanguages` test seams.
- `internal/cli/status.go` — remediation hint for the new reason.
- Tests: `tests/config/media_stt_on_uncovered_language_config_test.go`, `internal/ingest/stt_skip_uncovered_566_test.go`, `tests/ingest/stt_skip_uncovered_566_test.go`.

## Test plan

- `make build` ✓
- `go test ./internal/ingest/... ./internal/config/... ./tests/config/... ./tests/ingest/...` ✓
- `go vet ./...` ✓, `gocyclo -over 15` clean ✓, gofmt clean on edited files ✓
- New tests prove: covered language → transcribes; uncovered + `warn` → transcribes (transcriber invoked); uncovered + `skip` → `status=skipped` / `skip_reason=language_uncovered` / transcriber **not** invoked / reason in `SkipSummary`; unknown coverage under `skip` → transcribes; config default/validation/unknown-value rejection + flat & nested YAML parse + save/load roundtrip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `media.stt.on_uncovered_language` configuration.
  * By default, transcription proceeds when a language is outside the selected model’s coverage.
  * Added an optional strict mode that skips transcription and records `language_uncovered`.
  * Status output now provides guidance for resolving uncovered-language skips.

* **Bug Fixes**
  * Improved handling and reporting of media whose source language is not supported by the active STT model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->