### PR TITLE
fix(store): stop retrieval from serving the chunks of a failed document (#707)

### DIFF
--- a/internal/store/live_parent.go
+++ b/internal/store/live_parent.go
@@ -1,0 +1,26 @@
+package store
+
+// liveParentDocument is the SQL predicate that binds a chunk's liveness to its
+// parent document row (issue #707).
+//
+// A chunk is live only when its parent document is live. The parent is live
+// when it is not tombstoned (deleted = 0) and not in the error state
+// (status != 'error'). A chunk with no document row at all stays live, because
+// the join is a LEFT JOIN and a missing parent is not evidence of a failure.
+//
+// The predicate needs the documents table joined under the alias `d`.
+//
+// Why the invariant is enforced here, and not by a delete on failure: a
+// document goes to `error` for transient reasons too. A provider timeout, a
+// rate limit, or a locked file all set the same status. A delete would throw
+// away work that a later successful scan can reuse. This predicate hides the
+// content while the document is broken, and shows it again the moment the
+// document indexes again. It also keeps one rule in one place, instead of a
+// cleanup step that each failure path must remember to call.
+//
+// PR #456 (issue #425) first added this predicate to the embed queue, so a
+// failed document could not have more chunks embedded. The retrieval paths kept
+// serving the chunks that the document embedded on an earlier good run. The
+// same predicate now applies to lexical search, to vector-hit liveness, and to
+// the related-document seed, so all of them agree about which chunks are live.
+const liveParentDocument = `(d.rel_path IS NULL OR (d.deleted = 0 AND d.status != 'error'))`

--- a/internal/store/sqlite_bm25.go
+++ b/internal/store/sqlite_bm25.go
@@ -33,6 +33,12 @@ import (
 // embedding_status='error'. They must not surface via the lexical/hybrid path,
 // so the WHERE clause excludes them (embedding_status != 'error'). 'pending'
 // chunks remain searchable lexically (they need no embedding to match BM25).
+//
+// Parent filter (#707): a chunk is live only while its document is live, so the
+// WHERE clause also applies liveParentDocument. A document that failed a later
+// scan carries status='error' and keeps the chunks it embedded on an earlier
+// good run. Those chunks stay in the FTS index, so only this query-time filter
+// stops them from being searched and cited while the document is broken.
 func (s *SQLiteStore) SearchBM25(ctx context.Context, query string, k int, indexKind string) ([]model.SearchHit, error) {
 	query = strings.TrimSpace(query)
 	if query == "" {
@@ -76,7 +82,8 @@ func (s *SQLiteStore) SearchBM25(ctx context.Context, query string, k int, index
 	         LEFT JOIN (SELECT chunk_id, span_kind, start, "end", extra_json
 	                    FROM spans GROUP BY chunk_id) sp ON sp.chunk_id = c.chunk_id
 	         WHERE chunks_fts MATCH ? AND c.deleted = 0
-	               AND c.embedding_status != 'error'`
+	               AND c.embedding_status != 'error'
+	               AND ` + liveParentDocument
 	if kind := strings.TrimSpace(indexKind); kind != "" {
 		stmt += ` AND c.index_kind = ?`
 		args = append(args, kind)

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -1889,6 +1889,17 @@ func (s *SQLiteStore) ChunkMediaSpanByID(ctx context.Context, chunkID int64) (re
 // as a safe skip, honoring the tombstone so a job cannot resurrect a deleted
 // chunk (SPEC §6.6, §8.7.3 tombstone safety). textHash is returned separately so
 // a worker can detect a job enqueued for a since-changed chunk.
+//
+// A chunk whose parent document is tombstoned or in the error state is also
+// reported as model.ErrNotFound (liveParentDocument, #707). This method is what
+// retrieval uses to test whether a vector hit is still live, so the predicate
+// keeps a failed document's earlier chunks out of search results, out of the
+// related-document neighbours, and out of the answer context. The retrieval
+// liveness pass also evicts each such chunk from the in-memory vector index, so
+// the hit does not come back on the next query. A document that indexes again
+// gets a fresh set of chunks, which the same pass then admits again. The embed
+// worker sees the same answer, which matches NextPending: it does not embed a
+// chunk of a failed document.
 func (s *SQLiteStore) ChunkTaskByID(ctx context.Context, chunkID uint64) (task model.ChunkTask, textHash string, err error) {
 	if chunkID == 0 {
 		return model.ChunkTask{}, "", model.ErrNotFound
@@ -1915,7 +1926,8 @@ SELECT tc.chunk_id, tc.rel_path, tc.doc_type, tc.rep_type, tc.text, tc.text_hash
        COALESCE(sp.span_kind, ''), COALESCE(sp.start, 0), COALESCE(sp.end, 0), COALESCE(sp.extra_json, ''), COALESCE(d.mtime_unix, 0)
 FROM the_chunk tc
 LEFT JOIN ranked_spans sp ON sp.chunk_id = tc.chunk_id AND sp.rn = 1
-LEFT JOIN documents d ON d.rel_path = tc.rel_path`, int64(chunkID))
+LEFT JOIN documents d ON d.rel_path = tc.rel_path
+WHERE `+liveParentDocument, int64(chunkID))
 
 	var (
 		cid       int64
@@ -1980,6 +1992,11 @@ LEFT JOIN documents d ON d.rel_path = tc.rel_path`, int64(chunkID))
 // them from the neighbours (a document is never related to itself). A rel_path
 // that resolves to no embedded chunk returns an empty slice (the tool maps that
 // to INVALID_FIELD — the source could not be located).
+//
+// The chunks must also have a live parent document (liveParentDocument, #707).
+// A document that is tombstoned or in the error state therefore returns no
+// chunks, so it cannot seed a related-document query with content that the
+// corpus reports as failed.
 func (s *SQLiteStore) EmbeddedChunksByPath(ctx context.Context, relPath string) ([]model.ChunkTask, error) {
 	normalizedPath, err := normalizeRelPath(relPath)
 	if err != nil {
@@ -2009,6 +2026,7 @@ SELECT fc.chunk_id, fc.rel_path, fc.doc_type, fc.rep_type, fc.text, fc.index_kin
 FROM filtered_chunks fc
 LEFT JOIN ranked_spans sp ON sp.chunk_id = fc.chunk_id AND sp.rn = 1
 LEFT JOIN documents d ON d.rel_path = fc.rel_path
+WHERE `+liveParentDocument+`
 ORDER BY fc.chunk_id`, normalizedPath)
 	if err != nil {
 		return nil, err
@@ -2761,7 +2779,7 @@ func nextPendingQuery(indexKind string, limit int) (string, []any) {
 	            FROM chunks c
 	            LEFT JOIN documents d ON d.rel_path = c.rel_path
 	            WHERE c.embedding_status = ? AND c.deleted = 0 AND c.chunk_id > 0
-	              AND (d.rel_path IS NULL OR (d.deleted = 0 AND d.status != 'error'))` + kindPredicate + `
+	              AND ` + liveParentDocument + kindPredicate + `
 	            ORDER BY c.chunk_id
 	            LIMIT ?
 	          )

--- a/tests/store/errored_document_chunks_707_test.go
+++ b/tests/store/errored_document_chunks_707_test.go
@@ -1,0 +1,242 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// newErroredDocStore opens a fresh store for the #707 suite.
+func newErroredDocStore(t *testing.T) *store.SQLiteStore {
+	t.Helper()
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	if err := st.Init(context.Background()); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	return st
+}
+
+// setDocStatus upserts one document row with the given lifecycle status.
+func setDocStatus(t *testing.T, st *store.SQLiteStore, relPath, status string) {
+	t.Helper()
+	if err := st.UpsertDocument(context.Background(), model.Document{
+		RelPath: relPath,
+		DocType: "md",
+		Status:  status,
+	}); err != nil {
+		t.Fatalf("UpsertDocument(%s, %s): %v", relPath, status, err)
+	}
+}
+
+// addEmbeddedChunk inserts one chunk for a document and marks it embedded, so
+// it is live by every chunk-level rule: embedding_status='ok' and deleted=0.
+func addEmbeddedChunk(t *testing.T, st *store.SQLiteStore, id uint64, relPath, text string) {
+	t.Helper()
+	ctx := context.Background()
+	task := model.NewChunkTask(id, text, "text", model.ChunkMetadata{
+		ChunkID: id,
+		RelPath: relPath,
+		DocType: "md",
+		RepType: "raw_text",
+	})
+	if err := st.UpsertChunkTask(ctx, task); err != nil {
+		t.Fatalf("UpsertChunkTask(%d): %v", id, err)
+	}
+	if err := st.MarkEmbedded(ctx, []uint64{id}); err != nil {
+		t.Fatalf("MarkEmbedded(%d): %v", id, err)
+	}
+}
+
+// TestSearchBM25_ExcludesChunksOfErroredDocument is the lexical half of #707.
+//
+// A document indexes and embeds on one run. A later scan fails on it, so
+// persistBuildError writes status='error'. The chunks of the earlier good run
+// keep embedding_status='ok' and deleted=0, and their terms stay in the FTS
+// index, so only a query-time parent filter can hide them. Status and doctor
+// already report the document as failed, so a lexical hit on it would let the
+// corpus cite content that the operator believes is out of service.
+//
+// The test also pins the recovery direction: the chunks come back the moment
+// the document indexes again. That is what makes the query-time filter better
+// than a delete on failure, because a transient failure costs no re-embedding.
+func TestSearchBM25_ExcludesChunksOfErroredDocument(t *testing.T) {
+	ctx := context.Background()
+	st := newErroredDocStore(t)
+
+	const (
+		erroredChunk uint64 = 1
+		healthyChunk uint64 = 2
+	)
+	setDocStatus(t, st, "docs/broken.md", "ok")
+	setDocStatus(t, st, "docs/healthy.md", "ok")
+	addEmbeddedChunk(t, st, erroredChunk, "docs/broken.md", "quarterly revenue reconciliation notes")
+	addEmbeddedChunk(t, st, healthyChunk, "docs/healthy.md", "quarterly planning notes")
+
+	hits, err := st.SearchBM25(ctx, "quarterly", 10, "text")
+	if err != nil {
+		t.Fatalf("SearchBM25 (both documents ok): %v", err)
+	}
+	if len(hits) != 2 {
+		t.Fatalf("got %d hits while both documents are ok, want 2: %+v", len(hits), hits)
+	}
+
+	// The later scan fails on the first document.
+	setDocStatus(t, st, "docs/broken.md", "error")
+
+	hits, err = st.SearchBM25(ctx, "quarterly", 10, "text")
+	if err != nil {
+		t.Fatalf("SearchBM25 (one document errored): %v", err)
+	}
+	if len(hits) != 1 || hits[0].ChunkID != healthyChunk {
+		t.Fatalf("got %+v, want only chunk %d; a document in the error state must not be searchable", hits, healthyChunk)
+	}
+
+	// The document indexes again, so its chunks are live again.
+	setDocStatus(t, st, "docs/broken.md", "ok")
+
+	hits, err = st.SearchBM25(ctx, "quarterly", 10, "text")
+	if err != nil {
+		t.Fatalf("SearchBM25 (document recovered): %v", err)
+	}
+	if len(hits) != 2 {
+		t.Fatalf("got %d hits after the document indexed again, want 2: %+v", len(hits), hits)
+	}
+}
+
+// TestSearchBM25_ExcludesChunksOfDeletedDocument covers the other half of the
+// #707 predicate. MarkDocumentDeleted tombstones the chunks too, so this guards
+// a document row that carries deleted=1 while a chunk row was missed.
+func TestSearchBM25_ExcludesChunksOfDeletedDocument(t *testing.T) {
+	ctx := context.Background()
+	st := newErroredDocStore(t)
+
+	setDocStatus(t, st, "docs/gone.md", "ok")
+	addEmbeddedChunk(t, st, 1, "docs/gone.md", "withdrawn advisory text")
+	if err := st.MarkDocumentDeleted(ctx, "docs/gone.md"); err != nil {
+		t.Fatalf("MarkDocumentDeleted: %v", err)
+	}
+	// Re-mark the chunk live to isolate the parent rule from the chunk rule.
+	if err := st.UpsertChunkTask(ctx, model.NewChunkTask(1, "withdrawn advisory text", "text", model.ChunkMetadata{
+		ChunkID: 1,
+		RelPath: "docs/gone.md",
+		DocType: "md",
+		RepType: "raw_text",
+	})); err != nil {
+		t.Fatalf("UpsertChunkTask (revive chunk): %v", err)
+	}
+	if err := st.MarkEmbedded(ctx, []uint64{1}); err != nil {
+		t.Fatalf("MarkEmbedded: %v", err)
+	}
+
+	hits, err := st.SearchBM25(ctx, "advisory", 10, "text")
+	if err != nil {
+		t.Fatalf("SearchBM25: %v", err)
+	}
+	if len(hits) != 0 {
+		t.Fatalf("got %+v, want no hits; a chunk of a deleted document must not be searchable", hits)
+	}
+}
+
+// TestChunkTaskByID_ErroredDocument is the vector half of #707. Retrieval calls
+// ChunkTaskByID to test whether a vector hit is still live, so this lookup
+// decides whether a failed document's earlier vectors can be returned, reranked
+// and put in the answer context. It must report model.ErrNotFound, which is the
+// signal the liveness pass acts on.
+func TestChunkTaskByID_ErroredDocument(t *testing.T) {
+	ctx := context.Background()
+	st := newErroredDocStore(t)
+
+	setDocStatus(t, st, "docs/broken.md", "ok")
+	addEmbeddedChunk(t, st, 7, "docs/broken.md", "superseded payroll figures")
+
+	if _, _, err := st.ChunkTaskByID(ctx, 7); err != nil {
+		t.Fatalf("ChunkTaskByID while the document is ok: %v", err)
+	}
+
+	setDocStatus(t, st, "docs/broken.md", "error")
+
+	_, _, err := st.ChunkTaskByID(ctx, 7)
+	if !errors.Is(err, model.ErrNotFound) {
+		t.Fatalf("ChunkTaskByID = %v, want model.ErrNotFound; a chunk of a failed document is not live", err)
+	}
+
+	setDocStatus(t, st, "docs/broken.md", "ok")
+	if _, _, err := st.ChunkTaskByID(ctx, 7); err != nil {
+		t.Fatalf("ChunkTaskByID after the document indexed again: %v", err)
+	}
+}
+
+// TestEmbeddedChunksByPath_ErroredDocument is the related-document half of
+// #707. dir2mcp_related seeds a query-by-example from these chunks, so a failed
+// document could otherwise still pull neighbours out of the corpus on the
+// strength of content the corpus reports as failed. An empty result maps to the
+// tool's "source could not be located" answer, which is the honest reply.
+func TestEmbeddedChunksByPath_ErroredDocument(t *testing.T) {
+	ctx := context.Background()
+	st := newErroredDocStore(t)
+
+	setDocStatus(t, st, "docs/broken.md", "ok")
+	addEmbeddedChunk(t, st, 11, "docs/broken.md", "alpha")
+	addEmbeddedChunk(t, st, 12, "docs/broken.md", "beta")
+
+	got, err := st.EmbeddedChunksByPath(ctx, "docs/broken.md")
+	if err != nil {
+		t.Fatalf("EmbeddedChunksByPath while the document is ok: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d chunks while the document is ok, want 2", len(got))
+	}
+
+	setDocStatus(t, st, "docs/broken.md", "error")
+
+	got, err = st.EmbeddedChunksByPath(ctx, "docs/broken.md")
+	if err != nil {
+		t.Fatalf("EmbeddedChunksByPath after the document failed: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("got %+v, want no chunks; a failed document must not seed a related-document query", got)
+	}
+
+	setDocStatus(t, st, "docs/broken.md", "ok")
+	got, err = st.EmbeddedChunksByPath(ctx, "docs/broken.md")
+	if err != nil {
+		t.Fatalf("EmbeddedChunksByPath after the document indexed again: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d chunks after the document indexed again, want 2", len(got))
+	}
+}
+
+// TestLiveChunkRules_TolerateMissingDocumentRow pins the LEFT JOIN half of the
+// #707 predicate. A chunk with no document row stays live on every path. Tests
+// and older data carry such chunks, and a missing parent is not evidence of a
+// failure, so the rule must not hide them.
+func TestLiveChunkRules_TolerateMissingDocumentRow(t *testing.T) {
+	ctx := context.Background()
+	st := newErroredDocStore(t)
+
+	addEmbeddedChunk(t, st, 21, "docs/orphan.md", "orphan chunk text")
+
+	hits, err := st.SearchBM25(ctx, "orphan", 10, "text")
+	if err != nil {
+		t.Fatalf("SearchBM25: %v", err)
+	}
+	if len(hits) != 1 || hits[0].ChunkID != 21 {
+		t.Fatalf("SearchBM25 = %+v, want chunk 21; a chunk with no document row stays live", hits)
+	}
+	if _, _, err := st.ChunkTaskByID(ctx, 21); err != nil {
+		t.Fatalf("ChunkTaskByID: %v", err)
+	}
+	got, err := st.EmbeddedChunksByPath(ctx, "docs/orphan.md")
+	if err != nil {
+		t.Fatalf("EmbeddedChunksByPath: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("EmbeddedChunksByPath = %d chunks, want 1", len(got))
+	}
+}


### PR DESCRIPTION
Closes #707.

## What I re-verified against current `main` (75d1863)

The issue is still accurate. Every claim holds, with one line-number correction:

- `internal/store/sqlite_bm25.go` filters `c.deleted = 0` and `c.embedding_status != 'error'`. It joins `documents` for the title and mtime only. It does not look at `d.status` or `d.deleted`.
- `ChunkTaskByID` (`internal/store/sqlite_store.go`, now around line 1892) checks `chunks.deleted = 0` only.
- `EmbeddedChunksByPath` (around line 1983) checks `embedding_status = 'ok' AND deleted = 0` only.
- `persistBuildError` (`internal/ingest/service.go:2029`) writes `status = "error"` with a single `UpsertDocument`. It does not touch the representations, the chunks or the vectors.
- The parent predicate from PR #456 exists in exactly one place, `nextPendingQuery`. Its text is `(d.rel_path IS NULL OR (d.deleted = 0 AND d.status != 'error'))`.

Two facts that the issue does not state, and that shape the fix:

1. `pruneTombstonedHits` calls `ChunkTaskByID` on the final result set of both `search` and `related`, and evicts each dead chunk from the in-memory vector index. So one change to `ChunkTaskByID` covers the vector path, the rerank path and the answer context.
2. `documents.status` is `NOT NULL DEFAULT 'ok'` and `documents.deleted` is `NOT NULL DEFAULT 0`, so the only NULL case is a chunk with no document row at all.

## The behaviour I chose

**A chunk is live only while its parent document is live. The rule is applied at query time, not by a delete on failure.**

The predicate now lives in one named constant, `liveParentDocument`, and is applied at four sites: the embed queue (unchanged behaviour, same text as before), lexical selection, vector-hit liveness, and the related-document seed.

### Why a stale chunk is not better than no chunk

The alternative is to keep serving the old content, on the argument that a user prefers old content to nothing. That argument fails here for one reason: the rest of dir2mcp already tells the operator the opposite.

- SPEC §3.2: a `file_error` and a `file_skip` "partition the never-indexed set". A document at `status=error` is, by that sentence, a never-indexed document.
- SPEC §7.7: "A coverage gap MUST never be silent, and MUST never be reported as an indexed document."
- SPEC §8.6.12 states the zero-representation to `error` contract. `error` is defined as the state in which no representation survived. A document at `error` that still owns live chunks contradicts the definition of `error`.
- The alias precedent (SPEC §7.9) shows the intended shape of a present-but-not-indexed document: listable and openable, but it contributes "no chunks or embeddings and therefore no retrieval hits".

So `status`, `doctor`, `stats.recent_failures` and `list_files` all report the document as failed while retrieval keeps serving it. The corpus disagrees with itself. That is the same class of defect as #712, where `list_files` reported a `secret_excluded` document as `ok` while every other surface called it a skip. The fix there was to make the surfaces agree, not to soften the report.

The failure mode is also asymmetric:

- A missing hit is **visible and recoverable**. `status` names the file and the reason. The operator can fix the source and re-run.
- A stale hit is **invisible**. The answer carries a citation into a file whose current content no longer contains the cited text. The caller has no way to know. If the edit that broke ingest was the edit that removed sensitive text, dir2mcp keeps serving the text that the operator believes is out of service.

The related precedent settles it. A skipped document is unretrievable, and the spec calls `skip_reasons` the field that "answers what of it is retrievable". A failed document should not be more retrievable than a skipped one.

### Why a query-time filter, and not a tombstone on transition to error

The issue offers both. The filter is better on three counts:

1. **A failure is often transient.** A provider timeout, a rate limit or a locked file all produce the same `status=error`. A delete throws away every chunk and every embedding of the document. The next good scan then has to pay for the whole document again. The filter costs nothing on recovery: `resolveNeedsProcessing` already reprocesses a document whose previous status was `error`, and the content becomes visible again as soon as it does.
2. **The tombstone cannot actually be atomic.** The vectors do not live in SQLite. They live in the in-memory index, or in an external Tier C backend. "Atomically tombstone prior child rows and vectors" would need a new eviction path on every failure site. The liveness pass already evicts, so the filter reuses machinery that is in place and tested.
3. **One rule in one place.** A cleanup step has to be called by every failure path, and a new failure path added later will forget it. `persistBuildError` and the representation-failure path are two such sites today. A predicate on the read side cannot be forgotten.

### Scope

The predicate keeps the exact form PR #456 chose, including `d.rel_path IS NULL`. A chunk with no document row stays live, because a missing parent is not evidence of a failure. Older data and many existing tests carry such chunks, and a test pins that they still surface.

`skipped` and `secret_excluded` are deliberately **not** added to the predicate. This PR fixes the state the issue names. A skipped document produces no representation in the first place, so it has no chunks to hide on the forward path.

`ListEmbeddedChunkMetadata` is deliberately unchanged. It feeds startup reconciliation of the vector index, and it carries a dedicated keyset index plus a query-plan performance test (#732). A failed document's chunks may re-enter the in-memory index on restart, and `ChunkTaskByID` prunes and evicts them on the first query that surfaces one. Filtering the read side is sufficient and leaves the recovery path intact.

## No spec change is needed

I read the spec before choosing. The spec has no sentence of the form "a document at `status=error` MUST NOT be retrievable", and it does not describe the `ok` to `error` transition for a document that already has live chunks. But it also never permits the current behaviour, and §3.2, §7.7 and §8.6.12 make the served corpus the successfully-indexed subset. This PR closes a gap between the code and the spec's own model, so it needs no spec PR and it does not move the submodule pointer. A later editorial clarification in §6.6 or §7.7 that names the transition case would be welcome, but it is not a blocker for this fix.

## Verification

`make check` passes, including `gocyclo -over 15`. The change adds no branches.

Each regression test was confirmed to fail against `main` by the copy-aside method (`cp` the files to a scratch directory, `git checkout origin/main -- internal/store/sqlite_store.go internal/store/sqlite_bm25.go`, run, restore). `git stash` was not used at any point.

Against `main` the four regression tests fail:

```
--- FAIL: TestSearchBM25_ExcludesChunksOfErroredDocument
--- FAIL: TestSearchBM25_ExcludesChunksOfDeletedDocument
--- FAIL: TestChunkTaskByID_ErroredDocument
--- FAIL: TestEmbeddedChunksByPath_ErroredDocument
--- PASS: TestLiveChunkRules_TolerateMissingDocumentRow
```

The last test passes on both sides on purpose. It is the guard against over-filtering, so it must not change.

With the fix, all five pass. Each of the three lifecycle tests also asserts the recovery direction: the content comes back when the document indexes again. That is the property that makes the filter preferable to a delete.

The pre-existing `TestNextPending_ExcludesChunksOfErroredOrDeletedDocuments` and the `NextPendingQueryForTest` SQL-text assertion (#743) both still pass, which proves the extracted constant produces byte-identical SQL for the embed queue.
