### PR TITLE
feat(playbyplay): attribute each cue to the club its actor plays for (recovers #786)

### DIFF
--- a/annotator/dirstral_annotator/eval/ground_truth.py
+++ b/annotator/dirstral_annotator/eval/ground_truth.py
@@ -39,12 +39,24 @@ class PitchEvent:
     #: True for the top half. Carried because "bottom of the 9th" is how people
     #: ask for a moment, and an inning number alone cannot answer it.
     top_inning: bool = True
+    #: Club names as the feed spells them. Empty when the payload omits them,
+    #: which keeps every existing caller and fixture valid.
+    away_team: str = ""
+    home_team: str = ""
 
     def half_inning(self) -> str:
         """The half-inning phrased as a person would say it: "top of the 1st"."""
         if self.inning <= 0:
             return ""
         return f"{'top' if self.top_inning else 'bottom'} of the {_ordinal(self.inning)}"
+
+    def batting_team(self) -> str:
+        """The club at the plate. The visitors bat in the top half."""
+        return self.away_team if self.top_inning else self.home_team
+
+    def pitching_team(self) -> str:
+        """The club in the field."""
+        return self.home_team if self.top_inning else self.away_team
 
 
 def fetch_game(game_pk: int, timeout_s: float = 30.0) -> dict:
@@ -64,6 +76,11 @@ def load_game(path: str | Path) -> dict:
 def parse_pitches(feed: dict) -> list[PitchEvent]:
     game_pk = feed.get("gamePk", 0)
     events: list[PitchEvent] = []
+    # Which club bats follows from the half-inning, so the two club names are
+    # all that is needed; no per-player team lookup.
+    feed_teams = feed.get("gameData", {}).get("teams", {})
+    away_team = (feed_teams.get("away", {}) or {}).get("name", "")
+    home_team = (feed_teams.get("home", {}) or {}).get("name", "")
     plays = feed.get("liveData", {}).get("plays", {}).get("allPlays", [])
     for play in plays:
         matchup = play.get("matchup", {})
@@ -93,6 +110,8 @@ def parse_pitches(feed: dict) -> list[PitchEvent]:
                     batter_name=batter.get("fullName", ""),
                     inning=inning,
                     top_inning=top_inning,
+                    away_team=away_team,
+                    home_team=home_team,
                     description=(result_desc if is_last and result_desc else call),
                 )
             )

--- a/annotator/dirstral_annotator/recognizers/playbyplay.py
+++ b/annotator/dirstral_annotator/recognizers/playbyplay.py
@@ -19,6 +19,7 @@ lives in eval.ground_truth so both uses share one implementation.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 from ..eval.ground_truth import PitchEvent
@@ -30,6 +31,40 @@ from ..roster import Roster
 PRE_ROLL_S = 3.0
 POST_ROLL_S = 5.0
 CONFIDENCE = 0.98  # official record, minus alignment slop
+
+_SLUG_SEP = re.compile(r"[^a-z0-9]+")
+
+
+def team_id(name: str) -> str:
+    """"San Francisco Giants" -> "team:san-francisco-giants".
+
+    The slug round-trips through the emit layer's label fallback
+    (`id.split(":")[-1].replace("-", " ").title()`), so a club needs no roster
+    entry to reach the wire with a readable label. Returns "" for a name that
+    slugs to nothing, so callers can drop it rather than emit `team:`.
+    """
+    slug = _SLUG_SEP.sub("-", name.strip().lower()).strip("-")
+    return f"team:{slug}" if slug else ""
+
+
+def _with_team(player_id: str, team: str) -> tuple[str, ...]:
+    """The acting player, plus the club they are acting for.
+
+    The club rides in `entity_ids` and deliberately NOT in the cue text.
+    Writing it into the text was measured on the pilot corpus and made
+    retrieval WORSE: every statement names both clubs, so the label cannot
+    discriminate between candidates, and it drags a team-scoped query onto
+    whichever role happens to rank first. "Giants home run" came back as a
+    Giants pitcher throwing balls (dirstral-spec design 0004 §6.1).
+
+    As an entity it is exact, because the cue's `event` already records which
+    role this id is acting in: `pitch` is keyed on the pitcher and carries the
+    fielding club, `at_bat` is keyed on the batter and carries the club at the
+    plate. Selecting on entity AND event is therefore role-correct, which no
+    amount of phrasing in the text can achieve.
+    """
+    tid = team_id(team)
+    return (player_id, tid) if tid else (player_id,)
 
 
 class PlayByPlayRecognizer:
@@ -72,7 +107,7 @@ class PlayByPlayRecognizer:
                         start_s=start,
                         end_s=end,
                         event="pitch",
-                        entity_ids=(pitcher.id,),
+                        entity_ids=_with_team(pitcher.id, ev.pitching_team()),
                         confidence=CONFIDENCE,
                         text=f"Pitch: {pitcher_name} to {batter_name}{where}{desc}",
                     )
@@ -88,7 +123,7 @@ class PlayByPlayRecognizer:
                         start_s=start,
                         end_s=end,
                         event="at_bat",
-                        entity_ids=(batter.id,),
+                        entity_ids=_with_team(batter.id, ev.batting_team()),
                         confidence=CONFIDENCE,
                         text=f"At bat: {batter_name} vs {pitcher_name}{where}{desc}",
                     )

--- a/annotator/tests/test_emit.py
+++ b/annotator/tests/test_emit.py
@@ -33,3 +33,29 @@ def test_response_matches_design_0004_wire_contract():
 
 def test_response_json_round_trips():
     assert json.loads(response_json(doc())) == build_response(doc())
+
+
+def test_a_club_reaches_the_wire_with_a_readable_label():
+    """A club has no roster entry, so `build_response` must fall back to
+    deriving its label from the id. Without this the wire carries
+    `team:san-francisco-giants` and no way to render it, and dir2mcp cannot
+    show a user what they filtered on.
+    """
+    doc_with_club = Document(
+        media="game7.mp4",
+        annotations=[
+            Annotation(
+                start_s=1.0, end_s=2.0, event="pitch",
+                entity_ids=("player:webb-logan", "team:san-francisco-giants"),
+                text="Pitch: Logan Webb to Freddie Freeman",
+                confidence=0.97, sources=("playbyplay",),
+            )
+        ],
+    )
+    payload = build_response(doc_with_club)
+    by_id = {e["id"]: e for e in payload["entities"]}
+    assert by_id["team:san-francisco-giants"]["label"] == "San Francisco Giants"
+    # and the annotation still references both, in order
+    assert payload["annotations"][0]["entities"] == [
+        "player:webb-logan", "team:san-francisco-giants",
+    ]

--- a/annotator/tests/test_eval.py
+++ b/annotator/tests/test_eval.py
@@ -107,3 +107,52 @@ def test_report_renders(events, roster):
     text = render(card, alignment, roster, title="game7.mp4")
     assert "Logan Webb" in text and "100.0%" in text
     assert "DRIFT" not in text
+
+
+# --- club names off the feed (#741 follow-up) --------------------------------
+
+def _feed_with_clubs(top_inning: bool) -> dict:
+    """A minimal GUMBO payload carrying both clubs and one pitch."""
+    return {
+        "gamePk": 1,
+        "gameData": {"teams": {
+            "away": {"name": "Washington Nationals"},
+            "home": {"name": "San Francisco Giants"},
+        }},
+        "liveData": {"plays": {"allPlays": [{
+            "matchup": {"pitcher": {"id": 1, "fullName": "P"},
+                        "batter": {"id": 2, "fullName": "B"}},
+            "about": {"inning": 3, "isTopInning": top_inning},
+            "result": {"description": ""},
+            "playEvents": [{
+                "isPitch": True,
+                "startTime": "2026-08-01T20:00:00Z",
+                "details": {"description": "Ball"},
+            }],
+        }]}},
+    }
+
+
+def test_parse_pitches_reads_both_clubs():
+    ev = ground_truth.parse_pitches(_feed_with_clubs(top_inning=True))[0]
+    assert ev.away_team == "Washington Nationals"
+    assert ev.home_team == "San Francisco Giants"
+
+
+def test_the_batting_club_follows_the_half_inning():
+    """The visitors bat in the top half. This is the whole derivation, so it
+    is worth pinning in both directions rather than trusting one case."""
+    top = ground_truth.parse_pitches(_feed_with_clubs(top_inning=True))[0]
+    assert top.batting_team() == "Washington Nationals"
+    assert top.pitching_team() == "San Francisco Giants"
+
+    bottom = ground_truth.parse_pitches(_feed_with_clubs(top_inning=False))[0]
+    assert bottom.batting_team() == "San Francisco Giants"
+    assert bottom.pitching_team() == "Washington Nationals"
+
+
+def test_a_feed_without_gameData_leaves_the_clubs_empty(events):
+    """The shared fixture has no `gameData`; every existing caller and payload
+    must stay valid, with no club rather than a guessed one."""
+    assert all(e.away_team == "" and e.home_team == "" for e in events)
+    assert all(e.batting_team() == "" and e.pitching_team() == "" for e in events)

--- a/annotator/tests/test_playbyplay.py
+++ b/annotator/tests/test_playbyplay.py
@@ -141,3 +141,95 @@ def test_a_missing_inning_is_omitted_rather_than_guessed(roster):
     cues = PlayByPlayRecognizer([ev], 0.0, roster).recognize(Path("g.mp4"))
     pitch = next(c for c in cues if c.event == "pitch")
     assert "0th" not in pitch.text and "(" not in pitch.text
+
+
+# --- club attribution (#741 follow-up; dirstral-spec design 0004 §6.1) -------
+#
+# The club a player is acting for rides in `entity_ids`, NOT in the cue text.
+# That is a measured decision, not a stylistic one: writing the club into the
+# text was tried on the pilot corpus and made retrieval worse, because every
+# statement names both clubs and the label then drags a team-scoped query onto
+# whichever role ranks first. As an entity it is exact, because `event`
+# already records the role the id is acting in.
+
+BOTH_CLUBS = {"away_team": "Washington Nationals", "home_team": "San Francisco Giants"}
+
+
+def _pitch_with_clubs(pitcher, batter, *, top_inning, **kw):
+    return PitchEvent(
+        game_pk=1, epoch_s=1000.0, pitcher_id=pitcher, pitcher_name="P",
+        batter_id=batter, batter_name="B", inning=1, top_inning=top_inning,
+        description="Ball", **{**BOTH_CLUBS, **kw},
+    )
+
+
+def test_the_pitch_carries_the_fielding_club_and_the_at_bat_the_batting_club(roster):
+    """Bottom half: the home side bats, so our rostered batter is a Giant and
+    the pitcher he faces is fielding for Washington."""
+    ev = _pitch_with_clubs(OPP_PITCHER, RAMOS, top_inning=False)
+    cues = PlayByPlayRecognizer([ev], 0.0, roster).recognize(MEDIA)
+    at_bat = next(c for c in cues if c.event == "at_bat")
+    assert at_bat.entity_ids == ("player:ramos-heliot", "team:san-francisco-giants")
+
+
+def test_the_half_inning_decides_which_club_is_batting(roster):
+    """Top half: the visitors bat. Our rostered pitcher is therefore fielding
+    for the home club. Getting this backwards would attribute every moment to
+    the wrong side, which no amount of ranking could recover."""
+    ev = _pitch_with_clubs(WEBB, OPP_BATTER, top_inning=True)
+    cues = PlayByPlayRecognizer([ev], 0.0, roster).recognize(MEDIA)
+    pitch = next(c for c in cues if c.event == "pitch")
+    assert pitch.entity_ids == ("player:webb-logan", "team:san-francisco-giants")
+
+    # ... and in the bottom half the same pitcher would be fielding for the
+    # visitors, so the club is genuinely derived rather than constant.
+    flipped = _pitch_with_clubs(WEBB, OPP_BATTER, top_inning=False)
+    pitch = next(
+        c for c in PlayByPlayRecognizer([flipped], 0.0, roster).recognize(MEDIA)
+        if c.event == "pitch"
+    )
+    assert pitch.entity_ids == ("player:webb-logan", "team:washington-nationals")
+
+
+def test_both_roles_in_one_pitch_get_opposite_clubs(roster):
+    """The case that makes the entity filter role-exact: one moment, two
+    annotations, each naming the club its own actor plays for."""
+    ev = _pitch_with_clubs(WEBB, RAMOS, top_inning=True)
+    cues = PlayByPlayRecognizer([ev], 0.0, roster).recognize(MEDIA)
+    by_event = {c.event: c.entity_ids for c in cues}
+    assert by_event["pitch"] == ("player:webb-logan", "team:san-francisco-giants")
+    assert by_event["at_bat"] == ("player:ramos-heliot", "team:washington-nationals")
+
+
+def test_the_club_stays_out_of_the_cue_text(roster):
+    """The measured decision. If a club name ever appears in the text, the
+    retrieval regression that motivated this comes straight back."""
+    ev = _pitch_with_clubs(WEBB, RAMOS, top_inning=True)
+    for cue in PlayByPlayRecognizer([ev], 0.0, roster).recognize(MEDIA):
+        assert "Giants" not in cue.text
+        assert "Nationals" not in cue.text
+
+
+def test_a_feed_without_clubs_emits_exactly_what_it_did_before(roster):
+    """Back-compat: club names are optional, and a payload lacking them must
+    not produce a `team:` id with nothing in it."""
+    ev = _pitch(1000.0, WEBB, OPP_BATTER, pname="Logan Webb", bname="Opp Guy")
+    cues = PlayByPlayRecognizer([ev], 0.0, roster).recognize(MEDIA)
+    assert cues[0].entity_ids == ("player:webb-logan",)
+
+
+def test_the_club_id_round_trips_through_the_emit_label_fallback():
+    """A club has no roster entry, so its label comes from the emit fallback
+    (`id.split(":")[-1].replace("-", " ").title()`). The slug has to survive
+    that trip, or the wire carries an id nobody can read."""
+    from dirstral_annotator.recognizers.playbyplay import team_id
+    tid = team_id("San Francisco Giants")
+    assert tid == "team:san-francisco-giants"
+    assert tid.split(":", 1)[-1].replace("-", " ").title() == "San Francisco Giants"
+
+
+def test_a_club_name_that_slugs_to_nothing_is_dropped():
+    from dirstral_annotator.recognizers.playbyplay import team_id
+    assert team_id("") == ""
+    assert team_id("   ") == ""
+    assert team_id("!!!") == ""


### PR DESCRIPTION
**This re-lands #786, whose changes never reached `main`.**

#786 was stacked on #780. Both were merged within 14 seconds of each other (#780 to `main` at 23:54:55, #786 at 23:55:09), and GitHub had not yet retargeted #786's base from `feat/playbyplay-queryable-cue-text-741` to `main`. So #786 merged into a branch that had *already* been merged, and its commit is not an ancestor of `main`:

```
$ git merge-base --is-ancestor b99d8eb origin/main; echo $?
1
```

This is #786's commit cherry-picked onto current `main`, unchanged. It applied cleanly. 269 annotator tests pass.

The original PR body follows.

---

## The problem

"When did the Giants score" could not be answered. No recognition annotation names a club, so retrieval has nothing to select on.

## The obvious fix does not work, and it was measured

Writing the club into the cue text. Pilot corpus, 346 annotations, six team-scoped queries, re-embedded per variant, scored on club **and** outcome:

| variant | precision |
|---|---|
| no club in text (shipped) | 58.3% |
| club appended to each name | 47.8% |
| club and role appended | 34.8% |

Monotone degradation, no trade-off. The clearest case is `"Giants home run"`: three correct hits without the club in the text, **zero** with it, and the top results become a Giants **pitcher** throwing balls and fouls. Every statement names both clubs, so the label cannot discriminate between candidates; it only drags a team-scoped query onto whichever role ranks first.

(An earlier cut of this scored club attribution alone and made the middle variant look like a 65.2% *improvement*. That rule counts a Nationals ground-out as a correct answer to "Nationals home run". Full write-up and both scorings: dirstral-spec design 0004 §6.1.)

## What this does instead

The club rides in `entity_ids`. The cue text is **unchanged**.

That is exact rather than approximate, because `event` already records the role an id is acting in: `pitch` is keyed on the pitcher and carries the fielding club, `at_bat` is keyed on the batter and carries the club at the plate. Selecting on entity **and** event is role-correct.

Which club bats follows from the half-inning, so this needs the two club names and no per-player lookup. #780 carried `top_inning` for the text; it does double duty here.

## Compatibility

- Club names are optional. A payload without `gameData.teams` (including the shared `gumbo_min.json` fixture) produces exactly the entity ids it produced before, not an empty `team:`.
- No emit change: the slug round-trips through the existing label fallback, so a club reaches the wire as "San Francisco Giants" despite having no roster entry.
- 269 tests pass, including the design 0004 schema-agreement test. Note that **CI does not run these** (#787).

## Follow-up

dirstral-spec#82 is merged, so the dir2mcp side is now unblocked: `entities` and `event` must survive ingestion (today `internal/ingest/recognize.go:263-296` drops both), and search/ask gain the entity filter. That work re-pins the submodule and is a separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Play-by-play annotations now identify the relevant batting and pitching teams.
  * Team references use readable, stable identifiers, including for clubs not on the roster.
  * Team names remain available for parsed game events, including away and home teams.

* **Bug Fixes**
  * Preserved compatibility for feeds without team metadata.
  * Kept team names out of cue text while retaining accurate entity references.

* **Tests**
  * Added coverage for team attribution, opposing clubs, fallback identifiers, and unrostered teams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->