### PR TITLE
perf(store): bound the embedded-chunk page at candidate selection (#732)

### DIFF
--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -899,6 +899,11 @@ CREATE INDEX IF NOT EXISTS idx_chunks_rep_id ON chunks(rep_id);
 CREATE INDEX IF NOT EXISTS idx_chunks_embedding_status ON chunks(embedding_status);
 CREATE INDEX IF NOT EXISTS idx_chunks_index_kind ON chunks(index_kind);
 CREATE INDEX IF NOT EXISTS idx_chunks_rel_path_deleted ON chunks(rel_path, deleted);
+-- Serves the keyset page of ListEmbeddedChunkMetadata (#732): the three equality
+-- terms are the leading columns and chunk_id is last, so a kind-scoped page seeks
+-- straight to the cursor and reads only the rows it returns, already in chunk_id
+-- order (no sort, no scan of the rest of the corpus).
+CREATE INDEX IF NOT EXISTS idx_chunks_embedded_kind_seek ON chunks(embedding_status, deleted, index_kind, chunk_id);
 CREATE INDEX IF NOT EXISTS idx_spans_chunk_id_span_id ON spans(chunk_id, span_id);
 CREATE INDEX IF NOT EXISTS idx_mcp_sessions_last_seen ON mcp_sessions(last_seen_unix);
 CREATE INDEX IF NOT EXISTS idx_mcp_payment_outcomes_updated ON mcp_payment_outcomes(updated_unix);
@@ -2779,14 +2784,123 @@ func (s *SQLiteStore) ChunkModalityPresence(ctx context.Context, relPath string)
 	return m == 1, t == 1, nil
 }
 
+// embeddedChunkPageQuery builds one page of the ListEmbeddedChunkMetadata walk
+// together with its positional arguments.
+//
+// Both selective predicates (the index_kind filter and the page LIMIT) live
+// INSIDE filtered_chunks, which is what keeps a page's cost bounded (#732).
+// They used to sit in the outer query. SQLite pushes an outer equality term like
+// index_kind down on its own, but it can never push a LIMIT into a subquery, so
+// the CTE (and the ROW_NUMBER window materialized over its spans) still covered
+// EVERY embedded chunk above the cursor and the outer LIMIT threw all but one
+// page of it away: a full keyset walk therefore cost O(N^2 / pageSize). Written
+// this way the candidate scan itself stops at one page, and the walk is linear in
+// the corpus. idx_chunks_embedded_kind_seek makes the kind-scoped page a pure
+// index seek; without a kind, the leading embedding_status column of
+// idx_chunks_embedding_status plus the implicit rowid serves the same seek.
+//
+// An explicit ORDER BY chunk_id inside the CTE makes the LIMIT select the FIRST
+// page after the cursor (a bare LIMIT would take an arbitrary subset); the outer
+// ORDER BY is kept so the returned rows stay ordered for the caller's keyset
+// cursor regardless of how the joins are executed.
+//
+// The first span of a chunk is picked by joining on MIN(span_id) rather than by a
+// ROW_NUMBER() window over a spans CTE. Same row (spans.span_id is the primary
+// key, so the lowest span_id is the window's rn = 1), but once filtered_chunks is
+// materialized SQLite drives that window off a full scan of the spans table on
+// EVERY page, which reintroduces per-page O(N) work from the other side of the
+// join. The correlated MIN is one index seek per returned row.
+func embeddedChunkPageQuery(indexKind string, limit int, afterChunkID int64) (string, []any) {
+	args := []any{"ok", afterChunkID}
+	kindPredicate := ""
+	if strings.TrimSpace(indexKind) != "" {
+		kindPredicate = " AND c.index_kind = ?"
+	}
+	query := `WITH filtered_chunks AS (
+	            SELECT c.chunk_id, c.rel_path, c.doc_type, c.rep_type, c.text, c.index_kind, c.modality, c.media_ref, c.language
+	            FROM chunks c
+	            WHERE c.embedding_status = ? AND c.deleted = 0 AND c.chunk_id > ?` + kindPredicate + `
+	            ORDER BY c.chunk_id
+	            LIMIT ?
+	          )
+	          SELECT fc.chunk_id, fc.rel_path, fc.doc_type, fc.rep_type, fc.text, fc.index_kind,
+	                 COALESCE(sp.span_kind, ''), COALESCE(sp.start, 0), COALESCE(sp."end", 0), COALESCE(sp.extra_json, ''),
+	                 COALESCE(d.title, ''), fc.modality, fc.media_ref, fc.language, COALESCE(d.mtime_unix, 0)
+	          FROM filtered_chunks fc
+	          LEFT JOIN spans sp ON sp.span_id = (
+	            SELECT MIN(s.span_id) FROM spans s WHERE s.chunk_id = fc.chunk_id
+	          )
+	          LEFT JOIN documents d ON d.rel_path = fc.rel_path
+	          ORDER BY fc.chunk_id`
+	if kindPredicate != "" {
+		args = append(args, indexKind)
+	}
+	args = append(args, limit)
+	return query, args
+}
+
+// EmbeddedChunkPageQueryForTest returns the SQL a single ListEmbeddedChunkMetadata
+// page runs.
+//
+// Exported solely so the #732 regression test can live under tests/ as AGENTS.md
+// requires: the property worth pinning is WHERE in the statement the page's two
+// selective predicates sit, which is neither observable through the ordinary
+// store API nor reliably visible in a query plan (the planner is free to pick the
+// same index either way). Production code never calls this.
+func EmbeddedChunkPageQueryForTest(indexKind string, limit int, afterChunkID int64) (string, []any) {
+	return embeddedChunkPageQuery(indexKind, limit, afterChunkID)
+}
+
+// ExplainEmbeddedChunkPageForTest returns the SQLite query plan (one string per
+// plan row) for a single ListEmbeddedChunkMetadata page.
+//
+// Exported solely so the #732 regression test can live under tests/ as AGENTS.md
+// requires: the property worth pinning is that a page SEEKS its rows through an
+// index instead of scanning the whole chunks table, and a query plan is not
+// observable through the ordinary store API. Production code never calls this.
+func (s *SQLiteStore) ExplainEmbeddedChunkPageForTest(ctx context.Context, indexKind string, limit int, afterChunkID int64) ([]string, error) {
+	db, err := s.ensureReadDB(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer s.ReleaseDB()
+
+	query, args := embeddedChunkPageQuery(indexKind, limit, afterChunkID)
+	rows, err := db.QueryContext(ctx, "EXPLAIN QUERY PLAN "+query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var plan []string
+	for rows.Next() {
+		var id, parent, notUsed int
+		var detail string
+		if err := rows.Scan(&id, &parent, &notUsed, &detail); err != nil {
+			return nil, err
+		}
+		plan = append(plan, detail)
+	}
+	return plan, rows.Err()
+}
+
 // ListEmbeddedChunkMetadata pages through embedded ("ok") chunks using keyset
 // (seek) pagination: afterChunkID is an exclusive lower bound on chunk_id (pass 0
 // to start), and callers carry the last chunk_id of each page forward as the next
 // afterChunkID. Rows are ordered by chunk_id ascending, so this walks each row
 // exactly once — unlike OFFSET, which rescans and discards skipped rows every
 // page (quadratic on large embedded sets).
+//
+// It reads through the query-only pool (#631), not the single-connection writer:
+// it is a SELECT-only path, so on the writer it made every page queue behind
+// in-flight ingest writes and made two concurrent kind walks serialize inside
+// database/sql for no gain (#732). Both production callers (the startup warm-load
+// in internal/cli and the vector reconciliation in internal/index) call it
+// outside any write transaction, and the reconciler's interleaved re-pends only
+// touch chunk_ids at or below the cursor it has already passed, so reading a
+// slightly different snapshot than the writer holds cannot change the walk.
 func (s *SQLiteStore) ListEmbeddedChunkMetadata(ctx context.Context, indexKind string, limit int, afterChunkID int64) ([]model.ChunkTask, error) {
-	db, err := s.ensureDB(ctx)
+	db, err := s.ensureReadDB(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -2798,30 +2912,7 @@ func (s *SQLiteStore) ListEmbeddedChunkMetadata(ctx context.Context, indexKind s
 		afterChunkID = 0
 	}
 
-	args := []any{"ok", afterChunkID}
-	query := `WITH filtered_chunks AS (
-	            SELECT c.chunk_id, c.rel_path, c.doc_type, c.rep_type, c.text, c.index_kind, c.modality, c.media_ref, c.language
-	            FROM chunks c
-	            WHERE c.embedding_status = ? AND c.deleted = 0 AND c.chunk_id > ?
-	          ),
-	          ranked_spans AS (
-	            SELECT s.chunk_id, s.span_kind, s.start, s."end", s.extra_json,
-	                   ROW_NUMBER() OVER (PARTITION BY s.chunk_id ORDER BY s.span_id) AS rn
-	            FROM spans s
-	            JOIN filtered_chunks fc ON fc.chunk_id = s.chunk_id
-	          )
-	          SELECT fc.chunk_id, fc.rel_path, fc.doc_type, fc.rep_type, fc.text, fc.index_kind,
-	                 COALESCE(sp.span_kind, ''), COALESCE(sp.start, 0), COALESCE(sp.end, 0), COALESCE(sp.extra_json, ''),
-	                 COALESCE(d.title, ''), fc.modality, fc.media_ref, fc.language, COALESCE(d.mtime_unix, 0)
-	          FROM filtered_chunks fc
-	          LEFT JOIN ranked_spans sp ON sp.chunk_id = fc.chunk_id AND sp.rn = 1
-	          LEFT JOIN documents d ON d.rel_path = fc.rel_path`
-	if strings.TrimSpace(indexKind) != "" {
-		query += ` WHERE fc.index_kind = ?`
-		args = append(args, indexKind)
-	}
-	args = append(args, limit)
-	query += ` ORDER BY fc.chunk_id LIMIT ?`
+	query, args := embeddedChunkPageQuery(indexKind, limit, afterChunkID)
 
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {

--- a/tests/store/embedded_chunk_page_732_test.go
+++ b/tests/store/embedded_chunk_page_732_test.go
@@ -1,0 +1,472 @@
+package tests
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// #732: ListEmbeddedChunkMetadata applied both of its selective predicates (the
+// index_kind filter and the page LIMIT) OUTSIDE the CTE that gathered candidate
+// chunks, so every page of the startup warm-load materialized every embedded
+// chunk above the keyset cursor and threw all but one page away. A full walk
+// therefore cost O(N^2 / pageSize): measured on a synthetic 100k-chunk corpus,
+// walking both index kinds at pageSize 500 took 47.4s, and the "text" half alone
+// (whose chunk_ids sort first, so each of its pages still dragged the whole
+// "code" half through the CTE) took 37.1s against "code"'s 10.2s for the same
+// row count.
+//
+// These tests pin the shape of the fix, which is what keeps it linear: a page
+// seeks its rows through an index instead of scanning a table, and it reads
+// through the query-only pool rather than the single-connection writer. The
+// timings themselves live in TestEmbeddedChunkWalkPerf_732 (opt-in).
+
+// TestEmbeddedChunkPage_BoundsThePageAtCandidateSelection pins the placement of
+// the two selective predicates, which is the whole fix. It is a statement-shape
+// assertion rather than a plan assertion because the plan alone cannot express
+// it: with the kind filter and the LIMIT in the outer query the planner still
+// picks a perfectly reasonable index for the CTE, it just runs it over the whole
+// corpus and discards the surplus. Placement is what makes a page bounded.
+func TestEmbeddedChunkPage_BoundsThePageAtCandidateSelection(t *testing.T) {
+	for _, kind := range []string{"text", ""} {
+		query, args := store.EmbeddedChunkPageQueryForTest(kind, 500, 42)
+
+		// Everything up to the outer SELECT is the candidate CTE.
+		outer := strings.Index(query, "SELECT fc.chunk_id")
+		if outer < 0 {
+			t.Fatalf("kind=%q: cannot locate the outer SELECT in:\n%s", kind, query)
+		}
+		cte, tail := query[:outer], query[outer:]
+
+		if !strings.Contains(cte, "LIMIT ?") {
+			t.Fatalf("kind=%q: the page LIMIT is not applied at candidate selection; a page will materialize every embedded chunk above the cursor (#732):\n%s", kind, query)
+		}
+		if strings.Contains(tail, "LIMIT") {
+			t.Fatalf("kind=%q: an outer LIMIT is back, so the CTE is unbounded again (#732):\n%s", kind, query)
+		}
+		if kind != "" {
+			if !strings.Contains(cte, "c.index_kind = ?") {
+				t.Fatalf("kind=%q: the index_kind filter is not applied at candidate selection (#732):\n%s", kind, query)
+			}
+			if strings.Contains(tail, "index_kind = ?") {
+				t.Fatalf("kind=%q: the index_kind filter is back in the outer query (#732):\n%s", kind, query)
+			}
+		} else if strings.Contains(query, "index_kind = ?") {
+			// The kind is optional and must stay optional: an empty kind means
+			// "every embedded chunk" and must not bind a placeholder.
+			t.Fatalf("unfiltered page still filters on index_kind:\n%s", query)
+		}
+
+		// Moving a predicate moves its placeholder, so the positional arguments
+		// have to be rebuilt in step with it: one argument per "?", in order.
+		if placeholders := strings.Count(query, "?"); len(args) != placeholders {
+			t.Fatalf("kind=%q: %d args for %d placeholders: %v", kind, len(args), placeholders, args)
+		}
+		if args[0] != "ok" || args[1] != int64(42) {
+			t.Fatalf("kind=%q: leading args are %v, want the embedded status then the cursor", kind, args)
+		}
+		if args[len(args)-1] != 500 {
+			t.Fatalf("kind=%q: last arg is %v, want the limit 500", kind, args[len(args)-1])
+		}
+	}
+}
+
+// TestEmbeddedChunkPage_PlanSeeksRatherThanScans backs the placement assertion
+// with the plan the placement buys: every table the page touches is reached by a
+// seek, so the work per page is proportional to the page, not to the corpus.
+func TestEmbeddedChunkPage_PlanSeeksRatherThanScans(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+	seedEmbeddedPageCorpus(t, st)
+
+	t.Run("kind scoped page seeks on the kind too", func(t *testing.T) {
+		plan := explainPage(ctx, t, st, "text")
+		// index_kind can only appear in a seek term if the filter reached the
+		// candidate scan; with the pre-#732 outer filter it never can.
+		if !planHas(plan, "index_kind=?") {
+			t.Fatalf("kind-scoped page does not seek on index_kind; plan:\n%s", strings.Join(plan, "\n"))
+		}
+		if !planHas(plan, "idx_chunks_embedded_kind_seek") {
+			t.Fatalf("kind-scoped page does not use idx_chunks_embedded_kind_seek; plan:\n%s", strings.Join(plan, "\n"))
+		}
+		assertNoTableScan(t, plan)
+	})
+
+	// The kind argument is optional and must stay that way: the caller that passes
+	// "" gets every embedded chunk, and that page has to seek too (through the
+	// leading embedding_status column of idx_chunks_embedding_status plus the
+	// implicit rowid, since index_kind is unconstrained).
+	t.Run("unfiltered page still seeks", func(t *testing.T) {
+		plan := explainPage(ctx, t, st, "")
+		assertNoTableScan(t, plan)
+	})
+}
+
+// TestEmbeddedChunkPage_ReadsThroughReadPool pins the second half of #732: the
+// listing is SELECT-only, so it belongs on the #631 query-only pool. On the
+// single-connection writer handle this test deadlocks until the held write
+// transaction is rolled back, because there is exactly one writer connection.
+func TestEmbeddedChunkPage_ReadsThroughReadPool(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+	seedEmbeddedPageCorpus(t, st)
+
+	db, _, _, err := st.HandlesForTest(ctx)
+	if err != nil {
+		t.Fatalf("HandlesForTest: %v", err)
+	}
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin write tx: %v", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.ExecContext(ctx, `UPDATE documents SET title = ? WHERE rel_path = ?`, "held", "notes/a.md"); err != nil {
+		t.Fatalf("write inside tx: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		readCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+		defer cancel()
+		_, rerr := st.ListEmbeddedChunkMetadata(readCtx, "text", 10, 0)
+		done <- rerr
+	}()
+
+	select {
+	case rerr := <-done:
+		if rerr != nil {
+			t.Fatalf("listing during an open write tx failed: %v", rerr)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("listing blocked behind an open write transaction; it is still on the writer handle")
+	}
+}
+
+// TestEmbeddedChunkPage_SeekIndexIsCreatedOnAnExistingDatabase pins that a corpus
+// indexed before #732 picks the new index up on the next open rather than needing
+// a reindex: the index ships in the same idempotent schema block as every other
+// one, which runs on every Init. Dropping it stands in for such a database.
+func TestEmbeddedChunkPage_SeekIndexIsCreatedOnAnExistingDatabase(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "legacy.db")
+
+	old := store.NewSQLiteStore(dbPath)
+	if err := old.Init(ctx); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	db, _, _, err := old.HandlesForTest(ctx)
+	if err != nil {
+		t.Fatalf("HandlesForTest: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `DROP INDEX idx_chunks_embedded_kind_seek`); err != nil {
+		t.Fatalf("drop index: %v", err)
+	}
+	if err := old.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	reopened := store.NewSQLiteStore(dbPath)
+	defer func() { _ = reopened.Close() }()
+	if err := reopened.Init(ctx); err != nil {
+		t.Fatalf("reopen a pre-#732 database: %v", err)
+	}
+	plan, err := reopened.ExplainEmbeddedChunkPageForTest(ctx, "text", 500, 0)
+	if err != nil {
+		t.Fatalf("ExplainEmbeddedChunkPageForTest: %v", err)
+	}
+	if !planHas(plan, "idx_chunks_embedded_kind_seek") {
+		t.Fatalf("reopening a pre-#732 database did not create the seek index; plan:\n%s", strings.Join(plan, "\n"))
+	}
+}
+
+// TestEmbeddedChunkPage_LimitCountsMatchingRows pins the half of the contract the
+// pushed-down LIMIT could most easily have broken: the LIMIT counts rows that
+// MATCH the kind, not rows examined before the kind filter. The seeded corpus
+// interleaves kinds by chunk_id, so a 2-row "code" page from the start of the
+// walk must still return two code chunks.
+func TestEmbeddedChunkPage_LimitCountsMatchingRows(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+	seed := seedEmbeddedPageCorpus(t, st)
+
+	page, err := st.ListEmbeddedChunkMetadata(ctx, "code", 2, 0)
+	if err != nil {
+		t.Fatalf("ListEmbeddedChunkMetadata(code): %v", err)
+	}
+	if got := chunkIDs(page); len(got) != 2 || got[0] != seed.code[0] || got[1] != seed.code[1] {
+		t.Fatalf("code page = %v, want the first two code chunks %v", got, seed.code[:2])
+	}
+	for _, task := range page {
+		if task.IndexKind != "code" {
+			t.Fatalf("chunk %d has index_kind %q on a code page", task.Metadata.ChunkID, task.IndexKind)
+		}
+	}
+}
+
+// TestEmbeddedChunkPage_WalkReturnsEveryRowOnce pins that a full keyset walk
+// still yields exactly the embedded chunks of the requested kind, once each, in
+// ascending chunk_id order and independent of page size. Pending, failed and
+// soft-deleted chunks stay out; an empty kind means every kind.
+func TestEmbeddedChunkPage_WalkReturnsEveryRowOnce(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+	seed := seedEmbeddedPageCorpus(t, st)
+
+	for _, pageSize := range []int{1, 2, 100} {
+		if got := walkKind(ctx, t, st, "text", pageSize); !sameIDs(got, seed.text) {
+			t.Fatalf("text walk at pageSize %d = %v, want %v", pageSize, got, seed.text)
+		}
+		if got := walkKind(ctx, t, st, "code", pageSize); !sameIDs(got, seed.code) {
+			t.Fatalf("code walk at pageSize %d = %v, want %v", pageSize, got, seed.code)
+		}
+		want := mergeSorted(seed.text, seed.code)
+		if got := walkKind(ctx, t, st, "", pageSize); !sameIDs(got, want) {
+			t.Fatalf("unfiltered walk at pageSize %d = %v, want %v", pageSize, got, want)
+		}
+	}
+}
+
+// TestEmbeddedChunkPage_RowPayloadUnchanged pins the per-row payload across the
+// join rewrite: the joined document title/mtime, the FIRST span of a multi-span
+// chunk (the lowest span_id, which is the row the previous ROW_NUMBER() window
+// picked), and a span-less chunk still being returned.
+func TestEmbeddedChunkPage_RowPayloadUnchanged(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+	seed := seedEmbeddedPageCorpus(t, st)
+
+	all, err := st.ListEmbeddedChunkMetadata(ctx, "", 100, 0)
+	if err != nil {
+		t.Fatalf("ListEmbeddedChunkMetadata(all): %v", err)
+	}
+	byID := map[uint64]model.ChunkTask{}
+	for _, task := range all {
+		byID[task.Metadata.ChunkID] = task
+	}
+	multi, ok := byID[uint64(seed.multiSpan)]
+	if !ok {
+		t.Fatalf("multi-span chunk %d missing from the listing", seed.multiSpan)
+	}
+	if multi.Metadata.Span.StartLine != 10 || multi.Metadata.Span.EndLine != 11 {
+		t.Fatalf("multi-span chunk carries span %+v, want the first span (lines 10-11)", multi.Metadata.Span)
+	}
+	if multi.Metadata.Title != "Notes A" {
+		t.Fatalf("title = %q, want %q", multi.Metadata.Title, "Notes A")
+	}
+	if multi.Metadata.MTimeUnix != seedMTime {
+		t.Fatalf("mtime = %d, want %d", multi.Metadata.MTimeUnix, seedMTime)
+	}
+
+	// A chunk with no spans at all must still be returned, with the zero span the
+	// COALESCE defaults produce.
+	none, ok := byID[uint64(seed.noSpan)]
+	if !ok {
+		t.Fatalf("span-less chunk %d missing from the listing", seed.noSpan)
+	}
+	if none.Metadata.Span.StartLine != 0 || none.Metadata.Span.EndLine != 0 {
+		t.Fatalf("span-less chunk carries span %+v, want an empty lines span", none.Metadata.Span)
+	}
+}
+
+const seedMTime = 1700000000
+
+// embeddedPageSeed records the chunk ids the corpus below was built from.
+type embeddedPageSeed struct {
+	text      []int64
+	code      []int64
+	multiSpan int64
+	noSpan    int64
+}
+
+// seedEmbeddedPageCorpus builds a small corpus whose kinds INTERLEAVE by
+// chunk_id (text, code, text, code, ...) plus the rows a page must exclude: a
+// pending chunk, a failed chunk and a soft-deleted one.
+func seedEmbeddedPageCorpus(t *testing.T, st *store.SQLiteStore) embeddedPageSeed {
+	t.Helper()
+	ctx := context.Background()
+	if err := st.UpsertDocument(ctx, model.Document{
+		RelPath: "notes/a.md", DocType: "md", SourceType: "local", Status: "ok",
+		Title: "Notes A", MTimeUnix: seedMTime,
+	}); err != nil {
+		t.Fatalf("UpsertDocument: %v", err)
+	}
+	doc, err := st.GetDocumentByPath(ctx, "notes/a.md")
+	if err != nil {
+		t.Fatalf("GetDocumentByPath: %v", err)
+	}
+
+	var seed embeddedPageSeed
+	err = st.WithTx(ctx, func(tx model.RepresentationStore) error {
+		repID, rerr := tx.UpsertRepresentation(ctx, model.Representation{
+			DocID: doc.DocID, RepType: "raw_text", RepHash: "h1",
+		})
+		if rerr != nil {
+			return rerr
+		}
+		insert := func(ordinal int, kind, status string, deleted bool, spans []model.Span) (int64, error) {
+			return tx.InsertChunkWithSpans(ctx, model.Chunk{
+				RepID: repID, Ordinal: ordinal, Text: "chunk " + kind, TextHash: "h",
+				IndexKind: kind, EmbeddingStatus: status, Deleted: deleted,
+			}, spans)
+		}
+		ordinal := 0
+		for i := 0; i < 3; i++ {
+			id, cerr := insert(ordinal, "text", "ok", false, []model.Span{{Kind: "lines", StartLine: 1, EndLine: 2}})
+			if cerr != nil {
+				return cerr
+			}
+			seed.text = append(seed.text, id)
+			ordinal++
+			id, cerr = insert(ordinal, "code", "ok", false, []model.Span{{Kind: "lines", StartLine: 3, EndLine: 4}})
+			if cerr != nil {
+				return cerr
+			}
+			seed.code = append(seed.code, id)
+			ordinal++
+		}
+		// Rows a page must never return.
+		if _, cerr := insert(ordinal, "text", "pending", false, nil); cerr != nil {
+			return cerr
+		}
+		ordinal++
+		if _, cerr := insert(ordinal, "text", "failed", false, nil); cerr != nil {
+			return cerr
+		}
+		ordinal++
+		if _, cerr := insert(ordinal, "text", "ok", true, nil); cerr != nil {
+			return cerr
+		}
+		ordinal++
+		// A multi-span chunk (the page must carry its FIRST span) and a span-less one.
+		id, cerr := insert(ordinal, "text", "ok", false, []model.Span{
+			{Kind: "lines", StartLine: 10, EndLine: 11},
+			{Kind: "lines", StartLine: 20, EndLine: 21},
+		})
+		if cerr != nil {
+			return cerr
+		}
+		seed.multiSpan = id
+		seed.text = append(seed.text, id)
+		ordinal++
+		id, cerr = insert(ordinal, "text", "ok", false, nil)
+		if cerr != nil {
+			return cerr
+		}
+		seed.noSpan = id
+		seed.text = append(seed.text, id)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("seed corpus: %v", err)
+	}
+	return seed
+}
+
+// explainPage returns the query plan for one page, failing the test on error.
+func explainPage(ctx context.Context, t *testing.T, st *store.SQLiteStore, kind string) []string {
+	t.Helper()
+	plan, err := st.ExplainEmbeddedChunkPageForTest(ctx, kind, 500, 0)
+	if err != nil {
+		t.Fatalf("ExplainEmbeddedChunkPageForTest(kind=%q): %v", kind, err)
+	}
+	if len(plan) == 0 {
+		t.Fatalf("empty query plan for kind=%q", kind)
+	}
+	return plan
+}
+
+func planHas(plan []string, needle string) bool {
+	for _, line := range plan {
+		if strings.Contains(line, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+// assertNoTableScan fails if the plan scans any of the three base tables the page
+// touches. Scanning the materialized page itself ("SCAN fc") is fine: it holds at
+// most one page of rows.
+func assertNoTableScan(t *testing.T, plan []string) {
+	t.Helper()
+	scanned := map[string]string{
+		"SCAN c":         "chunks",
+		"SCAN chunks":    "chunks",
+		"SCAN s":         "spans",
+		"SCAN sp":        "spans",
+		"SCAN spans":     "spans",
+		"SCAN d":         "documents",
+		"SCAN documents": "documents",
+	}
+	for _, line := range plan {
+		for prefix, table := range scanned {
+			if strings.HasPrefix(line, prefix+" ") || line == prefix {
+				t.Fatalf("page scans the whole %s table (%q); a page must seek. Full plan:\n%s",
+					table, line, strings.Join(plan, "\n"))
+			}
+		}
+	}
+}
+
+// walkKind pages through one kind with the caller's keyset protocol and returns
+// the chunk ids in the order they were read.
+func walkKind(ctx context.Context, t *testing.T, st *store.SQLiteStore, kind string, pageSize int) []int64 {
+	t.Helper()
+	var (
+		out          []int64
+		afterChunkID int64
+	)
+	for {
+		page, err := st.ListEmbeddedChunkMetadata(ctx, kind, pageSize, afterChunkID)
+		if err != nil {
+			t.Fatalf("ListEmbeddedChunkMetadata(kind=%q, after=%d): %v", kind, afterChunkID, err)
+		}
+		out = append(out, chunkIDs(page)...)
+		if len(page) < pageSize {
+			return out
+		}
+		afterChunkID = int64(page[len(page)-1].Metadata.ChunkID)
+	}
+}
+
+func chunkIDs(tasks []model.ChunkTask) []int64 {
+	out := make([]int64, 0, len(tasks))
+	for _, task := range tasks {
+		out = append(out, int64(task.Metadata.ChunkID))
+	}
+	return out
+}
+
+func sameIDs(got, want []int64) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// mergeSorted merges two ascending id lists into one ascending list.
+func mergeSorted(a, b []int64) []int64 {
+	out := make([]int64, 0, len(a)+len(b))
+	i, j := 0, 0
+	for i < len(a) && j < len(b) {
+		if a[i] <= b[j] {
+			out = append(out, a[i])
+			i++
+			continue
+		}
+		out = append(out, b[j])
+		j++
+	}
+	out = append(out, a[i:]...)
+	return append(out, b[j:]...)
+}

--- a/tests/store/embedded_chunk_walk_perf_732_test.go
+++ b/tests/store/embedded_chunk_walk_perf_732_test.go
@@ -1,0 +1,158 @@
+package tests
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// TestEmbeddedChunkWalkPerf_732 measures the cost of a full keyset walk of
+// ListEmbeddedChunkMetadata over a synthetic corpus, per index kind and per page
+// size. It is a measurement harness, not an assertion: it is skipped unless
+// DIR2MCP_PERF=1 so `go test ./...` stays fast, and it exists so the #732 fix can
+// be defended with numbers instead of a plan reading.
+//
+// Corpus shape mirrors the #731 measurement: half the chunks are "text" with the
+// LOW chunk_ids and half are "code" with the high ones, which is what makes the
+// pre-fix query shape visibly quadratic (every text page still had to drag all
+// 50k code rows through the CTE).
+//
+//	DIR2MCP_PERF=1 go test ./tests/store -run EmbeddedChunkWalkPerf -v
+//	DIR2MCP_PERF=1 DIR2MCP_PERF_CHUNKS=200000 go test ./tests/store -run EmbeddedChunkWalkPerf -v
+func TestEmbeddedChunkWalkPerf_732(t *testing.T) {
+	if os.Getenv("DIR2MCP_PERF") != "1" {
+		t.Skip("set DIR2MCP_PERF=1 to run the #732 walk measurement")
+	}
+	total := 100000
+	if raw := os.Getenv("DIR2MCP_PERF_CHUNKS"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n <= 0 {
+			t.Fatalf("DIR2MCP_PERF_CHUNKS=%q: want a positive integer", raw)
+		}
+		total = n
+	}
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "perf.sqlite")
+	st := store.NewSQLiteStore(dbPath)
+	defer func() { _ = st.Close() }()
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	seedSyntheticEmbeddedCorpus(t, dbPath, total)
+
+	for _, pageSize := range []int{500, 5000} {
+		for _, kind := range []string{"text", "code"} {
+			start := time.Now()
+			rows, pages := walkEmbedded(ctx, t, st, kind, pageSize)
+			t.Logf("page=%-5d kind=%-4s rows=%-7d pages=%-4d elapsed=%v", pageSize, kind, rows, pages, time.Since(start))
+		}
+		start := time.Now()
+		rows, pages := walkEmbedded(ctx, t, st, "", pageSize)
+		t.Logf("page=%-5d kind=%-4s rows=%-7d pages=%-4d elapsed=%v", pageSize, "all", rows, pages, time.Since(start))
+	}
+}
+
+// walkEmbedded runs one full keyset walk and returns the rows and pages read.
+func walkEmbedded(ctx context.Context, t *testing.T, st *store.SQLiteStore, kind string, pageSize int) (rows, pages int) {
+	t.Helper()
+	var afterChunkID int64
+	for {
+		page, err := st.ListEmbeddedChunkMetadata(ctx, kind, pageSize, afterChunkID)
+		if err != nil {
+			t.Fatalf("ListEmbeddedChunkMetadata(kind=%q, after=%d): %v", kind, afterChunkID, err)
+		}
+		rows += len(page)
+		pages++
+		if len(page) < pageSize {
+			return rows, pages
+		}
+		afterChunkID = int64(page[len(page)-1].Metadata.ChunkID)
+	}
+}
+
+// seedSyntheticEmbeddedCorpus bulk-inserts total embedded chunks (plus their
+// documents, representations and one span each) straight into the schema the
+// store just created. It writes on its own connection because the goal is a large
+// corpus in seconds, not exercising the store's write path.
+func seedSyntheticEmbeddedCorpus(t *testing.T, dbPath string, total int) {
+	t.Helper()
+	db, err := sql.Open("sqlite", "file:"+dbPath+"?_pragma=journal_mode(WAL)&_pragma=synchronous(OFF)")
+	if err != nil {
+		t.Fatalf("open seed handle: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	const chunksPerDoc = 100
+	body := strings.Repeat("lorem ipsum dolor sit amet ", 15)
+	start := time.Now()
+
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("begin seed tx: %v", err)
+	}
+	docStmt, err := tx.Prepare(`INSERT INTO documents (rel_path, doc_type, source_type, title, mtime_unix, status, deleted)
+	                            VALUES (?, 'md', 'local', ?, 1700000000, 'ok', 0)`)
+	if err != nil {
+		t.Fatalf("prepare document insert: %v", err)
+	}
+	repStmt, err := tx.Prepare(`INSERT INTO representations (rep_id, doc_id, rep_type, rep_hash, created_unix, deleted)
+	                            VALUES (?, ?, 'raw_text', 'h', 1700000000, 0)`)
+	if err != nil {
+		t.Fatalf("prepare representation insert: %v", err)
+	}
+	chunkStmt, err := tx.Prepare(`INSERT INTO chunks (chunk_id, rep_id, ordinal, rel_path, doc_type, rep_type, text, index_kind, modality, language, embedding_status, deleted)
+	                              VALUES (?, ?, ?, ?, 'md', 'raw_text', ?, ?, 'text', 'en', 'ok', 0)`)
+	if err != nil {
+		t.Fatalf("prepare chunk insert: %v", err)
+	}
+	spanStmt, err := tx.Prepare(`INSERT INTO spans (chunk_id, span_kind, start, end, extra_json) VALUES (?, 'lines', ?, ?, '')`)
+	if err != nil {
+		t.Fatalf("prepare span insert: %v", err)
+	}
+
+	half := total / 2
+	docID := 0
+	for i := 1; i <= total; i++ {
+		// chunk_ids 1..half are "text", the rest "code": the kind split follows the
+		// key order, which is the shape the pre-fix CTE punished.
+		kind := "text"
+		if i > half {
+			kind = "code"
+		}
+		if (i-1)%chunksPerDoc == 0 {
+			docID++
+			relPath := fmt.Sprintf("corpus/%s/doc-%05d.md", kind, docID)
+			if _, err := docStmt.Exec(relPath, "Doc "+strconv.Itoa(docID)); err != nil {
+				t.Fatalf("insert document %d: %v", docID, err)
+			}
+			if _, err := repStmt.Exec(docID, docID); err != nil {
+				t.Fatalf("insert representation %d: %v", docID, err)
+			}
+		}
+		relPath := fmt.Sprintf("corpus/%s/doc-%05d.md", kind, docID)
+		if _, err := chunkStmt.Exec(i, docID, (i-1)%chunksPerDoc, relPath, body, kind); err != nil {
+			t.Fatalf("insert chunk %d: %v", i, err)
+		}
+		if _, err := spanStmt.Exec(i, i, i+5); err != nil {
+			t.Fatalf("insert span %d: %v", i, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit seed tx: %v", err)
+	}
+	// Deliberately no ANALYZE: production never runs it, so sqlite_stat1 is absent
+	// there and the planner works from its default heuristics. Collecting stats
+	// here would measure a planner the daemon never has.
+	t.Logf("seeded %d embedded chunks in %v", total, time.Since(start))
+}


### PR DESCRIPTION
Fixes #732.

`ListEmbeddedChunkMetadata` applied both of its selective predicates (the `index_kind` filter and the page `LIMIT`) in the outer query, so every page of the startup warm-load materialized every embedded chunk above the keyset cursor and discarded all but one page. A full walk cost `O(N^2 / pageSize)`.

## What changed

1. **Both predicates moved into `filtered_chunks`**, with an explicit `ORDER BY c.chunk_id` so the `LIMIT` takes the first page after the cursor. The optional-kind behaviour is preserved exactly: an empty kind binds no placeholder and returns every embedded chunk.
2. **New index** `idx_chunks_embedded_kind_seek ON chunks(embedding_status, deleted, index_kind, chunk_id)`, created in the same idempotent `CREATE INDEX IF NOT EXISTS` block as every other index, so an existing corpus picks it up on the next open with no reindex (pinned by a test that drops it and reopens).
3. **The `ranked_spans` window is gone**, replaced by `LEFT JOIN spans sp ON sp.span_id = (SELECT MIN(s.span_id) ...)`. Same row (span_id is the primary key, so the lowest one is the window's `rn = 1`), but see the plan note below.
4. **Reads through the #631 query-only pool** instead of the single-connection writer.

## Before / after: EXPLAIN QUERY PLAN

Captured on a 20k-chunk synthetic corpus with no `ANALYZE` (production never runs it, so `sqlite_stat1` is absent there too), kind-scoped page:

**Before (main):**

```
MATERIALIZE ranked_spans
  CO-ROUTINE (subquery-4)                                             <- filtered_chunks, unbounded
    SEARCH c USING INDEX idx_chunks_embedding_status (embedding_status=? AND rowid>?)
  SEARCH s USING INDEX idx_spans_chunk_id_span_id (chunk_id=?)
  USE TEMP B-TREE FOR ORDER BY
SCAN (subquery-4)                                                     <- filtered_chunks again, unbounded
  SEARCH c USING INDEX idx_chunks_index_kind (index_kind=? AND rowid>?)
BLOOM FILTER ON sp (chunk_id=? AND rn=?)
SEARCH sp USING AUTOMATIC PARTIAL COVERING INDEX (chunk_id=? AND rn=?) LEFT-JOIN
SEARCH d USING INDEX sqlite_autoindex_documents_1 (rel_path=?) LEFT-JOIN
```

**After:**

```
CO-ROUTINE filtered_chunks
  SEARCH c USING INDEX idx_chunks_embedded_kind_seek (embedding_status=? AND deleted=? AND index_kind=? AND chunk_id>?)
SCAN fc                                                               <- one page, at most `limit` rows
SEARCH sp USING INTEGER PRIMARY KEY (rowid=?) LEFT-JOIN
  CORRELATED SCALAR SUBQUERY 2
    SEARCH s USING COVERING INDEX idx_spans_chunk_id_span_id (chunk_id=?)
SEARCH d USING INDEX sqlite_autoindex_documents_1 (rel_path=?) LEFT-JOIN
USE TEMP B-TREE FOR ORDER BY                                          <- sorts one page
```

Unfiltered (`kind == ""`) pages seek too, via `SEARCH c USING INDEX idx_chunks_embedding_status (embedding_status=? AND rowid>?)`.

## Measurements

Synthetic corpus built the way #731 did: 100k embedded chunks, 50k `text` with the low `chunk_id`s and 50k `code` with the high ones, one span and one joined document per chunk. Harness is `TestEmbeddedChunkWalkPerf_732` (opt-in, `DIR2MCP_PERF=1`), so anyone can re-run it.

Full keyset walk, wall clock:

| walk | page 500 before | page 500 after | page 5000 before | page 5000 after |
| --- | --- | --- | --- | --- |
| `text` (50k rows) | 37.13s | **0.67s** | 4.47s | **0.71s** |
| `code` (50k rows) | 10.25s | **0.67s** | 1.87s | **0.66s** |
| both kinds (100k rows) | 47.38s | **1.32s** | 6.34s | **1.39s** |

Two things the numbers say beyond the headline:

- **Page size stopped mattering.** 500 and 5000 now cost the same (1.32s vs 1.39s for the full preload), which is the predicted consequence of a bounded page. #731's page-size bump is no longer load-bearing (left alone here, `internal/cli` is out of scope).
- **The per-kind asymmetry is gone.** `text` cost 3.6x `code` before for identical row counts; both are now 0.67s.

Linearity check at 200k chunks: 2.68s at page 500, 2.64s at page 5000, i.e. 2x the corpus for 2x the time. The old shape would have predicted roughly 190s.

Cost of the new index: bulk-inserting the 100k-chunk corpus in one transaction went from ~12.2s to ~13.5s, i.e. a few percent of write overhead on the ingest path, single samples on the same machine.

## Two things that contradict the issue's diagnosis

- **The `index_kind` filter was not the expensive half.** The before-plan shows SQLite pushing the outer `WHERE fc.index_kind = ?` down into the outer reference of the CTE by itself (`SEARCH c USING INDEX idx_chunks_index_kind (index_kind=? AND rowid>?)`). What it can never push down is the `LIMIT`, and the `ranked_spans` branch never got the kind term at all. The `LIMIT` placement is the quadratic; moving the kind filter mostly buys the covering seek.
- **Pushing the LIMIT down is not sufficient on its own.** With the `LIMIT` inside the CTE but the `ROW_NUMBER` window left in place, SQLite flips the spans join around and drives it off a full scan of `spans` on every page (`SCAN s USING INDEX idx_spans_chunk_id_span_id`, with an automatic index built on the materialized page), so the per-page work stays O(N) from the other side of the join. That is why the window had to go. It cost about a full extra second per walk before it showed up in the plan.

## Tests

`tests/store/embedded_chunk_page_732_test.go`:

- `BoundsThePageAtCandidateSelection` asserts predicate placement on the built statement. Verified to fail against pre-fix code. A plan assertion alone cannot express this: with the predicates outside, the planner still picks a sensible index for the CTE, it just runs it over the whole corpus.
- `PlanSeeksRatherThanScans` asserts the page seeks on `index_kind`, uses the new index, and scans none of `chunks` / `spans` / `documents`. This is what would have caught the spans-side regression above.
- `ReadsThroughReadPool` holds a write transaction open on the writer connection and requires the listing to complete anyway. Verified to fail (deadline exceeded) against pre-fix code.
- `SeekIndexIsCreatedOnAnExistingDatabase` drops the index, reopens, and requires the plan to use it again.
- `LimitCountsMatchingRows`, `WalkReturnsEveryRowOnce`, `RowPayloadUnchanged` pin the unchanged contract: the LIMIT counts kind-matching rows (not rows examined), a walk returns each embedded chunk once in `chunk_id` order at any page size with pending / failed / soft-deleted excluded, and each row still carries its first span, the joined title and the mtime, including the span-less case.

`tests/store/embedded_chunk_walk_perf_732_test.go` is the measurement harness (skipped unless `DIR2MCP_PERF=1`).

## Gates

`gofmt -l cmd internal tests` empty; `go vet ./...`; `gocyclo -over 15 cmd internal tests` empty; `go test ./...`; `go test -race ./internal/store/... ./tests/store/...`. Submodule pin untouched.

## Not in this PR

`NextPending` has the same shape (kind filter and LIMIT outside the CTE, plus the same `ranked_spans` window) and runs on every embed cycle. It has no keyset cursor, so it re-materializes the whole pending set per call rather than being quadratic across a walk, but it is the same class of defect and worth its own issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved pagination when browsing embedded chunk metadata, especially for filtered and large result sets.
  * Reduced unnecessary database scanning to support faster, more efficient retrieval.

* **Bug Fixes**
  * Improved pagination consistency across pages and page sizes.
  * Preserved associated document and span details in paginated results.
  * Improved reliability when reading during concurrent database activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->