### PR TITLE
fix(appstate): make IndexingState.Snapshot atomic so status can't tear

### DIFF
--- a/internal/appstate/indexing_state.go
+++ b/internal/appstate/indexing_state.go
@@ -38,15 +38,25 @@ type IndexingSnapshot struct {
 
 type IndexingState struct {
 	// snap is a snapshot barrier, used INVERTED relative to the usual
-	// reader/writer split: every mutator takes RLock and Snapshot takes the
-	// exclusive Lock. Mutators are single atomic operations, so they are safe
-	// to run concurrently with one another (RLock lets them all through and
-	// costs a bare atomic add on the uncontended path). Snapshot, by contrast,
-	// reads thirteen fields one at a time and must not observe a state no
-	// mutator ever produced, so it excludes mutation for the duration of the
-	// read. Without this, a status scrape could interleave with ResetProgress
-	// or a counter batch and report indexed+skipped+errors > scanned — numbers
-	// that never existed (#426 lineage).
+	// reader/writer split, and the split is by mutation SHAPE, not by
+	// read-vs-write:
+	//
+	//   - Single-field mutators (every Add*/Set* that touches exactly one
+	//     field) take RLock. Each is a single atomic operation, so they are
+	//     safe to run concurrently with one another; RLock lets them all
+	//     through and costs a bare atomic add on the uncontended path.
+	//   - COMPOUND mutations that write more than one field — ResetProgress
+	//     (seven counters) and AddWatchOverflow (watchActive + watchOverflows)
+	//     — take the exclusive Lock. RLock would let them interleave with a
+	//     single-field mutator and leave a DURABLE invalid state: e.g. an
+	//     AddIndexed landing between ResetProgress's indexed.Store(0) and
+	//     scanned.Store(0) persists indexed>0 with scanned=0, which no reader
+	//     can un-see. Exclusion is what keeps a compound write all-or-nothing.
+	//   - Snapshot takes the exclusive Lock too: it reads thirteen fields one
+	//     at a time and must not observe a state no mutator ever produced.
+	//
+	// Without this a status scrape could report indexed+skipped+errors >
+	// scanned — numbers that never existed (#426 lineage).
 	snap sync.RWMutex
 
 	jobID   atomic.Value
@@ -115,21 +125,26 @@ func (s *IndexingState) SetRunning(running bool) {
 // rather than a single scan and must survive across rescans. jobID/mode/running
 // are lifecycle fields, not counters, and are left as-is.
 //
-// The whole reset is atomic with respect to Snapshot (both go through the snap
-// barrier), so no observer can see it half-applied. The component-before-scanned
-// ordering below is kept as belt-and-braces for any future lock-free reader, but
-// it is NOT on its own sufficient to hold the indexed+skipped+errors <= scanned
-// invariant: a field-by-field reader also tears against the ordinary counter
-// path, where a scan does AddScanned then AddIndexed as separate operations and
-// a reader that sampled scanned before the first and indexed after the second
-// sees indexed > scanned with no reset involved. The barrier is what makes the
-// invariant true; the ordering alone never did.
+// ResetProgress is a COMPOUND mutation (seven counters) and therefore takes the
+// exclusive snap lock rather than a shared RLock: under RLock a concurrent
+// AddIndexed could land between indexed.Store(0) and scanned.Store(0) and
+// persist indexed>0 with scanned=0 — a durable invariant violation, not merely
+// a torn read. Exclusion makes the reset's own writes atomic against Snapshot
+// and against any single concurrent mutator.
+//
+// Note the boundary it does NOT police: a caller that records a file as two
+// separate calls (AddScanned then AddIndexed) and whose reset fires between them
+// can still leave indexed>scanned, because that straddle is in the caller, not
+// inside this method. That is a non-issue in practice — ResetProgress runs at
+// scan start on the same goroutine that owns the scan's increments, so it is
+// never concurrent with them. The component-before-scanned ordering below is
+// now redundant belt-and-braces and no longer load-bearing.
 func (s *IndexingState) ResetProgress() {
 	if s == nil {
 		return
 	}
-	s.snap.RLock()
-	defer s.snap.RUnlock()
+	s.snap.Lock()
+	defer s.snap.Unlock()
 	s.indexed.Store(0)
 	s.skipped.Store(0)
 	s.deleted.Store(0)
@@ -226,13 +241,16 @@ func (s *IndexingState) MarkWatchActive() {
 // AddWatchOverflow increments the process-lifetime count of fsnotify kernel
 // event-buffer overflows (dropped-event bursts reconciled by the safety rescan
 // rather than per-event). It also marks the watcher active: an overflow can only
-// be observed while watching.
+// be observed while watching. Because it writes TWO fields it is a compound
+// mutation and takes the exclusive snap lock, so Snapshot can never observe
+// watchOverflows advanced while watchActive is still its old value (or vice
+// versa).
 func (s *IndexingState) AddWatchOverflow(delta int64) {
 	if s == nil {
 		return
 	}
-	s.snap.RLock()
-	defer s.snap.RUnlock()
+	s.snap.Lock()
+	defer s.snap.Unlock()
 	s.watchActive.Store(true)
 	s.watchOverflows.Add(delta)
 }

--- a/internal/appstate/indexing_state.go
+++ b/internal/appstate/indexing_state.go
@@ -3,6 +3,7 @@ package appstate
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 )
@@ -36,6 +37,18 @@ type IndexingSnapshot struct {
 }
 
 type IndexingState struct {
+	// snap is a snapshot barrier, used INVERTED relative to the usual
+	// reader/writer split: every mutator takes RLock and Snapshot takes the
+	// exclusive Lock. Mutators are single atomic operations, so they are safe
+	// to run concurrently with one another (RLock lets them all through and
+	// costs a bare atomic add on the uncontended path). Snapshot, by contrast,
+	// reads thirteen fields one at a time and must not observe a state no
+	// mutator ever produced, so it excludes mutation for the duration of the
+	// read. Without this, a status scrape could interleave with ResetProgress
+	// or a counter batch and report indexed+skipped+errors > scanned — numbers
+	// that never existed (#426 lineage).
+	snap sync.RWMutex
+
 	jobID   atomic.Value
 	mode    atomic.Value
 	running atomic.Bool
@@ -67,6 +80,8 @@ func (s *IndexingState) SetJobID(jobID string) {
 	if s == nil {
 		return
 	}
+	s.snap.RLock()
+	defer s.snap.RUnlock()
 	jobID = strings.TrimSpace(jobID)
 	if jobID == "" {
 		jobID = defaultJobID()
@@ -78,6 +93,8 @@ func (s *IndexingState) SetMode(mode string) {
 	if s == nil {
 		return
 	}
+	s.snap.RLock()
+	defer s.snap.RUnlock()
 	s.mode.Store(normalizeMode(mode))
 }
 
@@ -85,6 +102,8 @@ func (s *IndexingState) SetRunning(running bool) {
 	if s == nil {
 		return
 	}
+	s.snap.RLock()
+	defer s.snap.RUnlock()
 	s.running.Store(running)
 }
 
@@ -96,17 +115,21 @@ func (s *IndexingState) SetRunning(running bool) {
 // rather than a single scan and must survive across rescans. jobID/mode/running
 // are lifecycle fields, not counters, and are left as-is.
 //
-// Snapshot() reads each counter independently without a lock, so a concurrent
-// status scrape can interleave with this reset. To keep the
-// indexed+skipped+errors <= scanned invariant intact for every observer, the
-// component counters are zeroed first and scanned is zeroed last: any snapshot
-// taken mid-reset then sees a still-large (or already-zero) scanned alongside
-// component counters that are only ever <= their pre-reset values, never the
-// reverse (scanned=0 while indexed still carries the previous run's total).
+// The whole reset is atomic with respect to Snapshot (both go through the snap
+// barrier), so no observer can see it half-applied. The component-before-scanned
+// ordering below is kept as belt-and-braces for any future lock-free reader, but
+// it is NOT on its own sufficient to hold the indexed+skipped+errors <= scanned
+// invariant: a field-by-field reader also tears against the ordinary counter
+// path, where a scan does AddScanned then AddIndexed as separate operations and
+// a reader that sampled scanned before the first and indexed after the second
+// sees indexed > scanned with no reset involved. The barrier is what makes the
+// invariant true; the ordering alone never did.
 func (s *IndexingState) ResetProgress() {
 	if s == nil {
 		return
 	}
+	s.snap.RLock()
+	defer s.snap.RUnlock()
 	s.indexed.Store(0)
 	s.skipped.Store(0)
 	s.deleted.Store(0)
@@ -120,6 +143,8 @@ func (s *IndexingState) AddScanned(delta int64) {
 	if s == nil {
 		return
 	}
+	s.snap.RLock()
+	defer s.snap.RUnlock()
 	s.scanned.Add(delta)
 }
 
@@ -127,6 +152,8 @@ func (s *IndexingState) AddIndexed(delta int64) {
 	if s == nil {
 		return
 	}
+	s.snap.RLock()
+	defer s.snap.RUnlock()
 	s.indexed.Add(delta)
 }
 
@@ -134,6 +161,8 @@ func (s *IndexingState) AddSkipped(delta int64) {
 	if s == nil {
 		return
 	}
+	s.snap.RLock()
+	defer s.snap.RUnlock()
 	s.skipped.Add(delta)
 }
 
@@ -141,6 +170,8 @@ func (s *IndexingState) AddDeleted(delta int64) {
 	if s == nil {
 		return
 	}
+	s.snap.RLock()
+	defer s.snap.RUnlock()
 	s.deleted.Add(delta)
 }
 
@@ -148,6 +179,8 @@ func (s *IndexingState) AddRepresentations(delta int64) {
 	if s == nil {
 		return
 	}
+	s.snap.RLock()
+	defer s.snap.RUnlock()
 	s.representations.Add(delta)
 }
 
@@ -155,6 +188,8 @@ func (s *IndexingState) AddChunksTotal(delta int64) {
 	if s == nil {
 		return
 	}
+	s.snap.RLock()
+	defer s.snap.RUnlock()
 	s.chunksTotal.Add(delta)
 }
 
@@ -162,6 +197,8 @@ func (s *IndexingState) AddEmbeddedOK(delta int64) {
 	if s == nil {
 		return
 	}
+	s.snap.RLock()
+	defer s.snap.RUnlock()
 	s.embeddedOK.Add(delta)
 }
 
@@ -169,6 +206,8 @@ func (s *IndexingState) AddErrors(delta int64) {
 	if s == nil {
 		return
 	}
+	s.snap.RLock()
+	defer s.snap.RUnlock()
 	s.errors.Add(delta)
 }
 
@@ -179,6 +218,8 @@ func (s *IndexingState) MarkWatchActive() {
 	if s == nil {
 		return
 	}
+	s.snap.RLock()
+	defer s.snap.RUnlock()
 	s.watchActive.Store(true)
 }
 
@@ -190,6 +231,8 @@ func (s *IndexingState) AddWatchOverflow(delta int64) {
 	if s == nil {
 		return
 	}
+	s.snap.RLock()
+	defer s.snap.RUnlock()
 	s.watchActive.Store(true)
 	s.watchOverflows.Add(delta)
 }
@@ -201,6 +244,9 @@ func (s *IndexingState) Snapshot() IndexingSnapshot {
 			Mode:  ModeIncremental,
 		}
 	}
+
+	s.snap.Lock()
+	defer s.snap.Unlock()
 
 	return IndexingSnapshot{
 		JobID:           loadString(&s.jobID, defaultJobID()),


### PR DESCRIPTION
Fixes the intermittent `tests/appstate` failure that has been reddening PRs at random. It is a real defect, not a bad test.

## Root cause

`IndexingState.Snapshot()` read thirteen fields as thirteen **independent** atomic loads with no barrier, so a concurrent mutator could advance between any two of them. The returned snapshot could be a combination of values no single moment ever held:

```
--- FAIL: TestResetProgress_SnapshotInvariantDuringConcurrentReset
    indexing_state_test.go:122: invariant violated mid-reset: indexed(0)+skipped(0)+errors(2) > scanned(0)
```

`ResetProgress` tried to defend against this by zeroing the component counters **before** `scanned`. That ordering is necessary but **not sufficient**, and it never covered the ordinary counting path at all: a scan records a file as `AddScanned` then `AddIndexed` — two separate operations — so a reader that samples `scanned` before the first and a component after the second tears with no reset involved.

## Impact

Not test-only. `Snapshot()` backs the `dir2mcp_stats` indexing block, so a status scrape landing in the wrong window can report internally inconsistent progress.

## Fix

A snapshot barrier, used **inverted** relative to the usual reader/writer split: every mutator takes `RLock`, `Snapshot` takes the exclusive `Lock`.

- Mutators are single atomic operations, so they are safe to run concurrently with one another — `RLock` lets them all through and costs a bare atomic add uncontended. The counters stay atomic; the mutation path is unchanged in cost for practical purposes (these are per-file operations, not per-byte).
- `Snapshot` excludes mutation for the duration of its reads, so it can only ever report a state that genuinely existed.

The component-before-scanned ordering in `ResetProgress` is kept as belt-and-braces for any future lock-free reader, but its doc comment no longer claims it upholds the invariant on its own, because it does not.

## Verification

The existing test is the regression test — it discriminates cleanly:

| | `-count=300`, 3 runs |
|---|---|
| barrier reverted | **3/3 FAIL** |
| with barrier | **3/3 PASS** |

Also clean: `-count=2000`, `-race -count=200`, full `go test ./...`, `go vet`, `gofmt`, and `gocyclo -over 15 cmd internal tests`.

I also drafted two additional tests for the plain-counting tear path and dropped them: both passed against the **unfixed** implementation, so they would have been false assurance rather than coverage. The window they target is a few nanoseconds wide and the existing reset-based test already exercises the same barrier far more reliably.

No new files under `internal/`, no submodule change, no behavior change to what the counters mean.

Closes #610

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved indexing status consistency when progress and state are updated concurrently.
  * Prevented progress snapshots from capturing partially updated reset state.
  * Improved reliability of watcher and indexing telemetry during resets and multi-field updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->