### PR TITLE
fix(ingest): complete the default ignore list and stop dropping valid archive members (#716, #718)

### DIFF
--- a/internal/corpusfs/corpusfs.go
+++ b/internal/corpusfs/corpusfs.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"io"
 	"io/fs"
+	"strings"
 )
 
 // defaultMaxFileSizeBytes mirrors the ingest discovery cap so a zero/negative
@@ -26,12 +27,41 @@ func DefaultMaxFileSizeBytes() int64 {
 
 // defaultExcludedDirs are directory names skipped during discovery regardless of
 // backend. For S3 these are matched against path segments of the object key.
+//
+// SPEC §7.1 makes `.git/`, `node_modules/`, `dist/`, `build/`, `.venv/`, and
+// `.dir2mcp/` the normative default ignore list; `vendor/` and `__pycache__/`
+// are dir2mcp additions of the same kind (checked-in dependency trees and
+// generated caches). `dist`, `build`, and `.venv` were missing until #716, so a
+// default scan indexed generated bundles, build output, and entire Python
+// virtualenvs that operators had been told were ignored.
+//
+// This set is a hard floor: there is no config key that re-includes an excluded
+// directory (`security.path_excludes` only adds exclusions). Adding a name here
+// therefore removes documents from every existing corpus on the next reindex, so
+// it stays anchored to the spec rather than growing by taste.
 var defaultExcludedDirs = map[string]struct{}{
 	".git":         {},
 	".dir2mcp":     {},
 	"node_modules": {},
 	"vendor":       {},
 	"__pycache__":  {},
+	"dist":         {},
+	"build":        {},
+	".venv":        {},
+}
+
+// IsExcludedDir reports whether a DIRECTORY with this name is skipped by default
+// discovery. It is exported so the ingest file watcher applies the same list as
+// the initial scan: the watcher used to keep its own copy of the map, and the
+// copies drifted (#716).
+//
+// The rule is directory-only. A regular FILE named `dist` or `vendor` is an
+// ordinary corpus document and must still be discovered, so callers must only
+// consult this for entries they already know are directories (the S3 backend
+// tests it against ancestor key segments only).
+func IsExcludedDir(name string) bool {
+	_, ok := defaultExcludedDirs[strings.TrimSpace(name)]
+	return ok
 }
 
 // DiscoveredFile holds metadata collected during corpus discovery.

--- a/internal/corpusfs/corpusfs.go
+++ b/internal/corpusfs/corpusfs.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"io"
 	"io/fs"
-	"strings"
 )
 
 // defaultMaxFileSizeBytes mirrors the ingest discovery cap so a zero/negative
@@ -59,8 +58,14 @@ var defaultExcludedDirs = map[string]struct{}{
 // ordinary corpus document and must still be discovered, so callers must only
 // consult this for entries they already know are directories (the S3 backend
 // tests it against ancestor key segments only).
+//
+// The match is exact. The name is a real directory entry or object key segment,
+// and ` dist ` is a different directory than `dist`: the old TrimSpace here made
+// discovery skip a legitimately-named tree whose documents nothing else would
+// have excluded, which is the same silent over-exclusion this change set exists
+// to remove.
 func IsExcludedDir(name string) bool {
-	_, ok := defaultExcludedDirs[strings.TrimSpace(name)]
+	_, ok := defaultExcludedDirs[name]
 	return ok
 }
 

--- a/internal/corpusfs/local.go
+++ b/internal/corpusfs/local.go
@@ -179,8 +179,7 @@ func ResolveSymlinkWithinRoot(rootResolved, linkPath string) (string, bool) {
 }
 
 func shouldSkipDirectory(name string) bool {
-	_, ok := defaultExcludedDirs[strings.TrimSpace(name)]
-	return ok
+	return IsExcludedDir(name)
 }
 
 type discoverWalker struct {

--- a/internal/corpusfs/s3.go
+++ b/internal/corpusfs/s3.go
@@ -388,7 +388,7 @@ func (s *S3FS) discoveredFromObject(obj s3types.Object, opts Options) (Discovere
 func keyHasExcludedDir(rel string) bool {
 	segs := strings.Split(rel, "/")
 	for _, seg := range segs[:len(segs)-1] {
-		if _, ok := defaultExcludedDirs[seg]; ok {
+		if IsExcludedDir(seg) {
 			return true
 		}
 	}

--- a/internal/ingest/archive.go
+++ b/internal/ingest/archive.go
@@ -9,8 +9,11 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
+
+	"github.com/dirstral/dir2mcp/internal/relpath"
 )
 
 const archiveMemberMaxBytes = 10 * 1024 * 1024 // 10 MiB
@@ -28,6 +31,11 @@ const (
 	// member would exceed this ceiling, bounding peak memory to roughly this value
 	// plus one member (#408).
 	archiveMaxTotalBytes = 512 * 1024 * 1024 // 512 MiB
+	// archiveMaxReportedSkips bounds how many individual refused/dropped members
+	// are retained for the caller's diagnostic (#718). The count is always exact;
+	// only the per-member sample is capped, so a hostile archive with 100k bad
+	// entries cannot turn an observability record into a memory problem.
+	archiveMaxReportedSkips = 20
 )
 
 // memberAccumulator collects archive members while enforcing the member-count
@@ -39,6 +47,12 @@ type memberAccumulator struct {
 	maxMembers   int
 	maxTotalByte int64
 	truncated    bool
+	// seen tracks the rel_paths already accumulated so two members that normalize
+	// onto the same rel_path are reported instead of one silently overwriting the
+	// other in the store (#718). See add.
+	seen map[string]struct{}
+	// skips is the observable record of members this archive did not yield.
+	skips archiveSkips
 }
 
 func newMemberAccumulator(maxMembers int, maxTotalBytes int64) *memberAccumulator {
@@ -48,13 +62,22 @@ func newMemberAccumulator(maxMembers int, maxTotalBytes int64) *memberAccumulato
 	if maxTotalBytes <= 0 {
 		maxTotalBytes = archiveMaxTotalBytes
 	}
-	return &memberAccumulator{maxMembers: maxMembers, maxTotalByte: maxTotalBytes}
+	return &memberAccumulator{
+		maxMembers:   maxMembers,
+		maxTotalByte: maxTotalBytes,
+		seen:         make(map[string]struct{}),
+	}
 }
 
 // add appends a member unless a cap would be exceeded. It returns stop=true when
 // a cap is hit: the member is NOT added and extraction should halt, and the
 // truncated flag is set so the caller surfaces a diagnostic instead of silently
 // dropping the remaining entries.
+//
+// A rel_path already accumulated is recorded as a collision. Both members are
+// kept (rel_path is the store's document key, so the later upsert wins, matching
+// tar's own last-entry-wins extraction semantics), but the earlier member's
+// content stops being reachable, so the collapse is reported rather than silent.
 func (a *memberAccumulator) add(relPath string, content []byte) (stop bool) {
 	if len(a.members) >= a.maxMembers {
 		a.truncated = true
@@ -64,9 +87,54 @@ func (a *memberAccumulator) add(relPath string, content []byte) (stop bool) {
 		a.truncated = true
 		return true
 	}
+	if _, dup := a.seen[relPath]; dup {
+		a.skips.record(relPath, "collides with an earlier member's rel_path; the later member wins")
+	}
+	a.seen[relPath] = struct{}{}
 	a.total += int64(len(content))
 	a.members = append(a.members, archiveMember{RelPath: relPath, Content: content})
 	return false
+}
+
+// archiveMemberSkip names one member an archive declared that did not become a
+// document, and why.
+type archiveMemberSkip struct {
+	// Name is the member name exactly as the archive declared it, never a
+	// rewritten form: the point of the record is what the archive actually said.
+	// (The one exception is a rel_path collision, which by definition is about
+	// the shared normalized path rather than either declared name.)
+	Name string
+	// Reason is a short operator-facing explanation.
+	Reason string
+}
+
+// archiveSkips is the extraction's admission record: how many members were
+// refused or dropped, plus a bounded sample naming them.
+//
+// It exists because a refused member is otherwise invisible: the archive is
+// indexed, the member simply is not there, and nothing distinguishes that from
+// an archive that never contained the file (#718). Options.OnUnsafeKey (#735)
+// and OnOversize (#497) are the same idea at discovery: an admission decision
+// must leave a trace.
+type archiveSkips struct {
+	Entries []archiveMemberSkip
+	Total   int
+}
+
+func (s *archiveSkips) record(name, reason string) {
+	s.Total++
+	if len(s.Entries) < archiveMaxReportedSkips {
+		s.Entries = append(s.Entries, archiveMemberSkip{Name: name, Reason: reason})
+	}
+}
+
+// archiveExtraction is the result of reading one archive: the members to ingest,
+// the record of what was not ingested, and whether a fan-out cap stopped the
+// read early (#408).
+type archiveExtraction struct {
+	Members   []archiveMember
+	Skips     archiveSkips
+	Truncated bool
 }
 
 // errUnsupportedArchiveFormat is returned by extractArchiveMembers when a path
@@ -84,29 +152,93 @@ type archiveMember struct {
 	Content []byte
 }
 
-// isSafeArchivePath returns true when the member path contains no traversal
-// sequences that could escape the extraction root (zip-slip prevention).
-func isSafeArchivePath(p string) bool {
-	if strings.Contains(p, "..") {
-		return false
+// errArchiveMemberTraversal is the refusal for a member name that carries a `..`
+// segment, before or after normalization.
+var errArchiveMemberTraversal = errors.New("member name has a `..` segment")
+
+// errArchiveMemberBackslash is the refusal for a member name containing a
+// backslash. See archiveMemberRelPath for why it is refused rather than mapped.
+var errArchiveMemberBackslash = errors.New("member name contains a backslash, which is a path separator on Windows")
+
+// archiveMemberRelPath validates an archive member's declared name and returns
+// the corpus-relative path the member is stored under, or an error explaining
+// the refusal.
+//
+// # Containment
+//
+// internal/relpath is the one containment rule for a corpus-relative path
+// (SPEC §7.8), and it has the final word here too: whatever this function
+// returns must be a path relpath.Normalize accepts, so an archive member can
+// never be admitted under a name that S3 discovery or the local walker would
+// refuse. Membership in `<archive>/...` is then guaranteed by construction:
+// caller prefixes the archive's own (already valid) rel_path.
+//
+// # Why this is not relpath.Normalize on its own
+//
+// relpath deliberately REJECTS rather than cleans a path that would change under
+// normalization: an S3 key is the address used to re-fetch the object, so
+// rewriting `a//b.txt` to `a/b.txt` would make discovery record a rel_path that
+// Open later resolves to a DIFFERENT object.
+//
+// An archive member is not an address. Its bytes are read from the archive
+// stream by position, never re-resolved by name, so normalizing the name cannot
+// retarget anything. And the difference is not academic. `tar -czf x.tgz .`,
+// the most common way a tarball is produced, names every member `./file.txt`,
+// which relpath.Normalize refuses. Applying the S3 rule verbatim would refuse
+// entire ordinary tarballs, trading one silent-drop bug for a much larger one.
+//
+// So pure normalization noise (`./`, `//`, a trailing `/`) is cleaned. What
+// cleaning CAN still do is collapse two distinct members onto one rel_path; that
+// is bounded to inside the archive's namespace and is reported by
+// memberAccumulator.add rather than left silent.
+//
+// # Refused
+//
+//   - an empty or whitespace-only name
+//   - a backslash anywhere: it is a legal byte in a POSIX member name and a path
+//     separator on Windows, where `..\escape` escapes exactly as `../escape`
+//     does. We cannot tell the two apart from the name alone, and guessing wrong
+//     in the unsafe direction is a traversal. Same call relpath makes.
+//   - an absolute name (`/etc/passwd`, `//etc/passwd`)
+//   - any `..` segment, checked BEFORE cleaning as well as after. `a/../b` does
+//     not escape, but cleaning it to `b` would file the member under a name the
+//     archive gave to a different entry, so it is refused rather than guessed at.
+func archiveMemberRelPath(name string) (string, error) {
+	if strings.TrimSpace(name) == "" {
+		return "", relpath.ErrNotRelative
 	}
-	// filepath.Clean normalises slashes; reject anything that escapes root.
-	cleaned := filepath.ToSlash(filepath.Clean("/" + p))
-	return strings.HasPrefix(cleaned, "/") && !strings.HasPrefix(cleaned, "/..")
+	if strings.Contains(name, `\`) {
+		return "", errArchiveMemberBackslash
+	}
+	if strings.HasPrefix(name, "/") {
+		return "", relpath.ErrOutsideRoot
+	}
+	if relpath.HasDotDotSegment(name) {
+		return "", errArchiveMemberTraversal
+	}
+	// path.Clean (not filepath.Clean): a member path is slash-separated by
+	// definition, and on Windows filepath.Clean would treat a backslash as a
+	// separator (already refused above, but the distinction is load-bearing).
+	cleaned := path.Clean(name)
+	if relpath.HasDotDotSegment(cleaned) {
+		return "", errArchiveMemberTraversal
+	}
+	// relpath has the final word: `.`, an absolute result, or anything else that
+	// is not a usable rel_path is refused here, by the same rule every backend
+	// uses.
+	return relpath.Normalize(cleaned)
 }
 
 // isSafeArchiveMemberName reports whether name is safe to use as the final path
-// segment of a single-compressed member's rel_path. It rejects empty names, the
-// "."/".." traversal segments, embedded path separators, and any ".." sequence
-// (mirroring isSafeArchivePath's traversal rejection).
+// segment of a single-compressed member's rel_path. It rejects empty/blank
+// names, the "."/".." traversal segments, and embedded path separators, but NOT
+// a name that merely contains consecutive dots, which is an ordinary filename
+// (`report..final.txt`).
 func isSafeArchiveMemberName(name string) bool {
-	if name == "" || name == "." || name == ".." {
+	if strings.TrimSpace(name) == "" || name == "." || name == ".." {
 		return false
 	}
-	if strings.ContainsAny(name, `/\`) {
-		return false
-	}
-	return !strings.Contains(name, "..")
+	return !strings.ContainsAny(name, `/\`)
 }
 
 // archiveFormat returns a canonical format string for the archive at relPath,
@@ -134,17 +266,18 @@ func archiveFormat(relPath string) string {
 }
 
 // extractArchiveMembers dispatches to the correct extractor based on archiveFormat.
-// Members that fail path safety checks or exceed archiveMemberMaxBytes are
-// silently skipped; corrupted archives return whatever members were read before
-// the error. An unrecognised format returns errUnsupportedArchiveFormat so the
-// caller can surface a diagnostic instead of silently dropping the document.
+// Members that fail the path rule or exceed archiveMemberMaxBytes are dropped and
+// recorded in the result's Skips so the caller can surface them (#718); corrupted
+// archives return whatever members were read before the error. An unrecognised
+// format returns errUnsupportedArchiveFormat so the caller can surface a
+// diagnostic instead of silently dropping the document.
 //
 // maxMembers and maxTotalBytes bound the member-count and aggregate-uncompressed
-// fan-out (#408); pass 0 for the package defaults. The returned truncated flag is
+// fan-out (#408); pass 0 for the package defaults. The returned Truncated flag is
 // true when extraction stopped early because a cap was hit — the members returned
 // before the cap are still valid and should be ingested, and the caller is
 // expected to log a warning so the truncation is visible.
-func extractArchiveMembers(absPath, archiveRelPath string, maxMembers int, maxTotalBytes int64) (members []archiveMember, truncated bool, err error) {
+func extractArchiveMembers(absPath, archiveRelPath string, maxMembers int, maxTotalBytes int64) (archiveExtraction, error) {
 	switch format := archiveFormat(archiveRelPath); format {
 	case "zip":
 		return extractZipMembers(absPath, archiveRelPath, maxMembers, maxTotalBytes)
@@ -153,7 +286,7 @@ func extractArchiveMembers(absPath, archiveRelPath string, maxMembers int, maxTo
 	case "gz", "bz2":
 		return extractSingleCompressedMember(absPath, archiveRelPath, format, maxMembers, maxTotalBytes)
 	default:
-		return nil, false, errUnsupportedArchiveFormat
+		return archiveExtraction{}, errUnsupportedArchiveFormat
 	}
 }
 
@@ -171,10 +304,10 @@ func extractArchiveMembers(absPath, archiveRelPath string, maxMembers int, maxTo
 // (a single payload), but the size cap must still be respected: a decoded member
 // larger than maxTotalBytes is refused and truncated=true is returned, matching
 // how the zip/tar paths signal truncation.
-func extractSingleCompressedMember(absPath, archiveRelPath, format string, maxMembers int, maxTotalBytes int64) ([]archiveMember, bool, error) {
+func extractSingleCompressedMember(absPath, archiveRelPath, format string, maxMembers int, maxTotalBytes int64) (archiveExtraction, error) {
 	f, err := os.Open(absPath)
 	if err != nil {
-		return nil, false, fmt.Errorf("open compressed file: %w", err)
+		return archiveExtraction{}, fmt.Errorf("open compressed file: %w", err)
 	}
 	defer func() { _ = f.Close() }()
 
@@ -183,7 +316,7 @@ func extractSingleCompressedMember(absPath, archiveRelPath, format string, maxMe
 	case "gz":
 		gr, err := gzip.NewReader(f)
 		if err != nil {
-			return nil, false, fmt.Errorf("gzip reader: %w", err)
+			return archiveExtraction{}, fmt.Errorf("gzip reader: %w", err)
 		}
 		defer func() { _ = gr.Close() }()
 		rd = gr
@@ -192,15 +325,19 @@ func extractSingleCompressedMember(absPath, archiveRelPath, format string, maxMe
 	default:
 		// Guard against a nil reader: the caller only dispatches "gz"/"bz2" here,
 		// but an unexpected value must fail loudly instead of dereferencing nil.
-		return nil, false, fmt.Errorf("unsupported single-compressed format %q", format)
+		return archiveExtraction{}, fmt.Errorf("unsupported single-compressed format %q", format)
 	}
 
 	content, err := io.ReadAll(io.LimitReader(rd, archiveMemberMaxBytes+1))
 	if err != nil {
-		return nil, false, fmt.Errorf("decompress %s: %w", archiveRelPath, err)
+		return archiveExtraction{}, fmt.Errorf("decompress %s: %w", archiveRelPath, err)
 	}
+	acc := newMemberAccumulator(maxMembers, maxTotalBytes)
 	if int64(len(content)) > archiveMemberMaxBytes {
-		return nil, false, nil // payload exceeds per-member cap; skip
+		// Payload exceeds the per-member cap: skipped, but recorded so the drop is
+		// visible rather than an empty archive with no explanation (#718).
+		acc.skips.record(filepath.Base(archiveRelPath), fmt.Sprintf("decompressed payload exceeds the %d-byte per-member cap", int64(archiveMemberMaxBytes)))
+		return archiveExtraction{Skips: acc.skips}, nil
 	}
 
 	base := filepath.Base(archiveRelPath)
@@ -211,23 +348,23 @@ func extractSingleCompressedMember(absPath, archiveRelPath, format string, maxMe
 	// Guard against edge-case archive names whose stripped member name is a
 	// traversal segment (e.g. "..gz" -> "." or "..bz2" -> "."): such a name would
 	// yield a "<archive>/.." style rel_path that escapes the archive namespace.
-	// Mirror isSafeArchivePath's traversal rejection and fall back to a benign
-	// synthetic name.
+	// Fall back to a benign synthetic name, and record the substitution so the
+	// stored name is not silently unrelated to the file on disk.
 	if !isSafeArchiveMemberName(memberName) {
+		acc.skips.record(memberName, "derived member name is not a usable path segment; stored as \"member\"")
 		memberName = "member"
 	}
 	// Route through the shared accumulator so the aggregate-size cap is enforced
 	// consistently with the zip/tar paths: if the single decoded member exceeds
 	// maxTotalBytes, it is refused and truncated=true is surfaced (#408).
-	acc := newMemberAccumulator(maxMembers, maxTotalBytes)
 	acc.add(archiveRelPath+"/"+memberName, content)
-	return acc.members, acc.truncated, nil
+	return archiveExtraction{Members: acc.members, Skips: acc.skips, Truncated: acc.truncated}, nil
 }
 
-func extractZipMembers(absPath, archiveRelPath string, maxMembers int, maxTotalBytes int64) ([]archiveMember, bool, error) {
+func extractZipMembers(absPath, archiveRelPath string, maxMembers int, maxTotalBytes int64) (archiveExtraction, error) {
 	r, err := zip.OpenReader(absPath)
 	if err != nil {
-		return nil, false, fmt.Errorf("open zip: %w", err)
+		return archiveExtraction{}, fmt.Errorf("open zip: %w", err)
 	}
 	defer func() { _ = r.Close() }()
 
@@ -236,32 +373,41 @@ func extractZipMembers(absPath, archiveRelPath string, maxMembers int, maxTotalB
 		if f.FileInfo().IsDir() {
 			continue
 		}
-		if !isSafeArchivePath(f.Name) {
-			continue // zip-slip: skip silently
+		memberRel, err := archiveMemberRelPath(f.Name)
+		if err != nil {
+			acc.skips.record(f.Name, err.Error()) // zip-slip and friends
+			continue
 		}
 		if f.UncompressedSize64 > archiveMemberMaxBytes {
-			continue // member too large
+			acc.skips.record(f.Name, fmt.Sprintf("member exceeds the %d-byte per-member cap", int64(archiveMemberMaxBytes)))
+			continue
 		}
 		rc, err := f.Open()
 		if err != nil {
+			acc.skips.record(f.Name, fmt.Sprintf("open failed: %v", err))
 			continue
 		}
 		content, readErr := io.ReadAll(io.LimitReader(rc, archiveMemberMaxBytes+1))
 		_ = rc.Close()
-		if readErr != nil || int64(len(content)) > archiveMemberMaxBytes {
+		if readErr != nil {
+			acc.skips.record(f.Name, fmt.Sprintf("read failed: %v", readErr))
 			continue
 		}
-		if acc.add(archiveRelPath+"/"+f.Name, content) {
+		if int64(len(content)) > archiveMemberMaxBytes {
+			acc.skips.record(f.Name, fmt.Sprintf("member exceeds the %d-byte per-member cap", int64(archiveMemberMaxBytes)))
+			continue
+		}
+		if acc.add(archiveRelPath+"/"+memberRel, content) {
 			break // member-count or aggregate-size cap hit (#408)
 		}
 	}
-	return acc.members, acc.truncated, nil
+	return archiveExtraction{Members: acc.members, Skips: acc.skips, Truncated: acc.truncated}, nil
 }
 
-func extractTarMembers(absPath, archiveRelPath string, maxMembers int, maxTotalBytes int64) ([]archiveMember, bool, error) {
+func extractTarMembers(absPath, archiveRelPath string, maxMembers int, maxTotalBytes int64) (archiveExtraction, error) {
 	f, err := os.Open(absPath)
 	if err != nil {
-		return nil, false, fmt.Errorf("open tar: %w", err)
+		return archiveExtraction{}, fmt.Errorf("open tar: %w", err)
 	}
 	defer func() { _ = f.Close() }()
 
@@ -270,7 +416,7 @@ func extractTarMembers(absPath, archiveRelPath string, maxMembers int, maxTotalB
 	case "tar.gz":
 		gr, err := gzip.NewReader(f)
 		if err != nil {
-			return nil, false, fmt.Errorf("gzip reader: %w", err)
+			return archiveExtraction{}, fmt.Errorf("gzip reader: %w", err)
 		}
 		defer func() { _ = gr.Close() }()
 		rd = gr
@@ -291,19 +437,27 @@ func extractTarMembers(absPath, archiveRelPath string, maxMembers int, maxTotalB
 		if hdr.Typeflag == tar.TypeDir {
 			continue
 		}
-		if !isSafeArchivePath(hdr.Name) {
+		memberRel, err := archiveMemberRelPath(hdr.Name)
+		if err != nil {
+			acc.skips.record(hdr.Name, err.Error())
 			continue
 		}
 		if hdr.Size > archiveMemberMaxBytes {
+			acc.skips.record(hdr.Name, fmt.Sprintf("member exceeds the %d-byte per-member cap", int64(archiveMemberMaxBytes)))
 			continue
 		}
 		content, readErr := io.ReadAll(io.LimitReader(tr, archiveMemberMaxBytes+1))
-		if readErr != nil || int64(len(content)) > archiveMemberMaxBytes {
+		if readErr != nil {
+			acc.skips.record(hdr.Name, fmt.Sprintf("read failed: %v", readErr))
 			continue
 		}
-		if acc.add(archiveRelPath+"/"+hdr.Name, content) {
+		if int64(len(content)) > archiveMemberMaxBytes {
+			acc.skips.record(hdr.Name, fmt.Sprintf("member exceeds the %d-byte per-member cap", int64(archiveMemberMaxBytes)))
+			continue
+		}
+		if acc.add(archiveRelPath+"/"+memberRel, content) {
 			break // member-count or aggregate-size cap hit (#408)
 		}
 	}
-	return acc.members, acc.truncated, nil
+	return archiveExtraction{Members: acc.members, Skips: acc.skips, Truncated: acc.truncated}, nil
 }

--- a/internal/ingest/gitignore.go
+++ b/internal/ingest/gitignore.go
@@ -6,6 +6,8 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+
+	"github.com/dirstral/dir2mcp/internal/corpusfs"
 )
 
 // defaultMaxFileSizeBytes mirrors corpusfs.DefaultMaxFileSizeBytes() as a
@@ -13,20 +15,13 @@ import (
 // directly.
 const defaultMaxFileSizeBytes int64 = 10 * 1024 * 1024
 
-// defaultExcludedDirs are directory names skipped during the incremental file
-// watch (the initial scan goes through internal/corpusfs, which keeps its own
-// copy). Kept here for the watcher's directory-walk and gitignore checks.
-var defaultExcludedDirs = map[string]struct{}{
-	".git":         {},
-	".dir2mcp":     {},
-	"node_modules": {},
-	"vendor":       {},
-	"__pycache__":  {},
-}
-
+// shouldSkipDirectory reports whether the incremental file watch skips a
+// directory. It delegates to corpusfs, which owns the default ignore list the
+// initial scan applies: the watcher used to keep a second copy of the map and
+// the two drifted apart, so a directory could be excluded from the scan and
+// still be picked up by the watcher (or vice versa). See #716.
 func shouldSkipDirectory(name string) bool {
-	_, ok := defaultExcludedDirs[strings.TrimSpace(name)]
-	return ok
+	return corpusfs.IsExcludedDir(name)
 }
 
 type gitIgnoreRule struct {

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -2594,7 +2594,7 @@ func (s *Service) processArchiveMembers(ctx context.Context, f DiscoveredFile, s
 		return false, nil
 	}
 	defer cleanup()
-	members, truncated, err := extractArchiveMembers(localPath, f.RelPath, s.archiveMaxMembersEff(), s.archiveMaxTotalBytesEff())
+	extraction, err := extractArchiveMembers(localPath, f.RelPath, s.archiveMaxMembersEff(), s.archiveMaxTotalBytesEff())
 	if err != nil {
 		if errors.Is(err, errUnsupportedArchiveFormat) {
 			// #398: .xz/.7z/.rar (and any other classified-but-unextractable
@@ -2609,7 +2609,8 @@ func (s *Service) processArchiveMembers(ctx context.Context, f DiscoveredFile, s
 		// and its content_hash stays withheld so the next scan retries.
 		return false, nil
 	}
-	if truncated {
+	members := extraction.Members
+	if extraction.Truncated {
 		// #408 decompression-bomb guard: extraction stopped once the archive hit
 		// the member-count or aggregate-uncompressed-size cap. The members read
 		// before the cap are still ingested below; surface a clear warning so the
@@ -2619,6 +2620,7 @@ func (s *Service) processArchiveMembers(ctx context.Context, f DiscoveredFile, s
 			f.RelPath, s.archiveMaxMembersEff(), s.archiveMaxTotalBytesEff(), len(members),
 		)
 	}
+	s.logArchiveMemberSkips(f.RelPath, extraction.Skips)
 	allMembersOK := true
 	for _, m := range members {
 		if err := ctx.Err(); err != nil {
@@ -2638,6 +2640,34 @@ func (s *Service) processArchiveMembers(ctx context.Context, f DiscoveredFile, s
 	// (that would re-extract on every scan forever with no benefit). Only genuine
 	// per-member failures leave the archive incomplete.
 	return allMembersOK, nil
+}
+
+// logArchiveMemberSkips surfaces members an archive declared but that did not
+// become documents (#718). A refused member is otherwise invisible: the archive
+// indexes fine, the member is simply absent, and nothing tells the operator the
+// difference between "the archive did not contain it" and "dir2mcp refused the
+// name". Log-only, matching the OnUnsafeKey precedent (#735): there is no usable
+// rel_path to key a skipped document row on (the unusable name IS the finding),
+// so this is not counted as a corpus skip either.
+//
+// Each member is named with its reason, up to the bounded sample the extractor
+// retained; the count is always exact.
+func (s *Service) logArchiveMemberSkips(archiveRelPath string, skips archiveSkips) {
+	if skips.Total == 0 {
+		return
+	}
+	details := make([]string, 0, len(skips.Entries))
+	for _, e := range skips.Entries {
+		details = append(details, fmt.Sprintf("%q (%s)", e.Name, e.Reason))
+	}
+	suffix := ""
+	if skips.Total > len(skips.Entries) {
+		suffix = fmt.Sprintf(" and %d more", skips.Total-len(skips.Entries))
+	}
+	s.getLogger().Printf(
+		"archive %s: %d member(s) not indexed: %s%s (#718)",
+		archiveRelPath, skips.Total, strings.Join(details, "; "), suffix,
+	)
 }
 
 // retainArchiveMembers adds all existing members of an unchanged archive to

--- a/internal/relpath/relpath.go
+++ b/internal/relpath/relpath.go
@@ -73,11 +73,11 @@ func Normalize(rel string) (string, error) {
 	if strings.HasPrefix(rel, "/") {
 		return "", ErrOutsideRoot
 	}
-	if hasDotDot(rel) {
+	if HasDotDotSegment(rel) {
 		return "", ErrOutsideRoot
 	}
 	cleaned := path.Clean(rel)
-	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "/") || hasDotDot(cleaned) {
+	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "/") || HasDotDotSegment(cleaned) {
 		return "", ErrOutsideRoot
 	}
 	if cleaned != rel {
@@ -94,7 +94,20 @@ func Valid(rel string) bool {
 	return err == nil
 }
 
-func hasDotDot(p string) bool {
+// HasDotDotSegment reports whether p has a `..` path SEGMENT.
+//
+// It is exported because "is this traversal?" kept being re-implemented as a
+// substring test, and a substring test is wrong in the dangerous direction of
+// dropping data: `v1..v2.txt`, `draft..final/report.md`, and `sub/...notes.md`
+// are ordinary filenames, not traversal. Only a segment that is exactly `..`
+// walks up a level. Callers that need the full containment rule should use
+// Normalize; this is for the ones that clean first and only need the traversal
+// question answered (archive members, the store's document key check; #718).
+//
+// p is slash-separated. A caller holding a path that may contain backslashes
+// must reject or convert them first: on Windows `..\x` is traversal, and this
+// function will not say so.
+func HasDotDotSegment(p string) bool {
 	for _, segment := range strings.Split(p, "/") {
 		if segment == ".." {
 			return true

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -19,6 +19,7 @@ import (
 	"github.com/dirstral/dir2mcp/internal/mistral"
 	"github.com/dirstral/dir2mcp/internal/model"
 	"github.com/dirstral/dir2mcp/internal/protocol"
+	"github.com/dirstral/dir2mcp/internal/relpath"
 )
 
 const relPathErrorMessage = "rel_path must be a non-empty relative path without parent-traversal or absolute paths"
@@ -3781,6 +3782,18 @@ func bootstrapSettingsLocked(ctx context.Context, db *sql.DB) error {
 	return nil
 }
 
+// normalizeRelPath is the store's own containment check on a document key: no
+// absolute path, no parent traversal.
+//
+// The traversal test is by SEGMENT, not substring. The old `strings.Contains(
+// normalized, "/..")` test rejected ordinary filenames whose name merely starts
+// with two dots (`sub/...notes.md`, `sub/..draft.txt`), and since the caller
+// only sees an upsert error, the file was counted as an error with no document
+// row and no path in the log: a silent drop (#718, same defect the archive
+// member check had). Note the substring test could never catch a real traversal
+// the segment test misses: filepath.Clean hoists every surviving `..` to the
+// front of the path, so a `..` segment after the first is unreachable by
+// construction, and the leading case is already covered by the `../` prefix.
 func normalizeRelPath(relPath string) (string, error) {
 	normalized := strings.TrimSpace(relPath)
 	if filepath.IsAbs(normalized) {
@@ -3792,7 +3805,7 @@ func normalizeRelPath(relPath string) (string, error) {
 		normalized == "." ||
 		normalized == ".." ||
 		strings.HasPrefix(normalized, "../") ||
-		strings.Contains(normalized, "/..") {
+		relpath.HasDotDotSegment(normalized) {
 		return "", errors.New(relPathErrorMessage)
 	}
 

--- a/tests/corpusfs/default_excludes_716_test.go
+++ b/tests/corpusfs/default_excludes_716_test.go
@@ -1,0 +1,147 @@
+package tests
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/corpusfs"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+)
+
+// spec716ExcludedDirs are the default-ignore directory names SPEC §7.1 requires
+// but that discovery did not implement (#716). They are listed separately from
+// the already-honored names so a regression re-introducing the gap names itself.
+var spec716ExcludedDirs = []string{"dist", "build", ".venv"}
+
+// TestLocalFSWalk_ExcludesSpecDefaultDirs pins SPEC §7.1's default ignore list
+// on the local backend: `dist/`, `build/`, and `.venv/` are normative defaults
+// that discovery previously enumerated and ingested (#716).
+func TestLocalFSWalk_ExcludesSpecDefaultDirs(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "keep.txt"), []byte("hello"))
+	mustWrite(t, filepath.Join(root, "dist", "bundle.js"), []byte("bundled"))
+	mustWrite(t, filepath.Join(root, "build", "generated.txt"), []byte("generated"))
+	mustWrite(t, filepath.Join(root, ".venv", "lib", "site-packages", "pkg.py"), []byte("pkg"))
+	// Nested under a normal directory: exclusion is by directory name at any
+	// depth, not only at the corpus root.
+	mustWrite(t, filepath.Join(root, "src", "dist", "nested.js"), []byte("nested"))
+
+	got, err := corpusfs.NewLocalFS(root).Walk(context.Background(), root, corpusfs.DefaultOptions())
+	if err != nil {
+		t.Fatalf("LocalFS.Walk: %v", err)
+	}
+	rels := map[string]bool{}
+	for _, f := range got {
+		rels[f.RelPath] = true
+	}
+	if !rels["keep.txt"] {
+		t.Fatalf("expected keep.txt to be discovered; got %v", rels)
+	}
+	for _, bad := range []string{
+		"dist/bundle.js",
+		"build/generated.txt",
+		".venv/lib/site-packages/pkg.py",
+		"src/dist/nested.js",
+	} {
+		if rels[bad] {
+			t.Errorf("SPEC §7.1 default ignore list: %q must not be discovered; got %v", bad, rels)
+		}
+	}
+}
+
+// TestLocalFSWalk_SpecDefaultDirNamesAsFilesStillDiscovered guards the
+// directory-vs-file rule while closing #716: only directories named `dist`,
+// `build`, `.venv` are skipped; a regular FILE with one of those names is a
+// normal corpus document and must still be discovered.
+func TestLocalFSWalk_SpecDefaultDirNamesAsFilesStillDiscovered(t *testing.T) {
+	root := t.TempDir()
+	for _, name := range spec716ExcludedDirs {
+		mustWrite(t, filepath.Join(root, name), []byte("a file, not a dir"))
+		mustWrite(t, filepath.Join(root, "sub", name), []byte("also a file"))
+	}
+
+	got, err := corpusfs.NewLocalFS(root).Walk(context.Background(), root, corpusfs.DefaultOptions())
+	if err != nil {
+		t.Fatalf("LocalFS.Walk: %v", err)
+	}
+	rels := map[string]bool{}
+	for _, f := range got {
+		rels[f.RelPath] = true
+	}
+	for _, name := range spec716ExcludedDirs {
+		if !rels[name] {
+			t.Errorf("file %q must still be discovered (it is a file, not a directory); got %v", name, rels)
+		}
+		if !rels["sub/"+name] {
+			t.Errorf("file %q must still be discovered (it is a file, not a directory); got %v", "sub/"+name, rels)
+		}
+	}
+}
+
+// TestS3FSWalk_ExcludesSpecDefaultDirs pins the same §7.1 defaults on the object
+// -store backend, where the "directory" is just a key segment (#716). LocalFS and
+// S3 must agree on the default ignore set or the same corpus indexes differently
+// depending on where it is stored.
+func TestS3FSWalk_ExcludesSpecDefaultDirs(t *testing.T) {
+	objs := map[string][]byte{
+		"corpus/keep.txt":                       []byte("hello"),
+		"corpus/dist/bundle.js":                 []byte("bundled"),
+		"corpus/build/generated.txt":            []byte("generated"),
+		"corpus/.venv/lib/site-packages/pkg.py": []byte("pkg"),
+		"corpus/src/dist/nested.js":             []byte("nested"),
+		"corpus/dist":                           []byte("a file, not a dir"),
+		"corpus/sub/build":                      []byte("also a file"),
+		"corpus/sub/.venv":                      []byte("also a file"),
+	}
+	fsys, _ := newFakeS3FS(t, "corpus/", objs, "")
+	got, err := fsys.Walk(context.Background(), "", corpusfs.DefaultOptions())
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	rels := map[string]bool{}
+	for _, f := range got {
+		rels[f.RelPath] = true
+	}
+	for _, want := range []string{"keep.txt", "dist", "sub/build", "sub/.venv"} {
+		if !rels[want] {
+			t.Errorf("expected %q to be discovered (file, not directory segment); got %v", want, rels)
+		}
+	}
+	for _, bad := range []string{
+		"dist/bundle.js",
+		"build/generated.txt",
+		".venv/lib/site-packages/pkg.py",
+		"src/dist/nested.js",
+	} {
+		if rels[bad] {
+			t.Errorf("SPEC §7.1 default ignore list: %q must not be discovered; got %v", bad, rels)
+		}
+	}
+}
+
+// TestDiscoverFiles_ExcludesSpecDefaultDirs checks the ingest-facing entry point
+// (the one the scan actually calls) so the fix is pinned at the seam operators
+// see, not only inside corpusfs.
+func TestDiscoverFiles_ExcludesSpecDefaultDirs(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "keep.txt"), []byte("hello"))
+	for _, name := range spec716ExcludedDirs {
+		mustWrite(t, filepath.Join(root, name, "artifact.txt"), []byte("artifact"))
+	}
+
+	got, err := ingest.DiscoverFiles(context.Background(), root, corpusfs.DefaultMaxFileSizeBytes())
+	if err != nil {
+		t.Fatalf("DiscoverFiles: %v", err)
+	}
+	for _, f := range got {
+		for _, name := range spec716ExcludedDirs {
+			if f.RelPath == name+"/artifact.txt" {
+				t.Errorf("DiscoverFiles returned %q; SPEC §7.1 excludes %s/ by default", f.RelPath, name)
+			}
+		}
+	}
+	if len(got) != 1 || got[0].RelPath != "keep.txt" {
+		t.Errorf("expected only keep.txt to survive discovery; got %+v", got)
+	}
+}

--- a/tests/corpusfs/default_excludes_716_test.go
+++ b/tests/corpusfs/default_excludes_716_test.go
@@ -79,6 +79,34 @@ func TestLocalFSWalk_SpecDefaultDirNamesAsFilesStillDiscovered(t *testing.T) {
 	}
 }
 
+// TestLocalFSWalk_ExcludedDirNamesMatchExactly pins that the exclusion is an
+// exact name match. A directory called ` dist ` is a different directory than
+// `dist`, and nothing else in the pipeline would exclude its documents, so
+// trimming before the lookup would silently drop a legitimately-named tree.
+func TestLocalFSWalk_ExcludedDirNamesMatchExactly(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, " dist ", "keep.txt"), []byte("padded name"))
+	mustWrite(t, filepath.Join(root, "dist.old", "keep.txt"), []byte("different name"))
+	mustWrite(t, filepath.Join(root, "dist", "bundle.js"), []byte("excluded"))
+
+	got, err := corpusfs.NewLocalFS(root).Walk(context.Background(), root, corpusfs.DefaultOptions())
+	if err != nil {
+		t.Fatalf("LocalFS.Walk: %v", err)
+	}
+	rels := map[string]bool{}
+	for _, f := range got {
+		rels[f.RelPath] = true
+	}
+	for _, want := range []string{" dist /keep.txt", "dist.old/keep.txt"} {
+		if !rels[want] {
+			t.Errorf("%q must be discovered: only an exact `dist` directory is excluded; got %v", want, rels)
+		}
+	}
+	if rels["dist/bundle.js"] {
+		t.Errorf("dist/bundle.js must still be excluded; got %v", rels)
+	}
+}
+
 // TestS3FSWalk_ExcludesSpecDefaultDirs pins the same §7.1 defaults on the object
 // -store backend, where the "directory" is just a key segment (#716). LocalFS and
 // S3 must agree on the default ignore set or the same corpus indexes differently

--- a/tests/ingest/archive_member_names_718_test.go
+++ b/tests/ingest/archive_member_names_718_test.go
@@ -1,0 +1,297 @@
+package tests
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/appstate"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// buildZipOrdered writes members in the given order, allowing duplicate or
+// hostile names that a map literal cannot express.
+func buildZipOrdered(t *testing.T, names []string, content string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	w := zip.NewWriter(&buf)
+	for _, name := range names {
+		fw, err := w.Create(name)
+		if err != nil {
+			t.Fatalf("zip create %q: %v", name, err)
+		}
+		if _, err := fw.Write([]byte(content)); err != nil {
+			t.Fatalf("zip write %q: %v", name, err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("zip close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// buildTarGzOrdered is buildTarGz with an explicit member order.
+func buildTarGzOrdered(t *testing.T, names []string, content string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+	for _, name := range names {
+		data := []byte(content)
+		hdr := &tar.Header{Name: name, Size: int64(len(data)), Typeflag: tar.TypeReg, Mode: 0o644}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("tar header %q: %v", name, err)
+		}
+		if _, err := tw.Write(data); err != nil {
+			t.Fatalf("tar write %q: %v", name, err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tar close: %v", err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// TestArchiveMember_BenignDoubleDotNamesIndexed is the #718 regression guard for
+// the false-positive direction: `..` INSIDE a path segment is an ordinary
+// filename, not traversal. The old check rejected any `..` substring, so these
+// members were dropped from the corpus with no diagnostic at all.
+func TestArchiveMember_BenignDoubleDotNamesIndexed(t *testing.T) {
+	benign := []string{
+		"v1..v2.txt",
+		"draft..final/report.md",
+		"...leading.txt",
+		"notes...md",
+	}
+
+	t.Run("zip", func(t *testing.T) {
+		st := runArchiveIngest(t, "docs.zip", buildZipOrdered(t, benign, "content"))
+		paths := docPaths(t, st)
+		for _, name := range benign {
+			if !paths["docs.zip/"+name] {
+				t.Errorf("member %q must be indexed (a `..` inside a segment is not traversal); got %v", name, paths)
+			}
+		}
+	})
+
+	t.Run("tar.gz", func(t *testing.T) {
+		st := runArchiveIngest(t, "bundle.tar.gz", buildTarGzOrdered(t, benign, "content"))
+		paths := docPaths(t, st)
+		for _, name := range benign {
+			if !paths["bundle.tar.gz/"+name] {
+				t.Errorf("member %q must be indexed (a `..` inside a segment is not traversal); got %v", name, paths)
+			}
+		}
+	})
+}
+
+// TestArchiveMember_SingleCompressedNamePreserved covers the third code path
+// named in #718: a bare `.gz`/`.bz2` payload derives its member name from the
+// archive's own filename, and the old `..` substring check replaced a perfectly
+// safe stem with the synthetic "member", losing the name in retrieval.
+func TestArchiveMember_SingleCompressedNamePreserved(t *testing.T) {
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	if _, err := gw.Write([]byte("gzipped body")); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+
+	st := runArchiveIngest(t, "report..final.txt.gz", buf.Bytes())
+	paths := docPaths(t, st)
+	want := "report..final.txt.gz/report..final.txt"
+	if !paths[want] {
+		t.Errorf("want member %q (the safe stem must be preserved); got %v", want, paths)
+	}
+	if paths["report..final.txt.gz/member"] {
+		t.Errorf("member name was replaced with the synthetic fallback; got %v", paths)
+	}
+}
+
+// TestArchiveMember_DotSlashPrefixedTarMembersIndexed pins the shape `tar -czf
+// archive.tgz .` produces for every member (`./a.txt`). The member is safe, so
+// it must be indexed, and under a clean rel_path, since `archive.tgz/./a.txt`
+// is not a path any other part of the system can produce or resolve.
+//
+// This one passes before the fix too, and that is the point: it is the guard
+// that stops the traversal rule from being tightened into relpath.Normalize's
+// reject-don't-clean form, which would refuse every member of an ordinary
+// `tar -czf x.tgz .` tarball. The rel_path was already being cleaned one layer
+// down by the store; the extractor now makes that explicit at admission time.
+func TestArchiveMember_DotSlashPrefixedTarMembersIndexed(t *testing.T) {
+	st := runArchiveIngest(t, "tree.tar.gz", buildTarGzOrdered(t, []string{"./a.txt", "./sub/b.txt"}, "content"))
+	paths := docPaths(t, st)
+	for _, want := range []string{"tree.tar.gz/a.txt", "tree.tar.gz/sub/b.txt"} {
+		if !paths[want] {
+			t.Errorf("want member %q indexed under a clean rel_path; got %v", want, paths)
+		}
+	}
+}
+
+// hostileMemberNames are the traversal shapes archive extraction must keep
+// refusing after #718 relaxes the `..`-substring test. Relaxing the check must
+// not open a zip-slip hole.
+//
+// Note the deliberately strict entries: `a/../b.txt` does not escape the archive
+// root, and `C:/Windows/x.txt` is only a traversal on a platform dir2mcp does not
+// ship binaries for. Both are refused anyway: a member name is refused, never
+// guessed at, when it does not mean exactly one thing.
+var hostileMemberNames = []string{
+	"../escape.txt",
+	"../../etc/passwd",
+	"a/../../escape.txt",
+	"a/b/../../../escape.txt",
+	"a/../b.txt",
+	"..",
+	"/absolute.txt",
+	"//absolute.txt",
+	`..\escape.txt`,
+	`a\..\..\escape.txt`,
+	`\\server\share\escape.txt`,
+	`C:\Windows\escape.txt`,
+	"sub/../../..",
+	"   ",
+}
+
+// assertOnlyContainedDocs fails when any document other than the archive itself
+// and the known-safe member exists: a refused member must produce no document at
+// all, under any name.
+func assertOnlyContainedDocs(t *testing.T, st *store.SQLiteStore, archive, hostile string) {
+	t.Helper()
+	paths := docPaths(t, st)
+	if !paths[archive+"/safe.txt"] {
+		t.Errorf("refusing %q must not drop the safe member in the same archive; got %v", hostile, paths)
+	}
+	for p := range paths {
+		if p == archive || p == archive+"/safe.txt" {
+			continue // the archive container itself and the safe member
+		}
+		t.Errorf("hostile member %q produced document %q; it must be refused entirely", hostile, p)
+	}
+}
+
+// TestArchiveMember_TraversalShapesRefused_Zip is the other direction of #718.
+func TestArchiveMember_TraversalShapesRefused_Zip(t *testing.T) {
+	for _, name := range hostileMemberNames {
+		t.Run(name, func(t *testing.T) {
+			st := runArchiveIngest(t, "test.zip", buildZipOrdered(t, []string{name, "safe.txt"}, "content"))
+			assertOnlyContainedDocs(t, st, "test.zip", name)
+		})
+	}
+}
+
+// TestArchiveMember_TraversalShapesRefused_Tar covers the same shapes on the tar
+// path. (`../` itself is not in the table: neither writer will encode a regular
+// member whose name ends in a slash, so it is not a shape a real archive can
+// present; `..` and `../escape.txt` cover the intent.)
+func TestArchiveMember_TraversalShapesRefused_Tar(t *testing.T) {
+	for _, name := range hostileMemberNames {
+		t.Run(name, func(t *testing.T) {
+			st := runArchiveIngest(t, "test.tar.gz", buildTarGzOrdered(t, []string{name, "safe.txt"}, "content"))
+			assertOnlyContainedDocs(t, st, "test.tar.gz", name)
+		})
+	}
+}
+
+// TestCorpusFile_LeadingDotsInSubdirIndexed pins the second half of the #718
+// defect, found while fixing the first: the STORE's rel_path check used the same
+// substring test, so an ordinary corpus file in a subdirectory whose name starts
+// with two dots (`sub/...notes.md`, `sub/..draft.txt`) was refused on upsert.
+// No archive is involved (this is a plain local corpus), and the failure was
+// invisible: no document row, no path in the log, just an anonymous +1 on the
+// error counter.
+func TestCorpusFile_LeadingDotsInSubdirIndexed(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	files := []string{
+		"ok.txt",
+		"sub/...notes.md",
+		"sub/..draft.txt",
+		"sub/deeper/...more.txt",
+		"v1..v2.txt",
+	}
+	for _, name := range files {
+		full := filepath.Join(root, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("mkdir for %s: %v", name, err)
+		}
+		if err := os.WriteFile(full, []byte("hello"), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("store init: %v", err)
+	}
+	cfg := config.Default()
+	cfg.RootDir = root
+	cfg.STTProvider = "off"
+	svc := mustNewIngestService(t, cfg, st)
+	state := appstate.NewIndexingState(appstate.ModeIncremental)
+	svc.SetIndexingState(state)
+	if err := svc.Run(ctx); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	paths := docPaths(t, st)
+	for _, name := range files {
+		if !paths[name] {
+			t.Errorf("corpus file %q must be indexed (a `..` inside a name is not traversal); got %v", name, paths)
+		}
+	}
+	if got := state.Snapshot().Errors; got != 0 {
+		t.Errorf("indexing errors = %d, want 0 (a legal filename must not fail its upsert)", got)
+	}
+}
+
+// TestArchiveMember_RefusalIsObservable pins the #718 observability requirement:
+// dropping a member is an admission decision, and an admission decision that
+// leaves no trace is indistinguishable from an archive that never held the file.
+// Precedent: Options.OnUnsafeKey (#735) and OnOversize (#497).
+func TestArchiveMember_RefusalIsObservable(t *testing.T) {
+	var logBuf bytes.Buffer
+	prevOut := log.Writer()
+	log.SetOutput(&logBuf)
+	t.Cleanup(func() { log.SetOutput(prevOut) })
+
+	ctx := context.Background()
+	root := t.TempDir()
+	data := buildZipOrdered(t, []string{"../../etc/passwd", "safe.txt"}, "content")
+	if err := os.WriteFile(filepath.Join(root, "test.zip"), data, 0o600); err != nil {
+		t.Fatalf("write archive: %v", err)
+	}
+
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("store init: %v", err)
+	}
+	cfg := config.Default()
+	cfg.RootDir = root
+	cfg.STTProvider = "off"
+	svc := mustNewIngestService(t, cfg, st)
+	if err := svc.Run(ctx); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	logged := logBuf.String()
+	if !strings.Contains(logged, "test.zip") {
+		t.Errorf("refusal log did not name the archive; got: %q", logged)
+	}
+	if !strings.Contains(logged, "../../etc/passwd") {
+		t.Errorf("refusal log did not name the refused member; got: %q", logged)
+	}
+}


### PR DESCRIPTION
Closes #716. Closes #718.

Both issues are ingest-side discovery/admission, and both were verified against
the code before anything was changed. Neither is stale.

## #718: the archive traversal check refused valid member names

`isSafeArchivePath` rejected any member path *containing* the substring `..`.
A `..` inside a segment is an ordinary filename, so `v1..v2.txt` and
`draft..final/report.md` were dropped, and the drop was invisible: the archive
indexed fine, the member simply was not there. `isSafeArchiveMemberName` had the
same test, so `report..final.txt.gz` lost its stem to the synthetic `member`.

### The rule, and why it is not `relpath.Normalize` verbatim

`internal/relpath` (#735) is the backend-independent containment rule and it has
the final word here: whatever `archiveMemberRelPath` returns must be a path
`relpath.Normalize` accepts, so a member can never be admitted under a name S3
discovery or the local walker would refuse. Containment inside `<archive>/...`
then holds by construction, since the caller prefixes the archive's own
(already valid) rel_path.

What is deliberately *different* is the reject-vs-clean call. relpath refuses a
path that would change under normalization because an S3 key is the address used
to re-fetch the object: rewriting `a//b.txt` to `a/b.txt` would make discovery
record a rel_path that `Open` later resolves to a **different object**. An
archive member has no such property. Its bytes are read from the archive stream
by position and the name is never used to re-fetch anything, so cleaning cannot
retarget.

And the difference is not academic. Measured:

```
$ tar -czf out.tgz .      # the ordinary way to make a tarball
$ tar -tzf out.tgz
./
./sub/
./a.txt
./sub/b.txt
```

`relpath.Normalize("./a.txt")` returns `ErrNotRelative`. Applying the S3 rule
verbatim would refuse **every member of an ordinary tarball**, trading one
silent-drop bug for a far bigger one. So normalization noise (`./`, `//`,
trailing `/`) is cleaned; everything that could mean two different things is
refused:

| shape | verdict |
| --- | --- |
| `v1..v2.txt`, `draft..final/report.md`, `notes...md` | admitted (this is the bug being fixed) |
| `./a.txt`, `sub//b.txt` | admitted, stored cleaned |
| `../escape.txt`, `a/../../escape.txt`, `..` | refused (`..` segment) |
| `a/../b.txt` | refused, even though it does not escape: cleaning it to `b.txt` would file the member under a name the archive gave to a **different** entry |
| `/absolute.txt`, `//absolute.txt` | refused |
| `..\escape.txt`, `\\server\share\x`, `C:\Windows\x` | refused: a backslash is a legal byte in a POSIX member name and a separator on Windows, where `..\x` escapes exactly as `../x` does. Same call relpath makes. |

The one risk cleaning introduces is two distinct members collapsing onto one
rel_path. That is bounded to inside the archive's namespace, and it is reported
(see below) rather than silent. Worth noting: the store *already* cleaned
rel_paths on upsert, so this collapse was happening one layer down anyway; the
change makes it explicit at admission time, where it can be observed.

### A dropped member is now observable

Following the `Options.OnUnsafeKey` (#735) and `OnOversize` (#497) precedent,
extraction returns an admission record (`archiveExtraction.Skips`) and the
service logs it with each member's name and reason:

```
archive test.zip: 1 member(s) not indexed: "../../etc/passwd" (member name has a `..` segment) (#718)
```

This covers refused names, per-member size-cap drops, open/read failures, the
single-compressed synthetic-name substitution, and rel_path collisions. The
count is exact; the per-member sample is capped at 20 so a hostile archive with
100k bad entries cannot turn an observability record into a memory problem.
Log-only, like `OnUnsafeKey`: there is no usable rel_path to key a skipped
document row on, because the unusable name **is** the finding.

### Same defect in the store, found while fixing this

`store.normalizeRelPath` used `strings.Contains(normalized, "/..")`, so an
ordinary corpus file in a subdirectory whose name starts with two dots
(`sub/...notes.md`, `sub/..draft.txt`) was refused on upsert. No archive
involved. Measured on a plain local corpus of five files before the fix:

```
doc "...notes.txt" ok      doc "..hidden.txt" ok      doc "ok.txt" ok
doc "v1..v2.txt"   ok      (sub/...x.md: absent)
snapshot: Scanned:5 Indexed:4 Errors:1
```

One anonymous error, no document row, no path in the log. The substring test
could never have caught a real traversal the segment test misses, because
`filepath.Clean` hoists every surviving `..` to the front of the path, so a `..`
segment after the first is unreachable by construction and the leading case is
already covered by the existing `../` prefix check. Removing it weakens nothing.

The segment test now lives in one place, `relpath.HasDotDotSegment`, since
re-implementing it as a substring test is exactly what caused this bug twice.

## #716: `dist/`, `build/`, `.venv/` missing from default discovery

SPEC 7.1 makes the default ignore list `.git/`, `node_modules/`, `dist/`,
`build/`, `.venv/`, `.dir2mcp/`. `corpusfs.defaultExcludedDirs` had five names
and none of the three, on both LocalFS and S3. `internal/ingest/gitignore.go`
kept a **second copy** of the map for the file watcher, which is how the two
were able to drift; the watcher now delegates to `corpusfs.IsExcludedDir` so
there is one list.

### Compatibility: yes, a reindex will drop documents. That is the point.

Anything currently indexed under `dist/`, `build/`, or `.venv/` becomes
undiscoverable and is tombstoned on the next scan. I think that is acceptable:
the spec promised these were ignored, so every such document is content the
operator was told would not be there, and it is generated output (bundles, build
artifacts, an entire vendored Python environment) rather than authored source.
It also removes real cost, since those trees dominate embedding spend and
duplicate retrieval results on any repo-shaped corpus.

### The escape hatch question, answered honestly: there is none

I checked. The excluded-directory set is **hardcoded and not configurable**.
`security.path_excludes` is operator-configurable but only *adds* exclusions,
`.gitignore` support likewise, and there is no `.dir2mcpignore`. So an operator
who genuinely wants `dist/` indexed has no way to say so, and today has the same
problem with `node_modules/`, `vendor/`, and `__pycache__/`.

This PR does not invent a config key for it, because the config surface is
spec-governed and adding one is a spec-first change (a `dirstral-spec` PR first,
then a gated submodule re-pin). This PR is pure conformance to a spec section
that already exists, so it needs no spec change at all. Filed #773 for the
override key as a spec-first follow-up. The tradeoff is stated in `defaultExcludedDirs`'s
doc comment so the next person adding a name knows the list is a hard floor.

## Tests

Each new test was proven to fail first by stashing **only** the source change
(`git stash push -- internal`) and re-running:

| test | fails without fix |
| --- | --- |
| `TestLocalFSWalk_ExcludesSpecDefaultDirs` | yes |
| `TestS3FSWalk_ExcludesSpecDefaultDirs` | yes |
| `TestDiscoverFiles_ExcludesSpecDefaultDirs` | yes |
| `TestArchiveMember_BenignDoubleDotNamesIndexed` (zip + tar.gz) | yes |
| `TestArchiveMember_SingleCompressedNamePreserved` | yes |
| `TestArchiveMember_TraversalShapesRefused_Zip` / `_Tar` (14 shapes each) | yes (4 shapes each) |
| `TestCorpusFile_LeadingDotsInSubdirIndexed` | yes |
| `TestArchiveMember_RefusalIsObservable` | yes |
| `TestLocalFSWalk_SpecDefaultDirNamesAsFilesStillDiscovered` | no, by design (guard: a *file* named `dist` must still be indexed) |
| `TestArchiveMember_DotSlashPrefixedTarMembersIndexed` | no, by design (guard: the rule must not be tightened into relpath's reject-don't-clean form) |

Both directions of #718 are covered: the valid members that were being dropped
are now indexed, and every traversal shape is still refused with no document
produced under any name, while the safe member in the same archive still lands.

`make check` passes (exit 0), gocyclo `-over 15` included.

## Notes for review

- Not a live escape on the platforms dir2mcp ships. Before this change,
  `/absolute.txt` and `C:\Windows\x` members landed *inside* `test.zip/` anyway
  because the store cleaned the rel_path. The value of the tightened rule is
  Windows correctness and path-shape hygiene, not patching an exploitable hole.
  The false-positive data loss was the live problem.
- A member name containing a literal backslash was accepted before and is
  refused now. Rare on POSIX, refused for the reason relpath refuses it, and no
  longer silent.
