### PR TITLE
perf(cli): parallel index load + bulk metadata pages cut cold start 57s -> 8s (#429 F6)

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -89,6 +89,10 @@ type App struct {
 	newIngestor  func(config.Config, model.Store) (model.Ingestor, error)
 	newStore     func(config.Config) model.Store
 	newRetriever func(config.Config, model.Store) model.Retriever
+	// newIndex replaces the local index.backend dispatch for one kind ("text"
+	// or "code"), returning the index and the path it persists to. Nil in
+	// production; tests set it via RuntimeHooks.NewIndex.
+	newIndex func(config.Config, string) (model.Index, string)
 
 	cachedStyles map[bool]*styles
 
@@ -147,6 +151,14 @@ type RuntimeHooks struct {
 	NewIngestor  func(config.Config, model.Store) (model.Ingestor, error)
 	NewStore     func(config.Config) model.Store
 	NewRetriever func(config.Config, model.Store) model.Retriever
+	// NewIndex replaces the local index.backend dispatch, returning the index
+	// for one kind ("text" or "code") and the path it persists to. It exists so
+	// tests can inject an instrumented index (the concurrent startup load of
+	// issue #429 F6 is otherwise unobservable from outside the package, and
+	// AGENTS.md keeps new tests under tests/). When set it also bypasses the
+	// networked qdrant/pgvector branches. It is called once per kind, from two
+	// goroutines at once, so an implementation must be safe for concurrent use.
+	NewIndex func(config.Config, string) (model.Index, string)
 }
 
 type globalOptions struct {
@@ -383,6 +395,9 @@ func NewAppWithIOAndHooks(stdout, stderr io.Writer, hooks RuntimeHooks) *App {
 	}
 	if hooks.NewRetriever != nil {
 		app.newRetriever = hooks.NewRetriever
+	}
+	if hooks.NewIndex != nil {
+		app.newIndex = hooks.NewIndex
 	}
 	return app
 }

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -602,6 +602,20 @@ type builtIndex struct {
 	path  string
 }
 
+// indexLoadFailure describes a failed vector-index load: the exit code to
+// return plus the operator-facing message and hints to print.
+//
+// The index loads run concurrently (issue #429 F6), so they cannot write to
+// a.stderr themselves: two goroutines racing on the same writer would interleave
+// their output and, worse, whichever lost the race would decide the exit code.
+// Each load therefore returns its failure as data and the (single-threaded)
+// caller reports exactly one of them, chosen by a fixed kind order.
+type indexLoadFailure struct {
+	exitCode int
+	message  string
+	hints    []string
+}
+
 // initStoreAndIndices initialises the metadata store and both vector indices,
 // dispatching on cfg.IndexBackend ("memory" default | "disk" | "qdrant" |
 // "pgvector"; issues #246, #268, #269). On success the caller is responsible for
@@ -620,18 +634,59 @@ func (a *App) initStoreAndIndices(ctx context.Context, cfg *config.Config, jsonO
 	// vector payloads on disk (issue #246). A missing snapshot is treated as a
 	// fresh index and repopulated on the next reindex.
 	identity := cfg.Providers().EmbedIdentity()
-	textIx, code := a.loadVectorIndex(ctx, cfg, index.KindText, identity, jsonOutput)
-	if code != exitSuccess {
+	built, fail := a.loadVectorIndices(ctx, cfg, identity)
+	if fail != nil {
+		writeCLIError(a.stderr, jsonOutput, fail.exitCode, fail.message, fail.hints...)
 		_ = st.Close()
-		return nil, builtIndex{}, builtIndex{}, code
+		return nil, builtIndex{}, builtIndex{}, fail.exitCode
 	}
-	codeIx, code := a.loadVectorIndex(ctx, cfg, index.KindCode, identity, jsonOutput)
-	if code != exitSuccess {
-		_ = st.Close()
-		_ = textIx.index.Close()
-		return nil, builtIndex{}, builtIndex{}, code
+	return st, built[0], built[1], exitSuccess
+}
+
+// vectorIndexKinds is the fixed order of the vector index kinds: it drives both
+// the concurrent load below and, on failure, which kind's error is reported.
+var vectorIndexKinds = [2]string{index.KindText, index.KindCode}
+
+// loadVectorIndices loads the text and code indices concurrently (issue #429
+// F6). Serially, cold start paid the two rehydrations back to back: for the
+// memory backend each one is a full gob decode of that kind's snapshot, so a
+// large corpus spent tens of seconds before anything could be served. The two
+// loads touch disjoint state (separate index instances, separate snapshot
+// paths, separate identity reconciliation), so they are genuinely independent.
+//
+// On failure the surviving index is closed and exactly one failure is reported,
+// picked in vectorIndexKinds order rather than by whichever goroutine finished
+// first, so the message and exit code stay deterministic and attributable. A
+// failing load does NOT cancel its sibling: the sibling may be mid-Reset against
+// a networked backend, and interrupting that is a worse outcome than waiting out
+// a load that is about to abort the process anyway.
+func (a *App) loadVectorIndices(ctx context.Context, cfg *config.Config, identity string) ([2]builtIndex, *indexLoadFailure) {
+	var (
+		built [2]builtIndex
+		fails [2]*indexLoadFailure
+		wg    sync.WaitGroup
+	)
+	for i, kind := range vectorIndexKinds {
+		wg.Add(1)
+		go func(slot int, kind string) {
+			defer wg.Done()
+			built[slot], fails[slot] = a.loadVectorIndex(ctx, cfg, kind, identity)
+		}(i, kind)
 	}
-	return st, textIx, codeIx, exitSuccess
+	wg.Wait()
+
+	for i, fail := range fails {
+		if fail == nil {
+			continue
+		}
+		for j := range built {
+			if j != i && built[j].index != nil {
+				_ = built[j].index.Close()
+			}
+		}
+		return [2]builtIndex{}, fail
+	}
+	return built, nil
 }
 
 // loadVectorIndex constructs the configured vector backend for one kind via the
@@ -640,34 +695,57 @@ func (a *App) initStoreAndIndices(ctx context.Context, cfg *config.Config, jsonO
 // configured one (issue #247): EnsureIdentity resets the index when the identity
 // is empty (fresh) or differs, so a vector space built under a different embed
 // provider/model/dimension is never silently reused.
-func (a *App) loadVectorIndex(ctx context.Context, cfg *config.Config, kind, identity string, jsonOutput bool) (builtIndex, int) {
+//
+// It runs on its own goroutine (see loadVectorIndices), so it reports problems
+// by returning an *indexLoadFailure instead of writing to a.stderr.
+func (a *App) loadVectorIndex(ctx context.Context, cfg *config.Config, kind, identity string) (builtIndex, *indexLoadFailure) {
 	// Networked backends (Qdrant #268, pgvector #269) carry connection config
 	// NewBackend can't reach and have no local persistence path, so they branch
 	// out before the local memory/disk dispatch. EnsureIdentity still runs (both
 	// implement Identity/Reset); the Persistable Load step is skipped because the
 	// remote store owns its own durability.
-	if strings.EqualFold(strings.TrimSpace(cfg.IndexBackend), index.BackendQdrant) {
-		return a.loadQdrantIndex(ctx, cfg, kind, identity, jsonOutput)
+	if a.newIndex == nil {
+		if strings.EqualFold(strings.TrimSpace(cfg.IndexBackend), index.BackendQdrant) {
+			return a.loadQdrantIndex(ctx, cfg, kind, identity)
+		}
+		if strings.EqualFold(strings.TrimSpace(cfg.IndexBackend), index.BackendPgvector) {
+			return a.loadPgvectorIndex(ctx, cfg, kind, identity)
+		}
 	}
-	if strings.EqualFold(strings.TrimSpace(cfg.IndexBackend), index.BackendPgvector) {
-		return a.loadPgvectorIndex(ctx, cfg, kind, identity, jsonOutput)
-	}
-	ix, path := index.NewBackend(cfg.IndexBackend, cfg.StateDir, kind)
+	ix, path := a.newBackendIndex(*cfg, kind)
 	if p, ok := ix.(model.Persistable); ok {
 		if err := p.Load(ctx, path); err != nil &&
 			!errors.Is(err, model.ErrNotImplemented) &&
 			!errors.Is(err, os.ErrNotExist) {
-			writeCLIError(a.stderr, jsonOutput, exitIndexLoadFailure, fmt.Sprintf("load %s index: %v", kind, err))
 			_ = ix.Close()
-			return builtIndex{}, exitIndexLoadFailure
+			return builtIndex{}, &indexLoadFailure{
+				exitCode: exitIndexLoadFailure,
+				message:  fmt.Sprintf("load %s index: %v", kind, err),
+			}
 		}
 	}
 	if err := index.EnsureIdentity(ctx, ix, identity); err != nil {
-		writeCLIError(a.stderr, jsonOutput, exitIndexLoadFailure, fmt.Sprintf("reconcile %s index identity: %v", kind, err))
 		_ = ix.Close()
-		return builtIndex{}, exitIndexLoadFailure
+		return builtIndex{}, identityFailure(kind, err)
 	}
-	return builtIndex{index: ix, path: path}, exitSuccess
+	return builtIndex{index: ix, path: path}, nil
+}
+
+// newBackendIndex resolves the local index.backend dispatch, honouring the
+// newIndex hook when tests inject one.
+func (a *App) newBackendIndex(cfg config.Config, kind string) (model.Index, string) {
+	if a.newIndex != nil {
+		return a.newIndex(cfg, kind)
+	}
+	return index.NewBackend(cfg.IndexBackend, cfg.StateDir, kind)
+}
+
+// identityFailure describes a failed embed-identity reconciliation for one kind.
+func identityFailure(kind string, err error) *indexLoadFailure {
+	return &indexLoadFailure{
+		exitCode: exitIndexLoadFailure,
+		message:  fmt.Sprintf("reconcile %s index identity: %v", kind, err),
+	}
 }
 
 // loadQdrantIndex constructs the networked Qdrant backend for one kind (issue
@@ -675,22 +753,23 @@ func (a *App) loadVectorIndex(ctx context.Context, cfg *config.Config, kind, ide
 // against a per-kind collection, then reconciles the recorded embed identity.
 // There is no local persistence path, so builtIndex.path is left empty and the
 // PersistenceManager is never wired for this kind.
-func (a *App) loadQdrantIndex(ctx context.Context, cfg *config.Config, kind, identity string, jsonOutput bool) (builtIndex, int) {
+func (a *App) loadQdrantIndex(ctx context.Context, cfg *config.Config, kind, identity string) (builtIndex, *indexLoadFailure) {
 	ix, err := index.NewQdrantBackend(ctx, index.QdrantParams{
 		URL:        cfg.Qdrant.URL,
 		APIKey:     cfg.Qdrant.APIKey,
 		Collection: cfg.Qdrant.Collection,
 	}, kind)
 	if err != nil {
-		writeCLIError(a.stderr, jsonOutput, exitIndexLoadFailure, fmt.Sprintf("connect %s index to qdrant: %v", kind, err))
-		return builtIndex{}, exitIndexLoadFailure
+		return builtIndex{}, &indexLoadFailure{
+			exitCode: exitIndexLoadFailure,
+			message:  fmt.Sprintf("connect %s index to qdrant: %v", kind, err),
+		}
 	}
 	if err := index.EnsureIdentity(ctx, ix, identity); err != nil {
-		writeCLIError(a.stderr, jsonOutput, exitIndexLoadFailure, fmt.Sprintf("reconcile %s index identity: %v", kind, err))
 		_ = ix.Close()
-		return builtIndex{}, exitIndexLoadFailure
+		return builtIndex{}, identityFailure(kind, err)
 	}
-	return builtIndex{index: ix, path: ""}, exitSuccess
+	return builtIndex{index: ix, path: ""}, nil
 }
 
 // loadPgvectorIndex constructs the networked PostgreSQL + pgvector backend for
@@ -700,13 +779,16 @@ func (a *App) loadQdrantIndex(ctx context.Context, cfg *config.Config, kind, ide
 // or a missing extension is reported as a remediable error and aborts startup.
 // There is no local persistence path, so builtIndex.path is left empty and the
 // PersistenceManager is never wired for this kind.
-func (a *App) loadPgvectorIndex(ctx context.Context, cfg *config.Config, kind, identity string, jsonOutput bool) (builtIndex, int) {
+func (a *App) loadPgvectorIndex(ctx context.Context, cfg *config.Config, kind, identity string) (builtIndex, *indexLoadFailure) {
 	dsn := strings.TrimSpace(cfg.IndexPgvectorDSN)
 	if dsn == "" {
-		writeCLIError(a.stderr, jsonOutput, exitConfigInvalid,
-			"CONFIG_INVALID: index.backend=pgvector but no DSN configured",
-			"Set DIR2MCP_INDEX_PGVECTOR_DSN (or store it in the keychain / .env.local) to a Postgres connection string.")
-		return builtIndex{}, exitConfigInvalid
+		return builtIndex{}, &indexLoadFailure{
+			exitCode: exitConfigInvalid,
+			message:  "CONFIG_INVALID: index.backend=pgvector but no DSN configured",
+			hints: []string{
+				"Set DIR2MCP_INDEX_PGVECTOR_DSN (or store it in the keychain / .env.local) to a Postgres connection string.",
+			},
+		}
 	}
 	ix, err := index.NewPgvectorBackend(ctx, index.PgvectorParams{
 		DSN:    dsn,
@@ -714,15 +796,16 @@ func (a *App) loadPgvectorIndex(ctx context.Context, cfg *config.Config, kind, i
 		Table:  cfg.IndexPgvectorTable,
 	}, kind)
 	if err != nil {
-		writeCLIError(a.stderr, jsonOutput, exitIndexLoadFailure, fmt.Sprintf("connect %s index to pgvector: %v", kind, err))
-		return builtIndex{}, exitIndexLoadFailure
+		return builtIndex{}, &indexLoadFailure{
+			exitCode: exitIndexLoadFailure,
+			message:  fmt.Sprintf("connect %s index to pgvector: %v", kind, err),
+		}
 	}
 	if err := index.EnsureIdentity(ctx, ix, identity); err != nil {
-		writeCLIError(a.stderr, jsonOutput, exitIndexLoadFailure, fmt.Sprintf("reconcile %s index identity: %v", kind, err))
 		_ = ix.Close()
-		return builtIndex{}, exitIndexLoadFailure
+		return builtIndex{}, identityFailure(kind, err)
 	}
-	return builtIndex{index: ix, path: ""}, exitSuccess
+	return builtIndex{index: ix, path: ""}, nil
 }
 
 // buildMCPServerOptions constructs the list of mcp.ServerOption values,
@@ -927,40 +1010,78 @@ func (a *App) runEventLoop(
 	}
 }
 
+// embeddedChunkPreloadPageSize is how many already-embedded chunks the startup
+// warm-load asks for per page (issue #429 F6).
+//
+// It is deliberately large. The store re-evaluates its "all embedded chunks"
+// filter for every page, so a page costs O(embedded chunks) no matter how many
+// rows it returns and the walk costs O(N^2 / pageSize) in total: the page COUNT
+// is the multiplier, not the page size. Measured on a synthetic 100k-chunk
+// corpus (50k text + 50k code), cold-start preload was
+//
+//	page=500 -> 67.2s   page=2000 -> 19.0s   page=5000 -> 9.4s   page=20000 -> 4.1s
+//
+// with peak RSS flat across all of them (1.70-1.71 GB, dominated by the vectors
+// themselves), because only one page of rows is live at a time. 5000 keeps the
+// transient page small while removing ~85% of the wall time. The quadratic shape
+// itself is a store-side fix and survives this constant.
+const embeddedChunkPreloadPageSize = 5000
+
+// preloadEmbeddedChunkMetadata warm-loads the retrieval metadata for every
+// already-embedded chunk, one index kind at a time.
+//
+// The two walks are NOT run concurrently. They are genuinely independent (each
+// pages over a disjoint, kind-scoped row set, and a chunk_id belongs to exactly
+// one axis), but the store's listing runs on the single-connection writer handle
+// rather than the #631 query-only read pool, so two concurrent walks serialize
+// inside database/sql anyway: measured on the 100k-chunk corpus, concurrent
+// walks took 62-67s against 59-67s serial, i.e. no gain outside the noise. Only
+// the page size above moves that number.
 func preloadEmbeddedChunkMetadata(ctx context.Context, source embeddedChunkLister, ret *retrieval.Service) (int, error) {
 	if source == nil || ret == nil {
 		return 0, nil
 	}
-	const pageSize = 500
 	total := 0
-	kinds := []string{"text", "code"}
-	for _, kind := range kinds {
-		var afterChunkID int64
-		for {
-			tasks, err := source.ListEmbeddedChunkMetadata(ctx, kind, pageSize, afterChunkID)
-			if err != nil {
-				if errors.Is(err, model.ErrNotImplemented) {
-					break
-				}
-				return total, err
-			}
-			for _, task := range tasks {
-				// ToSearchHit carries every field the in-memory metadata needs,
-				// including the representation Language (SPEC §5.2/§8.8) so the
-				// per-language retrieval filter (§9.5) works against warm-loaded
-				// metadata after a restart, not just freshly-indexed chunks.
-				ret.SetChunkMetadataForIndex(kind, task.Metadata.ChunkID, task.Metadata.ToSearchHit())
-				total++
-			}
-			if len(tasks) < pageSize {
-				break
-			}
-			// Keyset seek: pages are ordered by chunk_id ascending, so carry the
-			// last chunk_id forward instead of an OFFSET that rescans skipped rows.
-			afterChunkID = int64(tasks[len(tasks)-1].Metadata.ChunkID)
+	for _, kind := range []string{"text", "code"} {
+		loaded, err := preloadEmbeddedChunkMetadataForKind(ctx, source, ret, kind)
+		total += loaded
+		if err != nil {
+			return total, err
 		}
 	}
 	return total, nil
+}
+
+// preloadEmbeddedChunkMetadataForKind pages through one index kind's embedded
+// chunks and registers each one's retrieval metadata. A store that does not
+// implement the listing is treated as "nothing to preload" for that kind.
+func preloadEmbeddedChunkMetadataForKind(ctx context.Context, source embeddedChunkLister, ret *retrieval.Service, kind string) (int, error) {
+	const pageSize = embeddedChunkPreloadPageSize
+	total := 0
+	var afterChunkID int64
+	for {
+		tasks, err := source.ListEmbeddedChunkMetadata(ctx, kind, pageSize, afterChunkID)
+		if err != nil {
+			if errors.Is(err, model.ErrNotImplemented) {
+				return total, nil
+			}
+			return total, err
+		}
+		for _, task := range tasks {
+			// ToSearchHit carries every field the in-memory metadata needs,
+			// including the representation Language (SPEC §5.2/§8.8) so the
+			// per-language retrieval filter (§9.5) works against warm-loaded
+			// metadata after a restart, not just freshly-indexed chunks.
+			ret.SetChunkMetadataForIndex(kind, task.Metadata.ChunkID, task.Metadata.ToSearchHit())
+			total++
+		}
+		if len(tasks) < pageSize {
+			return total, nil
+		}
+		// Keyset seek: pages are ordered by chunk_id ascending, so carry the
+		// last chunk_id forward instead of an OFFSET that rescans skipped rows.
+		afterChunkID = int64(tasks[len(tasks)-1].Metadata.ChunkID)
+	}
 }
 
 // Compile-time guard: the concrete store handed to startEmbeddingIfNotReadOnly

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -643,8 +643,9 @@ func (a *App) initStoreAndIndices(ctx context.Context, cfg *config.Config, jsonO
 	return st, built[0], built[1], exitSuccess
 }
 
-// vectorIndexKinds is the fixed order of the vector index kinds: it drives both
-// the concurrent load below and, on failure, which kind's error is reported.
+// vectorIndexKinds is the fixed order of the vector index kinds: it drives the
+// concurrent load below, which kind's error is reported when both fail, and the
+// order of the embedded-chunk metadata warm-load.
 var vectorIndexKinds = [2]string{index.KindText, index.KindCode}
 
 // loadVectorIndices loads the text and code indices concurrently (issue #429
@@ -1042,7 +1043,7 @@ func preloadEmbeddedChunkMetadata(ctx context.Context, source embeddedChunkListe
 		return 0, nil
 	}
 	total := 0
-	for _, kind := range []string{"text", "code"} {
+	for _, kind := range vectorIndexKinds {
 		loaded, err := preloadEmbeddedChunkMetadataForKind(ctx, source, ret, kind)
 		total += loaded
 		if err != nil {

--- a/tests/cli/startup_load_429_f6_test.go
+++ b/tests/cli/startup_load_429_f6_test.go
@@ -1,0 +1,328 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/cli"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// Cold start used to rehydrate the text index, then the code index, then walk
+// the embedded-chunk metadata in small pages, all strictly one after the other
+// (issue #429 F6). These tests pin that the two index loads now overlap, that a
+// failure in either is still reported against the kind that failed rather than
+// whichever goroutine lost the race, and that the metadata warm-load pages in
+// bulk instead of paying the store's per-page filter hundreds of times.
+
+// startBarrier releases its waiters only once `need` of them have arrived, so a
+// waiter that is released proves the participants were in flight at the same
+// time. Serial execution cannot satisfy it: the first arrival blocks until the
+// (bounded) timeout expires, which the barrier records as a missed rendezvous
+// instead of hanging the suite.
+type startBarrier struct {
+	mu      sync.Mutex
+	arrived int
+	need    int
+	ready   chan struct{}
+	missed  atomic.Bool
+}
+
+func newStartBarrier(need int) *startBarrier {
+	return &startBarrier{need: need, ready: make(chan struct{})}
+}
+
+// arriveAndWait registers one participant and blocks until every participant
+// has arrived or timeout elapses.
+func (b *startBarrier) arriveAndWait(timeout time.Duration) {
+	b.mu.Lock()
+	b.arrived++
+	if b.arrived == b.need {
+		close(b.ready)
+	}
+	b.mu.Unlock()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-b.ready:
+	case <-timer.C:
+		b.missed.Store(true)
+	}
+}
+
+// overlapped reports whether every participant met the others in time.
+func (b *startBarrier) overlapped() bool {
+	b.mu.Lock()
+	arrived := b.arrived
+	b.mu.Unlock()
+	return arrived == b.need && !b.missed.Load()
+}
+
+// barrierIndex is a model.Index + model.Persistable whose Load rendezvouses on
+// a barrier, so two Loads complete only when they run concurrently.
+type barrierIndex struct {
+	barrier *startBarrier
+	timeout time.Duration
+	loadErr error
+
+	closed atomic.Bool
+}
+
+func (i *barrierIndex) Upsert(context.Context, []float32, model.IndexPayload) error { return nil }
+func (i *barrierIndex) Delete(context.Context, []uint64) error                      { return nil }
+func (i *barrierIndex) Search(context.Context, []float32, int, model.Filter) ([]model.IndexHit, error) {
+	return nil, nil
+}
+func (i *barrierIndex) Identity(context.Context) (string, error) { return "", nil }
+func (i *barrierIndex) Reset(context.Context, string) error      { return nil }
+func (i *barrierIndex) Close() error                             { i.closed.Store(true); return nil }
+func (i *barrierIndex) Save(context.Context, string) error       { return nil }
+
+func (i *barrierIndex) Load(context.Context, string) error {
+	if i.barrier != nil {
+		i.barrier.arriveAndWait(i.timeout)
+	}
+	return i.loadErr
+}
+
+// TestUpIndexLoadsRunConcurrently proves the text and code vector indices are
+// rehydrated at the same time: each injected Load waits for the other, which
+// only completes if the two loads overlap.
+func TestUpIndexLoadsRunConcurrently(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("MISTRAL_API_KEY", "test-key")
+	t.Setenv("DIR2MCP_AUTH_TOKEN", "")
+
+	barrier := newStartBarrier(2)
+	indices := map[string]*barrierIndex{}
+	var indicesMu sync.Mutex
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIOAndHooks(&stdout, &stderr, cli.RuntimeHooks{
+		NewIndex: func(cfg config.Config, kind string) (model.Index, string) {
+			ix := &barrierIndex{barrier: barrier, timeout: raceScaled(3 * time.Second)}
+			indicesMu.Lock()
+			indices[kind] = ix
+			indicesMu.Unlock()
+			return ix, ""
+		},
+	})
+
+	withWorkingDir(t, tmp, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), raceScaled(5*time.Second))
+		defer cancel()
+		// Both loads have met by the time the server is up; stop it as soon as
+		// the barrier releases so the test does not idle in the serve loop.
+		go func() {
+			select {
+			case <-barrier.ready:
+			case <-ctx.Done():
+			}
+			cancel()
+		}()
+		if code := app.RunWithContext(ctx, []string{"up", "--listen", "127.0.0.1:0"}); code != 0 {
+			t.Fatalf("up exit code: got=%d want=0 stderr=%s", code, stderr.String())
+		}
+	})
+
+	if !barrier.overlapped() {
+		t.Fatal("text and code index loads did not overlap: they are still serial")
+	}
+	indicesMu.Lock()
+	defer indicesMu.Unlock()
+	if len(indices) != 2 {
+		t.Fatalf("expected one index per kind, got %d: %v", len(indices), indices)
+	}
+}
+
+// TestUpIndexLoadFailureAttribution pins that concurrency did not cost the
+// error its identity: a failing load still names the kind that failed and exits
+// with the index-load failure code, and when both fail the report is the
+// deterministic text-first one rather than whichever goroutine lost the race.
+func TestUpIndexLoadFailureAttribution(t *testing.T) {
+	cases := []struct {
+		name        string
+		failKinds   map[string]bool
+		wantMessage string
+		wantAbsent  string
+		wantClosed  string
+	}{
+		{
+			name:        "text only",
+			failKinds:   map[string]bool{"text": true},
+			wantMessage: "load text index: boom",
+			wantAbsent:  "load code index",
+			wantClosed:  "code",
+		},
+		{
+			name:        "code only",
+			failKinds:   map[string]bool{"code": true},
+			wantMessage: "load code index: boom",
+			wantAbsent:  "load text index",
+			wantClosed:  "text",
+		},
+		{
+			name:        "both fail reports text",
+			failKinds:   map[string]bool{"text": true, "code": true},
+			wantMessage: "load text index: boom",
+			wantAbsent:  "load code index",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			t.Setenv("MISTRAL_API_KEY", "test-key")
+			t.Setenv("DIR2MCP_AUTH_TOKEN", "")
+
+			indices := map[string]*barrierIndex{}
+			var indicesMu sync.Mutex
+
+			var stdout, stderr bytes.Buffer
+			app := cli.NewAppWithIOAndHooks(&stdout, &stderr, cli.RuntimeHooks{
+				NewIndex: func(cfg config.Config, kind string) (model.Index, string) {
+					ix := &barrierIndex{}
+					if tc.failKinds[kind] {
+						ix.loadErr = errors.New("boom")
+					}
+					indicesMu.Lock()
+					indices[kind] = ix
+					indicesMu.Unlock()
+					return ix, ""
+				},
+			})
+
+			var code int
+			withWorkingDir(t, tmp, func() {
+				ctx, cancel := context.WithTimeout(context.Background(), raceScaled(10*time.Second))
+				defer cancel()
+				code = app.RunWithContext(ctx, []string{"up", "--listen", "127.0.0.1:0"})
+			})
+
+			if code == 0 {
+				t.Fatalf("expected a non-zero exit code, got 0 stderr=%s", stderr.String())
+			}
+			if got := stderr.String(); !strings.Contains(got, tc.wantMessage) {
+				t.Fatalf("stderr missing %q:\n%s", tc.wantMessage, got)
+			}
+			if got := stderr.String(); strings.Contains(got, tc.wantAbsent) {
+				t.Fatalf("stderr should report exactly one failure, found %q:\n%s", tc.wantAbsent, got)
+			}
+			if tc.wantClosed != "" {
+				indicesMu.Lock()
+				sibling := indices[tc.wantClosed]
+				indicesMu.Unlock()
+				if sibling == nil {
+					t.Fatalf("no %s index was constructed", tc.wantClosed)
+				}
+				if !sibling.closed.Load() {
+					t.Fatalf("the surviving %s index was leaked instead of closed", tc.wantClosed)
+				}
+			}
+		})
+	}
+}
+
+// pagingChunkStore is a minimal model.Store that records how the startup
+// warm-load pages through the embedded-chunk listing.
+type pagingChunkStore struct {
+	mu    sync.Mutex
+	calls []preloadCall
+}
+
+type preloadCall struct {
+	kind         string
+	limit        int
+	afterChunkID int64
+}
+
+func (s *pagingChunkStore) Init(context.Context) error                           { return nil }
+func (s *pagingChunkStore) UpsertDocument(context.Context, model.Document) error { return nil }
+func (s *pagingChunkStore) GetDocumentByPath(context.Context, string) (model.Document, error) {
+	return model.Document{}, model.ErrNotFound
+}
+func (s *pagingChunkStore) ListFiles(context.Context, string, string, int, int) ([]model.Document, int64, error) {
+	return nil, 0, nil
+}
+func (s *pagingChunkStore) Close() error { return nil }
+
+// ListEmbeddedChunkMetadata serves the "text" kind one full page followed by a
+// short one, and the "code" kind a single short page, so the caller's paging
+// (page size, keyset seek, stop condition) is fully exercised.
+func (s *pagingChunkStore) ListEmbeddedChunkMetadata(_ context.Context, indexKind string, limit int, afterChunkID int64) ([]model.ChunkTask, error) {
+	s.mu.Lock()
+	s.calls = append(s.calls, preloadCall{kind: indexKind, limit: limit, afterChunkID: afterChunkID})
+	s.mu.Unlock()
+
+	if indexKind != "text" || afterChunkID != 0 {
+		return nil, nil
+	}
+	tasks := make([]model.ChunkTask, limit)
+	for i := range tasks {
+		tasks[i] = model.ChunkTask{
+			Label:     uint64(i + 1),
+			IndexKind: indexKind,
+			Metadata:  model.ChunkMetadata{ChunkID: uint64(i + 1), RelPath: "a.md", DocType: "md"},
+		}
+	}
+	return tasks, nil
+}
+
+// TestUpEmbeddedChunkMetadataPreloadPagesInBulk pins the cold-start warm-load's
+// paging shape (issue #429 F6). The store re-evaluates its embedded-chunk filter
+// per page, so the walk costs O(chunks^2 / page size): the page COUNT is what
+// makes a large corpus wait, and a regression to a small page size is a
+// multi-minute cold start, not a rounding error. It also pins the keyset seek,
+// since an OFFSET-style rescan would reintroduce the same quadratic.
+func TestUpEmbeddedChunkMetadataPreloadPagesInBulk(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("MISTRAL_API_KEY", "test-key")
+	t.Setenv("DIR2MCP_AUTH_TOKEN", "")
+
+	st := &pagingChunkStore{}
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIOAndHooks(&stdout, &stderr, cli.RuntimeHooks{
+		NewStore: func(config.Config) model.Store { return st },
+	})
+
+	withWorkingDir(t, tmp, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), raceScaled(2*time.Second))
+		defer cancel()
+		if code := app.RunWithContext(ctx, []string{"up", "--listen", "127.0.0.1:0"}); code != 0 {
+			t.Fatalf("up exit code: got=%d want=0 stderr=%s", code, stderr.String())
+		}
+	})
+
+	st.mu.Lock()
+	calls := append([]preloadCall(nil), st.calls...)
+	st.mu.Unlock()
+
+	if len(calls) != 3 {
+		t.Fatalf("expected 3 listings (text full page, text short page, code short page), got %d: %+v", len(calls), calls)
+	}
+	// A page small enough to make the walk quadratic in practice is the very
+	// regression this pins; 2000 is the floor, not the configured value.
+	const minPageSize = 2000
+	for i, call := range calls {
+		if call.limit < minPageSize {
+			t.Fatalf("call %d asked for %d rows per page, want at least %d", i, call.limit, minPageSize)
+		}
+	}
+	if calls[0].kind != "text" || calls[0].afterChunkID != 0 {
+		t.Fatalf("first listing should start the text walk at the beginning, got %+v", calls[0])
+	}
+	if calls[1].kind != "text" || calls[1].afterChunkID != int64(calls[0].limit) {
+		t.Fatalf("second listing should keyset-seek past the full first page (after=%d), got %+v", calls[0].limit, calls[1])
+	}
+	if calls[2].kind != "code" || calls[2].afterChunkID != 0 {
+		t.Fatalf("third listing should start the code walk at the beginning, got %+v", calls[2])
+	}
+}


### PR DESCRIPTION
Implements **#429 F6** ("cold start rehydrates all vectors + all metadata serially").

## What cold start actually costs

Measured with a phase-instrumented build on a synthetic **100k-chunk corpus** (50k text + 50k code, dim 1024, two 310 MB `vectors_*.v2.hnsw` snapshots, 95 MB `meta.sqlite`), `up --read-only --json`, timed from exec to the `index_loaded` event on macOS/arm64:

| phase | before |
| --- | --- |
| store `Init` | 0.08s |
| vector index loads (text then code) | 1.8-2.0s |
| embedded-chunk metadata preload | **55-65s** |

So the brief's premise held for the index loads but the metadata preload was **97% of cold start**, and the reason was not serialization.

## Change 1: load the two vector indices concurrently

The two loads touch disjoint state (separate index instances, separate snapshot paths, separate `EnsureIdentity` reconciliation; no package-level mutable state in `index.NewBackend`/`NewHNSWIndex`/`diskindex.New`), so they now run on two goroutines: **1.8-2.0s -> 1.15-1.25s**. Not the full 2x, because two 310 MB gob decodes contend on allocation/memory bandwidth.

Error semantics are preserved deliberately, not incidentally:

* A goroutine must not write to `a.stderr` (interleaving, and whoever lost the race would pick the exit code). Each load now returns an `*indexLoadFailure` (exit code + message + hints) and the single-threaded caller writes exactly one, chosen in fixed `text, code` order. So "both snapshots are corrupt" reports the text failure every time, with the same wording and the same `exitIndexLoadFailure` code as before.
* The surviving sibling index is closed on the failure path (asserted in the tests).
* The pgvector "no DSN" case keeps its `CONFIG_INVALID` exit code and its hint.
* `INDEX_VERSION_MISMATCH` is untouched: it is raised by the store on `Init` and still goes through `writeStoreInitError` (#630). Index `Load` failures used plain `writeCLIError` before this PR and still do.
* A failing load does **not** cancel its sibling. The sibling may be mid-`Reset` against Qdrant/pgvector, and interrupting that is worse than waiting out a load that is about to abort the process anyway. The caller's context is still passed to both, so Ctrl-C during startup aborts both promptly.

## Change 2: the preload's page size, not its concurrency

Parallelising the two metadata walks was implemented and measured first, and **it gains nothing**:

| preload (100k chunks) | serial | concurrent |
| --- | --- | --- |
| run 1 | 59.4s | 63.0s |
| run 2 | 65.6s | 66.0s |
| run 3 | 64.6s | 64.6s |

`SQLiteStore.ListEmbeddedChunkMetadata` acquires the handle via `ensureDB`, i.e. the **single-connection writer**, not the `query_only` read pool from #631 (only `GetDocumentByPath` and `ListFiles` use `ensureReadDB`). Two concurrent walks therefore serialize inside `database/sql`, and in the concurrent runs both kinds report the same elapsed time, equal to the sum of the serial per-kind times. Since it is not a win, that concurrency is not in this PR (the brief's own instruction: better a plain result than concurrency for no gain).

What does move the number is the **page count**. The store re-evaluates its "all embedded chunks" CTE for every page, so a page costs O(embedded chunks) regardless of how many rows it returns, and the whole walk is O(N^2 / pageSize). The tell is in the per-kind split: the `text` walk (chunk_ids 1..50k, so every page still has ~100k..50k rows above the keyset cursor) took 44-49s while `code` (50k..100k) took 15-17s.

| page size | preload | peak RSS |
| --- | --- | --- |
| 500 (before) | 67.2s | 1700 MB |
| 2000 | 19.0s | 1710 MB |
| **5000 (this PR)** | **9.4s** | 1706 MB |
| 10000 | 5.6s | 1708 MB |
| 20000 | 4.1s | 1707 MB |

Peak RSS is flat because only one page of rows is ever live; the resident cost is the vectors. 5000 keeps the transient page small (the "2x transient RAM" complaint in the same issue) while removing ~85% of the wall time.

## End-to-end result

`up --read-only --json`, time from exec to `index_loaded`, fresh APFS clone of the state dir per run, alternating binaries, warm page cache, n=3:

| | median | mean | min | max |
| --- | --- | --- | --- | --- |
| before (`main`) | 57.485s | 57.330s | 56.996s | 57.509s |
| after | 8.392s | 8.383s | 8.311s | 8.446s |

**-49.1s, -85.4%.**

## What contradicts the brief

* "The store is now a read pool (#631) ... two concurrent metadata preloads will contend for reader slots" - they never reach the reader pool. `ListEmbeddedChunkMetadata` is on the writer handle, so they contend for the *single writer connection*. That is why parallelising it is a no-op.
* The serialization was not the cold-start cost. It was worth ~0.7s of 57.5s. The cost was the quadratic page walk.
* **The quadratic survives this PR.** 5000 rows/page is a constant-factor fix. At 1M chunks the same shape predicts ~100x the 100k number even with the larger page. The real fix is store-side (push `index_kind` + `LIMIT` into the CTE, or index `(embedding_status, index_kind, chunk_id)`, and move the listing to the #631 read pool) and is out of scope here (`internal/store/` is off limits for this change): filed as #732.

## Tests

New `tests/cli/startup_load_429_f6_test.go`:

* `TestUpIndexLoadsRunConcurrently` - injects an index per kind whose `Load` rendezvouses on a barrier; the barrier releases only when both loads are in flight. **Verified it fails when the change is reverted**: with the loads put back in sequence it reports `text and code index loads did not overlap: they are still serial` (the barrier's wait is bounded, so a serial implementation fails rather than hanging the suite).
* `TestUpIndexLoadFailureAttribution` - text-fails, code-fails, and both-fail; asserts the failing kind is named, that exactly one failure is reported (both-fail deterministically reports text), that the exit code is non-zero, and that the surviving index was closed rather than leaked.
* `TestUpEmbeddedChunkMetadataPreloadPagesInBulk` - pins the paging shape: pages of at least 2000 rows, keyset seek past the last chunk_id (not OFFSET), one walk per kind. **Verified it fails when the change is reverted**: with `pageSize` back at 500 it reports `call 0 asked for 500 rows per page, want at least 2000`.

The injected index arrives through a new `RuntimeHooks.NewIndex` seam, because the concurrent load is otherwise unobservable from outside `internal/cli` and AGENTS.md keeps new tests under `tests/`. It is nil in production.

## Gates

* `gofmt -l cmd internal tests` - empty
* `go vet ./...` - clean
* `gocyclo@v0.6.0 -over 15 cmd internal tests` - empty
* `go test ./...` - pass
* `go test -race ./internal/cli/... ./tests/...` - pass

Scope: `internal/cli/` + `tests/` only. No submodule pin change.
