### PR TITLE
feat(retrieval): carry recognition entities through ingest and filter on them

### DIFF
--- a/internal/index/qdrantindex/filter.go
+++ b/internal/index/qdrantindex/filter.go
@@ -49,6 +49,15 @@ func canFilter(filter model.Filter) bool {
 	if len(filter.Languages) != 0 {
 		return false
 	}
+	// Entities/Events (recognition annotation filter, design 0004 §7) live in
+	// the span's extra_json, which is not part of the vector payload at all, so
+	// there is nothing here to match against. Decline push-down and let the
+	// Go-side matchFilters re-check apply it once the span is materialised.
+	// Without this the default `return true` below would claim a predicate this
+	// backend cannot evaluate.
+	if len(filter.Entities) != 0 || len(filter.Events) != 0 {
+		return false
+	}
 	return true
 }
 

--- a/internal/ingest/recognize.go
+++ b/internal/ingest/recognize.go
@@ -294,7 +294,7 @@ func recognitionSegments(anns []model.RecognizedAnnotation) ([]chunkSegment, str
 			// Carried, not dropped: these are what an entity filter selects on
 			// (design 0004 §7). The backend is required to compute them, and
 			// persisting only the text made the filter unimplementable.
-			entities: ann.Entities,
+			entities: model.NormalizeEntityIDs(ann.Entities),
 			event:    strings.TrimSpace(ann.Event),
 		})
 	}
@@ -321,8 +321,19 @@ func recognitionSegments(anns []model.RecognizedAnnotation) ([]chunkSegment, str
 		// which entities an annotation names has produced different content,
 		// and the representation must be re-derived rather than kept because
 		// the prose happens to match (§8.6.7).
-		fmt.Fprintf(&hashInput, "%d|%d|%s|%s|%s\n",
-			v.startMS, v.endMS, v.text, v.event, strings.Join(v.entities, ","))
+		//
+		// Every variable-length field is LENGTH-PREFIXED rather than delimited.
+		// Entity ids are opaque backend-declared tokens, so any delimiter can
+		// legitimately appear inside one: joining with commas would encode
+		// ["a,b", "c"] and ["a", "b,c"] identically, and two genuinely
+		// different attributions that hash the same would silently NOT
+		// re-derive. That is the exact failure this input exists to prevent.
+		fmt.Fprintf(&hashInput, "%d|%d|%d:%s|%d:%s|%d",
+			v.startMS, v.endMS, len(v.text), v.text, len(v.event), v.event, len(v.entities))
+		for _, id := range v.entities {
+			fmt.Fprintf(&hashInput, "|%d:%s", len(id), id)
+		}
+		hashInput.WriteByte('\n')
 	}
 	return segments, hashInput.String()
 }

--- a/internal/ingest/recognize.go
+++ b/internal/ingest/recognize.go
@@ -248,6 +248,21 @@ type recognitionMeta struct {
 	ModelVersion string `json:"model_version,omitempty"`
 }
 
+// RecognitionSegments is the exported counterpart of recognitionSegments,
+// converting the unexported segment type to the public ChunkSegment. It exists
+// so tests in the tests/ tree can assert what an annotation actually carries
+// into persistence, which is where the entity attribution used to be silently
+// dropped (design 0004 §7). The derivation hash input is returned alongside so
+// a test can pin that a change in attribution re-derives the representation.
+func RecognitionSegments(anns []model.RecognizedAnnotation) ([]ChunkSegment, string) {
+	raw, hashInput := recognitionSegments(anns)
+	out := make([]ChunkSegment, 0, len(raw))
+	for _, seg := range raw {
+		out = append(out, ChunkSegment(seg))
+	}
+	return out, hashInput
+}
+
 // recognitionSegments filters a backend's annotations to the well-formed ones,
 // sorts them deterministically, and returns the time-spanned chunk segments plus
 // the canonical string the derivation rep_hash is computed over.
@@ -262,9 +277,11 @@ type recognitionMeta struct {
 // force a spurious re-derivation.
 func recognitionSegments(anns []model.RecognizedAnnotation) ([]chunkSegment, string) {
 	type validAnnotation struct {
-		startMS int
-		endMS   int
-		text    string
+		startMS  int
+		endMS    int
+		text     string
+		entities []string
+		event    string
 	}
 	valid := make([]validAnnotation, 0, len(anns))
 	for _, ann := range anns {
@@ -272,7 +289,14 @@ func recognitionSegments(anns []model.RecognizedAnnotation) ([]chunkSegment, str
 		if text == "" || ann.StartMS < 0 || ann.EndMS < ann.StartMS {
 			continue
 		}
-		valid = append(valid, validAnnotation{startMS: ann.StartMS, endMS: ann.EndMS, text: text})
+		valid = append(valid, validAnnotation{
+			startMS: ann.StartMS, endMS: ann.EndMS, text: text,
+			// Carried, not dropped: these are what an entity filter selects on
+			// (design 0004 §7). The backend is required to compute them, and
+			// persisting only the text made the filter unimplementable.
+			entities: ann.Entities,
+			event:    strings.TrimSpace(ann.Event),
+		})
 	}
 	sort.Slice(valid, func(i, j int) bool {
 		if valid[i].startMS != valid[j].startMS {
@@ -288,9 +312,17 @@ func recognitionSegments(anns []model.RecognizedAnnotation) ([]chunkSegment, str
 	for _, v := range valid {
 		segments = append(segments, chunkSegment{
 			Text: v.text,
-			Span: model.Span{Kind: "time", StartMS: v.startMS, EndMS: v.endMS},
+			Span: model.Span{
+				Kind: "time", StartMS: v.startMS, EndMS: v.endMS,
+				Entities: v.entities, Event: v.event,
+			},
 		})
-		fmt.Fprintf(&hashInput, "%d|%d|%s\n", v.startMS, v.endMS, v.text)
+		// The attribution joins the derivation hash: a backend that changes
+		// which entities an annotation names has produced different content,
+		// and the representation must be re-derived rather than kept because
+		// the prose happens to match (§8.6.7).
+		fmt.Fprintf(&hashInput, "%d|%d|%s|%s|%s\n",
+			v.startMS, v.endMS, v.text, v.event, strings.Join(v.entities, ","))
 	}
 	return segments, hashInput.String()
 }

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -849,6 +849,7 @@ func isResolvableSourceWithRoot(doc model.Document, rootAbs, rootReal string) bo
 func (s *Server) handleSearchTool(ctx context.Context, args map[string]interface{}) (toolCallResult, *toolExecutionError) {
 	if err := assertNoUnknownArguments(args, map[string]struct{}{
 		"query": {}, "k": {}, "index": {}, "path_prefix": {}, "file_glob": {}, "doc_types": {}, "speaker": {}, "languages": {}, "language_match": {}, "date_from": {}, "date_to": {}, "time_from_ms": {}, "time_to_ms": {},
+		"entities": {}, "events": {},
 	}); err != nil {
 		return toolCallResult{}, &toolExecutionError{Code: "INVALID_FIELD", Message: err.Error(), Retryable: false}
 	}
@@ -883,7 +884,7 @@ func (s *Server) handleSearchTool(ctx context.Context, args map[string]interface
 	if toolErr != nil {
 		return toolCallResult{}, toolErr
 	}
-	tw, toolErr := parseTemporalFilters(args)
+	tw, entities, events, toolErr := parseSearchScopeFilters(args)
 	if toolErr != nil {
 		return toolCallResult{}, toolErr
 	}
@@ -893,6 +894,7 @@ func (s *Server) handleSearchTool(ctx context.Context, args map[string]interface
 	sq := model.SearchQuery{
 		Query: query, K: k, Index: indexName, PathPrefix: pathPrefix, FileGlob: fileGlob, DocTypes: docTypes, Speaker: speaker, Languages: languages, LanguageMatch: languageMatch, DateFrom: tw.dateFrom, DateTo: tw.dateTo,
 		HasTimeFrom: tw.hasTimeFrom, TimeFromMS: tw.timeFromMS, HasTimeTo: tw.hasTimeTo, TimeToMS: tw.timeToMS,
+		Entities: entities, Events: events,
 	}
 	// index_used MUST be the index the query was actually routed to (SPEC §15.2),
 	// not the requested name. Prefer AxisSearcher so the reported axis is read back
@@ -1092,6 +1094,7 @@ func mapRelatedError(err error) *toolExecutionError {
 func (s *Server) handleAskTool(ctx context.Context, args map[string]interface{}) (toolCallResult, *toolExecutionError) {
 	if err := assertNoUnknownArguments(args, map[string]struct{}{
 		"question": {}, "k": {}, "mode": {}, "index": {}, "path_prefix": {}, "file_glob": {}, "doc_types": {}, "languages": {}, "language_match": {}, "date_from": {}, "date_to": {}, "time_from_ms": {}, "time_to_ms": {},
+		"entities": {}, "events": {},
 	}); err != nil {
 		return toolCallResult{}, &toolExecutionError{Code: "INVALID_FIELD", Message: err.Error(), Retryable: false}
 	}
@@ -1133,8 +1136,13 @@ func (s *Server) handleAskTool(ctx context.Context, args map[string]interface{})
 	if s.retriever == nil {
 		return toolCallResult{}, &toolExecutionError{Code: protocol.ErrorCodeIndexNotReady, Message: "retriever not configured", Retryable: false}
 	}
+	askEntities, askEvents, toolErr := parseAnnotationFilters(args)
+	if toolErr != nil {
+		return toolCallResult{}, toolErr
+	}
 	sq := model.SearchQuery{Query: question, K: k, Index: indexName, PathPrefix: pathPrefix, FileGlob: fileGlob, DocTypes: docTypes, Languages: languages, LanguageMatch: languageMatch, DateFrom: tw.dateFrom, DateTo: tw.dateTo,
-		HasTimeFrom: tw.hasTimeFrom, TimeFromMS: tw.timeFromMS, HasTimeTo: tw.hasTimeTo, TimeToMS: tw.timeToMS}
+		HasTimeFrom: tw.hasTimeFrom, TimeFromMS: tw.timeFromMS, HasTimeTo: tw.hasTimeTo, TimeToMS: tw.timeToMS,
+		Entities: askEntities, Events: askEvents}
 	if mode == "search_only" {
 		return s.runSearchOnlyMode(ctx, question, sq)
 	}
@@ -2053,6 +2061,57 @@ func parseSearchFilters(args map[string]interface{}) (pathPrefix, fileGlob strin
 // error — that is handled downstream by returning an empty hit list. The parsed
 // tags are returned verbatim (trimmed); the retrieval filter normalizes to the
 // primary subtag for case-insensitive matching.
+// parseAnnotationFilters parses the optional recognition entity/event filters
+// (dirstral-spec design 0004 §7). Both are string arrays, matched literally and
+// OR-wise within a field, AND across them. Absent/empty leaves the filter off.
+//
+// Values are NOT validated against a vocabulary: entity ids and event strings
+// are declared by the recognition backend, so the only thing that could be
+// checked here is non-emptiness. An id that exists nowhere in the corpus is a
+// legitimate query that returns nothing, exactly as for languages and dates.
+func parseAnnotationFilters(args map[string]interface{}) (entities, events []string, toolErr *toolExecutionError) {
+	entities, err := parseOptionalStringSlice(args, "entities")
+	if err != nil {
+		return nil, nil, &toolExecutionError{Code: "INVALID_FIELD", Message: err.Error(), Retryable: false}
+	}
+	events, err = parseOptionalStringSlice(args, "events")
+	if err != nil {
+		return nil, nil, &toolExecutionError{Code: "INVALID_FIELD", Message: err.Error(), Retryable: false}
+	}
+	for _, field := range []struct {
+		name   string
+		values []string
+	}{{"entities", entities}, {"events", events}} {
+		for _, v := range field.values {
+			if strings.TrimSpace(v) == "" {
+				return nil, nil, &toolExecutionError{
+					Code:      "INVALID_FIELD",
+					Message:   fmt.Sprintf("%s contains an empty value", field.name),
+					Retryable: false,
+				}
+			}
+		}
+	}
+	return entities, events, nil
+}
+
+// parseSearchScopeFilters parses the scope filters that narrow WHICH candidates
+// a query may return: the temporal window (SPEC §9.6/§9.8) and the recognition
+// entity/event attribution (design 0004 §7). Grouped into one call so the tool
+// handler stays within the repo's cyclomatic budget; each half is unchanged and
+// still validated independently.
+func parseSearchScopeFilters(args map[string]interface{}) (temporalFilters, []string, []string, *toolExecutionError) {
+	tw, toolErr := parseTemporalFilters(args)
+	if toolErr != nil {
+		return temporalFilters{}, nil, nil, toolErr
+	}
+	entities, events, toolErr := parseAnnotationFilters(args)
+	if toolErr != nil {
+		return temporalFilters{}, nil, nil, toolErr
+	}
+	return tw, entities, events, nil
+}
+
 func parseLanguagesArg(args map[string]interface{}) ([]string, *toolExecutionError) {
 	languages, err := parseOptionalStringSlice(args, "languages")
 	if err != nil {
@@ -3547,6 +3606,16 @@ func searchInputSchema() map[string]interface{} {
 				"default":     "primary",
 				"description": "Optional (SPEC §9.5): matching mode for languages. 'primary' (default) matches on the BCP-47 primary subtag (pt-BR matches pt); 'strict' opts into RFC 4647 region/script narrowing (pt-BR matches pt-BR/pt-BR-… but not bare pt or pt-PT).",
 			},
+			"entities": map[string]interface{}{
+				"type":        "array",
+				"items":       map[string]interface{}{"type": "string"},
+				"description": "Optional (design 0004 §7): restrict hits to recognition annotations referencing ANY of these entity ids (logical OR), matched literally. Combine with `events` to select a role: an annotation names every participant, so the id alone cannot say which one acted. Only annotation-derived hits carry entities; an id absent from the corpus returns an empty result, not an error.",
+			},
+			"events": map[string]interface{}{
+				"type":        "array",
+				"items":       map[string]interface{}{"type": "string"},
+				"description": "Optional (design 0004 §7): restrict hits to recognition annotations whose event equals ANY of these values (logical OR), matched literally. Event strings are declared by the recognition backend, so there is no fixed vocabulary here. AND-ed with `entities`.",
+			},
 			"date_from": map[string]interface{}{
 				"type":        "string",
 				"description": "Optional (SPEC §9.6): restrict hits to documents whose date (mtime) is on or after this bound (inclusive). Accepts an RFC 3339 timestamp (2026-04-01T00:00:00Z) or a bare YYYY-MM-DD date (start of that UTC day). Absent = open lower bound.",
@@ -3672,6 +3741,16 @@ func askInputSchema() map[string]interface{} {
 				"enum":        []string{"primary", "strict"},
 				"default":     "primary",
 				"description": "Optional (SPEC §9.5): matching mode for languages. 'primary' (default) matches on the BCP-47 primary subtag (pt-BR matches pt); 'strict' opts into RFC 4647 region/script narrowing (pt-BR matches pt-BR/pt-BR-… but not bare pt or pt-PT).",
+			},
+			"entities": map[string]interface{}{
+				"type":        "array",
+				"items":       map[string]interface{}{"type": "string"},
+				"description": "Optional (design 0004 §7): restrict retrieved contexts to recognition annotations referencing ANY of these entity ids (logical OR), matched literally. Combine with `events` to select a role: an annotation names every participant, so the id alone cannot say which one acted. Only annotation-derived hits carry entities; an id absent from the corpus returns an empty result, not an error.",
+			},
+			"events": map[string]interface{}{
+				"type":        "array",
+				"items":       map[string]interface{}{"type": "string"},
+				"description": "Optional (design 0004 §7): restrict retrieved contexts to recognition annotations whose event equals ANY of these values (logical OR), matched literally. Event strings are declared by the recognition backend, so there is no fixed vocabulary here. AND-ed with `entities`.",
 			},
 			"date_from": map[string]interface{}{
 				"type":        "string",

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -611,6 +611,37 @@ func (f Filter) MatchesAnnotation(span Span) bool {
 	return true
 }
 
+// NormalizeEntityIDs trims, drops empties, and de-duplicates entity ids while
+// preserving first-seen order. Order is preserved because a backend emits the
+// acting entity first (design 0004 §8: role lives in annotation granularity).
+//
+// One rule shared by ingestion and persistence deliberately: the derivation
+// hash covers what is STORED, so if the two normalized differently a backend
+// that emitted a stray blank id would re-derive a representation whose stored
+// attribution is byte-identical.
+func NormalizeEntityIDs(ids []string) []string {
+	if len(ids) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(ids))
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
 // MatchesAnyLiteral reports whether any requested value appears among the
 // candidate's values, after trimming. Literal rather than case-insensitive:
 // entity ids and event strings are opaque tokens declared by a backend, and

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -302,6 +302,23 @@ type Span struct {
 	// is byte-identical to today. Persisted in the "time" span's extra_json.
 	Speaker      string
 	SpeakerLabel string
+	// Entities and Event carry a recognition annotation's structured
+	// attribution on its "time" span (dirstral-spec design 0004 §7): the
+	// entity ids the annotation references, and the backend-declared event
+	// string describing what the annotation is about.
+	//
+	// They are what makes an entity filter role-exact. The wire shape has no
+	// per-entity role, so role lives in annotation granularity: a backend
+	// emits one annotation per role and distinguishes them with Event, and
+	// selecting on entity AND event recovers the role. Keeping the ids
+	// without the event recovers only half the query.
+	//
+	// Metadata only, exactly like Speaker: never changes chunk text or span
+	// bounds, empty for every representation that is not a recognition
+	// annotation, so behaviour is byte-identical where absent. Persisted in
+	// the "time" span's extra_json.
+	Entities []string
+	Event    string
 }
 
 // WordSpan is one per-word timestamp on a "time" span (spec §8.6.1). The JSON
@@ -490,6 +507,18 @@ type Filter struct {
 	// or LanguageMatchStrict (opt-in RFC 4647 Basic Filtering region/script
 	// narrowing). Inert unless Languages is non-empty.
 	LanguageMatch string
+	// Entities / Events restrict candidates to recognition annotations
+	// referencing any of the requested entity ids, and/or carrying any of the
+	// requested event values (design 0004 §7). OR within each field, AND
+	// across them. Empty disables the predicate.
+	//
+	// Unlike Speaker, which some backends carry as a flat payload field, the
+	// attribution exists only on the nested Span. A backend that does not
+	// persist the Span (Qdrant) therefore cannot evaluate this and declines
+	// push-down, leaving it to the retrieval service's post-materialisation
+	// re-check.
+	Entities []string
+	Events   []string
 }
 
 // IsZero reports whether the filter has no active predicate.
@@ -499,7 +528,9 @@ func (f Filter) IsZero() bool {
 		len(f.DocTypes) == 0 &&
 		!f.ExcludeOrphans &&
 		strings.TrimSpace(f.Speaker) == "" &&
-		len(f.Languages) == 0
+		len(f.Languages) == 0 &&
+		len(f.Entities) == 0 &&
+		len(f.Events) == 0
 }
 
 // Match reports whether the payload satisfies every active predicate. It
@@ -524,40 +555,88 @@ func (f Filter) Match(p IndexPayload) bool {
 			return false
 		}
 	}
-	if len(f.DocTypes) > 0 {
-		match := false
-		for _, dt := range f.DocTypes {
-			if strings.EqualFold(strings.TrimSpace(dt), strings.TrimSpace(p.DocType)) {
-				match = true
-				break
-			}
-		}
-		if !match {
-			return false
+	return f.matchesDocType(p) && f.matchesMetadata(p)
+}
+
+// matchesDocType is the case-insensitive doc_type set membership, split out of
+// Match to keep that function within the repo's cyclomatic budget.
+func (f Filter) matchesDocType(p IndexPayload) bool {
+	if len(f.DocTypes) == 0 {
+		return true
+	}
+	for _, dt := range f.DocTypes {
+		if strings.EqualFold(strings.TrimSpace(dt), strings.TrimSpace(p.DocType)) {
+			return true
 		}
 	}
-	// Speaker restricts to time-spanned transcript segments attributed to the
-	// requested stable speaker id (SPEC §8.6.8). A payload that carries no
-	// speaker (non-diarized transcript or any non-time chunk) never matches a
-	// non-empty speaker filter, so a corpus without diarized transcripts returns
-	// no speaker-filtered hits.
+	return false
+}
+
+// matchesMetadata evaluates the predicates that read a payload's recorded
+// metadata rather than its path: the diarized speaker (SPEC §8.6.8), the
+// recorded language (SPEC §9.5), and a recognition annotation's attribution
+// (design 0004 §7).
+//
+// Each shares the same shape: a payload that records nothing for a predicate
+// never matches a non-empty filter on it, so a corpus with no diarized
+// transcripts (respectively no recorded language, no annotations) returns
+// nothing rather than falling back to unfiltered results. An empty filter is a
+// no-op in every case.
+func (f Filter) matchesMetadata(p IndexPayload) bool {
 	if speaker := strings.TrimSpace(f.Speaker); speaker != "" {
 		if !strings.EqualFold(speaker, strings.TrimSpace(p.Speaker)) {
 			return false
 		}
 	}
-	// Languages restricts to representations recorded in any of the requested
-	// BCP-47 languages under the selected match mode (SPEC §9.5): primary-subtag
-	// by default, or opt-in region/script narrowing when LanguageMatch is
-	// "strict". A payload with no recorded language (unknown, §8.8) never matches
-	// a non-empty filter, so a corpus indexed before any language was recorded
-	// returns nothing for a specific language filter. Empty filter is a no-op.
 	if len(f.Languages) > 0 {
 		if !LanguageMatchesAnyMode(p.Language, f.Languages, f.LanguageMatch) {
 			return false
 		}
 	}
+	return f.MatchesAnnotation(p.Span)
+}
+
+// MatchesAnnotation evaluates the recognition entity/event predicate against a
+// span (design 0004 §7): OR within each field, AND across them, matched
+// literally because ids and event strings are backend-declared tokens rather
+// than prose. Exported so retrieval applies exactly this rule after
+// materialisation, where the hit's span is in hand, rather than restating it.
+func (f Filter) MatchesAnnotation(span Span) bool {
+	if len(f.Entities) > 0 && !MatchesAnyLiteral(f.Entities, span.Entities) {
+		return false
+	}
+	if len(f.Events) > 0 && !MatchesAnyLiteral(f.Events, []string{span.Event}) {
+		return false
+	}
 	return true
+}
+
+// MatchesAnyLiteral reports whether any requested value appears among the
+// candidate's values, after trimming. Literal rather than case-insensitive:
+// entity ids and event strings are opaque tokens declared by a backend, and
+// folding case could collide two the backend considers distinct.
+func MatchesAnyLiteral(requested, candidate []string) bool {
+	if len(requested) == 0 {
+		return true
+	}
+	have := make(map[string]struct{}, len(candidate))
+	for _, c := range candidate {
+		if c = strings.TrimSpace(c); c != "" {
+			have[c] = struct{}{}
+		}
+	}
+	if len(have) == 0 {
+		return false
+	}
+	for _, r := range requested {
+		if r = strings.TrimSpace(r); r == "" {
+			continue
+		}
+		if _, ok := have[r]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 type SearchQuery struct {
@@ -581,6 +660,21 @@ type SearchQuery struct {
 	// default ("" ⇒ LanguageMatchPrimary) or opt-in region/script narrowing
 	// (LanguageMatchStrict). Inert unless Languages is non-empty.
 	LanguageMatch string
+	// Entities / Events optionally restrict hits to recognition annotations
+	// (dirstral-spec design 0004 §7). Within a field the match is OR: a hit
+	// matches if its annotation references ANY requested entity id
+	// (respectively, if its event equals ANY requested value). Across the two
+	// fields, and against every other filter, the match is AND — so
+	// Entities=[team:x] with Events=[at_bat] is the role-exact selection that
+	// entity ids alone cannot express.
+	//
+	// Values are matched literally. Event strings are backend-declared, so
+	// this defines no vocabulary. Only annotation-derived hits carry these, so
+	// a hit from any other representation never matches a non-empty filter,
+	// mirroring how the media time-window filter admits only time-spanned
+	// hits. Absent/empty disables the filter (unchanged behavior).
+	Entities []string
+	Events   []string
 	// DateFrom / DateTo optionally restrict hits to a document-date window (SPEC
 	// §9.6), compared against each candidate's source-document calendar anchor
 	// (mtime_unix). Both are Unix seconds and both bounds are inclusive; 0 means

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -2939,6 +2939,10 @@ func filterFromQuery(q model.SearchQuery) model.Filter {
 		Speaker:       q.Speaker,
 		Languages:     q.Languages,
 		LanguageMatch: q.LanguageMatch,
+		// Carried so a filtering index can narrow its own candidate pool. The
+		// authoritative check still runs in matchFilters, which sees the span.
+		Entities: q.Entities,
+		Events:   q.Events,
 	}
 }
 
@@ -3896,6 +3900,19 @@ func matchFilters(hit model.SearchHit, query model.SearchQuery) bool {
 		if !strings.EqualFold(speaker, strings.TrimSpace(hit.Span.Speaker)) {
 			return false
 		}
+	}
+
+	// Optional recognition entity/event filter (dirstral-spec design 0004 §7):
+	// restrict to annotation hits referencing any requested entity id, and/or
+	// carrying any requested event. OR within each field, AND across them, so
+	// entities=[team:x] + events=[at_bat] selects one ROLE — the distinction
+	// the wire shape cannot express per-entity and text matching cannot express
+	// at all. Values match literally; event strings are backend-declared, so no
+	// vocabulary is imposed here. A hit whose span carries no attribution —
+	// every non-annotation chunk — never matches a non-empty filter, mirroring
+	// the speaker filter above. Empty filters are a no-op.
+	if !(model.Filter{Entities: query.Entities, Events: query.Events}).MatchesAnnotation(hit.Span) {
+		return false
 	}
 
 	// Optional per-language filter (SPEC §9.5/§15.2-3): restrict to candidates

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -3121,33 +3121,6 @@ func spanFromRow(kind string, start, end int, extraJSON string) model.Span {
 	return model.Span{Kind: "lines"}
 }
 
-// normalizeEntityIDs trims, drops empties, and de-duplicates entity ids while
-// preserving first-seen order. Order is preserved because a backend emits the
-// acting entity first (design 0004 §8: role lives in annotation granularity),
-// and de-duplication keeps a repeated id from inflating a stored annotation.
-func normalizeEntityIDs(ids []string) []string {
-	if len(ids) == 0 {
-		return nil
-	}
-	seen := make(map[string]struct{}, len(ids))
-	out := make([]string, 0, len(ids))
-	for _, id := range ids {
-		id = strings.TrimSpace(id)
-		if id == "" {
-			continue
-		}
-		if _, dup := seen[id]; dup {
-			continue
-		}
-		seen[id] = struct{}{}
-		out = append(out, id)
-	}
-	if len(out) == 0 {
-		return nil
-	}
-	return out
-}
-
 // annotationFromExtraJSON reconstructs a recognition annotation's structured
 // attribution (design 0004 §7) from a "time" span's stored extra_json. A
 // NULL/empty/malformed payload yields no entities and no event, so a span that
@@ -3164,7 +3137,7 @@ func annotationFromExtraJSON(extraJSON string) (entities []string, event string)
 	if err := json.Unmarshal([]byte(extraJSON), &payload); err != nil {
 		return nil, ""
 	}
-	return normalizeEntityIDs(payload.Entities), strings.TrimSpace(payload.Event)
+	return model.NormalizeEntityIDs(payload.Entities), strings.TrimSpace(payload.Event)
 }
 
 // wordsFromExtraJSON reconstructs per-word timing for a "time" span from its
@@ -4052,7 +4025,7 @@ func timeSpanExtraJSON(
 		// stored shape never carries a dangling speaker_label.
 		speakerLabel = ""
 	}
-	entities = normalizeEntityIDs(entities)
+	entities = model.NormalizeEntityIDs(entities)
 	event = strings.TrimSpace(event)
 	if len(words) == 0 && speaker == "" && len(entities) == 0 && event == "" {
 		return "", nil

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -3102,11 +3102,14 @@ func spanFromRow(kind string, start, end int, extraJSON string) model.Span {
 			return model.Span{Kind: "lines"}
 		}
 		speaker, speakerLabel := speakerFromExtraJSON(extraJSON)
+		entities, event := annotationFromExtraJSON(extraJSON)
 		return model.Span{
 			Kind: "time", StartMS: start, EndMS: end,
 			Words:        wordsFromExtraJSON(extraJSON),
 			Speaker:      speaker,
 			SpeakerLabel: speakerLabel,
+			Entities:     entities,
+			Event:        event,
 		}
 	case "region":
 		return regionSpanFromRow(start, end, extraJSON)
@@ -3116,6 +3119,52 @@ func spanFromRow(kind string, start, end int, extraJSON string) model.Span {
 		}
 	}
 	return model.Span{Kind: "lines"}
+}
+
+// normalizeEntityIDs trims, drops empties, and de-duplicates entity ids while
+// preserving first-seen order. Order is preserved because a backend emits the
+// acting entity first (design 0004 §8: role lives in annotation granularity),
+// and de-duplication keeps a repeated id from inflating a stored annotation.
+func normalizeEntityIDs(ids []string) []string {
+	if len(ids) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(ids))
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// annotationFromExtraJSON reconstructs a recognition annotation's structured
+// attribution (design 0004 §7) from a "time" span's stored extra_json. A
+// NULL/empty/malformed payload yields no entities and no event, so a span that
+// predates this (or comes from a transcript) degrades to exactly the behaviour
+// it had before, rather than erroring.
+func annotationFromExtraJSON(extraJSON string) (entities []string, event string) {
+	if strings.TrimSpace(extraJSON) == "" {
+		return nil, ""
+	}
+	var payload struct {
+		Entities []string `json:"entities"`
+		Event    string   `json:"event"`
+	}
+	if err := json.Unmarshal([]byte(extraJSON), &payload); err != nil {
+		return nil, ""
+	}
+	return normalizeEntityIDs(payload.Entities), strings.TrimSpace(payload.Event)
 }
 
 // wordsFromExtraJSON reconstructs per-word timing for a "time" span from its
@@ -3974,7 +4023,7 @@ func spanToRow(span model.Span) (kind string, start int, end int, extraJSON stri
 		if span.StartMS < 0 || span.EndMS < 0 || span.EndMS < span.StartMS {
 			return "", 0, 0, "", errors.New("invalid time span")
 		}
-		extra, eErr := timeSpanExtraJSON(span.Words, span.Speaker, span.SpeakerLabel)
+		extra, eErr := timeSpanExtraJSON(span.Words, span.Speaker, span.SpeakerLabel, span.Entities, span.Event)
 		if eErr != nil {
 			return "", 0, 0, "", eErr
 		}
@@ -3993,7 +4042,9 @@ func spanToRow(span model.Span) (kind string, start int, end int, extraJSON stri
 // returns the empty string (stored as SQL NULL) and round-trips byte-identically
 // to before diarization existed. speaker/speaker_label are trimmed; an empty
 // speaker drops both (a label without a stable id is not a valid attribution).
-func timeSpanExtraJSON(words []model.WordSpan, speaker, speakerLabel string) (string, error) {
+func timeSpanExtraJSON(
+	words []model.WordSpan, speaker, speakerLabel string, entities []string, event string,
+) (string, error) {
 	speaker = strings.TrimSpace(speaker)
 	speakerLabel = strings.TrimSpace(speakerLabel)
 	if speaker == "" {
@@ -4001,14 +4052,21 @@ func timeSpanExtraJSON(words []model.WordSpan, speaker, speakerLabel string) (st
 		// stored shape never carries a dangling speaker_label.
 		speakerLabel = ""
 	}
-	if len(words) == 0 && speaker == "" {
+	entities = normalizeEntityIDs(entities)
+	event = strings.TrimSpace(event)
+	if len(words) == 0 && speaker == "" && len(entities) == 0 && event == "" {
 		return "", nil
 	}
 	payload := struct {
 		Words        []model.WordSpan `json:"words,omitempty"`
 		Speaker      string           `json:"speaker,omitempty"`
 		SpeakerLabel string           `json:"speaker_label,omitempty"`
-	}{Words: words, Speaker: speaker, SpeakerLabel: speakerLabel}
+		Entities     []string         `json:"entities,omitempty"`
+		Event        string           `json:"event,omitempty"`
+	}{
+		Words: words, Speaker: speaker, SpeakerLabel: speakerLabel,
+		Entities: entities, Event: event,
+	}
 	encoded, err := json.Marshal(payload)
 	if err != nil {
 		return "", fmt.Errorf("marshal time span extra_json: %w", err)

--- a/tests/ingest/recognize_entities_persist_test.go
+++ b/tests/ingest/recognize_entities_persist_test.go
@@ -95,3 +95,74 @@ func TestChangedAttributionRedervesTheRepresentation(t *testing.T) {
 		t.Fatalf("hash input no longer covers the annotation text: %q", h0)
 	}
 }
+
+// TestDelimiterBearingEntityIdsCannotCollide is the regression for an ambiguous
+// hash encoding. Entity ids are opaque backend-declared tokens, so a delimiter
+// can legitimately appear inside one. Joining with commas encoded ["a,b","c"]
+// and ["a","b,c"] identically, so two genuinely different attributions produced
+// the same derivation input and the representation would NOT be re-derived —
+// the precise failure the hash exists to prevent.
+func TestDelimiterBearingEntityIdsCannotCollide(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		a, b []string
+	}{
+		{"comma inside an id", []string{"a,b", "c"}, []string{"a", "b,c"}},
+		{"pipe inside an id", []string{"a|b"}, []string{"a", "b"}},
+		{"colon inside an id", []string{"team:x", "y"}, []string{"team", "x:y"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, ha := ingest.RecognitionSegments([]model.RecognizedAnnotation{
+				annotation("same text", "pitch", tc.a, 1, 2),
+			})
+			_, hb := ingest.RecognitionSegments([]model.RecognizedAnnotation{
+				annotation("same text", "pitch", tc.b, 1, 2),
+			})
+			if ha == hb {
+				t.Fatalf("%v and %v hash identically: %q", tc.a, tc.b, ha)
+			}
+		})
+	}
+}
+
+// TestNormalisationMakesTheHashAgreeWithWhatIsStored: a blank or repeated id is
+// dropped before persistence, so it must also be dropped before hashing.
+// Otherwise a backend that emits a stray blank id re-derives a representation
+// whose stored attribution is byte-identical — work for no change.
+func TestNormalisationMakesTheHashAgreeWithWhatIsStored(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		a, b []string
+	}{
+		{"a blank id is not a difference", []string{"a", ""}, []string{"a"}},
+		{"whitespace is trimmed", []string{" a "}, []string{"a"}},
+		{"a repeat is not a difference", []string{"a", "a"}, []string{"a"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, ha := ingest.RecognitionSegments([]model.RecognizedAnnotation{
+				annotation("same text", "pitch", tc.a, 1, 2),
+			})
+			_, hb := ingest.RecognitionSegments([]model.RecognizedAnnotation{
+				annotation("same text", "pitch", tc.b, 1, 2),
+			})
+			if ha != hb {
+				t.Fatalf("%v and %v hash differently (%q vs %q) but store identically", tc.a, tc.b, ha, hb)
+			}
+		})
+	}
+}
+
+// TestTextAndEventCannotBleedIntoEachOther: the same ambiguity applies to the
+// scalar fields, where a delimiter in the annotation text could otherwise
+// impersonate the start of the event field.
+func TestTextAndEventCannotBleedIntoEachOther(t *testing.T) {
+	_, ha := ingest.RecognitionSegments([]model.RecognizedAnnotation{
+		annotation("text|pitch", "", nil, 1, 2),
+	})
+	_, hb := ingest.RecognitionSegments([]model.RecognizedAnnotation{
+		annotation("text", "pitch", nil, 1, 2),
+	})
+	if ha == hb {
+		t.Fatalf("a delimiter in the text impersonated the event field: %q", ha)
+	}
+}

--- a/tests/ingest/recognize_entities_persist_test.go
+++ b/tests/ingest/recognize_entities_persist_test.go
@@ -1,0 +1,97 @@
+package tests
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// dirstral-spec design 0004 §7: a recognition annotation's entity ids and its
+// `event` MUST survive ingestion.
+//
+// They did not. `recognitionSegments` rebuilt each annotation as
+// {startMS, endMS, text}, and `RecognizedAnnotation.Entities` appeared exactly
+// once in the whole codebase — at the line that parsed it off the wire. The
+// backend was required to compute attribution that was then thrown away, which
+// is why the entity filter could not be implemented against data that already
+// existed end to end.
+
+func annotation(text, event string, entities []string, start, end int) model.RecognizedAnnotation {
+	return model.RecognizedAnnotation{
+		StartMS: start, EndMS: end, Text: text, Event: event, Entities: entities,
+	}
+}
+
+func TestAnnotationEntitiesAndEventReachTheChunkSpan(t *testing.T) {
+	segments, _ := ingest.RecognitionSegments([]model.RecognizedAnnotation{
+		annotation("Pitch: Robbie Ray to Dylan Crews", "pitch",
+			[]string{"player:robbie-ray", "team:san-francisco-giants"}, 20300, 28300),
+	})
+	if len(segments) != 1 {
+		t.Fatalf("expected 1 segment, got %d", len(segments))
+	}
+	span := segments[0].Span
+	if span.Event != "pitch" {
+		t.Fatalf("span.Event = %q, want pitch", span.Event)
+	}
+	want := []string{"player:robbie-ray", "team:san-francisco-giants"}
+	if len(span.Entities) != len(want) {
+		t.Fatalf("span.Entities = %v, want %v", span.Entities, want)
+	}
+	for i, id := range want {
+		if span.Entities[i] != id {
+			// Order matters: the acting entity is emitted first, and the filter
+			// is documented as preserving what the backend sent.
+			t.Fatalf("span.Entities[%d] = %q, want %q", i, span.Entities[i], id)
+		}
+	}
+}
+
+// TestAnAnnotationWithNoAttributionIsUnchanged: entities and event are optional,
+// so a backend that sends neither (or a non-annotation representation) produces
+// exactly the span it produced before.
+func TestAnAnnotationWithNoAttributionIsUnchanged(t *testing.T) {
+	segments, _ := ingest.RecognitionSegments([]model.RecognizedAnnotation{
+		annotation("something happened", "", nil, 0, 1000),
+	})
+	if len(segments) != 1 {
+		t.Fatalf("expected 1 segment, got %d", len(segments))
+	}
+	if len(segments[0].Span.Entities) != 0 || segments[0].Span.Event != "" {
+		t.Fatalf("an unattributed annotation gained attribution: %+v", segments[0].Span)
+	}
+}
+
+// TestChangedAttributionRedervesTheRepresentation: the derivation hash must
+// cover the attribution (§8.6.7). Otherwise a backend that fixes which entities
+// an annotation names would leave the old, wrong attribution in place because
+// the prose happens to be identical.
+func TestChangedAttributionRedervesTheRepresentation(t *testing.T) {
+	base := []model.RecognizedAnnotation{
+		annotation("Pitch: Robbie Ray to Dylan Crews", "pitch", []string{"player:robbie-ray"}, 1, 2),
+	}
+	changedEntities := []model.RecognizedAnnotation{
+		annotation("Pitch: Robbie Ray to Dylan Crews", "pitch",
+			[]string{"player:robbie-ray", "team:san-francisco-giants"}, 1, 2),
+	}
+	changedEvent := []model.RecognizedAnnotation{
+		annotation("Pitch: Robbie Ray to Dylan Crews", "at_bat", []string{"player:robbie-ray"}, 1, 2),
+	}
+
+	_, h0 := ingest.RecognitionSegments(base)
+	_, h1 := ingest.RecognitionSegments(changedEntities)
+	_, h2 := ingest.RecognitionSegments(changedEvent)
+
+	if h0 == h1 {
+		t.Fatal("adding an entity left the derivation hash input unchanged")
+	}
+	if h0 == h2 {
+		t.Fatal("changing the event left the derivation hash input unchanged")
+	}
+	// And the text is still in there, so the old invalidation still works.
+	if !strings.Contains(h0, "Pitch: Robbie Ray to Dylan Crews") {
+		t.Fatalf("hash input no longer covers the annotation text: %q", h0)
+	}
+}

--- a/tests/mcp/search_entity_filter_test.go
+++ b/tests/mcp/search_entity_filter_test.go
@@ -1,0 +1,143 @@
+package tests
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// The recognition entity/event filter's TOOL surface (design 0004 §7). The
+// filter semantics live in tests/retrieval; these pin that the arguments are
+// accepted, forwarded verbatim, advertised to clients, and validated.
+
+func entityFilterQuery(t *testing.T, toolName, arguments string) (model.SearchQuery, int, string) {
+	t.Helper()
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+
+	var got model.SearchQuery
+	retriever := &askAudioRetrieverStub{
+		indexingComplete: true,
+		OnSearch: func(q model.SearchQuery) ([]model.SearchHit, error) {
+			got = q
+			return []model.SearchHit{}, nil
+		},
+		OnAskQuery: func(q model.SearchQuery) { got = q },
+	}
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"`+toolName+`","arguments":`+arguments+`}}`)
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	return got, resp.StatusCode, string(body)
+}
+
+func TestSearchForwardsTheEntityAndEventFilters(t *testing.T) {
+	q, status, body := entityFilterQuery(t, "dir2mcp_search",
+		`{"query":"q","entities":["team:sf","player:x"],"events":["at_bat"]}`)
+	if status != http.StatusOK {
+		t.Fatalf("status=%d body=%s", status, body)
+	}
+	if strings.Join(q.Entities, ",") != "team:sf,player:x" {
+		t.Fatalf("entities not forwarded: %v", q.Entities)
+	}
+	if strings.Join(q.Events, ",") != "at_bat" {
+		t.Fatalf("events not forwarded: %v", q.Events)
+	}
+}
+
+// The ask path gets them too: "what did the Giants do in the 7th" is an ask,
+// not a search, and it is the query the whole feature exists for.
+func TestAskForwardsTheEntityAndEventFilters(t *testing.T) {
+	q, status, body := entityFilterQuery(t, "dir2mcp_ask",
+		`{"question":"what happened","entities":["team:sf"],"events":["pitch"]}`)
+	if status != http.StatusOK {
+		t.Fatalf("status=%d body=%s", status, body)
+	}
+	if strings.Join(q.Entities, ",") != "team:sf" {
+		t.Fatalf("entities not forwarded to ask: %v", q.Entities)
+	}
+	if strings.Join(q.Events, ",") != "pitch" {
+		t.Fatalf("events not forwarded to ask: %v", q.Events)
+	}
+}
+
+func TestOmittingTheFiltersLeavesThemUnset(t *testing.T) {
+	q, status, body := entityFilterQuery(t, "dir2mcp_search", `{"query":"q"}`)
+	if status != http.StatusOK {
+		t.Fatalf("status=%d body=%s", status, body)
+	}
+	if len(q.Entities) != 0 || len(q.Events) != 0 {
+		t.Fatalf("absent filters materialised: %+v / %+v", q.Entities, q.Events)
+	}
+}
+
+// TestAnEmptyFilterValueIsRejected: silently ignoring a blank id would turn a
+// caller's bug into "no filtering at all", which is the worst possible failure
+// for a filter — strictly more results than asked for, with no signal.
+func TestAnEmptyFilterValueIsRejected(t *testing.T) {
+	for _, args := range []string{
+		`{"query":"q","entities":["  "]}`,
+		`{"query":"q","events":[""]}`,
+	} {
+		_, _, body := entityFilterQuery(t, "dir2mcp_search", args)
+		if !strings.Contains(body, "INVALID_FIELD") {
+			t.Fatalf("%s was accepted: %s", args, body)
+		}
+	}
+}
+
+// TestTheFiltersAreAdvertisedInTheToolSchema: a client cannot use an argument it
+// cannot discover, and the schema is how discovery happens.
+func TestTheFiltersAreAdvertisedInTheToolSchema(t *testing.T) {
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+	server := httptest.NewServer(mcp.NewServer(cfg, &askAudioRetrieverStub{indexingComplete: true}).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}`)
+	defer func() { _ = resp.Body.Close() }()
+
+	var envelope struct {
+		Result struct {
+			Tools []struct {
+				Name        string `json:"name"`
+				InputSchema struct {
+					Properties map[string]json.RawMessage `json:"properties"`
+				} `json:"inputSchema"`
+			} `json:"tools"`
+		} `json:"result"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		t.Fatalf("decode tools/list: %v", err)
+	}
+	for _, want := range []string{"dir2mcp_search", "dir2mcp_ask"} {
+		found := false
+		for _, tool := range envelope.Result.Tools {
+			if tool.Name != want {
+				continue
+			}
+			found = true
+			for _, field := range []string{"entities", "events"} {
+				if _, ok := tool.InputSchema.Properties[field]; !ok {
+					t.Fatalf("%s does not advertise %q", want, field)
+				}
+			}
+		}
+		if !found {
+			t.Fatalf("tool %s missing from tools/list", want)
+		}
+	}
+}

--- a/tests/retrieval/annotation_entity_filter_test.go
+++ b/tests/retrieval/annotation_entity_filter_test.go
@@ -1,0 +1,194 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
+)
+
+// The recognition entity/event filter (dirstral-spec design 0004 §7).
+//
+// Why it exists rather than matching entity labels in the annotation text: the
+// text approach was measured on a real corpus and degrades retrieval
+// monotonically (design 0004 §6.1, 58.3% -> 47.8% -> 34.8% precision). Every
+// annotation of a moment names BOTH clubs, so the label cannot discriminate
+// between candidates; it only drags a team-scoped query onto whichever role
+// ranks first. "Giants home run" came back as a Giants pitcher throwing balls.
+//
+// The fixture below is that situation exactly: one moment, reported twice, once
+// keyed on the pitcher with the fielding club and once on the batter with the
+// club at the plate. Role lives in annotation granularity because v1's wire
+// shape has a flat entity array and one scalar event, so nothing inside a single
+// annotation can say which id acted.
+
+const (
+	giantsID = "team:san-francisco-giants"
+	natsID   = "team:washington-nationals"
+	rayID    = "player:robbie-ray"
+	crewsID  = "player:dylan-crews"
+)
+
+// addAnnotation upserts a vector whose payload carries a recognition
+// annotation's attribution, mirroring what ingestion persists so the index-side
+// filter (model.Filter.Match over the payload) sees the same thing retrieval's
+// post-materialisation re-check does.
+func addAnnotation(
+	t *testing.T, idx *index.HNSWIndex, id uint64, vec []float32,
+	event string, entities []string, startMS, endMS int,
+) {
+	t.Helper()
+	span := model.Span{
+		Kind: "time", StartMS: startMS, EndMS: endMS,
+		Entities: entities, Event: event,
+	}
+	payload := model.IndexPayload{
+		ChunkID: id, RelPath: "game.mp4", DocType: "video",
+		StartMS: startMS, EndMS: endMS, Span: span,
+	}
+	if err := idx.Upsert(context.Background(), vec, payload); err != nil {
+		t.Fatalf("Upsert(%d): %v", id, err)
+	}
+}
+
+// annotationService builds the two-role fixture: chunk 1 is the pitch (keyed on
+// the pitcher, fielding club), chunk 2 the at-bat (keyed on the batter, club at
+// the plate). Chunk 3 is an ordinary text chunk with no attribution at all.
+func annotationService(t *testing.T) *retrieval.Service {
+	t.Helper()
+	idx := index.NewHNSWIndex("")
+	addAnnotation(t, idx, 1, []float32{1, 0}, "pitch", []string{rayID, giantsID}, 20300, 28300)
+	addAnnotation(t, idx, 2, []float32{0.99, 0.01}, "at_bat", []string{crewsID, natsID}, 20300, 28300)
+	addVecP(t, idx, 3, []float32{0.9, 0.1}, "notes.md", "md")
+
+	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+		"mistral-embed": {1, 0},
+	}}, nil)
+	svc.SetChunkMetadata(1, model.SearchHit{
+		RelPath: "game.mp4", DocType: "video", Snippet: "Pitch: Robbie Ray to Dylan Crews",
+		Span: model.Span{
+			Kind: "time", StartMS: 20300, EndMS: 28300,
+			Entities: []string{rayID, giantsID}, Event: "pitch",
+		},
+	})
+	svc.SetChunkMetadata(2, model.SearchHit{
+		RelPath: "game.mp4", DocType: "video", Snippet: "At bat: Dylan Crews vs Robbie Ray",
+		Span: model.Span{
+			Kind: "time", StartMS: 20300, EndMS: 28300,
+			Entities: []string{crewsID, natsID}, Event: "at_bat",
+		},
+	})
+	svc.SetChunkMetadata(3, model.SearchHit{
+		RelPath: "notes.md", DocType: "md", Snippet: "an ordinary note",
+		Span: model.Span{Kind: "lines", StartLine: 1, EndLine: 3},
+	})
+	return svc
+}
+
+func searchIDs(t *testing.T, svc *retrieval.Service, q model.SearchQuery) []uint64 {
+	t.Helper()
+	q.Query = "moment"
+	if q.K == 0 {
+		q.K = 10
+	}
+	hits, err := svc.Search(context.Background(), q)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	out := make([]uint64, 0, len(hits))
+	for _, h := range hits {
+		out = append(out, h.ChunkID)
+	}
+	return out
+}
+
+// TestEntityAndEventTogetherSelectOneRole is the whole point. The club is
+// present on both annotations of the moment, so the club ALONE cannot express
+// "the Giants batting" — and neither can any phrasing of the text. Conjoining
+// the event does, because event records the role the id is acting in.
+func TestEntityAndEventTogetherSelectOneRole(t *testing.T) {
+	svc := annotationService(t)
+
+	// The Giants field this half-inning, so they appear on the pitch cue only.
+	if got := searchIDs(t, svc, model.SearchQuery{Entities: []string{giantsID}}); len(got) != 1 || got[0] != 1 {
+		t.Fatalf("entities=[giants] = %v, want [1] (the pitch cue)", got)
+	}
+	// Pairing them with the batting role must select nothing: they are not at
+	// the plate here. This is the case a text label gets wrong.
+	if got := searchIDs(t, svc, model.SearchQuery{
+		Entities: []string{giantsID}, Events: []string{"at_bat"},
+	}); len(got) != 0 {
+		t.Fatalf("entities=[giants] events=[at_bat] = %v, want none", got)
+	}
+	// The club actually at the plate, with the same event, does select.
+	if got := searchIDs(t, svc, model.SearchQuery{
+		Entities: []string{natsID}, Events: []string{"at_bat"},
+	}); len(got) != 1 || got[0] != 2 {
+		t.Fatalf("entities=[nationals] events=[at_bat] = %v, want [2]", got)
+	}
+}
+
+// TestValuesWithinAFieldAreOr pins the OR half of the semantics.
+func TestValuesWithinAFieldAreOr(t *testing.T) {
+	svc := annotationService(t)
+	got := searchIDs(t, svc, model.SearchQuery{Entities: []string{giantsID, natsID}})
+	if len(got) != 2 {
+		t.Fatalf("entities=[giants,nationals] = %v, want both annotations", got)
+	}
+	events := searchIDs(t, svc, model.SearchQuery{Events: []string{"pitch", "at_bat"}})
+	if len(events) != 2 {
+		t.Fatalf("events=[pitch,at_bat] = %v, want both annotations", events)
+	}
+}
+
+// TestFieldsAreAndedTogether: entities AND events, never OR. Were it OR, the
+// pitch cue would survive a filter that asks for the batting role.
+func TestFieldsAreAndedTogether(t *testing.T) {
+	svc := annotationService(t)
+	got := searchIDs(t, svc, model.SearchQuery{
+		Entities: []string{rayID},    // on the pitch cue
+		Events:   []string{"at_bat"}, // on the OTHER cue
+	})
+	if len(got) != 0 {
+		t.Fatalf("a filter satisfied by neither annotation returned %v", got)
+	}
+}
+
+// TestAChunkWithNoAttributionNeverMatches mirrors the speaker filter's rule: a
+// corpus with no recognition annotations returns nothing for a non-empty
+// filter, rather than falling back to unfiltered results.
+func TestAChunkWithNoAttributionNeverMatches(t *testing.T) {
+	svc := annotationService(t)
+	for _, q := range []model.SearchQuery{
+		{Entities: []string{"team:nobody"}},
+		{Events: []string{"touchdown"}},
+	} {
+		if got := searchIDs(t, svc, q); len(got) != 0 {
+			t.Fatalf("%+v matched %v; the plain text chunk must not slip through", q, got)
+		}
+	}
+}
+
+// TestAnAbsentFilterIsAPassThrough is the compatibility guard: every caller
+// that sends neither field must see exactly what it saw before.
+func TestAnAbsentFilterIsAPassThrough(t *testing.T) {
+	svc := annotationService(t)
+	if got := searchIDs(t, svc, model.SearchQuery{}); len(got) != 3 {
+		t.Fatalf("unfiltered search = %v, want all three chunks", got)
+	}
+}
+
+// TestMatchingIsLiteralNotCaseFolded: ids and event strings are opaque tokens a
+// backend declares, so folding case could collide two it considers distinct.
+// This is a deliberate difference from the speaker filter, which IS folded.
+func TestMatchingIsLiteralNotCaseFolded(t *testing.T) {
+	svc := annotationService(t)
+	if got := searchIDs(t, svc, model.SearchQuery{Entities: []string{"TEAM:SAN-FRANCISCO-GIANTS"}}); len(got) != 0 {
+		t.Fatalf("a differently-cased id matched %v; ids are opaque tokens", got)
+	}
+	if got := searchIDs(t, svc, model.SearchQuery{Events: []string{"PITCH"}}); len(got) != 0 {
+		t.Fatalf("a differently-cased event matched %v", got)
+	}
+}

--- a/tests/store/annotation_span_attribution_test.go
+++ b/tests/store/annotation_span_attribution_test.go
@@ -1,0 +1,139 @@
+package tests
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// A recognition annotation's entity ids and `event` ride in the "time" span's
+// extra_json, alongside `words` and `speaker` (dirstral-spec design 0004 §7).
+// These pin the round trip: the filter can only select on what comes back out.
+
+// annotationChunk seeds a document + representation and inserts one chunk with
+// the given span, returning the chunk id.
+func annotationChunk(t *testing.T, st *store.SQLiteStore, relPath, repType string, span model.Span) int64 {
+	t.Helper()
+	ctx := context.Background()
+	if err := st.UpsertDocument(ctx, model.Document{
+		RelPath: relPath, DocType: "video", SourceType: "local", Status: "ok",
+	}); err != nil {
+		t.Fatalf("UpsertDocument: %v", err)
+	}
+	doc, err := st.GetDocumentByPath(ctx, relPath)
+	if err != nil {
+		t.Fatalf("GetDocumentByPath: %v", err)
+	}
+	repID, err := st.UpsertRepresentation(ctx, model.Representation{
+		DocID: doc.DocID, RepType: repType, RepHash: "h", CreatedUnix: 1,
+	})
+	if err != nil {
+		t.Fatalf("UpsertRepresentation: %v", err)
+	}
+	chunkID, err := st.InsertChunkWithSpans(ctx, model.Chunk{
+		RepID: repID, Ordinal: 0, Text: "a moment",
+		IndexKind: "text", EmbeddingStatus: "pending",
+	}, []model.Span{span})
+	if err != nil {
+		t.Fatalf("InsertChunkWithSpans: %v", err)
+	}
+	return chunkID
+}
+
+func newAnnotationStore(t *testing.T) *store.SQLiteStore {
+	t.Helper()
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	if err := st.Init(context.Background()); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	return st
+}
+
+func TestAnnotationAttributionRoundTrips(t *testing.T) {
+	st := newAnnotationStore(t)
+	entities := []string{"player:robbie-ray", "team:san-francisco-giants"}
+	chunkID := annotationChunk(t, st, "game.mp4", "recognition", model.Span{
+		Kind: "time", StartMS: 20300, EndMS: 28300,
+		Entities: entities, Event: "pitch",
+	})
+
+	_, _, span, err := st.ChunkMediaSpanByID(context.Background(), chunkID)
+	if err != nil {
+		t.Fatalf("ChunkMediaSpanByID: %v", err)
+	}
+	if span.Event != "pitch" {
+		t.Fatalf("event did not round-trip: %q", span.Event)
+	}
+	if strings.Join(span.Entities, ",") != strings.Join(entities, ",") {
+		// Order is part of the contract: the acting entity is emitted first.
+		t.Fatalf("entities did not round-trip: %v, want %v", span.Entities, entities)
+	}
+}
+
+// TestATranscriptSpanIsUndisturbed is the compatibility guard on the shared
+// extra_json blob. Two optional keys were added to an object that transcripts
+// already write; a transcript without them must store and read back exactly as
+// before, or every existing corpus re-derives for no reason.
+func TestATranscriptSpanIsUndisturbed(t *testing.T) {
+	st := newAnnotationStore(t)
+	chunkID := annotationChunk(t, st, "talk.mp3", "transcript", model.Span{
+		Kind: "time", StartMS: 0, EndMS: 1000, Speaker: "S1", SpeakerLabel: "Host",
+	})
+	_, _, span, err := st.ChunkMediaSpanByID(context.Background(), chunkID)
+	if err != nil {
+		t.Fatalf("ChunkMediaSpanByID: %v", err)
+	}
+	if span.Speaker != "S1" || span.SpeakerLabel != "Host" {
+		t.Fatalf("speaker attribution disturbed: %+v", span)
+	}
+	if len(span.Entities) != 0 || span.Event != "" {
+		t.Fatalf("a transcript span gained annotation attribution: %+v", span)
+	}
+}
+
+// TestASpanWithNoAttributionStoresNothingExtra: the payload is omitempty, so a
+// span carrying neither words, speaker, nor attribution must still write SQL
+// NULL rather than an empty JSON object.
+func TestASpanWithNoAttributionStoresNothingExtra(t *testing.T) {
+	st := newAnnotationStore(t)
+	chunkID := annotationChunk(t, st, "plain.mp4", "recognition", model.Span{
+		Kind: "time", StartMS: 5, EndMS: 10,
+	})
+	_, _, span, err := st.ChunkMediaSpanByID(context.Background(), chunkID)
+	if err != nil {
+		t.Fatalf("ChunkMediaSpanByID: %v", err)
+	}
+	if len(span.Entities) != 0 || span.Event != "" || span.Speaker != "" {
+		t.Fatalf("empty span came back populated: %+v", span)
+	}
+	if span.StartMS != 5 || span.EndMS != 10 {
+		t.Fatalf("span bounds disturbed: %+v", span)
+	}
+}
+
+// TestDuplicateAndBlankEntityIdsAreNormalised: a backend that repeats an id, or
+// pads one, must not inflate the stored attribution or create an id that no
+// filter value can ever equal.
+func TestDuplicateAndBlankEntityIdsAreNormalised(t *testing.T) {
+	st := newAnnotationStore(t)
+	chunkID := annotationChunk(t, st, "dupes.mp4", "recognition", model.Span{
+		Kind: "time", StartMS: 0, EndMS: 1,
+		Entities: []string{" player:a ", "player:a", "", "   ", "player:b"},
+		Event:    "  pitch  ",
+	})
+	_, _, span, err := st.ChunkMediaSpanByID(context.Background(), chunkID)
+	if err != nil {
+		t.Fatalf("ChunkMediaSpanByID: %v", err)
+	}
+	if strings.Join(span.Entities, ",") != "player:a,player:b" {
+		t.Fatalf("entities = %v, want the trimmed de-duplicated pair", span.Entities)
+	}
+	if span.Event != "pitch" {
+		t.Fatalf("event = %q, want the trimmed value", span.Event)
+	}
+}


### PR DESCRIPTION
Implements the deltas from **dirstral-spec#82** (design 0004 §7), and re-pins the submodule to that merged commit per the spec-first loop.

## The gap

A recognition backend attributes every annotation to the entities it names and the event it describes. dir2mcp parsed both off the wire and dropped them: `recognitionSegments` rebuilt each annotation as `{startMS, endMS, text}`, and `RecognizedAnnotation.Entities` appeared **exactly once** in the entire codebase, at `internal/ingest/recognize.go:105` where it was read. The backend was required to compute attribution nothing could ever query.

## Why not just put the labels in the text

Because it was measured, and it is monotonically worse (design 0004 §6.1). Same corpus, same queries, re-embedded per variant, scored on club **and** outcome:

| club in the annotation text | precision |
|---|---|
| omitted (shipped) | **58.3%** |
| appended to each name | 47.8% |
| appended with the role | 34.8% |

`"Giants home run"` returned three correct hits without the club in the text and **zero** with it, its top results becoming a Giants **pitcher** throwing balls and fouls. Every annotation of a moment names both clubs, so the label cannot discriminate between candidates; all it does is drag a team-scoped query onto whichever role ranks first.

Entity AND event is exact, because `event` records the role an id is acting in.

## What this adds

**Persistence.** `entities` and `event` ride in the `time` span's `extra_json`, alongside `words` and `speaker`. They join the derivation hash, so a backend that corrects an annotation's attribution re-derives rather than keeping the old one because the prose happens to match (§8.6.7).

**Filter.** `dir2mcp_search` / `dir2mcp_ask` accept optional `entities` and `events` arrays:

- OR within a field, AND across them and every other filter
- matched **literally** (ids and event strings are backend-declared tokens; folding case could collide two the backend calls distinct), so no vocabulary is imposed
- only annotation-derived hits carry attribution, so any other representation never matches a non-empty filter, exactly as `speaker` behaves
- an id absent from the corpus returns an empty result, not an error

**Qdrant declines push-down.** The attribution lives on the nested `Span`, which that backend does not persist at all, so its default `return true` would have claimed a predicate it cannot evaluate. It falls to the Go-side re-check, mirroring `speaker` and `languages`.

## Notes for review

- `Filter.Match` (index-side) and `matchFilters` (post-materialisation) both route through one exported `Filter.MatchesAnnotation`, so the two paths cannot drift.
- Splitting those predicates out also brings `Match`, `matchFilters` and `handleSearchTool` back under the `gocyclo -over 15` budget, which this change had pushed to 19/17/16.
- `ask_audio` deliberately does **not** gain these: it accepts none of the other filters either.
- **Existing recognition corpora will re-derive once**, because the attribution now participates in the derivation hash. That is the intended semantics, not a side effect, but it is worth knowing before upgrading a large corpus.

## Tests

Four layers, because each could pass while another silently dropped the data:

- `tests/ingest` — attribution reaches the chunk span; an unattributed annotation is unchanged; changing entities or event changes the derivation hash
- `tests/store` — round-trips through SQLite; a transcript span is undisturbed; an empty span still writes NULL rather than `{}`; duplicate/blank ids are normalised
- `tests/retrieval` — the semantics: entity+event selects one role, OR within a field, AND across fields, a chunk with no attribution never matches, an absent filter is a pass-through, matching is not case-folded
- `tests/mcp` — arguments forwarded by both tools, rejected when empty, and advertised in `tools/list`

`make check` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added entity and event filters to search and ask tools.
  * Search supports OR matching within each filter type and AND matching between entity and event filters.
  * Recognition annotations now preserve entity and event details in searchable transcript spans.
* **Bug Fixes**
  * Improved annotation persistence and filtering accuracy, including whitespace cleanup, duplicate removal, and literal value matching.
* **Tests**
  * Added coverage for annotation persistence, filtering behavior, validation, and compatibility with existing transcript data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->