### PR TITLE
fix(x402): emit a standard v2 PaymentRequired in the challenge header (#700)

### DIFF
--- a/internal/x402/types.go
+++ b/internal/x402/types.go
@@ -53,27 +53,50 @@ type Requirement struct {
 	MaxTimeoutSeconds int
 }
 
-// X402Payload represents the JSON object returned in the PAYMENT-REQUIRED header.
-// It mirrors the previous map structure but provides compile-time safety.
+// X402Payload is the JSON object returned in the PAYMENT-REQUIRED header: a
+// standard x402 v2 `PaymentRequired`.
 //
-// Consumers depend on the field names to match the existing keys, so the tags
-// are chosen accordingly.
+// It advertises `x402Version: 2`, so it has to BE a v2 object. It was not
+// (#700): `resource` sat inside each accept entry as a bare string and there
+// was no top-level resource at all, while the v2 SDK already vendored in this
+// module defines `PaymentRequired` as x402Version + a first-class
+// `resource *ResourceInfo` + `accepts []PaymentRequirements`, whose entries
+// carry no `resource` field. SPEC §18 requires the standard shape in as many
+// words: "first-class `resource` + `accepts[]` with `maxTimeoutSeconds`".
+//
+// A client parsing this header with the SDK's own types read no resource at
+// all, which matters because the adapter binds a proof to the challenge
+// `resource` and refuses one issued for a different route: the field a client
+// needs in order to comply was not where the format says it is.
 type X402Payload struct {
 	X402Version int           `json:"x402Version"`
+	Resource    *ResourceInfo `json:"resource,omitempty"`
 	Accept      []AcceptEntry `json:"accepts"`
 }
 
-// AcceptEntry describes a single acceptable payment requirement.
-// The json tags match the keys previously used in the map literal.
+// ResourceInfo describes the resource being paid for. Mirrors the SDK type;
+// only `url` is populated here, the rest are bazaar service metadata this
+// adapter does not emit.
+type ResourceInfo struct {
+	URL string `json:"url"`
+}
+
+// AcceptEntry is one entry of `accepts`, matching the SDK's
+// `PaymentRequirements`.
+//
+// No `resource`: it moved to the top level, where v2 puts it. `Extra` is the
+// SDK's own escape hatch and is where `maxAmountRequired` now lives — that
+// field is this adapter's, not the standard's (the canonical spec never
+// mentions it), and it is kept on the wire because the request fingerprint the
+// replay ledger binds to includes it.
 type AcceptEntry struct {
-	Scheme            string `json:"scheme"`
-	Network           string `json:"network"`
-	Amount            string `json:"amount"`
-	MaxAmountRequired string `json:"maxAmountRequired,omitempty"`
-	Asset             string `json:"asset"`
-	PayTo             string `json:"payTo"`
-	Resource          string `json:"resource"`
-	MaxTimeoutSeconds int    `json:"maxTimeoutSeconds"`
+	Scheme            string                 `json:"scheme"`
+	Network           string                 `json:"network"`
+	Amount            string                 `json:"amount"`
+	Asset             string                 `json:"asset"`
+	PayTo             string                 `json:"payTo"`
+	MaxTimeoutSeconds int                    `json:"maxTimeoutSeconds"`
+	Extra             map[string]interface{} `json:"extra,omitempty"`
 }
 
 const allowedSchemesText = "exact, upto"
@@ -147,20 +170,25 @@ func BuildPaymentRequiredHeaderValue(req Requirement) (string, error) {
 
 	// assemble a typed payload rather than a loose map; this aids
 	// compile-time checking and prevents inadvertent typos.
+	entry := AcceptEntry{
+		Scheme:            req.Scheme,
+		Network:           req.Network,
+		Amount:            req.Amount,
+		Asset:             req.Asset,
+		PayTo:             req.PayTo,
+		MaxTimeoutSeconds: req.MaxTimeoutSeconds,
+	}
+	if max := strings.TrimSpace(req.MaxAmountRequired); max != "" {
+		entry.Extra = map[string]interface{}{"maxAmountRequired": max}
+	}
 	p := X402Payload{
 		X402Version: X402Version,
-		Accept: []AcceptEntry{
-			{
-				Scheme:            req.Scheme,
-				Network:           req.Network,
-				Amount:            req.Amount,
-				MaxAmountRequired: req.MaxAmountRequired,
-				Asset:             req.Asset,
-				PayTo:             req.PayTo,
-				Resource:          req.Resource,
-				MaxTimeoutSeconds: req.MaxTimeoutSeconds,
-			},
-		},
+		Accept:      []AcceptEntry{entry},
+	}
+	// Only when the operator configured a resource base URL. An empty `url`
+	// would be a worse claim than an absent resource object.
+	if resource := strings.TrimSpace(req.Resource); resource != "" {
+		p.Resource = &ResourceInfo{URL: resource}
 	}
 
 	raw, err := json.Marshal(p)

--- a/tests/x402/payment_required_v2_shape_700_test.go
+++ b/tests/x402/payment_required_v2_shape_700_test.go
@@ -1,0 +1,142 @@
+package x402
+
+import (
+	"encoding/json"
+	"testing"
+
+	sdktypes "github.com/x402-foundation/x402/go/types"
+
+	"github.com/dirstral/dir2mcp/internal/x402"
+)
+
+// #700: the PAYMENT-REQUIRED header advertised `x402Version: 2` while emitting
+// a shape that is not a v2 `PaymentRequired`. `resource` sat inside each accept
+// entry as a bare string and there was no top-level resource object, though the
+// v2 SDK already vendored in this module defines `PaymentRequired` as
+// x402Version + a first-class `resource *ResourceInfo` + `accepts`, whose
+// entries carry no `resource` field at all. SPEC §18 requires the standard
+// shape in as many words.
+//
+// It matters beyond tidiness: the adapter binds a proof to the challenge
+// `resource` and refuses one issued for another route, so the field a client
+// must read in order to comply was not where the format says it is.
+//
+// Nothing asserted the header's shape before this file, which is why it
+// shipped: every existing x402 test checks status codes, headers being present,
+// and settlement behaviour, never the object itself.
+
+func requirement() x402.Requirement {
+	return x402.Requirement{
+		Scheme:            "exact",
+		Network:           "eip155:8453",
+		Amount:            "1000",
+		MaxAmountRequired: "1000",
+		Asset:             "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+		PayTo:             "0x1111111111111111111111111111111111111111",
+		Resource:          "https://resource.example.com/mcp",
+		MaxTimeoutSeconds: 300,
+	}
+}
+
+// TestPaymentRequiredParsesAsTheSDKsOwnV2Type is the assertion that matters: a
+// client using the official types must be able to read what we emit. Anything
+// weaker just re-describes our own struct back to itself.
+func TestPaymentRequiredParsesAsTheSDKsOwnV2Type(t *testing.T) {
+	raw, err := x402.BuildPaymentRequiredHeaderValue(requirement())
+	if err != nil {
+		t.Fatalf("BuildPaymentRequiredHeaderValue: %v", err)
+	}
+
+	var got sdktypes.PaymentRequired
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("the header does not parse as the SDK's PaymentRequired: %v\nraw=%s", err, raw)
+	}
+
+	if got.X402Version != 2 {
+		t.Fatalf("x402Version = %d, want 2", got.X402Version)
+	}
+	if got.Resource == nil {
+		t.Fatalf("no top-level resource; a v2 client reads the resource from there, and the adapter binds proofs to it\nraw=%s", raw)
+	}
+	if got.Resource.URL != "https://resource.example.com/mcp" {
+		t.Fatalf("resource.url = %q, want the configured resource", got.Resource.URL)
+	}
+	if len(got.Accepts) != 1 {
+		t.Fatalf("accepts has %d entries, want 1", len(got.Accepts))
+	}
+	entry := got.Accepts[0]
+	if entry.Scheme != "exact" || entry.Network != "eip155:8453" {
+		t.Fatalf("accepts[0] scheme/network = %q/%q", entry.Scheme, entry.Network)
+	}
+	if entry.Amount != "1000" || entry.PayTo == "" || entry.Asset == "" {
+		t.Fatalf("accepts[0] lost a required field: %+v", entry)
+	}
+	if entry.MaxTimeoutSeconds != 300 {
+		t.Fatalf("accepts[0] maxTimeoutSeconds = %d, want 300", entry.MaxTimeoutSeconds)
+	}
+}
+
+// TestAcceptEntriesCarryNoResource pins the half that was wrong. The SDK's
+// PaymentRequirements has no such field, so a `resource` inside an accept entry
+// is not merely redundant: it is not part of the format being advertised.
+func TestAcceptEntriesCarryNoResource(t *testing.T) {
+	raw, err := x402.BuildPaymentRequiredHeaderValue(requirement())
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	var envelope struct {
+		Accepts []map[string]interface{} `json:"accepts"`
+	}
+	if err := json.Unmarshal([]byte(raw), &envelope); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(envelope.Accepts) != 1 {
+		t.Fatalf("accepts has %d entries", len(envelope.Accepts))
+	}
+	if _, present := envelope.Accepts[0]["resource"]; present {
+		t.Fatalf("accepts[0] still carries a resource field: %v", envelope.Accepts[0])
+	}
+}
+
+// TestOurNonStandardFieldTravelsInExtra: `maxAmountRequired` is this adapter's
+// field, not the standard's — the canonical spec never mentions it — but the
+// request fingerprint the replay ledger binds to includes it, so it has to stay
+// on the wire. `extra` is the SDK's own escape hatch for exactly this.
+func TestOurNonStandardFieldTravelsInExtra(t *testing.T) {
+	raw, err := x402.BuildPaymentRequiredHeaderValue(requirement())
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	var envelope struct {
+		Accepts []struct {
+			MaxAmountRequired interface{}            `json:"maxAmountRequired"`
+			Extra             map[string]interface{} `json:"extra"`
+		} `json:"accepts"`
+	}
+	if err := json.Unmarshal([]byte(raw), &envelope); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	entry := envelope.Accepts[0]
+	if entry.MaxAmountRequired != nil {
+		t.Fatalf("maxAmountRequired is still a top-level accept field: %v", entry.MaxAmountRequired)
+	}
+	if got := entry.Extra["maxAmountRequired"]; got != "1000" {
+		t.Fatalf("extra.maxAmountRequired = %v, want \"1000\"", got)
+	}
+}
+
+// TestAMissingResourceIsRefusedRatherThanAdvertisedEmpty: the resource is
+// REQUIRED, not optional — `Validate` rejects a requirement without one, so a
+// challenge can never advertise an empty resource. That is the stronger
+// guarantee: the adapter binds proofs to this value, and a client binding to ""
+// would be worse than no challenge at all.
+//
+// The nil guard in the builder is therefore defensive rather than reachable,
+// and this test records which of the two actually holds the line.
+func TestAMissingResourceIsRefusedRatherThanAdvertisedEmpty(t *testing.T) {
+	req := requirement()
+	req.Resource = ""
+	if _, err := x402.BuildPaymentRequiredHeaderValue(req); err == nil {
+		t.Fatal("a requirement with no resource produced a challenge; it must be refused")
+	}
+}


### PR DESCRIPTION
Closes #700.

The `PAYMENT-REQUIRED` header advertised `x402Version: 2` while emitting a shape that is **not** a v2 `PaymentRequired`: `resource` sat inside each accept entry as a bare string, and there was no top-level resource object at all.

The v2 SDK **already vendored in this module** defines `PaymentRequired` as `x402Version` + a first-class `resource *ResourceInfo` + `accepts []PaymentRequirements`, whose entries carry no `resource` field. SPEC §18 requires the standard shape in as many words: *"first-class `resource` + `accepts[]` with `maxTimeoutSeconds`"*. Conformance, so no spec PR.

## Why it matters beyond tidiness

The adapter binds a proof to the challenge `resource` and refuses one issued for another route (#699, just merged). So **the field a client must read in order to comply was not where the format says it is** — a client parsing the header with the SDK's own types saw no resource whatsoever.

## `maxAmountRequired`

Moved into the entry's `extra`. It is this adapter's field rather than the standard's — the canonical spec never mentions it — but the request fingerprint the replay ledger binds to includes it, so it stays on the wire. `extra` is the SDK's own escape hatch for exactly that.

## Nothing was asserting the shape

That is why the wrong one shipped, and why **this fix passed the entire existing suite untouched**: every x402 test checks status codes, header presence and settlement behaviour, never the object itself.

The new tests parse the header with the SDK's `PaymentRequired` type. A client using the official types being able to read what we emit is the only assertion that means anything here — a hand-rolled struct comparison would just describe our own code back to itself.

## One test I wrote and replaced

I asserted that an unconfigured resource is omitted from the object. `Validate` **requires** a resource, so that state is unreachable. The test now pins what actually holds the line — such a requirement is refused outright — and the builder's nil guard is documented as defensive rather than load-bearing.

`make check` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated payment requirement headers to use the v2 format.
  - Added support for a top-level resource URL.
  - Preserved additional payment details through the `extra` field.
- **Bug Fixes**
  - Removed resource data from individual payment options.
  - Empty or missing resources are no longer advertised in generated headers.
- **Tests**
  - Added coverage confirming v2 compatibility and correct handling of resources and additional payment fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->