### PR TITLE
feat(mcp,retrieval,store): dir2mcp_related "more like this" tool (#324)

### DIFF
--- a/internal/mcp/output_schema_conformance_test.go
+++ b/internal/mcp/output_schema_conformance_test.go
@@ -298,6 +298,29 @@ func TestSearchOutputSchemaConformance(t *testing.T) {
 	assertConforms(t, "search", searchOutputSchema(), structured)
 }
 
+func TestRelatedOutputSchemaConformance(t *testing.T) {
+	// chunk_id request: source_chunk_id is echoed alongside the required fields.
+	structured := map[string]interface{}{
+		"source_chunk_id":   uint64(42),
+		"source_rel_path":   "docs/report.pdf",
+		"k":                 15,
+		"index_used":        "text",
+		"hits":              []map[string]interface{}{serializeHit(fullSearchHit())},
+		"indexing_complete": true,
+	}
+	assertConforms(t, "related", relatedOutputSchema(), structured)
+
+	// rel_path request: source_chunk_id is omitted (still conforms — it is optional).
+	relPathReq := map[string]interface{}{
+		"source_rel_path":   "docs/report.pdf",
+		"k":                 15,
+		"index_used":        "both",
+		"hits":              []map[string]interface{}{},
+		"indexing_complete": false,
+	}
+	assertConforms(t, "related-relpath", relatedOutputSchema(), relPathReq)
+}
+
 func TestAskOutputSchemaConformance(t *testing.T) {
 	result := model.AskResult{
 		Question: "what drove revenue?",

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -54,6 +54,7 @@ const (
 
 var toolOrder = []string{
 	protocol.ToolNameSearch,
+	protocol.ToolNameRelated,
 	protocol.ToolNameAsk,
 	protocol.ToolNameAskAudio,
 	protocol.ToolNameTranscribe,
@@ -123,6 +124,13 @@ func (s *Server) buildToolRegistry() map[string]toolDefinition {
 			InputSchema:  searchInputSchema(),
 			OutputSchema: searchOutputSchema(),
 			handler:      s.handleSearchTool,
+		},
+		protocol.ToolNameRelated: {
+			Name:         protocol.ToolNameRelated,
+			Description:  "Nearest-neighbour segments for a given chunk or document ('more like this').",
+			InputSchema:  relatedInputSchema(),
+			OutputSchema: relatedOutputSchema(),
+			handler:      s.handleRelatedTool,
 		},
 		protocol.ToolNameAsk: {
 			Name:         protocol.ToolNameAsk,
@@ -868,6 +876,138 @@ func normalizeIndexAxis(axis string) string {
 		return axis
 	default:
 		return "text"
+	}
+}
+
+// handleRelatedTool serves dir2mcp_related (SPEC §15.12): query-by-example
+// nearest-neighbour retrieval. Exactly one of chunk_id / rel_path identifies the
+// seed; the same §9.5/§9.6 filters as dir2mcp_search narrow the neighbours.
+func (s *Server) handleRelatedTool(ctx context.Context, args map[string]interface{}) (toolCallResult, *toolExecutionError) {
+	rq, toolErr := parseRelatedArgs(args)
+	if toolErr != nil {
+		return toolCallResult{}, toolErr
+	}
+	if s.retriever == nil {
+		return toolCallResult{}, &toolExecutionError{Code: protocol.ErrorCodeIndexNotReady, Message: "retriever not configured", Retryable: false}
+	}
+	rs, ok := s.retriever.(model.RelatedSearcher)
+	if !ok {
+		return toolCallResult{}, &toolExecutionError{Code: protocol.ErrorCodeIndexNotReady, Message: "related retrieval not available", Retryable: false}
+	}
+	res, relErr := rs.Related(ctx, rq)
+	if relErr != nil {
+		return toolCallResult{}, mapRelatedError(relErr)
+	}
+	structured := map[string]interface{}{
+		"source_rel_path":   res.SourceRelPath,
+		"k":                 res.K,
+		"index_used":        normalizeIndexAxis(res.IndexUsed),
+		"hits":              serializeSearchHits(res.Hits),
+		"indexing_complete": res.IndexingComplete,
+	}
+	if res.HasSourceChunkID {
+		structured["source_chunk_id"] = res.SourceChunkID
+	}
+	return toolCallResult{
+		Content:           []toolContentItem{{Type: "text", Text: renderSearchHitsText(res.Hits, "related segment")}},
+		StructuredContent: structured,
+	}, nil
+}
+
+// parseRelatedArgs validates and projects the dir2mcp_related arguments into a
+// model.RelatedQuery. It enforces the chunk_id/rel_path oneOf and reuses the
+// shared k/index/filter/date parsers so dir2mcp_related and dir2mcp_search stay
+// in lockstep on those semantics.
+func parseRelatedArgs(args map[string]interface{}) (model.RelatedQuery, *toolExecutionError) {
+	if err := assertNoUnknownArguments(args, map[string]struct{}{
+		"chunk_id": {}, "rel_path": {}, "k": {}, "index": {}, "exclude_same_document": {},
+		"path_prefix": {}, "file_glob": {}, "doc_types": {}, "languages": {}, "date_from": {}, "date_to": {},
+	}); err != nil {
+		return model.RelatedQuery{}, &toolExecutionError{Code: "INVALID_FIELD", Message: err.Error(), Retryable: false}
+	}
+	chunkID, chunkPresent, err := parseOptionalIntegerWithPresence(args, "chunk_id")
+	if err != nil {
+		return model.RelatedQuery{}, &toolExecutionError{Code: "INVALID_FIELD", Message: err.Error(), Retryable: false}
+	}
+	relPath, relPresent, toolErr := parseRelatedRelPath(args)
+	if toolErr != nil {
+		return model.RelatedQuery{}, toolErr
+	}
+	// oneOf: exactly one of chunk_id / rel_path (neither or both is INVALID_FIELD).
+	if chunkPresent == relPresent {
+		return model.RelatedQuery{}, &toolExecutionError{Code: "INVALID_FIELD", Message: "exactly one of chunk_id or rel_path is required", Retryable: false}
+	}
+	if chunkPresent && chunkID < 1 {
+		return model.RelatedQuery{}, &toolExecutionError{Code: "INVALID_FIELD", Message: "chunk_id must be >= 1", Retryable: false}
+	}
+	k, toolErr := parseKArg(args)
+	if toolErr != nil {
+		return model.RelatedQuery{}, toolErr
+	}
+	indexName, toolErr := parseIndexArg(args)
+	if toolErr != nil {
+		return model.RelatedQuery{}, toolErr
+	}
+	excludeSameDoc, err := parseOptionalBool(args, "exclude_same_document", true)
+	if err != nil {
+		return model.RelatedQuery{}, &toolExecutionError{Code: "INVALID_FIELD", Message: err.Error(), Retryable: false}
+	}
+	pathPrefix, fileGlob, docTypes, toolErr := parseSearchFilters(args)
+	if toolErr != nil {
+		return model.RelatedQuery{}, toolErr
+	}
+	languages, toolErr := parseLanguagesArg(args)
+	if toolErr != nil {
+		return model.RelatedQuery{}, toolErr
+	}
+	dateFrom, dateTo, toolErr := parseDateWindow(args)
+	if toolErr != nil {
+		return model.RelatedQuery{}, toolErr
+	}
+	rq := model.RelatedQuery{
+		K: k, Index: indexName, ExcludeSameDocument: excludeSameDoc,
+		PathPrefix: pathPrefix, FileGlob: fileGlob, DocTypes: docTypes,
+		Languages: languages, DateFrom: dateFrom, DateTo: dateTo,
+	}
+	if chunkPresent {
+		rq.SourceChunkID = uint64(chunkID)
+	} else {
+		rq.SourceRelPath = relPath
+	}
+	return rq, nil
+}
+
+// parseRelatedRelPath reports the rel_path argument and whether it was supplied.
+// A present-but-non-string or empty rel_path is INVALID_FIELD; an absent key
+// yields ("", false, nil) so the caller can enforce the chunk_id/rel_path oneOf.
+func parseRelatedRelPath(args map[string]interface{}) (string, bool, *toolExecutionError) {
+	raw, ok := args["rel_path"]
+	if !ok {
+		return "", false, nil
+	}
+	str, isStr := raw.(string)
+	if !isStr {
+		return "", true, &toolExecutionError{Code: "INVALID_FIELD", Message: "rel_path must be a string", Retryable: false}
+	}
+	if strings.TrimSpace(str) == "" {
+		return "", true, &toolExecutionError{Code: "INVALID_FIELD", Message: "rel_path must not be empty", Retryable: false}
+	}
+	return str, true, nil
+}
+
+// mapRelatedError converts a Related error into a toolExecutionError. An
+// unresolvable seed is INVALID_FIELD (SPEC §15.12: the source could not be
+// located, not an empty result).
+func mapRelatedError(err error) *toolExecutionError {
+	switch {
+	case errors.Is(err, model.ErrRelatedSourceNotFound):
+		return &toolExecutionError{Code: "INVALID_FIELD", Message: "chunk_id or rel_path does not resolve to an indexed segment", Retryable: false}
+	case errors.Is(err, model.ErrRelatedNotSupported):
+		return &toolExecutionError{Code: protocol.ErrorCodeIndexNotReady, Message: "related retrieval not available", Retryable: false}
+	case errors.Is(err, model.ErrIndexNotReady) || errors.Is(err, model.ErrIndexNotConfigured):
+		return &toolExecutionError{Code: protocol.ErrorCodeIndexNotReady, Message: "index not ready", Retryable: true}
+	default:
+		return &toolExecutionError{Code: "INTERNAL_ERROR", Message: "internal server error", Retryable: true}
 	}
 }
 
@@ -3147,6 +3287,70 @@ func searchOutputSchema() map[string]interface{} {
 			"indexing_complete": map[string]interface{}{"type": "boolean"},
 		},
 		"required":    []string{"query", "k", "index_used", "hits", "indexing_complete"},
+		"definitions": sharedDefinitions(),
+	}
+}
+
+func relatedInputSchema() map[string]interface{} {
+	return map[string]interface{}{
+		"type":                 "object",
+		"additionalProperties": false,
+		"description":          "Exactly ONE of chunk_id / rel_path identifies the source segment. Supplying neither or both is INVALID_FIELD.",
+		"oneOf": []interface{}{
+			map[string]interface{}{"required": []string{"chunk_id"}, "not": map[string]interface{}{"required": []string{"rel_path"}}},
+			map[string]interface{}{"required": []string{"rel_path"}, "not": map[string]interface{}{"required": []string{"chunk_id"}}},
+		},
+		"properties": map[string]interface{}{
+			"chunk_id": map[string]interface{}{
+				"type":        "integer",
+				"minimum":     1,
+				"description": "The source segment: neighbours are ranked by similarity to this chunk's embedding vector. The source chunk itself is always excluded from hits.",
+			},
+			"rel_path": map[string]interface{}{
+				"type":        "string",
+				"minLength":   1,
+				"description": "The source document (corpus-relative, normalized '/'): neighbours are ranked against the document's own chunk vectors. Chunks belonging to this document are always excluded from hits.",
+			},
+			"k":     map[string]interface{}{"type": "integer", "minimum": 1, "maximum": MaxSearchK, "default": DefaultSearchK},
+			"index": map[string]interface{}{"type": "string", "enum": []string{"auto", "text", "code", "both"}, "default": "auto", "description": "Which logical vector axis to search (SPEC §6.1). 'auto' matches the source segment's own index_kind."},
+			"exclude_same_document": map[string]interface{}{
+				"type":        "boolean",
+				"default":     true,
+				"description": "For a chunk_id request: when true (default) all chunks of the source chunk's document are excluded ('other documents like this'); when false the source document's OTHER chunks may appear (the source chunk itself is always excluded). No-op for a rel_path request — a document's own chunks are always excluded (a document is never related to itself).",
+			},
+			"path_prefix": map[string]interface{}{"type": "string"},
+			"file_glob":   map[string]interface{}{"type": "string"},
+			"doc_types":   map[string]interface{}{"type": "array", "items": map[string]interface{}{"type": "string"}},
+			"languages": map[string]interface{}{
+				"type":        "array",
+				"items":       map[string]interface{}{"type": "string"},
+				"description": "Optional (SPEC §9.5): restrict hits to representations recorded in any of these BCP-47 languages (case-insensitive primary-subtag match). Absent/empty = no filtering.",
+			},
+			"date_from": map[string]interface{}{
+				"type":        "string",
+				"description": "Optional (SPEC §9.6): RFC 3339 timestamp or bare YYYY-MM-DD; exclude hits from documents dated before this (inclusive). Absent = open lower bound.",
+			},
+			"date_to": map[string]interface{}{
+				"type":        "string",
+				"description": "Optional (SPEC §9.6): RFC 3339 timestamp or bare YYYY-MM-DD; exclude hits from documents dated after this (inclusive). Absent = open upper bound.",
+			},
+		},
+	}
+}
+
+func relatedOutputSchema() map[string]interface{} {
+	return map[string]interface{}{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": map[string]interface{}{
+			"source_chunk_id":   map[string]interface{}{"type": "integer", "description": "Echo of the resolved source chunk_id when the request supplied chunk_id; omitted for a rel_path request."},
+			"source_rel_path":   map[string]interface{}{"type": "string", "description": "Echo of the resolved source document rel_path (present for both request shapes)."},
+			"k":                 map[string]interface{}{"type": "integer"},
+			"index_used":        map[string]interface{}{"type": "string", "enum": []string{"text", "code", "both"}},
+			"hits":              map[string]interface{}{"type": "array", "items": map[string]interface{}{"$ref": "#/definitions/Hit"}},
+			"indexing_complete": map[string]interface{}{"type": "boolean"},
+		},
+		"required":    []string{"source_rel_path", "k", "index_used", "hits", "indexing_complete"},
 		"definitions": sharedDefinitions(),
 	}
 }

--- a/internal/model/errors.go
+++ b/internal/model/errors.go
@@ -33,6 +33,17 @@ var (
 	// should retry once ingestion completes rather than fall back to raw bytes.
 	ErrOCRNotReady = errors.New("ocr not ready")
 
+	// ErrRelatedSourceNotFound is returned by RelatedSearcher.Related when the
+	// seed chunk_id / rel_path resolves to no indexed segment (SPEC §15.12): the
+	// source could not be located, so the tool layer surfaces INVALID_FIELD rather
+	// than an empty result.
+	ErrRelatedSourceNotFound = errors.New("related source segment not found")
+
+	// ErrRelatedNotSupported is returned by RelatedSearcher.Related when the
+	// configured store cannot resolve seed segments, so dir2mcp_related cannot be
+	// served.
+	ErrRelatedNotSupported = errors.New("related retrieval not supported by this store")
+
 	// ErrMediaNoText indicates a multimodal media-only document (SPEC 8.1.7):
 	// embedded directly under model.embed.multimodal=replace with no text
 	// representation. This is a permanent condition — unlike ErrOCRNotReady,

--- a/internal/model/interfaces.go
+++ b/internal/model/interfaces.go
@@ -129,6 +129,18 @@ type AxisSearcher interface {
 	SearchWithAxis(ctx context.Context, query SearchQuery) ([]SearchHit, string, error)
 }
 
+// RelatedSearcher is an optional Retriever capability that performs
+// query-by-example "more like this" retrieval (SPEC §15.12, dir2mcp #324):
+// given a seed chunk or document it returns the nearest-neighbour segments over
+// the SAME vector index, excluding the seed itself. It is additive — the MCP
+// dir2mcp_related tool type-asserts the retriever against this interface,
+// mirroring AxisSearcher; a retriever that does not implement it simply does not
+// expose the tool. Ordering is pure vector similarity (the reranker does NOT
+// apply), so no query text is involved.
+type RelatedSearcher interface {
+	Related(ctx context.Context, query RelatedQuery) (RelatedResult, error)
+}
+
 type Ingestor interface {
 	Run(ctx context.Context) error
 	Reindex(ctx context.Context) error

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -442,6 +442,52 @@ type SearchQuery struct {
 	DateTo   int64
 }
 
+// RelatedQuery is the input to a query-by-example "more like this" retrieval
+// (SPEC §15.12): exactly ONE of SourceChunkID / SourceRelPath identifies the
+// seed segment (the tool layer enforces the oneOf), and the same §9.5/§9.6
+// filters as SearchQuery narrow the returned neighbours.
+type RelatedQuery struct {
+	// SourceChunkID is the seed chunk when the request identified the source by
+	// chunk_id; 0 when the source was given by rel_path.
+	SourceChunkID uint64
+	// SourceRelPath is the seed document (corpus-relative) when the request
+	// identified the source by rel_path; "" when the source was given by chunk_id.
+	SourceRelPath string
+	K             int
+	// Index selects the vector axis to search: auto|text|code|both. "auto"
+	// matches the seed segment's own index_kind.
+	Index string
+	// ExcludeSameDocument widens seed exclusion for a chunk_id request: when true
+	// (default) every chunk of the seed chunk's document is excluded; when false
+	// only the seed chunk itself is excluded. No-op for a rel_path request — a
+	// document's own chunks are always excluded.
+	ExcludeSameDocument bool
+	PathPrefix          string
+	FileGlob            string
+	DocTypes            []string
+	Languages           []string
+	LanguageMatch       string
+	DateFrom            int64
+	DateTo              int64
+}
+
+// RelatedResult is the output of a RelatedSearcher.Related call (SPEC §15.12).
+type RelatedResult struct {
+	// SourceChunkID / HasSourceChunkID echo the resolved seed chunk id for a
+	// chunk_id request; HasSourceChunkID is false for a rel_path request so the
+	// field is omitted from the tool output.
+	SourceChunkID    uint64
+	HasSourceChunkID bool
+	// SourceRelPath is the resolved seed document rel_path (present for both
+	// request shapes).
+	SourceRelPath string
+	K             int
+	// IndexUsed is the axis actually searched (text|code|both).
+	IndexUsed        string
+	Hits             []SearchHit
+	IndexingComplete bool
+}
+
 type SearchHit struct {
 	ChunkID uint64
 	RelPath string

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -17,6 +17,7 @@ const (
 	ToolNameAnnotate         = "dir2mcp_annotate"
 	ToolNameTranscribeAndAsk = "dir2mcp_transcribe_and_ask"
 	ToolNameOpenMediaClip    = "dir2mcp_open_media_clip"
+	ToolNameRelated          = "dir2mcp_related"
 )
 
 const (

--- a/internal/retrieval/related.go
+++ b/internal/retrieval/related.go
@@ -1,0 +1,427 @@
+package retrieval
+
+import (
+	"context"
+	"errors"
+	"math"
+	"sort"
+	"strings"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// Related implements the query-by-example "more like this" retrieval of SPEC
+// §15.12 (dir2mcp #324): given a seed chunk (SourceChunkID) or document
+// (SourceRelPath) it ranks indexed segments by embedding similarity to the
+// seed's vector(s) over the SAME vector index, applies the §9.5/§9.6 filters,
+// excludes the seed itself (and — for a chunk_id request with
+// ExcludeSameDocument — every chunk of the seed's document), and returns the top
+// k Hits. Ordering is pure vector similarity with an ascending chunk_id tiebreak
+// (the reranker does NOT apply — there is no query text). Partial-index state is
+// reflected exactly as dir2mcp_search does.
+//
+// The seed vector is reconstructed by re-embedding the seed segment's stored
+// text with the index-time embed role, so the same neighbour ranking is produced
+// across every index backend without a per-backend vector-readback capability.
+func (s *Service) Related(ctx context.Context, q model.RelatedQuery) (model.RelatedResult, error) {
+	if s.embedder == nil {
+		return model.RelatedResult{}, ErrMissingEmbedder
+	}
+	cs, ok := s.store.(relatedChunkStore)
+	if !ok {
+		return model.RelatedResult{}, model.ErrRelatedNotSupported
+	}
+	k := q.K
+	if k <= 0 {
+		k = 15
+	}
+	seed, err := s.resolveRelatedSource(ctx, cs, q)
+	if err != nil {
+		return model.RelatedResult{}, err
+	}
+	hits, indexUsed, err := s.relatedNeighbors(ctx, q, seed, k)
+	if err != nil {
+		return model.RelatedResult{}, err
+	}
+	indexingComplete, _ := s.IndexingComplete(ctx)
+	return model.RelatedResult{
+		SourceChunkID:    seed.chunkID,
+		HasSourceChunkID: seed.hasChunkID,
+		SourceRelPath:    seed.relPath,
+		K:                k,
+		IndexUsed:        indexUsed,
+		Hits:             hits,
+		IndexingComplete: indexingComplete,
+	}, nil
+}
+
+// compile-time assertion that Service satisfies the optional RelatedSearcher
+// capability the MCP dir2mcp_related tool type-asserts against.
+var _ model.RelatedSearcher = (*Service)(nil)
+
+// relatedExcludeMargin over-fetches a few extra neighbours beyond k plus the
+// seed-exclusion count, so a filter drop or a same-document chunk that ranks
+// inside the pool cannot starve the result below k.
+const relatedExcludeMargin = 8
+
+// relatedSeedSampleCap bounds how many of a document's chunk texts are embedded
+// into a rel_path seed vector. The seed is a centroid, so a large document is
+// well-approximated by its first N (chunk-id-ordered, deterministic) chunks
+// without paying an unbounded embed cost. Every chunk of the document is still
+// excluded from the neighbours regardless of this cap.
+const relatedSeedSampleCap = 256
+
+// relatedChunkStore is the store capability dir2mcp_related needs to resolve a
+// seed segment. It is type-asserted on the service's store (mirroring the
+// LexicalSearcher / DocumentHashLister optional-capability pattern); a store
+// that does not implement it makes Related return ErrRelatedNotSupported.
+type relatedChunkStore interface {
+	ChunkTaskByID(ctx context.Context, chunkID uint64) (model.ChunkTask, string, error)
+	EmbeddedChunksByPath(ctx context.Context, relPath string) ([]model.ChunkTask, error)
+}
+
+// relatedSeed is the resolved seed of a Related request: the source document, the
+// axis to search, the per-axis texts to embed into the seed vector, and the set
+// of chunk ids to exclude from the neighbours.
+type relatedSeed struct {
+	relPath     string
+	chunkID     uint64
+	hasChunkID  bool
+	axis        string // text|code|both
+	excludeIDs  map[uint64]struct{}
+	textsByAxis map[string][]string
+}
+
+// resolveRelatedSource dispatches to the chunk_id or rel_path seed resolver.
+func (s *Service) resolveRelatedSource(ctx context.Context, cs relatedChunkStore, q model.RelatedQuery) (*relatedSeed, error) {
+	if q.SourceChunkID != 0 {
+		return s.resolveRelatedChunkSeed(ctx, cs, q)
+	}
+	return resolveRelatedPathSeed(ctx, cs, q)
+}
+
+// resolveRelatedChunkSeed resolves a chunk_id seed: the neighbours are ranked
+// against that chunk's own embedding vector. The source chunk is always excluded;
+// ExcludeSameDocument additionally excludes every chunk of its document.
+func (s *Service) resolveRelatedChunkSeed(ctx context.Context, cs relatedChunkStore, q model.RelatedQuery) (*relatedSeed, error) {
+	task, _, err := cs.ChunkTaskByID(ctx, q.SourceChunkID)
+	if err != nil {
+		if errors.Is(err, model.ErrNotFound) {
+			return nil, model.ErrRelatedSourceNotFound
+		}
+		return nil, err
+	}
+	relPath := task.Metadata.RelPath
+	axis := resolveRelatedAxis(q.Index, chunkAxis(task.IndexKind))
+	exclude := map[uint64]struct{}{q.SourceChunkID: {}}
+	if q.ExcludeSameDocument {
+		docChunks, err := cs.EmbeddedChunksByPath(ctx, relPath)
+		if err != nil {
+			return nil, err
+		}
+		for _, c := range docChunks {
+			exclude[c.Label] = struct{}{}
+		}
+	}
+	texts := make(map[string][]string, 2)
+	for _, ax := range activeAxes(axis) {
+		texts[ax] = []string{task.Text}
+	}
+	return &relatedSeed{
+		relPath:     relPath,
+		chunkID:     q.SourceChunkID,
+		hasChunkID:  true,
+		axis:        axis,
+		excludeIDs:  exclude,
+		textsByAxis: texts,
+	}, nil
+}
+
+// resolveRelatedPathSeed resolves a rel_path seed: the neighbours are ranked
+// against the document's own chunk vectors, aggregated. Every chunk of the
+// document is always excluded (a document is never related to itself), so
+// ExcludeSameDocument is a no-op here.
+func resolveRelatedPathSeed(ctx context.Context, cs relatedChunkStore, q model.RelatedQuery) (*relatedSeed, error) {
+	chunks, err := cs.EmbeddedChunksByPath(ctx, q.SourceRelPath)
+	if err != nil {
+		return nil, err
+	}
+	if len(chunks) == 0 {
+		return nil, model.ErrRelatedSourceNotFound
+	}
+	relPath := chunks[0].Metadata.RelPath
+	exclude := make(map[uint64]struct{}, len(chunks))
+	textsByKind := make(map[string][]string, 2)
+	countByKind := make(map[string]int, 2)
+	for _, c := range chunks {
+		exclude[c.Label] = struct{}{}
+		ax := chunkAxis(c.IndexKind)
+		textsByKind[ax] = append(textsByKind[ax], c.Text)
+		countByKind[ax]++
+	}
+	axis := resolveRelatedAxis(q.Index, majorityAxis(countByKind))
+	texts := make(map[string][]string, 2)
+	for _, ax := range activeAxes(axis) {
+		texts[ax] = textsByKind[ax]
+	}
+	return &relatedSeed{
+		relPath:     relPath,
+		axis:        axis,
+		excludeIDs:  exclude,
+		textsByAxis: texts,
+	}, nil
+}
+
+// relatedNeighbors runs the pure vector nearest-neighbour retrieval for the
+// resolved seed: it embeds the per-axis seed text(s), searches each active index
+// axis with the §9.5/§9.6 filters, merges any per-axis pools, drops the excluded
+// seed/same-document chunks, orders by descending similarity (ascending chunk_id
+// tiebreak), truncates to k, and prunes tombstoned chunks — exactly as
+// dir2mcp_search does for its final result set.
+func (s *Service) relatedNeighbors(ctx context.Context, q model.RelatedQuery, seed *relatedSeed, k int) ([]model.SearchHit, string, error) {
+	filters := model.SearchQuery{
+		K:             k,
+		PathPrefix:    q.PathPrefix,
+		FileGlob:      q.FileGlob,
+		DocTypes:      q.DocTypes,
+		Languages:     q.Languages,
+		LanguageMatch: q.LanguageMatch,
+		DateFrom:      q.DateFrom,
+		DateTo:        q.DateTo,
+	}
+	poolK := k + len(seed.excludeIDs) + relatedExcludeMargin
+	perAxis := make([][]model.SearchHit, 0, 2)
+	searched := make([]string, 0, 2)
+	for _, ax := range activeAxes(seed.axis) {
+		texts := seed.textsByAxis[ax]
+		if len(texts) == 0 {
+			continue
+		}
+		idx, modelName := s.indexAndModelForAxis(ax)
+		if idx == nil {
+			continue
+		}
+		vec, err := s.buildSeedVector(ctx, modelName, texts)
+		if err != nil {
+			return nil, "", err
+		}
+		if len(vec) == 0 {
+			continue
+		}
+		cand, err := s.collectVectorCandidates(ctx, vec, idx, ax, filters, poolK)
+		if err != nil {
+			return nil, "", err
+		}
+		perAxis = append(perAxis, cand)
+		searched = append(searched, ax)
+	}
+	merged := mergeRelatedAxes(perAxis)
+	merged = excludeSeedChunks(merged, seed.excludeIDs)
+	sortRelatedHits(merged)
+	merged = truncateSearchHits(merged, k)
+	return s.pruneTombstonedHits(ctx, merged), effectiveIndexUsed(seed.axis, searched), nil
+}
+
+// effectiveIndexUsed reports the axis actually searched (SPEC §15.12: index_used
+// reflects what was searched). When "both" was requested but only one axis held
+// seed vectors, the single searched axis is reported; a request that produced no
+// searchable axis falls back to the requested axis so index_used stays a legal
+// enum value.
+func effectiveIndexUsed(requested string, searched []string) string {
+	switch len(searched) {
+	case 0:
+		return requested
+	case 1:
+		return searched[0]
+	default:
+		return "both"
+	}
+}
+
+// indexAndModelForAxis returns the physical index and embed model for an axis.
+func (s *Service) indexAndModelForAxis(axis string) (model.Index, string) {
+	s.metaMu.RLock()
+	defer s.metaMu.RUnlock()
+	if axis == "code" {
+		return s.codeIndex, s.codeModel
+	}
+	return s.textIndex, s.textModel
+}
+
+// buildSeedVector re-embeds the seed text(s) at the index-time embed role and
+// mean-pools them into a single seed vector (SPEC §15.12: a rel_path seed
+// aggregates the document's chunk vectors; a chunk_id seed has a single text).
+func (s *Service) buildSeedVector(ctx context.Context, modelName string, texts []string) ([]float32, error) {
+	if len(texts) > relatedSeedSampleCap {
+		texts = texts[:relatedSeedSampleCap]
+	}
+	vecs, err := s.embedder.Embed(ctx, modelName, model.EmbedDocument, texts)
+	if err != nil {
+		return nil, err
+	}
+	return meanPool(vecs), nil
+}
+
+// mergeRelatedAxes merges the per-axis candidate pools. A single-axis request
+// passes its pool through unchanged; an index=both request min-max normalizes
+// each axis's scores (they come from different embedding spaces) and keeps the
+// best-scoring occurrence of each chunk, mirroring searchBothIndices.
+func mergeRelatedAxes(perAxis [][]model.SearchHit) []model.SearchHit {
+	if len(perAxis) == 0 {
+		return nil
+	}
+	if len(perAxis) == 1 {
+		return perAxis[0]
+	}
+	for _, hits := range perAxis {
+		normalizeScores(hits)
+	}
+	merged := make(map[uint64]model.SearchHit)
+	for _, hits := range perAxis {
+		for _, h := range hits {
+			if existing, ok := merged[h.ChunkID]; !ok || h.Score > existing.Score {
+				merged[h.ChunkID] = h
+			}
+		}
+	}
+	out := make([]model.SearchHit, 0, len(merged))
+	for _, h := range merged {
+		out = append(out, h)
+	}
+	return out
+}
+
+// excludeSeedChunks drops the seed's excluded chunk ids from the candidate pool.
+func excludeSeedChunks(hits []model.SearchHit, exclude map[uint64]struct{}) []model.SearchHit {
+	out := make([]model.SearchHit, 0, len(hits))
+	for _, h := range hits {
+		if _, skip := exclude[h.ChunkID]; skip {
+			continue
+		}
+		out = append(out, h)
+	}
+	return out
+}
+
+// sortRelatedHits orders hits by descending similarity, breaking ties by
+// ascending chunk_id so repeated calls (and independent implementations) produce
+// the same order (SPEC §15.12).
+func sortRelatedHits(hits []model.SearchHit) {
+	sort.SliceStable(hits, func(i, j int) bool {
+		if hits[i].Score != hits[j].Score {
+			return hits[i].Score > hits[j].Score
+		}
+		return hits[i].ChunkID < hits[j].ChunkID
+	})
+}
+
+// resolveRelatedAxis maps the requested index mode to a physical axis: an
+// explicit text/code/both is honored; "auto" (and any unrecognized value) matches
+// the seed's own index_kind (SPEC §15.12).
+func resolveRelatedAxis(mode, seedAxis string) string {
+	switch normalizeRelatedIndex(mode) {
+	case "text":
+		return "text"
+	case "code":
+		return "code"
+	case "both":
+		return "both"
+	default: // auto
+		return seedAxis
+	}
+}
+
+// normalizeRelatedIndex lower-cases/trims the requested index mode, defaulting an
+// empty or unrecognized value to "auto".
+func normalizeRelatedIndex(mode string) string {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case "text":
+		return "text"
+	case "code":
+		return "code"
+	case "both":
+		return "both"
+	default:
+		return "auto"
+	}
+}
+
+// chunkAxis maps a chunk's index_kind to a physical axis (anything not "code" is
+// text, matching the store's default index_kind).
+func chunkAxis(indexKind string) string {
+	if strings.EqualFold(strings.TrimSpace(indexKind), "code") {
+		return "code"
+	}
+	return "text"
+}
+
+// majorityAxis picks the axis with more chunks for a rel_path seed, breaking a
+// tie (and the no-chunks case) toward text.
+func majorityAxis(countByKind map[string]int) string {
+	if countByKind["code"] > countByKind["text"] {
+		return "code"
+	}
+	return "text"
+}
+
+// activeAxes expands an axis into the physical axes to search: "both" fans out to
+// text and code; any single axis is searched alone.
+func activeAxes(axis string) []string {
+	if axis == "both" {
+		return []string{"text", "code"}
+	}
+	return []string{axis}
+}
+
+// meanPool averages a set of embedding vectors into one and L2-normalizes the
+// result (so a rel_path seed is the centroid of the document's chunk vectors).
+// Empty and dimension-mismatched vectors are skipped; nil is returned when no
+// usable vector remains.
+func meanPool(vecs [][]float32) []float32 {
+	dim := 0
+	for _, v := range vecs {
+		if len(v) > 0 {
+			dim = len(v)
+			break
+		}
+	}
+	if dim == 0 {
+		return nil
+	}
+	sum := make([]float64, dim)
+	n := 0
+	for _, v := range vecs {
+		if len(v) != dim {
+			continue
+		}
+		for i, x := range v {
+			sum[i] += float64(x)
+		}
+		n++
+	}
+	if n == 0 {
+		return nil
+	}
+	out := make([]float32, dim)
+	for i := range sum {
+		out[i] = float32(sum[i] / float64(n))
+	}
+	return l2Normalize(out)
+}
+
+// l2Normalize scales a vector to unit length; a zero-norm vector is returned
+// unchanged (cosine ranking is scale-invariant regardless).
+func l2Normalize(v []float32) []float32 {
+	var norm float64
+	for _, x := range v {
+		norm += float64(x) * float64(x)
+	}
+	if norm == 0 {
+		return v
+	}
+	inv := 1.0 / math.Sqrt(norm)
+	for i := range v {
+		v[i] = float32(float64(v[i]) * inv)
+	}
+	return v
+}

--- a/internal/retrieval/related_test.go
+++ b/internal/retrieval/related_test.go
@@ -1,0 +1,246 @@
+package retrieval
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// relatedFakeStore is a minimal model.Store that also satisfies the
+// relatedChunkStore capability, resolving seed segments from an in-memory map.
+type relatedFakeStore struct {
+	chunks map[uint64]model.ChunkTask
+}
+
+func (f *relatedFakeStore) Init(context.Context) error { return nil }
+func (f *relatedFakeStore) UpsertDocument(context.Context, model.Document) error {
+	return nil
+}
+func (f *relatedFakeStore) GetDocumentByPath(context.Context, string) (model.Document, error) {
+	return model.Document{}, model.ErrNotFound
+}
+func (f *relatedFakeStore) ListFiles(context.Context, string, string, int, int) ([]model.Document, int64, error) {
+	return nil, 0, nil
+}
+func (f *relatedFakeStore) Close() error { return nil }
+
+func (f *relatedFakeStore) ChunkTaskByID(_ context.Context, chunkID uint64) (model.ChunkTask, string, error) {
+	t, ok := f.chunks[chunkID]
+	if !ok {
+		return model.ChunkTask{}, "", model.ErrNotFound
+	}
+	return t, "", nil
+}
+
+func (f *relatedFakeStore) EmbeddedChunksByPath(_ context.Context, relPath string) ([]model.ChunkTask, error) {
+	ids := make([]uint64, 0, len(f.chunks))
+	for id := range f.chunks {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	var out []model.ChunkTask
+	for _, id := range ids {
+		if f.chunks[id].Metadata.RelPath == relPath {
+			out = append(out, f.chunks[id])
+		}
+	}
+	return out, nil
+}
+
+// textVecEmbedder maps an exact input text to a fixed vector, so re-embedding a
+// stored chunk's text reproduces its indexed vector deterministically.
+type textVecEmbedder struct {
+	vecByText map[string][]float32
+}
+
+func (e *textVecEmbedder) Embed(_ context.Context, _ string, _ model.EmbedRole, texts []string) ([][]float32, error) {
+	out := make([][]float32, len(texts))
+	for i, t := range texts {
+		v, ok := e.vecByText[t]
+		if !ok {
+			return nil, fmt.Errorf("textVecEmbedder: no vector for %q", t)
+		}
+		out[i] = v
+	}
+	return out, nil
+}
+
+func relatedChunk(id uint64, relPath, text string) model.ChunkTask {
+	return model.NewChunkTask(id, text, "text", model.ChunkMetadata{
+		ChunkID: id,
+		RelPath: relPath,
+		DocType: "txt",
+		RepType: "raw_text",
+		Snippet: text,
+		Span:    model.Span{Kind: "lines", StartLine: 1, EndLine: 1},
+	})
+}
+
+// newRelatedService wires an HNSW index + fake store + text->vector embedder over
+// a fixed 4-chunk corpus and returns the service ready for Related calls.
+func newRelatedService(t *testing.T) *Service {
+	t.Helper()
+	chunks := map[uint64]model.ChunkTask{
+		1: relatedChunk(1, "docs/a.txt", "alpha"),
+		2: relatedChunk(2, "docs/a.txt", "alpha-two"),
+		3: relatedChunk(3, "docs/b.txt", "beta"),
+		4: relatedChunk(4, "other/c.txt", "gamma"),
+	}
+	vecByText := map[string][]float32{
+		"alpha":     {1, 0},
+		"alpha-two": {0.94, 0.34}, // ~0.94 cosine to alpha, same document
+		"beta":      {0.8, 0.6},   // 0.80 cosine to alpha
+		"gamma":     {0, 1},       // 0 cosine to alpha
+	}
+	idx := index.NewHNSWIndex("")
+	for id, task := range chunks {
+		addVecP(t, idx, id, vecByText[task.Text], task.Metadata.RelPath, task.Metadata.DocType)
+	}
+	svc := NewService(&relatedFakeStore{chunks: chunks}, idx, &textVecEmbedder{vecByText: vecByText}, nil)
+	for id, task := range chunks {
+		svc.SetChunkMetadata(id, task.Metadata.ToSearchHit())
+	}
+	return svc
+}
+
+func hitIDs(hits []model.SearchHit) []uint64 {
+	ids := make([]uint64, len(hits))
+	for i, h := range hits {
+		ids[i] = h.ChunkID
+	}
+	return ids
+}
+
+func containsID(ids []uint64, want uint64) bool {
+	for _, id := range ids {
+		if id == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestRelated_ChunkID_ExcludesSameDocument(t *testing.T) {
+	svc := newRelatedService(t)
+	res, err := svc.Related(context.Background(), model.RelatedQuery{
+		SourceChunkID:       1,
+		K:                   10,
+		ExcludeSameDocument: true,
+	})
+	if err != nil {
+		t.Fatalf("Related: %v", err)
+	}
+	if !res.HasSourceChunkID || res.SourceChunkID != 1 {
+		t.Fatalf("source_chunk_id echo = (%v,%d), want (true,1)", res.HasSourceChunkID, res.SourceChunkID)
+	}
+	if res.SourceRelPath != "docs/a.txt" {
+		t.Fatalf("source_rel_path = %q, want docs/a.txt", res.SourceRelPath)
+	}
+	if res.IndexUsed != "text" {
+		t.Fatalf("index_used = %q, want text", res.IndexUsed)
+	}
+	ids := hitIDs(res.Hits)
+	// The source chunk (1) and its same-document sibling (2) are both excluded.
+	if want := []uint64{3, 4}; fmt.Sprint(ids) != fmt.Sprint(want) {
+		t.Fatalf("hits = %v, want %v (source + same-document excluded)", ids, want)
+	}
+}
+
+func TestRelated_ChunkID_KeepsSameDocumentWhenNotExcluded(t *testing.T) {
+	svc := newRelatedService(t)
+	res, err := svc.Related(context.Background(), model.RelatedQuery{
+		SourceChunkID:       1,
+		K:                   10,
+		ExcludeSameDocument: false,
+	})
+	if err != nil {
+		t.Fatalf("Related: %v", err)
+	}
+	ids := hitIDs(res.Hits)
+	if containsID(ids, 1) {
+		t.Fatalf("hits = %v, must never contain the source chunk itself", ids)
+	}
+	if !containsID(ids, 2) {
+		t.Fatalf("hits = %v, expected same-document sibling (2) when exclude_same_document=false", ids)
+	}
+	// Highest-similarity survivor is the same-document sibling.
+	if ids[0] != 2 {
+		t.Fatalf("hits[0] = %d, want 2 (nearest neighbour)", ids[0])
+	}
+}
+
+func TestRelated_RelPath_ExcludesWholeDocument(t *testing.T) {
+	svc := newRelatedService(t)
+	res, err := svc.Related(context.Background(), model.RelatedQuery{
+		SourceRelPath: "docs/a.txt",
+		K:             10,
+		// exclude_same_document is a no-op for a rel_path request even when false.
+		ExcludeSameDocument: false,
+	})
+	if err != nil {
+		t.Fatalf("Related: %v", err)
+	}
+	if res.HasSourceChunkID {
+		t.Fatalf("source_chunk_id must be omitted for a rel_path request")
+	}
+	if res.SourceRelPath != "docs/a.txt" {
+		t.Fatalf("source_rel_path = %q, want docs/a.txt", res.SourceRelPath)
+	}
+	ids := hitIDs(res.Hits)
+	if containsID(ids, 1) || containsID(ids, 2) {
+		t.Fatalf("hits = %v, a document is never related to itself (chunks 1,2 must be excluded)", ids)
+	}
+	if want := []uint64{3, 4}; fmt.Sprint(ids) != fmt.Sprint(want) {
+		t.Fatalf("hits = %v, want %v", ids, want)
+	}
+}
+
+func TestRelated_FilterPassthrough(t *testing.T) {
+	svc := newRelatedService(t)
+	res, err := svc.Related(context.Background(), model.RelatedQuery{
+		SourceChunkID:       1,
+		K:                   10,
+		ExcludeSameDocument: true,
+		PathPrefix:          "other",
+	})
+	if err != nil {
+		t.Fatalf("Related: %v", err)
+	}
+	ids := hitIDs(res.Hits)
+	if want := []uint64{4}; fmt.Sprint(ids) != fmt.Sprint(want) {
+		t.Fatalf("hits = %v, want %v (path_prefix=other keeps only other/c.txt)", ids, want)
+	}
+}
+
+func TestRelated_UnknownChunkIDIsSourceNotFound(t *testing.T) {
+	svc := newRelatedService(t)
+	_, err := svc.Related(context.Background(), model.RelatedQuery{SourceChunkID: 999, K: 5})
+	if err == nil {
+		t.Fatal("expected error for unknown chunk_id")
+	}
+	if err != model.ErrRelatedSourceNotFound {
+		t.Fatalf("err = %v, want ErrRelatedSourceNotFound", err)
+	}
+}
+
+func TestRelated_UnknownRelPathIsSourceNotFound(t *testing.T) {
+	svc := newRelatedService(t)
+	_, err := svc.Related(context.Background(), model.RelatedQuery{SourceRelPath: "nope/missing.txt", K: 5})
+	if err != model.ErrRelatedSourceNotFound {
+		t.Fatalf("err = %v, want ErrRelatedSourceNotFound", err)
+	}
+}
+
+func TestRelated_NotSupportedStore(t *testing.T) {
+	// A store that does not implement relatedChunkStore degrades to not-supported.
+	idx := index.NewHNSWIndex("")
+	svc := NewService(nil, idx, &textVecEmbedder{vecByText: map[string][]float32{}}, nil)
+	_, err := svc.Related(context.Background(), model.RelatedQuery{SourceChunkID: 1, K: 5})
+	if err != model.ErrRelatedNotSupported {
+		t.Fatalf("err = %v, want ErrRelatedNotSupported", err)
+	}
+}

--- a/internal/store/related_chunks_test.go
+++ b/internal/store/related_chunks_test.go
@@ -1,0 +1,78 @@
+package store
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// insertRelatedChunk inserts one chunk (pending) for the given document.
+func insertRelatedChunk(t *testing.T, st *SQLiteStore, id uint64, relPath, text, indexKind string) {
+	t.Helper()
+	task := model.NewChunkTask(id, text, indexKind, model.ChunkMetadata{
+		ChunkID: id,
+		RelPath: relPath,
+		DocType: "txt",
+		RepType: "raw_text",
+	})
+	if err := st.UpsertChunkTask(context.Background(), task); err != nil {
+		t.Fatalf("UpsertChunkTask(%d): %v", id, err)
+	}
+}
+
+// TestEmbeddedChunksByPath returns only embedded, non-deleted chunks of one
+// document, ordered by chunk_id, carrying text + index_kind — the seed material
+// dir2mcp_related's rel_path path aggregates (SPEC §15.12).
+func TestEmbeddedChunksByPath(t *testing.T) {
+	ctx := context.Background()
+	st := NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+
+	insertRelatedChunk(t, st, 1, "docs/a.txt", "alpha", "text")
+	insertRelatedChunk(t, st, 2, "docs/a.txt", "alpha-two", "code")
+	insertRelatedChunk(t, st, 3, "docs/a.txt", "pending-not-embedded", "text")
+	insertRelatedChunk(t, st, 4, "docs/b.txt", "beta", "text")
+
+	// Only 1, 2 (of doc a) and 4 are embedded; chunk 3 stays pending.
+	if err := st.MarkEmbedded(ctx, []uint64{1, 2, 4}); err != nil {
+		t.Fatalf("MarkEmbedded: %v", err)
+	}
+
+	got, err := st.EmbeddedChunksByPath(ctx, "docs/a.txt")
+	if err != nil {
+		t.Fatalf("EmbeddedChunksByPath(docs/a.txt): %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d chunks, want 2 (embedded only, pending excluded): %+v", len(got), got)
+	}
+	if got[0].Label != 1 || got[1].Label != 2 {
+		t.Fatalf("chunk order = [%d %d], want [1 2] (ascending chunk_id)", got[0].Label, got[1].Label)
+	}
+	if got[0].Text != "alpha" || got[0].IndexKind != "text" {
+		t.Fatalf("chunk 1 = (%q,%q), want (alpha,text)", got[0].Text, got[0].IndexKind)
+	}
+	if got[1].IndexKind != "code" {
+		t.Fatalf("chunk 2 index_kind = %q, want code", got[1].IndexKind)
+	}
+
+	other, err := st.EmbeddedChunksByPath(ctx, "docs/b.txt")
+	if err != nil {
+		t.Fatalf("EmbeddedChunksByPath(docs/b.txt): %v", err)
+	}
+	if len(other) != 1 || other[0].Label != 4 {
+		t.Fatalf("docs/b.txt = %+v, want single chunk 4", other)
+	}
+
+	empty, err := st.EmbeddedChunksByPath(ctx, "docs/does-not-exist.txt")
+	if err != nil {
+		t.Fatalf("EmbeddedChunksByPath(missing): %v", err)
+	}
+	if len(empty) != 0 {
+		t.Fatalf("missing document = %+v, want empty (resolves to no indexed chunk)", empty)
+	}
+}

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -1778,6 +1778,99 @@ LEFT JOIN documents d ON d.rel_path = tc.rel_path`, int64(chunkID))
 	return t, thash, nil
 }
 
+// EmbeddedChunksByPath returns the embedded (status='ok'), non-deleted chunks of
+// one document (corpus-relative rel_path), ordered by chunk_id. It is the store
+// half of dir2mcp_related's (SPEC §15.12) rel_path seed: the tool aggregates the
+// returned chunks' vectors as the query-by-example seed and excludes every one of
+// them from the neighbours (a document is never related to itself). A rel_path
+// that resolves to no embedded chunk returns an empty slice (the tool maps that
+// to INVALID_FIELD — the source could not be located).
+func (s *SQLiteStore) EmbeddedChunksByPath(ctx context.Context, relPath string) ([]model.ChunkTask, error) {
+	normalizedPath, err := normalizeRelPath(relPath)
+	if err != nil {
+		return nil, err
+	}
+	db, err := s.ensureDB(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer s.ReleaseDB()
+
+	rows, err := db.QueryContext(ctx, `
+WITH filtered_chunks AS (
+  SELECT c.chunk_id, c.rel_path, c.doc_type, c.rep_type, c.text, c.index_kind, c.modality, c.media_ref, c.language
+  FROM chunks c
+  WHERE c.rel_path = ? AND c.embedding_status = 'ok' AND c.deleted = 0
+),
+ranked_spans AS (
+  SELECT s.chunk_id, s.span_kind, s.start, s."end", s.extra_json,
+         ROW_NUMBER() OVER (PARTITION BY s.chunk_id ORDER BY s.span_id) AS rn
+  FROM spans s
+  JOIN filtered_chunks fc ON fc.chunk_id = s.chunk_id
+)
+SELECT fc.chunk_id, fc.rel_path, fc.doc_type, fc.rep_type, fc.text, fc.index_kind,
+       COALESCE(sp.span_kind, ''), COALESCE(sp.start, 0), COALESCE(sp.end, 0), COALESCE(sp.extra_json, ''),
+       COALESCE(d.title, ''), fc.modality, fc.media_ref, fc.language, COALESCE(d.mtime_unix, 0)
+FROM filtered_chunks fc
+LEFT JOIN ranked_spans sp ON sp.chunk_id = fc.chunk_id AND sp.rn = 1
+LEFT JOIN documents d ON d.rel_path = fc.rel_path
+ORDER BY fc.chunk_id`, normalizedPath)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []model.ChunkTask
+	for rows.Next() {
+		var (
+			chunkID   int64
+			rp        string
+			docType   string
+			repType   string
+			text      string
+			kind      string
+			spanK     string
+			spanS     int
+			spanE     int
+			spanExtra string
+			title     string
+			modality  string
+			mediaRef  string
+			language  string
+			mtimeUnix int64
+		)
+		if err := rows.Scan(&chunkID, &rp, &docType, &repType, &text, &kind, &spanK, &spanS, &spanE, &spanExtra, &title, &modality, &mediaRef, &language, &mtimeUnix); err != nil {
+			return nil, err
+		}
+		if chunkID <= 0 {
+			return nil, fmt.Errorf("invalid non-positive chunk_id from database: %d", chunkID)
+		}
+		uid := uint64(chunkID)
+		span := spanFromRow(spanK, spanS, spanE, spanExtra)
+		out = append(out, model.ChunkTask{
+			Label:     uid,
+			Text:      text,
+			IndexKind: kind,
+			Modality:  modality,
+			MediaRef:  mediaRef,
+			Metadata: model.ChunkMetadata{
+				ChunkID:   uid,
+				RelPath:   rp,
+				Title:     title,
+				DocType:   docType,
+				RepType:   repType,
+				Snippet:   snippet(text, 240),
+				Span:      span,
+				Modality:  modality,
+				MediaRef:  mediaRef,
+				Language:  language,
+				MTimeUnix: mtimeUnix,
+			},
+		})
+	}
+	return out, rows.Err()
+}
+
 func (s *SQLiteStore) MarkDocumentDeleted(ctx context.Context, relPath string) error {
 	normalizedPath, err := normalizeRelPath(relPath)
 	if err != nil {

--- a/tests/mcp/related_test.go
+++ b/tests/mcp/related_test.go
@@ -1,0 +1,253 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// relatedRetrieverStub is a model.Retriever that additionally implements
+// model.RelatedSearcher, capturing the RelatedQuery the dir2mcp_related handler
+// forwards and returning a canned RelatedResult (or a canned error).
+type relatedRetrieverStub struct {
+	lastQuery model.RelatedQuery
+	called    bool
+	result    model.RelatedResult
+	err       error
+}
+
+func (s *relatedRetrieverStub) Search(context.Context, model.SearchQuery) ([]model.SearchHit, error) {
+	return nil, model.ErrNotImplemented
+}
+func (s *relatedRetrieverStub) Ask(context.Context, string, model.SearchQuery) (model.AskResult, error) {
+	return model.AskResult{}, model.ErrNotImplemented
+}
+func (s *relatedRetrieverStub) OpenFile(context.Context, string, model.Span, int) (string, error) {
+	return "", model.ErrNotImplemented
+}
+func (s *relatedRetrieverStub) Stats(context.Context) (model.Stats, error) {
+	return model.Stats{}, model.ErrNotImplemented
+}
+func (s *relatedRetrieverStub) IndexingComplete(context.Context) (bool, error) { return true, nil }
+
+func (s *relatedRetrieverStub) Related(_ context.Context, q model.RelatedQuery) (model.RelatedResult, error) {
+	s.called = true
+	s.lastQuery = q
+	if s.err != nil {
+		return model.RelatedResult{}, s.err
+	}
+	res := s.result
+	res.K = q.K
+	if q.SourceChunkID != 0 {
+		res.SourceChunkID = q.SourceChunkID
+		res.HasSourceChunkID = true
+	}
+	if res.SourceRelPath == "" {
+		res.SourceRelPath = q.SourceRelPath
+	}
+	if res.IndexUsed == "" {
+		res.IndexUsed = "text"
+	}
+	return res, nil
+}
+
+var _ model.Retriever = (*relatedRetrieverStub)(nil)
+var _ model.RelatedSearcher = (*relatedRetrieverStub)(nil)
+
+func relatedStructured(t *testing.T, body []byte) map[string]interface{} {
+	t.Helper()
+	var env struct {
+		Result struct {
+			StructuredContent map[string]interface{} `json:"structuredContent"`
+			IsError           bool                   `json:"isError"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(body, &env); err != nil {
+		t.Fatalf("decode: %v body=%s", err, body)
+	}
+	if env.Result.IsError {
+		t.Fatalf("unexpected tool error: %s", body)
+	}
+	return env.Result.StructuredContent
+}
+
+func TestMCPRelated_ChunkIDForwardedAndEchoed(t *testing.T) {
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+	retriever := &relatedRetrieverStub{result: model.RelatedResult{
+		SourceRelPath: "docs/a.txt",
+		Hits:          []model.SearchHit{{ChunkID: 7, RelPath: "docs/b.txt", Score: 0.9, Snippet: "hi", Span: model.Span{Kind: "lines", StartLine: 1, EndLine: 2}}},
+	}}
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"dir2mcp_related","arguments":{"chunk_id":5,"k":3,"exclude_same_document":false}}}`)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d body=%s", resp.StatusCode, string(payload))
+	}
+	if retriever.lastQuery.SourceChunkID != 5 {
+		t.Fatalf("SourceChunkID = %d, want 5", retriever.lastQuery.SourceChunkID)
+	}
+	if retriever.lastQuery.SourceRelPath != "" {
+		t.Fatalf("SourceRelPath = %q, want empty for a chunk_id request", retriever.lastQuery.SourceRelPath)
+	}
+	if retriever.lastQuery.ExcludeSameDocument {
+		t.Fatal("ExcludeSameDocument = true, want false (forwarded verbatim)")
+	}
+	if retriever.lastQuery.K != 3 {
+		t.Fatalf("K = %d, want 3", retriever.lastQuery.K)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	sc := relatedStructured(t, body)
+	if got, ok := sc["source_chunk_id"]; !ok || int(got.(float64)) != 5 {
+		t.Fatalf("source_chunk_id = %v, want 5", sc["source_chunk_id"])
+	}
+	if sc["source_rel_path"] != "docs/a.txt" {
+		t.Fatalf("source_rel_path = %v, want docs/a.txt", sc["source_rel_path"])
+	}
+	if sc["index_used"] != "text" {
+		t.Fatalf("index_used = %v, want text", sc["index_used"])
+	}
+}
+
+func TestMCPRelated_RelPathOmitsSourceChunkID(t *testing.T) {
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+	retriever := &relatedRetrieverStub{result: model.RelatedResult{Hits: []model.SearchHit{}}}
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"dir2mcp_related","arguments":{"rel_path":"docs/a.txt","k":5,"path_prefix":"docs","languages":["en"],"date_from":"2026-01-01"}}}`)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d body=%s", resp.StatusCode, string(payload))
+	}
+	if retriever.lastQuery.SourceRelPath != "docs/a.txt" {
+		t.Fatalf("SourceRelPath = %q, want docs/a.txt", retriever.lastQuery.SourceRelPath)
+	}
+	if retriever.lastQuery.PathPrefix != "docs" || len(retriever.lastQuery.Languages) != 1 || retriever.lastQuery.Languages[0] != "en" {
+		t.Fatalf("filters not forwarded: %+v", retriever.lastQuery)
+	}
+	if retriever.lastQuery.DateFrom == 0 {
+		t.Fatal("date_from not forwarded")
+	}
+	body, _ := io.ReadAll(resp.Body)
+	sc := relatedStructured(t, body)
+	if _, ok := sc["source_chunk_id"]; ok {
+		t.Fatalf("source_chunk_id must be omitted for a rel_path request, got %v", sc["source_chunk_id"])
+	}
+	if sc["source_rel_path"] != "docs/a.txt" {
+		t.Fatalf("source_rel_path = %v, want docs/a.txt", sc["source_rel_path"])
+	}
+}
+
+func TestMCPRelated_OneOfViolationBoth(t *testing.T) {
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+	retriever := &relatedRetrieverStub{}
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"dir2mcp_related","arguments":{"chunk_id":1,"rel_path":"docs/a.txt"}}}`)
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	if got := string(body); !containsCanonicalCode(got, "INVALID_FIELD") {
+		t.Fatalf("supplying both chunk_id and rel_path must be INVALID_FIELD, body=%s", got)
+	}
+	if retriever.called {
+		t.Fatal("retriever.Related must not be called on a oneOf violation")
+	}
+}
+
+func TestMCPRelated_OneOfViolationNeither(t *testing.T) {
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+	retriever := &relatedRetrieverStub{}
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"dir2mcp_related","arguments":{"k":5}}}`)
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	if got := string(body); !containsCanonicalCode(got, "INVALID_FIELD") {
+		t.Fatalf("supplying neither chunk_id nor rel_path must be INVALID_FIELD, body=%s", got)
+	}
+	if retriever.called {
+		t.Fatal("retriever.Related must not be called on a oneOf violation")
+	}
+}
+
+func TestMCPRelated_SourceNotFoundIsInvalidField(t *testing.T) {
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+	retriever := &relatedRetrieverStub{err: model.ErrRelatedSourceNotFound}
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"dir2mcp_related","arguments":{"chunk_id":999}}}`)
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	if got := string(body); !containsCanonicalCode(got, "INVALID_FIELD") {
+		t.Fatalf("an unresolvable source must be INVALID_FIELD, body=%s", got)
+	}
+}
+
+func TestMCPRelated_ExcludeSameDocumentDefaultsTrue(t *testing.T) {
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+	retriever := &relatedRetrieverStub{result: model.RelatedResult{SourceRelPath: "docs/a.txt", Hits: []model.SearchHit{}}}
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"dir2mcp_related","arguments":{"chunk_id":5}}}`)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d body=%s", resp.StatusCode, string(payload))
+	}
+	if !retriever.lastQuery.ExcludeSameDocument {
+		t.Fatal("exclude_same_document must default to true when omitted")
+	}
+}
+
+func TestMCPRelated_UnknownArgumentRejected(t *testing.T) {
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+	retriever := &relatedRetrieverStub{}
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"dir2mcp_related","arguments":{"chunk_id":1,"language_match":"strict"}}}`)
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	if got := string(body); !containsCanonicalCode(got, "INVALID_FIELD") {
+		t.Fatalf("an undeclared argument must be INVALID_FIELD, body=%s", got)
+	}
+	if retriever.called {
+		t.Fatal("retriever.Related must not be called when an undeclared argument is present")
+	}
+}

--- a/tests/retrieval/related_test.go
+++ b/tests/retrieval/related_test.go
@@ -1,4 +1,4 @@
-package retrieval
+package tests
 
 import (
 	"context"
@@ -8,6 +8,7 @@ import (
 
 	"github.com/dirstral/dir2mcp/internal/index"
 	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
 )
 
 // relatedFakeStore is a minimal model.Store that also satisfies the
@@ -82,7 +83,7 @@ func relatedChunk(id uint64, relPath, text string) model.ChunkTask {
 
 // newRelatedService wires an HNSW index + fake store + text->vector embedder over
 // a fixed 4-chunk corpus and returns the service ready for Related calls.
-func newRelatedService(t *testing.T) *Service {
+func newRelatedService(t *testing.T) *retrieval.Service {
 	t.Helper()
 	chunks := map[uint64]model.ChunkTask{
 		1: relatedChunk(1, "docs/a.txt", "alpha"),
@@ -100,7 +101,7 @@ func newRelatedService(t *testing.T) *Service {
 	for id, task := range chunks {
 		addVecP(t, idx, id, vecByText[task.Text], task.Metadata.RelPath, task.Metadata.DocType)
 	}
-	svc := NewService(&relatedFakeStore{chunks: chunks}, idx, &textVecEmbedder{vecByText: vecByText}, nil)
+	svc := retrieval.NewService(&relatedFakeStore{chunks: chunks}, idx, &textVecEmbedder{vecByText: vecByText}, nil)
 	for id, task := range chunks {
 		svc.SetChunkMetadata(id, task.Metadata.ToSearchHit())
 	}
@@ -113,15 +114,6 @@ func hitIDs(hits []model.SearchHit) []uint64 {
 		ids[i] = h.ChunkID
 	}
 	return ids
-}
-
-func containsID(ids []uint64, want uint64) bool {
-	for _, id := range ids {
-		if id == want {
-			return true
-		}
-	}
-	return false
 }
 
 func TestRelated_ChunkID_ExcludesSameDocument(t *testing.T) {
@@ -238,7 +230,7 @@ func TestRelated_UnknownRelPathIsSourceNotFound(t *testing.T) {
 func TestRelated_NotSupportedStore(t *testing.T) {
 	// A store that does not implement relatedChunkStore degrades to not-supported.
 	idx := index.NewHNSWIndex("")
-	svc := NewService(nil, idx, &textVecEmbedder{vecByText: map[string][]float32{}}, nil)
+	svc := retrieval.NewService(nil, idx, &textVecEmbedder{vecByText: map[string][]float32{}}, nil)
 	_, err := svc.Related(context.Background(), model.RelatedQuery{SourceChunkID: 1, K: 5})
 	if err != model.ErrRelatedNotSupported {
 		t.Fatalf("err = %v, want ErrRelatedNotSupported", err)

--- a/tests/store/related_chunks_test.go
+++ b/tests/store/related_chunks_test.go
@@ -1,4 +1,4 @@
-package store
+package tests
 
 import (
 	"context"
@@ -6,10 +6,11 @@ import (
 	"testing"
 
 	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
 )
 
 // insertRelatedChunk inserts one chunk (pending) for the given document.
-func insertRelatedChunk(t *testing.T, st *SQLiteStore, id uint64, relPath, text, indexKind string) {
+func insertRelatedChunk(t *testing.T, st *store.SQLiteStore, id uint64, relPath, text, indexKind string) {
 	t.Helper()
 	task := model.NewChunkTask(id, text, indexKind, model.ChunkMetadata{
 		ChunkID: id,
@@ -27,7 +28,7 @@ func insertRelatedChunk(t *testing.T, st *SQLiteStore, id uint64, relPath, text,
 // dir2mcp_related's rel_path path aggregates (SPEC §15.12).
 func TestEmbeddedChunksByPath(t *testing.T) {
 	ctx := context.Background()
-	st := NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
 	if err := st.Init(ctx); err != nil {
 		t.Fatalf("init: %v", err)
 	}


### PR DESCRIPTION
## Summary

Adds the **`dir2mcp_related`** MCP tool (SPEC §15.12, dir2mcp #324): query-by-example "more like this" retrieval over the existing vector index. Given a seed **chunk** (`chunk_id`) or **document** (`rel_path`), it ranks indexed segments by embedding similarity to the seed's vector(s), applies the §9.5/§9.6 filters, excludes the seed itself (and — for a `chunk_id` request with `exclude_same_document` — the seed's whole document), and returns the top-`k` `Hit`s ordered by **pure vector similarity** with an ascending `chunk_id` tiebreak. The reranker does not apply, and partial-index state is reflected exactly as `dir2mcp_search` does.

The seed vector is reconstructed by re-embedding the seed segment's stored text at the index-time embed role, so the same ranking is produced across every index backend (memory/disk/qdrant/pgvector) without a per-backend vector-readback capability. A `rel_path` seed aggregates (mean-pools) the document's chunk vectors.

Closes #324.

## Spec governance

Re-pins the `dirstral-spec` submodule to `55151bd` (the merged §15.12 spec, `spec/tools/schemas/related.json`).

## Net diff

- `internal/protocol/constants.go` — `ToolNameRelated`
- `internal/model/{interfaces,types,errors}.go` — `RelatedQuery`/`RelatedResult`, `RelatedSearcher` capability, `ErrRelatedSourceNotFound`/`ErrRelatedNotSupported`
- `internal/retrieval/related.go` — `Service.Related` + NN core (seed resolution, per-axis seed embedding, filter/exclude/sort/truncate)
- `internal/store/sqlite_store.go` — `EmbeddedChunksByPath` (resolves a `rel_path` seed's embedded chunks)
- `internal/mcp/tools.go` — tool registration, handler, input/output schemas (`oneOf` `chunk_id`/`rel_path`, `additionalProperties:false`)
- tests + submodule re-pin

## Test plan

- `internal/retrieval/related_test.go` — NN core: `chunk_id` path, `rel_path` path, self-exclusion, `exclude_same_document` on/off, filter passthrough, source-not-found, not-supported store.
- `tests/mcp/related_test.go` — MCP integration: `chunk_id`/`rel_path` forwarding + echo, `oneOf` violations (both/neither → `INVALID_FIELD`), source-not-found → `INVALID_FIELD`, `exclude_same_document` default true, undeclared-arg rejection.
- `internal/store/related_chunks_test.go` — `EmbeddedChunksByPath` returns embedded-only, ordered, with text + index_kind.
- `internal/mcp/output_schema_conformance_test.go` — `dir2mcp_related` structuredContent validates against the output schema.
- `make ci` green; `go vet`, `gocyclo -over 15`, `gofmt` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `dir2mcp_related` tool for finding content similar to a specified chunk or document path.
  * Supports text and code search, filtering, result limits, and optional same-document exclusions.
  * Returns similarity-ranked results with source and indexing information.

* **Bug Fixes**
  * Improved handling and reporting of unavailable indexes and missing source content.

* **Tests**
  * Added coverage for request validation, filtering, exclusions, response formatting, and retrieval behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->