### PR TITLE
refactor(annotator): overlay-text reader + baseball interpreter (#741 milestone 2)

### DIFF
--- a/annotator/README.md
+++ b/annotator/README.md
@@ -36,18 +36,18 @@ unavailable.
 `recognizers/overlay.py` is the reusable half of the scorebug recognizer:
 find the band of the frame that holds burned-in text, defeat light-on-dark
 with a second hard-thresholded pass, OCR both, and hand back
-`(timestamp, region, texts)`. It knows nothing about sport, roster or
-language. `ScorebugRecognizer` is one consumer of it (baseball fields against
-a roster); a news archive is another (headline banners, tickers, a burned-in
-clock badge as a wall-clock anchor), and gets there with different `regions=`
-and a different interpretation rather than different reading code.
+`(timestamp, region, texts)`. It knows nothing about sport or roster.
+`ScorebugRecognizer` is one consumer of it (baseball fields against a roster);
+a news archive is another (headline banners, tickers, a burned-in clock badge
+as a wall-clock anchor), and gets there with different `regions=` and a
+different interpretation rather than different reading code.
 
 The interpretation is passed in, and it also tells the reader how much
 evidence each band held: that hit count is what the band search locks onto,
 and it has to be the caller's judgement, because "the OCR returned something"
 is true of a crop of crowd texture too.
 
-OCR language is a parameter, never a constant:
+OCR language is configurable, never a constant in the code:
 
 ```bash
 DIRSTRAL_ANNOTATOR_OCR_LANG=rus dirstral-annotate serve …   # or lang="rus"

--- a/annotator/README.md
+++ b/annotator/README.md
@@ -31,6 +31,31 @@ Core (play-by-play, fusion, serving, eval) is **stdlib-only**; vision
 recognizers pull their stacks via extras and are skipped gracefully when
 unavailable.
 
+### The overlay text reader
+
+`recognizers/overlay.py` is the reusable half of the scorebug recognizer:
+find the band of the frame that holds burned-in text, defeat light-on-dark
+with a second hard-thresholded pass, OCR both, and hand back
+`(timestamp, region, texts)`. It knows nothing about sport, roster or
+language. `ScorebugRecognizer` is one consumer of it (baseball fields against
+a roster); a news archive is another (headline banners, tickers, a burned-in
+clock badge as a wall-clock anchor), and gets there with different `regions=`
+and a different interpretation rather than different reading code.
+
+The interpretation is passed in, and it also tells the reader how much
+evidence each band held: that hit count is what the band search locks onto,
+and it has to be the caller's judgement, because "the OCR returned something"
+is true of a crop of crowd texture too.
+
+OCR language is a parameter, never a constant:
+
+```bash
+DIRSTRAL_ANNOTATOR_OCR_LANG=rus dirstral-annotate serve …   # or lang="rus"
+```
+
+Non-Latin scripts need the matching tesseract traineddata installed
+(`brew install tesseract-lang`, `apt install tesseract-ocr-rus`).
+
 ## Run the backend
 
 ```bash

--- a/annotator/dirstral_annotator/recognizers/base.py
+++ b/annotator/dirstral_annotator/recognizers/base.py
@@ -36,6 +36,12 @@ class RecognizerUnavailable(RuntimeError):
     the cascade still runs."""
 
 
+#: A run of frames may drop a detection for a beat (OCR flicker, a replay that
+#: hides the overlay, a face turning away); allow this many seconds of gap
+#: before closing the run.
+RUN_GAP_S = 3.0
+
+
 #: Extractions already performed this process, keyed by
 #: (resolved path, mtime, size, fps). Every recognizer in the cascade samples
 #: the SAME media at the SAME fps, and each used to trigger its own full
@@ -246,3 +252,42 @@ def iter_frames(
                 _FRAME_USERS.pop(key, None)
             _evict_locked()
             _FRAME_LOCK.notify_all()
+
+
+def collapse_sightings(
+    sightings: list[tuple[float, str, float]],
+    source: str,
+    event: str,
+    frame_gap: float,
+) -> list[Cue]:
+    """Collapse per-frame (t, entity_id, confidence) hits into per-run cues.
+
+    Shared by every frame-sampling recognizer (scorebug, jersey, face).
+    A run of consecutive sightings of one entity becomes one cue spanning
+    first..last sighting (extended by one frame interval so a single-frame
+    sighting still has nonzero duration); confidence is the run's max.
+    """
+    runs: dict[str, list[tuple[float, float, float, float]]] = {}
+    for t, pid, conf in sorted(sightings):
+        pruns = runs.setdefault(pid, [])
+        if pruns and t - pruns[-1][1] <= frame_gap + RUN_GAP_S:
+            s, _, c, first = pruns[-1]
+            pruns[-1] = (s, t, max(c, conf), first)
+        else:
+            pruns.append((t, t, conf, t))
+
+    cues = []
+    for pid, pruns in runs.items():
+        for start, end, conf, _ in pruns:
+            cues.append(
+                Cue(
+                    source=source,
+                    start_s=start,
+                    end_s=end + frame_gap,
+                    event=event,
+                    entity_ids=(pid,),
+                    confidence=round(conf, 4),
+                )
+            )
+    cues.sort(key=lambda c: (c.start_s, c.entity_ids))
+    return cues

--- a/annotator/dirstral_annotator/recognizers/faces.py
+++ b/annotator/dirstral_annotator/recognizers/faces.py
@@ -22,8 +22,7 @@ from pathlib import Path
 
 from ..model import Cue
 from ..roster import Roster
-from .base import RecognizerUnavailable, iter_frames
-from .scorebug import collapse_sightings
+from .base import RecognizerUnavailable, collapse_sightings, iter_frames
 
 Embedding = list[float]
 # (frame jpeg) -> [(embedding, (x, y, w, h))]

--- a/annotator/dirstral_annotator/recognizers/jersey.py
+++ b/annotator/dirstral_annotator/recognizers/jersey.py
@@ -31,11 +31,12 @@ from .base import RecognizerUnavailable, collapse_sightings, iter_frames
 from .overlay import (
     OcrFn,
     Workspaces,
-    _new_executor,
+    default_lang,
     default_ocr,
     default_workers,
     lookahead_for,
     map_in_order,
+    new_executor,
 )
 
 Bbox = tuple[int, int, int, int]  # x, y, w, h
@@ -82,6 +83,10 @@ class JerseyRecognizer:
         self.roster = roster
         self.detector = detector if detector is not None else default_detector()
         self.ocr = ocr if ocr is not None else default_ocr(lang=lang)
+        # The language the default adapter was built with, resolved. Records
+        # what this recognizer will read in; says nothing about an injected
+        # OCR callable, which answers for its own language.
+        self.lang = default_lang() if lang is None else lang
         self.fps = fps
         self.workers = default_workers() if workers is None else max(1, int(workers))
         # An injected detector is used as given: the caller supplied the
@@ -211,7 +216,7 @@ class _PooledReader:
         self._detectors = detectors
         self._ocr = ocr
         self._workspaces = Workspaces(work)
-        self._executor = _new_executor(workers, name)
+        self._executor = new_executor(workers, name)
 
     def _read_here(self, frame: Path) -> list[str]:
         return read_numbers(

--- a/annotator/dirstral_annotator/recognizers/jersey.py
+++ b/annotator/dirstral_annotator/recognizers/jersey.py
@@ -1,19 +1,19 @@
 """Jersey-number recognizer: OCR digits on tracked player crops.
 
 Person detection is injected as `(jpeg_path) -> [bbox]` (default adapter:
-ultralytics YOLO when installed) and reuses the scorebug OCR callable on
-each crop. Numbers resolve to players via the roster; a number nobody on
+ultralytics YOLO when installed) and reuses the overlay reader's OCR callable
+on each crop. Numbers resolve to players via the roster; a number nobody on
 the roster wears is dropped rather than guessed.
 
-Weakest signal in the cascade (low resolution, motion blur — see the
+Weakest signal in the cascade (low resolution, motion blur; see the
 SoccerNet jersey benchmarks), so its confidence ceiling is deliberately
 modest and it exists to corroborate, not to decide.
 
-Frames are read on a worker pool for the same reason the scorebug's are: the
-per-frame detect-crop-OCR is the whole cost, it is a pure function of the
-frame, and a broadcast has thousands of them. Results come back keyed by
-frame so the sighting list is the serial one whatever order the workers
-finish in.
+Frames are read on a worker pool for the same reason the overlay reader's are:
+the per-frame detect-crop-OCR is the whole cost, it is a pure function of the
+frame, and a broadcast has thousands of them. The pool plumbing (worker count,
+per-thread scratch, in-order results) is shared with the overlay reader rather
+than reimplemented here; what is left below is the crop-and-read itself.
 """
 
 from __future__ import annotations
@@ -21,29 +21,28 @@ from __future__ import annotations
 import re
 import tempfile
 import threading
-from collections import deque
 from collections.abc import Callable, Iterable, Iterator
-from concurrent.futures import Executor, Future, ThreadPoolExecutor
 from pathlib import Path
 from typing import Self
 
 from ..model import Cue
 from ..roster import Roster
-from .base import RecognizerUnavailable, iter_frames
-from .scorebug import OcrFn, collapse_sightings, default_ocr, default_workers
+from .base import RecognizerUnavailable, collapse_sightings, iter_frames
+from .overlay import (
+    OcrFn,
+    Workspaces,
+    _new_executor,
+    default_ocr,
+    default_workers,
+    lookahead_for,
+    map_in_order,
+)
 
 Bbox = tuple[int, int, int, int]  # x, y, w, h
 DetectFn = Callable[[Path], list[Bbox]]
 
 NUMBER_RE = re.compile(r"(?<!\d)(\d{1,2})(?!\d)")
 CONFIDENCE_CEILING = 0.6
-
-# Frames dispatched ahead of the loop that consumes them. Same reasoning as
-# the scorebug's window: enough per worker that the pool never drains while
-# the caller folds one frame's numbers into the sighting list, small enough
-# that only a handful of results are held at once.
-LOOKAHEAD_PER_WORKER = 4
-MIN_LOOKAHEAD = 16
 
 
 def default_detector() -> DetectFn:
@@ -78,10 +77,11 @@ class JerseyRecognizer:
         ocr: OcrFn | None = None,
         fps: float = 0.5,
         workers: int | None = None,  # None: default_workers(); 1: serial
+        lang: str | None = None,  # OCR language; None: the shared default
     ):
         self.roster = roster
         self.detector = detector if detector is not None else default_detector()
-        self.ocr = ocr if ocr is not None else default_ocr()
+        self.ocr = ocr if ocr is not None else default_ocr(lang=lang)
         self.fps = fps
         self.workers = default_workers() if workers is None else max(1, int(workers))
         # An injected detector is used as given: the caller supplied the
@@ -110,7 +110,7 @@ class JerseyRecognizer:
         if self.workers <= 1:
             return _SerialReader(self.detector, self.ocr, work)
         detectors = _Detectors(self._new_detector, seed=self.detector)
-        return _PooledReader(detectors, self.ocr, work, self.workers)
+        return _PooledReader(detectors, self.ocr, work, self.workers, self.name)
 
 
 def read_numbers(detect: DetectFn, ocr: OcrFn, frame: Path, work: Path) -> list[str]:
@@ -159,33 +159,6 @@ class _Detectors:
         return detect
 
 
-class _Workspaces:
-    """A scratch directory per worker thread.
-
-    Crops are written under a fixed name and overwritten per detection, so
-    two threads sharing one directory would swap crops between the write and
-    the OCR of it. A directory per thread keeps the scratch bounded (one file
-    per worker for a whole run) and keeps the crops out of the frame cache
-    directory, which the other recognizers in the cascade are iterating.
-    """
-
-    def __init__(self, root: Path):
-        self._root = root
-        self._local = threading.local()
-        self._lock = threading.Lock()
-        self._issued = 0
-
-    def current(self) -> Path:
-        work = getattr(self._local, "work", None)
-        if work is None:
-            with self._lock:
-                self._issued += 1
-                work = self._root / f"worker-{self._issued}"
-            work.mkdir(parents=True, exist_ok=True)
-            self._local.work = work
-        return work
-
-
 class _SerialReader:
     """Read one frame at a time on the calling thread: the reference path."""
 
@@ -212,11 +185,11 @@ class _SerialReader:
 class _PooledReader:
     """Read frames on a worker pool, yielding them back in frame order.
 
-    Nothing about this recognizer is sequential (unlike the scorebug's region
-    search), so ordering needs no reconciliation: frames are dispatched in
-    order, held in a bounded window, and awaited in that same order. A worker
-    finishing early simply waits its turn, so the sighting list, and with it
-    every cue, is the serial one.
+    Nothing about this recognizer is sequential (unlike the overlay reader's
+    region search), so ordering needs no reconciliation and `map_in_order` is
+    the whole of it: frames go in in order, are held in a bounded window, and
+    are awaited in that same order, so a worker finishing early simply waits
+    its turn and the sighting list, and with it every cue, is the serial one.
 
     The pool is threads, not processes, because the measurement says the GIL
     is not the constraint here: pytesseract shells out to the `tesseract`
@@ -226,12 +199,19 @@ class _PooledReader:
     loaded model) could not satisfy.
     """
 
-    def __init__(self, detectors: _Detectors, ocr: OcrFn, work: Path, workers: int):
+    def __init__(
+        self,
+        detectors: _Detectors,
+        ocr: OcrFn,
+        work: Path,
+        workers: int,
+        name: str = "jersey",
+    ):
         self.workers = workers
         self._detectors = detectors
         self._ocr = ocr
-        self._workspaces = _Workspaces(work)
-        self._executor = _new_executor(workers)
+        self._workspaces = Workspaces(work)
+        self._executor = _new_executor(workers, name)
 
     def _read_here(self, frame: Path) -> list[str]:
         return read_numbers(
@@ -241,33 +221,15 @@ class _PooledReader:
     def read(
         self, frames: Iterable[tuple[float, Path]]
     ) -> Iterator[tuple[float, list[str]]]:
-        lookahead = max(MIN_LOOKAHEAD, LOOKAHEAD_PER_WORKER * self.workers)
-        window: deque[tuple[float, Future[list[str]]]] = deque()
-        source = iter(frames)
-
-        def top_up() -> None:
-            while len(window) < lookahead:
-                item = next(source, None)
-                if item is None:
-                    return
-                t, frame = item
-                window.append((t, self._executor.submit(self._read_here, frame)))
-
-        top_up()
-        while window:
-            t, pending = window.popleft()
-            yield t, pending.result()
-            top_up()
+        return map_in_order(
+            self._executor, self._read_here, frames, lookahead_for(self.workers)
+        )
 
     def __enter__(self) -> Self:
         return self
 
     def __exit__(self, *exc: object) -> None:
         self._executor.shutdown(wait=True, cancel_futures=True)
-
-
-def _new_executor(workers: int) -> Executor:
-    return ThreadPoolExecutor(max_workers=workers, thread_name_prefix="jersey")
 
 
 def _crop(frame: Path, bbox: Bbox, work: Path) -> Path:

--- a/annotator/dirstral_annotator/recognizers/overlay.py
+++ b/annotator/dirstral_annotator/recognizers/overlay.py
@@ -1,0 +1,605 @@
+"""Overlay-text reader: pull burned-in text off sampled frames, time-anchored.
+
+Most archive footage carries no structured feed, so the only machine-readable
+description of what is on screen is what the broadcaster burned into the
+picture: a sports scorebug, a news headline banner, a scrolling ticker, a
+segment title, a clock badge. Reading those reliably is one capability, and it
+is the hard half. What the strings *mean* is not: a sports bug names players
+against a roster, a news banner names a topic, and no single module can know
+which. This module does the reading and stops there.
+
+Reading well takes three things, and the naive "OCR the whole frame" loop gets
+none of them:
+
+1. *Where.* An overlay occupies a few percent of the frame. Whole-frame OCR has
+   to segment everything else before it reaches the 30-pixel-tall text, and
+   usually never does. A handful of candidate bands are OCR'd instead, and
+   whichever one actually produces reads is locked onto so the rest of the run
+   pays for one crop. See `_RegionSearch`.
+2. *How.* Overlay text is light-on-dark, small and JPEG-soft. Upscaling the
+   crop to a fixed text height and binarising it turns a garbled read into a
+   clean one. The two passes (grey and hard-thresholded) disagree often enough
+   on real footage to be worth running both: on the pilot fixture 44 of 215
+   readable frames were readable ONLY after thresholding, because a fixed cut
+   handles light-on-dark that Otsu does not. See `_prepared_crops`.
+3. *Fast enough.* Reading a frame costs about a second, so a three hour
+   broadcast is nearly two hours of OCR. It is embarrassingly parallel, so it
+   runs on a worker pool, and the pool is arranged so that completion order can
+   never reach the caller's output. See `_PooledReader` and `_with_lookahead`.
+
+Nothing here assumes a language, a script or a corpus. The OCR engine is
+injected as a callable `(image_path) -> str`; the default adapter uses
+pytesseract when installed and takes its language as a parameter (or from
+`DIRSTRAL_ANNOTATOR_OCR_LANG`), never a hardcoded one. Callers that know their
+corpus pass their own regions and their own interpretation.
+
+The interpretation seam is `OverlayReader.read(media, interpret)`. `interpret`
+receives one band's text and returns whatever it made of it plus a *hit count*:
+how much evidence this band held. That count is the only thing the reader takes
+back, and it is what drives the band lock. It has to come from the caller
+because "this band is the overlay" is a judgement about content: a crop of
+crowd texture yields plenty of text, and locking onto it because it was not
+empty is precisely how a reader ends up OCR'ing the wrong 3% of every frame for
+three hours. The default interpreter (`any_text`) is deliberately weak and is
+for callers with nothing better to offer.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import threading
+from collections import deque
+from collections.abc import Callable, Iterable, Iterator
+from concurrent.futures import Executor, Future, ThreadPoolExecutor
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Self, TypeVar
+
+from .base import RecognizerUnavailable, iter_frames
+
+OcrFn = Callable[[Path], str]
+#: Fractional (x, y, w, h) box, so one set of bands fits SD, HD and 4K alike.
+Region = tuple[float, float, float, float]
+
+# Fractional boxes searched for the overlay, covering the corners broadcasts
+# actually use: sports bugs hang top left or along the bottom. Deliberately
+# generous, because a band that clips the text is worse than one that includes
+# some background.
+CANDIDATE_REGIONS: tuple[Region, ...] = (
+    (0.00, 0.02, 0.55, 0.16),  # upper left
+    (0.00, 0.80, 0.55, 0.18),  # lower left
+    (0.20, 0.80, 0.60, 0.18),  # lower centre
+    (0.20, 0.02, 0.60, 0.16),  # upper centre
+)
+
+# Full-width bands, for overlays that span the frame: news tickers, lower
+# thirds, headline banners. Not in the default sweep, because a wider crop is a
+# slower OCR and a noisier one; a caller that knows its corpus asks for these.
+WIDE_REGIONS: tuple[Region, ...] = (
+    (0.00, 0.78, 1.00, 0.22),  # lower band: ticker, lower third
+    (0.00, 0.00, 1.00, 0.20),  # upper band: headline banner, clock badge
+)
+
+# Crops are upscaled so the band is about this tall before OCR. Fixed pixels,
+# not a fixed factor, so an SD archive gets the magnification it needs and a
+# 4K master is not blown up into a slow no-op.
+TARGET_BAND_PX = 320
+MAX_UPSCALE = 4.0
+# Everything darker than this becomes black in the second pass. Overlay text is
+# near-white by design, so the cut can sit high.
+BINARY_THRESHOLD = 140
+# tesseract page-segmentation mode for a cropped overlay strip: "a single
+# uniform block of text". Tesseract's default keeps hunting for page structure
+# that a 200-pixel-tall strip does not have.
+OCR_PSM = 6
+
+# Region search: while unlocked, only every Nth frame pays for the full sweep;
+# once one band has produced this many reads it is the only one OCR'd.
+SCAN_STRIDE = 4
+LOCK_AFTER_READS = 5
+
+# Worker pool for the per-frame read. The default is a quarter of the core
+# count, not all of it, for a measured reason: tesseract is built against
+# OpenMP and runs four threads per page (NLWP 4 on every invocation), so N
+# workers put 4N threads on the machine. On the pilot's 16 core host that
+# makes 4 workers the fastest setting (3.0x to 3.3x on the scorebug), 8
+# workers slower than running serially (0.83x to 0.90x) and 12 workers four
+# times slower than serial. Raise DIRSTRAL_ANNOTATOR_WORKERS where tesseract
+# is built without OpenMP, or where the host has cores to spare. Setting
+# OMP_THREAD_LIMIT=1 makes each worker use one core and lets the count go
+# higher, but it is process wide: it would also throttle the torch and
+# onnxruntime work the jersey and face recognizers do in the same process.
+WORKERS_ENV = "DIRSTRAL_ANNOTATOR_WORKERS"
+OCR_THREADS_PER_WORKER = 4
+MAX_DEFAULT_WORKERS = 8
+# How far ahead of the authoritative loop frames are speculatively dispatched.
+# Has to exceed the worker count or the pool drains while the main thread folds
+# one frame's reads into its own state; a few frames per worker is enough, and
+# each pending entry is only a path and a short result list.
+LOOKAHEAD_PER_WORKER = 4
+MIN_LOOKAHEAD = 16
+
+#: Language(s) handed to the default OCR adapter, in tesseract's own notation
+#: ("rus", "eng+rus"). Unset means tesseract's built-in default. This exists so
+#: an operator can point the whole cascade at a corpus in another script
+#: without a code change; a caller that knows better passes `lang=` instead.
+LANG_ENV = "DIRSTRAL_ANNOTATOR_OCR_LANG"
+
+#: Shortest stripped text `any_text` will treat as evidence of an overlay.
+#: Below this a read is as likely to be JPEG noise as a word.
+MIN_USEFUL_CHARS = 4
+
+
+def default_lang() -> str | None:
+    """Configured OCR language, or None for the engine's own default."""
+    return os.environ.get(LANG_ENV, "").strip() or None
+
+
+def default_ocr(psm: int | None = None, lang: str | None = None) -> OcrFn:
+    """pytesseract adapter, optionally pinned to a page-segmentation mode.
+
+    `psm` is left alone by default because other recognizers share this adapter
+    on crops of their own shape; the overlay reader asks for `OCR_PSM`.
+
+    `lang` is a parameter and never a constant. The pilot corpus is English and
+    the second is Russian, and neither is a property of this code: passing None
+    falls back to `DIRSTRAL_ANNOTATOR_OCR_LANG` and then to whatever the local
+    tesseract defaults to. Non-Latin scripts need the matching traineddata
+    installed (`tesseract-lang` on Homebrew, `tesseract-ocr-rus` on Debian).
+    """
+    try:
+        import pytesseract  # type: ignore
+        from PIL import Image  # type: ignore
+    except ImportError as exc:
+        raise RecognizerUnavailable(
+            "overlay OCR needs pytesseract + Pillow (pip install "
+            "'dirstral-annotator[ocr]') and a tesseract binary"
+        ) from exc
+
+    config = f"--psm {psm}" if psm is not None else ""
+    language = default_lang() if lang is None else lang
+
+    def ocr(frame: Path) -> str:
+        with Image.open(frame) as img:
+            img.load()
+            return pytesseract.image_to_string(img, config=config, lang=language)
+
+    return ocr
+
+
+def default_workers() -> int:
+    """How many frames to read at once, from the environment or the host.
+
+    `DIRSTRAL_ANNOTATOR_WORKERS=1` forces the serial path; a value that is not
+    a positive integer is ignored rather than silently disabling the pool. The
+    unset default divides the core count by the threads one OCR pass already
+    uses, because a worker is not one core's worth of work: see
+    OCR_THREADS_PER_WORKER.
+    """
+    raw = os.environ.get(WORKERS_ENV, "").strip()
+    if raw:
+        try:
+            requested = int(raw)
+        except ValueError:
+            requested = 0
+        if requested >= 1:
+            return requested
+    cores = os.cpu_count() or 1
+    return max(1, min(cores // OCR_THREADS_PER_WORKER, MAX_DEFAULT_WORKERS))
+
+
+def lookahead_for(workers: int) -> int:
+    """Size of the dispatch window in front of a pool of `workers`."""
+    return max(MIN_LOOKAHEAD, LOOKAHEAD_PER_WORKER * workers)
+
+
+@dataclass(frozen=True)
+class OverlayRead:
+    """Everything one band of one sampled frame yielded: text, and when.
+
+    `texts` holds one string per preprocessing pass, in a fixed order, and is
+    not deduplicated: the passes disagree, and which one is right depends on
+    the frame. Callers merge them under their own rules.
+    """
+
+    index: int  # sampled-frame ordinal, 0-based
+    timestamp_s: float
+    region: Region
+    texts: tuple[str, ...] = field(default_factory=tuple)
+
+    def best(self) -> str:
+        """The longest pass, for callers that want one string and no rules."""
+        return max(self.texts, key=len, default="")
+
+
+_T = TypeVar("_T")
+#: One band's text in, (whatever the caller made of it, hit count) out. The hit
+#: count is evidence that this band holds the overlay, and drives the band lock.
+Interpreter = Callable[[OverlayRead], tuple[_T, int]]
+
+
+def any_text(read: OverlayRead) -> tuple[tuple[str, ...], int]:
+    """Default interpreter: keep every substantial pass, count the band once.
+
+    Weak on purpose. It cannot tell an overlay from a shop sign in the
+    background, so a caller that can distinguish them should say so rather than
+    accept this.
+    """
+    kept = tuple(text for text in read.texts if len(text.strip()) >= MIN_USEFUL_CHARS)
+    return kept, 1 if kept else 0
+
+
+class OverlayReader:
+    """Sample a media file and OCR its overlay band, frame by frame.
+
+    Holds no interpretation of its own: `read` takes the caller's, and the only
+    thing that crosses back is a hit count. Everything else about a run (which
+    band, how many workers, which language) is a constructor argument with a
+    general default.
+    """
+
+    def __init__(
+        self,
+        ocr: OcrFn | None = None,
+        fps: float = 0.5,
+        crop: Region | None = None,  # fraction box; None searches for the band
+        regions: Iterable[Region] | None = None,
+        workers: int | None = None,  # None: default_workers(); 1: serial
+        lang: str | None = None,  # None: LANG_ENV, else the engine's default
+        psm: int | None = OCR_PSM,
+        name: str = "overlay",  # scratch dir and worker thread prefix
+    ):
+        self.ocr = ocr if ocr is not None else default_ocr(psm=psm, lang=lang)
+        self.fps = fps
+        self.crop = crop
+        if crop is not None:
+            self.regions: tuple[Region, ...] = (tuple(crop),)  # type: ignore[assignment]
+        else:
+            self.regions = tuple(regions) if regions is not None else CANDIDATE_REGIONS
+        self.workers = default_workers() if workers is None else max(1, int(workers))
+        self.name = name
+
+    def read(
+        self,
+        media_path: Path,
+        interpret: Interpreter[_T] = any_text,  # type: ignore[assignment]
+    ) -> Iterator[tuple[OverlayRead, _T]]:
+        """Yield (read, interpretation) for every band the search wanted.
+
+        One frame can yield several bands while the search is still sweeping,
+        and none at all on a strided frame. A band that produced hits ends the
+        frame: the overlay was found, the other crops are background.
+
+        `interpret` is called on the caller's thread, in frame order, so it may
+        accumulate state. The pool sits upstream of it and cannot reorder
+        anything: see `_with_lookahead`.
+        """
+        search = _RegionSearch(self.regions)
+        with (
+            tempfile.TemporaryDirectory(prefix=f"dirstral-{self.name}-") as tmp,
+            _reader(self.ocr, Path(tmp), self.workers, self.name) as pool,
+        ):
+            frames = iter_frames(media_path, fps=self.fps)
+            for i, timestamp, frame in _with_lookahead(frames, search, pool):
+                for region in search.regions_for(i):
+                    read = OverlayRead(
+                        index=i,
+                        timestamp_s=timestamp,
+                        region=region,
+                        texts=tuple(pool.read(i, frame, region)),
+                    )
+                    value, hits = interpret(read)
+                    yield read, value
+                    search.record(region, hits)
+                    if hits:
+                        break  # this band answered; skip the other crops
+
+    def read_text(self, media_path: Path) -> Iterator[OverlayRead]:
+        """Every band's text, and nothing else. The no-interpretation path."""
+        for read, _ in self.read(media_path):
+            yield read
+
+
+class _RegionSearch:
+    """Try every candidate band until one proves itself, then stay on it.
+
+    Sweeping four bands on every frame would cost more OCR than the whole-frame
+    pass this replaces, so unlocked sweeps are strided and the winner is locked
+    in after a few reads. If the overlay moves (a graphics package change part
+    way through a file) the lock releases once the locked band goes quiet.
+    """
+
+    RELEASE_AFTER_MISSES = 60
+
+    def __init__(self, regions: tuple[Region, ...]):
+        self.regions = regions
+        self.locked: Region | None = regions[0] if len(regions) == 1 else None
+        self.scores: dict[Region, int] = {}
+        self.misses = 0
+
+    def regions_for(self, frame_index: int) -> tuple[Region, ...]:
+        if self.locked is not None:
+            return (self.locked,)
+        if frame_index % SCAN_STRIDE:
+            return ()
+        return self.regions
+
+    def record(self, region: Region, hits: int) -> None:
+        if hits:
+            self.scores[region] = self.scores.get(region, 0) + hits
+            self.misses = 0
+            if self.locked is None and self.scores[region] >= LOCK_AFTER_READS:
+                self.locked = region
+        elif self.locked == region and len(self.regions) > 1:
+            self.misses += 1
+            if self.misses >= self.RELEASE_AFTER_MISSES:
+                self.locked = None
+                self.scores.clear()
+                self.misses = 0
+
+
+def read_band(ocr: OcrFn, frame: Path, region: Region, work: Path) -> list[str]:
+    """OCR one band of one frame, once per preprocessing pass.
+
+    The whole of the expensive per-frame work, and a pure function of
+    (frame, region): nothing here reads or writes reader state, which is what
+    makes it safe to run several at once. Returns the raw strings in pass
+    order; merging them is the caller's judgement, not the engine's.
+    """
+    return [ocr(path) for path in _prepared_crops(frame, region, work)]
+
+
+class Workspaces:
+    """A scratch directory per worker thread.
+
+    Crops are written under fixed names and rewritten per frame, so threads
+    sharing one directory would overwrite each other's crop between the write
+    and the OCR of it. A directory per thread keeps the fixed names, and with
+    them a bounded amount of scratch (a couple of files per worker, rewritten
+    every frame, rather than a couple per frame kept until the run ends).
+    """
+
+    def __init__(self, root: Path):
+        self._root = root
+        self._local = threading.local()
+        self._lock = threading.Lock()
+        self._issued = 0
+
+    def current(self) -> Path:
+        work = getattr(self._local, "work", None)
+        if work is None:
+            with self._lock:
+                self._issued += 1
+                work = self._root / f"worker-{self._issued}"
+            work.mkdir(parents=True, exist_ok=True)
+            self._local.work = work
+        return work
+
+
+class _SerialReader:
+    """Read one band at a time on the calling thread.
+
+    The reference behaviour, and what `workers=1` selects. `dispatch` and
+    `retire` exist so the loop in `OverlayReader.read` is written once.
+    """
+
+    workers = 1
+
+    def __init__(self, ocr: OcrFn, work: Path):
+        self._ocr = ocr
+        self._work = work
+
+    def dispatch(self, index: int, frame: Path, region: Region) -> None:
+        pass
+
+    def read(self, index: int, frame: Path, region: Region) -> list[str]:
+        return read_band(self._ocr, frame, region, self._work)
+
+    def retire(self, index: int) -> None:
+        pass
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        pass
+
+
+class _PooledReader:
+    """Read bands on a worker pool, keyed by frame index so order cannot leak.
+
+    Results are handed back only when the reading loop asks for a specific
+    (frame index, region), so the caller sees frames in order whatever order
+    the workers happen to finish in. A band that was dispatched and then not
+    asked for (the region search changed its mind) is dropped; a band that is
+    asked for and was never dispatched is read on the spot.
+
+    The pool is threads, not processes, which the task's own measurement
+    justifies: on the pilot fixture 6 threads and 6 processes both returned
+    the same reads at the same speed (4.98x versus 4.92x over serial), because
+    pytesseract shells out to the `tesseract` binary and Pillow drops the GIL
+    around its own work, so the interpreter lock is not the constraint.
+    Threads then win on everything else: no pickling constraint on the
+    injected OCR callable (the default adapter is a closure), no second copy
+    of any model per worker, and a RecognizerUnavailable raised in a worker
+    arrives at `future.result()` as itself.
+    """
+
+    def __init__(self, ocr: OcrFn, work: Path, workers: int, name: str = "overlay"):
+        self.workers = workers
+        self._ocr = ocr
+        self._workspaces = Workspaces(work)
+        self._executor = _new_executor(workers, name)
+        self._pending: dict[tuple[int, Region], Future[list[str]]] = {}
+
+    def _read_here(self, frame: Path, region: Region) -> list[str]:
+        return read_band(self._ocr, frame, region, self._workspaces.current())
+
+    def dispatch(self, index: int, frame: Path, region: Region) -> None:
+        key = (index, region)
+        if key not in self._pending:
+            self._pending[key] = self._executor.submit(self._read_here, frame, region)
+
+    def read(self, index: int, frame: Path, region: Region) -> list[str]:
+        pending = self._pending.pop((index, region), None)
+        if pending is None:
+            return self._read_here(frame, region)
+        return pending.result()
+
+    def retire(self, index: int) -> None:
+        """Drop dispatches for frames the loop has already passed."""
+        for key in [k for k in self._pending if k[0] <= index]:
+            self._pending.pop(key).cancel()
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        for pending in self._pending.values():
+            pending.cancel()
+        self._pending.clear()
+        self._executor.shutdown(wait=True, cancel_futures=True)
+
+
+def _new_executor(workers: int, name: str = "overlay") -> Executor:
+    return ThreadPoolExecutor(max_workers=workers, thread_name_prefix=name)
+
+
+def _reader(
+    ocr: OcrFn, work: Path, workers: int, name: str = "overlay"
+) -> _SerialReader | _PooledReader:
+    if workers <= 1:
+        return _SerialReader(ocr, work)
+    return _PooledReader(ocr, work, workers, name)
+
+
+def _with_lookahead(
+    frames: Iterable[tuple[float, Path]],
+    search: _RegionSearch,
+    reader: _SerialReader | _PooledReader,
+) -> Iterator[tuple[int, float, Path]]:
+    """Yield (index, timestamp, frame) while dispatching the reads to come.
+
+    Which band a frame is OCR'd on is sequential state: it depends on what the
+    frames before it produced, so the pool cannot simply be handed the whole
+    file. It is handed a guess instead, taken from the region search as it
+    stands when the frame enters the window, and the reading loop stays
+    authoritative: it asks the search which bands it actually wants and takes a
+    dispatched result only for exactly those. A guess the search does not take
+    is dropped, and a band it wants that was never guessed is read on the spot,
+    so the output is the serial one whatever the pool did.
+
+    The whole window is re-dispatched on every step. Dispatching is keyed and
+    idempotent, so this costs one dict lookup per frame in the window and
+    means the handful of frames already in flight when the search locks onto a
+    band get read on the pool rather than one at a time.
+    """
+    lookahead = lookahead_for(reader.workers)
+    window: deque[tuple[int, float, Path]] = deque()
+    numbered = enumerate(frames)
+
+    def top_up() -> None:
+        while len(window) < lookahead:
+            item = next(numbered, None)
+            if item is None:
+                break
+            index, (timestamp, frame) = item
+            window.append((index, timestamp, frame))
+        for index, _timestamp, frame in window:
+            for region in search.regions_for(index):
+                reader.dispatch(index, frame, region)
+
+    top_up()
+    while window:
+        current = window.popleft()
+        yield current
+        reader.retire(current[0])
+        top_up()
+
+
+_K = TypeVar("_K")
+_A = TypeVar("_A")
+_R = TypeVar("_R")
+
+
+def map_in_order(
+    executor: Executor,
+    fn: Callable[[_A], _R],
+    items: Iterable[tuple[_K, _A]],
+    lookahead: int,
+) -> Iterator[tuple[_K, _R]]:
+    """Run `fn` over `items` on the pool, yielding results in *input* order.
+
+    For per-frame work that carries no sequential state, which is the easy half
+    of the problem `_with_lookahead` solves: items go in in order, are held in
+    a bounded window, and are awaited in that same order, so a worker finishing
+    early simply waits its turn and completion order never reaches the caller.
+    The window is what keeps a long file from submitting every frame at once.
+    """
+    window: deque[tuple[_K, Future[_R]]] = deque()
+    source = iter(items)
+
+    def top_up() -> None:
+        while len(window) < lookahead:
+            item = next(source, None)
+            if item is None:
+                return
+            key, arg = item
+            window.append((key, executor.submit(fn, arg)))
+
+    top_up()
+    while window:
+        key, pending = window.popleft()
+        yield key, pending.result()
+        top_up()
+
+
+def _prepared_crops(frame: Path, region: Region, work: Path) -> Iterator[Path]:
+    """Yield OCR-ready renderings of one band: upscaled greyscale, and the same
+    crop hard-thresholded.
+
+    Overlay text is light on dark, which Otsu handles badly when the crop also
+    catches a bright background; a fixed threshold recovers the text in exactly
+    the frames the grey pass garbles. Both are written to the reader's own temp
+    dir rather than beside the frame, because the frame directory is a cache
+    other recognizers iterate.
+    """
+    try:
+        from PIL import Image, ImageOps  # required by the OCR extra
+    except ImportError as exc:  # pragma: no cover - exercised via the contract test
+        # A caller's recognize() must degrade the cascade, not abort it, so a
+        # missing Pillow has to arrive as RecognizerUnavailable, not ImportError.
+        raise RecognizerUnavailable("Pillow is required for overlay OCR") from exc
+
+    # load() inside the context manager pulls the pixels into memory and lets
+    # the descriptor close immediately. This runs at least once per frame, so
+    # relying on garbage collection to release it leaks handles across a long
+    # media file and can exhaust the process limit.
+    with Image.open(frame) as opened:
+        opened.load()
+        img = opened.copy()
+    x, y, w, h = region
+    box = (
+        max(0, int(x * img.width)),
+        max(0, int(y * img.height)),
+        min(img.width, int((x + w) * img.width)),
+        min(img.height, int((y + h) * img.height)),
+    )
+    if box[2] <= box[0] or box[3] <= box[1]:
+        return
+    crop = img.crop(box).convert("L")
+    scale = min(MAX_UPSCALE, max(1.0, TARGET_BAND_PX / max(1, crop.height)))
+    if scale > 1.0:
+        crop = crop.resize(
+            (int(crop.width * scale), int(crop.height * scale)), Image.LANCZOS
+        )
+    crop = ImageOps.autocontrast(crop)
+
+    grey = work / "band-grey.png"
+    crop.save(grey)
+    yield grey
+
+    binary = work / "band-bin.png"
+    crop.point(lambda p: 255 if p > BINARY_THRESHOLD else 0).save(binary)
+    yield binary

--- a/annotator/dirstral_annotator/recognizers/overlay.py
+++ b/annotator/dirstral_annotator/recognizers/overlay.py
@@ -251,6 +251,11 @@ class OverlayReader:
         name: str = "overlay",  # scratch dir and worker thread prefix
     ):
         self.ocr = ocr if ocr is not None else default_ocr(psm=psm, lang=lang)
+        # The language the default adapter was built with, resolved through
+        # LANG_ENV. Records what this reader will read in; says nothing about
+        # an injected OCR callable, which answers for its own language.
+        self.lang = default_lang() if lang is None else lang
+        self.psm = psm
         self.fps = fps
         self.crop = crop
         if crop is not None:
@@ -430,7 +435,7 @@ class _PooledReader:
         self.workers = workers
         self._ocr = ocr
         self._workspaces = Workspaces(work)
-        self._executor = _new_executor(workers, name)
+        self._executor = new_executor(workers, name)
         self._pending: dict[tuple[int, Region], Future[list[str]]] = {}
 
     def _read_here(self, frame: Path, region: Region) -> list[str]:
@@ -462,7 +467,7 @@ class _PooledReader:
         self._executor.shutdown(wait=True, cancel_futures=True)
 
 
-def _new_executor(workers: int, name: str = "overlay") -> Executor:
+def new_executor(workers: int, name: str = "overlay") -> Executor:
     return ThreadPoolExecutor(max_workers=workers, thread_name_prefix=name)
 
 

--- a/annotator/dirstral_annotator/recognizers/scorebug.py
+++ b/annotator/dirstral_annotator/recognizers/scorebug.py
@@ -1,121 +1,83 @@
-"""Scorebug recognizer: OCR the broadcast overlay.
+"""Scorebug recognizer: read a baseball broadcast's overlay against a roster.
+
+One consumer of the generic overlay-text reader in `overlay.py`. Everything
+about *finding* burned-in text and getting a clean string out of it lives
+there; everything here is baseball. The split is where it is because the two
+halves generalise differently: the reader reaches 96.5% identity coverage on
+pilot footage with no data feed and transfers unchanged to a corpus in another
+language, while the interpretation below transfers to nothing that is not a
+baseball broadcast.
 
 The overlay names the current batter and pitcher during every at-bat, which
-makes this the workhorse signal for broadcast footage that has no structured
-play-by-play feed (the normal case for an archive). Unlike the play-by-play
-recognizer it needs nothing but the pixels.
-
-Reading it well takes three things, and the naive "OCR the whole frame and
-fuzzy-match every line against the roster" loop got none of them:
-
-1. *Where.* The bug occupies about 3% of the frame. Whole-frame OCR has to
-   segment a crowd, a scoreboard and a sponsor board before it reaches the
-   30-pixel-tall name, and usually never does. We OCR a handful of candidate
-   overlay bands instead, then lock onto whichever one is actually producing
-   reads so the rest of the run pays for one crop.
-2. *How.* Overlay text is light-on-dark, small and JPEG-soft. Upscaling the
-   crop to a fixed text height and binarising it turns a garbled read into a
-   clean one; the two passes (grey and binarised) disagree often enough on
-   real footage to be worth running both.
-3. *What.* The bug is structured, not prose: `5.LILE` is the batter in the
-   fifth lineup slot, `RAY  P: 90` is the pitcher and his pitch count,
-   `SLIDER 88 MPH` is the pitch that was just thrown. Parsing those forms and
-   matching only the name part against the roster is what keeps precision up:
-   feeding whole OCR lines to a fuzzy matcher turns "ee" into Jung Hoo Lee and
-   "#0" into the player wearing 0.
+makes this the workhorse signal for footage that has no structured play-by-play
+feed (the normal case for an archive). What the parser has to get right is that
+the bug is *structured*, not prose: `5.LILE` is the batter in the fifth lineup
+slot, `RAY  P: 90` is the pitcher and his pitch count, `SLIDER 88 MPH` is the
+pitch that was just thrown. Parsing those forms and matching only the name part
+against the roster is what keeps precision up (0.541 to 0.991 on the 450-frame
+fixture): feeding whole OCR lines to a fuzzy matcher turns "ee" into Jung Hoo
+Lee and "#0" into the player wearing 0.
 
 Note on the leading digit: it is the *lineup slot*, not the jersey number
 (Daylen Lile bats fifth wearing 4), so it is used as a structural marker for
 "this is the batter field" and never as a number-vs-roster constraint.
 
-Consecutive frames resolving to the same player collapse into one cue
-spanning the run: the overlay persisting for 20 seconds is one at-bat
-sighting, not 20 observations (which would also defeat fusion's per-source
-confidence cap).
+Consecutive frames resolving to the same player collapse into one cue spanning
+the run: the overlay persisting for 20 seconds is one at-bat sighting, not 20
+observations (which would also defeat fusion's per-source confidence cap).
 
-The OCR engine is injected as a callable `(image_path) -> str`; the default
-adapter uses pytesseract when installed.
-
-Reading a frame is the expensive step (about a second per frame on the pilot
-host, so nearly two hours for a three hour broadcast) and it is embarrassingly
-parallel, so it runs on a worker pool; see `_PooledReader` for why the pool is
-threads and `_with_lookahead` for how the cue list stays identical to a serial
-run despite the band search being sequential state.
+This module also supplies the reader's band search with its evidence.
+`_interpret` returns a hit count that is deliberately not "the OCR returned
+something": a crop of crowd texture returns plenty. It is "the OCR returned
+something this roster recognises as a field", which is the signal that made the
+region search land on the bug instead of on the stands.
 """
 
 from __future__ import annotations
 
 import difflib
-import os
 import re
-import tempfile
-import threading
 import unicodedata
-from collections import deque
-from collections.abc import Callable, Iterable, Iterator
-from concurrent.futures import Executor, Future, ThreadPoolExecutor
+from collections.abc import Iterable
+from contextlib import closing
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Self
 
 from ..model import Cue
 from ..roster import Roster
-from .base import RecognizerUnavailable, iter_frames
-
-OcrFn = Callable[[Path], str]
-Region = tuple[float, float, float, float]
-
-# Fractional (x, y, w, h) boxes searched for the overlay, covering the corners
-# broadcasts actually use: MLB/NBC hangs its bug top left, most other sports
-# put it along the bottom. Deliberately generous, because a band that clips the
-# name is worse than one that includes some crowd.
-CANDIDATE_REGIONS: tuple[Region, ...] = (
-    (0.00, 0.02, 0.55, 0.16),  # upper left
-    (0.00, 0.80, 0.55, 0.18),  # lower left
-    (0.20, 0.80, 0.60, 0.18),  # lower centre
-    (0.20, 0.02, 0.60, 0.16),  # upper centre
+from .base import collapse_sightings
+from .overlay import (
+    OCR_PSM,
+    OcrFn,
+    OverlayRead,
+    OverlayReader,
+    Region,
+    default_ocr,
+    default_workers,
 )
 
-# A run of frames may drop a detection for a beat (OCR flicker, or a replay
-# that hides the bug); allow this many seconds of gap before closing the run.
-RUN_GAP_S = 3.0
-
-# Crops are upscaled so the band is about this tall before OCR. Fixed pixels,
-# not a fixed factor, so an SD archive gets the magnification it needs and a
-# 4K master is not blown up into a slow no-op.
-TARGET_BAND_PX = 320
-MAX_UPSCALE = 4.0
-# Everything darker than this becomes black in the second pass. Overlay text is
-# near-white by design, so the cut can sit high.
-BINARY_THRESHOLD = 140
-# tesseract page-segmentation mode for a cropped overlay strip.
-OCR_PSM = 6
-
-# Region search: while unlocked, only every Nth frame pays for the full sweep;
-# once one band has produced this many reads it is the only one OCR'd.
-SCAN_STRIDE = 4
-LOCK_AFTER_READS = 5
-
-# Worker pool for the per-frame read. The default is a quarter of the core
-# count, not all of it, for a measured reason: tesseract is built against
-# OpenMP and runs four threads per page (NLWP 4 on every invocation), so N
-# workers put 4N threads on the machine. On the pilot's 16 core host that
-# makes 4 workers the fastest setting (3.0x to 3.3x on the scorebug), 8
-# workers slower than running serially (0.83x to 0.90x) and 12 workers four
-# times slower than serial. Raise DIRSTRAL_ANNOTATOR_WORKERS where tesseract
-# is built without OpenMP, or where the host has cores to spare. Setting
-# OMP_THREAD_LIMIT=1 makes each worker use one core and lets the count go
-# higher, but it is process wide: it would also throttle the torch and
-# onnxruntime work the jersey and face recognizers do in the same process.
-WORKERS_ENV = "DIRSTRAL_ANNOTATOR_WORKERS"
-OCR_THREADS_PER_WORKER = 4
-MAX_DEFAULT_WORKERS = 8
-# How far ahead of the authoritative loop frames are speculatively dispatched.
-# Has to exceed the worker count or the pool drains while the main thread
-# folds one frame's reads into the sighting lists; a few frames per worker is
-# enough, and each pending entry is only a path and a short result list.
-LOOKAHEAD_PER_WORKER = 4
-MIN_LOOKAHEAD = 16
+# `collapse_sightings`, `OcrFn` and `default_ocr` have always been imported
+# from this module by the other recognizers and by tests. Their homes are now
+# `base` (cue shaping) and `overlay` (reading), but the names stay valid here.
+__all__ = [
+    "BATTER",
+    "LOOSE",
+    "PITCHER",
+    "PITCH_TYPES",
+    "PLAUSIBLE_SPEED",
+    "UNKNOWN",
+    "NameRead",
+    "OcrFn",
+    "PitchRead",
+    "Region",
+    "ScorebugRecognizer",
+    "collapse_sightings",
+    "default_ocr",
+    "default_workers",
+    "match_name",
+    "parse_bands",
+    "parse_overlay",
+]
 
 # Name matching. Short reads (three or four characters: RAY, COX) are accepted
 # only on an exact roster match, because that is the length at which fuzzy
@@ -175,54 +137,6 @@ PLAUSIBLE_SPEED = range(40, 121)
 _WORD_RE = re.compile(r"[A-Z][A-Z'\-]{2,}")
 
 
-def default_ocr(psm: int | None = None) -> OcrFn:
-    """pytesseract adapter, optionally pinned to a page-segmentation mode.
-
-    `psm` is left alone by default because the other recognizers share this
-    adapter on crops of their own shape. The scorebug asks for mode 6, "a
-    single uniform block of text": tesseract's default keeps hunting for page
-    structure that a 200-pixel-tall overlay strip does not have.
-    """
-    try:
-        import pytesseract  # type: ignore
-        from PIL import Image  # type: ignore
-    except ImportError as exc:
-        raise RecognizerUnavailable(
-            "scorebug OCR needs pytesseract + Pillow (pip install "
-            "'dirstral-annotator[ocr]') and a tesseract binary"
-        ) from exc
-
-    config = f"--psm {psm}" if psm is not None else ""
-
-    def ocr(frame: Path) -> str:
-        with Image.open(frame) as img:
-            img.load()
-            return pytesseract.image_to_string(img, config=config)
-
-    return ocr
-
-
-def default_workers() -> int:
-    """How many frames to read at once, from the environment or the host.
-
-    `DIRSTRAL_ANNOTATOR_WORKERS=1` forces the serial path; a value that is not
-    a positive integer is ignored rather than silently disabling the pool. The
-    unset default divides the core count by the threads one OCR pass already
-    uses, because a worker is not one core's worth of work: see
-    OCR_THREADS_PER_WORKER.
-    """
-    raw = os.environ.get(WORKERS_ENV, "").strip()
-    if raw:
-        try:
-            requested = int(raw)
-        except ValueError:
-            requested = 0
-        if requested >= 1:
-            return requested
-    cores = os.cpu_count() or 1
-    return max(1, min(cores // OCR_THREADS_PER_WORKER, MAX_DEFAULT_WORKERS))
-
-
 @dataclass(frozen=True)
 class NameRead:
     """One name the overlay parser recovered, with the role its position in
@@ -246,9 +160,17 @@ class PitchRead:
         return " ".join(parts)
 
 
-#: Everything one band of one frame yields: the names it named and the pitch
-#: graphic it showed. The unit of work the reader pool schedules.
-_Band = tuple[list[NameRead], list[PitchRead]]
+@dataclass(frozen=True)
+class _Fields:
+    """What one band of one frame said, once the roster has had its say.
+
+    `names` is (player id, confidence, role) so the caller does not resolve the
+    same read twice; `pitches` stays unresolved because a speed graphic names
+    nobody.
+    """
+
+    names: tuple[tuple[str, float, str], ...] = ()
+    pitches: tuple[PitchRead, ...] = ()
 
 
 def parse_overlay(text: str) -> tuple[list[NameRead], list[PitchRead]]:
@@ -320,6 +242,27 @@ def parse_overlay(text: str) -> tuple[list[NameRead], list[PitchRead]]:
     return names, _dedupe_pitches(pitches)
 
 
+def parse_bands(texts: Iterable[str]) -> tuple[list[NameRead], list[PitchRead]]:
+    """Merge one band's preprocessing passes into one set of fields.
+
+    The grey and thresholded passes disagree, and neither is reliably better:
+    44 of 215 readable frames on the pilot fixture were readable only after
+    thresholding. So both are parsed and the union kept, with each (name, role)
+    counted once and each speed described by its fullest reading.
+    """
+    names: list[NameRead] = []
+    pitches: list[PitchRead] = []
+    seen: set[tuple[str, str]] = set()
+    for text in texts:
+        found_names, found_pitches = parse_overlay(text)
+        for read in found_names:
+            if (read.name, read.role) not in seen:
+                seen.add((read.name, read.role))
+                names.append(read)
+        pitches += found_pitches
+    return names, _dedupe_pitches(pitches)
+
+
 class ScorebugRecognizer:
     name = "scorebug"
 
@@ -332,17 +275,27 @@ class ScorebugRecognizer:
         regions: Iterable[Region] | None = None,
         pitch_cues: bool = True,
         workers: int | None = None,  # None: default_workers(); 1: serial
+        lang: str | None = None,  # OCR language; None: the reader's default
     ):
         self.roster = roster
-        self.ocr = ocr if ocr is not None else default_ocr(psm=OCR_PSM)
-        self.fps = fps
-        self.crop = crop
-        if crop is not None:
-            self.regions: tuple[Region, ...] = (tuple(crop),)  # type: ignore[assignment]
-        else:
-            self.regions = tuple(regions) if regions is not None else CANDIDATE_REGIONS
         self.pitch_cues = pitch_cues
-        self.workers = default_workers() if workers is None else max(1, int(workers))
+        self.reader = OverlayReader(
+            ocr=ocr,
+            fps=fps,
+            crop=crop,
+            regions=regions,
+            workers=workers,
+            lang=lang,
+            psm=OCR_PSM,
+            name=self.name,
+        )
+        # Mirrored so the recognizer still answers for its own configuration.
+        # The reader owns them; these are reads of what it settled on.
+        self.ocr = self.reader.ocr
+        self.fps = self.reader.fps
+        self.crop = self.reader.crop
+        self.regions = self.reader.regions
+        self.workers = self.reader.workers
         self._index = _name_index(roster)
 
     def recognize(self, media_path: Path) -> list[Cue]:
@@ -352,42 +305,30 @@ class ScorebugRecognizer:
         loose: list[tuple[float, str, float]] = []
         graphics: list[tuple[float, PitchRead]] = []
 
-        search = _RegionSearch(self.regions)
-        with (
-            tempfile.TemporaryDirectory(prefix="dirstral-scorebug-") as tmp,
-            _reader(self.ocr, Path(tmp), self.workers) as reader,
-        ):
-            frames = iter_frames(media_path, fps=self.fps)
-            for i, t, frame in _with_lookahead(frames, search, reader):
-                for region in search.regions_for(i):
-                    names, pitches = reader.read(i, frame, region)
-                    hits = 0
-                    for read in names:
-                        resolved = self._resolve(read)
-                        if resolved is None:
-                            continue
-                        pid, conf = resolved
-                        if read.role == LOOSE:
-                            # Not evidence of anything on its own, and not
-                            # evidence that this band holds the bug either,
-                            # so it does not count towards the region lock.
-                            loose.append((t, pid, conf))
-                            continue
-                        hits += 1
-                        if read.role == BATTER:
-                            batters.append((t, pid, conf))
-                            continue
-                        if read.role == PITCHER:
-                            pitchers.append((t, pid, conf))
-                        # Named, but not at the plate: the pitcher between
-                        # deliveries, or whoever else the graphics package
-                        # chose to put on screen.
-                        appearances.append((t, pid, conf))
-                    hits += len(pitches)
-                    graphics += [(t, pitch) for pitch in pitches]
-                    search.record(region, hits)
-                    if hits:
-                        break  # this band answered; skip the other crops
+        # `closing` because the reader owns a worker pool and a scratch
+        # directory for the length of the iteration: abandoning it part way
+        # through (an error in this loop, an interrupt) has to shut them down
+        # now rather than whenever the generator is collected.
+        with closing(self.reader.read(media_path, self._interpret)) as reads:
+            for read, fields in reads:
+                t = read.timestamp_s
+                for pid, conf, role in fields.names:
+                    if role == LOOSE:
+                        # Not evidence of anything on its own, and not
+                        # evidence that this band holds the bug either, which
+                        # is why `_interpret` keeps it out of the hit count.
+                        loose.append((t, pid, conf))
+                        continue
+                    if role == BATTER:
+                        batters.append((t, pid, conf))
+                        continue
+                    if role == PITCHER:
+                        pitchers.append((t, pid, conf))
+                    # Named, but not at the plate: the pitcher between
+                    # deliveries, or whoever else the graphics package chose
+                    # to put on screen.
+                    appearances.append((t, pid, conf))
+                graphics += [(t, pitch) for pitch in fields.pitches]
 
         gap = 1.0 / self.fps
         confirmed = batters + appearances
@@ -400,6 +341,28 @@ class ScorebugRecognizer:
             cues += self._pitch_cues(graphics, pitchers)
         cues.sort(key=lambda c: (c.start_s, c.event, c.entity_ids))
         return cues
+
+    def _interpret(self, read: OverlayRead) -> tuple[_Fields, int]:
+        """Turn one band's text into roster-resolved fields plus a hit count.
+
+        The hit count is what the reader's band search runs on, and it counts
+        only reads this roster recognises off a structured line, plus pitch
+        graphics. A loose word never counts even when it resolves: it is as
+        likely to have come out of the stands as off the bug, and letting it
+        vote would let crowd texture win the band search.
+        """
+        names, pitches = parse_bands(read.texts)
+        resolved: list[tuple[str, float, str]] = []
+        hits = 0
+        for name_read in names:
+            hit = self._resolve(name_read)
+            if hit is None:
+                continue
+            pid, conf = hit
+            resolved.append((pid, conf, name_read.role))
+            if name_read.role != LOOSE:
+                hits += 1
+        return _Fields(tuple(resolved), tuple(pitches)), hits + len(pitches)
 
     def _resolve(self, read: NameRead) -> tuple[str, float] | None:
         hit = match_name(self._index, read.name)
@@ -448,278 +411,6 @@ class ScorebugRecognizer:
                 )
             )
         return cues
-
-
-class _RegionSearch:
-    """Try every candidate band until one proves itself, then stay on it.
-
-    Sweeping four bands on every frame would cost more OCR than the whole-frame
-    pass this replaces, so unlocked sweeps are strided and the winner is locked
-    in after a few reads. If the overlay moves (a graphics package change part
-    way through a file) the lock releases once the locked band goes quiet.
-    """
-
-    RELEASE_AFTER_MISSES = 60
-
-    def __init__(self, regions: tuple[Region, ...]):
-        self.regions = regions
-        self.locked: Region | None = regions[0] if len(regions) == 1 else None
-        self.scores: dict[Region, int] = {}
-        self.misses = 0
-
-    def regions_for(self, frame_index: int) -> tuple[Region, ...]:
-        if self.locked is not None:
-            return (self.locked,)
-        if frame_index % SCAN_STRIDE:
-            return ()
-        return self.regions
-
-    def record(self, region: Region, hits: int) -> None:
-        if hits:
-            self.scores[region] = self.scores.get(region, 0) + hits
-            self.misses = 0
-            if self.locked is None and self.scores[region] >= LOCK_AFTER_READS:
-                self.locked = region
-        elif self.locked == region and len(self.regions) > 1:
-            self.misses += 1
-            if self.misses >= self.RELEASE_AFTER_MISSES:
-                self.locked = None
-                self.scores.clear()
-                self.misses = 0
-
-
-def read_band(ocr: OcrFn, frame: Path, region: Region, work: Path) -> _Band:
-    """OCR one band of one frame and parse both preprocessing passes.
-
-    The whole of the expensive per-frame work, and a pure function of
-    (frame, region): nothing here reads or writes recognizer state, which is
-    what makes it safe to run several at once.
-    """
-    names: list[NameRead] = []
-    pitches: list[PitchRead] = []
-    seen: set[tuple[str, str]] = set()
-    for path in _prepared_crops(frame, region, work):
-        found_names, found_pitches = parse_overlay(ocr(path))
-        for read in found_names:
-            if (read.name, read.role) not in seen:
-                seen.add((read.name, read.role))
-                names.append(read)
-        pitches += found_pitches
-    return names, _dedupe_pitches(pitches)
-
-
-class _Workspaces:
-    """A scratch directory per worker thread.
-
-    `_prepared_crops` writes its two renderings under fixed names, so threads
-    sharing one directory would overwrite each other's crop between the write
-    and the OCR of it. A directory per thread keeps the fixed names, and with
-    them a bounded amount of scratch (two files per worker, rewritten every
-    frame, rather than two per frame kept until the run ends).
-    """
-
-    def __init__(self, root: Path):
-        self._root = root
-        self._local = threading.local()
-        self._lock = threading.Lock()
-        self._issued = 0
-
-    def current(self) -> Path:
-        work = getattr(self._local, "work", None)
-        if work is None:
-            with self._lock:
-                self._issued += 1
-                work = self._root / f"worker-{self._issued}"
-            work.mkdir(parents=True, exist_ok=True)
-            self._local.work = work
-        return work
-
-
-class _SerialReader:
-    """Read one band at a time on the calling thread.
-
-    The reference behaviour, and what `workers=1` selects. `dispatch` and
-    `retire` exist so the loop in `recognize` is written once.
-    """
-
-    workers = 1
-
-    def __init__(self, ocr: OcrFn, work: Path):
-        self._ocr = ocr
-        self._work = work
-
-    def dispatch(self, index: int, frame: Path, region: Region) -> None:
-        pass
-
-    def read(self, index: int, frame: Path, region: Region) -> _Band:
-        return read_band(self._ocr, frame, region, self._work)
-
-    def retire(self, index: int) -> None:
-        pass
-
-    def __enter__(self) -> Self:
-        return self
-
-    def __exit__(self, *exc: object) -> None:
-        pass
-
-
-class _PooledReader:
-    """Read bands on a worker pool, keyed by frame index so order cannot leak.
-
-    Results are handed back only when `recognize` asks for a specific
-    (frame index, region), so the cue list is built in frame order whatever
-    order the workers happen to finish in. A band that was dispatched and then
-    not asked for (the region search changed its mind) is dropped; a band that
-    is asked for and was never dispatched is read on the spot.
-
-    The pool is threads, not processes, which the task's own measurement
-    justifies: on the pilot fixture 6 threads and 6 processes both returned
-    the same reads at the same speed (4.98x versus 4.92x over serial), because
-    pytesseract shells out to the `tesseract` binary and Pillow drops the GIL
-    around its own work, so the interpreter lock is not the constraint.
-    Threads then win on everything else: no pickling constraint on the
-    injected OCR callable (the default adapter is a closure), no second copy
-    of any model per worker, and a RecognizerUnavailable raised in a worker
-    arrives at `future.result()` as itself.
-    """
-
-    def __init__(self, ocr: OcrFn, work: Path, workers: int):
-        self.workers = workers
-        self._ocr = ocr
-        self._workspaces = _Workspaces(work)
-        self._executor = _new_executor(workers)
-        self._pending: dict[tuple[int, Region], Future[_Band]] = {}
-
-    def _read_here(self, frame: Path, region: Region) -> _Band:
-        return read_band(self._ocr, frame, region, self._workspaces.current())
-
-    def dispatch(self, index: int, frame: Path, region: Region) -> None:
-        key = (index, region)
-        if key not in self._pending:
-            self._pending[key] = self._executor.submit(self._read_here, frame, region)
-
-    def read(self, index: int, frame: Path, region: Region) -> _Band:
-        pending = self._pending.pop((index, region), None)
-        if pending is None:
-            return self._read_here(frame, region)
-        return pending.result()
-
-    def retire(self, index: int) -> None:
-        """Drop dispatches for frames the loop has already passed."""
-        for key in [k for k in self._pending if k[0] <= index]:
-            self._pending.pop(key).cancel()
-
-    def __enter__(self) -> Self:
-        return self
-
-    def __exit__(self, *exc: object) -> None:
-        for pending in self._pending.values():
-            pending.cancel()
-        self._pending.clear()
-        self._executor.shutdown(wait=True, cancel_futures=True)
-
-
-def _new_executor(workers: int) -> Executor:
-    return ThreadPoolExecutor(max_workers=workers, thread_name_prefix="scorebug")
-
-
-def _reader(ocr: OcrFn, work: Path, workers: int) -> _SerialReader | _PooledReader:
-    return _SerialReader(ocr, work) if workers <= 1 else _PooledReader(ocr, work, workers)
-
-
-def _with_lookahead(
-    frames: Iterable[tuple[float, Path]],
-    search: _RegionSearch,
-    reader: _SerialReader | _PooledReader,
-) -> Iterator[tuple[int, float, Path]]:
-    """Yield (index, timestamp, frame) while dispatching the reads to come.
-
-    Which band a frame is OCR'd on is sequential state: it depends on what the
-    frames before it produced, so the pool cannot simply be handed the whole
-    file. It is handed a guess instead, taken from the region search as it
-    stands when the frame enters the window, and `recognize` stays
-    authoritative: it asks the search which bands it actually wants and takes a
-    dispatched result only for exactly those. A guess the search does not take
-    is dropped, and a band it wants that was never guessed is read on the spot,
-    so the cue list is the serial one whatever the pool did.
-
-    The whole window is re-dispatched on every step. Dispatching is keyed and
-    idempotent, so this costs one dict lookup per frame in the window and
-    means the handful of frames already in flight when the search locks onto a
-    band get read on the pool rather than one at a time.
-    """
-    lookahead = max(MIN_LOOKAHEAD, LOOKAHEAD_PER_WORKER * reader.workers)
-    window: deque[tuple[int, float, Path]] = deque()
-    numbered = enumerate(frames)
-
-    def top_up() -> None:
-        while len(window) < lookahead:
-            item = next(numbered, None)
-            if item is None:
-                break
-            index, (timestamp, frame) = item
-            window.append((index, timestamp, frame))
-        for index, _timestamp, frame in window:
-            for region in search.regions_for(index):
-                reader.dispatch(index, frame, region)
-
-    top_up()
-    while window:
-        current = window.popleft()
-        yield current
-        reader.retire(current[0])
-        top_up()
-
-
-def _prepared_crops(frame: Path, region: Region, work: Path) -> Iterator[Path]:
-    """Yield OCR-ready renderings of one band: upscaled greyscale, and the same
-    crop hard-thresholded.
-
-    Overlay text is light on dark, which Otsu handles badly when the crop also
-    catches a bright crowd; a fixed threshold recovers the name in exactly the
-    frames the grey pass garbles. Both are written to the recognizer's own temp
-    dir rather than beside the frame, because the frame directory is a cache
-    other recognizers iterate.
-    """
-    try:
-        from PIL import Image, ImageOps  # required by the OCR extra
-    except ImportError as exc:  # pragma: no cover - exercised via the contract test
-        # recognize() must degrade the cascade, not abort it, so a missing
-        # Pillow has to arrive as RecognizerUnavailable rather than ImportError.
-        raise RecognizerUnavailable("Pillow is required for scorebug OCR") from exc
-
-    # load() inside the context manager pulls the pixels into memory and lets
-    # the descriptor close immediately. This runs at least once per frame, so
-    # relying on garbage collection to release it leaks handles across a long
-    # media file and can exhaust the process limit.
-    with Image.open(frame) as opened:
-        opened.load()
-        img = opened.copy()
-    x, y, w, h = region
-    box = (
-        max(0, int(x * img.width)),
-        max(0, int(y * img.height)),
-        min(img.width, int((x + w) * img.width)),
-        min(img.height, int((y + h) * img.height)),
-    )
-    if box[2] <= box[0] or box[3] <= box[1]:
-        return
-    crop = img.crop(box).convert("L")
-    scale = min(MAX_UPSCALE, max(1.0, TARGET_BAND_PX / max(1, crop.height)))
-    if scale > 1.0:
-        crop = crop.resize(
-            (int(crop.width * scale), int(crop.height * scale)), Image.LANCZOS
-        )
-    crop = ImageOps.autocontrast(crop)
-
-    grey = work / "band-grey.png"
-    crop.save(grey)
-    yield grey
-
-    binary = work / "band-bin.png"
-    crop.point(lambda p: 255 if p > BINARY_THRESHOLD else 0).save(binary)
-    yield binary
 
 
 def _cluster_graphics(
@@ -842,6 +533,10 @@ def _fold(text: str) -> str:
     whichever it feels like; folding both to ASCII makes them one string. The
     structure (the lineup digit, the `P:` marker) has to survive, so this is
     the form the field patterns run against.
+
+    Latin-specific, and deliberately not shared with the reader: decomposing
+    and dropping combining marks is right for Nuñez and wrong for Cyrillic,
+    where it would fold Russian's short i onto a plain i.
     """
     folded = unicodedata.normalize("NFKD", text)
     folded = "".join(c for c in folded if not unicodedata.combining(c))
@@ -852,42 +547,3 @@ def _upper(text: str) -> str:
     """Fold to letters and spaces only: the form roster names are keyed by."""
     kept = [c if (c.isalpha() and c.isascii()) or c in " '-" else " " for c in _fold(text)]
     return " ".join("".join(kept).split())
-
-
-def collapse_sightings(
-    sightings: list[tuple[float, str, float]],
-    source: str,
-    event: str,
-    frame_gap: float,
-) -> list[Cue]:
-    """Collapse per-frame (t, player_id, confidence) hits into per-run cues.
-
-    Shared by every frame-sampling recognizer (scorebug, jersey, face).
-    A run of consecutive sightings of one player becomes one cue spanning
-    first..last sighting (extended by one frame interval so a single-frame
-    sighting still has nonzero duration); confidence is the run's max.
-    """
-    runs: dict[str, list[tuple[float, float, float, float]]] = {}
-    for t, pid, conf in sorted(sightings):
-        pruns = runs.setdefault(pid, [])
-        if pruns and t - pruns[-1][1] <= frame_gap + RUN_GAP_S:
-            s, _, c, first = pruns[-1]
-            pruns[-1] = (s, t, max(c, conf), first)
-        else:
-            pruns.append((t, t, conf, t))
-
-    cues = []
-    for pid, pruns in runs.items():
-        for start, end, conf, _ in pruns:
-            cues.append(
-                Cue(
-                    source=source,
-                    start_s=start,
-                    end_s=end + frame_gap,
-                    event=event,
-                    entity_ids=(pid,),
-                    confidence=round(conf, 4),
-                )
-            )
-    cues.sort(key=lambda c: (c.start_s, c.entity_ids))
-    return cues

--- a/annotator/dirstral_annotator/recognizers/scorebug.py
+++ b/annotator/dirstral_annotator/recognizers/scorebug.py
@@ -296,6 +296,7 @@ class ScorebugRecognizer:
         self.crop = self.reader.crop
         self.regions = self.reader.regions
         self.workers = self.reader.workers
+        self.lang = self.reader.lang
         self._index = _name_index(roster)
 
     def recognize(self, media_path: Path) -> list[Cue]:

--- a/annotator/tests/test_overlay.py
+++ b/annotator/tests/test_overlay.py
@@ -113,7 +113,7 @@ def test_the_reader_keeps_every_preprocessing_pass(monkeypatch, tmp_path):
     )
     passes = iter(["grey read", "binarised read"])
     reader = OverlayReader(ocr=lambda p: next(passes), crop=WHOLE, workers=1)
-    assert list(reader.read_text(MEDIA))[0].texts == ("grey read", "binarised read")
+    assert next(iter(reader.read_text(MEDIA))).texts == ("grey read", "binarised read")
 
 
 def test_best_is_the_longest_pass():
@@ -321,6 +321,17 @@ def test_the_page_segmentation_mode_is_a_parameter(
     overlay.default_ocr()(jpeg)
     overlay.default_ocr(psm=overlay.OCR_PSM)(jpeg)
     assert [call["config"] for call in fake_tesseract.calls] == ["", "--psm 6"]
+
+
+def test_a_reader_reports_the_language_it_settled_on(monkeypatch):
+    """Resolved, not echoed: a caller inspecting the reader should see what it
+    will actually OCR in, whether that came from the argument or the
+    environment."""
+    monkeypatch.setenv(overlay.LANG_ENV, "rus")
+    assert OverlayReader(ocr=lambda p: "").lang == "rus"
+    assert OverlayReader(ocr=lambda p: "", lang="eng").lang == "eng"
+    monkeypatch.delenv(overlay.LANG_ENV)
+    assert OverlayReader(ocr=lambda p: "").lang is None
 
 
 def test_a_missing_engine_degrades_instead_of_aborting(monkeypatch):

--- a/annotator/tests/test_overlay.py
+++ b/annotator/tests/test_overlay.py
@@ -1,0 +1,369 @@
+"""The generic overlay-text reader: what it must do for any corpus.
+
+Everything here is language- and sport-free on purpose. The reader's whole
+claim is that finding burned-in text and getting a clean string out of it is
+one capability, separable from what the string means, so these tests pin the
+capability and never the interpretation. The pilot corpus is an English
+baseball broadcast and the second is Russian news; neither may show up here as
+an assumption.
+
+Backend-free except where a test is explicitly about Pillow or pytesseract, in
+which case the module is faked.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+import threading
+from concurrent.futures import Future
+from pathlib import Path
+
+import pytest
+
+from dirstral_annotator.recognizers import overlay
+from dirstral_annotator.recognizers.base import RecognizerUnavailable
+from dirstral_annotator.recognizers.overlay import (
+    OverlayRead,
+    OverlayReader,
+    _RegionSearch,
+    any_text,
+    map_in_order,
+)
+
+MEDIA = "broadcast.mp4"
+WHOLE = (0.0, 0.0, 1.0, 1.0)
+# Two bands of a hypothetical frame, named for what a caller would find there.
+BACKGROUND = (0.00, 0.00, 1.00, 0.20)
+BADGE = (0.00, 0.80, 1.00, 0.20)
+
+
+# --- region search ---------------------------------------------------------
+
+def test_search_sweeps_on_a_stride_then_locks():
+    regions = (("a",), ("b",))
+    search = _RegionSearch(regions)  # type: ignore[arg-type]
+    assert search.regions_for(0) == regions
+    assert search.regions_for(1) == ()
+    for _ in range(overlay.LOCK_AFTER_READS):
+        search.record(regions[1], hits=1)
+    assert search.regions_for(0) == (regions[1],)
+
+
+def test_a_single_region_is_locked_from_the_start():
+    search = _RegionSearch((("only",),))  # type: ignore[arg-type]
+    assert search.regions_for(1) == (("only",),)
+
+
+def test_lock_releases_when_the_overlay_moves():
+    regions = (("a",), ("b",))
+    search = _RegionSearch(regions)  # type: ignore[arg-type]
+    for _ in range(overlay.LOCK_AFTER_READS):
+        search.record(regions[0], hits=1)
+    for _ in range(_RegionSearch.RELEASE_AFTER_MISSES):
+        search.record(regions[0], hits=0)
+    assert search.regions_for(0) == regions
+
+
+# --- the reader yields text and nothing else -------------------------------
+
+@pytest.fixture
+def bands(monkeypatch, tmp_path):
+    """Drive the reader off a per-band script, without images or an engine.
+
+    `install({region: text, ...}, frames=n)` makes every sampled frame answer
+    with that text for that band, which is the shape a real overlay has: one
+    band holds the graphic, the others hold whatever was behind it.
+    """
+
+    def install(script, frames=24, fps=0.5):
+        listing = []
+        for i in range(frames):
+            path = tmp_path / f"frame-{i:05d}.jpg"
+            path.write_text(str(i))
+            listing.append((i / fps, path))
+        monkeypatch.setattr(overlay, "iter_frames", lambda *a, **k: iter(listing))
+        monkeypatch.setattr(
+            overlay,
+            "read_band",
+            lambda ocr, frame, region, work: [script.get(tuple(region), "")],
+        )
+        return listing
+
+    return install
+
+
+def test_a_read_carries_the_text_its_time_and_its_place(bands):
+    bands({WHOLE: "SEGMENT TITLE"}, frames=3)
+    reads = list(OverlayReader(ocr=lambda p: "", crop=WHOLE, workers=1).read_text(MEDIA))
+    assert [r.timestamp_s for r in reads] == [0.0, 2.0, 4.0]
+    assert {r.region for r in reads} == {WHOLE}
+    assert all(r.texts == ("SEGMENT TITLE",) for r in reads)
+    assert reads[0].index == 0
+
+
+def test_the_reader_keeps_every_preprocessing_pass(monkeypatch, tmp_path):
+    """Both passes reach the caller, in order and undeduplicated: which one is
+    right depends on the frame, and only the caller can decide."""
+    frame = tmp_path / "frame-00000.jpg"
+    frame.write_text("x")
+    monkeypatch.setattr(overlay, "iter_frames", lambda *a, **k: iter([(0.0, frame)]))
+    monkeypatch.setattr(
+        overlay, "_prepared_crops", lambda frame, region, work: iter([frame, frame])
+    )
+    passes = iter(["grey read", "binarised read"])
+    reader = OverlayReader(ocr=lambda p: next(passes), crop=WHOLE, workers=1)
+    assert list(reader.read_text(MEDIA))[0].texts == ("grey read", "binarised read")
+
+
+def test_best_is_the_longest_pass():
+    assert OverlayRead(0, 0.0, WHOLE, ("21:3", "21:35 MCK")).best() == "21:35 MCK"
+    assert OverlayRead(0, 0.0, WHOLE, ()).best() == ""
+
+
+# --- the band lock runs on the caller's judgement --------------------------
+
+def test_the_default_interpreter_cannot_tell_an_overlay_from_a_shop_sign(bands):
+    """`any_text` locks onto the first band that returned anything, which for a
+    frame with text in the background is the wrong band. This is not a bug in
+    the default; it is why the hit count is a parameter."""
+    bands({BACKGROUND: "lorem ipsum dolor", BADGE: "21:35 MCK"})
+    reader = OverlayReader(
+        ocr=lambda p: "", regions=(BACKGROUND, BADGE), workers=1
+    )
+    assert {r.region for r in reader.read_text(MEDIA)} == {BACKGROUND}
+
+
+def test_a_caller_that_can_tell_them_apart_moves_the_lock(bands):
+    """The same footage, the same reader, one different callback: the search
+    now lands on the band that holds the graphic the caller came for.
+
+    This is the whole seam. A reader that scored bands itself would have to
+    guess what "useful" means, and on real footage guessing "not empty" is how
+    three hours of OCR ends up pointed at the crowd.
+    """
+    bands({BACKGROUND: "lorem ipsum dolor", BADGE: "21:35 MCK"})
+    reader = OverlayReader(ocr=lambda p: "", regions=(BACKGROUND, BADGE), workers=1)
+
+    def looks_like_a_clock(read):
+        text = read.best()
+        return text, sum(":" in part for part in text.split())
+
+    reads = [read for read, _ in reader.read(MEDIA, looks_like_a_clock)]
+    # Once locked, the reader pays for one crop, and it is the caller's.
+    assert {read.region for read in reads[-8:]} == {BADGE}
+
+
+def test_any_text_ignores_debris_but_keeps_a_word():
+    assert any_text(OverlayRead(0, 0.0, WHOLE, ("", " a ", "\n"))) == ((), 0)
+    kept, hits = any_text(OverlayRead(0, 0.0, WHOLE, ("21:35 MCK", "")))
+    assert kept == ("21:35 MCK",) and hits == 1
+
+
+# --- parallelism is invisible ----------------------------------------------
+
+def test_parallel_reading_matches_serial(bands):
+    bands({BACKGROUND: "", BADGE: "21:35 MCK"}, frames=60)
+    serial = list(OverlayReader(ocr=lambda p: "", regions=(BACKGROUND, BADGE),
+                                workers=1).read_text(MEDIA))
+    bands({BACKGROUND: "", BADGE: "21:35 MCK"}, frames=60)
+    parallel = list(OverlayReader(ocr=lambda p: "", regions=(BACKGROUND, BADGE),
+                                  workers=4).read_text(MEDIA))
+    assert serial == parallel and serial
+
+
+def test_a_worker_that_cannot_read_surfaces_as_unavailable(monkeypatch, tmp_path):
+    """A missing backend has to degrade the cascade, so it must arrive at the
+    caller as RecognizerUnavailable rather than as a broken pool."""
+    frame = tmp_path / "frame-00000.jpg"
+    frame.write_text("x")
+    monkeypatch.setattr(overlay, "iter_frames", lambda *a, **k: iter([(0.0, frame)] * 8))
+    monkeypatch.setattr(
+        overlay, "_prepared_crops", lambda frame, region, work: iter([frame])
+    )
+
+    def refuses(path):
+        raise RecognizerUnavailable("Pillow is required for overlay OCR")
+
+    with pytest.raises(RecognizerUnavailable):
+        list(OverlayReader(ocr=refuses, crop=WHOLE, workers=4).read_text(MEDIA))
+
+
+def test_reads_leave_the_calling_thread_under_the_readers_own_name(bands, monkeypatch):
+    bands({WHOLE: "text"}, frames=40)
+    seen: set[str] = set()
+    lock = threading.Lock()
+    real = overlay.read_band
+
+    def watched(ocr, frame, region, work):
+        with lock:
+            seen.add(threading.current_thread().name)
+        return real(ocr, frame, region, work)
+
+    monkeypatch.setattr(overlay, "read_band", watched)
+    reader = OverlayReader(ocr=lambda p: "", crop=WHOLE, workers=4, name="ticker")
+    list(reader.read_text(MEDIA))
+    assert len(seen) > 1, f"reads never left the calling thread: {seen}"
+    assert all(name.startswith("ticker") for name in seen), seen
+
+
+class _ReverseExecutor:
+    """Runs everything, but only hands back results in reverse submit order.
+
+    The worst case for any implementation that lets completion order reach the
+    caller: nothing runs until a result is awaited, and then the most recently
+    submitted task runs first.
+    """
+
+    def __init__(self):
+        self._queued: list[tuple[Future, object, tuple]] = []
+
+    def submit(self, fn, *args):
+        future: Future = Future()
+        self._queued.append((future, fn, args))
+        return future
+
+    def drain(self):
+        while self._queued:
+            future, fn, args = self._queued.pop()  # newest first
+            if future.set_running_or_notify_cancel():
+                future.set_result(fn(*args))
+
+
+def test_map_in_order_yields_input_order_whatever_finishes_first(monkeypatch):
+    pool = _ReverseExecutor()
+    original = Future.result
+
+    def result(self, timeout=None):
+        pool.drain()
+        return original(self, timeout)
+
+    monkeypatch.setattr(Future, "result", result)
+    items = [(f"key-{i}", i) for i in range(20)]
+    got = list(map_in_order(pool, lambda n: n * 2, items, lookahead=4))
+    assert got == [(f"key-{i}", i * 2) for i in range(20)]
+
+
+def test_the_lookahead_scales_with_the_pool_and_has_a_floor():
+    assert overlay.lookahead_for(1) == overlay.MIN_LOOKAHEAD
+    assert overlay.lookahead_for(8) == 8 * overlay.LOOKAHEAD_PER_WORKER
+
+
+# --- no language and no corpus baked in ------------------------------------
+
+def test_the_reader_imports_nothing_corpus_specific():
+    """Structural, because a docstring cannot be linted. The reader may know
+    about frames and OCR; it may not know about rosters, players or any one
+    recognizer, or the seam has leaked."""
+    tree = ast.parse(Path(overlay.__file__).read_text(encoding="utf-8"))
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module.split(".")[-1])
+        elif isinstance(node, ast.Import):
+            imported.update(alias.name.split(".")[0] for alias in node.names)
+    forbidden = {"scorebug", "jersey", "faces", "playbyplay", "roster", "model",
+                 "fusion"}
+    assert not (imported & forbidden), imported & forbidden
+
+
+class _FakeTesseract:
+    """Records what the adapter asked of the engine."""
+
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    def image_to_string(self, image, config="", lang=None):
+        self.calls.append({"config": config, "lang": lang})
+        return "text"
+
+
+@pytest.fixture
+def fake_tesseract(monkeypatch):
+    fake = _FakeTesseract()
+    monkeypatch.setitem(sys.modules, "pytesseract", fake)
+    return fake
+
+
+@pytest.fixture
+def jpeg(tmp_path):
+    pillow = pytest.importorskip("PIL.Image")
+    path = tmp_path / "frame-00000001.jpg"
+    pillow.new("RGB", (640, 360), (20, 20, 20)).save(path)
+    return path
+
+
+def test_the_ocr_language_is_a_parameter(monkeypatch, fake_tesseract, jpeg):
+    monkeypatch.delenv(overlay.LANG_ENV, raising=False)
+    overlay.default_ocr()(jpeg)
+    overlay.default_ocr(lang="rus")(jpeg)
+    overlay.default_ocr(lang="eng+rus")(jpeg)
+    assert [call["lang"] for call in fake_tesseract.calls] == [None, "rus", "eng+rus"]
+
+
+def test_the_ocr_language_can_come_from_the_environment(
+    monkeypatch, fake_tesseract, jpeg
+):
+    """So an operator can point the cascade at a corpus in another script
+    without a code change. An explicit argument still wins."""
+    monkeypatch.setenv(overlay.LANG_ENV, "rus")
+    overlay.default_ocr()(jpeg)
+    overlay.default_ocr(lang="eng")(jpeg)
+    assert [call["lang"] for call in fake_tesseract.calls] == ["rus", "eng"]
+    monkeypatch.setenv(overlay.LANG_ENV, "   ")
+    assert overlay.default_lang() is None
+
+
+def test_the_page_segmentation_mode_is_a_parameter(
+    monkeypatch, fake_tesseract, jpeg
+):
+    monkeypatch.delenv(overlay.LANG_ENV, raising=False)
+    overlay.default_ocr()(jpeg)
+    overlay.default_ocr(psm=overlay.OCR_PSM)(jpeg)
+    assert [call["config"] for call in fake_tesseract.calls] == ["", "--psm 6"]
+
+
+def test_a_missing_engine_degrades_instead_of_aborting(monkeypatch):
+    monkeypatch.setitem(sys.modules, "pytesseract", None)
+    with pytest.raises(RecognizerUnavailable):
+        overlay.default_ocr()
+
+
+# --- preprocessing ---------------------------------------------------------
+
+def test_both_passes_are_rendered_and_the_second_is_binary(jpeg, tmp_path):
+    """Light-on-dark text defeats Otsu, so a hard threshold runs as well as the
+    grey pass; on the pilot fixture 44 of 215 readable frames were readable
+    only after it."""
+    image = pytest.importorskip("PIL.Image")
+    crops = list(overlay._prepared_crops(jpeg, (0.0, 0.8, 1.0, 0.2), tmp_path))
+    assert len(crops) == 2 and all(p.exists() for p in crops)
+    with image.open(crops[0]) as grey:
+        # 360 * 0.2 = 72 rows, upscaled towards TARGET_BAND_PX and capped.
+        assert grey.height == 72 * int(overlay.MAX_UPSCALE)
+    with image.open(crops[1]) as binary:
+        # Nothing between the two extremes survived the threshold.
+        assert sum(binary.histogram()[1:255]) == 0
+
+
+def test_a_degenerate_region_renders_nothing(jpeg, tmp_path):
+    assert list(overlay._prepared_crops(jpeg, (0.0, 0.0, 0.0, 0.0), tmp_path)) == []
+
+
+def test_missing_pillow_degrades_the_cascade(monkeypatch, tmp_path):
+    """_prepared_crops must raise RecognizerUnavailable, not ImportError, so the
+    pipeline skips the recognizer instead of aborting the whole run."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def no_pil(name, *a, **kw):
+        if name == "PIL" or name.startswith("PIL."):
+            raise ImportError("No module named 'PIL'")
+        return real_import(name, *a, **kw)
+
+    monkeypatch.setattr(builtins, "__import__", no_pil)
+    frame = tmp_path / "frame-00000001.jpg"
+    frame.write_bytes(b"\xff\xd8\xff")
+    with pytest.raises(RecognizerUnavailable):
+        list(overlay._prepared_crops(frame, WHOLE, tmp_path))

--- a/annotator/tests/test_parallel_recognizers.py
+++ b/annotator/tests/test_parallel_recognizers.py
@@ -27,7 +27,7 @@ from concurrent.futures import Future
 
 import pytest
 
-from dirstral_annotator.recognizers import jersey, scorebug
+from dirstral_annotator.recognizers import jersey, overlay, scorebug
 from dirstral_annotator.recognizers.base import RecognizerUnavailable
 from dirstral_annotator.recognizers.jersey import JerseyRecognizer
 from dirstral_annotator.recognizers.scorebug import ScorebugRecognizer, default_workers
@@ -82,12 +82,14 @@ def frames(monkeypatch, tmp_path):
             path.write_text(text)
             listing.append((i / fps, path))
 
-        for module in (scorebug, jersey):
+        # The scorebug samples and preprocesses through the shared overlay
+        # reader; the jersey recognizer still does its own crop.
+        for module in (overlay, jersey):
             monkeypatch.setattr(module, "iter_frames", lambda *a, **k: iter(listing))
         # The real crop needs Pillow and a real JPEG; the fakes hand the OCR
         # callable the frame itself.
         monkeypatch.setattr(
-            scorebug, "_prepared_crops", lambda frame, region, work: iter([frame])
+            overlay, "_prepared_crops", lambda frame, region, work: iter([frame])
         )
         monkeypatch.setattr(jersey, "_crop", lambda frame, bbox, work: frame)
         return lambda frame: frame.read_text()
@@ -104,7 +106,7 @@ class _ReverseExecutor:
     recently submitted task runs first.
     """
 
-    def __init__(self, max_workers=None, thread_name_prefix=""):
+    def __init__(self, max_workers=None, thread_name_prefix="", *args, **kwargs):
         self._queued: list[tuple[Future, object, tuple, dict]] = []
 
     def submit(self, fn, *args, **kwargs):
@@ -141,10 +143,15 @@ def _watching(ocr):
 
 
 def _reverse_executor_factory(monkeypatch, module):
-    """Make `module` schedule on a reverse-completion pool."""
+    """Make `module` schedule on a reverse-completion pool.
+
+    The scorebug's pool lives in `overlay` now, the jersey's still in `jersey`,
+    so the module to patch differs; both look their factory up by module global
+    at construction time.
+    """
     pool = _ReverseExecutor()
 
-    def new_executor(workers):
+    def new_executor(workers, name="test"):
         return pool
 
     monkeypatch.setattr(module, "_new_executor", new_executor)
@@ -162,25 +169,25 @@ def _reverse_executor_factory(monkeypatch, module):
 # --- worker count ----------------------------------------------------------
 
 def test_worker_count_comes_from_the_environment(monkeypatch):
-    monkeypatch.setenv(scorebug.WORKERS_ENV, "3")
+    monkeypatch.setenv(overlay.WORKERS_ENV, "3")
     assert default_workers() == 3
 
 
 def test_one_worker_selects_the_serial_path(monkeypatch, tmp_path, roster, frames):
-    monkeypatch.setenv(scorebug.WORKERS_ENV, "1")
+    monkeypatch.setenv(overlay.WORKERS_ENV, "1")
     assert default_workers() == 1
     rec = ScorebugRecognizer(roster, ocr=frames(SCRIPT), crop=WHOLE)
     assert rec.workers == 1
-    assert isinstance(scorebug._reader(rec.ocr, tmp_path, rec.workers),
-                      scorebug._SerialReader)
-    assert isinstance(scorebug._reader(rec.ocr, tmp_path, 2), scorebug._PooledReader)
+    assert isinstance(overlay._reader(rec.ocr, tmp_path, rec.workers),
+                      overlay._SerialReader)
+    assert isinstance(overlay._reader(rec.ocr, tmp_path, 2), overlay._PooledReader)
 
 
 def test_recognizers_read_in_parallel_unless_told_otherwise(monkeypatch, roster, frames):
     """The pool is the default, not an opt-in: an unset environment on a
     multi-core host has to give more than one worker."""
-    monkeypatch.delenv(scorebug.WORKERS_ENV, raising=False)
-    monkeypatch.setattr(scorebug.os, "cpu_count", lambda: 16)
+    monkeypatch.delenv(overlay.WORKERS_ENV, raising=False)
+    monkeypatch.setattr(overlay.os, "cpu_count", lambda: 16)
     assert default_workers() > 1
     assert ScorebugRecognizer(roster, ocr=frames(SCRIPT)).workers > 1
     assert JerseyRecognizer(
@@ -192,21 +199,21 @@ def test_the_default_leaves_the_host_room_for_tesseracts_own_threads(monkeypatch
     """A worker is not one core's worth of work: tesseract runs four threads
     per page, so N workers put 4N threads on the machine. The default has to
     scale with the host and stay capped."""
-    monkeypatch.delenv(scorebug.WORKERS_ENV, raising=False)
+    monkeypatch.delenv(overlay.WORKERS_ENV, raising=False)
     for cores, expected in ((1, 1), (4, 1), (8, 2), (16, 4), (32, 8), (256, 8)):
-        monkeypatch.setattr(scorebug.os, "cpu_count", lambda cores=cores: cores)
+        monkeypatch.setattr(overlay.os, "cpu_count", lambda cores=cores: cores)
         assert default_workers() == expected, cores
     # cpu_count() is documented as possibly None.
-    monkeypatch.setattr(scorebug.os, "cpu_count", lambda: None)
+    monkeypatch.setattr(overlay.os, "cpu_count", lambda: None)
     assert default_workers() == 1
 
 
 def test_a_nonsense_worker_count_falls_back_to_the_host(monkeypatch):
     for junk in ("", "  ", "many", "0", "-4", "2.5"):
-        monkeypatch.setenv(scorebug.WORKERS_ENV, junk)
+        monkeypatch.setenv(overlay.WORKERS_ENV, junk)
         assert default_workers() >= 1
-    monkeypatch.delenv(scorebug.WORKERS_ENV)
-    assert 1 <= default_workers() <= scorebug.MAX_DEFAULT_WORKERS
+    monkeypatch.delenv(overlay.WORKERS_ENV)
+    assert 1 <= default_workers() <= overlay.MAX_DEFAULT_WORKERS
 
 
 # --- scorebug --------------------------------------------------------------
@@ -235,7 +242,7 @@ def test_scorebug_parallel_matches_serial_with_a_pinned_region(roster, frames):
 
 def test_scorebug_survives_reversed_completion_order(monkeypatch, roster, frames):
     serial = ScorebugRecognizer(roster, ocr=frames(SCRIPT), workers=1).recognize(MEDIA)
-    _reverse_executor_factory(monkeypatch, scorebug)
+    _reverse_executor_factory(monkeypatch, overlay)
     reversed_run = ScorebugRecognizer(
         roster, ocr=frames(SCRIPT), workers=WORKERS
     ).recognize(MEDIA)
@@ -250,7 +257,7 @@ def test_scorebug_parallel_matches_serial_across_a_lock_release(roster, frames):
     change under the pool. Getting that wrong is how a parallel run would
     quietly read the wrong crop and lock onto a different band.
     """
-    quiet = scorebug._RegionSearch.RELEASE_AFTER_MISSES + 10
+    quiet = overlay._RegionSearch.RELEASE_AFTER_MISSES + 10
     script = SCRIPT[:20] + ["Beir Lee GAS Pt atthe"] * quiet + SCRIPT[:20]
     serial = ScorebugRecognizer(roster, ocr=frames(script), workers=1)
     parallel = ScorebugRecognizer(roster, ocr=frames(script), workers=WORKERS)
@@ -263,8 +270,9 @@ def test_pooled_reader_reads_a_band_nobody_dispatched(roster, frames, tmp_path):
     depend on that: a band it was never handed is read on the spot."""
     ocr = frames(SCRIPT)
     frame = tmp_path / "frame-00000.jpg"
-    with scorebug._PooledReader(ocr, tmp_path, WORKERS) as reader:
-        names, pitches = reader.read(7, frame, WHOLE)
+    with overlay._PooledReader(ocr, tmp_path, WORKERS) as reader:
+        texts = reader.read(7, frame, WHOLE)
+    names, pitches = scorebug.parse_bands(texts)
     assert scorebug.NameRead("LILE", scorebug.BATTER) in names
     assert [p.speed for p in pitches] == []
 

--- a/annotator/tests/test_parallel_recognizers.py
+++ b/annotator/tests/test_parallel_recognizers.py
@@ -154,7 +154,7 @@ def _reverse_executor_factory(monkeypatch, module):
     def new_executor(workers, name="test"):
         return pool
 
-    monkeypatch.setattr(module, "_new_executor", new_executor)
+    monkeypatch.setattr(module, "new_executor", new_executor)
 
     original = Future.result
 

--- a/annotator/tests/test_scorebug.py
+++ b/annotator/tests/test_scorebug.py
@@ -1,4 +1,8 @@
-"""Scorebug overlay parsing, roster matching and cue shape.
+"""Scorebug interpretation: overlay parsing, roster matching and cue shape.
+
+This is the baseball half of the seam. The reading half (region search,
+preprocessing, the pool, the OCR adapter) is generic and lives in
+`test_overlay.py`; what is pinned here is what the strings *mean*.
 
 Backend-free: no tesseract, no Pillow, no video. The OCR strings below are
 verbatim tesseract output from the pilot fixture (a Nationals at Giants
@@ -11,8 +15,9 @@ import sys
 
 import pytest
 
-from dirstral_annotator.recognizers import scorebug
+from dirstral_annotator.recognizers import overlay, scorebug
 from dirstral_annotator.recognizers.base import RecognizerUnavailable
+from dirstral_annotator.recognizers.overlay import OverlayRead
 from dirstral_annotator.recognizers.scorebug import (
     BATTER,
     LOOSE,
@@ -20,8 +25,8 @@ from dirstral_annotator.recognizers.scorebug import (
     UNKNOWN,
     ScorebugRecognizer,
     _name_index,
-    _RegionSearch,
     match_name,
+    parse_bands,
     parse_overlay,
 )
 from dirstral_annotator.roster import Roster
@@ -111,6 +116,25 @@ def test_bare_words_are_kept_only_alongside_structure():
     assert scorebug.NameRead("SEYMOUR", UNKNOWN) in names
 
 
+def test_both_preprocessing_passes_are_merged_not_chosen_between():
+    """Neither pass is reliably better, so the union of the two is kept: 44 of
+    215 readable pilot frames were readable only after thresholding."""
+    names, pitches = parse_bands([
+        "5.LILE 1-2 RAY P: 87",          # the grey pass lost the pitch graphic
+        "5.LILE 1-2 SLIDER 88 MPH",      # the binarised pass lost the pitcher
+    ])
+    assert scorebug.NameRead("LILE", BATTER) in names
+    assert scorebug.NameRead("RAY", PITCHER) in names
+    assert [(p.pitch_type, p.speed) for p in pitches] == [("SLIDER", 88)]
+    # A name both passes agree on is one read, not two.
+    assert [n for n in names if n.name == "LILE"] == [scorebug.NameRead("LILE", BATTER)]
+
+
+def test_a_speed_read_twice_keeps_the_fuller_description():
+    _, pitches = parse_bands(["SLIDER 88", "SLIDER 88 MPH"])
+    assert [p.describe() for p in pitches] == ["SLIDER 88 MPH"]
+
+
 # --- roster matching -------------------------------------------------------
 
 def test_exact_surname_matches(index):
@@ -144,31 +168,34 @@ def test_a_shared_surname_resolves_to_nobody(index):
     assert match_name(index, "SMITH") is None
 
 
-# --- region search ---------------------------------------------------------
+# --- the evidence handed back to the band search ---------------------------
 
-def test_search_sweeps_on_a_stride_then_locks():
-    regions = (("a",), ("b",))
-    search = _RegionSearch(regions)  # type: ignore[arg-type]
-    assert search.regions_for(0) == regions
-    assert search.regions_for(1) == ()
-    for _ in range(scorebug.LOCK_AFTER_READS):
-        search.record(regions[1], hits=1)
-    assert search.regions_for(0) == (regions[1],)
+def _hits(roster, text):
+    rec = ScorebugRecognizer(roster, ocr=lambda p: "", crop=WHOLE)
+    _, hits = rec._interpret(OverlayRead(0, 0.0, WHOLE, (text,)))
+    return hits
 
 
-def test_a_single_region_is_locked_from_the_start():
-    search = _RegionSearch((("only",),))  # type: ignore[arg-type]
-    assert search.regions_for(1) == (("only",),)
+def test_only_roster_reads_off_a_structured_line_count_as_evidence(roster):
+    """The reader locks its band search on this number, and the number is the
+    reason the search lands on the bug rather than on the stands. "The OCR
+    returned something" would not do: crowd texture returns plenty."""
+    assert _hits(roster, "5.LILE 1-2 RAY P: 87") == 2  # batter and pitcher
+    assert _hits(roster, "5.LILE 1-2 SLIDER 88 MPH") == 2  # batter and a graphic
 
 
-def test_lock_releases_when_the_bug_moves():
-    regions = (("a",), ("b",))
-    search = _RegionSearch(regions)  # type: ignore[arg-type]
-    for _ in range(scorebug.LOCK_AFTER_READS):
-        search.record(regions[0], hits=1)
-    for _ in range(_RegionSearch.RELEASE_AFTER_MISSES):
-        search.record(regions[0], hits=0)
-    assert search.regions_for(0) == regions
+def test_crowd_texture_is_worth_nothing_to_the_band_search(roster):
+    # Verbatim from a replay: plenty of text, one word of it a real surname.
+    noise = "Beir Lee GAS Pt atthe gL) TAT eM we PA) a pik wee Se bh"
+    fields, hits = ScorebugRecognizer(
+        roster, ocr=lambda p: "", crop=WHOLE
+    )._interpret(OverlayRead(0, 0.0, WHOLE, (noise,)))
+    assert hits == 0, "a loose read must never vote for a band"
+    assert [role for _, _, role in fields.names] == [LOOSE]
+
+
+def test_a_name_nobody_on_the_roster_shares_is_worth_nothing(roster):
+    assert _hits(roster, "5.BONDS 1-2 MAYS P: 87") == 0
 
 
 # --- recognizer ------------------------------------------------------------
@@ -184,11 +211,13 @@ def fake_frames(monkeypatch, tmp_path):
             path.write_text(text)
             frames.append((i / fps, path))
 
-        monkeypatch.setattr(scorebug, "iter_frames", lambda *a, **k: iter(frames))
+        # Frame sampling and preprocessing belong to the reader now, so the
+        # fakes are installed there.
+        monkeypatch.setattr(overlay, "iter_frames", lambda *a, **k: iter(frames))
         # The real crop needs Pillow and a real JPEG; the fake hands the OCR
         # callable the frame itself, once per preprocessing pass.
         monkeypatch.setattr(
-            scorebug, "_prepared_crops", lambda frame, region, work: iter([frame])
+            overlay, "_prepared_crops", lambda frame, region, work: iter([frame])
         )
         return lambda frame: frame.read_text()
 
@@ -285,22 +314,11 @@ def test_velocity_branch_rejects_implausible_speeds():
         assert bad == [], f"accepted implausible speed: {line} -> {bad}"
 
 
-def test_missing_pillow_degrades_the_cascade(monkeypatch, tmp_path):
-    """_prepared_crops must raise RecognizerUnavailable, not ImportError, so the
-    pipeline skips this recognizer instead of aborting the whole run."""
-    import builtins
-    from dirstral_annotator.recognizers import scorebug as sb
-    from dirstral_annotator.recognizers.base import RecognizerUnavailable
-
-    real_import = builtins.__import__
-
-    def no_pil(name, *a, **kw):
-        if name == "PIL" or name.startswith("PIL."):
-            raise ImportError("No module named 'PIL'")
-        return real_import(name, *a, **kw)
-
-    monkeypatch.setattr(builtins, "__import__", no_pil)
-    frame = tmp_path / "frame-00000001.jpg"
-    frame.write_bytes(b"\xff\xd8\xff")
-    with pytest.raises(RecognizerUnavailable):
-        list(sb._prepared_crops(frame, (0.0, 0.0, 1.0, 1.0), tmp_path))
+def test_the_names_other_modules_import_from_here_still_resolve():
+    """`collapse_sightings`, `OcrFn` and `default_ocr` moved to `base` and
+    `overlay` with the split; jersey, faces and callers outside the package
+    have always imported them from here."""
+    assert scorebug.collapse_sightings is not None
+    assert scorebug.default_ocr is overlay.default_ocr
+    assert scorebug.default_workers is overlay.default_workers
+    assert scorebug.OcrFn is overlay.OcrFn

--- a/annotator/tests/test_scorebug.py
+++ b/annotator/tests/test_scorebug.py
@@ -15,7 +15,7 @@ import sys
 
 import pytest
 
-from dirstral_annotator.recognizers import overlay, scorebug
+from dirstral_annotator.recognizers import base, overlay, scorebug
 from dirstral_annotator.recognizers.base import RecognizerUnavailable
 from dirstral_annotator.recognizers.overlay import OverlayRead
 from dirstral_annotator.recognizers.scorebug import (
@@ -318,7 +318,7 @@ def test_the_names_other_modules_import_from_here_still_resolve():
     """`collapse_sightings`, `OcrFn` and `default_ocr` moved to `base` and
     `overlay` with the split; jersey, faces and callers outside the package
     have always imported them from here."""
-    assert scorebug.collapse_sightings is not None
+    assert scorebug.collapse_sightings is base.collapse_sightings
     assert scorebug.default_ocr is overlay.default_ocr
     assert scorebug.default_workers is overlay.default_workers
     assert scorebug.OcrFn is overlay.OcrFn


### PR DESCRIPTION
Milestone 2 of #741: split `ScorebugRecognizer` into a reusable overlay-text
reader and a baseball-specific interpreter.

## Why here

The pilot's win was never "identify baseball players". It was: find the few
percent of the frame that holds burned-in text, survive light-on-dark, and get
a clean string out of it, at a speed that lets you do it to a three hour
broadcast. That transfers. Matching the result against a roster does not, which
the second-corpus survey in #741 made concrete: TV Rain's overlays carry
headline banners, tickers, segment titles and a burned-in clock badge, and no
speaker plate at all.

## What moved

New `recognizers/overlay.py`:

- `_RegionSearch`: strided candidate sweeps, lock after N reads, release after
  misses.
- `_prepared_crops`: upscale, greyscale, and a hard-thresholded second pass.
- The OCR adapter (`OcrFn`, `default_ocr`, PSM handling), with **language as a
  parameter**, defaulting to `DIRSTRAL_ANNOTATOR_OCR_LANG` and then to the
  engine's own default. No script is hardcoded anywhere.
- The reader pool: worker derivation, lookahead, speculative dispatch,
  deterministic ordering, plus `map_in_order` for per-frame work that carries
  no sequential state.
- `WIDE_REGIONS`, full-width bands for ticker-style overlays. Not in the
  default sweep, so nothing about the pilot's band search changes.

`scorebug.py` keeps only the interpretation: `_LINEUP_RE`, `_PITCH_COUNT_RE`,
`_VELOCITY_RE`, `PITCH_TYPES`, `PLAUSIBLE_SPEED`, `NameRead`/`PitchRead`,
roster matching, cue construction. `jersey.py` drops its duplicated
workspaces, executor factory, lookahead constants and window loop for the
shared ones. `collapse_sightings` moves to `base.py`, so `faces.py` no longer
imports a sport to get it; `scorebug.collapse_sightings`, `scorebug.OcrFn` and
`scorebug.default_ocr` still resolve, and a test pins that.

Latin-specific accent folding (`_fold`) deliberately stayed in `scorebug.py`.
NFKD plus combining-mark stripping is right for Nuñez and wrong for Cyrillic,
where it folds Russian's short i onto a plain i.

## Where the proposed seam was wrong

The brief asked for a reader that "yields text and nothing else". It cannot,
and the reason is the reason precision went from 0.541 to 0.991.

The band lock is fed by a hit count, and in the pilot that count is *roster
resolved structured reads*, not "the OCR returned something". A crop of crowd
texture returns pages of three-letter words. A reader that locked on non-empty
text would lock onto the stands and OCR them for three hours.

So `OverlayReader.read(media, interpret)` takes the caller's interpretation and
takes back `(value, hits)`. `read_text(media)` is the pure shape the brief
asked for, and uses a deliberately weak default (`any_text`) that is documented
as weak. Two tests pin the difference: with `any_text` the reader locks onto a
band holding background text, and with a caller-supplied scorer, on the same
footage and the same reader, the lock moves to the band holding the graphic.

## Measured, not argued

Real footage, real tesseract, four labelled plate appearances, sha256 over the
serialised cues:

| run | digest | cues | elapsed |
|---|---|---|---|
| pre-split, serial | `f76ad03c…40b0c` | 25 | 80.3s |
| post-split, serial | `f76ad03c…40b0c` | 25 | 79.8s |
| post-split, 4 workers | `f76ad03c…40b0c` | 25 | 49.1s |

Byte-identical. The worker default is untouched: `cpu_count // 4`, capped at 8,
with the OpenMP reasoning kept verbatim in the constant's comment.

## The reader on a corpus it was never built for

Streamed over `rclone serve http`, 90 seconds of TV Rain news, `lang="rus"`,
`regions=WIDE_REGIONS`, no roster and nothing baseball imported:

```
    0.0s  region=(0.0, 0.78, 1.0, 0.22)  «ЯНДЕКС» ОШТРАФОВАЛИ ЗА ОТКАЗ ПРЕДОСТАВИТЬ ФСБ ДОСТУП К «АЛИСЕ»
    8.0s  region=(0.0, 0.78, 1.0, 0.22)  «ЯНДЕКС» ОШТРАФОВАЛИ ЗА ОТКАЗ ПРЕДОСТАВИТЬ ФСБ ДОСТУП К «АЛИСЕ»
   16.0s  …
   34.0s  … (strided sweep to 32s, then locked and reading every frame)
```

Serial and 4-worker output are byte-identical here too (sha256 over the dump),
at 2.35x.

Two findings worth recording:

- The **clock badge reads only off the thresholded pass**. On `news_1500.jpg`
  the grey pass returns nothing and the threshold pass returns `10:25 МСК`.
  That is the pilot's 44-of-215 finding reproducing on a different broadcaster,
  a different language and a different graphics package, which is the best
  evidence that preprocessing belongs in the generic half.
- The **wrong language is worse than no reading**. The same frame under `eng`
  comes back as `CAHQEKC» OLITPADOBANIM 3A OTKAS…`: confident Latin
  lookalikes, not an empty read. A downstream consumer cannot tell that apart
  from a real string, which is why language is a parameter and not a guess.

Also observed, for milestone 3 rather than this PR: TV Rain's poll panel and
ticker are **dark-on-light**, the opposite of the `BINARY_THRESHOLD` assumption.
The headline banner and clock badge are light-on-dark and read fine. An
inverted third pass is the obvious follow-up, but it costs a third OCR per
band and would change the pilot's timings, so it is not in this PR.

## Gates

- `python -m pytest tests/ -q`: 152 passed (129 before; 1 skip is the
  pre-existing `dirstral-spec` submodule schema test, not checked out in this
  worktree).
- `ruff check --select E701,E702,F dirstral_annotator tests`: clean.
- `dirstral-spec` submodule pin untouched. No `eval/` or Go code touched.

Refs #741.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reusable OCR processing for video overlays, including region detection, preprocessing, timestamped results, and configurable languages.
  * Added support for caller-defined interpretation and evidence scoring of OCR results.
  * Improved jersey and scorebug recognition with shared overlay processing and broader language support.
  * Recognition now consolidates intermittent detections into continuous, duration-based cues.

* **Documentation**
  * Added guidance for using the overlay OCR reader, interpreting results, and supporting non-Latin scripts.

* **Bug Fixes**
  * Improved OCR parsing, duplicate-name handling, pitch description retention, and recognition consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->