### PR TITLE
feat(config): warn on unrecognized config keys and surface Config.Warnings

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -1088,6 +1088,24 @@ func writeCLIError(stderr io.Writer, jsonOutput bool, exitCode int, message stri
 	writeCLIErrorWithCode(stderr, jsonOutput, exitCode, exitCodeLabel(exitCode), message, hints...)
 }
 
+// emitConfigWarnings prints the non-fatal config-load diagnostics collected in
+// Config.Warnings to stderr.
+//
+// Nothing consumed that field before (#628): warnings about a deprecated
+// DIR2MCP_SESSION_TIMEOUT, an unparseable duration, or an unrecognized config
+// key were appended and then silently discarded, so an operator whose config was
+// partly ignored had no way to find out. Diagnostics go to stderr so they never
+// contaminate --json stdout, and --quiet suppresses them like other non-error
+// output.
+func (a *App) emitConfigWarnings(cfg config.Config, quiet bool) {
+	if quiet {
+		return
+	}
+	for _, w := range cfg.Warnings {
+		_, _ = fmt.Fprintf(a.stderr, "warning: %v\n", w)
+	}
+}
+
 // writeCLIErrorWithCode is writeCLIError with an explicit machine-readable
 // `code` for the JSON payload, decoupling the emitted error code from the
 // process exit code. It lets a failure keep its canonical §14 code (e.g. a bind

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -1444,6 +1444,7 @@ func (a *App) prepareUpConfig(opts upOptions) (config.Config, authMaterial, stri
 		writeCLIError(a.stderr, opts.jsonOutput, exitConfigInvalid, fmt.Sprintf("load config: %v", err))
 		return config.Config{}, authMaterial{}, "", "", false, exitConfigInvalid
 	}
+	a.emitConfigWarnings(cfg, opts.quiet)
 	tlsCertFile, tlsKeyFile, code := a.applyTLSConfig(&cfg, opts)
 	if code != exitSuccess {
 		return config.Config{}, authMaterial{}, "", "", false, code

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -1001,6 +1002,12 @@ func ParseSTTTracks(raw []string) (STTTrackSelection, error) {
 }
 
 type fileConfig struct {
+	// unknownKeys collects config-file keys that no setter claimed, so the
+	// loader can warn instead of discarding operator intent in silence (#628).
+	// Not a config value itself: it never participates in the overlay onto
+	// Config, only in the warning surfaced after load.
+	unknownKeys []string
+
 	RootDir         *string
 	StateDir        *string
 	ListenAddr      *string
@@ -2056,6 +2063,15 @@ func applyFileOverrides(cfg *Config, path string) error {
 		return fmt.Errorf("parse config file %s: %w", path, err)
 	}
 	applyParsedFileOverrides(cfg, fileCfg)
+	// Keys nobody claimed are operator intent that would otherwise be discarded
+	// without a word — a typo, a stale key from an older release, or a writer/
+	// loader spelling mismatch like #624. Warn rather than fail: an unknown key
+	// must not break an existing deployment (#628).
+	if len(fileCfg.unknownKeys) > 0 {
+		cfg.Warnings = append(cfg.Warnings, fmt.Errorf(
+			"config file %s: %d unrecognized key(s) ignored: %s",
+			path, len(fileCfg.unknownKeys), strings.Join(fileCfg.unknownKeys, ", ")))
+	}
 
 	// Decode the dynamic providers:/model: subtree with yaml.v3
 	// (SPEC 0.7.0 §16.2) — independent of the flat parser above.
@@ -2742,6 +2758,9 @@ func parseConfigYAML(raw []byte) (fileConfig, error) {
 	lineNo := 0
 	currentListKey := ""
 	sectionByIndent := map[int]string{}
+	// True while inside a top-level block decoded separately with yaml.v3, whose
+	// children must not be reported as unrecognized keys (#628).
+	inSideParsedBlock := false
 
 	for scanner.Scan() {
 		lineNo++
@@ -2770,6 +2789,11 @@ func parseConfigYAML(raw []byte) (fileConfig, error) {
 		if key == "" {
 			return fileConfig{}, fmt.Errorf("line %d: empty key", lineNo)
 		}
+		// A top-level key re-decides whether we are inside a side-parsed block;
+		// nested lines inherit the enclosing block's answer.
+		if indent == 0 {
+			inSideParsedBlock = sideParsedTopLevelBlocks[key]
+		}
 
 		if value == "" {
 			newListKey, err := handleYAMLEmptyValue(&cfg, key, sectionByIndent, indent)
@@ -2787,7 +2811,7 @@ func parseConfigYAML(raw []byte) (fileConfig, error) {
 			continue
 		}
 
-		if err := handleYAMLScalarValue(&cfg, key, value); err != nil {
+		if err := handleYAMLScalarValue(&cfg, key, value, !inSideParsedBlock); err != nil {
 			return fileConfig{}, fmt.Errorf("line %d: %w", lineNo, err)
 		}
 	}
@@ -2803,7 +2827,9 @@ func parseConfigYAML(raw []byte) (fileConfig, error) {
 // scalar field, so it is routed to the list appender — otherwise the keyword forms
 // (`first`/`all`) of media.stt.tracks would be silently dropped by the scalar path,
 // which has no such field.
-func handleYAMLScalarValue(cfg *fileConfig, key, value string) error {
+// `collectUnknown` is false while the parser is inside a side-parsed top-level
+// block, whose children legitimately never reach a scalar setter (#628).
+func handleYAMLScalarValue(cfg *fileConfig, key, value string, collectUnknown bool) error {
 	value = unquoteYAMLScalar(value)
 	if strings.Contains(value, "\\n") {
 		value = strings.ReplaceAll(value, "\\n", "\n")
@@ -2812,7 +2838,58 @@ func handleYAMLScalarValue(cfg *fileConfig, key, value string) error {
 		setFileListValue(cfg, key, value)
 		return nil
 	}
-	return setFileScalarValue(cfg, key, value)
+	if err := setFileScalarValue(cfg, key, value); err != nil {
+		return err
+	}
+	if collectUnknown && !scalarKeyIsRecognized(key, value) {
+		cfg.unknownKeys = append(cfg.unknownKeys, key)
+	}
+	return nil
+}
+
+// sideParsedTopLevelBlocks are the top-level config blocks decoded separately
+// with yaml.v3 rather than by the flat parser: the provider/model bindings (SPEC
+// §16.2), the cost.prices overrides (#327) and the carbon block (#328). The flat
+// parser still walks their lines, and because they are not registered map
+// sections their children arrive UNPREFIXED (`kind`, `base_url`, `provider`, …),
+// so they must be exempted by enclosing block rather than by key prefix.
+// Otherwise every valid config carrying a providers: block would warn — a false
+// positive far worse than the silence this warning replaces (#628).
+var sideParsedTopLevelBlocks = map[string]bool{
+	"providers": true,
+	"model":     true,
+	"cost":      true,
+	"carbon":    true,
+}
+
+// sideParsedKeyPrefixes are the nested maps decoded separately that DO arrive
+// prefixed, because they sit under the registered `media` section (#574, #566).
+var sideParsedKeyPrefixes = []string{
+	"media.translate.glossary.",
+	"media.stt.language_providers.",
+}
+
+// scalarKeyIsRecognized reports whether any setter claims key.
+//
+// Detection is by EFFECT rather than by enumerating every known key: the string
+// keys live in switch chains that cannot be enumerated at runtime, and a
+// hand-maintained list would drift out of step exactly like the alias table did
+// in #624. Every fileConfig field is a pointer, so applying the key to a fresh
+// fileConfig and finding it unchanged proves nothing assigned it.
+func scalarKeyIsRecognized(key, value string) bool {
+	for _, prefix := range sideParsedKeyPrefixes {
+		if strings.HasPrefix(key, prefix) {
+			return true
+		}
+	}
+	var probe fileConfig
+	if err := setFileScalarValue(&probe, key, value); err != nil {
+		// A parse/validation error means a setter DID claim the key; the caller
+		// surfaces the error itself.
+		return true
+	}
+	probe.unknownKeys = nil
+	return !reflect.DeepEqual(probe, fileConfig{})
 }
 
 // resolveYAMLKey splits a "key: value" line, prefixes the key with the

--- a/tests/cli/config_warnings_628_test.go
+++ b/tests/cli/config_warnings_628_test.go
@@ -1,0 +1,95 @@
+package tests
+
+// #628 part 2: Config.Warnings was appended to but never read by any production
+// code path, so non-fatal config diagnostics — a deprecated env var, an
+// unparseable duration, and now an unrecognized config key — were collected and
+// then silently discarded. `up` now prints them to stderr before the startup
+// preflights, so an operator whose config was partly ignored is told.
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/cli"
+)
+
+func writeConfigWithUnknownKeys(t *testing.T, dir string) {
+	t.Helper()
+	body := "" +
+		"root_dir: .\n" +
+		"stt_provider: off\n" +
+		"recognise_provider: serve\n" + // misspelling
+		"some_stale_key: 1\n" // stale key from an older release
+	if err := os.WriteFile(filepath.Join(dir, ".dir2mcp.yaml"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}
+
+// The warning must reach stderr even though `up` later fails its embed preflight:
+// the point is that config problems surface, not that startup succeeds.
+func TestUp_WarnsAboutUnrecognizedConfigKeys(t *testing.T) {
+	tmp := t.TempDir()
+	clearProviderEnv(t)
+	writeConfigWithUnknownKeys(t, tmp)
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIOAndHooks(&stdout, &stderr, cli.RuntimeHooks{})
+	withWorkingDir(t, tmp, func() {
+		_ = app.RunWithContext(context.Background(),
+			[]string{"up", "--non-interactive", "--foreground", "--listen", "127.0.0.1:0"})
+	})
+
+	got := stderr.String()
+	if !strings.Contains(got, "warning:") {
+		t.Fatalf("stderr carries no warning; config problems are still silent.\nstderr: %s", got)
+	}
+	for _, want := range []string{"unrecognized", "recognise_provider", "some_stale_key"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("stderr missing %q\nstderr: %s", want, got)
+		}
+	}
+}
+
+// --quiet suppresses non-error output, warnings included.
+func TestUp_QuietSuppressesConfigWarnings(t *testing.T) {
+	tmp := t.TempDir()
+	clearProviderEnv(t)
+	writeConfigWithUnknownKeys(t, tmp)
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIOAndHooks(&stdout, &stderr, cli.RuntimeHooks{})
+	withWorkingDir(t, tmp, func() {
+		_ = app.RunWithContext(context.Background(),
+			[]string{"up", "--quiet", "--non-interactive", "--foreground", "--listen", "127.0.0.1:0"})
+	})
+
+	if strings.Contains(stderr.String(), "unrecognized") {
+		t.Errorf("--quiet must suppress config warnings; stderr: %s", stderr.String())
+	}
+}
+
+// A valid config must stay silent — a false-positive warning on good config
+// would be worse than the silence this replaces.
+func TestUp_ValidConfigEmitsNoUnrecognizedKeyWarning(t *testing.T) {
+	tmp := t.TempDir()
+	clearProviderEnv(t)
+	body := "root_dir: .\nstt_provider: off\nrag_k_default: 7\n"
+	if err := os.WriteFile(filepath.Join(tmp, ".dir2mcp.yaml"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIOAndHooks(&stdout, &stderr, cli.RuntimeHooks{})
+	withWorkingDir(t, tmp, func() {
+		_ = app.RunWithContext(context.Background(),
+			[]string{"up", "--non-interactive", "--foreground", "--listen", "127.0.0.1:0"})
+	})
+
+	if strings.Contains(stderr.String(), "unrecognized") {
+		t.Errorf("valid config must not warn; stderr: %s", stderr.String())
+	}
+}

--- a/tests/config/generated_config_roundtrip_test.go
+++ b/tests/config/generated_config_roundtrip_test.go
@@ -87,6 +87,11 @@ func TestGeneratedConfig_EveryWrittenKeyIsReadable(t *testing.T) {
 				t.Fatalf("write mutated config: %v", err)
 			}
 			got, loadErr := config.LoadFile(p)
+			// Warnings must not participate in the comparison: since #628 an
+			// IGNORED key adds an "unrecognized key(s)" warning, which would make
+			// the Config differ and be misread here as proof the key was read —
+			// inverting this guard's meaning. Compare config VALUES only.
+			got.Warnings, base.Warnings = nil, nil
 			// A validation failure also proves the value reached the loader.
 			if loadErr != nil || !reflect.DeepEqual(got, base) {
 				read = true

--- a/tests/config/unrecognized_keys_628_test.go
+++ b/tests/config/unrecognized_keys_628_test.go
@@ -11,6 +11,8 @@ package tests
 // config would be worse than the silence it replaces.
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -67,11 +69,17 @@ func TestGeneratedConfig_ProducesNoWarnings(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read generated: %v", err)
 	}
+	// The base_url is served by an httptest server rather than hard-coded, per the
+	// repo guideline against embedding provider base URLs. Nothing in this test
+	// dials it: LoadFile only parses, so the server exists to supply a real URL.
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	defer srv.Close()
+
 	enriched := string(generated) + "" +
 		"providers:\n" +
 		"  ollama:\n" +
 		"    kind: openai\n" +
-		"    base_url: http://localhost:11434/v1\n" +
+		"    base_url: " + srv.URL + "/v1\n" +
 		"    embed_text_model: bge-m3:latest\n" +
 		"    chat_model: qwen2.5:7b-instruct\n" +
 		"model:\n" +

--- a/tests/config/unrecognized_keys_628_test.go
+++ b/tests/config/unrecognized_keys_628_test.go
@@ -1,0 +1,123 @@
+package tests
+
+// #628: a config key no setter claims used to be discarded in total silence.
+// That is how #624 hurt — `.dir2mcp.yaml` said `recognize_provider: serve` (put
+// there by `dir2mcp config init`), the loader did not recognise that spelling,
+// and recognition stayed off with no error and no warning. Typos, stale keys
+// from older releases and wrong nesting depth were all swallowed the same way.
+//
+// The loader now records one warning naming the ignored keys. The most important
+// property under test is the absence of FALSE POSITIVES: a warning on valid
+// config would be worse than the silence it replaces.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/provider"
+)
+
+func warningsText(cfg config.Config) string {
+	var b strings.Builder
+	for _, w := range cfg.Warnings {
+		b.WriteString(w.Error())
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func TestUnrecognizedKey_Warns(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".dir2mcp.yaml")
+	writeFile(t, path, ""+
+		"root_dir: ./repo\n"+
+		"recognise_provider: serve\n"+ // misspelling of a real key
+		"stt.provdier: off\n") // transposed characters
+
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile must not fail on unknown keys (warn, don't break deployments): %v", err)
+	}
+	got := warningsText(cfg)
+	for _, want := range []string{"recognise_provider", "stt.provdier", "unrecognized"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("warnings %q missing %q", got, want)
+		}
+	}
+	// The valid key on the same file must still be applied.
+	if cfg.RootDir != "./repo" {
+		t.Errorf("RootDir=%q; a bad neighbouring key must not discard a good one", cfg.RootDir)
+	}
+}
+
+// TestGeneratedConfig_ProducesNoWarnings is the false-positive guard that matters
+// most: everything `config init` writes, plus the separately-parsed
+// providers:/model:/carbon:/cost: blocks, must load silently. The flat parser
+// still walks those blocks' lines, so without the side-parsed exemption every
+// valid config would warn about them.
+func TestGeneratedConfig_ProducesNoWarnings(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".dir2mcp.yaml")
+	if err := config.SaveFile(path, config.Default()); err != nil {
+		t.Fatalf("SaveFile: %v", err)
+	}
+	generated, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read generated: %v", err)
+	}
+	enriched := string(generated) + "" +
+		"providers:\n" +
+		"  ollama:\n" +
+		"    kind: openai\n" +
+		"    base_url: http://localhost:11434/v1\n" +
+		"    embed_text_model: bge-m3:latest\n" +
+		"    chat_model: qwen2.5:7b-instruct\n" +
+		"model:\n" +
+		"  embed:\n" +
+		"    provider: ollama\n" +
+		"  chat:\n" +
+		"    provider: ollama\n" +
+		"carbon:\n" +
+		"  enabled: true\n" +
+		"cost:\n" +
+		"  prices:\n" +
+		"    mistral-embed:\n" +
+		"      input_per_1k: 0.01\n" +
+		"      output_per_1k: 0.02\n"
+	if err := os.WriteFile(path, []byte(enriched), 0o600); err != nil {
+		t.Fatalf("write enriched: %v", err)
+	}
+
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if got := warningsText(cfg); got != "" {
+		t.Errorf("a valid config must load silently, got warnings:\n%s", got)
+	}
+	// Sanity: the enriched blocks really were applied, so the silence above is
+	// not the silence of a config that failed to parse at all.
+	if _, err := cfg.Providers().Resolve(provider.CapEmbed); err != nil {
+		t.Errorf("providers/model block did not load: %v", err)
+	}
+}
+
+// TestRecognizeUnderscoreKeys_ProduceNoWarnings pins the #624 keys specifically:
+// they are legitimate now, so they must not be reported as unrecognized.
+func TestRecognizeUnderscoreKeys_ProduceNoWarnings(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".dir2mcp.yaml")
+	writeFile(t, path, ""+
+		"recognize_provider: serve\n"+
+		"recognize_serve_url: http://127.0.0.1:8765\n"+
+		"recognize_serve_command: dirstral-annotate serve\n")
+
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if got := warningsText(cfg); got != "" {
+		t.Errorf("the #624 recognize keys are valid and must not warn, got:\n%s", got)
+	}
+}


### PR DESCRIPTION
Closes #628. Follow-up to #624/#626 — the operator-facing half of that failure mode.

## Two halves of the same silence

**1. Unrecognized keys were dropped without a word.** The flat parser's setter chain ends in a `default:` no-op, so a key nobody claims is discarded silently. That is how #624 hurt: `.dir2mcp.yaml` said `recognize_provider: serve` (put there by `dir2mcp config init`), the loader did not recognise that spelling, and recognition stayed off with no error and no warning. Ordinary mistakes — a typo, a stale key from an older release, wrong nesting depth — were swallowed identically.

**2. `Config.Warnings` had no readers.** Documented as *"callers can inspect and log these as desired"*, it has four append sites and **zero production readers** (only tests read it). So warnings about a deprecated `DIR2MCP_SESSION_TIMEOUT`, an unparseable duration, an invalid boolean, and a failed config snapshot were already being collected and thrown away.

Either half alone is useless: detecting unknown keys into a channel nobody reads changes nothing, and surfacing a channel nothing meaningful writes to helps little.

## Approach

**Detection by effect, not by enumeration.** The string keys live in switch chains that cannot be enumerated at runtime, and a hand-maintained known-key list would drift out of step *exactly like the alias table did in #624*. Instead: every `fileConfig` field is a pointer, so applying a key to a fresh `fileConfig` and finding it unchanged proves nothing claimed it. (A parse error means a setter *did* claim it — the caller surfaces that error itself.)

**False positives were the real risk** — a warning on valid config would be worse than the silence it replaces. `providers:` / `model:` / `cost:` / `carbon:` are decoded separately with yaml.v3, and because they are not registered map sections their children arrive **unprefixed** (`kind`, `base_url`, `provider`), so they are exempted by *enclosing block*, tracked via indentation. The nested `media.translate.glossary` / `media.stt.language_providers` maps *do* arrive prefixed and are exempted that way.

I got this wrong on the first cut — the prefix check never matched `kind`/`base_url` — and the false-positive test caught it before it went anywhere. Worth noting since that test is the reason the design ended up correct.

**Warn, don't fail:** an unknown key must not break an existing deployment. Warnings go to stderr so they never contaminate `--json` stdout, and `--quiet` suppresses them like other non-error output.

## What an operator now sees

```
warning: config file .dir2mcp.yaml: 2 unrecognized key(s) ignored: recognise_provider, some_stale_key
```

## Tests

`tests/config/unrecognized_keys_628_test.go`
- a typo'd and a transposed key both warn, and a valid neighbouring key is still applied;
- **the false-positive guard**: everything `config init` writes *plus* populated `providers:`/`model:`/`carbon:`/`cost:` blocks loads completely silently (with a sanity assert that the blocks really did load, so the silence is not that of a config which failed to parse);
- the #624 `recognize_*` underscore keys are legitimate and must not warn.

`tests/cli/config_warnings_628_test.go` — drives the real CLI through `NewAppWithIOAndHooks`:
- `up` prints the warning to stderr (before the embed preflight fails — the point is that config problems surface, not that startup succeeds);
- `--quiet` suppresses it;
- a valid config produces no warning.

Full `go test ./...` green, including `tests/security` (CLI boundary); gofmt and gocyclo clean.

## Scope note

The emitter is wired into `prepareUpConfig`, i.e. the `up`/daemon path where config correctness matters most and where #624 actually bit. Other subcommands load config through the same `loadConfigWithGlobalOptions` but each would need its own emit call; happy to extend coverage in this PR or a follow-up if you'd prefer it everywhere.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added warnings for unrecognized configuration keys, including the affected file and ignored keys.
  * Configuration warnings appear during `up` startup before preflight checks.
  * Use `--quiet` to suppress configuration warning messages.

* **Bug Fixes**
  * Valid settings continue loading when unknown or misspelled keys are present.
  * Prevented false warnings for supported nested sections and generated configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->