### PR TITLE
fix(auth): enforce owner-only permissions on a reused secret.token (#715)

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -1620,7 +1620,20 @@ func ensureRootAccessible(root string) error {
 // prepareAuthMaterial resolves the bearer-token auth material for the
 // configured auth mode: "none" disables auth, "auto" delegates to
 // prepareAutoAuthMaterial, and "file:<path>" loads a token from disk.
-func prepareAuthMaterial(cfg config.Config) (authMaterial, error) {
+//
+// The two token modes have deliberately different contracts. "auto" owns
+// <state-dir>/secret.token: dir2mcp creates it, may rewrite it, and enforces
+// the SPEC §4.2 owner-only requirement on it. "file:<path>" is
+// operator-managed: the path is read and required to be non-empty, and
+// nothing else. Its mode is not checked and never changed, because a
+// deliberately group-readable token shared with other processes on the host
+// is a legitimate setup there, and because that flag is the documented escape
+// hatch (SPEC §17) for a token that must live outside the state directory.
+//
+// warn receives operator-facing security notices; they are written whatever
+// the output mode, because a credential that may have been exposed is not
+// status chatter that --quiet asked to be spared.
+func prepareAuthMaterial(cfg config.Config, warn io.Writer) (authMaterial, error) {
 	mode := strings.TrimSpace(cfg.AuthMode)
 	if mode == "" {
 		mode = "auto"
@@ -1634,7 +1647,7 @@ func prepareAuthMaterial(cfg config.Config) (authMaterial, error) {
 	}
 
 	if strings.EqualFold(mode, "auto") {
-		return prepareAutoAuthMaterial(cfg)
+		return prepareAutoAuthMaterial(cfg, warn)
 	}
 
 	if len(mode) >= len("file:") && strings.EqualFold(mode[:len("file:")], "file:") {
@@ -1670,7 +1683,11 @@ func prepareAuthMaterial(cfg config.Config) (authMaterial, error) {
 // prepareAutoAuthMaterial resolves auth material in "auto" mode: it prefers
 // the env-var token, otherwise reads the persisted secret.token, generating
 // and persisting a new random token when none exists.
-func prepareAutoAuthMaterial(cfg config.Config) (authMaterial, error) {
+//
+// The persisted token is hardened before it is read or rewritten, so an
+// existing file is held to the same SPEC §4.2 owner-only requirement as one
+// this run creates (#715).
+func prepareAutoAuthMaterial(cfg config.Config, warn io.Writer) (authMaterial, error) {
 	if token := strings.TrimSpace(os.Getenv(authTokenEnvVar)); token != "" {
 		return authMaterial{
 			mode:              "auto",
@@ -1680,6 +1697,9 @@ func prepareAutoAuthMaterial(cfg config.Config) (authMaterial, error) {
 		}, nil
 	}
 	tokenPath := filepath.Join(cfg.StateDir, secretTokenName)
+	if err := hardenSecretToken(tokenPath, warn); err != nil {
+		return authMaterial{}, err
+	}
 	token, err := readToken(tokenPath, true)
 	if err != nil {
 		return authMaterial{}, err
@@ -1706,6 +1726,48 @@ func prepareAutoAuthMaterial(cfg config.Config) (authMaterial, error) {
 	}, nil
 }
 
+// hardenSecretToken enforces SPEC §4.2 on the auto-managed token file before
+// it is read or rewritten, and tells the operator when it had to.
+//
+// Repair rather than refuse: this file is dir2mcp's own, and the modes get
+// lost for mundane reasons (a corpus restored from a tarball, copied with
+// `cp -r`, created by an older build under a 022 umask). Refusing would turn
+// every one of those into a dead daemon for a condition the daemon can fix
+// itself. But the repair is announced, because tightening the file does not
+// un-read it: a token another local account could read may already be in that
+// account's hands, and only the operator knows whether this host has other
+// accounts that matter.
+//
+// It is announced rather than acted on, too. Rotating the token would be the
+// safe reflex, but it invalidates every client that already holds it (the
+// Claude/ElevenLabs registrations, connection.json consumers, anything with
+// the bearer baked into a config), so a permission repair on startup would
+// silently break a working deployment. Whether the exposure warrants that
+// depends on who else has an account on this host, which the daemon cannot
+// know, so the warning names the one command instead of guessing.
+//
+// A non-regular path is refused outright: see statefs.HardenSecret for why a
+// symlinked credential is a different question from a symlinked cache.
+func hardenSecretToken(path string, warn io.Writer) error {
+	prior, exists, err := statefs.HardenSecret(path)
+	if err != nil {
+		if errors.Is(err, statefs.ErrNotRegular) {
+			return fmt.Errorf("%w; auto auth owns this file: it reads it and may rewrite it, so it must be a plain "+
+				"file. Remove it to have a fresh token generated, or point --auth file:<path> at an "+
+				"operator-managed token", err)
+		}
+		return fmt.Errorf("secure %s: %w", path, err)
+	}
+	if !exists || !statefs.WiderThanOwnerOnly(prior) {
+		return nil
+	}
+	writef(warn, "warning: %s was mode %04o, readable by other local accounts, and has been tightened to %04o\n",
+		path, prior.Perm(), statefs.FileMode.Perm())
+	writef(warn, "warning: tightening does not undo the exposure. If other accounts on this host may have read it, "+
+		"rotate the token: stop the server, delete %s, start again (a new token is generated) and re-register your clients\n", path)
+	return nil
+}
+
 // readToken reads and trims the token at path; when allowMissing is set, a
 // missing file yields an empty token instead of an error.
 func readToken(path string, allowMissing bool) (string, error) {
@@ -1729,10 +1791,17 @@ func generateTokenHex() (string, error) {
 	return hex.EncodeToString(buf), nil
 }
 
-// writeSecretToken writes token to path with 0o600 permissions, truncating
-// any existing file.
+// writeSecretToken writes token to path owner-only, truncating any existing
+// file.
+//
+// statefs.Create rather than a bare os.OpenFile with the same mode: a create
+// mode says nothing about a file that already exists, so an existing token
+// left 0644 (by an older build, or by a restore that dropped the modes) would
+// otherwise keep that mode through every rewrite. statefs.Create tightens the
+// open descriptor, which also settles the case where the path was swapped
+// between the check in hardenSecretToken and this write.
 func writeSecretToken(path, token string) error {
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	file, err := statefs.Create(path)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -1643,7 +1643,7 @@ func (a *App) prepareUpConfig(opts upOptions) (config.Config, authMaterial, stri
 			"The embed provider/model changed since the index was built — run `dir2mcp reindex`, or restore the previous embed config.")
 		return config.Config{}, authMaterial{}, "", "", false, exitConfigInvalid
 	}
-	auth, err := prepareAuthMaterial(cfg)
+	auth, err := prepareAuthMaterial(cfg, a.stderr)
 	if err != nil {
 		writeCLIError(a.stderr, opts.jsonOutput, exitAuthOrPayment, fmt.Sprintf("auth setup: %v", err))
 		return config.Config{}, authMaterial{}, "", "", false, exitAuthOrPayment

--- a/internal/statefs/statefs.go
+++ b/internal/statefs/statefs.go
@@ -109,6 +109,65 @@ func Harden(path string) error {
 	return chmodInfoIfWider(path, info, want)
 }
 
+// ErrNotRegular reports a path that must be a plain file and is not: a
+// symlink, a FIFO, a socket, a device node or a directory.
+var ErrNotRegular = errors.New("not a regular file")
+
+// HardenSecret tightens an existing secret file to the owner-only mode and
+// reports the permissions it had beforehand, so the caller can tell the
+// operator that the secret had been readable by other local accounts.
+// Tightening does not undo an exposure, so silently repairing a credential
+// without saying anything would be the wrong kind of quiet.
+//
+// Two things this does that `Harden` does not, both because a credential is
+// not derived content:
+//
+//   - It refuses a path that is not a regular file, without following it.
+//     `HardenTree` deliberately skips symlinks, because for a cache the mode
+//     that matters is the target's and the target may live outside the tree
+//     on purpose. A symlinked credential is the case that must not be
+//     trusted: it is read from outside the state directory at whatever mode
+//     that target happens to have, and rewriting it truncates the target. An
+//     operator who wants the token to live elsewhere has `--auth file:<path>`,
+//     which is operator-managed by contract.
+//   - A missing path is not an error: it reports exists=false so the caller
+//     can create the file itself.
+//
+// Windows has no POSIX mode bits. Go synthesizes 0666/0444 from the read-only
+// attribute and os.Chmod can only toggle that attribute, so the tightening
+// degrades to a no-op there and the file's confidentiality rests on the NTFS
+// ACLs it inherits from the state directory; no ACL repair is attempted. The
+// regular-file refusal is enforced on every platform.
+//
+// The mode is checked and then changed by path, so a state directory another
+// account can write to leaves a small window between the two. That account can
+// replace the token outright anyway, which is the larger problem and not one a
+// chmod can fix.
+func HardenSecret(path string) (prior fs.FileMode, exists bool, err error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return 0, false, nil
+		}
+		return 0, false, err
+	}
+	if !info.Mode().IsRegular() {
+		return 0, true, fmt.Errorf("%s is %s: %w", path, info.Mode().String(), ErrNotRegular)
+	}
+	prior = info.Mode().Perm()
+	if err := chmodInfoIfWider(path, info, FileMode); err != nil {
+		return prior, true, err
+	}
+	return prior, true, nil
+}
+
+// WiderThanOwnerOnly reports whether mode grants any access beyond the owner.
+// On Windows the bits are synthetic (see HardenSecret), so this describes the
+// file the way Go reports it rather than the ACL that actually governs it.
+func WiderThanOwnerOnly(mode fs.FileMode) bool {
+	return mode.Perm()&^FileMode != 0
+}
+
 // HardenTree tightens root and everything under it.
 //
 // Called on the state directory at startup so a corpus indexed by an older

--- a/tests/security/auth_token_permissions_715_test.go
+++ b/tests/security/auth_token_permissions_715_test.go
@@ -1,0 +1,382 @@
+//go:build unix
+
+// POSIX permission bits, syscall.Umask and syscall.Mkfifo. Windows has no
+// umask and no mode bits: the owner-only guarantee there is an ACL contract
+// (see statefs.HardenSecret), which is not what these tests measure. The
+// non-regular-file refusal does apply on every platform.
+
+package tests
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/cli"
+	"github.com/dirstral/dir2mcp/internal/statefs"
+)
+
+// #715: auto auth REUSED an existing <state-dir>/secret.token without looking
+// at it. writeSecretToken passed 0600, but a create mode says nothing about a
+// file that already exists, and readToken only read bytes. SPEC §4.2 requires
+// that file to be owner-only.
+//
+// Measured on the unfixed tree, through a real `up`:
+//
+//   - a 0644 token was reused and ended up 0600, but only because #726's
+//     HardenTree happens to walk the state directory earlier in startup, and
+//     it does that silently. The auto-auth path itself enforced nothing.
+//   - a secret.token SYMLINK survived untouched: HardenTree deliberately skips
+//     links, so the token was read from outside the state directory at mode
+//     0644 and the server started as if it were private.
+//   - a symlink pointing at a file that trimmed to empty was written THROUGH:
+//     the generated token truncated and overwrote that file, in place, at its
+//     original 0644.
+//
+// The two symlink tests below fail on the unfixed tree (they exit 0 and the
+// outside file is read/overwritten). The mode tests pin the policy: repair,
+// never widen, never rotate behind the operator's back.
+
+const seededToken = "seeded-token-that-clients-already-hold"
+
+// upResult is what a scripted `up` run leaves behind for a test to measure.
+type upResult struct {
+	code   int
+	stderr string
+}
+
+// runUpInDir runs `up` in dir with auto auth, returning as soon as the daemon
+// has published connection.json (everything under test happens before that) or
+// as soon as it exits on its own.
+func runUpInDir(t *testing.T, dir string) upResult {
+	t.Helper()
+	t.Setenv("MISTRAL_API_KEY", "test-key")
+	t.Setenv("DIR2MCP_AUTH_TOKEN", "")
+	// The startup embed probe is a live API call; it is unrelated to auth
+	// material and would make this test depend on network reachability.
+	t.Setenv("DIR2MCP_SKIP_EMBED_PROBE", "1")
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+
+	original, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get cwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(original); err != nil {
+			t.Fatalf("restore cwd: %v", err)
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	done := make(chan int, 1)
+	go func() { done <- app.RunWithContext(ctx, []string{"up", "--listen", "127.0.0.1:0"}) }()
+
+	connection := filepath.Join(dir, ".dir2mcp", "connection.json")
+	deadline := time.Now().Add(25 * time.Second)
+	for {
+		select {
+		case code := <-done:
+			return upResult{code: code, stderr: stderr.String()}
+		default:
+		}
+		if _, err := os.Stat(connection); err == nil {
+			cancel()
+			return upResult{code: <-done, stderr: stderr.String()}
+		}
+		if time.Now().After(deadline) {
+			cancel()
+			t.Fatalf("up neither started nor exited within the deadline: stderr=%s", stderr.String())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// seedCorpusWithToken lays out a corpus whose state directory was created by an
+// older build (0755) and whose token carries mode.
+func seedCorpusWithToken(t *testing.T, mode os.FileMode) (root, tokenPath string) {
+	t.Helper()
+	root = t.TempDir()
+	state := filepath.Join(root, ".dir2mcp")
+	if err := os.MkdirAll(state, 0o755); err != nil {
+		t.Fatalf("seed state dir: %v", err)
+	}
+	tokenPath = filepath.Join(state, "secret.token")
+	if err := os.WriteFile(tokenPath, []byte(seededToken+"\n"), mode); err != nil {
+		t.Fatalf("seed token: %v", err)
+	}
+	if err := os.Chmod(tokenPath, mode); err != nil { // defeat the umask on the seed
+		t.Fatalf("seed token mode: %v", err)
+	}
+	if got := modeOf(t, tokenPath); got != mode {
+		t.Fatalf("seed did not reproduce the reported state: token is %04o, want %04o", got, mode)
+	}
+	return root, tokenPath
+}
+
+func tokenOf(t *testing.T, path string) string {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return strings.TrimSpace(string(raw))
+}
+
+// TestAutoAuthTightensAWorldReadableTokenAndKeepsIt: the repair-not-refuse and
+// no-silent-rotation halves of the policy, end to end. Clients already hold
+// this token; rotating it on a permission repair would break them without
+// being asked.
+func TestAutoAuthTightensAWorldReadableTokenAndKeepsIt(t *testing.T) {
+	withPermissiveUmask(t)
+	root, tokenPath := seedCorpusWithToken(t, 0o644)
+
+	res := runUpInDir(t, root)
+	if res.code != 0 {
+		t.Fatalf("up refused a repairable token: exit=%d stderr=%s", res.code, res.stderr)
+	}
+	if got := modeOf(t, tokenPath); got != statefs.FileMode {
+		t.Fatalf("reused token left at %04o, want %04o: another local account can read the bearer token", got, statefs.FileMode)
+	}
+	if got := tokenOf(t, tokenPath); got != seededToken {
+		t.Fatalf("token was rotated behind the operator's back: got %q", got)
+	}
+}
+
+// TestAutoAuthLeavesAPrivateTokenAlone: the common case stays silent and
+// untouched: no warning, no rewrite.
+func TestAutoAuthLeavesAPrivateTokenAlone(t *testing.T) {
+	withPermissiveUmask(t)
+	root, tokenPath := seedCorpusWithToken(t, statefs.FileMode)
+
+	res := runUpInDir(t, root)
+	if res.code != 0 {
+		t.Fatalf("up failed on an already-private token: exit=%d stderr=%s", res.code, res.stderr)
+	}
+	if got := modeOf(t, tokenPath); got != statefs.FileMode {
+		t.Fatalf("private token changed to %04o", got)
+	}
+	if got := tokenOf(t, tokenPath); got != seededToken {
+		t.Fatalf("private token was rewritten: got %q", got)
+	}
+	if strings.Contains(res.stderr, "readable by other local accounts") {
+		t.Fatalf("warned about an already-private token: stderr=%s", res.stderr)
+	}
+}
+
+// TestAutoAuthDoesNotWidenAMoreRestrictiveToken: an operator who made the
+// token read-only meant it. Enforcing 0600 must only ever remove bits.
+func TestAutoAuthDoesNotWidenAMoreRestrictiveToken(t *testing.T) {
+	withPermissiveUmask(t)
+	root, tokenPath := seedCorpusWithToken(t, 0o400)
+
+	res := runUpInDir(t, root)
+	if res.code != 0 {
+		t.Fatalf("up failed on a 0400 token: exit=%d stderr=%s", res.code, res.stderr)
+	}
+	if got := modeOf(t, tokenPath); got != 0o400 {
+		t.Fatalf("a deliberately restrictive token was widened to %04o", got)
+	}
+	if got := tokenOf(t, tokenPath); got != seededToken {
+		t.Fatalf("0400 token was rewritten: got %q", got)
+	}
+}
+
+// TestAutoAuthCreatesAFreshTokenOwnerOnly: the create path, under the umask
+// that made this defect class invisible.
+func TestAutoAuthCreatesAFreshTokenOwnerOnly(t *testing.T) {
+	withPermissiveUmask(t)
+	root := t.TempDir()
+
+	res := runUpInDir(t, root)
+	if res.code != 0 {
+		t.Fatalf("up failed on a fresh corpus: exit=%d stderr=%s", res.code, res.stderr)
+	}
+	tokenPath := filepath.Join(root, ".dir2mcp", "secret.token")
+	if got := modeOf(t, tokenPath); got != statefs.FileMode {
+		t.Fatalf("freshly created token is %04o, want %04o", got, statefs.FileMode)
+	}
+	if got := tokenOf(t, tokenPath); len(got) != 64 {
+		t.Fatalf("unexpected generated token length %d", len(got))
+	}
+}
+
+// TestAutoAuthRefusesASymlinkedToken: HardenTree skips symlinks, so this is
+// the case #726 could not reach. On the unfixed tree the server started and
+// used a 0644 token living outside the state directory.
+func TestAutoAuthRefusesASymlinkedToken(t *testing.T) {
+	withPermissiveUmask(t)
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".dir2mcp"), 0o755); err != nil {
+		t.Fatalf("seed state dir: %v", err)
+	}
+	outside := filepath.Join(t.TempDir(), "elsewhere.token")
+	if err := os.WriteFile(outside, []byte("token-someone-else-can-read\n"), 0o644); err != nil {
+		t.Fatalf("seed outside token: %v", err)
+	}
+	if err := os.Chmod(outside, 0o644); err != nil {
+		t.Fatalf("seed outside mode: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, ".dir2mcp", "secret.token")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	res := runUpInDir(t, root)
+	if res.code == 0 {
+		t.Fatalf("up served a symlinked secret.token as if it were private: stderr=%s", res.stderr)
+	}
+	if !strings.Contains(res.stderr, "--auth file:") {
+		t.Fatalf("refusal does not name the operator-managed escape hatch: stderr=%s", res.stderr)
+	}
+	if got := modeOf(t, outside); got != 0o644 {
+		t.Fatalf("refusal reached through the link and chmod'd %s to %04o", outside, got)
+	}
+	if got := tokenOf(t, outside); got != "token-someone-else-can-read" {
+		t.Fatalf("refusal rewrote the link target: got %q", got)
+	}
+}
+
+// TestAutoAuthDoesNotWriteThroughASymlink: the sharper half. With an empty
+// target the auto path GENERATES a token, and on the unfixed tree wrote it
+// through the link, truncating a file outside the state directory.
+func TestAutoAuthDoesNotWriteThroughASymlink(t *testing.T) {
+	withPermissiveUmask(t)
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".dir2mcp"), 0o755); err != nil {
+		t.Fatalf("seed state dir: %v", err)
+	}
+	victim := filepath.Join(t.TempDir(), "victim.conf")
+	const victimContent = "   \n" // non-empty file, empty token
+	if err := os.WriteFile(victim, []byte(victimContent), 0o644); err != nil {
+		t.Fatalf("seed victim: %v", err)
+	}
+	if err := os.Symlink(victim, filepath.Join(root, ".dir2mcp", "secret.token")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	res := runUpInDir(t, root)
+	if res.code == 0 {
+		t.Fatalf("up accepted a symlinked secret.token: stderr=%s", res.stderr)
+	}
+	raw, err := os.ReadFile(victim)
+	if err != nil {
+		t.Fatalf("read victim: %v", err)
+	}
+	if string(raw) != victimContent {
+		t.Fatalf("a generated token was written through the symlink into %s: %q", victim, string(raw))
+	}
+}
+
+// TestHardenSecretReportsThePriorMode: the primitive the CLI warning is built
+// on. A caller cannot tell the operator what it repaired unless the repair
+// reports what it found.
+func TestHardenSecretReportsThePriorMode(t *testing.T) {
+	withPermissiveUmask(t)
+	dir := t.TempDir()
+
+	for _, tc := range []struct {
+		name  string
+		seed  os.FileMode
+		final os.FileMode
+		wider bool
+	}{
+		{"world readable", 0o644, statefs.FileMode, true},
+		{"group readable", 0o640, statefs.FileMode, true},
+		{"already private", 0o600, 0o600, false},
+		{"more restrictive", 0o400, 0o400, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(dir, strings.ReplaceAll(tc.name, " ", "-"))
+			if err := os.WriteFile(path, []byte("token\n"), tc.seed); err != nil {
+				t.Fatalf("seed: %v", err)
+			}
+			if err := os.Chmod(path, tc.seed); err != nil {
+				t.Fatalf("seed mode: %v", err)
+			}
+			prior, exists, err := statefs.HardenSecret(path)
+			if err != nil {
+				t.Fatalf("HardenSecret: %v", err)
+			}
+			if !exists {
+				t.Fatal("existing file reported as missing")
+			}
+			if prior != tc.seed {
+				t.Fatalf("prior mode reported as %04o, want %04o", prior, tc.seed)
+			}
+			if got := statefs.WiderThanOwnerOnly(prior); got != tc.wider {
+				t.Fatalf("WiderThanOwnerOnly(%04o)=%v, want %v", prior, got, tc.wider)
+			}
+			if got := modeOf(t, path); got != tc.final {
+				t.Fatalf("file left at %04o, want %04o", got, tc.final)
+			}
+		})
+	}
+}
+
+// TestHardenSecretOnAMissingPath: creating the token is the caller's job, so a
+// missing path is a report, not an error.
+func TestHardenSecretOnAMissingPath(t *testing.T) {
+	withPermissiveUmask(t)
+	prior, exists, err := statefs.HardenSecret(filepath.Join(t.TempDir(), "secret.token"))
+	if err != nil {
+		t.Fatalf("HardenSecret on a missing path: %v", err)
+	}
+	if exists {
+		t.Fatal("missing path reported as existing")
+	}
+	if prior != 0 {
+		t.Fatalf("missing path reported prior mode %04o", prior)
+	}
+}
+
+// TestHardenSecretRefusesNonRegularPaths: a FIFO would hang the startup that
+// read it; a directory and a symlink are not credentials either.
+func TestHardenSecretRefusesNonRegularPaths(t *testing.T) {
+	withPermissiveUmask(t)
+	dir := t.TempDir()
+
+	fifo := filepath.Join(dir, "fifo.token")
+	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
+		t.Skipf("mkfifo unavailable: %v", err)
+	}
+	subdir := filepath.Join(dir, "dir.token")
+	if err := os.Mkdir(subdir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	target := filepath.Join(dir, "target")
+	if err := os.WriteFile(target, []byte("x"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := os.Chmod(target, 0o644); err != nil {
+		t.Fatalf("seed mode: %v", err)
+	}
+	link := filepath.Join(dir, "link.token")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	for _, path := range []string{fifo, subdir, link} {
+		_, _, err := statefs.HardenSecret(path)
+		if err == nil {
+			t.Fatalf("HardenSecret accepted a non-regular path: %s", path)
+		}
+		if !errors.Is(err, statefs.ErrNotRegular) {
+			t.Fatalf("unexpected error for %s: %v", path, err)
+		}
+	}
+	if got := modeOf(t, target); got != 0o644 {
+		t.Fatalf("HardenSecret chmod'd through a symlink: target is %04o", got)
+	}
+}


### PR DESCRIPTION
Closes #715.

## What was actually broken

`prepareAutoAuthMaterial` called `readToken(tokenPath, true)` and used any
non-empty result as-is. `writeSecretToken` passed `0600` to `os.OpenFile`, but a
create mode says nothing about a file that already exists, and `readToken` never
stat'd anything. SPEC §4.2: `secret.token` permissions **MUST** be restrictive
(0600 on Unix-like systems).

I measured the reported scenario through a real `up` before writing anything,
and the picture is more specific than the issue text:

| seeded state | unfixed behaviour |
| --- | --- |
| `.dir2mcp/` 0755 + `secret.token` 0644 | reused, and the file **did** end at 0600 |
| `secret.token` -> symlink to a 0644 file outside the state dir | reused at **0644**, server started as if private, exit 0 |
| same symlink, target trims to empty | generated token **written through the link**, truncating that outside file in place, exit 0 |

The first row is not the fix landing early: #726's `statefs.HardenTree` walks the
state directory in `prepareUpDirectories`, which runs before auth prep, so it
repairs a plain 0644 token as a side effect, and does so silently. Two things
that leaves:

1. `HardenTree` deliberately **skips symlinks** (right for a cache: the mode that
   matters is the target's, and the target may live outside the tree on purpose).
   A symlinked credential is the opposite case, and it is a live hole today: read
   from outside the state directory at an arbitrary mode, and rewritten through
   the link. Rows 2 and 3 above are real, not theoretical.
2. The auto-auth path enforced nothing of its own. Its compliance with §4.2 was
   inherited from a distant caller that happens to run first.

## The fix

`internal/statefs`

- `HardenSecret(path) (prior fs.FileMode, exists bool, err error)`: tightens an
  existing regular file to `FileMode`, reusing the existing "only ever remove
  bits" chmod, and reports the mode it found so a caller can say what it
  repaired. Refuses non-regular paths via `Lstat`, without following them
  (`ErrNotRegular`). A missing path reports `exists=false`, not an error.
- `WiderThanOwnerOnly(mode)`: the "was this exposed" predicate, so call sites do
  not re-derive the bitmask.

`internal/cli/app.go`

- `prepareAutoAuthMaterial` hardens the token before reading or rewriting it.
- `writeSecretToken` uses `statefs.Create`, so rewriting an existing permissive
  token also lands at 0600 (the issue's "same problem applies if
  writeSecretToken truncates an existing permissive file" half). It hardens the open
  descriptor, which also covers a path swapped between the check and the write.
- `--auth file:<path>` documented as operator-managed and left alone (below).

`internal/cli/up.go` is touched on **one line** (`prepareAuthMaterial(cfg,
a.stderr)`), so the warning has somewhere to go. Nothing near
`support_bundle.go` or `service*.go`.

## The three decisions you asked for

**Repair, or refuse? Repair, and say so out loud.** This file is dir2mcp's own in
auto mode, and its mode is lost for mundane reasons: a corpus restored from a
tarball, `cp -r`'d, or created by an older build under a 022 umask. Refusing
turns each of those into a dead daemon for a condition the daemon can fix in one
syscall. But repairing silently would be the wrong kind of quiet, because a
chmod does not un-read a file: if another local account could read the token, it
may already have. So the repair is announced on stderr, naming the mode found,
and it is announced regardless of `--quiet`/`--json` (it goes to stderr; JSON
output is on stdout) because a possibly-exposed credential is not status chatter.

Honest caveat about reach: in `up` today, `HardenTree` usually repairs a plain
0644 token before auth prep sees it, so this warning is mostly a backstop for
the create/rewrite path and for any caller that does not harden the tree first.
Making #726's tree walk itself report what it tightened would be the way to
surface the plain-0644 case loudly, and that belongs in a `HardenTree` change
across `up.go`/`reindex.go`, not here. Say the word and I will file it.

**Rotate, or just chmod?** No automatic rotation, and I want to be explicit
rather than silent about it. A token found world-readable is genuinely suspect,
and chmod does not restore its secrecy. But rotating it on startup invalidates
every client that already holds it (Claude/ElevenLabs registrations,
`connection.json` consumers, anything with the bearer baked into a config), so a
permission repair would silently break a working deployment: the exact failure
mode the "repair, do not refuse" choice was meant to avoid, arriving by a
different door. Whether the exposure matters depends on who else has an account
on this host, which the daemon cannot know. So the warning states plainly that
tightening does not undo the exposure and names the rotation, which is one
command: stop the server, delete `secret.token`, start again (auto mode
regenerates), re-register clients.

**Windows.** No POSIX mode bits. Go synthesizes 0666/0444 from the read-only
attribute and `os.Chmod` can only toggle that attribute, so the tightening
degrades to a no-op there and the file's confidentiality rests on the NTFS ACLs
it inherits from the state directory. No ACL repair is attempted, and this is
stated in the `HardenSecret` doc comment rather than left to be discovered. The
**regular-file refusal is enforced on every platform**. The tests are
`//go:build unix` because `syscall.Umask` does not exist on Windows.

**`--auth file:<path>`** (the issue's last acceptance criterion): explicitly
operator-managed. The path is read and required non-empty; its mode is never
inspected and never changed. A deliberately group-readable token shared with
other processes on the host is a legitimate setup there, and SPEC §17 already
describes that flag as "a user-provided token file with restrictive
permissions". Documented at the call site so the asymmetry with auto mode is
intentional and visible.

## Tests

`tests/security/auth_token_permissions_715_test.go`, `//go:build unix`, forcing
`syscall.Umask(0o022)` via the existing `withPermissiveUmask` helper from the
#726 suite (this class of defect is invisible under a strict umask). They
measure the resulting file rather than asserting on log lines: mode, content,
and whether an outside file survived.

- `TestAutoAuthRefusesASymlinkedToken` and
  `TestAutoAuthDoesNotWriteThroughASymlink` **fail without the source change**.
  Proven by reverting only `internal/cli/app.go` + `internal/cli/up.go` (keeping
  the additive `statefs` helper so the package still compiles) and re-running:

  ```
  --- FAIL: TestAutoAuthRefusesASymlinkedToken (0.42s)
      up served a symlinked secret.token as if it were private
  --- FAIL: TestAutoAuthDoesNotWriteThroughASymlink (0.40s)
      up accepted a symlinked secret.token
  ```

  Both pass with the change restored.
- `TestAutoAuthTightensAWorldReadableTokenAndKeepsIt` (0644 -> 0600, token value
  unchanged), `TestAutoAuthLeavesAPrivateTokenAlone` (0600 untouched, no
  warning), `TestAutoAuthDoesNotWidenAMoreRestrictiveToken` (0400 stays 0400),
  `TestAutoAuthCreatesAFreshTokenOwnerOnly` (fresh token 0600, 64 hex chars).
  These pass on the unfixed tree too, for the `HardenTree` reason above: they
  are policy guards (repair, never widen, never rotate), not the proof.
- Unit coverage on the new primitive: prior-mode reporting for 0644/0640/0600/
  0400, missing path, and refusal of FIFO / directory / symlink with the link
  target measured unchanged.

No new file under `internal/cli/`, so `tests/security/cli_boundary_test.go`
needs no allowlist entry (checked; the boundary suite passes).

`make check` passes locally (fmt, vet, golangci-lint 0 issues, gocyclo -over 15,
ineffassign, misspell, full test suite, build).
