### PR TITLE
fix(annotator): tag rostered batters' at-bats as at_bat, not pitch

### DIFF
--- a/annotator/dirstral_annotator/recognizers/playbyplay.py
+++ b/annotator/dirstral_annotator/recognizers/playbyplay.py
@@ -6,6 +6,13 @@ Given the game's `game_pk` and a wall-clock→video-time offset (estimated
 from anchors, see eval.align), every recorded pitch becomes a high-
 confidence cue on the video timeline.
 
+A pitch has two rostered-relevant roles: the pitcher *threw* it and the
+batter *faced* it. They are emitted as distinct events — `pitch` for the
+pitcher, `at_bat` for the batter — because the phase-1 metric is pitcher-
+keyed: a rostered batter appearing at an opponent's pitch is a real
+appearance, not a pitch by that player, and tagging it `pitch` would make
+every opponent-pitched at-bat a false positive.
+
 This recognizer doubles as the eval ground-truth source; the fetch/parse
 lives in eval.ground_truth so both uses share one implementation.
 """
@@ -45,21 +52,39 @@ class PlayByPlayRecognizer:
                 continue  # event predates the video entirely; nothing to cite
             pitcher = self.roster.by_mlbam(ev.pitcher_id)
             batter = self.roster.by_mlbam(ev.batter_id)
-            entities = tuple(p.id for p in (pitcher, batter) if p)
-            if not entities:
+            if pitcher is None and batter is None:
                 continue  # nobody on our roster is involved; skip, don't guess
             pitcher_name = pitcher.name if pitcher else ev.pitcher_name
             batter_name = batter.name if batter else ev.batter_name
             desc = f" — {ev.description}" if ev.description else ""
-            cues.append(
-                Cue(
-                    source=self.name,
-                    start_s=start,
-                    end_s=end,
-                    event="pitch",
-                    entity_ids=entities,
-                    confidence=CONFIDENCE,
-                    text=f"Pitch: {pitcher_name} to {batter_name}{desc}",
+            if pitcher is not None:
+                # A pitch thrown BY a rostered player — the event the phase-1
+                # metric scores (recall/precision are pitcher-keyed).
+                cues.append(
+                    Cue(
+                        source=self.name,
+                        start_s=start,
+                        end_s=end,
+                        event="pitch",
+                        entity_ids=(pitcher.id,),
+                        confidence=CONFIDENCE,
+                        text=f"Pitch: {pitcher_name} to {batter_name}{desc}",
+                    )
                 )
-            )
+            if batter is not None:
+                # A rostered player AT THE PLATE. They appear at this pitch but
+                # did not throw it, so it is an at-bat, not a pitch — tagging it
+                # "pitch" would count every opponent-pitched at-bat as a false
+                # positive under the pitcher-keyed precision metric.
+                cues.append(
+                    Cue(
+                        source=self.name,
+                        start_s=start,
+                        end_s=end,
+                        event="at_bat",
+                        entity_ids=(batter.id,),
+                        confidence=CONFIDENCE,
+                        text=f"At bat: {batter_name} vs {pitcher_name}{desc}",
+                    )
+                )
         return cues

--- a/annotator/tests/test_playbyplay.py
+++ b/annotator/tests/test_playbyplay.py
@@ -70,6 +70,7 @@ def test_our_pitcher_facing_our_batter_splits_into_two_events(roster):
     # intrasquad edge: both rostered -> one pitch (pitcher) + one at_bat (batter)
     ev = _pitch(1000.0, WEBB, RAMOS)
     cues = PlayByPlayRecognizer([ev], 0.0, roster).recognize(MEDIA)
+    assert len(cues) == 2  # exactly one pitch + one at_bat, no duplicates
     assert {(c.event, c.entity_ids) for c in cues} == {
         ("pitch", ("player:webb-logan",)),
         ("at_bat", ("player:ramos-heliot",)),

--- a/annotator/tests/test_playbyplay.py
+++ b/annotator/tests/test_playbyplay.py
@@ -1,0 +1,101 @@
+"""Play-by-play recognizer: role-aware event typing.
+
+A pitch involves two rostered-relevant roles. The pitcher *threw* it (a
+`pitch` event, which the pitcher-keyed phase-1 metric scores); the batter
+*faced* it (an `at_bat` appearance, which must NOT enter the pitch pool). The
+regression these tests lock down: a rostered batter facing an opponent's
+pitch used to be emitted as a `pitch` cue, turning every opponent-pitched
+at-bat into a precision false positive and flooring precision to ~50% even
+with a perfect metadata source.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from dirstral_annotator.eval.align import Anchor, estimate
+from dirstral_annotator.eval.ground_truth import PitchEvent
+from dirstral_annotator.eval.score import score
+from dirstral_annotator.fusion import fuse
+from dirstral_annotator.recognizers.playbyplay import PlayByPlayRecognizer
+from dirstral_annotator.roster import Roster
+
+MEDIA = Path("game.mp4")  # unused by the recognizer: labels are external
+
+# roster: one of our pitchers, one of our position players
+WEBB = 657277
+RAMOS = 671218
+OPP_PITCHER = 111111
+OPP_BATTER = 222222
+
+
+@pytest.fixture
+def roster(tmp_path):
+    path = tmp_path / "roster.json"
+    path.write_text(json.dumps([
+        {"id": "player:webb-logan", "name": "Logan Webb", "number": "62", "mlbam_id": WEBB},
+        {"id": "player:ramos-heliot", "name": "Heliot Ramos", "number": "17", "mlbam_id": RAMOS},
+    ]))
+    return Roster.load(path)
+
+
+def _pitch(epoch, pitcher, batter, pname="P", bname="B", desc="Ball"):
+    return PitchEvent(
+        game_pk=1, epoch_s=epoch, pitcher_id=pitcher, pitcher_name=pname,
+        batter_id=batter, batter_name=bname, inning=1, description=desc,
+    )
+
+
+def test_rostered_pitcher_emits_pitch(roster):
+    ev = _pitch(1000.0, WEBB, OPP_BATTER, pname="Logan Webb", bname="Opp Guy")
+    cues = PlayByPlayRecognizer([ev], 0.0, roster).recognize(MEDIA)
+    assert len(cues) == 1
+    assert cues[0].event == "pitch"
+    assert cues[0].entity_ids == ("player:webb-logan",)
+    assert "Logan Webb" in cues[0].text
+
+
+def test_rostered_batter_emits_at_bat_not_pitch(roster):
+    # opponent pitching to our batter -> at_bat, NEVER pitch
+    ev = _pitch(1000.0, OPP_PITCHER, RAMOS, pname="Opp Ace", bname="Heliot Ramos")
+    cues = PlayByPlayRecognizer([ev], 0.0, roster).recognize(MEDIA)
+    assert len(cues) == 1
+    assert cues[0].event == "at_bat"
+    assert cues[0].entity_ids == ("player:ramos-heliot",)
+    assert "Heliot Ramos" in cues[0].text
+
+
+def test_our_pitcher_facing_our_batter_splits_into_two_events(roster):
+    # intrasquad edge: both rostered -> one pitch (pitcher) + one at_bat (batter)
+    ev = _pitch(1000.0, WEBB, RAMOS)
+    cues = PlayByPlayRecognizer([ev], 0.0, roster).recognize(MEDIA)
+    assert {(c.event, c.entity_ids) for c in cues} == {
+        ("pitch", ("player:webb-logan",)),
+        ("at_bat", ("player:ramos-heliot",)),
+    }
+
+
+def test_no_rostered_participant_skipped(roster):
+    ev = _pitch(1000.0, OPP_PITCHER, OPP_BATTER)
+    assert PlayByPlayRecognizer([ev], 0.0, roster).recognize(MEDIA) == []
+
+
+def test_batter_appearance_is_not_a_precision_false_positive(roster):
+    # THE REGRESSION: a game that is half our-pitcher, half our-batter. The
+    # at-bats must not be scored as pitch false positives -> precision stays
+    # 1.0, not ~0.5.
+    events = [
+        _pitch(1000.0, WEBB, OPP_BATTER, pname="Logan Webb"),        # our pitch
+        _pitch(1100.0, OPP_PITCHER, RAMOS, bname="Heliot Ramos"),    # our at-bat
+        _pitch(1200.0, WEBB, OPP_BATTER, pname="Logan Webb"),        # our pitch
+        _pitch(1300.0, OPP_PITCHER, RAMOS, bname="Heliot Ramos"),    # our at-bat
+    ]
+    alignment = estimate([Anchor(events[0].epoch_s, 5.0)])
+    cues = PlayByPlayRecognizer(events, alignment.offset_s, roster).recognize(MEDIA)
+    anns = fuse(cues)
+    card = score(anns, events, alignment, roster)
+    # only Webb's two pitches are rostered-pitcher events
+    assert card.total_events == 2
+    assert card.overall.recall == 1.0
+    assert card.overall.precision == 1.0  # at-bats stay out of the pitch pool


### PR DESCRIPTION
Closes #620.

## Problem

The phase-1 eval metric (`eval/score.py`) is **pitcher-keyed**, but `recognizers/playbyplay.py` emitted an `event="pitch"` cue whenever **either** the pitcher **or** the batter was rostered. So every pitch a rostered *batter* faced from a non-rostered opponent pitcher became an unmatchable `pitch` annotation — a pure false positive.

Verified on the SF Giants pilot (game_pk 823195, 264 real GUMBO pitches), play-by-play recognizer alone:

| | before | after |
|---|---|---|
| recall | 100.0% | 100.0% |
| precision | **49.2%** | **100.0%** |
| exit code | 1 | 0 |

A perfect metadata source scoring ~50% precision would have been misread as recognizer failure on live footage.

## Fix

Split the two rostered-relevant roles into distinct events:

- pitcher rostered → `event="pitch"`, `entity_ids=(pitcher.id,)` — the scored event
- batter rostered → `event="at_bat"`, `entity_ids=(batter.id,)` — a real appearance, kept out of the pitch-precision pool

`at_bat` is already an anticipated `Cue.event` value; a batter at an opponent's pitch is a genuine appearance, not a pitch *by* that player. Different event + different entity means fusion keeps them as separate annotations.

## Tests

Adds `tests/test_playbyplay.py` covering the rostered-batter path the existing fixture never exercised (its only rostered player is a pitcher, so the FP was invisible). Includes the end-to-end regression: a half-our-pitcher / half-our-batter game must score precision 1.0, not ~0.5. Full annotator suite green (35 passed).

## Scope / governance

Annotator-local. The eval metric is defined only in the reference backend, not normatively in dirstral-spec, so no spec change is required. No behavior change for existing callers whose rostered players pitch (identical `pitch` cues); rostered batters now additionally surface as `at_bat` appearances.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected play-by-play event labeling for rostered pitchers and batters.
  * Batter appearances are now recorded as at-bat events instead of being incorrectly classified as pitches.
  * When both participants are rostered, separate pitch and at-bat events are generated.
  * Improved evaluation accuracy by preventing false-positive pitch events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->