### PR TITLE
chore: gofmt three files that had drifted out of format on main

### DIFF
--- a/internal/ingest/exclude.go
+++ b/internal/ingest/exclude.go
@@ -74,11 +74,11 @@ func RedactSecretsInMessage(msg string, patterns []*regexp.Regexp) string {
 // `keyword: value` form — so a redaction here never hides the actionable part of
 // an error (SPEC §15.6 recent_failures actionability).
 var highConfidenceCredentialRedactors = []*regexp.Regexp{
-	regexp.MustCompile(`(?i)bearer\s+[A-Za-z0-9._\-+/=]{20,}`),                              // Bearer token
-	regexp.MustCompile(`\b(?:AKIA|ASIA)[0-9A-Z]{16}\b`),                                     // AWS access key (long-term / temporary)
-	regexp.MustCompile(`(?i)\b(?:sk|pk|rk)[-_][A-Za-z0-9_\-]{16,}`),                         // Stripe / OpenAI (sk-proj-…) / Anthropic-style key
-	regexp.MustCompile(`\bgh[pousr]_[A-Za-z0-9_]{20,}`),                                     // GitHub PAT / OAuth
-	regexp.MustCompile(`\bxox[baprs]-[A-Za-z0-9-]{10,}`),                                    // Slack
+	regexp.MustCompile(`(?i)bearer\s+[A-Za-z0-9._\-+/=]{20,}`),                             // Bearer token
+	regexp.MustCompile(`\b(?:AKIA|ASIA)[0-9A-Z]{16}\b`),                                    // AWS access key (long-term / temporary)
+	regexp.MustCompile(`(?i)\b(?:sk|pk|rk)[-_][A-Za-z0-9_\-]{16,}`),                        // Stripe / OpenAI (sk-proj-…) / Anthropic-style key
+	regexp.MustCompile(`\bgh[pousr]_[A-Za-z0-9_]{20,}`),                                    // GitHub PAT / OAuth
+	regexp.MustCompile(`\bxox[baprs]-[A-Za-z0-9-]{10,}`),                                   // Slack
 	regexp.MustCompile(`eyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-.]{10,}\.[A-Za-z0-9_\-]{5,}`), // JWT
 }
 

--- a/internal/retrieval/min_score_floor_rrf_test.go
+++ b/internal/retrieval/min_score_floor_rrf_test.go
@@ -87,11 +87,11 @@ func TestApplyMinScoreFloor_Normalized(t *testing.T) {
 		floor float64
 		want  []uint64
 	}{
-		{0, []uint64{1, 2, 3}},       // disabled: pass-through
-		{0.4, []uint64{1, 2}},        // keeps top two (norm 1.0, 0.5), drops norm 0.0
-		{0.5, []uint64{1, 2}},        // boundary: norm == floor is KEPT (strict <)
-		{0.6, []uint64{1}},           // only the top survives
-		{1.5, []uint64{}},            // above every normalized score → empty
+		{0, []uint64{1, 2, 3}}, // disabled: pass-through
+		{0.4, []uint64{1, 2}},  // keeps top two (norm 1.0, 0.5), drops norm 0.0
+		{0.5, []uint64{1, 2}},  // boundary: norm == floor is KEPT (strict <)
+		{0.6, []uint64{1}},     // only the top survives
+		{1.5, []uint64{}},      // above every normalized score → empty
 	}
 	for _, tc := range cases {
 		got := floorSurvivors(tc.floor, hits)

--- a/internal/store/extractable_extensions_test.go
+++ b/internal/store/extractable_extensions_test.go
@@ -23,12 +23,12 @@ func TestExtractableExtensionCounts(t *testing.T) {
 	}
 
 	docs := []model.Document{
-		{RelPath: "a.PDF", DocType: "pdf", Status: "ok", ContentHash: "h1"},   // uppercase ext → normalized
-		{RelPath: "b.pdf", DocType: "pdf", Status: "ok", ContentHash: "h2"},   // second .pdf
+		{RelPath: "a.PDF", DocType: "pdf", Status: "ok", ContentHash: "h1"}, // uppercase ext → normalized
+		{RelPath: "b.pdf", DocType: "pdf", Status: "ok", ContentHash: "h2"}, // second .pdf
 		{RelPath: "scan.tiff", DocType: "image", Status: "ok", ContentHash: "h3"},
 		{RelPath: "notes.odt", DocType: "document", Status: "ok", ContentHash: "h4"},
-		{RelPath: "main.go", DocType: "code", Status: "ok", ContentHash: "h5"},        // not extractable
-		{RelPath: "bad.docx", DocType: "document", Status: "error", ContentHash: "h6"}, // wrong status
+		{RelPath: "main.go", DocType: "code", Status: "ok", ContentHash: "h5"},                // not extractable
+		{RelPath: "bad.docx", DocType: "document", Status: "error", ContentHash: "h6"},        // wrong status
 		{RelPath: "gone.pdf", DocType: "pdf", Status: "ok", Deleted: true, ContentHash: "h7"}, // deleted
 	}
 	for _, d := range docs {


### PR DESCRIPTION
`gofmt -l cmd internal tests` reports three files as unformatted on `main`:

- `internal/ingest/exclude.go`
- `internal/retrieval/min_score_floor_rrf_test.go`
- `internal/store/extractable_extensions_test.go`

All three are **trailing-comment alignment only**. `git diff -w --stat` is empty, so there is no semantic change whatsoever.

## Why bother

CI does **not** currently gate on `gofmt` — only the Makefile's `fmt` target runs it, and that writes rather than verifies. So this was not breaking any build.

It is still worth clearing: the noise appears in every `gofmt -l` run and reads as though the branch you are currently working on introduced it. I had to stash and re-check against `main` twice while reviewing unrelated changes to confirm it was pre-existing.

## Possible follow-up

If you want this to stay clean, CI's `checks` job could add a verify step:

```
test -z "$(gofmt -l cmd internal tests)"
```

Not included here to keep this diff to the formatting itself.

Verified: `go build ./...` and the three affected packages' tests pass.