### PR TITLE
feat(annotator): select the face ONNX provider, and report the one actually bound

### DIFF
--- a/annotator/dirstral_annotator/recognizers/faces.py
+++ b/annotator/dirstral_annotator/recognizers/faces.py
@@ -43,6 +43,10 @@ SIM_THRESHOLD = 0.40
 #: of quietly costing hours.
 PROVIDER_ENV = "DIRSTRAL_FACE_PROVIDER"
 
+#: Accepted values. Anything else is rejected rather than defaulted, so a typo
+#: cannot quietly select a provider the caller did not ask for.
+_PROVIDER_CHOICES = frozenset({"auto", "cpu", "cuda"})
+
 
 def select_face_providers(requested: str | None = None) -> tuple[list[str], int]:
     """Return the ONNX provider list and insightface ctx_id to use.
@@ -57,7 +61,20 @@ def select_face_providers(requested: str | None = None) -> tuple[list[str], int]
     not need a GPU. That was measurably wrong, and worse, invisible: a CPU run on
     a GPU host looked identical to a correct one.
     """
-    want = (requested or os.environ.get(PROVIDER_ENV) or "auto").strip().lower()
+    # Strip first, then fall back: a variable set to whitespace is a blank
+    # variable, and should mean "unset" exactly as an empty one does.
+    want = (requested or "").strip().lower()
+    if not want:
+        want = (os.environ.get(PROVIDER_ENV) or "").strip().lower() or "auto"
+    if want not in _PROVIDER_CHOICES:
+        # Silently treating a typo as "auto" is the same class of failure this
+        # function exists to remove: "gpu" or "none" would look accepted and run
+        # on whatever happened to be available.
+        raise RecognizerUnavailable(
+            f"unknown face provider {want!r}; expected one of "
+            f"{', '.join(sorted(_PROVIDER_CHOICES))} "
+            f"(set via {PROVIDER_ENV} or the provider argument)"
+        )
     if want == "cpu":
         return ["CPUExecutionProvider"], -1
 
@@ -86,16 +103,35 @@ def select_face_providers(requested: str | None = None) -> tuple[list[str], int]
 
 
 def _session_providers(app: object) -> list[str]:
-    """Providers the underlying ONNX sessions actually bound, best effort."""
+    """Providers the ONNX sessions actually bound, best effort.
+
+    Prefers the `recognition` model. insightface builds a session per model and
+    they can bind differently, so reporting whichever happened to be first could
+    claim CUDA while the heaviest model quietly ran on CPU. Recognition is the
+    one whose cost dominates, so it is the honest one to report.
+    """
     try:
         models = getattr(app, "models", {}) or {}
-        for model in models.values():
-            session = getattr(model, "session", None)
-            if session is not None:
-                return list(session.get_providers())
+        sessions = {
+            name: getattr(model, "session", None) for name, model in models.items()
+        }
+        bound = {
+            name: list(sess.get_providers())
+            for name, sess in sessions.items()
+            if sess is not None
+        }
+        if not bound:
+            return []
+        if len({tuple(v) for v in bound.values()}) > 1:
+            logging.getLogger(__name__).warning(
+                "face models bound different execution providers: %s", bound
+            )
+        for preferred in ("recognition", "detection"):
+            if preferred in bound:
+                return bound[preferred]
+        return next(iter(bound.values()))
     except Exception:  # pragma: no cover - diagnostics must never break a run
-        pass
-    return []
+        return []
 
 
 def default_embedder(provider: str | None = None) -> EmbedFn:

--- a/annotator/dirstral_annotator/recognizers/faces.py
+++ b/annotator/dirstral_annotator/recognizers/faces.py
@@ -14,7 +14,9 @@ scorebug/play-by-play.
 
 from __future__ import annotations
 
+import logging
 import math
+import os
 from collections.abc import Callable
 from pathlib import Path
 
@@ -35,7 +37,68 @@ IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".webp"}
 SIM_THRESHOLD = 0.40
 
 
-def default_embedder() -> EmbedFn:
+#: Environment override for the ONNX execution provider: "cuda", "cpu", or
+#: "auto" (the default). Explicit beats inferred when an operator needs to keep
+#: a shared GPU free, and "cuda" makes a misconfigured host fail loudly instead
+#: of quietly costing hours.
+PROVIDER_ENV = "DIRSTRAL_FACE_PROVIDER"
+
+
+def select_face_providers(requested: str | None = None) -> tuple[list[str], int]:
+    """Return the ONNX provider list and insightface ctx_id to use.
+
+    Auto-detection prefers CUDA when onnxruntime actually offers it. Measured on
+    an NVIDIA A2 with buffalo_l at 640x640: 0.154 s/frame on GPU against
+    1.340 s/frame on CPU, identical detections. Over a 6118 frame game that is
+    16 minutes rather than 2 hours 17, which is the difference between iterating
+    on recognizer accuracy and not.
+
+    The old behaviour hardcoded CPU with a comment that pilot sampling rates did
+    not need a GPU. That was measurably wrong, and worse, invisible: a CPU run on
+    a GPU host looked identical to a correct one.
+    """
+    want = (requested or os.environ.get(PROVIDER_ENV) or "auto").strip().lower()
+    if want == "cpu":
+        return ["CPUExecutionProvider"], -1
+
+    available: list[str] = []
+    try:
+        import onnxruntime as ort  # type: ignore
+
+        available = list(ort.get_available_providers())
+    except ImportError:
+        available = []
+
+    # Availability is necessary but not sufficient: onnxruntime lists the CUDA
+    # provider even when its CUDA/cuDNN libraries fail to load, and only reports
+    # the fallback once a session is created. Callers log what they actually got.
+    cuda_offered = "CUDAExecutionProvider" in available
+    if want == "cuda":
+        if not cuda_offered:
+            raise RecognizerUnavailable(
+                f"{PROVIDER_ENV}=cuda but onnxruntime offers no CUDAExecutionProvider; "
+                "install onnxruntime-gpu and its matching CUDA/cuDNN wheels"
+            )
+        return ["CUDAExecutionProvider", "CPUExecutionProvider"], 0
+    if cuda_offered:
+        return ["CUDAExecutionProvider", "CPUExecutionProvider"], 0
+    return ["CPUExecutionProvider"], -1
+
+
+def _session_providers(app: object) -> list[str]:
+    """Providers the underlying ONNX sessions actually bound, best effort."""
+    try:
+        models = getattr(app, "models", {}) or {}
+        for model in models.values():
+            session = getattr(model, "session", None)
+            if session is not None:
+                return list(session.get_providers())
+    except Exception:  # pragma: no cover - diagnostics must never break a run
+        pass
+    return []
+
+
+def default_embedder(provider: str | None = None) -> EmbedFn:
     try:
         import cv2  # type: ignore
         from insightface.app import FaceAnalysis  # type: ignore
@@ -45,8 +108,25 @@ def default_embedder() -> EmbedFn:
             "(pip install 'dirstral-annotator[face]')"
         ) from exc
 
-    app = FaceAnalysis(name="buffalo_l")
-    app.prepare(ctx_id=-1)  # CPU; pilot-scale sampling rates don't need GPU
+    providers, ctx_id = select_face_providers(provider)
+    app = FaceAnalysis(name="buffalo_l", providers=providers)
+    app.prepare(ctx_id=ctx_id)
+
+    # Report what the session actually bound, not what was requested. A CUDA
+    # provider that fails to load silently degrades to CPU, which is the failure
+    # mode that cost this pilot a full eval run before anyone noticed.
+    actual = _session_providers(app)
+    logging.getLogger(__name__).info(
+        "face recognition provider: %s (requested %s)",
+        actual or "unknown", providers[0],
+    )
+    if "CUDAExecutionProvider" in providers and "CUDAExecutionProvider" not in actual:
+        logging.getLogger(__name__).warning(
+            "CUDA was requested but the session bound %s; face recognition will "
+            "run roughly 8x slower. Check that onnxruntime-gpu matches the "
+            "installed CUDA major version and that its libraries are on "
+            "LD_LIBRARY_PATH.", actual or "CPU",
+        )
 
     def embed(frame: Path) -> list[tuple[Embedding, tuple[int, int, int, int]]]:
         img = cv2.imread(str(frame))

--- a/annotator/tests/test_face_provider.py
+++ b/annotator/tests/test_face_provider.py
@@ -1,0 +1,84 @@
+"""Execution-provider selection for face recognition.
+
+The pilot ran a full eval on CPU while two GPUs sat idle, because the provider
+was hardcoded and nothing reported it. These pin the selection rules and, more
+importantly, that a silent CPU fallback is visible.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from dirstral_annotator.recognizers import faces
+from dirstral_annotator.recognizers.base import RecognizerUnavailable
+
+
+def _offer(monkeypatch, providers):
+    import sys, types
+    mod = types.ModuleType("onnxruntime")
+    mod.get_available_providers = lambda: list(providers)
+    monkeypatch.setitem(sys.modules, "onnxruntime", mod)
+
+
+def test_auto_prefers_cuda_when_offered(monkeypatch):
+    monkeypatch.delenv(faces.PROVIDER_ENV, raising=False)
+    _offer(monkeypatch, ["CUDAExecutionProvider", "CPUExecutionProvider"])
+    providers, ctx = faces.select_face_providers()
+    assert providers[0] == "CUDAExecutionProvider"
+    assert ctx == 0
+    assert providers[-1] == "CPUExecutionProvider", "CPU must remain a fallback"
+
+
+def test_auto_falls_back_to_cpu(monkeypatch):
+    monkeypatch.delenv(faces.PROVIDER_ENV, raising=False)
+    _offer(monkeypatch, ["AzureExecutionProvider", "CPUExecutionProvider"])
+    assert faces.select_face_providers() == (["CPUExecutionProvider"], -1)
+
+
+def test_explicit_cpu_wins_over_an_available_gpu(monkeypatch):
+    """An operator keeping a shared GPU free must be able to say so."""
+    _offer(monkeypatch, ["CUDAExecutionProvider", "CPUExecutionProvider"])
+    monkeypatch.setenv(faces.PROVIDER_ENV, "cpu")
+    assert faces.select_face_providers() == (["CPUExecutionProvider"], -1)
+    assert faces.select_face_providers("cpu") == (["CPUExecutionProvider"], -1)
+
+
+def test_explicit_cuda_fails_loudly_when_unavailable(monkeypatch):
+    """Asking for CUDA on a host that cannot provide it must raise, not quietly
+    cost hours; that silent degradation is what this whole change is about."""
+    _offer(monkeypatch, ["CPUExecutionProvider"])
+    monkeypatch.setenv(faces.PROVIDER_ENV, "cuda")
+    with pytest.raises(RecognizerUnavailable) as exc:
+        faces.select_face_providers()
+    assert "onnxruntime-gpu" in str(exc.value)
+
+
+def test_missing_onnxruntime_degrades_to_cpu(monkeypatch):
+    import sys
+    monkeypatch.delenv(faces.PROVIDER_ENV, raising=False)
+    monkeypatch.setitem(sys.modules, "onnxruntime", None)
+    monkeypatch.setattr(faces, "select_face_providers", faces.select_face_providers)
+    import builtins
+    real = builtins.__import__
+
+    def no_ort(name, *a, **kw):
+        if name == "onnxruntime":
+            raise ImportError("no onnxruntime")
+        return real(name, *a, **kw)
+
+    monkeypatch.setattr(builtins, "__import__", no_ort)
+    assert faces.select_face_providers() == (["CPUExecutionProvider"], -1)
+
+
+def test_session_providers_never_raises():
+    """Diagnostics must not be able to break a run."""
+    assert faces._session_providers(object()) == []
+
+    class Broken:
+        @property
+        def models(self):
+            raise RuntimeError("boom")
+
+    assert faces._session_providers(Broken()) == []

--- a/annotator/tests/test_face_provider.py
+++ b/annotator/tests/test_face_provider.py
@@ -82,3 +82,63 @@ def test_session_providers_never_raises():
             raise RuntimeError("boom")
 
     assert faces._session_providers(Broken()) == []
+
+
+@pytest.mark.parametrize("bad", ["gpu", "none", "CUDA11", "cude"])
+def test_unknown_provider_is_rejected(monkeypatch, bad):
+    """A typo must not quietly mean auto. That silent-default behaviour is the
+    exact failure this module exists to remove."""
+    _offer(monkeypatch, ["CUDAExecutionProvider", "CPUExecutionProvider"])
+    monkeypatch.setenv(faces.PROVIDER_ENV, bad)
+    with pytest.raises(RecognizerUnavailable) as exc:
+        faces.select_face_providers()
+    assert "unknown face provider" in str(exc.value)
+
+
+@pytest.mark.parametrize("value", ["", "  ", "AUTO", "auto ", " CPU "])
+def test_blank_and_cased_values_are_accepted(monkeypatch, value):
+    """An empty variable means unset, and case/whitespace are normalised; only
+    genuinely unrecognised words are rejected."""
+    _offer(monkeypatch, ["CUDAExecutionProvider", "CPUExecutionProvider"])
+    monkeypatch.setenv(faces.PROVIDER_ENV, value)
+    providers, _ = faces.select_face_providers()
+    expected = "CPUExecutionProvider" if value.strip().lower() == "cpu" else "CUDAExecutionProvider"
+    assert providers[0] == expected
+
+
+def test_session_providers_prefers_recognition():
+    """Models can bind differently; reporting the first one found could claim
+    CUDA while the model whose cost dominates ran on CPU."""
+    class Sess:
+        def __init__(self, provs): self._p = provs
+        def get_providers(self): return list(self._p)
+
+    class Model:
+        def __init__(self, provs): self.session = Sess(provs)
+
+    class App:
+        models = {
+            "detection": Model(["CUDAExecutionProvider"]),
+            "recognition": Model(["CPUExecutionProvider"]),
+        }
+
+    assert faces._session_providers(App()) == ["CPUExecutionProvider"]
+
+
+def test_session_providers_warns_on_disagreement(caplog):
+    class Sess:
+        def __init__(self, provs): self._p = provs
+        def get_providers(self): return list(self._p)
+
+    class Model:
+        def __init__(self, provs): self.session = Sess(provs)
+
+    class App:
+        models = {
+            "detection": Model(["CUDAExecutionProvider"]),
+            "recognition": Model(["CPUExecutionProvider"]),
+        }
+
+    with caplog.at_level(logging.WARNING):
+        faces._session_providers(App())
+    assert any("different execution providers" in r.message for r in caplog.records)


### PR DESCRIPTION
Closes #638.

## The measurement

Face recognition hardcoded `ctx_id=-1` with a comment that "pilot-scale sampling rates don't need GPU". Measured on the pilot host (NVIDIA A2, `buffalo_l` at 640x640, 40 real broadcast frames):

| | per frame | 6118-frame game | faces detected |
|---|---|---|---|
| CPU | 1.340 s | ~2h 17m | 254 |
| GPU | 0.154 s | **~16 min** | 254 |

**8.7x**, with identical detections. Equal face counts is the check that matters: a speedup that changed the output would be a different algorithm, not a faster one.

## The part that actually mattered

It was **invisible**. A CPU run on a two-GPU host looked exactly like a correct one, and the pilot completed a full eval that way before anyone noticed both GPUs had been idle throughout. Speed was the symptom; silence was the defect.

## Change

- Auto by default, preferring CUDA when onnxruntime genuinely offers it.
- `DIRSTRAL_FACE_PROVIDER=cpu|cuda|auto` to override. Explicit `cpu` beats an available GPU, so an operator can keep a shared device free. Explicit `cuda` raises `RecognizerUnavailable` when the provider is missing, rather than quietly costing hours.
- **The bound providers are read back off the session and logged**, with a warning naming the ~8x cost when CUDA was requested but CPU was bound.

That last point is not decoration. `onnxruntime` lists `CUDAExecutionProvider` as available **even when its CUDA libraries fail to load**, and only reveals the fallback once a session exists. Availability is necessary but not sufficient, so trusting `get_available_providers()` alone reproduces exactly the silent failure this fixes.

## Deployment notes, learned the hard way

Getting a working GPU stack took four wrong turns, each of which would cost the next person an hour:

1. `insightface` pulls the **CPU** `onnxruntime`, which shadows `onnxruntime-gpu`; both install into the same namespace.
2. Uninstalling the CPU build **breaks the GPU one** (shared files). It needs `--force-reinstall --no-deps` afterwards.
3. `onnxruntime-gpu` 1.28 requires **CUDA 13**, and NVIDIA's `-cu13` wheels are not on PyPI (only a `0.0.1` placeholder).
4. `onnxruntime-gpu==1.22.0` plus the `-cu12` wheels works against a 13.2 driver, which is backward compatible.

The venv's `nvidia/*/lib` directories must be on `LD_LIBRARY_PATH`. On a shared box, pin the device (`CUDA_VISIBLE_DEVICES`); GPU0 on the pilot host has another tenant.

## Tests

Six covering the selection matrix: auto prefers CUDA, auto falls back, explicit `cpu` wins over an available GPU, explicit `cuda` fails loudly, a missing `onnxruntime` degrades, and the session probe cannot raise. 95 annotator tests pass; ruff clean.

Verified end to end on the pilot host: the GPU venv selects and binds CUDA and logs it; the CPU venv selects CPU with no spurious warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Face recognition now supports configurable processing providers through `DIRSTRAL_FACE_PROVIDER`.
  - Automatically uses CUDA when available, with CPU fallback when necessary.
  - Supports explicit CPU selection for predictable processing.
  - Reports the providers used during face recognition and warns when CUDA falls back to CPU.
- **Bug Fixes**
  - Explicit CUDA requests now fail clearly when CUDA is unavailable.
  - Face recognition remains usable with CPU processing when ONNX Runtime capabilities are limited.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->