### PR TITLE
feat(annotator): read news overlays into citable text cues (#745 piece 4)

### DIFF
--- a/annotator/README.md
+++ b/annotator/README.md
@@ -104,6 +104,8 @@ roster; a news broadcast has no roster and no feed, so the words are the
 payload.
 
 ```python
+from pathlib import Path
+
 from dirstral_annotator.recognizers.news import NewsOverlayRecognizer
 
 cues = NewsOverlayRecognizer(lang="rus").recognize(Path("broadcast.mp4"))

--- a/annotator/README.md
+++ b/annotator/README.md
@@ -96,6 +96,49 @@ scorebug's:
   model returns `MCK` for Cyrillic `МСК`, so a Russian corpus may want both
   spellings in the table).
 
+### The news overlay interpreter
+
+`recognizers/news.py` is the corpus-side counterpart of the scorebug: same
+reader, different idea of what the text MEANS. Baseball resolves it against a
+roster; a news broadcast has no roster and no feed, so the words are the
+payload.
+
+```python
+from dirstral_annotator.recognizers.news import NewsOverlayRecognizer
+
+cues = NewsOverlayRecognizer(lang="rus").recognize(Path("broadcast.mp4"))
+# [Cue(source='news', event='headline', start_s=0.0, end_s=90.0,
+#      text='«ЯНДЕКС» ОШТРАФОВАЛИ ЗА ОТКАЗ ПРЕДОСТАВИТЬ ФСБ ДОСТУП К «АЛИСЕ»'), ...]
+```
+
+The interpreter has no vocabulary to check against, so what it counts as
+evidence is **agreement between the two preprocessing passes**. Real glyphs
+survive both renderings; noise is a property of the rendering and does not.
+Measured on 105 band reads of a TV Rain broadcast, comparing the two overlay
+bands against five background bands per frame:
+
+| population | median agreement | worst |
+|---|---|---|
+| overlay (30 reads) | 0.70 | 0.20 |
+| background (75 reads) | 0.00 | 0.00 |
+
+No background band agreed at all, so the default floor of 0.3 keeps 93% of
+overlay reads and admits none of the 75 background ones. It is a parameter
+regardless: one corpus is one corpus.
+
+A news frame carries several overlays at once, so each role gets its own reader
+over its own bands (the clock badge is `clock.py`, which has much stronger
+evidence in a parseable time next to a named zone). Frame extraction is shared,
+so a second role costs OCR on a second band, not a second decode.
+
+**Known limitation.** Ticker cues can carry a garbage prefix, and on the 90s
+sample one cue of ten is garbage throughout. It is stable across both passes,
+so it is real pixels being misread rather than noise the agreement floor can
+reject. A token-level cleaner was built and measured against this footage and
+is NOT shipped: it dropped real content (`220` from `около 220 тысяч`, the
+preposition `К`) while missing the actual garbage, which has perfectly ordinary
+character statistics.
+
 ## Run the backend
 
 ```bash

--- a/annotator/dirstral_annotator/recognizers/base.py
+++ b/annotator/dirstral_annotator/recognizers/base.py
@@ -481,6 +481,7 @@ def collapse_text_sightings(
     frame_gap: float,
     similarity: float = TEXT_RUN_SIMILARITY,
     min_tokens: int = MIN_MATCH_TOKENS,
+    cue_gap: float | None = None,
 ) -> list[Cue]:
     """Collapse per-frame (t, text, confidence) reads into per-passage cues.
 
@@ -520,6 +521,17 @@ def collapse_text_sightings(
     can be thousands of frames long, but it is the first thing to try if the
     carried text is ever the weak link.
 
+    `frame_gap` answers "how far apart may two reads be and still be the same
+    sighting", and by default it also sets how far a cue runs past its last
+    read. Those are the same number whenever reads arrive one sampling interval
+    apart, which is why they were one parameter until a caller turned up where
+    they differ. `OverlayReader` samples sparsely until its band search locks,
+    so a news reader has to tolerate joins across the SEARCH stride while cues
+    still end one FRAME later; passing `cue_gap` separates them. Widening
+    `frame_gap` alone would push every cue's end past the start of the next
+    one, which for a ticker means overlapping citations for consecutive
+    headlines.
+
     Unlike `collapse_sightings` this walks one chronological channel and does
     not track several entities at once: an overlay band shows one string per
     frame, so interleaved sightings of two different passages are two runs,
@@ -546,11 +558,12 @@ def collapse_text_sightings(
             runs.append(_TextRun(start_s=t, last_s=t, confidence=conf,
                                  anchor=tokens, best_text=stripped))
 
+    trailing = frame_gap if cue_gap is None else cue_gap
     cues = [
         Cue(
             source=source,
             start_s=run.start_s,
-            end_s=run.last_s + frame_gap,
+            end_s=run.last_s + trailing,
             event=event,
             entity_ids=(),
             confidence=round(run.confidence, 4),

--- a/annotator/dirstral_annotator/recognizers/base.py
+++ b/annotator/dirstral_annotator/recognizers/base.py
@@ -559,6 +559,11 @@ def collapse_text_sightings(
                                  anchor=tokens, best_text=stripped))
 
     trailing = frame_gap if cue_gap is None else cue_gap
+    if trailing < 0:
+        # A cue may not end before its last observation: with one sighting a
+        # negative extension puts end_s before start_s, which Cue refuses, and
+        # with several it silently claims a span the overlay had already left.
+        raise ValueError(f"cue_gap must not be negative: {trailing}")
     cues = [
         Cue(
             source=source,

--- a/annotator/dirstral_annotator/recognizers/news.py
+++ b/annotator/dirstral_annotator/recognizers/news.py
@@ -216,6 +216,12 @@ class NewsOverlayRecognizer:
             raise ValueError("a news recognizer needs at least one overlay role")
         if not 0.0 <= agreement <= 1.0:
             raise ValueError(f"agreement floor out of [0,1]: {agreement}")
+        # Checked here rather than at the first division: every timing this
+        # class derives is 1/fps or a multiple, so a zero raises deep inside a
+        # collapse and a negative one quietly produces cues that end before
+        # they start.
+        if fps <= 0:
+            raise ValueError(f"fps must be positive: {fps}")
         self.fps = fps
         self.agreement = agreement
         self.similarity = similarity
@@ -252,7 +258,11 @@ class NewsOverlayRecognizer:
     def recognize(self, media_path: Path) -> list[Cue]:
         cues: list[Cue] = []
         for role_reader in self._readers:
+            # Both, not just the sightings: a recognizer reused on a second
+            # file with no overlay would otherwise still report the band the
+            # PREVIOUS file answered from.
             role_reader.sightings.clear()
+            role_reader.answered = None
             # `closing` because the reader owns a worker pool and a scratch
             # directory for the length of the iteration: abandoning it part way
             # through has to shut them down now, not at collection.

--- a/annotator/dirstral_annotator/recognizers/news.py
+++ b/annotator/dirstral_annotator/recognizers/news.py
@@ -1,0 +1,306 @@
+"""Read burned-in news overlays into time-anchored text cues.
+
+The corpus-side counterpart of `scorebug.py`. Both drive the generic reader in
+`overlay.py`; what differs is what the text is taken to MEAN. Baseball resolves
+it against a roster and emits identities. A news broadcast has no roster and no
+feed, so the text is the payload: a headline banner, a scrolling ticker, a
+segment title. The cue carries the words, and `#741 milestone 3` is about
+getting those words onto a timeline something can cite.
+
+## What counts as evidence
+
+`overlay.py` warns that the interpreter is not optional decoration: it supplies
+the hit count that drives the band lock, so a reader with a weak interpreter
+locks onto the crowd. Baseball has a strong signal for free, because a roster
+either recognises a name or it does not. Here there is no vocabulary to check
+against, and "the OCR returned something" is true of studio furniture, a
+bookshelf behind a presenter, and a wall of moire.
+
+The signal used instead is **agreement between the two preprocessing passes**.
+`_prepared_crops` renders each band twice, greyscale and hard-thresholded, and
+those are two largely independent views of the same pixels. Real glyphs survive
+both. Noise is a property of the rendering, so it does not: the passes invent
+different garbage and their texts have nothing in common.
+
+Measured on 105 band reads from 15 frames of a TV Rain news broadcast, OCR'd
+with tesseract `rus`, comparing the two overlay bands against five background
+bands per frame:
+
+  | population              | median agreement | worst |
+  |-------------------------|------------------|-------|
+  | overlay (30 reads)      | 0.70             | 0.20  |
+  | background (75 reads)   | 0.00             | 0.00  |
+
+Not one background band produced ANY agreement, which is why the default floor
+is low: at 0.3 this keeps 93% of overlay reads and admits none of the 75
+background ones. The separation is wide enough that the exact number is not
+delicate, and it is a parameter regardless, because one corpus is one corpus.
+
+The reads it loses are all one all-caps display face whose letterforms OCR
+inconsistently between the two renderings. They are lost, not misread: a
+dropped frame of a ticker costs nothing, because the passage is still on screen
+in the next one and `collapse_text_sightings` joins the run across the gap.
+
+## One reader per role
+
+`_RegionSearch` locks a single band and `OverlayReader.read` stops a frame once
+a band answers, which is right when there is one overlay to find. A news frame
+carries several at once: a headline banner and a ticker occupy different bands
+and say different things, and a clock badge occupies a third (that one is
+`clock.py`, which has its own much stronger evidence in a parseable time next
+to a named zone).
+
+So each role gets its own reader over its own candidate bands. The frame
+extraction is shared, because `iter_frames` memoises per (media, fps), so the
+extra cost is OCR on a second band rather than a second decode of the file.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from contextlib import closing
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from ..model import Cue
+from .base import collapse_text_sightings, text_overlap, text_tokens
+from .overlay import SCAN_STRIDE, OcrFn, OverlayRead, OverlayReader, Region
+
+__all__ = [
+    "DEFAULT_AGREEMENT",
+    "HEADLINE_REGIONS",
+    "NEWS_ROLES",
+    "TICKER_REGIONS",
+    "NewsOverlayRecognizer",
+    "OverlayRole",
+    "read_agreement",
+]
+
+#: Minimum agreement between the two preprocessing passes for a band read to
+#: count as overlay text. See the module docstring for the measurement; the
+#: background population sat at 0.00, so this is a floor with room under it
+#: rather than a boundary between two touching distributions.
+DEFAULT_AGREEMENT = 0.3
+
+#: Candidate bands for a headline banner, and for a ticker along the bottom.
+#: Broadcast convention rather than one broadcaster's layout, in the spirit of
+#: `CLOCK_REGIONS`: a lower third sits in the bottom quarter and a ticker below
+#: it. Kept disjoint so two readers over one frame cannot both lock the same
+#: band and report it twice under different names.
+HEADLINE_REGIONS: tuple[Region, ...] = (
+    (0.0, 0.80, 1.0, 0.10),
+    (0.0, 0.70, 1.0, 0.10),
+)
+TICKER_REGIONS: tuple[Region, ...] = (
+    (0.0, 0.91, 1.0, 0.09),
+    (0.0, 0.90, 1.0, 0.07),
+)
+
+
+@dataclass(frozen=True)
+class OverlayRole:
+    """One kind of overlay to look for, and where to look for it.
+
+    `event` names the cue, so it is what a downstream consumer filters on. The
+    regions are candidates, not a location: the reader sweeps them and locks
+    whichever proves itself, exactly as it does for a scorebug.
+    """
+
+    event: str
+    regions: tuple[Region, ...]
+
+    def __post_init__(self) -> None:
+        if not self.event.strip():
+            raise ValueError("an overlay role needs an event name")
+        if not self.regions:
+            raise ValueError(f"role {self.event!r} has no candidate regions")
+
+
+#: The roles a news broadcast usually carries. A caller with a different
+#: graphics package passes its own; nothing below assumes these two.
+NEWS_ROLES: tuple[OverlayRole, ...] = (
+    OverlayRole(event="headline", regions=HEADLINE_REGIONS),
+    OverlayRole(event="ticker", regions=TICKER_REGIONS),
+)
+
+
+def read_agreement(read: OverlayRead) -> float:
+    """How much the preprocessing passes agree about what this band says.
+
+    0.0 when either pass found no tokens, which is the ordinary shape of a
+    background band: one rendering yields nothing and the other yields noise.
+    """
+    texts = [text for text in read.texts if text.strip()]
+    if len(texts) < 2:
+        return 0.0
+    # Pairwise best rather than first-against-second, so the measure does not
+    # depend on how many passes `_prepared_crops` happens to yield.
+    return max(
+        text_overlap(texts[i], texts[j])
+        for i in range(len(texts))
+        for j in range(i + 1, len(texts))
+    )
+
+
+def _fullest(read: OverlayRead) -> str:
+    """The pass that recovered the most words.
+
+    By token count, not character count: a pass that dissolves a line into
+    punctuation can be the longest string while carrying the least text.
+    """
+    return max(read.texts, key=lambda text: len(text_tokens(text)), default="")
+
+
+@dataclass
+class _RoleReader:
+    """One role's reader and the sightings it has produced."""
+
+    role: OverlayRole
+    reader: OverlayReader
+    agreement: float
+    sightings: list[tuple[float, str, float]] = field(default_factory=list)
+    #: The band this role's reads actually came from. The reader cannot report
+    #: it: the lock lives in a `_RegionSearch` built per `read()` call and
+    #: discarded with the generator, so the interpreter is the only place that
+    #: sees which region answered.
+    answered: Region | None = None
+
+    def interpret(self, read: OverlayRead) -> tuple[str, int]:
+        """Return this band's text and whether it counts as evidence.
+
+        The hit is all-or-nothing rather than proportional to the text: a long
+        noisy read must not outvote a short clean one in the band search, and
+        length is exactly what a band of background texture has plenty of.
+        """
+        agreed = read_agreement(read)
+        if agreed < self.agreement:
+            return "", 0
+        text = _fullest(read).strip()
+        if not text_tokens(text):
+            return "", 0
+        self.sightings.append((read.timestamp_s, text, round(min(agreed, 1.0), 4)))
+        self.answered = read.region
+        return text, 1
+
+
+class NewsOverlayRecognizer:
+    """Turn a broadcast's burned-in overlays into citable text cues.
+
+    Emits one cue per passage per role: a headline that stays up for twenty
+    seconds is one cue, and a ticker that scrolls through five stories is five,
+    because `collapse_text_sightings` joins reads that are still the same
+    passage and starts a new run when the words have turned over.
+
+    Confidence is the agreement between the preprocessing passes, which is a
+    statement about how firmly the text was read and not about whether it is
+    true. Nothing here resolves an entity, so cues carry no `entity_ids`.
+    """
+
+    name = "news"
+
+    def __init__(
+        self,
+        *,
+        roles: Iterable[OverlayRole] = NEWS_ROLES,
+        lang: str | None = None,
+        psm: int | None = None,
+        fps: float = 0.5,
+        agreement: float = DEFAULT_AGREEMENT,
+        workers: int | None = None,
+        ocr: OcrFn | None = None,
+        similarity: float | None = None,
+        frame_gap: float | None = None,
+    ) -> None:
+        roles = tuple(roles)
+        if not roles:
+            raise ValueError("a news recognizer needs at least one overlay role")
+        if not 0.0 <= agreement <= 1.0:
+            raise ValueError(f"agreement floor out of [0,1]: {agreement}")
+        self.fps = fps
+        self.agreement = agreement
+        self.similarity = similarity
+        self.roles = roles
+        # The collapse gap has to be at least the BAND SEARCH's sampling
+        # interval, not the frame interval. Until a band locks, `_RegionSearch`
+        # only offers crops every SCAN_STRIDE frames, so at fps 0.5 the first
+        # reads of a file arrive 8s apart by design. A gap of 1/fps treats each
+        # of them as its own run and a banner that never moved comes back as
+        # five two-second cues instead of one, which is what it did before this
+        # was set: the reads are sparse, not the overlay.
+        self.frame_gap = frame_gap if frame_gap is not None else SCAN_STRIDE / fps
+        # `psm` is only forwarded when the caller set one: OverlayReader
+        # defaults it to OCR_PSM, and passing None through would silently swap
+        # that for the engine's own default.
+        psm_kwargs = {} if psm is None else {"psm": psm}
+        self._readers = [
+            _RoleReader(
+                role=role,
+                reader=OverlayReader(
+                    ocr=ocr,
+                    lang=lang,
+                    fps=fps,
+                    regions=role.regions,
+                    workers=workers,
+                    name=f"{self.name}-{role.event}",
+                    **psm_kwargs,
+                ),
+                agreement=agreement,
+            )
+            for role in roles
+        ]
+
+    def recognize(self, media_path: Path) -> list[Cue]:
+        cues: list[Cue] = []
+        for role_reader in self._readers:
+            role_reader.sightings.clear()
+            # `closing` because the reader owns a worker pool and a scratch
+            # directory for the length of the iteration: abandoning it part way
+            # through has to shut them down now, not at collection.
+            with closing(
+                role_reader.reader.read(media_path, role_reader.interpret)
+            ) as reads:
+                for _ in reads:
+                    pass
+            cues += self._collapse(role_reader)
+        cues.sort(key=lambda cue: (cue.start_s, cue.event))
+        return cues
+
+    def _collapse(self, role_reader: _RoleReader) -> list[Cue]:
+        extra = {} if self.similarity is None else {"similarity": self.similarity}
+        return collapse_text_sightings(
+            role_reader.sightings,
+            source=self.name,
+            event=role_reader.role.event,
+            frame_gap=self.frame_gap,
+            # A cue ends one FRAME after its last read, not one search stride:
+            # widening both would run every ticker cue past the start of the
+            # next headline and produce overlapping citations.
+            cue_gap=1.0 / self.fps,
+            **extra,
+        )
+
+    @property
+    def regions(self) -> tuple[Region, ...]:
+        """Every candidate band across every role, for callers that report them."""
+        seen: list[Region] = []
+        for role in self.roles:
+            for region in role.regions:
+                if region not in seen:
+                    seen.append(region)
+        return tuple(seen)
+
+    def answered_regions(self) -> dict[str, Region | None]:
+        """Which band each role's reads came from, after a `recognize`.
+
+        Useful for reporting on an unfamiliar corpus: a role that answered from
+        nowhere found no overlay at all, which is a different answer from
+        finding one and reading it badly. None until a `recognize` has run.
+        """
+        return {rr.role.event: rr.answered for rr in self._readers}
+
+
+def roles_from(spec: Sequence[tuple[str, Sequence[Region]]]) -> tuple[OverlayRole, ...]:
+    """Build roles from a plain (event, regions) sequence, for config loading."""
+    return tuple(
+        OverlayRole(event=event, regions=tuple(regions)) for event, regions in spec
+    )

--- a/annotator/tests/test_news.py
+++ b/annotator/tests/test_news.py
@@ -1,0 +1,238 @@
+"""Backend-free tests for the news overlay interpreter.
+
+The reader is driven off a per-band script rather than images and an engine, so
+these run anywhere. What they pin is the interpretation: what counts as
+evidence that a band holds an overlay, and what shape the cues come out in.
+"""
+
+import pytest
+
+from dirstral_annotator.recognizers import news, overlay
+from dirstral_annotator.recognizers.news import (
+    DEFAULT_AGREEMENT,
+    NEWS_ROLES,
+    NewsOverlayRecognizer,
+    OverlayRole,
+    read_agreement,
+)
+from dirstral_annotator.recognizers.overlay import OverlayRead
+
+MEDIA = __import__("pathlib").Path("broadcast.mp4")
+HEADLINE_BAND = (0.0, 0.80, 1.0, 0.10)
+TICKER_BAND = (0.0, 0.91, 1.0, 0.09)
+BACKGROUND = (0.0, 0.30, 1.0, 0.10)
+
+HEADLINE = "«ЯНДЕКС» ОШТРАФОВАЛИ ЗА ОТКАЗ ПРЕДОСТАВИТЬ ФСБ ДОСТУП К «АЛИСЕ»"
+
+
+def read(*texts, region=HEADLINE_BAND, t=0.0):
+    return OverlayRead(index=0, timestamp_s=t, region=region, texts=tuple(texts))
+
+
+# --- what counts as evidence ------------------------------------------------
+
+def test_passes_that_agree_are_evidence():
+    """Real glyphs survive both renderings, so the two passes say the same
+    thing. This is the whole signal, since there is no roster to check against."""
+    assert read_agreement(read(HEADLINE, HEADLINE)) == 1.0
+    assert read_agreement(read(HEADLINE, HEADLINE[:40])) >= 0.5
+
+
+def test_a_band_only_one_pass_could_read_is_not_evidence():
+    """The ordinary shape of a background band: one rendering yields nothing
+    and the other yields noise. Nothing corroborates anything."""
+    assert read_agreement(read("", "какой-то шум")) == 0.0
+    assert read_agreement(read(HEADLINE, "")) == 0.0
+    assert read_agreement(read(HEADLINE)) == 0.0
+
+
+def test_passes_that_invent_different_garbage_are_not_evidence():
+    """Noise is a property of the rendering, so the two passes do not agree on
+    it. Measured on 75 background bands of real footage: agreement 0.00 on every
+    single one."""
+    assert read_agreement(read("ЕЕК ЕЕЕ НЕЕ", "ы:евм шсп 1=")) < DEFAULT_AGREEMENT
+
+
+# --- roles ------------------------------------------------------------------
+
+def test_a_role_needs_a_name_and_somewhere_to_look():
+    with pytest.raises(ValueError):
+        OverlayRole(event="", regions=(HEADLINE_BAND,))
+    with pytest.raises(ValueError):
+        OverlayRole(event="headline", regions=())
+
+
+def test_the_recognizer_refuses_an_impossible_agreement_floor():
+    with pytest.raises(ValueError):
+        NewsOverlayRecognizer(agreement=1.5)
+    with pytest.raises(ValueError):
+        NewsOverlayRecognizer(roles=())
+
+
+# --- reading ----------------------------------------------------------------
+
+@pytest.fixture
+def bands(monkeypatch, tmp_path):
+    """Script one text per band, per frame index.
+
+    `install({region: text_or_fn})` makes every sampled frame answer with that
+    text for that band. A callable receives the frame index, which is how a
+    scrolling ticker is expressed.
+    """
+
+    def install(script, frames=40, fps=0.5):
+        listing = []
+        for i in range(frames):
+            path = tmp_path / f"frame-{i:05d}.jpg"
+            path.write_text(str(i))
+            listing.append((i / fps, path))
+        index = {}
+
+        def read_band(ocr, frame, region, work):
+            i = index[frame]
+            value = script.get(tuple(region), "")
+            text = value(i) if callable(value) else value
+            # Both preprocessing passes: a scripted band is a legible one, so
+            # they agree, which is exactly what the interpreter looks for.
+            return [text, text]
+
+        for i, (_, path) in enumerate(listing):
+            index[path] = i
+        monkeypatch.setattr(overlay, "iter_frames", lambda *a, **k: iter(listing))
+        monkeypatch.setattr(overlay, "read_band", read_band)
+        return listing
+
+    return install
+
+
+def only(recognizer, event):
+    return [c for c in recognizer.recognize(MEDIA) if c.event == event]
+
+
+def test_a_static_banner_is_one_cue_not_one_per_frame(bands):
+    bands({HEADLINE_BAND: HEADLINE})
+    cues = only(NewsOverlayRecognizer(workers=1), "headline")
+    assert len(cues) == 1
+    assert cues[0].text == HEADLINE
+    assert cues[0].source == "news"
+
+
+def test_a_banner_seen_only_during_the_strided_search_is_still_one_cue(bands):
+    """The reader samples every SCAN_STRIDE frames until a band locks, so the
+    first reads of a file arrive one search stride apart by design. Collapsing
+    on the frame interval would call each of them its own sighting and report a
+    banner that never moved as a handful of two-second cues."""
+    bands({HEADLINE_BAND: HEADLINE})
+    cues = only(NewsOverlayRecognizer(workers=1), "headline")
+    assert len(cues) == 1
+    assert cues[0].start_s == 0.0
+
+
+def test_a_cue_ends_one_frame_after_its_last_read_not_one_stride(bands):
+    """The join tolerance and the trailing extension are different numbers.
+    Widening both would run each cue past the start of the next, so consecutive
+    ticker headlines would carry overlapping citations."""
+    fps, frames = 0.5, 40  # enough to get past the strided search and lock
+    bands({HEADLINE_BAND: HEADLINE}, frames=frames, fps=fps)
+    (cue,) = only(NewsOverlayRecognizer(workers=1, fps=fps), "headline")
+    last_read_s = (frames - 1) / fps
+    assert cue.end_s == pytest.approx(last_read_s + 1.0 / fps)
+    # The point of the assertion: one frame, not one search stride.
+    assert cue.end_s < last_read_s + overlay.SCAN_STRIDE / fps
+
+
+def test_consecutive_ticker_passages_do_not_overlap(bands):
+    """A ticker's cues have to tile: a citation that claims a span belonging to
+    the next headline is worse than no citation."""
+    stories = [
+        "Власти США одобрили продажу Украине ракет увеличенной дальности",
+        "Умер советский и российский композитор Родион Щедрин сегодня утром",
+        "Европейские лидеры обсуждают создание буферной зоны на линии фронта",
+    ]
+
+    def scroll(i):
+        return stories[min(i // 14, len(stories) - 1)]
+
+    bands({TICKER_BAND: scroll}, frames=42)
+    cues = only(NewsOverlayRecognizer(workers=1), "ticker")
+    assert len(cues) >= len(stories)
+    for earlier, later in zip(cues, cues[1:]):
+        assert earlier.end_s <= later.start_s + 1e-9
+
+
+def test_two_roles_read_two_bands_and_are_reported_apart(bands):
+    """A news frame carries a headline and a ticker at once, saying different
+    things. One reader locks one band, so each role gets its own."""
+    ticker = "Число пострадавших выросло до сорока человек по данным МЧС"
+    bands({HEADLINE_BAND: HEADLINE, TICKER_BAND: ticker})
+    recognizer = NewsOverlayRecognizer(workers=1)
+    cues = recognizer.recognize(MEDIA)
+    events = {c.event for c in cues}
+    assert events == {"headline", "ticker"}
+    assert any(c.text == HEADLINE for c in cues if c.event == "headline")
+    assert any(c.text == ticker for c in cues if c.event == "ticker")
+    assert recognizer.answered_regions() == {
+        "headline": HEADLINE_BAND,
+        "ticker": TICKER_BAND,
+    }
+
+
+def test_footage_with_no_overlay_yields_no_cues(bands):
+    """Declining is an answer. Inventing a headline out of studio furniture is
+    the failure this interpreter exists to avoid."""
+    bands({BACKGROUND: "чтото в кадре"})
+    recognizer = NewsOverlayRecognizer(workers=1)
+    assert recognizer.recognize(MEDIA) == []
+    assert set(recognizer.answered_regions().values()) == {None}
+
+
+def test_a_band_whose_passes_disagree_is_not_read(monkeypatch, tmp_path):
+    """The band search runs on the hit count, so a band that fails the
+    agreement floor must not vote for itself either."""
+    listing = []
+    for i in range(24):
+        path = tmp_path / f"frame-{i:05d}.jpg"
+        path.write_text(str(i))
+        listing.append((i / 0.5, path))
+    monkeypatch.setattr(overlay, "iter_frames", lambda *a, **k: iter(listing))
+    monkeypatch.setattr(
+        overlay,
+        "read_band",
+        lambda ocr, frame, region, work: ["ЕЕК ЕЕЕ НЕЕ ЕЕЕЕ", "ы:евм шсп 1= ннн"],
+    )
+    recognizer = NewsOverlayRecognizer(workers=1)
+    assert recognizer.recognize(MEDIA) == []
+
+
+def test_cues_carry_no_entity_ids(bands):
+    """Headline text is a topic, not an entity; nothing here resolves a roster."""
+    bands({HEADLINE_BAND: HEADLINE})
+    for cue in NewsOverlayRecognizer(workers=1).recognize(MEDIA):
+        assert cue.entity_ids == ()
+
+
+def test_confidence_is_how_firmly_the_text_was_read(bands):
+    """Agreement between the two renderings, which says nothing about whether
+    the headline is true. Identical passes are a perfect read."""
+    bands({HEADLINE_BAND: HEADLINE})
+    (cue,) = only(NewsOverlayRecognizer(workers=1), "headline")
+    assert cue.confidence == 1.0
+
+
+def test_the_agreement_floor_is_a_parameter(bands):
+    """One corpus is one corpus. A caller on different footage moves it."""
+    assert news.DEFAULT_AGREEMENT == pytest.approx(0.3)
+    bands({HEADLINE_BAND: HEADLINE})
+    assert only(NewsOverlayRecognizer(workers=1, agreement=0.99), "headline")
+
+
+def test_the_default_roles_look_where_broadcasters_put_overlays(bands):
+    """Convention, not one broadcaster's layout. The two default bands must
+    stay disjoint, or two readers could lock the same band and report it twice
+    under different names."""
+    assert [r.event for r in NEWS_ROLES] == ["headline", "ticker"]
+    for headline_band in news.HEADLINE_REGIONS:
+        for ticker_band in news.TICKER_REGIONS:
+            h_top, h_bottom = headline_band[1], headline_band[1] + headline_band[3]
+            t_top, t_bottom = ticker_band[1], ticker_band[1] + ticker_band[3]
+            assert h_bottom <= t_top or t_bottom <= h_top

--- a/annotator/tests/test_news.py
+++ b/annotator/tests/test_news.py
@@ -236,3 +236,27 @@ def test_the_default_roles_look_where_broadcasters_put_overlays(bands):
             h_top, h_bottom = headline_band[1], headline_band[1] + headline_band[3]
             t_top, t_bottom = ticker_band[1], ticker_band[1] + ticker_band[3]
             assert h_bottom <= t_top or t_bottom <= h_top
+
+
+def test_a_recognizer_reused_on_a_second_file_does_not_report_the_first_ones_band(bands):
+    """`answered_regions` says where a role's reads came from. Reporting the
+    PREVIOUS file's band for a file with no overlay would turn "found nothing"
+    into "found it here", which is the opposite answer."""
+    bands({HEADLINE_BAND: HEADLINE})
+    recognizer = NewsOverlayRecognizer(workers=1)
+    assert recognizer.recognize(MEDIA)
+    assert recognizer.answered_regions()["headline"] == HEADLINE_BAND
+
+    bands({BACKGROUND: "чтото в кадре"})
+    assert recognizer.recognize(MEDIA) == []
+    assert set(recognizer.answered_regions().values()) == {None}
+
+
+def test_a_non_positive_fps_is_refused_at_construction():
+    """Every timing this class derives is 1/fps or a multiple of it, so zero
+    raises deep inside a collapse and a negative quietly produces cues that end
+    before they start."""
+    with pytest.raises(ValueError):
+        NewsOverlayRecognizer(fps=0)
+    with pytest.raises(ValueError):
+        NewsOverlayRecognizer(fps=-0.5)

--- a/annotator/tests/test_text_collapse.py
+++ b/annotator/tests/test_text_collapse.py
@@ -394,3 +394,32 @@ def test_this_measure_is_steadier_than_a_substring_at_a_fixed_separation():
     assert max(ours) == pytest.approx(1.000, abs=0.001)
     assert max(substring) / min(substring) == pytest.approx(2.6, abs=0.05)
     assert max(ours) / min(ours) == pytest.approx(1.6, abs=0.05)
+
+
+def test_a_cue_may_not_end_before_its_last_observation():
+    """`cue_gap` is how far a cue runs past its last read. Negative is not a
+    shorter cue, it is a cue that ends before the overlay was last seen: with
+    one sighting `Cue` refuses it outright, and with several it silently claims
+    a span the text had already left."""
+    sightings = [(0.0, "Европейские лидеры обсуждают создание буферной зоны", 0.6)]
+    with pytest.raises(ValueError):
+        collapse_text_sightings(sightings, source="t", event="e", frame_gap=1.0,
+                                cue_gap=-1.0)
+
+
+def test_the_join_tolerance_and_the_trailing_extension_are_separable():
+    """They are the same number only when reads arrive one sampling interval
+    apart. A reader that samples sparsely while it searches needs to join
+    across the wider gap while its cues still end one frame later, or
+    consecutive passages carry overlapping spans."""
+    line = "Европейские лидеры обсуждают создание буферной зоны на линии фронта"
+    sightings = [(0.0, line, 0.6), (8.0, line, 0.6)]
+
+    (joined,) = collapse_text_sightings(sightings, source="t", event="e",
+                                        frame_gap=8.0, cue_gap=2.0)
+    assert joined.start_s == 0.0
+    assert joined.end_s == 10.0  # last read plus the FRAME, not the stride
+
+    # Without the wider join tolerance the same reads are two sightings.
+    assert len(collapse_text_sightings(sightings, source="t", event="e",
+                                       frame_gap=2.0)) == 2


### PR DESCRIPTION
Part of #741 milestone 3, piece 4 of #745.

The corpus-side counterpart of `scorebug.py`: same reader, different idea of what the text **means**. Baseball resolves it against a roster and emits identities. A news broadcast has no roster and no feed, so the words are the payload.

## What counts as evidence

`overlay.py` warns that the interpreter is not optional decoration: it supplies the hit count that drives the band lock, so a reader with a weak interpreter locks onto the crowd. Baseball gets a strong signal for free, because a roster either recognises a name or it does not. Here there is no vocabulary to check against, and "the OCR returned something" is true of studio furniture and a wall of moire.

The signal is **agreement between the two preprocessing passes**. Real glyphs survive both renderings; noise is a property of the rendering, so the passes invent different garbage. Measured on 105 band reads from 15 frames, comparing the two overlay bands against five background bands per frame:

| population | median agreement | worst |
|---|---|---|
| overlay (30 reads) | 0.70 | 0.20 |
| background (75 reads) | 0.00 | **0.00** |

Not one background band agreed at all. At the 0.3 default that keeps 93% of overlay reads and admits none of the 75 background ones.

Finding the bands was itself a measurement: a blind vertical sweep flagged exactly the two real overlays per frame and none of the other 40 bands. It also **corrected a band coordinate I had been using all session** — what I had called the ticker at y=0.895 is noise on this footage; the ticker is at 0.95 and a headline banner sits at 0.85.

## One reader per role

`_RegionSearch` locks a single band, so a frame carrying a headline *and* a ticker needs one reader each (the clock badge is `clock.py`, which has much stronger evidence). `iter_frames` memoises per (media, fps), so the second role costs OCR on a second band rather than a second decode.

## A conflation this exposed in #746

`collapse_text_sightings` used `frame_gap` for two different things: how far apart two reads may be and still join, and how far a cue runs past its last read. Those coincide when reads arrive one sampling interval apart, which is why they were one parameter.

They do not coincide here. `OverlayReader` samples every `SCAN_STRIDE` frames until a band locks, so the first reads of a file are 8s apart by design at fps 0.5:

- with the frame interval as the gap, a banner that never moved came back as **five two-second cues**
- widening the gap fixed that and made every ticker cue run 8s past its last read, so **consecutive headlines carried overlapping citations**

Split into `frame_gap` (join) and `cue_gap` (trailing extension, defaulting to `frame_gap`, so every existing caller is unchanged). Both failure modes have regression tests.

## On real footage

90s of TV Rain, **no feed of any kind**:

```
[  0.0- 90.0] headline conf=1.00  «ЯНДЕКС» ОШТРАФОВАЛИ ЗА ОТКАЗ ПРЕДОСТАВИТЬ ФСБ ДОСТУП К «АЛИСЕ»
[ 16.0- 26.0] ticker   conf=0.92  ... — Пентагон // На войне погибли около 220 тысяч российских
[ 68.0- 82.0] ticker   conf=0.93  ... дание 40-километровой буферной зоны на линии фронта между
```

Headline exact, one cue spanning the file; ticker as nine tiling cues carrying readable passages.

## What is NOT shipped

Ticker cues can carry a garbage prefix, and one of ten is garbage throughout. It agrees across both passes, so it is real pixels being misread rather than something the agreement floor can reject.

I built a token-level cleaner and measured it on this footage. It **dropped real content** (`220` out of `около 220 тысяч`, and the preposition `К`) while **missing the actual garbage**, whose character statistics are perfectly ordinary. Recorded in the README as a known limitation rather than shipped.

## Tests

16 backend-free tests: what counts as evidence, both cue-gap failure modes, two roles reported apart, footage with no overlay yielding nothing, and that the default bands stay disjoint (that last one caught overlapping defaults I had written while claiming in the docstring they were disjoint).

235 tests pass, ruff clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recognition of burned-in news overlays, including headlines and tickers.
  * Supports configurable regions, OCR settings, confidence thresholds, sampling, and processing options.
  * Produces time-anchored cues with recognized text, confidence, and entity information.
  * Handles multiple overlay roles and identifies regions with reliable results.

* **Documentation**
  * Added usage guidance, evidence scoring details, measured results, and known ticker-cleaning limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->