### PR TITLE
fix(mcp): resolve on-demand media through the CorpusFS (#759)

### DIFF
--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -121,7 +121,19 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 		return !indexingState.Snapshot().Running
 	})
 
+	corpusFS, err := buildCorpusFS(ctx, cfg)
+	if err != nil {
+		writeCLIError(a.stderr, opts.jsonOutput, exitConfigInvalid, fmt.Sprintf("initialize corpus source: %v", err))
+		return exitConfigInvalid
+	}
+
 	serverOptions := buildMCPServerOptions(&cfg, st, indexingState, emitter)
+	// Route the on-demand tool paths (open_media_clip, on-demand audio init,
+	// on-demand content reads) through the corpus filesystem so they work on an
+	// object-store corpus, which has no file at RootDir/rel_path (#759). The
+	// server ignores it for a local/NFS corpus, which keeps its filesystem-native
+	// resolution.
+	serverOptions = append(serverOptions, mcp.WithCorpusFS(corpusFS))
 	mcpServer := mcp.NewServer(cfg, ret, serverOptions...)
 	ing, err := a.newIngestor(cfg, st)
 	if err != nil {
@@ -136,11 +148,6 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 	})
 	wireDerivationCacheIdentities(ret, ing)
 
-	corpusFS, err := buildCorpusFS(ctx, cfg)
-	if err != nil {
-		writeCLIError(a.stderr, opts.jsonOutput, exitConfigInvalid, fmt.Sprintf("initialize corpus source: %v", err))
-		return exitConfigInvalid
-	}
 	setCorpusFSIfSupported(ing, corpusFS)
 	// Route retrieval-time reads (open_file raw text / OCR / transcript) through
 	// the corpus filesystem for object-store backends so open_file works on an S3

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -29,6 +29,7 @@ import (
 	"github.com/dirstral/dir2mcp/internal/avutil"
 	"github.com/dirstral/dir2mcp/internal/buildinfo"
 	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/corpusfs"
 	"github.com/dirstral/dir2mcp/internal/identity"
 	"github.com/dirstral/dir2mcp/internal/model"
 	"github.com/dirstral/dir2mcp/internal/protocol"
@@ -146,6 +147,13 @@ type Server struct {
 	// to avutil.ExtractSegment and is an injectable seam so tests can stub
 	// extraction without ffmpeg on PATH.
 	extractSegment func(ctx context.Context, path string, startMS, endMS int) ([]byte, error)
+
+	// corpusFS supplies the bytes for the on-demand tool paths (open_media_clip,
+	// on-demand audio init, on-demand content reads) when the corpus lives on a
+	// non-local backend (#759). It is set once at construction and read-only
+	// thereafter. nil (the default) and a local corpus source both keep the
+	// historical local-filesystem resolution; see corpusFSForOnDemand.
+	corpusFS corpusfs.CorpusFS
 }
 
 type rpcRequest struct {
@@ -228,6 +236,21 @@ func WithTTS(tts TTSSynthesizer) ServerOption {
 func WithExtractSegment(fn func(ctx context.Context, path string, startMS, endMS int) ([]byte, error)) ServerOption {
 	return func(s *Server) {
 		s.extractSegment = fn
+	}
+}
+
+// WithCorpusFS injects the corpus filesystem backend the on-demand tool paths
+// read through (issue #759). It matters only for a non-local corpus source: an
+// object store has no file at RootDir/rel_path, so open_media_clip, on-demand
+// audio init and on-demand content reads have to obtain the bytes through the
+// backend instead of joining a path that names nothing.
+//
+// A local/NFS corpus ignores it and keeps the filesystem-native resolution
+// (EvalSymlinks containment plus the symlink-target exclusion re-check), which
+// has no object-store analogue and must not be weakened by an injection.
+func WithCorpusFS(fsys corpusfs.CorpusFS) ServerOption {
+	return func(s *Server) {
+		s.corpusFS = fsys
 	}
 }
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -21,12 +21,14 @@ import (
 
 	"github.com/dirstral/dir2mcp/internal/avutil"
 	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/corpusfs"
 	"github.com/dirstral/dir2mcp/internal/ingest"
 	"github.com/dirstral/dir2mcp/internal/mistral"
 	"github.com/dirstral/dir2mcp/internal/model"
 	"github.com/dirstral/dir2mcp/internal/protocol"
 	"github.com/dirstral/dir2mcp/internal/provider"
 	"github.com/dirstral/dir2mcp/internal/providerfactory"
+	"github.com/dirstral/dir2mcp/internal/relpath"
 )
 
 // maxOpenFilePage caps the open_file page argument so a caller cannot request
@@ -1618,7 +1620,11 @@ func (s *Server) handleOpenMediaClipTool(ctx context.Context, args map[string]in
 		return toolCallResult{}, &toolExecutionError{Code: "CLIP_TOO_LARGE", Message: fmt.Sprintf("requested clip duration %dms exceeds max %dms; request a shorter span", req.endMS-req.startMS, maxDurationMS), Retryable: false}
 	}
 
-	absPath, pathErr := s.resolveDocumentPath(req.relPath)
+	// The clip is cut from a real local path, so a non-local corpus materializes
+	// a temporary copy here; the cleanup runs on every path below, including the
+	// extraction-failure and clip-too-large returns (#759).
+	absPath, cleanup, pathErr := s.localizeDocument(ctx, req.relPath)
+	defer cleanup()
 	if pathErr != nil {
 		return toolCallResult{}, mapPathError(pathErr)
 	}
@@ -2375,10 +2381,15 @@ func (s *Server) initAudioDocumentOnDemand(ctx context.Context, normalizedRel st
 	if s.store == nil {
 		return model.Document{}, &toolExecutionError{Code: "STORE_CORRUPT", Message: "store not configured", Retryable: false}
 	}
-	absPath, pathErr := s.resolveDocumentPath(normalizedRel)
+	absPath, cleanup, pathErr := s.localizeDocument(ctx, normalizedRel)
+	defer cleanup()
 	if pathErr != nil {
 		return model.Document{}, mapPathError(pathErr)
 	}
+	// For a non-local corpus this stats the downloaded copy: its size is the
+	// object's size, but its mtime is the download time, not the object's
+	// LastModified. That only feeds the on-demand document row's MTimeUnix, which
+	// discovery overwrites with the backend's own value on the next scan.
 	info, statErr := os.Stat(absPath)
 	if statErr != nil {
 		return model.Document{}, mapFileAccessError(statErr)
@@ -2451,7 +2462,7 @@ func mapReadDocumentError(err error) *toolExecutionError {
 }
 
 func (s *Server) ensureTranscriptForAudioDoc(ctx context.Context, doc model.Document, retranscribe bool, language string) (string, bool, bool, *toolExecutionError) {
-	content, err := s.readDocumentContent(doc.RelPath)
+	content, err := s.readDocumentContent(ctx, doc.RelPath)
 	if err != nil {
 		return "", false, false, mapReadDocumentError(err)
 	}
@@ -2546,7 +2557,7 @@ func (s *Server) sourceTextForAnnotation(ctx context.Context, doc model.Document
 		}
 		return text, ingest.RepTypeTranscript, nil
 	case "pdf", "image", "document":
-		content, err := s.readDocumentContent(doc.RelPath)
+		content, err := s.readDocumentContent(ctx, doc.RelPath)
 		if err != nil {
 			return "", "", annotationReadError(err)
 		}
@@ -2584,7 +2595,7 @@ func (s *Server) sourceTextForAnnotation(ctx context.Context, doc model.Document
 		}
 		return text, ingest.RepTypeOCRMarkdown, nil
 	default:
-		content, err := s.readDocumentContent(doc.RelPath)
+		content, err := s.readDocumentContent(ctx, doc.RelPath)
 		if err != nil {
 			return "", "", annotationReadError(err)
 		}
@@ -2644,12 +2655,127 @@ func (s *Server) refuseIfSecretContent(text string) *toolExecutionError {
 	return nil
 }
 
-func (s *Server) readDocumentContent(relPath string) ([]byte, error) {
-	targetReal, err := s.resolveDocumentPath(relPath)
+func (s *Server) readDocumentContent(ctx context.Context, relPath string) ([]byte, error) {
+	targetReal, cleanup, err := s.localizeDocument(ctx, relPath)
+	defer cleanup()
 	if err != nil {
 		return nil, err
 	}
 	return os.ReadFile(targetReal)
+}
+
+// noopCleanup is the cleanup returned whenever nothing was materialized, so the
+// on-demand callers can `defer cleanup()` unconditionally instead of nil-checking
+// on every error path.
+func noopCleanup() {}
+
+// corpusFSForOnDemand returns the CorpusFS the on-demand tool paths must read
+// through, or nil when they should keep the historical local resolution.
+//
+// Both conditions matter. The backend is used only when one was injected AND the
+// configured corpus source is non-local: a local corpus keeps resolveDocumentPath
+// because its containment guarantee is expressed in resolved symlinks (a symlink
+// inside the corpus whose real target is excluded is refused by the post-resolution
+// re-check), and an object store has no symlinks to resolve. Gating on the source
+// kind as well as on injection means an accidentally injected local backend can
+// never silently downgrade that guarantee.
+func (s *Server) corpusFSForOnDemand() corpusfs.CorpusFS {
+	if s.corpusFS == nil || !corpusSourceIsRemote(s.cfg) {
+		return nil
+	}
+	return s.corpusFS
+}
+
+// corpusSourceIsRemote reports whether the corpus lives on a backend with no
+// local file at RootDir/rel_path. It mirrors the CLI's sourceIsRemote.
+func corpusSourceIsRemote(cfg config.Config) bool {
+	return strings.EqualFold(strings.TrimSpace(cfg.Source.Kind), "s3")
+}
+
+// localizeDocument resolves relPath to a real local filesystem path the
+// on-demand tool paths can read (ffmpeg extraction, a bounded os.Stat+read),
+// plus a cleanup func the caller MUST invoke on EVERY path including errors.
+// The returned cleanup is never nil, so `defer cleanup()` immediately after the
+// call is always correct.
+//
+// For a local corpus this is exactly resolveDocumentPath: the in-root resolved
+// path, no copy, a no-op cleanup. For an object store it is a temporary download
+// through CorpusFS.Localize, because S3FS.Walk ignores RootDir and reports no
+// local path (DiscoveredFile.AbsPath == ""), so RootDir/rel_path names a file
+// that does not exist and every on-demand branch failed with ENOENT (#759).
+func (s *Server) localizeDocument(ctx context.Context, relPath string) (string, func(), error) {
+	fsys := s.corpusFSForOnDemand()
+	if fsys == nil {
+		resolved, err := s.resolveDocumentPath(relPath)
+		if err != nil {
+			return "", noopCleanup, err
+		}
+		return resolved, noopCleanup, nil
+	}
+	// Containment and the corpus path-exclusion policy are enforced BEFORE the
+	// fetch. Localize on an object store downloads the object, so checking after
+	// it would mean an operator-excluded file is pulled out of the bucket and
+	// written to the local cache before being refused.
+	normalized, err := s.checkRemoteDocumentPolicy(relPath)
+	if err != nil {
+		return "", noopCleanup, err
+	}
+	localPath, cleanup, err := fsys.Localize(ctx, normalized)
+	if err != nil {
+		// The contract is that a failed Localize materialized nothing, but call a
+		// non-nil cleanup anyway rather than trusting every backend to honour it.
+		if cleanup != nil {
+			cleanup()
+		}
+		return "", noopCleanup, mapCorpusFSError(err)
+	}
+	if cleanup == nil {
+		cleanup = noopCleanup
+	}
+	return localPath, cleanup, nil
+}
+
+// checkRemoteDocumentPolicy is the backend-independent half of
+// resolveDocumentPath: root containment plus the corpus path-exclusion policy
+// (#407), with no filesystem involved. It returns the rel_path to hand to the
+// backend, unchanged.
+//
+// Containment comes from relpath.Normalize (#735), which is the same rule S3
+// discovery applies to every key it emits, rather than from EvalSymlinks, which
+// means nothing for an object store. It is deliberately stricter than the local
+// branch's filepath.Clean: a rel_path whose cleaned form differs from itself
+// (`a//b.mp3`, `./a.mp3`, a trailing slash) is REFUSED rather than rewritten,
+// because an S3 key is an opaque byte string and cleaning it would both address
+// a different object than the caller named and let a path dodge an exclusion
+// glob that the un-cleaned form matches.
+func (s *Server) checkRemoteDocumentPolicy(relPath string) (string, error) {
+	// No TrimSpace: leading/trailing spaces are legal, meaningful bytes in an S3
+	// key, and trimming would address a different object than the corpus indexed
+	// (the same reason corpusfs.keyForRel does not trim).
+	normalized, err := relpath.Normalize(relPath)
+	if err != nil {
+		return "", model.ErrPathOutsideRoot
+	}
+	if ingest.MatchesAnyPathExclude(normalized, s.cfg.PathExcludes) {
+		return "", model.ErrForbidden
+	}
+	return normalized, nil
+}
+
+// mapCorpusFSError translates a CorpusFS failure into the sentinels the tool
+// error mappers (mapPathError/mapReadDocumentError/annotationReadError) already
+// understand, so a backend refusal reports PATH_OUTSIDE_ROOT rather than the
+// generic fallback. Backend errors are wrapped, never re-worded: they can carry
+// a bucket/key or a local cache path, and the mappers emit fixed messages.
+func mapCorpusFSError(err error) error {
+	switch {
+	case errors.Is(err, corpusfs.ErrPathEscapesRoot),
+		errors.Is(err, relpath.ErrOutsideRoot),
+		errors.Is(err, relpath.ErrNotRelative):
+		return model.ErrPathOutsideRoot
+	default:
+		return err
+	}
 }
 
 func (s *Server) resolveDocumentPath(relPath string) (string, error) {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2749,9 +2749,12 @@ func (s *Server) localizeDocument(ctx context.Context, relPath string) (string, 
 // a different object than the caller named and let a path dodge an exclusion
 // glob that the un-cleaned form matches.
 func (s *Server) checkRemoteDocumentPolicy(relPath string) (string, error) {
-	// No TrimSpace: leading/trailing spaces are legal, meaningful bytes in an S3
-	// key, and trimming would address a different object than the corpus indexed
-	// (the same reason corpusfs.keyForRel does not trim).
+	// No TrimSpace here: leading/trailing spaces are legal, meaningful bytes in
+	// an S3 key, and trimming would address a different object than the caller
+	// named (the same reason corpusfs.keyForRel does not trim). It only means
+	// this check adds no trim of its own; a rel_path arriving through the store
+	// has already been trimmed by store.normalizeRelPath, so such a key cannot
+	// currently round-trip through the corpus at all.
 	normalized, err := relpath.Normalize(relPath)
 	if err != nil {
 		return "", model.ErrPathOutsideRoot

--- a/tests/mcp/media_corpusfs_759_test.go
+++ b/tests/mcp/media_corpusfs_759_test.go
@@ -227,6 +227,11 @@ func TestOpenMediaClip_S3Corpus_CutsFromLocalizedCopy(t *testing.T) {
 	if sawPath == filepath.Join(c.cfg.RootDir, "media", "voice.mp3") {
 		t.Fatalf("extraction used the reconstructed RootDir path %q; it must come from the CorpusFS", sawPath)
 	}
+	// The copy lives in the backend's own cache dir under the (always local)
+	// state dir, not anywhere under the corpus root.
+	if !strings.HasPrefix(sawPath, c.cacheDir+string(os.PathSeparator)) {
+		t.Fatalf("extraction path %q is not inside the CorpusFS cache dir %q", sawPath, c.cacheDir)
+	}
 	if got := len(c.client.gets); got != 1 {
 		t.Fatalf("GetObject called %d time(s), want exactly 1: %v", got, c.client.gets)
 	}
@@ -303,8 +308,8 @@ func TestAnnotate_S3Corpus_ReadsDocumentContent(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }()
 
 	// FORBIDDEN here is the secret-content gate, which runs on bytes that were
-	// actually read. Before the fix this was PERMISSION_DENIED from the failed
-	// path resolution.
+	// actually read. Before the fix this was FILE_NOT_FOUND, the ENOENT from the
+	// failed path resolution.
 	assertToolCallErrorCode(t, resp, protocol.ErrorCodeForbidden)
 	if len(c.client.gets) == 0 {
 		t.Fatal("no object was fetched; the content was not read through the CorpusFS")

--- a/tests/mcp/media_corpusfs_759_test.go
+++ b/tests/mcp/media_corpusfs_759_test.go
@@ -142,11 +142,13 @@ func newS3Corpus(t *testing.T, objects map[string][]byte) *s3Corpus {
 
 // seedDoc records an already-indexed document, the state an S3 corpus is in
 // after a successful scan (which is precisely when #759 bit: indexing worked,
-// the on-demand tools did not).
+// the on-demand tools did not). SourceType is "filesystem" for an S3 corpus too:
+// the store normalizes source_type to archive_member or filesystem, and there is
+// no per-backend value.
 func seedDoc(t *testing.T, st *store.SQLiteStore, relPath, docType string, size int) {
 	t.Helper()
 	if err := st.UpsertDocument(context.Background(), model.Document{
-		RelPath: relPath, DocType: docType, SourceType: "s3",
+		RelPath: relPath, DocType: docType, SourceType: "filesystem",
 		SizeBytes: int64(size), MTimeUnix: 1, ContentHash: "seed", Status: "ok",
 	}); err != nil {
 		t.Fatalf("upsert document %q: %v", relPath, err)

--- a/tests/mcp/media_corpusfs_759_test.go
+++ b/tests/mcp/media_corpusfs_759_test.go
@@ -1,0 +1,529 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/corpusfs"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/protocol"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// Issue #759: the MCP on-demand media paths reconstructed a local path as
+// RootDir+rel_path. S3FS.Walk ignores RootDir and reports no local path
+// (DiscoveredFile.AbsPath == ""), so nothing exists at that path for an
+// object-store corpus and open_media_clip, on-demand audio init and on-demand
+// content reads all failed on a corpus that indexed fine.
+//
+// The tests below drive the three entry points against a real corpusfs.S3FS
+// over a network-free stub client (the shape of tests/corpusfs/s3_test.go's
+// newFakeS3FS, which lives in another package), and pin the two guarantees that
+// had to survive the fix: root containment and the #407 path-exclusion policy,
+// both enforced BEFORE any object is fetched.
+
+// stubS3 is a network-free stand-in for the S3 client surface corpusfs.S3FS
+// uses. It serves objects from memory and records every GetObject key so a test
+// can assert that a refused request fetched NOTHING.
+type stubS3 struct {
+	objects map[string][]byte
+	gets    []string
+}
+
+func (f *stubS3) ListObjectsV2(_ context.Context, in *s3.ListObjectsV2Input, _ ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
+	prefix := aws.ToString(in.Prefix)
+	out := &s3.ListObjectsV2Output{IsTruncated: aws.Bool(false)}
+	for key, body := range f.objects {
+		if !strings.HasPrefix(key, prefix) {
+			continue
+		}
+		out.Contents = append(out.Contents, s3types.Object{
+			Key:          aws.String(key),
+			Size:         aws.Int64(int64(len(body))),
+			ETag:         aws.String("\"etag-" + key + "\""),
+			LastModified: aws.Time(time.Unix(1700000000, 0)),
+		})
+	}
+	return out, nil
+}
+
+func (f *stubS3) HeadObject(_ context.Context, in *s3.HeadObjectInput, _ ...func(*s3.Options)) (*s3.HeadObjectOutput, error) {
+	body, ok := f.objects[aws.ToString(in.Key)]
+	if !ok {
+		return nil, &s3types.NoSuchKey{}
+	}
+	return &s3.HeadObjectOutput{ContentLength: aws.Int64(int64(len(body)))}, nil
+}
+
+func (f *stubS3) GetObject(_ context.Context, in *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	key := aws.ToString(in.Key)
+	f.gets = append(f.gets, key)
+	body, ok := f.objects[key]
+	if !ok {
+		return nil, &s3types.NoSuchKey{}
+	}
+	return &s3.GetObjectOutput{Body: io.NopCloser(bytes.NewReader(body))}, nil
+}
+
+// s3Corpus is the fixture for an S3-backed MCP server: the config, the live
+// store, the stub client (for fetch assertions) and the download cache dir (for
+// cleanup assertions).
+type s3Corpus struct {
+	cfg      config.Config
+	store    *store.SQLiteStore
+	client   *stubS3
+	fsys     corpusfs.CorpusFS
+	cacheDir string
+}
+
+const s3CorpusPrefix = "corpus/"
+
+// newS3Corpus builds an MCP config whose corpus source is s3, plus a real
+// corpusfs.S3FS over a stub client. objects are keyed by rel_path (the prefix is
+// added here).
+//
+// RootDir points at a real, EMPTY directory: the root exists, so a failure can
+// only come from the missing RootDir/rel_path file, which is exactly the #759
+// bug and not a "root does not exist" artifact.
+func newS3Corpus(t *testing.T, objects map[string][]byte) *s3Corpus {
+	t.Helper()
+	rootDir := t.TempDir()
+	stateDir := t.TempDir()
+	cacheDir := filepath.Join(stateDir, "corpus-cache")
+
+	keyed := make(map[string][]byte, len(objects))
+	for rel, body := range objects {
+		keyed[s3CorpusPrefix+rel] = body
+	}
+	client := &stubS3{objects: keyed}
+	fsys, err := corpusfs.NewS3FS(client, corpusfs.S3Config{
+		Bucket:   "bkt",
+		Prefix:   s3CorpusPrefix,
+		CacheDir: cacheDir,
+	})
+	if err != nil {
+		t.Fatalf("NewS3FS: %v", err)
+	}
+
+	st := store.NewSQLiteStore(filepath.Join(stateDir, "meta.sqlite"))
+	if err := st.Init(context.Background()); err != nil {
+		t.Fatalf("init sqlite store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	cfg := config.Default()
+	cfg.RootDir = rootDir
+	cfg.StateDir = stateDir
+	cfg.MCPPath = protocol.DefaultMCPPath
+	cfg.AuthMode = "none"
+	cfg.Source.Kind = "s3"
+	cfg.Source.S3Bucket = "bkt"
+	cfg.Source.S3Prefix = s3CorpusPrefix
+	cfg.Source.S3Region = "us-east-1"
+
+	return &s3Corpus{cfg: cfg, store: st, client: client, fsys: fsys, cacheDir: cacheDir}
+}
+
+// seedDoc records an already-indexed document, the state an S3 corpus is in
+// after a successful scan (which is precisely when #759 bit: indexing worked,
+// the on-demand tools did not).
+func seedDoc(t *testing.T, st *store.SQLiteStore, relPath, docType string, size int) {
+	t.Helper()
+	if err := st.UpsertDocument(context.Background(), model.Document{
+		RelPath: relPath, DocType: docType, SourceType: "s3",
+		SizeBytes: int64(size), MTimeUnix: 1, ContentHash: "seed", Status: "ok",
+	}); err != nil {
+		t.Fatalf("upsert document %q: %v", relPath, err)
+	}
+}
+
+// assertNoFetch fails when any object was fetched. It is the assertion that a
+// refusal happened BEFORE the download, not after it.
+func assertNoFetch(t *testing.T, c *s3Corpus) {
+	t.Helper()
+	if len(c.client.gets) != 0 {
+		t.Fatalf("expected no object fetch, got GetObject for %v", c.client.gets)
+	}
+}
+
+// assertCacheEmpty fails when a localized copy survived the request, which is
+// how a missed cleanup on an error path shows up.
+func assertCacheEmpty(t *testing.T, c *s3Corpus) {
+	t.Helper()
+	entries, err := os.ReadDir(c.cacheDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return // nothing was ever downloaded
+		}
+		t.Fatalf("read cache dir: %v", err)
+	}
+	if len(entries) != 0 {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("localized copies left behind in %s: %v", c.cacheDir, names)
+	}
+}
+
+func (c *s3Corpus) start(t *testing.T, extra ...mcp.ServerOption) (*httptest.Server, string) {
+	t.Helper()
+	opts := append([]mcp.ServerOption{mcp.WithStore(c.store), mcp.WithCorpusFS(c.fsys)}, extra...)
+	srv := httptest.NewServer(mcp.NewServer(c.cfg, nil, opts...).Handler())
+	t.Cleanup(srv.Close)
+	return srv, initializeSession(t, srv.URL+c.cfg.MCPPath)
+}
+
+// TestOpenMediaClip_S3Corpus_CutsFromLocalizedCopy pins entry point 1
+// (handleOpenMediaClipTool). Before the fix the request died in
+// resolveDocumentPath with ENOENT on RootDir/rel_path; extraction now runs
+// against a localized copy whose bytes are the object's.
+func TestOpenMediaClip_S3Corpus_CutsFromLocalizedCopy(t *testing.T) {
+	media := []byte("ID3-S3-OBJECT-AUDIO-BYTES")
+	c := newS3Corpus(t, map[string][]byte{"media/voice.mp3": media})
+	seedDoc(t, c.store, "media/voice.mp3", "audio", len(media))
+
+	var sawPath string
+	var sawBytes []byte
+	clip := &clipExtractStub{data: []byte("CLIPPED")}
+	extract := func(ctx context.Context, path string, startMS, endMS int) ([]byte, error) {
+		sawPath = path
+		// Read the file the handler handed us WHILE it is still alive: the whole
+		// point is that a real, readable path exists at extraction time.
+		sawBytes, _ = os.ReadFile(path)
+		return clip.extract(ctx, path, startMS, endMS)
+	}
+
+	srv, session := c.start(t, mcp.WithExtractSegment(extract))
+	resp := postRPC(t, srv.URL+c.cfg.MCPPath, session,
+		`{"jsonrpc":"2.0","id":7591,"method":"tools/call","params":{"name":"dir2mcp_open_media_clip","arguments":{"rel_path":"media/voice.mp3","start_ms":0,"end_ms":1000}}}`)
+	defer func() { _ = resp.Body.Close() }()
+
+	sc := decodeClipResult(t, resp)
+	if sc["rel_path"] != "media/voice.mp3" {
+		t.Fatalf("rel_path = %#v, want media/voice.mp3", sc["rel_path"])
+	}
+	if !bytes.Equal(sawBytes, media) {
+		t.Fatalf("extraction read %q, want the object bytes %q", sawBytes, media)
+	}
+	if sawPath == filepath.Join(c.cfg.RootDir, "media", "voice.mp3") {
+		t.Fatalf("extraction used the reconstructed RootDir path %q; it must come from the CorpusFS", sawPath)
+	}
+	if got := len(c.client.gets); got != 1 {
+		t.Fatalf("GetObject called %d time(s), want exactly 1: %v", got, c.client.gets)
+	}
+	// The copy is released once the clip is cut.
+	assertCacheEmpty(t, c)
+}
+
+// TestOpenMediaClip_S3Corpus_ReleasesCopyOnExtractFailure pins the cleanup
+// contract on an error path: the localized copy must not survive a failed
+// extraction.
+func TestOpenMediaClip_S3Corpus_ReleasesCopyOnExtractFailure(t *testing.T) {
+	media := []byte("ID3-S3-OBJECT-AUDIO-BYTES")
+	c := newS3Corpus(t, map[string][]byte{"media/voice.mp3": media})
+	seedDoc(t, c.store, "media/voice.mp3", "audio", len(media))
+
+	clip := &clipExtractStub{err: os.ErrInvalid}
+	srv, session := c.start(t, mcp.WithExtractSegment(clip.extract))
+	resp := postRPC(t, srv.URL+c.cfg.MCPPath, session,
+		`{"jsonrpc":"2.0","id":7592,"method":"tools/call","params":{"name":"dir2mcp_open_media_clip","arguments":{"rel_path":"media/voice.mp3","start_ms":0,"end_ms":1000}}}`)
+	defer func() { _ = resp.Body.Close() }()
+
+	assertToolCallErrorCode(t, resp, "MEDIA_CLIP_FAILED")
+	if clip.gotPath == "" {
+		t.Fatal("extraction was never reached; the media was not localized")
+	}
+	assertCacheEmpty(t, c)
+	if _, err := os.Stat(clip.gotPath); err == nil {
+		t.Fatalf("localized copy %s survived the failed extraction", clip.gotPath)
+	}
+}
+
+// TestTranscribeOnDemand_S3Corpus_InitializesDocumentFromObject pins entry
+// point 2 (initAudioDocumentOnDemand): an audio object that is not yet indexed
+// gets its document row created from the object's bytes. Transcription itself
+// then fails for want of a provider, which is irrelevant here — the assertion
+// is the persisted row, which only exists if the bytes were reachable.
+func TestTranscribeOnDemand_S3Corpus_InitializesDocumentFromObject(t *testing.T) {
+	media := []byte("RIFF0000WAVEfmt s3-audio")
+	c := newS3Corpus(t, map[string][]byte{"fresh.wav": media})
+
+	srv, session := c.start(t)
+	resp := postRPC(t, srv.URL+c.cfg.MCPPath, session,
+		`{"jsonrpc":"2.0","id":7593,"method":"tools/call","params":{"name":"dir2mcp_transcribe","arguments":{"rel_path":"fresh.wav"}}}`)
+	defer func() { _ = resp.Body.Close() }()
+
+	doc, err := c.store.GetDocumentByPath(context.Background(), "fresh.wav")
+	if err != nil {
+		t.Fatalf("on-demand init did not create the document row: %v", err)
+	}
+	if doc.DocType != "audio" {
+		t.Fatalf("doc_type = %q, want audio", doc.DocType)
+	}
+	if doc.SizeBytes != int64(len(media)) {
+		t.Fatalf("size_bytes = %d, want %d", doc.SizeBytes, len(media))
+	}
+	if want := ingest.ComputeContentHash(media); doc.ContentHash != want {
+		t.Fatalf("content_hash = %q, want %q (the hash of the OBJECT bytes)", doc.ContentHash, want)
+	}
+	assertCacheEmpty(t, c)
+}
+
+// TestAnnotate_S3Corpus_ReadsDocumentContent pins entry point 3
+// (readDocumentContent). The document's bytes carry a secret-pattern match, so
+// a successful read is observable without any provider: the secret gate refuses
+// with FORBIDDEN, which can only happen once the content has been read.
+func TestAnnotate_S3Corpus_ReadsDocumentContent(t *testing.T) {
+	content := []byte("aws key " + exampleAWSKey)
+	c := newS3Corpus(t, map[string][]byte{"note.txt": content})
+	seedDoc(t, c.store, "note.txt", "text", len(content))
+
+	srv, session := c.start(t)
+	resp := postRPC(t, srv.URL+c.cfg.MCPPath, session,
+		`{"jsonrpc":"2.0","id":7594,"method":"tools/call","params":{"name":"dir2mcp_annotate","arguments":{"rel_path":"note.txt","schema_json":{"type":"object"}}}}`)
+	defer func() { _ = resp.Body.Close() }()
+
+	// FORBIDDEN here is the secret-content gate, which runs on bytes that were
+	// actually read. Before the fix this was PERMISSION_DENIED from the failed
+	// path resolution.
+	assertToolCallErrorCode(t, resp, protocol.ErrorCodeForbidden)
+	if len(c.client.gets) == 0 {
+		t.Fatal("no object was fetched; the content was not read through the CorpusFS")
+	}
+	assertCacheEmpty(t, c)
+}
+
+// TestTranscribeOnDemand_S3Corpus_ExcludedPathRefusedWithoutFetch is the
+// security half of #759: the #407 exclusion policy must still refuse an
+// operator-excluded path, and must do so BEFORE the object is downloaded.
+func TestTranscribeOnDemand_S3Corpus_ExcludedPathRefusedWithoutFetch(t *testing.T) {
+	c := newS3Corpus(t, map[string][]byte{"private/voice.wav": []byte("RIFF0000WAVEfmt secret")})
+	c.cfg.PathExcludes = append(c.cfg.PathExcludes, "private/**")
+
+	srv, session := c.start(t)
+	resp := postRPC(t, srv.URL+c.cfg.MCPPath, session,
+		`{"jsonrpc":"2.0","id":7595,"method":"tools/call","params":{"name":"dir2mcp_transcribe","arguments":{"rel_path":"private/voice.wav"}}}`)
+	defer func() { _ = resp.Body.Close() }()
+
+	assertToolCallErrorCode(t, resp, protocol.ErrorCodeForbidden)
+	assertNoFetch(t, c)
+	assertCacheEmpty(t, c)
+	if _, err := c.store.GetDocumentByPath(context.Background(), "private/voice.wav"); err == nil {
+		t.Fatal("an excluded path was initialized as a document")
+	}
+}
+
+// TestOpenMediaClip_S3Corpus_ExcludedPathRefusedWithoutFetch is the same
+// guarantee on the clip path, for a document that was indexed before the
+// operator added the exclusion.
+func TestOpenMediaClip_S3Corpus_ExcludedPathRefusedWithoutFetch(t *testing.T) {
+	media := []byte("ID3-private")
+	c := newS3Corpus(t, map[string][]byte{"private/voice.mp3": media})
+	seedDoc(t, c.store, "private/voice.mp3", "audio", len(media))
+	c.cfg.PathExcludes = append(c.cfg.PathExcludes, "private/**")
+
+	clip := &clipExtractStub{data: []byte("CLIPPED")}
+	srv, session := c.start(t, mcp.WithExtractSegment(clip.extract))
+	resp := postRPC(t, srv.URL+c.cfg.MCPPath, session,
+		`{"jsonrpc":"2.0","id":7596,"method":"tools/call","params":{"name":"dir2mcp_open_media_clip","arguments":{"rel_path":"private/voice.mp3","start_ms":0,"end_ms":1000}}}`)
+	defer func() { _ = resp.Body.Close() }()
+
+	assertToolCallErrorCode(t, resp, protocol.ErrorCodeForbidden)
+	assertNoFetch(t, c)
+	assertCacheEmpty(t, c)
+	if clip.gotPath != "" {
+		t.Fatalf("extraction ran on %q for an excluded path", clip.gotPath)
+	}
+}
+
+// toolCallErrorCode decodes an errored tool result and returns its canonical
+// code. It exists because a rel_path can be refused by more than one guard and
+// some assertions care that it WAS refused (and that nothing was fetched) more
+// than about which guard got there first.
+func toolCallErrorCode(t *testing.T, resp *http.Response) string {
+	t.Helper()
+	if resp.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d want=%d body=%s", resp.StatusCode, http.StatusOK, string(payload))
+	}
+	var envelope struct {
+		Result struct {
+			IsError           bool                   `json:"isError"`
+			StructuredContent map[string]interface{} `json:"structuredContent"`
+		} `json:"result"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !envelope.Result.IsError {
+		t.Fatalf("expected isError=true, got success with structuredContent=%#v", envelope.Result.StructuredContent)
+	}
+	errObj, _ := envelope.Result.StructuredContent["error"].(map[string]interface{})
+	code, _ := errObj["code"].(string)
+	if code == "" {
+		t.Fatalf("expected structuredContent.error.code, got %#v", envelope.Result.StructuredContent)
+	}
+	return code
+}
+
+// TestOnDemand_S3Corpus_RefusesPathsOutsideRoot pins root containment on the
+// object-store backend, where EvalSymlinks means nothing.
+//
+// A `..`/absolute rel_path never reaches the on-demand branch at all: the store's
+// own rel_path guard rejects it during the document lookup (STORE_CORRUPT), which
+// is why the assertion is "refused, and nothing fetched" rather than a specific
+// code. A doubled separator DOES reach it — the store cleans `media//voice.wav`
+// to `media/voice.wav` for the lookup — and is refused by the backend-independent
+// containment check, because an S3 key is a byte string and the two names are two
+// different objects.
+func TestOnDemand_S3Corpus_RefusesPathsOutsideRoot(t *testing.T) {
+	cases := []struct {
+		name     string
+		relPath  string
+		wantCode string // empty: any refusal is acceptable
+	}{
+		{name: "traversal", relPath: "../outside.wav"},
+		{name: "nested traversal", relPath: "media/../../outside.wav"},
+		{name: "absolute", relPath: "/etc/secret.wav"},
+		{name: "doubled separator", relPath: "media//voice.wav", wantCode: "PATH_OUTSIDE_ROOT"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newS3Corpus(t, map[string][]byte{"media/voice.wav": []byte("RIFF0000WAVEfmt x")})
+			srv, session := c.start(t)
+			resp := postRPC(t, srv.URL+c.cfg.MCPPath, session,
+				`{"jsonrpc":"2.0","id":7597,"method":"tools/call","params":{"name":"dir2mcp_transcribe","arguments":{"rel_path":"`+tc.relPath+`"}}}`)
+			defer func() { _ = resp.Body.Close() }()
+
+			if got := toolCallErrorCode(t, resp); tc.wantCode != "" && got != tc.wantCode {
+				t.Fatalf("error code = %q, want %q", got, tc.wantCode)
+			}
+			assertNoFetch(t, c)
+			assertCacheEmpty(t, c)
+		})
+	}
+}
+
+// unusableCorpusFS fails the test if it is ever consulted. A local corpus must
+// keep resolving through the filesystem, so an injected backend is inert.
+type unusableCorpusFS struct{ t *testing.T }
+
+func (f *unusableCorpusFS) Walk(context.Context, string, corpusfs.Options) ([]corpusfs.DiscoveredFile, error) {
+	f.t.Fatal("Walk called for a local corpus")
+	return nil, nil
+}
+
+func (f *unusableCorpusFS) Open(context.Context, string) (io.ReadSeekCloser, error) {
+	f.t.Fatal("Open called for a local corpus")
+	return nil, nil
+}
+
+func (f *unusableCorpusFS) Localize(context.Context, string) (string, func(), error) {
+	f.t.Fatal("Localize called for a local corpus: local resolution must be unchanged")
+	return "", nil, nil
+}
+
+// TestOpenMediaClip_LocalCorpus_UsesInRootPathUnchanged pins that a local
+// corpus is untouched by the fix: extraction gets the symlink-resolved in-root
+// path, no copy is made, and an injected CorpusFS is never consulted.
+func TestOpenMediaClip_LocalCorpus_UsesInRootPathUnchanged(t *testing.T) {
+	media := []byte("ID3-local-audio")
+	cfg, st, rootDir := setupMCPToolStore(t, "media/voice.mp3", "audio", media)
+
+	clip := &clipExtractStub{data: []byte("CLIPPED")}
+	srv := httptest.NewServer(mcp.NewServer(cfg, nil,
+		mcp.WithStore(st),
+		mcp.WithExtractSegment(clip.extract),
+		mcp.WithCorpusFS(&unusableCorpusFS{t: t}),
+	).Handler())
+	defer srv.Close()
+
+	session := initializeSession(t, srv.URL+cfg.MCPPath)
+	resp := postRPC(t, srv.URL+cfg.MCPPath, session,
+		`{"jsonrpc":"2.0","id":7598,"method":"tools/call","params":{"name":"dir2mcp_open_media_clip","arguments":{"rel_path":"media/voice.mp3","start_ms":0,"end_ms":1000}}}`)
+	defer func() { _ = resp.Body.Close() }()
+
+	decodeClipResult(t, resp)
+	// The in-root file itself, symlink-resolved (t.TempDir hands back a path
+	// under a symlinked /var on macOS), and NOT a copy.
+	want, err := filepath.EvalSymlinks(filepath.Join(rootDir, "media", "voice.mp3"))
+	if err != nil {
+		t.Fatalf("eval symlinks: %v", err)
+	}
+	if clip.gotPath != want {
+		t.Fatalf("extraction path = %q, want the in-root file %q", clip.gotPath, want)
+	}
+	got, err := os.ReadFile(clip.gotPath)
+	if err != nil || !bytes.Equal(got, media) {
+		t.Fatalf("extraction path does not hold the source bytes: %v / %q", err, got)
+	}
+}
+
+// TestOnDemand_LocalCorpus_RefusesTraversal pins that containment on the local
+// backend still refuses a traversal rel_path, and that an escaping path reaching
+// the on-demand branch is refused there with PATH_OUTSIDE_ROOT.
+func TestOnDemand_LocalCorpus_RefusesTraversal(t *testing.T) {
+	cfg, st, rootDir := setupMCPToolStore(t, "voice.wav", "audio", []byte("RIFF0000WAVEfmt x"))
+	// A real file one level above the corpus root: the traversal must not reach it.
+	if err := os.WriteFile(filepath.Join(filepath.Dir(rootDir), "outside.wav"), []byte("RIFF0000WAVEfmt outside"), 0o644); err != nil {
+		t.Fatalf("write out-of-root file: %v", err)
+	}
+
+	srv := httptest.NewServer(mcp.NewServer(cfg, nil,
+		mcp.WithStore(st),
+		mcp.WithCorpusFS(&unusableCorpusFS{t: t}),
+	).Handler())
+	defer srv.Close()
+
+	session := initializeSession(t, srv.URL+cfg.MCPPath)
+	resp := postRPC(t, srv.URL+cfg.MCPPath, session,
+		`{"jsonrpc":"2.0","id":7599,"method":"tools/call","params":{"name":"dir2mcp_transcribe","arguments":{"rel_path":"../outside.wav"}}}`)
+	defer func() { _ = resp.Body.Close() }()
+
+	// The store's rel_path guard refuses it during the lookup, before the
+	// on-demand branch; either refusal is fine, reaching the file is not.
+	toolCallErrorCode(t, resp)
+	if _, err := st.GetDocumentByPath(context.Background(), "outside.wav"); err == nil {
+		t.Fatal("an out-of-root file was initialized as a document")
+	}
+}
+
+// TestOnDemand_LocalCorpus_RefusesSymlinkToExcludedTarget pins the local-only
+// half of the exclusion guarantee: a symlink whose REAL target is excluded is
+// refused. That check is expressed in resolved symlinks and has no object-store
+// analogue, which is why a local corpus must keep resolving through the
+// filesystem rather than through an injected backend.
+func TestOnDemand_LocalCorpus_RefusesSymlinkToExcludedTarget(t *testing.T) {
+	cfg, st, rootDir := setupMCPToolStore(t, "private/voice.wav", "audio", []byte("RIFF0000WAVEfmt secret"))
+	cfg.PathExcludes = append(cfg.PathExcludes, "private/**")
+	if err := os.Symlink(filepath.Join(rootDir, "private", "voice.wav"), filepath.Join(rootDir, "link.wav")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	srv := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st)).Handler())
+	defer srv.Close()
+
+	session := initializeSession(t, srv.URL+cfg.MCPPath)
+	resp := postRPC(t, srv.URL+cfg.MCPPath, session,
+		`{"jsonrpc":"2.0","id":7600,"method":"tools/call","params":{"name":"dir2mcp_transcribe","arguments":{"rel_path":"link.wav"}}}`)
+	defer func() { _ = resp.Body.Close() }()
+
+	assertToolCallErrorCode(t, resp, protocol.ErrorCodeForbidden)
+}


### PR DESCRIPTION
Closes #759.

## What was broken

`internal/mcp/tools.go::resolveDocumentPath` built `filepath.Join(RootDir, rel_path)` and then `filepath.EvalSymlinks`'d it. `S3FS.Walk` ignores its `root` argument and emits `DiscoveredFile{AbsPath: ""}`, so for `source.kind=s3` there is no file at that path and the resolve failed with ENOENT before any tool logic ran. All three callers were affected: `handleOpenMediaClipTool`, `initAudioDocumentOnDemand`, `readDocumentContent` (three call sites).

I reproduced it rather than taking the issue's word for it: with the fix's dispatch forced back to the old branch, the new tests report `FILE_NOT_FOUND` (the ENOENT, mapped) on the clip path, the annotate read path and the on-demand init path. See "Proving the tests fail first" below.

## What changed

- `mcp.WithCorpusFS` injects the corpus filesystem at construction; `up.go` builds it once (moved a few lines earlier) and passes it to both the ingestor/retriever wiring and the server.
- `Server.localizeDocument(ctx, relPath) (path, cleanup, error)` is the single resolution seam for all three entry points. The returned cleanup is **never nil**, so `defer cleanup()` on the line after the call is always correct, and it is called on every path: success, `MEDIA_CLIP_FAILED`, `CLIP_TOO_LARGE`, `FILE_TOO_LARGE`, store errors, and the failed-`Localize` path itself (where a non-nil cleanup is invoked defensively even though the contract says nothing was materialized).
- `readDocumentContent` takes a `ctx` (all three call sites already had one).

### The two guarantees

**Containment.** For a non-local corpus it comes from `relpath.Normalize` (#735), the same rule S3 discovery applies to every key it emits, because `EvalSymlinks` means nothing for an object store. A local corpus keeps `resolveDocumentPath` verbatim, including the symlink-target re-check.

**Exclusion (#407).** `checkRemoteDocumentPolicy` runs `ingest.MatchesAnyPathExclude` **before** `Localize`, so an excluded object is never fetched. This is load-bearing, not decorative: with the exclusion check deleted, `TestOpenMediaClip_S3Corpus_ExcludedPathRefusedWithoutFetch` goes green-path and returns the clip bytes of the excluded file. The test asserts `GetObject` was called **zero** times, not merely that the call was refused.

### Why the local branch is not routed through `LocalFS.Localize`

`LocalFS.Localize` would give the right path (resolved in-root, no copy), but `resolveDocumentPath` does one thing it cannot: after `EvalSymlinks`, it re-applies the exclusion policy to the **symlink-resolved** rel path, so `link.wav -> private/voice.wav` is refused when `private/**` is excluded. That check has no object-store analogue, so rather than reimplement it generically I left the local path untouched and gated the CorpusFS branch on `corpusFS != nil && source.kind == s3`. Gating on the source kind as well as on injection means an accidentally injected local backend cannot silently downgrade that guarantee. `TestOnDemand_LocalCorpus_RefusesSymlinkToExcludedTarget` pins it, and the local tests inject a CorpusFS whose every method fails the test if called.

## Where the issue's framing needed adjusting

Two places, both about what is reachable rather than about the diagnosis:

1. **`..` and absolute rel_paths never reach the on-demand branch on either backend.** The store's own `normalizeRelPath` rejects them during the document lookup that precedes it, so the observable code is `STORE_CORRUPT`, not `PATH_OUTSIDE_ROOT`. I did not change that (it is a correct refusal with a poor code, and it is outside this issue). The traversal tests therefore assert "refused, and nothing fetched, and no document row created" rather than pinning a code that the on-demand branch does not get to produce. The case that *does* reach the new containment check is a doubled separator (`media//voice.wav`, which the store cleans for the lookup but which names a different S3 object), and that one is pinned to `PATH_OUTSIDE_ROOT`.

2. **The remote branch is deliberately stricter than the local one.** The local branch cleans (`filepath.Clean`), so `media//voice.wav` and `./a.mp3` resolve. `relpath.Normalize` refuses them instead of rewriting them, because an S3 key is an opaque byte string: cleaning would address a different object than the caller named, and would also let a path dodge an exclusion glob that the uncleaned form matches. So the same rel_path can be accepted on a local corpus and refused on an S3 one. That asymmetry is intentional and it is what #735 established for discovery; the alternative (clean, then fetch) is the unsafe one.

## Known, unchanged, out of scope

- A `Localize` failure that is not a containment refusal (a missing object, a network error) maps to the existing default, `PERMISSION_DENIED`. `corpusfs` does not classify a NoSuchKey as `fs.ErrNotExist`, and teaching it to do so touches the embedding worker's error classification, so I left it alone rather than widen the blast radius. Worth a follow-up.
- `initAudioDocumentOnDemand` stats the localized copy, so for S3 the on-demand row's `MTimeUnix` is the download time, not the object's `LastModified`. Size and content hash are the object's. Discovery overwrites the row on the next scan. Commented in place.
- Transcribe reads the object twice (on-demand init, then `ensureTranscriptForAudioDoc`), so a first-time transcribe on S3 costs two GETs. Pre-existing shape; no correctness impact.

No spec change is needed: this restores behaviour SPEC §7.8 already requires on every backend.

## Tests

`tests/mcp/media_corpusfs_759_test.go`, driving a **real** `corpusfs.S3FS` over a network-free stub client (the shape of `tests/corpusfs/s3_test.go::newFakeS3FS`, which is in another package), so the S3 key mapping, `guardRel`, the temp download and the cleanup are the production ones. `RootDir` is a real but empty directory, so a failure can only come from the missing `RootDir/rel_path` and not from a missing root.

- all three entry points against an S3 corpus: the clip is cut from a copy holding the object's bytes (and *not* from the `RootDir` path); the on-demand row is created with the object's size and content hash; annotate's read is proven by the secret-content gate firing (`FORBIDDEN` only happens on bytes that were actually read, and it needs no provider)
- excluded path refused on S3 with `GetObject` called zero times, on both the transcribe and the clip path, and no document row created
- traversal/absolute/doubled-separator refused on S3 with nothing fetched; traversal refused locally with the out-of-root file never reached
- local unchanged: extraction gets the symlink-resolved in-root path holding the source bytes, no copy, and an injected CorpusFS is never consulted; a symlink to an excluded target is still `FORBIDDEN`
- cleanup: the cache dir is asserted empty after every request, including the failed-extraction one, and the localized path is asserted gone

### Proving the tests fail first

I did not stash the whole source change (the tests would not compile without `WithCorpusFS`). Instead I forced `corpusFSForOnDemand` to return nil, which is exactly the pre-fix dispatch, and ran the suite:

```
--- FAIL: TestOpenMediaClip_S3Corpus_CutsFromLocalizedCopy
    expected success, got error: {"code":"FILE_NOT_FOUND", ...}
--- FAIL: TestOpenMediaClip_S3Corpus_ReleasesCopyOnExtractFailure
    got="FILE_NOT_FOUND" want="MEDIA_CLIP_FAILED"
--- FAIL: TestTranscribeOnDemand_S3Corpus_InitializesDocumentFromObject
    on-demand init did not create the document row: file does not exist
--- FAIL: TestAnnotate_S3Corpus_ReadsDocumentContent
    got="FILE_NOT_FOUND" want="FORBIDDEN"
--- FAIL: TestOnDemand_S3Corpus_RefusesPathsOutsideRoot/doubled_separator
    error code = "FILE_NOT_FOUND", want "PATH_OUTSIDE_ROOT"
```

The exclusion and local-behaviour tests pass in both states by design: they are guard tests for what must *not* change, and their power is shown by the separate mutation above (deleting the exclusion check makes both exclusion tests fail, one of them by returning the excluded file's clip).

`make check` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SsfcqnbrNzpUEnSVJ3oow8

## Review

`coderabbit review --agent --committed` raised two findings; both are addressed in the follow-up commit:

- *"persist the configured corpus source type instead of hardcoding `SourceType: \"filesystem\"`"* — not valid as stated: `store.normalizeSourceType` collapses every value to `archive_member` or `filesystem`, and ingest does not set it either, so an S3-discovered document is already stored as `filesystem`. Writing `"s3"` would be normalized straight back. I did fix the mirror image of it in the test, which seeded `source_type="s3"` and implied a value that does not exist.
- *"preserve leading/trailing whitespace in `lookupDocumentForTool`"* — out of scope and moot: `store.normalizeRelPath` trims too, so a key with edge whitespace cannot round-trip through the corpus today regardless. I corrected my own comment, which overstated what the no-trim in `checkRemoteDocumentPolicy` buys.
