### PR TITLE
security(x402): enforce the v2 nonce and validity window before Verify (#699)

### DIFF
--- a/internal/mcp/payment.go
+++ b/internal/mcp/payment.go
@@ -122,10 +122,17 @@ func (s *Server) handleToolsCallRequest(ctx context.Context, w http.ResponseWrit
 	now := time.Now().UTC()
 	parsed := parsePaymentPayload(paymentSignature)
 
-	// Validity window (bs-010): reject a proof whose validAfter/validBefore
-	// window does not cover now, or whose age exceeds maxTimeoutSeconds. This is
-	// enforced adapter-side and does not rely on the facilitator alone.
-	if reason := validityWindowError(parsed, s.x402Requirement.MaxTimeoutSeconds, now); reason != "" {
+	// The v2 primitives the adapter spec makes normative: a client-signed
+	// single-use nonce and a validity window whose age is bounded by the
+	// matched maxTimeoutSeconds. Checked BEFORE the facilitator call, because
+	// "MUST NOT rely on the facilitator alone for the time check" and because a
+	// facilitator that approves a proof the adapter cannot inspect would
+	// otherwise bypass every local control (#699).
+	//
+	// Strict only in `required` mode. `on` is documented as fail-open on
+	// incomplete input and keeps its previous tolerance.
+	strictProof := strings.EqualFold(strings.TrimSpace(s.cfg.X402.Mode), x402.ModeRequired)
+	if reason := v2ProofError(parsed, strictProof, s.x402Requirement.MaxTimeoutSeconds, now); reason != "" {
 		s.rejectPaymentWindow(w, id, reason)
 		return
 	}

--- a/internal/mcp/paymentpayload.go
+++ b/internal/mcp/paymentpayload.go
@@ -14,11 +14,14 @@ import (
 
 // parsedPaymentPayload carries the x402 v2 primitives the adapter enforces
 // server-side: the client's single-use authorization nonce and its
-// validAfter/validBefore validity window. These fields already exist in the
-// x402 v2 PaymentPayload wire format; this revision enforces them rather than
-// adding new fields. Fields are best-effort: an opaque or legacy PAYMENT-SIGNATURE
-// that carries no authorization leaves HasNonce/HasWindow false and the caller
-// falls back to a signature-derived nonce with no window check.
+// validAfter/validBefore validity window. Both already exist in the v2
+// PaymentPayload wire format; the adapter enforces them rather than adding new
+// fields.
+//
+// Parsing stays best-effort and reports what it found. Deciding whether an
+// absent primitive is fatal belongs to `v2ProofError`, because the answer
+// depends on the configured mode: `required` fails closed, `on` is documented
+// as fail-open on incomplete configuration and keeps the legacy tolerance.
 type parsedPaymentPayload struct {
 	Nonce       string
 	HasNonce    bool
@@ -113,11 +116,16 @@ func parseUnixSeconds(raw json.RawMessage) (int64, bool) {
 }
 
 // replayNonce returns the ledger key for a payment. When the payload carries an
-// authorization nonce it is used verbatim (single-use replay keys off the
-// client-signed nonce, per spec). Otherwise a deterministic signature-derived
-// fallback is used so an opaque/legacy signature is still single-use per its own
-// bytes (never keyed off the raw request bytes, so retry-vs-replay classification
-// still holds).
+// authorization nonce it is used verbatim, because the adapter spec requires
+// replay detection to key off the client-signed nonce and NOT the raw request
+// bytes.
+//
+// The signature-derived fallback below is for `x402.mode=on` only, and it is a
+// materially weaker guarantee: an opaque proof is single-use per its own bytes
+// rather than per a client-signed single-use value, and its ledger entry
+// expires on the local TTL rather than with the proof. In `required` mode
+// `v2ProofError` rejects a payload with no nonce before this is ever reached,
+// so required mode never keys a payment off a signature hash (#699).
 func replayNonce(paymentSignature string, parsed parsedPaymentPayload) string {
 	if parsed.HasNonce {
 		return "n:" + parsed.Nonce
@@ -126,13 +134,58 @@ func replayNonce(paymentSignature string, parsed parsedPaymentPayload) string {
 	return "s:" + hex.EncodeToString(sum[:])
 }
 
-// validityWindowError reports whether the payment's validity window fails to
-// cover now, or exceeds the matched maxTimeoutSeconds. It returns a non-empty
-// reason string when the proof must be rejected. When the payload carries no
-// window (legacy/opaque signature) it returns "" (no enforcement possible).
-func validityWindowError(parsed parsedPaymentPayload, maxTimeoutSeconds int, now time.Time) string {
+// v2ProofError reports why a payment proof must be rejected before the adapter
+// calls the facilitator, or "" when it may proceed.
+//
+// The adapter spec makes the v2 primitives normative: the authorization nonce
+// "MUST be treated as single-use", "Replay detection MUST key off the
+// authorization nonce", the adapter "MUST reject a proof whose
+// validAfter/validBefore window does not cover the current time", and it "MUST
+// enforce the matched PaymentRequirements.maxTimeoutSeconds as the maximum age
+// between challenge and PAYMENT-SIGNATURE" and "MUST NOT rely on the
+// facilitator alone for the time check".
+//
+// The implementation parsed all of that as optional. An opaque or partially
+// malformed payload left HasNonce/HasWindow false, the nonce fell back to
+// SHA-256 of the signature, the window check returned success, and the request
+// proceeded to Verify and to tool execution even in `required` mode. A
+// facilitator that approved a proof shape the adapter could not inspect
+// therefore bypassed every local control, and the signature-derived ledger
+// entry expired on the local TTL after which the identical timeless proof was
+// classified fresh and could execute again (#699).
+//
+// `strict` is `x402.mode=required`. `on` keeps the previous tolerance, because
+// fail-open on incomplete input is that mode's documented meaning; the
+// difference between the two modes is now real rather than nominal.
+//
+// On maxTimeoutSeconds: the spec bounds the AGE of the proof, not its remaining
+// life. The previous check measured `validBefore - now`, so a window that
+// opened arbitrarily far in the past but closes soon passed unimpeded, which is
+// exactly the shape a stale replayed proof has. Age is measured from
+// `validAfter`, which is the only signed statement in the payload about when
+// the authorization began, so strict mode requires it to be set: without it the
+// age the spec mandates cannot be computed at all, and pretending otherwise is
+// how the requirement stayed nominal.
+func v2ProofError(parsed parsedPaymentPayload, strict bool, maxTimeoutSeconds int, now time.Time) string {
+	if maxTimeoutSeconds <= 0 {
+		maxTimeoutSeconds = x402.DefaultMaxTimeoutSeconds
+	}
+	if strict {
+		if !parsed.HasNonce {
+			return "payment authorization is missing a nonce"
+		}
+		if !parsed.HasWindow {
+			return "payment authorization is missing a validity window"
+		}
+		if parsed.ValidAfter <= 0 {
+			return "payment authorization is missing validAfter"
+		}
+	}
 	if !parsed.HasWindow {
 		return ""
+	}
+	if parsed.ValidBefore <= parsed.ValidAfter {
+		return "payment authorization has an empty validity window"
 	}
 	nowUnix := now.UTC().Unix()
 	if nowUnix < parsed.ValidAfter {
@@ -141,15 +194,21 @@ func validityWindowError(parsed parsedPaymentPayload, maxTimeoutSeconds int, now
 	if nowUnix > parsed.ValidBefore {
 		return "payment authorization has expired"
 	}
-	if maxTimeoutSeconds <= 0 {
-		maxTimeoutSeconds = x402.DefaultMaxTimeoutSeconds
-	}
-	// Bound the remaining validity of the proof by the matched maxTimeoutSeconds:
-	// a client following the challenge sets validBefore ≈ now + maxTimeoutSeconds,
-	// so a window that stays valid far longer than the advertised maximum is
-	// rejected. Measured against validBefore (not validAfter) so the common
-	// validAfter=0 encoding is not false-rejected.
-	if parsed.ValidBefore-nowUnix > int64(maxTimeoutSeconds) {
+	// The age bound, per spec. Only computable when validAfter is set; in `on`
+	// mode a payload without it keeps the older remaining-time bound rather
+	// than going unchecked entirely.
+	if parsed.ValidAfter > 0 {
+		// Age only. A separate bound on the window's total LIFETIME was written
+		// first and removed: the spec mandates the age between challenge and
+		// signature and nothing about how long a client's window may span, and
+		// the extra rule rejected an ordinary `now-5 .. now+60` proof under a
+		// 300s maximum. The age check already refuses the shape #699 names — a
+		// window opened arbitrarily far in the past that closes soon — so the
+		// lifetime bound bought nothing and cost working payments.
+		if nowUnix-parsed.ValidAfter > int64(maxTimeoutSeconds) {
+			return "payment authorization is older than the maximum validity window"
+		}
+	} else if parsed.ValidBefore-nowUnix > int64(maxTimeoutSeconds) {
 		return "payment authorization exceeds the maximum validity window"
 	}
 	return ""

--- a/tests/conformance/x402_test.go
+++ b/tests/conformance/x402_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dirstral/dir2mcp/internal/config"
 	"github.com/dirstral/dir2mcp/internal/mcp"
 	"github.com/dirstral/dir2mcp/internal/x402"
 )
@@ -24,13 +25,16 @@ import (
 // fixture is therefore refused there by design. That matters for a CONFORMANCE
 // suite in particular: asserting that an opaque proof is accepted in required
 // mode was asserting the non-conformance this fixes.
-func validV2Signature(t *testing.T) string {
+func validV2Signature(t *testing.T, cfg config.Config) string {
 	t.Helper()
 	now := time.Now().UTC().Unix()
+	// The CONFIGURED scheme/network, not a hardcoded pair: a proof that does
+	// not match the requirement it is verified against would make this pass for
+	// the wrong reason.
 	raw, err := json.Marshal(map[string]interface{}{
 		"x402Version": 2,
-		"scheme":      "exact",
-		"network":     "eip155:8453",
+		"scheme":      strings.TrimSpace(cfg.X402.Scheme),
+		"network":     strings.TrimSpace(cfg.X402.Network),
 		"payload": map[string]interface{}{
 			"authorization": map[string]interface{}{
 				"nonce":       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
@@ -193,7 +197,7 @@ func TestX402_ModeRequired_ValidPaymentAccepted(t *testing.T) {
 
 	sid := initSession(t, srv.URL+cfg.MCPPath)
 	resp := sendRPC(t, srv.URL+cfg.MCPPath, sid, statsCallBody(6), map[string]string{
-		paymentSignatureHeader: validV2Signature(t),
+		paymentSignatureHeader: validV2Signature(t, cfg),
 	})
 	body := readBody(t, resp)
 

--- a/tests/conformance/x402_test.go
+++ b/tests/conformance/x402_test.go
@@ -1,12 +1,14 @@
 package conformance
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/dirstral/dir2mcp/internal/mcp"
 	"github.com/dirstral/dir2mcp/internal/x402"
@@ -15,6 +17,34 @@ import (
 // TestX402_ModeOff_NoPaymentHeaders verifies that when mode=off, tools/call
 // succeeds without any payment header, and no PAYMENT-REQUIRED header is set
 // on the response.
+// validV2Signature builds a syntactically complete x402 v2 PAYMENT-SIGNATURE.
+//
+// The adapter spec makes the v2 primitives normative, and `required` mode now
+// enforces them adapter-side before calling the facilitator (#699). An opaque
+// fixture is therefore refused there by design. That matters for a CONFORMANCE
+// suite in particular: asserting that an opaque proof is accepted in required
+// mode was asserting the non-conformance this fixes.
+func validV2Signature(t *testing.T) string {
+	t.Helper()
+	now := time.Now().UTC().Unix()
+	raw, err := json.Marshal(map[string]interface{}{
+		"x402Version": 2,
+		"scheme":      "exact",
+		"network":     "eip155:8453",
+		"payload": map[string]interface{}{
+			"authorization": map[string]interface{}{
+				"nonce":       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+				"validAfter":  now - 5,
+				"validBefore": now + 60,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal v2 payload: %v", err)
+	}
+	return base64.StdEncoding.EncodeToString(raw)
+}
+
 func TestX402_ModeOff_NoPaymentHeaders(t *testing.T) {
 	t.Parallel()
 	cfg := defaultConfig()
@@ -163,7 +193,7 @@ func TestX402_ModeRequired_ValidPaymentAccepted(t *testing.T) {
 
 	sid := initSession(t, srv.URL+cfg.MCPPath)
 	resp := sendRPC(t, srv.URL+cfg.MCPPath, sid, statsCallBody(6), map[string]string{
-		paymentSignatureHeader: "valid-sig",
+		paymentSignatureHeader: validV2Signature(t),
 	})
 	body := readBody(t, resp)
 

--- a/tests/mcp/x402_v2_proof_enforcement_699_test.go
+++ b/tests/mcp/x402_v2_proof_enforcement_699_test.go
@@ -65,6 +65,26 @@ func v2Payload(t *testing.T, nonce string, validAfter, validBefore int64) string
 	return base64.StdEncoding.EncodeToString(raw)
 }
 
+// v2PayloadRawAuth builds a payload whose authorization block is supplied
+// verbatim, so a test can put a WRONG-TYPED value where a timestamp belongs.
+// v2Payload can only omit a field or set an integer, and "malformed" is a
+// distinct case from "missing": the parser has to refuse a string, an object
+// and a float where it expects unix seconds, rather than silently reading them
+// as absent and falling through to the lenient path.
+func v2PayloadRawAuth(t *testing.T, auth map[string]interface{}) string {
+	t.Helper()
+	raw, err := json.Marshal(map[string]interface{}{
+		"x402Version": 2,
+		"scheme":      "exact",
+		"network":     "eip155:8453",
+		"payload":     map[string]interface{}{"authorization": auth},
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	return base64.StdEncoding.EncodeToString(raw)
+}
+
 func freshNonce() string {
 	return "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 }
@@ -148,6 +168,30 @@ func TestRequiredModeRejectsProofsMissingAV2Primitive(t *testing.T) {
 			// old remaining-time-only check let straight through.
 			name:      "stale window closing soon",
 			signature: v2Payload(t, freshNonce(), now-86400, now+30),
+		},
+		{
+			name: "validAfter is a string",
+			signature: v2PayloadRawAuth(t, map[string]interface{}{
+				"nonce": freshNonce(), "validAfter": "not-a-timestamp", "validBefore": now + 60,
+			}),
+		},
+		{
+			name: "validBefore is an object",
+			signature: v2PayloadRawAuth(t, map[string]interface{}{
+				"nonce": freshNonce(), "validAfter": now - 5, "validBefore": map[string]interface{}{},
+			}),
+		},
+		{
+			name: "validBefore is a bool",
+			signature: v2PayloadRawAuth(t, map[string]interface{}{
+				"nonce": freshNonce(), "validAfter": now - 5, "validBefore": true,
+			}),
+		},
+		{
+			name: "nonce is not a string",
+			signature: v2PayloadRawAuth(t, map[string]interface{}{
+				"nonce": 12345, "validAfter": now - 5, "validBefore": now + 60,
+			}),
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/tests/mcp/x402_v2_proof_enforcement_699_test.go
+++ b/tests/mcp/x402_v2_proof_enforcement_699_test.go
@@ -1,0 +1,229 @@
+package tests
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/mcp"
+)
+
+// #699: the adapter parsed the x402 v2 primitives as optional best effort. An
+// opaque or partially malformed PAYMENT-SIGNATURE left HasNonce/HasWindow
+// false, the replay key fell back to SHA-256 of the signature, the window check
+// returned success, and the request proceeded to facilitator Verify and to tool
+// execution EVEN IN `required` MODE.
+//
+// The adapter spec makes all of it normative: the authorization nonce "MUST be
+// treated as single-use", "Replay detection MUST key off the authorization
+// nonce", the adapter "MUST reject a proof whose validAfter/validBefore window
+// does not cover the current time", and it "MUST enforce the matched
+// PaymentRequirements.maxTimeoutSeconds as the maximum age between challenge and
+// PAYMENT-SIGNATURE" while "MUST NOT rely on the facilitator alone for the time
+// check".
+//
+// So a facilitator that approved a proof shape the adapter could not inspect
+// bypassed every local control, and the signature-derived ledger entry expired
+// on the local TTL, after which the identical timeless proof was classified
+// fresh and could execute and settle again.
+//
+// Every test here asserts the facilitator's Verify was NEVER called. That is
+// the actual requirement: rejecting after Verify would still have asked a third
+// party to approve a proof the adapter is required to refuse itself.
+
+// v2Payload builds a syntactically valid x402 v2 PAYMENT-SIGNATURE.
+func v2Payload(t *testing.T, nonce string, validAfter, validBefore int64) string {
+	t.Helper()
+	auth := map[string]interface{}{}
+	if nonce != "" {
+		auth["nonce"] = nonce
+	}
+	if validAfter >= 0 {
+		auth["validAfter"] = validAfter
+	}
+	if validBefore >= 0 {
+		auth["validBefore"] = validBefore
+	}
+	// A complete v2 envelope, not just the authorization block: the facilitator
+	// client detects the version from x402Version and refuses a payload without
+	// it, so a fixture carrying only the authorization would be rejected
+	// downstream and would tell us nothing about the adapter-side check.
+	raw, err := json.Marshal(map[string]interface{}{
+		"x402Version": 2,
+		"scheme":      "exact",
+		"network":     "eip155:8453",
+		"payload":     map[string]interface{}{"authorization": auth},
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	return base64.StdEncoding.EncodeToString(raw)
+}
+
+func freshNonce() string {
+	return "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+}
+
+// callWithProof runs one paid tools/call in x402.mode=required and returns the
+// HTTP status plus how many times the facilitator's Verify was invoked.
+func callWithProof(t *testing.T, signature string) (int, int64, string) {
+	t.Helper()
+	fac := newFacilitatorStub(t)
+	fac.verifyStatus = http.StatusOK
+	fac.settleStatus = http.StatusOK
+	fac.verifyBody = `{"ok":true,"isValid":true,"payer":"payer-1"}`
+	fac.settleBody = `{"ok":true,"success":true,"transaction":"abc123","txHash":"abc123","network":"eip155:8453"}`
+	facServer := httptest.NewServer(fac)
+	defer facServer.Close()
+
+	cfg := x402EnabledTestConfig("https://resource.example.com")
+	cfg.AuthMode = "none"
+	cfg.X402.Mode = "required"
+	cfg.X402.FacilitatorURL = facServer.URL
+
+	server := httptest.NewServer(mcp.NewServer(cfg, nil).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPCWithHeaders(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":700,"method":"tools/call","params":{"name":"dir2mcp_stats","arguments":{}}}`,
+		map[string]string{"PAYMENT-SIGNATURE": signature})
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, fac.verifyCalls.Load(), string(body)
+}
+
+func TestRequiredModeRejectsProofsMissingAV2Primitive(t *testing.T) {
+	now := time.Now().UTC().Unix()
+	for _, tc := range []struct {
+		name      string
+		signature string
+	}{
+		{
+			// The exact fixture the existing suite used to demonstrate success.
+			name:      "opaque legacy token",
+			signature: "signed-payment-payload",
+		},
+		{
+			name:      "no nonce",
+			signature: v2Payload(t, "", now-10, now+60),
+		},
+		{
+			name:      "empty nonce",
+			signature: v2Payload(t, "   ", now-10, now+60),
+		},
+		{
+			name:      "no validity window",
+			signature: v2Payload(t, freshNonce(), -1, -1),
+		},
+		{
+			name:      "validBefore only",
+			signature: v2Payload(t, freshNonce(), -1, now+60),
+		},
+		{
+			// The age the spec mandates cannot be computed without validAfter,
+			// which is how the requirement stayed nominal.
+			name:      "validAfter unset (zero)",
+			signature: v2Payload(t, freshNonce(), 0, now+60),
+		},
+		{
+			name:      "window already expired",
+			signature: v2Payload(t, freshNonce(), now-600, now-300),
+		},
+		{
+			name:      "window not yet valid",
+			signature: v2Payload(t, freshNonce(), now+300, now+600),
+		},
+		{
+			name:      "empty window",
+			signature: v2Payload(t, freshNonce(), now, now),
+		},
+		{
+			// Opened arbitrarily far in the past, closes soon: the shape the
+			// old remaining-time-only check let straight through.
+			name:      "stale window closing soon",
+			signature: v2Payload(t, freshNonce(), now-86400, now+30),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			status, verifyCalls, body := callWithProof(t, tc.signature)
+			if status == http.StatusOK {
+				t.Fatalf("required mode executed the tool for %s; body=%s", tc.name, body)
+			}
+			if verifyCalls != 0 {
+				t.Fatalf("facilitator Verify was called %d times for %s; the adapter must refuse this itself rather than ask a third party",
+					verifyCalls, tc.name)
+			}
+		})
+	}
+}
+
+// TestRequiredModeAcceptsAWellFormedV2Proof is the other half: the enforcement
+// must not refuse a proof that satisfies the spec, or it would simply break
+// payments instead of securing them.
+func TestRequiredModeAcceptsAWellFormedV2Proof(t *testing.T) {
+	now := time.Now().UTC().Unix()
+	status, verifyCalls, body := callWithProof(t, v2Payload(t, freshNonce(), now-5, now+60))
+	if status != http.StatusOK {
+		t.Fatalf("a well-formed v2 proof was rejected: status=%d body=%s", status, body)
+	}
+	if verifyCalls != 1 {
+		t.Fatalf("facilitator Verify called %d times, want 1", verifyCalls)
+	}
+}
+
+// TestModeOnKeepsItsDocumentedTolerance: `on` is specified as fail-open on
+// incomplete input, and CLAUDE.md records that as its meaning. Tightening it
+// here would change a documented mode's contract under cover of a security fix.
+func TestModeOnKeepsItsDocumentedTolerance(t *testing.T) {
+	fac := newFacilitatorStub(t)
+	fac.verifyStatus = http.StatusOK
+	fac.settleStatus = http.StatusOK
+	fac.verifyBody = `{"ok":true,"isValid":true,"payer":"payer-1"}`
+	fac.settleBody = `{"ok":true,"success":true,"transaction":"abc123","txHash":"abc123","network":"eip155:8453"}`
+	facServer := httptest.NewServer(fac)
+	defer facServer.Close()
+
+	cfg := x402EnabledTestConfig("https://resource.example.com")
+	cfg.AuthMode = "none"
+	cfg.X402.Mode = "on"
+	cfg.X402.FacilitatorURL = facServer.URL
+
+	server := httptest.NewServer(mcp.NewServer(cfg, nil).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPCWithHeaders(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":701,"method":"tools/call","params":{"name":"dir2mcp_stats","arguments":{}}}`,
+		map[string]string{"PAYMENT-SIGNATURE": "signed-payment-payload"})
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(resp.Body)
+		t.Fatalf("mode=on rejected an opaque proof: status=%d body=%s", resp.StatusCode, payload)
+	}
+}
+
+// TestRequiredModeRejectionNamesTheMissingPrimitive: an operator debugging a
+// declined payment needs to know WHICH control refused it, and the message must
+// not be so vague that a client cannot correct its payload.
+func TestRequiredModeRejectionNamesTheMissingPrimitive(t *testing.T) {
+	now := time.Now().UTC().Unix()
+	for _, tc := range []struct {
+		signature string
+		want      string
+	}{
+		{v2Payload(t, "", now-10, now+60), "nonce"},
+		{v2Payload(t, freshNonce(), -1, -1), "validity window"},
+		{v2Payload(t, freshNonce(), now-86400, now+30), "older than"},
+	} {
+		_, _, body := callWithProof(t, tc.signature)
+		if !strings.Contains(strings.ToLower(body), tc.want) {
+			t.Fatalf("rejection body does not name %q: %s", tc.want, body)
+		}
+	}
+}

--- a/tests/x402/parity_test.go
+++ b/tests/x402/parity_test.go
@@ -214,13 +214,17 @@ func TestParityModeOff_NoPaymentHeaderPassesThrough(t *testing.T) {
 // facilitator, acceptance of a good payment — and an opaque fixture would now
 // exercise the proof check instead of the thing under test, which is exactly
 // the confusion that let the vulnerable behaviour read as a passing suite.
-func validV2Signature(t *testing.T) string {
+func validV2Signature(t *testing.T, cfg config.Config) string {
 	t.Helper()
 	now := time.Now().UTC().Unix()
+	// The proof's scheme/network must be the CONFIGURED ones. Hardcoding
+	// eip155:8453 against a Solana requirement produced a proof that does not
+	// match the requirement it is verified against, so the test would have
+	// passed for a reason unrelated to what it claims to check.
 	raw, err := json.Marshal(map[string]interface{}{
 		"x402Version": 2,
-		"scheme":      "exact",
-		"network":     "eip155:8453",
+		"scheme":      strings.TrimSpace(cfg.X402.Scheme),
+		"network":     strings.TrimSpace(cfg.X402.Network),
 		"payload": map[string]interface{}{
 			"authorization": map[string]interface{}{
 				"nonce":       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
@@ -531,7 +535,7 @@ func TestParityModeRequired_ValidPaymentAccepted(t *testing.T) {
 
 	sid := parityInitSession(t, srv.URL+cfg.MCPPath)
 	resp := paritySendRPC(t, srv.URL+cfg.MCPPath, sid, toolsCallBody(10), map[string]string{
-		x402.HeaderPaymentSignature: validV2Signature(t),
+		x402.HeaderPaymentSignature: validV2Signature(t, cfg),
 	})
 	defer func() { _ = resp.Body.Close() }()
 
@@ -567,7 +571,7 @@ func TestParityModeRequired_FacilitatorUnavailableIsFailClosed(t *testing.T) {
 		// A real v2 proof, so the request actually reaches the unavailable
 		// facilitator. With an opaque one the adapter now refuses it first and
 		// the test would pass for the wrong reason.
-		x402.HeaderPaymentSignature: validV2Signature(t),
+		x402.HeaderPaymentSignature: validV2Signature(t, cfg),
 	})
 	defer func() { _ = resp.Body.Close() }()
 

--- a/tests/x402/parity_test.go
+++ b/tests/x402/parity_test.go
@@ -10,6 +10,7 @@ package x402_test
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -205,6 +206,35 @@ func TestParityModeOff_NoPaymentHeaderPassesThrough(t *testing.T) {
 
 // TestParityModeOff_PaymentSignatureIsIgnored verifies that when mode=off,
 // a payment signature header is silently ignored (no facilitator call made).
+// validV2Signature builds a syntactically complete x402 v2 PAYMENT-SIGNATURE.
+//
+// `required` mode enforces the v2 primitives adapter-side before it calls the
+// facilitator (#699), so an opaque token is refused there by design. These
+// parity tests are about mode behaviour — fail-closed on an unavailable
+// facilitator, acceptance of a good payment — and an opaque fixture would now
+// exercise the proof check instead of the thing under test, which is exactly
+// the confusion that let the vulnerable behaviour read as a passing suite.
+func validV2Signature(t *testing.T) string {
+	t.Helper()
+	now := time.Now().UTC().Unix()
+	raw, err := json.Marshal(map[string]interface{}{
+		"x402Version": 2,
+		"scheme":      "exact",
+		"network":     "eip155:8453",
+		"payload": map[string]interface{}{
+			"authorization": map[string]interface{}{
+				"nonce":       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+				"validAfter":  now - 5,
+				"validBefore": now + 60,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal v2 payload: %v", err)
+	}
+	return base64.StdEncoding.EncodeToString(raw)
+}
+
 func TestParityModeOff_PaymentSignatureIsIgnored(t *testing.T) {
 	t.Parallel()
 	fac := newParityFacilitator()
@@ -501,7 +531,7 @@ func TestParityModeRequired_ValidPaymentAccepted(t *testing.T) {
 
 	sid := parityInitSession(t, srv.URL+cfg.MCPPath)
 	resp := paritySendRPC(t, srv.URL+cfg.MCPPath, sid, toolsCallBody(10), map[string]string{
-		x402.HeaderPaymentSignature: "valid-sig",
+		x402.HeaderPaymentSignature: validV2Signature(t),
 	})
 	defer func() { _ = resp.Body.Close() }()
 
@@ -534,7 +564,10 @@ func TestParityModeRequired_FacilitatorUnavailableIsFailClosed(t *testing.T) {
 
 	sid := parityInitSession(t, srv.URL+cfg.MCPPath)
 	resp := paritySendRPC(t, srv.URL+cfg.MCPPath, sid, toolsCallBody(11), map[string]string{
-		x402.HeaderPaymentSignature: "sig",
+		// A real v2 proof, so the request actually reaches the unavailable
+		// facilitator. With an opaque one the adapter now refuses it first and
+		// the test would pass for the wrong reason.
+		x402.HeaderPaymentSignature: validV2Signature(t),
 	})
 	defer func() { _ = resp.Body.Close() }()
 


### PR DESCRIPTION
Closes #699.

The adapter parsed the x402 v2 primitives as **optional best effort**. An opaque or partially malformed `PAYMENT-SIGNATURE` left `HasNonce`/`HasWindow` false, the replay key fell back to SHA-256 of the signature, the window check returned success, and the request proceeded to facilitator Verify and to tool execution **even in `required` mode**.

A facilitator that approved a proof shape the adapter could not inspect therefore bypassed every local control — and the signature-derived ledger entry expired on the local TTL, after which the identical timeless proof was classified fresh and could execute and settle **again**.

## Conformance, not a spec change

The adapter spec already makes this normative, so no `dirstral-spec` PR is needed:

- the authorization nonce *"MUST be treated as single-use"*
- *"Replay detection MUST key off the authorization `nonce`"*
- the adapter *"MUST reject a proof whose `validAfter`/`validBefore` window does not cover the current time"*
- and *"MUST enforce the matched `PaymentRequirements.maxTimeoutSeconds` as the maximum age between challenge and `PAYMENT-SIGNATURE`"*, while it *"MUST NOT rely on the facilitator alone for the time check"*

## Before Verify, not after

`v2ProofError` refuses a required-mode proof with no nonce, no window, or no `validAfter` **before the facilitator call**. Rejecting afterwards would still have asked a third party to approve a proof the adapter is required to refuse itself, so **every test asserts Verify was never called**.

## The age bound was measuring the wrong quantity

The spec bounds the **age** of the proof. The old check measured `validBefore - now`, so a window opened arbitrarily far in the past that closes soon passed unimpeded — exactly the shape a stale replayed proof has.

Age requires `validAfter`, the only signed statement in the payload about when the authorization began, so required mode insists on it. Without it the mandated age cannot be computed at all, and pretending otherwise is how the requirement stayed nominal.

## `on` is untouched

Fail-open on incomplete input is that mode's documented meaning (CLAUDE.md). Tightening it under cover of a security fix would change a documented contract. The difference between the two modes is now real rather than nominal.

## One rule I wrote and removed

I first added a bound on the window's total **lifetime**. The spec mandates the age and says nothing about how long a client's window may span, and the extra rule rejected an ordinary `now-5 .. now+60` proof under a 300s maximum. My own acceptance test caught it. The age check already refuses the stale-window shape, so the lifetime bound bought nothing and cost working payments.

## Tests

Ten negative cases plus an acceptance case. **Eight fail pre-fix**, including the opaque `signed-payment-payload` the existing suite used as a *success* fixture.

Three existing required-mode fixtures were opaque tokens and are replaced with real v2 payloads, which is what the issue's acceptance criteria ask for. One of them was in `tests/conformance` — **a conformance suite asserting that an opaque proof is accepted in required mode was asserting the non-conformance this fixes.**

`make check` passes.

## Siblings not in this PR

#697 (persisted outcomes lose nonce-aligned expiry) and #700 (PAYMENT-REQUIRED is not a valid v2 object) are adjacent and left separate so this security fix lands on its own.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Strengthened payment proof validation in required mode by enforcing nonce, validity-window, and `validAfter` checks.
  - Improved rejection messages to identify missing or invalid proof details.
  - Preserved tolerant, fail-open behavior in optional payment mode.
  - Improved replay protection by prioritizing client-signed authorization nonces.

- **Tests**
  - Added comprehensive coverage for valid, invalid, incomplete, and time-bounded payment proofs.
  - Updated conformance checks to use realistic, structured payment signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->