### PR TITLE
fix(embedqueue): give distributed embedding jobs a corpus and a payload identity (#708, #709, #710)

### DIFF
--- a/docs/dual-machine-deployment.md
+++ b/docs/dual-machine-deployment.md
@@ -380,6 +380,47 @@ Run as many `embed-worker` processes as your GPU(s) can feed. Because all worker
 write to the same Tier-C collection under the same embed identity, the result is a
 single coherent index.
 
+### 4.4 Sharing one broker between corpora
+
+Two corpora may point at the same `sqlite_path`. Each corpus is identified by a
+stable `corpus_id` (SPEC §5.5), derived on first use from the corpus root (or,
+for `source.kind: s3`, from bucket + prefix + endpoint) and persisted in that
+corpus's own metadata store. It is an opaque digest: it carries no path, bucket,
+endpoint or credential, so a queue file readable by both corpora discloses
+neither corpus's layout to the other.
+
+Every job carries its `corpus_id`, and it governs routing end to end:
+
+- the queue deduplicates jobs per corpus, so two corpora whose chunk ids collide
+  (they are per-corpus SQLite rowids, so this is normal, not exotic) each keep
+  their own job;
+- a worker leases only jobs for the corpus its metadata store belongs to, and
+  refuses to execute one for any other corpus even if a broker hands it over.
+
+Moving or re-mounting a corpus does not change its `corpus_id` — the persisted
+value wins over the derived one, so in-flight jobs and already-written vectors
+stay bound to the corpus they came from.
+
+### 4.5 When a job cannot succeed
+
+A job is redelivered up to `max_attempts` times and then dead-lettered. On that
+final attempt the chunk itself is recorded as `embedding_status=error` with a
+category, so:
+
+- it leaves the pending set and the coordinator stops minting new jobs for it —
+  a permanent misconfiguration (mismatched embed identity, an index axis no
+  worker serves) fails **bounded** instead of retrying forever;
+- it appears in `dir2mcp status` and `dir2mcp doctor` under the error-category
+  breakdown, alongside in-process embedding failures.
+
+A failure that clears within the retry budget is simply redelivered and succeeds;
+nothing is recorded. To retry a chunk that was recorded as failed — after fixing
+the cause — re-pend it with `dir2mcp reindex`.
+
+A job whose chunk changed after it was enqueued (re-ingested with different text,
+or moved to the other index axis) is acknowledged as **superseded** without being
+embedded, and the coordinator enqueues the chunk's current form on its next pass.
+
 ---
 
 ## 5. Caveats and current limitations

--- a/internal/cli/embed_worker.go
+++ b/internal/cli/embed_worker.go
@@ -13,6 +13,7 @@ import (
 	"github.com/dirstral/dir2mcp/internal/config"
 	"github.com/dirstral/dir2mcp/internal/embedqueue"
 	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
 )
 
 // embedWorkerOptions holds the parsed flags for the standalone embed-worker
@@ -133,6 +134,27 @@ func (a *App) requireDistributedPrereqs(cfg config.Config, global globalOptions)
 	return exitSuccess
 }
 
+// requireSharedStoreCapabilities asserts the two optional store capabilities a
+// distributed worker cannot run without: read-by-id (ChunkTaskByID) so it can
+// load the authoritative chunk for a leased job (§8.7.4), and the chunk source
+// so EmbedAndIndex — and the terminal-failure path (#709) — can write status
+// back. Both are satisfied by the SQLite-backed metadata store.
+func (a *App) requireSharedStoreCapabilities(st model.Store, global globalOptions) (embedqueue.TaskFetcher, index.ChunkSource, int) {
+	fetcher, ok := st.(embedqueue.TaskFetcher)
+	if !ok {
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid,
+			"CONFIG_INVALID: metadata store does not support ChunkTaskByID (required for distributed embedding)")
+		return nil, nil, exitConfigInvalid
+	}
+	chunkSource, ok := st.(index.ChunkSource)
+	if !ok {
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid,
+			"CONFIG_INVALID: metadata store does not support the chunk source interface (required for distributed embedding)")
+		return nil, nil, exitConfigInvalid
+	}
+	return fetcher, chunkSource, exitSuccess
+}
+
 // runEmbedWorkerLoop opens the shared store, the Tier-C indices, the corpus
 // filesystem and the broker, builds per-axis embedders, and runs embedqueue.Run
 // until the context is cancelled. Setup failures are remediable config errors;
@@ -158,21 +180,9 @@ func (a *App) runEmbedWorkerLoop(ctx context.Context, cfg config.Config, global 
 		}
 	}()
 
-	// The shared store must expose read-by-id (ChunkTaskByID) so the worker can
-	// load the authoritative chunk for a leased job (§8.7.4), and the chunk
-	// source so EmbedAndIndex can write status back. Both are satisfied by the
-	// SQLite-backed metadata store.
-	fetcher, ok := st.(embedqueue.TaskFetcher)
-	if !ok {
-		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid,
-			"CONFIG_INVALID: metadata store does not support ChunkTaskByID (required for distributed embedding)")
-		return exitConfigInvalid
-	}
-	chunkSource, ok := st.(index.ChunkSource)
-	if !ok {
-		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid,
-			"CONFIG_INVALID: metadata store does not support the chunk source interface (required for distributed embedding)")
-		return exitConfigInvalid
+	fetcher, chunkSource, code := a.requireSharedStoreCapabilities(st, global)
+	if code != exitSuccess {
+		return code
 	}
 
 	embedder, _, textModel, codeModel := a.resolveModelClients(cfg)
@@ -205,11 +215,25 @@ func (a *App) runEmbedWorkerLoop(ctx context.Context, cfg config.Config, global 
 		return exitConfigInvalid
 	}
 
+	// The corpus binding comes from the SHARED metadata store this worker reads
+	// chunks out of, not from its own config, so a worker's identity and its data
+	// plane are the same fact. A standalone worker is the case #708 is really
+	// about: it is deployed against a broker built to be shared, and without a
+	// binding it will execute whatever it is handed against whichever corpus its
+	// store happens to be.
+	corpusID, err := resolveCorpusID(ctx, cfg, st)
+	if err != nil {
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("embed-worker: %v", err))
+		return exitConfigInvalid
+	}
+
 	identityStr := cfg.Providers().EmbedIdentity()
 	workerCfg := embedqueue.Config{
 		Broker:        broker,
 		Fetcher:       fetcher,
 		Embedders:     embedders,
+		CorpusID:      corpusID,
+		Status:        chunkSource,
 		EmbedIdentity: identityStr,
 		LeaseDuration: opts.leaseDuration,
 		PollInterval:  opts.pollInterval,

--- a/internal/cli/up_distributed_embed.go
+++ b/internal/cli/up_distributed_embed.go
@@ -12,6 +12,7 @@ import (
 	"github.com/dirstral/dir2mcp/internal/config"
 	"github.com/dirstral/dir2mcp/internal/corpusfs"
 	"github.com/dirstral/dir2mcp/internal/embedqueue"
+	"github.com/dirstral/dir2mcp/internal/identity"
 	"github.com/dirstral/dir2mcp/internal/index"
 	"github.com/dirstral/dir2mcp/internal/model"
 	"github.com/dirstral/dir2mcp/internal/retrieval"
@@ -68,6 +69,11 @@ func startDistributedEmbedding(
 		return errors.New("distributed embedding: embed identity could not be resolved")
 	}
 
+	corpusID, err := resolveCorpusID(ctx, cfg, st)
+	if err != nil {
+		return fmt.Errorf("distributed embedding: %w", err)
+	}
+
 	// Single-coordinator guard (issue #435 C3): refuse to start a second
 	// coordinator for this corpus. The default broker is in-process and cannot
 	// dedup across processes, so two daemons on one corpus would otherwise both
@@ -106,15 +112,23 @@ func startDistributedEmbedding(
 	coord := &embedqueue.Coordinator{
 		Source:        chunkSource,
 		Broker:        broker,
-		CorpusID:      rootDir,
+		CorpusID:      corpusID,
 		SourceKind:    cfg.Source.Kind,
 		EmbedIdentity: identityStr,
 	}
 
 	workerCfg := embedqueue.Config{
-		Broker:        broker,
-		Fetcher:       fetcher,
-		Embedders:     embedders,
+		Broker:    broker,
+		Fetcher:   fetcher,
+		Embedders: embedders,
+		// The coordinator and the worker resolve the corpus id from the SAME store,
+		// so the in-process pair is bound to one corpus by construction and a
+		// broker shared with another corpus cannot cross-wire them (#708).
+		CorpusID: corpusID,
+		// Terminal per-chunk failures go through the same store the in-process loop
+		// marks status on, so a dead-lettered job leaves the pending set instead of
+		// being re-enqueued on the next coordinator tick (#709).
+		Status:        chunkSource,
 		EmbedIdentity: identityStr,
 		// Lease/embed up to distributedEmbedBatchSize chunks per iteration so the
 		// distributed path batches through the provider like the in-process loop
@@ -165,6 +179,48 @@ func startDistributedEmbedding(
 		}
 	})
 	return nil
+}
+
+// resolveCorpusID returns the stable corpus identity (SPEC §5.5) that scopes
+// every distributed embedding job this process enqueues or executes, reading it
+// from — and seeding it into — the corpus's own metadata store.
+//
+// It replaces the root path the coordinator used to stamp onto jobs (#708). A
+// path is the wrong key three times over: it is not stable (moving or
+// re-mounting the corpus renames it), it is not unique for an object-store
+// corpus (S3FS ignores the local root, so two buckets launched from one
+// directory shared an identity — the same defect #737 fixed for the instance
+// name), and it is not safe to publish into a queue several corpora may share.
+// The persisted digest is all three.
+//
+// The key derivation is identity's, not a second implementation of it, so the
+// corpus id and the MCP instance name are derived from exactly the same notion
+// of "which corpus is this" and no credential can reach either.
+func resolveCorpusID(ctx context.Context, cfg config.Config, st model.Store) (string, error) {
+	settings, ok := st.(identity.SettingsStore)
+	if !ok {
+		return "", fmt.Errorf("store %T cannot persist %s; a shared broker cannot route this corpus's jobs safely",
+			st, identity.CorpusIDSettingKey)
+	}
+	corpusID, err := identity.ResolveCorpusID(ctx, settings, corpusIdentityKey(cfg))
+	if err != nil {
+		return "", fmt.Errorf("resolve corpus id: %w", err)
+	}
+	return corpusID, nil
+}
+
+// corpusIdentityKey returns the canonical key this corpus is identified by,
+// mirroring resolveServerName's source branch so one deployment can never be two
+// identities depending on which of the two asked.
+func corpusIdentityKey(cfg config.Config) string {
+	if sourceIsRemote(cfg) {
+		return identity.CorpusKeyForS3(cfg.Source.S3Bucket, cfg.Source.S3Prefix, cfg.Source.S3Endpoint)
+	}
+	abs, err := filepath.Abs(cfg.RootDir)
+	if err != nil {
+		abs = cfg.RootDir
+	}
+	return identity.CorpusKey(abs)
 }
 
 // runCoordinatorLoop enqueues pending chunks on a fixed interval until ctx is

--- a/internal/embedqueue/broker.go
+++ b/internal/embedqueue/broker.go
@@ -25,6 +25,24 @@ type Lease struct {
 	// deadline has passed MUST treat its in-flight write as possibly raced by a
 	// redelivery (idempotency, keyed by chunk_id, makes that safe — §8.7.3).
 	Deadline time.Time
+
+	// Attempts is how many times this job has been delivered INCLUDING this
+	// delivery, and MaxAttempts is the broker's redelivery budget (0 = the broker
+	// does not bound it). Together they tell a worker whether a Nack it is about
+	// to issue will REDELIVER the job or DEAD-LETTER it, which is the difference
+	// between a failure the pool may still recover from and a terminal one the
+	// chunk has to record (SPEC §8.7.3 failure handling; #709). Without them a
+	// worker cannot distinguish the two and a permanently unexecutable job is
+	// retried, dead-lettered, and then enqueued again forever.
+	Attempts    int
+	MaxAttempts int
+}
+
+// Final reports whether this delivery is the last one the broker will make: a
+// Nack now dead-letters the job instead of redelivering it. A broker that does
+// not bound redelivery (MaxAttempts <= 0) is never final.
+func (l Lease) Final() bool {
+	return l.MaxAttempts > 0 && l.Attempts >= l.MaxAttempts
 }
 
 // Broker is the implementation-defined transport that carries embedding jobs
@@ -62,6 +80,28 @@ type Broker interface {
 
 	// Close releases any resources the broker holds.
 	Close() error
+}
+
+// CorpusScopedBroker is an OPTIONAL Broker capability: leasing only the jobs of
+// one corpus (SPEC §8.7.2 corpus reference, §8.7.4 corpus isolation on shared
+// infrastructure). Both built-in brokers implement it; the worker discovers it
+// by type assertion, exactly like the store's optional capabilities, so an
+// external adapter that predates it keeps working unchanged.
+//
+// Worker-side rejection of a foreign corpus's job (worker.prepare) is the
+// mandatory half of the isolation and stands on its own. This is the half that
+// keeps a shared queue EFFICIENT as well as correct: without it, a worker that
+// serves corpus B leases corpus A's jobs only to reject them, burning A's
+// redelivery budget and eventually dead-lettering work that nothing was wrong
+// with (#708).
+type CorpusScopedBroker interface {
+	Broker
+
+	// LeaseForCorpus claims the next available job whose CorpusID equals
+	// corpusID, ignoring every other corpus's jobs. An empty corpusID means "any
+	// corpus" and is identical to Lease. Returns ErrNoJob when this corpus has no
+	// claimable job, even if other corpora do.
+	LeaseForCorpus(ctx context.Context, corpusID string, visibility time.Duration) (Lease, error)
 }
 
 // Stats is a point-in-time view of the queue (SPEC §8.7.4 observability).

--- a/internal/embedqueue/coordinator.go
+++ b/internal/embedqueue/coordinator.go
@@ -22,8 +22,14 @@ type PendingSource interface {
 // It is opt-in: the in-process loop remains the default and this type is only
 // constructed when distributed mode is enabled.
 type Coordinator struct {
-	Source        PendingSource
-	Broker        Broker
+	Source PendingSource
+	Broker Broker
+	// CorpusID MUST be the corpus's stable persisted identity (SPEC §5.5 —
+	// identity.ResolveCorpusID), not a root path or any other incidental string.
+	// It is what namespaces this corpus's jobs inside a broker several corpora
+	// may share, and what a worker checks before it executes one. A coordinator
+	// that leaves it empty can only be used against a broker it does not share
+	// (#708).
 	CorpusID      string
 	SourceKind    string
 	EmbedIdentity string
@@ -39,8 +45,9 @@ type Coordinator struct {
 // interface has no offset cursor, so one call enqueues the head it observes — NOT
 // necessarily the entire backlog. The coordinator loop (runCoordinatorLoop) calls
 // this on a ticker, so as the head drains the next pending chunks are picked up;
-// the broker dedups by chunk_id+index_kind, so repeated ticks never pile up
-// duplicate live jobs (SPEC §8.7.3). Re-running is always safe: an already-
+// the broker dedups by corpus_id+chunk_id+index_kind, so repeated ticks never
+// pile up duplicate live jobs and a chunk id that collides with another corpus's
+// is still enqueued (SPEC §8.7.3, #708). Re-running is always safe: an already-
 // embedded chunk is no longer pending, and a duplicate job is idempotent at the
 // embed layer (vector writes keyed by chunk_id).
 func (c *Coordinator) EnqueuePending(ctx context.Context, indexKind string) (int, error) {
@@ -115,11 +122,15 @@ func (c *Coordinator) jobFromTask(t model.ChunkTask) Job {
 		Source:    c.SourceKind,
 		ChunkID:   id,
 		IndexKind: idxKind,
-		// TextHash (payload identity, §8.7.2) is left empty here: NextPending does
-		// not surface the chunk's text_hash, and it is not load-bearing for
-		// correctness — the worker re-reads the AUTHORITATIVE task (text, span,
-		// tombstone status) from the shared store by chunk_id (ChunkTaskByID), so
-		// a since-changed or tombstoned chunk is handled there.
+		// TextHash is the job's PAYLOAD identity (SPEC §8.7.2). Re-reading the
+		// authoritative task by chunk_id is not sufficient on its own, which is
+		// why this used to be left empty and no longer is (#710): a chunk_id is
+		// stable across an in-place re-ingest of the same (rep_id, ordinal) while
+		// the text, hash and index_kind are rewritten under it, so a worker that
+		// only re-read the task could not tell "the chunk this job named" from "a
+		// different chunk that inherited the id". The hash makes a superseded
+		// delivery recognisable instead of silently executable.
+		TextHash: t.TextHash,
 		Modality: t.Modality,
 		RelPath:  t.MediaRef,
 		Span: Span{

--- a/internal/embedqueue/membroker.go
+++ b/internal/embedqueue/membroker.go
@@ -34,6 +34,10 @@ type memJob struct {
 	notBefore time.Time // job is not claimable before this (Nack retryAfter)
 }
 
+// Both built-in brokers carry the optional corpus-scoped claim path, so the
+// default single-binary topology gets corpus isolation without an adapter.
+var _ CorpusScopedBroker = (*MemBroker)(nil)
+
 // NewMemBroker returns an in-process broker. maxAttempts bounds redelivery: a job
 // Nacked after being delivered maxAttempts times is dead-lettered (SPEC §8.7.3).
 // A non-positive maxAttempts defaults to 5.
@@ -64,16 +68,22 @@ func (b *MemBroker) Enqueue(_ context.Context, job Job) error {
 	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	// Dedup: skip when a LIVE (pending or in-flight) job for this chunk_id+
-	// index_kind already exists, so re-enqueuing the same still-pending head
-	// across coordinator ticks does not pile up duplicate jobs (SPEC §8.7.3).
+	// Dedup: skip when a LIVE (pending or in-flight) job for this corpus_id+
+	// chunk_id+index_kind already exists, so re-enqueuing the same still-pending
+	// head across coordinator ticks does not pile up duplicate jobs (SPEC §8.7.3).
+	//
+	// corpus_id is part of the key, not decoration: chunk ids are per-corpus
+	// SQLite rowids, so two corpora sharing one broker BOTH have a chunk 1. Keyed
+	// on (chunk_id, index_kind) alone, the second corpus's job was silently
+	// swallowed by the first corpus's live job and that chunk was never embedded
+	// (#708).
 	for _, mj := range b.pending {
-		if mj.job.ChunkID == job.ChunkID && mj.job.IndexKind == job.IndexKind {
+		if sameJobKey(mj.job, job) {
 			return nil
 		}
 	}
 	for _, mj := range b.inflight {
-		if mj.job.ChunkID == job.ChunkID && mj.job.IndexKind == job.IndexKind {
+		if sameJobKey(mj.job, job) {
 			return nil
 		}
 	}
@@ -81,9 +91,22 @@ func (b *MemBroker) Enqueue(_ context.Context, job Job) error {
 	return nil
 }
 
+// sameJobKey reports whether two jobs name the same unit of work: the same
+// vector axis of the same chunk of the SAME corpus (SPEC §8.7.2).
+func sameJobKey(a, b Job) bool {
+	return a.CorpusID == b.CorpusID && a.ChunkID == b.ChunkID && a.IndexKind == b.IndexKind
+}
+
 // Lease reclaims any expired in-flight jobs, then claims the first pending job
-// whose notBefore has passed.
-func (b *MemBroker) Lease(_ context.Context, visibility time.Duration) (Lease, error) {
+// whose notBefore has passed, from any corpus.
+func (b *MemBroker) Lease(ctx context.Context, visibility time.Duration) (Lease, error) {
+	return b.LeaseForCorpus(ctx, "", visibility)
+}
+
+// LeaseForCorpus claims the first claimable pending job belonging to corpusID
+// (SPEC §8.7.2 corpus reference). An empty corpusID claims from any corpus,
+// which is what Lease does.
+func (b *MemBroker) LeaseForCorpus(_ context.Context, corpusID string, visibility time.Duration) (Lease, error) {
 	if visibility <= 0 {
 		visibility = 30 * time.Second
 	}
@@ -95,10 +118,14 @@ func (b *MemBroker) Lease(_ context.Context, visibility time.Duration) (Lease, e
 
 	idx := -1
 	for i, mj := range b.pending {
-		if !mj.notBefore.After(now) {
-			idx = i
-			break
+		if mj.notBefore.After(now) {
+			continue
 		}
+		if corpusID != "" && mj.job.CorpusID != corpusID {
+			continue
+		}
+		idx = i
+		break
 	}
 	if idx < 0 {
 		return Lease{}, ErrNoJob
@@ -110,7 +137,13 @@ func (b *MemBroker) Lease(_ context.Context, visibility time.Duration) (Lease, e
 	mj.token = fmt.Sprintf("mem-%d", b.tokenSeq.Add(1))
 	mj.deadline = now.Add(visibility)
 	b.inflight[mj.token] = mj
-	return Lease{Job: mj.job, Token: mj.token, Deadline: mj.deadline}, nil
+	return Lease{
+		Job:         mj.job,
+		Token:       mj.token,
+		Deadline:    mj.deadline,
+		Attempts:    mj.attempts,
+		MaxAttempts: b.maxAttempts,
+	}, nil
 }
 
 // reclaimExpiredLocked moves in-flight jobs whose lease deadline has passed back

--- a/internal/embedqueue/sqlitebroker.go
+++ b/internal/embedqueue/sqlitebroker.go
@@ -30,26 +30,35 @@ type SQLiteBroker struct {
 	now         func() time.Time
 }
 
+var _ CorpusScopedBroker = (*SQLiteBroker)(nil)
+
 // NewSQLiteBroker opens (or creates) a SQLite-backed queue at path. maxAttempts
 // bounds redelivery before dead-lettering (non-positive defaults to 5).
 func NewSQLiteBroker(ctx context.Context, path string, maxAttempts int) (*SQLiteBroker, error) {
-	db, err := sql.Open("sqlite", path)
+	// busy_timeout is a PER-CONNECTION setting, so it travels in the DSN and is
+	// in effect the moment database/sql opens any connection. Setting it with a
+	// single ExecContext (as this did) lands on whichever pooled connection
+	// served that one call: with several workers leasing concurrently, the pool
+	// opens further connections that never got it, and their reclaim-write-first
+	// Lease fails IMMEDIATELY with "database is locked" instead of waiting. That
+	// is the same defect #429 F11 fixed in internal/store, and the broker is
+	// where it bites hardest — a failed Ack under contention leaves the job
+	// in-flight until its lease expires. Surfaced by the multi-worker shared-queue
+	// test added for #708.
+	db, err := sql.Open("sqlite", "file:"+path+"?_pragma=busy_timeout(5000)")
 	if err != nil {
 		return nil, fmt.Errorf("embedqueue: open sqlite broker: %w", err)
 	}
-	// Order matters: busy_timeout MUST come before journal_mode (mirrors
-	// internal/store/sqlite_store.go). Under the multi-worker pool the
-	// reclaim-write-first Lease otherwise hits "database is locked" immediately
-	// instead of waiting; WAL further reduces read/write blocking across
-	// connections and processes.
-	for _, pragma := range []string{
-		`PRAGMA busy_timeout=5000;`,
-		`PRAGMA journal_mode=WAL;`,
-	} {
-		if _, err := db.ExecContext(ctx, pragma); err != nil {
-			_ = db.Close()
-			return nil, fmt.Errorf("embedqueue: configure sqlite broker: %w", err)
-		}
+	// Every broker operation (Enqueue/Lease/Ack/Nack) writes, so concurrent
+	// connections to one SQLite file can only contend. Serializing them through a
+	// single connection is what internal/store does for the same reason.
+	db.SetMaxOpenConns(1)
+	// journal_mode is persistent and database-level, so one connection setting it
+	// is enough; it must come AFTER busy_timeout, because the switch itself can
+	// return SQLITE_BUSY when another process holds the lock.
+	if _, err := db.ExecContext(ctx, `PRAGMA journal_mode=WAL;`); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("embedqueue: configure sqlite broker: %w", err)
 	}
 	b, err := newSQLiteBroker(ctx, db, true, maxAttempts)
 	if err != nil {
@@ -110,6 +119,10 @@ CREATE TABLE IF NOT EXISTS embed_jobs (
 );
 CREATE INDEX IF NOT EXISTS idx_embed_jobs_state ON embed_jobs(state, not_before_ns);
 CREATE INDEX IF NOT EXISTS idx_embed_jobs_token ON embed_jobs(token);
+-- Serves both corpus-scoped claiming (LeaseForCorpus) and the corpus-scoped
+-- dedup probe Enqueue runs on every coordinator tick (#708).
+CREATE INDEX IF NOT EXISTS idx_embed_jobs_corpus ON embed_jobs(corpus_id, state, not_before_ns);
+CREATE INDEX IF NOT EXISTS idx_embed_jobs_dedup ON embed_jobs(corpus_id, chunk_id, index_kind, state);
 `
 	if _, err := b.db.ExecContext(ctx, ddl); err != nil {
 		return fmt.Errorf("embedqueue: migrate broker schema: %w", err)
@@ -137,20 +150,26 @@ func (b *SQLiteBroker) Enqueue(ctx context.Context, job Job) error {
 		return err
 	}
 	// Dedup: do not insert when a LIVE (pending or in-flight) job already exists
-	// for this chunk_id+index_kind, so re-enqueuing the same still-pending head
-	// across coordinator ticks cannot pile up duplicate jobs (SPEC §8.7.3). A
-	// dead-lettered job does NOT block a fresh enqueue (a later retry is allowed).
+	// for this corpus_id+chunk_id+index_kind, so re-enqueuing the same
+	// still-pending head across coordinator ticks cannot pile up duplicate jobs
+	// (SPEC §8.7.3). A dead-lettered job does NOT block a fresh enqueue (a later
+	// retry is allowed).
+	//
+	// corpus_id belongs in the key because chunk ids are per-corpus SQLite
+	// rowids: two corpora pointed at one broker file both have a chunk 1, and
+	// without the corpus term the second corpus's enqueue was silently swallowed
+	// by the first corpus's live job (#708).
 	_, err := b.db.ExecContext(ctx, `
 INSERT INTO embed_jobs(corpus_id, source, chunk_id, index_kind, text_hash, modality,
   rel_path, span_kind, span_page, span_start_ms, span_end_ms, embed_identity, state)
 SELECT ?,?,?,?,?,?,?,?,?,?,?,?, 'pending'
 WHERE NOT EXISTS (
   SELECT 1 FROM embed_jobs
-   WHERE chunk_id = ? AND index_kind = ? AND state IN ('pending','inflight')
+   WHERE corpus_id = ? AND chunk_id = ? AND index_kind = ? AND state IN ('pending','inflight')
 )`,
 		job.CorpusID, job.Source, int64(job.ChunkID), job.IndexKind, job.TextHash, job.Modality,
 		job.RelPath, job.Span.Kind, job.Span.Page, job.Span.StartMS, job.Span.EndMS, job.EmbedIdentity,
-		int64(job.ChunkID), job.IndexKind)
+		job.CorpusID, int64(job.ChunkID), job.IndexKind)
 	if err != nil {
 		return fmt.Errorf("embedqueue: enqueue: %w", err)
 	}
@@ -186,8 +205,16 @@ func (b *SQLiteBroker) reclaimExpired(ctx context.Context, q execer, nowNS int64
 }
 
 // Lease reclaims expired leases, then atomically claims the oldest claimable
-// pending job.
+// pending job, from any corpus.
 func (b *SQLiteBroker) Lease(ctx context.Context, visibility time.Duration) (Lease, error) {
+	return b.LeaseForCorpus(ctx, "", visibility)
+}
+
+// LeaseForCorpus claims the oldest claimable pending job belonging to corpusID,
+// leaving every other corpus's jobs for the workers that serve them (SPEC
+// §8.7.2, §8.7.4). An empty corpusID claims from any corpus, which is what Lease
+// does.
+func (b *SQLiteBroker) LeaseForCorpus(ctx context.Context, corpusID string, visibility time.Duration) (Lease, error) {
 	if visibility <= 0 {
 		visibility = 30 * time.Second
 	}
@@ -199,31 +226,18 @@ func (b *SQLiteBroker) Lease(ctx context.Context, visibility time.Duration) (Lea
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	// Reclaim expired in-flight leases (SPEC §8.7.3 lease expiry).
+	// Reclaim expired in-flight leases (SPEC §8.7.3 lease expiry). Reclaim stays
+	// queue-wide rather than corpus-scoped: it is maintenance on rows this
+	// transaction is about to read past, and a corpus whose only worker died must
+	// not depend on another corpus's worker never running to get its jobs back.
 	if err := b.reclaimExpired(ctx, tx, nowNS); err != nil {
 		return Lease{}, err
 	}
 
-	var (
-		id  int64
-		job Job
-	)
-	row := tx.QueryRowContext(ctx, `
-SELECT id, corpus_id, source, chunk_id, index_kind, text_hash, modality, rel_path,
-       span_kind, span_page, span_start_ms, span_end_ms, embed_identity
-  FROM embed_jobs
- WHERE state='pending' AND not_before_ns <= ?
- ORDER BY id LIMIT 1`, nowNS)
-	var chunkID int64
-	if err := row.Scan(&id, &job.CorpusID, &job.Source, &chunkID, &job.IndexKind, &job.TextHash,
-		&job.Modality, &job.RelPath, &job.Span.Kind, &job.Span.Page, &job.Span.StartMS,
-		&job.Span.EndMS, &job.EmbedIdentity); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return Lease{}, ErrNoJob
-		}
-		return Lease{}, fmt.Errorf("embedqueue: lease select: %w", err)
+	id, job, priorAttempts, err := b.claimableJob(ctx, tx, corpusID, nowNS)
+	if err != nil {
+		return Lease{}, err
 	}
-	job.ChunkID = uint64(chunkID)
 
 	token, err := newLeaseToken(id)
 	if err != nil {
@@ -238,7 +252,52 @@ SELECT id, corpus_id, source, chunk_id, index_kind, text_hash, modality, rel_pat
 	if err := tx.Commit(); err != nil {
 		return Lease{}, fmt.Errorf("embedqueue: lease commit: %w", err)
 	}
-	return Lease{Job: job, Token: token, Deadline: deadline}, nil
+	return Lease{
+		Job:      job,
+		Token:    token,
+		Deadline: deadline,
+		// The row read and the increment share one transaction, so the delivery
+		// count this lease represents is exactly one more than what was on disk.
+		Attempts:    priorAttempts + 1,
+		MaxAttempts: b.maxAttempts,
+	}, nil
+}
+
+// claimableJob selects the oldest claimable pending row, optionally restricted
+// to one corpus. Split out of LeaseForCorpus so the claim path stays within the
+// cyclomatic budget and the two SELECT variants sit next to each other.
+func (b *SQLiteBroker) claimableJob(ctx context.Context, tx *sql.Tx, corpusID string, nowNS int64) (int64, Job, int, error) {
+	const columns = `id, attempts, corpus_id, source, chunk_id, index_kind, text_hash, modality, rel_path,
+       span_kind, span_page, span_start_ms, span_end_ms, embed_identity`
+	query := `SELECT ` + columns + `
+  FROM embed_jobs
+ WHERE state='pending' AND not_before_ns <= ?
+ ORDER BY id LIMIT 1`
+	args := []any{nowNS}
+	if corpusID != "" {
+		query = `SELECT ` + columns + `
+  FROM embed_jobs
+ WHERE corpus_id = ? AND state='pending' AND not_before_ns <= ?
+ ORDER BY id LIMIT 1`
+		args = []any{corpusID, nowNS}
+	}
+
+	var (
+		id       int64
+		attempts int
+		job      Job
+		chunkID  int64
+	)
+	if err := tx.QueryRowContext(ctx, query, args...).Scan(&id, &attempts, &job.CorpusID, &job.Source, &chunkID,
+		&job.IndexKind, &job.TextHash, &job.Modality, &job.RelPath, &job.Span.Kind, &job.Span.Page,
+		&job.Span.StartMS, &job.Span.EndMS, &job.EmbedIdentity); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, Job{}, 0, ErrNoJob
+		}
+		return 0, Job{}, 0, fmt.Errorf("embedqueue: lease select: %w", err)
+	}
+	job.ChunkID = uint64(chunkID)
+	return id, job, attempts, nil
 }
 
 // Ack deletes the leased job. An unknown/expired token deletes nothing.

--- a/internal/embedqueue/worker.go
+++ b/internal/embedqueue/worker.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
 )
 
 // TaskFetcher loads the authoritative chunk task for a leased job from the shared
@@ -28,6 +29,20 @@ type Embedder interface {
 	EmbedAndIndex(ctx context.Context, indexKind string, tasks []model.ChunkTask) (int, error)
 }
 
+// StatusWriter records a TERMINAL per-chunk embedding failure (SPEC §5.3
+// embedding_status=error, §7.7 per-document/per-chunk errors). The metadata
+// store satisfies it via MarkFailedWithCategory, the same entry point the
+// in-process embedding loop uses, so a distributed failure lands in `dir2mcp
+// status` / `doctor` in the exact shape an in-process one does.
+//
+// It exists because dead-lettering a job is not, by itself, a terminal outcome
+// for the CHUNK: the broker forgets the job, the chunk stays `pending`, and the
+// coordinator's next tick mints a fresh job with a fresh retry budget. Recording
+// the failure against the chunk is what stops that loop (#709).
+type StatusWriter interface {
+	MarkFailedWithCategory(ctx context.Context, labels []uint64, category, reason string) error
+}
+
 // Config configures a distributed embed-worker run-loop (SPEC §8.7.1, the
 // embed-worker / compute-plane role). All fields except the optional Logger and
 // the tuning knobs are required.
@@ -40,6 +55,24 @@ type Config struct {
 	// for that axis. A job whose index_kind has no embedder is dead-lettered
 	// (misconfiguration, never a vector in the wrong space).
 	Embedders map[string]Embedder
+
+	// Status records terminal per-chunk failures so a job that can never succeed
+	// stops being re-created (#709). Optional: with no StatusWriter the worker
+	// still rejects what it must, but a permanently-failing chunk stays `pending`
+	// and the coordinator keeps re-enqueuing it, so production wiring MUST set it.
+	Status StatusWriter
+
+	// CorpusID is the stable corpus identity (SPEC §5.5) THIS worker serves — the
+	// same value the coordinator for that corpus stamps on its jobs. A job naming
+	// any other corpus is rejected without being executed and without touching
+	// this worker's store.
+	//
+	// Empty means "unbound": the worker accepts every job it is handed, which is
+	// only safe on a broker it does not share with another corpus. Production
+	// wiring always sets it, resolved from the shared metadata store the job's
+	// chunk would be read from, so a worker's corpus binding and its data plane
+	// can never disagree (#708).
+	CorpusID string
 
 	// EmbedIdentity is THIS worker's configured embed identity (SPEC §8.1.4). A
 	// job whose EmbedIdentity differs is rejected (Nacked for redelivery /
@@ -157,7 +190,7 @@ func Run(ctx context.Context, cfg Config) error {
 			return ctx.Err()
 		default:
 		}
-		lease, err := cfg.Broker.Lease(ctx, cfg.leaseDuration())
+		lease, err := cfg.lease(ctx)
 		if errors.Is(err, ErrNoJob) {
 			if waitErr := sleepCtx(ctx, cfg.pollInterval()); waitErr != nil {
 				return waitErr
@@ -189,7 +222,7 @@ func (cfg Config) drainBatch(ctx context.Context, first Lease) []Lease {
 		if ctx.Err() != nil {
 			break
 		}
-		lease, err := cfg.Broker.Lease(ctx, cfg.leaseDuration())
+		lease, err := cfg.lease(ctx)
 		if err != nil {
 			// ErrNoJob (queue drained) or a transient lease error: embed what we
 			// already hold; the next Run cycle re-leases / backs off.
@@ -198,6 +231,21 @@ func (cfg Config) drainBatch(ctx context.Context, first Lease) []Lease {
 		leases = append(leases, lease)
 	}
 	return leases
+}
+
+// lease claims one job, restricted to this worker's corpus when both the worker
+// is bound to one and the broker can filter (SPEC §8.7.2). Claiming another
+// corpus's job only to reject it is not merely wasteful: every rejected delivery
+// consumes a redelivery attempt that belonged to the corpus that owns the job,
+// so a mixed queue drained by the wrong worker dead-letters healthy work (#708).
+// Brokers without the capability fall back to an unfiltered claim, where the
+// per-job corpus check in prepare is the guard.
+func (cfg Config) lease(ctx context.Context) (Lease, error) {
+	corpusID := strings.TrimSpace(cfg.CorpusID)
+	if scoped, ok := cfg.Broker.(CorpusScopedBroker); ok && corpusID != "" {
+		return scoped.LeaseForCorpus(ctx, corpusID, cfg.leaseDuration())
+	}
+	return cfg.Broker.Lease(ctx, cfg.leaseDuration())
 }
 
 // processBatch prepares every leased job (validate / identity / kind / fetch),
@@ -228,45 +276,97 @@ func (cfg Config) processBatch(ctx context.Context, leases []Lease) {
 
 // prepare runs the per-job checks that gate embedding a single leased job. It
 // returns ok=false (having already Acked/Nacked the lease) when the job must not
-// be embedded: an invalid job, an embed-identity mismatch, or an unknown
-// index_kind Nack for redelivery/dead-lettering; a tombstoned/missing chunk is
-// Acked as a safe no-op (SPEC §8.7.3 / §6.6). On ok=true the returned preparedJob
-// carries the authoritative task and its axis embedder.
+// be embedded. On ok=true the returned preparedJob carries the AUTHORITATIVE
+// task and the embedder for the axis that task currently belongs to.
+//
+// The three gates run in this order, and the order is load-bearing:
+//
+//  1. corpus binding — is this job even ours? A foreign job is rejected before
+//     anything reads or writes this worker's store (#708);
+//  2. job-level identity — is the job well-formed, in our vector space, and is
+//     its axis one we serve (SPEC §8.7.3);
+//  3. payload currency — does the job still describe the chunk as it exists
+//     now, and route to the axis that chunk is on NOW (#710).
 func (cfg Config) prepare(ctx context.Context, lease Lease) (preparedJob, bool) {
+	if !cfg.servesCorpus(ctx, lease) {
+		return preparedJob{}, false
+	}
+	if !cfg.acceptsJob(ctx, lease) {
+		return preparedJob{}, false
+	}
+	return cfg.routeToCurrentAxis(ctx, lease)
+}
+
+// servesCorpus reports whether the leased job belongs to the corpus this worker
+// serves (SPEC §8.7.2 corpus reference, §8.7.4 corpus isolation). A foreign job
+// is Nacked back for the corpus's own worker.
+//
+// Two properties matter here. It runs FIRST, before the store is touched: a
+// worker resolves chunk ids against ITS OWN metadata store, so executing corpus
+// A's job would read corpus B's chunk of the same id, embed it, write it into
+// B's Tier-C namespace and Ack A's job — A silently loses the work and B gets a
+// vector nothing asked for. And it never records a chunk failure: the chunk this
+// job names is not in this worker's store, so there is nothing here to fail.
+func (cfg Config) servesCorpus(ctx context.Context, lease Lease) bool {
+	want := strings.TrimSpace(cfg.CorpusID)
+	if want == "" {
+		// Unbound worker (single-corpus deployments and the in-process default).
+		return true
+	}
+	if got := strings.TrimSpace(lease.Job.CorpusID); got != want {
+		// The job's corpus id is logged; it is a digest by construction
+		// (identity.CorpusID), so this cannot disclose another corpus's path or
+		// bucket. Never log lease.Token — it is a lease credential (§16.1.1).
+		cfg.logf("embedqueue: job for chunk %d belongs to corpus %q, this worker serves %q; returning it unexecuted",
+			lease.Job.ChunkID, got, want)
+		_ = cfg.Broker.Nack(ctx, lease.Token, cfg.retryAfter())
+		return false
+	}
+	return true
+}
+
+// acceptsJob runs the checks that depend only on the job payload: it is
+// well-formed, it was enqueued in this worker's vector space, and its axis is
+// one this worker can write. Each failure is permanent for THIS worker, so the
+// job goes back for another worker to try — and, on the delivery that exhausts
+// the broker's budget, is recorded against the chunk so it stops being re-made.
+func (cfg Config) acceptsJob(ctx context.Context, lease Lease) bool {
 	job := lease.Job
 	if err := job.Validate(); err != nil {
-		// Never log lease.Token — it is an opaque lease credential (§16.1.1).
 		cfg.logf("embedqueue: invalid job for chunk %d: %v", job.ChunkID, err)
-		_ = cfg.Broker.Nack(ctx, lease.Token, cfg.retryAfter())
-		return preparedJob{}, false
+		cfg.rejectJob(ctx, lease, string(store.ErrorCategoryEmbeddingFailure), "invalid embedding job: "+err.Error())
+		return false
 	}
 
 	// Per-job embed identity enforcement (SPEC §8.7.3 / §6.4): a worker whose
-	// embed identity does not match the job MUST NOT write a vector. This is a
-	// permanent mismatch for THIS worker, so Nack for redelivery to a matching
-	// worker (or eventual dead-lettering) — never embed.
+	// embed identity does not match the job MUST NOT write a vector.
 	if strings.TrimSpace(job.EmbedIdentity) != strings.TrimSpace(cfg.EmbedIdentity) {
 		cfg.logf("embedqueue: embed identity mismatch for chunk %d (job=%q worker=%q); rejecting",
 			job.ChunkID, job.EmbedIdentity, cfg.EmbedIdentity)
-		_ = cfg.Broker.Nack(ctx, lease.Token, cfg.retryAfter())
-		return preparedJob{}, false
+		cfg.rejectJob(ctx, lease, string(store.ErrorCategoryEmbeddingFailure),
+			"embed identity mismatch: job was enqueued for a different embedding space than any worker in the pool provides")
+		return false
 	}
+	return true
+}
 
-	indexKind := strings.ToLower(strings.TrimSpace(job.IndexKind))
-	if indexKind == "" {
-		indexKind = "text"
-	}
-	emb, ok := cfg.Embedders[indexKind]
-	if !ok {
-		cfg.logf("embedqueue: no embedder for index_kind %q (chunk %d); rejecting", indexKind, job.ChunkID)
-		_ = cfg.Broker.Nack(ctx, lease.Token, cfg.retryAfter())
-		return preparedJob{}, false
-	}
-
-	// Load the authoritative task from the shared store. A tombstoned/missing
-	// chunk is a safe skip (tombstone safety, §8.7.3 / §6.6): Ack so the job is
-	// not redelivered for a chunk that no longer exists.
-	task, _, err := cfg.Fetcher.ChunkTaskByID(ctx, job.ChunkID)
+// routeToCurrentAxis loads the authoritative chunk and routes the job by what
+// that chunk is NOW, not by what the job said it was at enqueue time.
+//
+// A chunk_id survives an in-place re-ingest of the same (rep_id, ordinal) while
+// the text, the hash, the index_kind and the embedding status are all rewritten
+// under it. A job enqueued before such a rewrite therefore names a payload that
+// no longer exists. Executing it through the job's stale axis would write a
+// code-axis vector for what is now a text chunk AND mark the chunk embedded, so
+// the correct text-axis job is never created and a wrong-axis vector stays
+// searchable. Such a job is ACKED as superseded, not failed: nothing is broken,
+// the chunk is simply still pending and the coordinator will enqueue its current
+// form (#710).
+func (cfg Config) routeToCurrentAxis(ctx context.Context, lease Lease) (preparedJob, bool) {
+	job := lease.Job
+	// A tombstoned/missing chunk is a safe skip (tombstone safety, §8.7.3 / §6.6):
+	// Ack so the job is not redelivered for a chunk that no longer exists.
+	task, hash, err := cfg.Fetcher.ChunkTaskByID(ctx, job.ChunkID)
 	if err != nil {
 		if errors.Is(err, model.ErrNotFound) {
 			cfg.logf("embedqueue: chunk %d not found / tombstoned; acking (no-op)", job.ChunkID)
@@ -274,10 +374,104 @@ func (cfg Config) prepare(ctx context.Context, lease Lease) (preparedJob, bool) 
 			return preparedJob{}, false
 		}
 		cfg.logf("embedqueue: fetch chunk %d: %v; redelivering", job.ChunkID, err)
-		_ = cfg.Broker.Nack(ctx, lease.Token, cfg.retryAfter())
+		cfg.rejectJob(ctx, lease, string(store.ClassifyError(err)),
+			"could not read chunk from the shared metadata store: "+err.Error())
+		return preparedJob{}, false
+	}
+
+	if reason, superseded := supersededReason(job, task, hash); superseded {
+		cfg.logf("embedqueue: job for chunk %d is superseded (%s); acking without embedding", job.ChunkID, reason)
+		_ = cfg.Broker.Ack(ctx, lease.Token)
+		return preparedJob{}, false
+	}
+
+	// The axis comes from the TASK, never from the job: the two agree by the time
+	// we get here (supersededReason just proved it), and taking it from the task
+	// is what makes that guarantee structural rather than a convention a later
+	// edit could quietly drop.
+	indexKind := normalizeIndexKind(task.IndexKind)
+	emb, ok := cfg.Embedders[indexKind]
+	if !ok {
+		cfg.logf("embedqueue: no embedder for index_kind %q (chunk %d); rejecting", indexKind, job.ChunkID)
+		cfg.rejectJob(ctx, lease, string(store.ErrorCategoryEmbeddingFailure),
+			"no embedder configured for index_kind "+indexKind)
 		return preparedJob{}, false
 	}
 	return preparedJob{lease: lease, task: task, indexKind: indexKind, embedder: emb}, true
+}
+
+// supersededReason reports whether a leased job still describes the chunk the
+// store holds, returning a short human-readable reason when it does not.
+//
+// An EMPTY hash on either side means "unknown", never "mismatch": jobs enqueued
+// by a build that predates payload identity are still sitting in durable SQLite
+// queues, and a chunk may legitimately carry no hash. Treating unknown as a
+// mismatch would ack every one of them unexecuted and stall the queue, so the
+// comparison is deliberately one-sided — it can only prove staleness, never
+// freshness.
+func supersededReason(job Job, task model.ChunkTask, storeHash string) (string, bool) {
+	jobKind, taskKind := normalizeIndexKind(job.IndexKind), normalizeIndexKind(task.IndexKind)
+	if jobKind != taskKind {
+		return "chunk is now index_kind " + taskKind + ", job names " + jobKind, true
+	}
+	jobHash := strings.TrimSpace(job.TextHash)
+	if jobHash != "" && strings.TrimSpace(storeHash) != "" && jobHash != strings.TrimSpace(storeHash) {
+		return "chunk text_hash changed since the job was enqueued", true
+	}
+	return "", false
+}
+
+// normalizeIndexKind folds an index kind to its canonical form; an unset kind is
+// "text" (SPEC §6.1), which is how both the coordinator and the store treat it.
+func normalizeIndexKind(kind string) string {
+	if k := strings.ToLower(strings.TrimSpace(kind)); k != "" {
+		return k
+	}
+	return "text"
+}
+
+// rejectJob returns a job this worker could not execute to the broker and, when
+// this delivery is the last the broker will make, records the failure against
+// the chunk (SPEC §8.7.3: dead-lettering is "surfaced as a per-chunk error").
+//
+// Recording it is what makes dead-lettering TERMINAL. Dead-lettering alone only
+// ends the JOB: the chunk stays `embedding_status=pending`, the coordinator's
+// next tick selects it again, and a brand-new job starts a brand-new retry
+// budget — a configuration mismatch then burns provider quota and broker rows
+// forever without ever converging (#709). A chunk in `error` leaves the pending
+// set, so no new job is minted, and the failure appears in `dir2mcp status` /
+// `doctor` with a category and a sample instead of only as a queue counter an
+// operator has no command to read.
+//
+// A failure that DESERVES a retry still gets every one it was budgeted: this
+// fires only on the final delivery, so a transient fault that clears within the
+// retry budget is redelivered and succeeds normally, and an operator who fixes
+// the underlying cause re-pends the chunk (`dir2mcp reindex`) to hand it back to
+// the queue.
+func (cfg Config) rejectJob(ctx context.Context, lease Lease, category, reason string) {
+	if lease.Final() {
+		cfg.failChunk(ctx, lease, category, reason)
+	}
+	_ = cfg.Broker.Nack(ctx, lease.Token, cfg.retryAfter())
+}
+
+// failChunk records the terminal per-chunk failure, or says loudly why it could
+// not. A worker with no StatusWriter cannot break the re-enqueue loop, and a
+// silent inability to do so is exactly the failure mode #709 describes, so it is
+// logged rather than ignored.
+func (cfg Config) failChunk(ctx context.Context, lease Lease, category, reason string) {
+	chunkID := lease.Job.ChunkID
+	if cfg.Status == nil {
+		cfg.logf("embedqueue: chunk %d exhausted its %d delivery attempts (%s) but no status writer is configured; "+
+			"it stays pending and will be re-enqueued", chunkID, lease.Attempts, category)
+		return
+	}
+	if err := cfg.Status.MarkFailedWithCategory(ctx, []uint64{chunkID}, category, store.SanitizeReason(reason)); err != nil {
+		cfg.logf("embedqueue: record terminal failure for chunk %d: %v", chunkID, err)
+		return
+	}
+	cfg.logf("embedqueue: chunk %d dead-lettered after %d attempts (%s); recorded as a terminal embedding error",
+		chunkID, lease.Attempts, category)
 }
 
 // embedGroup embeds a same-index_kind group of prepared jobs in ONE provider call
@@ -311,10 +505,13 @@ func (cfg Config) embedGroup(ctx context.Context, indexKind string, group []prep
 		if len(group) == 1 {
 			// EmbedAndIndex already records embedding_status=error for permanent
 			// failures (SPEC §5.3); Nack lets the broker redeliver up to its limit
-			// and then dead-letter, mirroring the in-process behavior.
+			// and then dead-letter, mirroring the in-process behavior. A TRANSIENT
+			// failure deliberately leaves the chunk pending (#412) so it is retried,
+			// which is also why the final delivery has to record it: otherwise a
+			// fault that outlives the retry budget loops forever (#709).
 			cfg.logf("embedqueue: embed chunk %d (%s): %v; redelivering",
 				group[0].lease.Job.ChunkID, indexKind, err)
-			_ = cfg.Broker.Nack(ctx, group[0].lease.Token, cfg.retryAfter())
+			cfg.rejectJob(ctx, group[0].lease, string(store.ClassifyError(err)), "embedding failed: "+err.Error())
 			return
 		}
 		cfg.logf("embedqueue: batch embed of %d chunk(s) (%s) failed: %v; isolating per-chunk",
@@ -356,7 +553,7 @@ func (cfg Config) embedOne(ctx context.Context, indexKind string, pj preparedJob
 	if _, err := pj.embedder.EmbedAndIndex(ctx, indexKind, []model.ChunkTask{pj.task}); err != nil {
 		cfg.logf("embedqueue: embed chunk %d (%s): %v; redelivering",
 			pj.lease.Job.ChunkID, indexKind, err)
-		_ = cfg.Broker.Nack(ctx, pj.lease.Token, cfg.retryAfter())
+		cfg.rejectJob(ctx, pj.lease, string(store.ClassifyError(err)), "embedding failed: "+err.Error())
 		return
 	}
 	if err := cfg.Broker.Ack(ctx, pj.lease.Token); err != nil {

--- a/internal/identity/corpus.go
+++ b/internal/identity/corpus.go
@@ -1,0 +1,119 @@
+package identity
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// CorpusIDSettingKey is the `settings` row that holds the corpus's stable
+// identity (SPEC §5.5). Once written it is authoritative: the derived value is
+// only a seed, so moving or renaming the indexed directory does not silently
+// mint a second corpus out of one store.
+const CorpusIDSettingKey = "corpus_id"
+
+// corpusIDHexLen is how much of the key digest the corpus id carries. 32 hex
+// chars = 128 bits, which makes an accidental collision between two corpora
+// sharing one broker not a thing an operator has to think about.
+const corpusIDHexLen = 32
+
+// CorpusKey returns the canonical identity key for a corpus whose bytes live
+// under a local (or NFS-mounted) root. It is the same key AutoServerName hashes
+// into the instance name, so the corpus identity and the MCP server identity
+// can never disagree about which corpus is which.
+//
+// rootAbs is expected to already be absolute; identity is only as stable as the
+// caller's normalization.
+func CorpusKey(rootAbs string) string {
+	return filepath.Clean(rootAbs)
+}
+
+// CorpusKeyForS3 returns the canonical identity key for a corpus that lives in
+// an object store: `s3://[endpoint-host/]bucket[/prefix]`.
+//
+// It is the key AutoServerNameForS3 hashes (#737), reused rather than
+// re-derived, and it inherits that function's two deliberate properties: the
+// endpoint host participates ONLY when one is configured (two S3-compatible
+// stores can host the same bucket name, while AWS bucket names are global), and
+// no credential and no region ever participates. The key reaches diagnostics.
+func CorpusKeyForS3(bucket, prefix, endpoint string) string {
+	key := "s3://"
+	if host := endpointHost(endpoint); host != "" {
+		key += host + "/"
+	}
+	key += strings.ToLower(strings.TrimSpace(bucket))
+	if p := normalizeS3Prefix(prefix); p != "" {
+		key += "/" + p
+	}
+	return key
+}
+
+// CorpusID derives the stable corpus identity (SPEC §5.5) from a canonical
+// identity key: `corpus-<32 hex>` over sha256(key).
+//
+// It is deliberately OPAQUE, unlike the instance name the same keys produce.
+// A corpus id is written onto every distributed embedding job (SPEC §8.7.2) and
+// therefore lands in a broker that, by design, several corpora may share — on a
+// multi-tenant host that queue is the one place where corpus A can read rows
+// corpus B wrote. A human-readable slug there would publish B's local path or
+// bucket name to A; a digest identifies the corpus without describing it. An
+// operator who needs the mapping reads it back from that corpus's own store
+// (`settings.corpus_id`), which is exactly the boundary the id is meant to keep.
+//
+// It also deliberately omits the dev/release prefix AutoServerName carries: a
+// persisted corpus identity that changed when the same corpus was opened by a
+// dev build would split one corpus into two.
+func CorpusID(key string) string {
+	sum := sha256.Sum256([]byte(key))
+	return "corpus-" + hex.EncodeToString(sum[:])[:corpusIDHexLen]
+}
+
+// SettingsStore is the `settings` (SPEC §5.5) read/write capability
+// ResolveCorpusID needs. The metadata store satisfies it; it is declared here
+// as a two-method interface so this package keeps its zero dependency on the
+// store package. A missing key MUST be reported as os.ErrNotExist (what
+// store.SQLiteStore.GetSetting returns).
+type SettingsStore interface {
+	GetSetting(ctx context.Context, key string) (string, error)
+	SetSetting(ctx context.Context, key, value string) error
+}
+
+// ResolveCorpusID returns the corpus's stable identity (SPEC §5.5), reading the
+// persisted value and seeding it from key on first use.
+//
+// The PERSISTED value wins whenever there is one. That is the whole point of
+// the setting: a corpus that is moved to a new path, re-mounted at a different
+// mountpoint, or re-pointed at a renamed bucket keeps the identity its already-
+// enqueued jobs, its already-written vectors and its running workers were bound
+// to. Deriving on every call instead would rename the corpus underneath them.
+//
+// A read failure other than "not set" is returned rather than papered over: a
+// worker that guesses a corpus identity is exactly the cross-wiring the id
+// exists to prevent.
+func ResolveCorpusID(ctx context.Context, st SettingsStore, key string) (string, error) {
+	if st == nil {
+		return "", errors.New("identity: resolve corpus id: nil settings store")
+	}
+	existing, err := st.GetSetting(ctx, CorpusIDSettingKey)
+	switch {
+	case err == nil:
+		if trimmed := strings.TrimSpace(existing); trimmed != "" {
+			return trimmed, nil
+		}
+	case errors.Is(err, os.ErrNotExist):
+		// First use of this store: fall through and seed it below.
+	default:
+		return "", fmt.Errorf("identity: read %s: %w", CorpusIDSettingKey, err)
+	}
+
+	derived := CorpusID(key)
+	if err := st.SetSetting(ctx, CorpusIDSettingKey, derived); err != nil {
+		return "", fmt.Errorf("identity: persist %s: %w", CorpusIDSettingKey, err)
+	}
+	return derived, nil
+}

--- a/internal/identity/name.go
+++ b/internal/identity/name.go
@@ -60,8 +60,8 @@ func Resolve(rootAbs, override string, dev bool) string {
 // over whatever was passed and identity is therefore only as stable as
 // the caller's normalization.
 func AutoServerName(rootAbs string, dev bool) string {
-	clean := filepath.Clean(rootAbs)
-	return nameFromKey(clean, filepath.Base(clean), dev)
+	key := CorpusKey(rootAbs)
+	return nameFromKey(key, filepath.Base(key), dev)
 }
 
 // AutoServerNameForS3 derives the name for a corpus that lives in an object
@@ -91,14 +91,7 @@ func AutoServerName(rootAbs string, dev bool) string {
 func AutoServerNameForS3(bucket, prefix, endpoint string, dev bool) string {
 	bucket = strings.ToLower(strings.TrimSpace(bucket))
 	prefix = normalizeS3Prefix(prefix)
-	key := "s3://"
-	if host := endpointHost(endpoint); host != "" {
-		key += host + "/"
-	}
-	key += bucket
-	if prefix != "" {
-		key += "/" + prefix
-	}
+	key := CorpusKeyForS3(bucket, prefix, endpoint)
 	// The slug is the human-readable half. The bucket alone would make two
 	// prefixes of one bucket visually identical, so the last prefix segment is
 	// appended when there is one.

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -764,6 +764,15 @@ type ChunkTask struct {
 	// corpus rel_path whose bytes the worker embeds. Empty/"text" for text.
 	Modality string
 	MediaRef string
+	// TextHash is the chunk's persisted content hash (SPEC §5.3). It is the
+	// chunk's PAYLOAD identity: chunk_id survives an in-place re-ingest of the
+	// same (rep_id, ordinal) while the text, the hash and the index_kind are all
+	// rewritten, so the id alone does not say WHICH bytes a task names. The
+	// distributed coordinator stamps it onto every job (SPEC §8.7.2) so a worker
+	// can tell a job for the chunk's current form from one enqueued for a form
+	// that has since been replaced. Empty when the producer did not supply one;
+	// consumers MUST treat empty as "unknown", never as a mismatch.
+	TextHash string
 	// Context is the chunk's generated document-aware context (SPEC §8.1.8,
 	// issue #330). It participates in EmbedInput ONLY: Text remains the raw
 	// chunk that snippets, reranking, and citations use, so the generated

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -1939,6 +1939,10 @@ LEFT JOIN documents d ON d.rel_path = tc.rel_path`, int64(chunkID))
 	})
 	t.Modality = modality
 	t.MediaRef = mediaRef
+	// Payload identity (SPEC §5.3). It is also returned separately, which is the
+	// form the distributed worker compares against its leased job (#710); the
+	// field keeps a task loaded here interchangeable with one from NextPending.
+	t.TextHash = thash
 	// The generated context rides on the task's Context field only — Text stays
 	// the raw chunk, so a caller that renders a snippet/citation from this task
 	// (reranking, liveness) can never surface it (SPEC §8.1.8, #403). Only the
@@ -2686,7 +2690,7 @@ func nextPendingQuery(indexKind string, limit int) (string, []any) {
 		kindPredicate = " AND c.index_kind = ?"
 	}
 	query := `WITH filtered_chunks AS (
-	            SELECT c.chunk_id, c.rel_path, c.doc_type, c.rep_type, c.text, c.index_kind, c.modality, c.media_ref, c.language,
+	            SELECT c.chunk_id, c.rel_path, c.doc_type, c.rep_type, c.text, c.text_hash, c.index_kind, c.modality, c.media_ref, c.language,
 	                   c.chunk_context,
 	                   COALESCE(d.mtime_unix, 0) AS mtime_unix
 	            FROM chunks c
@@ -2696,7 +2700,7 @@ func nextPendingQuery(indexKind string, limit int) (string, []any) {
 	            ORDER BY c.chunk_id
 	            LIMIT ?
 	          )
-	          SELECT fc.chunk_id, fc.rel_path, fc.doc_type, fc.rep_type, fc.text, fc.index_kind, fc.modality, fc.media_ref, fc.language,
+	          SELECT fc.chunk_id, fc.rel_path, fc.doc_type, fc.rep_type, fc.text, fc.text_hash, fc.index_kind, fc.modality, fc.media_ref, fc.language,
 	                 fc.chunk_context,
 	                 COALESCE(sp.span_kind, ''), COALESCE(sp.start, 0), COALESCE(sp."end", 0), COALESCE(sp.extra_json, ''), fc.mtime_unix
 	          FROM filtered_chunks fc
@@ -2782,6 +2786,7 @@ func (s *SQLiteStore) NextPending(ctx context.Context, limit int, indexKind stri
 			docType   string
 			repType   string
 			text      string
+			textHash  string
 			idxKind   string
 			modality  string
 			mediaRef  string
@@ -2793,7 +2798,7 @@ func (s *SQLiteStore) NextPending(ctx context.Context, limit int, indexKind stri
 			spanExtra string
 			mtimeUnix int64
 		)
-		if err := rows.Scan(&chunkID, &relPath, &docType, &repType, &text, &idxKind, &modality, &mediaRef, &language, &chunkCtx, &spanK, &spanS, &spanE, &spanExtra, &mtimeUnix); err != nil {
+		if err := rows.Scan(&chunkID, &relPath, &docType, &repType, &text, &textHash, &idxKind, &modality, &mediaRef, &language, &chunkCtx, &spanK, &spanS, &spanE, &spanExtra, &mtimeUnix); err != nil {
 			return nil, err
 		}
 		if chunkID <= 0 {
@@ -2815,6 +2820,10 @@ func (s *SQLiteStore) NextPending(ctx context.Context, limit int, indexKind stri
 		})
 		task.Modality = modality
 		task.MediaRef = mediaRef
+		// Payload identity (SPEC §5.3/§8.7.2): the distributed coordinator stamps
+		// this onto the job it enqueues so a worker can recognise a job it leases
+		// for a chunk whose bytes have since been replaced in place (#710).
+		task.TextHash = textHash
 		// Contextual retrieval (SPEC §8.1.8): the generated context travels as a
 		// SEPARATE field so only the embed path (ChunkTask.EmbedInput) joins it to
 		// the chunk. Snippet above is built from the raw text, so nothing the

--- a/tests/embedqueue/corpus_fixture_test.go
+++ b/tests/embedqueue/corpus_fixture_test.go
@@ -1,0 +1,228 @@
+package embedqueue_test
+
+import (
+	"context"
+	"io"
+	"log"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/embedqueue"
+	"github.com/dirstral/dir2mcp/internal/identity"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// testCorpus is a REAL corpus: its own SQLite metadata store, its own chunk ids
+// (SQLite rowids, so two corpora independently start at 1), and the corpus id
+// production resolves from that store.
+//
+// The isolation bugs in #708/#709/#710 are all about a job carrying too little
+// about which corpus and which payload it names, and none of them reproduce
+// against a hand-built fake job: they need the real store's id allocation, its
+// in-place (rep_id, ordinal) upsert, and its pending-selection. So the fixture
+// builds the real thing.
+type testCorpus struct {
+	name  string
+	store *store.SQLiteStore
+	id    string
+	rep   int64
+}
+
+// newTestCorpus creates a corpus rooted at a distinct path, with one
+// representation ready to hold chunks.
+func newTestCorpus(t *testing.T, name string) *testCorpus {
+	t.Helper()
+	ctx := context.Background()
+
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.db"))
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("%s: init store: %v", name, err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	relPath := "notes.md"
+	if err := st.UpsertDocument(ctx, model.Document{
+		RelPath: relPath, DocType: "md", SourceType: "local", Status: "ok", Title: name,
+	}); err != nil {
+		t.Fatalf("%s: seed document: %v", name, err)
+	}
+	doc, err := st.GetDocumentByPath(ctx, relPath)
+	if err != nil {
+		t.Fatalf("%s: read document: %v", name, err)
+	}
+	repID, err := st.UpsertRepresentation(ctx, model.Representation{
+		DocID: doc.DocID, RepType: "raw_text", RepHash: "rep-" + name,
+	})
+	if err != nil {
+		t.Fatalf("%s: seed representation: %v", name, err)
+	}
+
+	// The corpus id comes from the same call production uses, against this
+	// corpus's own store, so the test exercises the real derive-and-persist path
+	// rather than inventing an id.
+	corpusID, err := identity.ResolveCorpusID(ctx, st, identity.CorpusKey("/corpora/"+name))
+	if err != nil {
+		t.Fatalf("%s: resolve corpus id: %v", name, err)
+	}
+
+	return &testCorpus{name: name, store: st, id: corpusID, rep: repID}
+}
+
+// addChunk writes a pending chunk at the given ordinal and returns its
+// store-allocated chunk id. Re-calling it with the same ordinal is the in-place
+// re-ingest #710 is about: the chunk id is preserved while text, hash, axis and
+// status are all replaced.
+func (c *testCorpus) addChunk(t *testing.T, ordinal int, text, hash, indexKind string) uint64 {
+	t.Helper()
+	id, err := c.store.InsertChunkWithSpans(context.Background(), model.Chunk{
+		RepID: c.rep, Ordinal: ordinal, Text: text, TextHash: hash,
+		IndexKind: indexKind, EmbeddingStatus: "pending",
+	}, nil)
+	if err != nil {
+		t.Fatalf("%s: insert chunk: %v", c.name, err)
+	}
+	return uint64(id)
+}
+
+// pendingIDs returns the chunk ids the embed pipeline still considers pending.
+func (c *testCorpus) pendingIDs(t *testing.T) []uint64 {
+	t.Helper()
+	tasks, err := c.store.NextPending(context.Background(), 100, "")
+	if err != nil {
+		t.Fatalf("%s: NextPending: %v", c.name, err)
+	}
+	ids := make([]uint64, 0, len(tasks))
+	for _, task := range tasks {
+		ids = append(ids, task.Metadata.ChunkID)
+	}
+	return ids
+}
+
+// isPending reports whether chunkID is still awaiting embedding.
+func (c *testCorpus) isPending(t *testing.T, chunkID uint64) bool {
+	t.Helper()
+	for _, id := range c.pendingIDs(t) {
+		if id == chunkID {
+			return true
+		}
+	}
+	return false
+}
+
+// failureCategories returns the per-category count of chunks recorded as
+// terminally failed — the same aggregate `dir2mcp status` and `doctor` render.
+func (c *testCorpus) failureCategories(t *testing.T) map[string]int64 {
+	t.Helper()
+	stats, err := c.store.CorpusStats(context.Background())
+	if err != nil {
+		t.Fatalf("%s: CorpusStats: %v", c.name, err)
+	}
+	if stats.FailureSummary == nil {
+		return map[string]int64{}
+	}
+	return stats.FailureSummary.Categories
+}
+
+// recordingEmbedder is an Embedder bound to ONE corpus's store. It records the
+// text of everything it embeds and marks those chunks embedded in that store, so
+// a cross-corpus mix-up shows up both as recorded text from the wrong corpus and
+// as a status write in the wrong store.
+type recordingEmbedder struct {
+	mu       sync.Mutex
+	corpus   *testCorpus
+	embedded []string
+	failNext func(tasks []model.ChunkTask) error
+}
+
+func (e *recordingEmbedder) EmbedAndIndex(ctx context.Context, _ string, tasks []model.ChunkTask) (int, error) {
+	e.mu.Lock()
+	fail := e.failNext
+	e.mu.Unlock()
+	if fail != nil {
+		if err := fail(tasks); err != nil {
+			return 0, err
+		}
+	}
+
+	labels := make([]uint64, 0, len(tasks))
+	texts := make([]string, 0, len(tasks))
+	for _, task := range tasks {
+		labels = append(labels, task.Metadata.ChunkID)
+		texts = append(texts, task.Text)
+	}
+	// Mark BEFORE recording: a test that waits on the recording would otherwise
+	// observe the embed and inspect chunk status before this write landed.
+	if err := e.corpus.store.MarkEmbedded(ctx, labels); err != nil {
+		return 0, err
+	}
+	e.mu.Lock()
+	e.embedded = append(e.embedded, texts...)
+	e.mu.Unlock()
+	return len(tasks), nil
+}
+
+func (e *recordingEmbedder) texts() []string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([]string, len(e.embedded))
+	copy(out, e.embedded)
+	return out
+}
+
+// discardLogger keeps the rejection/dead-letter logging these tests deliberately
+// provoke out of the test output.
+func discardLogger() *log.Logger {
+	return log.New(io.Discard, "", 0)
+}
+
+// runWorkerFor runs the worker loop for a fixed window and waits for it to exit.
+// A fixed window (rather than "until it does the right thing") is what lets a
+// test assert a NEGATIVE: the worker was given every chance to misbehave.
+func runWorkerFor(t *testing.T, cfg embedqueue.Config, d time.Duration) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), d)
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		_ = embedqueue.Run(ctx, cfg)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(d + 5*time.Second):
+		t.Fatal("worker did not exit after its context was cancelled")
+	}
+}
+
+// runWorkerUntilOrTimeout runs the worker loop until done() reports true (then
+// stops it) or the timeout expires. Unlike runWorkerFor it stops as soon as the
+// expected state is reached, so a positive assertion does not pay the full
+// window.
+func runWorkerUntilOrTimeout(t *testing.T, cfg embedqueue.Config, timeout time.Duration, done func() bool) bool {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	finished := make(chan struct{})
+	go func() {
+		_ = embedqueue.Run(ctx, cfg)
+		close(finished)
+	}()
+	deadline := time.After(timeout)
+	for {
+		if done() {
+			cancel()
+			<-finished
+			return true
+		}
+		select {
+		case <-deadline:
+			cancel()
+			<-finished
+			return false
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+}

--- a/tests/embedqueue/cross_corpus_708_test.go
+++ b/tests/embedqueue/cross_corpus_708_test.go
@@ -1,0 +1,239 @@
+package embedqueue_test
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/embedqueue"
+)
+
+// #708: two corpora pointed at ONE broker collided. Jobs carried `corpus_id`,
+// but nothing keyed on it: both brokers deduplicated enqueues by (chunk_id,
+// index_kind) only, and a worker executed whatever it leased against its OWN
+// store. Chunk ids are per-corpus SQLite rowids, so both corpora have a chunk 1
+// and the two failures compound — one corpus's enqueue is swallowed, and the
+// other corpus's worker embeds the wrong bytes and acks work it never did.
+//
+// These tests set up the real thing: two real stores, two real corpus ids, one
+// real shared SQLite broker file, and the real worker loop.
+
+// sharedBroker opens one SQLite broker file, the deployment shape #708 is about
+// (SPEC §8.7.4: a shared queue on an NFS-reachable path).
+func sharedBroker(t *testing.T, maxAttempts int) *embedqueue.SQLiteBroker {
+	t.Helper()
+	broker, err := embedqueue.NewSQLiteBroker(context.Background(),
+		filepath.Join(t.TempDir(), "embed-queue.db"), maxAttempts)
+	if err != nil {
+		t.Fatalf("open shared broker: %v", err)
+	}
+	t.Cleanup(func() { _ = broker.Close() })
+	return broker
+}
+
+// TestSharedBroker_TwoCorporaWithTheSameChunkIDBothGetTheirJob pins the enqueue
+// half of the collision. Corpus A and corpus B each independently allocate chunk
+// id 1. Deduplicating on (chunk_id, index_kind) alone made B's enqueue a no-op
+// because A already had a live job for "1/text", so B's chunk was never queued
+// at all and simply never got embedded.
+func TestSharedBroker_TwoCorporaWithTheSameChunkIDBothGetTheirJob(t *testing.T) {
+	ctx := context.Background()
+	broker := sharedBroker(t, 3)
+
+	corpusA := newTestCorpus(t, "alpha")
+	corpusB := newTestCorpus(t, "beta")
+	idA := corpusA.addChunk(t, 1, "alpha chunk", "hash-alpha", "text")
+	idB := corpusB.addChunk(t, 1, "beta chunk", "hash-beta", "text")
+	if idA != idB {
+		t.Fatalf("fixture precondition: the two corpora allocated different chunk ids (%d vs %d); "+
+			"the collision this test is about needs them to be the same", idA, idB)
+	}
+	if corpusA.id == corpusB.id {
+		t.Fatalf("two distinct corpora resolved to the same corpus id %q", corpusA.id)
+	}
+
+	for _, c := range []*testCorpus{corpusA, corpusB} {
+		coord := &embedqueue.Coordinator{
+			Source: c.store, Broker: broker, CorpusID: c.id,
+			SourceKind: "local", EmbedIdentity: testIdentity,
+		}
+		n, err := coord.EnqueuePending(ctx, "")
+		if err != nil {
+			t.Fatalf("%s: EnqueuePending: %v", c.name, err)
+		}
+		if n != 1 {
+			t.Fatalf("%s: enqueued %d jobs, want 1", c.name, n)
+		}
+	}
+
+	stats, err := broker.Stats(ctx)
+	if err != nil {
+		t.Fatalf("Stats: %v", err)
+	}
+	if stats.Pending != 2 {
+		t.Fatalf("shared queue holds %d pending job(s), want 2 (one per corpus); "+
+			"a corpus whose chunk id collides with another's has silently lost its job", stats.Pending)
+	}
+
+	// And each queued job must be claimable BY ITS OWN corpus: one job each,
+	// naming that corpus, with no second job left over for either.
+	for _, c := range []*testCorpus{corpusA, corpusB} {
+		lease, err := broker.LeaseForCorpus(ctx, c.id, time.Minute)
+		if err != nil {
+			t.Fatalf("%s: LeaseForCorpus: %v", c.name, err)
+		}
+		if lease.Job.CorpusID != c.id {
+			t.Fatalf("%s: leased a job for corpus %q", c.name, lease.Job.CorpusID)
+		}
+		if _, err := broker.LeaseForCorpus(ctx, c.id, time.Minute); !errors.Is(err, embedqueue.ErrNoJob) {
+			t.Fatalf("%s: a second job was claimable for this corpus, want ErrNoJob, got %v", c.name, err)
+		}
+	}
+}
+
+// TestSharedBroker_WorkerNeverExecutesAnotherCorpusJob pins the execution half,
+// end to end through the real worker loop.
+//
+// Only corpus B runs a worker. Before the fix, that worker leased corpus A's job
+// (nothing scoped the queue and nothing checked the binding), resolved chunk 1
+// against ITS OWN store, embedded corpus B's bytes, wrote them under A's job and
+// acked it. A lost the work while the queue reported it done; B got a vector for
+// a chunk nobody asked to embed on A's behalf.
+func TestSharedBroker_WorkerNeverExecutesAnotherCorpusJob(t *testing.T) {
+	ctx := context.Background()
+	broker := sharedBroker(t, 3)
+
+	corpusA := newTestCorpus(t, "alpha")
+	corpusB := newTestCorpus(t, "beta")
+	chunkA := corpusA.addChunk(t, 1, "alpha chunk", "hash-alpha", "text")
+	chunkB := corpusB.addChunk(t, 1, "beta chunk", "hash-beta", "text")
+
+	// Only corpus A enqueues. B's worker must not touch that job at all.
+	coordA := &embedqueue.Coordinator{
+		Source: corpusA.store, Broker: broker, CorpusID: corpusA.id,
+		SourceKind: "local", EmbedIdentity: testIdentity,
+	}
+	if _, err := coordA.EnqueuePending(ctx, ""); err != nil {
+		t.Fatalf("alpha: EnqueuePending: %v", err)
+	}
+
+	embedderB := &recordingEmbedder{corpus: corpusB}
+	workerB := embedqueue.Config{
+		Broker:        broker,
+		Fetcher:       corpusB.store,
+		Embedders:     map[string]embedqueue.Embedder{"text": embedderB},
+		Status:        corpusB.store,
+		CorpusID:      corpusB.id,
+		EmbedIdentity: testIdentity,
+		PollInterval:  5 * time.Millisecond,
+		RetryAfter:    time.Millisecond,
+		Logger:        discardLogger(),
+	}
+
+	// Give B's worker a generous window to misbehave, then stop it.
+	runWorkerFor(t, workerB, 400*time.Millisecond)
+
+	if got := embedderB.texts(); len(got) != 0 {
+		t.Fatalf("corpus beta's worker embedded %v; it must not execute another corpus's job", got)
+	}
+	if !corpusB.isPending(t, chunkB) {
+		t.Fatalf("corpus beta's chunk %d left the pending set without any job for it", chunkB)
+	}
+	if !corpusA.isPending(t, chunkA) {
+		t.Fatalf("corpus alpha's chunk %d was embedded by corpus beta's worker", chunkA)
+	}
+
+	// A's job must still be in the queue, intact and claimable, for A's own
+	// worker: B must not have acked it away nor burned its retry budget.
+	lease, err := broker.LeaseForCorpus(ctx, corpusA.id, time.Minute)
+	if err != nil {
+		t.Fatalf("corpus alpha's job is gone from the shared queue: %v", err)
+	}
+	if lease.Job.ChunkID != chunkA {
+		t.Fatalf("leased chunk %d, want alpha's chunk %d", lease.Job.ChunkID, chunkA)
+	}
+	if lease.Attempts != 1 {
+		t.Fatalf("alpha's job is on delivery attempt %d; corpus beta's worker consumed %d of alpha's retries",
+			lease.Attempts, lease.Attempts-1)
+	}
+	if cats := corpusB.failureCategories(t); len(cats) != 0 {
+		t.Fatalf("corpus beta recorded chunk failures %v while rejecting another corpus's job; "+
+			"a foreign job names no chunk of this store and must never mark one failed", cats)
+	}
+}
+
+// TestSharedBroker_EachCorpusWorkerEmbedsItsOwnBytes is the positive case: with
+// both corpora coordinating and working against the one broker, each ends up
+// with exactly its own chunk embedded, from its own store.
+func TestSharedBroker_EachCorpusWorkerEmbedsItsOwnBytes(t *testing.T) {
+	ctx := context.Background()
+	broker := sharedBroker(t, 3)
+
+	corpusA := newTestCorpus(t, "alpha")
+	corpusB := newTestCorpus(t, "beta")
+	corpusA.addChunk(t, 1, "alpha chunk", "hash-alpha", "text")
+	corpusB.addChunk(t, 1, "beta chunk", "hash-beta", "text")
+
+	embedders := map[string]*recordingEmbedder{}
+	for _, c := range []*testCorpus{corpusA, corpusB} {
+		coord := &embedqueue.Coordinator{
+			Source: c.store, Broker: broker, CorpusID: c.id,
+			SourceKind: "local", EmbedIdentity: testIdentity,
+		}
+		if _, err := coord.EnqueuePending(ctx, ""); err != nil {
+			t.Fatalf("%s: EnqueuePending: %v", c.name, err)
+		}
+		embedders[c.name] = &recordingEmbedder{corpus: c}
+	}
+
+	// Both workers stop on the same condition — the shared queue fully drained —
+	// rather than after a fixed window, so neither is cancelled between embedding
+	// a chunk and acking it (which would leave a live lease behind and say
+	// nothing about corpus routing).
+	drained := func() bool {
+		stats, err := broker.Stats(ctx)
+		if err != nil {
+			return false
+		}
+		return stats.Pending == 0 && stats.InFlight == 0
+	}
+
+	done := make(chan struct{}, 2)
+	for _, c := range []*testCorpus{corpusA, corpusB} {
+		cfg := embedqueue.Config{
+			Broker:        broker,
+			Fetcher:       c.store,
+			Embedders:     map[string]embedqueue.Embedder{"text": embedders[c.name]},
+			Status:        c.store,
+			CorpusID:      c.id,
+			EmbedIdentity: testIdentity,
+			PollInterval:  5 * time.Millisecond,
+			RetryAfter:    time.Millisecond,
+			Logger:        discardLogger(),
+		}
+		go func() {
+			if !runWorkerUntilOrTimeout(t, cfg, 5*time.Second, drained) {
+				t.Errorf("%s: the shared queue never drained", c.name)
+			}
+			done <- struct{}{}
+		}()
+	}
+	<-done
+	<-done
+
+	for _, c := range []*testCorpus{corpusA, corpusB} {
+		got := embedders[c.name].texts()
+		if len(got) != 1 || got[0] != c.name+" chunk" {
+			t.Fatalf("%s embedded %v, want exactly its own %q", c.name, got, c.name+" chunk")
+		}
+	}
+	stats, err := broker.Stats(ctx)
+	if err != nil {
+		t.Fatalf("Stats: %v", err)
+	}
+	if stats.Pending != 0 || stats.InFlight != 0 || stats.DeadLettered != 0 {
+		t.Fatalf("shared queue did not drain cleanly: %+v", stats)
+	}
+}

--- a/tests/embedqueue/dead_letter_709_test.go
+++ b/tests/embedqueue/dead_letter_709_test.go
@@ -1,0 +1,210 @@
+package embedqueue_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/embedqueue"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// #709: the retry limit was not terminal. A job that could never succeed —
+// embed identity mismatch, an axis no worker serves, a persistent store fault —
+// was Nacked to exhaustion and dead-lettered, but the CHUNK stayed
+// `embedding_status=pending`. The coordinator's next tick therefore selected it
+// again and minted a fresh job with a fresh retry budget, forever: unbounded
+// provider calls, an `embed_jobs` table that grows a dead row per cycle, and
+// nothing in `status`/`doctor` ever saying why the corpus will not finish.
+//
+// The existing TestWorker_EmbedIdentityMismatchRejected stops at the FIRST dead
+// letter and never runs a coordinator, so it cannot see the loop. These tests
+// run both together and measure how many times the cycle repeats.
+
+// runPairFor runs a coordinator and a worker against each other for one window,
+// exactly as `up` wires them, and returns the queue state afterwards.
+func runPairFor(t *testing.T, coord *embedqueue.Coordinator, worker embedqueue.Config, broker embedqueue.Broker, d time.Duration) embedqueue.Stats {
+	t.Helper()
+	coordDone := make(chan struct{})
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), d)
+		defer cancel()
+		embedqueue.RunCoordinator(ctx, coord, embedqueue.CoordinatorLoopOptions{Interval: 5 * time.Millisecond})
+		close(coordDone)
+	}()
+	runWorkerFor(t, worker, d)
+	<-coordDone
+
+	stats, err := broker.Stats(context.Background())
+	if err != nil {
+		t.Fatalf("Stats: %v", err)
+	}
+	return stats
+}
+
+// requireConverged runs the pair for TWO consecutive windows and requires the
+// second to add nothing.
+//
+// The absolute dead-letter count is not the right measurement: a coordinator can
+// legitimately read the pending set microseconds before the worker records the
+// terminal failure, so ONE redundant job may still be minted. What distinguishes
+// convergence from the #709 loop is whether the count keeps CLIMBING with
+// wall-clock time. Two windows answer that; a single snapshot cannot.
+func requireConverged(t *testing.T, coord *embedqueue.Coordinator, worker embedqueue.Config, broker embedqueue.Broker) {
+	t.Helper()
+	const window = 500 * time.Millisecond
+
+	first := runPairFor(t, coord, worker, broker, window)
+	second := runPairFor(t, coord, worker, broker, window)
+
+	if second.DeadLettered != first.DeadLettered {
+		t.Fatalf("dead letters grew from %d to %d over a second identical window: the chunk is being "+
+			"re-enqueued with a fresh retry budget after every dead letter and will never converge",
+			first.DeadLettered, second.DeadLettered)
+	}
+	if second.Pending != 0 || second.InFlight != 0 {
+		t.Fatalf("queue has not settled: %+v", second)
+	}
+}
+
+// TestDeadLetter_PermanentMismatchConvergesInsteadOfLooping runs a coordinator
+// and a mismatched worker together, past the retry limit, and requires the
+// system to SETTLE. The retry budget is 2 attempts against a 5ms coordinator
+// tick and a 1ms redelivery delay, so each window below is worth dozens of
+// re-enqueue cycles.
+func TestDeadLetter_PermanentMismatchConvergesInsteadOfLooping(t *testing.T) {
+	corpus := newTestCorpus(t, "alpha")
+	chunkID := corpus.addChunk(t, 1, "some text", "hash-1", "text")
+	broker := sharedBroker(t, 2)
+
+	coord := &embedqueue.Coordinator{
+		Source: corpus.store, Broker: broker, CorpusID: corpus.id,
+		SourceKind: "local", EmbedIdentity: testIdentity,
+	}
+	embedder := &recordingEmbedder{corpus: corpus}
+	worker := embedqueue.Config{
+		Broker:    broker,
+		Fetcher:   corpus.store,
+		Embedders: map[string]embedqueue.Embedder{"text": embedder},
+		Status:    corpus.store,
+		CorpusID:  corpus.id,
+		// The worker's vector space is not the one the jobs were enqueued under:
+		// a real, permanent, operator-visible misconfiguration.
+		EmbedIdentity: "openai|text-embedding-3-small||1536|0|off",
+		PollInterval:  time.Millisecond,
+		RetryAfter:    time.Millisecond,
+		Logger:        discardLogger(),
+	}
+
+	requireConverged(t, coord, worker, broker)
+
+	if got := embedder.texts(); len(got) != 0 {
+		t.Fatalf("a worker from another vector space embedded %v", got)
+	}
+
+	// The chunk itself must have left the pending set — that is what stops the
+	// coordinator re-creating the job — and it must say why.
+	if corpus.isPending(t, chunkID) {
+		t.Fatalf("chunk %d is still pending after its job was dead-lettered; "+
+			"the next coordinator tick will enqueue it again", chunkID)
+	}
+	cats := corpus.failureCategories(t)
+	if total := totalCount(cats); total != 1 {
+		t.Fatalf("status/doctor report %d failed chunk(s) %v, want exactly 1 with an actionable category", total, cats)
+	}
+}
+
+// TestDeadLetter_UnservedAxisIsRecordedTerminally covers the second preparation
+// failure #709 names: a job whose axis this pool has no embedder for. It is
+// permanent in exactly the same way and must converge in exactly the same way.
+func TestDeadLetter_UnservedAxisIsRecordedTerminally(t *testing.T) {
+	corpus := newTestCorpus(t, "alpha")
+	chunkID := corpus.addChunk(t, 1, "func main() {}", "hash-1", "code")
+	broker := sharedBroker(t, 2)
+
+	coord := &embedqueue.Coordinator{
+		Source: corpus.store, Broker: broker, CorpusID: corpus.id,
+		SourceKind: "local", EmbedIdentity: testIdentity,
+	}
+	// Text-only pool: nothing can ever write the code axis.
+	worker := embedqueue.Config{
+		Broker:        broker,
+		Fetcher:       corpus.store,
+		Embedders:     map[string]embedqueue.Embedder{"text": &recordingEmbedder{corpus: corpus}},
+		Status:        corpus.store,
+		CorpusID:      corpus.id,
+		EmbedIdentity: testIdentity,
+		PollInterval:  time.Millisecond,
+		RetryAfter:    time.Millisecond,
+		Logger:        discardLogger(),
+	}
+
+	requireConverged(t, coord, worker, broker)
+
+	if corpus.isPending(t, chunkID) {
+		t.Fatalf("chunk %d is still pending, so the coordinator will keep re-enqueuing it", chunkID)
+	}
+	if total := totalCount(corpus.failureCategories(t)); total != 1 {
+		t.Fatalf("status/doctor report %d failed chunk(s), want the one code chunk no worker can embed", total)
+	}
+}
+
+// TestDeadLetter_TransientFailureStillGetsItsRetries is the other half of the
+// contract and the reason the terminal write is gated on the LAST delivery
+// rather than on any failure: a fault that clears within the retry budget must
+// be redelivered and succeed, and must never leave a failure behind.
+func TestDeadLetter_TransientFailureStillGetsItsRetries(t *testing.T) {
+	corpus := newTestCorpus(t, "alpha")
+	chunkID := corpus.addChunk(t, 1, "some text", "hash-1", "text")
+	broker := sharedBroker(t, 4)
+
+	coord := &embedqueue.Coordinator{
+		Source: corpus.store, Broker: broker, CorpusID: corpus.id,
+		SourceKind: "local", EmbedIdentity: testIdentity,
+	}
+	if _, err := coord.EnqueuePending(context.Background(), ""); err != nil {
+		t.Fatalf("EnqueuePending: %v", err)
+	}
+
+	var attempts int
+	embedder := &recordingEmbedder{corpus: corpus}
+	embedder.failNext = func([]model.ChunkTask) error {
+		attempts++
+		if attempts <= 2 {
+			return errors.New("connection reset by peer")
+		}
+		return nil
+	}
+	worker := embedqueue.Config{
+		Broker:        broker,
+		Fetcher:       corpus.store,
+		Embedders:     map[string]embedqueue.Embedder{"text": embedder},
+		Status:        corpus.store,
+		CorpusID:      corpus.id,
+		EmbedIdentity: testIdentity,
+		PollInterval:  time.Millisecond,
+		RetryAfter:    time.Millisecond,
+		Logger:        discardLogger(),
+	}
+
+	if !runWorkerUntilOrTimeout(t, worker, 3*time.Second, func() bool {
+		return len(embedder.texts()) > 0
+	}) {
+		t.Fatal("a chunk that failed twice transiently was never retried to success")
+	}
+	if corpus.isPending(t, chunkID) {
+		t.Fatalf("chunk %d is still pending after a successful embed", chunkID)
+	}
+	if cats := corpus.failureCategories(t); len(cats) != 0 {
+		t.Fatalf("a chunk that recovered within its retry budget was recorded as failed: %v", cats)
+	}
+}
+
+func totalCount(counts map[string]int64) int64 {
+	var total int64
+	for _, n := range counts {
+		total += n
+	}
+	return total
+}

--- a/tests/embedqueue/stale_payload_710_test.go
+++ b/tests/embedqueue/stale_payload_710_test.go
@@ -1,0 +1,216 @@
+package embedqueue_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/embedqueue"
+)
+
+// #710: jobs carried no payload identity and workers threw away the one the
+// store returned. A chunk_id survives an in-place re-ingest of the same
+// (rep_id, ordinal) while text, text_hash, index_kind and embedding status are
+// all rewritten under it, so a job enqueued before such a rewrite named bytes
+// that no longer existed — and the worker routed the NEW task through the OLD
+// job's axis and embedder, marking the chunk embedded on the wrong axis.
+//
+// These tests are deterministic: the chunk is rewritten between enqueue and
+// lease, with no concurrency.
+
+// enqueueOnce runs one coordinator pass over the corpus's pending head.
+func enqueueOnce(t *testing.T, corpus *testCorpus, broker embedqueue.Broker) int {
+	t.Helper()
+	coord := &embedqueue.Coordinator{
+		Source: corpus.store, Broker: broker, CorpusID: corpus.id,
+		SourceKind: "local", EmbedIdentity: testIdentity,
+	}
+	n, err := coord.EnqueuePending(context.Background(), "")
+	if err != nil {
+		t.Fatalf("EnqueuePending: %v", err)
+	}
+	return n
+}
+
+// twoAxisWorker builds a worker that serves both axes, so a mis-route lands in a
+// real embedder rather than being caught by a missing one.
+func twoAxisWorker(corpus *testCorpus, broker embedqueue.Broker, text, code *recordingEmbedder) embedqueue.Config {
+	return embedqueue.Config{
+		Broker:        broker,
+		Fetcher:       corpus.store,
+		Embedders:     map[string]embedqueue.Embedder{"text": text, "code": code},
+		Status:        corpus.store,
+		CorpusID:      corpus.id,
+		EmbedIdentity: testIdentity,
+		PollInterval:  time.Millisecond,
+		RetryAfter:    time.Millisecond,
+		Logger:        discardLogger(),
+	}
+}
+
+// TestStaleJob_AxisChangeIsNotEmbeddedThroughTheOldAxis is the race from the
+// issue, made deterministic: enqueue chunk N while it is `code`, re-ingest the
+// same (rep_id, ordinal) as `text` (same chunk id, new hash, new axis, pending
+// again), then let a worker lease the old job.
+//
+// The old job must not be executed. Executing it wrote a CODE vector for what is
+// now a text chunk and marked the chunk embedded, so the correct text-axis job
+// was never enqueued and a wrong-axis vector stayed searchable.
+func TestStaleJob_AxisChangeIsNotEmbeddedThroughTheOldAxis(t *testing.T) {
+	corpus := newTestCorpus(t, "alpha")
+	broker := sharedBroker(t, 3)
+
+	chunkID := corpus.addChunk(t, 1, "func main() {}", "hash-code", "code")
+	if n := enqueueOnce(t, corpus, broker); n != 1 {
+		t.Fatalf("enqueued %d jobs, want 1", n)
+	}
+	requireQueuedJobCarriesHash(t, broker, corpus, "hash-code")
+
+	// The in-place re-ingest: same representation and ordinal, so the store keeps
+	// the chunk id and rewrites everything else.
+	if got := corpus.addChunk(t, 1, "just prose now", "hash-text", "text"); got != chunkID {
+		t.Fatalf("re-ingest allocated chunk %d, want the same id %d; the fixture is not "+
+			"reproducing the in-place update this test is about", got, chunkID)
+	}
+
+	textEmbedder := &recordingEmbedder{corpus: corpus}
+	codeEmbedder := &recordingEmbedder{corpus: corpus}
+	runWorkerFor(t, twoAxisWorker(corpus, broker, textEmbedder, codeEmbedder), 300*time.Millisecond)
+
+	if got := codeEmbedder.texts(); len(got) != 0 {
+		t.Fatalf("the stale code-axis job embedded %v; the chunk is a TEXT chunk now and a code "+
+			"vector for it would stay searchable on the wrong axis", got)
+	}
+	if got := textEmbedder.texts(); len(got) != 0 {
+		t.Fatalf("the stale job was re-routed to the text axis and embedded %v; a superseded job "+
+			"must be acked, leaving the coordinator to enqueue the chunk's current form", got)
+	}
+	if !corpus.isPending(t, chunkID) {
+		t.Fatalf("chunk %d was marked embedded by a job that named its previous form", chunkID)
+	}
+
+	// The stale job is gone (acked, not retried) rather than lingering or being
+	// dead-lettered: nothing was wrong with it, it was simply out of date.
+	stats, err := broker.Stats(context.Background())
+	if err != nil {
+		t.Fatalf("Stats: %v", err)
+	}
+	if stats.Pending != 0 || stats.InFlight != 0 || stats.DeadLettered != 0 {
+		t.Fatalf("superseded job was not acked away: %+v", stats)
+	}
+
+	// And the chunk converges: the next coordinator pass enqueues its CURRENT
+	// form, which embeds on the axis it is actually on now.
+	if n := enqueueOnce(t, corpus, broker); n != 1 {
+		t.Fatalf("re-enqueued %d jobs for the updated chunk, want 1", n)
+	}
+	if !runWorkerUntilOrTimeout(t, twoAxisWorker(corpus, broker, textEmbedder, codeEmbedder),
+		3*time.Second, func() bool { return len(textEmbedder.texts()) > 0 }) {
+		t.Fatal("the chunk's current text-axis form was never embedded")
+	}
+	if got := codeEmbedder.texts(); len(got) != 0 {
+		t.Fatalf("code axis embedded %v after the chunk became text", got)
+	}
+}
+
+// requireQueuedJobCarriesHash inspects the head of the queue without consuming
+// it: a job that names no payload gives the worker nothing to compare against,
+// so every downstream assertion in this file would be vacuous.
+func requireQueuedJobCarriesHash(t *testing.T, broker *embedqueue.SQLiteBroker, corpus *testCorpus, want string) {
+	t.Helper()
+	ctx := context.Background()
+	lease, err := broker.LeaseForCorpus(ctx, corpus.id, time.Minute)
+	if err != nil {
+		t.Fatalf("inspect queued job: %v", err)
+	}
+	if lease.Job.TextHash != want {
+		t.Fatalf("queued job carries text_hash %q, want the chunk's persisted %q; a job with no "+
+			"payload identity cannot be recognised as superseded (SPEC §8.7.2)", lease.Job.TextHash, want)
+	}
+	if err := broker.Nack(ctx, lease.Token, 0); err != nil {
+		t.Fatalf("return inspected job: %v", err)
+	}
+}
+
+// TestStaleJob_ChangedTextOnTheSameAxisIsNotEmbedded covers the same-axis case:
+// the chunk keeps index_kind=text but its bytes are replaced. The axis check
+// alone would let this through, so it is the text_hash that has to catch it.
+func TestStaleJob_ChangedTextOnTheSameAxisIsNotEmbedded(t *testing.T) {
+	corpus := newTestCorpus(t, "alpha")
+	broker := sharedBroker(t, 3)
+
+	chunkID := corpus.addChunk(t, 1, "first revision", "hash-v1", "text")
+	if n := enqueueOnce(t, corpus, broker); n != 1 {
+		t.Fatalf("enqueued %d jobs, want 1", n)
+	}
+	if got := corpus.addChunk(t, 1, "second revision", "hash-v2", "text"); got != chunkID {
+		t.Fatalf("re-ingest allocated chunk %d, want %d", got, chunkID)
+	}
+
+	textEmbedder := &recordingEmbedder{corpus: corpus}
+	codeEmbedder := &recordingEmbedder{corpus: corpus}
+	runWorkerFor(t, twoAxisWorker(corpus, broker, textEmbedder, codeEmbedder), 300*time.Millisecond)
+
+	if got := textEmbedder.texts(); len(got) != 0 {
+		t.Fatalf("a job enqueued for text_hash hash-v1 embedded %v; a job whose payload has been "+
+			"replaced must be acked as superseded, not executed", got)
+	}
+	if !corpus.isPending(t, chunkID) {
+		t.Fatalf("chunk %d was marked embedded through a superseded job", chunkID)
+	}
+}
+
+// TestStaleJob_UnchangedChunkStillEmbeds is the guard against over-rejection:
+// the check must only fire when the payload actually changed. A job whose chunk
+// is untouched embeds exactly as before.
+func TestStaleJob_UnchangedChunkStillEmbeds(t *testing.T) {
+	corpus := newTestCorpus(t, "alpha")
+	broker := sharedBroker(t, 3)
+
+	chunkID := corpus.addChunk(t, 1, "unchanged text", "hash-v1", "text")
+	if n := enqueueOnce(t, corpus, broker); n != 1 {
+		t.Fatalf("enqueued %d jobs, want 1", n)
+	}
+
+	textEmbedder := &recordingEmbedder{corpus: corpus}
+	codeEmbedder := &recordingEmbedder{corpus: corpus}
+	if !runWorkerUntilOrTimeout(t, twoAxisWorker(corpus, broker, textEmbedder, codeEmbedder),
+		3*time.Second, func() bool { return len(textEmbedder.texts()) > 0 }) {
+		t.Fatal("an unchanged chunk was never embedded")
+	}
+	if got := textEmbedder.texts(); len(got) != 1 || got[0] != "unchanged text" {
+		t.Fatalf("text axis embedded %v, want the chunk once", got)
+	}
+	if corpus.isPending(t, chunkID) {
+		t.Fatalf("chunk %d is still pending after a successful embed", chunkID)
+	}
+}
+
+// TestStaleJob_JobWithoutPayloadIdentityStillEmbeds pins the compatibility rule
+// the comparison depends on: a durable SQLite queue can hold jobs written by a
+// build that predated payload identity. An empty hash means UNKNOWN, so such a
+// job must still execute — treating it as a mismatch would ack every queued job
+// on upgrade and stall the corpus.
+func TestStaleJob_JobWithoutPayloadIdentityStillEmbeds(t *testing.T) {
+	corpus := newTestCorpus(t, "alpha")
+	broker := sharedBroker(t, 3)
+
+	chunkID := corpus.addChunk(t, 1, "legacy job text", "hash-v1", "text")
+	if err := broker.Enqueue(context.Background(), embedqueue.Job{
+		CorpusID:      corpus.id,
+		Source:        "local",
+		ChunkID:       chunkID,
+		IndexKind:     "text",
+		EmbedIdentity: testIdentity,
+		// TextHash deliberately absent, as a pre-#710 job on disk would be.
+	}); err != nil {
+		t.Fatalf("enqueue legacy job: %v", err)
+	}
+
+	textEmbedder := &recordingEmbedder{corpus: corpus}
+	codeEmbedder := &recordingEmbedder{corpus: corpus}
+	if !runWorkerUntilOrTimeout(t, twoAxisWorker(corpus, broker, textEmbedder, codeEmbedder),
+		3*time.Second, func() bool { return len(textEmbedder.texts()) > 0 }) {
+		t.Fatal("a job carrying no payload identity was never executed; an unknown hash must not read as stale")
+	}
+}

--- a/tests/identity/corpus_id_test.go
+++ b/tests/identity/corpus_id_test.go
@@ -1,0 +1,142 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/identity"
+)
+
+// The corpus id (SPEC §5.5) is what scopes a corpus's jobs inside a broker that
+// several corpora may share (#708). These tests pin the three properties that
+// makes it safe to put there: it distinguishes corpora, it is stable once
+// written, and it discloses nothing about the corpus it names.
+
+// memSettings is an in-memory settings table with the store's contract: a
+// missing key reads back as os.ErrNotExist.
+type memSettings struct {
+	values  map[string]string
+	readErr error
+	writes  int
+}
+
+func newMemSettings() *memSettings { return &memSettings{values: map[string]string{}} }
+
+func (m *memSettings) GetSetting(_ context.Context, key string) (string, error) {
+	if m.readErr != nil {
+		return "", m.readErr
+	}
+	v, ok := m.values[key]
+	if !ok {
+		return "", os.ErrNotExist
+	}
+	return v, nil
+}
+
+func (m *memSettings) SetSetting(_ context.Context, key, value string) error {
+	m.writes++
+	m.values[key] = value
+	return nil
+}
+
+func TestCorpusID_DistinguishesCorpora(t *testing.T) {
+	cases := []struct{ name, a, b string }{
+		{"different local roots", identity.CorpusKey("/srv/alpha"), identity.CorpusKey("/srv/beta")},
+		{"different buckets", identity.CorpusKeyForS3("alpha", "", ""), identity.CorpusKeyForS3("beta", "", "")},
+		{"different prefixes of one bucket", identity.CorpusKeyForS3("shared", "alpha", ""), identity.CorpusKeyForS3("shared", "beta", "")},
+		{"same bucket on different endpoints", identity.CorpusKeyForS3("c", "", "minio-a.example:9000"), identity.CorpusKeyForS3("c", "", "minio-b.example:9000")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if identity.CorpusID(tc.a) == identity.CorpusID(tc.b) {
+				t.Fatalf("two corpora share one id; on a shared broker they would share a job namespace")
+			}
+		})
+	}
+}
+
+// TestCorpusID_SpellingsOfOneCorpusAgree pins that the normalization #737
+// established for the instance name governs the corpus id too, so one
+// deployment cannot become two identities depending on how it was written down.
+func TestCorpusID_SpellingsOfOneCorpusAgree(t *testing.T) {
+	want := identity.CorpusID(identity.CorpusKeyForS3("bkt", "corpus", ""))
+	for _, spelling := range []string{"corpus/", "/corpus", "/corpus/", "corpus//"} {
+		if got := identity.CorpusID(identity.CorpusKeyForS3("bkt", spelling, "")); got != want {
+			t.Fatalf("prefix spelling %q yields a different corpus id", spelling)
+		}
+	}
+	if got := identity.CorpusID(identity.CorpusKeyForS3("BKT", "corpus", "")); got != want {
+		t.Fatalf("bucket case changes the corpus id")
+	}
+	if got := identity.CorpusID(identity.CorpusKey("/srv/alpha/")); got != identity.CorpusID(identity.CorpusKey("/srv/alpha")) {
+		t.Fatalf("a trailing slash changes the corpus id")
+	}
+}
+
+// TestCorpusID_CarriesNoCorpusDetail is the property that lets the id sit in a
+// queue several corpora can read: it must not describe the corpus. A path, a
+// bucket, or an endpoint appearing in the id would publish one tenant's layout
+// to another.
+func TestCorpusID_CarriesNoCorpusDetail(t *testing.T) {
+	id := identity.CorpusID(identity.CorpusKeyForS3("customer-a-private", "invoices/2026", "https://key:secret@minio.internal:9000"))
+	for _, leak := range []string{"customer", "private", "invoices", "2026", "minio", "internal", "key", "secret", "s3"} {
+		if strings.Contains(strings.ToLower(id), leak) {
+			t.Fatalf("corpus id %q contains %q; the id reaches a shared broker and its logs", id, leak)
+		}
+	}
+	if !strings.HasPrefix(id, "corpus-") {
+		t.Fatalf("corpus id %q lost its prefix", id)
+	}
+	local := identity.CorpusID(identity.CorpusKey("/home/alice/Documents/taxes"))
+	for _, leak := range []string{"alice", "documents", "taxes", "home"} {
+		if strings.Contains(strings.ToLower(local), leak) {
+			t.Fatalf("corpus id %q contains %q from the local root", local, leak)
+		}
+	}
+}
+
+// TestResolveCorpusID_SeedsThenIsStable is the reason the id is PERSISTED rather
+// than derived on demand: a corpus that moves keeps the identity its queued
+// jobs, its written vectors and its running workers are already bound to.
+func TestResolveCorpusID_SeedsThenIsStable(t *testing.T) {
+	ctx := context.Background()
+	settings := newMemSettings()
+
+	first, err := identity.ResolveCorpusID(ctx, settings, identity.CorpusKey("/srv/alpha"))
+	if err != nil {
+		t.Fatalf("ResolveCorpusID: %v", err)
+	}
+	if first != identity.CorpusID(identity.CorpusKey("/srv/alpha")) {
+		t.Fatalf("seeded id %q is not the derived id", first)
+	}
+	if settings.values[identity.CorpusIDSettingKey] != first {
+		t.Fatalf("corpus id was not persisted to settings.%s", identity.CorpusIDSettingKey)
+	}
+
+	// Same store, corpus now mounted somewhere else: the persisted value wins.
+	moved, err := identity.ResolveCorpusID(ctx, settings, identity.CorpusKey("/mnt/relocated/alpha"))
+	if err != nil {
+		t.Fatalf("ResolveCorpusID after move: %v", err)
+	}
+	if moved != first {
+		t.Fatalf("moving the corpus renamed it from %q to %q; every job already queued under the old id "+
+			"would be orphaned", first, moved)
+	}
+	if settings.writes != 1 {
+		t.Fatalf("settings written %d times, want 1: a resolved id must not be rewritten on every start", settings.writes)
+	}
+}
+
+// TestResolveCorpusID_SurfacesReadFailures: a worker that cannot read the corpus
+// identity must not guess one. Guessing is precisely the cross-wiring the id
+// exists to prevent.
+func TestResolveCorpusID_SurfacesReadFailures(t *testing.T) {
+	settings := newMemSettings()
+	settings.readErr = errors.New("database is locked")
+	if _, err := identity.ResolveCorpusID(context.Background(), settings, identity.CorpusKey("/srv/alpha")); err == nil {
+		t.Fatal("ResolveCorpusID silently derived an id after a settings read failure")
+	}
+}


### PR DESCRIPTION
Fixes #708. Fixes #709. Fixes #710.

All three were verified against the code before anything was changed; all three
are real and accurately described. They share one root cause, which is why they
are one PR: **a job did not carry enough about WHICH corpus and WHICH payload it
named**, so a broker several corpora share could cross wires, and a job that
could never succeed was re-created forever. Split apart, the three fixes touch
the same `prepare` path, the same `Job`, and both brokers.

## Which change serves which issue

### #708 — shared brokers can collide and execute jobs across corpora

| Change | Effect |
|---|---|
| `Coordinator.CorpusID` is the stable persisted corpus id, not `rootDir` | jobs name a corpus that survives a move and is unique for an S3 corpus |
| `MemBroker`/`SQLiteBroker` dedup on `corpus_id+chunk_id+index_kind` | corpus B's job is no longer swallowed by corpus A's live job for the same id |
| new optional `CorpusScopedBroker` (`LeaseForCorpus`), implemented by both built-ins | a worker claims only its own corpus's jobs |
| `Config.CorpusID` + `servesCorpus` check, first, before the store is touched | a foreign job is returned unexecuted and never marks a chunk in the wrong store |

### #709 — dead-lettered preparation failures are re-enqueued

| Change | Effect |
|---|---|
| `Lease.Attempts` / `Lease.MaxAttempts` / `Lease.Final()` | the worker can tell a Nack that redelivers from one that dead-letters |
| new optional `Config.Status` (`MarkFailedWithCategory`), wired from the chunk source in both CLI paths | the final delivery records `embedding_status=error` + category |
| all reject paths route through `rejectJob` | applies to identity mismatch, unserved axis, persistent fetch failure, and embed failure alike |

### #710 — jobs omit payload identity and can route a changed payload to a stale consumer

| Change | Effect |
|---|---|
| `model.ChunkTask.TextHash`, populated by `NextPending` and `ChunkTaskByID` | the coordinator has a hash to stamp |
| `Job.TextHash` is populated | the job names its payload (SPEC §8.7.2) |
| worker keeps the store's hash and compares it, and routes by `task.IndexKind` | a superseded job is acked without embedding; a chunk is never marked embedded through an axis it is not on |

## Design decisions

**What identifies a corpus.** `identity.CorpusKey` / `CorpusKeyForS3` are the
key derivations `AutoServerName` / `AutoServerNameForS3` (#737) already used,
factored out so there is exactly one notion of "which corpus is this" and both
consumers share it — `AutoServerNameForS3` now calls `CorpusKeyForS3`, and its
existing tests pass unchanged. `identity.CorpusID` hashes that key to
`corpus-<32 hex>` and `ResolveCorpusID` persists it in `settings.corpus_id`
(SPEC §5.5, previously specified but never written).

Three deliberate properties:

- **Opaque, not human-readable.** Unlike the instance name the same key
  produces, the corpus id carries no path, bucket, endpoint or credential. It
  lands in a queue that by design several corpora may share, which on a
  multi-tenant host is the one place corpus A can read rows corpus B wrote. A
  digest identifies a corpus without describing it; an operator maps it back
  from that corpus's own store. Nothing credential-bearing reaches a broker, a
  queue name, or a log — `servesCorpus` logs the digest only.
- **Persisted value wins.** Deriving on every start would rename a corpus that
  was moved or re-mounted, orphaning its queued jobs and its written vectors.
- **No dev/release prefix.** `AutoServerName` carries one; a persisted corpus
  identity that changed when a dev build opened the same corpus would split one
  corpus in two.

**What "dead" means (#709).** Dead-lettering only ends the *job*. The chunk
stayed `pending`, so the coordinator's next tick minted a new job with a new
budget. "Dead" now means the **chunk** is terminal: `embedding_status=error`
with a category. That is what breaks the loop, because `NextPending` selects
only pending chunks — and it is also how an operator sees it, in the existing
`dir2mcp status` / `doctor` error-category breakdown and samples, in the same
shape an in-process failure appears. No new surface was invented for it.

**A job that legitimately deserves a retry** is untouched: the terminal write
fires only on the delivery that exhausts the broker's budget, so a transient
fault that clears inside the budget is redelivered and succeeds with nothing
recorded (pinned by a test). An operator who fixes the cause re-pends the chunk
with `dir2mcp reindex`. Dead rows are now bounded at ~one per permanently-failing
chunk rather than growing without limit.

**Payload-shape identity (#710): `text_hash`, not `EmbedIdentity`, and no new
schema version.** `EmbedIdentity` keys the *embedding space*; it is already
carried and already enforced, and it does not change when a chunk's bytes
change, so it cannot detect a superseded payload. SPEC §8.7.2 names `text_hash`
as the payload identity and that is what is now carried. A separate
payload-*schema* version was considered and rejected: the one problem it would
solve is a durable SQLite queue holding jobs written by an older binary, and
that is handled precisely by treating an empty hash as **unknown** rather than
as a mismatch — the comparison can only prove staleness, never freshness. A
version field would add a migration and a compatibility matrix to buy nothing
the one-sided comparison does not already give. There is a test for the
legacy-job case.

## Also fixed (found by the new tests)

`NewSQLiteBroker` set `busy_timeout` with a single `ExecContext`, which lands on
one pooled connection. With two workers on one queue file, `database/sql` opens
further connections that never got it, so their reclaim-write-first `Lease`
failed *immediately* with SQLITE_BUSY and a failed `Ack` stranded a leased job
until its 30s lease expired. It now travels in the DSN with
`SetMaxOpenConns(1)`, the fix and the reasoning `internal/store` already
documents for the same defect (#429 F11). This is the shape #708 is about — a
shared broker with concurrent workers — and the existing white-box pragma test
still passes.

## Testing — proven to fail first

Each test was run against the tree with **only its source change reverted**
(behaviour removed, API kept, so it still compiles):

**#708** — the cross-corpus test is a real collision, not a mocked assertion:
two real SQLite metadata stores each independently allocating chunk id 1, two
real corpus ids resolved through the real persist path, one real shared
`SQLiteBroker` file, and the real worker loop.

- reverting the corpus term in the dedup predicate:
  `shared queue holds 1 pending job(s), want 2 ... a corpus whose chunk id
  collides with another's has silently lost its job`
- reverting corpus-scoped leasing + the worker's binding check:
  `corpus beta's worker embedded [beta chunk]; it must not execute another
  corpus's job` — the full original bug, with corpus A's job consumed and acked
  by a worker that embedded corpus B's bytes.

**#709** — coordinator and worker run **together**, past the retry limit, over
two consecutive identical windows. The measurement is whether the dead-letter
count keeps climbing with wall-clock time, which is what distinguishes
convergence from the loop (a single snapshot cannot: one redundant job is
legitimately possible from a coordinator read that races the terminal write).
Reverting the terminal write:

- `dead letters grew from 94 to 187 over a second identical window`
- unserved-axis variant: `grew from 86 to 177`

With the fix both settle and stop. A third test pins that a transient failure
still gets its full retry budget and is recorded nowhere.

**#710** — deterministic, no concurrency: enqueue while the chunk is `code`,
re-ingest the same `(rep_id, ordinal)` as `text` (the store preserves the chunk
id and rewrites hash, axis and status), then lease.

- with `Job.TextHash` left empty: `queued job carries text_hash "", want the
  chunk's persisted hash`
- with routing taken from the job: `the stale code-axis job embedded [just prose
  now]; the chunk is a TEXT chunk now and a code vector for it would stay
  searchable on the wrong axis`
- same-axis hash change: `a job enqueued for text_hash hash-v1 embedded [second
  revision]`

Plus guards against over-rejection: an unchanged chunk still embeds, and a job
with no payload identity still executes.

## Checklist

- `make check` green (`gocyclo -over 15` clean; `golangci-lint` 0 issues)
- `go test -race ./tests/embedqueue ./tests/identity -count=4` green
- No new files under `internal/cli/`, so `tests/security/cli_boundary_test.go`
  needs no change (verified — it passes)
- Tests live under `tests/embedqueue/` and `tests/identity/`
- `docs/dual-machine-deployment.md` §4.4/§4.5 document the corpus-isolation and
  terminal-failure behaviour
