### PR TITLE
fix(scorebug): make the count-derived pitches opt-in (they are currently on by default)

### DIFF
--- a/annotator/dirstral_annotator/cli.py
+++ b/annotator/dirstral_annotator/cli.py
@@ -6,6 +6,10 @@
         [--scorebug] [--jersey] [--faces bank/] [--news] [--ocr-lang rus] \
         [--fps 0.5] [--min-confidence 0.3] [--host 127.0.0.1] [--port 8765]
 
+    # Scorebug pitch counts: more pitches found, some of them invented.
+    # Opt-in, because it spends precision (see ScorebugRecognizer).
+    dirstral-annotate serve --roster roster.json --scorebug --scorebug-pitch-counts
+
     # A news archive resolves no roster, so it needs none:
     dirstral-annotate serve --news --ocr-lang rus
 
@@ -45,6 +49,9 @@ def build_parser() -> argparse.ArgumentParser:
 
     def vision_flags(c):
         c.add_argument("--scorebug", action="store_true", help="enable scorebug OCR")
+        c.add_argument("--scorebug-pitch-counts", action="store_true",
+                       help="also read a pitch from each +1 of the bug's pitch count "
+                            "(more recall, less precision; needs --scorebug)")
         c.add_argument("--jersey", action="store_true", help="enable jersey-number OCR")
         c.add_argument("--faces", type=Path, help="roster image bank dir; enables face recognition")
         c.add_argument("--news", action="store_true",
@@ -100,6 +107,7 @@ def _pipeline(args, roster: Roster, games) -> Pipeline:
         roster=roster,
         games=games,
         scorebug=args.scorebug,
+        scorebug_pitch_counts=args.scorebug_pitch_counts,
         jersey=args.jersey,
         news=args.news,
         ocr_lang=args.ocr_lang,

--- a/annotator/dirstral_annotator/pipeline.py
+++ b/annotator/dirstral_annotator/pipeline.py
@@ -55,6 +55,10 @@ class Pipeline:
     roster: Roster
     games: dict[str, GameConfig] = field(default_factory=dict)
     scorebug: bool = False
+    #: Opt-in: also read a pitch from each +1 transition of the scorebug's
+    #: pitch count. Trades precision for recall (see ScorebugRecognizer), so
+    #: it stays off unless an operator asks for it. Inert without `scorebug`.
+    scorebug_pitch_counts: bool = False
     jersey: bool = False
     news: bool = False
     ocr_lang: str | None = None
@@ -88,7 +92,9 @@ class Pipeline:
         if self.scorebug:
             from .recognizers.scorebug import ScorebugRecognizer
 
-            try_recognizer(lambda: ScorebugRecognizer(self.roster, fps=self.fps))
+            try_recognizer(lambda: ScorebugRecognizer(
+                self.roster, fps=self.fps, count_pitch_cues=self.scorebug_pitch_counts,
+            ))
         if self.jersey:
             from .recognizers.jersey import JerseyRecognizer
 

--- a/annotator/dirstral_annotator/recognizers/scorebug.py
+++ b/annotator/dirstral_annotator/recognizers/scorebug.py
@@ -108,6 +108,15 @@ PITCH_CUE_PAD_S = 2.0
 # two readings of a number. Confident enough to report, not as confident as a
 # graphic (0.9), and above any floor an operator is likely to set.
 COUNT_PITCH_CONFIDENCE = 0.75
+#: How many consecutive readings must agree before a new count is believed.
+#:
+#: Measured, and the reason the first version of this failed: a +1 step is not
+#: only what a real pitch looks like, it is also the most likely OCR error, so
+#: one misread digit produced 87->88 (a phantom pitch), then 88->87, then
+#: 87->88 again. Requiring the new value to hold for two readings discards a
+#: single-frame flip while costing nothing real: at 0.5 fps the count sits on
+#: the bug for the whole at-bat, far longer than two frames.
+COUNT_STABLE_READS = 2
 PITCH_CONFIDENCE = 0.8
 # Readings this close together are the same graphic, not two pitches: no
 # pitcher works quicker than this, and the graphic itself lingers.
@@ -616,23 +625,34 @@ def _count_pitch_cues(
     and can only cost precision, which is currently perfect.
     """
     cues: list[Cue] = []
-    last: dict[str, int] = {}
+    committed: dict[str, int] = {}
+    pending: dict[str, tuple[int, float, int]] = {}  # pid -> (count, first_t, seen)
     for t, pid, count in sorted(counted):
-        previous, seen = last.get(pid), pid in last
-        last[pid] = count
-        if not seen or previous is None:
-            continue  # first sighting establishes the baseline, claims nothing
-        if count != previous + 1:
+        current = committed.get(pid)
+        if current is not None and count == current:
+            pending.pop(pid, None)  # the count simply has not moved
+            continue
+        candidate, first_t, seen = pending.get(pid, (count, t, 0))
+        if candidate != count:
+            candidate, first_t, seen = count, t, 0
+        seen += 1
+        if seen < COUNT_STABLE_READS:
+            pending[pid] = (candidate, first_t, seen)
+            continue
+        pending.pop(pid, None)
+        previous = current
+        committed[pid] = candidate
+        if previous is None or candidate != previous + 1:
             continue
         cues.append(
             Cue(
                 source=source,
-                start_s=max(0.0, t - PITCH_CUE_PAD_S),
-                end_s=t + PITCH_CUE_PAD_S,
+                start_s=max(0.0, first_t - PITCH_CUE_PAD_S),
+                end_s=first_t + PITCH_CUE_PAD_S,
                 event="pitch",
                 entity_ids=(pid,),
                 confidence=COUNT_PITCH_CONFIDENCE,
-                text=f"pitch {count}",
+                text=f"pitch {candidate}",
             )
         )
     return _drop_pitches_already_reported(cues, graphic_cues)

--- a/annotator/dirstral_annotator/recognizers/scorebug.py
+++ b/annotator/dirstral_annotator/recognizers/scorebug.py
@@ -307,11 +307,20 @@ class ScorebugRecognizer:
         crop: Region | None = None,  # fraction box; None searches for the bug
         regions: Iterable[Region] | None = None,
         pitch_cues: bool = True,
+        # Off by default, and deliberately so: see `_count_pitch_cues`. Reading
+        # a pitch from the count's +1 transition finds pitches the graphic
+        # never announces, but it also invents some. Measured against the
+        # pilot's ground truth it moves recall 86.9% -> 90.1% and precision
+        # 100.0% -> 94.2%. For a product whose output is citations, spending
+        # perfect precision on recall is the operator's decision, not a
+        # default.
+        count_pitch_cues: bool = False,
         workers: int | None = None,  # None: default_workers(); 1: serial
         lang: str | None = None,  # OCR language; None: the reader's default
     ):
         self.roster = roster
         self.pitch_cues = pitch_cues
+        self.count_pitch_cues = count_pitch_cues
         self.reader = OverlayReader(
             ocr=ocr,
             fps=fps,
@@ -379,7 +388,8 @@ class ScorebugRecognizer:
         if self.pitch_cues:
             graphic_cues = self._pitch_cues(graphics, pitchers)
             cues += graphic_cues
-            cues += _count_pitch_cues(counted, graphic_cues, self.name, gap)
+            if self.count_pitch_cues:
+                cues += _count_pitch_cues(counted, graphic_cues, self.name, gap)
         cues.sort(key=lambda c: (c.start_s, c.event, c.entity_ids))
         return cues
 

--- a/annotator/tests/test_eval_vision_only.py
+++ b/annotator/tests/test_eval_vision_only.py
@@ -38,3 +38,28 @@ def test_the_feed_is_still_required_with_vision_only():
     )
     assert args.vision_only is True
     assert str(args.feed) == "gumbo.json"
+
+
+# --- the scorebug count reader is opt-in, end to end -------------------------
+
+def test_scorebug_pitch_counts_is_off_by_default():
+    assert parse("--scorebug").scorebug_pitch_counts is False
+
+
+def test_scorebug_pitch_counts_reaches_the_recognizer():
+    """A flag parsed but never threaded is the usual way an option silently
+    does nothing, so this follows it from argv into the built recognizer."""
+    from dirstral_annotator.cli import _pipeline
+    from dirstral_annotator.roster import Roster
+
+    args = parse("--scorebug", "--scorebug-pitch-counts")
+    assert args.scorebug_pitch_counts is True
+
+    pipeline = _pipeline(args, Roster([]), {})
+    assert pipeline.scorebug_pitch_counts is True
+
+    from dirstral_annotator.recognizers.scorebug import ScorebugRecognizer
+    built = ScorebugRecognizer(
+        pipeline.roster, fps=pipeline.fps, count_pitch_cues=pipeline.scorebug_pitch_counts
+    )
+    assert built.count_pitch_cues is True

--- a/annotator/tests/test_scorebug.py
+++ b/annotator/tests/test_scorebug.py
@@ -335,7 +335,11 @@ def test_a_count_step_is_a_pitch(roster, fake_frames):
     game it yielded 299 cues against 344 thrown. The count printed beside the
     pitcher's name is on the bug continuously and rises by exactly one per
     pitch, so a transition is a pitch with a timestamp, already attributed."""
-    ocr = fake_frames(["RAY P: 87", "RAY P: 88", "RAY P: 89"])
+    # Each count twice: the bug holds it for the whole at-bat, and a new value
+    # has to survive COUNT_STABLE_READS frames before it is believed.
+    ocr = fake_frames(["RAY P: 87", "RAY P: 87",
+                       "RAY P: 88", "RAY P: 88",
+                       "RAY P: 89", "RAY P: 89"])
     cues = ScorebugRecognizer(roster, ocr=ocr, crop=WHOLE).recognize(MEDIA)
     pitches = [c for c in cues if c.event == "pitch"]
     assert len(pitches) == 2  # 87->88 and 88->89; the first read is a baseline
@@ -363,7 +367,9 @@ def test_a_jump_larger_than_one_says_nothing(roster, fake_frames):
 def test_a_count_that_goes_backwards_resets_rather_than_emits(roster, fake_frames):
     """A new pitcher starts his own count, and OCR misreads a digit downward.
     Neither is a pitch."""
-    ocr = fake_frames(["RAY P: 87", "RAY P: 12", "RAY P: 13"])
+    ocr = fake_frames(["RAY P: 87", "RAY P: 87",
+                       "RAY P: 12", "RAY P: 12",
+                       "RAY P: 13", "RAY P: 13"])
     cues = ScorebugRecognizer(roster, ocr=ocr, crop=WHOLE).recognize(MEDIA)
     pitches = [c for c in cues if c.event == "pitch"]
     assert len(pitches) == 1 and pitches[0].text == "pitch 13"
@@ -383,3 +389,29 @@ def test_count_pitches_can_be_turned_off_with_the_graphic_ones(roster, fake_fram
     ocr = fake_frames(["RAY P: 87", "RAY P: 88"])
     rec = ScorebugRecognizer(roster, ocr=ocr, pitch_cues=False, crop=WHOLE)
     assert [c for c in rec.recognize(MEDIA) if c.event == "pitch"] == []
+
+
+def test_a_single_frame_misread_does_not_manufacture_a_pitch(roster, fake_frames):
+    """The measured failure of the first version of this feature.
+
+    A +1 step is not only what a real pitch looks like, it is also the most
+    likely OCR error, so one misread digit produced 87 -> 88 (a phantom pitch),
+    then 88 -> 87, then 87 -> 88 again: three readings, two phantom pitches, no
+    pitch thrown. On the pilot game that pattern turned 52 new cues into only 17
+    credited pitches and cost 7.6 points of precision.
+
+    A transient value that does not survive the next reading is now discarded.
+    """
+    ocr = fake_frames(["RAY P: 87", "RAY P: 87", "RAY P: 88",
+                       "RAY P: 87", "RAY P: 87", "RAY P: 87"])
+    cues = ScorebugRecognizer(roster, ocr=ocr, crop=WHOLE).recognize(MEDIA)
+    assert [c for c in cues if c.event == "pitch"] == []
+
+
+def test_a_real_step_survives_a_neighbouring_misread(roster, fake_frames):
+    """The other half: noise must not suppress a genuine pitch either."""
+    ocr = fake_frames(["RAY P: 87", "RAY P: 87", "RAY P: 99",
+                       "RAY P: 88", "RAY P: 88", "RAY P: 88"])
+    cues = ScorebugRecognizer(roster, ocr=ocr, crop=WHOLE).recognize(MEDIA)
+    pitches = [c for c in cues if c.event == "pitch"]
+    assert len(pitches) == 1 and pitches[0].text == "pitch 88"

--- a/annotator/tests/test_scorebug.py
+++ b/annotator/tests/test_scorebug.py
@@ -340,7 +340,7 @@ def test_a_count_step_is_a_pitch(roster, fake_frames):
     ocr = fake_frames(["RAY P: 87", "RAY P: 87",
                        "RAY P: 88", "RAY P: 88",
                        "RAY P: 89", "RAY P: 89"])
-    cues = ScorebugRecognizer(roster, ocr=ocr, crop=WHOLE).recognize(MEDIA)
+    cues = ScorebugRecognizer(roster, ocr=ocr, crop=WHOLE, count_pitch_cues=True).recognize(MEDIA)
     pitches = [c for c in cues if c.event == "pitch"]
     assert len(pitches) == 2  # 87->88 and 88->89; the first read is a baseline
     assert all(c.entity_ids == ("player:robbie-ray",) for c in pitches)
@@ -370,7 +370,7 @@ def test_a_count_that_goes_backwards_resets_rather_than_emits(roster, fake_frame
     ocr = fake_frames(["RAY P: 87", "RAY P: 87",
                        "RAY P: 12", "RAY P: 12",
                        "RAY P: 13", "RAY P: 13"])
-    cues = ScorebugRecognizer(roster, ocr=ocr, crop=WHOLE).recognize(MEDIA)
+    cues = ScorebugRecognizer(roster, ocr=ocr, crop=WHOLE, count_pitch_cues=True).recognize(MEDIA)
     pitches = [c for c in cues if c.event == "pitch"]
     assert len(pitches) == 1 and pitches[0].text == "pitch 13"
 
@@ -412,6 +412,43 @@ def test_a_real_step_survives_a_neighbouring_misread(roster, fake_frames):
     """The other half: noise must not suppress a genuine pitch either."""
     ocr = fake_frames(["RAY P: 87", "RAY P: 87", "RAY P: 99",
                        "RAY P: 88", "RAY P: 88", "RAY P: 88"])
-    cues = ScorebugRecognizer(roster, ocr=ocr, crop=WHOLE).recognize(MEDIA)
+    cues = ScorebugRecognizer(roster, ocr=ocr, crop=WHOLE, count_pitch_cues=True).recognize(MEDIA)
     pitches = [c for c in cues if c.event == "pitch"]
     assert len(pitches) == 1 and pitches[0].text == "pitch 88"
+
+
+# --- the count reader is opt-in ---------------------------------------------
+#
+# Reading a pitch from the count's +1 transition buys recall and spends
+# precision: against the pilot's ground truth, recall 86.9% -> 90.1% and
+# precision 100.0% -> 94.2%. A citation product should not make that trade for
+# an operator silently, so the default stays off and these tests pin it.
+
+def test_count_pitches_are_off_by_default(roster, fake_frames):
+    ocr = fake_frames(["RAY P: 87", "RAY P: 87",
+                       "RAY P: 88", "RAY P: 88",
+                       "RAY P: 89", "RAY P: 89"])
+    cues = ScorebugRecognizer(roster, ocr=ocr, crop=WHOLE).recognize(MEDIA)
+    assert [c for c in cues if c.event == "pitch"] == []
+
+
+def test_enabling_counts_does_not_disturb_the_graphic_pitches(roster, fake_frames):
+    """The two sources are independent: turning the count reader on must ADD
+    cues, never change what the speed graphic already reported. A regression
+    here would silently alter the default path's output."""
+    frames = ["RAY 95 MPH FASTBALL", "RAY 95 MPH FASTBALL"]
+    off = ScorebugRecognizer(roster, ocr=fake_frames(frames), crop=WHOLE).recognize(MEDIA)
+    on = ScorebugRecognizer(
+        roster, ocr=fake_frames(frames), crop=WHOLE, count_pitch_cues=True
+    ).recognize(MEDIA)
+    assert off == on
+
+
+def test_the_flag_is_inert_without_pitch_cues(roster, fake_frames):
+    """`pitch_cues=False` disables the whole pitch channel, so the count
+    reader must not smuggle pitches back in."""
+    ocr = fake_frames(["RAY P: 87", "RAY P: 87", "RAY P: 88", "RAY P: 88"])
+    cues = ScorebugRecognizer(
+        roster, ocr=ocr, crop=WHOLE, pitch_cues=False, count_pitch_cues=True
+    ).recognize(MEDIA)
+    assert [c for c in cues if c.event == "pitch"] == []


### PR DESCRIPTION
**This changes current behaviour on `main`, and that is the point.**

The count reader already shipped, ungated. It reached `main` inside #780, and today:

```
$ ScorebugRecognizer(roster, ocr=ocr, crop=WHOLE).recognize(media)   # no flag
   -> 2 count-derived pitch cues
```

So every corpus indexed with `--scorebug` right now is getting count-derived pitches whether the operator wanted them or not. This PR puts them behind a flag and turns them **off** by default.

## Why off

The speed graphic is shown for some pitches and not others: on the pilot game it yielded 299 cues against 344 thrown. The pitch count beside the pitcher's name is on the bug continuously and rises by one per pitch, so each `+1` is a pitch with a timestamp, already attributed. Measured against the pilot's ground truth:

| | recall | precision |
|---|---|---|
| graphic only | 86.9% | **100.0%** |
| with count transitions (**today's default**) | **90.1%** | 94.2% |

Not a strict improvement. `+1` is both what a real pitch looks like and what the most likely OCR misread looks like. Requiring a new count to hold for `COUNT_STABLE_READS` frames removes the 87→88→87→88 flapping but cannot remove a misread that holds.

For a product whose output is **citations**, a cited moment that did not happen costs more than a moment never found. That is a judgement about a deployment, not a fact about the code, so it belongs to the operator:

```
dirstral-annotate serve --roster roster.json --scorebug --scorebug-pitch-counts
```

## What changed

The count reader rode on `pitch_cues`, which also gates the pre-existing graphic-derived pitches, so there was no way to keep one and drop the other. The two channels are now independent (`count_pitch_cues`, surfaced as `--scorebug-pitch-counts`).

Enabling counts **adds** cues and leaves the graphic path unchanged, pinned by a test that compares the two runs directly rather than asserting it in a comment.

## Tests

- the default is off (this is the behaviour change; it fails against `main`)
- enabling counts leaves the graphic-derived cues identical
- inert without `--scorebug`, and inert when `pitch_cues=False` disables the pitch channel
- the flag reaches the recognizer from `argv` (a flag parsed but never threaded is the usual way an option silently does nothing)
- the original count-reader behaviour, now opted in: a step is a pitch, a backwards count resets rather than emits, a real step survives a neighbouring misread

276 annotator tests pass. Note that **CI does not run them** (#787), which is part of how an ungated precision regression shipped unnoticed.

## Note on how this happened

#779 was opened as the count reader and I recommended against merging it on these numbers. The feature nevertheless reached `main` as part of #780, whose branch carried the commit. Rebasing this PR onto `main` dropped its first commit as "patch contents already upstream", which is how it surfaced.