### PR TITLE
fix(x402): persist the nonce-aligned expiry of a payment outcome (#697)

### DIFF
--- a/internal/mcp/payment.go
+++ b/internal/mcp/payment.go
@@ -702,6 +702,13 @@ func paymentOutcomeToRecord(key string, outcome paymentExecutionOutcome) (storep
 		Settled:         outcome.Settled,
 		PaymentResponse: strings.TrimSpace(outcome.PaymentResponse),
 		UpdatedAt:       updatedAt,
+		// Persist the nonce-aligned expiry too. Without it a restart restored the
+		// outcome with a zero ExpiresAt, so pruning fell back to the fixed
+		// paymentOutcomeTTL and dropped an outcome whose nonce was still consumed
+		// in the ledger. A valid idempotent retry then got "nonce already used"
+		// instead of the result it had already paid for (#697). A zero value stays
+		// zero and keeps the fallback.
+		ExpiresAt: outcome.ExpiresAt.UTC(),
 	}, true
 }
 
@@ -715,6 +722,12 @@ func paymentOutcomeFromRecord(rec storepkg.MCPPaymentOutcomeRecord) (paymentExec
 	outcome.Settled = rec.Settled
 	outcome.PaymentResponse = strings.TrimSpace(rec.PaymentResponse)
 	outcome.UpdatedAt = rec.UpdatedAt.UTC()
+	// A row written before the expires_unix column existed reads back as a zero
+	// time. Pruning then uses the UpdatedAt plus TTL fallback, which is the
+	// behavior those rows already had, so an old database still loads (#697).
+	if !rec.ExpiresAt.IsZero() {
+		outcome.ExpiresAt = rec.ExpiresAt.UTC()
+	}
 	if strings.TrimSpace(rec.ResultJSON) != "" {
 		var result toolCallResult
 		if err := json.Unmarshal([]byte(rec.ResultJSON), &result); err != nil {

--- a/internal/store/mcp_payment_outcome_test.go
+++ b/internal/store/mcp_payment_outcome_test.go
@@ -1,0 +1,148 @@
+package store
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestMCPPaymentOutcomeRoundTripsExpiry pins the store half of issue #697. The
+// payment outcome carries a nonce-aligned expiry, and the row must keep it, so a
+// restart restores the real expiry instead of falling back to a fixed TTL on
+// UpdatedAt. A row written without an expiry must still read back with a zero
+// time, which is what an existing database holds after the migration.
+func TestMCPPaymentOutcomeRoundTripsExpiry(t *testing.T) {
+	ctx := context.Background()
+	st := NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+
+	updatedAt := time.Now().UTC().Truncate(time.Second)
+	expiresAt := updatedAt.Add(15 * time.Minute)
+
+	withExpiry := MCPPaymentOutcomeRecord{
+		ExecutionKey: "nonce-a:request-a",
+		StatusCode:   200,
+		ResultJSON:   `{"content":[]}`,
+		Settled:      true,
+		UpdatedAt:    updatedAt,
+		ExpiresAt:    expiresAt,
+	}
+	withoutExpiry := MCPPaymentOutcomeRecord{
+		ExecutionKey: "nonce-b:request-b",
+		StatusCode:   200,
+		ResultJSON:   `{"content":[]}`,
+		Settled:      true,
+		UpdatedAt:    updatedAt,
+	}
+	for _, rec := range []MCPPaymentOutcomeRecord{withExpiry, withoutExpiry} {
+		if err := st.UpsertMCPPaymentOutcome(ctx, rec); err != nil {
+			t.Fatalf("upsert %s: %v", rec.ExecutionKey, err)
+		}
+	}
+
+	byKey := listPaymentOutcomesByKey(t, st)
+	got, ok := byKey[withExpiry.ExecutionKey]
+	if !ok {
+		t.Fatalf("row %s is missing", withExpiry.ExecutionKey)
+	}
+	if !got.ExpiresAt.Equal(expiresAt) {
+		t.Errorf("ExpiresAt=%v, want %v", got.ExpiresAt, expiresAt)
+	}
+
+	got, ok = byKey[withoutExpiry.ExecutionKey]
+	if !ok {
+		t.Fatalf("row %s is missing", withoutExpiry.ExecutionKey)
+	}
+	if !got.ExpiresAt.IsZero() {
+		t.Errorf("ExpiresAt=%v, want a zero time for a row written without one", got.ExpiresAt)
+	}
+
+	// An update must move the expiry too, because settlement rewrites the row.
+	moved := withExpiry
+	moved.ExpiresAt = expiresAt.Add(10 * time.Minute)
+	if err := st.UpsertMCPPaymentOutcome(ctx, moved); err != nil {
+		t.Fatalf("re-upsert %s: %v", moved.ExecutionKey, err)
+	}
+	byKey = listPaymentOutcomesByKey(t, st)
+	if got := byKey[moved.ExecutionKey]; !got.ExpiresAt.Equal(moved.ExpiresAt) {
+		t.Errorf("ExpiresAt after update=%v, want %v", got.ExpiresAt, moved.ExpiresAt)
+	}
+}
+
+// TestMCPPaymentOutcomeMigratesLegacyRow proves the additive migration path:
+// a database whose mcp_payment_outcomes table predates expires_unix gets the
+// column, and the rows it already held read back with a zero expiry.
+func TestMCPPaymentOutcomeMigratesLegacyRow(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "meta.sqlite")
+
+	legacy := NewSQLiteStore(path)
+	if err := legacy.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	db, err := legacy.ensureDB(ctx)
+	if err != nil {
+		t.Fatalf("ensureDB: %v", err)
+	}
+	// Recreate the pre-#697 table shape and put one row in it.
+	stmts := []string{
+		`DROP TABLE mcp_payment_outcomes`,
+		`CREATE TABLE mcp_payment_outcomes (
+		  execution_key TEXT PRIMARY KEY,
+		  status_code INTEGER NOT NULL,
+		  result_json TEXT NOT NULL DEFAULT '',
+		  rpc_error_json TEXT NOT NULL DEFAULT '',
+		  requires_settle INTEGER NOT NULL DEFAULT 0,
+		  settled INTEGER NOT NULL DEFAULT 0,
+		  payment_response TEXT NOT NULL DEFAULT '',
+		  updated_unix INTEGER NOT NULL
+		)`,
+		`INSERT INTO mcp_payment_outcomes(execution_key, status_code, result_json, settled, updated_unix)
+		 VALUES('legacy-key', 200, '{"content":[]}', 1, 1700000000)`,
+	}
+	for _, stmt := range stmts {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			t.Fatalf("prepare legacy schema: %v", err)
+		}
+	}
+	legacy.ReleaseDB()
+	if err := legacy.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Re-open. Init runs the additive migration on the legacy table.
+	upgraded := NewSQLiteStore(path)
+	if err := upgraded.Init(ctx); err != nil {
+		t.Fatalf("re-Init: %v", err)
+	}
+	defer func() { _ = upgraded.Close() }()
+
+	byKey := listPaymentOutcomesByKey(t, upgraded)
+	got, ok := byKey["legacy-key"]
+	if !ok {
+		t.Fatalf("the legacy row did not survive the migration")
+	}
+	if !got.ExpiresAt.IsZero() {
+		t.Errorf("legacy ExpiresAt=%v, want a zero time", got.ExpiresAt)
+	}
+	if !got.Settled || got.StatusCode != 200 {
+		t.Errorf("legacy row changed: settled=%v status=%d", got.Settled, got.StatusCode)
+	}
+}
+
+func listPaymentOutcomesByKey(t *testing.T, st *SQLiteStore) map[string]MCPPaymentOutcomeRecord {
+	t.Helper()
+	records, err := st.ListMCPPaymentOutcomes(context.Background())
+	if err != nil {
+		t.Fatalf("list payment outcomes: %v", err)
+	}
+	byKey := make(map[string]MCPPaymentOutcomeRecord, len(records))
+	for _, rec := range records {
+		byKey[rec.ExecutionKey] = rec
+	}
+	return byKey
+}

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -116,6 +116,12 @@ type MCPPaymentOutcomeRecord struct {
 	Settled         bool
 	PaymentResponse string
 	UpdatedAt       time.Time
+	// ExpiresAt is the nonce-aligned lifetime of the outcome. The adapter keeps
+	// the outcome until this time, so an idempotent retry of the same
+	// (nonce, request) pair can get the recorded result for as long as the
+	// nonce ledger keeps the nonce consumed. A zero value means the row is from
+	// an older schema; the caller then uses the fixed TTL fallback (#697).
+	ExpiresAt time.Time
 }
 
 // MCPNonceLedgerRecord is the durable single-use replay ledger entry for an x402
@@ -757,6 +763,15 @@ func applyAdditiveColumnMigrations(ctx context.Context, db *sql.DB) error {
 		// credential and made no request at all. Existing rows default to 0,
 		// which the aggregate reports as "unknown age" rather than as 1970.
 		`ALTER TABLE chunks ADD COLUMN embedding_failed_unix INTEGER NOT NULL DEFAULT 0`,
+		// expires_unix stores the nonce-aligned lifetime of a persisted x402
+		// payment outcome (issue #697). The in-memory outcome already carried
+		// this time, but the row did not, so a restart fell back to the fixed
+		// 10-minute TTL on UpdatedAt. The nonce ledger keeps a consumed nonce
+		// for at least 15 minutes, so a valid idempotent retry inside that gap
+		// found the outcome gone and got "nonce already used" instead of the
+		// result it had already paid for. Existing rows default to 0, which
+		// reads back as a zero time and keeps the old TTL fallback.
+		`ALTER TABLE mcp_payment_outcomes ADD COLUMN expires_unix INTEGER NOT NULL DEFAULT 0`,
 	}
 	for _, stmt := range migrations {
 		if _, err := db.ExecContext(ctx, stmt); err != nil && !isDuplicateColumnError(err) {
@@ -879,7 +894,8 @@ CREATE TABLE IF NOT EXISTS mcp_payment_outcomes (
   requires_settle INTEGER NOT NULL DEFAULT 0,
   settled INTEGER NOT NULL DEFAULT 0,
   payment_response TEXT NOT NULL DEFAULT '',
-  updated_unix INTEGER NOT NULL
+  updated_unix INTEGER NOT NULL,
+  expires_unix INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS mcp_nonce_ledger (
@@ -3423,8 +3439,8 @@ func (s *SQLiteStore) UpsertMCPPaymentOutcome(ctx context.Context, rec MCPPaymen
 		ctx,
 		`INSERT INTO mcp_payment_outcomes(
 			execution_key, status_code, result_json, rpc_error_json,
-			requires_settle, settled, payment_response, updated_unix
-		) VALUES(?, ?, ?, ?, ?, ?, ?, ?)
+			requires_settle, settled, payment_response, updated_unix, expires_unix
+		) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(execution_key) DO UPDATE SET
 			status_code=excluded.status_code,
 			result_json=excluded.result_json,
@@ -3432,7 +3448,8 @@ func (s *SQLiteStore) UpsertMCPPaymentOutcome(ctx context.Context, rec MCPPaymen
 			requires_settle=excluded.requires_settle,
 			settled=excluded.settled,
 			payment_response=excluded.payment_response,
-			updated_unix=excluded.updated_unix`,
+			updated_unix=excluded.updated_unix,
+			expires_unix=excluded.expires_unix`,
 		rec.ExecutionKey,
 		rec.StatusCode,
 		strings.TrimSpace(rec.ResultJSON),
@@ -3441,8 +3458,27 @@ func (s *SQLiteStore) UpsertMCPPaymentOutcome(ctx context.Context, rec MCPPaymen
 		boolToInt(rec.Settled),
 		strings.TrimSpace(rec.PaymentResponse),
 		rec.UpdatedAt.UTC().Unix(),
+		optionalUnix(rec.ExpiresAt),
 	)
 	return err
+}
+
+// optionalUnix encodes a time that may be unset. A zero time becomes 0, not the
+// year-1 Unix value, so a reader can tell "no time recorded" from a real time.
+func optionalUnix(t time.Time) int64 {
+	if t.IsZero() {
+		return 0
+	}
+	return t.UTC().Unix()
+}
+
+// timeFromOptionalUnix is the inverse of optionalUnix. A value of 0 or less
+// becomes a zero time, which every caller reads as "no time recorded".
+func timeFromOptionalUnix(unix int64) time.Time {
+	if unix <= 0 {
+		return time.Time{}
+	}
+	return time.Unix(unix, 0).UTC()
 }
 
 func (s *SQLiteStore) DeleteMCPPaymentOutcome(ctx context.Context, executionKey string) error {
@@ -3469,7 +3505,7 @@ func (s *SQLiteStore) ListMCPPaymentOutcomes(ctx context.Context) ([]MCPPaymentO
 
 	rows, err := db.QueryContext(
 		ctx,
-		`SELECT execution_key, status_code, result_json, rpc_error_json, requires_settle, settled, payment_response, updated_unix
+		`SELECT execution_key, status_code, result_json, rpc_error_json, requires_settle, settled, payment_response, updated_unix, expires_unix
 		 FROM mcp_payment_outcomes
 		 ORDER BY updated_unix DESC`,
 	)
@@ -3484,6 +3520,7 @@ func (s *SQLiteStore) ListMCPPaymentOutcomes(ctx context.Context) ([]MCPPaymentO
 			rec                     MCPPaymentOutcomeRecord
 			requiresSettle, settled int
 			updatedUnix             int64
+			expiresUnix             int64
 		)
 		if err := rows.Scan(
 			&rec.ExecutionKey,
@@ -3494,12 +3531,14 @@ func (s *SQLiteStore) ListMCPPaymentOutcomes(ctx context.Context) ([]MCPPaymentO
 			&settled,
 			&rec.PaymentResponse,
 			&updatedUnix,
+			&expiresUnix,
 		); err != nil {
 			return nil, err
 		}
 		rec.RequiresSettle = requiresSettle == 1
 		rec.Settled = settled == 1
 		rec.UpdatedAt = time.Unix(updatedUnix, 0).UTC()
+		rec.ExpiresAt = timeFromOptionalUnix(expiresUnix)
 		out = append(out, rec)
 	}
 	return out, rows.Err()

--- a/tests/mcp/x402_outcome_expiry_697_test.go
+++ b/tests/mcp/x402_outcome_expiry_697_test.go
@@ -1,0 +1,200 @@
+package tests
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// v2PaymentSignature697 builds a minimal x402 v2 PAYMENT-SIGNATURE value. The
+// adapter reads the single-use authorization nonce and the validity window from
+// it, so the test drives the real nonce path and not the opaque-token fallback.
+func v2PaymentSignature697(nonce string, now time.Time) string {
+	return fmt.Sprintf(
+		`{"x402Version":2,"scheme":"exact","payload":{"authorization":{"nonce":%q,"validAfter":%d,"validBefore":%d}}}`,
+		nonce, now.Add(-5*time.Second).Unix(), now.Add(5*time.Minute).Unix(),
+	)
+}
+
+// agePersistedPaymentOutcomes697 moves every persisted payment outcome's
+// UpdatedAt into the past. It only rewrites UpdatedAt: every other field of the
+// record, including the nonce-aligned expiry, is written back unchanged. The
+// consumed nonce keeps its own ledger expiry, which is at least 15 minutes, so
+// an age past the 10-minute outcome TTL puts the two windows out of step.
+func agePersistedPaymentOutcomes697(t *testing.T, st *store.SQLiteStore, age time.Duration) int {
+	t.Helper()
+	records, err := st.ListMCPPaymentOutcomes(t.Context())
+	if err != nil {
+		t.Fatalf("list payment outcomes: %v", err)
+	}
+	for _, rec := range records {
+		rec.UpdatedAt = time.Now().UTC().Add(-age)
+		if err := st.UpsertMCPPaymentOutcome(t.Context(), rec); err != nil {
+			t.Fatalf("age payment outcome %s: %v", rec.ExecutionKey, err)
+		}
+	}
+	return len(records)
+}
+
+// TestX402OutcomeExpirySurvivesRestart697 pins issue #697. A settled outcome
+// carries a nonce-aligned ExpiresAt so it stays available for as long as its
+// nonce stays consumed. That expiry was not persisted, so a restart restored the
+// outcome with a zero expiry and pruning fell back to the fixed 10-minute TTL on
+// UpdatedAt. The nonce ledger keeps a consumed nonce for at least 15 minutes, so
+// inside that 5-minute gap an exact idempotent retry lost its outcome and was
+// refused as "nonce already used" instead of getting the paid result.
+//
+// The test crosses the 10-minute boundary while the nonce is still live, then
+// repeats the identical call against a new server on the same store.
+func TestX402OutcomeExpirySurvivesRestart697(t *testing.T) {
+	fac := newFacilitatorStub(t)
+	facServer := httptest.NewServer(fac)
+	defer facServer.Close()
+
+	cfg := x402EnabledTestConfig("https://resource.example.com")
+	cfg.AuthMode = "none"
+	cfg.X402.FacilitatorURL = facServer.URL
+
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	if err := st.Init(t.Context()); err != nil {
+		t.Fatalf("Init store: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+
+	const paidCall = `{"jsonrpc":"2.0","id":697,"method":"tools/call","params":{"name":"dir2mcp_stats","arguments":{}}}`
+	sig := v2PaymentSignature697("nonce-697-a", time.Now().UTC())
+
+	// First server: the paid call verifies, executes and settles exactly once.
+	server1 := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st)).Handler())
+	session1 := initializeSession(t, server1.URL+cfg.MCPPath)
+	resp1 := postRPCWithHeaders(t, server1.URL+cfg.MCPPath, session1, paidCall, map[string]string{"PAYMENT-SIGNATURE": sig})
+	body1, _ := io.ReadAll(resp1.Body)
+	_ = resp1.Body.Close()
+	if resp1.StatusCode != http.StatusOK {
+		t.Fatalf("paid call status=%d want=200 body=%s", resp1.StatusCode, string(body1))
+	}
+	if fac.verifyCalls.Load() != 1 || fac.settleCalls.Load() != 1 {
+		t.Fatalf("after the paid call: verify=%d settle=%d, want 1/1", fac.verifyCalls.Load(), fac.settleCalls.Load())
+	}
+	server1.Close()
+
+	// Age the stored outcome past the fixed 10-minute fallback TTL. The nonce
+	// ledger entry is untouched and still has about 4 minutes to run.
+	if n := agePersistedPaymentOutcomes697(t, st, 11*time.Minute); n != 1 {
+		t.Fatalf("persisted payment outcomes=%d, want 1", n)
+	}
+
+	// Second server on the same store. The identical call is an exact idempotent
+	// retry of the same (nonce, request) pair, so it must return the recorded
+	// result without a second verify, execution or settle.
+	server2 := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st)).Handler())
+	defer server2.Close()
+	session2 := initializeSession(t, server2.URL+cfg.MCPPath)
+	resp2 := postRPCWithHeaders(t, server2.URL+cfg.MCPPath, session2, paidCall, map[string]string{"PAYMENT-SIGNATURE": sig})
+	body2, _ := io.ReadAll(resp2.Body)
+	defer func() { _ = resp2.Body.Close() }()
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("idempotent retry after restart status=%d want=200 body=%s", resp2.StatusCode, string(body2))
+	}
+	if strings.TrimSpace(resp2.Header.Get("PAYMENT-RESPONSE")) == "" {
+		t.Error("idempotent retry is missing the PAYMENT-RESPONSE header")
+	}
+	if got := fac.verifyCalls.Load(); got != 1 {
+		t.Errorf("verify calls after restart=%d, want 1 (no re-verification)", got)
+	}
+	if got := fac.settleCalls.Load(); got != 1 {
+		t.Errorf("settle calls after restart=%d, want 1 (no re-settlement)", got)
+	}
+}
+
+// TestX402RestoredOutcomeStillRefusesReplay697 is the safety half of #697. The
+// fix keeps a settled outcome alive for longer, so it must not make a replay
+// succeed. Replay classification keys off the authorization nonce and the
+// logical request, never off the presence of a cached outcome: the retained
+// outcome is reachable only under its own execution key, which is
+// nonce + canonical request.
+//
+// The test reaches the exact state the fix creates, an outcome restored past the
+// 10-minute fallback with a live consumed nonce, then presents the SAME nonce
+// with a DIFFERENT request. The adapter must reject it and must not verify,
+// execute or settle again.
+func TestX402RestoredOutcomeStillRefusesReplay697(t *testing.T) {
+	fac := newFacilitatorStub(t)
+	facServer := httptest.NewServer(fac)
+	defer facServer.Close()
+
+	cfg := x402EnabledTestConfig("https://resource.example.com")
+	cfg.AuthMode = "none"
+	cfg.X402.FacilitatorURL = facServer.URL
+
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	if err := st.Init(t.Context()); err != nil {
+		t.Fatalf("Init store: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+
+	const paidCall = `{"jsonrpc":"2.0","id":697,"method":"tools/call","params":{"name":"dir2mcp_stats","arguments":{}}}`
+	// A different logical request under the same nonce: same tool, different
+	// arguments, so the canonical request key differs.
+	const replayedCall = `{"jsonrpc":"2.0","id":698,"method":"tools/call","params":{"name":"dir2mcp_stats","arguments":{"include_skipped":true}}}`
+	sig := v2PaymentSignature697("nonce-697-b", time.Now().UTC())
+
+	server1 := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st)).Handler())
+	session1 := initializeSession(t, server1.URL+cfg.MCPPath)
+	resp1 := postRPCWithHeaders(t, server1.URL+cfg.MCPPath, session1, paidCall, map[string]string{"PAYMENT-SIGNATURE": sig})
+	body1, _ := io.ReadAll(resp1.Body)
+	_ = resp1.Body.Close()
+	if resp1.StatusCode != http.StatusOK {
+		t.Fatalf("paid call status=%d want=200 body=%s", resp1.StatusCode, string(body1))
+	}
+	server1.Close()
+
+	if n := agePersistedPaymentOutcomes697(t, st, 11*time.Minute); n != 1 {
+		t.Fatalf("persisted payment outcomes=%d, want 1", n)
+	}
+
+	server2 := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st)).Handler())
+	defer server2.Close()
+	session2 := initializeSession(t, server2.URL+cfg.MCPPath)
+
+	verifyBefore := fac.verifyCalls.Load()
+	settleBefore := fac.settleCalls.Load()
+
+	resp2 := postRPCWithHeaders(t, server2.URL+cfg.MCPPath, session2, replayedCall, map[string]string{"PAYMENT-SIGNATURE": sig})
+	body2, _ := io.ReadAll(resp2.Body)
+	defer func() { _ = resp2.Body.Close() }()
+	if resp2.StatusCode != http.StatusPaymentRequired {
+		t.Fatalf("replay status=%d want=402 body=%s", resp2.StatusCode, string(body2))
+	}
+	if !strings.Contains(string(body2), "nonce already used") {
+		t.Errorf("replay response does not name the reused nonce: %s", string(body2))
+	}
+	if got := fac.verifyCalls.Load(); got != verifyBefore {
+		t.Errorf("verify calls during the replay=%d, want %d (no re-verification)", got, verifyBefore)
+	}
+	if got := fac.settleCalls.Load(); got != settleBefore {
+		t.Errorf("settle calls during the replay=%d, want %d (no second settlement)", got, settleBefore)
+	}
+
+	// The retained outcome must not leak into the replay response either.
+	if strings.TrimSpace(resp2.Header.Get("PAYMENT-RESPONSE")) != "" {
+		t.Error("replay response carries a PAYMENT-RESPONSE header")
+	}
+
+	// The legitimate retry of the ORIGINAL request still works, so the rejection
+	// above is a request mismatch and not a lost outcome.
+	resp3 := postRPCWithHeaders(t, server2.URL+cfg.MCPPath, session2, paidCall, map[string]string{"PAYMENT-SIGNATURE": sig})
+	body3, _ := io.ReadAll(resp3.Body)
+	defer func() { _ = resp3.Body.Close() }()
+	if resp3.StatusCode != http.StatusOK {
+		t.Fatalf("idempotent retry status=%d want=200 body=%s", resp3.StatusCode, string(body3))
+	}
+}

--- a/tests/mcp/x402_outcome_expiry_697_test.go
+++ b/tests/mcp/x402_outcome_expiry_697_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/dirstral/dir2mcp/internal/mcp"
 	"github.com/dirstral/dir2mcp/internal/store"
+	"github.com/dirstral/dir2mcp/internal/x402"
 )
 
 // v2PaymentSignature697 builds a minimal x402 v2 PAYMENT-SIGNATURE value. The
@@ -22,6 +24,33 @@ func v2PaymentSignature697(nonce string, now time.Time) string {
 		`{"x402Version":2,"scheme":"exact","payload":{"authorization":{"nonce":%q,"validAfter":%d,"validBefore":%d}}}`,
 		nonce, now.Add(-5*time.Second).Unix(), now.Add(5*time.Minute).Unix(),
 	)
+}
+
+// rpcPaymentError697 is the JSON-RPC error a payment rejection returns. The
+// `data` fields are the machine-readable contract a client acts on; the message
+// is human-facing text.
+type rpcPaymentError697 struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    struct {
+		Code      string `json:"code"`
+		Retryable bool   `json:"retryable"`
+	} `json:"data"`
+}
+
+// decodeRPCPaymentError697 extracts the JSON-RPC error from a response body.
+func decodeRPCPaymentError697(t *testing.T, body []byte) rpcPaymentError697 {
+	t.Helper()
+	var parsed struct {
+		Error *rpcPaymentError697 `json:"error"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("decode the payment error: %v body=%s", err, string(body))
+	}
+	if parsed.Error == nil {
+		t.Fatalf("the response carries no JSON-RPC error: %s", string(body))
+	}
+	return *parsed.Error
 }
 
 // agePersistedPaymentOutcomes697 moves every persisted payment outcome's
@@ -174,7 +203,16 @@ func TestX402RestoredOutcomeStillRefusesReplay697(t *testing.T) {
 	if resp2.StatusCode != http.StatusPaymentRequired {
 		t.Fatalf("replay status=%d want=402 body=%s", resp2.StatusCode, string(body2))
 	}
-	if !strings.Contains(string(body2), "nonce already used") {
+	// Assert on the structured error first, because that is the contract a
+	// client reads. The message text is a secondary, human-facing check.
+	rejection := decodeRPCPaymentError697(t, body2)
+	if rejection.Data.Code != x402.CodePaymentInvalid {
+		t.Errorf("replay error code=%q, want %q", rejection.Data.Code, x402.CodePaymentInvalid)
+	}
+	if rejection.Data.Retryable {
+		t.Error("replay error is marked retryable; a reused nonce is a terminal rejection")
+	}
+	if !strings.Contains(rejection.Message, "nonce already used") {
 		t.Errorf("replay response does not name the reused nonce: %s", string(body2))
 	}
 	if got := fac.verifyCalls.Load(); got != verifyBefore {

--- a/tests/store/mcp_payment_outcome_expiry_697_test.go
+++ b/tests/store/mcp_payment_outcome_expiry_697_test.go
@@ -1,10 +1,14 @@
-package store
+package tests
 
 import (
 	"context"
 	"path/filepath"
 	"testing"
 	"time"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/dirstral/dir2mcp/internal/store"
 )
 
 // TestMCPPaymentOutcomeRoundTripsExpiry pins the store half of issue #697. The
@@ -14,7 +18,7 @@ import (
 // time, which is what an existing database holds after the migration.
 func TestMCPPaymentOutcomeRoundTripsExpiry(t *testing.T) {
 	ctx := context.Background()
-	st := NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
 	if err := st.Init(ctx); err != nil {
 		t.Fatalf("Init: %v", err)
 	}
@@ -23,7 +27,7 @@ func TestMCPPaymentOutcomeRoundTripsExpiry(t *testing.T) {
 	updatedAt := time.Now().UTC().Truncate(time.Second)
 	expiresAt := updatedAt.Add(15 * time.Minute)
 
-	withExpiry := MCPPaymentOutcomeRecord{
+	withExpiry := store.MCPPaymentOutcomeRecord{
 		ExecutionKey: "nonce-a:request-a",
 		StatusCode:   200,
 		ResultJSON:   `{"content":[]}`,
@@ -31,20 +35,20 @@ func TestMCPPaymentOutcomeRoundTripsExpiry(t *testing.T) {
 		UpdatedAt:    updatedAt,
 		ExpiresAt:    expiresAt,
 	}
-	withoutExpiry := MCPPaymentOutcomeRecord{
+	withoutExpiry := store.MCPPaymentOutcomeRecord{
 		ExecutionKey: "nonce-b:request-b",
 		StatusCode:   200,
 		ResultJSON:   `{"content":[]}`,
 		Settled:      true,
 		UpdatedAt:    updatedAt,
 	}
-	for _, rec := range []MCPPaymentOutcomeRecord{withExpiry, withoutExpiry} {
+	for _, rec := range []store.MCPPaymentOutcomeRecord{withExpiry, withoutExpiry} {
 		if err := st.UpsertMCPPaymentOutcome(ctx, rec); err != nil {
 			t.Fatalf("upsert %s: %v", rec.ExecutionKey, err)
 		}
 	}
 
-	byKey := listPaymentOutcomesByKey(t, st)
+	byKey := listPaymentOutcomesByKey697(t, st)
 	got, ok := byKey[withExpiry.ExecutionKey]
 	if !ok {
 		t.Fatalf("row %s is missing", withExpiry.ExecutionKey)
@@ -67,7 +71,7 @@ func TestMCPPaymentOutcomeRoundTripsExpiry(t *testing.T) {
 	if err := st.UpsertMCPPaymentOutcome(ctx, moved); err != nil {
 		t.Fatalf("re-upsert %s: %v", moved.ExecutionKey, err)
 	}
-	byKey = listPaymentOutcomesByKey(t, st)
+	byKey = listPaymentOutcomesByKey697(t, st)
 	if got := byKey[moved.ExecutionKey]; !got.ExpiresAt.Equal(moved.ExpiresAt) {
 		t.Errorf("ExpiresAt after update=%v, want %v", got.ExpiresAt, moved.ExpiresAt)
 	}
@@ -78,17 +82,18 @@ func TestMCPPaymentOutcomeRoundTripsExpiry(t *testing.T) {
 // column, and the rows it already held read back with a zero expiry.
 func TestMCPPaymentOutcomeMigratesLegacyRow(t *testing.T) {
 	ctx := context.Background()
-	path := filepath.Join(t.TempDir(), "meta.sqlite")
+	dbPath := filepath.Join(t.TempDir(), "meta.sqlite")
 
-	legacy := NewSQLiteStore(path)
+	legacy := store.NewSQLiteStore(dbPath)
 	if err := legacy.Init(ctx); err != nil {
 		t.Fatalf("Init: %v", err)
 	}
-	db, err := legacy.ensureDB(ctx)
-	if err != nil {
-		t.Fatalf("ensureDB: %v", err)
+	if err := legacy.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
 	}
-	// Recreate the pre-#697 table shape and put one row in it.
+
+	// Recreate the pre-#697 table shape out-of-band and put one row in it.
+	raw := openRaw(t, dbPath)
 	stmts := []string{
 		`DROP TABLE mcp_payment_outcomes`,
 		`CREATE TABLE mcp_payment_outcomes (
@@ -105,23 +110,22 @@ func TestMCPPaymentOutcomeMigratesLegacyRow(t *testing.T) {
 		 VALUES('legacy-key', 200, '{"content":[]}', 1, 1700000000)`,
 	}
 	for _, stmt := range stmts {
-		if _, err := db.ExecContext(ctx, stmt); err != nil {
-			t.Fatalf("prepare legacy schema: %v", err)
+		if _, err := raw.ExecContext(ctx, stmt); err != nil {
+			t.Fatalf("prepare the legacy schema: %v", err)
 		}
 	}
-	legacy.ReleaseDB()
-	if err := legacy.Close(); err != nil {
-		t.Fatalf("Close: %v", err)
+	if err := raw.Close(); err != nil {
+		t.Fatalf("close the raw connection: %v", err)
 	}
 
 	// Re-open. Init runs the additive migration on the legacy table.
-	upgraded := NewSQLiteStore(path)
+	upgraded := store.NewSQLiteStore(dbPath)
 	if err := upgraded.Init(ctx); err != nil {
 		t.Fatalf("re-Init: %v", err)
 	}
 	defer func() { _ = upgraded.Close() }()
 
-	byKey := listPaymentOutcomesByKey(t, upgraded)
+	byKey := listPaymentOutcomesByKey697(t, upgraded)
 	got, ok := byKey["legacy-key"]
 	if !ok {
 		t.Fatalf("the legacy row did not survive the migration")
@@ -130,17 +134,26 @@ func TestMCPPaymentOutcomeMigratesLegacyRow(t *testing.T) {
 		t.Errorf("legacy ExpiresAt=%v, want a zero time", got.ExpiresAt)
 	}
 	if !got.Settled || got.StatusCode != 200 {
-		t.Errorf("legacy row changed: settled=%v status=%d", got.Settled, got.StatusCode)
+		t.Errorf("the legacy row changed: settled=%v status=%d", got.Settled, got.StatusCode)
+	}
+
+	// The upgraded row must now accept and keep an expiry.
+	got.ExpiresAt = time.Now().UTC().Add(15 * time.Minute).Truncate(time.Second)
+	if err := upgraded.UpsertMCPPaymentOutcome(ctx, got); err != nil {
+		t.Fatalf("upsert the migrated row: %v", err)
+	}
+	if after := listPaymentOutcomesByKey697(t, upgraded)["legacy-key"]; !after.ExpiresAt.Equal(got.ExpiresAt) {
+		t.Errorf("ExpiresAt on the migrated row=%v, want %v", after.ExpiresAt, got.ExpiresAt)
 	}
 }
 
-func listPaymentOutcomesByKey(t *testing.T, st *SQLiteStore) map[string]MCPPaymentOutcomeRecord {
+func listPaymentOutcomesByKey697(t *testing.T, st *store.SQLiteStore) map[string]store.MCPPaymentOutcomeRecord {
 	t.Helper()
 	records, err := st.ListMCPPaymentOutcomes(context.Background())
 	if err != nil {
 		t.Fatalf("list payment outcomes: %v", err)
 	}
-	byKey := make(map[string]MCPPaymentOutcomeRecord, len(records))
+	byKey := make(map[string]store.MCPPaymentOutcomeRecord, len(records))
 	for _, rec := range records {
 		byKey[rec.ExecutionKey] = rec
 	}


### PR DESCRIPTION
Closes #697.

## The bug

`paymentExecutionOutcome.ExpiresAt` is the nonce-aligned lifetime of a settled outcome. The adapter keeps the outcome until that time so an exact idempotent retry of the same `(nonce, request)` pair gets the recorded result and is never charged twice. `prunePaymentOutcomesLocked` honours it for both TTL eviction and capacity eviction.

The row did not hold that time. `MCPPaymentOutcomeRecord` had `UpdatedAt` and no `ExpiresAt`, and neither `paymentOutcomeToRecord` nor `paymentOutcomeFromRecord` mapped it. After a restart every outcome came back with a zero expiry, so pruning fell back to the fixed 10-minute `paymentOutcomeTTL` on `UpdatedAt`.

The nonce ledger keeps a consumed nonce for at least 15 minutes (`nonceLedgerDefaultTTL`). The default configuration therefore has a 5-minute gap where the nonce is still consumed but its outcome is already deleted. In that gap `classifyNonce` returns `nonceConsumed`, `resurfaceConsumedOutcome` finds nothing, and the server answers a valid retry with:

```
payment rejected: authorization nonce already used
```

I re-verified this on current `main` (`f406823`). The issue's claims all still hold, at `internal/mcp/payment.go`, `internal/mcp/server.go` and `internal/store/sqlite_store.go`.

## The fix

- `MCPPaymentOutcomeRecord` gains `ExpiresAt`.
- `mcp_payment_outcomes` gains `expires_unix INTEGER NOT NULL DEFAULT 0`, in the table DDL and as an additive `ALTER TABLE ADD COLUMN` migration.
- The upsert writes it and the list statement reads it.
- `paymentOutcomeToRecord` / `paymentOutcomeFromRecord` map the field.

A zero time is stored as `0`, not as the year-1 Unix value, and reads back as a zero time. An existing row therefore keeps exactly the previous `UpdatedAt` plus TTL fallback, so an old database still loads and behaves as before.

## Why this does not make a replay succeed

No part of the replay decision changed. The retained outcome is not itself an authorisation, and it is never what admits a request.

1. **Reachability is keyed by the nonce.** A cached outcome is only reachable under its execution key, which is `replayNonce(...) + ":" + canonicalPaymentRequestKey(rawParams, requirement)`. A request that does not present the same nonce AND the same canonical params AND the same full `PaymentRequirements` fingerprint computes a different key and misses the cache. Longer retention cannot widen that.
2. **Cross-request replay is still rejected before verify.** After the cache miss, `classifyNonce` compares the ledger entry's `RequestKey`. A different request under the same nonce is `nonceReplay` and goes to `rejectReplayedNonce`. The facilitator is never called, so an idempotent-success or sandbox facilitator cannot re-approve it.
3. **The nonce is still single-use.** `commitNonce` is unchanged and the ledger is unchanged. This PR touches only the outcome table.
4. **An expired proof still cannot reach the cache.** `v2ProofError` runs first, before `replayCachedPaymentOutcomeIfAny`, and rejects a proof whose window does not cover now or whose age exceeds the matched `maxTimeoutSeconds` (#699). A retained outcome cannot be resurfaced by a stale proof.
5. **Retention is bounded and shrinks, it does not grow.** The persisted expiry is the same `pc.expiresAt` the in-memory path already used: `nonceLedgerTTL`, which is capped by `nonceLedgerMaxTTL` (24h). Before this PR a restored outcome lived for 10 minutes past its last write with no relation to its nonce. Now it lives exactly as long as its nonce does, which is what #421 and #699 assume.

`TestX402RestoredOutcomeStillRefusesReplay697` proves point 2 in the exact state the fix creates.

## Tests

`tests/mcp/x402_outcome_expiry_697_test.go`

- `TestX402OutcomeExpirySurvivesRestart697` settles a paid call, moves only the persisted `UpdatedAt` to 11 minutes ago (leaving the consumed nonce with about 4 minutes to run), starts a new `Server` on the same store, and repeats the identical call. It asserts HTTP 200, a `PAYMENT-RESPONSE` header, and `verify == 1 && settle == 1`.
- `TestX402RestoredOutcomeStillRefusesReplay697` reaches the same restored state, then presents the SAME nonce with DIFFERENT arguments. It asserts HTTP 402 naming the reused nonce, no extra verify or settle call, and no `PAYMENT-RESPONSE` header. It then repeats the ORIGINAL request and asserts it still replays, so the rejection is a request mismatch and not a lost outcome.

Both use a real x402 v2 payload with an authorisation nonce and a validity window, so they drive the nonce path and not the opaque-token fallback.

`internal/store/mcp_payment_outcome_test.go`

- `TestMCPPaymentOutcomeRoundTripsExpiry`: the expiry round-trips, an update moves it, and a row written without one reads back as a zero time.
- `TestMCPPaymentOutcomeMigratesLegacyRow`: builds the pre-#697 table shape with a row in it, reopens the store, and asserts the migration adds the column, the row survives, and its expiry is zero.

### Confirmed failing against `main`

I checked both server tests against `main` with the copy-aside method (no `git stash`): copied my `internal/store/sqlite_store.go` and `internal/mcp/payment.go` to a scratch directory, ran `git checkout origin/main -- <those two files>`, ran the tests, and restored my copies.

```
=== RUN   TestX402OutcomeExpirySurvivesRestart697
    idempotent retry after restart status=402 want=200
    body={"error":{"message":"payment rejected: authorization nonce already used", ...}}
--- FAIL: TestX402OutcomeExpirySurvivesRestart697
=== RUN   TestX402RestoredOutcomeStillRefusesReplay697
    idempotent retry status=402 want=200
    body={"error":{"message":"payment rejected: authorization nonce already used", ...}}
--- FAIL: TestX402RestoredOutcomeStillRefusesReplay697
```

That is the reported symptom exactly. Note the second test's replay rejection passes on `main` too, which is the point: it passes before and after, so it shows the fix did not weaken it.

## Spec

No spec change is needed. `dirstral-spec/docs/x402-payment-adapter-spec.md` already requires this. "On success the adapter MUST retain the settled outcome and re-surface it on any idempotent retry of the same `(nonce, request)` pair (never a re-charge)", and the *Payment state model* requires a consumed nonce to survive process restart "for at least its validity window". The code did not do that across a restart. The submodule pointer is untouched.

## Checks

`make check` passes, including `gocyclo -over 15`, `golangci-lint` and `misspell`. No helper needed extracting; the change adds no branches to any existing function.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Payment outcome expiration timestamps are now preserved across updates and server restarts.
  - Previously stored payment records continue to work with the existing expiration fallback.
  - Identical requests can reliably retrieve valid cached payment results without repeat processing.
  - Replay attempts using a consumed nonce remain rejected, while legitimate original requests stay idempotent.
- **Reliability**
  - Improved consistency for payment outcome expiration and replay protection across restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->