### PR TITLE
test(store): scale ConcurrentWritersNoBusy deadline under -race (#614)

### DIFF
--- a/tests/store/racetimeout_norace.go
+++ b/tests/store/racetimeout_norace.go
@@ -4,5 +4,6 @@ package tests
 
 import "time"
 
-// raceScaled is the identity outside `-race` builds; see the race-tagged variant.
+// raceScaled is the identity outside `-race` builds; see the race-tagged variant
+// for why deadlines are expanded when the race detector is enabled.
 func raceScaled(d time.Duration) time.Duration { return d }

--- a/tests/store/racetimeout_race.go
+++ b/tests/store/racetimeout_race.go
@@ -5,8 +5,9 @@ package tests
 import "time"
 
 // raceScaled expands a fixed test deadline when the binary is built with the
-// race detector. `-race` slows the CGO sqlite paths (and WAL lock contention)
-// roughly an order of magnitude, so a deadline that is ample normally would
-// otherwise expire and produce a spurious "context deadline exceeded" failure
-// unrelated to any data race (issue #419).
+// race detector. `-race` slows the CGO sqlite store paths roughly an order of
+// magnitude, so deadlines that are generous in a normal build would otherwise
+// expire under full-suite CI contention and produce spurious "context deadline
+// exceeded" failures that have nothing to do with a data race (issue #614).
+// Mirrors the tests/cli helper of the same name (issue #419).
 func raceScaled(d time.Duration) time.Duration { return d * 10 }

--- a/tests/store/sqlite_concurrent_writers_test.go
+++ b/tests/store/sqlite_concurrent_writers_test.go
@@ -34,8 +34,14 @@ func TestSQLiteStore_ConcurrentWritersNoBusy(t *testing.T) {
 
 	// Bound the test so a regression that re-introduces lock contention or
 	// blocking causes a fast, descriptive failure rather than an unbounded
-	// CI hang. 30s is generous for the workload below on cold cache.
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	// CI hang. 30s is generous for the workload below on cold cache. The bound
+	// guards against a genuine hang, not throughput: this test asserts the
+	// absence of SQLITE_BUSY under contention, so the wall-clock ceiling is
+	// incidental to what it checks. raceScaled expands the deadline under
+	// `-race` (5-20x slowdown), where full-suite contention on a shared CI
+	// runner would otherwise trip the 30s ceiling and surface as a spurious
+	// "context deadline exceeded" — a timeout, not a busy error (issue #614).
+	ctx, cancel := context.WithTimeout(context.Background(), raceScaled(30*time.Second))
 	defer cancel()
 
 	dbPath := filepath.Join(t.TempDir(), "meta.sqlite")


### PR DESCRIPTION
De-flakes `TestSQLiteStore_ConcurrentWritersNoBusy`, which reddens unrelated PRs in the `race` job.

## Root cause

Not a data race (the detector reports none) and not a product bug. The test sets a 30s context deadline and asserts **no `SQLITE_BUSY`** under concurrent writers. Under `-race` (≈10× slowdown on the CGO sqlite paths) sharing a runner with the rest of `tests/store`, the writers legitimately exceed 30s, so the deadline trips:

```
UpsertChunkTask: context deadline exceeded  (30.04s)
```

a timeout, incidental to the SQLITE_BUSY assertion — reproduces 0/8 locally, only under full-suite `-race` contention.

## Fix

Wrap the deadline in `raceScaled` (30s → 300s under `-race`, unchanged otherwise), reusing the **exact build-tag helper already established in `tests/cli`** (`racetimeout_race.go` / `racetimeout_norace.go`, from #419) — now mirrored into `tests/store`. The bound still fails a genuine hang; it just stops punishing the instrumented run. The SQLITE_BUSY assertion is untouched, the writer/iteration counts unchanged.

## Verification

- `go test -race ./tests/store/ -run TestSQLiteStore_ConcurrentWritersNoBusy -count=5` → **pass** (~6s per run, far under the scaled ceiling)
- non-race run, `gocyclo -over 15 cmd internal tests`, `gofmt` → clean

Net diff: the one test + the two-file `raceScaled` helper pair.

Closes #614