### PR TITLE
fix(mcp): hide a nested dotfile when list_files excludes hidden paths (#693)

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -3313,19 +3313,15 @@ func normalizeFileStatus(status string) string {
 	}
 }
 
+// isListFilesNoisePath reports whether `list_files` hides a row when the caller
+// asks for `include_hidden=false`.
+//
+// The rule itself lives in relpath.IsHidden, next to the SQL form the store
+// pages with (relpath.NotHiddenSQL). Both listing paths must hide the same rows:
+// this Go form runs in the walk fallback, the SQL form runs in every production
+// listing, and a caller cannot tell which one served the page.
 func isListFilesNoisePath(relPath string) bool {
-	normalized := strings.TrimSpace(filepath.ToSlash(relPath))
-	if normalized == "" {
-		return false
-	}
-	first := normalized
-	if idx := strings.IndexByte(normalized, '/'); idx >= 0 {
-		first = normalized[:idx]
-	}
-	if strings.HasPrefix(first, ".") {
-		return true
-	}
-	return false
+	return relpath.IsHidden(filepath.ToSlash(relPath))
 }
 
 // looksLikeBinaryContent reports whether the payload is unsafe to surface as

--- a/internal/relpath/hidden.go
+++ b/internal/relpath/hidden.go
@@ -19,10 +19,10 @@ import (
 //
 // The input is slash-separated, as every corpus rel_path is (see Normalize,
 // which rejects a backslash). The path is cleaned first, so `./docs/.env` and
-// `docs/x/../.env` give the same answer as `docs/.env`. An empty path, `.` and
-// `..` name no file, so they are not hidden. A path that still starts with
-// `../` after cleaning is hidden: it is not a valid rel_path at all, and a
-// listing filter must fail toward hiding.
+// `docs/x/../.env` give the same answer as `docs/.env`. An empty path and `.`
+// name no file, so they are not hidden. `..`, and any path that still starts
+// with `../` after cleaning, are hidden: they are not valid rel_paths at all,
+// and a listing filter must fail toward hiding.
 //
 // NotHiddenSQL is the SQL form of this rule. Change the two together.
 func IsHidden(rel string) bool {

--- a/internal/relpath/hidden.go
+++ b/internal/relpath/hidden.go
@@ -1,0 +1,58 @@
+package relpath
+
+import (
+	"path"
+	"strings"
+)
+
+// IsHidden reports whether a corpus-relative path is hidden.
+//
+// A path is hidden when ANY of its segments starts with a dot. `docs/.env`,
+// `docs/.git/config` and `.claude/settings.json` are all hidden;
+// `docs/v1.2/file.md` is not, because a dot inside a name is an ordinary
+// character.
+//
+// This is the one rule for `list_files include_hidden=false` (#693). The old
+// rule looked at the FIRST segment only, so a dotfile below a visible directory
+// was listed as an ordinary file and the flag's meaning changed with directory
+// depth.
+//
+// The input is slash-separated, as every corpus rel_path is (see Normalize,
+// which rejects a backslash). The path is cleaned first, so `./docs/.env` and
+// `docs/x/../.env` give the same answer as `docs/.env`. An empty path, `.` and
+// `..` name no file, so they are not hidden. A path that still starts with
+// `../` after cleaning is hidden: it is not a valid rel_path at all, and a
+// listing filter must fail toward hiding.
+//
+// NotHiddenSQL is the SQL form of this rule. Change the two together.
+func IsHidden(rel string) bool {
+	cleaned := path.Clean(strings.TrimSpace(rel))
+	if cleaned == "." || cleaned == "/" {
+		return false
+	}
+	for _, segment := range strings.Split(cleaned, "/") {
+		if segment != "." && strings.HasPrefix(segment, ".") {
+			return true
+		}
+	}
+	return false
+}
+
+// NotHiddenSQL is IsHidden as a SQL predicate over column: it keeps the rows
+// IsHidden calls visible, and drops the rest.
+//
+// A store that pages in SQL cannot call IsHidden per row and still report an
+// honest total, so the rule has to exist in both forms. It lives beside IsHidden
+// so the pair stays in step; #716 is what a second, distant copy costs.
+//
+// The two forms agree byte for byte on every stored rel_path, because a stored
+// rel_path is already cleaned and slash-separated: it has no `./` prefix, no
+// `.` or `..` segment, and no trailing slash. So "some segment starts with a
+// dot" is exactly "the path starts with a dot, or it contains `/.`". Neither
+// `.` nor `/` is a LIKE metacharacter, so no ESCAPE clause is needed.
+//
+// column must be a trusted identifier from the caller's own SQL, never user
+// input.
+func NotHiddenSQL(column string) string {
+	return "(" + column + " NOT LIKE '.%' AND " + column + " NOT LIKE '%/.%')"
+}

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -2215,14 +2215,10 @@ func (s *SQLiteStore) ListFiles(ctx context.Context, prefix, glob string, limit,
 //
 // The MCP handler used to apply that policy in Go, which forced it to walk the
 // whole matching corpus from offset zero on every single call just to know how
-// many rows survived. The predicate is exactly "the normalized rel_path starts
-// with a dot": mcp.isListFilesNoisePath takes the FIRST '/'-delimited segment
-// and tests strings.HasPrefix(first, "."), and testing the first segment's
-// prefix is testing the whole string's prefix. rel_paths are stored
-// filepath.Clean'd and slash-normalized (see normalizeRelPath), with no leading
-// "./" and no "." or ".." components, so `rel_path NOT LIKE '.%'` is a
-// byte-for-byte equivalent — and '.' is not a LIKE metacharacter, so no ESCAPE
-// clause is needed.
+// many rows survived. The policy is "hide a path when ANY segment starts with a
+// dot" (#693), and relpath.NotHiddenSQL is that rule in SQL. It sits beside
+// relpath.IsHidden, the Go form the handler's walk fallback uses, so the two
+// cannot drift apart.
 //
 // Adding it to `where` is what makes this worth doing: the same slice is
 // threaded through whereClause into the SQL LIMIT/OFFSET page query, into
@@ -2261,7 +2257,7 @@ func (s *SQLiteStore) ListVisibleFiles(ctx context.Context, prefix, glob string,
 		prefixArgs = append(prefixArgs, escapeLike(normalizedPrefix)+"%")
 	}
 	if !includeHidden {
-		where = append(where, `rel_path NOT LIKE '.%'`)
+		where = append(where, relpath.NotHiddenSQL("rel_path"))
 	}
 	whereClause := " WHERE " + strings.Join(where, " AND ")
 

--- a/tests/mcp/list_files_nested_hidden_693_test.go
+++ b/tests/mcp/list_files_nested_hidden_693_test.go
@@ -1,0 +1,142 @@
+package tests
+
+import (
+	"context"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// #693: `list_files` with `include_hidden=false` still returned nested
+// dotfiles and dot-directories, because the hidden-path predicate tested the
+// FIRST path segment only. A caller that asked not to see hidden entries saw
+// `docs/.env`, `docs/.git/config` and `docs/public/.private/key.txt`, and the
+// `total` counted them too.
+//
+// The rule now tests every segment. These tests drive the real tool, and they
+// drive it over BOTH listing paths: the SQL pushdown that production takes, and
+// the walk fallback for a store without the ListVisibleFiles capability. The
+// two paths hold two copies of the rule, and a caller cannot tell which one
+// served the page.
+
+// hiddenCorpus693 pairs each seeded path with the visibility the tool must give
+// it when include_hidden=false.
+var hiddenCorpus693 = []struct {
+	relPath string
+	hidden  bool
+}{
+	{relPath: "a.md", hidden: false},
+	{relPath: "docs/readme.md", hidden: false},
+	{relPath: "docs/v1.2/file.md", hidden: false}, // a dot INSIDE a name stays visible
+	{relPath: ".env", hidden: true},
+	{relPath: ".claude/settings.json", hidden: true},
+	{relPath: "docs/.env", hidden: true},
+	{relPath: "docs/.git/config", hidden: true},
+	{relPath: "docs/public/.private/key.txt", hidden: true},
+	{relPath: "a/b/c/.deep/d/e.md", hidden: true},
+}
+
+func TestListFilesHidesNestedDotPaths_693(t *testing.T) {
+	for _, arm := range []struct {
+		name     string
+		walkOnly bool
+	}{
+		{name: "sql pushdown", walkOnly: false},
+		{name: "walk fallback", walkOnly: true},
+	} {
+		t.Run(arm.name, func(t *testing.T) {
+			tmp, root, st := seedHiddenCorpus693(t)
+			var lister model.Store = st
+			if arm.walkOnly {
+				lister = walkOnly694{st}
+			}
+
+			var wantVisible, wantAll []string
+			for _, doc := range hiddenCorpus693 {
+				wantAll = append(wantAll, doc.relPath)
+				if !doc.hidden {
+					wantVisible = append(wantVisible, doc.relPath)
+				}
+			}
+
+			excluded := listFilesPage694(t, tmp, root, lister, `"limit":50,"offset":0,"include_hidden":false`)
+			assertRelPathSet694(t, "include_hidden=false", excluded, wantVisible)
+			if excluded.Total != int64(len(wantVisible)) {
+				t.Fatalf("include_hidden=false total=%d want %d; the total must count the "+
+					"same rows the page is drawn from (#693)", excluded.Total, len(wantVisible))
+			}
+
+			// include_hidden=true keeps the inclusive behavior it always had.
+			included := listFilesPage694(t, tmp, root, lister, `"limit":50,"offset":0,"include_hidden":true`)
+			assertRelPathSet694(t, "include_hidden=true", included, wantAll)
+			if included.Total != int64(len(wantAll)) {
+				t.Fatalf("include_hidden=true total=%d want %d", included.Total, len(wantAll))
+			}
+		})
+	}
+}
+
+// TestListFilesPagesOnlyVisibleRows_693 walks the default listing one row per
+// page. `files`, `total`, `limit` and `offset` must all describe the same
+// filtered set, so a client looping `while offset < total` sees every visible
+// file once and no hidden file at all.
+func TestListFilesPagesOnlyVisibleRows_693(t *testing.T) {
+	tmp, root, st := seedHiddenCorpus693(t)
+
+	var wantVisible []string
+	for _, doc := range hiddenCorpus693 {
+		if !doc.hidden {
+			wantVisible = append(wantVisible, doc.relPath)
+		}
+	}
+
+	seen := make(map[string]bool, len(wantVisible))
+	for offset := 0; offset < len(hiddenCorpus693)+1; offset++ {
+		page := listFilesPage694(t, tmp, root, st,
+			`"limit":1,"offset":`+strconv.Itoa(offset)+`,"include_hidden":false`)
+		if page.Total != int64(len(wantVisible)) {
+			t.Fatalf("offset=%d total=%d want %d", offset, page.Total, len(wantVisible))
+		}
+		if int64(offset) >= page.Total {
+			break
+		}
+		for _, f := range page.Files {
+			if seen[f.RelPath] {
+				t.Fatalf("offset=%d repeated %q", offset, f.RelPath)
+			}
+			seen[f.RelPath] = true
+		}
+	}
+
+	for _, want := range wantVisible {
+		if !seen[want] {
+			t.Fatalf("the page walk never saw %q (saw %v)", want, keysOf694(seen))
+		}
+	}
+	if len(seen) != len(wantVisible) {
+		t.Fatalf("the page walk saw %v, want %v", keysOf694(seen), wantVisible)
+	}
+}
+
+func seedHiddenCorpus693(t *testing.T) (stateDir, root string, st *store.SQLiteStore) {
+	t.Helper()
+	tmp := t.TempDir()
+	st = store.NewSQLiteStore(filepath.Join(tmp, "meta.sqlite"))
+	if err := st.Init(context.Background()); err != nil {
+		t.Fatalf("init store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	root = filepath.Join(tmp, "corpus")
+	docs := make([]model.Document, 0, len(hiddenCorpus693))
+	for i, doc := range hiddenCorpus693 {
+		docs = append(docs, model.Document{
+			RelPath: doc.relPath, DocType: "md", MTimeUnix: int64(100 * (i + 1)), Status: "ok",
+		})
+	}
+	seedCorpus(t, st, root, docs)
+	return tmp, root, st
+}

--- a/tests/mcp/list_files_page_694_test.go
+++ b/tests/mcp/list_files_page_694_test.go
@@ -111,9 +111,9 @@ func TestListFilesDeepPageDoesNotRestartFromZero_694(t *testing.T) {
 }
 
 // TestListFilesHiddenFilteringSurvivesTheSQLPushdown_694 pins the translation
-// itself. The Go predicate looks at the FIRST path segment only, so
-// `visible/.config/b.md` is NOT hidden — which is exactly what a naive SQL
-// translation ("rel_path LIKE '%/.%'", or a per-segment test) gets wrong.
+// itself: the SQL form must hide exactly the rows the Go form hides. Since #693
+// the rule is "any segment that starts with a dot", so `visible/.config/b.md`
+// is hidden too.
 func TestListFilesHiddenFilteringSurvivesTheSQLPushdown_694(t *testing.T) {
 	tmp := t.TempDir()
 	st := store.NewSQLiteStore(filepath.Join(tmp, "meta.sqlite"))
@@ -134,10 +134,10 @@ func TestListFilesHiddenFilteringSurvivesTheSQLPushdown_694(t *testing.T) {
 	excluded := listFilesPage694(t, tmp, root, st, `"limit":50,"offset":0,"include_hidden":false`)
 	included := listFilesPage694(t, tmp, root, st, `"limit":50,"offset":0,"include_hidden":true`)
 
-	// Exactly the set the Go predicate isListFilesNoisePath produces: a
-	// dot-prefixed FIRST segment, and nothing else.
-	wantVisible := []string{"a.md", "dir/sub/c.md", "visible/.config/b.md"}
-	wantAll := append([]string{".hidden/a.md", ".x"}, wantVisible...)
+	// Exactly the set the Go predicate isListFilesNoisePath produces: no
+	// segment that starts with a dot.
+	wantVisible := []string{"a.md", "dir/sub/c.md"}
+	wantAll := append([]string{".hidden/a.md", ".x", "visible/.config/b.md"}, wantVisible...)
 
 	assertRelPathSet694(t, "include_hidden=false", excluded, wantVisible)
 	assertRelPathSet694(t, "include_hidden=true", included, wantAll)

--- a/tests/mcp/list_files_secret_excluded_712_test.go
+++ b/tests/mcp/list_files_secret_excluded_712_test.go
@@ -123,6 +123,10 @@ func seedCorpus(t *testing.T, st *store.SQLiteStore, root string, docs []model.D
 // rel_path -> status. Going through the tool rather than the helper is the
 // point: the defect was in the projection the tool applies, and a unit test on
 // the store would have shown the correct `secret_excluded` all along.
+//
+// It asks for hidden paths as well. The subject here is the status projection,
+// and a secret-bearing file is very often a dotfile (`config/.env`), which the
+// default listing hides since #693.
 func listFileStatuses(t *testing.T, stateDir, root string, st *store.SQLiteStore) map[string]string {
 	t.Helper()
 	cfg := config.Default()
@@ -136,7 +140,7 @@ func listFileStatuses(t *testing.T, stateDir, root string, st *store.SQLiteStore
 
 	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
 	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
-		`{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"dir2mcp_list_files","arguments":{"limit":50,"offset":0}}}`)
+		`{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"dir2mcp_list_files","arguments":{"limit":50,"offset":0,"include_hidden":true}}}`)
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		payload, _ := io.ReadAll(resp.Body)

--- a/tests/store/list_visible_files_cache_694_test.go
+++ b/tests/store/list_visible_files_cache_694_test.go
@@ -36,7 +36,7 @@ func TestListVisibleFilesTotalIsNotCrossedBetweenVisibilityPolicies_694(t *testi
 	seed := []string{
 		"a.md",
 		"dir/sub/c.md",
-		"visible/.config/b.md", // dot in a LATER segment: visible
+		"visible/.config/b.md", // dot in a LATER segment: hidden since #693
 		".hidden/a.md",
 		".x",
 	}
@@ -47,7 +47,7 @@ func TestListVisibleFilesTotalIsNotCrossedBetweenVisibilityPolicies_694(t *testi
 			t.Fatalf("seed %s: %v", relPath, err)
 		}
 	}
-	const wantVisible, wantAll = 3, 5
+	const wantVisible, wantAll = 2, 5
 
 	for _, tc := range []struct {
 		name string

--- a/tests/store/list_visible_files_hidden_693_test.go
+++ b/tests/store/list_visible_files_hidden_693_test.go
@@ -1,0 +1,196 @@
+package tests
+
+import (
+	"context"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/relpath"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// #693: `list_files include_hidden=false` hid a path only when its FIRST
+// segment started with a dot. A dotfile below a visible directory
+// (`docs/.env`, `docs/.git/config`) was listed as an ordinary file, so the
+// flag's meaning changed with directory depth.
+//
+// The rule is now "hide a path when ANY segment starts with a dot", and it
+// exists in two forms: relpath.IsHidden for the handler's walk fallback, and
+// relpath.NotHiddenSQL for the store's paged query. The tests below pin the Go
+// form on its own and then hold the SQL form against it, so the pair cannot
+// drift (#716).
+
+// hiddenCorpus693 is the shared fixture: every path plus the answer the rule
+// must give for it.
+var hiddenCorpus693 = []struct {
+	relPath string
+	hidden  bool
+}{
+	{relPath: "a.md", hidden: false},
+	{relPath: "dir/sub/c.md", hidden: false},
+	{relPath: "docs/v1.2/file.md", hidden: false},           // dots INSIDE names
+	{relPath: "docs/report.final.md", hidden: false},        // a dotted file name
+	{relPath: "docs/v1..2/notes.md", hidden: false},         // not a `..` segment
+	{relPath: ".env", hidden: true},                         // first segment
+	{relPath: ".claude/settings.json", hidden: true},        // first segment
+	{relPath: "docs/.env", hidden: true},                    // depth 2
+	{relPath: "docs/.git/config", hidden: true},             // dot DIRECTORY
+	{relPath: "docs/public/.private/key.txt", hidden: true}, // depth 3
+	{relPath: "a/b/c/.deep/d/e.md", hidden: true},           // depth 4
+}
+
+func TestHiddenRelPathRuleChecksEverySegment_693(t *testing.T) {
+	for _, tc := range hiddenCorpus693 {
+		if got := relpath.IsHidden(tc.relPath); got != tc.hidden {
+			t.Errorf("relpath.IsHidden(%q)=%v want %v", tc.relPath, got, tc.hidden)
+		}
+	}
+
+	// Paths that name no file, and paths that are not valid rel_paths. A
+	// listing filter must answer them without panicking, and must fail toward
+	// hiding when the path is malformed.
+	for _, tc := range []struct {
+		relPath string
+		hidden  bool
+	}{
+		{relPath: "", hidden: false},
+		{relPath: "   ", hidden: false},
+		{relPath: ".", hidden: false},
+		{relPath: "./docs/readme.md", hidden: false},
+		{relPath: "./docs/.env", hidden: true},
+		{relPath: "docs/./.env", hidden: true},
+		{relPath: "docs/sub/../.env", hidden: true},
+		{relPath: "docs/.git/../readme.md", hidden: false},
+		{relPath: "..", hidden: true},
+		{relPath: "../outside.md", hidden: true},
+	} {
+		if got := relpath.IsHidden(tc.relPath); got != tc.hidden {
+			t.Errorf("relpath.IsHidden(%q)=%v want %v", tc.relPath, got, tc.hidden)
+		}
+	}
+}
+
+// TestListVisibleFilesHidesEverySegment_693 holds the SQL form against the Go
+// form over the same corpus. Both listing paths of the store are covered: the
+// plain prefix query and the Go-side glob scan.
+func TestListVisibleFilesHidesEverySegment_693(t *testing.T) {
+	ctx := context.Background()
+	st := seedHiddenCorpus693(t)
+
+	var wantVisible, wantAll []string
+	for _, tc := range hiddenCorpus693 {
+		wantAll = append(wantAll, tc.relPath)
+		if !relpath.IsHidden(tc.relPath) {
+			wantVisible = append(wantVisible, tc.relPath)
+		}
+	}
+
+	for _, arm := range []struct{ name, glob string }{
+		{name: "sql path", glob: ""},
+		{name: "glob path", glob: "**"},
+	} {
+		t.Run(arm.name, func(t *testing.T) {
+			docs, total, err := st.ListVisibleFiles(ctx, "", arm.glob, 50, 0, false)
+			if err != nil {
+				t.Fatalf("ListVisibleFiles: %v", err)
+			}
+			assertRelPaths693(t, "include_hidden=false", docs, wantVisible)
+			if total != int64(len(wantVisible)) {
+				t.Fatalf("include_hidden=false total=%d want %d; the total must count "+
+					"the same rows the page is drawn from (#693)", total, len(wantVisible))
+			}
+
+			docs, total, err = st.ListVisibleFiles(ctx, "", arm.glob, 50, 0, true)
+			if err != nil {
+				t.Fatalf("ListVisibleFiles: %v", err)
+			}
+			assertRelPaths693(t, "include_hidden=true", docs, wantAll)
+			if total != int64(len(wantAll)) {
+				t.Fatalf("include_hidden=true total=%d want %d", total, len(wantAll))
+			}
+		})
+	}
+}
+
+// TestListVisibleFilesPagesTheVisibleSet_693 walks the listing one row at a
+// time. limit, offset and total must all describe the filtered set, so the walk
+// must see every visible path exactly once and no hidden path at all.
+func TestListVisibleFilesPagesTheVisibleSet_693(t *testing.T) {
+	ctx := context.Background()
+	st := seedHiddenCorpus693(t)
+
+	var wantVisible []string
+	for _, tc := range hiddenCorpus693 {
+		if !relpath.IsHidden(tc.relPath) {
+			wantVisible = append(wantVisible, tc.relPath)
+		}
+	}
+
+	var walked []string
+	for offset := 0; ; offset++ {
+		docs, total, err := st.ListVisibleFiles(ctx, "", "", 1, offset, false)
+		if err != nil {
+			t.Fatalf("ListVisibleFiles offset=%d: %v", offset, err)
+		}
+		if total != int64(len(wantVisible)) {
+			t.Fatalf("offset=%d total=%d want %d", offset, total, len(wantVisible))
+		}
+		if len(docs) == 0 {
+			break
+		}
+		walked = append(walked, docs[0].RelPath)
+		if offset > len(hiddenCorpus693) {
+			t.Fatalf("the walk did not end after %d pages", offset)
+		}
+	}
+
+	sort.Strings(walked)
+	want := append([]string{}, wantVisible...)
+	sort.Strings(want)
+	if len(walked) != len(want) {
+		t.Fatalf("the walk saw %v, want %v", walked, want)
+	}
+	for i := range want {
+		if walked[i] != want[i] {
+			t.Fatalf("the walk saw %v, want %v", walked, want)
+		}
+	}
+}
+
+func seedHiddenCorpus693(t *testing.T) *store.SQLiteStore {
+	t.Helper()
+	ctx := context.Background()
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("init store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	for i, tc := range hiddenCorpus693 {
+		if err := st.UpsertDocument(ctx, model.Document{
+			RelPath: tc.relPath, DocType: "md", MTimeUnix: int64(100 * (i + 1)), Status: "ok",
+		}); err != nil {
+			t.Fatalf("seed %s: %v", tc.relPath, err)
+		}
+	}
+	return st
+}
+
+func assertRelPaths693(t *testing.T, label string, docs []model.Document, want []string) {
+	t.Helper()
+	got := make(map[string]bool, len(docs))
+	for _, doc := range docs {
+		got[doc.RelPath] = true
+	}
+	for _, w := range want {
+		if !got[w] {
+			t.Errorf("%s: %q is missing from the listing", label, w)
+		}
+		delete(got, w)
+	}
+	for leftover := range got {
+		t.Errorf("%s: %q must not be listed (#693)", label, leftover)
+	}
+}


### PR DESCRIPTION
## Problem

`dir2mcp_list_files` defaults `include_hidden` to false, but the hidden-path rule tested the FIRST path segment only. A dotfile below a visible directory was listed as an ordinary file, so a caller that asked not to see hidden entries saw:

| rel_path | before | after |
|---|---|---|
| `.env` | excluded | excluded |
| `.claude/settings.json` | excluded | excluded |
| `docs/.env` | **included** | excluded |
| `docs/.git/config` | **included** | excluded |
| `docs/public/.private/key.txt` | **included** | excluded |
| `docs/v1.2/file.md` | included | included |

`total` counted those rows too, so pagination described a different set than the flag requested. The meaning of the flag changed with directory depth.

Verified against current `main` before coding: `internal/mcp/tools.go` took the first `/`-delimited segment, and #694 translated exactly that rule into SQL as `rel_path NOT LIKE '.%'`. Both copies had the defect.

## Fix

The rule is now "hide a path when ANY segment starts with a dot". A dot inside a name stays an ordinary character, so `docs/v1.2/file.md` is still visible. `include_hidden=true` keeps the inclusive behavior it always had.

A store that pages in SQL cannot call a Go predicate per row and still report an honest total, so the rule has to exist in two forms. Both now live side by side in `internal/relpath`, which is already "the one rule for what a corpus-relative path may be":

- `relpath.IsHidden` is the Go form. `mcp.isListFilesNoisePath` delegates to it, so the handler's walk fallback uses it.
- `relpath.NotHiddenSQL` is the SQL form. `SQLiteStore.ListVisibleFiles` uses it, so `files`, `total`, `limit` and `offset` all come from the same filtered set.

Fixing one form and leaving the other was the trap here. The two paths serve the same tool and a caller cannot tell which one answered the call. #716 is what a second, distant copy costs.

`open_file` and the `search`/`ask` path filters were checked: they hold no copy of this rule, so nothing else needed to change.

## Scope

- The published schema is unchanged. `include_hidden` keeps its type and its `false` default, and the result shape is untouched.
- The `dirstral-spec` submodule pointer is untouched. The spec schema carries no prose for `include_hidden`, so nothing in it contradicts this fix. The issue's last acceptance bullet (clarify the semantics in the canonical tool prose) is spec-first work and stays with dirstral-spec #57.
- `include_hidden` is not an authorization boundary. `open_file` exclusions remain the security control.

## Tests

New tests, all confirmed to FAIL against `main` first (the impl files were copied aside and `main`'s versions restored, never `git stash`):

- `tests/mcp/list_files_nested_hidden_693_test.go` drives the real tool over BOTH listing paths: the SQL pushdown that production takes, and the walk fallback for a store without `ListVisibleFiles`. Both arms failed against `main`.
- `tests/store/list_visible_files_hidden_693_test.go` pins the Go form on its own (nested depths, `docs/v1.2/file.md`, `docs/report.final.md`, `.`/`..` normalization, empty input) and then holds the SQL form against it over one shared corpus, on both the prefix query and the glob scan. That is the drift guard for the pair.
- Both suites walk the listing one row per page, so `files`, `total`, `limit` and `offset` are proven to describe the same set.

Updated tests that pinned the old first-segment rule: `TestListFilesHiddenFilteringSurvivesTheSQLPushdown_694` and `TestListVisibleFilesTotalIsNotCrossedBetweenVisibilityPolicies_694`. The #712 status test now asks for hidden paths, because its fixture is a `config/.env` and its subject is the status projection, not visibility.

## Checks

- `make check` passes (`fmt`, `vet`, `golangci-lint`, `gocyclo -over 15`, `ineffassign`, `misspell`, full test suite, build).
- `coderabbit review` run; its one finding (a docstring that contradicted itself about `..`) is fixed.

Closes #693
