### PR TITLE
fix(eval): explain why a recognizer contributed nothing, instead of printing a zero

### DIFF
--- a/annotator/dirstral_annotator/cli.py
+++ b/annotator/dirstral_annotator/cli.py
@@ -9,7 +9,12 @@
     # Phase-1 accuracy gate against Statcast ground truth
     dirstral-annotate eval game7.mp4 --roster roster.json \
         (--game-pk 745123 | --feed saved-gumbo.json) --anchor "EPOCH=VIDEO_S" \
-        [--report report.md]
+        [--report report.md] [--debug]
+
+The report always carries per-source diagnostics (cues emitted, cues surviving
+fusion and the confidence floor, near-miss distances) so a recognizer that
+contributes nothing to the pitcher-keyed metric can be told apart from one the
+metric cannot read; `--debug` adds sample cues per source.
 
 `games.json` binds media basenames to their play-by-play source and time
 anchors: {"game7.mp4": {"game_pk": 745123, "anchors": ["1789265400.0=60.0"]}}.
@@ -23,6 +28,7 @@ import argparse
 import sys
 from pathlib import Path
 
+from .eval import diagnose as diagnose_mod
 from .eval import report as report_mod
 from .eval import score as score_mod
 from .pipeline import GameConfig, Pipeline, load_games
@@ -55,6 +61,11 @@ def build_parser() -> argparse.ArgumentParser:
     e.add_argument("--feed", type=Path, help="saved GUMBO JSON (skips the network fetch)")
     e.add_argument("--anchor", action="append", default=[], metavar="EPOCH=VIDEO_S", required=True)
     e.add_argument("--report", type=Path, help="write markdown report here")
+    e.add_argument(
+        "--debug",
+        action="store_true",
+        help="add per-source sample cues to the report's diagnostics",
+    )
     vision_flags(e)
     return p
 
@@ -105,13 +116,22 @@ def main(argv: list[str] | None = None) -> int:
         )
 
     pipeline = _pipeline(args, roster, {args.media.name: game})
-    annotations = pipeline.annotations_for(args.media)
+    # Keep the pre-fusion cues: they are what makes an empty source row
+    # explainable (ineligible / floored / weak) instead of just empty.
+    cues, annotations = diagnose_mod.run_pipeline(pipeline, args.media)
     for msg in pipeline.skipped:
         print(f"skipped: {msg}", file=sys.stderr)
 
     events = game.events()
     card = score_mod.score(annotations, events, alignment, roster)
-    text = report_mod.render(card, alignment, roster, title=args.media.name)
+    diagnostics = diagnose_mod.diagnose(
+        cues, annotations, events, alignment, roster, card,
+        min_confidence=args.min_confidence,
+    )
+    text = report_mod.render(
+        card, alignment, roster, title=args.media.name,
+        diagnostics=diagnostics, debug=args.debug,
+    )
     if args.report:
         args.report.write_text(text, encoding="utf-8")
         print(f"wrote {args.report}")

--- a/annotator/dirstral_annotator/eval/diagnose.py
+++ b/annotator/dirstral_annotator/eval/diagnose.py
@@ -1,0 +1,290 @@
+"""Per-source diagnostics: why a recognizer contributed nothing.
+
+`score()` answers exactly one question: for each ground-truth pitch, did some
+predicted annotation with event `pitch`, naming that *pitcher*, overlap it?
+Both qualifiers are load-bearing. A recognizer that never emits a `pitch` cue,
+or never names the pitcher, cannot appear in the "found by source" table
+however well it works: its zero is a property of the metric, not a measurement
+of the recognizer.
+
+Reading that table on its own therefore invites the wrong conclusion. These
+diagnostics separate the cases that all render as an absent row:
+
+  * structurally ineligible: the source's cues are not the kind of claim the
+    metric scores (wrong event, or never names the pitcher), so no amount of
+    recognizer quality could ever produce a hit;
+  * dropped: cues existed and fused, but the `--min-confidence` floor removed
+    the annotation;
+  * genuinely weak: eligible cues existed and simply did not land near a
+    ground-truth pitch. The near-miss distances say how far off they were.
+
+Nothing here changes the committed accuracy metric. It reports the same run
+from the recognizers' side so "vision is weak" and "vision is invisible to
+this scorer" stop looking identical.
+"""
+
+from __future__ import annotations
+
+import statistics
+from bisect import bisect_left, bisect_right
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from ..fusion import fuse
+from ..model import Annotation, Cue
+from ..roster import Roster
+from .align import Alignment
+from .ground_truth import PitchEvent
+from .score import SCORED_EVENT, TOLERANCE_S, Scorecard
+
+if TYPE_CHECKING:  # pragma: no cover - import cycle guard, typing only
+    from ..pipeline import Pipeline
+
+# How many example cues a --debug listing shows per source.
+DEBUG_SAMPLE = 10
+
+
+def run_pipeline(pipeline: "Pipeline", media_path: Path) -> tuple[list[Cue], list[Annotation]]:
+    """Run the cascade keeping the pre-fusion cues.
+
+    `Pipeline.annotations_for` throws the cues away, and the cues are what
+    make a zero row explainable (how many a source emitted before fusion and
+    before the confidence floor).
+    """
+    cues = pipeline.cues_for(media_path)
+    return cues, fuse(cues, min_confidence=pipeline.min_confidence)
+
+
+@dataclass(frozen=True)
+class ScoredWindow:
+    """One ground-truth pitch as the scorer sees it: on the video timeline,
+    with the roster ids of the two players the play involves."""
+
+    video_s: float
+    pitcher_id: str
+    batter_id: str | None
+
+
+@dataclass
+class SourceDiagnostics:
+    source: str
+    cues: int = 0
+    cues_by_event: dict[str, int] = field(default_factory=lambda: defaultdict(int))
+    annotations_fused: int = 0  # fused annotations this source contributed to
+    annotations_dropped: int = 0  # ... that the min-confidence floor removed
+    scored_event_cues: int = 0  # cues whose event the scorer even looks at
+    cues_near_pitch: int = 0  # cues overlapping a scored pitch within tolerance
+    cues_naming_pitcher: int = 0  # ... that name that pitch's pitcher
+    cues_naming_batter: int = 0  # ... that name that pitch's batter
+    unknown_entity_ids: set[str] = field(default_factory=set)
+    # Where on the video timeline this source's cues actually sit. A span that
+    # runs past the media is a plumbing fault (corrupt frame timestamps), not a
+    # recognition result, and it is invisible in any per-pitch count.
+    first_cue_s: float | None = None
+    last_cue_s: float | None = None
+    near_miss_s: list[float] = field(default_factory=list)  # off-target cue distances
+    pitches_with_pitcher_cue: int = 0
+    pitches_with_batter_cue: int = 0
+    pitches_covered: int = 0  # pitcher or batter named within tolerance
+    found_pitches: int = 0  # credited by the scorecard
+    samples: list[Cue] = field(default_factory=list)
+
+    @property
+    def verdict(self) -> str:
+        if self.found_pitches:
+            return f"counted: credited on {self.found_pitches} scored pitch(es)"
+        if not self.cues:
+            return "no cues emitted (recognizer produced nothing, or was skipped)"
+        if self.annotations_fused == 0 and self.annotations_dropped:
+            return (
+                f"dropped: all {self.annotations_dropped} fused annotation(s) fell "
+                "below --min-confidence"
+            )
+        if self.scored_event_cues == 0:
+            events = ", ".join(f"`{e}`" for e in sorted(self.cues_by_event))
+            return (
+                f"UNREACHABLE by this metric: emits {events} cues, never "
+                f"`{SCORED_EVENT}`; the scorecard reads `{SCORED_EVENT}` "
+                "annotations only"
+            )
+        # Order matters: "never lands near a pitch" is a recognizer result and
+        # must not be dressed up as an unreachable target. Only cues that DO
+        # overlap a pitch can testify about the role (pitcher vs batter) they
+        # name, so the role verdict comes second.
+        if self.cues_near_pitch == 0:
+            return "weak: eligible cues exist but none land within tolerance of a pitch"
+        if self.cues_naming_pitcher == 0:
+            return (
+                "UNREACHABLE by this metric: never names the ground-truth "
+                "pitcher of a pitch it overlaps (the metric is pitcher-keyed)"
+            )
+        return "eligible and on time but uncredited: scorer plumbing needs a look"
+
+    @property
+    def unreachable(self) -> bool:
+        return self.verdict.startswith("UNREACHABLE")
+
+
+@dataclass
+class Diagnostics:
+    tolerance_s: float
+    min_confidence: float
+    scored_pitches: int
+    per_source: dict[str, SourceDiagnostics] = field(default_factory=dict)
+
+    @property
+    def unreachable_sources(self) -> list[str]:
+        return sorted(s for s, d in self.per_source.items() if d.unreachable)
+
+
+def scored_windows(
+    events: list[PitchEvent], alignment: Alignment, roster: Roster
+) -> list[ScoredWindow]:
+    """The ground-truth pitches `score()` actually scores, on video time.
+
+    Mirrors the scorer's filter exactly (pitches by a rostered pitcher); a
+    diagnostic measured against a different denominator would not explain the
+    scorecard it sits next to.
+    """
+    windows = []
+    for ev in events:
+        pitcher = roster.by_mlbam(ev.pitcher_id)
+        if pitcher is None:
+            continue
+        batter = roster.by_mlbam(ev.batter_id)
+        windows.append(
+            ScoredWindow(
+                video_s=alignment.to_video(ev.epoch_s),
+                pitcher_id=pitcher.id,
+                batter_id=batter.id if batter else None,
+            )
+        )
+    windows.sort(key=lambda w: w.video_s)
+    return windows
+
+
+def diagnose(
+    cues: list[Cue],
+    annotations: list[Annotation],
+    events: list[PitchEvent],
+    alignment: Alignment,
+    roster: Roster,
+    card: Scorecard,
+    min_confidence: float = 0.0,
+    tolerance_s: float = TOLERANCE_S,
+) -> Diagnostics:
+    """Explain, per source, what happened to its cues.
+
+    `annotations` must be the post-floor list the scorecard was built from;
+    the unfloored fusion is recomputed here so "dropped by the floor" is
+    measured rather than guessed.
+    """
+    windows = scored_windows(events, alignment, roster)
+    times = [w.video_s for w in windows]
+    diag = Diagnostics(
+        tolerance_s=tolerance_s,
+        min_confidence=min_confidence,
+        scored_pitches=len(windows),
+    )
+
+    def bucket(source: str) -> SourceDiagnostics:
+        return diag.per_source.setdefault(source, SourceDiagnostics(source=source))
+
+    # Sources are enumerated from cues *and* annotations: a source whose every
+    # annotation was floored still deserves a row, and so does one that only
+    # shows up post-fusion.
+    for cue in cues:
+        bucket(cue.source)
+    for ann in annotations:
+        for src in ann.sources:
+            bucket(src)
+    for src, found in card.per_source_found.items():
+        bucket(src).found_pitches = found
+
+    # Re-fuse without the floor: the difference against `min_confidence` is
+    # what the floor removed, measured rather than guessed. Same cues in, so
+    # the groups are identical and only the filter differs.
+    unfloored = fuse(cues, min_confidence=0.0) if cues else list(annotations)
+    for ann in unfloored:
+        dropped = ann.confidence < min_confidence
+        for src in ann.sources:
+            b = bucket(src)
+            if dropped:
+                b.annotations_dropped += 1
+            else:
+                b.annotations_fused += 1
+
+    # Pitch coverage is per-window so one chatty cue cannot cover a pitch twice.
+    covered_pitcher: dict[str, set[int]] = defaultdict(set)
+    covered_batter: dict[str, set[int]] = defaultdict(set)
+
+    for cue in cues:
+        b = bucket(cue.source)
+        b.cues += 1
+        b.cues_by_event[cue.event] += 1
+        b.first_cue_s = (cue.start_s if b.first_cue_s is None
+                         else min(b.first_cue_s, cue.start_s))
+        b.last_cue_s = (cue.end_s if b.last_cue_s is None
+                        else max(b.last_cue_s, cue.end_s))
+        if cue.event == SCORED_EVENT:
+            b.scored_event_cues += 1
+        for pid in cue.entity_ids:
+            if roster.get(pid) is None:
+                b.unknown_entity_ids.add(pid)
+        if len(b.samples) < DEBUG_SAMPLE:
+            b.samples.append(cue)
+
+        lo = bisect_left(times, cue.start_s - tolerance_s)
+        hi = bisect_right(times, cue.end_s + tolerance_s)
+        if lo >= hi:
+            b.near_miss_s.append(_distance_to_nearest(cue, times, lo))
+            continue
+        b.cues_near_pitch += 1
+        named_pitcher = named_batter = False
+        for idx in range(lo, hi):
+            w = windows[idx]
+            if w.pitcher_id in cue.entity_ids:
+                named_pitcher = True
+                covered_pitcher[cue.source].add(idx)
+            if w.batter_id is not None and w.batter_id in cue.entity_ids:
+                named_batter = True
+                covered_batter[cue.source].add(idx)
+        b.cues_naming_pitcher += int(named_pitcher)
+        b.cues_naming_batter += int(named_batter)
+
+    for src, b in diag.per_source.items():
+        b.pitches_with_pitcher_cue = len(covered_pitcher[src])
+        b.pitches_with_batter_cue = len(covered_batter[src])
+        b.pitches_covered = len(covered_pitcher[src] | covered_batter[src])
+    return diag
+
+
+def near_miss_summary(distances: list[float]) -> dict[str, float] | None:
+    """min / median / p90 / max of off-target cue distances, or None."""
+    if not distances:
+        return None
+    ordered = sorted(distances)
+    p90 = ordered[min(len(ordered) - 1, int(round(0.9 * (len(ordered) - 1))))]
+    return {
+        "count": float(len(ordered)),
+        "min": ordered[0],
+        "median": statistics.median(ordered),
+        "p90": p90,
+        "max": ordered[-1],
+    }
+
+
+def _distance_to_nearest(cue: Cue, times: list[float], lo: int) -> float:
+    """Seconds between this cue's range and the closest scored pitch.
+
+    Zero would mean overlap, so callers only reach this for cues that already
+    failed the tolerance test; `inf` when there is nothing to be near.
+    """
+    best = float("inf")
+    for idx in (lo - 1, lo):
+        if 0 <= idx < len(times):
+            t = times[idx]
+            best = min(best, max(cue.start_s - t, t - cue.end_s, 0.0))
+    return best

--- a/annotator/dirstral_annotator/eval/report.py
+++ b/annotator/dirstral_annotator/eval/report.py
@@ -1,17 +1,34 @@
-"""Render a Scorecard as the phase-1 markdown accuracy report."""
+"""Render a Scorecard as the phase-1 markdown accuracy report.
+
+The scorecard alone is not a readable report. Its headline pair and its
+per-source table are both narrower than they look: with play-by-play enabled
+the headline mostly measures wall-clock alignment, and the source table can
+only list sources that reached a credited `pitch` annotation. When
+`eval.diagnose` output is supplied, the renderer states both limits and prints
+the per-source evidence, so an absent source reads as "not eligible" or "weak"
+rather than as an unexplained zero.
+"""
 
 from __future__ import annotations
 
 from ..roster import Roster
 from .align import Alignment
-from .score import Scorecard
+from .diagnose import DEBUG_SAMPLE, Diagnostics, near_miss_summary
+from .score import SCORED_EVENT, Scorecard
 
 
 def _pct(v: float | None) -> str:
     return f"{v * 100:.1f}%" if v is not None else "n/a"
 
 
-def render(card: Scorecard, alignment: Alignment, roster: Roster, title: str) -> str:
+def render(
+    card: Scorecard,
+    alignment: Alignment,
+    roster: Roster,
+    title: str,
+    diagnostics: Diagnostics | None = None,
+    debug: bool = False,
+) -> str:
     lines = [
         f"# Accuracy report — {title}",
         "",
@@ -22,6 +39,10 @@ def render(card: Scorecard, alignment: Alignment, roster: Roster, title: str) ->
         f"spread {alignment.spread_s:.2f}s"
         + (" — **DRIFT WARNING: timeline is not a single linear shift; "
            "re-anchor per segment**" if alignment.drifty else ""),
+        "",
+        f"> Scope of the headline: it scores `{SCORED_EVENT}` annotations naming the "
+        "ground-truth **pitcher**. When play-by-play is enabled it is therefore "
+        "mostly a measurement of wall-clock alignment, not of computer vision.",
         "",
         "## Per player",
         "",
@@ -40,6 +61,11 @@ def render(card: Scorecard, alignment: Alignment, roster: Roster, title: str) ->
         "",
         "## Pitches found, by contributing source",
         "",
+        f"Counts sources that reached a credited `{SCORED_EVENT}` annotation naming "
+        "the pitcher. **An absent source has not been measured as weak**; it may "
+        "be making a kind of claim this metric never reads. See the diagnostics "
+        "below before drawing any conclusion from this table.",
+        "",
         "| Source | Found pitches it contributed to |",
         "|---|---|",
     ]
@@ -48,4 +74,128 @@ def render(card: Scorecard, alignment: Alignment, roster: Roster, title: str) ->
     if not card.per_source_found:
         lines.append("| _none_ | 0 |")
     lines.append("")
+    if diagnostics is not None:
+        lines += _diagnostics_sections(diagnostics, roster, debug)
     return "\n".join(lines)
+
+
+def _diagnostics_sections(diag: Diagnostics, roster: Roster, debug: bool) -> list[str]:
+    lines = [
+        "## Source diagnostics",
+        "",
+        f"Tolerance ±{diag.tolerance_s:.1f}s; confidence floor "
+        f"{diag.min_confidence:.2f}; {diag.scored_pitches} scored pitch(es).",
+        "",
+        "| Source | Cues | Events | Cue span (s) | Fused anns | Floored "
+        "| Scored-event cues | Cues near a pitch | Verdict |",
+        "|---|---|---|---|---|---|---|---|---|",
+    ]
+    for src in sorted(diag.per_source):
+        d = diag.per_source[src]
+        events = ", ".join(f"{e} {n}" for e, n in sorted(d.cues_by_event.items())) or "none"
+        span = ("none" if d.first_cue_s is None
+                else f"{d.first_cue_s:.0f}..{d.last_cue_s:.0f}")
+        lines.append(
+            f"| {src} | {d.cues} | {events} | {span} | {d.annotations_fused} "
+            f"| {d.annotations_dropped} | {d.scored_event_cues} "
+            f"| {d.cues_near_pitch} | {d.verdict} |"
+        )
+    lines += [
+        "",
+        "Read `Cue span` against the media's own duration first: a source whose "
+        "cues run past the end of the file has corrupt timestamps, and every "
+        "per-pitch number for it below is meaningless until that is fixed.",
+    ]
+    unreachable = diag.unreachable_sources
+    if unreachable:
+        lines += [
+            "",
+            f"> **{', '.join(unreachable)} cannot score on this metric.** The metric "
+            f"asks a pitcher-keyed question about `{SCORED_EVENT}` annotations; these "
+            "sources report who is visible on screen, which at a pitch is usually the "
+            "batter. Their absence from the table above is a property of the target, "
+            "not a recognizer result. Judge them on the identity-coverage numbers "
+            "below, and change the metric (not the recognizers) if pitcher-keyed "
+            f"`{SCORED_EVENT}` coverage is what the archive needs from them.",
+        ]
+
+    lines += [
+        "",
+        "### Identity coverage (diagnostic, NOT the phase-1 gate)",
+        "",
+        f"Role-agnostic: of the {diag.scored_pitches} scored pitch(es), how many had "
+        f"at least one cue from this source within ±{diag.tolerance_s:.1f}s naming "
+        "that pitch's pitcher or batter. This says whether a recognizer works at all; "
+        "it is deliberately easier than the gate above and must never be quoted as "
+        "accuracy.",
+        "",
+        "| Source | Pitches w/ pitcher cue | Pitches w/ batter cue | Pitches covered "
+        "| Coverage |",
+        "|---|---|---|---|---|",
+    ]
+    for src in sorted(diag.per_source):
+        d = diag.per_source[src]
+        pct = _pct(d.pitches_covered / diag.scored_pitches if diag.scored_pitches else None)
+        lines.append(
+            f"| {src} | {d.pitches_with_pitcher_cue} | {d.pitches_with_batter_cue} "
+            f"| {d.pitches_covered} | {pct} |"
+        )
+
+    off_target = {
+        src: near_miss_summary(d.near_miss_s)
+        for src, d in diag.per_source.items()
+        if d.near_miss_s
+    }
+    if off_target:
+        lines += [
+            "",
+            "### Near misses (cues that land outside tolerance)",
+            "",
+            "Distance in seconds from the cue's range to the nearest scored pitch. "
+            "Small numbers mean the tolerance or the cue windows are the problem; "
+            "moderate ones mean the cue is about something else entirely (a "
+            "between-pitch close-up, a dugout shot); distances on the order of the "
+            "media duration mean the cue's timestamps are wrong, which is a "
+            "plumbing bug, not a recognizer verdict.",
+            "",
+            "| Source | Off-target cues | min | median | p90 | max |",
+            "|---|---|---|---|---|---|",
+        ]
+        for src in sorted(off_target):
+            s = off_target[src]
+            lines.append(
+                f"| {src} | {int(s['count'])} | {s['min']:.1f} | {s['median']:.1f} "
+                f"| {s['p90']:.1f} | {s['max']:.1f} |"
+            )
+
+    unknown = {src: d.unknown_entity_ids for src, d in diag.per_source.items()
+               if d.unknown_entity_ids}
+    if unknown:
+        lines += ["", "### Entity ids not on the roster", ""]
+        for src in sorted(unknown):
+            ids = ", ".join(f"`{i}`" for i in sorted(unknown[src])[:DEBUG_SAMPLE])
+            lines.append(f"- **{src}**: {ids}")
+        lines.append("")
+        lines.append(
+            "These cues can never match a roster-keyed event; the recognizer and the "
+            "roster disagree on the entity vocabulary."
+        )
+
+    if debug:
+        lines += ["", "### Sample cues (--debug)", ""]
+        for src in sorted(diag.per_source):
+            d = diag.per_source[src]
+            lines.append(f"**{src}** (first {len(d.samples)} of {d.cues})")
+            lines.append("")
+            for cue in d.samples:
+                names = ", ".join(
+                    (roster.get(pid).name if roster.get(pid) else pid)
+                    for pid in cue.entity_ids
+                )
+                lines.append(
+                    f"- `{cue.start_s:.1f}-{cue.end_s:.1f}s` {cue.event} "
+                    f"conf {cue.confidence:.2f}: {names or '(no entity)'}"
+                )
+            lines.append("")
+    lines.append("")
+    return lines

--- a/annotator/dirstral_annotator/eval/report.py
+++ b/annotator/dirstral_annotator/eval/report.py
@@ -63,8 +63,17 @@ def render(
         "",
         f"Counts sources that reached a credited `{SCORED_EVENT}` annotation naming "
         "the pitcher. **An absent source has not been measured as weak**; it may "
-        "be making a kind of claim this metric never reads. See the diagnostics "
-        "below before drawing any conclusion from this table.",
+        "be making a kind of claim this metric never reads."
+        + (
+            " See the diagnostics below before drawing any conclusion from this"
+            " table."
+            if diagnostics is not None
+            # Without diagnostics there is no section below to consult, and
+            # pointing at one that is not there reads as though the reader
+            # simply failed to find it.
+            else " Re-run with diagnostics enabled to tell an unreachable source"
+            " apart from a weak one."
+        ),
         "",
         "| Source | Found pitches it contributed to |",
         "|---|---|",

--- a/annotator/dirstral_annotator/eval/score.py
+++ b/annotator/dirstral_annotator/eval/score.py
@@ -4,8 +4,15 @@ The pilot's committed metric is event-level: for each ground-truth pitch,
 did some predicted pitch annotation involving that pitcher overlap it
 (within tolerance)? Recall = found pitches / all pitches; precision =
 predicted pitch annotations that correspond to some real pitch by that
-player. Reported overall, per player, and per contributing source (which is
-what decides which recognizers the archive actually needs).
+player. Reported overall, per player, and per contributing source.
+
+Read the per-source counts narrowly. They say which sources contributed to a
+credited `pitch` annotation naming the *pitcher*; they do NOT rank recognizer
+quality, and an absent source has not been measured as weak. A recognizer
+that reports who is on screen (scorebug, jersey, face) emits `at_bat` /
+`appearance` cues about whoever it sees, which at a pitch is usually the
+batter, so it can never enter this table however well it works. `eval.diagnose`
+exists to tell those cases apart; the report prints both together on purpose.
 """
 
 from __future__ import annotations
@@ -19,6 +26,9 @@ from .align import Alignment
 from .ground_truth import PitchEvent
 
 TOLERANCE_S = 5.0
+# The only annotation event this metric looks at. Named so the diagnostics can
+# state the eligibility rule instead of re-hardcoding the string.
+SCORED_EVENT = "pitch"
 
 
 @dataclass
@@ -42,7 +52,9 @@ class PRCount:
 class Scorecard:
     overall: PRCount = field(default_factory=PRCount)
     per_player: dict[str, PRCount] = field(default_factory=lambda: defaultdict(PRCount))
-    # source tag -> pitches found by annotations that source contributed to
+    # source tag -> pitches found by annotations that source contributed to.
+    # Only sources that reach a credited `pitch` annotation can appear; see the
+    # module docstring before reading an absent source as a weak one.
     per_source_found: dict[str, int] = field(default_factory=lambda: defaultdict(int))
     total_events: int = 0
 
@@ -55,7 +67,7 @@ def score(
     tolerance_s: float = TOLERANCE_S,
 ) -> Scorecard:
     card = Scorecard()
-    pitch_anns = [a for a in annotations if a.event == "pitch"]
+    pitch_anns = [a for a in annotations if a.event == SCORED_EVENT]
     matched_anns: set[int] = set()
 
     # Recall: every rostered ground-truth pitch must be covered.

--- a/annotator/tests/test_eval_diagnostics.py
+++ b/annotator/tests/test_eval_diagnostics.py
@@ -1,0 +1,279 @@
+"""Diagnostics that tell "vision is weak" apart from "vision is invisible".
+
+The pilot's headline (99.4% recall, 100% precision, playbyplay the only listed
+source) was read as "the three vision recognizers found nothing". These tests
+pin the actual reason: the metric scores `pitch` annotations naming the
+ground-truth pitcher, vision emits `at_bat` / `appearance` cues naming whoever
+is on screen, and fusion never merges across event types, so a vision cue
+cannot reach the table no matter how good it is.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from dirstral_annotator.eval import ground_truth
+from dirstral_annotator.eval.align import Anchor, estimate
+from dirstral_annotator.eval.diagnose import diagnose, run_pipeline, scored_windows
+from dirstral_annotator.eval.report import render
+from dirstral_annotator.eval.score import score
+from dirstral_annotator.fusion import fuse
+from dirstral_annotator.model import Cue
+from dirstral_annotator.pipeline import GameConfig, Pipeline
+from dirstral_annotator.roster import Roster
+
+FIXTURE = Path(__file__).parent / "fixtures" / "gumbo_min.json"
+PITCHER = "player:webb-logan"
+BATTER = "player:freeman-freddie"
+
+
+@pytest.fixture
+def events():
+    return ground_truth.parse_pitches(ground_truth.load_game(FIXTURE))
+
+
+@pytest.fixture
+def roster(tmp_path):
+    path = tmp_path / "roster.json"
+    path.write_text(json.dumps([
+        {"id": PITCHER, "name": "Logan Webb", "number": "62", "mlbam_id": 657277},
+        {"id": BATTER, "name": "Freddie Freeman", "number": "5", "mlbam_id": 518692},
+    ]))
+    return Roster.load(path)
+
+
+@pytest.fixture
+def alignment(events):
+    return estimate([Anchor(events[0].epoch_s, 60.0)])
+
+
+def pitch_cue(alignment, events, i, entity=PITCHER, source="playbyplay", conf=0.98):
+    t = alignment.to_video(events[i].epoch_s)
+    return Cue(source=source, start_s=t - 3, end_s=t + 5, event="pitch",
+               entity_ids=(entity,), confidence=conf, text="")
+
+
+def vision_cue(alignment, events, i, entity=BATTER, source="scorebug",
+               event="at_bat", conf=0.6, shift=0.0):
+    t = alignment.to_video(events[i].epoch_s) + shift
+    return Cue(source=source, start_s=t - 2, end_s=t + 2, event=event,
+               entity_ids=(entity,), confidence=conf, text="")
+
+
+def run(cues, events, alignment, roster, min_confidence=0.0):
+    annotations = fuse(cues, min_confidence=min_confidence)
+    card = score(annotations, events, alignment, roster)
+    diag = diagnose(cues, annotations, events, alignment, roster, card,
+                    min_confidence=min_confidence)
+    return card, diag
+
+
+# --- the root cause -------------------------------------------------------
+
+
+def test_fusion_never_merges_across_event_types(alignment, events):
+    """A perfectly co-timed `at_bat` cue cannot join a `pitch` annotation.
+
+    This is the mechanism behind the empty source table: fusion groups by
+    event, so no vision cue can ever end up in `Annotation.sources` of the
+    annotations the scorer reads.
+    """
+    cues = [pitch_cue(alignment, events, 0),
+            vision_cue(alignment, events, 0, entity=PITCHER)]
+    annotations = fuse(cues)
+    assert len(annotations) == 2
+    by_event = {a.event: a for a in annotations}
+    assert by_event["pitch"].sources == ("playbyplay",)
+    assert by_event["at_bat"].sources == ("scorebug",)
+
+
+def test_vision_source_is_unreachable_not_weak(alignment, events, roster):
+    """Scorebug sees every pitch, at the right time, and still scores zero."""
+    cues = [pitch_cue(alignment, events, i) for i in range(len(events))]
+    cues += [vision_cue(alignment, events, i) for i in range(len(events))]
+    card, diag = run(cues, events, alignment, roster)
+
+    assert card.overall.recall == 1.0
+    assert dict(card.per_source_found) == {"playbyplay": 4}  # the misleading table
+
+    sb = diag.per_source["scorebug"]
+    assert sb.cues == 4  # cues were emitted
+    assert sb.annotations_fused == 4 and sb.annotations_dropped == 0  # and survived
+    assert sb.cues_near_pitch == 4  # and landed on real pitches
+    assert sb.scored_event_cues == 0  # but are not the event the metric reads
+    assert sb.found_pitches == 0
+    assert sb.unreachable
+    assert "UNREACHABLE" in sb.verdict and "at_bat" in sb.verdict
+    assert diag.unreachable_sources == ["scorebug"]
+
+
+def test_pitch_event_source_that_never_names_the_pitcher_is_unreachable(
+    alignment, events, roster
+):
+    """Same trap one level down: right event, wrong role.
+
+    A recognizer emitting `pitch` cues about the batter clears the event
+    filter and still cannot score, because the metric is pitcher-keyed.
+    """
+    cues = [vision_cue(alignment, events, i, entity=BATTER, source="jersey",
+                       event="pitch") for i in range(len(events))]
+    _, diag = run(cues, events, alignment, roster)
+    j = diag.per_source["jersey"]
+    assert j.scored_event_cues == 4 and j.cues_near_pitch == 4
+    # Two of the four fixture pitches are to a rostered batter (Freeman); the
+    # other two are to Betts, who is not on this roster.
+    assert j.cues_naming_pitcher == 0 and j.cues_naming_batter == 2
+    assert j.unreachable and "pitcher-keyed" in j.verdict
+
+
+# --- the cases the diagnostics must NOT confuse with unreachability -------
+
+
+def test_genuinely_weak_source_reads_as_weak(alignment, events, roster):
+    """Eligible in every structural way, simply late: verdict is `weak`."""
+    cues = [Cue(source="face", start_s=5000, end_s=5010, event="pitch",
+                entity_ids=(PITCHER,), confidence=0.6)]
+    _, diag = run(cues, events, alignment, roster)
+    f = diag.per_source["face"]
+    assert not f.unreachable
+    assert f.cues_near_pitch == 0
+    assert f.verdict.startswith("weak")
+    assert f.near_miss_s and f.near_miss_s[0] > 1000  # far from any pitch
+
+
+def test_near_miss_distance_shows_a_tolerance_problem(alignment, events, roster):
+    """A cue 8s off a pitch is a tolerance question, not a vision failure."""
+    cues = [vision_cue(alignment, events, 0, entity=PITCHER, source="face",
+                       event="pitch", shift=8.0)]
+    _, diag = run(cues, events, alignment, roster)
+    f = diag.per_source["face"]
+    assert f.cues_near_pitch == 0
+    # The cue spans t+6..t+10: 6s from the pitch, just past the 5s tolerance.
+    # A 6s number says "widen the tolerance or the cue window"; a 600s number
+    # would say "this recognizer is looking at something else".
+    assert f.near_miss_s == pytest.approx([6.0], abs=0.01)
+
+
+def test_confidence_floor_is_reported_as_dropped(alignment, events, roster):
+    cues = [pitch_cue(alignment, events, 0)]
+    cues += [vision_cue(alignment, events, i, source="face", event="appearance",
+                        conf=0.2) for i in range(len(events))]
+    _, diag = run(cues, events, alignment, roster, min_confidence=0.5)
+    f = diag.per_source["face"]
+    assert f.cues == 4
+    assert f.annotations_fused == 0 and f.annotations_dropped > 0
+    assert f.verdict.startswith("dropped")
+
+
+def test_cue_span_exposes_corrupt_timestamps(alignment, events, roster):
+    """Cues running past the end of the media are a plumbing fault.
+
+    Observed for real: with `--jersey --faces` together, the face recognizer's
+    cues ran to 6446s on a 900s clip, and every per-pitch number for it was
+    meaningless. A per-pitch count cannot show that; the cue span can.
+    """
+    cues = [Cue(source="face", start_s=t, end_s=t + 4, event="appearance",
+                entity_ids=(PITCHER,), confidence=0.6)
+            for t in (100.0, 6400.0)]
+    card, diag = run(cues, events, alignment, roster)
+    f = diag.per_source["face"]
+    assert (f.first_cue_s, f.last_cue_s) == (100.0, 6404.0)
+    text = render(card, alignment, roster, title="clip.mp4", diagnostics=diag)
+    assert "100..6404" in text
+    assert "corrupt timestamps" in text
+
+
+def test_entity_ids_off_the_roster_are_surfaced(alignment, events, roster):
+    cues = [Cue(source="jersey", start_s=57, end_s=65, event="appearance",
+                entity_ids=("player:not-on-this-roster",), confidence=0.6)]
+    _, diag = run(cues, events, alignment, roster)
+    assert diag.per_source["jersey"].unknown_entity_ids == {"player:not-on-this-roster"}
+
+
+# --- the honest, clearly-labelled vision number ---------------------------
+
+
+def test_identity_coverage_credits_batter_sightings(alignment, events, roster):
+    """The number that says whether vision works, kept out of the gate."""
+    cues = [vision_cue(alignment, events, i) for i in range(2)]
+    _, diag = run(cues, events, alignment, roster)
+    sb = diag.per_source["scorebug"]
+    assert diag.scored_pitches == 4
+    assert sb.pitches_with_batter_cue == 2 and sb.pitches_with_pitcher_cue == 0
+    assert sb.pitches_covered == 2
+
+
+def test_coverage_counts_each_pitch_once(alignment, events, roster):
+    """A chatty recognizer cannot inflate coverage by repeating itself."""
+    cues = [vision_cue(alignment, events, 0) for _ in range(10)]
+    _, diag = run(cues, events, alignment, roster)
+    assert diag.per_source["scorebug"].pitches_covered == 1
+
+
+def test_scored_windows_mirror_the_scorer(events, alignment, roster, tmp_path):
+    """Diagnostics must use the scorer's denominator, not a different one."""
+    path = tmp_path / "pitcherless.json"
+    path.write_text(json.dumps([{"id": BATTER, "name": "Freddie Freeman",
+                                 "mlbam_id": 518692}]))
+    pitcherless = Roster.load(path)
+    assert scored_windows(events, alignment, pitcherless) == []
+    assert len(scored_windows(events, alignment, roster)) == 4
+
+
+# --- report + wiring ------------------------------------------------------
+
+
+def test_report_states_the_unreachability(alignment, events, roster):
+    cues = [pitch_cue(alignment, events, i) for i in range(len(events))]
+    cues += [vision_cue(alignment, events, i) for i in range(len(events))]
+    card, diag = run(cues, events, alignment, roster)
+    text = render(card, alignment, roster, title="game7.mp4", diagnostics=diag,
+                  debug=True)
+    assert "cannot score on this metric" in text
+    assert "has not been measured as weak" in text
+    assert "Identity coverage" in text
+    assert "NOT the phase-1 gate" in text
+    assert "Sample cues" in text
+    # the headline stays where it was, with its scope spelled out
+    assert "recall: **100.0%**" in text
+    assert "mostly a measurement of wall-clock alignment" in text
+
+
+def test_report_without_diagnostics_is_unchanged(alignment, events, roster):
+    cues = [pitch_cue(alignment, events, i) for i in range(len(events))]
+    card, _ = run(cues, events, alignment, roster)
+    text = render(card, alignment, roster, title="game7.mp4")
+    assert "Source diagnostics" not in text
+
+
+def test_run_pipeline_keeps_the_cues(tmp_path, roster, events):
+    """`Pipeline.annotations_for` discards cues; the eval path must not."""
+    media = tmp_path / "game7.mp4"
+    media.write_bytes(b"\x00")
+    game = GameConfig.parse({
+        "feed": str(FIXTURE), "anchors": [f"{events[0].epoch_s}=60.0"],
+    })
+    pipeline = Pipeline(roster=roster, games={media.name: game})
+    cues, annotations = run_pipeline(pipeline, media)
+    assert cues and annotations
+    assert {c.event for c in cues} == {"pitch", "at_bat"}
+    assert annotations == pipeline.annotations_for(media)
+
+
+def test_eval_cli_emits_diagnostics(tmp_path, events):
+    from dirstral_annotator.cli import main
+
+    media = tmp_path / "game7.mp4"
+    media.write_bytes(b"\x00")
+    roster_path = tmp_path / "cli-roster.json"
+    roster_path.write_text(json.dumps([
+        {"id": PITCHER, "name": "Logan Webb", "number": "62", "mlbam_id": 657277},
+    ]))
+    report = tmp_path / "report.md"
+    rc = main(["eval", str(media), "--roster", str(roster_path), "--feed", str(FIXTURE),
+               "--anchor", f"{events[0].epoch_s}=60.0", "--report", str(report)])
+    assert rc == 0
+    text = report.read_text()
+    assert "## Source diagnostics" in text
+    assert "playbyplay" in text


### PR DESCRIPTION
## The problem

`dirstral-annotate eval --scorebug --jersey --faces` on the full broadcast printed:

```
Overall recall: 99.4%  precision: 100.0%   (344 ground-truth pitches)
## Pitches found, by contributing source
| playbyplay | 342 |
```

Three vision recognizers, zero contribution. That table was read as "vision found nothing". It is not a measurement of vision at all, and the report gave the reader no way to tell.

## Root cause: the scored target is structurally unreachable for vision

`score()` credits a source only when it reaches an annotation that satisfies **both** of:

1. `event == "pitch"`, and
2. `entity_ids` contains the ground-truth **pitcher**.

Only `PlayByPlayRecognizer` ever emits a `pitch` cue. The vision recognizers emit what they actually observe: scorebug emits `at_bat`, jersey and face emit `appearance`, each naming whoever is on screen (at a pitch, usually the batter). And `fusion.fuse` groups strictly by event, so an `at_bat` cue landing exactly on a pitch cannot join that pitch's annotation and cannot appear in its `sources`.

The per-source table was therefore a tautology. It could only ever print `playbyplay`; every other source's absence was guaranteed by the metric, independent of recognizer quality. `test_fusion_never_merges_across_event_types` pins the mechanism.

## Evidence (measured, not assumed)

Run on the host against `segment_5900_6800.mp4` (900s, 23 ground-truth pitches, anchor `1781125929.0=0.0`), full cascade at fps 0.5, `min_confidence=0.0`:

| source | cues | events emitted | cue span (s) | survived fusion + floor | `pitch` cues | cues within 5s of a scored pitch |
|---|---|---|---|---|---|---|
| playbyplay | 354 | at_bat 177, pitch 177 | 20..5775 | 350 | 177 | 46 |
| scorebug | 31 | at_bat 31 | 4..842 | 31 | **0** | 9 |
| jersey | 98 | appearance 98 | 16..890 | 98 | **0** | 47 |
| face | 41 | appearance 41 | 106..6446 | 41 | **0** | 2 |

170 vision cues emitted, 170 survived, **0** of the event type the scorer reads.

### Hypotheses ruled out, and how

- **"Cue windows too narrow vs the 5s TOLERANCE_S"**: ruled out. 58 vision cues land *within* tolerance of a scored pitch (jersey 47, scorebug 9, face 2). Landing on the pitch does not help them, because the event filter runs first.
- **"Fusion dropping cues below min_confidence"**: ruled out. The run used `min_confidence=0.0` and 170/170 vision cues survived into fused annotations (0 floored). Vision confidences were 0.50 to 1.00, well clear of any plausible floor.
- **"Entity-id mismatch between recognizer output and roster ids"**: ruled out. Zero cues carried an id the roster does not know; recognizers resolve through `Roster` before emitting, so the vocabulary already agrees. (The diagnostics still check this, since it is the failure that would look identical.)
- **"The scorer is pitcher-keyed so batter/fielder cues can never count"**: **confirmed**, and it is the weaker half of the cause. Even a vision cue tagged `pitch` would need to name the pitcher; on this segment scorebug names the pitcher at only 4 of 23 pitches. The stronger half is the event filter, which stops vision one step earlier.

## What changed

Nothing about the committed metric. The report now says what it measures and shows the per-source evidence.

- **`eval/diagnose.py`** (new). Per source: cues emitted by event, cue span on the video timeline, annotations surviving fusion, annotations the confidence floor removed, cues landing within tolerance of a scored pitch, whether they name that pitch's pitcher or batter, entity ids the roster does not know, and the near-miss distance distribution for off-target cues.
- **A per-source verdict** that separates the three states that all used to render as an absent row: `UNREACHABLE` (structural: wrong event, or never names the pitcher), `dropped` (the floor), `weak` (a real recognizer result). Ordering is deliberate: "never lands near a pitch" is reported as weak and is never dressed up as an unreachable target.
- **Report**: states the headline's scope (with play-by-play enabled it is mostly a measurement of wall-clock alignment, not of vision); captions the contributing-source table so an absent source cannot be read as a weak one; adds a role-agnostic identity-coverage table explicitly labelled a diagnostic and **not** the phase-1 gate.
- **`--debug`** adds sample cues per source.
- **`score.py`**: behaviour unchanged. Its docstring stops claiming the per-source table "decides which recognizers the archive actually needs", which is the sentence that invited the wrong reading.
- **eval wiring**: runs the cascade through `diagnose.run_pipeline` so the pre-fusion cues survive (`Pipeline.annotations_for` discards them). This is the only change outside `eval/`; `recognizers/` is untouched.

## The honest vision numbers this surfaces

Role-agnostic identity coverage on the same segment (23 pitches). This is deliberately easier than the gate and must not be quoted as accuracy:

| source | pitches w/ pitcher cue | pitches w/ batter cue | pitches covered | coverage |
|---|---|---|---|---|
| scorebug | 4 | 2 | 6 | 26.1% |
| jersey | 0 | 2 | 2 | 8.7% |
| face (run alone) | 0 | 0 | 0 | 0.0% |

So vision is both invisible to this scorer **and** weak on this footage. Those are two separate findings and the report now reports them separately. The recognizers do produce correct identities (face names Robbie Ray at 0.84 confidence, scorebug reads the overlay); they mostly do so between pitches, on close-ups and dugout shots, which is exactly what an "appearance" recognizer is for.

## Secondary bug found, deliberately not fixed here

The `Cue span` column earned itself on the first run: **face cues run to 6446s on a 900s clip** when `--jersey --faces` are enabled together.

Cause: `JerseyRecognizer._crop` writes its person crops as `frame-<n>-p<x>x<y>.jpg` into the same directory the shared frame cache hands out, and the next recognizer's `sorted(cached.glob("frame-*.jpg"))` picks them up as if they were sampled frames, assigning them timestamps `i / fps`. Reproduced cleanly on a 60s clip:

```
face alone         face cues=  4 max end=    44.0s   (clip is 60s)
jersey then face   face cues=  7 max end=   202.0s   (clip is 60s)
```

That is in `recognizers/base.py` and `recognizers/jersey.py`, which are out of scope for this PR (another agent is working there). Filing it separately. Until it is fixed, any `--jersey --faces` run reports garbage face timings, and the report now says so out loud instead of scoring it silently as 0%.

Two smaller observations, also not addressed here:

- `Roster.by_number` returns the first player with a given number, and `roster_823215.json` has 6 numbers shared by two players (both teams in one roster). Jersey identifications on those numbers are a coin flip.
- `PlayByPlayRecognizer` emits cues for the whole game regardless of the media's duration (354 cues, out to 5775s, on a 900s file). Correct for a full-game eval; it makes any segment-scoped eval look precision-poor.

## Tests

`annotator/tests/test_eval_diagnostics.py` (13 new tests) pins:

- fusion never merges across event types (the mechanism);
- a vision source that sees every pitch at the right time still scores zero, and is reported `UNREACHABLE`, not weak;
- right event + wrong role (a `pitch` cue naming the batter) is also `UNREACHABLE`, with the pitcher-keyed reason;
- a genuinely late source reads as `weak`, never as unreachable;
- near-miss distance turns a 6s offset into a tolerance question;
- the confidence floor is reported as `dropped`;
- entity ids off the roster are surfaced;
- identity coverage credits batter sightings and counts each pitch once;
- the cue span exposes corrupt timestamps;
- the diagnostics denominator mirrors the scorer's exactly;
- the report renders the unreachability statement, and is unchanged when no diagnostics are passed.

Gate on the host: `./venv/bin/python -m pytest annotator/tests -q` -> **56 passed, 1 skipped**. No Go code touched.
