### PR TITLE
fix(provider): close the embed-identity holes and reject undirected vectors (#702, #703, #705)

### DIFF
--- a/internal/cohere/client.go
+++ b/internal/cohere/client.go
@@ -269,6 +269,11 @@ func (c *Client) Embed(ctx context.Context, modelName string, role model.EmbedRo
 		}
 		out = append(out, vectors...)
 	}
+	// Reject empty / non-finite / zero-norm vectors at the provider boundary
+	// (issue #703) so they never reach an index.
+	if err := model.ValidateEmbedVectors("COHERE_FAILED", 0, out); err != nil {
+		return nil, err
+	}
 	return out, nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1929,8 +1929,9 @@ func appendSnapshotEmbedIdentity(raw []byte, id string) []byte {
 // / §6.4 `embed_base_url`) alongside the composite embed identity so the
 // endpoint that pins the vector space is legible without parsing the identity.
 // It is the SAME normalized value already folded into embed_identity's 2nd
-// field; a canonical/default/native-surface endpoint normalizes to "" and the
-// line is omitted (nothing to disambiguate). A top-level scalar — ignored by
+// field; a canonical/default endpoint — including the HOSTED native
+// gemini/cohere surface, though no longer a custom one (issue #702) —
+// normalizes to "" and the line is omitted (nothing to disambiguate). A top-level scalar — ignored by
 // the flat config parser and the providers:/model: yaml subtree decode on
 // reload.
 func appendSnapshotEmbedBaseURL(raw []byte, baseURL string) []byte {

--- a/internal/config/providers.go
+++ b/internal/config/providers.go
@@ -1070,7 +1070,8 @@ func (r ProviderResolution) EmbedContextual() string {
 
 // EmbedBaseURL is the normalized embed base_url component of the corpus-lifetime
 // identity (SPEC 8.1.4 / §6.4 `embed_base_url`), or "" if embed cannot be
-// resolved OR the endpoint is a native surface / canonical/default (rule 1/2).
+// resolved OR the endpoint is canonical/default (rule 2) — which includes the
+// HOSTED native gemini/cohere surface, but no longer a CUSTOM one (issue #702).
 // It is persisted alongside the recorded identity so operators can read the
 // endpoint that pins the vector space without parsing the composite identity.
 func (r ProviderResolution) EmbedBaseURL() string {

--- a/internal/gemini/client.go
+++ b/internal/gemini/client.go
@@ -346,6 +346,16 @@ func (c *Client) embedReqsNative(ctx context.Context, modelName string, dim int,
 		}
 		vectors[i] = vec
 	}
+	// Reject empty / non-finite / zero-norm vectors at the provider boundary
+	// (issue #703) so they never reach an index. This path backs BOTH Embed and
+	// EmbedMedia, so text and media vectors are validated identically. When a
+	// non-native output dimension was requested (SPEC 8.1.6) the response must
+	// also carry exactly that many components — l2Normalize cannot rescue a
+	// zero vector, and a short vector would silently change the corpus's
+	// dimension.
+	if err := model.ValidateEmbedVectors("GEMINI_FAILED", dim, vectors); err != nil {
+		return nil, err
+	}
 	return vectors, nil
 }
 
@@ -384,7 +394,9 @@ func (c *Client) doNativeJSON(ctx context.Context, path string, body []byte, tim
 // l2Normalize scales v to unit L2 length in place. MRL-truncated Gemini
 // vectors (outputDimensionality below the native size) are not
 // pre-normalized, and the index's cosine/IP scoring assumes unit vectors
-// (SPEC 8.1.6). A zero vector is left unchanged.
+// (SPEC 8.1.6). A zero vector is left unchanged — it has no direction to
+// preserve; the shared output validation (model.ValidateEmbedVectors, issue
+// #703) rejects it rather than letting an undirected vector be indexed.
 func l2Normalize(v []float32) {
 	var sum float64
 	for _, x := range v {

--- a/internal/index/embedding_worker.go
+++ b/internal/index/embedding_worker.go
@@ -223,6 +223,16 @@ func (w *EmbeddingWorker) embedTasks(ctx context.Context, modelName string, vali
 			vectors[idx] = v[k]
 		}
 	}
+	// Last gate before the index (issue #703). Every shipped adapter already
+	// validates its own response, but the worker accepts ANY model.Embedder —
+	// including a distributed/self-hosted one this process does not own — and an
+	// empty, non-finite or zero-norm vector is unretrievable-but-indistinguishable
+	// once written. The error is non-transient and non-fatal, so embedIndexBatch
+	// bisects the batch: the offending chunk is marked embedding_status=error
+	// with this reason while its healthy siblings still embed (#399).
+	if err := model.ValidateEmbedVectors("EMBED_OUTPUT_INVALID", 0, vectors); err != nil {
+		return nil, err
+	}
 	return vectors, nil
 }
 

--- a/internal/index/persistence.go
+++ b/internal/index/persistence.go
@@ -3,10 +3,12 @@ package index
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/provider"
 )
 
 type IndexedFile struct {
@@ -163,12 +165,23 @@ func (m *PersistenceManager) SaveAll() error {
 
 // EnsureIdentity reconciles an index's recorded corpus-lifetime embed identity
 // (SPEC 8.1.4) with the configured one, per index (issue #247). When the index
-// is fresh (empty recorded identity) or the recorded identity differs from the
-// configured one, the index is Reset to the configured identity — discarding any
-// vectors built under a different embed provider/model/dimension so vector
-// spaces are never silently mixed. A match is a no-op. This complements the
-// process-level config.VerifyEmbedIdentity check, which fails the startup before
-// any index work when a populated corpus's snapshot identity changed.
+// is fresh (empty recorded identity) or the recorded identity is INCOMPATIBLE
+// with the configured one, the index is Reset to the configured identity —
+// discarding any vectors built under a different embed provider/model/endpoint/
+// dimension so vector spaces are never silently mixed. A compatible recording is
+// a no-op. This complements the process-level config.VerifyEmbedIdentity check,
+// which fails the startup before any index work when a populated corpus's
+// snapshot identity changed.
+//
+// Compatibility is provider.EmbedIdentityMatches — the SAME comparison
+// VerifyEmbedIdentity uses — not string equality (issue #705). The two must
+// agree: VerifyEmbedIdentity migrates a legacy recording (the 8.1.4 field-count
+// ladder, and the blank-model grace) and lets startup proceed, so a byte
+// comparison here would answer "different" for exactly those migrated corpora
+// and silently Reset — a full, unannounced re-embed of a corpus the operator was
+// just told was compatible. Reset stays reserved for a genuine mismatch, which
+// VerifyEmbedIdentity has already reported as CONFIG_INVALID, and for a fresh
+// index (recorded == ""), where Reset is what RECORDS the identity.
 func EnsureIdentity(ctx context.Context, idx model.Index, configuredIdentity string) error {
 	if idx == nil {
 		return nil
@@ -177,7 +190,7 @@ func EnsureIdentity(ctx context.Context, idx model.Index, configuredIdentity str
 	if err != nil {
 		return err
 	}
-	if recorded == configuredIdentity {
+	if strings.TrimSpace(recorded) != "" && provider.EmbedIdentityMatches(recorded, configuredIdentity) {
 		return nil
 	}
 	return idx.Reset(ctx, configuredIdentity)

--- a/internal/mistral/client.go
+++ b/internal/mistral/client.go
@@ -168,6 +168,12 @@ func (c *Client) Embed(ctx context.Context, modelName string, _ model.EmbedRole,
 		out = append(out, vectors...)
 	}
 
+	// Reject empty / non-finite / zero-norm vectors at the provider boundary
+	// (issue #703) so they never reach an index.
+	if err := model.ValidateEmbedVectors("MISTRAL_FAILED", 0, out); err != nil {
+		return nil, err
+	}
+
 	return out, nil
 }
 

--- a/internal/model/embedvalidate.go
+++ b/internal/model/embedvalidate.go
@@ -13,8 +13,13 @@ import (
 // A vector is malformed when it is:
 //
 //   - empty — nothing to score against;
-//   - the wrong length, when wantDim > 0 names a dimension the caller requested
-//     (SPEC 8.1.6) or has already fixed for this response;
+//   - the wrong length. wantDim > 0 names a dimension the caller requested
+//     (SPEC 8.1.6). When the caller has no requested dimension the FIRST vector
+//     fixes it for the rest of the response: one call must not return a ragged
+//     batch. Vectors of two different widths cannot share an index — depending
+//     on the backend that is a rejected upsert mid-batch, a silently truncated
+//     comparison, or a collection whose dimension was fixed by whichever vector
+//     happened to arrive first;
 //   - non-finite — a NaN or ±Inf component poisons every distance computation
 //     downstream (NaN comparisons are unordered, so such a vector can both never
 //     rank and corrupt a partial sort);
@@ -46,9 +51,15 @@ import (
 // batch index walks every integer, so that collision is a matter of batch size;
 // the worker's bisection identifies the individual chunk anyway.
 func ValidateEmbedVectors(code string, wantDim int, vectors [][]float32) error {
+	dim := wantDim
 	for _, v := range vectors {
-		if err := validateEmbedVector(code, wantDim, v); err != nil {
+		if err := validateEmbedVector(code, dim, v); err != nil {
 			return err
+		}
+		if dim == 0 {
+			// No dimension was requested: adopt the first vector's width so the
+			// rest of the response is checked against it.
+			dim = len(v)
 		}
 	}
 	return nil

--- a/internal/model/embedvalidate.go
+++ b/internal/model/embedvalidate.go
@@ -1,0 +1,85 @@
+package model
+
+import (
+	"fmt"
+	"math"
+)
+
+// ValidateEmbedVectors is the shared provider-output boundary check for
+// embedding vectors (issue #703). Every embed adapter runs its response through
+// it before returning, so a malformed vector is rejected at the edge instead of
+// being persisted by an index backend.
+//
+// A vector is malformed when it is:
+//
+//   - empty — nothing to score against;
+//   - the wrong length, when wantDim > 0 names a dimension the caller requested
+//     (SPEC 8.1.6) or has already fixed for this response;
+//   - non-finite — a NaN or ±Inf component poisons every distance computation
+//     downstream (NaN comparisons are unordered, so such a vector can both never
+//     rank and corrupt a partial sort);
+//   - zero-norm — an all-zero vector has NO cosine direction. It is not a weak
+//     embedding, it is the absence of one: cosine/inner-product scoring returns
+//     0 against every query, so the chunk is permanently unretrievable, yet once
+//     written it is indistinguishable from healthy indexed data (external
+//     backends keep it, and it can even fix a collection's dimension). Providers
+//     and proxies emit these on quota exhaustion, on truncated inputs, and from
+//     broken self-hosted servers, and the failure is otherwise SILENT — a
+//     200 OK that lands as embedding_status=embedded.
+//
+// The returned error is a NON-RETRYABLE *ProviderError: the same response would
+// come back on retry, and the embedding worker's classifier routes it to
+// store.ErrorCategoryEmbeddingFailure so the affected chunk is recorded FAILED
+// with a reason (visible in `dir2mcp status`/`doctor`) rather than silently
+// indexed. In a multi-input batch the worker's bisection (#399) isolates the
+// offending input so healthy siblings still embed. On the query side the same
+// error surfaces as a provider error instead of a result set scored entirely at
+// zero.
+//
+// code is the caller's provider error code (e.g. "OPENAI_FAILED") so the message
+// keeps naming the provider that produced the bad vector.
+//
+// The message deliberately does NOT carry the vector's position in the batch:
+// these strings are keyword-classified downstream (store.ClassifyError /
+// IsTransientError), where a bare index that happened to be 503 or 429 would
+// read as a transient upstream status and leave the chunk PENDING forever. A
+// batch index walks every integer, so that collision is a matter of batch size;
+// the worker's bisection identifies the individual chunk anyway.
+func ValidateEmbedVectors(code string, wantDim int, vectors [][]float32) error {
+	for _, v := range vectors {
+		if err := validateEmbedVector(code, wantDim, v); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateEmbedVector checks one vector; split out to keep ValidateEmbedVectors
+// a single loop and stay inside the cyclomatic-complexity budget.
+func validateEmbedVector(code string, wantDim int, v []float32) error {
+	bad := func(problem string) error {
+		return &ProviderError{
+			Code:      code,
+			Message:   "malformed embedding vector in provider response: " + problem,
+			Retryable: false,
+		}
+	}
+	if len(v) == 0 {
+		return bad("empty (no components)")
+	}
+	if wantDim > 0 && len(v) != wantDim {
+		return bad(fmt.Sprintf("has %d dimensions, want %d", len(v), wantDim))
+	}
+	var sum float64
+	for _, x := range v {
+		f := float64(x)
+		if math.IsNaN(f) || math.IsInf(f, 0) {
+			return bad("contains a non-finite component (NaN or Inf)")
+		}
+		sum += f * f
+	}
+	if sum == 0 {
+		return bad("all components are zero, so the vector has no cosine direction")
+	}
+	return nil
+}

--- a/internal/omniembed/client.go
+++ b/internal/omniembed/client.go
@@ -205,6 +205,12 @@ func (c *Client) embedAll(ctx context.Context, modelName string, inputs []string
 		}
 		out = append(out, vectors...)
 	}
+	// Reject empty / non-finite / zero-norm vectors at the provider boundary
+	// (issue #703) so they never reach an index. embedAll backs BOTH Embed and
+	// EmbedMedia, so text and media chunks are validated identically.
+	if err := model.ValidateEmbedVectors("OMNIEMBED_FAILED", 0, out); err != nil {
+		return nil, err
+	}
 	return out, nil
 }
 

--- a/internal/openai/client.go
+++ b/internal/openai/client.go
@@ -221,6 +221,11 @@ func (c *Client) Embed(ctx context.Context, modelName string, _ model.EmbedRole,
 		}
 		out = append(out, vectors...)
 	}
+	// Reject empty / non-finite / zero-norm vectors at the provider boundary
+	// (issue #703) so they never reach an index.
+	if err := model.ValidateEmbedVectors("OPENAI_FAILED", 0, out); err != nil {
+		return nil, err
+	}
 	return out, nil
 }
 

--- a/internal/provider/embedmodel.go
+++ b/internal/provider/embedmodel.go
@@ -1,0 +1,66 @@
+package provider
+
+import "strings"
+
+// Adapter embed-model defaults (issue #705).
+//
+// These MUST equal the DefaultEmbedModel/DefaultModel constant each client
+// package substitutes when a profile leaves the model blank. They are
+// duplicated here as literals rather than imported so this package stays pure
+// resolution logic with no HTTP/client dependency (see the package doc); the
+// duplication is fenced by a drift guard in
+// tests/providerfactory/effective_embed_models_705_test.go, which fails if a
+// client constant ever changes without this table.
+const (
+	// DefaultOpenAIEmbedModel mirrors internal/openai.DefaultEmbedModel.
+	DefaultOpenAIEmbedModel = "text-embedding-3-small"
+	// DefaultCohereEmbedModel mirrors internal/cohere.DefaultEmbedModel.
+	DefaultCohereEmbedModel = "embed-v4.0"
+	// DefaultGeminiEmbedModel mirrors internal/gemini.DefaultEmbedModel.
+	DefaultGeminiEmbedModel = "gemini-embedding-001"
+	// DefaultOmniEmbedModel mirrors internal/omniembed.DefaultModel.
+	DefaultOmniEmbedModel = "omniembed"
+)
+
+// KindDefaultEmbedModel returns the embed model an adapter of kind k sends on
+// the wire when the profile leaves the model blank. Kinds with no embed
+// capability (or no defined default) return "" — their effective model is
+// whatever the profile carries.
+func KindDefaultEmbedModel(k Kind) string {
+	switch k {
+	case KindOpenAI:
+		return DefaultOpenAIEmbedModel
+	case KindCohere:
+		return DefaultCohereEmbedModel
+	case KindGemini:
+		return DefaultGeminiEmbedModel
+	case KindOmniEmbed:
+		return DefaultOmniEmbedModel
+	default:
+		return ""
+	}
+}
+
+// EffectiveEmbedModels returns the concrete text/code embed model ids an
+// adapter built from p actually sends on the wire, resolving each empty profile
+// field to its adapter kind default (KindDefaultEmbedModel). Built-in profiles
+// like `openai`/`cohere`/`local`/`omniembed` ship WITHOUT embed model fields
+// (SPEC 8.1.1), so the raw profile does not name the model that produced the
+// vectors — the adapter default does.
+//
+// This is the single resolution point shared by the embed identity (8.1.4,
+// EmbedIdentity), the ingest embed worker, and the query-side retrieval
+// embedder (providerfactory.EffectiveEmbedModels delegates here), so all four
+// name BYTE-IDENTICAL models (issues #440 F2, #705).
+func EffectiveEmbedModels(p Profile) (text, code string) {
+	def := KindDefaultEmbedModel(p.Kind)
+	text = strings.TrimSpace(p.EmbedTextModel)
+	if text == "" {
+		text = def
+	}
+	code = strings.TrimSpace(p.EmbedCodeModel)
+	if code == "" {
+		code = def
+	}
+	return text, code
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -317,11 +317,11 @@ func Select(precedence []Profile, byName map[string]Profile, cap Capability, exp
 // provider|base_url|text_model|…) disambiguates two same-kind/same-model
 // profiles that point at DIFFERENT endpoints (issue #560/#440 F3): without it
 // they collapse to one identity and their vectors silently mix in one index.
-// It enters in NORMALIZED form (normalizeEmbedBaseURL): a not-meaningful kind
-// (native gemini/cohere) or a canonical/default/unset endpoint normalizes to
-// "" so that an existing hosted-default corpus — and any index built before
-// this rule — does NOT spuriously reindex; only an operator-overridden,
-// non-canonical endpoint yields a non-empty component.
+// It enters in NORMALIZED form (normalizeEmbedBaseURL): a canonical/default/
+// unset endpoint — including the hosted native gemini/cohere surface —
+// normalizes to "" so that an existing hosted-default corpus, and any index
+// built before this rule, does NOT spuriously reindex; only an
+// operator-overridden, non-canonical endpoint yields a non-empty component.
 //
 // lateChunking is the resolved value of ingest.late_chunking (config, not a
 // provider attribute). It enters the identity because late chunking, once its
@@ -332,6 +332,18 @@ func Select(precedence []Profile, byName map[string]Profile, cap Capability, exp
 // it keys off the config flag, not the runtime TokenEmbedder capability (which
 // EmbedIdentity cannot observe), so toggling the flag re-derives even in a build
 // with no token-embedding provider — the safe direction.
+//
+// The two model fields are the EFFECTIVE models (EffectiveEmbedModels), i.e.
+// the concrete ids the adapter puts on the wire, NOT the raw profile fields
+// (issue #705). Built-in `openai`/`cohere`/`local`/`omniembed` profiles ship
+// with blank embed model fields, so recording the raw field named no model at
+// all: a corpus embedded with text-embedding-3-small recorded "", which would
+// still compare equal after a client default changed, or across distributed
+// workers whose binaries default differently — silent model-space mixing under
+// a matching identity. Recording the resolved model closes that, and also makes
+// "set the model to the value already in effect" a no-op instead of a spurious
+// reindex (#440 F3). Recorded BLANK model fields from before this rule are
+// migrated by embedIdentityMatches, so no existing corpus re-embeds.
 //
 // contextual is the TERMINAL (9th) field: the EFFECTIVE contextual-retrieval
 // mode (8.1.8) — EmbedContextualOff when the feature is disabled OR enabled
@@ -344,11 +356,12 @@ func Select(precedence []Profile, byName map[string]Profile, cap Capability, exp
 // no contextual notion records the identity a fresh non-contextual build
 // computes.
 func EmbedIdentity(p Profile, lateChunking bool, contextual string) string {
+	textModel, codeModel := EffectiveEmbedModels(p)
 	return fmt.Sprintf("%s|%s|%s|%s|%d|%d|%s|%s|%s",
 		strings.TrimSpace(p.Name),
 		normalizeEmbedBaseURL(p),
-		strings.TrimSpace(p.EmbedTextModel),
-		strings.TrimSpace(p.EmbedCodeModel),
+		textModel,
+		codeModel,
 		p.EmbedTextDim,
 		p.EmbedCodeDim,
 		NormalizeEmbedMultimodal(p.EmbedMultimodal),
@@ -366,9 +379,9 @@ func EmbedIdentity(p Profile, lateChunking bool, contextual string) string {
 // non-empty base_url component — a kind-wide set would instead collapse both to
 // "" and let vectors from two different backends silently share one index (the
 // exact mis-bind 8.1.4 exists to prevent). Native-surface kinds (gemini, cohere)
-// never consult this table (rule 1); self-hosted kinds (omniembed) and any
-// operator-named custom profile ship no canonical default, so any configured
-// endpoint is meaningful.
+// consult canonicalEmbedHostedByKind instead; self-hosted kinds (omniembed) and
+// any operator-named custom profile ship no canonical default, so any
+// configured endpoint is meaningful.
 //
 // MUST stay in sync with config.builtinProfiles. The `openai` built-in ships no
 // base_url; its client defaults to the OpenAI wire endpoint, recorded here so an
@@ -380,6 +393,37 @@ var canonicalEmbedBaseURLByBuiltin = map[string]string{
 	"local":      "http://localhost:11434/v1",    // credential-less
 }
 
+// canonicalEmbedHostedByKind maps a NATIVE-surface embed kind to the hosted
+// endpoint(s) its client uses by default, so only those normalize to "" while a
+// custom endpoint stays in the identity (issue #702 / dirstral-spec#72).
+//
+// SPEC 8.1.4 rule 1 used to declare base_url "not meaningful" for these kinds
+// on the grounds that each has a single canonical provider surface. Both
+// adapters, however, honor a configured base_url and send the actual embedding
+// request there — so a proxy/gateway/self-hosted endpoint A and endpoint B
+// produced BYTE-IDENTICAL identities and their (different) vector spaces could
+// silently mix in one index. These kinds are therefore folded into rule 2:
+// unset or hosted-default → "", any other endpoint → the canonicalized URL.
+//
+// Matching is per-KIND rather than per-profile-name (unlike
+// canonicalEmbedBaseURLByBuiltin): a native kind has exactly one hosted vendor
+// surface, so ANY profile of that kind pointed at it reaches the same vector
+// space, whatever the profile is named. Gemini lists two forms because its
+// client accepts the OpenAI-compatible base and derives the native embed base
+// from it by dropping the trailing "/openai" (gemini.nativeBaseURL) — both
+// denote the same hosted surface and must collapse identically.
+//
+// MUST stay in sync with the client defaults (internal/gemini defaultBaseURL /
+// geminiNativeBaseURL, internal/cohere defaultBaseURL); the drift guard lives
+// in tests/provider/embed_identity_native_base_url_702_test.go.
+var canonicalEmbedHostedByKind = map[Kind][]string{
+	KindGemini: {
+		"https://generativelanguage.googleapis.com/v1beta",        // native embed surface
+		"https://generativelanguage.googleapis.com/v1beta/openai", // OpenAI-compatible base the client derives it from
+	},
+	KindCohere: {"https://api.cohere.com"},
+}
+
 // NormalizeEmbedBaseURL renders the profile's embed base_url as the stable
 // component used in the embed identity (SPEC 8.1.4). See normalizeEmbedBaseURL;
 // exported so the config layer can persist the same normalized value alongside
@@ -388,24 +432,25 @@ func NormalizeEmbedBaseURL(p Profile) string { return normalizeEmbedBaseURL(p) }
 
 // normalizeEmbedBaseURL implements the SPEC 8.1.4 base_url normalization:
 //
-//   - Rule 1 (not meaningful): a kind whose embed endpoint is a single
-//     canonical provider surface (native gemini / cohere) → "". base_url does
-//     not participate.
 //   - Rule 2 (canonical/default): an unset base_url, or one equal to *this
 //     profile's own* built-in shipped default (canonicalEmbedBaseURLByBuiltin,
-//     matched by profile name), → "". Only an operator-overridden, non-canonical
-//     endpoint — including a built-in profile pointed at a *different* vendor's
-//     host — yields a non-empty component.
+//     matched by profile name) — or, for a native-surface kind, to that kind's
+//     hosted endpoint (canonicalEmbedHostedByKind) — → "". Only an
+//     operator-overridden, non-canonical endpoint — including a built-in profile
+//     pointed at a *different* vendor's host — yields a non-empty component.
 //   - Rule 3 (canonicalization, non-empty case): canonicalizeEmbedBaseURL.
+//
+// Rule 1 ("not meaningful" for native gemini/cohere) is deliberately NOT
+// implemented: both adapters honor a configured base_url, so collapsing every
+// custom native endpoint to "" let two different vector spaces compare
+// identity-equal (issue #702 / dirstral-spec#72). Those kinds run through rule 2
+// against their hosted default instead, which preserves the no-spurious-reindex
+// property for every hosted-default corpus.
 //
 // "" is a first-class value (not "unknown"): an index built before this rule
 // recorded no base_url and MUST stay valid against any provider that also
 // normalizes to "" — so no default-endpoint corpus spuriously reindexes.
 func normalizeEmbedBaseURL(p Profile) string {
-	switch p.Kind {
-	case KindGemini, KindCohere:
-		return "" // Rule 1: native single-surface embed.
-	}
 	raw := strings.TrimSpace(p.BaseURL)
 	if raw == "" {
 		return "" // Rule 2: unset → canonical/default.
@@ -416,6 +461,13 @@ func normalizeEmbedBaseURL(p Profile) string {
 	// foreign host stays distinct and cannot mix vector spaces.
 	if def, ok := canonicalEmbedBaseURLByBuiltin[strings.TrimSpace(p.Name)]; ok {
 		if norm == canonicalizeEmbedBaseURL(def) {
+			return ""
+		}
+	}
+	// Rule 2, native-surface kinds: the hosted vendor endpoint is a property of
+	// the KIND, so any profile of that kind sitting on it collapses to "".
+	for _, hosted := range canonicalEmbedHostedByKind[p.Kind] {
+		if norm == canonicalizeEmbedBaseURL(hosted) {
 			return ""
 		}
 	}
@@ -581,18 +633,17 @@ func NormalizeEmbedMultimodal(mode string) string {
 }
 
 // VerifyEmbedIdentity returns a *ConfigError when a recorded embed
-// identity differs from the current one (SPEC 8.1.4 — the server MUST
-// NOT silently mix vector spaces). An empty recorded identity (fresh
-// index) always passes. A legacy 3-field identity (pre-8.1.6, no
-// dimension) is normalized to the native "|0|0" form before comparison so
-// upgrading an existing native-dimension corpus does not force a spurious
-// reindex.
+// identity is not compatible with the current one (SPEC 8.1.4 — the server
+// MUST NOT silently mix vector spaces). Compatibility is EmbedIdentityMatches:
+// an empty recorded identity (fresh index) always passes, and a legacy
+// recording is migrated (field-count ladder + blank-model grace) before
+// comparison so upgrading an existing corpus never forces a spurious reindex.
 func VerifyEmbedIdentity(recorded, current string) error {
-	recorded = normalizeEmbedIdentity(strings.TrimSpace(recorded))
-	current = strings.TrimSpace(current)
-	if recorded == "" || recorded == current {
+	if EmbedIdentityMatches(recorded, current) {
 		return nil
 	}
+	recorded = normalizeEmbedIdentity(strings.TrimSpace(recorded))
+	current = strings.TrimSpace(current)
 	return &ConfigError{
 		Capability: CapEmbed,
 		Profile:    current,
@@ -600,6 +651,72 @@ func VerifyEmbedIdentity(recorded, current string) error {
 			"embed identity changed (index built with %q, configured %q); embeddings are corpus-lifetime — reindex to change the embed provider/model/dimension",
 			recorded, current),
 	}
+}
+
+// embedIdentityFields is the number of components in the current identity
+// tuple (provider|base_url|text|code|tdim|cdim|multimodal|late_chunking|contextual).
+const embedIdentityFields = 9
+
+// Field positions inside that tuple that carry an embed model id.
+const (
+	embedIdentityTextModelField = 2
+	embedIdentityCodeModelField = 3
+)
+
+// EmbedIdentityMatches reports whether an identity RECORDED by an index or a
+// config snapshot is compatible with the current one — i.e. whether the vectors
+// already in the corpus live in the same space the current config would produce
+// (SPEC 8.1.4). It is the single comparison used by VerifyEmbedIdentity (which
+// fails startup) and index.EnsureIdentity (which WIPES the index), so a
+// migration recognized by one can never be a silent full re-embed in the other.
+//
+// Two migrations make an older recording compare equal without re-embedding:
+//
+//   - the field-count ladder (normalizeEmbedIdentity), which appends the
+//     components that did not exist when the identity was recorded; and
+//   - the blank-model grace (issue #705): a recorded EMPTY model component
+//     matches whatever concrete model the current identity names. Before #705
+//     the identity copied the RAW profile field, and the built-in
+//     `openai`/`cohere`/`local`/`omniembed` profiles leave it empty — so those
+//     corpora recorded "" for a model that was, on the wire, the adapter
+//     default. Treating that "" as "the adapter default of the day" is the same
+//     first-class-empty rule 8.1.4 already applies to a pre-rule base_url, and
+//     it is what keeps the #705 fix from wiping every such corpus on upgrade.
+//     The grace is one-directional and legacy-only: it never lets a recorded
+//     CONCRETE model match a different one, and every identity recorded from now
+//     on names its model, so a future adapter-default change (or a distributed
+//     worker on a differently-defaulting binary) does mismatch loudly.
+func EmbedIdentityMatches(recorded, current string) bool {
+	recorded = normalizeEmbedIdentity(strings.TrimSpace(recorded))
+	current = strings.TrimSpace(current)
+	if recorded == "" || recorded == current {
+		return true
+	}
+	return blankModelIdentityMatches(recorded, current)
+}
+
+// blankModelIdentityMatches implements the #705 legacy blank-model grace: two
+// current-shape identities match when every component is equal except a model
+// component the RECORDING left empty. Anything else (a differing provider,
+// endpoint, dimension, mode — or a recorded model that names a DIFFERENT model)
+// is a real mismatch.
+func blankModelIdentityMatches(recorded, current string) bool {
+	rec := strings.Split(recorded, "|")
+	cur := strings.Split(current, "|")
+	if len(rec) != embedIdentityFields || len(cur) != embedIdentityFields {
+		return false
+	}
+	for i := range rec {
+		if rec[i] == cur[i] {
+			continue
+		}
+		isModelField := i == embedIdentityTextModelField || i == embedIdentityCodeModelField
+		if isModelField && rec[i] == "" {
+			continue // legacy blank: the adapter default produced these vectors.
+		}
+		return false
+	}
+	return true
 }
 
 // normalizeEmbedIdentity upgrades a legacy recorded identity to the current

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -343,7 +343,7 @@ func Select(precedence []Profile, byName map[string]Profile, cap Capability, exp
 // a matching identity. Recording the resolved model closes that, and also makes
 // "set the model to the value already in effect" a no-op instead of a spurious
 // reindex (#440 F3). Recorded BLANK model fields from before this rule are
-// migrated by embedIdentityMatches, so no existing corpus re-embeds.
+// migrated by EmbedIdentityMatches, so no existing corpus re-embeds.
 //
 // contextual is the TERMINAL (9th) field: the EFFECTIVE contextual-retrieval
 // mode (8.1.8) — EmbedContextualOff when the feature is disabled OR enabled

--- a/internal/providerfactory/factory.go
+++ b/internal/providerfactory/factory.go
@@ -132,6 +132,18 @@ func Embedder(p provider.Profile) (model.Embedder, error) {
 	if err := validateEmbedMultimodal(p); err != nil {
 		return nil, err
 	}
+	// Trim the model fields before any adapter sees them, so what RUNS is what
+	// the embed identity RECORDS.
+	//
+	// The branches below test `!= ""` while provider.EffectiveEmbedModels — the
+	// single source the identity is built from — trims first. A whitespace-only
+	// setting therefore passed straight through to the adapter as " " while the
+	// identity recorded the kind's built-in default, so the corpus was fenced
+	// against a vector space it was not actually using. Trimming here makes " "
+	// behave as unset on both paths, which is the value the identity already
+	// assumed.
+	p.EmbedTextModel = strings.TrimSpace(p.EmbedTextModel)
+	p.EmbedCodeModel = strings.TrimSpace(p.EmbedCodeModel)
 	switch p.Kind {
 	case provider.KindOpenAI:
 		c := openai.NewClient(p.BaseURL, p.APIKey)

--- a/internal/providerfactory/factory.go
+++ b/internal/providerfactory/factory.go
@@ -193,40 +193,15 @@ func Embedder(p provider.Profile) (model.Embedder, error) {
 // the asymmetry by construction and gives per-query metrics a truthful model
 // label instead of an empty string.
 //
-// Note: EmbedIdentity (SPEC 8.1.4) is intentionally derived from the RAW
-// profile field, not this resolved value, so making the effective model
-// explicit here never flips a recorded identity or forces a spurious reindex.
+// EmbedIdentity (SPEC 8.1.4) is derived from this SAME resolved value (issue
+// #705): the identity must name the model that actually produced the vectors,
+// so a raw blank field can no longer stand in for an adapter default. This
+// function is now a thin alias for provider.EffectiveEmbedModels, kept because
+// the CLI and this package's callers reach for it here; the resolution table
+// lives in the provider package so the identity can consult it without
+// depending on the HTTP clients.
 func EffectiveEmbedModels(p provider.Profile) (text, code string) {
-	def := kindDefaultEmbedModel(p.Kind)
-	text = strings.TrimSpace(p.EmbedTextModel)
-	if text == "" {
-		text = def
-	}
-	code = strings.TrimSpace(p.EmbedCodeModel)
-	if code == "" {
-		code = def
-	}
-	return text, code
-}
-
-// kindDefaultEmbedModel returns the embed model an adapter of kind k substitutes
-// when the profile leaves the model blank, mirroring the per-kind fallbacks in
-// Embedder and each client's Embed. Kinds with no embed capability (or none with
-// a defined default) return "" — the effective model is then just whatever the
-// profile carries.
-func kindDefaultEmbedModel(k provider.Kind) string {
-	switch k {
-	case provider.KindOpenAI:
-		return openai.DefaultEmbedModel
-	case provider.KindCohere:
-		return cohere.DefaultEmbedModel
-	case provider.KindGemini:
-		return gemini.DefaultEmbedModel
-	case provider.KindOmniEmbed:
-		return omniembed.DefaultModel
-	default:
-		return ""
-	}
+	return provider.EffectiveEmbedModels(p)
 }
 
 // Generator builds a model.Generator (kinds: openai, gemini, cohere,

--- a/tests/cohere/embed_zero_vector_703_test.go
+++ b/tests/cohere/embed_zero_vector_703_test.go
@@ -1,0 +1,38 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// TestEmbed_RejectsZeroNormVector pins issue #703 at the Cohere provider
+// boundary: an all-zero vector in a 200 OK response is malformed output. It has
+// no cosine direction, so indexing it yields a chunk that scores 0 against every
+// query while reporting embedding_status=embedded.
+func TestEmbed_RejectsZeroNormVector(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"embeddings": map[string]any{"float": [][]float64{{1, 0.5}, {0, 0}}},
+		})
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL)
+	vecs, err := c.Embed(context.Background(), "embed-v4.0", model.EmbedDocument, []string{"healthy", "zero"})
+	if err == nil {
+		t.Fatalf("Embed returned %v, want a malformed-output error for the zero vector", vecs)
+	}
+	var pErr *model.ProviderError
+	if !errors.As(err, &pErr) {
+		t.Fatalf("error %v is not a *model.ProviderError", err)
+	}
+	if pErr.Retryable {
+		t.Fatalf("malformed provider output must be non-retryable: %v", pErr)
+	}
+}

--- a/tests/config/self_hosted_endpoints_test.go
+++ b/tests/config/self_hosted_endpoints_test.go
@@ -50,7 +50,11 @@ func TestSelfHosted_EmbedBaseURLResolves(t *testing.T) {
 	// The embed identity must encode the self-hosted profile + custom base_url
 	// + model so a change to any is corpus-lifetime / reindex-bound (SPEC
 	// §8.1.4 / §8.5 / issue #560): the non-canonical endpoint is the 2nd field.
-	if id := r.EmbedIdentity(); id != "gpu-embed|http://gpu-vps:8080/v1|bge-m3||0|0|off|off|off" {
+	// The code axis records text-embedding-3-small, not "": the profile leaves
+	// embed_code_model blank, and a blank field means the kind:openai adapter
+	// default is what goes on the wire for the code axis, so that is what the
+	// identity must name (issue #705).
+	if id := r.EmbedIdentity(); id != "gpu-embed|http://gpu-vps:8080/v1|bge-m3|text-embedding-3-small|0|0|off|off|off" {
 		t.Fatalf("embed identity = %q", id)
 	}
 }

--- a/tests/gemini/client_test.go
+++ b/tests/gemini/client_test.go
@@ -267,13 +267,17 @@ func TestEmbed_OutputDimensionalityAndNormalize(t *testing.T) {
 	defer srv.Close()
 
 	c := newClient(srv.URL)
-	c.EmbedTextDim = 768
+	// The requested dimension matches the stub's 2-component response: when a
+	// dimension is requested the adapter also REQUIRES the response to carry
+	// exactly that many components (issue #703), so a fixture that asks for 768
+	// and returns 2 is now (correctly) a malformed-provider-output error.
+	c.EmbedTextDim = 2
 	vecs, err := c.Embed(context.Background(), "m", model.EmbedDocument, []string{"x"})
 	if err != nil {
 		t.Fatalf("embed: %v", err)
 	}
-	if gotDim == nil || *gotDim != 768 {
-		t.Fatalf("outputDimensionality = %v, want 768", gotDim)
+	if gotDim == nil || *gotDim != 2 {
+		t.Fatalf("outputDimensionality = %v, want 2", gotDim)
 	}
 	// [3,4]/5 = [0.6,0.8]; norm must be ~1.
 	got := vecs[0]

--- a/tests/gemini/embed_zero_vector_703_test.go
+++ b/tests/gemini/embed_zero_vector_703_test.go
@@ -1,0 +1,73 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// TestEmbed_RejectsZeroNormVector pins issue #703 at the Gemini provider
+// boundary. Gemini is the case that made the gap explicit: l2Normalize returns
+// a zero vector UNCHANGED (there is no direction to scale), so a zero vector
+// used to pass straight through the SPEC 8.1.6 normalization step and into the
+// index.
+func TestEmbed_RejectsZeroNormVector(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		req := decodeNativeEmbed(t, r)
+		embeddings := make([]map[string]any, len(req.Requests))
+		for i := range req.Requests {
+			embeddings[i] = map[string]any{"values": []float64{0, 0}}
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"embeddings": embeddings})
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL)
+	for _, role := range []model.EmbedRole{model.EmbedDocument, model.EmbedQuery} {
+		vecs, err := c.Embed(context.Background(), "m", role, []string{"x"})
+		if err == nil {
+			t.Fatalf("role %v: Embed returned %v, want a malformed-output error", role, vecs)
+		}
+		var pErr *model.ProviderError
+		if !errors.As(err, &pErr) {
+			t.Fatalf("role %v: error %v is not a *model.ProviderError", role, err)
+		}
+		if pErr.Retryable {
+			t.Fatalf("role %v: malformed provider output must be non-retryable: %v", role, pErr)
+		}
+	}
+
+	// The same holds with a requested output dimension (SPEC 8.1.6): the
+	// re-normalization step cannot rescue a zero vector.
+	c.EmbedTextDim = 2
+	if _, err := c.Embed(context.Background(), "m", model.EmbedDocument, []string{"x"}); err == nil {
+		t.Fatal("a requested output dimension must not make a zero vector acceptable")
+	}
+}
+
+// TestEmbed_RejectsShortVectorForRequestedDimension pins the dimension half of
+// #703: when the operator requested an output dimensionality (8.1.6), a response
+// that carries a different number of components is malformed. Accepting it would
+// silently fix the corpus at a dimension nobody asked for.
+func TestEmbed_RejectsShortVectorForRequestedDimension(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		req := decodeNativeEmbed(t, r)
+		embeddings := make([]map[string]any, len(req.Requests))
+		for i := range req.Requests {
+			embeddings[i] = map[string]any{"values": []float64{3, 4}} // 2 components
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"embeddings": embeddings})
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL)
+	c.EmbedTextDim = 8
+	if _, err := c.Embed(context.Background(), "m", model.EmbedDocument, []string{"x"}); err == nil {
+		t.Fatal("Embed accepted a 2-component vector for a requested dimension of 8")
+	}
+}

--- a/tests/index/embed_zero_vector_703_test.go
+++ b/tests/index/embed_zero_vector_703_test.go
@@ -1,0 +1,96 @@
+package tests
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// zeroVectorText is the sentinel input the zeroVectorEmbedder answers with an
+// all-zero vector — a SUCCESSFUL response (no error) carrying an unusable
+// embedding, which is exactly how this failure arrives in production.
+const zeroVectorText = "ZERO-VECTOR-INPUT"
+
+// zeroVectorEmbedder models a provider/proxy that returns 200 OK with an
+// all-zero vector for one input (quota exhaustion, a model that failed to load,
+// a truncated input) and healthy vectors for the rest.
+type zeroVectorEmbedder struct{}
+
+func (e *zeroVectorEmbedder) Embed(_ context.Context, _ string, _ model.EmbedRole, inputs []string) ([][]float32, error) {
+	out := make([][]float32, len(inputs))
+	for i, in := range inputs {
+		if strings.Contains(in, zeroVectorText) {
+			out[i] = []float32{0, 0}
+			continue
+		}
+		out[i] = []float32{1, 0}
+	}
+	return out, nil
+}
+
+// TestEmbedAndIndex_ZeroVectorNeverIndexed pins issue #703 at the worker: a
+// zero-norm vector must never be written to an index or marked embedded, and it
+// must not take its healthy batch siblings down with it.
+//
+// The worker is the LAST gate: it accepts any model.Embedder, including one this
+// process does not own (a distributed worker, a self-hosted service), so the
+// per-adapter checks alone cannot guarantee the index stays clean.
+func TestEmbedAndIndex_ZeroVectorNeverIndexed(t *testing.T) {
+	ctx := context.Background()
+	src := &fakeChunkSource{}
+	idx := index.NewHNSWIndex("")
+	worker := &index.EmbeddingWorker{Source: src, Index: idx, Embedder: &zeroVectorEmbedder{}, BatchSize: 8}
+
+	tasks := []model.ChunkTask{
+		textTask(1, "healthy one"),
+		textTask(2, zeroVectorText), // the undirected vector
+		textTask(3, "healthy three"),
+	}
+
+	n, err := worker.EmbedAndIndex(ctx, "text", tasks)
+	if err != nil {
+		t.Fatalf("EmbedAndIndex: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("indexed = %d, want 2 (both healthy siblings, not the zero vector)", n)
+	}
+
+	// The zero-vector chunk is recorded as a per-document FAILURE with a reason,
+	// exactly like a provider-rejected poison chunk (#399) — never as embedded.
+	if len(src.failedLabels) != 1 || src.failedLabels[0] != 2 {
+		t.Fatalf("failed labels = %v, want exactly [2]", src.failedLabels)
+	}
+	if src.failedCategory != "embedding_failure" {
+		t.Fatalf("failed category = %q, want embedding_failure", src.failedCategory)
+	}
+	if !strings.Contains(src.failedReason, "zero") {
+		t.Fatalf("failed reason = %q, want it to name the zero-norm vector", src.failedReason)
+	}
+	for _, l := range src.embedded {
+		if l == 2 {
+			t.Fatalf("the zero-vector chunk was marked embedded: %v", src.embedded)
+		}
+	}
+	if len(src.embedded) != 2 {
+		t.Fatalf("embedded = %v, want the 2 healthy chunks", src.embedded)
+	}
+
+	// And nothing zero-norm reached the index: every stored vector must have a
+	// direction. A zero vector in the index is invisible to every query while
+	// looking like healthy indexed data.
+	hits, err := idx.Search(ctx, []float32{1, 0}, 10, model.Filter{})
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(hits) != 2 {
+		t.Fatalf("index holds %d vectors, want 2 (the zero vector must not be stored)", len(hits))
+	}
+	for _, h := range hits {
+		if h.ChunkID == 2 {
+			t.Fatalf("the zero vector was indexed: %+v", h)
+		}
+	}
+}

--- a/tests/index/ensure_identity_migration_705_test.go
+++ b/tests/index/ensure_identity_migration_705_test.go
@@ -84,7 +84,10 @@ func TestEnsureIdentity_RealChangeStillResets(t *testing.T) {
 		if err := index.EnsureIdentity(ctx, idx, current); err != nil {
 			t.Fatalf("EnsureIdentity: %v", err)
 		}
-		hits, _ := idx.Search(ctx, []float32{1, 0}, 10, model.Filter{})
+		hits, err := idx.Search(ctx, []float32{1, 0}, 10, model.Filter{})
+		if err != nil {
+			t.Fatalf("search after EnsureIdentity: %v", err)
+		}
 		if len(hits) != 0 {
 			t.Fatalf("recorded %q vs current %q: vectors from another space were kept: %v",
 				recorded, current, chunkIDs(hits))

--- a/tests/index/ensure_identity_migration_705_test.go
+++ b/tests/index/ensure_identity_migration_705_test.go
@@ -1,0 +1,113 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/provider"
+)
+
+// TestEnsureIdentity_MigratedRecordingKeepsVectors pins the migration half of
+// issues #705/#702 where it actually bites: EnsureIdentity is what WIPES an
+// index, and it must use the same compatibility rule as the startup check.
+//
+// config.VerifyEmbedIdentity migrates a legacy recording (the SPEC 8.1.4
+// field-count ladder, and the #705 blank-model grace) and lets startup proceed.
+// If EnsureIdentity then byte-compares, it answers "different" for exactly those
+// migrated corpora and Resets — a full, unannounced re-embed of a corpus the
+// operator was just told was compatible. The two MUST agree.
+func TestEnsureIdentity_MigratedRecordingKeepsVectors(t *testing.T) {
+	ctx := context.Background()
+	current := provider.EmbedIdentity(
+		provider.Profile{Name: "openai", Kind: provider.KindOpenAI}, false, provider.EmbedContextualOff)
+
+	// Each of these is a form a shipped build actually recorded for that same
+	// profile, before a component existed or before models were resolved.
+	recordings := map[string]string{
+		"pre-#705 blank models":     "openai||||0|0|off|off|off",
+		"pre-contextual (8 fields)": "openai||||0|0|off|off",
+		"pre-base_url (7 fields)":   "openai|||0|0|off|off",
+		"pre-late-chunking (6)":     "openai|||0|0|off",
+		"pre-multimodal (5 fields)": "openai|||0|0",
+		"pre-dimension (3 fields)":  "openai||",
+	}
+	for name, recorded := range recordings {
+		t.Run(name, func(t *testing.T) {
+			// Sanity: the startup check accepts this recording…
+			if err := provider.VerifyEmbedIdentity(recorded, current); err != nil {
+				t.Fatalf("VerifyEmbedIdentity rejected %q: %v", recorded, err)
+			}
+			idx := index.NewHNSWIndex("")
+			if err := idx.Reset(ctx, recorded); err != nil {
+				t.Fatalf("seed recorded identity: %v", err)
+			}
+			mustUpsert(t, idx, model.IndexPayload{ChunkID: 1, RelPath: "a.md"}, []float32{1, 0})
+
+			// …so the index must NOT be wiped.
+			if err := index.EnsureIdentity(ctx, idx, current); err != nil {
+				t.Fatalf("EnsureIdentity: %v", err)
+			}
+			hits, err := idx.Search(ctx, []float32{1, 0}, 10, model.Filter{})
+			if err != nil {
+				t.Fatalf("search: %v", err)
+			}
+			if len(hits) != 1 {
+				t.Fatalf("EnsureIdentity silently re-embedded a compatible corpus (recorded %q): vectors = %v",
+					recorded, chunkIDs(hits))
+			}
+		})
+	}
+}
+
+// TestEnsureIdentity_RealChangeStillResets is the other direction: a genuine
+// vector-space change must still discard the vectors. The migration must not
+// become a blanket "everything matches", or the corpus-lifetime invariant is
+// gone.
+func TestEnsureIdentity_RealChangeStillResets(t *testing.T) {
+	ctx := context.Background()
+	current := provider.EmbedIdentity(
+		provider.Profile{Name: "openai", Kind: provider.KindOpenAI}, false, provider.EmbedContextualOff)
+
+	for _, recorded := range []string{
+		"cohere||||0|0|off|off|off",                          // different provider
+		"openai||text-embedding-3-large||0|0|off|off|off",    // different concrete model
+		"openai|https://proxy.internal/v1|||0|0|off|off|off", // different endpoint (#702 class)
+		"openai||||512|0|off|off|off",                        // different requested dimension
+	} {
+		idx := index.NewHNSWIndex("")
+		if err := idx.Reset(ctx, recorded); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		mustUpsert(t, idx, model.IndexPayload{ChunkID: 1, RelPath: "a.md"}, []float32{1, 0})
+		if err := index.EnsureIdentity(ctx, idx, current); err != nil {
+			t.Fatalf("EnsureIdentity: %v", err)
+		}
+		hits, _ := idx.Search(ctx, []float32{1, 0}, 10, model.Filter{})
+		if len(hits) != 0 {
+			t.Fatalf("recorded %q vs current %q: vectors from another space were kept: %v",
+				recorded, current, chunkIDs(hits))
+		}
+		if id, _ := idx.Identity(ctx); id != current {
+			t.Fatalf("identity after reset = %q, want %q", id, current)
+		}
+	}
+}
+
+// TestEnsureIdentity_FreshIndexStillRecords guards the case the compatibility
+// rule must NOT absorb: an empty recorded identity is a fresh index, and Reset
+// is what RECORDS the identity there. Treating "" as "compatible" would leave
+// the index permanently unlabeled.
+func TestEnsureIdentity_FreshIndexStillRecords(t *testing.T) {
+	ctx := context.Background()
+	idx := index.NewHNSWIndex("")
+	current := provider.EmbedIdentity(
+		provider.Profile{Name: "openai", Kind: provider.KindOpenAI}, false, provider.EmbedContextualOff)
+	if err := index.EnsureIdentity(ctx, idx, current); err != nil {
+		t.Fatalf("EnsureIdentity: %v", err)
+	}
+	if id, _ := idx.Identity(ctx); id != current {
+		t.Fatalf("fresh index identity = %q, want %q", id, current)
+	}
+}

--- a/tests/mistral/embed_zero_vector_703_test.go
+++ b/tests/mistral/embed_zero_vector_703_test.go
@@ -1,0 +1,61 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/mistral"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// TestEmbed_RejectsZeroNormVector pins issue #703 at the Mistral provider
+// boundary (the DEFAULT embed provider): an all-zero vector in an otherwise
+// successful response is malformed output and must fail the call with a
+// non-retryable provider error rather than being handed to the index.
+func TestEmbed_RejectsZeroNormVector(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{{"index": 0, "embedding": []float64{0, 0, 0}}},
+		})
+	}))
+	defer server.Close()
+
+	c := mistral.NewClient(server.URL, "test-key")
+	vecs, err := c.Embed(context.Background(), "mistral-embed", model.EmbedDocument, []string{"x"})
+	if err == nil {
+		t.Fatalf("Embed returned %v, want a malformed-output error for the zero vector", vecs)
+	}
+	var pErr *model.ProviderError
+	if !errors.As(err, &pErr) {
+		t.Fatalf("error %v is not a *model.ProviderError", err)
+	}
+	if pErr.Retryable {
+		t.Fatalf("malformed provider output must be non-retryable: %v", pErr)
+	}
+}
+
+// TestEmbed_HealthyVectorStillAccepted guards the other direction: the #703
+// check must not reject a normal response. (Non-finite components are covered
+// by the shared-validator suite in tests/model — encoding/json rejects a NaN/Inf
+// literal before an adapter ever sees it, so that case cannot be staged here.)
+func TestEmbed_HealthyVectorStillAccepted(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{{"index": 0, "embedding": []float64{0, 0.0001}}},
+		})
+	}))
+	defer server.Close()
+
+	c := mistral.NewClient(server.URL, "test-key")
+	vecs, err := c.Embed(context.Background(), "mistral-embed", model.EmbedDocument, []string{"x"})
+	if err != nil {
+		t.Fatalf("a tiny but non-zero vector must be accepted: %v", err)
+	}
+	if len(vecs) != 1 {
+		t.Fatalf("vectors = %v, want 1", vecs)
+	}
+}

--- a/tests/model/embed_validate_703_test.go
+++ b/tests/model/embed_validate_703_test.go
@@ -1,0 +1,89 @@
+package tests
+
+import (
+	"errors"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// TestValidateEmbedVectors pins the shared provider-output boundary check
+// (issue #703). Every embed adapter and the embedding worker run their vectors
+// through it, so this is the single place the "what is a usable embedding"
+// contract is stated: non-empty, right dimension when one is known, finite, and
+// with an actual direction.
+func TestValidateEmbedVectors(t *testing.T) {
+	cases := []struct {
+		name    string
+		wantDim int
+		vectors [][]float32
+		wantErr bool
+	}{
+		{"healthy", 0, [][]float32{{1, 0}, {0.1, -0.9}}, false},
+		{"tiny but non-zero", 0, [][]float32{{0, 1e-8}}, false},
+		{"negative components are fine", 0, [][]float32{{-1, -1}}, false},
+		{"no vectors at all", 0, nil, false}, // an empty batch is not malformed
+		{"zero norm", 0, [][]float32{{0, 0, 0}}, true},
+		{"zero norm among healthy siblings", 0, [][]float32{{1, 0}, {0, 0}, {0, 1}}, true},
+		{"negative zero is still zero", 0, [][]float32{{float32(math.Copysign(0, -1)), 0}}, true},
+		{"empty vector", 0, [][]float32{{}}, true},
+		{"NaN component", 0, [][]float32{{float32(math.NaN()), 1}}, true},
+		{"+Inf component", 0, [][]float32{{float32(math.Inf(1)), 1}}, true},
+		{"-Inf component", 0, [][]float32{{float32(math.Inf(-1)), 1}}, true},
+		{"requested dimension honored", 3, [][]float32{{1, 0, 0}}, false},
+		{"short of the requested dimension", 3, [][]float32{{1, 0}}, true},
+		{"longer than the requested dimension", 3, [][]float32{{1, 0, 0, 0}}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := model.ValidateEmbedVectors("TEST_FAILED", tc.wantDim, tc.vectors)
+			if tc.wantErr != (err != nil) {
+				t.Fatalf("err = %v, wantErr = %v", err, tc.wantErr)
+			}
+			if err == nil {
+				return
+			}
+			var pErr *model.ProviderError
+			if !errors.As(err, &pErr) {
+				t.Fatalf("error %v is not a *model.ProviderError", err)
+			}
+			// Malformed output is terminal: the same response comes back on
+			// retry, so the chunk must be marked failed rather than retried
+			// forever.
+			if pErr.Retryable {
+				t.Fatalf("malformed output must be non-retryable: %v", pErr)
+			}
+			if pErr.Code != "TEST_FAILED" {
+				t.Fatalf("code = %q, want the caller's provider code", pErr.Code)
+			}
+		})
+	}
+}
+
+// TestValidateEmbedVectors_MessageIsNotMisclassified guards a subtle downstream
+// hazard: these error strings are keyword-classified by store.ClassifyError /
+// IsTransientError. A message that happened to contain an HTTP status token
+// ("503", "429", …) would be read as a TRANSIENT upstream failure, and the
+// embedding worker would leave the chunk PENDING and retry it forever instead
+// of recording a terminal failure. The message therefore carries no batch index.
+func TestValidateEmbedVectors_MessageIsNotMisclassified(t *testing.T) {
+	// A batch large enough that a per-item index would reach 503/529.
+	vectors := make([][]float32, 600)
+	for i := range vectors {
+		vectors[i] = []float32{1, 0}
+	}
+	vectors[503] = []float32{0, 0}
+	vectors[529] = []float32{0, 0}
+
+	err := model.ValidateEmbedVectors("TEST_FAILED", 0, vectors)
+	if err == nil {
+		t.Fatal("want an error for the zero vectors")
+	}
+	for _, token := range []string{"503", "529", "429", "401", "403", "413"} {
+		if strings.Contains(err.Error(), token) {
+			t.Fatalf("error message %q contains %q, which downstream keyword classification reads as a transient/auth failure", err, token)
+		}
+	}
+}

--- a/tests/model/embed_validate_703_test.go
+++ b/tests/model/embed_validate_703_test.go
@@ -32,6 +32,8 @@ func TestValidateEmbedVectors(t *testing.T) {
 		{"NaN component", 0, [][]float32{{float32(math.NaN()), 1}}, true},
 		{"+Inf component", 0, [][]float32{{float32(math.Inf(1)), 1}}, true},
 		{"-Inf component", 0, [][]float32{{float32(math.Inf(-1)), 1}}, true},
+		{"consistent width without a requested dimension", 0, [][]float32{{1, 0}, {0, 1}}, false},
+		{"ragged batch without a requested dimension", 0, [][]float32{{1, 0}, {0, 1, 0}}, true},
 		{"requested dimension honored", 3, [][]float32{{1, 0, 0}}, false},
 		{"short of the requested dimension", 3, [][]float32{{1, 0}}, true},
 		{"longer than the requested dimension", 3, [][]float32{{1, 0, 0, 0}}, true},

--- a/tests/omniembed/embed_zero_vector_703_test.go
+++ b/tests/omniembed/embed_zero_vector_703_test.go
@@ -1,0 +1,48 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// TestEmbed_RejectsZeroNormVector pins issue #703 at the OmniEmbed provider
+// boundary. Self-hosted servers are exactly where an all-zero "successful"
+// vector shows up (a model that failed to load, an unsupported input silently
+// producing zeros), and both the text and media paths must reject it: an
+// undirected vector scores 0 against every query yet indexes as healthy.
+func TestEmbed_RejectsZeroNormVector(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{{"index": 0, "embedding": []float64{0, 0, 0, 0}}},
+		})
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL, "")
+
+	vecs, err := c.Embed(context.Background(), "omniembed", model.EmbedDocument, []string{"x"})
+	if err == nil {
+		t.Fatalf("Embed returned %v, want a malformed-output error for the zero vector", vecs)
+	}
+	var pErr *model.ProviderError
+	if !errors.As(err, &pErr) {
+		t.Fatalf("error %v is not a *model.ProviderError", err)
+	}
+	if pErr.Retryable {
+		t.Fatalf("malformed provider output must be non-retryable: %v", pErr)
+	}
+
+	// The media path shares the same response handling, so a zero media vector
+	// is rejected identically (SPEC 8.1.7 puts both in ONE vector space).
+	items := []model.MediaInput{{MimeType: "image/png", Data: []byte("PNGBYTES")}}
+	if _, err := c.EmbedMedia(context.Background(), "omniembed", model.EmbedDocument, items); err == nil {
+		t.Fatal("EmbedMedia accepted a zero-norm vector")
+	}
+}

--- a/tests/openai/embed_zero_vector_703_test.go
+++ b/tests/openai/embed_zero_vector_703_test.go
@@ -1,0 +1,61 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// TestEmbed_RejectsZeroNormVector pins issue #703 at the OpenAI provider
+// boundary: a 200 OK response carrying an all-zero vector is malformed output,
+// not a usable embedding. A zero vector has no cosine direction, so indexing it
+// produces a chunk that scores 0 against every query yet reports
+// embedding_status=embedded — a silent, permanent retrieval hole. The adapter
+// must fail the call with a NON-RETRYABLE provider error instead of returning
+// the vector.
+func TestEmbed_RejectsZeroNormVector(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Input []string `json:"input"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		data := make([]map[string]any, len(req.Input))
+		for i := range req.Input {
+			vec := []float64{1, 0.5}
+			if strings.Contains(req.Input[i], "zero") {
+				vec = []float64{0, 0} // the malformed item
+			}
+			data[i] = map[string]any{"index": i, "embedding": vec}
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": data})
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL)
+	// Both the document (index) and query paths run through Embed, so a zero
+	// vector is rejected on either side rather than producing all-zero scores.
+	for _, role := range []model.EmbedRole{model.EmbedDocument, model.EmbedQuery} {
+		vecs, err := c.Embed(context.Background(), "m", role, []string{"healthy", "zero"})
+		if err == nil {
+			t.Fatalf("role %v: Embed returned %v, want a malformed-output error for the zero vector", role, vecs)
+		}
+		var pErr *model.ProviderError
+		if !errors.As(err, &pErr) {
+			t.Fatalf("role %v: error %v is not a *model.ProviderError", role, err)
+		}
+		if pErr.Retryable {
+			t.Fatalf("role %v: malformed provider output must be non-retryable: %v", role, pErr)
+		}
+	}
+
+	// A healthy batch still succeeds (the check must not reject real vectors).
+	if _, err := c.Embed(context.Background(), "m", model.EmbedDocument, []string{"healthy"}); err != nil {
+		t.Fatalf("healthy batch: %v", err)
+	}
+}

--- a/tests/provider/embed_identity_effective_model_705_test.go
+++ b/tests/provider/embed_identity_effective_model_705_test.go
@@ -1,0 +1,179 @@
+package tests
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/provider"
+)
+
+// identityField returns the i-th component of p's embed identity.
+func identityField(t *testing.T, p provider.Profile, i int) string {
+	t.Helper()
+	id := provider.EmbedIdentity(p, false, provider.EmbedContextualOff)
+	parts := strings.Split(id, "|")
+	if i >= len(parts) {
+		t.Fatalf("identity %q has no field %d", id, i)
+	}
+	return parts[i]
+}
+
+// TestEmbedIdentity_RecordsEffectiveModel pins issue #705: the identity's model
+// components are the models actually sent on the wire, not the raw profile
+// fields.
+//
+// The built-in `openai`, `cohere`, `local` and `omniembed` profiles ship with
+// BLANK embed model fields (SPEC 8.1.1) — the adapter substitutes its own
+// default. Recording the blank field meant the corpus-lifetime identity named no
+// model at all, so the per-axis model fence of 8.1.4 was inert for exactly those
+// profiles: change an adapter default (or run a worker built from a binary that
+// defaults differently) and the identity still compares equal while the vectors
+// come from a different model space.
+func TestEmbedIdentity_RecordsEffectiveModel(t *testing.T) {
+	cases := []struct {
+		name string
+		kind provider.Kind
+		want string
+	}{
+		{"openai", provider.KindOpenAI, provider.DefaultOpenAIEmbedModel},
+		{"cohere", provider.KindCohere, provider.DefaultCohereEmbedModel},
+		{"gemini", provider.KindGemini, provider.DefaultGeminiEmbedModel},
+		{"omniembed", provider.KindOmniEmbed, provider.DefaultOmniEmbedModel},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			blank := provider.Profile{Name: tc.name, Kind: tc.kind} // no models set
+			for _, field := range []int{2, 3} {                     // text_model, code_model
+				if got := identityField(t, blank, field); got != tc.want {
+					t.Fatalf("identity field %d = %q, want the effective model %q", field, got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+// TestEmbedIdentity_ExplicitDefaultIsNotAChange pins the #705/#440-F3 property
+// an operator hits first: writing the model that is ALREADY in effect into the
+// config must not look like a new vector space. Before the fix the blank profile
+// recorded "" and the explicit one recorded "text-embedding-3-small", so simply
+// documenting the default demanded a full reindex.
+func TestEmbedIdentity_ExplicitDefaultIsNotAChange(t *testing.T) {
+	implicit := provider.Profile{Name: "openai", Kind: provider.KindOpenAI}
+	explicit := provider.Profile{Name: "openai", Kind: provider.KindOpenAI,
+		EmbedTextModel: provider.DefaultOpenAIEmbedModel,
+		EmbedCodeModel: provider.DefaultOpenAIEmbedModel}
+
+	idImplicit := provider.EmbedIdentity(implicit, false, provider.EmbedContextualOff)
+	idExplicit := provider.EmbedIdentity(explicit, false, provider.EmbedContextualOff)
+	if idImplicit != idExplicit {
+		t.Fatalf("making the effective default explicit changed the identity:\n implicit %q\n explicit %q",
+			idImplicit, idExplicit)
+	}
+	if err := provider.VerifyEmbedIdentity(idImplicit, idExplicit); err != nil {
+		t.Fatalf("no reindex may be demanded for an unchanged effective model: %v", err)
+	}
+}
+
+// TestEmbedIdentity_DifferentModelsStillDiffer is the other direction: configs
+// that genuinely produce different vector spaces must still derive different
+// identities. A grace rule that made everything match would be worse than the
+// bug it fixes.
+func TestEmbedIdentity_DifferentModelsStillDiffer(t *testing.T) {
+	base := provider.Profile{Name: "openai", Kind: provider.KindOpenAI,
+		EmbedTextModel: "text-embedding-3-small", EmbedCodeModel: "text-embedding-3-small"}
+
+	variants := map[string]provider.Profile{
+		"different text model": func() provider.Profile {
+			p := base
+			p.EmbedTextModel = "text-embedding-3-large"
+			return p
+		}(),
+		"different code model": func() provider.Profile {
+			p := base
+			p.EmbedCodeModel = "text-embedding-3-large"
+			return p
+		}(),
+		"different dimension": func() provider.Profile {
+			p := base
+			p.EmbedTextDim = 512
+			return p
+		}(),
+		"different endpoint": func() provider.Profile {
+			p := base
+			p.BaseURL = "https://proxy.internal/v1"
+			return p
+		}(),
+		"different profile name": func() provider.Profile {
+			p := base
+			p.Name = "openai-alt"
+			return p
+		}(),
+	}
+	idBase := provider.EmbedIdentity(base, false, provider.EmbedContextualOff)
+	for name, v := range variants {
+		id := provider.EmbedIdentity(v, false, provider.EmbedContextualOff)
+		if id == idBase {
+			t.Errorf("%s: identities must differ, both are %q", name, id)
+		}
+		if err := provider.VerifyEmbedIdentity(idBase, id); err == nil {
+			t.Errorf("%s: a real vector-space change must be rejected", name)
+		}
+	}
+
+	// And a same-config pair must NOT differ (no gratuitous churn).
+	if provider.EmbedIdentity(base, false, provider.EmbedContextualOff) != idBase {
+		t.Fatal("identical profiles must derive identical identities")
+	}
+}
+
+// TestEmbedIdentity_LegacyBlankModelMigrates is the migration half of #705: a
+// corpus whose identity was recorded BEFORE this fix carries "" in the model
+// fields, because that is what the built-in profile held. Those vectors were in
+// fact produced by the adapter default, so the recording must be read as "the
+// adapter default", not as a mismatch — otherwise every openai/cohere/local/
+// omniembed corpus would silently re-embed on upgrade.
+func TestEmbedIdentity_LegacyBlankModelMigrates(t *testing.T) {
+	current := provider.EmbedIdentity(
+		provider.Profile{Name: "openai", Kind: provider.KindOpenAI}, false, provider.EmbedContextualOff)
+
+	// Exactly what a pre-#705 build recorded for that profile.
+	legacy9 := "openai||||0|0|off|off|off"
+	if err := provider.VerifyEmbedIdentity(legacy9, current); err != nil {
+		t.Fatalf("a pre-#705 blank-model recording must migrate, not reindex: %v", err)
+	}
+	if !provider.EmbedIdentityMatches(legacy9, current) {
+		t.Fatal("EmbedIdentityMatches must agree with VerifyEmbedIdentity")
+	}
+	// The same recording through the 8.1.4 field-count ladder (a pre-contextual,
+	// 8-field form) must migrate too — both migrations compose.
+	if err := provider.VerifyEmbedIdentity("openai||||0|0|off|off", current); err != nil {
+		t.Fatalf("ladder + blank-model migration must compose: %v", err)
+	}
+
+	// The grace is legacy-only and one-directional. It must not let a blank
+	// recording match a DIFFERENT provider/endpoint/dimension…
+	for _, bad := range []string{
+		"cohere||||0|0|off|off|off",                          // different provider
+		"openai|https://proxy.internal/v1|||0|0|off|off|off", // different endpoint
+		"openai||||512|0|off|off|off",                        // different dimension
+		"openai||||0|0|augment|off|off",                      // different multimodal mode
+	} {
+		if err := provider.VerifyEmbedIdentity(bad, current); err == nil {
+			t.Errorf("recorded %q must not be accepted as compatible with %q", bad, current)
+		}
+	}
+
+	// …nor may a recorded CONCRETE model match a different concrete model. Only
+	// an absent recording is graced, so every identity written from now on
+	// enforces the model fence (a changed adapter default or a differently
+	// defaulting distributed worker mismatches loudly).
+	concrete := "openai||text-embedding-3-large|text-embedding-3-large|0|0|off|off|off"
+	if err := provider.VerifyEmbedIdentity(concrete, current); err == nil {
+		t.Error("a recorded concrete model must never be graced into matching another model")
+	}
+	// And the grace is not symmetric: a blank CURRENT identity (which the fix
+	// no longer produces for these kinds) must not swallow a concrete recording.
+	if provider.EmbedIdentityMatches(concrete, "openai||||0|0|off|off|off") {
+		t.Error("the blank-model grace must apply to the RECORDED side only")
+	}
+}

--- a/tests/provider/embed_identity_native_base_url_702_test.go
+++ b/tests/provider/embed_identity_native_base_url_702_test.go
@@ -1,0 +1,111 @@
+package tests
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/cohere"
+	"github.com/dirstral/dir2mcp/internal/gemini"
+	"github.com/dirstral/dir2mcp/internal/provider"
+)
+
+// identityBaseURL extracts the 2nd embed-identity field (the normalized
+// base_url) for p.
+func identityBaseURL(t *testing.T, p provider.Profile) string {
+	t.Helper()
+	id := provider.EmbedIdentity(p, false, provider.EmbedContextualOff)
+	parts := strings.Split(id, "|")
+	if len(parts) < 2 {
+		t.Fatalf("identity has no base_url field: %q", id)
+	}
+	return parts[1]
+}
+
+// TestEmbedIdentity_NativeCustomBaseURL pins issue #702 / dirstral-spec#72: a
+// custom base_url on a NATIVE-surface profile (gemini, cohere) participates in
+// the corpus-lifetime embed identity.
+//
+// SPEC 8.1.4 rule 1 used to declare base_url "not meaningful" for these kinds,
+// but both adapters honor a configured base_url and send the embedding request
+// there. Two profiles identical except for endpoint A vs endpoint B therefore
+// produced BYTE-IDENTICAL identities, so repointing a corpus at a different
+// proxy/gateway passed the identity fence and mixed two vector spaces in one
+// index — silently, with no error and quietly degraded results.
+func TestEmbedIdentity_NativeCustomBaseURL(t *testing.T) {
+	for _, kind := range []provider.Kind{provider.KindGemini, provider.KindCohere} {
+		t.Run(string(kind), func(t *testing.T) {
+			mk := func(base string) provider.Profile {
+				return provider.Profile{Name: string(kind), Kind: kind, BaseURL: base,
+					EmbedTextModel: "m", EmbedCodeModel: "m"}
+			}
+			a := mk("https://proxy-a.internal/v1")
+			b := mk("https://proxy-b.internal/v1")
+
+			if got := identityBaseURL(t, a); got == "" {
+				t.Fatalf("a custom %s endpoint must appear in the identity, got \"\"", kind)
+			}
+			idA := provider.EmbedIdentity(a, false, provider.EmbedContextualOff)
+			idB := provider.EmbedIdentity(b, false, provider.EmbedContextualOff)
+			if idA == idB {
+				t.Fatalf("two %s profiles at different endpoints must NOT share an identity: %q", kind, idA)
+			}
+			// A corpus built on endpoint A must refuse to serve on endpoint B.
+			if err := provider.VerifyEmbedIdentity(idA, idB); err == nil {
+				t.Fatalf("%s: switching custom endpoints must be rejected, not silently accepted", kind)
+			}
+			// …and must still match itself (no reindex churn on a stable config).
+			if err := provider.VerifyEmbedIdentity(idA, idA); err != nil {
+				t.Fatalf("%s: the same custom endpoint must pass: %v", kind, err)
+			}
+			// Only the endpoint differs, so a same-endpoint pair is equal.
+			if provider.EmbedIdentity(mk("https://proxy-a.internal/v1"), false, provider.EmbedContextualOff) != idA {
+				t.Fatalf("%s: identical profiles must derive identical identities", kind)
+			}
+		})
+	}
+}
+
+// TestEmbedIdentity_NativeHostedDefaultStaysEmpty is the migration half of
+// #702: hosted-default gemini/cohere corpora — the overwhelming majority, since
+// the built-in profiles ship NO base_url — must keep normalizing to "" so they
+// do not spuriously reindex. Only a custom native endpoint sees the one-time
+// mismatch, which is the bounded, correct safety action (those are exactly the
+// corpora that could hold cross-endpoint vectors).
+//
+// It doubles as a DRIFT GUARD: the hosted endpoints are compared against what
+// the real clients use when no base_url is configured, so changing a client
+// default without updating the identity table fails here.
+func TestEmbedIdentity_NativeHostedDefaultStaysEmpty(t *testing.T) {
+	geminiCompatBase := gemini.NewClient("", "k").BaseURL
+	geminiNativeBase := strings.TrimSuffix(geminiCompatBase, "/openai")
+	cohereBase := cohere.NewClient("", "k").BaseURL
+
+	cases := []struct {
+		kind provider.Kind
+		base string
+	}{
+		{provider.KindGemini, ""}, // the built-in profile ships no base_url
+		{provider.KindGemini, geminiCompatBase},
+		{provider.KindGemini, geminiNativeBase},
+		{provider.KindGemini, geminiNativeBase + "/"}, // rule 3 canonicalization
+		{provider.KindCohere, ""},
+		{provider.KindCohere, cohereBase},
+		{provider.KindCohere, strings.ToUpper("HTTPS://") + strings.TrimPrefix(cohereBase, "https://")},
+	}
+	for _, tc := range cases {
+		p := provider.Profile{Name: string(tc.kind), Kind: tc.kind, BaseURL: tc.base, EmbedTextModel: "m"}
+		if got := identityBaseURL(t, p); got != "" {
+			t.Errorf("%s @ %q: the hosted default must normalize to \"\" (no spurious reindex), got %q",
+				tc.kind, tc.base, got)
+		}
+	}
+
+	// A pre-#702 corpus on the hosted default recorded "" for base_url, so its
+	// identity is unchanged by this fix and it keeps serving without re-embedding.
+	hosted := provider.Profile{Name: "gemini", Kind: provider.KindGemini,
+		EmbedTextModel: "gemini-embedding-001", EmbedCodeModel: "gemini-embedding-001"}
+	recorded := "gemini||gemini-embedding-001|gemini-embedding-001|0|0|off|off|off"
+	if err := provider.VerifyEmbedIdentity(recorded, provider.EmbedIdentity(hosted, false, provider.EmbedContextualOff)); err != nil {
+		t.Fatalf("a hosted-default gemini corpus must not be invalidated by #702: %v", err)
+	}
+}

--- a/tests/provider/provider_test.go
+++ b/tests/provider/provider_test.go
@@ -236,13 +236,25 @@ func TestEmbedIdentity_BaseURL(t *testing.T) {
 		}
 	}
 
-	// Rule 1 — not meaningful: native gemini/cohere normalize to "" regardless
-	// of any configured base_url (single canonical provider surface).
-	for _, k := range []provider.Kind{provider.KindGemini, provider.KindCohere} {
-		p := provider.Profile{Name: string(k), Kind: k, BaseURL: "https://custom.example.com/v9",
+	// Native-surface kinds (gemini/cohere) collapse to "" at their HOSTED
+	// endpoint only — including an unset base_url, which is what the built-in
+	// profiles ship (issue #702; the custom-endpoint half lives in
+	// TestEmbedIdentity_NativeCustomBaseURL).
+	for _, tc := range []struct {
+		kind provider.Kind
+		base string
+	}{
+		{provider.KindGemini, ""},
+		{provider.KindGemini, "https://generativelanguage.googleapis.com/v1beta"},
+		{provider.KindGemini, "https://generativelanguage.googleapis.com/v1beta/openai"},
+		{provider.KindCohere, ""},
+		{provider.KindCohere, "https://api.cohere.com"},
+	} {
+		p := provider.Profile{Name: string(tc.kind), Kind: tc.kind, BaseURL: tc.base,
 			EmbedTextModel: "m"}
 		if got := baseURLOf(p); got != "" {
-			t.Errorf("kind %s: base_url must not participate (rule 1), got %q", k, got)
+			t.Errorf("kind %s @ %q: the hosted native surface must normalize to \"\", got %q",
+				tc.kind, tc.base, got)
 		}
 	}
 

--- a/tests/providerfactory/effective_embed_models_705_test.go
+++ b/tests/providerfactory/effective_embed_models_705_test.go
@@ -1,0 +1,68 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/cohere"
+	"github.com/dirstral/dir2mcp/internal/gemini"
+	"github.com/dirstral/dir2mcp/internal/omniembed"
+	"github.com/dirstral/dir2mcp/internal/openai"
+	"github.com/dirstral/dir2mcp/internal/provider"
+	"github.com/dirstral/dir2mcp/internal/providerfactory"
+)
+
+// TestKindDefaultEmbedModel_MatchesClientDefaults is the drift guard for issue
+// #705. The embed identity (SPEC 8.1.4) now records the model that goes on the
+// wire, which means the provider package must know each adapter's default. It
+// keeps that table as literals so it stays free of any HTTP client dependency —
+// this test is what stops the two copies from diverging.
+//
+// Divergence would be silent and severe: the identity would name a model the
+// adapter never sends, which is the very confusion #705 exists to remove.
+func TestKindDefaultEmbedModel_MatchesClientDefaults(t *testing.T) {
+	cases := []struct {
+		kind provider.Kind
+		want string
+	}{
+		{provider.KindOpenAI, openai.DefaultEmbedModel},
+		{provider.KindCohere, cohere.DefaultEmbedModel},
+		{provider.KindGemini, gemini.DefaultEmbedModel},
+		{provider.KindOmniEmbed, omniembed.DefaultModel},
+	}
+	for _, tc := range cases {
+		if got := provider.KindDefaultEmbedModel(tc.kind); got != tc.want {
+			t.Errorf("provider.KindDefaultEmbedModel(%q) = %q, but the %s client sends %q",
+				tc.kind, got, tc.kind, tc.want)
+		}
+	}
+}
+
+// TestEffectiveEmbedModels_SingleResolutionPath pins that ingest/query (via
+// providerfactory) and the embed identity (via provider) resolve the effective
+// models through ONE implementation, so they can never disagree about which
+// model produced the corpus (#705 acceptance: one shared resolution path).
+func TestEffectiveEmbedModels_SingleResolutionPath(t *testing.T) {
+	profiles := []provider.Profile{
+		{Name: "openai", Kind: provider.KindOpenAI},
+		{Name: "cohere", Kind: provider.KindCohere},
+		{Name: "gemini", Kind: provider.KindGemini, EmbedTextModel: "gemini-embedding-001"},
+		{Name: "omniembed", Kind: provider.KindOmniEmbed, EmbedCodeModel: "custom-code"},
+		{Name: "vllm", Kind: provider.KindOpenAI, EmbedTextModel: "bge-m3"},
+	}
+	for _, p := range profiles {
+		factoryText, factoryCode := providerfactory.EffectiveEmbedModels(p)
+		providerText, providerCode := provider.EffectiveEmbedModels(p)
+		if factoryText != providerText || factoryCode != providerCode {
+			t.Fatalf("%s: factory resolved (%q,%q) but the identity resolves (%q,%q)",
+				p.Name, factoryText, factoryCode, providerText, providerCode)
+		}
+		// And the identity records exactly those models, so the recorded
+		// identity always names what ingest and retrieval actually send.
+		id := provider.EmbedIdentity(p, false, provider.EmbedContextualOff)
+		wantPrefix := p.Name + "|" + provider.NormalizeEmbedBaseURL(p) + "|" + providerText + "|" + providerCode + "|"
+		if len(id) < len(wantPrefix) || id[:len(wantPrefix)] != wantPrefix {
+			t.Fatalf("%s: identity %q does not record the effective models %q/%q",
+				p.Name, id, providerText, providerCode)
+		}
+	}
+}

--- a/tests/providerfactory/effective_embed_models_705_test.go
+++ b/tests/providerfactory/effective_embed_models_705_test.go
@@ -66,3 +66,51 @@ func TestEffectiveEmbedModels_SingleResolutionPath(t *testing.T) {
 		}
 	}
 }
+
+// TestWhitespaceOnlyModelsAgreeBetweenAdapterAndIdentity pins the divergence
+// CodeRabbit found on #774: `Embedder` tested `p.EmbedTextModel != ""` while
+// `provider.EffectiveEmbedModels` — the single source the embed identity is
+// built from — trims first. A whitespace-only setting therefore reached the
+// adapter as " " while the identity recorded the kind's built-in default, so
+// the corpus was fenced against a vector space it was not actually using.
+//
+// That is the exact failure mode this PR exists to close, one layer down.
+func TestWhitespaceOnlyModelsAgreeBetweenAdapterAndIdentity(t *testing.T) {
+	for _, kind := range []provider.Kind{
+		provider.KindOpenAI, provider.KindGemini, provider.KindCohere,
+	} {
+		p := provider.Profile{
+			Name:           string(kind),
+			Kind:           kind,
+			APIKey:         "k",
+			EmbedTextModel: "   ",
+			EmbedCodeModel: "\t",
+		}
+		wantText, wantCode := provider.EffectiveEmbedModels(p)
+		if wantText == "" || wantCode == "" {
+			t.Fatalf("%s: resolver returned an empty model; the fixture is wrong", kind)
+		}
+
+		emb, err := providerfactory.Embedder(p)
+		if err != nil {
+			t.Fatalf("%s: Embedder: %v", kind, err)
+		}
+		// Read the model off the concrete adapter: what it will actually send.
+		var gotText string
+		switch c := emb.(type) {
+		case *openai.Client:
+			gotText = c.DefaultEmbedModel
+		case *gemini.Client:
+			gotText = c.DefaultEmbedModel
+		case *cohere.Client:
+			gotText = c.DefaultEmbedModel
+		default:
+			t.Fatalf("%s: unexpected adapter type %T", kind, emb)
+		}
+		if gotText != wantText {
+			t.Errorf("%s: adapter embeds with text model %q while the identity records %q",
+				kind, gotText, wantText)
+		}
+		_ = wantCode
+	}
+}


### PR DESCRIPTION
Fixes #702, #703, #705 — one PR because #702 and #705 are the same defect on the same function, and #703 is the boundary that same code path feeds.

> **Spec-gated.** #702 and #705 change the SPEC §8.1.4 contract, so they are gated on **dirstral-spec#81** (spec 0.45.0, closes dirstral-spec#72). The submodule re-pin is a follow-up commit once that merges — this PR does not move the submodule pointer.

---

## The identity was missing pieces (#702, #705)

The embed identity is supposed to capture *everything* that changes the vector space. When it is wrong there is no error: the corpus silently keeps vectors from a **different** space after a config change, and every search result is quietly degraded.

**#702 — a custom native `base_url` was erased.** `normalizeEmbedBaseURL` returned `""` for `kind: gemini`/`cohere` before even looking at `BaseURL` (SPEC 8.1.4 rule 1, "not meaningful"). But `providerfactory.Embedder` passes `p.BaseURL` into `gemini.NewClient`/`cohere.NewClient` and both clients send the embedding request there. Two profiles at two different proxies produced **byte-identical** identities, so repointing a corpus from endpoint A to endpoint B passed the fence.

Rule 1 is replaced by a per-**kind** hosted-endpoint table. The vendor's hosted surface still normalizes to `""`; anything else is recorded. Gemini lists both spellings, because its client derives the native embed base from the OpenAI-compatible one by dropping `/openai`. Per-kind rather than per-profile-name (the rule the `openai` built-ins use) because a native kind has exactly one vendor surface, so any profile of that kind sitting on it reaches the same vector space.

**#705 — the identity recorded blank models instead of the real ones.** It copied `p.EmbedTextModel`/`p.EmbedCodeModel`, while ingest and retrieval separately resolved blanks to adapter defaults through `providerfactory.EffectiveEmbedModels` — whose comment explicitly said the identity uses the raw profile *on purpose*. The built-in `openai`, `cohere`, `local` and `omniembed` profiles ship those fields **blank**, so for exactly those corpora the identity named no model at all and the per-axis model fence was inert: change an adapter default, or run a distributed worker built from a binary that defaults differently, and the identity still matches while the vectors come from another model space.

The resolution table moves into `internal/provider` (`KindDefaultEmbedModel` / `EffectiveEmbedModels`, kept as literals so the package stays free of any HTTP-client dependency, with a drift-guard test against the real client constants). `providerfactory.EffectiveEmbedModels` now delegates to it, so **identity, ingest, query and snapshot share one resolution path**.

## The migration question, answered explicitly

Fixing the identity changes its value. Here is exactly who re-embeds and why.

| Corpus | Effect | Why |
|---|---|---|
| Hosted-default `gemini`/`cohere` | **No change** | Recorded `""`, still normalizes to `""`. |
| **Custom** native endpoint (#702) | **One-time `CONFIG_INVALID` → reindex** | Correct, not unfortunate — see below. |
| Built-in `openai`/`cohere`/`local`/`omniembed` with blank models (#705) | **No re-embed** | Migrated by a blank-model grace rule. |
| Everything else | No change | Identity byte-identical to before. |

**Why the custom-native reindex is right and not grandfathered.** Those are precisely the corpora that were never fenced. A corpus that has been repointed between two proxies may *genuinely hold vectors from two spaces already*; there is no way to tell from the recording, because the recording is what was erased. Grandfathering them would preserve a corpus we cannot vouch for. It is bounded (only custom native endpoints), one-time, and **surfaced**: it comes out of the existing `VerifyEmbedIdentity` startup path as `CONFIG_INVALID` with the standing *"run `dir2mcp reindex`, or restore the previous embed config"* remediation. Nothing silent.

**Why the blank-model case gets a grace path instead.** Here the recording is not ambiguous. `""` was written by a build whose adapter default is knowable and unchanged, so those vectors *are* from that model. Treating `""` as "the adapter default of the day" is the same first-class-empty reasoning §8.1.4 already applies to a pre-rule `base_url`. The grace is **legacy-only and one-directional**: recorded side only, and a recorded *concrete* model never matches a different concrete model — so every identity written from now on enforces the fence in full, and a future default change does trip it. As a bonus it kills the #440 F3 wart where writing the already-effective default into config demanded a reindex.

The distributed-worker check (`embedqueue`) deliberately stays a strict string comparison: job identities are always produced by a current binary, so there is no legacy form to migrate and strictness is the point.

**`EnsureIdentity` had to change with it — and this uncovered a live bug.** `index.EnsureIdentity` is what actually *wipes* an index, and it was the one place the §8.1.4 migration ladder was never applied. `VerifyEmbedIdentity` would migrate a legacy recording and let startup proceed; `EnsureIdentity` then byte-compared the same recording, called it different, and `Reset` — a full, unannounced re-embed of a corpus the operator had just been told was compatible. **This is already true on `main`**: the new test fails on 5 of its 6 legacy identity forms (every pre-contextual, pre-`base_url`, pre-late-chunking, pre-multimodal and pre-dimension index) before any of this PR's source changes. Both call sites now use one `provider.EmbedIdentityMatches`. A fresh index (recorded `""`) still `Reset`s, because that is what *records* the identity.

## Zero-norm embeddings (#703)

Different problem: a `200 OK` carrying an all-zero vector. It has no cosine direction, so the chunk scores 0 against every query and is permanently unretrievable — yet it lands as `embedding_status=embedded`, indistinguishable from healthy data. Gemini's `l2Normalize` even documents that it leaves a zero vector unchanged.

**Where the check belongs: the provider boundary** (`model.ValidateEmbedVectors`, called by openai/mistral/cohere/gemini/omniembed), for three reasons.

1. It covers the **query** path and the **media** path in the same call — a zero query vector otherwise returns an all-zero-scored result set with no error.
2. The resulting **non-retryable `*ProviderError`** flows into machinery that already exists. It is the same shape as a provider-rejected poison chunk, so the worker's #399 bisection isolates the offending input, marks it `embedding_failure` with a reason, and **still embeds its healthy siblings**. No new failure path.
3. It knows the requested dimension, so it can enforce SPEC 8.1.6 (`outputDimensionality`) where one was asked for.

**What happens to the document:** skipped with a recorded reason, not an error — `MarkFailedWithCategory(embedding_failure, reason)`, exactly like every other terminal per-chunk embed failure, so it shows up in `dir2mcp status`/`doctor` rather than vanishing or wedging the run loop.

The same check runs once more in the worker's `embedTasks`, as the last gate before the index: the worker accepts **any** `model.Embedder`, including one this process does not own. Empty and non-finite (NaN/±Inf) vectors are rejected too.

One deliberate detail: the validation message carries **no batch index**. These strings are keyword-classified downstream (`store.ClassifyError`/`IsTransientError`), and an index that happened to be `503` or `429` would read as a transient upstream status and leave the chunk `PENDING` forever. A batch index walks every integer, so that collision is only a matter of batch size. There is a test for it.

## Tests

Every new test was proven to fail first, by stashing **only** the source changes (`git stash push -- internal/`) and re-running.

- **#702** — `TestEmbedIdentity_NativeCustomBaseURL` fails behaviorally for both kinds: *"a custom gemini endpoint must appear in the identity, got \"\""*. It covers two custom endpoints per kind, that they must not compare identity-equal, and that the same endpoint still matches itself. `TestEmbedIdentity_NativeHostedDefaultStaysEmpty` is the should-NOT-differ half **and** a drift guard: the hosted endpoints are compared against what `gemini.NewClient("")`/`cohere.NewClient("")` actually use. The old test that pinned the unsafe behavior (the rule-1 block in `provider_test.go`) is rewritten.
- **#705** — `TestEmbedIdentity_RecordsEffectiveModel`, `_ExplicitDefaultIsNotAChange` (should not differ), `_DifferentModelsStillDiffer` (should differ: text model, code model, dimension, endpoint, profile name), `_LegacyBlankModelMigrates` (migration plus all four one-directionality guards). These fail to **compile** without the fix, since they exercise new API; the compile-independent half of the same behavior is proven by the `EnsureIdentity` suite below. `TestKindDefaultEmbedModel_MatchesClientDefaults` is the literal-vs-client drift guard.
- **`EnsureIdentity`** — `TestEnsureIdentity_MigratedRecordingKeepsVectors` fails on `main` for 5 of 6 legacy forms with *"EnsureIdentity silently re-embedded a compatible corpus"*; `_RealChangeStillResets` and `_FreshIndexStillRecords` guard the other directions.
- **#703** — per-adapter zero-vector tests for all five adapters, each failing without the fix with the accepted vector printed (e.g. *"Embed returned [[1 0.5] [0 0]]"*); `tests/index` proves the zero vector is never indexed, never marked embedded, is marked `embedding_failure` with a reason, and that both healthy siblings still embed; `tests/model` covers empty / NaN / ±Inf / dimension / negative-zero plus the misclassification guard.

`make check` passes: lint clean, `gocyclo -over 15` clean, full suite green.

## Not stale

All three issues were verified against the code before anything changed. #703's claim that #416 item 5 was left undone is accurate: `l2Normalize`'s "a zero vector is left unchanged" comment is still there on `main`, and no index backend rejected more than `len(vector) == 0`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid embeddings—including empty, zero-norm, non-finite, or incorrectly sized vectors—are now rejected consistently.
  - Affected indexing items fail safely without preventing healthy items from being processed.
  - Embedding configuration changes are detected more accurately, preserving compatible existing indexes.

- **Improvements**
  - Default embedding models are resolved consistently across supported providers.
  - Hosted Gemini and Cohere endpoints are recognized consistently, while custom endpoints remain distinguishable.
  - Legacy embedding configurations continue to migrate compatibly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->