### PR TITLE
fix(ingest): make a skipped symlink observable at discovery (#781)

### DIFF
--- a/internal/corpusfs/corpusfs.go
+++ b/internal/corpusfs/corpusfs.go
@@ -114,6 +114,23 @@ type Options struct {
 	// form is exactly what could not be trusted. It must not block or panic;
 	// the walker calls it inline.
 	OnUnsafeKey func(key string, err error)
+	// OnSkippedSymlink, when non-nil, is invoked once for every directory entry
+	// dropped because it is a symlink and FollowSymlinks is false (#781).
+	//
+	// The refusal to follow links by default is not in question (#717 tightened
+	// containment for the case where following IS enabled); its invisibility was.
+	// A corpus populated with links into a media library walked to nothing and
+	// reported `scanned: 0, skipped: 0, errors: 0`, which is indistinguishable
+	// from an empty directory or a wrong root_dir. Same reasoning as OnOversize
+	// (#497) and OnUnsafeKey (#735): a policy drop the caller cannot see is a
+	// policy the operator cannot diagnose.
+	//
+	// relPath is the corpus-root-relative slash path of the LINK ITSELF, and it
+	// fires for links to directories as well as to files: with following
+	// disabled the walker never resolves the target, so it cannot tell the two
+	// apart without doing the very thing it was told not to do. It must not
+	// block or panic; the walker calls it inline during the walk.
+	OnSkippedSymlink func(relPath string)
 }
 
 // CachedDirEntry is a directory child's identity recorded in the scan cache: its

--- a/internal/corpusfs/local.go
+++ b/internal/corpusfs/local.go
@@ -237,6 +237,16 @@ func (w *discoverWalker) reportOversize(relPath string, size int64) {
 	}
 }
 
+// reportSkippedSymlink surfaces a symlink dropped because FollowSymlinks is off
+// to the caller-provided Options.OnSkippedSymlink hook (issue #781). Like
+// reportOversize it is a no-op when no hook is set, so which files discovery
+// returns is unchanged: only the caller's ability to see the drop changes.
+func (w *discoverWalker) reportSkippedSymlink(relPath string) {
+	if w.options.OnSkippedSymlink != nil {
+		w.options.OnSkippedSymlink(relPath)
+	}
+}
+
 // visitDir processes a single directory entry that is known to be a directory.
 func (w *discoverWalker) visitDir(ctx context.Context, fullPath, relPath, name string, rules []gitIgnoreRule) error {
 	if shouldSkipDirectory(name) {
@@ -360,6 +370,12 @@ func (w *discoverWalker) processFullEntry(ctx context.Context, absDir, relDir, n
 
 	if lstat.Mode()&os.ModeSymlink != 0 {
 		if !w.options.FollowSymlinks {
+			// Report before returning: this is the only place a not-followed link
+			// is dropped, and the drop is otherwise invisible to the caller (#781).
+			// It stays the single report point because the scan cache refuses to
+			// store a signature for a directory holding a symlink child, so such a
+			// directory is always re-read here rather than served from cache.
+			w.reportSkippedSymlink(relPath)
 			return CachedDirEntry{}, false, nil
 		}
 		if err := w.handleSymlink(ctx, fullPath, relPath, rules); err != nil {

--- a/internal/ingest/discover.go
+++ b/internal/ingest/discover.go
@@ -86,6 +86,11 @@ type DiscoverOptions struct {
 	// above the directory it was asked to walk, but a bucket is untrusted
 	// input and its keys are whatever someone put there.
 	OnUnsafeKey func(key string, err error)
+	// OnSkippedSymlink, when non-nil, is invoked once for each entry dropped
+	// because it is a symlink and FollowSymlinks is false (#781). The entry is
+	// still dropped; this only makes the drop visible, so a corpus made of links
+	// is distinguishable from an empty one. See corpusfs.Options.OnSkippedSymlink.
+	OnSkippedSymlink func(relPath string)
 }
 
 // DefaultDiscoverOptions returns discovery defaults used by ingestion.
@@ -104,12 +109,13 @@ func DefaultDiscoverOptions() DiscoverOptions {
 // corpusfsOptions converts ingest DiscoverOptions to corpusfs.Options.
 func (o DiscoverOptions) corpusfsOptions() corpusfs.Options {
 	return corpusfs.Options{
-		MaxSizeBytes:   o.MaxSizeBytes,
-		UseGitIgnore:   o.UseGitIgnore,
-		FollowSymlinks: o.FollowSymlinks,
-		ScanCache:      o.ScanCache,
-		OnOversize:     o.OnOversize,
-		OnUnsafeKey:    o.OnUnsafeKey,
+		MaxSizeBytes:     o.MaxSizeBytes,
+		UseGitIgnore:     o.UseGitIgnore,
+		FollowSymlinks:   o.FollowSymlinks,
+		ScanCache:        o.ScanCache,
+		OnOversize:       o.OnOversize,
+		OnUnsafeKey:      o.OnUnsafeKey,
+		OnSkippedSymlink: o.OnSkippedSymlink,
 	}
 }
 

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -1698,6 +1698,25 @@ func (s *Service) runScan(ctx context.Context) error {
 			key, unsafeErr,
 		)
 	}
+	// A symlink is dropped at discovery under the default
+	// ingest.follow_symlinks=false, which is right, but until #781 it was also
+	// silent: a corpus of links into a media library reported scanned=0,
+	// skipped=0, errors=0 and a ready daemon, exactly like an empty directory.
+	// Log-only, matching the OnUnsafeKey precedent (#735) rather than the
+	// OnOversize one (#497): the scanned/skipped counters cannot honestly absorb
+	// these yet. SPEC §15.2 closes the skip_reasons enum for a spec minor and
+	// §3.2 requires the file_skip event count to equal the run's terminal
+	// indexing.skipped, so every skipped bump must carry a reason from that enum.
+	// None of the eight describes a not-followed link, and borrowing
+	// path_excluded/ignore_rule would mislabel it in the honest-coverage
+	// aggregate. Counting these belongs behind a spec change that adds the
+	// reason; the log is what unblocks the operator today.
+	discoverOpts.OnSkippedSymlink = func(relPath string) {
+		s.getLogger().Printf(
+			"discovery: skipping %s (symlink); ingest.follow_symlinks is false, so links are not indexed. Set ingest.follow_symlinks: true to include it (a followed link must still resolve inside the corpus root)",
+			relPath,
+		)
+	}
 	discovered, err := s.corpusFS().Walk(ctx, s.cfg.RootDir, discoverOpts.corpusfsOptions())
 	if err != nil {
 		return err

--- a/tests/corpusfs/symlink_skip_781_test.go
+++ b/tests/corpusfs/symlink_skip_781_test.go
@@ -1,0 +1,170 @@
+package tests
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/corpusfs"
+)
+
+// #781: with the default ingest.follow_symlinks=false the LocalFS walker
+// dropped a symlinked entry and told nobody. An operator whose corpus is a
+// curated tree of links into a media library (the natural layout when the media
+// is large and lives elsewhere) saw `scanned: 0, skipped: 0, errors: 0` and a
+// daemon reporting itself ready, which is indistinguishable from an empty
+// directory or a wrong root_dir.
+//
+// Not following links is the right default and is not what these tests pin.
+// They pin that the refusal is observable, the way Options.OnOversize (#497)
+// and Options.OnUnsafeKey (#735) already make their drops observable.
+
+// symlinkOrSkip creates a symlink, skipping the test when the filesystem cannot
+// (Windows without the privilege, or a mount with no symlink support). A skip is
+// honest here: with no link to drop there is nothing to assert.
+func symlinkOrSkip(t *testing.T, target, link string) {
+	t.Helper()
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("filesystem cannot create symlinks (%v); nothing to observe", err)
+	}
+}
+
+// walkReportingSymlinks walks root with following disabled and returns the
+// discovered rel paths plus every rel path handed to OnSkippedSymlink, both
+// sorted so assertions do not depend on directory read order.
+func walkReportingSymlinks(t *testing.T, root string, cache corpusfs.ScanCache) (discovered, skipped []string) {
+	t.Helper()
+	files, err := corpusfs.NewLocalFS(root).Walk(context.Background(), root, corpusfs.Options{
+		MaxSizeBytes:     1 << 20,
+		ScanCache:        cache,
+		OnSkippedSymlink: func(relPath string) { skipped = append(skipped, relPath) },
+	})
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	sort.Strings(skipped)
+	return relPaths(files), skipped
+}
+
+// TestLocalFSWalk_ReportsSkippedSymlinks covers the corpus shape from the issue:
+// links pointing at a library outside the corpus root, so nothing at all is
+// discovered through them.
+func TestLocalFSWalk_ReportsSkippedSymlinks(t *testing.T) {
+	library := t.TempDir()
+	mustWrite(t, filepath.Join(library, "clip.mp4"), []byte("frames"))
+	mustWrite(t, filepath.Join(library, "season", "ep1.mp4"), []byte("more frames"))
+
+	root := t.TempDir()
+	// A file link and a directory link: the walker cannot tell them apart with
+	// following disabled (it never resolves the target), so both must report.
+	symlinkOrSkip(t, filepath.Join(library, "clip.mp4"), filepath.Join(root, "clip.mp4"))
+	symlinkOrSkip(t, filepath.Join(library, "season"), filepath.Join(root, "season"))
+
+	discovered, skipped := walkReportingSymlinks(t, root, nil)
+
+	if len(discovered) != 0 {
+		t.Fatalf("discovered %v; links are still not followed by default", discovered)
+	}
+	want := []string{"clip.mp4", "season"}
+	if !reflect.DeepEqual(skipped, want) {
+		t.Fatalf("OnSkippedSymlink saw %v, want %v (once per dropped link, file and directory alike)", skipped, want)
+	}
+}
+
+// TestLocalFSWalk_SkippedSymlinkDoesNotSuppressRealFiles guards the other half:
+// reporting a link must not cost the ordinary files sitting next to it.
+func TestLocalFSWalk_SkippedSymlinkDoesNotSuppressRealFiles(t *testing.T) {
+	library := t.TempDir()
+	mustWrite(t, filepath.Join(library, "clip.mp4"), []byte("frames"))
+
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "notes.txt"), []byte("hello"))
+	mustWrite(t, filepath.Join(root, "sub", "deep.txt"), []byte("deeper"))
+	symlinkOrSkip(t, filepath.Join(library, "clip.mp4"), filepath.Join(root, "sub", "clip.mp4"))
+
+	discovered, skipped := walkReportingSymlinks(t, root, nil)
+
+	if want := []string{"notes.txt", "sub/deep.txt"}; !reflect.DeepEqual(discovered, want) {
+		t.Fatalf("discovered %v, want %v", discovered, want)
+	}
+	// Reported by its corpus-relative path, not its bare name, so an operator can
+	// find it in a deep tree.
+	if want := []string{"sub/clip.mp4"}; !reflect.DeepEqual(skipped, want) {
+		t.Fatalf("OnSkippedSymlink saw %v, want %v", skipped, want)
+	}
+}
+
+// TestLocalFSWalk_SkippedSymlinkSurvivesScanCache pins the reporting against the
+// directory-scan cache (#267 item 5): a second walk of an unchanged tree must
+// still report the link. The cache is what could plausibly swallow it, since its
+// whole purpose is to avoid re-reading a directory.
+func TestLocalFSWalk_SkippedSymlinkSurvivesScanCache(t *testing.T) {
+	library := t.TempDir()
+	mustWrite(t, filepath.Join(library, "clip.mp4"), []byte("frames"))
+
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "notes.txt"), []byte("hello"))
+	symlinkOrSkip(t, filepath.Join(library, "clip.mp4"), filepath.Join(root, "clip.mp4"))
+
+	cache := newFakeScanCache()
+	want := []string{"clip.mp4"}
+	for i := 1; i <= 2; i++ {
+		_, skipped := walkReportingSymlinks(t, root, cache)
+		if !reflect.DeepEqual(skipped, want) {
+			t.Fatalf("walk %d: OnSkippedSymlink saw %v, want %v", i, skipped, want)
+		}
+	}
+}
+
+// TestLocalFSWalk_FollowSymlinksReportsNoSkips pins the opposite policy: with
+// following enabled a link is not a skip. An in-root link is discovered; a link
+// escaping the root is refused by the #717 containment rule, and that refusal is
+// its own event, not a follow_symlinks skip, so the hook must stay silent.
+func TestLocalFSWalk_FollowSymlinksReportsNoSkips(t *testing.T) {
+	outside := t.TempDir()
+	mustWrite(t, filepath.Join(outside, "secret.txt"), []byte("top secret"))
+
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "real", "inside.txt"), []byte("in the corpus"))
+	symlinkOrSkip(t, filepath.Join(root, "real", "inside.txt"), filepath.Join(root, "alias.txt"))
+	symlinkOrSkip(t, filepath.Join(outside, "secret.txt"), filepath.Join(root, "escape.txt"))
+
+	var skipped []string
+	files, err := corpusfs.NewLocalFS(root).Walk(context.Background(), root, corpusfs.Options{
+		MaxSizeBytes:     1 << 20,
+		FollowSymlinks:   true,
+		OnSkippedSymlink: func(relPath string) { skipped = append(skipped, relPath) },
+	})
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+
+	if want := []string{"alias.txt", "real/inside.txt"}; !reflect.DeepEqual(relPaths(files), want) {
+		t.Fatalf("discovered %v, want %v (the escaping link stays out, #717)", relPaths(files), want)
+	}
+	if len(skipped) != 0 {
+		t.Fatalf("OnSkippedSymlink fired %v with follow_symlinks enabled; nothing was skipped for being a link", skipped)
+	}
+}
+
+// TestLocalFSWalk_NilSkippedSymlinkHookIsSafe keeps the hook optional: an
+// unset callback must leave the walk exactly as it was, not panic.
+func TestLocalFSWalk_NilSkippedSymlinkHookIsSafe(t *testing.T) {
+	library := t.TempDir()
+	mustWrite(t, filepath.Join(library, "clip.mp4"), []byte("frames"))
+
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "notes.txt"), []byte("hello"))
+	symlinkOrSkip(t, filepath.Join(library, "clip.mp4"), filepath.Join(root, "clip.mp4"))
+
+	files, err := corpusfs.NewLocalFS(root).Walk(context.Background(), root, corpusfs.Options{MaxSizeBytes: 1 << 20})
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if want := []string{"notes.txt"}; !reflect.DeepEqual(relPaths(files), want) {
+		t.Fatalf("discovered %v, want %v", relPaths(files), want)
+	}
+}

--- a/tests/ingest/discover_test.go
+++ b/tests/ingest/discover_test.go
@@ -112,6 +112,42 @@ func TestDiscoverFilesWithOptions_OnOversize_NotCalledWhenAllFit(t *testing.T) {
 	}
 }
 
+// TestDiscoverFilesWithOptions_OnSkippedSymlink_IsPluggedThrough asserts the
+// ingest layer actually hands its hook to the walker (#781). The walker-level
+// behavior is covered in tests/corpusfs; what this pins is the plumbing, because
+// a dropped field in corpusfsOptions would silently restore the old
+// scanned=0/skipped=0 blindness with every corpusfs test still passing.
+func TestDiscoverFilesWithOptions_OnSkippedSymlink_IsPluggedThrough(t *testing.T) {
+	library := t.TempDir()
+	mustWriteFile(t, filepath.Join(library, "clip.mp4"), []byte("frames"))
+
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, "keep.txt"), []byte("hi"))
+	if err := os.Symlink(filepath.Join(library, "clip.mp4"), filepath.Join(root, "clip.mp4")); err != nil {
+		t.Skipf("filesystem cannot create symlinks (%v); nothing to observe", err)
+	}
+
+	var skipped []string
+	files, err := ingest.DiscoverFilesWithOptions(context.Background(), root, ingest.DiscoverOptions{
+		MaxSizeBytes:     1 << 20,
+		OnSkippedSymlink: func(relPath string) { skipped = append(skipped, relPath) },
+	})
+	if err != nil {
+		t.Fatalf("DiscoverFilesWithOptions failed: %v", err)
+	}
+
+	got := make([]string, 0, len(files))
+	for _, f := range files {
+		got = append(got, f.RelPath)
+	}
+	if !slices.Equal(got, []string{"keep.txt"}) {
+		t.Fatalf("expected only the regular file discovered, got %v", got)
+	}
+	if !slices.Equal(skipped, []string{"clip.mp4"}) {
+		t.Fatalf("OnSkippedSymlink saw %v, want [clip.mp4]", skipped)
+	}
+}
+
 func TestDiscoverFiles_ContextCancelled(t *testing.T) {
 	root := t.TempDir()
 	mustWriteFile(t, filepath.Join(root, "a.txt"), []byte("x"))


### PR DESCRIPTION
Closes #781.

## The failure an operator actually sees

With the default `ingest.follow_symlinks: false`, `LocalFS`'s walker dropped a symlinked entry and said nothing: no callback, no log, no counter. A corpus populated with links into a media library (the natural layout when the media is large and lives elsewhere, and how #781 was hit while standing up the Giants demo) produces:

```
"scanned": 0, "indexed": 0, "skipped": 0, "errors": 0
```

plus a daemon reporting itself healthy and ready for connections. Nothing scanned, nothing skipped, nothing errored. That is indistinguishable from an empty directory or a misconfigured `root_dir`, and the one field that could hint at an exclusion (`skipped`) says nothing happened.

## The two precedents

Refusing to follow links by default is right and not touched here (#717 tightened containment for the case where following IS enabled). The gap is that the refusal was invisible, and this repo has already decided how to handle that, twice:

- **#497** added `Options.OnOversize`, which is why a size-capped file now logs `discovery: skipping giants_segment.mp4 (2292120009 bytes) ... exceeds ingest.max_file_mb cap`.
- **#735** added `Options.OnUnsafeKey`, on the stated rationale that "a silent skip looks the same as an empty prefix".

A silently skipped symlink looks the same as an empty corpus. Same failure mode, no callback.

## What changed

- `corpusfs.Options.OnSkippedSymlink func(relPath string)`: invoked once per entry dropped for being a symlink while `FollowSymlinks` is false, carrying the corpus-relative slash path of the link itself. Named and shaped after its two siblings; a nil hook is a no-op, so which files discovery returns is unchanged.
- `local.go`: `reportSkippedSymlink` mirrors `reportOversize`, called from the single `!FollowSymlinks` branch in `processFullEntry`. It fires for links to directories as well as to files: with following disabled the walker never resolves the target, so it cannot tell the two apart without doing the thing it was told not to do. It stays the single report point because the scan cache refuses to store a signature for a directory holding a symlink child, so such a directory is always re-read through this branch.
- `ingest.DiscoverOptions.OnSkippedSymlink` plumbed through `corpusfsOptions()`.
- `runScan` logs each drop, naming the key that caused it and how to change it:

```
discovery: skipping season/ep1.mp4 (symlink); ingest.follow_symlinks is false, so links are not indexed. Set ingest.follow_symlinks: true to include it (a followed link must still resolve inside the corpus root)
```

`follow_symlinks: true` is untouched: a link is followed and discovered, and an escaping link is still refused by the #717 containment rule. That refusal is its own event, not a `follow_symlinks` skip, so the hook deliberately stays silent there.

## The counter decision: log-only, and why

I looked hard at counting these as `skipped`, since the issue is right that `scanned: 0, skipped: 0` over a non-empty directory is its own small lie. I landed on log-only, matching the `OnUnsafeKey` precedent rather than the `OnOversize` one, because the counters cannot absorb these honestly today:

- SPEC §15.2 declares the `skip_reasons` enum **closed for a given spec minor** (`unsupported_format`, `binary_ignored`, `archive`, `ignore_rule`, `secret_excluded`, `path_excluded`, `size_cap`, `language_uncovered`); new reasons arrive only by a minor bump.
- SPEC §3.2 requires that "the count of `file_skip` events emitted for a run equals the run's terminal `indexing.skipped`". Every existing `addSkipped(1)` in `runScan`/`scanPass` is paired with a `notifyDocumentSkip` carrying a reason from that enum (size-cap persists a `size_cap` row; path-excludes emit the event without persisting).

So bumping `skipped` for a not-followed link would either break that normative equality, or force a `file_skip` with a mislabelled reason: none of the eight describes a link, and `path_excluded` / `ignore_rule` would corrupt the honest-coverage aggregate that #414/#395 exist to make trustworthy. Per the spec-first governance loop, adding a `skip_reason` for this belongs in a `dirstral-spec` PR first, and the code change to count it would then be a small follow-up on top of the callback this PR adds. The log is what unblocks the operator today, and it is the same level of observability #735 chose for its own class of silent drop. I did not touch the submodule pointer.

## Verification

- `make check` passes (exit 0), including `gocyclo -over 15`; the added code introduces no new branches in `runScan`.
- New `tests/corpusfs/symlink_skip_781_test.go`, covering the issue's suggested regression list: an all-symlinks corpus (file link and directory link, each reported exactly once, nothing discovered); a regular file alongside a link still indexing with the link reported by its deep rel path; the report surviving a second walk with the scan cache enabled; `follow_symlinks: true` reporting no skips while still enforcing #717 containment; and a nil hook leaving the walk untouched. Symlink creation failures `t.Skip` cleanly.
- New plumbing test in `tests/ingest/discover_test.go`, because a dropped field in `corpusfsOptions` would silently restore the old blindness with every corpusfs test still green.
- **Fail-first confirmed**: I stashed only `internal/corpusfs/local.go` (keeping the option defined and plumbed so the tests still compiled) and re-ran. `TestLocalFSWalk_ReportsSkippedSymlinks`, `..._SkippedSymlinkDoesNotSuppressRealFiles`, `..._SkippedSymlinkSurvivesScanCache` and `TestDiscoverFilesWithOptions_OnSkippedSymlink_IsPluggedThrough` all failed with `OnSkippedSymlink saw []`. Restoring the stash turned them green.
