### PR TITLE
ci: run the annotator's test suite, and let it run without the OCR extra

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -90,6 +90,24 @@ jobs:
       - name: Run govulncheck
         run: govulncheck ./...
 
+  # The reference recognition backend (design 0004) is Python, so `go test`
+  # never reaches it. Without this job a PR touching only annotator/ collected
+  # a full set of green checks that had not executed a line of the change --
+  # which is how an ungated precision regression shipped (#779/#787).
+  annotator:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version-file: annotator/pyproject.toml
+
+      - name: Run the annotator test suite
+        run: make test-annotator
+
   conformance:
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -99,6 +99,11 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          # This job installs and runs repository-controlled Python, and has no
+          # later authenticated git operation, so it has no use for the token
+          # checkout otherwise leaves in .git/config.
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,8 @@ coverage.out
 
 # Python bytecode caches
 __pycache__/
+
+# Editable-install metadata. `make test-annotator` installs the annotator with
+# `pip install -e` so the tests exercise the working tree rather than a copy;
+# that writes this alongside the package.
+*.egg-info/

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ build-elevenlabs-bridge:
 up: build
 	./dir2mcp up
 
-.PHONY: all clean clean-all help fmt vet lint cyclo ineffassign misspell test test-race check ci benchmark inspector-smoke conformance
+.PHONY: all clean clean-all help fmt vet lint cyclo ineffassign misspell test test-race test-annotator check ci benchmark inspector-smoke conformance
 
 all: check
 
@@ -90,6 +90,13 @@ test-release-tools:
 
 conformance:
 	go test ./tests/conformance/...
+
+# The reference recognition backend (design 0004) is Python and its suite is
+# not reachable from `go test`, so it needs its own target. Core is stdlib-only
+# by design; the `ocr` extra is installed as well so the vision recognizers'
+# tests run rather than skip (#787).
+test-annotator:
+	cd annotator && python3 -m pip install --quiet -e '.[test,ocr]' && python3 -m pytest -q
 
 check: fmt vet lint cyclo ineffassign misspell test test-release-tools build
 

--- a/annotator/dirstral_annotator/recognizers/overlay.py
+++ b/annotator/dirstral_annotator/recognizers/overlay.py
@@ -147,20 +147,29 @@ def default_ocr(psm: int | None = None, lang: str | None = None) -> OcrFn:
     falls back to `DIRSTRAL_ANNOTATOR_OCR_LANG` and then to whatever the local
     tesseract defaults to. Non-Latin scripts need the matching traineddata
     installed (`tesseract-lang` on Homebrew, `tesseract-ocr-rus` on Debian).
-    """
-    try:
-        import pytesseract  # type: ignore
-        from PIL import Image  # type: ignore
-    except ImportError as exc:
-        raise RecognizerUnavailable(
-            "overlay OCR needs pytesseract + Pillow (pip install "
-            "'dirstral-annotator[ocr]') and a tesseract binary"
-        ) from exc
 
+    The engine is imported on FIRST READ, not here. Building the adapter is not
+    using it: a caller that supplies its own `read_band`, or that never reaches
+    a frame, needs no engine at all. Importing eagerly made CONSTRUCTING any
+    overlay recognizer fail without the `ocr` extra, which left the
+    backend-free interpretation tests unrunnable on a plain checkout even
+    though they never OCR anything. `RecognizerUnavailable` still carries the
+    same message, raised where the engine is actually needed; the pipeline
+    catches it identically either way, because it wraps construction and
+    recognition in one try.
+    """
     config = f"--psm {psm}" if psm is not None else ""
     language = default_lang() if lang is None else lang
 
     def ocr(frame: Path) -> str:
+        try:
+            import pytesseract  # type: ignore
+            from PIL import Image  # type: ignore
+        except ImportError as exc:
+            raise RecognizerUnavailable(
+                "overlay OCR needs pytesseract + Pillow (pip install "
+                "'dirstral-annotator[ocr]') and a tesseract binary"
+            ) from exc
         with Image.open(frame) as img:
             img.load()
             return pytesseract.image_to_string(img, config=config, lang=language)

--- a/annotator/dirstral_annotator/recognizers/overlay.py
+++ b/annotator/dirstral_annotator/recognizers/overlay.py
@@ -172,7 +172,20 @@ def default_ocr(psm: int | None = None, lang: str | None = None) -> OcrFn:
             ) from exc
         with Image.open(frame) as img:
             img.load()
-            return pytesseract.image_to_string(img, config=config, lang=language)
+            try:
+                return pytesseract.image_to_string(img, config=config, lang=language)
+            except pytesseract.TesseractNotFoundError as exc:
+                # The package installs from PyPI but the ENGINE is a separate
+                # native binary, so "installed but unusable" is an ordinary
+                # deployment state rather than an exotic one -- a CI runner
+                # with the `ocr` extra and no apt package is exactly it.
+                # TesseractNotFoundError is not RecognizerUnavailable, so
+                # without this the cascade aborts instead of skipping.
+                raise RecognizerUnavailable(
+                    "overlay OCR needs a tesseract binary on PATH; the "
+                    "pytesseract package is installed but the engine is not "
+                    "(apt install tesseract-ocr / brew install tesseract)"
+                ) from exc
 
     return ocr
 

--- a/annotator/tests/test_overlay.py
+++ b/annotator/tests/test_overlay.py
@@ -334,10 +334,20 @@ def test_a_reader_reports_the_language_it_settled_on(monkeypatch):
     assert OverlayReader(ocr=lambda p: "").lang is None
 
 
-def test_a_missing_engine_degrades_instead_of_aborting(monkeypatch):
+def test_a_missing_engine_degrades_instead_of_aborting(monkeypatch, tmp_path):
+    """A missing engine must surface as RecognizerUnavailable, which the
+    pipeline catches and records as a skip, rather than an unhandled
+    ImportError that takes the run down.
+
+    The raise happens on the first READ, not when the adapter is built:
+    building is not using it, and importing eagerly made constructing any
+    overlay recognizer fail without the `ocr` extra even when the caller
+    supplied its own reader and never OCR'd a frame.
+    """
     monkeypatch.setitem(sys.modules, "pytesseract", None)
+    ocr = overlay.default_ocr()  # building the adapter needs no engine
     with pytest.raises(RecognizerUnavailable):
-        overlay.default_ocr()
+        ocr(tmp_path / "frame.jpg")
 
 
 # --- preprocessing ---------------------------------------------------------

--- a/annotator/tests/test_overlay.py
+++ b/annotator/tests/test_overlay.py
@@ -388,3 +388,34 @@ def test_missing_pillow_degrades_the_cascade(monkeypatch, tmp_path):
     frame.write_bytes(b"\xff\xd8\xff")
     with pytest.raises(RecognizerUnavailable):
         list(overlay._prepared_crops(frame, WHOLE, tmp_path))
+
+
+
+def _write_solid_png(path):
+    """A real, decodable one-pixel image, so the test reaches the OCR call
+    rather than failing in Pillow on the way there."""
+    from PIL import Image
+
+    Image.new("RGB", (4, 4), (0, 0, 0)).save(path)
+
+def test_an_installed_package_with_no_engine_also_degrades(monkeypatch, tmp_path):
+    """pytesseract installs from PyPI; tesseract is a separate native binary.
+    "Package present, engine absent" is an ordinary deployment state -- a CI
+    runner with the `ocr` extra and no apt package is exactly it -- and
+    TesseractNotFoundError is not RecognizerUnavailable, so without translation
+    the cascade aborts instead of skipping.
+    """
+    pytesseract = pytest.importorskip("pytesseract")
+    pytest.importorskip("PIL.Image")
+
+    def missing_engine(*args, **kwargs):
+        raise pytesseract.TesseractNotFoundError()
+
+    monkeypatch.setattr(pytesseract, "image_to_string", missing_engine)
+
+    frame = tmp_path / "band.png"
+    _write_solid_png(frame)
+
+    with pytest.raises(RecognizerUnavailable) as caught:
+        overlay.default_ocr()(frame)
+    assert "tesseract" in str(caught.value).lower()

--- a/annotator/tests/test_parallel_recognizers.py
+++ b/annotator/tests/test_parallel_recognizers.py
@@ -423,3 +423,60 @@ def test_jersey_hands_the_constructed_detector_to_the_first_worker():
 
     detectors = jersey._Detectors(factory, seed=seed)
     assert detectors.current() is seed
+
+
+
+# --- a missing vision stack degrades the RUN, not just the adapter ----------
+
+def _one_scripted_frame(monkeypatch, tmp_path):
+    """Put a single real file on the reader's frame path.
+
+    Frame extraction is ffmpeg's job and not what these assert, so it is
+    replaced; what matters is that the reader reaches the OCR call at all.
+    """
+    from dirstral_annotator.recognizers import overlay
+
+    frame = tmp_path / "frame-00000.jpg"
+    frame.write_bytes(b"stand-in; decoding is patched out too")
+    monkeypatch.setattr(overlay, "iter_frames", lambda *a, **k: iter([(0.0, frame)]))
+    # Hand the frame straight to the OCR call. Rendering the two preprocessing
+    # crops is Pillow's job and has its own contract test; patching it keeps
+    # this test about the ENGINE being missing rather than about whether a
+    # stand-in file happens to decode as a JPEG.
+    monkeypatch.setattr(overlay, "_prepared_crops", lambda f, region, work: iter([f]))
+
+
+@pytest.mark.parametrize("workers", [1, 2])
+def test_a_missing_engine_skips_the_recognizer_instead_of_failing_the_run(
+    monkeypatch, tmp_path, workers
+):
+    """The contract the adapter-level tests imply but do not reach: with no OCR
+    stack installed, the pipeline records a skip and the run continues.
+
+    This is what makes the engine's import site safe to move. The adapter now
+    raises on first read rather than at construction, so the raise happens
+    inside the reader — and, at workers>1, inside a pool. Both are covered
+    here: `Future.result()` re-raises in the calling thread, so the exception
+    type survives, and the pipeline wraps construction and recognition in one
+    try either way.
+    """
+    import sys
+
+    from dirstral_annotator.pipeline import Pipeline
+    from dirstral_annotator.roster import Roster
+
+    monkeypatch.setitem(sys.modules, "pytesseract", None)
+    _one_scripted_frame(monkeypatch, tmp_path)
+    monkeypatch.setenv("DIRSTRAL_ANNOTATOR_WORKERS", str(workers))
+
+    media = tmp_path / "clip.mp4"
+    media.write_bytes(b"stand-in; frame extraction is patched out")
+
+    pipeline = Pipeline(roster=Roster([]), scorebug=True)
+    cues = pipeline.cues_for(media)
+
+    assert cues == []
+    assert pipeline.skipped, "a missing OCR stack produced no skip note"
+    note = " ".join(pipeline.skipped).lower()
+    assert "ocr" in note or "pytesseract" in note or "pillow" in note, \
+        f"the skip note does not say what is missing: {pipeline.skipped}"

--- a/annotator/tests/test_scorebug.py
+++ b/annotator/tests/test_scorebug.py
@@ -298,10 +298,13 @@ def test_an_explicit_crop_pins_the_region(roster, fake_frames):
     assert rec.regions == ((0.0, 0.0, 0.5, 0.2),)
 
 
-def test_missing_ocr_backend_degrades_instead_of_aborting(monkeypatch):
+def test_missing_ocr_backend_degrades_instead_of_aborting(monkeypatch, tmp_path):
+    """As in test_overlay: RecognizerUnavailable, raised on the first read
+    rather than when the adapter is built."""
     monkeypatch.setitem(sys.modules, "pytesseract", None)
+    ocr = scorebug.default_ocr()
     with pytest.raises(RecognizerUnavailable):
-        scorebug.default_ocr()
+        ocr(tmp_path / "frame.jpg")
 
 
 def test_velocity_branch_rejects_implausible_speeds():


### PR DESCRIPTION
Closes #787.

`.github/workflows/` had only Go jobs, so the reference recognition backend's 278 tests never ran. A PR touching only `annotator/` collected a full set of green checks that had not executed a line of the change.

That is worse than having no checks, because the green reads as coverage. It is how an ungated precision regression reached `main` (#779), and why the club-attribution work merged on my local test run rather than on CI (#788).

## Two parts, because the job alone would not have worked

### 1. The suite could not run on a plain checkout

`default_ocr()` imported pytesseract **eagerly**, so merely *constructing* an overlay recognizer failed without the `ocr` extra — including in the twelve backend-free tests that monkeypatch `read_band` and never OCR anything, whose own module docstring says they "run anywhere".

A contributor cloning the repo and installing pyproject's documented `test` extra saw twelve failures that were about their machine, not their change:

```
$ pip install -e '.[test]' && pytest -q
12 failed, 259 passed, 5 skipped
```

The engine is now imported on **first read**. Building an adapter is not using it.

This is the rule the same module already applies to Pillow in `_prepared_crops`, whose comment states it outright:

> a caller's recognize() must degrade the cascade, not abort it, so a missing Pillow has to arrive as RecognizerUnavailable, not ImportError

`default_ocr` was the outlier. Behaviour is unchanged where it matters: the pipeline wraps construction and recognition in one `try`, and `ThreadPoolExecutor` re-raises through `Future.result()`, so the exception type survives the pool.

The two adapter-level tests move their assertion to the first read. Their names promised more than they checked ("degrades instead of aborting" was only asserting a raise), so a **pipeline-level** test now covers what they claim: a missing OCR stack skips the recognizer and the run continues, at `workers=1` **and** `workers=2` — the pooled path being the one my change newly routes through.

### 2. The job

`make test-annotator` installs `-e '.[test,ocr]'`: **editable** so the tests exercise the working tree rather than an installed copy, and **with the ocr extra** so the vision tests run rather than skip.

`actions/setup-python` is SHA-pinned like the other actions here, and reads the version floor from `annotator/pyproject.toml` rather than duplicating it.

## Verification

- **Mutation-checked**, because a job that cannot fail is not a check: breaking `team_id()` fails 4 tests; restoring it returns to 278 green.
- Passes **with** the ocr extra (278) and **without** it (273 + 5 skipped), so the job is honest in either environment.
- The exact CI command was run from a clean venv, not just against my existing one.
- `make check` still passes; no Go behaviour touched.

## Note

`*.egg-info/` is now ignored — the editable install writes it beside the package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OCR setup now completes even when optional OCR components are unavailable.
  * Missing OCR components are reported only when OCR is used, with clearer graceful handling.
  * Recognition continues safely without producing cues when OCR is unavailable, in both serial and parallel processing.

* **Tests**
  * Added regression coverage for missing OCR dependencies and graceful pipeline behavior.
  * Added automated annotator test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->