### PR TITLE
feat(news): gate overlay cues on readability before they become citable (#751)

### DIFF
--- a/annotator/README.md
+++ b/annotator/README.md
@@ -144,15 +144,59 @@ play-by-play, which all resolve names against it. Point dir2mcp at the backend
 as usual and each headline and ticker passage lands as a `recognition` chunk
 with a `time` span, which `ask`/`search` cite directly.
 
-**Known limitation.** Ticker cues can carry a long garbage prefix ahead of
-their real text, where a stable graphic in the band OCRs as a run of repeated
-letters. It agrees across both preprocessing passes, because it is real pixels
-being misread rather than noise, so the agreement floor cannot reject it and
-confidence does not separate it: such reads score 0.90 like the good ones.
+#### The readability gate
 
-The text behind the prefix is intact, so the cue is still usable; what suffers
-is the fraction of a citation that is signal. Two remedies were built and
-measured against real footage, and NEITHER is shipped:
+Agreement decides which band holds an overlay. It does not decide whether the
+words that came off that band are words. A cue therefore passes a second gate,
+and this one is **on by default**: a cue is emitted only if its text is at
+least 20 characters long AND it was read with agreement of at least 0.6.
+
+Measured on 145 cues (94 headline, 51 ticker) from 15 minutes of a TV Rain
+broadcast, read with tesseract `rus`. A cue counted as readable when it held a
+word of 4 or more Cyrillic letters that the programme's own subtitle track also
+held, so the vocabulary came from the same broadcast and needed no external
+dictionary.
+
+| gate | keeps | precision | recall |
+|---|---|---|---|
+| none | 145 | 40.0% | 100.0% |
+| agreement >= 0.6 | 60 | 60.0% | 62.1% |
+| chars >= 20 | 87 | 65.5% | 98.3% |
+| **chars >= 20 and agreement >= 0.6** | **40** | **90.0%** | **62.1%** |
+| chars >= 25 and agreement >= 0.6 | 36 | 91.7% | 56.9% |
+
+Neither signal works alone. Agreement alone is flat: a floor of 0.5 gives 48.5%
+precision and a floor of 1.0 gives 48.8%, while recall falls from 81.0% to
+34.5%. Length alone is the stronger single signal, because the garbage is short
+(median 15 characters against 32), but it tops out near 68%. Together they take
+precision from 40% to 90%.
+
+The gate is on by default because the product of this cascade is citations. The
+ungated stream is 60% noise, so a citation drawn from it is more likely to be
+garbage than text, and a cited span that says nothing costs a reader more than
+a passage never found. The cost is real: 38% of readable passages go with it.
+An operator who wants recall over precision, or who is on footage this
+measurement does not describe, turns the gate off:
+
+```bash
+dirstral-annotate serve --news --news-min-chars 0 --news-min-agreement 0
+```
+
+Both floors are also parameters of `NewsOverlayRecognizer`, and
+`rejected_counts()` reports how many cues per role the gate dropped, so a role
+that found an overlay and could not read it stays distinct from a role that
+found none.
+
+**Known limitation.** The gate rejects a cue that is garbage. It does not clean
+a cue that is PART garbage. Ticker cues can carry a long garbage prefix ahead of
+their real text, where a stable graphic in the band OCRs as a run of repeated
+letters. That text is real pixels being misread rather than noise, so both
+preprocessing passes agree on it and it scores 0.90 like a good read. Such a
+cue is long and firmly read, so it passes the gate, which is the right answer:
+the words behind the prefix are intact and citable.
+
+Four other remedies were built and measured against real footage, and NONE is
+shipped:
 
 - A token-level cleaner dropped real content (`220` out of `около 220 тысяч`,
   and the preposition `К`) while missing the actual garbage, whose character
@@ -161,6 +205,14 @@ measured against real footage, and NEITHER is shipped:
   no candidate dominates: against the current longest-read rule, a medoid
   selector gains 2.8 points of token precision on a ticker with a graphic in
   the band and loses 4.3 precision and 3.7 recall on one without.
+- Vowel fraction. The garbage has MORE vowels than readable text (0.50 against
+  0.44), so it separates the wrong way.
+- Character bigram plausibility. The medians separate but the ranges overlap,
+  and it degenerates on short text, which is where the garbage is.
+
+Cyrillic fraction was also measured and is 1.00 for both populations, because
+the reader is pinned to one script and returns that script whatever the pixels
+were.
 
 See #751.
 

--- a/annotator/dirstral_annotator/cli.py
+++ b/annotator/dirstral_annotator/cli.py
@@ -13,6 +13,10 @@
     # A news archive resolves no roster, so it needs none:
     dirstral-annotate serve --news --ocr-lang rus
 
+    # News overlay cues pass a readability gate before they are emitted.
+    # It is on by default. This turns it off and returns every cue:
+    dirstral-annotate serve --news --news-min-chars 0 --news-min-agreement 0
+
     # Phase-1 accuracy gate against Statcast ground truth
     dirstral-annotate eval game7.mp4 --roster roster.json \
         (--game-pk 745123 | --feed saved-gumbo.json) --anchor "EPOCH=VIDEO_S" \
@@ -56,6 +60,12 @@ def build_parser() -> argparse.ArgumentParser:
         c.add_argument("--faces", type=Path, help="roster image bank dir; enables face recognition")
         c.add_argument("--news", action="store_true",
                        help="enable news overlay text (headline banner + ticker); needs no roster")
+        c.add_argument("--news-min-chars", type=int, metavar="N",
+                       help="drop news overlay cues shorter than N characters "
+                            "(default 20; 0 disables this half of the gate)")
+        c.add_argument("--news-min-agreement", type=float, metavar="F",
+                       help="drop news overlay cues read with less agreement than F "
+                            "(default 0.6; 0 disables this half of the gate)")
         c.add_argument("--ocr-lang", help="OCR language for the overlay readers (e.g. rus)")
         c.add_argument("--fps", type=float, default=0.5, help="frame sampling rate (default 0.5)")
         c.add_argument("--min-confidence", type=float, default=0.0)
@@ -110,6 +120,8 @@ def _pipeline(args, roster: Roster, games) -> Pipeline:
         scorebug_pitch_counts=args.scorebug_pitch_counts,
         jersey=args.jersey,
         news=args.news,
+        news_min_chars=args.news_min_chars,
+        news_min_agreement=args.news_min_agreement,
         ocr_lang=args.ocr_lang,
         faces_bank=args.faces,
         fps=args.fps,

--- a/annotator/dirstral_annotator/pipeline.py
+++ b/annotator/dirstral_annotator/pipeline.py
@@ -61,6 +61,11 @@ class Pipeline:
     scorebug_pitch_counts: bool = False
     jersey: bool = False
     news: bool = False
+    #: Readability gate on the news overlay cues. None keeps the recognizer's
+    #: measured defaults, which are ON: see `READABLE_MIN_CHARS`. An operator
+    #: who wants the ungated stream passes 0 to both.
+    news_min_chars: int | None = None
+    news_min_agreement: float | None = None
     ocr_lang: str | None = None
     faces_bank: Path | None = None
     fps: float = 0.5
@@ -108,7 +113,16 @@ class Pipeline:
             # the payload, not a name to resolve.
             from .recognizers.news import NewsOverlayRecognizer
 
+            # Only the floors an operator actually set are forwarded, so the
+            # measured defaults stay in one place: the recognizer.
+            gate = {}
+            if self.news_min_chars is not None:
+                gate["readable_chars"] = self.news_min_chars
+            if self.news_min_agreement is not None:
+                gate["readable_agreement"] = self.news_min_agreement
             try_recognizer(
-                lambda: NewsOverlayRecognizer(lang=self.ocr_lang, fps=self.fps)
+                lambda: NewsOverlayRecognizer(
+                    lang=self.ocr_lang, fps=self.fps, **gate
+                )
             )
         return cues

--- a/annotator/dirstral_annotator/recognizers/news.py
+++ b/annotator/dirstral_annotator/recognizers/news.py
@@ -41,6 +41,29 @@ inconsistently between the two renderings. They are lost, not misread: a
 dropped frame of a ticker costs nothing, because the passage is still on screen
 in the next one and `collapse_text_sightings` joins the run across the gap.
 
+## Readable enough to cite
+
+Agreement decides which BAND holds an overlay. It does not decide whether the
+words that came off that band are words. A fixed graphic inside the band is
+real pixels, so both passes misread it the same way and it scores as high as a
+clean read. The output is therefore citable text of which most is noise, and a
+citation pointing at noise is worse than no citation at all.
+
+So an emitted cue passes a second gate, on the cue rather than on the band.
+See `READABLE_MIN_CHARS` for the measurement that chose it. Two properties of
+where the gate sits matter:
+
+* It runs AFTER the collapse, on the cue, because that is what was measured
+  and what a consumer cites. A per-frame gate would also change which band
+  locks, since `interpret` supplies the band search its evidence: a short read
+  is still evidence that this band carries an overlay, and rejecting it there
+  would move the lock and change what gets READ, not just what gets emitted.
+* It drops the cue instead of lowering its confidence. Confidence here means
+  agreement between the passes and nothing else, and `fusion.fuse` combines
+  confidences under noisy-OR, so two rejected cues of one passage would
+  compound back into a high-confidence annotation. A floor that is not applied
+  is also no floor: `min_confidence` defaults to 0.0.
+
 ## One reader per role
 
 `_RegionSearch` locks a single band and `OverlayReader.read` stops a frame once
@@ -70,9 +93,12 @@ __all__ = [
     "DEFAULT_AGREEMENT",
     "HEADLINE_REGIONS",
     "NEWS_ROLES",
+    "READABLE_MIN_AGREEMENT",
+    "READABLE_MIN_CHARS",
     "TICKER_REGIONS",
     "NewsOverlayRecognizer",
     "OverlayRole",
+    "is_readable",
     "read_agreement",
 ]
 
@@ -81,6 +107,45 @@ __all__ = [
 #: background population sat at 0.00, so this is a floor with room under it
 #: rather than a boundary between two touching distributions.
 DEFAULT_AGREEMENT = 0.3
+
+#: The readability gate on an emitted cue: how many characters its text must
+#: carry, and how firmly that text must have been read. Both floors apply, and
+#: either one set to 0 switches its half of the gate off.
+#:
+#: Measured on 145 cues (94 headline, 51 ticker) from 15 minutes of a TV Rain
+#: broadcast at 720p, read with tesseract `rus`. A cue counted as readable when
+#: it held a word of 4 or more Cyrillic letters that the programme's own
+#: subtitle track also held, so the vocabulary came from the same broadcast and
+#: needed no external dictionary. Garbled text almost never lands on a real
+#: word by accident.
+#:
+#:   | gate                             | keeps | precision | recall |
+#:   |----------------------------------|-------|-----------|--------|
+#:   | none                             |   145 |     40.0% | 100.0% |
+#:   | agreement >= 0.6                 |    60 |     60.0% |  62.1% |
+#:   | chars >= 20                      |    87 |     65.5% |  98.3% |
+#:   | chars >= 20 and agreement >= 0.6 |    40 |     90.0% |  62.1% |
+#:   | chars >= 25 and agreement >= 0.6 |    36 |     91.7% |  56.9% |
+#:
+#: Neither signal works alone. Agreement alone is flat, not weak: a floor of
+#: 0.5 gives 48.5% precision and a floor of 1.0 gives 48.8%, while recall falls
+#: from 81.0% to 34.5%. Length alone is the stronger single signal, because the
+#: garbage is short (median 15 characters against 32), but it tops out near
+#: 68%. Together they take precision from 40% to 90%, and that is the point:
+#: agreement carries real information once the short fragments are gone.
+#:
+#: 20 and 0.6 is the knee. Moving the length floor to 25 buys 1.7 points of
+#: precision for 5.2 points of recall.
+#:
+#: Measured on the same cues and REJECTED: vowel fraction (the garbage has MORE
+#: vowels, 0.50 against 0.44, so it separates the wrong way), Cyrillic fraction
+#: (1.00 for both, because the reader is pinned to one script), and character
+#: bigram plausibility (the medians separate but the ranges overlap, and it
+#: degenerates on short text, which is exactly where the garbage is).
+#:
+#: One corpus is one corpus, so both floors are parameters. See #751.
+READABLE_MIN_CHARS = 20
+READABLE_MIN_AGREEMENT = 0.6
 
 #: Candidate bands for a headline banner, and for a ticker along the bottom.
 #: Broadcast convention rather than one broadcaster's layout, in the spirit of
@@ -142,6 +207,22 @@ def read_agreement(read: OverlayRead) -> float:
     )
 
 
+def is_readable(
+    cue: Cue,
+    *,
+    min_chars: int = READABLE_MIN_CHARS,
+    min_agreement: float = READABLE_MIN_AGREEMENT,
+) -> bool:
+    """Whether a cue carries words rather than misread pixels.
+
+    Both floors have to hold. Each one alone admits most of the garbage; see
+    `READABLE_MIN_CHARS` for the numbers. The cue's confidence IS the run's
+    agreement, so this is the same quantity the band floor uses, applied a
+    second time at a higher level and a higher threshold.
+    """
+    return len(cue.text.strip()) >= min_chars and cue.confidence >= min_agreement
+
+
 def _fullest(read: OverlayRead) -> str:
     """The pass that recovered the most words.
 
@@ -164,6 +245,11 @@ class _RoleReader:
     #: discarded with the generator, so the interpreter is the only place that
     #: sees which region answered.
     answered: Region | None = None
+    #: How many collapsed cues the readability gate dropped on the last run.
+    #: Without it an empty result is ambiguous: a role that found no overlay
+    #: and a role that found one and could not read it look the same, and they
+    #: are different answers, exactly as `answered` exists to say.
+    rejected: int = 0
 
     def interpret(self, read: OverlayRead) -> tuple[str, int]:
         """Return this band's text and whether it counts as evidence.
@@ -194,6 +280,12 @@ class NewsOverlayRecognizer:
     Confidence is the agreement between the preprocessing passes, which is a
     statement about how firmly the text was read and not about whether it is
     true. Nothing here resolves an entity, so cues carry no `entity_ids`.
+
+    A cue that fails the readability gate is not emitted. The gate is ON by
+    default, because the ungated output measured 40% precision and the product
+    of this cascade is citations: a cited span whose text is noise costs more
+    than a passage never found. `readable_chars=0, readable_agreement=0.0`
+    turns it off and returns the ungated stream.
     """
 
     name = "news"
@@ -206,6 +298,8 @@ class NewsOverlayRecognizer:
         psm: int | None = None,
         fps: float = 0.5,
         agreement: float = DEFAULT_AGREEMENT,
+        readable_chars: int = READABLE_MIN_CHARS,
+        readable_agreement: float = READABLE_MIN_AGREEMENT,
         workers: int | None = None,
         ocr: OcrFn | None = None,
         similarity: float | None = None,
@@ -216,6 +310,12 @@ class NewsOverlayRecognizer:
             raise ValueError("a news recognizer needs at least one overlay role")
         if not 0.0 <= agreement <= 1.0:
             raise ValueError(f"agreement floor out of [0,1]: {agreement}")
+        if readable_chars < 0:
+            raise ValueError(f"readable_chars must not be negative: {readable_chars}")
+        if not 0.0 <= readable_agreement <= 1.0:
+            raise ValueError(
+                f"readability agreement floor out of [0,1]: {readable_agreement}"
+            )
         # Checked here rather than at the first division: every timing this
         # class derives is 1/fps or a multiple, so a zero raises deep inside a
         # collapse and a negative one quietly produces cues that end before
@@ -224,6 +324,8 @@ class NewsOverlayRecognizer:
             raise ValueError(f"fps must be positive: {fps}")
         self.fps = fps
         self.agreement = agreement
+        self.readable_chars = readable_chars
+        self.readable_agreement = readable_agreement
         self.similarity = similarity
         self.roles = roles
         # The collapse gap has to be at least the BAND SEARCH's sampling
@@ -263,6 +365,7 @@ class NewsOverlayRecognizer:
             # PREVIOUS file answered from.
             role_reader.sightings.clear()
             role_reader.answered = None
+            role_reader.rejected = 0
             # `closing` because the reader owns a worker pool and a scratch
             # directory for the length of the iteration: abandoning it part way
             # through has to shut them down now, not at collection.
@@ -277,7 +380,7 @@ class NewsOverlayRecognizer:
 
     def _collapse(self, role_reader: _RoleReader) -> list[Cue]:
         extra = {} if self.similarity is None else {"similarity": self.similarity}
-        return collapse_text_sightings(
+        cues = collapse_text_sightings(
             role_reader.sightings,
             source=self.name,
             event=role_reader.role.event,
@@ -288,6 +391,21 @@ class NewsOverlayRecognizer:
             cue_gap=1.0 / self.fps,
             **extra,
         )
+        # The gate goes here, on the whole run's cue, because the run is what
+        # was measured and what a consumer cites. It cannot go in `interpret`:
+        # that return value is the band search's evidence, so rejecting a short
+        # read there would move the lock and change which band gets read.
+        keep = [
+            cue
+            for cue in cues
+            if is_readable(
+                cue,
+                min_chars=self.readable_chars,
+                min_agreement=self.readable_agreement,
+            )
+        ]
+        role_reader.rejected = len(cues) - len(keep)
+        return keep
 
     @property
     def regions(self) -> tuple[Region, ...]:
@@ -307,6 +425,15 @@ class NewsOverlayRecognizer:
         finding one and reading it badly. None until a `recognize` has run.
         """
         return {rr.role.event: rr.answered for rr in self._readers}
+
+    def rejected_counts(self) -> dict[str, int]:
+        """How many cues per role the readability gate dropped, after a `recognize`.
+
+        A role that answered from a band and still emitted nothing found an
+        overlay it could not read, which is a different answer from finding no
+        overlay. Zero until a `recognize` has run.
+        """
+        return {rr.role.event: rr.rejected for rr in self._readers}
 
 
 def roles_from(spec: Sequence[tuple[str, Sequence[Region]]]) -> tuple[OverlayRole, ...]:

--- a/annotator/tests/test_news.py
+++ b/annotator/tests/test_news.py
@@ -8,11 +8,15 @@ evidence that a band holds an overlay, and what shape the cues come out in.
 import pytest
 
 from dirstral_annotator.recognizers import news, overlay
+from dirstral_annotator.model import Cue
 from dirstral_annotator.recognizers.news import (
     DEFAULT_AGREEMENT,
     NEWS_ROLES,
+    READABLE_MIN_AGREEMENT,
+    READABLE_MIN_CHARS,
     NewsOverlayRecognizer,
     OverlayRole,
+    is_readable,
     read_agreement,
 )
 from dirstral_annotator.recognizers.overlay import OverlayRead
@@ -77,7 +81,9 @@ def bands(monkeypatch, tmp_path):
 
     `install({region: text_or_fn})` makes every sampled frame answer with that
     text for that band. A callable receives the frame index, which is how a
-    scrolling ticker is expressed.
+    scrolling ticker is expressed. A tuple is the two preprocessing passes
+    said separately, which is how a band the passes only half agree on is
+    expressed; a plain string is a legible band, where they agree.
     """
 
     def install(script, frames=40, fps=0.5):
@@ -92,6 +98,8 @@ def bands(monkeypatch, tmp_path):
             i = index[frame]
             value = script.get(tuple(region), "")
             text = value(i) if callable(value) else value
+            if isinstance(text, tuple):
+                return list(text)
             # Both preprocessing passes: a scripted band is a legible one, so
             # they agree, which is exactly what the interpreter looks for.
             return [text, text]
@@ -262,6 +270,123 @@ def test_a_non_positive_fps_is_refused_at_construction():
         NewsOverlayRecognizer(fps=-0.5)
 
 
+# --- the readability gate ---------------------------------------------------
+#
+# Agreement says which BAND holds an overlay. It does not say whether the words
+# that came off it are words. Measured on 145 cues of real TV Rain footage, the
+# ungated stream is 40.0% precision: 60% of what a reader would cite is noise.
+# The gate is `chars >= 20 and agreement >= 0.6`, which measured 90.0%
+# precision at 62.1% recall. See READABLE_MIN_CHARS for the full table.
+
+#: The shape of the garbage: short. Median 15 characters, against 32 for a
+#: readable cue. This one is 14, and both passes agree on it perfectly, which
+#: is why the agreement floor alone cannot reject it.
+SHORT_GARBAGE = "ЕЕК ЕЕЕ НЕЕЕЕ"
+
+#: Long enough to pass the length floor, and the two passes only half agree:
+#: three of six tokens survive both renderings, so agreement is 0.50. This is
+#: an all-caps display face OCR'ing inconsistently, which the module docstring
+#: describes; the reader should decline to cite it.
+HALF_READ = (
+    "Правительство одобрило новые правила перевозки грузов",
+    "Правительстзо одобрило нозые правила перевозки грузоз",
+)
+
+
+def test_the_measured_thresholds_are_what_ships():
+    """Anyone changing these is changing a measured claim, not a taste."""
+    assert READABLE_MIN_CHARS == 20
+    assert READABLE_MIN_AGREEMENT == pytest.approx(0.6)
+
+
+def test_neither_signal_gates_alone():
+    """The finding that chose this gate. Length alone tops out at 65.5%
+    precision and agreement alone is flat (48.5% at 0.5, 48.8% at 1.0), so
+    both floors have to hold."""
+    long_and_firm = Cue(source="news", start_s=0.0, end_s=1.0, event="headline",
+                        entity_ids=(), confidence=0.9, text=HEADLINE)
+    assert is_readable(long_and_firm)
+    # Firmly read, and too short to be a sentence.
+    short = Cue(source="news", start_s=0.0, end_s=1.0, event="headline",
+                entity_ids=(), confidence=1.0, text=SHORT_GARBAGE)
+    assert not is_readable(short)
+    # Long, and the passes did not agree it says this.
+    weak = Cue(source="news", start_s=0.0, end_s=1.0, event="headline",
+               entity_ids=(), confidence=0.5, text=HEADLINE)
+    assert not is_readable(weak)
+
+
+def test_a_short_cue_is_not_emitted(bands):
+    """A citation pointing at noise is worse than no citation, so the gate is
+    on by default. The band is still found: the gate changes what is emitted,
+    not what is read."""
+    bands({HEADLINE_BAND: SHORT_GARBAGE})
+    recognizer = NewsOverlayRecognizer(workers=1)
+    assert only(recognizer, "headline") == []
+    assert recognizer.answered_regions()["headline"] == HEADLINE_BAND
+
+
+def test_a_cue_the_passes_only_half_agreed_on_is_not_emitted(bands):
+    """Long enough, and read at 0.50. That clears the band floor of 0.3,
+    because the band really does hold an overlay, and it fails the cue floor
+    of 0.6, because the words are not trustworthy enough to quote."""
+    bands({HEADLINE_BAND: HALF_READ})
+    (cue,) = only(NewsOverlayRecognizer(workers=1, readable_agreement=0.0), "headline")
+    assert cue.confidence == pytest.approx(0.5)
+    assert len(cue.text) >= READABLE_MIN_CHARS
+
+    assert only(NewsOverlayRecognizer(workers=1), "headline") == []
+
+
+def test_the_gate_can_be_turned_off(bands):
+    """The trade costs 38% of recall, which is a real loss. An operator on
+    footage this measurement does not describe gets the ungated stream."""
+    bands({HEADLINE_BAND: SHORT_GARBAGE})
+    ungated = NewsOverlayRecognizer(
+        workers=1, readable_chars=0, readable_agreement=0.0
+    )
+    (cue,) = only(ungated, "headline")
+    assert cue.text == SHORT_GARBAGE
+
+
+def test_a_readable_cue_is_untouched_by_the_gate(bands):
+    """The gate drops cues; it does not edit them. A headline that passes must
+    come out byte-identical to the ungated one."""
+    bands({HEADLINE_BAND: HEADLINE})
+    (gated,) = only(NewsOverlayRecognizer(workers=1), "headline")
+    bands({HEADLINE_BAND: HEADLINE})
+    (ungated,) = only(
+        NewsOverlayRecognizer(workers=1, readable_chars=0, readable_agreement=0.0),
+        "headline",
+    )
+    assert gated == ungated
+
+
+def test_the_gate_reports_what_it_dropped(bands):
+    """An empty result has two meanings: no overlay, or an overlay nobody
+    could read. Those are different answers, so the count is reported."""
+    bands({HEADLINE_BAND: SHORT_GARBAGE})
+    recognizer = NewsOverlayRecognizer(workers=1)
+    assert recognizer.recognize(MEDIA) == []
+    assert recognizer.rejected_counts()["headline"] == 1
+    assert recognizer.rejected_counts()["ticker"] == 0
+
+    # And a second file with nothing in the band must not report the first
+    # file's rejections, for the same reason `answered_regions` is cleared.
+    bands({BACKGROUND: "чтото в кадре"})
+    assert recognizer.recognize(MEDIA) == []
+    assert set(recognizer.rejected_counts().values()) == {0}
+
+
+def test_impossible_gate_floors_are_refused_at_construction():
+    with pytest.raises(ValueError):
+        NewsOverlayRecognizer(readable_chars=-1)
+    with pytest.raises(ValueError):
+        NewsOverlayRecognizer(readable_agreement=1.5)
+    with pytest.raises(ValueError):
+        NewsOverlayRecognizer(readable_agreement=-0.1)
+
+
 # --- wiring -----------------------------------------------------------------
 
 def test_the_news_recognizer_needs_no_roster():
@@ -299,4 +424,36 @@ def test_the_pipeline_runs_the_news_recognizer_when_asked(monkeypatch, tmp_path)
     pipeline_mod.Pipeline(
         roster=Roster([]), news=True, ocr_lang="rus", fps=0.25
     ).cues_for(media)
+    # No gate arguments: the measured defaults live in the recognizer, and the
+    # pipeline forwards only what an operator actually set.
     assert built == {"lang": "rus", "fps": 0.25}
+
+
+def test_the_gate_floors_reach_the_recognizer_from_argv(monkeypatch, tmp_path):
+    """A flag parsed but never threaded is the usual way an option silently
+    does nothing, and this one's job is to turn a default-on gate off."""
+    from dirstral_annotator import pipeline as pipeline_mod
+    from dirstral_annotator.cli import _pipeline, build_parser
+    from dirstral_annotator.recognizers import news as news_mod
+    from dirstral_annotator.roster import Roster
+
+    built = {}
+
+    class Fake:
+        def __init__(self, **kwargs):
+            built.update(kwargs)
+
+        def recognize(self, media_path):
+            return []
+
+    monkeypatch.setattr(news_mod, "NewsOverlayRecognizer", Fake)
+    monkeypatch.setattr(pipeline_mod, "fuse", lambda cues, min_confidence=0.0: [])
+    media = tmp_path / "broadcast.mp4"
+    media.write_bytes(b"")
+
+    args = build_parser().parse_args(
+        ["serve", "--news", "--news-min-chars", "0", "--news-min-agreement", "0"]
+    )
+    _pipeline(args, Roster([]), {}).cues_for(media)
+    assert built["readable_chars"] == 0
+    assert built["readable_agreement"] == pytest.approx(0.0)


### PR DESCRIPTION
Closes #751.

The measurement the issue demanded is in its final comment: 145 cues (94 headline, 51 ticker) from 15 minutes of TV Rain, read with tesseract `rus`, scored against the programme's own `.ru.vtt` vocabulary. This PR is the gate that measurement chose.

## What the numbers say

The ungated stream is **40.0% precision**. A citation drawn from a news overlay today is more likely to be noise than to be text.

| gate | keeps | precision | recall |
|---|---|---|---|
| none | 145 | 40.0% | 100.0% |
| agreement >= 0.6 | 60 | 60.0% | 62.1% |
| chars >= 20 | 87 | 65.5% | 98.3% |
| **chars >= 20 and agreement >= 0.6** | **40** | **90.0%** | **62.1%** |
| chars >= 25 and agreement >= 0.6 | 36 | 91.7% | 56.9% |

Neither signal works alone. Confidence is not weak, it is **flat**: a floor of 0.5 gives 48.5% precision and a floor of 1.0 gives 48.8%, while recall falls from 81.0% to 34.5%. Length is the stronger single signal, because the garbage is short (median 15 characters against 32), but it tops out near 68%. Together they take precision from 40% to 90%. Agreement carries real information once the short fragments are gone.

`20` and `0.6` is the knee. Moving the length floor to 25 buys 1.7 points of precision for 5.2 points of recall.

Measured on the same cues and **rejected**: vowel fraction (the garbage has more vowels, 0.50 against 0.44, so it separates the wrong way), Cyrillic fraction (1.00 for both, because the reader is pinned to one script), character bigram plausibility (medians separate, ranges overlap, and it degenerates on short text, which is where the garbage is). All three are recorded in the constant's comment and in the README, next to the four ideas this milestone already failed to ship.

## Decision 1: on by default, not opt-in

The issue suggested opt-in. This ships it **on**.

The cost of the gate is real and I am not hiding it: 38% of readable passages are dropped. But the two errors are not symmetric. A passage never found is a gap a reader can fill another way. A cited span whose text is noise spends the reader's trust in every other citation the product makes, because a citation is a claim that this span says something.

The repo already made this call in #779, which took a recall gain (86.9% to 90.1%) **off** by default because it also invented pitches, on the reasoning that "a cited moment that did not happen costs more than a moment never found". Defaulting a 40%-precision stream to on is the same mistake with the sign flipped: it makes the operator opt in to correctness.

The escape hatch is one command, and it is documented in the CLI docstring and the README:

```bash
dirstral-annotate serve --news --news-min-chars 0 --news-min-agreement 0
```

Both floors are also `NewsOverlayRecognizer` parameters, because one corpus is one corpus and the next person may need to re-cut them.

## Decision 2: the gate drops the cue, after the collapse

Three places were possible. The choice is argued in the module docstring, not just here.

**After the collapse, on the cue.** That is what was measured (`n_chars` and `conf` are properties of a cue) and what a consumer cites.

**Not in `interpret`.** That return value is the band search's evidence, so rejecting a short read there would move the band lock and change what gets **read**, not just what gets emitted. A short read is still evidence that this band holds an overlay.

**Not by lowering confidence and letting fusion decide.** Three reasons:
- Confidence here means agreement between the two preprocessing passes and nothing else. Overloading it to also mean readability would make it unreadable as either.
- `fusion.fuse` combines confidences under noisy-OR, so two marked-down cues of one passage would compound back into a high-confidence annotation.
- `min_confidence` defaults to 0.0, so the floor would not be applied at all unless an operator set one. A gate nobody applies is not a gate.

## What the gate does not do

It rejects a cue that **is** garbage. It does not clean a cue that is **part** garbage. The long garbage prefix from a fixed graphic in the ticker band still rides on real text, and such a cue is long and firmly read, so it passes. That is the right answer: the words behind the prefix are intact and citable. The remaining lever there is spatial, and #751's second comment says why it is not urgent.

## Also here

`rejected_counts()` reports what the gate dropped per role. With a default-on gate, an empty result would otherwise be ambiguous between "no overlay in this footage" and "an overlay nobody could read", which are different answers. That is the same distinction `answered_regions()` exists to preserve.

## Testing

`make check` passes. The annotator suite passes: 288 tests.

The 8 new tests were confirmed to fail against `main` by the copy-aside method (no `git stash`): the working files were copied to a scratch directory, `git checkout origin/main --` restored main's copies, and the suite was run. Because the new tests import names main does not have, collection failed as an `ImportError`, which proves nothing about behaviour. So the constants and `is_readable` were shimmed onto main's recognizer, leaving the actual gate absent, and the suite re-run:

```
FAILED tests/test_news.py::test_a_short_cue_is_not_emitted
FAILED tests/test_news.py::test_a_cue_the_passes_only_half_agreed_on_is_not_emitted
FAILED tests/test_news.py::test_the_gate_can_be_turned_off
FAILED tests/test_news.py::test_a_readable_cue_is_untouched_by_the_gate
FAILED tests/test_news.py::test_the_gate_reports_what_it_dropped
FAILED tests/test_news.py::test_impossible_gate_floors_are_refused_at_construction
FAILED tests/test_news.py::test_the_gate_floors_reach_the_recognizer_from_argv
7 failed, 22 passed
```

The working files were then restored and the full suite re-run green.

What the tests pin: the measured thresholds themselves (changing them changes a measured claim); that neither signal gates alone; that a short cue is dropped while the band is still found, so the gate did not move the lock; that a cue the passes only half agreed on (0.50, which clears the band floor of 0.3) is dropped; that the gate can be turned off; that a cue which passes comes out byte-identical to the ungated one; the rejection counts, including that they clear between files; the constructor's validation; and that the flags actually reach the recognizer from `argv`, since a flag parsed but never threaded is the usual way an option silently does nothing.

The `bands` fixture now accepts a tuple to script the two preprocessing passes separately, which is how a band the passes only half agree on is expressed. Existing usages are unchanged.

The `dirstral-spec` submodule pointer is untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a readability filter for news overlays based on minimum text length and OCR agreement confidence.
  - Added CLI options to customize or disable readability thresholds.
  - Added per-role counts for cues rejected by the readability filter.

- **Bug Fixes**
  - Filters unreadable news cues while preserving stable graphic prefixes and readable results.

- **Tests**
  - Added coverage for filtering, configuration, validation, disabled behavior, and rejection reporting.

- **Documentation**
  - Documented defaults, configuration options, performance results, and unshipped remediation experiments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->