### PR TITLE
fix(s3): stop requiring a local corpus root at startup and service install (#738)

### DIFF
--- a/docs/dual-machine-deployment.md
+++ b/docs/dual-machine-deployment.md
@@ -184,6 +184,17 @@ persisted** to the config file or the effective-config snapshot. With
 `source.kind: s3`, startup fails loudly (`CONFIG_INVALID`-style) if the bucket is
 missing or the access key + secret are not resolvable.
 
+**No local corpus directory is required for `s3`.** The bucket + prefix *is* the
+corpus root, so `root_dir` (the `--dir` root) is ignored by the S3 backend and
+does not have to exist. Only the **state directory** must be local
+(`dirstral-spec/docs/SPEC.md` §7.8) — that is where SQLite, the index and the
+caches live. `dir2mcp up` on an `s3` source therefore no longer fails with
+`root inaccessible` when no local corpus is present, and `dir2mcp service
+install` anchors the supervised daemon's working directory on the **directory
+holding your config file** (where `.dir2mcp.yaml` and `.env.local` live) instead
+of the ignored corpus root. `local`/`nfs` are unchanged: they still require an
+accessible root directory and still boot the service in it.
+
 `rel_path` (document identity) is stable across schemes: for `local`/`nfs` it is
 the path under the root; for `s3` it is the object key minus the configured
 prefix. A corpus can be relocated `local ⇄ nfs ⇄ s3` without forcing a reindex

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -1402,13 +1402,17 @@ func consumeGlobalFlagValue(flagName string, args []string) (string, int, error)
 	return value, 2, nil
 }
 
+// defaultConfigFileName is the config file `dir2mcp` discovers in the process
+// working directory when no --config is supplied.
+const defaultConfigFileName = ".dir2mcp.yaml"
+
 // resolveConfigPath returns the configured config path, defaulting to
 // ".dir2mcp.yaml" when none was supplied.
 func resolveConfigPath(global globalOptions) string {
 	if trimmed := strings.TrimSpace(global.configPath); trimmed != "" {
 		return trimmed
 	}
-	return ".dir2mcp.yaml"
+	return defaultConfigFileName
 }
 
 // applyGlobalPathOverrides overlays the --dir and --state-dir global flags

--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -86,7 +86,7 @@ func (a *App) runDown(ctx context.Context, global globalOptions, args []string) 
 	// just stopped will be respawned at next login/boot. Inform the operator
 	// (do NOT auto-uninstall) so `down` in a teardown script isn't mistaken
 	// for a permanent stop (#434).
-	writeDownInfo(a.stdout, global.jsonOutput, cfg.StateDir, pid, true, "stopped", a.corpusServiceManaged(cfg))
+	writeDownInfo(a.stdout, global.jsonOutput, cfg.StateDir, pid, true, "stopped", a.corpusServiceManaged(cfg, global))
 	return exitSuccess
 }
 
@@ -95,8 +95,8 @@ func (a *App) runDown(ctx context.Context, global globalOptions, args []string) 
 // unsupported platform) yields false so the informational note is simply
 // omitted and `down` never fails over it. Takes the already-loaded config so it
 // doesn't reload it.
-func (a *App) corpusServiceManaged(cfg config.Config) bool {
-	sc, err := serviceContextFromConfig(cfg, "")
+func (a *App) corpusServiceManaged(cfg config.Config, global globalOptions) bool {
+	sc, err := serviceContextFromConfig(cfg, "", resolveConfigPath(global))
 	if err != nil {
 		return false
 	}

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -118,29 +118,91 @@ func (a *App) resolveServiceContext(global globalOptions, nameOverride string) (
 	if err != nil {
 		return serviceContext{}, config.Config{}, fmt.Errorf("load config: %w", err)
 	}
-	sc, err := serviceContextFromConfig(cfg, nameOverride)
+	sc, err := serviceContextFromConfig(cfg, nameOverride, resolveConfigPath(global))
 	if err != nil {
 		return serviceContext{}, config.Config{}, err
 	}
 	return sc, cfg, nil
 }
 
+// absOrSelf returns the absolute form of p, falling back to p itself when the
+// working directory cannot be read (the historical behavior of every
+// filepath.Abs call on this path).
+func absOrSelf(p string) string {
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return p
+	}
+	return abs
+}
+
+// isExistingDir reports whether p names an existing directory.
+func isExistingDir(p string) bool {
+	info, err := os.Stat(p)
+	return err == nil && info.IsDir()
+}
+
+// serviceWorkingDirBase picks the directory the supervised daemon is booted in.
+//
+// For a filesystem-backed corpus (local/nfs) this stays the absolute corpus
+// root, unchanged: that is where the operator's .dir2mcp.yaml and .env.local
+// live by convention, and both the config loader (relative ".dir2mcp.yaml") and
+// the dotenv loader (relative ".env.local") resolve against the process working
+// directory.
+//
+// For an object-store corpus there is no local root to boot in (SPEC §7.8), and
+// rendering the ignored RootDir as launchd's WorkingDirectory / systemd's
+// WorkingDirectory installs a unit that cannot start (#738). The config file's
+// own directory is used instead: it is the one local directory that is
+// guaranteed to be the source of the config the operator just installed from,
+// so the booted daemon rediscovers the same .dir2mcp.yaml and the same
+// .env.local (which is also where persistAndWarnCredentials writes the AWS
+// credentials, and what systemd renders as EnvironmentFile).
+func serviceWorkingDirBase(cfg config.Config, configPath string) string {
+	if !sourceIsRemote(cfg) {
+		return absOrSelf(cfg.RootDir)
+	}
+	p := strings.TrimSpace(configPath)
+	if p == "" {
+		p = defaultConfigFileName
+	}
+	return filepath.Dir(absOrSelf(p))
+}
+
+// resolveServiceDirs resolves the supervisor working directory and the absolute
+// state directory together, because they are coupled: a relative state_dir is
+// resolved by the booted daemon against its own working directory, so install
+// must resolve it against the same base or it would create (and log into) a
+// different directory than the daemon uses.
+//
+// When the config directory itself does not exist (an explicit --config naming a
+// path under a missing directory), the working directory falls back to the state
+// directory, which is always local (SPEC §7.8) and is created before the unit is
+// written.
+func resolveServiceDirs(cfg config.Config, configPath string) (workingDir, stateDir string) {
+	base := serviceWorkingDirBase(cfg, configPath)
+	stateDir = strings.TrimSpace(cfg.StateDir)
+	if stateDir == "" {
+		stateDir = filepath.Join(base, ".dir2mcp")
+	}
+	if !filepath.IsAbs(stateDir) {
+		stateDir = filepath.Join(base, stateDir)
+	}
+	workingDir = base
+	if sourceIsRemote(cfg) && !isExistingDir(base) {
+		workingDir = stateDir
+	}
+	return workingDir, stateDir
+}
+
 // serviceContextFromConfig derives the service context from an already-loaded
 // config, so callers holding a config (e.g. `down`) don't pay a redundant
 // config reload. nameOverride is assumed pre-validated by the caller.
-func serviceContextFromConfig(cfg config.Config, nameOverride string) (serviceContext, error) {
+// configPath is the config path the caller resolved (see resolveConfigPath); it
+// anchors the working directory when the corpus root is remote (#738).
+func serviceContextFromConfig(cfg config.Config, nameOverride, configPath string) (serviceContext, error) {
 	name := resolveClaudeServerName(&cfg, nameOverride)
-	abs, err := filepath.Abs(cfg.RootDir)
-	if err != nil {
-		abs = cfg.RootDir
-	}
-	stateDir := strings.TrimSpace(cfg.StateDir)
-	if stateDir == "" {
-		stateDir = filepath.Join(abs, ".dir2mcp")
-	}
-	if !filepath.IsAbs(stateDir) {
-		stateDir = filepath.Join(abs, stateDir)
-	}
+	workingDir, stateDir := resolveServiceDirs(cfg, configPath)
 	bin, err := os.Executable()
 	if err != nil {
 		return serviceContext{}, fmt.Errorf("locate dir2mcp executable: %w", err)
@@ -148,11 +210,33 @@ func serviceContextFromConfig(cfg config.Config, nameOverride string) (serviceCo
 	return serviceContext{
 		label:      serviceLabel(name),
 		serverName: name,
-		workingDir: abs,
+		workingDir: workingDir,
 		stateDir:   stateDir,
 		binaryPath: bin,
 		logPath:    filepath.Join(stateDir, "service.log"),
 	}, nil
+}
+
+// installServiceArgs builds the argv the supervisor launches, propagating the
+// operator's global flag overrides so the installed service restarts with the
+// exact same config/state-dir they used for install, rather than re-discovering
+// defaults from the working directory alone.
+//
+// Both propagated paths are made ABSOLUTE (#738). A relative --config was
+// previously copied verbatim into the unit and then re-resolved by the daemon
+// against its own working directory, which is not the directory the operator ran
+// install from — so the unit could point at a config that does not exist. The
+// state directory is taken from the already-resolved serviceContext, which is
+// the same directory install just created and writes service.log into.
+func installServiceArgs(global globalOptions, sc serviceContext) []string {
+	serviceArgs := []string{"up", "--foreground"}
+	if p := strings.TrimSpace(global.configPath); p != "" {
+		serviceArgs = append(serviceArgs, "--config", absOrSelf(p))
+	}
+	if p := strings.TrimSpace(global.stateDir); p != "" {
+		serviceArgs = append(serviceArgs, "--state-dir", sc.stateDir)
+	}
+	return serviceArgs
 }
 
 // runServiceInstall handles `dir2mcp service install`.
@@ -171,16 +255,7 @@ func (a *App) runServiceInstall(global globalOptions, args []string) int {
 	}
 	savedCreds, failedCreds := a.persistAndWarnCredentials(sc.workingDir, cfg, global.jsonOutput, global.quiet)
 
-	// Propagate global flag overrides so the installed service restarts
-	// with the exact same config/state-dir the operator used for install,
-	// rather than re-discovering defaults from the working directory alone.
-	serviceArgs := []string{"up", "--foreground"}
-	if p := strings.TrimSpace(global.configPath); p != "" {
-		serviceArgs = append(serviceArgs, "--config", p)
-	}
-	if p := strings.TrimSpace(global.stateDir); p != "" {
-		serviceArgs = append(serviceArgs, "--state-dir", p)
-	}
+	serviceArgs := installServiceArgs(global, sc)
 
 	unitPath, err := mgr.install(serviceSpec{
 		Label:      sc.label,

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
 )
 
 func TestServiceLabel(t *testing.T) {
@@ -431,5 +433,171 @@ func TestRunService_RejectsBadSubcommand(t *testing.T) {
 		if !strings.Contains(errBuf.String(), "subcommand") {
 			t.Errorf("args=%v: stderr missing subcommand hint: %q", args, errBuf.String())
 		}
+	}
+}
+
+// --- issue #738: remote corpora must not anchor the service on a local root ---
+
+// s3ServiceConfig builds a native-S3 corpus config whose corpus root is a local
+// path that does not exist. Per SPEC §7.8 the bucket + prefix IS the corpus root
+// for source.kind=s3, so this is a legitimate remote-only deployment.
+func s3ServiceConfig(rootDir, stateDir string) config.Config {
+	cfg := config.Default()
+	cfg.RootDir = rootDir
+	cfg.StateDir = stateDir
+	cfg.Source.Kind = "s3"
+	cfg.Source.S3Bucket = "my-corpus-bucket"
+	cfg.Source.S3Prefix = "corpus/"
+	return cfg
+}
+
+// For an S3 corpus the supervisor working directory must be a directory that
+// actually exists — the config file's own directory — not the ignored local
+// corpus root. Before the fix this rendered abs(RootDir), installing a unit
+// whose WorkingDirectory does not exist.
+func TestServiceContext_S3AnchorsWorkingDirOnConfigDir_738(t *testing.T) {
+	tmp := t.TempDir()
+	confDir := filepath.Join(tmp, "conf")
+	if err := os.MkdirAll(confDir, 0o700); err != nil {
+		t.Fatalf("mkdir conf: %v", err)
+	}
+	cfg := s3ServiceConfig(filepath.Join(tmp, "does-not-exist"), filepath.Join(tmp, "state"))
+
+	sc, err := serviceContextFromConfig(cfg, "", filepath.Join(confDir, ".dir2mcp.yaml"))
+	if err != nil {
+		t.Fatalf("serviceContextFromConfig: %v", err)
+	}
+	if sc.workingDir != confDir {
+		t.Fatalf("workingDir = %q, want the config directory %q", sc.workingDir, confDir)
+	}
+	if !isExistingDir(sc.workingDir) {
+		t.Fatalf("rendered WorkingDirectory %q does not exist", sc.workingDir)
+	}
+	if sc.stateDir != filepath.Join(tmp, "state") {
+		t.Errorf("stateDir = %q, want the configured absolute state dir", sc.stateDir)
+	}
+}
+
+// A relative state_dir must resolve against the SAME base the booted daemon
+// resolves it against (its working directory), or install would create and log
+// into a different directory than the daemon uses.
+func TestServiceContext_S3RelativeStateDirFollowsWorkingDir_738(t *testing.T) {
+	tmp := t.TempDir()
+	cfg := s3ServiceConfig(filepath.Join(tmp, "does-not-exist"), ".dir2mcp")
+
+	sc, err := serviceContextFromConfig(cfg, "", filepath.Join(tmp, ".dir2mcp.yaml"))
+	if err != nil {
+		t.Fatalf("serviceContextFromConfig: %v", err)
+	}
+	if want := filepath.Join(tmp, ".dir2mcp"); sc.stateDir != want {
+		t.Fatalf("stateDir = %q, want %q (resolved against the working dir)", sc.stateDir, want)
+	}
+	if sc.logPath != filepath.Join(tmp, ".dir2mcp", "service.log") {
+		t.Errorf("logPath = %q, want it under the resolved state dir", sc.logPath)
+	}
+}
+
+// When an explicit --config names a path under a directory that does not exist,
+// the working directory falls back to the state directory, which is always local
+// (SPEC §7.8) and is created before the unit is written.
+func TestServiceContext_S3FallsBackToStateDirWhenConfigDirMissing_738(t *testing.T) {
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, "state")
+	cfg := s3ServiceConfig(filepath.Join(tmp, "does-not-exist"), stateDir)
+
+	sc, err := serviceContextFromConfig(cfg, "", filepath.Join(tmp, "gone", "conf.yaml"))
+	if err != nil {
+		t.Fatalf("serviceContextFromConfig: %v", err)
+	}
+	if sc.workingDir != stateDir {
+		t.Fatalf("workingDir = %q, want the state dir %q", sc.workingDir, stateDir)
+	}
+}
+
+// The local/NFS contract is byte-identical to the pre-#738 behavior: the working
+// directory is the absolute corpus root and a relative state_dir hangs off it,
+// regardless of where the config file lives.
+func TestServiceContext_LocalAndNFSKeepCorpusRootWorkingDir_738(t *testing.T) {
+	for _, kind := range []string{"", "local", "nfs"} {
+		tmp := t.TempDir()
+		root := filepath.Join(tmp, "corpus")
+		if err := os.MkdirAll(root, 0o700); err != nil {
+			t.Fatalf("mkdir corpus: %v", err)
+		}
+		cfg := config.Default()
+		cfg.RootDir = root
+		cfg.StateDir = ".dir2mcp"
+		cfg.Source.Kind = kind
+
+		sc, err := serviceContextFromConfig(cfg, "", filepath.Join(tmp, "elsewhere", ".dir2mcp.yaml"))
+		if err != nil {
+			t.Fatalf("kind=%q: serviceContextFromConfig: %v", kind, err)
+		}
+		if sc.workingDir != root {
+			t.Errorf("kind=%q: workingDir = %q, want the corpus root %q", kind, sc.workingDir, root)
+		}
+		if want := filepath.Join(root, ".dir2mcp"); sc.stateDir != want {
+			t.Errorf("kind=%q: stateDir = %q, want %q", kind, sc.stateDir, want)
+		}
+	}
+}
+
+// The rendered unit is what launchd/systemd actually consume, so pin the
+// end-to-end result too: an S3 corpus with no local root must render a
+// WorkingDirectory that exists on both backends.
+func TestRenderedUnitsUseAnExistingWorkingDirForS3_738(t *testing.T) {
+	tmp := t.TempDir()
+	missingRoot := filepath.Join(tmp, "does-not-exist")
+	cfg := s3ServiceConfig(missingRoot, filepath.Join(tmp, "state"))
+	sc, err := serviceContextFromConfig(cfg, "", filepath.Join(tmp, ".dir2mcp.yaml"))
+	if err != nil {
+		t.Fatalf("serviceContextFromConfig: %v", err)
+	}
+	spec := serviceSpec{
+		Label:      sc.label,
+		BinaryPath: sc.binaryPath,
+		WorkingDir: sc.workingDir,
+		Args:       []string{"up", "--foreground"},
+		LogPath:    sc.logPath,
+	}
+	if !isExistingDir(spec.WorkingDir) {
+		t.Fatalf("rendered WorkingDirectory %q does not exist", spec.WorkingDir)
+	}
+	for name, rendered := range map[string]string{
+		"launchd": renderLaunchdPlist(spec),
+		"systemd": renderSystemdUnit(spec),
+	} {
+		if !strings.Contains(rendered, "WorkingDirectory") {
+			t.Fatalf("%s unit has no WorkingDirectory:\n%s", name, rendered)
+		}
+		// The unit must not reference the ignored local corpus root anywhere:
+		// WorkingDirectory, the systemd EnvironmentFile, or the log paths.
+		if strings.Contains(rendered, missingRoot) {
+			t.Errorf("%s unit still points at the ignored local corpus root %q:\n%s", name, missingRoot, rendered)
+		}
+	}
+}
+
+// A relative --config was copied verbatim into the unit and then re-resolved by
+// the daemon against ITS working directory, which is not the directory the
+// operator ran install from. Both propagated paths are now absolute.
+func TestInstallServiceArgs_PropagatesAbsolutePaths_738(t *testing.T) {
+	sc := serviceContext{stateDir: filepath.Join("/srv", "corpus", "state")}
+	args := installServiceArgs(globalOptions{configPath: "conf/d.yaml", stateDir: "./state"}, sc)
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	want := []string{"up", "--foreground",
+		"--config", filepath.Join(cwd, "conf", "d.yaml"),
+		"--state-dir", sc.stateDir}
+	if strings.Join(args, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("installServiceArgs = %v, want %v", args, want)
+	}
+
+	// No overrides -> no propagated paths (unchanged).
+	if got := installServiceArgs(globalOptions{}, sc); strings.Join(got, " ") != "up --foreground" {
+		t.Fatalf("installServiceArgs without overrides = %v", got)
 	}
 }

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -441,9 +441,29 @@ func (a *App) validateUpConfig(cfg *config.Config, opts upOptions) int {
 			return exitConfigInvalid
 		}
 	}
-	if err := ensureRootAccessible(cfg.RootDir); err != nil {
-		writeCLIError(a.stderr, opts.jsonOutput, exitRootInaccessible, fmt.Sprintf("root inaccessible: %v", err))
-		return exitRootInaccessible
+	return a.prepareUpDirectories(cfg, opts)
+}
+
+// prepareUpDirectories enforces the corpus-root requirement and creates the
+// local state hierarchy `up` needs. Split out of validateUpConfig to keep that
+// function under the cyclomatic-complexity budget.
+//
+// It runs AFTER x402 validation so the payments subdirectory is only created
+// for a config that already validated (including mode="off"), and never leaves
+// an inconsistent state behind.
+func (a *App) prepareUpDirectories(cfg *config.Config, opts upOptions) int {
+	// The corpus root is a LOCAL directory only for the filesystem-backed
+	// schemes. For an object-store source the bucket + prefix IS the corpus root
+	// (SPEC §7.8) and S3FS.Walk ignores its root argument outright, so demanding
+	// a local directory here fails a healthy remote-only deployment before S3 is
+	// ever contacted (#738). Only the state directory must stay local, and it is
+	// created and hardened immediately below. local/nfs keep the requirement:
+	// an NFS mount is an ordinary local path.
+	if !sourceIsRemote(*cfg) {
+		if err := ensureRootAccessible(cfg.RootDir); err != nil {
+			writeCLIError(a.stderr, opts.jsonOutput, exitRootInaccessible, fmt.Sprintf("root inaccessible: %v", err))
+			return exitRootInaccessible
+		}
 	}
 	if err := statefs.MkdirAllHardened(cfg.StateDir); err != nil {
 		writeCLIError(a.stderr, opts.jsonOutput, exitRootInaccessible, fmt.Sprintf("create state dir: %v", err))
@@ -458,12 +478,8 @@ func (a *App) validateUpConfig(cfg *config.Config, opts upOptions) int {
 		writeCLIError(a.stderr, opts.jsonOutput, exitRootInaccessible, fmt.Sprintf("secure state dir: %v", err))
 		return exitRootInaccessible
 	}
-	// create payments subdirectory while x402 configuration has been
-	// validated above. creating the state directory first ensures the
-	// parent exists. the call is intentionally unconditional here: we ensure
-	// the directory exists regardless of mode, avoiding inconsistent state.
-	// because it's done after x402 validation, a valid config (including
-	// mode="off") won't leave an inconsistent state.
+	// The payments subdirectory is created unconditionally so the layout is the
+	// same regardless of x402 mode, avoiding inconsistent state.
 	if err := statefs.MkdirAllHardened(filepath.Join(cfg.StateDir, "payments")); err != nil {
 		writeCLIError(a.stderr, opts.jsonOutput, exitRootInaccessible, fmt.Sprintf("create payments dir: %v", err))
 		return exitRootInaccessible

--- a/tests/cli/s3_no_local_root_738_test.go
+++ b/tests/cli/s3_no_local_root_738_test.go
@@ -1,0 +1,127 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/cli"
+)
+
+// s3ConfigYAML renders a minimal, valid native-S3 corpus config whose corpus
+// root points at a local directory that does NOT exist. Per SPEC §7.8 the
+// bucket+prefix IS the corpus root for source.kind=s3 (S3FS.Walk ignores its
+// root argument), so this is a legitimate remote-only deployment: only the
+// state directory has to be local.
+func s3ConfigYAML(rootDir, stateDir string) string {
+	return "root_dir: " + rootDir + "\n" +
+		"state_dir: " + stateDir + "\n" +
+		"source:\n" +
+		"  kind: s3\n" +
+		"  s3:\n" +
+		"    bucket: my-corpus-bucket\n" +
+		"    prefix: corpus/\n"
+}
+
+// writeConfig writes cfg to <dir>/.dir2mcp.yaml.
+func writeConfig(t *testing.T, dir, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, ".dir2mcp.yaml"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}
+
+// prepareS3UpEnv clears every provider credential (so the run stops at the
+// embed preflight, which is the FIRST check after root validation) and supplies
+// the AWS credentials source.kind=s3 requires at runtime.
+func prepareS3UpEnv(t *testing.T) {
+	t.Helper()
+	clearProviderEnv(t)
+	t.Setenv("DIR2MCP_DISABLE_KEYCHAIN", "1")
+	t.Setenv("AWS_ACCESS_KEY_ID", "test-access-key")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "test-secret-key")
+}
+
+// Issue #738: `up` on a native-S3 corpus must not demand a local corpus root.
+// Before the fix validateUpConfig called ensureRootAccessible(cfg.RootDir)
+// unconditionally, so a healthy remote-only deployment exited with
+// "root inaccessible" before S3 was ever contacted.
+//
+// The assertion is bounded: with no embedding provider configured the run must
+// reach the embed preflight (the next check after root validation) and fail
+// there instead.
+func TestUpS3SourceDoesNotRequireLocalRoot_738(t *testing.T) {
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, "state")
+	missingRoot := filepath.Join(tmp, "does-not-exist")
+	writeConfig(t, tmp, s3ConfigYAML(missingRoot, stateDir))
+	prepareS3UpEnv(t)
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIOAndHooks(&stdout, &stderr, cli.RuntimeHooks{})
+	var code int
+	withWorkingDir(t, tmp, func() {
+		code = app.RunWithContext(context.Background(), []string{"up", "--foreground"})
+	})
+	if code == 0 {
+		t.Fatalf("expected a non-zero exit from the embed preflight, stderr=%s", stderr.String())
+	}
+	out := stderr.String()
+	if strings.Contains(out, "root inaccessible") {
+		t.Fatalf("s3 source must not require a local corpus root (#738); got: %s", out)
+	}
+	if !strings.Contains(out, "no embedding provider configured") {
+		t.Fatalf("expected startup to reach the embed preflight; got: %s", out)
+	}
+}
+
+// The local-corpus contract is unchanged: a missing root_dir is still a hard
+// startup failure for the default source.kind.
+func TestUpLocalSourceStillRequiresLocalRoot_738(t *testing.T) {
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, "state")
+	missingRoot := filepath.Join(tmp, "does-not-exist")
+	writeConfig(t, tmp, "root_dir: "+missingRoot+"\nstate_dir: "+stateDir+"\n")
+	clearProviderEnv(t)
+	t.Setenv("DIR2MCP_DISABLE_KEYCHAIN", "1")
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIOAndHooks(&stdout, &stderr, cli.RuntimeHooks{})
+	var code int
+	withWorkingDir(t, tmp, func() {
+		code = app.RunWithContext(context.Background(), []string{"up", "--foreground"})
+	})
+	if code == 0 {
+		t.Fatalf("a missing local corpus root must fail, stderr=%s", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "root inaccessible") {
+		t.Fatalf("local source must still require an accessible root; got: %s", stderr.String())
+	}
+}
+
+// nfs is a mounted filesystem path, so it keeps the local-root requirement too.
+func TestUpNFSSourceStillRequiresLocalRoot_738(t *testing.T) {
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, "state")
+	missingRoot := filepath.Join(tmp, "does-not-exist")
+	writeConfig(t, tmp,
+		"root_dir: "+missingRoot+"\nstate_dir: "+stateDir+"\nsource:\n  kind: nfs\n")
+	clearProviderEnv(t)
+	t.Setenv("DIR2MCP_DISABLE_KEYCHAIN", "1")
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIOAndHooks(&stdout, &stderr, cli.RuntimeHooks{})
+	var code int
+	withWorkingDir(t, tmp, func() {
+		code = app.RunWithContext(context.Background(), []string{"up", "--foreground"})
+	})
+	if code == 0 {
+		t.Fatalf("a missing nfs mount root must fail, stderr=%s", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "root inaccessible") {
+		t.Fatalf("nfs source must still require an accessible root; got: %s", stderr.String())
+	}
+}


### PR DESCRIPTION
Closes #738.

## The brief was right, and here is what I measured

Both claims in the issue check out against the code:

- `internal/corpusfs/s3.go:199` — *"The root argument is ignored: the configured prefix is the corpus root."*
- `dirstral-spec/docs/SPEC.md` §7.8 — *"State stays local. Regardless of `source.kind`, the state directory ... is always local ... Only the corpus content is remote."*
- `internal/cli/up.go` `validateUpConfig` called `ensureRootAccessible(cfg.RootDir)` unconditionally.
- `internal/cli/service.go` `serviceContextFromConfig` always set `workingDir = abs(cfg.RootDir)`, which `renderLaunchdPlist`/`renderSystemdUnit` emit as `WorkingDirectory` (and systemd also as `EnvironmentFile=<workdir>/.env.local`).

Measured before writing any fix, on the pre-fix tree:

```
$ go test ./tests/cli -run 738
    s3 source must not require a local corpus root (#738); got: root inaccessible:
    stat .../does-not-exist: no such file or directory

$ go test ./internal/cli -run TestProbePreFixServiceWorkingDir   # throwaway probe
    workingDir=.../does-not-exist stateDir=.../state
    PRE-FIX DEFECT: rendered WorkingDirectory does not exist
```

No spec change is needed: §7.8 already permits a remote corpus root with a local state directory, so this brings the implementation into conformance rather than introducing new normative behaviour.

## What changed

**1. Local-root validation is now source-aware.** `validateUpConfig` gates `ensureRootAccessible` on the existing `sourceIsRemote(cfg)` helper (`internal/cli/up.go:1357`), which reads the resolved `source.kind` (`config.validateSource` normalizes/validates it and defaults empty to `local`; the same helper already routes retrieval-time reads for #432). `local`, `nfs`, and empty keep the requirement verbatim — an NFS mount is an ordinary local path. The state directory is created and hardened exactly as before, for every kind.

The directory block moved into a new `prepareUpDirectories` helper purely to keep `validateUpConfig` under the gocyclo budget (adding the branch pushed it to 16, over the `-over 15` gate). No behavioural change; the ordering relative to x402 validation is preserved, and the reason for it is now in the helper's doc comment.

**2. Service working directory for a remote corpus: the config file's directory.**

I considered the two candidates the issue names. The state-directory parent is the wrong answer, and I want the reasoning on record. The working directory is not cosmetic — it is the resolution base for three things:

- `config.load` reads dotenv via `loadDotEnvFiles([]string{".env.local", ".env"}, ...)` — **relative**, i.e. against the process cwd.
- `resolveConfigPath` defaults to `".dir2mcp.yaml"` — **relative**, against the process cwd.
- `persistAndWarnCredentials(sc.workingDir, ...)` writes `.env.local` there, and systemd renders `EnvironmentFile=<WorkingDir>/.env.local`.

If the booted daemon's cwd were the state directory, then unless the operator happened to pass an explicit `--config`, the daemon would find no `.dir2mcp.yaml` there and boot on **pure defaults** — including `source.kind: local`. That silently converts an S3 deployment into a local one. The config file's own directory is the only choice that keeps all three consistent: the daemon rediscovers the same config and the same `.env.local` the operator installed from, which is also where `dir2mcp config init` writes credentials.

It also demonstrably exists: it is `filepath.Dir` of the absolute resolved config path, i.e. the installing process's cwd in the default case. For the one case where it may not exist (an explicit `--config` naming a path under a missing directory), the fallback is the **state directory** — always local per §7.8, and already `MkdirAll`'d by `runServiceInstall` before the unit is written. Both are asserted by tests.

**3. Coupled path resolution.** A relative `state_dir` is resolved by the booted daemon against *its* working directory, so install must use the same base or it would create and log into a different directory than the daemon opens. `resolveServiceDirs` now returns both together. For `local`/`nfs` the base is still `abs(RootDir)`, so this is byte-identical to before.

**4. Propagated `--config`/`--state-dir` are absolutized.** A relative `--config` was copied verbatim into the unit and then re-resolved by the daemon against its own working directory, which is not the cwd the operator ran install from. `--state-dir` now propagates the already-resolved `sc.stateDir` (the same directory install creates and writes `service.log` into), which is semantically identical to the old relative value whenever the daemon cwd equals the install base — i.e. always, for local corpora. This is the substance of **#721** (*"service: relative --config and --state-dir paths are reinterpreted after install"*), which I did not set out to fix: it became load-bearing here, because moving the remote working directory off the corpus root changes what a relative `--config` resolves to. **#721 can be closed or re-scoped against this PR.** The only case where a local corpus behaves differently is `--config <relative>` invoked from a cwd other than the corpus root, where the previous unit pointed at a path that does not exist.

## Local corpora do not regress

`TestServiceContext_LocalAndNFSKeepCorpusRootWorkingDir_738` pins `kind` in `{"", "local", "nfs"}` to `workingDir == abs(RootDir)` and `stateDir == RootDir/.dir2mcp` even when the config file lives elsewhere. `TestUpLocalSourceStillRequiresLocalRoot_738` and `TestUpNFSSourceStillRequiresLocalRoot_738` pin that a missing root is still a hard `root inaccessible` startup failure. Both of those two passed on the pre-fix tree as well, which is the point — they are the control.

## Tests

`tests/cli/s3_no_local_root_738_test.go` (new):
- `TestUpS3SourceDoesNotRequireLocalRoot_738` — **fails on the pre-fix tree** with `root inaccessible` (output above). Drives the real `up --foreground` path with a valid s3 config, absent local root, and no embed provider, so the assertion is bounded: startup must reach the embed preflight (the very next check) and fail *there* instead.
- `TestUpLocalSourceStillRequiresLocalRoot_738`, `TestUpNFSSourceStillRequiresLocalRoot_738` — controls; pass before and after.

`internal/cli/service_test.go` (appended to the existing, already-allowlisted file, so `tests/security/cli_boundary_test.go` needs no change — no new file under `internal/cli/`):
- `TestServiceContext_S3AnchorsWorkingDirOnConfigDir_738`
- `TestServiceContext_S3RelativeStateDirFollowsWorkingDir_738`
- `TestServiceContext_S3FallsBackToStateDirWhenConfigDirMissing_738`
- `TestServiceContext_LocalAndNFSKeepCorpusRootWorkingDir_738`
- `TestRenderedUnitsUseAnExistingWorkingDirForS3_738` — renders both the launchd plist and the systemd unit and asserts the rendered `WorkingDirectory` exists and that neither unit references the ignored local corpus root anywhere.
- `TestInstallServiceArgs_PropagatesAbsolutePaths_738`

These service-layer tests are written against the new `serviceContextFromConfig(cfg, nameOverride, configPath)` signature, so on the pre-fix tree they do not compile rather than fail. The defect they encode was verified separately with the throwaway probe quoted at the top, which ran against the unmodified implementation and showed `workingDir` pointing at the nonexistent root.

`make check` passes (vet, golangci-lint 0 issues, gocyclo `-over 15`, misspell, full suite, python).

## Other local-root assumptions I found, and did not fix here

I swept the rest of the startup path. Everything else on it is already remote-safe: `EmbeddingWorker` prefers `Corpus` over `RootDir`, retrieval gets `SetCorpusFS` for remote sources (#432), and `openScanCache` already skips non-local kinds. What remains is out of scope for #738 and, in almost every case, **already tracked**:

- **`ingest.Watch` registers fsnotify on `abs(cfg.RootDir)`** for every kind. For S3 this is not fatal — `addWatchDirs` fails, logs one line, and the loop degrades to the 10-minute safety rescan, which does walk S3 via CorpusFS — but the log line is misleading. Already **#695**.
- **`mcp.Server.resolveDocumentPath`** (on-demand transcribe/annotate) joins and `EvalSymlinks`es `cfg.RootDir`, so those tools cannot read an S3 corpus. `resolveRoot` (list_files) already degrades gracefully. Related open items: **#684**, **#736**, **#734**. The transcribe/annotate path specifically does not appear to be filed — flagging it here rather than filing a near-duplicate.
- **`internal/cli/export_ttml.go:132`** joins `cfg.RootDir` for the media path (same family as **#736** / **#729** / **#730**).
- **`config.load` reads `.env.local` relative to cwd, not to `--config`'s directory** — **#677**. The remote working-dir choice here aligns with, rather than contradicts, whatever #677 lands on.

Deliberately untouched: `resolveServerName` / instance-identity derivation (**#737**). The #738 tests show the derived name still tracking the ignored local root (`dir2mcp-dev-does-not-exist-<hash>`), which is exactly #737's subject; I left it for that PR and shaped the assertions so they do not depend on it.

## Docs

`docs/dual-machine-deployment.md` §2.3 now states plainly that `source.kind: s3` needs no local corpus directory, that only the state directory must be local, and where `service install` anchors the daemon for a remote source.
