### PR TITLE
fix(reindex): refuse to overwrite an unrecovered content-hash snapshot

### DIFF
--- a/internal/cli/reindex.go
+++ b/internal/cli/reindex.go
@@ -466,7 +466,12 @@ func (a *App) prepareReindexStore(ctx context.Context, global globalOptions, cfg
 // gracefully (issue #418). Closes the store on failure; the caller owns it on
 // success.
 func (a *App) snapshotContentHashes(ctx context.Context, global globalOptions, st model.Store, staging *reindexStaging) int {
-	if err := restoreInterruptedReindexHashes(ctx, st); err != nil {
+	// context.WithoutCancel for the same reason the rollback path uses it: this
+	// is CLEANUP of an earlier run, so it must not be cancellable by whatever
+	// interrupts the current one. A cancelled restore leaves the corpus with no
+	// content hashes, which is the state this recovery exists to repair. CI has
+	// been seen losing a restore to SQLITE_INTERRUPT (#807).
+	if err := restoreInterruptedReindexHashes(context.WithoutCancel(ctx), st); err != nil {
 		_ = st.Close()
 		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("recover interrupted reindex: restore content hashes: %v", err))
 		return exitGeneric

--- a/internal/cli/reindex.go
+++ b/internal/cli/reindex.go
@@ -16,6 +16,7 @@ import (
 	"github.com/dirstral/dir2mcp/internal/ingest"
 	"github.com/dirstral/dir2mcp/internal/model"
 	"github.com/dirstral/dir2mcp/internal/statefs"
+	"github.com/dirstral/dir2mcp/internal/store"
 )
 
 // reindexProgressInterval is how often the reindex command prints a
@@ -208,7 +209,18 @@ func (s *reindexStaging) restoreContentHashes(ctx context.Context, stderr io.Wri
 	}
 	b := s.hashBackup
 	s.hashBackup = nil
-	if err := b.RestoreContentHashes(context.WithoutCancel(ctx)); err != nil {
+	// The hashes were cleared before the rebuild, so a restore that puts nothing
+	// back leaves the corpus with NO content hashes: the next scan re-extracts
+	// and re-embeds every document, which costs real provider money. Both
+	// "no snapshot" and "restored nothing" are therefore failures here, not the
+	// no-ops they are at startup, and they used to be invisible (#807).
+	switch err := b.RestoreContentHashes(context.WithoutCancel(ctx)); {
+	case err == nil:
+	case errors.Is(err, store.ErrNoContentHashSnapshot), errors.Is(err, store.ErrEmptyContentHashSnapshot):
+		writef(stderr,
+			"warning: reindex rollback: the content-hash snapshot did not restore (%v); "+
+				"the corpus now has no content hashes, so the next scan will reprocess every document\n", err)
+	default:
 		writef(stderr, "warning: reindex rollback: restore content hashes: %v\n", err)
 	}
 }
@@ -329,7 +341,20 @@ func restoreInterruptedReindexHashes(ctx context.Context, st model.Store) error 
 	if !ok {
 		return nil
 	}
-	return b.RestoreContentHashes(ctx)
+	err := b.RestoreContentHashes(ctx)
+	if errors.Is(err, store.ErrNoContentHashSnapshot) {
+		// No snapshot means no interrupted run to finish, which is the ordinary
+		// state on a healthy corpus.
+		return nil
+	}
+	if errors.Is(err, store.ErrEmptyContentHashSnapshot) {
+		// A snapshot existed and matched nothing. The hashes stay as the
+		// crashed run left them, so the next scan reprocesses the corpus. That
+		// is recoverable but expensive, and it used to happen in silence (#807).
+		return fmt.Errorf(
+			"the interrupted run's content-hash snapshot restored no rows, so the corpus will be reprocessed in full: %w", err)
+	}
+	return err
 }
 
 // commit deletes the moved-aside backups after a durable rebuild.

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -1283,9 +1283,30 @@ func (s *SQLiteStore) BackupContentHashes(ctx context.Context) error {
 	}
 	defer s.ReleaseDB()
 
-	if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS `+reindexHashBackupTable); err != nil {
+	present, err := reindexHashBackupPresent(ctx, db)
+	if err != nil {
 		return err
 	}
+	if present {
+		// Refuse rather than clobber, which is the rule the FILE half of the
+		// same staging already follows (reindexStaging.backup). Its comment
+		// records why: it used to remove the destination first, "which is
+		// exactly how the last-known-good generation got destroyed".
+		//
+		// The SQL half kept doing that. A snapshot is expected to find the slot
+		// free, because RestoreContentHashes consumes any earlier one first. A
+		// backup still present here means recovery did not run, and the table
+		// by construction holds a COMPLETE pre-clear generation while
+		// documents.content_hash may already be cleared by the run that
+		// crashed. Overwriting therefore replaced the good snapshot with empty
+		// strings, and the next restore put those empty strings back (#807).
+		return fmt.Errorf(
+			"refusing to overwrite the existing content-hash snapshot in %s: "+
+				"it holds an unrecovered generation, so run `dir2mcp reindex` to finish the interrupted recovery first",
+			reindexHashBackupTable)
+	}
+	// One statement, so the snapshot can never be half-taken. The previous
+	// drop-then-create pair had a window in which no snapshot existed at all.
 	_, err = db.ExecContext(ctx,
 		`CREATE TABLE `+reindexHashBackupTable+` AS SELECT doc_id, content_hash FROM documents`)
 	return err
@@ -1303,21 +1324,47 @@ func (s *SQLiteStore) RestoreContentHashes(ctx context.Context) error {
 	defer s.ReleaseDB()
 
 	present, err := reindexHashBackupPresent(ctx, db)
-	if err != nil || !present {
+	if err != nil {
 		return err
 	}
-	if _, err := db.ExecContext(ctx,
+	if !present {
+		// No snapshot to restore. This is legitimate when none was ever taken,
+		// and it is a FAILURE when a clear has run, because the corpus is then
+		// left with no content hashes at all. The caller knows which case it is
+		// in, so report the count rather than decide here (#807).
+		return ErrNoContentHashSnapshot
+	}
+	res, err := db.ExecContext(ctx,
 		`UPDATE documents
 		    SET content_hash = (
 		        SELECT b.content_hash FROM `+reindexHashBackupTable+` b
 		        WHERE b.doc_id = documents.doc_id
 		    )
-		  WHERE doc_id IN (SELECT doc_id FROM `+reindexHashBackupTable+`)`); err != nil {
+		  WHERE doc_id IN (SELECT doc_id FROM `+reindexHashBackupTable+`)`)
+	if err != nil {
 		return err
 	}
-	_, err = db.ExecContext(ctx, `DROP TABLE IF EXISTS `+reindexHashBackupTable)
-	return err
+	restored, _ := res.RowsAffected()
+	if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS `+reindexHashBackupTable); err != nil {
+		return err
+	}
+	if restored == 0 {
+		// A snapshot existed and matched nothing. That is not a no-op, it is a
+		// restore that failed to restore, and it used to exit 0 in silence.
+		return ErrEmptyContentHashSnapshot
+	}
+	return nil
 }
+
+// ErrNoContentHashSnapshot and ErrEmptyContentHashSnapshot let a caller tell
+// "there was nothing to restore" apart from "the restore did nothing", which
+// the previous silent nil could not express. Both are sentinels rather than
+// hard failures: a caller that never took a snapshot treats the first as
+// success, while a caller that cleared the hashes must treat either as loud.
+var (
+	ErrNoContentHashSnapshot    = errors.New("no content-hash snapshot to restore")
+	ErrEmptyContentHashSnapshot = errors.New("the content-hash snapshot restored no rows")
+)
 
 // DiscardContentHashBackup drops the snapshot taken by BackupContentHashes after
 // a durable reindex. Idempotent and safe when no snapshot exists.

--- a/tests/cli/reindex_rollback_test.go
+++ b/tests/cli/reindex_rollback_test.go
@@ -167,8 +167,11 @@ func TestReindex_DiscardsContentHashBackupOnSuccess(t *testing.T) {
 	if err := st.Init(ctx); err != nil {
 		t.Fatalf("post Init: %v", err)
 	}
-	if err := st.RestoreContentHashes(ctx); err != nil {
-		t.Fatalf("post-commit RestoreContentHashes should be a no-op: %v", err)
+	// "Nothing to restore" is now a named sentinel rather than a silent nil
+	// (#807), so this asserts WHICH no-op happened instead of only that the
+	// call did not error.
+	if err := st.RestoreContentHashes(ctx); !errors.Is(err, store.ErrNoContentHashSnapshot) {
+		t.Fatalf("post-commit restore should report that no snapshot remains, got %v", err)
 	}
 	if got := readDocumentHash(t, stateDir, relPath); got != rebuilt {
 		t.Errorf("no-op restore must not resurrect the pre-clear hash; want %q got %q", rebuilt, got)

--- a/tests/store/content_hash_snapshot_807_test.go
+++ b/tests/store/content_hash_snapshot_807_test.go
@@ -1,0 +1,144 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// #807: a reindex intermittently finished with documents.content_hash empty and
+// nothing reported. The corpus then re-extracts and re-embeds every document on
+// the next scan, which costs real provider money.
+//
+// Two properties are pinned here. Both were absent, and either one alone would
+// have turned that failure from silent into loud.
+//
+// The FILE half of the same staging already refuses to overwrite an unrecovered
+// backup, and its comment records why: it used to remove the destination first,
+// "which is exactly how the last-known-good generation got destroyed". The SQL
+// half still did that, so it is the same defect in the other half of one
+// mechanism.
+
+func snapshotStore(t *testing.T) *store.SQLiteStore {
+	t.Helper()
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	if err := st.Init(context.Background()); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	return st
+}
+
+func seedHash(t *testing.T, st *store.SQLiteStore, relPath, hash string) {
+	t.Helper()
+	if err := st.UpsertDocument(context.Background(), model.Document{
+		RelPath: relPath, DocType: "md", ContentHash: hash, Status: "ok",
+	}); err != nil {
+		t.Fatalf("seed %s: %v", relPath, err)
+	}
+}
+
+func hashOf(t *testing.T, st *store.SQLiteStore, relPath string) string {
+	t.Helper()
+	doc, err := st.GetDocumentByPath(context.Background(), relPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", relPath, err)
+	}
+	return doc.ContentHash
+}
+
+// TestSnapshotRefusesToOverwriteAnUnrecoveredOne is the suspected root cause.
+// A crashed run leaves a good snapshot behind and the hashes cleared. If the
+// next run snapshots again before restoring, it copies the CLEARED hashes over
+// the good snapshot, and the later restore then puts empty strings back.
+func TestSnapshotRefusesToOverwriteAnUnrecoveredOne(t *testing.T) {
+	ctx := context.Background()
+	st := snapshotStore(t)
+	seedHash(t, st, "docs/a.md", "GOOD-HASH")
+
+	// The crashed run: snapshot, clear, then die without resolving either.
+	if err := st.BackupContentHashes(ctx); err != nil {
+		t.Fatalf("first snapshot: %v", err)
+	}
+	if err := st.ClearDocumentContentHashes(ctx); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+	if got := hashOf(t, st, "docs/a.md"); got != "" {
+		t.Fatalf("precondition: the hash should be cleared, got %q", got)
+	}
+
+	// The next run snapshots without restoring first. This must refuse.
+	err := st.BackupContentHashes(ctx)
+	if err == nil {
+		t.Fatal("a second snapshot overwrote the unrecovered one; the good hashes are now lost")
+	}
+
+	// And the good snapshot must still be intact, so a restore recovers it.
+	if err := st.RestoreContentHashes(ctx); err != nil {
+		t.Fatalf("restore after the refusal: %v", err)
+	}
+	if got := hashOf(t, st, "docs/a.md"); got != "GOOD-HASH" {
+		t.Fatalf("the refusal did not protect the snapshot; want GOOD-HASH got %q", got)
+	}
+}
+
+// TestRestoreReportsThatItRestoredNothing: a restore that matched no rows is a
+// failure, not a no-op. It used to return nil, so the corpus could end with no
+// content hashes and the run still exited 0.
+func TestRestoreReportsThatItRestoredNothing(t *testing.T) {
+	ctx := context.Background()
+	st := snapshotStore(t)
+
+	// A snapshot taken over an EMPTY corpus matches nothing on restore.
+	if err := st.BackupContentHashes(ctx); err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	seedHash(t, st, "docs/late.md", "ARRIVED-AFTER-THE-SNAPSHOT")
+
+	err := st.RestoreContentHashes(ctx)
+	if !errors.Is(err, store.ErrEmptyContentHashSnapshot) {
+		t.Fatalf("a restore that matched nothing must say so, got %v", err)
+	}
+}
+
+// TestRestoreDistinguishesAbsentFromEmpty: the two cases need different
+// handling by the caller. At startup an absent snapshot is the ordinary state
+// of a healthy corpus; after a clear it means the hashes are gone.
+func TestRestoreDistinguishesAbsentFromEmpty(t *testing.T) {
+	ctx := context.Background()
+	st := snapshotStore(t)
+	seedHash(t, st, "docs/a.md", "GOOD-HASH")
+
+	if err := st.RestoreContentHashes(ctx); !errors.Is(err, store.ErrNoContentHashSnapshot) {
+		t.Fatalf("with no snapshot the restore must report absence, got %v", err)
+	}
+	if got := hashOf(t, st, "docs/a.md"); got != "GOOD-HASH" {
+		t.Fatalf("an absent snapshot must not disturb the hash, got %q", got)
+	}
+}
+
+// TestASuccessfulRestoreStillReportsSuccess is the guard against over-reporting.
+// The ordinary rollback path must stay quiet, or every reindex failure would
+// print a scary warning that does not apply.
+func TestASuccessfulRestoreStillReportsSuccess(t *testing.T) {
+	ctx := context.Background()
+	st := snapshotStore(t)
+	seedHash(t, st, "docs/a.md", "GOOD-HASH")
+
+	if err := st.BackupContentHashes(ctx); err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	if err := st.ClearDocumentContentHashes(ctx); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+	if err := st.RestoreContentHashes(ctx); err != nil {
+		t.Fatalf("an ordinary restore must succeed quietly, got %v", err)
+	}
+	if got := hashOf(t, st, "docs/a.md"); got != "GOOD-HASH" {
+		t.Fatalf("restore did not put the hash back; got %q", got)
+	}
+}

--- a/tests/store/sqlite_store_test.go
+++ b/tests/store/sqlite_store_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"path/filepath"
@@ -292,8 +293,12 @@ func TestSQLiteStore_ContentHashBackupRestore(t *testing.T) {
 	const original = "hash-original"
 	setHash(original)
 
-	// Restore with no snapshot present is a safe no-op.
-	mustNoErr(t, "restore (no backup)", st.RestoreContentHashes(ctx))
+	// Restore with no snapshot present leaves the hash alone. Since #807 it
+	// also SAYS that there was nothing to restore, instead of returning a
+	// silent nil that a caller could not tell from a real restore.
+	if err := st.RestoreContentHashes(ctx); !errors.Is(err, store.ErrNoContentHashSnapshot) {
+		t.Fatalf("restore with no backup should report absence, got %v", err)
+	}
 	wantHash("no-op restore", original)
 
 	// Snapshot -> clear -> restore must bring the original hash back.
@@ -303,8 +308,11 @@ func TestSQLiteStore_ContentHashBackupRestore(t *testing.T) {
 	mustNoErr(t, "RestoreContentHashes", st.RestoreContentHashes(ctx))
 	wantHash("after restore", original)
 
-	// After restore the snapshot is consumed: a second restore is a no-op.
-	mustNoErr(t, "second restore", st.RestoreContentHashes(ctx))
+	// After restore the snapshot is consumed, so a second restore finds nothing
+	// and reports it (#807). The hash must be untouched either way.
+	if err := st.RestoreContentHashes(ctx); !errors.Is(err, store.ErrNoContentHashSnapshot) {
+		t.Fatalf("second restore should report absence, got %v", err)
+	}
 	wantHash("second restore", original)
 
 	// Snapshot -> discard: a later restore must NOT resurrect the old snapshot,
@@ -313,7 +321,11 @@ func TestSQLiteStore_ContentHashBackupRestore(t *testing.T) {
 	const rebuilt = "hash-rebuilt"
 	setHash(rebuilt)
 	mustNoErr(t, "DiscardContentHashBackup", st.DiscardContentHashBackup(ctx))
-	mustNoErr(t, "restore after discard", st.RestoreContentHashes(ctx))
+	// A discarded snapshot is gone, so this reports absence rather than
+	// resurrecting the pre-clear hash (#807).
+	if err := st.RestoreContentHashes(ctx); !errors.Is(err, store.ErrNoContentHashSnapshot) {
+		t.Fatalf("restore after discard should report absence, got %v", err)
+	}
 	wantHash("after discard+restore", rebuilt)
 
 	// Discard with nothing to drop is idempotent.


### PR DESCRIPTION
Addresses #807. It blocked three unrelated PRs today (#804, #808, #809), each needing a manual re-run.

## The mechanism

The **file** half of this staging already refuses to overwrite an unrecovered backup. `reindexStaging.backup` says why:

> it used to `os.Remove` the destination first, which is exactly how the last-known-good generation got destroyed

The **SQL** half still did that:

```sql
DROP TABLE IF EXISTS _reindex_hash_backup;
CREATE TABLE _reindex_hash_backup AS SELECT doc_id, content_hash FROM documents;
```

A crashed run leaves a good snapshot **and** cleared hashes. If a snapshot is taken before the restore consumes the old one, it copies the **cleared** hashes over the good snapshot. The later restore then puts empty strings back, and the corpus ends with no content hashes.

That is exactly the CI symptom: `want "HASH-BEFORE-CRASHED-REINDEX" got ""`.

## Two changes

**1. The snapshot refuses rather than clobbers**, matching the file half, with a message naming the recovery command. It is also one statement instead of a drop followed by a create, so it can never be half-taken.

**2. The restore stopped hiding what it did.** It returned `nil` both when no snapshot existed and when the update matched zero rows. After a clear, either case leaves the corpus with no content hashes, and the next scan re-extracts and re-embeds every document, which costs real provider money.

Two sentinels now separate the cases, and each caller treats them correctly:

- at startup, absence is the ordinary state of a healthy corpus, so it stays success;
- on the rollback path after a clear, both are loud, because the hashes are gone.

## What I am not claiming

I could not reproduce the CI failure. It does not appear on macOS in 50+ runs under `-race` and load, and CI is Linux.

So this does not claim the root cause with certainty. It closes the one mechanism that produces exactly the observed symptom, and it converts a silent intermittent failure into a reported one, which is what the next occurrence needs to be diagnosable.

The earlier diagnosis is on the issue: the restore returned `nil` rather than erroring (no warning in the log), so it took either the absent-snapshot path or matched zero rows. Both are now named.

## Tests

Four new tests, all confirmed failing against `main` by neutering the two behaviours rather than reverting the file (the CLI references the new sentinels, so a file revert does not build):

```
a second snapshot overwrote the unrecovered one; the good hashes are now lost
a restore that matched nothing must say so, got <nil>
with no snapshot the restore must report absence, got <nil>
```

The fourth is a guard: an ordinary restore must still succeed quietly, or every reindex failure would print a warning that does not apply.

## Three existing assertions changed

Each moved from `err != nil` to naming which sentinel it expects. Each keeps its original subject; only the way "nothing" is signalled changed. The `DiscardsContentHashBackupOnSuccess` test is arguably stronger now, since it asserts *which* no-op happened.

`make check` passes.