### PR TITLE
fix(ingest): run recognition independently of the transcript path

### DIFF
--- a/internal/ingest/recognize.go
+++ b/internal/ingest/recognize.go
@@ -302,8 +302,19 @@ func recognitionSegments(anns []model.RecognizedAnnotation) ([]chunkSegment, str
 // document is not a video. A backend that returns zero annotations persists
 // nothing — an empty representation would only inflate coverage.
 func (s *Service) GenerateRecognitionRepresentation(ctx context.Context, doc model.Document) error {
+	_, err := s.generateRecognitionRepresentation(ctx, doc)
+	return err
+}
+
+// generateRecognitionRepresentation is GenerateRecognitionRepresentation plus
+// whether a recognition representation was actually persisted. The media
+// pipeline needs that signal because recognition is an independent
+// representation source (§5.2 `recognize`): a video whose only available source
+// is recognition must still count as searchable rather than being reported as
+// representation-less (#622).
+func (s *Service) generateRecognitionRepresentation(ctx context.Context, doc model.Document) (bool, error) {
 	if s.repGen == nil || s.recognizer == nil || doc.DocType != "video" {
-		return nil
+		return false, nil
 	}
 	absPath := filepath.Join(s.cfg.RootDir, filepath.FromSlash(doc.RelPath))
 	result, err := s.recognizer.Recognize(ctx, absPath)
@@ -311,12 +322,12 @@ func (s *Service) GenerateRecognitionRepresentation(ctx context.Context, doc mod
 		// Tag with the provider-failure sentinel so a transient recognize-backend
 		// failure classifies as RECOGNIZE_FAILED (manifestErrorCode), parallel to
 		// the STT/OCR provider sentinels — not the generic EXTRACT_FAILED.
-		return fmt.Errorf("%w: recognize %s: %w", ErrRecognitionProviderFailure, doc.RelPath, err)
+		return false, fmt.Errorf("%w: recognize %s: %w", ErrRecognitionProviderFailure, doc.RelPath, err)
 	}
 
 	segments, hashInput := recognitionSegments(result.Annotations)
 	if len(segments) == 0 {
-		return nil
+		return false, nil
 	}
 
 	meta, err := json.Marshal(recognitionMeta{
@@ -326,7 +337,7 @@ func (s *Service) GenerateRecognitionRepresentation(ctx context.Context, doc mod
 		ModelVersion: result.Version,
 	})
 	if err != nil {
-		return fmt.Errorf("marshal recognition meta: %w", err)
+		return false, fmt.Errorf("marshal recognition meta: %w", err)
 	}
 
 	rep := model.Representation{
@@ -345,8 +356,8 @@ func (s *Service) GenerateRecognitionRepresentation(ctx context.Context, doc mod
 		return s.repGen.upsertChunksForRepresentationWithStore(ctx, tx, repID, "text", segments, quarantineDecision{})
 	})
 	if err != nil {
-		return err
+		return false, err
 	}
 	s.addRepresentations(1)
-	return nil
+	return true, nil
 }

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -498,13 +498,15 @@ var errBinaryOnRawTextPath = errors.New(
 // errNoVideoRepresentation marks a video document that produced zero
 // representations: no subtitle sidecar (.vtt/.srt/.ttml) was found next to it, no
 // transcript was derived (speech-to-text is off/unconfigured, or the video has no
-// audio track to transcribe — issue #495), and multimodal keyframe embedding is
-// off. Such a video is known but unsearchable, so it is surfaced as a durable
-// non-fatal diagnostic instead of a silent no-op (#398).
+// audio track to transcribe — issue #495), multimodal keyframe embedding is off,
+// and recognition produced nothing either (recognize.provider=off, or the backend
+// returned no annotations — #622). Such a video is known but unsearchable, so it
+// is surfaced as a durable non-fatal diagnostic instead of a silent no-op (#398).
 var errNoVideoRepresentation = errors.New(
 	"video produced no representation: no subtitle sidecar found, no transcript was derived " +
-		"(speech-to-text is off/unconfigured or the video has no audio track), and multimodal keyframe embedding is off — " +
-		"configure a speech-to-text provider, enable embed_multimodal, or provide a .vtt/.srt sidecar to make it searchable")
+		"(speech-to-text is off/unconfigured or the video has no audio track), multimodal keyframe embedding is off, " +
+		"and no recognition annotations were produced — configure a speech-to-text provider, enable embed_multimodal, " +
+		"configure a recognition backend (recognize.provider), or provide a .vtt/.srt sidecar to make it searchable")
 
 // activeExtractionAvailability derives which extraction engines are active for
 // this run (§7.4.B "Extractor availability") from the resolved extractors. The
@@ -3385,18 +3387,51 @@ func (s *Service) generateRepresentations(ctx context.Context, doc model.Documen
 	// transcript when audio media chunks were produced (SPEC 8.1.7). `augment`
 	// and `off` keep the transcript path unchanged.
 	skipTranscript := s.embedMultimodal == "replace" && mediaProduced
-	if skipTranscript {
-		return false, nil
+
+	var noVideoRep bool
+	if !skipTranscript {
+		nonFatalErrored, noVideoRep, err = s.generateTranscriptOrSidecar(ctx, doc, content, secretPatterns, forceReindex, mediaProduced)
+		if nonFatalErrored || err != nil {
+			return nonFatalErrored, err
+		}
 	}
 
-	nonFatalErrored, err = s.generateTranscriptOrSidecar(ctx, doc, content, secretPatterns, forceReindex, mediaProduced)
-	if nonFatalErrored || err != nil {
-		return nonFatalErrored, err
+	return s.recognizeAndFinalizeMedia(ctx, doc, secretPatterns, noVideoRep)
+}
+
+// recognizeAndFinalizeMedia runs recognition over a media document and finalizes
+// the video no-representation verdict.
+//
+// Recognition (design 0004 §4) runs after transcript handling, but it is an
+// INDEPENDENT representation source (§5.2 `recognize`), not a step subordinate to
+// the transcript: it must run even when the transcript path produced nothing (STT
+// off, no sidecar, no audio track) and even when multimodal `replace` skipped the
+// transcript entirely — otherwise a video whose only available source is
+// recognition is never recognized at all (#622). A recognition-backend failure is
+// a hard per-document error exactly like an STT failure.
+//
+// `noVideoRep` is the provisional verdict from generateTranscriptOrSidecar; it
+// only becomes a durable status="error" diagnostic when recognition came up empty
+// too. Split out of generateRepresentations to keep that function within the
+// cyclomatic-complexity budget.
+func (s *Service) recognizeAndFinalizeMedia(ctx context.Context, doc model.Document, secretPatterns []*regexp.Regexp, noVideoRep bool) (bool, error) {
+	recognized, err := s.generateRecognitionRepresentation(ctx, doc)
+	if err != nil {
+		return false, err
 	}
-	// Recognition (design 0004) runs after the transcript: both are derived
-	// representations of the same media, and a recognition-backend failure is
-	// a hard per-document error exactly like an STT failure.
-	return false, s.GenerateRecognitionRepresentation(ctx, doc)
+	if noVideoRep && !recognized {
+		// Only now is the verdict final: no sidecar, no derived transcript, no
+		// multimodal keyframe chunks AND no recognition — the video is known but
+		// unsearchable, so record it as a durable status="error" diagnostic
+		// (#398/#495) while letting the run continue.
+		s.getLogger().Printf("no representation produced for video %s: %v", doc.RelPath, errNoVideoRepresentation)
+		s.addErrors(1)
+		s.persistNonFatalDocError(ctx, doc, errNoVideoRepresentation, secretPatterns)
+		// The document is now durably status="error" and counted; signal the caller
+		// not to also credit it as indexed (issue #426).
+		return true, nil
+	}
+	return false, nil
 }
 
 // htmlRoutesToStructured reports whether an html document should be promoted to
@@ -3468,21 +3503,24 @@ func (s *Service) generateHTMLStructured(ctx context.Context, doc model.Document
 // any stale sidecar transcripts and re-running STT. Sidecar ingestion bypasses
 // the quality gate (authored, not model-derived; §8.6.6/§8.6.7).
 //
-// It returns (nonFatalErrored, err) with the same contract as
-// generateRepresentations: nonFatalErrored is true when a soft-failure path
-// persisted the document as status="error" and counted it as an error itself, so
-// the caller must not also credit it as indexed (issue #426).
-func (s *Service) generateTranscriptOrSidecar(ctx context.Context, doc model.Document, content []byte, secretPatterns []*regexp.Regexp, forceReindex, mediaProduced bool) (bool, error) {
+// It returns (nonFatalErrored, noVideoRepresentation, err). nonFatalErrored is
+// true when a soft-failure path persisted the document as status="error" and
+// counted it as an error itself, so the caller must not also credit it as
+// indexed (issue #426). noVideoRepresentation is true when this video yielded
+// no transcript, no sidecar and no media chunks — a PROVISIONAL verdict the
+// caller finalizes only after recognition has had its chance, since recognition
+// is an independent representation source (#622).
+func (s *Service) generateTranscriptOrSidecar(ctx context.Context, doc model.Document, content []byte, secretPatterns []*regexp.Regexp, forceReindex, mediaProduced bool) (bool, bool, error) {
 	if !forceReindex {
 		ingested, err := s.ingestSidecarTranscripts(ctx, doc)
 		if err != nil {
-			return false, err
+			return false, false, err
 		}
 		if ingested {
-			return false, nil
+			return false, false, nil
 		}
 	} else if err := s.retireStaleSidecarTranscripts(ctx, doc); err != nil {
-		return false, err
+		return false, false, err
 	}
 
 	// Route audio AND video (issue #495) through the same STT transcript path when
@@ -3497,7 +3535,7 @@ func (s *Service) generateTranscriptOrSidecar(ctx context.Context, doc model.Doc
 		// emit degraded output. Handled in a helper so this function stays under the
 		// cyclomatic-complexity budget; see skipUncoveredLanguageTranscript.
 		if skip, suppressCredit := s.skipUncoveredLanguageTranscript(ctx, doc, mediaProduced); skip {
-			return suppressCredit, nil
+			return suppressCredit, false, nil
 		}
 		produced, err := s.generateTranscriptRepresentation(ctx, doc, content)
 		if err != nil {
@@ -3523,15 +3561,15 @@ func (s *Service) generateTranscriptOrSidecar(ctx context.Context, doc model.Doc
 					// above; signal the caller not to also credit it as indexed
 					// (issue #426). A doc that DID produce media chunks stays "ok"
 					// and searchable, so it is still credited (returns false).
-					return true, nil
+					return true, false, nil
 				}
-				return false, nil
+				return false, false, nil
 			}
-			return false, err
+			return false, false, err
 		}
 		if produced {
 			s.addRepresentations(1)
-			return false, nil
+			return false, false, nil
 		}
 		// produced == false: the transcript was empty (silence) or the video has no
 		// audio track to transcribe. Fall through so an otherwise unsearchable video
@@ -3539,18 +3577,15 @@ func (s *Service) generateTranscriptOrSidecar(ctx context.Context, doc model.Doc
 	}
 
 	// #398/#495: a video with no subtitle sidecar (handled above), no derived
-	// transcript, and no multimodal keyframe chunks yields zero representations —
-	// known but unsearchable. Record it as status="error" so it is durably visible
-	// (CorpusStats.Errors / RecentFailures) and retried once a sidecar is added,
-	// STT is configured, or embed_multimodal is enabled. The run still continues
-	// (returns nil), mirroring the #413 provider-failure path.
+	// transcript, and no multimodal keyframe chunks has produced nothing HERE.
+	// The verdict is only provisional though: recognition (#622) is an
+	// independent representation source that has not run yet, so report the
+	// condition upward and let the caller record the durable status="error"
+	// diagnostic if recognition comes up empty too.
 	if doc.DocType == "video" && !mediaProduced {
-		s.getLogger().Printf("no representation produced for video %s: %v", doc.RelPath, errNoVideoRepresentation)
-		s.addErrors(1)
-		s.persistNonFatalDocError(ctx, doc, errNoVideoRepresentation, secretPatterns)
-		return true, nil
+		return false, true, nil
 	}
-	return false, nil
+	return false, false, nil
 }
 
 // retireStaleSidecarTranscripts tombstones a media document's existing

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -3391,12 +3391,12 @@ func (s *Service) generateRepresentations(ctx context.Context, doc model.Documen
 	var noVideoRep bool
 	if !skipTranscript {
 		nonFatalErrored, noVideoRep, err = s.generateTranscriptOrSidecar(ctx, doc, content, secretPatterns, forceReindex, mediaProduced)
-		if nonFatalErrored || err != nil {
+		if err != nil {
 			return nonFatalErrored, err
 		}
 	}
 
-	return s.recognizeAndFinalizeMedia(ctx, doc, secretPatterns, noVideoRep)
+	return s.recognizeAndFinalizeMedia(ctx, doc, secretPatterns, noVideoRep, nonFatalErrored)
 }
 
 // recognizeAndFinalizeMedia runs recognition over a media document and finalizes
@@ -3414,10 +3414,19 @@ func (s *Service) generateRepresentations(ctx context.Context, doc model.Documen
 // only becomes a durable status="error" diagnostic when recognition came up empty
 // too. Split out of generateRepresentations to keep that function within the
 // cyclomatic-complexity budget.
-func (s *Service) recognizeAndFinalizeMedia(ctx context.Context, doc model.Document, secretPatterns []*regexp.Regexp, noVideoRep bool) (bool, error) {
+//
+// `transcriptSoftFailed` carries that function's own non-fatal outcome through
+// unchanged. The transcript path can soft-fail for reasons that leave the media
+// with no transcript but say nothing about recognition — an uncovered-language
+// skip, or an STT provider failure with no media chunks — and those are precisely
+// the cases where recognition is the only remaining source, so recognition still
+// runs. Its already-persisted status="error" and error count are preserved either
+// way, so the transcript is retried on the next incremental run even when
+// recognition indexed annotations in the meantime.
+func (s *Service) recognizeAndFinalizeMedia(ctx context.Context, doc model.Document, secretPatterns []*regexp.Regexp, noVideoRep, transcriptSoftFailed bool) (bool, error) {
 	recognized, err := s.generateRecognitionRepresentation(ctx, doc)
 	if err != nil {
-		return false, err
+		return transcriptSoftFailed, err
 	}
 	if noVideoRep && !recognized {
 		// Only now is the verdict final: no sidecar, no derived transcript, no
@@ -3431,7 +3440,7 @@ func (s *Service) recognizeAndFinalizeMedia(ctx context.Context, doc model.Docum
 		// not to also credit it as indexed (issue #426).
 		return true, nil
 	}
-	return false, nil
+	return transcriptSoftFailed, nil
 }
 
 // htmlRoutesToStructured reports whether an html document should be promoted to

--- a/tests/ingest/recognize_independent_source_622_test.go
+++ b/tests/ingest/recognize_independent_source_622_test.go
@@ -1,0 +1,133 @@
+package tests
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// Regression guard for #622: recognition is an INDEPENDENT representation source
+// (design 0004 §5.2 `recognize`), not a step subordinate to the transcript.
+//
+// Before the fix, generateRepresentations returned early as soon as the
+// transcript path reported a sidecar-less/STT-less video as representation-less,
+// so GenerateRecognitionRepresentation never ran: a configured recognition
+// backend was never called, nothing was persisted, and the video was recorded as
+// status="error" — even though recognition was the whole reason the operator
+// pointed dir2mcp at that corpus.
+
+// runVideoIngestWithRecognizer indexes a single sidecar-less .mp4 through the
+// FULL ingest pipeline (not GenerateRecognitionRepresentation directly) with a
+// recognizer bound, mirroring runArchiveIngest.
+func runVideoIngestWithRecognizer(t *testing.T, rec model.Recognizer) *store.SQLiteStore {
+	t.Helper()
+	ctx := context.Background()
+	root := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(root, "clip.mp4"), []byte("fake-video-bytes"), 0o600); err != nil {
+		t.Fatalf("write video: %v", err)
+	}
+
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("store init: %v", err)
+	}
+
+	cfg := config.Default()
+	cfg.RootDir = root
+	if rec != nil {
+		// The backend is a test double, but the provider must look configured so
+		// the persisted representation records an honest derivation identity.
+		// Left at the default `off` when no double is injected, so the service
+		// binds no recognizer at all.
+		cfg.RecognizeProvider = "serve"
+	}
+	svc := mustNewIngestService(t, cfg, st)
+	if rec != nil {
+		svc.SetRecognizer(rec)
+	}
+
+	if err := svc.Run(ctx); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	return st
+}
+
+// TestRecognition_RunsWhenTranscriptPathProducesNothing is the core #622 guard:
+// STT off + no sidecar + multimodal off, but a recognition backend IS configured.
+// Recognition must run, persist its representation, and the video must NOT be
+// reported as representation-less.
+func TestRecognition_RunsWhenTranscriptPathProducesNothing(t *testing.T) {
+	rec := &fakeRecognizer{result: recognizeTestResult()}
+	st := runVideoIngestWithRecognizer(t, rec)
+
+	if rec.calls != 1 {
+		t.Fatalf("recognition backend calls = %d, want 1 — recognition must run even when "+
+			"the transcript path produced nothing (#622)", rec.calls)
+	}
+
+	doc := documentByPath(t, st, "clip.mp4")
+	if doc.Status == "error" {
+		t.Errorf("status = %q with error_message %q; a video carrying recognition annotations "+
+			"IS searchable and must not be recorded as representation-less", doc.Status, doc.ErrorMessage)
+	}
+
+	repTypes, err := st.RepresentationTypesByPath(context.Background(), "clip.mp4")
+	if err != nil {
+		t.Fatalf("RepresentationTypesByPath: %v", err)
+	}
+	var found bool
+	for _, rt := range repTypes {
+		if rt == ingest.RepTypeRecognition {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("no %q representation persisted, got %v", ingest.RepTypeRecognition, repTypes)
+	}
+}
+
+// TestRecognition_NoBackend_StillReportsUnsearchableVideo pins the other side of
+// the fix: with NO recognizer bound, the pre-existing #398/#495 diagnostic must
+// still fire. The verdict was deferred, not removed.
+func TestRecognition_NoBackend_StillReportsUnsearchableVideo(t *testing.T) {
+	st := runVideoIngestWithRecognizer(t, nil)
+
+	doc := documentByPath(t, st, "clip.mp4")
+	if doc.Status != "error" {
+		t.Fatalf("status = %q, want \"error\": with no sidecar, no transcript, no multimodal "+
+			"and no recognition the video is genuinely unsearchable (#398/#495)", doc.Status)
+	}
+	if !strings.Contains(strings.ToLower(doc.ErrorMessage), "no representation") {
+		t.Errorf("error_message = %q, want it to explain the video produced no representation", doc.ErrorMessage)
+	}
+	// The remedy text must now mention recognition too, so an operator who has a
+	// backend available is told about it (#622).
+	if !strings.Contains(strings.ToLower(doc.ErrorMessage), "recogni") {
+		t.Errorf("error_message = %q, want it to offer a recognition backend as a remedy", doc.ErrorMessage)
+	}
+}
+
+// TestRecognition_EmptyAnnotations_StillReportsUnsearchableVideo covers the
+// backend-present-but-silent case: a recognizer that returns zero annotations
+// persists nothing, so the video really is unsearchable and must be reported.
+func TestRecognition_EmptyAnnotations_StillReportsUnsearchableVideo(t *testing.T) {
+	rec := &fakeRecognizer{result: model.RecognizeResult{Name: "dirstral-annotator", Version: "0.2.0"}}
+	st := runVideoIngestWithRecognizer(t, rec)
+
+	if rec.calls != 1 {
+		t.Fatalf("recognition backend calls = %d, want 1", rec.calls)
+	}
+	doc := documentByPath(t, st, "clip.mp4")
+	if doc.Status != "error" {
+		t.Fatalf("status = %q, want \"error\": a backend returning zero annotations persists "+
+			"nothing, so the video stays unsearchable", doc.Status)
+	}
+}

--- a/tests/ingest/recognize_independent_source_622_test.go
+++ b/tests/ingest/recognize_independent_source_622_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -112,6 +113,55 @@ func TestRecognition_NoBackend_StillReportsUnsearchableVideo(t *testing.T) {
 	// backend available is told about it (#622).
 	if !strings.Contains(strings.ToLower(doc.ErrorMessage), "recogni") {
 		t.Errorf("error_message = %q, want it to offer a recognition backend as a remedy", doc.ErrorMessage)
+	}
+}
+
+// TestRecognition_RunsWhenTranscriptProviderFails covers the review finding on
+// #623: generateTranscriptOrSidecar also soft-fails (nonFatalErrored=true, err=nil)
+// when STT is configured but the provider fails and no media chunks exist. That
+// leaves the document with no transcript — exactly when recognition is the only
+// remaining source — so recognition must still run, and the transcript failure's
+// own status="error" must be preserved so it is retried next run.
+func TestRecognition_RunsWhenTranscriptProviderFails(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "clip.mp4"), []byte("fake-video-bytes"), 0o600); err != nil {
+		t.Fatalf("write video: %v", err)
+	}
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("store init: %v", err)
+	}
+	cfg := config.Default()
+	cfg.RootDir = root
+	cfg.RecognizeProvider = "serve"
+	svc := mustNewIngestService(t, cfg, st)
+	// STT configured but failing, with no media chunks -> the transcript path
+	// soft-fails and previously short-circuited before recognition.
+	svc.SetTranscriber(&fakeTranscriber{err: errors.New("stt backend down")})
+	rec := &fakeRecognizer{result: recognizeTestResult()}
+	svc.SetRecognizer(rec)
+
+	if err := svc.Run(ctx); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if rec.calls != 1 {
+		t.Fatalf("recognition backend calls = %d, want 1 — a transcript provider failure "+
+			"must not skip recognition", rec.calls)
+	}
+	repTypes, err := st.RepresentationTypesByPath(ctx, "clip.mp4")
+	if err != nil {
+		t.Fatalf("RepresentationTypesByPath: %v", err)
+	}
+	var found bool
+	for _, rt := range repTypes {
+		if rt == ingest.RepTypeRecognition {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("no %q representation persisted, got %v", ingest.RepTypeRecognition, repTypes)
 	}
 }
 


### PR DESCRIPTION
Closes #622.

## Problem

Recognition is an independent representation source (design 0004 §5.2 `recognize`), but `generateRepresentations` treated it as a step subordinate to the transcript:

```go
nonFatalErrored, err = s.generateTranscriptOrSidecar(...)
if nonFatalErrored || err != nil {
    return nonFatalErrored, err          // <-- short-circuits
}
return false, s.GenerateRecognitionRepresentation(ctx, doc)
```

With STT off/unconfigured, no sidecar and multimodal off, the transcript path records `errNoVideoRepresentation` and returns `nonFatalErrored=true` — so recognition **never ran**. The configured backend was never called, nothing was persisted, and the video was recorded `status="error"`, even though recognition was the whole reason the operator pointed dir2mcp at that corpus. Multimodal `replace` skipped recognition for the same reason (it returned before the recognition call).

Found while running a real `dir2mcp up` against the reference Python backend; the backend's access log stayed empty and the diagnostic never mentioned recognition.

## Fix

Recognition always runs; the no-representation verdict is finalized only once every source has had its chance.

- `generateTranscriptOrSidecar` returns a **provisional** `noVideoRepresentation` flag instead of persisting the diagnostic itself.
- New `recognizeAndFinalizeMedia` runs recognition and records the durable #398/#495 `status="error"` diagnostic only when recognition also produced nothing. (Split out to keep `generateRepresentations` within the gocyclo budget — it hit 17 inline.)
- `generateRecognitionRepresentation` reports whether it persisted a representation; exported `GenerateRecognitionRepresentation` keeps its signature and delegates, so existing callers/tests are untouched.
- `errNoVideoRepresentation` now also names a recognition backend as a remedy.

## Verification

End-to-end against the reference backend (`recognize.provider=serve`), corpus = one `.mp4`, STT off, keyless Ollama embedder:

| | before | after |
|---|---|---|
| backend `/recognize` calls | 0 | 1 |
| `recognition` representations | 0 | 1 (`{"source":"recognize","provider":"serve","model":"dirstral-annotator","model_version":"0.2.0"}`) |
| recognition chunks | 0 | **264** |
| errors | 1 | **0** |

Chunks contain real queryable statements, e.g. `Pitch: Tyler Mahle to Christian Yelich — Called Strike`.

## Tests

`tests/ingest/recognize_independent_source_622_test.go` drives the **full ingest pipeline** (not the method directly):

1. recognition runs and persists when the transcript path produces nothing, and the video is no longer errored;
2. with **no** recognizer bound, the pre-existing #398/#495 diagnostic still fires — the verdict was deferred, not removed — and now offers recognition as a remedy;
3. a backend returning **zero** annotations still yields the unsearchable-video diagnostic.

Full `go test ./...` green; gocyclo ≤15; gofmt clean.

## Scope

`recognize.provider` defaults to `off`, so behaviour is unchanged for anyone who has not opted in. No spec delta: recognize's promotion to normative text is still deferred, and this restores the behaviour design 0004 §4/§6 already describes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Video recognition now runs even when transcript generation produces no results.
  * Videos are no longer incorrectly marked unsearchable when recognition provides usable results.
  * Improved handling and reporting for videos with no transcript, recognition backend, or recognition annotations.
  * Recognition provider failures are reported more accurately.

* **Tests**
  * Added coverage for recognition-only video ingestion and unsearchable video scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->