### PR TITLE
fix(ingest): localize media through the CorpusFS before recognition (#734)

### DIFF
--- a/internal/ingest/recognize.go
+++ b/internal/ingest/recognize.go
@@ -316,7 +316,36 @@ func (s *Service) generateRecognitionRepresentation(ctx context.Context, doc mod
 	if s.repGen == nil || s.recognizer == nil || doc.DocType != "video" {
 		return false, nil
 	}
-	absPath := filepath.Join(s.cfg.RootDir, filepath.FromSlash(doc.RelPath))
+	// Recognition backends read the media from a real filesystem path, so the
+	// media must be resolved through the CorpusFS rather than reconstructed from
+	// RootDir+rel_path (#734): an object-store backend reports no local path
+	// (DiscoveredFile.AbsPath == "") and its Walk ignores RootDir, so a joined
+	// path names a file that does not exist and recognition fails on a corpus
+	// that ingested fine. Localize returns the resolved in-root path with a
+	// no-op cleanup for a local corpus (no copy, unchanged behavior) and a temp
+	// download for an object store. The Recognizer contract is synchronous — the
+	// backend has finished reading the file by the time Recognize returns — so
+	// releasing the copy on return is safe.
+	localPath, cleanup, err := s.corpusFS().Localize(ctx, doc.RelPath)
+	if err != nil {
+		// The backend was never reached, but the outcome for this document is the
+		// same as a backend failure — no recognition, retriable next scan — so it
+		// carries the same sentinel and classifies as RECOGNIZE_FAILED rather than
+		// the generic EXTRACT_FAILED (parallel to the STT path, which tags a failed
+		// audio-track extraction as a transcript provider failure).
+		return false, fmt.Errorf("%w: localize %s: %w", ErrRecognitionProviderFailure, doc.RelPath, err)
+	}
+	defer cleanup()
+
+	// The serve wire contract is an ABSOLUTE media path (design 0004 §5). LocalFS
+	// already returns one; an object store's temp copy lands under StateDir, which
+	// can be configured relative (e.g. "./.dir2mcp"), so absolutize before handing
+	// the path over — a connect-only backend does not share the daemon's CWD.
+	absPath, err := filepath.Abs(localPath)
+	if err != nil {
+		return false, fmt.Errorf("%w: resolve media path for %s: %w", ErrRecognitionProviderFailure, doc.RelPath, err)
+	}
+
 	result, err := s.recognizer.Recognize(ctx, absPath)
 	if err != nil {
 		// Tag with the provider-failure sentinel so a transient recognize-backend

--- a/tests/ingest/recognize_corpusfs_734_test.go
+++ b/tests/ingest/recognize_corpusfs_734_test.go
@@ -1,0 +1,343 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/corpusfs"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// localizingRemoteFS is a stub object-store CorpusFS shaped like S3FS for the
+// properties that matter to issue #734: discovery reports no local path
+// (DiscoveredFile.AbsPath == ""), Walk ignores the RootDir argument, and
+// Localize materializes a temp copy under its own cache dir and returns a
+// cleanup that removes it. It records Localize/cleanup calls so a test can
+// assert the recognizer is fed the localized copy and that the copy is released
+// on both the success and the failure path.
+type localizingRemoteFS struct {
+	bodies   map[string][]byte
+	cacheDir string
+
+	mu            sync.Mutex
+	localizeCalls int
+	cleanupCalls  int
+	localizeErr   error
+	lastLocalPath string
+}
+
+func newLocalizingRemoteFS(t *testing.T) *localizingRemoteFS {
+	t.Helper()
+	return &localizingRemoteFS{bodies: map[string][]byte{}, cacheDir: t.TempDir()}
+}
+
+func (f *localizingRemoteFS) add(relPath, body string) {
+	f.bodies[relPath] = []byte(body)
+}
+
+func (f *localizingRemoteFS) Walk(_ context.Context, _ string, _ corpusfs.Options) ([]corpusfs.DiscoveredFile, error) {
+	out := make([]corpusfs.DiscoveredFile, 0, len(f.bodies))
+	for rel, body := range f.bodies {
+		// AbsPath deliberately empty: an object store has no local path.
+		out = append(out, corpusfs.DiscoveredFile{RelPath: rel, SizeBytes: int64(len(body))})
+	}
+	return out, nil
+}
+
+func (f *localizingRemoteFS) Open(_ context.Context, relPath string) (io.ReadSeekCloser, error) {
+	body, ok := f.bodies[relPath]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	return nopReadSeekCloser{bytes.NewReader(body)}, nil
+}
+
+func (f *localizingRemoteFS) Localize(_ context.Context, relPath string) (string, func(), error) {
+	f.mu.Lock()
+	f.localizeCalls++
+	localizeErr := f.localizeErr
+	f.mu.Unlock()
+	if localizeErr != nil {
+		return "", nil, localizeErr
+	}
+	body, ok := f.bodies[relPath]
+	if !ok {
+		return "", nil, os.ErrNotExist
+	}
+	tmp, err := os.CreateTemp(f.cacheDir, "obj-*"+filepath.Ext(relPath))
+	if err != nil {
+		return "", nil, err
+	}
+	path := tmp.Name()
+	if _, err := tmp.Write(body); err != nil {
+		_ = tmp.Close()
+		return "", nil, err
+	}
+	if err := tmp.Close(); err != nil {
+		return "", nil, err
+	}
+	f.mu.Lock()
+	f.lastLocalPath = path
+	f.mu.Unlock()
+	return path, func() {
+		f.mu.Lock()
+		f.cleanupCalls++
+		f.mu.Unlock()
+		_ = os.Remove(path)
+	}, nil
+}
+
+func (f *localizingRemoteFS) counts() (localize, cleanup int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.localizeCalls, f.cleanupCalls
+}
+
+func (f *localizingRemoteFS) localPath() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.lastLocalPath
+}
+
+// readingRecognizer is a model.Recognizer double that actually opens the path it
+// is handed, which is the whole point of #734: a path the backend cannot read is
+// worthless no matter what it is named.
+type readingRecognizer struct {
+	result  model.RecognizeResult
+	err     error
+	calls   int
+	path    string
+	gotBody []byte
+	readErr error
+}
+
+func (r *readingRecognizer) Recognize(_ context.Context, absPath string) (model.RecognizeResult, error) {
+	r.calls++
+	r.path = absPath
+	r.gotBody, r.readErr = os.ReadFile(absPath) //nolint:gosec // test double reads the path under test
+	if r.err != nil {
+		return model.RecognizeResult{}, r.err
+	}
+	return r.result, nil
+}
+
+// TestRecognize_RemoteCorpusFS_FeedsLocalizedPath pins issue #734: with a
+// non-local CorpusFS (source.kind=s3), recognition must obtain the media through
+// CorpusFS.Localize instead of reconstructing RootDir+rel_path, which names a
+// file that does not exist for an object store. The recognizer must be able to
+// READ the path it receives, and the localized copy must be released afterwards.
+func TestRecognize_RemoteCorpusFS_FeedsLocalizedPath(t *testing.T) {
+	t.Parallel()
+	// RootDir exists but is empty: for an object store it is not where the bytes
+	// live, so any RootDir-joined path is a dangling reference.
+	root := t.TempDir()
+	fsys := newLocalizingRemoteFS(t)
+	fsys.add("games/game7.mp4", "remote-video-bytes")
+
+	st := &fakeIngestStore{}
+	svc := mustNewIngestService(t, config.Config{RootDir: root, StateDir: t.TempDir()}, st)
+	svc.SetCorpusFS(fsys)
+	rec := &readingRecognizer{result: recognizeTestResult()}
+	svc.SetRecognizer(rec)
+
+	doc := model.Document{DocID: 1, RelPath: "games/game7.mp4", DocType: "video"}
+	if err := svc.GenerateRecognitionRepresentation(context.Background(), doc); err != nil {
+		t.Fatalf("GenerateRecognitionRepresentation: %v", err)
+	}
+	if rec.calls != 1 {
+		t.Fatalf("expected exactly one backend call, got %d", rec.calls)
+	}
+	if rec.readErr != nil {
+		t.Fatalf("recognizer could not read the path it was handed (%q): %v", rec.path, rec.readErr)
+	}
+	if got := string(rec.gotBody); got != "remote-video-bytes" {
+		t.Fatalf("recognizer read %q, want the object bytes %q", got, "remote-video-bytes")
+	}
+	if rec.path == filepath.Join(root, "games", "game7.mp4") {
+		t.Fatalf("recognizer received a RootDir-joined path %q; it must receive the CorpusFS-localized copy", rec.path)
+	}
+	if want := fsys.localPath(); rec.path != want {
+		t.Fatalf("recognizer path = %q, want the localized copy %q", rec.path, want)
+	}
+	localize, cleanup := fsys.counts()
+	if localize != 1 || cleanup != 1 {
+		t.Fatalf("Localize called %d time(s), cleanup %d time(s); want exactly 1 each", localize, cleanup)
+	}
+	if _, err := os.Stat(fsys.localPath()); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("localized copy %q survived the call (stat err %v); cleanup must remove it", fsys.localPath(), err)
+	}
+	if len(st.reps) != 1 || st.reps[0].RepType != ingest.RepTypeRecognition {
+		t.Fatalf("expected one recognition representation, got %+v", st.reps)
+	}
+}
+
+// TestRecognize_RemoteCorpusFS_CleanupOnBackendError asserts the localized copy
+// is released on the error path too: a recognize-backend failure must not leak a
+// downloaded temp file per document, and the failure still classifies as a
+// recognition provider failure (RECOGNIZE_FAILED).
+func TestRecognize_RemoteCorpusFS_CleanupOnBackendError(t *testing.T) {
+	t.Parallel()
+	fsys := newLocalizingRemoteFS(t)
+	fsys.add("games/game7.mp4", "remote-video-bytes")
+
+	st := &fakeIngestStore{}
+	svc := mustNewIngestService(t, config.Config{RootDir: t.TempDir(), StateDir: t.TempDir()}, st)
+	svc.SetCorpusFS(fsys)
+	svc.SetRecognizer(&readingRecognizer{err: errors.New("backend down")})
+
+	doc := model.Document{DocID: 1, RelPath: "games/game7.mp4", DocType: "video"}
+	err := svc.GenerateRecognitionRepresentation(context.Background(), doc)
+	if err == nil {
+		t.Fatal("expected the backend error to propagate")
+	}
+	if !errors.Is(err, ingest.ErrRecognitionProviderFailure) {
+		t.Fatalf("backend failure must stay a recognition provider failure, got %v", err)
+	}
+	localize, cleanup := fsys.counts()
+	if localize != 1 || cleanup != 1 {
+		t.Fatalf("Localize called %d time(s), cleanup %d time(s); want exactly 1 each on the error path", localize, cleanup)
+	}
+	if _, statErr := os.Stat(fsys.localPath()); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("localized copy leaked on the error path (stat err %v)", statErr)
+	}
+}
+
+// TestRecognize_LocalizeFailureIsRecognizeFailure asserts a media the CorpusFS
+// cannot materialize (deleted object, download failure) is reported as a
+// recognition failure rather than silently producing nothing, and that the
+// backend is never called with an unusable path.
+func TestRecognize_LocalizeFailureIsRecognizeFailure(t *testing.T) {
+	t.Parallel()
+	fsys := newLocalizingRemoteFS(t)
+	fsys.add("games/game7.mp4", "remote-video-bytes")
+	fsys.localizeErr = errors.New("download failed")
+
+	st := &fakeIngestStore{}
+	svc := mustNewIngestService(t, config.Config{RootDir: t.TempDir(), StateDir: t.TempDir()}, st)
+	svc.SetCorpusFS(fsys)
+	rec := &readingRecognizer{result: recognizeTestResult()}
+	svc.SetRecognizer(rec)
+
+	doc := model.Document{DocID: 1, RelPath: "games/game7.mp4", DocType: "video"}
+	err := svc.GenerateRecognitionRepresentation(context.Background(), doc)
+	if err == nil {
+		t.Fatal("expected a localize failure to be reported")
+	}
+	if !errors.Is(err, ingest.ErrRecognitionProviderFailure) {
+		t.Fatalf("localize failure must classify as RECOGNIZE_FAILED, got %v", err)
+	}
+	if rec.calls != 0 {
+		t.Fatalf("backend must not be called when the media cannot be localized, got %d call(s)", rec.calls)
+	}
+	if len(st.reps) != 0 {
+		t.Fatalf("expected no representation, got %+v", st.reps)
+	}
+}
+
+// relativePathFS is a CorpusFS whose Localize returns a CWD-relative path,
+// which an object-store backend can legitimately produce: the S3 temp copy
+// lands under StateDir, and StateDir may be configured relative (several CLI
+// paths default it to "./.dir2mcp"). The serve wire contract is an absolute
+// media path (design 0004 §5), so recognition must absolutize before the call.
+type relativePathFS struct {
+	relPath string
+}
+
+func (f *relativePathFS) Walk(context.Context, string, corpusfs.Options) ([]corpusfs.DiscoveredFile, error) {
+	return nil, nil
+}
+
+func (f *relativePathFS) Open(context.Context, string) (io.ReadSeekCloser, error) {
+	return nil, os.ErrNotExist
+}
+
+func (f *relativePathFS) Localize(context.Context, string) (string, func(), error) {
+	return f.relPath, func() {}, nil
+}
+
+func TestRecognize_LocalizedPathIsAbsolute(t *testing.T) {
+	t.Parallel()
+	media := filepath.Join(t.TempDir(), "game7.mp4")
+	writeFile(t, media, "fake-video")
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	rel, err := filepath.Rel(cwd, media)
+	if err != nil {
+		t.Fatalf("rel: %v", err)
+	}
+	if filepath.IsAbs(rel) {
+		t.Skipf("cannot express %q relative to the test CWD", media)
+	}
+
+	st := &fakeIngestStore{}
+	svc := mustNewIngestService(t, config.Config{RootDir: t.TempDir(), StateDir: t.TempDir()}, st)
+	svc.SetCorpusFS(&relativePathFS{relPath: rel})
+	rec := &readingRecognizer{result: recognizeTestResult()}
+	svc.SetRecognizer(rec)
+
+	doc := model.Document{DocID: 1, RelPath: "games/game7.mp4", DocType: "video"}
+	if err := svc.GenerateRecognitionRepresentation(context.Background(), doc); err != nil {
+		t.Fatalf("GenerateRecognitionRepresentation: %v", err)
+	}
+	if !filepath.IsAbs(rec.path) {
+		t.Fatalf("backend received a relative path %q; the serve contract is an absolute media path (design 0004 §5)", rec.path)
+	}
+	assertSameFile(t, media, rec.path)
+}
+
+// TestRecognize_LocalCorpusStillGetsInRootPath guards the no-regression half of
+// #734: a local corpus must keep handing the recognizer the real in-root file
+// (LocalFS.Localize returns the resolved path with a no-op cleanup), NOT a copy.
+// The file must still be there after the call, and be the same file as the one
+// in the corpus root.
+func TestRecognize_LocalCorpusStillGetsInRootPath(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	inRoot := filepath.Join(root, "games", "game7.mp4")
+	writeFile(t, inRoot, "fake-video")
+
+	st := &fakeIngestStore{}
+	svc := mustNewIngestService(t, config.Config{RootDir: root, StateDir: t.TempDir()}, st)
+	rec := &readingRecognizer{result: recognizeTestResult()}
+	svc.SetRecognizer(rec)
+
+	doc := model.Document{DocID: 1, RelPath: "games/game7.mp4", DocType: "video"}
+	if err := svc.GenerateRecognitionRepresentation(context.Background(), doc); err != nil {
+		t.Fatalf("GenerateRecognitionRepresentation: %v", err)
+	}
+	if rec.calls != 1 {
+		t.Fatalf("expected exactly one backend call, got %d", rec.calls)
+	}
+	// Still the in-root file itself (not a copy) and still there afterwards: the
+	// local path is only symlink-resolved, so identity is checked with SameFile.
+	assertSameFile(t, inRoot, rec.path)
+}
+
+// assertSameFile fails unless both paths name the same file on disk. It is the
+// symlink-tolerant form of comparing a corpus path to the path handed to a
+// backend: CorpusFS.Localize resolves symlinks (a temp root is symlinked on
+// macOS), so string equality would compare resolution styles, not identity.
+func assertSameFile(t *testing.T, wantPath, gotPath string) {
+	t.Helper()
+	want, err := os.Stat(wantPath)
+	if err != nil {
+		t.Fatalf("stat %q: %v", wantPath, err)
+	}
+	got, err := os.Stat(gotPath)
+	if err != nil {
+		t.Fatalf("stat %q (the path handed to the backend): %v", gotPath, err)
+	}
+	if !os.SameFile(want, got) {
+		t.Fatalf("path %q is not the same file as %q", gotPath, wantPath)
+	}
+}

--- a/tests/ingest/recognize_test.go
+++ b/tests/ingest/recognize_test.go
@@ -71,9 +71,11 @@ func TestRecognize_GeneratesRecognitionRepresentation(t *testing.T) {
 	if rec.calls != 1 {
 		t.Fatalf("expected exactly one backend call, got %d", rec.calls)
 	}
-	if want := filepath.Join(root, "games", "game7.mp4"); rec.lastAbsPath != want {
-		t.Fatalf("backend must receive the absolute media path, got %q want %q", rec.lastAbsPath, want)
-	}
+	// The backend must receive an absolute path to the media itself. For a local
+	// corpus that is the in-root file, but it comes from CorpusFS.Localize (#734),
+	// which resolves symlinks on the way — so identity is asserted with SameFile
+	// rather than string equality (a temp root is symlinked on macOS).
+	assertSameFile(t, filepath.Join(root, "games", "game7.mp4"), rec.lastAbsPath)
 
 	if len(st.reps) != 1 || st.reps[0].RepType != ingest.RepTypeRecognition {
 		t.Fatalf("expected one recognition representation, got %+v", st.reps)


### PR DESCRIPTION
Closes #734.

## What was actually wrong

`generateRecognitionRepresentation` built the media path itself:

```go
absPath := filepath.Join(s.cfg.RootDir, filepath.FromSlash(doc.RelPath))
result, err := s.recognizer.Recognize(ctx, absPath)
```

I verified the framing in the issue rather than trusting it:

- `S3FS.Walk` emits `DiscoveredFile{AbsPath: ""}` (documented on the struct: "for object-store backends (S3FS) it is empty because there is no local path until Localize is called") and never consults the `root` argument. So for `source.kind=s3` there is no `<RootDir>/videos/game.mp4`, and the recognizer was handed a dangling path. Confirmed by a failing test, not by reading: see below.
- Recognition really was the only media path doing this. `grep` for `corpusFS().Localize` finds archive extraction, `probeDuration`, `warnMultiTrackAudio`, `detectLeadingSilence`, `probeTrackInfo`; recognition was the outlier.

**One correction to the issue text:** it says OCR calls `Localize`. It does not. OCR/extractors take bytes (`extractor.Extract(ctx, relPath, content)`), and those bytes come from `corpusFS().Open`. So OCR was never broken and is not the precedent for the cleanup contract; the archive/probe paths are. The conclusion is unchanged: everything else goes through the CorpusFS one way or another, and only recognition bypassed it.

## The fix

`internal/ingest/recognize.go`: resolve the media with `s.corpusFS().Localize(ctx, doc.RelPath)` and `defer cleanup()`, matching the archive and probe paths. Cleanup is deferred immediately after the error check, so it runs on the success path, the backend-error path, and every early return in between; `cleanup` is only ever deferred when `err == nil`, and both `LocalFS` and `S3FS` return a nil cleanup only alongside an error.

Two judgement calls, flagged rather than buried:

1. **A localize failure is tagged `ErrRecognitionProviderFailure`.** The backend was not reached, but the outcome for the document is identical to a backend failure (no recognition, retriable next scan), and today a missing local file already surfaces as `RECOGNIZE_FAILED` via the backend's own error. The precedent is `readTrackTranscript`, which tags a failed *local* audio-track extraction with `ErrTranscriptProviderFailure` so it lands in `TRANSCRIBE_FAILED` instead of the generic `EXTRACT_FAILED`. Without the sentinel this class would silently reclassify to `EXTRACT_FAILED`.
2. **The localized path is absolutized.** Design 0004 §5 specifies `{"path": "<absolute media path>"}`. `LocalFS.Localize` already returns an absolute path, but `S3FS.Localize` materializes under `StateDir/corpus-cache`, and several CLI paths default `StateDir` to a relative `./.dir2mcp` (`internal/cli/ask.go`, `status.go`, `export.go`, ...). A connect-only backend does not share the daemon's CWD. This goes slightly beyond the literal issue, so it has its own test.

## Async re-read: checked, not assumed

The concern was whether the backend re-reads the path asynchronously after the call, which would make `defer cleanup()` too early. It does not, on both sides of the contract:

- `RecognizeServeClient.Recognize` does a blocking `httpClient.Do` and fully decodes the response body into `model.RecognizeResult` before returning; nothing retains the path.
- The reference backend in this repo (`annotator/dirstral_annotator/serve.py`) runs `pipeline.annotations_for(media)` inline inside the `POST /recognize` handler and replies afterwards. The file is fully consumed before the HTTP response is written.

So releasing the localized copy when `Recognize` returns is safe. (The backend does echo `media.name` — now a temp basename — in its response `document` field, but `RecognizeServeClient` only reads `recognizer` and `annotations`, so nothing downstream sees it.)

## Local corpora: measured, no regression

`LocalFS.Localize` returns the resolved in-root path with a `func(){}` cleanup: no copy, no download, no I/O beyond the containment resolution `Open` already performs on every read of the same file. `TestRecognize_LocalCorpusStillGetsInRootPath` asserts with `os.SameFile` that the recognizer is handed the corpus file itself and that the file is still there after the call.

**One visible behavioural difference for local corpora, deliberate:** `LocalFS.Localize` resolves symlinks (`resolveWithinRoot` → `EvalSymlinks`) and rejects paths escaping the root, so the recognizer now receives e.g. `/private/var/...` where it previously received `/var/...` on macOS. That is the same resolution every other media path already applies, and it adds the corpus-containment guard recognition lacked. It broke exactly one existing assertion, `TestRecognize_GeneratesRecognitionRepresentation`'s string comparison against `filepath.Join(root, ...)`; that assertion is now `os.SameFile`, which tests identity instead of resolution style.

## Testing: failed first, then fixed

New suite `tests/ingest/recognize_corpusfs_734_test.go`. Written and run **before** the fix. Against unmodified `recognize.go`:

```
--- FAIL: TestRecognize_RemoteCorpusFS_CleanupOnBackendError
    Localize called 0 time(s), cleanup 0 time(s); want exactly 1 each on the error path
--- FAIL: TestRecognize_LocalizeFailureIsRecognizeFailure
    expected a localize failure to be reported
--- FAIL: TestRecognize_RemoteCorpusFS_FeedsLocalizedPath
    recognizer could not read the path it was handed
    (".../TestRecognize_.../001/games/game7.mp4"): no such file or directory
```

That third failure is the bug itself, reproduced: the recognizer double actually `os.ReadFile`s the path it is given, so the test fails for the real reason (an unopenable path) rather than on a string comparison.

`TestRecognize_LocalizedPathIsAbsolute` was likewise verified to fail without the `filepath.Abs` step (backend received `../../../../../var/folders/...`).

`TestRecognize_LocalCorpusStillGetsInRootPath` passes both before and after, by design: it is the no-regression guard.

Coverage:

| test | asserts |
| --- | --- |
| `TestRecognize_RemoteCorpusFS_FeedsLocalizedPath` | recognizer gets the localized copy (not the RootDir join), can read it, gets the object's bytes; exactly 1 Localize + 1 cleanup; temp file gone afterwards |
| `TestRecognize_RemoteCorpusFS_CleanupOnBackendError` | cleanup still runs and the copy is removed when the backend fails; error still `errors.Is` `ErrRecognitionProviderFailure` |
| `TestRecognize_LocalizeFailureIsRecognizeFailure` | unmaterializable media is reported (not silently empty), classifies as `RECOGNIZE_FAILED`, and the backend is never called |
| `TestRecognize_LocalizedPathIsAbsolute` | a relative `Localize` result is absolutized before the backend call |
| `TestRecognize_LocalCorpusStillGetsInRootPath` | local corpus still gets the in-root file itself (`os.SameFile`), no copy |

The remote double (`localizingRemoteFS`) mirrors S3FS on the properties that matter here: empty `AbsPath`, RootDir-ignoring `Walk`, temp materialization plus a removing cleanup. I did not reuse `tests/corpusfs/s3_test.go`'s fake S3 client: it lives in a different test package, and driving a real `S3FS` through ingest would exercise the AWS stub surface rather than the seam under change (`Service.SetCorpusFS`).

## Deliberately not done

- **No end-to-end S3 ingest test.** The seam that broke is `Service` → `CorpusFS`, and `SetCorpusFS` exercises it directly. Standing up a fake S3 client through a full scan would add a lot of surface without touching the defect.
- **No `MediaURL` fast path for recognition.** `S3FS` can presign a range-seekable URL and the embedding worker prefers it over a whole-object download. The recognize wire contract is a filesystem path, and a recognizer samples frames across the entire video anyway, so `Localize` is the right call; a URL-capable recognizer would be a spec change (design 0004 §5).
- **No spec change.** Design 0004 §5 already says "absolute media path"; nothing here alters the wire contract or the persisted representation, so no `dirstral-spec` PR is needed under the spec-first rule.
- **No change to the other `Localize` call sites.** They were already correct.

## Checks

- `make check` passes locally (full suite: `gofmt`/`vet`/`lint`/`cyclo`/`ineffassign`/`misspell`/tests/build). The touched function stays well under the `gocyclo -over 15` budget (+2 branches).
- `coderabbit review --agent --committed --base main`: 0 findings.
- No new files under `internal/cli/`, so the `tests/security/cli_boundary_test.go` allowlist is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SsfcqnbrNzpUEnSVJ3oow8
