### PR TITLE
fix(ingest): count a skipped symlink, now that the spec names the reason

### DIFF
--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -1712,19 +1712,24 @@ func (s *Service) runScan(ctx context.Context) error {
 		)
 	}
 	// A symlink is dropped at discovery under the default
-	// ingest.follow_symlinks=false, which is right, but until #781 it was also
-	// silent: a corpus of links into a media library reported scanned=0,
-	// skipped=0, errors=0 and a ready daemon, exactly like an empty directory.
-	// Log-only, matching the OnUnsafeKey precedent (#735) rather than the
-	// OnOversize one (#497): the scanned/skipped counters cannot honestly absorb
-	// these yet. SPEC §15.2 closes the skip_reasons enum for a spec minor and
-	// §3.2 requires the file_skip event count to equal the run's terminal
-	// indexing.skipped, so every skipped bump must carry a reason from that enum.
-	// None of the eight describes a not-followed link, and borrowing
-	// path_excluded/ignore_rule would mislabel it in the honest-coverage
-	// aggregate. Counting these belongs behind a spec change that adds the
-	// reason; the log is what unblocks the operator today.
+	// ingest.follow_symlinks=false, which is right, but it used to be silent
+	// too: a corpus of links into a media library reported scanned=0,
+	// skipped=0, errors=0 and a ready daemon, exactly like an empty directory
+	// (#781). #792 added the log. This now also COUNTS the drop, which #792
+	// could not: SPEC §15.2 closes the skip_reasons enum for a spec minor, and
+	// none of the eight reasons then described a not-followed link. Borrowing
+	// path_excluded would have named a false cause in the honest-coverage
+	// aggregate, so the count waited for spec 0.46.0 to add symlink_ignored.
+	//
+	// Counted like OnOversize (#497) rather than logged like OnUnsafeKey
+	// (#735), because the two cases differ: an unsafe bucket key is not a
+	// corpus file dir2mcp declined to index, while a link IS a corpus entry
+	// with a deliberate policy applied to it.
+	symlinks := make(map[string]struct{})
 	discoverOpts.OnSkippedSymlink = func(relPath string) {
+		s.addScanned(1)
+		s.addSkipped(1)
+		symlinks[relPath] = struct{}{}
 		s.getLogger().Printf(
 			"discovery: skipping %s (symlink); ingest.follow_symlinks is false, so links are not indexed. Set ingest.follow_symlinks: true to include it (a followed link must still resolve inside the corpus root)",
 			relPath,
@@ -1779,6 +1784,7 @@ func (s *Service) runScan(ctx context.Context) error {
 	// Register size-capped drops as durable skipped rows before the pass(es)
 	// run so they survive markMissingAsDeleted and feed the coverage aggregate.
 	s.persistOversizeSkips(ctx, oversize, seen)
+	s.persistSymlinkSkips(ctx, symlinks, seen)
 
 	// Optional two-phase pass split (SPEC §8.6.11): run media ingest as two ordered
 	// passes over the corpus — a transcription pass (STT/sidecar → source
@@ -2891,6 +2897,43 @@ func (s *Service) persistOversizeSkips(ctx context.Context, oversize map[string]
 		// Emitted here rather than at the OnOversize counter bump so the event and
 		// the persisted row stay one-to-one; the oversize map is keyed by relPath,
 		// so no document raises it twice.
+		s.notifyDocumentSkip(doc)
+	}
+}
+
+// persistSymlinkSkips upserts a minimal skipped document row for each entry
+// dropped at discovery for being a symbolic link while ingest.follow_symlinks
+// is false (#781), stamping skip_reason=symlink_ignored so
+// CorpusStats.SkipSummary reports it and §3.2's "one file_skip event per
+// terminal skipped" invariant holds.
+//
+// It mirrors persistOversizeSkips step for step, including the seen
+// registration that stops markMissingAsDeleted from tombstoning the row it
+// just wrote, and the best-effort per-path error handling.
+//
+// SizeBytes is deliberately left zero. With following off the walker never
+// resolves the target, so the only size available is the link's own inode
+// size, which describes the path string rather than any content. Reporting
+// that as the document size would be worse than reporting nothing.
+func (s *Service) persistSymlinkSkips(ctx context.Context, symlinks map[string]struct{}, seen map[string]struct{}) {
+	for relPath := range symlinks {
+		seen[relPath] = struct{}{}
+		doc := model.Document{
+			RelPath:    relPath,
+			DocType:    ClassifyDocType(relPath),
+			Status:     "skipped",
+			SkipReason: model.SkipReasonSymlinkIgnored,
+		}
+		if err := s.store.UpsertDocument(ctx, doc); err != nil {
+			s.getLogger().Printf("discovery: persist symlink skip row for %s: %v", relPath, err)
+		}
+		// Emitted even when the upsert failed, matching the size-cap path. The
+		// skipped counter was already bumped at discovery, and SPEC §3.2 ties
+		// the file_skip event count to the terminal indexing.skipped value. To
+		// return early here would keep the count and drop the event, so a
+		// failed row would break that invariant instead of only costing the
+		// coverage aggregate one entry. The map is keyed by relPath, so one
+		// link never raises two events.
 		s.notifyDocumentSkip(doc)
 	}
 }

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -80,6 +80,12 @@ const (
 	// SkipReasonSizeCap: the file exceeded ingest.max_file_mb and was dropped
 	// at discovery.
 	SkipReasonSizeCap = "size_cap"
+	// SkipReasonSymlinkIgnored: a discovered entry is a symbolic link and
+	// ingest.follow_symlinks is false, so the walker does not follow the link
+	// and does not index the target. It covers a link to a file and a link to a
+	// directory alike: with following off the walker never resolves the target,
+	// so it cannot tell the two apart (SPEC §7.1/§15.2, spec 0.46.0).
+	SkipReasonSymlinkIgnored = "symlink_ignored"
 	// SkipReasonLanguageUncovered: media whose resolved source language is outside
 	// the selected STT model's declared stt_languages coverage, skipped under
 	// media.stt.on_uncovered_language=skip (SPEC §8.2.1) instead of transcribed to

--- a/tests/ingest/skip_reason_coverage_test.go
+++ b/tests/ingest/skip_reason_coverage_test.go
@@ -35,6 +35,10 @@ func TestSkipReasonCoverage(t *testing.T) {
 	writeCorpusFile(t, root, "big.bin", bytes.Repeat([]byte("x"), 2*1024*1024))
 	// A path-excluded file -> counted in-run, NOT persisted.
 	writeCorpusFile(t, root, filepath.Join("skipdir", "ignored.txt"), []byte("excluded by glob"))
+	// A symlink under the default follow_symlinks=false -> skip_reason=symlink_ignored
+	// (#781, spec 0.46.0). Before the reason existed this drop was logged but
+	// never counted, so an all-symlink corpus reported a clean empty scan.
+	linkSkipped := writeCorpusSymlink(t, root, "notes.txt", "link-to-notes.txt")
 
 	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
 	if err := st.Init(ctx); err != nil {
@@ -60,6 +64,7 @@ func TestSkipReasonCoverage(t *testing.T) {
 	assertSkipReason(t, ctx, st, ".env", "skipped", model.SkipReasonIgnoreRule)
 	assertSkipReason(t, ctx, st, "creds.txt", "secret_excluded", model.SkipReasonSecretExcluded)
 	assertSkipReason(t, ctx, st, "big.bin", "skipped", model.SkipReasonSizeCap)
+	assertSymlinkSkip(t, ctx, st, linkSkipped)
 
 	// The ingestable file is NOT skipped and carries no skip_reason.
 	if doc, err := st.GetDocumentByPath(ctx, "notes.txt"); err != nil {
@@ -91,6 +96,7 @@ func TestSkipReasonCoverage(t *testing.T) {
 			t.Errorf("SkipSummary.Categories[%q] = %d, want %d (full=%+v)", reason, got, want, stats.SkipSummary.Categories)
 		}
 	}
+	assertSymlinkAggregate(t, stats, linkSkipped)
 	// path_excluded is NOT durable, so it must not appear in the store aggregate.
 	if got := stats.SkipSummary.Categories[model.SkipReasonPathExcluded]; got != 0 {
 		t.Errorf("SkipSummary should not contain path_excluded (non-persisted), got %d", got)
@@ -142,4 +148,42 @@ func emptyZip(t *testing.T) []byte {
 		t.Fatalf("close zip: %v", err)
 	}
 	return buf.Bytes()
+}
+
+// writeCorpusSymlink creates a symbolic link inside the corpus and reports
+// whether it could. A filesystem that refuses symlinks (some CI containers,
+// Windows without privilege) must not fail the whole coverage test, so the
+// caller guards the symlink assertions on this instead.
+func writeCorpusSymlink(t *testing.T, root, target, name string) bool {
+	t.Helper()
+	if err := os.Symlink(filepath.Join(root, target), filepath.Join(root, name)); err != nil {
+		t.Logf("skipping the symlink case: this filesystem cannot create links: %v", err)
+		return false
+	}
+	return true
+}
+
+// assertSymlinkSkip checks the persisted row for a link dropped under the
+// default follow_symlinks=false (#781). Split out of TestSkipReasonCoverage so
+// that test stays inside the repo's gocyclo budget: the filesystem guard adds a
+// branch, and the test already carries one per skip class.
+func assertSymlinkSkip(t *testing.T, ctx context.Context, st *store.SQLiteStore, linkSkipped bool) {
+	t.Helper()
+	if !linkSkipped {
+		return
+	}
+	assertSkipReason(t, ctx, st, "link-to-notes.txt", "skipped", model.SkipReasonSymlinkIgnored)
+}
+
+// assertSymlinkAggregate checks the durable coverage aggregate counts the link.
+// Counting is the half #792 could not do: the reason did not exist until spec
+// 0.46.0, and borrowing another reason would have named a false cause.
+func assertSymlinkAggregate(t *testing.T, stats model.CorpusStats, linkSkipped bool) {
+	t.Helper()
+	if !linkSkipped {
+		return
+	}
+	if got := stats.SkipSummary.Categories[model.SkipReasonSymlinkIgnored]; got != 1 {
+		t.Errorf("SkipSummary.Categories[symlink_ignored] = %d, want 1 (full=%+v)", got, stats.SkipSummary.Categories)
+	}
 }

--- a/tests/ingest/symlink_skip_counted_781_test.go
+++ b/tests/ingest/symlink_skip_counted_781_test.go
@@ -1,0 +1,135 @@
+package tests
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/appstate"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// #781, counting half. PR #792 made a not-followed symlink visible in the log.
+// It could not count the drop, because SPEC 15.2 kept the skip_reasons enum
+// closed and no reason described a link the walker does not follow. Spec
+// 0.46.0 added symlink_ignored, so the drop is now counted, persisted and
+// reported as a file_skip event.
+//
+// TestSkipReasonCoverage asserts one file link inside a mixed corpus. These
+// cover the contracts that mix cannot express: a corpus that is ONLY links
+// (the case from the issue), a link to a directory, and follow_symlinks=true.
+// The callback itself is covered at the walker level in
+// tests/corpusfs/symlink_skip_781_test.go.
+
+// symlinkCorpus builds a corpus of links and runs one ingest pass over it.
+// It reports false when the filesystem cannot create a link, so a CI image
+// without that permission skips instead of failing.
+func symlinkCorpus(t *testing.T, followSymlinks bool) (*store.SQLiteStore, *ingest.Service, bool) {
+	t.Helper()
+	ctx := context.Background()
+	root := t.TempDir()
+
+	// The link targets live OUTSIDE the corpus, which is the shape the issue
+	// describes: a curated tree of links into a media library.
+	external := t.TempDir()
+	if err := os.WriteFile(filepath.Join(external, "clip.txt"), []byte("real content"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(external, "season"), 0o700); err != nil {
+		t.Fatalf("mkdir target dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(external, "season", "ep1.txt"), []byte("episode"), 0o600); err != nil {
+		t.Fatalf("write nested target: %v", err)
+	}
+
+	if err := os.Symlink(filepath.Join(external, "clip.txt"), filepath.Join(root, "clip.txt")); err != nil {
+		t.Logf("this filesystem cannot create a symlink, so the case is skipped: %v", err)
+		return nil, nil, false
+	}
+	if err := os.Symlink(filepath.Join(external, "season"), filepath.Join(root, "season")); err != nil {
+		t.Logf("this filesystem cannot create a directory symlink, so the case is skipped: %v", err)
+		return nil, nil, false
+	}
+
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("store init: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	cfg := config.Default()
+	cfg.RootDir = root
+	cfg.STTProvider = "off"
+	cfg.IngestFollowSymlinks = followSymlinks
+
+	svc := mustNewIngestService(t, cfg, st)
+	svc.SetIndexingState(appstate.NewIndexingState(appstate.ModeIncremental))
+	if err := svc.Run(ctx); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	return st, svc, true
+}
+
+// TestSymlinkOnlyCorpusReportsItsSkips is the case from the issue. Before the
+// count, such a corpus reported scanned=0, skipped=0, errors=0 and a ready
+// daemon. That output is what an empty directory reports, and what a wrong
+// root_dir reports, so an operator could not tell the three apart.
+func TestSymlinkOnlyCorpusReportsItsSkips(t *testing.T) {
+	st, _, ok := symlinkCorpus(t, false)
+	if !ok {
+		return
+	}
+	ctx := context.Background()
+
+	stats, err := st.CorpusStats(ctx)
+	if err != nil {
+		t.Fatalf("CorpusStats: %v", err)
+	}
+	if stats.SkipSummary == nil {
+		t.Fatalf("SkipSummary = nil, want the symlink drops")
+	}
+	got := stats.SkipSummary.Categories[model.SkipReasonSymlinkIgnored]
+	if got == 0 {
+		t.Fatalf("a corpus of only symlinks reported no symlink_ignored skips: %+v", stats.SkipSummary.Categories)
+	}
+}
+
+// TestADirectorySymlinkIsCountedToo: with following off the walker never
+// resolves the target, so it cannot tell a link to a file from a link to a
+// directory. Both must therefore be reported the same way, which is what the
+// spec text for symlink_ignored says.
+func TestADirectorySymlinkIsCountedToo(t *testing.T) {
+	st, _, ok := symlinkCorpus(t, false)
+	if !ok {
+		return
+	}
+	ctx := context.Background()
+	assertSkipReason(t, ctx, st, "season", "skipped", model.SkipReasonSymlinkIgnored)
+	assertSkipReason(t, ctx, st, "clip.txt", "skipped", model.SkipReasonSymlinkIgnored)
+}
+
+// TestFollowSymlinksTrueCountsNoSkips is the other half of the contract. When
+// the operator opts in, the links are followed and indexed, so there is
+// nothing to report. A skip row here would mean the count fires on a path the
+// walker actually took.
+func TestFollowSymlinksTrueCountsNoSkips(t *testing.T) {
+	st, _, ok := symlinkCorpus(t, true)
+	if !ok {
+		return
+	}
+	ctx := context.Background()
+
+	stats, err := st.CorpusStats(ctx)
+	if err != nil {
+		t.Fatalf("CorpusStats: %v", err)
+	}
+	if stats.SkipSummary != nil {
+		if got := stats.SkipSummary.Categories[model.SkipReasonSymlinkIgnored]; got != 0 {
+			t.Fatalf("follow_symlinks=true recorded %d symlink_ignored skips, want 0", got)
+		}
+	}
+}


### PR DESCRIPTION
Closes #781. Re-pins the submodule to spec `main`, which carries dirstral-spec#85 (0.46.0) and #86 (0.47.0).

## What was left over

PR #792 made a not-followed symlink visible in the log. It could not add the file to the `skipped` count, and it correctly refused to guess.

Two rules blocked it:

- SPEC 15.2 kept the `skip_reasons` enum closed for a spec minor.
- SPEC 3.2 requires the `file_skip` event count to equal the terminal `indexing.skipped` value.

None of the eight reasons described a link the walker does not follow. To borrow `path_excluded` would have named a false cause in the aggregate that #414 and #395 built to be honest.

dirstral-spec#85 adds `symlink_ignored`. This PR uses it.

## What changes

A dropped link now bumps `scanned` and `skipped` at discovery, persists a skipped document row with `skip_reason=symlink_ignored`, and emits the `file_skip` event.

So an all-symlink corpus reports what it did. Before #792 it reported `scanned: 0, skipped: 0, errors: 0` and a ready daemon, which is what an empty directory reports and what a wrong `root_dir` reports.

The drop is now counted like `OnOversize` (#497) rather than logged like `OnUnsafeKey` (#735). The two cases are not alike: an unsafe bucket key is not a corpus file that dir2mcp declined to index, but a link **is** a corpus entry with a deliberate policy applied to it.

## Two details worth review

**The event follows the counter, not the row.** `persistSymlinkSkips` emits `file_skip` even when the upsert fails, which is what the size-cap path does. My first draft returned early on that error. That was wrong: the counter is already bumped at discovery, so an early return keeps the count and drops the event, and breaks the SPEC 3.2 invariant. A failed row should cost the coverage aggregate one entry, not corrupt the count.

**`SizeBytes` stays zero.** With following off the walker never resolves the target, so the only size available is the link's own inode size, which describes the path string rather than any content. To report that as the document size is worse than to report nothing.

## Verification

`persistSymlinkSkips` mirrors `persistOversizeSkips` step for step, including the `seen` registration that stops `markMissingAsDeleted` from tombstoning the row it just wrote.

The mixed-corpus coverage test (`TestSkipReasonCoverage`, the #414 regression guard) gains the symlink case, so the row, the reason and the aggregate are all asserted next to the seven existing skip classes.

**Confirmed it fails against `main`**: I copied `service.go` aside, restored the `main` version, and the test failed. Restored, it passes. I did not use `git stash`, which trades work between worktrees.

The symlink assertions sit in two helpers rather than inline. The filesystem guard adds a branch, and the test was already at the `gocyclo -over 15` limit.

`make check` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Symlinks excluded when symlink following is disabled are now consistently counted as scanned and skipped.
  * Skipped symlinks are recorded with a clear reason and generate file-skip notifications.
  * Skip records and aggregate counts are preserved without interrupting the scan if persistence encounters an issue.

* **Tests**
  * Added coverage to verify symlink skip reasons and aggregate statistics where supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->