### PR TITLE
fix(service): stop reporting lifecycle success the supervisor never achieved (#722, #723, #724, #725)

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,10 @@ Running `dir2mcp` with no arguments prints usage, which you can consult anytime 
 
 The launchd job starts from a clean environment and will **not** inherit a `MISTRAL_API_KEY` you only `export`ed in a shell. Persist the credential first with `dir2mcp config init` (writes `.env.local` in the corpus directory) so the booted daemon can find it; `service install` warns when no persisted credential is present.
 
+`service install` sweeps **every** credential the effective config needs, not just provider API keys: the S3 source credentials (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`), `QDRANT_API_KEY`, `DIR2MCP_INDEX_PGVECTOR_DSN`, `DIR2MCP_DISTRIBUTED_EMBED_BROKER_URL`, and `DIR2MCP_X402_FACILITATOR_TOKEN`. These have no config-file home by design, so the environment / keychain / `.env.local` is their only source. Any of them found in your current shell is copied into `.env.local`; any that is **required** by the config and has no persistent source is named in a warning (and in `missing_credentials` under `--json`) — the service is installed, but it will not boot until you give that secret a persistent source. Values are never printed.
+
+Install and uninstall are also fail-safe: a supervisor step that fails during install rolls the previous service definition (and its loaded/enabled state) back, and `uninstall` refuses to delete a unit whose daemon it could not verifiably stop, so a running daemon is never orphaned. On Linux, `service status` returns an error rather than reporting `installed, not running` when `systemctl --user` cannot answer (no user bus, permission denied, systemctl missing).
+
 ## MCP Tools
 
 | Tool | Description |

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/xml"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -253,7 +254,7 @@ func (a *App) runServiceInstall(global globalOptions, args []string) int {
 		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("create state dir %s: %v", sc.stateDir, err))
 		return exitGeneric
 	}
-	savedCreds, failedCreds := a.persistAndWarnCredentials(sc.workingDir, cfg, global.jsonOutput, global.quiet)
+	creds := a.persistAndWarnCredentials(sc.workingDir, cfg, global.jsonOutput, global.quiet)
 
 	serviceArgs := installServiceArgs(global, sc)
 
@@ -273,15 +274,24 @@ func (a *App) runServiceInstall(global globalOptions, args []string) int {
 		return a.emitServiceJSON(map[string]interface{}{
 			"action": "install", "label": sc.label, "backend": mgr.backendName(),
 			"unit_path": unitPath, "working_dir": sc.workingDir, "binary": sc.binaryPath,
-			"persisted_credentials": savedCreds,
-			"failed_credentials":    failedCreds,
+			"persisted_credentials": creds.saved,
+			"failed_credentials":    creds.failed,
+			// missing_credentials names required runtime secrets with no
+			// persistent source: the service is installed but cannot boot
+			// until each is resolvable from .env.local/keychain (#722).
+			"missing_credentials": creds.missing,
 		})
 	}
 	if !global.quiet {
 		writef(a.stdout, "installed %s service %q\n", mgr.backendName(), sc.label)
 		writef(a.stdout, "  unit:    %s\n", unitPath)
 		writef(a.stdout, "  workdir: %s\n", sc.workingDir)
-		writeln(a.stdout, "the daemon will start now and again at every login")
+		if len(creds.missing) > 0 {
+			writef(a.stdout, "the daemon will start at every login, but %d required credential(s) are still missing (see warnings above)\n",
+				len(creds.missing))
+		} else {
+			writeln(a.stdout, "the daemon will start now and again at every login")
+		}
 	}
 	return exitSuccess
 }
@@ -399,43 +409,150 @@ func (a *App) emitServiceJSON(payload map[string]interface{}) int {
 	return exitSuccess
 }
 
-// persistAndWarnCredentials is called during `service install`. It looks
-// for provider credentials in the current process environment (from the
-// operator's `export KEY=...` session) and persists any it finds to
-// .env.local in the corpus working directory, so the launchd service can
-// read them after a reboot — launchd does not inherit shell exports.
+// serviceCredentialReport is the outcome of the install-time credential sweep.
+// Every field holds env var NAMES only — never values (#722).
+type serviceCredentialReport struct {
+	// saved were found in the current process environment and written to
+	// .env.local, so the supervised daemon will see them after a reboot.
+	saved []string
+	// failed could not be written (bad value or write error).
+	failed []string
+	// missing are REQUIRED by the effective config and have no persistent
+	// source at all: the installed service cannot boot until they get one.
+	missing []string
+}
+
+// persistAndWarnCredentials is called during `service install`. It looks for the
+// runtime credentials the effective config depends on in the current process
+// environment (from the operator's `export KEY=...` session) and persists any it
+// finds to .env.local in the corpus working directory, so the supervised service
+// can read them after a reboot — launchd/systemd do not inherit shell exports.
 //
-// In JSON or quiet mode all normal output is suppressed; the caller
-// receives (saved, failed) to include in structured output instead.
-// Write failures and invalid values (containing newlines) are collected
-// into failed and reported as warnings in text mode.
-func (a *App) persistAndWarnCredentials(workingDir string, cfg config.Config, jsonOut, quiet bool) (saved, failed []string) {
+// The sweep covers BOTH provider-profile `api_key` references (ProviderEnvVarRefs)
+// and the non-provider runtime secrets of the effective config (RuntimeSecretRefs:
+// S3 credentials, the Qdrant key, the pgvector DSN, the broker URL, the x402
+// facilitator token). Before #722 only the provider refs were considered, so an
+// `source.kind: s3` install validated against AWS credentials that existed only
+// in the installing shell, then silently produced a service that could not boot.
+//
+// In JSON or quiet mode all normal output is suppressed; the caller receives the
+// report to include in structured output instead.
+func (a *App) persistAndWarnCredentials(workingDir string, cfg config.Config, jsonOut, quiet bool) serviceCredentialReport {
 	envPath := filepath.Join(workingDir, ".env.local")
-	refs := cfg.ProviderEnvVarRefs()
-	saved, failed = persistCredentialsFromEnv(envPath, refs)
+	providerRefs := cfg.ProviderEnvVarRefs()
+	runtimeRefs := cfg.RuntimeSecretRefs()
+
+	var rep serviceCredentialReport
+	rep.saved, rep.failed = persistCredentialsFromEnv(envPath, credentialSweepKeys(providerRefs, runtimeRefs))
+	rep.missing = unpersistedRequiredSecrets(workingDir, runtimeRefs, rep.saved)
 
 	if jsonOut || quiet {
-		return
+		return rep
 	}
-	for _, key := range saved {
-		writef(a.stdout, "  saved %s to %s (will survive reboots)\n", key, envPath)
+	a.reportCredentialSweep(envPath, rep, runtimeRefs)
+	// The provider-credential warning below is about PROVIDER keys only, so it
+	// must be suppressed only by a provider key: capturing an AWS credential
+	// says nothing about whether an embedding provider will resolve at boot.
+	if anyOf(rep.saved, providerRefs) || persistentCredentialInDotenv(workingDir, providerRefs) {
+		return rep
 	}
-	for _, key := range failed {
-		writef(a.stderr, "  warning: failed to persist %s to %s (check file permissions or key value)\n", key, envPath)
-	}
-	if len(saved) > 0 {
-		return
-	}
-	// Nothing in the current environment to auto-save. Fall back to the
-	// warning if there's also nothing already persisted in a dotenv file.
-	if persistentCredentialInDotenv(workingDir, refs) {
-		return
-	}
+	// Nothing in the current environment to auto-save, and nothing already
+	// persisted in a dotenv file.
 	writef(a.stderr, "warning: no persisted provider credential found in %s\n", envPath)
 	writeln(a.stderr, "  The service starts from a clean environment and will NOT inherit credentials exported in your shell.")
 	writeln(a.stderr, "  Run `dir2mcp config init` to persist the credential to .env.local (or add a providers: block to .dir2mcp.yaml),")
 	writeln(a.stderr, "  otherwise the daemon will fail at boot with \"no embedding provider configured\".")
-	return
+	return rep
+}
+
+// anyOf reports whether haystack contains at least one member of wanted.
+func anyOf(haystack, wanted []string) bool {
+	for _, w := range wanted {
+		if slices.Contains(haystack, w) {
+			return true
+		}
+	}
+	return false
+}
+
+// credentialSweepKeys merges the provider env var refs with the non-provider
+// runtime secret names, preserving first-seen order and dropping duplicates so a
+// key referenced by both is only written once.
+func credentialSweepKeys(providerRefs []string, runtimeRefs []config.RuntimeSecretRef) []string {
+	keys := make([]string, 0, len(providerRefs)+len(runtimeRefs))
+	seen := make(map[string]struct{}, len(providerRefs)+len(runtimeRefs))
+	add := func(name string) {
+		if _, dup := seen[name]; dup || strings.TrimSpace(name) == "" {
+			return
+		}
+		seen[name] = struct{}{}
+		keys = append(keys, name)
+	}
+	for _, name := range providerRefs {
+		add(name)
+	}
+	for _, ref := range runtimeRefs {
+		add(ref.Name)
+	}
+	return keys
+}
+
+// unpersistedRequiredSecrets names the required runtime secrets the installed
+// service will not be able to resolve at boot.
+//
+// A secret is satisfied when it was just persisted to .env.local, when the
+// target directory's dotenv already defines it, or when the effective config
+// resolved it from a source other than the current environment (the keychain).
+// The keychain caveat is documented in the README: a background agent may not be
+// able to unlock it unattended, so keychain-only credentials are still best
+// mirrored into .env.local with `dir2mcp config init`.
+func unpersistedRequiredSecrets(workingDir string, refs []config.RuntimeSecretRef, saved []string) []string {
+	var missing []string
+	for _, ref := range refs {
+		if !ref.Required || slices.Contains(saved, ref.Name) {
+			continue
+		}
+		fromEnv := strings.TrimSpace(os.Getenv(ref.Name)) != ""
+		if !fromEnv && ref.Resolved {
+			continue // resolved from a persistent source (keychain / dotenv)
+		}
+		if persistentCredentialInDotenv(workingDir, []string{ref.Name}) {
+			continue
+		}
+		missing = append(missing, ref.Name)
+	}
+	return missing
+}
+
+// reportCredentialSweep prints the human-readable half of the sweep: what was
+// persisted, what could not be, and which required secrets have no persistent
+// source. Values are never printed.
+func (a *App) reportCredentialSweep(envPath string, rep serviceCredentialReport, refs []config.RuntimeSecretRef) {
+	for _, key := range rep.saved {
+		writef(a.stdout, "  saved %s to %s (will survive reboots)\n", key, envPath)
+	}
+	for _, key := range rep.failed {
+		writef(a.stderr, "  warning: failed to persist %s to %s (check file permissions or key value)\n", key, envPath)
+	}
+	if len(rep.missing) == 0 {
+		return
+	}
+	writeln(a.stderr, "warning: the installed service is NOT bootable yet — required credentials have no persistent source:")
+	for _, key := range rep.missing {
+		writef(a.stderr, "  %s (required by %s)\n", key, secretFeature(refs, key))
+	}
+	writef(a.stderr, "  Export each one and re-run `dir2mcp service install` to capture it into %s,\n", envPath)
+	writeln(a.stderr, "  or add it to .env.local yourself. The supervised daemon starts from a clean environment.")
+}
+
+// secretFeature returns the config setting that pulls name in, for messages.
+func secretFeature(refs []config.RuntimeSecretRef, name string) string {
+	for _, ref := range refs {
+		if ref.Name == name {
+			return ref.Feature
+		}
+	}
+	return "the effective config"
 }
 
 // persistCredentialsFromEnv writes each key in envVarRefs that is found
@@ -505,6 +622,245 @@ func dotenvHasCredential(path string, refs []string) bool {
 	// credential found (conservative) — if the warning fires the operator
 	// can explicitly confirm credentials are configured another way.
 	return false
+}
+
+// --- supervisor output classification (#723, #725) ---
+//
+// Both backends invoke their supervisor through runCmd, which merges stderr into
+// stdout. A non-zero exit is NORMAL for several benign outcomes (booting out a
+// service that is not loaded, asking whether an absent unit is active), so the
+// exit status alone cannot tell a benign result from a real failure. The
+// discriminator is the OUTPUT, and the rule is deny-by-default: only a
+// positively recognized benign phrase is treated as benign; anything else — a
+// dead user bus, a permission denial, a missing binary — is surfaced.
+
+// containsAnyFold reports whether s contains any of phrases, case-insensitively.
+// phrases must already be lowercase.
+func containsAnyFold(s string, phrases []string) bool {
+	lower := strings.ToLower(s)
+	for _, p := range phrases {
+		if strings.Contains(lower, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// launchctlPrintAbsentPhrases are the substrings `launchctl print` emits for a
+// service that is not registered in the domain. Kept deliberately narrow: this
+// list decides whether `service status` reports a clean absent state or an
+// operational error.
+var launchctlPrintAbsentPhrases = []string{
+	"could not find service",
+	"not found in domain",
+}
+
+// launchctlBootoutAbsentPhrases are the substrings `launchctl bootout` emits
+// when there is nothing to unload. It is a superset of the print phrases:
+// bootout also reports the POSIX errno text ("No such process" for a service
+// that is not booted in, "No such file or directory" for a plist path that does
+// not exist), both of which mean the same thing — already absent.
+var launchctlBootoutAbsentPhrases = append([]string{
+	"no such process",
+	"no such file or directory",
+	"could not find specified service",
+}, launchctlPrintAbsentPhrases...)
+
+// launchctlPrintReportsAbsent reports whether a failed `launchctl print`
+// positively identified the service as unregistered.
+func launchctlPrintReportsAbsent(out string) bool {
+	return containsAnyFold(out, launchctlPrintAbsentPhrases)
+}
+
+// launchctlBootoutReportsAbsent reports whether a failed `launchctl bootout`
+// positively identified the service as already unloaded. Anything else — a
+// permission denial, a broken domain — must NOT be swallowed (#723).
+func launchctlBootoutReportsAbsent(out string) bool {
+	return containsAnyFold(out, launchctlBootoutAbsentPhrases)
+}
+
+// systemctlTransportPhrases mark an invocation that never reached the user
+// manager at all. They are checked FIRST because systemd reports a dead user bus
+// as "Failed to connect to bus: No such file or directory" — text that would
+// otherwise read as a missing unit and launder a transport failure into a benign
+// absent state (#725).
+var systemctlTransportPhrases = []string{
+	"failed to connect to bus",
+	"failed to get d-bus connection",
+	"connection refused",
+	"no medium found",
+	"permission denied",
+	"access denied",
+	"interactive authentication required",
+	"refusing to operate",
+}
+
+// systemctlAbsentPhrases are the substrings systemctl emits for a unit it does
+// not know or that is not loaded.
+var systemctlAbsentPhrases = []string{
+	"does not exist",
+	"not loaded",
+	"no such unit",
+	"no such file or directory",
+}
+
+// systemctlReportsAbsent reports whether a failed systemctl invocation
+// positively identified the unit as absent/not loaded, rather than failing to
+// reach systemd at all.
+func systemctlReportsAbsent(out string) bool {
+	if containsAnyFold(out, systemctlTransportPhrases) {
+		return false
+	}
+	return containsAnyFold(out, systemctlAbsentPhrases)
+}
+
+// systemctlQuery describes one `systemctl --user is-*` probe: the documented
+// one-word verdicts it can print, and the verdict a "unit does not exist"
+// diagnostic stands for.
+type systemctlQuery struct {
+	name   string
+	absent string
+	states []string
+}
+
+var (
+	// systemctlIsActive covers the ACTIVE STATE column of `systemctl list-units`.
+	systemctlIsActive = systemctlQuery{
+		name:   "is-active",
+		absent: "inactive",
+		states: []string{"active", "reloading", "inactive", "failed", "activating", "deactivating", "maintenance", "refreshing", "unknown"},
+	}
+	// systemctlIsEnabled covers the documented `is-enabled` verdicts.
+	systemctlIsEnabled = systemctlQuery{
+		name:   "is-enabled",
+		absent: "not-found",
+		states: []string{"enabled", "enabled-runtime", "linked", "linked-runtime", "alias", "masked", "masked-runtime", "static", "indirect", "disabled", "generated", "transient", "not-found", "bad"},
+	}
+)
+
+// classify turns one is-* invocation into a verdict or an operational error.
+//
+// The verdict is located by matching a documented state word on ANY output line
+// rather than by trusting the whole output: runCmd merges stderr in, and some
+// systemd versions print a diagnostic ("Failed to get unit file state for
+// x.service: No such file or directory") alongside — or instead of — the word.
+// When no verdict is present, an absent-unit diagnostic maps to the query's
+// absent verdict; everything else is a failure the caller must surface (#725).
+func (q systemctlQuery) classify(out string, err error) (string, error) {
+	for _, line := range strings.Split(out, "\n") {
+		if s := strings.TrimSpace(line); slices.Contains(q.states, s) {
+			return s, nil
+		}
+	}
+	if systemctlReportsAbsent(out) {
+		return q.absent, nil
+	}
+	detail := strings.TrimSpace(out)
+	if detail == "" {
+		detail = "(no output)"
+	}
+	if err != nil {
+		return "", fmt.Errorf("systemctl --user %s: %w: %s", q.name, err, detail)
+	}
+	return "", fmt.Errorf("systemctl --user %s: unrecognized output: %s", q.name, detail)
+}
+
+// --- transactional definition replacement (#724) ---
+
+// unitTxn captures a service definition file's prior contents so a failed
+// install can put back exactly what was there before.
+//
+// It makes the FILE half of an install atomic: the replacement is staged in the
+// same directory and renamed into place (a supervisor never observes a truncated
+// definition), and a rollback restores the prior bytes byte-for-byte, or removes
+// the file entirely when the install was a first-time one. The SUPERVISOR half —
+// re-loading the previous service — is backend-specific and layered on top.
+type unitTxn struct {
+	path string
+	// perm is the mode a freshly written definition gets.
+	perm os.FileMode
+	// prior/priorPerm/had describe what was on disk before write. priorPerm is
+	// tracked separately from perm so a rollback restores the previous file's
+	// own mode without the replacement inheriting it.
+	prior     []byte
+	priorPerm os.FileMode
+	had       bool
+}
+
+// beginUnitTxn snapshots the definition currently at path. A missing file is not
+// an error: it marks a first-time install, whose rollback is a removal.
+func beginUnitTxn(path string, perm os.FileMode) (*unitTxn, error) {
+	txn := &unitTxn{path: path, perm: perm, priorPerm: perm}
+	body, err := os.ReadFile(path)
+	switch {
+	case err == nil:
+		txn.prior, txn.had = body, true
+		if info, statErr := os.Stat(path); statErr == nil {
+			txn.priorPerm = info.Mode().Perm()
+		}
+		return txn, nil
+	case errors.Is(err, os.ErrNotExist):
+		return txn, nil
+	default:
+		return nil, err
+	}
+}
+
+// write atomically replaces the definition with content.
+func (t *unitTxn) write(content string) error {
+	return t.writeBytes([]byte(content), t.perm)
+}
+
+func (t *unitTxn) writeBytes(content []byte, perm os.FileMode) error {
+	dir := filepath.Dir(t.path)
+	f, err := os.CreateTemp(dir, ".dir2mcp-unit-*")
+	if err != nil {
+		return err
+	}
+	tmp := f.Name()
+	defer func() { _ = os.Remove(tmp) }()
+	if _, err := f.Write(content); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmp, perm); err != nil {
+		return err
+	}
+	return os.Rename(tmp, t.path)
+}
+
+// rollback restores the definition to its pre-write state.
+func (t *unitTxn) rollback() error {
+	if !t.had {
+		if err := os.Remove(t.path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		return nil
+	}
+	return t.writeBytes(t.prior, t.priorPerm)
+}
+
+// describeRestored states what the definition on disk is after a rollback, so
+// the operator does not have to guess.
+func (t *unitTxn) describeRestored() string {
+	if t.had {
+		return fmt.Sprintf("the previous service definition at %s was restored", t.path)
+	}
+	return fmt.Sprintf("no service definition was left at %s", t.path)
+}
+
+// wrapInstallRollback annotates a failed install with the state the machine was
+// left in: either a clean undo, or an explicit list of what could not be undone.
+// A partially rolled back install is the one case an operator must never have to
+// infer, so the problems are named rather than summarized.
+func wrapInstallRollback(cause error, txn *unitTxn, problems []string) error {
+	if len(problems) == 0 {
+		return fmt.Errorf("%w (rolled back: %s)", cause, txn.describeRestored())
+	}
+	return fmt.Errorf("%w; ROLLBACK INCOMPLETE: %s", cause, strings.Join(problems, "; "))
 }
 
 // renderLaunchdPlist builds a macOS LaunchAgent property list for spec.

--- a/internal/cli/service_darwin.go
+++ b/internal/cli/service_darwin.go
@@ -58,8 +58,21 @@ func (m *launchdManager) serviceTarget(label string) string {
 	return fmt.Sprintf("gui/%d/%s", m.uid, label)
 }
 
-// install writes the LaunchAgent plist and bootstraps it into the user's
-// GUI domain, kicking off an immediate (re)start via kickstart -k.
+// install writes the LaunchAgent plist and bootstraps it into the user's GUI
+// domain, kicking off an immediate (re)start via kickstart -k.
+//
+// It is transactional as far as launchd permits (#724). The prior plist and
+// whether the prior service was loaded are captured first; the replacement is
+// written atomically; and any supervisor step that fails rolls the machine back
+// to that captured state — the previous definition on disk, and, when we had
+// unloaded it, the previous service booted back in. A first-time install whose
+// supervisor step fails leaves no plist behind at all, so it cannot silently
+// activate at the next login.
+//
+// What remains non-atomic: launchd itself has no transaction, so between the
+// bootout and the successful re-bootstrap of the previous service there is a
+// window in which the old daemon is down. Rollback closes that window rather
+// than preventing it, and reports explicitly when it could not.
 func (m *launchdManager) install(spec serviceSpec) (string, error) {
 	plistPath := m.plistPath(spec.Label)
 	// launchd must be able to read this; it is a service definition, not
@@ -67,30 +80,85 @@ func (m *launchdManager) install(spec serviceSpec) (string, error) {
 	if err := os.MkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
 		return "", fmt.Errorf("create LaunchAgents dir: %w", err)
 	}
-	if err := os.WriteFile(plistPath, []byte(renderLaunchdPlist(spec)), 0o644); err != nil {
-		return "", fmt.Errorf("write plist %s: %w", plistPath, err)
+	txn, err := beginUnitTxn(plistPath, 0o644)
+	if err != nil {
+		return "", fmt.Errorf("read existing plist %s: %w", plistPath, err)
 	}
-	// Reload idempotently: bootout an existing copy (ignore the error
-	// when nothing is loaded yet), then bootstrap the fresh plist.
-	_, _ = m.runCmd("launchctl", "bootout", m.domainTarget(), plistPath)
+	priorLoaded := txn.had && m.serviceLoaded(spec.Label)
+	if err := txn.write(renderLaunchdPlist(spec)); err != nil {
+		return plistPath, fmt.Errorf("write plist %s: %w", plistPath, err)
+	}
+	// Reload idempotently: bootout an existing copy — but only a positively
+	// identified "nothing loaded" result is benign (#723).
+	if out, err := m.runCmd("launchctl", "bootout", m.domainTarget(), plistPath); err != nil && !launchctlBootoutReportsAbsent(out) {
+		// Nothing was unloaded, so the previous service is still live on its
+		// previous in-memory definition: restoring the file is a complete undo.
+		return plistPath, m.rollbackInstall(txn, spec.Label, false, false,
+			fmt.Errorf("launchctl bootout: %w: %s", err, strings.TrimSpace(out)))
+	}
 	if out, err := m.runCmd("launchctl", "bootstrap", m.domainTarget(), plistPath); err != nil {
-		return plistPath, fmt.Errorf("launchctl bootstrap: %w: %s", err, strings.TrimSpace(out))
+		return plistPath, m.rollbackInstall(txn, spec.Label, true, priorLoaded,
+			fmt.Errorf("launchctl bootstrap: %w: %s", err, strings.TrimSpace(out)))
 	}
 	// RunAtLoad starts it on bootstrap; kickstart -k forces a clean
 	// (re)start so reinstalls pick up the new plist immediately.
 	if out, err := m.runCmd("launchctl", "kickstart", "-k", m.serviceTarget(spec.Label)); err != nil {
-		return plistPath, fmt.Errorf("launchctl kickstart: %w: %s", err, strings.TrimSpace(out))
+		return plistPath, m.rollbackInstall(txn, spec.Label, true, priorLoaded,
+			fmt.Errorf("launchctl kickstart: %w: %s", err, strings.TrimSpace(out)))
 	}
 	return plistPath, nil
 }
 
-// uninstall bootouts the service from the user's GUI domain and removes
-// the plist file. Returns removed=false when the service was not installed.
+// serviceLoaded reports whether label is currently registered in the user's GUI
+// domain. A launchctl failure counts as "not loaded": rollback then leaves the
+// service down instead of bootstrapping a definition launchd may already hold.
+func (m *launchdManager) serviceLoaded(label string) bool {
+	_, err := m.runCmd("launchctl", "print", m.serviceTarget(label))
+	return err == nil
+}
+
+// rollbackInstall undoes a partially applied install and returns cause annotated
+// with the resulting state.
+//
+// unloadNew bootouts a replacement that may already be registered; reloadPrior
+// bootstraps the restored definition because the service it replaced was loaded
+// before the install started.
+func (m *launchdManager) rollbackInstall(txn *unitTxn, label string, unloadNew, reloadPrior bool, cause error) error {
+	var problems []string
+	if unloadNew {
+		if out, err := m.runCmd("launchctl", "bootout", m.domainTarget(), txn.path); err != nil && !launchctlBootoutReportsAbsent(out) {
+			problems = append(problems, fmt.Sprintf("could not boot out the replacement service %s: %v: %s",
+				label, err, strings.TrimSpace(out)))
+		}
+	}
+	if err := txn.rollback(); err != nil {
+		problems = append(problems, fmt.Sprintf("could not restore %s: %v", txn.path, err))
+		return wrapInstallRollback(cause, txn, problems)
+	}
+	if reloadPrior {
+		if out, err := m.runCmd("launchctl", "bootstrap", m.domainTarget(), txn.path); err != nil {
+			problems = append(problems, fmt.Sprintf("the previous service %s is no longer loaded: %v: %s",
+				label, err, strings.TrimSpace(out)))
+		}
+	}
+	return wrapInstallRollback(cause, txn, problems)
+}
+
+// uninstall bootouts the service from the user's GUI domain and removes the
+// plist file. Returns removed=false when the service was not installed.
+//
+// Only a positively identified "already unloaded" bootout result is treated as
+// success (#723). Any other launchctl failure keeps the plist on disk and is
+// returned: deleting the definition of a daemon that is still running would
+// orphan it and destroy the file needed to retry.
 func (m *launchdManager) uninstall(label string) (string, bool, error) {
 	plistPath := m.plistPath(label)
-	// Unload first (ignore error: it may already be stopped/absent),
-	// then remove the plist so it won't reload at next login.
-	_, _ = m.runCmd("launchctl", "bootout", m.domainTarget(), plistPath)
+	// Unload first, then remove the plist so it won't reload at next login.
+	if out, err := m.runCmd("launchctl", "bootout", m.domainTarget(), plistPath); err != nil && !launchctlBootoutReportsAbsent(out) {
+		return plistPath, false, fmt.Errorf(
+			"launchctl bootout %s: %w: %s (the service may still be running; %s was kept so you can retry)",
+			m.serviceTarget(label), err, strings.TrimSpace(out), plistPath)
+	}
 	if _, err := os.Stat(plistPath); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return plistPath, false, nil
@@ -101,15 +169,6 @@ func (m *launchdManager) uninstall(label string) (string, bool, error) {
 		return plistPath, false, fmt.Errorf("remove plist %s: %w", plistPath, err)
 	}
 	return plistPath, true, nil
-}
-
-// launchdNotFoundPhrases are substrings launchctl prints when a service
-// is not registered in the domain. Only these known-absent outputs are
-// treated as "not installed / not loaded"; any other error is returned
-// to the caller so genuine command failures don't masquerade as absent.
-var launchdNotFoundPhrases = []string{
-	"could not find service",
-	"not found in domain",
 }
 
 // status queries the launchd GUI domain for label and returns whether the
@@ -129,16 +188,13 @@ func (m *launchdManager) status(label string) (serviceState, error) {
 	if err != nil {
 		// Distinguish "service not registered" (normal absent state) from
 		// real command failures (permission denied, domain error, etc.).
-		msg := strings.ToLower(strings.TrimSpace(out))
-		for _, phrase := range launchdNotFoundPhrases {
-			if strings.Contains(msg, phrase) {
-				if state.Installed {
-					state.Detail = "installed, not loaded"
-				} else {
-					state.Detail = "not installed"
-				}
-				return state, nil
+		if launchctlPrintReportsAbsent(out) {
+			if state.Installed {
+				state.Detail = "installed, not loaded"
+			} else {
+				state.Detail = "not installed"
 			}
+			return state, nil
 		}
 		return state, fmt.Errorf("launchctl print %s: %w: %s", m.serviceTarget(label), err, strings.TrimSpace(out))
 	}

--- a/internal/cli/service_darwin_test.go
+++ b/internal/cli/service_darwin_test.go
@@ -10,28 +10,31 @@ import (
 	"testing"
 )
 
-type recordedCmd struct {
-	name string
-	args []string
+// newFakeLaunchd builds a launchd manager whose launchctl invocations are
+// scripted per subcommand (see scriptedRunner). A subcommand with no scripted
+// result succeeds silently.
+func newFakeLaunchd(t *testing.T, script map[string][]cmdResult) (*launchdManager, *scriptedRunner) {
+	t.Helper()
+	runner := newScriptedRunner(script)
+	return &launchdManager{uid: 501, home: t.TempDir(), runCmd: runner.run}, runner
 }
 
-func newFakeLaunchd(t *testing.T, output string, runErr error) (*launchdManager, *[]recordedCmd) {
+// seedPlist writes a placeholder definition at the manager's plist path for
+// label and returns the path.
+func seedPlist(t *testing.T, mgr *launchdManager, label, body string) string {
 	t.Helper()
-	home := t.TempDir()
-	calls := &[]recordedCmd{}
-	mgr := &launchdManager{
-		uid:  501,
-		home: home,
-		runCmd: func(name string, args ...string) (string, error) {
-			*calls = append(*calls, recordedCmd{name: name, args: args})
-			return output, runErr
-		},
+	path := mgr.plistPath(label)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
 	}
-	return mgr, calls
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("seed plist: %v", err)
+	}
+	return path
 }
 
 func TestLaunchdManager_InstallWritesPlistAndBootstraps(t *testing.T) {
-	mgr, calls := newFakeLaunchd(t, "", nil)
+	mgr, runner := newFakeLaunchd(t, nil)
 	spec := serviceSpec{
 		Label:      "com.dirstral.dir2mcp-demo-abc123",
 		BinaryPath: "/usr/local/bin/dir2mcp",
@@ -58,11 +61,11 @@ func TestLaunchdManager_InstallWritesPlistAndBootstraps(t *testing.T) {
 	}
 
 	wantSeq := []string{"bootout", "bootstrap", "kickstart"}
-	if len(*calls) != len(wantSeq) {
-		t.Fatalf("got %d launchctl calls, want %d: %+v", len(*calls), len(wantSeq), *calls)
+	if len(runner.calls) != len(wantSeq) {
+		t.Fatalf("got %d launchctl calls, want %d: %v", len(runner.calls), len(wantSeq), runner.lines())
 	}
 	for i, want := range wantSeq {
-		c := (*calls)[i]
+		c := runner.calls[i]
 		if c.name != "launchctl" || len(c.args) == 0 || c.args[0] != want {
 			t.Errorf("call %d = %+v, want launchctl %s ...", i, c, want)
 		}
@@ -70,9 +73,9 @@ func TestLaunchdManager_InstallWritesPlistAndBootstraps(t *testing.T) {
 }
 
 func TestLaunchdManager_InstallSurfacesBootstrapFailure(t *testing.T) {
-	mgr, _ := newFakeLaunchd(t, "Bootstrap failed: 5: Input/output error", fmt.Errorf("exit status 5"))
-	// bootout is best-effort (error ignored), but bootstrap failure must
-	// surface. The fake returns an error for every call, so bootstrap fails.
+	mgr, _ := newFakeLaunchd(t, map[string][]cmdResult{
+		"bootstrap": {{out: "Bootstrap failed: 5: Input/output error", err: fmt.Errorf("exit status 5")}},
+	})
 	_, err := mgr.install(serviceSpec{Label: "com.dirstral.x", BinaryPath: "/bin/dir2mcp", WorkingDir: "/x"})
 	if err == nil {
 		t.Fatal("expected bootstrap failure to surface")
@@ -83,15 +86,9 @@ func TestLaunchdManager_InstallSurfacesBootstrapFailure(t *testing.T) {
 }
 
 func TestLaunchdManager_UninstallRemovesPlist(t *testing.T) {
-	mgr, calls := newFakeLaunchd(t, "", nil)
+	mgr, runner := newFakeLaunchd(t, nil)
 	label := "com.dirstral.dir2mcp-demo-abc123"
-	plistPath := mgr.plistPath(label)
-	if err := os.MkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	if err := os.WriteFile(plistPath, []byte("<plist/>"), 0o644); err != nil {
-		t.Fatalf("seed plist: %v", err)
-	}
+	plistPath := seedPlist(t, mgr, label, "<plist/>")
 
 	_, removed, err := mgr.uninstall(label)
 	if err != nil {
@@ -103,13 +100,13 @@ func TestLaunchdManager_UninstallRemovesPlist(t *testing.T) {
 	if _, statErr := os.Stat(plistPath); !os.IsNotExist(statErr) {
 		t.Errorf("plist still present after uninstall: %v", statErr)
 	}
-	if len(*calls) != 1 || (*calls)[0].args[0] != "bootout" {
-		t.Errorf("expected a single bootout call, got %+v", *calls)
+	if len(runner.calls) != 1 || runner.calls[0].args[0] != "bootout" {
+		t.Errorf("expected a single bootout call, got %v", runner.lines())
 	}
 }
 
 func TestLaunchdManager_UninstallAbsentIsNoop(t *testing.T) {
-	mgr, _ := newFakeLaunchd(t, "", nil)
+	mgr, _ := newFakeLaunchd(t, nil)
 	_, removed, err := mgr.uninstall("com.dirstral.not-installed")
 	if err != nil {
 		t.Fatalf("uninstall absent: %v", err)
@@ -120,15 +117,11 @@ func TestLaunchdManager_UninstallAbsentIsNoop(t *testing.T) {
 }
 
 func TestLaunchdManager_StatusReportsRunning(t *testing.T) {
-	mgr, _ := newFakeLaunchd(t, "service = {\n\tstate = running\n}\n", nil)
+	mgr, _ := newFakeLaunchd(t, map[string][]cmdResult{
+		"print": {ok("service = {\n\tstate = running\n}\n")},
+	})
 	label := "com.dirstral.dir2mcp-demo-abc123"
-	plistPath := mgr.plistPath(label)
-	if err := os.MkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	if err := os.WriteFile(plistPath, []byte("<plist/>"), 0o644); err != nil {
-		t.Fatalf("seed plist: %v", err)
-	}
+	seedPlist(t, mgr, label, "<plist/>")
 
 	state, err := mgr.status(label)
 	if err != nil {
@@ -144,7 +137,9 @@ func TestLaunchdManager_StatusReportsRunning(t *testing.T) {
 // which is the known-absent phrase the status method uses to distinguish
 // a clean absent state from a real command failure.
 func TestLaunchdManager_StatusReportsNotInstalled(t *testing.T) {
-	mgr, _ := newFakeLaunchd(t, "Could not find service \"com.dirstral.absent\" in domain for port", fmt.Errorf("exit status 113"))
+	mgr, _ := newFakeLaunchd(t, map[string][]cmdResult{
+		"print": {{out: "Could not find service \"com.dirstral.absent\" in domain for port", err: fmt.Errorf("exit status 113")}},
+	})
 	state, err := mgr.status("com.dirstral.absent")
 	if err != nil {
 		t.Fatalf("status should not error for a known-absent service: %v", err)
@@ -158,7 +153,7 @@ func TestLaunchdManager_StatusReportsNotInstalled(t *testing.T) {
 // failure whose output does not match a known-absent phrase is surfaced
 // as an error rather than silently reported as "not installed".
 func TestLaunchdManager_StatusErrorsOnCommandFailure(t *testing.T) {
-	mgr, _ := newFakeLaunchd(t, "permission denied", fmt.Errorf("exit status 1"))
+	mgr, _ := newFakeLaunchd(t, map[string][]cmdResult{"print": {fails("permission denied")}})
 	_, err := mgr.status("com.dirstral.some-label")
 	if err == nil {
 		t.Fatal("expected status to surface non-absent launchctl failure as error")
@@ -172,7 +167,7 @@ func TestLaunchdManager_StatusErrorsOnCommandFailure(t *testing.T) {
 // defense-in-depth in plistPath: even if a label containing separators
 // somehow reaches the method, the returned path stays inside LaunchAgents.
 func TestLaunchdManager_PlistPathClampsTraversal(t *testing.T) {
-	mgr, _ := newFakeLaunchd(t, "", nil)
+	mgr, _ := newFakeLaunchd(t, nil)
 	crafted := "../../etc/evil"
 	got := mgr.plistPath(crafted)
 	base := filepath.Base(got)
@@ -182,5 +177,212 @@ func TestLaunchdManager_PlistPathClampsTraversal(t *testing.T) {
 	}
 	if base != "evil.plist" {
 		t.Errorf("expected clamped basename evil.plist, got %q", base)
+	}
+}
+
+// --- issue #723: uninstall must not orphan a running daemon ---
+
+const priorPlistBody = "<plist><!-- previous definition --></plist>"
+
+// TestLaunchdManager_UninstallKeepsPlistOnBootoutFailure_723 pins the fix: a
+// bootout failure that is NOT a positively identified "already unloaded" result
+// aborts the uninstall with the plist intact. Before the fix every bootout error
+// was discarded, so a permission failure deleted the definition of a daemon that
+// kept running, with nothing left to retry from.
+func TestLaunchdManager_UninstallKeepsPlistOnBootoutFailure_723(t *testing.T) {
+	mgr, runner := newFakeLaunchd(t, map[string][]cmdResult{
+		"bootout": {fails("Boot-out failed: 1: Operation not permitted")},
+	})
+	label := "com.dirstral.dir2mcp-demo-abc123"
+	plistPath := seedPlist(t, mgr, label, priorPlistBody)
+
+	_, removed, err := mgr.uninstall(label)
+	if err == nil {
+		t.Fatal("expected a bootout failure to abort the uninstall")
+	}
+	if removed {
+		t.Error("removed must be false when the service could not be unloaded")
+	}
+	if _, statErr := os.Stat(plistPath); statErr != nil {
+		t.Errorf("the plist must be kept so the operator can retry: %v", statErr)
+	}
+	for _, want := range []string{"bootout", "still be running", plistPath} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error should mention %q: %v", want, err)
+		}
+	}
+	if runner.count("bootout") != 1 {
+		t.Errorf("expected exactly one bootout attempt: %v", runner.lines())
+	}
+}
+
+// TestLaunchdManager_UninstallNotLoadedStaysIdempotent_723 pins that the
+// known-absent results stay benign: uninstalling a service that is not booted in
+// still removes the plist and reports success.
+func TestLaunchdManager_UninstallNotLoadedStaysIdempotent_723(t *testing.T) {
+	for _, out := range []string{
+		"Boot-out failed: 3: No such process",
+		"Boot-out failed: 2: No such file or directory",
+		`Could not find service "com.dirstral.dir2mcp-demo-abc123" in domain for port`,
+	} {
+		mgr, _ := newFakeLaunchd(t, map[string][]cmdResult{"bootout": {fails(out)}})
+		label := "com.dirstral.dir2mcp-demo-abc123"
+		plistPath := seedPlist(t, mgr, label, priorPlistBody)
+
+		_, removed, err := mgr.uninstall(label)
+		if err != nil {
+			t.Fatalf("out=%q: uninstall should succeed for a not-loaded service: %v", out, err)
+		}
+		if !removed {
+			t.Errorf("out=%q: expected removed=true", out)
+		}
+		if _, statErr := os.Stat(plistPath); !os.IsNotExist(statErr) {
+			t.Errorf("out=%q: plist should have been removed: %v", out, statErr)
+		}
+	}
+}
+
+// --- issue #724: a failed install must not strand or stop the previous service ---
+
+// TestLaunchdManager_InstallRollsBackPriorServiceOnBootstrapFailure_724 is the
+// core reinstall case: bootout succeeds (the previous service is stopped) and
+// bootstrap then fails. Before the fix the operator was left with the previous
+// daemon STOPPED and its plist overwritten by the replacement.
+func TestLaunchdManager_InstallRollsBackPriorServiceOnBootstrapFailure_724(t *testing.T) {
+	mgr, runner := newFakeLaunchd(t, map[string][]cmdResult{
+		// print succeeds => the previous service was loaded.
+		"print": {ok("service = {\n\tstate = running\n}\n")},
+		// The install's bootstrap fails; the rollback's re-bootstrap succeeds.
+		"bootstrap": {fails("Bootstrap failed: 5: Input/output error"), ok("")},
+	})
+	label := "com.dirstral.dir2mcp-demo-abc123"
+	plistPath := seedPlist(t, mgr, label, priorPlistBody)
+
+	_, err := mgr.install(serviceSpec{Label: label, BinaryPath: "/bin/dir2mcp", WorkingDir: "/x", LogPath: "/x/l.log"})
+	if err == nil {
+		t.Fatal("expected the bootstrap failure to surface")
+	}
+	body, readErr := os.ReadFile(plistPath)
+	if readErr != nil {
+		t.Fatalf("read plist: %v", readErr)
+	}
+	if string(body) != priorPlistBody {
+		t.Errorf("the previous plist was not restored:\n%s", body)
+	}
+	if runner.count("bootstrap") != 2 {
+		t.Errorf("the previously loaded service should have been booted back in: %v", runner.lines())
+	}
+	if !strings.Contains(err.Error(), "rolled back") {
+		t.Errorf("error should state the rollback: %v", err)
+	}
+	if strings.Contains(err.Error(), "ROLLBACK INCOMPLETE") {
+		t.Errorf("rollback should have been complete: %v", err)
+	}
+}
+
+// TestLaunchdManager_InstallRollsBackOnKickstartFailure_724 covers the last
+// step: kickstart failed, so the replacement may already be loaded. It must be
+// booted out and the previous definition put back.
+func TestLaunchdManager_InstallRollsBackOnKickstartFailure_724(t *testing.T) {
+	mgr, runner := newFakeLaunchd(t, map[string][]cmdResult{
+		"print":     {ok("service = {\n\tstate = running\n}\n")},
+		"kickstart": {fails("Could not kickstart service")},
+	})
+	label := "com.dirstral.dir2mcp-demo-abc123"
+	plistPath := seedPlist(t, mgr, label, priorPlistBody)
+
+	_, err := mgr.install(serviceSpec{Label: label, BinaryPath: "/bin/dir2mcp", WorkingDir: "/x", LogPath: "/x/l.log"})
+	if err == nil {
+		t.Fatal("expected the kickstart failure to surface")
+	}
+	body, _ := os.ReadFile(plistPath)
+	if string(body) != priorPlistBody {
+		t.Errorf("the previous plist was not restored:\n%s", body)
+	}
+	// bootout: once for the reload, once to unload the failed replacement.
+	if runner.count("bootout") != 2 {
+		t.Errorf("the replacement should have been booted out: %v", runner.lines())
+	}
+	if runner.count("bootstrap") != 2 {
+		t.Errorf("the previous service should have been booted back in: %v", runner.lines())
+	}
+}
+
+// TestLaunchdManager_InstallKeepsPriorServiceOnBootoutFailure_724 covers the
+// case where nothing was unloaded: the previous service is still live on its
+// in-memory definition, so the rollback restores the file and must NOT bootstrap
+// anything on top of it.
+func TestLaunchdManager_InstallKeepsPriorServiceOnBootoutFailure_724(t *testing.T) {
+	mgr, runner := newFakeLaunchd(t, map[string][]cmdResult{
+		"print":   {ok("service = {\n\tstate = running\n}\n")},
+		"bootout": {fails("Boot-out failed: 1: Operation not permitted")},
+	})
+	label := "com.dirstral.dir2mcp-demo-abc123"
+	plistPath := seedPlist(t, mgr, label, priorPlistBody)
+
+	_, err := mgr.install(serviceSpec{Label: label, BinaryPath: "/bin/dir2mcp", WorkingDir: "/x", LogPath: "/x/l.log"})
+	if err == nil {
+		t.Fatal("expected the bootout failure to surface")
+	}
+	body, _ := os.ReadFile(plistPath)
+	if string(body) != priorPlistBody {
+		t.Errorf("the previous plist was not restored:\n%s", body)
+	}
+	if runner.count("bootstrap") != 0 {
+		t.Errorf("nothing should have been bootstrapped over a still-loaded service: %v", runner.lines())
+	}
+	if runner.count("kickstart") != 0 {
+		t.Errorf("install must stop at the failed bootout: %v", runner.lines())
+	}
+}
+
+// TestLaunchdManager_InstallCleansUpFailedFirstInstall_724 pins the first-time
+// case: a failed install must leave NO plist behind, so a half-installed service
+// cannot activate at the next login.
+func TestLaunchdManager_InstallCleansUpFailedFirstInstall_724(t *testing.T) {
+	mgr, runner := newFakeLaunchd(t, map[string][]cmdResult{
+		"bootstrap": {fails("Bootstrap failed: 5: Input/output error")},
+	})
+	label := "com.dirstral.dir2mcp-demo-abc123"
+	plistPath, err := mgr.install(serviceSpec{Label: label, BinaryPath: "/bin/dir2mcp", WorkingDir: "/x", LogPath: "/x/l.log"})
+	if err == nil {
+		t.Fatal("expected the bootstrap failure to surface")
+	}
+	if _, statErr := os.Stat(plistPath); !os.IsNotExist(statErr) {
+		t.Errorf("a failed first install must not leave a plist behind: %v", statErr)
+	}
+	if !strings.Contains(err.Error(), "no service definition was left") {
+		t.Errorf("error should state that nothing was left installed: %v", err)
+	}
+	// No previous service existed, so nothing may be bootstrapped back.
+	if runner.count("bootstrap") != 1 {
+		t.Errorf("rollback must not bootstrap a service that never existed: %v", runner.lines())
+	}
+	// A never-loaded prior service is not probed with print.
+	if runner.count("print") != 0 {
+		t.Errorf("a first install should not probe the previous service: %v", runner.lines())
+	}
+}
+
+// TestLaunchdManager_InstallReportsIncompleteRollback_724 pins the honesty
+// requirement: when the rollback itself fails, the operator is told exactly what
+// could not be restored instead of getting a bare install error.
+func TestLaunchdManager_InstallReportsIncompleteRollback_724(t *testing.T) {
+	mgr, _ := newFakeLaunchd(t, map[string][]cmdResult{
+		"print":     {ok("service = {\n\tstate = running\n}\n")},
+		"bootstrap": {fails("Bootstrap failed: 5: Input/output error"), fails("Bootstrap failed: 1: Operation not permitted")},
+	})
+	label := "com.dirstral.dir2mcp-demo-abc123"
+	seedPlist(t, mgr, label, priorPlistBody)
+
+	_, err := mgr.install(serviceSpec{Label: label, BinaryPath: "/bin/dir2mcp", WorkingDir: "/x", LogPath: "/x/l.log"})
+	if err == nil {
+		t.Fatal("expected the install failure to surface")
+	}
+	if !strings.Contains(err.Error(), "ROLLBACK INCOMPLETE") {
+		t.Errorf("an unrecoverable rollback must be explicit: %v", err)
+	}
+	if !strings.Contains(err.Error(), "no longer loaded") {
+		t.Errorf("error should say the previous service is down: %v", err)
 	}
 }

--- a/internal/cli/service_linux.go
+++ b/internal/cli/service_linux.go
@@ -44,36 +44,158 @@ func (m *systemdManager) unitPath(label string) string {
 	return filepath.Join(m.home, ".config", "systemd", "user", filepath.Base(label)+".service")
 }
 
+// priorUnitState is the supervisor state a failed install has to put back: the
+// unit's enablement and whether it was running.
+type priorUnitState struct {
+	enabled bool
+	active  bool
+}
+
 // install writes the user unit, reloads the daemon, and enables+starts it.
+//
+// It is transactional as far as systemd permits (#724):
+//
+//  1. the prior supervisor state is captured BEFORE anything is mutated, so an
+//     unreachable user manager fails with the machine completely untouched;
+//  2. the replacement unit is written atomically;
+//  3. any failing systemctl step restores the prior unit file, reloads, and
+//     re-establishes the prior enablement/running state — or, for a first-time
+//     install, disables the partial registration and removes the unit so it
+//     cannot activate at the next login;
+//  4. anything the rollback could not undo is named in the returned error.
+//
+// What remains non-atomic: `enable --now` is two operations to systemd (link +
+// start) with no combined undo, so a failure can leave the replacement briefly
+// enabled or started. Rollback reverses it explicitly with `disable --now`; it
+// cannot make the window not exist.
 func (m *systemdManager) install(spec serviceSpec) (string, error) {
 	if err := rejectMultilineSpec(spec); err != nil {
 		return "", err
 	}
 	unit := m.unitPath(spec.Label)
+	base := filepath.Base(unit)
 	// systemd must be able to read this; it is a service definition, not
 	// corpus-derived content (#726).
 	if err := os.MkdirAll(filepath.Dir(unit), 0o755); err != nil {
 		return "", fmt.Errorf("create systemd user dir: %w", err)
 	}
-	if err := os.WriteFile(unit, []byte(renderSystemdUnit(spec)), 0o644); err != nil {
+	txn, err := beginUnitTxn(unit, 0o644)
+	if err != nil {
+		return "", fmt.Errorf("read existing unit %s: %w", unit, err)
+	}
+	prior, err := m.captureUnitState(base)
+	if err != nil {
+		// Nothing has been written yet: fail with the machine untouched rather
+		// than installing a unit we cannot enable or roll back.
+		return unit, err
+	}
+	if err := txn.write(renderSystemdUnit(spec)); err != nil {
 		return unit, fmt.Errorf("write unit %s: %w", unit, err)
 	}
 	if out, err := m.runCmd("systemctl", "--user", "daemon-reload"); err != nil {
-		return unit, fmt.Errorf("systemctl daemon-reload: %w: %s", err, strings.TrimSpace(out))
+		return unit, m.rollbackInstall(txn, base, false, prior,
+			fmt.Errorf("systemctl daemon-reload: %w: %s", err, strings.TrimSpace(out)))
 	}
-	if out, err := m.runCmd("systemctl", "--user", "enable", "--now", filepath.Base(unit)); err != nil {
-		return unit, fmt.Errorf("systemctl enable --now: %w: %s", err, strings.TrimSpace(out))
+	if out, err := m.runCmd("systemctl", "--user", "enable", "--now", base); err != nil {
+		return unit, m.rollbackInstall(txn, base, true, prior,
+			fmt.Errorf("systemctl enable --now: %w: %s", err, strings.TrimSpace(out)))
 	}
 	return unit, nil
 }
 
+// captureUnitState records whether the unit is currently enabled and running.
+// A systemctl invocation that cannot answer is an error, not an assumption.
+func (m *systemdManager) captureUnitState(base string) (priorUnitState, error) {
+	active, err := m.queryState(systemctlIsActive, base)
+	if err != nil {
+		return priorUnitState{}, err
+	}
+	enabled, err := m.queryState(systemctlIsEnabled, base)
+	if err != nil {
+		return priorUnitState{}, err
+	}
+	return priorUnitState{enabled: systemctlEnabledMeansInstalled(enabled), active: active == "active"}, nil
+}
+
+// queryState runs one `systemctl --user is-*` probe and classifies its result.
+func (m *systemdManager) queryState(q systemctlQuery, base string) (string, error) {
+	out, err := m.runCmd("systemctl", "--user", q.name, base)
+	return q.classify(out, err)
+}
+
+// systemctlEnabledMeansInstalled reports whether an is-enabled verdict implies
+// the unit is registered with systemd (and so "installed" for status purposes).
+func systemctlEnabledMeansInstalled(verdict string) bool {
+	switch verdict {
+	case "enabled", "enabled-runtime", "static", "linked", "linked-runtime":
+		return true
+	default:
+		return false
+	}
+}
+
+// rollbackInstall undoes a partially applied install and returns cause annotated
+// with the resulting state. disableNew reverses an `enable --now` that may have
+// partially taken effect.
+func (m *systemdManager) rollbackInstall(txn *unitTxn, base string, disableNew bool, prior priorUnitState, cause error) error {
+	var problems []string
+	if disableNew {
+		if out, err := m.runCmd("systemctl", "--user", "disable", "--now", base); err != nil && !systemctlReportsAbsent(out) {
+			problems = append(problems, fmt.Sprintf("could not disable the partially installed unit %s: %v: %s",
+				base, err, strings.TrimSpace(out)))
+		}
+	}
+	if err := txn.rollback(); err != nil {
+		problems = append(problems, fmt.Sprintf("could not restore %s: %v", txn.path, err))
+		return wrapInstallRollback(cause, txn, problems)
+	}
+	if out, err := m.runCmd("systemctl", "--user", "daemon-reload"); err != nil {
+		problems = append(problems, fmt.Sprintf("could not reload systemd after restoring %s: %v: %s",
+			txn.path, err, strings.TrimSpace(out)))
+	}
+	if txn.had {
+		problems = append(problems, m.restorePriorUnit(base, prior)...)
+	}
+	return wrapInstallRollback(cause, txn, problems)
+}
+
+// restorePriorUnit re-establishes the enablement/running state the unit had
+// before the install, returning a description of anything it could not restore.
+func (m *systemdManager) restorePriorUnit(base string, prior priorUnitState) []string {
+	var problems []string
+	switch {
+	case prior.enabled && prior.active:
+		if out, err := m.runCmd("systemctl", "--user", "enable", "--now", base); err != nil {
+			problems = append(problems, fmt.Sprintf("could not re-enable and restart the previous unit %s: %v: %s", base, err, strings.TrimSpace(out)))
+		}
+	case prior.enabled:
+		if out, err := m.runCmd("systemctl", "--user", "enable", base); err != nil {
+			problems = append(problems, fmt.Sprintf("could not re-enable the previous unit %s: %v: %s", base, err, strings.TrimSpace(out)))
+		}
+	case prior.active:
+		if out, err := m.runCmd("systemctl", "--user", "start", base); err != nil {
+			problems = append(problems, fmt.Sprintf("could not restart the previous unit %s: %v: %s", base, err, strings.TrimSpace(out)))
+		}
+	}
+	return problems
+}
+
 // uninstall disables+stops the unit, removes the file, and reloads the
 // daemon. Idempotent: removed=false when the unit file was already absent.
+//
+// Only a positively identified "unit absent / not loaded" disable result counts
+// as idempotent success (#723). A dead user bus, a permission denial, or a
+// missing systemctl keeps the unit file on disk and returns an error: removing
+// the definition of a unit that may still be running would orphan the daemon and
+// leave dangling enablement symlinks with nothing left to retry from.
 func (m *systemdManager) uninstall(label string) (string, bool, error) {
 	unit := m.unitPath(label)
-	// Best-effort disable+stop (ignore the error when the unit is not loaded),
-	// then remove the file so it won't re-enable at next login.
-	_, _ = m.runCmd("systemctl", "--user", "disable", "--now", filepath.Base(unit))
+	base := filepath.Base(unit)
+	if out, err := m.runCmd("systemctl", "--user", "disable", "--now", base); err != nil && !systemctlReportsAbsent(out) {
+		return unit, false, fmt.Errorf(
+			"systemctl --user disable --now %s: %w: %s (the unit may still be running; %s was kept so you can retry)",
+			base, err, strings.TrimSpace(out), unit)
+	}
 	_, err := os.Stat(unit)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -91,10 +213,17 @@ func (m *systemdManager) uninstall(label string) (string, bool, error) {
 }
 
 // status reports whether the unit is installed (file on disk / enabled) and
-// running (active). is-active/is-enabled exit non-zero for the normal
-// inactive/disabled states, so their errors are best-effort ignored and the
-// verdict is read from stdout ("active"/"enabled"/...); the on-disk unit file
-// is the authoritative installed signal.
+// running (active).
+//
+// is-active/is-enabled exit non-zero for the normal inactive/disabled/not-found
+// states, so the exit status alone cannot distinguish them from a real failure.
+// Previously BOTH errors were discarded, which laundered an unreachable user bus
+// or a missing systemctl into a plausible-looking "installed, not running"
+// snapshot derived from the on-disk file (#725). The verdict word is now the
+// discriminator: documented states are normal, and anything else is returned as
+// an error so `service status` reports "systemctl could not answer" instead of
+// inventing a state. The on-disk unit file remains the authoritative installed
+// signal for the states systemd does answer.
 func (m *systemdManager) status(label string) (serviceState, error) {
 	unit := m.unitPath(label)
 	state := serviceState{UnitPath: unit}
@@ -105,12 +234,17 @@ func (m *systemdManager) status(label string) (serviceState, error) {
 	}
 
 	base := filepath.Base(unit)
-	activeOut, _ := m.runCmd("systemctl", "--user", "is-active", base)
-	state.Running = strings.TrimSpace(activeOut) == "active"
+	active, err := m.queryState(systemctlIsActive, base)
+	if err != nil {
+		return state, err
+	}
+	state.Running = active == "active"
 
-	enabledOut, _ := m.runCmd("systemctl", "--user", "is-enabled", base)
-	enabled := strings.TrimSpace(enabledOut)
-	if enabled == "enabled" || enabled == "static" || enabled == "linked" {
+	enabled, err := m.queryState(systemctlIsEnabled, base)
+	if err != nil {
+		return state, err
+	}
+	if systemctlEnabledMeansInstalled(enabled) {
 		state.Installed = true
 	}
 

--- a/internal/cli/service_linux_test.go
+++ b/internal/cli/service_linux_test.go
@@ -10,33 +10,38 @@ import (
 	"testing"
 )
 
-type recordedCmd struct {
-	name string
-	args []string
-}
-
-func newFakeSystemd(t *testing.T, output string, runErr error) (*systemdManager, *[]recordedCmd) {
+// newFakeSystemd builds a systemd manager whose systemctl invocations are
+// scripted per subcommand (see scriptedRunner). The is-active/is-enabled probes
+// default to the verdicts a real systemd gives for a unit it does not know, so
+// the happy path only has to script what it wants to fail.
+func newFakeSystemd(t *testing.T, script map[string][]cmdResult) (*systemdManager, *scriptedRunner) {
 	t.Helper()
-	home := t.TempDir()
-	calls := &[]recordedCmd{}
-	mgr := &systemdManager{
-		home: home,
-		runCmd: func(name string, args ...string) (string, error) {
-			*calls = append(*calls, recordedCmd{name: name, args: args})
-			return output, runErr
-		},
+	merged := map[string][]cmdResult{
+		"is-active":  {fails("inactive\n")},
+		"is-enabled": {fails("not-found\n")},
 	}
-	return mgr, calls
+	for k, v := range script {
+		merged[k] = v
+	}
+	runner := newScriptedRunner(merged)
+	return &systemdManager{home: t.TempDir(), runCmd: runner.run}, runner
 }
 
-// argLine joins a recorded command back into a single string for sequence
-// assertions.
-func argLine(c recordedCmd) string {
-	return c.name + " " + strings.Join(c.args, " ")
+// seedUnit writes a placeholder unit at the manager's unit path for label.
+func seedUnit(t *testing.T, mgr *systemdManager, label, body string) string {
+	t.Helper()
+	unit := mgr.unitPath(label)
+	if err := os.MkdirAll(filepath.Dir(unit), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(unit, []byte(body), 0o644); err != nil {
+		t.Fatalf("seed unit: %v", err)
+	}
+	return unit
 }
 
 func TestSystemdManager_InstallWritesUnitAndEnables(t *testing.T) {
-	mgr, calls := newFakeSystemd(t, "", nil)
+	mgr, runner := newFakeSystemd(t, nil)
 	spec := serviceSpec{
 		Label:      "com.dirstral.dir2mcp-demo-abc123",
 		BinaryPath: "/usr/local/bin/dir2mcp",
@@ -66,22 +71,29 @@ func TestSystemdManager_InstallWritesUnitAndEnables(t *testing.T) {
 		t.Errorf("unit missing supervision block:\n%s", body)
 	}
 
+	// The is-active/is-enabled probes capture the prior supervisor state before
+	// anything is mutated (#724), so a failed step can put it back.
 	want := []string{
+		"systemctl --user is-active com.dirstral.dir2mcp-demo-abc123.service",
+		"systemctl --user is-enabled com.dirstral.dir2mcp-demo-abc123.service",
 		"systemctl --user daemon-reload",
 		"systemctl --user enable --now com.dirstral.dir2mcp-demo-abc123.service",
 	}
-	if len(*calls) != len(want) {
-		t.Fatalf("got %d systemctl calls, want %d: %+v", len(*calls), len(want), *calls)
+	got := runner.lines()
+	if len(got) != len(want) {
+		t.Fatalf("got %d systemctl calls, want %d: %v", len(got), len(want), got)
 	}
 	for i, w := range want {
-		if got := argLine((*calls)[i]); got != w {
-			t.Errorf("call %d = %q, want %q", i, got, w)
+		if got[i] != w {
+			t.Errorf("call %d = %q, want %q", i, got[i], w)
 		}
 	}
 }
 
 func TestSystemdManager_InstallSurfacesEnableFailure(t *testing.T) {
-	mgr, _ := newFakeSystemd(t, "Failed to enable unit", fmt.Errorf("exit status 1"))
+	mgr, _ := newFakeSystemd(t, map[string][]cmdResult{
+		"enable": {fails("Failed to enable unit")},
+	})
 	_, err := mgr.install(serviceSpec{Label: "com.dirstral.x", BinaryPath: "/bin/dir2mcp", WorkingDir: "/x", LogPath: "/x/l.log"})
 	if err == nil {
 		t.Fatal("expected enable/daemon-reload failure to surface")
@@ -89,26 +101,20 @@ func TestSystemdManager_InstallSurfacesEnableFailure(t *testing.T) {
 }
 
 func TestSystemdManager_InstallRejectsNewlineValue(t *testing.T) {
-	mgr, calls := newFakeSystemd(t, "", nil)
+	mgr, runner := newFakeSystemd(t, nil)
 	_, err := mgr.install(serviceSpec{Label: "com.dirstral.x\ninjected=1", BinaryPath: "/bin/dir2mcp", WorkingDir: "/x", LogPath: "/x/l.log"})
 	if err == nil {
 		t.Fatal("expected a newline-in-value rejection")
 	}
-	if len(*calls) != 0 {
-		t.Errorf("no systemctl call should run when the spec is rejected, got %+v", *calls)
+	if len(runner.calls) != 0 {
+		t.Errorf("no systemctl call should run when the spec is rejected, got %v", runner.lines())
 	}
 }
 
 func TestSystemdManager_UninstallRemovesUnit(t *testing.T) {
-	mgr, calls := newFakeSystemd(t, "", nil)
+	mgr, runner := newFakeSystemd(t, nil)
 	label := "com.dirstral.dir2mcp-demo-abc123"
-	unit := mgr.unitPath(label)
-	if err := os.MkdirAll(filepath.Dir(unit), 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	if err := os.WriteFile(unit, []byte("[Unit]\n"), 0o644); err != nil {
-		t.Fatalf("seed unit: %v", err)
-	}
+	unit := seedUnit(t, mgr, label, "[Unit]\n")
 
 	_, removed, err := mgr.uninstall(label)
 	if err != nil {
@@ -124,18 +130,19 @@ func TestSystemdManager_UninstallRemovesUnit(t *testing.T) {
 		"systemctl --user disable --now com.dirstral.dir2mcp-demo-abc123.service",
 		"systemctl --user daemon-reload",
 	}
-	if len(*calls) != len(want) {
-		t.Fatalf("got %d calls, want %d: %+v", len(*calls), len(want), *calls)
+	got := runner.lines()
+	if len(got) != len(want) {
+		t.Fatalf("got %d calls, want %d: %v", len(got), len(want), got)
 	}
 	for i, w := range want {
-		if got := argLine((*calls)[i]); got != w {
-			t.Errorf("call %d = %q, want %q", i, got, w)
+		if got[i] != w {
+			t.Errorf("call %d = %q, want %q", i, got[i], w)
 		}
 	}
 }
 
 func TestSystemdManager_UninstallAbsentIsIdempotent(t *testing.T) {
-	mgr, calls := newFakeSystemd(t, "", nil)
+	mgr, runner := newFakeSystemd(t, nil)
 	_, removed, err := mgr.uninstall("com.dirstral.not-installed")
 	if err != nil {
 		t.Fatalf("uninstall absent: %v", err)
@@ -143,32 +150,19 @@ func TestSystemdManager_UninstallAbsentIsIdempotent(t *testing.T) {
 	if removed {
 		t.Error("expected removed=false when no unit exists")
 	}
-	// Only the best-effort disable ran; no file to remove, no reload needed.
-	if len(*calls) != 1 || argLine((*calls)[0]) != "systemctl --user disable --now com.dirstral.not-installed.service" {
-		t.Errorf("expected a single disable call, got %+v", *calls)
+	// Only the disable ran; no file to remove, no reload needed.
+	if len(runner.calls) != 1 || runner.lines()[0] != "systemctl --user disable --now com.dirstral.not-installed.service" {
+		t.Errorf("expected a single disable call, got %v", runner.lines())
 	}
 }
 
 func TestSystemdManager_StatusReportsRunning(t *testing.T) {
-	// is-active -> "active", is-enabled -> "enabled".
-	outputs := []string{"active\n", "enabled\n"}
-	var i int
-	mgr := &systemdManager{
-		home: t.TempDir(),
-		runCmd: func(_ string, _ ...string) (string, error) {
-			o := outputs[i]
-			i++
-			return o, nil
-		},
-	}
+	mgr, _ := newFakeSystemd(t, map[string][]cmdResult{
+		"is-active":  {ok("active\n")},
+		"is-enabled": {ok("enabled\n")},
+	})
 	label := "com.dirstral.dir2mcp-demo-abc123"
-	unit := mgr.unitPath(label)
-	if err := os.MkdirAll(filepath.Dir(unit), 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	if err := os.WriteFile(unit, []byte("[Unit]\n"), 0o644); err != nil {
-		t.Fatalf("seed unit: %v", err)
-	}
+	seedUnit(t, mgr, label, "[Unit]\n")
 
 	state, err := mgr.status(label)
 	if err != nil {
@@ -181,16 +175,7 @@ func TestSystemdManager_StatusReportsRunning(t *testing.T) {
 
 func TestSystemdManager_StatusReportsNotInstalled(t *testing.T) {
 	// is-active exits non-zero with "inactive"; is-enabled with "not-found".
-	outputs := []string{"inactive\n", "not-found\n"}
-	var i int
-	mgr := &systemdManager{
-		home: t.TempDir(),
-		runCmd: func(_ string, _ ...string) (string, error) {
-			o := outputs[i]
-			i++
-			return o, fmt.Errorf("exit status 1")
-		},
-	}
+	mgr, _ := newFakeSystemd(t, nil)
 	state, err := mgr.status("com.dirstral.absent")
 	if err != nil {
 		t.Fatalf("status should not error for an absent unit: %v", err)
@@ -204,7 +189,7 @@ func TestSystemdManager_StatusReportsNotInstalled(t *testing.T) {
 }
 
 func TestSystemdManager_UnitPathClampsTraversal(t *testing.T) {
-	mgr, _ := newFakeSystemd(t, "", nil)
+	mgr, _ := newFakeSystemd(t, nil)
 	got := mgr.unitPath("../../etc/evil")
 	wantDir := filepath.Join(mgr.home, ".config", "systemd", "user")
 	if filepath.Dir(got) != wantDir {
@@ -212,5 +197,279 @@ func TestSystemdManager_UnitPathClampsTraversal(t *testing.T) {
 	}
 	if filepath.Base(got) != "evil.service" {
 		t.Errorf("expected clamped basename evil.service, got %q", filepath.Base(got))
+	}
+}
+
+// --- issue #725: a systemctl that cannot answer is not a stopped service ---
+
+// TestSystemdManager_StatusFailsWhenSystemctlCannotAnswer_725 pins the fix: a
+// dead user bus, a permission denial, or a missing systemctl must surface as an
+// operational error. Before the fix both is-active and is-enabled errors were
+// discarded, so status derived "installed: true, running: false" from the
+// on-disk unit file alone — a state snapshot the tool had not actually measured.
+func TestSystemdManager_StatusFailsWhenSystemctlCannotAnswer_725(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		script map[string][]cmdResult
+	}{
+		{"dead user bus", map[string][]cmdResult{"is-active": {fails("Failed to connect to bus: No such file or directory\n")}}},
+		{"no session bus", map[string][]cmdResult{"is-active": {fails("Failed to connect to bus: No medium found\n")}}},
+		{"permission denied on is-enabled", map[string][]cmdResult{"is-enabled": {fails("Failed to get unit file state: Permission denied\n")}}},
+		{"systemctl missing", map[string][]cmdResult{"is-active": {{err: fmt.Errorf(`exec: "systemctl": executable file not found in $PATH`)}}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mgr, _ := newFakeSystemd(t, tc.script)
+			label := "com.dirstral.dir2mcp-demo-abc123"
+			seedUnit(t, mgr, label, "[Unit]\n")
+
+			state, err := mgr.status(label)
+			if err == nil {
+				t.Fatalf("expected an operational error, got state %+v", state)
+			}
+			if state.Running {
+				t.Errorf("a failed probe must never report running: %+v", state)
+			}
+		})
+	}
+}
+
+// TestSystemdManager_StatusKeepsDocumentedStatesNormal_725 pins the other side:
+// the documented inactive/failed/disabled/not-found verdicts still exit non-zero
+// and must stay ordinary state, not errors.
+func TestSystemdManager_StatusKeepsDocumentedStatesNormal_725(t *testing.T) {
+	for _, tc := range []struct {
+		active, enabled string
+		wantRunning     bool
+		wantInstalled   bool
+	}{
+		{"inactive\n", "disabled\n", false, true},
+		{"failed\n", "enabled\n", false, true},
+		{"active\n", "static\n", true, true},
+		{"activating\n", "enabled-runtime\n", false, true},
+	} {
+		mgr, _ := newFakeSystemd(t, map[string][]cmdResult{
+			"is-active":  {fails(tc.active)},
+			"is-enabled": {fails(tc.enabled)},
+		})
+		label := "com.dirstral.dir2mcp-demo-abc123"
+		seedUnit(t, mgr, label, "[Unit]\n")
+
+		state, err := mgr.status(label)
+		if err != nil {
+			t.Fatalf("active=%q enabled=%q: status should not error: %v", tc.active, tc.enabled, err)
+		}
+		if state.Running != tc.wantRunning || state.Installed != tc.wantInstalled {
+			t.Errorf("active=%q enabled=%q: got %+v", tc.active, tc.enabled, state)
+		}
+	}
+}
+
+// --- issue #723: uninstall must not orphan a running daemon ---
+
+// TestSystemdManager_UninstallKeepsUnitOnDisableFailure_723 pins the fix: a
+// disable failure that is NOT a positively identified absent unit aborts the
+// uninstall with the unit file intact. Before the fix the error was discarded
+// and the unit was deleted while its daemon kept running, leaving dangling
+// enablement symlinks and nothing to retry from.
+func TestSystemdManager_UninstallKeepsUnitOnDisableFailure_723(t *testing.T) {
+	for _, out := range []string{
+		"Failed to connect to bus: No medium found\n",
+		"Failed to disable unit: Access denied\n",
+		"Interactive authentication required.\n",
+	} {
+		mgr, runner := newFakeSystemd(t, map[string][]cmdResult{"disable": {fails(out)}})
+		label := "com.dirstral.dir2mcp-demo-abc123"
+		unit := seedUnit(t, mgr, label, "[Unit]\n")
+
+		_, removed, err := mgr.uninstall(label)
+		if err == nil {
+			t.Fatalf("out=%q: expected the disable failure to abort the uninstall", out)
+		}
+		if removed {
+			t.Errorf("out=%q: removed must be false when the unit could not be stopped", out)
+		}
+		if _, statErr := os.Stat(unit); statErr != nil {
+			t.Errorf("out=%q: the unit must be kept so the operator can retry: %v", out, statErr)
+		}
+		if !strings.Contains(err.Error(), "still be running") {
+			t.Errorf("out=%q: error should warn the unit may still run: %v", out, err)
+		}
+		if runner.count("daemon-reload") != 0 {
+			t.Errorf("out=%q: uninstall must stop at the failed disable: %v", out, runner.lines())
+		}
+	}
+}
+
+// TestSystemdManager_UninstallAbsentUnitStaysIdempotent_723 pins that a
+// positively identified absent/not-loaded unit remains benign.
+func TestSystemdManager_UninstallAbsentUnitStaysIdempotent_723(t *testing.T) {
+	for _, out := range []string{
+		"Failed to disable unit: Unit file com.dirstral.dir2mcp-demo-abc123.service does not exist.\n",
+		"Failed to stop com.dirstral.dir2mcp-demo-abc123.service: Unit com.dirstral.dir2mcp-demo-abc123.service not loaded.\n",
+	} {
+		mgr, _ := newFakeSystemd(t, map[string][]cmdResult{"disable": {fails(out)}})
+		label := "com.dirstral.dir2mcp-demo-abc123"
+		unit := seedUnit(t, mgr, label, "[Unit]\n")
+
+		_, removed, err := mgr.uninstall(label)
+		if err != nil {
+			t.Fatalf("out=%q: uninstall should succeed for an absent unit: %v", out, err)
+		}
+		if !removed {
+			t.Errorf("out=%q: expected removed=true", out)
+		}
+		if _, statErr := os.Stat(unit); !os.IsNotExist(statErr) {
+			t.Errorf("out=%q: unit should have been removed: %v", out, statErr)
+		}
+	}
+}
+
+// --- issue #724: a failed install must not strand or stop the previous unit ---
+
+const priorUnitBody = "[Service]\nExecStart=/old/dir2mcp up --foreground\n"
+
+// TestSystemdManager_InstallRestoresPriorUnitOnEnableFailure_724 is the core
+// reinstall case: the unit was overwritten and `enable --now` then failed.
+// Before the fix the new unit stayed on disk (possibly partially enabled) with
+// no restoration of the previous definition or its enabled+running state.
+func TestSystemdManager_InstallRestoresPriorUnitOnEnableFailure_724(t *testing.T) {
+	mgr, runner := newFakeSystemd(t, map[string][]cmdResult{
+		"is-active":  {fails("active\n")},
+		"is-enabled": {ok("enabled\n")},
+		"enable":     {fails("Failed to enable unit: Invalid argument"), ok("")},
+	})
+	label := "com.dirstral.dir2mcp-demo-abc123"
+	unit := seedUnit(t, mgr, label, priorUnitBody)
+
+	_, err := mgr.install(serviceSpec{Label: label, BinaryPath: "/bin/dir2mcp", WorkingDir: "/x", LogPath: "/x/l.log"})
+	if err == nil {
+		t.Fatal("expected the enable failure to surface")
+	}
+	body, readErr := os.ReadFile(unit)
+	if readErr != nil {
+		t.Fatalf("read unit: %v", readErr)
+	}
+	if string(body) != priorUnitBody {
+		t.Errorf("the previous unit was not restored:\n%s", body)
+	}
+	// The partial `enable --now` is reversed, then the prior unit is re-enabled.
+	if runner.count("disable") != 1 {
+		t.Errorf("the partially enabled replacement should have been disabled: %v", runner.lines())
+	}
+	if runner.count("enable") != 2 {
+		t.Errorf("the previously enabled+active unit should have been re-enabled: %v", runner.lines())
+	}
+	if runner.count("daemon-reload") != 2 {
+		t.Errorf("systemd should be reloaded after restoring the unit: %v", runner.lines())
+	}
+	if !strings.Contains(err.Error(), "rolled back") {
+		t.Errorf("error should state the rollback: %v", err)
+	}
+	if strings.Contains(err.Error(), "ROLLBACK INCOMPLETE") {
+		t.Errorf("rollback should have been complete: %v", err)
+	}
+}
+
+// TestSystemdManager_InstallRestoresPriorUnitOnReloadFailure_724 covers the
+// earlier step: daemon-reload failed, so nothing was enabled and the rollback
+// only has to put the unit file back.
+func TestSystemdManager_InstallRestoresPriorUnitOnReloadFailure_724(t *testing.T) {
+	mgr, runner := newFakeSystemd(t, map[string][]cmdResult{
+		"is-active":     {fails("inactive\n")},
+		"is-enabled":    {ok("enabled\n")},
+		"daemon-reload": {fails("Failed to connect to bus: No medium found"), ok("")},
+	})
+	label := "com.dirstral.dir2mcp-demo-abc123"
+	unit := seedUnit(t, mgr, label, priorUnitBody)
+
+	_, err := mgr.install(serviceSpec{Label: label, BinaryPath: "/bin/dir2mcp", WorkingDir: "/x", LogPath: "/x/l.log"})
+	if err == nil {
+		t.Fatal("expected the daemon-reload failure to surface")
+	}
+	body, _ := os.ReadFile(unit)
+	if string(body) != priorUnitBody {
+		t.Errorf("the previous unit was not restored:\n%s", body)
+	}
+	if runner.count("disable") != 0 {
+		t.Errorf("nothing was enabled, so nothing may be disabled: %v", runner.lines())
+	}
+	// Enabled but not active: re-enable without --now.
+	lines := runner.lines()
+	if lines[len(lines)-1] != "systemctl --user enable com.dirstral.dir2mcp-demo-abc123.service" {
+		t.Errorf("an enabled-but-stopped unit must not be started by the rollback: %v", lines)
+	}
+}
+
+// TestSystemdManager_InstallCleansUpFailedFirstInstall_724 pins the first-time
+// case: a failed install must leave no unit behind, so it cannot activate at the
+// next login, and must not try to re-enable a unit that never existed.
+func TestSystemdManager_InstallCleansUpFailedFirstInstall_724(t *testing.T) {
+	mgr, runner := newFakeSystemd(t, map[string][]cmdResult{
+		"enable": {fails("Failed to enable unit: Invalid argument")},
+	})
+	label := "com.dirstral.dir2mcp-demo-abc123"
+	unit, err := mgr.install(serviceSpec{Label: label, BinaryPath: "/bin/dir2mcp", WorkingDir: "/x", LogPath: "/x/l.log"})
+	if err == nil {
+		t.Fatal("expected the enable failure to surface")
+	}
+	if _, statErr := os.Stat(unit); !os.IsNotExist(statErr) {
+		t.Errorf("a failed first install must not leave a unit behind: %v", statErr)
+	}
+	if !strings.Contains(err.Error(), "no service definition was left") {
+		t.Errorf("error should state that nothing was left installed: %v", err)
+	}
+	if runner.count("enable") != 1 {
+		t.Errorf("rollback must not re-enable a unit that never existed: %v", runner.lines())
+	}
+	if runner.count("disable") != 1 {
+		t.Errorf("the partial registration should have been disabled: %v", runner.lines())
+	}
+}
+
+// TestSystemdManager_InstallFailsBeforeWritingWhenBusUnreachable_724 pins the
+// strongest transactionality guarantee available here: when systemd cannot be
+// reached at all, install fails with the previous definition untouched on disk,
+// because the prior state is captured before anything is written.
+func TestSystemdManager_InstallFailsBeforeWritingWhenBusUnreachable_724(t *testing.T) {
+	mgr, runner := newFakeSystemd(t, map[string][]cmdResult{
+		"is-active": {fails("Failed to connect to bus: No medium found\n")},
+	})
+	label := "com.dirstral.dir2mcp-demo-abc123"
+	unit := seedUnit(t, mgr, label, priorUnitBody)
+
+	_, err := mgr.install(serviceSpec{Label: label, BinaryPath: "/bin/dir2mcp", WorkingDir: "/x", LogPath: "/x/l.log"})
+	if err == nil {
+		t.Fatal("expected an unreachable user manager to fail the install")
+	}
+	body, _ := os.ReadFile(unit)
+	if string(body) != priorUnitBody {
+		t.Errorf("the unit must not be touched when systemd cannot be reached:\n%s", body)
+	}
+	if runner.count("daemon-reload") != 0 || runner.count("enable") != 0 {
+		t.Errorf("no mutation may be attempted: %v", runner.lines())
+	}
+}
+
+// TestSystemdManager_InstallReportsIncompleteRollback_724 pins the honesty
+// requirement: when the rollback cannot restore the previous unit, the operator
+// is told exactly what is still wrong.
+func TestSystemdManager_InstallReportsIncompleteRollback_724(t *testing.T) {
+	mgr, _ := newFakeSystemd(t, map[string][]cmdResult{
+		"is-active":  {fails("active\n")},
+		"is-enabled": {ok("enabled\n")},
+		"enable":     {fails("Failed to enable unit: Invalid argument"), fails("Failed to enable unit: Access denied")},
+	})
+	label := "com.dirstral.dir2mcp-demo-abc123"
+	seedUnit(t, mgr, label, priorUnitBody)
+
+	_, err := mgr.install(serviceSpec{Label: label, BinaryPath: "/bin/dir2mcp", WorkingDir: "/x", LogPath: "/x/l.log"})
+	if err == nil {
+		t.Fatal("expected the install failure to surface")
+	}
+	if !strings.Contains(err.Error(), "ROLLBACK INCOMPLETE") {
+		t.Errorf("an unrecoverable rollback must be explicit: %v", err)
+	}
+	if !strings.Contains(err.Error(), "could not re-enable and restart the previous unit") {
+		t.Errorf("error should name what could not be restored: %v", err)
 	}
 }

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -1169,3 +1169,55 @@ func slicesContains(haystack []string, needle string) bool {
 	}
 	return false
 }
+
+// TestLaunchctlReportsAbsent_723_725 pins the darwin-side classifiers the same
+// way TestSystemctlReportsAbsent_723 pins the linux ones, and lives in this
+// UNTAGGED file on purpose.
+//
+// They are pure string classifiers with no darwin dependency, and keeping their
+// only coverage behind `//go:build darwin` meant Linux CI never exercised the
+// logic that decides whether `service status` reports a clean absent state or an
+// operational error. It also made `launchctlPrintReportsAbsent` dead code on
+// Linux, which is what golangci-lint's `unused` pass reported.
+func TestLaunchctlReportsAbsent_723_725(t *testing.T) {
+	t.Run("print: only a positively unregistered service is absent", func(t *testing.T) {
+		for _, tc := range []struct {
+			out  string
+			want bool
+		}{
+			{"Could not find service \"com.dirstral.x\" in domain for user", true},
+			{"Service not found in domain", true},
+			// A bootout-only phrase must NOT make `print` report absent: print
+			// never emits it, so seeing it means something else went wrong.
+			{"No such process", false},
+			// Everything that is not a positive identification stays an error,
+			// or status would launder a broken launchd into "installed, stopped".
+			{"Operation not permitted", false},
+			{"Could not connect to the bootstrap server", false},
+			{"", false},
+		} {
+			if got := launchctlPrintReportsAbsent(tc.out); got != tc.want {
+				t.Errorf("launchctlPrintReportsAbsent(%q) = %v, want %v", tc.out, got, tc.want)
+			}
+		}
+	})
+
+	t.Run("bootout: absent covers the errno spellings too", func(t *testing.T) {
+		for _, tc := range []struct {
+			out  string
+			want bool
+		}{
+			{"No such process", true},
+			{"No such file or directory", true},
+			{"Could not find specified service", true},
+			// A superset of the print phrases, so those still count.
+			{"Could not find service \"com.dirstral.x\" in domain for user", true},
+			{"Operation not permitted", false},
+			{"", false},
+		} {
+			if got := launchctlBootoutReportsAbsent(tc.out); got != tc.want {
+				t.Errorf("launchctlBootoutReportsAbsent(%q) = %v, want %v", tc.out, got, tc.want)
+			}
+		}
+	})
+}

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"bytes"
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,6 +12,93 @@ import (
 
 	"github.com/dirstral/dir2mcp/internal/config"
 )
+
+// recordedCmd is one supervisor invocation captured by the platform fakes.
+type recordedCmd struct {
+	name string
+	args []string
+}
+
+// argLine joins a recorded command back into a single string for sequence
+// assertions.
+func argLine(c recordedCmd) string {
+	return c.name + " " + strings.Join(c.args, " ")
+}
+
+// cmdResult is one scripted (combined output, error) pair.
+type cmdResult struct {
+	out string
+	err error
+}
+
+// fails builds a scripted failure with the given combined output.
+func fails(out string) cmdResult { return cmdResult{out: out, err: errors.New("exit status 1")} }
+
+// ok builds a scripted success with the given combined output.
+func ok(out string) cmdResult { return cmdResult{out: out} }
+
+// scriptedRunner is a runCmd stand-in that returns per-subcommand results and
+// records every call, so a test can inject a failure at ONE supervisor step and
+// assert what the manager did afterwards.
+//
+// Results are queued per subcommand: the first `bootstrap` result is consumed by
+// the install, the second by a rollback re-bootstrap. An exhausted or unscripted
+// subcommand succeeds silently, which keeps the happy path terse.
+type scriptedRunner struct {
+	results map[string][]cmdResult
+	calls   []recordedCmd
+}
+
+func newScriptedRunner(script map[string][]cmdResult) *scriptedRunner {
+	results := make(map[string][]cmdResult, len(script))
+	for k, v := range script {
+		results[k] = append([]cmdResult(nil), v...)
+	}
+	return &scriptedRunner{results: results}
+}
+
+// run is the injected runCmd. The script key is the first non-flag argument:
+// "bootout" for `launchctl bootout gui/501 …`, "is-active" for
+// `systemctl --user is-active …`.
+func (s *scriptedRunner) run(name string, args ...string) (string, error) {
+	s.calls = append(s.calls, recordedCmd{name: name, args: args})
+	key := ""
+	for _, a := range args {
+		if !strings.HasPrefix(a, "-") {
+			key = a
+			break
+		}
+	}
+	queue := s.results[key]
+	if len(queue) == 0 {
+		return "", nil
+	}
+	s.results[key] = queue[1:]
+	return queue[0].out, queue[0].err
+}
+
+// lines renders the recorded calls for assertions and failure messages.
+func (s *scriptedRunner) lines() []string {
+	out := make([]string, 0, len(s.calls))
+	for _, c := range s.calls {
+		out = append(out, argLine(c))
+	}
+	return out
+}
+
+// count returns how many recorded calls used the given subcommand.
+func (s *scriptedRunner) count(sub string) int {
+	n := 0
+	for _, c := range s.calls {
+		for _, a := range c.args {
+			if a == sub {
+				n++
+				break
+			}
+		}
+	}
+	return n
+}
 
 func TestServiceLabel(t *testing.T) {
 	got := serviceLabel("dir2mcp-stas-legal-main-45a264")
@@ -600,4 +689,483 @@ func TestInstallServiceArgs_PropagatesAbsolutePaths_738(t *testing.T) {
 	if got := installServiceArgs(globalOptions{}, sc); strings.Join(got, " ") != "up --foreground" {
 		t.Fatalf("installServiceArgs without overrides = %v", got)
 	}
+}
+
+// --- issue #725 / #723: supervisor output classification ---
+
+// TestSystemctlQueryClassify_725 pins the discriminator between a normal
+// systemd verdict and a systemctl that could not answer. Both exit non-zero, so
+// only the OUTPUT can tell them apart: before the fix every is-active/is-enabled
+// error was discarded and the CLI derived a plausible "installed, not running"
+// snapshot from the on-disk unit file instead.
+func TestSystemctlQueryClassify_725(t *testing.T) {
+	exit1 := errors.New("exit status 1")
+	for _, tc := range []struct {
+		name    string
+		query   systemctlQuery
+		out     string
+		err     error
+		want    string
+		wantErr bool
+	}{
+		{name: "active", query: systemctlIsActive, out: "active\n", want: "active"},
+		{name: "inactive exits non-zero but is normal", query: systemctlIsActive, out: "inactive\n", err: errors.New("exit status 3"), want: "inactive"},
+		{name: "failed is a normal state", query: systemctlIsActive, out: "failed\n", err: errors.New("exit status 3"), want: "failed"},
+		{name: "enabled", query: systemctlIsEnabled, out: "enabled\n", want: "enabled"},
+		{name: "disabled exits non-zero but is normal", query: systemctlIsEnabled, out: "disabled\n", err: exit1, want: "disabled"},
+		{name: "not-found verdict", query: systemctlIsEnabled, out: "not-found\n", err: exit1, want: "not-found"},
+		{
+			name:  "absent unit reported only as a diagnostic",
+			query: systemctlIsEnabled,
+			out:   "Failed to get unit file state for com.dirstral.x.service: No such file or directory\n",
+			err:   exit1,
+			want:  "not-found",
+		},
+		{
+			name:  "diagnostic printed alongside the verdict",
+			query: systemctlIsEnabled,
+			out:   "Failed to get unit file state for com.dirstral.x.service: No such file or directory\nnot-found\n",
+			err:   exit1,
+			want:  "not-found",
+		},
+		{
+			name:    "dead user bus must not read as a missing unit",
+			query:   systemctlIsActive,
+			out:     "Failed to connect to bus: No such file or directory\n",
+			err:     exit1,
+			wantErr: true,
+		},
+		{
+			name:    "no session bus",
+			query:   systemctlIsActive,
+			out:     "Failed to connect to bus: No medium found\n",
+			err:     exit1,
+			wantErr: true,
+		},
+		{
+			name:    "permission denied",
+			query:   systemctlIsEnabled,
+			out:     "Failed to get unit file state: Permission denied\n",
+			err:     exit1,
+			wantErr: true,
+		},
+		{
+			name:    "systemctl missing entirely",
+			query:   systemctlIsActive,
+			out:     "",
+			err:     errors.New(`exec: "systemctl": executable file not found in $PATH`),
+			wantErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.query.classify(tc.out, tc.err)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected an operational error, got verdict %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("verdict = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSystemctlReportsAbsent_723 pins the uninstall-side classification: only a
+// positively identified absent/not-loaded unit is benign. A transport or
+// permission failure must NOT be swallowed, or uninstall would delete the unit
+// file of a daemon that is still running.
+func TestSystemctlReportsAbsent_723(t *testing.T) {
+	for _, tc := range []struct {
+		out  string
+		want bool
+	}{
+		{"Failed to disable unit: Unit file com.dirstral.x.service does not exist.", true},
+		{"Failed to stop com.dirstral.x.service: Unit com.dirstral.x.service not loaded.", true},
+		{"Failed to disable unit com.dirstral.x.service: No such unit", true},
+		{"Failed to connect to bus: No such file or directory", false},
+		{"Failed to connect to bus: No medium found", false},
+		{"Failed to disable unit: Access denied", false},
+		{"Interactive authentication required.", false},
+		{"", false},
+	} {
+		if got := systemctlReportsAbsent(tc.out); got != tc.want {
+			t.Errorf("systemctlReportsAbsent(%q) = %v, want %v", tc.out, got, tc.want)
+		}
+	}
+}
+
+// TestLaunchctlBootoutReportsAbsent_723 is the launchd analog: launchctl reports
+// "nothing to unload" through POSIX errno text, which is benign, while every
+// other failure means the service may still be booted in.
+func TestLaunchctlBootoutReportsAbsent_723(t *testing.T) {
+	for _, tc := range []struct {
+		out  string
+		want bool
+	}{
+		{"Boot-out failed: 3: No such process", true},
+		{"Boot-out failed: 2: No such file or directory", true},
+		{`Could not find service "com.dirstral.x" in domain for port`, true},
+		{"Boot-out failed: 1: Operation not permitted", false},
+		{"Could not connect to the Mach bootstrap server", false},
+		{"", false},
+	} {
+		if got := launchctlBootoutReportsAbsent(tc.out); got != tc.want {
+			t.Errorf("launchctlBootoutReportsAbsent(%q) = %v, want %v", tc.out, got, tc.want)
+		}
+	}
+}
+
+// --- issue #724: transactional definition replacement ---
+
+// TestUnitTxn_RollbackRestoresPriorDefinition_724 pins the file half of an
+// atomic install: a failed install must leave the PREVIOUS definition on disk,
+// byte-for-byte and with its original permissions, not the half-installed
+// replacement.
+func TestUnitTxn_RollbackRestoresPriorDefinition_724(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "com.dirstral.demo.service")
+	const prior = "[Service]\nExecStart=/old/dir2mcp up\n"
+	if err := os.WriteFile(path, []byte(prior), 0o644); err != nil {
+		t.Fatalf("seed prior unit: %v", err)
+	}
+
+	txn, err := beginUnitTxn(path, 0o644)
+	if err != nil {
+		t.Fatalf("beginUnitTxn: %v", err)
+	}
+	if !txn.had {
+		t.Fatal("expected the prior definition to be captured")
+	}
+	if err := txn.write("[Service]\nExecStart=/new/dir2mcp up\n"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if body, _ := os.ReadFile(path); string(body) == prior {
+		t.Fatal("write did not replace the definition")
+	}
+	if err := txn.rollback(); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read restored unit: %v", err)
+	}
+	if string(body) != prior {
+		t.Errorf("rollback did not restore the prior definition:\n%s", body)
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat restored unit: %v", err)
+	}
+	if fi.Mode().Perm() != 0o644 {
+		t.Errorf("restored perms = %v, want 0644", fi.Mode().Perm())
+	}
+	if !strings.Contains(txn.describeRestored(), path) {
+		t.Errorf("describeRestored should name the path: %q", txn.describeRestored())
+	}
+}
+
+// TestUnitTxn_ReplacementDoesNotInheritPriorMode_724 pins that the previous
+// file's mode is used only to RESTORE it: the replacement definition gets the
+// mode the backend asked for, so a stray 0600 plist cannot silently narrow the
+// permissions of every future install.
+func TestUnitTxn_ReplacementDoesNotInheritPriorMode_724(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "com.dirstral.demo.service")
+	if err := os.WriteFile(path, []byte("old"), 0o600); err != nil {
+		t.Fatalf("seed prior unit: %v", err)
+	}
+
+	txn, err := beginUnitTxn(path, 0o644)
+	if err != nil {
+		t.Fatalf("beginUnitTxn: %v", err)
+	}
+	if err := txn.write("new"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if fi.Mode().Perm() != 0o644 {
+		t.Errorf("replacement perms = %v, want the requested 0644", fi.Mode().Perm())
+	}
+	if err := txn.rollback(); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	fi, err = os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat restored: %v", err)
+	}
+	if fi.Mode().Perm() != 0o600 {
+		t.Errorf("restored perms = %v, want the prior 0600", fi.Mode().Perm())
+	}
+}
+
+// TestUnitTxn_RollbackRemovesFirstInstall_724 pins the other half: when there
+// was no previous definition, a failed install must leave NOTHING behind, so a
+// half-installed unit cannot activate at the next login.
+func TestUnitTxn_RollbackRemovesFirstInstall_724(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "com.dirstral.demo.plist")
+
+	txn, err := beginUnitTxn(path, 0o644)
+	if err != nil {
+		t.Fatalf("beginUnitTxn: %v", err)
+	}
+	if txn.had {
+		t.Fatal("expected a first-time install")
+	}
+	if err := txn.write("<plist/>"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := txn.rollback(); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("definition still present after rollback: %v", err)
+	}
+	// Rolling back twice must stay clean (the removal is idempotent).
+	if err := txn.rollback(); err != nil {
+		t.Errorf("second rollback: %v", err)
+	}
+	// No staging files may be left in the directory.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("temporary staging files left behind: %v", entries)
+	}
+}
+
+// TestWrapInstallRollback_724 pins the operator-facing contract: a clean undo
+// says so, and an incomplete one names what could not be undone rather than
+// leaving the operator to infer the machine's state.
+func TestWrapInstallRollback_724(t *testing.T) {
+	txn := &unitTxn{path: "/tmp/x.service", had: true}
+	cause := fmt.Errorf("systemctl enable --now: exit status 1")
+
+	clean := wrapInstallRollback(cause, txn, nil)
+	if !strings.Contains(clean.Error(), "rolled back") || !strings.Contains(clean.Error(), "restored") {
+		t.Errorf("clean rollback error should state the undo: %v", clean)
+	}
+	dirty := wrapInstallRollback(cause, txn, []string{"could not restart the previous unit"})
+	if !strings.Contains(dirty.Error(), "ROLLBACK INCOMPLETE") {
+		t.Errorf("incomplete rollback must be explicit: %v", dirty)
+	}
+	if !strings.Contains(dirty.Error(), "could not restart the previous unit") {
+		t.Errorf("incomplete rollback must name the problem: %v", dirty)
+	}
+	if !errors.Is(dirty, cause) {
+		t.Errorf("the original cause must stay unwrappable: %v", dirty)
+	}
+}
+
+// --- issue #722: the install credential sweep must cover runtime secrets ---
+
+// clearRuntimeSecretEnv unsets every secret this test file manipulates, so a
+// developer machine with real AWS/Qdrant credentials exported cannot make the
+// assertions pass or fail spuriously.
+func clearRuntimeSecretEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{
+		"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN",
+		"QDRANT_API_KEY", "DIR2MCP_INDEX_PGVECTOR_DSN",
+		"DIR2MCP_DISTRIBUTED_EMBED_BROKER_URL", "DIR2MCP_X402_FACILITATOR_TOKEN",
+	} {
+		t.Setenv(key, "")
+	}
+}
+
+// TestPersistAndWarnCredentials_S3CapturesAWSKeys_722 is the issue's exact
+// reproduction: an s3 corpus installed from a shell that exports the AWS
+// credentials. Before the fix the sweep only looked at provider `api_key`
+// references, so the keys were neither written to .env.local nor reported, and
+// the supervised daemon failed at boot with the missing-credentials error.
+func TestPersistAndWarnCredentials_S3CapturesAWSKeys_722(t *testing.T) {
+	clearRuntimeSecretEnv(t)
+	dir := t.TempDir()
+	t.Setenv("AWS_ACCESS_KEY_ID", "AKIAEXAMPLE")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "s3cr3t-value")
+
+	cfg := s3ServiceConfig(filepath.Join(dir, "corpus"), filepath.Join(dir, "state"))
+	cfg.Source.S3AccessKeyID = "AKIAEXAMPLE"
+	cfg.Source.S3SecretAccessKey = "s3cr3t-value"
+
+	var out, errBuf bytes.Buffer
+	app := NewAppWithIO(&out, &errBuf)
+	rep := app.persistAndWarnCredentials(dir, cfg, false, false)
+
+	for _, key := range []string{"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"} {
+		if !slicesContains(rep.saved, key) {
+			t.Errorf("%s was not persisted; saved=%v", key, rep.saved)
+		}
+	}
+	if len(rep.missing) != 0 {
+		t.Errorf("nothing should be missing once the keys are captured: %v", rep.missing)
+	}
+	body, err := os.ReadFile(filepath.Join(dir, ".env.local"))
+	if err != nil {
+		t.Fatalf("read .env.local: %v", err)
+	}
+	if !strings.Contains(string(body), "AWS_SECRET_ACCESS_KEY=s3cr3t-value") {
+		t.Errorf(".env.local missing the captured AWS credential:\n%s", body)
+	}
+}
+
+// TestPersistAndWarnCredentials_ReportsMissingRequiredSecret_722 pins the other
+// half of the issue: a required runtime secret with NO persistent source is
+// named (never valued) instead of the install reporting a clean success.
+func TestPersistAndWarnCredentials_ReportsMissingRequiredSecret_722(t *testing.T) {
+	clearRuntimeSecretEnv(t)
+	dir := t.TempDir()
+	cfg := s3ServiceConfig(filepath.Join(dir, "corpus"), filepath.Join(dir, "state"))
+
+	var out, errBuf bytes.Buffer
+	app := NewAppWithIO(&out, &errBuf)
+	rep := app.persistAndWarnCredentials(dir, cfg, false, false)
+
+	for _, key := range []string{"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"} {
+		if !slicesContains(rep.missing, key) {
+			t.Errorf("%s should be reported missing; missing=%v", key, rep.missing)
+		}
+	}
+	// The optional session token must not raise a false alarm.
+	if slicesContains(rep.missing, "AWS_SESSION_TOKEN") {
+		t.Errorf("the optional session token must not be reported missing: %v", rep.missing)
+	}
+	warn := errBuf.String()
+	if !strings.Contains(warn, "AWS_SECRET_ACCESS_KEY") || !strings.Contains(warn, "source.kind=s3") {
+		t.Errorf("stderr should name the secret and the feature that needs it:\n%s", warn)
+	}
+	if !strings.Contains(warn, "NOT bootable") {
+		t.Errorf("stderr should say the service is not bootable:\n%s", warn)
+	}
+}
+
+// TestPersistAndWarnCredentials_DotenvSatisfiesRequirement_722 pins that a
+// credential already persisted in the target directory's .env.local is not
+// re-reported as missing: the sweep measures whether the DAEMON will find it,
+// not whether this shell exported it.
+func TestPersistAndWarnCredentials_DotenvSatisfiesRequirement_722(t *testing.T) {
+	clearRuntimeSecretEnv(t)
+	dir := t.TempDir()
+	seed := "AWS_ACCESS_KEY_ID=AKIAFROMFILE\nAWS_SECRET_ACCESS_KEY=from-file\n"
+	if err := os.WriteFile(filepath.Join(dir, ".env.local"), []byte(seed), 0o600); err != nil {
+		t.Fatalf("seed .env.local: %v", err)
+	}
+	cfg := s3ServiceConfig(filepath.Join(dir, "corpus"), filepath.Join(dir, "state"))
+
+	var out, errBuf bytes.Buffer
+	app := NewAppWithIO(&out, &errBuf)
+	if rep := app.persistAndWarnCredentials(dir, cfg, false, false); len(rep.missing) != 0 {
+		t.Errorf("credentials already in .env.local must not be reported missing: %v", rep.missing)
+	}
+}
+
+// TestPersistAndWarnCredentials_PgvectorDSNRequired_722 covers the second
+// required runtime secret: `index.pgvector.dsn` has no config-file setter, so an
+// installed pgvector service is unbootable without it.
+func TestPersistAndWarnCredentials_PgvectorDSNRequired_722(t *testing.T) {
+	clearRuntimeSecretEnv(t)
+	dir := t.TempDir()
+	cfg := config.Default()
+	cfg.RootDir = dir
+	cfg.IndexBackend = "pgvector"
+
+	var out, errBuf bytes.Buffer
+	app := NewAppWithIO(&out, &errBuf)
+	rep := app.persistAndWarnCredentials(dir, cfg, false, false)
+	if !slicesContains(rep.missing, "DIR2MCP_INDEX_PGVECTOR_DSN") {
+		t.Errorf("the pgvector DSN should be reported missing: %v", rep.missing)
+	}
+
+	// With the DSN exported it is captured instead.
+	t.Setenv("DIR2MCP_INDEX_PGVECTOR_DSN", "postgres://user:pw@localhost/db")
+	cfg.IndexPgvectorDSN = "postgres://user:pw@localhost/db"
+	rep = app.persistAndWarnCredentials(dir, cfg, true, false)
+	if !slicesContains(rep.saved, "DIR2MCP_INDEX_PGVECTOR_DSN") {
+		t.Errorf("the pgvector DSN should have been persisted: %v", rep.saved)
+	}
+	if len(rep.missing) != 0 {
+		t.Errorf("nothing should be missing after capture: %v", rep.missing)
+	}
+}
+
+// TestPersistAndWarnCredentials_LocalCorpusUnchanged_722 pins that a plain local
+// corpus with a provider credential behaves exactly as before: no runtime
+// secrets apply, so nothing new is demanded of an existing deployment.
+func TestPersistAndWarnCredentials_LocalCorpusUnchanged_722(t *testing.T) {
+	clearRuntimeSecretEnv(t)
+	dir := t.TempDir()
+	t.Setenv("MISTRAL_API_KEY", "sk-live")
+	cfg := config.Default()
+	cfg.RootDir = dir
+
+	var out, errBuf bytes.Buffer
+	app := NewAppWithIO(&out, &errBuf)
+	rep := app.persistAndWarnCredentials(dir, cfg, false, false)
+	if !slicesContains(rep.saved, "MISTRAL_API_KEY") {
+		t.Errorf("the provider credential should still be persisted: %v", rep.saved)
+	}
+	if len(rep.missing) != 0 {
+		t.Errorf("a local corpus has no required runtime secrets: %v", rep.missing)
+	}
+}
+
+// TestPersistAndWarnCredentials_AWSCaptureDoesNotSilenceProviderWarning_722
+// pins that widening the sweep did not weaken the pre-existing warning: saving
+// an AWS credential says nothing about whether an embedding provider will
+// resolve at boot, so the "no persisted provider credential" warning must still
+// fire.
+func TestPersistAndWarnCredentials_AWSCaptureDoesNotSilenceProviderWarning_722(t *testing.T) {
+	clearRuntimeSecretEnv(t)
+	dir := t.TempDir()
+	for _, key := range config.Default().ProviderEnvVarRefs() {
+		t.Setenv(key, "")
+	}
+	t.Setenv("AWS_ACCESS_KEY_ID", "AKIAEXAMPLE")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "s3cr3t-value")
+
+	cfg := s3ServiceConfig(filepath.Join(dir, "corpus"), filepath.Join(dir, "state"))
+	cfg.Source.S3AccessKeyID = "AKIAEXAMPLE"
+	cfg.Source.S3SecretAccessKey = "s3cr3t-value"
+
+	var out, errBuf bytes.Buffer
+	app := NewAppWithIO(&out, &errBuf)
+	app.persistAndWarnCredentials(dir, cfg, false, false)
+	if !strings.Contains(errBuf.String(), "no persisted provider credential") {
+		t.Errorf("the provider-credential warning must survive an AWS-only capture:\n%s", errBuf.String())
+	}
+}
+
+// TestCredentialSweepKeys_722 pins the merge of the provider refs with the
+// runtime secret names: order is stable and a key referenced by both appears
+// once, so it is never written to .env.local twice.
+func TestCredentialSweepKeys_722(t *testing.T) {
+	runtime := []config.RuntimeSecretRef{
+		{Name: "AWS_ACCESS_KEY_ID"},
+		{Name: "MISTRAL_API_KEY"},
+		{Name: ""},
+	}
+	got := credentialSweepKeys([]string{"MISTRAL_API_KEY", "OPENAI_API_KEY"}, runtime)
+	want := []string{"MISTRAL_API_KEY", "OPENAI_API_KEY", "AWS_ACCESS_KEY_ID"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("credentialSweepKeys = %v, want %v", got, want)
+	}
+}
+
+// slicesContains keeps the credential assertions readable.
+func slicesContains(haystack []string, needle string) bool {
+	for _, v := range haystack {
+		if v == needle {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/config/runtime_secrets.go
+++ b/internal/config/runtime_secrets.go
@@ -1,0 +1,140 @@
+package config
+
+import "strings"
+
+// RuntimeSecretRef describes one secret the booted daemon needs for THIS
+// configuration and that has no representation in the config file.
+//
+// The set is defined by a single, checkable rule (#722): a value belongs here
+// when it is resolvable ONLY from the runtime credential sources of SPEC
+// §16.1.1 (environment → keychain → .env.local/.env) because the config-file
+// key for it is deliberately absent or ignored. `source.s3.region` has a file
+// home and is therefore NOT a runtime secret; `AWS_SECRET_ACCESS_KEY`,
+// `QDRANT_API_KEY`, `index.pgvector.dsn`, `distributed_embed.broker_url`, and
+// `x402_facilitator_token` have none and are.
+//
+// Provider-profile credentials are NOT included: they are already enumerated by
+// ProviderEnvVarRefs, which understands `${VAR}` references in user-defined
+// profiles. RuntimeSecretRefs covers everything else.
+type RuntimeSecretRef struct {
+	// Name is the environment variable the daemon reads the value from. It is
+	// also the keychain account name and the .env.local key, so one name
+	// identifies the value across every source.
+	Name string
+	// Feature is the config setting that pulls this secret in, for
+	// operator-facing messages ("source.kind=s3"). Never a value.
+	Feature string
+	// Required reports whether the daemon fails to boot without the value.
+	// Optional secrets (an unsecured Qdrant, an absent session token) are still
+	// worth persisting when present, but their absence is not an error.
+	Required bool
+	// Resolved reports whether the effective config already carries a value.
+	// On an env-aware load this is true when ANY source supplied it, so callers
+	// must compare against the current process environment to tell "only in
+	// this shell" from "already persisted".
+	Resolved bool
+}
+
+// RuntimeSecretRefs returns the non-provider secrets the effective config
+// depends on, in a deterministic order. Only secrets for ACTIVE features are
+// returned: a local corpus contributes no AWS refs, a memory index contributes
+// no Qdrant/pgvector refs.
+//
+// `dir2mcp service install` uses this to persist runtime-only credentials the
+// supervised daemon could otherwise never see (launchd/systemd start from a
+// clean environment) and to name the ones that have no persistent source.
+func (cfg Config) RuntimeSecretRefs() []RuntimeSecretRef {
+	var refs []RuntimeSecretRef
+	refs = append(refs, cfg.sourceSecretRefs()...)
+	refs = append(refs, cfg.indexSecretRefs()...)
+	refs = append(refs, cfg.distributedEmbedSecretRefs()...)
+	refs = append(refs, cfg.x402SecretRefs()...)
+	return refs
+}
+
+// RuntimeSecretNames returns just the environment-variable names from
+// RuntimeSecretRefs, for callers that only need the key set.
+func (cfg Config) RuntimeSecretNames() []string {
+	refs := cfg.RuntimeSecretRefs()
+	names := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		names = append(names, ref.Name)
+	}
+	return names
+}
+
+// sourceSecretRefs returns the S3 corpus-source credentials. They are populated
+// by applySourceEnvOverrides on env-aware loads only and are never written to
+// the config file or the effective-config snapshot, so a supervised daemon can
+// see them only through the environment, the keychain, or .env.local.
+//
+// The access key and secret are REQUIRED: validateSourceRuntimeSecrets rejects
+// an s3 source without both, so a service installed without them cannot boot.
+// The session token is optional (only STS/temporary credentials carry one).
+func (cfg Config) sourceSecretRefs() []RuntimeSecretRef {
+	if strings.ToLower(strings.TrimSpace(cfg.Source.Kind)) != "s3" {
+		return nil
+	}
+	const feature = "source.kind=s3"
+	return []RuntimeSecretRef{
+		{Name: "AWS_ACCESS_KEY_ID", Feature: feature, Required: true, Resolved: isSet(cfg.Source.S3AccessKeyID)},
+		{Name: "AWS_SECRET_ACCESS_KEY", Feature: feature, Required: true, Resolved: isSet(cfg.Source.S3SecretAccessKey)},
+		{Name: "AWS_SESSION_TOKEN", Feature: feature, Required: false, Resolved: isSet(cfg.Source.S3SessionToken)},
+	}
+}
+
+// indexSecretRefs returns the Tier C vector-store credential for the selected
+// index backend. The pgvector DSN is required (loadPgvectorIndex fails without
+// it, and `index.pgvector.dsn` has no config-file setter); the Qdrant API key is
+// optional because a local/unsecured instance needs none.
+func (cfg Config) indexSecretRefs() []RuntimeSecretRef {
+	switch strings.ToLower(strings.TrimSpace(cfg.IndexBackend)) {
+	case "qdrant":
+		return []RuntimeSecretRef{{
+			Name: "QDRANT_API_KEY", Feature: "index.backend=qdrant",
+			Required: false, Resolved: isSet(cfg.Qdrant.APIKey),
+		}}
+	case "pgvector":
+		return []RuntimeSecretRef{{
+			Name: "DIR2MCP_INDEX_PGVECTOR_DSN", Feature: "index.backend=pgvector",
+			Required: true, Resolved: isSet(cfg.IndexPgvectorDSN),
+		}}
+	default:
+		return nil
+	}
+}
+
+// distributedEmbedSecretRefs returns the external broker connection URL, which
+// may embed credentials and is therefore runtime-only (SPEC §16.1.1).
+//
+// It is reported as OPTIONAL on purpose: this build ships only the in-process
+// "memory" and "sqlite" brokers (validateDistributedEmbed rejects anything
+// else), neither of which reads BrokerURL, so requiring it would raise a false
+// alarm on every valid distributed deployment. It is still captured when set so
+// an external-broker deployment does not lose it at reboot.
+func (cfg Config) distributedEmbedSecretRefs() []RuntimeSecretRef {
+	if !cfg.DistributedEmbed.Enabled {
+		return nil
+	}
+	return []RuntimeSecretRef{{
+		Name: "DIR2MCP_DISTRIBUTED_EMBED_BROKER_URL", Feature: "distributed_embed.enabled",
+		Required: false, Resolved: isSet(cfg.DistributedEmbed.BrokerURL),
+	}}
+}
+
+// x402SecretRefs returns the facilitator bearer token. The config loader
+// deliberately ignores a file value for it, so it is environment/keychain-only.
+// It is optional: a facilitator may accept unauthenticated settlement calls.
+func (cfg Config) x402SecretRefs() []RuntimeSecretRef {
+	mode := strings.ToLower(strings.TrimSpace(cfg.X402.Mode))
+	if mode == "" || mode == "off" || !isSet(cfg.X402.FacilitatorURL) {
+		return nil
+	}
+	return []RuntimeSecretRef{{
+		Name: "DIR2MCP_X402_FACILITATOR_TOKEN", Feature: "x402.mode=" + mode,
+		Required: false, Resolved: isSet(cfg.X402.FacilitatorToken),
+	}}
+}
+
+// isSet reports whether a resolved config value carries content.
+func isSet(v string) bool { return strings.TrimSpace(v) != "" }

--- a/tests/config/runtime_secrets_722_test.go
+++ b/tests/config/runtime_secrets_722_test.go
@@ -1,0 +1,191 @@
+package tests
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/secrets"
+)
+
+// refByName finds a runtime secret ref by env var name.
+func refByName(refs []config.RuntimeSecretRef, name string) (config.RuntimeSecretRef, bool) {
+	for _, ref := range refs {
+		if ref.Name == name {
+			return ref, true
+		}
+	}
+	return config.RuntimeSecretRef{}, false
+}
+
+// TestRuntimeSecretRefs_OnlyActiveFeatures_722 pins the capability-driven shape
+// of the set: a plain local corpus on the default index depends on no
+// non-provider runtime secret, so `service install` demands nothing new of an
+// existing deployment.
+func TestRuntimeSecretRefs_OnlyActiveFeatures_722(t *testing.T) {
+	if refs := config.Default().RuntimeSecretRefs(); len(refs) != 0 {
+		t.Errorf("a default local config should contribute no runtime secrets, got %+v", refs)
+	}
+}
+
+// TestRuntimeSecretRefs_S3_722 pins the S3 source credentials, the case from the
+// issue: the access key and secret are REQUIRED (validateSourceRuntimeSecrets
+// rejects an s3 source without them) and the session token is optional.
+func TestRuntimeSecretRefs_S3_722(t *testing.T) {
+	cfg := config.Default()
+	cfg.Source.Kind = "s3"
+	cfg.Source.S3Bucket = "corpus"
+	refs := cfg.RuntimeSecretRefs()
+
+	for _, want := range []struct {
+		name     string
+		required bool
+	}{
+		{"AWS_ACCESS_KEY_ID", true},
+		{"AWS_SECRET_ACCESS_KEY", true},
+		{"AWS_SESSION_TOKEN", false},
+	} {
+		ref, found := refByName(refs, want.name)
+		if !found {
+			t.Fatalf("%s missing from RuntimeSecretRefs: %+v", want.name, refs)
+		}
+		if ref.Required != want.required {
+			t.Errorf("%s Required = %v, want %v", want.name, ref.Required, want.required)
+		}
+		if !strings.Contains(ref.Feature, "s3") {
+			t.Errorf("%s Feature = %q, should name the s3 source", want.name, ref.Feature)
+		}
+		if ref.Resolved {
+			t.Errorf("%s should be unresolved when the config carries no value", want.name)
+		}
+	}
+
+	// A resolved credential (from env/keychain/.env.local) is reported as such,
+	// which is what lets install tell "only in this shell" from "already
+	// persisted" without ever handling the value itself.
+	cfg.Source.S3AccessKeyID = "AKIAEXAMPLE"
+	ref, _ := refByName(cfg.RuntimeSecretRefs(), "AWS_ACCESS_KEY_ID")
+	if !ref.Resolved {
+		t.Error("a populated credential should be reported as resolved")
+	}
+}
+
+// TestRuntimeSecretRefs_IndexBackends_722 pins the Tier C store credentials:
+// the pgvector DSN is required (it has no config-file setter and the daemon
+// refuses to start without it), the Qdrant key is optional (a local instance may
+// be unsecured), and an embedded backend contributes neither.
+func TestRuntimeSecretRefs_IndexBackends_722(t *testing.T) {
+	for _, tc := range []struct {
+		backend  string
+		want     string
+		required bool
+	}{
+		{"qdrant", "QDRANT_API_KEY", false},
+		{"pgvector", "DIR2MCP_INDEX_PGVECTOR_DSN", true},
+	} {
+		cfg := config.Default()
+		cfg.IndexBackend = tc.backend
+		ref, found := refByName(cfg.RuntimeSecretRefs(), tc.want)
+		if !found {
+			t.Fatalf("backend=%s: %s missing", tc.backend, tc.want)
+		}
+		if ref.Required != tc.required {
+			t.Errorf("backend=%s: %s Required = %v, want %v", tc.backend, tc.want, ref.Required, tc.required)
+		}
+	}
+
+	cfg := config.Default()
+	cfg.IndexBackend = "memory"
+	for _, name := range []string{"QDRANT_API_KEY", "DIR2MCP_INDEX_PGVECTOR_DSN"} {
+		if _, found := refByName(cfg.RuntimeSecretRefs(), name); found {
+			t.Errorf("an embedded backend must not demand %s", name)
+		}
+	}
+}
+
+// TestRuntimeSecretRefs_OptionalFeatures_722 pins the broker URL and the x402
+// facilitator token. Both are captured when present but never required: this
+// build ships only the in-process brokers (which ignore BrokerURL), and a
+// facilitator may accept unauthenticated calls. Requiring either would raise a
+// false alarm on a valid deployment.
+func TestRuntimeSecretRefs_OptionalFeatures_722(t *testing.T) {
+	cfg := config.Default()
+	cfg.DistributedEmbed.Enabled = true
+	ref, found := refByName(cfg.RuntimeSecretRefs(), "DIR2MCP_DISTRIBUTED_EMBED_BROKER_URL")
+	if !found {
+		t.Fatal("the broker URL should be captured when distributed embedding is on")
+	}
+	if ref.Required {
+		t.Error("the broker URL must not be required: no shipped broker reads it")
+	}
+	// Distributed embedding off (the default) contributes nothing.
+	if _, found := refByName(config.Default().RuntimeSecretRefs(), "DIR2MCP_DISTRIBUTED_EMBED_BROKER_URL"); found {
+		t.Error("distributed_embed.enabled=false must not demand a broker URL")
+	}
+
+	x := config.Default()
+	x.X402.Mode = "required"
+	x.X402.FacilitatorURL = "https://facilitator.example/v1"
+	ref, found = refByName(x.RuntimeSecretRefs(), "DIR2MCP_X402_FACILITATOR_TOKEN")
+	if !found {
+		t.Fatal("the facilitator token should be captured when x402 gating is on")
+	}
+	if ref.Required {
+		t.Error("the facilitator token must not be required")
+	}
+	// x402 off (the default) contributes nothing.
+	if _, found := refByName(config.Default().RuntimeSecretRefs(), "DIR2MCP_X402_FACILITATOR_TOKEN"); found {
+		t.Error("x402.mode=off must not demand a facilitator token")
+	}
+}
+
+// TestRuntimeSecretRefs_CoverKeychainManagedNonProviderVars_722 is the
+// anti-drift guard. Every non-provider credential the keychain backend manages
+// exists precisely because it cannot live in the config file, which is the same
+// rule RuntimeSecretRefs encodes. If a new one is added to secrets.ManagedEnvVars
+// without a RuntimeSecretRefs entry, `service install` would silently stop
+// persisting it and this test fails.
+func TestRuntimeSecretRefs_CoverKeychainManagedNonProviderVars_722(t *testing.T) {
+	cfg := config.Default()
+	cfg.Source.Kind = "s3"
+	cfg.Source.S3Bucket = "corpus"
+	cfg.IndexBackend = "pgvector"
+	covered := map[string]struct{}{}
+	for _, ref := range cfg.RuntimeSecretRefs() {
+		covered[ref.Name] = struct{}{}
+	}
+	// The Qdrant key needs the other backend selected.
+	qdrant := config.Default()
+	qdrant.IndexBackend = "qdrant"
+	for _, ref := range qdrant.RuntimeSecretRefs() {
+		covered[ref.Name] = struct{}{}
+	}
+	providerRefs := map[string]struct{}{}
+	for _, name := range config.Default().ProviderEnvVarRefs() {
+		providerRefs[name] = struct{}{}
+	}
+
+	for _, managed := range secrets.ManagedEnvVars() {
+		if _, isProvider := providerRefs[managed]; isProvider {
+			continue // already swept via ProviderEnvVarRefs
+		}
+		if _, ok := covered[managed]; !ok {
+			t.Errorf("keychain-managed secret %q is not covered by RuntimeSecretRefs; "+
+				"`dir2mcp service install` would not persist or report it", managed)
+		}
+	}
+}
+
+// TestRuntimeSecretNames_722 pins the convenience projection used by the CLI.
+func TestRuntimeSecretNames_722(t *testing.T) {
+	cfg := config.Default()
+	cfg.Source.Kind = "s3"
+	cfg.Source.S3Bucket = "corpus"
+	names := cfg.RuntimeSecretNames()
+	if len(names) != len(cfg.RuntimeSecretRefs()) {
+		t.Fatalf("RuntimeSecretNames dropped entries: %v", names)
+	}
+	if names[0] != "AWS_ACCESS_KEY_ID" {
+		t.Errorf("order must be deterministic, got %v", names)
+	}
+}


### PR DESCRIPTION
## Theme

All four issues are the same defect wearing different clothes: **the service lifecycle reports success it has not achieved, and fails in ways that leave a state neither the operator nor the tool can reason about.**

- `install` validates against credentials that exist only in the installing shell, then reports success for a daemon that cannot boot (#722).
- `uninstall` discards every stop error, then deletes the definition and reports success — possibly orphaning a running daemon (#723).
- a failed `install` leaves the machine somewhere between the old service and the new one, with no statement of where (#724).
- Linux `status` launders "systemctl could not answer" into the benign-looking "installed, not running" (#725).

They all live in `internal/cli/service*.go` and touch the same functions, so they ship as one PR.

All four were verified against the code before changing anything. **None was stale**; every quoted line in every issue is present on `main` as described.

---

## #722 — install now persists/reports every runtime secret, not just provider keys

`persistAndWarnCredentials` swept only `cfg.ProviderEnvVarRefs()` (provider-profile `api_key` refs). An `source.kind: s3` install validated *because* the shell exported `AWS_*`, then wrote a unit that boots from a clean environment and dies on `validateSourceRuntimeSecrets`.

**Which secrets, and why exactly those.** New `Config.RuntimeSecretRefs()` (`internal/config/runtime_secrets.go`) encodes one checkable rule: *a value belongs here when it has no config-file home, so environment / keychain / `.env.local` is its only source.* That is not a judgement call — it is verifiable in the loader:

| secret | config-file key | status |
|---|---|---|
| `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | none at all | **required** when `source.kind=s3` |
| `AWS_SESSION_TOKEN` | none at all | optional (only STS credentials have one) |
| `DIR2MCP_INDEX_PGVECTOR_DSN` | `index.pgvector.dsn` — alias exists, **no setter**, silently ignored | **required** when `index.backend=pgvector` |
| `QDRANT_API_KEY` | `index.qdrant.api_key` — alias exists, **no setter** | optional (a local instance may be unsecured) |
| `DIR2MCP_DISTRIBUTED_EMBED_BROKER_URL` | `distributed_embed.broker_url` — **no setter** | optional, see below |
| `DIR2MCP_X402_FACILITATOR_TOKEN` | file value deliberately ignored by the loader | optional (a facilitator may accept unauthenticated calls) |

`AWS_REGION` and the `DIR2MCP_SOURCE_S3_*` overrides are **deliberately excluded**: they have real config-file homes (`source.s3.region`, etc.), so the right fix for those is to write them into the config, not to smuggle them into `.env.local`.

`DIR2MCP_DISTRIBUTED_EMBED_BROKER_URL` is reported **optional, never required** — measured, not assumed: it is set from env at `config.go:4112` and read nowhere else, because this build only constructs the in-process `memory`/`sqlite` brokers. Requiring it would raise a false alarm on every valid distributed deployment. It is still captured when present so an external-broker deployment does not lose it at reboot.

**Behaviour.** Install now sweeps `providerRefs ∪ runtimeRefs`. For each *required* ref it then classifies: just persisted → fine; resolved from a non-environment source (keychain / dotenv) → fine; present in the target directory's dotenv → fine; otherwise **missing**. Missing secrets are named (never valued) in a loud stderr warning naming the feature that needs them, and the final line changes from "the daemon will start now and again at every login" to a count of what is still missing.

**Install still exits 0** when secrets are missing. The issue explicitly allows "persist … *or* refuse/warn clearly"; the unit *is* installed, the operator may supply the secret afterwards, and a non-zero exit would be a silent breaking change for scripts. The honesty requirement is met by naming each missing secret in both output modes.

**Guard against drift**: `TestRuntimeSecretRefs_CoverKeychainManagedNonProviderVars_722` asserts every non-provider entry of `secrets.ManagedEnvVars()` is covered by `RuntimeSecretRefs`, so adding a keychain-managed secret without a ref fails CI rather than silently un-persisting it.

## #723 — uninstall no longer swallows stop failures

Both backends did `_, _ = m.runCmd(... stop ...)` and then deleted the definition. Permission errors, dead buses, and transient failures were indistinguishable from the expected already-absent case.

Now: **deny by default.** Only a positively identified benign phrase lets the uninstall proceed:
- launchd (`launchctlBootoutReportsAbsent`): `no such process`, `no such file or directory`, `could not find specified service`, plus the two phrases `status` already used.
- systemd (`systemctlReportsAbsent`): `does not exist`, `not loaded`, `no such unit`, `no such file or directory`.

**The subtle part, and why systemd needed a two-stage check:** a dead user bus is reported as `Failed to connect to bus: No such file or directory` — which matches an "absent unit" phrase. So `systemctlTransportPhrases` (bus/permission/authentication failures) is checked **first** and vetoes the absent classification. Without that, the #723 fix would have re-introduced the #723 bug for the single most common failure mode. `TestSystemctlReportsAbsent_723` pins exactly this pair of cases.

On a real stop failure the definition is **kept** and a non-zero, machine-parseable error is returned naming the unit path and warning the daemon may still be running. I did **not** add the optional post-stop liveness verification the issue mentions: `launchctl bootout` / `systemctl disable --now` exiting 0 while the service is still loaded is not a failure mode I could evidence, and it would add a probe to every uninstall.

## #724 — install is transactional as far as the supervisor permits

**What "atomic install" means here.** The supervisor is the source of truth for *loaded/enabled/running*; the file is the source of truth for *what will load next login*. Neither launchd nor systemd offers a transaction, so "atomic" is decomposed:

1. **File half — genuinely atomic.** `unitTxn` (shared, `service.go`) snapshots the prior bytes+mode, stages the replacement in the same directory and `rename()`s it into place (a supervisor never observes a truncated definition), and can restore the prior bytes byte-for-byte or remove the file for a first-time install.
2. **Supervisor half — real rollback, not best-effort cleanup.** The prior loaded/enabled/running state is captured *before* anything is mutated, and every failing step drives an undo: boot the replacement out, restore the file, and put the previous service back the way it was (`bootstrap` on launchd; `enable` / `enable --now` / `start` on systemd, matching the exact prior state).
3. **First-time install:** rollback removes the definition entirely, so a half-installed unit cannot activate at the next login.
4. **Failure of the rollback is reported, not hidden**: `wrapInstallRollback` returns either `… (rolled back: the previous service definition at X was restored)` or `… ; ROLLBACK INCOMPLETE: <each thing that could not be undone>`.

systemd gets one extra guarantee for free: because the prior state is captured with `is-active`/`is-enabled` **before** the unit is written, an unreachable user manager now fails the install with **nothing mutated at all**. (`TestSystemdManager_InstallFailsBeforeWritingWhenBusUnreachable_724`.)

**What remains non-atomic, explicitly:**
- **The downtime window.** On launchd, install must `bootout` before `bootstrap`; on failure the old daemon is down until the rollback boots it back in. Rollback *closes* that window, it cannot prevent it.
- **`enable --now` is two systemd operations** (link + start) with no combined undo, so a failure can leave the replacement briefly enabled or started. Rollback reverses it with `disable --now`; the window exists.
- **A rollback step can itself fail** (permissions revoked mid-install, bus dies). There is no third-level undo — this is precisely why it is reported verbatim instead of summarized.
- **No cross-process locking.** Two concurrent `service install` runs on the same label can still interleave; the `rename()` keeps the file coherent but the supervisor state is last-writer-wins. Out of scope here.

## #725 — Linux status distinguishes "stopped" from "could not answer"

`is-active` / `is-enabled` exit non-zero for the *normal* inactive/disabled/not-found verdicts, which is why their errors were discarded — and that also discarded dead buses, permission denials, and a missing `systemctl`, after which status was reconstructed from the on-disk file as `installed: true, running: false`.

**No new status vocabulary was invented.** Status is modelled as `serviceState{Installed, Running, Detail, UnitPath}` plus an `error` return, and the darwin backend *already* uses that error return for exactly this case ("only known not-found phrases are absent; everything else is returned"). Linux now does the same, so both backends express "could not answer" identically and `--json` gets the existing structured `writeCLIError` payload. `Detail` strings are unchanged.

The discriminator is the **verdict word**, matched on any output line (`runCmd` merges stderr, and some systemd versions print `Failed to get unit file state for x.service: No such file or directory` alongside — or instead of — `not-found`). Documented verdicts → normal state. An absent-unit diagnostic → the query's absent verdict. Anything else → error.

Deliberately **not** changed: a unit in systemd's `failed` state still reports `installed, not running`. That is a real second honesty gap, but it is not one of these four issues and it would change `Detail`, which is user-visible text.

---

## `--json` contract

**One additive field**, on `service install` only:

```json
"missing_credentials": ["AWS_SECRET_ACCESS_KEY"]
```

Names only, never values; `null`/absent-equivalent when nothing is missing. `persisted_credentials` and `failed_credentials` keep their meaning; no field was removed or renamed. `service status` and `service uninstall` payloads are byte-identical — #725 and #723 surface failures through the existing `writeCLIError` structured-error path, not through new fields.

**Checked for anything pinning the old shape**: nothing in `tests/` asserts on any `service` JSON payload, and the spec submodule does not document the `service` command at all (so no `dirstral-spec` PR is needed). `README.md` is the only doc that describes `service install` behaviour and is updated in this PR.

---

## Testing — every test proven to fail first

Each proof reverted **only the source**, keeping the new tests, and re-ran.

| issue | tests | proof |
|---|---|---|
| **#722** | `TestPersistAndWarnCredentials_{S3CapturesAWSKeys,ReportsMissingRequiredSecret,PgvectorDSNRequired}_722` | with `runtimeRefs` forced empty (exact pre-#722 behaviour): **3 FAIL** |
| **#723/#724 launchd** | `TestLaunchdManager_{UninstallKeepsPlistOnBootoutFailure_723, InstallRollsBackPriorServiceOnBootstrapFailure_724, InstallRollsBackOnKickstartFailure_724, InstallKeepsPriorServiceOnBootoutFailure_724, InstallCleansUpFailedFirstInstall_724, InstallReportsIncompleteRollback_724}` | with `service_darwin.go` restored from `main`: **6 FAIL** |
| **#723/#724/#725 systemd** | `TestSystemdManager_{StatusFailsWhenSystemctlCannotAnswer_725, UninstallKeepsUnitOnDisableFailure_723, InstallRestoresPriorUnitOnEnableFailure_724, InstallRestoresPriorUnitOnReloadFailure_724, InstallCleansUpFailedFirstInstall_724, InstallFailsBeforeWritingWhenBusUnreachable_724, InstallReportsIncompleteRollback_724}` | with `service_linux.go` restored from `main`: **7 FAIL** |

The systemd backend is `//go:build linux` and this was developed on darwin, so those tests were executed locally by copying `service_linux{,_test}.go` to un-suffixed filenames and disabling the darwin backend — the manager is pure file+exec logic with no linux syscalls, so it runs identically. Both the fail-first and pass-after runs were done that way; the temporary copies are not in the diff. CI runs them natively on `ubuntu-latest`.

**Fakes**: the existing `newFakeLaunchd`/`newFakeSystemd` helpers returned one canned `(output, error)` for *every* command, which cannot express "step 3 fails". They are replaced by a shared `scriptedRunner` (in the untagged `service_test.go`, so both backends share it) that queues results **per subcommand** — so a test can fail `bootstrap` on the install and succeed on the rollback's re-bootstrap, and assert the exact call sequence afterwards. `newFakeSystemd` defaults the `is-active`/`is-enabled` probes to the verdicts real systemd gives for an unknown unit.

Also added, running on every platform (the same reason `renderSystemdUnit` is tested in the untagged file): `TestSystemctlQueryClassify_725` (12 cases incl. the dead-bus/absent-unit collision), `TestSystemctlReportsAbsent_723`, `TestLaunchctlBootoutReportsAbsent_723`, `TestUnitTxn_*_724`, `TestWrapInstallRollback_724`, and `tests/config/runtime_secrets_722_test.go`.

Two bugs found in my **own** line-review, both now pinned by tests:
- capturing an `AWS_*` credential wrongly suppressed the pre-existing "no persisted provider credential" warning (`…AWSCaptureDoesNotSilenceProviderWarning_722`);
- `unitTxn` reused the prior file's mode for the *replacement*, so a stray `0600` plist would narrow every future install (`…ReplacementDoesNotInheritPriorMode_724`).

---

## Constraints checked

- `make check` passes (fmt, vet, golangci-lint, gocyclo, ineffassign, misspell, full test suite, build). `GOOS=linux go vet ./...` clean.
- **gocyclo `-over 15`**: 0 findings. Worst touched function is 9 (`launchdManager.install`); the rollback logic is split into `rollbackInstall` / `restorePriorUnit` / `captureUnitState` / `queryState` / `systemctlQuery.classify` precisely to keep it there.
- **`tests/security/cli_boundary_test.go`**: checked — **no new files under `internal/cli/`**, so the allowlist needs no change (verified by running the suite). New files are `internal/config/runtime_secrets.go` and `tests/config/runtime_secrets_722_test.go`, neither of which is allowlisted.
- Rebased on current `main` (`ff01584`), fast-forward, trial-merge clean.
- **#738 and #721 preserved**: `serviceWorkingDirBase` / `resolveServiceDirs` / `installServiceArgs` are untouched, and their tests (`*_738`) still pass. `.env.local` is still written to `sc.workingDir`, which for a remote corpus is the config file's directory — and this PR *strengthens* that: the AWS credentials #722 now persists land in exactly the `.env.local` #738 made the daemon boot next to.

## Adjacent gap found, deliberately not fixed

`ProviderEnvVarRefs` scans `api_key` but **not** `base_url`, although `toProfiles` env-expands both (`providers.go:657` vs `:662`). A `${VAR}` in a profile's `base_url` is therefore never persisted by `service install` — the same class of bug as #722. It is not a one-line fix: the built-in `whisper`/`omniembed`/`colbert` profiles use `${WHISPER_BASE_URL}` etc., so adding those refs would also widen the "is any provider credential persisted?" check and could suppress the missing-credential warning. Worth its own issue rather than a silent scope extension here.
