### PR TITLE
fix(retrieval): stop cross-file dedup collapsing a single document (#782)

### DIFF
--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -2596,11 +2596,16 @@ func dedupMediaCandidates(hits []model.SearchHit) []model.SearchHit {
 // (SPEC 9.1.1) and truncation to k — so the candidate POOL shrinks, preserving
 // the no-result-loss guarantee (a query MAY then return fewer than k hits).
 //
-// Grouping is by content_hash directly. Hits whose rel_path has no known (or an
-// empty) content_hash are passed through untouched and NEVER grouped together.
-// The first (best pre-rerank) survivor per group is kept and the relative order
-// of survivors is preserved, so the result is deterministic. When disabled or
-// when no hash map is loaded, this is a pass-through.
+// Grouping is by content_hash ACROSS DISTINCT documents: a hit is only ever
+// collapsed against a survivor from a different rel_path. A document is not a
+// duplicate of itself, so its own intra-document hits (transcript/recognition
+// time spans, pages, line ranges) all survive; grouping on the hash alone would
+// collapse a single-file corpus to exactly one hit (#782). Hits whose rel_path
+// has no known (or an empty) content_hash are passed through untouched and NEVER
+// grouped together. The first (best pre-rerank) survivor per group claims the
+// group and the relative order of survivors is preserved, so the result is
+// deterministic. When disabled or when no hash map is loaded, this is a
+// pass-through.
 func (s *Service) dedupCrossFileCandidates(hits []model.SearchHit) []model.SearchHit {
 	s.metaMu.RLock()
 	enabled := s.crossFileDedupEnabled
@@ -2611,7 +2616,9 @@ func (s *Service) dedupCrossFileCandidates(hits []model.SearchHit) []model.Searc
 		return hits
 	}
 
-	seen := make(map[string]struct{}, len(hits))
+	// content_hash → rel_path of the document that claimed the group. Storing
+	// the path (not just presence) is what keeps the dedup cross-FILE.
+	claimedBy := make(map[string]string, len(hits))
 	out := make([]model.SearchHit, 0, len(hits))
 	for _, h := range hits {
 		contentHash := groupKeyByRelPath[h.RelPath]
@@ -2620,11 +2627,20 @@ func (s *Service) dedupCrossFileCandidates(hits []model.SearchHit) []model.Searc
 			out = append(out, h)
 			continue
 		}
-		if _, dup := seen[contentHash]; dup {
+		owner, claimed := claimedBy[contentHash]
+		if claimed && owner != h.RelPath {
 			continue
 		}
-		seen[contentHash] = struct{}{}
+		if !claimed {
+			claimedBy[contentHash] = h.RelPath
+		}
 		out = append(out, h)
+	}
+	if collapsed := len(hits) - len(out); collapsed > 0 {
+		// Fewer than k hits is a legal SPEC 9.2 outcome, so candidate loss is
+		// otherwise invisible to an operator debugging thin results (#782).
+		// Same reasoning as OnOversize (#497) and OnUnsafeKey (#735).
+		s.logf("dedup: collapsed %d of %d cross-file duplicate candidates", collapsed, len(hits))
 	}
 	return out
 }

--- a/tests/retrieval/cross_file_dedup_test.go
+++ b/tests/retrieval/cross_file_dedup_test.go
@@ -1,7 +1,10 @@
 package tests
 
 import (
+	"bytes"
 	"context"
+	"log"
+	"strings"
 	"testing"
 
 	"github.com/dirstral/dir2mcp/internal/index"
@@ -128,6 +131,77 @@ func TestSearch_CrossFileDedup_NoMapIsPassThrough(t *testing.T) {
 	got := searchChunkIDs(t, svc, "alpha")
 	if len(got) != 2 {
 		t.Fatalf("no hash map must pass through; got %v", got)
+	}
+}
+
+// TestSearch_CrossFileDedup_SingleDocumentKeepsAllItsHits pins #782: cross-file
+// dedup groups across DISTINCT documents only. Every hit from one document maps
+// to that document's own content_hash, so grouping on the hash alone collapsed a
+// single-file corpus (the normal shape of a video corpus, whose retrievable
+// units are intra-document time spans) to exactly one hit.
+func TestSearch_CrossFileDedup_SingleDocumentKeepsAllItsHits(t *testing.T) {
+	idx := index.NewHNSWIndex("")
+	addVec(t, idx, 1, []float32{1, 0})
+	addVec(t, idx, 2, []float32{0.99, 0.01})
+	addVec(t, idx, 3, []float32{0.95, 0.05})
+
+	svc := newCrossFileDedupService(idx, true, []model.DocumentHash{
+		{RelPath: "game.mp4", ContentHash: "H1"},
+	})
+	// Three distinct moments in the same video: none is a duplicate of another.
+	svc.SetChunkMetadata(1, model.SearchHit{RelPath: "game.mp4", Snippet: "struck out swinging",
+		Span: model.Span{Kind: "time", StartMS: 1000, EndMS: 2000}})
+	svc.SetChunkMetadata(2, model.SearchHit{RelPath: "game.mp4", Snippet: "walked",
+		Span: model.Span{Kind: "time", StartMS: 3000, EndMS: 4000}})
+	svc.SetChunkMetadata(3, model.SearchHit{RelPath: "game.mp4", Snippet: "grand slam",
+		Span: model.Span{Kind: "time", StartMS: 5000, EndMS: 6000}})
+
+	got := searchChunkIDs(t, svc, "at bat")
+
+	want := []uint64{1, 2, 3}
+	if len(got) != len(want) {
+		t.Fatalf("a document must never dedup against itself: want %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("order/survivor mismatch: want %v, got %v", want, got)
+		}
+	}
+}
+
+// TestSearch_CrossFileDedup_AliasCollapsedButOriginalHitsSurvive pins the two
+// rules together: the alias document collapses away (SPEC 9.2) while every hit
+// from the surviving document is kept, including ones ranked below the alias.
+func TestSearch_CrossFileDedup_AliasCollapsedButOriginalHitsSurvive(t *testing.T) {
+	idx := index.NewHNSWIndex("")
+	addVec(t, idx, 1, []float32{1, 0})       // a.md      (hash H1) - best
+	addVec(t, idx, 2, []float32{0.99, 0.01}) // copy/a.md (hash H1) - alias
+	addVec(t, idx, 3, []float32{0.95, 0.05}) // a.md      (hash H1) - second chunk
+
+	svc := newCrossFileDedupService(idx, true, []model.DocumentHash{
+		{RelPath: "a.md", ContentHash: "H1"},
+		{RelPath: "copy/a.md", ContentHash: "H1"},
+	})
+	svc.SetChunkMetadata(1, model.SearchHit{RelPath: "a.md", Snippet: "alpha"})
+	svc.SetChunkMetadata(2, model.SearchHit{RelPath: "copy/a.md", Snippet: "alpha"})
+	svc.SetChunkMetadata(3, model.SearchHit{RelPath: "a.md", Snippet: "alpha again"})
+
+	var logbuf bytes.Buffer
+	svc.SetLogger(log.New(&logbuf, "", 0))
+
+	got := searchChunkIDs(t, svc, "alpha")
+
+	want := []uint64{1, 3}
+	if len(got) != len(want) {
+		t.Fatalf("want %v (alias 2 collapsed, both a.md chunks kept), got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("order/survivor mismatch: want %v, got %v", want, got)
+		}
+	}
+	if !strings.Contains(logbuf.String(), "dedup: collapsed 1 of 3") {
+		t.Fatalf("collapsed candidates must be reported; log was %q", logbuf.String())
 	}
 }
 


### PR DESCRIPTION
Closes #782.

## The defect

`dedupCrossFileCandidates` (`internal/retrieval/service.go`) grouped candidates by `content_hash` alone:

```go
contentHash := groupKeyByRelPath[h.RelPath]
if _, dup := seen[contentHash]; dup {
    continue
}
```

SPEC 9.2 defines this as *cross-file* dedup: collapse **distinct documents** that are byte-identical. The key never checked that the hits came from different files, so every hit from a **single** document mapped to that document's own hash and all but the first was dropped. A document deduped against itself. The function's own docstring already framed it correctly ("collapse candidate hits whose **source documents** share an identical content_hash"); the implementation just did not enforce it.

## Measured impact

Not an edge case for media: a video corpus is commonly one file whose retrievable units are intra-document moments (`kind: "time"` spans). On a real corpus (one 2.2 GB video, 346 recognition chunks, identical query and k):

| `dedup_retrieval` | hits returned | key moment present | generated answer |
|---|---|---|---|
| `false` | 19 | yes | "struck out swinging, walked, and hit a grand slam" |
| `true`  | **1** | no | "struck out swinging." |

The 18 dropped moments (including the grand slam) went before rerank and truncation, and silently: fewer than k hits is a documented legal outcome, so nothing reported the loss.

## What changed

- The grouping map now records the `rel_path` that **claimed** each `content_hash`, and a candidate is collapsed only when the claimant is a **different** document. Intra-document hits (time spans, pages, line ranges) all survive; a genuine alias document still collapses away entirely, including alias hits ranked below the survivor.
- Unchanged: default-off pass-through, the empty/unknown `content_hash` never-grouped rule, first (best pre-rerank) survivor per group, order preservation, and the position of the stage (after fusion, before rerank/truncation).
- Added a log line with the collapsed-candidate count, emitted only when something was actually dropped. Silent candidate loss is hard to diagnose; this follows the observability precedents in #497 (`OnOversize`) and #735 (`OnUnsafeKey`).

No spec change is needed: SPEC 9.2 collapses hits "whose source documents belong to the same duplicate group (§7.9)", and §7.9 duplicate groups are sets of distinct documents. The submodule pointer is untouched.

## Verification

Two new tests in `tests/retrieval/cross_file_dedup_test.go`:

- `TestSearch_CrossFileDedup_SingleDocumentKeepsAllItsHits`: one video, three distinct time-span moments, dedup on. Expects all three.
- `TestSearch_CrossFileDedup_AliasCollapsedButOriginalHitsSurvive`: `a.md` (two chunks) plus its byte-identical alias `copy/a.md` interleaved by rank. Expects the alias gone, both `a.md` chunks kept, and the collapsed-count log line emitted.

Both were confirmed to FAIL against unmodified `main` (source change stashed): each returned exactly `[1]`, reproducing the reported one-hit collapse. They pass with the fix, alongside the four pre-existing SPEC 9.2 tests, which are unchanged.

`make check` passes locally (vet, golangci-lint, `gocyclo -over 15`, misspell, full test suite).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate-result handling so multiple matches within the same document are preserved.
  * Duplicate matches across different paths are now consolidated while retaining the surviving document’s results.
  * Added logging to report how many duplicate candidates were removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->