### PR TITLE
fix(cli): surface INDEX_VERSION_MISMATCH as the canonical code, not GENERIC_ERROR (#422 V6)

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -1111,6 +1111,30 @@ func (a *App) emitConfigWarnings(cfg config.Config, quiet bool) {
 // process exit code. It lets a failure keep its canonical §14 code (e.g. a bind
 // failure carries exit code exitServerBindFailure but code "BIND_FAILED") rather
 // than the coarser exit-code label. The plain-text path is unaffected.
+// writeStoreInitError reports a metadata-store Init failure, preserving any
+// canonical §14 code the store attached to the error.
+//
+// Every Init call site funnelled failures through writeCLIError, which stamps
+// the JSON `code` field from the exit code (GENERIC_ERROR). An index-format
+// mismatch therefore reached machine consumers as GENERIC_ERROR even though the
+// store raises a typed *store.IndexVersionMismatchError whose Code() is
+// INDEX_VERSION_MISMATCH; the canonical code survived only as a prefix inside
+// the human-readable message, which is the "CLI prose only" gap of #422 V6.
+// BIND_FAILED and TLS_CONFIG_INVALID are wired through writeCLIErrorWithCode
+// for exactly this reason — the store path just has many more call sites, so it
+// gets one helper rather than eleven copies of the same errors.As.
+func writeStoreInitError(stderr io.Writer, jsonOutput bool, exitCode int, err error, message string) {
+	var mismatch *store.IndexVersionMismatchError
+	if errors.As(err, &mismatch) {
+		// The remedy is already in mismatch.Error() ("reindex the corpus"), so the
+		// hint names the command rather than restating the diagnosis.
+		writeCLIErrorWithCode(stderr, jsonOutput, exitCode, mismatch.Code(), message,
+			"run `dir2mcp reindex --force` with a compatible binary, or point --state-dir at a fresh directory")
+		return
+	}
+	writeCLIError(stderr, jsonOutput, exitCode, message)
+}
+
 func writeCLIErrorWithCode(stderr io.Writer, jsonOutput bool, exitCode int, code, message string, hints ...string) {
 	if jsonOutput {
 		filteredHints := make([]string, 0, len(hints))

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -1129,7 +1129,7 @@ func writeStoreInitError(stderr io.Writer, jsonOutput bool, exitCode int, err er
 		// The remedy is already in mismatch.Error() ("reindex the corpus"), so the
 		// hint names the command rather than restating the diagnosis.
 		writeCLIErrorWithCode(stderr, jsonOutput, exitCode, mismatch.Code(), message,
-			"run `dir2mcp reindex --force` with a compatible binary, or point --state-dir at a fresh directory")
+			"run `dir2mcp reindex` with a compatible binary, or point --state-dir at a fresh directory")
 		return
 	}
 	writeCLIError(stderr, jsonOutput, exitCode, message)

--- a/internal/cli/ask.go
+++ b/internal/cli/ask.go
@@ -73,7 +73,7 @@ func (a *App) runAskLocal(ctx context.Context, global globalOptions, opts askOpt
 	st := a.storeForConfig(cfg)
 	defer func() { _ = st.Close() }()
 	if err := st.Init(ctx); err != nil && !errors.Is(err, model.ErrNotImplemented) {
-		writeCLIError(a.stderr, global.jsonOutput, exitIndexLoadFailure, fmt.Sprintf("initialize metadata store: %v", err))
+		writeStoreInitError(a.stderr, global.jsonOutput, exitIndexLoadFailure, err, fmt.Sprintf("initialize metadata store: %v", err))
 		return exitIndexLoadFailure
 	}
 

--- a/internal/cli/error_codes_test.go
+++ b/internal/cli/error_codes_test.go
@@ -3,12 +3,15 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net"
 	"path/filepath"
 	"testing"
 
 	"github.com/dirstral/dir2mcp/internal/config"
 	"github.com/dirstral/dir2mcp/internal/protocol"
+	"github.com/dirstral/dir2mcp/internal/store"
 )
 
 // decodeCLIErrorCode extracts the machine-readable `code` from a JSON CLI error
@@ -75,5 +78,57 @@ func TestApplyTLSConfig_EmitsTLSConfigInvalid(t *testing.T) {
 	}
 	if got := decodeCLIErrorCode(t, stderr.Bytes()); got != protocol.ErrorCodeTLSConfigInvalid {
 		t.Fatalf("error code = %q, want %q (body=%s)", got, protocol.ErrorCodeTLSConfigInvalid, stderr.String())
+	}
+}
+
+// TestWriteStoreInitError_EmitsIndexVersionMismatch proves an index-format
+// mismatch reaches machine consumers as the canonical §14.3
+// INDEX_VERSION_MISMATCH code rather than the coarse exit-code label.
+//
+// This is the gap #422 V6 called "CLI prose only": the store already raised a
+// typed *store.IndexVersionMismatchError whose Code() was correct, but every
+// Init call site funnelled it through writeCLIError, which derives the JSON
+// `code` from the exit code. The canonical code survived only as a prefix
+// inside the human-readable message, so a machine consumer saw GENERIC_ERROR.
+// The pre-existing test asserted Code() on the raw Go error and never crossed
+// the CLI boundary, which is why the gap went undetected.
+func TestWriteStoreInitError_EmitsIndexVersionMismatch(t *testing.T) {
+	mismatch := &store.IndexVersionMismatchError{Persisted: "1", Expected: "2"}
+
+	var stderr bytes.Buffer
+	writeStoreInitError(&stderr, true, exitIndexLoadFailure, mismatch,
+		fmt.Sprintf("initialize metadata store: %v", mismatch))
+
+	if got := decodeCLIErrorCode(t, stderr.Bytes()); got != protocol.ErrorCodeIndexVersionMismatch {
+		t.Errorf("code = %q, want %q\npayload: %s",
+			got, protocol.ErrorCodeIndexVersionMismatch, stderr.String())
+	}
+}
+
+// TestWriteStoreInitError_WrappedMismatchStillDetected covers the realistic
+// path: a store implementation that wraps the sentinel before returning it.
+// errors.As must still find it, or the fix only works for the one backend that
+// happens to return the error bare.
+func TestWriteStoreInitError_WrappedMismatchStillDetected(t *testing.T) {
+	wrapped := fmt.Errorf("open corpus: %w",
+		&store.IndexVersionMismatchError{Persisted: "1", Expected: "2"})
+
+	var stderr bytes.Buffer
+	writeStoreInitError(&stderr, true, exitIndexLoadFailure, wrapped, "initialize metadata store")
+
+	if got := decodeCLIErrorCode(t, stderr.Bytes()); got != protocol.ErrorCodeIndexVersionMismatch {
+		t.Errorf("wrapped mismatch: code = %q, want %q", got, protocol.ErrorCodeIndexVersionMismatch)
+	}
+}
+
+// TestWriteStoreInitError_UnrelatedErrorKeepsGenericCode is the false-positive
+// guard: an ordinary Init failure must NOT be relabelled as a version mismatch.
+func TestWriteStoreInitError_UnrelatedErrorKeepsGenericCode(t *testing.T) {
+	var stderr bytes.Buffer
+	writeStoreInitError(&stderr, true, exitIndexLoadFailure,
+		errors.New("disk full"), "initialize metadata store: disk full")
+
+	if got := decodeCLIErrorCode(t, stderr.Bytes()); got == protocol.ErrorCodeIndexVersionMismatch {
+		t.Errorf("unrelated error was mislabelled %q", got)
 	}
 }

--- a/internal/cli/error_codes_test.go
+++ b/internal/cli/error_codes_test.go
@@ -128,7 +128,12 @@ func TestWriteStoreInitError_UnrelatedErrorKeepsGenericCode(t *testing.T) {
 	writeStoreInitError(&stderr, true, exitIndexLoadFailure,
 		errors.New("disk full"), "initialize metadata store: disk full")
 
-	if got := decodeCLIErrorCode(t, stderr.Bytes()); got == protocol.ErrorCodeIndexVersionMismatch {
-		t.Errorf("unrelated error was mislabelled %q", got)
+	// Assert the exact expected label, not merely "not the mismatch code": a
+	// weaker check would pass if the helper started emitting some third, equally
+	// wrong code. exitIndexLoadFailure has no dedicated label, so exitCodeLabel
+	// maps it to GENERIC_ERROR, which is exactly the pre-fix behaviour that must
+	// survive for errors this helper does not classify.
+	if got, want := decodeCLIErrorCode(t, stderr.Bytes()), exitCodeLabel(exitIndexLoadFailure); got != want {
+		t.Errorf("unrelated error: code = %q, want %q", got, want)
 	}
 }

--- a/internal/cli/export.go
+++ b/internal/cli/export.go
@@ -60,7 +60,7 @@ func (a *App) runExport(ctx context.Context, global globalOptions, args []string
 	st := a.storeForConfig(cfg)
 	defer a.closeStoreWithLog(st)
 	if initErr := st.Init(ctx); initErr != nil && !errors.Is(initErr, model.ErrNotImplemented) {
-		writeCLIError(a.stderr, global.jsonOutput, exitIndexLoadFailure, fmt.Sprintf("initialize metadata store: %v", initErr))
+		writeStoreInitError(a.stderr, global.jsonOutput, exitIndexLoadFailure, initErr, fmt.Sprintf("initialize metadata store: %v", initErr))
 		return exitIndexLoadFailure
 	}
 

--- a/internal/cli/reindex.go
+++ b/internal/cli/reindex.go
@@ -267,7 +267,7 @@ func (a *App) prepareReindexStore(ctx context.Context, global globalOptions, cfg
 	st := a.storeForConfig(cfg)
 	if err := st.Init(ctx); err != nil && !errors.Is(err, model.ErrNotImplemented) {
 		_ = st.Close()
-		writeCLIError(a.stderr, global.jsonOutput, exitIndexLoadFailure, fmt.Sprintf("initialize metadata store: %v", err))
+		writeStoreInitError(a.stderr, global.jsonOutput, exitIndexLoadFailure, err, fmt.Sprintf("initialize metadata store: %v", err))
 		return nil, nil, exitIndexLoadFailure
 	}
 	// Snapshot the content-hash gate BEFORE clearing it so an interrupted or

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -46,7 +46,7 @@ func (a *App) runStatus(ctx context.Context, global globalOptions, args []string
 		st := a.storeForConfig(cfg)
 		defer func() { _ = st.Close() }()
 		if initErr := st.Init(ctx); initErr != nil && !errors.Is(initErr, model.ErrNotImplemented) {
-			writeCLIError(a.stderr, global.jsonOutput, exitIndexLoadFailure, fmt.Sprintf("initialize metadata store: %v", initErr))
+			writeStoreInitError(a.stderr, global.jsonOutput, exitIndexLoadFailure, initErr, fmt.Sprintf("initialize metadata store: %v", initErr))
 			return exitIndexLoadFailure
 		}
 		// status --json must emit a single JSON object, not an NDJSON stream.

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -609,7 +609,7 @@ type builtIndex struct {
 func (a *App) initStoreAndIndices(ctx context.Context, cfg *config.Config, jsonOutput bool) (model.Store, builtIndex, builtIndex, int) {
 	st := a.storeForConfig(*cfg)
 	if err := st.Init(ctx); err != nil && !errors.Is(err, model.ErrNotImplemented) {
-		writeCLIError(a.stderr, jsonOutput, exitIndexLoadFailure, fmt.Sprintf("initialize metadata store: %v", err))
+		writeStoreInitError(a.stderr, jsonOutput, exitIndexLoadFailure, err, fmt.Sprintf("initialize metadata store: %v", err))
 		return nil, builtIndex{}, builtIndex{}, exitIndexLoadFailure
 	}
 


### PR DESCRIPTION
Closes the last open item in **#422 V6**.

## The gap

`internal/store` raises a typed `*IndexVersionMismatchError` whose `Code()` correctly returns the canonical §14.3 `INDEX_VERSION_MISMATCH`. But every CLI `Init` call site passed it to `writeCLIError`, which derives the JSON `code` field from the *exit code*:

```json
{"error":{"code":"GENERIC_ERROR","message":"initialize metadata store: INDEX_VERSION_MISMATCH: corpus index_format_version \"1\" does not match this binary's \"2\"; reindex the corpus"}}
```

The canonical code survived only as a **prefix inside the human-readable message**, so a machine consumer parsing `code` could not distinguish a version mismatch from any other startup failure. That is precisely the "CLI prose only" defect #422 recorded for this code.

`BIND_FAILED` and `TLS_CONFIG_INVALID` were wired through `writeCLIErrorWithCode` in #523 for the same reason; this does the equivalent for the store path.

## Approach

One `writeStoreInitError` helper in `app.go` rather than eleven copies of the same `errors.As`. Five sites that write the §14 error channel now route through it: `up`, `ask`, `export`, `reindex`, `status`.

`errors.As` (not a type assertion) so a store backend that wraps the sentinel before returning it is still classified correctly.

**Deliberately out of scope:** `support_bundle.go` wraps Init failures with `%w`, and `server_doctor.go` returns a `doctorCheck` struct. Neither writes the CLI JSON error contract, so neither is part of §14's surface.

## Tests

The pre-existing `TestCheckIndexFormatVersion_MatchAndMismatch` asserted `Code()` on the raw Go error and never crossed the CLI boundary, which is why this survived. The new tests assert the **JSON payload's `code` field**:

- `TestWriteStoreInitError_EmitsIndexVersionMismatch` — the bare sentinel
- `TestWriteStoreInitError_WrappedMismatchStillDetected` — wrapped with `%w`
- `TestWriteStoreInitError_UnrelatedErrorKeepsGenericCode` — false-positive guard, an ordinary failure is not relabelled

Verified these **fail** when the `errors.As` branch is disabled, and pass with it.

## Gates

`gofmt` clean on all touched files, `go vet` clean, `gocyclo -over 15` (v0.6.0, CI-pinned) empty, `tests/security` boundary tests pass, `internal/cli` suite passes.

> Unrelated note: `gofmt -l` flags three files that are **already** unformatted on `main` (`internal/ingest/exclude.go`, `internal/retrieval/min_score_floor_rrf_test.go`, `internal/store/extractable_extensions_test.go`). Not touched here to keep the diff scoped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI error reporting when the local data store requires reindexing or a fresh state.
  * Store version mismatch errors now provide a specific error code and actionable guidance.
  * Other initialization failures retain their existing error codes, messages, and exit behavior.

* **Tests**
  * Added coverage for direct and wrapped store version mismatch errors, as well as unrelated failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->