### PR TITLE
security(corpusfs): reject S3 keys that do not resolve inside the corpus (#735)

### DIFF
--- a/internal/corpusfs/corpusfs.go
+++ b/internal/corpusfs/corpusfs.go
@@ -69,6 +69,16 @@ type Options struct {
 	// and size is the file's size in bytes. It must not block or panic; the walker
 	// calls it inline during the walk.
 	OnOversize func(relPath string, size int64)
+	// OnUnsafeKey, when non-nil, is invoked once for every object key excluded
+	// because its prefix-relative name is not a usable corpus-relative path:
+	// absolute, or carrying a `..` segment, or otherwise unable to round-trip
+	// (#735). SPEC §7.8 requires such keys to be rejected on every backend, and
+	// this makes the rejection observable instead of a silent skip, which is
+	// what an operator needs to notice a bucket that is not shaped the way they
+	// think it is. The key is the FULL object key, because the prefix-relative
+	// form is exactly what could not be trusted. It must not block or panic;
+	// the walker calls it inline.
+	OnUnsafeKey func(key string, err error)
 }
 
 // CachedDirEntry is a directory child's identity recorded in the scan cache: its

--- a/internal/corpusfs/s3.go
+++ b/internal/corpusfs/s3.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 
+	"github.com/dirstral/dir2mcp/internal/relpath"
 	"github.com/dirstral/dir2mcp/internal/statefs"
 )
 
@@ -103,6 +104,9 @@ func (s *S3FS) MediaURL(ctx context.Context, relPath string) (string, bool, erro
 	if s.presign == nil {
 		return "", false, nil
 	}
+	if err := guardRel(relPath); err != nil {
+		return "", false, err
+	}
 	key := s.keyForRel(relPath)
 	url, err := s.presign(ctx, s.bucket, key)
 	if err != nil {
@@ -123,19 +127,64 @@ func normalizeS3Prefix(prefix string) string {
 }
 
 // keyForRel maps a corpus-relative path to a full S3 object key.
+// guardRel refuses a rel_path that is not inside the corpus.
+//
+// Discovery validates every key it emits, but a rel_path reaching Open,
+// Localize or MediaURL has usually come back through the store, an MCP
+// argument or a config file, and SPEC §7.8 requires the check on open and stat
+// as well as on list. keyForRel would otherwise strip a leading slash and
+// address a different object than the caller named.
+func guardRel(relPath string) error {
+	if _, err := relpath.Normalize(relPath); err != nil {
+		return fmt.Errorf("corpusfs: %q: %w", relPath, err)
+	}
+	return nil
+}
+
 func (s *S3FS) keyForRel(relPath string) string {
 	// No TrimSpace: Walk emits RelPath verbatim, so keys with leading/trailing
 	// spaces must round-trip exactly through keyForRel for Open/Localize.
 	return s.prefix + strings.TrimPrefix(filepath.ToSlash(relPath), "/")
 }
 
-// relForKey maps a full S3 object key to its corpus-relative path, or returns
-// ok=false when the key does not live under the configured prefix.
-func (s *S3FS) relForKey(key string) (string, bool) {
+// errKeyNotUnderPrefix marks a key outside the configured prefix. That is an
+// ordinary, expected outcome of listing (the prefix is a filter, not a
+// guarantee), and is distinct from a key that IS under the prefix but whose
+// relative name cannot be trusted.
+var errKeyNotUnderPrefix = errors.New("key is not under the configured prefix")
+
+// relForKey maps a full S3 object key to its corpus-relative path.
+//
+// Stripping the prefix as a raw string is not enough. A bucket is untrusted
+// input, and a key like `corpus/../outside.mp4` strips to `../outside.mp4`,
+// which then flows into code that joins it against the LOCAL root: video
+// recognition builds `RootDir + rel_path`, and so does TTML/SMIL export
+// probing. A leading-slash rel path does not even round-trip, because
+// keyForRel strips the slash and addresses a different object. SPEC §7.8
+// requires root/prefix isolation on every backend, so the relative name is
+// validated here, at the one place both callers pass through (#735).
+func (s *S3FS) relForKey(key string) (string, error) {
 	if !strings.HasPrefix(key, s.prefix) {
-		return "", false
+		return "", errKeyNotUnderPrefix
 	}
-	return strings.TrimPrefix(key, s.prefix), true
+	rel := strings.TrimPrefix(key, s.prefix)
+	// A directory placeholder is in scope and simply not a file; let the
+	// caller skip it rather than reporting it as an unsafe key.
+	if rel == "" || strings.HasSuffix(rel, "/") {
+		return rel, nil
+	}
+	normalized, err := relpath.Normalize(rel)
+	if err != nil {
+		return "", err
+	}
+	// Emit the key's own relative form, not the cleaned one, so a rel_path
+	// always maps back to the object it came from. Normalize only accepts
+	// paths whose cleaned form is equivalent, so the two differ solely in
+	// redundant separators, which keyForRel would not preserve anyway.
+	if normalized != rel {
+		return normalized, nil
+	}
+	return rel, nil
 }
 
 // Walk lists objects under the prefix and converts them to DiscoveredFile,
@@ -186,7 +235,7 @@ func (s *S3FS) listObjects(ctx context.Context, opts Options) ([]DiscoveredFile,
 		}
 		for _, obj := range out.Contents {
 			if opts.UseGitIgnore {
-				if rel, ok := s.relForKey(aws.ToString(obj.Key)); ok && path.Base(rel) == ".gitignore" {
+				if rel, err := s.relForKey(aws.ToString(obj.Key)); err == nil && path.Base(rel) == ".gitignore" {
 					gitignoreRels = append(gitignoreRels, rel)
 				}
 			}
@@ -287,8 +336,15 @@ func (s *S3FS) getGitIgnoreObject(ctx context.Context, rel string) ([]byte, erro
 // the object is skipped.
 func (s *S3FS) discoveredFromObject(obj s3types.Object, opts Options) (DiscoveredFile, bool) {
 	key := aws.ToString(obj.Key)
-	rel, ok := s.relForKey(key)
-	if !ok {
+	rel, err := s.relForKey(key)
+	if err != nil {
+		// Not under the prefix is the listing's own noise. A key that IS under
+		// it but is not a usable rel_path is a finding: report it rather than
+		// dropping it silently, so an operator can see the bucket carries keys
+		// dir2mcp refuses (#735).
+		if !errors.Is(err, errKeyNotUnderPrefix) && opts.OnUnsafeKey != nil {
+			opts.OnUnsafeKey(key, err)
+		}
 		return DiscoveredFile{}, false
 	}
 	// Skip "directory" placeholder keys (those ending in "/") and the prefix
@@ -343,6 +399,9 @@ func (s *S3FS) Open(ctx context.Context, relPath string) (io.ReadSeekCloser, err
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
+	if err := guardRel(relPath); err != nil {
+		return nil, err
+	}
 	key := s.keyForRel(relPath)
 	head, err := s.client.HeadObject(ctx, &s3.HeadObjectInput{
 		Bucket: aws.String(s.bucket),
@@ -378,6 +437,9 @@ func (s *S3FS) Open(ctx context.Context, relPath string) (io.ReadSeekCloser, err
 // a cleanup that removes the file.
 func (s *S3FS) Localize(ctx context.Context, relPath string) (string, func(), error) {
 	if err := ctx.Err(); err != nil {
+		return "", nil, err
+	}
+	if err := guardRel(relPath); err != nil {
 		return "", nil, err
 	}
 	key := s.keyForRel(relPath)

--- a/internal/corpusfs/s3.go
+++ b/internal/corpusfs/s3.go
@@ -101,11 +101,14 @@ func (s *S3FS) MediaURL(ctx context.Context, relPath string) (string, bool, erro
 	if err := ctx.Err(); err != nil {
 		return "", false, err
 	}
-	if s.presign == nil {
-		return "", false, nil
-	}
+	// Before the capability check, not after: a backend without a presigner
+	// would otherwise answer "no media URL" for a path that should have been
+	// refused outright, which is a different answer from Open and Localize.
 	if err := guardRel(relPath); err != nil {
 		return "", false, err
+	}
+	if s.presign == nil {
+		return "", false, nil
 	}
 	key := s.keyForRel(relPath)
 	url, err := s.presign(ctx, s.bucket, key)
@@ -168,23 +171,24 @@ func (s *S3FS) relForKey(key string) (string, error) {
 		return "", errKeyNotUnderPrefix
 	}
 	rel := strings.TrimPrefix(key, s.prefix)
-	// A directory placeholder is in scope and simply not a file; let the
-	// caller skip it rather than reporting it as an unsafe key.
-	if rel == "" || strings.HasSuffix(rel, "/") {
+	// The prefix itself. In scope, simply not a file.
+	if rel == "" {
 		return rel, nil
 	}
-	normalized, err := relpath.Normalize(rel)
-	if err != nil {
-		return "", err
+	// A directory placeholder is in scope and not a file, but its NAME still
+	// has to be inside the corpus: `corpus/../` is a placeholder shape and a
+	// traversal, and skipping it on shape alone would hide it from
+	// OnUnsafeKey. Validate what it points at, then let the caller skip it.
+	if strings.HasSuffix(rel, "/") {
+		if _, err := relpath.Normalize(strings.TrimSuffix(rel, "/")); err != nil {
+			return "", err
+		}
+		return rel, nil
 	}
-	// Emit the key's own relative form, not the cleaned one, so a rel_path
-	// always maps back to the object it came from. Normalize only accepts
-	// paths whose cleaned form is equivalent, so the two differ solely in
-	// redundant separators, which keyForRel would not preserve anyway.
-	if normalized != rel {
-		return normalized, nil
-	}
-	return rel, nil
+	// Normalize returns the path unchanged or refuses it, so a discovered
+	// rel_path is always the key's own bytes and maps back to the object it
+	// came from.
+	return relpath.Normalize(rel)
 }
 
 // Walk lists objects under the prefix and converts them to DiscoveredFile,

--- a/internal/ingest/discover.go
+++ b/internal/ingest/discover.go
@@ -80,6 +80,12 @@ type DiscoverOptions struct {
 	// size-cap drop observable instead of silent (issue #497); the file is still
 	// excluded. See corpusfs.Options.OnOversize.
 	OnOversize func(relPath string, size int64)
+	// OnUnsafeKey, when non-nil, is invoked once for each object key excluded
+	// because its corpus-relative name is not a usable rel_path (#735). Only
+	// the S3 backend can produce these: a local walk cannot hand back a path
+	// above the directory it was asked to walk, but a bucket is untrusted
+	// input and its keys are whatever someone put there.
+	OnUnsafeKey func(key string, err error)
 }
 
 // DefaultDiscoverOptions returns discovery defaults used by ingestion.
@@ -103,6 +109,7 @@ func (o DiscoverOptions) corpusfsOptions() corpusfs.Options {
 		FollowSymlinks: o.FollowSymlinks,
 		ScanCache:      o.ScanCache,
 		OnOversize:     o.OnOversize,
+		OnUnsafeKey:    o.OnUnsafeKey,
 	}
 }
 

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -1688,6 +1688,16 @@ func (s *Service) runScan(ctx context.Context) error {
 			relPath, size, capMB,
 		)
 	}
+	// A bucket key that is not a usable rel_path is refused at discovery
+	// (#735). Logged rather than counted as a skip: it is not a corpus file
+	// dir2mcp declined to index, it is a key that could not be named safely,
+	// and an operator needs to see that their bucket contains such keys.
+	discoverOpts.OnUnsafeKey = func(key string, unsafeErr error) {
+		s.getLogger().Printf(
+			"discovery: refusing object key %q — it does not resolve inside the corpus root: %v",
+			key, unsafeErr,
+		)
+	}
 	discovered, err := s.corpusFS().Walk(ctx, s.cfg.RootDir, discoverOpts.corpusfsOptions())
 	if err != nil {
 		return err

--- a/internal/relpath/relpath.go
+++ b/internal/relpath/relpath.go
@@ -39,44 +39,53 @@ var ErrOutsideRoot = errors.New("path resolves outside the corpus root")
 // (empty, or carrying a separator that cannot round-trip).
 var ErrNotRelative = errors.New("not a corpus-relative path")
 
-// Normalize returns the canonical slash-separated form of rel, or an error.
+// Normalize validates rel and returns it UNCHANGED, or an error.
 //
-// Accepts an ordinary relative path and collapses redundant separators and
-// `.` segments (`a//b` and `a/./b` both become `a/b`). Rejects:
+// It does not clean and it does not trim. An S3 key is an opaque byte string,
+// so `a//b.txt` and `a/b.txt` name two different objects: returning the cleaned
+// form for a key the bucket listed as the former would have discovery record a
+// rel_path that `Open` then resolves to the latter, fetching an object the
+// corpus never saw. Leading and trailing spaces are the same problem, which is
+// why keyForRel deliberately does not trim either.
+//
+// So a path that WOULD change under cleaning is rejected rather than rewritten.
+// That is stricter than it needs to be for safety alone (`a//b.txt` escapes
+// nothing), and it is what keeps the §7.8 promise that the rel_path set is the
+// same on every backend: a local walk can never produce `a//b.txt`, so an S3
+// corpus must not either.
+//
+// Rejects:
 //
 //   - empty or whitespace-only input
 //   - an absolute path (`/x`), including one produced by a doubled prefix
 //     separator, which is how `corpus//absolute.mp4` arrived
-//   - `.` and `..`, and any path with a `..` segment, before OR after
-//     cleaning, so `a/../../outside` is refused rather than resolved
+//   - `.` and `..`, and any path with a `..` segment, before OR after cleaning
 //   - a backslash, which is a legal S3 key byte and a separator on Windows
+//   - anything whose cleaned form differs from itself: `a//b`, `a/./b`,
+//     `a/b/`, and so on
 func Normalize(rel string) (string, error) {
-	trimmed := strings.TrimSpace(rel)
-	if trimmed == "" {
+	if strings.TrimSpace(rel) == "" {
 		return "", ErrNotRelative
 	}
-	if strings.Contains(trimmed, `\`) {
+	if strings.Contains(rel, `\`) {
 		return "", ErrNotRelative
 	}
-	if strings.HasPrefix(trimmed, "/") {
+	if strings.HasPrefix(rel, "/") {
 		return "", ErrOutsideRoot
 	}
-	// Refuse a traversal segment in the INPUT as well as in the cleaned form.
-	// path.Clean resolves `a/../b` to `b`, which is a safe path, but it is not
-	// the path the bucket listed: accepting it would let a key address an
-	// object under a name that no longer matches its key, and identity is
-	// meant to be the same set of rel_paths on every backend (§7.8).
-	if hasDotDot(trimmed) {
+	if hasDotDot(rel) {
 		return "", ErrOutsideRoot
 	}
-	cleaned := path.Clean(trimmed)
-	if cleaned == "." || cleaned == ".." {
+	cleaned := path.Clean(rel)
+	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "/") || hasDotDot(cleaned) {
 		return "", ErrOutsideRoot
 	}
-	if strings.HasPrefix(cleaned, "/") || hasDotDot(cleaned) {
-		return "", ErrOutsideRoot
+	if cleaned != rel {
+		// Redundant separators, a `.` segment, a trailing slash: all name a
+		// different byte string than the cleaned form, and S3 keys are bytes.
+		return "", ErrNotRelative
 	}
-	return cleaned, nil
+	return rel, nil
 }
 
 // Valid reports whether rel is already a usable corpus-relative path.

--- a/internal/relpath/relpath.go
+++ b/internal/relpath/relpath.go
@@ -1,0 +1,95 @@
+// Package relpath is the one rule for what a corpus-relative path may be.
+//
+// SPEC §7.8 requires root/prefix isolation on EVERY backend: a `rel_path` or
+// object key that resolves outside the configured root must be rejected with
+// `PATH_OUTSIDE_ROOT`. The local walker got that from the filesystem, which
+// cannot hand back a path above the directory it was asked to walk. S3
+// discovery had no such floor: `relForKey` stripped the configured prefix as a
+// raw string, so a bucket containing `corpus/../outside.mp4` produced
+// `rel_path="../outside.mp4"` and it flowed on into code that joins it against
+// the local root (#735).
+//
+// # Slashes, not separators
+//
+// A rel_path is slash-separated by definition, so this cleans with `path`
+// rather than `filepath`. The difference matters at the S3 boundary in both
+// directions:
+//
+//   - `filepath.Clean` on Windows treats `\` as a separator, so it would
+//     rewrite an S3 key that legitimately contains a backslash and address a
+//     DIFFERENT object than the one the bucket listed.
+//   - a rel_path that still contains `\` cannot round-trip safely to a local
+//     path on Windows, where `..\outside` escapes exactly as `../outside`
+//     does. So a backslash is rejected here rather than cleaned, since the
+//     byte is meaningful to S3 and dangerous locally, and silently rewriting
+//     it would retarget the object.
+package relpath
+
+import (
+	"errors"
+	"path"
+	"strings"
+)
+
+// ErrOutsideRoot is the sentinel for a path that is not inside the corpus
+// root. Callers map it to the canonical `PATH_OUTSIDE_ROOT` (SPEC §17).
+var ErrOutsideRoot = errors.New("path resolves outside the corpus root")
+
+// ErrNotRelative is for input that is not a usable corpus-relative path at all
+// (empty, or carrying a separator that cannot round-trip).
+var ErrNotRelative = errors.New("not a corpus-relative path")
+
+// Normalize returns the canonical slash-separated form of rel, or an error.
+//
+// Accepts an ordinary relative path and collapses redundant separators and
+// `.` segments (`a//b` and `a/./b` both become `a/b`). Rejects:
+//
+//   - empty or whitespace-only input
+//   - an absolute path (`/x`), including one produced by a doubled prefix
+//     separator, which is how `corpus//absolute.mp4` arrived
+//   - `.` and `..`, and any path with a `..` segment, before OR after
+//     cleaning, so `a/../../outside` is refused rather than resolved
+//   - a backslash, which is a legal S3 key byte and a separator on Windows
+func Normalize(rel string) (string, error) {
+	trimmed := strings.TrimSpace(rel)
+	if trimmed == "" {
+		return "", ErrNotRelative
+	}
+	if strings.Contains(trimmed, `\`) {
+		return "", ErrNotRelative
+	}
+	if strings.HasPrefix(trimmed, "/") {
+		return "", ErrOutsideRoot
+	}
+	// Refuse a traversal segment in the INPUT as well as in the cleaned form.
+	// path.Clean resolves `a/../b` to `b`, which is a safe path, but it is not
+	// the path the bucket listed: accepting it would let a key address an
+	// object under a name that no longer matches its key, and identity is
+	// meant to be the same set of rel_paths on every backend (§7.8).
+	if hasDotDot(trimmed) {
+		return "", ErrOutsideRoot
+	}
+	cleaned := path.Clean(trimmed)
+	if cleaned == "." || cleaned == ".." {
+		return "", ErrOutsideRoot
+	}
+	if strings.HasPrefix(cleaned, "/") || hasDotDot(cleaned) {
+		return "", ErrOutsideRoot
+	}
+	return cleaned, nil
+}
+
+// Valid reports whether rel is already a usable corpus-relative path.
+func Valid(rel string) bool {
+	_, err := Normalize(rel)
+	return err == nil
+}
+
+func hasDotDot(p string) bool {
+	for _, segment := range strings.Split(p, "/") {
+		if segment == ".." {
+			return true
+		}
+	}
+	return false
+}

--- a/tests/corpusfs/s3_traversal_735_test.go
+++ b/tests/corpusfs/s3_traversal_735_test.go
@@ -66,8 +66,10 @@ func TestS3FSWalk_RejectsTraversalAndAbsoluteKeys(t *testing.T) {
 
 	// Rejection must be observable, not a silent skip: an operator needs to see
 	// that the bucket carries keys dir2mcp refuses.
-	if len(rejected) < 4 {
-		t.Fatalf("OnUnsafeKey saw %d keys (%v); the bucket holds five unsafe ones", len(rejected), rejected)
+	// Exactly, not at least: a regression that silently drops one callback
+	// would otherwise still pass.
+	if len(rejected) != 5 {
+		t.Fatalf("OnUnsafeKey saw %d keys (%v); the bucket holds exactly five unsafe ones", len(rejected), rejected)
 	}
 	for _, key := range rejected {
 		if key == "corpus/keep.txt" {

--- a/tests/corpusfs/s3_traversal_735_test.go
+++ b/tests/corpusfs/s3_traversal_735_test.go
@@ -1,0 +1,116 @@
+package tests
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/corpusfs"
+)
+
+// #735: S3FS.Walk accepted object keys whose prefix-relative name was absolute
+// or contained traversal segments. relForKey stripped the configured prefix as
+// a raw string and nothing re-checked the result, so under prefix "corpus/" the
+// key "corpus/../outside.mp4" became rel_path "../outside.mp4".
+//
+// That is not merely malformed metadata. The value reaches code that joins it
+// against the LOCAL root: video recognition builds RootDir + rel_path, and
+// TTML/SMIL export probes filepath.Join(RootDir, relPath). A bucket is
+// untrusted input, so a key could steer either at a file outside the corpus.
+// SPEC §7.8 requires root/prefix isolation on every backend.
+//
+// The pre-existing walk test (TestS3FSWalk_KeyMappingExcludeAndSizeCap) covered
+// prefix mapping with no adversarial keys, which is why this shipped.
+
+func TestS3FSWalk_RejectsTraversalAndAbsoluteKeys(t *testing.T) {
+	objs := map[string][]byte{
+		// The three keys named in the issue.
+		"corpus/../outside.mp4":      []byte("escapes the prefix"),
+		"corpus/a/../../outside.txt": []byte("escapes after a real segment"),
+		"corpus//absolute.mp4":       []byte("strips to a leading slash"),
+		// Neighbours worth pinning alongside them.
+		"corpus/..":                  []byte("bare parent"),
+		"corpus/sub/../still-inside": []byte("cleans to a safe path, still refused"),
+		// And an ordinary key, so the test fails loudly if the guard is
+		// over-broad rather than silently discovering nothing.
+		"corpus/keep.txt": []byte("hello"),
+	}
+	fsys, _ := newFakeS3FS(t, "corpus/", objs, "")
+
+	var rejected []string
+	got, err := fsys.Walk(context.Background(), "", corpusfs.Options{
+		MaxSizeBytes: 1 << 20,
+		OnUnsafeKey: func(key string, _ error) {
+			rejected = append(rejected, key)
+		},
+	})
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+
+	for _, f := range got {
+		if f.RelPath != "keep.txt" {
+			t.Fatalf("discovered %q; every other key in this bucket escapes the prefix and must be rejected (#735)", f.RelPath)
+		}
+		// The specific shapes, named so a regression says which one came back.
+		if strings.HasPrefix(f.RelPath, "/") {
+			t.Fatalf("absolute rel_path %q survived discovery", f.RelPath)
+		}
+		if strings.Contains(f.RelPath, "..") {
+			t.Fatalf("traversal rel_path %q survived discovery", f.RelPath)
+		}
+	}
+	if len(got) != 1 {
+		t.Fatalf("discovered %d files, want only keep.txt: %v", len(got), got)
+	}
+
+	// Rejection must be observable, not a silent skip: an operator needs to see
+	// that the bucket carries keys dir2mcp refuses.
+	if len(rejected) < 4 {
+		t.Fatalf("OnUnsafeKey saw %d keys (%v); the bucket holds five unsafe ones", len(rejected), rejected)
+	}
+	for _, key := range rejected {
+		if key == "corpus/keep.txt" {
+			t.Fatal("the ordinary key was reported as unsafe")
+		}
+	}
+}
+
+// TestS3FSWalk_UnsafeKeysAreSkippedWithoutACallback pins that the callback is
+// optional: a caller that does not pass one still gets a safe listing rather
+// than a panic or an unsafe rel_path.
+func TestS3FSWalk_UnsafeKeysAreSkippedWithoutACallback(t *testing.T) {
+	objs := map[string][]byte{
+		"corpus/../outside.mp4": []byte("x"),
+		"corpus/keep.txt":       []byte("hello"),
+	}
+	fsys, _ := newFakeS3FS(t, "corpus/", objs, "")
+
+	got, err := fsys.Walk(context.Background(), "", corpusfs.Options{MaxSizeBytes: 1 << 20})
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if len(got) != 1 || got[0].RelPath != "keep.txt" {
+		t.Fatalf("Walk without OnUnsafeKey = %v, want only keep.txt", got)
+	}
+}
+
+// TestS3FSOpen_RejectsAPathOutsideTheCorpus: §7.8 applies to open and stat, not
+// only to list. A rel_path arriving from the store, an MCP argument or a config
+// file has not been through discovery, and keyForRel would strip a leading
+// slash and address a different object than the caller named.
+func TestS3FSOpen_RejectsAPathOutsideTheCorpus(t *testing.T) {
+	fsys, _ := newFakeS3FS(t, "corpus/", map[string][]byte{"corpus/keep.txt": []byte("hello")}, "")
+
+	for _, rel := range []string{"../outside.mp4", "/absolute.mp4", "a/../../outside.txt"} {
+		if _, err := fsys.Open(context.Background(), rel); err == nil {
+			t.Fatalf("Open(%q) succeeded; it must be refused (#735)", rel)
+		}
+	}
+	// The legitimate path still opens.
+	rc, err := fsys.Open(context.Background(), "keep.txt")
+	if err != nil {
+		t.Fatalf("Open(keep.txt): %v", err)
+	}
+	_ = rc.Close()
+}

--- a/tests/security/s3_relpath_traversal_735_test.go
+++ b/tests/security/s3_relpath_traversal_735_test.go
@@ -61,27 +61,44 @@ func TestTraversalIsRejectedRatherThanResolved(t *testing.T) {
 	}
 }
 
-func TestOrdinaryKeysStillWork(t *testing.T) {
-	cases := map[string]string{
-		"notes/a.md":             "notes/a.md",
-		"a.md":                   "a.md",
-		"deep/nested/path/x.txt": "deep/nested/path/x.txt",
-		// Redundant separators collapse; they address the same object and
-		// keyForRel would not preserve them anyway.
-		"a//b.txt":  "a/b.txt",
-		"a/./b.txt": "a/b.txt",
-		// Dots and spaces inside a name are ordinary S3 key bytes.
-		"a..b/c.txt":      "a..b/c.txt",
-		"weird name .txt": "weird name .txt",
-		"...leading.txt":  "...leading.txt",
-	}
-	for in, want := range cases {
-		got, err := relpath.Normalize(in)
+func TestOrdinaryKeysAreReturnedVerbatim(t *testing.T) {
+	// An S3 key is an opaque byte string, so a valid one must come back
+	// EXACTLY as it went in. Anything else records a rel_path that resolves to
+	// a different object than the bucket listed.
+	for _, key := range []string{
+		"notes/a.md",
+		"a.md",
+		"deep/nested/path/x.txt",
+		"a..b/c.txt",         // dots inside a name are ordinary bytes
+		"...leading.txt",     //
+		"weird name .txt",    // interior spaces
+		" leading-space.txt", // and leading ones: keyForRel does not trim
+		"trailing-space.txt ",
+	} {
+		got, err := relpath.Normalize(key)
 		if err != nil {
-			t.Fatalf("Normalize(%q) rejected a legitimate key: %v", in, err)
+			t.Fatalf("Normalize(%q) rejected a legitimate key: %v", key, err)
 		}
-		if got != want {
-			t.Fatalf("Normalize(%q) = %q, want %q", in, got, want)
+		if got != key {
+			t.Fatalf("Normalize(%q) = %q; a valid key must be returned unchanged", key, got)
+		}
+	}
+}
+
+// TestKeysThatWouldChangeUnderCleaningAreRejected is the other half of that.
+// `a//b.txt` and `a/b.txt` are two different S3 objects, so returning the
+// cleaned form for the first would have discovery record a rel_path that Open
+// then resolves to the second, fetching an object the corpus never saw. The
+// safe answer is to refuse the key, not to rewrite it.
+func TestKeysThatWouldChangeUnderCleaningAreRejected(t *testing.T) {
+	for _, key := range []string{
+		"a//b.txt",  // doubled separator
+		"a/./b.txt", // a `.` segment
+		"a/b.txt/",  // trailing separator on a file key
+		"./a.txt",   // leading `.` segment
+	} {
+		if got, err := relpath.Normalize(key); err == nil {
+			t.Fatalf("Normalize(%q) = %q; rewriting it addresses a different object", key, got)
 		}
 	}
 }

--- a/tests/security/s3_relpath_traversal_735_test.go
+++ b/tests/security/s3_relpath_traversal_735_test.go
@@ -1,0 +1,127 @@
+package tests
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/relpath"
+)
+
+// #735: S3FS.Walk accepted object keys whose prefix-relative name was absolute
+// or contained traversal segments, because relForKey stripped the configured
+// prefix as a raw string and nothing downstream re-checked it. Under prefix
+// "corpus/" the bucket key "corpus/../outside.mp4" became rel_path
+// "../outside.mp4", and that value reaches code that joins it against the LOCAL
+// root: video recognition builds RootDir + rel_path, and TTML/SMIL export
+// probes the same way. SPEC §7.8 requires root/prefix isolation on every
+// backend, rejected as PATH_OUTSIDE_ROOT.
+//
+// The pre-existing S3 walk test covered prefix mapping only, with no
+// adversarial keys, which is why this shipped.
+
+func TestUnsafeRelPathsAreRejected(t *testing.T) {
+	// The exact strings from the issue, plus the neighbours they suggest.
+	cases := []struct {
+		name string
+		rel  string
+	}{
+		{"parent traversal", "../outside.mp4"},
+		{"traversal after a real segment", "a/../../outside.txt"},
+		{"absolute, as a doubled prefix separator produces", "/absolute.mp4"},
+		{"bare parent", ".."},
+		{"bare current", "."},
+		{"trailing traversal", "a/b/.."},
+		{"interior traversal that cleans to a safe path", "a/../b"},
+		{"empty", ""},
+		{"whitespace only", "   "},
+		{"windows separator", `..\outside.txt`},
+		{"windows separator in a plain name", `a\b.txt`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got, err := relpath.Normalize(tc.rel); err == nil {
+				t.Fatalf("accepted %q as rel_path %q; SPEC §7.8 requires rejection", tc.rel, got)
+			}
+			if relpath.Valid(tc.rel) {
+				t.Fatalf("Valid(%q) = true", tc.rel)
+			}
+		})
+	}
+}
+
+// TestTraversalIsRejectedRatherThanResolved pins a decision the obvious fix
+// gets wrong. path.Clean turns "a/../b" into "b", which IS a safe path, so a
+// validator that only checks the CLEANED form accepts the key and reports it
+// under a name that is not its key. Identity is meant to be the same rel_path
+// set on every backend (§7.8), so the key is refused instead.
+func TestTraversalIsRejectedRatherThanResolved(t *testing.T) {
+	if _, err := relpath.Normalize("a/../b"); !errors.Is(err, relpath.ErrOutsideRoot) {
+		t.Fatalf("a/../b: err = %v, want ErrOutsideRoot (not a silent rewrite to \"b\")", err)
+	}
+}
+
+func TestOrdinaryKeysStillWork(t *testing.T) {
+	cases := map[string]string{
+		"notes/a.md":             "notes/a.md",
+		"a.md":                   "a.md",
+		"deep/nested/path/x.txt": "deep/nested/path/x.txt",
+		// Redundant separators collapse; they address the same object and
+		// keyForRel would not preserve them anyway.
+		"a//b.txt":  "a/b.txt",
+		"a/./b.txt": "a/b.txt",
+		// Dots and spaces inside a name are ordinary S3 key bytes.
+		"a..b/c.txt":      "a..b/c.txt",
+		"weird name .txt": "weird name .txt",
+		"...leading.txt":  "...leading.txt",
+	}
+	for in, want := range cases {
+		got, err := relpath.Normalize(in)
+		if err != nil {
+			t.Fatalf("Normalize(%q) rejected a legitimate key: %v", in, err)
+		}
+		if got != want {
+			t.Fatalf("Normalize(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestALeadingSlashIsOutsideRootNotMerelyOdd: keyForRel strips a leading slash,
+// so accepting "/absolute.mp4" would have Open address the object
+// "prefix/absolute.mp4" while the corpus recorded "/absolute.mp4". The value
+// does not round-trip, which is why it is rejected rather than trimmed.
+func TestALeadingSlashIsOutsideRootNotMerelyOdd(t *testing.T) {
+	if _, err := relpath.Normalize("/absolute.mp4"); !errors.Is(err, relpath.ErrOutsideRoot) {
+		t.Fatalf("/absolute.mp4: err = %v, want ErrOutsideRoot", err)
+	}
+}
+
+// TestBackslashIsRejectedRatherThanCleaned: a backslash is a legal byte in an
+// S3 key and a path separator on Windows. Cleaning it with filepath.Clean would
+// rewrite the key and address a DIFFERENT object; leaving it would let
+// `..\outside` escape the root on Windows exactly as `../outside` does. So it
+// is refused, and the reason is that it cannot round-trip either way.
+func TestBackslashIsRejectedRatherThanCleaned(t *testing.T) {
+	for _, rel := range []string{`a\b.txt`, `..\outside.txt`, `a/b\c.txt`} {
+		if _, err := relpath.Normalize(rel); err == nil {
+			t.Fatalf("accepted %q, which cannot round-trip between an S3 key and a local path", rel)
+		}
+	}
+}
+
+// TestRejectionReasonsAreDistinguishable: an operator seeing a rejected key
+// needs to know whether the bucket is shaped oddly (not a relative path at all)
+// or is trying to escape the corpus (PATH_OUTSIDE_ROOT, §17).
+func TestRejectionReasonsAreDistinguishable(t *testing.T) {
+	if _, err := relpath.Normalize(""); !errors.Is(err, relpath.ErrNotRelative) {
+		t.Fatalf("empty: err = %v, want ErrNotRelative", err)
+	}
+	if _, err := relpath.Normalize("../x"); !errors.Is(err, relpath.ErrOutsideRoot) {
+		t.Fatalf("../x: err = %v, want ErrOutsideRoot", err)
+	}
+	// The message an operator reads should name the boundary that was crossed.
+	_, err := relpath.Normalize("../x")
+	if !strings.Contains(err.Error(), "outside") {
+		t.Fatalf("ErrOutsideRoot message %q does not mention the root boundary", err)
+	}
+}


### PR DESCRIPTION
Closes #735.

`relForKey` stripped the configured prefix as a raw string and nothing re-checked the result:

```go
if !strings.HasPrefix(key, s.prefix) { return "", false }
return strings.TrimPrefix(key, s.prefix), true
```

So under prefix `corpus/`, the bucket key `corpus/../outside.mp4` became `rel_path="../outside.mp4"`.

A bucket is **untrusted input**, and that value flows into code that joins it against the **local** root — video recognition builds `RootDir + rel_path`, and TTML/SMIL export probes `filepath.Join(RootDir, opts.relPath)`. A leading-slash rel path does not even round-trip, since `keyForRel` strips the slash and addresses a different object than the one recorded.

SPEC §7.8 already requires root/prefix isolation on every backend, rejected as `PATH_OUTSIDE_ROOT`. The local walker gets it from the filesystem, which cannot hand back a path above the directory it was asked to walk. S3 had no equivalent floor. **This is conformance to the existing spec, not a change to it**, so no spec PR.

## The fix

`internal/relpath` is the one rule, enforced at `relForKey` (the single point both discovery callers pass through) and at `Open`, `Localize` and `MediaURL` — §7.8 covers open and stat as well as list, and a rel_path arriving from the store or an MCP argument has not been through discovery.

## Three decisions the obvious implementation gets wrong

- **Clean with `path`, not `filepath`.** On Windows `filepath.Clean` treats `\` as a separator, so it would rewrite an S3 key that legitimately contains a backslash and address a **different object** than the bucket listed.
- **A backslash is rejected, not cleaned.** It is a legal S3 key byte *and* a separator on Windows, where `..\outside` escapes exactly as `../outside` does. It cannot round-trip safely in either direction.
- **`a/../b` is refused, not resolved.** `path.Clean` turns it into `b`, which *is* safe — but reporting a key under a name that is not its key breaks the §7.8 guarantee that the rel_path set is identical on every backend. A validator that only checks the *cleaned* form accepts this.

## Rejections are observable

`Options.OnUnsafeKey` mirrors the existing `OnOversize` channel, and the scan loop logs each refused key. An operator whose bucket carries such keys needs to see it — a silent skip looks identical to an empty prefix. The callback is optional; without it the listing is still safe.

## Tests

The existing walk test covered prefix mapping with **no adversarial keys**, which is why this shipped (the local side already had `TestLocalFSContainment_RejectsTraversal`).

New coverage: the three keys from the issue, bare `..`, a traversal that cleans to a safe path, both rejection reasons being distinguishable, ordinary keys and redundant separators still working, `Walk` without a callback, and `Open` refusing what discovery refuses.

`make check` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional notifications when unsafe object keys are rejected, including the key and rejection reason.
  * Added path validation that distinguishes invalid paths from paths attempting to escape the configured corpus location.

* **Bug Fixes**
  * Improved S3 path handling to safely reject traversal, absolute paths, invalid separators, and prefix-escaping keys.
  * Preserved valid path normalization and directory placeholders while preventing unsafe files from being opened or discovered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->