### PR TITLE
fix(mistral): count OCR retries the way every other operation counts them

### DIFF
--- a/internal/mistral/client.go
+++ b/internal/mistral/client.go
@@ -464,25 +464,31 @@ func (c *Client) wait(ctx context.Context, d time.Duration) error {
 }
 
 func (c *Client) Extract(ctx context.Context, relPath string, data []byte) (string, error) {
-	// the public entrypoint simply delegates to a retry-capable helper. the
-	// retry logic mirrors embedBatchWithRetry so that network/rate-limit/5xx
-	// conditions are automatically retried up to configured limits.
+	// The public entrypoint delegates to a retry-capable helper. The retry
+	// logic counts attempts the same way embedBatchWithRetry does, so a
+	// network, rate-limit or 5xx condition gets the same number of retries
+	// here as it gets for an embedding.
 	return c.extractWithRetry(ctx, relPath, data)
 }
 
-// extractWithRetry wraps extractOnce with retry logic similar to
-// embedBatchWithRetry.  Only provider errors marked Retryable will be
-// retried, up to Client.MaxRetries attempts with exponential backoff.
-// The helper intentionally mirrors the structure of embedBatchWithRetry so
-// behaviour is consistent between embedding and OCR operations.
+// extractWithRetry wraps extractOnce with retry logic. Only a provider error
+// marked Retryable is retried, and the operation makes one attempt plus
+// Client.MaxRetries retries, with exponential backoff.
+//
+// This helper counts the same way embedBatchWithRetry, transcribeWithRetry and
+// the generation path count. It did not: it read MaxRetries as a TOTAL attempt
+// count and looped below it, so MaxRetries=1 disabled OCR retry while it gave
+// every other Mistral operation one retry, and the default 3 gave OCR three
+// attempts against their four (#698). A caller who set the most intuitive
+// value got the one operation with no retry at all.
 func (c *Client) extractWithRetry(ctx context.Context, relPath string, data []byte) (string, error) {
-	maxAttempts := c.MaxRetries
-	if maxAttempts <= 0 {
-		maxAttempts = 1
+	maxRetries := c.MaxRetries
+	if maxRetries < 0 {
+		maxRetries = 0
 	}
 
 	var lastErr error
-	for attempt := 0; attempt < maxAttempts; attempt++ {
+	for attempt := 0; attempt <= maxRetries; attempt++ {
 		out, err := c.extractOnce(ctx, relPath, data)
 		if err == nil {
 			return out, nil
@@ -490,7 +496,7 @@ func (c *Client) extractWithRetry(ctx context.Context, relPath string, data []by
 		lastErr = err
 
 		var providerErr *model.ProviderError
-		if !errors.As(err, &providerErr) || !providerErr.Retryable || attempt == maxAttempts-1 {
+		if !errors.As(err, &providerErr) || !providerErr.Retryable || attempt == maxRetries {
 			return "", err
 		}
 

--- a/tests/mistral/ocr_retry_semantics_698_test.go
+++ b/tests/mistral/ocr_retry_semantics_698_test.go
@@ -1,0 +1,119 @@
+package tests
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/mistral"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// #698: OCR read MaxRetries as a TOTAL attempt count and looped below it,
+// while embed, transcribe and generate each make one attempt plus MaxRetries
+// retries. So MaxRetries=1 disabled OCR retry and gave every other operation
+// one retry, and the default 3 gave OCR three attempts against their four.
+//
+// The pre-existing OCR retry test did not catch this. It sets MaxRetries=3 and
+// succeeds on the third attempt, which both countings reach, so it passes
+// either way. These tests count the attempts the client actually makes.
+
+// countingTransport answers every request with the same retryable status and
+// counts the calls, so a test can read how many attempts the client made.
+func countingTransport(status int, body string, counter *int) *http.Client {
+	return &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		*counter++
+		return newJSONResponse(status, body), nil
+	})}
+}
+
+func ocrClient(t *testing.T, maxRetries int, counter *int) *mistral.Client {
+	t.Helper()
+	c := mistral.NewClient("https://api.mistral.ai", "key")
+	c.HTTPClient = countingTransport(http.StatusTooManyRequests, "rate limited", counter)
+	c.MaxRetries = maxRetries
+	// Shrink the backoff so the table below does not sleep through real waits.
+	// A zero falls back to the shipped default, so the value must be positive.
+	c.InitialBackoff = time.Nanosecond
+	c.MaxBackoff = time.Nanosecond
+	return c
+}
+
+// TestOCRMakesOneAttemptPlusMaxRetries is the contract. MaxRetries counts
+// RETRIES, so the total attempt count is always one more than the value.
+func TestOCRMakesOneAttemptPlusMaxRetries(t *testing.T) {
+	for _, tc := range []struct {
+		maxRetries   int
+		wantAttempts int
+	}{
+		{0, 1},  // no retry: one attempt
+		{1, 2},  // the value that used to disable OCR retry entirely
+		{3, 4},  // the shipped default
+		{-1, 1}, // a negative value clamps to no retry
+	} {
+		attempts := 0
+		c := ocrClient(t, tc.maxRetries, &attempts)
+		if _, err := c.Extract(context.Background(), "file.pdf", []byte("data")); err == nil {
+			t.Fatalf("MaxRetries=%d: expected the retryable failure to surface", tc.maxRetries)
+		}
+		if attempts != tc.wantAttempts {
+			t.Errorf("MaxRetries=%d made %d attempts, want %d (one attempt plus MaxRetries retries)",
+				tc.maxRetries, attempts, tc.wantAttempts)
+		}
+	}
+}
+
+// TestOCRRetryCanSucceedOnTheSecondAttempt is the case the old counting broke.
+// With MaxRetries=1 the operation must retry once, so a call that fails once
+// and then succeeds returns the result rather than the first error.
+func TestOCRRetryCanSucceedOnTheSecondAttempt(t *testing.T) {
+	attempts := 0
+	c := mistral.NewClient("https://api.mistral.ai", "key")
+	c.MaxRetries = 1
+	c.InitialBackoff = time.Nanosecond
+	c.MaxBackoff = time.Nanosecond
+	c.HTTPClient = &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		attempts++
+		if attempts == 1 {
+			return newJSONResponse(http.StatusTooManyRequests, "rate limited"), nil
+		}
+		return newJSONResponse(http.StatusOK, `{"pages":[{"markdown":"ok"}]}`), nil
+	})}
+
+	out, err := c.Extract(context.Background(), "file.pdf", []byte("data"))
+	if err != nil {
+		t.Fatalf("MaxRetries=1 must retry once, but the call failed: %v", err)
+	}
+	if out != "ok" {
+		t.Fatalf("output = %q, want the second attempt's result", out)
+	}
+	if attempts != 2 {
+		t.Fatalf("made %d attempts, want 2", attempts)
+	}
+}
+
+// TestOCRAndEmbedAgreeOnTheAttemptCount is the guard against a second drift.
+// The two operations share one MaxRetries field, so the same value must buy
+// the same number of attempts. This is what #698 reported: one field, two
+// meanings, and no test comparing them.
+func TestOCRAndEmbedAgreeOnTheAttemptCount(t *testing.T) {
+	const maxRetries = 2
+
+	ocrAttempts := 0
+	ocr := ocrClient(t, maxRetries, &ocrAttempts)
+	_, _ = ocr.Extract(context.Background(), "file.pdf", []byte("data"))
+
+	embedAttempts := 0
+	embed := mistral.NewClient("https://api.mistral.ai", "key")
+	embed.MaxRetries = maxRetries
+	embed.InitialBackoff = time.Nanosecond
+	embed.MaxBackoff = time.Nanosecond
+	embed.HTTPClient = countingTransport(http.StatusTooManyRequests, "rate limited", &embedAttempts)
+	_, _ = embed.Embed(context.Background(), "mistral-embed", model.EmbedDocument, []string{"x"})
+
+	if ocrAttempts != embedAttempts {
+		t.Fatalf("one MaxRetries value bought %d OCR attempts and %d embed attempts; "+
+			"the field must mean the same thing for both", ocrAttempts, embedAttempts)
+	}
+}


### PR DESCRIPTION
Closes #698.

## The bug

`Client.MaxRetries` meant two different things.

| operation | attempts for `MaxRetries=N` |
|---|---|
| embed, transcribe, generate | `N + 1` |
| **OCR** | **`N`** |

OCR read the field as a TOTAL attempt count and looped below it. So `MaxRetries=1` gave every other operation one retry and gave OCR **none**. The shipped default of 3 gave OCR three attempts against their four.

A caller who picked the most intuitive value got the one operation with no retry at all, and nothing reported it.

## The fix

`extractWithRetry` now clamps a negative value to zero retries and loops through the limit inclusive, which is what `embedBatchWithRetry` does.

Two doc comments claimed the helper already mirrored embed. They described the intent rather than the code, so they are corrected.

## Why the existing test did not catch it

The issue says the old test "codifies the off-by-one behavior". It is worth being exact: it does not.

`TestExtract_RetryableErrorsAreRetried` sets `MaxRetries=3` and succeeds on the third attempt. Both countings reach a third attempt, so the test passes either way. It **failed to detect** the bug rather than pinned it. It still passes unchanged after this fix.

## The new tests

They count the attempts the client actually makes:

- `MaxRetries=0` gives 1 attempt
- `MaxRetries=1` gives 2, and a call that fails once then succeeds now returns the result. That is the case the old counting broke.
- the default `3` gives 4
- a negative value clamps to 1

The last test compares OCR against embed with **one shared value**. That is the guard against a second drift: the field is one field, so it must buy the same number of attempts for both. #698 existed because nothing compared them.

**Confirmed against `main`** with the copy-aside method, not `git stash`:

```
MaxRetries=1 made 1 attempts, want 2
MaxRetries=3 made 3 attempts, want 4
one MaxRetries value bought 2 OCR attempts and 3 embed attempts
```

## One note on the local gate

My first `make check` run failed with two `context deadline exceeded` errors in sqlite init and index load. Neither test touches `internal/mistral`.

They were load-induced: I had four other agents running test suites, and the load average reached 55. Both pass on re-run, and a later full `make check` passes clean. I report this rather than hide it, in case the same pair flakes in CI.