### PR TITLE
perf(annotator): read frames in parallel in the OCR recognizers (3.3x scorebug, 5.9x jersey)

### DIFF
--- a/annotator/dirstral_annotator/recognizers/jersey.py
+++ b/annotator/dirstral_annotator/recognizers/jersey.py
@@ -8,24 +8,42 @@ the roster wears is dropped rather than guessed.
 Weakest signal in the cascade (low resolution, motion blur — see the
 SoccerNet jersey benchmarks), so its confidence ceiling is deliberately
 modest and it exists to corroborate, not to decide.
+
+Frames are read on a worker pool for the same reason the scorebug's are: the
+per-frame detect-crop-OCR is the whole cost, it is a pure function of the
+frame, and a broadcast has thousands of them. Results come back keyed by
+frame so the sighting list is the serial one whatever order the workers
+finish in.
 """
 
 from __future__ import annotations
 
 import re
-from collections.abc import Callable
+import tempfile
+import threading
+from collections import deque
+from collections.abc import Callable, Iterable, Iterator
+from concurrent.futures import Executor, Future, ThreadPoolExecutor
 from pathlib import Path
+from typing import Self
 
 from ..model import Cue
 from ..roster import Roster
 from .base import RecognizerUnavailable, iter_frames
-from .scorebug import OcrFn, collapse_sightings, default_ocr
+from .scorebug import OcrFn, collapse_sightings, default_ocr, default_workers
 
 Bbox = tuple[int, int, int, int]  # x, y, w, h
 DetectFn = Callable[[Path], list[Bbox]]
 
 NUMBER_RE = re.compile(r"(?<!\d)(\d{1,2})(?!\d)")
 CONFIDENCE_CEILING = 0.6
+
+# Frames dispatched ahead of the loop that consumes them. Same reasoning as
+# the scorebug's window: enough per worker that the pool never drains while
+# the caller folds one frame's numbers into the sighting list, small enough
+# that only a handful of results are held at once.
+LOOKAHEAD_PER_WORKER = 4
+MIN_LOOKAHEAD = 16
 
 
 def default_detector() -> DetectFn:
@@ -59,19 +77,28 @@ class JerseyRecognizer:
         detector: DetectFn | None = None,
         ocr: OcrFn | None = None,
         fps: float = 0.5,
+        workers: int | None = None,  # None: default_workers(); 1: serial
     ):
         self.roster = roster
         self.detector = detector if detector is not None else default_detector()
         self.ocr = ocr if ocr is not None else default_ocr()
         self.fps = fps
+        self.workers = default_workers() if workers is None else max(1, int(workers))
+        # An injected detector is used as given: the caller supplied the
+        # instance, and knows whether sharing it is safe. The default adapter
+        # is rebuilt per worker thread instead; see _Detectors.
+        self._new_detector: Callable[[], DetectFn] = (
+            default_detector if detector is None else (lambda: self.detector)
+        )
 
     def recognize(self, media_path: Path) -> list[Cue]:
         sightings: list[tuple[float, str, float]] = []
-        for t, frame in iter_frames(media_path, fps=self.fps):
-            for bbox in self.detector(frame):
-                crop = _crop(frame, bbox)
-                text = self.ocr(crop)
-                for num in NUMBER_RE.findall(text):
+        with (
+            tempfile.TemporaryDirectory(prefix="dirstral-jersey-") as tmp,
+            self._reader(Path(tmp)) as reader,
+        ):
+            for t, numbers in reader.read(iter_frames(media_path, fps=self.fps)):
+                for num in numbers:
                     player = self.roster.by_number(num)
                     if player:
                         sightings.append((t, player.id, CONFIDENCE_CEILING))
@@ -79,12 +106,181 @@ class JerseyRecognizer:
             sightings, source=self.name, event="appearance", frame_gap=1.0 / self.fps
         )
 
+    def _reader(self, work: Path) -> _SerialReader | _PooledReader:
+        if self.workers <= 1:
+            return _SerialReader(self.detector, self.ocr, work)
+        detectors = _Detectors(self._new_detector, seed=self.detector)
+        return _PooledReader(detectors, self.ocr, work, self.workers)
 
-def _crop(frame: Path, bbox: Bbox) -> Path:
-    from PIL import Image  # required transitively by the OCR extra
+
+def read_numbers(detect: DetectFn, ocr: OcrFn, frame: Path, work: Path) -> list[str]:
+    """Every jersey number one frame shows, in detection order.
+
+    The whole of the expensive per-frame work, and a pure function of the
+    frame: no recognizer state is read or written here, which is what makes
+    it safe to run several at once.
+    """
+    numbers: list[str] = []
+    for bbox in detect(frame):
+        numbers += NUMBER_RE.findall(ocr(_crop(frame, bbox, work)))
+    return numbers
+
+
+class _Detectors:
+    """One person detector per worker thread.
+
+    An ultralytics model is not documented thread safe (a predictor hangs
+    per-call state off the model object), so threads sharing one instance can
+    read each other's boxes. yolov8n is a few megabytes, so a copy per worker
+    is cheap next to being wrong. The instance built in the constructor (which
+    is what makes a missing ultralytics fail fast, as RecognizerUnavailable at
+    construction rather than mid-run) is handed to the first thread to ask
+    rather than left idle.
+
+    Construction is serialised. The default adapter's first call fetches the
+    weights file if it is not already on disk, and several workers racing that
+    would write the same path at once; serialising also keeps the workers from
+    loading a model each at the same moment, which is the one point in the run
+    where they would all want memory together.
+    """
+
+    def __init__(self, factory: Callable[[], DetectFn], seed: DetectFn | None = None):
+        self._factory = factory
+        self._spare = [seed] if seed is not None else []
+        self._lock = threading.Lock()
+        self._local = threading.local()
+
+    def current(self) -> DetectFn:
+        detect = getattr(self._local, "detect", None)
+        if detect is None:
+            with self._lock:
+                detect = self._spare.pop() if self._spare else self._factory()
+            self._local.detect = detect
+        return detect
+
+
+class _Workspaces:
+    """A scratch directory per worker thread.
+
+    Crops are written under a fixed name and overwritten per detection, so
+    two threads sharing one directory would swap crops between the write and
+    the OCR of it. A directory per thread keeps the scratch bounded (one file
+    per worker for a whole run) and keeps the crops out of the frame cache
+    directory, which the other recognizers in the cascade are iterating.
+    """
+
+    def __init__(self, root: Path):
+        self._root = root
+        self._local = threading.local()
+        self._lock = threading.Lock()
+        self._issued = 0
+
+    def current(self) -> Path:
+        work = getattr(self._local, "work", None)
+        if work is None:
+            with self._lock:
+                self._issued += 1
+                work = self._root / f"worker-{self._issued}"
+            work.mkdir(parents=True, exist_ok=True)
+            self._local.work = work
+        return work
+
+
+class _SerialReader:
+    """Read one frame at a time on the calling thread: the reference path."""
+
+    workers = 1
+
+    def __init__(self, detect: DetectFn, ocr: OcrFn, work: Path):
+        self._detect = detect
+        self._ocr = ocr
+        self._work = work
+
+    def read(
+        self, frames: Iterable[tuple[float, Path]]
+    ) -> Iterator[tuple[float, list[str]]]:
+        for t, frame in frames:
+            yield t, read_numbers(self._detect, self._ocr, frame, self._work)
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        pass
+
+
+class _PooledReader:
+    """Read frames on a worker pool, yielding them back in frame order.
+
+    Nothing about this recognizer is sequential (unlike the scorebug's region
+    search), so ordering needs no reconciliation: frames are dispatched in
+    order, held in a bounded window, and awaited in that same order. A worker
+    finishing early simply waits its turn, so the sighting list, and with it
+    every cue, is the serial one.
+
+    The pool is threads, not processes, because the measurement says the GIL
+    is not the constraint here: pytesseract shells out to the `tesseract`
+    binary and ultralytics spends its time inside torch, both of which drop
+    the lock. Threads also keep the injected detector and OCR callables free
+    of any pickling constraint, which the default adapters (closures over a
+    loaded model) could not satisfy.
+    """
+
+    def __init__(self, detectors: _Detectors, ocr: OcrFn, work: Path, workers: int):
+        self.workers = workers
+        self._detectors = detectors
+        self._ocr = ocr
+        self._workspaces = _Workspaces(work)
+        self._executor = _new_executor(workers)
+
+    def _read_here(self, frame: Path) -> list[str]:
+        return read_numbers(
+            self._detectors.current(), self._ocr, frame, self._workspaces.current()
+        )
+
+    def read(
+        self, frames: Iterable[tuple[float, Path]]
+    ) -> Iterator[tuple[float, list[str]]]:
+        lookahead = max(MIN_LOOKAHEAD, LOOKAHEAD_PER_WORKER * self.workers)
+        window: deque[tuple[float, Future[list[str]]]] = deque()
+        source = iter(frames)
+
+        def top_up() -> None:
+            while len(window) < lookahead:
+                item = next(source, None)
+                if item is None:
+                    return
+                t, frame = item
+                window.append((t, self._executor.submit(self._read_here, frame)))
+
+        top_up()
+        while window:
+            t, pending = window.popleft()
+            yield t, pending.result()
+            top_up()
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self._executor.shutdown(wait=True, cancel_futures=True)
+
+
+def _new_executor(workers: int) -> Executor:
+    return ThreadPoolExecutor(max_workers=workers, thread_name_prefix="jersey")
+
+
+def _crop(frame: Path, bbox: Bbox, work: Path) -> Path:
+    try:
+        from PIL import Image  # required transitively by the OCR extra
+    except ImportError as exc:  # pragma: no cover - exercised via the contract test
+        # recognize() must degrade the cascade, not abort it, so a missing
+        # Pillow has to arrive as RecognizerUnavailable rather than ImportError.
+        raise RecognizerUnavailable("Pillow is required for jersey OCR") from exc
 
     x, y, w, h = bbox
-    img = Image.open(frame)
-    out = frame.with_name(f"{frame.stem}-p{x}x{y}.jpg")
-    img.crop((max(0, x), max(0, y), x + w, y + h)).save(out)
+    out = work / "crop.jpg"
+    with Image.open(frame) as opened:
+        opened.load()
+        opened.crop((max(0, x), max(0, y), x + w, y + h)).save(out)
     return out

--- a/annotator/dirstral_annotator/recognizers/scorebug.py
+++ b/annotator/dirstral_annotator/recognizers/scorebug.py
@@ -35,17 +35,28 @@ confidence cap).
 
 The OCR engine is injected as a callable `(image_path) -> str`; the default
 adapter uses pytesseract when installed.
+
+Reading a frame is the expensive step (about a second per frame on the pilot
+host, so nearly two hours for a three hour broadcast) and it is embarrassingly
+parallel, so it runs on a worker pool; see `_PooledReader` for why the pool is
+threads and `_with_lookahead` for how the cue list stays identical to a serial
+run despite the band search being sequential state.
 """
 
 from __future__ import annotations
 
 import difflib
+import os
 import re
 import tempfile
+import threading
 import unicodedata
+from collections import deque
 from collections.abc import Callable, Iterable, Iterator
+from concurrent.futures import Executor, Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Self
 
 from ..model import Cue
 from ..roster import Roster
@@ -84,6 +95,27 @@ OCR_PSM = 6
 # once one band has produced this many reads it is the only one OCR'd.
 SCAN_STRIDE = 4
 LOCK_AFTER_READS = 5
+
+# Worker pool for the per-frame read. The default is a quarter of the core
+# count, not all of it, for a measured reason: tesseract is built against
+# OpenMP and runs four threads per page (NLWP 4 on every invocation), so N
+# workers put 4N threads on the machine. On the pilot's 16 core host that
+# makes 4 workers the fastest setting (3.0x to 3.3x on the scorebug), 8
+# workers slower than running serially (0.83x to 0.90x) and 12 workers four
+# times slower than serial. Raise DIRSTRAL_ANNOTATOR_WORKERS where tesseract
+# is built without OpenMP, or where the host has cores to spare. Setting
+# OMP_THREAD_LIMIT=1 makes each worker use one core and lets the count go
+# higher, but it is process wide: it would also throttle the torch and
+# onnxruntime work the jersey and face recognizers do in the same process.
+WORKERS_ENV = "DIRSTRAL_ANNOTATOR_WORKERS"
+OCR_THREADS_PER_WORKER = 4
+MAX_DEFAULT_WORKERS = 8
+# How far ahead of the authoritative loop frames are speculatively dispatched.
+# Has to exceed the worker count or the pool drains while the main thread
+# folds one frame's reads into the sighting lists; a few frames per worker is
+# enough, and each pending entry is only a path and a short result list.
+LOOKAHEAD_PER_WORKER = 4
+MIN_LOOKAHEAD = 16
 
 # Name matching. Short reads (three or four characters: RAY, COX) are accepted
 # only on an exact roster match, because that is the length at which fuzzy
@@ -170,6 +202,27 @@ def default_ocr(psm: int | None = None) -> OcrFn:
     return ocr
 
 
+def default_workers() -> int:
+    """How many frames to read at once, from the environment or the host.
+
+    `DIRSTRAL_ANNOTATOR_WORKERS=1` forces the serial path; a value that is not
+    a positive integer is ignored rather than silently disabling the pool. The
+    unset default divides the core count by the threads one OCR pass already
+    uses, because a worker is not one core's worth of work: see
+    OCR_THREADS_PER_WORKER.
+    """
+    raw = os.environ.get(WORKERS_ENV, "").strip()
+    if raw:
+        try:
+            requested = int(raw)
+        except ValueError:
+            requested = 0
+        if requested >= 1:
+            return requested
+    cores = os.cpu_count() or 1
+    return max(1, min(cores // OCR_THREADS_PER_WORKER, MAX_DEFAULT_WORKERS))
+
+
 @dataclass(frozen=True)
 class NameRead:
     """One name the overlay parser recovered, with the role its position in
@@ -191,6 +244,11 @@ class PitchRead:
     def describe(self) -> str:
         parts = [p for p in (self.pitch_type, str(self.speed), self.unit) if p]
         return " ".join(parts)
+
+
+#: Everything one band of one frame yields: the names it named and the pitch
+#: graphic it showed. The unit of work the reader pool schedules.
+_Band = tuple[list[NameRead], list[PitchRead]]
 
 
 def parse_overlay(text: str) -> tuple[list[NameRead], list[PitchRead]]:
@@ -273,6 +331,7 @@ class ScorebugRecognizer:
         crop: Region | None = None,  # fraction box; None searches for the bug
         regions: Iterable[Region] | None = None,
         pitch_cues: bool = True,
+        workers: int | None = None,  # None: default_workers(); 1: serial
     ):
         self.roster = roster
         self.ocr = ocr if ocr is not None else default_ocr(psm=OCR_PSM)
@@ -283,6 +342,7 @@ class ScorebugRecognizer:
         else:
             self.regions = tuple(regions) if regions is not None else CANDIDATE_REGIONS
         self.pitch_cues = pitch_cues
+        self.workers = default_workers() if workers is None else max(1, int(workers))
         self._index = _name_index(roster)
 
     def recognize(self, media_path: Path) -> list[Cue]:
@@ -293,11 +353,14 @@ class ScorebugRecognizer:
         graphics: list[tuple[float, PitchRead]] = []
 
         search = _RegionSearch(self.regions)
-        with tempfile.TemporaryDirectory(prefix="dirstral-scorebug-") as tmp:
-            work = Path(tmp)
-            for i, (t, frame) in enumerate(iter_frames(media_path, fps=self.fps)):
+        with (
+            tempfile.TemporaryDirectory(prefix="dirstral-scorebug-") as tmp,
+            _reader(self.ocr, Path(tmp), self.workers) as reader,
+        ):
+            frames = iter_frames(media_path, fps=self.fps)
+            for i, t, frame in _with_lookahead(frames, search, reader):
                 for region in search.regions_for(i):
-                    names, pitches = self._read(frame, region, work)
+                    names, pitches = reader.read(i, frame, region)
                     hits = 0
                     for read in names:
                         resolved = self._resolve(read)
@@ -306,8 +369,8 @@ class ScorebugRecognizer:
                         pid, conf = resolved
                         if read.role == LOOSE:
                             # Not evidence of anything on its own, and not
-                            # evidence that this band holds the bug either, so
-                            # it does not count towards the region lock.
+                            # evidence that this band holds the bug either,
+                            # so it does not count towards the region lock.
                             loose.append((t, pid, conf))
                             continue
                         hits += 1
@@ -324,7 +387,7 @@ class ScorebugRecognizer:
                     graphics += [(t, pitch) for pitch in pitches]
                     search.record(region, hits)
                     if hits:
-                        break  # this band answered; the others need not be OCR'd
+                        break  # this band answered; skip the other crops
 
         gap = 1.0 / self.fps
         confirmed = batters + appearances
@@ -337,21 +400,6 @@ class ScorebugRecognizer:
             cues += self._pitch_cues(graphics, pitchers)
         cues.sort(key=lambda c: (c.start_s, c.event, c.entity_ids))
         return cues
-
-    def _read(
-        self, frame: Path, region: Region, work: Path
-    ) -> tuple[list[NameRead], list[PitchRead]]:
-        names: list[NameRead] = []
-        pitches: list[PitchRead] = []
-        seen: set[tuple[str, str]] = set()
-        for path in _prepared_crops(frame, region, work):
-            found_names, found_pitches = parse_overlay(self.ocr(path))
-            for read in found_names:
-                if (read.name, read.role) not in seen:
-                    seen.add((read.name, read.role))
-                    names.append(read)
-            pitches += found_pitches
-        return names, _dedupe_pitches(pitches)
 
     def _resolve(self, read: NameRead) -> tuple[str, float] | None:
         hit = match_name(self._index, read.name)
@@ -438,6 +486,190 @@ class _RegionSearch:
                 self.locked = None
                 self.scores.clear()
                 self.misses = 0
+
+
+def read_band(ocr: OcrFn, frame: Path, region: Region, work: Path) -> _Band:
+    """OCR one band of one frame and parse both preprocessing passes.
+
+    The whole of the expensive per-frame work, and a pure function of
+    (frame, region): nothing here reads or writes recognizer state, which is
+    what makes it safe to run several at once.
+    """
+    names: list[NameRead] = []
+    pitches: list[PitchRead] = []
+    seen: set[tuple[str, str]] = set()
+    for path in _prepared_crops(frame, region, work):
+        found_names, found_pitches = parse_overlay(ocr(path))
+        for read in found_names:
+            if (read.name, read.role) not in seen:
+                seen.add((read.name, read.role))
+                names.append(read)
+        pitches += found_pitches
+    return names, _dedupe_pitches(pitches)
+
+
+class _Workspaces:
+    """A scratch directory per worker thread.
+
+    `_prepared_crops` writes its two renderings under fixed names, so threads
+    sharing one directory would overwrite each other's crop between the write
+    and the OCR of it. A directory per thread keeps the fixed names, and with
+    them a bounded amount of scratch (two files per worker, rewritten every
+    frame, rather than two per frame kept until the run ends).
+    """
+
+    def __init__(self, root: Path):
+        self._root = root
+        self._local = threading.local()
+        self._lock = threading.Lock()
+        self._issued = 0
+
+    def current(self) -> Path:
+        work = getattr(self._local, "work", None)
+        if work is None:
+            with self._lock:
+                self._issued += 1
+                work = self._root / f"worker-{self._issued}"
+            work.mkdir(parents=True, exist_ok=True)
+            self._local.work = work
+        return work
+
+
+class _SerialReader:
+    """Read one band at a time on the calling thread.
+
+    The reference behaviour, and what `workers=1` selects. `dispatch` and
+    `retire` exist so the loop in `recognize` is written once.
+    """
+
+    workers = 1
+
+    def __init__(self, ocr: OcrFn, work: Path):
+        self._ocr = ocr
+        self._work = work
+
+    def dispatch(self, index: int, frame: Path, region: Region) -> None:
+        pass
+
+    def read(self, index: int, frame: Path, region: Region) -> _Band:
+        return read_band(self._ocr, frame, region, self._work)
+
+    def retire(self, index: int) -> None:
+        pass
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        pass
+
+
+class _PooledReader:
+    """Read bands on a worker pool, keyed by frame index so order cannot leak.
+
+    Results are handed back only when `recognize` asks for a specific
+    (frame index, region), so the cue list is built in frame order whatever
+    order the workers happen to finish in. A band that was dispatched and then
+    not asked for (the region search changed its mind) is dropped; a band that
+    is asked for and was never dispatched is read on the spot.
+
+    The pool is threads, not processes, which the task's own measurement
+    justifies: on the pilot fixture 6 threads and 6 processes both returned
+    the same reads at the same speed (4.98x versus 4.92x over serial), because
+    pytesseract shells out to the `tesseract` binary and Pillow drops the GIL
+    around its own work, so the interpreter lock is not the constraint.
+    Threads then win on everything else: no pickling constraint on the
+    injected OCR callable (the default adapter is a closure), no second copy
+    of any model per worker, and a RecognizerUnavailable raised in a worker
+    arrives at `future.result()` as itself.
+    """
+
+    def __init__(self, ocr: OcrFn, work: Path, workers: int):
+        self.workers = workers
+        self._ocr = ocr
+        self._workspaces = _Workspaces(work)
+        self._executor = _new_executor(workers)
+        self._pending: dict[tuple[int, Region], Future[_Band]] = {}
+
+    def _read_here(self, frame: Path, region: Region) -> _Band:
+        return read_band(self._ocr, frame, region, self._workspaces.current())
+
+    def dispatch(self, index: int, frame: Path, region: Region) -> None:
+        key = (index, region)
+        if key not in self._pending:
+            self._pending[key] = self._executor.submit(self._read_here, frame, region)
+
+    def read(self, index: int, frame: Path, region: Region) -> _Band:
+        pending = self._pending.pop((index, region), None)
+        if pending is None:
+            return self._read_here(frame, region)
+        return pending.result()
+
+    def retire(self, index: int) -> None:
+        """Drop dispatches for frames the loop has already passed."""
+        for key in [k for k in self._pending if k[0] <= index]:
+            self._pending.pop(key).cancel()
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        for pending in self._pending.values():
+            pending.cancel()
+        self._pending.clear()
+        self._executor.shutdown(wait=True, cancel_futures=True)
+
+
+def _new_executor(workers: int) -> Executor:
+    return ThreadPoolExecutor(max_workers=workers, thread_name_prefix="scorebug")
+
+
+def _reader(ocr: OcrFn, work: Path, workers: int) -> _SerialReader | _PooledReader:
+    return _SerialReader(ocr, work) if workers <= 1 else _PooledReader(ocr, work, workers)
+
+
+def _with_lookahead(
+    frames: Iterable[tuple[float, Path]],
+    search: _RegionSearch,
+    reader: _SerialReader | _PooledReader,
+) -> Iterator[tuple[int, float, Path]]:
+    """Yield (index, timestamp, frame) while dispatching the reads to come.
+
+    Which band a frame is OCR'd on is sequential state: it depends on what the
+    frames before it produced, so the pool cannot simply be handed the whole
+    file. It is handed a guess instead, taken from the region search as it
+    stands when the frame enters the window, and `recognize` stays
+    authoritative: it asks the search which bands it actually wants and takes a
+    dispatched result only for exactly those. A guess the search does not take
+    is dropped, and a band it wants that was never guessed is read on the spot,
+    so the cue list is the serial one whatever the pool did.
+
+    The whole window is re-dispatched on every step. Dispatching is keyed and
+    idempotent, so this costs one dict lookup per frame in the window and
+    means the handful of frames already in flight when the search locks onto a
+    band get read on the pool rather than one at a time.
+    """
+    lookahead = max(MIN_LOOKAHEAD, LOOKAHEAD_PER_WORKER * reader.workers)
+    window: deque[tuple[int, float, Path]] = deque()
+    numbered = enumerate(frames)
+
+    def top_up() -> None:
+        while len(window) < lookahead:
+            item = next(numbered, None)
+            if item is None:
+                break
+            index, (timestamp, frame) = item
+            window.append((index, timestamp, frame))
+        for index, _timestamp, frame in window:
+            for region in search.regions_for(index):
+                reader.dispatch(index, frame, region)
+
+    top_up()
+    while window:
+        current = window.popleft()
+        yield current
+        reader.retire(current[0])
+        top_up()
 
 
 def _prepared_crops(frame: Path, region: Region, work: Path) -> Iterator[Path]:

--- a/annotator/tests/test_parallel_recognizers.py
+++ b/annotator/tests/test_parallel_recognizers.py
@@ -1,0 +1,417 @@
+"""Parallel per-frame reading must be invisible in the output.
+
+The scorebug and jersey recognizers read frames on a worker pool. The whole
+contract of that change is that it buys wall time and nothing else: the same
+media must yield the same cue list, in the same order, at the same
+confidences, whatever order the workers happen to finish in.
+
+These tests attack that from both ends. They compare a serial run with a
+parallel one on identical input, and they force the pathological completion
+order (last frame first) that a naive implementation would leak into the cue
+list. Backend-free: no tesseract, no Pillow, no video.
+
+Note on what the completion-order tests can prove for each recognizer. The
+jersey recognizer carries each frame's timestamp alongside its own result and
+`collapse_sightings` sorts, so shuffling the order results come back in is
+harmless there and pairing a result with the wrong timestamp is the failure
+worth testing. The scorebug's region search is real sequential state, so for
+it the order genuinely does matter and taking the wrong band's result is the
+failure worth testing. Both are pinned below.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from concurrent.futures import Future
+
+import pytest
+
+from dirstral_annotator.recognizers import jersey, scorebug
+from dirstral_annotator.recognizers.base import RecognizerUnavailable
+from dirstral_annotator.recognizers.jersey import JerseyRecognizer
+from dirstral_annotator.recognizers.scorebug import ScorebugRecognizer, default_workers
+from dirstral_annotator.roster import Roster
+
+MEDIA = "game.mp4"
+WHOLE = (0.0, 0.0, 1.0, 1.0)
+WORKERS = 4
+
+
+@pytest.fixture
+def roster(tmp_path):
+    path = tmp_path / "roster.json"
+    path.write_text(json.dumps([
+        {"id": "player:daylen-lile", "name": "Daylen Lile", "number": "4",
+         "aliases": ["Lile"], "mlbam_id": 1},
+        {"id": "player:robbie-ray", "name": "Robbie Ray", "number": "38",
+         "aliases": ["Ray"], "mlbam_id": 2},
+        {"id": "player:drew-gilbert", "name": "Drew Gilbert", "number": "0",
+         "aliases": ["Gilbert"], "mlbam_id": 4},
+        {"id": "player:jung-hoo-lee", "name": "Jung Hoo Lee", "number": "51",
+         "aliases": ["Lee"], "mlbam_id": 5},
+    ]))
+    return Roster.load(path)
+
+
+# A broadcast's worth of variety in a handful of frames: an at-bat that runs,
+# a pitch graphic, a replay with no bug in it at all, a bug that only offers a
+# loose read, and a second at-bat after the break.
+SCRIPT = [
+    "5.LILE 1-2 RAY P: 87 “6 @@ 2-0",
+    "5.LILE 1-2 RAY P: 87 “6 @@ 2-0",
+    "5.LILE 1-2 SLIDER 88 MPH “6 @@ 2-0",
+    "5.LILE 2-2 RAY P: 88 “6 @@ 2-0",
+    "Beir Lee GAS Pt atthe gL) TAT eM we",
+    "",
+    "a ray of light on the FRR ahe ey Maes",
+    "6.GILBERT 0-0 RAY P: 91 “6 @@ 2-0",
+    "6.GILBERT 0-1 FOURSEAM 92upeq “G @@",
+    "6.GILBERT 0-1 RAY P: 92 “6 @@ 2-0",
+] * 6
+
+
+@pytest.fixture
+def frames(monkeypatch, tmp_path):
+    """Drive both recognizers off a scripted list of per-frame OCR strings."""
+
+    def install(texts, fps=0.5):
+        listing = []
+        for i, text in enumerate(texts):
+            path = tmp_path / f"frame-{i:05d}.jpg"
+            path.write_text(text)
+            listing.append((i / fps, path))
+
+        for module in (scorebug, jersey):
+            monkeypatch.setattr(module, "iter_frames", lambda *a, **k: iter(listing))
+        # The real crop needs Pillow and a real JPEG; the fakes hand the OCR
+        # callable the frame itself.
+        monkeypatch.setattr(
+            scorebug, "_prepared_crops", lambda frame, region, work: iter([frame])
+        )
+        monkeypatch.setattr(jersey, "_crop", lambda frame, bbox, work: frame)
+        return lambda frame: frame.read_text()
+
+    return install
+
+
+class _ReverseExecutor:
+    """Runs everything, but only hands back results in reverse submit order.
+
+    A pool whose completion order is exactly the opposite of the frame order:
+    the worst case for any implementation that lets completion order reach the
+    cue list. Nothing runs until a result is awaited, and then the most
+    recently submitted task runs first.
+    """
+
+    def __init__(self, max_workers=None, thread_name_prefix=""):
+        self._queued: list[tuple[Future, object, tuple, dict]] = []
+
+    def submit(self, fn, *args, **kwargs):
+        future: Future = Future()
+        self._queued.append((future, fn, args, kwargs))
+        return future
+
+    def _drain(self):
+        while self._queued:
+            future, fn, args, kwargs = self._queued.pop()  # newest first
+            if not future.set_running_or_notify_cancel():
+                continue
+            try:
+                future.set_result(fn(*args, **kwargs))
+            except BaseException as exc:  # noqa: BLE001 - mirrors Executor
+                future.set_exception(exc)
+
+    def shutdown(self, wait=True, cancel_futures=False):
+        if cancel_futures:
+            self._queued.clear()
+
+
+def _watching(ocr):
+    """Wrap an OCR callable so the test can see which threads called it."""
+    threads: set[str] = set()
+    lock = threading.Lock()
+
+    def watched(frame):
+        with lock:
+            threads.add(threading.current_thread().name)
+        return ocr(frame)
+
+    return watched, threads
+
+
+def _reverse_executor_factory(monkeypatch, module):
+    """Make `module` schedule on a reverse-completion pool."""
+    pool = _ReverseExecutor()
+
+    def new_executor(workers):
+        return pool
+
+    monkeypatch.setattr(module, "_new_executor", new_executor)
+
+    original = Future.result
+
+    def result(self, timeout=None):
+        pool._drain()
+        return original(self, timeout)
+
+    monkeypatch.setattr(Future, "result", result)
+    return pool
+
+
+# --- worker count ----------------------------------------------------------
+
+def test_worker_count_comes_from_the_environment(monkeypatch):
+    monkeypatch.setenv(scorebug.WORKERS_ENV, "3")
+    assert default_workers() == 3
+
+
+def test_one_worker_selects_the_serial_path(monkeypatch, tmp_path, roster, frames):
+    monkeypatch.setenv(scorebug.WORKERS_ENV, "1")
+    assert default_workers() == 1
+    rec = ScorebugRecognizer(roster, ocr=frames(SCRIPT), crop=WHOLE)
+    assert rec.workers == 1
+    assert isinstance(scorebug._reader(rec.ocr, tmp_path, rec.workers),
+                      scorebug._SerialReader)
+    assert isinstance(scorebug._reader(rec.ocr, tmp_path, 2), scorebug._PooledReader)
+
+
+def test_recognizers_read_in_parallel_unless_told_otherwise(monkeypatch, roster, frames):
+    """The pool is the default, not an opt-in: an unset environment on a
+    multi-core host has to give more than one worker."""
+    monkeypatch.delenv(scorebug.WORKERS_ENV, raising=False)
+    monkeypatch.setattr(scorebug.os, "cpu_count", lambda: 16)
+    assert default_workers() > 1
+    assert ScorebugRecognizer(roster, ocr=frames(SCRIPT)).workers > 1
+    assert JerseyRecognizer(
+        roster, detector=lambda frame: [], ocr=frames(SCRIPT)
+    ).workers > 1
+
+
+def test_the_default_leaves_the_host_room_for_tesseracts_own_threads(monkeypatch):
+    """A worker is not one core's worth of work: tesseract runs four threads
+    per page, so N workers put 4N threads on the machine. The default has to
+    scale with the host and stay capped."""
+    monkeypatch.delenv(scorebug.WORKERS_ENV, raising=False)
+    for cores, expected in ((1, 1), (4, 1), (8, 2), (16, 4), (32, 8), (256, 8)):
+        monkeypatch.setattr(scorebug.os, "cpu_count", lambda cores=cores: cores)
+        assert default_workers() == expected, cores
+    # cpu_count() is documented as possibly None.
+    monkeypatch.setattr(scorebug.os, "cpu_count", lambda: None)
+    assert default_workers() == 1
+
+
+def test_a_nonsense_worker_count_falls_back_to_the_host(monkeypatch):
+    for junk in ("", "  ", "many", "0", "-4", "2.5"):
+        monkeypatch.setenv(scorebug.WORKERS_ENV, junk)
+        assert default_workers() >= 1
+    monkeypatch.delenv(scorebug.WORKERS_ENV)
+    assert 1 <= default_workers() <= scorebug.MAX_DEFAULT_WORKERS
+
+
+# --- scorebug --------------------------------------------------------------
+
+def test_scorebug_parallel_matches_serial(roster, frames):
+    """The headline contract: same input, same cue list, in the same order."""
+    serial = ScorebugRecognizer(roster, ocr=frames(SCRIPT), workers=1).recognize(MEDIA)
+    parallel = ScorebugRecognizer(
+        roster, ocr=frames(SCRIPT), workers=WORKERS
+    ).recognize(MEDIA)
+    assert serial == parallel
+    assert serial, "the fixture must produce cues, or this proves nothing"
+
+
+def test_scorebug_parallel_matches_serial_with_a_pinned_region(roster, frames):
+    # The swept path locks onto a band part way through; the pinned one never
+    # sweeps at all. Both have to survive the pool.
+    serial = ScorebugRecognizer(
+        roster, ocr=frames(SCRIPT), crop=WHOLE, workers=1
+    ).recognize(MEDIA)
+    parallel = ScorebugRecognizer(
+        roster, ocr=frames(SCRIPT), crop=WHOLE, workers=WORKERS
+    ).recognize(MEDIA)
+    assert serial == parallel and serial
+
+
+def test_scorebug_survives_reversed_completion_order(monkeypatch, roster, frames):
+    serial = ScorebugRecognizer(roster, ocr=frames(SCRIPT), workers=1).recognize(MEDIA)
+    _reverse_executor_factory(monkeypatch, scorebug)
+    reversed_run = ScorebugRecognizer(
+        roster, ocr=frames(SCRIPT), workers=WORKERS
+    ).recognize(MEDIA)
+    assert reversed_run == serial and serial
+
+
+def test_scorebug_parallel_matches_serial_across_a_lock_release(roster, frames):
+    """The band lock is the sequential state the pool has to be guessed past.
+
+    A long stretch with no bug in it releases the lock and puts the search
+    back to sweeping, so the bands wanted for the frames already dispatched
+    change under the pool. Getting that wrong is how a parallel run would
+    quietly read the wrong crop and lock onto a different band.
+    """
+    quiet = scorebug._RegionSearch.RELEASE_AFTER_MISSES + 10
+    script = SCRIPT[:20] + ["Beir Lee GAS Pt atthe"] * quiet + SCRIPT[:20]
+    serial = ScorebugRecognizer(roster, ocr=frames(script), workers=1)
+    parallel = ScorebugRecognizer(roster, ocr=frames(script), workers=WORKERS)
+    cues = serial.recognize(MEDIA)
+    assert cues and cues == parallel.recognize(MEDIA)
+
+
+def test_pooled_reader_reads_a_band_nobody_dispatched(roster, frames, tmp_path):
+    """The loop dispatches what it is about to want, but `read` must not
+    depend on that: a band it was never handed is read on the spot."""
+    ocr = frames(SCRIPT)
+    frame = tmp_path / "frame-00000.jpg"
+    with scorebug._PooledReader(ocr, tmp_path, WORKERS) as reader:
+        names, pitches = reader.read(7, frame, WHOLE)
+    assert scorebug.NameRead("LILE", scorebug.BATTER) in names
+    assert [p.speed for p in pitches] == []
+
+
+def test_scorebug_reads_every_frame_exactly_once_per_wanted_band(roster, frames):
+    """A speculative dispatch that is not taken must not reach the cue list,
+    and a band that is taken must not be OCR'd twice into it."""
+    base = frames(SCRIPT)
+    seen: list[str] = []
+    lock = threading.Lock()
+
+    def counting_ocr(frame):
+        text = base(frame)
+        with lock:
+            seen.append(frame.name)
+        return text
+
+    rec = ScorebugRecognizer(roster, ocr=counting_ocr, crop=WHOLE, workers=WORKERS)
+    rec.recognize(MEDIA)
+    # One band, one preprocessing pass per frame under the fake crop.
+    assert sorted(seen) == sorted(f"frame-{i:05d}.jpg" for i in range(len(SCRIPT)))
+
+
+def test_scorebug_reads_on_the_worker_pool(roster, frames):
+    """Equality with a serial run is also what a silently serial pool would
+    give, so pin that the reads really do leave the calling thread."""
+    ocr, threads = _watching(frames(SCRIPT))
+    ScorebugRecognizer(roster, ocr=ocr, crop=WHOLE, workers=WORKERS).recognize(MEDIA)
+    assert len(threads) > 1, f"reads never left the calling thread: {threads}"
+    assert all(name.startswith("scorebug") for name in threads), threads
+
+
+def test_scorebug_unavailable_backend_propagates_from_a_worker(roster, frames):
+    """A worker that cannot read a frame must surface as an unavailable
+    recognizer, which the pipeline skips, not as a broken pool."""
+    frames(SCRIPT)
+
+    def refuses(frame):
+        raise RecognizerUnavailable("Pillow is required for scorebug OCR")
+
+    rec = ScorebugRecognizer(roster, ocr=refuses, crop=WHOLE, workers=WORKERS)
+    with pytest.raises(RecognizerUnavailable):
+        rec.recognize(MEDIA)
+
+
+# --- jersey ----------------------------------------------------------------
+
+JERSEY_SCRIPT = ["4", "38", "", "51", "4", "0", "99", "38", "", "4"] * 6
+
+
+@pytest.fixture
+def jersey_parts(frames):
+    """A detector that finds one player per frame and OCR that reads the
+    frame's scripted number off it."""
+    ocr = frames(JERSEY_SCRIPT)
+    return (lambda frame: [(0, 0, 10, 10)]), ocr
+
+
+def test_jersey_parallel_matches_serial(roster, jersey_parts):
+    detect, ocr = jersey_parts
+    serial = JerseyRecognizer(
+        roster, detector=detect, ocr=ocr, workers=1
+    ).recognize(MEDIA)
+    parallel = JerseyRecognizer(
+        roster, detector=detect, ocr=ocr, workers=WORKERS
+    ).recognize(MEDIA)
+    assert serial == parallel
+    assert serial, "the fixture must produce cues, or this proves nothing"
+
+
+def test_jersey_survives_reversed_completion_order(monkeypatch, roster, jersey_parts):
+    detect, ocr = jersey_parts
+    serial = JerseyRecognizer(
+        roster, detector=detect, ocr=ocr, workers=1
+    ).recognize(MEDIA)
+    _reverse_executor_factory(monkeypatch, jersey)
+    reversed_run = JerseyRecognizer(
+        roster, detector=detect, ocr=ocr, workers=WORKERS
+    ).recognize(MEDIA)
+    assert reversed_run == serial and serial
+
+
+def test_jersey_keeps_a_multi_player_frame_in_detection_order(roster, frames):
+    """Several detections in one frame are still one frame: their numbers must
+    reach the sighting list in the order the detector returned them."""
+    ocr = frames(["4 38 51"] * 12)
+
+    def detect(frame):
+        return [(0, 0, 10, 10)]
+
+    serial = JerseyRecognizer(roster, detector=detect, ocr=ocr, workers=1)
+    parallel = JerseyRecognizer(roster, detector=detect, ocr=ocr, workers=WORKERS)
+    assert serial.recognize(MEDIA) == parallel.recognize(MEDIA)
+
+
+def test_jersey_reads_on_the_worker_pool(roster, jersey_parts):
+    detect, base = jersey_parts
+    ocr, threads = _watching(base)
+    JerseyRecognizer(roster, detector=detect, ocr=ocr, workers=WORKERS).recognize(MEDIA)
+    assert len(threads) > 1, f"reads never left the calling thread: {threads}"
+    assert all(name.startswith("jersey") for name in threads), threads
+
+
+def test_jersey_unavailable_backend_propagates_from_a_worker(roster, jersey_parts):
+    detect, _ = jersey_parts
+
+    def refuses(frame):
+        raise RecognizerUnavailable("Pillow is required for jersey OCR")
+
+    rec = JerseyRecognizer(roster, detector=detect, ocr=refuses, workers=WORKERS)
+    with pytest.raises(RecognizerUnavailable):
+        rec.recognize(MEDIA)
+
+
+def test_jersey_builds_a_detector_per_worker_thread(roster, frames):
+    """Ultralytics models are not thread safe, so the default adapter is
+    rebuilt per worker rather than shared."""
+    built: list[int] = []
+    lock = threading.Lock()
+
+    def factory():
+        with lock:
+            built.append(1)
+        return lambda frame: [(0, 0, 10, 10)]
+
+    detectors = jersey._Detectors(factory)
+    threads = [threading.Thread(target=lambda: detectors.current()) for _ in range(3)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert len(built) == 3
+    # A thread that asks twice keeps the one it was given.
+    detectors.current()
+    detectors.current()
+    assert len(built) == 4
+
+
+def test_jersey_hands_the_constructed_detector_to_the_first_worker():
+    """The instance built in the constructor is used, not left idle beside a
+    freshly built one."""
+
+    def seed(frame):
+        return []
+
+    def factory():
+        return lambda frame: []
+
+    detectors = jersey._Detectors(factory, seed=seed)
+    assert detectors.current() is seed


### PR DESCRIPTION
## What

`ScorebugRecognizer` and `JerseyRecognizer` read frames on a bounded worker pool instead of one at a time. `FaceRecognizer` and `recognizers/base.py` are untouched.

Nothing about the output changes. Every measurement below reports the sha256 of the JSON cue list, and it is the same in every configuration.

## Why

A full-game eval was dominated by per-frame OCR run serially on a 16 core host, and every frame is independent of every other. Measured per frame on the fixture:

| recognizer | s/frame serial | 6118 frames (3h24m at 0.5 fps) |
|---|---|---|
| scorebug | 1.00 to 1.04 | 1h42m to 1h46m |
| jersey | 1.71 | 2h55m |
| face (untouched, GPU) | 0.154 | 16m |

The two OCR recognizers were about 4h40m of a run whose one ffmpeg extraction pass is 35 minutes.

## BEFORE / AFTER

Host `q2e`, 16 cores, `segment_5900_6800.mp4`, 0.5 fps. Frame extraction is shared and excluded from every time below.

**Scorebug, all 450 frames of the fixture, one process, one extraction:**

```
                                                        cues  sha256 of cue JSON
serial        448.7s  0.997 s/frame  1.00x               115  d60ac91b5fba88bc...
parallel x4   135.9s  0.302 s/frame  3.30x  identical    115  d60ac91b5fba88bc...
parallel x6   140.5s  0.312 s/frame  3.19x  identical    115  d60ac91b5fba88bc...
parallel x8   498.4s  1.108 s/frame  0.90x  identical    115  d60ac91b5fba88bc...
parallel x12 1976.8s  4.393 s/frame  0.23x  identical    115  d60ac91b5fba88bc...
```

An earlier run of the same comparison at 6 workers on a busier box: 466.7s to 140.4s, 3.32x, same digest.

**Jersey, first 100 frames:**

```
serial        171.2s  1.712 s/frame  1.00x               25  fee6b7f604a484bb...
parallel x6    29.1s  0.291 s/frame  5.88x  identical    25  fee6b7f604a484bb...
```

**Proof the output is unchanged.** Every row above is `serial_cues == parallel_cues` as Python objects *and* an equal sha256 over `json.dumps([asdict(c) for c in cues], sort_keys=True)`. That holds at 12 workers on a box at load 47, which is the most completion-order shuffling this will ever see in practice.

## Threads, not processes, and the measurement that says so

The brief asked for processes unless the GIL could be shown not to be the constraint. It is not. Same fixture, same work, 6 workers, identical read digests:

```
serial       66.31s  1.036 s/frame  1.00x
threads x6   13.32s  0.208 s/frame  4.98x
procs   x6   13.48s  0.211 s/frame  4.92x
```

Within 1% of each other, because `pytesseract.image_to_string` shells out to the `tesseract` binary and Pillow (and torch, for jersey) drop the GIL around their own work. Threads then win on everything else:

- no pickling constraint on the injected OCR and detector callables, and the default adapters are closures over loaded models, so a process pool would have needed them redesigned;
- no second copy of a model per worker;
- `RecognizerUnavailable` raised in a worker arrives at `future.result()` as itself.

## The worker default is measured, and it is not the core count

`tesseract` here is built against OpenMP and runs **four threads per page** (`NLWP 4` on every invocation), so N workers put 4N threads on the machine. That produces a hard cliff, reproduced in an interleaved A/B on an otherwise idle box (120 frames, two rounds, load recorded per arm):

```
round 0 x1  125.6s  1.00x   load  7.9 ->  4.2
round 0 x4   41.9s  3.00x   load  4.2 ->  8.4
round 0 x6   46.7s  2.69x   load  8.4 -> 14.4
round 0 x8  151.3s  0.83x   load 14.4 -> 29.0
round 1 x1  118.9s  1.06x   load 29.0 ->  7.1
round 1 x4   40.3s  3.11x   load  7.1 ->  8.2
round 1 x6   52.2s  2.41x   load  8.2 -> 14.8
round 1 x8  169.0s  0.74x   load 14.8 -> 30.4
```

The load column tracks 4 threads per worker exactly. At 8 workers (32 threads on 16 cores) the run is slower than serial; at 12 it is four times slower.

So the default is `max(1, min(cpu_count // 4, 8))`, which is 4 on this host, the fastest measured setting. `DIRSTRAL_ANNOTATOR_WORKERS` overrides it (`1` selects the serial path); a value that is not a positive integer is ignored rather than silently disabling the pool. `OMP_THREAD_LIMIT=1` would let the count go higher, but it is process wide and would also throttle the torch and onnxruntime work the jersey and face recognizers do in the same process, so it is documented rather than set.

## How determinism is guaranteed

Not by sorting at the end and hoping.

**Jersey** has no sequential state. Frames are dispatched in order, held in a bounded window, and awaited in that same order; a worker that finishes early waits its turn. Each frame's timestamp travels with its own future.

**Scorebug** does have sequential state: `_RegionSearch` decides which of four candidate overlay bands a frame is OCR'd on, based on what earlier frames produced, so the pool cannot be handed the whole file. It is handed a *guess* taken from the search as it stands, and `recognize()` stays authoritative:

- it asks the search which bands it wants and takes a dispatched result only for exactly those `(frame index, band)` keys;
- a guess the search does not take is dropped and cancelled;
- a band it wants that was never guessed is read on the spot.

The whole look-ahead window is re-dispatched on each step (dispatch is keyed and idempotent), so the frames already in flight when the search locks or releases a band get read on the pool rather than one at a time.

## Tests

`annotator/tests/test_parallel_recognizers.py`, 20 tests, backend-free (no tesseract, no Pillow, no video):

- serial vs parallel cue-list equality for both recognizers, swept and pinned-region;
- equality across a band lock *release*, the transition that makes the scorebug's guesses wrong;
- a `_ReverseExecutor` that completes tasks in exactly the opposite order to submission;
- every frame read exactly once per wanted band, and reads really leaving the calling thread (so a silently serial pool fails);
- `RecognizerUnavailable` from a worker surfacing as itself for both recognizers;
- worker-count parsing, including the `cpu_count // 4` table and `cpu_count()` returning `None`;
- a detector per worker thread, and the constructor-built one going to the first worker.

I mutation-tested these rather than trusting them. Live-code mutations caught: scorebug `read()` taking any pending band, `retire()` dropping one frame too many, `dispatch()` becoming a no-op, and jersey pairing a result with the next frame's timestamp. One mutation survives by design and is documented in the test module: reversing jersey's window is genuinely harmless, because each timestamp travels with its own result and `collapse_sightings` sorts.

## Incidental fixes in the same files

- Jersey wrote its crops into the **shared frame cache directory** and never removed them, leaving one JPEG per detection per frame on disk for the whole run (tens of thousands for a game). Crops now go to a scratch directory per worker thread under a fixed name, so the scratch is one file per worker for a whole run and the frame cache other recognizers iterate stays clean.
- Jersey's crop step raised bare `ImportError` for a missing Pillow, which would abort the cascade; it now raises `RecognizerUnavailable` so the pipeline skips the recognizer, matching the scorebug.
- The default ultralytics detector is built per worker thread (an ultralytics model is not documented thread safe), with construction serialised so workers cannot race the weights fetch on first use.

## Recommended, deliberately not implemented: per-recognizer sampling

The brief asked whether decoupling per-recognizer sampling rates is a bigger win than parallelism. **It is not, and it is not free.**

The shape it would have to take is a per-recognizer *stride over the shared extracted frames*, not a per-recognizer fps: `iter_frames` is memoised on `(media, fps)`, so a second fps triggers a second full decode and gives back the ~35 minutes that #637 saved.

At stride 2 the scorebug's cost halves. That is at most another 2x, against the 3.0x to 3.3x already delivered here, and unlike this change it moves the output:

- `at_bat` and `appearance` are safe. Runs merge across `frame_gap + RUN_GAP_S`, which goes from 2+3=5s to 4+3=7s, so runs still close correctly.
- `pitch` is not safe. A pitch-speed graphic is transient; `PITCH_MERGE_S` of 6s is the standing assumption about how long it lingers. Going from 2s to 4s between samples takes the graphic from about two samples to about one, so pitch recall would degrade by an amount only an eval can measure.

So: worth doing, as its own PR with an eval run behind it, and it composes with this one (a further ~2x on top). Parallelism is the bigger and much safer win, which is why it is the one in this PR.

## Gates

- `./venv/bin/python -m pytest annotator/tests -q` on `q2e`: **108 passed, 1 skipped**
- `ruff check --select E701,E702,F annotator/` (ruff 0.16.1): **All checks passed**
- The two recognizer files are also clean under ruff's full default ruleset, which the rest of the package is not.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable parallel processing for jersey and scorebug recognition.
  * Preserved ordered results while processing frames concurrently.
  * Added automatic cleanup for temporary recognition files.
  * Added clear handling when required image-processing support is unavailable.

* **Bug Fixes**
  * Improved detector and OCR processing reliability across worker threads.
  * Preserved sequential scorebug region behavior and recognition output consistency.

* **Tests**
  * Added coverage for serial and parallel processing, worker configuration, ordering, error handling, and resource cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->