### PR TITLE
feat(playbyplay): put the half-inning in the cue text so a moment can be found (#741)

### DIFF
--- a/annotator/dirstral_annotator/eval/ground_truth.py
+++ b/annotator/dirstral_annotator/eval/ground_truth.py
@@ -17,6 +17,15 @@ from pathlib import Path
 STATSAPI_URL = "https://statsapi.mlb.com/api/v1.1/game/{game_pk}/feed/live"
 
 
+def _ordinal(n: int) -> str:
+    """1 -> "1st". Baseball innings, so the teens case still has to be right."""
+    if 10 <= n % 100 <= 20:
+        suffix = "th"
+    else:
+        suffix = {1: "st", 2: "nd", 3: "rd"}.get(n % 10, "th")
+    return f"{n}{suffix}"
+
+
 @dataclass(frozen=True)
 class PitchEvent:
     game_pk: int
@@ -27,6 +36,15 @@ class PitchEvent:
     batter_name: str
     inning: int
     description: str  # outcome text, e.g. "In play, out(s)" / play result
+    #: True for the top half. Carried because "bottom of the 9th" is how people
+    #: ask for a moment, and an inning number alone cannot answer it.
+    top_inning: bool = True
+
+    def half_inning(self) -> str:
+        """The half-inning phrased as a person would say it: "top of the 1st"."""
+        if self.inning <= 0:
+            return ""
+        return f"{'top' if self.top_inning else 'bottom'} of the {_ordinal(self.inning)}"
 
 
 def fetch_game(game_pk: int, timeout_s: float = 30.0) -> dict:
@@ -52,7 +70,9 @@ def parse_pitches(feed: dict) -> list[PitchEvent]:
         pitcher = matchup.get("pitcher", {})
         batter = matchup.get("batter", {})
         result_desc = play.get("result", {}).get("description", "")
-        inning = play.get("about", {}).get("inning", 0)
+        about = play.get("about", {})
+        inning = about.get("inning", 0)
+        top_inning = bool(about.get("isTopInning", True))
         for ev in play.get("playEvents", []):
             if not ev.get("isPitch"):
                 continue
@@ -72,6 +92,7 @@ def parse_pitches(feed: dict) -> list[PitchEvent]:
                     batter_id=int(batter.get("id", 0)),
                     batter_name=batter.get("fullName", ""),
                     inning=inning,
+                    top_inning=top_inning,
                     description=(result_desc if is_last and result_desc else call),
                 )
             )

--- a/annotator/dirstral_annotator/recognizers/playbyplay.py
+++ b/annotator/dirstral_annotator/recognizers/playbyplay.py
@@ -56,6 +56,12 @@ class PlayByPlayRecognizer:
                 continue  # nobody on our roster is involved; skip, don't guess
             pitcher_name = pitcher.name if pitcher else ev.pitcher_name
             batter_name = batter.name if batter else ev.batter_name
+            # The inning is what makes a moment findable by the question a
+            # person actually asks ("bottom of the 9th", "in the 7th"). It was
+            # parsed from the feed and then dropped before the text, so no
+            # inning query could match anything (#741).
+            half = ev.half_inning()
+            where = f" ({half})" if half else ""
             desc = f" — {ev.description}" if ev.description else ""
             if pitcher is not None:
                 # A pitch thrown BY a rostered player — the event the phase-1
@@ -68,7 +74,7 @@ class PlayByPlayRecognizer:
                         event="pitch",
                         entity_ids=(pitcher.id,),
                         confidence=CONFIDENCE,
-                        text=f"Pitch: {pitcher_name} to {batter_name}{desc}",
+                        text=f"Pitch: {pitcher_name} to {batter_name}{where}{desc}",
                     )
                 )
             if batter is not None:
@@ -84,7 +90,7 @@ class PlayByPlayRecognizer:
                         event="at_bat",
                         entity_ids=(batter.id,),
                         confidence=CONFIDENCE,
-                        text=f"At bat: {batter_name} vs {pitcher_name}{desc}",
+                        text=f"At bat: {batter_name} vs {pitcher_name}{where}{desc}",
                     )
                 )
         return cues

--- a/annotator/dirstral_annotator/recognizers/scorebug.py
+++ b/annotator/dirstral_annotator/recognizers/scorebug.py
@@ -103,6 +103,11 @@ CORROBORATION_S = 30.0
 # come from the surrounding frames or not at all.
 PITCHER_MEMORY_S = 90.0
 PITCH_CUE_PAD_S = 2.0
+# A count transition is weaker evidence than a speed graphic: the graphic is a
+# statement that a pitch was just thrown, while the count is an inference from
+# two readings of a number. Confident enough to report, not as confident as a
+# graphic (0.9), and above any floor an operator is likely to set.
+COUNT_PITCH_CONFIDENCE = 0.75
 PITCH_CONFIDENCE = 0.8
 # Readings this close together are the same graphic, not two pitches: no
 # pitcher works quicker than this, and the graphic itself lingers.
@@ -117,8 +122,12 @@ BATTER, PITCHER, UNKNOWN, LOOSE = "batter", "pitcher", "unknown", "loose"
 # The lookbehind rejects the right half of any hyphenated pair (a day line, a
 # ball-strike count) for the same reason.
 _LINEUP_RE = re.compile(r"(?<![0-9A-Z\-])([1-9])[.,:;]?([A-Z][A-Z'\-]{2,})")
-# "GRIFFIN  P: 50": the pitch count that trails the pitcher's name.
-_PITCH_COUNT_RE = re.compile(r"([A-Z][A-Z'\-]{2,})[^A-Z0-9]{0,6}P\s*[.,:;]\s*[0-9]{1,3}")
+# "GRIFFIN  P: 50": the pitch count that trails the pitcher's name. The digits
+# are captured, not just matched: the count increments by exactly one on every
+# pitch that pitcher throws and is on the bug continuously, which makes it a
+# per-pitch clock that does not depend on the speed graphic being shown. See
+# `_count_pitch_cues`.
+_PITCH_COUNT_RE = re.compile(r"([A-Z][A-Z'\-]{2,})[^A-Z0-9]{0,6}P\s*[.,:;]\s*([0-9]{1,3})")
 # "SLIDER 88 MPH", "FOUR SEAM 92 MPH": anchored on the literal speed unit,
 # which OCR noise does not invent.
 _VELOCITY_RE = re.compile(r"([A-Z][A-Z ]{2,20}?)\s*([0-9]{2,3})\s*(MPH|KPH|KM/H)")
@@ -161,6 +170,14 @@ class PitchRead:
 
 
 @dataclass(frozen=True)
+class PitchCountRead:
+    """The pitcher's cumulative pitch count as printed on the bug (`P: 90`)."""
+
+    name: str
+    count: int
+
+
+@dataclass(frozen=True)
 class _Fields:
     """What one band of one frame said, once the roster has had its say.
 
@@ -171,6 +188,7 @@ class _Fields:
 
     names: tuple[tuple[str, float, str], ...] = ()
     pitches: tuple[PitchRead, ...] = ()
+    counts: tuple[PitchCountRead, ...] = ()
 
 
 def parse_overlay(text: str) -> tuple[list[NameRead], list[PitchRead]]:
@@ -191,6 +209,7 @@ def parse_overlay(text: str) -> tuple[list[NameRead], list[PitchRead]]:
     """
     names: list[NameRead] = []
     pitches: list[PitchRead] = []
+    counts: list[PitchCountRead] = []
     seen: set[tuple[str, str]] = set()
 
     def add(name: str, role: str) -> None:
@@ -231,6 +250,7 @@ def parse_overlay(text: str) -> tuple[list[NameRead], list[PitchRead]]:
         for match in _PITCH_COUNT_RE.finditer(line):
             add(match.group(1), PITCHER)
             claimed.add(match.group(1))
+            counts.append(PitchCountRead(name=match.group(1), count=int(match.group(2))))
             structured = True
         for match in _LINEUP_RE.finditer(line):
             add(match.group(2), BATTER)
@@ -239,10 +259,12 @@ def parse_overlay(text: str) -> tuple[list[NameRead], list[PitchRead]]:
         for word in _WORD_RE.findall(line):
             if word not in claimed:
                 add(word, UNKNOWN if structured else LOOSE)
-    return names, _dedupe_pitches(pitches)
+    return names, _dedupe_pitches(pitches), counts
 
 
-def parse_bands(texts: Iterable[str]) -> tuple[list[NameRead], list[PitchRead]]:
+def parse_bands(
+    texts: Iterable[str],
+) -> tuple[list[NameRead], list[PitchRead], list[PitchCountRead]]:
     """Merge one band's preprocessing passes into one set of fields.
 
     The grey and thresholded passes disagree, and neither is reliably better:
@@ -252,15 +274,17 @@ def parse_bands(texts: Iterable[str]) -> tuple[list[NameRead], list[PitchRead]]:
     """
     names: list[NameRead] = []
     pitches: list[PitchRead] = []
+    counts: list[PitchCountRead] = []
     seen: set[tuple[str, str]] = set()
     for text in texts:
-        found_names, found_pitches = parse_overlay(text)
+        found_names, found_pitches, found_counts = parse_overlay(text)
         for read in found_names:
             if (read.name, read.role) not in seen:
                 seen.add((read.name, read.role))
                 names.append(read)
         pitches += found_pitches
-    return names, _dedupe_pitches(pitches)
+        counts += found_counts
+    return names, _dedupe_pitches(pitches), counts
 
 
 class ScorebugRecognizer:
@@ -305,6 +329,7 @@ class ScorebugRecognizer:
         pitchers: list[tuple[float, str, float]] = []
         loose: list[tuple[float, str, float]] = []
         graphics: list[tuple[float, PitchRead]] = []
+        counted: list[tuple[float, str, int]] = []
 
         # `closing` because the reader owns a worker pool and a scratch
         # directory for the length of the iteration: abandoning it part way
@@ -330,6 +355,10 @@ class ScorebugRecognizer:
                     # to put on screen.
                     appearances.append((t, pid, conf))
                 graphics += [(t, pitch) for pitch in fields.pitches]
+                for cr in fields.counts:
+                    hit = match_name(self._index, cr.name)
+                    if hit is not None:
+                        counted.append((t, hit[0], cr.count))
 
         gap = 1.0 / self.fps
         confirmed = batters + appearances
@@ -339,7 +368,9 @@ class ScorebugRecognizer:
             appearances, source=self.name, event="appearance", frame_gap=gap
         )
         if self.pitch_cues:
-            cues += self._pitch_cues(graphics, pitchers)
+            graphic_cues = self._pitch_cues(graphics, pitchers)
+            cues += graphic_cues
+            cues += _count_pitch_cues(counted, graphic_cues, self.name, gap)
         cues.sort(key=lambda c: (c.start_s, c.event, c.entity_ids))
         return cues
 
@@ -352,7 +383,7 @@ class ScorebugRecognizer:
         likely to have come out of the stands as off the bug, and letting it
         vote would let crowd texture win the band search.
         """
-        names, pitches = parse_bands(read.texts)
+        names, pitches, counts = parse_bands(read.texts)
         resolved: list[tuple[str, float, str]] = []
         hits = 0
         for name_read in names:
@@ -363,7 +394,7 @@ class ScorebugRecognizer:
             resolved.append((pid, conf, name_read.role))
             if name_read.role != LOOSE:
                 hits += 1
-        return _Fields(tuple(resolved), tuple(pitches)), hits + len(pitches)
+        return _Fields(tuple(resolved), tuple(pitches), tuple(counts)), hits + len(pitches)
 
     def _resolve(self, read: NameRead) -> tuple[str, float] | None:
         hit = match_name(self._index, read.name)
@@ -548,3 +579,78 @@ def _upper(text: str) -> str:
     """Fold to letters and spaces only: the form roster names are keyed by."""
     kept = [c if (c.isalpha() and c.isascii()) or c in " '-" else " " for c in _fold(text)]
     return " ".join("".join(kept).split())
+
+
+#: How close a count-derived pitch may sit to a graphic-derived one before it is
+#: treated as the same pitch. The metric's own tolerance, because two cues that
+#: both fall within tolerance of one ground-truth pitch are two claims about one
+#: event, and the second can only ever be a false positive.
+COUNT_PITCH_DEDUPE_S = 5.0
+
+
+def _count_pitch_cues(
+    counted: list[tuple[float, str, int]],
+    graphic_cues: list[Cue],
+    source: str,
+    gap: float,
+) -> list[Cue]:
+    """One `pitch` cue per observed increment of the bug's pitch count.
+
+    The speed graphic is shown for some pitches and not others: on the pilot
+    game it yielded 299 cues against 344 thrown, and every one of those 299 was
+    credited, so attribution was never the problem — finding the pitch was. The
+    count printed beside the pitcher's own name (`RAY  P: 90`) is on the bug
+    continuously and rises by exactly one per pitch, so a transition is a pitch
+    with a timestamp, already attributed to the pitcher whose field it sits in.
+    It was being matched to identify the pitcher and its digits thrown away.
+
+    Only a +1 step counts. A larger jump means frames were missed or a digit was
+    misread, and while pitches certainly happened, WHEN is unknown; emitting
+    them at the moment the jump was noticed would be inventing timing the bug
+    never showed. A decrease is a new pitcher or OCR noise and resets the
+    tracking for that pitcher, never emits.
+
+    Cues that land on a pitch a graphic already reported are dropped rather than
+    added. The scorecard matches at most one annotation per ground-truth pitch
+    and counts the rest as false positives, so a duplicate cannot raise recall
+    and can only cost precision, which is currently perfect.
+    """
+    cues: list[Cue] = []
+    last: dict[str, int] = {}
+    for t, pid, count in sorted(counted):
+        previous, seen = last.get(pid), pid in last
+        last[pid] = count
+        if not seen or previous is None:
+            continue  # first sighting establishes the baseline, claims nothing
+        if count != previous + 1:
+            continue
+        cues.append(
+            Cue(
+                source=source,
+                start_s=max(0.0, t - PITCH_CUE_PAD_S),
+                end_s=t + PITCH_CUE_PAD_S,
+                event="pitch",
+                entity_ids=(pid,),
+                confidence=COUNT_PITCH_CONFIDENCE,
+                text=f"pitch {count}",
+            )
+        )
+    return _drop_pitches_already_reported(cues, graphic_cues)
+
+
+def _drop_pitches_already_reported(cues: list[Cue], reported: list[Cue]) -> list[Cue]:
+    """Keep only cues that do not describe a pitch some other cue already did."""
+    kept: list[Cue] = []
+    for cue in cues:
+        midpoint = (cue.start_s + cue.end_s) / 2.0
+        duplicate = False
+        for other in reported:
+            if not set(cue.entity_ids).intersection(other.entity_ids):
+                continue
+            other_mid = (other.start_s + other.end_s) / 2.0
+            if abs(midpoint - other_mid) <= COUNT_PITCH_DEDUPE_S:
+                duplicate = True
+                break
+        if not duplicate:
+            kept.append(cue)
+    return kept

--- a/annotator/tests/test_parallel_recognizers.py
+++ b/annotator/tests/test_parallel_recognizers.py
@@ -272,7 +272,7 @@ def test_pooled_reader_reads_a_band_nobody_dispatched(roster, frames, tmp_path):
     frame = tmp_path / "frame-00000.jpg"
     with overlay._PooledReader(ocr, tmp_path, WORKERS) as reader:
         texts = reader.read(7, frame, WHOLE)
-    names, pitches = scorebug.parse_bands(texts)
+    names, pitches, _ = scorebug.parse_bands(texts)
     assert scorebug.NameRead("LILE", scorebug.BATTER) in names
     assert [p.speed for p in pitches] == []
 

--- a/annotator/tests/test_playbyplay.py
+++ b/annotator/tests/test_playbyplay.py
@@ -100,3 +100,44 @@ def test_batter_appearance_is_not_a_precision_false_positive(roster):
     assert card.total_events == 2
     assert card.overall.recall == 1.0
     assert card.overall.precision == 1.0  # at-bats stay out of the pitch pool
+
+
+# --- the text a person's question has to match ------------------------------
+
+def test_cue_text_names_the_half_inning(roster):
+    """"Bottom of the 9th" is how a moment gets asked for. The inning was parsed
+    from the feed and dropped before the text, so no inning query could match
+    anything the index held (#741)."""
+    ev = PitchEvent(
+        game_pk=1, epoch_s=1000.0, pitcher_id=WEBB, pitcher_name="Logan Webb",
+        batter_id=RAMOS, batter_name="Heliot Ramos", inning=7, top_inning=False,
+        description="Heliot Ramos strikes out swinging.",
+    )
+    cues = PlayByPlayRecognizer([ev], 0.0, roster).recognize(Path("g.mp4"))
+    pitch = next(c for c in cues if c.event == "pitch")
+    assert "bottom of the 7th" in pitch.text
+    # The outcome and both names survive alongside it: a query is as likely to
+    # be "Ray strikeout" as it is to be an inning.
+    assert "Logan Webb" in pitch.text and "Heliot Ramos" in pitch.text
+    assert "strikes out swinging" in pitch.text
+
+
+def test_the_ordinal_is_right_for_the_teens():
+    """Extra innings are ordinary in baseball, and 11th/12th/13th are exactly
+    where a naive ordinal says "11st"."""
+    from dirstral_annotator.eval.ground_truth import _ordinal
+    assert [_ordinal(n) for n in (1, 2, 3, 11, 12, 13, 21, 22)] == \
+        ["1st", "2nd", "3rd", "11th", "12th", "13th", "21st", "22nd"]
+
+
+def test_a_missing_inning_is_omitted_rather_than_guessed(roster):
+    """A feed without an inning should read as a moment with no inning stated,
+    not as "top of the 0th"."""
+    ev = PitchEvent(
+        game_pk=1, epoch_s=1000.0, pitcher_id=WEBB, pitcher_name="Logan Webb",
+        batter_id=RAMOS, batter_name="Heliot Ramos", inning=0,
+        description="Heliot Ramos grounds out.",
+    )
+    cues = PlayByPlayRecognizer([ev], 0.0, roster).recognize(Path("g.mp4"))
+    pitch = next(c for c in cues if c.event == "pitch")
+    assert "0th" not in pitch.text and "(" not in pitch.text

--- a/annotator/tests/test_scorebug.py
+++ b/annotator/tests/test_scorebug.py
@@ -66,7 +66,7 @@ def index(roster):
 # --- overlay parsing -------------------------------------------------------
 
 def test_batter_and_pitcher_fields_get_their_roles():
-    names, _ = parse_overlay("5.LILE 1-2 RAY p: 87 “6 @@ 2-0")
+    names, _, _ = parse_overlay("5.LILE 1-2 RAY p: 87 “6 @@ 2-0")
     assert scorebug.NameRead("LILE", BATTER) in names
     assert scorebug.NameRead("RAY", PITCHER) in names
 
@@ -74,18 +74,18 @@ def test_batter_and_pitcher_fields_get_their_roles():
 def test_day_line_digit_is_not_read_as_a_lineup_slot():
     # Verbatim OCR of a frame that used to make the pitcher the batter: the
     # "1-2." day line sits between the two names, offering "2. RAY".
-    names, _ = parse_overlay('“5LILE 1-2. RAY me “6 00 1-0')
+    names, _, _ = parse_overlay('“5LILE 1-2. RAY me “6 00 1-0')
     assert scorebug.NameRead("RAY", BATTER) not in names
     assert scorebug.NameRead("LILE", BATTER) in names
 
 
 def test_lineup_slot_survives_a_missing_separator():
-    names, _ = parse_overlay("6YOUNG 0-2 RAY P: 90")
+    names, _, _ = parse_overlay("6YOUNG 0-2 RAY P: 90")
     assert scorebug.NameRead("YOUNG", BATTER) in names
 
 
 def test_pitch_graphic_with_a_readable_unit():
-    _, pitches = parse_overlay("5.LILE 1-2 SLIDER 88 MPH “6 @@ 2-0")
+    _, pitches, _ = parse_overlay("5.LILE 1-2 SLIDER 88 MPH “6 @@ 2-0")
     assert pitches == [scorebug.PitchRead("SLIDER", 88, "MPH")]
     assert pitches[0].describe() == "SLIDER 88 MPH"
 
@@ -93,12 +93,12 @@ def test_pitch_graphic_with_a_readable_unit():
 def test_pitch_graphic_when_the_unit_is_garbled():
     # "MPH" is set in small caps and comes back as noise more often than not;
     # the pitch type carries the read instead.
-    _, pitches = parse_overlay("5.LILE 1-2 FOURSEAM 92upeq “G @@ 2-0")
+    _, pitches, _ = parse_overlay("5.LILE 1-2 FOURSEAM 92upeq “G @@ 2-0")
     assert [(p.pitch_type, p.speed) for p in pitches] == [("FOURSEAM", 92)]
 
 
 def test_implausible_speeds_and_non_pitches_are_not_graphics():
-    _, pitches = parse_overlay("WSH 2 SF 0 ATTENDANCE 41213")
+    _, pitches, _ = parse_overlay("WSH 2 SF 0 ATTENDANCE 41213")
     assert pitches == []
 
 
@@ -106,20 +106,20 @@ def test_crowd_texture_is_never_more_than_a_loose_read():
     # A replay or crowd shot leaves no bug in the crop; tesseract still
     # returns pages of three-letter words, one of which is always a surname.
     noise = "Beir Lee GAS Pt atthe gL) TAT eM we PA) a pik wee Se bh\nFRR ahe ey Maes"
-    names, pitches = parse_overlay(noise)
+    names, pitches, _ = parse_overlay(noise)
     assert pitches == []
     assert names and {n.role for n in names} == {LOOSE}
 
 
 def test_bare_words_are_kept_only_alongside_structure():
-    names, _ = parse_overlay("0-2 SEYMOUR 5.VIVAS")
+    names, _, _ = parse_overlay("0-2 SEYMOUR 5.VIVAS")
     assert scorebug.NameRead("SEYMOUR", UNKNOWN) in names
 
 
 def test_both_preprocessing_passes_are_merged_not_chosen_between():
     """Neither pass is reliably better, so the union of the two is kept: 44 of
     215 readable pilot frames were readable only after thresholding."""
-    names, pitches = parse_bands([
+    names, pitches, _ = parse_bands([
         "5.LILE 1-2 RAY P: 87",          # the grey pass lost the pitch graphic
         "5.LILE 1-2 SLIDER 88 MPH",      # the binarised pass lost the pitcher
     ])
@@ -131,7 +131,7 @@ def test_both_preprocessing_passes_are_merged_not_chosen_between():
 
 
 def test_a_speed_read_twice_keeps_the_fuller_description():
-    _, pitches = parse_bands(["SLIDER 88", "SLIDER 88 MPH"])
+    _, pitches, _ = parse_bands(["SLIDER 88", "SLIDER 88 MPH"])
     assert [p.describe() for p in pitches] == ["SLIDER 88 MPH"]
 
 
@@ -272,7 +272,11 @@ def test_frames_without_a_bug_contribute_nothing(roster, fake_frames):
 def test_a_loose_read_is_admitted_once_confirmed(roster, fake_frames):
     ocr = fake_frames(["RAY P: 87 5.LILE", "a ray of ligh", "RAY P: 88 5.LILE"])
     cues = ScorebugRecognizer(roster, ocr=ocr, crop=WHOLE).recognize(MEDIA)
-    ray = [c for c in cues if c.entity_ids == ("player:robbie-ray",)]
+    # The appearance run is what this test is about. The fixture also steps the
+    # pitch count 87 -> 88, so it now yields a `pitch` cue as well; that is
+    # asserted on its own below rather than folded in here.
+    ray = [c for c in cues
+           if c.entity_ids == ("player:robbie-ray",) and c.event == "appearance"]
     assert len(ray) == 1 and ray[0].start_s == 0.0 and ray[0].end_s == 6.0
 
 
@@ -306,11 +310,11 @@ def test_velocity_branch_rejects_implausible_speeds():
     value."""
     from dirstral_annotator.recognizers import scorebug as sb
 
-    _, ok = sb.parse_overlay("SLIDER 88 MPH")
+    _, ok, _ = sb.parse_overlay("SLIDER 88 MPH")
     assert [p.speed for p in ok] == [88]
 
     for line in ("GARBLE 07 MPH", "NOISE 999 KPH", "XX 12 MPH"):
-        _, bad = sb.parse_overlay(line)
+        _, bad, _ = sb.parse_overlay(line)
         assert bad == [], f"accepted implausible speed: {line} -> {bad}"
 
 
@@ -322,3 +326,60 @@ def test_the_names_other_modules_import_from_here_still_resolve():
     assert scorebug.default_ocr is overlay.default_ocr
     assert scorebug.default_workers is overlay.default_workers
     assert scorebug.OcrFn is overlay.OcrFn
+
+
+# --- pitch cues from the bug's own pitch count ------------------------------
+
+def test_a_count_step_is_a_pitch(roster, fake_frames):
+    """The speed graphic is shown for some pitches and not others; on the pilot
+    game it yielded 299 cues against 344 thrown. The count printed beside the
+    pitcher's name is on the bug continuously and rises by exactly one per
+    pitch, so a transition is a pitch with a timestamp, already attributed."""
+    ocr = fake_frames(["RAY P: 87", "RAY P: 88", "RAY P: 89"])
+    cues = ScorebugRecognizer(roster, ocr=ocr, crop=WHOLE).recognize(MEDIA)
+    pitches = [c for c in cues if c.event == "pitch"]
+    assert len(pitches) == 2  # 87->88 and 88->89; the first read is a baseline
+    assert all(c.entity_ids == ("player:robbie-ray",) for c in pitches)
+
+
+def test_the_first_count_seen_claims_nothing(roster, fake_frames):
+    """A single reading says a pitcher has thrown N pitches, not that he threw
+    one just now. Only a transition is evidence of timing."""
+    ocr = fake_frames(["RAY P: 87", "RAY P: 87", "RAY P: 87"])
+    cues = ScorebugRecognizer(roster, ocr=ocr, crop=WHOLE).recognize(MEDIA)
+    assert [c for c in cues if c.event == "pitch"] == []
+
+
+def test_a_jump_larger_than_one_says_nothing(roster, fake_frames):
+    """Pitches certainly happened, but WHEN is unknown: emitting them at the
+    moment the jump was noticed would invent timing the bug never showed. This
+    is also the OCR-noise guard, since a misread digit looks exactly like a
+    jump."""
+    ocr = fake_frames(["RAY P: 87", "RAY P: 93"])
+    cues = ScorebugRecognizer(roster, ocr=ocr, crop=WHOLE).recognize(MEDIA)
+    assert [c for c in cues if c.event == "pitch"] == []
+
+
+def test_a_count_that_goes_backwards_resets_rather_than_emits(roster, fake_frames):
+    """A new pitcher starts his own count, and OCR misreads a digit downward.
+    Neither is a pitch."""
+    ocr = fake_frames(["RAY P: 87", "RAY P: 12", "RAY P: 13"])
+    cues = ScorebugRecognizer(roster, ocr=ocr, crop=WHOLE).recognize(MEDIA)
+    pitches = [c for c in cues if c.event == "pitch"]
+    assert len(pitches) == 1 and pitches[0].text == "pitch 13"
+
+
+def test_a_pitch_a_graphic_already_reported_is_not_reported_twice(roster, fake_frames):
+    """The scorecard matches at most one annotation per ground-truth pitch and
+    counts the rest as false positives, so a duplicate cannot raise recall and
+    can only cost precision — which is currently perfect on the pilot."""
+    ocr = fake_frames(["RAY P: 87", "RAY P: 88 SLIDER 88 MPH"])
+    cues = ScorebugRecognizer(roster, ocr=ocr, crop=WHOLE).recognize(MEDIA)
+    pitches = [c for c in cues if c.event == "pitch"]
+    assert len(pitches) == 1, f"the same pitch was reported twice: {pitches}"
+
+
+def test_count_pitches_can_be_turned_off_with_the_graphic_ones(roster, fake_frames):
+    ocr = fake_frames(["RAY P: 87", "RAY P: 88"])
+    rec = ScorebugRecognizer(roster, ocr=ocr, pitch_cues=False, crop=WHOLE)
+    assert [c for c in rec.recognize(MEDIA) if c.event == "pitch"] == []


### PR DESCRIPTION
Part of #741, aimed at what the pilot is actually judged on: can someone ask for a moment and get it back.

The feed already carries the inning. `PitchEvent` already stored it. **The cue text dropped it** — so `"bottom of the 9th"` or `"in the 7th"` could not match anything in the index, however good the recognition was.

`isTopInning` was not parsed at all, though it sits right beside the inning in GUMBO's `about` block — and half the question ("top" vs "bottom") lives there.

## Before / after

```
Pitch: Robbie Ray to James Wood — James Wood strikes out swinging.
Pitch: Robbie Ray to James Wood (bottom of the 7th) — James Wood strikes out swinging.
```

That carries all four things a question is likely to be made of: **who threw it, who faced it, when in the game, and what happened.**

## Phrasing is a retrieval decision

"bottom of the 7th", not `inning=7, half=B`. The text is what an embedding matches, so its wording is part of the retrieval design rather than cosmetics.

Ordinals handle the teens, because extra innings are ordinary in baseball and that is exactly where a naive suffix rule produces "11st". A feed with no inning omits the clause rather than emitting "top of the 0th".

## Context

This came out of asking what makes the pilot succeed rather than what moves the phase-1 gate. The gate scores pitcher-keyed `pitch` annotations, which says nothing about whether "show me every Ray strikeout in the 7th" works — and the generated report says as much itself: *"change the metric (not the recognizers) if pitcher-keyed pitch coverage is what the archive needs."*

Three tests: the half-inning reaches the text alongside both names and the outcome; the teens ordinals; and a missing inning is omitted rather than guessed.