### PR TITLE
feat: intra-document media time-window filter for search/ask (§9.8)

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -771,7 +771,7 @@ func isResolvableSourceWithRoot(doc model.Document, rootAbs, rootReal string) bo
 
 func (s *Server) handleSearchTool(ctx context.Context, args map[string]interface{}) (toolCallResult, *toolExecutionError) {
 	if err := assertNoUnknownArguments(args, map[string]struct{}{
-		"query": {}, "k": {}, "index": {}, "path_prefix": {}, "file_glob": {}, "doc_types": {}, "speaker": {}, "languages": {}, "language_match": {}, "date_from": {}, "date_to": {},
+		"query": {}, "k": {}, "index": {}, "path_prefix": {}, "file_glob": {}, "doc_types": {}, "speaker": {}, "languages": {}, "language_match": {}, "date_from": {}, "date_to": {}, "time_from_ms": {}, "time_to_ms": {},
 	}); err != nil {
 		return toolCallResult{}, &toolExecutionError{Code: "INVALID_FIELD", Message: err.Error(), Retryable: false}
 	}
@@ -806,7 +806,7 @@ func (s *Server) handleSearchTool(ctx context.Context, args map[string]interface
 	if toolErr != nil {
 		return toolCallResult{}, toolErr
 	}
-	dateFrom, dateTo, toolErr := parseDateWindow(args)
+	tw, toolErr := parseTemporalFilters(args)
 	if toolErr != nil {
 		return toolCallResult{}, toolErr
 	}
@@ -814,7 +814,8 @@ func (s *Server) handleSearchTool(ctx context.Context, args map[string]interface
 		return toolCallResult{}, &toolExecutionError{Code: protocol.ErrorCodeIndexNotReady, Message: "retriever not configured", Retryable: false}
 	}
 	sq := model.SearchQuery{
-		Query: query, K: k, Index: indexName, PathPrefix: pathPrefix, FileGlob: fileGlob, DocTypes: docTypes, Speaker: speaker, Languages: languages, LanguageMatch: languageMatch, DateFrom: dateFrom, DateTo: dateTo,
+		Query: query, K: k, Index: indexName, PathPrefix: pathPrefix, FileGlob: fileGlob, DocTypes: docTypes, Speaker: speaker, Languages: languages, LanguageMatch: languageMatch, DateFrom: tw.dateFrom, DateTo: tw.dateTo,
+		HasTimeFrom: tw.hasTimeFrom, TimeFromMS: tw.timeFromMS, HasTimeTo: tw.hasTimeTo, TimeToMS: tw.timeToMS,
 	}
 	// index_used MUST be the index the query was actually routed to (SPEC §15.2),
 	// not the requested name. Prefer AxisSearcher so the reported axis is read back
@@ -1013,7 +1014,7 @@ func mapRelatedError(err error) *toolExecutionError {
 
 func (s *Server) handleAskTool(ctx context.Context, args map[string]interface{}) (toolCallResult, *toolExecutionError) {
 	if err := assertNoUnknownArguments(args, map[string]struct{}{
-		"question": {}, "k": {}, "mode": {}, "index": {}, "path_prefix": {}, "file_glob": {}, "doc_types": {}, "languages": {}, "language_match": {}, "date_from": {}, "date_to": {},
+		"question": {}, "k": {}, "mode": {}, "index": {}, "path_prefix": {}, "file_glob": {}, "doc_types": {}, "languages": {}, "language_match": {}, "date_from": {}, "date_to": {}, "time_from_ms": {}, "time_to_ms": {},
 	}); err != nil {
 		return toolCallResult{}, &toolExecutionError{Code: "INVALID_FIELD", Message: err.Error(), Retryable: false}
 	}
@@ -1048,14 +1049,15 @@ func (s *Server) handleAskTool(ctx context.Context, args map[string]interface{})
 	if toolErr != nil {
 		return toolCallResult{}, toolErr
 	}
-	dateFrom, dateTo, toolErr := parseDateWindow(args)
+	tw, toolErr := parseTemporalFilters(args)
 	if toolErr != nil {
 		return toolCallResult{}, toolErr
 	}
 	if s.retriever == nil {
 		return toolCallResult{}, &toolExecutionError{Code: protocol.ErrorCodeIndexNotReady, Message: "retriever not configured", Retryable: false}
 	}
-	sq := model.SearchQuery{Query: question, K: k, Index: indexName, PathPrefix: pathPrefix, FileGlob: fileGlob, DocTypes: docTypes, Languages: languages, LanguageMatch: languageMatch, DateFrom: dateFrom, DateTo: dateTo}
+	sq := model.SearchQuery{Query: question, K: k, Index: indexName, PathPrefix: pathPrefix, FileGlob: fileGlob, DocTypes: docTypes, Languages: languages, LanguageMatch: languageMatch, DateFrom: tw.dateFrom, DateTo: tw.dateTo,
+		HasTimeFrom: tw.hasTimeFrom, TimeFromMS: tw.timeFromMS, HasTimeTo: tw.hasTimeTo, TimeToMS: tw.timeToMS}
 	if mode == "search_only" {
 		return s.runSearchOnlyMode(ctx, question, sq)
 	}
@@ -2077,6 +2079,61 @@ func parseDateWindow(args map[string]interface{}) (dateFrom, dateTo int64, toolE
 		}
 	}
 	return dateFrom, dateTo, nil
+}
+
+// parseTimeWindow parses the optional time_from_ms/time_to_ms arguments (SPEC
+// §9.8) into an inclusive intra-document millisecond window with explicit
+// presence flags. Each bound, when present, must be an integer >= 0; an inverted
+// window (from after to) is an INVALID_FIELD error (df-008). Presence is
+// explicit — not inferred from the value — because 0 is a valid lower bound
+// (video start). A window that simply matches nothing is left to retrieval to
+// return as an empty result, not an error.
+func parseTimeWindow(args map[string]interface{}) (fromMS int, hasFrom bool, toMS int, hasTo bool, toolErr *toolExecutionError) {
+	fromMS, hasFrom, err := parseOptionalIntegerWithPresence(args, "time_from_ms")
+	if err != nil {
+		return 0, false, 0, false, &toolExecutionError{Code: "INVALID_FIELD", Message: err.Error(), Retryable: false}
+	}
+	toMS, hasTo, err = parseOptionalIntegerWithPresence(args, "time_to_ms")
+	if err != nil {
+		return 0, false, 0, false, &toolExecutionError{Code: "INVALID_FIELD", Message: err.Error(), Retryable: false}
+	}
+	if hasFrom && fromMS < 0 {
+		return 0, false, 0, false, &toolExecutionError{Code: "INVALID_FIELD", Message: "time_from_ms must be >= 0", Retryable: false}
+	}
+	if hasTo && toMS < 0 {
+		return 0, false, 0, false, &toolExecutionError{Code: "INVALID_FIELD", Message: "time_to_ms must be >= 0", Retryable: false}
+	}
+	if hasFrom && hasTo && fromMS > toMS {
+		return 0, false, 0, false, &toolExecutionError{Code: "INVALID_FIELD", Message: "time_from_ms must not be after time_to_ms", Retryable: false}
+	}
+	return fromMS, hasFrom, toMS, hasTo, nil
+}
+
+// temporalFilters bundles the parsed optional temporal retrieval filters: the
+// §9.6 document-date window and the §9.8 intra-document media time window.
+type temporalFilters struct {
+	dateFrom, dateTo int64
+	timeFromMS       int
+	hasTimeFrom      bool
+	timeToMS         int
+	hasTimeTo        bool
+}
+
+// parseTemporalFilters parses the date_from/date_to (§9.6) and
+// time_from_ms/time_to_ms (§9.8) arguments together, so search/ask validate both
+// temporal windows in one step and share identical semantics.
+func parseTemporalFilters(args map[string]interface{}) (temporalFilters, *toolExecutionError) {
+	var tf temporalFilters
+	var toolErr *toolExecutionError
+	tf.dateFrom, tf.dateTo, toolErr = parseDateWindow(args)
+	if toolErr != nil {
+		return temporalFilters{}, toolErr
+	}
+	tf.timeFromMS, tf.hasTimeFrom, tf.timeToMS, tf.hasTimeTo, toolErr = parseTimeWindow(args)
+	if toolErr != nil {
+		return temporalFilters{}, toolErr
+	}
+	return tf, nil
 }
 
 // mapSearchError converts a search/ask error into a toolExecutionError.
@@ -3270,6 +3327,16 @@ func searchInputSchema() map[string]interface{} {
 				"type":        "string",
 				"description": "Optional (SPEC §9.6): restrict hits to documents whose date (mtime) is on or before this bound (inclusive). Accepts an RFC 3339 timestamp or a bare YYYY-MM-DD date (end of that UTC day, 23:59:59Z). Absent = open upper bound.",
 			},
+			"time_from_ms": map[string]interface{}{
+				"type":        "integer",
+				"minimum":     0,
+				"description": "Optional (SPEC §9.8): intra-document media time-window lower bound, in milliseconds within a document's timeline (§5.4). When set, only time-spanned hits are eligible and are kept iff their span overlaps [time_from_ms, time_to_ms] (inclusive). Absent = open lower bound. time_from_ms > time_to_ms is INVALID_FIELD.",
+			},
+			"time_to_ms": map[string]interface{}{
+				"type":        "integer",
+				"minimum":     0,
+				"description": "Optional (SPEC §9.8): intra-document media time-window upper bound, in milliseconds within a document's timeline (§5.4). Absent = open upper bound.",
+			},
 		},
 		"required": []string{"query"},
 	}
@@ -3385,6 +3452,16 @@ func askInputSchema() map[string]interface{} {
 			"date_to": map[string]interface{}{
 				"type":        "string",
 				"description": "Optional (SPEC §9.6): restrict retrieved contexts to documents whose date (mtime) is on or before this bound (inclusive). Accepts an RFC 3339 timestamp or a bare YYYY-MM-DD date (end of that UTC day, 23:59:59Z). Absent = open upper bound.",
+			},
+			"time_from_ms": map[string]interface{}{
+				"type":        "integer",
+				"minimum":     0,
+				"description": "Optional (SPEC §9.8): intra-document media time-window lower bound, in milliseconds within a document's timeline (§5.4). When set, only time-spanned contexts are eligible and are kept iff their span overlaps [time_from_ms, time_to_ms] (inclusive). Absent = open lower bound. time_from_ms > time_to_ms is INVALID_FIELD.",
+			},
+			"time_to_ms": map[string]interface{}{
+				"type":        "integer",
+				"minimum":     0,
+				"description": "Optional (SPEC §9.8): intra-document media time-window upper bound, in milliseconds within a document's timeline (§5.4). Absent = open upper bound.",
 			},
 		},
 		"required": []string{"question"},

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -589,6 +589,20 @@ type SearchQuery struct {
 	// filter (unchanged behavior). Callers validate DateFrom <= DateTo upstream.
 	DateFrom int64
 	DateTo   int64
+	// TimeFromMS / TimeToMS optionally restrict hits to an intra-document media
+	// time window (SPEC §9.8): non-negative millisecond offsets within a
+	// document's timeline, both bounds inclusive, with overlap (not containment)
+	// semantics. Each bound is meaningful only when its HasTimeFrom / HasTimeTo
+	// flag is set — 0 is a valid lower bound (video start), so presence cannot be
+	// inferred from the value, and a zero-value SearchQuery leaves the filter off.
+	// The filter is active when EITHER bound is present; while active, only
+	// time-spanned hits are eligible (a non-time span never matches), so a corpus
+	// without time-spanned representations returns no time-filtered hits. Callers
+	// validate TimeFromMS <= TimeToMS upstream.
+	HasTimeFrom bool
+	TimeFromMS  int
+	HasTimeTo   bool
+	TimeToMS    int
 }
 
 // RelatedQuery is the input to a query-by-example "more like this" retrieval

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -3615,6 +3615,39 @@ func matchFilters(hit model.SearchHit, query model.SearchQuery) bool {
 		return false
 	}
 
+	// Optional intra-document media time-window (SPEC §9.8): when either bound is
+	// set, restrict to time-spanned hits whose span overlaps the inclusive
+	// [time_from_ms, time_to_ms] window. Mirrors the speaker filter — a hit with a
+	// non-time span (or none) never matches an active window, so a corpus without
+	// time-spanned representations returns no time-filtered hits. Applied here at
+	// candidate selection (before de-dup, reranking, and truncation to k), so k
+	// counts only in-window hits; inactive by default.
+	if !withinTimeWindow(hit.Span, query) {
+		return false
+	}
+
+	return true
+}
+
+// withinTimeWindow implements the SPEC §9.8 intra-document media time-window
+// filter. It is inactive (returns true) unless the query set at least one bound.
+// When active, only a hit carrying a `time` span that OVERLAPS the inclusive
+// [TimeFromMS, TimeToMS] window is kept — overlap, not containment, so a segment
+// straddling a bound still surfaces. An absent bound (Has*=false) is unbounded on
+// that side.
+func withinTimeWindow(span model.Span, query model.SearchQuery) bool {
+	if !query.HasTimeFrom && !query.HasTimeTo {
+		return true // filter inactive — behaviour unchanged
+	}
+	if span.Kind != "time" {
+		return false // only time-spanned hits are eligible
+	}
+	if query.HasTimeTo && span.StartMS > query.TimeToMS {
+		return false
+	}
+	if query.HasTimeFrom && span.EndMS < query.TimeFromMS {
+		return false
+	}
 	return true
 }
 

--- a/tests/mcp/search_time_window_test.go
+++ b/tests/mcp/search_time_window_test.go
@@ -1,0 +1,180 @@
+package tests
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// TestMCPSearch_TimeWindowPassedThrough verifies dir2mcp_search accepts the
+// optional time_from_ms/time_to_ms bounds (SPEC §9.8) and forwards them to the
+// retriever's SearchQuery with explicit presence flags.
+func TestMCPSearch_TimeWindowPassedThrough(t *testing.T) {
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+
+	var got model.SearchQuery
+	retriever := &askAudioRetrieverStub{
+		indexingComplete: true,
+		OnSearch: func(q model.SearchQuery) ([]model.SearchHit, error) {
+			got = q
+			return []model.SearchHit{}, nil
+		},
+	}
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"dir2mcp_search","arguments":{"query":"q","time_from_ms":15000,"time_to_ms":35000}}}`)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d body=%s", resp.StatusCode, string(payload))
+	}
+	if !got.HasTimeFrom || got.TimeFromMS != 15000 || !got.HasTimeTo || got.TimeToMS != 35000 {
+		t.Fatalf("time window not forwarded: hasFrom=%v from=%d hasTo=%v to=%d",
+			got.HasTimeFrom, got.TimeFromMS, got.HasTimeTo, got.TimeToMS)
+	}
+}
+
+// TestMCPSearch_TimeWindowZeroLowerBoundIsPresent pins the presence design: a
+// time_from_ms of 0 is forwarded as PRESENT (HasTimeFrom true), not treated as
+// absent — 0 is a valid lower bound (video start).
+func TestMCPSearch_TimeWindowZeroLowerBoundIsPresent(t *testing.T) {
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+
+	var got model.SearchQuery
+	retriever := &askAudioRetrieverStub{
+		indexingComplete: true,
+		OnSearch: func(q model.SearchQuery) ([]model.SearchHit, error) {
+			got = q
+			return []model.SearchHit{}, nil
+		},
+	}
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"dir2mcp_search","arguments":{"query":"q","time_from_ms":0,"time_to_ms":5000}}}`)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d body=%s", resp.StatusCode, string(payload))
+	}
+	if !got.HasTimeFrom || got.TimeFromMS != 0 {
+		t.Fatalf("time_from_ms=0 must forward as present with value 0, got hasFrom=%v from=%d", got.HasTimeFrom, got.TimeFromMS)
+	}
+}
+
+// TestMCPSearch_TimeWindowAbsentIsNoFilter verifies omitting the bounds leaves
+// both presence flags false (open on both sides, behaviour unchanged, §9.8).
+func TestMCPSearch_TimeWindowAbsentIsNoFilter(t *testing.T) {
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+
+	got := model.SearchQuery{HasTimeFrom: true, HasTimeTo: true} // poison to prove reset
+	retriever := &askAudioRetrieverStub{
+		indexingComplete: true,
+		OnSearch: func(q model.SearchQuery) ([]model.SearchHit, error) {
+			got = q
+			return []model.SearchHit{}, nil
+		},
+	}
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"dir2mcp_search","arguments":{"query":"q"}}}`)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d body=%s", resp.StatusCode, string(payload))
+	}
+	if got.HasTimeFrom || got.HasTimeTo {
+		t.Fatalf("absent time window must leave both presence flags false, got hasFrom=%v hasTo=%v", got.HasTimeFrom, got.HasTimeTo)
+	}
+}
+
+// TestMCPSearch_InvertedTimeWindowIsInvalidField verifies time_from_ms after
+// time_to_ms is INVALID_FIELD (df-008), not a silently-empty result, and the
+// retriever is never called.
+func TestMCPSearch_InvertedTimeWindowIsInvalidField(t *testing.T) {
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+	retriever := &askAudioRetrieverStub{indexingComplete: true}
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"dir2mcp_search","arguments":{"query":"q","time_from_ms":5000,"time_to_ms":1000}}}`)
+	defer func() { _ = resp.Body.Close() }()
+
+	body, _ := io.ReadAll(resp.Body)
+	if got := string(body); !containsCanonicalCode(got, "INVALID_FIELD") {
+		t.Fatalf("inverted time window must yield INVALID_FIELD, body=%s", got)
+	}
+	if retriever.searchCalled.Load() {
+		t.Fatal("retriever.Search must not be called for an inverted time window")
+	}
+}
+
+// TestMCPSearch_NegativeTimeIsInvalidField verifies a negative bound is
+// INVALID_FIELD (df-008), and the retriever is never called.
+func TestMCPSearch_NegativeTimeIsInvalidField(t *testing.T) {
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+	retriever := &askAudioRetrieverStub{indexingComplete: true}
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"dir2mcp_search","arguments":{"query":"q","time_from_ms":-1}}}`)
+	defer func() { _ = resp.Body.Close() }()
+
+	body, _ := io.ReadAll(resp.Body)
+	if got := string(body); !containsCanonicalCode(got, "INVALID_FIELD") {
+		t.Fatalf("negative time_from_ms must yield INVALID_FIELD, body=%s", got)
+	}
+	if retriever.searchCalled.Load() {
+		t.Fatal("retriever.Search must not be called for a negative bound")
+	}
+}
+
+// TestMCPAsk_TimeWindowPassedThrough verifies dir2mcp_ask forwards
+// time_from_ms/time_to_ms to Ask's query (SPEC §9.8/§15.3).
+func TestMCPAsk_TimeWindowPassedThrough(t *testing.T) {
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+
+	var got model.SearchQuery
+	retriever := &askAudioRetrieverStub{
+		indexingComplete: true,
+		askResult:        model.AskResult{Answer: "ok"},
+		OnAskQuery:       func(q model.SearchQuery) { got = q },
+	}
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"dir2mcp_ask","arguments":{"question":"q","time_from_ms":20000}}}`)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d body=%s", resp.StatusCode, string(payload))
+	}
+	if !got.HasTimeFrom || got.TimeFromMS != 20000 || got.HasTimeTo {
+		t.Fatalf("ask time window not forwarded, got hasFrom=%v from=%d hasTo=%v", got.HasTimeFrom, got.TimeFromMS, got.HasTimeTo)
+	}
+}

--- a/tests/retrieval/time_window_filter_test.go
+++ b/tests/retrieval/time_window_filter_test.go
@@ -1,0 +1,170 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
+)
+
+// timeCorpus builds a corpus of three time-spanned (media) hits plus one
+// non-time (text) hit, so the §9.8 intra-document media time-window filter can be
+// exercised against matchFilters. Distinct rel_paths sidestep media de-dup (the
+// filter itself is path-agnostic); the time spans are the point:
+//
+//	id 1: [0,     10000]  (0–10s)
+//	id 2: [20000, 30000]  (20–30s)
+//	id 3: [50000, 60000]  (50–60s)
+//	id 4: non-time (lines) — eligible only when the filter is inactive
+func timeCorpus(t *testing.T) *retrieval.Service {
+	t.Helper()
+	idx := index.NewHNSWIndex("")
+	addVec(t, idx, 1, []float32{1, 0})
+	addVec(t, idx, 2, []float32{0.97, 0.03})
+	addVec(t, idx, 3, []float32{0.94, 0.06})
+	addVec(t, idx, 4, []float32{0.91, 0.09})
+	return newDateService(t, idx, map[uint64]model.SearchHit{
+		1: {RelPath: "a.mp4", DocType: "video", Snippet: "0-10s", Span: model.Span{Kind: "time", StartMS: 0, EndMS: 10000}},
+		2: {RelPath: "b.mp4", DocType: "video", Snippet: "20-30s", Span: model.Span{Kind: "time", StartMS: 20000, EndMS: 30000}},
+		3: {RelPath: "c.mp4", DocType: "video", Snippet: "50-60s", Span: model.Span{Kind: "time", StartMS: 50000, EndMS: 60000}},
+		4: {RelPath: "notes.txt", DocType: "text", Snippet: "text", Span: model.Span{Kind: "lines", StartLine: 1, EndLine: 1}},
+	})
+}
+
+// TestSearch_TimeWindow_BothBoundsOverlap pins SPEC §9.8: a closed
+// [time_from_ms, time_to_ms] window keeps only time-spanned hits whose span
+// overlaps it, and excludes the non-time hit.
+func TestSearch_TimeWindow_BothBoundsOverlap(t *testing.T) {
+	svc := timeCorpus(t)
+	// [15000, 35000] overlaps only the 20–30s segment (id 2).
+	got := dateSearchIDs(t, svc, model.SearchQuery{
+		Query: "x", K: 10,
+		HasTimeFrom: true, TimeFromMS: 15000,
+		HasTimeTo: true, TimeToMS: 35000,
+	})
+	if len(got) != 1 || got[0] != 2 {
+		t.Fatalf("window [15s,35s] must yield only the 20–30s hit (id 2), got %v", got)
+	}
+}
+
+// TestSearch_TimeWindow_OverlapNotContainment pins §9.8: a hit is kept when its
+// span OVERLAPS the window, even if it is not contained — a boundary-straddling
+// segment still surfaces.
+func TestSearch_TimeWindow_OverlapNotContainment(t *testing.T) {
+	svc := timeCorpus(t)
+	// [8000, 22000] straddles the tail of id 1 (0–10s) and the head of id 2
+	// (20–30s); neither is contained, but both overlap.
+	got := dateSearchIDs(t, svc, model.SearchQuery{
+		Query: "x", K: 10,
+		HasTimeFrom: true, TimeFromMS: 8000,
+		HasTimeTo: true, TimeToMS: 22000,
+	})
+	if len(got) != 2 || !hasID(got, 1) || !hasID(got, 2) {
+		t.Fatalf("overlap (not containment) must keep ids 1 and 2, got %v", got)
+	}
+}
+
+// TestSearch_TimeWindow_OpenLowerBound pins §9.8: an absent time_from_ms leaves
+// the lower side open, so only time_to_ms constrains.
+func TestSearch_TimeWindow_OpenLowerBound(t *testing.T) {
+	svc := timeCorpus(t)
+	got := dateSearchIDs(t, svc, model.SearchQuery{
+		Query: "x", K: 10,
+		HasTimeTo: true, TimeToMS: 15000,
+	})
+	if len(got) != 1 || got[0] != 1 {
+		t.Fatalf("open-lower window (≤15s) must keep only the 0–10s hit (id 1), got %v", got)
+	}
+}
+
+// TestSearch_TimeWindow_OpenUpperBound pins §9.8: an absent time_to_ms leaves the
+// upper side open, so only time_from_ms constrains.
+func TestSearch_TimeWindow_OpenUpperBound(t *testing.T) {
+	svc := timeCorpus(t)
+	got := dateSearchIDs(t, svc, model.SearchQuery{
+		Query: "x", K: 10,
+		HasTimeFrom: true, TimeFromMS: 35000,
+	})
+	if len(got) != 1 || got[0] != 3 {
+		t.Fatalf("open-upper window (≥35s) must keep only the 50–60s hit (id 3), got %v", got)
+	}
+}
+
+// TestSearch_TimeWindow_ZeroIsAValidLowerBound pins the crux of the presence
+// design: time_from_ms=0 is an ACTIVE bound (video start), not "absent". A
+// [0, 5000] window overlaps only the 0–10s hit and excludes the non-time hit,
+// proving the filter is active even though the lower bound is the zero value.
+func TestSearch_TimeWindow_ZeroIsAValidLowerBound(t *testing.T) {
+	svc := timeCorpus(t)
+	got := dateSearchIDs(t, svc, model.SearchQuery{
+		Query: "x", K: 10,
+		HasTimeFrom: true, TimeFromMS: 0,
+		HasTimeTo: true, TimeToMS: 5000,
+	})
+	if len(got) != 1 || got[0] != 1 {
+		t.Fatalf("window [0s,5s] must be active and keep only the 0–10s hit (id 1), got %v", got)
+	}
+}
+
+// TestSearch_TimeWindow_NonTimeHitExcludedWhenActive pins §9.8: when either bound
+// is present, a hit with any non-time span never matches.
+func TestSearch_TimeWindow_NonTimeHitExcludedWhenActive(t *testing.T) {
+	svc := timeCorpus(t)
+	// A wide window covering every media span; the text hit (id 4) must still be
+	// excluded because it carries no time span.
+	got := dateSearchIDs(t, svc, model.SearchQuery{
+		Query: "x", K: 10,
+		HasTimeFrom: true, TimeFromMS: 0,
+		HasTimeTo: true, TimeToMS: 60000,
+	})
+	if hasID(got, 4) {
+		t.Fatalf("a non-time hit must never match an active time window, got %v", got)
+	}
+	if len(got) != 3 {
+		t.Fatalf("the wide window must keep all three media hits, got %v", got)
+	}
+}
+
+// TestSearch_TimeWindow_BothAbsentIsNoFilter pins §9.8: with both bounds absent
+// the filter is a no-op — every candidate is returned, including the non-time hit.
+func TestSearch_TimeWindow_BothAbsentIsNoFilter(t *testing.T) {
+	svc := timeCorpus(t)
+	got := dateSearchIDs(t, svc, model.SearchQuery{Query: "x", K: 10})
+	if len(got) != 4 {
+		t.Fatalf("no time window must return all four hits (non-time included), got %d: %v", len(got), got)
+	}
+}
+
+// TestSearch_TimeWindow_NoMatchIsEmptyNotError pins §9.8: a valid window matching
+// nothing returns an empty hit list, not an error.
+func TestSearch_TimeWindow_NoMatchIsEmptyNotError(t *testing.T) {
+	svc := timeCorpus(t)
+	hits, err := svc.Search(context.Background(), model.SearchQuery{
+		Query: "x", K: 10,
+		HasTimeFrom: true, TimeFromMS: 70000,
+		HasTimeTo: true, TimeToMS: 80000,
+	})
+	if err != nil {
+		t.Fatalf("a no-match time window must not error: %v", err)
+	}
+	if len(hits) != 0 {
+		t.Fatalf("a no-match time window must return an empty hit list, got %d", len(hits))
+	}
+}
+
+// TestSearch_TimeWindow_KCountsOnlyInWindow pins §9.8: the window is applied at
+// candidate selection, so k counts only in-window hits — id 1 has the highest
+// score but is out of the window, yet k=1 still surfaces the in-window id 2.
+func TestSearch_TimeWindow_KCountsOnlyInWindow(t *testing.T) {
+	svc := timeCorpus(t)
+	got := dateSearchIDs(t, svc, model.SearchQuery{
+		Query: "x", K: 1,
+		HasTimeFrom: true, TimeFromMS: 15000,
+		HasTimeTo: true, TimeToMS: 35000,
+	})
+	if len(got) != 1 || got[0] != 2 {
+		t.Fatalf("k=1 over the [15s,35s] window must return the in-window id 2, got %v", got)
+	}
+}


### PR DESCRIPTION
## Summary

Implements **SPEC §9.8** (merged in dirstral-spec#55): optional `time_from_ms` / `time_to_ms` arguments on `dir2mcp_search` and `dir2mcp_ask` that restrict hits to an **intra-document media time window**. This is the query-time control behind *"player X moments in the first half of a video"* — combine `time_to_ms` with a `path_prefix`/`file_glob` scope + the document's known duration.

Spec-first governance: the submodule is **re-pinned to post-#55 spec** (`744c88e`) in this PR.

## What changed
- **`model.SearchQuery`** — `HasTimeFrom`/`TimeFromMS`/`HasTimeTo`/`TimeToMS`. **Explicit presence flags**, not a zero sentinel: `0` is a valid lower bound (video start), so a zero-value `SearchQuery` from internal callers leaves the filter **off** (no silent behavior change).
- **`retrieval.matchFilters`** — new `withinTimeWindow` applied at candidate selection (right after the §9.6 date window), so `k` counts only in-window hits. When either bound is set, **only time-spanned hits are eligible** (mirrors the `speaker` filter); a hit is kept iff its span **overlaps** the inclusive window — overlap, not containment, so a boundary-straddling segment still surfaces.
- **`mcp/tools.go`** — `parseTimeWindow` (`>= 0`; inverted → `INVALID_FIELD`) folded with `parseDateWindow` into `parseTemporalFilters`; wired into the search + ask handlers and **both served input schemas**. `dir2mcp_related` is intentionally untouched (§9.8 is search/ask only).

Additive / off-by-default: absent bounds leave both sides open; existing callers observe no change. No new tool, error code, span kind, or output-schema change.

## Semantics (mirrors the §9.6 `date_from` family)
| | |
|---|---|
| Units | non-negative integer **ms** offsets within a document's timeline (§5.4) |
| Eligibility | only `time`-spanned hits when active — a corpus without transcripts/media/recognition returns none |
| Match | overlap, inclusive: `span.start ≤ time_to_ms ∧ span.end ≥ time_from_ms` |
| Errors | negative or `time_from_ms > time_to_ms` → `INVALID_FIELD`; no-match → empty, not error |
| Placement | candidate-selection, before de-dup/rerank/truncation |

## Tests
- **`tests/retrieval/time_window_filter_test.go`** — overlap-not-containment, open-lower/upper, **zero-is-a-valid-bound**, non-time-excluded-when-active, both-absent-is-no-filter, no-match-empty, k-counts-only-in-window.
- **`tests/mcp/search_time_window_test.go`** — passthrough with presence flags, **zero-lower-bound-present**, absent-is-no-filter, inverted → INVALID_FIELD, negative → INVALID_FIELD, ask forwarding.

Local: `go build ./...`, `gocyclo -over 15` (clean, via `parseTemporalFilters` extraction), conformance + affected suites all green.