### PR TITLE
fix(retrieval): bound the open_file source read to the answer it returns (#690)

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2528,8 +2528,8 @@ func (s *Server) initAudioDocumentOnDemand(ctx context.Context, normalizedRel st
 	if statErr != nil {
 		return model.Document{}, mapFileAccessError(statErr)
 	}
-	// Bound the read to the ingest file-size cap. open_file streams via
-	// readFileBounded; this on-demand branch previously used an unbounded
+	// Bound the read to the ingest file-size cap. open_file streams its source
+	// (issue #690); this on-demand branch previously used an unbounded
 	// os.ReadFile, so a large within-root audio file could OOM the daemon
 	// (issue #407). Files over the cap are never indexed by discovery either,
 	// so refusing here keeps the two paths consistent.

--- a/internal/retrieval/open_file_stream.go
+++ b/internal/retrieval/open_file_stream.go
@@ -1,0 +1,521 @@
+package retrieval
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"io"
+	"regexp"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// This file holds the bounded read path for open_file (issue #690).
+//
+// open_file publishes a bounded answer: max_chars is clamped to 50000 runes.
+// The raw-source path used to read the COMPLETE local file or S3 object into
+// memory, convert the full byte slice to a string, scan that string, slice it,
+// and only then truncate. A source that grew after indexing, or a large remote
+// text file, therefore cost unbounded memory for a strictly bounded answer.
+//
+// The selectors below stream the source instead. Each one retains at most one
+// read budget of bytes, and it discards every other byte after it has looked at
+// it. Peak memory is therefore a function of max_chars, not of source size.
+// The shape follows internal/protocol.ReadLimitedResponseBody (PR #803): read
+// through io.LimitReader, keep one unit past the cap so an overflow is visible,
+// and give the caller a clear result instead of a confusing failure.
+
+const (
+	// openFileReadChunkBytes is the fixed working buffer that moves source
+	// bytes through the selectors and the secret scanner. It bounds the
+	// per-read allocation, and it is large enough that one syscall serves many
+	// lines of ordinary text.
+	openFileReadChunkBytes = 64 << 10
+
+	// secretScanOverlapBytes is the number of trailing bytes that carry from
+	// one scanned chunk into the next. A secret that lands on a chunk boundary
+	// is still matched, because the scanner always sees the boundary inside one
+	// window. 4 KiB is far longer than the shortest match of any credential
+	// pattern the product ships or an operator writes.
+	secretScanOverlapBytes = 4 << 10
+
+	// secretScanMarginBytes is how far past the answer the scanner keeps
+	// reading. The margin covers a secret that starts inside the answer window
+	// and continues past its end, and it holds the scan to a fixed cost instead
+	// of the size of the source.
+	//
+	// The value matches the ingest-time secret sample (64 KiB, see
+	// internal/ingest.secretScanSampleBytes). open_file always reads from the
+	// first byte of the source, so every request scans at least the same head
+	// bytes that ingest scans. A document that ingest withholds can therefore
+	// never be served by the tool, which is what SPEC 15.4 requires.
+	secretScanMarginBytes = 64 << 10
+)
+
+// errSecretMatch reports that a secret pattern matched the source. It travels
+// out of the reader, so a match stops the read at once instead of after the
+// whole source has moved. The caller maps it to model.ErrForbidden, which is
+// the error the tool contract publishes.
+var errSecretMatch = errors.New("retrieval: source matches a secret pattern")
+
+// openFileReadBudgetBytes returns the number of source bytes that a selector
+// may retain to build a maxChars-rune answer.
+//
+// The budget is NOT maxChars. A caller asks for characters, and the bytes that
+// carry those characters depend on the encoding: one UTF-8 rune takes up to
+// utf8.UTFMax bytes. maxChars*utf8.UTFMax bytes therefore always hold at least
+// maxChars runes, whatever the text. One extra rune of slack makes an
+// over-length source visible: when a selector fills the budget, the retained
+// text holds more than maxChars runes, so the rune truncation that follows both
+// cuts the answer to the published size and reports truncated=true. The slack
+// also keeps a rune that is split at the budget edge out of the answer, because
+// that partial rune always sits past position maxChars.
+func openFileReadBudgetBytes(maxChars int) int {
+	if maxChars <= 0 {
+		maxChars = 1
+	}
+	return (maxChars + 1) * utf8.UTFMax
+}
+
+// spanSelection is the bounded result of a streaming selector.
+type spanSelection struct {
+	// text is the selected content. It never exceeds the read budget.
+	text string
+	// truncated reports that the selector stopped at the budget, so the source
+	// holds more content for this span than the answer carries.
+	truncated bool
+}
+
+// ctxReader stops a read as soon as the request context is done. A large local
+// file and a large remote object both move through many Read calls, so the
+// cancellation lands within one chunk instead of after the whole source.
+type ctxReader struct {
+	ctx context.Context
+	r   io.Reader
+}
+
+func (c *ctxReader) Read(p []byte) (int, error) {
+	if err := c.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return c.r.Read(p)
+}
+
+// secretScanner applies the configured secret patterns to a stream instead of
+// to one buffered string. It keeps only a small overlap window, so every byte
+// that open_file reads is covered while memory stays flat.
+//
+// One property differs from a whole-string match: a pattern that is anchored to
+// the start or the end of the text (^ or $ without the multi-line flag) sees a
+// chunk boundary as a text boundary. The drift is fail-closed, because it can
+// only refuse content that a whole-string match would have served. It never
+// serves content that a whole-string match would have refused.
+type secretScanner struct {
+	patterns []*regexp.Regexp
+	// tail holds the last bytes of the previous chunk, and window joins that
+	// tail to the current chunk. Both buffers are reused across chunks, so a
+	// scan of a large source allocates nothing per chunk.
+	tail   []byte
+	window []byte
+}
+
+func newSecretScanner(patterns []*regexp.Regexp) *secretScanner {
+	active := make([]*regexp.Regexp, 0, len(patterns))
+	for _, re := range patterns {
+		if re != nil {
+			active = append(active, re)
+		}
+	}
+	return &secretScanner{patterns: active}
+}
+
+// enabled reports whether any pattern is configured. With no pattern the read
+// stops as soon as the answer is complete, so an object store never sends the
+// bytes past the requested window.
+func (sc *secretScanner) enabled() bool {
+	return sc != nil && len(sc.patterns) > 0
+}
+
+// scan checks one chunk together with the tail of the previous chunk.
+func (sc *secretScanner) scan(p []byte) error {
+	if !sc.enabled() || len(p) == 0 {
+		return nil
+	}
+	window := p
+	if len(sc.tail) > 0 {
+		sc.window = append(sc.window[:0], sc.tail...)
+		sc.window = append(sc.window, p...)
+		window = sc.window
+	}
+	for _, re := range sc.patterns {
+		if re.Match(window) {
+			return errSecretMatch
+		}
+	}
+	sc.keepTail(window)
+	return nil
+}
+
+// keepTail stores the last secretScanOverlapBytes bytes of the scanned window.
+func (sc *secretScanner) keepTail(window []byte) {
+	keep := window
+	if len(keep) > secretScanOverlapBytes {
+		keep = keep[len(keep)-secretScanOverlapBytes:]
+	}
+	sc.tail = append(sc.tail[:0], keep...)
+}
+
+// scanMargin reads secretScanMarginBytes past the answer and keeps none of
+// them, so a secret that begins inside the answer window and runs past its end
+// is still matched. With no pattern configured the function returns at once and
+// those bytes stay unread.
+func (sc *secretScanner) scanMargin(r io.Reader) error {
+	if !sc.enabled() {
+		return nil
+	}
+	// io.Discard reads through a pooled buffer, so the margin keeps no bytes
+	// and allocates nothing per chunk.
+	if _, err := io.Copy(io.Discard, io.LimitReader(r, secretScanMarginBytes)); err != nil {
+		return err
+	}
+	return nil
+}
+
+// scanningReader feeds every byte that a selector reads to the secret scanner
+// before the selector sees it. The scanner therefore covers the stream in
+// order, across both the selection phase and the margin phase.
+type scanningReader struct {
+	r       io.Reader
+	scanner *secretScanner
+}
+
+func (s *scanningReader) Read(p []byte) (int, error) {
+	n, err := s.r.Read(p)
+	if n > 0 {
+		if scanErr := s.scanner.scan(p[:n]); scanErr != nil {
+			return n, scanErr
+		}
+	}
+	return n, err
+}
+
+// boundedBuilder collects selected text up to a hard byte limit. It reports
+// when it is full, so a selector can stop reading instead of growing.
+type boundedBuilder struct {
+	b     strings.Builder
+	limit int
+	full  bool
+	// wroteLine records that writeLine has run at least once. An empty first
+	// line still needs the separator before the second line, so the flag cannot
+	// be replaced by a length test.
+	wroteLine bool
+}
+
+func newBoundedBuilder(limit int) *boundedBuilder {
+	if limit < 0 {
+		limit = 0
+	}
+	return &boundedBuilder{limit: limit}
+}
+
+// writeString appends as much of s as the limit allows.
+func (bb *boundedBuilder) writeString(s string) {
+	if bb.full || s == "" {
+		return
+	}
+	room := bb.limit - bb.b.Len()
+	if room <= 0 {
+		bb.full = true
+		return
+	}
+	if len(s) > room {
+		s = s[:room]
+		bb.full = true
+	}
+	bb.b.WriteString(s)
+	if bb.b.Len() >= bb.limit {
+		bb.full = true
+	}
+}
+
+// writeLine appends one line, with a newline separator before every line but
+// the first. It mirrors strings.Join(lines, "\n").
+func (bb *boundedBuilder) writeLine(line string) {
+	if bb.wroteLine {
+		bb.writeString("\n")
+	}
+	bb.wroteLine = true
+	bb.writeString(line)
+}
+
+func (bb *boundedBuilder) String() string { return bb.b.String() }
+
+func (bb *boundedBuilder) len() int { return bb.b.Len() }
+
+// sourceLine is one logical line of the source.
+type sourceLine struct {
+	text string
+	// truncated reports that the line was longer than the retained limit. The
+	// rest of the line was consumed and dropped.
+	truncated bool
+}
+
+// lineReader yields the logical lines of a stream. It splits on "\n" exactly as
+// strings.Split does, so a source that ends with a newline yields a final empty
+// line and an empty source yields one empty line. It retains at most limit
+// bytes of any single line, so one very long line cannot exhaust memory.
+type lineReader struct {
+	br    *bufio.Reader
+	limit int
+	done  bool
+}
+
+func newLineReader(r io.Reader, limit int) *lineReader {
+	return &lineReader{br: bufio.NewReaderSize(r, openFileReadChunkBytes), limit: limit}
+}
+
+// next returns the next line. ok=false means the stream is finished.
+func (lr *lineReader) next() (sourceLine, bool, error) {
+	if lr.done {
+		return sourceLine{}, false, nil
+	}
+	out := newBoundedBuilder(lr.limit)
+	dropped := false
+	for {
+		chunk, err := lr.br.ReadSlice('\n')
+		switch {
+		case err == nil:
+			appendChunk(out, chunk[:len(chunk)-1], &dropped)
+			return sourceLine{text: out.String(), truncated: dropped}, true, nil
+		case errors.Is(err, bufio.ErrBufferFull):
+			appendChunk(out, chunk, &dropped)
+		case errors.Is(err, io.EOF):
+			lr.done = true
+			appendChunk(out, chunk, &dropped)
+			return sourceLine{text: out.String(), truncated: dropped}, true, nil
+		default:
+			return sourceLine{}, false, err
+		}
+	}
+}
+
+// appendChunk adds a chunk to a bounded builder and records whether the builder
+// had to drop bytes.
+func appendChunk(out *boundedBuilder, chunk []byte, dropped *bool) {
+	before := out.len()
+	out.writeString(string(chunk))
+	if out.len()-before < len(chunk) {
+		*dropped = true
+	}
+}
+
+// selectSpan streams the source and returns the requested window. It reproduces
+// the span semantics of the buffered path: an empty kind with no line numbers
+// returns the head of the document, "lines" returns a line range, "page"
+// returns a form-feed delimited page, and "time" returns the timestamped lines
+// inside a time window.
+func selectSpan(r io.Reader, kind string, span model.Span, budget int) (spanSelection, error) {
+	switch kind {
+	case "", "lines":
+		if kind == "lines" || span.StartLine > 0 || span.EndLine > 0 {
+			return selectLineRange(r, span.StartLine, span.EndLine, budget)
+		}
+		return selectPrefix(r, budget)
+	case "page":
+		return selectPage(r, span.Page, budget)
+	case "time":
+		return selectTimeRange(r, span, budget)
+	default:
+		return spanSelection{}, model.ErrDocTypeUnsupported
+	}
+}
+
+// selectPrefix returns the head of the document. It reads one budget of bytes
+// and stops, so a 5 GB text file costs the same as a 5 KB one.
+func selectPrefix(r io.Reader, budget int) (spanSelection, error) {
+	data, err := io.ReadAll(io.LimitReader(r, int64(budget)))
+	if err != nil {
+		return spanSelection{}, err
+	}
+	return spanSelection{text: string(data), truncated: len(data) >= budget}, nil
+}
+
+// selectLineRange returns lines start..end. It streams to the first requested
+// line and keeps none of the lines before it, so "line 9000 of a large file" is
+// a seek problem, not a buffering problem: the prefix passes through the fixed
+// working buffer and is dropped. Only the requested lines are retained, and
+// only up to the budget.
+func selectLineRange(r io.Reader, start, end, budget int) (spanSelection, error) {
+	if start <= 0 {
+		start = 1
+	}
+	if end <= 0 || end < start {
+		end = start
+	}
+	lr := newLineReader(r, budget)
+	out := newBoundedBuilder(budget)
+	truncated := false
+	for idx := 1; idx <= end; idx++ {
+		line, ok, err := lr.next()
+		if err != nil {
+			return spanSelection{}, err
+		}
+		if !ok {
+			break
+		}
+		if idx < start {
+			continue
+		}
+		if line.truncated {
+			truncated = true
+		}
+		out.writeLine(line.text)
+		if out.full {
+			truncated = true
+			break
+		}
+	}
+	return spanSelection{text: out.String(), truncated: truncated}, nil
+}
+
+// selectPage returns one form-feed delimited page. It discards every earlier
+// page as it passes, and it retains at most one budget of the requested page.
+//
+// The page count follows the buffered rule (#427): a form feed at the very end
+// of the document terminates the last page, it does not open a phantom empty
+// page. A document with more than one page also has its page text trimmed of
+// leading and trailing newlines, so the reader must know whether a second page
+// exists before it can answer for page 1. One peeked byte answers that.
+func selectPage(r io.Reader, page, budget int) (spanSelection, error) {
+	if page <= 0 {
+		page = 1
+	}
+	br := bufio.NewReaderSize(r, openFileReadChunkBytes)
+	for idx := 1; idx < page; idx++ {
+		_, _, delimited, err := readFormFeedSegment(br, 0)
+		if err != nil {
+			return spanSelection{}, err
+		}
+		if !delimited {
+			// The document ended before this page began.
+			return spanSelection{}, model.ErrDocTypeUnsupported
+		}
+	}
+
+	text, truncated, delimited, err := readFormFeedSegment(br, budget)
+	if err != nil {
+		return spanSelection{}, err
+	}
+	multiPage := page > 1
+	if delimited {
+		more, peekErr := hasMoreBytes(br)
+		if peekErr != nil {
+			return spanSelection{}, peekErr
+		}
+		multiPage = multiPage || more
+	} else if page > 1 && text == "" && !truncated {
+		// A trailing form feed produced this empty segment. It is not a page.
+		return spanSelection{}, model.ErrDocTypeUnsupported
+	}
+	if multiPage {
+		text = strings.Trim(text, "\n")
+	}
+	return spanSelection{text: text, truncated: truncated}, nil
+}
+
+// readFormFeedSegment consumes one form-feed delimited segment. It retains at
+// most limit bytes of it and drops the rest, and it always consumes the segment
+// to its end so the caller can look at what follows. delimited reports that a
+// form feed, not the end of the source, closed the segment.
+func readFormFeedSegment(br *bufio.Reader, limit int) (text string, truncated, delimited bool, err error) {
+	out := newBoundedBuilder(limit)
+	dropped := false
+	for {
+		chunk, readErr := br.ReadSlice('\f')
+		switch {
+		case readErr == nil:
+			appendChunk(out, chunk[:len(chunk)-1], &dropped)
+			return out.String(), dropped, true, nil
+		case errors.Is(readErr, bufio.ErrBufferFull):
+			appendChunk(out, chunk, &dropped)
+		case errors.Is(readErr, io.EOF):
+			appendChunk(out, chunk, &dropped)
+			return out.String(), dropped, false, nil
+		default:
+			return "", false, false, readErr
+		}
+	}
+}
+
+// hasMoreBytes reports whether the stream holds at least one more byte.
+func hasMoreBytes(br *bufio.Reader) (bool, error) {
+	if _, err := br.Peek(1); err != nil {
+		if errors.Is(err, io.EOF) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// selectTimeRange returns the timestamped lines inside the requested window. It
+// keeps only the matching lines, up to the budget, and it stops reading once
+// the budget is full. A source with no timestamp at all is not a transcript, so
+// it reports model.ErrDocTypeUnsupported, as the buffered path did.
+func selectTimeRange(r io.Reader, span model.Span, budget int) (spanSelection, error) {
+	startMS, endMS := normalizeTimeBounds(span)
+	lr := newLineReader(r, budget)
+	out := newBoundedBuilder(budget)
+	truncated := false
+	found := false
+	for {
+		line, ok, err := lr.next()
+		if err != nil {
+			return spanSelection{}, err
+		}
+		if !ok {
+			break
+		}
+		m := timePrefixRe.FindStringSubmatch(line.text)
+		if len(m) == 0 {
+			continue
+		}
+		found = true
+		ts := parseTimestampMS(m[1], m[2], m[3])
+		if ts < startMS || (endMS > 0 && ts > endMS) {
+			continue
+		}
+		if line.truncated {
+			truncated = true
+		}
+		out.writeLine(line.text)
+		if out.full {
+			truncated = true
+			break
+		}
+	}
+	if !found {
+		return spanSelection{}, model.ErrDocTypeUnsupported
+	}
+	return spanSelection{text: out.String(), truncated: truncated}, nil
+}
+
+// normalizeTimeBounds clamps the requested time window the way the buffered
+// path did: negative values become 0, and an end before the start becomes the
+// start.
+func normalizeTimeBounds(span model.Span) (startMS, endMS int) {
+	startMS = span.StartMS
+	endMS = span.EndMS
+	if startMS < 0 {
+		startMS = 0
+	}
+	if endMS < 0 {
+		endMS = 0
+	}
+	if endMS > 0 && endMS < startMS {
+		endMS = startMS
+	}
+	return startMS, endMS
+}

--- a/internal/retrieval/open_file_stream_690_test.go
+++ b/internal/retrieval/open_file_stream_690_test.go
@@ -1,0 +1,235 @@
+package retrieval
+
+import (
+	"errors"
+	"math/rand"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// The streaming selectors replaced buffered ones that split the whole document
+// into a string slice (issue #690). The reference implementations below are the
+// buffered originals. The tests compare the two over many generated documents,
+// so the streaming rewrite keeps the span semantics it inherited.
+
+func refSliceLines(content string, start, end int) string {
+	lines := strings.Split(content, "\n")
+	if start <= 0 {
+		start = 1
+	}
+	if end <= 0 {
+		end = start
+	}
+	if start > len(lines) {
+		return ""
+	}
+	if end > len(lines) {
+		end = len(lines)
+	}
+	if end < start {
+		end = start
+	}
+	return strings.Join(lines[start-1:end], "\n")
+}
+
+func refSlicePage(content string, page int) (string, bool) {
+	if page <= 0 {
+		page = 1
+	}
+	parts := strings.Split(content, "\f")
+	if len(parts) > 1 && parts[len(parts)-1] == "" {
+		parts = parts[:len(parts)-1]
+	}
+	if len(parts) > 1 {
+		if page > len(parts) {
+			return "", false
+		}
+		return strings.Trim(parts[page-1], "\n"), true
+	}
+	if page == 1 {
+		return parts[0], true
+	}
+	return "", false
+}
+
+func refSliceTime(content string, startMS, endMS int) (string, bool) {
+	lines := strings.Split(content, "\n")
+	out := make([]string, 0, len(lines))
+	found := false
+	for _, line := range lines {
+		m := timePrefixRe.FindStringSubmatch(line)
+		if len(m) == 0 {
+			continue
+		}
+		found = true
+		ts := parseTimestampMS(m[1], m[2], m[3])
+		if ts < startMS || (endMS > 0 && ts > endMS) {
+			continue
+		}
+		out = append(out, line)
+	}
+	if !found {
+		return "", false
+	}
+	return strings.Join(out, "\n"), true
+}
+
+// TestSelectLineRange_MatchesBufferedSemantics compares the streaming line
+// selector with the buffered original over generated documents.
+func TestSelectLineRange_MatchesBufferedSemantics(t *testing.T) {
+	rng := rand.New(rand.NewSource(690))
+	pieces := []string{"", "a", "line text", "\n", "b\n", "  ", "\f"}
+	for i := 0; i < 300; i++ {
+		var b strings.Builder
+		for j := 0; j < rng.Intn(12); j++ {
+			b.WriteString(pieces[rng.Intn(len(pieces))])
+			if rng.Intn(2) == 0 {
+				b.WriteString("\n")
+			}
+		}
+		content := b.String()
+		start := rng.Intn(8) - 1
+		end := rng.Intn(8) - 1
+		got, err := selectLineRange(strings.NewReader(content), start, end, testSelectBudget)
+		if err != nil {
+			t.Fatalf("selectLineRange(%q, %d, %d): %v", content, start, end, err)
+		}
+		if want := refSliceLines(content, start, end); got.text != want {
+			t.Fatalf("selectLineRange(%q, %d, %d) = %q, want %q", content, start, end, got.text, want)
+		}
+	}
+}
+
+// TestSelectPage_MatchesBufferedSemantics compares the streaming page selector
+// with the buffered original, including the page-count edge cases of #427.
+func TestSelectPage_MatchesBufferedSemantics(t *testing.T) {
+	rng := rand.New(rand.NewSource(427))
+	pieces := []string{"", "p", "text\n", "\n", "\f", "a\fb"}
+	for i := 0; i < 300; i++ {
+		var b strings.Builder
+		for j := 0; j < rng.Intn(10); j++ {
+			b.WriteString(pieces[rng.Intn(len(pieces))])
+		}
+		content := b.String()
+		page := rng.Intn(5)
+		got, err := selectPage(strings.NewReader(content), page, testSelectBudget)
+		wantText, wantOK := refSlicePage(content, page)
+		if err != nil {
+			if !errors.Is(err, model.ErrDocTypeUnsupported) {
+				t.Fatalf("selectPage(%q, %d): %v", content, page, err)
+			}
+			if wantOK {
+				t.Fatalf("selectPage(%q, %d) reported out of range, want %q", content, page, wantText)
+			}
+			continue
+		}
+		if !wantOK {
+			t.Fatalf("selectPage(%q, %d) = %q, want out of range", content, page, got.text)
+		}
+		if got.text != wantText {
+			t.Fatalf("selectPage(%q, %d) = %q, want %q", content, page, got.text, wantText)
+		}
+	}
+}
+
+// TestSelectTimeRange_MatchesBufferedSemantics compares the streaming time
+// selector with the buffered original.
+func TestSelectTimeRange_MatchesBufferedSemantics(t *testing.T) {
+	rng := rand.New(rand.NewSource(9))
+	pieces := []string{"[00:10] intro", "[01:00] middle", "[02:30] later", "no timestamp", ""}
+	for i := 0; i < 200; i++ {
+		lines := make([]string, 0, 8)
+		for j := 0; j < rng.Intn(8); j++ {
+			lines = append(lines, pieces[rng.Intn(len(pieces))])
+		}
+		content := strings.Join(lines, "\n")
+		span := model.Span{Kind: "time", StartMS: rng.Intn(3) * 60000, EndMS: rng.Intn(4) * 60000}
+		got, err := selectTimeRange(strings.NewReader(content), span, testSelectBudget)
+		startMS, endMS := normalizeTimeBounds(span)
+		wantText, wantOK := refSliceTime(content, startMS, endMS)
+		if err != nil {
+			if !errors.Is(err, model.ErrDocTypeUnsupported) {
+				t.Fatalf("selectTimeRange(%q): %v", content, err)
+			}
+			if wantOK {
+				t.Fatalf("selectTimeRange(%q) reported unsupported, want %q", content, wantText)
+			}
+			continue
+		}
+		if !wantOK {
+			t.Fatalf("selectTimeRange(%q) = %q, want unsupported", content, got.text)
+		}
+		if got.text != wantText {
+			t.Fatalf("selectTimeRange(%q) = %q, want %q", content, got.text, wantText)
+		}
+	}
+}
+
+// TestOpenFileReadBudgetBytes_HoldsTheRequestedRunes pins the relationship
+// between the character contract and the byte budget: the budget must hold more
+// than max_chars runes even when every rune is four bytes long, so the answer is
+// never short and a cut rune never reaches the caller.
+func TestOpenFileReadBudgetBytes_HoldsTheRequestedRunes(t *testing.T) {
+	for _, maxChars := range []int{200, 20000, 50000} {
+		budget := openFileReadBudgetBytes(maxChars)
+		if budget < maxChars*utf8.UTFMax {
+			t.Fatalf("budget %d for %d runes cannot hold four-byte runes", budget, maxChars)
+		}
+		body := strings.Repeat("𝔘", maxChars+10)
+		selection, err := selectPrefix(strings.NewReader(body), budget)
+		if err != nil {
+			t.Fatalf("selectPrefix: %v", err)
+		}
+		out, truncated := truncateRunesWithFlag(selection.text, maxChars)
+		if got := utf8.RuneCountInString(out); got != maxChars {
+			t.Fatalf("answer holds %d runes, want %d", got, maxChars)
+		}
+		if !truncated {
+			t.Fatalf("expected truncated=true for a source longer than %d runes", maxChars)
+		}
+		if strings.ContainsRune(out, utf8.RuneError) {
+			t.Fatalf("answer holds a cut rune")
+		}
+	}
+}
+
+// TestSelectLineRange_OneHugeLineStaysBounded checks that a single line longer
+// than the budget is cut instead of buffered. A document can be one line.
+func TestSelectLineRange_OneHugeLineStaysBounded(t *testing.T) {
+	const budget = 4096
+	body := strings.Repeat("z", 1<<20) + "\nsecond line"
+	got, err := selectLineRange(strings.NewReader(body), 1, 1, budget)
+	if err != nil {
+		t.Fatalf("selectLineRange: %v", err)
+	}
+	if len(got.text) != budget {
+		t.Fatalf("retained %d bytes, want the budget of %d", len(got.text), budget)
+	}
+	if !got.truncated {
+		t.Fatalf("expected truncated=true for a line longer than the budget")
+	}
+}
+
+// TestSelectPrefix_StopsAtTheBudget checks the head selector keeps one budget
+// and reports that more content follows.
+func TestSelectPrefix_StopsAtTheBudget(t *testing.T) {
+	const budget = 1024
+	got, err := selectPrefix(strings.NewReader(strings.Repeat("q", 4096)), budget)
+	if err != nil {
+		t.Fatalf("selectPrefix: %v", err)
+	}
+	if len(got.text) != budget || !got.truncated {
+		t.Fatalf("selectPrefix kept %d bytes (truncated=%v), want %d and true", len(got.text), got.truncated, budget)
+	}
+
+	short, err := selectPrefix(strings.NewReader("tiny"), budget)
+	if err != nil {
+		t.Fatalf("selectPrefix: %v", err)
+	}
+	if short.text != "tiny" || short.truncated {
+		t.Fatalf("selectPrefix on a short source = (%q,%v), want (\"tiny\",false)", short.text, short.truncated)
+	}
+}

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -2004,37 +2004,30 @@ func isBinaryDocType(relPath string) bool {
 	return ext == ".pdf" || isImageExt(ext) || isAudioExt(ext)
 }
 
-// readSourceBytes returns the full byte content of the corpus document at
-// relPath. When a CorpusFS backend is injected (object stores such as S3) the
-// read routes through its Open seam — the same seam the media/embedding paths
-// use — so remote corpora return content instead of failing on a missing local
-// path (#432). With no backend it preserves the historical local read exactly:
-// a directory target maps to the actionable DOC_TYPE_UNSUPPORTED rather than an
-// opaque OS error, then readFileBounded returns the bytes. The bool mirrors
-// readFileBounded's truncation flag (always false here since the read is
-// unbounded; open_file applies its own maxChars downstream).
-func (s *Service) readSourceBytes(ctx context.Context, corpusFS corpusfs.CorpusFS, resolvedAbs, relPath string) ([]byte, bool, error) {
+// openSource opens the corpus document at relPath for streaming. When a
+// CorpusFS backend is injected (object stores such as S3) the read routes
+// through its Open seam, the same seam the media and embedding paths use, so
+// remote corpora return content instead of failing on a missing local path
+// (#432). With no backend it preserves the historical local behavior: a
+// directory target maps to the actionable DOC_TYPE_UNSUPPORTED rather than an
+// opaque OS error.
+//
+// The function returns a reader, never the bytes. open_file answers at most
+// max_chars runes, so the caller streams the source and keeps only the window
+// it returns (issue #690).
+func (s *Service) openSource(ctx context.Context, corpusFS corpusfs.CorpusFS, resolvedAbs, relPath string) (io.ReadCloser, error) {
 	if corpusFS != nil {
-		rc, err := corpusFS.Open(ctx, relPath)
-		if err != nil {
-			return nil, false, err
-		}
-		defer func() { _ = rc.Close() }()
-		data, readErr := io.ReadAll(rc)
-		if readErr != nil {
-			return nil, false, readErr
-		}
-		return data, false, nil
+		return corpusFS.Open(ctx, relPath)
 	}
 
 	info, err := os.Stat(resolvedAbs)
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 	if info.IsDir() {
-		return nil, false, model.ErrDocTypeUnsupported
+		return nil, model.ErrDocTypeUnsupported
 	}
-	return readFileBounded(resolvedAbs, 0)
+	return os.Open(resolvedAbs)
 }
 
 // hashSourceBytes computes the sha256 hex digest of the corpus document at
@@ -2273,24 +2266,64 @@ func (s *Service) openFileFromMetadata(normalizedRel string, span model.Span, ma
 	return out, truncated, true, nil
 }
 
+// openFileFromResolvedPath serves the raw source of a text-native document. It
+// streams the source and retains at most one read budget of bytes, so memory
+// stays bounded by max_chars and not by the size of the file or object (issue
+// #690). The published tool contract is unchanged: a caller that asks for a
+// legitimate window still gets that window.
+//
+// The secret policy applies to every byte the request reads, which is the
+// answer window, everything before it, and a fixed margin past it. Three
+// properties follow, and together they satisfy SPEC 15.4:
+//
+//  1. Every returned byte was scanned.
+//  2. The read always starts at the first byte of the source, so no answer can
+//     begin after an unscanned region. A caller cannot step over a secret to
+//     reach the text behind it.
+//  3. The scan always covers at least the head bytes that ingest samples
+//     (internal/ingest.secretScanSampleBytes), so a document that ingest
+//     withholds can never be served by this tool.
+//
+// The buffered path scanned the whole source, so it also refused the head of a
+// document whose only secret sat far past the answer. Reproducing that would
+// mean reading the whole source on every request, which is the cost this fix
+// removes, and it would still be weaker than it looks, because ingest itself
+// decides on a 64 KiB sample.
 func (s *Service) openFileFromResolvedPath(ctx context.Context, corpusFS corpusfs.CorpusFS, resolvedAbs, relPath string, secretPatterns []*regexp.Regexp, kind string, span model.Span, maxChars int) (string, bool, error) {
-	raw, readTruncated, err := s.readSourceBytes(ctx, corpusFS, resolvedAbs, relPath)
+	rc, err := s.openSource(ctx, corpusFS, resolvedAbs, relPath)
 	if err != nil {
 		return "", false, err
 	}
-	content := string(raw)
+	defer func() { _ = rc.Close() }()
 
-	if hasSecretMatch(secretPatterns, content) {
-		return "", false, model.ErrForbidden
+	scanner := newSecretScanner(secretPatterns)
+	source := &scanningReader{r: &ctxReader{ctx: ctx, r: rc}, scanner: scanner}
+
+	selection, selErr := selectSpan(source, kind, span, openFileReadBudgetBytes(maxChars))
+	// The buffered path refused a secret-bearing document before it looked at
+	// the span, so a secret outranks an unsatisfiable span. Keep that order:
+	// finish the scan before reporting that the span does not exist.
+	if selErr == nil || errors.Is(selErr, model.ErrDocTypeUnsupported) {
+		if marginErr := scanner.scanMargin(source); marginErr != nil {
+			return "", false, mapSourceReadError(marginErr)
+		}
+	}
+	if selErr != nil {
+		return "", false, mapSourceReadError(selErr)
 	}
 
-	selected, err := sliceContentBySpan(content, kind, span)
-	if err != nil {
-		return "", false, err
-	}
+	out, outTruncated := truncateRunesWithFlag(selection.text, maxChars)
+	return out, selection.truncated || outTruncated, nil
+}
 
-	out, outTruncated := truncateRunesWithFlag(selected, maxChars)
-	return out, readTruncated || outTruncated, nil
+// mapSourceReadError converts a streaming read failure into the open_file error
+// contract. A secret match becomes the published ErrForbidden; every other
+// error passes through unchanged.
+func mapSourceReadError(err error) error {
+	if errors.Is(err, errSecretMatch) {
+		return model.ErrForbidden
+	}
+	return err
 }
 
 // hasSecretMatch reports whether any of the compiled secret patterns matches s.
@@ -2364,55 +2397,8 @@ func resolveSymlinkInRoot(targetAbs, realRoot string, pathExcludes []string, s *
 	return resolvedAbs, nil
 }
 
-// sliceContentBySpan extracts the portion of content identified by the given
-// span kind. An empty kind or "lines" applies line-range slicing; "page" and
-// "time" select the relevant page/time segment.
-func sliceContentBySpan(content, kind string, span model.Span) (string, error) {
-	switch kind {
-	case "", "lines":
-		if kind == "lines" || span.StartLine > 0 || span.EndLine > 0 {
-			return sliceLines(content, span.StartLine, span.EndLine), nil
-		}
-		return content, nil
-	case "page":
-		page := span.Page
-		if page <= 0 {
-			page = 1
-		}
-		// metadata-backed OCR handled above; fall back to slicing pages directly
-		paged, ok := slicePage(content, page)
-		if !ok {
-			return "", model.ErrDocTypeUnsupported
-		}
-		return paged, nil
-	case "time":
-		return sliceTimeSpan(content, span)
-	default:
-		return "", model.ErrDocTypeUnsupported
-	}
-}
-
-// sliceTimeSpan normalises the time boundaries and extracts the matching
-// transcript segment from content.
-func sliceTimeSpan(content string, span model.Span) (string, error) {
-	startMS := span.StartMS
-	endMS := span.EndMS
-	if startMS < 0 {
-		startMS = 0
-	}
-	if endMS < 0 {
-		endMS = 0
-	}
-	if endMS > 0 && endMS < startMS {
-		endMS = startMS
-	}
-	// metadata-backed slices for time spans are handled earlier; just extract
-	timeSlice, ok := sliceTime(content, startMS, endMS)
-	if !ok {
-		return "", model.ErrDocTypeUnsupported
-	}
-	return timeSlice, nil
-}
+// Span selection lives in open_file_stream.go. It runs over a stream instead of
+// a buffered string, so open_file never holds a whole source in memory.
 
 func (s *Service) Stats(ctx context.Context) (model.Stats, error) {
 	if err := ctx.Err(); err != nil {
@@ -4257,26 +4243,6 @@ func globToRegexp(glob string) string {
 	return b.String()
 }
 
-func sliceLines(content string, start, end int) string {
-	lines := strings.Split(content, "\n")
-	if start <= 0 {
-		start = 1
-	}
-	if end <= 0 {
-		end = start
-	}
-	if start > len(lines) {
-		return ""
-	}
-	if end > len(lines) {
-		end = len(lines)
-	}
-	if end < start {
-		end = start
-	}
-	return strings.Join(lines[start-1:end], "\n")
-}
-
 func truncateRunesWithFlag(s string, max int) (string, bool) {
 	if max <= 0 {
 		return s, false
@@ -4286,26 +4252,6 @@ func truncateRunesWithFlag(s string, max int) (string, bool) {
 		return s, false
 	}
 	return string(r[:max]), true
-}
-
-func readFileBounded(path string, maxBytes int) ([]byte, bool, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, false, err
-	}
-	defer func() { _ = f.Close() }()
-
-	if maxBytes <= 0 {
-		data, readErr := io.ReadAll(f)
-		return data, false, readErr
-	}
-
-	lim := io.LimitReader(f, int64(maxBytes))
-	data, readErr := io.ReadAll(lim)
-	if readErr != nil {
-		return nil, false, readErr
-	}
-	return data, len(data) == maxBytes, nil
 }
 
 func (s *Service) sliceFromMetadata(relPath string, requested model.Span) (string, bool) {
@@ -4388,64 +4334,6 @@ func overlapsTime(aStart, aEnd, bStart, bEnd int) bool {
 		bEnd = bStart
 	}
 	return aStart <= bEnd && bStart <= aEnd
-}
-
-func slicePage(content string, page int) (string, bool) {
-	if page <= 0 {
-		page = 1
-	}
-	parts := strings.Split(content, "\f")
-	// A form-feed terminator on the final page yields a trailing empty segment
-	// (e.g. "p1\fp2\f" splits into 3 parts), which would otherwise present a
-	// phantom empty page beyond the last real one — open_file page=3 on a
-	// 2-page doc returning "" with ok=true. Drop it so the page count reflects
-	// real pages and an out-of-range index errors instead (#427).
-	if len(parts) > 1 && parts[len(parts)-1] == "" {
-		parts = parts[:len(parts)-1]
-	}
-	if len(parts) > 1 {
-		if page > len(parts) {
-			return "", false
-		}
-		return strings.Trim(parts[page-1], "\n"), true
-	}
-	if page == 1 {
-		// parts[0], not content: a single-page doc ending in a form-feed splits to
-		// ["text", ""] and the trailing-empty drop above leaves ["text"], so
-		// returning content would re-attach the stripped \f (#427 review).
-		return parts[0], true
-	}
-	return "", false
-}
-
-func sliceTime(content string, startMS, endMS int) (string, bool) {
-	lines := strings.Split(content, "\n")
-	out := make([]string, 0, len(lines))
-	foundTimestamp := false
-
-	for _, line := range lines {
-		m := timePrefixRe.FindStringSubmatch(line)
-		if len(m) == 0 {
-			continue
-		}
-		foundTimestamp = true
-		tsMS := parseTimestampMS(m[1], m[2], m[3])
-		if tsMS < startMS {
-			continue
-		}
-		if endMS > 0 && tsMS > endMS {
-			continue
-		}
-		out = append(out, line)
-	}
-
-	if !foundTimestamp {
-		return "", false
-	}
-	if len(out) == 0 {
-		return "", true
-	}
-	return strings.Join(out, "\n"), true
 }
 
 func parseTimestampMS(a, b, c string) int {

--- a/internal/retrieval/slice_regex_427_test.go
+++ b/internal/retrieval/slice_regex_427_test.go
@@ -1,44 +1,100 @@
 package retrieval
 
 import (
+	"errors"
 	"strings"
 	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
 )
+
+// testSelectBudget is a read budget far larger than any fixture below, so these
+// cases exercise span semantics rather than truncation.
+const testSelectBudget = 1 << 20
+
+// selectPageString runs the streaming page selector over an in-memory document.
+// It restores the (text, ok) shape the buffered slicePage had, so the #427
+// cases below keep reading as page-count assertions. Page selection now streams
+// (issue #690), and these cases pin that the stream counts pages the same way.
+func selectPageString(t *testing.T, content string, page int) (string, bool) {
+	t.Helper()
+	selection, err := selectPage(strings.NewReader(content), page, testSelectBudget)
+	if err != nil {
+		if errors.Is(err, model.ErrDocTypeUnsupported) {
+			return "", false
+		}
+		t.Fatalf("selectPage(%q, %d) returned err: %v", content, page, err)
+	}
+	return selection.text, true
+}
+
+// selectTimeString runs the streaming time selector over an in-memory
+// transcript and restores the (text, ok) shape of the buffered sliceTime.
+func selectTimeString(t *testing.T, content string, startMS, endMS int) (string, bool) {
+	t.Helper()
+	span := model.Span{Kind: "time", StartMS: startMS, EndMS: endMS}
+	selection, err := selectTimeRange(strings.NewReader(content), span, testSelectBudget)
+	if err != nil {
+		if errors.Is(err, model.ErrDocTypeUnsupported) {
+			return "", false
+		}
+		t.Fatalf("selectTimeRange returned err: %v", err)
+	}
+	return selection.text, true
+}
 
 // TestSlicePage_NoPhantomTrailingPage pins #427: a form-feed-terminated document
 // ("p1\fp2\f") must expose exactly its real pages. The trailing empty segment
-// from strings.Split must not present a phantom page beyond the last, so an
-// out-of-range page index errors (ok=false) rather than returning "" with ok=true.
+// must not present a phantom page beyond the last, so an out-of-range page index
+// errors (ok=false) rather than returning "" with ok=true.
 func TestSlicePage_NoPhantomTrailingPage(t *testing.T) {
 	content := "page one\fpage two\f" // 2 real pages, terminating form-feed
 
-	if got, ok := slicePage(content, 1); !ok || got != "page one" {
+	if got, ok := selectPageString(t, content, 1); !ok || got != "page one" {
 		t.Fatalf("page 1: got (%q,%v), want (%q,true)", got, ok, "page one")
 	}
-	if got, ok := slicePage(content, 2); !ok || got != "page two" {
+	if got, ok := selectPageString(t, content, 2); !ok || got != "page two" {
 		t.Fatalf("page 2: got (%q,%v), want (%q,true)", got, ok, "page two")
 	}
 	// Page 3 is past the last real page: must be out-of-range, not a phantom.
-	if got, ok := slicePage(content, 3); ok || got != "" {
+	if got, ok := selectPageString(t, content, 3); ok || got != "" {
 		t.Fatalf("phantom page 3: got (%q,%v), want (\"\",false)", got, ok)
 	}
 }
 
 // TestSlicePage_SinglePageTrailingFormFeed pins the #427 review fix: a single-page
 // document ending in a form-feed must return the clean text, not re-attach the
-// stripped \f (the trailing-empty drop leaves one segment, so page 1 returns
-// parts[0], not the raw content).
+// stripped \f (the trailing-empty segment leaves one page, so page 1 returns the
+// first segment, not the raw content).
 func TestSlicePage_SinglePageTrailingFormFeed(t *testing.T) {
-	if got, ok := slicePage("only page\f", 1); !ok || got != "only page" {
+	if got, ok := selectPageString(t, "only page\f", 1); !ok || got != "only page" {
 		t.Fatalf("single page w/ trailing form-feed: got (%q,%v), want (%q,true)", got, ok, "only page")
 	}
 	// A plain single-page doc (no form-feed) is unchanged.
-	if got, ok := slicePage("just text", 1); !ok || got != "just text" {
+	if got, ok := selectPageString(t, "just text", 1); !ok || got != "just text" {
 		t.Fatalf("plain single page: got (%q,%v), want (%q,true)", got, ok, "just text")
 	}
 	// Page 2 of a single-page doc is out of range.
-	if got, ok := slicePage("only page\f", 2); ok || got != "" {
+	if got, ok := selectPageString(t, "only page\f", 2); ok || got != "" {
 		t.Fatalf("single-page page 2: got (%q,%v), want (\"\",false)", got, ok)
+	}
+}
+
+// TestSlicePage_MultiPageTrimsNewlines pins the trimming rule a multi-page
+// document carries: page text loses its leading and trailing newlines, while a
+// single-page document keeps them. The streaming selector must decide this
+// without buffering the whole document, so it peeks one byte past the first
+// form feed.
+func TestSlicePage_MultiPageTrimsNewlines(t *testing.T) {
+	if got, ok := selectPageString(t, "\npage one\n\fpage two", 1); !ok || got != "page one" {
+		t.Fatalf("multi-page page 1: got (%q,%v), want (%q,true)", got, ok, "page one")
+	}
+	if got, ok := selectPageString(t, "\nonly page\n", 1); !ok || got != "\nonly page\n" {
+		t.Fatalf("single page: got (%q,%v), want (%q,true)", got, ok, "\nonly page\n")
+	}
+	// An empty middle page is a real page, not a phantom.
+	if got, ok := selectPageString(t, "a\f\fb", 2); !ok || got != "" {
+		t.Fatalf("empty middle page: got (%q,%v), want (\"\",true)", got, ok)
 	}
 }
 
@@ -65,13 +121,13 @@ func TestTimePrefixRe_MinutesOver99(t *testing.T) {
 		}
 	}
 
-	// End-to-end through sliceTime: a >=100-minute cue must be selectable.
+	// End-to-end through the time selector: a >=100-minute cue must be selectable.
 	transcript := "[00:10] intro\n[100:30] the hundred-minute mark\n[101:00] just after"
-	out, ok := sliceTime(transcript, 100*60*1000, 101*60*1000)
+	out, ok := selectTimeString(t, transcript, 100*60*1000, 101*60*1000)
 	if !ok {
-		t.Fatalf("sliceTime returned ok=false; expected timestamps to be found")
+		t.Fatalf("time selection returned ok=false; expected timestamps to be found")
 	}
 	if !strings.Contains(out, "[100:30] the hundred-minute mark") {
-		t.Fatalf("sliceTime output %q missing the >=100-minute cue", out)
+		t.Fatalf("time selection output %q missing the >=100-minute cue", out)
 	}
 }

--- a/tests/retrieval/open_file_bounded_690_test.go
+++ b/tests/retrieval/open_file_bounded_690_test.go
@@ -1,0 +1,439 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/dirstral/dir2mcp/internal/corpusfs"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
+)
+
+// Issue #690: open_file publishes a bounded answer (max_chars, clamped to
+// 50000 runes) but used to read the COMPLETE local file or S3 object into
+// memory, convert it to a string, scan it, slice it, and only then truncate. A
+// source that grew after indexing, or a large remote text file, therefore cost
+// unbounded memory and bandwidth for a strictly bounded answer.
+//
+// The tests below fail against the buffered implementation: the capped readers
+// return an error as soon as the read runs past the budget, and the allocation
+// probe sees the whole-source copies.
+
+// errReadPastCap reports that a reader was asked for more bytes than the test
+// allows. It stands in for the memory and bandwidth an unbounded read spends.
+var errReadPastCap = errors.New("read ran past the cap the test allows")
+
+// cappedReader serves a document and fails once a caller has read more than cap
+// bytes from it.
+type cappedReader struct {
+	data []byte
+	off  int
+	cap  int
+	read *int
+}
+
+func (c *cappedReader) Read(p []byte) (int, error) {
+	if *c.read >= c.cap {
+		return 0, fmt.Errorf("%w: %d bytes", errReadPastCap, *c.read)
+	}
+	if c.off >= len(c.data) {
+		return 0, io.EOF
+	}
+	n := copy(p, c.data[c.off:])
+	c.off += n
+	*c.read += n
+	return n, nil
+}
+
+func (c *cappedReader) Seek(offset int64, whence int) (int64, error) {
+	switch whence {
+	case io.SeekStart:
+		c.off = int(offset)
+	case io.SeekCurrent:
+		c.off += int(offset)
+	case io.SeekEnd:
+		c.off = len(c.data) + int(offset)
+	}
+	return int64(c.off), nil
+}
+
+func (c *cappedReader) Close() error { return nil }
+
+// cappedCorpusFS is an object-store stand-in whose objects are served through a
+// capped reader. It has no local file, so it exercises the same remote read path
+// that S3 corpora use (#432).
+type cappedCorpusFS struct {
+	objects   map[string][]byte
+	cap       int
+	bytesRead int
+}
+
+func (f *cappedCorpusFS) Open(ctx context.Context, relPath string) (io.ReadSeekCloser, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	data, ok := f.objects[relPath]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	return &cappedReader{data: data, cap: f.cap, read: &f.bytesRead}, nil
+}
+
+func (f *cappedCorpusFS) Walk(context.Context, string, corpusfs.Options) ([]corpusfs.DiscoveredFile, error) {
+	return nil, errors.New("cappedCorpusFS: Walk not implemented")
+}
+
+func (f *cappedCorpusFS) Localize(context.Context, string) (string, func(), error) {
+	return "", func() {}, errors.New("cappedCorpusFS: Localize not implemented")
+}
+
+// cancellingCorpusFS cancels the request context after the first read, then
+// keeps serving bytes. A read that honours the context stops at once; a read
+// that ignores it returns the whole object.
+type cancellingCorpusFS struct {
+	data   []byte
+	cancel context.CancelFunc
+}
+
+type cancellingReader struct {
+	data   []byte
+	off    int
+	cancel context.CancelFunc
+}
+
+func (c *cancellingReader) Read(p []byte) (int, error) {
+	if c.off >= len(c.data) {
+		return 0, io.EOF
+	}
+	n := copy(p, c.data[c.off:])
+	c.off += n
+	c.cancel()
+	return n, nil
+}
+
+func (c *cancellingReader) Seek(int64, int) (int64, error) { return int64(c.off), nil }
+func (c *cancellingReader) Close() error                   { return nil }
+
+func (f *cancellingCorpusFS) Open(ctx context.Context, _ string) (io.ReadSeekCloser, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return &cancellingReader{data: f.data, cancel: f.cancel}, nil
+}
+
+func (f *cancellingCorpusFS) Walk(context.Context, string, corpusfs.Options) ([]corpusfs.DiscoveredFile, error) {
+	return nil, errors.New("cancellingCorpusFS: Walk not implemented")
+}
+
+func (f *cancellingCorpusFS) Localize(context.Context, string) (string, func(), error) {
+	return "", func() {}, errors.New("cancellingCorpusFS: Localize not implemented")
+}
+
+// newBoundedService returns a retrieval service rooted at root with no secret
+// pattern configured.
+func newBoundedService(root string) *retrieval.Service {
+	svc := retrieval.NewService(nil, nil, nil, nil)
+	svc.SetRootDir(root)
+	svc.SetStateDir(filepath.Join(root, ".dir2mcp"))
+	return svc
+}
+
+// repeatToSize returns unit repeated until it holds at least size bytes.
+func repeatToSize(unit string, size int) string {
+	return strings.Repeat(unit, size/len(unit)+1)
+}
+
+// allocatedBytes reports how many bytes fn allocated in total. Cumulative
+// allocation, not live heap, is the honest probe here: a streaming read touches
+// every byte of the source but keeps only a window, so its total stays flat
+// while a buffered read allocates the source several times over.
+func allocatedBytes(fn func()) uint64 {
+	var before, after runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+	fn()
+	runtime.ReadMemStats(&after)
+	return after.TotalAlloc - before.TotalAlloc
+}
+
+// TestOpenFile_LocalSourceGrewAfterIndexing_ReadStaysBounded covers the exact
+// condition #690 describes: the source is far larger than the answer, because it
+// grew after it was indexed. open_file must answer from a bounded read.
+//
+// The probe is allocation. The buffered path allocated the file as bytes, again
+// as a string, and again as a rune slice inside the truncation, so a 24 MiB file
+// cost about 150 MiB. The streaming path reads one read budget: 200004 bytes at
+// the 50000-rune cap.
+func TestOpenFile_LocalSourceGrewAfterIndexing_ReadStaysBounded(t *testing.T) {
+	root := t.TempDir()
+	relPath := "notes/grown.txt"
+	abs := filepath.Join(root, filepath.FromSlash(relPath))
+	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// The document as indexed: small.
+	if err := os.WriteFile(abs, []byte("short at index time\n"), 0o644); err != nil {
+		t.Fatalf("write small file: %v", err)
+	}
+	// The document as it is now: 24 MiB, with the head still readable.
+	const grownBytes = 24 << 20
+	head := "alpha bravo charlie delta echo foxtrot golf hotel india juliet\n"
+	if err := os.WriteFile(abs, []byte(repeatToSize(head, grownBytes)), 0o644); err != nil {
+		t.Fatalf("grow file: %v", err)
+	}
+
+	svc := newBoundedService(root)
+
+	var out string
+	var truncated bool
+	var err error
+	allocated := allocatedBytes(func() {
+		out, truncated, err = svc.OpenFileWithMeta(context.Background(), relPath, model.Span{}, 50000)
+	})
+	if err != nil {
+		t.Fatalf("OpenFileWithMeta on a grown source returned err: %v", err)
+	}
+	if got := utf8.RuneCountInString(out); got != 50000 {
+		t.Fatalf("answer holds %d runes, want the published cap of 50000", got)
+	}
+	if !truncated {
+		t.Fatalf("expected truncated=true for a 24 MiB source answered with 50000 runes")
+	}
+	if !strings.HasPrefix(out, "alpha bravo charlie") {
+		t.Fatalf("answer does not start with the document head: %q", out[:40])
+	}
+	// One read budget is 200004 bytes. 8 MiB leaves generous room for the
+	// runtime's own allocations while still failing the buffered path, which
+	// allocated about 150 MiB for this file.
+	const allocCap = 8 << 20
+	if allocated > allocCap {
+		t.Fatalf("open_file allocated %d bytes for a %d-byte source; want at most %d", allocated, grownBytes, allocCap)
+	}
+}
+
+// TestOpenFile_CorpusFSLargeObject_StopsAfterTheWindow verifies that a large
+// remote text object is not downloaded in full for a bounded answer. The capped
+// reader fails the request once the read runs past 1 MiB.
+func TestOpenFile_CorpusFSLargeObject_StopsAfterTheWindow(t *testing.T) {
+	root := t.TempDir()
+	const objectBytes = 16 << 20
+	body := repeatToSize("remote object line with enough text to be interesting\n", objectBytes)
+	fs := &cappedCorpusFS{objects: map[string][]byte{"docs/big.md": []byte(body)}, cap: 1 << 20}
+
+	svc := newBoundedService(root)
+	svc.SetCorpusFS(fs)
+
+	out, truncated, err := svc.OpenFileWithMeta(context.Background(), "docs/big.md", model.Span{}, 20000)
+	if err != nil {
+		t.Fatalf("OpenFileWithMeta over CorpusFS returned err: %v", err)
+	}
+	if got := utf8.RuneCountInString(out); got != 20000 {
+		t.Fatalf("answer holds %d runes, want 20000", got)
+	}
+	if !truncated {
+		t.Fatalf("expected truncated=true for a 16 MiB object answered with 20000 runes")
+	}
+	if fs.bytesRead > 1<<20 {
+		t.Fatalf("read %d bytes of a %d-byte object for a 20000-rune answer", fs.bytesRead, objectBytes)
+	}
+}
+
+// TestOpenFile_LateLineRange_DoesNotBufferTheTail covers the line addressing
+// case. Line 9000 is not the first 50000 characters: the selector must stream
+// past the lines before it and keep none of them, and it must stop once the
+// requested range is complete instead of buffering the rest of the document.
+func TestOpenFile_LateLineRange_DoesNotBufferTheTail(t *testing.T) {
+	root := t.TempDir()
+	var b strings.Builder
+	for i := 1; i <= 9002; i++ {
+		fmt.Fprintf(&b, "line %d: the quick brown fox jumps over the lazy dog\n", i)
+	}
+	prefixBytes := b.Len()
+	// A large tail after the requested range. A bounded read never touches it.
+	b.WriteString(repeatToSize("tail padding that must never be buffered\n", 16<<20))
+	fs := &cappedCorpusFS{objects: map[string][]byte{"docs/lines.txt": []byte(b.String())}, cap: prefixBytes + (1 << 20)}
+
+	svc := newBoundedService(root)
+	svc.SetCorpusFS(fs)
+
+	span := model.Span{Kind: "lines", StartLine: 9000, EndLine: 9002}
+	out, _, err := svc.OpenFileWithMeta(context.Background(), "docs/lines.txt", span, 20000)
+	if err != nil {
+		t.Fatalf("OpenFileWithMeta for a late line range returned err: %v", err)
+	}
+	want := "line 9000: the quick brown fox jumps over the lazy dog\n" +
+		"line 9001: the quick brown fox jumps over the lazy dog\n" +
+		"line 9002: the quick brown fox jumps over the lazy dog"
+	if out != want {
+		t.Fatalf("late line range returned %q, want %q", out, want)
+	}
+}
+
+// TestOpenFile_MultibyteRunes_AnswerIsWholeRunes checks the byte budget against
+// the character contract. max_chars counts runes, and a rune takes up to four
+// bytes, so the read budget is four bytes per requested character plus slack. A
+// budget that reused the max_chars number would return a short answer, and a
+// budget that cut a rune would return a replacement character.
+func TestOpenFile_MultibyteRunes_AnswerIsWholeRunes(t *testing.T) {
+	root := t.TempDir()
+	relPath := "docs/multibyte.txt"
+	abs := filepath.Join(root, filepath.FromSlash(relPath))
+	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Four-byte runes are the worst case for the byte budget.
+	body := strings.Repeat("𝔘𝔫𝔦𝔠𝔬𝔡𝔢", 20000)
+	if err := os.WriteFile(abs, []byte(body), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	svc := newBoundedService(root)
+	out, truncated, err := svc.OpenFileWithMeta(context.Background(), relPath, model.Span{}, 1000)
+	if err != nil {
+		t.Fatalf("OpenFileWithMeta on multibyte text returned err: %v", err)
+	}
+	if got := utf8.RuneCountInString(out); got != 1000 {
+		t.Fatalf("answer holds %d runes, want 1000", got)
+	}
+	if !truncated {
+		t.Fatalf("expected truncated=true")
+	}
+	if !utf8.ValidString(out) || strings.ContainsRune(out, utf8.RuneError) {
+		t.Fatalf("answer holds a cut rune: %q", out[:20])
+	}
+	if out != string([]rune(body)[:1000]) {
+		t.Fatalf("answer is not the first 1000 runes of the document")
+	}
+}
+
+// writeSecretDoc writes a document at relPath under root and returns a service
+// with one secret pattern configured.
+func writeSecretDoc(t *testing.T, root, relPath, body string) *retrieval.Service {
+	t.Helper()
+	abs := filepath.Join(root, filepath.FromSlash(relPath))
+	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(abs, []byte(body), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	svc := newBoundedService(root)
+	if err := svc.SetSecretPatterns([]string{`AKIA[0-9A-Z]{16}`}); err != nil {
+		t.Fatalf("SetSecretPatterns: %v", err)
+	}
+	return svc
+}
+
+// TestOpenFile_SecretJustPastTheWindow_StillRefuses pins the margin the scanner
+// reads past the answer. A secret that starts inside the window, or just after
+// it, must refuse the request even though the answer itself looks harmless.
+func TestOpenFile_SecretJustPastTheWindow_StillRefuses(t *testing.T) {
+	root := t.TempDir()
+	relPath := "docs/margin.txt"
+	// 20000 runes of answer, then the secret a few bytes later.
+	body := strings.Repeat("a", 20050) + "\nAKIAIOSFODNN7EXAMPLE\n" + strings.Repeat("b", 1<<20)
+	svc := writeSecretDoc(t, root, relPath, body)
+
+	if _, err := svc.OpenFile(context.Background(), relPath, model.Span{}, 20000); !errors.Is(err, model.ErrForbidden) {
+		t.Fatalf("expected ErrForbidden for a secret just past the window, got %v", err)
+	}
+}
+
+// TestOpenFile_SecretBeforeTheWindow_AlwaysRefuses pins the property that makes
+// the bounded scan sound: the read always starts at the first byte, so a caller
+// cannot ask for a late window to step over a secret and reach the text behind
+// it. It also keeps the tool from serving a document that ingest withholds,
+// because ingest decides on the head of the file.
+func TestOpenFile_SecretBeforeTheWindow_AlwaysRefuses(t *testing.T) {
+	root := t.TempDir()
+	relPath := "docs/early-secret.txt"
+	var b strings.Builder
+	b.WriteString("AKIAIOSFODNN7EXAMPLE\n")
+	for i := 2; i <= 9002; i++ {
+		fmt.Fprintf(&b, "line %d: ordinary text\n", i)
+	}
+	svc := writeSecretDoc(t, root, relPath, b.String())
+
+	span := model.Span{Kind: "lines", StartLine: 9000, EndLine: 9002}
+	if _, err := svc.OpenFile(context.Background(), relPath, span, 20000); !errors.Is(err, model.ErrForbidden) {
+		t.Fatalf("expected ErrForbidden for a late window behind a secret, got %v", err)
+	}
+}
+
+// TestOpenFile_SecretFarPastTheWindow_IsNotRead documents the one semantic the
+// bounded read changes on purpose. The buffered path read the whole source, so
+// a secret 8 MiB down refused the head of the document as well. The bounded
+// read stops after the answer and its margin, so the head is served. The bytes
+// it returns were all scanned, and ingest itself decides on a 64 KiB sample, so
+// this document was indexed and searchable already.
+func TestOpenFile_SecretFarPastTheWindow_IsNotRead(t *testing.T) {
+	root := t.TempDir()
+	relPath := "docs/late-secret.txt"
+	head := repeatToSize("harmless prose that says nothing at all\n", 8<<20)
+	svc := writeSecretDoc(t, root, relPath, head+"\nAKIAIOSFODNN7EXAMPLE\n")
+
+	var out string
+	var err error
+	allocated := allocatedBytes(func() {
+		out, err = svc.OpenFile(context.Background(), relPath, model.Span{}, 20000)
+	})
+	if err != nil {
+		t.Fatalf("OpenFile returned err: %v", err)
+	}
+	if !strings.HasPrefix(out, "harmless prose") {
+		t.Fatalf("expected the scanned head of the document, got %q", out[:40])
+	}
+	if strings.Contains(out, "AKIA") {
+		t.Fatalf("the answer holds secret material")
+	}
+	const allocCap = 8 << 20
+	if allocated > allocCap {
+		t.Fatalf("open_file allocated %d bytes for an 8 MiB source; want at most %d", allocated, allocCap)
+	}
+}
+
+// TestOpenFile_SecretAcrossAChunkBoundary_StillRefuses checks the overlap the
+// streaming scanner carries between chunks. A secret that straddles two reads
+// must still match.
+func TestOpenFile_SecretAcrossAChunkBoundary_StillRefuses(t *testing.T) {
+	root := t.TempDir()
+	relPath := "docs/boundary.txt"
+	const secret = "AKIAIOSFODNN7EXAMPLE"
+	// Place the secret so that it spans several plausible chunk edges. Every
+	// offset stays inside the answer plus its scan margin.
+	for _, offset := range []int{(64 << 10) - 7, (64 << 10) - 1, 100 << 10} {
+		body := strings.Repeat("x", offset) + secret + strings.Repeat("y", 4096)
+		svc := writeSecretDoc(t, root, relPath, body)
+		if _, err := svc.OpenFile(context.Background(), relPath, model.Span{}, 20000); !errors.Is(err, model.ErrForbidden) {
+			t.Fatalf("secret at offset %d: expected ErrForbidden, got %v", offset, err)
+		}
+	}
+}
+
+// TestOpenFile_ContextCancelled_StopsTheRead verifies that a cancelled request
+// interrupts a long read instead of running it to the end of the source.
+func TestOpenFile_ContextCancelled_StopsTheRead(t *testing.T) {
+	root := t.TempDir()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	fs := &cancellingCorpusFS{data: []byte(repeatToSize("cancel me\n", 8<<20)), cancel: cancel}
+	svc := newBoundedService(root)
+	svc.SetCorpusFS(fs)
+	if err := svc.SetSecretPatterns([]string{`AKIA[0-9A-Z]{16}`}); err != nil {
+		t.Fatalf("SetSecretPatterns: %v", err)
+	}
+
+	_, err := svc.OpenFile(ctx, "docs/slow.md", model.Span{}, 50000)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled once the request is cancelled, got %v", err)
+	}
+}


### PR DESCRIPTION
Closes #690.

## The defect

`dir2mcp_open_file` publishes a bounded answer: `max_chars` is clamped to 50,000 runes. The raw-source path read the **complete** local file or S3 object into memory, converted the full byte slice to a string, scanned that string for secrets, sliced it, and only then truncated. A source that grew after indexing, or a large remote text file, cost unbounded memory and bandwidth for a strictly bounded answer.

Re-verified against current `main` (`2c1de24`): `readSourceBytes` still did `io.ReadAll(rc)` for `CorpusFS` and `readFileBounded(resolvedAbs, 0)` for local, and `readFileBounded` still treated `maxBytes <= 0` as an unbounded `io.ReadAll`. `truncateRunesWithFlag` then built a `[]rune` of the whole string, so a 24 MiB file cost about 180 MB of allocation (measured, see tests).

The fix follows PR #803 (`internal/protocol/response_limit.go`): read through `io.LimitReader`, keep one unit past the cap so an overflow is visible, and give the caller a clear result instead of a confusing failure. `internal/ingest/recognize.go` (`recognizeMaxResponseBytes`) is the older precedent.

## The cap is not `max_chars`

A caller asks for characters; the bytes that carry them depend on the encoding. One UTF-8 rune takes up to `utf8.UTFMax` (4) bytes, so the read budget is `(max_chars + 1) * 4` bytes:

* `max_chars * 4` always holds at least `max_chars` runes, whatever the text, so the answer is never short. Reusing the `max_chars` number would return a quarter of the requested characters for CJK or emoji text.
* the extra rune of slack makes an over-length source visible: a selector that fills the budget holds more than `max_chars` runes, so the rune truncation both cuts the answer to the published size and reports `truncated=true`.
* the slack also keeps a rune that splits at the budget edge out of the answer, because that partial rune always sits past position `max_chars`.

At the 50,000 clamp the budget is 200,004 bytes.

## Addressing

Each span kind gets its own streaming selector. None of them retains more than one budget.

| span | how it is served |
| --- | --- |
| no span | read one budget and stop. A 5 GB file costs the same as a 5 KB one. |
| `lines` | stream to the first requested line and keep **none** of the prefix; retain the requested lines up to the budget. "Line 9000 of a large file" is a seek problem, not a buffering problem: the prefix passes through a fixed 64 KiB working buffer and is dropped. One very long line is cut at the budget, not buffered, so a single-line document cannot exhaust memory either. |
| `page` | discard each earlier form-feed page as it passes. The #427 page-count rules are preserved: a trailing form feed terminates the last page rather than opening a phantom one, and a multi-page document still has its page text trimmed. Deciding the trim for page 1 needs to know whether a second page exists, which one peeked byte answers. |
| `time` | keep only the timestamped lines inside the window, up to the budget, and stop reading once the budget is full. |

## The secret policy

This is the part worth arguing. `secret_patterns` is non-empty by default, so "scan the whole source" and "do not read the whole source" cannot both hold.

**New rule: every byte the request reads is scanned.** That is the answer window, everything before it (the read always starts at byte 0; there is no seek), and a fixed 64 KiB margin past it. The scan runs over the stream with a 4 KiB rolling overlap and keeps nothing, so it costs no memory. Three properties follow:

1. every returned byte was scanned;
2. no answer can begin behind an unscanned region, so a caller cannot ask for a late window to step over a secret and reach the text behind it (a secret anywhere before the window still refuses the request);
3. the scan always covers at least the head bytes that ingest samples, so a document that ingest withholds can never be served by the tool.

Property 3 is what SPEC 15.4 asks for: "tool-level bypass of ingestion filters is impossible". The margin matches `internal/ingest.secretScanSampleBytes` (64 KiB) for exactly that reason: **ingest itself decides on a 64 KiB head sample** (`contentSample`), so a document whose only secret sits past 64 KiB is already indexed, and its text is already reachable through `search` and `ask`.

**What changes:** a secret far past the answer no longer refuses the head of the document. Reproducing the old behavior would mean transferring the whole object on every request, which is the cost this issue is about, and it would still be an illusion of safety next to ingest's own 64 KiB sample. The relaxation only exposes bytes that were scanned and found clean. `tests/retrieval/open_file_bounded_690_test.go` pins the new semantics in both directions, including the deliberate change.

Two more scanner notes:

* the 4 KiB overlap is far longer than the shortest match of any shipped or plausible operator pattern, so a secret on a chunk boundary is still matched (test included at three boundary offsets);
* a pattern anchored with `^` or `$` sees a chunk boundary as a text boundary. The drift is fail-closed: it can only refuse content a whole-string match would have served, never the reverse. Documented at the type.

## Contract

Unchanged. Same tool schema, same span semantics, same error codes (`FORBIDDEN`, `DOC_TYPE_UNSUPPORTED`), same precedence between them (a secret still outranks an unsatisfiable span). A caller asking for a legitimate window still gets that window. No `dirstral-spec` submodule change: SPEC 15.4 speaks of "extracted content", which this satisfies.

Context cancellation now interrupts a long local or remote read, which it did not before.

## Tests

New: `tests/retrieval/open_file_bounded_690_test.go` (service level) and `internal/retrieval/open_file_stream_690_test.go` (selector level).

Verified failing against `main` with the copy-aside method (`git stash` is banned in this repo: `refs/stash` is shared across worktrees). Files were copied to a scratch directory, `git checkout origin/main -- internal/retrieval/service.go internal/retrieval/slice_regex_427_test.go`, the new file removed, tests run, then restored. Results against `main`:

* `TestOpenFile_LocalSourceGrewAfterIndexing_ReadStaysBounded` FAIL: "open_file allocated 180323376 bytes for a 25165824-byte source; want at most 8388608";
* `TestOpenFile_CorpusFSLargeObject_StopsAfterTheWindow` FAIL: read ran past the 1 MiB cap on a 16 MiB object;
* `TestOpenFile_LateLineRange_DoesNotBufferTheTail` FAIL: read ran past the cap into the tail;
* `TestOpenFile_ContextCancelled_StopsTheRead` FAIL: no error, the whole object was read;
* `TestOpenFile_SecretFarPastTheWindow_IsNotRead` FAIL: `main` refuses the document (the deliberate semantic change);
* the preservation tests (multibyte runes, secret before the window, secret across a chunk boundary) PASS on `main`, as they must.

The selector suite compares the streaming selectors against the buffered originals over 800 generated documents. That comparison caught a real bug during development: an empty first line lost its separator, because the builder tested its own length instead of tracking that a line had been written.

`internal/retrieval/slice_regex_427_test.go` keeps its #427 coverage and now drives the streaming page and time selectors, plus one new case for the multi-page trim rule.

## Not in scope

`openFileFromOCRCache` still reads its whole cache file with `os.ReadFile`. That is our own generated state file rather than a source that can grow under us, and #690 is specific to the raw-source path, so it is left alone. Worth a small follow-up.

## Checklist

- [x] `coderabbit review --committed --base main`: no findings
- [x] `make check` passes locally (including `gocyclo -over 15`; helpers were extracted rather than the gate worked around)
- [x] new behavior has test coverage that fails against `main`
- [x] `README.md` and `docs/` remain truthful (neither documents the whole-source scan)
- [x] no unrelated files changed, submodule pointer untouched
