### PR TITLE
fix(reindex): recover a crashed run's backups instead of destroying them (#727)

### DIFF
--- a/internal/cli/reindex.go
+++ b/internal/cli/reindex.go
@@ -278,6 +278,14 @@ func recoverInterruptedReindex(stateDir string, stderr io.Writer) error {
 		if name == reindexBackupSuffix || !strings.HasSuffix(name, reindexBackupSuffix) {
 			continue
 		}
+		// Only regular files are ours: staging produces a backup by renaming an
+		// index file, never a directory or a symlink. Renaming something of
+		// another shape into the live slot would move an unrelated path (or
+		// point the index at an arbitrary target), so leave it alone and let
+		// backup() refuse the occupied slot with its own explicit error.
+		if !entry.Type().IsRegular() {
+			continue
+		}
 		live := strings.TrimSuffix(name, reindexBackupSuffix)
 		if err := os.Rename(filepath.Join(stateDir, name), filepath.Join(stateDir, live)); err != nil {
 			return fmt.Errorf("restore last-known-good index %s: %w", live, err)

--- a/internal/cli/reindex.go
+++ b/internal/cli/reindex.go
@@ -171,6 +171,11 @@ const reindexBackupSuffix = ".reindex-old"
 // AND keeps its content hashes so the next incremental sync does not reprocess
 // the whole corpus (issue #418). A nil-safe zero value (no state dir, no
 // backups, no hash backup) makes every operation a no-op.
+//
+// Neither commit nor rollback runs when the process is killed outright, so the
+// artifacts staged here are also the on-disk recovery record a crashed run
+// leaves behind; recoverInterruptedReindex reads them back on the next run
+// (issue #727).
 type reindexStaging struct {
 	stateDir string
 	backups  []string // basenames moved to name+reindexBackupSuffix
@@ -210,13 +215,22 @@ func (s *reindexStaging) discardContentHashBackup(ctx context.Context, stderr io
 }
 
 // backup renames stateDir/name aside to name+reindexBackupSuffix. A missing
-// source is a no-op (nothing to preserve). Any pre-existing backup from an
-// earlier interrupted run is cleared first so the rename can land.
+// source is a no-op (nothing to preserve).
+//
+// The backup slot is expected to be free: recoverInterruptedReindex runs first
+// and restores any generation an earlier crashed run left there (issue #727).
+// A backup still present at this point therefore means recovery did not do its
+// job, and it is by construction a complete previous generation while the file
+// about to overwrite it may be a crashed run's partial output. So this refuses
+// rather than clobbers: it used to os.Remove the destination first, which is
+// exactly how the last-known-good generation got destroyed.
 func (s *reindexStaging) backup(name string) error {
 	src := filepath.Join(s.stateDir, name)
 	dst := src + reindexBackupSuffix
-	if err := os.Remove(dst); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("clear stale backup %s: %w", dst, err)
+	if _, err := os.Lstat(dst); err == nil {
+		return fmt.Errorf("refusing to overwrite existing backup %s: it holds an unrecovered index generation", dst)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("inspect backup %s: %w", dst, err)
 	}
 	if err := os.Rename(src, dst); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -225,6 +239,55 @@ func (s *reindexStaging) backup(name string) error {
 		return fmt.Errorf("move aside %s: %w", src, err)
 	}
 	s.backups = append(s.backups, name)
+	return nil
+}
+
+// recoverInterruptedReindex finishes the rollback that a crashed reindex never
+// got to run, and must be called before any new generation is staged.
+//
+// A reindex that is killed (SIGKILL, OOM, power loss) leaves the previous,
+// complete index in stateDir/<name>+reindexBackupSuffix and its own partial
+// output live at stateDir/<name>. Nothing in-process cleans that up: rollback
+// only runs for handled failures and Ctrl-C. The backup slot is therefore the
+// last-known-good generation, and the next run must not treat it as its own
+// leftover to overwrite (issue #727).
+//
+// Policy: adopt. Every *.reindex-old file is renamed back over whatever is live
+// before staging starts, which is exactly the rollback the crashed run owed us.
+// This is safe by construction: a backup file is only ever produced by an
+// atomic rename of a file that was complete and live, so it is never partial,
+// while the live file after a crash may be anything. Restoring is a single
+// rename (not remove-then-rename) so a crash inside recovery itself can never
+// leave neither copy.
+//
+// Recovery failure is fatal to the run: if the good generation cannot be put
+// back, staging would move the partial file into the recovery slot and destroy
+// it, so the caller aborts with the error instead.
+func recoverInterruptedReindex(stateDir string, stderr io.Writer) error {
+	entries, err := os.ReadDir(stateDir)
+	if err != nil {
+		return fmt.Errorf("scan state dir %s: %w", stateDir, err)
+	}
+	var recovered []string
+	for _, entry := range entries {
+		name := entry.Name()
+		// Scan by suffix rather than iterating index.StaleIndexFiles for the
+		// configured backend: a crash under one backend can be retried under
+		// another, and the leftovers of the backend that crashed are part of
+		// the same last-known-good set.
+		if name == reindexBackupSuffix || !strings.HasSuffix(name, reindexBackupSuffix) {
+			continue
+		}
+		live := strings.TrimSuffix(name, reindexBackupSuffix)
+		if err := os.Rename(filepath.Join(stateDir, name), filepath.Join(stateDir, live)); err != nil {
+			return fmt.Errorf("restore last-known-good index %s: %w", live, err)
+		}
+		recovered = append(recovered, live)
+	}
+	if len(recovered) > 0 {
+		writef(stderr, "warning: recovered %d index file(s) left by an interrupted reindex before rebuilding: %s\n",
+			len(recovered), strings.Join(recovered, ", "))
+	}
 	return nil
 }
 
@@ -239,13 +302,15 @@ func (s *reindexStaging) commit() {
 // rollback restores the moved-aside index files over any partially-written
 // rebuild so an interrupted or failed reindex leaves the previous, working
 // index intact. Best-effort: warnings are logged but never fail teardown.
+//
+// The restore is a single rename over the partial file rather than a remove
+// followed by a rename: the two-step version had a window in which neither copy
+// existed, and a crash inside it lost the generation outright. Rename replaces
+// the destination atomically on both unix and Windows (issue #727).
 func (s *reindexStaging) rollback(stderr io.Writer) {
 	for _, name := range s.backups {
 		dst := filepath.Join(s.stateDir, name)
 		src := dst + reindexBackupSuffix
-		if err := os.Remove(dst); err != nil && !errors.Is(err, os.ErrNotExist) {
-			writef(stderr, "warning: reindex rollback: remove partial %s: %v\n", dst, err)
-		}
 		if err := os.Rename(src, dst); err != nil && !errors.Is(err, os.ErrNotExist) {
 			writef(stderr, "warning: reindex rollback: restore %s: %v\n", dst, err)
 		}
@@ -271,23 +336,22 @@ func (a *App) prepareReindexStore(ctx context.Context, global globalOptions, cfg
 		writeCLIError(a.stderr, global.jsonOutput, exitRootInaccessible, fmt.Sprintf("secure state dir: %v", err))
 		return nil, nil, exitRootInaccessible
 	}
+	// Complete an earlier crashed run's rollback BEFORE staging anything, or the
+	// staging below would move that run's partial output into the recovery slot
+	// and delete the only good generation (issue #727).
+	if err := recoverInterruptedReindex(cfg.StateDir, a.stderr); err != nil {
+		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("recover interrupted reindex: %v", err),
+			"The previous index generation is still on disk as *"+reindexBackupSuffix+" in the state directory; fix the error above and re-run `dir2mcp reindex`.")
+		return nil, nil, exitGeneric
+	}
 	st := a.storeForConfig(cfg)
 	if err := st.Init(ctx); err != nil && !errors.Is(err, model.ErrNotImplemented) {
 		_ = st.Close()
 		writeStoreInitError(a.stderr, global.jsonOutput, exitIndexLoadFailure, err, fmt.Sprintf("initialize metadata store: %v", err))
 		return nil, nil, exitIndexLoadFailure
 	}
-	// Snapshot the content-hash gate BEFORE clearing it so an interrupted or
-	// failed rebuild can restore the incremental "already indexed" state instead
-	// of reprocessing the whole corpus on the next sync (issue #418). Behind an
-	// optional-capability interface so non-sqlite stores degrade gracefully.
-	if b, ok := interface{}(st).(contentHashBackuper); ok {
-		if err := b.BackupContentHashes(ctx); err != nil {
-			_ = st.Close()
-			writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("snapshot content hashes: %v", err))
-			return nil, nil, exitGeneric
-		}
-		staging.hashBackup = b
+	if code := a.snapshotContentHashes(ctx, global, st, staging); code != exitSuccess {
+		return nil, nil, code
 	}
 	if code := clearContentHashesIfSupported(ctx, st, a.stderr, global.jsonOutput); code != exitSuccess {
 		staging.discardContentHashBackup(ctx, a.stderr)
@@ -311,6 +375,42 @@ func (a *App) prepareReindexStore(ctx context.Context, global globalOptions, cfg
 		}
 	}
 	return st, staging, exitSuccess
+}
+
+// snapshotContentHashes takes the pre-clear documents.content_hash snapshot the
+// rollback path restores from, after first completing the store-side rollback a
+// crashed run never ran.
+//
+// Order matters. A crashed reindex leaves its own snapshot table behind with the
+// live hashes cleared, so that table — not the live column — is the
+// last-known-good state. Restoring it first means the new snapshot captures the
+// real hashes; re-snapshotting straight away would capture the cleared values
+// and drop the good ones on the floor (issue #727). RestoreContentHashes is a
+// no-op when no snapshot exists, which is the normal, non-crashed case.
+//
+// Restore failure is fatal: the good snapshot may still be there and taking a
+// new one would overwrite it.
+//
+// Behind an optional-capability interface so non-sqlite stores degrade
+// gracefully (issue #418). Closes the store on failure; the caller owns it on
+// success.
+func (a *App) snapshotContentHashes(ctx context.Context, global globalOptions, st model.Store, staging *reindexStaging) int {
+	b, ok := interface{}(st).(contentHashBackuper)
+	if !ok {
+		return exitSuccess
+	}
+	if err := b.RestoreContentHashes(ctx); err != nil {
+		_ = st.Close()
+		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("recover interrupted reindex: restore content hashes: %v", err))
+		return exitGeneric
+	}
+	if err := b.BackupContentHashes(ctx); err != nil {
+		_ = st.Close()
+		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("snapshot content hashes: %v", err))
+		return exitGeneric
+	}
+	staging.hashBackup = b
+	return exitSuccess
 }
 
 // finishReindex maps the ingestor's return error to the user-facing exit

--- a/tests/cli/reindex_backup_preservation_727_test.go
+++ b/tests/cli/reindex_backup_preservation_727_test.go
@@ -1,0 +1,259 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/cli"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/index/diskindex"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// Issue #727: a reindex that CRASHED (SIGKILL / power loss) never runs its
+// in-process rollback, so it leaves the last-known-good generation on disk:
+//
+//   - <index file>.reindex-old   — the previous, complete index (atomic rename)
+//   - _reindex_hash_backup       — the pre-clear documents.content_hash snapshot
+//
+// while the live index file is the crashed run's partial output and the live
+// content hashes are cleared. The next `reindex` used to treat those recovery
+// copies as its own leftovers: it deleted the good `.reindex-old` file and
+// rotated the partial live file into its place, and re-snapshotted the cleared
+// hashes over the good snapshot. The first retry after a crash therefore
+// destroyed the only good generation.
+//
+// These tests simulate a crash the way a crash actually happens — by leaving
+// the interrupted run's artifacts in place, never by calling the rollback path,
+// which is precisely what does not run on a crash.
+
+const (
+	crashGoodIndex    = "LAST-KNOWN-GOOD-INDEX"
+	crashPartialIndex = "PARTIAL-REBUILD-FROM-CRASHED-RUN"
+	crashGoodHash     = "HASH-BEFORE-CRASHED-REINDEX"
+)
+
+// seedCrashedReindexState lays down the on-disk and in-store state a crashed
+// reindex leaves behind: the good index moved aside to *.reindex-old with the
+// crashed run's partial output live, plus the content-hash snapshot table with
+// the live hashes cleared. Returns the live index path.
+func seedCrashedReindexState(t *testing.T, stateDir, relPath string) string {
+	t.Helper()
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	live := filepath.Join(stateDir, index.TextIndexFileName)
+	// The crashed run had already renamed the good index aside...
+	if err := os.WriteFile(live+".reindex-old", []byte(crashGoodIndex), 0o600); err != nil {
+		t.Fatalf("seed backup index: %v", err)
+	}
+	// ...and had written part of the new one before it was killed.
+	if err := os.WriteFile(live, []byte(crashPartialIndex), 0o600); err != nil {
+		t.Fatalf("seed partial index: %v", err)
+	}
+	seedCrashedHashState(t, stateDir, relPath)
+	return live
+}
+
+// seedCrashedHashState reproduces the store side of a crashed reindex: a
+// document whose good hash is captured in _reindex_hash_backup while the live
+// documents.content_hash has been cleared. It drives the real store calls the
+// staging path makes (BackupContentHashes then ClearDocumentContentHashes) and
+// then simply stops, standing in for the process being killed.
+func seedCrashedHashState(t *testing.T, stateDir, relPath string) {
+	t.Helper()
+	ctx := context.Background()
+	st := store.NewSQLiteStore(filepath.Join(stateDir, "meta.sqlite"))
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("crash-seed Init: %v", err)
+	}
+	if err := st.UpsertDocument(ctx, model.Document{
+		RelPath:     relPath,
+		DocType:     "md",
+		ContentHash: crashGoodHash,
+		Status:      "ready",
+	}); err != nil {
+		t.Fatalf("crash-seed UpsertDocument: %v", err)
+	}
+	if err := st.BackupContentHashes(ctx); err != nil {
+		t.Fatalf("crash-seed BackupContentHashes: %v", err)
+	}
+	if err := st.ClearDocumentContentHashes(ctx); err != nil {
+		t.Fatalf("crash-seed ClearDocumentContentHashes: %v", err)
+	}
+	// No rollback, no commit: the process "dies" here.
+	if err := st.Close(); err != nil {
+		t.Fatalf("crash-seed Close: %v", err)
+	}
+}
+
+// runReindexInDir runs `dir2mcp reindex` with the given ingestor hook from tmp
+// as the working directory and returns the exit code and stderr.
+func runReindexInDir(t *testing.T, tmp string, newIngestor func(config.Config, model.Store) (model.Ingestor, error)) (int, string) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIOAndHooks(&stdout, &stderr, cli.RuntimeHooks{NewIngestor: newIngestor})
+	var code int
+	withWorkingDir(t, tmp, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		code = app.RunWithContext(ctx, []string{"reindex"})
+	})
+	return code, stderr.String()
+}
+
+func readFileString(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
+}
+
+// TestReindex_AfterCrash_RetryPreservesLastKnownGood is the core #727
+// regression: a retry after a crash must not rotate the crashed run's partial
+// output into the recovery slot. When that retry itself fails, what is left
+// live must be the ORIGINAL good index and the ORIGINAL content hashes, not the
+// partial rebuild the crash left behind.
+func TestReindex_AfterCrash_RetryPreservesLastKnownGood(t *testing.T) {
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, ".dir2mcp")
+	const relPath = "docs/a.md"
+	live := seedCrashedReindexState(t, stateDir, relPath)
+
+	code, stderr := runReindexInDir(t, tmp, func(config.Config, model.Store) (model.Ingestor, error) {
+		return reindexFailingIngestor{}, nil
+	})
+	if code == 0 {
+		t.Fatalf("reindex should fail when the ingestor errors; got exit 0 stderr=%q", stderr)
+	}
+
+	if got := readFileString(t, live); got != crashGoodIndex {
+		t.Errorf("live index after a failed retry must be the last-known-good generation left by the crashed run; want %q got %q", crashGoodIndex, got)
+	}
+	if got := readDocumentHash(t, stateDir, relPath); got != crashGoodHash {
+		t.Errorf("content_hash after a failed retry must be the pre-crash snapshot; want %q got %q", crashGoodHash, got)
+	}
+	if _, err := os.Stat(live + ".reindex-old"); !os.IsNotExist(err) {
+		t.Errorf("no backup sidecar should linger after the retry rolled back; stat err=%v", err)
+	}
+}
+
+// TestReindex_AfterCrash_RepeatedCrashesDoNotRotatePartialState covers the
+// "repeated retries" case from the issue: however many times the rebuild
+// fails, the recovery slot must still hold the original good generation and
+// never a partial one.
+func TestReindex_AfterCrash_RepeatedCrashesDoNotRotatePartialState(t *testing.T) {
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, ".dir2mcp")
+	const relPath = "docs/a.md"
+	live := seedCrashedReindexState(t, stateDir, relPath)
+
+	for attempt := 1; attempt <= 3; attempt++ {
+		code, stderr := runReindexInDir(t, tmp, func(config.Config, model.Store) (model.Ingestor, error) {
+			return reindexFailingIngestor{}, nil
+		})
+		if code == 0 {
+			t.Fatalf("attempt %d: reindex should fail when the ingestor errors; stderr=%q", attempt, stderr)
+		}
+		if got := readFileString(t, live); got != crashGoodIndex {
+			t.Fatalf("attempt %d: live index must still be the last-known-good generation; want %q got %q", attempt, crashGoodIndex, got)
+		}
+		if got := readDocumentHash(t, stateDir, relPath); got != crashGoodHash {
+			t.Fatalf("attempt %d: content_hash must still be the pre-crash snapshot; want %q got %q", attempt, crashGoodHash, got)
+		}
+	}
+}
+
+// TestReindex_AfterCrash_RecoversEveryLeftoverGeneration covers the issue's
+// "recovery covers HNSW, disk segment + identity sidecar, and all stale/legacy
+// index files" requirement. The leftovers here include names that
+// index.StaleIndexFiles does NOT return for the configured (default, memory)
+// backend — the disk backend's segment and its identity sidecar — because a
+// crash under one backend can be retried under another, and those files are
+// just as much part of the last-known-good set.
+func TestReindex_AfterCrash_RecoversEveryLeftoverGeneration(t *testing.T) {
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, ".dir2mcp")
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	seg := diskindex.SegmentFileName(index.KindText)
+	leftovers := []string{
+		index.TextIndexFileName,
+		index.CodeIndexFileName,
+		index.LegacyIndexFileNames[0],
+		seg,
+		seg + diskindex.IdentitySidecarSuffix,
+	}
+	for _, name := range leftovers {
+		path := filepath.Join(stateDir, name)
+		if err := os.WriteFile(path+".reindex-old", []byte(crashGoodIndex+"/"+name), 0o600); err != nil {
+			t.Fatalf("seed backup %s: %v", name, err)
+		}
+		if err := os.WriteFile(path, []byte(crashPartialIndex), 0o600); err != nil {
+			t.Fatalf("seed partial %s: %v", name, err)
+		}
+	}
+
+	code, stderr := runReindexInDir(t, tmp, func(config.Config, model.Store) (model.Ingestor, error) {
+		return reindexFailingIngestor{}, nil
+	})
+	if code == 0 {
+		t.Fatalf("reindex should fail when the ingestor errors; got exit 0 stderr=%q", stderr)
+	}
+
+	for _, name := range leftovers {
+		path := filepath.Join(stateDir, name)
+		want := crashGoodIndex + "/" + name
+		if got := readFileString(t, path); got != want {
+			t.Errorf("%s must be restored from the crashed run's backup; want %q got %q", name, want, got)
+		}
+		// Recovered files stay owner-only (#726): the state tree is hardened
+		// before recovery and a rename preserves the mode.
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat %s: %v", path, err)
+		}
+		if perm := info.Mode().Perm(); perm&0o077 != 0 {
+			t.Errorf("recovered %s must stay owner-only; got mode %o", name, perm)
+		}
+	}
+}
+
+// TestReindex_AfterCrash_SuccessfulRetryClearsRecoveredBackups pins the commit
+// side: once a retry rebuilds durably, the recovered generation is no longer
+// needed and must not be left behind as a permanent second copy of the index.
+func TestReindex_AfterCrash_SuccessfulRetryClearsRecoveredBackups(t *testing.T) {
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, ".dir2mcp")
+	const relPath = "docs/a.md"
+	const rebuilt = "HASH-AFTER-REBUILD"
+	live := seedCrashedReindexState(t, stateDir, relPath)
+
+	code, stderr := runReindexInDir(t, tmp, func(_ config.Config, st model.Store) (model.Ingestor, error) {
+		return reindexRebuildingIngestor{st: st, relPath: relPath, newHash: rebuilt}, nil
+	})
+	if code != 0 {
+		t.Fatalf("reindex should succeed; got exit %d stderr=%q", code, stderr)
+	}
+	if _, err := os.Stat(live + ".reindex-old"); !os.IsNotExist(err) {
+		t.Errorf("committed reindex must not leave a recovery copy behind; stat err=%v", err)
+	}
+	if got := readDocumentHash(t, stateDir, relPath); got != rebuilt {
+		t.Errorf("committed reindex must keep the rebuild's hash; want %q got %q", rebuilt, got)
+	}
+	// The recovered generation was adopted as this run's rollback target and
+	// then committed away; the live file is whatever the rebuild left (here the
+	// stub writes none), never the crashed run's partial output.
+	if data, err := os.ReadFile(live); err == nil && string(data) == crashPartialIndex {
+		t.Errorf("the crashed run's partial index must not survive a committed retry")
+	}
+}

--- a/tests/cli/reindex_backup_preservation_727_test.go
+++ b/tests/cli/reindex_backup_preservation_727_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -37,6 +38,11 @@ const (
 	crashGoodIndex    = "LAST-KNOWN-GOOD-INDEX"
 	crashPartialIndex = "PARTIAL-REBUILD-FROM-CRASHED-RUN"
 	crashGoodHash     = "HASH-BEFORE-CRASHED-REINDEX"
+	// crashBackupSuffix mirrors reindexBackupSuffix in internal/cli, which is
+	// unexported. Deliberately spelled out here rather than exported from the
+	// package: the on-disk name is part of what a crashed corpus looks like to
+	// an operator, so the test should notice if it silently changes.
+	crashBackupSuffix = ".reindex-old"
 )
 
 // seedCrashedReindexState lays down the on-disk and in-store state a crashed
@@ -50,7 +56,7 @@ func seedCrashedReindexState(t *testing.T, stateDir, relPath string) string {
 	}
 	live := filepath.Join(stateDir, index.TextIndexFileName)
 	// The crashed run had already renamed the good index aside...
-	if err := os.WriteFile(live+".reindex-old", []byte(crashGoodIndex), 0o600); err != nil {
+	if err := os.WriteFile(live+crashBackupSuffix, []byte(crashGoodIndex), 0o600); err != nil {
 		t.Fatalf("seed backup index: %v", err)
 	}
 	// ...and had written part of the new one before it was killed.
@@ -81,6 +87,24 @@ func seedCrashedHashState(t *testing.T, stateDir, relPath string) {
 	}); err != nil {
 		t.Fatalf("crash-seed UpsertDocument: %v", err)
 	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("crash-seed Close: %v", err)
+	}
+	crashHashStateFromCurrent(t, stateDir)
+}
+
+// crashHashStateFromCurrent stages the store side of a reindex over whatever
+// hashes are there NOW (snapshot, then clear) and stops without resolving it,
+// standing in for the process being killed mid-run. Split out from
+// seedCrashedHashState so a second simulated crash chains onto the state the
+// previous run left rather than re-establishing a known-good one.
+func crashHashStateFromCurrent(t *testing.T, stateDir string) {
+	t.Helper()
+	ctx := context.Background()
+	st := store.NewSQLiteStore(filepath.Join(stateDir, "meta.sqlite"))
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("crash-seed Init: %v", err)
+	}
 	if err := st.BackupContentHashes(ctx); err != nil {
 		t.Fatalf("crash-seed BackupContentHashes: %v", err)
 	}
@@ -91,6 +115,22 @@ func seedCrashedHashState(t *testing.T, stateDir, relPath string) {
 	if err := st.Close(); err != nil {
 		t.Fatalf("crash-seed Close: %v", err)
 	}
+}
+
+// recrashReindex simulates another crash on top of the CURRENT corpus state:
+// it stages whatever is live now exactly as a real run would (an atomic rename
+// into the backup slot), leaves a partial file live, and stages-then-abandons
+// the content-hash snapshot. Nothing here calls the rollback path, which is the
+// point: a crash is when rollback does not run.
+func recrashReindex(t *testing.T, stateDir, live string) {
+	t.Helper()
+	if err := os.Rename(live, live+crashBackupSuffix); err != nil {
+		t.Fatalf("re-crash stage %s: %v", live, err)
+	}
+	if err := os.WriteFile(live, []byte(crashPartialIndex), 0o600); err != nil {
+		t.Fatalf("re-crash partial index: %v", err)
+	}
+	crashHashStateFromCurrent(t, stateDir)
 }
 
 // runReindexInDir runs `dir2mcp reindex` with the given ingestor hook from tmp
@@ -141,15 +181,22 @@ func TestReindex_AfterCrash_RetryPreservesLastKnownGood(t *testing.T) {
 	if got := readDocumentHash(t, stateDir, relPath); got != crashGoodHash {
 		t.Errorf("content_hash after a failed retry must be the pre-crash snapshot; want %q got %q", crashGoodHash, got)
 	}
-	if _, err := os.Stat(live + ".reindex-old"); !os.IsNotExist(err) {
+	if _, err := os.Stat(live + crashBackupSuffix); !os.IsNotExist(err) {
 		t.Errorf("no backup sidecar should linger after the retry rolled back; stat err=%v", err)
 	}
 }
 
 // TestReindex_AfterCrash_RepeatedCrashesDoNotRotatePartialState covers the
-// "repeated retries" case from the issue: however many times the rebuild
-// fails, the recovery slot must still hold the original good generation and
-// never a partial one.
+// "repeated crashes do not rotate partial state into the recovery slot" case
+// from the issue: however many times the rebuild is killed, the recovery slot
+// must still hold the original good generation and never a partial one.
+//
+// Every pass re-crashes on top of whatever the previous pass left, rather than
+// re-establishing a known-good corpus: a run that recovered and rolled back
+// leaves no leftovers at all, so re-seeding from constants would just exercise
+// the ordinary failed-retry path three times. Chaining means that if partial
+// state were ever rotated into the recovery slot, the corruption would carry
+// forward into the next pass's assertion instead of being papered over.
 func TestReindex_AfterCrash_RepeatedCrashesDoNotRotatePartialState(t *testing.T) {
 	tmp := t.TempDir()
 	stateDir := filepath.Join(tmp, ".dir2mcp")
@@ -157,6 +204,9 @@ func TestReindex_AfterCrash_RepeatedCrashesDoNotRotatePartialState(t *testing.T)
 	live := seedCrashedReindexState(t, stateDir, relPath)
 
 	for attempt := 1; attempt <= 3; attempt++ {
+		if attempt > 1 {
+			recrashReindex(t, stateDir, live)
+		}
 		code, stderr := runReindexInDir(t, tmp, func(config.Config, model.Store) (model.Ingestor, error) {
 			return reindexFailingIngestor{}, nil
 		})
@@ -195,7 +245,7 @@ func TestReindex_AfterCrash_RecoversEveryLeftoverGeneration(t *testing.T) {
 	}
 	for _, name := range leftovers {
 		path := filepath.Join(stateDir, name)
-		if err := os.WriteFile(path+".reindex-old", []byte(crashGoodIndex+"/"+name), 0o600); err != nil {
+		if err := os.WriteFile(path+crashBackupSuffix, []byte(crashGoodIndex+"/"+name), 0o600); err != nil {
 			t.Fatalf("seed backup %s: %v", name, err)
 		}
 		if err := os.WriteFile(path, []byte(crashPartialIndex), 0o600); err != nil {
@@ -215,6 +265,11 @@ func TestReindex_AfterCrash_RecoversEveryLeftoverGeneration(t *testing.T) {
 		want := crashGoodIndex + "/" + name
 		if got := readFileString(t, path); got != want {
 			t.Errorf("%s must be restored from the crashed run's backup; want %q got %q", name, want, got)
+		}
+		// The warning is the only signal an operator gets that a previous run
+		// was interrupted, and it must name what it touched.
+		if !strings.Contains(stderr, name) {
+			t.Errorf("recovery warning must name %s; stderr=%q", name, stderr)
 		}
 		// Recovered files stay owner-only (#726): the state tree is hardened
 		// before recovery and a rename preserves the mode.
@@ -244,7 +299,7 @@ func TestReindex_AfterCrash_SuccessfulRetryClearsRecoveredBackups(t *testing.T) 
 	if code != 0 {
 		t.Fatalf("reindex should succeed; got exit %d stderr=%q", code, stderr)
 	}
-	if _, err := os.Stat(live + ".reindex-old"); !os.IsNotExist(err) {
+	if _, err := os.Stat(live + crashBackupSuffix); !os.IsNotExist(err) {
 		t.Errorf("committed reindex must not leave a recovery copy behind; stat err=%v", err)
 	}
 	if got := readDocumentHash(t, stateDir, relPath); got != rebuilt {

--- a/tests/cli/reindex_rollback_test.go
+++ b/tests/cli/reindex_rollback_test.go
@@ -115,8 +115,11 @@ func TestReindex_RestoresContentHashesOnFailure(t *testing.T) {
 		t.Fatalf("reindex should fail when the ingestor errors; got exit 0 stderr=%q", stderr.String())
 	}
 
+	// Include stderr in the failure: the restore is best-effort and only warns,
+	// so a restore that errored is otherwise invisible and a CI failure here
+	// reads as an unexplained flake with no cause attached.
 	if got := readDocumentHash(t, stateDir, relPath); got != original {
-		t.Errorf("content_hash must be restored after a failed reindex; want %q got %q", original, got)
+		t.Errorf("content_hash must be restored after a failed reindex; want %q got %q stderr=%q", original, got, stderr.String())
 	}
 }
 


### PR DESCRIPTION
Closes #727.

## The issue's claims, verified against the code

Both quoted excerpts are still accurate on `main` (`57e1bc2`), modulo line drift:

- `internal/cli/reindex.go` `reindexStaging.backup` did `os.Remove(dst)` then `os.Rename(src, dst)`, where `dst` is `<name>.reindex-old`. So the prior generation was deleted and the current (possibly partial) file rotated into its slot.
- `internal/store/sqlite_store.go` `BackupContentHashes` does `DROP TABLE IF EXISTS _reindex_hash_backup` then `CREATE TABLE ... AS SELECT doc_id, content_hash FROM documents`. So the prior snapshot was dropped and the current (possibly cleared) hashes snapshotted over it.

The issue's framing is right, and the reproduction is real. One correction to its emphasis: this is not only about the retry *failing*. The good generation is destroyed at **stage** time, before the rebuild even starts, so it is gone whether the retry succeeds, fails, or crashes again. The retry failing is just when the damage becomes visible.

## The state machine

What is on disk under `StateDir` after each outcome (`X` = an index basename from `index.StaleIndexFiles`):

| after | `X` (live) | `X.reindex-old` | `documents.content_hash` | `_reindex_hash_backup` |
|---|---|---|---|---|
| **success** (commit) | rebuild output, complete | absent (deleted by `commit`) | rebuild's fresh hashes | absent (dropped before close) |
| **handled failure / Ctrl-C** (rollback) | previous generation, restored | absent | pre-clear hashes, restored | absent |
| **crash, no rollback** | crashed run's partial output, or absent | **previous generation, complete** | cleared (`''`) | **pre-clear hashes** |

The third row is the whole issue: after a crash the *backup slot holds the only good copy* and the *live slot holds garbage*, which is the exact inverse of what the staging code assumed when it cleared the backup slot to make room.

Two properties make the recovery decidable without a new journal format:

1. A `.reindex-old` file is never partial. It is only ever produced by `os.Rename` of a file that was complete and live, and rename is atomic. Partial bytes can only ever land in the live slot.
2. `_reindex_hash_backup` existing at start-up already *is* an in-flight marker: it is created at stage time and dropped on both commit and rollback, so a run that resolved never leaves one. This also means corpora crashed by **already-released builds** recover on upgrade, which a new marker file would not have given us.

## Policy: adopt (finish the rollback the crashed run owed)

`prepareReindexStore` now runs `recoverInterruptedReindex` before staging anything: every `*.reindex-old` in the state dir is renamed back over whatever is live, and `snapshotContentHashes` calls `RestoreContentHashes` (a no-op when no snapshot exists) *before* taking the new snapshot. The corpus is put back into the "handled failure" row above, and only then does the new generation get staged.

Why adopt and not the alternatives:

- **Refuse and tell the operator.** Safest in the abstract, worst in practice: `reindex` is the command an operator runs *to recover*, and refusing it wedges exactly that path behind manual `mv` of internal file names (`vectors_text.diskv1.idx.identity.json.reindex-old`) that no doc describes. It also wedges unattended/service retries. We do keep this as the fallback: if recovery itself fails, the run aborts with the error and an actionable hint, because staging over an unrecovered generation is the one thing we must never do.
- **Move it aside under a distinct name** (`.reindex-old.1`, timestamped dir). It preserves bytes but does not solve the problem: the crashed run's partial output stays live and becomes the *new* run's rollback target, so a second failure still restores garbage. It also grows without bound under a crash loop (a corpus whose index is tens of GB, crash-looping on OOM, is precisely the population that hits this bug) and leaves the operator to work out which of N copies is good.
- **Adopt** costs one thing: if the crash happened in the narrow window *after* a successful rebuild was durable and *during* `commit`'s backup deletion, we restore the older generation over a newer good one. That is not data loss (both are complete, valid indices) and it is inert here, because recovery only ever runs at the start of a run that is about to rebuild every one of those files from scratch. The only thing the recovered generation is used for is being the rollback target if *this* run fails, and an older complete index is a strictly better rollback target than a partial one.

Recovery scans by suffix rather than iterating `index.StaleIndexFiles(cfg.IndexBackend)` on purpose: a crash under one backend can be retried under another (and `StaleIndexFiles` returns `nil` for qdrant/pgvector), so a backend-filtered recovery would strand the crashed backend's good files in the backup slot forever. This is also what fixes the disk backend's segment + identity sidecar, which #757 just made commit as a single generation.

Two supporting fixes in the same paths:

- `backup()` now **refuses** an occupied backup slot instead of `os.Remove`-ing it. After recovery the slot is always free, so this is a second line of defence: if recovery ever misses a case, the reindex fails loudly with the good generation still on disk instead of silently eating it.
- `rollback()` now restores with a single `os.Rename` instead of `os.Remove` + `os.Rename`. The two-step version had a window in which neither copy existed, so a crash inside rollback lost the generation outright: the same bug class, one level down. Rename replaces the destination atomically on unix and (via `MOVEFILE_REPLACE_EXISTING`) on Windows.

### `internal/statefs` (#726) interaction

Checked; nothing to add, and one thing worth stating explicitly. Recovery creates no directories, so there is no new `MkdirAll` to route through `statefs` (the state root already goes through `statefs.MkdirAllHardened`). It only *renames*, which preserves the inode's mode, and it runs **after** `statefs.HardenTree(cfg.StateDir)` in `prepareReindexStore` — and `HardenTree` walks the whole tree, `.reindex-old` files included. So a backup written 0644 by an older build is tightened to 0600 before it is restored, and the recovered live file is owner-only. `TestReindex_AfterCrash_RecoversEveryLeftoverGeneration` asserts `perm&0o077 == 0` on every recovered file to pin that ordering.

## Tests

`tests/cli/reindex_backup_preservation_727_test.go` (new). A crash is simulated by **leaving the interrupted run's artifacts in place** — good index at `*.reindex-old`, partial output live, `BackupContentHashes` + `ClearDocumentContentHashes` driven through the real store and then simply abandoned — never by calling `rollback`, since a crash is exactly the case where rollback did not run.

- `..._RetryPreservesLastKnownGood` — after a failing retry, the live index and the content hashes are the pre-crash ones, not the partial rebuild.
- `..._RepeatedCrashesDoNotRotatePartialState` — three crashes in a row, each staged on top of what the previous pass left rather than re-seeded from constants (a pass that recovers and rolls back leaves no leftovers, so re-seeding would just run the ordinary failed-retry path three times). Chaining means partial state rotated into the recovery slot would carry forward into the next pass's assertion instead of being overwritten.
- `..._RecoversEveryLeftoverGeneration` — HNSW v2 (text + code), a legacy pre-#247 name, and the disk segment + identity sidecar, all recovered under the default (memory) backend, all owner-only afterwards, and all named in the recovery warning on stderr (the only signal an operator gets that a previous run was interrupted).
- `..._SuccessfulRetryClearsRecoveredBackups` — commit side: a recovered generation is adopted as the run's rollback target and then cleaned up, not left behind as a permanent second copy. (This one passes before the fix too; it is a guard against the recovery leaking copies, not a regression witness.)

**Proof they fail first.** With only the source reverted (`git checkout main -- internal/cli/reindex.go`) and the tests intact:

```
--- FAIL: TestReindex_AfterCrash_RetryPreservesLastKnownGood (0.34s)
    live index after a failed retry must be the last-known-good generation left by the crashed run;
      want "LAST-KNOWN-GOOD-INDEX" got "PARTIAL-REBUILD-FROM-CRASHED-RUN"
    content_hash after a failed retry must be the pre-crash snapshot;
      want "HASH-BEFORE-CRASHED-REINDEX" got ""
--- FAIL: TestReindex_AfterCrash_RepeatedCrashesDoNotRotatePartialState (0.32s)
    attempt 1: live index must still be the last-known-good generation;
      want "LAST-KNOWN-GOOD-INDEX" got "PARTIAL-REBUILD-FROM-CRASHED-RUN"
--- FAIL: TestReindex_AfterCrash_RecoversEveryLeftoverGeneration (0.34s)
    vectors_text.v2.hnsw must be restored from the crashed run's backup; ... (x5 files)
    recovery warning must name vectors_text.v2.hnsw; stderr="reindex failed: forced reindex failure\n"
--- PASS: TestReindex_AfterCrash_SuccessfulRetryClearsRecoveredBackups (0.34s)
```

All four pass with the fix restored.

`make check` passes locally (including `gocyclo -over 15`; `prepareReindexStore` is 10 and the extracted `snapshotContentHashes`/`recoverInterruptedReindex` are 7 and below). No new file under `internal/cli/` — the whole fix lives in the existing `reindex.go` — so the `tests/security/cli_boundary_test.go` allowlist needs no entry; the new test file is under `tests/cli/`, which that allowlist does not cover. Verified by running `go test ./tests/security`.

## On the `TestReindex_RestoresContentHashesOnFailure` CI flake

Partially characterised, not reproduced, and not caused by this change.

- The 0.36s runtime is **normal completion**, not a truncated run: that test takes 0.35–0.43s on every local run, before and after this change. So it failed an assertion; it did not time out.
- 40 consecutive local runs pass post-fix, and the whole `tests/cli` package passes.
- The reachable failure modes are narrow. If the store had failed earlier (Init, snapshot, clear) the hashes would never have been cleared and the assertion would have *passed*, so a `got ""` failure means `RestoreContentHashes` ran and returned an error. That error is best-effort: `reindexStaging.restoreContentHashes` only writes `warning: reindex rollback: restore content hashes: %v` to stderr. The test did not print stderr on that assertion, so the cause was discarded — which is exactly why it reads as an unexplained flake.
- I ruled out the obvious in-process suspects: `withWorkingDir` serialises the `chdir` under `cwdMu` and nothing in `tests/cli` calls `t.Parallel()`; the progress poller is joined (`stopProgress()` then `<-progressDone`) before the restore runs, so it cannot be racing `ensureDB`/`ReleaseDB`; and the restore uses `context.WithoutCancel`, so a cancelled parent cannot abort it. A genuine `SQLITE_BUSY`/`database is locked` from the environment (CI disk or a leftover `-wal`) remains plausible and would be swallowed the same way.
- So the only actionable change here: the assertion now includes stderr, so the next CI occurrence carries its cause instead of just `want/got`. If it recurs and stderr shows a sqlite error, that is a real bug in the restore path worth its own issue; if stderr is empty, the failure is somewhere I have not modelled.

## Review round

`coderabbit review` (CLI) reported 0 findings; the GitHub bot raised 4 nitpicks, all addressed in `d61e420`:

- **Skip non-regular entries in the recovery scan.** Taken, and for a stronger reason than the one given: staging only ever creates a backup by renaming an index file, so a directory *or symlink* named `*.reindex-old` is not ours, and renaming one into the live slot would move an unrelated path or point the index at an arbitrary target. Skipping leaves the abort to `backup()`, which names the occupied slot explicitly.
- **The repeated-crash loop was really a repeated-retry loop.** Correct catch: pass 1 recovers and rolls back, which leaves no leftovers, so passes 2 and 3 started clean. Rather than re-seeding from constants (which would hide a partial rotated into the recovery slot), each pass now re-crashes on top of the previous pass's output.
- **Assert the recovery warning on stderr.** Taken, per file name.
- **Local constant for `.reindex-old` in the test.** Taken.

## Out of scope (worth a follow-up)

`dir2mcp up` does not do this recovery. An operator who restarts the daemon after a crash rather than re-running `reindex` gets the partial live index served, with the good generation sitting untouched in the backup slot. That is a read-path bug, not the destruction this issue is about, and it needs its own decision (a daemon adopting a rollback under a corpus it is about to open is a bigger change than a reindex doing it at stage time).

No spec change: this alters no tool, CLI, or error contract. The only user-visible addition is a `warning: recovered N index file(s) left by an interrupted reindex before rebuilding: ...` line on stderr.
