### PR TITLE
feat(annotator): read the scorebug as fields, not as prose (0.54 -> 0.99 precision, 4.9% -> 64% coverage)

### DIFF
--- a/annotator/dirstral_annotator/recognizers/scorebug.py
+++ b/annotator/dirstral_annotator/recognizers/scorebug.py
@@ -1,19 +1,50 @@
 """Scorebug recognizer: OCR the broadcast overlay.
 
-The overlay names the current batter (and often the pitcher) during every
-at-bat, which makes this the workhorse signal for broadcast-era footage.
-The OCR engine is injected as a callable `(jpeg_path) -> str`; the default
-adapter uses pytesseract when installed.
+The overlay names the current batter and pitcher during every at-bat, which
+makes this the workhorse signal for broadcast footage that has no structured
+play-by-play feed (the normal case for an archive). Unlike the play-by-play
+recognizer it needs nothing but the pixels.
+
+Reading it well takes three things, and the naive "OCR the whole frame and
+fuzzy-match every line against the roster" loop got none of them:
+
+1. *Where.* The bug occupies about 3% of the frame. Whole-frame OCR has to
+   segment a crowd, a scoreboard and a sponsor board before it reaches the
+   30-pixel-tall name, and usually never does. We OCR a handful of candidate
+   overlay bands instead, then lock onto whichever one is actually producing
+   reads so the rest of the run pays for one crop.
+2. *How.* Overlay text is light-on-dark, small and JPEG-soft. Upscaling the
+   crop to a fixed text height and binarising it turns a garbled read into a
+   clean one; the two passes (grey and binarised) disagree often enough on
+   real footage to be worth running both.
+3. *What.* The bug is structured, not prose: `5.LILE` is the batter in the
+   fifth lineup slot, `RAY  P: 90` is the pitcher and his pitch count,
+   `SLIDER 88 MPH` is the pitch that was just thrown. Parsing those forms and
+   matching only the name part against the roster is what keeps precision up:
+   feeding whole OCR lines to a fuzzy matcher turns "ee" into Jung Hoo Lee and
+   "#0" into the player wearing 0.
+
+Note on the leading digit: it is the *lineup slot*, not the jersey number
+(Daylen Lile bats fifth wearing 4), so it is used as a structural marker for
+"this is the batter field" and never as a number-vs-roster constraint.
 
 Consecutive frames resolving to the same player collapse into one cue
-spanning the run — the overlay persisting for 20 seconds is one at-bat
+spanning the run: the overlay persisting for 20 seconds is one at-bat
 sighting, not 20 observations (which would also defeat fusion's per-source
 confidence cap).
+
+The OCR engine is injected as a callable `(image_path) -> str`; the default
+adapter uses pytesseract when installed.
 """
 
 from __future__ import annotations
 
-from collections.abc import Callable
+import difflib
+import re
+import tempfile
+import unicodedata
+from collections.abc import Callable, Iterable, Iterator
+from dataclasses import dataclass
 from pathlib import Path
 
 from ..model import Cue
@@ -21,13 +52,105 @@ from ..roster import Roster
 from .base import RecognizerUnavailable, iter_frames
 
 OcrFn = Callable[[Path], str]
+Region = tuple[float, float, float, float]
 
-# A run of frames may drop a detection for a beat (OCR flicker); allow this
-# many seconds of gap before closing the run.
+# Fractional (x, y, w, h) boxes searched for the overlay, covering the corners
+# broadcasts actually use: MLB/NBC hangs its bug top left, most other sports
+# put it along the bottom. Deliberately generous, because a band that clips the
+# name is worse than one that includes some crowd.
+CANDIDATE_REGIONS: tuple[Region, ...] = (
+    (0.00, 0.02, 0.55, 0.16),  # upper left
+    (0.00, 0.80, 0.55, 0.18),  # lower left
+    (0.20, 0.80, 0.60, 0.18),  # lower centre
+    (0.20, 0.02, 0.60, 0.16),  # upper centre
+)
+
+# A run of frames may drop a detection for a beat (OCR flicker, or a replay
+# that hides the bug); allow this many seconds of gap before closing the run.
 RUN_GAP_S = 3.0
 
+# Crops are upscaled so the band is about this tall before OCR. Fixed pixels,
+# not a fixed factor, so an SD archive gets the magnification it needs and a
+# 4K master is not blown up into a slow no-op.
+TARGET_BAND_PX = 320
+MAX_UPSCALE = 4.0
+# Everything darker than this becomes black in the second pass. Overlay text is
+# near-white by design, so the cut can sit high.
+BINARY_THRESHOLD = 140
+# tesseract page-segmentation mode for a cropped overlay strip.
+OCR_PSM = 6
 
-def default_ocr() -> OcrFn:
+# Region search: while unlocked, only every Nth frame pays for the full sweep;
+# once one band has produced this many reads it is the only one OCR'd.
+SCAN_STRIDE = 4
+LOCK_AFTER_READS = 5
+
+# Name matching. Short reads (three or four characters: RAY, COX) are accepted
+# only on an exact roster match, because that is the length at which fuzzy
+# matching starts turning OCR debris into confident nonsense ("ee" scored 0.8
+# against "Lee", "inn" 0.86 against "Winn").
+FUZZY_MIN_LEN = 5
+FUZZY_THRESHOLD = 0.85
+EXACT_CONFIDENCE = 0.95
+FUZZY_CEILING = 0.9
+# A bare name with no structural marker around it could be anyone the graphics
+# package chose to mention, so discount it against a parsed batter or pitcher
+# field.
+UNKNOWN_ROLE_FACTOR = 0.85
+# A name off a line with no overlay structure at all is admitted only when the
+# same player was read properly nearby, and never at full strength. This buys
+# back the frames where OCR recovers the name but loses the row around it,
+# without admitting the surnames that crowd texture invents.
+LOOSE_ROLE_FACTOR = 0.7
+CORROBORATION_S = 30.0
+
+# How far a pitch-speed graphic may look for the pitcher it belongs to. The
+# name field is covered by the graphic while it is up, so the pitcher has to
+# come from the surrounding frames or not at all.
+PITCHER_MEMORY_S = 90.0
+PITCH_CUE_PAD_S = 2.0
+PITCH_CONFIDENCE = 0.8
+# Readings this close together are the same graphic, not two pitches: no
+# pitcher works quicker than this, and the graphic itself lingers.
+PITCH_MERGE_S = 6.0
+
+BATTER, PITCHER, UNKNOWN, LOOSE = "batter", "pitcher", "unknown", "loose"
+
+# "5.LILE", "6YOUNG": a single lineup digit punctuated onto (or glued to) the
+# surname, with nothing between. The tight form is deliberate. The batter's
+# day line sits between the two names, so "5.LILE 1-2. RAY P:87" offers "2. RAY"
+# as a lineup field too, and a looser pattern reads the pitcher as the batter.
+# The lookbehind rejects the right half of any hyphenated pair (a day line, a
+# ball-strike count) for the same reason.
+_LINEUP_RE = re.compile(r"(?<![0-9A-Z\-])([1-9])[.,:;]?([A-Z][A-Z'\-]{2,})")
+# "GRIFFIN  P: 50": the pitch count that trails the pitcher's name.
+_PITCH_COUNT_RE = re.compile(r"([A-Z][A-Z'\-]{2,})[^A-Z0-9]{0,6}P\s*[.,:;]\s*[0-9]{1,3}")
+# "SLIDER 88 MPH", "FOUR SEAM 92 MPH": anchored on the literal speed unit,
+# which OCR noise does not invent.
+_VELOCITY_RE = re.compile(r"([A-Z][A-Z ]{2,20}?)\s*([0-9]{2,3})\s*(MPH|KPH|KM/H)")
+# The unit is set in small caps and is the first thing tesseract loses (MPH
+# comes back as "upeq", "mpq", "upv"), so a second anchor takes the pitch type
+# instead: a known delivery followed by a plausible speed. The vocabulary is
+# baseball's, like the rest of this pilot's event names.
+_TYPED_SPEED_RE = re.compile(r"([A-Z][A-Z ]{3,20}?)\s*([0-9]{2,3})(?![0-9])")
+PITCH_TYPES = (
+    "FOUR SEAM", "FOURSEAM", "TWO SEAM", "TWOSEAM", "FASTBALL", "SINKER",
+    "SLIDER", "SWEEPER", "CURVEBALL", "CURVE", "CHANGEUP", "CUTTER",
+    "SPLITTER", "KNUCKLEBALL", "KNUCKLE CURVE", "SCREWBALL", "SLURVE",
+)
+PITCH_TYPE_THRESHOLD = 0.86
+PLAUSIBLE_SPEED = range(40, 121)
+_WORD_RE = re.compile(r"[A-Z][A-Z'\-]{2,}")
+
+
+def default_ocr(psm: int | None = None) -> OcrFn:
+    """pytesseract adapter, optionally pinned to a page-segmentation mode.
+
+    `psm` is left alone by default because the other recognizers share this
+    adapter on crops of their own shape. The scorebug asks for mode 6, "a
+    single uniform block of text": tesseract's default keeps hunting for page
+    structure that a 200-pixel-tall overlay strip does not have.
+    """
     try:
         import pytesseract  # type: ignore
         from PIL import Image  # type: ignore
@@ -37,10 +160,99 @@ def default_ocr() -> OcrFn:
             "'dirstral-annotator[ocr]') and a tesseract binary"
         ) from exc
 
+    config = f"--psm {psm}" if psm is not None else ""
+
     def ocr(frame: Path) -> str:
-        return pytesseract.image_to_string(Image.open(frame))
+        return pytesseract.image_to_string(Image.open(frame), config=config)
 
     return ocr
+
+
+@dataclass(frozen=True)
+class NameRead:
+    """One name the overlay parser recovered, with the role its position in
+    the bug implies."""
+
+    name: str
+    role: str
+
+
+@dataclass(frozen=True)
+class PitchRead:
+    """A pitch-speed graphic. The speed is always read; the type and the unit
+    are whatever survived the OCR."""
+
+    pitch_type: str
+    speed: int
+    unit: str = ""
+
+    def describe(self) -> str:
+        parts = [p for p in (self.pitch_type, str(self.speed), self.unit) if p]
+        return " ".join(parts)
+
+
+def parse_overlay(text: str) -> tuple[list[NameRead], list[PitchRead]]:
+    """Pull structured fields out of one OCR pass over the bug.
+
+    Returns the names it recognised as fields (batter, pitcher, or an
+    unattributed word on a line that is demonstrably the bug) and any
+    pitch-speed graphic. Nothing here touches the roster: this is purely
+    "what does the overlay say".
+
+    A bare word is only trusted (role `unknown`) when its line also yielded a
+    lineup slot, a pitch count or a pitch graphic. During a replay or a crowd
+    shot the bug is gone and the crop is texture, and tesseract turns texture
+    into pages of three-letter words, one of which is eventually somebody's
+    surname: that is where "LEE" and "LORD" came from. Structure on the line is
+    the evidence that there is a bug to read at all. Words off an unstructured
+    line come back as role `loose`, for the caller to corroborate or discard.
+    """
+    names: list[NameRead] = []
+    pitches: list[PitchRead] = []
+    seen: set[tuple[str, str]] = set()
+
+    def add(name: str, role: str) -> None:
+        key = (name, role)
+        if key not in seen:
+            seen.add(key)
+            names.append(NameRead(name=name, role=role))
+
+    for raw in text.splitlines():
+        line = _fold(raw)
+        if not line:
+            continue
+        claimed: set[str] = set()
+        structured = False
+        for match in _VELOCITY_RE.finditer(line):
+            # The type sits directly left of the speed; anything further left
+            # belongs to another field, so keep at most the last two words.
+            kind = " ".join(match.group(1).split()[-2:])
+            kind = kind if _is_pitch_type(kind) else ""
+            pitches.append(
+                PitchRead(pitch_type=kind, speed=int(match.group(2)), unit=match.group(3))
+            )
+            claimed.update(kind.split())
+            claimed.add(match.group(3))
+            structured = True
+        for match in _TYPED_SPEED_RE.finditer(line):
+            kind = " ".join(match.group(1).split()[-2:])
+            speed = int(match.group(2))
+            if speed in PLAUSIBLE_SPEED and _is_pitch_type(kind):
+                pitches.append(PitchRead(pitch_type=kind, speed=speed))
+                claimed.update(kind.split())
+                structured = True
+        for match in _PITCH_COUNT_RE.finditer(line):
+            add(match.group(1), PITCHER)
+            claimed.add(match.group(1))
+            structured = True
+        for match in _LINEUP_RE.finditer(line):
+            add(match.group(2), BATTER)
+            claimed.add(match.group(2))
+            structured = True
+        for word in _WORD_RE.findall(line):
+            if word not in claimed:
+                add(word, UNKNOWN if structured else LOOSE)
+    return names, _dedupe_pitches(pitches)
 
 
 class ScorebugRecognizer:
@@ -51,41 +263,345 @@ class ScorebugRecognizer:
         roster: Roster,
         ocr: OcrFn | None = None,
         fps: float = 0.5,
-        crop=None,  # optional (x, y, w, h) fraction box; None = full frame
+        crop: Region | None = None,  # fraction box; None searches for the bug
+        regions: Iterable[Region] | None = None,
+        pitch_cues: bool = True,
     ):
         self.roster = roster
-        self.ocr = ocr if ocr is not None else default_ocr()
+        self.ocr = ocr if ocr is not None else default_ocr(psm=OCR_PSM)
         self.fps = fps
         self.crop = crop
+        if crop is not None:
+            self.regions: tuple[Region, ...] = (tuple(crop),)  # type: ignore[assignment]
+        else:
+            self.regions = tuple(regions) if regions is not None else CANDIDATE_REGIONS
+        self.pitch_cues = pitch_cues
+        self._index = _name_index(roster)
 
     def recognize(self, media_path: Path) -> list[Cue]:
-        sightings: list[tuple[float, str, float]] = []  # (t, player_id, conf)
-        for t, frame in iter_frames(media_path, fps=self.fps):
-            frame = self._cropped(frame)
-            text = self.ocr(frame)
-            for line in text.splitlines():
-                hit = self.roster.resolve_name(line)
-                if hit:
-                    player, conf = hit
-                    sightings.append((t, player.id, conf))
-        return collapse_sightings(
-            sightings, source=self.name, event="at_bat", frame_gap=1.0 / self.fps
-        )
+        batters: list[tuple[float, str, float]] = []
+        appearances: list[tuple[float, str, float]] = []
+        pitchers: list[tuple[float, str, float]] = []
+        loose: list[tuple[float, str, float]] = []
+        graphics: list[tuple[float, PitchRead]] = []
 
-    def _cropped(self, frame: Path) -> Path:
-        if self.crop is None:
-            return frame
-        from PIL import Image  # optional dep; only reached when crop is set
+        search = _RegionSearch(self.regions)
+        with tempfile.TemporaryDirectory(prefix="dirstral-scorebug-") as tmp:
+            work = Path(tmp)
+            for i, (t, frame) in enumerate(iter_frames(media_path, fps=self.fps)):
+                for region in search.regions_for(i):
+                    names, pitches = self._read(frame, region, work)
+                    hits = 0
+                    for read in names:
+                        resolved = self._resolve(read)
+                        if resolved is None:
+                            continue
+                        pid, conf = resolved
+                        if read.role == LOOSE:
+                            # Not evidence of anything on its own, and not
+                            # evidence that this band holds the bug either, so
+                            # it does not count towards the region lock.
+                            loose.append((t, pid, conf))
+                            continue
+                        hits += 1
+                        if read.role == BATTER:
+                            batters.append((t, pid, conf))
+                            continue
+                        if read.role == PITCHER:
+                            pitchers.append((t, pid, conf))
+                        # Named, but not at the plate: the pitcher between
+                        # deliveries, or whoever else the graphics package
+                        # chose to put on screen.
+                        appearances.append((t, pid, conf))
+                    hits += len(pitches)
+                    graphics += [(t, pitch) for pitch in pitches]
+                    search.record(region, hits)
+                    if hits:
+                        break  # this band answered; the others need not be OCR'd
 
-        img = Image.open(frame)
-        x, y, w, h = self.crop
-        px = (
-            int(x * img.width), int(y * img.height),
-            int((x + w) * img.width), int((y + h) * img.height),
+        gap = 1.0 / self.fps
+        confirmed = batters + appearances
+        appearances += [s for s in loose if _corroborated(s, confirmed)]
+        cues = collapse_sightings(batters, source=self.name, event="at_bat", frame_gap=gap)
+        cues += collapse_sightings(
+            appearances, source=self.name, event="appearance", frame_gap=gap
         )
-        out = frame.with_name(frame.stem + "-crop.jpg")
-        img.crop(px).save(out)
-        return out
+        if self.pitch_cues:
+            cues += self._pitch_cues(graphics, pitchers)
+        cues.sort(key=lambda c: (c.start_s, c.event, c.entity_ids))
+        return cues
+
+    def _read(
+        self, frame: Path, region: Region, work: Path
+    ) -> tuple[list[NameRead], list[PitchRead]]:
+        names: list[NameRead] = []
+        pitches: list[PitchRead] = []
+        seen: set[tuple[str, str]] = set()
+        for path in _prepared_crops(frame, region, work):
+            found_names, found_pitches = parse_overlay(self.ocr(path))
+            for read in found_names:
+                if (read.name, read.role) not in seen:
+                    seen.add((read.name, read.role))
+                    names.append(read)
+            pitches += found_pitches
+        return names, _dedupe_pitches(pitches)
+
+    def _resolve(self, read: NameRead) -> tuple[str, float] | None:
+        hit = match_name(self._index, read.name)
+        if hit is None:
+            return None
+        pid, conf = hit
+        if read.role == UNKNOWN:
+            conf *= UNKNOWN_ROLE_FACTOR
+        elif read.role == LOOSE:
+            conf *= LOOSE_ROLE_FACTOR
+        return pid, round(conf, 4)
+
+    def _pitch_cues(
+        self,
+        graphics: list[tuple[float, PitchRead]],
+        pitchers: list[tuple[float, str, float]],
+    ) -> list[Cue]:
+        """One cue per pitch-speed graphic, credited to the pitcher the bug was
+        naming around it.
+
+        This is the only per-pitch timing available without a feed, and it is
+        emitted as `pitch` (the event the pilot metric scores) rather than
+        folded into the pitcher's appearance run: one cue spanning a whole
+        stint would claim a single long pitch instead of forty short ones.
+
+        The graphic stays up for a few seconds, so consecutive frames see the
+        same pitch (sometimes disagreeing about the speed by a digit). Readings
+        close together are therefore one pitch, described by the fullest read.
+        """
+        cues: list[Cue] = []
+        for cluster in _cluster_graphics(graphics):
+            first, last = cluster[0][0], cluster[-1][0]
+            pid = _nearest(pitchers, first, PITCHER_MEMORY_S)
+            if pid is None:
+                continue  # no idea who threw it; say nothing rather than guess
+            best = max((p for _, p in cluster), key=_detail)
+            cues.append(
+                Cue(
+                    source=self.name,
+                    start_s=max(0.0, first - PITCH_CUE_PAD_S),
+                    end_s=last + PITCH_CUE_PAD_S,
+                    event="pitch",
+                    entity_ids=(pid,),
+                    confidence=PITCH_CONFIDENCE,
+                    text=best.describe(),
+                )
+            )
+        return cues
+
+
+class _RegionSearch:
+    """Try every candidate band until one proves itself, then stay on it.
+
+    Sweeping four bands on every frame would cost more OCR than the whole-frame
+    pass this replaces, so unlocked sweeps are strided and the winner is locked
+    in after a few reads. If the overlay moves (a graphics package change part
+    way through a file) the lock releases once the locked band goes quiet.
+    """
+
+    RELEASE_AFTER_MISSES = 60
+
+    def __init__(self, regions: tuple[Region, ...]):
+        self.regions = regions
+        self.locked: Region | None = regions[0] if len(regions) == 1 else None
+        self.scores: dict[Region, int] = {}
+        self.misses = 0
+
+    def regions_for(self, frame_index: int) -> tuple[Region, ...]:
+        if self.locked is not None:
+            return (self.locked,)
+        if frame_index % SCAN_STRIDE:
+            return ()
+        return self.regions
+
+    def record(self, region: Region, hits: int) -> None:
+        if hits:
+            self.scores[region] = self.scores.get(region, 0) + hits
+            self.misses = 0
+            if self.locked is None and self.scores[region] >= LOCK_AFTER_READS:
+                self.locked = region
+        elif self.locked == region and len(self.regions) > 1:
+            self.misses += 1
+            if self.misses >= self.RELEASE_AFTER_MISSES:
+                self.locked = None
+                self.scores.clear()
+                self.misses = 0
+
+
+def _prepared_crops(frame: Path, region: Region, work: Path) -> Iterator[Path]:
+    """Yield OCR-ready renderings of one band: upscaled greyscale, and the same
+    crop hard-thresholded.
+
+    Overlay text is light on dark, which Otsu handles badly when the crop also
+    catches a bright crowd; a fixed threshold recovers the name in exactly the
+    frames the grey pass garbles. Both are written to the recognizer's own temp
+    dir rather than beside the frame, because the frame directory is a cache
+    other recognizers iterate.
+    """
+    from PIL import Image, ImageOps  # required by the OCR extra
+
+    img = Image.open(frame)
+    x, y, w, h = region
+    box = (
+        max(0, int(x * img.width)),
+        max(0, int(y * img.height)),
+        min(img.width, int((x + w) * img.width)),
+        min(img.height, int((y + h) * img.height)),
+    )
+    if box[2] <= box[0] or box[3] <= box[1]:
+        return
+    crop = img.crop(box).convert("L")
+    scale = min(MAX_UPSCALE, max(1.0, TARGET_BAND_PX / max(1, crop.height)))
+    if scale > 1.0:
+        crop = crop.resize(
+            (int(crop.width * scale), int(crop.height * scale)), Image.LANCZOS
+        )
+    crop = ImageOps.autocontrast(crop)
+
+    grey = work / "band-grey.png"
+    crop.save(grey)
+    yield grey
+
+    binary = work / "band-bin.png"
+    crop.point(lambda p: 255 if p > BINARY_THRESHOLD else 0).save(binary)
+    yield binary
+
+
+def _cluster_graphics(
+    graphics: list[tuple[float, PitchRead]]
+) -> list[list[tuple[float, PitchRead]]]:
+    """Group pitch-speed readings that are the same graphic seen twice."""
+    clusters: list[list[tuple[float, PitchRead]]] = []
+    for t, pitch in sorted(graphics, key=lambda g: g[0]):
+        if clusters and t - clusters[-1][-1][0] <= PITCH_MERGE_S:
+            clusters[-1].append((t, pitch))
+        else:
+            clusters.append([(t, pitch)])
+    return clusters
+
+
+def _is_pitch_type(word: str) -> bool:
+    """Is this OCR word one of baseball's deliveries, give or take a letter?"""
+    if not word:
+        return False
+    return any(
+        difflib.SequenceMatcher(None, word, kind).ratio() >= PITCH_TYPE_THRESHOLD
+        for kind in PITCH_TYPES
+    )
+
+
+def _dedupe_pitches(pitches: list[PitchRead]) -> list[PitchRead]:
+    """Both preprocessing passes and both speed patterns usually see the same
+    graphic; keep the fullest reading of each speed."""
+    best: dict[int, PitchRead] = {}
+    for pitch in pitches:
+        current = best.get(pitch.speed)
+        if current is None or _detail(pitch) > _detail(current):
+            best[pitch.speed] = pitch
+    return [best[speed] for speed in sorted(best)]
+
+
+def _detail(pitch: PitchRead) -> int:
+    return bool(pitch.pitch_type) + bool(pitch.unit)
+
+
+def _name_index(roster: Roster) -> dict[str, set[str]]:
+    """Normalised name form -> player ids.
+
+    Every roster spelling plus its surname, minus the `#number` forms
+    `Player.all_names()` adds: matching those against OCR text is how a stray
+    "#0" becomes a confident sighting of whoever wears 0.
+    """
+    index: dict[str, set[str]] = {}
+    for player in roster.players:
+        for form in (player.name, *player.aliases):
+            key = _upper(form)
+            parts = key.split()
+            if not parts or len(key.replace(" ", "")) < 3:
+                continue
+            index.setdefault(key, set()).add(player.id)
+            if len(parts[-1]) >= 3:
+                index.setdefault(parts[-1], set()).add(player.id)
+    return index
+
+
+def match_name(index: dict[str, set[str]], token: str) -> tuple[str, float] | None:
+    """Resolve one OCR name to a player id, or None.
+
+    Exact wins. Fuzzy is allowed only for tokens long enough that a near miss
+    means something, and a surname two players share resolves to neither: the
+    overlay gives no way to tell them apart, so a guess would be wrong half the
+    time.
+    """
+    key = _upper(token)
+    if len(key.replace(" ", "")) < 3:
+        return None
+    ids = index.get(key)
+    if ids:
+        return (next(iter(ids)), EXACT_CONFIDENCE) if len(ids) == 1 else None
+    if len(key) < FUZZY_MIN_LEN:
+        return None
+    best: tuple[str, float] | None = None
+    for form, form_ids in index.items():
+        if len(form_ids) != 1:
+            continue
+        ratio = difflib.SequenceMatcher(None, key, form).ratio()
+        if ratio >= FUZZY_THRESHOLD and (best is None or ratio > best[1]):
+            best = (next(iter(form_ids)), ratio)
+    if best is None:
+        return None
+    return best[0], round(best[1] * FUZZY_CEILING, 4)
+
+
+def _corroborated(
+    loose: tuple[float, str, float], confirmed: list[tuple[float, str, float]]
+) -> bool:
+    """Was this player also read off a structured line close enough in time?
+
+    "SEYMOUR" on its own is worth something when the bug named Seymour twenty
+    seconds ago and nothing else has happened; the same word out of a crowd
+    shot in an inning he never appears in is worth nothing.
+    """
+    t, pid, _ = loose
+    return any(
+        other_pid == pid and abs(other_t - t) <= CORROBORATION_S
+        for other_t, other_pid, _ in confirmed
+    )
+
+
+def _nearest(
+    sightings: list[tuple[float, str, float]], t: float, window: float
+) -> str | None:
+    best: tuple[float, str] | None = None
+    for seen_t, pid, _ in sightings:
+        delta = abs(seen_t - t)
+        if delta <= window and (best is None or delta < best[0]):
+            best = (delta, pid)
+    return best[1] if best else None
+
+
+def _fold(text: str) -> str:
+    """Uppercase and strip accents, keeping digits and punctuation.
+
+    The overlay writes NUNEZ, the roster writes Nuñez, and tesseract writes
+    whichever it feels like; folding both to ASCII makes them one string. The
+    structure (the lineup digit, the `P:` marker) has to survive, so this is
+    the form the field patterns run against.
+    """
+    folded = unicodedata.normalize("NFKD", text)
+    folded = "".join(c for c in folded if not unicodedata.combining(c))
+    return folded.upper()
+
+
+def _upper(text: str) -> str:
+    """Fold to letters and spaces only: the form roster names are keyed by."""
+    kept = [c if (c.isalpha() and c.isascii()) or c in " '-" else " " for c in _fold(text)]
+    return " ".join("".join(kept).split())
 
 
 def collapse_sightings(

--- a/annotator/dirstral_annotator/recognizers/scorebug.py
+++ b/annotator/dirstral_annotator/recognizers/scorebug.py
@@ -163,7 +163,9 @@ def default_ocr(psm: int | None = None) -> OcrFn:
     config = f"--psm {psm}" if psm is not None else ""
 
     def ocr(frame: Path) -> str:
-        return pytesseract.image_to_string(Image.open(frame), config=config)
+        with Image.open(frame) as img:
+            img.load()
+            return pytesseract.image_to_string(img, config=config)
 
     return ocr
 
@@ -228,8 +230,13 @@ def parse_overlay(text: str) -> tuple[list[NameRead], list[PitchRead]]:
             # belongs to another field, so keep at most the last two words.
             kind = " ".join(match.group(1).split()[-2:])
             kind = kind if _is_pitch_type(kind) else ""
+            speed = int(match.group(2))
+            # Same plausibility gate as the typed branch: a garbled line ending
+            # in digits followed by a unit is otherwise accepted at any value.
+            if speed not in PLAUSIBLE_SPEED:
+                continue
             pitches.append(
-                PitchRead(pitch_type=kind, speed=int(match.group(2)), unit=match.group(3))
+                PitchRead(pitch_type=kind, speed=speed, unit=match.group(3))
             )
             claimed.update(kind.split())
             claimed.add(match.group(3))
@@ -443,9 +450,20 @@ def _prepared_crops(frame: Path, region: Region, work: Path) -> Iterator[Path]:
     dir rather than beside the frame, because the frame directory is a cache
     other recognizers iterate.
     """
-    from PIL import Image, ImageOps  # required by the OCR extra
+    try:
+        from PIL import Image, ImageOps  # required by the OCR extra
+    except ImportError as exc:  # pragma: no cover - exercised via the contract test
+        # recognize() must degrade the cascade, not abort it, so a missing
+        # Pillow has to arrive as RecognizerUnavailable rather than ImportError.
+        raise RecognizerUnavailable("Pillow is required for scorebug OCR") from exc
 
-    img = Image.open(frame)
+    # load() inside the context manager pulls the pixels into memory and lets
+    # the descriptor close immediately. This runs at least once per frame, so
+    # relying on garbage collection to release it leaks handles across a long
+    # media file and can exhaust the process limit.
+    with Image.open(frame) as opened:
+        opened.load()
+        img = opened.copy()
     x, y, w, h = region
     box = (
         max(0, int(x * img.width)),

--- a/annotator/tests/test_scorebug.py
+++ b/annotator/tests/test_scorebug.py
@@ -1,0 +1,271 @@
+"""Scorebug overlay parsing, roster matching and cue shape.
+
+Backend-free: no tesseract, no Pillow, no video. The OCR strings below are
+verbatim tesseract output from the pilot fixture (a Nationals at Giants
+broadcast), including its mistakes, so the parser is tested against what the
+engine actually returns rather than against clean text.
+"""
+
+import json
+import sys
+
+import pytest
+
+from dirstral_annotator.recognizers import scorebug
+from dirstral_annotator.recognizers.base import RecognizerUnavailable
+from dirstral_annotator.recognizers.scorebug import (
+    BATTER,
+    LOOSE,
+    PITCHER,
+    UNKNOWN,
+    ScorebugRecognizer,
+    _name_index,
+    _RegionSearch,
+    match_name,
+    parse_overlay,
+)
+from dirstral_annotator.roster import Roster
+
+MEDIA = "game.mp4"
+WHOLE = (0.0, 0.0, 1.0, 1.0)  # pin the region: these tests are about parsing
+
+
+@pytest.fixture
+def roster(tmp_path):
+    path = tmp_path / "roster.json"
+    path.write_text(json.dumps([
+        {"id": "player:daylen-lile", "name": "Daylen Lile", "number": "4",
+         "aliases": ["D. Lile", "Lile"], "mlbam_id": 1},
+        {"id": "player:robbie-ray", "name": "Robbie Ray", "number": "38",
+         "aliases": ["R. Ray", "Ray"], "mlbam_id": 2},
+        {"id": "player:nasim-nunez", "name": "Nasim Nuñez", "number": "26",
+         "aliases": ["N. Nuñez", "Nuñez"], "mlbam_id": 3},
+        {"id": "player:drew-gilbert", "name": "Drew Gilbert", "number": "0",
+         "aliases": ["Gilbert"], "mlbam_id": 4},
+        {"id": "player:jung-hoo-lee", "name": "Jung Hoo Lee", "number": "51",
+         "aliases": ["Lee"], "mlbam_id": 5},
+        # two Smiths: the overlay shows a surname, which cannot separate them
+        {"id": "player:dylan-smith", "name": "Dylan Smith", "number": "66",
+         "aliases": ["Smith"], "mlbam_id": 6},
+        {"id": "player:will-smith", "name": "Will Smith", "number": "13",
+         "aliases": ["Smith"], "mlbam_id": 7},
+    ]))
+    return Roster.load(path)
+
+
+@pytest.fixture
+def index(roster):
+    return _name_index(roster)
+
+
+# --- overlay parsing -------------------------------------------------------
+
+def test_batter_and_pitcher_fields_get_their_roles():
+    names, _ = parse_overlay("5.LILE 1-2 RAY p: 87 “6 @@ 2-0")
+    assert scorebug.NameRead("LILE", BATTER) in names
+    assert scorebug.NameRead("RAY", PITCHER) in names
+
+
+def test_day_line_digit_is_not_read_as_a_lineup_slot():
+    # Verbatim OCR of a frame that used to make the pitcher the batter: the
+    # "1-2." day line sits between the two names, offering "2. RAY".
+    names, _ = parse_overlay('“5LILE 1-2. RAY me “6 00 1-0')
+    assert scorebug.NameRead("RAY", BATTER) not in names
+    assert scorebug.NameRead("LILE", BATTER) in names
+
+
+def test_lineup_slot_survives_a_missing_separator():
+    names, _ = parse_overlay("6YOUNG 0-2 RAY P: 90")
+    assert scorebug.NameRead("YOUNG", BATTER) in names
+
+
+def test_pitch_graphic_with_a_readable_unit():
+    _, pitches = parse_overlay("5.LILE 1-2 SLIDER 88 MPH “6 @@ 2-0")
+    assert pitches == [scorebug.PitchRead("SLIDER", 88, "MPH")]
+    assert pitches[0].describe() == "SLIDER 88 MPH"
+
+
+def test_pitch_graphic_when_the_unit_is_garbled():
+    # "MPH" is set in small caps and comes back as noise more often than not;
+    # the pitch type carries the read instead.
+    _, pitches = parse_overlay("5.LILE 1-2 FOURSEAM 92upeq “G @@ 2-0")
+    assert [(p.pitch_type, p.speed) for p in pitches] == [("FOURSEAM", 92)]
+
+
+def test_implausible_speeds_and_non_pitches_are_not_graphics():
+    _, pitches = parse_overlay("WSH 2 SF 0 ATTENDANCE 41213")
+    assert pitches == []
+
+
+def test_crowd_texture_is_never_more_than_a_loose_read():
+    # A replay or crowd shot leaves no bug in the crop; tesseract still
+    # returns pages of three-letter words, one of which is always a surname.
+    noise = "Beir Lee GAS Pt atthe gL) TAT eM we PA) a pik wee Se bh\nFRR ahe ey Maes"
+    names, pitches = parse_overlay(noise)
+    assert pitches == []
+    assert names and {n.role for n in names} == {LOOSE}
+
+
+def test_bare_words_are_kept_only_alongside_structure():
+    names, _ = parse_overlay("0-2 SEYMOUR 5.VIVAS")
+    assert scorebug.NameRead("SEYMOUR", UNKNOWN) in names
+
+
+# --- roster matching -------------------------------------------------------
+
+def test_exact_surname_matches(index):
+    assert match_name(index, "LILE") == ("player:daylen-lile", 0.95)
+
+
+def test_accents_fold_both_ways(index):
+    assert match_name(index, "NUNEZ")[0] == "player:nasim-nunez"
+
+
+def test_ocr_debris_no_longer_resolves(index):
+    # Every one of these produced a confident cue before: "ee" scored 0.80
+    # against Lee, "inn" 0.86 against Winn, and "#0" matched the roster's
+    # own "#number" alias at 1.00.
+    for junk in ("ee", "12", "#0", "in", "e"):
+        assert match_name(index, junk) is None
+
+
+def test_short_tokens_need_an_exact_match(index):
+    assert match_name(index, "RAY") == ("player:robbie-ray", 0.95)
+    assert match_name(index, "RAM") is None  # one letter off, and too short to tell
+
+
+def test_fuzzy_match_is_allowed_for_longer_names(index):
+    hit = match_name(index, "GILBERI")
+    assert hit is not None and hit[0] == "player:drew-gilbert"
+    assert hit[1] < 0.95
+
+
+def test_a_shared_surname_resolves_to_nobody(index):
+    assert match_name(index, "SMITH") is None
+
+
+# --- region search ---------------------------------------------------------
+
+def test_search_sweeps_on_a_stride_then_locks():
+    regions = (("a",), ("b",))
+    search = _RegionSearch(regions)  # type: ignore[arg-type]
+    assert search.regions_for(0) == regions
+    assert search.regions_for(1) == ()
+    for _ in range(scorebug.LOCK_AFTER_READS):
+        search.record(regions[1], hits=1)
+    assert search.regions_for(0) == (regions[1],)
+
+
+def test_a_single_region_is_locked_from_the_start():
+    search = _RegionSearch((("only",),))  # type: ignore[arg-type]
+    assert search.regions_for(1) == (("only",),)
+
+
+def test_lock_releases_when_the_bug_moves():
+    regions = (("a",), ("b",))
+    search = _RegionSearch(regions)  # type: ignore[arg-type]
+    for _ in range(scorebug.LOCK_AFTER_READS):
+        search.record(regions[0], hits=1)
+    for _ in range(_RegionSearch.RELEASE_AFTER_MISSES):
+        search.record(regions[0], hits=0)
+    assert search.regions_for(0) == regions
+
+
+# --- recognizer ------------------------------------------------------------
+
+@pytest.fixture
+def fake_frames(monkeypatch, tmp_path):
+    """Drive the recognizer off a scripted list of per-frame OCR strings."""
+
+    def install(texts, fps=0.5):
+        frames = []
+        for i, text in enumerate(texts):
+            path = tmp_path / f"frame-{i}.jpg"
+            path.write_text(text)
+            frames.append((i / fps, path))
+
+        monkeypatch.setattr(scorebug, "iter_frames", lambda *a, **k: iter(frames))
+        # The real crop needs Pillow and a real JPEG; the fake hands the OCR
+        # callable the frame itself, once per preprocessing pass.
+        monkeypatch.setattr(
+            scorebug, "_prepared_crops", lambda frame, region, work: iter([frame])
+        )
+        return lambda frame: frame.read_text()
+
+    return install
+
+
+def test_batter_becomes_an_at_bat_run_and_pitcher_an_appearance(roster, fake_frames):
+    ocr = fake_frames(["5.LILE 1-2 RAY P: 87 “6 @@ 2-0"] * 4)
+    cues = ScorebugRecognizer(roster, ocr=ocr, fps=0.5, crop=WHOLE).recognize(MEDIA)
+    at_bat = [c for c in cues if c.event == "at_bat"]
+    appearance = [c for c in cues if c.event == "appearance"]
+    assert len(at_bat) == 1 and at_bat[0].entity_ids == ("player:daylen-lile",)
+    assert at_bat[0].start_s == 0.0 and at_bat[0].end_s == 8.0
+    assert len(appearance) == 1 and appearance[0].entity_ids == ("player:robbie-ray",)
+
+
+def test_pitch_graphic_becomes_one_pitch_cue_for_the_pitcher(roster, fake_frames):
+    ocr = fake_frames([
+        "5.LILE 1-2 RAY P: 87 “6 @@ 2-0",
+        "5.LILE 1-2 SLIDER 88 MPH “6 @@ 2-0",
+        "5.LILE 1-2 SLIDER 88 MPH “6 @@ 2-0",  # same graphic, next frame
+        "5.LILE 1-2 RAY P: 88 “6 @@ 2-1",
+    ])
+    pitches = [c for c in ScorebugRecognizer(roster, ocr=ocr, crop=WHOLE).recognize(MEDIA)
+               if c.event == "pitch"]
+    assert len(pitches) == 1
+    assert pitches[0].entity_ids == ("player:robbie-ray",)
+    assert pitches[0].text == "SLIDER 88 MPH"
+    assert pitches[0].start_s < 2.0 < pitches[0].end_s
+
+
+def test_pitch_with_no_pitcher_in_sight_is_dropped(roster, fake_frames):
+    ocr = fake_frames(["5.LILE 1-2 SLIDER 88 MPH “6 @@ 2-0"])
+    cues = ScorebugRecognizer(roster, ocr=ocr, crop=WHOLE).recognize(MEDIA)
+    assert [c for c in cues if c.event == "pitch"] == []
+
+
+def test_pitch_cues_can_be_turned_off(roster, fake_frames):
+    ocr = fake_frames(["RAY P: 87", "SLIDER 88 MPH"])
+    rec = ScorebugRecognizer(roster, ocr=ocr, pitch_cues=False, crop=WHOLE)
+    cues = rec.recognize(MEDIA)
+    assert [c for c in cues if c.event == "pitch"] == []
+
+
+def test_frames_without_a_bug_contribute_nothing(roster, fake_frames):
+    # "Lee" is on the roster and is the surname tesseract hallucinates most;
+    # with no structured read of him anywhere near, it stays dropped.
+    ocr = fake_frames(["Beir Lee GAS Pt atthe", "FRR ahe ey Maes", ""])
+    assert ScorebugRecognizer(roster, ocr=ocr, crop=WHOLE).recognize(MEDIA) == []
+
+
+def test_a_loose_read_is_admitted_once_confirmed(roster, fake_frames):
+    ocr = fake_frames(["RAY P: 87 5.LILE", "a ray of ligh", "RAY P: 88 5.LILE"])
+    cues = ScorebugRecognizer(roster, ocr=ocr, crop=WHOLE).recognize(MEDIA)
+    ray = [c for c in cues if c.entity_ids == ("player:robbie-ray",)]
+    assert len(ray) == 1 and ray[0].start_s == 0.0 and ray[0].end_s == 6.0
+
+
+def test_the_default_sweep_finds_the_bug_without_being_told_where(roster, fake_frames):
+    # No crop given: the recognizer sweeps its candidate bands, locks onto the
+    # one producing reads, and keeps reading once locked.
+    ocr = fake_frames(["5.LILE 1-2 RAY P: 87 “6 @@ 2-0"] * 24)
+    cues = ScorebugRecognizer(roster, ocr=ocr).recognize(MEDIA)
+    at_bat = [c for c in cues if c.event == "at_bat"]
+    assert at_bat and {c.entity_ids for c in at_bat} == {("player:daylen-lile",)}
+    # Pre-lock sweeps are strided, so the early reads are spaced out and land
+    # in separate runs; what matters is that reading continues past the lock.
+    assert max(c.end_s for c in at_bat) > 40.0
+
+
+def test_an_explicit_crop_pins_the_region(roster, fake_frames):
+    fake_frames(["5.LILE 1-2 RAY P: 87"])
+    rec = ScorebugRecognizer(roster, ocr=lambda p: "", crop=(0.0, 0.0, 0.5, 0.2))
+    assert rec.regions == ((0.0, 0.0, 0.5, 0.2),)
+
+
+def test_missing_ocr_backend_degrades_instead_of_aborting(monkeypatch):
+    monkeypatch.setitem(sys.modules, "pytesseract", None)
+    with pytest.raises(RecognizerUnavailable):
+        scorebug.default_ocr()

--- a/annotator/tests/test_scorebug.py
+++ b/annotator/tests/test_scorebug.py
@@ -269,3 +269,38 @@ def test_missing_ocr_backend_degrades_instead_of_aborting(monkeypatch):
     monkeypatch.setitem(sys.modules, "pytesseract", None)
     with pytest.raises(RecognizerUnavailable):
         scorebug.default_ocr()
+
+
+def test_velocity_branch_rejects_implausible_speeds():
+    """The unit-anchored pattern must apply the same plausibility gate as the
+    typed one; a garbled line ending in digits plus a unit was accepted at any
+    value."""
+    from dirstral_annotator.recognizers import scorebug as sb
+
+    _, ok = sb.parse_overlay("SLIDER 88 MPH")
+    assert [p.speed for p in ok] == [88]
+
+    for line in ("GARBLE 07 MPH", "NOISE 999 KPH", "XX 12 MPH"):
+        _, bad = sb.parse_overlay(line)
+        assert bad == [], f"accepted implausible speed: {line} -> {bad}"
+
+
+def test_missing_pillow_degrades_the_cascade(monkeypatch, tmp_path):
+    """_prepared_crops must raise RecognizerUnavailable, not ImportError, so the
+    pipeline skips this recognizer instead of aborting the whole run."""
+    import builtins
+    from dirstral_annotator.recognizers import scorebug as sb
+    from dirstral_annotator.recognizers.base import RecognizerUnavailable
+
+    real_import = builtins.__import__
+
+    def no_pil(name, *a, **kw):
+        if name == "PIL" or name.startswith("PIL."):
+            raise ImportError("No module named 'PIL'")
+        return real_import(name, *a, **kw)
+
+    monkeypatch.setattr(builtins, "__import__", no_pil)
+    frame = tmp_path / "frame-00000001.jpg"
+    frame.write_bytes(b"\xff\xd8\xff")
+    with pytest.raises(RecognizerUnavailable):
+        list(sb._prepared_crops(frame, (0.0, 0.0, 1.0, 1.0), tmp_path))


### PR DESCRIPTION
## Why

`playbyplay` carries the pilot's 99.4% recall, but it needs an MLB GUMBO feed. Scorebug OCR is the capability that generalises: it reads the broadcast's own overlay, needs nothing at inference time, and is the only identity signal available for the archives dir2mcp actually targets. It was also the weakest thing in the cascade, and it was underperforming rather than fundamentally limited: the bug is crisply legible by eye in every non-cutaway frame.

## Measured, on a real fixture

`segment_5900_6800.mp4` (15 min of the pilot game, 1920x1080), 450 frames at the default 0.5 fps. Ground truth is the GUMBO feed for game 823215 aligned onto the video clock: **23 pitches**, six at-bats, Robbie Ray and Carson Seymour pitching.

A cue counts as correct when the player it names is involved in a pitch within 45 s of the cue. The role-aware column additionally requires the claim to be the right one (an `at_bat` cue must name the batter, a `pitch` cue the pitcher).

| | cues | correct | wrong | precision | role-aware precision |
|---|---|---|---|---|---|
| before | 37 | 20 | 17 | **0.541** | 0.216 |
| after | 110 | 109 | 1 | **0.991** | 0.991 |

| | before | after |
|---|---|---|
| clip covered by a correct cue | 4.9% | 64.4% |
| at-bats whose batter is named | 3 / 6 | **6 / 6** |
| at-bats whose pitcher is named | 6 / 6 (all as `at_bat`, i.e. claiming he was batting) | **6 / 6** (as `appearance` / `pitch`) |
| per-pitch `pitch` cues | none emitted | **19**, each matching a distinct real pitch within 10 s (precision 1.000, recall 0.826 of 23) |

The baseline row is the current recognizer's logic (whole-frame `pytesseract`, `roster.resolve_name` per line, `collapse_sightings`) replayed over the same 450 frames.

Raising the pipeline's `--fps` to 1.0 (a knob this PR does not touch) takes the same code to **23 pitch cues, every one matching a distinct real pitch: recall 1.000 of 23, precision 1.000**, with 92 cues at 0.978 precision and 69.9% coverage. Every pitch in the window, correctly attributed, with no feed.

It is not free. Single process on the same host: the whole-frame pass costs **0.54 s/frame**, the two crop passes **1.09 s/frame**. The second pass is what buys it: across the clip, 44 of the 215 frames that produced any read were readable *only* after thresholding, and another 45 gained a field from it. Halving the cost by making the second pass conditional would cost a fifth of the reads, so it is left as a knob for later rather than taken now.

## What was actually wrong

Three causes, each verified before it was changed.

**Where it looked.** It OCR'd the whole frame. The bug is 2.7% of it and the name is 30 px tall, so tesseract segmented a crowd, a scoreboard and a sponsor board and mostly never reached it. Now a small set of candidate overlay bands (top-left, bottom-left, bottom-centre, top-centre) is cropped, upscaled to a fixed text height (pixels, not a fixed factor, so SD archives get the magnification they need) and OCR'd in two passes: greyscale, and hard-thresholded, because light-on-dark overlay text defeats Otsu when the crop also catches a bright crowd. The two passes disagree often enough to be worth both. Whichever band produces reads locks in, so the sweep is paid once. `crop=` still pins a region explicitly.

**How it matched.** It handed whole OCR lines to a fuzzy roster matcher. That produced all 17 wrong cues: `ee` scored 0.80 against Jung Hoo **Lee**, `inn` 0.86 against **Winn**, `12` 0.80 against Adrian Houser, and `#0` matched the roster's own `#number` alias at 1.00, i.e. whoever wears 0. Matching now runs on parsed name fields only, is exact-only below five characters, ignores the `#number` aliases, folds accents (the bug writes `NUÑEZ`, tesseract writes whatever it likes), and returns nothing for a surname two players share rather than guessing.

**What it claimed.** Every cue was an `at_bat`, including for the pitcher. Roles now come from the overlay's own structure: a lineup slot (`5.LILE`) is the batter, a name trailing a pitch count (`RAY  P: 90`) is the pitcher, and a bare word is trusted only on a line that has structure elsewhere on it, or when the same player was read properly within 30 s. That last rule is what removed the residual noise: during replays the bug is gone and tesseract turns crowd texture into pages of three-letter words, one of which is eventually somebody's surname.

Note for whoever reads the brief: the leading digit is the **lineup slot**, not the jersey number (Daylen Lile bats fifth wearing 4, Nuñez seventh wearing 26). It is used as a structural marker for "this is the batter field" and never as a number-vs-roster constraint, which would have been actively wrong.

## New: per-pitch events with no feed

The pitch-speed graphic (`SLIDER 88 MPH`) becomes a `pitch` cue carrying type and speed, credited to the pitcher the bug was naming around it (the graphic covers the name field while it is up, so the pitcher comes from the surrounding frames or the cue is dropped). Anchoring is on the literal unit, plus a pitch-type vocabulary because "MPH" is set in small caps and comes back as `upeq`/`mpq`/`upv` about half the time.

This is what makes the recognizer scorable on its own terms: `eval.score` only counts `event == "pitch"`, so before this change scorebug could not contribute to the headline metric at all. Entity ids stay pitcher-only, matching `playbyplay`'s role split, so a batter can never become a precision false positive.

Count, outs and inning are also parseable and were deliberately left out: on this bug the ball-strike count and the batter's day line are both `d-d` on the same row, and separating them needs layout knowledge this recognizer does not have. Emitting the wrong one as a fact seemed worse than not emitting it.

## Contracts

- `Recognizer` protocol, `RecognizerUnavailable` degradation, and the `collapse_sightings` / `OcrFn` / `default_ocr` exports that `jersey.py` and `faces.py` import are unchanged.
- `default_ocr()` gained an optional `psm`; the scorebug asks for mode 6, and every other caller keeps tesseract's default, so jersey OCR is untouched.
- Crops are written to the recognizer's own temp dir instead of next to the frame. Frames are now a shared cache glob-ed as `frame-*.jpg`, and the old `frame-N-crop.jpg` sat right inside it.

## Test plan

- `./venv/bin/python -m pytest annotator/tests -q` on the pilot host: **67 passed, 1 skipped**.
- 26 new backend-free tests in `annotator/tests/test_scorebug.py` (no tesseract, no Pillow, no video). The OCR strings in them are verbatim tesseract output from the fixture, mistakes included, so the parser is pinned against what the engine really returns.
- Regressions pinned by name: the day-line digit that used to make the pitcher the batter, each of the four debris strings that used to resolve to a player, the shared surname, and the crowd-texture frame.
