### PR TITLE
fix(ingest): apply subtitle drop_urls/collapse_repeats before embedding (#765)

### DIFF
--- a/internal/cli/export.go
+++ b/internal/cli/export.go
@@ -97,6 +97,14 @@ func (a *App) runExport(ctx context.Context, global globalOptions, args []string
 // media.subtitles.* editorial cleaning passes (glossary, drop_phrases,
 // scrub_phrases, collapse_repeats, drop_urls).
 //
+// Four of the five cleaning keys (drop_urls, drop_phrases, scrub_phrases,
+// collapse_repeats) are ALSO applied at ingest, before chunks are embedded
+// (issues #545, #765), from the same subtitle.CleanOptions shape this builds.
+// Re-running them here is deliberate rather than redundant: under broadcast
+// segmentation the cues are rebuilt finer than the stored chunks, and a corpus
+// indexed before the keys were enabled still carries uncleaned chunks until it
+// is re-indexed. Only glossary is export-only (SPEC §8.6.2).
+//
 // It exists because TTML used to skip the cleaning half entirely (issue #729):
 // the same transcript exported as SRT and as TTML disagreed on every rule under
 // media.subtitles.*, and bilingual TTML aligned cue sets that the exports would

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -721,11 +721,21 @@ type Config struct {
 	// exporting the same transcript in two formats must not yield two different
 	// editorial results. TTML used to skip all five (issue #729).
 	//
-	// This is the export surface. Two of the five (drop_phrases, scrub_phrases)
-	// ALSO run at ingest, before chunks are embedded, so the retrieval index
-	// agrees with the exported sidecar (issue #545); the other three
-	// (glossary, collapse_repeats, drop_urls) are export-only and do not change
-	// what is indexed or cited. Each key notes which it is.
+	// This is the export surface. Four of the five (drop_urls, drop_phrases,
+	// scrub_phrases, collapse_repeats) ALSO run at ingest, before chunks are
+	// embedded, so the retrieval index agrees with the exported sidecar (issues
+	// #545, #765): they are hallucination filters, and a cue an operator
+	// configured away must not stay embedded and citable. glossary is export-only
+	// because SPEC §8.6.2 defines it as an export-time find/replace on
+	// already-rendered cue text. Each key notes which it is.
+	//
+	// The ingest half runs when a document is (re)indexed, so enabling or widening
+	// any of the four on an EXISTING corpus cleans the exported sidecar
+	// immediately but leaves already-embedded chunks as they were until the corpus
+	// is re-indexed (`dir2mcp reindex`). The derivation identity (§8.6.7)
+	// deliberately tracks provider/model provenance only, not operator cleaning
+	// preferences: folding these keys into it would re-run transcription (the
+	// transcript cache is keyed by that identity) for an editorial toggle.
 
 	// MediaSubtitlesGlossary is an optional list of editorial term replacements
 	// applied to exported cue text in every format (config
@@ -734,21 +744,30 @@ type Config struct {
 	// "Aju?bei=>Adzhubei" to normalize a transliterated name). Unlike
 	// media.filter_words (which deletes phrases) this REWRITES text and never
 	// drops a cue. Empty by default = off. Export-only: indexed/cited transcript
-	// text is not rewritten.
+	// text is not rewritten, because SPEC §8.6.2 pins this key as a deterministic,
+	// export-time find/replace on already-rendered cue text. The consequence is
+	// worth knowing: search matches the pre-glossary spelling while every exported
+	// artifact shows the post-glossary one (issue #765). Changing that is a spec
+	// change first, not a code change.
 	MediaSubtitlesGlossary []string
 
 	// MediaSubtitlesCollapseRepeats drops the Nth-and-later cue in a run of
 	// identical consecutive cues on export in every format (config
 	// `media.subtitles.collapse_repeats`), the whisper repetition-collapse
 	// artifact. A value < 2 disables the pass (the default 0 = off), so
-	// legitimate short repeats survive; a typical setting is 3. Export-only: the
-	// repeated cues remain in the retrieval index.
+	// legitimate short repeats survive; a typical setting is 3. Also applied at
+	// ingest, so a repetition artifact cannot dominate a document's chunks (#765).
 	MediaSubtitlesCollapseRepeats int
 
 	// MediaSubtitlesDropURLs opts IN to dropping exported cues whose text is a
 	// hallucinated URL / bare domain / credit line (config
-	// `media.subtitles.drop_urls`), in every format. OFF by default. Export-only:
-	// the dropped cues remain in the retrieval index.
+	// `media.subtitles.drop_urls`), in every format. OFF by default. Also applied
+	// at ingest, so a cue whisper hallucinated over silence is never embedded and
+	// can never be cited for a span where nobody said anything (#765). It is a
+	// whole-cue verdict on both surfaces: a stored chunk that merges several cues
+	// is dropped entirely when any of its text trips the URL pattern, which is
+	// exactly what the export pass does with the same chunk. That bluntness is why
+	// the key is opt-in.
 	MediaSubtitlesDropURLs bool
 
 	// MediaSubtitlesDropPhrases is an optional list of regular expressions; an

--- a/internal/ingest/represent.go
+++ b/internal/ingest/represent.go
@@ -1111,53 +1111,105 @@ func applyWordFilterToSegments(segs []chunkSegment, filter *subtitle.WordFilter)
 	return out
 }
 
-// applyDropScrubToSegments applies the configured subtitle drop/scrub cleaning
-// (config media.subtitles.drop_phrases / scrub_phrases) to each chunk segment's
-// text at INGEST, before embedding — mirroring applyWordFilterToSegments for
-// media.filter_words, so the same phrases that are stripped from the exported
-// sidecar are also stripped from what gets chunked and embedded (issue #545).
-// A segment whose text is composed ENTIRELY of drop phrases (DropSet.IsSpam) is
-// dropped, so whisper keyword-spam over non-speech is never embedded; a segment
-// carrying a leaked phrase glued to real speech is scrubbed (DropSet.Scrub) and
-// kept, and dropped only if the scrub empties it. Both sets are the exact same
-// subtitle primitives the export path invokes (subtitle.CleanCues →
-// DropSet.IsSpam/Scrub) built from the same config keys, so the index and the
-// exported sidecar agree cue-for-cue. Nil/inactive sets return segs unchanged,
-// so the empty-config path is a byte-for-byte no-op. Drop is applied before
-// scrub (matching CleanCues ordering); spans (timing) are preserved verbatim on
-// surviving segments.
-func applyDropScrubToSegments(segs []chunkSegment, drop, scrub *subtitle.DropSet) []chunkSegment {
-	if !drop.Active() && !scrub.Active() {
+// applyCueCleaningToSegments is the ingest-time cue-cleaning pass: it applies
+// the configured media.subtitles.* hallucination filters (drop_urls,
+// drop_phrases, scrub_phrases, collapse_repeats) to each chunk segment's text
+// before embedding, using the very same subtitle primitives the export pass
+// invokes (subtitle.IsURLCue, DropSet.IsSpam/Scrub, subtitle.RepeatCollapser).
+// #545 moved drop_phrases/scrub_phrases here; #765 moved drop_urls/
+// collapse_repeats, which had stayed export-only, so a hallucinated URL cue or a
+// repetition artifact was stripped from the exported sidecar and left embedded:
+// retrievable, and citable for a span where nobody said anything.
+//
+// The segment IS the cue unit on both sides, which is what makes "the index and
+// the exported sidecar agree cue-for-cue" literally true: export re-derives its
+// cues from these stored chunks (BuildCues over TranscriptSpanChunks), so a
+// verdict made per-segment here is a verdict made on exactly the text export
+// will clean. It also means a merged chunk is dropped whole when any of its cues
+// trips drop_urls, which is precisely what export does with the same chunk; both
+// passes are opt-in for that reason.
+//
+// Order is deliberate and mirrors subtitle.CleanCues step for step, because the
+// passes do NOT commute:
+//   - drop_urls first: it is a whole-segment verdict on the ORIGINAL text. Run
+//     after a scrub, an excision could remove the very token that identified the
+//     segment as a credit line, so the same segment would be dropped on export
+//     and kept in the index.
+//   - drop_phrases before scrub_phrases: a wholly-spam segment must be dropped
+//     outright rather than scrubbed down to a punctuation husk that then reads
+//     as an empty-but-present cue.
+//   - collapse_repeats LAST, on the post-scrub text: two segments that differ
+//     only by a leaked hallucination phrase are the same cue once scrubbed, and
+//     a run must be counted on the text that is actually stored. Counting first
+//     would miss that run in the index while export (which scrubs first) drops
+//     it, and the two would disagree.
+//
+// media.subtitles.glossary is deliberately NOT applied here: SPEC §8.6.2 pins it
+// as a deterministic, export-time find/replace on already-rendered cue text, so
+// rewriting indexed text with it is a spec change, not a bug fix. Were it ever
+// added, it would have to run AFTER the collapse (a rewrite can make two
+// distinct texts identical and fabricate a run), exactly as CleanCues orders it.
+//
+// Inactive options return segs unchanged, so the off-by-default path is a
+// byte-for-byte no-op. Spans (timing) are preserved verbatim on surviving
+// segments.
+func applyCueCleaningToSegments(segs []chunkSegment, opts subtitle.CleanOptions) []chunkSegment {
+	if !opts.Active() {
 		return segs
 	}
 	out := make([]chunkSegment, 0, len(segs))
+	collapse := subtitle.NewRepeatCollapser(opts.CollapseRepeats)
 	for _, seg := range segs {
-		if drop.IsSpam(seg.Text) {
+		cleaned, keep := cleanSegment(seg, opts)
+		if !keep {
 			continue
 		}
-		if scrub.Active() {
-			scrubbed := scrub.Scrub(seg.Text)
-			if strings.TrimSpace(scrubbed) == "" {
-				continue
-			}
-			// Only touch a segment the scrub actually changed. filterWordSpansToText
-			// is an approximate multiset token match, so re-running it on an
-			// UNCHANGED segment risks silently dropping a word timing on any
-			// tokenization/punctuation mismatch (numerals, contractions) — for every
-			// segment when scrub_phrases is set, not just scrubbed ones. An unchanged
-			// segment keeps its Text and Span.Words verbatim.
-			if scrubbed != seg.Text {
-				seg.Text = scrubbed
-				// Excise the scrubbed words from the per-word timings too: Span.Words is
-				// later rebuilt into broadcast cues / other word-level consumers, so
-				// leaving the removed phrase's words here would re-introduce the spam the
-				// scrub just removed from Text.
-				seg.Span.Words = filterWordSpansToText(seg.Span.Words, scrubbed)
-			}
+		// Every surviving segment must be fed to the collapser, in order, or the
+		// run counter loses track of which repeat is the Nth.
+		if collapse.Drop(cleaned.Text) {
+			continue
 		}
-		out = append(out, seg)
+		out = append(out, cleaned)
 	}
 	return out
+}
+
+// cleanSegment applies the per-segment half of the cleaning (the passes that
+// judge a segment on its own, independent of its neighbours) to one chunk
+// segment and reports whether it survives. The stateful collapse pass is the
+// caller's job. A segment no rule matched is returned verbatim, byte for byte.
+func cleanSegment(seg chunkSegment, opts subtitle.CleanOptions) (chunkSegment, bool) {
+	if strings.TrimSpace(seg.Text) == "" {
+		return seg, false
+	}
+	if opts.DropURLs && subtitle.IsURLCue(seg.Text) {
+		return seg, false
+	}
+	if opts.Drop.IsSpam(seg.Text) {
+		return seg, false
+	}
+	if !opts.Scrub.Active() {
+		return seg, true
+	}
+	scrubbed := opts.Scrub.Scrub(seg.Text)
+	if strings.TrimSpace(scrubbed) == "" {
+		return seg, false
+	}
+	// Only touch a segment the scrub actually changed. filterWordSpansToText
+	// is an approximate multiset token match, so re-running it on an
+	// UNCHANGED segment risks silently dropping a word timing on any
+	// tokenization/punctuation mismatch (numerals, contractions) — for every
+	// segment when scrub_phrases is set, not just scrubbed ones. An unchanged
+	// segment keeps its Text and Span.Words verbatim.
+	if scrubbed != seg.Text {
+		seg.Text = scrubbed
+		// Excise the scrubbed words from the per-word timings too: Span.Words is
+		// later rebuilt into broadcast cues / other word-level consumers, so
+		// leaving the removed phrase's words here would re-introduce the spam the
+		// scrub just removed from Text.
+		seg.Span.Words = filterWordSpansToText(seg.Span.Words, scrubbed)
+	}
+	return seg, true
 }
 
 // filterWordSpansToText drops per-word timings whose token is no longer present
@@ -1792,17 +1844,26 @@ func ChunkTranscriptByTimeWithWordsFiltered(content string, words []model.TimedW
 	return out
 }
 
-// ApplyDropScrubToSegments is the exported counterpart of
-// applyDropScrubToSegments, exposed for tests in the tests/ tree. It applies the
-// configured subtitle drop/scrub cleaning to chunk segments exactly as the ingest
-// path does after chunking (before persistence/embedding). Nil/inactive sets
-// return the input unchanged.
+// ApplyDropScrubToSegments applies just the drop_phrases/scrub_phrases half of
+// the ingest cue cleaning, exposed for tests in the tests/ tree. It is a thin
+// wrapper over ApplyCueCleaningToSegments so the drop/scrub coverage predating
+// #765 keeps exercising the production path. Nil/inactive sets return the input
+// unchanged.
 func ApplyDropScrubToSegments(segs []ChunkSegment, drop, scrub *subtitle.DropSet) []ChunkSegment {
+	return ApplyCueCleaningToSegments(segs, subtitle.CleanOptions{Drop: drop, Scrub: scrub})
+}
+
+// ApplyCueCleaningToSegments is the exported counterpart of
+// applyCueCleaningToSegments, exposed for tests in the tests/ tree. It applies
+// the configured media.subtitles.* cue cleaning to chunk segments exactly as the
+// ingest path does after chunking (before persistence/embedding). Inactive
+// options return the input unchanged.
+func ApplyCueCleaningToSegments(segs []ChunkSegment, opts subtitle.CleanOptions) []ChunkSegment {
 	raw := make([]chunkSegment, len(segs))
 	for i, seg := range segs {
 		raw[i] = chunkSegment(seg)
 	}
-	cleaned := applyDropScrubToSegments(raw, drop, scrub)
+	cleaned := applyCueCleaningToSegments(raw, opts)
 	out := make([]ChunkSegment, 0, len(cleaned))
 	for _, seg := range cleaned {
 		out = append(out, ChunkSegment(seg))

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -1203,25 +1203,38 @@ func (s *Service) captionWordFilter() *subtitle.WordFilter {
 	return subtitle.NewWordFilter(s.cfg.MediaFilterWords)
 }
 
-// captionDropScrub builds the shared subtitle drop/scrub sets from
-// media.subtitles.drop_phrases / scrub_phrases (issue #545). The same sets clean
-// STT transcript chunks and sidecar-cue chunks before embedding, mirroring how
-// the export path (subtitle.CleanCues) cleans the exported sidecar — so a
-// wholly-spam chunk is never indexed and a chunk with a leaked phrase is embedded
-// scrubbed, keeping the index and sidecar in agreement. Empty config yields
-// inactive (nil) sets, which the cleaning treats as a no-op. The patterns were
-// already validated at config load (config.Validate → subtitle.NewDropSet), so a
-// compile error here is unexpected; it is logged and treated as no cleaning
-// (nil set) rather than failing ingestion.
-func (s *Service) captionDropScrub() (drop, scrub *subtitle.DropSet) {
-	var err error
-	if drop, err = subtitle.NewDropSet(s.cfg.MediaSubtitlesDropPhrases); err != nil {
+// captionCleanOptions builds the shared ingest-time cue cleaning from
+// media.subtitles.{drop_urls,drop_phrases,scrub_phrases,collapse_repeats}
+// (issues #545, #765). The same options clean STT transcript chunks, translated
+// transcript chunks and sidecar-cue chunks before embedding, and they are the
+// SAME subtitle.CleanOptions shape the export path builds (cli.newCuePipeline),
+// so a hallucinated URL, a wholly-spam chunk or a repetition run is neither
+// exported nor indexed, keeping the index and the sidecar in agreement rather
+// than leaving cues that are invisible in the sidecar but citable from the index.
+//
+// Glossary is deliberately left unset: SPEC §8.6.2 pins media.subtitles.glossary
+// as an export-time find/replace on already-rendered cue text, so rewriting
+// indexed text with it needs a spec change first, not a code fix. With every key
+// unset the options are inactive and the cleaning is a byte-for-byte no-op.
+//
+// The patterns were already validated at config load (config.Validate →
+// subtitle.NewDropSet), so a compile error here is unexpected; it is logged and
+// treated as no cleaning (nil set) rather than failing ingestion.
+func (s *Service) captionCleanOptions() subtitle.CleanOptions {
+	drop, err := subtitle.NewDropSet(s.cfg.MediaSubtitlesDropPhrases)
+	if err != nil {
 		s.getLogger().Printf("media.subtitles.drop_phrases invalid at ingest, ignoring: %v", err)
 	}
-	if scrub, err = subtitle.NewDropSet(s.cfg.MediaSubtitlesScrubPhrases); err != nil {
+	scrub, err := subtitle.NewDropSet(s.cfg.MediaSubtitlesScrubPhrases)
+	if err != nil {
 		s.getLogger().Printf("media.subtitles.scrub_phrases invalid at ingest, ignoring: %v", err)
 	}
-	return drop, scrub
+	return subtitle.CleanOptions{
+		DropURLs:        s.cfg.MediaSubtitlesDropURLs,
+		Drop:            drop,
+		Scrub:           scrub,
+		CollapseRepeats: s.cfg.MediaSubtitlesCollapseRepeats,
+	}
 }
 
 func sttExpectedLanguage(cfg config.Config) string {
@@ -4490,11 +4503,11 @@ func (s *Service) transcribeAndPersistTrack(ctx context.Context, doc model.Docum
 	}
 
 	segments := chunkTranscriptByTimeWithWordsFiltered(transcriptText, words, s.captionWordFilter())
-	// Strip configured subtitle drop/scrub phrases from the chunk text BEFORE
-	// embedding (issue #545), so whisper keyword-spam never pollutes the index —
-	// the same cleaning the export path applies to the sidecar. Off by default.
-	dropSet, scrubSet := s.captionDropScrub()
-	segments = applyDropScrubToSegments(segments, dropSet, scrubSet)
+	// Apply the configured subtitle cue cleaning to the chunk text BEFORE
+	// embedding (issues #545, #765), so whisper keyword-spam, hallucinated URL /
+	// credit lines and repetition runs never pollute the index: the same cleaning
+	// the export path applies to the sidecar. Off by default.
+	segments = applyCueCleaningToSegments(segments, s.captionCleanOptions())
 	if len(segments) == 0 {
 		return false, false, nil
 	}
@@ -4878,10 +4891,10 @@ func (s *Service) translateOneTranscript(ctx context.Context, doc model.Document
 	// English track. translatedWords is nil for the chat engine, leaving that path
 	// chunk-only as before.
 	segments := chunkTranscriptByTimeWithWordsFiltered(translated, translatedWords, s.captionWordFilter())
-	// Strip configured subtitle drop/scrub phrases from the translated chunk text
-	// before embedding (issue #545), consistent with the source transcript path.
-	dropSet, scrubSet := s.captionDropScrub()
-	segments = applyDropScrubToSegments(segments, dropSet, scrubSet)
+	// Apply the configured subtitle cue cleaning to the translated chunk text
+	// before embedding (issues #545, #765), consistent with the source transcript
+	// path.
+	segments = applyCueCleaningToSegments(segments, s.captionCleanOptions())
 	// Bail BEFORE creating the representation when the translation was fully
 	// stripped (drop/scrub emptied every segment): otherwise we would leave a
 	// dangling rep row with no chunks and inflate the representation count. The

--- a/internal/ingest/sidecar.go
+++ b/internal/ingest/sidecar.go
@@ -363,15 +363,18 @@ func (s *Service) ingestSidecarTranscripts(ctx context.Context, doc model.Docume
 	}
 	sort.Strings(langs)
 
-	// Build the drop/scrub sets once for all languages; they are config-derived
-	// and language-independent. They strip configured subtitle drop/scrub phrases
-	// from the chunk text before embedding (issue #545), the same cleaning the
-	// export path applies to the sidecar. Off by default (inactive sets = no-op).
-	dropSet, scrubSet := s.captionDropScrub()
+	// Build the cleaning options once for all languages; they are config-derived
+	// and language-independent. They apply the configured media.subtitles.*
+	// cleaning to the chunk text before embedding (issues #545, #765), the same
+	// cleaning the export path applies to the sidecar. Off by default (inactive
+	// options = no-op). The collapse-repeats run counter stays per language: each
+	// applyCueCleaningToSegments call builds a fresh collapser, so one language's
+	// trailing cue can never start a run in the next.
+	cleanOpts := s.captionCleanOptions()
 	ingested := false
 	for _, lang := range langs {
 		segments := chunkSubtitleCuesFiltered(groups[lang], s.captionWordFilter())
-		segments = applyDropScrubToSegments(segments, dropSet, scrubSet)
+		segments = applyCueCleaningToSegments(segments, cleanOpts)
 		if len(segments) == 0 {
 			continue
 		}

--- a/internal/subtitle/clean.go
+++ b/internal/subtitle/clean.go
@@ -226,10 +226,17 @@ func (d *DropSet) Scrub(text string) string {
 	return strings.TrimSpace(strings.Trim(text, ",;:—- "))
 }
 
-// CleanOptions configures the export-time cue-cleaning pass (port of the pilot's
+// CleanOptions configures the cue-cleaning pass (port of the pilot's
 // clean_srt.py). All fields are additive and off by default, so a zero
-// CleanOptions leaves cues unchanged. It is applied AFTER WordFilter on export,
-// so filter_words removal and this cleanup compose.
+// CleanOptions leaves cues unchanged. It is applied AFTER WordFilter, so
+// filter_words removal and this cleanup compose.
+//
+// The same options value drives BOTH surfaces: the export pass (CleanCues over
+// built cues) and the ingest pass (internal/ingest applies the hallucination
+// filters to chunk segments before embedding, issue #765), so the index and the
+// exported sidecar agree cue-for-cue. Glossary is the one field ingest does NOT
+// set; see MediaSubtitlesGlossary in internal/config for why it stays
+// export-only.
 type CleanOptions struct {
 	// DropURLs drops any cue whose text looks like a hallucinated URL / domain /
 	// credit line (whisper emits these over silence or music).
@@ -269,24 +276,82 @@ func (o CleanOptions) Active() bool {
 // [\w-] label immediately abutting a letter-led TLD.
 var urlCueRE = regexp.MustCompile(`(?i)(https?://|www\.|\b[\w-]+\.[a-z]{2,24}\b)`)
 
-// CleanCues applies the configured cleanup passes to cues in order: drop empty
-// cues, drop URL/credit hallucinations, collapse identical-consecutive runs, and
-// rewrite text via the glossary (dropping any cue the rewrite empties). Surviving
-// cues are re-indexed gap-free (as FilterCues does). Timing is preserved verbatim.
-// A zero/empty CleanOptions returns cues unchanged.
+// IsURLCue reports whether text looks like a hallucinated URL / bare domain /
+// credit line (see urlCueRE). It is exported because the ingest pass makes the
+// same verdict on chunk segments before embedding (issue #765): sharing the one
+// regexp is what keeps the dropped-at-export and dropped-at-ingest sets
+// identical, instead of two pattern copies that drift apart.
+func IsURLCue(text string) bool {
+	return urlCueRE.MatchString(text)
+}
+
+// RepeatCollapser is the stateful half of the collapse_repeats pass: it walks a
+// cue (or chunk-segment) sequence in order and reports which entries fall in the
+// tail of a run of identical consecutive texts. It is exported for the same
+// reason as IsURLCue: ingest collapses the runs before embedding and must count
+// runs exactly the way export does (issue #765).
+//
+// A limit < 2 disables the pass, so legitimate short repeats ("Yes." "Yes.")
+// survive and only long identical runs (the whisper repetition-collapse
+// artifact) are collapsed.
+type RepeatCollapser struct {
+	limit  int
+	text   string
+	runLen int
+}
+
+// NewRepeatCollapser returns a collapser keeping the first limit-1 entries of
+// every identical-consecutive run. limit < 2 yields an inactive collapser whose
+// Drop is always false.
+func NewRepeatCollapser(limit int) *RepeatCollapser {
+	return &RepeatCollapser{limit: limit}
+}
+
+// Active reports whether the collapser drops anything. When false, Drop is
+// always false and callers can skip it.
+func (c *RepeatCollapser) Active() bool {
+	return c != nil && c.limit >= 2
+}
+
+// Drop advances the run state with the next text and reports whether that entry
+// should be dropped. Callers MUST pass every surviving entry, in order, even
+// when they ignore the verdict: the run counter is what makes "the Nth and later
+// identical entry" meaningful. The comparison anchor updates only when the text
+// changes, so a run of K identical entries keeps the first limit-1 and drops the
+// rest.
+func (c *RepeatCollapser) Drop(text string) bool {
+	if !c.Active() {
+		return false
+	}
+	if text == c.text {
+		c.runLen++
+		return c.runLen >= c.limit
+	}
+	c.text = text
+	c.runLen = 1
+	return false
+}
+
+// CleanCues applies the configured cleanup passes to cues in this order: drop
+// empty cues, drop URL/credit hallucinations, drop wholly-spam cues, scrub a
+// leaked phrase out of a real cue, collapse identical-consecutive runs, and
+// rewrite text via the glossary (dropping any cue the rewrite empties). The
+// order is load-bearing and is mirrored by the ingest pass (issue #765): see
+// applyCueCleaningToSegments in internal/ingest for the per-step reasoning.
+// Surviving cues are re-indexed gap-free (as FilterCues does). Timing is
+// preserved verbatim. A zero/empty CleanOptions returns cues unchanged.
 func CleanCues(cues []Cue, opts CleanOptions) []Cue {
 	if !opts.Active() {
 		return cues
 	}
 	out := make([]Cue, 0, len(cues))
-	var runText string
-	var runLen int
+	collapse := NewRepeatCollapser(opts.CollapseRepeats)
 	for _, cue := range cues {
 		text := strings.TrimSpace(cue.Text)
 		if text == "" {
 			continue
 		}
-		if opts.DropURLs && urlCueRE.MatchString(text) {
+		if opts.DropURLs && IsURLCue(text) {
 			continue
 		}
 		if opts.Drop.IsSpam(text) {
@@ -301,20 +366,10 @@ func CleanCues(cues []Cue, opts CleanOptions) []Cue {
 				continue
 			}
 		}
-		// Repetition-collapse compares the pre-glossary text so a rewrite cannot
-		// mask a collapse run. The comparison anchor (runText) updates only when
-		// the text changes, so a run of K identical cues keeps the first
-		// CollapseRepeats-1 and drops the rest.
-		if opts.CollapseRepeats >= 2 {
-			if text == runText {
-				runLen++
-				if runLen >= opts.CollapseRepeats {
-					continue
-				}
-			} else {
-				runText = text
-				runLen = 1
-			}
+		// Repetition-collapse compares the post-scrub, pre-glossary text so
+		// neither a leaked phrase nor a rewrite can mask a collapse run.
+		if collapse.Drop(text) {
+			continue
 		}
 		if opts.Glossary.Active() {
 			// Re-trim after the rewrite: a glossary rule may empty a cue (an empty

--- a/tests/ingest/cue_cleaning_765_test.go
+++ b/tests/ingest/cue_cleaning_765_test.go
@@ -1,0 +1,277 @@
+package tests
+
+import (
+	"context"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/subtitle"
+)
+
+// Issue #765: media.subtitles.drop_urls and collapse_repeats used to run only on
+// the export path, so a hallucinated URL cue or a repetition artifact was stripped
+// from the exported sidecar and left embedded: retrievable, and citable for a span
+// where nobody said anything. These tests pin that both now clean the chunk text
+// at ingest, in the same order the export pass uses.
+
+// urlFixture is a time-stamped transcript whose middle line is the credit-line /
+// bare-domain hallucination whisper emits over silence or music.
+const urlFixture = "[00:00] Welcome to the broadcast\n" +
+	"[00:02] Subtitles by www.example.com\n" +
+	"[00:05] Today we discuss the regional economy"
+
+// TestCueCleaningEmptyConfigUnchanged pins that inactive options leave the ingest
+// chunk segments byte-for-byte identical, so the off-by-default path changes
+// nothing. A glossary-only configuration counts as inactive at ingest: the
+// glossary is deliberately not part of the ingest pass (SPEC §8.6.2 pins it as
+// export-time), so configuring one must not perturb the index.
+func TestCueCleaningEmptyConfigUnchanged(t *testing.T) {
+	base := ingest.ChunkTranscriptByTime(urlFixture)
+	glossary, err := subtitle.NewGlossary([]string{"economy=>economics"})
+	if err != nil {
+		t.Fatalf("NewGlossary: %v", err)
+	}
+	for name, opts := range map[string]subtitle.CleanOptions{
+		"zero":          {},
+		"collapse-of-1": {CollapseRepeats: 1},
+		"glossary-only": {Glossary: glossary},
+	} {
+		got := ingest.ApplyCueCleaningToSegments(base, opts)
+		if !reflect.DeepEqual(got, base) {
+			t.Fatalf("%s options changed chunks:\n got %#v\nwant %#v", name, got, base)
+		}
+	}
+}
+
+// TestDropURLsNeverEmbedded pins that a hallucinated URL / credit-line chunk is
+// removed at ingest, so it is never embedded and can never be cited, while the
+// surrounding real speech keeps its text and time span.
+func TestDropURLsNeverEmbedded(t *testing.T) {
+	base := ingest.ChunkTranscriptByTime(urlFixture)
+	got := ingest.ApplyCueCleaningToSegments(base, subtitle.CleanOptions{DropURLs: true})
+
+	joined := joinSegText(got)
+	if strings.Contains(joined, "example.com") {
+		t.Fatalf("hallucinated URL leaked into ingest chunks: %q", joined)
+	}
+	if len(got) != len(base)-1 {
+		t.Fatalf("expected exactly the URL chunk dropped: got %d, base %d", len(got), len(base))
+	}
+	if !strings.Contains(joined, "Welcome to the broadcast") ||
+		!strings.Contains(joined, "regional economy") {
+		t.Fatalf("drop_urls removed real speech: %q", joined)
+	}
+	for _, seg := range got {
+		if seg.Span.Kind != "time" {
+			t.Fatalf("surviving chunk lost its time span: %#v", seg.Span)
+		}
+	}
+}
+
+// TestCollapseRepeatsAtIngest pins that a run of identical consecutive chunks is
+// collapsed before embedding: the first collapse_repeats-1 survive and the rest
+// are dropped, so a repetition artifact cannot dominate a document's chunks.
+func TestCollapseRepeatsAtIngest(t *testing.T) {
+	const repeated = "[00:00] Real opening line\n" +
+		"[00:02] Продолжение следует\n" +
+		"[00:04] Продолжение следует\n" +
+		"[00:06] Продолжение следует\n" +
+		"[00:08] Продолжение следует\n" +
+		"[00:10] Real closing line"
+	base := ingest.ChunkTranscriptByTime(repeated)
+	got := ingest.ApplyCueCleaningToSegments(base, subtitle.CleanOptions{CollapseRepeats: 3})
+
+	var repeats int
+	for _, seg := range got {
+		if strings.Contains(seg.Text, "Продолжение следует") {
+			repeats++
+		}
+	}
+	if repeats != 2 {
+		t.Fatalf("expected the first 2 of 4 identical chunks to survive, got %d: %q", repeats, joinSegText(got))
+	}
+	joined := joinSegText(got)
+	if !strings.Contains(joined, "Real opening line") || !strings.Contains(joined, "Real closing line") {
+		t.Fatalf("collapse dropped non-repeated speech: %q", joined)
+	}
+	// The run is broken by the closing line, so a later identical text would start
+	// a fresh run rather than continuing the collapsed one.
+	if len(got) != len(base)-2 {
+		t.Fatalf("expected exactly 2 chunks dropped: got %d, base %d", len(got), len(base))
+	}
+}
+
+// TestDropURLsRunsBeforeScrub pins the ordering of the two whole-chunk passes:
+// drop_urls sees the ORIGINAL text. Here the scrub phrase would excise the very
+// token that identifies the chunk as a credit line, so scrubbing first would keep
+// a chunk that the export pass drops, and the index and the sidecar would
+// disagree. Both surfaces must reach the same verdict.
+func TestDropURLsRunsBeforeScrub(t *testing.T) {
+	const text = "[00:00] Real reporting here\n[00:02] Смотрите нас на example.com"
+	opts := subtitle.CleanOptions{
+		DropURLs: true,
+		Scrub:    mustDropSet(t, []string{`example\.com`}),
+	}
+
+	got := ingest.ApplyCueCleaningToSegments(ingest.ChunkTranscriptByTime(text), opts)
+	joined := joinSegText(got)
+	if strings.Contains(joined, "Смотрите нас") {
+		t.Fatalf("credit-line chunk survived the scrub instead of being dropped: %q", joined)
+	}
+	if !strings.Contains(joined, "Real reporting here") {
+		t.Fatalf("expected the real chunk to survive: %q", joined)
+	}
+
+	// Export makes the same call on the same chunks.
+	exportCues := subtitle.CleanCues(subtitle.BuildCues(chunksFromSegments(ingest.ChunkTranscriptByTime(text))), opts)
+	if len(exportCues) != len(got) {
+		t.Fatalf("ingest kept %d chunks, export kept %d cues: the two disagree", len(got), len(exportCues))
+	}
+}
+
+// TestCollapseRepeatsRunsAfterScrub pins the other half of the ordering: the run
+// is counted on the POST-scrub text that is actually stored. Two chunks that
+// differ only by a leaked hallucination phrase are the same cue once scrubbed, so
+// counting the run before the scrub would leave the duplicate in the index while
+// export (which scrubs first) drops it.
+func TestCollapseRepeatsRunsAfterScrub(t *testing.T) {
+	const text = "[00:00] Мы продолжаем\n" +
+		"[00:02] Мы продолжаем Крым, НАТО\n" +
+		"[00:04] Real closing line"
+	opts := subtitle.CleanOptions{
+		Scrub:           mustDropSet(t, []string{"Крым, НАТО"}),
+		CollapseRepeats: 2,
+	}
+
+	got := ingest.ApplyCueCleaningToSegments(ingest.ChunkTranscriptByTime(text), opts)
+	var repeats int
+	for _, seg := range got {
+		if strings.TrimSpace(seg.Text) == "Мы продолжаем" {
+			repeats++
+		}
+	}
+	if repeats != 1 {
+		t.Fatalf("expected the scrubbed duplicate to be collapsed, got %d copies: %q", repeats, joinSegText(got))
+	}
+	if !strings.Contains(joinSegText(got), "Real closing line") {
+		t.Fatalf("collapse dropped real speech: %q", joinSegText(got))
+	}
+}
+
+// TestCueCleaningIngestAndExportAgree pins the invariant #545 stated and #765
+// completes: with the same options, the text the index keeps and the text the
+// exported sidecar keeps are the same, cue for cue.
+func TestCueCleaningIngestAndExportAgree(t *testing.T) {
+	const text = "[00:00] Real reporting here\n" +
+		"[00:02] www.example.com\n" +
+		"[00:04] Повтор\n" +
+		"[00:06] Повтор\n" +
+		"[00:08] Повтор"
+	opts := subtitle.CleanOptions{DropURLs: true, CollapseRepeats: 2}
+
+	ingestSegs := ingest.ApplyCueCleaningToSegments(ingest.ChunkTranscriptByTime(text), opts)
+	exportCues := subtitle.CleanCues(subtitle.BuildCues(chunksFromSegments(ingest.ChunkTranscriptByTime(text))), opts)
+
+	ingestTexts := make([]string, 0, len(ingestSegs))
+	for _, seg := range ingestSegs {
+		ingestTexts = append(ingestTexts, strings.TrimSpace(seg.Text))
+	}
+	exportTexts := make([]string, 0, len(exportCues))
+	for _, c := range exportCues {
+		exportTexts = append(exportTexts, strings.TrimSpace(c.Text))
+	}
+	if !reflect.DeepEqual(ingestTexts, exportTexts) {
+		t.Fatalf("index and sidecar disagree:\n index  %q\n export %q", ingestTexts, exportTexts)
+	}
+	if len(ingestTexts) != 2 {
+		t.Fatalf("expected the URL chunk dropped and the repeat run collapsed to one, got %q", ingestTexts)
+	}
+}
+
+// chunksFromSegments adapts ingest chunk segments to the export cue builder's
+// input shape, so a test can clean the very same chunks on both surfaces.
+func chunksFromSegments(segs []ingest.ChunkSegment) []subtitle.TranscriptChunk {
+	out := make([]subtitle.TranscriptChunk, 0, len(segs))
+	for _, s := range segs {
+		out = append(out, subtitle.TranscriptChunk{Text: s.Text, Span: s.Span})
+	}
+	return out
+}
+
+// longCue pads text to more than TranscriptChunkMaxChars so one cue becomes one
+// stored chunk. The cue unit at ingest IS the stored chunk (export re-derives its
+// cues from these chunks), so a fixture that merges every cue into a single chunk
+// could not tell a per-cue verdict apart from a whole-document one.
+func longCue(text string) string {
+	return text + " " + strings.Repeat("подробности передачи ", 70)
+}
+
+// TestSidecarIngest_DropsHallucinatedURLCue drives the full sidecar ingest path
+// with media.subtitles.drop_urls enabled and pins that the credit-line cue never
+// reaches a stored chunk, while the real cues do.
+func TestSidecarIngest_DropsHallucinatedURLCue(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "media", "lecture.mp3"), "fake-audio")
+	writeFile(t, filepath.Join(root, "media", "lecture.vtt"),
+		"WEBVTT\n\n"+
+			"00:00:00.000 --> 00:00:20.000\n"+longCue("Реальный репортаж")+"\n\n"+
+			"00:00:20.000 --> 00:00:22.000\nSubtitles by www.example.com\n\n"+
+			"00:00:22.000 --> 00:00:40.000\n"+longCue("Продолжение репортажа")+"\n")
+
+	st := &fakeIngestStore{}
+	svc := mustNewIngestService(t, config.Config{
+		RootDir:                root,
+		StateDir:               t.TempDir(),
+		MediaSubtitlesDropURLs: true,
+	}, st)
+
+	doc := model.Document{DocID: 1, RelPath: "media/lecture.mp3", DocType: "audio"}
+	if _, err := svc.IngestSidecarTranscripts(context.Background(), doc); err != nil {
+		t.Fatalf("IngestSidecarTranscripts: %v", err)
+	}
+	if len(st.chunks) != 2 {
+		t.Fatalf("expected 2 stored chunks (the URL cue dropped), got %d", len(st.chunks))
+	}
+	for _, c := range st.chunks {
+		if strings.Contains(c.Text, "example.com") {
+			t.Fatalf("hallucinated URL cue was embedded: %q", c.Text)
+		}
+	}
+}
+
+// TestSidecarIngest_CollapsesRepeatedCues drives the full sidecar ingest path
+// with media.subtitles.collapse_repeats enabled and pins that only the first
+// collapse_repeats-1 chunks of an identical run are stored.
+func TestSidecarIngest_CollapsesRepeatedCues(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	repeated := longCue("Продолжение следует")
+	writeFile(t, filepath.Join(root, "media", "clip.mp3"), "fake-audio")
+	writeFile(t, filepath.Join(root, "media", "clip.vtt"),
+		"WEBVTT\n\n"+
+			"00:00:00.000 --> 00:00:20.000\n"+repeated+"\n\n"+
+			"00:00:20.000 --> 00:00:40.000\n"+repeated+"\n\n"+
+			"00:00:40.000 --> 00:01:00.000\n"+repeated+"\n\n"+
+			"00:01:00.000 --> 00:01:20.000\n"+repeated+"\n")
+
+	st := &fakeIngestStore{}
+	svc := mustNewIngestService(t, config.Config{
+		RootDir:                       root,
+		StateDir:                      t.TempDir(),
+		MediaSubtitlesCollapseRepeats: 3,
+	}, st)
+
+	doc := model.Document{DocID: 1, RelPath: "media/clip.mp3", DocType: "audio"}
+	if _, err := svc.IngestSidecarTranscripts(context.Background(), doc); err != nil {
+		t.Fatalf("IngestSidecarTranscripts: %v", err)
+	}
+	if len(st.chunks) != 2 {
+		t.Fatalf("expected the 4-cue run collapsed to 2 stored chunks, got %d", len(st.chunks))
+	}
+}

--- a/tests/subtitle/cue_cleaning_765_test.go
+++ b/tests/subtitle/cue_cleaning_765_test.go
@@ -1,0 +1,101 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/subtitle"
+)
+
+// Issue #765 split the drop_urls verdict and the collapse_repeats run counter out
+// of CleanCues so the ingest pass can make the SAME verdicts on chunk segments
+// before embedding. These tests pin the extracted primitives directly, because a
+// drift between them and CleanCues is exactly the failure mode the split exists
+// to prevent (two copies of a pattern, two answers, index and sidecar disagree).
+
+// TestIsURLCueMatchesHallucinatedCredits pins the shared URL/credit-line verdict:
+// it catches real domains in any position without hardcoding ccTLDs, and leaves
+// ordinary prose with sentence periods, decimals and honorifics alone.
+func TestIsURLCueMatchesHallucinatedCredits(t *testing.T) {
+	urls := []string{
+		"https://example.com",
+		"Subtitles by www.example.org",
+		"amara.org",
+		"Субтитры сделал DimaTorzok tvrain.tv",
+	}
+	for _, s := range urls {
+		if !subtitle.IsURLCue(s) {
+			t.Errorf("IsURLCue(%q) = false, want true", s)
+		}
+	}
+	prose := []string{
+		"That is the end. Next we turn to the economy.",
+		"Inflation reached 3.14 percent",
+		"Mr. Smith took the floor",
+		"Сегодня обсуждаем экономику региона",
+	}
+	for _, s := range prose {
+		if subtitle.IsURLCue(s) {
+			t.Errorf("IsURLCue(%q) = true, want false", s)
+		}
+	}
+}
+
+// TestRepeatCollapserKeepsLeadingRun pins the run counter: a run of K identical
+// texts keeps the first limit-1 and drops the rest, a changed text restarts the
+// run, and a limit below 2 is inactive (legitimate short repeats survive).
+func TestRepeatCollapserKeepsLeadingRun(t *testing.T) {
+	c := subtitle.NewRepeatCollapser(3)
+	if !c.Active() {
+		t.Fatal("collapser with limit 3 must be active")
+	}
+	seq := []string{"a", "a", "a", "a", "b", "a"}
+	want := []bool{false, false, true, true, false, false}
+	for i, text := range seq {
+		if got := c.Drop(text); got != want[i] {
+			t.Fatalf("Drop(%q) at %d = %v, want %v", text, i, got, want[i])
+		}
+	}
+
+	for _, limit := range []int{0, 1, -1} {
+		inactive := subtitle.NewRepeatCollapser(limit)
+		if inactive.Active() {
+			t.Fatalf("collapser with limit %d must be inactive", limit)
+		}
+		for _, text := range seq {
+			if inactive.Drop(text) {
+				t.Fatalf("inactive collapser (limit %d) dropped %q", limit, text)
+			}
+		}
+	}
+	// A nil collapser is inactive too, so callers need no nil guard.
+	var nilCollapser *subtitle.RepeatCollapser
+	if nilCollapser.Active() || nilCollapser.Drop("a") {
+		t.Fatal("nil collapser must be inactive")
+	}
+}
+
+// TestCleanCuesUsesSharedRepeatCounter pins that CleanCues still collapses runs
+// exactly as before the primitives were extracted: the first limit-1 cues of a
+// run survive, and surviving cues are re-indexed gap-free.
+func TestCleanCuesUsesSharedRepeatCounter(t *testing.T) {
+	cues := []subtitle.Cue{
+		{Index: 1, StartMS: 0, EndMS: 1000, Text: "opening"},
+		{Index: 2, StartMS: 1000, EndMS: 2000, Text: "repeat"},
+		{Index: 3, StartMS: 2000, EndMS: 3000, Text: "repeat"},
+		{Index: 4, StartMS: 3000, EndMS: 4000, Text: "repeat"},
+		{Index: 5, StartMS: 4000, EndMS: 5000, Text: "closing"},
+	}
+	got := subtitle.CleanCues(cues, subtitle.CleanOptions{CollapseRepeats: 2})
+	want := []string{"opening", "repeat", "closing"}
+	if len(got) != len(want) {
+		t.Fatalf("CleanCues kept %d cues, want %d: %+v", len(got), len(want), got)
+	}
+	for i, c := range got {
+		if c.Text != want[i] {
+			t.Fatalf("cue %d = %q, want %q", i, c.Text, want[i])
+		}
+		if c.Index != i+1 {
+			t.Fatalf("cue %d has index %d, want gap-free %d", i, c.Index, i+1)
+		}
+	}
+}


### PR DESCRIPTION
Closes #765.

## What was verified against `main`

Re-checked every claim in the issue before touching anything:

- **Confirmed.** `internal/ingest` had exactly two cleaning entry points, `captionWordFilter` and `captionDropScrub`. There was no ingest-side construction of `DropURLs`, `CollapseRepeats` or `Glossary`; the only `Glossary` matches under `internal/ingest` are `media.translate_glossary` (prompt guidance, a different key and mechanism).
- **Confirmed.** The three keys were applied only in `cli.newCuePipeline` -> `subtitle.CleanCues`, and the config doc comments said so in as many words ("Export-only: the dropped cues remain in the retrieval index").
- **Confirmed.** SPEC has no normative definition of `media.subtitles.{glossary,drop_urls,collapse_repeats,drop_phrases,scrub_phrases,filter_words}` at all. The single mention of `media.subtitles.glossary` is the aside in §8.6.2 that calls it "a deterministic, **export-time** find/replace on already-rendered cue text"; `drop_urls` and `collapse_repeats` do not appear in the spec in any form, which is why #545 could move `drop_phrases`/`scrub_phrases` to ingest without a spec PR and this PR can move these two.
- **Did not reproduce as stated: the granularity.** The issue frames these as cue-level passes. On the export path the cue unit is not the source cue: `renderTranscriptExport` loads the stored chunks and calls `BuildCues` over them, so under the default `chunk` segmentation the export pass already makes its verdicts on merged chunk text. That is what makes the segment-level ingest pass an exact match rather than an approximation, and it is called out in the code comment.

## What changed

- `applyDropScrubToSegments` becomes `applyCueCleaningToSegments`, taking the same `subtitle.CleanOptions` value the export pipeline builds; `captionDropScrub` becomes `captionCleanOptions` and now carries `DropURLs` and `CollapseRepeats`. All three ingest call sites (STT transcript, translated transcript, sidecar cues) go through it, exactly as they did for drop/scrub.
- The verdicts are extracted out of `CleanCues` into shared primitives, `subtitle.IsURLCue` and `subtitle.RepeatCollapser`, and `CleanCues` now calls them. Ingest and export reach their answers through one implementation instead of two copies of a regexp and a run counter that can drift apart. `CleanCues` behavior is unchanged (pinned by a test).
- The per-segment half is split into `cleanSegment` so `applyCueCleaningToSegments` stays well under `gocyclo -over 15`.
- Config docs updated: the four keys that now run on both surfaces say so, `glossary` says why it does not and what that costs an operator, and the re-index note lives next to the export/ingest split.

`ApplyDropScrubToSegments` is kept as a thin exported wrapper so the drop/scrub coverage from #545 keeps exercising the production path unchanged.

## The ordering decision

The passes do not commute, so the ingest pass mirrors `CleanCues` step for step:

1. **`drop_urls` first**, on the ORIGINAL text. It is a whole-segment verdict; run after a scrub, an excision can remove the very token that identified the segment as a credit line, so export (which drops first) and the index (which would keep it) end up disagreeing. `TestDropURLsRunsBeforeScrub` pins this and asserts both surfaces keep the same number of entries.
2. **`drop_phrases` before `scrub_phrases`** (unchanged from #545): a wholly-spam segment is dropped outright rather than scrubbed down to a punctuation husk.
3. **`collapse_repeats` last, on the post-scrub text.** Two segments that differ only by a leaked hallucination phrase are the same cue once scrubbed, and the run has to be counted on the text that is actually stored. Counting first would miss the run in the index while export drops it. `TestCollapseRepeatsRunsAfterScrub` pins this.
4. **Glossary would have to come after the collapse** if it were ever applied at ingest, because a rewrite can make two distinct texts identical and fabricate a run. That is how `CleanCues` already orders it, and the reasoning is recorded in the comment so a future spec change has the answer waiting.

## Glossary: deliberately not moved

`media.subtitles.glossary` stays export-only. SPEC §8.6.2 pins it as a deterministic, export-time find/replace on already-rendered cue text, so rewriting indexed text with it is a spec change and not a bug fix, and per the repo's spec-first rule that needs a `dirstral-spec` PR merged before any code. The submodule pointer is untouched here. The consequence the issue names (search matches the pre-glossary spelling while every exported artifact shows the post-glossary one) is now written on the config key instead of being silent, so an operator hits documentation rather than confusion.

## Already-indexed corpora

**No re-derivation is triggered, and that is deliberate.** The derivation identity (§8.6.7) is built from capability/provider/model/version/language, is compared only against STT and OCR provenance, and explicitly never invalidates a sidecar-sourced transcript. Nothing in it covers operator cleaning preferences, so enabling `drop_urls` or `collapse_repeats` on an existing corpus cleans the exported sidecar immediately and leaves already-embedded chunks as they were until the corpus is re-indexed.

Folding the cleaning config into that identity was considered and rejected: `transcriptCacheKey` folds the same identity into the on-disk transcript cache key, so a cleaning-config change would miss the cache and re-run paid transcription corpus-wide for an editorial toggle. Bumping `index_format_version` is heavier still, since it refuses to open the corpus at all. Both are the wrong price for an opt-in, off-by-default editorial key.

The migration story is therefore `dir2mcp reindex`, which re-chunks from the cached transcripts (the cache key is unchanged, so no re-transcription), and it is now documented on the config keys themselves. This matches the existing behavior of `media.filter_words` and of `drop_phrases`/`scrub_phrases` since #545, so it introduces no new sharp edge, only a documented one.

## Verification

- **Tests fail against current `main`.** Verified by stashing the source change and running the two full-ingest tests against unmodified `main`: `expected 2 stored chunks (the URL cue dropped), got 3` and `expected the 4-cue run collapsed to 2 stored chunks, got 4`. Both pass with the change. These two drive `IngestSidecarTranscripts` end to end and assert on the chunks handed to the store, so they compile and run against `main` and fail on behavior rather than on a missing symbol.
- `tests/ingest/cue_cleaning_765_test.go`: off-by-default no-op (including a glossary-only config, which must not perturb the index), `drop_urls` at ingest, `collapse_repeats` at ingest, both ordering pins, index/sidecar agreement, and the two sidecar-ingest tests above.
- `tests/subtitle/cue_cleaning_765_test.go`: the extracted primitives directly (URL matches versus prose with sentence periods, decimals and honorifics; run counting, reset, inactive and nil collapsers), plus a pin that `CleanCues` still collapses runs and re-indexes gap-free.
- `make check` passes: gofmt, vet, golangci-lint (0 issues), `gocyclo -over 15`, ineffassign, misspell, and the full suite.
