### PR TITLE
fix(cli): reject stray operands and clear the stale connection file on down (#706, #714)

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -521,6 +521,13 @@ func (a *App) runCommand(ctx context.Context, globalOpts globalOptions, remainin
 	case "down":
 		return a.runDown(ctx, globalOpts, remaining[1:])
 	case "version":
+		// version takes no operands. Reject extra arguments so a typo or a
+		// concatenated command does not look like a success (#706).
+		if extra := remaining[1:]; len(extra) > 0 {
+			writeCLIError(a.stderr, globalOpts.jsonOutput || jsonRequested, exitConfigInvalid,
+				fmt.Sprintf("version command does not accept arguments: %s", strings.Join(extra, " ")))
+			return exitConfigInvalid
+		}
 		if !globalOpts.quiet {
 			writeln(a.stdout, "dir2mcp "+buildinfo.Display())
 		}

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -113,35 +113,46 @@ func (a *App) runConfig(ctx context.Context, global globalOptions, args []string
 	case "secrets":
 		return a.runConfigListSecrets(global, args[1:])
 	case "print":
-		cfg, err := loadConfigWithGlobalOptions(global)
-		if err != nil {
-			writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("load config: %v", err))
-			return exitConfigInvalid
-		}
-		if global.quiet {
-			return exitSuccess
-		}
-		embedProvider, embedReady := "none", false
-		embedBaseURL := ""
-		if ep, perr := cfg.Providers().Resolve(provider.CapEmbed); perr == nil {
-			embedProvider, embedReady = ep.Name, true
-			embedBaseURL = provider.NormalizeEmbedBaseURL(ep)
-		}
-		writef(
-			a.stdout,
-			"root=%s state_dir=%s listen=%s mcp_path=%s embed_provider=%s embed_base_url=%s embed_ready=%t\n",
-			cfg.RootDir,
-			cfg.StateDir,
-			cfg.ListenAddr,
-			cfg.MCPPath,
-			embedProvider,
-			embedBaseURL,
-			embedReady,
-		)
+		return a.runConfigPrint(global, args[1:])
 	default:
 		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("unknown config subcommand: %s", args[0]))
 		return exitConfigInvalid
 	}
+}
+
+// runConfigPrint prints the effective configuration. The subcommand takes no
+// operands. It rejects extra arguments so a typo does not look like a success
+// (#706).
+func (a *App) runConfigPrint(global globalOptions, args []string) int {
+	if len(args) > 0 {
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("config print does not accept arguments: %s", strings.Join(args, " ")))
+		return exitConfigInvalid
+	}
+	cfg, err := loadConfigWithGlobalOptions(global)
+	if err != nil {
+		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, fmt.Sprintf("load config: %v", err))
+		return exitConfigInvalid
+	}
+	if global.quiet {
+		return exitSuccess
+	}
+	embedProvider, embedReady := "none", false
+	embedBaseURL := ""
+	if ep, perr := cfg.Providers().Resolve(provider.CapEmbed); perr == nil {
+		embedProvider, embedReady = ep.Name, true
+		embedBaseURL = provider.NormalizeEmbedBaseURL(ep)
+	}
+	writef(
+		a.stdout,
+		"root=%s state_dir=%s listen=%s mcp_path=%s embed_provider=%s embed_base_url=%s embed_ready=%t\n",
+		cfg.RootDir,
+		cfg.StateDir,
+		cfg.ListenAddr,
+		cfg.MCPPath,
+		embedProvider,
+		embedBaseURL,
+		embedReady,
+	)
 	return exitSuccess
 }
 

--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -90,7 +90,11 @@ func (a *App) downWithoutLiveDaemon(global globalOptions, stateDir, pidPath stri
 		reason, reportedPID = "recycled_pid", pid
 	}
 	if ownership != pidNoFile {
-		_ = removePIDFile(pidPath)
+		// Report a failed removal. The pid record names no live daemon, so the
+		// exit code stays 0, but the operator must know that residue remains.
+		if err := removePIDFile(pidPath); err != nil {
+			writef(a.stderr, "warning: remove pid file %s: %v\n", pidPath, err)
+		}
 	}
 	// No daemon owns this state directory, so any connection.json is residue
 	// from a crashed or already-stopped run. Clients and installers read that

--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -40,30 +40,8 @@ func (a *App) runDown(ctx context.Context, global globalOptions, args []string) 
 
 	pidPath := pidFilePath(cfg.StateDir)
 	pid, ownership := classifyPIDFile(pidPath)
-	switch ownership {
-	case pidNoFile:
-		writeDownInfo(a.stdout, global.jsonOutput, cfg.StateDir, 0, false, "no_pid_file", false)
-		return exitSuccess
-	case pidMalformed:
-		// Malformed pid file is suspicious — surface and continue cleanup so
-		// `down` always leaves a clean state behind.
-		writef(a.stderr, "warning: pid file %s is malformed; removing it\n", pidPath)
-		_ = removePIDFile(pidPath)
-		writeDownInfo(a.stdout, global.jsonOutput, cfg.StateDir, 0, false, "malformed_pid_file", false)
-		return exitSuccess
-	case pidDead:
-		_ = removePIDFile(pidPath)
-		writeDownInfo(a.stdout, global.jsonOutput, cfg.StateDir, pid, false, "stale_pid", false)
-		return exitSuccess
-	case pidRecycled:
-		// The recorded pid is alive but its start-time token no longer matches:
-		// the OS recycled it to an unrelated process after our daemon crashed
-		// without cleanup. Signalling it would SIGTERM/SIGKILL a bystander
-		// (issue #418) — so clean up the stale pid file and stop, killing
-		// nothing.
-		_ = removePIDFile(pidPath)
-		writeDownInfo(a.stdout, global.jsonOutput, cfg.StateDir, pid, false, "recycled_pid", false)
-		return exitSuccess
+	if ownership != pidLive {
+		return a.downWithoutLiveDaemon(global, cfg.StateDir, pidPath, pid, ownership)
 	}
 
 	if err := stopDaemon(pid); err != nil {
@@ -75,19 +53,64 @@ func (a *App) runDown(ctx context.Context, global globalOptions, args []string) 
 		// the user-facing exit code over a leftover file.
 		writef(a.stderr, "warning: remove pid file %s: %v\n", pidPath, err)
 	}
-	// Also remove the connection.json the daemon wrote so a subsequent
-	// `dir2mcp up` doesn't observe a stale "daemon ready" file from the
-	// now-stopped server. See the same cleanup in runUpAsDaemonParent.
-	connPath := connectionFilePath(cfg.StateDir)
-	if err := os.Remove(connPath); err != nil && !errors.Is(err, os.ErrNotExist) {
-		writef(a.stderr, "warning: remove %s: %v\n", connPath, err)
-	}
+	// The daemon is stopped, so its published endpoint is dead. Clear it only
+	// here, after the stop succeeded: a failed stop returns above and keeps
+	// connection.json, because a daemon that still serves must stay reachable.
+	a.clearConnectionFile(cfg.StateDir)
 	// If this corpus is also under launchd/systemd supervision, the daemon we
 	// just stopped will be respawned at next login/boot. Inform the operator
 	// (do NOT auto-uninstall) so `down` in a teardown script isn't mistaken
 	// for a permanent stop (#434).
 	writeDownInfo(a.stdout, global.jsonOutput, cfg.StateDir, pid, true, "stopped", a.corpusServiceManaged(cfg, global))
 	return exitSuccess
+}
+
+// downWithoutLiveDaemon handles every pid classification that proves no owned
+// live daemon exists: no pid file, a malformed record, a dead pid, or a pid the
+// OS recycled to an unrelated process. Each case clears the pid record and the
+// published connection.json, then reports the outcome with exit 0.
+//
+// The pid record goes first and the connection file second. If the command dies
+// between the two steps, the next `down` classifies the corpus as pidNoFile and
+// removes the connection file, so the state directory still converges to clean.
+// A recycled pid is never signalled (#418): the process is a bystander.
+func (a *App) downWithoutLiveDaemon(global globalOptions, stateDir, pidPath string, pid int, ownership pidOwnership) int {
+	// The no-pid-file case reports pid 0, as does a malformed record: neither
+	// names a process the operator can act on.
+	reason, reportedPID := "no_pid_file", 0
+	switch ownership {
+	case pidMalformed:
+		// A malformed pid file is suspicious. Report it, then clean up so
+		// `down` always leaves a clean state behind.
+		writef(a.stderr, "warning: pid file %s is malformed; removing it\n", pidPath)
+		reason = "malformed_pid_file"
+	case pidDead:
+		reason, reportedPID = "stale_pid", pid
+	case pidRecycled:
+		reason, reportedPID = "recycled_pid", pid
+	}
+	if ownership != pidNoFile {
+		_ = removePIDFile(pidPath)
+	}
+	// No daemon owns this state directory, so any connection.json is residue
+	// from a crashed or already-stopped run. Clients and installers read that
+	// file as the connection source, so a successful `down` must not leave a
+	// dead endpoint behind (#714).
+	a.clearConnectionFile(stateDir)
+	writeDownInfo(a.stdout, global.jsonOutput, stateDir, reportedPID, false, reason, false)
+	return exitSuccess
+}
+
+// clearConnectionFile removes the connection.json published for stateDir so a
+// later `up`, client, or bridge does not read a stale endpoint. An absent file
+// is a normal result and keeps `down` idempotent. A removal failure is a
+// warning only: the daemon is already gone, so the leftover file must not
+// change the exit code.
+func (a *App) clearConnectionFile(stateDir string) {
+	connPath := connectionFilePath(stateDir)
+	if err := os.Remove(connPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		writef(a.stderr, "warning: remove %s: %v\n", connPath, err)
+	}
 }
 
 // corpusServiceManaged reports whether a launchd/systemd unit is installed

--- a/tests/cli/command_behavior_test.go
+++ b/tests/cli/command_behavior_test.go
@@ -1046,3 +1046,123 @@ func TestVersionUsesBuildInfo(t *testing.T) {
 		t.Fatalf("version output=%q want=%q", strings.TrimSpace(stdout.String()), want)
 	}
 }
+
+// TestZeroOperandCommandsRejectExtraArgs pins issue #706: `version` and
+// `config print` take no operands. A trailing argument is a typo or a
+// concatenated command, so both must fail with CONFIG_INVALID (exit 2) instead
+// of printing normal output and exiting 0.
+func TestZeroOperandCommandsRejectExtraArgs(t *testing.T) {
+	cases := []struct {
+		name     string
+		args     []string
+		wantText string
+	}{
+		{
+			name:     "version",
+			args:     []string{"version", "extra"},
+			wantText: "version command does not accept arguments: extra",
+		},
+		{
+			name:     "config print",
+			args:     []string{"config", "print", "extra"},
+			wantText: "config print does not accept arguments: extra",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			var stdout, stderr bytes.Buffer
+			app := cli.NewAppWithIO(&stdout, &stderr)
+
+			withWorkingDir(t, tmp, func() {
+				code := app.RunWithContext(context.Background(), tc.args)
+				if code != 2 {
+					t.Fatalf("exit code: got=%d want=2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+				}
+			})
+			if !strings.Contains(stderr.String(), tc.wantText) {
+				t.Fatalf("stderr=%q want it to contain %q", stderr.String(), tc.wantText)
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("stdout must stay empty on a rejected command, got %q", stdout.String())
+			}
+		})
+	}
+}
+
+// TestZeroOperandCommandsRejectExtraArgsJSON covers the same rejection under
+// --json: scripts get the structured CONFIG_INVALID envelope.
+func TestZeroOperandCommandsRejectExtraArgsJSON(t *testing.T) {
+	cases := []struct {
+		name     string
+		args     []string
+		wantText string
+	}{
+		{
+			name:     "version",
+			args:     []string{"--json", "version", "extra"},
+			wantText: "version command does not accept arguments",
+		},
+		{
+			name:     "version trailing json flag",
+			args:     []string{"version", "extra", "--json"},
+			wantText: "version command does not accept arguments",
+		},
+		{
+			name:     "config print",
+			args:     []string{"--json", "config", "print", "extra"},
+			wantText: "config print does not accept arguments",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			var stdout, stderr bytes.Buffer
+			app := cli.NewAppWithIO(&stdout, &stderr)
+
+			withWorkingDir(t, tmp, func() {
+				code := app.RunWithContext(context.Background(), tc.args)
+				if code != 2 {
+					t.Fatalf("exit code: got=%d want=2 stderr=%s", code, stderr.String())
+				}
+			})
+
+			var payload struct {
+				Error struct {
+					Code    string `json:"code"`
+					Message string `json:"message"`
+				} `json:"error"`
+				ExitCode int `json:"exit_code"`
+			}
+			if err := json.Unmarshal(stderr.Bytes(), &payload); err != nil {
+				t.Fatalf("unmarshal error payload: %v raw=%s", err, stderr.String())
+			}
+			if payload.Error.Code != "CONFIG_INVALID" || payload.ExitCode != 2 {
+				t.Fatalf("unexpected payload: %+v", payload)
+			}
+			if !strings.Contains(payload.Error.Message, tc.wantText) {
+				t.Fatalf("message=%q want it to contain %q", payload.Error.Message, tc.wantText)
+			}
+		})
+	}
+}
+
+// TestConfigPrintZeroOperandFormStillWorks: the valid form is unchanged by the
+// stricter argument check.
+func TestConfigPrintZeroOperandFormStillWorks(t *testing.T) {
+	tmp := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+
+	withWorkingDir(t, tmp, func() {
+		code := app.RunWithContext(context.Background(), []string{"config", "print"})
+		if code != 0 {
+			t.Fatalf("exit code: got=%d want=0 stderr=%s", code, stderr.String())
+		}
+	})
+	if !strings.Contains(stdout.String(), "root=") {
+		t.Fatalf("config print output=%q want it to contain root=", stdout.String())
+	}
+}

--- a/tests/cli/down_test.go
+++ b/tests/cli/down_test.go
@@ -117,6 +117,128 @@ func TestDown_RejectsPositionalArguments(t *testing.T) {
 	}
 }
 
+// TestDown_ClearsStaleConnectionFile_ForEveryNonLivePID pins issue #714.
+// Each pid classification below proves that no owned live daemon exists. A
+// successful `down` must therefore clear both the pid record and the published
+// connection.json. A leftover connection.json points clients, bridges, and the
+// legacy remote commands at a dead or reassigned endpoint.
+func TestDown_ClearsStaleConnectionFile_ForEveryNonLivePID(t *testing.T) {
+	const staleConnection = `{"format_version":"0.1.0","url":"http://127.0.0.1:9/mcp"}`
+
+	cases := []struct {
+		name string
+		// seedPID writes the pid file for this classification. A nil value
+		// means "no pid file at all".
+		seedPID    func(t *testing.T, pidPath string)
+		wantReason string
+	}{
+		{
+			name:       "no_pid_file",
+			seedPID:    nil,
+			wantReason: "no_pid_file",
+		},
+		{
+			name: "malformed_pid_file",
+			seedPID: func(t *testing.T, pidPath string) {
+				t.Helper()
+				if err := os.WriteFile(pidPath, []byte("not-a-pid\n"), 0o600); err != nil {
+					t.Fatalf("seed malformed pid file: %v", err)
+				}
+			},
+			wantReason: "malformed_pid_file",
+		},
+		{
+			name: "dead_pid",
+			seedPID: func(t *testing.T, pidPath string) {
+				t.Helper()
+				if err := os.WriteFile(pidPath, []byte("999999\n"), 0o600); err != nil {
+					t.Fatalf("seed stale pid file: %v", err)
+				}
+			},
+			wantReason: "stale_pid",
+		},
+		{
+			name: "recycled_pid",
+			seedPID: func(t *testing.T, pidPath string) {
+				t.Helper()
+				// A live pid (this test process) under a start-time token that
+				// does not match: the signature of a recycled pid. The process
+				// must stay untouched (#418).
+				realToken := requireStartTokens(t)
+				if err := cli.WritePIDRecordForTest(pidPath, os.Getpid(), realToken+"-stale"); err != nil {
+					t.Fatalf("seed recycled pid file: %v", err)
+				}
+			},
+			wantReason: "recycled_pid",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root, stateDir := newDownFixture(t)
+			pidPath := filepath.Join(stateDir, "server.pid")
+			connPath := filepath.Join(stateDir, "connection.json")
+			if tc.seedPID != nil {
+				tc.seedPID(t, pidPath)
+			}
+			if err := os.WriteFile(connPath, []byte(staleConnection), 0o600); err != nil {
+				t.Fatalf("seed connection file: %v", err)
+			}
+
+			var stdout, stderr bytes.Buffer
+			app := cli.NewAppWithIO(&stdout, &stderr)
+			withWorkingDir(t, root, func() {
+				code := app.RunWithContext(context.Background(), []string{"--json", "down"})
+				if code != 0 {
+					t.Fatalf("exit code: got=%d want=0 stderr=%s", code, stderr.String())
+				}
+			})
+
+			var payload struct {
+				Stopped bool   `json:"stopped"`
+				Reason  string `json:"reason"`
+			}
+			if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+				t.Fatalf("unmarshal stdout: %v raw=%s", err, stdout.String())
+			}
+			if payload.Reason != tc.wantReason {
+				t.Errorf("reason: got %q want %q", payload.Reason, tc.wantReason)
+			}
+			if payload.Stopped {
+				t.Errorf("stopped: want false (nothing live to stop) got true")
+			}
+			if _, err := os.Stat(connPath); !os.IsNotExist(err) {
+				t.Errorf("connection.json should have been removed; stat err=%v", err)
+			}
+			if _, err := os.Stat(pidPath); !os.IsNotExist(err) {
+				t.Errorf("pid file should have been removed; stat err=%v", err)
+			}
+		})
+	}
+}
+
+// TestDown_IsIdempotentWithoutConnectionFile: `down` must not fail when there
+// is no connection.json to remove, so teardown scripts can run twice.
+func TestDown_IsIdempotentWithoutConnectionFile(t *testing.T) {
+	root, stateDir := newDownFixture(t)
+	for i := 0; i < 2; i++ {
+		var stdout, stderr bytes.Buffer
+		app := cli.NewAppWithIO(&stdout, &stderr)
+		withWorkingDir(t, root, func() {
+			code := app.RunWithContext(context.Background(), []string{"down"})
+			if code != 0 {
+				t.Fatalf("run %d exit code: got=%d stderr=%s", i, code, stderr.String())
+			}
+		})
+		if strings.Contains(stderr.String(), "warning") {
+			t.Errorf("run %d: unexpected warning: %q", i, stderr.String())
+		}
+	}
+	if _, err := os.Stat(filepath.Join(stateDir, "connection.json")); !os.IsNotExist(err) {
+		t.Errorf("connection.json should not exist; stat err=%v", err)
+	}
+}
+
 // newDownFixture builds a root directory with a .dir2mcp state subdir
 // pre-created. The state dir is what the down command operates on.
 func newDownFixture(t *testing.T) (root, stateDir string) {


### PR DESCRIPTION
Closes #706
Closes #714

Two small CLI correctness fixes in `internal/cli`. They are grouped because
both are argument- and state-hygiene fixes on the same package, and the review
cost of one PR is lower than two.

## #706: `version` and `config print` ignored extra operands

Both commands accepted trailing positional arguments, ignored them, printed
normal output and exited 0. A typo or a concatenated command therefore looked
like a success to a script.

Every other zero-operand command already rejects extra operands with
`CONFIG_INVALID` (exit 2). Both commands now do the same:

```console
$ dir2mcp version extra
error: version command does not accept arguments: extra
$ echo $?
2

$ dir2mcp config print extra
error: config print does not accept arguments: extra
$ echo $?
2
```

The message shape follows the precedent in `status`, `reindex` and
`config init`. Under `--json` the error is the standard `CONFIG_INVALID`
envelope with `exit_code: 2`. The valid zero-operand forms do not change.

The `config print` body moved into its own `runConfigPrint` method. That keeps
the check next to the subcommand it guards, and matches how `config init`,
`config set-secret` and the other subcommands are already structured.

## #714: `down` left a stale `connection.json`

`down` removed `connection.json` only after it stopped a live pid. Each
idempotent "already gone" branch (no pid file, malformed record, dead pid,
recycled pid) returned before that step. A crashed daemon therefore left an
advertised endpoint behind, and `down` reported success. Clients, bridges and
the legacy remote commands read that file as the connection source, so the
residue is actionable: it points at a dead port, or at a port the OS reassigned
to something else.

The four non-live paths now share one helper. They clear the pid record and
the connection file, then report the same outcomes as before.

### The ordering argument

There are three cases, and they want two different orders.

**No owned live daemon (no file, malformed, dead, recycled).** Nothing serves
this state directory, so both files are residue. The pid record goes first and
the connection file second. If the process dies between the two steps, the
next `down` classifies the corpus as `pidNoFile` and removes the connection
file, so the state directory still converges to clean. The reverse order has
no such property: a pid record with no connection file is the shape a starting
daemon has, which is a worse thing to leave behind.

A recycled pid is still never signalled (#418). The process that holds it is a
bystander. Only the two files are touched.

**Live daemon.** The order is unchanged: stop the daemon, remove the pid file,
then clear the connection file. The connection file is cleared last and only
after `stopDaemon` returns without error. If the stop fails, `down` returns
exit 1 and keeps `connection.json` in place, because the daemon still serves
and clients must still be able to reach it. Removing the endpoint of a daemon
we failed to stop would turn a reported failure into a silent outage.

The removal is idempotent: an absent file is a normal result, and a removal
failure is a warning only, so a leftover file never changes the exit code.

A note on the no-pid-file case: every serving process claims the pid file
through `acquireSingleInstanceLock` before it serves, foreground and
service-managed runs included. `pidNoFile` therefore means "no daemon owns
this directory", not "the daemon may be running unrecorded", so the removal is
safe there too.

## Tests

- `tests/cli/down_test.go`: a table over all four non-live classifications
  seeds `connection.json` plus the matching pid record, and asserts that both
  are gone and that the reported reason is unchanged. A second test runs `down`
  twice on a clean directory to pin idempotency when there is no connection
  file to remove.
- `tests/cli/command_behavior_test.go`: `version extra` and
  `config print extra` in plain and `--json` form, including a trailing
  `--json` flag, plus a test that the valid `config print` form still works.

All new tests were verified to FAIL against `main`. The three changed source
files were copied aside, `git checkout origin/main --` restored them, the tests
were run (all six subtests failed with exit 0 and the residue present), and the
files were copied back. `git stash` was not used at any point.

`make check` gates run clean locally: `gofmt`, `go vet`, `golangci-lint`
(0 issues), `gocyclo -over 15`, `ineffassign`, `misspell`, and
`go test ./tests/cli ./tests/security`. Five `TestUp*` daemon tests flake under
full-suite parallel load with `context deadline exceeded` from sqlite; they
pass in isolation and are untouched by this change.

No spec change was needed. bs-001 lists the commands and the exit-code table,
but says nothing about operand arity per command, and exit 2 for an invalid
invocation is already the documented meaning. The submodule pointer is
untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `version` and `config print` now reject unexpected arguments with clear configuration errors in all supported output formats.
  * `down` now cleans up stale connection and process files when no live daemon is running.
  * Repeated `down` commands behave idempotently without unnecessary warnings.
  * Failed daemon shutdowns preserve connection details for troubleshooting.

* **New Features**
  * Added the `config print` command for viewing the effective configuration, including quiet and formatted output options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->