### PR TITLE
fix(retrieval): count one moment once in a generated answer (#784)

### DIFF
--- a/internal/retrieval/moments.go
+++ b/internal/retrieval/moments.go
@@ -1,0 +1,112 @@
+package retrieval
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// Moment grouping for the answer path (issue #784).
+//
+// A recognition backend reports one moment once per role. The reference backend
+// reports one pitch twice: once as `pitch` keyed on the pitcher, and once as
+// `at_bat` keyed on the batter. The two annotations carry the same time span on
+// the same file.
+//
+// That split is deliberate, and it must stay. The v1 wire shape holds a flat
+// entity array and one scalar event, so one annotation cannot record that this
+// id pitched and that id batted. Role lives in the granularity of the
+// annotations alone. A merged annotation destroys the role-exact entity filter
+// (dirstral-spec design 0004 section 8, and the filter of PR #789).
+//
+// The cost of the split falls on the answer. Each annotation becomes its own
+// context document, so the generator reads one event as two events and counts
+// it twice. On the pilot corpus, 312 of 346 chunks were such pairs, and `ask`
+// reported that a player "walked twice" when he walked once.
+//
+// Design 0004 section 8 names the remedy that stays inside v1: keep the
+// annotations separate, and group them on the shared time span at answer time.
+// This file does that grouping. It changes the prompt only. Search results,
+// their order, the hits on the ask result, and every span stay as they are.
+
+// moment holds each candidate that reports one event. members are indices into
+// the hit slice, in rank order.
+type moment struct {
+	members []int
+}
+
+// primary returns the index of the best-ranked member. That member represents
+// the moment in the prompt. It returns -1 for a moment with no member, which
+// groupMoments never builds, so a caller can range over any moment slice
+// safely.
+func (m moment) primary() int {
+	if len(m.members) == 0 {
+		return -1
+	}
+	return m.members[0]
+}
+
+// momentKey returns the group key of a recognition annotation. It also reports
+// whether the hit is one.
+//
+// Only a recognition annotation groups. A hit with no attribution keeps its own
+// moment, even if its span equals the span of another hit. Two transcript
+// segments, or an OCR window and a transcript window over the same seconds,
+// carry different text. To collapse them would discard evidence.
+//
+// A span with no end is unknown, so it does not group either. Grouping on an
+// unknown span would put unrelated annotations into one moment.
+func momentKey(h model.SearchHit) (string, bool) {
+	if !strings.EqualFold(strings.TrimSpace(h.Span.Kind), "time") {
+		return "", false
+	}
+	if strings.TrimSpace(h.Span.Event) == "" && len(h.Span.Entities) == 0 {
+		return "", false
+	}
+	if h.Span.EndMS <= 0 || h.Span.EndMS < h.Span.StartMS {
+		return "", false
+	}
+	return h.RelPath + "\x00" + strconv.Itoa(h.Span.StartMS) + "\x00" + strconv.Itoa(h.Span.EndMS), true
+}
+
+// groupMoments collects the hits that report one event into one moment each.
+// Two hits share a moment when both carry a recognition attribution and their
+// (rel_path, start_ms, end_ms) are equal. Every other hit becomes a moment of
+// one member, so a corpus without recognition annotations groups into exactly
+// the hit list it was given.
+//
+// The result keeps the rank order of the hits: a moment holds the position of
+// its best-ranked member, and its members stay in rank order.
+func groupMoments(hits []model.SearchHit) []moment {
+	out := make([]moment, 0, len(hits))
+	byKey := make(map[string]int, len(hits))
+	for i, h := range hits {
+		key, ok := momentKey(h)
+		if !ok {
+			out = append(out, moment{members: []int{i}})
+			continue
+		}
+		if at, seen := byKey[key]; seen {
+			out[at].members = append(out[at].members, i)
+			continue
+		}
+		byKey[key] = len(out)
+		out = append(out, moment{members: []int{i}})
+	}
+	return out
+}
+
+// momentMemberIndices returns the hit indices of the given moments, in rank
+// order. The answer cites every member of each moment it used, because each
+// member is real provenance for the same seconds of the same file. Only the
+// count of events changes, not the evidence a caller can open.
+func momentMemberIndices(moments []moment) []int {
+	out := make([]int, 0, len(moments))
+	for _, m := range moments {
+		out = append(out, m.members...)
+	}
+	sort.Ints(out)
+	return out
+}

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -1638,7 +1638,13 @@ func (s *Service) generateGroundedAnswer(
 	// `hits` and `citations` built above are never mutated, so cited spans
 	// remain byte-for-byte identical to what was retrieved. usedIdx reports
 	// which hits actually reached the model's context window (issue #403 F1).
-	prompt, usedIdx := buildRAGPrompt(question, hits, s.contextTexts(ctx, hits), systemPrompt, maxContextChars, compressor)
+	// Group the candidates that report one moment before the model reads them
+	// (issue #784). A recognition backend reports one moment once per role, so
+	// two candidates can carry the same time span on the same file. One block
+	// per moment stops the generator from counting one event twice. Every
+	// member of a used moment stays citable; see moments.go.
+	moments := groupMoments(hits)
+	prompt, usedIdx := buildRAGPrompt(question, hits, moments, s.contextTexts(ctx, hits, moments), systemPrompt, maxContextChars, compressor)
 	var generated string
 	genErr := usage.TimeStage(ctx, usage.StageGenerate, func() error {
 		var gErr error
@@ -3255,12 +3261,20 @@ func buildFallbackAnswer(question string, hits []model.SearchHit) string {
 	lines := make([]string, 0, len(hits)+1)
 	lines = append(lines, fmt.Sprintf("Question: %s", question))
 	lines = append(lines, "Top context:")
-	limit := len(hits)
+	// List one line per moment, not one per hit (issue #784). Two annotations
+	// of one moment would otherwise fill two of the five lines, and a reader
+	// would count one event twice, exactly as the generator did.
+	moments := groupMoments(hits)
+	limit := len(moments)
 	if limit > 5 {
 		limit = 5
 	}
 	for i := 0; i < limit; i++ {
-		h := hits[i]
+		p := moments[i].primary()
+		if p < 0 || p >= len(hits) {
+			continue
+		}
+		h := hits[p]
 		snippet := truncateSnippet(strings.TrimSpace(h.Snippet), 300)
 		if snippet == "" {
 			snippet = "(no snippet)"
@@ -3286,12 +3300,17 @@ const ragMinDocTextChars = 16
 // store lacks the capability, the chunk id is zero, the lookup fails, or the
 // chunk carries no text (a media chunk), and the builder then falls back to the
 // hit's Snippet. At most ragMaxContextDocs lookups run per ask.
-func (s *Service) contextTexts(ctx context.Context, hits []model.SearchHit) []string {
-	limit := len(hits)
+//
+// moments carries the answer-time grouping (issue #784). Only the primary
+// member of a moment reaches the prompt, so only a primary needs its text. The
+// returned slice stays indexed by HIT index, and an entry that no moment uses
+// stays empty.
+func (s *Service) contextTexts(ctx context.Context, hits []model.SearchHit, moments []moment) []string {
+	limit := len(moments)
 	if limit > ragMaxContextDocs {
 		limit = ragMaxContextDocs
 	}
-	texts := make([]string, limit)
+	texts := make([]string, len(hits))
 	// Copy the store under the guard like every other accessor in this file
 	// (applyRecencyDecay, rerankPool): the field can be reassigned after
 	// construction, so an unguarded read races with that assignment.
@@ -3303,14 +3322,15 @@ func (s *Service) contextTexts(ctx context.Context, hits []model.SearchHit) []st
 		return texts
 	}
 	for i := 0; i < limit; i++ {
-		if hits[i].ChunkID == 0 {
+		p := moments[i].primary()
+		if p < 0 || p >= len(hits) || hits[p].ChunkID == 0 {
 			continue
 		}
-		task, _, err := fetcher.ChunkTaskByID(ctx, hits[i].ChunkID)
+		task, _, err := fetcher.ChunkTaskByID(ctx, hits[p].ChunkID)
 		if err != nil {
 			continue
 		}
-		texts[i] = strings.TrimSpace(task.Text)
+		texts[p] = strings.TrimSpace(task.Text)
 	}
 	return texts
 }
@@ -3331,7 +3351,16 @@ func (s *Service) contextTexts(ctx context.Context, hits []model.SearchHit) []st
 // match-centered window of that size (SPEC §9.4.2, issue #403 F5) rather than a
 // flat 300-rune head, so a clause past the head of a 2500-rune chunk still
 // reaches the model that cites it.
-func buildRAGPrompt(question string, hits []model.SearchHit, fullTexts []string, systemPrompt string, maxContextChars int, compressor contextCompressor) (string, []int) {
+//
+// moments groups the candidates that report one event (issue #784, see
+// moments.go). One block is emitted per moment, and the text of its best-ranked
+// member fills that block. The model therefore reads one moment once, and it
+// can no longer count a role-split recognition annotation as two events. The
+// returned indices name EVERY member of each moment that reached the context,
+// so provenance is unchanged: each member cites the same seconds of the same
+// file that the block quoted. A corpus without recognition annotations groups
+// one hit per moment, so the prompt is byte-identical to before.
+func buildRAGPrompt(question string, hits []model.SearchHit, moments []moment, fullTexts []string, systemPrompt string, maxContextChars int, compressor contextCompressor) (string, []int) {
 	systemPrompt = strings.TrimSpace(systemPrompt)
 	if systemPrompt == "" {
 		systemPrompt = defaultRAGSystemPrompt
@@ -3351,14 +3380,18 @@ func buildRAGPrompt(question string, hits []model.SearchHit, fullTexts []string,
 	b.WriteString("\n\nContext:\n")
 
 	remaining := maxContextChars
-	limit := len(hits)
+	limit := len(moments)
 	if limit > ragMaxContextDocs {
 		limit = ragMaxContextDocs
 	}
 	perDoc := maxContextChars / limitOrOne(limit)
-	used := make([]int, 0, limit)
+	used := make([]moment, 0, limit)
 	for i := 0; i < limit && remaining > 0; i++ {
-		block, ok := ragDocBlock(question, hits[i], docTextAt(fullTexts, i), perDoc, remaining, compressor)
+		p := moments[i].primary()
+		if p < 0 || p >= len(hits) {
+			continue
+		}
+		block, ok := ragDocBlock(question, hits[p], docTextAt(fullTexts, p), perDoc, remaining, compressor)
 		if !ok {
 			// The remaining budget cannot hold a complete, fenced block for this
 			// document. Stop rather than emit a partial one: a truncated block
@@ -3368,9 +3401,9 @@ func buildRAGPrompt(question string, hits []model.SearchHit, fullTexts []string,
 		}
 		b.WriteString(block)
 		remaining -= len([]rune(block))
-		used = append(used, i)
+		used = append(used, moments[i])
 	}
-	return b.String(), used
+	return b.String(), momentMemberIndices(used)
 }
 
 // limitOrOne guards the per-document division against a zero document count.

--- a/tests/retrieval/moment_grouping_784_test.go
+++ b/tests/retrieval/moment_grouping_784_test.go
@@ -1,0 +1,230 @@
+package tests
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
+)
+
+// Answer-time moment grouping (issue #784, dirstral-spec design 0004 §8).
+//
+// A recognition backend reports one moment once per role. The reference backend
+// reports one plate appearance twice: once as `pitch` keyed on the pitcher, and
+// once as `at_bat` keyed on the batter. Both annotations carry the same time
+// span on the same file.
+//
+// The split must stay. The v1 wire shape has a flat entity array and one scalar
+// event, so a merged annotation cannot say which id acted in which role, and the
+// role-exact entity filter of PR #789 dies with it (design 0004 §8). So the
+// answer path groups the two on the shared span instead. The generator then
+// reads one moment once, and it can no longer report a single walk as two.
+//
+// The citations stay complete. Both annotations name the same seconds of the
+// same file, so both are real provenance for what the answer says.
+
+const (
+	walkStartMS = 3725205
+	walkEndMS   = 3733205
+	slamStartMS = 4110000
+	slamEndMS   = 4118000
+
+	batterID  = "player:bryce-eldridge"
+	pitcherID = "player:paxton-schultz"
+)
+
+// ragBlockOpen is the untrusted-document open marker the prompt builder emits.
+// One occurrence is one context document, so counting it counts the moments the
+// model was shown.
+const ragBlockOpen = "<<<BEGIN UNTRUSTED DOCUMENT"
+
+// countBlocks counts the context documents in a prompt. It counts in the
+// Context section only, because the system prompt names the marker as well.
+func countBlocks(t *testing.T, prompt string) int {
+	t.Helper()
+	_, context, ok := strings.Cut(prompt, "\n\nContext:\n")
+	if !ok {
+		t.Fatalf("prompt has no Context section:\n%s", prompt)
+	}
+	return strings.Count(context, ragBlockOpen)
+}
+
+// walkService builds the pilot corpus situation. Chunks 1 and 2 are the two
+// role-keyed annotations of ONE walk, with the identical span. Chunk 3 is a
+// different moment in the same video.
+func walkService(t *testing.T, gen model.Generator) *retrieval.Service {
+	t.Helper()
+	idx := index.NewHNSWIndex("")
+	addAnnotation(t, idx, 1, []float32{1, 0}, "at_bat", []string{batterID}, walkStartMS, walkEndMS)
+	addAnnotation(t, idx, 2, []float32{0.99, 0.01}, "pitch", []string{pitcherID}, walkStartMS, walkEndMS)
+	addAnnotation(t, idx, 3, []float32{0.98, 0.02}, "at_bat", []string{batterID}, slamStartMS, slamEndMS)
+
+	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+		"mistral-embed": {1, 0},
+	}}, gen)
+	svc.SetChunkMetadata(1, model.SearchHit{
+		RelPath: "game.mp4", DocType: "video",
+		Snippet: "At bat: Bryce Eldridge vs Paxton Schultz - Bryce Eldridge walks.",
+		Span: model.Span{
+			Kind: "time", StartMS: walkStartMS, EndMS: walkEndMS,
+			Entities: []string{batterID}, Event: "at_bat",
+		},
+	})
+	svc.SetChunkMetadata(2, model.SearchHit{
+		RelPath: "game.mp4", DocType: "video",
+		Snippet: "Pitch: Paxton Schultz to Bryce Eldridge - Bryce Eldridge walks.",
+		Span: model.Span{
+			Kind: "time", StartMS: walkStartMS, EndMS: walkEndMS,
+			Entities: []string{pitcherID}, Event: "pitch",
+		},
+	})
+	svc.SetChunkMetadata(3, model.SearchHit{
+		RelPath: "game.mp4", DocType: "video",
+		Snippet: "At bat: Bryce Eldridge vs Paxton Schultz - Bryce Eldridge hits a grand slam.",
+		Span: model.Span{
+			Kind: "time", StartMS: slamStartMS, EndMS: slamEndMS,
+			Entities: []string{batterID}, Event: "at_bat",
+		},
+	})
+	return svc
+}
+
+// TestAsk_ShowsOneRoleSplitMomentOnce is the defect. Before the fix the prompt
+// carried one block per annotation, so the model saw the walk twice and
+// answered that the player "walked twice". The model must now see it once.
+func TestAsk_ShowsOneRoleSplitMomentOnce(t *testing.T) {
+	gen := &fakeGenerator{out: "Bryce Eldridge walked once and hit a grand slam. [game.mp4]"}
+	svc := walkService(t, gen)
+
+	if _, err := svc.Ask(context.Background(), "what did Bryce Eldridge do", model.SearchQuery{K: 10}); err != nil {
+		t.Fatalf("Ask: %v", err)
+	}
+	if got := countBlocks(t, gen.lastPrompt); got != 2 {
+		t.Fatalf("prompt held %d context blocks, want 2 (the walk and the grand slam)\n%s", got, gen.lastPrompt)
+	}
+	if got := strings.Count(gen.lastPrompt, "walks."); got != 1 {
+		t.Fatalf("the walk is stated %d times in the prompt, want 1\n%s", got, gen.lastPrompt)
+	}
+	if !strings.Contains(gen.lastPrompt, "grand slam") {
+		t.Fatalf("grouping dropped the other moment\n%s", gen.lastPrompt)
+	}
+}
+
+// TestAsk_KeepsEveryCitationOfAGroupedMoment pins the provenance half of the
+// fix. One block reaches the model, but both annotations of that moment stay
+// cited: each names the same seconds of the same file, so each opens the
+// evidence the answer used.
+func TestAsk_KeepsEveryCitationOfAGroupedMoment(t *testing.T) {
+	gen := &fakeGenerator{out: "Bryce Eldridge walked once and hit a grand slam. [game.mp4]"}
+	svc := walkService(t, gen)
+
+	got, err := svc.Ask(context.Background(), "what did Bryce Eldridge do", model.SearchQuery{K: 10})
+	if err != nil {
+		t.Fatalf("Ask: %v", err)
+	}
+	if len(got.Citations) != 3 {
+		t.Fatalf("got %d citations, want 3 (both roles of the walk, plus the grand slam)", len(got.Citations))
+	}
+	cited := make(map[uint64]model.Span, len(got.Citations))
+	for _, c := range got.Citations {
+		cited[c.ChunkID] = c.Span
+	}
+	for _, id := range []uint64{1, 2, 3} {
+		if _, ok := cited[id]; !ok {
+			t.Fatalf("chunk %d is missing from the citations: %+v", id, got.Citations)
+		}
+	}
+	// The spans must survive byte for byte. Grouping never rewrites a span.
+	for _, id := range []uint64{1, 2} {
+		if cited[id].StartMS != walkStartMS || cited[id].EndMS != walkEndMS {
+			t.Fatalf("chunk %d cites span %d-%d, want %d-%d",
+				id, cited[id].StartMS, cited[id].EndMS, walkStartMS, walkEndMS)
+		}
+	}
+	// The hits are the retrieval result, so they stay untouched as well.
+	if len(got.Hits) != 3 {
+		t.Fatalf("got %d hits, want the 3 retrieved chunks", len(got.Hits))
+	}
+}
+
+// TestFallbackAnswer_ListsOneRoleSplitMomentOnce covers the path with no
+// generator. That answer is user facing too, and it listed the same moment
+// twice for the same reason.
+func TestFallbackAnswer_ListsOneRoleSplitMomentOnce(t *testing.T) {
+	svc := walkService(t, nil)
+
+	got, err := svc.Ask(context.Background(), "what did Bryce Eldridge do", model.SearchQuery{K: 10})
+	if err != nil {
+		t.Fatalf("Ask: %v", err)
+	}
+	if n := strings.Count(got.Answer, "walks."); n != 1 {
+		t.Fatalf("the fallback answer states the walk %d times, want 1\n%s", n, got.Answer)
+	}
+}
+
+// TestAsk_KeepsDistinctMomentsApart guards the fix against over-reach. Two
+// annotations that report different seconds are two moments, so they must stay
+// two blocks even when their text is alike.
+func TestAsk_KeepsDistinctMomentsApart(t *testing.T) {
+	gen := &fakeGenerator{out: "answer [game.mp4]"}
+	idx := index.NewHNSWIndex("")
+	addAnnotation(t, idx, 1, []float32{1, 0}, "at_bat", []string{batterID}, walkStartMS, walkEndMS)
+	addAnnotation(t, idx, 2, []float32{0.99, 0.01}, "at_bat", []string{batterID}, walkStartMS, walkEndMS+1000)
+
+	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+		"mistral-embed": {1, 0},
+	}}, gen)
+	svc.SetChunkMetadata(1, model.SearchHit{
+		RelPath: "game.mp4", DocType: "video", Snippet: "first walk",
+		Span: model.Span{
+			Kind: "time", StartMS: walkStartMS, EndMS: walkEndMS,
+			Entities: []string{batterID}, Event: "at_bat",
+		},
+	})
+	svc.SetChunkMetadata(2, model.SearchHit{
+		RelPath: "game.mp4", DocType: "video", Snippet: "second walk",
+		Span: model.Span{
+			Kind: "time", StartMS: walkStartMS, EndMS: walkEndMS + 1000,
+			Entities: []string{batterID}, Event: "at_bat",
+		},
+	})
+
+	if _, err := svc.Ask(context.Background(), "how many walks", model.SearchQuery{K: 10}); err != nil {
+		t.Fatalf("Ask: %v", err)
+	}
+	if got := countBlocks(t, gen.lastPrompt); got != 2 {
+		t.Fatalf("prompt held %d context blocks, want 2 (two different moments)\n%s", got, gen.lastPrompt)
+	}
+}
+
+// TestAsk_GroupsOnlyRecognitionAnnotations keeps the rule narrow. Two chunks
+// with no recognition attribution can share a time span, for example a
+// transcript window and an OCR window over the same seconds. They carry
+// different text, so they stay two documents and the model reads both.
+func TestAsk_GroupsOnlyRecognitionAnnotations(t *testing.T) {
+	gen := &fakeGenerator{out: "answer [talk.mp4]"}
+	idx := index.NewHNSWIndex("")
+	addVecP(t, idx, 1, []float32{1, 0}, "talk.mp4", "video")
+	addVecP(t, idx, 2, []float32{0.99, 0.01}, "talk.mp4", "video")
+
+	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+		"mistral-embed": {1, 0},
+	}}, gen)
+	span := model.Span{Kind: "time", StartMS: 1000, EndMS: 9000}
+	svc.SetChunkMetadata(1, model.SearchHit{
+		RelPath: "talk.mp4", DocType: "video", Snippet: "the spoken words", Span: span,
+	})
+	svc.SetChunkMetadata(2, model.SearchHit{
+		RelPath: "talk.mp4", DocType: "video", Snippet: "the words on the slide", Span: span,
+	})
+
+	if _, err := svc.Ask(context.Background(), "what was said", model.SearchQuery{K: 10}); err != nil {
+		t.Fatalf("Ask: %v", err)
+	}
+	if got := countBlocks(t, gen.lastPrompt); got != 2 {
+		t.Fatalf("prompt held %d context blocks, want 2 (no attribution, so no grouping)\n%s", got, gen.lastPrompt)
+	}
+}


### PR DESCRIPTION
Closes #784.

## The defect

A recognition backend reports one moment once per role. The reference backend reports one plate appearance twice: once as `pitch` keyed on the pitcher, and once as `at_bat` keyed on the batter. Both annotations carry the same time span on the same file.

Each annotation became its own context document in the prompt. The generator therefore read one event as two events. On the pilot corpus, 312 of 346 chunks were such pairs. `ask` reported that a player "walked twice" when he walked once, and it cited two chunks with the identical span `3725205-3733205`.

The count is the defect. The two citations are not. Both name the same seconds of the same file, so both are real provenance for the same statement.

## Why the annotations stay separate

The v1 wire shape holds a flat entity array and one scalar event. One annotation cannot record that this id pitched and that id batted. Role lives in the granularity of the annotations alone, and a merge destroys the role-exact entity filter that PR #789 shipped. That filter measured 82.6% precision against 52.2%.

dirstral-spec design 0004 section 8 states this, and it names the two lawful options. It calls a merge "not a purely local fix" and it defers a per-entity role structure to a v2 wire change with its own design. The option this PR takes is the first one: keep the annotations separate, and group them on the shared time span at answer time.

## What this PR does

`internal/retrieval/moments.go` groups the candidates that report one event. Two hits share a moment when both carry a recognition attribution and their `(rel_path, start_ms, end_ms)` are equal.

The answer path then works on moments:

- `buildRAGPrompt` emits one block per moment, filled with the text of the best-ranked member. The model reads one moment once.
- `contextTexts` resolves the full chunk text of the primary member only, so the number of store lookups per ask does not grow.
- `buildFallbackAnswer` lists one line per moment. That answer is user facing too, and it listed one moment twice for the same reason.

Two useful effects follow. The document cap (`ragMaxContextDocs`) and the character budget now cover twice as many distinct moments on a role-split corpus. And the context section no longer restates half of the top-k.

## What does not change

- Search results, their order, and every span. The grouping touches the prompt only.
- The hits on the ask result.
- The citations. Every member of a moment that reached the context stays cited, so a caller can still open each annotation.
- The entity filter of #789. `tests/retrieval/annotation_entity_filter_test.go` is untouched and it passes.
- A corpus with no recognition annotations. It groups one hit per moment, so the prompt is byte-identical to before.

## Scope of the grouping

Only a recognition annotation groups. Two chunks with no attribution keep their own moments, even when their spans are equal. A transcript window and an OCR window over the same seconds carry different text, and to collapse them would discard evidence. A span with no end does not group either, because an unknown span cannot identify a moment.

## Tests

`tests/retrieval/moment_grouping_784_test.go` adds five tests:

- the prompt shows a role-split moment once,
- every citation of a grouped moment survives, with its span unchanged,
- the fallback answer lists the moment once,
- two annotations with different spans stay two blocks,
- two chunks with no attribution and one shared span stay two blocks.

The two defect tests were confirmed to FAIL against `main`. I copied `internal/retrieval/service.go` aside, moved `moments.go` out of the tree, checked out `origin/main -- internal/retrieval/service.go`, and ran the suite. `TestAsk_ShowsOneRoleSplitMomentOnce` reported 3 context blocks where 2 are wanted, and `TestFallbackAnswer_ListsOneRoleSplitMomentOnce` reported the walk twice. I then restored my files. No `git stash` was used at any point.

The three guard tests pass on `main` as well, which is the point of a guard.

`make check` passes. The `dirstral-spec` submodule pointer is unchanged, because design 0004 section 8 already sanctions this option.

## What remains open

This PR does not change the candidate pool. Search still returns both annotations of a moment, which is correct for the entity filter and for provenance. A caller that ranks moments rather than chunks is a separate change. The self-collapsing `dedup_retrieval` issue that #784 mentions is also separate and untouched.
