### PR TITLE
fix(embeddings): retry chunks stranded in error without re-ingesting (#783)

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ DIR2MCP_DEMO_TOKEN="$(cat .dir2mcp/secret.token)" \
 | `search "<query>"` | Legacy compatibility shim; prefer `dirstral-cli` for client UX |
 | `open-file <rel-path>` | Legacy compatibility shim; prefer `dirstral-cli` for client UX |
 | `list-files` | Legacy compatibility shim; prefer `dirstral-cli` for client UX |
-| `reindex` | Force full re-ingestion |
+| `reindex` | Force full re-ingestion. `--embeddings-only` instead retries just the chunks that failed to embed (see [Recovering from a failed embed run](#recovering-from-a-failed-embed-run)) |
 | `embed-worker` | Run a standalone distributed embed worker (no MCP serving; requires a Tier-C store + broker) |
 | `export` | Render a transcript as VTT/SRT/TTML subtitles (`export --format vtt\|srt\|ttml <path>`) |
 | `bridge` | Run helper adapters (for example the ElevenLabs webhook bridge) |
@@ -269,6 +269,21 @@ DIR2MCP_DEMO_TOKEN="$(cat .dir2mcp/secret.token)" \
 
 Running `dir2mcp` with no arguments prints usage, which you can consult anytime to see available commands.
 `ask`, `search`, `open-file`, and `list-files` are legacy compatibility shims; new client/orchestrator UX belongs in `dirstral-cli`.
+
+### Recovering from a failed embed run
+
+When the embedding provider rejects a request for a reason that is not the chunk's fault (a key revoked, rotated or billing-suspended mid-run, a quota that went hard-limit, an upstream outage), the affected chunks are recorded as failed and are **not** retried on their own. Restarting the daemon with a working credential does not help by itself: the chunks are in an error state, not a pending one, so `status` reports `embedded_pending=0, errors=N` and the worker sits idle.
+
+Fix the provider first, then re-queue the failed chunks:
+
+```bash
+dir2mcp reindex --embeddings-only                          # retry the provider-side failures
+dir2mcp reindex --embeddings-only --error-category auth    # or just one category
+```
+
+This re-runs only the embed step: extraction (OCR, transcription, media analysis) is **not** repeated, which is the whole point — extraction is usually the expensive half and its output has not changed. It is safe to run while the daemon is up; the running embed worker picks the chunks up on its next cycle. With no daemon running, start one with `dir2mcp up`.
+
+By default it retries the categories a provider fix can plausibly clear: `auth`, `rate_limit`, `transient_net`, and `unknown` (the catch-all for failures the classifier could not label). Failures that are a property of the stored input — `payload_too_large`, `parse_error`, `embedding_failure`, `quality_gate` — are left alone, because re-sending identical bytes to the same provider just fails again; those need a real re-ingest (`dir2mcp reindex`) after changing the input or the configuration. `dir2mcp doctor` names the retryable count when there is one.
 
 ### Auto-start at login (macOS)
 

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -660,6 +660,16 @@ func (a *App) printUsage() {
 	}
 	writeln(o)
 
+	writeln(o, s.sectionHeader("Reindex Flags")+" "+s.Dim.Render("(reindex)"))
+	reindexFlags := [][2]string{
+		{"--embeddings-only", "retry chunks that failed to embed, without re-running extraction"},
+		{"--error-category <csv>", "with --embeddings-only: which failure categories to retry"},
+	}
+	for _, f := range reindexFlags {
+		writef(o, "  %-30s %s\n", s.Accent.Render(f[0]), s.Dim.Render(f[1]))
+	}
+	writeln(o)
+
 	writeln(o, s.sectionHeader("Payment Flags")+" "+s.Dim.Render("(up, x402)"))
 	x402Flags := [][2]string{
 		{"--x402 <mode>", "payment gating: off | on | required"},

--- a/internal/cli/reindex.go
+++ b/internal/cli/reindex.go
@@ -25,9 +25,21 @@ import (
 const reindexProgressInterval = 5 * time.Second
 
 func (a *App) runReindex(ctx context.Context, global globalOptions, args []string) int {
-	if len(args) > 0 {
-		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("reindex command does not accept arguments: %s", strings.Join(args, " ")))
+	opts, positional, err := parseReindexOptions(args)
+	if err != nil {
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("invalid reindex flags: %v", err))
 		return exitConfigInvalid
+	}
+	if len(positional) > 0 {
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("reindex command does not accept arguments: %s", strings.Join(positional, " ")))
+		return exitConfigInvalid
+	}
+	// --embeddings-only is a different operation, not a narrower rebuild: it
+	// re-queues chunks a provider rejected and touches neither the extracted
+	// representations nor the on-disk index, so it skips the staging, the
+	// live-daemon refusal and the destructive-action prompt below (issue #783).
+	if opts.embeddingsOnly {
+		return a.runReindexEmbeddingsOnly(ctx, global, opts)
 	}
 
 	cfg, code := a.loadReindexConfig(global)

--- a/internal/cli/retry_embeddings.go
+++ b/internal/cli/retry_embeddings.go
@@ -1,0 +1,253 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// reindexOptions holds the parsed `dir2mcp reindex` flags.
+type reindexOptions struct {
+	// embeddingsOnly selects the embed-step retry instead of a full rebuild:
+	// failed chunks are moved back to pending WITHOUT re-running extraction.
+	embeddingsOnly bool
+	// errorCategories narrows the retry to specific store.ErrorCategory values.
+	// Empty selects the default retryable set (store.RequeueableErrorCategories).
+	errorCategories []string
+}
+
+// parseReindexOptions parses the reindex flag set. Positional arguments are
+// still rejected by the caller with the historical message, so scripts that
+// depend on that contract are unaffected.
+func parseReindexOptions(args []string) (reindexOptions, []string, error) {
+	opts := reindexOptions{}
+	var categories string
+	fs := flag.NewFlagSet("reindex", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	fs.BoolVar(&opts.embeddingsOnly, "embeddings-only", false,
+		"retry chunks that failed to embed (reset them to pending) without re-running extraction")
+	fs.StringVar(&categories, "error-category", "",
+		"comma-separated error categories to retry (default: "+strings.Join(store.RequeueableErrorCategories(), ",")+")")
+	if err := fs.Parse(args); err != nil {
+		return reindexOptions{}, nil, err
+	}
+
+	parsed, err := parseErrorCategoryList(categories)
+	if err != nil {
+		return reindexOptions{}, nil, err
+	}
+	if len(parsed) > 0 && !opts.embeddingsOnly {
+		// A full rebuild re-creates every chunk, so it has no notion of retrying
+		// a subset by failure category. Silently ignoring the filter would let an
+		// operator believe they had scoped a run that in fact reprocesses the
+		// whole corpus.
+		return reindexOptions{}, nil, errors.New("--error-category is only valid with --embeddings-only")
+	}
+	opts.errorCategories = parsed
+	return opts, fs.Args(), nil
+}
+
+// parseErrorCategoryList splits and validates a comma-separated
+// --error-category value. An unrecognized name is rejected with the real
+// vocabulary rather than accepted into a retry that would match zero rows and
+// report a confusing "0 chunks requeued".
+func parseErrorCategoryList(raw string) ([]string, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+	out := []string{}
+	for _, field := range strings.Split(raw, ",") {
+		name := strings.TrimSpace(field)
+		if name == "" {
+			continue
+		}
+		if !store.IsKnownErrorCategory(name) {
+			return nil, fmt.Errorf("unknown error category %q (known: %s)", name, strings.Join(store.KnownErrorCategories(), ", "))
+		}
+		out = append(out, strings.ToLower(name))
+	}
+	if len(out) == 0 {
+		return nil, errors.New("--error-category was empty")
+	}
+	return out, nil
+}
+
+// failedChunkRequeuer is the optional store capability the embed-step retry
+// needs: move chunks parked in embedding_status='error' back to pending. Kept
+// as a local interface (the contentHashBackuper pattern) so a non-sqlite store
+// degrades to a clear "unsupported" error instead of a nil-pointer panic.
+type failedChunkRequeuer interface {
+	RequeueFailedChunks(ctx context.Context, categories []string) (int64, error)
+}
+
+// runReindexEmbeddingsOnly retries the embed step for chunks that a provider
+// rejected, without re-running extraction (issue #783).
+//
+// This is the recovery path for a credential- or provider-shaped failure. A key
+// that is valid at startup and then revoked, rotated, billing-suspended, or
+// rate-limited into a non-retryable class strands every chunk it touches in
+// embedding_status='error', and nothing moved those chunks back: the only
+// statement that resets a chunk to pending is the ingest-time chunk upsert. So
+// the only supported recovery was re-ingesting the affected documents, which
+// redoes extraction (the expensive half: OCR, transcription, a recognition
+// cascade over a video) purely to redo the embed step (seconds). The §2.5
+// startup probe added for issue #399 prevents the failure from beginning; it
+// cannot help a daemon that is already up when the credential dies.
+//
+// Deliberately NOT guarded by refuseReindexIfDaemonRunning, unlike a full
+// rebuild. That guard exists because a rebuild clears content hashes and
+// unlinks index files under a process that holds them open (#418). This path
+// does neither: it is one UPDATE over the chunks table, which WAL plus the
+// store's busy_timeout already serialize, and a chunk in 'error' never had a
+// vector written for it, so there is nothing in the live index to reconcile.
+// Running it under a live daemon is in fact the fastest recovery there is: the
+// daemon's embed worker polls NextPending on a ticker and drains the requeued
+// chunks without a restart.
+//
+// It also does not prompt: it is not destructive (a chunk that fails again
+// simply returns to 'error'), and prompting would break exactly the scripted,
+// non-interactive recovery this exists to enable.
+func (a *App) runReindexEmbeddingsOnly(ctx context.Context, global globalOptions, opts reindexOptions) int {
+	cfg, code := a.loadReindexConfig(global)
+	if code != exitSuccess {
+		return code
+	}
+
+	st := a.storeForConfig(cfg)
+	defer a.closeStoreWithLog(st)
+	if err := st.Init(ctx); err != nil && !errors.Is(err, model.ErrNotImplemented) {
+		writeStoreInitError(a.stderr, global.jsonOutput, exitIndexLoadFailure, err, fmt.Sprintf("initialize metadata store: %v", err))
+		return exitIndexLoadFailure
+	}
+	requeuer, ok := interface{}(st).(failedChunkRequeuer)
+	if !ok {
+		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, "configured store does not support retrying failed embeddings")
+		return exitGeneric
+	}
+
+	categories := opts.errorCategories
+	if len(categories) == 0 {
+		categories = store.RequeueableErrorCategories()
+	}
+	// Read the failure breakdown BEFORE the retry: afterwards the requeued rows
+	// are gone from it, and the per-category counts are what make the result
+	// legible ("346 auth", not just "346").
+	failed := failedCategoryCounts(ctx, st)
+
+	requeued, err := requeuer.RequeueFailedChunks(ctx, categories)
+	if err != nil {
+		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("retry failed embeddings: %v", err))
+		return exitGeneric
+	}
+
+	return a.reportEmbeddingsOnlyRetry(global, cfg, categories, failed, requeued)
+}
+
+// failedCategoryCounts returns the currently-failed chunk counts by error
+// category, or nil when the store cannot supply them. Best-effort: the retry
+// itself does not depend on this, it only makes the report specific.
+func failedCategoryCounts(ctx context.Context, st model.Store) map[string]int64 {
+	stats, ok := corpusStatsForReindex(ctx, st)
+	if !ok || stats.FailureSummary == nil {
+		return nil
+	}
+	return stats.FailureSummary.Categories
+}
+
+// reportEmbeddingsOnlyRetry renders the retry result in the CLI's JSON and
+// human styles, including what was left alone and what happens next.
+func (a *App) reportEmbeddingsOnlyRetry(global globalOptions, cfg config.Config, categories []string, failed map[string]int64, requeued int64) int {
+	daemonRunning := daemonIsLive(cfg.StateDir)
+	retried, terminal := splitFailedCounts(failed, categories)
+
+	if global.jsonOutput {
+		payload := map[string]interface{}{
+			"state_dir":       cfg.StateDir,
+			"embeddings_only": true,
+			"categories":      categories,
+			"requeued":        requeued,
+			"daemon_running":  daemonRunning,
+		}
+		if len(retried) > 0 {
+			// Observed immediately BEFORE the retry, so it explains the total
+			// rather than restating it; the two can differ by chunks a live
+			// daemon failed in between.
+			payload["matched_by_category"] = retried
+		}
+		if len(terminal) > 0 {
+			payload["not_retried_by_category"] = terminal
+		}
+		if err := emitJSON(a.stdout, payload); err != nil {
+			writeCLIError(a.stderr, true, exitGeneric, fmt.Sprintf("encode reindex json: %v", err))
+			return exitGeneric
+		}
+		return exitSuccess
+	}
+	if global.quiet {
+		return exitSuccess
+	}
+
+	writef(a.stderr, "[reindex] embeddings-only: requeued %d chunk(s) for embedding [categories=%s]\n",
+		requeued, strings.Join(categories, ","))
+	if breakdown := formatCategoryCounts(terminal); breakdown != "" {
+		writef(a.stderr, "[reindex] not retried (terminal; re-ingest to change the input): %s\n", breakdown)
+	}
+	switch {
+	case requeued == 0:
+		writeln(a.stderr, "[reindex] nothing to retry: no failed chunks in those categories")
+	case daemonRunning:
+		writeln(a.stderr, "[reindex] a daemon is running here; its embed worker will pick these up on its next cycle")
+	default:
+		writeln(a.stderr, "[reindex] run `dir2mcp up` to embed them")
+	}
+	return exitSuccess
+}
+
+// splitFailedCounts partitions the currently-failed counts into the categories
+// this run retried and those it left alone, so the report can say why the
+// untouched ones stayed put instead of silently under-reporting.
+func splitFailedCounts(failed map[string]int64, categories []string) (retried, terminal map[string]int64) {
+	if len(failed) == 0 {
+		return nil, nil
+	}
+	selected := make(map[string]struct{}, len(categories))
+	for _, c := range categories {
+		selected[c] = struct{}{}
+	}
+	retried = map[string]int64{}
+	terminal = map[string]int64{}
+	for category, n := range failed {
+		if _, ok := selected[category]; ok {
+			retried[category] = n
+			continue
+		}
+		terminal[category] = n
+	}
+	return retried, terminal
+}
+
+// formatCategoryCounts renders a stable "category=N category=N" line, or ""
+// when there is nothing to report.
+func formatCategoryCounts(counts map[string]int64) string {
+	if len(counts) == 0 {
+		return ""
+	}
+	names := make([]string, 0, len(counts))
+	for name := range counts {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	parts := make([]string, 0, len(names))
+	for _, name := range names {
+		parts = append(parts, fmt.Sprintf("%s=%d", name, counts[name]))
+	}
+	return strings.Join(parts, " ")
+}

--- a/internal/cli/retry_embeddings_internal_test.go
+++ b/internal/cli/retry_embeddings_internal_test.go
@@ -1,0 +1,99 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestParseReindexOptions covers the flag contract of the #783 embed-step
+// retry, including the combinations that must be refused rather than silently
+// reinterpreted.
+func TestParseReindexOptions(t *testing.T) {
+	cases := []struct {
+		name           string
+		args           []string
+		wantErr        string
+		wantEmbedOnly  bool
+		wantCategories []string
+		wantPositional []string
+	}{
+		{
+			name: "bare reindex keeps the full-rebuild shape",
+			args: nil,
+		},
+		{
+			name:          "embeddings-only",
+			args:          []string{"--embeddings-only"},
+			wantEmbedOnly: true,
+		},
+		{
+			name:           "category list is split and lower-cased",
+			args:           []string{"--embeddings-only", "--error-category", "Auth, rate_limit"},
+			wantEmbedOnly:  true,
+			wantCategories: []string{"auth", "rate_limit"},
+		},
+		{
+			name:           "positional args survive for the caller to reject",
+			args:           []string{"extra"},
+			wantPositional: []string{"extra"},
+		},
+		{
+			// A full rebuild re-creates every chunk, so a per-category filter has
+			// no meaning there; accepting it would imply a scoped run that is in
+			// fact a whole-corpus reprocess.
+			name:    "category filter requires embeddings-only",
+			args:    []string{"--error-category", "auth"},
+			wantErr: "only valid with --embeddings-only",
+		},
+		{
+			name:    "unknown category is rejected with the vocabulary",
+			args:    []string{"--embeddings-only", "--error-category", "auth,nope"},
+			wantErr: "unknown error category",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts, positional, err := parseReindexOptions(tc.args)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err = %v, want one containing %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseReindexOptions: %v", err)
+			}
+			if opts.embeddingsOnly != tc.wantEmbedOnly {
+				t.Errorf("embeddingsOnly = %v, want %v", opts.embeddingsOnly, tc.wantEmbedOnly)
+			}
+			if strings.Join(opts.errorCategories, ",") != strings.Join(tc.wantCategories, ",") {
+				t.Errorf("errorCategories = %v, want %v", opts.errorCategories, tc.wantCategories)
+			}
+			if strings.Join(positional, ",") != strings.Join(tc.wantPositional, ",") {
+				t.Errorf("positional = %v, want %v", positional, tc.wantPositional)
+			}
+		})
+	}
+}
+
+// TestSplitFailedCounts pins that the report separates what the run retried
+// from what it deliberately left in place, so a partial retry never reads as a
+// complete one.
+func TestSplitFailedCounts(t *testing.T) {
+	failed := map[string]int64{"auth": 346, "payload_too_large": 2, "quality_gate": 5}
+	retried, terminal := splitFailedCounts(failed, []string{"auth", "rate_limit"})
+
+	if retried["auth"] != 346 || len(retried) != 1 {
+		t.Errorf("retried = %v, want only auth=346", retried)
+	}
+	if terminal["payload_too_large"] != 2 || terminal["quality_gate"] != 5 || len(terminal) != 2 {
+		t.Errorf("terminal = %v, want payload_too_large=2 quality_gate=5", terminal)
+	}
+	if got := formatCategoryCounts(terminal); got != "payload_too_large=2 quality_gate=5" {
+		t.Errorf("formatCategoryCounts = %q", got)
+	}
+	if got := formatCategoryCounts(nil); got != "" {
+		t.Errorf("formatCategoryCounts(nil) = %q, want empty", got)
+	}
+}

--- a/internal/cli/server_doctor.go
+++ b/internal/cli/server_doctor.go
@@ -450,8 +450,10 @@ func indexingFailureCheck(ctx context.Context, a *App, cfg config.Config) doctor
 func renderIndexingFailureCheck(stats model.CorpusStats) doctorCheck {
 	docErrors := stats.Errors
 	var chunkCategories map[string]int64
+	var lastFailureUnix int64
 	if stats.FailureSummary != nil {
 		chunkCategories = stats.FailureSummary.Categories
+		lastFailureUnix = stats.FailureSummary.LastFailureUnix
 	}
 	if docErrors == 0 && len(chunkCategories) == 0 {
 		return doctorCheck{Name: "indexing_failures", Status: doctorStatusOK, Detail: "0 failures"}
@@ -461,9 +463,36 @@ func renderIndexingFailureCheck(stats model.CorpusStats) doctorCheck {
 		parts = append(parts, fmt.Sprintf("%d document(s) failed extraction", docErrors))
 	}
 	if len(chunkCategories) > 0 {
-		parts = append(parts, "chunk failures: "+summarizeFailureCategories(chunkCategories))
+		chunkPart := "chunk failures: " + summarizeFailureCategories(chunkCategories)
+		// These counts are chunks CURRENTLY in a failed state, which may have
+		// been recorded by a long-past run. Say when the newest of them happened
+		// so the reader does not take a stale set for a live one (#783).
+		if lastFailureUnix > 0 {
+			chunkPart += fmt.Sprintf(" (latest %s)", time.Unix(lastFailureUnix, 0).UTC().Format(time.RFC3339))
+		}
+		parts = append(parts, chunkPart)
+		if hint := retryableFailureHint(chunkCategories); hint != "" {
+			parts = append(parts, hint)
+		}
 	}
 	return doctorCheck{Name: "indexing_failures", Status: doctorStatusWarn, Detail: strings.Join(parts, "; ")}
+}
+
+// retryableFailureHint names the recovery command when some of the failed
+// chunks are in a category a plain embed retry can clear (#783). Without it the
+// doctor reports the stranded chunks but leaves the operator to guess that the
+// only supported fix used to be a full re-ingest.
+func retryableFailureHint(categories map[string]int64) string {
+	var retryable int64
+	for category, n := range categories {
+		if store.IsRequeueableCategory(category) {
+			retryable += n
+		}
+	}
+	if retryable == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%d retryable after fixing the provider: run `dir2mcp reindex --embeddings-only`", retryable)
 }
 
 // summarizeFailureCategories renders the failure-category map as a

--- a/internal/cli/support_bundle.go
+++ b/internal/cli/support_bundle.go
@@ -280,7 +280,11 @@ func redactFailureSamples(fs *model.FailureSummary, includeContent bool) *model.
 	if fs == nil {
 		return nil
 	}
-	out := &model.FailureSummary{}
+	// LastFailureUnix is a timestamp, not corpus content, and it is the field
+	// that tells a maintainer reading the bundle whether the failures it reports
+	// are current or were stranded long before the bundle was taken (#783), so
+	// it is preserved in both modes.
+	out := &model.FailureSummary{LastFailureUnix: fs.LastFailureUnix}
 	if fs.Categories != nil {
 		out.Categories = make(map[string]int64, len(fs.Categories))
 		for k, v := range fs.Categories {
@@ -291,9 +295,10 @@ func redactFailureSamples(fs *model.FailureSummary, includeContent bool) *model.
 		out.Samples = make([]model.FailureSample, len(fs.Samples))
 		for i, s := range fs.Samples {
 			out.Samples[i] = model.FailureSample{
-				RelPath:  listFileRelPath(s.RelPath, includeContent),
-				Category: s.Category,
-				Message:  redactContentField(s.Message, includeContent),
+				RelPath:    listFileRelPath(s.RelPath, includeContent),
+				Category:   s.Category,
+				Message:    redactContentField(s.Message, includeContent),
+				FailedUnix: s.FailedUnix,
 			}
 		}
 	}

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -1023,9 +1023,23 @@ type SkipSample struct {
 // Categories is keyed by the string form of store.ErrorCategory (kept
 // as plain map[string]int64 here so the model package does not depend
 // on internal/store).
+//
+// It describes the chunks that are CURRENTLY in a failed state, not the
+// failures observed during the run that produced the enclosing snapshot. The
+// distinction used to be invisible and actively misleading: corpus.json stamps
+// each write with a fresh `ts`, so failures persisted hours earlier by a
+// different run read as if this run had just made (and lost) that many
+// provider calls. LastFailureUnix carries the age of the newest of those
+// failures so a reader can tell "stranded since yesterday" from "failing right
+// now" (issue #783).
 type FailureSummary struct {
 	Categories map[string]int64 `json:"categories"`
 	Samples    []FailureSample  `json:"samples,omitempty"`
+	// LastFailureUnix is when the most recent still-failed chunk was recorded
+	// (UTC unix seconds). Zero (omitted) means no failed chunk carries a
+	// timestamp — a corpus whose failures predate the embedding_failed_unix
+	// column — and must be read as "age unknown", never as 1970.
+	LastFailureUnix int64 `json:"last_failure_unix,omitempty"`
 }
 
 // FailureSample is one representative failed chunk: enough information
@@ -1034,6 +1048,11 @@ type FailureSample struct {
 	RelPath  string `json:"rel_path"`
 	Category string `json:"category"`
 	Message  string `json:"message"`
+	// FailedUnix is when this chunk was recorded as failed (UTC unix seconds),
+	// or 0 when it predates the timestamp column. Per-sample rather than
+	// summary-only so a mixed corpus (old stranded failures plus a fresh one)
+	// is readable instead of collapsing to a single newest-wins timestamp.
+	FailedUnix int64 `json:"failed_unix,omitempty"`
 }
 
 // MarshalJSON ensures that a nil DocCounts map is encoded as an empty object

--- a/internal/store/errcat.go
+++ b/internal/store/errcat.go
@@ -52,6 +52,113 @@ const (
 	ErrorCategoryQualityGate ErrorCategory = "quality_gate"
 )
 
+// allErrorCategories lists every category the classifier can produce, in a
+// stable order. It is the validation set for operator-supplied category names
+// (`reindex --embeddings-only --error-category=…`) so a typo is rejected with
+// the real vocabulary instead of silently matching nothing.
+var allErrorCategories = []ErrorCategory{
+	ErrorCategoryAuth,
+	ErrorCategoryRateLimit,
+	ErrorCategoryTransientNet,
+	ErrorCategoryUnknown,
+	ErrorCategoryPayloadTooLarge,
+	ErrorCategoryParseError,
+	ErrorCategoryEmbeddingFailure,
+	ErrorCategoryQualityGate,
+}
+
+// requeueableCategories is the set of failures a bare re-run of the embed step
+// can plausibly clear, with the chunk's stored bytes untouched (issue #783).
+//
+// The dividing line is WHERE the fault lives. auth / rate_limit /
+// transient_net are provider-side or environmental: the chunk was never the
+// problem, and a rotated credential, a quota window that rolled over, or an
+// upstream that came back turns the identical request into a success. The
+// categories left out — payload_too_large, parse_error, embedding_failure,
+// quality_gate — are properties of the input as stored, so re-sending the same
+// bytes to the same provider re-fails deterministically and only spends quota.
+// Those stay terminal until ingestion produces a different chunk.
+//
+// unknown is on the retryable side even though, by definition, we cannot say
+// where its fault lives. It is the classifier's universal default: it covers
+// every message the keyword table did not recognise (5xx-shaped provider
+// errors, provider-specific prose) plus every failure recorded through the
+// unclassified MarkFailed entry point or written before the category column
+// existed. Excluding it would leave that whole class permanently stranded —
+// the exact bug this distinction exists to fix — while including it costs at
+// most one re-failure that the operator explicitly asked for.
+var requeueableCategories = map[ErrorCategory]bool{
+	ErrorCategoryAuth:         true,
+	ErrorCategoryRateLimit:    true,
+	ErrorCategoryTransientNet: true,
+	ErrorCategoryUnknown:      true,
+}
+
+// NormalizeErrorCategory folds a persisted or operator-supplied category
+// string into the canonical enum value. An empty category (a legacy row, or
+// one written through MarkFailed without a classification) reads as
+// ErrorCategoryUnknown, matching how the failure aggregates in
+// loadFailureCategories normalize it in SQL — so "unknown" means the same
+// thing on both the reporting and the retry side.
+func NormalizeErrorCategory(raw string) ErrorCategory {
+	trimmed := strings.ToLower(strings.TrimSpace(raw))
+	if trimmed == "" {
+		return ErrorCategoryUnknown
+	}
+	return ErrorCategory(trimmed)
+}
+
+// IsKnownErrorCategory reports whether raw names a category this binary can
+// produce. Used to reject a mistyped --error-category rather than run a retry
+// that would silently match zero rows.
+func IsKnownErrorCategory(raw string) bool {
+	category := NormalizeErrorCategory(raw)
+	for _, known := range allErrorCategories {
+		if known == category {
+			return true
+		}
+	}
+	return false
+}
+
+// IsRequeueableCategory reports whether a failed chunk in this category should
+// be moved back to pending by a plain embed retry. See requeueableCategories
+// for the reasoning behind the split.
+func IsRequeueableCategory(raw string) bool {
+	return requeueableCategories[NormalizeErrorCategory(raw)]
+}
+
+// RequeueableErrorCategories returns the default retry set as strings, in the
+// stable order of allErrorCategories.
+func RequeueableErrorCategories() []string {
+	return filterCategoryStrings(func(c ErrorCategory) bool { return requeueableCategories[c] })
+}
+
+// TerminalErrorCategories returns the categories a plain embed retry cannot
+// clear, in the stable order of allErrorCategories. Callers use it to explain
+// why a category was not retried.
+func TerminalErrorCategories() []string {
+	return filterCategoryStrings(func(c ErrorCategory) bool { return !requeueableCategories[c] })
+}
+
+// KnownErrorCategories returns every category this binary can produce, in a
+// stable order, for error messages that need to show the vocabulary.
+func KnownErrorCategories() []string {
+	return filterCategoryStrings(func(ErrorCategory) bool { return true })
+}
+
+// filterCategoryStrings projects allErrorCategories through a predicate,
+// preserving declaration order so CLI output is byte-identical across runs.
+func filterCategoryStrings(keep func(ErrorCategory) bool) []string {
+	out := make([]string, 0, len(allErrorCategories))
+	for _, c := range allErrorCategories {
+		if keep(c) {
+			out = append(out, string(c))
+		}
+	}
+	return out
+}
+
 // classifierRule pairs a category with the keyword set that triggers
 // it. Order matters: the first matching rule wins, so the more
 // specific categories (rate-limit, auth, payload) are listed before

--- a/internal/store/failure_summary.go
+++ b/internal/store/failure_summary.go
@@ -29,7 +29,32 @@ func loadFailureSummary(ctx context.Context, db *sql.DB, maxSamples int) (*model
 	if err != nil {
 		return nil, err
 	}
-	return &model.FailureSummary{Categories: categories, Samples: samples}, nil
+	lastFailure, err := loadLastFailureUnix(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	return &model.FailureSummary{Categories: categories, Samples: samples, LastFailureUnix: lastFailure}, nil
+}
+
+// loadLastFailureUnix returns the newest embedding_failed_unix across the
+// chunks that are still in the error state, or 0 when none of them carries a
+// timestamp (a corpus whose failures predate the column). It is what lets a
+// consumer tell a stale, stranded failure set from one this run just produced
+// (issue #783) — the snapshot's own `ts` cannot, because it is stamped at
+// write time regardless of when the failures happened.
+func loadLastFailureUnix(ctx context.Context, db *sql.DB) (int64, error) {
+	var last sql.NullInt64
+	err := db.QueryRowContext(ctx, `
+		SELECT MAX(embedding_failed_unix)
+		FROM chunks
+		WHERE deleted = 0 AND embedding_status = 'error'`).Scan(&last)
+	if err != nil {
+		return 0, err
+	}
+	if !last.Valid {
+		return 0, nil
+	}
+	return last.Int64, nil
 }
 
 // loadFailureCategories returns a count of failed chunks per
@@ -72,7 +97,7 @@ func loadFailureSamples(ctx context.Context, db *sql.DB, maxSamples int) ([]mode
 		return nil, nil
 	}
 	rows, err := db.QueryContext(ctx, `
-		SELECT rel_path, COALESCE(NULLIF(error_category, ''), 'unknown') AS category, embedding_error
+		SELECT rel_path, COALESCE(NULLIF(error_category, ''), 'unknown') AS category, embedding_error, embedding_failed_unix
 		FROM chunks
 		WHERE deleted = 0 AND embedding_status = 'error'
 		ORDER BY category, chunk_id
@@ -85,7 +110,7 @@ func loadFailureSamples(ctx context.Context, db *sql.DB, maxSamples int) ([]mode
 	out := make([]model.FailureSample, 0, maxSamples)
 	for rows.Next() {
 		var sample model.FailureSample
-		if err := rows.Scan(&sample.RelPath, &sample.Category, &sample.Message); err != nil {
+		if err := rows.Scan(&sample.RelPath, &sample.Category, &sample.Message, &sample.FailedUnix); err != nil {
 			return nil, err
 		}
 		out = append(out, sample)

--- a/internal/store/requeue.go
+++ b/internal/store/requeue.go
@@ -1,0 +1,96 @@
+package store
+
+import (
+	"context"
+	"strings"
+	"time"
+)
+
+// embeddingFailureStamp returns the value to persist in
+// chunks.embedding_failed_unix for a row moving into embedding_status. Only a
+// failed row carries a timestamp; every other status clears it, so the column
+// never outlives the failure it describes (issue #783).
+func embeddingFailureStamp(status string, now time.Time) int64 {
+	if strings.TrimSpace(status) != "error" {
+		return 0
+	}
+	return now.UTC().Unix()
+}
+
+// RequeueFailedChunks moves chunks that are parked in embedding_status='error'
+// back to 'pending' so the embed worker picks them up again through
+// NextPending, clearing the stale error text, category and failure timestamp
+// as it goes. Only chunks whose (normalized) error_category appears in
+// categories are touched; passing no categories is a no-op that reports 0.
+// The returned count is the number of chunks actually moved.
+//
+// This is the recovery half of a provider-side failure (issue #783). Before
+// it existed the ONLY statement that reset a chunk to pending was the chunk
+// upsert, so a corpus stranded by a revoked/rotated credential could only be
+// recovered by re-ingesting every affected document — re-running extraction
+// (the expensive half, up to a full recognition cascade over a video) purely
+// to redo the embed step (seconds). The startup credential probe added for
+// issue #399 prevents the failure from starting, but cannot recover a corpus
+// whose credential died after the daemon was already up.
+//
+// Nothing else has to be undone: a chunk in 'error' never had a vector written
+// for it, so no index entry is left behind to reconcile. The caller decides
+// which categories are worth retrying (see IsRequeueableCategory).
+func (s *SQLiteStore) RequeueFailedChunks(ctx context.Context, categories []string) (int64, error) {
+	normalized := normalizeRequeueCategories(categories)
+	if len(normalized) == 0 {
+		return 0, nil
+	}
+
+	db, err := s.ensureDB(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer s.ReleaseDB()
+
+	args := make([]any, 0, len(normalized))
+	for _, category := range normalized {
+		args = append(args, category)
+	}
+	// The IN list is built from placeholders only; the category values travel as
+	// bound parameters, so an operator-supplied name can never reach the SQL text.
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(normalized)), ",")
+	res, err := db.ExecContext(ctx, `
+		UPDATE chunks
+		   SET embedding_status = 'pending',
+		       embedding_error = '',
+		       error_category = '',
+		       embedding_failed_unix = 0
+		 WHERE deleted = 0
+		   AND embedding_status = 'error'
+		   AND COALESCE(NULLIF(error_category, ''), 'unknown') IN (`+placeholders+`)`, args...)
+	if err != nil {
+		return 0, err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	return affected, nil
+}
+
+// normalizeRequeueCategories canonicalizes and de-duplicates the requested
+// categories, dropping empties. The empty-to-"unknown" fold matches the SQL
+// aggregate in loadFailureCategories, so a category the status output names is
+// exactly the category the retry matches.
+func normalizeRequeueCategories(categories []string) []string {
+	seen := make(map[ErrorCategory]struct{}, len(categories))
+	out := make([]string, 0, len(categories))
+	for _, raw := range categories {
+		if strings.TrimSpace(raw) == "" {
+			continue
+		}
+		category := NormalizeErrorCategory(raw)
+		if _, dup := seen[category]; dup {
+			continue
+		}
+		seen[category] = struct{}{}
+		out = append(out, string(category))
+	}
+	return out
+}

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -363,8 +363,8 @@ func languageFromRepMeta(metaJSON string) string {
 func insertChunkWithSpansWith(ctx context.Context, exec dbExecutor, chunk model.Chunk, spans []model.Span, relPath, docType, repType, language string) (int64, error) {
 	_, err := exec.ExecContext(
 		ctx,
-		`INSERT INTO chunks(rep_id, ordinal, rel_path, doc_type, rep_type, text, text_hash, tokens_est, index_kind, modality, media_ref, language, embedding_status, embedding_error, error_category, chunk_context, embedding_mode, deleted)
-		 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`INSERT INTO chunks(rep_id, ordinal, rel_path, doc_type, rep_type, text, text_hash, tokens_est, index_kind, modality, media_ref, language, embedding_status, embedding_error, error_category, embedding_failed_unix, chunk_context, embedding_mode, deleted)
+		 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		 ON CONFLICT(rep_id, ordinal) DO UPDATE SET
 		   rel_path=excluded.rel_path,
 		   doc_type=excluded.doc_type,
@@ -379,6 +379,7 @@ func insertChunkWithSpansWith(ctx context.Context, exec dbExecutor, chunk model.
 		   embedding_status=excluded.embedding_status,
 		   embedding_error=excluded.embedding_error,
 		   error_category=excluded.error_category,
+		   embedding_failed_unix=excluded.embedding_failed_unix,
 		   chunk_context=excluded.chunk_context,
 		   embedding_mode=excluded.embedding_mode,
 		   deleted=excluded.deleted`,
@@ -397,6 +398,11 @@ func insertChunkWithSpansWith(ctx context.Context, exec dbExecutor, chunk model.
 		normalizeEmbeddingStatus(chunk.EmbeddingStatus),
 		strings.TrimSpace(chunk.EmbeddingError),
 		strings.TrimSpace(chunk.ErrorCategory),
+		// A chunk can be born failed: the output quality gate quarantines a
+		// degenerate transcript/OCR chunk at insert time. Stamp that the same
+		// way a mid-run failure is stamped so the failure aggregates can age it
+		// (issue #783).
+		embeddingFailureStamp(normalizeEmbeddingStatus(chunk.EmbeddingStatus), time.Now()),
 		chunk.Context,
 		model.NormalizeEmbeddingMode(chunk.EmbeddingMode),
 		boolToInt(chunk.Deleted),
@@ -742,6 +748,15 @@ func applyAdditiveColumnMigrations(ctx context.Context, db *sql.DB) error {
 		// and its embed identity migrates to `…|off` — so no reindex.
 		`ALTER TABLE chunks ADD COLUMN chunk_context TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE chunks ADD COLUMN embedding_mode TEXT NOT NULL DEFAULT 'disabled'`,
+		// embedding_failed_unix stamps WHEN a chunk entered embedding_status
+		// ='error' so the failure aggregates can say how old the failures they
+		// report are (issue #783). Without it corpus.json re-reported failures
+		// persisted hours earlier under this run's fresh `ts`, which reads as
+		// "this run just failed N times against the provider" — the worst
+		// possible signal for an operator who is mid-way through swapping a
+		// credential and made no request at all. Existing rows default to 0,
+		// which the aggregate reports as "unknown age" rather than as 1970.
+		`ALTER TABLE chunks ADD COLUMN embedding_failed_unix INTEGER NOT NULL DEFAULT 0`,
 	}
 	for _, stmt := range migrations {
 		if _, err := db.ExecContext(ctx, stmt); err != nil && !isDuplicateColumnError(err) {
@@ -826,6 +841,7 @@ CREATE TABLE IF NOT EXISTS chunks (
   embedding_status TEXT NOT NULL DEFAULT 'pending',
   embedding_error TEXT NOT NULL DEFAULT '',
   error_category TEXT NOT NULL DEFAULT '',
+  embedding_failed_unix INTEGER NOT NULL DEFAULT 0,
   chunk_context TEXT NOT NULL DEFAULT '',
   embedding_mode TEXT NOT NULL DEFAULT 'disabled',
   deleted INTEGER NOT NULL DEFAULT 0,
@@ -1133,7 +1149,12 @@ func (s *SQLiteStore) UpsertChunkTask(ctx context.Context, task model.ChunkTask)
 		   deleted=0,
 		   embedding_status='pending',
 		   embedding_error='',
-		   error_category=''`,
+		   error_category='',
+		   -- Clear the failure stamp alongside the error text it belongs to: a
+		   -- row moving back to pending is no longer failed, so leaving the
+		   -- timestamp behind would let a future aggregate age the new failure
+		   -- from the old one's clock (issue #783).
+		   embedding_failed_unix=0`,
 		int64(task.Label),
 		relPath,
 		defaultIfEmpty(task.Metadata.DocType, "unknown"),
@@ -3673,14 +3694,19 @@ func (s *SQLiteStore) markEmbeddingStatus(ctx context.Context, labels []uint64, 
 	defer func() { _ = tx.Rollback() }()
 
 	stmt, err := tx.PrepareContext(ctx,
-		`UPDATE chunks SET embedding_status = ?, embedding_error = ?, error_category = ? WHERE chunk_id = ?`)
+		`UPDATE chunks SET embedding_status = ?, embedding_error = ?, error_category = ?, embedding_failed_unix = ? WHERE chunk_id = ?`)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = stmt.Close() }()
 
+	// Stamp the failure time on the way into 'error' and clear it on the way
+	// out, so the value always describes the state the row is actually in: a
+	// chunk that later embeds (or is re-queued) must not keep advertising an
+	// old failure the aggregates would then report as current (issue #783).
+	failedUnix := embeddingFailureStamp(status, time.Now())
 	for _, label := range labels {
-		if _, err := stmt.ExecContext(ctx, status, reason, category, int64(label)); err != nil {
+		if _, err := stmt.ExecContext(ctx, status, reason, category, failedUnix, int64(label)); err != nil {
 			return err
 		}
 	}

--- a/tests/cli/reindex_embeddings_only_783_test.go
+++ b/tests/cli/reindex_embeddings_only_783_test.go
@@ -1,0 +1,206 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/cli"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// Issue #783: an embed failure with a provider-side cause (a revoked or rotated
+// key) parked every affected chunk in embedding_status='error', and nothing
+// moved it back. Restarting with a VALID key changed nothing, because 'error'
+// is not 'pending'. The only supported recovery was re-ingesting the documents,
+// which re-runs extraction (minutes to hours) purely to redo the embed step
+// (seconds). `reindex --embeddings-only` is that recovery.
+
+// seedEmbedFailure creates a state dir whose corpus has one chunk parked in
+// embedding_status='error' under the given category, and returns its chunk id.
+func seedEmbedFailure(t *testing.T, stateDir, relPath, category string) uint64 {
+	t.Helper()
+	ctx := context.Background()
+	st := store.NewSQLiteStore(filepath.Join(stateDir, "meta.sqlite"))
+	defer func() { _ = st.Close() }()
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("seed Init: %v", err)
+	}
+	if err := st.UpsertDocument(ctx, model.Document{
+		RelPath: relPath, DocType: "md", SourceType: "filesystem", Status: "ok",
+	}); err != nil {
+		t.Fatalf("seed UpsertDocument: %v", err)
+	}
+	doc, err := st.GetDocumentByPath(ctx, relPath)
+	if err != nil {
+		t.Fatalf("seed GetDocumentByPath: %v", err)
+	}
+	var chunkID int64
+	err = st.WithTx(ctx, func(tx model.RepresentationStore) error {
+		repID, rerr := tx.UpsertRepresentation(ctx, model.Representation{
+			DocID: doc.DocID, RepType: "raw_text", RepHash: "h-" + relPath,
+		})
+		if rerr != nil {
+			return rerr
+		}
+		id, cerr := tx.InsertChunkWithSpans(ctx, model.Chunk{
+			RepID: repID, Ordinal: 0, Text: "body of " + relPath, TextHash: "th-" + relPath,
+			IndexKind: "text", EmbeddingStatus: "pending",
+		}, nil)
+		chunkID = id
+		return cerr
+	})
+	if err != nil {
+		t.Fatalf("seed chunk: %v", err)
+	}
+	if err := st.MarkFailedWithCategory(ctx, []uint64{uint64(chunkID)}, category, "401 unauthorized"); err != nil {
+		t.Fatalf("seed MarkFailedWithCategory: %v", err)
+	}
+	return uint64(chunkID)
+}
+
+// embedPendingCount reports how many chunks the embed worker would pick up.
+func embedPendingCount(t *testing.T, stateDir string) int64 {
+	t.Helper()
+	ctx := context.Background()
+	st := store.NewSQLiteStore(filepath.Join(stateDir, "meta.sqlite"))
+	defer func() { _ = st.Close() }()
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("stats Init: %v", err)
+	}
+	stats, err := st.CorpusStats(ctx)
+	if err != nil {
+		t.Fatalf("CorpusStats: %v", err)
+	}
+	return stats.EmbeddedPending
+}
+
+// runCLIInDir runs the CLI with args from tmp and returns exit code, stdout and
+// stderr.
+func runCLIInDir(t *testing.T, tmp string, args []string) (int, string, string) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	var code int
+	withWorkingDir(t, tmp, func() {
+		code = app.RunWithContext(context.Background(), args)
+	})
+	return code, stdout.String(), stderr.String()
+}
+
+// TestReindexEmbeddingsOnly_RequeuesProviderFailures is the #783 regression:
+// the failed chunks return to the embed queue, and no ingestor is constructed,
+// so extraction is never re-run.
+func TestReindexEmbeddingsOnly_RequeuesProviderFailures(t *testing.T) {
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, ".dir2mcp")
+	seedEmbedFailure(t, stateDir, "docs/a.md", "auth")
+
+	if got := embedPendingCount(t, stateDir); got != 0 {
+		t.Fatalf("precondition: embedded_pending=%d, want 0 (the chunk is parked in error)", got)
+	}
+
+	code, _, stderr := runCLIInDir(t, tmp, []string{"reindex", "--embeddings-only"})
+	if code != 0 {
+		t.Fatalf("reindex --embeddings-only exit=%d stderr=%q", code, stderr)
+	}
+	if got := embedPendingCount(t, stateDir); got != 1 {
+		t.Fatalf("embedded_pending=%d after the retry, want 1", got)
+	}
+	if !strings.Contains(stderr, "requeued 1 chunk(s)") {
+		t.Errorf("expected a requeue summary on stderr, got %q", stderr)
+	}
+}
+
+// TestReindexEmbeddingsOnly_LeavesTerminalCategories pins that a failure which
+// is a property of the stored input is not retried: re-sending identical bytes
+// to the same provider re-fails deterministically and only spends quota.
+func TestReindexEmbeddingsOnly_LeavesTerminalCategories(t *testing.T) {
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, ".dir2mcp")
+	seedEmbedFailure(t, stateDir, "docs/huge.md", "payload_too_large")
+
+	code, _, stderr := runCLIInDir(t, tmp, []string{"reindex", "--embeddings-only"})
+	if code != 0 {
+		t.Fatalf("reindex --embeddings-only exit=%d stderr=%q", code, stderr)
+	}
+	if got := embedPendingCount(t, stateDir); got != 0 {
+		t.Fatalf("embedded_pending=%d, want 0: payload_too_large must stay terminal", got)
+	}
+	if !strings.Contains(stderr, "not retried") {
+		t.Errorf("expected the report to name what it left alone, got %q", stderr)
+	}
+}
+
+// TestReindexEmbeddingsOnly_JSONPayload pins the machine-readable shape a
+// recovery script consumes.
+func TestReindexEmbeddingsOnly_JSONPayload(t *testing.T) {
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, ".dir2mcp")
+	seedEmbedFailure(t, stateDir, "docs/a.md", "auth")
+
+	code, stdout, stderr := runCLIInDir(t, tmp, []string{"--json", "reindex", "--embeddings-only"})
+	if code != 0 {
+		t.Fatalf("exit=%d stderr=%q", code, stderr)
+	}
+	var payload struct {
+		Requeued          int64            `json:"requeued"`
+		Categories        []string         `json:"categories"`
+		MatchedByCategory map[string]int64 `json:"matched_by_category"`
+		EmbeddingsOnly    bool             `json:"embeddings_only"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("unmarshal %q: %v", stdout, err)
+	}
+	if payload.Requeued != 1 || !payload.EmbeddingsOnly {
+		t.Fatalf("unexpected payload: %+v", payload)
+	}
+	if payload.MatchedByCategory["auth"] != 1 {
+		t.Errorf("expected the per-category breakdown to explain the total, got %+v", payload.MatchedByCategory)
+	}
+	if len(payload.Categories) == 0 {
+		t.Errorf("expected the retried categories to be reported, got %+v", payload.Categories)
+	}
+}
+
+// TestReindexEmbeddingsOnly_ErrorCategoryFilter pins the --error-category
+// filter and its validation.
+func TestReindexEmbeddingsOnly_ErrorCategoryFilter(t *testing.T) {
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, ".dir2mcp")
+	seedEmbedFailure(t, stateDir, "docs/a.md", "auth")
+	seedEmbedFailure(t, stateDir, "docs/b.md", "rate_limit")
+
+	code, _, stderr := runCLIInDir(t, tmp, []string{"reindex", "--embeddings-only", "--error-category", "auth"})
+	if code != 0 {
+		t.Fatalf("exit=%d stderr=%q", code, stderr)
+	}
+	if got := embedPendingCount(t, stateDir); got != 1 {
+		t.Fatalf("embedded_pending=%d, want 1 (only the auth failure was selected)", got)
+	}
+
+	badCode, _, badStderr := runCLIInDir(t, tmp, []string{"reindex", "--embeddings-only", "--error-category", "not-a-category"})
+	if badCode != 2 {
+		t.Fatalf("unknown category exit=%d, want 2 (stderr=%q)", badCode, badStderr)
+	}
+	if !strings.Contains(badStderr, "unknown error category") {
+		t.Errorf("expected an explicit vocabulary error, got %q", badStderr)
+	}
+}
+
+// TestReindex_StillRejectsPositionalArguments guards the pre-existing CLI
+// contract: adding flags must not turn `reindex extra` into a valid invocation.
+func TestReindex_StillRejectsPositionalArguments(t *testing.T) {
+	tmp := t.TempDir()
+	code, _, stderr := runCLIInDir(t, tmp, []string{"reindex", "extra"})
+	if code != 2 {
+		t.Fatalf("exit=%d, want 2 (stderr=%q)", code, stderr)
+	}
+	if !strings.Contains(stderr, "reindex command does not accept arguments") {
+		t.Errorf("unexpected message: %q", stderr)
+	}
+}

--- a/tests/security/cli_boundary_test.go
+++ b/tests/security/cli_boundary_test.go
@@ -190,6 +190,8 @@ func TestRepoSplitBoundary_InternalCLIFileOwnership(t *testing.T) {
 		"registration_hint.go":                   {},
 		"registration_hint_test.go":              {},
 		"remote_commands.go":                     {},
+		"retry_embeddings.go":                    {},
+		"retry_embeddings_internal_test.go":      {},
 		"rerank_selection_test.go":               {},
 		"routing_decision.go":                    {},
 		"server_doctor.go":                       {},

--- a/tests/store/requeue_failed_chunks_783_test.go
+++ b/tests/store/requeue_failed_chunks_783_test.go
@@ -1,0 +1,219 @@
+package tests
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// seedFailedChunk inserts one chunk for relPath and parks it in
+// embedding_status='error' with the given category, the exact state a
+// provider-side embed rejection leaves behind.
+func seedFailedChunk(t *testing.T, ctx context.Context, st *store.SQLiteStore, relPath, category string) uint64 {
+	t.Helper()
+	if err := st.UpsertDocument(ctx, model.Document{
+		RelPath: relPath, DocType: "md", SourceType: "filesystem", Status: "ok",
+	}); err != nil {
+		t.Fatalf("UpsertDocument(%s): %v", relPath, err)
+	}
+	doc, err := st.GetDocumentByPath(ctx, relPath)
+	if err != nil {
+		t.Fatalf("GetDocumentByPath(%s): %v", relPath, err)
+	}
+	var chunkID int64
+	err = st.WithTx(ctx, func(tx model.RepresentationStore) error {
+		repID, rerr := tx.UpsertRepresentation(ctx, model.Representation{
+			DocID: doc.DocID, RepType: "raw_text", RepHash: "h-" + relPath,
+		})
+		if rerr != nil {
+			return rerr
+		}
+		id, cerr := tx.InsertChunkWithSpans(ctx, model.Chunk{
+			RepID: repID, Ordinal: 0, Text: "body of " + relPath, TextHash: "th-" + relPath,
+			IndexKind: "text", EmbeddingStatus: "pending",
+		}, nil)
+		chunkID = id
+		return cerr
+	})
+	if err != nil {
+		t.Fatalf("seed chunk for %s: %v", relPath, err)
+	}
+	if err := st.MarkFailedWithCategory(ctx, []uint64{uint64(chunkID)}, category, "provider rejected the request"); err != nil {
+		t.Fatalf("MarkFailedWithCategory(%s): %v", relPath, err)
+	}
+	return uint64(chunkID)
+}
+
+// pendingChunkIDs returns the chunk ids the embed worker would pick up next.
+func pendingChunkIDs(t *testing.T, ctx context.Context, st *store.SQLiteStore) map[uint64]struct{} {
+	t.Helper()
+	tasks, err := st.NextPending(ctx, 100, "")
+	if err != nil {
+		t.Fatalf("NextPending: %v", err)
+	}
+	out := map[uint64]struct{}{}
+	for _, task := range tasks {
+		out[task.Label] = struct{}{}
+	}
+	return out
+}
+
+// TestRequeueFailedChunks_RetryableOnly is the core of issue #783: a chunk that
+// a provider rejected for a provider-side reason (a revoked key) can be put
+// back in the embed queue WITHOUT re-ingesting its document, while a failure
+// that is a property of the stored input stays terminal.
+func TestRequeueFailedChunks_RetryableOnly(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	defer func() { _ = st.Close() }()
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	authChunk := seedFailedChunk(t, ctx, st, "auth-failed.md", "auth")
+	oversizeChunk := seedFailedChunk(t, ctx, st, "too-large.md", "payload_too_large")
+
+	// Nothing is pending: both chunks are parked in 'error'.
+	if pending := pendingChunkIDs(t, ctx, st); len(pending) != 0 {
+		t.Fatalf("expected no pending chunks before the retry, got %v", pending)
+	}
+
+	requeued, err := st.RequeueFailedChunks(ctx, store.RequeueableErrorCategories())
+	if err != nil {
+		t.Fatalf("RequeueFailedChunks: %v", err)
+	}
+	if requeued != 1 {
+		t.Fatalf("requeued %d chunk(s), want 1 (only the auth failure is retryable)", requeued)
+	}
+
+	pending := pendingChunkIDs(t, ctx, st)
+	if _, ok := pending[authChunk]; !ok {
+		t.Errorf("auth-failed chunk %d was not returned to the embed queue (pending=%v)", authChunk, pending)
+	}
+	if _, ok := pending[oversizeChunk]; ok {
+		t.Errorf("payload_too_large chunk %d was requeued; terminal categories must stay terminal", oversizeChunk)
+	}
+
+	stats, err := st.CorpusStats(ctx)
+	if err != nil {
+		t.Fatalf("CorpusStats: %v", err)
+	}
+	if stats.EmbeddedPending != 1 {
+		t.Errorf("embedded_pending=%d, want 1", stats.EmbeddedPending)
+	}
+	if stats.FailureSummary == nil || stats.FailureSummary.Categories["payload_too_large"] != 1 {
+		t.Errorf("payload_too_large should still be reported as failed, got %+v", stats.FailureSummary)
+	}
+	if stats.FailureSummary != nil && stats.FailureSummary.Categories["auth"] != 0 {
+		t.Errorf("auth failures should be cleared after the retry, got %+v", stats.FailureSummary)
+	}
+}
+
+// TestRequeueFailedChunks_UnclassifiedFailuresAreRecoverable pins the decision
+// that "unknown" (which includes every failure recorded through the
+// unclassified MarkFailed entry point) belongs to the retryable set. Excluding
+// it would strand that whole class permanently, which is the bug #783 is about.
+func TestRequeueFailedChunks_UnclassifiedFailuresAreRecoverable(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	defer func() { _ = st.Close() }()
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	chunkID := seedFailedChunk(t, ctx, st, "unclassified.md", "")
+
+	requeued, err := st.RequeueFailedChunks(ctx, store.RequeueableErrorCategories())
+	if err != nil {
+		t.Fatalf("RequeueFailedChunks: %v", err)
+	}
+	if requeued != 1 {
+		t.Fatalf("requeued %d chunk(s), want 1", requeued)
+	}
+	if _, ok := pendingChunkIDs(t, ctx, st)[chunkID]; !ok {
+		t.Errorf("chunk %d with an empty error_category was not requeued", chunkID)
+	}
+}
+
+// TestRequeueFailedChunks_ExplicitCategoryFilter pins the --error-category
+// path: only the named category moves, everything else is left exactly where
+// it was.
+func TestRequeueFailedChunks_ExplicitCategoryFilter(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	defer func() { _ = st.Close() }()
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	authChunk := seedFailedChunk(t, ctx, st, "auth.md", "auth")
+	rateChunk := seedFailedChunk(t, ctx, st, "rate.md", "rate_limit")
+
+	requeued, err := st.RequeueFailedChunks(ctx, []string{"rate_limit"})
+	if err != nil {
+		t.Fatalf("RequeueFailedChunks: %v", err)
+	}
+	if requeued != 1 {
+		t.Fatalf("requeued %d chunk(s), want 1", requeued)
+	}
+	pending := pendingChunkIDs(t, ctx, st)
+	if _, ok := pending[rateChunk]; !ok {
+		t.Errorf("rate_limit chunk %d was not requeued", rateChunk)
+	}
+	if _, ok := pending[authChunk]; ok {
+		t.Errorf("auth chunk %d was requeued despite --error-category=rate_limit", authChunk)
+	}
+
+	// An empty selection is a no-op rather than a corpus-wide reset.
+	if n, err := st.RequeueFailedChunks(ctx, nil); err != nil || n != 0 {
+		t.Errorf("RequeueFailedChunks(nil) = (%d, %v), want (0, nil)", n, err)
+	}
+}
+
+// TestFailureSummary_CarriesFailureAge pins the reporting half of #783: the
+// failure aggregate says WHEN the failures it reports happened, so a set
+// stranded by an earlier run cannot read as one this run just produced (the
+// corpus.json `ts` is stamped at write time and cannot make that distinction).
+func TestFailureSummary_CarriesFailureAge(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	defer func() { _ = st.Close() }()
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	before := time.Now().UTC().Add(-2 * time.Second).Unix()
+	seedFailedChunk(t, ctx, st, "auth.md", "auth")
+	after := time.Now().UTC().Add(2 * time.Second).Unix()
+
+	stats, err := st.CorpusStats(ctx)
+	if err != nil {
+		t.Fatalf("CorpusStats: %v", err)
+	}
+	if stats.FailureSummary == nil {
+		t.Fatalf("expected a failure summary")
+	}
+	if stats.FailureSummary.LastFailureUnix < before || stats.FailureSummary.LastFailureUnix > after {
+		t.Errorf("last_failure_unix=%d outside [%d,%d]", stats.FailureSummary.LastFailureUnix, before, after)
+	}
+	if len(stats.FailureSummary.Samples) != 1 || stats.FailureSummary.Samples[0].FailedUnix == 0 {
+		t.Errorf("expected the sample to carry its own failure timestamp, got %+v", stats.FailureSummary.Samples)
+	}
+
+	// The stamp must not outlive the failure: a requeued chunk is no longer
+	// failed, so the aggregate must stop reporting a failure age at all.
+	if _, err := st.RequeueFailedChunks(ctx, []string{"auth"}); err != nil {
+		t.Fatalf("RequeueFailedChunks: %v", err)
+	}
+	cleared, err := st.CorpusStats(ctx)
+	if err != nil {
+		t.Fatalf("CorpusStats after retry: %v", err)
+	}
+	if cleared.FailureSummary != nil {
+		t.Errorf("failure summary should be empty after the retry, got %+v", cleared.FailureSummary)
+	}
+}


### PR DESCRIPTION
Closes #783.

## The gap

When an embed call fails non-retryably the chunk is persisted as `embedding_status='error'`, and nothing ever moved it back. The only statement in the store that reset a chunk to `pending` was the ingest-time chunk upsert (`internal/store/sqlite_store.go`), so the only supported recovery from a provider-side failure was re-ingesting the document: re-running extraction (OCR, transcription, a recognition cascade over a video: minutes to hours) purely in order to redo the embed step (seconds, unchanged input). `reindex` accepted no arguments, so the embed step could not be retried on its own.

On the corpus that prompted the issue: 346 chunks, all `error`/`auth`. Restarting with a valid key changed nothing (`embedded_pending=0, embedded_ok=0, errors=0`, daemon idle) because `error` is not `pending`. The fix was a hand-written `UPDATE`, after which all 346 embedded in under four seconds.

## Why prevention (#399) is not recovery

#399 item 3 described this failure mode and was closed with a *prevention* fix: the §2.5 startup credential probe in `internal/cli/up.go`. That probe stops a bad credential from starting a corpus-wide failure, but it runs once, before bind. A key that is valid at startup and then revoked, rotated, billing-suspended, or rate-limited into a non-retryable class strands every chunk it touches while the daemon is already up, where the probe cannot reach. Prevention narrows the window; it does not un-strand anything that fell into it.

## What this implements

`dir2mcp reindex --embeddings-only [--error-category=auth,rate_limit]` (issue's preferred shape 1): moves failed chunks back to `pending` and does nothing else. It skips the full-rebuild machinery deliberately, and each omission is documented in code:

- **no index staging, no content-hash clear** — the extracted representations are untouched, which is the entire point;
- **not refused under a live daemon** (unlike a full rebuild, which is refused for #418): this is one `UPDATE` over `chunks`, serialized by WAL + the store's `busy_timeout`, and a chunk in `error` never had a vector written for it, so there is nothing in the live index to reconcile. Running it under a live daemon is the *fastest* recovery: the embed worker polls `NextPending` on a ticker and drains the requeued chunks with no restart;
- **no confirmation prompt** — it is not destructive (a chunk that fails again simply returns to `error`) and prompting would break the scripted recovery this exists to enable.

Positional arguments still produce the historical `reindex command does not accept arguments` error, and `--error-category` without `--embeddings-only` is rejected rather than silently ignored (a full rebuild has no notion of a per-category subset).

## Which categories retry, and why

The dividing line is where the fault lives (`internal/store/errcat.go`).

**Retried by default** — provider-side or environmental, so the identical request can succeed once the provider is fixed:
- `auth` — the credential was the problem, not the chunk
- `rate_limit` — the quota window rolls over
- `transient_net` — the upstream came back
- `unknown` — the classifier's universal default. It covers every message the keyword table did not recognise (5xx-shaped provider errors, provider-specific prose) plus everything recorded through the unclassified `MarkFailed` entry point or written before `error_category` existed. Excluding it would leave that whole class permanently stranded, which is the bug this distinction exists to fix; including it costs at most one re-failure the operator asked for.

**Left terminal** — properties of the input as stored, so re-sending identical bytes to the same provider re-fails deterministically and only spends quota:
- `payload_too_large`, `parse_error`, `embedding_failure`, `quality_gate`

Terminal categories can still be named explicitly via `--error-category` (an operator who raised a size cap knows something the store does not), but they are never in the default set. The human report prints what it left alone (`not retried (terminal; re-ingest to change the input): payload_too_large=2`) so a partial retry never reads as a complete one.

## Secondary: stale failures no longer look current

`corpus.json` stamps every write with a fresh `ts`, so a `failure_summary` of failures persisted hours earlier by a different run read as "this run just failed N times against the provider" — the worst possible signal for an operator mid-way through swapping a credential who made no request at all.

New `chunks.embedding_failed_unix` (additive migration, defaults to 0) is stamped when a chunk enters the error state and cleared when it leaves (embedded, requeued, or re-ingested), so the value never outlives the failure it describes. It surfaces as `failure_summary.last_failure_unix` and per-sample `failed_unix`; `doctor` renders `chunk failures: auth=346 (latest 2026-08-07T19:04:11Z)` and, when some are retryable, names the recovery command. `FailureSummary`'s doc comment now states explicitly that it describes chunks *currently in a failed state*, not failures observed this run. A corpus whose failures predate the column reports 0, documented as "age unknown", never as 1970.

Option 2 from the issue (automatic re-queue when the embed provider is re-initialized) is deliberately **not** included: it belongs behind the §2.5 probe result (a probe that just succeeded is the evidence that an `auth` failure is resolved), which is a larger change in `up`'s startup path and a separate risk profile from an explicit, operator-driven command. Worth a follow-up.

## Verification

- `make check` passes locally (fmt, vet, golangci-lint 0 issues, `gocyclo -over 15` clean, ineffassign, misspell, full test suite, release tools, build).
- New tests were confirmed to fail against `main`: with the source changes stashed and only the tests in place, the CLI tests fail behaviourally (`reindex --embeddings-only` → `exit=2 reindex command does not accept arguments: --embeddings-only`) and the store/internal tests fail to build against the absent API. Restored and re-run green afterwards.
- Coverage added: store-level requeue (retryable only, unclassified failures recoverable, explicit category filter, empty selection is a no-op, failure-age stamping and its clearing), CLI-level end-to-end (requeue via the real command, terminal categories untouched, `--json` payload shape, `--error-category` filter and its validation), a guard that `reindex extra` still fails the old way, and flag-parsing unit tests.
- No `dirstral-spec` submodule change: bs-001 documents `reindex` as "Force full rebuild", which the argument-less invocation still is, and enumerates per-command flags only for `up`. No normative statement is changed or weakened. Flagging it for the maintainer in case the CLI surface addition should still be mirrored into bs-001.
