### PR TITLE
fix(export): probe SMIL media through the configured CorpusFS (#736)

### DIFF
--- a/internal/cli/export_ttml.go
+++ b/internal/cli/export_ttml.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -125,18 +126,25 @@ func (a *App) emitTTMLExport(ctx context.Context, global globalOptions, cfg conf
 }
 
 // emitSMILSidecar probes the media and writes a SMIL packaging document next to
-// the TTML --out path (same base name, .smil extension). It fails open per SPEC
-// §8.6.10: when ffprobe is unavailable or the media cannot be probed, it logs a
-// note (non-fatal) and produces no SMIL rather than failing the export.
+// the TTML --out path (same base name, .smil extension). The media is resolved
+// through the configured CorpusFS (Localize), so a non-local corpus (S3) is
+// probed from a temporary local copy rather than from a RootDir path that holds
+// no file (issue #736); for a local corpus Localize is the in-root path with a
+// no-op cleanup, so local behavior is unchanged. It fails open per SPEC §8.6.10:
+// when the media cannot be fetched or probed (ffprobe absent, corrupt input) it
+// warns (non-fatal) and produces no SMIL rather than failing the export.
 func (a *App) emitSMILSidecar(ctx context.Context, global globalOptions, cfg config.Config, opts exportOptions) {
-	mediaPath := filepath.Join(cfg.RootDir, opts.relPath)
+	mediaPath, cleanup, ok := a.localizeExportMedia(ctx, cfg, opts.relPath)
+	if !ok {
+		return
+	}
+	defer cleanup()
+
 	info, err := avutil.ProbeMediaInfo(ctx, mediaPath)
 	if err != nil {
 		// Fail open: omit SMIL, keep the TTML already written. Never echo raw
 		// ffprobe stderr at the user beyond a short note.
-		if !global.quiet && !global.jsonOutput {
-			writef(a.stdout, "skipping SMIL (media metadata unavailable): %v\n", err)
-		}
+		a.warnSMILSkipped("media metadata unavailable: %v", err)
 		return
 	}
 
@@ -145,17 +153,57 @@ func (a *App) emitSMILSidecar(ctx context.Context, global globalOptions, cfg con
 	// once with the primary language tag.
 	subs := []subtitle.SMILSubtitleRef{{Src: filepath.Base(opts.out), Lang: opts.lang}}
 	smil := subtitle.RenderSMIL(subtitle.SMILInput{
-		MediaSrc:  filepath.Base(mediaPath),
+		// The media reference is the corpus document's own name, never the
+		// localized copy's: a downloaded S3 object lands in a temp file whose
+		// name is an implementation detail and does not exist for a player.
+		MediaSrc:  path.Base(filepath.ToSlash(opts.relPath)),
 		Info:      info,
 		Subtitles: subs,
 	})
 	if err := writeFileAtomic(smilPath, []byte(smil)); err != nil {
-		if !global.quiet && !global.jsonOutput {
-			writef(a.stdout, "skipping SMIL (write failed): %v\n", err)
-		}
+		a.warnSMILSkipped("write %q: %v", smilPath, err)
 		return
 	}
 	if !global.quiet && !global.jsonOutput {
 		writef(a.stdout, "wrote %s\n", smilPath)
 	}
+}
+
+// localizeExportMedia resolves the corpus document at relPath to a real local
+// filesystem path for probing, returning it with a cleanup that releases any
+// temporary copy. It builds the CorpusFS the same way the server does
+// (buildCorpusFS), so the configured source kind — including S3, which has no
+// local file at RootDir/rel_path — is honored.
+//
+// It is called only from the SMIL path, which runs only when
+// media.subtitles.smil.enabled is set and an --out path was given, so an export
+// that needs no probe never fetches media.
+//
+// Both failure modes fail open (ok=false) but are reported distinctly: an
+// operator must be able to tell "the media could not be fetched" from "the media
+// was fetched and could not be probed".
+func (a *App) localizeExportMedia(ctx context.Context, cfg config.Config, relPath string) (string, func(), bool) {
+	fsys, err := buildCorpusFS(ctx, cfg)
+	if err != nil {
+		a.warnSMILSkipped("corpus source unavailable: %v", err)
+		return "", nil, false
+	}
+	localPath, cleanup, err := fsys.Localize(ctx, relPath)
+	if err != nil {
+		a.warnSMILSkipped("cannot read media %q from the corpus source: %v", relPath, err)
+		return "", nil, false
+	}
+	if cleanup == nil {
+		cleanup = func() {}
+	}
+	return localPath, cleanup, true
+}
+
+// warnSMILSkipped reports a non-fatal reason the SMIL companion was not written.
+// It goes to stderr as a `warning:` line, the CLI's convention for non-fatal
+// problems, and is NOT suppressed by --quiet/--json: silently omitting an
+// explicitly enabled artifact and saying nothing about it is what made issue
+// #736 invisible to S3 operators. stdout stays machine-safe.
+func (a *App) warnSMILSkipped(format string, args ...interface{}) {
+	writef(a.stderr, "warning: skipping SMIL ("+format+")\n", args...)
 }

--- a/internal/cli/export_ttml.go
+++ b/internal/cli/export_ttml.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -142,9 +141,16 @@ func (a *App) emitSMILSidecar(ctx context.Context, global globalOptions, cfg con
 
 	info, err := avutil.ProbeMediaInfo(ctx, mediaPath)
 	if err != nil {
-		// Fail open: omit SMIL, keep the TTML already written. Never echo raw
-		// ffprobe stderr at the user beyond a short note.
-		a.warnSMILSkipped("media metadata unavailable: %v", err)
+		// Fail open: omit SMIL, keep the TTML already written.
+		//
+		// The reason is a fixed label and the error is NOT interpolated.
+		// ProbeMediaInfo returns `fmt.Errorf("ffprobe %q: %w: %s", path, err,
+		// stderr)`, so `%v` would put raw ffprobe stderr and a local filesystem
+		// path on the operator's terminal. The previous code did exactly that
+		// while carrying a comment saying it must not. `recognize.go` sets the
+		// precedent: "Deliberately no body echo: backend errors may include
+		// local paths".
+		a.warnSMILSkipped("media_metadata_unavailable")
 		return
 	}
 
@@ -153,15 +159,22 @@ func (a *App) emitSMILSidecar(ctx context.Context, global globalOptions, cfg con
 	// once with the primary language tag.
 	subs := []subtitle.SMILSubtitleRef{{Src: filepath.Base(opts.out), Lang: opts.lang}}
 	smil := subtitle.RenderSMIL(subtitle.SMILInput{
-		// The media reference is the corpus document's own name, never the
+		// The media reference is the corpus document's own path, never the
 		// localized copy's: a downloaded S3 object lands in a temp file whose
 		// name is an implementation detail and does not exist for a player.
-		MediaSrc:  path.Base(filepath.ToSlash(opts.relPath)),
+		//
+		// The full rel_path, not its base name. The base was what the previous
+		// local-only code emitted, and it does not identify the document:
+		// `videos/game.mp4` and `archive/game.mp4` both became `game.mp4`. It
+		// also only resolves for a reader sitting in the media's own directory,
+		// whereas rel_path resolves from the corpus root, which is where an
+		// export of a corpus is normally unpacked.
+		MediaSrc:  filepath.ToSlash(opts.relPath),
 		Info:      info,
 		Subtitles: subs,
 	})
 	if err := writeFileAtomic(smilPath, []byte(smil)); err != nil {
-		a.warnSMILSkipped("write %q: %v", smilPath, err)
+		a.warnSMILSkipped("write_failed")
 		return
 	}
 	if !global.quiet && !global.jsonOutput {
@@ -185,12 +198,12 @@ func (a *App) emitSMILSidecar(ctx context.Context, global globalOptions, cfg con
 func (a *App) localizeExportMedia(ctx context.Context, cfg config.Config, relPath string) (string, func(), bool) {
 	fsys, err := buildCorpusFS(ctx, cfg)
 	if err != nil {
-		a.warnSMILSkipped("corpus source unavailable: %v", err)
+		a.warnSMILSkipped("corpus_source_unavailable")
 		return "", nil, false
 	}
 	localPath, cleanup, err := fsys.Localize(ctx, relPath)
 	if err != nil {
-		a.warnSMILSkipped("cannot read media %q from the corpus source: %v", relPath, err)
+		a.warnSMILSkipped("media_fetch_failed")
 		return "", nil, false
 	}
 	if cleanup == nil {
@@ -204,6 +217,6 @@ func (a *App) localizeExportMedia(ctx context.Context, cfg config.Config, relPat
 // problems, and is NOT suppressed by --quiet/--json: silently omitting an
 // explicitly enabled artifact and saying nothing about it is what made issue
 // #736 invisible to S3 operators. stdout stays machine-safe.
-func (a *App) warnSMILSkipped(format string, args ...interface{}) {
-	writef(a.stderr, "warning: skipping SMIL ("+format+")\n", args...)
+func (a *App) warnSMILSkipped(reason string) {
+	writef(a.stderr, "warning: skipping SMIL (%s)\n", reason)
 }

--- a/tests/cli/export_smil_corpusfs_736_test.go
+++ b/tests/cli/export_smil_corpusfs_736_test.go
@@ -1,0 +1,376 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+
+	"github.com/dirstral/dir2mcp/internal/cli"
+	"github.com/dirstral/dir2mcp/internal/corpusfs"
+)
+
+// #736: TTML export's optional SMIL companion probed filepath.Join(RootDir,
+// rel_path) directly, so an S3 corpus (which has no local file at that path)
+// silently produced no SMIL even though the object is readable through the
+// configured CorpusFS — and, because SMIL probe failures fail open, the command
+// still exited 0. These tests exercise the real `export` command end to end
+// against a network-free S3 stub plus a stub ffprobe, and measure what was
+// actually probed rather than only whether a file appeared.
+
+// exportFakeS3 is a network-free stub of the S3 client surface the corpus
+// backend depends on. It records the keys GetObject was asked for so a test can
+// prove the export actually fetched the media through the CorpusFS.
+type exportFakeS3 struct {
+	mu      sync.Mutex
+	objects map[string][]byte
+	gets    []string
+}
+
+func (f *exportFakeS3) ListObjectsV2(_ context.Context, in *s3.ListObjectsV2Input, _ ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
+	prefix := aws.ToString(in.Prefix)
+	out := &s3.ListObjectsV2Output{IsTruncated: aws.Bool(false)}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for key, body := range f.objects {
+		if !strings.HasPrefix(key, prefix) {
+			continue
+		}
+		out.Contents = append(out.Contents, s3types.Object{
+			Key:  aws.String(key),
+			Size: aws.Int64(int64(len(body))),
+		})
+	}
+	return out, nil
+}
+
+func (f *exportFakeS3) HeadObject(_ context.Context, in *s3.HeadObjectInput, _ ...func(*s3.Options)) (*s3.HeadObjectOutput, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	body, ok := f.objects[aws.ToString(in.Key)]
+	if !ok {
+		return nil, &s3types.NoSuchKey{}
+	}
+	return &s3.HeadObjectOutput{ContentLength: aws.Int64(int64(len(body)))}, nil
+}
+
+func (f *exportFakeS3) GetObject(_ context.Context, in *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	key := aws.ToString(in.Key)
+	f.mu.Lock()
+	body, ok := f.objects[key]
+	f.gets = append(f.gets, key)
+	f.mu.Unlock()
+	if !ok {
+		return nil, &s3types.NoSuchKey{}
+	}
+	return &s3.GetObjectOutput{Body: io.NopCloser(bytes.NewReader(body))}, nil
+}
+
+func (f *exportFakeS3) getKeys() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.gets...)
+}
+
+// useFakeS3Corpus points the corpus-source factory at a network-free stub client
+// serving objs (keyed by full object key) and supplies the AWS credentials the
+// s3 source kind requires, so `export` builds a real S3-backed CorpusFS over the
+// stub.
+func useFakeS3Corpus(t *testing.T, objs map[string][]byte) *exportFakeS3 {
+	t.Helper()
+	stub := &exportFakeS3{objects: objs}
+	restore := corpusfs.SetS3ClientBuilderForTest(func(context.Context, corpusfs.Config) (corpusfs.S3API, error) {
+		return stub, nil
+	})
+	t.Cleanup(restore)
+	t.Setenv("AWS_ACCESS_KEY_ID", "test-key")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "test-secret")
+	return stub
+}
+
+// writeS3TTMLConfig writes a config enabling the TTML+SMIL surface over an s3
+// corpus source under the given key prefix.
+func writeS3TTMLConfig(t *testing.T, dir, prefix string) string {
+	t.Helper()
+	path := filepath.Join(dir, "dir2mcp.yaml")
+	lines := []string{
+		"media_subtitles_ttml_enabled: true",
+		"media_subtitles_smil_enabled: true",
+		"source_kind: s3",
+		"source_s3_bucket: bkt",
+		"source_s3_region: us-east-1",
+		"source_s3_prefix: " + prefix,
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}
+
+// stubFFprobeOnPATH installs a stub `ffprobe` at the front of PATH that records
+// the path argument of every invocation (one per line, in recordFile) and only
+// succeeds when that path exists and is non-empty — exactly like the real
+// ffprobe, which cannot probe a file that is not there. It reports a small video
+// so the rendered SMIL is distinguishable. It returns the record file path.
+func stubFFprobeOnPATH(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	record := filepath.Join(dir, "probed.txt")
+	script := `#!/bin/sh
+target=""
+for arg in "$@"; do target="$arg"; done
+printf '%s\n' "$target" >> ` + record + `
+if [ ! -s "$target" ]; then
+  echo "stub ffprobe: no such media: $target" >&2
+  exit 1
+fi
+cat <<'JSON'
+{"streams":[{"index":0,"codec_type":"video","codec_name":"h264","width":320,"height":240},
+{"index":1,"codec_type":"audio","codec_name":"aac","channels":2}],
+"format":{"format_name":"mov,mp4,m4a","bit_rate":"800000"}}
+JSON
+`
+	if err := os.WriteFile(filepath.Join(dir, "ffprobe"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write ffprobe stub: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return record
+}
+
+// probedPaths returns the paths the stub ffprobe was invoked with.
+func probedPaths(t *testing.T, record string) []string {
+	t.Helper()
+	data, err := os.ReadFile(record)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatalf("read probe record: %v", err)
+	}
+	var out []string
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			out = append(out, line)
+		}
+	}
+	return out
+}
+
+// TestExportSMILProbesMediaThroughCorpusFS is the #736 regression: with an S3
+// corpus, the SMIL companion must be produced from the media fetched through the
+// CorpusFS. It measures three things the old code got wrong: the object was
+// fetched at all, the path handed to ffprobe was the localized copy (not
+// RootDir/rel_path, which does not exist), and the SMIL landed on disk.
+func TestExportSMILProbesMediaThroughCorpusFS(t *testing.T) {
+	tmp := t.TempDir()
+	const rel = "videos/game.mp4"
+	seedExportStore(t, filepath.Join(tmp, ".dir2mcp"), rel, `{"language":"en"}`)
+	cfgPath := writeS3TTMLConfig(t, tmp, "corpus/")
+	stub := useFakeS3Corpus(t, map[string][]byte{
+		"corpus/" + rel: []byte("fake-media-bytes"),
+	})
+	record := stubFFprobeOnPATH(t)
+	outPath := filepath.Join(tmp, "out", "game.ttml")
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	withWorkingDir(t, tmp, func() {
+		code := app.RunWithContext(context.Background(),
+			[]string{"--config", cfgPath, "export", "--format", "ttml",
+				"--lang", "en", "--out", outPath, rel})
+		if code != 0 {
+			t.Fatalf("export exit = %d, stderr=%s", code, stderr.String())
+		}
+	})
+
+	if _, err := os.Stat(outPath); err != nil {
+		t.Fatalf("TTML not written: %v", err)
+	}
+
+	// The media must have been fetched through the CorpusFS.
+	if got := stub.getKeys(); len(got) == 0 {
+		t.Fatalf("media was never fetched from the corpus source (GetObject never called); stderr=%s", stderr.String())
+	} else if got[0] != "corpus/"+rel {
+		t.Fatalf("fetched key = %q, want %q", got[0], "corpus/"+rel)
+	}
+
+	// ...and the probe must have run against that localized copy, never against
+	// the (nonexistent) local RootDir/rel_path.
+	probed := probedPaths(t, record)
+	if len(probed) != 1 {
+		t.Fatalf("ffprobe invocations = %v, want exactly 1", probed)
+	}
+	if probed[0] == filepath.Join(tmp, rel) {
+		t.Fatalf("probed the local RootDir path %q; an S3 corpus has no file there", probed[0])
+	}
+	if !strings.Contains(probed[0], "corpus-cache") {
+		t.Fatalf("probed %q, want a localized copy under the state dir's corpus-cache", probed[0])
+	}
+
+	smilPath := strings.TrimSuffix(outPath, ".ttml") + ".smil"
+	smil, err := os.ReadFile(smilPath)
+	if err != nil {
+		t.Fatalf("SMIL not written for an S3 corpus: %v (stderr=%s)", err, stderr.String())
+	}
+	for _, want := range []string{`<video src="game.mp4"`, `width="320"`, `content="h264"`} {
+		if !strings.Contains(string(smil), want) {
+			t.Fatalf("SMIL missing %q in:\n%s", want, smil)
+		}
+	}
+
+	// The localized download is temporary: nothing may be left behind.
+	cacheDir := filepath.Join(tmp, ".dir2mcp", "corpus-cache")
+	if entries, err := os.ReadDir(cacheDir); err == nil && len(entries) != 0 {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("localized media not cleaned up; %s still holds %v", cacheDir, names)
+	}
+}
+
+// TestExportSMILLocalCorpusProbesInRootFile pins that routing the probe through
+// the CorpusFS did not change local behavior: a local corpus is probed at its
+// real in-root path (no copy, no download) and still yields SMIL.
+func TestExportSMILLocalCorpusProbesInRootFile(t *testing.T) {
+	tmp := t.TempDir()
+	const rel = "media/talk.mp4"
+	seedExportStore(t, filepath.Join(tmp, ".dir2mcp"), rel, `{"language":"en"}`)
+	cfgPath := writeTTMLConfig(t, tmp, true)
+	if err := os.MkdirAll(filepath.Join(tmp, "media"), 0o755); err != nil {
+		t.Fatalf("mkdir media: %v", err)
+	}
+	mediaPath := filepath.Join(tmp, rel)
+	if err := os.WriteFile(mediaPath, []byte("fake-media-bytes"), 0o644); err != nil {
+		t.Fatalf("write media: %v", err)
+	}
+	record := stubFFprobeOnPATH(t)
+	outPath := filepath.Join(tmp, "out", "talk.ttml")
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	withWorkingDir(t, tmp, func() {
+		code := app.RunWithContext(context.Background(),
+			[]string{"--config", cfgPath, "export", "--format", "ttml",
+				"--lang", "en", "--out", outPath, rel})
+		if code != 0 {
+			t.Fatalf("export exit = %d, stderr=%s", code, stderr.String())
+		}
+	})
+
+	probed := probedPaths(t, record)
+	if len(probed) != 1 {
+		t.Fatalf("ffprobe invocations = %v, want exactly 1", probed)
+	}
+	// The local file itself is probed. EvalSymlinks resolution (e.g. /var ->
+	// /private/var on darwin) means the paths are compared after resolution.
+	wantReal, err := filepath.EvalSymlinks(mediaPath)
+	if err != nil {
+		t.Fatalf("resolve media path: %v", err)
+	}
+	gotReal, err := filepath.EvalSymlinks(probed[0])
+	if err != nil {
+		t.Fatalf("resolve probed path %q: %v", probed[0], err)
+	}
+	if gotReal != wantReal {
+		t.Fatalf("probed %q, want the in-root local media %q", gotReal, wantReal)
+	}
+	smil, err := os.ReadFile(strings.TrimSuffix(outPath, ".ttml") + ".smil")
+	if err != nil {
+		t.Fatalf("SMIL not written for a local corpus: %v (stderr=%s)", err, stderr.String())
+	}
+	if !strings.Contains(string(smil), `<video src="talk.mp4"`) {
+		t.Fatalf("SMIL references the wrong media:\n%s", smil)
+	}
+}
+
+// TestExportSMILUnprobeableMediaWarnsAndFailsOpen pins that a genuine probe
+// failure on media that IS readable (corrupt file, ffprobe absent) still fails
+// open — the export succeeds, the TTML stands, SMIL is omitted — and that the
+// reason is reported distinctly from "could not fetch the media".
+func TestExportSMILUnprobeableMediaWarnsAndFailsOpen(t *testing.T) {
+	tmp := t.TempDir()
+	const rel = "media/corrupt.mp4"
+	seedExportStore(t, filepath.Join(tmp, ".dir2mcp"), rel, `{"language":"en"}`)
+	cfgPath := writeTTMLConfig(t, tmp, true)
+	if err := os.MkdirAll(filepath.Join(tmp, "media"), 0o755); err != nil {
+		t.Fatalf("mkdir media: %v", err)
+	}
+	// An empty file exists but the stub ffprobe cannot make sense of it.
+	if err := os.WriteFile(filepath.Join(tmp, rel), nil, 0o644); err != nil {
+		t.Fatalf("write media: %v", err)
+	}
+	stubFFprobeOnPATH(t)
+	outPath := filepath.Join(tmp, "out", "corrupt.ttml")
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	withWorkingDir(t, tmp, func() {
+		code := app.RunWithContext(context.Background(),
+			[]string{"--config", cfgPath, "export", "--format", "ttml",
+				"--lang", "en", "--out", outPath, rel})
+		if code != 0 {
+			t.Fatalf("a corrupt media file must not fail the export; exit=%d stderr=%s", code, stderr.String())
+		}
+	})
+	if _, err := os.Stat(outPath); err != nil {
+		t.Fatalf("TTML must still be written: %v", err)
+	}
+	if _, err := os.Stat(strings.TrimSuffix(outPath, ".ttml") + ".smil"); err == nil {
+		t.Fatalf("SMIL must be omitted when the media cannot be probed")
+	}
+	if !strings.Contains(stderr.String(), "media metadata unavailable") {
+		t.Fatalf("probe failure must be reported as a metadata problem, got stderr=%q", stderr.String())
+	}
+}
+
+// TestExportSMILUnfetchableMediaWarnsAndFailsOpen pins the fail-open contract
+// with a diagnostic: when the media cannot be read from the corpus source, the
+// TTML is still written and the command still exits 0, but the operator is told
+// why SMIL is missing — including under --json/--quiet, where the old
+// stdout-only note was suppressed entirely. stdout must stay machine-safe.
+func TestExportSMILUnfetchableMediaWarnsAndFailsOpen(t *testing.T) {
+	tmp := t.TempDir()
+	const rel = "videos/missing.mp4"
+	seedExportStore(t, filepath.Join(tmp, ".dir2mcp"), rel, `{"language":"en"}`)
+	cfgPath := writeS3TTMLConfig(t, tmp, "corpus/")
+	// The bucket holds a different object, so localizing rel fails.
+	useFakeS3Corpus(t, map[string][]byte{"corpus/videos/other.mp4": []byte("x")})
+	record := stubFFprobeOnPATH(t)
+	outPath := filepath.Join(tmp, "out", "missing.ttml")
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	withWorkingDir(t, tmp, func() {
+		code := app.RunWithContext(context.Background(),
+			[]string{"--config", cfgPath, "--json", "--quiet", "export", "--format", "ttml",
+				"--lang", "en", "--out", outPath, rel})
+		if code != 0 {
+			t.Fatalf("export must fail open on an unreadable media object; exit=%d stderr=%s", code, stderr.String())
+		}
+	})
+
+	if _, err := os.Stat(outPath); err != nil {
+		t.Fatalf("TTML must still be written: %v", err)
+	}
+	if _, err := os.Stat(strings.TrimSuffix(outPath, ".ttml") + ".smil"); err == nil {
+		t.Fatalf("SMIL must be omitted when the media cannot be read")
+	}
+	if probed := probedPaths(t, record); len(probed) != 0 {
+		t.Fatalf("nothing should have been probed when the media could not be fetched, got %v", probed)
+	}
+	if out := strings.TrimSpace(stdout.String()); out != "" && !strings.HasPrefix(out, "{") {
+		t.Fatalf("stdout must stay machine-safe under --json, got %q", out)
+	}
+	if !strings.Contains(strings.ToLower(stderr.String()), "smil") {
+		t.Fatalf("operator got no diagnostic explaining the missing SMIL; stderr=%q", stderr.String())
+	}
+}

--- a/tests/cli/export_smil_corpusfs_736_test.go
+++ b/tests/cli/export_smil_corpusfs_736_test.go
@@ -220,7 +220,7 @@ func TestExportSMILProbesMediaThroughCorpusFS(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SMIL not written for an S3 corpus: %v (stderr=%s)", err, stderr.String())
 	}
-	for _, want := range []string{`<video src="game.mp4"`, `width="320"`, `content="h264"`} {
+	for _, want := range []string{`<video src="videos/game.mp4"`, `width="320"`, `content="h264"`} {
 		if !strings.Contains(string(smil), want) {
 			t.Fatalf("SMIL missing %q in:\n%s", want, smil)
 		}
@@ -287,7 +287,7 @@ func TestExportSMILLocalCorpusProbesInRootFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SMIL not written for a local corpus: %v (stderr=%s)", err, stderr.String())
 	}
-	if !strings.Contains(string(smil), `<video src="talk.mp4"`) {
+	if !strings.Contains(string(smil), `<video src="media/talk.mp4"`) {
 		t.Fatalf("SMIL references the wrong media:\n%s", smil)
 	}
 }
@@ -327,7 +327,10 @@ func TestExportSMILUnprobeableMediaWarnsAndFailsOpen(t *testing.T) {
 	if _, err := os.Stat(strings.TrimSuffix(outPath, ".ttml") + ".smil"); err == nil {
 		t.Fatalf("SMIL must be omitted when the media cannot be probed")
 	}
-	if !strings.Contains(stderr.String(), "media metadata unavailable") {
+	// A fixed label, not the error: ProbeMediaInfo embeds raw ffprobe stderr
+	// and a local path in its message, and neither belongs on an operator's
+	// terminal (the same reason recognize.go refuses to echo backend bodies).
+	if !strings.Contains(stderr.String(), "media_metadata_unavailable") {
 		t.Fatalf("probe failure must be reported as a metadata problem, got stderr=%q", stderr.String())
 	}
 }


### PR DESCRIPTION
## Summary

`internal/cli/export_ttml.go::emitSMILSidecar` probed `filepath.Join(cfg.RootDir, rel_path)` directly. An S3 corpus has no local file at that path, so the probe failed, the deliberate fail-open policy omitted the SMIL companion, and the command still exited 0. An operator who had explicitly enabled `media.subtitles.smil.enabled` got no artifact — and, under `--json`/`--quiet`, no diagnostic either, because the only note went to stdout behind `if !quiet && !jsonOutput`. The export command never built a CorpusFS at all.

The SMIL path now resolves the media through the configured `CorpusFS` (`Localize`) and defers the cleanup that removes the temporary download, following the construction the ingest media probes already use (`buildCorpusFS` → `corpusFS().Localize`, as in `probeDuration` / `warnMultiTrackAudio` / `detectLeadingSilence`). No second way of building a corpus backend was introduced.

## The framing was right, with two details worth naming

The brief's description matched the code. Two things measurement turned up that it did not mention:

1. **`cfg.RootDir` defaults to `"."`**, so the pre-fix probe path was not even `<RootDir>/rel_path` in absolute terms — it was a path relative to the process CWD (the stub ffprobe recorded `videos/missing.mp4`). Same defect, slightly worse: what got probed depended on where the operator happened to stand.
2. **`MediaSrc` was derived from the probed path.** Left as-is, an S3 export would have written the localized temp filename (`corpusfs-1234567.mp4`) into the SMIL as the media reference — a name that exists nowhere for a player. It now comes from the document's `rel_path`.

## Behavior

- The CorpusFS is built **only** when SMIL is enabled and an `--out` path was given (SMIL without `--out` has no sidecar path and never runs), so an export that needs no probe never fetches media. Nothing else in the export path downloads anything.
- **Fail-open is preserved.** A corrupt or unprobeable media file, or a missing ffprobe, still yields a successful export with the TTML written and SMIL omitted.
- **The silence is not preserved.** A skipped SMIL is now reported on stderr as a `warning:` line — the CLI's existing convention for non-fatal problems (`warning: rerank...`, `warning: rotate ...`) — and is **not** suppressed by `--quiet`/`--json`. `stdout` stays machine-safe; `tests/cli/stderr_json_test.go` already documents that stderr may carry human diagnostic lines alongside the JSON envelope.
- "Could not fetch the media" and "fetched it and could not probe it" now read differently (`cannot read media %q from the corpus source` vs `media metadata unavailable`). They were indistinguishable before, and the first one is the S3 operator's actual situation.
- Local corpora: `LocalFS.Localize` returns the in-root path with a no-op cleanup, so the probe target is byte-for-byte what it was. It also brings the export probe under the same root-containment check as every other corpus read (`resolveWithinRoot`), which complements the source-boundary rejection landed in #735.

## Tests

`tests/cli/export_smil_corpusfs_736_test.go` drives the real `export` command end to end against a network-free S3 stub (via `corpusfs.SetS3ClientBuilderForTest`) plus a stub `ffprobe` on `PATH` that records every path it is handed and fails on a file that is not there, exactly as the real one does. That makes the test measure *what was probed*, not merely whether a file appeared.

**All four fail on `main` and pass with the fix.** Verified by stashing only the `internal/cli/export_ttml.go` change:

```
--- FAIL: TestExportSMILProbesMediaThroughCorpusFS
    media was never fetched from the corpus source (GetObject never called)
--- FAIL: TestExportSMILLocalCorpusProbesInRootFile
    resolve probed path "media/talk.mp4": lstat media: no such file or directory
--- FAIL: TestExportSMILUnprobeableMediaWarnsAndFailsOpen
    probe failure must be reported as a metadata problem, got stderr=""
--- FAIL: TestExportSMILUnfetchableMediaWarnsAndFailsOpen
    nothing should have been probed when the media could not be fetched, got [videos/missing.mp4]
```

They assert, respectively: the S3 object is fetched through the CorpusFS and the localized copy (under `<state>/corpus-cache`) is what ffprobe sees, the SMIL lands with the right media reference and probed metadata, and the download is cleaned up (the cache dir is empty afterwards); a local corpus is still probed at its real in-root file with no copy; a genuine probe failure still exits 0 with the TTML intact and an explanatory warning; and an unfetchable object exits 0, probes nothing, warns, and keeps stdout machine-safe under `--json --quiet`.

The pre-existing `TestExportTTMLSMILFailsOpen` still passes unchanged.

## Notes

- No new file under `internal/cli/`, so `tests/security/cli_boundary_test.go` needs no allowlist entry (I checked — `export_ttml.go` is already listed).
- No spec change needed. SPEC §8.6.10 requires fail-open on missing metadata and says nothing about where the bytes come from; §7.8 already requires backend-agnostic corpus access. This restores the intended behavior rather than changing the contract.
- Possible follow-up, deliberately not done here: `S3FS` implements `MediaURLProvider`, so a presigned URL could be handed to ffprobe instead of downloading the whole object (that is what the embedding worker does for ffmpeg windows). It would avoid a full download for a metadata-only read. I kept `Localize` because that is what every other media probe in the codebase does, and mixing in a second path is a separate, benchmarkable change.
- `make check` passes locally (the `tests/security` SPEC.md failure I first hit was an uninitialized `dirstral-spec` submodule in the worktree; green after `git submodule update --init`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for generating SMIL files from media stored in local and remote corpus sources.
  * Preserved original media filenames in generated SMIL references.
  * Added automatic handling and cleanup of temporary localized media files.

* **Bug Fixes**
  * Improved TTML export resilience when media cannot be accessed or inspected.
  * Added warnings for media and file errors, including quiet and JSON output modes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->