### PR TITLE
fix(export): route TTML through the shared cue pipeline and resolve its language (#729, #730)

### DIFF
--- a/internal/cli/export.go
+++ b/internal/cli/export.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/dirstral/dir2mcp/internal/config"
 	"github.com/dirstral/dir2mcp/internal/model"
 	"github.com/dirstral/dir2mcp/internal/store"
 	"github.com/dirstral/dir2mcp/internal/subtitle"
@@ -78,36 +79,12 @@ func (a *App) runExport(ctx context.Context, global globalOptions, args []string
 		return a.runTTMLExport(ctx, global, cfg, ts, opts)
 	}
 
-	filter := subtitle.NewWordFilter(cfg.MediaFilterWords)
-	// The glossary was already validated at config load, so a parse error here is
-	// unexpected; surface it rather than silently dropping the glossary.
-	glossary, err := subtitle.NewGlossary(cfg.MediaSubtitlesGlossary)
+	pipe, err := newCuePipeline(cfg)
 	if err != nil {
-		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("invalid media.subtitles.glossary: %v", err))
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, err.Error())
 		return exitConfigInvalid
 	}
-	// The drop set was already validated at config load, so a parse error here is
-	// unexpected; surface it rather than silently dropping the rules.
-	drop, err := subtitle.NewDropSet(cfg.MediaSubtitlesDropPhrases)
-	if err != nil {
-		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("invalid media.subtitles.drop_phrases: %v", err))
-		return exitConfigInvalid
-	}
-	// The scrub set was already validated at config load, so a parse error here is
-	// unexpected; surface it rather than silently dropping the rules.
-	scrub, err := subtitle.NewDropSet(cfg.MediaSubtitlesScrubPhrases)
-	if err != nil {
-		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("invalid media.subtitles.scrub_phrases: %v", err))
-		return exitConfigInvalid
-	}
-	clean := subtitle.CleanOptions{
-		DropURLs:        cfg.MediaSubtitlesDropURLs,
-		Drop:            drop,
-		Scrub:           scrub,
-		CollapseRepeats: cfg.MediaSubtitlesCollapseRepeats,
-		Glossary:        glossary,
-	}
-	rendered, code := a.renderTranscriptExport(ctx, global, ts, opts, filter, clean, cfg.MediaSubtitlesSegmentation)
+	rendered, code := a.renderTranscriptExport(ctx, global, ts, opts, pipe, cfg.MediaSubtitlesSegmentation)
 	if code != exitSuccess {
 		return code
 	}
@@ -115,11 +92,74 @@ func (a *App) runExport(ctx context.Context, global globalOptions, args []string
 	return a.emitExport(global, opts, rendered)
 }
 
+// cuePipeline is the single cue-preparation pipeline every subtitle format
+// renders through: the media.filter_words word filter followed by the
+// media.subtitles.* editorial cleaning passes (glossary, drop_phrases,
+// scrub_phrases, collapse_repeats, drop_urls).
+//
+// It exists because TTML used to skip the cleaning half entirely (issue #729):
+// the same transcript exported as SRT and as TTML disagreed on every rule under
+// media.subtitles.*, and bilingual TTML aligned cue sets that the exports would
+// never render. Formats differ in how cues are BUILT (segmentation, bilingual
+// alignment) but MUST NOT differ in how cues are CLEANED, so the cleaning half
+// lives here and every renderer calls apply.
+//
+// Note what is deliberately NOT here: media.subtitles.segmentation. Broadcast
+// re-segmentation rewrites cue boundaries for VTT/SRT reading speed and is
+// documented as VTT/SRT-only in config; it is a build-stage concern, not an
+// editorial one, and stays with the VTT/SRT builder.
+type cuePipeline struct {
+	filter *subtitle.WordFilter
+	clean  subtitle.CleanOptions
+}
+
+// newCuePipeline compiles the configured filter/glossary/drop/scrub rules. The
+// config loader already validated all of them, so a compile error here is
+// unexpected; it is returned (and surfaced as a config-time failure) rather than
+// silently degrading into a no-op pipeline that would ship uncleaned cues.
+func newCuePipeline(cfg config.Config) (cuePipeline, error) {
+	glossary, err := subtitle.NewGlossary(cfg.MediaSubtitlesGlossary)
+	if err != nil {
+		return cuePipeline{}, fmt.Errorf("invalid media.subtitles.glossary: %w", err)
+	}
+	drop, err := subtitle.NewDropSet(cfg.MediaSubtitlesDropPhrases)
+	if err != nil {
+		return cuePipeline{}, fmt.Errorf("invalid media.subtitles.drop_phrases: %w", err)
+	}
+	scrub, err := subtitle.NewDropSet(cfg.MediaSubtitlesScrubPhrases)
+	if err != nil {
+		return cuePipeline{}, fmt.Errorf("invalid media.subtitles.scrub_phrases: %w", err)
+	}
+	return cuePipeline{
+		filter: subtitle.NewWordFilter(cfg.MediaFilterWords),
+		clean: subtitle.CleanOptions{
+			DropURLs:        cfg.MediaSubtitlesDropURLs,
+			Drop:            drop,
+			Scrub:           scrub,
+			CollapseRepeats: cfg.MediaSubtitlesCollapseRepeats,
+			Glossary:        glossary,
+		},
+	}, nil
+}
+
+// apply runs the word filter then the cleaning passes over built cues, in that
+// order, so filter_words removal and the cleanup compose (a cue emptied by the
+// filter is dropped before the cleaning passes ever see it). An empty config
+// leaves cues unchanged, so enabling nothing changes nothing.
+func (p cuePipeline) apply(cues []subtitle.Cue) []subtitle.Cue {
+	// media.filter_words: exported subtitles never contain the configured
+	// boilerplate/credits/watermark phrases, consistent with how ingest strips
+	// them before embedding. Cues empty after filtering are dropped.
+	cues = subtitle.FilterCues(cues, p.filter)
+	// media.subtitles.{glossary,drop_phrases,scrub_phrases,collapse_repeats,drop_urls}.
+	return subtitle.CleanCues(cues, p.clean)
+}
+
 // renderTranscriptExport resolves the transcript representation, builds cues
 // from its chunks, and renders them in the requested format. It returns the
 // serialized document, or an exit code on error (no transcript, no chunks,
 // unknown language, store failure).
-func (a *App) renderTranscriptExport(ctx context.Context, global globalOptions, ts transcriptStore, opts exportOptions, filter *subtitle.WordFilter, clean subtitle.CleanOptions, segmentation string) (string, int) {
+func (a *App) renderTranscriptExport(ctx context.Context, global globalOptions, ts transcriptStore, opts exportOptions, pipe cuePipeline, segmentation string) (string, int) {
 	reps, err := ts.TranscriptRepresentations(ctx, opts.relPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -150,16 +190,7 @@ func (a *App) renderTranscriptExport(ctx context.Context, global globalOptions, 
 	for _, r := range rows {
 		chunks = append(chunks, subtitle.TranscriptChunk{Text: r.Text, Span: r.Span})
 	}
-	cues := buildCuesForSegmentation(chunks, segmentation, transcriptRepIsTranslation(rep.MetaJSON))
-	// Apply the configured caption word filter (media.filter_words) on export so
-	// exported VTT/SRT never contain the boilerplate/credits/watermark phrases,
-	// consistent with how ingest strips them before embedding. Cues empty after
-	// filtering are dropped. An empty config leaves cues unchanged.
-	cues = subtitle.FilterCues(cues, filter)
-	// Apply the configured cue-cleaning passes (media.subtitles.glossary /
-	// collapse_repeats / drop_urls) after word-filtering, so filter_words removal
-	// and this cleanup compose. An empty config leaves cues unchanged.
-	cues = subtitle.CleanCues(cues, clean)
+	cues := pipe.apply(buildCuesForSegmentation(chunks, segmentation, transcriptRepIsTranslation(rep.MetaJSON)))
 	if len(cues) == 0 {
 		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("document %q transcript has no time-coded cues to export", opts.relPath))
 		return "", exitGeneric

--- a/internal/cli/export_ttml.go
+++ b/internal/cli/export_ttml.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/dirstral/dir2mcp/internal/avutil"
 	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/store"
 	"github.com/dirstral/dir2mcp/internal/subtitle"
 )
 
@@ -29,23 +30,35 @@ func (a *App) runTTMLExport(ctx context.Context, global globalOptions, cfg confi
 		return exitConfigInvalid
 	}
 
-	filter := subtitle.NewWordFilter(cfg.MediaFilterWords)
+	// The same cue-preparation pipeline VTT/SRT render through (issue #729). It is
+	// built after the enabled gate so a disabled surface still reports "TTML export
+	// is disabled" rather than an unrelated config error.
+	pipe, err := newCuePipeline(cfg)
+	if err != nil {
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, err.Error())
+		return exitConfigInvalid
+	}
 
-	primaryCues, code := a.resolveCues(ctx, global, ts, opts.relPath, opts.lang, filter)
+	primaryCues, primaryLang, code := a.resolveCues(ctx, global, ts, opts.relPath, opts.lang, pipe)
 	if code != exitSuccess {
 		return code
 	}
 
 	var bilingual []subtitle.BilingualCue
 	if opts.secondaryLang != "" {
-		secondaryCues, scode := a.resolveCues(ctx, global, ts, opts.relPath, opts.secondaryLang, filter)
+		secondaryCues, secondaryLang, scode := a.resolveCues(ctx, global, ts, opts.relPath, opts.secondaryLang, pipe)
 		if scode != exitSuccess {
 			return scode
 		}
+		// Both languages are cleaned by resolveCues BEFORE alignment, so the cue
+		// set that is aligned is exactly the cue set that is rendered. Aligning
+		// pre-clean cues would pair (and time-region-merge) cues that cleaning then
+		// drops, which is both non-deterministic w.r.t. config and breaks the
+		// §8.6.10 guarantee that both runs map back to the same segment span.
 		bilingual = subtitle.AlignBilingual(primaryCues, secondaryCues,
-			opts.lang, opts.secondaryLang, cfg.MediaSubtitlesTTMLAlignToleranceMS)
+			primaryLang, secondaryLang, cfg.MediaSubtitlesTTMLAlignToleranceMS)
 	} else {
-		bilingual = subtitle.MonolingualBilingualCues(primaryCues, opts.lang)
+		bilingual = subtitle.MonolingualBilingualCues(primaryCues, primaryLang)
 	}
 	if len(bilingual) == 0 {
 		writeCLIError(a.stderr, global.jsonOutput, exitGeneric,
@@ -53,28 +66,34 @@ func (a *App) runTTMLExport(ctx context.Context, global globalOptions, cfg confi
 		return exitGeneric
 	}
 
-	ttml := subtitle.RenderTTML(bilingual, opts.lang)
-	return a.emitTTMLExport(ctx, global, cfg, opts, ttml)
+	ttml := subtitle.RenderTTML(bilingual, primaryLang)
+	return a.emitTTMLExport(ctx, global, cfg, opts, primaryLang, ttml)
 }
 
 // resolveCues loads the transcript representation for lang, builds its cues, and
-// applies the configured word filter. A non-empty lang with no matching
-// transcript is reported as INVALID_FIELD (SPEC §8.6.10/§8.6.3). It returns the
-// cues, or an exit code on error.
-func (a *App) resolveCues(ctx context.Context, global globalOptions, ts transcriptStore, relPath, lang string, filter *subtitle.WordFilter) ([]subtitle.Cue, int) {
+// runs them through the shared cue pipeline (word filter + editorial cleaning).
+// A non-empty lang with no matching transcript is reported as INVALID_FIELD
+// (SPEC §8.6.10/§8.6.3).
+//
+// It returns the cues AND the resolved language tag, or an exit code on error.
+// Returning the tag is the fix for issue #730: `--lang` is a SELECTOR, not the
+// value to emit. With `--lang` omitted the selector is empty but the selected
+// representation still knows its own language, and passing the raw flag through
+// produced `xml:lang=""` on a transcript that records `en`.
+func (a *App) resolveCues(ctx context.Context, global globalOptions, ts transcriptStore, relPath, lang string, pipe cuePipeline) ([]subtitle.Cue, string, int) {
 	reps, err := ts.TranscriptRepresentations(ctx, relPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("no document found at %q", relPath))
-			return nil, exitGeneric
+			return nil, "", exitGeneric
 		}
 		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("load transcript representations: %v", err))
-		return nil, exitGeneric
+		return nil, "", exitGeneric
 	}
 	if len(reps) == 0 {
 		writeCLIError(a.stderr, global.jsonOutput, exitGeneric,
 			fmt.Sprintf("document %q has no transcript representation", relPath))
-		return nil, exitGeneric
+		return nil, "", exitGeneric
 	}
 
 	rep, ok := selectTranscriptRep(reps, lang)
@@ -84,20 +103,46 @@ func (a *App) resolveCues(ctx context.Context, global globalOptions, ts transcri
 		// no transcript is INVALID_FIELD").
 		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid,
 			fmt.Sprintf("INVALID_FIELD: document %q has no transcript for language %q", relPath, lang))
-		return nil, exitConfigInvalid
+		return nil, "", exitConfigInvalid
 	}
 
 	rows, err := ts.TranscriptSpanChunks(ctx, rep.RepID)
 	if err != nil {
 		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("load transcript chunks: %v", err))
-		return nil, exitGeneric
+		return nil, "", exitGeneric
 	}
 	chunks := make([]subtitle.TranscriptChunk, 0, len(rows))
 	for _, r := range rows {
 		chunks = append(chunks, subtitle.TranscriptChunk{Text: r.Text, Span: r.Span})
 	}
-	cues := subtitle.FilterCues(subtitle.BuildCues(chunks), filter)
-	return cues, exitSuccess
+	return pipe.apply(subtitle.BuildCues(chunks)), resolvedExportLanguage(rep), exitSuccess
+}
+
+// resolvedExportLanguage reports the language tag to emit for a selected
+// transcript representation (issue #730).
+//
+// The representation's OWN recorded tag wins whenever it has one. That is the
+// authoritative record of what language the cues are actually in, and it is what
+// makes an omitted --lang work: selectTranscriptRep returns the first/source
+// transcript, and its meta_json language is the tag that describes it.
+// Preferring the record also canonicalizes the spelling, since --lang matching
+// is case-insensitive: `--lang EN` against a transcript recording `en` emits
+// `en`, not the caller's `EN`.
+//
+// When the representation records no language at all, the tag stays EMPTY, and
+// the caller's --lang is deliberately NOT echoed in its place. That case is
+// reachable only with an omitted --lang anyway (a non-empty --lang can only
+// match a representation that recorded a language, so there is nothing to echo),
+// i.e. a legacy transcript indexed before language tagging. There is no
+// fallback by design: an empty xml:lang means "no language information is
+// available" per XML 1.0 §2.12 and is what TTML1's own examples use, whereas
+// substituting a guessed or configured default would put a plausible-but-wrong
+// BCP-47 tag into a broadcast subtitle file. Players act on that tag (track
+// selection, font/shaping), so a wrong tag misroutes where an absent one merely
+// degrades. Downstream, RenderTTML omits per-run xml:lang and RenderSMIL omits
+// systemLanguage for an empty tag.
+func resolvedExportLanguage(rep store.TranscriptRepresentation) string {
+	return transcriptRepLanguage(rep.MetaJSON)
 }
 
 // emitTTMLExport writes the TTML document and, when SMIL is enabled and an --out
@@ -105,7 +150,10 @@ func (a *App) resolveCues(ctx context.Context, global globalOptions, ts transcri
 // is written to stdout and SMIL is not produced (a single stream has no sidecar
 // path to reference). SMIL fails open: a probe failure omits the SMIL but never
 // fails the TTML emission.
-func (a *App) emitTTMLExport(ctx context.Context, global globalOptions, cfg config.Config, opts exportOptions, ttml string) int {
+//
+// lang is the RESOLVED primary language (see resolvedExportLanguage), not the
+// raw --lang flag, so the SMIL sidecar tags the same language the TTML does.
+func (a *App) emitTTMLExport(ctx context.Context, global globalOptions, cfg config.Config, opts exportOptions, lang, ttml string) int {
 	if strings.TrimSpace(opts.out) == "" {
 		writef(a.stdout, "%s", ttml)
 		return exitSuccess
@@ -119,7 +167,7 @@ func (a *App) emitTTMLExport(ctx context.Context, global globalOptions, cfg conf
 	}
 
 	if cfg.MediaSubtitlesSMILEnabled {
-		a.emitSMILSidecar(ctx, global, cfg, opts)
+		a.emitSMILSidecar(ctx, global, cfg, opts, lang)
 	}
 	return exitSuccess
 }
@@ -132,7 +180,7 @@ func (a *App) emitTTMLExport(ctx context.Context, global globalOptions, cfg conf
 // no-op cleanup, so local behavior is unchanged. It fails open per SPEC §8.6.10:
 // when the media cannot be fetched or probed (ffprobe absent, corrupt input) it
 // warns (non-fatal) and produces no SMIL rather than failing the export.
-func (a *App) emitSMILSidecar(ctx context.Context, global globalOptions, cfg config.Config, opts exportOptions) {
+func (a *App) emitSMILSidecar(ctx context.Context, global globalOptions, cfg config.Config, opts exportOptions, lang string) {
 	mediaPath, cleanup, ok := a.localizeExportMedia(ctx, cfg, opts.relPath)
 	if !ok {
 		return
@@ -156,8 +204,11 @@ func (a *App) emitSMILSidecar(ctx context.Context, global globalOptions, cfg con
 
 	smilPath := strings.TrimSuffix(opts.out, filepath.Ext(opts.out)) + ".smil"
 	// A bilingual TTML carries both languages in one document, so it is referenced
-	// once with the primary language tag.
-	subs := []subtitle.SMILSubtitleRef{{Src: filepath.Base(opts.out), Lang: opts.lang}}
+	// once with the RESOLVED primary language tag (issue #730). It used to be the
+	// raw --lang flag, so an omitted --lang produced a <textstream> with no
+	// systemLanguage even when the transcript recorded one. An empty resolved tag
+	// still omits the attribute, which RenderSMIL handles.
+	subs := []subtitle.SMILSubtitleRef{{Src: filepath.Base(opts.out), Lang: lang}}
 	smil := subtitle.RenderSMIL(subtitle.SMILInput{
 		// The media reference is the corpus document's own path, never the
 		// localized copy's: a downloaded S3 object lands in a temp file whose

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -667,8 +667,8 @@ type Config struct {
 	// credits / watermark phrases stripped from transcript and subtitle text
 	// (config `media.filter_words`). Matching is case-insensitive substring
 	// removal; the same filter is applied during transcript chunking (so the
-	// phrases are never embedded) and on subtitle export (so VTT/SRT never
-	// contain them). Empty by default = off: behavior is unchanged everywhere
+	// phrases are never embedded) and on subtitle export in every format (so no
+	// exported VTT/SRT/TTML contains them). Empty by default = off: behavior is unchanged everywhere
 	// when no phrases are configured. There are NO built-in defaults — the list
 	// carries no language- or domain-specific phrases.
 	MediaFilterWords []string
@@ -706,44 +706,68 @@ type Config struct {
 	// subtitle.BuildBroadcastCues. "broadcast" needs word timings; a transcript/
 	// span without them falls back to the chunk builder, so behavior is unchanged
 	// when word timings are absent. Only affects VTT/SRT export, never ingest.
+	//
+	// This key is DELIBERATELY format-specific, unlike the editorial cleaning keys
+	// below (issue #729): it rewrites cue BOUNDARIES for VTT/SRT reading speed,
+	// whereas TTML cue regions are the alignment unit for bilingual packaging
+	// (§8.6.10) and must stay the stored transcript segment spans so both language
+	// runs remain traceable to the same span.
 	MediaSubtitlesSegmentation string
 
+	// The five media.subtitles.* keys below are the editorial cue-cleaning
+	// pipeline. They apply to EVERY exported subtitle format — VTT, SRT and TTML
+	// (plus its companion SMIL) — not to one format each: the spec describes
+	// media.subtitles.glossary in format-neutral, export-time terms (§8.6.2), and
+	// exporting the same transcript in two formats must not yield two different
+	// editorial results. TTML used to skip all five (issue #729).
+	//
+	// This is the export surface. Two of the five (drop_phrases, scrub_phrases)
+	// ALSO run at ingest, before chunks are embedded, so the retrieval index
+	// agrees with the exported sidecar (issue #545); the other three
+	// (glossary, collapse_repeats, drop_urls) are export-only and do not change
+	// what is indexed or cited. Each key notes which it is.
+
 	// MediaSubtitlesGlossary is an optional list of editorial term replacements
-	// applied to exported VTT/SRT cue text (config `media.subtitles.glossary`).
-	// Each entry is "pattern=>replacement" where pattern is a case-insensitive,
-	// ASCII-word-bounded regular expression (e.g. "Aju?bei=>Adzhubei" to
-	// normalize a transliterated name). Unlike media.filter_words (which deletes
-	// phrases) this REWRITES text and never drops a cue. Empty by default = off.
+	// applied to exported cue text in every format (config
+	// `media.subtitles.glossary`). Each entry is "pattern=>replacement" where
+	// pattern is a case-insensitive, ASCII-word-bounded regular expression (e.g.
+	// "Aju?bei=>Adzhubei" to normalize a transliterated name). Unlike
+	// media.filter_words (which deletes phrases) this REWRITES text and never
+	// drops a cue. Empty by default = off. Export-only: indexed/cited transcript
+	// text is not rewritten.
 	MediaSubtitlesGlossary []string
 
 	// MediaSubtitlesCollapseRepeats drops the Nth-and-later cue in a run of
-	// identical consecutive cues on export (config
+	// identical consecutive cues on export in every format (config
 	// `media.subtitles.collapse_repeats`), the whisper repetition-collapse
 	// artifact. A value < 2 disables the pass (the default 0 = off), so
-	// legitimate short repeats survive; a typical setting is 3.
+	// legitimate short repeats survive; a typical setting is 3. Export-only: the
+	// repeated cues remain in the retrieval index.
 	MediaSubtitlesCollapseRepeats int
 
 	// MediaSubtitlesDropURLs opts IN to dropping exported cues whose text is a
 	// hallucinated URL / bare domain / credit line (config
-	// `media.subtitles.drop_urls`). OFF by default. Only affects VTT/SRT export.
+	// `media.subtitles.drop_urls`), in every format. OFF by default. Export-only:
+	// the dropped cues remain in the retrieval index.
 	MediaSubtitlesDropURLs bool
 
 	// MediaSubtitlesDropPhrases is an optional list of regular expressions; an
 	// exported cue whose text is composed ENTIRELY of matches (plus punctuation)
-	// is dropped (config `media.subtitles.drop_phrases`). This removes whisper
-	// keyword-spam hallucinated over silence/music/B-roll that survives the
-	// URL-drop and consecutive-identical collapse passes, without harming real
-	// speech that merely mentions one of the words. Empty by default. Only affects
-	// VTT/SRT export.
+	// is dropped (config `media.subtitles.drop_phrases`), in every format. This
+	// removes whisper keyword-spam hallucinated over silence/music/B-roll that
+	// survives the URL-drop and consecutive-identical collapse passes, without
+	// harming real speech that merely mentions one of the words. Empty by
+	// default. Also applied at ingest, so the phrases are never embedded (#545).
 	MediaSubtitlesDropPhrases []string
 
 	// MediaSubtitlesScrubPhrases is an optional list of regular expressions
-	// EXCISED from exported cue text (config `media.subtitles.scrub_phrases`).
-	// Unlike drop_phrases (a whole-cue verdict), a scrub removes just the matched
-	// phrase from a cue that also carries real speech — for a hallucinated phrase
-	// that leaked into the same cue as genuine words. Configure with the full
-	// contiguous phrase so legitimate mentions of a single word are untouched. A
-	// cue that scrubs to empty is dropped. Empty by default. Only affects VTT/SRT.
+	// EXCISED from exported cue text in every format (config
+	// `media.subtitles.scrub_phrases`). Unlike drop_phrases (a whole-cue verdict),
+	// a scrub removes just the matched phrase from a cue that also carries real
+	// speech — for a hallucinated phrase that leaked into the same cue as genuine
+	// words. Configure with the full contiguous phrase so legitimate mentions of a
+	// single word are untouched. A cue that scrubs to empty is dropped. Empty by
+	// default. Also applied at ingest, so the phrases are never embedded (#545).
 	MediaSubtitlesScrubPhrases []string
 
 	// MediaTrimLeadingSilence opts IN to trimming leading silence from media

--- a/tests/cli/export_ttml_cleaning_729_test.go
+++ b/tests/cli/export_ttml_cleaning_729_test.go
@@ -1,0 +1,220 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/cli"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// cleaningConfigLines is the media.subtitles.* editorial config shared by the
+// VTT/SRT cleaning test (export_clean_test.go) and these TTML tests, so both
+// formats are asserted against the SAME configuration. Issue #729: TTML applied
+// only media.filter_words, so the same transcript exported as SRT and as TTML
+// disagreed on every rule below.
+func cleaningConfigLines() []string {
+	return []string{
+		"media_subtitles_ttml_enabled: true",
+		"media:",
+		"  subtitles:",
+		"    glossary:",
+		"      - Aju?bei=>Adzhubei",
+		"    drop_phrases:",
+		"      - Crimea|NATO",
+		"    scrub_phrases:",
+		"      - Crimea,?\\s*NATO\\.?",
+		"    collapse_repeats: 3",
+		"    drop_urls: true",
+	}
+}
+
+// writeCleaningTTMLConfig writes the shared cleaning config with the TTML
+// surface enabled, returning its path.
+func writeCleaningTTMLConfig(t *testing.T, dir string) string {
+	t.Helper()
+	path := filepath.Join(dir, "dir2mcp.yaml")
+	if err := os.WriteFile(path, []byte(strings.Join(cleaningConfigLines(), "\n")+"\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}
+
+// TestExportTTMLAppliesCueCleaning729 pins that --format ttml applies the same
+// media.subtitles.* editorial pipeline as VTT/SRT: glossary rewrite,
+// repetition-collapse, URL drop, drop_phrases and scrub_phrases. It reuses the
+// exact fixture the SRT test uses (seedCleanExportStore), so a divergence
+// between the two formats fails here.
+//
+// Fails before the fix: TTML built cues with FilterCues only, so "Ajubei",
+// "spam.com", four "No." cues and "Crimea, NATO" all survived into the TTML.
+func TestExportTTMLAppliesCueCleaning729(t *testing.T) {
+	tmp := t.TempDir()
+	seedCleanExportStore(t, filepath.Join(tmp, ".dir2mcp"), "media/talk.mp3")
+	cfgPath := writeCleaningTTMLConfig(t, tmp)
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	withWorkingDir(t, tmp, func() {
+		if code := app.RunWithContext(context.Background(),
+			[]string{"--config", cfgPath, "export", "--format", "ttml", "media/talk.mp3"}); code != 0 {
+			t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
+		}
+	})
+	out := stdout.String()
+
+	if strings.Contains(out, "Ajubei") || !strings.Contains(out, "Adzhubei") {
+		t.Errorf("glossary rewrite not applied to TTML:\n%s", out)
+	}
+	if strings.Contains(strings.ToLower(out), "spam.com") {
+		t.Errorf("URL cue not dropped from TTML:\n%s", out)
+	}
+	if n := strings.Count(out, "No."); n != 2 {
+		t.Errorf("repetition-collapse: got %d 'No.' cues in TTML, want 2:\n%s", n, out)
+	}
+	if strings.Contains(out, "Crimea, NATO") {
+		t.Errorf("phrase not removed from TTML (drop_phrases + scrub_phrases):\n%s", out)
+	}
+	if !strings.Contains(out, "Genuine words.") {
+		t.Errorf("scrub_phrases dropped the whole leaked TTML cue instead of keeping the sentence:\n%s", out)
+	}
+	if !strings.Contains(out, "Real closing line") {
+		t.Errorf("real closing cue missing from TTML:\n%s", out)
+	}
+}
+
+// TestExportTTMLNoCleaningConfigUnchanged729 pins the empty-config contract: with
+// the TTML surface enabled but no media.subtitles.* editorial rules, every cue
+// survives verbatim. This guards the fix against becoming an unconditional
+// rewrite of TTML output.
+func TestExportTTMLNoCleaningConfigUnchanged729(t *testing.T) {
+	tmp := t.TempDir()
+	seedCleanExportStore(t, filepath.Join(tmp, ".dir2mcp"), "media/talk.mp3")
+	cfgPath := writeTTMLConfig(t, tmp, false)
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	withWorkingDir(t, tmp, func() {
+		if code := app.RunWithContext(context.Background(),
+			[]string{"--config", cfgPath, "export", "--format", "ttml", "media/talk.mp3"}); code != 0 {
+			t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
+		}
+	})
+	out := stdout.String()
+
+	if !strings.Contains(out, "Ajubei") {
+		t.Errorf("without config the name should be untouched in TTML:\n%s", out)
+	}
+	if !strings.Contains(strings.ToLower(out), "spam.com") {
+		t.Errorf("without config the URL cue should survive in TTML:\n%s", out)
+	}
+	if n := strings.Count(out, "No."); n != 4 {
+		t.Errorf("without config all 4 'No.' cues should survive in TTML, got %d:\n%s", n, out)
+	}
+	if !strings.Contains(out, "Crimea, NATO") {
+		t.Errorf("without config the phrase-only cue should survive in TTML:\n%s", out)
+	}
+}
+
+// seedBilingualCleanStore seeds two language-tagged transcripts that BOTH carry
+// cleanable content, so a fix that cleans only the primary language is caught.
+// The two languages' cue timings overlap, so alignment pairs them.
+func seedBilingualCleanStore(t *testing.T, stateDir, relPath string) {
+	t.Helper()
+	ctx := context.Background()
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	st := store.NewSQLiteStore(filepath.Join(stateDir, "meta.sqlite"))
+	defer func() { _ = st.Close() }()
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if err := st.UpsertDocument(ctx, model.Document{
+		RelPath: relPath, DocType: "audio", SourceType: "local", Status: "ok",
+	}); err != nil {
+		t.Fatalf("UpsertDocument: %v", err)
+	}
+	doc, err := st.GetDocumentByPath(ctx, relPath)
+	if err != nil {
+		t.Fatalf("GetDocumentByPath: %v", err)
+	}
+
+	type langRep struct {
+		repType string
+		meta    string
+		hash    string
+		chunks  [][3]any // text, startMS, endMS
+	}
+	reps := []langRep{
+		{"transcript-en", `{"language":"en"}`, "en1", [][3]any{
+			{"Letter signed by Ajubei", 0, 2000},
+			{"Subtitles by www.spam.com", 5000, 7000},
+		}},
+		{"transcript-fr", `{"language":"fr"}`, "fr1", [][3]any{
+			{"Lettre signee par Ajubei", 200, 2100},
+			{"Sous-titres par www.spam.com", 5100, 7100},
+		}},
+	}
+	err = st.WithTx(ctx, func(tx model.RepresentationStore) error {
+		for _, r := range reps {
+			repID, rerr := tx.UpsertRepresentation(ctx, model.Representation{
+				DocID: doc.DocID, RepType: r.repType, RepHash: r.hash, MetaJSON: r.meta,
+			})
+			if rerr != nil {
+				return rerr
+			}
+			for i, c := range r.chunks {
+				if _, cerr := tx.InsertChunkWithSpans(ctx,
+					model.Chunk{RepID: repID, Ordinal: i, Text: c[0].(string), IndexKind: "text"},
+					[]model.Span{{Kind: "time", StartMS: c[1].(int), EndMS: c[2].(int)}},
+				); cerr != nil {
+					return cerr
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("seed transcripts: %v", err)
+	}
+}
+
+// TestExportTTMLBilingualCleansBothLanguages729 pins that BOTH languages are
+// cleaned before bilingual alignment, not just the primary: alignment must run
+// on the same cue set the exports render, otherwise pairing is computed over
+// cues that will not be emitted.
+func TestExportTTMLBilingualCleansBothLanguages729(t *testing.T) {
+	tmp := t.TempDir()
+	seedBilingualCleanStore(t, filepath.Join(tmp, ".dir2mcp"), "media/talk.mp3")
+	cfgPath := writeCleaningTTMLConfig(t, tmp)
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	withWorkingDir(t, tmp, func() {
+		if code := app.RunWithContext(context.Background(),
+			[]string{"--config", cfgPath, "export", "--format", "ttml",
+				"--lang", "en", "--secondary-lang", "fr", "media/talk.mp3"}); code != 0 {
+			t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
+		}
+	})
+	out := stdout.String()
+
+	if strings.Contains(out, "Ajubei") {
+		t.Errorf("glossary must rewrite BOTH languages before alignment:\n%s", out)
+	}
+	if !strings.Contains(out, "Letter signed by Adzhubei") {
+		t.Errorf("primary language cue missing its glossary rewrite:\n%s", out)
+	}
+	if !strings.Contains(out, "Lettre signee par Adzhubei") {
+		t.Errorf("secondary language cue missing its glossary rewrite:\n%s", out)
+	}
+	if strings.Contains(strings.ToLower(out), "spam.com") {
+		t.Errorf("URL cues must be dropped in BOTH languages:\n%s", out)
+	}
+}

--- a/tests/cli/export_ttml_lang_730_test.go
+++ b/tests/cli/export_ttml_lang_730_test.go
@@ -1,0 +1,236 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/cli"
+)
+
+// Issue #730: `export --format ttml` documents --lang as optional and correctly
+// selects the first/source transcript when it is omitted, but it handed the raw
+// (empty) flag value to the renderer instead of the SELECTED representation's
+// recorded language. A transcript whose meta_json records {"language":"en"}
+// therefore exported as `<tt ... xml:lang="">` with unlabelled text runs and a
+// SMIL with no systemLanguage.
+//
+// The resolution rule these tests pin: the effective language is the recorded
+// language of the representation that was actually selected. There is NO
+// invented fallback — for a genuinely untagged legacy transcript the tag stays
+// empty (see TestExportTTMLUntaggedTranscriptEmitsNoLanguage730).
+
+// TestExportTTMLOmittedLangUsesRecordedLanguage730 is the core regression: with
+// --lang omitted, the document-level xml:lang and the cue text runs must carry
+// the selected transcript's recorded language.
+//
+// Fails before the fix: emits xml:lang="" and bare <span>.
+func TestExportTTMLOmittedLangUsesRecordedLanguage730(t *testing.T) {
+	tmp := t.TempDir()
+	seedExportStore(t, filepath.Join(tmp, ".dir2mcp"), "media/talk.mp3", `{"language":"en"}`)
+	cfgPath := writeTTMLConfig(t, tmp, false)
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	withWorkingDir(t, tmp, func() {
+		if code := app.RunWithContext(context.Background(),
+			[]string{"--config", cfgPath, "export", "--format", "ttml", "media/talk.mp3"}); code != 0 {
+			t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
+		}
+	})
+	out := stdout.String()
+
+	if strings.Contains(out, `xml:lang=""`) {
+		t.Errorf("empty xml:lang emitted for a transcript recording a language:\n%s", out)
+	}
+	if !strings.Contains(out, `<tt xmlns="http://www.w3.org/ns/ttml" xml:lang="en">`) {
+		t.Errorf("document xml:lang must be the recorded language \"en\":\n%s", out)
+	}
+	if !strings.Contains(out, `<span xml:lang="en">First part</span>`) {
+		t.Errorf("cue text run must carry the resolved language:\n%s", out)
+	}
+}
+
+// TestExportTTMLOmittedLangMatchesExplicitLang730 pins that omitting --lang and
+// passing the transcript's own --lang produce the SAME document: the flag
+// selects a transcript, it is not an independent source of the emitted tag.
+func TestExportTTMLOmittedLangMatchesExplicitLang730(t *testing.T) {
+	render := func(t *testing.T, args ...string) string {
+		t.Helper()
+		tmp := t.TempDir()
+		seedExportStore(t, filepath.Join(tmp, ".dir2mcp"), "media/talk.mp3", `{"language":"en"}`)
+		cfgPath := writeTTMLConfig(t, tmp, false)
+		var stdout, stderr bytes.Buffer
+		app := cli.NewAppWithIO(&stdout, &stderr)
+		withWorkingDir(t, tmp, func() {
+			argv := append([]string{"--config", cfgPath, "export", "--format", "ttml"}, args...)
+			if code := app.RunWithContext(context.Background(), append(argv, "media/talk.mp3")); code != 0 {
+				t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
+			}
+		})
+		return stdout.String()
+	}
+
+	omitted := render(t)
+	explicit := render(t, "--lang", "en")
+	if omitted != explicit {
+		t.Errorf("omitted --lang must render identically to --lang en\nomitted:\n%s\nexplicit:\n%s", omitted, explicit)
+	}
+}
+
+// TestExportTTMLUntaggedTranscriptEmitsNoLanguage730 pins the deliberate
+// no-fallback decision for a genuinely untagged legacy transcript (empty
+// meta_json): the document tag stays the empty string, which per XML 1.0 §2.12
+// means "no language information is available" (TTML1's own examples use
+// `<tt xml:lang="">`), and text runs omit xml:lang entirely.
+//
+// The alternative — substituting a configured or guessed default — would put a
+// plausible-but-wrong BCP-47 tag in a broadcast subtitle file, which downstream
+// players act on (track selection, font/shaping). An absent tag degrades; a
+// wrong tag misroutes.
+func TestExportTTMLUntaggedTranscriptEmitsNoLanguage730(t *testing.T) {
+	tmp := t.TempDir()
+	seedExportStore(t, filepath.Join(tmp, ".dir2mcp"), "media/talk.mp3", "")
+	cfgPath := writeTTMLConfig(t, tmp, false)
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	withWorkingDir(t, tmp, func() {
+		if code := app.RunWithContext(context.Background(),
+			[]string{"--config", cfgPath, "export", "--format", "ttml", "media/talk.mp3"}); code != 0 {
+			t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
+		}
+	})
+	out := stdout.String()
+
+	if !strings.Contains(out, `<tt xmlns="http://www.w3.org/ns/ttml" xml:lang="">`) {
+		t.Errorf("untagged transcript must emit the explicit empty tag, not a guess:\n%s", out)
+	}
+	if !strings.Contains(out, `<span>First part</span>`) {
+		t.Errorf("untagged text runs must omit xml:lang entirely:\n%s", out)
+	}
+	// No invented tag of any kind.
+	for _, bad := range []string{`xml:lang="en"`, `xml:lang="und"`, `xml:lang="ru"`} {
+		if strings.Contains(out, bad) {
+			t.Errorf("untagged transcript must not invent %s:\n%s", bad, out)
+		}
+	}
+}
+
+// TestExportTTMLBilingualOmittedLangResolvesBothTags730 pins that BOTH tags are
+// resolved from their representations: with --lang omitted the primary tag comes
+// from the selected (first) transcript, and the secondary run keeps its own.
+func TestExportTTMLBilingualOmittedLangResolvesBothTags730(t *testing.T) {
+	tmp := t.TempDir()
+	seedBilingualStore(t, filepath.Join(tmp, ".dir2mcp"), "media/talk.mp3")
+	cfgPath := writeTTMLConfig(t, tmp, false)
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	withWorkingDir(t, tmp, func() {
+		if code := app.RunWithContext(context.Background(),
+			[]string{"--config", cfgPath, "export", "--format", "ttml",
+				"--secondary-lang", "fr", "media/talk.mp3"}); code != 0 {
+			t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
+		}
+	})
+	out := stdout.String()
+
+	if !strings.Contains(out, `<tt xmlns="http://www.w3.org/ns/ttml" xml:lang="en">`) {
+		t.Errorf("primary tag must resolve from the selected transcript:\n%s", out)
+	}
+	for _, want := range []string{
+		`<span xml:lang="en">Hello</span>`,
+		`<span xml:lang="fr">Bonjour</span>`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("bilingual TTML missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// TestExportTTMLSecondaryLangTagComesFromRepresentation730 pins that the emitted
+// tag is the representation's recorded tag, not the raw flag spelling: --lang
+// matching is case-insensitive, so "EN"/"FR" select the same transcripts and
+// must still render the canonical recorded "en"/"fr".
+func TestExportTTMLSecondaryLangTagComesFromRepresentation730(t *testing.T) {
+	tmp := t.TempDir()
+	seedBilingualStore(t, filepath.Join(tmp, ".dir2mcp"), "media/talk.mp3")
+	cfgPath := writeTTMLConfig(t, tmp, false)
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	withWorkingDir(t, tmp, func() {
+		if code := app.RunWithContext(context.Background(),
+			[]string{"--config", cfgPath, "export", "--format", "ttml",
+				"--lang", "EN", "--secondary-lang", "FR", "media/talk.mp3"}); code != 0 {
+			t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
+		}
+	})
+	out := stdout.String()
+
+	for _, bad := range []string{`xml:lang="EN"`, `xml:lang="FR"`} {
+		if strings.Contains(out, bad) {
+			t.Errorf("emitted tag must be the recorded one, not the flag spelling %s:\n%s", bad, out)
+		}
+	}
+	for _, want := range []string{`xml:lang="en"`, `xml:lang="fr"`} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing recorded tag %s in:\n%s", want, out)
+		}
+	}
+}
+
+// TestExportTTMLSMILUsesResolvedLanguage730 pins that the companion SMIL's
+// <textstream systemLanguage> is the same resolved tag the TTML carries, with
+// --lang omitted. It probes through a stub ffprobe so no real codec tooling is
+// needed.
+//
+// Fails before the fix: systemLanguage is omitted entirely because opts.lang was
+// empty.
+func TestExportTTMLSMILUsesResolvedLanguage730(t *testing.T) {
+	tmp := t.TempDir()
+	const rel = "media/talk.mp4"
+	seedExportStore(t, filepath.Join(tmp, ".dir2mcp"), rel, `{"language":"en"}`)
+	cfgPath := writeTTMLConfig(t, tmp, true)
+	stubFFprobeOnPATH(t)
+
+	// A real (non-empty) local media file so the stub probe succeeds.
+	if err := os.MkdirAll(filepath.Join(tmp, "media"), 0o755); err != nil {
+		t.Fatalf("mkdir media: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, rel), []byte("not-really-mp4"), 0o644); err != nil {
+		t.Fatalf("write media: %v", err)
+	}
+
+	outPath := filepath.Join(tmp, "out", "talk.ttml")
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	withWorkingDir(t, tmp, func() {
+		if code := app.RunWithContext(context.Background(),
+			[]string{"--config", cfgPath, "export", "--format", "ttml",
+				"--out", outPath, rel}); code != 0 {
+			t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
+		}
+	})
+
+	smilPath := strings.TrimSuffix(outPath, ".ttml") + ".smil"
+	smilRaw, err := os.ReadFile(smilPath)
+	if err != nil {
+		t.Fatalf("SMIL must be written (stderr=%s): %v", stderr.String(), err)
+	}
+	if !strings.Contains(string(smilRaw), `systemLanguage="en"`) {
+		t.Errorf("SMIL must carry the resolved language:\n%s", smilRaw)
+	}
+
+	ttmlRaw, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read TTML: %v", err)
+	}
+	if !strings.Contains(string(ttmlRaw), `xml:lang="en"`) {
+		t.Errorf("TTML and SMIL must agree on the resolved language:\n%s", ttmlRaw)
+	}
+}


### PR DESCRIPTION
Fixes #729. Fixes #730.

Both issues live in the TTML branch of `export`, one line apart in `resolveCues`, so they are fixed together rather than as two conflicting PRs.

Rebased on current `main` (`57e1bc2`). Everything #736 landed is preserved: SMIL probing still goes through `CorpusFS.Localize`, the `warnSMILSkipped` reasons are still fixed labels with no error interpolation, and `MediaSrc` is still the full `rel_path`.

---

## #729 — TTML bypassed the cleaning/glossary pipeline

**Verified before changing anything.** `runTTMLExport` is dispatched at `export.go:78`, which returns *before* `export.go` ever builds `CleanOptions`. So `subtitle.CleanCues` had exactly one production call site in the repo, on the VTT/SRT path. TTML did `subtitle.FilterCues(subtitle.BuildCues(chunks), filter)` and nothing else.

### Where cleaning is applied on the ingest side, and why export did not go through it

This was the key question, and the answer changes where the fix belongs. Measured, not assumed:

| config key | applied at ingest (indexed text) | export vtt/srt | export ttml (before) |
|---|---|---|---|
| `media.filter_words` | yes | yes | yes |
| `media.subtitles.drop_phrases` | yes (#545) | yes | **no** |
| `media.subtitles.scrub_phrases` | yes (#545) | yes | **no** |
| `media.subtitles.glossary` | **no** | yes | **no** |
| `media.subtitles.collapse_repeats` | **no** | yes | **no** |
| `media.subtitles.drop_urls` | **no** | yes | **no** |

Ingest applies `filter_words` plus drop/scrub in all three chunking paths (`ingest/service.go:4462` STT, `:4850` translate, `ingest/sidecar.go:370` sidecar), via `applyWordFilterToSegments` and `applyDropScrubToSegments`. That cleaned text is what lands in `chunks.text` and is what `TranscriptSpanChunks` reads back — so yes, export re-reads already-partly-cleaned cues from the store.

But **glossary, collapse_repeats and drop_urls are applied nowhere on the ingest side** (grep-verified: their only readers outside `internal/config` were `export.go`). The stored text is *not* glossary-rewritten. So the export path genuinely has to apply them, and moving the fix to ingest would not work: a glossary is an editorial rewrite of rendered cue text, and the spec calls it exactly that — "a deterministic, export-time find/replace on **already-rendered cue text**" (SPEC §8.6.2). The fix belongs in export, and specifically in the shared step both formats run.

Re-running drop/scrub at export on top of ingest's pass is idempotent and was already the pre-existing VTT/SRT behavior; this PR does not change that.

### Which surface this fixes, and which it does not

To be explicit, given the #545 history:

- **Fixed here:** the *export* surface. `--format ttml` (and its companion SMIL) now applies the same five `media.subtitles.*` rules that `--format vtt|srt` already applied.
- **Not touched here:** the *retrieval index*. `glossary`, `collapse_repeats` and `drop_urls` are still export-only — a hallucinated URL cue is still embedded, cited and searchable, and a glossary rewrite still does not reach the indexed text. That is the residual half of the gap #545 named ("prefer a single shared cleaning entry point used by both ingest and export"); #545 closed having moved only drop/scrub to ingest. Changing what gets embedded is an ingest-side, re-index-forcing behavior change and is deliberately out of scope for a TTML export fix. The config doc comments in this PR now state, per key, which of the two it is, so the gap is documented rather than silent.

### The fix

A single `cuePipeline` (`export.go`) holding the word filter plus `CleanOptions`, with one `apply` used by both renderers. Formats may differ in how cues are **built** (segmentation, bilingual alignment); they must not differ in how cues are **cleaned**.

For bilingual TTML, each language is cleaned **before** `AlignBilingual`, not after. Aligning pre-clean cues would time-region-merge pairs that cleaning then drops, which makes alignment depend on config in a way §8.6.10's determinism and same-segment-span guarantees do not allow.

`media.subtitles.segmentation` is deliberately **not** in the shared pipeline. It rewrites cue *boundaries* for VTT/SRT reading speed, and TTML cue regions are the alignment unit for bilingual packaging and must stay the stored segment spans. Per the issue's "if some settings are intentionally format-specific, scope them explicitly", its config comment now says so and why.

### Contract reconciliation

The issue notes the config comments and the canonical spec disagreed. Checked the submodule: SPEC.md never mentions `drop_phrases`, `scrub_phrases`, `collapse_repeats`, `drop_urls` or `filter_words` at all, and its only wording for `media.subtitles.glossary` is format-neutral export-time language. **The spec was already right; the code and its comments were the outliers.** No spec change is needed and the submodule pin is untouched — this PR moves the code toward the existing spec text rather than changing the contract.

Four comments were factually wrong and are corrected: `drop_phrases` and `scrub_phrases` claimed "Only affects VTT/SRT export" while having run at ingest since #545, and `media.filter_words` claimed export coverage of "VTT/SRT" when TTML already filtered too.

---

## #730 — empty language metadata when `--lang` is omitted

**Verified before changing anything.** Reproduced exactly as reported: a transcript whose `meta_json` is `{"language":"en"}`, exported with `--lang` omitted, emitted `<tt ... xml:lang="">`, bare `<span>` runs, and a SMIL with no `systemLanguage`.

### What the correct value is, and why

**The selected representation's own recorded language.** Not a configured default, and not a refusal.

`--lang` is a *selector*: `selectTranscriptRep(reps, "")` already picks the first/source transcript correctly. The bug was purely that the chosen representation was thrown away and the raw flag echoed onward. The representation's `meta_json` language is the authoritative record of what language those cues are actually in, so it is the tag to emit. Refusing the export would break the documented optional-`--lang` path; a configured default would be a value the operator set for something else.

This also canonicalizes spelling: `--lang` matching is case-insensitive, so `--lang EN` against a transcript recording `en` now emits `en` rather than the caller's `EN`.

**For a genuinely untagged legacy transcript the tag stays empty, by design.** No fallback is invented. `xml:lang=""` means "no language information is available" per XML 1.0 §2.12, and TTML1's own examples use `<tt xml:lang="">`; text runs omit `xml:lang` entirely and SMIL omits `systemLanguage`. Substituting a guess (or `und`) would put a plausible-but-wrong BCP-47 tag into a broadcast subtitle file, and players act on that tag for track selection and font/shaping. A wrong tag misroutes; an absent tag merely degrades. This case is only reachable with `--lang` omitted anyway — a non-empty `--lang` can only match a representation that recorded a language, so there is never a caller tag to echo.

The resolved tag is threaded through all four consumers the issue lists: `MonolingualBilingualCues`, `AlignBilingual` (both tags), `RenderTTML`, and the SMIL sidecar.

---

## Testing

New tests under `tests/cli/`, **proven to fail first**: source change stashed (`git stash push -- internal/`, tests kept), suite re-run, then restored. 7 of 9 fail without the fix:

```
--- FAIL: TestExportTTMLAppliesCueCleaning729
--- FAIL: TestExportTTMLBilingualCleansBothLanguages729
--- FAIL: TestExportTTMLOmittedLangUsesRecordedLanguage730
--- FAIL: TestExportTTMLOmittedLangMatchesExplicitLang730
--- FAIL: TestExportTTMLBilingualOmittedLangResolvesBothTags730
--- FAIL: TestExportTTMLSecondaryLangTagComesFromRepresentation730
--- FAIL: TestExportTTMLSMILUsesResolvedLanguage730
```

`export_ttml_cleaning_729_test.go` reuses the *exact* fixture the existing SRT cleaning test uses (`seedCleanExportStore`) with the same config, so any future divergence between the two formats fails here.

The two that pass both before and after are deliberate contract guards, not regressions:

- `TestExportTTMLNoCleaningConfigUnchanged729` — empty config leaves TTML byte-compatible, guarding the fix from becoming an unconditional rewrite (the issue's "empty config remains byte/behavior compatible").
- `TestExportTTMLUntaggedTranscriptEmitsNoLanguage730` — pins the no-fallback decision above, asserting no `en`/`und`/`ru` is ever invented.

Invalid glossary/regex still fails at config time on the TTML path too; the pipeline is built *after* the enabled gate, so a disabled surface still reports "TTML export is disabled" rather than an unrelated config error (`TestExportTTMLDisabledByDefault` still passes).

No new file under `internal/cli/`, so `tests/security/cli_boundary_test.go` needs no allowlist entry — checked, and that suite passes.

`make check` passes locally, including `gocyclo -over 15`, `go vet` and `golangci-lint`.

## Not done

- Moving `glossary`/`collapse_repeats`/`drop_urls` to ingest so the retrieval index matches the exports. Real, and named above; it forces a re-index and is a separate change.
