### PR TITLE
perf(index): one fsync per batch on the disk backend (#429 F8)

### DIFF
--- a/internal/index/diskindex/batch_upsert_test.go
+++ b/internal/index/diskindex/batch_upsert_test.go
@@ -1,0 +1,248 @@
+package diskindex
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// Issue #429 F8: the disk backend's per-record open+write+fsync+close capped
+// ingest at the fsync rate (EmbeddingWorker.indexChunks upserts once per chunk).
+// BatchUpsert pays ONE durability barrier for the whole batch. These tests are
+// in-package because they hook the unexported syncFile seam to count fsyncs.
+
+// countSyncs replaces the package fsync seam with a counter for the duration of
+// the test. Tests using it must not run in parallel (shared package state).
+func countSyncs(t *testing.T) *int {
+	t.Helper()
+	orig := syncFile
+	n := 0
+	syncFile = func(f *os.File) error {
+		n++
+		return orig(f)
+	}
+	t.Cleanup(func() { syncFile = orig })
+	return &n
+}
+
+func newTestIndex(t *testing.T) *DiskIndex {
+	t.Helper()
+	idx := New(filepath.Join(t.TempDir(), SegmentFileName("text")))
+	t.Cleanup(func() { _ = idx.Close() })
+	return idx
+}
+
+func batchItems(n int) []model.IndexUpsert {
+	items := make([]model.IndexUpsert, n)
+	for i := range items {
+		id := uint64(i + 1)
+		items[i] = model.IndexUpsert{
+			Vector:  []float32{float32(i), 1, 0, 0},
+			Payload: model.IndexPayload{ChunkID: id, RelPath: "a.txt", DocType: "md"},
+		}
+	}
+	return items
+}
+
+func mustFileSize(t *testing.T, path string) int64 {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	return info.Size()
+}
+
+// TestBatchUpsert_OneFsyncPerBatch is the regression test for #429 F8: a batch
+// of N vectors must cost exactly ONE fsync, where the equivalent per-chunk
+// Upsert loop costs N. Reverting BatchUpsert to a loop over appendRecord makes
+// the batch count N and fails this test.
+func TestBatchUpsert_OneFsyncPerBatch(t *testing.T) {
+	ctx := context.Background()
+	const n = 50
+	items := batchItems(n)
+
+	syncs := countSyncs(t)
+	batched := newTestIndex(t)
+	if err := batched.BatchUpsert(ctx, items); err != nil {
+		t.Fatalf("BatchUpsert: %v", err)
+	}
+	if *syncs != 1 {
+		t.Fatalf("BatchUpsert of %d vectors did %d fsyncs, want exactly 1", n, *syncs)
+	}
+
+	serial := newTestIndex(t)
+	before := *syncs
+	for _, it := range items {
+		if err := serial.Upsert(ctx, it.Vector, it.Payload); err != nil {
+			t.Fatalf("Upsert(%d): %v", it.Payload.ChunkID, err)
+		}
+	}
+	if got := *syncs - before; got != n {
+		t.Fatalf("per-chunk Upsert of %d vectors did %d fsyncs, want %d (the behavior the batch path replaces)", n, got, n)
+	}
+
+	// The two paths must produce the same index: same live set, same bytes.
+	if len(batched.locators) != len(serial.locators) {
+		t.Fatalf("locator counts differ: batched=%d serial=%d", len(batched.locators), len(serial.locators))
+	}
+	if a, b := mustFileSize(t, batched.path), mustFileSize(t, serial.path); a != b {
+		t.Fatalf("segment sizes differ: batched=%d serial=%d", a, b)
+	}
+	hits, err := batched.Search(ctx, items[7].Vector, 1, model.Filter{})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(hits) != 1 || hits[0].ChunkID != items[7].Payload.ChunkID {
+		t.Fatalf("batched search hits = %+v, want chunk %d", hits, items[7].Payload.ChunkID)
+	}
+}
+
+// TestBatchUpsert_LastWriterWinsWithinBatch pins that a repeated chunk ID inside
+// one batch resolves exactly as a sequence of Upserts would: the last item wins.
+func TestBatchUpsert_LastWriterWinsWithinBatch(t *testing.T) {
+	ctx := context.Background()
+	idx := newTestIndex(t)
+	items := []model.IndexUpsert{
+		{Vector: []float32{1, 0}, Payload: model.IndexPayload{ChunkID: 9, RelPath: "old.txt"}},
+		{Vector: []float32{0, 1}, Payload: model.IndexPayload{ChunkID: 9, RelPath: "new.txt"}},
+	}
+	if err := idx.BatchUpsert(ctx, items); err != nil {
+		t.Fatalf("BatchUpsert: %v", err)
+	}
+	hits, err := idx.Search(ctx, []float32{0, 1}, 5, model.Filter{})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(hits) != 1 {
+		t.Fatalf("hits = %+v, want exactly one record for chunk 9", hits)
+	}
+	if hits[0].Payload.RelPath != "new.txt" {
+		t.Fatalf("rel_path = %q, want the last writer (new.txt)", hits[0].Payload.RelPath)
+	}
+}
+
+// TestBatchUpsert_ValidationRejectsBeforeAnyWrite pins that a malformed item
+// fails the whole batch WITHOUT leaving records behind: validation happens
+// before the file is touched.
+func TestBatchUpsert_ValidationRejectsBeforeAnyWrite(t *testing.T) {
+	ctx := context.Background()
+	idx := newTestIndex(t)
+	items := append(batchItems(3), model.IndexUpsert{
+		Vector:  []float32{1, 0},
+		Payload: model.IndexPayload{ChunkID: 0},
+	})
+	if err := idx.BatchUpsert(ctx, items); err == nil {
+		t.Fatal("BatchUpsert with a zero chunk_id must fail")
+	}
+	if len(idx.locators) != 0 {
+		t.Fatalf("locators = %d, want 0 (nothing may be applied)", len(idx.locators))
+	}
+	if _, err := os.Stat(idx.path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("segment must not be created by a rejected batch: stat err = %v", err)
+	}
+}
+
+// TestBatchUpsert_RollsBackFailedBatch pins the crash-safety guarantee: when the
+// batch's durability barrier fails, the segment is truncated back to its
+// pre-batch length and the in-memory state is untouched — so the index is never
+// left half-applied and remains appendable and loadable.
+func TestBatchUpsert_RollsBackFailedBatch(t *testing.T) {
+	ctx := context.Background()
+	idx := newTestIndex(t)
+	seed := batchItems(2)
+	if err := idx.BatchUpsert(ctx, seed); err != nil {
+		t.Fatalf("seed BatchUpsert: %v", err)
+	}
+	sizeBefore := mustFileSize(t, idx.path)
+	endBefore, versionBefore := idx.appendEnd, idx.version
+
+	failing := []model.IndexUpsert{
+		{Vector: []float32{1, 0, 0, 0}, Payload: model.IndexPayload{ChunkID: 101, RelPath: "x.txt"}},
+		{Vector: []float32{0, 1, 0, 0}, Payload: model.IndexPayload{ChunkID: 102, RelPath: "y.txt"}},
+	}
+	boom := errors.New("simulated fsync failure")
+	orig := syncFile
+	syncFile = func(f *os.File) error { return boom }
+	err := idx.BatchUpsert(ctx, failing)
+	syncFile = orig
+	if !errors.Is(err, boom) {
+		t.Fatalf("BatchUpsert error = %v, want it to surface %v", err, boom)
+	}
+
+	if got := mustFileSize(t, idx.path); got != sizeBefore {
+		t.Fatalf("segment size = %d after a failed batch, want the pre-batch %d (rolled back)", got, sizeBefore)
+	}
+	if idx.appendEnd != endBefore || idx.version != versionBefore {
+		t.Fatalf("in-memory state advanced on a failed batch: appendEnd %d->%d version %d->%d",
+			endBefore, idx.appendEnd, versionBefore, idx.version)
+	}
+	if len(idx.locators) != len(seed) {
+		t.Fatalf("locators = %d after a failed batch, want the seeded %d", len(idx.locators), len(seed))
+	}
+
+	// The rolled-back segment must still be appendable and parseable.
+	if err := idx.BatchUpsert(ctx, failing); err != nil {
+		t.Fatalf("retry BatchUpsert after rollback: %v", err)
+	}
+	reopened := New(idx.path)
+	t.Cleanup(func() { _ = reopened.Close() })
+	if err := reopened.Load(ctx, idx.path); err != nil {
+		t.Fatalf("Load after rollback+retry: %v", err)
+	}
+	if len(reopened.locators) != len(seed)+len(failing) {
+		t.Fatalf("reloaded live set = %d, want %d", len(reopened.locators), len(seed)+len(failing))
+	}
+}
+
+// TestLoad_RecoversTornTail pins that a segment whose tail was torn by an
+// ungraceful crash mid-batch loads to the last COMPLETE record instead of
+// erroring out, and that the torn bytes are dropped so later appends are still
+// readable. Batching widens the window in which unsynced bytes can be in flight,
+// so this is the crash mode the batch path must survive.
+func TestLoad_RecoversTornTail(t *testing.T) {
+	ctx := context.Background()
+	idx := newTestIndex(t)
+	if err := idx.BatchUpsert(ctx, batchItems(3)); err != nil {
+		t.Fatalf("BatchUpsert: %v", err)
+	}
+	path := idx.path
+	full := mustFileSize(t, path)
+	if err := idx.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Simulate a crash that left only part of the last record on disk.
+	if err := os.Truncate(path, full-6); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+
+	reopened := New(path)
+	t.Cleanup(func() { _ = reopened.Close() })
+	if err := reopened.Load(ctx, path); err != nil {
+		t.Fatalf("Load with a torn tail must recover, got: %v", err)
+	}
+	if len(reopened.locators) != 2 {
+		t.Fatalf("recovered live set = %d, want the 2 complete records", len(reopened.locators))
+	}
+	if got := mustFileSize(t, path); got != reopened.appendEnd {
+		t.Fatalf("torn tail not dropped: file size %d, appendEnd %d", got, reopened.appendEnd)
+	}
+
+	// Appending after the recovery must survive another reopen.
+	if err := reopened.Upsert(ctx, []float32{9, 9, 9, 9}, model.IndexPayload{ChunkID: 77, RelPath: "z.txt"}); err != nil {
+		t.Fatalf("Upsert after recovery: %v", err)
+	}
+	again := New(path)
+	t.Cleanup(func() { _ = again.Close() })
+	if err := again.Load(ctx, path); err != nil {
+		t.Fatalf("reload after recovery: %v", err)
+	}
+	if _, ok := again.locators[77]; !ok || len(again.locators) != 3 {
+		t.Fatalf("post-recovery append lost: locators = %v", again.locators)
+	}
+}

--- a/internal/index/diskindex/batch_upsert_test.go
+++ b/internal/index/diskindex/batch_upsert_test.go
@@ -149,7 +149,7 @@ func TestBatchUpsert_ValidationRejectsBeforeAnyWrite(t *testing.T) {
 
 // TestBatchUpsert_RollsBackFailedBatch pins the crash-safety guarantee: when the
 // batch's durability barrier fails, the segment is truncated back to its
-// pre-batch length and the in-memory state is untouched — so the index is never
+// pre-batch length and the in-memory state is untouched, so the index is never
 // left half-applied and remains appendable and loadable.
 func TestBatchUpsert_RollsBackFailedBatch(t *testing.T) {
 	ctx := context.Background()

--- a/internal/index/diskindex/diskindex.go
+++ b/internal/index/diskindex/diskindex.go
@@ -44,6 +44,7 @@ import (
 	"io"
 	"math"
 	"os"
+	"path/filepath"
 	"sort"
 	"sync"
 	"time"
@@ -232,12 +233,14 @@ func (d *DiskIndex) BatchUpsert(ctx context.Context, items []model.IndexUpsert) 
 			return errors.New("payload chunk_id cannot be zero")
 		}
 	}
+	// Item validation stays ahead of the lock so a malformed batch is rejected
+	// without touching shared state. Reading d.path must NOT: Load assigns it
+	// under d.mu, so an unlocked read here races a concurrent reopen.
+	d.mu.Lock()
+	defer d.mu.Unlock()
 	if d.path == "" {
 		return errors.New("disk index requires a path")
 	}
-
-	d.mu.Lock()
-	defer d.mu.Unlock()
 	return d.appendBatch(items)
 }
 
@@ -401,6 +404,24 @@ func (d *DiskIndex) appendRecord(chunkID uint64, tombstone bool, vector []float3
 
 // ensureAppendEnd initialises d.appendEnd from the open file, writing the header
 // on a fresh/empty file. Caller holds the write lock.
+// syncDir fsyncs the directory holding path so a newly created file's directory
+// entry is durable. Syncing the file alone leaves a window where the contents
+// are on stable storage but the name is not, so a crash can lose a segment the
+// caller was told was durable. Best-effort: platforms that cannot open a
+// directory for read report no error rather than failing an otherwise good
+// write.
+func syncDir(path string) error {
+	dir, err := os.Open(filepath.Dir(path))
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = dir.Close() }()
+	if err := dir.Sync(); err != nil && !errors.Is(err, os.ErrInvalid) {
+		return err
+	}
+	return nil
+}
+
 func (d *DiskIndex) ensureAppendEnd(f *os.File) error {
 	if d.appendEnd != 0 {
 		return nil
@@ -411,6 +432,12 @@ func (d *DiskIndex) ensureAppendEnd(f *os.File) error {
 	}
 	if info.Size() == 0 {
 		if err := writeHeader(f); err != nil {
+			return err
+		}
+		// The segment file was just created; persist its directory entry too, so
+		// the durability the batch barrier promises covers the file's existence
+		// and not only its contents.
+		if err := syncDir(d.path); err != nil {
 			return err
 		}
 		d.appendEnd = int64(headerLen)
@@ -768,17 +795,20 @@ func (d *DiskIndex) Load(ctx context.Context, path string) error {
 		return scanErr
 	}
 
+	d.mu.Lock()
+	defer d.mu.Unlock()
 	// Drop a torn tail left by an ungraceful crash mid-append/mid-batch before
 	// anything appends after it, otherwise the garbage bytes would sit in the
 	// middle of the log and make every later scan stop short of the new records.
+	//
+	// This runs INSIDE the critical section: truncating outside it lets a
+	// concurrent durable append land past end between the scan and the truncate,
+	// and the truncate would then silently destroy it.
 	if torn {
 		if err := os.Truncate(path, end); err != nil {
 			return fmt.Errorf("diskindex: truncate torn segment tail at %d: %w", end, err)
 		}
 	}
-
-	d.mu.Lock()
-	defer d.mu.Unlock()
 	if err := d.invalidateReaderLocked(); err != nil {
 		return err
 	}

--- a/internal/index/diskindex/diskindex.go
+++ b/internal/index/diskindex/diskindex.go
@@ -127,9 +127,22 @@ var (
 	_ model.BatchUpserter  = (*DiskIndex)(nil)
 )
 
-// syncFile fsyncs f. It is a package-level var solely so the batch tests can
-// count durability barriers (one per batch vs one per record); production
-// behavior is always (*os.File).Sync.
+// SetSyncHookForTest replaces the fsync used as the durability barrier and
+// returns a function restoring the previous one.
+//
+// It is exported solely so the batch tests can count fsyncs from tests/ rather
+// than in-package: AGENTS.md requires new test files to live under tests/, and
+// counting durability barriers is the only way to pin "one fsync per batch
+// instead of one per record" (#429 F8) as an observable property. Production
+// code never calls this; the zero state is a real f.Sync().
+func SetSyncHookForTest(fn func(*os.File) error) (restore func()) {
+	prev := syncFile
+	syncFile = fn
+	return func() { syncFile = prev }
+}
+
+// syncFile fsyncs f. It is a package-level var solely so SetSyncHookForTest can
+// swap it; every production path leaves it at the real f.Sync() below.
 var syncFile = func(f *os.File) error { return f.Sync() }
 
 // New creates an empty disk index. path is the segment file used by Save/Load

--- a/internal/index/diskindex/diskindex.go
+++ b/internal/index/diskindex/diskindex.go
@@ -949,6 +949,12 @@ func readRecordAt(reader *mmap.ReaderAt, loc locator) ([]float32, model.IndexPay
 // store believes is indexed; the chunks are simply still pending and get
 // re-embedded. Erroring instead would make one torn record poison the whole
 // segment on load.
+// maxRecordBodyLen bounds a single record's body when scanning. Real records are
+// a vector plus a small payload (a 3072-dimension vector is about 12 KB), so 1
+// GiB is far above anything legitimate and far below the ~21.5 GB a corrupt
+// uint32 pair can encode.
+const maxRecordBodyLen = 1 << 30
+
 func scanSegment(path string) (map[uint64]locator, int64, bool, error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -980,6 +986,18 @@ func scanSegment(path string) (map[uint64]locator, int64, bool, error) {
 		vecLen := binary.LittleEndian.Uint32(hdr[9:13])
 		payloadLen := binary.LittleEndian.Uint32(hdr[13:17])
 		bodyLen := int64(vecLen)*4 + int64(payloadLen)
+		// vecLen and payloadLen are uint32, so a corrupt header can encode a body
+		// near 21.5 GB. Discard takes an int, which is 32-bit on some platforms,
+		// where that value wraps and can go negative; bufio panics on a negative
+		// count, crashing Load instead of failing cleanly. Bound it first.
+		//
+		// An over-long body is treated as a torn tail rather than an error, which
+		// matches what the scan already does for every other unreadable record:
+		// stop at the last complete one. Startup then recovers instead of
+		// bricking, and only records at or after the damage are dropped.
+		if bodyLen < 0 || bodyLen > maxRecordBodyLen {
+			return locators, offset, true, nil
+		}
 		if _, err := r.Discard(int(bodyLen)); err != nil {
 			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 				// Torn record body: stop at the last complete record.

--- a/internal/index/diskindex/diskindex.go
+++ b/internal/index/diskindex/diskindex.go
@@ -118,13 +118,19 @@ type DiskIndex struct {
 	lastSaveTime        time.Time
 }
 
-// compile-time assertions: DiskIndex satisfies the core contract and both
-// optional capabilities (issue #246/#247).
+// compile-time assertions: DiskIndex satisfies the core contract and the
+// optional capabilities (issue #246/#247/#429 F8).
 var (
 	_ model.Index          = (*DiskIndex)(nil)
 	_ model.Persistable    = (*DiskIndex)(nil)
 	_ model.FilteringIndex = (*DiskIndex)(nil)
+	_ model.BatchUpserter  = (*DiskIndex)(nil)
 )
+
+// syncFile fsyncs f. It is a package-level var solely so the batch tests can
+// count durability barriers (one per batch vs one per record); production
+// behavior is always (*os.File).Sync.
+var syncFile = func(f *os.File) error { return f.Sync() }
 
 // New creates an empty disk index. path is the segment file used by Save/Load
 // and the append log; it may be empty for a purely in-process instance, in
@@ -181,6 +187,136 @@ func (d *DiskIndex) Upsert(ctx context.Context, vector []float32, payload model.
 	return d.appendRecord(payload.ChunkID, false, vector, payload)
 }
 
+// BatchUpsert appends every item to the segment through ONE file open, ONE
+// buffered write pass and ONE fsync (issue #429 F8), instead of the open +
+// write + fsync + close that Upsert pays per record. Ingest upserts one vector
+// per chunk, so the per-record barrier capped disk-backend indexing at the
+// fsync rate; batching moves that cap to once per embed batch.
+//
+// Durability is honestly per BATCH, not per item: when this returns nil every
+// item is on stable storage, but a crash part-way through loses the whole batch
+// (the caller's chunks simply stay pending and are re-embedded — see
+// EmbeddingWorker.indexChunks, which only marks chunks embedded after this
+// returns). Nothing is ever silently half-applied: a write or fsync failure
+// truncates the segment back to its pre-batch length so the log can never be
+// scanned as a mix of applied and torn records, and the in-memory locator map
+// is only advanced after the barrier succeeds.
+func (d *DiskIndex) BatchUpsert(ctx context.Context, items []model.IndexUpsert) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if len(items) == 0 {
+		return nil
+	}
+	// Validate the whole batch before touching the file so a malformed item
+	// cannot leave a partially written segment behind (Upsert rejects the same
+	// two cases).
+	for i := range items {
+		if len(items[i].Vector) == 0 {
+			return errors.New("vector cannot be empty")
+		}
+		if items[i].Payload.ChunkID == 0 {
+			return errors.New("payload chunk_id cannot be zero")
+		}
+	}
+	if d.path == "" {
+		return errors.New("disk index requires a path")
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.appendBatch(items)
+}
+
+// appendBatch writes every item as a record, fsyncs once, and then publishes the
+// new locators. On any failure it rolls the segment back to its pre-batch length
+// and leaves the in-memory state untouched. Caller holds the write lock.
+func (d *DiskIndex) appendBatch(items []model.IndexUpsert) error {
+	f, err := os.OpenFile(d.path, os.O_RDWR|os.O_CREATE, 0o644)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	if err := d.ensureAppendEnd(f); err != nil {
+		return err
+	}
+	if _, err := f.Seek(d.appendEnd, io.SeekStart); err != nil {
+		return err
+	}
+
+	start := d.appendEnd
+	locs, end, werr := writeBatch(f, start, items)
+	if werr == nil {
+		// The single durability barrier for the whole batch.
+		werr = syncFile(f)
+	}
+	if werr != nil {
+		return d.rollbackBatch(f, start, werr)
+	}
+
+	// Published only now that the bytes are durable. Applying in slice order
+	// makes a repeated chunk ID within one batch resolve last-writer-wins,
+	// exactly as a sequence of Upserts would.
+	for i := range items {
+		d.locators[items[i].Payload.ChunkID] = locs[i]
+	}
+	d.appendEnd = end
+	// One mutation per item keeps the autosave delta accounting identical to the
+	// per-record path.
+	d.version += uint64(len(items))
+	// The mmap view is now stale (file grew); drop it so the next read re-maps.
+	return d.invalidateReaderLocked()
+}
+
+// writeBatch encodes every item into w through a single buffered writer, with
+// the first record landing at offset start. It returns one locator per item
+// (parallel to items) and the new end offset. It does not fsync — appendBatch
+// owns the batch's single durability barrier.
+func writeBatch(w io.Writer, start int64, items []model.IndexUpsert) ([]locator, int64, error) {
+	bw := bufio.NewWriter(w)
+	locs := make([]locator, len(items))
+	offset := start
+	for i := range items {
+		payloadBytes, err := encodePayload(items[i].Payload)
+		if err != nil {
+			return nil, 0, err
+		}
+		n, err := writeRecord(bw, items[i].Payload.ChunkID, false, items[i].Vector, payloadBytes)
+		if err != nil {
+			return nil, 0, err
+		}
+		locs[i] = locator{
+			offset:     offset,
+			vecLen:     uint32(len(items[i].Vector)),
+			payloadLen: uint32(len(payloadBytes)),
+		}
+		offset += int64(n)
+	}
+	if err := bw.Flush(); err != nil {
+		return nil, 0, err
+	}
+	return locs, offset, nil
+}
+
+// rollbackBatch truncates the segment back to its pre-batch length after a
+// failed batch and returns cause (joined with any rollback failure). d.locators
+// and d.appendEnd are never advanced before the fsync succeeds, so after the
+// truncation the in-memory state already matches the file again; only the mmap
+// view has to be dropped. Caller holds the write lock.
+func (d *DiskIndex) rollbackBatch(f *os.File, start int64, cause error) error {
+	if terr := f.Truncate(start); terr != nil {
+		return errors.Join(cause, fmt.Errorf("diskindex: rollback truncate to %d: %w", start, terr))
+	}
+	if serr := syncFile(f); serr != nil {
+		return errors.Join(cause, fmt.Errorf("diskindex: rollback sync: %w", serr))
+	}
+	if ierr := d.invalidateReaderLocked(); ierr != nil {
+		return errors.Join(cause, ierr)
+	}
+	return cause
+}
+
 // Delete writes a tombstone record for each id and drops the locator. Unknown
 // ids are ignored. Tombstones keep the on-disk log append-only and consistent;
 // space is reclaimed on the next Save (compaction).
@@ -230,7 +366,7 @@ func (d *DiskIndex) appendRecord(chunkID uint64, tombstone bool, vector []float3
 	if err != nil {
 		return err
 	}
-	if err := f.Sync(); err != nil {
+	if err := syncFile(f); err != nil {
 		return err
 	}
 	d.appendEnd += int64(n)
@@ -607,7 +743,7 @@ func (d *DiskIndex) Load(ctx context.Context, path string) error {
 		return errors.New("path is required")
 	}
 
-	locators, end, scanErr := scanSegment(path)
+	locators, end, torn, scanErr := scanSegment(path)
 	if scanErr != nil {
 		if errors.Is(scanErr, os.ErrNotExist) {
 			d.mu.Lock()
@@ -617,6 +753,15 @@ func (d *DiskIndex) Load(ctx context.Context, path string) error {
 			return nil
 		}
 		return scanErr
+	}
+
+	// Drop a torn tail left by an ungraceful crash mid-append/mid-batch before
+	// anything appends after it — otherwise the garbage bytes would sit in the
+	// middle of the log and make every later scan stop short of the new records.
+	if torn {
+		if err := os.Truncate(path, end); err != nil {
+			return fmt.Errorf("diskindex: truncate torn segment tail at %d: %w", end, err)
+		}
 	}
 
 	d.mu.Lock()
@@ -750,17 +895,27 @@ func readRecordAt(reader *mmap.ReaderAt, loc locator) ([]float32, model.IndexPay
 
 // scanSegment reads the segment header + record headers to rebuild the locator
 // map (last-writer-wins, tombstones drop entries) without retaining vectors. It
-// returns the locator map and the end-of-file offset.
-func scanSegment(path string) (map[uint64]locator, int64, error) {
+// returns the locator map, the offset just past the last COMPLETE record, and
+// whether the segment ended in a torn (partially written) record.
+//
+// A torn tail is not an error: the segment is an append log whose durability
+// barrier is per write (Upsert) or per batch (BatchUpsert, issue #429 F8), so an
+// ungraceful crash can leave a prefix of an unsynced batch in the file. Those
+// records belong to chunks the embed worker never marked embedded — it marks
+// only after the barrier returns — so dropping them loses nothing the metadata
+// store believes is indexed; the chunks are simply still pending and get
+// re-embedded. Erroring instead would make one torn record poison the whole
+// segment on load.
+func scanSegment(path string) (map[uint64]locator, int64, bool, error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, false, err
 	}
 	defer func() { _ = f.Close() }()
 
 	r := bufio.NewReader(f)
 	if err := verifyHeader(r); err != nil {
-		return nil, 0, err
+		return nil, 0, false, err
 	}
 
 	locators := make(map[uint64]locator)
@@ -769,9 +924,13 @@ func scanSegment(path string) (map[uint64]locator, int64, error) {
 	for {
 		if _, err := io.ReadFull(r, hdr); err != nil {
 			if errors.Is(err, io.EOF) {
-				break
+				return locators, offset, false, nil
 			}
-			return nil, 0, err
+			if errors.Is(err, io.ErrUnexpectedEOF) {
+				// Torn record header: stop at the last complete record.
+				return locators, offset, true, nil
+			}
+			return nil, 0, false, err
 		}
 		chunkID := binary.LittleEndian.Uint64(hdr[0:8])
 		tombstone := hdr[8] == 1
@@ -779,7 +938,11 @@ func scanSegment(path string) (map[uint64]locator, int64, error) {
 		payloadLen := binary.LittleEndian.Uint32(hdr[13:17])
 		bodyLen := int64(vecLen)*4 + int64(payloadLen)
 		if _, err := r.Discard(int(bodyLen)); err != nil {
-			return nil, 0, fmt.Errorf("truncated record body for chunk %d: %w", chunkID, err)
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+				// Torn record body: stop at the last complete record.
+				return locators, offset, true, nil
+			}
+			return nil, 0, false, fmt.Errorf("truncated record body for chunk %d: %w", chunkID, err)
 		}
 		if tombstone {
 			delete(locators, chunkID)
@@ -788,7 +951,6 @@ func scanSegment(path string) (map[uint64]locator, int64, error) {
 		}
 		offset += int64(recordHdrLen) + bodyLen
 	}
-	return locators, offset, nil
 }
 
 // verifyHeader reads and validates the segment magic + version.

--- a/internal/index/diskindex/diskindex.go
+++ b/internal/index/diskindex/diskindex.go
@@ -195,7 +195,7 @@ func (d *DiskIndex) Upsert(ctx context.Context, vector []float32, payload model.
 //
 // Durability is honestly per BATCH, not per item: when this returns nil every
 // item is on stable storage, but a crash part-way through loses the whole batch
-// (the caller's chunks simply stay pending and are re-embedded — see
+// (the caller's chunks simply stay pending and are re-embedded; see
 // EmbeddingWorker.indexChunks, which only marks chunks embedded after this
 // returns). Nothing is ever silently half-applied: a write or fsync failure
 // truncates the segment back to its pre-batch length so the log can never be
@@ -271,7 +271,7 @@ func (d *DiskIndex) appendBatch(items []model.IndexUpsert) error {
 
 // writeBatch encodes every item into w through a single buffered writer, with
 // the first record landing at offset start. It returns one locator per item
-// (parallel to items) and the new end offset. It does not fsync — appendBatch
+// (parallel to items) and the new end offset. It does not fsync: appendBatch
 // owns the batch's single durability barrier.
 func writeBatch(w io.Writer, start int64, items []model.IndexUpsert) ([]locator, int64, error) {
 	bw := bufio.NewWriter(w)
@@ -756,7 +756,7 @@ func (d *DiskIndex) Load(ctx context.Context, path string) error {
 	}
 
 	// Drop a torn tail left by an ungraceful crash mid-append/mid-batch before
-	// anything appends after it — otherwise the garbage bytes would sit in the
+	// anything appends after it, otherwise the garbage bytes would sit in the
 	// middle of the log and make every later scan stop short of the new records.
 	if torn {
 		if err := os.Truncate(path, end); err != nil {
@@ -901,8 +901,8 @@ func readRecordAt(reader *mmap.ReaderAt, loc locator) ([]float32, model.IndexPay
 // A torn tail is not an error: the segment is an append log whose durability
 // barrier is per write (Upsert) or per batch (BatchUpsert, issue #429 F8), so an
 // ungraceful crash can leave a prefix of an unsynced batch in the file. Those
-// records belong to chunks the embed worker never marked embedded — it marks
-// only after the barrier returns — so dropping them loses nothing the metadata
+// records belong to chunks the embed worker never marked embedded (it marks
+// only after the barrier returns), so dropping them loses nothing the metadata
 // store believes is indexed; the chunks are simply still pending and get
 // re-embedded. Erroring instead would make one torn record poison the whole
 // segment on load.

--- a/internal/index/embedding_worker.go
+++ b/internal/index/embedding_worker.go
@@ -623,7 +623,57 @@ func payloadFromTask(t model.ChunkTask) model.IndexPayload {
 // indexChunks adds each vector to the index and fires the OnIndexedChunk hook.
 // On an index error it marks the failed chunk and, if any chunks were already
 // added, marks those as embedded first.
+//
+// When the backend implements model.BatchUpserter (issue #429 F8) the whole
+// batch is applied in one call first — the on-disk backend fsyncs once per batch
+// there instead of once per chunk, which is what caps disk-backend ingest at the
+// fsync rate. The batch is a pure fast path: any batch error falls through to
+// the per-chunk loop below, which reproduces the existing error contract exactly
+// (partial MarkEmbedded, transient-vs-terminal classification, per-chunk
+// MarkFailedWithCategory) by finding the offending chunk itself. Replaying is
+// safe because BatchUpserter requires a failed batch to leave the index
+// replayable (the disk backend rolls its segment back).
+//
+// Durability note: with the batch path a chunk's vector is durable per batch
+// rather than per chunk. The invariant that matters is unchanged — BatchUpsert
+// returns only after its durability barrier, and chunks are marked embedded in
+// the store strictly after indexChunks returns — so a crash can never leave the
+// store claiming a chunk is embedded whose vector was lost; those chunks stay
+// pending and are re-embedded on the next run.
 func (w *EmbeddingWorker) indexChunks(ctx context.Context, validTasks []model.ChunkTask, labels []uint64, vectors [][]float32) (int, error) {
+	if batcher, ok := w.Index.(model.BatchUpserter); ok {
+		if w.batchIndexChunks(ctx, batcher, validTasks, vectors) {
+			return len(labels), nil
+		}
+	}
+	return w.upsertChunksSerially(ctx, validTasks, labels, vectors)
+}
+
+// batchIndexChunks applies every vector through the backend's batch path and
+// reports whether it succeeded. On success it fires OnIndexedChunk in task order,
+// exactly as the per-chunk loop does; on failure it reports false so the caller
+// can replay per chunk and attribute the error.
+func (w *EmbeddingWorker) batchIndexChunks(ctx context.Context, batcher model.BatchUpserter, validTasks []model.ChunkTask, vectors [][]float32) bool {
+	items := make([]model.IndexUpsert, len(validTasks))
+	for idx := range validTasks {
+		items[idx] = model.IndexUpsert{Vector: vectors[idx], Payload: payloadFromTask(validTasks[idx])}
+	}
+	if err := batcher.BatchUpsert(ctx, items); err != nil {
+		w.logf("batch upsert of %d chunks failed (%v); replaying per chunk to isolate the offender", len(items), err)
+		return false
+	}
+	for idx := range validTasks {
+		if w.OnIndexedChunk != nil {
+			w.OnIndexedChunk(validTasks[idx].Metadata.ChunkID, validTasks[idx].Metadata)
+		}
+	}
+	return true
+}
+
+// upsertChunksSerially is the per-chunk index path: the fallback for backends
+// without model.BatchUpserter and the replay that attributes a failed batch to a
+// specific chunk. It owns the index-error contract described on indexChunks.
+func (w *EmbeddingWorker) upsertChunksSerially(ctx context.Context, validTasks []model.ChunkTask, labels []uint64, vectors [][]float32) (int, error) {
 	for idx := range validTasks {
 		if addErr := w.Index.Upsert(ctx, vectors[idx], payloadFromTask(validTasks[idx])); addErr != nil {
 			if idx > 0 {

--- a/internal/index/embedding_worker.go
+++ b/internal/index/embedding_worker.go
@@ -625,7 +625,7 @@ func payloadFromTask(t model.ChunkTask) model.IndexPayload {
 // added, marks those as embedded first.
 //
 // When the backend implements model.BatchUpserter (issue #429 F8) the whole
-// batch is applied in one call first — the on-disk backend fsyncs once per batch
+// batch is applied in one call first: the on-disk backend fsyncs once per batch
 // there instead of once per chunk, which is what caps disk-backend ingest at the
 // fsync rate. The batch is a pure fast path: any batch error falls through to
 // the per-chunk loop below, which reproduces the existing error contract exactly
@@ -635,9 +635,9 @@ func payloadFromTask(t model.ChunkTask) model.IndexPayload {
 // replayable (the disk backend rolls its segment back).
 //
 // Durability note: with the batch path a chunk's vector is durable per batch
-// rather than per chunk. The invariant that matters is unchanged — BatchUpsert
+// rather than per chunk. The invariant that matters is unchanged, because BatchUpsert
 // returns only after its durability barrier, and chunks are marked embedded in
-// the store strictly after indexChunks returns — so a crash can never leave the
+// the store strictly after indexChunks returns, so a crash can never leave the
 // store claiming a chunk is embedded whose vector was lost; those chunks stay
 // pending and are re-embedded on the next run.
 func (w *EmbeddingWorker) indexChunks(ctx context.Context, validTasks []model.ChunkTask, labels []uint64, vectors [][]float32) (int, error) {

--- a/internal/index/reconcile.go
+++ b/internal/index/reconcile.go
@@ -14,9 +14,12 @@ import (
 // ungraceful crash (SIGKILL/OOM/power loss) before the snapshot ran.
 //
 // Durable backends (disk, qdrant, pgvector) deliberately do NOT implement it:
-// their writes are individually durable and they rebuild from a durable store on
-// load, so there is nothing to reconcile. ReconcileEmbeddedVectors treats a
-// backend that does not implement VectorPresence as a no-op.
+// their writes are durable before the write call returns — the disk backend
+// fsyncs per record, or once per batch on the model.BatchUpserter path (issue
+// #429 F8), always before the caller marks those chunks embedded — and they
+// rebuild from a durable store on load, so there is nothing to reconcile.
+// ReconcileEmbeddedVectors treats a backend that does not implement
+// VectorPresence as a no-op.
 type VectorPresence interface {
 	HasVectors(ctx context.Context, chunkIDs []uint64) (map[uint64]bool, error)
 }

--- a/internal/index/reconcile.go
+++ b/internal/index/reconcile.go
@@ -14,9 +14,9 @@ import (
 // ungraceful crash (SIGKILL/OOM/power loss) before the snapshot ran.
 //
 // Durable backends (disk, qdrant, pgvector) deliberately do NOT implement it:
-// their writes are durable before the write call returns — the disk backend
+// their writes are durable before the write call returns; the disk backend
 // fsyncs per record, or once per batch on the model.BatchUpserter path (issue
-// #429 F8), always before the caller marks those chunks embedded — and they
+// #429 F8), always before the caller marks those chunks embedded), and they
 // rebuild from a durable store on load, so there is nothing to reconcile.
 // ReconcileEmbeddedVectors treats a backend that does not implement
 // VectorPresence as a no-op.

--- a/internal/model/interfaces.go
+++ b/internal/model/interfaces.go
@@ -84,6 +84,41 @@ type Index interface {
 	Close() error
 }
 
+// IndexUpsert is one (vector, payload) pair for a batched upsert. It carries
+// exactly the two arguments Index.Upsert takes, so a batch is semantically a
+// sequence of Upserts applied in slice order (last writer wins on a repeated
+// ChunkID).
+type IndexUpsert struct {
+	Vector  []float32
+	Payload IndexPayload
+}
+
+// BatchUpserter is the OPTIONAL capability for indexes that can apply many
+// upserts as a single unit (issue #429 F8). It exists because a per-write
+// durability barrier — the on-disk backend fsyncs every appended record — caps
+// ingest at the fsync rate: one fsync per chunk. A backend that implements this
+// pays the barrier once per batch instead.
+//
+// Callers type-assert against it (mirroring Persistable / FilteringIndex /
+// LexicalSearcher) and fall back to a per-item Upsert loop when the backend does
+// not implement it, so memory/Qdrant/pgvector are unaffected.
+//
+// Contract:
+//   - Applying items in order MUST be equivalent to calling Upsert once per
+//     item: same validation (empty vector / zero ChunkID are errors), same
+//     last-writer-wins semantics.
+//   - Durability is per BATCH, not per item: on return with a nil error every
+//     item is as durable as an individual Upsert would have been, but a crash
+//     mid-batch may lose the whole batch. Callers must therefore not record a
+//     batch's items as persisted anywhere until BatchUpsert has returned nil.
+//   - On a non-nil error the index MUST be left in a state where replaying the
+//     same items through Upsert is safe — either by rolling the batch back or
+//     by relying on the last-writer-wins idempotency of Upsert. Callers use that
+//     replay to attribute the failure to a specific item.
+type BatchUpserter interface {
+	BatchUpsert(ctx context.Context, items []IndexUpsert) error
+}
+
 // Persistable is the optional capability for indexes that can durably
 // snapshot/restore themselves to a path (issue #247). The in-memory HNSW and
 // the future on-disk backend implement it; networked backends (Qdrant,

--- a/internal/model/interfaces.go
+++ b/internal/model/interfaces.go
@@ -95,7 +95,7 @@ type IndexUpsert struct {
 
 // BatchUpserter is the OPTIONAL capability for indexes that can apply many
 // upserts as a single unit (issue #429 F8). It exists because a per-write
-// durability barrier — the on-disk backend fsyncs every appended record — caps
+// durability barrier (the on-disk backend fsyncs every appended record) caps
 // ingest at the fsync rate: one fsync per chunk. A backend that implements this
 // pays the barrier once per batch instead.
 //
@@ -112,7 +112,7 @@ type IndexUpsert struct {
 //     mid-batch may lose the whole batch. Callers must therefore not record a
 //     batch's items as persisted anywhere until BatchUpsert has returned nil.
 //   - On a non-nil error the index MUST be left in a state where replaying the
-//     same items through Upsert is safe — either by rolling the batch back or
+//     same items through Upsert is safe, either by rolling the batch back or
 //     by relying on the last-writer-wins idempotency of Upsert. Callers use that
 //     replay to attribute the failure to a specific item.
 type BatchUpserter interface {

--- a/tests/index/batch_upsert_diskindex_test.go
+++ b/tests/index/batch_upsert_diskindex_test.go
@@ -1,4 +1,4 @@
-package diskindex
+package tests
 
 import (
 	"context"
@@ -7,33 +7,51 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/dirstral/dir2mcp/internal/index/diskindex"
 	"github.com/dirstral/dir2mcp/internal/model"
 )
 
 // Issue #429 F8: the disk backend's per-record open+write+fsync+close capped
 // ingest at the fsync rate (EmbeddingWorker.indexChunks upserts once per chunk).
-// BatchUpsert pays ONE durability barrier for the whole batch. These tests are
-// in-package because they hook the unexported syncFile seam to count fsyncs.
+// BatchUpsert pays ONE durability barrier for the whole batch. Counting fsyncs
+// is the only way to pin that as an observable property, so diskindex exports
+// SetSyncHookForTest and these tests live under tests/ per AGENTS.md.
+
+// liveRecords counts the records a segment will actually serve, using the public
+// Search path rather than reaching into unexported state. A generous k returns
+// every live record, so this is a faithful stand-in for the live-set size.
+func liveRecords(t *testing.T, idx *diskindex.DiskIndex, dim int) int {
+	t.Helper()
+	probe := make([]float32, dim)
+	for i := range probe {
+		probe[i] = 1
+	}
+	hits, err := idx.Search(context.Background(), probe, 10000, model.Filter{})
+	if err != nil {
+		t.Fatalf("Search while counting live records: %v", err)
+	}
+	return len(hits)
+}
 
 // countSyncs replaces the package fsync seam with a counter for the duration of
 // the test. Tests using it must not run in parallel (shared package state).
 func countSyncs(t *testing.T) *int {
 	t.Helper()
-	orig := syncFile
 	n := 0
-	syncFile = func(f *os.File) error {
+	restore := diskindex.SetSyncHookForTest(func(f *os.File) error {
 		n++
-		return orig(f)
-	}
-	t.Cleanup(func() { syncFile = orig })
+		return f.Sync()
+	})
+	t.Cleanup(restore)
 	return &n
 }
 
-func newTestIndex(t *testing.T) *DiskIndex {
+func newTestIndex(t *testing.T) (*diskindex.DiskIndex, string) {
 	t.Helper()
-	idx := New(filepath.Join(t.TempDir(), SegmentFileName("text")))
+	path := filepath.Join(t.TempDir(), diskindex.SegmentFileName("text"))
+	idx := diskindex.New(path)
 	t.Cleanup(func() { _ = idx.Close() })
-	return idx
+	return idx, path
 }
 
 func batchItems(n int) []model.IndexUpsert {
@@ -67,7 +85,7 @@ func TestBatchUpsert_OneFsyncPerBatch(t *testing.T) {
 	items := batchItems(n)
 
 	syncs := countSyncs(t)
-	batched := newTestIndex(t)
+	batched, batchedPath := newTestIndex(t)
 	if err := batched.BatchUpsert(ctx, items); err != nil {
 		t.Fatalf("BatchUpsert: %v", err)
 	}
@@ -75,7 +93,7 @@ func TestBatchUpsert_OneFsyncPerBatch(t *testing.T) {
 		t.Fatalf("BatchUpsert of %d vectors did %d fsyncs, want exactly 1", n, *syncs)
 	}
 
-	serial := newTestIndex(t)
+	serial, serialPath := newTestIndex(t)
 	before := *syncs
 	for _, it := range items {
 		if err := serial.Upsert(ctx, it.Vector, it.Payload); err != nil {
@@ -87,10 +105,10 @@ func TestBatchUpsert_OneFsyncPerBatch(t *testing.T) {
 	}
 
 	// The two paths must produce the same index: same live set, same bytes.
-	if len(batched.locators) != len(serial.locators) {
-		t.Fatalf("locator counts differ: batched=%d serial=%d", len(batched.locators), len(serial.locators))
+	if a, b := liveRecords(t, batched, 4), liveRecords(t, serial, 4); a != b {
+		t.Fatalf("live record counts differ: batched=%d serial=%d", a, b)
 	}
-	if a, b := mustFileSize(t, batched.path), mustFileSize(t, serial.path); a != b {
+	if a, b := mustFileSize(t, batchedPath), mustFileSize(t, serialPath); a != b {
 		t.Fatalf("segment sizes differ: batched=%d serial=%d", a, b)
 	}
 	hits, err := batched.Search(ctx, items[7].Vector, 1, model.Filter{})
@@ -106,7 +124,7 @@ func TestBatchUpsert_OneFsyncPerBatch(t *testing.T) {
 // one batch resolves exactly as a sequence of Upserts would: the last item wins.
 func TestBatchUpsert_LastWriterWinsWithinBatch(t *testing.T) {
 	ctx := context.Background()
-	idx := newTestIndex(t)
+	idx, _ := newTestIndex(t)
 	items := []model.IndexUpsert{
 		{Vector: []float32{1, 0}, Payload: model.IndexPayload{ChunkID: 9, RelPath: "old.txt"}},
 		{Vector: []float32{0, 1}, Payload: model.IndexPayload{ChunkID: 9, RelPath: "new.txt"}},
@@ -131,7 +149,7 @@ func TestBatchUpsert_LastWriterWinsWithinBatch(t *testing.T) {
 // before the file is touched.
 func TestBatchUpsert_ValidationRejectsBeforeAnyWrite(t *testing.T) {
 	ctx := context.Background()
-	idx := newTestIndex(t)
+	idx, segPath := newTestIndex(t)
 	items := append(batchItems(3), model.IndexUpsert{
 		Vector:  []float32{1, 0},
 		Payload: model.IndexPayload{ChunkID: 0},
@@ -139,10 +157,10 @@ func TestBatchUpsert_ValidationRejectsBeforeAnyWrite(t *testing.T) {
 	if err := idx.BatchUpsert(ctx, items); err == nil {
 		t.Fatal("BatchUpsert with a zero chunk_id must fail")
 	}
-	if len(idx.locators) != 0 {
-		t.Fatalf("locators = %d, want 0 (nothing may be applied)", len(idx.locators))
+	if n := liveRecords(t, idx, 4); n != 0 {
+		t.Fatalf("live records = %d, want 0 (nothing may be applied)", n)
 	}
-	if _, err := os.Stat(idx.path); !errors.Is(err, os.ErrNotExist) {
+	if _, err := os.Stat(segPath); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("segment must not be created by a rejected batch: stat err = %v", err)
 	}
 }
@@ -153,49 +171,48 @@ func TestBatchUpsert_ValidationRejectsBeforeAnyWrite(t *testing.T) {
 // left half-applied and remains appendable and loadable.
 func TestBatchUpsert_RollsBackFailedBatch(t *testing.T) {
 	ctx := context.Background()
-	idx := newTestIndex(t)
+	idx, segPath := newTestIndex(t)
 	seed := batchItems(2)
 	if err := idx.BatchUpsert(ctx, seed); err != nil {
 		t.Fatalf("seed BatchUpsert: %v", err)
 	}
-	sizeBefore := mustFileSize(t, idx.path)
-	endBefore, versionBefore := idx.appendEnd, idx.version
+	sizeBefore := mustFileSize(t, segPath)
+	liveBefore := liveRecords(t, idx, 4)
 
 	failing := []model.IndexUpsert{
 		{Vector: []float32{1, 0, 0, 0}, Payload: model.IndexPayload{ChunkID: 101, RelPath: "x.txt"}},
 		{Vector: []float32{0, 1, 0, 0}, Payload: model.IndexPayload{ChunkID: 102, RelPath: "y.txt"}},
 	}
 	boom := errors.New("simulated fsync failure")
-	orig := syncFile
-	syncFile = func(f *os.File) error { return boom }
+	restore := diskindex.SetSyncHookForTest(func(*os.File) error { return boom })
 	err := idx.BatchUpsert(ctx, failing)
-	syncFile = orig
+	restore()
 	if !errors.Is(err, boom) {
 		t.Fatalf("BatchUpsert error = %v, want it to surface %v", err, boom)
 	}
 
-	if got := mustFileSize(t, idx.path); got != sizeBefore {
+	if got := mustFileSize(t, segPath); got != sizeBefore {
 		t.Fatalf("segment size = %d after a failed batch, want the pre-batch %d (rolled back)", got, sizeBefore)
 	}
-	if idx.appendEnd != endBefore || idx.version != versionBefore {
-		t.Fatalf("in-memory state advanced on a failed batch: appendEnd %d->%d version %d->%d",
-			endBefore, idx.appendEnd, versionBefore, idx.version)
+	if got := liveRecords(t, idx, 4); got != liveBefore {
+		t.Fatalf("live set changed on a failed batch: %d -> %d (the batch must roll back entirely)",
+			liveBefore, got)
 	}
-	if len(idx.locators) != len(seed) {
-		t.Fatalf("locators = %d after a failed batch, want the seeded %d", len(idx.locators), len(seed))
+	if n := liveRecords(t, idx, 4); n != len(seed) {
+		t.Fatalf("live records = %d after a failed batch, want the seeded %d", n, len(seed))
 	}
 
 	// The rolled-back segment must still be appendable and parseable.
 	if err := idx.BatchUpsert(ctx, failing); err != nil {
 		t.Fatalf("retry BatchUpsert after rollback: %v", err)
 	}
-	reopened := New(idx.path)
+	reopened := diskindex.New(segPath)
 	t.Cleanup(func() { _ = reopened.Close() })
-	if err := reopened.Load(ctx, idx.path); err != nil {
+	if err := reopened.Load(ctx, segPath); err != nil {
 		t.Fatalf("Load after rollback+retry: %v", err)
 	}
-	if len(reopened.locators) != len(seed)+len(failing) {
-		t.Fatalf("reloaded live set = %d, want %d", len(reopened.locators), len(seed)+len(failing))
+	if n := liveRecords(t, reopened, 4); n != len(seed)+len(failing) {
+		t.Fatalf("reloaded live set = %d, want %d", n, len(seed)+len(failing))
 	}
 }
 
@@ -206,11 +223,11 @@ func TestBatchUpsert_RollsBackFailedBatch(t *testing.T) {
 // so this is the crash mode the batch path must survive.
 func TestLoad_RecoversTornTail(t *testing.T) {
 	ctx := context.Background()
-	idx := newTestIndex(t)
+	idx, segPath := newTestIndex(t)
 	if err := idx.BatchUpsert(ctx, batchItems(3)); err != nil {
 		t.Fatalf("BatchUpsert: %v", err)
 	}
-	path := idx.path
+	path := segPath
 	full := mustFileSize(t, path)
 	if err := idx.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
@@ -221,28 +238,28 @@ func TestLoad_RecoversTornTail(t *testing.T) {
 		t.Fatalf("truncate: %v", err)
 	}
 
-	reopened := New(path)
+	reopened := diskindex.New(path)
 	t.Cleanup(func() { _ = reopened.Close() })
 	if err := reopened.Load(ctx, path); err != nil {
 		t.Fatalf("Load with a torn tail must recover, got: %v", err)
 	}
-	if len(reopened.locators) != 2 {
-		t.Fatalf("recovered live set = %d, want the 2 complete records", len(reopened.locators))
+	if n := liveRecords(t, reopened, 4); n != 2 {
+		t.Fatalf("recovered live set = %d, want the 2 complete records", n)
 	}
-	if got := mustFileSize(t, path); got != reopened.appendEnd {
-		t.Fatalf("torn tail not dropped: file size %d, appendEnd %d", got, reopened.appendEnd)
-	}
+	// The torn tail is dropped rather than served: the count above already
+	// excludes it, and the post-recovery append below proves the segment is
+	// writable again from the recovered offset.
 
 	// Appending after the recovery must survive another reopen.
 	if err := reopened.Upsert(ctx, []float32{9, 9, 9, 9}, model.IndexPayload{ChunkID: 77, RelPath: "z.txt"}); err != nil {
 		t.Fatalf("Upsert after recovery: %v", err)
 	}
-	again := New(path)
+	again := diskindex.New(path)
 	t.Cleanup(func() { _ = again.Close() })
 	if err := again.Load(ctx, path); err != nil {
 		t.Fatalf("reload after recovery: %v", err)
 	}
-	if _, ok := again.locators[77]; !ok || len(again.locators) != 3 {
-		t.Fatalf("post-recovery append lost: locators = %v", again.locators)
+	if n := liveRecords(t, again, 4); n != 3 {
+		t.Fatalf("post-recovery append lost: live records = %d, want 3", n)
 	}
 }

--- a/tests/index/batch_upsert_diskindex_test.go
+++ b/tests/index/batch_upsert_diskindex_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"os"
 	"path/filepath"
@@ -261,5 +262,49 @@ func TestLoad_RecoversTornTail(t *testing.T) {
 	}
 	if n := liveRecords(t, again, 4); n != 3 {
 		t.Fatalf("post-recovery append lost: live records = %d, want 3", n)
+	}
+}
+
+// TestLoad_CorruptOversizedHeaderDoesNotPanic covers a corrupt record header
+// whose vecLen/payloadLen encode a body far larger than the file.
+//
+// Both are uint32, so the computed body length can approach 21.5 GB. Discard
+// takes an int, 32-bit on some platforms, where that value wraps and can go
+// negative; bufio panics on a negative count, so Load would crash rather than
+// fail cleanly. The scan bounds the length first and treats an impossible
+// record as a torn tail, which is what it already does for every other
+// unreadable record.
+//
+// Honest limitation: on a 64-bit host int is wide enough that the value stays
+// positive and Discard merely hits EOF, so this test passes with or without the
+// bound here. It pins the recoverable OUTCOME on every platform and documents
+// the corrupt-header case; the panic it guards against is reachable only where
+// int is 32 bits.
+func TestLoad_CorruptOversizedHeaderDoesNotPanic(t *testing.T) {
+	ctx := context.Background()
+	idx, segPath := newTestIndex(t)
+	mustUpsertDisk(t, idx, model.IndexPayload{ChunkID: 1, RelPath: "good.txt"}, []float32{1, 0, 0, 0})
+
+	raw, err := os.ReadFile(segPath)
+	if err != nil {
+		t.Fatalf("read segment: %v", err)
+	}
+	// Append a header claiming the largest body two uint32 fields can express.
+	hdr := make([]byte, 17)
+	binary.LittleEndian.PutUint64(hdr[0:8], 99)
+	hdr[8] = 0
+	binary.LittleEndian.PutUint32(hdr[9:13], ^uint32(0))
+	binary.LittleEndian.PutUint32(hdr[13:17], ^uint32(0))
+	if err := os.WriteFile(segPath, append(raw, hdr...), 0o600); err != nil {
+		t.Fatalf("write corrupt segment: %v", err)
+	}
+
+	reopened := diskindex.New(segPath)
+	t.Cleanup(func() { _ = reopened.Close() })
+	if err := reopened.Load(ctx, segPath); err != nil {
+		t.Fatalf("Load must recover from a corrupt oversized header, got: %v", err)
+	}
+	if n := liveRecords(t, reopened, 4); n != 1 {
+		t.Fatalf("live records = %d, want the 1 good record before the corruption", n)
 	}
 }

--- a/tests/index/batch_upsert_worker_test.go
+++ b/tests/index/batch_upsert_worker_test.go
@@ -1,0 +1,226 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/index/diskindex"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// Issue #429 F8: EmbeddingWorker.indexChunks upserts one vector per chunk, which
+// on the on-disk backend meant one fsync per chunk. The worker now type-asserts
+// the index against the optional model.BatchUpserter and applies the whole batch
+// in one call, falling back to the per-chunk loop for backends that do not
+// implement it (memory/Qdrant/pgvector) and for batch failures.
+
+// batchIndex is a model.Index that records how the worker dispatched its
+// upserts. batchErr, when set, fails BatchUpsert; upsertErrFor fails the
+// per-chunk Upsert for one chunk ID so the fallback's error attribution can be
+// asserted.
+type batchIndex struct {
+	batches      [][]model.IndexUpsert
+	upserted     []uint64
+	batchErr     error
+	upsertErrFor uint64
+}
+
+func (b *batchIndex) BatchUpsert(_ context.Context, items []model.IndexUpsert) error {
+	if b.batchErr != nil {
+		return b.batchErr
+	}
+	cp := make([]model.IndexUpsert, len(items))
+	copy(cp, items)
+	b.batches = append(b.batches, cp)
+	return nil
+}
+
+func (b *batchIndex) Upsert(_ context.Context, _ []float32, payload model.IndexPayload) error {
+	if b.upsertErrFor != 0 && payload.ChunkID == b.upsertErrFor {
+		return errors.New("upsert rejected")
+	}
+	b.upserted = append(b.upserted, payload.ChunkID)
+	return nil
+}
+
+func (b *batchIndex) Delete(_ context.Context, _ []uint64) error { return nil }
+func (b *batchIndex) Search(_ context.Context, _ []float32, _ int, _ model.Filter) ([]model.IndexHit, error) {
+	return nil, nil
+}
+func (b *batchIndex) Identity(_ context.Context) (string, error) { return "", nil }
+func (b *batchIndex) Reset(_ context.Context, _ string) error    { return nil }
+func (b *batchIndex) Close() error                               { return nil }
+
+// serialIndex is a model.Index WITHOUT BatchUpsert: the fallback path.
+type serialIndex struct{ upserted []uint64 }
+
+func (s *serialIndex) Upsert(_ context.Context, _ []float32, payload model.IndexPayload) error {
+	s.upserted = append(s.upserted, payload.ChunkID)
+	return nil
+}
+func (s *serialIndex) Delete(_ context.Context, _ []uint64) error { return nil }
+func (s *serialIndex) Search(_ context.Context, _ []float32, _ int, _ model.Filter) ([]model.IndexHit, error) {
+	return nil, nil
+}
+func (s *serialIndex) Identity(_ context.Context) (string, error) { return "", nil }
+func (s *serialIndex) Reset(_ context.Context, _ string) error    { return nil }
+func (s *serialIndex) Close() error                               { return nil }
+
+func batchTasks(ids ...uint64) []model.ChunkTask {
+	tasks := make([]model.ChunkTask, 0, len(ids))
+	for _, id := range ids {
+		tasks = append(tasks, model.NewChunkTask(id, "text", "text", model.ChunkMetadata{ChunkID: id, RelPath: "a.txt"}))
+	}
+	return tasks
+}
+
+func unitVectors(n int) [][]float32 {
+	vecs := make([][]float32, n)
+	for i := range vecs {
+		vecs[i] = []float32{float32(i + 1), 1}
+	}
+	return vecs
+}
+
+// TestIndexChunks_UsesBatchUpsertWhenAvailable pins that a BatchUpserter backend
+// receives ONE batch containing every chunk (not one Upsert per chunk), that the
+// payloads are the same ones the per-chunk path builds, and that OnIndexedChunk
+// still fires once per chunk in task order.
+func TestIndexChunks_UsesBatchUpsertWhenAvailable(t *testing.T) {
+	ctx := context.Background()
+	src := &fakeChunkSource{}
+	idx := &batchIndex{}
+	var indexed []uint64
+	worker := &index.EmbeddingWorker{
+		Source: src, Index: idx, Embedder: &fakeEmbedder{vectors: unitVectors(3)}, BatchSize: 8,
+		OnIndexedChunk: func(label uint64, _ model.ChunkMetadata) { indexed = append(indexed, label) },
+	}
+
+	n, err := worker.EmbedAndIndex(ctx, "text", batchTasks(11, 22, 33))
+	if err != nil {
+		t.Fatalf("EmbedAndIndex: %v", err)
+	}
+	if n != 3 {
+		t.Fatalf("indexed = %d, want 3", n)
+	}
+	if len(idx.batches) != 1 {
+		t.Fatalf("BatchUpsert called %d times, want exactly 1 for a 3-chunk batch", len(idx.batches))
+	}
+	if len(idx.upserted) != 0 {
+		t.Fatalf("per-chunk Upsert also called for %v; the batch path must replace it", idx.upserted)
+	}
+	got := make([]uint64, 0, 3)
+	for _, item := range idx.batches[0] {
+		got = append(got, item.Payload.ChunkID)
+		if item.Payload.RelPath != "a.txt" {
+			t.Fatalf("batched payload lost fields: %+v", item.Payload)
+		}
+		if len(item.Vector) == 0 {
+			t.Fatalf("batched item %d carries no vector", item.Payload.ChunkID)
+		}
+	}
+	if len(got) != 3 || got[0] != 11 || got[1] != 22 || got[2] != 33 {
+		t.Fatalf("batched chunk ids = %v, want [11 22 33] in task order", got)
+	}
+	if len(indexed) != 3 {
+		t.Fatalf("OnIndexedChunk fired %d times, want 3", len(indexed))
+	}
+	if len(src.embedded) != 3 {
+		t.Fatalf("embedded = %v, want all three marked", src.embedded)
+	}
+}
+
+// TestIndexChunks_FallsBackWithoutBatchUpsert pins that a backend that does NOT
+// implement model.BatchUpserter keeps the existing per-chunk behavior.
+func TestIndexChunks_FallsBackWithoutBatchUpsert(t *testing.T) {
+	ctx := context.Background()
+	src := &fakeChunkSource{}
+	idx := &serialIndex{}
+	worker := &index.EmbeddingWorker{
+		Source: src, Index: idx, Embedder: &fakeEmbedder{vectors: unitVectors(2)}, BatchSize: 8,
+	}
+
+	n, err := worker.EmbedAndIndex(ctx, "text", batchTasks(11, 22))
+	if err != nil {
+		t.Fatalf("EmbedAndIndex: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("indexed = %d, want 2", n)
+	}
+	if len(idx.upserted) != 2 || idx.upserted[0] != 11 || idx.upserted[1] != 22 {
+		t.Fatalf("upserted = %v, want [11 22] via the per-chunk fallback", idx.upserted)
+	}
+	if len(src.embedded) != 2 {
+		t.Fatalf("embedded = %v, want both marked", src.embedded)
+	}
+}
+
+// TestIndexChunks_BatchFailureReplaysPerChunk pins the partial-failure contract:
+// when the batch call fails, the worker replays per chunk so the offending chunk
+// is still attributed — healthy predecessors are marked embedded and only the
+// bad chunk is marked failed with its category.
+func TestIndexChunks_BatchFailureReplaysPerChunk(t *testing.T) {
+	ctx := context.Background()
+	src := &fakeChunkSource{}
+	idx := &batchIndex{batchErr: errors.New("batch write failed"), upsertErrFor: 22}
+	worker := &index.EmbeddingWorker{
+		Source: src, Index: idx, Embedder: &fakeEmbedder{vectors: unitVectors(3)}, BatchSize: 8,
+	}
+
+	n, err := worker.EmbedAndIndex(ctx, "text", batchTasks(11, 22, 33))
+	if err == nil {
+		t.Fatal("EmbedAndIndex must surface the per-chunk index error")
+	}
+	if n != 1 {
+		t.Fatalf("indexed = %d, want 1 (chunk 11 landed before chunk 22 failed)", n)
+	}
+	if len(idx.upserted) != 1 || idx.upserted[0] != 11 {
+		t.Fatalf("replayed upserts = %v, want [11] before the failure", idx.upserted)
+	}
+	if len(src.embedded) != 1 || src.embedded[0] != 11 {
+		t.Fatalf("embedded = %v, want [11] marked before the index error", src.embedded)
+	}
+	if len(src.failedLabels) != 1 || src.failedLabels[0] != 22 {
+		t.Fatalf("failed = %v, want exactly the offending chunk [22]", src.failedLabels)
+	}
+	if src.failedCategory == "" {
+		t.Fatal("failed chunk lost its error category")
+	}
+}
+
+// TestEmbedAndIndex_DiskBackendBatchesEndToEnd wires the real disk backend to the
+// worker and pins that the batch path leaves the segment durable and searchable —
+// including after a reopen, so the single per-batch fsync really persisted every
+// vector.
+func TestEmbedAndIndex_DiskBackendBatchesEndToEnd(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), diskindex.SegmentFileName("text"))
+	idx := diskindex.New(path)
+	src := &fakeChunkSource{}
+	worker := &index.EmbeddingWorker{
+		Source: src, Index: idx, Embedder: &fakeEmbedder{vectors: unitVectors(3)}, BatchSize: 8,
+	}
+
+	if _, err := worker.EmbedAndIndex(ctx, "text", batchTasks(11, 22, 33)); err != nil {
+		t.Fatalf("EmbedAndIndex: %v", err)
+	}
+	if err := idx.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopened := diskindex.New(path)
+	defer func() { _ = reopened.Close() }()
+	if err := reopened.Load(ctx, path); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	hits, err := reopened.Search(ctx, []float32{2, 1}, 10, model.Filter{})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(hits) != 3 {
+		t.Fatalf("hits after reopen = %d, want all 3 batched vectors durable", len(hits))
+	}
+}

--- a/tests/index/batch_upsert_worker_test.go
+++ b/tests/index/batch_upsert_worker_test.go
@@ -160,7 +160,7 @@ func TestIndexChunks_FallsBackWithoutBatchUpsert(t *testing.T) {
 
 // TestIndexChunks_BatchFailureReplaysPerChunk pins the partial-failure contract:
 // when the batch call fails, the worker replays per chunk so the offending chunk
-// is still attributed — healthy predecessors are marked embedded and only the
+// is still attributed: healthy predecessors are marked embedded and only the
 // bad chunk is marked failed with its category.
 func TestIndexChunks_BatchFailureReplaysPerChunk(t *testing.T) {
 	ctx := context.Background()
@@ -192,7 +192,7 @@ func TestIndexChunks_BatchFailureReplaysPerChunk(t *testing.T) {
 }
 
 // TestEmbedAndIndex_DiskBackendBatchesEndToEnd wires the real disk backend to the
-// worker and pins that the batch path leaves the segment durable and searchable —
+// worker and pins that the batch path leaves the segment durable and searchable,
 // including after a reopen, so the single per-batch fsync really persisted every
 // vector.
 func TestEmbedAndIndex_DiskBackendBatchesEndToEnd(t *testing.T) {

--- a/tests/index/disk_index_test.go
+++ b/tests/index/disk_index_test.go
@@ -338,12 +338,12 @@ func TestDiskIndex_LoadBadMagicErrors(t *testing.T) {
 // This deliberately replaces the older "a torn tail is an error" expectation
 // (issue #429 F8). The batch path (BatchUpsert) trades one fsync per record for
 // one per batch, so an ungraceful crash can leave a prefix of a batch in the
-// file; failing the load would make the whole index unusable — the daemon exits
-// with exitIndexLoadFailure — after a crash that lost nothing. It loses nothing
+// file; failing the load would make the whole index unusable (the daemon exits
+// with exitIndexLoadFailure) after a crash that lost nothing. It loses nothing
 // because BatchUpsert returns only after its fsync and the embed worker marks
 // chunks embedded strictly after that returns: every record in a torn tail
 // belongs to a chunk still PENDING in sqlite, which is simply re-embedded. A
-// structurally wrong file (bad magic/version) is still a hard error — see
+// structurally wrong file (bad magic/version) is still a hard error; see
 // TestDiskIndex_LoadBadMagicErrors.
 func TestDiskIndex_LoadTruncatedBodyRecovers(t *testing.T) {
 	ctx := context.Background()

--- a/tests/index/disk_index_test.go
+++ b/tests/index/disk_index_test.go
@@ -331,10 +331,21 @@ func TestDiskIndex_LoadBadMagicErrors(t *testing.T) {
 	}
 }
 
-// TestDiskIndex_LoadTruncatedBodyErrors verifies a segment truncated mid-record
-// (a torn write) is reported as an error rather than panicking or silently
-// dropping data.
-func TestDiskIndex_LoadTruncatedBodyErrors(t *testing.T) {
+// TestDiskIndex_LoadTruncatedBodyRecovers verifies a segment truncated
+// mid-record (a torn write) loads to the last COMPLETE record instead of
+// panicking or erroring.
+//
+// This deliberately replaces the older "a torn tail is an error" expectation
+// (issue #429 F8). The batch path (BatchUpsert) trades one fsync per record for
+// one per batch, so an ungraceful crash can leave a prefix of a batch in the
+// file; failing the load would make the whole index unusable — the daemon exits
+// with exitIndexLoadFailure — after a crash that lost nothing. It loses nothing
+// because BatchUpsert returns only after its fsync and the embed worker marks
+// chunks embedded strictly after that returns: every record in a torn tail
+// belongs to a chunk still PENDING in sqlite, which is simply re-embedded. A
+// structurally wrong file (bad magic/version) is still a hard error — see
+// TestDiskIndex_LoadBadMagicErrors.
+func TestDiskIndex_LoadTruncatedBodyRecovers(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()
 	segPath := filepath.Join(dir, diskindex.SegmentFileName("text"))
@@ -355,8 +366,30 @@ func TestDiskIndex_LoadTruncatedBodyErrors(t *testing.T) {
 
 	reopened := diskindex.New(segPath)
 	t.Cleanup(func() { _ = reopened.Close() })
-	if err := reopened.Load(ctx, segPath); err == nil {
-		t.Fatal("expected an error loading a truncated segment, got nil")
+	if err := reopened.Load(ctx, segPath); err != nil {
+		t.Fatalf("loading a segment with a torn tail must recover, got: %v", err)
+	}
+	// The torn record is dropped (it is the only one here), and the recovered
+	// segment is usable: a fresh append lands and survives another reopen.
+	hits, err := reopened.Search(ctx, []float32{1, 2, 3}, 10, model.Filter{})
+	if err != nil {
+		t.Fatalf("Search after recovery: %v", err)
+	}
+	if len(hits) != 0 {
+		t.Fatalf("hits = %+v, want none (the torn record must not be served)", hits)
+	}
+	mustUpsertDisk(t, reopened, model.IndexPayload{ChunkID: 2, RelPath: "b.md"}, []float32{4, 5, 6})
+	again := diskindex.New(segPath)
+	t.Cleanup(func() { _ = again.Close() })
+	if err := again.Load(ctx, segPath); err != nil {
+		t.Fatalf("Load after post-recovery append: %v", err)
+	}
+	hits, err = again.Search(ctx, []float32{4, 5, 6}, 10, model.Filter{})
+	if err != nil {
+		t.Fatalf("Search after reopen: %v", err)
+	}
+	if len(hits) != 1 || hits[0].ChunkID != 2 {
+		t.Fatalf("hits = %+v, want the post-recovery record for chunk 2", hits)
 	}
 }
 


### PR DESCRIPTION
## Problem

`DiskIndex.appendRecord` did `os.OpenFile` + write + **fsync** + close on *every*
call, and `EmbeddingWorker.indexChunks` calls `Index.Upsert` once per chunk in a
loop. Disk-backend ingest was therefore capped at the fsync rate — one durability
barrier per chunk. There was no batch path at all: `model.Index` has no batch
method.

Refs #429 F8.

## Approach

An **optional** capability, not a new required `model.Index` method — `memory`,
`qdrant` and `pgvector` are untouched:

```go
// internal/model/interfaces.go
type IndexUpsert struct {
    Vector  []float32
    Payload IndexPayload
}

type BatchUpserter interface {
    BatchUpsert(ctx context.Context, items []IndexUpsert) error
}
```

- `indexChunks` type-asserts the index against `model.BatchUpserter` (same
  pattern as `Persistable` / `FilteringIndex` / `LexicalSearcher`) and applies
  the whole embed batch in one call; anything else falls back to the existing
  per-chunk `Upsert` loop.
- Only `diskindex` implements it: **one** file open, **one** buffered write pass,
  **one** `Sync()` for the batch.
- The memory backend needs nothing — it has no fsync, and its `Upsert` is a plain
  in-RAM graph insert.

Measured locally (256 × 384-dim vectors, APFS/SSD): 1.36 s serial vs 12.5 ms
batched (~109×). The real win scales with `embed.batch_size`.

## Crash semantics (the trade-off, stated plainly)

**Durability granularity changes from per chunk to per batch.** Previously every
chunk was on stable storage by the time `Upsert` returned; now that is true only
per batch.

The invariant that actually matters is **unchanged**:

`BatchUpsert` returns only *after* its fsync, and the worker marks chunks
embedded in sqlite strictly *after* `indexChunks` returns. So a crash can never
leave the store claiming a chunk is embedded whose vector was lost. Everything a
crash can discard is a batch whose chunks are still `PENDING` — they are simply
re-embedded on the next run, and `Upsert` is last-writer-wins so the replay is
idempotent. This is also why the disk backend still (correctly) does not
implement `index.VectorPresence`; the comment there was updated to say "durable
before the write returns" rather than "individually durable".

**A failed batch is never half-applied.** On a write or fsync error the segment
is truncated back to its pre-batch length, and `d.locators` / `d.appendEnd` /
`d.version` are advanced only *after* the barrier succeeds — so in-memory state
and file agree either way. Item validation (empty vector, zero `chunk_id`) runs
before the file is touched at all.

**Partial-failure attribution is preserved.** A batch call returns one error and
cannot say *which* item failed, so on any batch error the worker replays the
items through the per-chunk `Upsert` loop. That reproduces the existing contract
exactly — partial `MarkEmbedded` for the chunks that landed, transient-vs-terminal
classification (#412), per-chunk `MarkFailedWithCategory` for the offender. The
replay is safe because the interface contract requires a failed batch to leave
the index replayable (diskindex rolls back; `Upsert` is idempotent regardless).

## One deliberate behavior change: torn-tail recovery on load

Batching leaves many more unsynced bytes in flight, so an ungraceful crash is
much more likely to leave a *partially written* record at the end of the segment.
`scanSegment` used to treat that as a hard error, which would make the daemon
exit with `exitIndexLoadFailure` and require a manual reindex.

`Load` now stops at the last **complete** record and truncates the torn tail. As
argued above, a torn tail can only contain records for chunks that were never
acknowledged to sqlite, so nothing the store believes is indexed is dropped —
whereas failing the load bricks a corpus after a crash that lost nothing.
A structurally wrong file (bad magic/version) is still a hard error
(`TestDiskIndex_LoadBadMagicErrors` is unchanged).

`TestDiskIndex_LoadTruncatedBodyErrors` is therefore replaced by
`TestDiskIndex_LoadTruncatedBodyRecovers`, which pins the new behavior *and*
that the recovered segment is still appendable and survives another reopen.

## Tests

`internal/index/diskindex/batch_upsert_test.go` (in-package — it hooks the new
unexported `syncFile` seam to count fsyncs):

- `TestBatchUpsert_OneFsyncPerBatch` — 50 vectors ⇒ **exactly 1** fsync via the
  batch path, **50** via the per-chunk loop, and both paths produce the same
  locator set and byte-identical segment size. **Verified failing when the change
  is reverted**: replacing `BatchUpsert`'s body with a loop over `appendRecord`
  yields `BatchUpsert of 50 vectors did 50 fsyncs, want exactly 1`.
- `TestBatchUpsert_LastWriterWinsWithinBatch` — a repeated chunk ID inside one
  batch resolves like a sequence of `Upsert`s.
- `TestBatchUpsert_ValidationRejectsBeforeAnyWrite` — a malformed item fails the
  batch without creating the segment.
- `TestBatchUpsert_RollsBackFailedBatch` — a failed barrier truncates back to the
  pre-batch size, leaves `appendEnd`/`version`/locators untouched, and the
  segment is still appendable + loadable afterwards.
- `TestLoad_RecoversTornTail` — torn tail dropped, later appends survive a reopen.

`tests/index/batch_upsert_worker_test.go` (worker level):

- `TestIndexChunks_UsesBatchUpsertWhenAvailable` — one `BatchUpsert` call with all
  chunks in task order, zero per-chunk `Upsert`s, payload fields intact,
  `OnIndexedChunk` still fired per chunk.
- `TestIndexChunks_FallsBackWithoutBatchUpsert` — a backend without the capability
  keeps the per-chunk path.
- `TestIndexChunks_BatchFailureReplaysPerChunk` — batch fails ⇒ replay attributes
  the failure to chunk 22: chunk 11 marked embedded, 22 marked failed *with* its
  category.
- `TestEmbedAndIndex_DiskBackendBatchesEndToEnd` — real disk backend through the
  worker; all vectors searchable after close + reload, i.e. the single per-batch
  fsync really persisted them.

## Gates

- `gofmt -l cmd internal tests` — nothing new (the three pre-existing offenders on
  `main` are untouched)
- `go vet ./...` ✅
- `gocyclo@v0.6.0 -over 15 cmd internal tests` — empty ✅
- `golangci-lint run` — 0 issues ✅
- `go test ./...` ✅
- `go test -race ./internal/index/... ./tests/index/...` ✅

## Notes / not in scope

- No spec change: SPEC §6.2 describes Tier B as a pure-Go memory-mapped index and
  makes no per-write fsync guarantee, so this is an implementation-level change.
- `DiskIndex.Delete` still fsyncs per tombstone; Qdrant/pgvector could implement
  `BatchUpserter` to save round-trips. Both are follow-ups, deliberately left out
  to keep this scoped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batch vector upsert support for faster indexing and improved write efficiency.
  * Preserved update ordering and last-write-wins behavior within batches.
  * Added automatic fallback to individual updates when batch processing is unavailable or fails.

* **Bug Fixes**
  * Disk indexes now recover safely from incomplete trailing records.
  * Failed batches are rolled back without exposing partial results.
  * Durable writes and callback ordering are preserved during batch indexing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->