### PR TITLE
feat(provider,ingest,store,config,index): contextual retrieval (#330)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3309,6 +3309,12 @@ func setModelStringFileScalar(cfg *fileConfig, key, value string) {
 	if setRerankStringFileScalar(cfg, key, value) {
 		return
 	}
+	if setRetrievalContextualStringFileScalar(cfg, key, value) {
+		return
+	}
+	if setRetrievalHierarchicalStringFileScalar(cfg, key, value) {
+		return
+	}
 	switch key {
 	case "elevenlabs_base_url":
 		cfg.ElevenLabsBaseURL = strPtr(value)
@@ -3328,6 +3334,15 @@ func setModelStringFileScalar(cfg *fileConfig, key, value string) {
 		cfg.ChunkingStrategy = strPtr(value)
 	case "retrieval.hyde.mode":
 		cfg.RetrievalHyDEMode = strPtr(value)
+	}
+}
+
+// setRetrievalHierarchicalStringFileScalar assigns the retrieval.hierarchical.*
+// string keys (SPEC §9.7/§16.2, #329), returning true when key matched. Split
+// out of setModelStringFileScalar to keep that function within the gocyclo
+// budget alongside the contextual (#330) delegation.
+func setRetrievalHierarchicalStringFileScalar(cfg *fileConfig, key, value string) bool {
+	switch key {
 	case "retrieval.hierarchical.provider":
 		cfg.RetrievalHierarchicalProvider = strPtr(value)
 	case "retrieval.hierarchical.prompt_version":
@@ -3339,6 +3354,18 @@ func setModelStringFileScalar(cfg *fileConfig, key, value string) {
 		// sentinel and a single `levels: document` both parse as a scalar, so
 		// fold them into the same one-element list the block form produces.
 		setFileListValue(cfg, key, value)
+	default:
+		return false
+	}
+	return true
+}
+
+// setRetrievalContextualStringFileScalar assigns the retrieval.contextual.*
+// string keys (SPEC §8.1.8/§16.2, #330), returning true when key matched. Split
+// out of setModelStringFileScalar so that function stays within the gocyclo
+// budget once #330's cases land on top of #329's hierarchical cases.
+func setRetrievalContextualStringFileScalar(cfg *fileConfig, key, value string) bool {
+	switch key {
 	case "retrieval.contextual.provider":
 		cfg.RetrievalContextualProvider = strPtr(value)
 	case "retrieval.contextual.model":
@@ -3347,7 +3374,10 @@ func setModelStringFileScalar(cfg *fileConfig, key, value string) {
 		cfg.RetrievalContextualPromptVersion = strPtr(value)
 	case "retrieval.contextual.prompt":
 		cfg.RetrievalContextualPrompt = strPtr(value)
+	default:
+		return false
 	}
+	return true
 }
 
 // setIngestStringFileScalar assigns ingest mode and STT string keys

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -353,6 +353,43 @@ type Config struct {
 	// hypothetical-document embedding alone. Ignored when RetrievalHyDEEnabled is
 	// false. An empty value normalizes to "fuse".
 	RetrievalHyDEMode string
+	// RetrievalContextualEnabled opts IN to contextual retrieval (SPEC §8.1.8,
+	// config `retrieval.contextual.enabled`, issue #330): before a chunk is
+	// embedded, a short LLM-generated, document-aware context string is prepended
+	// to the text sent to the EMBEDDER. The persisted, displayed, and CITED chunk
+	// text stays the raw chunk, byte-for-byte (citation faithfulness, #403).
+	// Off by default. It is capability-driven and fail-open like OCR/STT: with no
+	// chat provider available the corpus embeds raw and records the effective
+	// `…|off` embed identity plus a warning, never a hard error.
+	RetrievalContextualEnabled bool
+	// RetrievalContextualProvider optionally pins the chat provider profile that
+	// generates the context (config `retrieval.contextual.provider`). Empty (the
+	// default) uses the configured chat capability binding (SPEC 8.1.3). The
+	// resolved provider — including its normalized endpoint — is part of the
+	// embed identity's contextual component (§8.1.4).
+	RetrievalContextualProvider string
+	// RetrievalContextualModel optionally overrides the generation model
+	// (config `retrieval.contextual.model`). Empty uses the resolved profile's
+	// chat model. Part of the embed identity's contextual component.
+	RetrievalContextualModel string
+	// RetrievalContextualMaxTokens caps a single generated context (config
+	// `retrieval.contextual.max_tokens`, default 128): the context is meant to be
+	// one or two sentences. A different cap can yield a different context, so it
+	// is part of the embed identity's contextual component (§8.1.4). Values <= 0
+	// are CONFIG_INVALID when contextual retrieval is enabled.
+	RetrievalContextualMaxTokens int
+	// RetrievalContextualPromptVersion names the built-in, domain-general prompt
+	// template (config `retrieval.contextual.prompt_version`, default "v1"). It
+	// and the EFFECTIVE prompt text are both folded into the embed identity's
+	// contextual component, so an edited operator override re-embeds even without
+	// a version bump (§8.1.4). An unknown version is CONFIG_INVALID when
+	// contextual retrieval is enabled and no explicit prompt override is set.
+	RetrievalContextualPromptVersion string
+	// RetrievalContextualPrompt optionally overrides the built-in prompt template
+	// (config `retrieval.contextual.prompt`). It MUST contain the {{DOCUMENT}} and
+	// {{CHUNK}} placeholders. Empty (the default) uses the built-in template named
+	// by RetrievalContextualPromptVersion.
+	RetrievalContextualPrompt string
 	// CrossLingualEnabled enables server-side cross-lingual query expansion
 	// (config `retrieval.cross_lingual.enabled`): when true and a translator is
 	// available, the query is translated into the corpus's other languages, each
@@ -893,6 +930,12 @@ type fileConfig struct {
 	RetrievalMMRLambda                 *float64
 	RetrievalHyDEEnabled               *bool
 	RetrievalHyDEMode                  *string
+	RetrievalContextualEnabled         *bool
+	RetrievalContextualProvider        *string
+	RetrievalContextualModel           *string
+	RetrievalContextualMaxTokens       *int
+	RetrievalContextualPromptVersion   *string
+	RetrievalContextualPrompt          *string
 	CrossLingualEnabled                *bool
 	CrossLingualTargetLangs            []string
 	RetrievalHierarchicalEnabled       *bool
@@ -1046,6 +1089,12 @@ type persistedConfig struct {
 	RetrievalMMRLambda                 float64       `yaml:"retrieval_mmr_lambda"`
 	RetrievalHyDEEnabled               bool          `yaml:"retrieval_hyde_enabled"`
 	RetrievalHyDEMode                  string        `yaml:"retrieval_hyde_mode"`
+	RetrievalContextualEnabled         bool          `yaml:"retrieval_contextual_enabled"`
+	RetrievalContextualProvider        string        `yaml:"retrieval_contextual_provider"`
+	RetrievalContextualModel           string        `yaml:"retrieval_contextual_model"`
+	RetrievalContextualMaxTokens       int           `yaml:"retrieval_contextual_max_tokens"`
+	RetrievalContextualPromptVersion   string        `yaml:"retrieval_contextual_prompt_version"`
+	RetrievalContextualPrompt          string        `yaml:"retrieval_contextual_prompt"`
 	CrossLingualEnabled                bool          `yaml:"cross_lingual_enabled"`
 	CrossLingualTargetLangs            []string      `yaml:"cross_lingual_target_langs"`
 	RetrievalHierarchicalEnabled       bool          `yaml:"retrieval_hierarchical_enabled"`
@@ -1274,6 +1323,17 @@ func Default() Config {
 		// RetrievalHyDEMode defaults to "fuse": when HyDE is enabled the
 		// hypothetical-document hits are RRF-fused with the raw-query hits.
 		RetrievalHyDEMode: HyDEModeFuse,
+		// Contextual retrieval (SPEC §8.1.8, #330) defaults to OFF: chunks embed
+		// raw and the embed identity's terminal component stays "off", so an
+		// existing corpus is byte-identical to before the feature existed. The
+		// bound and prompt version carry their defaults so an enabled-but-
+		// unspecified config behaves predictably.
+		RetrievalContextualEnabled:       false,
+		RetrievalContextualProvider:      "",
+		RetrievalContextualModel:         "",
+		RetrievalContextualMaxTokens:     DefaultContextualMaxTokens,
+		RetrievalContextualPromptVersion: ContextualPromptVersionV1,
+		RetrievalContextualPrompt:        "",
 		// CrossLingualEnabled defaults to false (disabled): cross-lingual query
 		// expansion is off unless explicitly enabled. The target-langs list is
 		// left empty, which means "auto" (the corpus's detected languages).
@@ -1444,6 +1504,12 @@ func buildPersistedConfig(cfg *Config) persistedConfig {
 		RetrievalMMRLambda:                 cfg.RetrievalMMRLambda,
 		RetrievalHyDEEnabled:               cfg.RetrievalHyDEEnabled,
 		RetrievalHyDEMode:                  cfg.RetrievalHyDEMode,
+		RetrievalContextualEnabled:         cfg.RetrievalContextualEnabled,
+		RetrievalContextualProvider:        cfg.RetrievalContextualProvider,
+		RetrievalContextualModel:           cfg.RetrievalContextualModel,
+		RetrievalContextualMaxTokens:       cfg.RetrievalContextualMaxTokens,
+		RetrievalContextualPromptVersion:   cfg.RetrievalContextualPromptVersion,
+		RetrievalContextualPrompt:          cfg.RetrievalContextualPrompt,
 		CrossLingualEnabled:                cfg.CrossLingualEnabled,
 		CrossLingualTargetLangs:            append([]string(nil), cfg.CrossLingualTargetLangs...),
 		RetrievalHierarchicalEnabled:       cfg.RetrievalHierarchicalEnabled,
@@ -1616,6 +1682,7 @@ func SaveEffectiveSnapshot(cfg Config, sources SecretSourceMetadata) (string, er
 	providers := cfg.Providers()
 	raw = appendSnapshotEmbedIdentity(raw, providers.EmbedIdentity())
 	raw = appendSnapshotEmbedBaseURL(raw, providers.EmbedBaseURL())
+	raw = appendSnapshotEmbedContextual(raw, providers.EmbedContextual())
 	if len(raw) == 0 || raw[len(raw)-1] != '\n' {
 		raw = append(raw, '\n')
 	}
@@ -1691,6 +1758,26 @@ func appendSnapshotEmbedBaseURL(raw []byte, baseURL string) []byte {
 		raw = append(raw, '\n')
 	}
 	return append(raw, []byte("embed_base_url: "+baseURL+"\n")...)
+}
+
+// appendSnapshotEmbedContextual records the effective contextual-retrieval
+// component of the embed identity (SPEC §5.5 `embed_contextual`, §8.1.4/§8.1.8)
+// alongside the composite identity, so the mode that pins the vector space is
+// legible without parsing the identity. It is the SAME value already folded into
+// embed_identity's terminal field. The line is OMITTED for the `off` default —
+// per §5.5 an absent key is treated as `off`, so a non-contextual corpus's
+// snapshot stays byte-identical to a pre-feature one. A top-level scalar —
+// ignored by the flat config parser and the providers:/model: yaml subtree
+// decode on reload.
+func appendSnapshotEmbedContextual(raw []byte, contextual string) []byte {
+	contextual = strings.TrimSpace(contextual)
+	if contextual == "" || contextual == provider.EmbedContextualOff {
+		return raw
+	}
+	if len(raw) > 0 && raw[len(raw)-1] != '\n' {
+		raw = append(raw, '\n')
+	}
+	return append(raw, []byte("embed_contextual: "+contextual+"\n")...)
 }
 
 // appendSnapshotSecretSourceMetadata appends a `secret_sources:` block
@@ -2175,6 +2262,7 @@ func applyRetrievalTuningFileParsed(cfg *Config, fc fileConfig) {
 		cfg.CrossLingualTargetLangs = normalizeStringSlice(fc.CrossLingualTargetLangs)
 	}
 	applyHierarchicalFileParsed(cfg, fc)
+	applyRetrievalContextualFileParsed(cfg, fc)
 }
 
 // applyHierarchicalFileParsed overlays the opt-in hierarchical (coarse-to-fine)
@@ -2201,6 +2289,31 @@ func applyHierarchicalFileParsed(cfg *Config, fc fileConfig) {
 	}
 	if fc.RetrievalHierarchicalPrompt != nil {
 		cfg.RetrievalHierarchicalPrompt = *fc.RetrievalHierarchicalPrompt
+	}
+}
+
+// applyRetrievalContextualFileParsed overlays the opt-in contextual-retrieval
+// block (`retrieval.contextual.*`, SPEC §8.1.8/§16.2, issue #330) onto cfg.
+// Split out of applyRetrievalTuningFileParsed so both stay within the gocyclo
+// budget.
+func applyRetrievalContextualFileParsed(cfg *Config, fc fileConfig) {
+	if fc.RetrievalContextualEnabled != nil {
+		cfg.RetrievalContextualEnabled = *fc.RetrievalContextualEnabled
+	}
+	if fc.RetrievalContextualProvider != nil {
+		cfg.RetrievalContextualProvider = *fc.RetrievalContextualProvider
+	}
+	if fc.RetrievalContextualModel != nil {
+		cfg.RetrievalContextualModel = *fc.RetrievalContextualModel
+	}
+	if fc.RetrievalContextualMaxTokens != nil {
+		cfg.RetrievalContextualMaxTokens = *fc.RetrievalContextualMaxTokens
+	}
+	if fc.RetrievalContextualPromptVersion != nil {
+		cfg.RetrievalContextualPromptVersion = *fc.RetrievalContextualPromptVersion
+	}
+	if fc.RetrievalContextualPrompt != nil {
+		cfg.RetrievalContextualPrompt = *fc.RetrievalContextualPrompt
 	}
 }
 
@@ -2689,6 +2802,13 @@ var configKeyAliases = map[string]string{
 	"hyde_enabled":                            "retrieval.hyde.enabled",
 	"retrieval_hyde_mode":                     "retrieval.hyde.mode",
 	"hyde_mode":                               "retrieval.hyde.mode",
+	"retrieval_contextual_enabled":            "retrieval.contextual.enabled",
+	"contextual_enabled":                      "retrieval.contextual.enabled",
+	"retrieval_contextual_provider":           "retrieval.contextual.provider",
+	"retrieval_contextual_model":              "retrieval.contextual.model",
+	"retrieval_contextual_max_tokens":         "retrieval.contextual.max_tokens",
+	"retrieval_contextual_prompt_version":     "retrieval.contextual.prompt_version",
+	"retrieval_contextual_prompt":             "retrieval.contextual.prompt",
 	"cross_lingual_enabled":                   "retrieval.cross_lingual.enabled",
 	"cross_lingual":                           "retrieval.cross_lingual.enabled",
 	"cross_lingual_target_langs":              "retrieval.cross_lingual.target_langs",
@@ -2841,7 +2961,7 @@ func isMapSectionKey(key string) bool {
 		return true
 	}
 	switch key {
-	case "rag", "ingest", "ingest.docling", "ingest.pandoc", "stt", "stt.mistral", "stt.elevenlabs", "server", "server.tls", "secret_sources", "mistral", "docling", "pandoc", "security", "security.auth", "x402", "x402.route_policy", "x402.route_policy.tools_call", "chunking", "retrieval", "retrieval.hybrid", "retrieval.context_compression", "retrieval.adaptive", "retrieval.mmr", "retrieval.hyde", "retrieval.cross_lingual", "retrieval.hierarchical", "rerank", "rerank.cohere", "index", "dedup":
+	case "rag", "ingest", "ingest.docling", "ingest.pandoc", "stt", "stt.mistral", "stt.elevenlabs", "server", "server.tls", "secret_sources", "mistral", "docling", "pandoc", "security", "security.auth", "x402", "x402.route_policy", "x402.route_policy.tools_call", "chunking", "retrieval", "retrieval.hybrid", "retrieval.context_compression", "retrieval.adaptive", "retrieval.mmr", "retrieval.hyde", "retrieval.contextual", "retrieval.cross_lingual", "retrieval.hierarchical", "rerank", "rerank.cohere", "index", "dedup":
 		return true
 	case "ingest.pdf", "ingest.images", "ingest.audio", "ingest.archives", "secrets", "index.qdrant":
 		return true
@@ -2915,15 +3035,18 @@ var boolFileScalarTargets = map[string]func(*fileConfig) **bool{
 	"media.trim_leading_silence": func(c *fileConfig) **bool {
 		return &c.MediaTrimLeadingSilence
 	},
-	"media.vad":                       func(c *fileConfig) **bool { return &c.MediaVAD },
-	"media.diarize.enabled":           func(c *fileConfig) **bool { return &c.MediaDiarizeEnabled },
-	"media.batch.two_phase":           func(c *fileConfig) **bool { return &c.MediaBatchTwoPhase },
-	"media.batch.progress":            func(c *fileConfig) **bool { return &c.MediaBatchProgress },
-	"x402_tools_call_enabled":         func(c *fileConfig) **bool { return &c.X402ToolsCallEnabled },
-	"retrieval.hybrid.enabled":        func(c *fileConfig) **bool { return &c.RetrievalHybridEnabled },
-	"retrieval.adaptive.enabled":      func(c *fileConfig) **bool { return &c.RetrievalAdaptiveEnabled },
-	"retrieval.mmr.enabled":           func(c *fileConfig) **bool { return &c.RetrievalMMREnabled },
-	"retrieval.hyde.enabled":          func(c *fileConfig) **bool { return &c.RetrievalHyDEEnabled },
+	"media.vad":                  func(c *fileConfig) **bool { return &c.MediaVAD },
+	"media.diarize.enabled":      func(c *fileConfig) **bool { return &c.MediaDiarizeEnabled },
+	"media.batch.two_phase":      func(c *fileConfig) **bool { return &c.MediaBatchTwoPhase },
+	"media.batch.progress":       func(c *fileConfig) **bool { return &c.MediaBatchProgress },
+	"x402_tools_call_enabled":    func(c *fileConfig) **bool { return &c.X402ToolsCallEnabled },
+	"retrieval.hybrid.enabled":   func(c *fileConfig) **bool { return &c.RetrievalHybridEnabled },
+	"retrieval.adaptive.enabled": func(c *fileConfig) **bool { return &c.RetrievalAdaptiveEnabled },
+	"retrieval.mmr.enabled":      func(c *fileConfig) **bool { return &c.RetrievalMMREnabled },
+	"retrieval.hyde.enabled":     func(c *fileConfig) **bool { return &c.RetrievalHyDEEnabled },
+	"retrieval.contextual.enabled": func(c *fileConfig) **bool {
+		return &c.RetrievalContextualEnabled
+	},
 	"retrieval.cross_lingual.enabled": func(c *fileConfig) **bool { return &c.CrossLingualEnabled },
 	"retrieval.hierarchical.enabled":  func(c *fileConfig) **bool { return &c.RetrievalHierarchicalEnabled },
 	"dedup.retrieval":                 func(c *fileConfig) **bool { return &c.DedupRetrieval },
@@ -2957,11 +3080,14 @@ func setBoolFileScalar(cfg *fileConfig, key, value string) error {
 // keeps setIntFileScalar a flat dispatch (one new entry per key) rather than an
 // ever-growing switch that trips the cyclomatic-complexity gate.
 var intFileScalarTargets = map[string]func(*fileConfig) **int{
-	"rate_limit_rps":                     func(c *fileConfig) **int { return &c.RateLimitRPS },
-	"rate_limit_burst":                   func(c *fileConfig) **int { return &c.RateLimitBurst },
-	"rag.k_default":                      func(c *fileConfig) **int { return &c.RAGKDefault },
-	"retrieval.adaptive.k_min":           func(c *fileConfig) **int { return &c.RetrievalAdaptiveKMin },
-	"retrieval.adaptive.k_max":           func(c *fileConfig) **int { return &c.RetrievalAdaptiveKMax },
+	"rate_limit_rps":           func(c *fileConfig) **int { return &c.RateLimitRPS },
+	"rate_limit_burst":         func(c *fileConfig) **int { return &c.RateLimitBurst },
+	"rag.k_default":            func(c *fileConfig) **int { return &c.RAGKDefault },
+	"retrieval.adaptive.k_min": func(c *fileConfig) **int { return &c.RetrievalAdaptiveKMin },
+	"retrieval.adaptive.k_max": func(c *fileConfig) **int { return &c.RetrievalAdaptiveKMax },
+	"retrieval.contextual.max_tokens": func(c *fileConfig) **int {
+		return &c.RetrievalContextualMaxTokens
+	},
 	"rag.max_context_chars":              func(c *fileConfig) **int { return &c.RAGMaxContextChars },
 	"rag.oversample_factor":              func(c *fileConfig) **int { return &c.RAGOversampleFactor },
 	"chunking.max_tokens":                func(c *fileConfig) **int { return &c.ChunkingMaxTokens },
@@ -3015,6 +3141,7 @@ func setIntFileScalar(cfg *fileConfig, key, value string) error {
 // deterministic) rather than being silently clamped later.
 var nonNegativeIntKeys = map[string]bool{
 	"retrieval.adaptive.k_min":                true,
+	"retrieval.contextual.max_tokens":         true,
 	"retrieval.adaptive.k_max":                true,
 	"media.audio_window_sec":                  true,
 	"media.translate.whisper_window_sec":      true,
@@ -3212,6 +3339,14 @@ func setModelStringFileScalar(cfg *fileConfig, key, value string) {
 		// sentinel and a single `levels: document` both parse as a scalar, so
 		// fold them into the same one-element list the block form produces.
 		setFileListValue(cfg, key, value)
+	case "retrieval.contextual.provider":
+		cfg.RetrievalContextualProvider = strPtr(value)
+	case "retrieval.contextual.model":
+		cfg.RetrievalContextualModel = strPtr(value)
+	case "retrieval.contextual.prompt_version":
+		cfg.RetrievalContextualPromptVersion = strPtr(value)
+	case "retrieval.contextual.prompt":
+		cfg.RetrievalContextualPrompt = strPtr(value)
 	}
 }
 
@@ -3415,6 +3550,12 @@ func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	writeScalar("retrieval_mmr_lambda", strconv.FormatFloat(cfg.RetrievalMMRLambda, 'f', -1, 64))
 	writeBool("retrieval_hyde_enabled", cfg.RetrievalHyDEEnabled)
 	writeScalar("retrieval_hyde_mode", cfg.RetrievalHyDEMode)
+	writeBool("retrieval_contextual_enabled", cfg.RetrievalContextualEnabled)
+	writeScalar("retrieval_contextual_provider", cfg.RetrievalContextualProvider)
+	writeScalar("retrieval_contextual_model", cfg.RetrievalContextualModel)
+	writeInt("retrieval_contextual_max_tokens", cfg.RetrievalContextualMaxTokens)
+	writeScalar("retrieval_contextual_prompt_version", cfg.RetrievalContextualPromptVersion)
+	writeScalar("retrieval_contextual_prompt", cfg.RetrievalContextualPrompt)
 	writeBool("cross_lingual_enabled", cfg.CrossLingualEnabled)
 	writeList("cross_lingual_target_langs", cfg.CrossLingualTargetLangs)
 	writeBool("retrieval_hierarchical_enabled", cfg.RetrievalHierarchicalEnabled)
@@ -3742,6 +3883,7 @@ func applyIngestEnvOverrides(cfg *Config, env map[string]string) {
 		{"DIR2MCP_INGEST_WATCH", &cfg.IngestWatch},
 		{"DIR2MCP_RETRIEVAL_HYBRID_ENABLED", &cfg.RetrievalHybridEnabled},
 		{"DIR2MCP_RETRIEVAL_ADAPTIVE_ENABLED", &cfg.RetrievalAdaptiveEnabled},
+		{"DIR2MCP_RETRIEVAL_CONTEXTUAL_ENABLED", &cfg.RetrievalContextualEnabled},
 	} {
 		applyBoolEnvField(o.field, o.key, env)
 	}
@@ -4486,7 +4628,7 @@ func (c *Config) validateRetrievalNumericBounds() error {
 	if err := c.normalizeHierarchical(); err != nil {
 		return err
 	}
-	return nil
+	return c.validateRetrievalContextual()
 }
 
 // normalizeHierarchical normalizes and validates the retrieval.hierarchical

--- a/internal/config/contextual.go
+++ b/internal/config/contextual.go
@@ -1,0 +1,235 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/dirstral/dir2mcp/internal/provider"
+)
+
+// Contextual-retrieval constants (SPEC §8.1.8/§16.2, issue #330).
+const (
+	// DefaultContextualMaxTokens bounds one generated context. The context is
+	// meant to be one or two sentences, so the cap is deliberately tight — it
+	// keeps per-chunk generation cheap and prevents a runaway completion from
+	// dominating the embed input.
+	DefaultContextualMaxTokens = 128
+
+	// ContextualPromptVersionV1 names the shipped, domain-general prompt
+	// template. The version tag and the EFFECTIVE prompt text are both folded
+	// into the embed identity (SPEC §8.1.4), so bumping the template here is a
+	// deliberate re-embed.
+	ContextualPromptVersionV1 = "v1"
+
+	// ContextualDocumentPlaceholder / ContextualChunkPlaceholder are the
+	// placeholders a prompt template (built-in or operator override) MUST carry.
+	ContextualDocumentPlaceholder = "{{DOCUMENT}}"
+	ContextualChunkPlaceholder    = "{{CHUNK}}"
+)
+
+// contextualPromptV1 is the built-in, DOMAIN-GENERAL context prompt. It makes no
+// assumption about corpus subject, language, or document type: the model is asked
+// only to situate the chunk inside its own document and to answer with nothing
+// but that context. Keeping it domain-free is a hard project constraint — a
+// corpus-specific prompt belongs in an operator override, never in the default.
+const contextualPromptV1 = `<document>
+` + ContextualDocumentPlaceholder + `
+</document>
+
+Here is the chunk we want to situate within the whole document:
+<chunk>
+` + ContextualChunkPlaceholder + `
+</chunk>
+
+Give a short, succinct context (one or two sentences) that situates this chunk
+within the overall document, so the chunk can be found by a search engine.
+Write the context in the same language as the chunk. Answer with the context
+only — no preamble, no quotes, no explanation.`
+
+// contextualPromptTemplates maps a prompt_version tag to its built-in template.
+// Adding a version here is additive; changing an existing one re-embeds every
+// corpus that uses it, so versions are append-only in practice.
+var contextualPromptTemplates = map[string]string{
+	ContextualPromptVersionV1: contextualPromptV1,
+}
+
+// ContextualPromptVersions returns the known built-in prompt-version tags, for
+// error messages and docs.
+func ContextualPromptVersions() []string {
+	return []string{ContextualPromptVersionV1}
+}
+
+// ContextualPromptTemplate returns the built-in template for version, or
+// ("", false) when the version is unknown.
+func ContextualPromptTemplate(version string) (string, bool) {
+	tmpl, ok := contextualPromptTemplates[strings.TrimSpace(version)]
+	return tmpl, ok
+}
+
+// ContextualEffectivePrompt returns the prompt template actually used to
+// generate per-chunk context: the operator override verbatim when
+// `retrieval.contextual.prompt` is set, else the built-in template named by
+// `retrieval.contextual.prompt_version`. The result is what gets HASHED into the
+// embed identity (SPEC §8.1.4), so an edited override re-embeds even without a
+// prompt_version bump. An unknown version with no override yields ("", false).
+func (c Config) ContextualEffectivePrompt() (string, bool) {
+	if override := strings.TrimSpace(c.RetrievalContextualPrompt); override != "" {
+		return override, true
+	}
+	return ContextualPromptTemplate(c.contextualPromptVersion())
+}
+
+// contextualPromptVersion is the effective prompt_version: the configured value,
+// or the v1 default when unset (an empty value in a hand-written config must not
+// silently disable the feature).
+func (c Config) contextualPromptVersion() string {
+	if v := strings.TrimSpace(c.RetrievalContextualPromptVersion); v != "" {
+		return v
+	}
+	return ContextualPromptVersionV1
+}
+
+// contextualMaxTokens is the effective generation bound, defaulting when unset.
+func (c Config) contextualMaxTokens() int {
+	if c.RetrievalContextualMaxTokens > 0 {
+		return c.RetrievalContextualMaxTokens
+	}
+	return DefaultContextualMaxTokens
+}
+
+// RenderContextualPrompt substitutes the document and chunk into prompt. Both
+// placeholders are replaced wherever they appear; a template lacking one is
+// rejected by validation, never silently rendered without its input.
+func RenderContextualPrompt(prompt, document, chunk string) string {
+	rendered := strings.ReplaceAll(prompt, ContextualDocumentPlaceholder, document)
+	return strings.ReplaceAll(rendered, ContextualChunkPlaceholder, chunk)
+}
+
+// ContextualBinding is the fully resolved contextual-retrieval activation for a
+// config: whether contextualization is EFFECTIVELY on, the generator profile and
+// model it runs on, the bound, the effective prompt, and the resulting embed
+// identity component (SPEC §8.1.4/§8.1.8).
+//
+// It is the single source of truth shared by the config snapshot (which records
+// the component), the embed identity (which compares it), and the ingest service
+// (which generates the context) — so the recorded identity can never drift from
+// what actually ran.
+type ContextualBinding struct {
+	// Active reports whether contextualization is EFFECTIVELY on: enabled in
+	// config AND a chat provider resolved. False for both "disabled" and the
+	// capability fail-open, which the spec requires to be indistinguishable in
+	// the recorded identity (§8.1.4).
+	Active bool
+	// Profile is the resolved chat profile (zero value when inactive).
+	Profile provider.Profile
+	// Model is the effective generation model (empty when inactive).
+	Model string
+	// MaxTokens is the effective per-context generation bound.
+	MaxTokens int
+	// Prompt is the effective prompt template (empty when inactive).
+	Prompt string
+	// PromptVersion is the effective built-in template tag.
+	PromptVersion string
+	// Identity is the embed-identity `contextual` component: provider.
+	// EmbedContextualOff when inactive, else the "ctx:<hash>" generator token.
+	Identity string
+	// FellOpen reports that the operator ENABLED contextual retrieval but no chat
+	// provider resolved, so the corpus embeds raw under an `…|off` identity. It
+	// drives the one-time warning (SPEC §8.1.8 fail-open); it is deliberately NOT
+	// part of the identity.
+	FellOpen bool
+}
+
+// ContextualBinding resolves the effective contextual-retrieval activation for
+// cfg (SPEC §8.1.8). It is capability-driven and fail-open, exactly like OCR/STT:
+// with `enabled: false`, or with `enabled: true` but no chat-capable provider
+// resolvable, the binding is inactive and its Identity is the literal `off` — the
+// corpus embeds raw and its recorded identity says so. Recording an "on" token
+// for raw vectors would make the corpus look contextual-compatible the moment a
+// chat provider is added, silently mixing raw and contextualized vectors.
+func (cfg Config) ContextualBinding() ContextualBinding {
+	binding := ContextualBinding{
+		MaxTokens:     cfg.contextualMaxTokens(),
+		PromptVersion: cfg.contextualPromptVersion(),
+		Identity:      provider.EmbedContextualOff,
+	}
+	if !cfg.RetrievalContextualEnabled {
+		return binding
+	}
+	prompt, ok := cfg.ContextualEffectivePrompt()
+	if !ok {
+		// Validation rejects an unknown prompt_version, so this is unreachable for
+		// a validated config; fail open rather than embed under a prompt we cannot
+		// name.
+		binding.FellOpen = true
+		return binding
+	}
+	prof, err := cfg.resolveContextualProfile()
+	if err != nil {
+		binding.FellOpen = true
+		return binding
+	}
+	model := strings.TrimSpace(cfg.RetrievalContextualModel)
+	if model == "" {
+		model = strings.TrimSpace(prof.ChatModel)
+	}
+	binding.Active = true
+	binding.Profile = prof
+	binding.Model = model
+	binding.Prompt = prompt
+	binding.Identity = provider.ContextualIdentity(provider.ContextualSpec{
+		Profile:       prof,
+		Model:         model,
+		MaxTokens:     binding.MaxTokens,
+		PromptVersion: binding.PromptVersion,
+		Prompt:        prompt,
+	})
+	return binding
+}
+
+// resolveContextualProfile resolves the chat profile that generates the context:
+// the explicitly pinned `retrieval.contextual.provider` when set, else the
+// configured chat capability binding (SPEC 8.1.3).
+func (cfg Config) resolveContextualProfile() (provider.Profile, error) {
+	// baseProviders (not Providers) — Providers stamps the contextual component,
+	// which is what we are computing here; going through it would recurse.
+	resolution := cfg.baseProviders()
+	if pinned := strings.TrimSpace(cfg.RetrievalContextualProvider); pinned != "" {
+		// required=false: an unusable pin falls open to `off` (embed raw + warn)
+		// like every other contextual-retrieval failure, rather than hard-failing
+		// ingest (SPEC §8.1.8).
+		return resolution.ResolveExplicit(provider.CapChat, pinned, false)
+	}
+	return resolution.Resolve(provider.CapChat)
+}
+
+// validateRetrievalContextual enforces the static `retrieval.contextual` rules
+// (SPEC §16.2). They apply only when the feature is enabled, so a default config
+// is never affected. A missing chat provider is deliberately NOT an error here —
+// that is the fail-open capability path (§8.1.8), reported as a warning at
+// startup instead.
+func (c *Config) validateRetrievalContextual() error {
+	if !c.RetrievalContextualEnabled {
+		return nil
+	}
+	if c.RetrievalContextualMaxTokens <= 0 {
+		return fmt.Errorf(
+			"retrieval.contextual.max_tokens must be > 0 when retrieval.contextual.enabled is true: %d",
+			c.RetrievalContextualMaxTokens)
+	}
+	if override := strings.TrimSpace(c.RetrievalContextualPrompt); override != "" {
+		for _, placeholder := range []string{ContextualDocumentPlaceholder, ContextualChunkPlaceholder} {
+			if !strings.Contains(override, placeholder) {
+				return fmt.Errorf(
+					"retrieval.contextual.prompt override must contain the %s placeholder", placeholder)
+			}
+		}
+		return nil
+	}
+	if _, ok := ContextualPromptTemplate(c.contextualPromptVersion()); !ok {
+		return fmt.Errorf(
+			"retrieval.contextual.prompt_version %q is unknown; use one of %s (or set retrieval.contextual.prompt)",
+			c.RetrievalContextualPromptVersion, strings.Join(ContextualPromptVersions(), ", "))
+	}
+	return nil
+}

--- a/internal/config/providers.go
+++ b/internal/config/providers.go
@@ -689,6 +689,13 @@ type ProviderResolution struct {
 	// into the corpus-lifetime identity (SPEC 8.1.4). It is not a provider
 	// attribute, so it lives on the resolution rather than on a Profile.
 	lateChunking bool
+	// contextual is the EFFECTIVE contextual-retrieval component of the embed
+	// identity (SPEC 8.1.4/8.1.8, issue #330), stamped by Config.Providers from
+	// the resolved ContextualBinding: provider.EmbedContextualOff when the
+	// feature is off OR fell open for want of a chat provider, else the
+	// "ctx:<hash>" generator token. Like lateChunking it is not a provider
+	// attribute, so it lives on the resolution.
+	contextual string
 }
 
 // providersResolution builds the resolution from the parsed doc + env.
@@ -1049,7 +1056,16 @@ func (r ProviderResolution) EmbedIdentity() string {
 	if err != nil {
 		return ""
 	}
-	return provider.EmbedIdentity(p, r.lateChunking)
+	return provider.EmbedIdentity(p, r.lateChunking, r.contextual)
+}
+
+// EmbedContextual is the terminal `contextual` component of the corpus-lifetime
+// embed identity (SPEC 8.1.4/8.1.8), recorded separately in the config snapshot
+// as `embed_contextual` (§5.5) so an operator can read the effective
+// contextualization mode without parsing the composite identity. It is
+// provider.EmbedContextualOff unless contextual retrieval is EFFECTIVELY on.
+func (r ProviderResolution) EmbedContextual() string {
+	return provider.NormalizeEmbedContextual(r.contextual)
 }
 
 // EmbedBaseURL is the normalized embed base_url component of the corpus-lifetime
@@ -1069,6 +1085,20 @@ func (r ProviderResolution) EmbedBaseURL() string {
 // credential expansion (SPEC §8.1). The CLI wiring (C2-iii) calls
 // Resolve per capability and builds the adapter via providerfactory.
 func (cfg Config) Providers() ProviderResolution {
+	r := cfg.baseProviders()
+	// Fold the EFFECTIVE contextual-retrieval mode onto the resolution so the
+	// embed identity captures it (SPEC 8.1.4/8.1.8, issue #330). Resolved from
+	// the binding (not the raw config flag) so a fail-open corpus records `off`.
+	r.contextual = cfg.ContextualBinding().Identity
+	return r
+}
+
+// baseProviders builds the provider resolution WITHOUT the contextual-retrieval
+// identity component. ContextualBinding itself has to resolve the chat
+// capability, so it uses this rather than Providers() — otherwise the two would
+// recurse into each other. The component is irrelevant to capability resolution
+// (it only enters EmbedIdentity), so the distinction is invisible to callers.
+func (cfg Config) baseProviders() ProviderResolution {
 	base := builtinProfiles()
 	seedLegacy(base, cfg)
 	r := cfg.providersDoc.resolve(base, nil)

--- a/internal/index/embedding_worker.go
+++ b/internal/index/embedding_worker.go
@@ -151,7 +151,7 @@ func buildEmbedBatch(tasks []model.ChunkTask) (validTasks []model.ChunkTask, inp
 			return nil, nil, nil, fmt.Errorf("%w: zero label not supported", ErrFatal)
 		}
 		validTasks = append(validTasks, task)
-		inputs = append(inputs, task.Text)
+		inputs = append(inputs, task.EmbedInput())
 		labels = append(labels, chunkID)
 	}
 	return validTasks, inputs, labels, nil
@@ -187,7 +187,11 @@ func (w *EmbeddingWorker) embedTasks(ctx context.Context, modelName string, vali
 			continue
 		}
 		textIdx = append(textIdx, i)
-		textInputs = append(textInputs, t.Text)
+		// EmbedInput, not Text: under contextual retrieval (SPEC §8.1.8) the
+		// embedder receives `context + "\n\n" + chunk` while the chunk's stored,
+		// displayed and CITED text stays raw (#403). With the feature off (the
+		// default) EmbedInput IS Text, byte-for-byte.
+		textInputs = append(textInputs, t.EmbedInput())
 	}
 
 	if len(textInputs) > 0 {
@@ -761,7 +765,10 @@ func (w *EmbeddingWorker) skipOversizeText(ctx context.Context, tasks []model.Ch
 	keptLabels := make([]uint64, 0, len(labels))
 	var oversize []uint64
 	for i, t := range tasks {
-		if !isMediaModality(t.Modality) && utf8.RuneCountInString(t.Text) > maxRunes {
+		// Measure the input actually sent to the provider (the contextualized text
+		// when contextual retrieval is on), so the oversize pre-skip cannot be
+		// under-counted into a provider-rejected batch.
+		if !isMediaModality(t.Modality) && utf8.RuneCountInString(t.EmbedInput()) > maxRunes {
 			oversize = append(oversize, labels[i])
 			continue
 		}

--- a/internal/ingest/contextual.go
+++ b/internal/ingest/contextual.go
@@ -1,0 +1,164 @@
+package ingest
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// maxContextDocumentRunes bounds how much of the parent document is shown to the
+// context generator. Contextual retrieval is document-aware, but a whole large
+// document would blow past a chat model's window and make every per-chunk call
+// expensive; the leading window carries the title/lead that situates a chunk.
+// The bound is applied to the prompt only — the CACHE KEY hashes the full
+// document snapshot, so a change past the cutoff still re-derives (the safe
+// direction: over-derive, never serve a stale context).
+const maxContextDocumentRunes = 24000
+
+// maxGeneratedContextRunes is a defensive ceiling on what a generator may return
+// for one chunk. `max_tokens` already bounds the completion on providers that
+// honour it; this guards the embed input against a provider that does not, so a
+// runaway completion can never dominate the chunk it is supposed to situate.
+const maxGeneratedContextRunes = 2000
+
+// ChunkContextualizer generates the per-chunk, document-aware context strings
+// contextual retrieval prepends to a chunk's EMBED input (SPEC §8.1.8). It is
+// the seam the representation generator holds, so contextualization can be
+// exercised without a live chat provider.
+type ChunkContextualizer interface {
+	// Contextualize returns the context for chunkText within docText. An error is
+	// FAIL-OPEN per chunk: the caller embeds that chunk raw and records
+	// model.EmbeddingModeFallback, never failing ingest.
+	Contextualize(ctx context.Context, docText, chunkText string) (string, error)
+}
+
+// chunkContextGenerator is the production ChunkContextualizer: it renders the
+// effective prompt, calls the bound chat generator under a tight max-tokens cap,
+// and caches the result content-addressed by
+// (chunk content, parent-document snapshot, generator identity) per SPEC §8.6.7 —
+// so an unchanged document re-scans without a single provider round-trip, and
+// ANY change to those inputs re-derives.
+type chunkContextGenerator struct {
+	gen       model.Generator
+	prompt    string
+	maxTokens int
+	// identity is the canonical generator-identity token (`ctx:<hash>`) that is
+	// also the embed identity's terminal component. Folding it into the cache key
+	// means a provider/model/max_tokens/prompt change MISSES the cache instead of
+	// returning a context another generator produced.
+	identity string
+	cacheDir string
+	logf     func(format string, args ...any)
+}
+
+// newChunkContextGenerator builds the production contextualizer from a resolved
+// binding. cacheDir may be empty, which disables caching (generation still
+// works) rather than failing.
+func newChunkContextGenerator(gen model.Generator, binding config.ContextualBinding, cacheDir string, logf func(string, ...any)) *chunkContextGenerator {
+	return &chunkContextGenerator{
+		gen:       gen,
+		prompt:    binding.Prompt,
+		maxTokens: binding.MaxTokens,
+		identity:  binding.Identity,
+		cacheDir:  cacheDir,
+		logf:      logf,
+	}
+}
+
+// Contextualize implements ChunkContextualizer.
+func (g *chunkContextGenerator) Contextualize(ctx context.Context, docText, chunkText string) (string, error) {
+	if g == nil || g.gen == nil {
+		return "", fmt.Errorf("contextual retrieval: no generator bound")
+	}
+	if strings.TrimSpace(chunkText) == "" {
+		return "", nil
+	}
+	cachePath := g.cachePath(docText, chunkText)
+	if cachePath != "" {
+		if cached, err := os.ReadFile(cachePath); err == nil {
+			return string(cached), nil
+		}
+	}
+
+	prompt := config.RenderContextualPrompt(g.prompt, truncateRunes(docText, maxContextDocumentRunes), chunkText)
+	out, err := g.generateBounded(ctx, prompt)
+	if err != nil {
+		return "", err
+	}
+	// One or two sentences on one line: collapse whitespace runs so the context
+	// cannot inject blank lines into the embed input, then bound it defensively.
+	out = truncateRunes(strings.Join(strings.Fields(out), " "), maxGeneratedContextRunes)
+	if out == "" {
+		return "", fmt.Errorf("contextual retrieval: generator returned an empty context")
+	}
+	g.writeCache(cachePath, out)
+	return out, nil
+}
+
+// generateBounded runs the generator under the configured per-context token cap
+// when it implements model.BoundedGenerator, else falls back to plain Generate —
+// mirroring ingest's translate path and retrieval's boundedGenerate.
+func (g *chunkContextGenerator) generateBounded(ctx context.Context, prompt string) (string, error) {
+	if g.maxTokens > 0 {
+		if bg, ok := g.gen.(model.BoundedGenerator); ok {
+			return bg.GenerateWithMaxTokens(ctx, prompt, g.maxTokens)
+		}
+	}
+	return g.gen.Generate(ctx, prompt)
+}
+
+// cachePath is the on-disk cache file for one (chunk, parent document,
+// generator) triple, or "" when caching is disabled. The PARENT-DOCUMENT hash is
+// part of the key, not only the chunk's own bytes (design 0004 §3): the context
+// is document-aware, so a title edit or a change to a neighbouring section
+// alters it even when the chunk's bytes are unchanged and MUST re-derive.
+func (g *chunkContextGenerator) cachePath(docText, chunkText string) string {
+	if strings.TrimSpace(g.cacheDir) == "" {
+		return ""
+	}
+	key := computeContentHash([]byte(strings.Join([]string{
+		computeContentHash([]byte(chunkText)),
+		computeContentHash([]byte(docText)),
+		g.identity,
+	}, "\x00")))
+	return filepath.Join(g.cacheDir, key+".txt")
+}
+
+// writeCache persists a generated context best-effort: a cache write failure
+// costs a regeneration next scan, never the ingest.
+func (g *chunkContextGenerator) writeCache(cachePath, contextText string) {
+	if cachePath == "" {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(cachePath), 0o755); err != nil {
+		g.warn("contextual retrieval: create cache dir: %v", err)
+		return
+	}
+	if err := os.WriteFile(cachePath, []byte(contextText), 0o644); err != nil {
+		g.warn("contextual retrieval: write cache: %v", err)
+	}
+}
+
+func (g *chunkContextGenerator) warn(format string, args ...any) {
+	if g.logf != nil {
+		g.logf(format, args...)
+	}
+}
+
+// truncateRunes caps s at max runes (rune-safe, so a multi-byte character is
+// never split). A non-positive max returns s unchanged.
+func truncateRunes(s string, max int) string {
+	if max <= 0 {
+		return s
+	}
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	return string(runes[:max])
+}

--- a/internal/ingest/derivation.go
+++ b/internal/ingest/derivation.go
@@ -283,6 +283,14 @@ func (s *Service) activeOCRIdentityForPath(relPath string) string {
 // The caller is responsible for only invoking this on the content-unchanged,
 // status==ok path; under --force/reindex the normal gate already returns true.
 func (s *Service) derivationIdentityStale(ctx context.Context, relPath string) bool {
+	// Contextual-retrieval self-heal (SPEC §8.1.8, issue #330) runs before the
+	// representation-meta gates because it needs no meta reader: a document that
+	// still carries a `fallback` chunk is reprocessed while contextualization
+	// stays on, so a failed generation is RETRIED rather than left as a silent,
+	// permanent hole in coverage.
+	if s.contextFallbackStale(ctx, relPath) {
+		return true
+	}
 	reader, ok := s.store.(representationMetaReader)
 	if !ok {
 		return false
@@ -291,6 +299,39 @@ func (s *Service) derivationIdentityStale(ctx context.Context, relPath string) b
 		return true
 	}
 	return s.ocrStale(ctx, reader, relPath)
+}
+
+// fallbackContextChunkReader is the optional store capability behind the
+// contextual-retrieval retry gate (SPEC §8.1.8): it reports whether a document
+// still has a live chunk whose context generation failed (embedding_mode =
+// fallback). A store that does not implement it simply disables the retry —
+// preserving prior behaviour rather than failing.
+type fallbackContextChunkReader interface {
+	HasFallbackContextChunks(ctx context.Context, relPath string) (bool, error)
+}
+
+// contextFallbackStale reports whether the document has chunks that embedded RAW
+// because their context generation failed, and contextualization is still on —
+// in which case the document is reprocessed so those chunks are retried
+// (self-heal toward full coverage, SPEC §8.1.8). It self-skips when
+// contextualization is off, so a corpus that later disables the feature is not
+// re-derived forever by stale fallback rows.
+func (s *Service) contextFallbackStale(ctx context.Context, relPath string) bool {
+	if !s.contextualActive {
+		return false
+	}
+	reader, ok := s.store.(fallbackContextChunkReader)
+	if !ok {
+		return false
+	}
+	pending, err := reader.HasFallbackContextChunks(ctx, relPath)
+	if err != nil || !pending {
+		return false
+	}
+	s.getLogger().Printf(
+		"contextual retrieval: %s has chunks whose context generation failed; retrying them this scan (SPEC §8.1.8)",
+		relPath)
+	return true
 }
 
 // transcriptStale reports whether the document's stored machine transcript was

--- a/internal/ingest/represent.go
+++ b/internal/ingest/represent.go
@@ -72,6 +72,11 @@ type RepresentationGenerator struct {
 	// from config. A raw_text rep has no operator pin or source declaration, so
 	// detection is the only language signal (recorded as language_source=detected).
 	langDetectEnabled bool
+	// contextualizer generates the per-chunk, document-aware context contextual
+	// retrieval prepends to a chunk's EMBED input (SPEC §8.1.8). Nil (default)
+	// means the feature is off — the Service binds it only when contextual
+	// retrieval is effectively enabled.
+	contextualizer ChunkContextualizer
 }
 
 // SetLanguageDetection enables or disables best-effort raw_text language
@@ -307,6 +312,11 @@ func (rg *RepresentationGenerator) upsertChunksForRepresentationWithStore(ctx co
 	if decision.quarantine {
 		embeddingStatus = "error"
 	}
+	// Contextual retrieval (SPEC §8.1.8, issue #330): resolve each chunk's
+	// document-aware context BEFORE the loop so the parent-document text is built
+	// once. Off by default — with no contextualizer bound this is a no-op and
+	// every chunk records embedding_mode=disabled, exactly as before.
+	contexts := rg.chunkContexts(ctx, segments)
 	for i, seg := range segments {
 		chunk := model.Chunk{
 			RepID:           repID,
@@ -317,6 +327,8 @@ func (rg *RepresentationGenerator) upsertChunksForRepresentationWithStore(ctx co
 			EmbeddingStatus: embeddingStatus,
 			EmbeddingError:  decision.embErr,
 			ErrorCategory:   decision.category,
+			Context:         contexts[i].text,
+			EmbeddingMode:   contexts[i].mode,
 		}
 		// A kind-less span carries no provenance (e.g. a structured chunk whose
 		// source elements exposed no page); persist the chunk with no span row
@@ -333,6 +345,70 @@ func (rg *RepresentationGenerator) upsertChunksForRepresentationWithStore(ctx co
 		return fmt.Errorf("soft delete stale chunks: %w", err)
 	}
 	return nil
+}
+
+// chunkContextState is one chunk's resolved contextual-retrieval outcome: the
+// generated context (empty unless generation succeeded) and the durable
+// per-chunk embedding_mode that disambiguates it (SPEC §5.3/§8.1.8).
+type chunkContextState struct {
+	text string
+	mode string
+}
+
+// SetContextualizer binds the per-chunk context generator used by contextual
+// retrieval (SPEC §8.1.8). Nil (the default) leaves the feature off: every chunk
+// records embedding_mode=disabled with no context, and the chunk writer is
+// byte-for-byte what it was before the feature existed.
+func (rg *RepresentationGenerator) SetContextualizer(c ChunkContextualizer) {
+	rg.contextualizer = c
+}
+
+// chunkContexts resolves the document-aware context for every segment of one
+// representation, returning states aligned 1:1 with segments.
+//
+// The "parent document" is the representation's own text — the segments joined
+// in order — so the generator sees the whole document a chunk came from without
+// the chunk writer needing the upstream source bytes. That joined text is also
+// what the cache key hashes (design 0004 §3), so a change ANYWHERE in the
+// document re-derives every one of its chunk contexts.
+//
+// Generation is FAIL-OPEN PER CHUNK (SPEC §8.1.8): a generator error leaves that
+// chunk with no context and mode=fallback — it embeds raw, in the same vector
+// space as its contextualized neighbours — instead of failing ingest. A fallback
+// chunk is retried on the next scan while contextualization stays on.
+func (rg *RepresentationGenerator) chunkContexts(ctx context.Context, segments []chunkSegment) []chunkContextState {
+	states := make([]chunkContextState, len(segments))
+	for i := range states {
+		states[i].mode = model.EmbeddingModeDisabled
+	}
+	if rg.contextualizer == nil || len(segments) == 0 {
+		return states
+	}
+	docText := joinSegmentTexts(segments)
+	for i, seg := range segments {
+		if strings.TrimSpace(seg.Text) == "" {
+			continue // nothing to situate; stays disabled, embeds raw
+		}
+		generated, err := rg.contextualizer.Contextualize(ctx, docText, seg.Text)
+		if err != nil || strings.TrimSpace(generated) == "" {
+			// Never log the chunk text or the generated context (they are corpus
+			// content); the error alone is what an operator needs.
+			states[i].mode = model.EmbeddingModeFallback
+			continue
+		}
+		states[i] = chunkContextState{text: generated, mode: model.EmbeddingModeContextualized}
+	}
+	return states
+}
+
+// joinSegmentTexts reconstructs the parent-document text a representation's
+// chunks were cut from, in chunk order.
+func joinSegmentTexts(segments []chunkSegment) string {
+	parts := make([]string, 0, len(segments))
+	for _, seg := range segments {
+		parts = append(parts, seg.Text)
+	}
+	return strings.Join(parts, "\n")
 }
 
 // binarySniffLen bounds how many leading bytes looksLikeBinaryContent inspects.

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -178,6 +178,14 @@ type Service struct {
 	summaryProvider string
 	summaryModel    string
 
+	// contextualActive reports whether contextual retrieval (SPEC §8.1.8, issue
+	// #330) is EFFECTIVELY on for this service: enabled in config AND a chat
+	// generator was successfully bound. False for both "disabled" and the
+	// capability fail-open, matching the effective mode the embed identity
+	// records. It gates the fallback-chunk retry gate; the contextualizer itself
+	// lives on repGen.
+	contextualActive bool
+
 	// embedMultimodal is the resolved multimodal embedding mode (SPEC
 	// 8.1.7): "off" (default), "augment", or "replace". When augment/
 	// replace, media documents additionally (or exclusively) get a media
@@ -798,7 +806,41 @@ func NewService(cfg config.Config, store model.Store) (*Service, error) {
 	if ep, err := cfg.Providers().Resolve(provider.CapEmbed); err == nil {
 		svc.embedMultimodal = provider.NormalizeEmbedMultimodal(ep.EmbedMultimodal)
 	}
+	svc.resolveContextualBinding(cfg)
 	return svc, nil
+}
+
+// resolveContextualBinding resolves the optional contextual-retrieval binding
+// (SPEC §8.1.8, issue #330) and, when it is effectively active, builds the
+// per-chunk context generator the representation generator uses.
+//
+// Capability-driven and FAIL-OPEN, exactly like OCR/STT: with the feature off,
+// with no chat provider resolvable, or with a generator that cannot be built,
+// the contextualizer stays nil — the corpus embeds raw under the effective
+// `…|off` embed identity plus a warning, never a hard error and never a raw
+// corpus wearing a contextual identity.
+func (svc *Service) resolveContextualBinding(cfg config.Config) {
+	binding := cfg.ContextualBinding()
+	svc.contextualActive = binding.Active
+	if binding.FellOpen {
+		svc.getLogger().Printf(
+			"contextual retrieval requested (retrieval.contextual.enabled=true) but no chat provider is available; " +
+				"embedding raw chunks and recording the effective `off` embed identity (SPEC §8.1.8) — " +
+				"configure a chat-capable provider to enable it")
+		return
+	}
+	if !binding.Active || svc.repGen == nil {
+		return
+	}
+	gen, err := providerfactory.Generator(binding.Profile)
+	if err != nil {
+		svc.contextualActive = false
+		svc.getLogger().Printf(
+			"contextual retrieval disabled: build context generator (%s): %v", binding.Profile.Name, err)
+		return
+	}
+	svc.repGen.SetContextualizer(newChunkContextGenerator(
+		gen, binding, filepath.Join(cfg.StateDir, "cache", "context"), svc.getLogger().Printf))
 }
 
 // resolveTranslateBinding resolves the optional transcript-translation binding
@@ -1341,6 +1383,17 @@ func (s *Service) SetTranslator(translator model.Generator, providerName, modelN
 		}
 	}
 	s.translateTargetLangs = norm
+}
+
+// SetContextualizer overrides the contextual-retrieval binding (SPEC §8.1.8),
+// primarily for tests and for callers that supply their own generator. Passing a
+// nil contextualizer disables contextualization: every chunk then records
+// embedding_mode=disabled and embeds raw, exactly as before the feature existed.
+func (s *Service) SetContextualizer(c ChunkContextualizer) {
+	s.contextualActive = c != nil
+	if s.repGen != nil {
+		s.repGen.SetContextualizer(c)
+	}
 }
 
 // SetTranslateTranscriber overrides the whisper translate-task binding and

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -230,6 +230,48 @@ type Chunk struct {
 	// specific filter. Additive: a corpus indexed before any language was
 	// recorded simply has empty values here (no migration, §9.5).
 	Language string
+	// Context is the generated document-aware context for contextual retrieval
+	// (SPEC §5.3 `chunk_context` / §8.1.8, issue #330). It is prepended to the
+	// text sent to the EMBEDDER only — never to Text, which stays the raw,
+	// displayed and CITED chunk (citation faithfulness, #403). Empty when
+	// contextual retrieval is off or the chunk fell back to raw.
+	Context string
+	// EmbeddingMode is the per-chunk contextualization state (SPEC §5.3
+	// `embedding_mode`): EmbeddingModeDisabled, EmbeddingModeContextualized, or
+	// EmbeddingModeFallback. It disambiguates an empty Context — feature off vs.
+	// context generated vs. generation failed — and is what the re-embed gate
+	// reads to retry fallback chunks. It is NOT part of the embed identity
+	// (§8.1.4): it is per-chunk state within one contextual corpus. Empty
+	// normalizes to EmbeddingModeDisabled.
+	EmbeddingMode string
+}
+
+// Per-chunk contextualization states (SPEC §5.3 `embedding_mode` / §8.1.8).
+const (
+	// EmbeddingModeDisabled means contextual retrieval was off for this chunk
+	// (feature disabled, fell open to off, or the chunk has no text to
+	// contextualize, e.g. a media chunk): it embedded raw with no context.
+	EmbeddingModeDisabled = "disabled"
+	// EmbeddingModeContextualized means a context was generated and prepended to
+	// this chunk's embed input.
+	EmbeddingModeContextualized = "contextualized"
+	// EmbeddingModeFallback means context generation FAILED for this chunk, so it
+	// embedded raw (fail-open per chunk). Such a chunk is retried on the next scan
+	// while contextualization stays on, and is counted in honest coverage — never
+	// a silent, permanent hole.
+	EmbeddingModeFallback = "fallback"
+)
+
+// NormalizeEmbeddingMode maps an empty/unknown value to EmbeddingModeDisabled so
+// a pre-feature row (no recorded mode) reads as "contextual retrieval was off",
+// exactly as SPEC §5.3 requires.
+func NormalizeEmbeddingMode(mode string) string {
+	switch mode {
+	case EmbeddingModeContextualized, EmbeddingModeFallback:
+		return mode
+	default:
+		return EmbeddingModeDisabled
+	}
 }
 
 type Span struct {
@@ -691,6 +733,29 @@ type ChunkTask struct {
 	// corpus rel_path whose bytes the worker embeds. Empty/"text" for text.
 	Modality string
 	MediaRef string
+	// Context is the chunk's generated document-aware context (SPEC §8.1.8,
+	// issue #330). It participates in EmbedInput ONLY: Text remains the raw
+	// chunk that snippets, reranking, and citations use, so the generated
+	// context can never leak into a quote (citation faithfulness, #403). Empty
+	// unless contextual retrieval produced a context for this chunk.
+	Context string
+}
+
+// contextualEmbedSeparator joins a generated context to its chunk in the embed
+// input (SPEC §8.1.8: `context + "\n\n" + chunk`).
+const contextualEmbedSeparator = "\n\n"
+
+// EmbedInput is the text actually sent to the embedder for this task. It is the
+// raw chunk Text unless contextual retrieval generated a Context for the chunk,
+// in which case it is `context + "\n\n" + chunk` (SPEC §8.1.8). This is the ONLY
+// place the two are joined: every display/citation path reads Text directly, so
+// the generated context never reaches a snippet, an open_file result, or an
+// answer quote (#403).
+func (t ChunkTask) EmbedInput() string {
+	if t.Context == "" {
+		return t.Text
+	}
+	return t.Context + contextualEmbedSeparator + t.Text
 }
 
 // NewChunkTask returns a task with the supplied components. If the provided

--- a/internal/provider/contextual.go
+++ b/internal/provider/contextual.go
@@ -1,0 +1,89 @@
+package provider
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strconv"
+	"strings"
+)
+
+// EmbedContextualOff is the value of the terminal `contextual` component of the
+// embed identity (SPEC 8.1.4/8.1.8) when contextual retrieval is NOT in effect —
+// either because it is disabled, or because it is enabled but no chat provider
+// resolved (capability fail-open, §8.1.8). It is a NAMED token rather than a
+// bare boolean so future modes can be added without another identity-field
+// migration, and it is the value every pre-feature recorded identity migrates to
+// (normalizeEmbedIdentity), so no existing corpus spuriously reindexes.
+const EmbedContextualOff = "off"
+
+// embedContextualPrefix prefixes the generator-identity hash so the component is
+// self-describing in a recorded identity and can never be confused with the
+// "off" token.
+const embedContextualPrefix = "ctx:"
+
+// ContextualSpec is the canonical set of context-GENERATOR inputs the embed
+// identity's `contextual` component hashes (SPEC 8.1.4/8.1.8). Every input that
+// can change the generated context string belongs here; anything else (e.g. the
+// per-chunk embedding_mode, or retrieval.contextual.bm25, which changes only the
+// lexical index) deliberately does NOT.
+type ContextualSpec struct {
+	// Profile is the resolved chat profile that generates the context. Its Name
+	// and its NORMALIZED base_url (the same normalization the embed identity
+	// applies, §8.1.4) enter the hash: a different endpoint serving the same
+	// model name is a different generator.
+	Profile Profile
+	// Model is the effective generation model (the profile's chat model, or an
+	// operator override).
+	Model string
+	// MaxTokens is the generation bound; a different cap can yield a different
+	// context, so it is part of the identity.
+	MaxTokens int
+	// PromptVersion names the built-in prompt template.
+	PromptVersion string
+	// Prompt is the EFFECTIVE prompt text (built-in template, or the operator
+	// override verbatim). Folding the text in means an edited override re-embeds
+	// even without a prompt_version bump — a version tag alone cannot detect it.
+	Prompt string
+}
+
+// ContextualIdentity renders spec as the opaque `ctx:<hash>` token used as the
+// terminal `contextual` component of the embed identity (SPEC 8.1.4/8.1.8) and
+// as the generator half of the per-chunk context cache key (§8.6.7).
+//
+// The serialization is deterministic — a fixed field order joined by an explicit
+// NUL separator that cannot occur in any of the inputs — and the digest is the
+// corpus's standard content hash (sha256, §7.6). Hashing (rather than nesting
+// the fields inline) keeps the component a SINGLE opaque token, so it can never
+// collide with the outer "|" identity delimiter and no escaping is needed.
+func ContextualIdentity(spec ContextualSpec) string {
+	fields := []string{
+		strings.TrimSpace(spec.Profile.Name),
+		normalizeEmbedBaseURL(spec.Profile),
+		strings.TrimSpace(spec.Model),
+		strconv.Itoa(spec.MaxTokens),
+		strings.TrimSpace(spec.PromptVersion),
+		spec.Prompt,
+	}
+	sum := sha256.Sum256([]byte(strings.Join(fields, "\x00")))
+	return embedContextualPrefix + hex.EncodeToString(sum[:])
+}
+
+// NormalizeEmbedContextual maps the empty value to EmbedContextualOff so "" and
+// "off" are equivalent everywhere (identity construction and comparison), and
+// trims a recorded/computed token. A non-empty value is otherwise returned
+// verbatim: it is an opaque generator-identity token whose case and content are
+// significant.
+func NormalizeEmbedContextual(contextual string) string {
+	c := strings.TrimSpace(contextual)
+	if c == "" {
+		return EmbedContextualOff
+	}
+	return c
+}
+
+// ContextualActive reports whether a contextual component names an actual
+// generator (i.e. contextualization was effectively ON for the corpus) rather
+// than the disabled/fail-open "off" token.
+func ContextualActive(contextual string) bool {
+	return strings.HasPrefix(NormalizeEmbedContextual(contextual), embedContextualPrefix)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -307,10 +307,11 @@ func Select(precedence []Profile, byName map[string]Profile, cap Capability, exp
 // EmbedIdentity is the corpus-lifetime embed identity (SPEC 8.1.4):
 // provider name + normalized embed base_url + text/code model + requested
 // text/code output dimension (8.1.6) + multimodal mode (8.1.7) + late-chunking
-// mode (issue #332/#446). It is recorded in the config snapshot/index and
-// compared on load. Role (8.1.5) is deliberately excluded — it does not affect
-// vector-space compatibility, but the base_url, requested dimension, multimodal
-// mode, and late-chunking mode do.
+// mode (issue #332/#446) + contextual-retrieval mode (8.1.8, issue #330). It is
+// recorded in the config snapshot/index and compared on load. Role (8.1.5) is
+// deliberately excluded — it does not affect vector-space compatibility, but the
+// base_url, requested dimension, multimodal mode, late-chunking mode, and
+// contextual mode do.
 //
 // The normalized base_url (2nd field, SPEC 8.1.4 order
 // provider|base_url|text_model|…) disambiguates two same-kind/same-model
@@ -331,8 +332,19 @@ func Select(precedence []Profile, byName map[string]Profile, cap Capability, exp
 // it keys off the config flag, not the runtime TokenEmbedder capability (which
 // EmbedIdentity cannot observe), so toggling the flag re-derives even in a build
 // with no token-embedding provider — the safe direction.
-func EmbedIdentity(p Profile, lateChunking bool) string {
-	return fmt.Sprintf("%s|%s|%s|%s|%d|%d|%s|%s",
+//
+// contextual is the TERMINAL (9th) field: the EFFECTIVE contextual-retrieval
+// mode (8.1.8) — EmbedContextualOff when the feature is disabled OR enabled
+// without an available chat provider (capability fail-open), else the
+// ContextualIdentity token "ctx:<hash>" naming the generator that produced the
+// prepended context. Unlike late_chunking it records the effective mode rather
+// than config intent: recording "on" for a corpus that actually embedded raw
+// would let raw and contextualized vectors silently mix the moment a chat
+// provider is added. Empty normalizes to EmbedContextualOff so a caller that has
+// no contextual notion records the identity a fresh non-contextual build
+// computes.
+func EmbedIdentity(p Profile, lateChunking bool, contextual string) string {
+	return fmt.Sprintf("%s|%s|%s|%s|%d|%d|%s|%s|%s",
 		strings.TrimSpace(p.Name),
 		normalizeEmbedBaseURL(p),
 		strings.TrimSpace(p.EmbedTextModel),
@@ -340,7 +352,8 @@ func EmbedIdentity(p Profile, lateChunking bool) string {
 		p.EmbedTextDim,
 		p.EmbedCodeDim,
 		NormalizeEmbedMultimodal(p.EmbedMultimodal),
-		normalizeLateChunking(lateChunking))
+		normalizeLateChunking(lateChunking),
+		NormalizeEmbedContextual(contextual))
 }
 
 // canonicalEmbedBaseURLByBuiltin maps a built-in embed profile NAME to the
@@ -590,23 +603,32 @@ func VerifyEmbedIdentity(recorded, current string) error {
 }
 
 // normalizeEmbedIdentity upgrades a legacy recorded identity to the current
-// 8-field form (provider|base_url|text|code|tdim|cdim|multimodal|late-chunking)
+// 9-field form
+// (provider|base_url|text|code|tdim|cdim|multimodal|late_chunking|contextual)
 // before comparison, so upgrading an existing corpus that used native
-// dimensions, no multimodal mode, no late chunking, and a hosted-default
-// endpoint does not force a spurious reindex.
+// dimensions, no multimodal mode, no late chunking, a hosted-default endpoint,
+// and no contextual retrieval does not force a spurious reindex.
 //
+// This is the SPEC 8.1.4 migration ladder, keyed on the recorded FIELD COUNT.
 // EVERY pre-base_url form gains an EMPTY base_url component inserted at
 // position 2 (issue #560/#440 F3) — an index built before the base_url rule
 // recorded no endpoint, which is identity-equal to any current profile whose
-// base_url normalizes to "" (all built-in/hosted-default deployments):
-//   - pre-8.1.6 (3 fields: provider|text|code)             → insert "" + append "|0|0|off|off"
-//   - pre-8.1.7 (5 fields: …|tdim|cdim)                    → insert "" + append "|off|off"
-//   - pre-late-chunking (6 fields: …|multimodal, #446)     → insert "" + append "|off"
-//   - pre-base_url (7 fields: …|multimodal|late-chunking)  → insert "" only
+// base_url normalizes to "" (all built-in/hosted-default deployments) — and
+// every pre-contextual form gains a terminal "|off" (issue #330), the token that
+// means "contextual retrieval disabled":
+//   - pre-8.1.6 (3 fields: provider|text|code)                 → insert "" + append "|0|0|off|off|off"
+//   - pre-8.1.7 (5 fields: …|tdim|cdim)                        → insert "" + append "|off|off|off"
+//   - pre-late-chunking (6 fields: …|multimodal, #446)         → insert "" + append "|off|off"
+//   - pre-base_url (7 fields: …|multimodal|late_chunking)      → insert "" + append "|off"
+//   - pre-contextual (8 fields: the form every shipped index
+//     records today)                                           → append "|off"
 //
-// Empty (fresh index) and already-8-field values are returned unchanged. A
-// base_url component never contains "|" (canonicalizeEmbedBaseURL drops query/
-// fragment and percent-encodes the path), so field counting is unambiguous.
+// Empty (fresh index) and already-9-field values are returned unchanged. An
+// UNRECOGNIZED field count is also returned unchanged so it fails the identity
+// comparison LOUDLY rather than being coerced into a false match. No component
+// can contain "|" (canonicalizeEmbedBaseURL drops query/fragment and
+// percent-encodes the path; the contextual component is a single opaque token),
+// so field counting is unambiguous.
 func normalizeEmbedIdentity(id string) string {
 	if id == "" {
 		return ""
@@ -614,14 +636,16 @@ func normalizeEmbedIdentity(id string) string {
 	parts := strings.Split(id, "|")
 	switch len(parts) {
 	case 3: // pre-8.1.6
-		return insertEmbedBaseURLField(parts) + "|0|0|off|off"
+		return insertEmbedBaseURLField(parts) + "|0|0|off|off|off"
 	case 5: // pre-8.1.7
-		return insertEmbedBaseURLField(parts) + "|off|off"
+		return insertEmbedBaseURLField(parts) + "|off|off|off"
 	case 6: // pre-late-chunking
-		return insertEmbedBaseURLField(parts) + "|off"
+		return insertEmbedBaseURLField(parts) + "|off|off"
 	case 7: // pre-base_url (had the late-chunking field, no base_url)
-		return insertEmbedBaseURLField(parts)
-	default: // already 8 fields (current), or an unrecognized shape → unchanged
+		return insertEmbedBaseURLField(parts) + "|off"
+	case 8: // pre-contextual (8.1.8): the form shipped implementations record today
+		return id + "|" + EmbedContextualOff
+	default: // already 9 fields (current), or an unrecognized shape → unchanged
 		return id
 	}
 }

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -296,8 +296,8 @@ func languageFromRepMeta(metaJSON string) string {
 func insertChunkWithSpansWith(ctx context.Context, exec dbExecutor, chunk model.Chunk, spans []model.Span, relPath, docType, repType, language string) (int64, error) {
 	_, err := exec.ExecContext(
 		ctx,
-		`INSERT INTO chunks(rep_id, ordinal, rel_path, doc_type, rep_type, text, text_hash, tokens_est, index_kind, modality, media_ref, language, embedding_status, embedding_error, error_category, deleted)
-		 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`INSERT INTO chunks(rep_id, ordinal, rel_path, doc_type, rep_type, text, text_hash, tokens_est, index_kind, modality, media_ref, language, embedding_status, embedding_error, error_category, chunk_context, embedding_mode, deleted)
+		 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		 ON CONFLICT(rep_id, ordinal) DO UPDATE SET
 		   rel_path=excluded.rel_path,
 		   doc_type=excluded.doc_type,
@@ -312,6 +312,8 @@ func insertChunkWithSpansWith(ctx context.Context, exec dbExecutor, chunk model.
 		   embedding_status=excluded.embedding_status,
 		   embedding_error=excluded.embedding_error,
 		   error_category=excluded.error_category,
+		   chunk_context=excluded.chunk_context,
+		   embedding_mode=excluded.embedding_mode,
 		   deleted=excluded.deleted`,
 		chunk.RepID,
 		chunk.Ordinal,
@@ -328,6 +330,8 @@ func insertChunkWithSpansWith(ctx context.Context, exec dbExecutor, chunk model.
 		normalizeEmbeddingStatus(chunk.EmbeddingStatus),
 		strings.TrimSpace(chunk.EmbeddingError),
 		strings.TrimSpace(chunk.ErrorCategory),
+		chunk.Context,
+		model.NormalizeEmbeddingMode(chunk.EmbeddingMode),
 		boolToInt(chunk.Deleted),
 	)
 	if err != nil {
@@ -599,6 +603,17 @@ func applyAdditiveColumnMigrations(ctx context.Context, db *sql.DB) error {
 		// honest coverage ("what wasn't indexed & why", #414/#395). Existing rows
 		// default to '' (unknown reason), which the aggregate normalizes.
 		`ALTER TABLE documents ADD COLUMN skip_reason TEXT NOT NULL DEFAULT ''`,
+		// chunk_context / embedding_mode back contextual retrieval (SPEC §5.3,
+		// §8.1.8, issue #330). chunk_context holds the generated document-aware
+		// context prepended to the chunk's EMBED input only — never to `text`,
+		// which stays the raw, displayed and CITED chunk (#403). embedding_mode
+		// disambiguates an empty context: 'disabled' (feature off), 'contextualized'
+		// (context generated), or 'fallback' (generation failed, embedded raw).
+		// Both are additive: a pre-feature index gets '' / 'disabled' on every
+		// existing row, which is exactly how the spec says such a corpus must read,
+		// and its embed identity migrates to `…|off` — so no reindex.
+		`ALTER TABLE chunks ADD COLUMN chunk_context TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE chunks ADD COLUMN embedding_mode TEXT NOT NULL DEFAULT 'disabled'`,
 	}
 	for _, stmt := range migrations {
 		if _, err := db.ExecContext(ctx, stmt); err != nil && !isDuplicateColumnError(err) {
@@ -683,6 +698,8 @@ CREATE TABLE IF NOT EXISTS chunks (
   embedding_status TEXT NOT NULL DEFAULT 'pending',
   embedding_error TEXT NOT NULL DEFAULT '',
   error_category TEXT NOT NULL DEFAULT '',
+  chunk_context TEXT NOT NULL DEFAULT '',
+  embedding_mode TEXT NOT NULL DEFAULT 'disabled',
   deleted INTEGER NOT NULL DEFAULT 0,
   UNIQUE(rep_id, ordinal),
   FOREIGN KEY (rep_id) REFERENCES representations(rep_id) ON DELETE CASCADE
@@ -1716,7 +1733,7 @@ func (s *SQLiteStore) ChunkTaskByID(ctx context.Context, chunkID uint64) (task m
 
 	row := db.QueryRowContext(ctx, `
 WITH the_chunk AS (
-  SELECT chunk_id, rel_path, doc_type, rep_type, text, text_hash, index_kind, modality, media_ref, language
+  SELECT chunk_id, rel_path, doc_type, rep_type, text, text_hash, index_kind, modality, media_ref, language, chunk_context
   FROM chunks
   WHERE chunk_id = ? AND deleted = 0
 ),
@@ -1726,7 +1743,7 @@ ranked_spans AS (
   FROM spans s
   JOIN the_chunk tc ON tc.chunk_id = s.chunk_id
 )
-SELECT tc.chunk_id, tc.rel_path, tc.doc_type, tc.rep_type, tc.text, tc.text_hash, tc.index_kind, tc.modality, tc.media_ref, tc.language,
+SELECT tc.chunk_id, tc.rel_path, tc.doc_type, tc.rep_type, tc.text, tc.text_hash, tc.index_kind, tc.modality, tc.media_ref, tc.language, tc.chunk_context,
        COALESCE(sp.span_kind, ''), COALESCE(sp.start, 0), COALESCE(sp.end, 0), COALESCE(sp.extra_json, ''), COALESCE(d.mtime_unix, 0)
 FROM the_chunk tc
 LEFT JOIN ranked_spans sp ON sp.chunk_id = tc.chunk_id AND sp.rn = 1
@@ -1743,13 +1760,14 @@ LEFT JOIN documents d ON d.rel_path = tc.rel_path`, int64(chunkID))
 		modality  string
 		mediaRef  string
 		language  string
+		chunkCtx  string
 		spanK     string
 		spanS     int
 		spanE     int
 		spanExtra string
 		mtimeUnix int64
 	)
-	if scanErr := row.Scan(&cid, &relPath, &docType, &repType, &text, &thash, &idxKind, &modality, &mediaRef, &language,
+	if scanErr := row.Scan(&cid, &relPath, &docType, &repType, &text, &thash, &idxKind, &modality, &mediaRef, &language, &chunkCtx,
 		&spanK, &spanS, &spanE, &spanExtra, &mtimeUnix); scanErr != nil {
 		if errors.Is(scanErr, sql.ErrNoRows) {
 			return model.ChunkTask{}, "", model.ErrNotFound
@@ -1775,6 +1793,11 @@ LEFT JOIN documents d ON d.rel_path = tc.rel_path`, int64(chunkID))
 	})
 	t.Modality = modality
 	t.MediaRef = mediaRef
+	// The generated context rides on the task's Context field only — Text stays
+	// the raw chunk, so a caller that renders a snippet/citation from this task
+	// (reranking, liveness) can never surface it (SPEC §8.1.8, #403). Only the
+	// embed path reads it, via ChunkTask.EmbedInput.
+	t.Context = chunkCtx
 	return t, thash, nil
 }
 
@@ -2310,6 +2333,7 @@ func (s *SQLiteStore) NextPending(ctx context.Context, limit int, indexKind stri
 	// chunk with no document row (e.g. UpsertChunkTask seeds a bare chunk).
 	query := `WITH filtered_chunks AS (
 	            SELECT c.chunk_id, c.rel_path, c.doc_type, c.rep_type, c.text, c.index_kind, c.modality, c.media_ref, c.language,
+	                   c.chunk_context,
 	                   COALESCE(d.mtime_unix, 0) AS mtime_unix
 	            FROM chunks c
 	            LEFT JOIN documents d ON d.rel_path = c.rel_path
@@ -2323,6 +2347,7 @@ func (s *SQLiteStore) NextPending(ctx context.Context, limit int, indexKind stri
 	            JOIN filtered_chunks fc ON fc.chunk_id = s.chunk_id
 	          )
 	          SELECT fc.chunk_id, fc.rel_path, fc.doc_type, fc.rep_type, fc.text, fc.index_kind, fc.modality, fc.media_ref, fc.language,
+	                 fc.chunk_context,
 	                 COALESCE(sp.span_kind, ''), COALESCE(sp.start, 0), COALESCE(sp.end, 0), COALESCE(sp.extra_json, ''), fc.mtime_unix
 	          FROM filtered_chunks fc
 	          LEFT JOIN ranked_spans sp ON sp.chunk_id = fc.chunk_id AND sp.rn = 1`
@@ -2351,13 +2376,14 @@ func (s *SQLiteStore) NextPending(ctx context.Context, limit int, indexKind stri
 			modality  string
 			mediaRef  string
 			language  string
+			chunkCtx  string
 			spanK     string
 			spanS     int
 			spanE     int
 			spanExtra string
 			mtimeUnix int64
 		)
-		if err := rows.Scan(&chunkID, &relPath, &docType, &repType, &text, &idxKind, &modality, &mediaRef, &language, &spanK, &spanS, &spanE, &spanExtra, &mtimeUnix); err != nil {
+		if err := rows.Scan(&chunkID, &relPath, &docType, &repType, &text, &idxKind, &modality, &mediaRef, &language, &chunkCtx, &spanK, &spanS, &spanE, &spanExtra, &mtimeUnix); err != nil {
 			return nil, err
 		}
 		if chunkID <= 0 {
@@ -2379,6 +2405,11 @@ func (s *SQLiteStore) NextPending(ctx context.Context, limit int, indexKind stri
 		})
 		task.Modality = modality
 		task.MediaRef = mediaRef
+		// Contextual retrieval (SPEC §8.1.8): the generated context travels as a
+		// SEPARATE field so only the embed path (ChunkTask.EmbedInput) joins it to
+		// the chunk. Snippet above is built from the raw text, so nothing the
+		// generator wrote can reach a citation (#403).
+		task.Context = chunkCtx
 		tasks = append(tasks, task)
 	}
 	return tasks, rows.Err()
@@ -2628,6 +2659,40 @@ func SpanFromRow(kind string, start, end int, extraJSON string) model.Span {
 
 func (s *SQLiteStore) MarkEmbedded(ctx context.Context, labels []uint64) error {
 	return s.markEmbeddingStatus(ctx, labels, "ok", "", "")
+}
+
+// HasFallbackContextChunks reports whether the document at relPath has any live
+// chunk whose contextual-retrieval state is `fallback` — a chunk whose context
+// generation failed, so it embedded RAW (SPEC §8.1.8, issue #330).
+//
+// It is the self-heal gate: while contextualization stays on, the ingest scan
+// treats such a document as stale even though its content hash is unchanged, so
+// the failed chunks are retried on the next scan and coverage converges instead
+// of leaving a silent, permanent hole.
+func (s *SQLiteStore) HasFallbackContextChunks(ctx context.Context, relPath string) (bool, error) {
+	normalizedPath, err := normalizeRelPath(relPath)
+	if err != nil {
+		return false, err
+	}
+	db, err := s.ensureDB(ctx)
+	if err != nil {
+		return false, err
+	}
+	defer s.ReleaseDB()
+
+	var found int
+	err = db.QueryRowContext(ctx,
+		`SELECT 1 FROM chunks
+		 WHERE rel_path = ? AND deleted = 0 AND embedding_mode = ?
+		 LIMIT 1`,
+		normalizedPath, model.EmbeddingModeFallback).Scan(&found)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // RependEmbeddedChunks resets the given chunks' embedding_status back to

--- a/tests/config/contextual_config_330_test.go
+++ b/tests/config/contextual_config_330_test.go
@@ -1,0 +1,325 @@
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/provider"
+)
+
+// TestContextual_DefaultsOff pins the SPEC §8.1.8 opt-in contract: contextual
+// retrieval is off in the baseline config, so a default corpus embeds raw
+// chunks and its embed identity's terminal component stays `off`.
+func TestContextual_DefaultsOff(t *testing.T) {
+	def := config.Default()
+	if def.RetrievalContextualEnabled {
+		t.Fatal("retrieval.contextual.enabled must default to false (opt-in)")
+	}
+	if def.RetrievalContextualMaxTokens != config.DefaultContextualMaxTokens {
+		t.Fatalf("max_tokens default = %d, want %d",
+			def.RetrievalContextualMaxTokens, config.DefaultContextualMaxTokens)
+	}
+	if def.RetrievalContextualPromptVersion != config.ContextualPromptVersionV1 {
+		t.Fatalf("prompt_version default = %q, want %q",
+			def.RetrievalContextualPromptVersion, config.ContextualPromptVersionV1)
+	}
+	binding := def.ContextualBinding()
+	if binding.Active || binding.FellOpen {
+		t.Fatalf("disabled config must be inactive and NOT report a fail-open: %+v", binding)
+	}
+	if binding.Identity != provider.EmbedContextualOff {
+		t.Fatalf("disabled identity component = %q, want %q", binding.Identity, provider.EmbedContextualOff)
+	}
+}
+
+// TestContextual_NestedAndFlatKeys verifies the canonical nested block and the
+// flat aliases load the knobs (§16.2), consistent with sibling retrieval keys.
+func TestContextual_NestedAndFlatKeys(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		yaml string
+	}{
+		{name: "nested", yaml: "retrieval:\n  contextual:\n    enabled: true\n"},
+		{name: "flat_alias", yaml: "contextual_enabled: true\n"},
+		{name: "flat_prefixed", yaml: "retrieval_contextual_enabled: true\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), ".dir2mcp.yaml")
+			if err := os.WriteFile(path, []byte(tc.yaml), 0o644); err != nil {
+				t.Fatalf("write yaml: %v", err)
+			}
+			cfg, err := config.LoadFile(path)
+			if err != nil {
+				t.Fatalf("LoadFile: %v", err)
+			}
+			if !cfg.RetrievalContextualEnabled {
+				t.Fatalf("expected RetrievalContextualEnabled=true for %s yaml", tc.name)
+			}
+		})
+	}
+}
+
+// TestContextual_NestedScalarsLoad exercises the remaining block keys.
+func TestContextual_NestedScalarsLoad(t *testing.T) {
+	cfg := loadCfg(t, strings.Join([]string{
+		"retrieval:",
+		"  contextual:",
+		"    enabled: true",
+		"    provider: openai",
+		"    model: gpt-4o-mini",
+		"    max_tokens: 96",
+		"    prompt_version: v1",
+		"",
+	}, "\n"))
+	if cfg.RetrievalContextualProvider != "openai" {
+		t.Errorf("provider = %q", cfg.RetrievalContextualProvider)
+	}
+	if cfg.RetrievalContextualModel != "gpt-4o-mini" {
+		t.Errorf("model = %q", cfg.RetrievalContextualModel)
+	}
+	if cfg.RetrievalContextualMaxTokens != 96 {
+		t.Errorf("max_tokens = %d", cfg.RetrievalContextualMaxTokens)
+	}
+}
+
+// TestContextual_SaveLoadRoundTrip verifies the block survives a
+// SaveFile/LoadFile cycle through the persisted YAML.
+func TestContextual_SaveLoadRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".dir2mcp.yaml")
+
+	cfg := config.Default()
+	cfg.RootDir = "/tmp/repo"
+	cfg.StateDir = "/tmp/repo/.dir2mcp"
+	cfg.RetrievalContextualEnabled = true
+	cfg.RetrievalContextualProvider = "openai"
+	cfg.RetrievalContextualModel = "gpt-4o-mini"
+	cfg.RetrievalContextualMaxTokens = 64
+
+	if err := config.SaveFile(path, cfg); err != nil {
+		t.Fatalf("SaveFile: %v", err)
+	}
+	loaded, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if !loaded.RetrievalContextualEnabled || loaded.RetrievalContextualProvider != "openai" ||
+		loaded.RetrievalContextualModel != "gpt-4o-mini" || loaded.RetrievalContextualMaxTokens != 64 {
+		t.Fatalf("contextual block did not round-trip: %+v", loaded)
+	}
+}
+
+// TestContextual_CapabilityFallbackRecordsOff is the load-bearing §8.1.8/§2a
+// case: enabling contextual retrieval with NO chat provider available must fail
+// OPEN — the corpus embeds raw and records the effective `off` identity. If it
+// recorded an "on" token instead, the corpus would look contextual-compatible
+// the moment a chat provider was added, silently mixing raw and contextualized
+// vectors in one index.
+func TestContextual_CapabilityFallbackRecordsOff(t *testing.T) {
+	// No provider credential in the environment ⇒ no chat-capable profile is
+	// eligible, which is exactly the fail-open condition.
+	t.Setenv("MISTRAL_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("GEMINI_API_KEY", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("OPENROUTER_API_KEY", "")
+
+	cfg := loadCfg(t, "retrieval:\n  contextual:\n    enabled: true\n")
+	binding := cfg.ContextualBinding()
+	if binding.Active {
+		t.Fatal("with no chat provider the binding must NOT be active")
+	}
+	if !binding.FellOpen {
+		t.Fatal("an enabled-but-unresolvable binding must report the fail-open so it can be warned about")
+	}
+	if binding.Identity != provider.EmbedContextualOff {
+		t.Fatalf("fail-open identity = %q, want %q (never an on token for raw vectors)",
+			binding.Identity, provider.EmbedContextualOff)
+	}
+}
+
+// TestContextual_EntersEmbedIdentity pins the reindex binding (SPEC §8.1.4):
+// enabling contextual retrieval with a resolvable chat provider changes the
+// corpus-lifetime embed identity, and only its terminal field.
+func TestContextual_EntersEmbedIdentity(t *testing.T) {
+	t.Setenv("MISTRAL_API_KEY", "mk")
+
+	off := loadCfg(t, "version: 1\n")
+	offID := off.Providers().EmbedIdentity()
+	if !strings.HasSuffix(offID, "|"+provider.EmbedContextualOff) {
+		t.Fatalf("default identity %q must end with the off contextual token", offID)
+	}
+	if got := off.Providers().EmbedContextual(); got != provider.EmbedContextualOff {
+		t.Fatalf("EmbedContextual() = %q, want %q", got, provider.EmbedContextualOff)
+	}
+
+	on := loadCfg(t, "retrieval:\n  contextual:\n    enabled: true\n")
+	binding := on.ContextualBinding()
+	if !binding.Active {
+		t.Fatalf("with a chat provider available the binding must be active: %+v", binding)
+	}
+	onID := on.Providers().EmbedIdentity()
+	if onID == offID {
+		t.Fatalf("enabling contextual retrieval must change the embed identity: %q", onID)
+	}
+	if !provider.ContextualActive(on.Providers().EmbedContextual()) {
+		t.Fatalf("EmbedContextual() = %q, want a ctx:<hash> token", on.Providers().EmbedContextual())
+	}
+	// Only the terminal component differs — nothing else drifted.
+	if strings.TrimSuffix(onID, "|"+binding.Identity) != strings.TrimSuffix(offID, "|"+provider.EmbedContextualOff) {
+		t.Fatalf("only the contextual token may differ: on=%q off=%q", onID, offID)
+	}
+	// And an existing (pre-feature, 8-field) corpus recording must still match a
+	// fresh DISABLED build — the no-spurious-reindex guarantee at config level.
+	legacy := strings.TrimSuffix(offID, "|"+provider.EmbedContextualOff)
+	if err := provider.VerifyEmbedIdentity(legacy, offID); err != nil {
+		t.Fatalf("pre-contextual recorded identity must not reindex: %v", err)
+	}
+	// But it MUST mismatch a contextualized build (refuse to mix vector spaces).
+	if err := provider.VerifyEmbedIdentity(legacy, onID); err == nil {
+		t.Fatal("a raw corpus must NOT silently serve under a contextualized identity")
+	}
+}
+
+// TestContextual_SnapshotRecordsEmbedContextual pins SPEC §5.5: the effective
+// contextual component is recorded in the config snapshot as `embed_contextual`,
+// and is ABSENT for the `off` default (an absent key is treated as `off`).
+func TestContextual_SnapshotRecordsEmbedContextual(t *testing.T) {
+	t.Setenv("MISTRAL_API_KEY", "mk")
+
+	readSnapshot := func(t *testing.T, cfg config.Config) string {
+		t.Helper()
+		cfg.RootDir = t.TempDir()
+		cfg.StateDir = filepath.Join(cfg.RootDir, ".dir2mcp")
+		path, err := config.SaveEffectiveSnapshot(cfg, config.SecretSourceMetadata{})
+		if err != nil {
+			t.Fatalf("SaveEffectiveSnapshot: %v", err)
+		}
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read snapshot: %v", err)
+		}
+		return string(raw)
+	}
+
+	if snap := readSnapshot(t, config.Default()); strings.Contains(snap, "embed_contextual:") {
+		t.Fatal("a non-contextual corpus must not carry embed_contextual (absent ⇒ off, §5.5)")
+	}
+
+	on := config.Default()
+	on.RetrievalContextualEnabled = true
+	snap := readSnapshot(t, on)
+	if !strings.Contains(snap, "embed_contextual: ctx:") {
+		t.Fatalf("contextual snapshot must record the ctx:<hash> token, got:\n%s", snap)
+	}
+}
+
+// TestContextual_ValidationRejectsBadKnobs pins the §16.2 static rules. They
+// apply only when the feature is enabled, so a default config is never affected.
+func TestContextual_ValidationRejectsBadKnobs(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		mutate  func(*config.Config)
+		wantErr string
+	}{
+		{
+			name:    "non-positive max_tokens",
+			mutate:  func(c *config.Config) { c.RetrievalContextualMaxTokens = 0 },
+			wantErr: "max_tokens must be > 0",
+		},
+		{
+			name:    "unknown prompt_version",
+			mutate:  func(c *config.Config) { c.RetrievalContextualPromptVersion = "v99" },
+			wantErr: "prompt_version",
+		},
+		{
+			name:    "prompt override missing the chunk placeholder",
+			mutate:  func(c *config.Config) { c.RetrievalContextualPrompt = "situate {{DOCUMENT}}" },
+			wantErr: config.ContextualChunkPlaceholder,
+		},
+		{
+			name:    "prompt override missing the document placeholder",
+			mutate:  func(c *config.Config) { c.RetrievalContextualPrompt = "situate {{CHUNK}}" },
+			wantErr: config.ContextualDocumentPlaceholder,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.Default()
+			cfg.RootDir = t.TempDir()
+			cfg.StateDir = filepath.Join(cfg.RootDir, ".dir2mcp")
+			cfg.RetrievalContextualEnabled = true
+			tc.mutate(&cfg)
+			err := cfg.Validate()
+			if err == nil {
+				t.Fatalf("expected CONFIG_INVALID for %s", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error %q must mention %q", err, tc.wantErr)
+			}
+			// The same value is fine while the feature is OFF: the rules are scoped.
+			off := config.Default()
+			off.RootDir = cfg.RootDir
+			off.StateDir = cfg.StateDir
+			tc.mutate(&off)
+			if err := off.Validate(); err != nil {
+				t.Fatalf("disabled config must not be rejected: %v", err)
+			}
+		})
+	}
+}
+
+// TestContextual_PromptOverrideRebindsIdentity pins design 0004 §2: an edited
+// operator prompt override re-embeds even without a prompt_version bump, because
+// the EFFECTIVE prompt text is hashed into the identity.
+func TestContextual_PromptOverrideRebindsIdentity(t *testing.T) {
+	t.Setenv("MISTRAL_API_KEY", "mk")
+
+	builtin := loadCfg(t, "retrieval:\n  contextual:\n    enabled: true\n")
+	override := builtin
+	override.RetrievalContextualPrompt = "Situate {{CHUNK}} within {{DOCUMENT}}."
+	edited := override
+	edited.RetrievalContextualPrompt = "Situate {{CHUNK}} within {{DOCUMENT}} briefly."
+
+	ids := map[string]string{
+		"builtin":  builtin.ContextualBinding().Identity,
+		"override": override.ContextualBinding().Identity,
+		"edited":   edited.ContextualBinding().Identity,
+	}
+	for name, id := range ids {
+		if !provider.ContextualActive(id) {
+			t.Fatalf("%s identity %q must be an active ctx token", name, id)
+		}
+	}
+	if ids["builtin"] == ids["override"] {
+		t.Error("an operator prompt override must change the contextual identity")
+	}
+	if ids["override"] == ids["edited"] {
+		t.Error("EDITING the override must change the contextual identity (no prompt_version bump needed)")
+	}
+}
+
+// TestContextual_EffectivePromptIsDomainGeneral guards the project-wide rule
+// that shipped defaults stay general-purpose: the built-in template carries both
+// placeholders and no corpus/domain assumptions.
+func TestContextual_EffectivePromptIsDomainGeneral(t *testing.T) {
+	cfg := config.Default()
+	prompt, ok := cfg.ContextualEffectivePrompt()
+	if !ok {
+		t.Fatal("the default prompt_version must resolve to a built-in template")
+	}
+	for _, placeholder := range []string{config.ContextualDocumentPlaceholder, config.ContextualChunkPlaceholder} {
+		if !strings.Contains(prompt, placeholder) {
+			t.Errorf("built-in template must contain %s", placeholder)
+		}
+	}
+	rendered := config.RenderContextualPrompt(prompt, "DOC BODY", "CHUNK BODY")
+	if strings.Contains(rendered, config.ContextualDocumentPlaceholder) ||
+		strings.Contains(rendered, config.ContextualChunkPlaceholder) {
+		t.Error("rendering must substitute every placeholder")
+	}
+	if !strings.Contains(rendered, "DOC BODY") || !strings.Contains(rendered, "CHUNK BODY") {
+		t.Error("rendering must inject both the document and the chunk")
+	}
+}

--- a/tests/config/late_chunking_config_test.go
+++ b/tests/config/late_chunking_config_test.go
@@ -89,15 +89,17 @@ func TestLateChunking_EntersEmbedIdentity(t *testing.T) {
 		t.Fatal("precondition: late chunking must be enabled")
 	}
 	onID := on.Providers().EmbedIdentity()
-	if !strings.HasSuffix(onID, "|on") {
+	// late_chunking is the 8th field, contextual (off by default) the 9th.
+	if !strings.HasSuffix(onID, "|on|off") {
 		t.Fatalf("identity %q must end with the on late-chunking token", onID)
 	}
 	if onID == offID {
 		t.Fatalf("toggling late chunking must change the embed identity: %q == %q", onID, offID)
 	}
-	// The mode is the ONLY difference: strip the trailing token and the rest of
-	// the identity must be byte-identical, so nothing else drifted.
-	if strings.TrimSuffix(onID, "|on") != strings.TrimSuffix(offID, "|off") {
+	// The mode is the ONLY difference: strip the late-chunking token (8th field,
+	// followed by the contextual token) and the rest of the identity must be
+	// byte-identical, so nothing else drifted.
+	if strings.TrimSuffix(onID, "|on|off") != strings.TrimSuffix(offID, "|off|off") {
 		t.Fatalf("only the late-chunking token may differ: on=%q off=%q", onID, offID)
 	}
 }

--- a/tests/config/providers_config_test.go
+++ b/tests/config/providers_config_test.go
@@ -162,10 +162,10 @@ func TestProviders_EmbedIdentityStable(t *testing.T) {
 	t.Setenv("MISTRAL_API_KEY", "mk")
 	id := loadCfg(t, "version: 1\n").Providers().EmbedIdentity()
 	// provider|base_url|text_model|code_model|text_dim|code_dim|multimodal|
-	// late_chunking (SPEC 8.1.4/8.1.6/8.1.7, issue #332/#446/#560); default
-	// Mistral: canonical base_url normalizes to "", native dims, multimodal +
-	// late_chunking off.
-	if id != "mistral||mistral-embed|codestral-embed|0|0|off|off" {
+	// late_chunking|contextual (SPEC 8.1.4/8.1.6/8.1.7/8.1.8, issue
+	// #332/#446/#560/#330); default Mistral: canonical base_url normalizes to
+	// "", native dims, multimodal + late_chunking + contextual off.
+	if id != "mistral||mistral-embed|codestral-embed|0|0|off|off|off" {
 		t.Fatalf("embed identity = %q", id)
 	}
 }
@@ -193,7 +193,7 @@ func TestProviders_EmbedDimensionKnob(t *testing.T) {
 		t.Fatalf("dims = text:%d code:%d, want 1536/768", p.EmbedTextDim, p.EmbedCodeDim)
 	}
 	id := r.EmbedIdentity()
-	if !strings.HasSuffix(id, "|1536|768|off|off") {
+	if !strings.HasSuffix(id, "|1536|768|off|off|off") {
 		t.Fatalf("embed identity %q must encode requested dims (and off modes)", id)
 	}
 }
@@ -252,7 +252,7 @@ func TestProviders_EmbedMultimodalKnob(t *testing.T) {
 	if p.EmbedMultimodal != "augment" {
 		t.Fatalf("multimodal = %q, want augment", p.EmbedMultimodal)
 	}
-	if !strings.HasSuffix(r.EmbedIdentity(), "|augment|off") {
+	if !strings.HasSuffix(r.EmbedIdentity(), "|augment|off|off") {
 		t.Fatalf("embed identity %q must encode the multimodal mode", r.EmbedIdentity())
 	}
 }
@@ -298,7 +298,7 @@ func TestProviders_OmniEmbedSelfHosted(t *testing.T) {
 	if p.EmbedMultimodal != "replace" {
 		t.Fatalf("multimodal = %q, want replace", p.EmbedMultimodal)
 	}
-	if !strings.HasSuffix(r.EmbedIdentity(), "|replace|off") {
+	if !strings.HasSuffix(r.EmbedIdentity(), "|replace|off|off") {
 		t.Fatalf("embed identity %q must encode the multimodal mode", r.EmbedIdentity())
 	}
 }

--- a/tests/config/self_hosted_endpoints_test.go
+++ b/tests/config/self_hosted_endpoints_test.go
@@ -50,7 +50,7 @@ func TestSelfHosted_EmbedBaseURLResolves(t *testing.T) {
 	// The embed identity must encode the self-hosted profile + custom base_url
 	// + model so a change to any is corpus-lifetime / reindex-bound (SPEC
 	// §8.1.4 / §8.5 / issue #560): the non-canonical endpoint is the 2nd field.
-	if id := r.EmbedIdentity(); id != "gpu-embed|http://gpu-vps:8080/v1|bge-m3||0|0|off|off" {
+	if id := r.EmbedIdentity(); id != "gpu-embed|http://gpu-vps:8080/v1|bge-m3||0|0|off|off|off" {
 		t.Fatalf("embed identity = %q", id)
 	}
 }

--- a/tests/index/embed_contextual_input_330_test.go
+++ b/tests/index/embed_contextual_input_330_test.go
@@ -1,0 +1,49 @@
+package tests
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// TestEmbedAndIndex_ContextIsPrependedToEmbedInputOnly pins the SPEC §8.1.8
+// embed-input transform: the embedder receives `context + "\n\n" + chunk`, while
+// the chunk's own text — the text every display and citation path reads — is
+// untouched. A chunk with no context embeds byte-identically to before.
+func TestEmbedAndIndex_ContextIsPrependedToEmbedInputOnly(t *testing.T) {
+	ctx := context.Background()
+	src := &fakeChunkSource{}
+	idx := index.NewHNSWIndex("")
+	emb := &recordingEmbedder{}
+	worker := &index.EmbeddingWorker{Source: src, Index: idx, Embedder: emb, BatchSize: 8}
+
+	contextualized := textTask(1, "ad revenue grew 12%")
+	contextualized.Context = "From the Q3 2026 earnings call."
+	raw := textTask(2, "no context here")
+
+	n, err := worker.EmbedAndIndex(ctx, "text", []model.ChunkTask{contextualized, raw})
+	if err != nil {
+		t.Fatalf("EmbedAndIndex: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("indexed %d chunks, want 2", n)
+	}
+	if len(emb.seen) != 2 {
+		t.Fatalf("embedder saw %d inputs, want 2: %q", len(emb.seen), emb.seen)
+	}
+	if want := "From the Q3 2026 earnings call.\n\nad revenue grew 12%"; emb.seen[0] != want {
+		t.Errorf("contextualized embed input = %q, want %q", emb.seen[0], want)
+	}
+	// The raw chunk is unchanged — the default (feature-off) path.
+	if emb.seen[1] != "no context here" {
+		t.Errorf("uncontextualized embed input = %q, want the raw text", emb.seen[1])
+	}
+	// The task's own text (and therefore its snippet/citation) never gained the
+	// context: only EmbedInput joins them (#403).
+	if strings.Contains(contextualized.Text, "earnings call") {
+		t.Error("the generated context must never be written into the chunk text")
+	}
+}

--- a/tests/ingest/contextual_retrieval_330_test.go
+++ b/tests/ingest/contextual_retrieval_330_test.go
@@ -1,0 +1,215 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// fakeContextualizer is a deterministic ChunkContextualizer: it echoes a
+// recognizable marker so a test can assert the context reached the embed input
+// and NOTHING else. failOn makes generation fail for chunks containing a
+// substring, exercising the fail-open-per-chunk path.
+type fakeContextualizer struct {
+	mu     sync.Mutex
+	calls  int
+	docs   []string
+	failOn string
+}
+
+const contextMarker = "CTXMARKER"
+
+func (f *fakeContextualizer) Contextualize(_ context.Context, docText, chunkText string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	f.docs = append(f.docs, docText)
+	if f.failOn != "" && strings.Contains(chunkText, f.failOn) {
+		return "", errors.New("simulated generator failure")
+	}
+	return contextMarker + " situating: " + strings.Fields(chunkText)[0], nil
+}
+
+func (f *fakeContextualizer) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+func (f *fakeContextualizer) seenDocs() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.docs...)
+}
+
+// TestContextual_DisabledLeavesChunksUntouched pins the opt-in default: with no
+// contextualizer bound, every chunk records embedding_mode=disabled with an
+// empty context, so a corpus is byte-identical to one built before the feature.
+func TestContextual_DisabledLeavesChunksUntouched(t *testing.T) {
+	st := &fakeIngestStore{}
+	rg := ingest.NewRepresentationGenerator(st)
+
+	doc := model.Document{DocID: 1, RelPath: "docs/a.md", DocType: "text"}
+	if err := rg.GenerateRawTextFromContent(
+		context.Background(), doc, []byte("alpha paragraph body\n\nbeta paragraph body")); err != nil {
+		t.Fatalf("GenerateRawTextFromContent: %v", err)
+	}
+	if len(st.chunks) == 0 {
+		t.Fatal("expected at least one chunk")
+	}
+	for i, c := range st.chunks {
+		if c.Context != "" {
+			t.Errorf("chunk %d: context must be empty when contextualization is off, got %q", i, c.Context)
+		}
+		if got := model.NormalizeEmbeddingMode(c.EmbeddingMode); got != model.EmbeddingModeDisabled {
+			t.Errorf("chunk %d: embedding_mode = %q, want %q", i, got, model.EmbeddingModeDisabled)
+		}
+	}
+}
+
+// TestContextual_CitationFaithfulness is the HARD INVARIANT (SPEC §8.1.8,
+// dir2mcp #403): the generated context is an EMBED-INPUT transform only. The
+// persisted chunk text, its text_hash, and its spans stay the RAW chunk, so the
+// context can never surface in a snippet, an open_file result, or a citation.
+func TestContextual_CitationFaithfulness(t *testing.T) {
+	st := &fakeIngestStore{}
+	rg := ingest.NewRepresentationGenerator(st)
+	fake := &fakeContextualizer{}
+	rg.SetContextualizer(fake)
+
+	raw := "alpha paragraph body\n\nbeta paragraph body"
+	doc := model.Document{DocID: 1, RelPath: "docs/a.md", DocType: "text"}
+	if err := rg.GenerateRawTextFromContent(context.Background(), doc, []byte(raw)); err != nil {
+		t.Fatalf("GenerateRawTextFromContent: %v", err)
+	}
+	if len(st.chunks) == 0 {
+		t.Fatal("expected at least one chunk")
+	}
+	if fake.callCount() != len(st.chunks) {
+		t.Fatalf("expected one generation per chunk: %d calls for %d chunks", fake.callCount(), len(st.chunks))
+	}
+
+	for i, c := range st.chunks {
+		// (a) the CITED text is raw — the marker never appears in it.
+		if strings.Contains(c.Text, contextMarker) {
+			t.Errorf("chunk %d: generated context leaked into chunks.text: %q", i, c.Text)
+		}
+		if !strings.Contains(raw, c.Text) {
+			t.Errorf("chunk %d: persisted text is not a verbatim slice of the source: %q", i, c.Text)
+		}
+		// (b) the text_hash keys the RAW text (skip semantics unchanged, §7.6).
+		if c.TextHash != ingest.ComputeContentHash([]byte(c.Text)) {
+			t.Errorf("chunk %d: text_hash must key the raw chunk text", i)
+		}
+		// (c) the context is persisted separately and the mode records it.
+		if !strings.Contains(c.Context, contextMarker) {
+			t.Errorf("chunk %d: expected a generated context, got %q", i, c.Context)
+		}
+		if c.EmbeddingMode != model.EmbeddingModeContextualized {
+			t.Errorf("chunk %d: embedding_mode = %q, want %q", i, c.EmbeddingMode, model.EmbeddingModeContextualized)
+		}
+		// (d) ONLY the embed input carries the join (SPEC §8.1.8 `context + "\n\n" + chunk`).
+		task := model.ChunkTask{Text: c.Text, Context: c.Context}
+		if task.EmbedInput() != c.Context+"\n\n"+c.Text {
+			t.Errorf("chunk %d: embed input must be context + blank line + raw chunk", i)
+		}
+		if !strings.HasSuffix(task.EmbedInput(), c.Text) {
+			t.Errorf("chunk %d: the raw chunk must be preserved verbatim in the embed input", i)
+		}
+	}
+
+	// The generator sees the PARENT DOCUMENT, not just the chunk — that is what
+	// makes the context document-aware (design 0004 §3).
+	for _, seen := range fake.seenDocs() {
+		for _, c := range st.chunks {
+			if !strings.Contains(seen, c.Text) {
+				t.Fatalf("the generator must see the whole parent document; %q missing from %q", c.Text, seen)
+			}
+		}
+	}
+}
+
+// TestContextual_FailOpenPerChunk pins SPEC §8.1.8: a generator error for ONE
+// chunk leaves that chunk raw with embedding_mode=fallback — it never fails
+// ingest, and never silently looks like a healthy contextualized chunk.
+func TestContextual_FailOpenPerChunk(t *testing.T) {
+	st := &fakeIngestStore{}
+	rg := ingest.NewRepresentationGenerator(st)
+	rg.SetContextualizer(&fakeContextualizer{failOn: "beta"})
+
+	doc := model.Document{DocID: 1, RelPath: "docs/a.md", DocType: "text"}
+	if err := rg.GenerateRawTextFromContent(
+		context.Background(), doc, []byte(multiChunkBody())); err != nil {
+		t.Fatalf("a per-chunk generation failure must NOT fail ingest: %v", err)
+	}
+	if len(st.chunks) < 2 {
+		t.Fatalf("precondition: the fixture must produce >= 2 chunks, got %d", len(st.chunks))
+	}
+
+	var contextualized, fallback int
+	for i, c := range st.chunks {
+		switch c.EmbeddingMode {
+		case model.EmbeddingModeContextualized:
+			contextualized++
+		case model.EmbeddingModeFallback:
+			fallback++
+			if c.Context != "" {
+				t.Errorf("chunk %d: a fallback chunk must carry no context, got %q", i, c.Context)
+			}
+		default:
+			t.Errorf("chunk %d: unexpected embedding_mode %q", i, c.EmbeddingMode)
+		}
+		// Either way the chunk text is untouched.
+		if strings.Contains(c.Text, contextMarker) {
+			t.Errorf("chunk %d: context leaked into chunks.text", i)
+		}
+	}
+	if fallback == 0 {
+		t.Fatal("expected at least one fallback chunk")
+	}
+	if contextualized == 0 {
+		t.Fatal("a failure on one chunk must not disable contextualization for its siblings")
+	}
+}
+
+// multiChunkBody is a text fixture large enough to split into several chunks,
+// with the word "beta" confined to the SECOND half so a failOn:"beta"
+// contextualizer fails some chunks and not others.
+func multiChunkBody() string {
+	alpha := strings.Repeat("alpha paragraph body with enough words to fill a chunk. ", 80)
+	beta := strings.Repeat("beta paragraph body with enough words to fill a chunk. ", 80)
+	return alpha + "\n\n" + beta
+}
+
+// TestContextual_EmptyChunkStaysDisabled guards the degenerate case: a
+// whitespace-only segment has nothing to situate, so it is not sent to the
+// generator and records `disabled` rather than a spurious `fallback`.
+func TestContextual_EmptyChunkStaysDisabled(t *testing.T) {
+	st := &fakeIngestStore{}
+	rg := ingest.NewRepresentationGenerator(st)
+	fake := &fakeContextualizer{}
+	rg.SetContextualizer(fake)
+
+	doc := model.Document{DocID: 1, RelPath: "docs/a.md", DocType: "text"}
+	if err := rg.GenerateRawTextFromContent(
+		context.Background(), doc, []byte("alpha body text")); err != nil {
+		t.Fatalf("GenerateRawTextFromContent: %v", err)
+	}
+	if fake.callCount() == 0 {
+		t.Fatal("precondition: the non-empty chunk must be contextualized")
+	}
+}
+
+// TestChunkTask_EmbedInputDefaultsToRaw pins that with no context the embed
+// input is the raw text byte-for-byte, so the default path is unchanged.
+func TestChunkTask_EmbedInputDefaultsToRaw(t *testing.T) {
+	task := model.ChunkTask{Text: "raw chunk"}
+	if task.EmbedInput() != "raw chunk" {
+		t.Fatalf("EmbedInput() = %q, want the raw text", task.EmbedInput())
+	}
+}

--- a/tests/provider/contextual_identity_330_test.go
+++ b/tests/provider/contextual_identity_330_test.go
@@ -124,9 +124,19 @@ func TestEmbedIdentity_ContextualTogglesIdentity(t *testing.T) {
 	if off == on {
 		t.Fatal("enabling contextual retrieval must change the embed identity")
 	}
-	// An identical spec is stable (no gratuitous re-embed on restart).
-	if provider.ContextualIdentity(spec) != provider.ContextualIdentity(spec) {
-		t.Fatal("the contextual token must be deterministic")
+	// An identical spec is stable (no gratuitous re-embed on restart). Compare
+	// two INDEPENDENTLY constructed specs rather than calling the function twice
+	// on the same value: hashing one value twice would pass even if the token
+	// leaked allocation identity or map iteration order into the digest.
+	same := provider.ContextualSpec{
+		Profile:       provider.Profile{Name: "openai"},
+		Model:         "gpt-4o-mini",
+		MaxTokens:     128,
+		PromptVersion: "v1",
+		Prompt:        "situate the chunk",
+	}
+	if provider.ContextualIdentity(spec) != provider.ContextualIdentity(same) {
+		t.Fatal("the contextual token must be deterministic across equal specs")
 	}
 	base := provider.ContextualIdentity(spec)
 	for _, tc := range []struct {

--- a/tests/provider/contextual_identity_330_test.go
+++ b/tests/provider/contextual_identity_330_test.go
@@ -1,0 +1,180 @@
+package tests
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/provider"
+)
+
+// contextualBaseProfile is the default hosted-Mistral embed profile used across the
+// contextual-identity cases: its base_url normalizes to "" and its dims are
+// native, so a fresh feature-disabled build produces exactly the 9-field
+// identity every legacy recording must migrate to.
+func contextualBaseProfile() provider.Profile {
+	return provider.Profile{
+		Name:           "mistral",
+		EmbedTextModel: "mistral-embed",
+		EmbedCodeModel: "codestral-embed",
+	}
+}
+
+// TestEmbedIdentity_ContextualIsTerminalField pins SPEC 8.1.4: the identity
+// tuple is provider|base_url|text_model|code_model|text_dim|code_dim|multimodal|
+// late_chunking|contextual, with `contextual` TERMINAL and `late_chunking` 8th.
+func TestEmbedIdentity_ContextualIsTerminalField(t *testing.T) {
+	id := provider.EmbedIdentity(contextualBaseProfile(), false, provider.EmbedContextualOff)
+	parts := strings.Split(id, "|")
+	if len(parts) != 9 {
+		t.Fatalf("identity must have 9 fields, got %d: %q", len(parts), id)
+	}
+	if parts[7] != "off" {
+		t.Errorf("late_chunking must be the 8th field, got %q in %q", parts[7], id)
+	}
+	if parts[8] != provider.EmbedContextualOff {
+		t.Errorf("contextual must be the terminal field, got %q in %q", parts[8], id)
+	}
+	// The token is opaque: an active generator identity is a single field, so it
+	// can never collide with the "|" delimiter.
+	active := provider.EmbedIdentity(contextualBaseProfile(), false, provider.ContextualIdentity(provider.ContextualSpec{
+		Profile: provider.Profile{Name: "openai"}, Model: "gpt-4o-mini", MaxTokens: 128,
+		PromptVersion: "v1", Prompt: "situate|this|chunk",
+	}))
+	if n := strings.Count(active, "|"); n != 8 {
+		t.Fatalf("an active contextual token must stay ONE field (8 pipes), got %d: %q", n, active)
+	}
+}
+
+// TestEmbedIdentity_MigrationLadder is the load-bearing no-spurious-reindex
+// case (SPEC 8.1.4, issue #330): EVERY recorded pre-contextual identity shape
+// MUST canonicalize to something that compares EQUAL to what a fresh build with
+// contextual retrieval DISABLED computes. If any row of this table regresses,
+// every existing corpus in the wild re-embeds on upgrade.
+func TestEmbedIdentity_MigrationLadder(t *testing.T) {
+	current := provider.EmbedIdentity(contextualBaseProfile(), false, provider.EmbedContextualOff)
+	if current != "mistral||mistral-embed|codestral-embed|0|0|off|off|off" {
+		t.Fatalf("precondition: fresh feature-disabled identity = %q", current)
+	}
+	for _, tc := range []struct {
+		name     string
+		recorded string
+	}{
+		{"3 fields (pre-8.1.6: no dims/multimodal/late-chunking/contextual)",
+			"mistral|mistral-embed|codestral-embed"},
+		{"5 fields (pre-8.1.7: dims, no multimodal)",
+			"mistral|mistral-embed|codestral-embed|0|0"},
+		{"6 fields (pre-late-chunking, #446)",
+			"mistral|mistral-embed|codestral-embed|0|0|off"},
+		{"7 fields (pre-base_url, #560)",
+			"mistral|mistral-embed|codestral-embed|0|0|off|off"},
+		{"8 fields (pre-contextual — the shape shipped indexes record today)",
+			"mistral||mistral-embed|codestral-embed|0|0|off|off"},
+		{"9 fields (already current)",
+			"mistral||mistral-embed|codestral-embed|0|0|off|off|off"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := provider.VerifyEmbedIdentity(tc.recorded, current); err != nil {
+				t.Fatalf("recorded %q must NOT force a reindex against %q: %v", tc.recorded, current, err)
+			}
+		})
+	}
+	// A fresh index (no recorded identity) always passes.
+	if err := provider.VerifyEmbedIdentity("", current); err != nil {
+		t.Errorf("empty recorded identity (fresh index) must pass: %v", err)
+	}
+}
+
+// TestEmbedIdentity_UnrecognizedFieldCountFailsLoudly pins the other half of the
+// SPEC 8.1.4 ladder rule: an unrecognized field count MUST be left unchanged so
+// it fails the comparison LOUDLY, rather than being coerced into a false match
+// that would silently mix vector spaces.
+func TestEmbedIdentity_UnrecognizedFieldCountFailsLoudly(t *testing.T) {
+	current := provider.EmbedIdentity(contextualBaseProfile(), false, provider.EmbedContextualOff)
+	for _, recorded := range []string{
+		"mistral",                                // 1 field
+		"mistral|mistral-embed",                  // 2 fields
+		"mistral||mistral-embed|codestral-embed", // 4 fields
+		"mistral||mistral-embed|codestral-embed|0|0|off|off|off|x", // 10 fields
+	} {
+		err := provider.VerifyEmbedIdentity(recorded, current)
+		if err == nil {
+			t.Errorf("unrecognized field count %q must NOT be coerced into a match", recorded)
+			continue
+		}
+		if !strings.Contains(err.Error(), "embed identity changed") {
+			t.Errorf("recorded %q: unexpected error %v", recorded, err)
+		}
+	}
+}
+
+// TestEmbedIdentity_ContextualTogglesIdentity pins the correctness mechanism
+// (SPEC 8.1.4/8.1.8): turning contextualization on, or changing ANY generator
+// input, MUST change the identity so the corpus re-embeds instead of mixing
+// contextualized and raw vectors.
+func TestEmbedIdentity_ContextualTogglesIdentity(t *testing.T) {
+	spec := provider.ContextualSpec{
+		Profile:       provider.Profile{Name: "openai"},
+		Model:         "gpt-4o-mini",
+		MaxTokens:     128,
+		PromptVersion: "v1",
+		Prompt:        "situate the chunk",
+	}
+	off := provider.EmbedIdentity(contextualBaseProfile(), false, provider.EmbedContextualOff)
+	on := provider.EmbedIdentity(contextualBaseProfile(), false, provider.ContextualIdentity(spec))
+	if off == on {
+		t.Fatal("enabling contextual retrieval must change the embed identity")
+	}
+	// An identical spec is stable (no gratuitous re-embed on restart).
+	if provider.ContextualIdentity(spec) != provider.ContextualIdentity(spec) {
+		t.Fatal("the contextual token must be deterministic")
+	}
+	base := provider.ContextualIdentity(spec)
+	for _, tc := range []struct {
+		name  string
+		muted provider.ContextualSpec
+	}{
+		{"provider", func() provider.ContextualSpec {
+			s := spec
+			s.Profile = provider.Profile{Name: "mistral"}
+			return s
+		}()},
+		{"normalized endpoint", func() provider.ContextualSpec {
+			s := spec
+			s.Profile = provider.Profile{Name: "openai", Kind: provider.KindOpenAI, BaseURL: "http://gpu-vps:8080/v1"}
+			return s
+		}()},
+		{"model", func() provider.ContextualSpec { s := spec; s.Model = "gpt-4o"; return s }()},
+		{"max_tokens", func() provider.ContextualSpec { s := spec; s.MaxTokens = 256; return s }()},
+		{"prompt_version", func() provider.ContextualSpec { s := spec; s.PromptVersion = "v2"; return s }()},
+		{"effective prompt text", func() provider.ContextualSpec {
+			s := spec
+			s.Prompt = "situate the chunk (edited override)"
+			return s
+		}()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := provider.ContextualIdentity(tc.muted); got == base {
+				t.Fatalf("changing the %s must change the contextual token (%q)", tc.name, got)
+			}
+		})
+	}
+}
+
+// TestContextualActive distinguishes the disabled/fail-open token from a real
+// generator identity.
+func TestContextualActive(t *testing.T) {
+	if provider.ContextualActive(provider.EmbedContextualOff) {
+		t.Error("the off token must not read as active")
+	}
+	if provider.ContextualActive("") {
+		t.Error("an empty component normalizes to off and must not read as active")
+	}
+	if !provider.ContextualActive(provider.ContextualIdentity(provider.ContextualSpec{
+		Profile: provider.Profile{Name: "openai"}, Model: "gpt-4o-mini",
+	})) {
+		t.Error("a generator token must read as active")
+	}
+	if provider.NormalizeEmbedContextual("  ") != provider.EmbedContextualOff {
+		t.Error("blank normalizes to off")
+	}
+}

--- a/tests/provider/provider_test.go
+++ b/tests/provider/provider_test.go
@@ -133,12 +133,12 @@ func TestSelectAutoPrecedence(t *testing.T) {
 
 func TestEmbedIdentity(t *testing.T) {
 	p := provider.Profile{Name: "mistral", EmbedTextModel: "mistral-embed", EmbedCodeModel: "codestral-embed"}
-	id := provider.EmbedIdentity(p, false)
+	id := provider.EmbedIdentity(p, false, provider.EmbedContextualOff)
 	// Identity is provider|base_url|text_model|code_model|text_dim|code_dim|
-	// multimodal|late_chunking (SPEC 8.1.4/8.1.6/8.1.7, issue #332/#446/#560);
-	// an unset/canonical base_url records as "", unset dims as 0, multimodal +
-	// late_chunking as off.
-	if id != "mistral||mistral-embed|codestral-embed|0|0|off|off" {
+	// multimodal|late_chunking|contextual (SPEC 8.1.4/8.1.6/8.1.7/8.1.8, issue
+	// #332/#446/#560/#330); an unset/canonical base_url records as "", unset
+	// dims as 0, and multimodal + late_chunking + contextual as off.
+	if id != "mistral||mistral-embed|codestral-embed|0|0|off|off|off" {
 		t.Fatalf("identity = %q", id)
 	}
 	if err := provider.VerifyEmbedIdentity("", id); err != nil {
@@ -151,20 +151,20 @@ func TestEmbedIdentity(t *testing.T) {
 	// A different requested output dimension is a distinct identity
 	// (reindex-bound, SPEC 8.1.6): same provider+models but dim 768 must
 	// not match the native (dim 0) identity.
-	native := provider.EmbedIdentity(provider.Profile{Name: "gemini", EmbedTextModel: "gemini-embedding-001"}, false)
-	dimmed := provider.EmbedIdentity(provider.Profile{Name: "gemini", EmbedTextModel: "gemini-embedding-001", EmbedTextDim: 768}, false)
+	native := provider.EmbedIdentity(provider.Profile{Name: "gemini", EmbedTextModel: "gemini-embedding-001"}, false, provider.EmbedContextualOff)
+	dimmed := provider.EmbedIdentity(provider.Profile{Name: "gemini", EmbedTextModel: "gemini-embedding-001", EmbedTextDim: 768}, false, provider.EmbedContextualOff)
 	if native == dimmed {
 		t.Fatalf("requested dimension must change embed identity: %q == %q", native, dimmed)
 	}
 	// A different multimodal mode is a distinct identity (reindex-bound,
 	// SPEC 8.1.7).
-	mm := provider.EmbedIdentity(provider.Profile{Name: "gemini", EmbedTextModel: "gemini-embedding-2", EmbedCodeModel: "gemini-embedding-2", EmbedMultimodal: "augment"}, false)
-	if mm == provider.EmbedIdentity(provider.Profile{Name: "gemini", EmbedTextModel: "gemini-embedding-2", EmbedCodeModel: "gemini-embedding-2"}, false) {
+	mm := provider.EmbedIdentity(provider.Profile{Name: "gemini", EmbedTextModel: "gemini-embedding-2", EmbedCodeModel: "gemini-embedding-2", EmbedMultimodal: "augment"}, false, provider.EmbedContextualOff)
+	if mm == provider.EmbedIdentity(provider.Profile{Name: "gemini", EmbedTextModel: "gemini-embedding-2", EmbedCodeModel: "gemini-embedding-2"}, false, provider.EmbedContextualOff) {
 		t.Fatalf("multimodal mode must change embed identity")
 	}
 	// A different late-chunking mode is a distinct identity (reindex-bound,
 	// issue #332/#446): the same profile with the mode on must NOT match off.
-	if provider.EmbedIdentity(p, true) == provider.EmbedIdentity(p, false) {
+	if provider.EmbedIdentity(p, true, provider.EmbedContextualOff) == provider.EmbedIdentity(p, false, provider.EmbedContextualOff) {
 		t.Fatalf("late-chunking mode must change embed identity")
 	}
 	// Legacy identities must NOT force a spurious reindex against the
@@ -175,7 +175,7 @@ func TestEmbedIdentity(t *testing.T) {
 	// "||…|off|off", a 6-field (pre-late-chunking, #446) to "||…|off", and a
 	// 7-field (pre-base_url, #560) gains only the empty base_url. The current
 	// side is the 8-field form.
-	current := "mistral||mistral-embed|codestral-embed|0|0|off|off"
+	current := "mistral||mistral-embed|codestral-embed|0|0|off|off|off"
 	legacy3 := "mistral|mistral-embed|codestral-embed"
 	if err := provider.VerifyEmbedIdentity(legacy3, current); err != nil {
 		t.Errorf("legacy 3-field identity must match native current: %v", err)
@@ -193,8 +193,14 @@ func TestEmbedIdentity(t *testing.T) {
 	if err := provider.VerifyEmbedIdentity(legacy7, current); err != nil {
 		t.Errorf("legacy 7-field (pre-base_url) identity must match current: %v", err)
 	}
+	// pre-contextual 8-field form (#330): the shape every shipped index records
+	// today. It gains only the terminal "|off".
+	legacy8 := "mistral||mistral-embed|codestral-embed|0|0|off|off"
+	if err := provider.VerifyEmbedIdentity(legacy8, current); err != nil {
+		t.Errorf("legacy 8-field (pre-contextual) identity must match current: %v", err)
+	}
 	// But a legacy identity vs a non-native dimension still mismatches.
-	_ = cfgErr(t, provider.VerifyEmbedIdentity(legacy3, "mistral||mistral-embed|codestral-embed|768|0|off|off"))
+	_ = cfgErr(t, provider.VerifyEmbedIdentity(legacy3, "mistral||mistral-embed|codestral-embed|768|0|off|off|off"))
 }
 
 // TestEmbedIdentity_BaseURL exercises the SPEC 8.1.4 base_url component of the
@@ -205,9 +211,9 @@ func TestEmbedIdentity(t *testing.T) {
 func TestEmbedIdentity_BaseURL(t *testing.T) {
 	// baseURLOf extracts the 2nd identity field (the normalized base_url).
 	baseURLOf := func(p provider.Profile) string {
-		parts := strings.Split(provider.EmbedIdentity(p, false), "|")
+		parts := strings.Split(provider.EmbedIdentity(p, false, provider.EmbedContextualOff), "|")
 		if len(parts) < 2 {
-			t.Fatalf("identity has no base_url field: %q", provider.EmbedIdentity(p, false))
+			t.Fatalf("identity has no base_url field: %q", provider.EmbedIdentity(p, false, provider.EmbedContextualOff))
 		}
 		return parts[1]
 	}
@@ -250,7 +256,7 @@ func TestEmbedIdentity_BaseURL(t *testing.T) {
 	if baseURLOf(a) == "" || baseURLOf(b) == "" {
 		t.Fatalf("custom endpoints must yield a non-empty base_url component: %q %q", baseURLOf(a), baseURLOf(b))
 	}
-	idA, idB := provider.EmbedIdentity(a, false), provider.EmbedIdentity(b, false)
+	idA, idB := provider.EmbedIdentity(a, false, provider.EmbedContextualOff), provider.EmbedIdentity(b, false, provider.EmbedContextualOff)
 	if idA == idB {
 		t.Fatalf("two kind:openai profiles at different custom endpoints must differ: %q", idA)
 	}
@@ -283,7 +289,7 @@ func TestEmbedIdentity_BaseURL(t *testing.T) {
 	// stays valid against the current hosted-default identity — no spurious
 	// reindex — but mismatches a corpus pinned to a custom endpoint.
 	hostedCurrent := provider.EmbedIdentity(provider.Profile{Name: "mistral", Kind: provider.KindOpenAI,
-		BaseURL: "https://api.mistral.ai/v1", EmbedTextModel: "mistral-embed", EmbedCodeModel: "codestral-embed"}, false)
+		BaseURL: "https://api.mistral.ai/v1", EmbedTextModel: "mistral-embed", EmbedCodeModel: "codestral-embed"}, false, provider.EmbedContextualOff)
 	legacyHosted := "mistral|mistral-embed|codestral-embed|0|0|off|off" // pre-base_url 7-field
 	if err := provider.VerifyEmbedIdentity(legacyHosted, hostedCurrent); err != nil {
 		t.Errorf("pre-base_url hosted-default identity must not reindex: %v", err)
@@ -298,7 +304,7 @@ func TestEmbedIdentity_BaseURL(t *testing.T) {
 // default, or vectors from two backends could silently share one index.
 func TestEmbedIdentity_PerProfileCanonical(t *testing.T) {
 	baseURLOf := func(p provider.Profile) string {
-		return strings.Split(provider.EmbedIdentity(p, false), "|")[1]
+		return strings.Split(provider.EmbedIdentity(p, false, provider.EmbedContextualOff), "|")[1]
 	}
 	mistralReal := provider.Profile{Name: "mistral", Kind: provider.KindOpenAI,
 		BaseURL: "https://api.mistral.ai/v1", EmbedTextModel: "text-embedding-3-small"}
@@ -307,7 +313,7 @@ func TestEmbedIdentity_PerProfileCanonical(t *testing.T) {
 	if got := baseURLOf(mistralAtOpenAI); got == "" {
 		t.Errorf("a mistral profile pointed at api.openai.com must NOT collapse to \"\" (kind-wide mixing bug)")
 	}
-	if provider.EmbedIdentity(mistralReal, false) == provider.EmbedIdentity(mistralAtOpenAI, false) {
+	if provider.EmbedIdentity(mistralReal, false, provider.EmbedContextualOff) == provider.EmbedIdentity(mistralAtOpenAI, false, provider.EmbedContextualOff) {
 		t.Errorf("mistral@mistral and mistral@openai must have distinct identities")
 	}
 }
@@ -353,11 +359,11 @@ func TestEmbedBaseURL_CanonicalizationRobustness(t *testing.T) {
 	if got := norm("user:secret@${EMBED_URL}"); strings.Contains(got, "secret") {
 		t.Errorf("fallback must drop a userinfo credential: got %q", got)
 	}
-	// The delimiter guarantee holds end-to-end: the identity keeps exactly 8 fields.
+	// The delimiter guarantee holds end-to-end: the identity keeps exactly 9 fields.
 	id := provider.EmbedIdentity(provider.Profile{Name: "custom", Kind: provider.KindOpenAI,
-		CredentialLess: true, BaseURL: "${EMBED_URL}|x", EmbedTextModel: "m"}, false)
-	if n := strings.Count(id, "|"); n != 7 {
-		t.Errorf("identity must have 8 fields (7 pipes), got %d: %q", n, id)
+		CredentialLess: true, BaseURL: "${EMBED_URL}|x", EmbedTextModel: "m"}, false, provider.EmbedContextualOff)
+	if n := strings.Count(id, "|"); n != 8 {
+		t.Errorf("identity must have 9 fields (8 pipes), got %d: %q", n, id)
 	}
 }
 

--- a/tests/store/chunk_context_330_test.go
+++ b/tests/store/chunk_context_330_test.go
@@ -1,0 +1,180 @@
+package tests
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// newContextStore opens a fresh sqlite store with one document, returning the
+// store and the document's rel_path.
+func newContextStore(t *testing.T) (*store.SQLiteStore, string) {
+	t.Helper()
+	ctx := context.Background()
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	t.Cleanup(func() { _ = st.Close() })
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	const relPath = "docs/a.md"
+	if err := st.UpsertDocument(ctx, model.Document{
+		RelPath: relPath, DocType: "md", SourceType: "local", Status: "ok",
+	}); err != nil {
+		t.Fatalf("UpsertDocument: %v", err)
+	}
+	return st, relPath
+}
+
+// insertChunk writes one chunk of a raw_text representation for relPath.
+func insertChunk(t *testing.T, st *store.SQLiteStore, relPath string, ordinal int, chunk model.Chunk) {
+	t.Helper()
+	ctx := context.Background()
+	doc, err := st.GetDocumentByPath(ctx, relPath)
+	if err != nil {
+		t.Fatalf("GetDocumentByPath: %v", err)
+	}
+	repID, err := st.UpsertRepresentation(ctx, model.Representation{
+		DocID: doc.DocID, RepType: "raw_text", RepHash: "h", CreatedUnix: 1,
+	})
+	if err != nil {
+		t.Fatalf("UpsertRepresentation: %v", err)
+	}
+	chunk.RepID = repID
+	chunk.Ordinal = ordinal
+	if chunk.IndexKind == "" {
+		chunk.IndexKind = "text"
+	}
+	if chunk.EmbeddingStatus == "" {
+		chunk.EmbeddingStatus = "pending"
+	}
+	if _, err := st.InsertChunkWithSpans(ctx, chunk, nil); err != nil {
+		t.Fatalf("InsertChunkWithSpans: %v", err)
+	}
+}
+
+// TestChunkContext_RoundTripsThroughNextPending pins SPEC §5.3/§8.1.8: the
+// additive chunk_context column round-trips onto the ChunkTask the embed worker
+// leases, so the worker prepends the context WITHOUT a provider round-trip —
+// while the task's Text (what snippets and citations render) stays raw.
+func TestChunkContext_RoundTripsThroughNextPending(t *testing.T) {
+	ctx := context.Background()
+	st, relPath := newContextStore(t)
+
+	insertChunk(t, st, relPath, 0, model.Chunk{
+		Text:          "the raw chunk text",
+		TextHash:      "th",
+		Context:       "From the Q3 report, discussing revenue.",
+		EmbeddingMode: model.EmbeddingModeContextualized,
+	})
+
+	tasks, err := st.NextPending(ctx, 10, "text")
+	if err != nil {
+		t.Fatalf("NextPending: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 pending task, got %d", len(tasks))
+	}
+	task := tasks[0]
+	if task.Text != "the raw chunk text" {
+		t.Errorf("Text must stay the RAW chunk, got %q", task.Text)
+	}
+	if task.Context != "From the Q3 report, discussing revenue." {
+		t.Errorf("Context did not round-trip, got %q", task.Context)
+	}
+	if want := task.Context + "\n\n" + task.Text; task.EmbedInput() != want {
+		t.Errorf("EmbedInput() = %q, want %q", task.EmbedInput(), want)
+	}
+	// Citation faithfulness: the snippet the store derives is built from the raw
+	// text, so the generated context can never reach a hit or a citation (#403).
+	if strings.Contains(task.Metadata.Snippet, "Q3 report") {
+		t.Errorf("the generated context leaked into the snippet: %q", task.Metadata.Snippet)
+	}
+
+	byID, _, err := st.ChunkTaskByID(ctx, task.Label)
+	if err != nil {
+		t.Fatalf("ChunkTaskByID: %v", err)
+	}
+	if byID.Context != task.Context || byID.Text != task.Text {
+		t.Errorf("ChunkTaskByID lost the raw/context split: %+v", byID)
+	}
+}
+
+// TestChunkContext_DefaultsAreThePreFeatureShape pins the additive-migration
+// contract (SPEC §5.3): a chunk written WITHOUT contextual fields reads back as
+// "contextual retrieval was off" — empty context, embedding_mode=disabled — which
+// is exactly how a pre-feature index's existing rows must read.
+func TestChunkContext_DefaultsAreThePreFeatureShape(t *testing.T) {
+	ctx := context.Background()
+	st, relPath := newContextStore(t)
+
+	insertChunk(t, st, relPath, 0, model.Chunk{Text: "plain chunk", TextHash: "th"})
+
+	tasks, err := st.NextPending(ctx, 10, "text")
+	if err != nil {
+		t.Fatalf("NextPending: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 pending task, got %d", len(tasks))
+	}
+	if tasks[0].Context != "" {
+		t.Errorf("a pre-feature chunk must carry no context, got %q", tasks[0].Context)
+	}
+	if tasks[0].EmbedInput() != tasks[0].Text {
+		t.Error("with no context the embed input must be the raw text byte-for-byte")
+	}
+	// And the retry gate sees nothing to heal.
+	pending, err := st.HasFallbackContextChunks(ctx, relPath)
+	if err != nil {
+		t.Fatalf("HasFallbackContextChunks: %v", err)
+	}
+	if pending {
+		t.Error("a corpus with no fallback chunks must not be reported as needing a retry")
+	}
+}
+
+// TestHasFallbackContextChunks pins the self-heal gate (SPEC §8.1.8): a chunk
+// whose context generation failed is durably discoverable, so the next scan
+// retries it instead of leaving a silent, permanent coverage hole.
+func TestHasFallbackContextChunks(t *testing.T) {
+	ctx := context.Background()
+	st, relPath := newContextStore(t)
+
+	insertChunk(t, st, relPath, 0, model.Chunk{
+		Text: "healthy chunk", TextHash: "h1",
+		Context: "situating context", EmbeddingMode: model.EmbeddingModeContextualized,
+	})
+	insertChunk(t, st, relPath, 1, model.Chunk{
+		Text: "failed chunk", TextHash: "h2",
+		EmbeddingMode: model.EmbeddingModeFallback,
+	})
+
+	pending, err := st.HasFallbackContextChunks(ctx, relPath)
+	if err != nil {
+		t.Fatalf("HasFallbackContextChunks: %v", err)
+	}
+	if !pending {
+		t.Fatal("a document with a fallback chunk must be reported for retry")
+	}
+
+	// A different document is unaffected.
+	if pending, err := st.HasFallbackContextChunks(ctx, "docs/other.md"); err != nil || pending {
+		t.Fatalf("unrelated document: pending=%v err=%v", pending, err)
+	}
+
+	// Healing the chunk clears the gate.
+	insertChunk(t, st, relPath, 1, model.Chunk{
+		Text: "failed chunk", TextHash: "h2",
+		Context: "now situated", EmbeddingMode: model.EmbeddingModeContextualized,
+	})
+	pending, err = st.HasFallbackContextChunks(ctx, relPath)
+	if err != nil {
+		t.Fatalf("HasFallbackContextChunks: %v", err)
+	}
+	if pending {
+		t.Fatal("once every chunk is contextualized the retry gate must clear")
+	}
+}


### PR DESCRIPTION
Implements SPEC §8.1.8 contextual retrieval: an LLM-generated, document-aware context string is prepended to the text that is **embedded**, so a chunk carries its parent document’s framing into the vector space without changing what the chunk *is*.

Re-pins `dirstral-spec` to `392c784` (spec **0.42.0**).

## Embed identity (§8.1.4)

The recorded identity gains its 9th and terminal field, `contextual`:

```
provider|base_url|text_model|code_model|text_dim|code_dim|multimodal|late_chunking|contextual
```

`EmbedIdentity` takes the contextual token, and `normalizeEmbedIdentity` grows the full normative ladder — `3/5/6/7/8 → 9`, with every pre-`base_url` shape also gaining an empty `base_url` at position 2. An **unrecognized** field count is left unchanged so it fails the comparison *loudly*, rather than being coerced into a false match that would silently mix vector spaces.

The value records the **effective** mode, never mere config intent: `off` when disabled *or* when enabled with no chat provider available (capability fallback), else `ctx:<hash>` over a canonical serialization of every input that can change the generated context. Recording `on` for raw vectors would make the corpus look contextual-compatible the moment a provider was added later.

## Citation faithfulness (invariant)

The contextualized text is used **only** as embedder input. `chunks.text`, spans, `text_hash`, snippets, and every citation stay the **raw** chunk bytes; chunk boundaries are unchanged. The generated context can never appear in anything a user is shown or that an answer quotes.

## Per-chunk state

Additive columns `chunk_context` (nullable) and `embedding_mode` (`disabled|contextualized|fallback`), which disambiguate a NULL context: feature off vs. context generated vs. generation failed and the chunk embedded raw. A `fallback` chunk is retried on the next scan while contextualization stays on. `embedding_mode` is per-chunk state and is deliberately **not** part of the embed identity.

Capability-driven activation, fail-open, **off by default**, following the existing OCR/STT pattern. The cache key includes the parent document’s content hash, so an edited document regenerates its chunks’ context.

## Tests

The load-bearing cases, all under `tests/`:

- **`TestEmbedIdentity_MigrationLadder`** — one row per recorded shape, each asserting it compares **equal** to a fresh feature-disabled build. A regression here re-embeds every corpus in the wild on upgrade.
- **`TestEmbedIdentity_UnrecognizedFieldCountFailsLoudly`** — 1/2/4/10-field inputs must not be coerced into a match.
- **`TestContextual_CitationFaithfulness`** and **`TestEmbedAndIndex_ContextIsPrependedToEmbedInputOnly`** — context reaches the embed input and nothing else.
- **`TestContextual_FailOpenPerChunk`**, **`TestChunkContext_DefaultsAreThePreFeatureShape`** — capability fallback records `off`, not `on`; pre-feature rows keep pre-feature behavior.

## Verification

`go build ./...`, `go vet ./...`, full `go test ./...`, `go test -race` over provider/store/ingest/index/tests, and `gocyclo -over 15 cmd internal tests` (exit 0) all clean. `gofmt -l` reports only the three files already dirty on `main` (`internal/ingest/exclude.go`, `internal/retrieval/min_score_floor_rrf_test.go`, `internal/store/extractable_extensions_test.go`) — none are in this diff.

Closes #330