### PR TITLE
feat(annotator): derive a wall-clock anchor from a burned-in clock badge (#741 milestone 3)

### DIFF
--- a/annotator/README.md
+++ b/annotator/README.md
@@ -56,6 +56,42 @@ DIRSTRAL_ANNOTATOR_OCR_LANG=rus dirstral-annotate serve …   # or lang="rus"
 Non-Latin scripts need the matching tesseract traineddata installed
 (`brew install tesseract-lang`, `apt install tesseract-ocr-rus`).
 
+### The burned-in clock reader
+
+`recognizers/clock.py` is one consumer of that reader, and the one that pays
+for itself fastest on an archive: a video timestamp is only citable once
+something says what wall-clock instant it was, and a news broadcast burns that
+into the corner of the frame.
+
+```python
+from dirstral_annotator.recognizers.clock import ClockReader
+
+reader = ClockReader(zones={"MSK": "Europe/Moscow"}, anchor_date=date(2025, 8, 20))
+anchor = reader.anchor(Path("broadcast.mp4"))   # None when there is no badge
+anchor.wall_clock_at(1830.0)                    # aware datetime of video 00:30:30
+```
+
+What it will not do is guess. The zone table is required (a badge label the
+caller has not named is not a reading), the date is required for an epoch (a
+badge shows a time of day and no date), a single reading is never an anchor,
+and readings that imply two different anchors are reported as two segments
+rather than averaged into one that is wrong for both.
+
+Two settings are measured rather than stylistic, and both differ from the
+scorebug's:
+
+- **psm 11, not 6.** A badge is an island of text in an empty corner, not a
+  dense strip. On sample footage psm 6 never read the badge at any crop size;
+  psm 11 read it.
+- **The OCR language changes the digits.** On the same pixels, a badge showing
+  `21:35` read as `21:35` under `eng` and as `21:55` under `rus`. Neither
+  reading is detectably wrong on its own, and a 20 minute error in an anchor is
+  inherited by every citation under it. Do not hand the clock reader the
+  language you use for the prose overlays without checking it against a frame,
+  and list the zone label the way your OCR actually renders it (a Latin-script
+  model returns `MCK` for Cyrillic `МСК`, so a Russian corpus may want both
+  spellings in the table).
+
 ## Run the backend
 
 ```bash

--- a/annotator/README.md
+++ b/annotator/README.md
@@ -64,11 +64,15 @@ something says what wall-clock instant it was, and a news broadcast burns that
 into the corner of the frame.
 
 ```python
+from datetime import date
+from pathlib import Path
+
 from dirstral_annotator.recognizers.clock import ClockReader
 
 reader = ClockReader(zones={"MSK": "Europe/Moscow"}, anchor_date=date(2025, 8, 20))
 anchor = reader.anchor(Path("broadcast.mp4"))   # None when there is no badge
-anchor.wall_clock_at(1830.0)                    # aware datetime of video 00:30:30
+if anchor is not None:
+    anchor.wall_clock_at(1830.0)                # aware datetime of video 00:30:30
 ```
 
 What it will not do is guess. The zone table is required (a badge label the
@@ -85,7 +89,7 @@ scorebug's:
   psm 11 read it.
 - **The OCR language changes the digits.** On the same pixels, a badge showing
   `21:35` read as `21:35` under `eng` and as `21:55` under `rus`. Neither
-  reading is detectably wrong on its own, and a 20 minute error in an anchor is
+  reading is detectably wrong on its own, and a 20-minute error in an anchor is
   inherited by every citation under it. Do not hand the clock reader the
   language you use for the prose overlays without checking it against a frame,
   and list the zone label the way your OCR actually renders it (a Latin-script

--- a/annotator/dirstral_annotator/recognizers/clock.py
+++ b/annotator/dirstral_annotator/recognizers/clock.py
@@ -1,0 +1,697 @@
+"""Burned-in clock reader: turn a broadcast's own clock badge into a wall-clock
+anchor for the file.
+
+Every citation an archive can make is relative to a video timestamp, and a
+video timestamp means nothing on its own: "at 00:42:10" is only useful once
+something says what wall-clock instant 00:42:10 was. Deriving that anchor is
+normally manual and expensive. For the baseball pilot it took a scorebug
+transition cross-referenced against a structured feed, repeated at the other
+end of the file to check for drift, and it was only possible because a feed
+existed at all.
+
+Broadcast news does not need the feed. It burns the clock into the frame, so
+the anchor is written on the picture: read `21:35 MSK` at video t=300 and the
+file started at 21:30 local. This module reads that badge off the generic
+overlay reader in `overlay.py` and turns a run of readings into an anchor.
+
+Four things make that harder than parsing a string, and all four are why this
+is a module rather than a regex:
+
+1. **A wrong anchor is worse than no anchor.** It is inherited by every
+   citation the file ever produces, silently. OCR on a frame where the badge is
+   absent or occluded returns confident nonsense, and on a frame where it is
+   present it still sometimes returns the wrong digit: on the sample used to
+   build this, one frame showing `21:35` read as `21:55`, which is a plausible
+   time, in the right format, with the right zone label, and twenty minutes
+   wrong. Nothing about that single reading is detectably bad. So no single
+   reading is ever trusted: readings are grouped by the anchor they imply and a
+   group has to reach `min_readings` before it is an anchor at all.
+
+2. **The badge shows minutes, so a reading is an interval, not a point.** A
+   badge reading `21:35` was displayed for the whole minute, so one reading
+   only says the anchor is somewhere in a 60 second window. That makes the
+   anchor an intersection of intervals rather than an average of points, which
+   is both more honest and much tighter: see `_intersect`. It also inverts what
+   spread means. Readings that all imply the same offset have sampled the same
+   phase of the minute and pin nothing; readings that disagree by 59 seconds
+   have bracketed the minute boundary and pin the anchor to a second. Spread is
+   information, not error, which is the opposite of the usual reading.
+
+3. **Long files are edited.** A recording is not always one continuous take,
+   and a cut moves the anchor for everything after it. Readings from the start
+   and the end of a file that do not agree are reported as separate segments
+   rather than averaged into one anchor that is wrong for both halves.
+
+4. **A zone label is data.** `MSK`, `ET`, `CET` are printed by the broadcaster
+   and mean nothing to a reader that does not know them, and guessing the
+   reader's own local zone is how an anchor ends up three hours out with no
+   evidence of it. The zone table is a required argument; a time whose label is
+   not in it is not a reading. The date is data too, and one the badge does not
+   carry: a badge gives a time of day, so an epoch needs a date from somewhere
+   else. Without one this returns the time-of-day anchor and declines to invent
+   an epoch. (The container's `creation_time` is not that date. On the sample
+   file it was the upload's timestamp, eleven hours off the badge.)
+
+Nothing here knows a corpus, a language or a broadcaster. The zone table, the
+OCR language, the candidate regions and the sampling rate are all arguments.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Iterator, Mapping
+from contextlib import closing
+from dataclasses import dataclass, field
+from datetime import date as Date
+from datetime import datetime, time, timedelta, timezone, tzinfo
+from pathlib import Path
+
+from .overlay import (
+    OcrFn,
+    OverlayRead,
+    OverlayReader,
+    Region,
+)
+
+__all__ = [
+    "CLOCK_PSM",
+    "CLOCK_REGIONS",
+    "ClockAnchor",
+    "ClockRead",
+    "ClockReader",
+    "ClockSegment",
+    "ParsedTime",
+    "parse_times",
+    "resolve_zones",
+]
+
+DAY_S = 86400
+MINUTE_S = 60
+
+# Candidate bands for a clock badge: the four corners, generously sized. A
+# badge is a few percent of the frame and every broadcaster puts it in a
+# corner, but not the same corner. These are deliberately small, and that is
+# load bearing rather than an optimisation: the same badge that reads cleanly
+# out of a corner box returns nothing at all out of `overlay.WIDE_REGIONS`,
+# because a wide band buries a two-word island in mostly-empty picture. The
+# reader's own band search picks whichever of these actually holds a clock and
+# then pays for one crop per frame.
+CLOCK_REGIONS: tuple[Region, ...] = (
+    (0.00, 0.00, 0.30, 0.14),  # upper left
+    (0.70, 0.00, 0.30, 0.14),  # upper right
+    (0.00, 0.86, 0.30, 0.14),  # lower left
+    (0.70, 0.86, 0.30, 0.14),  # lower right
+)
+
+# tesseract page-segmentation mode 11, "sparse text: find as much text as
+# possible in no particular order". Measured, and it is the difference between
+# reading the badge and not reading it: on the sample frames psm 6 (the
+# overlay reader's default, "one uniform block") returned only the fragment of
+# the LIVE flag next to the badge and never the time, under either preprocessing
+# pass, at every crop size tried. psm 6 is right for a dense strip like a
+# scorebug and wrong for an island of text in an otherwise empty corner.
+CLOCK_PSM = 11
+
+# How far either side of a time a zone label may sit and still be taken as
+# belonging to it. Wide enough for "21:35  MSK" with OCR's invented spaces,
+# narrow enough that a label somewhere else in the crop does not adopt an
+# unrelated number.
+ZONE_WINDOW = 10
+
+#: A group of readings has to be at least this large before it is an anchor.
+#: One confident misread is a group of one; the guard against it is corroboration
+#: and nothing else, because a single reading carries no evidence of its own
+#: correctness.
+MIN_READINGS = 3
+
+# Hours and minutes, with the separator OCR might have mangled (a colon comes
+# back as a dot or a semicolon often enough to be worth accepting), and optional
+# seconds for badges that show them. The lookarounds keep a longer digit run
+# from being read as a time: "12754" must not yield 12:75.
+_TIME_RE = re.compile(
+    r"(?<![0-9])([0-9]{1,2})\s*[:;.]\s*([0-9]{2})(?:\s*[:;.]\s*([0-9]{2}))?(?![0-9])"
+)
+# Everything that is not a letter or a digit is separator, so a zone label can
+# be recovered from whatever punctuation OCR sprayed around it.
+_NOT_WORD_RE = re.compile(r"[^\w]+", re.UNICODE)
+
+
+def resolve_zones(zones: Mapping[str, str | int | tzinfo]) -> dict[str, tzinfo]:
+    """Normalise a badge-label to timezone table into label -> tzinfo.
+
+    A value may be an IANA name ("Europe/Moscow"), a fixed offset in seconds
+    (10800), or a tzinfo. IANA names are resolved through `zoneinfo`, so a
+    zone with a DST history is applied correctly for the anchor's own date
+    rather than at today's offset; fixed offsets are for badges that name an
+    offset rather than a zone, and for hosts with no tz database.
+
+    Labels are matched case-insensitively and with punctuation stripped, so
+    "MSK", "msk" and "M.S.K" are one entry.
+    """
+    resolved: dict[str, tzinfo] = {}
+    for label, spec in zones.items():
+        key = _fold_label(label)
+        if not key:
+            raise ValueError(f"zone label is empty after folding: {label!r}")
+        resolved[key] = _as_tzinfo(spec, label)
+    return resolved
+
+
+def _as_tzinfo(spec: str | int | tzinfo, label: str) -> tzinfo:
+    if isinstance(spec, tzinfo):
+        return spec
+    if isinstance(spec, int):
+        return timezone(timedelta(seconds=spec))
+    try:
+        from zoneinfo import ZoneInfo
+    except ImportError as exc:  # pragma: no cover - zoneinfo is stdlib on 3.9+
+        raise ValueError(f"cannot resolve zone {spec!r} for {label!r}") from exc
+    try:
+        return ZoneInfo(spec)
+    except Exception as exc:
+        # A missing tz database is a configuration problem the caller has to
+        # see, not something to paper over with a guessed offset.
+        raise ValueError(
+            f"unknown timezone {spec!r} for badge label {label!r}: {exc}"
+        ) from exc
+
+
+def _fold_label(label: str) -> str:
+    return _NOT_WORD_RE.sub("", label).upper()
+
+
+@dataclass(frozen=True)
+class ParsedTime:
+    """One time of day found in one OCR string, with the zone it was labelled
+    with. Purely what the text said; nothing here has been corroborated."""
+
+    seconds_of_day: int
+    zone: str  # the folded label, as it keys the zone table
+
+    @property
+    def hour(self) -> int:
+        return self.seconds_of_day // 3600
+
+    @property
+    def minute(self) -> int:
+        return self.seconds_of_day // 60 % 60
+
+
+def parse_times(
+    text: str,
+    zones: Iterable[str],
+    default_zone: str | None = None,
+) -> list[ParsedTime]:
+    """Every plausible zone-labelled time of day in one OCR pass.
+
+    Plausible is doing real work: OCR of a corner that holds no badge returns
+    digits, and digits with a colon in them are not rare (a poll panel, a
+    duration, a score). Three things have to hold before a match is a reading.
+    The hour must be under 24 and the minute under 60, so `21:75` is debris.
+    The digits must not be part of a longer run, so `12754` is not `12:75`. And
+    a zone label the caller knows must sit next to it, which is the strongest of
+    the three, because it is the one piece of the badge that a stray number
+    cannot accidentally satisfy.
+
+    `default_zone` is for a broadcaster that prints an unlabelled clock; it is
+    an explicit statement by the caller about that corpus, never a fallback
+    this module chooses. With no default, an unlabelled time is not a reading.
+    """
+    known = {_fold_label(z) for z in zones}
+    default = _fold_label(default_zone) if default_zone else None
+    found: list[ParsedTime] = []
+    for match in _TIME_RE.finditer(text):
+        hour, minute = int(match.group(1)), int(match.group(2))
+        second = int(match.group(3) or 0)
+        if hour > 23 or minute > 59 or second > 59:
+            continue
+        zone = _zone_beside(text, match.start(), match.end(), known)
+        if zone is None:
+            if default is None:
+                continue
+            zone = default
+        found.append(
+            ParsedTime(seconds_of_day=hour * 3600 + minute * 60 + second, zone=zone)
+        )
+    return found
+
+
+def _zone_beside(text: str, start: int, end: int, known: set[str]) -> str | None:
+    """The zone label printed immediately after (or before) a time, if any.
+
+    Anchored to the time rather than searched for anywhere in the window: a
+    label has to be the next thing printed after the digits (or the last thing
+    before them) once punctuation and OCR's invented spaces are folded out.
+    A loose substring test would let a two-letter label like `ET` match inside
+    any word that happens to contain it.
+    """
+    after = _fold_label(text[end : end + ZONE_WINDOW])
+    before = _fold_label(text[max(0, start - ZONE_WINDOW) : start])
+    for label in sorted(known, key=len, reverse=True):
+        if label and (after.startswith(label) or before.endswith(label)):
+            return label
+    return None
+
+
+@dataclass(frozen=True)
+class ClockRead:
+    """One frame's accepted badge reading."""
+
+    timestamp_s: float  # video time this frame was sampled at
+    seconds_of_day: int  # what the badge said, in its own zone
+    zone: str
+    texts: tuple[str, ...] = ()  # the OCR passes it was reconciled from
+
+    @property
+    def implied_offset_s(self) -> float:
+        """Wall-clock second of the day that video t=0 fell on, per this frame.
+
+        Modulo a day, so a file that runs past midnight still yields one
+        consistent number.
+        """
+        return (self.seconds_of_day - self.timestamp_s) % DAY_S
+
+
+@dataclass(frozen=True)
+class ClockSegment:
+    """A run of readings that agree on one anchor, and the interval they pin it
+    to.
+
+    `lower_s` and `upper_s` bound the wall-clock second of the day that video
+    t=0 fell on. They are an intersection of every reading's own 60 second
+    window, so the segment is only as wide as the readings leave it, and they
+    are kept unwrapped (they may sit outside [0, 86400)) so the arithmetic
+    stays monotonic across midnight. `offset_s` is the midpoint, wrapped.
+    """
+
+    zone: str
+    lower_s: float
+    upper_s: float
+    first_s: float  # video time of the first reading in the segment
+    last_s: float
+    readings: tuple[ClockRead, ...] = field(default_factory=tuple)
+
+    @property
+    def offset_s(self) -> float:
+        """Best single estimate of the wall clock at video t=0, as a second of
+        the day."""
+        return ((self.lower_s + self.upper_s) / 2.0) % DAY_S
+
+    @property
+    def uncertainty_s(self) -> float:
+        """Half the width of the interval: the most this anchor can be out by."""
+        return (self.upper_s - self.lower_s) / 2.0
+
+    @property
+    def spread_s(self) -> float:
+        """How far apart the readings' implied offsets were.
+
+        The complement of the interval width, and the reason spread is worth
+        reporting: readings that disagree have sampled different phases of the
+        badge's minute and have bracketed it. Zero spread means every reading
+        landed on the same phase and the anchor is only known to a minute.
+        """
+        return MINUTE_S - (self.upper_s - self.lower_s)
+
+    @property
+    def count(self) -> int:
+        return len(self.readings)
+
+
+@dataclass(frozen=True)
+class ClockAnchor:
+    """What a file's clock badge established, and how firmly.
+
+    `segments` is every group of readings that agreed among themselves; more
+    than one means the readings do not describe a single continuous recording,
+    and the extras are reported rather than averaged away. `segment` is the
+    largest, and the one the epoch and the offsets come from.
+    """
+
+    segment: ClockSegment
+    segments: tuple[ClockSegment, ...]
+    zone_label: str
+    tz: tzinfo | None = None
+    anchor_date: Date | None = None
+    readings_total: int = 0  # accepted frame readings, before grouping
+    conflicts: int = 0  # frames whose OCR passes contradicted each other
+    bands_read: int = 0  # band crops the reader offered, locked or sweeping
+
+    @property
+    def offset_s(self) -> float:
+        return self.segment.offset_s
+
+    @property
+    def uncertainty_s(self) -> float:
+        return self.segment.uncertainty_s
+
+    @property
+    def spread_s(self) -> float:
+        return self.segment.spread_s
+
+    @property
+    def drifted(self) -> tuple[ClockSegment, ...]:
+        """Segments that describe a stretch of video this anchor does not.
+
+        A second anchor over video the first never covered is an edit: the
+        recording is not one continuous take, and citations after the cut
+        belong to a different wall clock. Reported, never averaged in.
+        """
+        return tuple(
+            segment
+            for segment in self.segments
+            if segment is not self.segment and not _overlapping(segment, self.segment)
+        )
+
+    @property
+    def contested(self) -> tuple[ClockSegment, ...]:
+        """Segments claiming a different anchor for video this one also covers.
+
+        Not an edit, and worth separating from one: no stretch of video has two
+        wall clocks, so a segment whose readings sit inside the anchor's own
+        span is a run of misreads that happened to agree. They do agree, often
+        enough to pass any corroboration count on their own; the measured case
+        was fourteen consecutive frames of a badge reading 21:40 that OCR'd as
+        23:30. Overlap in video time is what tells the two apart, and it costs
+        nothing to check.
+        """
+        return tuple(
+            segment
+            for segment in self.segments
+            if segment is not self.segment and _overlapping(segment, self.segment)
+        )
+
+    @property
+    def drift(self) -> bool:
+        """Does the file imply more than one anchor over more than one stretch?"""
+        return bool(self.drifted)
+
+    def segment_for(self, video_s: float) -> ClockSegment | None:
+        """The segment whose readings cover this video timestamp, if any.
+
+        For a file whose anchor moves part way through, this is how a consumer
+        cites the second half correctly rather than through the anchor derived
+        from the first. Outside every segment's span it returns None: nothing
+        was read there, and extrapolating across a cut is what produced the
+        wrong answer in the first place.
+        """
+        covering = [
+            segment
+            for segment in self.segments
+            if segment.first_s <= video_s <= segment.last_s
+        ]
+        if not covering:
+            return None
+        return max(covering, key=lambda segment: segment.count)
+
+    @property
+    def agreement(self) -> float:
+        """Share of accepted readings that back the reported anchor."""
+        return self.segment.count / self.readings_total if self.readings_total else 0.0
+
+    @property
+    def epoch_s(self) -> float | None:
+        """Unix epoch of video t=0, or None when no date was supplied.
+
+        The badge names a time of day and no date, so this is None unless the
+        caller said which day the file starts on. Returning a guess would be
+        the one failure this module exists to prevent.
+        """
+        if self.tz is None or self.anchor_date is None:
+            return None
+        return self._at(self.anchor_date, self.offset_s).timestamp()
+
+    def wall_clock_at(self, video_s: float) -> datetime | None:
+        """Aware datetime of a video timestamp, or None without a date.
+
+        Aware, always: an anchor that a caller has to interpret in its own
+        local zone is an anchor that will eventually be interpreted in the
+        wrong one.
+        """
+        epoch = self.epoch_s
+        if epoch is None or self.tz is None:
+            return None
+        return datetime.fromtimestamp(epoch + video_s, tz=self.tz)
+
+    def time_of_day_at(self, video_s: float) -> float:
+        """Second of the day a video timestamp falls on, with no date needed."""
+        return (self.offset_s + video_s) % DAY_S
+
+    def _at(self, day: Date, seconds: float) -> datetime:
+        assert self.tz is not None
+        midnight = datetime.combine(day, time(0, 0), tzinfo=self.tz)
+        # Rebuilt through the zone rather than added to a UTC instant, so a
+        # local midnight and a DST change on the same day stay consistent.
+        return (midnight + timedelta(seconds=seconds)).astimezone(self.tz)
+
+    def describe(self) -> str:
+        """One line, for a log or an eval report."""
+        notes = [
+            f"{self.segment.count}/{self.readings_total} readings",
+            f"spread {self.spread_s:.1f}s",
+        ]
+        if self.drifted:
+            notes.append(f"DRIFT: {len(self.drifted)} other stretch(es) of this file")
+        if self.contested:
+            notes.append(f"{len(self.contested)} contested")
+        return (
+            f"t=0 is {_hhmmss(self.offset_s)} {self.zone_label} "
+            f"+/-{self.uncertainty_s:.1f}s (" + ", ".join(notes) + ")"
+        )
+
+
+def _overlapping(one: ClockSegment, other: ClockSegment) -> bool:
+    """Do two segments' readings cover any of the same video?"""
+    return one.first_s <= other.last_s and other.first_s <= one.last_s
+
+
+class ClockReader:
+    """Read a burned-in clock badge and derive the file's wall-clock anchor.
+
+    One consumer of the generic overlay reader, in the same shape as the
+    scorebug recognizer: everything about finding burned-in text lives in
+    `overlay.py`, and everything about what a clock badge is lives here. The
+    interpretation it hands back to the reader counts a band as a hit only when
+    a plausible zone-labelled time came out of it, which is what keeps the band
+    search off the crowd, the ticker and the poll panel: all of them return
+    text, none of them return a time next to a zone the caller named.
+
+    `zones` maps badge labels to timezones and is required. It is how the caller
+    says what the corpus prints, and there is no default: a badge label this
+    reader does not know is a badge it declines to read, which is the correct
+    outcome for a module whose worst failure mode is a confident wrong answer.
+    """
+
+    name = "clock"
+
+    def __init__(
+        self,
+        zones: Mapping[str, str | int | tzinfo],
+        ocr: OcrFn | None = None,
+        fps: float = 0.5,
+        crop: Region | None = None,  # fraction box; None searches the corners
+        regions: Iterable[Region] | None = None,
+        workers: int | None = None,  # None: the reader's default; 1: serial
+        lang: str | None = None,  # OCR language; None: the reader's default
+        psm: int | None = CLOCK_PSM,
+        default_zone: str | None = None,  # for badges that print no label
+        min_readings: int = MIN_READINGS,
+        anchor_date: Date | None = None,  # calendar date of video t=0
+    ):
+        self.zones = resolve_zones(zones)
+        if default_zone is not None and _fold_label(default_zone) not in self.zones:
+            raise ValueError(f"default_zone {default_zone!r} is not in the zone table")
+        self.default_zone = default_zone
+        self.min_readings = max(1, int(min_readings))
+        self.anchor_date = anchor_date
+        self.reader = OverlayReader(
+            ocr=ocr,
+            fps=fps,
+            crop=crop,
+            regions=CLOCK_REGIONS if (crop is None and regions is None) else regions,
+            workers=workers,
+            lang=lang,
+            psm=psm,
+            name=self.name,
+        )
+        # Mirrored so the reader answers for its own configuration, as the
+        # other recognizers do. The overlay reader owns them.
+        self.fps = self.reader.fps
+        self.regions = self.reader.regions
+        self.workers = self.reader.workers
+        self.lang = self.reader.lang
+        self._conflicts = 0
+        self._bands = 0
+
+    def read_clock(self, media_path: Path) -> list[ClockRead]:
+        """Every frame reading the badge produced, in video order."""
+        self._conflicts = 0
+        self._bands = 0
+        reads: list[ClockRead] = []
+        # `closing` because the overlay reader holds a worker pool and a scratch
+        # directory for the length of the iteration: leaving this loop early has
+        # to shut them down now, not whenever the generator is collected.
+        with closing(self.reader.read(media_path, self._interpret)) as stream:
+            for _, found in stream:
+                if found is not None:
+                    reads.append(found)
+        return reads
+
+    def anchor(self, media_path: Path) -> ClockAnchor | None:
+        """Derive the file's wall-clock anchor, or None if it cannot be.
+
+        None is a real answer and the common one: most footage carries no clock
+        badge, and this returns nothing at all for it rather than an anchor
+        assembled out of whatever digits the corners happened to hold.
+        """
+        return self.anchor_from(self.read_clock(media_path))
+
+    def anchor_from(self, reads: Iterable[ClockRead]) -> ClockAnchor | None:
+        """The derivation on its own, for readings gathered elsewhere.
+
+        Separate from the reading so an anchor can be recomputed, or derived
+        from readings taken out of several windows of one file, without paying
+        for the OCR again. The counters it reports (`conflicts`, `bands_read`)
+        describe this reader's last `read_clock`, so they are zero for readings
+        it did not take itself.
+        """
+        readings = list(reads)
+        segments = _segments(readings, self.min_readings)
+        if not segments:
+            return None
+        # Largest first: the anchor most of the file's readings agree on, with
+        # ties going to the earlier one so the answer does not depend on
+        # dictionary order.
+        ranked = sorted(segments, key=lambda s: (-s.count, s.first_s))
+        best = ranked[0]
+        return ClockAnchor(
+            segment=best,
+            segments=tuple(sorted(segments, key=lambda s: s.first_s)),
+            zone_label=best.zone,
+            tz=self.zones.get(best.zone),
+            anchor_date=self.anchor_date,
+            readings_total=len(readings),
+            conflicts=self._conflicts,
+            bands_read=self._bands,
+        )
+
+    def _interpret(self, read: OverlayRead) -> tuple[ClockRead | None, int]:
+        """Reconcile one band's preprocessing passes into at most one reading.
+
+        The passes disagree: on the sample frames the grey pass read the badge
+        on some frames and returned nothing on others, and the thresholded pass
+        did the same on a different set, which is the reason both are run. Where
+        exactly one time survives across the passes it is the reading. Where two
+        survive, the frame is dropped and counted as a conflict, because the
+        passes contradicting each other is the only in-band evidence available
+        that this frame's OCR is unreliable, and a frame is cheap while a wrong
+        anchor is not.
+
+        The hit count is 1 whenever a plausible time was seen at all, conflict
+        or not: the band search asks "is the clock here", which a contradicted
+        read still answers, and it must not lose the band over a frame this
+        method then refuses to use.
+        """
+        self._bands += 1
+        seen: set[tuple[int, str]] = set()
+        for text in read.texts:
+            for parsed in parse_times(text, self.zones, self.default_zone):
+                seen.add((parsed.seconds_of_day, parsed.zone))
+        if not seen:
+            return None, 0
+        if len(seen) > 1:
+            self._conflicts += 1
+            return None, 1
+        seconds_of_day, zone = seen.pop()
+        return (
+            ClockRead(
+                timestamp_s=read.timestamp_s,
+                seconds_of_day=seconds_of_day,
+                zone=zone,
+                texts=read.texts,
+            ),
+            1,
+        )
+
+
+def _segments(reads: list[ClockRead], min_readings: int) -> list[ClockSegment]:
+    """Group readings into the anchors they are consistent with.
+
+    Each reading says the anchor lies in a 60 second window (the badge showed
+    that minute for the whole of it), so a set of readings is consistent
+    exactly when their windows intersect. Groups are grown from the earliest
+    implied offset upwards, which is the standard sweep for covering points
+    with fixed-width intervals and yields the fewest groups.
+
+    Grouping per zone label, because two labels are two different claims about
+    what the clock means even when they resolve to the same offset.
+    """
+    segments: list[ClockSegment] = []
+    for zone in sorted({read.zone for read in reads}):
+        same_zone = [read for read in reads if read.zone == zone]
+        for group in _consistent_groups(same_zone):
+            if len(group) < min_readings:
+                continue  # one confident misread is a group of one
+            lower, upper = _intersect(group)
+            segments.append(
+                ClockSegment(
+                    zone=zone,
+                    lower_s=lower,
+                    upper_s=upper,
+                    first_s=min(read.timestamp_s for read in group),
+                    last_s=max(read.timestamp_s for read in group),
+                    readings=tuple(sorted(group, key=lambda r: r.timestamp_s)),
+                )
+            )
+    return segments
+
+
+def _consistent_groups(reads: list[ClockRead]) -> Iterator[list[ClockRead]]:
+    if not reads:
+        return
+    reference = reads[0].implied_offset_s
+    ordered = sorted(reads, key=lambda r: _unwrap(r.implied_offset_s, reference))
+    group: list[ClockRead] = []
+    floor = 0.0
+    for read in ordered:
+        offset = _unwrap(read.implied_offset_s, reference)
+        if group and offset - floor >= MINUTE_S:
+            yield group
+            group = []
+        if not group:
+            floor = offset
+        group.append(read)
+    if group:
+        yield group
+
+
+def _unwrap(offset: float, reference: float) -> float:
+    """Put an offset on the same side of midnight as `reference`.
+
+    Offsets are seconds of the day, so an anchor near midnight is read as both
+    ~0 and ~86400 by different frames. Comparing them raw would split one
+    anchor into two segments a day apart.
+    """
+    return reference + (offset - reference + DAY_S / 2) % DAY_S - DAY_S / 2
+
+
+def _intersect(group: list[ClockRead]) -> tuple[float, float]:
+    """The window every reading in the group agrees the anchor lies in.
+
+    A badge reading M was displayed from M:00 until M:59, so the anchor is at
+    or after `implied` and less than a minute after it. Intersecting those
+    windows gives [max implied, min implied + 60), and this is where the
+    minute-flip refinement falls out for free rather than needing a search: two
+    readings four seconds apart that straddle a minute boundary are 56 seconds
+    apart in implied offset, and their intersection is four seconds wide. No
+    special case looks for the flip; sampling faster simply makes the interval
+    tighter, down to the frame interval.
+    """
+    reference = group[0].implied_offset_s
+    offsets = [_unwrap(read.implied_offset_s, reference) for read in group]
+    return max(offsets), min(offsets) + MINUTE_S
+
+
+def _hhmmss(seconds: float) -> str:
+    whole = int(seconds) % DAY_S
+    return f"{whole // 3600:02d}:{whole // 60 % 60:02d}:{whole % 60:02d}"

--- a/annotator/dirstral_annotator/recognizers/clock.py
+++ b/annotator/dirstral_annotator/recognizers/clock.py
@@ -244,13 +244,52 @@ def _zone_beside(text: str, start: int, end: int, known: set[str]) -> str | None
     before them) once punctuation and OCR's invented spaces are folded out.
     A loose substring test would let a two-letter label like `ET` match inside
     any word that happens to contain it.
+
+    Anchoring alone is not enough, because folding is what removes the word
+    boundaries: `11:20 ETA 5 min` folds to `ETA5MIN`, which starts with `ET`,
+    and `TICKET 11:20` folds to `TICKET`, which ends with it. Both read as a
+    labelled time before this check.
+
+    So the boundary is checked against the ORIGINAL text rather than the folded
+    window. Folding cannot answer the question it creates: `MSK LIVE` and
+    `MSKVA` fold to strings that both continue with a letter past `MSK`, and
+    the first is a real badge while the second is not. Keeping each folded
+    character's source index lets the fold do what it is for (`11:20 E T` is
+    what OCR returns for a letter-spaced badge) while the word boundary is
+    still read off the text as printed.
     """
-    after = _fold_label(text[end : end + ZONE_WINDOW])
-    before = _fold_label(text[max(0, start - ZONE_WINDOW) : start])
+    after, after_at = _fold_indexed(text, end, min(len(text), end + ZONE_WINDOW))
+    lo = max(0, start - ZONE_WINDOW)
+    before, before_at = _fold_indexed(text, lo, start)
     for label in sorted(known, key=len, reverse=True):
-        if label and (after.startswith(label) or before.endswith(label)):
+        if not label:
+            continue
+        n = len(label)
+        if after.startswith(label) and not _letter_after(text, after_at[n - 1]):
+            return label
+        if before.endswith(label) and not _letter_before(text, before_at[-n]):
             return label
     return None
+
+
+def _fold_indexed(text: str, lo: int, hi: int) -> tuple[str, list[int]]:
+    """`_fold_label` over `text[lo:hi]`, plus each kept character's source index."""
+    folded: list[str] = []
+    where: list[int] = []
+    for offset in range(lo, hi):
+        char = text[offset]
+        if not _NOT_WORD_RE.match(char):
+            folded.append(char.upper())
+            where.append(offset)
+    return "".join(folded), where
+
+
+def _letter_before(text: str, index: int) -> bool:
+    return index > 0 and text[index - 1].isalpha()
+
+
+def _letter_after(text: str, index: int) -> bool:
+    return index + 1 < len(text) and text[index + 1].isalpha()
 
 
 @dataclass(frozen=True)
@@ -260,7 +299,10 @@ class ClockRead:
     timestamp_s: float  # video time this frame was sampled at
     seconds_of_day: int  # what the badge said, in its own zone
     zone: str
-    texts: tuple[str, ...] = ()  # the OCR passes it was reconciled from
+    #: The OCR passes it was reconciled from. Kept out of the repr: a real file
+    #: yields a hundred readings of several passes each, and a bare
+    #: `print(anchor)` would otherwise print every one of them.
+    texts: tuple[str, ...] = field(default=(), repr=False)
 
     @property
     def implied_offset_s(self) -> float:
@@ -289,7 +331,17 @@ class ClockSegment:
     upper_s: float
     first_s: float  # video time of the first reading in the segment
     last_s: float
-    readings: tuple[ClockRead, ...] = field(default_factory=tuple)
+    #: Kept out of the generated repr for the same reason as `ClockRead.texts`;
+    #: `__repr__` below reports the count instead, which is what a caller
+    #: inspecting a segment actually wants to see.
+    readings: tuple[ClockRead, ...] = field(default_factory=tuple, repr=False)
+
+    def __repr__(self) -> str:
+        return (
+            f"ClockSegment(zone={self.zone!r}, lower_s={self.lower_s!r}, "
+            f"upper_s={self.upper_s!r}, first_s={self.first_s!r}, "
+            f"last_s={self.last_s!r}, readings={len(self.readings)})"
+        )
 
     @property
     def offset_s(self) -> float:
@@ -552,8 +604,10 @@ class ClockReader:
         Separate from the reading so an anchor can be recomputed, or derived
         from readings taken out of several windows of one file, without paying
         for the OCR again. The counters it reports (`conflicts`, `bands_read`)
-        describe this reader's last `read_clock`, so they are zero for readings
-        it did not take itself.
+        describe this reader's last `read_clock` and carry over from it: they
+        are zero only on an instance that has never run one. On an instance
+        that has, they still describe that run and not the readings passed in
+        here, so read them from the reader that took the readings.
         """
         readings = list(reads)
         segments = _segments(readings, self.min_readings)

--- a/annotator/tests/test_clock.py
+++ b/annotator/tests/test_clock.py
@@ -83,9 +83,40 @@ def test_what_is_not_a_reading(text):
 
 def test_a_label_is_not_matched_inside_a_word():
     """`ET` is a real zone label and `TICKET` is a real word on a real overlay.
-    A substring test would turn one into the other."""
-    assert parse_times("11:20 TICKET", {"ET": -5 * 3600}) == []
-    assert parse_times("11:20 ET", {"ET": -5 * 3600})[0].hour == 11
+    A substring test would turn one into the other.
+
+    Anchoring to the digits is not sufficient on its own, because folding strips
+    the word boundaries: `ETA` after the time still starts with `ET`, and
+    `TICKET` before it still ends with `ET`. Only the first case here is caught
+    by position alone, which is what made the original test pass while both
+    others were open.
+    """
+    et = {"ET": -5 * 3600}
+    assert parse_times("11:20 TICKET", et) == []
+    assert parse_times("11:20 ETA 5 min", et) == []
+    assert parse_times("TICKET 11:20", et) == []
+    assert parse_times("11:20 ET", et)[0].hour == 11
+    assert parse_times("ET 11:20", et)[0].hour == 11
+
+
+def test_a_letter_spaced_label_still_reads():
+    """Why folding survives the boundary check: OCR returns `E T` for a
+    letter-spaced badge, and a whole-token comparison would reject it."""
+    et = {"ET": -5 * 3600}
+    assert parse_times("11:20 E T", et)[0].zone == "ET"
+    assert parse_times("11:20 (ET)", et)[0].zone == "ET"
+    assert parse_times("11:20 M S K", {"MSK": 3 * 3600})[0].zone == "MSK"
+
+
+def test_a_label_followed_by_another_word_still_reads():
+    """The case that rules out checking the boundary on the folded window:
+    `MSK LIVE` and `MSKVA` both continue with a letter once the space is folded
+    out, and only the first is a badge. The boundary has to be read off the
+    text as printed."""
+    msk = {"MSK": 3 * 3600}
+    assert parse_times("21:35 MSK LIVE", msk)[0].zone == "MSK"
+    assert parse_times("LIVE MSK 21:35", msk)[0].zone == "MSK"
+    assert parse_times("21:35 MSKVA", msk) == []
 
 
 def test_an_unlabelled_badge_needs_the_caller_to_say_which_zone():
@@ -104,14 +135,28 @@ def test_labels_fold_over_case_and_punctuation():
 
 # --- the zone table is data ------------------------------------------------
 
+def has_tzdata(name: str) -> bool:
+    """Whether an IANA name resolves on this host.
+
+    `clock.py` names a host with no tz database as a supported case, which is
+    why the zone table accepts fixed offsets at all, so the IANA leg of these
+    tests is skipped rather than failed there. `importorskip("zoneinfo")` does
+    not cover it: the module imports fine and only the lookup raises.
+    """
+    try:
+        resolve_zones({"_": name})
+    except ValueError:
+        return False
+    return True
+
+
 def test_a_zone_may_be_an_offset_a_name_or_a_tzinfo():
-    zones = resolve_zones(
-        {"A": 3 * 3600, "B": "UTC", "C": timezone(timedelta(hours=-5))}
-    )
+    zones = resolve_zones({"A": 3 * 3600, "C": timezone(timedelta(hours=-5))})
     at = datetime(2026, 1, 1, tzinfo=UTC)
     assert zones["A"].utcoffset(at) == timedelta(hours=3)
-    assert zones["B"].utcoffset(at) == timedelta(0)
     assert zones["C"].utcoffset(at) == timedelta(hours=-5)
+    if has_tzdata("UTC"):
+        assert resolve_zones({"B": "UTC"})["B"].utcoffset(at) == timedelta(0)
 
 
 def test_an_unresolvable_zone_is_an_error_not_a_guess():
@@ -189,7 +234,11 @@ def test_the_clock_moves_the_band_lock_onto_the_badge(frames):
     judgement is "a time next to a zone I named". A ticker full of numbers is
     not that, which is why the lock has to end up on the badge and stay."""
     frames(ticking(21 * 3600 + 30 * 60))
-    reads = [read for read, _ in reader().reader.read(MEDIA, reader()._interpret)]
+    # One instance: `reader()` twice would run the overlay reader of the first
+    # against the bound interpreter of a second, so the band counters would
+    # land on an object this test discards.
+    clock = reader()
+    reads = [read for read, _ in clock.reader.read(MEDIA, clock._interpret)]
     assert {read.region for read in reads[-10:]} == {BADGE}
 
 
@@ -398,7 +447,8 @@ def test_a_date_turns_the_anchor_into_an_aware_instant(frames):
 def test_the_zone_is_applied_at_the_anchors_own_date(frames):
     """A named zone is not a fixed offset. Resolving it at today's date, or at
     the reader's, silently moves an anchor by an hour for half the year."""
-    pytest.importorskip("zoneinfo")
+    if not has_tzdata("America/New_York"):
+        pytest.skip("no tz database on this host; fixed offsets cover that case")
     zones = {"ET": "America/New_York"}
     frames(ticking(12 * 3600, zone="ET"))
     winter = reader(zones=zones, anchor_date=date(2026, 1, 15)).anchor(MEDIA)

--- a/annotator/tests/test_clock.py
+++ b/annotator/tests/test_clock.py
@@ -1,0 +1,473 @@
+"""The burned-in clock reader: what it must derive, and what it must refuse.
+
+A wall-clock anchor is inherited by every citation the file produces, so the
+tests that matter most here are the ones about declining. A reader that returns
+an anchor for footage with no clock, or that averages an OCR misread into a
+real one, is worse than no reader at all: the failure is silent and it is
+downstream of everything.
+
+Backend-free. The OCR engine is a callable and the frames are scripted, so
+nothing here needs tesseract, Pillow or a media file. No corpus, language or
+broadcaster shows up as an assumption: the badges below are invented, and the
+zone labels are the caller's data in every test that uses one.
+"""
+
+from __future__ import annotations
+
+import ast
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from dirstral_annotator.recognizers import clock, overlay
+from dirstral_annotator.recognizers.clock import (
+    ClockRead,
+    ClockReader,
+    parse_times,
+    resolve_zones,
+)
+
+MEDIA = "broadcast.mp4"
+BADGE = (0.00, 0.00, 0.30, 0.14)
+NOISE = (0.70, 0.86, 0.30, 0.14)
+ZONES = {"MSK": 3 * 3600}
+UTC = timezone.utc
+
+
+def _badge(seconds_of_day: float, zone: str = "MSK") -> str:
+    """What a badge showing whole minutes prints at this second of the day."""
+    whole = int(seconds_of_day) % clock.DAY_S
+    return f"{whole // 3600:02d}:{whole // 60 % 60:02d} {zone}"
+
+
+# --- parsing: what counts as a reading -------------------------------------
+
+def test_a_labelled_time_parses_and_keeps_its_label():
+    (parsed,) = parse_times("21:35 MSK LIVE", ZONES)
+    assert (parsed.hour, parsed.minute, parsed.zone) == (21, 35, "MSK")
+    assert parsed.seconds_of_day == 21 * 3600 + 35 * 60
+
+
+def test_the_label_may_be_printed_before_the_time():
+    (parsed,) = parse_times("MSK 09:05", ZONES)
+    assert parsed.seconds_of_day == 9 * 3600 + 5 * 60
+
+
+def test_seconds_are_kept_when_the_badge_shows_them():
+    (parsed,) = parse_times("09:05:42 MSK", ZONES)
+    assert parsed.seconds_of_day == 9 * 3600 + 5 * 60 + 42
+
+
+def test_ocr_punctuation_does_not_lose_a_reading():
+    """The separator comes back as a dot or a semicolon often enough, and the
+    label arrives wrapped in whatever debris was around it."""
+    assert parse_times("21.35 |MSK|", ZONES)[0].minute == 35
+    assert parse_times("21;35 .MSK.", ZONES)[0].minute == 35
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "24:00 MSK",  # not a time of day
+        "21:75 MSK",  # not a minute
+        "Proголосовали 12754 MSK",  # digits, but not a time
+        "21:35",  # no zone, and none was configured
+        "21:35 CET",  # a zone this caller did not name
+        "2135 MSK",  # no separator
+    ],
+)
+def test_what_is_not_a_reading(text):
+    assert parse_times(text, ZONES) == []
+
+
+def test_a_label_is_not_matched_inside_a_word():
+    """`ET` is a real zone label and `TICKET` is a real word on a real overlay.
+    A substring test would turn one into the other."""
+    assert parse_times("11:20 TICKET", {"ET": -5 * 3600}) == []
+    assert parse_times("11:20 ET", {"ET": -5 * 3600})[0].hour == 11
+
+
+def test_an_unlabelled_badge_needs_the_caller_to_say_which_zone():
+    """Some broadcasters print a bare clock. That is readable, but only once
+    the caller has stated what zone it is in: this module will not pick one."""
+    assert parse_times("21:35", ZONES) == []
+    (parsed,) = parse_times("21:35", ZONES, default_zone="MSK")
+    assert parsed.zone == "MSK"
+
+
+def test_labels_fold_over_case_and_punctuation():
+    zones = resolve_zones({"m.s.k": 3 * 3600})
+    assert "MSK" in zones
+    assert parse_times("21:35 MSK", zones)[0].zone == "MSK"
+
+
+# --- the zone table is data ------------------------------------------------
+
+def test_a_zone_may_be_an_offset_a_name_or_a_tzinfo():
+    zones = resolve_zones(
+        {"A": 3 * 3600, "B": "UTC", "C": timezone(timedelta(hours=-5))}
+    )
+    at = datetime(2026, 1, 1, tzinfo=UTC)
+    assert zones["A"].utcoffset(at) == timedelta(hours=3)
+    assert zones["B"].utcoffset(at) == timedelta(0)
+    assert zones["C"].utcoffset(at) == timedelta(hours=-5)
+
+
+def test_an_unresolvable_zone_is_an_error_not_a_guess():
+    with pytest.raises(ValueError):
+        resolve_zones({"XYZ": "Not/AZone"})
+
+
+def test_a_default_zone_outside_the_table_is_refused():
+    with pytest.raises(ValueError):
+        ClockReader(zones=ZONES, ocr=lambda p: "", default_zone="CET")
+
+
+# --- reading a file --------------------------------------------------------
+
+@pytest.fixture
+def frames(monkeypatch, tmp_path):
+    """Script what each band of each sampled frame says, with no images.
+
+    `install(text_at, frames=n, fps=f)` calls `text_at(region, timestamp)` for
+    every band the reader asks for and returns one preprocessing pass; a list
+    return value is taken as several passes, which is how the disagreement
+    between the grey and thresholded passes is simulated.
+    """
+
+    def install(text_at, count=60, fps=0.5):
+        listing = []
+        for i in range(count):
+            path = tmp_path / f"frame-{i:05d}.jpg"
+            path.write_text(str(i))
+            listing.append((i / fps, path))
+        stamps = {path: timestamp for timestamp, path in listing}
+
+        def read_band(ocr, frame, region, work):
+            got = text_at(tuple(region), stamps[frame])
+            return list(got) if isinstance(got, (list, tuple)) else [got]
+
+        monkeypatch.setattr(overlay, "iter_frames", lambda *a, **k: iter(listing))
+        monkeypatch.setattr(overlay, "read_band", read_band)
+        return listing
+
+    return install
+
+
+def ticking(anchor_s: float, zone: str = "MSK", band=BADGE, live_from=0.0):
+    """A badge that ticks in real time from `anchor_s`, and background elsewhere."""
+
+    def text_at(region, timestamp):
+        if region != band or timestamp < live_from:
+            return "lorem ipsum 53% 12754"
+        return _badge(anchor_s + timestamp, zone)
+
+    return text_at
+
+
+def reader(**kwargs):
+    kwargs.setdefault("zones", ZONES)
+    kwargs.setdefault("ocr", lambda p: "")
+    kwargs.setdefault("regions", (NOISE, BADGE))
+    kwargs.setdefault("workers", 1)
+    return ClockReader(**kwargs)
+
+
+def test_the_anchor_is_the_wall_clock_at_video_zero(frames):
+    """The whole point: a badge read at t=300 says what t=0 was."""
+    frames(ticking(21 * 3600 + 30 * 60))
+    anchor = reader().anchor(MEDIA)
+    assert anchor is not None
+    assert anchor.zone_label == "MSK"
+    assert abs(anchor.offset_s - (21 * 3600 + 30 * 60)) <= 1.0
+    assert anchor.wall_clock_at(600.0) is None  # no date supplied, so no instant
+
+
+def test_the_clock_moves_the_band_lock_onto_the_badge(frames):
+    """The reader searches bands on the caller's judgement, and this caller's
+    judgement is "a time next to a zone I named". A ticker full of numbers is
+    not that, which is why the lock has to end up on the badge and stay."""
+    frames(ticking(21 * 3600 + 30 * 60))
+    reads = [read for read, _ in reader().reader.read(MEDIA, reader()._interpret)]
+    assert {read.region for read in reads[-10:]} == {BADGE}
+
+
+def test_footage_with_no_badge_yields_no_anchor(frames):
+    """The common case. Most archive footage carries no clock, and inventing an
+    anchor from whatever digits a corner held is the failure this module is
+    built to avoid."""
+    frames(lambda region, t: "lorem ipsum 53% | 12754 | 1-2")
+    assert reader().anchor(MEDIA) is None
+
+
+def test_one_reading_is_never_an_anchor(frames):
+    """A single confident misread looks exactly like a single correct read."""
+
+    def once(region, timestamp):
+        if region == BADGE and timestamp == 0.0:
+            return "21:35 MSK"
+        return ""
+
+    frames(once)
+    assert reader().anchor(MEDIA) is None
+
+
+def test_a_misread_among_agreeing_readings_is_dropped(frames):
+    """OCR turned a 3 into a 5 on one frame. It is a plausible time with the
+    right label, and nothing about the reading itself gives it away; only the
+    other readings do."""
+    truth = ticking(21 * 3600 + 30 * 60)
+
+    def with_a_misread(region, timestamp):
+        if region == BADGE and timestamp == 40.0:
+            return "21:55 MSK"
+        return truth(region, timestamp)
+
+    frames(with_a_misread)
+    anchor = reader().anchor(MEDIA)
+    assert anchor is not None
+    assert abs(anchor.offset_s - (21 * 3600 + 30 * 60)) <= 1.0
+    assert not anchor.drift
+    assert anchor.segment.count == anchor.readings_total - 1
+
+
+def test_readings_that_imply_two_anchors_are_reported_not_averaged(frames):
+    """A recording can be an edit of two takes, and a cut moves the anchor for
+    everything after it. Averaging the two would produce an anchor that is
+    wrong for both halves and looks fine."""
+    early = ticking(21 * 3600 + 30 * 60)
+    late = ticking(22 * 3600 + 30 * 60)
+
+    def edited(region, timestamp):
+        return (early if timestamp < 60 else late)(region, timestamp)
+
+    frames(edited, count=80)
+    anchor = reader().anchor(MEDIA)
+    assert anchor is not None and anchor.drift
+    assert len(anchor.segments) == 2 and len(anchor.drifted) == 1
+    offsets = sorted(round(segment.offset_s) for segment in anchor.segments)
+    assert offsets[1] - offsets[0] == 3600
+    assert anchor.agreement < 1.0
+
+
+def test_a_run_of_misreads_is_contested_not_drift(frames):
+    """Measured on real footage: fourteen consecutive frames of a badge showing
+    21:40 came back as 23:30, which is enough agreement to survive any
+    corroboration count. What gives it away is that those frames sit inside a
+    stretch of video another anchor already covers, and no second of video has
+    two wall clocks. An edit moves the anchor forward; a misread argues with
+    the anchor where it already applies."""
+    truth = ticking(21 * 3600 + 30 * 60)
+
+    def with_a_bad_run(region, timestamp):
+        if region == BADGE and 60.0 <= timestamp <= 80.0:
+            return _badge(23 * 3600 + 30 * 60 + timestamp)
+        return truth(region, timestamp)
+
+    frames(with_a_bad_run, count=80)
+    anchor = reader().anchor(MEDIA)
+    assert anchor is not None
+    assert len(anchor.segments) == 2
+    assert not anchor.drift and len(anchor.contested) == 1
+    assert abs(anchor.offset_s - (21 * 3600 + 30 * 60)) <= 1.0
+
+
+def test_a_citation_after_a_cut_can_ask_which_anchor_covers_it(frames):
+    """The point of reporting an edit rather than averaging it: the second half
+    of the file is still citable, through the anchor derived from the second
+    half."""
+    early = ticking(21 * 3600 + 30 * 60)
+    late = ticking(22 * 3600 + 30 * 60)
+    frames(lambda region, t: (early if t < 60 else late)(region, t), count=80)
+    anchor = reader().anchor(MEDIA)
+    assert anchor is not None
+    covering = anchor.segment_for(120.0)
+    assert covering is not None
+    assert abs(covering.offset_s - (22 * 3600 + 30 * 60)) <= 1.0
+    assert anchor.segment_for(10_000.0) is None  # no readings out there
+
+
+# --- minute resolution -----------------------------------------------------
+
+def test_a_minute_flip_pins_the_anchor_to_the_frame_interval(frames):
+    """The badge only shows minutes, so one reading places the anchor anywhere
+    in a 60 second window. Two readings either side of the minute flip narrow
+    it to the sampling interval, and no code goes looking for the flip: it is
+    what intersecting the readings' own windows does.
+    """
+    frames(ticking(21 * 3600 + 30 * 60 + 59), count=80, fps=1.0)
+    anchor = reader(fps=1.0).anchor(MEDIA)
+    assert anchor is not None
+    assert anchor.uncertainty_s <= 0.5  # half of the 1s frame interval
+    assert anchor.spread_s >= 59.0
+
+
+def test_readings_that_never_straddle_a_flip_stay_a_minute_wide(frames):
+    """The honest converse. Sampling every 60 seconds from a fixed phase reads
+    the badge repeatedly and learns nothing new; the anchor is still only known
+    to within the minute, and says so."""
+    frames(ticking(21 * 3600 + 30 * 60), count=30, fps=1 / 60)
+    anchor = reader(fps=1 / 60).anchor(MEDIA)
+    assert anchor is not None
+    assert anchor.spread_s == 0.0
+    assert anchor.uncertainty_s == pytest.approx(30.0)
+
+
+def test_spread_and_uncertainty_are_complements():
+    """Spread is not error here, it is coverage of the badge's minute: every
+    second of disagreement between readings is a second removed from the
+    anchor's uncertainty."""
+    reads = [
+        ClockRead(timestamp_s=0.0, seconds_of_day=100 * 60, zone="MSK"),
+        ClockRead(timestamp_s=50.0, seconds_of_day=100 * 60, zone="MSK"),
+    ]
+    (segment,) = clock._segments(reads, min_readings=2)
+    assert segment.spread_s == pytest.approx(50.0)
+    assert segment.uncertainty_s == pytest.approx(5.0)
+
+
+def test_a_file_that_runs_past_midnight_is_one_anchor(frames):
+    """Seconds of the day wrap and video time does not. Handled wrong, the
+    readings before and after midnight look like two different anchors."""
+    frames(ticking(clock.DAY_S - 30), count=60)
+    anchor = reader().anchor(MEDIA)
+    assert anchor is not None and not anchor.drift
+    assert abs(anchor.offset_s - (clock.DAY_S - 30)) <= 1.0
+
+
+# --- reconciling the preprocessing passes ----------------------------------
+
+def test_passes_that_contradict_each_other_drop_the_frame(frames):
+    """Both preprocessing passes are run because each reads frames the other
+    cannot. When both read and they disagree, one of them is wrong and there is
+    no way to tell which, so the frame is not used. The band still counts as a
+    hit: the clock is plainly there, and the reader must not lose the band over
+    a frame this refused."""
+    truth = ticking(21 * 3600 + 30 * 60)
+
+    def disagreeing(region, timestamp):
+        if region == BADGE and timestamp in (40.0, 60.0):
+            return [truth(region, timestamp), "23:59 MSK"]
+        return truth(region, timestamp)
+
+    frames(disagreeing)
+    reading = reader()
+    reads = reading.read_clock(MEDIA)
+    anchor = reading.anchor_from(reads)
+    assert anchor is not None and not anchor.drift
+    assert anchor.conflicts == 2
+    assert all(read.timestamp_s not in (40.0, 60.0) for read in reads)
+
+
+def test_a_pass_that_reads_nothing_costs_nothing(frames):
+    """The usual case on real footage: one pass sees the badge, the other
+    returns an empty string. That is not a contradiction."""
+    truth = ticking(21 * 3600 + 30 * 60)
+    frames(lambda region, t: ["", truth(region, t)])
+    anchor = reader().anchor(MEDIA)
+    assert anchor is not None and anchor.conflicts == 0
+
+
+# --- turning an anchor into an instant -------------------------------------
+
+def test_no_date_means_no_epoch(frames):
+    """The badge names a time of day and never a date. Supplying one is the
+    caller's business, and until then this reports the time of day and nothing
+    that pretends to be an instant."""
+    frames(ticking(21 * 3600 + 30 * 60))
+    anchor = reader().anchor(MEDIA)
+    assert anchor is not None
+    assert anchor.epoch_s is None and anchor.wall_clock_at(0.0) is None
+    assert anchor.time_of_day_at(1800.0) == pytest.approx(22 * 3600, abs=1.0)
+
+
+def test_a_date_turns_the_anchor_into_an_aware_instant(frames):
+    frames(ticking(21 * 3600 + 30 * 60))
+    anchor = reader(anchor_date=date(2026, 2, 3)).anchor(MEDIA)
+    assert anchor is not None
+    when = anchor.wall_clock_at(0.0)
+    assert when is not None and when.tzinfo is not None
+    # 21:30 in a UTC+3 zone is 18:30 UTC, whatever the reader's own zone is.
+    assert when.astimezone(UTC).replace(second=0, microsecond=0) == datetime(
+        2026, 2, 3, 18, 30, tzinfo=UTC
+    )
+    assert anchor.epoch_s == pytest.approx(when.timestamp())
+
+
+def test_the_zone_is_applied_at_the_anchors_own_date(frames):
+    """A named zone is not a fixed offset. Resolving it at today's date, or at
+    the reader's, silently moves an anchor by an hour for half the year."""
+    pytest.importorskip("zoneinfo")
+    zones = {"ET": "America/New_York"}
+    frames(ticking(12 * 3600, zone="ET"))
+    winter = reader(zones=zones, anchor_date=date(2026, 1, 15)).anchor(MEDIA)
+    summer = reader(zones=zones, anchor_date=date(2026, 7, 15)).anchor(MEDIA)
+    assert winter is not None and summer is not None
+    assert winter.wall_clock_at(0.0).utcoffset() == timedelta(hours=-5)
+    assert summer.wall_clock_at(0.0).utcoffset() == timedelta(hours=-4)
+
+
+def test_two_labels_are_two_claims_even_at_the_same_offset(frames):
+    """Zones are what the badge said, not what they resolve to. A file whose
+    badge changes label has changed what it is asserting, and that is reported
+    rather than merged."""
+    zones = {"MSK": 3 * 3600, "TRT": 3 * 3600}
+
+    def relabelled(region, timestamp):
+        zone = "MSK" if timestamp < 60 else "TRT"
+        return ticking(21 * 3600 + 30 * 60, zone=zone)(region, timestamp)
+
+    frames(relabelled, count=80)
+    anchor = reader(zones=zones).anchor(MEDIA)
+    assert anchor is not None
+    assert {segment.zone for segment in anchor.segments} == {"MSK", "TRT"}
+
+
+# --- configuration ---------------------------------------------------------
+
+def test_the_reader_searches_small_corner_bands_by_default():
+    """Measured, not stylistic: the badge that reads cleanly out of a corner
+    box returns nothing out of a full-width band, because a wide crop buries a
+    two-word island in empty picture."""
+    assert reader(regions=None).regions == clock.CLOCK_REGIONS
+    assert all(w <= 0.35 and h <= 0.2 for _x, _y, w, h in clock.CLOCK_REGIONS)
+
+
+def test_the_page_segmentation_mode_is_the_sparse_one(monkeypatch):
+    """psm 11 is the difference between reading the badge and not reading it,
+    so the default has to reach the engine rather than being decorative."""
+    seen = {}
+    monkeypatch.setattr(
+        overlay, "default_ocr", lambda psm=None, lang=None: seen.update(psm=psm) or (lambda p: "")
+    )
+    ClockReader(zones=ZONES)
+    assert seen["psm"] == clock.CLOCK_PSM == 11
+
+
+def test_the_ocr_language_stays_the_callers_choice(monkeypatch):
+    """It has to be, and for a sharper reason than script coverage: the
+    language model changes the *digits*. On the sample footage the Cyrillic
+    model read a badge showing 21:35 as 21:55 while the Latin model, on the
+    same pixels, read it correctly. Neither reading is detectably wrong on its
+    own, so this module cannot arbitrate and must not silently pick."""
+    monkeypatch.delenv(overlay.LANG_ENV, raising=False)
+    assert reader().lang is None
+    assert reader(lang="ces").lang == "ces"
+    monkeypatch.setenv(overlay.LANG_ENV, "ces")
+    assert reader().lang == "ces"
+
+
+def test_the_clock_reader_knows_nothing_about_a_corpus():
+    """Structural, because a docstring cannot be linted. It may know about the
+    overlay reader; a roster, a sport or a fixed zone table would mean the
+    generic half has leaked into it."""
+    source = Path(clock.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module.split(".")[-1])
+        elif isinstance(node, ast.Import):
+            imported.update(alias.name.split(".")[0] for alias in node.names)
+    assert not (imported & {"scorebug", "jersey", "faces", "playbyplay", "roster"})


### PR DESCRIPTION
Part of #745 / #741 milestone 3. A consumer of the generic overlay reader from #744.

## Why this is the highest-value piece

Aligning video time to wall-clock time is the prerequisite for grounding anything in an archive. For the baseball pilot we derived **one** anchor by hand: found a scorebug count transition, cross-referenced it against an MLB GUMBO feed, computed `anchor = pitch_epoch - video_t`, then verified drift by repeating the exercise at the other end of a 3h24m file. Hours of work, and only possible because a structured feed existed.

News burns the clock into the frame. This reads it.

## Verified on real footage

A 4 minute TV Rain talk-show segment, streamed, `lang="rus"`, `zones={"МСК": "Europe/Moscow"}`:

```
clock reads: 13   bands_read: 108   conflicts: 0
anchor: lower_s=78904.0  upper_s=78906.0
```

**Video t=0 is 21:55:04 MSK, to within one second**, from a badge that only shows minutes.

It gets there by intersecting constraints from successive minute-flips rather than trusting any single reading:

| observation | implies anchor in |
|---|---|
| badge shows 21:55 at t=48, 21:56 at t=56 | `[78904, 78912)` |
| badge shows 21:56 at t=114, 21:57 at t=116 | `[78904, 78906)` |
| intersection | **`[78904, 78906)`** |

That is the same technique used by hand for the baseball anchor (find the transition, not the value), automated, and it converges as more flips are seen. I verified the arithmetic independently.

## Design points that matter

**Zones are required, with no default.** A badge label the reader does not know is a badge it declines to read. The worst failure mode here is a confident wrong answer: a bad anchor silently poisons every downstream citation, so declining beats guessing.

**The interpreter counts a band as a hit only when a plausible zone-labelled time comes out of it.** That is what keeps the band search off the crowd, the ticker and the poll panel, all of which return text and none of which return a time beside a known zone label. Per #744, the hit count drives band lock and cannot be the reader's own judgement.

**Corroboration, spread, and conflicts are reported**, not averaged away. `conflicts=0` above; a file with edits that imply different anchors should say so rather than produce a plausible mean.

**Timezone is parsed data.** `МСК` is not hardcoded anywhere; the caller says what its corpus prints.

## Status

The agent that wrote this hit a session limit before finishing its own validation pass. I picked it up, verified it end to end on real footage, confirmed the anchor arithmetic by hand, and ran the gates: **191 tests pass** (154 before), ruff clean, zero em dashes in authored lines, submodule pin untouched.

**One rough edge I would fix before merge**: `ClockAnchor.__repr__` dumps every reading, so printing one anchor emits hundreds of lines (visible in the raw output above). It wants a compact repr with the readings behind an accessor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added burned-in clock recognition from OCR overlays.
  * Supports labeled time zones, optional dates, unlabeled clocks, midnight transitions, daylight-saving changes, and edited-file drift.
  * Provides wall-clock and epoch-time conversion with uncertainty details.
  * Rejects insufficient or conflicting readings instead of producing unreliable anchors.

* **Documentation**
  * Added setup and usage guidance, including clock positioning, required inputs, OCR configuration, and troubleshooting advice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->