### PR TITLE
fix(retrieval): stop a deleted document from returning from the vector payload (#687)

### DIFF
--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -83,6 +83,13 @@ const (
 	defaultOverfetchMultiplier = 5
 	maxOverfetchMultiplier     = 100
 
+	// evictDeleteTimeout bounds one vector-delete call made by an eviction. The
+	// eviction runs on the ingest or watcher loop, so an external backend that
+	// hangs would otherwise stall indexing for an unbounded time. A timeout
+	// degrades to the logged-failure path, where the metadata and the path
+	// tombstone still hide the chunks.
+	evictDeleteTimeout = 30 * time.Second
+
 	defaultRAGSystemPrompt = "Answer the question using only the provided context.\n" +
 		"Include concise source attributions in the form [rel_path].\n" +
 		"Security: the context consists of retrieved documents, each wrapped in " +
@@ -1038,7 +1045,8 @@ func (s *Service) dropLabels(labels []uint64) {
 // deleteVectors drops the labels from both index axes. Delete ignores unknown
 // ids, so a call to both axes is safe whichever one held a given label. A fresh
 // context is used, so the deletion still completes when the triggering query's
-// context was canceled. A failure is logged rather than swallowed; the in-memory
+// context was canceled; it carries evictDeleteTimeout, so a hung backend cannot
+// stall the caller. A failure is logged rather than swallowed; the in-memory
 // metadata and the path tombstone still hide the chunks, so the failure costs
 // index space, not correctness.
 func (s *Service) deleteVectors(textIndex, codeIndex model.Index, labels []uint64) {
@@ -1050,7 +1058,10 @@ func (s *Service) deleteVectors(textIndex, codeIndex model.Index, labels []uint6
 		if axis.idx == nil {
 			continue
 		}
-		if err := axis.idx.Delete(context.Background(), labels); err != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), evictDeleteTimeout)
+		err := axis.idx.Delete(ctx, labels)
+		cancel()
+		if err != nil {
 			s.logf("evict: %s index delete of %d chunk(s) failed; the chunks stay hidden but their vectors remain: %v",
 				axis.name, len(labels), err)
 		}

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
@@ -83,12 +84,14 @@ const (
 	defaultOverfetchMultiplier = 5
 	maxOverfetchMultiplier     = 100
 
-	// evictDeleteTimeout bounds one vector-delete call made by an eviction. The
-	// eviction runs on the ingest or watcher loop, so an external backend that
-	// hangs would otherwise stall indexing for an unbounded time. A timeout
-	// degrades to the logged-failure path, where the metadata and the path
-	// tombstone still hide the chunks.
-	evictDeleteTimeout = 30 * time.Second
+	// evictDeleteTimeout bounds one vector-delete call made by an eviction. An
+	// external backend that hangs would otherwise block the caller for an
+	// unbounded time. The caller is the ingest or watcher loop for a document
+	// eviction, but it is the query goroutine for the liveness prune
+	// (pruneTombstonedHits calls EvictChunks), so the bound is kept short. A
+	// timeout degrades to the logged-failure path, where the in-memory metadata
+	// and the path tombstone still hide the chunks.
+	evictDeleteTimeout = 10 * time.Second
 
 	defaultRAGSystemPrompt = "Answer the question using only the provided context.\n" +
 		"Include concise source attributions in the form [rel_path].\n" +
@@ -1028,6 +1031,22 @@ func (s *Service) labelsForRelPaths(normalized map[string]struct{}) []uint64 {
 	return labels
 }
 
+// sameIndex reports whether two index handles are the same object. It compares
+// pointers through reflection rather than with ==, because == on two interface
+// values of the same non-comparable dynamic type panics at run time, and this
+// runs on the delete path of a live daemon. A backend held by value reports
+// false, so the caller falls back to one call per axis, which is always correct.
+func sameIndex(a, b model.Index) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	av, bv := reflect.ValueOf(a), reflect.ValueOf(b)
+	if av.Kind() != reflect.Pointer || bv.Kind() != reflect.Pointer {
+		return false
+	}
+	return av.Pointer() == bv.Pointer()
+}
+
 // dropLabels removes the labels from the in-memory metadata and deletes their
 // vectors from the text and code indexes. It is the shared body of
 // EvictDocuments and EvictChunks.
@@ -1054,6 +1073,12 @@ func (s *Service) deleteVectors(textIndex, codeIndex model.Index, labels []uint6
 		name string
 		idx  model.Index
 	}{{"text", textIndex}, {"code", codeIndex}}
+	if sameIndex(textIndex, codeIndex) {
+		// The default wiring points both axes at one index, so one call does the
+		// whole job. Skipping the second call halves the backend round trips and
+		// the worst-case wait.
+		axes = axes[:1]
+	}
 	for _, axis := range axes {
 		if axis.idx == nil {
 			continue

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -157,8 +157,23 @@ type Service struct {
 	// so the previous per-index split (chunkByIndex) held a redundant second copy
 	// of every SearchHit; it was collapsed into this one map (issue #429 F4/D1).
 	chunkByLabel map[uint64]model.SearchHit
-	rootDir      string
-	stateDir     string
+	// tombstonedRelPaths holds the normalized path of every document evicted in
+	// this session (EvictDocuments). It is the read-time tombstone SPEC §6.6
+	// requires: a tombstoned chunk MUST NOT appear in results even when the
+	// backend's own deletion did not propagate. Two cases need it. A backend
+	// Delete can fail, and a payload-only backend holds no in-memory metadata,
+	// so eviction can resolve no chunk_id for the path. Registration of metadata
+	// for a path clears its tombstone, because a re-created file is a new live
+	// document (issue #687).
+	tombstonedRelPaths map[string]struct{}
+	// metadataRegistered latches true on the first SetChunkMetadata* call. It is
+	// the explicit "the in-memory metadata is authoritative" state that payload
+	// fallback consults. The previous predicate was len(chunkByLabel) > 0, which
+	// flipped back to false when eviction removed the last entry, and the deleted
+	// document then came back from the backend payload (issue #687).
+	metadataRegistered bool
+	rootDir            string
+	stateDir           string
 	// ocrCacheIdentity / transcriptCacheIdentity are the ACTIVE OCR-extraction and
 	// STT(+diarize) derivation identities (SPEC §8.6.7) of the ingest pipeline,
 	// plumbed in via SetDerivationCacheIdentities so open_file's OCR/transcript
@@ -351,6 +366,7 @@ func NewService(store model.Store, index model.Index, embedder model.Embedder, g
 		ragSystemPrompt:     defaultRAGSystemPrompt,
 		ragMaxContextChars:  defaultRAGMaxContext,
 		chunkByLabel:        make(map[uint64]model.SearchHit),
+		tombstonedRelPaths:  make(map[string]struct{}),
 		rootDir:             ".",
 		stateDir:            filepath.Join(".", ".dir2mcp"),
 		protocolVersion:     "2025-11-25",
@@ -911,8 +927,21 @@ func (s *Service) SetSecretPatterns(patterns []string) error {
 }
 
 func (s *Service) SetChunkMetadata(label uint64, metadata model.SearchHit) {
+	s.registerChunkMetadata(label, metadata)
+}
+
+// registerChunkMetadata stores one chunk's metadata. It also latches
+// metadataRegistered and clears any tombstone on the chunk's path: the chunk is
+// live, so a document re-created under an evicted path becomes visible again
+// (issue #687).
+func (s *Service) registerChunkMetadata(label uint64, metadata model.SearchHit) {
+	relPath := normalizeEvictPath(metadata.RelPath)
 	s.metaMu.Lock()
 	s.chunkByLabel[label] = metadata
+	s.metadataRegistered = true
+	if relPath != "" {
+		delete(s.tombstonedRelPaths, relPath)
+	}
 	s.metaMu.Unlock()
 }
 
@@ -921,50 +950,111 @@ func (s *Service) EvictDocument(relPath string) {
 	s.EvictDocuments([]string{relPath})
 }
 
-// EvictDocuments removes all in-memory chunk metadata for the given
-// documents. It is called when documents are tombstoned in the store so that
-// their chunks no longer appear in search results for the remainder of the
-// server session. The HNSW vector index has no delete support, so evicted
-// labels will still be returned by the ANN search, but matchFilters will
-// discard them because searchHitForLabel falls back to a stub with an empty
-// RelPath.
+// EvictDocuments removes the given documents from the live retrieval state. It
+// runs when the store tombstones the documents, so their chunks must not appear
+// in search results again. It does three things for each document: it records a
+// read-time tombstone for the path, it drops the in-memory metadata of the
+// document's chunks, and it deletes those chunks' vectors from the text and code
+// indexes.
+//
+// SPEC §6.6 makes the store tombstone the source of truth: a tombstoned chunk_id
+// MUST NOT appear in results even when the backend's own deletion did not
+// propagate. Delete is part of the model.Index contract and all four backends
+// (HNSW, disk, Qdrant, pgvector) implement it, so the vectors go away in the
+// normal case. The path tombstone covers the two remaining cases: a backend
+// Delete that fails, and a payload-only backend that holds no in-memory metadata,
+// where no chunk_id can be resolved for the path (issue #687).
 func (s *Service) EvictDocuments(relPaths []string) {
-	if len(relPaths) == 0 {
-		return
-	}
-	normalized := make(map[string]struct{}, len(relPaths))
-	for _, relPath := range relPaths {
-		norm := strings.TrimSpace(filepath.ToSlash(relPath))
-		if norm == "" {
-			continue
-		}
-		normalized[norm] = struct{}{}
-	}
+	normalized := normalizeEvictPaths(relPaths)
 	if len(normalized) == 0 {
 		return
 	}
-
-	// First, scan under a read lock to find labels to delete without blocking
-	// concurrent readers for the duration of the O(totalChunks) scan.
-	s.metaMu.RLock()
-	var labelsToDelete []uint64
-	for label, hit := range s.chunkByLabel {
-		if _, ok := normalized[strings.TrimSpace(filepath.ToSlash(hit.RelPath))]; ok {
-			labelsToDelete = append(labelsToDelete, label)
-		}
-	}
-	s.metaMu.RUnlock()
-
-	if len(labelsToDelete) == 0 {
+	s.tombstoneRelPaths(normalized)
+	labels := s.labelsForRelPaths(normalized)
+	if len(labels) == 0 {
 		return
 	}
+	s.dropLabels(labels)
+}
 
-	// Now take the write lock only for the actual deletions.
+// normalizeEvictPath returns the key form of one document path. Eviction,
+// tombstone lookup and metadata matching all use it, so they always agree.
+func normalizeEvictPath(relPath string) string {
+	return strings.TrimSpace(filepath.ToSlash(relPath))
+}
+
+// normalizeEvictPaths returns the set of non-empty normalized paths in relPaths.
+func normalizeEvictPaths(relPaths []string) map[string]struct{} {
+	if len(relPaths) == 0 {
+		return nil
+	}
+	normalized := make(map[string]struct{}, len(relPaths))
+	for _, relPath := range relPaths {
+		if norm := normalizeEvictPath(relPath); norm != "" {
+			normalized[norm] = struct{}{}
+		}
+	}
+	return normalized
+}
+
+// tombstoneRelPaths records the paths as evicted for the rest of the session.
+func (s *Service) tombstoneRelPaths(normalized map[string]struct{}) {
 	s.metaMu.Lock()
-	for _, label := range labelsToDelete {
+	for relPath := range normalized {
+		s.tombstonedRelPaths[relPath] = struct{}{}
+	}
+	s.metaMu.Unlock()
+}
+
+// labelsForRelPaths returns the labels of every registered chunk that belongs to
+// one of the given paths. The O(totalChunks) scan runs under a read lock, so it
+// does not block concurrent searches.
+func (s *Service) labelsForRelPaths(normalized map[string]struct{}) []uint64 {
+	s.metaMu.RLock()
+	defer s.metaMu.RUnlock()
+	var labels []uint64
+	for label, hit := range s.chunkByLabel {
+		if _, ok := normalized[normalizeEvictPath(hit.RelPath)]; ok {
+			labels = append(labels, label)
+		}
+	}
+	return labels
+}
+
+// dropLabels removes the labels from the in-memory metadata and deletes their
+// vectors from the text and code indexes. It is the shared body of
+// EvictDocuments and EvictChunks.
+func (s *Service) dropLabels(labels []uint64) {
+	s.metaMu.Lock()
+	textIndex := s.textIndex
+	codeIndex := s.codeIndex
+	for _, label := range labels {
 		delete(s.chunkByLabel, label)
 	}
 	s.metaMu.Unlock()
+	s.deleteVectors(textIndex, codeIndex, labels)
+}
+
+// deleteVectors drops the labels from both index axes. Delete ignores unknown
+// ids, so a call to both axes is safe whichever one held a given label. A fresh
+// context is used, so the deletion still completes when the triggering query's
+// context was canceled. A failure is logged rather than swallowed; the in-memory
+// metadata and the path tombstone still hide the chunks, so the failure costs
+// index space, not correctness.
+func (s *Service) deleteVectors(textIndex, codeIndex model.Index, labels []uint64) {
+	axes := []struct {
+		name string
+		idx  model.Index
+	}{{"text", textIndex}, {"code", codeIndex}}
+	for _, axis := range axes {
+		if axis.idx == nil {
+			continue
+		}
+		if err := axis.idx.Delete(context.Background(), labels); err != nil {
+			s.logf("evict: %s index delete of %d chunk(s) failed; the chunks stay hidden but their vectors remain: %v",
+				axis.name, len(labels), err)
+		}
+	}
 }
 
 // chunkByIDer is an optional store capability: it resolves a chunk by id,
@@ -993,24 +1083,9 @@ func (s *Service) EvictChunks(labels []uint64) {
 	if len(labels) == 0 {
 		return
 	}
-	s.metaMu.Lock()
-	textIndex := s.textIndex
-	codeIndex := s.codeIndex
-	for _, label := range labels {
-		delete(s.chunkByLabel, label)
-	}
-	s.metaMu.Unlock()
-
-	// Also drop the vectors so the ANN scan stops returning the tombstoned labels
-	// as candidates. Delete ignores unknown ids, so issuing to both indexes is
-	// safe regardless of which one held a given label. A fresh context is used so
-	// the eviction still completes if the triggering query's context was canceled.
-	if textIndex != nil {
-		_ = textIndex.Delete(context.Background(), labels)
-	}
-	if codeIndex != nil {
-		_ = codeIndex.Delete(context.Background(), labels)
-	}
+	// The vectors are dropped as well, so the ANN scan stops returning the
+	// tombstoned labels as candidates.
+	s.dropLabels(labels)
 }
 
 // pruneTombstonedHits drops (and evicts) hits whose chunk was soft-deleted in the
@@ -1053,9 +1128,7 @@ func (s *Service) pruneTombstonedHits(ctx context.Context, hits []model.SearchHi
 // chunk_id belongs to exactly one axis in production, so metadata is kept once in
 // chunkByLabel (issue #429 D1).
 func (s *Service) SetChunkMetadataForIndex(indexName string, label uint64, metadata model.SearchHit) {
-	s.metaMu.Lock()
-	s.chunkByLabel[label] = metadata
-	s.metaMu.Unlock()
+	s.registerChunkMetadata(label, metadata)
 }
 
 func (s *Service) SetRAGSystemPrompt(prompt string) {
@@ -3053,10 +3126,12 @@ func (s *Service) searchHitFromIndexHit(indexName string, h model.IndexHit) mode
 	// The in-memory chunk metadata is authoritative for the default HNSW path:
 	// a missing entry there is the eviction/orphan signal (EvictDocuments
 	// deletes the entry), so we must NOT resurrect such a chunk from the backend
-	// payload. Only fall back to the payload when the service holds no in-memory
-	// metadata at all — i.e. a non-default backend is the sole source of truth.
-	if strings.TrimSpace(hit.RelPath) == "" && !s.hasInMemoryMetadata() {
-		if payloadHit := h.Payload.ToSearchHit(); strings.TrimSpace(payloadHit.RelPath) != "" {
+	// payload. Only fall back to the payload when the service never held any
+	// in-memory metadata (a non-default backend is then the sole source of
+	// truth) and the payload's document is not tombstoned.
+	if strings.TrimSpace(hit.RelPath) == "" {
+		if payloadHit := h.Payload.ToSearchHit(); strings.TrimSpace(payloadHit.RelPath) != "" &&
+			s.payloadFallbackAllowed(payloadHit.RelPath) {
 			hit = payloadHit
 			hit.ChunkID = h.ChunkID
 		}
@@ -3072,15 +3147,27 @@ func (s *Service) searchHitFromIndexHit(indexName string, h model.IndexHit) mode
 	return hit
 }
 
-// hasInMemoryMetadata reports whether any chunk metadata has been registered in
-// the service (via SetChunkMetadata*). When true the in-memory maps are the
-// authoritative source for materialising hits; when false (e.g. an external
-// backend that never populated them) hits are materialised from the backend
-// payload instead.
-func (s *Service) hasInMemoryMetadata() bool {
+// payloadFallbackAllowed reports whether a hit with no in-memory metadata may be
+// materialised from the backend payload of relPath. Two conditions must hold.
+//
+// First, the service must never have registered chunk metadata. Metadata makes
+// the in-memory map authoritative, so a missing entry is the eviction or orphan
+// signal, not a gap to fill from the payload. The test is the metadataRegistered
+// latch, not the size of the map. Eviction of the last document empties the map,
+// so a size test made the deleted document visible again (issue #687).
+//
+// Second, the document must not be tombstoned. A payload-only backend registers
+// no metadata, so eviction can drop no label for it; the path tombstone is the
+// only state that hides the document until the backend deletion propagates
+// (SPEC §6.6).
+func (s *Service) payloadFallbackAllowed(relPath string) bool {
 	s.metaMu.RLock()
 	defer s.metaMu.RUnlock()
-	return len(s.chunkByLabel) > 0
+	if s.metadataRegistered {
+		return false
+	}
+	_, tombstoned := s.tombstonedRelPaths[normalizeEvictPath(relPath)]
+	return !tombstoned
 }
 
 // collectFilteredHits walks one batch of index hits and appends matching hits to

--- a/tests/retrieval/evict_resurrection_test.go
+++ b/tests/retrieval/evict_resurrection_test.go
@@ -1,0 +1,233 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
+)
+
+// payloadOnlyIndex is a test double for an external (Tier C) backend that owns
+// the chunk metadata itself: every hit carries its rel_path/doc_type in the
+// payload, and the service never registers in-memory metadata for those chunks.
+// Delete records the request but removes nothing, which models a native deletion
+// that has not propagated yet. SPEC §6.6 requires retrieval to hide a tombstoned
+// chunk in exactly that window.
+type payloadOnlyIndex struct {
+	entries []model.IndexHit
+	deleted [][]uint64
+}
+
+func newPayloadOnlyIndex(paths ...string) *payloadOnlyIndex {
+	idx := &payloadOnlyIndex{}
+	for i, relPath := range paths {
+		id := uint64(i + 1)
+		idx.entries = append(idx.entries, model.IndexHit{
+			ChunkID: id,
+			Score:   float32(1) - float32(i)/100,
+			Payload: model.IndexPayload{ChunkID: id, RelPath: relPath, DocType: "md"},
+		})
+	}
+	return idx
+}
+
+func (p *payloadOnlyIndex) Upsert(context.Context, []float32, model.IndexPayload) error { return nil }
+
+func (p *payloadOnlyIndex) Delete(_ context.Context, chunkIDs []uint64) error {
+	p.deleted = append(p.deleted, chunkIDs)
+	return nil
+}
+
+func (p *payloadOnlyIndex) Search(_ context.Context, _ []float32, k int, _ model.Filter) ([]model.IndexHit, error) {
+	if k > len(p.entries) {
+		k = len(p.entries)
+	}
+	out := make([]model.IndexHit, k)
+	copy(out, p.entries[:k])
+	return out, nil
+}
+
+func (p *payloadOnlyIndex) Identity(context.Context) (string, error) { return "", nil }
+func (p *payloadOnlyIndex) Reset(context.Context, string) error      { return nil }
+func (p *payloadOnlyIndex) Close() error                             { return nil }
+
+// deleteRefusingIndex wraps the real HNSW index and fails every Delete. It models
+// a backend whose deletion cannot be applied (a network error on an external
+// store, for example). The vectors and payloads stay in the index, so the service
+// alone must keep the evicted document out of the results.
+type deleteRefusingIndex struct {
+	*index.HNSWIndex
+	calls int
+}
+
+func (d *deleteRefusingIndex) Delete(context.Context, []uint64) error {
+	d.calls++
+	return errors.New("backend refuses deletion")
+}
+
+func newEvictionService(t *testing.T, idx model.Index) *retrieval.Service {
+	t.Helper()
+	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+		"mistral-embed": {1, 0},
+	}}, nil)
+	svc.SetHybridEnabled(false) // vector-only: deterministic, no BM25 store dependency
+	return svc
+}
+
+// evictSearchPaths runs one search and returns the rel_path of each hit.
+func evictSearchPaths(t *testing.T, svc *retrieval.Service, query string) []string {
+	t.Helper()
+	return searchRelPaths(t, svc, model.SearchQuery{Query: query, K: 10})
+}
+
+// TestEvictDocuments_LastDocumentDoesNotReturnFromPayload pins issue #687: the
+// corpus holds one document, so evicting it empties the in-memory metadata map.
+// The service must still report zero results. Before the fix the empty map made
+// the backend payload the source of truth again, and the deleted document came
+// back with its rel_path, doc_type and score intact.
+func TestEvictDocuments_LastDocumentDoesNotReturnFromPayload(t *testing.T) {
+	idx := index.NewHNSWIndex("")
+	addVecP(t, idx, 1, []float32{1, 0}, "docs/deleted.md", "md")
+
+	svc := newEvictionService(t, idx)
+	svc.SetChunkMetadata(1, model.SearchHit{ChunkID: 1, RelPath: "docs/deleted.md", DocType: "md", Snippet: "content"})
+
+	if got := evictSearchPaths(t, svc, "content"); len(got) != 1 {
+		t.Fatalf("expected the document before eviction, got %v", got)
+	}
+
+	svc.EvictDocument("docs/deleted.md")
+
+	if got := evictSearchPaths(t, svc, "content"); len(got) != 0 {
+		t.Fatalf("evicted last document came back from the vector payload: %v", got)
+	}
+
+	// The vector is deleted as well, so no orphan stays behind in the backend.
+	hits, err := idx.Search(context.Background(), []float32{1, 0}, 10, model.Filter{})
+	if err != nil {
+		t.Fatalf("index Search: %v", err)
+	}
+	if len(hits) != 0 {
+		t.Fatalf("expected the vector to be deleted from the index, got %v", hits)
+	}
+}
+
+// TestEvictDocuments_BatchEvictionOfEveryDocumentReturnsNothing covers the same
+// transition through a batch delete: one call removes every currently indexed
+// document, so the metadata map empties in one step.
+func TestEvictDocuments_BatchEvictionOfEveryDocumentReturnsNothing(t *testing.T) {
+	idx := index.NewHNSWIndex("")
+	paths := []string{"docs/a.md", "docs/b.md", "docs/c.md"}
+	for i, relPath := range paths {
+		id := uint64(i + 1)
+		addVecP(t, idx, id, []float32{1, float32(i) / 100}, relPath, "md")
+	}
+
+	svc := newEvictionService(t, idx)
+	for i, relPath := range paths {
+		id := uint64(i + 1)
+		svc.SetChunkMetadata(id, model.SearchHit{ChunkID: id, RelPath: relPath, DocType: "md", Snippet: "content"})
+	}
+
+	svc.EvictDocuments(paths)
+
+	if got := evictSearchPaths(t, svc, "content"); len(got) != 0 {
+		t.Fatalf("batch eviction of every document still returns hits: %v", got)
+	}
+}
+
+// TestEvictDocuments_PayloadOnlyBackendKeepsLiveDocuments proves the payload
+// fallback still works for a backend that is the sole source of chunk metadata:
+// the service registers no metadata at all, so live documents must materialise
+// from the payload. Only the evicted document is hidden, and it stays hidden even
+// though the backend deletion did not remove its vector.
+func TestEvictDocuments_PayloadOnlyBackendKeepsLiveDocuments(t *testing.T) {
+	idx := newPayloadOnlyIndex("docs/gone.md", "docs/live.md")
+	svc := newEvictionService(t, idx)
+
+	if got := evictSearchPaths(t, svc, "content"); len(got) != 2 {
+		t.Fatalf("expected both payload documents before eviction, got %v", got)
+	}
+
+	svc.EvictDocument("docs/gone.md")
+
+	got := evictSearchPaths(t, svc, "content")
+	if len(got) != 1 || got[0] != "docs/live.md" {
+		t.Fatalf("expected only docs/live.md after eviction, got %v", got)
+	}
+}
+
+// TestEvictDocuments_PayloadOnlyBackendBatchEvictionReturnsNothing evicts every
+// document of a payload-only backend in one batch. The service holds no metadata
+// for those chunks, so the path tombstone is the only state that can hide them.
+func TestEvictDocuments_PayloadOnlyBackendBatchEvictionReturnsNothing(t *testing.T) {
+	idx := newPayloadOnlyIndex("docs/a.md", "docs/b.md")
+	svc := newEvictionService(t, idx)
+
+	svc.EvictDocuments([]string{"docs/a.md", "docs/b.md"})
+
+	if got := evictSearchPaths(t, svc, "content"); len(got) != 0 {
+		t.Fatalf("payload-only backend still returns evicted documents: %v", got)
+	}
+	// The service holds no metadata for these chunks, so it can resolve no
+	// chunk_id for the paths and issues no backend delete. The vectors stay in
+	// the external store until a reconciliation pass removes them; the tombstone
+	// is what upholds the invariant meanwhile.
+	if len(idx.deleted) != 0 {
+		t.Fatalf("expected no chunk-id delete without in-memory metadata, got %v", idx.deleted)
+	}
+}
+
+// TestEvictDocuments_HidesDocumentWhenBackendDeleteFails covers a backend that
+// cannot apply the deletion. The vector stays in the index, so the invariant of
+// SPEC §6.6 has to hold on the read path alone.
+func TestEvictDocuments_HidesDocumentWhenBackendDeleteFails(t *testing.T) {
+	inner := index.NewHNSWIndex("")
+	addVecP(t, inner, 1, []float32{1, 0}, "docs/deleted.md", "md")
+	idx := &deleteRefusingIndex{HNSWIndex: inner}
+
+	svc := newEvictionService(t, idx)
+	svc.SetChunkMetadata(1, model.SearchHit{ChunkID: 1, RelPath: "docs/deleted.md", DocType: "md", Snippet: "content"})
+
+	svc.EvictDocument("docs/deleted.md")
+
+	if idx.calls == 0 {
+		t.Fatal("expected eviction to ask the backend to delete the vector")
+	}
+	if got := evictSearchPaths(t, svc, "content"); len(got) != 0 {
+		t.Fatalf("evicted document returned after a failed backend delete: %v", got)
+	}
+	// The vector is still in the backend, so the service, not the backend, is
+	// what hides the document.
+	hits, err := inner.Search(context.Background(), []float32{1, 0}, 10, model.Filter{})
+	if err != nil {
+		t.Fatalf("index Search: %v", err)
+	}
+	if len(hits) != 1 {
+		t.Fatalf("expected the vector to survive the refused delete, got %v", hits)
+	}
+}
+
+// TestEvictDocuments_ReindexClearsTheTombstone pins the un-tombstone rule: a file
+// that is deleted and then created again is a live document. Registration of
+// metadata for the path makes it visible once more.
+func TestEvictDocuments_ReindexClearsTheTombstone(t *testing.T) {
+	idx := newPayloadOnlyIndex("docs/recreated.md")
+	svc := newEvictionService(t, idx)
+
+	svc.EvictDocument("docs/recreated.md")
+	if got := evictSearchPaths(t, svc, "content"); len(got) != 0 {
+		t.Fatalf("expected no hits right after eviction, got %v", got)
+	}
+
+	// The file comes back and is indexed again.
+	svc.SetChunkMetadata(1, model.SearchHit{ChunkID: 1, RelPath: "docs/recreated.md", DocType: "md", Snippet: "content"})
+
+	got := evictSearchPaths(t, svc, "content")
+	if len(got) != 1 || got[0] != "docs/recreated.md" {
+		t.Fatalf("expected the re-indexed document to be searchable, got %v", got)
+	}
+}

--- a/tests/retrieval/evict_resurrection_test.go
+++ b/tests/retrieval/evict_resurrection_test.go
@@ -194,8 +194,10 @@ func TestEvictDocuments_HidesDocumentWhenBackendDeleteFails(t *testing.T) {
 
 	svc.EvictDocument("docs/deleted.md")
 
-	if idx.calls == 0 {
-		t.Fatal("expected eviction to ask the backend to delete the vector")
+	// The service points the text and code axis at one index, so the eviction
+	// issues exactly one delete for it.
+	if idx.calls != 1 {
+		t.Fatalf("expected exactly 1 backend delete, got %d", idx.calls)
 	}
 	if got := evictSearchPaths(t, svc, "content"); len(got) != 0 {
 		t.Fatalf("evicted document returned after a failed backend delete: %v", got)

--- a/tests/retrieval/pushdown_test.go
+++ b/tests/retrieval/pushdown_test.go
@@ -113,22 +113,23 @@ func TestSearch_PushDownExcludesNonMatchingPaths(t *testing.T) {
 
 // TestSearch_PushDownWidensPastEvictedChunks is a regression test for the
 // push-down under-fetch bug: the real HNSW index reports CanFilter true, so the
-// filter is pushed down, but in-memory eviction (EvictDocuments) removes only
-// the service's chunk metadata — the vector + payload stay in the HNSW. The
-// post-materialization matchFilters re-check drops those evicted chunks (their
-// in-memory rel_path is gone), so the search must widen the candidate pool to
-// still return k valid hits rather than letting evicted-but-indexed chunks
+// filter is pushed down. The index here refuses every delete, so eviction leaves
+// the vector + payload in the HNSW and only the service's chunk metadata goes
+// away. The post-materialization matchFilters re-check drops those evicted chunks
+// (their in-memory rel_path is gone), so the search must widen the candidate pool
+// to still return k valid hits rather than letting evicted-but-indexed chunks
 // silently shrink the result set below k.
 func TestSearch_PushDownWidensPastEvictedChunks(t *testing.T) {
 	ctx := context.Background()
-	idx := index.NewHNSWIndex("")
+	inner := index.NewHNSWIndex("")
+	idx := &deleteRefusingIndex{HNSWIndex: inner}
 	// 5 chunks under docs/, all matching the path-prefix filter. The first two
 	// (highest-scoring) will be evicted in-memory after indexing.
-	addVecP(t, idx, 1, []float32{1, 0}, "docs/a.md", "md")
-	addVecP(t, idx, 2, []float32{0.99, 0.01}, "docs/b.md", "md")
-	addVecP(t, idx, 3, []float32{0.98, 0.02}, "docs/c.md", "md")
-	addVecP(t, idx, 4, []float32{0.97, 0.03}, "docs/d.md", "md")
-	addVecP(t, idx, 5, []float32{0.96, 0.04}, "docs/e.md", "md")
+	addVecP(t, inner, 1, []float32{1, 0}, "docs/a.md", "md")
+	addVecP(t, inner, 2, []float32{0.99, 0.01}, "docs/b.md", "md")
+	addVecP(t, inner, 3, []float32{0.98, 0.02}, "docs/c.md", "md")
+	addVecP(t, inner, 4, []float32{0.97, 0.03}, "docs/d.md", "md")
+	addVecP(t, inner, 5, []float32{0.96, 0.04}, "docs/e.md", "md")
 
 	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
 		"mistral-embed": {1, 0},


### PR DESCRIPTION
Closes #687.

## The bug

`EvictDocuments` removed only the in-memory chunk metadata (`chunkByLabel`). When an eviction removed the **last** metadata entry, the payload-fallback predicate `len(chunkByLabel) > 0` turned false. `searchHitFromIndexHit` then treated the backend payload as the source of truth, and the deleted document came back with its `rel_path`, `doc_type` and score intact. A corpus of one document returned that document after it was deleted. A batch delete that removed every loaded chunk did the same.

## Claims re-verified against current main

- `EvictDocuments` deleted labels from `chunkByLabel` only, and its comment still said the HNSW index has no delete support. **The comment is out of date.** `Delete` is a required method of `model.Index`, and all four backends implement it: `internal/index/hnsw_index.go`, `internal/index/diskindex`, `internal/index/qdrantindex`, `internal/index/pgvectorindex`. `EvictChunks` already called it; `EvictDocuments` did not.
- `dirstral-spec` SPEC 6.6 confirmed in the submodule: "a vector whose `chunk_id` is tombstoned MUST NOT appear in results even if its native deletion has not yet propagated, so retrieval semantics are identical across backends". The SQLite `deleted=1` tombstone is the source of truth. **No spec change is needed**; this PR makes the code conform to the spec as written, and the submodule pointer is untouched.
- The existing eviction tests all keep at least one non-evicted document, so the empty-map transition had no coverage.

## Why the empty-metadata fallback exists

It is not dead code. An external (Tier C) backend can be the sole source of chunk metadata: the service registers nothing in `chunkByLabel`, and every hit has to be materialised from the backend payload. `tests/retrieval/pushdown_test.go` (`TestSearch_PushesFilterDownAndMaterialisesFromPayload`) pins exactly that: it deliberately registers no metadata and asserts the hit is built from the payload. Removing the fallback would break payload-only startup, so the fallback stays. What changes is the state it consults.

## The fix

1. **Delete the vectors.** `EvictDocuments` now drops the evicted labels from the text and code indexes, the way `EvictChunks` already did. `EvictDocuments` and `EvictChunks` share one `dropLabels` helper. This also stops the orphan-vector growth the issue reports.
2. **Explicit authority state.** The fallback now tests a `metadataRegistered` latch that is set on the first `SetChunkMetadata*` call, not the size of the map. Once metadata is authoritative it stays authoritative, so an eviction that empties the map cannot reopen the fallback.
3. **A read-time tombstone set.** `EvictDocuments` records the normalized path of every evicted document, and the payload fallback refuses a payload whose document is tombstoned.

### Why a tombstone set as well as the delete

Two cases are not covered by deletion alone:

- **A backend `Delete` that fails.** The vector and its payload stay in the index. The metadata latch covers the normal daemon, where metadata is always registered, and the tombstone covers the payload-only deployment.
- **A payload-only backend.** The service holds no metadata for those chunks, so the eviction can resolve no `chunk_id` for the path and has nothing to delete. The path tombstone is the only state that can hide the document until the native deletion propagates. This is exactly the window SPEC 6.6 legislates.

The set is bounded by the number of distinct paths deleted in a session. Registration of metadata for a path clears its tombstone, so a file that is deleted and created again is visible once more.

### Error handling

A failed backend `Delete` is logged with the axis name and the chunk count instead of being discarded (`EvictChunks` used to swallow it with `_ =`). The failure is not fatal: the metadata and the tombstone still hide the chunks, so it costs index space, not correctness. The delete call also carries a 30s timeout, so a hung external backend cannot stall the ingest or watcher loop that drives the eviction.

### Known limitation (not a regression)

For a payload-only backend the service still cannot delete the orphan vectors, because no `chunk_id` can be resolved for the path once the document is tombstoned in SQLite (`EmbeddedChunksByPath` selects live rows only). Reclaiming those vectors needs a store query that enumerates a tombstoned document's chunk ids. That is a separate reconciliation change; the test pins the current behavior so the gap is explicit.

## Tests

New `tests/retrieval/evict_resurrection_test.go`:

- `TestEvictDocuments_LastDocumentDoesNotReturnFromPayload`: the reproduction from the issue. One document, real HNSW index with a payload, evict, search. Also asserts the vector is gone from the index.
- `TestEvictDocuments_BatchEvictionOfEveryDocumentReturnsNothing`: one batch removes every document.
- `TestEvictDocuments_PayloadOnlyBackendKeepsLiveDocuments`: payload-only backend double whose `Delete` removes nothing. The evicted document is hidden and the live one still materialises from the payload.
- `TestEvictDocuments_PayloadOnlyBackendBatchEvictionReturnsNothing`: every document of a payload-only backend, in one batch.
- `TestEvictDocuments_HidesDocumentWhenBackendDeleteFails`: a backend that fails every `Delete`. The vector survives, and the document is still hidden.
- `TestEvictDocuments_ReindexClearsTheTombstone`: a re-created file becomes visible again.

`TestSearch_PushDownWidensPastEvictedChunks` now wraps the HNSW index in the delete-refusing double, so the vectors still survive the eviction and the test keeps exercising the widening overfetch loop it was written for.

**All six new tests were confirmed to FAIL against `main`** with the copy-aside method (copy `internal/retrieval/service.go` to the scratchpad, `git checkout main -- internal/retrieval/service.go`, run, restore). No `git stash` was used at any point. Failures on `main`:

```
--- FAIL: TestEvictDocuments_LastDocumentDoesNotReturnFromPayload
    evicted last document came back from the vector payload: [docs/deleted.md]
--- FAIL: TestEvictDocuments_BatchEvictionOfEveryDocumentReturnsNothing
    batch eviction of every document still returns hits: [docs/a.md docs/b.md docs/c.md]
--- FAIL: TestEvictDocuments_PayloadOnlyBackendKeepsLiveDocuments
    expected only docs/live.md after eviction, got [docs/gone.md docs/live.md]
--- FAIL: TestEvictDocuments_PayloadOnlyBackendBatchEvictionReturnsNothing
    payload-only backend still returns evicted documents: [docs/a.md docs/b.md]
--- FAIL: TestEvictDocuments_HidesDocumentWhenBackendDeleteFails
    expected eviction to ask the backend to delete the vector
--- FAIL: TestEvictDocuments_ReindexClearsTheTombstone
    expected no hits right after eviction, got [docs/recreated.md]
```

## Checks

- `make check` passes, including `gocyclo -over 15` (the eviction body was split into `normalizeEvictPaths`, `tombstoneRelPaths`, `labelsForRelPaths`, `dropLabels`, `deleteVectors`).
- `go test ./tests/retrieval/ -race` passes.
- `coderabbit review` run; its one finding (unbounded delete context) is fixed in the second commit.
- The `dirstral-spec` submodule pointer is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Evicted documents and chunks no longer reappear in search results through retained payloads.
  * Eviction now removes data from available search indexes while gracefully handling deletion failures.
  * Re-indexing a previously evicted document makes it searchable again.
  * Search continues to return live documents correctly when some indexed data has been evicted.

* **Tests**
  * Added coverage for single and batch eviction, failed deletions, payload-only search, and re-indexing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->