### PR TITLE
feat(annotator): add `eval --vision-only` for the feed-free measurement (#741)

### DIFF
--- a/annotator/dirstral_annotator/cli.py
+++ b/annotator/dirstral_annotator/cli.py
@@ -69,6 +69,12 @@ def build_parser() -> argparse.ArgumentParser:
     e.add_argument("--anchor", action="append", default=[], metavar="EPOCH=VIDEO_S", required=True)
     e.add_argument("--report", type=Path, help="write markdown report here")
     e.add_argument(
+        "--vision-only",
+        action="store_true",
+        help="score the vision cascade alone: the feed supplies ground truth but "
+             "does NOT run as a recognizer",
+    )
+    e.add_argument(
         "--debug",
         action="store_true",
         help="add per-source sample cues to the report's diagnostics",
@@ -147,7 +153,20 @@ def main(argv: list[str] | None = None) -> int:
             file=sys.stderr,
         )
 
-    pipeline = _pipeline(args, roster, {args.media.name: game})
+    # `--vision-only` is the feed-free measurement (#741 milestone 1). The feed
+    # still supplies ground truth, which is what a label set IS, but it is kept
+    # out of the pipeline so play-by-play does not run as a recognizer.
+    #
+    # Without this the headline is mostly a measurement of wall-clock alignment:
+    # play-by-play emits a `pitch` cue per feed event, the scorer reads `pitch`
+    # annotations, and the feed is therefore scored against itself. That is the
+    # right number for a corpus that HAS a feed and a misleading one for the
+    # archives this milestone targets.
+    bindings = {} if args.vision_only else {args.media.name: game}
+    pipeline = _pipeline(args, roster, bindings)
+    if args.vision_only:
+        print("vision-only: play-by-play supplies ground truth only, not cues",
+              file=sys.stderr)
     # Keep the pre-fusion cues: they are what makes an empty source row
     # explainable (ineligible / floored / weak) instead of just empty.
     cues, annotations = diagnose_mod.run_pipeline(pipeline, args.media)

--- a/annotator/tests/test_eval_vision_only.py
+++ b/annotator/tests/test_eval_vision_only.py
@@ -1,0 +1,40 @@
+"""The feed-free evaluation path (#741 milestone 1).
+
+`eval` binds the game into the pipeline, which enables the play-by-play
+recognizer, AND uses the same feed for ground truth. With both on, the headline
+is largely a measurement of wall-clock alignment: play-by-play emits one `pitch`
+cue per feed event, the scorer reads `pitch` annotations, and the feed is scored
+against itself. `--vision-only` keeps the feed as labels and out of the cascade.
+"""
+
+from dirstral_annotator.cli import build_parser
+
+
+def parse(*extra):
+    return build_parser().parse_args(
+        ["eval", "game.mp4", "--roster", "r.json", "--game-pk", "745123",
+         "--anchor", "1789265400.0=60.0", *extra]
+    )
+
+
+def test_vision_only_is_off_by_default():
+    """A corpus that HAS a feed should use it; this flag is for the archives
+    that do not, so it must be opt-in."""
+    assert parse().vision_only is False
+
+
+def test_vision_only_is_a_flag_on_eval():
+    assert parse("--vision-only").vision_only is True
+
+
+def test_the_feed_is_still_required_with_vision_only():
+    """The feed supplies ground truth, which is what a label set is. Dropping it
+    would leave nothing to score against, so `--vision-only` narrows what runs
+    as a recognizer and never what the labels are."""
+    parser = build_parser()
+    args = parser.parse_args(
+        ["eval", "game.mp4", "--roster", "r.json", "--feed", "gumbo.json",
+         "--anchor", "1789265400.0=60.0", "--vision-only"]
+    )
+    assert args.vision_only is True
+    assert str(args.feed) == "gumbo.json"


### PR DESCRIPTION
Part of #741 milestone 1.

`eval` binds the game into the pipeline — which enables the **play-by-play recognizer** — and uses that same feed for ground truth. With both on, the headline is largely a measurement of wall-clock alignment rather than of recognition: play-by-play emits one `pitch` cue per feed event, the scorer reads `pitch` annotations, and the feed is effectively scored against itself.

The generated report says so in its own words: *"When play-by-play is enabled it is therefore mostly a measurement of wall-clock alignment, not of computer vision."* The Giants pilot report shows it plainly — 99.4% recall, with play-by-play credited on **342 of 344** pitches.

`--vision-only` keeps the feed as labels and out of the cascade. That is the measurement #741 milestone 1 needs: what an archive with **no feed** actually gets.

- It narrows what runs as a **recognizer**, never what the **labels** are, so `--game-pk`/`--feed` is still required.
- Off by default: a corpus that has a feed should use it.

Being run now against the 3h24m Giants proxy on the GPU host to produce the milestone-1 baseline; the existing report's per-source diagnostics predict scorebug alone at 96.5% identity coverage, and this will show what the pitcher-keyed gate does without the feed in the cascade.