### PR TITLE
fix(up): recover a crashed reindex before serving from the partial index (#764)

### DIFF
--- a/internal/cli/reindex.go
+++ b/internal/cli/reindex.go
@@ -255,30 +255,36 @@ func (s *reindexStaging) backup(name string) error {
 }
 
 // recoverInterruptedReindex finishes the rollback that a crashed reindex never
-// got to run, and must be called before any new generation is staged.
+// got to run. `reindex` calls it before staging a new generation; `up` calls it
+// before opening the corpus to serve from it (issue #764), so the two commands
+// share one recovery path instead of two that can drift apart.
 //
 // A reindex that is killed (SIGKILL, OOM, power loss) leaves the previous,
 // complete index in stateDir/<name>+reindexBackupSuffix and its own partial
 // output live at stateDir/<name>. Nothing in-process cleans that up: rollback
 // only runs for handled failures and Ctrl-C. The backup slot is therefore the
 // last-known-good generation, and the next run must not treat it as its own
-// leftover to overwrite (issue #727).
+// leftover to overwrite (issue #727) nor serve what is beside it (issue #764).
 //
 // Policy: adopt. Every *.reindex-old file is renamed back over whatever is live
-// before staging starts, which is exactly the rollback the crashed run owed us.
-// This is safe by construction: a backup file is only ever produced by an
-// atomic rename of a file that was complete and live, so it is never partial,
-// while the live file after a crash may be anything. Restoring is a single
-// rename (not remove-then-rename) so a crash inside recovery itself can never
-// leave neither copy.
+// before staging (or serving) starts, which is exactly the rollback the crashed
+// run owed us. This is safe by construction: a backup file is only ever produced
+// by an atomic rename of a file that was complete and live, so it is never
+// partial, while the live file after a crash may be anything. Restoring is a
+// single rename (not remove-then-rename) so a crash inside recovery itself can
+// never leave neither copy.
 //
-// Recovery failure is fatal to the run: if the good generation cannot be put
-// back, staging would move the partial file into the recovery slot and destroy
-// it, so the caller aborts with the error instead.
-func recoverInterruptedReindex(stateDir string, stderr io.Writer) error {
+// Recovery failure is fatal to both callers: for `reindex` because staging would
+// then move the partial file into the recovery slot and destroy it, and for `up`
+// because the alternative is serving the partial generation, which is the bug.
+//
+// Returns the live basenames it restored so each caller can word its own warning
+// (the two commands do different things next), and so a caller can tell "nothing
+// to do" from "recovered" without re-scanning.
+func recoverInterruptedReindex(stateDir string) ([]string, error) {
 	entries, err := os.ReadDir(stateDir)
 	if err != nil {
-		return fmt.Errorf("scan state dir %s: %w", stateDir, err)
+		return nil, fmt.Errorf("scan state dir %s: %w", stateDir, err)
 	}
 	var recovered []string
 	for _, entry := range entries {
@@ -300,15 +306,30 @@ func recoverInterruptedReindex(stateDir string, stderr io.Writer) error {
 		}
 		live := strings.TrimSuffix(name, reindexBackupSuffix)
 		if err := os.Rename(filepath.Join(stateDir, name), filepath.Join(stateDir, live)); err != nil {
-			return fmt.Errorf("restore last-known-good index %s: %w", live, err)
+			return nil, fmt.Errorf("restore last-known-good index %s: %w", live, err)
 		}
 		recovered = append(recovered, live)
 	}
-	if len(recovered) > 0 {
-		writef(stderr, "warning: recovered %d index file(s) left by an interrupted reindex before rebuilding: %s\n",
-			len(recovered), strings.Join(recovered, ", "))
+	return recovered, nil
+}
+
+// restoreInterruptedReindexHashes is the store-side half of the rollback a
+// crashed reindex owed: it rolls the pre-clear documents.content_hash snapshot
+// back over the cleared gate and drops it.
+//
+// The file half (recoverInterruptedReindex) puts the last-known-good index back;
+// this puts back the hashes that describe it. Doing only the first would leave a
+// complete index behind a cleared gate, so the next ingest pass would re-OCR,
+// re-chunk and re-embed the whole corpus to arrive back where it already was.
+//
+// A no-op when the store does not support the capability or no snapshot exists
+// (the normal, non-crashed case), so both callers can call it unconditionally.
+func restoreInterruptedReindexHashes(ctx context.Context, st model.Store) error {
+	b, ok := interface{}(st).(contentHashBackuper)
+	if !ok {
+		return nil
 	}
-	return nil
+	return b.RestoreContentHashes(ctx)
 }
 
 // commit deletes the moved-aside backups after a durable rebuild.
@@ -359,10 +380,15 @@ func (a *App) prepareReindexStore(ctx context.Context, global globalOptions, cfg
 	// Complete an earlier crashed run's rollback BEFORE staging anything, or the
 	// staging below would move that run's partial output into the recovery slot
 	// and delete the only good generation (issue #727).
-	if err := recoverInterruptedReindex(cfg.StateDir, a.stderr); err != nil {
+	recovered, err := recoverInterruptedReindex(cfg.StateDir)
+	if err != nil {
 		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("recover interrupted reindex: %v", err),
 			"The previous index generation is still on disk as *"+reindexBackupSuffix+" in the state directory; fix the error above and re-run `dir2mcp reindex`.")
 		return nil, nil, exitGeneric
+	}
+	if len(recovered) > 0 {
+		writef(a.stderr, "warning: recovered %d index file(s) left by an interrupted reindex before rebuilding: %s\n",
+			len(recovered), strings.Join(recovered, ", "))
 	}
 	st := a.storeForConfig(cfg)
 	if err := st.Init(ctx); err != nil && !errors.Is(err, model.ErrNotImplemented) {
@@ -415,14 +441,14 @@ func (a *App) prepareReindexStore(ctx context.Context, global globalOptions, cfg
 // gracefully (issue #418). Closes the store on failure; the caller owns it on
 // success.
 func (a *App) snapshotContentHashes(ctx context.Context, global globalOptions, st model.Store, staging *reindexStaging) int {
-	b, ok := interface{}(st).(contentHashBackuper)
-	if !ok {
-		return exitSuccess
-	}
-	if err := b.RestoreContentHashes(ctx); err != nil {
+	if err := restoreInterruptedReindexHashes(ctx, st); err != nil {
 		_ = st.Close()
 		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("recover interrupted reindex: restore content hashes: %v", err))
 		return exitGeneric
+	}
+	b, ok := interface{}(st).(contentHashBackuper)
+	if !ok {
+		return exitSuccess
 	}
 	if err := b.BackupContentHashes(ctx); err != nil {
 		_ = st.Close()

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -701,9 +701,9 @@ type indexLoadFailure struct {
 // and an older complete index is strictly better to serve than a partial one.
 //
 // Failure to recover IS fatal, because the only alternative left at that point is
-// to serve the partial generation. Two servers starting against the same corpus
-// in the same instant are still lock-free here (see the pid check below for what
-// that does and does not cover), but the failure mode is benign: the rename is
+// to serve the partial generation. Two servers starting in the same instant, both
+// before either has claimed the pid file, are lock-free here (the ownership check
+// below sees no owner for either), but the failure mode is benign: the rename is
 // atomic, so the loser finds the backup already gone, reports that it could not
 // restore it, and exits without serving, which is the start the single-instance
 // lock was about to refuse anyway.
@@ -718,20 +718,30 @@ type indexLoadFailure struct {
 // the tree). A read-only server is in fact the case that most needs the repair,
 // since it never re-indexes its way out of a partial generation.
 func (a *App) openStateForServing(ctx context.Context, cfg *config.Config, jsonOutput bool) (model.Store, builtIndex, builtIndex, int) {
-	// Never repair a corpus another daemon is already serving: renaming an index
-	// file out from under its open handles is worse than anything repaired here.
-	// `up` claims the single-instance lock much further down (it needs the bound
-	// listener first), so the pid file is the only ownership signal available at
-	// this point, and it is the one `reindex` already guards itself with.
+	// Never repair a corpus another daemon already owns: renaming an index file
+	// out from under its open handles is worse than anything repaired here. `up`
+	// claims the single-instance lock much further down (it needs the bound
+	// listener first), so the pid file is the only ownership signal available this
+	// early, and it is the one `reindex` guards itself with.
 	//
-	// Skipping is safe rather than merely convenient: pidLive means the pid is
-	// alive, and acquireSingleInstanceLock refuses every start whose pid file
-	// names a live process. So this branch is only ever taken by a start that is
-	// about to be refused, never by one that goes on to serve the partial
-	// generation. The daemon child is unaffected: its parent clears the pid file
-	// before forking and writes it only once the child reports ready.
-	if _, ownership := classifyPIDFile(pidFilePath(cfg.StateDir)); ownership == pidLive {
-		return a.initStoreAndIndices(ctx, cfg, jsonOutput)
+	// A live owner is refused, not merely skipped. Skipping the repair and
+	// carrying on would reintroduce this issue through the back door: if the owner
+	// exits between this check and the lock claim, that claim SUCCEEDS (it
+	// reconciles a dead owner) and we would go on to serve a corpus we
+	// deliberately did not repair. Refusing costs nothing, because a live owner
+	// makes acquireSingleInstanceLock refuse this start anyway; it just says so
+	// before opening sqlite and rehydrating two snapshots, using that same
+	// contract's wording. A start refused this way recovers on its next attempt,
+	// once the pid file no longer names a live process.
+	//
+	// The daemon child is unaffected: its parent clears the pid file before
+	// forking and writes it only once the child reports ready.
+	if pid, ownership := classifyPIDFile(pidFilePath(cfg.StateDir)); ownership == pidLive {
+		writeCLIError(a.stderr, jsonOutput, exitGeneric,
+			fmt.Sprintf("%v for %s (pid %d)", errAlreadyRunning, cfg.StateDir, pid),
+			"Another dir2mcp server is already running for this state directory; check with `dir2mcp status` or stop it with `dir2mcp down`.",
+		)
+		return nil, builtIndex{}, builtIndex{}, exitGeneric
 	}
 	// Must run before the indices are loaded below: once a partial snapshot is
 	// rehydrated, the autosave timer will write it back over the live slot.

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -701,7 +701,12 @@ type indexLoadFailure struct {
 // and an older complete index is strictly better to serve than a partial one.
 //
 // Failure to recover IS fatal, because the only alternative left at that point is
-// to serve the partial generation.
+// to serve the partial generation. Two servers starting against the same corpus
+// in the same instant are still lock-free here (see the pid check below for what
+// that does and does not cover), but the failure mode is benign: the rename is
+// atomic, so the loser finds the backup already gone, reports that it could not
+// restore it, and exits without serving, which is the start the single-instance
+// lock was about to refuse anyway.
 //
 // A healthy corpus pays one os.ReadDir and one "does the snapshot table exist"
 // query, and nothing is written.
@@ -713,6 +718,21 @@ type indexLoadFailure struct {
 // the tree). A read-only server is in fact the case that most needs the repair,
 // since it never re-indexes its way out of a partial generation.
 func (a *App) openStateForServing(ctx context.Context, cfg *config.Config, jsonOutput bool) (model.Store, builtIndex, builtIndex, int) {
+	// Never repair a corpus another daemon is already serving: renaming an index
+	// file out from under its open handles is worse than anything repaired here.
+	// `up` claims the single-instance lock much further down (it needs the bound
+	// listener first), so the pid file is the only ownership signal available at
+	// this point, and it is the one `reindex` already guards itself with.
+	//
+	// Skipping is safe rather than merely convenient: pidLive means the pid is
+	// alive, and acquireSingleInstanceLock refuses every start whose pid file
+	// names a live process. So this branch is only ever taken by a start that is
+	// about to be refused, never by one that goes on to serve the partial
+	// generation. The daemon child is unaffected: its parent clears the pid file
+	// before forking and writes it only once the child reports ready.
+	if _, ownership := classifyPIDFile(pidFilePath(cfg.StateDir)); ownership == pidLive {
+		return a.initStoreAndIndices(ctx, cfg, jsonOutput)
+	}
 	// Must run before the indices are loaded below: once a partial snapshot is
 	// rehydrated, the autosave timer will write it back over the live slot.
 	// prepareUpDirectories has already run, so the state tree (backups included)

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -67,7 +67,7 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 		defer restoreLog()
 	}
 
-	st, textBuilt, codeBuilt, code := a.initStoreAndIndices(ctx, &cfg, opts.jsonOutput)
+	st, textBuilt, codeBuilt, code := a.openStateForServing(ctx, &cfg, opts.jsonOutput)
 	if code != exitSuccess {
 		return code
 	}
@@ -666,10 +666,106 @@ type indexLoadFailure struct {
 	hints    []string
 }
 
+// openStateForServing brings the corpus's on-disk state back to a known-good
+// generation and only then opens it for serving. It is `up`'s half of issue
+// #727: PR #761 taught `reindex` to finish the rollback a crashed run owed, so
+// an operator whose next move was another rebuild recovered. An operator whose
+// next move was simply restarting the daemon did not: they got the crashed run's
+// PARTIAL index served, with the complete one sitting untouched beside it in the
+// backup slot and nothing said about it (issue #764). That is the quieter
+// failure of the two: nothing errors, retrieval just returns less than it should.
+//
+// Policy: recover, exactly as `reindex` does, by calling the same two functions
+// rather than growing a second recovery path that can drift from the first.
+//
+//   - Serving the partial generation is the bug, so "warn and carry on" is not a
+//     fix; the operator would still be answering questions from a corpus that is
+//     missing documents.
+//   - Refusing to start is the safest-sounding option and the worst one here.
+//     `up` is what service managers restart unattended, so a refusal turns every
+//     crashed reindex into a corpus-wide outage that lasts until a human
+//     notices; and the only way out of it is `reindex`, which performs this very
+//     recovery and then rebuilds everything from scratch (hours of OCR and paid
+//     embedding calls) to arrive at the generation that was already on disk.
+//   - Recovering is a mutation the operator did not ask for, but it is not a new
+//     kind of one: startup already hardens the state tree, re-pends chunks whose
+//     vectors were lost to a crash (#402 A2), and rewrites the index snapshot on
+//     its autosave timer. Restoring a rename that a killed process never got to
+//     make is the same class of self-repair, and it lands the corpus in the
+//     state the operator last saw rather than in a new one.
+//
+// The cost is the same narrow window #761 accepted: a crash between the rebuild
+// becoming durable and commit deleting the backups makes us restore an older
+// complete generation over a newer complete one. Both are valid indices, the
+// restored hashes make the next ingest pass re-index anything that changed since,
+// and an older complete index is strictly better to serve than a partial one.
+//
+// Failure to recover IS fatal, because the only alternative left at that point is
+// to serve the partial generation.
+//
+// A healthy corpus pays one os.ReadDir and one "does the snapshot table exist"
+// query, and nothing is written.
+//
+// --read-only does not exempt a corpus from this. That flag governs what the
+// server does to the corpus once it is open (no ingest, no embedding), not
+// whether the state directory may be repaired before it can be opened at all;
+// `up` already requires a writable state directory there (it creates and hardens
+// the tree). A read-only server is in fact the case that most needs the repair,
+// since it never re-indexes its way out of a partial generation.
+func (a *App) openStateForServing(ctx context.Context, cfg *config.Config, jsonOutput bool) (model.Store, builtIndex, builtIndex, int) {
+	// Must run before the indices are loaded below: once a partial snapshot is
+	// rehydrated, the autosave timer will write it back over the live slot.
+	// prepareUpDirectories has already run, so the state tree (backups included)
+	// is hardened and a restored file keeps its owner-only mode across the rename.
+	recovered, err := recoverInterruptedReindex(cfg.StateDir)
+	if err != nil {
+		writeCLIError(a.stderr, jsonOutput, exitIndexLoadFailure, fmt.Sprintf("recover interrupted reindex: %v", err),
+			"The last-known-good index generation is still on disk as *"+reindexBackupSuffix+" in the state directory; fix the error above, then start the server again or rebuild with `dir2mcp reindex`.")
+		return nil, builtIndex{}, builtIndex{}, exitIndexLoadFailure
+	}
+	if len(recovered) > 0 {
+		// Loud on purpose, and durable: teeServerLog is already installed, so this
+		// reaches <state_dir>/server.log and the support bundle, which is where an
+		// operator looks after the fact to explain a rebuild that never finished.
+		writef(a.stderr, "warning: an interrupted reindex left this corpus inconsistent; restored %d last-known-good index file(s) before serving: %s\n",
+			len(recovered), strings.Join(recovered, ", "))
+	}
+	st, textBuilt, codeBuilt, code := a.initStoreAndIndices(ctx, cfg, jsonOutput)
+	if code != exitSuccess {
+		return nil, builtIndex{}, builtIndex{}, code
+	}
+	// Detached from ctx for the same reason the reindex rollback is: a Ctrl-C
+	// during startup must not abandon the rollback half-done, leaving a restored
+	// index behind a cleared gate.
+	if err := restoreInterruptedReindexHashes(context.WithoutCancel(ctx), st); err != nil {
+		closeBuiltIndex(textBuilt)
+		closeBuiltIndex(codeBuilt)
+		_ = st.Close()
+		writeCLIError(a.stderr, jsonOutput, exitIndexLoadFailure,
+			fmt.Sprintf("recover interrupted reindex: restore content hashes: %v", err),
+			"An interrupted reindex left a content-hash snapshot this server could not roll back; rebuild with `dir2mcp reindex`.")
+		return nil, builtIndex{}, builtIndex{}, exitIndexLoadFailure
+	}
+	return st, textBuilt, codeBuilt, exitSuccess
+}
+
+// closeBuiltIndex closes a loaded index, tolerating the nil index a single-axis
+// configuration leaves behind (closing a nil model.Index would panic).
+func closeBuiltIndex(b builtIndex) {
+	if b.index != nil {
+		_ = b.index.Close()
+	}
+}
+
 // initStoreAndIndices initialises the metadata store and both vector indices,
 // dispatching on cfg.IndexBackend ("memory" default | "disk" | "qdrant" |
 // "pgvector"; issues #246, #268, #269). On success the caller is responsible for
 // closing all three.
+//
+// `up` reaches this through openStateForServing, which repairs an interrupted
+// reindex first. The distributed embed worker calls it directly, deliberately: a
+// worker starts BESIDE a live daemon that already has these files open, so it
+// must never rename one out from under it. The daemon owns that repair.
 func (a *App) initStoreAndIndices(ctx context.Context, cfg *config.Config, jsonOutput bool) (model.Store, builtIndex, builtIndex, int) {
 	st := a.storeForConfig(*cfg)
 	if err := st.Init(ctx); err != nil && !errors.Is(err, model.ErrNotImplemented) {

--- a/tests/cli/up_interrupted_reindex_764_test.go
+++ b/tests/cli/up_interrupted_reindex_764_test.go
@@ -243,9 +243,10 @@ func TestUp_HealthyCorpus_IsUntouchedByRecovery(t *testing.T) {
 
 // TestUp_LiveDaemon_LeavesTheCorpusAlone pins the ownership guard: a second
 // server starting against a corpus a live daemon already owns must not rename
-// index files out from under that daemon's open handles. Its start is refused by
-// the single-instance lock either way, so the repair belongs to the process that
-// actually serves the corpus.
+// index files out from under that daemon's open handles, and must refuse rather
+// than carry on unrepaired: an owner that exits a moment later would otherwise
+// let this process take the corpus over and serve exactly the partial generation
+// this issue is about.
 func TestUp_LiveDaemon_LeavesTheCorpusAlone(t *testing.T) {
 	realToken := requireStartTokens(t)
 	tmp := t.TempDir()
@@ -258,9 +259,17 @@ func TestUp_LiveDaemon_LeavesTheCorpusAlone(t *testing.T) {
 		t.Fatalf("seed live pid file: %v", err)
 	}
 
-	code, stderr, _ := upStartupProbe(t, tmp)
+	code, stderr, indices := upStartupProbe(t, tmp)
 	if code == 0 {
 		t.Fatalf("up must refuse to start while a daemon owns the corpus; stderr=%q", stderr)
+	}
+	if !strings.Contains(stderr, "already running") {
+		t.Errorf("the refusal must use the single-instance contract's wording; stderr=%q", stderr)
+	}
+	// Refusing before the corpus is opened is the point: a process that got as far
+	// as loading the index would be one reconciled pid file away from serving it.
+	if len(indices) != 0 {
+		t.Errorf("the refusal must happen before any index is opened; built %d", len(indices))
 	}
 	if got := readFileString(t, live+crashBackupSuffix); got != crashGoodIndex {
 		t.Errorf("the backup slot must be untouched while another daemon owns the corpus; want %q got %q", crashGoodIndex, got)

--- a/tests/cli/up_interrupted_reindex_764_test.go
+++ b/tests/cli/up_interrupted_reindex_764_test.go
@@ -241,6 +241,38 @@ func TestUp_HealthyCorpus_IsUntouchedByRecovery(t *testing.T) {
 	}
 }
 
+// TestUp_LiveDaemon_LeavesTheCorpusAlone pins the ownership guard: a second
+// server starting against a corpus a live daemon already owns must not rename
+// index files out from under that daemon's open handles. Its start is refused by
+// the single-instance lock either way, so the repair belongs to the process that
+// actually serves the corpus.
+func TestUp_LiveDaemon_LeavesTheCorpusAlone(t *testing.T) {
+	realToken := requireStartTokens(t)
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, ".dir2mcp")
+	const relPath = "docs/a.md"
+	live := seedCrashedReindexState(t, stateDir, relPath)
+	// This process's pid with its real start-time token is, by the identity
+	// check, our own live daemon.
+	if err := cli.WritePIDRecordForTest(filepath.Join(stateDir, "server.pid"), os.Getpid(), realToken); err != nil {
+		t.Fatalf("seed live pid file: %v", err)
+	}
+
+	code, stderr, _ := upStartupProbe(t, tmp)
+	if code == 0 {
+		t.Fatalf("up must refuse to start while a daemon owns the corpus; stderr=%q", stderr)
+	}
+	if got := readFileString(t, live+crashBackupSuffix); got != crashGoodIndex {
+		t.Errorf("the backup slot must be untouched while another daemon owns the corpus; want %q got %q", crashGoodIndex, got)
+	}
+	if got := readFileString(t, live); got != crashPartialIndex {
+		t.Errorf("the live slot must be untouched while another daemon owns the corpus; want %q got %q", crashPartialIndex, got)
+	}
+	if got := readDocumentHash(t, stateDir, relPath); got != "" {
+		t.Errorf("the content-hash gate must be untouched while another daemon owns the corpus; want %q got %q", "", got)
+	}
+}
+
 // TestUp_RecoveryFailure_RefusesToServe pins the fallback: when the
 // last-known-good generation cannot be put back, the only thing left to serve is
 // the partial one, so the server must refuse to start rather than come up

--- a/tests/cli/up_interrupted_reindex_764_test.go
+++ b/tests/cli/up_interrupted_reindex_764_test.go
@@ -1,0 +1,279 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/cli"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// Issue #764: #727/#761 taught `reindex` to finish the rollback a crashed run
+// owed, which covers the operator whose next move is another rebuild. The
+// operator whose next move is restarting the daemon got the opposite outcome:
+// `up` opened the live slot, which after a crash holds the crashed run's PARTIAL
+// output, while the complete generation sat untouched beside it as
+// *.reindex-old. Nothing errored; retrieval simply answered from a corpus that
+// was missing documents.
+//
+// These tests seed a crash the same way the #727 suite does, by leaving the
+// interrupted run's artifacts in place and never calling the rollback path
+// (which is exactly what does not run on a crash), and then start the server.
+
+// idleIngestor stands in for the ingestion pipeline so a test server never walks
+// the corpus. Startup state is what is under test, and a real ingest pass would
+// rewrite the very content hashes the assertions read.
+type idleIngestor struct{}
+
+func (idleIngestor) Run(context.Context) error     { return nil }
+func (idleIngestor) Reindex(context.Context) error { return nil }
+
+// recordingIndex is a model.Index + model.Persistable that records the bytes
+// present at its snapshot path when the server rehydrates it. That is the
+// question this issue is really about: not which files are on disk afterwards,
+// but which generation the daemon actually opened to serve from.
+//
+// Save is a no-op so the persistence autosave cannot rewrite the live slot
+// underneath the assertions.
+type recordingIndex struct {
+	path string
+
+	mu     sync.Mutex
+	loaded []byte
+	onLoad func()
+}
+
+func (i *recordingIndex) Upsert(context.Context, []float32, model.IndexPayload) error { return nil }
+func (i *recordingIndex) Delete(context.Context, []uint64) error                      { return nil }
+func (i *recordingIndex) Search(context.Context, []float32, int, model.Filter) ([]model.IndexHit, error) {
+	return nil, nil
+}
+func (i *recordingIndex) Identity(context.Context) (string, error) { return "", nil }
+func (i *recordingIndex) Reset(context.Context, string) error      { return nil }
+func (i *recordingIndex) Close() error                             { return nil }
+func (i *recordingIndex) Save(context.Context, string) error       { return nil }
+
+func (i *recordingIndex) Load(context.Context, string) error {
+	data, err := os.ReadFile(i.path)
+	i.mu.Lock()
+	if err == nil {
+		i.loaded = data
+	}
+	i.mu.Unlock()
+	if i.onLoad != nil {
+		i.onLoad()
+	}
+	return nil
+}
+
+func (i *recordingIndex) loadedString() string {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return string(i.loaded)
+}
+
+// upStartupProbe runs `dir2mcp up` in tmp far enough to open the corpus and then
+// stops it, returning the exit code, stderr, and the per-kind indices it built.
+// The server is cancelled as soon as an index has been rehydrated: everything
+// this issue is about (recovery, store open, index load, content-hash rollback)
+// happens before the serve loop, so idling in it would only make the suite slow.
+func upStartupProbe(t *testing.T, tmp string) (int, string, map[string]*recordingIndex) {
+	t.Helper()
+	t.Setenv("MISTRAL_API_KEY", "test-key")
+	t.Setenv("DIR2MCP_AUTH_TOKEN", "")
+
+	stateDir := filepath.Join(tmp, ".dir2mcp")
+	indices := map[string]*recordingIndex{}
+	var indicesMu sync.Mutex
+	loadedOnce := make(chan struct{})
+	var closeLoaded sync.Once
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIOAndHooks(&stdout, &stderr, cli.RuntimeHooks{
+		NewIngestor: func(config.Config, model.Store) (model.Ingestor, error) {
+			return idleIngestor{}, nil
+		},
+		NewIndex: func(_ config.Config, kind string) (model.Index, string) {
+			path := filepath.Join(stateDir, indexFileNameForKind(kind))
+			ix := &recordingIndex{
+				path:   path,
+				onLoad: func() { closeLoaded.Do(func() { close(loadedOnce) }) },
+			}
+			indicesMu.Lock()
+			indices[kind] = ix
+			indicesMu.Unlock()
+			return ix, path
+		},
+	})
+
+	var code int
+	withWorkingDir(t, tmp, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), raceScaled(15*time.Second))
+		defer cancel()
+		go func() {
+			select {
+			case <-loadedOnce:
+			case <-ctx.Done():
+			}
+			cancel()
+		}()
+		code = app.RunWithContext(ctx, []string{"up", "--listen", "127.0.0.1:0"})
+	})
+
+	indicesMu.Lock()
+	defer indicesMu.Unlock()
+	return code, stderr.String(), indices
+}
+
+// seedReadyDocument stores one indexed document with a known content_hash and
+// no crash artifacts beside it: the healthy corpus the recovery path must leave
+// completely alone.
+func seedReadyDocument(t *testing.T, stateDir, relPath string) {
+	t.Helper()
+	ctx := context.Background()
+	st := store.NewSQLiteStore(filepath.Join(stateDir, "meta.sqlite"))
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("seed Init: %v", err)
+	}
+	if err := st.UpsertDocument(ctx, model.Document{
+		RelPath:     relPath,
+		DocType:     "md",
+		ContentHash: crashGoodHash,
+		Status:      "ready",
+	}); err != nil {
+		t.Fatalf("seed UpsertDocument: %v", err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("seed Close: %v", err)
+	}
+}
+
+// indexFileNameForKind maps a vector index kind to the memory backend's snapshot
+// basename, which is the name a crashed reindex leaves a backup beside.
+func indexFileNameForKind(kind string) string {
+	if kind == index.KindCode {
+		return index.CodeIndexFileName
+	}
+	return index.TextIndexFileName
+}
+
+// TestUp_AfterCrashedReindex_ServesRecoveredGeneration is the #764 regression:
+// a daemon started after a crashed reindex must open the last-known-good
+// generation, not the partial one the crash left live, and must put the content
+// hashes that describe it back too.
+func TestUp_AfterCrashedReindex_ServesRecoveredGeneration(t *testing.T) {
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, ".dir2mcp")
+	const relPath = "docs/a.md"
+	live := seedCrashedReindexState(t, stateDir, relPath)
+
+	code, stderr, indices := upStartupProbe(t, tmp)
+	if code != 0 {
+		t.Fatalf("up should start after recovering a crashed reindex; got exit %d stderr=%q", code, stderr)
+	}
+
+	textIx := indices[index.KindText]
+	if textIx == nil {
+		t.Fatalf("no text index was built; stderr=%q", stderr)
+	}
+	if got := textIx.loadedString(); got != crashGoodIndex {
+		t.Errorf("the daemon must serve the last-known-good generation, not the crashed run's partial output; want %q got %q", crashGoodIndex, got)
+	}
+	if got := readFileString(t, live); got != crashGoodIndex {
+		t.Errorf("live index after startup must be the last-known-good generation; want %q got %q", crashGoodIndex, got)
+	}
+	if _, err := os.Stat(live + crashBackupSuffix); !os.IsNotExist(err) {
+		t.Errorf("the backup slot must be empty once its generation is live again; stat err=%v", err)
+	}
+	// The file half without the store half would leave a complete index behind a
+	// cleared gate, so the next ingest pass would re-process the whole corpus.
+	if got := readDocumentHash(t, stateDir, relPath); got != crashGoodHash {
+		t.Errorf("content_hash must be restored from the crashed run's snapshot; want %q got %q", crashGoodHash, got)
+	}
+	// Recovery is a mutation the operator did not ask for, so it has to announce
+	// itself, by name, on the stream that is teed into server.log.
+	if !strings.Contains(stderr, "interrupted reindex") || !strings.Contains(stderr, index.TextIndexFileName) {
+		t.Errorf("startup must warn that it recovered an interrupted reindex and name what it touched; stderr=%q", stderr)
+	}
+}
+
+// TestUp_HealthyCorpus_IsUntouchedByRecovery pins the other half of the
+// contract: with no crash artifacts, startup neither writes anything nor says
+// anything new.
+func TestUp_HealthyCorpus_IsUntouchedByRecovery(t *testing.T) {
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, ".dir2mcp")
+	const relPath = "docs/a.md"
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	live := filepath.Join(stateDir, index.TextIndexFileName)
+	const healthy = "HEALTHY-INDEX"
+	if err := os.WriteFile(live, []byte(healthy), 0o600); err != nil {
+		t.Fatalf("seed live index: %v", err)
+	}
+	seedReadyDocument(t, stateDir, relPath)
+
+	code, stderr, indices := upStartupProbe(t, tmp)
+	if code != 0 {
+		t.Fatalf("up should start on a healthy corpus; got exit %d stderr=%q", code, stderr)
+	}
+	if got := indices[index.KindText].loadedString(); got != healthy {
+		t.Errorf("a healthy corpus must be opened as-is; want %q got %q", healthy, got)
+	}
+	if got := readFileString(t, live); got != healthy {
+		t.Errorf("a healthy live index must not be rewritten; want %q got %q", healthy, got)
+	}
+	if got := readDocumentHash(t, stateDir, relPath); got != crashGoodHash {
+		t.Errorf("a healthy corpus's content_hash must not be touched; want %q got %q", crashGoodHash, got)
+	}
+	if strings.Contains(stderr, "interrupted reindex") {
+		t.Errorf("a healthy corpus must not produce a recovery warning; stderr=%q", stderr)
+	}
+}
+
+// TestUp_RecoveryFailure_RefusesToServe pins the fallback: when the
+// last-known-good generation cannot be put back, the only thing left to serve is
+// the partial one, so the server must refuse to start rather than come up
+// quietly missing documents, and it must leave the good generation on disk for
+// the operator to recover by hand.
+func TestUp_RecoveryFailure_RefusesToServe(t *testing.T) {
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, ".dir2mcp")
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	live := filepath.Join(stateDir, index.TextIndexFileName)
+	// A non-empty directory in the live slot makes the restoring rename fail on
+	// every platform, standing in for any reason the file cannot be put back
+	// (permissions, a full disk, an ill-timed second process).
+	if err := os.MkdirAll(filepath.Join(live, "occupied"), 0o700); err != nil {
+		t.Fatalf("seed blocked live slot: %v", err)
+	}
+	if err := os.WriteFile(live+crashBackupSuffix, []byte(crashGoodIndex), 0o600); err != nil {
+		t.Fatalf("seed backup index: %v", err)
+	}
+
+	code, stderr, indices := upStartupProbe(t, tmp)
+	if code == 0 {
+		t.Fatalf("up must not serve a corpus whose good generation could not be restored; stderr=%q", stderr)
+	}
+	if !strings.Contains(stderr, "recover interrupted reindex") {
+		t.Errorf("the refusal must name its cause; stderr=%q", stderr)
+	}
+	if got := readFileString(t, live+crashBackupSuffix); got != crashGoodIndex {
+		t.Errorf("a failed recovery must leave the last-known-good generation on disk; want %q got %q", crashGoodIndex, got)
+	}
+	if len(indices) != 0 {
+		t.Errorf("the refusal must happen before any index is opened; built %d", len(indices))
+	}
+}


### PR DESCRIPTION
Closes #764.

## The issue's claims, re-verified against current `main` (`c08365f`)

`main` has moved eleven commits since #761 landed, so I re-checked rather than trusting the issue text. Everything in it still holds:

- `internal/cli/reindex.go` has 5 references to `recoverInterruptedReindex`; `internal/cli/up.go` had 0.
- `runUp` went straight to `initStoreAndIndices` -> `loadVectorIndices` -> `Persistable.Load(stateDir/<name>)`, i.e. the live slot, with nothing between `prepareUpDirectories` and the load that looks at `*.reindex-old`.
- `_reindex_hash_backup` is still created at stage time and dropped on both commit and rollback (`internal/store/sqlite_store.go`), so its presence is still a valid in-flight marker and needs no new state.
- The silent half is real and is proven by a test that fails on `main`: the daemon rehydrates `PARTIAL-REBUILD-FROM-CRASHED-RUN` while `LAST-KNOWN-GOOD-INDEX` sits in the backup slot, with `documents.content_hash` still cleared and nothing on stderr.

One correction to the issue's emphasis. Doing nothing is worse than "serves a stale corpus for a while": the crashed run also left the content-hash gate cleared, so the daemon that comes up on the partial index immediately re-OCRs, re-chunks and re-embeds the entire corpus (real money on a paid embedding provider) to rebuild by hand what was already complete on disk. The partial answers are the visible cost; the full re-index is the invoice.

## The decision: recover, same as `reindex`

The issue asks for this to be argued rather than assumed, and it explicitly warns that "the two commands should not disagree by accident". They now agree on purpose.

**Warn only** is not a fix. The complaint is that the daemon serves a corpus missing documents; a warning still serves it, and `up`'s warnings scroll past in `server.log` while the tool keeps answering questions confidently.

**Refuse to start** is the safest-sounding option and, concretely, the worst one. `up` is what launchd/systemd restart unattended, so a refusal converts every crashed reindex into a corpus-wide outage that lasts until a human reads a log. The prescribed way out (`dir2mcp reindex`) performs this exact recovery as its first act and then rebuilds everything from scratch, hours of OCR and paid embedding calls, to arrive at the generation that was already sitting on disk. Refusal trades a complete index we are holding in our hand for a guaranteed outage plus a full rebuild, on every occurrence.

**Recover** is a mutation the operator did not ask for, which is the honest objection, but it is not a new *kind* of mutation: `up` already hardens the whole state tree (#726), re-pends chunks whose vectors were lost to an ungraceful crash (#402 A2), and rewrites the index snapshot on an autosave timer. Finishing a rename that a killed process never got to make is the same class of self-repair, and it is the only one of the three options that leaves the operator with the corpus they last saw rather than a new one. It also has to happen *before* the load: once a partial snapshot is rehydrated, the autosave timer writes it back over the live slot, at which point the crash is baked in.

The cost is the window #761 already accepted: a crash between the rebuild becoming durable and `commit` deleting the backups makes us restore an older complete generation over a newer complete one. In `reindex` that was inert (the run rebuilds everything anyway). In `up` it means serving an index that is stale by one reindex window. Both generations are complete and valid, the restored hashes make the next ingest pass re-index whatever changed since, and an older complete index is strictly better to serve than a partial one. See "Not fixed here" below.

Recovery *failing* is fatal, because at that point the only thing left to serve is the partial generation. That is the refusal option, kept exactly where it is the right answer, and it mirrors `reindex`'s own "abort rather than proceed" fallback.

## How #761's path is reused

No second recovery path. `up` calls the same two functions `reindex` does:

- `recoverInterruptedReindex(stateDir)` (file half) is now shared verbatim. Its one change is that it returns the basenames it restored instead of writing the warning itself, because the two commands do different things next: `reindex` says "before rebuilding", `up` says "before serving". The `reindex` wording is byte-identical to before, which `TestReindex_AfterCrash_RecoversEveryLeftoverGeneration` already asserts per file name.
- `restoreInterruptedReindexHashes(ctx, st)` (store half) is extracted from `snapshotContentHashes`, which now calls it. Behaviour there is unchanged: same call, same fatality, same no-op when the store lacks the capability or no snapshot exists. `up` calls it under `context.WithoutCancel` for the same reason the reindex rollback does: a Ctrl-C during startup must not abandon the rollback half-done, leaving a restored index behind a cleared gate.

Both halves matter. Restoring the files without the hashes would leave a complete index behind a cleared gate and trigger the full re-ingest described above.

`runUp` is a 15-complexity function and `gocyclo -over 15` is a gate, so the call site could not grow a branch: the whole sequence lives in `openStateForServing`, which replaces the single `initStoreAndIndices` call and returns the same four values. `runUp` is still exactly 15.

The distributed embed worker keeps calling `initStoreAndIndices` directly, deliberately, and there is now a comment saying so: a worker starts *beside* a live daemon that already holds these files open, so it must never rename one out from under it. The daemon owns the repair.

## Ownership guard (two CodeRabbit rounds)

The CLI's first pass raised a major finding I agree with: `up` claims the single-instance lock only after the listener binds, so recovery would run with no ownership check at all, and a second `up` could rename index files out from under a live daemon. Guarded with the same pid-file signal `reindex` uses (`classifyPIDFile(...) == pidLive`), rather than by reordering the lock, which also installs the daemon-child signal handler and needs the bound listener, so moving it is a startup-lifecycle change well outside this issue.

The GitHub bot then found the hole in my first version of that guard, which *skipped* the repair and carried on: `acquireSingleInstanceLock` reconciles a *dead* owner, so an owner exiting between the classification and the claim lets this process take the corpus over having deliberately not repaired it. The invariant I had written in the comment was simply wrong, and the bug would have come back through the back door.

So a live owner is now **refused**, not skipped (88e90b5). Nothing legitimate is lost: a live owner makes that same lock refuse this start anyway, so the refusal reuses its message (`errAlreadyRunning`) and exit code and merely lands earlier, before sqlite is opened and two snapshots are rehydrated. The next attempt, once the pid file no longer names a live process, takes the normal recovery path. `TestUp_LiveDaemon_LeavesTheCorpusAlone` asserts the wording and that **no index is opened at all**, which is the property that makes the reconciled-pid-file path unreachable. I did not take the suggested close-recover-reopen alternative: it adds a second state-open path for a window that refusing closes outright.

The daemon child is unaffected throughout: its parent clears the pid file before forking and writes it only once the child reports ready, so the child sees no owner.

Two servers starting in the same instant, both before either has claimed the pid file, remain lock-free, and that residual failure is benign and documented in the code: the rename is atomic, so the loser finds the backup already gone, reports that it could not restore it, and exits without serving.

## Read-only commands (`status`, `ask --local`, MCP)

Deliberately unchanged, and this is an answer rather than an omission. A read-only command must not mutate the corpus, so the only thing it could add is a warning about a condition that the next `up` or `reindex` now repairs, which makes it a notice about a self-closing window. It is also the wrong altitude: the daemon is what serves answers, and after this PR no daemon serves a partial generation. If a warning is wanted anyway, `status` is a two-line follow-up, and I would rather add it on request than smuggle a second detection site into this PR.

## Tests

`tests/cli/up_interrupted_reindex_764_test.go` (new; under `tests/`, so no `tests/security/cli_boundary_test.go` allowlist entry is needed, and no new file was added under `internal/cli/`. Verified by running `go test ./tests/security`). The crash is seeded the way the #727 suite does it, by leaving the interrupted run's artifacts in place and never calling the rollback path, since a crash is exactly when rollback does not run; the helpers are reused from that file.

The indices are injected so each one records the bytes present at its snapshot path when the server rehydrates it. That is the question the issue is actually about: not which files are on disk afterwards, but which generation the daemon *opened to serve from*.

- `TestUp_AfterCrashedReindex_ServesRecoveredGeneration` (regression witness) - the daemon loads the last-known-good bytes, the live slot holds them, the backup slot is empty, `content_hash` is back to its pre-crash value, and stderr names what was touched.
- `TestUp_HealthyCorpus_IsUntouchedByRecovery` (guard) - no marker, no backups: opened as-is, nothing rewritten, no warning. Passes before the fix too, by design.
- `TestUp_LiveDaemon_LeavesTheCorpusAlone` (guard for the ownership check) - with a live pid record, both slots and the hash gate are untouched, the start is refused with the single-instance wording, and no index is opened.
- `TestUp_RecoveryFailure_RefusesToServe` (regression witness) - a blocked live slot makes the restoring rename fail; the server refuses to start, names the cause, leaves the good generation on disk, and opens no index at all.

**Proof they fail first.** Using the copy-aside method (`cp internal/cli/up.go` -> `git checkout origin/main -- internal/cli/up.go` -> run -> copy back), never `git stash`, since `refs/stash` is shared across worktrees:

```
--- FAIL: TestUp_AfterCrashedReindex_ServesRecoveredGeneration (0.41s)
    the daemon must serve the last-known-good generation, not the crashed run's partial output;
      want "LAST-KNOWN-GOOD-INDEX" got "PARTIAL-REBUILD-FROM-CRASHED-RUN"
    live index after startup must be the last-known-good generation;
      want "LAST-KNOWN-GOOD-INDEX" got "PARTIAL-REBUILD-FROM-CRASHED-RUN"
    the backup slot must be empty once its generation is live again; stat err=<nil>
    content_hash must be restored from the crashed run's snapshot;
      want "HASH-BEFORE-CRASHED-REINDEX" got ""
    startup must warn that it recovered an interrupted reindex and name what it touched; stderr="..."
--- PASS: TestUp_HealthyCorpus_IsUntouchedByRecovery (0.39s)
--- FAIL: TestUp_RecoveryFailure_RefusesToServe (0.37s)
    up must not serve a corpus whose good generation could not be restored; stderr="..."
```

All pass with the fix restored.

## Verification

- `make check` passes locally, including `gocyclo -over 15` (`runUp` unchanged at 15; `openStateForServing` is 6).
- `go test ./tests/cli` (whole package, including the four #727 reindex tests that pin the shared function's other caller) and `go test ./tests/security`.
- `go test -race -count=3` over the new tests plus `TestReindex_AfterCrash*`.
- `coderabbit review` (CLI): one major finding, fixed; re-run reports 0. The GitHub bot's major finding on top of that fix is addressed in 88e90b5 and its thread is resolved.

## Not fixed here

The commit-window durability gap CodeRabbit raised on its first pass, and which the doc comment names: a crash between `discardContentHashBackup` and `commit()` leaves fresh hashes beside a stale backup file, so recovery restores an older generation the hashes say is current, and no ingest pass corrects it. Closing that needs a durable commit marker, which is a redesign of #761's staging protocol rather than a change to `up`'s startup, and it is pre-existing (a `reindex` retry in that window is affected the same way). Happy to file it as a follow-up if you want it tracked.

No spec change: this alters no tool, CLI or error contract, and the submodule pointer is untouched. The only user-visible addition is a stderr warning on startup, which `teeServerLog` already mirrors into `<state_dir>/server.log` and the support bundle.
