### PR TITLE
feat(ingest): let an operator replace the discovery ignore list (#773)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dirstral/dir2mcp/internal/corpusfs"
 	"github.com/dirstral/dir2mcp/internal/netutil"
 	"github.com/dirstral/dir2mcp/internal/provider"
 	"github.com/dirstral/dir2mcp/internal/secrets"
@@ -499,11 +500,40 @@ type Config struct {
 	IngestGitignore      bool
 	IngestFollowSymlinks bool
 	IngestMaxFileMB      int
-	IngestPDFMode        string
-	IngestImagesMode     string
-	IngestAudioMode      string
-	IngestArchivesMode   string
-	IngestExtractor      string
+	// IngestExcludeDirs is the directory ignore list applied by discovery
+	// (config `ingest.exclude_dirs`, SPEC §7.1, issue #773). Discovery does not
+	// descend into a directory whose NAME matches an entry. An entry is a plain
+	// directory name: it is not a path and it is not a glob, and it matches at
+	// any depth below the root.
+	//
+	// A present key REPLACES the default list in full. It does not add to it.
+	// That is the list behaviour of `security.path_excludes`, so there is one
+	// rule to learn and not two. An absent key keeps the default list
+	// (corpusfs.DefaultExcludedDirs), so an existing corpus does not change.
+	//
+	// `.dir2mcp` is always added back, even when the operator's list omits it.
+	// The state directory lives under root_dir, so to index it is
+	// self-referential: the walk would read the index the same run writes, and
+	// watch mode would feed its own writes back into ingest. The loader records
+	// a warning when it adds the name back.
+	//
+	// THE GATES ARE INDEPENDENT AND THEY COMPOSE BY AND. A file reaches the
+	// index only if this list, `security.path_excludes` and the optional
+	// `.gitignore` rules ALL admit it. Five names are in BOTH this default list
+	// and the default `security.path_excludes`: `.git`, `.dir2mcp`,
+	// `node_modules`, `vendor` and `__pycache__`. To re-index such a directory
+	// an operator MUST clear the name from EVERY gate that lists it. To clear
+	// this one alone changes nothing the operator can observe, because
+	// `security.path_excludes` drops the same file a moment later.
+	// `node_modules` is blocked in retrieval as well
+	// (internal/retrieval/service.go defaultPathExcludes), so it needs a third
+	// edit.
+	IngestExcludeDirs  []string
+	IngestPDFMode      string
+	IngestImagesMode   string
+	IngestAudioMode    string
+	IngestArchivesMode string
+	IngestExtractor    string
 	// IngestOnUnsupported is the §7.4.B.2 degradation mode for a format no active
 	// extraction engine can read: "lenient" (default) skips with a warning and
 	// names the gap in the honest coverage report, "strict" records a non-fatal
@@ -1141,6 +1171,7 @@ type fileConfig struct {
 	IngestGitignore                    *bool
 	IngestFollowSymlinks               *bool
 	IngestMaxFileMB                    *int
+	IngestExcludeDirs                  []string
 	IngestPDFMode                      *string
 	IngestImagesMode                   *string
 	IngestAudioMode                    *string
@@ -1303,6 +1334,7 @@ type persistedConfig struct {
 	IngestGitignore                    bool          `yaml:"ingest_gitignore"`
 	IngestFollowSymlinks               bool          `yaml:"ingest_follow_symlinks"`
 	IngestMaxFileMB                    int           `yaml:"ingest_max_file_mb"`
+	IngestExcludeDirs                  []string      `yaml:"ingest_exclude_dirs"`
 	IngestPDFMode                      string        `yaml:"ingest_pdf_mode"`
 	IngestImagesMode                   string        `yaml:"ingest_images_mode"`
 	IngestAudioMode                    string        `yaml:"ingest_audio_mode"`
@@ -1555,6 +1587,7 @@ func Default() Config {
 		IngestGitignore:           true,
 		IngestFollowSymlinks:      false,
 		IngestMaxFileMB:           20,
+		IngestExcludeDirs:         corpusfs.DefaultExcludedDirs(),
 		IngestPDFMode:             "ocr",
 		IngestImagesMode:          "ocr_auto",
 		IngestAudioMode:           "auto",
@@ -1723,6 +1756,7 @@ func buildPersistedConfig(cfg *Config) persistedConfig {
 		IngestGitignore:                    cfg.IngestGitignore,
 		IngestFollowSymlinks:               cfg.IngestFollowSymlinks,
 		IngestMaxFileMB:                    cfg.IngestMaxFileMB,
+		IngestExcludeDirs:                  append([]string(nil), cfg.IngestExcludeDirs...),
 		IngestPDFMode:                      cfg.IngestPDFMode,
 		IngestImagesMode:                   cfg.IngestImagesMode,
 		IngestAudioMode:                    cfg.IngestAudioMode,
@@ -2554,6 +2588,21 @@ func applyChunkingFileParsed(cfg *Config, fc fileConfig) {
 // applyIngestModesFileParsed copies the set ingest discovery/mode file
 // fields (gitignore, symlinks, size limit, per-type modes, extractor)
 // onto cfg.
+// applyIngestExcludeDirsFileParsed copies a set `ingest.exclude_dirs` onto cfg.
+// A present key replaces the default list in full (SPEC §7.1, #773), so the
+// merge is an assignment, not an append. It is split out of
+// applyIngestModesFileParsed to keep that function inside the cyclomatic budget.
+func applyIngestExcludeDirsFileParsed(cfg *Config, fc fileConfig) {
+	if fc.IngestExcludeDirs == nil {
+		return
+	}
+	resolved, warn := resolveExcludeDirs(normalizeStringSlice(fc.IngestExcludeDirs))
+	cfg.IngestExcludeDirs = resolved
+	if warn != nil {
+		cfg.Warnings = append(cfg.Warnings, warn)
+	}
+}
+
 func applyIngestModesFileParsed(cfg *Config, fc fileConfig) {
 	if fc.IngestGitignore != nil {
 		cfg.IngestGitignore = *fc.IngestGitignore
@@ -2564,6 +2613,7 @@ func applyIngestModesFileParsed(cfg *Config, fc fileConfig) {
 	if fc.IngestMaxFileMB != nil {
 		cfg.IngestMaxFileMB = *fc.IngestMaxFileMB
 	}
+	applyIngestExcludeDirsFileParsed(cfg, fc)
 	if fc.IngestPDFMode != nil {
 		cfg.IngestPDFMode = *fc.IngestPDFMode
 	}
@@ -2805,6 +2855,55 @@ func applyX402FileParsed(cfg *Config, fc fileConfig) {
 	if fc.X402PayTo != nil {
 		cfg.X402.PayTo = *fc.X402PayTo
 	}
+}
+
+// validateIngestExcludeDirs rejects an entry that is not a plain directory
+// name. SPEC §7.1 states that an entry is a name, not a path and not a glob,
+// and that it matches at any depth. A value such as `src/dist` or `dist/**`
+// therefore matches nothing. Rejecting it tells the operator at once, instead
+// of leaving them to wonder why the directory is still indexed.
+func (c *Config) validateIngestExcludeDirs() error {
+	for _, name := range c.IngestExcludeDirs {
+		switch {
+		case strings.ContainsAny(name, "/\\"):
+			return fmt.Errorf("ingest.exclude_dirs entry %q must be a plain directory name, not a path", name)
+		case strings.ContainsAny(name, "*?["):
+			return fmt.Errorf("ingest.exclude_dirs entry %q must be a plain directory name, not a glob", name)
+		case name == "." || name == "..":
+			return fmt.Errorf("ingest.exclude_dirs entry %q is not a directory name", name)
+		}
+	}
+	return nil
+}
+
+// resolveExcludeDirs applies the SPEC §7.1 resolution rules to an operator
+// directory ignore list. The caller has already established that the key is
+// present, so the returned list REPLACES the default list in full.
+//
+// `.dir2mcp` is added back when the list omits it, because the state directory
+// lives under root_dir: the walk would read the index that the same run writes,
+// and watch mode would feed its own writes back into ingest. The spec says an
+// implementation SHOULD say that it did this, so the second return value is a
+// warning the loader surfaces. Duplicates are dropped and the operator's order
+// is kept, so `print-config` shows what the operator wrote.
+func resolveExcludeDirs(names []string) ([]string, error) {
+	seen := make(map[string]struct{}, len(names)+1)
+	resolved := make([]string, 0, len(names)+1)
+	for _, name := range names {
+		if _, dup := seen[name]; dup {
+			continue
+		}
+		seen[name] = struct{}{}
+		resolved = append(resolved, name)
+	}
+	if _, ok := seen[corpusfs.StateDirName]; ok {
+		return resolved, nil
+	}
+	resolved = append(resolved, corpusfs.StateDirName)
+	return resolved, fmt.Errorf(
+		"config: ingest.exclude_dirs does not list %q; the name was added back. "+
+			"The state directory is under root_dir, so to index it is self-referential (SPEC 7.1)",
+		corpusfs.StateDirName)
 }
 
 // normalizeStringSlice trims each value and drops empties, returning nil
@@ -3058,6 +3157,7 @@ var configKeyAliases = map[string]string{
 	"security.auth.mode":                      "auth_mode",
 	"security.allowed_origins":                "allowed_origins",
 	"security.path_excludes":                  "path_excludes",
+	"ingest.exclude_dirs":                     "ingest_exclude_dirs",
 	"security.secret_patterns":                "secret_patterns",
 	"docling.command":                         "docling_command",
 	"ingest.docling.command":                  "docling_command",
@@ -3799,6 +3899,8 @@ func setFileListValue(cfg *fileConfig, key, value string) {
 		appendConfigListValue(&cfg.TrustedProxies, value)
 	case "path_excludes":
 		appendConfigListValue(&cfg.PathExcludes, value)
+	case "ingest_exclude_dirs":
+		appendConfigListValue(&cfg.IngestExcludeDirs, value)
 	case "secret_patterns":
 		appendConfigListValue(&cfg.SecretPatterns, value)
 	case "allowed_origins":
@@ -3841,7 +3943,7 @@ func setRetrievalFileListValue(cfg *fileConfig, key, value string) bool {
 func isListConfigKey(key string) bool {
 	key = canonicalizeConfigKey(key)
 	switch key {
-	case "trusted_proxies", "path_excludes", "secret_patterns", "allowed_origins", "media.translate.target_langs", "media.stt.tracks", "media.filter_words", "media.subtitles.glossary", "media.subtitles.drop_phrases", "media.subtitles.scrub_phrases", "retrieval.cross_lingual.target_langs", "retrieval.hierarchical.source_reps", "retrieval.hierarchical.levels":
+	case "trusted_proxies", "path_excludes", "ingest_exclude_dirs", "secret_patterns", "allowed_origins", "media.translate.target_langs", "media.stt.tracks", "media.filter_words", "media.subtitles.glossary", "media.subtitles.drop_phrases", "media.subtitles.scrub_phrases", "retrieval.cross_lingual.target_langs", "retrieval.hierarchical.source_reps", "retrieval.hierarchical.levels":
 		return true
 	default:
 		return false
@@ -3864,6 +3966,16 @@ func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	}
 	writeBool := func(key string, value bool) {
 		writeScalar(key, strconv.FormatBool(value))
+	}
+	// writeComment emits YAML comment lines. The loader skips them (a line whose
+	// first non-space character is `#`), so they document the generated file for
+	// the operator without changing what is read back.
+	writeComment := func(lines ...string) {
+		for _, line := range lines {
+			b.WriteString("# ")
+			b.WriteString(line)
+			b.WriteByte('\n')
+		}
 	}
 	writeList := func(key string, values []string) {
 		b.WriteString(key)
@@ -3943,6 +4055,19 @@ func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	writeScalar("chunking_strategy", cfg.ChunkingStrategy)
 	writeInt("chunking_max_tokens", cfg.ChunkingMaxTokens)
 	writeInt("chunking_overlap_tokens", cfg.ChunkingOverlapTokens)
+	writeComment(
+		"ingest_exclude_dirs: directory names discovery does not descend into (SPEC 7.1).",
+		"A present key REPLACES this list in full. It does not add to it.",
+		"An entry is a plain directory name. It is not a path and it is not a glob.",
+		"`.dir2mcp` is always kept: the state directory is under root_dir, so to",
+		"index it is self-referential.",
+		"The gates compose by AND. A file is indexed only if this list,",
+		"path_excludes and the optional .gitignore rules all admit it. These five",
+		"names are in BOTH lists: .git, .dir2mcp, node_modules, vendor,",
+		"__pycache__. To re-index one of them, clear the name from BOTH keys.",
+		"Clearing one key alone changes nothing you can see.",
+	)
+	writeList("ingest_exclude_dirs", cfg.IngestExcludeDirs)
 	writeBool("ingest_gitignore", cfg.IngestGitignore)
 	writeBool("ingest_follow_symlinks", cfg.IngestFollowSymlinks)
 	writeInt("ingest_max_file_mb", cfg.IngestMaxFileMB)
@@ -4491,6 +4616,7 @@ func (c *Config) Validate() error {
 		c.validateMediaSubtitles,
 		c.validateMediaDiarize,
 		c.validateNumericBounds,
+		c.validateIngestExcludeDirs,
 		c.validateSource,
 		c.validateDistributedEmbed,
 		c.validateMediaBatch,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2588,21 +2588,6 @@ func applyChunkingFileParsed(cfg *Config, fc fileConfig) {
 // applyIngestModesFileParsed copies the set ingest discovery/mode file
 // fields (gitignore, symlinks, size limit, per-type modes, extractor)
 // onto cfg.
-// applyIngestExcludeDirsFileParsed copies a set `ingest.exclude_dirs` onto cfg.
-// A present key replaces the default list in full (SPEC §7.1, #773), so the
-// merge is an assignment, not an append. It is split out of
-// applyIngestModesFileParsed to keep that function inside the cyclomatic budget.
-func applyIngestExcludeDirsFileParsed(cfg *Config, fc fileConfig) {
-	if fc.IngestExcludeDirs == nil {
-		return
-	}
-	resolved, warn := resolveExcludeDirs(normalizeStringSlice(fc.IngestExcludeDirs))
-	cfg.IngestExcludeDirs = resolved
-	if warn != nil {
-		cfg.Warnings = append(cfg.Warnings, warn)
-	}
-}
-
 func applyIngestModesFileParsed(cfg *Config, fc fileConfig) {
 	if fc.IngestGitignore != nil {
 		cfg.IngestGitignore = *fc.IngestGitignore
@@ -2646,6 +2631,21 @@ func applyIngestModesFileParsed(cfg *Config, fc fileConfig) {
 	}
 	if fc.IngestWatchDebounce != nil {
 		cfg.IngestWatchDebounce = *fc.IngestWatchDebounce
+	}
+}
+
+// applyIngestExcludeDirsFileParsed copies a set `ingest.exclude_dirs` onto cfg.
+// A present key replaces the default list in full (SPEC §7.1, #773), so the
+// merge is an assignment, not an append. It is split out of
+// applyIngestModesFileParsed to keep that function inside the cyclomatic budget.
+func applyIngestExcludeDirsFileParsed(cfg *Config, fc fileConfig) {
+	if fc.IngestExcludeDirs == nil {
+		return
+	}
+	resolved, warn := resolveExcludeDirs(normalizeStringSlice(fc.IngestExcludeDirs))
+	cfg.IngestExcludeDirs = resolved
+	if warn != nil {
+		cfg.Warnings = append(cfg.Warnings, warn)
 	}
 }
 

--- a/internal/corpusfs/corpusfs.go
+++ b/internal/corpusfs/corpusfs.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"io"
 	"io/fs"
+	"sort"
 )
 
 // defaultMaxFileSizeBytes mirrors the ingest discovery cap so a zero/negative
@@ -24,23 +25,28 @@ func DefaultMaxFileSizeBytes() int64 {
 	return defaultMaxFileSizeBytes
 }
 
-// defaultExcludedDirs are directory names skipped during discovery regardless of
-// backend. For S3 these are matched against path segments of the object key.
+// StateDirName is the name of the state directory dir2mcp writes under the
+// corpus root. It is always part of the resolved directory ignore list: the
+// walk would otherwise read the index that the same run writes, and watch mode
+// would feed its own writes back into ingest (SPEC §7.1).
+const StateDirName = ".dir2mcp"
+
+// defaultExcludedDirs are the directory names skipped during discovery when the
+// operator sets no list. For S3 these are matched against path segments of the
+// object key.
 //
-// SPEC §7.1 makes `.git/`, `node_modules/`, `dist/`, `build/`, `.venv/`, and
-// `.dir2mcp/` the normative default ignore list; `vendor/` and `__pycache__/`
-// are dir2mcp additions of the same kind (checked-in dependency trees and
-// generated caches). `dist`, `build`, and `.venv` were missing until #716, so a
-// default scan indexed generated bundles, build output, and entire Python
-// virtualenvs that operators had been told were ignored.
+// SPEC §7.1 names these eight directories as the default ignore list. `dist`,
+// `build`, and `.venv` were missing until #716, so a default scan indexed
+// generated bundles, build output, and entire Python virtualenvs that operators
+// had been told were ignored.
 //
-// This set is a hard floor: there is no config key that re-includes an excluded
-// directory (`security.path_excludes` only adds exclusions). Adding a name here
-// therefore removes documents from every existing corpus on the next reindex, so
-// it stays anchored to the spec rather than growing by taste.
+// This list is the DEFAULT, not a floor. `ingest.exclude_dirs` replaces it in
+// full (#773), so adding a name here changes only the corpora that keep the
+// default. It still removes documents from each of those corpora on the next
+// reindex, so the list stays anchored to the spec rather than growing by taste.
 var defaultExcludedDirs = map[string]struct{}{
 	".git":         {},
-	".dir2mcp":     {},
+	StateDirName:   {},
 	"node_modules": {},
 	"vendor":       {},
 	"__pycache__":  {},
@@ -49,24 +55,84 @@ var defaultExcludedDirs = map[string]struct{}{
 	".venv":        {},
 }
 
-// IsExcludedDir reports whether a DIRECTORY with this name is skipped by default
-// discovery. It is exported so the ingest file watcher applies the same list as
-// the initial scan: the watcher used to keep its own copy of the map, and the
-// copies drifted (#716).
+// DefaultExcludedDirs returns the default directory ignore list in sorted
+// order. It is the value `internal/config` uses when `ingest.exclude_dirs` is
+// absent, so the default lives in one place only.
+func DefaultExcludedDirs() []string {
+	names := make([]string, 0, len(defaultExcludedDirs))
+	for name := range defaultExcludedDirs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// ExcludedDirSet is a resolved directory ignore list: the names discovery does
+// not descend into. Build one with ResolveExcludedDirs.
+//
+// The zero value resolves to the default list, so a caller that forgets to pass
+// a set still excludes `.git/` and `.dir2mcp/` instead of indexing them.
 //
 // The rule is directory-only. A regular FILE named `dist` or `vendor` is an
 // ordinary corpus document and must still be discovered, so callers must only
-// consult this for entries they already know are directories (the S3 backend
+// consult the set for entries they already know are directories (the S3 backend
 // tests it against ancestor key segments only).
 //
 // The match is exact. The name is a real directory entry or object key segment,
-// and ` dist ` is a different directory than `dist`: the old TrimSpace here made
+// and ` dist ` is a different directory than `dist`: an old TrimSpace here made
 // discovery skip a legitimately-named tree whose documents nothing else would
-// have excluded, which is the same silent over-exclusion this change set exists
-// to remove.
-func IsExcludedDir(name string) bool {
-	_, ok := defaultExcludedDirs[name]
+// have excluded.
+type ExcludedDirSet struct {
+	names map[string]struct{}
+}
+
+// ResolveExcludedDirs returns the ignore set for the supplied names.
+//
+// A nil slice keeps the default list. A non-nil slice REPLACES the default list
+// in full; it does not add to it (SPEC §7.1). `.dir2mcp` is always added back,
+// because the state directory lives under the corpus root and to index it is
+// self-referential. Blank names are dropped.
+//
+// This is the single resolver. The local walker, the S3 lister, and the ingest
+// file watcher all read the set it returns, so the three cannot drift into
+// judging the same directory differently, which is what #716 fixed and what
+// keeping a second copy of the list would undo.
+func ResolveExcludedDirs(names []string) ExcludedDirSet {
+	if names == nil {
+		return ExcludedDirSet{}
+	}
+	resolved := make(map[string]struct{}, len(names)+1)
+	for _, name := range names {
+		if name == "" {
+			continue
+		}
+		resolved[name] = struct{}{}
+	}
+	resolved[StateDirName] = struct{}{}
+	return ExcludedDirSet{names: resolved}
+}
+
+// Has reports whether a DIRECTORY with this name is skipped by discovery.
+func (s ExcludedDirSet) Has(name string) bool {
+	if s.names == nil {
+		_, ok := defaultExcludedDirs[name]
+		return ok
+	}
+	_, ok := s.names[name]
 	return ok
+}
+
+// Names returns the resolved directory names in sorted order.
+func (s ExcludedDirSet) Names() []string {
+	if s.names == nil {
+		return DefaultExcludedDirs()
+	}
+	names := make([]string, 0, len(s.names))
+	for name := range s.names {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
 }
 
 // DiscoveredFile holds metadata collected during corpus discovery.
@@ -90,6 +156,11 @@ type Options struct {
 	MaxSizeBytes   int64
 	UseGitIgnore   bool
 	FollowSymlinks bool
+	// ExcludeDirs is the directory ignore list (config `ingest.exclude_dirs`,
+	// SPEC §7.1). nil keeps the default list. A non-nil value REPLACES the
+	// default list in full; it does not add to it. `.dir2mcp` is always kept.
+	// See ResolveExcludedDirs, which every backend calls to read this field.
+	ExcludeDirs []string
 	// ScanCache, when non-nil, is an optional directory-discovery cache (issue
 	// #267 item 5) consulted by the LocalFS walker. It lets an unchanged
 	// directory skip re-reading and re-sorting its entries while still detecting

--- a/internal/corpusfs/local.go
+++ b/internal/corpusfs/local.go
@@ -61,6 +61,7 @@ func (l *LocalFS) Walk(ctx context.Context, _ string, opts Options) ([]Discovere
 		rootAbs:      absRoot,
 		rootResolved: rootResolved,
 		options:      opts,
+		excluded:     ResolveExcludedDirs(opts.ExcludeDirs),
 		files:        &files,
 		visitedDirs:  map[string]struct{}{rootResolved: {}},
 	}
@@ -178,14 +179,18 @@ func ResolveSymlinkWithinRoot(rootResolved, linkPath string) (string, bool) {
 	return resolved, true
 }
 
-func shouldSkipDirectory(name string) bool {
-	return IsExcludedDir(name)
+// shouldSkipDirectory reports whether the walk descends into a directory with
+// this name. It reads the set resolved once per Walk from Options.ExcludeDirs,
+// so the local walker, the S3 lister, and the ingest watcher apply one list.
+func (w *discoverWalker) shouldSkipDirectory(name string) bool {
+	return w.excluded.Has(name)
 }
 
 type discoverWalker struct {
 	rootAbs      string
 	rootResolved string
 	options      Options
+	excluded     ExcludedDirSet
 	files        *[]DiscoveredFile
 	visitedDirs  map[string]struct{}
 }
@@ -249,7 +254,7 @@ func (w *discoverWalker) reportSkippedSymlink(relPath string) {
 
 // visitDir processes a single directory entry that is known to be a directory.
 func (w *discoverWalker) visitDir(ctx context.Context, fullPath, relPath, name string, rules []gitIgnoreRule) error {
-	if shouldSkipDirectory(name) {
+	if w.shouldSkipDirectory(name) {
 		return nil
 	}
 	if w.options.UseGitIgnore && matchesGitIgnoreRules(rules, relPath, true) {
@@ -558,7 +563,7 @@ func (w *discoverWalker) handleSymlink(ctx context.Context, symlinkPath, relPath
 	}
 
 	if stat.IsDir() {
-		if shouldSkipDirectory(path.Base(relPath)) {
+		if w.shouldSkipDirectory(path.Base(relPath)) {
 			return nil
 		}
 		if w.options.UseGitIgnore && matchesGitIgnoreRules(rules, relPath, true) {

--- a/internal/corpusfs/s3.go
+++ b/internal/corpusfs/s3.go
@@ -203,7 +203,7 @@ func (s *S3FS) Walk(ctx context.Context, _ string, opts Options) ([]DiscoveredFi
 		opts.MaxSizeBytes = defaultMaxFileSizeBytes
 	}
 
-	files, gitignoreRels, err := s.listObjects(ctx, opts)
+	files, gitignoreRels, err := s.listObjects(ctx, opts, ResolveExcludedDirs(opts.ExcludeDirs))
 	if err != nil {
 		return nil, err
 	}
@@ -221,7 +221,7 @@ func (s *S3FS) Walk(ctx context.Context, _ string, opts Options) ([]DiscoveredFi
 // listObjects paginates the bucket listing, converting in-scope objects to
 // DiscoveredFile and (when gitignore is enabled) collecting the corpus-relative
 // paths of any .gitignore objects so their rules can be loaded afterward.
-func (s *S3FS) listObjects(ctx context.Context, opts Options) ([]DiscoveredFile, []string, error) {
+func (s *S3FS) listObjects(ctx context.Context, opts Options, excluded ExcludedDirSet) ([]DiscoveredFile, []string, error) {
 	files := make([]DiscoveredFile, 0, 256)
 	var gitignoreRels []string
 	var token *string
@@ -243,7 +243,7 @@ func (s *S3FS) listObjects(ctx context.Context, opts Options) ([]DiscoveredFile,
 					gitignoreRels = append(gitignoreRels, rel)
 				}
 			}
-			if f, ok := s.discoveredFromObject(obj, opts); ok {
+			if f, ok := s.discoveredFromObject(obj, opts, excluded); ok {
 				files = append(files, f)
 			}
 		}
@@ -338,7 +338,7 @@ func (s *S3FS) getGitIgnoreObject(ctx context.Context, rel string) ([]byte, erro
 // discoveredFromObject converts a listed object into a DiscoveredFile, applying
 // the directory-key skip, excluded-dir, and size-cap policies. ok=false means
 // the object is skipped.
-func (s *S3FS) discoveredFromObject(obj s3types.Object, opts Options) (DiscoveredFile, bool) {
+func (s *S3FS) discoveredFromObject(obj s3types.Object, opts Options, excluded ExcludedDirSet) (DiscoveredFile, bool) {
 	key := aws.ToString(obj.Key)
 	rel, err := s.relForKey(key)
 	if err != nil {
@@ -356,7 +356,7 @@ func (s *S3FS) discoveredFromObject(obj s3types.Object, opts Options) (Discovere
 	if rel == "" || strings.HasSuffix(rel, "/") {
 		return DiscoveredFile{}, false
 	}
-	if keyHasExcludedDir(rel) {
+	if keyHasExcludedDir(rel, excluded) {
 		return DiscoveredFile{}, false
 	}
 	size := aws.ToInt64(obj.Size)
@@ -379,16 +379,18 @@ func (s *S3FS) discoveredFromObject(obj s3types.Object, opts Options) (Discovere
 	}, true
 }
 
-// keyHasExcludedDir reports whether the relative key lives under a
-// default-excluded directory (e.g. .git, node_modules). Only ancestor path
-// segments are tested — the final segment is the object's own basename, and
-// LocalFS excludes directories, not regular files, so a file whose name happens
-// to equal an excluded-dir name (e.g. a file literally named "vendor") must
-// still be discovered for the two backends to stay in parity.
-func keyHasExcludedDir(rel string) bool {
+// keyHasExcludedDir reports whether the relative key lives under an excluded
+// directory (e.g. .git, node_modules). The set is the one resolved from
+// Options.ExcludeDirs, so an operator list applies to a bucket exactly as it
+// applies to a local corpus. Only ancestor path segments are tested: the final
+// segment is the object's own basename, and LocalFS excludes directories, not
+// regular files, so a file whose name happens to equal an excluded-dir name
+// (e.g. a file literally named "vendor") must still be discovered for the two
+// backends to stay in parity.
+func keyHasExcludedDir(rel string, excluded ExcludedDirSet) bool {
 	segs := strings.Split(rel, "/")
 	for _, seg := range segs[:len(segs)-1] {
-		if IsExcludedDir(seg) {
+		if excluded.Has(seg) {
 			return true
 		}
 	}

--- a/internal/ingest/discover.go
+++ b/internal/ingest/discover.go
@@ -71,6 +71,13 @@ type DiscoverOptions struct {
 	UseGitIgnore   bool
 	FollowSymlinks bool
 	MediaVariants  MediaVariantOptions
+	// ExcludeDirs is the directory ignore list (config `ingest.exclude_dirs`,
+	// SPEC §7.1, issue #773). nil keeps the default list. A non-nil value
+	// REPLACES the default list in full. `.dir2mcp` is always kept.
+	//
+	// The initial scan and the file watcher both read this one value, so the
+	// watcher cannot judge a directory differently from the scan (#716).
+	ExcludeDirs []string
 	// ScanCache, when non-nil, is the optional directory-discovery cache (issue
 	// #267 item 5) passed through to the local-filesystem walker. nil = disabled
 	// (a full re-walk every run). See corpusfs.ScanCache.
@@ -112,11 +119,18 @@ func (o DiscoverOptions) corpusfsOptions() corpusfs.Options {
 		MaxSizeBytes:     o.MaxSizeBytes,
 		UseGitIgnore:     o.UseGitIgnore,
 		FollowSymlinks:   o.FollowSymlinks,
+		ExcludeDirs:      o.ExcludeDirs,
 		ScanCache:        o.ScanCache,
 		OnOversize:       o.OnOversize,
 		OnUnsafeKey:      o.OnUnsafeKey,
 		OnSkippedSymlink: o.OnSkippedSymlink,
 	}
+}
+
+// ExcludedDirs resolves the directory ignore set these options select. The
+// watcher calls it so it applies the very list the scan applies.
+func (o DiscoverOptions) ExcludedDirs() corpusfs.ExcludedDirSet {
+	return corpusfs.ResolveExcludedDirs(o.ExcludeDirs)
 }
 
 // DiscoverFiles walks rootDir and returns regular files that pass default

--- a/internal/ingest/exclude_dirs_773_test.go
+++ b/internal/ingest/exclude_dirs_773_test.go
@@ -1,0 +1,116 @@
+package ingest
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/fsnotify/fsnotify"
+)
+
+// Issue #773: the file watcher must apply the operator's `ingest.exclude_dirs`
+// list, not a hardcoded default list. It is an internal test because it drives
+// the unexported addWatchDirs directly: that registers the watches from the
+// resolved list without waiting on real fsnotify event timing, so the parity
+// check is deterministic.
+//
+// Parity with the initial scan is the point. The watcher once kept its own copy
+// of the ignore list and the two drifted (#716), so a directory could be
+// excluded from the scan and still picked up by the watcher. Both now read one
+// resolved value: DiscoverOptionsFromConfig(cfg).ExcludedDirs().
+
+// watchedDirs registers watches for absRoot under opts and returns the
+// registered directory paths as a set.
+func watchedDirs(t *testing.T, absRoot string, opts DiscoverOptions) map[string]bool {
+	t.Helper()
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		t.Fatalf("new watcher: %v", err)
+	}
+	t.Cleanup(func() { _ = watcher.Close() })
+
+	svc := &Service{}
+	if err := svc.addWatchDirs(watcher, absRoot, opts); err != nil {
+		t.Fatalf("addWatchDirs: %v", err)
+	}
+	registered := map[string]bool{}
+	for _, dir := range watcher.WatchList() {
+		registered[dir] = true
+	}
+	return registered
+}
+
+// watchExcludeCorpus creates one directory per name the tests care about.
+func watchExcludeCorpus(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	for _, name := range []string{"dist", "node_modules", "notes", ".dir2mcp"} {
+		if err := os.MkdirAll(filepath.Join(root, name), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", name, err)
+		}
+	}
+	return root
+}
+
+// TestAddWatchDirs_HonorsConfiguredExcludeDirs pins the watcher to the
+// operator's list. `dist` leaves the list, so the watcher must watch it; the
+// list names `notes`, so the watcher must skip it.
+func TestAddWatchDirs_HonorsConfiguredExcludeDirs(t *testing.T) {
+	root := watchExcludeCorpus(t)
+
+	cfg := config.Default()
+	cfg.RootDir = root
+	cfg.IngestExcludeDirs = []string{"notes", "node_modules"}
+	registered := watchedDirs(t, root, DiscoverOptionsFromConfig(cfg))
+
+	if !registered[filepath.Join(root, "dist")] {
+		t.Errorf("dist must be watched once it leaves ingest.exclude_dirs; watched %v", registered)
+	}
+	if registered[filepath.Join(root, "notes")] {
+		t.Errorf("notes is listed, so it must not be watched; watched %v", registered)
+	}
+	if registered[filepath.Join(root, "node_modules")] {
+		t.Errorf("node_modules is listed, so it must not be watched; watched %v", registered)
+	}
+	if registered[filepath.Join(root, ".dir2mcp")] {
+		t.Errorf(".dir2mcp must not be watched even when the list omits it; watched %v", registered)
+	}
+}
+
+// TestAddWatchDirs_DefaultsUnchangedWhenNoListIsSet guards the existing corpus:
+// with no configured list the watcher keeps the default names.
+func TestAddWatchDirs_DefaultsUnchangedWhenNoListIsSet(t *testing.T) {
+	root := watchExcludeCorpus(t)
+
+	cfg := config.Default()
+	cfg.RootDir = root
+	registered := watchedDirs(t, root, DiscoverOptionsFromConfig(cfg))
+
+	if !registered[filepath.Join(root, "notes")] {
+		t.Errorf("an ordinary directory must be watched; watched %v", registered)
+	}
+	for _, name := range []string{"dist", "node_modules", ".dir2mcp"} {
+		if registered[filepath.Join(root, name)] {
+			t.Errorf("%s is a default excluded name, so it must not be watched; watched %v", name, registered)
+		}
+	}
+}
+
+// TestWatcherAndScanShareOneExcludedSet states the invariant directly: the set
+// the watcher applies is the set the scan applies, because both come from the
+// same DiscoverOptions.
+func TestWatcherAndScanShareOneExcludedSet(t *testing.T) {
+	cfg := config.Default()
+	cfg.IngestExcludeDirs = []string{"notes"}
+	opts := DiscoverOptionsFromConfig(cfg)
+
+	scanned := opts.corpusfsOptions().ExcludeDirs
+	if len(scanned) != len(opts.ExcludeDirs) {
+		t.Fatalf("the scan options must carry the configured list; got %v", scanned)
+	}
+	watched := opts.ExcludedDirs()
+	if !watched.Has("notes") || !watched.Has(".dir2mcp") || watched.Has("dist") {
+		t.Errorf("the watcher set must resolve the configured list; got %v", watched.Names())
+	}
+}

--- a/internal/ingest/gitignore.go
+++ b/internal/ingest/gitignore.go
@@ -16,12 +16,14 @@ import (
 const defaultMaxFileSizeBytes int64 = 10 * 1024 * 1024
 
 // shouldSkipDirectory reports whether the incremental file watch skips a
-// directory. It delegates to corpusfs, which owns the default ignore list the
-// initial scan applies: the watcher used to keep a second copy of the map and
-// the two drifted apart, so a directory could be excluded from the scan and
-// still be picked up by the watcher (or vice versa). See #716.
-func shouldSkipDirectory(name string) bool {
-	return corpusfs.IsExcludedDir(name)
+// directory. The set comes from the same DiscoverOptions the initial scan uses
+// (DiscoverOptionsFromConfig), so the watcher applies the operator's
+// `ingest.exclude_dirs` list and cannot hold a second copy of it: the watcher
+// once kept its own map and the two drifted apart, so a directory could be
+// excluded from the scan and still be picked up by the watcher (or the reverse).
+// See #716 and #773.
+func shouldSkipDirectory(excluded corpusfs.ExcludedDirSet, name string) bool {
+	return excluded.Has(name)
 }
 
 type gitIgnoreRule struct {

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -1039,6 +1039,8 @@ func DiscoverOptionsFromConfig(cfg config.Config) DiscoverOptions {
 	options := DefaultDiscoverOptions()
 	options.UseGitIgnore = cfg.IngestGitignore
 	options.FollowSymlinks = cfg.IngestFollowSymlinks
+	// One resolved list for the scan, the watcher, and the S3 lister (#773).
+	options.ExcludeDirs = append([]string(nil), cfg.IngestExcludeDirs...)
 	if cfg.IngestMaxFileMB > 0 {
 		options.MaxSizeBytes = int64(cfg.IngestMaxFileMB) * 1024 * 1024
 	}

--- a/internal/ingest/watch.go
+++ b/internal/ingest/watch.go
@@ -65,7 +65,8 @@ func (s *Service) Watch(ctx context.Context) error {
 	}
 	defer func() { _ = watcher.Close() }()
 
-	if err := s.addWatchDirs(watcher, absRoot, DiscoverOptionsFromConfig(s.cfg).FollowSymlinks); err != nil {
+	discoverOpts := DiscoverOptionsFromConfig(s.cfg)
+	if err := s.addWatchDirs(watcher, absRoot, discoverOpts); err != nil {
 		// A failure to register some dirs is non-fatal — the safety rescan
 		// still catches changes there. Log and continue.
 		s.getLogger().Printf("watch: registering directories: %v", err)
@@ -86,7 +87,8 @@ func (s *Service) Watch(ctx context.Context) error {
 		watcher:  watcher,
 		absRoot:  absRoot,
 		secrets:  secrets,
-		opts:     DiscoverOptionsFromConfig(s.cfg),
+		opts:     discoverOpts,
+		excluded: discoverOpts.ExcludedDirs(),
 		debounce: debounce,
 		pending:  make(map[string]*time.Timer),
 		fire:     make(chan watchJob, 256),
@@ -100,11 +102,14 @@ type watchJob struct {
 }
 
 type fsWatchLoop struct {
-	svc      *Service
-	watcher  *fsnotify.Watcher
-	absRoot  string
-	secrets  []*regexp.Regexp
-	opts     DiscoverOptions
+	svc     *Service
+	watcher *fsnotify.Watcher
+	absRoot string
+	secrets []*regexp.Regexp
+	opts    DiscoverOptions
+	// excluded is the directory ignore set resolved from opts once, so every
+	// watch decision reads the list the initial scan read (#773).
+	excluded corpusfs.ExcludedDirSet
 	debounce time.Duration
 
 	mu      sync.Mutex
@@ -207,7 +212,7 @@ func (w *fsWatchLoop) handleEvent(ev fsnotify.Event) {
 		// since fsnotify is not recursive and the Create events for nested
 		// children were emitted before we were watching them.
 		if info, err := os.Stat(abs); err == nil && info.IsDir() {
-			if !shouldSkipDirectory(filepath.Base(abs)) {
+			if !shouldSkipDirectory(w.excluded, filepath.Base(abs)) {
 				w.registerNewTree(abs)
 			}
 			return
@@ -248,7 +253,7 @@ func (w *fsWatchLoop) registerNewTree(absDir string) {
 			)
 			return
 		}
-		walkWatchTree(absDir, rootResolved, map[string]struct{}{}, addDir, armFile)
+		walkWatchTree(absDir, rootResolved, w.excluded, map[string]struct{}{}, addDir, armFile)
 		return
 	}
 	_ = filepath.WalkDir(absDir, func(path string, d os.DirEntry, err error) error {
@@ -256,7 +261,7 @@ func (w *fsWatchLoop) registerNewTree(absDir string) {
 			return nil
 		}
 		if d.IsDir() {
-			if path != absDir && shouldSkipDirectory(d.Name()) {
+			if path != absDir && shouldSkipDirectory(w.excluded, d.Name()) {
 				return filepath.SkipDir
 			}
 			addDir(path)
@@ -452,8 +457,10 @@ func matchesGitignoreForFile(absRoot, relPath string) (bool, error) {
 // fsnotify is not recursive, so each directory must be added individually. A
 // single unwatchable directory does not abort registration of its siblings;
 // per-directory failures are aggregated and returned.
-func (s *Service) addWatchDirs(watcher *fsnotify.Watcher, absRoot string, followSymlinks bool) error {
+func (s *Service) addWatchDirs(watcher *fsnotify.Watcher, absRoot string, opts DiscoverOptions) error {
 	var errs []error
+	followSymlinks := opts.FollowSymlinks
+	excluded := opts.ExcludedDirs()
 	add := func(path string) {
 		if addErr := watcher.Add(path); addErr != nil {
 			errs = append(errs, fmt.Errorf("watch %s: %w", path, addErr))
@@ -473,7 +480,7 @@ func (s *Service) addWatchDirs(watcher *fsnotify.Watcher, absRoot string, follow
 		if _, ok := corpusfs.ResolveSymlinkWithinRoot(rootResolved, absRoot); !ok {
 			return fmt.Errorf("watch %s: corpus root did not resolve; no directories watched", absRoot)
 		}
-		walkWatchTree(absRoot, rootResolved, map[string]struct{}{}, add, nil)
+		walkWatchTree(absRoot, rootResolved, excluded, map[string]struct{}{}, add, nil)
 		return errors.Join(errs...)
 	}
 	_ = filepath.WalkDir(absRoot, func(path string, d os.DirEntry, err error) error {
@@ -483,7 +490,7 @@ func (s *Service) addWatchDirs(watcher *fsnotify.Watcher, absRoot string, follow
 		if !d.IsDir() {
 			return nil
 		}
-		if path != absRoot && shouldSkipDirectory(d.Name()) {
+		if path != absRoot && shouldSkipDirectory(excluded, d.Name()) {
 			return filepath.SkipDir
 		}
 		add(path)
@@ -504,7 +511,7 @@ func (s *Service) addWatchDirs(watcher *fsnotify.Watcher, absRoot string, follow
 // the root any more than a file link can — #717).
 // onDir/onFile receive the lexical path (through the symlink) so emitted fsnotify
 // events map back to a path under the watched root.
-func walkWatchTree(absDir, rootResolved string, visited map[string]struct{}, onDir func(string), onFile func(string)) {
+func walkWatchTree(absDir, rootResolved string, excluded corpusfs.ExcludedDirSet, visited map[string]struct{}, onDir func(string), onFile func(string)) {
 	resolved, ok := corpusfs.ResolveSymlinkWithinRoot(rootResolved, absDir)
 	if !ok {
 		return
@@ -525,10 +532,10 @@ func walkWatchTree(absDir, rootResolved string, visited map[string]struct{}, onD
 		child := filepath.Join(absDir, name)
 		switch {
 		case entry.IsDir():
-			if shouldSkipDirectory(name) {
+			if shouldSkipDirectory(excluded, name) {
 				continue
 			}
-			walkWatchTree(child, rootResolved, visited, onDir, onFile)
+			walkWatchTree(child, rootResolved, excluded, visited, onDir, onFile)
 		case entry.Type()&os.ModeSymlink != 0:
 			// Resolve the link to decide dir-vs-file; descend symlinked dirs
 			// (containment is enforced on entry) and arm symlinked regular files.
@@ -537,10 +544,10 @@ func walkWatchTree(absDir, rootResolved string, visited map[string]struct{}, onD
 				continue
 			}
 			if target.IsDir() {
-				if shouldSkipDirectory(name) {
+				if shouldSkipDirectory(excluded, name) {
 					continue
 				}
-				walkWatchTree(child, rootResolved, visited, onDir, onFile)
+				walkWatchTree(child, rootResolved, excluded, visited, onDir, onFile)
 			} else if onFile != nil && target.Mode().IsRegular() {
 				onFile(child)
 			}

--- a/tests/config/exclude_dirs_773_test.go
+++ b/tests/config/exclude_dirs_773_test.go
@@ -1,0 +1,126 @@
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/corpusfs"
+)
+
+// Issue #773 / SPEC §7.1: `ingest.exclude_dirs` replaces the directory ignore
+// list. These tests cover the loader side: the key spelling, the replace
+// semantics, the forced `.dir2mcp`, and the entry shape.
+
+// writeExcludeDirsConfig writes body to a temp .dir2mcp.yaml and loads it.
+func writeExcludeDirsConfig(t *testing.T, body string) (config.Config, error) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), ".dir2mcp.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return config.LoadFile(path)
+}
+
+// TestExcludeDirs_DefaultsToTheSpecList pins the absent-key case. An existing
+// corpus must not change.
+func TestExcludeDirs_DefaultsToTheSpecList(t *testing.T) {
+	want := []string{".dir2mcp", ".git", ".venv", "__pycache__", "build", "dist", "node_modules", "vendor"}
+	if !reflect.DeepEqual(config.Default().IngestExcludeDirs, want) {
+		t.Errorf("the default list must be the eight SPEC §7.1 names; got %v", config.Default().IngestExcludeDirs)
+	}
+	if !reflect.DeepEqual(corpusfs.DefaultExcludedDirs(), want) {
+		t.Errorf("config and corpusfs must share one default list; got %v", corpusfs.DefaultExcludedDirs())
+	}
+
+	cfg, err := writeExcludeDirsConfig(t, "root_dir: .\n")
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if !reflect.DeepEqual(cfg.IngestExcludeDirs, want) {
+		t.Errorf("an absent key must keep the default list; got %v", cfg.IngestExcludeDirs)
+	}
+}
+
+// TestExcludeDirs_NestedKeyReplacesTheDefaultList covers the spec spelling
+// (`ingest: exclude_dirs:`) and the replace semantics: the key does not add to
+// the default list.
+func TestExcludeDirs_NestedKeyReplacesTheDefaultList(t *testing.T) {
+	cfg, err := writeExcludeDirsConfig(t, "ingest:\n  exclude_dirs:\n    - .git\n    - .dir2mcp\n    - notes\n")
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	want := []string{".git", ".dir2mcp", "notes"}
+	if !reflect.DeepEqual(cfg.IngestExcludeDirs, want) {
+		t.Errorf("a present key must replace the default list in full; got %v", cfg.IngestExcludeDirs)
+	}
+	if len(cfg.Warnings) != 0 {
+		t.Errorf("a list that names .dir2mcp must load without a warning; got %v", cfg.Warnings)
+	}
+}
+
+// TestExcludeDirs_InlineListForm covers the §16.2 template spelling.
+func TestExcludeDirs_InlineListForm(t *testing.T) {
+	cfg, err := writeExcludeDirsConfig(t, "ingest:\n  exclude_dirs: [\".git\", \".dir2mcp\", \"node_modules\"]\n")
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	want := []string{".git", ".dir2mcp", "node_modules"}
+	if !reflect.DeepEqual(cfg.IngestExcludeDirs, want) {
+		t.Errorf("the inline list form must be read; got %v", cfg.IngestExcludeDirs)
+	}
+}
+
+// TestExcludeDirs_StateDirIsAddedBackAndSaidSo pins the one name an operator
+// cannot drop, and the SHOULD: the loader says that it added the name back.
+func TestExcludeDirs_StateDirIsAddedBackAndSaidSo(t *testing.T) {
+	cfg, err := writeExcludeDirsConfig(t, "ingest:\n  exclude_dirs:\n    - notes\n")
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if !reflect.DeepEqual(cfg.IngestExcludeDirs, []string{"notes", ".dir2mcp"}) {
+		t.Errorf(".dir2mcp must be added back to the resolved list; got %v", cfg.IngestExcludeDirs)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w.Error(), "exclude_dirs") && strings.Contains(w.Error(), ".dir2mcp") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("the loader must say that it added .dir2mcp back; got %v", cfg.Warnings)
+	}
+}
+
+// TestExcludeDirs_EmptyListKeepsOnlyTheStateDir covers `exclude_dirs: []`. It
+// is a present key, so it replaces the default list with nothing.
+func TestExcludeDirs_EmptyListKeepsOnlyTheStateDir(t *testing.T) {
+	cfg, err := writeExcludeDirsConfig(t, "ingest:\n  exclude_dirs: []\n")
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if !reflect.DeepEqual(cfg.IngestExcludeDirs, []string{".dir2mcp"}) {
+		t.Errorf("an empty list must resolve to the forced state directory only; got %v", cfg.IngestExcludeDirs)
+	}
+}
+
+// TestExcludeDirs_RejectsAnEntryThatIsNotAName tells the operator at once that
+// a path or a glob matches nothing, instead of leaving them to wonder why the
+// directory is still indexed. SPEC §7.1: an entry is a plain directory name.
+func TestExcludeDirs_RejectsAnEntryThatIsNotAName(t *testing.T) {
+	for _, entry := range []string{"src/dist", "dist/**", "dist*", ".."} {
+		cfg := config.Default()
+		cfg.IngestExcludeDirs = []string{entry}
+		if err := cfg.Validate(); err == nil {
+			t.Errorf("entry %q must be rejected: it is not a plain directory name", entry)
+		}
+	}
+	cfg := config.Default()
+	cfg.IngestExcludeDirs = []string{".dir2mcp", "notes", "my dir"}
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("a plain directory name must be accepted; got %v", err)
+	}
+}

--- a/tests/config/generated_config_roundtrip_test.go
+++ b/tests/config/generated_config_roundtrip_test.go
@@ -112,6 +112,86 @@ func TestGeneratedConfig_EveryWrittenKeyIsReadable(t *testing.T) {
 	}
 }
 
+// TestGeneratedConfig_ExcludeDirsIsWrittenAndReadBack extends the guard above
+// to the `ingest.exclude_dirs` list key (#773). The guard above walks SCALAR
+// keys only, so a list key that SaveFile writes and LoadFile drops would pass
+// it unnoticed: this is the same writer/loader loop, closed for the list.
+//
+// It also pins the generated file's own documentation. SPEC §7.1 requires the
+// implementation to document that the gates compose by AND wherever it
+// documents the key, because an operator who clears only this list sees no
+// change for the five names that `security.path_excludes` also carries.
+func TestGeneratedConfig_ExcludeDirsIsWrittenAndReadBack(t *testing.T) {
+	dir := t.TempDir()
+	genPath := filepath.Join(dir, ".dir2mcp.yaml")
+	if err := config.SaveFile(genPath, config.Default()); err != nil {
+		t.Fatalf("SaveFile (what `config init` writes): %v", err)
+	}
+	raw, err := os.ReadFile(genPath)
+	if err != nil {
+		t.Fatalf("read generated config: %v", err)
+	}
+	text := string(raw)
+
+	assertExcludeDirsIsDocumented(t, text)
+
+	// The default file loads back to the default list, with no warning.
+	base, err := config.LoadFile(genPath)
+	if err != nil {
+		t.Fatalf("LoadFile of the generated config: %v", err)
+	}
+	if !reflect.DeepEqual(base.IngestExcludeDirs, config.Default().IngestExcludeDirs) {
+		t.Errorf("the generated list must round-trip to the default list; got %v", base.IngestExcludeDirs)
+	}
+	if len(base.Warnings) != 0 {
+		t.Errorf("the generated config must load without warnings; got %v", base.Warnings)
+	}
+
+	// An operator edit reaches the loader: drop `dist` to index a static-site
+	// corpus (#773).
+	edited := strings.Replace(text, "  - dist\n", "", 1)
+	if edited == text {
+		t.Fatalf("expected a `dist` entry to remove; got:\n%s", text)
+	}
+	editedPath := filepath.Join(t.TempDir(), ".dir2mcp.yaml")
+	if err := os.WriteFile(editedPath, []byte(edited), 0o600); err != nil {
+		t.Fatalf("write edited config: %v", err)
+	}
+	got, err := config.LoadFile(editedPath)
+	if err != nil {
+		t.Fatalf("LoadFile of the edited config: %v", err)
+	}
+	for _, name := range got.IngestExcludeDirs {
+		if name == "dist" {
+			t.Fatalf("`dist` must be gone after the operator removed it; got %v", got.IngestExcludeDirs)
+		}
+	}
+	if len(got.IngestExcludeDirs) != len(base.IngestExcludeDirs)-1 {
+		t.Errorf("only `dist` must go: got %v", got.IngestExcludeDirs)
+	}
+}
+
+// assertExcludeDirsIsDocumented checks that the generated config carries the
+// key, the whole default list, and the AND-composition warning SPEC §7.1
+// requires wherever the key is documented.
+func assertExcludeDirsIsDocumented(t *testing.T, text string) {
+	t.Helper()
+	if !strings.Contains(text, "ingest_exclude_dirs:") {
+		t.Fatalf("`config init` must write ingest_exclude_dirs; got:\n%s", text)
+	}
+	for _, name := range []string{".git", ".dir2mcp", "node_modules", "vendor", "__pycache__", "dist", "build", ".venv"} {
+		if !strings.Contains(text, "  - "+name+"\n") {
+			t.Errorf("the written list must carry the default name %q; got:\n%s", name, text)
+		}
+	}
+	// The trap: the gates are independent and compose by AND.
+	for _, phrase := range []string{"REPLACES", "AND", "path_excludes", "BOTH"} {
+		if !strings.Contains(text, phrase) {
+			t.Errorf("the generated config must document %q next to ingest_exclude_dirs; got:\n%s", phrase, text)
+		}
+	}
+}
+
 // topLevelScalar reports the key/value of lines[i] when it is a top-level
 // `key: value` scalar, skipping comments, blanks, indented children and the
 // header lines of nested sections/lists.

--- a/tests/corpusfs/exclude_dirs_773_test.go
+++ b/tests/corpusfs/exclude_dirs_773_test.go
@@ -1,0 +1,198 @@
+package tests
+
+import (
+	"context"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/corpusfs"
+)
+
+// Issue #773 / SPEC §7.1: `ingest.exclude_dirs` lets an operator replace the
+// directory ignore list. A present list replaces the default list in full; it
+// does not add to it. `.dir2mcp` stays in the resolved list either way.
+
+// walkRels walks root with opts and returns the discovered rel paths as a set.
+func walkRels(t *testing.T, root string, opts corpusfs.Options) map[string]bool {
+	t.Helper()
+	files, err := corpusfs.NewLocalFS(root).Walk(context.Background(), root, opts)
+	if err != nil {
+		t.Fatalf("LocalFS.Walk: %v", err)
+	}
+	rels := map[string]bool{}
+	for _, f := range files {
+		rels[f.RelPath] = true
+	}
+	return rels
+}
+
+// excludeDirsCorpus writes one file under each directory the tests care about.
+func excludeDirsCorpus(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "keep.txt"), []byte("keep"))
+	mustWrite(t, filepath.Join(root, "dist", "bundle.js"), []byte("bundled"))
+	mustWrite(t, filepath.Join(root, "node_modules", "lib.js"), []byte("dep"))
+	mustWrite(t, filepath.Join(root, ".dir2mcp", "index.db"), []byte("state"))
+	mustWrite(t, filepath.Join(root, "notes", "memo.md"), []byte("memo"))
+	return root
+}
+
+// TestLocalFSWalk_ExcludeDirsDropsANameFromTheList is the operator case in
+// #773: a corpus of published static-site output really does live in `dist/`.
+// Dropping `dist` from the list must index it.
+func TestLocalFSWalk_ExcludeDirsDropsANameFromTheList(t *testing.T) {
+	root := excludeDirsCorpus(t)
+
+	opts := corpusfs.DefaultOptions()
+	opts.ExcludeDirs = []string{".git", "node_modules", "vendor", "__pycache__", "build", ".venv"}
+	rels := walkRels(t, root, opts)
+
+	if !rels["dist/bundle.js"] {
+		t.Errorf("dist/bundle.js must be discovered once `dist` leaves ingest.exclude_dirs; got %v", rels)
+	}
+	if !rels["keep.txt"] {
+		t.Errorf("keep.txt must still be discovered; got %v", rels)
+	}
+	if rels["node_modules/lib.js"] {
+		t.Errorf("node_modules is still listed, so it must stay excluded; got %v", rels)
+	}
+}
+
+// TestLocalFSWalk_ExcludeDirsReplacesTheDefaultList pins the replace semantics.
+// A present key does not ADD to the default list. A list of one name leaves
+// every other default name indexable.
+func TestLocalFSWalk_ExcludeDirsReplacesTheDefaultList(t *testing.T) {
+	root := excludeDirsCorpus(t)
+
+	opts := corpusfs.DefaultOptions()
+	opts.ExcludeDirs = []string{"notes"}
+	rels := walkRels(t, root, opts)
+
+	if rels["notes/memo.md"] {
+		t.Errorf("notes is the only listed name, so it must be excluded; got %v", rels)
+	}
+	for _, want := range []string{"dist/bundle.js", "node_modules/lib.js"} {
+		if !rels[want] {
+			t.Errorf("%q must be discovered: a present list replaces the default list, it does not add to it; got %v", want, rels)
+		}
+	}
+}
+
+// TestLocalFSWalk_ExcludeDirsAlwaysKeepsTheStateDir pins the one name an
+// operator cannot drop. The state directory lives under the corpus root, so to
+// index it is self-referential: the walk would read the index the same run
+// writes.
+func TestLocalFSWalk_ExcludeDirsAlwaysKeepsTheStateDir(t *testing.T) {
+	root := excludeDirsCorpus(t)
+
+	opts := corpusfs.DefaultOptions()
+	opts.ExcludeDirs = []string{"notes"} // omits .dir2mcp on purpose
+	rels := walkRels(t, root, opts)
+
+	if rels[".dir2mcp/index.db"] {
+		t.Errorf(".dir2mcp must stay excluded even when the list omits it; got %v", rels)
+	}
+}
+
+// TestLocalFSWalk_ExcludeDirsEmptyListKeepsOnlyTheStateDir covers the explicit
+// `exclude_dirs: []`. It is a present key, so it replaces the default list with
+// nothing, and only the forced state directory remains.
+func TestLocalFSWalk_ExcludeDirsEmptyListKeepsOnlyTheStateDir(t *testing.T) {
+	root := excludeDirsCorpus(t)
+
+	opts := corpusfs.DefaultOptions()
+	opts.ExcludeDirs = []string{}
+	rels := walkRels(t, root, opts)
+
+	for _, want := range []string{"dist/bundle.js", "node_modules/lib.js", "notes/memo.md"} {
+		if !rels[want] {
+			t.Errorf("%q must be discovered under an empty list; got %v", want, rels)
+		}
+	}
+	if rels[".dir2mcp/index.db"] {
+		t.Errorf(".dir2mcp must stay excluded under an empty list; got %v", rels)
+	}
+}
+
+// TestLocalFSWalk_ExcludeDirsAbsentKeepsTheDefaults guards the existing corpus:
+// nil means the operator set nothing, so the default list still applies.
+func TestLocalFSWalk_ExcludeDirsAbsentKeepsTheDefaults(t *testing.T) {
+	root := excludeDirsCorpus(t)
+
+	rels := walkRels(t, root, corpusfs.DefaultOptions())
+
+	if !rels["keep.txt"] || !rels["notes/memo.md"] {
+		t.Errorf("ordinary files must be discovered; got %v", rels)
+	}
+	for _, bad := range []string{"dist/bundle.js", "node_modules/lib.js", ".dir2mcp/index.db"} {
+		if rels[bad] {
+			t.Errorf("%q must stay excluded when no list is set; got %v", bad, rels)
+		}
+	}
+}
+
+// TestS3FSWalk_ExcludeDirsMatchesLocal pins backend parity: one list governs a
+// bucket exactly as it governs a local corpus.
+func TestS3FSWalk_ExcludeDirsMatchesLocal(t *testing.T) {
+	objs := map[string][]byte{
+		"keep.txt":            []byte("keep"),
+		"dist/bundle.js":      []byte("bundled"),
+		"node_modules/lib.js": []byte("dep"),
+		".dir2mcp/index.db":   []byte("state"),
+		"notes/memo.md":       []byte("memo"),
+	}
+	fsys, _ := newFakeS3FS(t, "", objs, "")
+
+	opts := corpusfs.DefaultOptions()
+	opts.ExcludeDirs = []string{"notes"}
+	got, err := fsys.Walk(context.Background(), "", opts)
+	if err != nil {
+		t.Fatalf("S3FS.Walk: %v", err)
+	}
+	rels := map[string]bool{}
+	for _, f := range got {
+		rels[f.RelPath] = true
+	}
+
+	for _, want := range []string{"keep.txt", "dist/bundle.js", "node_modules/lib.js"} {
+		if !rels[want] {
+			t.Errorf("%q must be discovered: the list replaces the default list on S3 too; got %v", want, rels)
+		}
+	}
+	for _, bad := range []string{"notes/memo.md", ".dir2mcp/index.db"} {
+		if rels[bad] {
+			t.Errorf("%q must stay excluded on S3; got %v", bad, rels)
+		}
+	}
+}
+
+// TestResolveExcludedDirs pins the resolver the three consumers share.
+func TestResolveExcludedDirs(t *testing.T) {
+	want := []string{".dir2mcp", ".git", "__pycache__", ".venv", "build", "dist", "node_modules", "vendor"}
+	got := corpusfs.DefaultExcludedDirs()
+	if len(got) != len(want) {
+		t.Fatalf("the default list has %d names, want %d: %v", len(got), len(want), got)
+	}
+	for _, name := range want {
+		if !corpusfs.ResolveExcludedDirs(nil).Has(name) {
+			t.Errorf("a nil list must keep the default name %q", name)
+		}
+	}
+
+	// The zero value is the default list, so a consumer that forgets to resolve
+	// still excludes .git and .dir2mcp instead of indexing them.
+	var zero corpusfs.ExcludedDirSet
+	if !zero.Has(".git") || !zero.Has(".dir2mcp") {
+		t.Errorf("the zero value must fall back to the default list")
+	}
+
+	resolved := corpusfs.ResolveExcludedDirs([]string{"notes", "notes", ""})
+	if !reflect.DeepEqual(resolved.Names(), []string{".dir2mcp", "notes"}) {
+		t.Errorf("a present list must replace the defaults, drop duplicates and blanks, and keep .dir2mcp; got %v", resolved.Names())
+	}
+	if resolved.Has("dist") {
+		t.Errorf("a present list must not keep default names it omits")
+	}
+}


### PR DESCRIPTION
Closes #773.

Spec-first: `dirstral-spec` PR #86 (0.47.0) is merged. This PR re-pins the submodule to `dirstral-spec` `main`, which carries 0.46.0 and 0.47.0. PR #797 re-pins to the same commit. If it merges first, this re-pin becomes a no-op.

## The problem

The default excluded-directory set was a hard floor. An operator whose corpus is published static-site output in `dist/`, or documentation under `build/`, had no way to index it.

- `security.path_excludes` only adds exclusions. It cannot re-include.
- A `.gitignore` negation cannot help either. The walk tests the directory NAME before it reads any rule in that subtree, so it never descends and the rule is never consulted.

## Design

`ingest.exclude_dirs` replaces the directory ignore list.

**Why replace and not add/subtract.** A present key replaces the default list in full. It does not add to it. `security.path_excludes` already behaves this way, and `mergeFileConfig` already implements it: a present key wins wholesale. A reader therefore learns one list rule, not two. The alternative, an additive key plus a subtractive `include_dirs`, is more surgical but adds a second ordering rule to a surface that has none today. An absent key keeps the default list, so an existing corpus does not change.

The default list is the EIGHT names in SPEC 7.1: `.git`, `.dir2mcp`, `node_modules`, `vendor`, `__pycache__`, `dist`, `build`, `.venv`. Earlier spec editions named six. The reference implementation has always excluded eight.

**How `.dir2mcp` is forced back.** The state directory lives under `root_dir`. To index it is self-referential: the walk reads the index the same run writes, and watch mode feeds its own writes back into ingest. Two layers add the name back.

1. `internal/config` `resolveExcludeDirs` appends `.dir2mcp` when the operator's list omits it, and returns a warning. The loader appends that warning to `cfg.Warnings`, which is the spec's SHOULD ("an implementation MUST add `.dir2mcp/` back, and SHOULD say that it did").
2. `corpusfs.ResolveExcludedDirs` adds it back again, because it is the enforcement point and a direct `corpusfs` caller must not be able to skip the rule.

**One resolved value, three consumers.** The set is resolved in `internal/config`, carried on `ingest.DiscoverOptions.ExcludeDirs` to `corpusfs.Options.ExcludeDirs`, and read by:

- `LocalFS` (`discoverWalker.shouldSkipDirectory`, `internal/corpusfs/local.go`)
- the S3 lister (`keyHasExcludedDir`, `internal/corpusfs/s3.go`)
- the file watcher (`shouldSkipDirectory` in `internal/ingest/gitignore.go`, used from `internal/ingest/watch.go`)

The watcher takes it from the same `DiscoverOptionsFromConfig` the initial scan uses, so parity holds by construction. `corpusfs.IsExcludedDir` is gone: it read the default list only, so keeping it would leave a way to bypass the operator's list. That is the drift #716 fixed and a second copy would undo.

`ExcludedDirSet`'s zero value resolves to the default list, so a consumer that forgets to resolve still excludes `.git` and `.dir2mcp` instead of indexing them.

## The trap, and where it is documented

**The gates are independent and they compose by AND.** A file reaches the index only if the directory ignore list, `security.path_excludes` and the optional `.gitignore` rules ALL admit it.

Five names are in BOTH the default ignore list and the default `security.path_excludes`: `.git`, `.dir2mcp`, `node_modules`, `vendor`, `__pycache__`. An operator who clears only `ingest.exclude_dirs` sees no change for those five, because `path_excludes` drops the same file a moment later. `node_modules` is blocked in retrieval as well (`internal/retrieval/service.go` `defaultPathExcludes`), so it needs a third edit.

The spec requires this to be documented where the key is documented. It is in two places:

1. The config field comment on `Config.IngestExcludeDirs` (`internal/config/config.go`).
2. The `config init` output. `marshalConfigYAML` now has a `writeComment` helper, and the generated `.dir2mcp.yaml` carries the rule above the key:

```yaml
# ingest_exclude_dirs: directory names discovery does not descend into (SPEC 7.1).
# A present key REPLACES this list in full. It does not add to it.
# An entry is a plain directory name. It is not a path and it is not a glob.
# `.dir2mcp` is always kept: the state directory is under root_dir, so to
# index it is self-referential.
# The gates compose by AND. A file is indexed only if this list,
# path_excludes and the optional .gitignore rules all admit it. These five
# names are in BOTH lists: .git, .dir2mcp, node_modules, vendor,
# __pycache__. To re-index one of them, clear the name from BOTH keys.
# Clearing one key alone changes nothing you can see.
ingest_exclude_dirs:
  - .dir2mcp
  ...
```

The loader already skips comment lines, so the generated file still round-trips.

## Also

An entry that is not a plain directory name is rejected at validation: a path (`src/dist`), a glob (`dist/**`), `.` or `..`. SPEC 7.1 says an entry is a name that matches at any depth, so such a value matches nothing. Rejecting it tells the operator at once instead of leaving them to wonder why the directory is still indexed.

## Verification

`make check` passes, `gocyclo -over 15` included. Two functions were extracted to stay inside the budget rather than work around it: `applyIngestExcludeDirsFileParsed` out of `applyIngestModesFileParsed`, and `assertExcludeDirsIsDocumented` out of the new round-trip test. `validateIngestExcludeDirs` is a `Config` method in the validator list, not another branch in `validateNumericBounds`.

Every new test was confirmed to FAIL against `main`, using the copy-aside method (no `git stash`, since `refs/stash` is shared across worktrees):

- `internal/corpusfs/local.go` and `s3.go` restored from `origin/main` (with a temporary `IsExcludedDir` shim so the package still compiled): the four replace-semantics tests failed, and `dist/bundle.js` stayed unindexed. `AlwaysKeepsTheStateDir` and `AbsentKeepsTheDefaults` passed, which is correct, because they encode unchanged behaviour.
- The watcher: `excluded` set to `corpusfs.ExcludedDirSet{}` at both construction points, which reproduces main's hardcoded default set exactly. `TestAddWatchDirs_HonorsConfiguredExcludeDirs` failed: `dist` was not watched and `notes` was.
- The config: the merge branch and the `writeList` call removed, which reproduces main's "no such key". Five config tests failed.

Each file was then restored from its copy and the suites re-run green.

New coverage:

- `tests/corpusfs/exclude_dirs_773_test.go`: drop a name to index `dist/`; replace does not add; `.dir2mcp` forced back; empty list; absent key unchanged; S3 and local parity; the resolver itself.
- `internal/ingest/exclude_dirs_773_test.go`: the watcher registers watches from the operator's list, and skips `.dir2mcp` when the list omits it. It is internal because it drives `addWatchDirs` directly, which is deterministic and does not wait on fsnotify event timing.
- `tests/config/exclude_dirs_773_test.go`: the key spelling (nested and inline), replace semantics, forced `.dir2mcp` plus its warning, empty list, entry-shape rejection.
- `tests/config/generated_config_roundtrip_test.go`: the list key is written by `config init`, documents the AND trap, loads back, and an operator edit that removes `dist` reaches the loader. The existing guard walks SCALAR keys only, so a list key it dropped would have passed unnoticed.
