### PR TITLE
perf(store): stop re-counting and re-globbing on every list_files page (#429 F10)

### DIFF
--- a/internal/store/list_files_cache.go
+++ b/internal/store/list_files_cache.go
@@ -1,0 +1,239 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"sync"
+)
+
+// listFilesCache memoizes the expensive part of ListFiles across the pages of a
+// single listing walk (#429 F10): the `SELECT COUNT(*)` that the glob-free path
+// used to run on every page, and the full rescan-and-reglob that the glob path
+// used to run on every page. Walking a corpus of N documents cost O(N) count
+// scans (and O(N) glob rescans) before this; it now costs one per walk.
+//
+// Exactness contract (the reason this is a version-guarded memo and not a TTL
+// cache): an entry is reused ONLY while SQLite's `PRAGMA data_version` is
+// unchanged on a pinned read connection. data_version changes whenever any OTHER
+// connection or process commits to the database, so an unchanged value means no
+// commit has landed since the entry was computed and the memoized total is still
+// literally exact, not merely recent. The first commit from ingest (or from any
+// other process) drops the whole cache and the next call recomputes from SQL.
+//
+// The probe MUST run on a connection that never writes: data_version is
+// explicitly documented NOT to change for commits made on the same connection,
+// and its values are only comparable within one connection. Hence the pinned
+// *sql.Conn taken from the query_only read pool. When there is no read pool, or
+// the probe errors, the cache is bypassed entirely and every call recomputes,
+// which is exactly the pre-#429-F10 behaviour.
+type listFilesCache struct {
+	mu sync.Mutex
+	// conn is pinned for the store's lifetime because data_version readings are
+	// only comparable when they come from the same connection. It costs one slot
+	// of the read pool (sqliteReadPoolSize), which is why the probe is a single
+	// pragma read and never anything heavier.
+	conn    *sql.Conn
+	version int64
+	primed  bool
+	entries map[string]listFilesCacheEntry
+}
+
+// listFilesCacheEntry is one memoized listing: the exact number of matching
+// documents plus, for the glob path, a sparse index of where each block of
+// stride matches starts, so a later page can resume mid-corpus instead of
+// re-globbing from the first row.
+type listFilesCacheEntry struct {
+	total  int64
+	stride int
+	bounds []string
+}
+
+const (
+	// listFilesCacheMaxEntries bounds the number of distinct (prefix, glob)
+	// listings memoized within one data_version epoch. Overflow clears the map
+	// rather than evicting an LRU victim: entries are cheap to recompute, epochs
+	// are short-lived during ingest, and a clear cannot return a wrong total.
+	listFilesCacheMaxEntries = 32
+
+	// globBoundsMinStride keeps the sparse glob index small on tiny page sizes:
+	// a caller paging one row at a time would otherwise record one boundary per
+	// matching document.
+	globBoundsMinStride = 256
+
+	// globBoundsMaxCount caps the sparse glob index. On overflow the stride
+	// doubles and every second boundary is dropped, so memory stays bounded no
+	// matter how large the corpus is; the only cost is a slightly longer forward
+	// scan between boundaries.
+	globBoundsMaxCount = 4096
+)
+
+// begin probes the database change counter and returns the epoch that lookup
+// and store must be called with. ok is false when the cache is unavailable; the
+// caller then computes everything from SQL and memoizes nothing.
+func (c *listFilesCache) begin(ctx context.Context, rdb *sql.DB) (epoch int64, ok bool) {
+	if rdb == nil {
+		return 0, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.conn == nil {
+		conn, err := rdb.Conn(ctx)
+		if err != nil {
+			return 0, false
+		}
+		c.conn = conn
+	}
+	return c.probeLocked(ctx)
+}
+
+// probeLocked reads data_version on the pinned connection and rolls the epoch
+// forward, dropping every memo when a commit has landed. c.mu must be held and
+// c.conn must be non-nil.
+func (c *listFilesCache) probeLocked(ctx context.Context) (int64, bool) {
+	var version int64
+	if err := c.conn.QueryRowContext(ctx, `PRAGMA data_version`).Scan(&version); err != nil {
+		// A broken probe connection must not disable the cache forever: drop it so
+		// the next call re-pins, and bypass the cache for this call.
+		_ = c.conn.Close()
+		c.conn = nil
+		c.entries = nil
+		c.primed = false
+		return 0, false
+	}
+	if !c.primed || version != c.version {
+		c.entries = nil
+		c.version = version
+		c.primed = true
+	}
+	return version, true
+}
+
+// lookup returns the memoized entry for key, if it was computed in the epoch
+// that is still current.
+func (c *listFilesCache) lookup(epoch int64, key string) (listFilesCacheEntry, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.primed || epoch != c.version {
+		return listFilesCacheEntry{}, false
+	}
+	entry, ok := c.entries[key]
+	return entry, ok
+}
+
+// store memoizes entry under key, but only if no commit has landed since the
+// begin that produced epoch. It re-probes to establish that rather than trusting
+// the last epoch seen, because the commit that matters here is one that raced
+// the caller's own computation: such an entry describes a newer database state
+// than epoch, and memoizing it under epoch could hand a concurrent caller a
+// total that does not match the rows it sees. Dropping it costs one recount.
+func (c *listFilesCache) store(ctx context.Context, epoch int64, key string, entry listFilesCacheEntry) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.primed || c.conn == nil {
+		return
+	}
+	current, ok := c.probeLocked(ctx)
+	if !ok || current != epoch {
+		return
+	}
+	if len(c.entries) >= listFilesCacheMaxEntries {
+		c.entries = nil
+	}
+	if c.entries == nil {
+		c.entries = make(map[string]listFilesCacheEntry, 4)
+	}
+	c.entries[key] = entry
+}
+
+// reset drops every memo and releases the pinned probe connection. It MUST run
+// before the handle that connection came from is closed, and it leaves the cache
+// usable again if the store is later reopened.
+func (c *listFilesCache) reset() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.conn != nil {
+		_ = c.conn.Close()
+		c.conn = nil
+	}
+	c.entries = nil
+	c.version = 0
+	c.primed = false
+}
+
+// startFor maps a page offset onto the nearest recorded boundary at or before
+// it: the returned rel_path is where the SQL scan may resume, and skip is how
+// many matches to discard after it before the page begins. An entry with no
+// boundaries (or a non-glob entry) degrades to scanning from the first row.
+func (e listFilesCacheEntry) startFor(offset int) (start string, skip int) {
+	if e.stride <= 0 || len(e.bounds) == 0 || offset <= 0 {
+		return "", offset
+	}
+	i := offset / e.stride
+	if i >= len(e.bounds) {
+		i = len(e.bounds) - 1
+	}
+	return e.bounds[i], offset - i*e.stride
+}
+
+// globBounds accumulates the sparse resume index described on
+// listFilesCacheEntry while a full glob scan runs.
+type globBounds struct {
+	stride   int
+	maxCount int
+	bounds   []string
+}
+
+// newGlobBounds sizes the stride to the caller's page size so that a sequential
+// walk lands exactly on recorded boundaries and skips nothing.
+func newGlobBounds(pageLimit int) *globBounds {
+	return &globBounds{stride: max(pageLimit, globBoundsMinStride), maxCount: globBoundsMaxCount}
+}
+
+// observe records relPath when it is the first match of a stride-sized block.
+// matchIndex is the 0-based position of the match within the filtered listing.
+func (b *globBounds) observe(matchIndex int64, relPath string) {
+	if matchIndex%int64(b.stride) != 0 {
+		return
+	}
+	b.bounds = append(b.bounds, relPath)
+	if len(b.bounds) >= b.maxCount {
+		b.compact()
+	}
+}
+
+// compact halves the index in place and doubles the stride, preserving the
+// invariant that bounds[i] is the match at index i*stride.
+func (b *globBounds) compact() {
+	kept := b.bounds[:0]
+	for i := 0; i < len(b.bounds); i += 2 {
+		kept = append(kept, b.bounds[i])
+	}
+	b.bounds = kept
+	b.stride *= 2
+}
+
+// entry freezes the accumulated index into a cache entry with the given total.
+func (b *globBounds) entry(total int64) listFilesCacheEntry {
+	return listFilesCacheEntry{total: total, stride: b.stride, bounds: b.bounds}
+}
+
+// GlobBoundsIndexForTest builds the sparse glob resume index over matches, with
+// the boundary cap lowered so the compaction path is reachable. It returns the
+// final stride, the boundaries, and the (start, skip) pair the index would hand
+// a page starting at probeOffset.
+//
+// Exported solely so the #429 F10 test can live under tests/ as AGENTS.md
+// requires: the invariant worth pinning is bounds[i] == matches[i*stride] after
+// any number of compactions, which production only reaches on corpora of
+// millions of matching documents. Production code never calls this.
+func GlobBoundsIndexForTest(pageLimit, maxCount, probeOffset int, matches []string) (stride int, bounds []string, start string, skip int) {
+	b := newGlobBounds(pageLimit)
+	b.maxCount = maxCount
+	for i, m := range matches {
+		b.observe(int64(i), m)
+	}
+	entry := b.entry(int64(len(matches)))
+	start, skip = entry.startFor(probeOffset)
+	return entry.stride, entry.bounds, start, skip
+}

--- a/internal/store/list_files_cache.go
+++ b/internal/store/list_files_cache.go
@@ -26,13 +26,21 @@ import (
 // *sql.Conn taken from the query_only read pool. When there is no read pool, or
 // the probe errors, the cache is bypassed entirely and every call recomputes,
 // which is exactly the pre-#429-F10 behaviour.
+//
+// Locking: probeMu owns the pinned connection and is the only lock ever held
+// across database I/O; mu guards the in-memory epoch and entries and is only
+// ever held for a few field assignments. The order is always probeMu then mu,
+// never the reverse. Keeping them separate means a cache lookup never waits
+// behind someone else's probe.
 type listFilesCache struct {
-	mu sync.Mutex
+	probeMu sync.Mutex
 	// conn is pinned for the store's lifetime because data_version readings are
-	// only comparable when they come from the same connection. It costs one slot
-	// of the read pool (sqliteReadPoolSize), which is why the probe is a single
-	// pragma read and never anything heavier.
-	conn    *sql.Conn
+	// only comparable when they come from the same connection. It belongs to the
+	// dedicated single-connection probe handle (SQLiteStore.vdb), so pinning it
+	// costs the read pool nothing.
+	conn *sql.Conn
+
+	mu      sync.Mutex
 	version int64
 	primed  bool
 	entries map[string]listFilesCacheEntry
@@ -70,43 +78,60 @@ const (
 // begin probes the database change counter and returns the epoch that lookup
 // and store must be called with. ok is false when the cache is unavailable; the
 // caller then computes everything from SQL and memoizes nothing.
-func (c *listFilesCache) begin(ctx context.Context, rdb *sql.DB) (epoch int64, ok bool) {
-	if rdb == nil {
+func (c *listFilesCache) begin(ctx context.Context, vdb *sql.DB) (epoch int64, ok bool) {
+	if vdb == nil {
 		return 0, false
 	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.probeMu.Lock()
+	defer c.probeMu.Unlock()
+	return c.probeLocked(ctx, vdb)
+}
 
+// probeLocked reads data_version on the pinned connection and rolls the epoch
+// forward, dropping every memo when a commit has landed. c.probeMu must be held,
+// which is also what keeps concurrent probes from applying their epochs out of
+// order (data_version values are only defined for equality comparison, so a
+// later reading cannot be recognized as newer).
+func (c *listFilesCache) probeLocked(ctx context.Context, vdb *sql.DB) (int64, bool) {
 	if c.conn == nil {
-		conn, err := rdb.Conn(ctx)
+		conn, err := vdb.Conn(ctx)
 		if err != nil {
 			return 0, false
 		}
 		c.conn = conn
 	}
-	return c.probeLocked(ctx)
-}
-
-// probeLocked reads data_version on the pinned connection and rolls the epoch
-// forward, dropping every memo when a commit has landed. c.mu must be held and
-// c.conn must be non-nil.
-func (c *listFilesCache) probeLocked(ctx context.Context) (int64, bool) {
 	var version int64
 	if err := c.conn.QueryRowContext(ctx, `PRAGMA data_version`).Scan(&version); err != nil {
 		// A broken probe connection must not disable the cache forever: drop it so
 		// the next call re-pins, and bypass the cache for this call.
 		_ = c.conn.Close()
 		c.conn = nil
-		c.entries = nil
-		c.primed = false
+		c.invalidate()
 		return 0, false
 	}
+	c.roll(version)
+	return version, true
+}
+
+// roll makes version the current epoch, dropping every memo when it differs
+// from the epoch they were computed in.
+func (c *listFilesCache) roll(version int64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	if !c.primed || version != c.version {
 		c.entries = nil
 		c.version = version
 		c.primed = true
 	}
-	return version, true
+}
+
+// invalidate drops every memo and un-primes the epoch, so nothing is reused
+// until a probe succeeds again.
+func (c *listFilesCache) invalidate() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries = nil
+	c.primed = false
 }
 
 // lookup returns the memoized entry for key, if it was computed in the epoch
@@ -127,14 +152,20 @@ func (c *listFilesCache) lookup(epoch int64, key string) (listFilesCacheEntry, b
 // the caller's own computation: such an entry describes a newer database state
 // than epoch, and memoizing it under epoch could hand a concurrent caller a
 // total that does not match the rows it sees. Dropping it costs one recount.
-func (c *listFilesCache) store(ctx context.Context, epoch int64, key string, entry listFilesCacheEntry) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if !c.primed || c.conn == nil {
+func (c *listFilesCache) store(ctx context.Context, vdb *sql.DB, epoch int64, key string, entry listFilesCacheEntry) {
+	if vdb == nil {
 		return
 	}
-	current, ok := c.probeLocked(ctx)
+	c.probeMu.Lock()
+	defer c.probeMu.Unlock()
+	current, ok := c.probeLocked(ctx, vdb)
 	if !ok || current != epoch {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.primed || c.version != epoch {
 		return
 	}
 	if len(c.entries) >= listFilesCacheMaxEntries {
@@ -150,12 +181,14 @@ func (c *listFilesCache) store(ctx context.Context, epoch int64, key string, ent
 // before the handle that connection came from is closed, and it leaves the cache
 // usable again if the store is later reopened.
 func (c *listFilesCache) reset() {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.probeMu.Lock()
+	defer c.probeMu.Unlock()
 	if c.conn != nil {
 		_ = c.conn.Close()
 		c.conn = nil
 	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.entries = nil
 	c.version = 0
 	c.primed = false

--- a/internal/store/list_files_cache.go
+++ b/internal/store/list_files_cache.go
@@ -22,10 +22,11 @@ import (
 //
 // The probe MUST run on a connection that never writes: data_version is
 // explicitly documented NOT to change for commits made on the same connection,
-// and its values are only comparable within one connection. Hence the pinned
-// *sql.Conn taken from the query_only read pool. When there is no read pool, or
-// the probe errors, the cache is bypassed entirely and every call recomputes,
-// which is exactly the pre-#429-F10 behaviour.
+// and its values are only comparable within one connection. Hence the *sql.Conn
+// pinned from SQLiteStore.vdb, the dedicated single-connection query_only handle
+// that exists for nothing else. When that handle is unavailable, or the probe
+// errors, the cache is bypassed entirely and every call recomputes, which is
+// exactly the pre-#429-F10 behaviour.
 //
 // Locking: probeMu owns the pinned connection and is the only lock ever held
 // across database I/O; mu guards the in-memory epoch and entries and is only

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -2254,6 +2254,18 @@ func (s *SQLiteStore) listFilesSQLPaged(
 	probe := s.versionProbeDB()
 	epoch, cacheable := s.listCache.begin(ctx, probe)
 
+	key := "prefix\x00" + normalizedPrefix
+	var memo listFilesCacheEntry
+	memoized := false
+	if cacheable {
+		memo, memoized = s.listCache.lookup(epoch, key)
+	}
+	if memoized && int64(offset) >= memo.total {
+		// The memo proves the listing ends before this offset, so the page query
+		// would only make SQLite walk rows to discard them all.
+		return []model.Document{}, memo.total, nil
+	}
+
 	query := selectCols + whereClause + " ORDER BY rel_path LIMIT ? OFFSET ?"
 	args := append(append([]any{}, prefixArgs...), limit, offset)
 
@@ -2275,11 +2287,8 @@ func (s *SQLiteStore) listFilesSQLPaged(
 		return nil, 0, err
 	}
 
-	key := "prefix\x00" + normalizedPrefix
-	if cacheable {
-		if entry, ok := s.listCache.lookup(epoch, key); ok {
-			return docs, entry.total, nil
-		}
+	if memoized {
+		return docs, memo.total, nil
 	}
 
 	total, exact := derivedListTotal(len(docs), limit, offset)
@@ -2351,6 +2360,11 @@ func (s *SQLiteStore) listFilesGlobPaged(
 	epoch, cacheable := s.listCache.begin(ctx, probe)
 	if cacheable {
 		if entry, ok := s.listCache.lookup(epoch, key); ok {
+			if int64(offset) >= entry.total {
+				// The memo proves the listing ends before this offset, so scanning
+				// would only re-glob rows to discard them all.
+				return []model.Document{}, entry.total, nil
+			}
 			start, skip := entry.startFor(offset)
 			docs, err := s.scanGlobPage(ctx, db, selectCols, whereClause, prefixArgs, matcher, start, skip, limit)
 			if err != nil {

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	_ "modernc.org/sqlite"
@@ -32,10 +33,70 @@ type SQLiteStore struct {
 	// run concurrently with an in-flight write instead of queueing behind it.
 	// Nil until initLocked succeeds, and nil-safe: readDB falls back to db.
 	rdb *sql.DB
+	// vdb is a one-connection READ-ONLY handle used for nothing but the
+	// `PRAGMA data_version` probe that guards the ListFiles memo (#429 F10). It is
+	// deliberately separate from rdb: the probe pins its connection for the
+	// store's lifetime (data_version readings are only comparable within one
+	// connection), and pinning a slot of the shared read pool would both shrink
+	// read concurrency and put the probe behind whatever scans are in flight.
+	// Nil when it failed to open, which simply disables the memo.
+	vdb *sql.DB
+
+	// listCache memoizes the ListFiles total (and the glob resume index) for as
+	// long as no writer commits (#429 F10). It has its own lock and must never be
+	// held while mu is held.
+	listCache listFilesCache
+	// Counters behind ListFilesQueryStatsForTest; see that method.
+	listCountQueries  atomic.Int64
+	listGlobFullScans atomic.Int64
+	listGlobPageScans atomic.Int64
 
 	activeOps int
 	closing   bool
 	cond      *sync.Cond
+}
+
+// ListFilesQueryStats counts the database work ListFiles has done since the
+// store was opened. See ListFilesQueryStatsForTest.
+type ListFilesQueryStats struct {
+	// CountQueries is the number of `SELECT COUNT(*)` statements executed for a
+	// ListFiles total.
+	CountQueries int64
+	// GlobFullScans is the number of times the glob path scanned and re-globbed
+	// every prefix-matched row.
+	GlobFullScans int64
+	// GlobPageScans is the number of times the glob path materialized a page by
+	// resuming from a recorded boundary instead of rescanning from the start.
+	GlobPageScans int64
+}
+
+// ListFilesQueryStatsForTest reports the ListFiles query counters.
+//
+// Exported solely so the #429 F10 regression test can live under tests/ as
+// AGENTS.md requires: the property worth pinning is that paging through a corpus
+// stops re-running the COUNT and the full glob rescan per page, and the number
+// of statements a query path issues is not observable through the ordinary store
+// API. Production code never calls this.
+func (s *SQLiteStore) ListFilesQueryStatsForTest() ListFilesQueryStats {
+	return ListFilesQueryStats{
+		CountQueries:  s.listCountQueries.Load(),
+		GlobFullScans: s.listGlobFullScans.Load(),
+		GlobPageScans: s.listGlobPageScans.Load(),
+	}
+}
+
+// versionProbeDB returns the dedicated data_version handle, or nil when it
+// failed to open (in which case the ListFiles memo is bypassed and every call
+// recounts). The probe must never run on the writer handle: data_version by
+// definition does NOT change for commits made on the same connection, so a
+// probe there would miss this store's own ingest writes.
+//
+// Callers must already hold an activeOps reference (i.e. have called ensureDB or
+// ensureReadDB) so the returned handle cannot be closed underneath them.
+func (s *SQLiteStore) versionProbeDB() *sql.DB {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.vdb
 }
 
 type MCPSessionRecord struct {
@@ -487,6 +548,24 @@ func openReadDB(path string) (*sql.DB, error) {
 	return db, nil
 }
 
+// openVersionProbeDB opens the single-connection read-only handle that carries
+// the `PRAGMA data_version` probe (#429 F10). Like openReadDB it MUST run only
+// after openDB has passed the #405 tripwire and switched the file to WAL.
+//
+// One connection is the point: the probe pins it so successive data_version
+// readings are comparable (they are meaningless across connections), and keeping
+// it out of the shared read pool means the probe never queues behind a scan and
+// never costs the pool a slot.
+func openVersionProbeDB(path string) (*sql.DB, error) {
+	db, err := sql.Open("sqlite", sqliteReadOnlyDSN(path))
+	if err != nil {
+		return nil, err
+	}
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	return db, nil
+}
+
 // sqliteReadPoolSize bounds concurrent readers. Small on purpose: these are
 // short point lookups and paged scans, and every open connection costs a file
 // descriptor and its own page cache.
@@ -867,6 +946,11 @@ CREATE INDEX IF NOT EXISTS idx_mcp_nonce_ledger_expires ON mcp_nonce_ledger(expi
 	// refusing to start (#429 F11).
 	if rdb, rerr := openReadDB(s.path); rerr == nil {
 		s.rdb = rdb
+	}
+	// Same deal for the data_version probe handle (#429 F10): a failure here just
+	// disables the ListFiles memo, it never blocks startup.
+	if vdb, verr := openVersionProbeDB(s.path); verr == nil {
+		s.vdb = vdb
 	}
 	return nil
 }
@@ -2122,7 +2206,7 @@ func (s *SQLiteStore) ListFiles(ctx context.Context, prefix, glob string, limit,
 	// evaluate it in Go over the prefix-matched rows and paginate in Go. Without a
 	// glob the query keeps its efficient SQL LIMIT/OFFSET pagination unchanged.
 	if trimmedGlob == "" {
-		return s.listFilesSQLPaged(ctx, db, selectCols, whereClause, prefixArgs, limit, offset)
+		return s.listFilesSQLPaged(ctx, db, selectCols, whereClause, prefixArgs, normalizedPrefix, limit, offset)
 	}
 
 	matcher, err := model.CompileGlob(trimmedGlob)
@@ -2132,46 +2216,43 @@ func (s *SQLiteStore) ListFiles(ctx context.Context, prefix, glob string, limit,
 		return []model.Document{}, 0, nil
 	}
 
-	query := selectCols + whereClause + " ORDER BY rel_path"
-	rows, err := db.QueryContext(ctx, query, prefixArgs...)
-	if err != nil {
-		return nil, 0, err
-	}
-	defer func() { _ = rows.Close() }()
-
-	matched := make([]model.Document, 0, limit)
-	var total int64
-	for rows.Next() {
-		doc, scanErr := scanListFilesRow(rows)
-		if scanErr != nil {
-			return nil, 0, scanErr
-		}
-		if !matcher.Match(doc.RelPath) {
-			continue
-		}
-		total++
-		// Only materialize the requested page; earlier rows advance offset and
-		// later rows only bump the total count.
-		if int64(offset) < total && int64(len(matched)) < int64(limit) {
-			matched = append(matched, doc)
-		}
-	}
-	if err := rows.Err(); err != nil {
-		return nil, 0, err
-	}
-
-	return matched, total, nil
+	// The cache key is the full filter: whereClause/prefixArgs are a pure
+	// function of normalizedPrefix, so prefix plus glob identifies the listing.
+	key := "glob\x00" + normalizedPrefix + "\x00" + trimmedGlob
+	return s.listFilesGlobPaged(ctx, db, selectCols, whereClause, prefixArgs, matcher, key, limit, offset)
 }
 
 // listFilesSQLPaged runs the glob-free ListFiles path: prefix filtering plus
-// SQL-side ORDER BY / LIMIT / OFFSET pagination and a matching COUNT.
+// SQL-side ORDER BY / LIMIT / OFFSET pagination and a matching total.
+//
+// The total is obtained, in order of cost:
+//  1. from the page itself when the page came back short (that proves where the
+//     result set ends, so no COUNT is needed);
+//  2. from the memo, while no commit has landed since it was computed (see
+//     listFilesCache: the guard is SQLite's own data_version, so a reused total
+//     is a count of exactly the corpus the caller is looking at, not a stale
+//     count of an older one);
+//  3. from `SELECT COUNT(*)`, as before.
+//
+// Before #429 F10 step 3 ran on every page, so walking N documents cost O(N)
+// full count scans.
+//
+// Exactness is unchanged by the memo: the total is exact as of a database state
+// observed during this call. Ingest committing between the page query and the
+// total can still make the two describe adjacent states, exactly as it could
+// when every page ran its own COUNT after its own page query.
 func (s *SQLiteStore) listFilesSQLPaged(
 	ctx context.Context,
 	db *sql.DB,
 	selectCols, whereClause string,
 	prefixArgs []any,
+	normalizedPrefix string,
 	limit, offset int,
 ) ([]model.Document, int64, error) {
+	// Probe before the page query so a memo hit is pinned to a state no newer
+	// than the rows it is returned with.
+	epoch, cacheable := s.listCache.begin(ctx, s.versionProbeDB())
+
 	query := selectCols + whereClause + " ORDER BY rel_path LIMIT ? OFFSET ?"
 	args := append(append([]any{}, prefixArgs...), limit, offset)
 
@@ -2193,13 +2274,194 @@ func (s *SQLiteStore) listFilesSQLPaged(
 		return nil, 0, err
 	}
 
+	key := "prefix\x00" + normalizedPrefix
+	if cacheable {
+		if entry, ok := s.listCache.lookup(epoch, key); ok {
+			return docs, entry.total, nil
+		}
+	}
+
+	total, exact := derivedListTotal(len(docs), limit, offset)
+	if !exact {
+		total, err = s.countListFiles(ctx, db, whereClause, prefixArgs)
+		if err != nil {
+			return nil, 0, err
+		}
+	}
+	if cacheable {
+		s.listCache.store(ctx, epoch, key, listFilesCacheEntry{total: total})
+	}
+	return docs, total, nil
+}
+
+// derivedListTotal reports the total a page proves on its own. A page that came
+// back with fewer rows than the limit ended the result set, so the total is
+// exactly offset+len(page) and no COUNT is needed. A full page may or may not
+// have more rows behind it, and an empty page at a non-zero offset proves
+// nothing (the offset may simply be past the end); both report false.
+func derivedListTotal(pageLen, limit, offset int) (int64, bool) {
+	if pageLen >= limit {
+		return 0, false
+	}
+	if pageLen == 0 && offset > 0 {
+		return 0, false
+	}
+	return int64(offset + pageLen), true
+}
+
+// countListFiles runs the exact COUNT(*) for a ListFiles filter.
+func (s *SQLiteStore) countListFiles(
+	ctx context.Context,
+	db *sql.DB,
+	whereClause string,
+	prefixArgs []any,
+) (int64, error) {
+	s.listCountQueries.Add(1)
 	var total int64
 	countQuery := "SELECT COUNT(*) FROM documents" + whereClause
 	if err := db.QueryRowContext(ctx, countQuery, prefixArgs...).Scan(&total); err != nil {
-		return nil, 0, err
+		return 0, err
+	}
+	return total, nil
+}
+
+// listFilesGlobPaged runs the glob ListFiles path. The glob is evaluated in Go
+// (SQLite GLOB cannot express the canonical segment-aware/`**` semantics), so a
+// page cannot be expressed as SQL LIMIT/OFFSET.
+//
+// Before #429 F10 that meant every page rescanned and re-globbed every
+// prefix-matched row, making a walk quadratic. Now the first page's scan also
+// records the exact total and a sparse resume index, and later pages of the same
+// listing resume from the nearest recorded boundary and stop as soon as the page
+// is full. The memo (total and index alike) is dropped by the first commit from
+// any writer, so a resumed page is over exactly the rows the full scan saw and
+// the total is a count of that same corpus; see listFilesCache for the full
+// exactness contract.
+func (s *SQLiteStore) listFilesGlobPaged(
+	ctx context.Context,
+	db *sql.DB,
+	selectCols, whereClause string,
+	prefixArgs []any,
+	matcher *model.CompiledGlob,
+	key string,
+	limit, offset int,
+) ([]model.Document, int64, error) {
+	epoch, cacheable := s.listCache.begin(ctx, s.versionProbeDB())
+	if cacheable {
+		if entry, ok := s.listCache.lookup(epoch, key); ok {
+			start, skip := entry.startFor(offset)
+			docs, err := s.scanGlobPage(ctx, db, selectCols, whereClause, prefixArgs, matcher, start, skip, limit)
+			if err != nil {
+				return nil, 0, err
+			}
+			return docs, entry.total, nil
+		}
 	}
 
-	return docs, total, nil
+	docs, entry, err := s.scanGlobAll(ctx, db, selectCols, whereClause, prefixArgs, matcher, limit, offset)
+	if err != nil {
+		return nil, 0, err
+	}
+	if cacheable {
+		s.listCache.store(ctx, epoch, key, entry)
+	}
+	return docs, entry.total, nil
+}
+
+// scanGlobAll walks every prefix-matched row once, returning the requested page
+// plus the cache entry (exact total + sparse resume index) for the listing.
+func (s *SQLiteStore) scanGlobAll(
+	ctx context.Context,
+	db *sql.DB,
+	selectCols, whereClause string,
+	prefixArgs []any,
+	matcher *model.CompiledGlob,
+	limit, offset int,
+) ([]model.Document, listFilesCacheEntry, error) {
+	s.listGlobFullScans.Add(1)
+
+	query := selectCols + whereClause + " ORDER BY rel_path"
+	rows, err := db.QueryContext(ctx, query, prefixArgs...)
+	if err != nil {
+		return nil, listFilesCacheEntry{}, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	bounds := newGlobBounds(limit)
+	matched := make([]model.Document, 0, limit)
+	var total int64
+	for rows.Next() {
+		doc, scanErr := scanListFilesRow(rows)
+		if scanErr != nil {
+			return nil, listFilesCacheEntry{}, scanErr
+		}
+		if !matcher.Match(doc.RelPath) {
+			continue
+		}
+		bounds.observe(total, doc.RelPath)
+		// Only materialize the requested page; earlier rows advance offset and
+		// later rows only bump the total count.
+		if int64(offset) <= total && len(matched) < limit {
+			matched = append(matched, doc)
+		}
+		total++
+	}
+	if err := rows.Err(); err != nil {
+		return nil, listFilesCacheEntry{}, err
+	}
+	return matched, bounds.entry(total), nil
+}
+
+// scanGlobPage materializes one page of an already-counted glob listing: it
+// resumes at start (a boundary recorded by scanGlobAll), discards skip further
+// matches, and stops the moment the page is full.
+func (s *SQLiteStore) scanGlobPage(
+	ctx context.Context,
+	db *sql.DB,
+	selectCols, whereClause string,
+	prefixArgs []any,
+	matcher *model.CompiledGlob,
+	start string,
+	skip, limit int,
+) ([]model.Document, error) {
+	s.listGlobPageScans.Add(1)
+
+	query := selectCols + whereClause
+	args := append([]any{}, prefixArgs...)
+	if start != "" {
+		query += ` AND rel_path >= ?`
+		args = append(args, start)
+	}
+	query += " ORDER BY rel_path"
+
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	matched := make([]model.Document, 0, limit)
+	for rows.Next() {
+		doc, scanErr := scanListFilesRow(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		if !matcher.Match(doc.RelPath) {
+			continue
+		}
+		if skip > 0 {
+			skip--
+			continue
+		}
+		matched = append(matched, doc)
+		if len(matched) >= limit {
+			break
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return matched, nil
 }
 
 // scanListFilesRow scans one documents row into a model.Document for ListFiles.
@@ -3190,12 +3452,18 @@ func (s *SQLiteStore) Close() error {
 	s.closing = true
 	db := s.db
 	rdb := s.rdb
+	vdb := s.vdb
 	s.db = nil
 	s.rdb = nil
+	s.vdb = nil
 	for s.activeOps > 0 {
 		s.cond.Wait()
 	}
 	s.mu.Unlock()
+
+	// Release the pinned data_version probe connection BEFORE closing the handle
+	// it came from, and drop every memo so a reopened store starts clean.
+	s.listCache.reset()
 
 	err := db.Close()
 	if rdb != nil {
@@ -3203,6 +3471,11 @@ func (s *SQLiteStore) Close() error {
 		// failure can indicate unflushed work.
 		if rerr := rdb.Close(); err == nil {
 			err = rerr
+		}
+	}
+	if vdb != nil {
+		if verr := vdb.Close(); err == nil {
+			err = verr
 		}
 	}
 

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -2251,7 +2251,8 @@ func (s *SQLiteStore) listFilesSQLPaged(
 ) ([]model.Document, int64, error) {
 	// Probe before the page query so a memo hit is pinned to a state no newer
 	// than the rows it is returned with.
-	epoch, cacheable := s.listCache.begin(ctx, s.versionProbeDB())
+	probe := s.versionProbeDB()
+	epoch, cacheable := s.listCache.begin(ctx, probe)
 
 	query := selectCols + whereClause + " ORDER BY rel_path LIMIT ? OFFSET ?"
 	args := append(append([]any{}, prefixArgs...), limit, offset)
@@ -2289,7 +2290,7 @@ func (s *SQLiteStore) listFilesSQLPaged(
 		}
 	}
 	if cacheable {
-		s.listCache.store(ctx, epoch, key, listFilesCacheEntry{total: total})
+		s.listCache.store(ctx, probe, epoch, key, listFilesCacheEntry{total: total})
 	}
 	return docs, total, nil
 }
@@ -2346,7 +2347,8 @@ func (s *SQLiteStore) listFilesGlobPaged(
 	key string,
 	limit, offset int,
 ) ([]model.Document, int64, error) {
-	epoch, cacheable := s.listCache.begin(ctx, s.versionProbeDB())
+	probe := s.versionProbeDB()
+	epoch, cacheable := s.listCache.begin(ctx, probe)
 	if cacheable {
 		if entry, ok := s.listCache.lookup(epoch, key); ok {
 			start, skip := entry.startFor(offset)
@@ -2363,7 +2365,7 @@ func (s *SQLiteStore) listFilesGlobPaged(
 		return nil, 0, err
 	}
 	if cacheable {
-		s.listCache.store(ctx, epoch, key, entry)
+		s.listCache.store(ctx, probe, epoch, key, entry)
 	}
 	return docs, entry.total, nil
 }

--- a/tests/store/list_files_paging_429_test.go
+++ b/tests/store/list_files_paging_429_test.go
@@ -1,0 +1,315 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// #429 F10: ListFiles used to run a `SELECT COUNT(*)` on EVERY page of the
+// glob-free path, and to rescan plus re-glob every matching row on EVERY page of
+// the glob path. Walking a corpus therefore cost O(files) count scans and
+// O(files) glob rescans. These tests pin the reduction and, just as importantly,
+// pin that the total ListFiles returns stays exact while it does.
+
+// seedListFilesCorpus writes n documents, alternating between a docs/*.md file
+// (which the tests' glob matches) and a src/*.go file (which it does not), and
+// returns the rel_paths in rel_path order.
+func seedListFilesCorpus(t *testing.T, st *store.SQLiteStore, n int) (all, markdown []string) {
+	t.Helper()
+	ctx := context.Background()
+	for i := range n {
+		rel := fmt.Sprintf("src/f%05d.go", i)
+		if i%2 == 0 {
+			rel = fmt.Sprintf("docs/f%05d.md", i)
+		}
+		if err := st.UpsertDocument(ctx, model.Document{RelPath: rel, DocType: "text", Status: "ok"}); err != nil {
+			t.Fatalf("upsert %q: %v", rel, err)
+		}
+	}
+	// rel_path order: every docs/ path sorts before every src/ path, and the
+	// zero-padded counter keeps each group in numeric order.
+	for i := 0; i < n; i += 2 {
+		markdown = append(markdown, fmt.Sprintf("docs/f%05d.md", i))
+	}
+	all = append(all, markdown...)
+	for i := 1; i < n; i += 2 {
+		all = append(all, fmt.Sprintf("src/f%05d.go", i))
+	}
+	return all, markdown
+}
+
+func relPaths(docs []model.Document) []string {
+	out := make([]string, 0, len(docs))
+	for _, d := range docs {
+		out = append(out, d.RelPath)
+	}
+	return out
+}
+
+func assertSameOrder(t *testing.T, got, want []string, what string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("%s: got %d paths, want %d", what, len(got), len(want))
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("%s: path %d = %q, want %q", what, i, got[i], want[i])
+		}
+	}
+}
+
+// walkListFiles pages through ListFiles exactly the way the ingest, MCP and CLI
+// callers do, asserting the total is the same exact value on every page.
+func walkListFiles(t *testing.T, st *store.SQLiteStore, glob string, pageSize int, wantTotal int64) []string {
+	t.Helper()
+	ctx := context.Background()
+	var got []string
+	for offset := 0; ; offset += pageSize {
+		docs, total, err := st.ListFiles(ctx, "", glob, pageSize, offset)
+		if err != nil {
+			t.Fatalf("ListFiles(offset=%d): %v", offset, err)
+		}
+		if total != wantTotal {
+			t.Fatalf("ListFiles(offset=%d): total = %d, want %d", offset, total, wantTotal)
+		}
+		got = append(got, relPaths(docs)...)
+		if len(docs) < pageSize {
+			break
+		}
+	}
+	return got
+}
+
+// TestListFiles_PagedWalkDoesNotRecountPerPage is the glob-free half of #429
+// F10. Reverting the memo makes CountQueries equal the number of pages.
+func TestListFiles_PagedWalkDoesNotRecountPerPage(t *testing.T) {
+	st := newTestStore(t)
+	all, _ := seedListFilesCorpus(t, st, 50)
+
+	const pageSize = 10
+	got := walkListFiles(t, st, "", pageSize, int64(len(all)))
+	assertSameOrder(t, got, all, "paged walk")
+
+	stats := st.ListFilesQueryStatsForTest()
+	if stats.CountQueries > 1 {
+		t.Errorf(
+			"walking %d documents in pages of %d ran %d COUNT(*) queries, want at most 1 (#429 F10: it used to be one per page)",
+			len(all), pageSize, stats.CountQueries,
+		)
+	}
+}
+
+// TestListFiles_GlobPagedWalkDoesNotRescanPerPage is the glob half of #429 F10.
+// Reverting the change makes GlobFullScans equal the number of pages.
+func TestListFiles_GlobPagedWalkDoesNotRescanPerPage(t *testing.T) {
+	st := newTestStore(t)
+	_, markdown := seedListFilesCorpus(t, st, 50)
+
+	const pageSize = 10
+	got := walkListFiles(t, st, "docs/*.md", pageSize, int64(len(markdown)))
+	assertSameOrder(t, got, markdown, "paged glob walk")
+
+	stats := st.ListFilesQueryStatsForTest()
+	if stats.GlobFullScans != 1 {
+		t.Errorf(
+			"walking %d matches in pages of %d ran %d full glob scans, want exactly 1 (#429 F10: it used to be one per page)",
+			len(markdown), pageSize, stats.GlobFullScans,
+		)
+	}
+	if stats.GlobPageScans == 0 {
+		t.Errorf("no page resumed from a recorded boundary; the memo was never used")
+	}
+}
+
+// TestListFiles_GlobPagesMatchUnpagedListing pins that resuming from a recorded
+// boundary returns the same rows the old full-rescan-per-page code did, for
+// offsets that are NOT multiples of the boundary stride as well as those that
+// are, and for offsets past the end.
+func TestListFiles_GlobPagesMatchUnpagedListing(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+	_, markdown := seedListFilesCorpus(t, st, 1200)
+	total := int64(len(markdown))
+
+	// Prime the memo (and its boundary index) with a first page.
+	if _, got, err := listFilesPage(ctx, st, "docs/*.md", 100, 0); err != nil {
+		t.Fatalf("prime: %v", err)
+	} else if got != total {
+		t.Fatalf("prime: total = %d, want %d", got, total)
+	}
+
+	for _, tc := range []struct{ offset, limit int }{
+		{0, 100},
+		{1, 100},
+		{99, 7},
+		{100, 100},
+		{255, 100},
+		{256, 100},
+		{257, 3},
+		{300, 100},
+		{599, 1},
+		{len(markdown) - 1, 100},
+		{len(markdown), 100},
+		{len(markdown) + 500, 100},
+	} {
+		docs, got, err := listFilesPage(ctx, st, "docs/*.md", tc.limit, tc.offset)
+		if err != nil {
+			t.Fatalf("ListFiles(limit=%d offset=%d): %v", tc.limit, tc.offset, err)
+		}
+		if got != total {
+			t.Errorf("ListFiles(limit=%d offset=%d): total = %d, want %d", tc.limit, tc.offset, got, total)
+		}
+		want := markdown[min(tc.offset, len(markdown)):]
+		if len(want) > tc.limit {
+			want = want[:tc.limit]
+		}
+		assertSameOrder(t, relPaths(docs), want, fmt.Sprintf("page(limit=%d offset=%d)", tc.limit, tc.offset))
+	}
+}
+
+// listFilesPage is ListFiles with no path prefix, so the tests read as one call
+// site for both the glob-free and the glob filter.
+func listFilesPage(ctx context.Context, st *store.SQLiteStore, glob string, limit, offset int) ([]model.Document, int64, error) {
+	return st.ListFiles(ctx, "", glob, limit, offset)
+}
+
+// TestListFiles_TotalFollowsWrites is the correctness guard on the memo. The
+// total is memoized only while SQLite's data_version is unchanged, so the first
+// commit from the writer must be reflected immediately: a stale total here would
+// be worse than the per-page COUNT the memo replaces.
+func TestListFiles_TotalFollowsWrites(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+	all, markdown := seedListFilesCorpus(t, st, 30)
+
+	if _, total, err := listFilesPage(ctx, st, "", 10, 0); err != nil {
+		t.Fatalf("first page: %v", err)
+	} else if total != int64(len(all)) {
+		t.Fatalf("first page: total = %d, want %d", total, len(all))
+	}
+	if _, total, err := listFilesPage(ctx, st, "docs/*.md", 10, 0); err != nil {
+		t.Fatalf("first glob page: %v", err)
+	} else if total != int64(len(markdown)) {
+		t.Fatalf("first glob page: total = %d, want %d", total, len(markdown))
+	}
+
+	if err := st.UpsertDocument(ctx, model.Document{RelPath: "docs/zz-new.md", DocType: "text", Status: "ok"}); err != nil {
+		t.Fatalf("upsert new document: %v", err)
+	}
+
+	if _, total, err := listFilesPage(ctx, st, "", 10, 0); err != nil {
+		t.Fatalf("page after insert: %v", err)
+	} else if total != int64(len(all)+1) {
+		t.Errorf("page after insert: total = %d, want %d (memo outlived a commit)", total, len(all)+1)
+	}
+	if _, total, err := listFilesPage(ctx, st, "docs/*.md", 10, 0); err != nil {
+		t.Fatalf("glob page after insert: %v", err)
+	} else if total != int64(len(markdown)+1) {
+		t.Errorf("glob page after insert: total = %d, want %d (memo outlived a commit)", total, len(markdown)+1)
+	}
+
+	// A tombstone drops the document from the listing the same way.
+	if err := st.MarkDocumentDeleted(ctx, "docs/zz-new.md"); err != nil {
+		t.Fatalf("mark deleted: %v", err)
+	}
+	if _, total, err := listFilesPage(ctx, st, "", 10, 0); err != nil {
+		t.Fatalf("page after delete: %v", err)
+	} else if total != int64(len(all)) {
+		t.Errorf("page after delete: total = %d, want %d (memo outlived a commit)", total, len(all))
+	}
+	if _, total, err := listFilesPage(ctx, st, "docs/*.md", 10, 0); err != nil {
+		t.Fatalf("glob page after delete: %v", err)
+	} else if total != int64(len(markdown)) {
+		t.Errorf("glob page after delete: total = %d, want %d (memo outlived a commit)", total, len(markdown))
+	}
+}
+
+// TestListFiles_TotalExactWithoutCount pins the second half of the reduction:
+// a page that comes back shorter than its limit proves where the result set
+// ends, so no COUNT is needed at all. An EMPTY page past the end proves nothing,
+// and must still report the real total rather than the offset it was asked for.
+func TestListFiles_TotalExactWithoutCount(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+	all, _ := seedListFilesCorpus(t, st, 7)
+
+	docs, total, err := listFilesPage(ctx, st, "", 100, 0)
+	if err != nil {
+		t.Fatalf("single page: %v", err)
+	}
+	if total != int64(len(all)) {
+		t.Fatalf("single page: total = %d, want %d", total, len(all))
+	}
+	assertSameOrder(t, relPaths(docs), all, "single page")
+	if stats := st.ListFilesQueryStatsForTest(); stats.CountQueries != 0 {
+		t.Errorf("a page shorter than its limit ran %d COUNT(*) queries, want 0", stats.CountQueries)
+	}
+
+	// Fresh store so this exercises the uncached path: an offset past the end
+	// must not report the offset as the total.
+	other := newTestStore(t)
+	seedListFilesCorpus(t, other, 7)
+	docs, total, err = listFilesPage(ctx, other, "", 10, 1000)
+	if err != nil {
+		t.Fatalf("past-the-end page: %v", err)
+	}
+	if len(docs) != 0 {
+		t.Errorf("past-the-end page returned %d documents, want 0", len(docs))
+	}
+	if total != int64(len(all)) {
+		t.Errorf("past-the-end page: total = %d, want %d", total, len(all))
+	}
+}
+
+// TestGlobBoundsIndex_SurvivesCompaction pins the invariant the glob resume path
+// depends on: bounds[i] is always the match at index i*stride, including after
+// the index has been compacted (which halves it and doubles the stride). In
+// production the cap is 4096 boundaries, i.e. corpora of millions of matching
+// documents, so the cap is lowered here through the test seam.
+func TestGlobBoundsIndex_SurvivesCompaction(t *testing.T) {
+	matches := make([]string, 5000)
+	for i := range matches {
+		matches[i] = fmt.Sprintf("docs/f%05d.md", i)
+	}
+
+	for _, probeOffset := range []int{0, 1, 255, 256, 999, 4999, 6000} {
+		stride, bounds, start, skip := store.GlobBoundsIndexForTest(1, 8, probeOffset, matches)
+		if stride <= 0 {
+			t.Fatalf("stride = %d, want > 0", stride)
+		}
+		if len(bounds) > 8 {
+			t.Fatalf("bounds = %d entries, want at most the cap of 8", len(bounds))
+		}
+		for i, b := range bounds {
+			if want := matches[i*stride]; b != want {
+				t.Fatalf("bounds[%d] = %q, want %q (stride=%d)", i, b, want, stride)
+			}
+		}
+		// Resuming at start and discarding skip matches must land exactly on the
+		// requested offset, which is what makes a resumed page identical to a
+		// full rescan.
+		if start == "" {
+			if skip != probeOffset {
+				t.Fatalf("no boundary for offset %d: skip = %d, want %d", probeOffset, skip, probeOffset)
+			}
+			continue
+		}
+		idx := -1
+		for i, m := range matches {
+			if m == start {
+				idx = i
+				break
+			}
+		}
+		if idx < 0 {
+			t.Fatalf("boundary %q is not a match", start)
+		}
+		if idx+skip != probeOffset {
+			t.Fatalf("resume for offset %d lands on %d (start index %d + skip %d)", probeOffset, idx+skip, idx, skip)
+		}
+	}
+}

--- a/tests/store/list_files_paging_429_test.go
+++ b/tests/store/list_files_paging_429_test.go
@@ -169,6 +169,17 @@ func TestListFiles_GlobPagesMatchUnpagedListing(t *testing.T) {
 		}
 		assertSameOrder(t, relPaths(docs), want, fmt.Sprintf("page(limit=%d offset=%d)", tc.limit, tc.offset))
 	}
+
+	// An offset the memo already proves is past the end must not scan at all.
+	before := st.ListFilesQueryStatsForTest()
+	if _, total, err := listFilesPage(ctx, st, "docs/*.md", 100, len(markdown)+1000); err != nil {
+		t.Fatalf("far past-the-end page: %v", err)
+	} else if total != int64(len(markdown)) {
+		t.Errorf("far past-the-end page: total = %d, want %d", total, len(markdown))
+	}
+	if after := st.ListFilesQueryStatsForTest(); after != before {
+		t.Errorf("a page the memo proves is past the end still queried: %+v -> %+v", before, after)
+	}
 }
 
 // listFilesPage is ListFiles with no path prefix, so the tests read as one call
@@ -252,7 +263,7 @@ func TestListFiles_TotalExactWithoutCount(t *testing.T) {
 	// Fresh store so this exercises the uncached path: an offset past the end
 	// must not report the offset as the total.
 	other := newTestStore(t)
-	seedListFilesCorpus(t, other, 7)
+	otherAll, _ := seedListFilesCorpus(t, other, 9)
 	docs, total, err = listFilesPage(ctx, other, "", 10, 1000)
 	if err != nil {
 		t.Fatalf("past-the-end page: %v", err)
@@ -260,8 +271,8 @@ func TestListFiles_TotalExactWithoutCount(t *testing.T) {
 	if len(docs) != 0 {
 		t.Errorf("past-the-end page returned %d documents, want 0", len(docs))
 	}
-	if total != int64(len(all)) {
-		t.Errorf("past-the-end page: total = %d, want %d", total, len(all))
+	if total != int64(len(otherAll)) {
+		t.Errorf("past-the-end page: total = %d, want %d", total, len(otherAll))
 	}
 }
 


### PR DESCRIPTION
Part of #429 (F10).

## Problem

`ListFiles` paid for its total on **every page**.

- **Glob-free path (`listFilesSQLPaged`)**: ran the paged `SELECT ... LIMIT ? OFFSET ?` and then a separate `SELECT COUNT(*) FROM documents<where>` on every call. Walking a corpus of N files cost O(files) full count scans.
- **Glob path**: worse. The canonical glob matcher runs in Go (SQLite `GLOB` cannot express segment-aware `*` or `**`), so every page rescanned and re-globbed **every** matching row with no caching: paging through the corpus was quadratic.

`ListFiles` returns `([]model.Document, int64, error)` and the ingest/MCP/CLI callers use that `int64` to terminate their walks, so the total could not simply be dropped or faked.

## What changed (all inside `internal/store/`)

The total is now obtained in order of cost:

1. **From the page itself** when the page came back shorter than its limit: a short page proves where the result set ends, so the total is exactly `offset + len(page)` and no `COUNT` runs at all.
2. **From a memo**, for as long as SQLite reports the database unchanged.
3. **From `SELECT COUNT(*)`**, as before.

The memo (`internal/store/list_files_cache.go`) is guarded by SQLite's own cache-invalidation primitive, `PRAGMA data_version`:

- It is read on a **pinned connection** of a **dedicated one-connection read-only handle** (`vdb`). data_version readings are only comparable within a single connection, and it deliberately does **not** change for commits made on the connection that made them, so the probe must never run on the writer handle.
- An unchanged value means **no commit has landed from any connection or process** since the entry was computed. A reused total therefore counts exactly the corpus the caller is looking at; it is not a stale count of an older one.
- `store` **re-probes** before memoizing, so a commit that raced the computation drops the entry instead of publishing it under the old epoch.
- If the probe handle fails to open or the pragma errors, the memo is bypassed entirely and every call recounts, i.e. exactly the pre-F10 behaviour. Nothing about startup or serving depends on it.

The glob path additionally records a **sparse resume index** during its single full scan: the `rel_path` where each block of `stride` matches begins (`stride = max(pageSize, 256)`), capped at 4096 boundaries by doubling the stride and dropping every second entry, so memory stays bounded on any corpus size. Later pages of the same listing resume from the nearest boundary (`AND rel_path >= ?`) and **stop as soon as the page is full**, instead of rescanning from the first row.

The probe handle is deliberately **not** a connection of the #429 F11 read pool: pinning a pool slot would both shrink read concurrency from 4 to 3 and queue the probe behind whatever scan is in flight. `Close` releases the pinned connection before closing the handle and resets the memo, so a reopened store starts clean.

## Correctness trade-off (the important bit)

**The total stays exact; there is no silently-stale total.**

- A memoized total is only ever reused while `data_version` proves that not a single commit has landed since it was computed. It is not a TTL cache and not an in-process write counter: cross-process writes invalidate it too.
- What is unchanged (and was equally true before): under concurrent ingest, the page query and the total can describe **adjacent** database states, because they are separate statements. Previously that was "page at t1, `COUNT` at t2"; now it is "probe at t0, page at t1" on a memo hit. Both are "exact as of a database state observed during the call". No new class of skew is introduced.
- The derived-from-a-short-page total (case 1) is strictly **more** consistent than the old behaviour: it comes from the very statement that produced the page.
- One case had to stay a real `COUNT`: an **empty page at a non-zero offset** proves nothing (the offset may just be past the end), so it is never allowed to report `offset` as the total. `TestListFiles_TotalExactWithoutCount` pins that.

The glob resume index is only ever used within one data_version epoch, so a resumed page is over exactly the rows the full scan saw.

Deliberately **not** done: pushing the glob's literal prefix into SQL as a `LIKE`. The canonical matcher is ASCII case-insensitive and supports `**`, so deriving an equivalent SQL prefix is subtle enough to risk silently dropping matches; the resume index already removes the quadratic behaviour.

## Tests

New `tests/store/list_files_paging_429_test.go` (tests live under `tests/` per AGENTS.md, via two documented test-only seams: `ListFilesQueryStatsForTest` and `GlobBoundsIndexForTest`):

- `TestListFiles_PagedWalkDoesNotRecountPerPage`: 50 docs in pages of 10, total exact on every page, at most 1 `COUNT(*)` for the whole walk.
- `TestListFiles_GlobPagedWalkDoesNotRescanPerPage`: exactly 1 full glob scan for the whole walk, and later pages resume from a boundary.
- `TestListFiles_GlobPagesMatchUnpagedListing`: 600 matching docs; resumed pages are byte-identical to the unpaged listing at offsets that are and are not multiples of the stride, at the last row, at exactly the end, and past the end.
- `TestListFiles_TotalFollowsWrites`: the total reflects an insert and a tombstone immediately, on both the glob-free and the glob path. This is the guard on the whole design.
- `TestListFiles_TotalExactWithoutCount`: a short page needs 0 `COUNT`s, and a page past the end still reports the real total rather than its offset.
- `TestGlobBoundsIndex_SurvivesCompaction`: `bounds[i] == matches[i*stride]` after repeated compaction, and resume+skip lands exactly on the requested offset.

**Verified they fail when the change is reverted.** With the memo and the derived total disabled in place, the same suite reports:

```
--- FAIL: TestListFiles_PagedWalkDoesNotRecountPerPage
    walking 50 documents in pages of 10 ran 6 COUNT(*) queries, want at most 1
--- FAIL: TestListFiles_GlobPagedWalkDoesNotRescanPerPage
    walking 25 matches in pages of 10 ran 3 full glob scans, want exactly 1
--- FAIL: TestListFiles_TotalExactWithoutCount
    a page shorter than its limit ran 1 COUNT(*) queries, want 0
```

The two correctness tests (`TotalFollowsWrites`, `GlobPagesMatchUnpagedListing`) pass both before and after, which is the point: they pin behaviour the optimisation must not change.

`PRAGMA data_version` semantics were also verified empirically against the actual driver (modernc.org/sqlite, WAL, `query_only` reader): unchanged across repeated reads, changed by a write from another connection, changed on commit and not before.

## Gates

- `gofmt -l cmd internal tests` empty
- `go vet ./...`
- `gocyclo -over 15 cmd internal tests` empty
- `go test ./...`
- `go test -race ./internal/store/... ./tests/store/...`

## Scope

`internal/store/` and `tests/store/` only. No submodule re-pin, no docs changes (the SPEC contract for `list_files` is unchanged).

## Review follow-ups (commits 2 and 3)

- **Lock split** (CodeRabbit CLI, major): the memo held one mutex across the connection acquisition and the pragma read. `probeMu` now owns the pinned probe connection and is the only lock held across database I/O; `mu` guards nothing but the epoch and the entry map. Order is always probeMu then mu. Serializing probes on probeMu is also what keeps concurrent probes from applying their epochs out of order, since data_version values are only defined for equality comparison.
- **Past-the-end short-circuit** (Copilot): on a memo hit with `offset >= total` there is nothing to return, so neither the SQL page query nor the glob rescan runs at all. A stats assertion pins that a far out-of-range page issues no query.
- Doc correction: the probe connection comes from the dedicated `vdb` handle, not from the read pool.
- Test correction (CodeRabbit): the past-the-end assertion compared a second store's total against the first store's corpus; it now seeds a different size and asserts against its own.
