### PR TITLE
fix(ingest): retire the representations a changed pipeline no longer produces (#692)

### DIFF
--- a/internal/ingest/reconcile.go
+++ b/internal/ingest/reconcile.go
@@ -1,0 +1,341 @@
+package ingest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// Output-set reconciliation (dir2mcp #692).
+//
+// Incremental ingest treats a document's representations as independent upserts.
+// It writes the outputs the ACTIVE pipeline produces, but it never retires the
+// outputs a PREVIOUS pipeline produced. A representation can stop being wanted
+// for three different reasons, and they need different handling:
+//
+//  1. its derivation identity changed (a new STT/OCR model). §8.6.7 already
+//     covers this: the representation is re-derived in place, so the same
+//     rep_type is overwritten and nothing is left over. No reconciliation needed.
+//  2. the configuration no longer asks for that output at all (a translation
+//     target was removed, hierarchical summaries were switched off). NOTHING
+//     covers this today: the identity gate in §8.6.7 compares a recorded identity
+//     against an ACTIVE one, and when the capability is switched off there is no
+//     active identity to compare against, so the gate self-skips and the old row
+//     stays live and searchable forever. This file covers this case.
+//  3. the document type no longer supports that output. Out of scope here: a
+//     doc_type change is a content change, so the normal content gate already
+//     reprocesses the document.
+//
+// A full reindex does NOT fix case 2 either: `Reindex` clears
+// documents.content_hash to force "changed" semantics, it does not tombstone
+// representations, and re-running the pipeline only upserts the rep_types the
+// current configuration produces. So the leftover row survives `--force` too.
+//
+// Cost. Retiring an output is cheap; rebuilding one may not be. So this
+// reconciliation NEVER retires an output the active configuration still asks
+// for, even when that output failed to derive this run: a best-effort failure
+// leaves the last good row in place. It only retires outputs the operator has
+// explicitly stopped asking for, and both covered outputs are backed by an
+// on-disk derivation cache (translateCacheKey, summaryCacheKey), so re-enabling
+// the target rebuilds them from cache rather than from a paid provider call.
+//
+// Trigger. Reconciliation is gated on the PIPELINE OUTPUT IDENTITY: a compact,
+// greppable fingerprint of the configuration that decides the desired output
+// SET. It is recorded in the store after each completed scan. When the recorded
+// value differs from the active one the next scan reconciles every document it
+// visits — including documents whose content did not change, which is the whole
+// point — and then records the new value. On a steady-state scan the fingerprint
+// matches, and reconciliation costs one settings read for the entire run.
+
+// pipelineOutputIdentity is the canonical fingerprint of the configuration that
+// decides WHICH representation types a document should carry. It deliberately
+// covers only the inputs this reconciliation acts on, so an unrelated config
+// edit does not trigger a corpus-wide pass. It is a readable string rather than
+// a hash so it is greppable in logs and diffable in tests, matching
+// derivationIdentity (§8.6.7).
+func (s *Service) pipelineOutputIdentity() string {
+	translate := "off"
+	if s.cfg.MediaTranslateEnabled {
+		translate = "on"
+	}
+	summary := "off"
+	if s.cfg.HierarchicalDocumentLevelEnabled() {
+		summary = "on"
+	}
+	return fmt.Sprintf("translate=%s:%s|summary=%s",
+		translate, strings.Join(normalizedLanguageList(s.cfg.MediaTranslateTargetLangs), ","), summary)
+}
+
+// normalizedLanguageList lower-cases, trims, de-duplicates and sorts a language
+// tag list so the fingerprint does not change when the operator merely reorders
+// or re-cases the same targets.
+func normalizedLanguageList(langs []string) []string {
+	seen := make(map[string]struct{}, len(langs))
+	out := make([]string, 0, len(langs))
+	for _, lang := range langs {
+		lang = strings.ToLower(strings.TrimSpace(lang))
+		if lang == "" {
+			continue
+		}
+		if _, dup := seen[lang]; dup {
+			continue
+		}
+		seen[lang] = struct{}{}
+		out = append(out, lang)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// activeRepresentationLister is the optional store capability that enumerates a
+// document's active representations. A store without it disables reconciliation
+// entirely, preserving prior behaviour.
+type activeRepresentationLister interface {
+	ActiveRepresentations(ctx context.Context, relPath string) ([]store.RepresentationRow, error)
+}
+
+// representationRetirer is the optional store capability that tombstones a
+// chosen set of representations and their chunks in one transaction.
+type representationRetirer interface {
+	SoftDeleteRepresentations(ctx context.Context, relPath string, repIDs []int64) (int, error)
+}
+
+// pipelineOutputIdentityStore is the optional store capability that persists the
+// pipeline output identity across runs.
+type pipelineOutputIdentityStore interface {
+	PipelineOutputIdentity(ctx context.Context) (string, error)
+	SetPipelineOutputIdentity(ctx context.Context, identity string) error
+}
+
+// beginOutputReconciliation decides whether THIS scan must reconcile the output
+// set of every document it visits, and arms the per-document hook accordingly.
+// It is called once at the start of a scan.
+//
+// It arms the pass when the recorded pipeline output identity differs from the
+// active one, or when the operator forced a reindex (`--force` is the operator's
+// "make it right" lever, so it reconciles as well as re-derives). A corpus that
+// has never recorded an identity is also reconciled once: absence says nothing
+// about which outputs the previous configuration produced, and the pass is a
+// read plus a rare tombstone, so it cannot re-derive anything expensive. That is
+// why this differs from the §8.6.7 "an empty recorded identity always passes"
+// rule, whose whole purpose is to avoid a paid corpus-wide re-derivation.
+func (s *Service) beginOutputReconciliation(ctx context.Context, forceReindex bool) {
+	s.reconcileOutputs = false
+	s.pendingOutputIdentity = ""
+	if _, ok := s.store.(activeRepresentationLister); !ok {
+		return
+	}
+	if _, ok := s.store.(representationRetirer); !ok {
+		return
+	}
+	identityStore, ok := s.store.(pipelineOutputIdentityStore)
+	if !ok {
+		return
+	}
+	active := s.pipelineOutputIdentity()
+	recorded, err := identityStore.PipelineOutputIdentity(ctx)
+	if err != nil {
+		// Fail open: an unreadable setting must not start an unnecessary pass, and
+		// must not fail the scan. The identity stays UNRECORDED as well, so the next
+		// scan gets another chance to compare and reconcile instead of inheriting a
+		// value this run never applied.
+		s.getLogger().Printf("output reconciliation: read pipeline output identity failed, skipping this scan: %v", err)
+		return
+	}
+	s.pendingOutputIdentity = active
+	if recorded == active && !forceReindex {
+		return
+	}
+	s.reconcileOutputs = true
+	s.getLogger().Printf(
+		"output reconciliation: pipeline outputs changed (recorded %q, active %q); retiring representations the current configuration no longer produces (#692)",
+		recorded, active)
+}
+
+// commitOutputReconciliation records the pipeline output identity this scan
+// reconciled the corpus against. It runs only after the scan completed, so an
+// interrupted scan reconciles again on the next run instead of recording an
+// identity it did not finish applying.
+func (s *Service) commitOutputReconciliation(ctx context.Context) {
+	if s.pendingOutputIdentity == "" {
+		// The scan never established a comparable identity (no store capability, or
+		// the read failed), so it has nothing it is entitled to record.
+		return
+	}
+	identityStore, ok := s.store.(pipelineOutputIdentityStore)
+	if !ok {
+		return
+	}
+	if err := identityStore.SetPipelineOutputIdentity(ctx, s.pendingOutputIdentity); err != nil {
+		s.getLogger().Printf("output reconciliation: record pipeline output identity failed: %v", err)
+	}
+	s.pendingOutputIdentity = ""
+}
+
+// reconcileDocumentOutputs retires the document's active representations that
+// the current configuration no longer asks for. It is best-effort by contract:
+// it never returns an error and never changes the document status, because a
+// cleanup failure must not fail an otherwise good ingest. It is a no-op unless
+// this scan armed the pass.
+//
+// Callers MUST invoke it AFTER the document's replacement outputs commit, so a
+// representation is never destroyed before the output that supersedes it exists.
+func (s *Service) reconcileDocumentOutputs(ctx context.Context, relPath string) {
+	if !s.reconcileOutputs {
+		return
+	}
+	lister, ok := s.store.(activeRepresentationLister)
+	if !ok {
+		return
+	}
+	retirer, ok := s.store.(representationRetirer)
+	if !ok {
+		return
+	}
+	reps, err := lister.ActiveRepresentations(ctx, relPath)
+	if err != nil {
+		// A missing document is normal here (a skipped or path-excluded asset), so
+		// this is logged at the same low stakes as any other cleanup miss.
+		return
+	}
+	obsolete := s.obsoleteRepresentations(reps)
+	if len(obsolete) == 0 {
+		return
+	}
+	retired, err := retirer.SoftDeleteRepresentations(ctx, relPath, obsolete)
+	if err != nil {
+		s.getLogger().Printf("output reconciliation: retire representations for %s failed: %v", relPath, err)
+		return
+	}
+	if retired > 0 {
+		s.getLogger().Printf("output reconciliation: retired %d representation(s) for %s that the current pipeline no longer produces (#692)",
+			retired, relPath)
+	}
+}
+
+// obsoleteRepresentations selects, from a document's active representations, the
+// ones the current configuration no longer asks for. It is pure so the policy is
+// testable without a store.
+func (s *Service) obsoleteRepresentations(reps []store.RepresentationRow) []int64 {
+	wantedLangs, langsKnown := s.desiredTranslationTargets()
+	wantSummaries, summariesKnown := s.desiredSummaryOutputs()
+
+	var obsolete []int64
+	for _, rep := range reps {
+		if lang, ok := translatedTranscriptLanguage(rep); ok {
+			if langsKnown && !containsLanguage(wantedLangs, lang) {
+				obsolete = append(obsolete, rep.RepID)
+			}
+			continue
+		}
+		if model.IsSummaryRepType(rep.RepType) && summariesKnown && !wantSummaries {
+			obsolete = append(obsolete, rep.RepID)
+		}
+	}
+	return obsolete
+}
+
+// desiredTranslationTargets returns the set of target languages the active
+// configuration asks translated transcripts for, and whether that set is KNOWN.
+//
+// "Known" is the safety valve. An unresolved translator is NOT the same thing as
+// translation being switched off: a missing credential or a provider that failed
+// to build must leave every existing translation in place, because retiring them
+// would silently discard paid output over a transient wiring problem. So the set
+// is known in exactly two states:
+//
+//   - translation is wired and has targets: the desired set is those targets, so
+//     a REMOVED target is retired while the remaining ones are untouched;
+//   - the operator switched translation off in the configuration AND no
+//     translator is wired: the desired set is empty, so every translation is
+//     retired.
+//
+// Any other state (enabled in configuration but unresolved) reports unknown, and
+// nothing is retired.
+func (s *Service) desiredTranslationTargets() (map[string]struct{}, bool) {
+	if s.translationConfigured() {
+		wanted := make(map[string]struct{}, len(s.translateTargetLangs))
+		for _, lang := range normalizedLanguageList(s.translateTargetLangs) {
+			wanted[lang] = struct{}{}
+		}
+		return wanted, true
+	}
+	if !s.cfg.MediaTranslateEnabled && s.translator == nil && s.translateSTT == nil {
+		return map[string]struct{}{}, true
+	}
+	return nil, false
+}
+
+// desiredSummaryOutputs reports whether the active configuration asks for
+// document-level `summary` representations, and whether that answer is KNOWN. It
+// mirrors desiredTranslationTargets: summaries are known-unwanted only when the
+// operator switched hierarchical document-level generation off AND no summarizer
+// is wired, so a summarizer that failed to resolve never costs an operator their
+// existing summaries.
+//
+// Retiring them is what makes a disabled hierarchical mode actually flat: the
+// summary vectors are additive entries in the document's own vector space
+// (§8.6.7), so leaving them live lets a disabled feature keep consuming result
+// slots.
+func (s *Service) desiredSummaryOutputs() (wanted, known bool) {
+	if s.summaryConfigured() {
+		return true, true
+	}
+	if !s.cfg.HierarchicalDocumentLevelEnabled() && s.summarizer == nil {
+		return false, true
+	}
+	return false, false
+}
+
+// translatedTranscriptLanguage reports whether rep is a TRANSLATED transcript
+// and, if so, its target language.
+//
+// The verdict is read from the recorded provenance (meta_json `source`), never
+// from the rep_type string, for two reasons. A `transcript-<lang>` rep_type is
+// shared by an AUTHORED sidecar transcript (§8.6.4), which no translation
+// setting may ever retire; and a translation of an additional audio track
+// carries a track-qualified rep_type ("transcript@t1-es", §8.6.12), which a
+// rep_type prefix test would miss. A translation whose meta records no language
+// reports false, so an unreadable row is kept rather than guessed at.
+func translatedTranscriptLanguage(rep store.RepresentationRow) (string, bool) {
+	if !strings.HasPrefix(rep.RepType, RepTypeTranscript) {
+		return "", false
+	}
+	metaJSON := strings.TrimSpace(rep.MetaJSON)
+	if metaJSON == "" {
+		return "", false
+	}
+	var meta transcriptMeta
+	if err := json.Unmarshal([]byte(metaJSON), &meta); err != nil {
+		return "", false
+	}
+	if strings.TrimSpace(meta.Source) != translationSource {
+		return "", false
+	}
+	lang := strings.ToLower(strings.TrimSpace(meta.Language))
+	if lang == "" {
+		return "", false
+	}
+	return lang, true
+}
+
+// containsLanguage reports whether a desired-language set holds lang, matching
+// the loose comparison the translate loop uses to skip a no-op self-translation:
+// a tag matches when it equals a wanted tag or shares its primary subtag, so a
+// target written as "pt-BR" keeps a transcript recorded as "pt".
+func containsLanguage(wanted map[string]struct{}, lang string) bool {
+	if _, ok := wanted[lang]; ok {
+		return true
+	}
+	for want := range wanted {
+		if sameLanguage(want, lang) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/ingest/reconcile.go
+++ b/internal/ingest/reconcile.go
@@ -3,7 +3,9 @@ package ingest
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 
@@ -147,10 +149,23 @@ func (s *Service) beginOutputReconciliation(ctx context.Context, forceReindex bo
 		s.getLogger().Printf("output reconciliation: read pipeline output identity failed, skipping this scan: %v", err)
 		return
 	}
-	s.pendingOutputIdentity = active
+	// The identity may be recorded only when this scan can decide the WHOLE
+	// desired set. An unresolved translator or summarizer makes its half UNKNOWN,
+	// so the pass retires nothing for it. Recording the new identity anyway would
+	// mark the cleanup as done, and every later scan would then find the recorded
+	// identity already equal to the active one and never look again. Leaving the
+	// identity unrecorded costs one more armed pass; recording it early loses the
+	// cleanup permanently.
+	_, langsKnown := s.desiredTranslationTargets()
+	_, summariesKnown := s.desiredSummaryOutputs()
+	if langsKnown && summariesKnown {
+		s.pendingOutputIdentity = active
+	}
 	if recorded == active && !forceReindex {
 		return
 	}
+	// The pass is still armed when only one half is unknown: the KNOWN half is
+	// reconciled now, and the unknown half is retried on the next scan.
 	s.reconcileOutputs = true
 	s.getLogger().Printf(
 		"output reconciliation: pipeline outputs changed (recorded %q, active %q); retiring representations the current configuration no longer produces (#692)",
@@ -200,7 +215,10 @@ func (s *Service) reconcileDocumentOutputs(ctx context.Context, relPath string) 
 	reps, err := lister.ActiveRepresentations(ctx, relPath)
 	if err != nil {
 		// A missing document is normal here (a skipped or path-excluded asset), so
-		// this is logged at the same low stakes as any other cleanup miss.
+		// it stays silent. Any other error is a real cleanup miss and is logged.
+		if !errors.Is(err, os.ErrNotExist) {
+			s.getLogger().Printf("output reconciliation: list representations for %s failed: %v", relPath, err)
+		}
 		return
 	}
 	obsolete := s.obsoleteRepresentations(reps)

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -357,6 +357,22 @@ type Service struct {
 	// even when a document produces several (transcript + per-language translations).
 	quarantinedThisDoc bool
 
+	// reconcileOutputs arms the per-document output-set reconciliation (#692) for
+	// the scan currently running. It is set once per scan by
+	// beginOutputReconciliation, when the recorded pipeline output identity no
+	// longer matches the active one (or the operator forced a reindex), and read
+	// by reconcileDocumentOutputs on every asset the scan visits. Keeping it as
+	// per-run state is what makes a steady-state scan free: with no pipeline
+	// change there is one settings read for the whole run and no per-document
+	// query at all.
+	reconcileOutputs bool
+
+	// pendingOutputIdentity holds the pipeline output identity (#692) this scan is
+	// entitled to record when it completes. It is set only when the recorded value
+	// was read successfully, so a scan that could not compare identities records
+	// nothing and leaves the comparison to the next run.
+	pendingOutputIdentity string
+
 	// deferGateDocError suppresses the EAGER per-document status=error marking that
 	// the output quality gate normally applies (recordQualityGateDocError), scoping a
 	// gate rejection to the failing TRACK instead of the whole document (SPEC
@@ -1763,6 +1779,13 @@ func (s *Service) runScan(ctx context.Context) error {
 
 	forceReindex := s.indexingState != nil && s.indexingState.Snapshot().Mode == appstate.ModeFull
 
+	// Arm the output-set reconciliation for this scan (#692) when the pipeline's
+	// desired output SET changed since the last completed scan. This is what makes
+	// an UNCHANGED document eligible for cleanup: the content gate would skip it,
+	// so a removed translation target or a disabled summary level would otherwise
+	// stay searchable forever. It is a no-op on a steady-state scan.
+	s.beginOutputReconciliation(ctx, forceReindex)
+
 	// Optional batch-ergonomics run (SPEC §8.6.11): a JSONL run manifest and/or a
 	// side-channel progress reporter. nil (and inert) unless a media.batch feature
 	// is enabled, so the default ingest path is unchanged.
@@ -1804,13 +1827,26 @@ func (s *Service) runScan(ctx context.Context) error {
 		if err := s.scanPass(ctx, passDerivation, discovered, compiledSecrets, forceReindex, seen); err != nil {
 			return err
 		}
-		return s.markMissingAsDeleted(ctx, existing, seen)
+		return s.finishScan(ctx, existing, seen)
 	}
 
 	if err := s.scanPass(ctx, passSingle, discovered, compiledSecrets, forceReindex, seen); err != nil {
 		return err
 	}
-	return s.markMissingAsDeleted(ctx, existing, seen)
+	return s.finishScan(ctx, existing, seen)
+}
+
+// finishScan closes out a completed scan: it tombstones the documents that are
+// no longer present, then records the pipeline output identity this scan
+// reconciled the corpus against (#692). The identity is recorded LAST, and only
+// on success, so an interrupted scan reconciles again next run rather than
+// claiming a cleanup it did not finish.
+func (s *Service) finishScan(ctx context.Context, existing, seen map[string]struct{}) error {
+	if err := s.markMissingAsDeleted(ctx, existing, seen); err != nil {
+		return err
+	}
+	s.commitOutputReconciliation(ctx)
+	return nil
 }
 
 // scanPass processes every discovered asset once under the given pass (SPEC
@@ -2008,6 +2044,11 @@ func (s *Service) trySkipUnchangedRemoteDocument(ctx context.Context, f Discover
 // representations are still valid. Counters mirror the unchanged-content path so
 // status totals stay consistent across runs.
 func (s *Service) skipUnchangedRemoteDocument(ctx context.Context, f DiscoveredFile, existing model.Document, seen map[string]struct{}) {
+	// The remote fast path returns before processDocument's own reconciliation
+	// call sites, so reconcile here too (#692). Without this, an object-store
+	// corpus would never retire an obsolete output on the path it takes for every
+	// unchanged object.
+	s.reconcileDocumentOutputs(ctx, f.RelPath)
 	switch existing.Status {
 	case "ok":
 		s.addIndexed(1)
@@ -2163,6 +2204,12 @@ func (s *Service) processDocument(ctx context.Context, f DiscoveredFile, secretP
 		// No representation work performed this run (cache hit / unchanged content
 		// / non-ok status): record it as skipped for the batch manifest (§8.6.11).
 		// An ok cache hit is still a durably-indexed document, so credit it.
+		//
+		// This is the incremental path #692 is about. The document is unchanged, so
+		// nothing is re-derived, but the outputs a previous pipeline left on it are
+		// still retired. Retiring costs nothing to undo: both covered outputs are
+		// backed by an on-disk derivation cache.
+		s.reconcileDocumentOutputs(ctx, doc.RelPath)
 		s.creditIndexed(indexedPending)
 		s.markActiveSkipped()
 		return nil
@@ -2184,6 +2231,14 @@ func (s *Service) processDocument(ctx context.Context, f DiscoveredFile, secretP
 	// returns an error, so an absent summary leaves the document fully indexed and
 	// flat-retrievable, and the next scan retries.
 	s.GenerateDocumentSummaries(ctx, doc)
+	// Every output this pipeline produces for the document has now committed, so
+	// it is safe to retire the ones it no longer produces (#692). Running the
+	// reconciliation AFTER the generation pass is what guarantees a representation
+	// is never destroyed before the output that supersedes it exists, and it is
+	// also what makes the batch manifest's `outputs` report the FINAL active set:
+	// recordAssetOutputs reads the representation types after processDocument
+	// returns.
+	s.reconcileDocumentOutputs(ctx, doc.RelPath)
 	// Stamp the withheld #402 done marker now that the
 	// chunks are durably written. finalizeContentHash re-reads the row, so a
 	// document a soft-error path persisted as status="error" is left unmarked and

--- a/internal/store/reconcile.go
+++ b/internal/store/reconcile.go
@@ -1,0 +1,195 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"strings"
+)
+
+// RepresentationRow is a lightweight view of one ACTIVE (non-tombstoned)
+// representation of a document: enough for a caller to decide whether the active
+// pipeline still asks for that output, without loading its chunks or text.
+//
+// It is the read half of the output-set reconciliation (dir2mcp #692). Ingest
+// generates the outputs the CURRENT configuration asks for, then compares this
+// list against that desired set and retires whatever is left over. MetaJSON is
+// the recorded provenance (§5.2): the caller reads `source`, `language`, and the
+// derivation identity from it, so a policy decision never has to parse a
+// rep_type string.
+type RepresentationRow struct {
+	RepID    int64
+	RepType  string
+	MetaJSON string
+}
+
+// ActiveRepresentations returns every active representation of the document at
+// relPath, ordered by rep_id for determinism. An empty slice (with a nil error)
+// means the document exists but has no representations. The document-missing
+// case is reported as os.ErrNotExist, for parity with TranscriptRepresentations
+// and RepresentationMetaByType.
+//
+// This is deliberately a general enumeration rather than a per-type query: the
+// caller reconciles the document's WHOLE output set against the active
+// pipeline's desired set, so it must see outputs the current pipeline no longer
+// produces. A type-scoped query can only ever return the types the caller
+// already thought to ask for, which is exactly the blind spot #692 describes.
+func (s *SQLiteStore) ActiveRepresentations(ctx context.Context, relPath string) ([]RepresentationRow, error) {
+	normalizedPath, err := normalizeRelPath(relPath)
+	if err != nil {
+		return nil, err
+	}
+
+	db, err := s.ensureDB(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer s.ReleaseDB()
+
+	var docID int64
+	if err := db.QueryRowContext(
+		ctx,
+		`SELECT doc_id FROM documents WHERE rel_path = ? AND deleted = 0 LIMIT 1`,
+		normalizedPath,
+	).Scan(&docID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, os.ErrNotExist
+		}
+		return nil, err
+	}
+
+	rows, err := db.QueryContext(
+		ctx,
+		`SELECT rep_id, rep_type, COALESCE(meta_json, '')
+		   FROM representations
+		  WHERE doc_id = ? AND deleted = 0
+		  ORDER BY rep_id ASC`,
+		docID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := make([]RepresentationRow, 0)
+	for rows.Next() {
+		var rep RepresentationRow
+		if err := rows.Scan(&rep.RepID, &rep.RepType, &rep.MetaJSON); err != nil {
+			return nil, err
+		}
+		out = append(out, rep)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// SoftDeleteRepresentations tombstones (deleted = 1) the named representations
+// of the document at relPath together with their chunks, in ONE transaction, and
+// returns how many representations were retired. It is the write half of the
+// output-set reconciliation (#692) and the general form of the targeted
+// SoftDeleteSidecarTranscripts path.
+//
+// The chunk tombstone is what removes the retired output from retrieval: SQLite
+// `deleted = 1` is the source of truth a vector hit is tested against (§6.6), so
+// the stale vectors disappear from the current session AND stay gone after a
+// restart, with no separate vector-index eviction step.
+//
+// repIDs are scoped to relPath, so an id that belongs to another document (or to
+// no document) is ignored rather than retired. An empty repIDs list is a no-op.
+// The document-missing case is reported as os.ErrNotExist.
+func (s *SQLiteStore) SoftDeleteRepresentations(ctx context.Context, relPath string, repIDs []int64) (int, error) {
+	if len(repIDs) == 0 {
+		return 0, nil
+	}
+	normalizedPath, err := normalizeRelPath(relPath)
+	if err != nil {
+		return 0, err
+	}
+
+	db, err := s.ensureDB(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer s.ReleaseDB()
+
+	var docID int64
+	if err := db.QueryRowContext(
+		ctx,
+		`SELECT doc_id FROM documents WHERE rel_path = ? AND deleted = 0 LIMIT 1`,
+		normalizedPath,
+	).Scan(&docID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, os.ErrNotExist
+		}
+		return 0, err
+	}
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	retired := 0
+	for _, repID := range repIDs {
+		// Confirm the representation belongs to this document AND is still active
+		// before touching it. Re-checking inside the transaction keeps the operation
+		// idempotent: a representation another path already retired is not counted
+		// twice.
+		var owned int64
+		if err := tx.QueryRowContext(
+			ctx,
+			`SELECT rep_id FROM representations WHERE rep_id = ? AND doc_id = ? AND deleted = 0`,
+			repID, docID,
+		).Scan(&owned); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				continue
+			}
+			return 0, err
+		}
+		// Chunks first, then the representation: a crash between the two leaves the
+		// representation live with no live chunks, which retrieval already treats as
+		// "nothing to return", rather than a live chunk under a retired parent.
+		if _, err := tx.ExecContext(ctx, `UPDATE chunks SET deleted = 1 WHERE rep_id = ?`, owned); err != nil {
+			return 0, err
+		}
+		if _, err := tx.ExecContext(ctx, `UPDATE representations SET deleted = 1 WHERE rep_id = ?`, owned); err != nil {
+			return 0, err
+		}
+		retired++
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	return retired, nil
+}
+
+// PipelineOutputIdentitySetting is the settings key that records the pipeline
+// output identity (#692) the corpus was last reconciled against. It lives in the
+// same `settings` table as index_format_version, so it survives a restart and
+// costs one read per scan.
+const PipelineOutputIdentitySetting = "pipeline_output_identity"
+
+// PipelineOutputIdentity reads the recorded pipeline output identity. An absent
+// value returns ("", nil): the caller treats it as "never recorded".
+func (s *SQLiteStore) PipelineOutputIdentity(ctx context.Context) (string, error) {
+	value, err := s.GetSetting(ctx, PipelineOutputIdentitySetting)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", nil
+		}
+		return "", err
+	}
+	return strings.TrimSpace(value), nil
+}
+
+// SetPipelineOutputIdentity records the pipeline output identity the corpus is
+// now reconciled against. It is written only after a scan completes, so an
+// interrupted scan reconciles again on the next run.
+func (s *SQLiteStore) SetPipelineOutputIdentity(ctx context.Context, identity string) error {
+	return s.SetSetting(ctx, PipelineOutputIdentitySetting, strings.TrimSpace(identity))
+}

--- a/tests/ingest/reconcile_outputs_692_test.go
+++ b/tests/ingest/reconcile_outputs_692_test.go
@@ -1,0 +1,314 @@
+package tests
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// Output-set reconciliation (dir2mcp #692).
+//
+// Incremental ingest wrote the outputs the ACTIVE pipeline produces but never
+// retired the outputs a PREVIOUS pipeline produced. A removed translation target
+// or a switched-off summary level therefore stayed live, searchable, citable,
+// and exportable forever. A full reindex did not fix it either: a reindex clears
+// documents.content_hash to force reprocessing, it does not tombstone
+// representations.
+//
+// Every test below drives two complete scans over one unchanged corpus, so it
+// exercises the INCREMENTAL path: the second scan finds the content unchanged
+// and derives nothing.
+
+// translateConfig returns a config with transcript translation enabled for the
+// given target languages, as config validation would leave it.
+func translateConfig(root, stateDir string, targets ...string) config.Config {
+	return config.Config{
+		RootDir:                   root,
+		StateDir:                  stateDir,
+		STTProvider:               "off",
+		MediaTranslateEnabled:     true,
+		MediaTranslateTargetLangs: targets,
+	}
+}
+
+// translatingService builds a service that transcribes a media file and
+// translates the transcript into every target language in cfg.
+func translatingService(t *testing.T, cfg config.Config, st model.Store) *ingest.Service {
+	t.Helper()
+	svc := mustNewIngestService(t, cfg, st)
+	svc.SetTranscriber(&fakeTranscriber{text: "[00:00] intro\n[00:02] chapter one"})
+	svc.SetSTTIdentity("whisper", "whisper-large-v3")
+	svc.SetTranscriptLanguage("de")
+	svc.SetTranslator(&fakeTranslator{}, "mistral", "mistral-small-2506", cfg.MediaTranslateTargetLangs)
+	return svc
+}
+
+// activeRepTypes returns the rep_types of a document's live representations.
+func activeRepTypes(t *testing.T, st *store.SQLiteStore, relPath string) map[string]bool {
+	t.Helper()
+	types, err := st.RepresentationTypesByPath(context.Background(), relPath)
+	if err != nil {
+		t.Fatalf("RepresentationTypesByPath(%s): %v", relPath, err)
+	}
+	out := make(map[string]bool, len(types))
+	for _, repType := range types {
+		out[repType] = true
+	}
+	return out
+}
+
+// repIDForType returns the rep_id of a document's live representation of
+// repType, so the test can look at its chunks after it is retired.
+func repIDForType(t *testing.T, st *store.SQLiteStore, relPath, repType string) int64 {
+	t.Helper()
+	reps, err := st.ActiveRepresentations(context.Background(), relPath)
+	if err != nil {
+		t.Fatalf("ActiveRepresentations(%s): %v", relPath, err)
+	}
+	for _, rep := range reps {
+		if rep.RepType == repType {
+			return rep.RepID
+		}
+	}
+	t.Fatalf("no live %q representation on %s (have %+v)", repType, relPath, reps)
+	return 0
+}
+
+// assertChunksTombstoned fails unless every chunk of repID is tombstoned. The
+// SQLite tombstone is what removes a retired output from retrieval, in the
+// current session and after a restart (SPEC §6.6).
+func assertChunksTombstoned(t *testing.T, st *store.SQLiteStore, repID int64) {
+	t.Helper()
+	chunks, err := st.GetChunksByRepID(context.Background(), repID)
+	if err != nil {
+		t.Fatalf("GetChunksByRepID(%d): %v", repID, err)
+	}
+	if len(chunks) == 0 {
+		t.Fatalf("rep %d has no chunks, so the tombstone assertion proves nothing", repID)
+	}
+	for _, chunk := range chunks {
+		if !chunk.Deleted {
+			t.Errorf("chunk %d of retired rep %d is still live; its vector stays searchable", chunk.ChunkID, repID)
+		}
+	}
+}
+
+// TestReconcile_RemovedTranslationTargetIsRetired is the headline case: the
+// operator drops "es" from the target list. The es transcript must be retired,
+// while the still-wanted en transcript and the source transcript are untouched.
+func TestReconcile_RemovedTranslationTargetIsRetired(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	stateDir := t.TempDir()
+	writeFile(t, filepath.Join(root, "talk.mp3"), "fake-audio")
+	st := newRealStore(t)
+	ctx := context.Background()
+
+	first := translatingService(t, translateConfig(root, stateDir, "en", "es"), st)
+	if err := first.Run(ctx); err != nil {
+		t.Fatalf("first scan: %v", err)
+	}
+	types := activeRepTypes(t, st, "talk.mp3")
+	for _, want := range []string{ingest.RepTypeTranscript, ingest.TranscriptRepType("en"), ingest.TranscriptRepType("es")} {
+		if !types[want] {
+			t.Fatalf("first scan did not produce %q (have %v)", want, types)
+		}
+	}
+	esRepID := repIDForType(t, st, "talk.mp3", ingest.TranscriptRepType("es"))
+
+	// Second scan: same corpus, same bytes, "es" removed from the targets.
+	second := translatingService(t, translateConfig(root, stateDir, "en"), st)
+	if err := second.Run(ctx); err != nil {
+		t.Fatalf("second scan: %v", err)
+	}
+
+	types = activeRepTypes(t, st, "talk.mp3")
+	if types[ingest.TranscriptRepType("es")] {
+		t.Errorf("transcript-es is still live after es was removed from the targets (have %v)", types)
+	}
+	if !types[ingest.TranscriptRepType("en")] {
+		t.Errorf("transcript-en was retired, but en is still a configured target (have %v)", types)
+	}
+	if !types[ingest.RepTypeTranscript] {
+		t.Errorf("the source transcript was retired (have %v)", types)
+	}
+	assertChunksTombstoned(t, st, esRepID)
+}
+
+// TestReconcile_DisablingTranslationRetiresEveryTranslation covers the whole
+// capability going away. Both translated transcripts must go; the machine
+// transcript stays, because STT still produces it.
+func TestReconcile_DisablingTranslationRetiresEveryTranslation(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	stateDir := t.TempDir()
+	writeFile(t, filepath.Join(root, "talk.mp3"), "fake-audio")
+	st := newRealStore(t)
+	ctx := context.Background()
+
+	first := translatingService(t, translateConfig(root, stateDir, "en", "es"), st)
+	if err := first.Run(ctx); err != nil {
+		t.Fatalf("first scan: %v", err)
+	}
+
+	// Second scan: translation switched off, and no translator wired.
+	off := config.Config{RootDir: root, StateDir: stateDir, STTProvider: "off"}
+	second := mustNewIngestService(t, off, st)
+	second.SetTranscriber(&fakeTranscriber{text: "[00:00] intro\n[00:02] chapter one"})
+	second.SetSTTIdentity("whisper", "whisper-large-v3")
+	second.SetTranscriptLanguage("de")
+	if err := second.Run(ctx); err != nil {
+		t.Fatalf("second scan: %v", err)
+	}
+
+	types := activeRepTypes(t, st, "talk.mp3")
+	for _, gone := range []string{ingest.TranscriptRepType("en"), ingest.TranscriptRepType("es")} {
+		if types[gone] {
+			t.Errorf("%q is still live after translation was switched off (have %v)", gone, types)
+		}
+	}
+	if !types[ingest.RepTypeTranscript] {
+		t.Errorf("the source transcript was retired (have %v)", types)
+	}
+}
+
+// TestReconcile_UnresolvedTranslatorKeepsTranslations is the cost guard. A
+// missing credential leaves translation enabled but unwired. That is NOT the
+// operator asking for the translations to go away, and re-deriving them costs a
+// paid provider call, so every existing translation must survive.
+func TestReconcile_UnresolvedTranslatorKeepsTranslations(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	stateDir := t.TempDir()
+	writeFile(t, filepath.Join(root, "talk.mp3"), "fake-audio")
+	st := newRealStore(t)
+	ctx := context.Background()
+
+	first := translatingService(t, translateConfig(root, stateDir, "en", "es"), st)
+	if err := first.Run(ctx); err != nil {
+		t.Fatalf("first scan: %v", err)
+	}
+
+	// Second scan: translation still enabled, but the translator failed to build.
+	second := mustNewIngestService(t, translateConfig(root, stateDir, "en", "es"), st)
+	second.SetTranscriber(&fakeTranscriber{text: "[00:00] intro\n[00:02] chapter one"})
+	second.SetSTTIdentity("whisper", "whisper-large-v3")
+	second.SetTranscriptLanguage("de")
+	if err := second.Run(ctx); err != nil {
+		t.Fatalf("second scan: %v", err)
+	}
+
+	types := activeRepTypes(t, st, "talk.mp3")
+	for _, want := range []string{ingest.TranscriptRepType("en"), ingest.TranscriptRepType("es")} {
+		if !types[want] {
+			t.Errorf("%q was retired because the translator did not resolve; paid output must survive a wiring failure (have %v)", want, types)
+		}
+	}
+}
+
+// TestReconcile_SidecarTranscriptSurvivesTranslationOff is the provenance
+// guard. An authored subtitle sidecar persists under the same
+// "transcript-<lang>" rep_type a translation uses. A sidecar is not model
+// output, so no translation setting may ever retire it (§8.6.4).
+func TestReconcile_SidecarTranscriptSurvivesTranslationOff(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	stateDir := t.TempDir()
+	writeFile(t, filepath.Join(root, "talk.mp3"), "fake-audio")
+	writeFile(t, filepath.Join(root, "talk.en.srt"),
+		"1\n00:00:00,000 --> 00:00:02,000\nauthored line\n\n2\n00:00:02,000 --> 00:00:04,000\nsecond line\n")
+	st := newRealStore(t)
+	ctx := context.Background()
+
+	// First scan: translation on, so the pipeline output identity records it.
+	first := mustNewIngestService(t, translateConfig(root, stateDir, "fr"), st)
+	first.SetTranslator(&fakeTranslator{}, "mistral", "mistral-small-2506", []string{"fr"})
+	if err := first.Run(ctx); err != nil {
+		t.Fatalf("first scan: %v", err)
+	}
+	if !activeRepTypes(t, st, "talk.mp3")[ingest.TranscriptRepType("en")] {
+		t.Fatalf("first scan did not ingest the en sidecar (have %v)", activeRepTypes(t, st, "talk.mp3"))
+	}
+
+	// Second scan: translation off entirely. "en" is not a target and never was.
+	second := mustNewIngestService(t, config.Config{RootDir: root, StateDir: stateDir, STTProvider: "off"}, st)
+	if err := second.Run(ctx); err != nil {
+		t.Fatalf("second scan: %v", err)
+	}
+
+	if !activeRepTypes(t, st, "talk.mp3")[ingest.TranscriptRepType("en")] {
+		t.Errorf("the authored en sidecar transcript was retired by a translation setting (have %v)",
+			activeRepTypes(t, st, "talk.mp3"))
+	}
+}
+
+// TestReconcile_SteadyStateScanRetiresNothing pins the no-op case: rescanning
+// with an unchanged pipeline leaves every output in place.
+func TestReconcile_SteadyStateScanRetiresNothing(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	stateDir := t.TempDir()
+	writeFile(t, filepath.Join(root, "talk.mp3"), "fake-audio")
+	st := newRealStore(t)
+	ctx := context.Background()
+
+	for i := 0; i < 3; i++ {
+		svc := translatingService(t, translateConfig(root, stateDir, "en", "es"), st)
+		if err := svc.Run(ctx); err != nil {
+			t.Fatalf("scan %d: %v", i, err)
+		}
+	}
+
+	types := activeRepTypes(t, st, "talk.mp3")
+	for _, want := range []string{ingest.RepTypeTranscript, ingest.TranscriptRepType("en"), ingest.TranscriptRepType("es")} {
+		if !types[want] {
+			t.Errorf("steady-state rescan retired %q (have %v)", want, types)
+		}
+	}
+}
+
+// TestReconcile_DisabledSummariesAreRetired covers the second output type, and
+// with it #686: while a stale `summary` vector stays live, a disabled
+// hierarchical mode is not flat, because the summary keeps consuming result
+// slots.
+func TestReconcile_DisabledSummariesAreRetired(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	stateDir := t.TempDir()
+	writeFile(t, filepath.Join(root, "notes.txt"), "alpha beta gamma delta")
+	st := newRealStore(t)
+	ctx := context.Background()
+
+	on := hierarchicalConfig(stateDir)
+	on.RootDir = root
+	on.STTProvider = "off"
+	first := mustNewIngestService(t, on, st)
+	first.SetSummarizer(&fakeSummarizer{}, "mistral", "mistral-small-latest")
+	if err := first.Run(ctx); err != nil {
+		t.Fatalf("first scan: %v", err)
+	}
+	if !activeRepTypes(t, st, "notes.txt")[model.SummaryRepType] {
+		t.Fatalf("first scan produced no summary (have %v)", activeRepTypes(t, st, "notes.txt"))
+	}
+	summaryRepID := repIDForType(t, st, "notes.txt", model.SummaryRepType)
+
+	// Second scan: hierarchical retrieval switched off, no summarizer wired.
+	second := mustNewIngestService(t, config.Config{RootDir: root, StateDir: stateDir, STTProvider: "off"}, st)
+	if err := second.Run(ctx); err != nil {
+		t.Fatalf("second scan: %v", err)
+	}
+
+	types := activeRepTypes(t, st, "notes.txt")
+	if types[model.SummaryRepType] {
+		t.Errorf("the summary is still live after hierarchical retrieval was switched off (have %v)", types)
+	}
+	if !types[ingest.RepTypeRawText] {
+		t.Errorf("the raw_text representation was retired (have %v)", types)
+	}
+	assertChunksTombstoned(t, st, summaryRepID)
+}

--- a/tests/ingest/reconcile_outputs_692_test.go
+++ b/tests/ingest/reconcile_outputs_692_test.go
@@ -177,11 +177,21 @@ func TestReconcile_DisablingTranslationRetiresEveryTranslation(t *testing.T) {
 	}
 }
 
-// TestReconcile_UnresolvedTranslatorKeepsTranslations is the cost guard. A
-// missing credential leaves translation enabled but unwired. That is NOT the
-// operator asking for the translations to go away, and re-deriving them costs a
-// paid provider call, so every existing translation must survive.
-func TestReconcile_UnresolvedTranslatorKeepsTranslations(t *testing.T) {
+// TestReconcile_UnresolvedTranslatorDefersCleanup is the cost guard. A missing
+// credential leaves translation enabled but unwired. That is NOT the operator
+// asking for the translations to go away, and re-deriving them costs a paid
+// provider call, so every existing translation must survive.
+//
+// The second scan also REMOVES a target, so the pipeline output identity changes
+// and the reconciliation pass is genuinely armed. That is what proves the
+// translations survive through the "desired set unknown" decision rather than
+// because the pass never ran.
+//
+// The third scan then resolves the translator, and the deferred cleanup must
+// still happen. Without it, an unresolved scan would record the new identity,
+// every later scan would see it already matching, and the removed target's
+// transcript would stay live forever.
+func TestReconcile_UnresolvedTranslatorDefersCleanup(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
 	stateDir := t.TempDir()
@@ -194,8 +204,8 @@ func TestReconcile_UnresolvedTranslatorKeepsTranslations(t *testing.T) {
 		t.Fatalf("first scan: %v", err)
 	}
 
-	// Second scan: translation still enabled, but the translator failed to build.
-	second := mustNewIngestService(t, translateConfig(root, stateDir, "en", "es"), st)
+	// Second scan: "es" removed, but the translator failed to build.
+	second := mustNewIngestService(t, translateConfig(root, stateDir, "en"), st)
 	second.SetTranscriber(&fakeTranscriber{text: "[00:00] intro\n[00:02] chapter one"})
 	second.SetSTTIdentity("whisper", "whisper-large-v3")
 	second.SetTranscriptLanguage("de")
@@ -206,8 +216,22 @@ func TestReconcile_UnresolvedTranslatorKeepsTranslations(t *testing.T) {
 	types := activeRepTypes(t, st, "talk.mp3")
 	for _, want := range []string{ingest.TranscriptRepType("en"), ingest.TranscriptRepType("es")} {
 		if !types[want] {
-			t.Errorf("%q was retired because the translator did not resolve; paid output must survive a wiring failure (have %v)", want, types)
+			t.Fatalf("%q was retired while the translator did not resolve; paid output must survive a wiring failure (have %v)", want, types)
 		}
+	}
+
+	// Third scan: the translator resolves, so the deferred cleanup must run.
+	third := translatingService(t, translateConfig(root, stateDir, "en"), st)
+	if err := third.Run(ctx); err != nil {
+		t.Fatalf("third scan: %v", err)
+	}
+
+	types = activeRepTypes(t, st, "talk.mp3")
+	if types[ingest.TranscriptRepType("es")] {
+		t.Errorf("the deferred cleanup never ran: transcript-es is still live (have %v)", types)
+	}
+	if !types[ingest.TranscriptRepType("en")] {
+		t.Errorf("transcript-en was retired, but en is still a configured target (have %v)", types)
 	}
 }
 

--- a/tests/store/reconcile_representations_692_test.go
+++ b/tests/store/reconcile_representations_692_test.go
@@ -1,0 +1,208 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// Store primitives behind output-set reconciliation (dir2mcp #692):
+// ActiveRepresentations enumerates a document's live outputs, and
+// SoftDeleteRepresentations retires a chosen subset with their chunks.
+
+func newReconcileStore(t *testing.T) *store.SQLiteStore {
+	t.Helper()
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	t.Cleanup(func() { _ = st.Close() })
+	if err := st.Init(context.Background()); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	return st
+}
+
+func addDoc(t *testing.T, st *store.SQLiteStore, relPath string) int64 {
+	t.Helper()
+	ctx := context.Background()
+	if err := st.UpsertDocument(ctx, model.Document{
+		RelPath: relPath, DocType: "video", ContentHash: "h-" + relPath, Status: "ok",
+	}); err != nil {
+		t.Fatalf("UpsertDocument(%s): %v", relPath, err)
+	}
+	doc, err := st.GetDocumentByPath(ctx, relPath)
+	if err != nil {
+		t.Fatalf("GetDocumentByPath(%s): %v", relPath, err)
+	}
+	return doc.DocID
+}
+
+func addRep(t *testing.T, st *store.SQLiteStore, docID int64, repType, metaJSON string) int64 {
+	t.Helper()
+	repID, err := st.UpsertRepresentation(context.Background(), model.Representation{
+		DocID: docID, RepType: repType, RepHash: "h-" + repType, MetaJSON: metaJSON,
+	})
+	if err != nil {
+		t.Fatalf("UpsertRepresentation(%s): %v", repType, err)
+	}
+	return repID
+}
+
+func addChunk(t *testing.T, st *store.SQLiteStore, repID int64, ordinal int) {
+	t.Helper()
+	if _, err := st.InsertChunkWithSpans(context.Background(), model.Chunk{
+		RepID: repID, Ordinal: ordinal, Text: "body", TextHash: "th", IndexKind: "text",
+	}, nil); err != nil {
+		t.Fatalf("InsertChunkWithSpans: %v", err)
+	}
+}
+
+// TestActiveRepresentations_ListsLiveOutputs pins the enumeration: every live
+// representation with its rep_type and recorded provenance, ordered by rep_id,
+// and nothing that is already tombstoned.
+func TestActiveRepresentations_ListsLiveOutputs(t *testing.T) {
+	ctx := context.Background()
+	st := newReconcileStore(t)
+	docID := addDoc(t, st, "media/a.mp4")
+	addRep(t, st, docID, "transcript", `{"source":"stt"}`)
+	esRepID := addRep(t, st, docID, "transcript-es", `{"source":"translation","language":"es"}`)
+
+	reps, err := st.ActiveRepresentations(ctx, "media/a.mp4")
+	if err != nil {
+		t.Fatalf("ActiveRepresentations: %v", err)
+	}
+	if len(reps) != 2 {
+		t.Fatalf("reps = %+v, want 2", reps)
+	}
+	if reps[0].RepType != "transcript" || reps[1].RepType != "transcript-es" {
+		t.Errorf("reps are not rep_id ordered: %+v", reps)
+	}
+	if reps[1].MetaJSON != `{"source":"translation","language":"es"}` {
+		t.Errorf("meta_json = %q, want the recorded provenance", reps[1].MetaJSON)
+	}
+
+	if _, err := st.SoftDeleteRepresentations(ctx, "media/a.mp4", []int64{esRepID}); err != nil {
+		t.Fatalf("SoftDeleteRepresentations: %v", err)
+	}
+	reps, err = st.ActiveRepresentations(ctx, "media/a.mp4")
+	if err != nil {
+		t.Fatalf("ActiveRepresentations after retire: %v", err)
+	}
+	if len(reps) != 1 || reps[0].RepType != "transcript" {
+		t.Errorf("retired representation is still listed: %+v", reps)
+	}
+
+	// A missing document is reported as os.ErrNotExist, not as an empty list.
+	if _, err := st.ActiveRepresentations(ctx, "media/nope.mp4"); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("ActiveRepresentations(missing) err = %v, want os.ErrNotExist", err)
+	}
+}
+
+// TestSoftDeleteRepresentations_TombstonesChunks confirms the retired
+// representation's chunks are tombstoned too. The SQLite tombstone is what keeps
+// a retired output out of retrieval, in the session and after a restart.
+func TestSoftDeleteRepresentations_TombstonesChunks(t *testing.T) {
+	ctx := context.Background()
+	st := newReconcileStore(t)
+	docID := addDoc(t, st, "media/a.mp4")
+	keepRepID := addRep(t, st, docID, "transcript", `{"source":"stt"}`)
+	dropRepID := addRep(t, st, docID, "transcript-es", `{"source":"translation","language":"es"}`)
+	addChunk(t, st, keepRepID, 0)
+	addChunk(t, st, dropRepID, 0)
+	addChunk(t, st, dropRepID, 1)
+
+	retired, err := st.SoftDeleteRepresentations(ctx, "media/a.mp4", []int64{dropRepID})
+	if err != nil {
+		t.Fatalf("SoftDeleteRepresentations: %v", err)
+	}
+	if retired != 1 {
+		t.Fatalf("retired = %d, want 1", retired)
+	}
+
+	dropped, err := st.GetChunksByRepID(ctx, dropRepID)
+	if err != nil {
+		t.Fatalf("GetChunksByRepID(dropped): %v", err)
+	}
+	if len(dropped) != 2 {
+		t.Fatalf("dropped chunks = %d, want 2", len(dropped))
+	}
+	for _, chunk := range dropped {
+		if !chunk.Deleted {
+			t.Errorf("chunk %d of a retired representation is still live", chunk.ChunkID)
+		}
+	}
+
+	kept, err := st.GetChunksByRepID(ctx, keepRepID)
+	if err != nil {
+		t.Fatalf("GetChunksByRepID(kept): %v", err)
+	}
+	if len(kept) != 1 || kept[0].Deleted {
+		t.Errorf("the kept representation's chunk was tombstoned: %+v", kept)
+	}
+
+	// Idempotent: retiring the same representation again reports nothing retired.
+	again, err := st.SoftDeleteRepresentations(ctx, "media/a.mp4", []int64{dropRepID})
+	if err != nil {
+		t.Fatalf("SoftDeleteRepresentations (repeat): %v", err)
+	}
+	if again != 0 {
+		t.Errorf("repeat retire = %d, want 0", again)
+	}
+}
+
+// TestSoftDeleteRepresentations_ScopedToDocument is the blast-radius guard: a
+// rep_id that belongs to another document is ignored, so a caller that mixes up
+// two documents cannot retire the wrong corpus.
+func TestSoftDeleteRepresentations_ScopedToDocument(t *testing.T) {
+	ctx := context.Background()
+	st := newReconcileStore(t)
+	aDocID := addDoc(t, st, "media/a.mp4")
+	bDocID := addDoc(t, st, "media/b.mp4")
+	aRepID := addRep(t, st, aDocID, "transcript", `{"source":"stt"}`)
+	bRepID := addRep(t, st, bDocID, "transcript", `{"source":"stt"}`)
+
+	retired, err := st.SoftDeleteRepresentations(ctx, "media/a.mp4", []int64{aRepID, bRepID})
+	if err != nil {
+		t.Fatalf("SoftDeleteRepresentations: %v", err)
+	}
+	if retired != 1 {
+		t.Fatalf("retired = %d, want 1 (the foreign rep_id must be ignored)", retired)
+	}
+
+	bReps, err := st.ActiveRepresentations(ctx, "media/b.mp4")
+	if err != nil {
+		t.Fatalf("ActiveRepresentations(b): %v", err)
+	}
+	if len(bReps) != 1 {
+		t.Errorf("another document's representation was retired: %+v", bReps)
+	}
+}
+
+// TestPipelineOutputIdentity_RoundTrip pins the setting the reconciliation gate
+// reads once per scan: absent reads as empty, and a recorded value survives.
+func TestPipelineOutputIdentity_RoundTrip(t *testing.T) {
+	ctx := context.Background()
+	st := newReconcileStore(t)
+
+	got, err := st.PipelineOutputIdentity(ctx)
+	if err != nil {
+		t.Fatalf("PipelineOutputIdentity (absent): %v", err)
+	}
+	if got != "" {
+		t.Fatalf("absent identity = %q, want empty", got)
+	}
+
+	if err := st.SetPipelineOutputIdentity(ctx, "translate=on:en,es|summary=off"); err != nil {
+		t.Fatalf("SetPipelineOutputIdentity: %v", err)
+	}
+	got, err = st.PipelineOutputIdentity(ctx)
+	if err != nil {
+		t.Fatalf("PipelineOutputIdentity: %v", err)
+	}
+	if got != "translate=on:en,es|summary=off" {
+		t.Errorf("identity = %q, want the recorded value", got)
+	}
+}


### PR DESCRIPTION
Closes #692.

## What is wrong

Incremental ingest treats a document's representations as independent upserts.
It writes the outputs the ACTIVE pipeline produces. It never retires the outputs
a PREVIOUS pipeline produced.

Remove `es` from `media.translate.target_langs` and `transcript-es` stays live:
searchable, citable, exportable, and still occupying vector slots. Switch
hierarchical retrieval off and the `summary` vectors keep consuming result slots,
so a mode that must be flat is not flat.

## What "obsolete" means here

A representation can stop being wanted for three different reasons. They need
different handling, and only one of them is already solved.

1. **Its derivation identity changed** (a new STT or OCR model). SPEC 8.6.7
   already covers this. The representation is re-derived in place, so the same
   `rep_type` is overwritten and nothing is left over. No reconciliation needed.
2. **The configuration no longer asks for that output at all.** Nothing covers
   this today. **This PR covers this case.**
3. **The document type no longer supports that output.** Out of scope: a
   doc_type change is a content change, so the normal content gate already
   reprocesses the document.

## Why 8.6.7 does not reach case 2

The 8.6.7 gate compares a representation's RECORDED derivation identity against
the ACTIVE identity for that capability. When the capability is switched off
there is no active identity to compare against, so `transcriptStale`/`ocrStale`
self-skip by design and preserve the old row. The same is true per language: a
removed target has no active translate identity, so nothing ever flags its
transcript. The gate is a re-derivation trigger, not a set difference.

## A reindex does NOT already fix it

Worth stating plainly, because it changes what the fix has to be. `Reindex`
calls `ClearDocumentContentHashes`, which forces "changed" semantics. It does
not tombstone representations. Re-running the pipeline then only upserts the
`rep_type`s the current configuration produces, so the leftover row survives
`--force` too. This is therefore not only an incremental-path bug, and the fix
is not "make the incremental path behave like a reindex".

The incremental path is still where the interesting half is: an unchanged
document is skipped by the content gate, so a config change must make it
eligible for cleanup by some other route. See "Trigger" below.

## The fix

**Store primitives** (`internal/store/reconcile.go`), mechanism only:

- `ActiveRepresentations(relPath)` enumerates a document's live representations
  with their recorded provenance. Deliberately a general enumeration, not a
  per-type query: a type-scoped query can only return types the caller already
  thought to ask for, which is exactly the blind spot.
- `SoftDeleteRepresentations(relPath, repIDs)` tombstones a chosen subset and its
  chunks in one transaction, scoped to the document so a foreign `rep_id` is
  ignored. It is the general form of the existing targeted
  `SoftDeleteSidecarTranscripts`.
- `PipelineOutputIdentity` / `SetPipelineOutputIdentity` on the existing
  `settings` table.

**Ingest policy** (`internal/ingest/reconcile.go`), decisions only. After the
document's outputs commit, compare the live set against what the configuration
asks for and retire the leftovers.

Vector eviction needs no separate step: the SQLite `deleted = 1` tombstone is the
source of truth a vector hit is tested against (SPEC 6.6), so the stale vectors
disappear in the current session and stay gone after a restart.

## Trigger: pipeline output identity

Reconciliation is gated on a compact, greppable fingerprint of the configuration
that decides the desired output SET, for example
`translate=on:en,es|summary=off`. It is recorded after each completed scan.

- Recorded value equals the active one: the pass never arms. A steady-state scan
  costs one settings read for the whole run and **no per-document query**.
- They differ (or `--force`): the scan reconciles every asset it visits,
  including unchanged ones, then records the new value. That is what makes
  unchanged documents eligible.
- The identity is recorded LAST and only on success, so an interrupted scan
  reconciles again next run instead of claiming a cleanup it did not finish.

A corpus with no recorded identity is reconciled once. This intentionally differs
from the 8.6.7 "an empty recorded identity always passes" rule: that rule exists
to avoid a paid corpus-wide re-derivation on first upgrade, and this pass never
re-derives anything.

## Cases covered

- A translation target removed from `media.translate.target_langs`.
- Translation switched off entirely.
- Document-level hierarchical summaries switched off (also the ingest half of
  #686: a disabled hierarchical mode is now actually flat).

## Cost: the argument for retiring these two, and only these two

Dropping a representation is cheap. Rebuilding one may not be. The policy is
built around that asymmetry.

- **An output the configuration still asks for is never retired**, even when it
  failed to derive this run. A best-effort failure keeps its last good row, which
  is the acceptance criterion about not destroying the last good output.
- **Unresolved is not the same as off.** A missing credential leaves translation
  enabled but unwired. Treating that as "off" would silently discard paid
  translations over a transient wiring problem. The desired set is reported as
  *unknown* in that state and nothing is retired. Same rule for the summarizer.
  A scan in that state also does not RECORD the new pipeline output identity, so
  the cleanup is deferred rather than lost: the next scan with a resolved
  provider still performs it. There is a test for the whole sequence.
- **Both retired outputs are cheap to rebuild.** Translations are cached by
  `translateCacheKey` and summaries by `summaryCacheKey`, both on disk, so
  re-enabling a target rebuilds from cache rather than from a paid provider call.
  Speech to text is never re-run by anything in this PR.
- **Provenance, not `rep_type`, decides.** A `transcript-<lang>` row is shared by
  an AUTHORED subtitle sidecar (8.6.4), which no translation setting may ever
  retire, and a track-qualified translation carries `transcript@t1-es` (8.6.12),
  which a prefix test would miss. The verdict is read from meta_json `source`, so
  both are handled correctly. A row whose meta cannot be read is kept, not
  guessed at.

## Explicitly NOT in this PR

**Creating a newly required output on an unchanged document** (adding `fr` to the
targets). An absent output cannot be told apart from an output that was attempted
and legitimately produced nothing: an empty translation, a self-translation skip
(`sameLanguage`), a quality-gate rejection. Triggering re-derivation on absence
would therefore re-derive those documents on every scan forever and repeat the
provider cost each time. That needs a durable "attempted, produced nothing"
marker first. Until then, the issue's own framing holds: failing to create a
newly enabled output until content changes or `--force` is used is a smaller harm
than serving stale output as current.

Also out of scope, and still open on #692: HTML `raw_text` vs `extracted_markdown`
route switching, multimodal `media` chunks after `augment/replace -> off`,
recognition, per-track selection changes, sidecar changes outside the forced-STT
path, and summary source-representation/prompt/model changes on an unchanged
document. Each needs its own desired-key derivation; the mechanism added here is
the general one they would each plug into.

## Spec

No spec change is needed and the submodule pointer is untouched. This enforces
existing normative behaviour rather than adding any: 6.6 already makes the
SQLite tombstone the retrieval source of truth, and 8.6.7 already states that
toggling hierarchical retrieval is an index add/remove. The spec is silent on
retiring a translated transcript when its target is removed, so a clarifying
spec sentence would be a reasonable follow-up, but nothing here contradicts it.

## Tests

`tests/ingest/reconcile_outputs_692_test.go` drives two complete scans over one
unchanged corpus on a real SQLite store, so it exercises the incremental path:

- removed target `es` retired, `en` and the source transcript untouched, and the
  retired representation's chunks tombstoned;
- translation switched off retires both translations, keeps the STT transcript;
- **an enabled but unresolved translator retires nothing, and the cleanup is
  deferred, not lost**: the scan removes a target (so the pass IS armed) with the
  translator unwired, then a third scan with the translator resolved performs the
  cleanup (the cost guard);
- **an authored `transcript-en` sidecar survives translation being switched off**
  (the provenance guard);
- a steady-state rescan retires nothing;
- hierarchical off retires the `summary`, keeps `raw_text`, tombstones its chunks.

`tests/store/reconcile_representations_692_test.go` pins the primitives:
enumeration order and tombstone filtering, chunk tombstoning, idempotency,
document scoping for a foreign `rep_id`, and the identity round trip.

**Verified against `main` with the copy-aside method** (no `git stash`): with
`internal/ingest/reconcile.go` removed and `internal/ingest/service.go` restored
from `origin/main` (the additive store file kept, since alone it changes no
behaviour), the three transition tests FAIL:

```
--- FAIL: TestReconcile_DisabledSummariesAreRetired
    the summary is still live after hierarchical retrieval was switched off (have map[raw_text:true summary:true])
    chunk 2 of retired rep 2 is still live; its vector stays searchable
--- FAIL: TestReconcile_DisablingTranslationRetiresEveryTranslation
    "transcript-en" is still live after translation was switched off (have map[transcript:true transcript-en:true transcript-es:true])
    "transcript-es" is still live after translation was switched off
--- FAIL: TestReconcile_RemovedTranslationTargetIsRetired
    transcript-es is still live after es was removed from the targets (have map[transcript:true transcript-en:true transcript-es:true])
    chunk 5 of retired rep 3 is still live; its vector stays searchable
```

The guard tests (sidecar survival, steady state) pass both before and after,
which is the point of a guard.

## Review

`coderabbit review` found a real bug in the first commit and it is fixed in the
second: the scan recorded the new pipeline output identity even when the desired
set was unknown, which marked the cleanup as done and lost it permanently. The
identity is now recorded only when the whole desired set is resolvable. The same
review round also flagged that the unresolved-translator test never armed the
pass, so it was rewritten as the three-scan deferred-cleanup sequence above; it
fails against the first commit with "the deferred cleanup never ran:
transcript-es is still live". A store listing failure is now logged instead of
swallowed, with a missing document still silent.

`make check` passes, including `gocyclo -over 15`.
