### PR TITLE
docs(index): clarify memory/disk backends are exact scan, not ANN (#429 F3)

### DIFF
--- a/docs/dual-machine-deployment.md
+++ b/docs/dual-machine-deployment.md
@@ -191,12 +191,12 @@ on relocation alone. (`dirstral-spec/docs/SPEC.md` §7.8.)
 
 ### 2.4 Choose the vector backend (`index.backend`)
 
-| `index.backend` | Tier | External infra | When |
-|---|:--:|:--:|---|
-| `memory` (default) | A | none | In-memory HNSW, pure-Go, snapshotted to StateDir. Zero-infra default. |
-| `disk` | B | none | Pure-Go on-disk / memmapped single-node index; for corpora too large for RAM. |
-| `qdrant` | C | required | External Qdrant collection. |
-| `pgvector` | C | required | External PostgreSQL + pgvector. |
+| `index.backend` | Tier | External infra | Search | When |
+|---|:--:|:--:|---|---|
+| `memory` (default) | A | none | Exact, exhaustive scan | In-memory, pure-Go, snapshotted to StateDir. Zero-infra default. |
+| `disk` | B | none | Exact, exhaustive scan | Pure-Go on-disk / memmapped single-node index; for corpora too large for RAM. |
+| `qdrant` | C | required | Approximate (ANN) | External Qdrant collection. |
+| `pgvector` | C | required | Approximate (ANN) | External PostgreSQL + pgvector. |
 
 `memory` and `disk` keep all index state under the local StateDir and need no
 external service. The Tier-C backends are **optional** and connect to an external
@@ -224,6 +224,27 @@ Tier-C connection secrets (`qdrant.api_key`, `pgvector.dsn`) follow the same
 runtime-only credential rules and are never written to disk. A configured Tier-C
 backend that is unreachable at preflight fails startup rather than silently
 downgrading. (`dirstral-spec/docs/SPEC.md` §6.2–6.3.)
+
+#### `memory`/`disk` are exact search, not ANN
+
+Despite the `HNSWIndex` type name in `internal/index/hnsw_index.go` (kept as-is
+to avoid churn to a public type and its on-disk snapshot format), neither
+Tier-A/B backend builds an HNSW graph or does approximate nearest-neighbor
+search. Both `memory` and `disk` score every query vector against **every**
+stored vector with an exhaustive cosine scan and keep only the top-k. There is
+no ANN index to build, no recall/latency knob to tune, and no approximation
+error: recall is exact, always identical to a brute-force scan over the whole
+corpus. The trade-off is that query cost grows **linearly** with the number of
+indexed chunks, because every query touches every vector.
+
+As a rough order-of-magnitude guide — not a benchmark, and actual numbers
+depend on hardware, embedding dimensionality, and concurrent query load —
+expect the per-query cost of the exhaustive scan to become noticeable somewhere
+around **100K–200K chunks** (roughly **0.5–4s per query** in that range) and to
+reach multi-second latency around **~1M chunks**. If your corpus is at or
+approaching that order of magnitude and query latency matters, switch
+`index.backend` to `qdrant` or `pgvector` — both build real ANN indexes and
+stay sub-linear as the corpus grows.
 
 ### 2.5 Start the daemon and expose only the MCP endpoint
 

--- a/docs/dual-machine-deployment.md
+++ b/docs/dual-machine-deployment.md
@@ -237,14 +237,13 @@ error: recall is exact, always identical to a brute-force scan over the whole
 corpus. The trade-off is that query cost grows **linearly** with the number of
 indexed chunks, because every query touches every vector.
 
-As a rough order-of-magnitude guide — not a benchmark, and actual numbers
-depend on hardware, embedding dimensionality, and concurrent query load —
-expect the per-query cost of the exhaustive scan to become noticeable somewhere
+As a rough order-of-magnitude guide (not a benchmark; actual numbers depend on
+hardware, embedding dimensionality, and concurrent query load), expect the per-query cost of the exhaustive scan to become noticeable somewhere
 around **100K–200K chunks** (roughly **0.5–4s per query** in that range) and to
 reach multi-second latency around **~1M chunks**. If your corpus is at or
 approaching that order of magnitude and query latency matters, switch
-`index.backend` to `qdrant` or `pgvector` — both build real ANN indexes and
-stay sub-linear as the corpus grows.
+`index.backend` to `qdrant` or `pgvector`: both build real ANN indexes and stay
+sub-linear as the corpus grows.
 
 ### 2.5 Start the daemon and expose only the MCP endpoint
 

--- a/docs/dual-machine-deployment.md
+++ b/docs/dual-machine-deployment.md
@@ -196,7 +196,7 @@ on relocation alone. (`dirstral-spec/docs/SPEC.md` §7.8.)
 | `memory` (default) | A | none | Exact, exhaustive scan | In-memory, pure-Go, snapshotted to StateDir. Zero-infra default. |
 | `disk` | B | none | Exact, exhaustive scan | Pure-Go on-disk / memmapped single-node index; for corpora too large for RAM. |
 | `qdrant` | C | required | Approximate (ANN) | External Qdrant collection. |
-| `pgvector` | C | required | Approximate (ANN) | External PostgreSQL + pgvector. |
+| `pgvector` | C | required | Approximate (ANN), see note | External PostgreSQL + pgvector. |
 
 `memory` and `disk` keep all index state under the local StateDir and need no
 external service. The Tier-C backends are **optional** and connect to an external
@@ -242,8 +242,16 @@ hardware, embedding dimensionality, and concurrent query load), expect the per-q
 around **100K–200K chunks** (roughly **0.5–4s per query** in that range) and to
 reach multi-second latency around **~1M chunks**. If your corpus is at or
 approaching that order of magnitude and query latency matters, switch
-`index.backend` to `qdrant` or `pgvector`: both build real ANN indexes and stay
+`index.backend` to `qdrant` or `pgvector`, which build real ANN indexes and stay
 sub-linear as the corpus grows.
+
+One caveat on `pgvector`: its `hnsw`/`ivfflat` indexes are capped at
+**2000 dimensions** (`HNSWMaxDim`). Above that, dir2mcp skips the ANN index and
+warns, and the table answers queries by **exact sequential scan**, so you are
+back to linear cost with an external database in front of it. This is not a
+corner case: `gemini-embedding-001` defaults to 3072 dimensions. If you need ANN
+on `pgvector`, request a smaller Matryoshka output dimension (`<= 2000`) for the
+embedding model, or use `qdrant`, which has no such limit.
 
 ### 2.5 Start the daemon and expose only the MCP endpoint
 

--- a/internal/index/backend.go
+++ b/internal/index/backend.go
@@ -41,12 +41,20 @@ const (
 // the on-disk path it persists to (used by the caller to wire the
 // PersistenceManager and reindex cleanup).
 //
-//   - "memory" (default): the in-memory HNSW reference, persisted to the
-//     versioned vectors_<kind>.v2.hnsw snapshot. This path is byte-identical to
-//     legacy behavior.
+//   - "memory" (default): the in-memory reference (HNSWIndex; the name is
+//     historical — it performs an exhaustive brute-force cosine scan, not
+//     approximate HNSW search), persisted to the versioned
+//     vectors_<kind>.v2.hnsw snapshot. This path is byte-identical to legacy
+//     behavior.
 //   - "disk": the Tier-B pure-Go on-disk backend (internal/index/diskindex),
-//     persisted to vectors_<kind>.diskv1.idx with vector payloads kept
-//     memory-mapped on disk so the corpus is not bounded by RAM.
+//     also an exhaustive brute-force cosine scan (not ANN), persisted to
+//     vectors_<kind>.diskv1.idx with vector payloads kept memory-mapped on
+//     disk so the corpus is not bounded by RAM.
+//
+// Both memory and disk are exact (linear-cost) search, not approximate
+// nearest-neighbor; see docs/dual-machine-deployment.md §2.4 for the
+// exact-vs-ANN trade-off and the corpus-size guidance for switching to
+// "qdrant"/"pgvector" (issue #429 F3).
 //
 // An empty/unknown backend falls back to "memory"; config validation already
 // rejects unknown values, so this is defensive only.

--- a/internal/index/backend.go
+++ b/internal/index/backend.go
@@ -42,7 +42,7 @@ const (
 // PersistenceManager and reindex cleanup).
 //
 //   - "memory" (default): the in-memory reference (HNSWIndex; the name is
-//     historical — it performs an exhaustive brute-force cosine scan, not
+//     historical, and it performs an exhaustive brute-force cosine scan, not
 //     approximate HNSW search), persisted to the versioned
 //     vectors_<kind>.v2.hnsw snapshot. This path is byte-identical to legacy
 //     behavior.

--- a/internal/index/hnsw_index.go
+++ b/internal/index/hnsw_index.go
@@ -117,9 +117,15 @@ type hnswSnapshot struct {
 	Identity string
 }
 
-// NewHNSWIndex creates an empty in-memory HNSW index. The optional
-// path argument is used by Save/Load; if non-empty those methods will
-// persist to the given file.
+// NewHNSWIndex creates an empty in-memory index. Despite the type/function
+// name (kept for historical/on-disk-format compatibility rather than renamed;
+// issue #429 F3), this does not build an HNSW graph and is not an approximate
+// nearest-neighbor structure: Search performs an exhaustive brute-force cosine
+// scan over every stored vector, so query cost is linear in the number of
+// vectors. That makes recall exact (no ANN recall/latency trade-off to tune),
+// at the cost of not scaling sub-linearly the way the qdrant/pgvector backends
+// do. The optional path argument is used by Save/Load; if non-empty those
+// methods will persist to the given file.
 func NewHNSWIndex(path string) *HNSWIndex {
 	return &HNSWIndex{
 		path:                path,

--- a/internal/index/hnsw_index.go
+++ b/internal/index/hnsw_index.go
@@ -123,8 +123,9 @@ type hnswSnapshot struct {
 // nearest-neighbor structure: Search performs an exhaustive brute-force cosine
 // scan over every stored vector, so query cost is linear in the number of
 // vectors. That makes recall exact (no ANN recall/latency trade-off to tune),
-// at the cost of not scaling sub-linearly the way the qdrant/pgvector backends
-// do. The optional path argument is used by Save/Load; if non-empty those
+// at the cost of not scaling sub-linearly the way the qdrant backend does.
+// (pgvector is ANN only up to pgvector's 2000-dimension index limit; above it
+// that backend also falls back to an exact sequential scan.) The optional path argument is used by Save/Load; if non-empty those
 // methods will persist to the given file.
 func NewHNSWIndex(path string) *HNSWIndex {
 	return &HNSWIndex{


### PR DESCRIPTION
## Summary

Implements #429 F3 (docs only). The default `memory` vector backend is named `HNSWIndex` and its files are `vectors_*.hnsw`, and `docs/dual-machine-deployment.md`'s backend comparison table described it as "In-memory HNSW" — implying sub-linear approximate nearest-neighbor (ANN) search. That's not accurate: both `memory` and `disk` do an exhaustive brute-force cosine scan over every stored vector (confirmed by reading `internal/index/hnsw_index.go`'s `Search`/`scoreTopK`), so query cost is linear in corpus size. Only `qdrant` and `pgvector` build real ANN indexes.

This PR fixes the documentation so the naming stops misleading operators, without renaming the type, file, or on-disk snapshot format (explicitly out of scope per the issue — that would be invasive churn to a public type and on-disk format).

- `docs/dual-machine-deployment.md` §2.4: backend table now has a "Search" column (`Exact, exhaustive scan` vs `Approximate (ANN)`); new subsection spells out that `memory`/`disk` are exact/brute-force, states the genuine trade-off (exact recall, no ANN recall/latency tuning, vs. linear query cost), and gives an order-of-magnitude switching guide (~100-200K chunks / 0.5-4s per query, multi-second around ~1M) toward `qdrant`/`pgvector`, explicitly marked as an estimate, not a benchmark.
- `internal/index/hnsw_index.go`: corrected the `NewHNSWIndex` doc comment, which said "creates an empty in-memory HNSW index" with no caveat, to state plainly that it's an exhaustive brute-force scan, not an HNSW graph or ANN structure.
- `internal/index/backend.go`: corrected the `NewBackend` doc comment (called `memory` "the in-memory HNSW reference") to the same effect for both `memory` and `disk`, with a pointer to the docs section.

## Test plan

- [x] `gofmt -l cmd internal tests` — no new unformatted files (only the three pre-existing ones on `main`)
- [x] `go build ./...` — clean
- [x] `go test ./internal/index/...` and `go test ./tests/index/...` — pass (comment-only Go changes)
- [x] No new markdown links added (nothing for the docs link checker to break)