### PR TITLE
fix(ingest): stop the local file watcher from mutating a remote corpus (#695)

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,6 +589,7 @@ Notes:
 - The watcher runs alongside the existing embedding worker, so newly indexed files become searchable automatically without a manual `reindex`.
 - It is **best-effort, not a correctness guarantee**: a low-frequency safety rescan reconciles anything missed (kernel event coalescing, OS watch limits on very large trees), so the index converges even if individual events are dropped.
 - Excluded paths, `.gitignore` rules, and size/type limits apply to watched changes exactly as they do to the initial scan.
+- **The watcher needs a filesystem.** `source.kind: local` and `source.kind: nfs` are ordinary directory trees, so both use it. A remote corpus (`source.kind: s3`) has no filesystem to watch, so the watcher does not start for it. The index reconciles on a periodic rescan of the remote source instead, and `dir2mcp up` prints a warning at startup. `watch_debounce` and the `watch_overflows` stat apply only to the filesystem watcher; a remote corpus reports neither.
 - Env equivalents: `DIR2MCP_INGEST_WATCH=true`, `DIR2MCP_INGEST_WATCH_DEBOUNCE=500ms`.
 
 ### Gemini embeddings (`gemini-embedding-001`)

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -261,7 +261,7 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 		runCorpusWriter(runCtx, cfg.StateDir, st, indexingState, logSink, emitter)
 	}()
 	startIngestWorker(runCtx, opts.readOnly, ing, indexingState, ingestErrCh)
-	startWatchWorker(runCtx, opts.readOnly, cfg.IngestWatch, ing, logSink, &bgWG)
+	startWatchWorker(runCtx, opts.readOnly, cfg.IngestWatch, cfg.Source.Kind, ing, logSink, &bgWG)
 
 	// The server is now serving. A signal-triggered shutdown from here on is
 	// a normal, successful termination (a supervisor/`down`-requested stop),
@@ -1086,13 +1086,18 @@ type watchable interface {
 	Watch(context.Context) error
 }
 
-// startWatchWorker launches the filesystem watcher in the background when
+// startWatchWorker launches the continuous-sync worker in the background when
 // ingest.watch is enabled and the ingestor supports it. It runs concurrently
 // with the initial scan; processDocument hash-diffs, so any overlap is a cheap
 // no-op. Watcher failures are non-fatal — the watcher's own periodic safety
 // rescan reconciles drift — so a setup error is logged rather than terminating
 // the server.
-func startWatchWorker(runCtx context.Context, readOnly, enabled bool, ing interface {
+//
+// sourceKind is the configured source.kind. The worker still starts for a
+// remote source, but the ingestor runs a periodic reconcile instead of the
+// filesystem watcher (issue #695). The operator gets a warning here, because
+// the mechanism they asked for is not the mechanism they get.
+func startWatchWorker(runCtx context.Context, readOnly, enabled bool, sourceKind string, ing interface {
 	Run(context.Context) error
 }, stderr io.Writer, wg *sync.WaitGroup) {
 	if !enabled {
@@ -1108,6 +1113,7 @@ func startWatchWorker(runCtx context.Context, readOnly, enabled bool, ing interf
 	if !ok {
 		return
 	}
+	warnIfSourceHasNoFileWatch(sourceKind, stderr)
 	// Register on the drain group so the deferred cancel()+Wait() in runUp waits
 	// for this goroutine to exit before returning; its Watch error logging would
 	// otherwise race a caller reading the shared sink after return (issue #419).
@@ -1122,6 +1128,27 @@ func startWatchWorker(runCtx context.Context, readOnly, enabled bool, ing interf
 			_, _ = fmt.Fprintf(stderr, "watch: %v\n", err)
 		}
 	}()
+}
+
+// warnIfSourceHasNoFileWatch tells the operator that ingest.watch does not start
+// the filesystem watcher for the configured source, and says what runs instead.
+//
+// A remote corpus has no filesystem to watch. Before issue #695 the watcher
+// started anyway and rooted itself at the local root_dir, so a local edit or
+// delete could reprocess or tombstone the remote document with the same
+// relative path. The watcher is now gated, and the message keeps the change
+// visible: an operator who set ingest.watch expects a watcher, so the server
+// must not swap the mechanism in silence. The gate itself lives in
+// ingest.SourceSupportsFileWatch, so the CLI and the ingestor cannot disagree.
+func warnIfSourceHasNoFileWatch(sourceKind string, stderr io.Writer) {
+	if ingest.SourceSupportsFileWatch(sourceKind) {
+		return
+	}
+	kind := strings.ToLower(strings.TrimSpace(sourceKind))
+	_, _ = fmt.Fprintf(stderr,
+		"warning: ingest.watch is enabled, but source.kind=%s has no filesystem to watch; "+
+			"the file watcher is disabled and the corpus reconciles on a periodic rescan instead\n",
+		kind)
 }
 
 // runEventLoop runs the main select loop until the server stops, context is

--- a/internal/cli/watch_source_gate_695_test.go
+++ b/internal/cli/watch_source_gate_695_test.go
@@ -1,0 +1,78 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// stubWatchIngestor is the minimum an ingestor needs for startWatchWorker: a
+// Run method to satisfy the parameter type, and a Watch method to satisfy the
+// watchable assertion. It records that Watch ran.
+type stubWatchIngestor struct {
+	mu      sync.Mutex
+	watched bool
+}
+
+func (s *stubWatchIngestor) Run(context.Context) error { return nil }
+
+func (s *stubWatchIngestor) Watch(context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.watched = true
+	return nil
+}
+
+func (s *stubWatchIngestor) didWatch() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.watched
+}
+
+// TestStartWatchWorker_WarnsForSourceWithoutFileWatch pins the operator-facing
+// half of issue #695.
+//
+// An operator who sets ingest.watch expects a watcher. For an S3 corpus there is
+// no filesystem to watch, so the server runs a periodic reconcile instead. That
+// substitution must be visible, or it becomes a quiet failure. The worker still
+// starts, because the reconcile is what keeps the remote corpus in sync.
+func TestStartWatchWorker_WarnsForSourceWithoutFileWatch(t *testing.T) {
+	var out bytes.Buffer
+	var wg sync.WaitGroup
+	ing := &stubWatchIngestor{}
+
+	startWatchWorker(context.Background(), false, true, "s3", ing, &out, &wg)
+	wg.Wait()
+
+	got := out.String()
+	for _, want := range []string{"ingest.watch", "source.kind=s3", "periodic rescan"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("warning must mention %q; got %q", want, got)
+		}
+	}
+	if !ing.didWatch() {
+		t.Errorf("the worker must still start for a remote source, so the periodic reconcile runs")
+	}
+}
+
+// TestStartWatchWorker_NoWarningForFilesystemSources confirms a local or NFS
+// corpus is unchanged: it keeps the filesystem watcher and gets no warning.
+func TestStartWatchWorker_NoWarningForFilesystemSources(t *testing.T) {
+	for _, kind := range []string{"", "local", "nfs"} {
+		var out bytes.Buffer
+		var wg sync.WaitGroup
+		ing := &stubWatchIngestor{}
+
+		startWatchWorker(context.Background(), false, true, kind, ing, &out, &wg)
+		wg.Wait()
+
+		if out.Len() != 0 {
+			t.Errorf("source.kind=%q is a filesystem corpus and must not warn; got %q", kind, out.String())
+		}
+		if !ing.didWatch() {
+			t.Errorf("source.kind=%q must still start the watcher", kind)
+		}
+	}
+}

--- a/internal/ingest/watch.go
+++ b/internal/ingest/watch.go
@@ -25,10 +25,44 @@ const defaultWatchDebounce = 500 * time.Millisecond
 // deletes the watcher's per-path handler missed.
 const safetyRescanInterval = 10 * time.Minute
 
-// Watch runs a filesystem watcher that incrementally indexes added, changed,
-// and deleted files for the life of ctx. It is intended to run after the
-// initial Run() scan completes, turning a one-shot index into a continuously
-// maintained one.
+// remoteRescanInterval is how often a remote corpus (source.kind=s3)
+// reconciles while ingest.watch is on. A remote corpus has no filesystem event
+// source, so the reconcile is the only continuous-sync mechanism. It is a
+// separate constant from safetyRescanInterval on purpose: the two loops have
+// different semantics. safetyRescanInterval backstops a live fsnotify watcher;
+// this interval IS the sync. Debounce and overflow do not apply to it.
+const remoteRescanInterval = 10 * time.Minute
+
+// SourceSupportsFileWatch reports whether source.kind names a corpus that the
+// local filesystem watcher can observe.
+//
+// Only a real filesystem qualifies. "local" and "nfs" are both ordinary
+// directory trees under cfg.RootDir (SPEC §7.8), so an fsnotify event maps to
+// the true corpus path. An NFS mount sees fewer events than a local disk,
+// because inotify does not report a write made by another client. That is a
+// completeness limit, not a correctness one, and the safety rescan covers it.
+//
+// "s3" does not qualify. An S3 corpus is a set of objects under a bucket and
+// prefix. cfg.RootDir still defaults to ".", so the watcher would root itself
+// at an unrelated local directory and read local events as corpus events
+// (issue #695). Kind matching mirrors corpusfs.New: the comparison is
+// case-insensitive and an empty kind normalizes to local.
+func SourceSupportsFileWatch(kind string) bool {
+	switch strings.ToLower(strings.TrimSpace(kind)) {
+	case "", "local", "nfs":
+		return true
+	default:
+		return false
+	}
+}
+
+// Watch keeps the index in sync with the corpus for the life of ctx. It is
+// intended to run after the initial Run() scan completes, turning a one-shot
+// index into a continuously maintained one.
+//
+// The mechanism depends on source.kind (SPEC §7.8). A local or NFS corpus gets
+// the fsnotify watcher below. A remote corpus gets a periodic reconcile
+// through the configured CorpusFS instead. See watchRemote.
 //
 // Design notes:
 //   - Event draining (reading fsnotify events) is decoupled from per-document
@@ -49,6 +83,12 @@ const safetyRescanInterval = 10 * time.Minute
 func (s *Service) Watch(ctx context.Context) error {
 	if s.store == nil {
 		return nil
+	}
+	// The source-kind gate runs before the RootDir check. An S3 corpus does not
+	// need a local root at all (issue #738), so a non-empty RootDir must never
+	// decide which watch mechanism runs.
+	if !SourceSupportsFileWatch(s.cfg.Source.Kind) {
+		return s.watchRemote(ctx)
 	}
 	root := s.cfg.RootDir
 	if root == "" {
@@ -94,6 +134,39 @@ func (s *Service) Watch(ctx context.Context) error {
 		fire:     make(chan watchJob, 256),
 	}
 	return w.run(ctx)
+}
+
+// watchRemote keeps a remote corpus in sync with a periodic reconcile. It runs
+// instead of the fsnotify watcher when source.kind names a corpus that no local
+// filesystem event can describe (issue #695).
+//
+// The reconcile is a normal incremental scan. runScan enumerates through the
+// configured CorpusFS, so it reads the actual remote objects: a new or changed
+// object is ingested, and an object that is gone is tombstoned. Every mutation
+// therefore comes from the remote source itself. No local file event can reach
+// the store.
+//
+// This loop deliberately does NOT call MarkWatchActive. There is no fsnotify
+// watcher, so there is no kernel event buffer and no overflow to count. SPEC
+// §15.6 requires the server to omit watch_overflows when it does not run the
+// watcher, and a consumer must read that absence as "not applicable".
+//
+// Debounce does not apply either. ingest.watch_debounce coalesces editor write
+// bursts on a local disk; a scheduled full reconcile has no per-path bursts to
+// coalesce.
+func (s *Service) watchRemote(ctx context.Context) error {
+	ticker := time.NewTicker(remoteRescanInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			if err := s.runScan(ctx); err != nil && ctx.Err() == nil {
+				s.getLogger().Printf("watch: remote corpus rescan: %v", err)
+			}
+		}
+	}
 }
 
 type watchJob struct {

--- a/tests/ingest/watch_remote_source_695_test.go
+++ b/tests/ingest/watch_remote_source_695_test.go
@@ -1,0 +1,137 @@
+package tests
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/appstate"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// localEventSettleWindow is how long a test waits after it changes a local file
+// before it asserts that the remote corpus did not change.
+//
+// The assertion is an absence, so the test cannot poll for it. The window must
+// be long enough for the pre-#695 watcher to act: it debounces (10 ms here),
+// then hands the job to its worker, which writes the store. One second is far
+// more than that path needs.
+const localEventSettleWindow = 1 * time.Second
+
+// TestWatch_S3SourceIgnoresLocalFileEvents pins issue #695: with source.kind=s3,
+// a local file event MUST NOT mutate the remote corpus.
+//
+// The setup is the reported failure shape. The corpus lives in an object store
+// and holds docs/a.md. root_dir keeps its default meaning of "some local
+// directory", and that directory happens to hold a file at the same relative
+// path. Before the fix, Watch started fsnotify on that local directory, read the
+// local delete as a corpus delete, and tombstoned the remote document. The
+// remote object was still there, so retrieval hid a valid document until the next
+// full rescan.
+//
+// The test asserts three things after a local delete and a local create:
+//  1. the remote document is not tombstoned;
+//  2. the local-only file is not ingested as a remote document;
+//  3. the stats surface does not advertise a live watcher (SPEC §15.6).
+func TestWatch_S3SourceIgnoresLocalFileEvents(t *testing.T) {
+	// The remote corpus: one object, which stays present for the whole test.
+	fs := newFakeRemoteFS()
+	fs.add("docs/a.md", "etag-remote", "remote body")
+
+	st := newRemoteScanStore()
+	st.seed(model.Document{
+		DocID:       1,
+		RelPath:     "docs/a.md",
+		DocType:     "text",
+		SizeBytes:   int64(len("remote body")),
+		ContentHash: ingest.ComputeContentHash([]byte("remote body")),
+		ETag:        "etag-remote",
+		Status:      "ok",
+	})
+
+	// The local directory the daemon runs from. It collides with the corpus on
+	// docs/a.md, which is the whole hazard: the two paths name different things.
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "docs"), 0o755); err != nil {
+		t.Fatalf("mkdir docs: %v", err)
+	}
+	localDoc := filepath.Join(root, "docs", "a.md")
+	if err := os.WriteFile(localDoc, []byte("unrelated local body"), 0o600); err != nil {
+		t.Fatalf("write local doc: %v", err)
+	}
+
+	cfg := config.Config{
+		RootDir:             root,
+		IngestWatch:         true,
+		IngestWatchDebounce: 10 * time.Millisecond,
+		Source: config.SourceConfig{
+			Kind:     "s3",
+			S3Bucket: "corpus-bucket",
+		},
+	}
+	svc := mustNewIngestService(t, cfg, st)
+	svc.SetCorpusFS(fs)
+	state := appstate.NewIndexingState(appstate.ModeIncremental)
+	svc.SetIndexingState(state)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	watchDone := make(chan error, 1)
+	go func() { watchDone <- svc.Watch(ctx) }()
+	// Give a watcher time to register its directory watches, so the events below
+	// are not missed for an uninteresting reason.
+	time.Sleep(200 * time.Millisecond)
+
+	// The two local events from the issue's reproduction: a delete of a path the
+	// remote corpus also has, and a create of a path it does not.
+	if err := os.Remove(localDoc); err != nil {
+		t.Fatalf("remove local doc: %v", err)
+	}
+	localOnly := filepath.Join(root, "docs", "local-only.txt")
+	if err := os.WriteFile(localOnly, []byte("local scratch file"), 0o600); err != nil {
+		t.Fatalf("write local-only file: %v", err)
+	}
+	time.Sleep(localEventSettleWindow)
+
+	cancel()
+	if err := <-watchDone; err != nil {
+		t.Fatalf("Watch returned error: %v", err)
+	}
+
+	doc, ok := st.get("docs/a.md")
+	if !ok {
+		t.Fatalf("remote document docs/a.md disappeared from the store")
+	}
+	if doc.Deleted {
+		t.Errorf("a local delete tombstoned the remote document docs/a.md; the object is still in the bucket")
+	}
+	if _, ok := st.get("docs/local-only.txt"); ok {
+		t.Errorf("a local file event ingested docs/local-only.txt into the remote-backed store; no such object exists")
+	}
+	if state.Snapshot().WatchActive {
+		t.Errorf("watch reported active for an s3 corpus; no filesystem watcher governs that source (SPEC §15.6)")
+	}
+}
+
+// TestSourceSupportsFileWatch pins which source kinds may drive the local
+// filesystem watcher. local and nfs are ordinary directory trees under root_dir,
+// so an fsnotify event names a real corpus path. s3 is not, so it must not.
+// Matching is case-insensitive and an empty kind means local, mirroring
+// corpusfs.New.
+func TestSourceSupportsFileWatch(t *testing.T) {
+	watchable := []string{"", "local", "nfs", "LOCAL", " NFS ", "Local"}
+	for _, kind := range watchable {
+		if !ingest.SourceSupportsFileWatch(kind) {
+			t.Errorf("SourceSupportsFileWatch(%q) = false, want true: it is a filesystem corpus", kind)
+		}
+	}
+	notWatchable := []string{"s3", "S3", " s3 ", "gcs"}
+	for _, kind := range notWatchable {
+		if ingest.SourceSupportsFileWatch(kind) {
+			t.Errorf("SourceSupportsFileWatch(%q) = true, want false: it is not a local filesystem", kind)
+		}
+	}
+}

--- a/tests/security/cli_boundary_test.go
+++ b/tests/security/cli_boundary_test.go
@@ -217,6 +217,7 @@ func TestRepoSplitBoundary_InternalCLIFileOwnership(t *testing.T) {
 		"up_daemon.go":                           {},
 		"up_distributed_embed.go":                {},
 		"up_graceful_stop_test.go":               {},
+		"watch_source_gate_695_test.go":          {},
 	}
 
 	var unexpected []string


### PR DESCRIPTION
Closes #695.

## The bug, re-verified against current `main`

Every claim in the issue still holds at `f406823`.

| Claim | Where it is on `main` today |
|---|---|
| `up` starts the watcher from `cfg.IngestWatch` alone | `internal/cli/up.go:264`, `startWatchWorker` at `:1095` |
| `Watch` always builds an fsnotify watcher rooted at `cfg.RootDir` | `internal/ingest/watch.go:49-97` |
| `RootDir` still means a local path for an S3 corpus | `internal/cli/up.go:1534` in `buildCorpusFS` passes `cfg.RootDir` for every kind; the S3 backend ignores it |
| A local event becomes a corpus-relative path | `internal/ingest/watch.go:297-343`, `filepath.Rel(w.absRoot, job.absPath)` |
| `processDelete` tombstones without asking the source | `internal/ingest/watch.go:565-589` |
| `indexableFile` supplies local size and mtime, and an empty ETag | `internal/ingest/watch.go:348-389` |
| No source-kind check, no S3 watch test | confirmed by search |

The impact is the one the issue describes. A local delete of `docs/a.md` calls `MarkDocumentDeleted("docs/a.md")`. The S3 object is still in the bucket, but retrieval no longer serves it. A local write reprocesses the remote document with local metadata, and a purely local file is ingested as a corpus document.

## What this PR does

`Watch` now picks its mechanism from `source.kind`.

- `local` and `nfs` keep the fsnotify watcher, byte for byte unchanged.
- A remote corpus runs a new `watchRemote`: a periodic reconcile that calls the same `runScan` the safety rescan already used. `runScan` enumerates through the configured `CorpusFS`, so every mutation comes from the remote source itself. No local file event can reach the store.

`up` prints a warning at startup when `ingest.watch` is on and the source has no filesystem to watch:

```
warning: ingest.watch is enabled, but source.kind=s3 has no filesystem to watch;
the file watcher is disabled and the corpus reconciles on a periodic rescan instead
```

The gate is one exported function, `ingest.SourceSupportsFileWatch`. The CLI and the ingestor both call it, so they cannot disagree about which sources are watchable.

## The decisions you asked me to argue

### Should `up` refuse to start, or start without the watcher and warn?

It starts, it warns, and it keeps continuous sync by another mechanism.

A hard startup refusal is the wrong trade here. It converts a config that was accepted yesterday into a dead daemon today, for every S3 operator who set `ingest.watch`. Nothing else about that daemon is broken. The corpus indexes, retrieval answers, citations resolve. To refuse to serve because one knob names a mechanism the source cannot provide costs the operator their whole service to fix a problem that has a correct fallback.

Your objection to the alternative is right, though: to start without the watcher and say nothing is its own quiet failure. So this PR does not do that either. Three things keep it loud:

1. A warning on the same sink as the existing read-only watch warning, at startup, naming the source kind and the replacement mechanism.
2. The stats surface stops lying. `watchRemote` does not call `MarkWatchActive`, so `watch_overflows` is omitted rather than reported as `0`. SPEC §15.6 already defines that absence as "not applicable", so a monitor that watched the field now sees the truth: this server runs no file watcher.
3. The operator's actual intent, "keep the index in sync", is still met. It is met by the mechanism that was always doing the real work for S3.

That last point is what makes the warning honest rather than an apology. The operator does not lose continuous sync. They lose an fsnotify watcher that never observed their corpus in the first place.

### Does the ten-minute safety rescan already cover the S3 case?

Yes, and the loss from disabling fsnotify is close to zero.

`runScan` walks `s.corpusFS().Walk(ctx, ...)` (`internal/ingest/service.go:1740`). For an S3 corpus that is the S3 backend. It applies the SPEC §7.8 ETag change detection, ingests new and changed objects, and `markMissingAsDeleted` tombstones objects that are gone. It is the same function the fsnotify safety rescan already called, so this is not new machinery on an untested path.

Quantifying the loss:

- **Correctness loss: none.** Before this PR, no S3 change was ever detected by fsnotify. The kernel cannot report a change to an object in a bucket. Every real S3 change was already found by the rescan and only by the rescan.
- **Latency loss: none.** The rescan interval is unchanged at ten minutes. An S3 change was visible within ten minutes before, and it is visible within ten minutes now.
- **Actual change: the corpus stops being mutated by unrelated local activity.** That is the entire delta.

The watcher was not providing S3 coverage that this PR removes. It was providing a corruption channel.

### Is any other `source.kind` affected?

No. The set is closed: `validateSource` (`internal/config/config.go:5336`) accepts only `local`, `nfs` and `s3`, and `corpusfs.New` errors on anything else.

`nfs` stays on the watcher, and that is correct. An NFS corpus is a mounted directory tree at `cfg.RootDir`. A local event under that root names a real corpus path, so there is no cross-corpus mutation and no wrong-source hazard: the failure mode this issue is about cannot occur. NFS does have a weaker guarantee than a local disk, because inotify does not report a write made by another NFS client. That is a completeness limit, not a correctness one, and the safety rescan is exactly the backstop for it. It is documented on `SourceSupportsFileWatch`.

The gate is written as an allowlist, not an s3 denylist, so a future remote backend is refused by default rather than inheriting the bug.

## Acceptance criteria

| Criterion | Status |
|---|---|
| Gate watcher startup by source kind; local/NFS may use fsnotify, S3 must not | done |
| Validate or clearly warn for `source.kind=s3` + `ingest.watch=true` | warn, argued above |
| Never feed local `DiscoveredFile` metadata or local delete events into an S3-backed service | done, and tested |
| Report watch-active/overflow only for the watcher governing the source | done, `watchRemote` does not `MarkWatchActive` |
| S3-backed test proving local events cannot mutate remote state | done, see below |
| Model periodic remote reconciliation separately from debounce/overflow | done, separate `remoteRescanInterval`, no debounce, no overflow counter |
| Coordinate with dirstral-spec #62 `CorpusFS` contract cleanup | not attempted, see out of scope |

## Tests, and how I confirmed they fail on `main`

I did **not** use `git stash`. I copied the files aside, checked out `origin/main` over them, ran the test, and copied mine back.

`TestWatch_S3SourceIgnoresLocalFileEvents` (`tests/ingest/watch_remote_source_695_test.go`) builds the reported shape: a fake object-store `CorpusFS` holding `docs/a.md`, a store seeded with that document, and a local `root_dir` that happens to hold a file at the same relative path. It runs `Watch`, deletes the local file, creates a local-only file, then asserts the remote corpus is untouched.

Against `origin/main` (the test file compiled without the new exported helper), all three assertions fail:

```
watch_remote_source_695_test.go:109: a local delete tombstoned the remote document docs/a.md; the object is still in the bucket
watch_remote_source_695_test.go:112: a local file event ingested docs/local-only.txt into the remote-backed store; no such object exists
watch_remote_source_695_test.go:115: watch reported active for an s3 corpus; no filesystem watcher governs that source (SPEC §15.6)
--- FAIL: TestWatch_S3SourceIgnoresLocalFileEvents (1.21s)
```

It fails the same way on `-count=3`, so it is not a timing accident. With this branch it passes on `-count=3`.

Also added:

- `TestSourceSupportsFileWatch`: pins the allowlist, including case and whitespace handling.
- `TestStartWatchWorker_WarnsForSourceWithoutFileWatch` and `TestStartWatchWorker_NoWarningForFilesystemSources` (`internal/cli/watch_source_gate_695_test.go`): the warning fires for a remote source, the worker still starts so the reconcile runs, and a filesystem source is silent and unchanged. Registered in `tests/security/cli_boundary_test.go` as the CLI boundary allowlist requires.

## No spec change is needed

I checked before writing any code. SPEC §7.8 defines `local` and `nfs` as filesystem walks and `s3` as an object listing. It never promises a live watcher for any source. SPEC §15.6 already requires `watch_overflows` to be omitted when the server does not run the watcher, which is precisely what `watchRemote` does. This PR moves behaviour toward the spec, so it needs no `dirstral-spec` PR ahead of it. The submodule pointer is untouched.

## Out of scope

- **A configurable remote reconcile interval.** It would need a new config key, and a config key is spec-first. The interval is a named constant with its own doc comment, so the follow-up is a small one.
- **An S3-native watch.** Bucket notifications or a cheap `ListObjectsV2` poll would cut the ten-minute latency. That is a feature, and it belongs with the dirstral-spec #62 `CorpusFS` capability work the issue points at, not in a corruption fix.

## Checks

`make check` passes, including `gocyclo -over 15`. `tests/security` needed `git submodule update --init` in this worktree; the pinned commit is unchanged.
