### PR TITLE
fix(cli): drain in-flight work before shutdown closes the index and the store (#688, #689)

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -114,7 +114,13 @@ const daemonShutdownPoll = 200 * time.Millisecond
 
 // daemonShutdownGrace is the maximum time `down` waits for a SIGTERM-ed
 // process to exit before escalating to SIGKILL.
-const daemonShutdownGrace = 5 * time.Second
+//
+// It is derived from serverShutdownBudget, the worst-case wall time of a
+// graceful stop (issue #688). The two must not drift apart. A grace period
+// shorter than the budget makes the daemon's own drain theatre: `down` would
+// SIGKILL a server that is still finishing an MCP request or writing its final
+// index snapshot. The extra second covers process teardown after runUp returns.
+const daemonShutdownGrace = serverShutdownBudget + time.Second
 
 // serverLogRotateBytes is the size threshold at which the parent rotates
 // the existing server.log to server.log.1 when opening a new daemon.

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/dirstral/dir2mcp/internal/config"
@@ -897,6 +898,11 @@ func renderLaunchdPlist(spec serviceSpec) string {
 	// deterministically at boot (e.g. a missing credential) backs off instead
 	// of hot-looping.
 	b.WriteString("  <key>ThrottleInterval</key>\n  <integer>30</integer>\n")
+	// Give the daemon its full graceful-stop budget before launchd escalates to
+	// SIGKILL (issue #688). The launchd default is 20 seconds, but it is a
+	// default: state it so the drain cannot be cut short by a changed default.
+	b.WriteString("  <key>ExitTimeOut</key>\n  <integer>" +
+		strconv.Itoa(serviceStopTimeoutSeconds) + "</integer>\n")
 	writePlistString(&b, "ProcessType", "Background")
 	b.WriteString("</dict>\n</plist>\n")
 	return b.String()
@@ -952,7 +958,11 @@ func renderSystemdUnit(spec serviceSpec) string {
 	b.WriteString("StandardOutput=append:" + iniEscape(spec.LogPath) + "\n")
 	b.WriteString("StandardError=append:" + iniEscape(spec.LogPath) + "\n")
 	b.WriteString("Restart=on-failure\n")
-	b.WriteString("RestartSec=30\n\n")
+	b.WriteString("RestartSec=30\n")
+	// Give the daemon its full graceful-stop budget before systemd escalates to
+	// SIGKILL (issue #688). The systemd default is DefaultTimeoutStopSec, which
+	// a distribution can lower below the budget, so state the value here.
+	b.WriteString("TimeoutStopSec=" + strconv.Itoa(serviceStopTimeoutSeconds) + "\n\n")
 
 	b.WriteString("[Install]\n")
 	b.WriteString("WantedBy=default.target\n")

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -74,8 +74,11 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 	defer func() { _ = st.Close() }()
 	textIx, textIndexPath := textBuilt.index, textBuilt.path
 	codeIx, codeIndexPath := codeBuilt.index, codeBuilt.path
-	defer func() { _ = textIx.Close() }()
-	defer func() { _ = codeIx.Close() }()
+	// Step 4 of the shutdown order in up_shutdown.go. The fence keeps the
+	// indexes open when a periodic save still owns them (issue #689); the
+	// persistence stop below raises it.
+	indexFence := &indexCloseFence{}
+	defer func() { indexFence.closeIndexesAfterPersistence(a.stderr, codeIx, textIx) }()
 
 	embedder, generator, etm, ecm := a.resolveModelClients(cfg)
 	ret := retrieval.NewService(st, textIx, embedder, generator)
@@ -195,19 +198,19 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 		func(saveErr error) { writef(logSink, "index autosave warning: %v\n", saveErr) },
 	)
 	persistence.Start(runCtx)
-	defer a.stopPersistenceWithLog(persistence)
+	// Step 3 of the shutdown order in up_shutdown.go.
+	defer func() { a.stopPersistenceWithLog(persistence, indexFence) }()
 
-	// Drain every long-lived background goroutine before runUp returns: the embed
-	// workers (or, in distributed mode, the coordinator/worker/broker-closer), the
-	// corpus writer, and the watch worker. These are the goroutines whose
-	// unconditional startup/progress logging outlives the call otherwise, racing a
-	// caller that reads the sink after return (issue #419); waiting also stops them
-	// from touching the store/indices the deferred Close calls below tear down.
+	// Steps 1 and 2 of the shutdown order in up_shutdown.go. The drain group
+	// holds every long-lived background goroutine: the MCP transport, the
+	// initial ingest, the embed workers (or, in distributed mode, the
+	// coordinator/worker/broker-closer), the corpus writer, and the watch
+	// worker. Waiting for them stops their logging from outliving the call and
+	// racing a caller that reads the sink after return (issue #419), and stops
+	// them from touching the store or the indexes that the deferred Close calls
+	// below tear down (issue #688).
 	var bgWG sync.WaitGroup
-	defer func() {
-		cancel()
-		bgWG.Wait()
-	}()
+	defer func() { drainBackgroundWorkers(cancel, &bgWG, a.stderr) }()
 	// Startup reconciliation (#402 A2): re-pend chunks sqlite counts embedded but
 	// whose vectors were lost to an ungraceful crash before the in-memory index's
 	// periodic snapshot. Must run before the embed worker so the re-pended chunks
@@ -233,10 +236,7 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 
 	transport := mcp.NewSDKTransport(mcpServer, ln, tlsCertFile, tlsKeyFile)
 
-	serverErrCh := make(chan error, 1)
-	go func() {
-		serverErrCh <- transport.Serve(runCtx, mcpServer.Handler())
-	}()
+	serverErrCh := startTransportWorker(runCtx, transport, mcpServer.Handler(), &bgWG)
 
 	emitter.Emit("info", "server_started", map[string]interface{}{
 		"url":         mcpURL,
@@ -260,7 +260,7 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 		defer bgWG.Done()
 		runCorpusWriter(runCtx, cfg.StateDir, st, indexingState, logSink, emitter)
 	}()
-	startIngestWorker(runCtx, opts.readOnly, ing, indexingState, ingestErrCh)
+	startIngestWorker(runCtx, opts.readOnly, ing, indexingState, ingestErrCh, &bgWG)
 	startWatchWorker(runCtx, opts.readOnly, cfg.IngestWatch, cfg.Source.Kind, ing, logSink, &bgWG)
 
 	// The server is now serving. A signal-triggered shutdown from here on is
@@ -1059,14 +1059,25 @@ func startStdinQuitListener(nonInteractiveMode, jsonOutput bool) chan struct{} {
 
 // startIngestWorker launches the ingest goroutine (or closes the channel
 // immediately when readOnly is true).
+//
+// The goroutine joins the shutdown drain group (issue #688). The initial scan
+// writes to the same store and the same indexes that runUp closes on the way
+// out, so shutdown must wait for it. Without the wait, a cancelled scan can
+// still be inside a store write when st.Close runs.
 func startIngestWorker(runCtx context.Context, readOnly bool, ing interface {
 	Run(context.Context) error
-}, indexingState *appstate.IndexingState, ingestErrCh chan error) {
+}, indexingState *appstate.IndexingState, ingestErrCh chan error, bgWG *sync.WaitGroup) {
 	if readOnly {
 		close(ingestErrCh)
 		return
 	}
+	if bgWG != nil {
+		bgWG.Add(1)
+	}
 	go func() {
+		if bgWG != nil {
+			defer bgWG.Done()
+		}
 		defer close(ingestErrCh)
 		// mode is already set at creation time; just mark running state
 		indexingState.SetRunning(true)
@@ -1624,16 +1635,6 @@ func newFileSkipEmitter(emitter *ndjsonEmitter) func(relPath, docType, reason st
 			"doc_type": docType,
 			"reason":   reason,
 		})
-	}
-}
-
-// stopPersistenceWithLog stops the persistence manager and logs any non-cancel
-// errors to stderr.
-func (a *App) stopPersistenceWithLog(persistence *index.PersistenceManager) {
-	stopCtx, stopCancel := context.WithTimeout(context.Background(), 3*time.Second)
-	defer stopCancel()
-	if stopErr := persistence.StopAndSave(stopCtx); stopErr != nil && !errors.Is(stopErr, context.Canceled) {
-		writef(a.stderr, "final index save warning: %v\n", stopErr)
 	}
 }
 

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -78,7 +78,7 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 	// the concurrent phase (embed workers, corpus writer, watch worker, the
 	// persistence autosave callback, and the event loop). Without it, direct
 	// writef(stderr, ...) writes race the embed worker's *log.Logger writes on the
-	// same underlying sink (a bytes.Buffer under `go test -race`) — issue #419.
+	// same underlying sink (a bytes.Buffer under `go test -race`); see issue #419.
 	//
 	// It is created here, before the first shutdown defer, because the shutdown
 	// writers need it too: when the drain gives up, a background goroutine can

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -74,11 +74,22 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 	defer func() { _ = st.Close() }()
 	textIx, textIndexPath := textBuilt.index, textBuilt.path
 	codeIx, codeIndexPath := codeBuilt.index, codeBuilt.path
+	// One mutex-guarded sink shared by every goroutine that logs to stderr during
+	// the concurrent phase (embed workers, corpus writer, watch worker, the
+	// persistence autosave callback, and the event loop). Without it, direct
+	// writef(stderr, ...) writes race the embed worker's *log.Logger writes on the
+	// same underlying sink (a bytes.Buffer under `go test -race`) — issue #419.
+	//
+	// It is created here, before the first shutdown defer, because the shutdown
+	// writers need it too: when the drain gives up, a background goroutine can
+	// still be writing to this sink while the teardown reports the forced end.
+	logSink := NewSyncWriter(a.stderr)
+
 	// Step 4 of the shutdown order in up_shutdown.go. The fence keeps the
 	// indexes open when a periodic save still owns them (issue #689); the
 	// persistence stop below raises it.
 	indexFence := &indexCloseFence{}
-	defer func() { indexFence.closeIndexesAfterPersistence(a.stderr, codeIx, textIx) }()
+	defer func() { indexFence.closeIndexesAfterPersistence(logSink, codeIx, textIx) }()
 
 	embedder, generator, etm, ecm := a.resolveModelClients(cfg)
 	ret := retrieval.NewService(st, textIx, embedder, generator)
@@ -182,13 +193,6 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 		return code
 	}
 
-	// One mutex-guarded sink shared by every goroutine that logs to stderr during
-	// the concurrent phase (embed workers, corpus writer, watch worker, the
-	// persistence autosave callback, and the event loop). Without it, direct
-	// writef(stderr, ...) writes race the embed worker's *log.Logger writes on the
-	// same underlying sink (a bytes.Buffer under `go test -race`) — issue #419.
-	logSink := NewSyncWriter(a.stderr)
-
 	persistence := index.NewPersistenceManager(
 		[]index.IndexedFile{
 			{Path: textIndexPath, Index: textIx},
@@ -199,7 +203,7 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 	)
 	persistence.Start(runCtx)
 	// Step 3 of the shutdown order in up_shutdown.go.
-	defer func() { a.stopPersistenceWithLog(persistence, indexFence) }()
+	defer func() { stopPersistenceWithLog(persistence, indexFence, logSink) }()
 
 	// Steps 1 and 2 of the shutdown order in up_shutdown.go. The drain group
 	// holds every long-lived background goroutine: the MCP transport, the
@@ -210,7 +214,7 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 	// them from touching the store or the indexes that the deferred Close calls
 	// below tear down (issue #688).
 	var bgWG sync.WaitGroup
-	defer func() { drainBackgroundWorkers(cancel, &bgWG, a.stderr) }()
+	defer func() { drainBackgroundWorkers(cancel, &bgWG, logSink) }()
 	// Startup reconciliation (#402 A2): re-pend chunks sqlite counts embedded but
 	// whose vectors were lost to an ungraceful crash before the in-memory index's
 	// periodic snapshot. Must run before the embed worker so the re-pended chunks

--- a/internal/cli/up_shutdown.go
+++ b/internal/cli/up_shutdown.go
@@ -137,7 +137,10 @@ func (f *indexCloseFence) closeIndexesAfterPersistence(stderr io.Writer, indexes
 //
 // When the wait expires the autosave still owns the indexes, so the function
 // raises the fence and the caller keeps them open.
-func (a *App) stopPersistenceWithLog(persistence *index.PersistenceManager, fence *indexCloseFence) {
+//
+// stderr must be the synchronized sink, not the raw writer: a drain that gave
+// up leaves background goroutines writing to that same sink (issue #419).
+func stopPersistenceWithLog(persistence *index.PersistenceManager, fence *indexCloseFence, stderr io.Writer) {
 	stopCtx, stopCancel := context.WithTimeout(context.Background(), persistenceStopBudget)
 	defer stopCancel()
 
@@ -151,7 +154,7 @@ func (a *App) stopPersistenceWithLog(persistence *index.PersistenceManager, fenc
 	if errors.Is(stopErr, context.Canceled) {
 		return
 	}
-	writef(a.stderr, "final index save warning: %v\n", stopErr)
+	writef(stderr, "final index save warning: %v\n", stopErr)
 }
 
 // startTransportWorker launches the MCP transport on the shutdown drain group

--- a/internal/cli/up_shutdown.go
+++ b/internal/cli/up_shutdown.go
@@ -1,0 +1,174 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// Shutdown order for `dir2mcp up` (issues #688, #689).
+//
+// The deferred calls in runUp run in reverse order of registration. They
+// implement these four steps:
+//
+//  1. STOP ACCEPTING NEW WORK. Cancel the run context. The MCP transport stops
+//     accepting new connections, and the ingest, embed, corpus-writer and watch
+//     workers see the cancellation.
+//  2. DRAIN IN-FLIGHT WORK. Wait for the MCP transport, the initial ingest and
+//     the other background workers to return. A handler that already started
+//     keeps its index and its store until it finishes.
+//  3. STOP PERSISTENCE. Cancel the periodic autosave, wait for it, then write
+//     the final snapshot.
+//  4. CLOSE RESOURCES. Close the indexes and the store.
+//
+// Every wait in steps 2 and 3 has a deadline. A shutdown that can hang forever
+// is worse than one that gives up: the process stays alive, the supervisor
+// kills it with SIGKILL, and the operator gets no message.
+
+const (
+	// mcpDrainGrace is how long the MCP transport waits for in-flight requests
+	// after cancellation. It is the pre-existing http.Server.Shutdown window.
+	mcpDrainGrace = 5 * time.Second
+
+	// backgroundDrainBudget bounds step 2. It is mcpDrainGrace plus one second
+	// of slack, because the transport is the slowest member of the drain group
+	// and the other workers only need to observe the cancelled context.
+	backgroundDrainBudget = mcpDrainGrace + time.Second
+
+	// persistenceStopBudget bounds step 3: the wait for a running autosave plus
+	// the final forced save. It is the pre-existing 3-second window.
+	persistenceStopBudget = 3 * time.Second
+
+	// serverShutdownBudget is the worst-case wall time of a graceful stop.
+	//
+	// It must stay below the grace period of every process manager that stops
+	// the daemon, or the wait is theatre: the manager sends SIGKILL and the
+	// drain never finishes. The three managers are
+	//
+	//   - `dir2mcp down`, which escalates to SIGKILL after
+	//     daemonShutdownGrace. That constant is derived from this budget, so
+	//     the two cannot drift apart.
+	//   - launchd, which sends SIGKILL after the plist ExitTimeOut.
+	//   - systemd, which sends SIGKILL after the unit TimeoutStopSec.
+	//
+	// The launchd and the systemd values are written into the generated unit
+	// files as serviceStopTimeoutSeconds, so they do not depend on a platform
+	// default that a distribution can lower.
+	serverShutdownBudget = backgroundDrainBudget + persistenceStopBudget
+
+	// serviceStopTimeoutSeconds is the stop grace period written into the
+	// generated launchd plist and systemd unit. It must exceed
+	// serverShutdownBudget with room for process teardown.
+	serviceStopTimeoutSeconds = 20
+)
+
+// drainBackgroundWorkers performs steps 1 and 2 of the shutdown order.
+//
+// It cancels the run context and then waits for every registered background
+// goroutine: the MCP transport, the initial ingest, the embed workers, the
+// corpus writer and the watch worker. The wait stops after
+// backgroundDrainBudget.
+//
+// On expiry the function warns and returns. It does not wait longer. The
+// process is about to exit, and the goroutines that remain hold read-only work
+// (a request handler, a scan) rather than a snapshot writer, so the risk is a
+// truncated answer to one client, not a damaged file. The snapshot writer is
+// fenced separately, by stopPersistenceWithLog and closeIndexesAfterPersistence.
+func drainBackgroundWorkers(cancel context.CancelFunc, bgWG *sync.WaitGroup, stderr io.Writer) {
+	cancel()
+
+	done := make(chan struct{})
+	go func() {
+		bgWG.Wait()
+		close(done)
+	}()
+
+	timer := time.NewTimer(backgroundDrainBudget)
+	defer timer.Stop()
+	select {
+	case <-done:
+	case <-timer.C:
+		writef(stderr, "shutdown warning: background work did not stop within %s; the server stops waiting for it\n",
+			backgroundDrainBudget)
+	}
+}
+
+// indexCloseFence decides whether runUp may close the vector indexes.
+//
+// The persistence manager owns the indexes while it saves them. If a save is
+// still in flight when shutdown gives up waiting, a Close here races that
+// writer and can leave a truncated snapshot on disk (issue #689). The fence
+// then blocks the Close and the operating system reclaims the handles at
+// process exit instead.
+type indexCloseFence struct {
+	blocked bool
+	reason  error
+}
+
+// block marks the indexes as unsafe to close and records why.
+func (f *indexCloseFence) block(reason error) {
+	f.blocked = true
+	f.reason = reason
+}
+
+// closeIndexesAfterPersistence performs the index half of step 4. It runs after
+// stopPersistenceWithLog, which is what sets the fence.
+func (f *indexCloseFence) closeIndexesAfterPersistence(stderr io.Writer, indexes ...model.Index) {
+	if f.blocked {
+		writef(stderr, "shutdown warning: index files stay open because a save is still in flight: %v\n", f.reason)
+		return
+	}
+	for _, ix := range indexes {
+		if ix == nil {
+			continue
+		}
+		_ = ix.Close()
+	}
+}
+
+// stopPersistenceWithLog performs step 3. It stops the periodic autosave, waits
+// for it, and writes the final snapshot, all within persistenceStopBudget.
+//
+// When the wait expires the autosave still owns the indexes, so the function
+// raises the fence and the caller keeps them open.
+func (a *App) stopPersistenceWithLog(persistence *index.PersistenceManager, fence *indexCloseFence) {
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), persistenceStopBudget)
+	defer stopCancel()
+
+	stopErr := persistence.StopAndSave(stopCtx)
+	if stopErr == nil {
+		return
+	}
+	if errors.Is(stopErr, index.ErrSaveInFlight) && fence != nil {
+		fence.block(stopErr)
+	}
+	if errors.Is(stopErr, context.Canceled) {
+		return
+	}
+	writef(a.stderr, "final index save warning: %v\n", stopErr)
+}
+
+// startTransportWorker launches the MCP transport on the shutdown drain group
+// (issue #688).
+//
+// Membership of the group is what makes the shutdown order hold: runUp waits
+// for Serve to return, and Serve returns only after http.Server.Shutdown drains
+// the active handlers. Without it, runUp could close the index and the store
+// under a running ask/search/open_file handler, and the client would get an
+// internal error in place of its answer.
+func startTransportWorker(runCtx context.Context, transport *mcp.SDKTransport, handler mcp.Handler, bgWG *sync.WaitGroup) <-chan error {
+	transport.SetShutdownGrace(mcpDrainGrace)
+	serverErrCh := make(chan error, 1)
+	bgWG.Add(1)
+	go func() {
+		defer bgWG.Done()
+		serverErrCh <- transport.Serve(runCtx, handler)
+	}()
+	return serverErrCh
+}

--- a/internal/cli/up_shutdown_test.go
+++ b/internal/cli/up_shutdown_test.go
@@ -1,0 +1,222 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// closeCountingIndex is a model.Index that only records its Close calls.
+type closeCountingIndex struct {
+	closes int
+}
+
+func (i *closeCountingIndex) Upsert(context.Context, []float32, model.IndexPayload) error { return nil }
+func (i *closeCountingIndex) Delete(context.Context, []uint64) error                      { return nil }
+func (i *closeCountingIndex) Search(context.Context, []float32, int, model.Filter) ([]model.IndexHit, error) {
+	return nil, nil
+}
+func (i *closeCountingIndex) Identity(context.Context) (string, error) { return "", nil }
+func (i *closeCountingIndex) Reset(context.Context, string) error      { return nil }
+func (i *closeCountingIndex) Close() error                             { i.closes++; return nil }
+
+// TestShutdownBudgetFitsEveryProcessManager pins the reason the drain is real
+// work and not theatre (issue #688).
+//
+// A wait longer than the grace period of the process manager never finishes:
+// the manager sends SIGKILL first. `dir2mcp down` is the tightest of the three
+// managers, so its grace period must exceed the budget, and the generated
+// launchd and systemd stop timeouts must exceed it too.
+func TestShutdownBudgetFitsEveryProcessManager(t *testing.T) {
+	if backgroundDrainBudget <= mcpDrainGrace {
+		t.Fatalf("the drain budget (%s) must exceed the transport grace (%s), or the transport can never finish",
+			backgroundDrainBudget, mcpDrainGrace)
+	}
+	if serverShutdownBudget != backgroundDrainBudget+persistenceStopBudget {
+		t.Fatalf("the shutdown budget (%s) must cover both phases (%s + %s)",
+			serverShutdownBudget, backgroundDrainBudget, persistenceStopBudget)
+	}
+	if daemonShutdownGrace <= serverShutdownBudget {
+		t.Fatalf("`down` escalates to SIGKILL after %s, which is not more than the %s the server needs to stop; the drain would be cut short",
+			daemonShutdownGrace, serverShutdownBudget)
+	}
+	serviceTimeout := time.Duration(serviceStopTimeoutSeconds) * time.Second
+	if serviceTimeout <= daemonShutdownGrace {
+		t.Fatalf("the service stop timeout (%s) must exceed the `down` grace period (%s)",
+			serviceTimeout, daemonShutdownGrace)
+	}
+}
+
+// TestGeneratedServiceUnitsStateTheStopTimeout proves the launchd plist and the
+// systemd unit carry an explicit stop timeout. Both platforms have a default,
+// but a default can be lowered below the shutdown budget, which would make the
+// drain theatre on that host.
+func TestGeneratedServiceUnitsStateTheStopTimeout(t *testing.T) {
+	spec := serviceSpec{
+		Label:      "com.dirstral.test",
+		BinaryPath: "/usr/local/bin/dir2mcp",
+		WorkingDir: "/corpus",
+		LogPath:    "/corpus/.dir2mcp/server.log",
+	}
+
+	plist := renderLaunchdPlist(spec)
+	wantPlist := fmt.Sprintf("<key>ExitTimeOut</key>\n  <integer>%d</integer>", serviceStopTimeoutSeconds)
+	if !strings.Contains(plist, wantPlist) {
+		t.Fatalf("launchd plist missing %q:\n%s", wantPlist, plist)
+	}
+
+	unit := renderSystemdUnit(spec)
+	wantUnit := fmt.Sprintf("TimeoutStopSec=%d", serviceStopTimeoutSeconds)
+	if !strings.Contains(unit, wantUnit) {
+		t.Fatalf("systemd unit missing %q:\n%s", wantUnit, unit)
+	}
+}
+
+// TestDrainWaitsForInFlightMCPRequest proves the transport is part of the
+// shutdown drain (issue #688): a request that is already inside a handler keeps
+// the drain open, so runUp cannot reach the index and store Close calls while a
+// client is still waiting for its answer.
+//
+// The request goes to a non-MCP path so the test does not need the MCP
+// handshake. The drain mechanism is the same either way: both paths run on the
+// one http.Server whose Shutdown waits for active handlers.
+func TestDrainWaitsForInFlightMCPRequest(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	cfg := config.Config{MCPPath: "/mcp"}
+	transport := mcp.NewSDKTransport(mcp.NewServer(cfg, nil), ln, "", "")
+
+	inHandler := make(chan struct{})
+	release := make(chan struct{})
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(inHandler)
+		<-release
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("done"))
+	})
+
+	var bgWG sync.WaitGroup
+	runCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	serverErrCh := startTransportWorker(runCtx, transport, handler, &bgWG)
+
+	respCh := make(chan error, 1)
+	go func() {
+		resp, reqErr := http.Get("http://" + ln.Addr().String() + "/slow")
+		if reqErr != nil {
+			respCh <- reqErr
+			return
+		}
+		defer func() { _ = resp.Body.Close() }()
+		_, _ = io.Copy(io.Discard, resp.Body)
+		respCh <- nil
+	}()
+
+	select {
+	case <-inHandler:
+	case <-time.After(10 * time.Second):
+		close(release)
+		t.Fatal("the request never reached the handler")
+	}
+
+	drained := make(chan struct{})
+	go func() {
+		drainBackgroundWorkers(cancel, &bgWG, io.Discard)
+		close(drained)
+	}()
+
+	select {
+	case <-drained:
+		close(release)
+		t.Fatal("the drain returned while an MCP request was still in the handler; runUp would close the index and the store underneath it")
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	close(release)
+
+	select {
+	case <-drained:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the drain did not return after the handler finished")
+	}
+
+	if reqErr := <-respCh; reqErr != nil {
+		t.Fatalf("the in-flight request was cut short instead of served: %v", reqErr)
+	}
+	if serveErr := <-serverErrCh; serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
+		t.Fatalf("transport Serve: %v", serveErr)
+	}
+}
+
+// TestDrainStopsWaitingAtTheBudget proves the drain gives up instead of hanging.
+// A shutdown that can wait forever is worse than one that stops: the process
+// stays alive until the supervisor sends SIGKILL, and the operator gets no
+// message about it.
+func TestDrainStopsWaitingAtTheBudget(t *testing.T) {
+	var bgWG sync.WaitGroup
+	stuck := make(chan struct{})
+	bgWG.Add(1)
+	go func() {
+		defer bgWG.Done()
+		<-stuck
+	}()
+	defer close(stuck)
+
+	_, cancel := context.WithCancel(context.Background())
+	var stderr bytes.Buffer
+
+	done := make(chan struct{})
+	go func() {
+		drainBackgroundWorkers(cancel, &bgWG, &stderr)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(backgroundDrainBudget + 10*time.Second):
+		t.Fatal("the drain never gave up; a graceful stop can hang the process")
+	}
+	if got := stderr.String(); !strings.Contains(got, "background work did not stop") {
+		t.Fatalf("the forced end of the drain was silent; stderr=%q", got)
+	}
+}
+
+// TestIndexCloseFenceBlocksCloseWhileSaving proves the CLI honours the
+// persistence ownership contract (issue #689): when a save is still in flight,
+// the indexes stay open and the operator is told why.
+func TestIndexCloseFenceBlocksCloseWhileSaving(t *testing.T) {
+	ix := &closeCountingIndex{}
+
+	open := &indexCloseFence{}
+	var openLog bytes.Buffer
+	open.closeIndexesAfterPersistence(&openLog, ix)
+	if ix.closes != 1 {
+		t.Fatalf("a quiescent shutdown must close the index; closes=%d", ix.closes)
+	}
+
+	blocked := &indexCloseFence{}
+	blocked.block(errors.New("save still running"))
+	var blockedLog bytes.Buffer
+	blocked.closeIndexesAfterPersistence(&blockedLog, ix)
+	if ix.closes != 1 {
+		t.Fatalf("the index was closed under a running save; closes=%d", ix.closes)
+	}
+	if got := blockedLog.String(); !strings.Contains(got, "save is still in flight") {
+		t.Fatalf("the skipped close was silent; stderr=%q", got)
+	}
+}

--- a/internal/index/persistence.go
+++ b/internal/index/persistence.go
@@ -39,6 +39,15 @@ type PersistenceManager struct {
 	wg      sync.WaitGroup
 }
 
+// ErrSaveInFlight reports that StopAndSave stopped waiting while a periodic
+// save still used the indices (issue #689).
+//
+// The caller MUST NOT close the indices after this error. The save owns them
+// until it returns, so a Close here races the writer and can leave a truncated
+// or partly-written snapshot on disk. Leaking the file handles until the
+// process exits is the safe option; the operating system reclaims them.
+var ErrSaveInFlight = errors.New("index persistence: a periodic save was still in flight at shutdown")
+
 func NewPersistenceManager(indices []IndexedFile, interval time.Duration, onError func(error)) *PersistenceManager {
 	if interval <= 0 {
 		interval = 15 * time.Second
@@ -111,7 +120,13 @@ type AutosaveTicker interface {
 // AutosaveTicker capability when available, so a long ingest doesn't rewrite the
 // whole index on every tick (issue #429 C-a). It shares saveMu with SaveAll/Load
 // so saves never overlap.
-func (m *PersistenceManager) autosaveTick() error {
+//
+// ctx is the manager lifetime context, not context.Background() (issue #689).
+// StopAndSave cancels it, so a save that is already running observes shutdown
+// and can abandon its temporary file. That is the safe outcome: the previous
+// good snapshot stays on disk, and the sqlite store keeps the source of truth,
+// so startup reconciliation rebuilds the lost tail.
+func (m *PersistenceManager) autosaveTick(ctx context.Context) error {
 	m.saveMu.Lock()
 	defer m.saveMu.Unlock()
 
@@ -124,11 +139,19 @@ func (m *PersistenceManager) autosaveTick() error {
 		if !ok {
 			continue
 		}
+		// Do not start a new backend save after shutdown began. The tick can
+		// hold saveMu across several indices, so the context can expire part
+		// way through the loop.
+		select {
+		case <-ctx.Done():
+			return combined
+		default:
+		}
 		var err error
 		if t, ok := idx.Index.(AutosaveTicker); ok {
-			err = t.AutosaveTick(context.Background(), idx.Path)
+			err = t.AutosaveTick(ctx, idx.Path)
 		} else {
-			err = p.Save(context.Background(), idx.Path)
+			err = p.Save(ctx, idx.Path)
 		}
 		if err != nil {
 			combined = errors.Join(combined, err)
@@ -137,7 +160,14 @@ func (m *PersistenceManager) autosaveTick() error {
 	return combined
 }
 
+// SaveAll forces a save of every persistable index. The save is not bounded by
+// a context; use saveAll if you need to bound it.
 func (m *PersistenceManager) SaveAll() error {
+	return m.saveAll(context.Background())
+}
+
+// saveAll is the forced save path shared by SaveAll and StopAndSave.
+func (m *PersistenceManager) saveAll(ctx context.Context) error {
 	// protect against concurrent callers; the underlying model.Index
 	// implementations are not required to be goroutine‑safe so we serialize
 	// accesses here. callers such as the ticker goroutine and external
@@ -156,7 +186,7 @@ func (m *PersistenceManager) SaveAll() error {
 		if !ok {
 			continue
 		}
-		if err := p.Save(context.Background(), idx.Path); err != nil {
+		if err := p.Save(ctx, idx.Path); err != nil {
 			combined = errors.Join(combined, err)
 		}
 	}
@@ -231,7 +261,7 @@ func (m *PersistenceManager) Start(ctx context.Context) {
 			case <-runCtx.Done():
 				return
 			case <-ticker.C:
-				if err := m.autosaveTick(); err != nil {
+				if err := m.autosaveTick(runCtx); err != nil {
 					m.emitError(err)
 				}
 			}
@@ -240,10 +270,23 @@ func (m *PersistenceManager) Start(ctx context.Context) {
 }
 
 // StopAndSave cancels any running autosave goroutine and waits for it
-// to exit before performing a final SaveAll. The provided context is used to
-// bound the wait; if it expires the method returns ctx.Err() and the final
-// save may not occur. This prevents callers (such as CLI shutdown hooks)
-// from blocking forever on uncooperative indices or hung goroutines.
+// to exit before performing a final forced save. The provided context bounds
+// the whole operation: the wait for the autosave goroutine AND the final save.
+// This prevents callers (such as CLI shutdown hooks) from blocking forever on
+// uncooperative indices or hung goroutines.
+//
+// Shutdown order (issue #689):
+//
+//  1. Cancel the manager lifetime context. A periodic save that is already
+//     running observes the cancellation and can stop early.
+//  2. Wait for the autosave goroutine to exit, bounded by ctx.
+//  3. Run the final forced save, bounded by the same ctx.
+//
+// If step 2 runs out of time, the returned error wraps ErrSaveInFlight and the
+// final save is skipped. The caller must then leave the indices open: a
+// periodic save still owns them, and closing an index underneath its own writer
+// is the corruption this method exists to prevent. The abandoned save keeps
+// running until the backend returns or the process exits.
 func (m *PersistenceManager) StopAndSave(ctx context.Context) error {
 	m.stateMu.Lock()
 	cancel := m.cancel
@@ -264,10 +307,10 @@ func (m *PersistenceManager) StopAndSave(ctx context.Context) error {
 	case <-done:
 		// normal
 	case <-ctx.Done():
-		return ctx.Err()
+		return errors.Join(ctx.Err(), ErrSaveInFlight)
 	}
 
-	return m.SaveAll()
+	return m.saveAll(ctx)
 }
 
 func (m *PersistenceManager) emitError(err error) {

--- a/internal/mcp/transport_sdk.go
+++ b/internal/mcp/transport_sdk.go
@@ -24,21 +24,40 @@ import (
 // routed through the existing payment-aware path so that payment headers and
 // replay behavior stay identical to the legacy implementation.
 type SDKTransport struct {
-	server   *Server
-	listener net.Listener
-	certFile string
-	keyFile  string
+	server        *Server
+	listener      net.Listener
+	certFile      string
+	keyFile       string
+	shutdownGrace time.Duration
 }
+
+// DefaultShutdownGrace is how long Serve waits for in-flight MCP requests to
+// finish after its context is cancelled.
+const DefaultShutdownGrace = 5 * time.Second
 
 // NewSDKTransport constructs an SDKTransport. certFile and keyFile are
 // optional; both must be non-empty to enable TLS.
 func NewSDKTransport(server *Server, listener net.Listener, certFile, keyFile string) *SDKTransport {
 	return &SDKTransport{
-		server:   server,
-		listener: listener,
-		certFile: certFile,
-		keyFile:  keyFile,
+		server:        server,
+		listener:      listener,
+		certFile:      certFile,
+		keyFile:       keyFile,
+		shutdownGrace: DefaultShutdownGrace,
 	}
+}
+
+// SetShutdownGrace sets how long Serve waits for in-flight MCP requests after
+// its context is cancelled. A value of zero or less keeps the current value.
+//
+// The caller owns the shutdown budget (issue #688). It must wait for Serve to
+// return before it closes the index or the store that the in-flight handlers
+// still read, so it also needs to know when Serve stops waiting.
+func (t *SDKTransport) SetShutdownGrace(d time.Duration) {
+	if t == nil || d <= 0 {
+		return
+	}
+	t.shutdownGrace = d
 }
 
 // newMCPHTTPServer builds the http.Server for the MCP endpoint with timeouts
@@ -114,7 +133,15 @@ func (t *SDKTransport) Serve(ctx context.Context, handler Handler) error {
 
 	select {
 	case <-ctx.Done():
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		// Shutdown stops accepting new connections first, then waits for the
+		// active handlers. Serve returns only after that wait, so the caller
+		// can treat "Serve returned" as "no MCP handler still uses the index
+		// or the store" (issue #688).
+		grace := t.shutdownGrace
+		if grace <= 0 {
+			grace = DefaultShutdownGrace
+		}
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), grace)
 		defer cancel()
 		return server.Shutdown(shutdownCtx)
 	case err := <-errCh:

--- a/tests/cli/up_shutdown_drain_688_test.go
+++ b/tests/cli/up_shutdown_drain_688_test.go
@@ -1,0 +1,158 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/cli"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// Issue #688: `up` cancelled its run context and then returned. The initial
+// ingest goroutine and the MCP transport goroutine were not in the drain group,
+// so runUp could close the indexes and the store while the initial scan was
+// still writing to them. These tests pin the drain: the run does not return
+// until the initial ingest returns, and the shared resources are closed only
+// after that.
+
+// blockingIngestor holds its Run open until the test releases it, and records
+// when Run returned. It is the stand-in for a slow initial scan that is part way
+// through a store write when the operator stops the server.
+type blockingIngestor struct {
+	started  chan struct{}
+	release  chan struct{}
+	ctxSeen  atomic.Bool
+	returned atomic.Bool
+}
+
+func newBlockingIngestor() *blockingIngestor {
+	return &blockingIngestor{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+func (i *blockingIngestor) Run(ctx context.Context) error {
+	close(i.started)
+	// Wait for the test, not for the context. A cancelled context must not be
+	// enough to let shutdown continue: the scan is still inside its write.
+	<-i.release
+	if ctx.Err() != nil {
+		i.ctxSeen.Store(true)
+	}
+	i.returned.Store(true)
+	return nil
+}
+
+func (i *blockingIngestor) Reindex(context.Context) error { return nil }
+
+// closeOrderStore records whether the initial ingest had already returned when
+// the store was closed.
+type closeOrderStore struct {
+	ingest      *blockingIngestor
+	closed      atomic.Bool
+	closedEarly atomic.Bool
+}
+
+func (s *closeOrderStore) Init(context.Context) error                           { return nil }
+func (s *closeOrderStore) UpsertDocument(context.Context, model.Document) error { return nil }
+func (s *closeOrderStore) GetDocumentByPath(context.Context, string) (model.Document, error) {
+	return model.Document{}, model.ErrNotFound
+}
+func (s *closeOrderStore) ListFiles(context.Context, string, string, int, int) ([]model.Document, int64, error) {
+	return nil, 0, nil
+}
+
+func (s *closeOrderStore) Close() error {
+	if s.ingest != nil && !s.ingest.returned.Load() {
+		s.closedEarly.Store(true)
+	}
+	s.closed.Store(true)
+	return nil
+}
+
+// TestUpShutdownWaitsForInitialIngest proves `up` keeps running until the
+// initial ingest returns, and only then closes the store the scan writes to.
+//
+// Before the fix the run returned as soon as the context was cancelled, which
+// left the scan writing into a store that runUp was already closing.
+func TestUpShutdownWaitsForInitialIngest(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("MISTRAL_API_KEY", "test-key")
+	t.Setenv("DIR2MCP_AUTH_TOKEN", "")
+	t.Setenv("DIR2MCP_SKIP_EMBED_PROBE", "1")
+
+	ingestor := newBlockingIngestor()
+	st := &closeOrderStore{ingest: ingestor}
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIOAndHooks(&stdout, &stderr, cli.RuntimeHooks{
+		NewStore: func(config.Config) model.Store { return st },
+		NewIngestor: func(config.Config, model.Store) (model.Ingestor, error) {
+			return ingestor, nil
+		},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	codeCh := make(chan int, 1)
+	withWorkingDir(t, tmp, func() {
+		go func() {
+			codeCh <- app.RunWithContext(ctx, []string{"up", "--foreground", "--listen", "127.0.0.1:0"})
+		}()
+
+		select {
+		case <-ingestor.started:
+		case <-time.After(raceScaled(10 * time.Second)):
+			cancel()
+			close(ingestor.release)
+			<-codeCh
+			t.Fatal("the initial ingest never started")
+		}
+
+		// Stop the server the way a signal does, while the scan is in flight.
+		cancel()
+
+		// The run must stay inside its drain. A return here means shutdown
+		// abandoned the scan.
+		select {
+		case code := <-codeCh:
+			close(ingestor.release)
+			t.Fatalf("up returned code %d while the initial ingest was still running; shutdown did not drain it (stderr=%s)",
+				code, stderr.String())
+		case <-time.After(raceScaled(500 * time.Millisecond)):
+		}
+
+		if st.closed.Load() {
+			close(ingestor.release)
+			<-codeCh
+			t.Fatal("the store was closed while the initial ingest was still writing to it")
+		}
+
+		close(ingestor.release)
+
+		select {
+		case code := <-codeCh:
+			if code != 0 {
+				t.Fatalf("graceful stop exit code: got=%d want=0 stderr=%s", code, stderr.String())
+			}
+		case <-time.After(raceScaled(10 * time.Second)):
+			t.Fatal("up did not return after the initial ingest finished")
+		}
+	})
+
+	if !ingestor.ctxSeen.Load() {
+		t.Fatal("the initial ingest did not observe the cancelled run context")
+	}
+	if !st.closed.Load() {
+		t.Fatal("the store was never closed")
+	}
+	if st.closedEarly.Load() {
+		t.Fatal("the store was closed before the initial ingest returned; the shutdown order is wrong")
+	}
+}

--- a/tests/index/persistence_shutdown_689_test.go
+++ b/tests/index/persistence_shutdown_689_test.go
@@ -1,0 +1,244 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// Issue #689: the periodic autosave called every backend with
+// context.Background(), so shutdown could not reach a save that had already
+// started. StopAndSave then returned on its own deadline while that save still
+// owned the index, and the CLI closed the index underneath the writer. The
+// timeout bounded the wait, not the work.
+
+// blockingSaveIndex blocks inside Save until the test releases it. It records
+// whether the save observed a cancelled context, and whether Close was called
+// while the save was still running.
+type blockingSaveIndex struct {
+	coreIndexStub
+
+	// honorCancel selects the backend behaviour. A cooperative backend stops
+	// when its context is cancelled. An uncooperative one runs to the release
+	// whatever the context says; that is the case the close fence exists for.
+	honorCancel bool
+
+	started chan struct{}
+	release chan struct{}
+
+	saving        atomic.Bool
+	sawCancel     atomic.Bool
+	closedDuring  atomic.Bool
+	closeAttempts atomic.Int32
+}
+
+func newBlockingSaveIndex(honorCancel bool) *blockingSaveIndex {
+	return &blockingSaveIndex{
+		honorCancel: honorCancel,
+		started:     make(chan struct{}, 1),
+		release:     make(chan struct{}),
+	}
+}
+
+func (i *blockingSaveIndex) Save(ctx context.Context, _ string) error {
+	i.saving.Store(true)
+	defer i.saving.Store(false)
+
+	select {
+	case i.started <- struct{}{}:
+	default:
+	}
+
+	if i.honorCancel {
+		select {
+		case <-i.release:
+		case <-ctx.Done():
+			i.sawCancel.Store(true)
+			return ctx.Err()
+		}
+		return nil
+	}
+
+	<-i.release
+	if ctx.Err() != nil {
+		i.sawCancel.Store(true)
+	}
+	return nil
+}
+
+func (i *blockingSaveIndex) Load(context.Context, string) error { return nil }
+
+// Close stands in for the CLI teardown that must never overlap a save.
+func (i *blockingSaveIndex) Close() error {
+	i.closeAttempts.Add(1)
+	if i.saving.Load() {
+		i.closedDuring.Store(true)
+	}
+	return nil
+}
+
+// waitForSaveStart blocks until the index reports that a save began.
+func waitForSaveStart(t *testing.T, ix *blockingSaveIndex) {
+	t.Helper()
+	select {
+	case <-ix.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the periodic autosave never started")
+	}
+}
+
+// TestAutosaveObservesShutdownCancellation proves a save that is already
+// running sees the shutdown.
+//
+// Before the fix the tick handed the backend context.Background(), so a save
+// could not learn that the manager had been told to stop. It ran to completion
+// against an index the caller was already tearing down. A cancelable save can
+// instead abandon its temporary file, which leaves the previous good snapshot
+// on disk.
+func TestAutosaveObservesShutdownCancellation(t *testing.T) {
+	ix := newBlockingSaveIndex(true)
+	pm := index.NewPersistenceManager([]index.IndexedFile{
+		{Path: "text.idx", Index: ix},
+	}, 10*time.Millisecond, nil)
+
+	pm.Start(context.Background())
+	waitForSaveStart(t, ix)
+
+	// Stop the manager while the save is in flight. The deadline is short: the
+	// final forced save that follows blocks on the same release, and this test
+	// only asks whether the periodic save learned about the shutdown.
+	stopCtx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	stopErr := pm.StopAndSave(stopCtx)
+
+	// Release the save unconditionally so the test cannot hang if the
+	// cancellation never arrives.
+	close(ix.release)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for ix.saving.Load() && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	if !ix.sawCancel.Load() {
+		t.Fatalf("the in-progress autosave never observed the shutdown cancellation (StopAndSave returned %v)", stopErr)
+	}
+}
+
+// TestStopAndSaveFencesCloseWhileSaveInFlight proves the ownership contract: if
+// the wait runs out while a save still uses the index, StopAndSave says so, and
+// the caller must not close the index.
+//
+// The bounded wait is deliberate. An unbounded one turns a clean stop into a
+// hung process, which the supervisor ends with SIGKILL. But the caller cannot
+// treat "the wait expired" as "the index is mine again": the save still owns
+// the file. ErrSaveInFlight is the difference between the two.
+func TestStopAndSaveFencesCloseWhileSaveInFlight(t *testing.T) {
+	// The save ignores cancellation, which is the worst case the fence exists
+	// for: a backend that cannot be interrupted.
+	ix := newBlockingSaveIndex(false)
+	pm := index.NewPersistenceManager([]index.IndexedFile{
+		{Path: "text.idx", Index: ix},
+	}, 10*time.Millisecond, nil)
+
+	pm.Start(context.Background())
+	waitForSaveStart(t, ix)
+
+	stopCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	stopErr := pm.StopAndSave(stopCtx)
+	elapsed := time.Since(start)
+
+	if !errors.Is(stopErr, index.ErrSaveInFlight) {
+		t.Fatalf("StopAndSave returned %v; it must report ErrSaveInFlight so the caller keeps the index open", stopErr)
+	}
+	if !errors.Is(stopErr, context.DeadlineExceeded) {
+		t.Fatalf("StopAndSave returned %v; it must also report why it stopped waiting", stopErr)
+	}
+	if elapsed > 3*time.Second {
+		t.Fatalf("StopAndSave waited %s; the wait must stay bounded", elapsed)
+	}
+	if !ix.saving.Load() {
+		t.Fatal("the test did not reproduce an in-flight save; nothing was fenced")
+	}
+	if ix.closeAttempts.Load() != 0 {
+		t.Fatal("the persistence manager closed the index itself; only the caller may close it")
+	}
+
+	close(ix.release)
+	deadline := time.Now().Add(2 * time.Second)
+	for ix.saving.Load() && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if ix.closedDuring.Load() {
+		t.Fatal("the index was closed while a save was still writing it")
+	}
+}
+
+// TestStopAndSaveRunsFinalSaveWhenQuiescent pins the good path: when no periodic
+// save is in flight, StopAndSave still writes the final snapshot and reports the
+// index as safe to close.
+func TestStopAndSaveRunsFinalSaveWhenQuiescent(t *testing.T) {
+	ix := &fakePersistIndex{}
+	pm := index.NewPersistenceManager([]index.IndexedFile{
+		{Path: "text.idx", Index: ix},
+	}, time.Hour, nil)
+
+	pm.Start(context.Background())
+
+	stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := pm.StopAndSave(stopCtx); err != nil {
+		t.Fatalf("StopAndSave on an idle manager: %v", err)
+	}
+	if got := atomic.LoadInt32(&ix.saveCalls); got != 1 {
+		t.Fatalf("final forced save ran %d times, want 1", got)
+	}
+}
+
+// TestAutosaveTickSkipsBackendsAfterShutdown proves a tick that is part way
+// through the index list stops starting new backend saves once shutdown begins.
+// The tick holds one lock across every index, so without the check the second
+// index would start a fresh save after the manager was told to stop.
+func TestAutosaveTickSkipsBackendsAfterShutdown(t *testing.T) {
+	first := newBlockingSaveIndex(false)
+	second := &fakePersistIndex{}
+
+	pm := index.NewPersistenceManager([]index.IndexedFile{
+		{Path: "text.idx", Index: first},
+		{Path: "code.idx", Index: second},
+	}, 10*time.Millisecond, nil)
+
+	runCtx, cancelRun := context.WithCancel(context.Background())
+	pm.Start(runCtx)
+	waitForSaveStart(t, first)
+
+	// Cancel while the first index is saving, then let it finish.
+	cancelRun()
+	close(first.release)
+
+	stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	// The manager is already cancelled, so this only drains and runs the final
+	// forced save, which is allowed to touch every index.
+	_ = pm.StopAndSave(stopCtx)
+
+	// The forced final save is the only Save the second index may have seen
+	// from this run; the cancelled tick must not have started one.
+	if got := atomic.LoadInt32(&second.saveCalls); got > 1 {
+		t.Fatalf("the second index was saved %d times; a cancelled tick started a new backend save", got)
+	}
+}
+
+// blockingSaveIndex must satisfy the interfaces the manager type-asserts.
+var (
+	_ model.Index       = (*blockingSaveIndex)(nil)
+	_ model.Persistable = (*blockingSaveIndex)(nil)
+)

--- a/tests/security/cli_boundary_test.go
+++ b/tests/security/cli_boundary_test.go
@@ -217,6 +217,8 @@ func TestRepoSplitBoundary_InternalCLIFileOwnership(t *testing.T) {
 		"up_daemon.go":                           {},
 		"up_distributed_embed.go":                {},
 		"up_graceful_stop_test.go":               {},
+		"up_shutdown.go":                         {},
+		"up_shutdown_test.go":                    {},
 		"watch_source_gate_695_test.go":          {},
 	}
 


### PR DESCRIPTION
Closes #688. Closes #689.

Both issues are the same lifecycle defect seen from two ends, so they are fixed together. #688 is "shutdown does not wait for work that is still using the index and the store". #689 is "shutdown closes an index while a save is still writing it". A fix for either one alone would have had to touch the same teardown path.

Re-verified against current `main` (`2c1de24`): `runUp` still launched `transport.Serve` and the initial ingest outside `bgWG`, `runEventLoop` still returned immediately on cancellation, and `autosaveTick` still called every backend with `context.Background()`.

## The shutdown order

The order is now written down once, in `internal/cli/up_shutdown.go`, and the deferred calls in `runUp` implement it:

1. **Stop accepting new work.** Cancel the run context. The MCP transport stops accepting new connections. The ingest, embed, corpus-writer and watch workers see the cancellation.
2. **Drain in-flight work.** Wait for the MCP transport, the initial ingest and the other background workers to return. A handler that already started keeps its index and its store until it finishes.
3. **Stop persistence.** Cancel the periodic autosave, wait for it, then write the final snapshot.
4. **Close resources.** Close the indexes, then the store.

A close that races a writer is the bug in #689, so step 4 must be last and must be fenced. See "The autosave fence" below.

## What changed

**#688: the transport and the initial ingest join the drain group.**

`transport.Serve` and the initial ingest goroutine now register on `bgWG`, so shutdown waits for them before persistence stops and before the indexes and the store close. `http.Server.Shutdown` stops accepting connections and then waits for the active handlers, so "Serve returned" now means "no MCP handler still uses the index or the store". Before this, `runEventLoop` returned as soon as the context was cancelled and the deferred cleanup ran straight into `Index.Close` and `Store.Close`.

**#689: the autosave is cancelable, and the close is fenced.**

The periodic tick used `context.Background()`. It now uses the manager lifetime context, which `StopAndSave` cancels. `autosaveTick` also checks the context between indexes, because one tick holds `saveMu` across the whole list.

## Cancel the autosave, or wait for it?

Both, in that order. They answer different halves of the problem.

**Make it cancelable, because that is what is safest for the file on disk.** A save that is interrupted by SIGKILL can leave a half-written file. A save that observes cancellation returns before it commits, so the previous good snapshot stays on disk. The newest vectors are lost, but they are recoverable: sqlite keeps the source of truth and the existing startup reconciliation (#402 A2) re-pends chunks whose vectors are missing. A truncated snapshot is not recoverable. So a cancelable save is strictly better than a killed one.

**Then wait for it, because cancellation is a request, not a guarantee.** A backend may ignore the context. Waiting forever is not an option, so `StopAndSave` keeps its bounded wait. What changes is what it reports when the wait expires: it now returns `index.ErrSaveInFlight` joined with the context error, instead of a bare `ctx.Err()`.

## The autosave fence

`ErrSaveInFlight` is an ownership statement: a save still owns the indexes, so the caller must not close them. `runUp` honours it with `indexCloseFence`, which skips the `Close` calls and prints why. The file handles leak until the process exits, and the operating system reclaims them. Leaking a handle for the last moment of a process is a much smaller cost than closing a file underneath its own writer.

## The deadlines, and why they fit

| Wait | Budget | Note |
|---|---|---|
| MCP transport, in-flight requests | 5s | unchanged `http.Server.Shutdown` window |
| Background drain (step 2) | 6s | transport grace plus 1s of slack |
| Persistence stop and final save (step 3) | 3s | unchanged window |
| **Total graceful stop** | **9s** | |

The budget has to fit under the grace period of every process manager that stops the daemon, or the wait is theatre.

- **`dir2mcp down`** was the binding constraint and it was already too tight before this PR: it sent SIGTERM and escalated to SIGKILL after 5 seconds, while the transport alone could take 5 seconds and persistence another 3. `daemonShutdownGrace` is now derived from the budget (`serverShutdownBudget + 1s` = 10s) so the two cannot drift apart.
- **launchd** kills after the plist `ExitTimeOut`, default 20s. **systemd** kills after the unit `TimeoutStopSec`, default `DefaultTimeoutStopSec`, which a distribution can lower. Both are now written explicitly into the generated units at 20 seconds, so the drain does not depend on a platform default.

`TestShutdownBudgetFitsEveryProcessManager` asserts these relationships, so lowering a manager's grace period below the budget fails the build instead of silently making the drain theatre.

## What happens when a deadline expires

- **Background drain (step 2).** Warn on stderr, which is teed to `server.log` and reaches the support bundle, then continue. The goroutines that remain hold a request handler or a scan, so the cost is a truncated answer to one client, not a damaged file. Hanging instead would leave the process alive until the supervisor sends SIGKILL, with no message at all.
- **Persistence stop (step 3).** Raise the fence, skip the final save, keep the indexes open, and report both facts. This is the case `ErrSaveInFlight` exists for.

## Spec

`dirstral-spec/docs/specs/behavior/bs-005-mcp-lifecycle.md` covers only the wire-level `initialize` handshake and session-id assignment. It says nothing about process shutdown, so nothing here contradicts it. The submodule pointer is unchanged.

## Tests

Verified against `main` with the copy-aside method (`cp` the file aside, `git checkout origin/main -- <file>`, run, restore). `git stash` was not used.

Confirmed failing against `main`:

- `TestUpShutdownWaitsForInitialIngest` (`tests/cli`). End-to-end through `App.RunWithContext`, with a blocking ingestor and a store that records when it was closed. Against `main`: *"up returned code 0 while the initial ingest was still running; shutdown did not drain it"*.
- `TestAutosaveObservesShutdownCancellation` (`tests/index`). Against `main`: *"the in-progress autosave never observed the shutdown cancellation"*.
- `TestStopAndSaveFencesCloseWhileSaveInFlight` (`tests/index`). Against `main`: *"StopAndSave returned context deadline exceeded; it must report ErrSaveInFlight so the caller keeps the index open"*.
- `TestAutosaveTickSkipsBackendsAfterShutdown` (`tests/index`). Against `main`: *"the second index was saved 2 times; a cancelled tick started a new backend save"*.

The two `ErrSaveInFlight` assertions name a symbol that does not exist on `main`, so for the copy-aside run the sentinel was stubbed into `main`'s `persistence.go` to isolate the behavioural check from the compile error.

Also added, pinning behaviour that has no `main` equivalent to compile against:

- `TestDrainWaitsForInFlightMCPRequest`. A real `SDKTransport` with a request parked inside a handler; the drain must not return until the handler completes.
- `TestDrainStopsWaitingAtTheBudget`. A goroutine that never exits; the drain must give up and say so.
- `TestIndexCloseFenceBlocksCloseWhileSaving` and `TestGeneratedServiceUnitsStateTheStopTimeout`.

Runs:

- `make check` passes. The one failure on a fresh worktree was `TestSpecYAMLSecretPatterns_Compile_JWTAndBearer`, which needs `git submodule update --init`; it passes after initializing the submodule.
- `make cyclo` (`gocyclo -over 15`) is clean. `runUp` did not grow: the new logic lives in `internal/cli/up_shutdown.go`.
- `CGO_ENABLED=1 go test -race ./tests/cli/` passes (about 430s), as do `-race` runs of `./internal/cli/`, `./tests/index/` and `./tests/mcp/`. The intermittent `TestReindex_AfterCrash_RepeatedCrashesDoNotRotatePartialState` failure tracked as #807 did not appear.
- `internal/cli/up_shutdown.go` and `internal/cli/up_shutdown_test.go` are added to the allowlist in `tests/security/cli_boundary_test.go`.

## Review

`coderabbit review --committed --base main` raised one finding, which was valid and is fixed in a follow-up commit: the three shutdown writers used the raw `a.stderr` rather than the synchronized sink. That matters exactly in the case this PR adds, because a drain that gives up leaves background goroutines writing to that same sink (issue #419). The `NewSyncWriter` call is now hoisted above the first shutdown defer and passed to `drainBackgroundWorkers`, `stopPersistenceWithLog` and `closeIndexesAfterPersistence`. `go test -race ./tests/cli/ ./internal/cli/` was re-run after the change and passes.

## Checklist

- [x] `coderabbit review` run, the one finding addressed
- [x] `make check` passes locally, including `gocyclo -over 15`
- [x] new behavior has test coverage that fails against `main`
- [x] `README.md` and `docs/` remain truthful (neither documents a shutdown grace period)
- [x] no unrelated files changed, submodule pointer untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SsfcqnbrNzpUEnSVJ3oow8
