### PR TITLE
docs(annotator): correct the overlay-garbage claim (#751)

### DIFF
--- a/annotator/README.md
+++ b/annotator/README.md
@@ -144,19 +144,25 @@ play-by-play, which all resolve names against it. Point dir2mcp at the backend
 as usual and each headline and ticker passage lands as a `recognition` chunk
 with a `time` span, which `ask`/`search` cite directly.
 
-**Known limitation.** Ticker cues can carry a garbage prefix, and on the 90s
-sample one cue of ten is garbage throughout. It is stable across both passes,
-so it is real pixels being misread rather than noise the agreement floor can
-reject. A token-level cleaner was built and measured against this footage and
-is NOT shipped: it dropped real content (`220` from `около 220 тысяч`, the
-preposition `К`) while missing the actual garbage, which has perfectly ordinary
-character statistics.
+**Known limitation.** Ticker cues can carry a long garbage prefix ahead of
+their real text, where a stable graphic in the band OCRs as a run of repeated
+letters. It agrees across both preprocessing passes, because it is real pixels
+being misread rather than noise, so the agreement floor cannot reject it and
+confidence does not separate it: such reads score 0.90 like the good ones.
 
-The consequence for retrieval is that a garbage span is citable: it carries
-text, a non-negative start and a well-ordered range, so the ingest filter
-accepts it. Confidence does not separate it either, because the garbage is
-stable across both passes and scores 0.90. A gate wants a measure nobody has
-taken yet, so there is no gate rather than a guessed one.
+The text behind the prefix is intact, so the cue is still usable; what suffers
+is the fraction of a citation that is signal. Two remedies were built and
+measured against real footage, and NEITHER is shipped:
+
+- A token-level cleaner dropped real content (`220` out of `около 220 тысяч`,
+  and the preposition `К`) while missing the actual garbage, whose character
+  statistics are perfectly ordinary.
+- Changing which read of a run the cue carries. Measured across two corpora,
+  no candidate dominates: against the current longest-read rule, a medoid
+  selector gains 2.8 points of token precision on a ticker with a graphic in
+  the band and loses 4.3 precision and 3.7 recall on one without.
+
+See #751.
 
 ## Run the backend
 


### PR DESCRIPTION
Corrects a claim I made in #749/#750 and in #751.

## What was wrong

I wrote that one ticker cue in ten is **"garbage throughout"**. It is not. I took that from a truncated console line. The full read is a long garbage prefix followed by intact real text:

```
'ЕЕК ЕЕЕЕЕЕЕЕ...(110 chars)...ЕЕИ ИЕ етский и российский композитор Родион Щедрин // Европейские лидеры обсуждают с‹'
```

So the defect is narrower and different in kind: **not an unusable span, but a prefix that dilutes a usable one.** #751 has been corrected too.

## What chasing it found

The garbage adds *length*, and `collapse_text_sightings` carries a run's **longest** read — so the selector actively prefers the reads with the most garbage. `base.py` predicted exactly this: *"a medoid-of-run selector scored 0.876 precision … it is the first thing to try if the carried text is ever the weak link."*

I tried it, plus two others, measured on **both** corpora by token precision and recall against hand-written ground truth:

| selector | clean fixture P / R | news clip (graphic in band) P / R |
|---|---|---|
| **longest chars** (ships today) | **0.882** / 0.593 | 0.578 / **0.881** |
| most solid tokens | 0.833 / 0.593 | 0.568 / 0.881 |
| medoid | 0.839 / 0.556 | **0.606** / 0.857 |

**No candidate dominates.** The medoid buys 2.8 points of precision on the corpus with a graphic and costs 4.3 precision and 3.7 recall on the one without. So the selector is unchanged and the README now records the measurement instead of the assumption.

I had the medoid implemented and passing before this table existed; it is reverted, not shipped.

## Also measured

Tesseract's own per-word confidence — which the adapter discards, and which #751 named as the most promising unmeasured signal — **does not separate the two populations**: median 75.1 against 77.2, fully overlapping. Recorded on #751 so nobody spends the same afternoon.

Docs only; no behaviour change. 246 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded OCR limitation guidance for ticker text, including garbage prefixes, citation impact, and confidence behavior.
  * Added measured results for potential text-cleaning and alternate-reading improvements.
  * Linked the issue tracking this limitation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->