### PR TITLE
fix(mcp): report a secret-excluded document as skipped, not ok (#712)

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -3144,9 +3144,33 @@ func parseOptionalStringSlice(args map[string]interface{}, key string) ([]string
 	}
 }
 
+// normalizeFileStatus projects a stored document status onto the three values
+// the published list_files schema allows (`ok|skipped|error`, SPEC §5.1 and
+// spec/tools/schemas/list_files.json).
+//
+// The projection has to be conservative, because the default arm is what a
+// caller is told about any status this function does not know. Reporting a
+// withheld file as `ok` tells an agent a sensitive document was indexed
+// successfully, which is the opposite of true and the opposite of what every
+// other surface says about the same row.
+//
+// `secret_excluded` is a skip, not a success (#712). A document withheld for
+// containing secrets has zero searchable chunks, and the rest of the codebase
+// already agrees: CorpusStats counts `status IN ('skipped','secret_excluded')`
+// as skipped, and skip_summary.go pairs them the same way twice. This function
+// was the only place that disagreed, so `stats` reported a skip while
+// `list_files` reported the same document healthy.
+//
+// The store also normalizes a `pending` document status, which would fall
+// through to `ok` here. It is left alone deliberately: nothing in production
+// writes that value (every `pending` in the store is a CHUNK's
+// embedding_status), and the published enum has no state that honestly
+// describes "not indexed yet" — `skipped` would be a different lie. If a
+// document ever does become pending, this needs a spec-first status extension
+// rather than a guess.
 func normalizeFileStatus(status string) string {
 	switch strings.ToLower(strings.TrimSpace(status)) {
-	case "skipped":
+	case "skipped", "secret_excluded":
 		return "skipped"
 	case "error":
 		return "error"

--- a/tests/mcp/list_files_secret_excluded_712_test.go
+++ b/tests/mcp/list_files_secret_excluded_712_test.go
@@ -1,0 +1,168 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/protocol"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// #712: list_files reported every persisted `secret_excluded` document as
+// `status: "ok"`. `normalizeFileStatus` recognised only `skipped` and `error`,
+// so a document deliberately WITHHELD for containing secrets fell through the
+// default arm and was reported as successfully indexed.
+//
+// That is not merely cosmetic. It tells an agent a sensitive file was indexed
+// when it has zero searchable chunks, and it made the surfaces contradict each
+// other: CorpusStats counts `status IN ('skipped','secret_excluded')` as
+// skipped, and skip_summary.go pairs them the same way, so `stats` reported a
+// skip for the very row `list_files` called healthy. It also undid the
+// operator-facing audit value #425 restored by persisting the state at all.
+//
+// The published schema (spec/tools/schemas/list_files.json) pins status to
+// `ok|skipped|error`, so `skipped` is the conforming honest projection and no
+// spec change is needed.
+
+func TestListFilesReportsASecretExcludedDocumentAsSkipped(t *testing.T) {
+	tmp := t.TempDir()
+	st := store.NewSQLiteStore(filepath.Join(tmp, "meta.sqlite"))
+	if err := st.Init(context.Background()); err != nil {
+		t.Fatalf("init store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	seed := []model.Document{
+		{RelPath: "notes/ok.md", DocType: "md", MTimeUnix: 100, Status: "ok"},
+		{RelPath: "config/.env", DocType: "txt", MTimeUnix: 200, Status: "secret_excluded"},
+		{RelPath: "notes/big.bin", DocType: "bin", MTimeUnix: 300, Status: "skipped"},
+		{RelPath: "notes/bad.pdf", DocType: "pdf", MTimeUnix: 400, Status: "error"},
+	}
+	root := filepath.Join(tmp, "corpus")
+	seedCorpus(t, st, root, seed)
+
+	statuses := listFileStatuses(t, tmp, root, st)
+
+	if got := statuses["config/.env"]; got != "skipped" {
+		t.Fatalf("a withheld document is reported as %q; an agent is told a secret-bearing file was indexed (#712)", got)
+	}
+	// The projection must not disturb the states that were already correct.
+	if got := statuses["notes/ok.md"]; got != "ok" {
+		t.Fatalf("healthy document reported as %q", got)
+	}
+	if got := statuses["notes/big.bin"]; got != "skipped" {
+		t.Fatalf("skipped document reported as %q", got)
+	}
+	if got := statuses["notes/bad.pdf"]; got != "error" {
+		t.Fatalf("errored document reported as %q", got)
+	}
+}
+
+// TestListFilesStatusesStayInsideThePublishedEnum guards the projection itself
+// rather than one value: whatever the store grows next, this tool may only emit
+// the three states its schema advertises.
+func TestListFilesStatusesStayInsideThePublishedEnum(t *testing.T) {
+	tmp := t.TempDir()
+	st := store.NewSQLiteStore(filepath.Join(tmp, "meta.sqlite"))
+	if err := st.Init(context.Background()); err != nil {
+		t.Fatalf("init store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	docs := make([]model.Document, 0, 5)
+	for i, status := range []string{"ok", "skipped", "error", "secret_excluded", "pending"} {
+		docs = append(docs, model.Document{
+			RelPath:   "f" + string(rune('a'+i)) + ".md",
+			DocType:   "md",
+			MTimeUnix: int64(100 * (i + 1)),
+			Status:    status,
+		})
+	}
+	root := filepath.Join(tmp, "corpus")
+	seedCorpus(t, st, root, docs)
+
+	allowed := map[string]bool{"ok": true, "skipped": true, "error": true}
+	for relPath, status := range listFileStatuses(t, tmp, root, st) {
+		if !allowed[status] {
+			t.Fatalf("%s reported status %q, outside the published enum ok|skipped|error", relPath, status)
+		}
+	}
+}
+
+// seedCorpus writes a real file for each document and persists the row. The
+// listing resolves every row against the corpus root and drops what does not
+// exist there, so a store-only fixture returns nothing and would make this test
+// vacuous rather than failing.
+func seedCorpus(t *testing.T, st *store.SQLiteStore, root string, docs []model.Document) {
+	t.Helper()
+	for _, d := range docs {
+		full := filepath.Join(root, filepath.FromSlash(d.RelPath))
+		if err := os.MkdirAll(filepath.Dir(full), 0o700); err != nil {
+			t.Fatalf("mkdir for %s: %v", d.RelPath, err)
+		}
+		if err := os.WriteFile(full, []byte("x"), 0o600); err != nil {
+			t.Fatalf("write %s: %v", d.RelPath, err)
+		}
+		if err := st.UpsertDocument(context.Background(), d); err != nil {
+			t.Fatalf("seed %s: %v", d.RelPath, err)
+		}
+	}
+}
+
+// listFileStatuses calls the real dir2mcp_list_files tool over HTTP and returns
+// rel_path -> status. Going through the tool rather than the helper is the
+// point: the defect was in the projection the tool applies, and a unit test on
+// the store would have shown the correct `secret_excluded` all along.
+func listFileStatuses(t *testing.T, stateDir, root string, st *store.SQLiteStore) map[string]string {
+	t.Helper()
+	cfg := config.Default()
+	cfg.RootDir = root
+	cfg.StateDir = stateDir
+	cfg.MCPPath = protocol.DefaultMCPPath
+	cfg.AuthMode = "none"
+
+	server := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st)).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"dir2mcp_list_files","arguments":{"limit":50,"offset":0}}}`)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(resp.Body)
+		t.Fatalf("list_files status=%d body=%s", resp.StatusCode, payload)
+	}
+
+	var envelope struct {
+		Result struct {
+			StructuredContent struct {
+				Files []struct {
+					RelPath string `json:"rel_path"`
+					Status  string `json:"status"`
+				} `json:"files"`
+			} `json:"structuredContent"`
+		} `json:"result"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		t.Fatalf("decode list_files response: %v", err)
+	}
+	files := envelope.Result.StructuredContent.Files
+	if len(files) == 0 {
+		t.Fatal("list_files returned no files")
+	}
+	out := make(map[string]string, len(files))
+	for _, f := range files {
+		out[strings.TrimSpace(f.RelPath)] = f.Status
+	}
+	return out
+}


### PR DESCRIPTION
Closes #712.

`normalizeFileStatus` recognised only `skipped` and `error`, so every other stored status fell through to `ok`. A document deliberately **withheld for containing secrets** was reported to callers as successfully indexed, despite having zero searchable chunks.

The surfaces contradicted each other about the same row:

- `CorpusStats` counts `status IN ('skipped','secret_excluded')` as skipped
- `skip_summary.go` pairs them the same way, twice
- `list_files` called it healthy

This function was the only place that disagreed. It also undid the operator-facing audit value #425 restored by persisting the state at all.

The published schema pins status to `ok|skipped|error` (`spec/tools/schemas/list_files.json`), so `skipped` is the conforming honest projection — **no spec change needed**.

## The `pending` question, answered rather than ignored

The store also normalizes a `pending` document status, which falls through the same default arm. I left it alone deliberately, and recorded why at the call site:

- nothing in production writes it — verified, every `pending` in the store is a **chunk's** `embedding_status`, not a document status
- the published enum has no state that honestly describes "not indexed yet", so projecting it to `skipped` would be a different lie

If a document ever does become pending, that wants a spec-first status extension, not a guess.

## Tests

Two, driven through the real MCP tool over HTTP rather than the internal helper — the defect was in the projection the *tool* applies, and a store-level test would have shown the correct `secret_excluded` all along.

The first was **verified to fail pre-fix** with the reported symptom:

```
a withheld document is reported as "ok"; an agent is told a secret-bearing file was indexed (#712)
```

The second pins the projection itself: whatever status the store grows next, this tool may only emit the three states it advertises.

**Note for the next author of a `list_files` test:** the listing resolves every row against the corpus root and drops what does not exist there, so a store-only fixture returns zero files and makes such a test vacuous. My first draft did exactly that and passed trivially. The helper here writes a real file per document.

`make check` passes.