### PR TITLE
test(cli): tolerate diagnostic lines on stderr when parsing the up JSON error (#615)

### DIFF
--- a/tests/cli/stderr_json_test.go
+++ b/tests/cli/stderr_json_test.go
@@ -1,0 +1,76 @@
+package tests
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// jsonErrorPayloadFromStderr returns the first line of captured stderr that
+// parses as a JSON object, or nil if there is none.
+//
+// The `up --json` error envelope is emitted as a single JSON object on its own
+// line (internal/cli/app.go). stderr may ALSO carry human diagnostic lines that
+// the command is entitled to print — notably the port-rebind note ("note:
+// previous port (...) unavailable, binding a new one ...", internal/cli/up.go)
+// when a persisted port is already bound on a shared CI runner. Parsing the
+// whole stderr buffer as JSON then fails on the leading `note:` text. Scanning
+// for the JSON-object line keeps the payload assertions robust to those
+// non-JSON lines without weakening them (issue #615). The payload's message is
+// json.Marshal-escaped, so the object never spans multiple physical lines.
+func jsonErrorPayloadFromStderr(stderr string) []byte {
+	for _, line := range strings.Split(stderr, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "{") {
+			continue
+		}
+		var probe map[string]json.RawMessage
+		if json.Unmarshal([]byte(line), &probe) == nil {
+			return []byte(line)
+		}
+	}
+	return nil
+}
+
+// TestJSONErrorPayloadFromStderr pins that the payload extractor tolerates the
+// exact contamination that flaked TestUpReturnsExitCode3OnIngestionFatal (#615):
+// a human `note:` diagnostic line printed to stderr ahead of the JSON envelope.
+func TestJSONErrorPayloadFromStderr(t *testing.T) {
+	const payload = `{"error":{"code":"INGESTION_FATAL","message":"ingestion failed"},"exit_code":3}`
+
+	cases := []struct {
+		name   string
+		stderr string
+		want   string // "" means expect nil
+	}{
+		{"pure payload", payload + "\n", payload},
+		{
+			// The observed CI failure: a port-rebind note ahead of the payload.
+			name:   "note line then payload",
+			stderr: "note: previous port (127.0.0.1:51606) unavailable, binding a new one: bind: address already in use\n" + payload + "\n",
+			want:   payload,
+		},
+		{"payload then trailing note", payload + "\nnote: something after\n", payload},
+		{"no json at all", "note: only diagnostics here\n", ""},
+		{"empty", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := jsonErrorPayloadFromStderr(tc.stderr)
+			if tc.want == "" {
+				if got != nil {
+					t.Fatalf("want nil, got %s", got)
+				}
+				return
+			}
+			if string(got) != tc.want {
+				t.Fatalf("extracted %q, want %q", got, tc.want)
+			}
+			// The returned bytes must be valid, parseable JSON.
+			var probe map[string]json.RawMessage
+			if err := json.Unmarshal(got, &probe); err != nil {
+				t.Fatalf("extracted payload does not parse: %v", err)
+			}
+		})
+	}
+}

--- a/tests/cli/up_command_test.go
+++ b/tests/cli/up_command_test.go
@@ -288,7 +288,11 @@ func TestUpInvalidFlagWithJSONEmitsJSONError(t *testing.T) {
 		} `json:"error"`
 		ExitCode int `json:"exit_code"`
 	}
-	if err := json.Unmarshal(stderr.Bytes(), &payload); err != nil {
+	payloadJSON := jsonErrorPayloadFromStderr(stderr.String())
+	if payloadJSON == nil {
+		t.Fatalf("no JSON error payload found on stderr; raw=%s", stderr.String())
+	}
+	if err := json.Unmarshal(payloadJSON, &payload); err != nil {
 		t.Fatalf("unmarshal up parse error payload: %v raw=%s", err, stderr.String())
 	}
 	if payload.Error.Code != "CONFIG_INVALID" || payload.ExitCode != 2 {
@@ -783,7 +787,11 @@ func TestUpReturnsExitCode3OnIngestionFatal(t *testing.T) {
 		} `json:"error"`
 		ExitCode int `json:"exit_code"`
 	}
-	if err := json.Unmarshal(stderr.Bytes(), &payload); err != nil {
+	payloadJSON := jsonErrorPayloadFromStderr(stderr.String())
+	if payloadJSON == nil {
+		t.Fatalf("no JSON error payload found on stderr; raw=%s", stderr.String())
+	}
+	if err := json.Unmarshal(payloadJSON, &payload); err != nil {
 		t.Fatalf("unmarshal ingestion stderr payload: %v raw=%s", err, stderr.String())
 	}
 	if payload.Error.Code != "INGESTION_FATAL" || payload.ExitCode != 3 {


### PR DESCRIPTION
De-flakes `TestUpReturnsExitCode3OnIngestionFatal`, which reddens PRs whose diff never touches `internal/cli`.

## Root cause

The test `json.Unmarshal`d the **entire** captured stderr, assuming it is only the JSON envelope. But `up` legitimately prints a human note to stderr and rebinds when a persisted port is already bound on a shared runner (`internal/cli/up.go`):

```
note: previous port (127.0.0.1:51606) unavailable, binding a new one ...: bind: address already in use
{"error":{"code":"INGESTION_FATAL","message":"ingestion failed"},"exit_code":3}
```

so the unmarshal trips on the leading `n` of `note` (`invalid character 'o' in literal null`). Environmental (port contention, which the product handles correctly) surfacing a **test-robustness bug**.

## Fix

`jsonErrorPayloadFromStderr` scans stderr for the first line that parses as a JSON object. The `up --json` envelope is a single `json.Marshal`-escaped object on its own line (`internal/cli/app.go:1126`), so it never spans lines and the extraction is exact. Applied at the two `up_command_test.go` sites that parse the `up` JSON error from stderr.

**Scoped deliberately:** the six `command_behavior_test.go` sites parse `status`/`ask`/`reindex`/`config` errors — none reach the listen/binding path that emits the note — so they are left unchanged.

## Verification

- New unit test `TestJSONErrorPayloadFromStderr` drives the extractor through the **exact** contamination (a `note:` line ahead of the payload) plus trailing-note / no-json / empty cases — **pass**.
- The two `up` tests, the full `tests/cli` suite, `gocyclo -over 15`, and `gofmt` — **pass/clean**.

Payload-field assertions are unchanged.

Closes #615