### PR TITLE
security(state): create and repair the state hierarchy owner-only (#726)

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -31,6 +31,7 @@ import (
 	"github.com/dirstral/dir2mcp/internal/provider"
 	"github.com/dirstral/dir2mcp/internal/providerfactory"
 	"github.com/dirstral/dir2mcp/internal/retrieval"
+	"github.com/dirstral/dir2mcp/internal/statefs"
 	"github.com/dirstral/dir2mcp/internal/store"
 	"github.com/dirstral/dir2mcp/internal/usage"
 )
@@ -1991,9 +1992,12 @@ func writeCorpusSnapshot(ctx context.Context, stateDir string, st model.Store, i
 		return fmt.Errorf("marshal corpus snapshot: %w", err)
 	}
 
-	// Match previous file mode (0o644) used with os.WriteFile.
+	// Owner-only: this lives under the state directory and carries the corpus
+	// snapshot (paths, titles, counts), so it is corpus content in another
+	// shape rather than a public artifact (#726). atomicWriteFile chmods the
+	// temp file before the rename, so the mode is never briefly wider.
 	path := filepath.Join(stateDir, "corpus.json")
-	if err := atomicWriteFile(path, raw, 0o644); err != nil {
+	if err := atomicWriteFile(path, raw, statefs.FileMode); err != nil {
 		return fmt.Errorf("write corpus snapshot: %w", err)
 	}
 	return nil

--- a/internal/cli/reindex.go
+++ b/internal/cli/reindex.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dirstral/dir2mcp/internal/index"
 	"github.com/dirstral/dir2mcp/internal/ingest"
 	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/statefs"
 )
 
 // reindexProgressInterval is how often the reindex command prints a
@@ -260,8 +261,14 @@ func (s *reindexStaging) rollback(stderr io.Writer) {
 // already moved aside, writes a CLI error, and returns the exit code.
 func (a *App) prepareReindexStore(ctx context.Context, global globalOptions, cfg config.Config) (model.Store, *reindexStaging, int) {
 	staging := &reindexStaging{stateDir: cfg.StateDir}
-	if err := os.MkdirAll(cfg.StateDir, 0o755); err != nil {
+	if err := statefs.MkdirAllHardened(cfg.StateDir); err != nil {
 		writeCLIError(a.stderr, global.jsonOutput, exitRootInaccessible, fmt.Sprintf("create state dir: %v", err))
+		return nil, nil, exitRootInaccessible
+	}
+	// Same repair as `up`: a reindex is the other way a corpus's state tree is
+	// created, and it is where a tree from an older build most often arrives.
+	if err := statefs.HardenTree(cfg.StateDir); err != nil {
+		writeCLIError(a.stderr, global.jsonOutput, exitRootInaccessible, fmt.Sprintf("secure state dir: %v", err))
 		return nil, nil, exitRootInaccessible
 	}
 	st := a.storeForConfig(cfg)

--- a/internal/cli/server_doctor.go
+++ b/internal/cli/server_doctor.go
@@ -19,6 +19,7 @@ import (
 	"github.com/dirstral/dir2mcp/internal/model"
 	"github.com/dirstral/dir2mcp/internal/provider"
 	"github.com/dirstral/dir2mcp/internal/providerfactory"
+	"github.com/dirstral/dir2mcp/internal/statefs"
 	"github.com/dirstral/dir2mcp/internal/store"
 )
 
@@ -114,7 +115,7 @@ func configCheck(err error) doctorCheck {
 // instead of a stat-only check because permission bits don't always
 // reflect the effective writability of a path (mounts, ACLs).
 func stateDirCheck(stateDir string) doctorCheck {
-	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+	if err := statefs.MkdirAllHardened(stateDir); err != nil {
 		return doctorCheck{Name: "state_dir", Status: doctorStatusError, Detail: fmt.Sprintf("mkdir %s: %v", stateDir, err)}
 	}
 	probe, err := os.CreateTemp(stateDir, "doctor-probe-*")

--- a/internal/cli/service_darwin.go
+++ b/internal/cli/service_darwin.go
@@ -62,6 +62,8 @@ func (m *launchdManager) serviceTarget(label string) string {
 // GUI domain, kicking off an immediate (re)start via kickstart -k.
 func (m *launchdManager) install(spec serviceSpec) (string, error) {
 	plistPath := m.plistPath(spec.Label)
+	// launchd must be able to read this; it is a service definition, not
+	// corpus-derived content (#726).
 	if err := os.MkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
 		return "", fmt.Errorf("create LaunchAgents dir: %w", err)
 	}

--- a/internal/cli/service_linux.go
+++ b/internal/cli/service_linux.go
@@ -50,6 +50,8 @@ func (m *systemdManager) install(spec serviceSpec) (string, error) {
 		return "", err
 	}
 	unit := m.unitPath(spec.Label)
+	// systemd must be able to read this; it is a service definition, not
+	// corpus-derived content (#726).
 	if err := os.MkdirAll(filepath.Dir(unit), 0o755); err != nil {
 		return "", fmt.Errorf("create systemd user dir: %w", err)
 	}

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -30,6 +30,7 @@ import (
 	"github.com/dirstral/dir2mcp/internal/providerfactory"
 	"github.com/dirstral/dir2mcp/internal/retrieval"
 	"github.com/dirstral/dir2mcp/internal/setupwizard"
+	"github.com/dirstral/dir2mcp/internal/statefs"
 	"github.com/dirstral/dir2mcp/internal/store"
 )
 
@@ -444,8 +445,17 @@ func (a *App) validateUpConfig(cfg *config.Config, opts upOptions) int {
 		writeCLIError(a.stderr, opts.jsonOutput, exitRootInaccessible, fmt.Sprintf("root inaccessible: %v", err))
 		return exitRootInaccessible
 	}
-	if err := os.MkdirAll(cfg.StateDir, 0o755); err != nil {
+	if err := statefs.MkdirAllHardened(cfg.StateDir); err != nil {
 		writeCLIError(a.stderr, opts.jsonOutput, exitRootInaccessible, fmt.Sprintf("create state dir: %v", err))
+		return exitRootInaccessible
+	}
+	// Repair a tree an older build left world-readable. Creating the root
+	// owner-only does nothing for the caches, snapshots and index segments
+	// already under it, and those are the corpus in another shape. Failing
+	// here rather than warning: continuing would leave that content readable
+	// by other local accounts while reporting a private state directory.
+	if err := statefs.HardenTree(cfg.StateDir); err != nil {
+		writeCLIError(a.stderr, opts.jsonOutput, exitRootInaccessible, fmt.Sprintf("secure state dir: %v", err))
 		return exitRootInaccessible
 	}
 	// create payments subdirectory while x402 configuration has been
@@ -454,7 +464,7 @@ func (a *App) validateUpConfig(cfg *config.Config, opts upOptions) int {
 	// the directory exists regardless of mode, avoiding inconsistent state.
 	// because it's done after x402 validation, a valid config (including
 	// mode="off") won't leave an inconsistent state.
-	if err := os.MkdirAll(filepath.Join(cfg.StateDir, "payments"), 0o755); err != nil {
+	if err := statefs.MkdirAllHardened(filepath.Join(cfg.StateDir, "payments")); err != nil {
 		writeCLIError(a.stderr, opts.jsonOutput, exitRootInaccessible, fmt.Sprintf("create payments dir: %v", err))
 		return exitRootInaccessible
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,7 @@ import (
 	"github.com/dirstral/dir2mcp/internal/netutil"
 	"github.com/dirstral/dir2mcp/internal/provider"
 	"github.com/dirstral/dir2mcp/internal/secrets"
+	"github.com/dirstral/dir2mcp/internal/statefs"
 	"github.com/dirstral/dir2mcp/internal/subtitle"
 	"github.com/dirstral/dir2mcp/internal/usage"
 )
@@ -1797,6 +1798,8 @@ func SaveFile(path string, cfg Config) error {
 		raw = append(raw, '\n')
 	}
 
+	// Deliberately not owner-only: this is the operator's own .dir2mcp.yaml
+	// in their own directory, not the derived state tree (#726).
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return fmt.Errorf("create config directory: %w", err)
 	}
@@ -1840,10 +1843,14 @@ func SaveEffectiveSnapshot(cfg Config, sources SecretSourceMetadata) (string, er
 		raw = append(raw, '\n')
 	}
 
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	// The snapshot's directory IS the state directory, and this is often what
+	// creates it: any command that loads config against a fresh state path
+	// arrives here first. Creating it 0755 left the whole derived tree
+	// world-readable even though the snapshot itself was 0600 (#726).
+	if err := statefs.MkdirAllHardened(filepath.Dir(path)); err != nil {
 		return "", fmt.Errorf("create snapshot directory: %w", err)
 	}
-	if err := os.WriteFile(path, raw, 0o600); err != nil {
+	if err := statefs.WriteFile(path, raw); err != nil {
 		return "", fmt.Errorf("write snapshot file %s: %w", path, err)
 	}
 	return path, nil

--- a/internal/corpusfs/s3.go
+++ b/internal/corpusfs/s3.go
@@ -15,6 +15,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+
+	"github.com/dirstral/dir2mcp/internal/statefs"
 )
 
 // s3API is the subset of the S3 client S3FS depends on. Interfacing it lets
@@ -392,7 +394,7 @@ func (s *S3FS) Localize(ctx context.Context, relPath string) (string, func(), er
 	if strings.TrimSpace(dir) == "" {
 		dir = os.TempDir()
 	}
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := statefs.MkdirAll(dir); err != nil {
 		return "", nil, fmt.Errorf("corpusfs: create cache dir: %w", err)
 	}
 	ext := path.Ext(relPath)

--- a/internal/index/diskindex/diskindex.go
+++ b/internal/index/diskindex/diskindex.go
@@ -53,6 +53,7 @@ import (
 
 	"github.com/dirstral/dir2mcp/internal/index/topk"
 	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/statefs"
 )
 
 const (
@@ -248,7 +249,7 @@ func (d *DiskIndex) BatchUpsert(ctx context.Context, items []model.IndexUpsert) 
 // new locators. On any failure it rolls the segment back to its pre-batch length
 // and leaves the in-memory state untouched. Caller holds the write lock.
 func (d *DiskIndex) appendBatch(items []model.IndexUpsert) error {
-	f, err := os.OpenFile(d.path, os.O_RDWR|os.O_CREATE, 0o644)
+	f, err := statefs.OpenFile(d.path, os.O_RDWR|os.O_CREATE)
 	if err != nil {
 		return err
 	}
@@ -361,7 +362,7 @@ func (d *DiskIndex) Delete(ctx context.Context, chunkIDs []uint64) error {
 // file (with header) on first write, and updates the locator map. The caller
 // must hold the write lock.
 func (d *DiskIndex) appendRecord(chunkID uint64, tombstone bool, vector []float32, payload model.IndexPayload) error {
-	f, err := os.OpenFile(d.path, os.O_RDWR|os.O_CREATE, 0o644)
+	f, err := statefs.OpenFile(d.path, os.O_RDWR|os.O_CREATE)
 	if err != nil {
 		return err
 	}
@@ -598,7 +599,7 @@ func (d *DiskIndex) Reset(ctx context.Context, identity string) error {
 
 // truncateSegment rewrites path with just a fresh header.
 func truncateSegment(path string) error {
-	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
+	f, err := statefs.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC)
 	if err != nil {
 		return err
 	}
@@ -647,7 +648,7 @@ func (d *DiskIndex) Save(ctx context.Context, path string) error {
 	}
 
 	tmpPath := path + ".tmp"
-	out, err := os.Create(tmpPath)
+	out, err := statefs.Create(tmpPath)
 	if err != nil {
 		return err
 	}
@@ -1058,7 +1059,7 @@ func writeIdentitySidecar(path, identity string) error {
 		return err
 	}
 	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+	if err := statefs.WriteFile(tmp, data); err != nil {
 		return err
 	}
 	return os.Rename(tmp, path)

--- a/internal/index/hnsw_index.go
+++ b/internal/index/hnsw_index.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/dirstral/dir2mcp/internal/index/topk"
 	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/statefs"
 )
 
 // Persisted snapshot basenames (issue #247). The ".v2" marker distinguishes
@@ -381,13 +382,13 @@ func (i *HNSWIndex) Save(ctx context.Context, path string) error {
 	// both os.Create and os.Rename would otherwise fail with "no such file or
 	// directory" (issue #375). MkdirAll on an existing directory is a no-op.
 	if dir := filepath.Dir(path); dir != "" && dir != "." {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
+		if err := statefs.MkdirAll(dir); err != nil {
 			return err
 		}
 	}
 
 	tmpPath := path + ".tmp"
-	file, err := os.Create(tmpPath)
+	file, err := statefs.Create(tmpPath)
 	if err != nil {
 		return err
 	}

--- a/internal/ingest/contextual.go
+++ b/internal/ingest/contextual.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/dirstral/dir2mcp/internal/config"
 	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/statefs"
 )
 
 // maxContextDocumentRunes bounds how much of the parent document is shown to the
@@ -135,11 +136,11 @@ func (g *chunkContextGenerator) writeCache(cachePath, contextText string) {
 	if cachePath == "" {
 		return
 	}
-	if err := os.MkdirAll(filepath.Dir(cachePath), 0o755); err != nil {
+	if err := statefs.MkdirAll(filepath.Dir(cachePath)); err != nil {
 		g.warn("contextual retrieval: create cache dir: %v", err)
 		return
 	}
-	if err := os.WriteFile(cachePath, []byte(contextText), 0o644); err != nil {
+	if err := statefs.WriteFile(cachePath, []byte(contextText)); err != nil {
 		g.warn("contextual retrieval: write cache: %v", err)
 	}
 }

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -28,6 +28,7 @@ import (
 	"github.com/dirstral/dir2mcp/internal/providerfactory"
 	"github.com/dirstral/dir2mcp/internal/quality"
 	"github.com/dirstral/dir2mcp/internal/scancache"
+	"github.com/dirstral/dir2mcp/internal/statefs"
 	"github.com/dirstral/dir2mcp/internal/store"
 	"github.com/dirstral/dir2mcp/internal/subtitle"
 )
@@ -3893,7 +3894,7 @@ func (s *Service) persistStructuredRepresentation(ctx context.Context, doc model
 // detail (spec §7.4.B: the raw DoclingDocument is not a representation).
 func (s *Service) readOrComputeStructured(ctx context.Context, doc model.Document, content []byte, se structuredExtractor) (StructuredExtraction, error) {
 	cacheDir := filepath.Join(s.cfg.StateDir, "cache", "docling")
-	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+	if err := statefs.MkdirAll(cacheDir); err != nil {
 		return StructuredExtraction{}, fmt.Errorf("create docling cache dir: %w", err)
 	}
 	cachePath := filepath.Join(cacheDir, s.ocrCacheKey(content)+".json")
@@ -3909,7 +3910,7 @@ func (s *Service) readOrComputeStructured(ctx context.Context, doc model.Documen
 		return StructuredExtraction{}, err
 	}
 	if encoded, mErr := json.Marshal(res); mErr == nil {
-		if wErr := os.WriteFile(cachePath, encoded, 0o644); wErr != nil {
+		if wErr := statefs.WriteFile(cachePath, encoded); wErr != nil {
 			s.getLogger().Printf("cache structured extraction for %s: %v", doc.RelPath, wErr)
 		}
 	}
@@ -4063,7 +4064,7 @@ func (s *Service) generatePandocMarkdownRepresentation(ctx context.Context, doc 
 // readOrComputeOCR.
 func (s *Service) readOrComputePandoc(ctx context.Context, doc model.Document, content []byte) (string, error) {
 	cacheDir := filepath.Join(s.cfg.StateDir, "cache", "pandoc")
-	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+	if err := statefs.MkdirAll(cacheDir); err != nil {
 		return "", fmt.Errorf("create pandoc cache dir: %w", err)
 	}
 	cachePath := filepath.Join(cacheDir, computeContentHash(content)+".md")
@@ -4075,7 +4076,7 @@ func (s *Service) readOrComputePandoc(ctx context.Context, doc model.Document, c
 		return "", fmt.Errorf("%w: pandoc extract %s: %w", ErrOCRProviderFailure, doc.RelPath, err)
 	}
 	mdBytes := []byte(strings.ReplaceAll(strings.ReplaceAll(md, "\r\n", "\n"), "\r", "\n"))
-	if err := os.WriteFile(cachePath, mdBytes, 0o644); err != nil {
+	if err := statefs.WriteFile(cachePath, mdBytes); err != nil {
 		return "", fmt.Errorf("write pandoc cache: %w", err)
 	}
 	return string(mdBytes), nil
@@ -5116,7 +5117,7 @@ func (s *Service) EnforceOCRCachePolicy(cacheDir string) error {
 
 func (s *Service) readOrComputeOCR(ctx context.Context, doc model.Document, content []byte) (string, error) {
 	cacheDir := filepath.Join(s.cfg.StateDir, "cache", "ocr")
-	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+	if err := statefs.MkdirAll(cacheDir); err != nil {
 		return "", fmt.Errorf("create ocr cache dir: %w", err)
 	}
 
@@ -5138,7 +5139,7 @@ func (s *Service) readOrComputeOCR(ctx context.Context, doc model.Document, cont
 	}
 
 	ocrBytes := []byte(strings.ReplaceAll(strings.ReplaceAll(ocrText, "\r\n", "\n"), "\r", "\n"))
-	if err := os.WriteFile(cachePath, ocrBytes, 0o644); err != nil {
+	if err := statefs.WriteFile(cachePath, ocrBytes); err != nil {
 		return "", fmt.Errorf("write ocr cache: %w", err)
 	}
 	shouldEnforceAfterWrite := s.markOCRCacheWrite()
@@ -5268,7 +5269,7 @@ func (s *Service) readOrComputeTranscriptWithWords(ctx context.Context, doc mode
 	}
 
 	cacheDir := filepath.Join(s.cfg.StateDir, "cache", "transcribe")
-	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+	if err := statefs.MkdirAll(cacheDir); err != nil {
 		return "", nil, fmt.Errorf("create transcript cache dir: %w", err)
 	}
 
@@ -5292,7 +5293,7 @@ func (s *Service) readOrComputeTranscriptWithWords(ctx context.Context, doc mode
 	}
 
 	transcriptBytes := []byte(strings.ReplaceAll(strings.ReplaceAll(transcript, "\r\n", "\n"), "\r", "\n"))
-	if err := os.WriteFile(cachePath, transcriptBytes, 0o644); err != nil {
+	if err := statefs.WriteFile(cachePath, transcriptBytes); err != nil {
 		return "", nil, fmt.Errorf("write transcript cache: %w", err)
 	}
 	s.writeCachedWords(wordsPath, words)
@@ -5329,7 +5330,7 @@ func (s *Service) readOrComputeWhisperTranslation(ctx context.Context, doc model
 	}
 
 	cacheDir := filepath.Join(s.cfg.StateDir, "cache", "transcribe")
-	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+	if err := statefs.MkdirAll(cacheDir); err != nil {
 		return "", nil, fmt.Errorf("create transcript cache dir: %w", err)
 	}
 
@@ -5361,7 +5362,7 @@ func (s *Service) readOrComputeWhisperTranslation(ctx context.Context, doc model
 		return "", nil, fmt.Errorf("%w: whisper-translate %s: %w", ErrTranslateProviderFailure, doc.RelPath, err)
 	}
 	translatedBytes := []byte(strings.ReplaceAll(strings.ReplaceAll(translated, "\r\n", "\n"), "\r", "\n"))
-	if err := os.WriteFile(cachePath, translatedBytes, 0o644); err != nil {
+	if err := statefs.WriteFile(cachePath, translatedBytes); err != nil {
 		return "", nil, fmt.Errorf("write whisper-translate cache: %w", err)
 	}
 	s.writeCachedWords(wordsPath, words)
@@ -5502,7 +5503,7 @@ func (s *Service) writeCachedWords(path string, words []model.TimedWord) {
 		s.getLogger().Printf("marshal transcript words cache: %v", err)
 		return
 	}
-	if err := os.WriteFile(path, raw, 0o644); err != nil {
+	if err := statefs.WriteFile(path, raw); err != nil {
 		s.getLogger().Printf("write transcript words cache (%s): %v", path, err)
 	}
 }

--- a/internal/ingest/summary.go
+++ b/internal/ingest/summary.go
@@ -13,6 +13,7 @@ import (
 	"github.com/dirstral/dir2mcp/internal/model"
 	"github.com/dirstral/dir2mcp/internal/provider"
 	"github.com/dirstral/dir2mcp/internal/providerfactory"
+	"github.com/dirstral/dir2mcp/internal/statefs"
 	"github.com/dirstral/dir2mcp/internal/store"
 )
 
@@ -365,11 +366,11 @@ func (s *Service) readOrComputeSummary(ctx context.Context, sourceText string) (
 		return "", err
 	}
 	out := strings.ReplaceAll(strings.ReplaceAll(generated, "\r\n", "\n"), "\r", "\n")
-	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+	if err := statefs.MkdirAll(cacheDir); err != nil {
 		s.getLogger().Printf("hierarchical retrieval: create summary cache dir failed (continuing uncached): %v", err)
 		return out, nil
 	}
-	if err := os.WriteFile(cachePath, []byte(out), 0o644); err != nil {
+	if err := statefs.WriteFile(cachePath, []byte(out)); err != nil {
 		s.getLogger().Printf("hierarchical retrieval: write summary cache failed (continuing uncached): %v", err)
 	}
 	return out, nil

--- a/internal/ingest/translate.go
+++ b/internal/ingest/translate.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/dirstral/dir2mcp/internal/config"
 	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/statefs"
 )
 
 // readOrComputeTranslation returns the source transcript translated into
@@ -23,7 +24,7 @@ import (
 // same source media always yields the same translation for a given target.
 func (s *Service) readOrComputeTranslation(ctx context.Context, content []byte, sourceText, targetLang string) (string, error) {
 	cacheDir := filepath.Join(s.cfg.StateDir, "cache", "translate")
-	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+	if err := statefs.MkdirAll(cacheDir); err != nil {
 		return "", fmt.Errorf("create translate cache dir: %w", err)
 	}
 
@@ -50,7 +51,7 @@ func (s *Service) readOrComputeTranslation(ctx context.Context, content []byte, 
 	}
 
 	out := strings.ReplaceAll(strings.ReplaceAll(translated, "\r\n", "\n"), "\r", "\n")
-	if err := os.WriteFile(cachePath, []byte(out), 0o644); err != nil {
+	if err := statefs.WriteFile(cachePath, []byte(out)); err != nil {
 		return "", fmt.Errorf("write translate cache: %w", err)
 	}
 	return out, nil

--- a/internal/mcp/payment.go
+++ b/internal/mcp/payment.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/dirstral/dir2mcp/internal/statefs"
 	storepkg "github.com/dirstral/dir2mcp/internal/store"
 	"github.com/dirstral/dir2mcp/internal/x402"
 )
@@ -877,7 +878,7 @@ func (s *Server) appendPaymentLog(event string, data map[string]interface{}) {
 
 	// helper that (re)initializes the cached file/writer; caller must hold mutex.
 	initWriter := func() error {
-		if err := os.MkdirAll(filepath.Dir(s.paymentLogPath), 0o755); err != nil {
+		if err := statefs.MkdirAll(filepath.Dir(s.paymentLogPath)); err != nil {
 			return err
 		}
 		f, err := os.OpenFile(s.paymentLogPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600) // owner read/write only

--- a/internal/statefs/statefs.go
+++ b/internal/statefs/statefs.go
@@ -1,0 +1,193 @@
+// Package statefs creates and repairs the local state hierarchy with
+// owner-only permissions.
+//
+// Everything dir2mcp keeps under StateDir is derived from the corpus: OCR
+// output, transcripts, translations, summaries, contextual text, and index
+// payloads that carry titles, snippets, speakers and media references. That is
+// the corpus in a different shape, so it inherits the corpus's confidentiality
+// rather than a cache's convenience. meta.sqlite, bearer tokens and support
+// bundles were already owner-only; this is the rest of the tree catching up
+// (#726).
+//
+// Two properties the mode arguments alone did not give:
+//
+//   - `MkdirAll` does nothing to a directory that ALREADY exists, so a tree
+//     first created 0755 by an older build, or by whichever code path happened
+//     to run first, stayed 0755 forever. StateDir was created 0700 by
+//     `service` and `up --daemon` and 0755 by `up` and `reindex`, so its mode
+//     depended on how the operator started the daemon. `Harden` repairs an
+//     existing path instead of assuming a fresh one.
+//
+//   - 0700 and 0600 are umask-safe (a umask can only remove bits, and these
+//     grant none outside the owner), so the result does not depend on the
+//     ambient umask the way 0755 did.
+//
+// Not everything under a state path belongs here. Artifacts written FOR
+// something else to read — a launchd plist, a systemd unit, an export the
+// operator asked for — keep their own modes, and their call sites say so.
+package statefs
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+const (
+	// DirMode is the mode for every directory in the state hierarchy.
+	DirMode fs.FileMode = 0o700
+	// FileMode is the mode for every corpus-derived file in it.
+	FileMode fs.FileMode = 0o600
+)
+
+// MkdirAll creates path and any missing parents, owner-only.
+//
+// Existing directories keep their mode, which is what `Harden` is for: this
+// call cannot distinguish a parent the operator owns and shares deliberately
+// (a home directory) from one that is ours to tighten.
+func MkdirAll(path string) error {
+	return os.MkdirAll(path, DirMode)
+}
+
+// MkdirAllHardened creates path owner-only and tightens it if it already
+// existed with a wider mode. Use for directories that are ours: the state root
+// and the derived-content trees under it.
+func MkdirAllHardened(path string) error {
+	if err := MkdirAll(path); err != nil {
+		return err
+	}
+	return Harden(path)
+}
+
+// WriteFile writes data to path owner-only, truncating any existing file.
+//
+// os.WriteFile leaves an existing file's mode alone, so a file first written
+// 0644 stays 0644 through every later rewrite. This chmods after the write to
+// close that.
+func WriteFile(path string, data []byte) error {
+	if err := os.WriteFile(path, data, FileMode); err != nil {
+		return err
+	}
+	return chmodIfWider(path, FileMode)
+}
+
+// Create opens path for writing, owner-only, truncating an existing file.
+func Create(path string) (*os.File, error) {
+	return OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC)
+}
+
+// OpenFile opens path with the caller's flags at the owner-only mode, and
+// tightens an existing file whose mode is wider.
+func OpenFile(path string, flag int) (*os.File, error) {
+	file, err := os.OpenFile(path, flag, FileMode) //nolint:gosec // mode is FileMode
+	if err != nil {
+		return nil, err
+	}
+	if err := chmodFileIfWider(file, FileMode); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	return file, nil
+}
+
+// Harden tightens one path to the owner-only mode for its kind.
+//
+// A path we do not own cannot be chmod'd, and that is reported rather than
+// ignored: continuing would leave corpus-derived content readable by other
+// local accounts while the logs claimed the state directory was private.
+func Harden(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	want := FileMode
+	if info.IsDir() {
+		want = DirMode
+	}
+	return chmodInfoIfWider(path, info, want)
+}
+
+// HardenTree tightens root and everything under it.
+//
+// Called on the state directory at startup so a corpus indexed by an older
+// build, or under a permissive umask, becomes private on the next run instead
+// of only for newly written files. Paths that disappear mid-walk are skipped:
+// a live daemon rotates temporaries under here.
+func HardenTree(root string) error {
+	if _, err := os.Stat(root); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	return filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return nil
+			}
+			return err
+		}
+		info, statErr := entry.Info()
+		if statErr != nil {
+			if errors.Is(statErr, fs.ErrNotExist) {
+				return nil
+			}
+			return statErr
+		}
+		// Symlinks are not followed and not chmod'd: the mode that matters is
+		// the target's, and the target may deliberately live outside the tree.
+		if info.Mode()&fs.ModeSymlink != 0 {
+			return nil
+		}
+		want := FileMode
+		if entry.IsDir() {
+			want = DirMode
+		}
+		if cErr := chmodInfoIfWider(path, info, want); cErr != nil {
+			if errors.Is(cErr, fs.ErrNotExist) {
+				return nil
+			}
+			return cErr
+		}
+		return nil
+	})
+}
+
+// chmodIfWider tightens path when its current mode grants more than want.
+func chmodIfWider(path string, want fs.FileMode) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	return chmodInfoIfWider(path, info, want)
+}
+
+func chmodInfoIfWider(path string, info fs.FileInfo, want fs.FileMode) error {
+	current := info.Mode().Perm()
+	// Only ever remove bits. A file the operator deliberately made MORE
+	// restrictive (0400 on a read-only cache) stays that way.
+	if current&^want == 0 {
+		return nil
+	}
+	if err := os.Chmod(path, current&want); err != nil {
+		return fmt.Errorf("tighten %s to owner-only: %w", path, err)
+	}
+	return nil
+}
+
+func chmodFileIfWider(file *os.File, want fs.FileMode) error {
+	info, err := file.Stat()
+	if err != nil {
+		return err
+	}
+	current := info.Mode().Perm()
+	if current&^want == 0 {
+		return nil
+	}
+	if err := file.Chmod(current & want); err != nil {
+		return fmt.Errorf("tighten %s to owner-only: %w", file.Name(), err)
+	}
+	return nil
+}

--- a/tests/security/state_permissions_726_test.go
+++ b/tests/security/state_permissions_726_test.go
@@ -1,0 +1,189 @@
+//go:build unix
+
+// POSIX permission bits and syscall.Umask. Windows has no umask and its
+// owner-only guarantee is an ACL contract, which is a separate test.
+
+package tests
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/statefs"
+)
+
+// #726: dir2mcp keeps corpus-derived plaintext under StateDir (OCR output,
+// transcripts, translations, summaries, contextual text) plus index payloads
+// carrying titles, snippets, speakers and media references, and several normal
+// startup and ingest paths created that hierarchy 0755/0644. Under the usual
+// 022 umask any other local account could read the corpus in derived form even
+// when the corpus directory itself was private, which contradicted the
+// owner-only posture already applied to meta.sqlite, tokens and support
+// bundles.
+//
+// These tests run under a deliberately permissive umask, because the defect was
+// invisible under a restrictive one.
+
+// withPermissiveUmask forces 022 for the duration of a test, which is the
+// setting the reported defect needs and is NOT what a hardened CI box
+// necessarily has.
+func withPermissiveUmask(t *testing.T) {
+	t.Helper()
+	old := syscall.Umask(0o022)
+	t.Cleanup(func() { syscall.Umask(old) })
+}
+
+func modeOf(t *testing.T, path string) fs.FileMode {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	return info.Mode().Perm()
+}
+
+func TestStateDirectoriesAreOwnerOnlyUnderAPermissiveUmask(t *testing.T) {
+	withPermissiveUmask(t)
+	root := filepath.Join(t.TempDir(), "state")
+
+	if err := statefs.MkdirAll(filepath.Join(root, "cache", "ocr")); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	for _, dir := range []string{root, filepath.Join(root, "cache"), filepath.Join(root, "cache", "ocr")} {
+		if got := modeOf(t, dir); got != statefs.DirMode {
+			t.Fatalf("%s is %04o, want %04o: another local account can traverse the state tree", dir, got, statefs.DirMode)
+		}
+	}
+}
+
+func TestDerivedStateFilesAreOwnerOnlyUnderAPermissiveUmask(t *testing.T) {
+	withPermissiveUmask(t)
+	root := t.TempDir()
+
+	transcript := filepath.Join(root, "transcript.json")
+	if err := statefs.WriteFile(transcript, []byte(`{"text":"corpus content"}`)); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if got := modeOf(t, transcript); got != statefs.FileMode {
+		t.Fatalf("derived file is %04o, want %04o", got, statefs.FileMode)
+	}
+
+	snapshot := filepath.Join(root, "snapshot.bin")
+	file, err := statefs.Create(snapshot)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := file.WriteString("payload"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if got := modeOf(t, snapshot); got != statefs.FileMode {
+		t.Fatalf("index snapshot is %04o, want %04o", got, statefs.FileMode)
+	}
+}
+
+// TestAnExistingPermissiveStateTreeIsTightened pins the half a mode argument
+// could never fix: MkdirAll and WriteFile leave an EXISTING path's mode alone,
+// so a tree created 0755 by an older build stayed 0755 through every later run
+// no matter what mode the new code passed.
+func TestAnExistingPermissiveStateTreeIsTightened(t *testing.T) {
+	withPermissiveUmask(t)
+	root := filepath.Join(t.TempDir(), "legacy")
+
+	// A state tree exactly as an older build left it.
+	if err := os.MkdirAll(filepath.Join(root, "cache", "docling"), 0o755); err != nil {
+		t.Fatalf("seed dirs: %v", err)
+	}
+	derived := filepath.Join(root, "cache", "docling", "doc.md")
+	if err := os.WriteFile(derived, []byte("# extracted corpus text"), 0o644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	if modeOf(t, root) != 0o755 || modeOf(t, derived) != 0o644 {
+		t.Fatalf("seed did not reproduce the reported state: dir %04o file %04o",
+			modeOf(t, root), modeOf(t, derived))
+	}
+
+	if err := statefs.HardenTree(root); err != nil {
+		t.Fatalf("HardenTree: %v", err)
+	}
+	for _, dir := range []string{root, filepath.Join(root, "cache"), filepath.Join(root, "cache", "docling")} {
+		if got := modeOf(t, dir); got != statefs.DirMode {
+			t.Fatalf("pre-existing dir %s left at %04o", dir, got)
+		}
+	}
+	if got := modeOf(t, derived); got != statefs.FileMode {
+		t.Fatalf("pre-existing derived file left at %04o, want %04o", got, statefs.FileMode)
+	}
+}
+
+// TestRewritingAFilePreviouslyWorldReadableTightensIt covers the ingest caches,
+// which rewrite the same path on every re-derivation: os.WriteFile keeps the
+// existing mode, so a cache first written by an older build would otherwise
+// stay 0644 forever even as the content was refreshed.
+func TestRewritingAFilePreviouslyWorldReadableTightensIt(t *testing.T) {
+	withPermissiveUmask(t)
+	path := filepath.Join(t.TempDir(), "summary.txt")
+	if err := os.WriteFile(path, []byte("old"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := statefs.WriteFile(path, []byte("refreshed summary")); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if got := modeOf(t, path); got != statefs.FileMode {
+		t.Fatalf("rewritten cache is %04o, want %04o", got, statefs.FileMode)
+	}
+}
+
+// TestHardeningNeverWidens pins that this only ever removes bits: an operator
+// who made a cache read-only keeps it read-only.
+func TestHardeningNeverWidens(t *testing.T) {
+	withPermissiveUmask(t)
+	root := t.TempDir()
+	path := filepath.Join(root, "readonly.bin")
+	if err := os.WriteFile(path, []byte("x"), 0o400); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := statefs.HardenTree(root); err != nil {
+		t.Fatalf("HardenTree: %v", err)
+	}
+	if got := modeOf(t, path); got != 0o400 {
+		t.Fatalf("hardening widened a deliberately restrictive file to %04o", got)
+	}
+}
+
+// TestHardenTreeSkipsAVanishedPath: a live daemon rotates temporaries under the
+// state directory, so a walk that raced one must not fail the startup it is
+// protecting.
+func TestHardenTreeSkipsAVanishedPath(t *testing.T) {
+	withPermissiveUmask(t)
+	if err := statefs.HardenTree(filepath.Join(t.TempDir(), "never-created")); err != nil {
+		t.Fatalf("HardenTree on a missing root: %v", err)
+	}
+}
+
+// TestHardenTreeDoesNotFollowSymlinks: the mode that matters is the target's,
+// and a target may deliberately live outside the tree (an index moved to
+// another volume). Chmod'ing through the link would reach outside the state
+// directory entirely.
+func TestHardenTreeDoesNotFollowSymlinks(t *testing.T) {
+	withPermissiveUmask(t)
+	root := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "outside.txt")
+	if err := os.WriteFile(outside, []byte("not ours"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "link")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if err := statefs.HardenTree(root); err != nil {
+		t.Fatalf("HardenTree: %v", err)
+	}
+	if got := modeOf(t, outside); got != 0o644 {
+		t.Fatalf("hardening reached through a symlink and changed %s to %04o", outside, got)
+	}
+}


### PR DESCRIPTION
Closes #726.

Everything under `StateDir` is derived from the corpus — OCR output, transcripts, translations, summaries, contextual text, and index payloads carrying titles, snippets, speakers and media references. Several normal startup and ingest paths created it `0755`/`0644`, so under the usual `022` umask **any other local account could read the corpus in derived form** even when the corpus directory itself was private.

The modes were also *inconsistent* rather than merely wrong: `StateDir` was created `0700` by `service` and `up --daemon`, and `0755` by `up` and `reindex` — so its mode depended on how the operator happened to start the daemon.

## The fix

`internal/statefs` is the single place that answers this. Two things a mode argument alone could never fix:

- **`MkdirAll` and `WriteFile` leave an existing path's mode alone.** A tree first created `0755` by an older build stayed `0755` through every later run, however strict the new code was. `Harden`/`HardenTree` repair rather than assume.
- **`0700`/`0600` are umask-safe** (a umask only removes bits, and these grant none outside the owner), so the result no longer depends on the ambient umask.

Converted every writer under `StateDir`: the five ingest caches (docling, pandoc, OCR, transcript, translation), contextual and summary caches, the S3 local object cache, HNSW snapshots, disk-index segments and the identity sidecar, the payment log, `corpus.json`, and `StateDir` itself in `up`, `reindex`, `server_doctor` and the effective-config snapshot.

`up` and `reindex` additionally walk the tree at startup, so a corpus indexed by an older build becomes private on the next run rather than only for newly written files. A failure there is **fatal**: continuing would leave the content readable while reporting a private state directory.

## The issue's own repro found the last missing call site

```bash
umask 022
dir2mcp --state-dir /tmp/new-state support-bundle --output /tmp/bundle.tar.gz
stat -f '%Lp' /tmp/new-state     # was 755, now 700
```

That path touches neither `up` nor `reindex` — it arrives through `SaveEffectiveSnapshot`, which wrote a `0600` snapshot into a `0755` directory **it had just created**. The snapshot being owner-only while its own directory was not is precisely why this survived review, and I only caught it by running the reported repro against the built binary rather than trusting the converted call sites.

## Deliberately not owner-only

Marked at the call site so the next reader knows they were considered: the launchd plist and systemd unit (the service manager must read them), the operator's own `.dir2mcp.yaml`, `.gitignore`, exports, the operator-configured batch manifest, and the Claude Desktop config directory.

## Tests

Under a **forced `022` umask**, because the defect is invisible under a strict one, and `//go:build unix` since `syscall.Umask` does not exist on Windows (verified `GOOS=windows go vet` is clean).

Covers: fresh creation; repair of a pre-existing `0755`/`0644` tree; rewriting a cache first written world-readable; that hardening only ever **removes** bits (a deliberately `0400` file stays `0400`); a vanished path mid-walk (a live daemon rotates temporaries under here); and that symlinks are not followed, so hardening cannot reach outside the tree.

`make check` passes.