### PR TITLE
feat(eval): report coverage against what a source can actually reach

### DIFF
--- a/annotator/dirstral_annotator/eval/diagnose.py
+++ b/annotator/dirstral_annotator/eval/diagnose.py
@@ -88,6 +88,10 @@ class SourceDiagnostics:
     pitches_with_pitcher_cue: int = 0
     pitches_with_batter_cue: int = 0
     pitches_covered: int = 0  # pitcher or batter named within tolerance
+    #: Pitches whose pitcher or batter this source names SOMEWHERE in the media,
+    #: at any time. It is the source's own effective vocabulary, so it separates
+    #: "cannot identify this person at all" from "did not identify them here".
+    pitches_reachable: int = 0
     found_pitches: int = 0  # credited by the scorecard
     samples: list[Cue] = field(default_factory=list)
 
@@ -219,6 +223,11 @@ def diagnose(
     # Pitch coverage is per-window so one chatty cue cannot cover a pitch twice.
     covered_pitcher: dict[str, set[int]] = defaultdict(set)
     covered_batter: dict[str, set[int]] = defaultdict(set)
+    # Every identity a source emits anywhere, used below to compute what it
+    # could have covered. A face bank missing half a roster and a recognizer
+    # that rarely resolves a face both show up as low raw coverage; only this
+    # tells them apart, and they call for opposite responses.
+    vocabulary: dict[str, set[str]] = defaultdict(set)
 
     for cue in cues:
         b = bucket(cue.source)
@@ -231,6 +240,7 @@ def diagnose(
         if cue.event == SCORED_EVENT:
             b.scored_event_cues += 1
         for pid in cue.entity_ids:
+            vocabulary[cue.source].add(pid)
             if roster.get(pid) is None:
                 b.unknown_entity_ids.add(pid)
         if len(b.samples) < DEBUG_SAMPLE:
@@ -258,6 +268,11 @@ def diagnose(
         b.pitches_with_pitcher_cue = len(covered_pitcher[src])
         b.pitches_with_batter_cue = len(covered_batter[src])
         b.pitches_covered = len(covered_pitcher[src] | covered_batter[src])
+        known = vocabulary[src]
+        b.pitches_reachable = sum(
+            1 for w in windows
+            if w.pitcher_id in known or (w.batter_id is not None and w.batter_id in known)
+        )
     return diag
 
 

--- a/annotator/dirstral_annotator/eval/report.py
+++ b/annotator/dirstral_annotator/eval/report.py
@@ -138,16 +138,26 @@ def _diagnostics_sections(diag: Diagnostics, roster: Roster, debug: bool) -> lis
         "it is deliberately easier than the gate above and must never be quoted as "
         "accuracy.",
         "",
+        "`Reachable` is the pitches whose pitcher or batter this source names "
+        "*somewhere* in the media, so `of reachable` asks how often it identified "
+        "someone it demonstrably can identify. That is the column that separates a "
+        "recognizer which rarely resolves anyone from one whose gallery simply does "
+        "not contain half the roster; raw coverage cannot tell those apart, and they "
+        "call for opposite responses.",
+        "",
         "| Source | Pitches w/ pitcher cue | Pitches w/ batter cue | Pitches covered "
-        "| Coverage |",
-        "|---|---|---|---|---|",
+        "| Coverage | Reachable | of reachable |",
+        "|---|---|---|---|---|---|---|",
     ]
     for src in sorted(diag.per_source):
         d = diag.per_source[src]
         pct = _pct(d.pitches_covered / diag.scored_pitches if diag.scored_pitches else None)
+        reach_pct = _pct(
+            d.pitches_covered / d.pitches_reachable if d.pitches_reachable else None
+        )
         lines.append(
             f"| {src} | {d.pitches_with_pitcher_cue} | {d.pitches_with_batter_cue} "
-            f"| {d.pitches_covered} | {pct} |"
+            f"| {d.pitches_covered} | {pct} | {d.pitches_reachable} | {reach_pct} |"
         )
 
     off_target = {

--- a/annotator/tests/test_reachable_coverage.py
+++ b/annotator/tests/test_reachable_coverage.py
@@ -1,0 +1,78 @@
+"""Reachable-pitch coverage: separates a weak recognizer from a small gallery.
+
+Raw coverage conflates two failures that call for opposite fixes. A face bank
+holding 13 of 52 players and a recognizer that rarely resolves a face both read
+as low coverage. `pitches_reachable` uses the source's own emitted identities as
+its vocabulary, so the distinction needs no knowledge of the gallery.
+"""
+
+from __future__ import annotations
+
+import json
+
+from dirstral_annotator.eval import diagnose
+from dirstral_annotator.eval.align import Alignment
+from dirstral_annotator.eval.ground_truth import PitchEvent
+from dirstral_annotator.eval.score import Scorecard
+from dirstral_annotator.model import Cue
+from dirstral_annotator.roster import Roster
+
+
+def _roster(tmp_path, n):
+    rows = [
+        {"id": f"player:p{i}", "name": f"P{i}", "aliases": [f"P{i}"], "mlbam_id": 1000 + i}
+        for i in range(n)
+    ]
+    path = tmp_path / "roster.json"
+    path.write_text(json.dumps(rows))
+    return Roster.load(path)
+
+
+def _events(pitcher_idx, batter_idx):
+    """One pitch every 10s, players identified by roster index."""
+    return [
+        PitchEvent(game_pk=1, epoch_s=float(i) * 10, pitcher_id=1000 + p,
+                   pitcher_name=f"P{p}", batter_id=1000 + b, batter_name=f"P{b}",
+                   inning=1, description="")
+        for i, (p, b) in enumerate(zip(pitcher_idx, batter_idx))
+    ]
+
+
+def _cue(source, ids, start):
+    return Cue(source=source, start_s=start, end_s=start + 1.0, event="appearance",
+               entity_ids=tuple(ids), confidence=0.9, text="")
+
+
+def _run(tmp_path, pitcher_idx, batter_idx, cues, n_players=40):
+    return diagnose.diagnose(
+        cues=cues, annotations=[], events=_events(pitcher_idx, batter_idx),
+        alignment=Alignment(offset_s=0.0, spread_s=0.0, anchors=1),
+        roster=_roster(tmp_path, n_players), card=Scorecard(),
+    )
+
+
+def test_narrow_vocabulary_shrinks_the_reachable_set(tmp_path):
+    """A source that only ever names one player can only reach the pitches that
+    player appears in. That is the enrollment-limited signature."""
+    diag = _run(tmp_path, [0] * 5 + [1] * 5, list(range(10, 20)),
+                [_cue("narrow", ["player:p0"], 0.0)])
+    b = diag.per_source["narrow"]
+    assert b.pitches_reachable == 5, "only p0's 5 pitches are inside its vocabulary"
+    assert b.pitches_covered == 1
+
+
+def test_broad_vocabulary_keeps_the_reachable_set_large(tmp_path):
+    """A source naming many players reaches most pitches, so low coverage there
+    means it identifies rarely, not narrowly: the recognizer-limited signature."""
+    diag = _run(tmp_path, list(range(10)), list(range(10, 20)),
+                [_cue("broad", [f"player:p{i}"], float(i) * 10) for i in range(10)])
+    b = diag.per_source["broad"]
+    assert b.pitches_reachable == 10
+    assert b.pitches_covered == 10
+
+
+def test_a_source_naming_nobody_reaches_nothing(tmp_path):
+    diag = _run(tmp_path, [0] * 4, [1] * 4, [_cue("silent", [], 0.0)])
+    b = diag.per_source["silent"]
+    assert b.pitches_reachable == 0
+    assert b.pitches_covered == 0

--- a/annotator/tests/test_reachable_coverage.py
+++ b/annotator/tests/test_reachable_coverage.py
@@ -34,7 +34,8 @@ def _events(pitcher_idx, batter_idx):
         PitchEvent(game_pk=1, epoch_s=float(i) * 10, pitcher_id=1000 + p,
                    pitcher_name=f"P{p}", batter_id=1000 + b, batter_name=f"P{b}",
                    inning=1, description="")
-        for i, (p, b) in enumerate(zip(pitcher_idx, batter_idx))
+        # strict: a length mismatch is a bug in the caller, not fewer pitches to test
+        for i, (p, b) in enumerate(zip(pitcher_idx, batter_idx, strict=True))
     ]
 
 


### PR DESCRIPTION
Builds the decisive measurement for **#739**.

## Why

The pilot's face recognizer covered **16.3%** of pitches. That single number reads identically under two situations that call for opposite responses:

- **Gallery-limited**: the bank holds 13 of 52 players, zero Nationals. Fix by getting headshots.
- **Recognizer-limited**: broadcast wide shots put faces at 30-50 px and only close-ups resolve. Fix by changing what we ask of it, or retiring it.

Raw coverage cannot separate those, so the report was inviting a guess.

## What this adds

`pitches_reachable`: the pitches whose pitcher or batter a source names **somewhere in the media**, using the source's own emitted identities as its vocabulary.

- A **narrow gallery** shrinks the reachable set, so `of reachable` stays high while raw coverage is low.
- A **weak recognizer** keeps the reachable set wide and scores low against it.

Deliberately self-calibrating: it needs no knowledge of the face bank, which matters because `eval/diagnose.py` has no business knowing what a gallery contains, and the same question arises for any future source.

## What it will likely show

The enrollment ceiling was separately measured at **92.9%** of plays having an enrolled batter or pitcher (78/84), because one side is always the Giants and every play has both roles. So roughly 320 of 344 pitches are already reachable and face covered 56 of them, i.e. about **17% of what it can already reach**. If that holds, the answer is recognizer-limited and more headshots will not move it.

I have not run it on the real corpus yet: the pilot host is intermittently unreachable. The arithmetic above uses figures already measured, so the run is confirmation rather than discovery.

## Tests

Three, covering the narrow-vocabulary signature, the broad-vocabulary signature, and a source that names nobody. Written against the real `diagnose()` API with a real `Roster` rather than stubs, after my first draft guessed the signature wrong.

129 annotator tests pass; ruff clean. Only `eval/` and `tests/` touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reachable-pitch diagnostics to distinguish limited identity coverage from recognition misses.
  * Expanded identity coverage reports with reachable pitch counts and coverage percentages.
  * Displays “n/a” when reachable-pitch coverage cannot be calculated.

* **Tests**
  * Added coverage for narrow, broad, and empty source vocabularies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->