### PR TITLE
fix(support-bundle): tighten an overwritten archive and redact the config snapshot (#719, #720)

### DIFF
--- a/README.md
+++ b/README.md
@@ -779,7 +779,7 @@ filtered on two independent tiers:
 
 | Tier | What it covers | When it is removed |
 |---|---|---|
-| Credentials | bearer tokens, `Authorization` headers, token-style query parameters, and the `user:pass@` userinfo of any URL | **always**, in every mode |
+| Credentials | bearer tokens, `Authorization` headers, the `user:pass@` userinfo of any URL, and the value of every URL query/fragment parameter | **always**, in every mode |
 | Local environment | corpus paths and titles, extraction error messages, and the config snapshot's paths, bind addresses, endpoints, prompts and operator-written glob/regex/word lists | by default; kept with `--include-content` |
 
 `--include-content` widens the second tier only. It never re-enables credential

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ DIR2MCP_DEMO_TOKEN="$(cat .dir2mcp/secret.token)" \
 | `embed-worker` | Run a standalone distributed embed worker (no MCP serving; requires a Tier-C store + broker) |
 | `export` | Render a transcript as VTT/SRT/TTML subtitles (`export --format vtt\|srt\|ttml <path>`) |
 | `bridge` | Run helper adapters (for example the ElevenLabs webhook bridge) |
-| `support-bundle` | Collect logs + config + status into a shareable `tar.gz` |
+| `support-bundle` | Collect logs + config + status into a shareable `tar.gz` (owner-only; credentials always redacted, local paths/endpoints redacted unless `--include-content` — see [What a support bundle discloses](#what-a-support-bundle-discloses)) |
 | `config init` | Interactive setup wizard (on a TTY): prompts for provider API keys, where to store them (`.env.local` or the OS keychain), and a corpus profile, then writes/updates `.dir2mcp.yaml`. Non-interactive (`--non-interactive`/`--json`/`--quiet`/no TTY) just writes a baseline config. `dir2mcp up` also launches this wizard on first run when started interactively (a TTY, and not `--json`/`--non-interactive`/read-only) and no embedding provider resolves. |
 | `config print` | Print effective config |
 | `config set-secret <ENV_VAR>` | Store a provider credential in the OS keychain (encrypted at rest) instead of a plaintext `.env.local` |
@@ -771,6 +771,31 @@ and `STATE_DIR`.
 - `--public` binds to `0.0.0.0` (unless explicit `--listen` is provided)
 - `--public` with `--auth none` is rejected unless `--force-insecure` is set
 - Browser origins are allowlisted (localhost defaults + explicit additions)
+
+### What a support bundle discloses
+
+`dir2mcp support-bundle` is meant to be pasted into a public issue, so it is
+filtered on two independent tiers:
+
+| Tier | What it covers | When it is removed |
+|---|---|---|
+| Credentials | bearer tokens, `Authorization` headers, token-style query parameters, and the `user:pass@` userinfo of any URL | **always**, in every mode |
+| Local environment | corpus paths and titles, extraction error messages, and the config snapshot's paths, bind addresses, endpoints, prompts and operator-written glob/regex/word lists | by default; kept with `--include-content` |
+
+`--include-content` widens the second tier only. It never re-enables credential
+disclosure.
+
+What **remains** in a default bundle: the version and OS, the routing decisions
+(`routing.json`), and every closed-domain config setting — booleans, numbers,
+durations, enums, and provider/model names. That is the material a maintainer
+actually triages against. Removed values are marked `"[redacted]"` in
+`config.snapshot.yaml`, so an empty value still means "never configured" and the
+two cases stay distinguishable; a removed list also keeps its item count.
+
+The archive is written owner-only (`0600`) and atomically, so a failed run
+cannot leave a truncated or world-readable bundle behind. Redaction applies to
+the bundle's copy only — the snapshot on disk under the state directory is
+never rewritten.
 
 ## Optional x402 Mode
 

--- a/internal/cli/support_bundle.go
+++ b/internal/cli/support_bundle.go
@@ -548,10 +548,19 @@ var bundleURLPattern = regexp.MustCompile("(?i)\\b[a-z][a-z0-9+.-]*://[^\\s\"'`<
 // normalized on its way into the bundle.
 func redactURLCredentials(s string) string {
 	return bundleURLPattern.ReplaceAllStringFunc(s, func(raw string) string {
-		// Trailing sentence punctuation is prose, not part of the URL.
-		trimmed := strings.TrimRight(raw, ".,;:!)]}")
-		suffix := raw[len(trimmed):]
-		rest, fragment, hasFragment := strings.Cut(trimmed, "#")
+		// Trailing sentence punctuation after a URL in prose is not part of it,
+		// so it is trimmed off and re-appended. That is only safe when nothing
+		// at the end of the URL is being redacted: for a URL with parameters the
+		// trailing run would be the tail of the last parameter's VALUE, and
+		// re-appending it would leak the final characters of a credential. So a
+		// URL carrying a query or fragment keeps the punctuation inside the
+		// redacted value instead (cosmetic loss, no leak).
+		url, suffix := raw, ""
+		if !strings.ContainsAny(raw, "?#") {
+			url = strings.TrimRight(raw, ".,;:!)]}")
+			suffix = raw[len(url):]
+		}
+		rest, fragment, hasFragment := strings.Cut(url, "#")
 		rest, query, hasQuery := strings.Cut(rest, "?")
 
 		out := redactURLUserinfo(rest)

--- a/internal/cli/support_bundle.go
+++ b/internal/cli/support_bundle.go
@@ -44,7 +44,7 @@ const supportLogTailBytes int64 = 2 * 1024 * 1024 // 2 MB
 //     credential came from), never the credentials; server.log, the client
 //     bridge logs, the snapshot and connection URLs all run through
 //     redactBundleSecrets, which strips bearer tokens, Authorization headers,
-//     token-style query parameters and URL userinfo.
+//     URL userinfo, and the value of every URL query/fragment parameter.
 //   - Values naming the operator's machine or corpus — corpus paths and titles,
 //     extraction error messages, and the snapshot's paths, endpoints, hosts,
 //     prompts and hand-written lists — are removed unless the operator opts in
@@ -495,41 +495,114 @@ func supportEntryNames(files []supportFile) []string {
 	return names
 }
 
-// bundleSecretRedactors mask credential material that can appear in client
-// bridge logs and connection URLs (bearer tokens, Authorization headers, and
-// token-style query parameters) before they are written into the shared bundle.
+// bundleSecretRedactors mask header-shaped credential material (bearer tokens
+// and Authorization headers) before it is written into the shared bundle. URLs
+// are handled structurally instead — see redactURLCredentials.
 var bundleSecretRedactors = []*regexp.Regexp{
 	// Authorization header: header name + (optional "Bearer ") + value.
 	regexp.MustCompile(`(?i)(authorization["']?\s*[:=]\s*)(?:bearer\s+)?[^\s"',}]+`),
 	// Standalone "Bearer <token>".
 	regexp.MustCompile(`(?i)bearer\s+[A-Za-z0-9._~+/=-]+`),
-	// token-style query parameters (?token=..., &access_token=..., &api_key=...).
-	regexp.MustCompile(`(?i)([?&](?:token|access_token|api_key|apikey|key)=)[^&\s"']+`),
-	// URL userinfo: the `user:password@` (or bare `user@`) component of any
-	// absolute URL — https://u:p@host, postgres://u:p@host/db, redis://:p@host
-	// (#720).
-	//
-	// This is deliberately keyed on the SHAPE of the value, not on a list of
-	// known key names. A name-keyed rule only covers the URL-bearing settings
-	// that exist today and silently leaks the next one somebody adds; a
-	// shape-keyed rule covers every URL in every artifact — the config snapshot,
-	// server.log, the client bridge logs, connection.json — including fields not
-	// yet invented.
-	//
-	// The whole userinfo goes, not just the password: for an S3-compatible
-	// endpoint the *username* is the access key ID, which is credential
-	// material in its own right.
-	//
-	// The excluded characters keep the match inside a single URL authority, so
-	// `https://example.com/a@b` (an @ in the path) and a bare email address in
-	// prose are both left alone.
-	regexp.MustCompile(`(?i)\b([a-z][a-z0-9+.-]*://)[^\s/?#@\[\]"']+@`),
+}
+
+// bundleURLPattern finds absolute-URL-shaped substrings in free text so
+// redactURLCredentials can rewrite each one. The excluded characters stop a
+// match at whitespace or a quote, which is where a URL ends in a log line or a
+// YAML scalar.
+var bundleURLPattern = regexp.MustCompile("(?i)\\b[a-z][a-z0-9+.-]*://[^\\s\"'`<>]+")
+
+// redactURLCredentials removes credential material from every URL in s:
+// the userinfo component, and the VALUE of every query and fragment parameter.
+//
+// # Why every parameter, and not a list of credential-ish names
+//
+// The original rule redacted a fixed set of parameter names
+// (token/access_token/api_key/apikey/key). That is a deny-list, and it fails
+// OPEN: `?password=` and `?client_secret=` sailed straight through it, and so
+// would whatever name the next integration invents. Widening the vocabulary
+// only moves the boundary — it never closes it.
+//
+// So the value of EVERY parameter goes, with no vocabulary at all. Two
+// measurements say the cost is close to zero:
+//
+//   - A real effective-config snapshot contains no query parameters whatsoever.
+//     Persisted URLs are endpoints, and provider.NormalizeEmbedBaseURL already
+//     strips `RawQuery` before an endpoint is ever recorded.
+//   - dir2mcp does not build query-parameter URLs of its own, so server.log and
+//     the client bridge logs have essentially none to lose either.
+//
+// This also matches what the repo already does everywhere else it hands a URL
+// to something that logs or persists it: avutil.redactInput and
+// provider.NormalizeEmbedBaseURL both clear User, RawQuery and Fragment
+// wholesale rather than inspecting names. This is the same decision, one step
+// less destructive: parameter NAMES survive, because a name is not a credential
+// and "there was a password parameter here" is exactly the kind of thing a
+// maintainer reading a bundle needs to see.
+//
+// The whole userinfo goes, not just the password: for an S3-compatible endpoint
+// the *username* is the access key ID, which is credential material in its own
+// right.
+//
+// Rewriting is textual surgery on the matched substring rather than a
+// url.Parse/String round-trip, so a log line is never silently re-encoded or
+// normalized on its way into the bundle.
+func redactURLCredentials(s string) string {
+	return bundleURLPattern.ReplaceAllStringFunc(s, func(raw string) string {
+		// Trailing sentence punctuation is prose, not part of the URL.
+		trimmed := strings.TrimRight(raw, ".,;:!)]}")
+		suffix := raw[len(trimmed):]
+		rest, fragment, hasFragment := strings.Cut(trimmed, "#")
+		rest, query, hasQuery := strings.Cut(rest, "?")
+
+		out := redactURLUserinfo(rest)
+		if hasQuery {
+			out += "?" + redactParamValues(query)
+		}
+		if hasFragment {
+			out += "#" + redactParamValues(fragment)
+		}
+		return out + suffix
+	})
+}
+
+// redactURLUserinfo replaces the `user:pass@` component of scheme://authority.
+// An `@` later in the path is not userinfo and is left alone.
+func redactURLUserinfo(schemeAndPath string) string {
+	sep := strings.Index(schemeAndPath, "://")
+	if sep < 0 {
+		return schemeAndPath
+	}
+	head := schemeAndPath[:sep+3]
+	tail := schemeAndPath[sep+3:]
+	authority := tail
+	if slash := strings.Index(tail, "/"); slash >= 0 {
+		authority = tail[:slash]
+	}
+	at := strings.LastIndex(authority, "@")
+	if at < 0 {
+		return schemeAndPath
+	}
+	return head + "[REDACTED]" + tail[at:]
+}
+
+// redactParamValues blanks the value of every `name=value` pair in a query or
+// fragment, keeping the names. A component with no `=` (a plain `#anchor`)
+// carries no value and is returned untouched.
+func redactParamValues(component string) string {
+	pairs := strings.Split(component, "&")
+	for i, pair := range pairs {
+		name, _, ok := strings.Cut(pair, "=")
+		if !ok {
+			continue
+		}
+		pairs[i] = name + "=[REDACTED]"
+	}
+	return strings.Join(pairs, "&")
 }
 
 // redactBundleSecrets masks credential material in text destined for the support
-// bundle. It is intentionally conservative (pattern-based) — the bundle is meant
-// to be shareable with a maintainer, so leaking a bearer token would defeat the
-// purpose.
+// bundle. The bundle is meant to be shareable with a maintainer, so leaking a
+// bearer token would defeat the purpose.
 //
 // This is the bundle's TIER-1 filter: it removes credentials, and it runs over
 // every artifact in every mode. --include-content never disables it, because
@@ -539,9 +612,7 @@ func redactBundleSecrets(s string) string {
 	out := s
 	out = bundleSecretRedactors[0].ReplaceAllString(out, "${1}[REDACTED]")
 	out = bundleSecretRedactors[1].ReplaceAllString(out, "Bearer [REDACTED]")
-	out = bundleSecretRedactors[2].ReplaceAllString(out, "${1}[REDACTED]")
-	out = bundleSecretRedactors[3].ReplaceAllString(out, "${1}[REDACTED]@")
-	return out
+	return redactURLCredentials(out)
 }
 
 // claudeMCPLogDirs returns the OS-specific directories where Claude Desktop

--- a/internal/cli/support_bundle.go
+++ b/internal/cli/support_bundle.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"archive/tar"
+	"bytes"
 	"compress/gzip"
 	"context"
 	"encoding/json"
@@ -22,6 +23,7 @@ import (
 	"github.com/dirstral/dir2mcp/internal/buildinfo"
 	"github.com/dirstral/dir2mcp/internal/config"
 	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/statefs"
 )
 
 // supportLogTailBytes caps how much of server.log is included in the
@@ -33,13 +35,20 @@ const supportLogTailBytes int64 = 2 * 1024 * 1024 // 2 MB
 // small set of files (effective config snapshot, server log tail,
 // status JSON, list-files JSON, version, OS info, routing decisions)
 // into a single tar.gz suitable for sharing with a maintainer when
-// diagnosing install/indexing problems. No secret values are included
-// — the effective config snapshot only carries `secret_sources:`
-// metadata (where each credential came from), not the credentials
-// themselves; server.log and the client bridge logs are run through the
-// secret redactor; and list-files.json (plus status.json's failure samples)
-// redact corpus paths/titles/error messages unless the operator opts in with
-// --include-content.
+// diagnosing install/indexing problems.
+//
+// Two privacy tiers govern what lands in it (see support_bundle_redact.go):
+//
+//   - Credentials are removed from EVERY artifact in EVERY mode. The effective
+//     config snapshot carries only `secret_sources:` metadata (where each
+//     credential came from), never the credentials; server.log, the client
+//     bridge logs, the snapshot and connection URLs all run through
+//     redactBundleSecrets, which strips bearer tokens, Authorization headers,
+//     token-style query parameters and URL userinfo.
+//   - Values naming the operator's machine or corpus — corpus paths and titles,
+//     extraction error messages, and the snapshot's paths, endpoints, hosts,
+//     prompts and hand-written lists — are removed unless the operator opts in
+//     with --include-content. That flag never re-enables credential disclosure.
 func (a *App) runSupportBundle(ctx context.Context, global globalOptions, args []string) int {
 	fs := flag.NewFlagSet("support-bundle", flag.ContinueOnError)
 	// Route flag-parse output through writeCLIError so JSON callers get
@@ -48,7 +57,7 @@ func (a *App) runSupportBundle(ctx context.Context, global globalOptions, args [
 	fs.SetOutput(io.Discard)
 	output := fs.String("output", "", "destination tar.gz path (default: ./dir2mcp-support-<timestamp>.tar.gz)")
 	includeContent := fs.Bool("include-content", false,
-		"include corpus paths/titles/extraction error messages in list-files.json and status.json failure samples (may disclose corpus content — review the bundle before sharing)")
+		"include corpus paths/titles/extraction error messages in list-files.json and status.json, and local paths/endpoints/prompts in config.snapshot.yaml (may disclose corpus content and local layout — review the bundle before sharing; credentials stay redacted either way)")
 	if err := fs.Parse(args); err != nil {
 		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("support-bundle: %v", err))
 		return exitConfigInvalid
@@ -129,7 +138,14 @@ func collectSupportArtifacts(ctx context.Context, a *App, cfg config.Config, inc
 	add("version.txt", []byte(buildinfo.Display()+"\n"), nil)
 	add("os.txt", []byte(fmt.Sprintf("GOOS=%s\nGOARCH=%s\n", runtime.GOOS, runtime.GOARCH)), nil)
 
+	// The snapshot used to be copied verbatim, which put absolute corpus/state
+	// paths and any URL-embedded credential into the default bundle (#720).
+	// redactConfigSnapshot applies both privacy tiers; see
+	// support_bundle_redact.go.
 	cfgBytes, cfgErr := readFileBest(config.EffectiveSnapshotPath(cfg.StateDir))
+	if cfgErr == nil {
+		cfgBytes = redactConfigSnapshot(cfgBytes, includeContent)
+	}
 	add("config.snapshot.yaml", cfgBytes, cfgErr)
 
 	// server.log is redirected daemon stdout/stderr and can carry query text,
@@ -148,7 +164,7 @@ func collectSupportArtifacts(ctx context.Context, a *App, cfg config.Config, inc
 	add("list-files.json", listBytes, listErr)
 	if includeContent {
 		warnings = append(warnings, errors.New(
-			"list-files.json/status.json: --include-content may include corpus paths/titles/error messages; review the bundle before sharing it"))
+			"list-files.json/status.json/config.snapshot.yaml: --include-content may include corpus paths/titles/error messages and local paths, endpoints and prompts; review the bundle before sharing it"))
 	}
 
 	routingBytes, routingErr := marshalRoutingJSON(cfg)
@@ -242,8 +258,12 @@ func marshalStatusJSON(ctx context.Context, a *App, cfg config.Config, includeCo
 	}
 	snapshot.Indexing.FailureSummary = redactFailureSamples(snapshot.Indexing.FailureSummary, includeContent)
 	return json.MarshalIndent(map[string]interface{}{
-		"source":    source,
-		"state_dir": cfg.StateDir,
+		"source": source,
+		// state_dir is an absolute local path, so it is the same disclosure
+		// #720 reports for the snapshot's state_dir and is gated identically.
+		// Redacting it only in config.snapshot.yaml would have achieved
+		// nothing: the reader would simply have read it out of here instead.
+		"state_dir": redactContentField(cfg.StateDir, includeContent),
 		"snapshot":  snapshot,
 	}, "", "  ")
 }
@@ -403,27 +423,51 @@ func marshalRoutingJSON(cfg config.Config) ([]byte, error) {
 	}, "", "  ")
 }
 
-// writeSupportBundle writes files as a single gzip-compressed tarball
-// at destPath. Directories in destPath must already exist. Mode 0o600
-// keeps the bundle owner-readable only — its contents include the
-// server log and diagnostic metadata that should not be exposed to
-// other local users by an unfavourable umask.
+// writeSupportBundle writes files as a single gzip-compressed tarball at
+// destPath. Directories in destPath must already exist.
+//
+// The archive is owner-only. It used to be written with
+// os.OpenFile(..., O_TRUNC, 0o600), but an open mode is only applied when the
+// file is CREATED: overwriting an existing 0644 bundle truncated it in place and
+// left it world-readable, so the stated privacy boundary held only for the first
+// write to a given path (#719). Routing through atomicWriteFile — the same
+// temp+sync+chmod+rename helper the rest of the CLI uses — fixes that
+// structurally: rename installs a fresh inode carrying the temp file's mode, so
+// the destination's PRIOR mode cannot survive and no chmod race exists.
+//
+// (statefs's "tighten only if wider" rule deliberately does not apply here.
+// That rule protects a pre-existing file an operator may have made stricter;
+// this path owns the temp file outright and wants exactly statefs.FileMode.)
+//
+// Atomicity is the second half of the fix: a failure mid-write now leaves a
+// previously valid bundle untouched instead of destroying it. The artifacts are
+// already fully in memory, so buffering the tarball costs nothing beyond the
+// (log-tail-capped) bundle size.
 func writeSupportBundle(destPath string, files []supportFile) error {
-	f, err := os.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
-	if err != nil {
+	var buf bytes.Buffer
+	if err := writeSupportTarGz(&buf, files); err != nil {
 		return err
 	}
-	defer func() { _ = f.Close() }()
-	gz := gzip.NewWriter(f)
-	defer func() { _ = gz.Close() }()
+	return atomicWriteFile(destPath, buf.Bytes(), statefs.FileMode)
+}
+
+// writeSupportTarGz streams files into w as a gzip-compressed tarball.
+//
+// Entries are 0o600 rather than 0o644: extracting a deliberately owner-only
+// archive must not re-create the exposure the archive mode exists to prevent.
+//
+// Both writers are closed explicitly and their errors returned. They used to be
+// deferred with the error discarded, which meant a failed gzip/tar flush
+// produced a silently truncated bundle.
+func writeSupportTarGz(w io.Writer, files []supportFile) error {
+	gz := gzip.NewWriter(w)
 	tw := tar.NewWriter(gz)
-	defer func() { _ = tw.Close() }()
 
 	now := time.Now()
 	for _, file := range files {
 		hdr := &tar.Header{
 			Name:    file.Name,
-			Mode:    0o644,
+			Mode:    0o600,
 			Size:    int64(len(file.Bytes)),
 			ModTime: now,
 		}
@@ -433,6 +477,12 @@ func writeSupportBundle(destPath string, files []supportFile) error {
 		if _, err := tw.Write(file.Bytes); err != nil {
 			return err
 		}
+	}
+	if err := tw.Close(); err != nil {
+		return fmt.Errorf("finalize tar: %w", err)
+	}
+	if err := gz.Close(); err != nil {
+		return fmt.Errorf("finalize gzip: %w", err)
 	}
 	return nil
 }
@@ -455,17 +505,42 @@ var bundleSecretRedactors = []*regexp.Regexp{
 	regexp.MustCompile(`(?i)bearer\s+[A-Za-z0-9._~+/=-]+`),
 	// token-style query parameters (?token=..., &access_token=..., &api_key=...).
 	regexp.MustCompile(`(?i)([?&](?:token|access_token|api_key|apikey|key)=)[^&\s"']+`),
+	// URL userinfo: the `user:password@` (or bare `user@`) component of any
+	// absolute URL — https://u:p@host, postgres://u:p@host/db, redis://:p@host
+	// (#720).
+	//
+	// This is deliberately keyed on the SHAPE of the value, not on a list of
+	// known key names. A name-keyed rule only covers the URL-bearing settings
+	// that exist today and silently leaks the next one somebody adds; a
+	// shape-keyed rule covers every URL in every artifact — the config snapshot,
+	// server.log, the client bridge logs, connection.json — including fields not
+	// yet invented.
+	//
+	// The whole userinfo goes, not just the password: for an S3-compatible
+	// endpoint the *username* is the access key ID, which is credential
+	// material in its own right.
+	//
+	// The excluded characters keep the match inside a single URL authority, so
+	// `https://example.com/a@b` (an @ in the path) and a bare email address in
+	// prose are both left alone.
+	regexp.MustCompile(`(?i)\b([a-z][a-z0-9+.-]*://)[^\s/?#@\[\]"']+@`),
 }
 
 // redactBundleSecrets masks credential material in text destined for the support
 // bundle. It is intentionally conservative (pattern-based) — the bundle is meant
 // to be shareable with a maintainer, so leaking a bearer token would defeat the
 // purpose.
+//
+// This is the bundle's TIER-1 filter: it removes credentials, and it runs over
+// every artifact in every mode. --include-content never disables it, because
+// consenting to disclose your own corpus is not consenting to disclose a
+// password.
 func redactBundleSecrets(s string) string {
 	out := s
 	out = bundleSecretRedactors[0].ReplaceAllString(out, "${1}[REDACTED]")
 	out = bundleSecretRedactors[1].ReplaceAllString(out, "Bearer [REDACTED]")
 	out = bundleSecretRedactors[2].ReplaceAllString(out, "${1}[REDACTED]")
+	out = bundleSecretRedactors[3].ReplaceAllString(out, "${1}[REDACTED]@")
 	return out
 }
 

--- a/internal/cli/support_bundle_internal_test.go
+++ b/internal/cli/support_bundle_internal_test.go
@@ -97,12 +97,20 @@ func TestRedactBundleSecrets(t *testing.T) {
 			mustNot:  "hunter2hunter2",
 			mustHave: "https://[REDACTED]@minio.internal:9000/bucket?password=[REDACTED]",
 		},
-		// Prose punctuation after a URL is not part of it.
+		// A credential ending in punctuation must not have its tail survive the
+		// prose-punctuation trim: the trailing run is absorbed into the
+		// redaction rather than re-appended.
 		{
-			name:     "trailing sentence punctuation preserved",
+			name:     "credential ending in a period does not leak its tail",
 			in:       "failed against https://host/v1?token=abcdef123456.",
 			mustNot:  "abcdef123456",
-			mustHave: "?token=[REDACTED].",
+			mustHave: "?token=[REDACTED]",
+		},
+		{
+			name:     "userinfo credential ending in punctuation",
+			in:       "dial redis://:hunter2hunter2@cache.internal:6379.",
+			mustNot:  "hunter2hunter2",
+			mustHave: "redis://[REDACTED]@cache.internal:6379.",
 		},
 		// URL userinfo (#720). The whole userinfo goes, not just the password:
 		// for an S3-compatible endpoint the username IS the access key ID. The
@@ -165,6 +173,10 @@ func TestRedactBundleSecretsLeavesInnocuousTextIntact(t *testing.T) {
 		"git@github.com:dirstral/dir2mcp.git",
 		// A fragment with no `name=value` pair carries no value to remove.
 		"https://host/docs#installation",
+		// Prose punctuation after a parameterless URL is not part of it and is
+		// preserved: nothing at the end of this URL is being redacted.
+		"see https://api.mistral.ai/v1/embeddings.",
+		"docs at https://host/guide (recommended).",
 	} {
 		t.Run(in, func(t *testing.T) {
 			if got := redactBundleSecrets(in); got != in {

--- a/internal/cli/support_bundle_internal_test.go
+++ b/internal/cli/support_bundle_internal_test.go
@@ -36,6 +36,34 @@ func TestRedactBundleSecrets(t *testing.T) {
 			mustNot:  "supersecretquerytoken",
 			mustHave: "token=[REDACTED]",
 		},
+		// URL userinfo (#720). The whole userinfo goes, not just the password:
+		// for an S3-compatible endpoint the username IS the access key ID. The
+		// host survives, because knowing which endpoint was configured is the
+		// diagnostic and the host is not the credential.
+		{
+			name:     "https url userinfo",
+			in:       "source_s3_endpoint: https://audit-user:repro-only-secret@minio.internal:9000",
+			mustNot:  "repro-only-secret",
+			mustHave: "https://[REDACTED]@minio.internal:9000",
+		},
+		{
+			name:     "postgres dsn userinfo",
+			in:       "dial postgres://svc_ro:hunter2hunter2@db.internal:5432/vectors failed",
+			mustNot:  "hunter2hunter2",
+			mustHave: "postgres://[REDACTED]@db.internal:5432/vectors",
+		},
+		{
+			name:     "password only userinfo",
+			in:       "redis://:onlyapassword@cache.internal:6379",
+			mustNot:  "onlyapassword",
+			mustHave: "redis://[REDACTED]@cache.internal:6379",
+		},
+		{
+			name:     "username only userinfo",
+			in:       "https://AKIAIOSFODNN7EXAMPLE@s3.internal",
+			mustNot:  "AKIAIOSFODNN7EXAMPLE",
+			mustHave: "https://[REDACTED]@s3.internal",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -45,6 +73,32 @@ func TestRedactBundleSecrets(t *testing.T) {
 			}
 			if !strings.Contains(got, tc.mustHave) {
 				t.Fatalf("expected %q in redacted output, got %q", tc.mustHave, got)
+			}
+		})
+	}
+}
+
+// TestRedactBundleSecretsLeavesInnocuousTextIntact is the counterweight to the
+// shape-keyed URL-userinfo rule added for #720. A pattern that fires on an
+// ordinary URL, an @ in a path, or an email address in a log line would quietly
+// destroy the diagnostics the bundle exists to carry, so the false-positive
+// boundary is pinned as tightly as the true-positive one.
+func TestRedactBundleSecretsLeavesInnocuousTextIntact(t *testing.T) {
+	for _, in := range []string{
+		"http://localhost:8080/mcp",
+		"https://api.mistral.ai/v1/embeddings",
+		// @ in the path, not in the authority.
+		"https://example.com/users/alice@example.com/docs",
+		// A bare email address: no scheme, so no authority to redact.
+		"reported by alice@example.com",
+		// An IPv6 authority has brackets but no userinfo.
+		"http://[::1]:8080/mcp",
+		// scp-style remote, not a URL.
+		"git@github.com:dirstral/dir2mcp.git",
+	} {
+		t.Run(in, func(t *testing.T) {
+			if got := redactBundleSecrets(in); got != in {
+				t.Fatalf("redaction mangled innocuous text:\n got %q\nwant %q", got, in)
 			}
 		})
 	}

--- a/internal/cli/support_bundle_internal_test.go
+++ b/internal/cli/support_bundle_internal_test.go
@@ -36,6 +36,74 @@ func TestRedactBundleSecrets(t *testing.T) {
 			mustNot:  "supersecretquerytoken",
 			mustHave: "token=[REDACTED]",
 		},
+		// Password- and secret-style query parameters. The original rule listed
+		// only token/api_key names, so an endpoint authenticating with
+		// ?password= or &client_secret= survived into the bundle.
+		{
+			name:     "password query param",
+			in:       "https://host/mcp?password=hunter2hunter2&x=1",
+			mustNot:  "hunter2hunter2",
+			mustHave: "password=[REDACTED]",
+		},
+		{
+			name:     "client_secret query param",
+			in:       "https://host/oauth?client_secret=abcdef123456&grant_type=x",
+			mustNot:  "abcdef123456",
+			mustHave: "client_secret=[REDACTED]",
+		},
+		{
+			name:     "hyphenated client-secret query param",
+			in:       "https://host/oauth?client-secret=abcdef123456",
+			mustNot:  "abcdef123456",
+			mustHave: "client-secret=[REDACTED]",
+		},
+		{
+			name:     "x-api-key query param",
+			in:       "https://host/v1?x-api-key=abcdef123456",
+			mustNot:  "abcdef123456",
+			mustHave: "x-api-key=[REDACTED]",
+		},
+		{
+			name:     "fragment-form credential",
+			in:       "https://host/cb#id_token=abcdef123456&state=x",
+			mustNot:  "abcdef123456",
+			mustHave: "id_token=[REDACTED]",
+		},
+		{
+			name:     "signature query param",
+			in:       "https://host/blob?sig=abcdef123456",
+			mustNot:  "abcdef123456",
+			mustHave: "sig=[REDACTED]",
+		},
+		// No vocabulary: a parameter nobody has thought to name yet is redacted
+		// the same as `token`. This is the property a deny-list cannot have, and
+		// the reason the rule has no name list at all.
+		{
+			name:     "unknown parameter name is redacted too",
+			in:       "https://host/v1?wholly_novel_credential_name=abcdef123456",
+			mustNot:  "abcdef123456",
+			mustHave: "wholly_novel_credential_name=[REDACTED]",
+		},
+		{
+			name:     "every parameter in a multi-param URL",
+			in:       "https://host/v1?a=first-value&b=second-value",
+			mustNot:  "second-value",
+			mustHave: "a=[REDACTED]&b=[REDACTED]",
+		},
+		// Userinfo and query credentials in one URL: both go, host and path stay.
+		{
+			name:     "userinfo and query together",
+			in:       "https://u:p@minio.internal:9000/bucket?password=hunter2hunter2",
+			mustNot:  "hunter2hunter2",
+			mustHave: "https://[REDACTED]@minio.internal:9000/bucket?password=[REDACTED]",
+		},
+		// Prose punctuation after a URL is not part of it.
+		{
+			name:     "trailing sentence punctuation preserved",
+			in:       "failed against https://host/v1?token=abcdef123456.",
+			mustNot:  "abcdef123456",
+			mustHave: "?token=[REDACTED].",
+		},
 		// URL userinfo (#720). The whole userinfo goes, not just the password:
 		// for an S3-compatible endpoint the username IS the access key ID. The
 		// host survives, because knowing which endpoint was configured is the
@@ -95,6 +163,8 @@ func TestRedactBundleSecretsLeavesInnocuousTextIntact(t *testing.T) {
 		"http://[::1]:8080/mcp",
 		// scp-style remote, not a URL.
 		"git@github.com:dirstral/dir2mcp.git",
+		// A fragment with no `name=value` pair carries no value to remove.
+		"https://host/docs#installation",
 	} {
 		t.Run(in, func(t *testing.T) {
 			if got := redactBundleSecrets(in); got != in {

--- a/internal/cli/support_bundle_redact.go
+++ b/internal/cli/support_bundle_redact.go
@@ -1,0 +1,341 @@
+package cli
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Snapshot redaction for the support bundle (#720).
+//
+// `.dir2mcp.yaml.snapshot` used to be copied into the archive verbatim. It
+// carries `root_dir`, `state_dir` and every configured endpoint, so the default
+// bundle disclosed absolute corpus paths with no --include-content consent, and
+// disclosed credentials outright when an endpoint used URL userinfo
+// (`https://key:secret@minio.internal`).
+//
+// # The two tiers
+//
+// The bundle already had exactly two privacy tiers, and this reuses them rather
+// than inventing a third:
+//
+//	tier 1 — secrets      removed ALWAYS, in every mode (redactBundleSecrets)
+//	tier 2 — environment  removed by default, restored by --include-content
+//
+// A secret is credential material: a bearer token, an API key, the userinfo of
+// a URL. Tier 1 is shape-keyed and lives in redactBundleSecrets, so it applies
+// to this snapshot and to server.log alike.
+//
+// Merely sensitive is everything that describes the operator's machine and
+// deployment rather than authenticating to it: filesystem paths, hostnames and
+// endpoints, bind addresses, prompts, and the glob/regex/word lists an operator
+// writes by hand. A bucket name is in this class — it is not a credential, but
+// `acme-legal-discovery-2026` names the client, and this file is meant to be
+// pasted into a public GitHub issue. Tier 2 is exactly the class
+// --include-content already gates for list-files.json's rel_path/title and
+// status.json's failure samples, so path-bearing config joins it instead of
+// getting a flag of its own.
+//
+// # Why an allow-list
+//
+// snapshotAllowedKeys names the keys whose values are emitted; everything else
+// is redacted. The alternative — a deny-list of known-sensitive key names — was
+// rejected because persistedConfig is an actively growing struct (~180 keys and
+// counting). A deny-list fails OPEN: key #181 leaks until somebody remembers to
+// list it, which is precisely the failure mode that produced this issue, since
+// `source_s3_endpoint` was added long after the bundle's redaction was written.
+// An allow-list fails CLOSED: key #181 is redacted until somebody classifies
+// it. For an artifact whose purpose is public disclosure, fail-closed is the
+// only defensible default.
+//
+// The cost of an allow-list is real — it can drop a diagnostically useful
+// field — and is mitigated two ways. First, the list is generous: every tuning
+// knob a maintainer triages against is on it (see the classification rule
+// below), so what is lost is confined to operator-authored strings. Second,
+// redaction is VISIBLE: a removed value becomes "[redacted]", so an empty value
+// still means "the operator never set this" and the two cases stay
+// distinguishable. Collapsing them would make the bundle actively misleading —
+// a maintainer would read a redacted custom system prompt as a default one.
+//
+// # The classification rule
+//
+// A key is allowed when its value cannot carry operator environment, which is
+// true in exactly two cases:
+//
+//   - a closed value domain — bool, number, duration, or an enum drawn from a
+//     fixed vocabulary the config validator enforces (`ocr_auto`, `lenient`,
+//     `memory`, `warn`, a BCP-47 language code, an AWS region);
+//   - a third-party product identifier — a provider name, a model name, a
+//     prompt-version tag. These name software, not the operator's deployment.
+//
+// Everything else — paths, URLs, hosts, bind addresses, prompts, hand-written
+// pattern and word lists, and the operator-chosen names of buckets, collections
+// and database objects — is tier 2.
+//
+// Only the bundle's COPY is rewritten. The on-disk snapshot is untouched, so
+// config reload and `embed_identity` verification are unaffected.
+
+// snapshotRedactionHeader is prepended to the redacted snapshot so the person
+// reading the bundle can tell an unset key from a removed one without having to
+// know this file exists.
+const snapshotRedactionHeader = `# Redacted for sharing: values naming this machine or deployment (paths,
+# endpoints, hosts, prompts, operator-written lists) were removed. "[redacted]"
+# marks a value that WAS set and was removed; an empty value means the key was
+# genuinely unset. Re-run with --include-content to keep them. Credentials are
+# removed in both modes.
+`
+
+// snapshotRedactedMarker is the placeholder for a removed value. It is the same
+// lower-case marker listFileRelPath already uses for content-tier redaction
+// (upper-case [REDACTED] stays reserved for tier-1 secrets), and it is quoted so
+// the redacted snapshot remains parseable YAML — bare [redacted] would decode
+// as a one-element flow sequence.
+const snapshotRedactedMarker = `"[redacted]"`
+
+// snapshotAllowedKeys are the snapshot keys whose values survive a default
+// bundle, per the classification rule documented above. Adding a key here is a
+// disclosure decision: it asserts the value cannot name the operator's machine,
+// deployment or corpus.
+var snapshotAllowedKeys = map[string]bool{
+	// Server posture. public/auth_mode carry the security posture that
+	// listen_addr would otherwise be needed for; the address itself is
+	// environment.
+	"protocol_version": true,
+	"public":           true,
+	"auth_mode":        true,
+	"rate_limit_rps":   true,
+	"rate_limit_burst": true,
+
+	// Timeouts and intervals.
+	"session_inactivity_timeout": true,
+	"session_max_lifetime":       true,
+	"health_check_interval":      true,
+
+	// RAG / retrieval tuning. The *_prompt keys are absent by design: an
+	// operator-authored system prompt is free text.
+	"rag_generate_answer":                   true,
+	"rag_k_default":                         true,
+	"rag_max_context_chars":                 true,
+	"rag_oversample_factor":                 true,
+	"retrieval_hybrid_enabled":              true,
+	"dedup_retrieval":                       true,
+	"retrieval_min_score":                   true,
+	"retrieval_recency_half_life":           true,
+	"context_compression_enabled":           true,
+	"context_compression_target_ratio":      true,
+	"retrieval_adaptive_enabled":            true,
+	"retrieval_adaptive_k_min":              true,
+	"retrieval_adaptive_k_max":              true,
+	"retrieval_mmr_enabled":                 true,
+	"retrieval_mmr_lambda":                  true,
+	"retrieval_hyde_enabled":                true,
+	"retrieval_hyde_mode":                   true,
+	"retrieval_contextual_enabled":          true,
+	"retrieval_contextual_provider":         true,
+	"retrieval_contextual_model":            true,
+	"retrieval_contextual_max_tokens":       true,
+	"retrieval_contextual_prompt_version":   true,
+	"cross_lingual_enabled":                 true,
+	"cross_lingual_target_langs":            true,
+	"retrieval_hierarchical_enabled":        true,
+	"retrieval_hierarchical_source_reps":    true,
+	"retrieval_hierarchical_levels":         true,
+	"retrieval_hierarchical_provider":       true,
+	"retrieval_hierarchical_max_tokens":     true,
+	"retrieval_hierarchical_prompt_version": true,
+	"rerank_enabled":                        true,
+	"rerank_provider":                       true,
+	"rerank_model":                          true,
+	"rerank_candidate_pool":                 true,
+
+	// Chunking and ingest routing — the settings an extraction/OCR bug report
+	// is actually triaged against.
+	"chunking_strategy":       true,
+	"chunking_max_tokens":     true,
+	"chunking_overlap_tokens": true,
+	"ingest_gitignore":        true,
+	"ingest_follow_symlinks":  true,
+	"ingest_max_file_mb":      true,
+	"ingest_pdf_mode":         true,
+	"ingest_images_mode":      true,
+	"ingest_audio_mode":       true,
+	"ingest_archives_mode":    true,
+	"ingest_extractor":        true,
+	"ingest_on_unsupported":   true,
+	"index_backend":           true,
+	"ingest_scan_cache":       true,
+	"ingest_late_chunking":    true,
+	"ingest_watch":            true,
+	"ingest_watch_debounce":   true,
+
+	// Speech-to-text and recognition selection. recognize_serve_url/command are
+	// absent: a self-hosted endpoint and a command line are environment.
+	"stt_provider":                 true,
+	"stt_mistral_model":            true,
+	"stt_elevenlabs_model":         true,
+	"stt_elevenlabs_language_code": true,
+	"recognize_provider":           true,
+
+	// Quality and language.
+	"quality_gates_enabled":      true,
+	"language_detection_enabled": true,
+
+	// An ElevenLabs catalog voice ID names a vendor asset, not the operator's
+	// deployment, so it is a product identifier despite looking opaque. The
+	// matching elevenlabs_base_url is an endpoint and is absent.
+	"elevenlabs_tts_voice_id": true,
+
+	// Media pipeline. The word/phrase lists (media_filter_words,
+	// media_subtitles_glossary/drop_phrases/scrub_phrases) are absent: they are
+	// hand-written and routinely derived from the corpus itself.
+	"media_sidecars_disabled":                 true,
+	"media_variants_group":                    true,
+	"media_variants_select":                   true,
+	"media_translate_enabled":                 true,
+	"media_translate_target_langs":            true,
+	"media_translate_engine":                  true,
+	"media_subtitles_ttml_enabled":            true,
+	"media_subtitles_ttml_align_tolerance_ms": true,
+	"media_subtitles_smil_enabled":            true,
+	"media_subtitles_segmentation":            true,
+	"media_subtitles_collapse_repeats":        true,
+	"media_subtitles_drop_urls":               true,
+	"media_trim_leading_silence":              true,
+	"media_silence_threshold_db":              true,
+	"media_vad":                               true,
+	"media_diarize_enabled":                   true,
+	"media_audio_window_sec":                  true,
+	"media_translate_whisper_window_sec":      true,
+	"media_translate_window_lines":            true,
+	"media_translate_context_lines":           true,
+	"media_video_window_sec":                  true,
+	"media_clip_max_duration_ms":              true,
+	"media_clip_max_bytes":                    true,
+	"media_stt_max_payload_mb":                true,
+	"media_stt_request_timeout_sec":           true,
+	"media_stt_language_strict":               true,
+	"media_stt_on_uncovered_language":         true,
+	"media_stt_tracks":                        true,
+	"media_batch_two_phase":                   true,
+	"media_batch_progress":                    true,
+
+	// x402 gating. The URLs, the asset contract and the payee address are
+	// absent: they identify the operator's deployment and payee.
+	"x402_mode":               true,
+	"x402_tools_call_enabled": true,
+	"x402_price_atomic":       true,
+	"x402_network":            true,
+	"x402_scheme":             true,
+
+	// Corpus source. kind and region are closed vocabularies; bucket, prefix
+	// and endpoint name the operator's storage and are absent.
+	"source_kind":      true,
+	"source_s3_region": true,
+
+	// Distributed embedding. distributed_embed_broker is a backend SELECTOR
+	// (the credential-bearing broker URL is never persisted at all);
+	// distributed_embed_sqlite_path is a path and is absent.
+	"distributed_embed_enabled":      true,
+	"distributed_embed_broker":       true,
+	"distributed_embed_max_attempts": true,
+
+	// Embed identity components. embed_contextual is an enum. embed_identity
+	// and embed_base_url are absent: both embed the resolved endpoint, which
+	// for a self-hosted provider is an internal hostname.
+	"embed_contextual": true,
+
+	// secret_sources records WHERE each credential came from (env, keychain,
+	// file, session) and never a credential itself. It is the block the
+	// command's own documentation points maintainers at.
+	"secret_sources": true,
+}
+
+// redactConfigSnapshot rewrites the effective-config snapshot for inclusion in
+// the support bundle. See the file comment for the tier model and for why the
+// key set is an allow-list.
+//
+// The snapshot is emitted by config.marshalConfigYAML, a hand-rolled writer
+// producing a flat document: `key: value`, `key:` followed by indented `- item`
+// lines, and one nested `secret_sources:` block. Parsing it line-wise (rather
+// than through a YAML round-trip) preserves that byte-level shape and, more
+// importantly, means an unparseable or unfamiliar line is dropped rather than
+// passed through.
+func redactConfigSnapshot(raw []byte, includeContent bool) []byte {
+	if len(raw) == 0 {
+		return raw
+	}
+	if includeContent {
+		// Consent covers the operator's own environment, never credentials:
+		// tier 1 still runs.
+		return []byte(redactBundleSecrets(string(raw)))
+	}
+
+	lines := strings.Split(strings.TrimRight(string(raw), "\n"), "\n")
+	out := []string{strings.TrimRight(snapshotRedactionHeader, "\n")}
+	for i := 0; i < len(lines); {
+		key, value, ok := parseSnapshotKeyLine(lines[i])
+		if !ok {
+			// Blank, comment, or a shape this writer does not produce. Drop it:
+			// an unrecognized line has no classification, and fail-closed is
+			// the whole point of the allow-list.
+			i++
+			continue
+		}
+		block := snapshotIndentedBlock(lines[i+1:])
+		out = append(out, renderSnapshotEntry(lines[i], key, value, block)...)
+		i += 1 + len(block)
+	}
+	return []byte(strings.Join(out, "\n") + "\n")
+}
+
+// parseSnapshotKeyLine splits a top-level `key: value` line. A list header
+// (`key:`) yields an empty value, which renderSnapshotEntry disambiguates using
+// the following indented block.
+func parseSnapshotKeyLine(line string) (key, value string, ok bool) {
+	if line == "" || strings.HasPrefix(line, " ") || strings.HasPrefix(line, "\t") ||
+		strings.HasPrefix(line, "#") {
+		return "", "", false
+	}
+	idx := strings.Index(line, ":")
+	if idx <= 0 {
+		return "", "", false
+	}
+	return line[:idx], strings.TrimSpace(line[idx+1:]), true
+}
+
+// snapshotIndentedBlock returns the run of indented lines belonging to the
+// preceding key (list items, or the nested secret_sources entries).
+func snapshotIndentedBlock(rest []string) []string {
+	n := 0
+	for n < len(rest) && (strings.HasPrefix(rest[n], " ") || strings.HasPrefix(rest[n], "\t")) {
+		n++
+	}
+	return rest[:n]
+}
+
+// renderSnapshotEntry emits one snapshot key for the default (content-excluded)
+// bundle: verbatim when the key is allow-listed, and a visible placeholder
+// otherwise. Allow-listed values still pass through tier 1.
+func renderSnapshotEntry(line, key, value string, block []string) []string {
+	if snapshotAllowedKeys[key] {
+		out := make([]string, 0, 1+len(block))
+		out = append(out, redactBundleSecrets(line))
+		for _, b := range block {
+			out = append(out, redactBundleSecrets(b))
+		}
+		return out
+	}
+	if len(block) > 0 {
+		// A list with entries. The COUNT is kept: it distinguishes "the
+		// operator customized path_excludes" from "the operator did not",
+		// which is the diagnostic the list is usually consulted for, and a
+		// count discloses no entry. The count goes INSIDE the quotes so the
+		// line stays a single valid YAML scalar.
+		return []string{key + ": " + strconv.Quote("[redacted] ("+strconv.Itoa(len(block))+" items)")}
+	}
+	if value == "" || value == "[]" {
+		// Unset, or an explicitly empty list. Nothing was removed, so say so
+		// rather than claim a redaction that did not happen.
+		return []string{line}
+	}
+	return []string{key + ": " + snapshotRedactedMarker}
+}

--- a/tests/security/cli_boundary_test.go
+++ b/tests/security/cli_boundary_test.go
@@ -208,6 +208,7 @@ func TestRepoSplitBoundary_InternalCLIFileOwnership(t *testing.T) {
 		"style.go":                               {},
 		"support_bundle.go":                      {},
 		"support_bundle_internal_test.go":        {},
+		"support_bundle_redact.go":               {},
 		"syncwriter.go":                          {},
 		"syncwriter_test.go":                     {},
 		"up.go":                                  {},

--- a/tests/security/support_bundle_permissions_719_test.go
+++ b/tests/security/support_bundle_permissions_719_test.go
@@ -1,0 +1,153 @@
+//go:build unix
+
+// POSIX permission bits and syscall.Umask. Windows has neither, and its
+// owner-only guarantee is an ACL contract tested separately.
+
+package tests
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/cli"
+	"github.com/dirstral/dir2mcp/internal/statefs"
+)
+
+// #719: `support-bundle --output <path>` documents an owner-only 0600 archive,
+// but it opened the destination with
+//
+//	os.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+//
+// and an open mode is applied only when the file is CREATED. Overwriting an
+// existing group/world-readable bundle truncated it in place and left the mode
+// alone, so a bundle carrying server.log and diagnostic metadata stayed
+// readable by every local account. The promise held only for the first write to
+// a given path.
+//
+// These tests force a permissive umask because the defect is invisible under a
+// restrictive one: with umask 077 a fresh bundle is 0600 whatever the code
+// does, and the overwrite case needs a permissive file to have existed at all.
+// withPermissiveUmask and modeOf are shared with state_permissions_726_test.go.
+
+// runSupportBundleTo writes a bundle to dest and fails the test if the command
+// does not succeed.
+func runSupportBundleTo(t *testing.T, stateDir, dest string) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	if code := app.Run([]string{"--state-dir", stateDir, "support-bundle", "--output", dest}); code != 0 {
+		t.Fatalf("support-bundle exit=%d stderr=%q", code, stderr.String())
+	}
+}
+
+// TestSupportBundleOverwritingAPermissiveDestinationTightensIt is the reported
+// defect. It fails on the pre-fix code with mode 0644/0666 preserved.
+func TestSupportBundleOverwritingAPermissiveDestinationTightensIt(t *testing.T) {
+	withPermissiveUmask(t)
+
+	for _, seedMode := range []os.FileMode{0o644, 0o666} {
+		t.Run(seedMode.String(), func(t *testing.T) {
+			tmp := t.TempDir()
+			stateDir := filepath.Join(tmp, ".dir2mcp")
+			dest := filepath.Join(tmp, "bundle.tar.gz")
+
+			// A bundle left behind by an earlier run, or simply `touch`ed by the
+			// operator, exactly as the issue reproduces it.
+			if err := os.WriteFile(dest, []byte("stale bundle"), seedMode); err != nil {
+				t.Fatalf("seed destination: %v", err)
+			}
+			if err := os.Chmod(dest, seedMode); err != nil {
+				t.Fatalf("chmod seed: %v", err)
+			}
+			if got := modeOf(t, dest); got != seedMode {
+				t.Fatalf("seed did not reproduce the reported state: destination is %04o, want %04o", got, seedMode)
+			}
+
+			runSupportBundleTo(t, stateDir, dest)
+
+			if got := modeOf(t, dest); got != statefs.FileMode {
+				t.Fatalf("overwritten bundle is %04o, want %04o: server.log and diagnostics stay readable by other local accounts", got, statefs.FileMode)
+			}
+		})
+	}
+}
+
+// TestSupportBundleCreatesAnOwnerOnlyDestination retains the new-file guarantee
+// the issue asks to keep, under the same permissive umask.
+func TestSupportBundleCreatesAnOwnerOnlyDestination(t *testing.T) {
+	withPermissiveUmask(t)
+	tmp := t.TempDir()
+	dest := filepath.Join(tmp, "fresh.tar.gz")
+
+	runSupportBundleTo(t, filepath.Join(tmp, ".dir2mcp"), dest)
+
+	if got := modeOf(t, dest); got != statefs.FileMode {
+		t.Fatalf("newly created bundle is %04o, want %04o", got, statefs.FileMode)
+	}
+}
+
+// TestSupportBundleLeavesNoStrayTemporaries pins that the temp+rename flow
+// cleans up after itself: a state directory littered with half-written
+// archives would be its own disclosure.
+func TestSupportBundleLeavesNoStrayTemporaries(t *testing.T) {
+	withPermissiveUmask(t)
+	tmp := t.TempDir()
+	dest := filepath.Join(tmp, "bundle.tar.gz")
+
+	runSupportBundleTo(t, filepath.Join(tmp, ".dir2mcp"), dest)
+
+	entries, err := os.ReadDir(tmp)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	for _, e := range entries {
+		if e.Name() != "bundle.tar.gz" && e.Name() != ".dir2mcp" {
+			t.Fatalf("support-bundle left %q behind", e.Name())
+		}
+	}
+}
+
+// TestSupportBundleFailureDoesNotDestroyAnExistingBundle covers the second half
+// of the issue's expected behaviour: the write is atomic, so a failure cannot
+// leave the destination truncated. The pre-fix code opened the destination
+// O_TRUNC before writing a single byte, so any later failure destroyed a
+// previously valid bundle.
+//
+// The failure is induced by removing write permission on the containing
+// directory, which blocks creating the temporary file.
+func TestSupportBundleFailureDoesNotDestroyAnExistingBundle(t *testing.T) {
+	withPermissiveUmask(t)
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores directory write permission")
+	}
+	tmp := t.TempDir()
+	outDir := filepath.Join(tmp, "out")
+	if err := os.Mkdir(outDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	dest := filepath.Join(outDir, "bundle.tar.gz")
+	const previous = "a previously valid bundle"
+	if err := os.WriteFile(dest, []byte(previous), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := os.Chmod(outDir, 0o500); err != nil {
+		t.Fatalf("chmod dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(outDir, 0o700) })
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	if code := app.Run([]string{"--state-dir", filepath.Join(tmp, ".dir2mcp"), "support-bundle", "--output", dest}); code == 0 {
+		t.Fatalf("support-bundle unexpectedly succeeded writing into a read-only directory")
+	}
+
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("previous bundle gone: %v", err)
+	}
+	if string(got) != previous {
+		t.Fatalf("a failed write clobbered the previous bundle: got %q, want %q", got, previous)
+	}
+}

--- a/tests/security/support_bundle_snapshot_720_test.go
+++ b/tests/security/support_bundle_snapshot_720_test.go
@@ -1,0 +1,291 @@
+package tests
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/dirstral/dir2mcp/internal/cli"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// #720: the default `support-bundle` copied .dir2mcp.yaml.snapshot into the
+// shareable archive verbatim, applying neither the --include-content consent
+// gate nor the secret redactor. That disclosed (1) absolute corpus and state
+// paths with no consent, and (2) plaintext credentials whenever a persisted
+// endpoint carried URL userinfo — the S3-compatible case in the issue,
+// `https://user:pass@host`, which none of the existing redactors matched.
+//
+// Every test below builds a real bundle through the public CLI entry point from
+// a config that genuinely contains a URL credential, reproducing the issue's
+// end-to-end steps rather than exercising the redactor in isolation.
+
+const (
+	bundleURLPassword = "repro-only-secret"
+	bundleURLUser     = "audit-user"
+	bundleS3Bucket    = "audit-bucket"
+	bundleEndpoint    = "https://" + bundleURLUser + ":" + bundleURLPassword + "@example.invalid"
+)
+
+// buildCredentialBundle runs `support-bundle` against a config whose persisted
+// S3 endpoint embeds a username and password, and returns the archive entries
+// keyed by name plus the corpus root and state directory it used.
+func buildCredentialBundle(t *testing.T, extraArgs ...string) (entries map[string][]byte, rootDir, stateDir string) {
+	t.Helper()
+	tmp := t.TempDir()
+	rootDir = filepath.Join(tmp, "corpus-secret", "client-alpha")
+	if err := os.MkdirAll(rootDir, 0o700); err != nil {
+		t.Fatalf("mkdir corpus: %v", err)
+	}
+	stateDir = filepath.Join(tmp, "dir2mcp-state")
+	seedIndexedDocument(t, stateDir)
+
+	// The issue's reproduction, verbatim: credentials in the environment and a
+	// non-secret endpoint that happens to carry userinfo. The endpoint IS
+	// persisted to the snapshot; the AWS keys are not.
+	t.Setenv("AWS_ACCESS_KEY_ID", "audit-only")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "audit-only-secret")
+	t.Setenv("DIR2MCP_SOURCE_KIND", "s3")
+	t.Setenv("DIR2MCP_SOURCE_S3_BUCKET", bundleS3Bucket)
+	t.Setenv("DIR2MCP_SOURCE_S3_ENDPOINT", bundleEndpoint)
+
+	dest := filepath.Join(tmp, "bundle.tar.gz")
+	args := append([]string{"--dir", rootDir, "--state-dir", stateDir, "support-bundle", "--output", dest}, extraArgs...)
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	if code := app.Run(args); code != 0 {
+		t.Fatalf("support-bundle exit=%d stderr=%q", code, stderr.String())
+	}
+
+	// The persisted snapshot must really contain the credential, otherwise the
+	// test would pass for the wrong reason.
+	onDisk, err := os.ReadFile(filepath.Join(stateDir, ".dir2mcp.yaml.snapshot"))
+	if err != nil {
+		t.Fatalf("read persisted snapshot: %v", err)
+	}
+	if !bytes.Contains(onDisk, []byte(bundleURLPassword)) {
+		t.Fatalf("precondition failed: the persisted snapshot does not contain the URL credential, so this test proves nothing:\n%s", onDisk)
+	}
+
+	return extractBundleEntries(t, dest), rootDir, stateDir
+}
+
+// seedIndexedDocument puts a meta.sqlite under stateDir so status.json takes
+// its POPULATED branch. Without it status.json short-circuits to
+// {"available": false} and never emits state_dir, which would leave the
+// second copy of the same path disclosure untested.
+func seedIndexedDocument(t *testing.T, stateDir string) {
+	t.Helper()
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		t.Fatalf("mkdir state: %v", err)
+	}
+	ctx := context.Background()
+	st := store.NewSQLiteStore(filepath.Join(stateDir, "meta.sqlite"))
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("init store: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+	if err := st.UpsertDocument(ctx, model.Document{
+		RelPath:   "brief.pdf",
+		DocType:   "pdf",
+		SizeBytes: 1234,
+		Status:    "indexed",
+	}); err != nil {
+		t.Fatalf("upsert doc: %v", err)
+	}
+}
+
+func extractBundleEntries(t *testing.T, path string) map[string][]byte {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open bundle: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		t.Fatalf("gzip: %v", err)
+	}
+	defer func() { _ = gz.Close() }()
+
+	entries := map[string][]byte{}
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("tar: %v", err)
+		}
+		body, err := io.ReadAll(tr)
+		if err != nil {
+			t.Fatalf("read %s: %v", hdr.Name, err)
+		}
+		entries[hdr.Name] = body
+	}
+	return entries
+}
+
+// assertNoEntryContains fails naming the offending entry, since "which artifact
+// leaked it" is the whole diagnostic.
+func assertNoEntryContains(t *testing.T, entries map[string][]byte, needle, what string) {
+	t.Helper()
+	for name, body := range entries {
+		if bytes.Contains(body, []byte(needle)) {
+			t.Errorf("bundle entry %q leaked %s (%q)", name, what, needle)
+		}
+	}
+}
+
+// TestSupportBundleDefaultRedactsURLCredential is the credential half of the
+// issue. It fails on the pre-fix code: config.snapshot.yaml carried
+// `source_s3_endpoint: https://audit-user:repro-only-secret@example.invalid`.
+func TestSupportBundleDefaultRedactsURLCredential(t *testing.T) {
+	entries, _, _ := buildCredentialBundle(t)
+
+	snapshot, ok := entries["config.snapshot.yaml"]
+	if !ok {
+		t.Fatal("bundle has no config.snapshot.yaml")
+	}
+	if !bytes.Contains(snapshot, []byte("[redacted]")) {
+		t.Errorf("config.snapshot.yaml shows no redaction marker at all:\n%s", snapshot)
+	}
+	assertNoEntryContains(t, entries, bundleURLPassword, "a URL password")
+	assertNoEntryContains(t, entries, bundleURLUser, "a URL username (an S3 access key ID)")
+}
+
+// TestSupportBundleDefaultRedactsCorpusAndStatePaths is the path half. The
+// issue reports it against the snapshot; status.json emitted state_dir just as
+// plainly, so both are asserted — redacting only one would have left the reader
+// able to read the path out of the other.
+func TestSupportBundleDefaultRedactsCorpusAndStatePaths(t *testing.T) {
+	entries, rootDir, stateDir := buildCredentialBundle(t)
+
+	// Guard the guard: if status.json ever short-circuits to
+	// {"available": false} again it stops carrying state_dir, and the
+	// assertion below would pass without proving anything.
+	if !bytes.Contains(entries["status.json"], []byte(`"state_dir"`)) {
+		t.Fatalf("status.json is not the populated branch, so it cannot prove state_dir is redacted:\n%s", entries["status.json"])
+	}
+
+	assertNoEntryContains(t, entries, rootDir, "the absolute corpus path")
+	assertNoEntryContains(t, entries, stateDir, "the absolute state path")
+	assertNoEntryContains(t, entries, bundleS3Bucket, "the operator's bucket name")
+}
+
+// TestSupportBundleDefaultKeepsDiagnosticSettings is the counterweight: an
+// allow-list is only defensible if the bundle stays useful. These are the
+// closed-domain settings a maintainer triages an extraction or retrieval bug
+// against, and they must survive redaction.
+func TestSupportBundleDefaultKeepsDiagnosticSettings(t *testing.T) {
+	entries, _, _ := buildCredentialBundle(t)
+	snapshot := string(entries["config.snapshot.yaml"])
+
+	for _, want := range []string{
+		"ingest_extractor: auto",
+		"ingest_pdf_mode: ocr",
+		"index_backend: memory",
+		"retrieval_hybrid_enabled: true",
+		"chunking_max_tokens: 0",
+		"stt_provider: mistral",
+		"source_kind: s3",
+		"public: false",
+	} {
+		if !strings.Contains(snapshot, want) {
+			t.Errorf("redaction dropped a diagnostic setting %q:\n%s", want, snapshot)
+		}
+	}
+}
+
+// TestSupportBundleMarksRemovedValuesDistinctlyFromUnsetOnes pins that a reader
+// can tell "the operator never set this" from "this was removed". Collapsing
+// the two would make the bundle actively misleading: a redacted custom system
+// prompt would read as a default one.
+func TestSupportBundleMarksRemovedValuesDistinctlyFromUnsetOnes(t *testing.T) {
+	entries, _, _ := buildCredentialBundle(t)
+	snapshot := string(entries["config.snapshot.yaml"])
+
+	// root_dir was set and removed.
+	if !strings.Contains(snapshot, `root_dir: "[redacted]"`) {
+		t.Errorf("a removed value is not visibly marked:\n%s", snapshot)
+	}
+	// source_s3_prefix was never configured; nothing was removed, so it must
+	// not claim a redaction.
+	for _, line := range strings.Split(snapshot, "\n") {
+		if strings.HasPrefix(line, "source_s3_prefix:") && strings.Contains(line, "redacted") {
+			t.Errorf("an unset value is reported as redacted, which is a lie: %q", line)
+		}
+	}
+}
+
+// TestSupportBundleIncludeContentRestoresPathsButNeverCredentials pins the tier
+// boundary the issue's last bullet asks for: consenting to disclose your own
+// corpus layout is not consenting to disclose a password.
+func TestSupportBundleIncludeContentRestoresPathsButNeverCredentials(t *testing.T) {
+	entries, rootDir, _ := buildCredentialBundle(t, "--include-content")
+
+	snapshot := string(entries["config.snapshot.yaml"])
+	if !strings.Contains(snapshot, rootDir) {
+		t.Errorf("--include-content did not restore root_dir:\n%s", snapshot)
+	}
+	if !strings.Contains(snapshot, bundleS3Bucket) {
+		t.Errorf("--include-content did not restore the bucket name (not a credential):\n%s", snapshot)
+	}
+
+	assertNoEntryContains(t, entries, bundleURLPassword, "a URL password despite --include-content")
+	assertNoEntryContains(t, entries, bundleURLUser, "a URL username despite --include-content")
+	if !strings.Contains(snapshot, "[REDACTED]@example.invalid") {
+		t.Errorf("the endpoint host should survive with only its userinfo removed:\n%s", snapshot)
+	}
+}
+
+// TestSupportBundleRedactedSnapshotIsStillValidYAML pins that redaction does
+// not turn a .yaml artifact into something no parser will read. The marker is
+// quoted for exactly this reason: a bare [redacted] decodes as a one-element
+// flow sequence, and "[redacted] (3 items)" unquoted is a syntax error.
+func TestSupportBundleRedactedSnapshotIsStillValidYAML(t *testing.T) {
+	entries, _, _ := buildCredentialBundle(t)
+
+	var doc map[string]interface{}
+	if err := yaml.Unmarshal(entries["config.snapshot.yaml"], &doc); err != nil {
+		t.Fatalf("redacted snapshot is not parseable YAML: %v\n%s", err, entries["config.snapshot.yaml"])
+	}
+	if got, ok := doc["root_dir"].(string); !ok || got != "[redacted]" {
+		t.Errorf("root_dir did not decode as the redaction marker string, got %#v", doc["root_dir"])
+	}
+	if got, ok := doc["path_excludes"].(string); !ok || !strings.HasPrefix(got, "[redacted] (") {
+		t.Errorf("a redacted list did not decode as a scalar marker, got %#v", doc["path_excludes"])
+	}
+	// A closed-domain value must survive with its real type intact.
+	if got, ok := doc["public"].(bool); !ok || got {
+		t.Errorf("public did not decode as bool false, got %#v", doc["public"])
+	}
+}
+
+// TestSupportBundleSnapshotOnDiskIsUntouched pins that redaction applies to the
+// bundle's COPY only. Rewriting the persisted snapshot would break config
+// reload and embed-identity verification.
+func TestSupportBundleSnapshotOnDiskIsUntouched(t *testing.T) {
+	_, rootDir, stateDir := buildCredentialBundle(t)
+
+	onDisk, err := os.ReadFile(filepath.Join(stateDir, ".dir2mcp.yaml.snapshot"))
+	if err != nil {
+		t.Fatalf("read snapshot: %v", err)
+	}
+	for _, want := range []string{rootDir, bundleEndpoint} {
+		if !strings.Contains(string(onDisk), want) {
+			t.Errorf("bundling mutated the persisted snapshot; %q is gone:\n%s", want, onDisk)
+		}
+	}
+}

--- a/tests/security/support_bundle_snapshot_720_test.go
+++ b/tests/security/support_bundle_snapshot_720_test.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/dirstral/dir2mcp/internal/cli"
+	"github.com/dirstral/dir2mcp/internal/config"
 	"github.com/dirstral/dir2mcp/internal/model"
 	"github.com/dirstral/dir2mcp/internal/store"
 )
@@ -33,7 +34,11 @@ const (
 	bundleURLPassword = "repro-only-secret"
 	bundleURLUser     = "audit-user"
 	bundleS3Bucket    = "audit-bucket"
-	bundleEndpoint    = "https://" + bundleURLUser + ":" + bundleURLPassword + "@example.invalid"
+	// The endpoint carries a credential in BOTH persisted URL forms the issue
+	// names: HTTP userinfo, and a query-string parameter.
+	bundleQueryPassword = "repro-only-query-secret"
+	bundleEndpoint      = "https://" + bundleURLUser + ":" + bundleURLPassword +
+		"@example.invalid/?password=" + bundleQueryPassword
 )
 
 // buildCredentialBundle runs `support-bundle` against a config whose persisted
@@ -69,12 +74,14 @@ func buildCredentialBundle(t *testing.T, extraArgs ...string) (entries map[strin
 
 	// The persisted snapshot must really contain the credential, otherwise the
 	// test would pass for the wrong reason.
-	onDisk, err := os.ReadFile(filepath.Join(stateDir, ".dir2mcp.yaml.snapshot"))
+	onDisk, err := os.ReadFile(config.EffectiveSnapshotPath(stateDir))
 	if err != nil {
 		t.Fatalf("read persisted snapshot: %v", err)
 	}
-	if !bytes.Contains(onDisk, []byte(bundleURLPassword)) {
-		t.Fatalf("precondition failed: the persisted snapshot does not contain the URL credential, so this test proves nothing:\n%s", onDisk)
+	for _, credential := range []string{bundleURLPassword, bundleQueryPassword} {
+		if !bytes.Contains(onDisk, []byte(credential)) {
+			t.Fatalf("precondition failed: the persisted snapshot does not contain %q, so this test proves nothing:\n%s", credential, onDisk)
+		}
 	}
 
 	return extractBundleEntries(t, dest), rootDir, stateDir
@@ -163,6 +170,7 @@ func TestSupportBundleDefaultRedactsURLCredential(t *testing.T) {
 	}
 	assertNoEntryContains(t, entries, bundleURLPassword, "a URL password")
 	assertNoEntryContains(t, entries, bundleURLUser, "a URL username (an S3 access key ID)")
+	assertNoEntryContains(t, entries, bundleQueryPassword, "a query-string password")
 }
 
 // TestSupportBundleDefaultRedactsCorpusAndStatePaths is the path half. The
@@ -245,8 +253,12 @@ func TestSupportBundleIncludeContentRestoresPathsButNeverCredentials(t *testing.
 
 	assertNoEntryContains(t, entries, bundleURLPassword, "a URL password despite --include-content")
 	assertNoEntryContains(t, entries, bundleURLUser, "a URL username despite --include-content")
+	assertNoEntryContains(t, entries, bundleQueryPassword, "a query-string password despite --include-content")
 	if !strings.Contains(snapshot, "[REDACTED]@example.invalid") {
 		t.Errorf("the endpoint host should survive with only its userinfo removed:\n%s", snapshot)
+	}
+	if !strings.Contains(snapshot, "password=[REDACTED]") {
+		t.Errorf("the query parameter name should survive with only its value removed:\n%s", snapshot)
 	}
 }
 
@@ -279,7 +291,7 @@ func TestSupportBundleRedactedSnapshotIsStillValidYAML(t *testing.T) {
 func TestSupportBundleSnapshotOnDiskIsUntouched(t *testing.T) {
 	_, rootDir, stateDir := buildCredentialBundle(t)
 
-	onDisk, err := os.ReadFile(filepath.Join(stateDir, ".dir2mcp.yaml.snapshot"))
+	onDisk, err := os.ReadFile(config.EffectiveSnapshotPath(stateDir))
 	if err != nil {
 		t.Fatalf("read snapshot: %v", err)
 	}


### PR DESCRIPTION
Closes #719
Closes #720

Both defects live in `internal/cli/support_bundle.go`, so they land in one PR.

I verified each against the code before changing anything. **Both issues are real and reproduce exactly as filed.** Measuring the actual artifact also turned up a third copy of the same disclosure that neither issue mentions (see "What measuring found" below).

---

## #719 — an overwritten bundle kept its permissive mode

`writeSupportBundle` opened the destination with:

```go
os.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
```

An open mode is applied only when the file is **created**. Overwriting an existing bundle truncated it in place and left the inode mode untouched, so the owner-only promise held only for the *first* write to a given path. Confirmed at 0644 and 0666.

### Fix

The archive now routes through `atomicWriteFile` — the existing temp + sync + chmod + rename helper the rest of the CLI already uses — at `statefs.FileMode`.

`rename` installs a **fresh inode** carrying the temp file's mode, so the destination's prior mode cannot survive and there is no chmod race. This is the call-site change the issue's own "prefer an atomic temporary-file + chmod/fsync/rename flow" asks for, and it uses the helper that already exists rather than a parallel one.

Note on `statefs`: I used its `FileMode` constant but deliberately **not** its "tighten only if wider" logic. That rule protects a pre-existing file an operator may have made *stricter*; here the code owns the temp file outright and wants exactly 0600. There is no prior mode to preserve.

Two things came along because the same lines had to move:

- **Tar entry mode 0644 → 0600.** Extracting a deliberately owner-only archive should not re-create, one step later, the exposure the archive mode exists to prevent.
- **The gzip and tar writers are now closed with their errors checked.** They were `defer`red with `_ =`, so a failed flush produced a silently truncated bundle. Flagging in case you'd rather I split these out.

---

## #720 — the config snapshot was copied verbatim

`collectSupportArtifacts` read `.dir2mcp.yaml.snapshot` and added it as `config.snapshot.yaml` without passing it through *either* control the command advertises. Reproduced end-to-end: a default bundle contained the absolute corpus path, the absolute state path, and `source_s3_endpoint: https://audit-user:repro-only-secret@example.invalid` in plaintext.

The hard part here is judgement, so the reasoning is below and also lives in the file comment of `support_bundle_redact.go`, where the next person to touch this will actually read it.

### What is a secret vs merely sensitive

The bundle already had two tiers. I routed the snapshot through both rather than inventing a third:

| Tier | Class | Removed |
|---|---|---|
| 1 | **Credentials** — bearer tokens, `Authorization` headers, token query params, URL userinfo | **always**, every mode |
| 2 | **Operator environment** — paths, bind addresses, endpoints/hosts, prompts, hand-written glob/regex/word lists | by default; kept with `--include-content` |

A **bucket name is not a credential**, so it is not tier 1 — but `acme-legal-discovery-2026` names the client, so it *is* tier 2. `https://user:pass@host` contains a credential, so the userinfo is tier 1 and goes even under `--include-content`.

Tier 2 is exactly the class `--include-content` already gates for `list-files.json`'s `rel_path`/`title` and `status.json`'s failure samples, so path-bearing config joins that gate instead of getting a flag of its own. Consenting to disclose your own corpus is not consenting to disclose a password — so the flag widens tier 2 only, never tier 1.

**Prior art followed rather than reinvented:** `internal/secrets` establishes that credentials are env/keychain-resolved and *never persisted* (`persistedConfig` already omits the x402 token, the Qdrant api_key, the pgvector DSN and the broker URL — with comments saying so). `recognize.go`'s "*Deliberately no body echo: backend errors may include local paths*" establishes that **local paths are a disclosure class in their own right**, independent of secrets. That is precisely the tier-1/tier-2 split, so I used it. Markers follow the file's existing convention too: upper-case `[REDACTED]` for tier-1 secrets (as `redactBundleSecrets` already emits), lower-case `[redacted]` for tier-2 content (as `listFileRelPath` already emits). No third convention introduced.

### Allow-list or deny-list, and why

**Allow-list.** `snapshotAllowedKeys` names the keys whose values are emitted; everything else is redacted.

A deny-list of known-sensitive key names **fails open**: `persistedConfig` is an actively growing struct (~180 keys), and key #181 leaks until somebody remembers to add it. That is not hypothetical — it is the precise mechanism that produced this issue, since `source_s3_endpoint` was added long after the bundle's redaction was written. An allow-list **fails closed**: key #181 is redacted until somebody classifies it. For an artifact whose entire purpose is to be pasted into a public issue, fail-closed is the only defensible default.

The cost you flagged is real — an allow-list can drop diagnostically useful fields — so it is mitigated deliberately:

1. **The list is generous, on a rule that is auditable.** A key is allowed when its value cannot carry operator environment, which is true in exactly two cases: a *closed value domain* (bool, number, duration, or a validator-enforced enum), or a *third-party product identifier* (provider name, model name, prompt-version tag — these name software, not the operator's deployment). Everything else is tier 2. A reviewer can check any single entry against that rule.
2. **`routing.json` is untouched**, so the provider/extractor decisions survive regardless.

There's a regression test (`TestSupportBundleDefaultKeepsDiagnosticSettings`) asserting the bundle *keeps* `ingest_extractor`, `ingest_pdf_mode`, `index_backend`, `retrieval_hybrid_enabled`, `stt_provider`, `source_kind`, `public` and friends, so "we redacted it into uselessness" is a failing test, not a code review argument.

**Tier 1, by contrast, has no name list at all — it is purely structural.** URLs are rewritten by shape wherever they appear (the snapshot, `server.log`, the client bridge logs, `connection.json`): the userinfo component is removed, and the **value of every query and fragment parameter** is replaced. It removes the *whole* userinfo, not just the password, because for an S3-compatible endpoint the username **is** the access key ID.

Because a shape-keyed rule risks false positives that would quietly destroy diagnostics, its non-matches are pinned too: `http://localhost:8080/mcp`, `https://example.com/users/alice@example.com/docs` (an `@` in the path), a bare email in prose, `http://[::1]:8080/mcp`, `git@github.com:...` and a value-less fragment (`#installation`) all pass through byte-identical.

#### Why tier 1 has no parameter-name vocabulary (updated after review)

The first version of this PR redacted a *list* of credential-ish parameter names (`token`, `access_token`, `api_key`, `apikey`, `key`) — the rule that was already in the file. CodeRabbit immediately found that `?password=` and `&client_secret=` sailed straight through it.

That is worth stating plainly, because it is the same failure mode this PR argues against elsewhere: **that rule was a deny-list, and a deny-list fails open.** It was outrun within minutes of the PR opening. Appending `password` and `client_secret` would have left whoever adds the next name in exactly the same position, so I removed the vocabulary entirely rather than extending it.

Every parameter value is now redacted, with no name matching anywhere. **I measured before choosing this**, and the diagnostic cost is close to zero:

- a real effective-config snapshot contains **no query parameters at all** (the only `?` characters in it are inside `secret_patterns` regexes);
- `provider.NormalizeEmbedBaseURL` already does `u.RawQuery = ""` before an endpoint is ever recorded, so a persisted URL structurally cannot carry one;
- dir2mcp does not construct query-parameter URLs of its own, so `server.log` and the client bridge logs have essentially none to lose either.

This also follows prior art rather than inventing a third convention — the repo has already made this exact call twice, both times structurally and never by name:

- `avutil.redactInput`: `u.RawQuery = ""; u.Fragment = ""; u.User = nil`, commented "*replaced wholesale rather than risking a partial leak*";
- `provider.NormalizeEmbedBaseURL`: `u.User = nil // drop userinfo (never record/log a credential)`, `u.RawQuery = "" // drop query`, `u.Fragment = "" // drop fragment`.

Mine is the same decision, one step *less* destructive: parameter **names** survive, because a name is not a credential and "there was a `password` parameter here" is exactly what a maintainer reading a bundle needs to see. That also keeps the removed-vs-absent marking intact for URLs.

Rewriting is textual surgery on the matched substring rather than a `url.Parse`/`String` round-trip, so a log line is never silently re-encoded or normalized on its way into the bundle.

One edge worth calling out, found while reviewing my own change (f35b7b6): the trim that keeps a sentence's trailing period out of a matched URL was re-appending that run verbatim, and for a URL *with parameters* the trailing run is the tail of the last parameter's **value** — so a credential ending in punctuation kept its final characters. The trim now applies only to URLs with no query or fragment, where nothing at the end is being redacted; a parameterised URL absorbs the punctuation into the redaction instead. Cosmetic loss, no leak. Pinned both ways.

```
?password=                      -> password=[REDACTED]
?client_secret= / ?client-secret= -> client_secret=[REDACTED]
?x-api-key=                     -> x-api-key=[REDACTED]
#id_token=                      -> id_token=[REDACTED]   (fragment form, reachable)
?wholly_novel_credential_name=  -> [REDACTED]            (no vocabulary would catch this)
https://u:p@host/b?password=pw  -> https://[REDACTED]@host/b?password=[REDACTED]
```

### Should redacted output be visibly marked

**Yes.** `"[redacted]"`, and the distinction is load-bearing.

An empty value in this snapshot means "the operator never configured this" — that is real diagnostic signal (`rag_system_prompt:` empty means defaults are in play). If a removed value also rendered as empty, a maintainer would read a redacted *custom* system prompt as a default one, and the bundle would be actively misleading rather than merely reduced. So removed values are marked and unset values are left exactly as they were. A redacted **list** additionally keeps its item count (`path_excludes: "[redacted] (10 items)"`), which preserves the question the list is usually consulted for — "did the operator customize this?" — while disclosing no entry.

The marker is **quoted** so the artifact stays parseable YAML: bare `[redacted]` decodes as a one-element flow sequence, and an unquoted `[redacted] (10 items)` is a syntax error. There's a test that unmarshals the redacted snapshot and checks `root_dir` decodes as a string and `public` as a bool.

A header comment explains the convention in the artifact itself, so the reader does not have to know this code exists:

```yaml
# Redacted for sharing: values naming this machine or deployment (paths,
# endpoints, hosts, prompts, operator-written lists) were removed. "[redacted]"
# marks a value that WAS set and was removed; an empty value means the key was
# genuinely unset. Re-run with --include-content to keep them. Credentials are
# removed in both modes.
root_dir: "[redacted]"
state_dir: "[redacted]"
listen_addr: "[redacted]"
protocol_version: 2025-11-25
public: false
auth_mode: auto
server_name:
path_excludes: "[redacted] (10 items)"
...
ingest_extractor: auto
index_backend: memory
source_kind: s3
source_s3_bucket: "[redacted]"
source_s3_endpoint: "[redacted]"
```

### What measuring found that the issues didn't mention

`status.json` emitted `"state_dir": cfg.StateDir` verbatim, on the same line-of-sight as the snapshot's `state_dir`. **Redacting only `config.snapshot.yaml` would have achieved nothing** — the reader would simply have read the path out of `status.json` instead. It is now gated identically via the existing `redactContentField`. This is confirmed by a pre-fix test run (below) showing *both* entries leaking the state path.

### Scoping decisions I did not take

The issue offers "reject credentials in every persisted URL field" as an alternative. I did **not** add validation rejection, because: it is a breaking change for operators running a userinfo endpoint today; per this repo's spec-governance rule a behavior change of that kind needs a `dirstral-spec` PR merged first; and it would not fix the bundle for the other URL-bearing fields anyway. Redacting at the bundle boundary is the correctly-scoped fix — the on-disk snapshot lives at 0600 inside the state directory, which #726 already established as the corpus-confidentiality boundary. The leak reported here is the artifact that *crosses* that boundary. Happy to file the validation hardening separately if you want it.

Redaction applies to the bundle's **copy** only. The persisted snapshot is byte-identical after bundling (there's a test), so config reload and `embed_identity` verification are unaffected.

---

## Testing

Tests live under `tests/security/`. The permission tests force `syscall.Umask(0o022)` and are `//go:build unix`, copying `tests/security/state_permissions_726_test.go` and reusing its `withPermissiveUmask`/`modeOf` helpers — the #719 defect is invisible under a strict umask, and `syscall.Umask` does not exist on Windows.

Every regression test was **proven to fail first**, by reverting only the source change and leaving the tests in place:

```
--- FAIL: TestSupportBundleOverwritingAPermissiveDestinationTightensIt
        overwritten bundle is 0644, want 0600: server.log and diagnostics stay readable by other local accounts
        overwritten bundle is 0666, want 0600: server.log and diagnostics stay readable by other local accounts
--- FAIL: TestSupportBundleFailureDoesNotDestroyAnExistingBundle
    support-bundle unexpectedly succeeded writing into a read-only directory
--- FAIL: TestSupportBundleDefaultRedactsURLCredential
    bundle entry "config.snapshot.yaml" leaked a URL password ("repro-only-secret")
    bundle entry "config.snapshot.yaml" leaked a URL username (an S3 access key ID) ("audit-user")
--- FAIL: TestSupportBundleDefaultRedactsCorpusAndStatePaths
    bundle entry "config.snapshot.yaml" leaked the absolute corpus path (".../corpus-secret/client-alpha")
    bundle entry "config.snapshot.yaml" leaked the absolute state path (".../dir2mcp-state")
    bundle entry "status.json"          leaked the absolute state path (".../dir2mcp-state")
    bundle entry "config.snapshot.yaml" leaked the operator's bucket name ("audit-bucket")
--- FAIL: TestSupportBundleMarksRemovedValuesDistinctlyFromUnsetOnes
    a removed value is not visibly marked
--- FAIL: TestSupportBundleIncludeContentRestoresPathsButNeverCredentials
    bundle entry "config.snapshot.yaml" leaked a URL password despite --include-content
```

Per the issue's request, the #720 tests **assert on a real bundle built through the public CLI entry point from a config that actually contains a URL credential** — the issue's own reproduction, via `DIR2MCP_SOURCE_S3_ENDPOINT='https://audit-user:repro-only-secret@example.invalid'`. `buildCredentialBundle` asserts as a **precondition** that the persisted snapshot really contains the credential, so the tests cannot pass for the wrong reason, and the whole archive (not just the snapshot entry) is scanned for the secret. `status.json` is likewise asserted to be on its *populated* branch, so it cannot silently stop carrying `state_dir` and pass vacuously.

Coverage added:

- **#719**: overwrite 0644 → 0600; overwrite 0666 → 0600; new-file 0600 retained; no stray temporaries; a failed write leaves a previously valid bundle intact.
- **#720**: URL credential removed by default; corpus/state paths and bucket removed by default; diagnostic settings *kept*; removed-vs-unset visibly distinguishable; `--include-content` restores paths but never credentials (and the host survives with only its userinfo removed); redacted snapshot is still valid YAML; on-disk snapshot untouched.
- **Redactor unit tests** (extending the existing `TestRedactBundleSecrets`, no new `internal/cli` test file): userinfo in `https://`, `postgres://`, password-only `redis://:p@` and username-only forms; query/fragment credentials as `password`, `client_secret`, `client-secret`, `x-api-key`, `sig`, `#id_token`, a wholly novel parameter name, multi-parameter URLs, userinfo+query together, and trailing sentence punctuation; plus a false-positive suite pinning that innocuous URLs, emails, IPv6 authorities, scp-style remotes and value-less fragments pass through untouched.

## Checklist

- [x] `make check` passes locally (fmt, vet, golangci-lint `0 issues`, gocyclo `-over 15`, ineffassign, misspell, full test suite, build)
- [x] New `internal/cli/support_bundle_redact.go` added to `tests/security/cli_boundary_test.go` (CI's `checks` job would otherwise fail)
- [x] New/changed behavior has test coverage, proven failing first
- [x] `README.md` updated — the `support-bundle` row plus a new **"What a support bundle discloses"** subsection under Security Defaults, documenting exactly which metadata remains (#720's last bullet)
- [x] `--include-content` help text and the consent warning updated to cover the snapshot
- [x] No unrelated files changed
- [x] CodeRabbit review addressed and thread resolved — its one finding (query-parameter deny-list) led to removing the name vocabulary entirely; see "Why tier 1 has no parameter-name vocabulary" above

Not merging — opened for review as requested.
