### PR TITLE
feat(ingest,avutil,config): per-track transcription via media.stt.tracks (#567)

### DIFF
--- a/internal/avutil/avutil.go
+++ b/internal/avutil/avutil.go
@@ -475,13 +475,47 @@ func ExtractSegmentURL(ctx context.Context, url, srcExt string, startMS, endMS i
 // It returns ErrToolNotFound when ffprobe/ffmpeg are not installed and
 // ErrNoAudioStream when the media carries no audio track (nothing to transcribe).
 func ExtractAudioTrack(ctx context.Context, path string) ([]byte, error) {
-	// Probe first so a video with no audio track is reported as the distinct
-	// ErrNoAudioStream (a graceful "no transcript") instead of an opaque ffmpeg
-	// "does not contain any stream" failure. A probe error other than a missing
-	// tool is not fatal here: fall through and let ffmpeg surface the real error.
+	return extractAudioTrack(ctx, path, -1)
+}
+
+// ExtractAudioTrackIndex demuxes a SPECIFIC audio stream — selected by its
+// 0-based AUDIO-relative index (0 == the first audio stream, the one
+// ExtractAudioTrack picks by default) — into the same compact mono 16 kHz AAC
+// (.m4a) clip ExtractAudioTrack produces, so each audio track of a multi-track
+// container (an original mix plus per-language dubs, a music-&-effects track)
+// can be transcribed independently (SPEC §8.6.12, issue #567).
+//
+// The index maps to ffmpeg's `-map 0:a:<audioIndex>` stream selector, which is
+// audio-relative (matching MediaInfo.AudioStreams ordering), NOT the absolute
+// container stream index. An audioIndex past the container's audio-stream count
+// is reported as ErrNoAudioStream (the track does not exist) rather than an
+// opaque ffmpeg failure, so a caller can degrade that track gracefully. It
+// returns ErrToolNotFound when ffprobe/ffmpeg are not installed.
+func ExtractAudioTrackIndex(ctx context.Context, path string, audioIndex int) ([]byte, error) {
+	if audioIndex < 0 {
+		return nil, fmt.Errorf("avutil: negative audio track index %d for %q", audioIndex, path)
+	}
+	return extractAudioTrack(ctx, path, audioIndex)
+}
+
+// extractAudioTrack is the shared implementation behind ExtractAudioTrack (the
+// default/first audio stream, audioIndex < 0 ⇒ ffmpeg's `-vn` default mapping)
+// and ExtractAudioTrackIndex (a specific audio-relative stream, audioIndex >= 0
+// ⇒ `-map 0:a:<audioIndex>`). Both emit an identical mono 16 kHz AAC clip; the
+// only difference is stream selection.
+func extractAudioTrack(ctx context.Context, path string, audioIndex int) ([]byte, error) {
+	// Probe first so a video with no audio track — or a requested track index past
+	// the audio-stream count — is reported as the distinct ErrNoAudioStream (a
+	// graceful "no transcript") instead of an opaque ffmpeg "does not contain any
+	// stream" failure. A probe error other than a missing tool is not fatal here:
+	// fall through and let ffmpeg surface the real error.
 	if info, err := ProbeMediaInfo(ctx, path); err != nil {
 		if errors.Is(err, ErrToolNotFound) {
 			return nil, ErrToolNotFound
+		}
+	} else if audioIndex >= 0 {
+		if audioIndex >= len(info.AudioStreams) {
+			return nil, ErrNoAudioStream
 		}
 	} else if strings.TrimSpace(info.AudioCodec) == "" {
 		return nil, ErrNoAudioStream
@@ -499,16 +533,28 @@ func ExtractAudioTrack(ctx context.Context, path string) ([]byte, error) {
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 	outPath := filepath.Join(tmpDir, "audio.m4a")
 
-	cmd := exec.CommandContext(ctx, bin,
+	args := []string{
 		"-nostdin",
 		"-v", "error",
 		"-i", path,
-		"-vn",
+	}
+	if audioIndex >= 0 {
+		// Select exactly the requested audio-relative stream (0:a:<N>) and drop
+		// video; without an explicit map ffmpeg would pick its default audio stream.
+		args = append(args, "-map", fmt.Sprintf("0:a:%d", audioIndex))
+	} else {
+		// Default selection: drop video, let ffmpeg choose the default audio stream
+		// (byte-for-byte the historical ExtractAudioTrack behavior).
+		args = append(args, "-vn")
+	}
+	args = append(args,
 		"-ac", "1",
 		"-ar", "16000",
 		"-c:a", "aac",
 		"-y", outPath,
 	)
+
+	cmd := exec.CommandContext(ctx, bin, args...)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -781,6 +782,18 @@ type Config struct {
 	// The floor only applies when coverage is DECLARED (a non-empty stt_languages);
 	// unknown coverage never trips it under either mode.
 	MediaSTTOnUncoveredLanguage string
+	// MediaSTTTracks selects WHICH audio tracks of a multi-track media container
+	// are transcribed (config `media.stt.tracks`, SPEC §8.6.12, issue #567). It is
+	// the RAW, unvalidated form as written in config: an empty slice (the default)
+	// or the single keyword `first` means "only the first audio stream" (today's
+	// behavior and cost); `all` means "every audio track"; a list of 0-based
+	// audio-relative indices (e.g. `0`, `2`) means exactly those tracks. Parse it
+	// into the resolved selection with ParseSTTTracks, which also rejects invalid
+	// forms (duplicate/negative indices, a keyword mixed with indices) as
+	// CONFIG_INVALID. Track 0 always keeps the bare `transcript` rep_type; each
+	// additional track N>=1 gets a `transcript@t<N>` rep_type, so a single-track
+	// corpus is byte-for-byte unchanged.
+	MediaSTTTracks []string
 
 	// MediaBatchTwoPhase / MediaBatchProgress / MediaBatchManifest configure the
 	// optional batch-ergonomics surface for large-archive media ingests (SPEC
@@ -852,6 +865,91 @@ type Config struct {
 	// bespoke flat parser. Unexported/runtime-derived: not persisted,
 	// not part of Default()/persistedConfig. Access via cfg.Providers().
 	providersDoc providersDoc
+}
+
+// STTTrackMode is the resolved kind of a media.stt.tracks selection (SPEC
+// §8.6.12).
+type STTTrackMode int
+
+const (
+	// STTTracksFirst transcribes only the container's first audio stream — the
+	// default (and today's single-track behavior and cost). It is the zero value.
+	STTTracksFirst STTTrackMode = iota
+	// STTTracksAll transcribes every audio track.
+	STTTracksAll
+	// STTTracksList transcribes exactly the explicitly-listed 0-based tracks.
+	STTTracksList
+)
+
+// STTTrackSelection is the resolved, validated media.stt.tracks selection (SPEC
+// §8.6.12). Build it from the raw config with ParseSTTTracks. For STTTracksList
+// the Indices are sorted ascending and de-duplicated so they are processed in
+// container stream order regardless of how the list was written ([2,0] ≡ [0,2]).
+type STTTrackSelection struct {
+	Mode    STTTrackMode
+	Indices []int
+}
+
+// ParseSTTTracks resolves the raw media.stt.tracks config (Config.MediaSTTTracks)
+// into an STTTrackSelection (SPEC §8.6.12). The accepted forms are:
+//
+//   - empty / unset, or the single keyword "first"  -> STTTracksFirst (default)
+//   - the single keyword "all"                      -> STTTracksAll
+//   - a list of non-negative 0-based indices        -> STTTracksList
+//
+// It rejects, as CONFIG_INVALID: an unknown keyword; a keyword mixed with
+// indices; a negative or non-integer index; a duplicate index; and an explicit
+// empty list (which would select no tracks). Whether a listed index actually
+// exists in a given media file is a per-file, runtime concern (a corpus mixes
+// files with different track counts), so an out-of-range index is NOT rejected
+// here — it is handled per file by the ingest pipeline as a track-scoped skip.
+func ParseSTTTracks(raw []string) (STTTrackSelection, error) {
+	items := make([]string, 0, len(raw))
+	for _, r := range raw {
+		if t := strings.TrimSpace(r); t != "" {
+			items = append(items, t)
+		}
+	}
+	if len(items) == 0 {
+		return STTTrackSelection{Mode: STTTracksFirst}, nil
+	}
+	// A single keyword form.
+	if len(items) == 1 {
+		switch strings.ToLower(items[0]) {
+		case "first":
+			return STTTrackSelection{Mode: STTTracksFirst}, nil
+		case "all":
+			return STTTrackSelection{Mode: STTTracksAll}, nil
+		}
+	}
+	// Otherwise every element MUST be a non-negative integer index.
+	seen := make(map[int]struct{}, len(items))
+	indices := make([]int, 0, len(items))
+	for _, it := range items {
+		switch strings.ToLower(it) {
+		case "first", "all":
+			return STTTrackSelection{}, fmt.Errorf(
+				"CONFIG_INVALID: media.stt.tracks may not mix the keyword %q with track indices; use %q alone or a list of 0-based indices",
+				strings.ToLower(it), strings.ToLower(it))
+		}
+		n, err := strconv.Atoi(it)
+		if err != nil {
+			return STTTrackSelection{}, fmt.Errorf(
+				"CONFIG_INVALID: media.stt.tracks entry %q is not a valid track index; expected \"first\", \"all\", or 0-based integers", it)
+		}
+		if n < 0 {
+			return STTTrackSelection{}, fmt.Errorf(
+				"CONFIG_INVALID: media.stt.tracks index %d is negative; track indices are 0-based", n)
+		}
+		if _, dup := seen[n]; dup {
+			return STTTrackSelection{}, fmt.Errorf(
+				"CONFIG_INVALID: media.stt.tracks lists duplicate index %d", n)
+		}
+		seen[n] = struct{}{}
+		indices = append(indices, n)
+	}
+	sort.Ints(indices)
+	return STTTrackSelection{Mode: STTTracksList, Indices: indices}, nil
 }
 
 type fileConfig struct {
@@ -962,6 +1060,7 @@ type fileConfig struct {
 	MediaSTTRequestTimeoutSec          *int
 	MediaSTTLanguageStrict             *bool
 	MediaSTTOnUncoveredLanguage        *string
+	MediaSTTTracks                     []string
 	ElevenLabsAPIKey                   *string
 	ServerTLSCertFile                  *string
 	ServerTLSKeyFile                   *string
@@ -1113,6 +1212,7 @@ type persistedConfig struct {
 	MediaSTTRequestTimeoutSec          int           `yaml:"media_stt_request_timeout_sec"`
 	MediaSTTLanguageStrict             bool          `yaml:"media_stt_language_strict"`
 	MediaSTTOnUncoveredLanguage        string        `yaml:"media_stt_on_uncovered_language"`
+	MediaSTTTracks                     []string      `yaml:"media_stt_tracks"`
 	MediaBatchTwoPhase                 bool          `yaml:"media_batch_two_phase"`
 	MediaBatchProgress                 bool          `yaml:"media_batch_progress"`
 	MediaBatchManifest                 string        `yaml:"media_batch_manifest"`
@@ -1512,6 +1612,7 @@ func buildPersistedConfig(cfg *Config) persistedConfig {
 		MediaSTTRequestTimeoutSec:          cfg.MediaSTTRequestTimeoutSec,
 		MediaSTTLanguageStrict:             cfg.MediaSTTLanguageStrict,
 		MediaSTTOnUncoveredLanguage:        cfg.MediaSTTOnUncoveredLanguage,
+		MediaSTTTracks:                     append([]string(nil), cfg.MediaSTTTracks...),
 		ServerTLSCertFile:                  cfg.ServerTLSCertFile,
 		ServerTLSKeyFile:                   cfg.ServerTLSKeyFile,
 		X402Mode:                           cfg.X402.Mode,
@@ -2400,6 +2501,9 @@ func applyMediaSTTFileParsed(cfg *Config, fc fileConfig) {
 	if fc.MediaSTTOnUncoveredLanguage != nil {
 		cfg.MediaSTTOnUncoveredLanguage = *fc.MediaSTTOnUncoveredLanguage
 	}
+	if fc.MediaSTTTracks != nil {
+		cfg.MediaSTTTracks = normalizeStringSlice(fc.MediaSTTTracks)
+	}
 }
 
 // applyMediaSubtitlesFileParsed copies the set media.subtitles.* file fields
@@ -2540,11 +2644,7 @@ func parseConfigYAML(raw []byte) (fileConfig, error) {
 			continue
 		}
 
-		value = unquoteYAMLScalar(value)
-		if strings.Contains(value, "\\n") {
-			value = strings.ReplaceAll(value, "\\n", "\n")
-		}
-		if err := setFileScalarValue(&cfg, key, value); err != nil {
+		if err := handleYAMLScalarValue(&cfg, key, value); err != nil {
 			return fileConfig{}, fmt.Errorf("line %d: %w", lineNo, err)
 		}
 	}
@@ -2552,6 +2652,24 @@ func parseConfigYAML(raw []byte) (fileConfig, error) {
 		return fileConfig{}, err
 	}
 	return cfg, nil
+}
+
+// handleYAMLScalarValue assigns a single bare (non-list, non-section) value to the
+// fileConfig field selected by key, after unescaping. A bare scalar under a
+// list-valued key (e.g. `media.stt.tracks: all`) is a single-element list, not a
+// scalar field, so it is routed to the list appender — otherwise the keyword forms
+// (`first`/`all`) of media.stt.tracks would be silently dropped by the scalar path,
+// which has no such field.
+func handleYAMLScalarValue(cfg *fileConfig, key, value string) error {
+	value = unquoteYAMLScalar(value)
+	if strings.Contains(value, "\\n") {
+		value = strings.ReplaceAll(value, "\\n", "\n")
+	}
+	if isListConfigKey(key) {
+		setFileListValue(cfg, key, value)
+		return nil
+	}
+	return setFileScalarValue(cfg, key, value)
 }
 
 // resolveYAMLKey splits a "key: value" line, prefixes the key with the
@@ -2767,6 +2885,7 @@ var configKeyAliases = map[string]string{
 	"media_stt_request_timeout_sec":           "media.stt.request_timeout_sec",
 	"media_stt_language_strict":               "media.stt.language_strict",
 	"media_stt_on_uncovered_language":         "media.stt.on_uncovered_language",
+	"media_stt_tracks":                        "media.stt.tracks",
 	"stt_provider":                            "stt.provider",
 	"stt_mistral_model":                       "stt.mistral.model",
 	"stt_elevenlabs_model":                    "stt.elevenlabs.model",
@@ -3291,44 +3410,64 @@ func setX402StringFileScalar(cfg *fileConfig, key, value string) {
 // setFileListValue appends value to the list field selected by the
 // canonicalized key, initializing the slice on first use and skipping
 // blank items.
+// appendConfigListValue appends item to *target (allocating an empty slice
+// first so a set-but-empty list is distinguishable from an unset one), skipping
+// blank items. Shared by setFileListValue and its retrieval delegation.
+func appendConfigListValue(target *[]string, item string) {
+	if *target == nil {
+		*target = []string{}
+	}
+	if strings.TrimSpace(item) == "" {
+		return
+	}
+	*target = append(*target, item)
+}
+
 func setFileListValue(cfg *fileConfig, key, value string) {
 	key = canonicalizeConfigKey(key)
-	appendValue := func(target *[]string, item string) {
-		if *target == nil {
-			*target = []string{}
-		}
-		if strings.TrimSpace(item) == "" {
-			return
-		}
-		*target = append(*target, item)
+	if setRetrievalFileListValue(cfg, key, value) {
+		return
 	}
-
 	switch key {
 	case "trusted_proxies":
-		appendValue(&cfg.TrustedProxies, value)
+		appendConfigListValue(&cfg.TrustedProxies, value)
 	case "path_excludes":
-		appendValue(&cfg.PathExcludes, value)
+		appendConfigListValue(&cfg.PathExcludes, value)
 	case "secret_patterns":
-		appendValue(&cfg.SecretPatterns, value)
+		appendConfigListValue(&cfg.SecretPatterns, value)
 	case "allowed_origins":
-		appendValue(&cfg.AllowedOrigins, value)
+		appendConfigListValue(&cfg.AllowedOrigins, value)
 	case "media.translate.target_langs":
-		appendValue(&cfg.MediaTranslateTargetLangs, value)
+		appendConfigListValue(&cfg.MediaTranslateTargetLangs, value)
+	case "media.stt.tracks":
+		appendConfigListValue(&cfg.MediaSTTTracks, value)
 	case "media.filter_words":
-		appendValue(&cfg.MediaFilterWords, value)
+		appendConfigListValue(&cfg.MediaFilterWords, value)
 	case "media.subtitles.glossary":
-		appendValue(&cfg.MediaSubtitlesGlossary, value)
+		appendConfigListValue(&cfg.MediaSubtitlesGlossary, value)
 	case "media.subtitles.drop_phrases":
-		appendValue(&cfg.MediaSubtitlesDropPhrases, value)
+		appendConfigListValue(&cfg.MediaSubtitlesDropPhrases, value)
 	case "media.subtitles.scrub_phrases":
-		appendValue(&cfg.MediaSubtitlesScrubPhrases, value)
-	case "retrieval.cross_lingual.target_langs":
-		appendValue(&cfg.CrossLingualTargetLangs, value)
-	case "retrieval.hierarchical.source_reps":
-		appendValue(&cfg.RetrievalHierarchicalSourceReps, value)
-	case "retrieval.hierarchical.levels":
-		appendValue(&cfg.RetrievalHierarchicalLevels, value)
+		appendConfigListValue(&cfg.MediaSubtitlesScrubPhrases, value)
 	}
+}
+
+// setRetrievalFileListValue appends the retrieval.* list-valued keys
+// (cross-lingual target langs #574, hierarchical source_reps/levels #329),
+// returning true when key matched. Split out of setFileListValue so it stays
+// within the gocyclo budget once media.stt.tracks (#567) lands alongside them.
+func setRetrievalFileListValue(cfg *fileConfig, key, value string) bool {
+	switch key {
+	case "retrieval.cross_lingual.target_langs":
+		appendConfigListValue(&cfg.CrossLingualTargetLangs, value)
+	case "retrieval.hierarchical.source_reps":
+		appendConfigListValue(&cfg.RetrievalHierarchicalSourceReps, value)
+	case "retrieval.hierarchical.levels":
+		appendConfigListValue(&cfg.RetrievalHierarchicalLevels, value)
+	default:
+		return false
+	}
+	return true
 }
 
 // isListConfigKey reports whether key (after canonicalization) maps to
@@ -3336,7 +3475,7 @@ func setFileListValue(cfg *fileConfig, key, value string) {
 func isListConfigKey(key string) bool {
 	key = canonicalizeConfigKey(key)
 	switch key {
-	case "trusted_proxies", "path_excludes", "secret_patterns", "allowed_origins", "media.translate.target_langs", "media.filter_words", "media.subtitles.glossary", "media.subtitles.drop_phrases", "media.subtitles.scrub_phrases", "retrieval.cross_lingual.target_langs", "retrieval.hierarchical.source_reps", "retrieval.hierarchical.levels":
+	case "trusted_proxies", "path_excludes", "secret_patterns", "allowed_origins", "media.translate.target_langs", "media.stt.tracks", "media.filter_words", "media.subtitles.glossary", "media.subtitles.drop_phrases", "media.subtitles.scrub_phrases", "retrieval.cross_lingual.target_langs", "retrieval.hierarchical.source_reps", "retrieval.hierarchical.levels":
 		return true
 	default:
 		return false
@@ -3488,6 +3627,7 @@ func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	writeInt("media_stt_request_timeout_sec", cfg.MediaSTTRequestTimeoutSec)
 	writeBool("media_stt_language_strict", cfg.MediaSTTLanguageStrict)
 	writeScalar("media_stt_on_uncovered_language", cfg.MediaSTTOnUncoveredLanguage)
+	writeList("media_stt_tracks", cfg.MediaSTTTracks)
 	writeBool("media_batch_two_phase", cfg.MediaBatchTwoPhase)
 	writeBool("media_batch_progress", cfg.MediaBatchProgress)
 	writeScalar("media_batch_manifest", cfg.MediaBatchManifest)
@@ -4436,6 +4576,13 @@ func (c *Config) validateMediaSTTNumericBounds() error {
 	}
 	if c.MediaSTTRequestTimeoutSec < 0 {
 		return fmt.Errorf("media.stt.request_timeout_sec must be non-negative (0 = client default): %d", c.MediaSTTRequestTimeoutSec)
+	}
+	// media.stt.tracks (SPEC §8.6.12): reject an invalid selection (unknown keyword,
+	// keyword-mixed-with-indices, negative/non-integer/duplicate index) at startup so
+	// a typo fails fast rather than per file. ParseSTTTracks is the single source of
+	// truth for the grammar (also used by the ingest pipeline).
+	if _, err := ParseSTTTracks(c.MediaSTTTracks); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/ingest/derivation.go
+++ b/internal/ingest/derivation.go
@@ -90,6 +90,20 @@ func (s *Service) activeDiarizeIdentity() string {
 // produces valid meta_json (and an empty recorded identity that the gate treats
 // as "always passes").
 func (s *Service) sttTranscriptMetaJSON(speakers []Speaker, text string, hasWords bool) (string, error) {
+	meta := s.sttTranscriptMeta(speakers, text, hasWords)
+	encoded, err := json.Marshal(meta)
+	if err != nil {
+		return "", err
+	}
+	return string(encoded), nil
+}
+
+// sttTranscriptMeta builds the transcriptMeta value for a bare machine-
+// transcribed transcript representation (the struct behind sttTranscriptMetaJSON).
+// It is split out so the per-track path (SPEC §8.6.12) can layer the
+// track/track_language/track_label fields onto the same base before marshaling,
+// keeping the STT-identity/language/diarization construction in one place.
+func (s *Service) sttTranscriptMeta(speakers []Speaker, text string, hasWords bool) transcriptMeta {
 	meta := transcriptMeta{
 		Source:     sttSource,
 		Language:   strings.TrimSpace(s.transcriptLanguage),
@@ -140,11 +154,7 @@ func (s *Service) sttTranscriptMetaJSON(speakers []Speaker, text string, hasWord
 			meta.Speakers = speakers
 		}
 	}
-	encoded, err := json.Marshal(meta)
-	if err != nil {
-		return "", err
-	}
-	return string(encoded), nil
+	return meta
 }
 
 // activeTranscriptIdentity is the STT (+ diarize, when active) derivation

--- a/internal/ingest/errcode_test.go
+++ b/internal/ingest/errcode_test.go
@@ -148,7 +148,7 @@ func TestTranslateOneTranscript_ProviderFailureTaggedTranslateFailed(t *testing.
 		translator: failingGenerator{},
 	}
 	doc := model.Document{RelPath: "audio/talk.mp3", DocType: "audio"}
-	err := s.translateOneTranscript(context.Background(), doc, []byte("audio"), "[00:00] hallo", "de", "en", time.Second, 0)
+	err := s.translateOneTranscript(context.Background(), doc, []byte("audio"), "[00:00] hallo", "de", "en", time.Second, 0, 0)
 	if err == nil {
 		t.Fatal("expected a translation provider failure, got nil")
 	}

--- a/internal/ingest/represent.go
+++ b/internal/ingest/represent.go
@@ -64,6 +64,30 @@ func TranscriptRepType(language string) string {
 	return RepTypeTranscript + TranscriptLangSuffix(language)
 }
 
+// TrackRepQualifier returns the rep_type track qualifier for a 0-based
+// AUDIO-relative track index (SPEC §8.6.12). Track 0 (the container's first
+// audio stream) returns the empty string so it keeps the BARE "transcript"
+// rep_type — a single-track corpus is byte-for-byte unchanged and never
+// re-derives on upgrade. Each additional track N ≥ 1 returns "@t<N>", producing
+// the distinct "transcript@t<N>" rep_type. The "@" delimiter never appears in a
+// BCP-47 language suffix (which is "-"-prefixed), so a full rep-key
+// transcript[@t<N>][-<lang>] parses the track qualifier and the language suffix
+// independently.
+func TrackRepQualifier(track int) string {
+	if track <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("@t%d", track)
+}
+
+// TranscriptRepTypeForTrack composes a transcript rep_type for a given
+// 0-based audio track and optional language (SPEC §8.6.12/§8.6.2):
+// transcript[@t<N>][-<lang>]. Track 0 with an empty language yields the bare
+// "transcript"; track 2 into English yields "transcript@t2-en".
+func TranscriptRepTypeForTrack(track int, language string) string {
+	return RepTypeTranscript + TrackRepQualifier(track) + TranscriptLangSuffix(language)
+}
+
 // RepresentationGenerator handles creation of representations from documents
 type RepresentationGenerator struct {
 	store model.RepresentationStore

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -204,6 +204,13 @@ type Service struct {
 	// avutil.ErrNoAudioStream) without requiring the ffmpeg binary.
 	ExtractAudioTrackFunc func(ctx context.Context, path string) ([]byte, error)
 
+	// ExtractAudioTrackIndexFunc overrides extraction of a SPECIFIC audio stream
+	// (0-based audio-relative index) for per-track transcription (SPEC §8.6.12,
+	// issue #567). Defaults to avutil.ExtractAudioTrackIndex (ffmpeg `-map 0:a:<N>`)
+	// when nil; tests set it to supply deterministic per-track audio bytes (or
+	// avutil.ErrNoAudioStream for a track past the count) without the ffmpeg binary.
+	ExtractAudioTrackIndexFunc func(ctx context.Context, path string, audioIndex int) ([]byte, error)
+
 	// ProbeMediaInfoFunc overrides the container/stream probe used to detect
 	// multi-track audio (issue #567). Defaults to avutil.ProbeMediaInfo (ffprobe)
 	// when nil; tests set it to supply a deterministic stream census without the
@@ -331,6 +338,18 @@ type Service struct {
 	// single processDocument entry). A rejected representation is thus counted once
 	// even when a document produces several (transcript + per-language translations).
 	quarantinedThisDoc bool
+
+	// deferGateDocError suppresses the EAGER per-document status=error marking that
+	// the output quality gate normally applies (recordQualityGateDocError), scoping a
+	// gate rejection to the failing TRACK instead of the whole document (SPEC
+	// §8.6.12). It is set only while transcribing a multi-track selection (all/list):
+	// there a rejected track's transcript is dropped and recorded as honest coverage,
+	// and the document is marked error only if EVERY selected track failed — that
+	// final decision is made by the per-track orchestrator, not per gate call. The
+	// chunk-level quarantine encoded in the returned decision is unaffected. It is
+	// per-document/per-pass state (the scan loop is sequential) and is always reset to
+	// false after the multi-track loop.
+	deferGateDocError bool
 
 	// activePass selects which work the representation generators perform for the
 	// asset currently being processed under the optional two-phase pass split
@@ -2295,25 +2314,23 @@ func (s *Service) deriveDocument(ctx context.Context, f DiscoveredFile, secretPa
 	return nil
 }
 
-// deriveTranscriptTranslations recomputes the source transcript (a cache hit, so
-// no re-transcription) and translates it, reusing the SAME derivation logic and
-// trim/alignment as the single-pass path so the resulting translated transcript
-// representations and chunks are byte-identical to single-pass (SPEC §8.6.11).
+// deriveTranscriptTranslations recomputes each selected track's source transcript
+// (a cache hit, so no re-transcription) and translates it, reusing the SAME
+// derivation logic and trim/alignment as the single-pass path so the resulting
+// translated transcript representations and chunks are byte-identical to single-pass
+// (SPEC §8.6.11). Under a multi-track selection (§8.6.12) it derives the translations
+// for every selected track under its transcript@t<N>-<lang> keys; the default single
+// track is the degenerate one-track case.
 func (s *Service) deriveTranscriptTranslations(ctx context.Context, doc model.Document, content []byte) error {
-	transcriptText, _, err := s.readOrComputeTranscriptWithWords(ctx, doc, content, "")
+	sel, err := config.ParseSTTTracks(s.cfg.MediaSTTTracks)
 	if err != nil {
 		return err
-	}
-	transcriptText = strings.TrimSpace(transcriptText)
-	if transcriptText == "" {
-		return nil
 	}
 
 	var duration time.Duration
 	if d, derr := s.probeDuration(ctx, doc); derr == nil {
 		duration = d
 	}
-
 	// Recompute the same leading-silence trim offset the transcription pass applied
 	// to the source transcript so translated time windows stay aligned (dir2mcp#258
 	// / SPEC §8.6.2). Detection is deterministic for an unchanged asset.
@@ -2323,7 +2340,37 @@ func (s *Service) deriveTranscriptTranslations(ctx context.Context, doc model.Do
 			trimOffsetMS = int(offset.Milliseconds())
 		}
 	}
-	return s.translateTranscriptRepresentations(ctx, doc, content, transcriptText, duration, trimOffsetMS)
+
+	if sel.Mode == config.STTTracksFirst {
+		return s.deriveOneTrackTranslations(ctx, doc, content, trackContext{audioIndex: 0}, duration, trimOffsetMS)
+	}
+	indices := resolveTrackIndices(sel, s.probeTrackInfo(ctx, doc))
+	if len(indices) == 0 {
+		return s.deriveOneTrackTranslations(ctx, doc, content, trackContext{audioIndex: 0}, duration, trimOffsetMS)
+	}
+	var firstErr error
+	for _, n := range indices {
+		if derr := s.deriveOneTrackTranslations(ctx, doc, content, trackContext{audioIndex: n}, duration, trimOffsetMS); derr != nil && firstErr == nil {
+			firstErr = derr
+		}
+	}
+	return firstErr
+}
+
+// deriveOneTrackTranslations reads a single track's cached source transcript and
+// produces its per-language translations (SPEC §8.6.2/§8.6.12). A cache miss here
+// means the track produced no source transcript (empty/failed in the transcription
+// pass), which is a legitimate no-op — never a re-transcription.
+func (s *Service) deriveOneTrackTranslations(ctx context.Context, doc model.Document, content []byte, tc trackContext, duration time.Duration, trimOffsetMS int) error {
+	transcriptText, _, err := s.readTrackTranscript(ctx, doc, content, tc)
+	if err != nil {
+		return err
+	}
+	transcriptText = strings.TrimSpace(transcriptText)
+	if transcriptText == "" {
+		return nil
+	}
+	return s.translateTranscriptRepresentations(ctx, doc, content, transcriptText, duration, trimOffsetMS, tc.audioIndex)
 }
 
 // readDocumentContent reads an asset's bytes through the corpus filesystem,
@@ -4018,7 +4065,14 @@ func (s *Service) screenOutputQuality(ctx context.Context, doc model.Document, k
 	// continues. This is IN ADDITION to the chunk-level quarantine encoded in the
 	// returned decision (embedding_status=error), which keeps the degenerate text
 	// out of the embedding index.
-	s.recordQualityGateDocError(ctx, doc, kind, reason)
+	//
+	// §8.6.12: while transcribing a multi-track selection the doc-error marking is
+	// DEFERRED (deferGateDocError) so a gate rejection fails only that track; the
+	// orchestrator marks the document error only if every selected track failed. The
+	// chunk-level quarantine below is unaffected either way.
+	if !s.deferGateDocError {
+		s.recordQualityGateDocError(ctx, doc, kind, reason)
+	}
 	return quarantineDecision{
 		quarantine: true,
 		embErr:     embErr,
@@ -4100,35 +4154,156 @@ func (s *Service) transcriptExpectedLanguage() string {
 	return s.transcriptLanguage
 }
 
+// trackContext describes ONE audio track selected for transcription (SPEC
+// §8.6.12). audioIndex is the 0-based audio-relative stream index; stream carries
+// the container's declared per-stream metadata (language/title, when known);
+// warnExtras requests the legacy "only the first track was transcribed"
+// diagnostic (emitted only on the default first-track path).
+type trackContext struct {
+	audioIndex int
+	stream     avutil.AudioStream
+	hasStream  bool
+	warnExtras bool
+}
+
 // generateTranscriptRepresentation transcribes a media document (audio, or a
 // video's extracted audio track — issue #495) and persists the source transcript
-// representation and its chunks. It returns (produced, err): produced is true only
-// when a transcript representation was actually persisted, so the caller can tell a
-// real transcript from a legitimately empty one (silence, or a video with no audio
-// track) and surface an otherwise-unsearchable video (#398). A returned err follows
-// the same contract as generateRepresentations.
+// representation(s) and their chunks. It returns (produced, err): produced is true
+// when at least one transcript representation was actually persisted, so the caller
+// can tell a real transcript from a legitimately empty one (silence, or a video with
+// no audio track) and surface an otherwise-unsearchable video (#398). A returned err
+// follows the same contract as generateRepresentations.
+//
+// Which audio tracks are transcribed is governed by media.stt.tracks (SPEC §8.6.12):
+// the default `first` transcribes only track 0 (byte-for-byte today's behavior and
+// cost), while `all` / an explicit index list additionally transcribe each selected
+// track N ≥ 1 under a distinct `transcript@t<N>` rep_type.
 func (s *Service) generateTranscriptRepresentation(ctx context.Context, doc model.Document, content []byte) (bool, error) {
 	if s.repGen == nil || s.transcriber == nil {
 		return false, nil
 	}
-
-	transcriptText, words, err := s.readOrComputeTranscriptWithWords(ctx, doc, content, "")
+	sel, err := config.ParseSTTTracks(s.cfg.MediaSTTTracks)
 	if err != nil {
+		// Should never happen (validated at startup), but fail closed rather than
+		// silently transcribing the wrong track set.
 		return false, err
 	}
+	// Default (and overwhelmingly common) single-track path: transcribe only the
+	// first audio stream, keeping the eager quality-gate semantics and the honest
+	// "additional tracks dropped" diagnostic exactly as before (§8.6.12: track 0 is
+	// byte-for-byte unchanged).
+	if sel.Mode == config.STTTracksFirst {
+		produced, _, terr := s.transcribeAndPersistTrack(ctx, doc, content, trackContext{audioIndex: 0, warnExtras: true})
+		return produced, terr
+	}
+	return s.generateSelectedTrackTranscripts(ctx, doc, content, sel)
+}
 
-	// Multi-track honesty (issue #567): the transcription above fed only the first
-	// audio stream (ffmpeg's default selection) to STT. If the container carries
-	// additional audio streams — per-language dubs, an M&E track — surface them so
+// generateSelectedTrackTranscripts transcribes every audio track selected by an
+// `all` / explicit-index media.stt.tracks selection (SPEC §8.6.12), in container
+// stream order. Track-scoped failure semantics apply: a per-track transcription
+// error or quality-gate rejection fails ONLY that track (its representation is
+// dropped and recorded as honest coverage), and the DOCUMENT is reported as an
+// error only if EVERY selected track failed — otherwise it is ready with whatever
+// tracks succeeded.
+func (s *Service) generateSelectedTrackTranscripts(ctx context.Context, doc model.Document, content []byte, sel config.STTTrackSelection) (bool, error) {
+	info := s.probeTrackInfo(ctx, doc)
+	indices := resolveTrackIndices(sel, info)
+	if len(indices) == 0 {
+		if len(info.AudioStreams) == 0 {
+			// Unprobeable / no audio census (ffprobe absent, undecodable input): fall
+			// back to the default first-track path so a media file still gets its
+			// track-0 transcript rather than being silently skipped.
+			produced, _, terr := s.transcribeAndPersistTrack(ctx, doc, content, trackContext{audioIndex: 0, warnExtras: false})
+			return produced, terr
+		}
+		// The probe succeeded but an explicit index list matched no existing track in
+		// THIS file (every listed index is past its track count — a per-file
+		// condition, §8.6.12): transcribe nothing rather than falling back to an
+		// unselected track. A video with no other representation is still caught by
+		// the caller's no-representation check (#398).
+		s.getLogger().Printf("media.stt.tracks: none of the selected tracks exist in %s (%d audio stream(s)); no transcript produced (§8.6.12)", doc.RelPath, len(info.AudioStreams))
+		return false, nil
+	}
+
+	// Defer the eager per-document quality-gate error while looping so a rejected
+	// track fails only that track (§8.6.12); the all-failed decision below marks the
+	// document error at most once.
+	s.deferGateDocError = true
+	defer func() { s.deferGateDocError = false }()
+
+	producedAny := false
+	failed := 0
+	var firstFailErr error
+	for _, n := range indices {
+		tc := trackContext{audioIndex: n}
+		if n < len(info.AudioStreams) {
+			tc.stream = info.AudioStreams[n]
+			tc.hasStream = true
+		}
+		produced, rejected, terr := s.transcribeAndPersistTrack(ctx, doc, content, tc)
+		if terr != nil {
+			if isHardTranscriptError(terr) {
+				// A persistence/cache failure is not track-scoped; abort the document.
+				return producedAny, terr
+			}
+			// A provider/transient transcription failure is scoped to this track.
+			failed++
+			if firstFailErr == nil {
+				firstFailErr = terr
+			}
+			s.logTrackDropped(doc, tc, terr.Error())
+			continue
+		}
+		if rejected {
+			failed++
+			continue
+		}
+		if produced {
+			producedAny = true
+		}
+	}
+
+	// §8.6.6/§8.6.7 over the SELECTED track set: the document is an error only when
+	// every selected track failed (the degenerate single-track case is one track, so
+	// its failure is the document's). Surface it through the provider-failure channel
+	// so the caller marks the document status=error and retries it next run, without
+	// double-counting the video-no-representation path.
+	if failed == len(indices) {
+		if firstFailErr != nil {
+			return false, firstFailErr
+		}
+		return false, fmt.Errorf("%w: every selected audio track of %s failed transcription (§8.6.12)", ErrTranscriptProviderFailure, doc.RelPath)
+	}
+	return producedAny, nil
+}
+
+// transcribeAndPersistTrack transcribes ONE selected audio track and persists its
+// source transcript representation (plus, in single-pass mode, its translations).
+// It returns (produced, gateRejected, err): produced is true when a representation
+// was persisted; gateRejected is true when the quality gate dropped this track's
+// transcript under the deferred multi-track semantics (§8.6.12); err carries a
+// provider/transient transcription failure or a hard persistence error. Track 0
+// keeps the bare `transcript` rep_type and is byte-for-byte identical to the legacy
+// single-track path; each additional track N ≥ 1 is persisted under
+// `transcript@t<N>` with its container-declared track/language/label in meta_json.
+func (s *Service) transcribeAndPersistTrack(ctx context.Context, doc model.Document, content []byte, tc trackContext) (bool, bool, error) {
+	transcriptText, words, err := s.readTrackTranscript(ctx, doc, content, tc)
+	if err != nil {
+		return false, false, err
+	}
+
+	// Multi-track honesty (issue #567/#596): on the default first-track path the STT
+	// above fed only the first audio stream to STT; surface any additional streams so
 	// the selection is visible rather than silent. Fired BEFORE the empty-transcript
-	// early return so a non-dialogue first track (e.g. an M&E track yielding an empty
-	// transcript) still warns about the dropped dialogue tracks (optibot #596).
-	// Best-effort and non-fatal: it never affects the transcript that was produced.
-	s.warnMultiTrackAudio(ctx, doc)
+	// early return so a non-dialogue first track still warns about dropped tracks.
+	if tc.warnExtras {
+		s.warnMultiTrackAudio(ctx, doc)
+	}
 
 	transcriptText = strings.TrimSpace(transcriptText)
 	if transcriptText == "" {
-		return false, nil
+		return false, false, nil
 	}
 
 	var duration time.Duration
@@ -4140,6 +4315,15 @@ func (s *Service) generateTranscriptRepresentation(ctx context.Context, doc mode
 		ExpectedLanguage: s.transcriptExpectedLanguage(),
 		Duration:         duration,
 	})
+	// §8.6.12: under the deferred (multi-track) gate, a rejected track's transcript
+	// is DROPPED entirely (recorded as honest coverage) rather than persisted with
+	// quarantined chunks, so it never counts toward the document being "ready". On
+	// the eager (default) path deferGateDocError is false and the legacy
+	// persist-with-quarantine behavior below is preserved unchanged.
+	if decision.quarantine && s.deferGateDocError {
+		s.logTrackDropped(doc, tc, "output quality gate rejected the transcript")
+		return false, true, nil
+	}
 
 	segments := chunkTranscriptByTimeWithWordsFiltered(transcriptText, words, s.captionWordFilter())
 	// Strip configured subtitle drop/scrub phrases from the chunk text BEFORE
@@ -4148,7 +4332,7 @@ func (s *Service) generateTranscriptRepresentation(ctx context.Context, doc mode
 	dropSet, scrubSet := s.captionDropScrub()
 	segments = applyDropScrubToSegments(segments, dropSet, scrubSet)
 	if len(segments) == 0 {
-		return false, nil
+		return false, false, nil
 	}
 	// Optional model-driven speaker diarization (SPEC §8.6.8): when active and a
 	// diarizer is injected, attribute each segment to a speaker. This is metadata
@@ -4159,21 +4343,23 @@ func (s *Service) generateTranscriptRepresentation(ctx context.Context, doc mode
 	// attribution that is actually present on the segments.
 	s.applyDiarization(ctx, doc, content, segments)
 
-	metaJSON, err := s.sttTranscriptMetaJSON(distinctSpeakers(segments), transcriptText, segmentsHaveWordTiming(segments))
+	meta := s.sttTranscriptMeta(distinctSpeakers(segments), transcriptText, segmentsHaveWordTiming(segments))
+	applyTrackMeta(&meta, tc)
+	metaJSON, err := json.Marshal(meta)
 	if err != nil {
-		return false, fmt.Errorf("marshal transcript meta: %w", err)
+		return false, false, fmt.Errorf("marshal transcript meta: %w", err)
 	}
 	rep := model.Representation{
 		DocID:       doc.DocID,
-		RepType:     RepTypeTranscript,
+		RepType:     TranscriptRepTypeForTrack(tc.audioIndex, ""),
 		RepHash:     computeRepHash([]byte(transcriptText)),
-		MetaJSON:    metaJSON,
+		MetaJSON:    string(metaJSON),
 		CreatedUnix: time.Now().Unix(),
 		Deleted:     false,
 	}
 	repID, err := s.repGen.store.UpsertRepresentation(ctx, rep)
 	if err != nil {
-		return false, fmt.Errorf("upsert transcript representation: %w", err)
+		return false, false, fmt.Errorf("upsert transcript representation: %w", err)
 	}
 
 	// Optional leading-silence trim (dir2mcp#258): when enabled, subtract the
@@ -4190,7 +4376,7 @@ func (s *Service) generateTranscriptRepresentation(ctx context.Context, doc mode
 		}
 	}
 	if err := s.repGen.upsertChunksForRepresentation(ctx, repID, "text", segments, decision); err != nil {
-		return false, fmt.Errorf("persist transcript chunks: %w", err)
+		return false, false, fmt.Errorf("persist transcript chunks: %w", err)
 	}
 
 	// Optional translation step (SPEC §8.6.2): after the source transcript
@@ -4210,9 +4396,9 @@ func (s *Service) generateTranscriptRepresentation(ctx context.Context, doc mode
 	// final set of representations is identical either way — only the ordering
 	// differs. In single-pass mode (the default) it runs inline as before.
 	if s.activePass == passTranscription {
-		return true, nil
+		return true, false, nil
 	}
-	if err := s.translateTranscriptRepresentations(ctx, doc, content, transcriptText, duration, trimOffsetMS); err != nil {
+	if err := s.translateTranscriptRepresentations(ctx, doc, content, transcriptText, duration, trimOffsetMS, tc.audioIndex); err != nil {
 		s.getLogger().Printf("transcript translation skipped for %s: %v", doc.RelPath, err)
 		s.addErrors(1)
 		// §8.6.11/§14.4: record the canonical translation-failure code
@@ -4224,7 +4410,162 @@ func (s *Service) generateTranscriptRepresentation(ctx context.Context, doc mode
 		code := manifestErrorCode(err)
 		s.markActiveErrored(code, code+": transcript translation failed")
 	}
-	return true, nil
+	return true, false, nil
+}
+
+// readTrackTranscript resolves the transcript text (and optional per-word timing)
+// for a single selected audio track (SPEC §8.6.12). Track 0 is transcribed via the
+// exact legacy path (the document's bytes, with a video's default audio demuxed
+// inline), so its cache key and result are byte-for-byte unchanged. An additional
+// track N ≥ 1 is first demuxed to a compact per-track audio clip and transcribed as
+// a standalone audio document, keying the transcribe cache on the extracted bytes so
+// each track caches independently.
+func (s *Service) readTrackTranscript(ctx context.Context, doc model.Document, content []byte, tc trackContext) (string, []model.TimedWord, error) {
+	if tc.audioIndex <= 0 {
+		return s.readOrComputeTranscriptWithWords(ctx, doc, content, "")
+	}
+	audio, err := s.extractTrackAudio(ctx, doc, content, tc.audioIndex)
+	if err != nil {
+		if errors.Is(err, avutil.ErrNoAudioStream) {
+			// The requested track does not exist in this file: a track-scoped "no
+			// transcript" (handled by the caller as an empty, non-fatal outcome), not
+			// a provider failure.
+			s.getLogger().Printf("media.stt.tracks: %s has no audio track %d to transcribe; skipping it (§8.6.12)", doc.RelPath, tc.audioIndex)
+			return "", nil, nil
+		}
+		return "", nil, fmt.Errorf("%w: extract audio track %d of %s: %w", ErrTranscriptProviderFailure, tc.audioIndex, doc.RelPath, err)
+	}
+	// Transcribe the extracted clip as a standalone audio document: DocType audio so
+	// transcribe() does not re-demux, and an audio-suffixed rel_path so the provider
+	// infers an audio MIME. The extracted bytes drive the transcribe cache key, so
+	// each track's transcript caches independently of track 0 and its siblings.
+	trackDoc := doc
+	trackDoc.DocType = "audio"
+	trackDoc.RelPath = trackAudioRelPath(doc.RelPath, tc.audioIndex)
+	return s.readOrComputeTranscriptWithWords(ctx, trackDoc, audio, "")
+}
+
+// extractTrackAudio demuxes a specific audio-relative track to a compact STT-ready
+// clip (SPEC §8.6.12), mirroring extractVideoAudioTrack but selecting the track by
+// index via ExtractAudioTrackIndexFunc (default avutil.ExtractAudioTrackIndex). The
+// in-memory bytes are staged to a temp file because avutil slices by path.
+func (s *Service) extractTrackAudio(ctx context.Context, doc model.Document, content []byte, audioIndex int) ([]byte, error) {
+	tmp, err := os.CreateTemp("", "dir2mcp-vaudio-*"+filepath.Ext(doc.RelPath))
+	if err != nil {
+		return nil, fmt.Errorf("stage media for audio track extraction: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+	if _, err := tmp.Write(content); err != nil {
+		_ = tmp.Close()
+		return nil, fmt.Errorf("write staged media: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return nil, fmt.Errorf("flush staged media: %w", err)
+	}
+	extract := s.ExtractAudioTrackIndexFunc
+	if extract == nil {
+		extract = avutil.ExtractAudioTrackIndex
+	}
+	return extract(ctx, tmpPath, audioIndex)
+}
+
+// probeTrackInfo probes doc's container/stream census for track selection (SPEC
+// §8.6.12), resolving the media through the CorpusFS. It is best-effort: any error
+// (ffprobe absent, undecodable input, localize failure) yields a zero MediaInfo so
+// the caller degrades to the default first-track behavior.
+func (s *Service) probeTrackInfo(ctx context.Context, doc model.Document) avutil.MediaInfo {
+	probe := s.ProbeMediaInfoFunc
+	if probe == nil {
+		probe = avutil.ProbeMediaInfo
+	}
+	localPath, cleanup, err := s.corpusFS().Localize(ctx, doc.RelPath)
+	if err != nil {
+		return avutil.MediaInfo{}
+	}
+	defer cleanup()
+	info, err := probe(ctx, localPath)
+	if err != nil {
+		return avutil.MediaInfo{}
+	}
+	return info
+}
+
+// resolveTrackIndices resolves a media.stt.tracks selection against a probed track
+// census into the concrete, ordered (ascending, container stream order) set of
+// audio-relative indices to transcribe (SPEC §8.6.12). `all` expands to every probed
+// track; an explicit list keeps only in-range indices (an index past this file's
+// track count is skipped here as a track-scoped no-op — a corpus mixes files with
+// different track counts, so it is a per-file condition, not a global CONFIG_INVALID).
+// With no probed audio streams the result is empty and the caller falls back to the
+// default first-track path.
+func resolveTrackIndices(sel config.STTTrackSelection, info avutil.MediaInfo) []int {
+	n := len(info.AudioStreams)
+	if n == 0 {
+		return nil
+	}
+	switch sel.Mode {
+	case config.STTTracksAll:
+		out := make([]int, n)
+		for i := range out {
+			out[i] = i
+		}
+		return out
+	case config.STTTracksList:
+		out := make([]int, 0, len(sel.Indices))
+		for _, idx := range sel.Indices {
+			if idx >= 0 && idx < n {
+				out = append(out, idx)
+			}
+		}
+		return out
+	default: // STTTracksFirst
+		return []int{0}
+	}
+}
+
+// applyTrackMeta stamps the per-track fields onto a transcript's meta_json (SPEC
+// §8.6.12). Track 0 is left untouched (absence of `track` ⇒ track 0), so a legacy
+// single-track transcript's meta_json is byte-for-byte unchanged. An additional
+// track records its 0-based index plus the container's declared language/label when
+// present.
+func applyTrackMeta(meta *transcriptMeta, tc trackContext) {
+	if tc.audioIndex <= 0 {
+		return
+	}
+	meta.Track = tc.audioIndex
+	if tc.hasStream {
+		// track_language is the container's OWN declared tag, recorded verbatim (only
+		// trimmed): kept general-purpose with no hardcoded language remapping.
+		meta.TrackLanguage = strings.TrimSpace(tc.stream.Language)
+		meta.TrackLabel = strings.TrimSpace(tc.stream.Title)
+	}
+}
+
+// logTrackDropped records a track-scoped failure as honest coverage (SPEC §8.6.12):
+// a single greppable, content-free line naming the dropped track and the reason, so
+// a per-track transcription/quality failure is visible rather than silent while the
+// sibling tracks are retained.
+func (s *Service) logTrackDropped(doc model.Document, tc trackContext, reason string) {
+	desc := describeAudioStream(tc.audioIndex, tc.stream)
+	s.getLogger().Printf("media.stt.tracks: dropped audio track %s of %s: %s (issue #567)", desc, doc.RelPath, reason)
+}
+
+// isHardTranscriptError reports whether a per-track transcription error is a HARD
+// failure (persistence/cache/marshal) that must abort the whole document, as opposed
+// to a provider/transient transcription failure (ErrTranscriptProviderFailure) that
+// is scoped to the failing track under §8.6.12.
+func isHardTranscriptError(err error) bool {
+	return err != nil && !errors.Is(err, ErrTranscriptProviderFailure)
+}
+
+// trackAudioRelPath rewrites a media path to a per-track extracted-audio filename so
+// the STT provider infers an audio MIME from the extension rather than a video
+// container it would reject (mirrors videoAudioRelPath), while keeping the track
+// index in the stem for human-identifiable staging (SPEC §8.6.12).
+func trackAudioRelPath(relPath string, audioIndex int) string {
+	base := strings.TrimSuffix(relPath, filepath.Ext(relPath))
+	return fmt.Sprintf("%s.t%d.m4a", base, audioIndex)
 }
 
 // applyDiarization stamps speaker attribution onto the transcript segments via
@@ -4269,10 +4610,13 @@ func (s *Service) applyDiarization(ctx context.Context, doc model.Document, cont
 // so behaviour with translation off is identical to before. Each translated
 // transcript: is cached per-language via TranscriptLangSuffix so it is not
 // recomputed across re-ingests; carries a distinct rep_type via
-// TranscriptRepType(lang) so it coexists with the source transcript and any
-// sidecar per-language reps; routes through the output quality gate; and records
-// source_language + translate provider/model in meta_json.
-func (s *Service) translateTranscriptRepresentations(ctx context.Context, doc model.Document, content []byte, sourceText string, duration time.Duration, trimOffsetMS int) error {
+// TranscriptRepTypeForTrack(track, lang) so it coexists with the source transcript,
+// any sidecar per-language reps, and (for a multi-track selection) the other tracks'
+// translations (§8.6.12 keys them transcript@t<N>-<lang>); routes through the output
+// quality gate; and records source_language + translate provider/model in meta_json.
+// track is the 0-based audio-relative index of the transcript being translated (0
+// for the bare/default transcript).
+func (s *Service) translateTranscriptRepresentations(ctx context.Context, doc model.Document, content []byte, sourceText string, duration time.Duration, trimOffsetMS, track int) error {
 	if !s.translationConfigured() {
 		return nil
 	}
@@ -4284,7 +4628,7 @@ func (s *Service) translateTranscriptRepresentations(ctx context.Context, doc mo
 			// Skip a no-op translation into the source language itself.
 			continue
 		}
-		if err := s.translateOneTranscript(ctx, doc, content, sourceText, sourceLang, lang, duration, trimOffsetMS); err != nil {
+		if err := s.translateOneTranscript(ctx, doc, content, sourceText, sourceLang, lang, duration, trimOffsetMS, track); err != nil {
 			// Best-effort per language: a failure on one target must not suppress
 			// the remaining targets. Log here and keep going; the first error is
 			// returned so the caller can log/count it (non-fatally).
@@ -4326,7 +4670,7 @@ func sameLanguage(a, b string) bool {
 // is cached per-language (TranscriptLangSuffix) keyed by the SOURCE content hash
 // so re-ingesting an unchanged document reuses the cached translation instead of
 // re-calling the chat provider.
-func (s *Service) translateOneTranscript(ctx context.Context, doc model.Document, content []byte, sourceText, sourceLang, targetLang string, duration time.Duration, trimOffsetMS int) error {
+func (s *Service) translateOneTranscript(ctx context.Context, doc model.Document, content []byte, sourceText, sourceLang, targetLang string, duration time.Duration, trimOffsetMS, track int) error {
 	// Source the English text either from the chat generator (line-by-line over
 	// the source transcript) or, for engine=whisper, from Whisper's native
 	// translate task (a second pass over the audio that re-segments with its own
@@ -4407,6 +4751,12 @@ func (s *Service) translateOneTranscript(ctx context.Context, doc model.Document
 	if strings.TrimSpace(meta.Language) != "" {
 		meta.LanguageSource = langSourceConfigured
 	}
+	// §8.6.12: a translation of an ADDITIONAL track (N ≥ 1) records the same 0-based
+	// track index as its source transcript, so the derivative is attributable to the
+	// track it came from. Track 0 omits it (byte-for-byte unchanged).
+	if track > 0 {
+		meta.Track = track
+	}
 	metaJSON, err := json.Marshal(meta)
 	if err != nil {
 		return fmt.Errorf("marshal translated transcript meta: %w", err)
@@ -4414,7 +4764,7 @@ func (s *Service) translateOneTranscript(ctx context.Context, doc model.Document
 
 	rep := model.Representation{
 		DocID:       doc.DocID,
-		RepType:     TranscriptRepType(targetLang),
+		RepType:     TranscriptRepTypeForTrack(track, targetLang),
 		RepHash:     computeRepHash([]byte(translated)),
 		MetaJSON:    string(metaJSON),
 		CreatedUnix: time.Now().Unix(),

--- a/internal/ingest/sidecar.go
+++ b/internal/ingest/sidecar.go
@@ -147,6 +147,19 @@ type transcriptMeta struct {
 	DiarizeProvider string    `json:"diarize_provider,omitempty"`
 	DiarizeModel    string    `json:"diarize_model,omitempty"`
 	Speakers        []Speaker `json:"speakers,omitempty"`
+
+	// Track / TrackLanguage / TrackLabel record which audio stream a transcript was
+	// produced from in a multi-track container (SPEC §8.6.12). Track is the 0-based
+	// AUDIO-relative stream index and is recorded ONLY for an ADDITIONAL track
+	// (N ≥ 1): track 0 omits it (absence ⇒ track 0), so a legacy single-track
+	// transcript's meta_json is byte-for-byte unchanged. omitempty on a plain int is
+	// safe here because an additional track index is always ≥ 1, so a genuine value
+	// is never suppressed. TrackLanguage (BCP-47) and TrackLabel (e.g. "commentary")
+	// carry the container's declared per-stream language tag / title when present,
+	// and are absent otherwise.
+	Track         int    `json:"track,omitempty"`
+	TrackLanguage string `json:"track_language,omitempty"`
+	TrackLabel    string `json:"track_label,omitempty"`
 }
 
 // Speaker is one distinct speaker recorded in a diarized transcript's meta_json

--- a/tests/avutil/extract_audio_track_test.go
+++ b/tests/avutil/extract_audio_track_test.go
@@ -1,0 +1,30 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/avutil"
+)
+
+// TestExtractAudioTrackIndex_NegativeIndexRejected pins that a negative
+// audio-relative track index is rejected before any probe/ffmpeg work (SPEC
+// §8.6.12): the 0-based grammar has no negative track, so it is a programming
+// error, NOT a graceful ErrNoAudioStream. Asserting the specific cause (and that
+// it is distinct from ErrNoAudioStream) keeps the test honest even on a machine
+// that happens to have ffprobe/ffmpeg installed, where a bare `err != nil` could
+// otherwise be satisfied by the nonexistent input file rather than the guard.
+func TestExtractAudioTrackIndex_NegativeIndexRejected(t *testing.T) {
+	_, err := avutil.ExtractAudioTrackIndex(context.Background(), "does-not-matter.mkv", -1)
+	if err == nil {
+		t.Fatal("ExtractAudioTrackIndex(..., -1) = nil error, want a rejection")
+	}
+	if errors.Is(err, avutil.ErrNoAudioStream) {
+		t.Fatalf("negative index must be a hard programming error, not the graceful ErrNoAudioStream: %v", err)
+	}
+	if !strings.Contains(err.Error(), "negative") {
+		t.Fatalf("error should name the negative-index cause (the pre-probe guard), got: %v", err)
+	}
+}

--- a/tests/config/media_stt_tracks_config_test.go
+++ b/tests/config/media_stt_tracks_config_test.go
@@ -1,0 +1,162 @@
+package tests
+
+import (
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+)
+
+// TestParseSTTTracks_ResolvesForms covers the media.stt.tracks grammar (SPEC
+// §8.6.12): the default/`first` keyword, `all`, and an explicit 0-based index list
+// that is de-duplicated and sorted into container stream order.
+func TestParseSTTTracks_ResolvesForms(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		raw     []string
+		mode    config.STTTrackMode
+		indices []int
+	}{
+		{"empty defaults to first", nil, config.STTTracksFirst, nil},
+		{"first keyword", []string{"first"}, config.STTTracksFirst, nil},
+		{"all keyword", []string{"all"}, config.STTTracksAll, nil},
+		{"single index", []string{"0"}, config.STTTracksList, []int{0}},
+		{"index list", []string{"0", "2"}, config.STTTracksList, []int{0, 2}},
+		{"list sorted and deduped in stream order", []string{"2", "0"}, config.STTTracksList, []int{0, 2}},
+		{"blank entries ignored", []string{" ", "1"}, config.STTTracksList, []int{1}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sel, err := config.ParseSTTTracks(tc.raw)
+			if err != nil {
+				t.Fatalf("ParseSTTTracks(%v): %v", tc.raw, err)
+			}
+			if sel.Mode != tc.mode {
+				t.Errorf("mode = %v, want %v", sel.Mode, tc.mode)
+			}
+			if !reflect.DeepEqual(sel.Indices, tc.indices) {
+				t.Errorf("indices = %v, want %v", sel.Indices, tc.indices)
+			}
+		})
+	}
+}
+
+// TestParseSTTTracks_RejectsInvalid confirms the CONFIG_INVALID cases: an unknown
+// keyword, a keyword mixed with indices, a negative index, and a duplicate index.
+func TestParseSTTTracks_RejectsInvalid(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		raw  []string
+	}{
+		{"unknown keyword", []string{"middle"}},
+		{"keyword mixed with index", []string{"all", "1"}},
+		{"negative index", []string{"-1"}},
+		{"duplicate index", []string{"0", "0"}},
+		{"non-integer entry", []string{"0", "two"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := config.ParseSTTTracks(tc.raw); err == nil {
+				t.Fatalf("ParseSTTTracks(%v) = nil error, want CONFIG_INVALID", tc.raw)
+			}
+		})
+	}
+}
+
+// TestMediaSTTTracks_DefaultEmpty confirms the selection is unset by default, so an
+// unconfigured corpus transcribes only the first track (byte-for-byte unchanged).
+func TestMediaSTTTracks_DefaultEmpty(t *testing.T) {
+	cfg := config.Default()
+	if len(cfg.MediaSTTTracks) != 0 {
+		t.Errorf("media.stt.tracks default = %v, want empty", cfg.MediaSTTTracks)
+	}
+	sel, err := config.ParseSTTTracks(cfg.MediaSTTTracks)
+	if err != nil {
+		t.Fatalf("ParseSTTTracks(default): %v", err)
+	}
+	if sel.Mode != config.STTTracksFirst {
+		t.Errorf("default selection mode = %v, want first", sel.Mode)
+	}
+}
+
+// TestMediaSTTTracks_ParsesYAMLForms exercises the loader for the scalar keyword,
+// the inline list, and the block list forms.
+func TestMediaSTTTracks_ParsesYAMLForms(t *testing.T) {
+	base := []string{"root_dir: /tmp/repo", "state_dir: /tmp/repo/.dir2mcp"}
+	cases := map[string]struct {
+		lines []string
+		want  []string
+	}{
+		"scalar all": {
+			lines: append(append([]string(nil), base...), "media:", "  stt:", "    tracks: all"),
+			want:  []string{"all"},
+		},
+		"flat scalar first": {
+			lines: append(append([]string(nil), base...), "media_stt_tracks: first"),
+			want:  []string{"first"},
+		},
+		"inline list": {
+			lines: append(append([]string(nil), base...), "media:", "  stt:", "    tracks: [0, 2]"),
+			want:  []string{"0", "2"},
+		},
+		"block list": {
+			lines: append(append([]string(nil), base...), "media:", "  stt:", "    tracks:", "      - 0", "      - 2"),
+			want:  []string{"0", "2"},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), ".dir2mcp.yaml")
+			writeFile(t, path, strings.Join(tc.lines, "\n")+"\n")
+			cfg, err := config.LoadFile(path)
+			if err != nil {
+				t.Fatalf("LoadFile(%s): %v", name, err)
+			}
+			if !reflect.DeepEqual(cfg.MediaSTTTracks, tc.want) {
+				t.Errorf("%s: media.stt.tracks = %v, want %v", name, cfg.MediaSTTTracks, tc.want)
+			}
+		})
+	}
+}
+
+// TestMediaSTTTracks_RoundTripsThroughSaveLoad exercises the []string plumbing
+// (setFileListValue / writeList) end to end.
+func TestMediaSTTTracks_RoundTripsThroughSaveLoad(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".dir2mcp.yaml")
+	cfg := config.Default()
+	cfg.RootDir = "/tmp/repo"
+	cfg.StateDir = "/tmp/repo/.dir2mcp"
+	cfg.MediaSTTTracks = []string{"0", "2"}
+	if err := config.SaveFile(path, cfg); err != nil {
+		t.Fatalf("SaveFile: %v", err)
+	}
+	loaded, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if !reflect.DeepEqual(loaded.MediaSTTTracks, []string{"0", "2"}) {
+		t.Errorf("media.stt.tracks did not round-trip: got %v, want [0 2]", loaded.MediaSTTTracks)
+	}
+}
+
+// TestMediaSTTTracks_ValidateRejectsInvalid confirms an invalid selection fails
+// config validation (CONFIG_INVALID at startup, not per file).
+func TestMediaSTTTracks_ValidateRejectsInvalid(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		tracks []string
+	}{
+		{"duplicate", []string{"1", "1"}},
+		{"negative", []string{"-2"}},
+		{"unknown keyword", []string{"second"}},
+		{"mixed", []string{"all", "0"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.Default()
+			cfg.MediaSTTTracks = tc.tracks
+			if err := cfg.Validate(); err == nil {
+				t.Fatalf("Validate() = nil, want CONFIG_INVALID for %v", tc.tracks)
+			}
+		})
+	}
+}

--- a/tests/ingest/per_track_transcription_567_test.go
+++ b/tests/ingest/per_track_transcription_567_test.go
@@ -1,0 +1,292 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/avutil"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// perTrackTranscriber returns a transcript keyed by the exact bytes it is handed,
+// so a per-track test (SPEC §8.6.12) can assert that each selected audio track is
+// transcribed independently: track 0 receives the document's raw bytes, and each
+// additional track N receives its extracted per-track audio bytes. An entry in
+// failFor returns an error for that input (a track-scoped transcription failure);
+// an unknown input transcribes to the empty string (a legitimately empty track).
+type perTrackTranscriber struct {
+	byInput map[string]string
+	failFor map[string]error
+	calls   int
+}
+
+func (p *perTrackTranscriber) Transcribe(_ context.Context, _ string, data []byte) (string, error) {
+	p.calls++
+	key := string(data)
+	if err := p.failFor[key]; err != nil {
+		return "", err
+	}
+	return p.byInput[key], nil
+}
+
+// trackAudioBytes is the deterministic per-track audio the stubbed extractor emits
+// for an additional track N (N >= 1). Track 0 is transcribed from the document's
+// raw bytes, never through the extractor.
+func trackAudioBytes(audioIndex int) string {
+	return fmt.Sprintf("track-%d-audio-bytes", audioIndex)
+}
+
+// threeTrackProbe injects a three-audio-stream census (an original, a per-language
+// dub, and a music-&-effects track) without ffprobe.
+func threeTrackProbe() func(context.Context, string) (avutil.MediaInfo, error) {
+	return func(context.Context, string) (avutil.MediaInfo, error) {
+		return avutil.MediaInfo{
+			Container:  "matroska",
+			AudioCodec: "aac",
+			AudioStreams: []avutil.AudioStream{
+				{Index: 0, CodecName: "aac", Channels: 2, Language: "eng", Title: "Original"},
+				{Index: 1, CodecName: "aac", Channels: 2, Language: "rus", Title: "Dub"},
+				{Index: 2, CodecName: "aac", Channels: 6, Title: "Music & Effects"},
+			},
+		}, nil
+	}
+}
+
+// newPerTrackService wires an ingest Service with the injected probe/extractor
+// seams so a multi-track selection is exercised hermetically (no ffprobe/ffmpeg).
+func newPerTrackService(t *testing.T, root, stateDir string, st *store.SQLiteStore, tracks []string, tr *perTrackTranscriber) *ingest.Service {
+	t.Helper()
+	svc := mustNewIngestService(t, config.Config{
+		RootDir:        root,
+		StateDir:       stateDir,
+		STTProvider:    "off",
+		MediaSTTTracks: tracks,
+	}, st)
+	svc.SetTranscriber(tr)
+	svc.SetSTTIdentity("whisper", "whisper-large-v3")
+	svc.SetTranscriptLanguage("en")
+	svc.ProbeMediaInfoFunc = threeTrackProbe()
+	svc.ExtractAudioTrackIndexFunc = func(_ context.Context, _ string, audioIndex int) ([]byte, error) {
+		return []byte(trackAudioBytes(audioIndex)), nil
+	}
+	return svc
+}
+
+func ingestPerTrack(t *testing.T, svc *ingest.Service, st *store.SQLiteStore, name, body string) map[string]bool {
+	t.Helper()
+	f := ingest.DiscoveredFile{RelPath: name, SizeBytes: int64(len(body)), MTimeUnix: time.Now().Unix()}
+	if err := svc.ProcessDocument(context.Background(), f, nil, false); err != nil {
+		t.Fatalf("ProcessDocument(%s): %v", name, err)
+	}
+	return repTypesFor(t, st, name)
+}
+
+// TestPerTrack_FirstOnlyTrackZeroBareKey pins the default: `media.stt.tracks` unset
+// (⇒ first) transcribes ONLY track 0 under the BARE `transcript` rep_type, and the
+// extractor is never invoked for additional tracks — byte-for-byte today's behavior
+// and cost (SPEC §8.6.12).
+func TestPerTrack_FirstOnlyTrackZeroBareKey(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	body := "audio-file-bytes"
+	writeFile(t, filepath.Join(root, "talk.mp3"), body)
+	st := newRealStore(t)
+
+	tr := &perTrackTranscriber{byInput: map[string]string{body: "[00:00] first track"}}
+	// nil tracks ⇒ default first.
+	svc := newPerTrackService(t, root, t.TempDir(), st, nil, tr)
+	extractorCalls := 0
+	svc.ExtractAudioTrackIndexFunc = func(_ context.Context, _ string, audioIndex int) ([]byte, error) {
+		extractorCalls++
+		return []byte(trackAudioBytes(audioIndex)), nil
+	}
+
+	types := ingestPerTrack(t, svc, st, "talk.mp3", body)
+	if !types["transcript"] {
+		t.Fatalf("first mode: bare transcript missing; got %v", types)
+	}
+	if types["transcript@t1"] || types["transcript@t2"] {
+		t.Fatalf("first mode transcribed additional tracks; got %v", types)
+	}
+	if extractorCalls != 0 {
+		t.Fatalf("first mode invoked the per-track extractor %d times, want 0 (no extra cost)", extractorCalls)
+	}
+}
+
+// TestPerTrack_AllTracksDistinctKeys verifies `all` transcribes every audio stream,
+// keying track 0 as the bare `transcript` and each additional track N as
+// `transcript@t<N>` with its container-declared track/language/label in meta_json
+// (SPEC §8.6.12).
+func TestPerTrack_AllTracksDistinctKeys(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	body := "audio-file-bytes"
+	writeFile(t, filepath.Join(root, "multi.m4a"), body)
+	st := newRealStore(t)
+
+	tr := &perTrackTranscriber{byInput: map[string]string{
+		body:               "[00:00] original english",
+		trackAudioBytes(1): "[00:00] dubbed russian",
+		trackAudioBytes(2): "[00:00] score and effects",
+	}}
+	svc := newPerTrackService(t, root, t.TempDir(), st, []string{"all"}, tr)
+
+	types := ingestPerTrack(t, svc, st, "multi.m4a", body)
+	for _, want := range []string{"transcript", "transcript@t1", "transcript@t2"} {
+		if !types[want] {
+			t.Fatalf("all mode missing rep_type %q; got %v", want, types)
+		}
+	}
+	if tr.calls != 3 {
+		t.Errorf("all mode STT calls = %d, want 3 (one per audio track)", tr.calls)
+	}
+
+	// Track 0 meta must NOT carry a `track` field (absence ⇒ track 0), keeping a
+	// single-track transcript byte-for-byte unchanged.
+	if _, ok := metaField(t, st, "multi.m4a", "transcript", "track"); ok {
+		t.Error("track 0 transcript meta_json carries a `track` field; want absent")
+	}
+	// Track 1 meta records track=1 + declared language/label.
+	if got, _ := metaField(t, st, "multi.m4a", "transcript@t1", "track"); got != float64(1) {
+		t.Errorf("transcript@t1 track = %v, want 1", got)
+	}
+	if got, _ := metaField(t, st, "multi.m4a", "transcript@t1", "track_language"); got != "rus" {
+		t.Errorf("transcript@t1 track_language = %v, want rus", got)
+	}
+	if got, _ := metaField(t, st, "multi.m4a", "transcript@t1", "track_label"); got != "Dub" {
+		t.Errorf("transcript@t1 track_label = %v, want Dub", got)
+	}
+}
+
+// TestPerTrack_ExplicitListSelectsSubset verifies an explicit `[0, 2]` selection
+// transcribes exactly tracks 0 and 2 (skipping track 1), in container order.
+func TestPerTrack_ExplicitListSelectsSubset(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	body := "audio-file-bytes"
+	writeFile(t, filepath.Join(root, "sel.m4a"), body)
+	st := newRealStore(t)
+
+	tr := &perTrackTranscriber{byInput: map[string]string{
+		body:               "[00:00] original english",
+		trackAudioBytes(2): "[00:00] score and effects",
+	}}
+	// Written out of order to prove the set is processed in stream order, not list order.
+	svc := newPerTrackService(t, root, t.TempDir(), st, []string{"2", "0"}, tr)
+
+	types := ingestPerTrack(t, svc, st, "sel.m4a", body)
+	if !types["transcript"] || !types["transcript@t2"] {
+		t.Fatalf("explicit [0,2] missing expected reps; got %v", types)
+	}
+	if types["transcript@t1"] {
+		t.Fatalf("explicit [0,2] transcribed unselected track 1; got %v", types)
+	}
+}
+
+// TestPerTrack_OneTrackFailsOthersSucceed pins the track-scoped failure rule: when
+// one selected track fails transcription but a sibling succeeds, only the failing
+// track's representation is dropped and the DOCUMENT stays ready (SPEC §8.6.12).
+func TestPerTrack_OneTrackFailsOthersSucceed(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	body := "audio-file-bytes"
+	writeFile(t, filepath.Join(root, "partial.m4a"), body)
+	st := newRealStore(t)
+
+	tr := &perTrackTranscriber{
+		byInput: map[string]string{body: "[00:00] the original survives"},
+		failFor: map[string]error{trackAudioBytes(1): errors.New("provider 503")},
+	}
+	svc := newPerTrackService(t, root, t.TempDir(), st, []string{"0", "1"}, tr)
+
+	types := ingestPerTrack(t, svc, st, "partial.m4a", body)
+	if !types["transcript"] {
+		t.Fatalf("surviving track 0 transcript missing; got %v", types)
+	}
+	if types["transcript@t1"] {
+		t.Fatalf("failed track 1 left a representation; want it dropped. got %v", types)
+	}
+	doc, err := st.GetDocumentByPath(context.Background(), "partial.m4a")
+	if err != nil {
+		t.Fatalf("GetDocumentByPath: %v", err)
+	}
+	if doc.Status != "ok" {
+		t.Fatalf("document status = %q, want ok (a partial-track failure must not error the document)", doc.Status)
+	}
+}
+
+// TestPerTrack_AllTracksFailDocumentError pins the other half of the rule: when
+// EVERY selected track fails, the document is marked status=error (SPEC §8.6.12,
+// the zero-successful-tracks case of §8.6.7).
+func TestPerTrack_AllTracksFailDocumentError(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	body := "audio-file-bytes"
+	writeFile(t, filepath.Join(root, "dead.m4a"), body)
+	st := newRealStore(t)
+
+	tr := &perTrackTranscriber{
+		failFor: map[string]error{
+			body:               errors.New("provider 503 track 0"),
+			trackAudioBytes(1): errors.New("provider 503 track 1"),
+		},
+	}
+	svc := newPerTrackService(t, root, t.TempDir(), st, []string{"0", "1"}, tr)
+
+	_ = ingestPerTrack(t, svc, st, "dead.m4a", body)
+	doc, err := st.GetDocumentByPath(context.Background(), "dead.m4a")
+	if err != nil {
+		t.Fatalf("GetDocumentByPath: %v", err)
+	}
+	if doc.Status != "error" {
+		t.Fatalf("document status = %q, want error (every selected track failed)", doc.Status)
+	}
+}
+
+// TestPerTrack_ExplicitOutOfRangeProducesNothing pins that an explicit selection
+// whose indices are all past a file's track count transcribes NOTHING for that
+// file — it must not silently fall back to the unselected first track (SPEC
+// §8.6.12: an out-of-range index is a per-file, track-scoped skip).
+func TestPerTrack_ExplicitOutOfRangeProducesNothing(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	body := "audio-file-bytes"
+	writeFile(t, filepath.Join(root, "toohigh.m4a"), body)
+	st := newRealStore(t)
+
+	// Track 0 would transcribe if wrongly selected; assert it is NOT.
+	tr := &perTrackTranscriber{byInput: map[string]string{body: "[00:00] track zero must not appear"}}
+	svc := newPerTrackService(t, root, t.TempDir(), st, []string{"5"}, tr) // probe has only 3 tracks
+
+	types := ingestPerTrack(t, svc, st, "toohigh.m4a", body)
+	if types["transcript"] || types["transcript@t5"] {
+		t.Fatalf("out-of-range selection produced a transcript; want none. got %v", types)
+	}
+}
+
+// metaField unmarshals the meta_json of the given rep_type for relPath and returns
+// the named field's value (and whether it was present). A missing representation is
+// a test failure; a missing field returns (nil, false).
+func metaField(t *testing.T, st *store.SQLiteStore, relPath, repType, field string) (any, bool) {
+	t.Helper()
+	raw, err := st.RepresentationMetaByType(context.Background(), relPath, repType)
+	if err != nil {
+		t.Fatalf("RepresentationMetaByType(%s, %s): %v", relPath, repType, err)
+	}
+	if raw == "" {
+		t.Fatalf("no %q representation for %s", repType, relPath)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		t.Fatalf("meta_json for %q not valid json (%q): %v", repType, raw, err)
+	}
+	v, ok := parsed[field]
+	return v, ok
+}


### PR DESCRIPTION
## What & why

Closes #567. PR #596 landed the multi-track **diagnostic** (it only *warned* that extra audio tracks were dropped). This PR actually **transcribes** the selected tracks per the new `media.stt.tracks` selector, implementing SPEC §8.6.12 (already merged on `dirstral-spec` origin/main; submodule re-pinned to `55151bd`).

## Behavior (SPEC §8.6.12)

- **`media.stt.tracks`** — default `first` | `all` | a list of 0-based audio-relative indices (e.g. `[0, 2]`).
  - `first` (default): transcribe only track 0 — **byte-for-byte today's behavior and cost**, keeps the honest "additional tracks dropped" warning.
  - `all`: transcribe every audio track.
  - explicit list: transcribe exactly those tracks, processed in **container stream order** (`[2,0]` ≡ `[0,2]`). Duplicate/negative/keyword-mixed → `CONFIG_INVALID` at startup; an index past a given file's track count is a **per-file, track-scoped skip** (a corpus mixes files with different track counts).
- **Representation keying (backward-compatible):** track 0 → the **bare** `transcript` rep (unchanged, so no corpus reindexes); track N≥1 → `transcript@t<N>`; translations → `transcript@t<N>-<lang>`. The `@` delimiter never collides with the `-`-prefixed BCP-47 language suffix.
- **Meta:** track 0 omits `track` (absence ⇒ track 0); track N≥1 records `track` + the container's declared `track_language`/`track_label` when present.
- **Track-scoped failures:** a per-track transcription error or quality-gate rejection fails **only that track** (its rep is dropped, recorded as honest coverage); the **document** is `error` only if **every** selected track fails, otherwise it is ready with whatever tracks succeeded.

## Changes

- `internal/config`: `media.stt.tracks` parse/merge/validation (flat + nested + inline/block list forms) and the `ParseSTTTracks` resolver (single source of truth for the grammar).
- `internal/avutil`: `ExtractAudioTrackIndex` (`-map 0:a:<N>`) for per-track demux; `ExtractAudioTrack` refactored to share the impl (default `-vn` path unchanged).
- `internal/ingest`: track-set resolution + per-track transcribe/persist loop; `transcript@t<N>` rep-type helpers; track meta fields; deferred quality-gate doc-error for track-scoped semantics; two-phase derivation loops tracks too. New injectable `ExtractAudioTrackIndexFunc` seam.
- Re-pin `dirstral-spec` → `55151bd`.

## Test plan

- `tests/config`: `media.stt.tracks` grammar (`first`/`all`/list, dedup+sort), CONFIG_INVALID rejections, flat/nested/inline/block YAML parse, save/load round-trip, `Validate()` rejection.
- `tests/ingest` (hermetic via injected probe + `ExtractAudioTrackIndexFunc`, no ffmpeg/ffprobe): `first` (only track 0, bare key, extractor never called), `all` (each extra as `transcript@t<N>` + track/language/label meta), explicit `[0,2]` subset (stream order), one-track-fails-others-succeed → document **ready**, all-tracks-fail → document **error**, explicit out-of-range → no transcript (no silent fall-back to track 0).
- `internal/avutil`: negative-index guard.
- `make ci` green; `go vet` + `gocyclo -over 15` clean.

## Merge note

Touches `internal/ingest/service.go` + `internal/avutil/` and re-pins the submodule gitlink, so it will likely **conflict at merge with the sibling #566 PR** (service.go + gitlink) — a rebase may be needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for transcribing selected audio tracks from multi-audio media.
  - Configure `media.stt.tracks` to process the first track, all tracks, or specific track indices.
  - Added track-specific transcript and translation representations.
  - Transcript metadata now includes additional track language and label details.
- **Bug Fixes**
  - Track failures are handled independently; documents remain successful when other selected tracks complete.
  - Documents are marked as failed only when all selected tracks fail.
- **Validation**
  - Invalid, duplicate, negative, or out-of-range track selections are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->