### PR TITLE
fix(mcp): stop resurrecting deleted sessions and rescanning the corpus per list_files page (#694, #696)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,8 +79,11 @@ test:
 # race detector so concurrency regressions (issue #419) are caught. It needs the
 # C toolchain (CGO_ENABLED=1); it is a separate target rather than folded into
 # `check` because `check`/`ci` run with CGO_ENABLED=0.
+# tests/mcp joins the list for #696: session lifetime transitions are ordered
+# across goroutines now, and the regression test for that ordering is only a
+# durable guard if it keeps running under the race detector.
 test-race:
-	CGO_ENABLED=1 go test -race ./internal/cli/... ./internal/index/... ./tests/cli ./tests/index ./tests/store
+	CGO_ENABLED=1 go test -race ./internal/cli/... ./internal/index/... ./tests/cli ./tests/index ./tests/mcp ./tests/store
 
 test-release-tools:
 	cd scripts && python3 -m unittest discover -p 'test_*.py'

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -97,6 +97,25 @@ type Server struct {
 	// optional absolute lifetimes.
 	sessions map[string]sessionInfo
 
+	// sessionSeq orders session state transitions. It is allocated under
+	// sessionMu (see reserveSessionPersistLocked) so a token's order matches the
+	// order of the in-memory transition it describes, which is what lets the
+	// persistence layer tell an older write from a newer one (#696).
+	sessionSeq uint64
+
+	// sessionPersistMu serializes the store writes that mirror those in-memory
+	// transitions, and guards the two maps below. It is deliberately NOT
+	// sessionMu: sessionMu is taken on every request and must not be held across
+	// store I/O.
+	sessionPersistMu sync.Mutex
+	// sessionPersistSeq records, per session ID, the newest transition that has
+	// reached the store. A write carrying an older token is dropped.
+	sessionPersistSeq map[string]uint64
+	// sessionPersistInflight counts the reserved-but-not-yet-committed
+	// transitions per session ID, so the seq record can be dropped once nothing
+	// can still arrive late for that ID.
+	sessionPersistInflight map[string]int
+
 	rateLimiter *ipRateLimiter
 
 	x402Client      x402.FacilitatorClient
@@ -288,6 +307,10 @@ func NewServer(cfg config.Config, retriever model.Retriever, opts ...ServerOptio
 		retriever:       retriever,
 		sessions:        make(map[string]sessionInfo),
 		paymentOutcomes: make(map[string]paymentExecutionOutcome),
+
+		sessionPersistSeq:      make(map[string]uint64),
+		sessionPersistInflight: make(map[string]int),
+
 		paymentTTL:      paymentOutcomeTTL,
 		paymentMaxItems: paymentOutcomeMaxEntries,
 		nonceLedger:     make(map[string]nonceLedgerEntry),
@@ -642,15 +665,17 @@ func (s *Server) hasActiveSession(id string, now time.Time) (bool, string) {
 	}
 	if now.Sub(si.lastSeen) > inactivity {
 		delete(s.sessions, id)
+		seq := s.reserveSessionPersistLocked(id)
 		s.sessionMu.Unlock()
-		s.deletePersistedSession(id)
+		s.deletePersistedSession(id, seq)
 		log.Printf("session %s expired due to inactivity", maskSessionID(id))
 		return false, "inactivity"
 	}
 	if maxLife > 0 && now.Sub(si.created) > maxLife {
 		delete(s.sessions, id)
+		seq := s.reserveSessionPersistLocked(id)
 		s.sessionMu.Unlock()
-		s.deletePersistedSession(id)
+		s.deletePersistedSession(id, seq)
 		log.Printf("session %s expired due to max lifetime", maskSessionID(id))
 		return false, "max-lifetime"
 	}
@@ -658,8 +683,9 @@ func (s *Server) hasActiveSession(id string, now time.Time) (bool, string) {
 	// update lastSeen
 	si.lastSeen = now
 	s.sessions[id] = si
+	seq := s.reserveSessionPersistLocked(id)
 	s.sessionMu.Unlock()
-	s.persistSession(id, si)
+	s.persistSession(id, si, seq)
 	return true, ""
 }
 
@@ -668,8 +694,9 @@ func (s *Server) storeSession(id string, authScope string) {
 	si := sessionInfo{created: now, lastSeen: now, authScope: authScope}
 	s.sessionMu.Lock()
 	s.sessions[id] = si
+	seq := s.reserveSessionPersistLocked(id)
 	s.sessionMu.Unlock()
-	s.persistSession(id, si)
+	s.persistSession(id, si, seq)
 }
 
 // forgetSession removes a session from the in-memory map and the persistence
@@ -678,8 +705,69 @@ func (s *Server) storeSession(id string, authScope string) {
 func (s *Server) forgetSession(id string) {
 	s.sessionMu.Lock()
 	delete(s.sessions, id)
+	seq := s.reserveSessionPersistLocked(id)
 	s.sessionMu.Unlock()
-	s.deletePersistedSession(id)
+	s.deletePersistedSession(id, seq)
+}
+
+// reserveSessionPersistLocked allocates the ordering token for one session state
+// transition.
+//
+// It MUST be called with sessionMu held. That is the entire point: the token is
+// only meaningful because it is allocated inside the same critical section that
+// performs the in-memory transition it describes, so token order == transition
+// order. Allocating it after the unlock would reintroduce exactly the race this
+// machinery exists to close (#696).
+func (s *Server) reserveSessionPersistLocked(id string) uint64 {
+	s.sessionSeq++
+	seq := s.sessionSeq
+	s.sessionPersistMu.Lock()
+	s.sessionPersistInflight[id]++
+	s.sessionPersistMu.Unlock()
+	return seq
+}
+
+// commitSessionPersist runs apply only when seq is still the newest transition
+// for id, and holds sessionPersistMu across apply so a newer transition cannot
+// overtake an older one while the older one is mid-flight in the store.
+//
+// Both halves are load-bearing (#696). A check without holding the lock across
+// the store call does NOT fix the bug: the stale touch would pass the check,
+// then the DELETE would pass its own check and complete, and the touch would
+// still land last and resurrect the row. Holding the lock is what makes the
+// store's final state agree with the newest logical transition.
+//
+// Every reserveSessionPersistLocked must be paired with exactly one
+// commitSessionPersist, including when there is no persistence store to write
+// to, or the in-flight accounting leaks.
+func (s *Server) commitSessionPersist(id string, seq uint64, apply func()) {
+	s.sessionPersistMu.Lock()
+	defer s.sessionPersistMu.Unlock()
+	defer s.releaseSessionPersistLocked(id)
+
+	if seq <= s.sessionPersistSeq[id] {
+		// A newer transition for this ID already reached the store. This write
+		// describes a state the session has since left, so dropping it is the
+		// whole fix: it is the write that used to resurrect a deleted session.
+		return
+	}
+	s.sessionPersistSeq[id] = seq
+	apply()
+}
+
+// releaseSessionPersistLocked drops the ordering record for id once no
+// transition for it is still in flight. Callers hold sessionPersistMu.
+//
+// The record cannot be dropped any earlier: it is precisely what a late,
+// superseded write gets rejected against. It must be dropped eventually, or the
+// map grows without bound as sessions come and go over the life of the daemon.
+// The in-flight count reaching zero is the exact moment both are true.
+func (s *Server) releaseSessionPersistLocked(id string) {
+	s.sessionPersistInflight[id]--
+	if s.sessionPersistInflight[id] <= 0 {
+		delete(s.sessionPersistInflight, id)
+		delete(s.sessionPersistSeq, id)
+	}
 }
 
 func (s *Server) runSessionCleanup(ctx context.Context) {
@@ -742,23 +830,27 @@ func (s *Server) cleanupExpiredSessions(now time.Time) {
 	inactivity, maxLife := s.resolveSessionTimeouts()
 
 	s.sessionMu.Lock()
-	var toDelete []string
+	type expiredSession struct {
+		id  string
+		seq uint64
+	}
+	var toDelete []expiredSession
 	for id, si := range s.sessions {
-		if now.Sub(si.lastSeen) > inactivity {
-			toDelete = append(toDelete, id)
-			delete(s.sessions, id)
+		expired := now.Sub(si.lastSeen) > inactivity ||
+			(maxLife > 0 && now.Sub(si.created) > maxLife)
+		if !expired {
 			continue
 		}
-		if maxLife > 0 && now.Sub(si.created) > maxLife {
-			toDelete = append(toDelete, id)
-			delete(s.sessions, id)
-		}
+		delete(s.sessions, id)
+		// Reserve inside the same critical section as the in-memory delete, so a
+		// touch that raced this sweep cannot undo the expiry (#696).
+		toDelete = append(toDelete, expiredSession{id: id, seq: s.reserveSessionPersistLocked(id)})
 	}
 	s.sessionMu.Unlock()
 
 	// Perform I/O outside the lock
-	for _, id := range toDelete {
-		s.deletePersistedSession(id)
+	for _, expired := range toDelete {
+		s.deletePersistedSession(expired.id, expired.seq)
 	}
 }
 
@@ -837,24 +929,33 @@ func (s *Server) restorePaymentOutcomes(ctx context.Context) {
 	}
 }
 
-func (s *Server) persistSession(id string, si sessionInfo) {
-	store, ok := s.store.(sessionPersistenceStore)
-	if !ok || store == nil {
-		return
-	}
-	if err := store.UpsertMCPSession(context.Background(), id, si.created.UTC(), si.lastSeen.UTC(), si.authScope); err != nil {
-		log.Printf("warning: failed persisting session %s: %v", maskSessionID(id), err)
-	}
+// persistSession mirrors a session touch/creation into the store. seq comes
+// from reserveSessionPersistLocked and is what keeps this write from landing
+// after a delete that logically superseded it (#696).
+func (s *Server) persistSession(id string, si sessionInfo, seq uint64) {
+	s.commitSessionPersist(id, seq, func() {
+		store, ok := s.store.(sessionPersistenceStore)
+		if !ok || store == nil {
+			return
+		}
+		if err := store.UpsertMCPSession(context.Background(), id, si.created.UTC(), si.lastSeen.UTC(), si.authScope); err != nil {
+			log.Printf("warning: failed persisting session %s: %v", maskSessionID(id), err)
+		}
+	})
 }
 
-func (s *Server) deletePersistedSession(id string) {
-	store, ok := s.store.(sessionPersistenceStore)
-	if !ok || store == nil {
-		return
-	}
-	if err := store.DeleteMCPSession(context.Background(), id); err != nil {
-		log.Printf("warning: failed deleting persisted session %s: %v", maskSessionID(id), err)
-	}
+// deletePersistedSession removes a session from the store. seq orders it
+// against any concurrent touch for the same ID; see commitSessionPersist.
+func (s *Server) deletePersistedSession(id string, seq uint64) {
+	s.commitSessionPersist(id, seq, func() {
+		store, ok := s.store.(sessionPersistenceStore)
+		if !ok || store == nil {
+			return
+		}
+		if err := store.DeleteMCPSession(context.Background(), id); err != nil {
+			log.Printf("warning: failed deleting persisted session %s: %v", maskSessionID(id), err)
+		}
+	})
 }
 
 func (s *Server) runPaymentOutcomeCleanup(ctx context.Context) {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -617,18 +617,93 @@ func (s *Server) handleListFilesTool(ctx context.Context, args map[string]interf
 	}, nil
 }
 
-// listFilesFiltered paginates s.store.ListFiles and skips entries that violate
-// the list_files contract. Skipped entries are:
-//   - hidden paths (when includeHidden is false), so internal artifacts under
-//     dot-prefixed directories don't leak into the public listing.
-//   - filesystem-source documents whose rel_path no longer resolves to a real
-//     file under the configured root. Without this filter, stale rows left
-//     behind by older buggy ingest paths or manual edits would surface here
-//     and then 404 on the round-trip through open_file (issue #176).
+// visibleFilesLister is implemented by stores that can apply the list_files
+// hidden-path policy inside the query itself, so one page costs one store call
+// instead of a walk of the whole matching corpus (#694). Declared here as an
+// optional capability, the same way recentFailuresLister and
+// sessionPersistenceStore are, so model.Store keeps its narrow signature and
+// stores that cannot push the predicate down still work.
+type visibleFilesLister interface {
+	ListVisibleFiles(ctx context.Context, prefix, glob string, limit, offset int, includeHidden bool) ([]model.Document, int64, error)
+}
+
+// listFilesFiltered returns one page of the list_files listing plus its total.
 //
-// The total is the count of entries that survived filtering — the surviving
-// "real" total from the agent's perspective — not the raw store count.
+// Two filters define the listing:
+//   - hidden paths are dropped when includeHidden is false, so internal
+//     artifacts under dot-prefixed directories don't leak into the public
+//     listing. This is a pure function of rel_path, so the store evaluates it in
+//     SQL (SQLiteStore.ListVisibleFiles) and the page, the COUNT and the glob
+//     scan all agree on it for free.
+//   - filesystem-source documents whose rel_path no longer resolves to a real
+//     file under the configured root are dropped. Without this, stale rows left
+//     behind by older buggy ingest paths or manual edits would surface here and
+//     then 404 on the round-trip through open_file (issue #176). This one needs
+//     the filesystem, so it can only run in Go — but it now runs over the rows
+//     of the RETURNED PAGE, not over the corpus.
+//
+// Before #694 the handler pulled the entire matching corpus in 500-row store
+// pages on every call and stat'ed every row, because it wanted a `total` that
+// counted only rows surviving BOTH filters. That made `limit=1, offset=0` on a
+// million-document corpus roughly 2,000 store reads and a million
+// filepath.EvalSymlinks syscalls, and made a client's walk of all pages
+// quadratic. The paging work of #429 F10 was fully undone at the tool boundary.
+//
+// So `total` now means "matching, non-deleted, non-hidden rows in the store"
+// rather than "rows that also survived a filesystem stat". The two differ only
+// when the store holds a row whose backing file is gone, i.e. when ingest's
+// `deleted = 0` tombstoning has drifted — the degraded case the stat filter
+// exists as a safety net for. In a healthy corpus they are identical, and
+// `documents.deleted` is already the authoritative liveness signal that
+// ListFiles filters on in SQL. Paying O(corpus) stats on every request to keep
+// the total exact under drift is precisely the defect being fixed, so the
+// trade is deliberate.
+//
+// The visible consequence is that a page can come back SHORTER than `limit`
+// when a dead row is dropped from it. That was already possible at the end of a
+// listing, and a client looping `while offset < total` still terminates and
+// still observes every live file. What does NOT change is #176's actual
+// guarantee: every path this tool EMITS round-trips through open_file, because
+// page-scoped stat still gates every emitted row.
 func (s *Server) listFilesFiltered(ctx context.Context, pathPrefix, glob string, limit, offset int, includeHidden bool) ([]model.Document, int64, error) {
+	lister, ok := s.store.(visibleFilesLister)
+	if !ok {
+		return s.listFilesFilteredByWalk(ctx, pathPrefix, glob, limit, offset, includeHidden)
+	}
+
+	docs, total, err := lister.ListVisibleFiles(ctx, pathPrefix, glob, limit, offset, includeHidden)
+	if err != nil {
+		return nil, 0, err
+	}
+	return s.dropUnresolvableSources(docs), total, nil
+}
+
+// dropUnresolvableSources applies the #176 round-trip gate to the rows of a
+// single page. The root is resolved once for the page: the per-document gate
+// would otherwise re-run filepath.Abs + EvalSymlinks(root) per row. When the
+// configured root does not resolve at all the gate is skipped entirely, so a
+// misconfigured deployment still returns what the store has rather than an
+// empty list.
+func (s *Server) dropUnresolvableSources(docs []model.Document) []model.Document {
+	rootAbs, rootReal, ok := s.resolveRoot()
+	if !ok {
+		return docs
+	}
+	kept := make([]model.Document, 0, len(docs))
+	for _, doc := range docs {
+		if isResolvableSourceWithRoot(doc, rootAbs, rootReal) {
+			kept = append(kept, doc)
+		}
+	}
+	return kept
+}
+
+// listFilesFilteredByWalk is the pre-#694 implementation, kept as the fallback
+// for a store that cannot push the hidden-path predicate into its query. Such a
+// store cannot report a hidden-excluded total any other way, so the walk (and
+// its per-row stat) is unavoidable there; it is NOT the path any production
+// SQLiteStore takes.
+func (s *Server) listFilesFilteredByWalk(ctx context.Context, pathPrefix, glob string, limit, offset int, includeHidden bool) ([]model.Document, int64, error) {
 	const pageSize = 500
 	collected := make([]model.Document, 0, limit)
 	visibleSeen := 0

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -2176,7 +2176,39 @@ func (s *SQLiteStore) GetDocumentByPath(ctx context.Context, relPath string) (mo
 	return doc, nil
 }
 
+// ListFiles is the model.Store listing: every non-deleted matching document,
+// hidden dot-paths included. It is a thin delegate so the interface signature
+// (and its ~30 callers) stay unchanged; callers that need the list_files
+// visibility policy applied inside the query call ListVisibleFiles directly.
 func (s *SQLiteStore) ListFiles(ctx context.Context, prefix, glob string, limit, offset int) ([]model.Document, int64, error) {
+	return s.ListVisibleFiles(ctx, prefix, glob, limit, offset, true)
+}
+
+// ListVisibleFiles is ListFiles with the list_files hidden-path policy pushed
+// into SQL (#694).
+//
+// The MCP handler used to apply that policy in Go, which forced it to walk the
+// whole matching corpus from offset zero on every single call just to know how
+// many rows survived. The predicate is exactly "the normalized rel_path starts
+// with a dot": mcp.isListFilesNoisePath takes the FIRST '/'-delimited segment
+// and tests strings.HasPrefix(first, "."), and testing the first segment's
+// prefix is testing the whole string's prefix. rel_paths are stored
+// filepath.Clean'd and slash-normalized (see normalizeRelPath), with no leading
+// "./" and no "." or ".." components, so `rel_path NOT LIKE '.%'` is a
+// byte-for-byte equivalent — and '.' is not a LIKE metacharacter, so no ESCAPE
+// clause is needed.
+//
+// Adding it to `where` is what makes this worth doing: the same slice is
+// threaded through whereClause into the SQL LIMIT/OFFSET page query, into
+// countListFiles, and into the glob scan, so all three start operating on the
+// visible set and the caller can trust both the page AND the total without
+// re-filtering.
+//
+// The memo key must carry the visibility policy. Both listings share the same
+// prefix/glob filter but describe different result sets, so keying only on the
+// filter would let a hidden-excluding call serve its total to a
+// hidden-including one (and vice versa) for as long as no commit landed.
+func (s *SQLiteStore) ListVisibleFiles(ctx context.Context, prefix, glob string, limit, offset int, includeHidden bool) ([]model.Document, int64, error) {
 	// Read pool (#429 F11): SELECT-only, and the glob branch scans every matching
 	// row per page, so this is exactly the shape that should not block on ingest.
 	db, err := s.ensureReadDB(ctx)
@@ -2202,7 +2234,17 @@ func (s *SQLiteStore) ListFiles(ctx context.Context, prefix, glob string, limit,
 		where = append(where, `rel_path LIKE ? ESCAPE '\'`)
 		prefixArgs = append(prefixArgs, escapeLike(normalizedPrefix)+"%")
 	}
+	if !includeHidden {
+		where = append(where, `rel_path NOT LIKE '.%'`)
+	}
 	whereClause := " WHERE " + strings.Join(where, " AND ")
+
+	// Part of every memo key: the two visibility policies are two different
+	// listings over the same filter, and their totals must never be crossed.
+	visibility := "all"
+	if !includeHidden {
+		visibility = "visible"
+	}
 
 	// The `glob` filter uses the SAME canonical matcher as the search/ask
 	// `file_glob` filter (model.MatchGlob, issue #441): segment-aware `*`,
@@ -2211,7 +2253,8 @@ func (s *SQLiteStore) ListFiles(ctx context.Context, prefix, glob string, limit,
 	// evaluate it in Go over the prefix-matched rows and paginate in Go. Without a
 	// glob the query keeps its efficient SQL LIMIT/OFFSET pagination unchanged.
 	if trimmedGlob == "" {
-		return s.listFilesSQLPaged(ctx, db, selectCols, whereClause, prefixArgs, normalizedPrefix, limit, offset)
+		key := "prefix\x00" + visibility + "\x00" + normalizedPrefix
+		return s.listFilesSQLPaged(ctx, db, selectCols, whereClause, prefixArgs, key, limit, offset)
 	}
 
 	matcher, err := model.CompileGlob(trimmedGlob)
@@ -2222,8 +2265,9 @@ func (s *SQLiteStore) ListFiles(ctx context.Context, prefix, glob string, limit,
 	}
 
 	// The cache key is the full filter: whereClause/prefixArgs are a pure
-	// function of normalizedPrefix, so prefix plus glob identifies the listing.
-	key := "glob\x00" + normalizedPrefix + "\x00" + trimmedGlob
+	// function of normalizedPrefix and the visibility policy, so visibility plus
+	// prefix plus glob identifies the listing.
+	key := "glob\x00" + visibility + "\x00" + normalizedPrefix + "\x00" + trimmedGlob
 	return s.listFilesGlobPaged(ctx, db, selectCols, whereClause, prefixArgs, matcher, key, limit, offset)
 }
 
@@ -2251,7 +2295,7 @@ func (s *SQLiteStore) listFilesSQLPaged(
 	db *sql.DB,
 	selectCols, whereClause string,
 	prefixArgs []any,
-	normalizedPrefix string,
+	key string,
 	limit, offset int,
 ) ([]model.Document, int64, error) {
 	// Probe before the page query so a memo hit is pinned to a state no newer
@@ -2259,7 +2303,6 @@ func (s *SQLiteStore) listFilesSQLPaged(
 	probe := s.versionProbeDB()
 	epoch, cacheable := s.listCache.begin(ctx, probe)
 
-	key := "prefix\x00" + normalizedPrefix
 	var memo listFilesCacheEntry
 	memoized := false
 	if cacheable {

--- a/tests/mcp/list_files_page_694_test.go
+++ b/tests/mcp/list_files_page_694_test.go
@@ -1,0 +1,299 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/protocol"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// #694: every list_files call walked the ENTIRE matching corpus from store
+// offset zero, in 500-row store pages, and ran filepath.EvalSymlinks on every
+// row, purely to compute a post-filter total. `limit=1, offset=0` on a
+// million-document corpus therefore cost ~2,000 store reads and ~1,000,000
+// filesystem syscalls, and a client walking every page paid that per page,
+// making the walk quadratic. The store-level pagination of #429 F10 was
+// completely undone at the public tool boundary.
+//
+// The fix pushes the hidden-path predicate into SQL
+// (store.SQLiteStore.ListVisibleFiles) so one tool call is one store call over
+// one page, and the #176 round-trip gate runs only over the rows of that page.
+//
+// These tests are MCP-level on purpose: the store-level #429 tests already pass
+// against the broken handler, because the defect was entirely in how the
+// handler used the store.
+
+// countingStore694 counts how the handler reaches the store. It embeds the real
+// *store.SQLiteStore, so it is a fully functional model.Store; BOTH listing
+// methods are overridden because embedding would otherwise satisfy
+// ListVisibleFiles invisibly and the count would stay at zero.
+type countingStore694 struct {
+	*store.SQLiteStore
+	listFilesCalls atomic.Int64
+	visibleCalls   atomic.Int64
+}
+
+func (c *countingStore694) ListFiles(ctx context.Context, prefix, glob string, limit, offset int) ([]model.Document, int64, error) {
+	c.listFilesCalls.Add(1)
+	return c.SQLiteStore.ListFiles(ctx, prefix, glob, limit, offset)
+}
+
+func (c *countingStore694) ListVisibleFiles(ctx context.Context, prefix, glob string, limit, offset int, includeHidden bool) ([]model.Document, int64, error) {
+	c.visibleCalls.Add(1)
+	return c.SQLiteStore.ListVisibleFiles(ctx, prefix, glob, limit, offset, includeHidden)
+}
+
+// storeReads reports how many times the handler asked the store for rows,
+// however it asked. The contract under test is "one page costs one store read",
+// not "the handler uses a particular method".
+func (c *countingStore694) storeReads() int64 {
+	return c.listFilesCalls.Load() + c.visibleCalls.Load()
+}
+
+func TestListFilesServesASmallFirstPageInOneStoreRead_694(t *testing.T) {
+	// 1200 documents is 3 pages of the old 500-row walk, so the pre-fix
+	// handler cannot serve even `limit=5, offset=0` in fewer than 3 reads.
+	counting, root, stateDir := seedCountingCorpus694(t, 1200)
+
+	page := listFilesPage694(t, stateDir, root, counting, `"limit":5,"offset":0`)
+
+	if got := counting.storeReads(); got != 1 {
+		t.Fatalf("a 5-row first page cost %d store reads (ListFiles=%d ListVisibleFiles=%d); "+
+			"the handler is still walking the whole corpus to compute a total (#694)",
+			got, counting.listFilesCalls.Load(), counting.visibleCalls.Load())
+	}
+	if len(page.Files) != 5 {
+		t.Fatalf("first page returned %d files, want 5", len(page.Files))
+	}
+	if page.Total != 1200 {
+		t.Fatalf("total=%d want 1200", page.Total)
+	}
+	for i, f := range page.Files {
+		if want := corpusRelPath694(i); f.RelPath != want {
+			t.Fatalf("files[%d].rel_path=%q want %q", i, f.RelPath, want)
+		}
+	}
+}
+
+func TestListFilesDeepPageDoesNotRestartFromZero_694(t *testing.T) {
+	counting, root, stateDir := seedCountingCorpus694(t, 1200)
+
+	page := listFilesPage694(t, stateDir, root, counting, `"limit":5,"offset":1000`)
+
+	if got := counting.storeReads(); got != 1 {
+		t.Fatalf("offset=1000 cost %d store reads (ListFiles=%d ListVisibleFiles=%d); "+
+			"a later page must be served by the store's own LIMIT/OFFSET, not by "+
+			"re-walking every preceding row (#694)",
+			got, counting.listFilesCalls.Load(), counting.visibleCalls.Load())
+	}
+	if len(page.Files) != 5 {
+		t.Fatalf("deep page returned %d files, want 5", len(page.Files))
+	}
+	for i, f := range page.Files {
+		if want := corpusRelPath694(1000 + i); f.RelPath != want {
+			t.Fatalf("files[%d].rel_path=%q want %q", i, f.RelPath, want)
+		}
+	}
+	if page.Total != 1200 {
+		t.Fatalf("total=%d want 1200", page.Total)
+	}
+}
+
+// TestListFilesHiddenFilteringSurvivesTheSQLPushdown_694 pins the translation
+// itself. The Go predicate looks at the FIRST path segment only, so
+// `visible/.config/b.md` is NOT hidden — which is exactly what a naive SQL
+// translation ("rel_path LIKE '%/.%'", or a per-segment test) gets wrong.
+func TestListFilesHiddenFilteringSurvivesTheSQLPushdown_694(t *testing.T) {
+	tmp := t.TempDir()
+	st := store.NewSQLiteStore(filepath.Join(tmp, "meta.sqlite"))
+	if err := st.Init(context.Background()); err != nil {
+		t.Fatalf("init store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	root := filepath.Join(tmp, "corpus")
+	seedCorpus(t, st, root, []model.Document{
+		{RelPath: ".hidden/a.md", DocType: "md", MTimeUnix: 100, Status: "ok"},
+		{RelPath: "visible/.config/b.md", DocType: "md", MTimeUnix: 200, Status: "ok"},
+		{RelPath: "a.md", DocType: "md", MTimeUnix: 300, Status: "ok"},
+		{RelPath: ".x", DocType: "txt", MTimeUnix: 400, Status: "ok"},
+		{RelPath: "dir/sub/c.md", DocType: "md", MTimeUnix: 500, Status: "ok"},
+	})
+
+	excluded := listFilesPage694(t, tmp, root, st, `"limit":50,"offset":0,"include_hidden":false`)
+	included := listFilesPage694(t, tmp, root, st, `"limit":50,"offset":0,"include_hidden":true`)
+
+	// Exactly the set the Go predicate isListFilesNoisePath produces: a
+	// dot-prefixed FIRST segment, and nothing else.
+	wantVisible := []string{"a.md", "dir/sub/c.md", "visible/.config/b.md"}
+	wantAll := append([]string{".hidden/a.md", ".x"}, wantVisible...)
+
+	assertRelPathSet694(t, "include_hidden=false", excluded, wantVisible)
+	assertRelPathSet694(t, "include_hidden=true", included, wantAll)
+
+	if excluded.Total != int64(len(wantVisible)) {
+		t.Fatalf("include_hidden=false total=%d want %d; the total must describe the "+
+			"same set the page is drawn from", excluded.Total, len(wantVisible))
+	}
+	if included.Total != int64(len(wantAll)) {
+		t.Fatalf("include_hidden=true total=%d want %d", included.Total, len(wantAll))
+	}
+}
+
+// TestListFilesStillDropsRowsWhoseFileIsGone_694 is the #176 regression guard.
+// Pushing the total down to SQL deliberately stops the total from accounting
+// for tombstoning drift, but it must not weaken the guarantee that actually
+// matters: every EMITTED path round-trips through open_file. That gate is
+// page-scoped now, and page-scoped is enough.
+func TestListFilesStillDropsRowsWhoseFileIsGone_694(t *testing.T) {
+	tmp := t.TempDir()
+	st := store.NewSQLiteStore(filepath.Join(tmp, "meta.sqlite"))
+	if err := st.Init(context.Background()); err != nil {
+		t.Fatalf("init store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	root := filepath.Join(tmp, "corpus")
+	seedCorpus(t, st, root, []model.Document{
+		{RelPath: "live/one.md", DocType: "md", MTimeUnix: 100, Status: "ok"},
+		{RelPath: "live/two.md", DocType: "md", MTimeUnix: 200, Status: "ok"},
+	})
+	// A row whose backing file was never written: stale metadata of exactly the
+	// kind #176 was filed about.
+	if err := st.UpsertDocument(context.Background(), model.Document{
+		RelPath: "live/ghost.md", DocType: "md", MTimeUnix: 300, Status: "ok",
+	}); err != nil {
+		t.Fatalf("seed ghost row: %v", err)
+	}
+
+	page := listFilesPage694(t, tmp, root, st, `"limit":50,"offset":0`)
+
+	assertRelPathSet694(t, "listing", page, []string{"live/one.md", "live/two.md"})
+}
+
+// --- fixtures -------------------------------------------------------------
+
+type listFilesPageResult694 struct {
+	Limit  int64
+	Offset int64
+	Total  int64
+	Files  []struct {
+		RelPath string `json:"rel_path"`
+		Status  string `json:"status"`
+	}
+}
+
+func corpusRelPath694(i int) string {
+	return fmt.Sprintf("docs/f%04d.md", i)
+}
+
+// seedCountingCorpus694 writes n real files plus their store rows and wraps the
+// store in the counting decorator. Real files are mandatory: list_files
+// resolves every row against the corpus root and drops what is not there, so a
+// store-only fixture returns zero files and every assertion below would pass
+// vacuously against broken code.
+func seedCountingCorpus694(t *testing.T, n int) (*countingStore694, string, string) {
+	t.Helper()
+	tmp := t.TempDir()
+	st := store.NewSQLiteStore(filepath.Join(tmp, "meta.sqlite"))
+	if err := st.Init(context.Background()); err != nil {
+		t.Fatalf("init store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	root := filepath.Join(tmp, "corpus")
+	docs := make([]model.Document, 0, n)
+	for i := 0; i < n; i++ {
+		docs = append(docs, model.Document{
+			RelPath:   corpusRelPath694(i),
+			DocType:   "md",
+			MTimeUnix: int64(1700000000 + i),
+			Status:    "ok",
+		})
+	}
+	seedCorpus(t, st, root, docs)
+
+	counting := &countingStore694{SQLiteStore: st}
+	// Seeding wrote through the bare store; only handler traffic is counted.
+	counting.listFilesCalls.Store(0)
+	counting.visibleCalls.Store(0)
+	return counting, root, tmp
+}
+
+// listFilesPage694 calls the real dir2mcp_list_files tool over HTTP. Going
+// through the tool is the point: the defect lives in the handler's use of the
+// store, so anything short of the tool boundary would miss it.
+func listFilesPage694(t *testing.T, stateDir, root string, st model.Store, args string) listFilesPageResult694 {
+	t.Helper()
+	cfg := config.Default()
+	cfg.RootDir = root
+	cfg.StateDir = stateDir
+	cfg.MCPPath = protocol.DefaultMCPPath
+	cfg.AuthMode = "none"
+
+	server := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st)).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	body := `{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"dir2mcp_list_files","arguments":{` + args + `}}}`
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID, body)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(resp.Body)
+		t.Fatalf("list_files status=%d body=%s", resp.StatusCode, payload)
+	}
+
+	return decodeListFilesEnvelope694(t, resp.Body)
+}
+
+func decodeListFilesEnvelope694(t *testing.T, body io.Reader) listFilesPageResult694 {
+	t.Helper()
+	var envelope struct {
+		Result struct {
+			StructuredContent listFilesPageResult694 `json:"structuredContent"`
+		} `json:"result"`
+	}
+	if err := json.NewDecoder(body).Decode(&envelope); err != nil {
+		t.Fatalf("decode list_files response: %v", err)
+	}
+	return envelope.Result.StructuredContent
+}
+
+func assertRelPathSet694(t *testing.T, label string, page listFilesPageResult694, want []string) {
+	t.Helper()
+	got := make(map[string]bool, len(page.Files))
+	for _, f := range page.Files {
+		got[f.RelPath] = true
+	}
+	wanted := make(map[string]bool, len(want))
+	for _, w := range want {
+		wanted[w] = true
+		if !got[w] {
+			t.Fatalf("%s: %q missing from the listing (got %v)", label, w, keysOf694(got))
+		}
+	}
+	for g := range got {
+		if !wanted[g] {
+			t.Fatalf("%s: %q should not be listed (got %v, want %v)", label, g, keysOf694(got), want)
+		}
+	}
+}
+
+func keysOf694(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/tests/mcp/list_files_page_perf_694_test.go
+++ b/tests/mcp/list_files_page_perf_694_test.go
@@ -1,0 +1,234 @@
+package tests
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/protocol"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// TestListFilesPagePerf_694 measures what a list_files caller actually pays for
+// ONE page, before and after #694, over the same synthetic corpus in the same
+// process. It is a measurement harness, not an assertion, and is skipped unless
+// DIR2MCP_PERF=1 so `go test ./...` stays fast.
+//
+// The "before" arm is not a reimplementation: the handler keeps the pre-#694
+// walk as its fallback for stores that cannot push the hidden-path predicate
+// into their query, so hiding ListVisibleFiles behind a plain model.Store shim
+// routes the real handler down the real old code path. The two arms therefore
+// differ in exactly the thing the issue is about.
+//
+// Three numbers are logged per arm:
+//   - elapsed: wall time for one tools/call round trip.
+//   - reads:   how many times the handler asked the store for rows. The old
+//     walk needs ceil(total/500); the fix needs 1.
+//   - rows:    how many document rows the store handed back, which is also the
+//     number of rows the handler ran filepath.EvalSymlinks over. This is the
+//     syscall count, exactly, and it is the dominant cost on a network
+//     filesystem.
+//
+// The corpus is 10% hidden (dot-prefixed first segment) so the pushed-down
+// predicate is doing real work rather than matching everything.
+//
+//	DIR2MCP_PERF=1 go test ./tests/mcp -run ListFilesPagePerf -v
+//	DIR2MCP_PERF=1 DIR2MCP_PERF_FILES=50000 go test ./tests/mcp -run ListFilesPagePerf -v
+func TestListFilesPagePerf_694(t *testing.T) {
+	if os.Getenv("DIR2MCP_PERF") != "1" {
+		t.Skip("set DIR2MCP_PERF=1 to run the #694 page-cost measurement")
+	}
+	total := 20000
+	if raw := os.Getenv("DIR2MCP_PERF_FILES"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n <= 0 {
+			t.Fatalf("DIR2MCP_PERF_FILES=%q: want a positive integer", raw)
+		}
+		total = n
+	}
+	walkPages := 10
+	if raw := os.Getenv("DIR2MCP_PERF_WALK_PAGES"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n < 0 {
+			t.Fatalf("DIR2MCP_PERF_WALK_PAGES=%q: want a non-negative integer", raw)
+		}
+		walkPages = n
+	}
+
+	ctx := context.Background()
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "meta.sqlite")
+	root := filepath.Join(tmp, "corpus")
+	st := store.NewSQLiteStore(dbPath)
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	seedPerfCorpus694(t, dbPath, root, total)
+
+	counting := &perfStore694{SQLiteStore: st}
+	const pageSize = 50
+
+	for _, arm := range []struct {
+		label string
+		store model.Store
+	}{
+		// walkOnly694 hides ListVisibleFiles, so the handler falls back to the
+		// pre-#694 corpus walk. Same handler, same store, old path.
+		{label: "before", store: walkOnly694{counting}},
+		{label: "after", store: counting},
+	} {
+		url, sessionID := perfSession694(t, tmp, root, arm.store)
+
+		// One warm-up call: the first tools/call of a session also pays for
+		// SQLite's page cache filling, which would otherwise be charged to the
+		// first measurement and to the "before" arm only.
+		visible := perfListFiles694(t, url, sessionID, pageSize, 0).Total
+		deepOffset := int(visible) - 2*pageSize
+		if deepOffset < 0 {
+			deepOffset = 0
+		}
+
+		for _, offset := range []int{0, deepOffset} {
+			counting.reset()
+			start := time.Now()
+			page := perfListFiles694(t, url, sessionID, pageSize, offset)
+			elapsed := time.Since(start)
+			t.Logf("%-6s offset=%-6d files=%-3d total=%-6d reads=%-4d rows=%-7d elapsed=%v",
+				arm.label, offset, len(page.Files), page.Total,
+				counting.calls.Load(), counting.rows.Load(), elapsed)
+		}
+
+		// The quadratic part: a client paging through the listing pays the
+		// per-page cost again for every page.
+		if walkPages > 0 {
+			counting.reset()
+			start := time.Now()
+			for p := 0; p < walkPages; p++ {
+				perfListFiles694(t, url, sessionID, pageSize, p*pageSize)
+			}
+			t.Logf("%-6s walk pages=%-4d reads=%-5d rows=%-8d elapsed=%v",
+				arm.label, walkPages, counting.calls.Load(), counting.rows.Load(), time.Since(start))
+		}
+	}
+}
+
+// perfStore694 counts store reads and the rows they yield. Both listing methods
+// are overridden: embedding *store.SQLiteStore would otherwise satisfy
+// ListVisibleFiles silently and the "after" arm would count nothing.
+type perfStore694 struct {
+	*store.SQLiteStore
+	calls atomic.Int64
+	rows  atomic.Int64
+}
+
+func (p *perfStore694) reset() {
+	p.calls.Store(0)
+	p.rows.Store(0)
+}
+
+func (p *perfStore694) ListFiles(ctx context.Context, prefix, glob string, limit, offset int) ([]model.Document, int64, error) {
+	p.calls.Add(1)
+	docs, total, err := p.SQLiteStore.ListFiles(ctx, prefix, glob, limit, offset)
+	p.rows.Add(int64(len(docs)))
+	return docs, total, err
+}
+
+func (p *perfStore694) ListVisibleFiles(ctx context.Context, prefix, glob string, limit, offset int, includeHidden bool) ([]model.Document, int64, error) {
+	p.calls.Add(1)
+	docs, total, err := p.SQLiteStore.ListVisibleFiles(ctx, prefix, glob, limit, offset, includeHidden)
+	p.rows.Add(int64(len(docs)))
+	return docs, total, err
+}
+
+// walkOnly694 narrows a store to exactly model.Store, hiding the optional
+// ListVisibleFiles capability so the handler takes its pre-#694 fallback.
+type walkOnly694 struct{ model.Store }
+
+func perfSession694(t *testing.T, stateDir, root string, st model.Store) (string, string) {
+	t.Helper()
+	cfg := config.Default()
+	cfg.RootDir = root
+	cfg.StateDir = stateDir
+	cfg.MCPPath = protocol.DefaultMCPPath
+	cfg.AuthMode = "none"
+
+	server := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st)).Handler())
+	t.Cleanup(server.Close)
+	url := server.URL + cfg.MCPPath
+	return url, initializeSession(t, url)
+}
+
+func perfListFiles694(t *testing.T, url, sessionID string, limit, offset int) listFilesPageResult694 {
+	t.Helper()
+	body := fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"dir2mcp_list_files","arguments":{"limit":%d,"offset":%d}}}`,
+		limit, offset)
+	resp := postRPC(t, url, sessionID, body)
+	defer func() { _ = resp.Body.Close() }()
+	return decodeListFilesEnvelope694(t, resp.Body)
+}
+
+// seedPerfCorpus694 writes a real file per document and bulk-inserts the rows on
+// its own connection. Real files are mandatory: the handler drops rows that do
+// not resolve under the root, and a store-only corpus would measure a listing
+// that returns nothing. Rows go in directly rather than through UpsertDocument
+// because the goal is a large corpus in seconds, not exercising the write path.
+func seedPerfCorpus694(t *testing.T, dbPath, root string, total int) {
+	t.Helper()
+	start := time.Now()
+
+	db, err := sql.Open("sqlite", "file:"+dbPath+"?_pragma=journal_mode(WAL)&_pragma=synchronous(OFF)")
+	if err != nil {
+		t.Fatalf("open seed handle: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("begin seed tx: %v", err)
+	}
+	stmt, err := tx.Prepare(`INSERT INTO documents (rel_path, doc_type, source_type, title, size_bytes, mtime_unix, status, deleted)
+	                         VALUES (?, 'md', 'local', '', 1, 1700000000, 'ok', 0)`)
+	if err != nil {
+		t.Fatalf("prepare document insert: %v", err)
+	}
+
+	const perDir = 500
+	body := []byte("x")
+	for i := 0; i < total; i++ {
+		// Every tenth document is hidden, so the pushed-down predicate has a
+		// real result set to shrink rather than a no-op.
+		prefix := "corpus"
+		if i%10 == 0 {
+			prefix = ".cache"
+		}
+		relPath := fmt.Sprintf("%s/d%04d/f%07d.md", prefix, i/perDir, i)
+		full := filepath.Join(root, filepath.FromSlash(relPath))
+		if err := os.MkdirAll(filepath.Dir(full), 0o700); err != nil {
+			t.Fatalf("mkdir for %s: %v", relPath, err)
+		}
+		if err := os.WriteFile(full, body, 0o600); err != nil {
+			t.Fatalf("write %s: %v", relPath, err)
+		}
+		if _, err := stmt.Exec(relPath); err != nil {
+			t.Fatalf("insert %s: %v", relPath, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit seed tx: %v", err)
+	}
+	t.Logf("seeded %d documents (files + rows) in %v", total, time.Since(start))
+}

--- a/tests/mcp/session_resurrection_696_test.go
+++ b/tests/mcp/session_resurrection_696_test.go
@@ -1,0 +1,432 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/protocol"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// #696: session state transitions were ordered only in memory. Every mutation
+// released sessionMu and THEN wrote to the store, so the store could observe
+// the writes in an order that contradicted the in-memory order:
+//
+//  1. Request A validates the session, updates lastSeen under sessionMu,
+//     releases the lock, and is descheduled before/inside UpsertMCPSession.
+//  2. Request B handles DELETE for the same id, removes the in-memory entry,
+//     releases the lock, and completes DeleteMCPSession.
+//  3. Request A resumes; its older upsert lands AFTER the delete.
+//  4. The live process still rejects the id (its memory entry is gone), so
+//     nothing looks wrong. On the next restart restoreSessions reads the
+//     resurrected row and the terminated session is valid again.
+//
+// A session that was explicitly terminated coming back to life defeats the
+// point of terminating it, so these tests pin the ordering rather than the
+// symptom.
+
+// TestTerminatedSessionIsNotResurrectedByARacingTouch_696 reproduces the exact
+// interleaving above and asserts the outcome that actually matters: after a
+// restart, the terminated id is still terminated.
+//
+// The interleaving is forced through the persistence store rather than with a
+// sleep. Request A is parked INSIDE UpsertMCPSession, which is a point that
+// exists both before and after the fix, so this test compiles and runs against
+// the unfixed source.
+func TestTerminatedSessionIsNotResurrectedByARacingTouch_696(t *testing.T) {
+	dir := t.TempDir()
+	st := store.NewSQLiteStore(filepath.Join(dir, "meta.sqlite"))
+	if err := st.Init(context.Background()); err != nil {
+		t.Fatalf("init store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	paused := newPausingSessionStore(st)
+
+	cfg := config.Config{MCPPath: "/mcp", AuthMode: "none", StateDir: dir}
+	url, stop := startSessionRaceServer(t, cfg, paused)
+
+	sessionID := initializeSession(t, url)
+
+	// Arm the interleaving BEFORE either request is in flight.
+	upsertEntered, releaseUpsert := paused.pauseNextUpsert(sessionID)
+	deleteLanded := paused.watchDelete(sessionID)
+
+	// Request A: an ordinary call that touches the session. It completes its
+	// in-memory lastSeen update, then parks inside the store write.
+	touchErr := make(chan error, 1)
+	go func() {
+		_, err := doRPC(url, sessionID, `{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}`)
+		touchErr <- err
+	}()
+	select {
+	case <-upsertEntered:
+	case <-time.After(10 * time.Second):
+		t.Fatal("request A never reached UpsertMCPSession; the fixture cannot force the #696 interleaving")
+	}
+
+	// Request B: DELETE the session while A's older write is still in flight.
+	deleteErr := make(chan error, 1)
+	go func() {
+		deleteErr <- doDelete(url, sessionID)
+	}()
+
+	// Wait for B's delete to actually reach the store, which is what makes A's
+	// pending write definitively stale.
+	//
+	// This is asymmetric on purpose, and it is not a "sleep and hope". Against
+	// the UNFIXED code nothing serializes B behind A, so B's delete lands
+	// promptly and deleteLanded always fires: the resurrection is forced, not
+	// raced. Against the FIXED code B is parked behind the very serialization
+	// the fix introduces, so the signal cannot arrive until A is released; the
+	// timeout is this test observing that the fix is doing its job.
+	select {
+	case <-deleteLanded:
+	case <-time.After(2 * time.Second):
+	}
+
+	close(releaseUpsert)
+	if err := <-touchErr; err != nil {
+		t.Fatalf("request A: %v", err)
+	}
+	if err := <-deleteErr; err != nil {
+		t.Fatalf("request B (DELETE): %v", err)
+	}
+
+	// The persisted row is exactly what a restart reads back, so check it
+	// directly before simulating the restart.
+	if ids := persistedSessionIDs(t, st); contains(ids, sessionID) {
+		t.Fatalf("a terminated session is still persisted (%v); an older touch overtook the DELETE and a restart will revive it (#696)", ids)
+	}
+
+	// Simulate the restart: a fresh server over the same store runs
+	// restoreSessions during construction.
+	stop()
+	restartURL, restartStop := startSessionRaceServer(t, cfg, st)
+	defer restartStop()
+
+	status, err := doRPC(restartURL, sessionID, `{"jsonrpc":"2.0","id":3,"method":"tools/list","params":{}}`)
+	if err != nil {
+		t.Fatalf("post-restart request: %v", err)
+	}
+	if status != http.StatusNotFound {
+		t.Fatalf("a terminated session was accepted after restart (status %d, want 404); the DELETE was undone by an older touch write (#696)", status)
+	}
+}
+
+// TestExpiredSessionIsNotResurrectedByARacingTouch_696 covers the second half
+// of the bug: the same ordering can undo expiry, not just explicit DELETE.
+//
+// It asserts on the persisted row rather than on a restart, deliberately.
+// restoreSessions re-applies the expiry rules it was configured with, so under
+// an unchanged config a resurrected EXPIRED row would be filtered out again on
+// load and a restart-based assertion would pass vacuously against broken code.
+// The durable defect is the row surviving the expiry at all.
+func TestExpiredSessionIsNotResurrectedByARacingTouch_696(t *testing.T) {
+	dir := t.TempDir()
+	st := store.NewSQLiteStore(filepath.Join(dir, "meta.sqlite"))
+	if err := st.Init(context.Background()); err != nil {
+		t.Fatalf("init store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	paused := newPausingSessionStore(st)
+
+	// A short absolute lifetime makes the expiry fire deterministically off the
+	// session's creation time, with no dependency on the idle clock.
+	const maxLifetime = 150 * time.Millisecond
+	cfg := config.Config{MCPPath: "/mcp", AuthMode: "none", StateDir: dir, SessionMaxLifetime: maxLifetime}
+	url, stop := startSessionRaceServer(t, cfg, paused)
+	defer stop()
+
+	sessionID := initializeSession(t, url)
+
+	upsertEntered, releaseUpsert := paused.pauseNextUpsert(sessionID)
+	deleteLanded := paused.watchDelete(sessionID)
+
+	// Request A touches while the session is still inside its lifetime, then
+	// parks in the store write.
+	touchErr := make(chan error, 1)
+	go func() {
+		_, err := doRPC(url, sessionID, `{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}`)
+		touchErr <- err
+	}()
+	select {
+	case <-upsertEntered:
+	case <-time.After(10 * time.Second):
+		t.Fatal("request A never reached UpsertMCPSession; the fixture cannot force the #696 interleaving")
+	}
+
+	// Let the absolute lifetime lapse, then make request B observe the expiry.
+	time.Sleep(2 * maxLifetime)
+	expireErr := make(chan error, 1)
+	go func() {
+		_, err := doRPC(url, sessionID, `{"jsonrpc":"2.0","id":3,"method":"tools/list","params":{}}`)
+		expireErr <- err
+	}()
+
+	// See the note in the DELETE test: fires immediately pre-fix, times out
+	// post-fix because the fix serializes B behind A.
+	select {
+	case <-deleteLanded:
+	case <-time.After(2 * time.Second):
+	}
+
+	close(releaseUpsert)
+	if err := <-touchErr; err != nil {
+		t.Fatalf("request A: %v", err)
+	}
+	if err := <-expireErr; err != nil {
+		t.Fatalf("request B (expiring call): %v", err)
+	}
+
+	if ids := persistedSessionIDs(t, st); contains(ids, sessionID) {
+		t.Fatalf("an expired session is still persisted (%v); an older touch write undid the expiry (#696)", ids)
+	}
+}
+
+// TestConcurrentSessionTouchesStayConsistent_696 guards the other direction:
+// the ordering machinery must not drop or corrupt ordinary concurrent touches,
+// which are the common case. Run under -race.
+//
+// This one drives the plain HTTP handler rather than the SDK transport. The
+// touch path under test (the session middleware calling hasActiveSession) is
+// identical, and the SDK's streamable transport does not serve many concurrent
+// POSTs on a single session id — that is a property of the SDK's per-session
+// stream handling, unrelated to #696, and it stalls this test on unfixed and
+// fixed code alike.
+func TestConcurrentSessionTouchesStayConsistent_696(t *testing.T) {
+	dir := t.TempDir()
+	st := store.NewSQLiteStore(filepath.Join(dir, "meta.sqlite"))
+	if err := st.Init(context.Background()); err != nil {
+		t.Fatalf("init store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	cfg := config.Config{MCPPath: "/mcp", AuthMode: "none", StateDir: dir}
+	srv := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st)).Handler())
+	defer srv.Close()
+	url := srv.URL + cfg.MCPPath
+
+	sessionID := initializeSession(t, url)
+
+	const concurrency = 16
+	var wg sync.WaitGroup
+	errs := make(chan error, concurrency)
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			status, err := doRPC(url, sessionID, `{"jsonrpc":"2.0","id":4,"method":"tools/list","params":{}}`)
+			if err != nil {
+				errs <- err
+				return
+			}
+			if status != http.StatusOK {
+				t.Errorf("concurrent touch returned status %d, want 200", status)
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatalf("concurrent touch: %v", err)
+	}
+
+	// A live session must still be persisted exactly once after the storm.
+	ids := persistedSessionIDs(t, st)
+	if !contains(ids, sessionID) {
+		t.Fatalf("a live session was dropped from the store by concurrent touches (%v)", ids)
+	}
+	seen := 0
+	for _, id := range ids {
+		if id == sessionID {
+			seen++
+		}
+	}
+	if seen != 1 {
+		t.Fatalf("session persisted %d times, want exactly 1", seen)
+	}
+}
+
+// pausingSessionStore wraps a real SQLiteStore and lets a test park or observe
+// individual session persistence calls.
+//
+// It embeds the real store rather than reimplementing model.Store: the point is
+// to control the ORDER of the session writes, not to fake their behaviour, and
+// the restart assertion needs a genuine database underneath.
+type pausingSessionStore struct {
+	*store.SQLiteStore
+
+	mu sync.Mutex
+	// pauseUpsert holds the one-shot release channel for a session id whose
+	// next upsert should park; upsertEntered is closed when it does park.
+	pauseUpsert   map[string]chan struct{}
+	upsertEntered map[string]chan struct{}
+	// deleteLanded is closed AFTER the delete has actually been applied, so a
+	// test that waits on it knows the row is gone rather than merely that the
+	// call started.
+	deleteLanded map[string]chan struct{}
+}
+
+func newPausingSessionStore(st *store.SQLiteStore) *pausingSessionStore {
+	return &pausingSessionStore{
+		SQLiteStore:   st,
+		pauseUpsert:   make(map[string]chan struct{}),
+		upsertEntered: make(map[string]chan struct{}),
+		deleteLanded:  make(map[string]chan struct{}),
+	}
+}
+
+// pauseNextUpsert arms a one-shot park on the next UpsertMCPSession for id. It
+// returns a channel closed once that call has parked, and the channel the test
+// closes to let it proceed.
+func (p *pausingSessionStore) pauseNextUpsert(id string) (entered <-chan struct{}, release chan struct{}) {
+	enteredCh := make(chan struct{})
+	releaseCh := make(chan struct{})
+	p.mu.Lock()
+	p.upsertEntered[id] = enteredCh
+	p.pauseUpsert[id] = releaseCh
+	p.mu.Unlock()
+	return enteredCh, releaseCh
+}
+
+// watchDelete returns a channel closed once a DeleteMCPSession for id has been
+// applied to the underlying store.
+func (p *pausingSessionStore) watchDelete(id string) <-chan struct{} {
+	ch := make(chan struct{})
+	p.mu.Lock()
+	p.deleteLanded[id] = ch
+	p.mu.Unlock()
+	return ch
+}
+
+func (p *pausingSessionStore) UpsertMCPSession(ctx context.Context, sessionID string, created, lastSeen time.Time, authScope string) error {
+	p.mu.Lock()
+	release := p.pauseUpsert[sessionID]
+	entered := p.upsertEntered[sessionID]
+	if release != nil {
+		// One-shot: later upserts for this id run unimpeded.
+		delete(p.pauseUpsert, sessionID)
+		delete(p.upsertEntered, sessionID)
+	}
+	p.mu.Unlock()
+
+	if release != nil {
+		close(entered)
+		<-release
+	}
+	return p.SQLiteStore.UpsertMCPSession(ctx, sessionID, created, lastSeen, authScope)
+}
+
+func (p *pausingSessionStore) DeleteMCPSession(ctx context.Context, sessionID string) error {
+	p.mu.Lock()
+	landed := p.deleteLanded[sessionID]
+	if landed != nil {
+		delete(p.deleteLanded, sessionID)
+	}
+	p.mu.Unlock()
+
+	err := p.SQLiteStore.DeleteMCPSession(ctx, sessionID)
+	if landed != nil {
+		close(landed)
+	}
+	return err
+}
+
+// startSessionRaceServer serves an MCP server over the SDK transport, which is
+// the transport that implements the DELETE session-termination verb.
+func startSessionRaceServer(t *testing.T, cfg config.Config, st model.Store) (baseURL string, stop func()) {
+	t.Helper()
+	srv := mcp.NewServer(cfg, nil, mcp.WithStore(st))
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	tr := mcp.NewSDKTransport(srv, ln, "", "")
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- tr.Serve(ctx, srv.Handler())
+	}()
+
+	var once sync.Once
+	stop = func() {
+		once.Do(func() {
+			cancel()
+			select {
+			case err := <-done:
+				if err != nil {
+					t.Errorf("Serve returned unexpected error: %v", err)
+				}
+			case <-time.After(5 * time.Second):
+				t.Error("timeout waiting for Serve to exit")
+			}
+			_ = ln.Close()
+		})
+	}
+	return "http://" + ln.Addr().String() + cfg.MCPPath, stop
+}
+
+// doRPC and doDelete return errors instead of calling t.Fatalf because they run
+// on non-test goroutines, where Fatalf is not allowed.
+func doRPC(url, sessionID, body string) (int, error) {
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader([]byte(body)))
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set(protocol.MCPSessionHeader, sessionID)
+	resp, err := (&http.Client{Timeout: 30 * time.Second}).Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	return resp.StatusCode, nil
+}
+
+func doDelete(url, sessionID string) error {
+	req, err := http.NewRequest(http.MethodDelete, url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set(protocol.MCPSessionHeader, sessionID)
+	resp, err := (&http.Client{Timeout: 30 * time.Second}).Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	return nil
+}
+
+func persistedSessionIDs(t *testing.T, st *store.SQLiteStore) []string {
+	t.Helper()
+	records, err := st.ListMCPSessions(context.Background())
+	if err != nil {
+		t.Fatalf("list persisted sessions: %v", err)
+	}
+	ids := make([]string, 0, len(records))
+	for _, rec := range records {
+		ids = append(ids, rec.ID)
+	}
+	return ids
+}
+
+func contains(ids []string, want string) bool {
+	for _, id := range ids {
+		if id == want {
+			return true
+		}
+	}
+	return false
+}

--- a/tests/store/list_visible_files_cache_694_test.go
+++ b/tests/store/list_visible_files_cache_694_test.go
@@ -1,0 +1,127 @@
+package tests
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// #694 pushed the list_files hidden-path policy into the ListFiles query so the
+// MCP handler stops walking the whole corpus per page. The trap that comes with
+// it is the #429 F10 memo: it caches the exact total per listing, guarded by
+// SQLite's data_version, and two visibility policies over the SAME prefix/glob
+// are two DIFFERENT listings with two different totals.
+//
+// If the memo key carries only the filter, the first call's total is served to
+// the second for as long as no commit lands. The page rows come from a fresh
+// query and are correct, so the response is internally contradictory: a
+// hidden-inclusive page reported with a hidden-excluded total (or the reverse),
+// which is worse than either being wrong on its own — a client paging on
+// `offset < total` silently stops early and never sees the hidden rows.
+//
+// These calls are deliberately back-to-back with no write in between, because
+// that is the only window in which the memo is live.
+
+func TestListVisibleFilesTotalIsNotCrossedBetweenVisibilityPolicies_694(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("init store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	seed := []string{
+		"a.md",
+		"dir/sub/c.md",
+		"visible/.config/b.md", // dot in a LATER segment: visible
+		".hidden/a.md",
+		".x",
+	}
+	for i, relPath := range seed {
+		if err := st.UpsertDocument(ctx, model.Document{
+			RelPath: relPath, DocType: "md", MTimeUnix: int64(100 * (i + 1)), Status: "ok",
+		}); err != nil {
+			t.Fatalf("seed %s: %v", relPath, err)
+		}
+	}
+	const wantVisible, wantAll = 3, 5
+
+	for _, tc := range []struct {
+		name string
+		glob string
+	}{
+		// Both ListFiles paths memoize, and they build their keys separately.
+		{name: "sql path", glob: ""},
+		{name: "glob path", glob: "**"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, order := range []struct {
+				name  string
+				first bool // includeHidden of the FIRST call
+			}{
+				{name: "visible then all", first: false},
+				{name: "all then visible", first: true},
+			} {
+				t.Run(order.name, func(t *testing.T) {
+					firstWant, secondWant := int64(wantVisible), int64(wantAll)
+					if order.first {
+						firstWant, secondWant = int64(wantAll), int64(wantVisible)
+					}
+
+					docs, total, err := st.ListVisibleFiles(ctx, "", tc.glob, 50, 0, order.first)
+					if err != nil {
+						t.Fatalf("first ListVisibleFiles: %v", err)
+					}
+					if total != firstWant || int64(len(docs)) != firstWant {
+						t.Fatalf("first call: rows=%d total=%d want %d", len(docs), total, firstWant)
+					}
+
+					docs, total, err = st.ListVisibleFiles(ctx, "", tc.glob, 50, 0, !order.first)
+					if err != nil {
+						t.Fatalf("second ListVisibleFiles: %v", err)
+					}
+					if int64(len(docs)) != secondWant {
+						t.Fatalf("second call returned %d rows, want %d", len(docs), secondWant)
+					}
+					if total != secondWant {
+						t.Fatalf("second call returned %d rows but total=%d (want %d): the "+
+							"memoized total of the previous visibility policy was reused, so the "+
+							"page and its total describe different listings (#694)",
+							len(docs), total, secondWant)
+					}
+				})
+			}
+		})
+	}
+}
+
+// TestListFilesStaysHiddenInclusive_694 pins the delegation: model.Store's
+// ListFiles is unchanged for its ~30 existing callers, so it must keep
+// returning dot-prefixed rows.
+func TestListFilesStaysHiddenInclusive_694(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("init store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	for i, relPath := range []string{"a.md", ".hidden/a.md"} {
+		if err := st.UpsertDocument(ctx, model.Document{
+			RelPath: relPath, DocType: "md", MTimeUnix: int64(100 * (i + 1)), Status: "ok",
+		}); err != nil {
+			t.Fatalf("seed %s: %v", relPath, err)
+		}
+	}
+
+	docs, total, err := st.ListFiles(ctx, "", "", 50, 0)
+	if err != nil {
+		t.Fatalf("ListFiles: %v", err)
+	}
+	if total != 2 || len(docs) != 2 {
+		t.Fatalf("ListFiles rows=%d total=%d, want 2/2: ListFiles must stay hidden-inclusive", len(docs), total)
+	}
+}


### PR DESCRIPTION
Closes #696. Closes #694.

Both defects live in `internal/mcp` and both were verified against the code before anything was written. They ship together because they overlap: `listFilesFiltered` and the session lifetime path sit in the same package, and #694 reshapes the very store call that #696's test fixture wraps. As separate PRs they would have conflicted.

---

# #696 — a concurrent touch could resurrect a deleted session

This is the serious one. A session that was explicitly terminated coming back to life defeats whatever the termination was for.

## The interleaving

Session mutation was ordered **only in memory**. Every mutation released `sessionMu` and *then* wrote to the store, so nothing tied the order of the in-memory transitions to the order of the store writes.

Thread A — any authenticated request:

1. `hasActiveSession(id)` takes `sessionMu`, finds the session live, sets `si.lastSeen = now`, writes it back into `s.sessions`, and **releases `sessionMu`**.
2. A is descheduled before/inside `persistSession` → `store.UpsertMCPSession(id, …)`.

Thread B — `DELETE` for the same id:

3. `forgetSession(id)` takes `sessionMu`, does `delete(s.sessions, id)`, and **releases `sessionMu`**.
4. `deletePersistedSession(id)` → `store.DeleteMCPSession(id)` **completes**. The row is gone.

Thread A resumes:

5. A's `UpsertMCPSession` executes and **re-inserts the row**, carrying the `lastSeen` it captured back at step 1.

The in-memory order (touch, then delete) was correct. Only the **store** order got inverted (delete, then touch). And the damage is invisible while the process lives: memory has no entry, so the id is still rejected. The next restart is where it surfaces — `restoreSessions` reads the resurrected row, finds it inside the inactivity/max-life window, and loads it as **active**. The terminated session is valid again, for a freshly refreshed timeout.

The same inversion undoes expiry: `hasActiveSession`'s two expiry branches and `cleanupExpiredSessions` all delete-after-unlock too.

## The fix

A generation token per transition, allocated **inside the same critical section that performs the in-memory transition**, so token order equals transition order:

- `reserveSessionPersistLocked(id)` is called with `sessionMu` held, at all five mutation sites (touch, create, forget, both expiry branches, and the sweep).
- `commitSessionPersist(id, seq, apply)` drops the write when a newer token already reached the store, and **holds `sessionPersistMu` across the store call**.

Both halves are load-bearing, and the second is the non-obvious one. A check that does *not* hold the lock across the I/O does **not** fix this: the stale touch would pass its check, the DELETE would pass its own check and complete, and the touch would still land last. Serializing across the store call is what makes the store's final state agree with the newest logical transition.

`sessionPersistMu` is deliberately **not** `sessionMu`: `sessionMu` is taken on every request and must not be held across store I/O. The per-id seq record is dropped once its in-flight count hits zero — it cannot go earlier (it is exactly what a late write is rejected against) and must not go never (the map would otherwise grow for the life of the daemon).

## Tests — `tests/mcp/session_resurrection_696_test.go`

The interleaving is **forced through the persistence store, not slept on**. Request A is parked *inside* `UpsertMCPSession`, a point that exists both before and after the fix, so the tests compile and run against unfixed source.

Proven to fail with only `internal/mcp/server.go` stashed:

```
--- FAIL: TestTerminatedSessionIsNotResurrectedByARacingTouch_696 (0.13s)
    a terminated session is still persisted ([V22BQNTVRCK2Y7DUBIYX7L7ZQ5]); an older
    touch overtook the DELETE and a restart will revive it (#696)

--- FAIL: TestExpiredSessionIsNotResurrectedByARacingTouch_696 (0.43s)
    an expired session is still persisted ([OC6ZMRAVZENM6NGTRS57JIWYLF]); an older
    touch write undid the expiry (#696)
```

The DELETE test then goes the whole way: it stands up a **second server over the same store** (so `restoreSessions` runs) and asserts the terminated id now gets a 404.

Two deliberate calls worth flagging for review:

- **The wait for B's delete is asymmetric, and it is not a "sleep and hope".** Against unfixed code nothing serializes B behind A, so B's delete lands promptly and the signal always fires: the resurrection is *forced*, not raced — note the 0.13s/0.43s pre-fix runtimes. Against fixed code B is parked behind the very serialization the fix adds, so the signal cannot arrive until A is released, and the timeout is simply the test observing the fix work.
- **The expiry test asserts on the persisted row rather than on a restart.** `restoreSessions` re-applies the expiry rules it was configured with, so a resurrected *expired* row gets filtered out again on load and a restart-based assertion would have passed vacuously against broken code. The durable defect is the row surviving the expiry at all.

The third test is a **guard, not a reproduction**: it passes before and after by design, and exists so the new ordering machinery cannot silently break ordinary concurrent touches. `tests/mcp` is added to `make test-race` so that guard keeps running under `-race`, which is the only way it stays meaningful.

---

# #694 — every `list_files` page rescanned and stat'ed the whole corpus

`listFilesFiltered` walked the entire matching corpus from store offset zero **on every call**, in 500-row pages, running `filepath.EvalSymlinks` on every row, purely to compute a post-filter `total`. #429 F10's store-level pagination was fully undone at the tool boundary.

## The fix

Same shape as #732/#743: **push the selective predicate down to where the LIMIT already is.**

`isListFilesNoisePath` is exactly "the normalized rel_path starts with a dot" — it takes the first `/`-delimited segment and tests `HasPrefix(first, ".")`, and testing the first segment's prefix *is* testing the whole string's prefix. So it becomes `rel_path NOT LIKE '.%'` in the `where` slice, which is already threaded into the page query, `countListFiles`, **and** the glob scan. All three start agreeing on the visible set for free.

- `SQLiteStore.ListVisibleFiles` is the new entry point; `ListFiles` is a thin delegate, so `model.Store` and its ~30 callers are untouched.
- The MCP handler asks the store for **one page** through an optional `visibleFilesLister` capability (the `recentFailuresLister` idiom), then runs the #176 round-trip gate over **the rows of that page**.
- The pre-#694 walk is kept as the fallback for a store that cannot push the predicate down — and the perf harness reuses it as its honest "before" arm rather than reimplementing it.

The **memo key now carries the visibility policy**. This was the real trap: #429 F10 caches the exact total per listing, and two visibility policies over the same prefix/glob are two different listings. Without it a hidden-inclusive page gets served a hidden-excluded total, and a client paging on `offset < total` silently stops early.

## Measured — 20,000 documents (18,000 visible, 10% hidden), real files on disk

| | store reads | rows stat'ed | elapsed |
|---|---|---|---|
| first page (`limit=50, offset=0`) **before** | 40 | 20,000 | 3.304s |
| first page **after** | **1** | **50** | **33ms** |
| deep page (`offset=17,900`) **before** | 40 | 20,000 | 1.750s |
| deep page **after** | **1** | **50** | **59ms** |
| walking 10 pages **before** | 400 | 200,000 | 35.373s |
| walking 10 pages **after** | **10** | **500** | **339ms** |

Roughly 100x on a first page, and the quadratic term is gone: ten pages cost ten reads instead of 400. Rows-returned *is* the `EvalSymlinks` syscall count, which is the term that dominates on a network filesystem.

The harness is opt-in, following #742/#748, so the default suite stays fast:

```
DIR2MCP_PERF=1 go test ./tests/mcp -run ListFilesPagePerf -v
```

## What changed about `total` — stated plainly

`total` now means *"matching, non-deleted, non-hidden rows in the store"* rather than *"rows that also survived a filesystem stat"*.

Those differ **only** when the store holds a row whose backing file is gone — i.e. when ingest's `deleted = 0` tombstoning has drifted, which is the degraded case the stat filter exists as a safety net for. In a healthy corpus they are identical, and `documents.deleted` is already the authoritative liveness signal `ListFiles` filters on in SQL. Paying O(corpus) stats on every request to keep the total exact under drift **is the defect being fixed**, so the trade is deliberate rather than incidental.

Visible consequence: a page can come back shorter than `limit` when a dead row is dropped from it. That was already possible at the end of a listing, and a client looping `while offset < total` still terminates and still sees every live file. What does **not** change is #176's actual guarantee: every path the tool *emits* round-trips through `open_file`, because the page-scoped gate still covers every emitted row.

## Acceptance criteria not fully met

Two of the issue's criteria are only partially addressed, and I would rather say so than imply otherwise:

- **"Exact visible total"** is exact for a healthy corpus but is an upper bound under tombstoning drift, per the trade above. Making it exact *and* cheap needs ingest-time reconciliation so liveness becomes a SQL predicate — the issue's own first-choice option, and a considerably larger change than this.
- **Single-snapshot consistency** is much improved but not literally satisfied. One response is now one store call, so the page rows all come from a single query and the multi-call state-mixture the issue describes is gone. The total can still come from a separate `COUNT(*)` (or the #429 memo), so page and total can describe adjacent commits — already true before this PR, and documented on `listFilesSQLPaged`. There is no `BEGIN`-wrapped snapshot and no keyset/cursor API.
- **"Concurrent insert/delete tests proving no duplicates/skips within one response"** is not written, because with one page query there is no intra-response window left to test. A meaningful test would have to target the page/COUNT gap, which is pre-existing #429 territory and belongs in `tests/store`. Flagging it rather than silently dropping it.

## Tests

All of them drive the **real tool over HTTP** and **write real files on disk** — per PR #766's warning, `list_files` drops rows whose file does not exist, so a store-only fixture returns zero files and would make every assertion pass vacuously.

**Reproductions**, proven to fail first. With the handler pointed back at `listFilesFilteredByWalk`:

```
--- FAIL: TestListFilesServesASmallFirstPageInOneStoreRead_694
    a 5-row first page cost 3 store reads (ListFiles=3 ListVisibleFiles=0); the
    handler is still walking the whole corpus to compute a total (#694)

--- FAIL: TestListFilesDeepPageDoesNotRestartFromZero_694
    offset=1000 cost 3 store reads (ListFiles=3 ListVisibleFiles=0); a later page
    must be served by the store's own LIMIT/OFFSET, not by re-walking every
    preceding row (#694)
```

And with only the visibility component removed from the memo keys (SQL predicate left in place), which is how the cache-key trap was confirmed to be real on **both** paths:

```
--- FAIL: .../sql_path/visible_then_all
    second call returned 5 rows but total=3 (want 5): the memoized total of the
    previous visibility policy was reused, so the page and its total describe
    different listings (#694)
--- FAIL: .../glob_path/visible_then_all
```

**Guards, not reproductions** — flagged rather than dressed up as failures. `TestListFilesHiddenFilteringSurvivesTheSQLPushdown_694` and `TestListFilesStillDropsRowsWhoseFileIsGone_694` pass before and after by construction: they assert behavior that must stay *unchanged* across the pushdown. The first pins that `visible/.config/b.md` is **not** hidden (only the first segment counts, which is exactly what a naive `LIKE '%/.%'` translation breaks); the second is the #176 gate. `TestListFilesStaysHiddenInclusive_694` likewise pins that the `ListFiles` delegate stays hidden-inclusive for its existing callers.

---

`make check` passes. `make test-race` passes.
