### PR TITLE
perf(store): bound an embed batch at candidate selection (#743)

### DIFF
--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -2657,6 +2657,105 @@ func (s *SQLiteStore) CorpusStats(ctx context.Context) (model.CorpusStats, error
 	return stats, nil
 }
 
+// nextPendingQuery builds the SQL for one embed batch.
+//
+// Both selective predicates and the LIMIT sit INSIDE filtered_chunks. #732
+// fixed the same shape in embeddedChunkPageQuery; this one is #743. With
+// index_kind and the LIMIT outside the CTE, every call materialised the whole
+// pending set before discarding all but `limit` rows. That is not quadratic the
+// way the metadata walk was, because there is no cursor to compound it, but it
+// runs once per embed cycle for the life of an ingest: a deep queue paid a full
+// scan of everything still pending on every batch.
+//
+// The first span comes from a correlated MIN(span_id) rather than a
+// ROW_NUMBER() window for the reason #742 measured: with the LIMIT pushed down,
+// the window made SQLite drive the join off a full scan of `spans`, which cost
+// more than the CTE fix saved.
+//
+// The documents LEFT JOIN stays inside the CTE because it is a predicate, not
+// decoration: a chunk whose parent document is errored or tombstoned must not
+// be handed to the embed worker. The NULL guard preserves a chunk with no
+// document row (UpsertChunkTask seeds bare chunks).
+//
+// idx_chunks_embedded_kind_seek (embedding_status, deleted, index_kind,
+// chunk_id), added by #742, already covers this access path, so no new index.
+func nextPendingQuery(indexKind string, limit int) (string, []any) {
+	args := []any{"pending"}
+	kindPredicate := ""
+	if strings.TrimSpace(indexKind) != "" {
+		kindPredicate = " AND c.index_kind = ?"
+	}
+	query := `WITH filtered_chunks AS (
+	            SELECT c.chunk_id, c.rel_path, c.doc_type, c.rep_type, c.text, c.index_kind, c.modality, c.media_ref, c.language,
+	                   c.chunk_context,
+	                   COALESCE(d.mtime_unix, 0) AS mtime_unix
+	            FROM chunks c
+	            LEFT JOIN documents d ON d.rel_path = c.rel_path
+	            WHERE c.embedding_status = ? AND c.deleted = 0 AND c.chunk_id > 0
+	              AND (d.rel_path IS NULL OR (d.deleted = 0 AND d.status != 'error'))` + kindPredicate + `
+	            ORDER BY c.chunk_id
+	            LIMIT ?
+	          )
+	          SELECT fc.chunk_id, fc.rel_path, fc.doc_type, fc.rep_type, fc.text, fc.index_kind, fc.modality, fc.media_ref, fc.language,
+	                 fc.chunk_context,
+	                 COALESCE(sp.span_kind, ''), COALESCE(sp.start, 0), COALESCE(sp."end", 0), COALESCE(sp.extra_json, ''), fc.mtime_unix
+	          FROM filtered_chunks fc
+	          LEFT JOIN spans sp ON sp.span_id = (
+	            SELECT MIN(s.span_id) FROM spans s WHERE s.chunk_id = fc.chunk_id
+	          )
+	          ORDER BY fc.chunk_id`
+	if kindPredicate != "" {
+		args = append(args, indexKind)
+	}
+	args = append(args, limit)
+	return query, args
+}
+
+// NextPendingQueryForTest returns the SQL one embed batch runs.
+//
+// Exported solely so the #743 regression test can live under tests/ as
+// AGENTS.md requires. As #732 established, a query-plan assertion is not a
+// sufficient guard: with the predicates outside the CTE SQLite still picks a
+// reasonable index, so a plan-only test passes against unfixed code. What has
+// to be pinned is WHERE in the statement the predicates and the LIMIT sit.
+// Production code never calls this.
+func NextPendingQueryForTest(indexKind string, limit int) (string, []any) {
+	return nextPendingQuery(indexKind, limit)
+}
+
+// ExplainNextPendingForTest returns the SQLite query plan (one string per plan
+// row) for a single embed batch.
+//
+// Exported solely so the #743 regression test can live under tests/ as
+// AGENTS.md requires: the property worth pinning is that a batch SEEKS its rows
+// through an index rather than scanning the whole chunks table, which is not
+// observable through the ordinary store API. Production code never calls this.
+func (s *SQLiteStore) ExplainNextPendingForTest(ctx context.Context, indexKind string, limit int) ([]string, error) {
+	db, err := s.ensureReadDB(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer s.ReleaseDB()
+
+	query, args := nextPendingQuery(indexKind, limit)
+	rows, err := db.QueryContext(ctx, "EXPLAIN QUERY PLAN "+query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var plan []string
+	for rows.Next() {
+		var id, parent, notUsed int
+		var detail string
+		if err := rows.Scan(&id, &parent, &notUsed, &detail); err != nil {
+			return nil, err
+		}
+		plan = append(plan, detail)
+	}
+	return plan, rows.Err()
+}
+
 func (s *SQLiteStore) NextPending(ctx context.Context, limit int, indexKind string) ([]model.ChunkTask, error) {
 	db, err := s.ensureDB(ctx)
 	if err != nil {
@@ -2667,40 +2766,7 @@ func (s *SQLiteStore) NextPending(ctx context.Context, limit int, indexKind stri
 		limit = 32
 	}
 
-	args := []any{"pending"}
-	// Skip chunks whose parent document is errored or tombstoned: a doc whose
-	// status is 'error' (e.g. a later representation failed after an earlier
-	// rep's chunks committed) or is deleted must not keep live embeddable
-	// chunks that the embed worker re-embeds every cycle. Documents are keyed
-	// by rel_path, which chunks denormalize, so a LEFT JOIN on it predicates
-	// the parent's lifecycle at candidate selection. The NULL guard preserves a
-	// chunk with no document row (e.g. UpsertChunkTask seeds a bare chunk).
-	query := `WITH filtered_chunks AS (
-	            SELECT c.chunk_id, c.rel_path, c.doc_type, c.rep_type, c.text, c.index_kind, c.modality, c.media_ref, c.language,
-	                   c.chunk_context,
-	                   COALESCE(d.mtime_unix, 0) AS mtime_unix
-	            FROM chunks c
-	            LEFT JOIN documents d ON d.rel_path = c.rel_path
-	            WHERE c.embedding_status = ? AND c.deleted = 0 AND c.chunk_id > 0
-	              AND (d.rel_path IS NULL OR (d.deleted = 0 AND d.status != 'error'))
-	          ),
-	          ranked_spans AS (
-	            SELECT s.chunk_id, s.span_kind, s.start, s."end", s.extra_json,
-	                   ROW_NUMBER() OVER (PARTITION BY s.chunk_id ORDER BY s.span_id) AS rn
-	            FROM spans s
-	            JOIN filtered_chunks fc ON fc.chunk_id = s.chunk_id
-	          )
-	          SELECT fc.chunk_id, fc.rel_path, fc.doc_type, fc.rep_type, fc.text, fc.index_kind, fc.modality, fc.media_ref, fc.language,
-	                 fc.chunk_context,
-	                 COALESCE(sp.span_kind, ''), COALESCE(sp.start, 0), COALESCE(sp.end, 0), COALESCE(sp.extra_json, ''), fc.mtime_unix
-	          FROM filtered_chunks fc
-	          LEFT JOIN ranked_spans sp ON sp.chunk_id = fc.chunk_id AND sp.rn = 1`
-	if strings.TrimSpace(indexKind) != "" {
-		query += " WHERE fc.index_kind = ?"
-		args = append(args, indexKind)
-	}
-	args = append(args, limit)
-	query += " ORDER BY fc.chunk_id LIMIT ?"
+	query, args := nextPendingQuery(indexKind, limit)
 
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {

--- a/tests/store/next_pending_743_test.go
+++ b/tests/store/next_pending_743_test.go
@@ -246,14 +246,39 @@ type pendingSeed struct {
 	deletedDoc int64
 }
 
-// seedPendingCorpus builds a corpus whose kinds INTERLEAVE by chunk_id (text,
-// code, text, code, ...) plus the rows a batch must exclude: already-embedded
-// and failed chunks, a soft-deleted chunk, and chunks whose parent document is
-// errored or tombstoned.
-func seedPendingCorpus(t *testing.T, st *store.SQLiteStore) pendingSeed {
+// chunkInserter inserts seed chunks and carries the first error, so the seed
+// below reads as the corpus it describes rather than as one error check per
+// row. `add` returns 0 once an error has been recorded; the caller checks `err`
+// once at the end.
+type chunkInserter struct {
+	ctx     context.Context
+	tx      model.RepresentationStore
+	reps    map[string]int64
+	ordinal int
+	err     error
+}
+
+func (ci *chunkInserter) add(relPath, kind, status string, deleted bool, spans []model.Span) int64 {
+	if ci.err != nil {
+		return 0
+	}
+	ci.ordinal++
+	id, err := ci.tx.InsertChunkWithSpans(ci.ctx, model.Chunk{
+		RepID: ci.reps[relPath], Ordinal: ci.ordinal, Text: "chunk " + kind, TextHash: "h",
+		IndexKind: kind, EmbeddingStatus: status, Deleted: deleted,
+	}, spans)
+	if err != nil {
+		ci.err = err
+		return 0
+	}
+	return id
+}
+
+// seedPendingDocuments creates the three parent documents the corpus needs: a
+// healthy one, an errored one and a tombstoned one.
+func seedPendingDocuments(t *testing.T, st *store.SQLiteStore) map[string]int64 {
 	t.Helper()
 	ctx := context.Background()
-
 	docs := []struct {
 		relPath string
 		status  string
@@ -277,81 +302,57 @@ func seedPendingCorpus(t *testing.T, st *store.SQLiteStore) pendingSeed {
 		}
 		ids[d.relPath] = doc.DocID
 	}
+	return ids
+}
+
+// seedPendingCorpus builds a corpus whose kinds INTERLEAVE by chunk_id (text,
+// code, text, code, ...) plus the rows a batch must exclude: already-embedded
+// and errored chunks, a soft-deleted chunk, and chunks whose parent document is
+// errored or tombstoned.
+func seedPendingCorpus(t *testing.T, st *store.SQLiteStore) pendingSeed {
+	t.Helper()
+	ctx := context.Background()
+
+	docIDs := seedPendingDocuments(t, st)
 
 	var seed pendingSeed
 	err := st.WithTx(ctx, func(tx model.RepresentationStore) error {
-		reps := map[string]int64{}
-		for relPath, docID := range ids {
+		ins := &chunkInserter{ctx: ctx, tx: tx, reps: map[string]int64{}}
+		for relPath, docID := range docIDs {
 			repID, rerr := tx.UpsertRepresentation(ctx, model.Representation{
 				DocID: docID, RepType: "raw_text", RepHash: "h-" + relPath,
 			})
 			if rerr != nil {
 				return rerr
 			}
-			reps[relPath] = repID
-		}
-		ordinal := 0
-		insert := func(relPath, kind, status string, deleted bool, spans []model.Span) (int64, error) {
-			ordinal++
-			return tx.InsertChunkWithSpans(ctx, model.Chunk{
-				RepID: reps[relPath], Ordinal: ordinal, Text: "chunk " + kind, TextHash: "h",
-				IndexKind: kind, EmbeddingStatus: status, Deleted: deleted,
-			}, spans)
+			ins.reps[relPath] = repID
 		}
 		for i := 0; i < 3; i++ {
-			id, cerr := insert("notes/a.md", "text", "pending", false,
-				[]model.Span{{Kind: "lines", StartLine: 1, EndLine: 2}})
-			if cerr != nil {
-				return cerr
-			}
-			seed.text = append(seed.text, id)
-			id, cerr = insert("notes/a.md", "code", "pending", false,
-				[]model.Span{{Kind: "lines", StartLine: 3, EndLine: 4}})
-			if cerr != nil {
-				return cerr
-			}
-			seed.code = append(seed.code, id)
+			seed.text = append(seed.text, ins.add("notes/a.md", "text", "pending", false,
+				[]model.Span{{Kind: "lines", StartLine: 1, EndLine: 2}}))
+			seed.code = append(seed.code, ins.add("notes/a.md", "code", "pending", false,
+				[]model.Span{{Kind: "lines", StartLine: 3, EndLine: 4}}))
 		}
-		// Rows a batch must never return.
-		if _, cerr := insert("notes/a.md", "text", "ok", false, nil); cerr != nil {
-			return cerr
-		}
-		// "error", not "failed": normalizeEmbeddingStatus knows only
-		// ok/error/pending and maps anything else to pending, so a chunk seeded
-		// as "failed" is a PENDING chunk and would not test what it looks like
-		// it tests.
-		if _, cerr := insert("notes/a.md", "text", "error", false, nil); cerr != nil {
-			return cerr
-		}
-		if _, cerr := insert("notes/a.md", "text", "pending", true, nil); cerr != nil {
-			return cerr
-		}
-		id, cerr := insert("notes/bad.md", "text", "pending", false, nil)
-		if cerr != nil {
-			return cerr
-		}
-		seed.erroredDoc = id
-		if id, cerr = insert("notes/gone.md", "text", "pending", false, nil); cerr != nil {
-			return cerr
-		}
-		seed.deletedDoc = id
+		// Rows a batch must never return. "error", not "failed":
+		// normalizeEmbeddingStatus knows only ok/error/pending and maps anything
+		// else to pending, so a chunk seeded as "failed" is a PENDING chunk and
+		// would not test what it looks like it tests.
+		ins.add("notes/a.md", "text", "ok", false, nil)
+		ins.add("notes/a.md", "text", "error", false, nil)
+		ins.add("notes/a.md", "text", "pending", true, nil)
+		seed.erroredDoc = ins.add("notes/bad.md", "text", "pending", false, nil)
+		seed.deletedDoc = ins.add("notes/gone.md", "text", "pending", false, nil)
 
 		// A multi-span chunk (the batch must carry its FIRST span) and a
 		// span-less one.
-		if id, cerr = insert("notes/a.md", "text", "pending", false, []model.Span{
+		seed.multiSpan = ins.add("notes/a.md", "text", "pending", false, []model.Span{
 			{Kind: "lines", StartLine: 10, EndLine: 11},
 			{Kind: "lines", StartLine: 20, EndLine: 21},
-		}); cerr != nil {
-			return cerr
-		}
-		seed.multiSpan = id
-		seed.text = append(seed.text, id)
-		if id, cerr = insert("notes/a.md", "text", "pending", false, nil); cerr != nil {
-			return cerr
-		}
-		seed.noSpan = id
-		seed.text = append(seed.text, id)
-		return nil
+		})
+		seed.text = append(seed.text, seed.multiSpan)
+		seed.noSpan = ins.add("notes/a.md", "text", "pending", false, nil)
+		seed.text = append(seed.text, seed.noSpan)
+		return ins.err
 	})
 	if err != nil {
 		t.Fatalf("seed corpus: %v", err)

--- a/tests/store/next_pending_743_test.go
+++ b/tests/store/next_pending_743_test.go
@@ -1,0 +1,374 @@
+package tests
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// #743: NextPending carried the same defect #732 fixed in
+// ListEmbeddedChunkMetadata. The index_kind filter and the batch LIMIT sat
+// OUTSIDE the CTE that gathered candidate chunks, so every call materialized
+// the entire pending set and threw all but one batch away.
+//
+// The blast radius differs. The metadata walk is driven by a keyset cursor, so
+// the repeated materialization compounded into O(N^2) across a startup walk.
+// NextPending has no cursor, so a call is O(pending) rather than quadratic. But
+// it runs once per embed cycle for the life of an ingest, so a deep queue paid
+// a full scan of everything still pending on every batch.
+//
+// These tests pin the shape of the fix and the contract it had to preserve.
+
+// TestNextPending_BoundsTheBatchAtCandidateSelection pins the placement of the
+// two selective predicates, which is the whole fix. As #732 established this
+// has to be a statement-shape assertion rather than a plan assertion: with the
+// kind filter and the LIMIT in the outer query the planner still picks a
+// perfectly reasonable index for the CTE, it just runs it over the whole
+// pending set and discards the surplus, so a plan-only test passes against
+// unfixed code.
+func TestNextPending_BoundsTheBatchAtCandidateSelection(t *testing.T) {
+	for _, kind := range []string{"text", ""} {
+		query, args := store.NextPendingQueryForTest(kind, 32)
+
+		// Everything up to the outer SELECT is the candidate CTE.
+		outer := strings.Index(query, "SELECT fc.chunk_id")
+		if outer < 0 {
+			t.Fatalf("kind=%q: cannot locate the outer SELECT in:\n%s", kind, query)
+		}
+		cte, tail := query[:outer], query[outer:]
+
+		if !strings.Contains(cte, "LIMIT ?") {
+			t.Fatalf("kind=%q: the batch LIMIT is not applied at candidate selection; every embed cycle will materialize the whole pending set (#743):\n%s", kind, query)
+		}
+		if strings.Contains(tail, "LIMIT") {
+			t.Fatalf("kind=%q: an outer LIMIT is back, so the CTE is unbounded again (#743):\n%s", kind, query)
+		}
+		// The ROW_NUMBER() window is what #742 measured driving the spans join
+		// off a full table scan once the LIMIT moved down.
+		if strings.Contains(query, "ROW_NUMBER()") {
+			t.Fatalf("kind=%q: the ROW_NUMBER() window is back; with the LIMIT pushed down it makes SQLite scan the whole spans table (#742, #743):\n%s", kind, query)
+		}
+		if kind != "" {
+			if !strings.Contains(cte, "c.index_kind = ?") {
+				t.Fatalf("kind=%q: the index_kind filter is not applied at candidate selection (#743):\n%s", kind, query)
+			}
+			if strings.Contains(tail, "index_kind = ?") {
+				t.Fatalf("kind=%q: the index_kind filter is back in the outer query (#743):\n%s", kind, query)
+			}
+		} else if strings.Contains(query, "index_kind = ?") {
+			// The kind is optional and must stay optional: an empty kind means
+			// "every pending chunk" and must not bind a placeholder.
+			t.Fatalf("unfiltered batch still filters on index_kind:\n%s", query)
+		}
+
+		// Moving a predicate moves its placeholder, so the positional arguments
+		// have to be rebuilt in step with it: one argument per "?", in order.
+		if placeholders := strings.Count(query, "?"); len(args) != placeholders {
+			t.Fatalf("kind=%q: %d args for %d placeholders: %v", kind, len(args), placeholders, args)
+		}
+		if args[0] != "pending" {
+			t.Fatalf("kind=%q: leading arg is %v, want the pending status", kind, args[0])
+		}
+		if args[len(args)-1] != 32 {
+			t.Fatalf("kind=%q: last arg is %v, want the limit 32", kind, args[len(args)-1])
+		}
+	}
+}
+
+// TestNextPending_PlanSeeksRatherThanScans backs the placement assertion with
+// the plan it buys. #743 predicted idx_chunks_embedded_kind_seek (added by
+// #742) would already serve this access path; this pins that it does, so no
+// second index was needed.
+func TestNextPending_PlanSeeksRatherThanScans(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+	seedPendingCorpus(t, st)
+
+	t.Run("kind scoped batch seeks on the kind too", func(t *testing.T) {
+		plan, err := st.ExplainNextPendingForTest(ctx, "text", 32)
+		if err != nil {
+			t.Fatalf("ExplainNextPendingForTest: %v", err)
+		}
+		if !planHas(plan, "index_kind=?") {
+			t.Fatalf("kind-scoped batch does not seek on index_kind; plan:\n%s", strings.Join(plan, "\n"))
+		}
+		if !planHas(plan, "idx_chunks_embedded_kind_seek") {
+			t.Fatalf("kind-scoped batch does not use idx_chunks_embedded_kind_seek, so #742's index does not cover #743 after all; plan:\n%s", strings.Join(plan, "\n"))
+		}
+		assertNoTableScan(t, plan)
+	})
+
+	t.Run("unfiltered batch still seeks", func(t *testing.T) {
+		plan, err := st.ExplainNextPendingForTest(ctx, "", 32)
+		if err != nil {
+			t.Fatalf("ExplainNextPendingForTest: %v", err)
+		}
+		assertNoTableScan(t, plan)
+	})
+}
+
+// TestNextPending_LimitCountsMatchingRows pins the half of the contract the
+// pushed-down LIMIT could most easily have broken: the LIMIT counts rows that
+// MATCH the kind, not rows examined before the kind filter. The seeded corpus
+// interleaves kinds by chunk_id, so a 2-row "code" batch must still return two
+// code chunks rather than whatever the first two pending rows happened to be.
+func TestNextPending_LimitCountsMatchingRows(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+	seed := seedPendingCorpus(t, st)
+
+	batch, err := st.NextPending(ctx, 2, "code")
+	if err != nil {
+		t.Fatalf("NextPending(code): %v", err)
+	}
+	if got := chunkIDs(batch); len(got) != 2 || got[0] != seed.code[0] || got[1] != seed.code[1] {
+		t.Fatalf("code batch = %v, want the first two pending code chunks %v", got, seed.code[:2])
+	}
+	for _, task := range batch {
+		if task.IndexKind != "code" {
+			t.Fatalf("chunk %d has index_kind %q on a code batch", task.Metadata.ChunkID, task.IndexKind)
+		}
+	}
+}
+
+// TestNextPending_ExcludesChunksOfErroredOrDeletedDocuments pins the predicate
+// that had to stay INSIDE the CTE when the LIMIT moved in beside it. A chunk
+// whose parent document is errored or tombstoned must never reach the embed
+// worker, and a chunk with no document row at all must still be handed over.
+func TestNextPending_ExcludesChunksOfErroredOrDeletedDocuments(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+	seed := seedPendingCorpus(t, st)
+
+	batch, err := st.NextPending(ctx, 100, "")
+	if err != nil {
+		t.Fatalf("NextPending(all): %v", err)
+	}
+	got := map[int64]bool{}
+	for _, id := range chunkIDs(batch) {
+		got[id] = true
+	}
+	if got[seed.erroredDoc] {
+		t.Fatalf("chunk %d of an errored document was handed to the embed worker", seed.erroredDoc)
+	}
+	if got[seed.deletedDoc] {
+		t.Fatalf("chunk %d of a tombstoned document was handed to the embed worker", seed.deletedDoc)
+	}
+	if !got[seed.orphan] {
+		t.Fatalf("chunk %d has no document row and must still be embeddable", seed.orphan)
+	}
+}
+
+// TestNextPending_RowPayloadUnchanged pins the per-row payload across the join
+// rewrite: the FIRST span of a multi-span chunk (the lowest span_id, which is
+// the row the previous ROW_NUMBER() window picked), the joined document mtime,
+// and a span-less chunk still being returned.
+func TestNextPending_RowPayloadUnchanged(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+	seed := seedPendingCorpus(t, st)
+
+	batch, err := st.NextPending(ctx, 100, "")
+	if err != nil {
+		t.Fatalf("NextPending(all): %v", err)
+	}
+	byID := map[uint64]model.ChunkTask{}
+	for _, task := range batch {
+		byID[task.Metadata.ChunkID] = task
+	}
+
+	multi, ok := byID[uint64(seed.multiSpan)]
+	if !ok {
+		t.Fatalf("multi-span chunk %d missing from the batch", seed.multiSpan)
+	}
+	if multi.Metadata.Span.StartLine != 10 || multi.Metadata.Span.EndLine != 11 {
+		t.Fatalf("multi-span chunk carries span %+v, want the first span (lines 10-11)", multi.Metadata.Span)
+	}
+	if multi.Metadata.MTimeUnix != seedMTime {
+		t.Fatalf("mtime = %d, want %d", multi.Metadata.MTimeUnix, seedMTime)
+	}
+
+	none, ok := byID[uint64(seed.noSpan)]
+	if !ok {
+		t.Fatalf("span-less chunk %d missing from the batch", seed.noSpan)
+	}
+	if none.Metadata.Span.StartLine != 0 || none.Metadata.Span.EndLine != 0 {
+		t.Fatalf("span-less chunk carries span %+v, want an empty lines span", none.Metadata.Span)
+	}
+}
+
+// TestNextPending_DrainsEveryPendingChunkOnce pins that repeatedly asking for
+// the next batch, marking each one embedded as the worker does, still yields
+// every pending chunk exactly once and in ascending chunk_id order, at any
+// batch size.
+func TestNextPending_DrainsEveryPendingChunkOnce(t *testing.T) {
+	for _, batchSize := range []int{1, 2, 100} {
+		ctx := context.Background()
+		st := newTestStore(t)
+		seed := seedPendingCorpus(t, st)
+		want := mergeSorted(seed.text, seed.code)
+
+		var drained []int64
+		for {
+			batch, err := st.NextPending(ctx, batchSize, "")
+			if err != nil {
+				t.Fatalf("batchSize=%d: NextPending: %v", batchSize, err)
+			}
+			if len(batch) == 0 {
+				break
+			}
+			labels := make([]uint64, 0, len(batch))
+			for _, task := range batch {
+				drained = append(drained, int64(task.Metadata.ChunkID))
+				labels = append(labels, task.Metadata.ChunkID)
+			}
+			if err := st.MarkEmbedded(ctx, labels); err != nil {
+				t.Fatalf("batchSize=%d: MarkEmbedded: %v", batchSize, err)
+			}
+		}
+		if !sameIDs(drained, want) {
+			t.Fatalf("batchSize=%d: drained %v, want %v", batchSize, drained, want)
+		}
+	}
+}
+
+// pendingSeed records the chunk ids the corpus below was built from.
+type pendingSeed struct {
+	text       []int64
+	code       []int64
+	multiSpan  int64
+	noSpan     int64
+	orphan     int64
+	erroredDoc int64
+	deletedDoc int64
+}
+
+// seedPendingCorpus builds a corpus whose kinds INTERLEAVE by chunk_id (text,
+// code, text, code, ...) plus the rows a batch must exclude: already-embedded
+// and failed chunks, a soft-deleted chunk, and chunks whose parent document is
+// errored or tombstoned.
+func seedPendingCorpus(t *testing.T, st *store.SQLiteStore) pendingSeed {
+	t.Helper()
+	ctx := context.Background()
+
+	docs := []struct {
+		relPath string
+		status  string
+		deleted bool
+	}{
+		{"notes/a.md", "ok", false},
+		{"notes/bad.md", "error", false},
+		{"notes/gone.md", "ok", true},
+	}
+	ids := map[string]int64{}
+	for _, d := range docs {
+		if err := st.UpsertDocument(ctx, model.Document{
+			RelPath: d.relPath, DocType: "md", SourceType: "local", Status: d.status,
+			Title: "Doc", MTimeUnix: seedMTime, Deleted: d.deleted,
+		}); err != nil {
+			t.Fatalf("UpsertDocument(%s): %v", d.relPath, err)
+		}
+		doc, err := st.GetDocumentByPath(ctx, d.relPath)
+		if err != nil {
+			t.Fatalf("GetDocumentByPath(%s): %v", d.relPath, err)
+		}
+		ids[d.relPath] = doc.DocID
+	}
+
+	var seed pendingSeed
+	err := st.WithTx(ctx, func(tx model.RepresentationStore) error {
+		reps := map[string]int64{}
+		for relPath, docID := range ids {
+			repID, rerr := tx.UpsertRepresentation(ctx, model.Representation{
+				DocID: docID, RepType: "raw_text", RepHash: "h-" + relPath,
+			})
+			if rerr != nil {
+				return rerr
+			}
+			reps[relPath] = repID
+		}
+		ordinal := 0
+		insert := func(relPath, kind, status string, deleted bool, spans []model.Span) (int64, error) {
+			ordinal++
+			return tx.InsertChunkWithSpans(ctx, model.Chunk{
+				RepID: reps[relPath], Ordinal: ordinal, Text: "chunk " + kind, TextHash: "h",
+				IndexKind: kind, EmbeddingStatus: status, Deleted: deleted,
+			}, spans)
+		}
+		for i := 0; i < 3; i++ {
+			id, cerr := insert("notes/a.md", "text", "pending", false,
+				[]model.Span{{Kind: "lines", StartLine: 1, EndLine: 2}})
+			if cerr != nil {
+				return cerr
+			}
+			seed.text = append(seed.text, id)
+			id, cerr = insert("notes/a.md", "code", "pending", false,
+				[]model.Span{{Kind: "lines", StartLine: 3, EndLine: 4}})
+			if cerr != nil {
+				return cerr
+			}
+			seed.code = append(seed.code, id)
+		}
+		// Rows a batch must never return.
+		if _, cerr := insert("notes/a.md", "text", "ok", false, nil); cerr != nil {
+			return cerr
+		}
+		// "error", not "failed": normalizeEmbeddingStatus knows only
+		// ok/error/pending and maps anything else to pending, so a chunk seeded
+		// as "failed" is a PENDING chunk and would not test what it looks like
+		// it tests.
+		if _, cerr := insert("notes/a.md", "text", "error", false, nil); cerr != nil {
+			return cerr
+		}
+		if _, cerr := insert("notes/a.md", "text", "pending", true, nil); cerr != nil {
+			return cerr
+		}
+		id, cerr := insert("notes/bad.md", "text", "pending", false, nil)
+		if cerr != nil {
+			return cerr
+		}
+		seed.erroredDoc = id
+		if id, cerr = insert("notes/gone.md", "text", "pending", false, nil); cerr != nil {
+			return cerr
+		}
+		seed.deletedDoc = id
+
+		// A multi-span chunk (the batch must carry its FIRST span) and a
+		// span-less one.
+		if id, cerr = insert("notes/a.md", "text", "pending", false, []model.Span{
+			{Kind: "lines", StartLine: 10, EndLine: 11},
+			{Kind: "lines", StartLine: 20, EndLine: 21},
+		}); cerr != nil {
+			return cerr
+		}
+		seed.multiSpan = id
+		seed.text = append(seed.text, id)
+		if id, cerr = insert("notes/a.md", "text", "pending", false, nil); cerr != nil {
+			return cerr
+		}
+		seed.noSpan = id
+		seed.text = append(seed.text, id)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("seed corpus: %v", err)
+	}
+
+	// A chunk with no document row at all: UpsertChunkTask seeds bare chunks
+	// against a caller-chosen id, and the NULL guard in the CTE exists to keep
+	// them embeddable. The id sorts after every chunk above so the drain order
+	// stays ascending.
+	const orphanID = 900001
+	if err := st.UpsertChunkTask(ctx, model.ChunkTask{
+		Label: orphanID, Text: "orphan chunk", IndexKind: "text",
+		Metadata: model.ChunkMetadata{ChunkID: orphanID, RelPath: "notes/orphan.md"},
+	}); err != nil {
+		t.Fatalf("UpsertChunkTask: %v", err)
+	}
+	seed.orphan = orphanID
+	seed.text = append(seed.text, orphanID)
+	return seed
+}

--- a/tests/store/next_pending_perf_743_test.go
+++ b/tests/store/next_pending_perf_743_test.go
@@ -1,0 +1,172 @@
+package tests
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// TestNextPendingDrainPerf_743 measures what an ingest actually pays: the cost
+// of NextPending per embed cycle as a deep queue drains, not the cost of one
+// call. It is a measurement harness, not an assertion, and is skipped unless
+// DIR2MCP_PERF=1 so `go test ./...` stays fast.
+//
+// The distinction matters for reading the result. #732's walk was quadratic
+// because a keyset cursor compounded the repeated full materialization.
+// NextPending has no cursor, so the pre-fix cost is flat-but-wrong: every cycle
+// re-materialized the whole remaining pending set. That shows up here as a
+// per-cycle time that tracks the DEPTH OF THE QUEUE rather than the batch size,
+// and it should fall away as the queue drains. After the fix a cycle touches a
+// bounded number of rows, so per-cycle time should be flat and small from the
+// first cycle to the last.
+//
+// The kind split follows key order (low chunk_ids are "text", high ones
+// "code"), which is the shape that punished the pre-fix CTE hardest: a "code"
+// batch had to drag every pending "text" row through the CTE before the outer
+// filter discarded them.
+//
+//	DIR2MCP_PERF=1 go test ./tests/store -run NextPendingDrainPerf -v
+//	DIR2MCP_PERF=1 DIR2MCP_PERF_CHUNKS=200000 go test ./tests/store -run NextPendingDrainPerf -v
+func TestNextPendingDrainPerf_743(t *testing.T) {
+	if os.Getenv("DIR2MCP_PERF") != "1" {
+		t.Skip("set DIR2MCP_PERF=1 to run the #743 drain measurement")
+	}
+	total := 100000
+	if raw := os.Getenv("DIR2MCP_PERF_CHUNKS"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n <= 0 {
+			t.Fatalf("DIR2MCP_PERF_CHUNKS=%q: want a positive integer", raw)
+		}
+		total = n
+	}
+
+	for _, kind := range []string{"code", "text", ""} {
+		label := kind
+		if label == "" {
+			label = "all"
+		}
+		ctx := context.Background()
+		dbPath := filepath.Join(t.TempDir(), "perf.sqlite")
+		st := store.NewSQLiteStore(dbPath)
+		if err := st.Init(ctx); err != nil {
+			t.Fatalf("Init: %v", err)
+		}
+		seedSyntheticPendingCorpus(t, dbPath, total)
+
+		// A handful of cycles is enough to show the shape: the interesting
+		// comparison is the FIRST cycle (deepest queue) against a later one.
+		const batchSize = 32
+		const cycles = 20
+		var first, last time.Duration
+		start := time.Now()
+		for cycle := 0; cycle < cycles; cycle++ {
+			cycleStart := time.Now()
+			batch, err := st.NextPending(ctx, batchSize, kind)
+			if err != nil {
+				t.Fatalf("kind=%s cycle=%d: NextPending: %v", label, cycle, err)
+			}
+			elapsed := time.Since(cycleStart)
+			if cycle == 0 {
+				first = elapsed
+			}
+			last = elapsed
+			if len(batch) == 0 {
+				break
+			}
+			labels := make([]uint64, 0, len(batch))
+			for _, task := range batch {
+				labels = append(labels, task.Metadata.ChunkID)
+			}
+			if err := st.MarkEmbedded(ctx, labels); err != nil {
+				t.Fatalf("kind=%s cycle=%d: MarkEmbedded: %v", label, cycle, err)
+			}
+		}
+		t.Logf("kind=%-4s batch=%d cycles=%d first=%v last=%v total=%v",
+			label, batchSize, cycles, first, last, time.Since(start))
+		_ = st.Close()
+	}
+}
+
+// seedSyntheticPendingCorpus bulk-inserts total PENDING chunks (plus their
+// documents, representations and one span each) straight into the schema the
+// store just created. It writes on its own connection because the goal is a
+// large queue in seconds, not exercising the store's write path.
+func seedSyntheticPendingCorpus(t *testing.T, dbPath string, total int) {
+	t.Helper()
+	db, err := sql.Open("sqlite", "file:"+dbPath+"?_pragma=journal_mode(WAL)&_pragma=synchronous(OFF)")
+	if err != nil {
+		t.Fatalf("open seed handle: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	const chunksPerDoc = 100
+	body := strings.Repeat("lorem ipsum dolor sit amet ", 15)
+	start := time.Now()
+
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("begin seed tx: %v", err)
+	}
+	docStmt, err := tx.Prepare(`INSERT INTO documents (rel_path, doc_type, source_type, title, mtime_unix, status, deleted)
+	                            VALUES (?, 'md', 'local', ?, 1700000000, 'ok', 0)`)
+	if err != nil {
+		t.Fatalf("prepare document insert: %v", err)
+	}
+	repStmt, err := tx.Prepare(`INSERT INTO representations (rep_id, doc_id, rep_type, rep_hash, created_unix, deleted)
+	                            VALUES (?, ?, 'raw_text', 'h', 1700000000, 0)`)
+	if err != nil {
+		t.Fatalf("prepare representation insert: %v", err)
+	}
+	chunkStmt, err := tx.Prepare(`INSERT INTO chunks (chunk_id, rep_id, ordinal, rel_path, doc_type, rep_type, text, index_kind, modality, language, embedding_status, deleted)
+	                              VALUES (?, ?, ?, ?, 'md', 'raw_text', ?, ?, 'text', 'en', 'pending', 0)`)
+	if err != nil {
+		t.Fatalf("prepare chunk insert: %v", err)
+	}
+	spanStmt, err := tx.Prepare(`INSERT INTO spans (chunk_id, span_kind, start, end, extra_json) VALUES (?, 'lines', ?, ?, '')`)
+	if err != nil {
+		t.Fatalf("prepare span insert: %v", err)
+	}
+
+	half := total / 2
+	docID := 0
+	for i := 1; i <= total; i++ {
+		kind := "text"
+		if i > half {
+			kind = "code"
+		}
+		if (i-1)%chunksPerDoc == 0 {
+			docID++
+			relPath := fmt.Sprintf("corpus/%s/doc-%05d.md", kind, docID)
+			if _, err := docStmt.Exec(relPath, "Doc "+strconv.Itoa(docID)); err != nil {
+				t.Fatalf("insert document %d: %v", docID, err)
+			}
+			if _, err := repStmt.Exec(docID, docID); err != nil {
+				t.Fatalf("insert representation %d: %v", docID, err)
+			}
+		}
+		relPath := fmt.Sprintf("corpus/%s/doc-%05d.md", kind, docID)
+		if _, err := chunkStmt.Exec(i, docID, (i-1)%chunksPerDoc, relPath, body, kind); err != nil {
+			t.Fatalf("insert chunk %d: %v", i, err)
+		}
+		if _, err := spanStmt.Exec(i, i, i+5); err != nil {
+			t.Fatalf("insert span %d: %v", i, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit seed tx: %v", err)
+	}
+	// Deliberately no ANALYZE, for the reason #732's harness gives: production
+	// never runs it, so measuring with sqlite_stat1 present would measure a
+	// planner the daemon never has.
+	t.Logf("seeded %d pending chunks in %v", total, time.Since(start))
+}


### PR DESCRIPTION
Closes #743.

`NextPending` carried the shape #732 fixed in `ListEmbeddedChunkMetadata`: the `index_kind` filter and the batch `LIMIT` sat **outside** the CTE that gathered candidate chunks, so every call materialised the entire pending set and threw all but one batch away.

Without a keyset cursor to compound it this is not quadratic the way the metadata walk was. But it runs **once per embed cycle for the life of an ingest**, so a deep queue paid a full scan of everything still pending on every batch.

## The fix

Same as #742:

- Both selective predicates and the `LIMIT` move **into** the CTE.
- The `ROW_NUMBER()` window over `spans` becomes a correlated `MIN(span_id)`. #742 measured this as the difference between a bounded join and a full scan of `spans` once the `LIMIT` moves down.
- The `documents` LEFT JOIN stays inside the CTE, because it is a predicate (errored/tombstoned parents must not reach the embed worker), not decoration.

## Measured

Synthetic 100k-chunk pending queue, batch size 32, **per embed cycle**. "Before" is the pre-fix statement run against the same corpus, not an estimate:

| kind | before | after |
|------|--------|-------|
| code | 607 ms | 0.70 ms |
| text | 597 ms | 0.66 ms |
| all  | 595 ms | 0.65 ms |

Both are flat across cycles, which is the point: the old cost tracked the **depth of the queue** rather than the batch size, so it did not fall as the queue drained. Draining 100k chunks at batch 32 is 3125 cycles, or about **31 minutes of query overhead before and under two seconds after**.

Harness is opt-in, following #742's:

```bash
DIR2MCP_PERF=1 go test ./tests/store -run NextPendingDrainPerf -v
```

## No new index

#743 predicted `idx_chunks_embedded_kind_seek` (added by #742) would already serve this access path. It does. The plan test pins that and will fail if it stops being true.

## Tests

Following #732's structure, including its lesson that **a plan assertion is not a sufficient guard**: with the predicates outside the CTE the planner still picks a reasonable index, so a plan-only test passes against unfixed code. The guard is a statement-shape assertion on predicate placement, plus behaviour tests for what the pushed-down LIMIT could break:

- the LIMIT counts rows **matching the kind**, not rows examined before the filter
- chunks of errored or tombstoned parents stay out; a chunk with no document row stays in
- the **first** span of a multi-span chunk is still the one carried
- a full drain yields every pending chunk exactly once, at any batch size

## Note for the next seed author

The store's status vocabulary is `ok`/`error`/`pending`, and `normalizeEmbeddingStatus` maps anything else to `pending`. A chunk seeded as `"failed"` is a **pending** chunk. The drain test caught that here; #732's seed has the same mislabel, harmless there because it filters on `'ok'` and `"failed"` is excluded either way.