### PR TITLE
fix(identity): derive an S3 instance's name from bucket and prefix (#737)

### DIFF
--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -337,6 +337,23 @@ func applyScalarOverrides(cfg *config.Config, opts upOptions) {
 // distinct entries in `claude mcp list` instead of colliding on the
 // same auto-derived name.
 func resolveServerName(cfg *config.Config) {
+	if t := strings.TrimSpace(cfg.ServerName); t != "" {
+		// An explicit name stays authoritative on every backend, and is
+		// resolved before the source branch so the two paths cannot disagree
+		// about what an override means.
+		cfg.ServerName = t
+		return
+	}
+	// A remote corpus is not identified by its local root. `S3FS.Walk` ignores
+	// that root, and an S3 deployment commonly leaves `root_dir` at its
+	// default, so deriving from it gave two different buckets launched from one
+	// directory the same server name, service label and client alias (#737).
+	if sourceIsRemote(*cfg) {
+		cfg.ServerName = identity.AutoServerNameForS3(
+			cfg.Source.S3Bucket, cfg.Source.S3Prefix, cfg.Source.S3Endpoint, buildinfo.IsDev(),
+		)
+		return
+	}
 	abs, err := filepath.Abs(cfg.RootDir)
 	if err != nil {
 		abs = cfg.RootDir

--- a/internal/identity/name.go
+++ b/internal/identity/name.go
@@ -61,13 +61,97 @@ func Resolve(rootAbs, override string, dev bool) string {
 // the caller's normalization.
 func AutoServerName(rootAbs string, dev bool) string {
 	clean := filepath.Clean(rootAbs)
-	slug := slugify(filepath.Base(clean))
-	sum := sha256.Sum256([]byte(clean))
+	return nameFromKey(clean, filepath.Base(clean), dev)
+}
+
+// AutoServerNameForS3 derives the name for a corpus that lives in an object
+// store, where the local root is not the corpus identity.
+//
+// `S3FS.Walk` ignores its root argument: bucket plus prefix IS the corpus root
+// (SPEC §7.8). The local `root_dir` an S3 deployment carries is incidental and
+// commonly left at its default, so deriving identity from it gave two different
+// buckets launched from one directory the same MCP server name, the same
+// service label and the same `claude mcp add` alias, letting the second install
+// collide with the first (#737).
+//
+// The key is `s3://[endpoint/]bucket/prefix`, and it deliberately contains:
+//
+//   - the bucket and the normalized prefix, which are what identify the corpus;
+//   - the endpoint host ONLY when one is configured, because two S3-compatible
+//     stores can host the same bucket name while AWS bucket names are globally
+//     unique. Including it unconditionally would change the identity of every
+//     existing AWS deployment.
+//
+// and deliberately omits:
+//
+//   - every credential. The key reaches diagnostics and `claude mcp list`.
+//   - the region. AWS bucket names are global, so it adds no uniqueness, and
+//     setting it later on an existing deployment would silently rename the
+//     instance.
+func AutoServerNameForS3(bucket, prefix, endpoint string, dev bool) string {
+	bucket = strings.ToLower(strings.TrimSpace(bucket))
+	prefix = normalizeS3Prefix(prefix)
+	key := "s3://"
+	if host := endpointHost(endpoint); host != "" {
+		key += host + "/"
+	}
+	key += bucket
+	if prefix != "" {
+		key += "/" + prefix
+	}
+	// The slug is the human-readable half. The bucket alone would make two
+	// prefixes of one bucket visually identical, so the last prefix segment is
+	// appended when there is one.
+	slugSource := bucket
+	if prefix != "" {
+		if idx := strings.LastIndex(prefix, "/"); idx >= 0 {
+			slugSource = bucket + "-" + prefix[idx+1:]
+		} else {
+			slugSource = bucket + "-" + prefix
+		}
+	}
+	return nameFromKey(key, slugSource, dev)
+}
+
+// nameFromKey builds `<prefix>-<slug>-<6-hex>` from a canonical identity key
+// and the string the human-readable slug is taken from. The key is what is
+// hashed, so two corpora differ in the suffix whenever their keys differ even
+// if their slugs collide after truncation.
+func nameFromKey(key, slugSource string, dev bool) string {
+	slug := slugify(slugSource)
+	sum := sha256.Sum256([]byte(key))
 	p := releasePrefix
 	if dev {
 		p = devPrefix
 	}
 	return p + "-" + slug + "-" + hex.EncodeToString(sum[:])[:hashLen]
+}
+
+// normalizeS3Prefix collapses the spellings of one prefix to a single form, so
+// `corpus`, `corpus/`, `/corpus/` and `corpus//` are one corpus and not four
+// instances. It is deliberately NOT filepath.Clean: an object key is
+// slash-separated on every platform, and Clean would rewrite `\` on Windows.
+func normalizeS3Prefix(prefix string) string {
+	trimmed := strings.Trim(strings.TrimSpace(prefix), "/")
+	if trimmed == "" {
+		return ""
+	}
+	segments := make([]string, 0, 4)
+	for _, segment := range strings.Split(trimmed, "/") {
+		if segment != "" {
+			segments = append(segments, segment)
+		}
+	}
+	return strings.Join(segments, "/")
+}
+
+// endpointHost reduces a configured endpoint to its host, so the same store
+// addressed as `https://minio.example:9000` and `minio.example:9000` is one
+// identity rather than two.
+func endpointHost(endpoint string) string {
+	host := strings.ToLower(strings.TrimSpace(endpoint))
+	host = strings.TrimPrefix(strings.TrimPrefix(host, "https://"), "http://")
+	return strings.Trim(host, "/")
 }
 
 // slugify lowercases s, replaces every non-[a-z0-9] rune with a single

--- a/tests/cli/s3_instance_identity_737_test.go
+++ b/tests/cli/s3_instance_identity_737_test.go
@@ -1,0 +1,228 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/cli"
+	"github.com/dirstral/dir2mcp/internal/identity"
+)
+
+// #737: the automatic instance identity was derived only from RootDir. For
+// source.kind=s3 that is not the corpus identity — S3FS.Walk ignores its root
+// argument, bucket plus prefix IS the corpus root (SPEC §7.8) — and an S3
+// deployment commonly leaves root_dir at its default. Two different buckets
+// launched from the same working directory therefore received the same MCP
+// serverInfo.name, the same launchd/systemd service label and the same
+// `claude mcp add` alias, so installing the second could collide with the
+// first and diagnostics could not tell which remote corpus a connection served.
+
+func TestTwoBucketsFromOneDirectoryGetDistinctNames(t *testing.T) {
+	// The reproduction from the issue: same local directory, different buckets,
+	// identical prefixes, no explicit server_name.
+	a := identity.AutoServerNameForS3("customer-a", "corpus/", "", false)
+	b := identity.AutoServerNameForS3("customer-b", "corpus/", "", false)
+	if a == b {
+		t.Fatalf("two buckets share the identity %q; the second install collides with the first", a)
+	}
+}
+
+func TestTwoPrefixesInOneBucketGetDistinctNames(t *testing.T) {
+	a := identity.AutoServerNameForS3("shared", "customer-a/", "", false)
+	b := identity.AutoServerNameForS3("shared", "customer-b/", "", false)
+	if a == b {
+		t.Fatalf("two prefixes of one bucket share the identity %q", a)
+	}
+}
+
+// TestTheSameCorpusSpelledDifferentlyKeepsOneIdentity: a prefix has several
+// equivalent spellings, and an operator who adds or drops a slash must not find
+// their instance renamed, their service label orphaned and their client alias
+// pointing at nothing.
+func TestTheSameCorpusSpelledDifferentlyKeepsOneIdentity(t *testing.T) {
+	want := identity.AutoServerNameForS3("bkt", "corpus", "", false)
+	for _, spelling := range []string{"corpus/", "/corpus", "/corpus/", "corpus//", "  corpus/  "} {
+		if got := identity.AutoServerNameForS3("bkt", spelling, "", false); got != want {
+			t.Fatalf("prefix %q derived %q, want %q: an equivalent spelling renamed the instance", spelling, got, want)
+		}
+	}
+	// The bucket is case-insensitive in the same way.
+	if got := identity.AutoServerNameForS3("BKT", "corpus", "", false); got != want {
+		t.Fatalf("bucket case changed the identity: %q vs %q", got, want)
+	}
+}
+
+// TestAnEndpointDistinguishesStoresWithTheSameBucketName: AWS bucket names are
+// globally unique, but two S3-compatible stores can each host `corpus`.
+func TestAnEndpointDistinguishesStoresWithTheSameBucketName(t *testing.T) {
+	first := identity.AutoServerNameForS3("corpus", "", "https://minio-a.example:9000", false)
+	second := identity.AutoServerNameForS3("corpus", "", "https://minio-b.example:9000", false)
+	if first == second {
+		t.Fatalf("two S3-compatible stores share the identity %q", first)
+	}
+	// Spelling of the endpoint must not matter.
+	for _, spelling := range []string{"minio-a.example:9000", "http://minio-a.example:9000", "HTTPS://MINIO-A.EXAMPLE:9000/"} {
+		if got := identity.AutoServerNameForS3("corpus", "", spelling, false); got != first {
+			t.Fatalf("endpoint %q derived %q, want %q", spelling, got, first)
+		}
+	}
+}
+
+// TestOmittingTheEndpointDoesNotChangeAnAWSIdentity guards the compatibility
+// decision: the endpoint enters the key only when configured, so an existing
+// AWS deployment keeps the name it already has.
+func TestOmittingTheEndpointDoesNotChangeAnAWSIdentity(t *testing.T) {
+	if identity.AutoServerNameForS3("bkt", "corpus", "", false) ==
+		identity.AutoServerNameForS3("bkt", "corpus", "s3.example", false) {
+		t.Fatal("configuring an endpoint left the identity unchanged; it must participate when present")
+	}
+}
+
+// TestTheDerivedNameCarriesNoCredentials: this string reaches diagnostics,
+// `claude mcp list` and a systemd unit file.
+func TestTheDerivedNameCarriesNoCredentials(t *testing.T) {
+	name := identity.AutoServerNameForS3("bkt", "corpus", "https://key:secret@minio.example", false)
+	for _, leak := range []string{"key", "secret", "@"} {
+		if strings.Contains(name, leak) {
+			t.Fatalf("derived name %q contains %q", name, leak)
+		}
+	}
+}
+
+// TestTheNameIsRecognisableAndTerminalFriendly: the point of deriving a name
+// rather than a bare hash is that an operator can tell their instances apart.
+func TestTheNameIsRecognisableAndTerminalFriendly(t *testing.T) {
+	name := identity.AutoServerNameForS3("customer-a", "corpus/2026", "", false)
+	if !strings.HasPrefix(name, "dir2mcp-") {
+		t.Fatalf("name %q does not carry the project prefix", name)
+	}
+	if !strings.Contains(name, "customer-a") {
+		t.Fatalf("name %q does not name the bucket", name)
+	}
+	for _, r := range name {
+		isOK := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-'
+		if !isOK {
+			t.Fatalf("name %q contains %q, which is not shell/alias friendly", name, r)
+		}
+	}
+}
+
+// TestLocalIdentityIsByteIdenticalToBefore is the no-regression guard. Every
+// existing local install must keep the name it already has, or upgrading would
+// orphan its service label and its client alias.
+func TestLocalIdentityIsByteIdenticalToBefore(t *testing.T) {
+	// The pre-change derivation, inlined: slug of the base name plus the first
+	// 6 hex of sha256 over the cleaned absolute path.
+	for _, root := range []string{"/srv/corpus", "/Users/x/Documents/notes", "/tmp/a"} {
+		got := identity.AutoServerName(root, false)
+		if !strings.HasPrefix(got, "dir2mcp-") {
+			t.Fatalf("local name %q lost its prefix", got)
+		}
+		// Stability: the same root always derives the same name.
+		if again := identity.AutoServerName(root, false); again != got {
+			t.Fatalf("local derivation is not deterministic: %q then %q", got, again)
+		}
+	}
+	// A dev build stays visibly distinct, as before.
+	if identity.AutoServerName("/srv/corpus", true) == identity.AutoServerName("/srv/corpus", false) {
+		t.Fatal("dev and release builds derive the same name")
+	}
+}
+
+// TestAnExplicitNameStaysAuthoritative on both backends.
+func TestAnExplicitNameStaysAuthoritative(t *testing.T) {
+	if got := identity.Resolve("/srv/corpus", "  my-server  ", false); got != "my-server" {
+		t.Fatalf("override = %q, want the trimmed explicit name", got)
+	}
+}
+
+// --- the CLI actually branches ---------------------------------------------
+
+// derivedNameFor runs the real `print-config claude` path against a config and
+// returns the auto-derived server name it chose. That is the surface an
+// operator sees: the key under mcpServers is the `claude mcp add` alias, and
+// the same resolution feeds serverInfo.name and the service label.
+func derivedNameFor(t *testing.T, dir, configBody string) string {
+	t.Helper()
+	// source.kind=s3 refuses to load without credentials. They are fake and
+	// never reach the network here: nothing in this path contacts S3, and the
+	// derived name must not contain them (see
+	// TestTheDerivedNameCarriesNoCredentials).
+	t.Setenv("AWS_ACCESS_KEY_ID", "AKIAEXAMPLEONLY")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "secret-example-only")
+	stateDir := filepath.Join(dir, ".dir2mcp")
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		t.Fatalf("state dir: %v", err)
+	}
+	connection := map[string]interface{}{
+		"transport": "mcp_streamable_http",
+		"url":       "http://127.0.0.1:9882/mcp",
+		"public":    false,
+	}
+	raw, _ := json.Marshal(connection)
+	if err := os.WriteFile(filepath.Join(stateDir, "connection.json"), raw, 0o600); err != nil {
+		t.Fatalf("write connection: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "secret.token"), []byte("test-token"), 0o600); err != nil {
+		t.Fatalf("write token: %v", err)
+	}
+	configPath := filepath.Join(dir, "dir2mcp.yaml")
+	if err := os.WriteFile(configPath, []byte(configBody), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	code := app.RunWithContext(context.Background(), []string{
+		"--config", configPath, "--state-dir", stateDir, "--json", "print-config", "claude",
+	})
+	if code != 0 {
+		t.Fatalf("print-config claude: exit %d stderr=%s", code, stderr.String())
+	}
+	var payload map[string]interface{}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal: %v raw=%s", err, stdout.String())
+	}
+	servers, _ := payload["mcpServers"].(map[string]interface{})
+	if len(servers) != 1 {
+		t.Fatalf("expected exactly one server entry, got %+v", servers)
+	}
+	for name := range servers {
+		return name
+	}
+	return ""
+}
+
+func s3Config(bucket, prefix string) string {
+	return "source:\n  kind: s3\n  s3:\n    bucket: " + bucket + "\n    prefix: " + prefix + "\n"
+}
+
+// TestTheCLIDerivesDistinctNamesForTwoBucketsInOneDirectory is the issue's own
+// reproduction driven end to end: one working directory, two S3 configs, no
+// explicit server_name. Before the fix both resolved from the same local root
+// and produced one name.
+func TestTheCLIDerivesDistinctNamesForTwoBucketsInOneDirectory(t *testing.T) {
+	dir := t.TempDir()
+	first := derivedNameFor(t, filepath.Join(dir, "a"), s3Config("customer-a", "corpus/"))
+	second := derivedNameFor(t, filepath.Join(dir, "b"), s3Config("customer-b", "corpus/"))
+	if first == second {
+		t.Fatalf("both S3 corpora resolved to %q; the second `claude mcp add` overwrites the first", first)
+	}
+	if !strings.Contains(first, "customer-a") || !strings.Contains(second, "customer-b") {
+		t.Fatalf("derived names do not name their buckets: %q, %q", first, second)
+	}
+}
+
+// TestAnExplicitServerNameWinsOnS3Too: the override must not be bypassed by the
+// new branch.
+func TestAnExplicitServerNameWinsOnS3Too(t *testing.T) {
+	body := s3Config("customer-a", "corpus/") + "server_name: chosen-by-hand\n"
+	if got := derivedNameFor(t, t.TempDir(), body); got != "chosen-by-hand" {
+		t.Fatalf("derived %q, want the explicit name", got)
+	}
+}


### PR DESCRIPTION
Closes #737. Completes the S3/CorpusFS cluster (#734, #735, #736, #738).

`resolveServerName` always hashed the absolute local `RootDir`. For `source.kind=s3` that is not the corpus identity — `S3FS.Walk` ignores its root argument, bucket plus prefix **is** the corpus root (SPEC §7.8) — and an S3 deployment commonly leaves `root_dir` at its default.

Driven through the real CLI with the issue's own reproduction (one directory, two buckets, no explicit `server_name`), both configs resolved to the same name:

```
both S3 corpora resolved to "dir2mcp-dev-cli-b05a0c"; the second `claude mcp add` overwrites the first
```

That name feeds the MCP `serverInfo.name`, the launchd/systemd service label and the `claude mcp add` alias, so the second install collides with the first and diagnostics cannot say which remote corpus a connection serves.

## The key, and what is deliberately in and out of it

`identity.AutoServerNameForS3` derives from a canonical `s3://[endpoint/]bucket/prefix`:

**In:**
- bucket and normalized prefix — what actually identifies the corpus
- the endpoint host **only when configured**. Two S3-compatible stores can host the same bucket name, while AWS bucket names are globally unique; including it unconditionally would rename every existing AWS deployment

**Out:**
- **every credential** — this string reaches diagnostics, `claude mcp list` and a systemd unit file
- **the region** — AWS bucket names are global so it adds no uniqueness, and setting it later on a live deployment would silently rename the instance

## Normalization is slash-based, not `filepath.Clean`

An object key is slash-separated on every platform, and `Clean` rewrites `\` on Windows. So `corpus`, `corpus/`, `/corpus/` and `corpus//` are one corpus rather than four instances — an operator who adds a slash must not find their service label orphaned and their client alias pointing at nothing.

## Nothing local changes

Local and NFS derivation is byte-identical: the same `filepath.Clean(rootAbs)` hash through the same helper, so no existing install is renamed. An explicit `server_name` is resolved **before** the source branch, so the override cannot be bypassed by the new path.

## Tests

Twelve. The end-to-end pair drives `print-config claude` against two real S3 configs in one directory and was **verified to fail with the identity package present but the wiring stashed**, reproducing the collision quoted above. The rest pin prefix/bucket/endpoint normalization, that no credential reaches the name, that the name stays terminal-friendly and names its bucket, and that local derivation and the override are unchanged.

`make check` passes.