### PR TITLE
fix(diskindex): commit the segment and its identity as one generation (#728)

### DIFF
--- a/internal/index/diskindex/diskindex.go
+++ b/internal/index/diskindex/diskindex.go
@@ -590,11 +590,24 @@ func (d *DiskIndex) Reset(ctx context.Context, identity string) error {
 	if d.path == "" {
 		return nil
 	}
+	// Stage the new identity BEFORE destroying the segment, and publish it
+	// after. Whichever step fails, what is on disk stays a matched pair: a
+	// staging failure leaves the old segment with its old identity, and a
+	// publish failure leaves an empty segment with the old identity, which the
+	// next EnsureIdentity resets again onto an already-empty segment. The
+	// previous order could truncate and then fail, leaving live-looking vectors
+	// claimed by an identity that no longer described them (#728).
+	sidecarPath := identitySidecarPath(d.path)
+	staged, err := stageIdentitySidecar(sidecarPath, identity)
+	if err != nil {
+		return err
+	}
 	if err := truncateSegment(d.path); err != nil {
+		_ = os.Remove(staged)
 		return err
 	}
 	d.appendEnd = int64(headerLen)
-	return writeIdentitySidecar(identitySidecarPath(d.path), identity)
+	return publishIdentitySidecar(staged, sidecarPath)
 }
 
 // truncateSegment rewrites path with just a fresh header.
@@ -666,14 +679,22 @@ func (d *DiskIndex) Save(ctx context.Context, path string) error {
 	d.path = path
 	d.locators = newLocators
 	d.appendEnd = newEnd
-	// The compacted segment landed durably; record the version it captured so a
-	// subsequent Save with no intervening mutation is a no-op.
-	d.savedVersion = captured
-	d.lastSaveTime = time.Now()
 	if err := d.invalidateReaderLocked(); err != nil {
 		return err
 	}
-	return writeIdentitySidecar(identitySidecarPath(path), d.identity)
+	// The identity sidecar is part of this commit, not a postscript to it. A
+	// segment without its identity is unreadable on the next startup: Load maps
+	// a missing sidecar to "", EnsureIdentity reads that as a mismatch, and
+	// Reset discards every vector. So savedVersion must not advance until the
+	// sidecar is durable, or a failure here would mark the index clean and the
+	// `version == savedVersion` gate would ensure no later Save ever retried it
+	// (#728).
+	if err := writeIdentitySidecar(identitySidecarPath(path), d.identity); err != nil {
+		return err
+	}
+	d.savedVersion = captured
+	d.lastSaveTime = time.Now()
+	return nil
 }
 
 // AutosaveTick is the periodic-save entrypoint (issue #429 C-a): it compacts via
@@ -767,7 +788,9 @@ func finalizeFile(out *os.File, tmpPath, path string) error {
 		_ = os.Remove(tmpPath)
 		return err
 	}
-	return nil
+	// The file's own contents are synced above; the rename that makes them
+	// visible under `path` needs the directory synced too (#728).
+	return syncDir(path)
 }
 
 // Load reopens the segment at path: it rebuilds the locator map by scanning
@@ -787,9 +810,12 @@ func (d *DiskIndex) Load(ctx context.Context, path string) error {
 	locators, end, torn, scanErr := scanSegment(path)
 	if scanErr != nil {
 		if errors.Is(scanErr, os.ErrNotExist) {
+			// No segment at all. A sidecar that is damaged here has nothing to
+			// protect, so it is not worth failing startup over.
+			identity, _ := readIdentitySidecar(identitySidecarPath(path))
 			d.mu.Lock()
 			d.path = path
-			d.identity = readIdentitySidecar(identitySidecarPath(path))
+			d.identity = identity
 			d.mu.Unlock()
 			return nil
 		}
@@ -813,10 +839,31 @@ func (d *DiskIndex) Load(ctx context.Context, path string) error {
 	if err := d.invalidateReaderLocked(); err != nil {
 		return err
 	}
+	identity, idErr := readIdentitySidecar(identitySidecarPath(path))
+	if idErr != nil {
+		// A sidecar that EXISTS and cannot be understood. This used to read as
+		// "" exactly like a missing one, so EnsureIdentity saw a mismatch and
+		// Reset discarded every vector the segment still held (#728).
+		//
+		// Only the damaged case fails here. A missing sidecar over a populated
+		// segment is NOT damage: appends are durable immediately while the
+		// sidecar is only written by Save and Reset, so every index between its
+		// first append and its first save is legitimately in that state. I had
+		// this wrong and the existing suite caught it.
+		//
+		// Reported rather than repaired: adopting the configured identity would
+		// silently pair vectors with an embedding space that may not be theirs,
+		// which is worse than saying so. `reindex` is the deliberate recovery.
+		return fmt.Errorf(
+			"diskindex: segment %s holds %d vectors but its recorded embed identity is damaged (%w); "+
+				"run `dir2mcp reindex` to rebuild it deliberately rather than losing it silently",
+			path, len(locators), idErr,
+		)
+	}
 	d.path = path
 	d.locators = locators
 	d.appendEnd = end
-	d.identity = readIdentitySidecar(identitySidecarPath(path))
+	d.identity = identity
 	return nil
 }
 
@@ -1052,33 +1099,92 @@ func decodePayload(b []byte) (model.IndexPayload, error) {
 }
 
 func writeIdentitySidecar(path, identity string) error {
+	staged, err := stageIdentitySidecar(path, identity)
+	if err != nil {
+		return err
+	}
+	return publishIdentitySidecar(staged, path)
+}
+
+// stageIdentitySidecar writes the identity to a temporary file beside path and
+// returns that file's name, leaving it unpublished.
+//
+// Split from the rename so Reset can make the write durable BEFORE it destroys
+// anything, and rename afterwards.
+func stageIdentitySidecar(path, identity string) (string, error) {
 	data, err := json.Marshal(struct {
 		Identity string `json:"identity"`
 	}{Identity: identity})
 	if err != nil {
-		return err
+		return "", err
 	}
 	tmp := path + ".tmp"
-	if err := statefs.WriteFile(tmp, data); err != nil {
-		return err
+	file, err := statefs.Create(tmp)
+	if err != nil {
+		return "", err
 	}
-	return os.Rename(tmp, path)
+	if _, err := file.Write(data); err != nil {
+		_ = file.Close()
+		_ = os.Remove(tmp)
+		return "", err
+	}
+	// fsync the file, not just close it: statefs.WriteFile returns once the
+	// bytes are in the page cache, so a crash could publish a rename pointing
+	// at an empty or partial sidecar. The segment already syncs this way in
+	// finalizeFile; the sidecar did not, which is why the two were not one
+	// durable transaction (#728).
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		_ = os.Remove(tmp)
+		return "", err
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return "", err
+	}
+	return tmp, nil
 }
 
-// readIdentitySidecar returns the recorded identity, or "" when the sidecar is
-// missing/unreadable (treated as a fresh index, like a missing snapshot).
-func readIdentitySidecar(path string) string {
+// publishIdentitySidecar renames the staged file into place and fsyncs the
+// directory, without which the rename itself is not durable across a crash.
+func publishIdentitySidecar(staged, path string) error {
+	if err := os.Rename(staged, path); err != nil {
+		_ = os.Remove(staged)
+		return err
+	}
+	return syncDir(path)
+}
+
+// errSidecarUnreadable marks a sidecar that exists but cannot be understood, as
+// distinct from one that is simply absent. Collapsing the two to "" is what let
+// a damaged sidecar look exactly like a fresh index (#728).
+var errSidecarUnreadable = errors.New("identity sidecar is present but unreadable")
+
+// readIdentitySidecar returns the recorded identity.
+//
+// Three outcomes, deliberately not two:
+//
+//   - the sidecar is absent: ("", nil). For a segment that is also absent this
+//     is a genuinely fresh index.
+//   - the sidecar is readable: (identity, nil).
+//   - the sidecar exists and is damaged: ("", errSidecarUnreadable). This used
+//     to return "" like the first case, so EnsureIdentity saw a mismatch and
+//     Reset threw away every vector the segment still held.
+func readIdentitySidecar(path string) (string, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return ""
+		if errors.Is(err, os.ErrNotExist) {
+			return "", nil
+		}
+		return "", fmt.Errorf("%w: %s: %v", errSidecarUnreadable, path, err)
 	}
 	var s struct {
 		Identity string `json:"identity"`
 	}
-	if json.Unmarshal(data, &s) != nil {
-		return ""
+	if err := json.Unmarshal(data, &s); err != nil {
+		return "", fmt.Errorf("%w: %s: %v", errSidecarUnreadable, path, err)
 	}
-	return s.Identity
+	return s.Identity, nil
 }
 
 // --- float32 <-> bytes (little-endian) ---

--- a/tests/index/diskindex_atomic_generation_728_test.go
+++ b/tests/index/diskindex_atomic_generation_728_test.go
@@ -1,0 +1,238 @@
+package tests
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/index/diskindex"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// #728: the disk backend persisted the segment and its embed-identity sidecar as
+// two separate commits. Save renamed the compacted segment, marked the index
+// clean, and only then wrote the sidecar; a sidecar failure therefore returned
+// an error with the index ALREADY clean, so the `version == savedVersion` gate
+// made every later Save a no-op and the sidecar was never retried. On the next
+// startup Load mapped the missing sidecar to "", EnsureIdentity read that as a
+// mismatch, and Reset discarded the whole segment: an ordinary filesystem error
+// at a narrow boundary cost a full re-embed.
+
+// diskIndexAt builds an index over a caller-chosen path, so a test can reach
+// the segment and its sidecar on disk. (newDiskIndex in disk_index_test.go
+// hides the path inside a fresh TempDir.)
+func diskIndexAt(t *testing.T, dir string) (*diskindex.DiskIndex, string) {
+	t.Helper()
+	path := filepath.Join(dir, diskindex.SegmentFileName("text"))
+	idx := diskindex.New(path)
+	t.Cleanup(func() { _ = idx.Close() })
+	return idx, path
+}
+
+func upsert728(t *testing.T, idx *diskindex.DiskIndex, chunkID uint64, v []float32) {
+	t.Helper()
+	if err := idx.Upsert(context.Background(), v, model.IndexPayload{
+		ChunkID: chunkID, RelPath: "a.md", DocType: "md",
+	}); err != nil {
+		t.Fatalf("Upsert(%d): %v", chunkID, err)
+	}
+}
+
+// TestSaveDoesNotMarkTheIndexCleanUntilTheIdentityIsDurable is the reported
+// defect. With the sidecar path unwritable, Save must fail AND leave the index
+// dirty, so that a later Save retries rather than returning early at the
+// version gate having never persisted the identity.
+func TestSaveDoesNotMarkTheIndexCleanUntilTheIdentityIsDurable(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	idx, path := diskIndexAt(t, dir)
+	upsert728(t, idx, 1, []float32{1, 0})
+
+	// Make the sidecar unwritable by occupying its name with a directory: the
+	// staged write cannot be created and the rename cannot land.
+	sidecar := path + ".identity.json"
+	if err := os.MkdirAll(sidecar+".tmp", 0o700); err != nil {
+		t.Fatalf("seed obstruction: %v", err)
+	}
+
+	if err := idx.Save(ctx, path); err == nil {
+		t.Fatal("Save succeeded despite an unwritable identity sidecar")
+	}
+
+	// The retry is the point: before the fix this returned nil immediately,
+	// because savedVersion had already been advanced by the failed Save.
+	if err := os.RemoveAll(sidecar + ".tmp"); err != nil {
+		t.Fatalf("clear obstruction: %v", err)
+	}
+	if err := idx.Save(ctx, path); err != nil {
+		t.Fatalf("second Save did not retry cleanly: %v", err)
+	}
+	if _, err := os.Stat(sidecar); err != nil {
+		t.Fatalf("identity sidecar still absent after a successful Save: %v", err)
+	}
+}
+
+// TestAnIndexSurvivesRestartAfterAFailedSave closes the loop the issue
+// describes. It is not enough that Save reports an error: the vectors have to
+// still be there after the restart, and the thing that destroyed them was
+// EnsureIdentity, which reads a missing identity as a mismatch and calls Reset.
+// So the test goes through EnsureIdentity rather than Load alone.
+func TestAnIndexSurvivesRestartAfterAFailedSave(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	idx, path := diskIndexAt(t, dir)
+	const identity = "openai/text-embedding-3-small@1536"
+	if err := idx.Reset(ctx, identity); err != nil {
+		t.Fatalf("Reset(initial identity): %v", err)
+	}
+	upsert728(t, idx, 1, []float32{1, 0})
+	upsert728(t, idx, 2, []float32{0, 1})
+
+	// A save whose identity commit cannot land.
+	sidecar := path + ".identity.json"
+	if err := os.Remove(sidecar); err != nil {
+		t.Fatalf("clear the initial sidecar: %v", err)
+	}
+	if err := os.MkdirAll(sidecar+".tmp", 0o700); err != nil {
+		t.Fatalf("seed obstruction: %v", err)
+	}
+	if err := idx.Save(ctx, path); err == nil {
+		t.Fatal("Save succeeded despite an unwritable identity sidecar")
+	}
+	if err := os.RemoveAll(sidecar + ".tmp"); err != nil {
+		t.Fatalf("clear obstruction: %v", err)
+	}
+	// The retry that the version gate used to prevent.
+	if err := idx.Save(ctx, path); err != nil {
+		t.Fatalf("retry Save: %v", err)
+	}
+
+	reopened := diskindex.New(path)
+	defer func() { _ = reopened.Close() }()
+	if err := reopened.Load(ctx, path); err != nil {
+		t.Fatalf("Load after restart: %v", err)
+	}
+	// This is the step that used to discard everything.
+	if err := index.EnsureIdentity(ctx, reopened, identity); err != nil {
+		t.Fatalf("EnsureIdentity: %v", err)
+	}
+	hits, err := reopened.Search(ctx, []float32{1, 0}, 2, model.Filter{})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(hits) != 2 {
+		t.Fatalf("restart kept %d vectors, want 2: EnsureIdentity reset the segment", len(hits))
+	}
+}
+
+// TestADamagedIdentitySidecarIsReportedNotSilentlyReset pins the Load half.
+// readIdentitySidecar used to map a corrupt sidecar to "" exactly like a
+// missing one, so EnsureIdentity saw a mismatch and Reset threw the segment
+// away. Losing an index because a small JSON file went bad is not a recovery.
+func TestADamagedIdentitySidecarIsReportedNotSilentlyReset(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	idx, path := diskIndexAt(t, dir)
+	upsert728(t, idx, 1, []float32{1, 0})
+	if err := idx.Save(ctx, path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	sidecar := path + ".identity.json"
+	if err := os.WriteFile(sidecar, []byte("{not json"), 0o600); err != nil {
+		t.Fatalf("corrupt the sidecar: %v", err)
+	}
+
+	reopened := diskindex.New(path)
+	defer func() { _ = reopened.Close() }()
+	err := reopened.Load(ctx, path)
+	if err == nil {
+		t.Fatal("Load accepted a damaged identity sidecar; EnsureIdentity would then reset the segment")
+	}
+	// The message has to tell an operator what to do about it.
+	if !strings.Contains(err.Error(), "reindex") {
+		t.Fatalf("error does not name the recovery: %v", err)
+	}
+}
+
+// TestAMissingSidecarOverAPopulatedSegmentIsNotDamage guards the correction I
+// had to make while writing this. Appends are durable immediately while the
+// sidecar is only written by Save and Reset, so EVERY index between its first
+// append and its first save legitimately has vectors and no sidecar. Failing
+// that state would break ordinary operation, not protect it.
+func TestAMissingSidecarOverAPopulatedSegmentIsNotDamage(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	idx, path := diskIndexAt(t, dir)
+	upsert728(t, idx, 1, []float32{1, 0})
+
+	if _, err := os.Stat(path + ".identity.json"); !os.IsNotExist(err) {
+		t.Fatalf("expected no sidecar before the first Save, stat err = %v", err)
+	}
+	reopened := diskindex.New(path)
+	defer func() { _ = reopened.Close() }()
+	if err := reopened.Load(ctx, path); err != nil {
+		t.Fatalf("Load of an appended-but-unsaved segment must succeed: %v", err)
+	}
+	hits, err := reopened.Search(ctx, []float32{1, 0}, 1, model.Filter{})
+	if err != nil || len(hits) != 1 {
+		t.Fatalf("Search after load = %v, %v; the durable append was lost", hits, err)
+	}
+}
+
+// TestResetDoesNotDestroyTheSegmentWhenTheIdentityCannotBeCommitted: Reset used
+// to truncate FIRST and write the identity second, so a failure in between left
+// an emptied segment whose recorded identity still described the vectors that
+// were just deleted. Staging the identity before the destructive step means a
+// failure leaves the previous generation intact.
+func TestResetDoesNotDestroyTheSegmentWhenTheIdentityCannotBeCommitted(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	idx, path := diskIndexAt(t, dir)
+	const identity = "openai/text-embedding-3-small@1536"
+	if err := idx.Reset(ctx, identity); err != nil {
+		t.Fatalf("Reset(initial): %v", err)
+	}
+	upsert728(t, idx, 1, []float32{1, 0})
+	upsert728(t, idx, 2, []float32{0, 1})
+	if err := idx.Save(ctx, path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Make the identity commit impossible, then ask for a reset.
+	sidecar := path + ".identity.json"
+	if err := os.MkdirAll(sidecar+".tmp", 0o700); err != nil {
+		t.Fatalf("seed obstruction: %v", err)
+	}
+	if err := idx.Reset(ctx, "some-other-identity"); err == nil {
+		t.Fatal("Reset succeeded despite an uncommittable identity")
+	}
+	if err := os.RemoveAll(sidecar + ".tmp"); err != nil {
+		t.Fatalf("clear obstruction: %v", err)
+	}
+
+	// The segment on disk must still be the committed generation, not an empty
+	// file left behind by a half-done reset.
+	reopened := diskindex.New(path)
+	defer func() { _ = reopened.Close() }()
+	if err := reopened.Load(ctx, path); err != nil {
+		t.Fatalf("Load after the failed Reset: %v", err)
+	}
+	hits, err := reopened.Search(ctx, []float32{1, 0}, 2, model.Filter{})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(hits) != 2 {
+		t.Fatalf("a failed Reset destroyed the committed segment: %d vectors survive, want 2", len(hits))
+	}
+	recorded, err := reopened.Identity(ctx)
+	if err != nil {
+		t.Fatalf("Identity: %v", err)
+	}
+	if recorded != identity {
+		t.Fatalf("recorded identity = %q after a failed Reset, want the previous %q", recorded, identity)
+	}
+}


### PR DESCRIPTION
Closes #728.

`Save` renamed the compacted segment, set `savedVersion`, and **only then** wrote the identity sidecar. A sidecar failure therefore returned an error with the index already marked clean, so the `version == savedVersion` gate made every later `Save` a no-op and the sidecar was never retried.

On the next startup `Load` mapped the missing sidecar to `""`, `EnsureIdentity` read that as a mismatch, and `Reset` discarded the whole segment. **One filesystem error at a narrow boundary cost a full re-embed.**

## What changed

- **`Save`**: `savedVersion` advances only after the identity is durable, so a failure leaves the index dirty and the next `Save` retries.
- **`Reset`**: had the mirror problem — it truncated the segment before recording the new identity, so a failure in between left an emptied segment whose recorded identity still described the vectors just deleted. The identity is now staged before the destructive step and published after, so whichever step fails, what is on disk stays a matched pair.
- **Durability**: `statefs.WriteFile` returns once the bytes are in the page cache, and a rename is not durable until its directory is synced, so a crash could publish a rename pointing at an empty sidecar. The sidecar now fsyncs its file and its directory, as the segment already did via `finalizeFile` — which itself was missing the directory sync.
- **`readIdentitySidecar`**: mapped a *damaged* sidecar to `""` exactly like a missing one, so corrupt JSON cost the entire index. The two are now distinguished and `Load` reports the damaged case, naming `reindex` as the deliberate recovery. Reported rather than repaired on purpose: adopting the configured identity would silently pair vectors with an embedding space that may not be theirs.

## A correction the existing suite forced

I first extended that error to a **missing** sidecar over a populated segment, reasoning that the sidecar has existed since the backend's first commit (verified with `git log -S`), so its absence must be damage.

Five existing tests failed, and they were right. Appends are durable immediately while the sidecar is only written by `Save` and `Reset`, so **every index between its first append and its first save legitimately has vectors and no sidecar**. Only the damaged case fails now, and a new test pins that the ordinary one still loads.

## Tests

Four regression tests, each **verified to fail on the pre-fix code** by stashing only the source change:

- a failed identity commit leaves the index retryable
- an index survives restart **through `EnsureIdentity`** — the call that actually destroyed it
- a damaged sidecar is reported rather than silently reset
- a failed `Reset` leaves the committed generation intact

My first drafts of the restart and reset tests **passed against the unfixed code** — they exercised `Load` rather than `EnsureIdentity`, and a failing truncation rather than a failing identity commit. I rewrote both rather than keep tests that could not fail.

`make check` passes.