### PR TITLE
feat(annotator): serve news overlays as citable spans (#745 piece 5)

### DIFF
--- a/annotator/README.md
+++ b/annotator/README.md
@@ -133,6 +133,17 @@ over its own bands (the clock badge is `clock.py`, which has much stronger
 evidence in a parseable time next to a named zone). Frame extraction is shared,
 so a second role costs OCR on a second band, not a second decode.
 
+Serving a news archive needs no roster, because nothing here resolves one:
+
+```bash
+dirstral-annotate serve --news --ocr-lang rus --port 8765
+```
+
+`--roster` stays required for `--scorebug`, `--jersey`, `--faces` and
+play-by-play, which all resolve names against it. Point dir2mcp at the backend
+as usual and each headline and ticker passage lands as a `recognition` chunk
+with a `time` span, which `ask`/`search` cite directly.
+
 **Known limitation.** Ticker cues can carry a garbage prefix, and on the 90s
 sample one cue of ten is garbage throughout. It is stable across both passes,
 so it is real pixels being misread rather than noise the agreement floor can
@@ -140,6 +151,12 @@ reject. A token-level cleaner was built and measured against this footage and
 is NOT shipped: it dropped real content (`220` from `около 220 тысяч`, the
 preposition `К`) while missing the actual garbage, which has perfectly ordinary
 character statistics.
+
+The consequence for retrieval is that a garbage span is citable: it carries
+text, a non-negative start and a well-ordered range, so the ingest filter
+accepts it. Confidence does not separate it either, because the garbage is
+stable across both passes and scores 0.90. A gate wants a measure nobody has
+taken yet, so there is no gate rather than a guessed one.
 
 ## Run the backend
 

--- a/annotator/dirstral_annotator/cli.py
+++ b/annotator/dirstral_annotator/cli.py
@@ -3,8 +3,11 @@
     # Run the recognition backend dir2mcp connects to
     # (dir2mcp config: recognize.provider=serve, recognize.base_url=http://127.0.0.1:8765)
     dirstral-annotate serve --roster roster.json [--games games.json] \
-        [--scorebug] [--jersey] [--faces bank/] [--fps 0.5] [--min-confidence 0.3] \
-        [--host 127.0.0.1] [--port 8765]
+        [--scorebug] [--jersey] [--faces bank/] [--news] [--ocr-lang rus] \
+        [--fps 0.5] [--min-confidence 0.3] [--host 127.0.0.1] [--port 8765]
+
+    # A news archive resolves no roster, so it needs none:
+    dirstral-annotate serve --news --ocr-lang rus
 
     # Phase-1 accuracy gate against Statcast ground truth
     dirstral-annotate eval game7.mp4 --roster roster.json \
@@ -44,11 +47,15 @@ def build_parser() -> argparse.ArgumentParser:
         c.add_argument("--scorebug", action="store_true", help="enable scorebug OCR")
         c.add_argument("--jersey", action="store_true", help="enable jersey-number OCR")
         c.add_argument("--faces", type=Path, help="roster image bank dir; enables face recognition")
+        c.add_argument("--news", action="store_true",
+                       help="enable news overlay text (headline banner + ticker); needs no roster")
+        c.add_argument("--ocr-lang", help="OCR language for the overlay readers (e.g. rus)")
         c.add_argument("--fps", type=float, default=0.5, help="frame sampling rate (default 0.5)")
         c.add_argument("--min-confidence", type=float, default=0.0)
 
     s = sub.add_parser("serve", help="run the recognition backend for dir2mcp")
-    s.add_argument("--roster", type=Path, required=True)
+    s.add_argument("--roster", type=Path,
+                   help="entity vocabulary; required unless the only recognizer is --news")
     s.add_argument("--games", type=Path, help="games.json: media basename -> play-by-play binding")
     s.add_argument("--host", default="127.0.0.1")
     s.add_argument("--port", type=int, default=8765)
@@ -70,12 +77,26 @@ def build_parser() -> argparse.ArgumentParser:
     return p
 
 
+def _needs_roster(args) -> bool:
+    """Whether any enabled recognizer resolves names against a roster.
+
+    `eval` always does: it scores against a feed whose identities are roster
+    ids, so a run without one would report zero recall and look like a
+    recognition failure rather than a missing argument.
+    """
+    if args.command != "serve":
+        return True
+    return bool(args.scorebug or args.jersey or args.faces or args.games)
+
+
 def _pipeline(args, roster: Roster, games) -> Pipeline:
     return Pipeline(
         roster=roster,
         games=games,
         scorebug=args.scorebug,
         jersey=args.jersey,
+        news=args.news,
+        ocr_lang=args.ocr_lang,
         faces_bank=args.faces,
         fps=args.fps,
         min_confidence=args.min_confidence,
@@ -84,7 +105,18 @@ def _pipeline(args, roster: Roster, games) -> Pipeline:
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
-    roster = Roster.load(args.roster)
+    # A news archive has no roster, and inventing an empty one for the
+    # recognizers that DO read one would silently resolve nobody rather than
+    # say why. So the roster is optional exactly when nothing needs it.
+    if args.roster is None:
+        if _needs_roster(args):
+            raise SystemExit(
+                "--roster is required for --scorebug, --jersey, --faces and "
+                "play-by-play; only --news reads no roster"
+            )
+        roster = Roster([])
+    else:
+        roster = Roster.load(args.roster)
 
     if args.command == "serve":
         games = load_games(args.games) if args.games else {}

--- a/annotator/dirstral_annotator/fusion.py
+++ b/annotator/dirstral_annotator/fusion.py
@@ -10,11 +10,17 @@ signals beat either alone, which is the entire point of the cascade.
 from __future__ import annotations
 
 from .model import Annotation, Cue
+from .recognizers.base import TEXT_RUN_SIMILARITY, text_overlap
 
 # Cues for the same claim can disagree slightly on boundaries (scorebug
 # appears a beat after the play-by-play timestamp); ranges closer than this
 # gap (seconds) still merge.
 MERGE_GAP_S = 2.0
+
+# How much two entity-free cues' text must overlap to count as the same claim.
+# The same threshold the run collapsing uses, because it is the same question:
+# these are two views of one passage, or they are two passages.
+TEXT_MERGE_SIMILARITY = TEXT_RUN_SIMILARITY
 
 
 def fuse(cues: list[Cue], min_confidence: float = 0.0) -> list[Annotation]:
@@ -50,9 +56,40 @@ def _belongs(group: list[Cue], cue: Cue) -> bool:
     entities = {e for g in group for e in g.entity_ids}
     if cue.entity_ids and entities and not entities.intersection(cue.entity_ids):
         return False
+    if not _same_claim_by_text(group, cue, entities):
+        return False
     start = min(g.start_s for g in group)
     end = max(g.end_s for g in group)
     return cue.start_s <= end + MERGE_GAP_S and cue.end_s >= start - MERGE_GAP_S
+
+
+def _same_claim_by_text(group: list[Cue], cue: Cue, entities: set[str]) -> bool:
+    """For cues nothing identifies but their words, whether the words agree.
+
+    The entity test above only REJECTS when both sides name entities and the
+    names disagree, so a pair of cues that name nobody skips it entirely and
+    falls through to the time test. That is right for the baseball cascade,
+    where every cue resolves a roster, and wrong for overlay text, which
+    resolves nothing: consecutive ticker passages share an event, carry no
+    entities and sit next to each other in time, so they all merged into one
+    annotation. On 90s of TV Rain that turned nine ticker cues into four, one
+    of which spanned 58 seconds and five separate stories while `_merge` kept
+    only the longest text and dropped the other four outright.
+
+    So when neither side names anyone and both carry text, the text decides.
+    Two ticker cues describing different stories are different claims, however
+    close together they ran. The same threshold as the run collapsing that
+    produced them, because it is the same question: is this the same passage?
+
+    Cues with no text on either side are unaffected, and so is every existing
+    caller: the baseball recognizers all resolve entities.
+    """
+    if cue.entity_ids or entities or not cue.text.strip():
+        return True
+    texts = [g.text for g in group if g.text.strip()]
+    if not texts:
+        return True
+    return any(text_overlap(text, cue.text) >= TEXT_MERGE_SIMILARITY for text in texts)
 
 
 def _merge(group: list[Cue]) -> Annotation:

--- a/annotator/dirstral_annotator/pipeline.py
+++ b/annotator/dirstral_annotator/pipeline.py
@@ -56,6 +56,8 @@ class Pipeline:
     games: dict[str, GameConfig] = field(default_factory=dict)
     scorebug: bool = False
     jersey: bool = False
+    news: bool = False
+    ocr_lang: str | None = None
     faces_bank: Path | None = None
     fps: float = 0.5
     min_confidence: float = 0.0
@@ -95,4 +97,12 @@ class Pipeline:
             from .recognizers.faces import FaceRecognizer
 
             try_recognizer(lambda: FaceRecognizer(self.roster, self.faces_bank, fps=self.fps))
+        if self.news:
+            # The only recognizer here that reads no roster: overlay text is
+            # the payload, not a name to resolve.
+            from .recognizers.news import NewsOverlayRecognizer
+
+            try_recognizer(
+                lambda: NewsOverlayRecognizer(lang=self.ocr_lang, fps=self.fps)
+            )
         return cues

--- a/annotator/tests/test_fusion.py
+++ b/annotator/tests/test_fusion.py
@@ -63,3 +63,71 @@ def test_min_confidence_floor():
 def test_output_sorted_by_time():
     anns = fuse([cue("scorebug", 60, 70, 0.9), cue("scorebug", 10, 20, 0.9)])
     assert [a.start_s for a in anns] == [10, 60]
+
+
+# --- entity-free text cues (overlay readers) --------------------------------
+
+STORY_A = "Европейские лидеры обсуждают создание буферной зоны на линии фронта"
+STORY_B = "Умер советский и российский композитор Родион Щедрин сегодня утром"
+
+
+def text_cue(source, start, end, text, conf=0.9, event="ticker"):
+    return cue(source, start, end, conf, event=event, entities=(), text=text)
+
+
+def test_consecutive_ticker_passages_are_not_one_claim():
+    """The entity test only REJECTS when both sides name someone and the names
+    disagree, so two cues that name nobody skipped it and fell through to the
+    time test. Every ticker passage shares an event, names nobody, and sits
+    next to the previous one, so they all merged: on 90s of TV Rain that turned
+    nine cues into four, one spanning 58 seconds and five separate stories,
+    with `_merge` keeping the longest text and dropping the rest."""
+    anns = fuse([
+        text_cue("news", 0.0, 10.0, STORY_A),
+        text_cue("news", 10.0, 20.0, STORY_B),
+    ])
+    assert len(anns) == 2
+    assert {a.text for a in anns} == {STORY_A, STORY_B}
+
+
+def test_a_run_of_distinct_passages_does_not_chain_into_one_span():
+    """The group's end grows as cues join it, so without a text test the merge
+    chains: each passage is within the gap of the one before, and a whole
+    file's ticker becomes a single annotation."""
+    spans = [(0.0, 10.0), (10.0, 20.0), (20.0, 30.0), (30.0, 40.0)]
+    stories = [STORY_A, STORY_B, STORY_A + " сегодня", STORY_B + " в Москве"]
+    anns = fuse([text_cue("news", s, e, t) for (s, e), t in zip(spans, stories)])
+    assert len(anns) == 4
+    assert max(a.end_s - a.start_s for a in anns) == 10.0
+
+
+def test_two_readings_of_the_same_passage_still_merge():
+    """The point of fusion, which the text test must not break: two sources
+    that saw the same overlay are one claim, and their confidences combine."""
+    (ann,) = fuse([
+        text_cue("news", 10.0, 20.0, STORY_A, conf=0.6),
+        text_cue("other", 11.0, 21.0, "лидеры обсуждают создание буферной зоны", conf=0.5),
+    ])
+    assert ann.sources == ("news", "other")
+    assert ann.confidence == 0.8  # noisy-OR, as for any two agreeing sources
+    assert ann.start_s == 10.0 and ann.end_s == 21.0
+
+
+def test_cues_that_name_someone_are_unaffected_by_the_text_test():
+    """The baseball cascade resolves a roster on every cue, so the text test
+    must never reach it: two sources describing one pitch in different words
+    are still one claim."""
+    anns = fuse([
+        cue("playbyplay", 100.0, 108.0, 0.98, text="Pitch: Logan Webb to X"),
+        cue("scorebug", 99.0, 110.0, 0.9, text="WEBB"),
+    ])
+    assert len(anns) == 1
+
+
+def test_text_free_cues_merge_as_they_always_did():
+    """Nothing to compare, so the time and event rules decide alone."""
+    anns = fuse([
+        text_cue("news", 0.0, 10.0, ""),
+        text_cue("news", 10.0, 20.0, ""),
+    ])
+    assert len(anns) == 1

--- a/annotator/tests/test_news.py
+++ b/annotator/tests/test_news.py
@@ -260,3 +260,43 @@ def test_a_non_positive_fps_is_refused_at_construction():
         NewsOverlayRecognizer(fps=0)
     with pytest.raises(ValueError):
         NewsOverlayRecognizer(fps=-0.5)
+
+
+# --- wiring -----------------------------------------------------------------
+
+def test_the_news_recognizer_needs_no_roster():
+    """A news archive has no roster, and every other recognizer in the cascade
+    resolves one. Requiring it would make the corpus this milestone targets
+    unservable."""
+    from dirstral_annotator.cli import _needs_roster, build_parser
+
+    parse = build_parser().parse_args
+    assert _needs_roster(parse(["serve", "--news"])) is False
+    assert _needs_roster(parse(["serve", "--news", "--scorebug"])) is True
+    assert _needs_roster(parse(["serve", "--jersey"])) is True
+    assert _needs_roster(parse(["serve", "--games", "g.json"])) is True
+
+
+def test_the_pipeline_runs_the_news_recognizer_when_asked(monkeypatch, tmp_path):
+    """The cascade seam: `--news` has to reach a NewsOverlayRecognizer, with
+    the OCR language it was given rather than a constant."""
+    from dirstral_annotator import pipeline as pipeline_mod
+    from dirstral_annotator.recognizers import news as news_mod
+    from dirstral_annotator.roster import Roster
+
+    built = {}
+
+    class Fake:
+        def __init__(self, **kwargs):
+            built.update(kwargs)
+
+        def recognize(self, media_path):
+            return []
+
+    monkeypatch.setattr(news_mod, "NewsOverlayRecognizer", Fake)
+    media = tmp_path / "broadcast.mp4"
+    media.write_bytes(b"")
+    pipeline_mod.Pipeline(
+        roster=Roster([]), news=True, ocr_lang="rus", fps=0.25
+    ).cues_for(media)
+    assert built == {"lang": "rus", "fps": 0.25}


### PR DESCRIPTION
Part of #741 milestone 3, piece 5 of #745. Completes the milestone's shipped scope.

The ingest side already turns any backend's annotations into `recognition` chunks with `time` spans, so what piece 5 needed was for news cues to **reach it intact**. Two things stopped them.

## 1. Fusion collapsed the passages it was given

`_belongs` only *rejects* on entities when both sides name someone and the names disagree. Two cues that name nobody skip the test entirely and fall through to event and time. Right for the baseball cascade, where every cue resolves a roster; wrong for overlay text, which resolves nothing.

Consecutive ticker passages share an event, name nobody, and sit next to each other, so they merged — and because the group's end grows as cues join, it **chains**:

```
9 ticker cues  ->  4 annotations
  [ 0.0-  2.0] story 0
  [ 8.0- 10.0] story 1
  [16.0- 26.0] story 2
  [32.0- 90.0] story 3     <- 58 seconds, five separate stories, four texts dropped
```

`_merge` keeps only the longest text, so the other four stories vanished from the index. **The collapse work in #746 was being undone one stage later.**

Fix: when neither side names anyone and both carry text, the text decides, at the same threshold the run collapsing used — it is the same question. Two sources that saw the same passage still merge and still combine under noisy-OR (verified: 0.6 + 0.5 -> 0.8); the baseball path never reaches the test.

The #746 docstring predicted exactly this ("a consumer emitting these needs either distinct events or a fusion rule of its own"). It is now a rule rather than a warning.

## 2. A news archive has no roster

`serve --roster` was required, and every recognizer that reads one is optional. The roster is now required exactly when something needs it (`--scorebug`, `--jersey`, `--faces`, play-by-play), and omitted otherwise rather than defaulted to an empty one, which would resolve nobody instead of saying why.

`eval` still always requires it: it scores against a feed whose identities are roster ids, so a run without one would report zero recall and look like a recognition failure rather than a missing argument.

```bash
dirstral-annotate serve --news --ocr-lang rus --port 8765
```

## End to end

90s of TV Rain through the whole path, **no feed**: 8 annotations, every one accepted by `recognitionSegments`' rules (non-empty text, non-negative start, well-ordered range), so each headline and ticker passage lands as a chunk with a `time` span that `ask`/`search` cite directly. Fusion merged the two cues that genuinely shared a passage and kept the rest apart.

## The gap that stays open

A garbage span **is** citable: it carries text and a well-ordered range, so the ingest filter accepts it. Confidence does not separate it either — the garbage agrees across both preprocessing passes and scores 0.90.

Gating it wants a measure nobody has taken yet, so there is no gate rather than a guessed one. That is the third time this milestone that the measured answer beat the plausible one (the adaptive pass, the token cleaner, and now this), so I would rather file it than guess. Recorded in the README.

## Tests

246 pass. New: five fusion tests (the chaining case, the merge that must still happen, entity-bearing cues unaffected, text-free cues unchanged) and two wiring tests (roster requirement per flag, and that `--news` reaches the recognizer with the language it was given).