### PR TITLE
fix(watch): enforce resolved-root containment on followed symlinks (#717)

### DIFF
--- a/internal/corpusfs/local.go
+++ b/internal/corpusfs/local.go
@@ -54,11 +54,7 @@ func (l *LocalFS) Walk(ctx context.Context, _ string, opts Options) ([]Discovere
 		return nil, fmt.Errorf("root is not a directory: %s", absRoot)
 	}
 
-	rootResolved := absRoot
-	if resolved, err := filepath.EvalSymlinks(absRoot); err == nil {
-		rootResolved = resolved
-	}
-	rootResolved = filepath.Clean(rootResolved)
+	rootResolved := ResolveRoot(absRoot)
 
 	files := make([]DiscoveredFile, 0, 256)
 	walker := discoverWalker{
@@ -144,6 +140,42 @@ func resolveWithinRoot(root, relPath string) (string, error) {
 		return "", fmt.Errorf("%w: %q", ErrPathEscapesRoot, relPath)
 	}
 	return resolved, nil
+}
+
+// ResolveRoot returns the canonical (symlink-resolved, cleaned) form of an
+// absolute corpus root. It is the anchor every root-containment decision is made
+// against, so callers outside this package (the ingest watcher) compute it the
+// same way the discovery walk does. A resolve failure falls back to the lexical
+// form: the root is expected to exist, and a usable anchor is better than none.
+func ResolveRoot(absRoot string) string {
+	if resolved, err := filepath.EvalSymlinks(absRoot); err == nil {
+		return filepath.Clean(resolved)
+	}
+	return filepath.Clean(absRoot)
+}
+
+// ResolveSymlinkWithinRoot resolves linkPath (typically an in-root symlink) and
+// enforces that its target stays inside rootResolved, which must already be a
+// resolved root (see ResolveRoot). It returns the resolved target and ok=true
+// only when the link resolves AND lands in the corpus; ok=false means the caller
+// must treat the path as if it did not exist.
+//
+// This is the single implementation of the followed-symlink containment rule
+// required by SPEC §1/§7.1 root isolation: the discovery walk (handleSymlink
+// below) and the live watcher (internal/ingest/watch.go) both call it, so the
+// two cannot drift into judging the same link differently depending on when it
+// appeared (issue #717). Resolution happens on every call, never cached, so the
+// decision is always made against the link's current target.
+func ResolveSymlinkWithinRoot(rootResolved, linkPath string) (string, bool) {
+	resolved, err := filepath.EvalSymlinks(linkPath)
+	if err != nil {
+		return "", false
+	}
+	resolved = filepath.Clean(resolved)
+	if !isWithinRoot(rootResolved, resolved) {
+		return "", false
+	}
+	return resolved, true
 }
 
 func shouldSkipDirectory(name string) bool {
@@ -500,12 +532,8 @@ func (w *discoverWalker) handleSymlink(ctx context.Context, symlinkPath, relPath
 		return err
 	}
 
-	resolvedPath, err := filepath.EvalSymlinks(symlinkPath)
-	if err != nil {
-		return nil
-	}
-	resolvedPath = filepath.Clean(resolvedPath)
-	if !isWithinRoot(w.rootResolved, resolvedPath) {
+	resolvedPath, ok := ResolveSymlinkWithinRoot(w.rootResolved, symlinkPath)
+	if !ok {
 		return nil
 	}
 

--- a/internal/ingest/watch.go
+++ b/internal/ingest/watch.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/dirstral/dir2mcp/internal/corpusfs"
 	"github.com/fsnotify/fsnotify"
 )
 
@@ -235,7 +236,19 @@ func (w *fsWatchLoop) registerNewTree(absDir string) {
 	// which follows them when IngestFollowSymlinks is set. The default (off) path
 	// keeps the historical WalkDir behavior byte-for-byte.
 	if w.opts.FollowSymlinks {
-		walkWatchTree(absDir, resolvedRoot(w.absRoot), map[string]struct{}{}, addDir, armFile)
+		rootResolved := corpusfs.ResolveRoot(w.absRoot)
+		// A newly created (or moved-in) directory can itself be a symlink pointing
+		// outside the corpus. walkWatchTree refuses it, but say so: an operator who
+		// linked a directory into the corpus and sees nothing appear needs to know
+		// it was refused on purpose, not missed.
+		if _, ok := corpusfs.ResolveSymlinkWithinRoot(rootResolved, absDir); !ok {
+			w.svc.getLogger().Printf(
+				"watch: refusing directory %s: it does not resolve inside the corpus root; not watched or indexed",
+				absDir,
+			)
+			return
+		}
+		walkWatchTree(absDir, rootResolved, map[string]struct{}{}, addDir, armFile)
 		return
 	}
 	_ = filepath.WalkDir(absDir, func(path string, d os.DirEntry, err error) error {
@@ -332,15 +345,22 @@ func (w *fsWatchLoop) indexableFile(absPath, rel string, info os.FileInfo) (Disc
 		return DiscoveredFile{}, false
 	}
 	// Symlink policy: mirror the discovery walker. When symlinks are not
-	// followed, skip them; otherwise resolve to the target for size/type.
+	// followed, skip them; otherwise resolve the link and enforce root
+	// containment before looking at the target at all.
 	if info.Mode()&os.ModeSymlink != 0 {
-		if !w.opts.FollowSymlinks {
+		resolved, ok := w.followedSymlinkTarget(absPath, rel)
+		if !ok {
 			return DiscoveredFile{}, false
 		}
-		target, err := os.Stat(absPath)
+		target, err := os.Stat(resolved)
 		if err != nil {
 			return DiscoveredFile{}, false
 		}
+		// Hand downstream the RESOLVED path, exactly as the discovery walker
+		// records it in DiscoveredFile.AbsPath, so any consumer that reads the
+		// absolute path reads the target we just checked rather than re-traversing
+		// a link that may since have been repointed.
+		absPath = resolved
 		info = target
 	}
 	if !info.Mode().IsRegular() || info.Size() > w.opts.MaxSizeBytes {
@@ -361,6 +381,35 @@ func (w *fsWatchLoop) indexableFile(absPath, rel string, info os.FileInfo) (Disc
 		MTimeUnix: info.ModTime().Unix(),
 		Mode:      info.Mode(),
 	}, true
+}
+
+// followedSymlinkTarget applies the symlink policy to an in-root symlink the
+// watcher is about to index and returns its resolved target.
+//
+// It is the watcher's half of SPEC §1/§7.1 root isolation (issue #717): the
+// initial discovery walk refuses a symlink whose target resolves outside the
+// corpus, and a link that appears (or is repointed) while the watcher is running
+// must be refused on exactly the same terms, so a corpus cannot be extended past
+// its root just by creating a link after startup. The rule is not restated here:
+// corpusfs.ResolveSymlinkWithinRoot is the one implementation both walks call.
+//
+// Resolution happens on every call, i.e. when the event is handled, so the
+// decision is made against the link's target at that moment, not at creation.
+// ok=false is logged rather than dropped silently: an unexplained absence is
+// indistinguishable from "the watcher missed my file".
+func (w *fsWatchLoop) followedSymlinkTarget(absPath, rel string) (string, bool) {
+	if !w.opts.FollowSymlinks {
+		return "", false
+	}
+	resolved, ok := corpusfs.ResolveSymlinkWithinRoot(corpusfs.ResolveRoot(w.absRoot), absPath)
+	if !ok {
+		w.svc.getLogger().Printf(
+			"watch: refusing %s: symlink target does not resolve inside the corpus root; not indexed",
+			rel,
+		)
+		return "", false
+	}
+	return resolved, true
 }
 
 // matchesGitignoreForFile reports whether the file at slash-separated relPath
@@ -416,7 +465,15 @@ func (s *Service) addWatchDirs(watcher *fsnotify.Watcher, absRoot string, follow
 	// waiting for the 10-minute safety rescan (issue #409). Cycles terminate via
 	// the resolved-path visited set. The default (off) path is unchanged.
 	if followSymlinks {
-		walkWatchTree(absRoot, resolvedRoot(absRoot), map[string]struct{}{}, add, nil)
+		rootResolved := corpusfs.ResolveRoot(absRoot)
+		// walkWatchTree refuses any directory it cannot resolve, the root included.
+		// That can only happen if the root itself stopped resolving (deleted or
+		// unreadable), in which case there is nothing to watch; report it instead of
+		// registering zero watches silently.
+		if _, ok := corpusfs.ResolveSymlinkWithinRoot(rootResolved, absRoot); !ok {
+			return fmt.Errorf("watch %s: corpus root did not resolve; no directories watched", absRoot)
+		}
+		walkWatchTree(absRoot, rootResolved, map[string]struct{}{}, add, nil)
 		return errors.Join(errs...)
 	}
 	_ = filepath.WalkDir(absRoot, func(path string, d os.DirEntry, err error) error {
@@ -435,32 +492,6 @@ func (s *Service) addWatchDirs(watcher *fsnotify.Watcher, absRoot string, follow
 	return errors.Join(errs...)
 }
 
-// resolvedRoot resolves absRoot to its canonical path for use as the containment
-// anchor of a symlink-following watch walk. A resolve failure falls back to the
-// lexical (cleaned) root so the walk still proceeds.
-func resolvedRoot(absRoot string) string {
-	if r, err := filepath.EvalSymlinks(absRoot); err == nil {
-		return filepath.Clean(r)
-	}
-	return filepath.Clean(absRoot)
-}
-
-// withinResolvedRoot reports whether candidate resolves inside rootResolved,
-// mirroring the discovery walker's isWithinRoot containment check
-// (internal/corpusfs/local.go): the watcher follows a symlink only when its
-// target stays inside the corpus, so it never watches (or indexes) content the
-// initial scan would not.
-func withinResolvedRoot(rootResolved, candidate string) bool {
-	rel, err := filepath.Rel(rootResolved, filepath.Clean(candidate))
-	if err != nil {
-		return false
-	}
-	if rel == "." {
-		return true
-	}
-	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel)
-}
-
 // walkWatchTree recursively visits absDir, invoking onDir for every non-skipped
 // directory and onFile (when non-nil) for every regular file, descending into
 // symlinked directories too. It is used only on the symlink-following watch
@@ -468,12 +499,14 @@ func withinResolvedRoot(rootResolved, candidate string) bool {
 // visited set holds resolved (EvalSymlinks) directory paths already entered so a
 // symlink cycle terminates AND a target reachable via both its real and a
 // symlinked name is walked once (under whichever name is seen first); a
-// symlinked directory is followed only when its target stays within rootResolved.
+// symlinked directory is followed only when its target stays within rootResolved
+// (the shared corpusfs check, so a directory link cannot extend the watch past
+// the root any more than a file link can — #717).
 // onDir/onFile receive the lexical path (through the symlink) so emitted fsnotify
 // events map back to a path under the watched root.
 func walkWatchTree(absDir, rootResolved string, visited map[string]struct{}, onDir func(string), onFile func(string)) {
-	resolved := resolvedRoot(absDir)
-	if !withinResolvedRoot(rootResolved, resolved) {
+	resolved, ok := corpusfs.ResolveSymlinkWithinRoot(rootResolved, absDir)
+	if !ok {
 		return
 	}
 	if _, seen := visited[resolved]; seen {

--- a/tests/ingest/watch_symlink_escape_717_test.go
+++ b/tests/ingest/watch_symlink_escape_717_test.go
@@ -1,0 +1,238 @@
+package tests
+
+import (
+	"context"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// requireSymlinkWatch skips on platforms where this scenario is not meaningful.
+// Unlike the older watcher tests these are NOT gated behind RUN_INTEGRATION_TESTS:
+// this is a root-isolation regression (SPEC §1/§7.1), so it must run on every
+// `make check`. The positive controls (a plain file and an in-root symlink must
+// still be indexed) fail loudly if the watcher never fires, so a missed event
+// cannot masquerade as a pass.
+func requireSymlinkWatch(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping POSIX symlink watch test on Windows")
+	}
+}
+
+// watchSymlinkFixture spins up an indexed corpus with a live watcher and returns
+// the store plus the captured ingest log.
+func watchSymlinkFixture(t *testing.T, ctx context.Context, root string, followSymlinks bool) (*store.SQLiteStore, *syncBuffer) {
+	t.Helper()
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("store init: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	cfg := config.Default()
+	cfg.RootDir = root
+	cfg.IngestFollowSymlinks = followSymlinks
+	cfg.IngestWatchDebounce = 20 * time.Millisecond
+	cfg.STTProvider = "off"
+	svc := mustNewIngestService(t, cfg, st)
+
+	logs := &syncBuffer{}
+	svc.SetLogger(log.New(logs, "", 0))
+
+	if err := svc.Run(ctx); err != nil {
+		t.Fatalf("initial Run: %v", err)
+	}
+	startWatcher(t, ctx, svc)
+	return st, logs
+}
+
+// TestWatch_RefusesSymlinkEscapingRoot_717 covers issue #717: with
+// ingest.follow_symlinks on, a symlink CREATED AFTER the watcher started that
+// points at a regular file outside the corpus root must not be indexed. The
+// initial discovery walk already refuses it (corpusfs enforces resolved-root
+// containment), so before the fix the same link was accepted or rejected purely
+// on when it appeared, which is a root-isolation hole (SPEC §1/§7.1).
+//
+// The test also pins the two things a lazy fix would break: an in-root symlink
+// must still be followed and indexed, and a plain regular file must still be
+// indexed.
+func TestWatch_RefusesSymlinkEscapingRoot_717(t *testing.T) {
+	requireSymlinkWatch(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	root := t.TempDir()
+	outside := t.TempDir()
+	secret := filepath.Join(outside, "secret.txt")
+	if err := os.WriteFile(secret, []byte("out-of-root secret material"), 0o600); err != nil {
+		t.Fatalf("write secret: %v", err)
+	}
+	inRootTarget := filepath.Join(root, "real.txt")
+	if err := os.WriteFile(inRootTarget, []byte("in-root content"), 0o600); err != nil {
+		t.Fatalf("write in-root target: %v", err)
+	}
+
+	st, logs := watchSymlinkFixture(t, ctx, root, true)
+
+	// One mutation at a time: a burst of creations can be coalesced by the
+	// platform's event backend (macOS/kqueue re-reads the directory and reports
+	// the diff), which would leave it ambiguous whether the watcher declined the
+	// link or never saw it.
+	if err := os.Symlink(secret, filepath.Join(root, "leak.txt")); err != nil {
+		t.Fatalf("symlink leak: %v", err)
+	}
+	// The refusal must be observable, otherwise it is indistinguishable from
+	// "the watcher missed my file". Waiting for it also proves the watcher DID
+	// see the link, so the "not indexed" assertion below is not vacuous.
+	refusalLogged := waitForRefusal(logs, "leak.txt")
+
+	if err := os.Symlink(inRootTarget, filepath.Join(root, "link_ok.txt")); err != nil {
+		t.Fatalf("symlink link_ok: %v", err)
+	}
+	waitForPaths(t, st, "link_ok.txt", true)
+
+	if err := os.WriteFile(filepath.Join(root, "plain.txt"), []byte("plain"), 0o600); err != nil {
+		t.Fatalf("write plain: %v", err)
+	}
+	waitForPaths(t, st, "plain.txt", true)
+
+	if docPaths(t, st)["leak.txt"] {
+		t.Errorf("watcher indexed leak.txt, a symlink to a file outside the corpus root (issue #717)")
+	}
+	if !refusalLogged {
+		t.Errorf("no log line refused leak.txt; a silent drop is indistinguishable from a missed event. Log:\n%s", logs.String())
+	}
+}
+
+// waitForRefusal polls the captured ingest log for up to five seconds for a
+// single line that both names the path and states it was refused, so an
+// unrelated line that merely mentions the path does not satisfy the
+// observability assertion. It reports whether such a line appeared.
+func waitForRefusal(logs *syncBuffer, path string) bool {
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		for _, line := range strings.Split(logs.String(), "\n") {
+			if strings.Contains(line, path) && strings.Contains(line, "refusing") {
+				return true
+			}
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// TestWatch_RefusesRetargetedSymlink_717 covers the TOCTOU half of #717: a link
+// that is in-root when first indexed and is later repointed outside the root
+// must never have the out-of-root bytes read into its document. Containment is
+// re-evaluated when the event is handled, not cached from the first sighting.
+func TestWatch_RefusesRetargetedSymlink_717(t *testing.T) {
+	requireSymlinkWatch(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	root := t.TempDir()
+	outside := t.TempDir()
+	secret := filepath.Join(outside, "secret.txt")
+	if err := os.WriteFile(secret, []byte("out-of-root secret material"), 0o600); err != nil {
+		t.Fatalf("write secret: %v", err)
+	}
+	inRootTarget := filepath.Join(root, "real.txt")
+	if err := os.WriteFile(inRootTarget, []byte("in-root content"), 0o600); err != nil {
+		t.Fatalf("write in-root target: %v", err)
+	}
+	link := filepath.Join(root, "movable.txt")
+	if err := os.Symlink(inRootTarget, link); err != nil {
+		t.Fatalf("symlink movable: %v", err)
+	}
+
+	st, _ := watchSymlinkFixture(t, ctx, root, true)
+	// Indexed by the initial scan through its in-root target.
+	before := documentByPath(t, st, "movable.txt")
+	if before.ContentHash == "" {
+		t.Fatalf("expected a content hash for the initially in-root symlink")
+	}
+
+	// Repoint the link at the out-of-root file atomically (what `ln -sfn` does:
+	// create a temp link, rename it over the old one). A remove+recreate would
+	// let a delete job tombstone the document and mask the leak; the rename
+	// leaves the path continuously present, so the only way the document can
+	// change is the watcher reading through the repointed link.
+	tmpLink := filepath.Join(root, "movable.txt.tmp")
+	if err := os.Symlink(secret, tmpLink); err != nil {
+		t.Fatalf("stage repointed link: %v", err)
+	}
+	if err := os.Rename(tmpLink, link); err != nil {
+		t.Fatalf("repoint link: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "barrier.txt"), []byte("barrier"), 0o600); err != nil {
+		t.Fatalf("write barrier: %v", err)
+	}
+	waitForPaths(t, st, "barrier.txt", true)
+	// Extra settle time: the barrier only proves the watcher drained an event
+	// armed after the repoint, not that the repoint's own job already ran.
+	time.Sleep(300 * time.Millisecond)
+
+	// Either outcome is acceptable (the document may have been tombstoned by the
+	// remove), except taking on the out-of-root content.
+	if !docPaths(t, st)["movable.txt"] {
+		return
+	}
+	if got := documentByPath(t, st, "movable.txt"); got.ContentHash != before.ContentHash {
+		t.Errorf("document content changed after the symlink was repointed outside the root: %q -> %q (issue #717)",
+			before.ContentHash, got.ContentHash)
+	}
+}
+
+// TestWatch_SymlinkPolicyUnchangedWhenNotFollowing_717 pins that the fix is
+// scoped to follow_symlinks=true: with following off the watcher still refuses
+// every symlink (in-root ones included) and still indexes regular files.
+func TestWatch_SymlinkPolicyUnchangedWhenNotFollowing_717(t *testing.T) {
+	requireSymlinkWatch(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	root := t.TempDir()
+	outside := t.TempDir()
+	secret := filepath.Join(outside, "secret.txt")
+	if err := os.WriteFile(secret, []byte("out-of-root secret material"), 0o600); err != nil {
+		t.Fatalf("write secret: %v", err)
+	}
+	inRootTarget := filepath.Join(root, "real.txt")
+	if err := os.WriteFile(inRootTarget, []byte("in-root content"), 0o600); err != nil {
+		t.Fatalf("write in-root target: %v", err)
+	}
+
+	st, _ := watchSymlinkFixture(t, ctx, root, false)
+
+	if err := os.Symlink(secret, filepath.Join(root, "leak.txt")); err != nil {
+		t.Fatalf("symlink leak: %v", err)
+	}
+	if err := os.Symlink(inRootTarget, filepath.Join(root, "link_ok.txt")); err != nil {
+		t.Fatalf("symlink link_ok: %v", err)
+	}
+	// Settle past the debounce so the links' events have been drained before the
+	// barrier file is written, rather than riding on the same coalesced batch.
+	time.Sleep(200 * time.Millisecond)
+	if err := os.WriteFile(filepath.Join(root, "plain.txt"), []byte("plain"), 0o600); err != nil {
+		t.Fatalf("write plain: %v", err)
+	}
+	waitForPaths(t, st, "plain.txt", true)
+
+	paths := docPaths(t, st)
+	if paths["leak.txt"] {
+		t.Errorf("follow_symlinks=false: watcher indexed an out-of-root symlink")
+	}
+	if paths["link_ok.txt"] {
+		t.Errorf("follow_symlinks=false: watcher indexed an in-root symlink; symlink policy changed")
+	}
+}


### PR DESCRIPTION
Closes #717.

## What was actually happening (issue framing corrected)

The report is right about the hole and overstates the blast radius. I measured it before touching anything, by pointing an in-root symlink at an out-of-root file after the watcher was already running:

```
doc: {RelPath:leak.txt DocType:text SourceType:filesystem SizeBytes:27
      ContentHash: Status:error
      ErrorMessage:read leak.txt: corpusfs: path escapes the corpus root: "leak.txt"}
```

So:

- **Confirmed:** `fsWatchLoop.indexableFile` accepted the link (`os.Stat` on the link, no `EvalSymlinks`, no containment check), and the out-of-root file went all the way into `processDocument`. The same link present at startup is refused by the discovery walk, so admission depended purely on *when* the link appeared. That is the SPEC §1 / §7.1 violation the issue describes ("follow only if target resolves under root").
- **Not confirmed:** "search/open operations can then expose its content". They cannot today. Every content read goes through `corpusfs` by rel_path (`LocalFS.Open`/`Localize` → `resolveWithinRoot`), which re-resolves symlinks and refuses the escape. `DiscoveredFile.AbsPath` has no non-test consumers left. So the bytes were never read.
- **What did leak:** the out-of-root file's *existence, size and mtime* were written into the index as a document row (`size_bytes: 27` above is the outside file's size), the row is visible to `list_files`, and it burned an `errors` count with a confusing message. Root isolation was being upheld only by a second layer at read time; the discovery-policy layer was not enforcing it at all.

Severity is therefore metadata disclosure + index pollution, not content disclosure. The fix is the same either way: the watcher must apply the discovery policy itself rather than depend on a downstream check.

## The fix

One rule, one implementation. `internal/corpusfs` already owned the containment check (`discoverWalker.handleSymlink` → `isWithinRoot`); it now exposes it and calls it itself:

- `corpusfs.ResolveRoot(absRoot)` — the resolved containment anchor (was inlined in `Walk`, and duplicated in `ingest.resolvedRoot`).
- `corpusfs.ResolveSymlinkWithinRoot(rootResolved, linkPath)` — `EvalSymlinks` + `isWithinRoot`, returning the resolved target. `handleSymlink` now calls it, so the discovery walk and the watcher execute *the same function*, not two copies of the same idea.

`internal/ingest/watch.go` deletes its parallel `resolvedRoot`/`withinResolvedRoot` copies and routes every containment decision through those helpers. Net: one containment rule in the tree instead of two, which is the actual defence against this class recurring.

Change is confined to `internal/ingest` + `internal/corpusfs`. **`internal/cli/app.go` is untouched.**

### Points the issue asked me to get right

**Resolved target, resolved at handling time (TOCTOU).** `followedSymlinkTarget` runs on every debounced job, and `ResolveSymlinkWithinRoot` re-runs `EvalSymlinks` every call; nothing is cached from creation time. The resolved path is then what goes downstream as `DiscoveredFile.AbsPath` (matching what the discovery walker records), so a consumer reading the absolute path reads the target that was checked, not a link that may have been repointed since.

What this **does** guarantee: a link is judged on the target it has when its event is processed, and the value handed to the pipeline is the checked real path (no symlink components left to swap).

What it **does not** guarantee: it is a check-then-use, so a repoint in the window between `EvalSymlinks` and the read is not excluded, and a rename of the *resolved* file itself is not either. Two things bound that: the read boundary in `corpusfs` re-resolves and refuses out-of-root paths independently, and the safety rescan reconciles through the corpusfs walk. This PR closes the policy gap; it is not a TOCTOU-proof gate, and I would not claim one without an openat2/`O_NOFOLLOW`-style resolve-and-hold, which is out of scope here.

**`follow_symlinks: false` unaffected.** The not-following branch returns before any resolution, exactly as before, and is pinned by a test that also asserts an *in-root* link is still refused when following is off (i.e. the policy did not accidentally loosen).

**In-root symlinks still work.** Not fixed by refusing symlinks. Covered by a positive control in the escape test, plus the pre-existing `TestWatch_FollowsSymlinkedDir` (passes).

**Directory vs file symlinks — both checked.** They are genuinely different paths in the watcher:
- File links: `handleEvent` → `arm` → `process` → `indexableFile`. This is where the hole was.
- Directory links: `handleEvent` (`os.Stat` says dir) → `registerNewTree` → `walkWatchTree`, and initial registration via `addWatchDirs` → `walkWatchTree`. `walkWatchTree` *was* already enforcing containment on entry, so out-of-root directory links were never watched; it now enforces it via the shared helper, and `registerNewTree` logs the refusal instead of returning silently.
- Side effect of routing `walkWatchTree` through the shared helper: an unresolvable directory is now refused rather than falling back to its lexical path. For the walk entry that is the corpus root, so `addWatchDirs` now returns an explicit error ("corpus root did not resolve; no directories watched") rather than registering zero watches in silence. `Watch` already logs that non-fatally and the safety rescan still covers.

**Observability.** A refusal is logged, following the existing precedent for the analogous S3 case (`OnUnsafeKey`, #735):

```
watch: refusing leak.txt: symlink target does not resolve inside the corpus root; not indexed
watch: refusing directory /corpus/linked: it does not resolve inside the corpus root; not watched or indexed
```

Silence here would be indistinguishable from "the watcher missed my file", which is exactly how the next report of this would get misfiled. The test asserts on the log line, not just on absence from the store.

## Tests

`tests/ingest/watch_symlink_escape_717_test.go`, deliberately **not** gated behind `RUN_INTEGRATION_TESTS` (unlike the older watcher tests) — this is a root-isolation regression and must run on every `make check`.

1. `TestWatch_RefusesSymlinkEscapingRoot_717` — link created *after* the watcher starts, pointing at a file outside the root: never stored, and the refusal is logged. Waiting for the refusal line first also proves the watcher *saw* the link, so the "not indexed" assertion cannot pass vacuously. Positive controls in the same test: an in-root symlink still indexes, and a plain regular file still indexes.
2. `TestWatch_RefusesRetargetedSymlink_717` — a link indexed while in-root, then repointed outside via an atomic `rename` over it: the document must never take on the out-of-root content (content hash unchanged, or the document gone).
3. `TestWatch_SymlinkPolicyUnchangedWhenNotFollowing_717` — with `follow_symlinks=false`, neither the out-of-root nor the in-root link is indexed, and regular files still are.

**Proven to fail first.** With only the source change stashed (`git stash push -- internal/ingest/watch.go internal/corpusfs/local.go`), test 1 fails on both assertions:

```
--- FAIL: TestWatch_RefusesSymlinkEscapingRoot_717 (5.22s)
    watcher indexed leak.txt, a symlink to a file outside the corpus root (issue #717)
    no log line refused leak.txt; a silent drop is indistinguishable from a missed event. Log:
        watch: index leak.txt: read leak.txt: corpusfs: path escapes the corpus root: "leak.txt"
```

Honest caveat on test 2: on darwin I measured that repointing an existing symlink (both `remove`+`recreate` and `rename`-over) produces **no delivered event** — fsnotify's kqueue backend diffs directory listings, and a same-name replace nets zero change. So test 2 is vacuous on macOS and is expected to do real work on inotify (CI). Test 1 does not depend on that: it creates a new name. I kept test 2 because it is deterministic-pass on both (never flaky) and does exercise the repoint path where the platform delivers it.

Stability: `go test ./tests/ingest -run 717 -count=15` green (and `-count=10` again after the final restructure); `RUN_INTEGRATION_TESTS=1 go test ./tests/ingest -run TestWatch` green, including the pre-existing symlinked-directory watch test.

## Checks

- `make check` passes (fmt, vet, golangci-lint 0 issues, gocyclo `-over 15`, ineffassign, misspell, full `go test ./...`, build).
- No spec change: this makes the code match SPEC §7.1 as already written ("if enabled: follow only if target resolves under root"), so no `dirstral-spec` PR is needed.
