### PR TITLE
fix(config): resolve the recognize keys `config init` writes

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3078,6 +3078,19 @@ var configKeyAliases = map[string]string{
 	"media_batch_two_phase":                   "media.batch.two_phase",
 	"media_batch_progress":                    "media.batch.progress",
 	"media_batch_manifest":                    "media.batch.manifest",
+
+	// Recognition (design 0004). These underscore spellings are what the snapshot
+	// writer emits — and therefore what `dir2mcp config init` puts in the
+	// generated .dir2mcp.yaml — so they MUST resolve here or that generated file
+	// does not round-trip: the keys are dropped silently, recognition stays off
+	// with no error or warning, and because the provider never reaches the runtime
+	// config, validateRecognizeProvider never fires on an incomplete `serve`
+	// binding either (#624). Note recognize_serve_url maps to recognize.base_url —
+	// a rename, not a mechanical "_" -> "." substitution, which is why it was
+	// missed.
+	"recognize_provider":      "recognize.provider",
+	"recognize_serve_url":     "recognize.base_url",
+	"recognize_serve_command": "recognize.serve_command",
 }
 
 // canonicalizeConfigKey lower-cases and trims key and maps it through

--- a/tests/config/recognize_key_aliases_624_test.go
+++ b/tests/config/recognize_key_aliases_624_test.go
@@ -1,0 +1,79 @@
+package tests
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+)
+
+// Regression guard for #624: the snapshot writer emits the underscore spellings
+// (recognize_provider / recognize_serve_url / recognize_serve_command), and
+// `dir2mcp config init` uses that writer to generate the user-facing
+// .dir2mcp.yaml — but the file loader dispatches on the DOTTED keys. Without
+// legacy-key aliases those generated keys were dropped silently: recognition
+// stayed off with no error and no warning, and because the provider never
+// reached the runtime config, validateRecognizeProvider never fired on an
+// incomplete `serve` binding either.
+
+func TestLoadFile_RecognizeUnderscoreKeysRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".dir2mcp.yaml")
+	// Exactly the spellings `dir2mcp config init` writes.
+	writeFile(t, path, ""+
+		"recognize_provider: serve\n"+
+		"recognize_serve_url: http://127.0.0.1:8765\n"+
+		"recognize_serve_command: dirstral-annotate serve --port 8765\n")
+
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile failed: %v", err)
+	}
+	if cfg.RecognizeProvider != "serve" {
+		t.Errorf("RecognizeProvider=%q want %q — the generated config's recognize keys must round-trip (#624)",
+			cfg.RecognizeProvider, "serve")
+	}
+	if want := "http://127.0.0.1:8765"; cfg.RecognizeServeURL != want {
+		t.Errorf("RecognizeServeURL=%q want %q (recognize_serve_url maps to recognize.base_url)",
+			cfg.RecognizeServeURL, want)
+	}
+	if want := "dirstral-annotate serve --port 8765"; cfg.RecognizeServeCommand != want {
+		t.Errorf("RecognizeServeCommand=%q want %q", cfg.RecognizeServeCommand, want)
+	}
+}
+
+// TestLoadFile_RecognizeDottedKeysStillWork pins that adding the aliases did not
+// disturb the canonical dotted spellings.
+func TestLoadFile_RecognizeDottedKeysStillWork(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".dir2mcp.yaml")
+	writeFile(t, path, ""+
+		"recognize.provider: serve\n"+
+		"recognize.base_url: http://127.0.0.1:9001\n")
+
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile failed: %v", err)
+	}
+	if cfg.RecognizeProvider != "serve" || cfg.RecognizeServeURL != "http://127.0.0.1:9001" {
+		t.Errorf("dotted keys regressed: provider=%q url=%q",
+			cfg.RecognizeProvider, cfg.RecognizeServeURL)
+	}
+}
+
+// TestLoadFile_RecognizeUnderscoreServeWithoutURLIsInvalid is the sharpest
+// consequence of the bug: with the keys silently dropped, `serve` never reached
+// validation, so an incomplete binding started up as if recognition were simply
+// off. Now it must fail fast, exactly as the dotted form does.
+func TestLoadFile_RecognizeUnderscoreServeWithoutURLIsInvalid(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".dir2mcp.yaml")
+	writeFile(t, path, "recognize_provider: serve\n")
+
+	_, err := config.LoadFile(path)
+	if err == nil {
+		t.Fatal("expected CONFIG_INVALID for serve without a base_url, got nil " +
+			"(a silently-ignored recognize_provider hides the misconfiguration)")
+	}
+	if !strings.Contains(err.Error(), "CONFIG_INVALID") {
+		t.Errorf("error = %v, want a CONFIG_INVALID", err)
+	}
+}


### PR DESCRIPTION
Closes #624.

## Problem

`dir2mcp config init` generates a `.dir2mcp.yaml` containing the **underscore** spellings:

```yaml
recognize_provider: off
recognize_serve_url:
recognize_serve_command:
```

But the file loader dispatches on the **dotted** keys (`recognize.provider`, `recognize.base_url`, `recognize.serve_command`), and underscore spellings resolve only through the `configKeyAliases` table — which had no recognize entries.

An operator who enabled recognition by editing the generated file therefore got **silence**: keys dropped, recognition off, no error, no warning. And because the provider never reached the runtime config, `validateRecognizeProvider` never fired — so `recognize_provider: serve` with a blank serve URL started up as if recognition were simply off, instead of failing with the documented `CONFIG_INVALID`.

The generated config did not round-trip through its own loader.

## Evidence

Same binary and corpus, only the key spelling differs, `base_url` pointed at a dead port so a bound recognizer announces itself:

```
# underscore form (exactly as `config init` writes it) — BEFORE
-> no probe, no warning; recognizer never bound

# dotted form
-> warning: recognize backend http://127.0.0.1:9999 is not reachable yet:
   dial tcp 127.0.0.1:9999: connect: connection refused
```

After this fix, the underscore-only config produces the same `connection refused` probe — verified on a real host.

This was specific to recognize: `stt_provider` (underscore) already worked, which is what makes the inconsistency easy to trip over. It cost real debugging time during a live `recognize.provider=serve` bring-up.

## Fix

Add the three missing aliases:

```go
"recognize_provider":      "recognize.provider",
"recognize_serve_url":     "recognize.base_url",
"recognize_serve_command": "recognize.serve_command",
```

`recognize_serve_url` → `recognize.base_url` is a **rename**, not a mechanical `_`→`.` substitution, which is likely why it was missed.

Placed at the **end** of the map: an inline comment mid-map splits gofmt's alignment run and would have reformatted ~44 unrelated lines. This keeps the diff purely additive (+13).

## Tests

`tests/config/recognize_key_aliases_624_test.go`:

1. the underscore spellings `config init` writes round-trip into `RecognizeProvider` / `RecognizeServeURL` / `RecognizeServeCommand`;
2. the canonical dotted spellings still work (no regression);
3. `recognize_provider: serve` with no URL now fails `CONFIG_INVALID` — the sharpest consequence, since a silently-dropped key hid the misconfiguration entirely.

Full `go test ./...` green; gofmt and gocyclo clean.

## Follow-up worth considering (not in this PR)

Warn on unrecognized top-level config keys, so the next instance of this class fails loudly rather than silently.