### PR TITLE
fix(mcp): list the objects of an S3 corpus in list_files (#684)

### DIFF
--- a/internal/mcp/list_files_resolve_test.go
+++ b/internal/mcp/list_files_resolve_test.go
@@ -102,12 +102,73 @@ func TestIsResolvableSourceWithRoot(t *testing.T) {
 			doc:  model.Document{RelPath: filepath.Join(rootAbs, realName), SourceType: "filesystem"},
 			want: false,
 		},
+		{
+			name: "padded absolute path rejected",
+			doc:  model.Document{RelPath: " /etc/passwd", SourceType: "filesystem"},
+			want: false,
+		},
+		{
+			name: "archive member with a malformed path rejected",
+			doc:  model.Document{RelPath: "../escape.zip/inner.txt", SourceType: "archive_member"},
+			want: false,
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := isResolvableSourceWithRoot(tc.doc, rootAbs, rootReal); got != tc.want {
 				t.Fatalf("isResolvableSourceWithRoot(%+v)=%v want=%v", tc.doc, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIsListableRemoteSource covers the object-store gate of issue #684. An S3
+// corpus has no local file at RootDir/rel_path, so the gate must pass a
+// well-formed rel_path without touching disk, and must still refuse a path that
+// can never round-trip through open_file.
+func TestIsListableRemoteSource(t *testing.T) {
+	cases := []struct {
+		name string
+		doc  model.Document
+		want bool
+	}{
+		{
+			name: "remote object with no local file is listable",
+			doc:  model.Document{RelPath: "docs/a.md", SourceType: "filesystem"},
+			want: true,
+		},
+		{
+			name: "archive member is listable",
+			doc:  model.Document{RelPath: "bundle.zip/inner/note.md", SourceType: "archive_member"},
+			want: true,
+		},
+		{
+			name: "traversal rejected",
+			doc:  model.Document{RelPath: "../escape.md", SourceType: "filesystem"},
+			want: false,
+		},
+		{
+			name: "absolute path rejected",
+			doc:  model.Document{RelPath: "/etc/passwd", SourceType: "filesystem"},
+			want: false,
+		},
+		{
+			name: "padded absolute path rejected",
+			doc:  model.Document{RelPath: " /etc/passwd", SourceType: "filesystem"},
+			want: false,
+		},
+		{
+			name: "empty path rejected",
+			doc:  model.Document{RelPath: "  ", SourceType: "filesystem"},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isListableRemoteSource(tc.doc); got != tc.want {
+				t.Fatalf("isListableRemoteSource(%+v)=%v want=%v", tc.doc, got, tc.want)
 			}
 		})
 	}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -839,12 +839,12 @@ func (s *Server) canResolveRoot() bool {
 // candidate target are compared in their symlink-resolved form so equivalent
 // symlinked paths match.
 func isResolvableSourceWithRoot(doc model.Document, rootAbs, rootReal string) bool {
-	if isArchiveMemberSource(doc) {
-		return true
-	}
 	normalized, ok := normalizedListRelPath(doc.RelPath)
 	if !ok {
 		return false
+	}
+	if isArchiveMemberSource(doc) {
+		return true
 	}
 	absPath := filepath.Join(rootAbs, filepath.FromSlash(normalized))
 	targetReal, err := filepath.EvalSymlinks(absPath)
@@ -875,20 +875,18 @@ func isResolvableSourceWithRoot(doc model.Document, rootAbs, rootReal string) bo
 // (issue #684). No local file exists at RootDir/rel_path for such a corpus, so
 // the local existence check of isResolvableSourceWithRoot cannot say anything
 // about a remote object and must not run. What survives is the part that needs
-// no filesystem: archive members stay listable, and an affirmatively malformed
-// rel_path (traversal or absolute) stays excluded, because it can never
-// round-trip through open_file on any backend.
+// no filesystem: an affirmatively malformed rel_path (traversal or absolute)
+// stays excluded, because it can never round-trip through open_file on any
+// backend. Archive members keep passing, exactly as they do on a local corpus,
+// because their virtual path is a well-formed rel_path.
 func isListableRemoteSource(doc model.Document) bool {
-	if isArchiveMemberSource(doc) {
-		return true
-	}
 	_, ok := normalizedListRelPath(doc.RelPath)
 	return ok
 }
 
 // isArchiveMemberSource reports whether doc is a member of an archive. Such a
-// path is virtual (the backing file is the archive itself), so no per-document
-// source resolution applies to it.
+// path is virtual (the backing file is the archive itself), so the local
+// existence check does not apply to it.
 func isArchiveMemberSource(doc model.Document) bool {
 	return strings.EqualFold(strings.TrimSpace(doc.SourceType), "archive_member")
 }
@@ -896,9 +894,15 @@ func isArchiveMemberSource(doc model.Document) bool {
 // normalizedListRelPath cleans relPath into slash form and reports whether it is
 // a well-formed corpus-relative path. A traversal or absolute path is rejected:
 // it can never round-trip through open_file, so list_files must not emit it.
+//
+// The absolute test runs on the TRIMMED path, the same string every other test
+// here runs on. A padded value such as " /etc/passwd" passes the store's own
+// rel_path validation, so the untrimmed test let it through as a relative path
+// and the listing then advertised an absolute-looking path.
 func normalizedListRelPath(relPath string) (string, bool) {
-	normalized := filepath.ToSlash(filepath.Clean(strings.TrimSpace(relPath)))
-	if normalized == "." || normalized == ".." || strings.HasPrefix(normalized, "../") || filepath.IsAbs(relPath) {
+	trimmed := strings.TrimSpace(relPath)
+	normalized := filepath.ToSlash(filepath.Clean(trimmed))
+	if normalized == "." || normalized == ".." || strings.HasPrefix(normalized, "../") || filepath.IsAbs(trimmed) {
 		return "", false
 	}
 	return normalized, true

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -635,12 +635,15 @@ type visibleFilesLister interface {
 //     listing. This is a pure function of rel_path, so the store evaluates it in
 //     SQL (SQLiteStore.ListVisibleFiles) and the page, the COUNT and the glob
 //     scan all agree on it for free.
-//   - filesystem-source documents whose rel_path no longer resolves to a real
+//   - on a LOCAL corpus, documents whose rel_path no longer resolves to a real
 //     file under the configured root are dropped. Without this, stale rows left
 //     behind by older buggy ingest paths or manual edits would surface here and
 //     then 404 on the round-trip through open_file (issue #176). This one needs
 //     the filesystem, so it can only run in Go — but it now runs over the rows
-//     of the RETURNED PAGE, not over the corpus.
+//     of the RETURNED PAGE, not over the corpus. On an object-store corpus the
+//     backing object is not on the local filesystem at all, so only the
+//     path-shape part of the check applies (issue #684, see
+//     listFilesSourceGate).
 //
 // Before #694 the handler pulled the entire matching corpus in 500-row store
 // pages on every call and stat'ed every row, because it wanted a `total` that
@@ -679,23 +682,56 @@ func (s *Server) listFilesFiltered(ctx context.Context, pathPrefix, glob string,
 }
 
 // dropUnresolvableSources applies the #176 round-trip gate to the rows of a
-// single page. The root is resolved once for the page: the per-document gate
-// would otherwise re-run filepath.Abs + EvalSymlinks(root) per row. When the
-// configured root does not resolve at all the gate is skipped entirely, so a
-// misconfigured deployment still returns what the store has rather than an
-// empty list.
+// single page. The gate is built once for the page: the per-document check
+// would otherwise re-run filepath.Abs + EvalSymlinks(root) per row. A nil gate
+// means "keep everything", so a misconfigured deployment still returns what the
+// store has rather than an empty list.
 func (s *Server) dropUnresolvableSources(docs []model.Document) []model.Document {
-	rootAbs, rootReal, ok := s.resolveRoot()
-	if !ok {
+	gate := s.listFilesSourceGate()
+	if gate == nil {
 		return docs
 	}
 	kept := make([]model.Document, 0, len(docs))
 	for _, doc := range docs {
-		if isResolvableSourceWithRoot(doc, rootAbs, rootReal) {
+		if gate(doc) {
 			kept = append(kept, doc)
 		}
 	}
 	return kept
+}
+
+// listFilesSourceGate builds the per-document predicate that list_files applies
+// to the rows of a page, or nil when no gate applies.
+//
+// The gate depends on where the corpus lives (issue #684). A local corpus keeps
+// the #176 filesystem round-trip check: a row whose rel_path is gone under the
+// configured root must not be listed, because open_file would 404 on it. An
+// object-store corpus has NO local file at RootDir/rel_path at all (S3FS.Walk
+// ignores RootDir and reports no local path, the same asymmetry that broke the
+// on-demand media paths in #759), so that check condemns every remote document
+// and the tool reports an empty inventory for a corpus that indexes and
+// searches correctly.
+//
+// The source of truth is the live cfg.Source.Kind, not the persisted
+// source_type: the store normalizes source_type to filesystem or archive_member
+// only, and widening that vocabulary is a spec decision (dirstral-spec #63)
+// that has not landed. Gating on the running configuration needs no schema
+// change and no contract change.
+//
+// The remote gate is NOT "no gate": malformed rel_paths (traversal, absolute)
+// can never round-trip through open_file, so they stay excluded for every
+// backend.
+func (s *Server) listFilesSourceGate() func(model.Document) bool {
+	if corpusSourceIsRemote(s.cfg) {
+		return isListableRemoteSource
+	}
+	rootAbs, rootReal, ok := s.resolveRoot()
+	if !ok {
+		return nil
+	}
+	return func(doc model.Document) bool {
+		return isResolvableSourceWithRoot(doc, rootAbs, rootReal)
+	}
 }
 
 // listFilesFilteredByWalk is the pre-#694 implementation, kept as the fallback
@@ -710,19 +746,10 @@ func (s *Server) listFilesFilteredByWalk(ctx context.Context, pathPrefix, glob s
 	storeOffset := 0
 	var storeTotal int64
 
-	// Resolve root once up front. On large corpora the per-document gate would
-	// otherwise re-run filepath.Abs + EvalSymlinks(root) for every row, which
-	// is syscall-heavy enough to show up on `list_files`.
-	var (
-		rootResolvable bool
-		rootAbs        string
-		rootReal       string
-	)
-	if abs, resolved, ok := s.resolveRoot(); ok {
-		rootResolvable = true
-		rootAbs = abs
-		rootReal = resolved
-	}
+	// Build the source gate once up front. On large corpora the per-document
+	// check would otherwise re-run filepath.Abs + EvalSymlinks(root) for every
+	// row, which is syscall-heavy enough to show up on `list_files`.
+	gate := s.listFilesSourceGate()
 
 	for {
 		docs, total, err := s.store.ListFiles(ctx, pathPrefix, glob, pageSize, storeOffset)
@@ -737,7 +764,7 @@ func (s *Server) listFilesFilteredByWalk(ctx context.Context, pathPrefix, glob s
 			if !includeHidden && isListFilesNoisePath(doc.RelPath) {
 				continue
 			}
-			if rootResolvable && !isResolvableSourceWithRoot(doc, rootAbs, rootReal) {
+			if gate != nil && !gate(doc) {
 				continue
 			}
 			if visibleSeen >= offset && len(collected) < limit {
@@ -812,13 +839,11 @@ func (s *Server) canResolveRoot() bool {
 // candidate target are compared in their symlink-resolved form so equivalent
 // symlinked paths match.
 func isResolvableSourceWithRoot(doc model.Document, rootAbs, rootReal string) bool {
-	if strings.EqualFold(strings.TrimSpace(doc.SourceType), "archive_member") {
+	if isArchiveMemberSource(doc) {
 		return true
 	}
-	normalized := filepath.ToSlash(filepath.Clean(strings.TrimSpace(doc.RelPath)))
-	if normalized == "." || normalized == ".." || strings.HasPrefix(normalized, "../") || filepath.IsAbs(doc.RelPath) {
-		// An affirmatively malformed rel_path (traversal / absolute) can never
-		// round-trip through open_file, so excluding it is safe.
+	normalized, ok := normalizedListRelPath(doc.RelPath)
+	if !ok {
 		return false
 	}
 	absPath := filepath.Join(rootAbs, filepath.FromSlash(normalized))
@@ -844,6 +869,39 @@ func isResolvableSourceWithRoot(doc model.Document, rootAbs, rootReal string) bo
 		return false
 	}
 	return true
+}
+
+// isListableRemoteSource is the list_files gate for an object-store corpus
+// (issue #684). No local file exists at RootDir/rel_path for such a corpus, so
+// the local existence check of isResolvableSourceWithRoot cannot say anything
+// about a remote object and must not run. What survives is the part that needs
+// no filesystem: archive members stay listable, and an affirmatively malformed
+// rel_path (traversal or absolute) stays excluded, because it can never
+// round-trip through open_file on any backend.
+func isListableRemoteSource(doc model.Document) bool {
+	if isArchiveMemberSource(doc) {
+		return true
+	}
+	_, ok := normalizedListRelPath(doc.RelPath)
+	return ok
+}
+
+// isArchiveMemberSource reports whether doc is a member of an archive. Such a
+// path is virtual (the backing file is the archive itself), so no per-document
+// source resolution applies to it.
+func isArchiveMemberSource(doc model.Document) bool {
+	return strings.EqualFold(strings.TrimSpace(doc.SourceType), "archive_member")
+}
+
+// normalizedListRelPath cleans relPath into slash form and reports whether it is
+// a well-formed corpus-relative path. A traversal or absolute path is rejected:
+// it can never round-trip through open_file, so list_files must not emit it.
+func normalizedListRelPath(relPath string) (string, bool) {
+	normalized := filepath.ToSlash(filepath.Clean(strings.TrimSpace(relPath)))
+	if normalized == "." || normalized == ".." || strings.HasPrefix(normalized, "../") || filepath.IsAbs(relPath) {
+		return "", false
+	}
+	return normalized, true
 }
 
 func (s *Server) handleSearchTool(ctx context.Context, args map[string]interface{}) (toolCallResult, *toolExecutionError) {

--- a/tests/mcp/list_files_s3_684_test.go
+++ b/tests/mcp/list_files_s3_684_test.go
@@ -1,0 +1,135 @@
+package tests
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// Issue #684: `dir2mcp_list_files` resolved EVERY row against the local
+// filesystem. An object-store corpus has no local file at RootDir/rel_path
+// (S3FS.Walk ignores RootDir and reports no local path, the same asymmetry that
+// broke the on-demand media paths in #759), so the gate condemned every remote
+// document. The user saw an empty inventory and a `total` that counted rows the
+// listing then refused to show, on a corpus that indexed and searched fine.
+//
+// The fix gates that filesystem check on the live `source.kind`. These tests
+// pin both halves: remote objects become listable, and the path-shape and
+// archive-member rules that protect the listing stay in force.
+
+// listFilesOn684 calls dir2mcp_list_files against a server built from cfg and
+// st, and returns the structured page.
+func listFilesOn684(t *testing.T, cfg config.Config, st model.Store, args string) listFilesPageResult694 {
+	t.Helper()
+	server := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st)).Handler())
+	defer server.Close()
+
+	session := initializeSession(t, server.URL+cfg.MCPPath)
+	body := `{"jsonrpc":"2.0","id":684,"method":"tools/call","params":{"name":"dir2mcp_list_files","arguments":{` + args + `}}}`
+	resp := postRPC(t, server.URL+cfg.MCPPath, session, body)
+	defer func() { _ = resp.Body.Close() }()
+
+	return decodeListFilesEnvelope694(t, resp.Body)
+}
+
+// seedSourceTypedDoc684 records an indexed row with an explicit source_type. It
+// is the state an S3 corpus is in after a successful scan: the store normalizes
+// source_type to filesystem or archive_member, so a remote object is persisted
+// as "filesystem" and carries no per-backend marker.
+func seedSourceTypedDoc684(t *testing.T, st model.Store, relPath, sourceType string) {
+	t.Helper()
+	if err := st.UpsertDocument(context.Background(), model.Document{
+		RelPath: relPath, DocType: "md", SourceType: sourceType,
+		SizeBytes: 12, MTimeUnix: 1700000000, ContentHash: "seed-684", Status: "ok",
+	}); err != nil {
+		t.Fatalf("upsert document %q: %v", relPath, err)
+	}
+}
+
+// TestListFilesS3CorpusListsRemoteObjects_684 is the reproduction. RootDir is a
+// real but EMPTY directory, so the root resolves and the only reason a row can
+// disappear is the missing local RootDir/rel_path file, which is exactly the
+// bug. Before the fix this listing came back with zero files.
+func TestListFilesS3CorpusListsRemoteObjects_684(t *testing.T) {
+	objects := map[string][]byte{
+		"docs/a.md":          []byte("alpha"),
+		"docs/nested/b.md":   []byte("bravo"),
+		"reports/2026/c.txt": []byte("charlie"),
+	}
+	c := newS3Corpus(t, objects)
+	for rel := range objects {
+		seedDoc(t, c.store, rel, "md", 8)
+	}
+
+	page := listFilesOn684(t, c.cfg, c.store, `"limit":50,"offset":0`)
+
+	assertRelPathSet694(t, "s3 corpus listing", page, []string{
+		"docs/a.md", "docs/nested/b.md", "reports/2026/c.txt",
+	})
+	if page.Total != 3 {
+		t.Fatalf("total=%d want 3", page.Total)
+	}
+}
+
+// malformedStore684 injects rows the store itself refuses to persist.
+// UpsertDocument validates rel_path, so a traversal or absolute path can only
+// reach the tool through a store that hands one back. That is the shape of the
+// stale or hand-edited row the path-shape check exists for.
+type malformedStore684 struct {
+	*store.SQLiteStore
+	extra []model.Document
+}
+
+func (m *malformedStore684) ListVisibleFiles(ctx context.Context, prefix, glob string, limit, offset int, includeHidden bool) ([]model.Document, int64, error) {
+	docs, total, err := m.SQLiteStore.ListVisibleFiles(ctx, prefix, glob, limit, offset, includeHidden)
+	if err != nil {
+		return nil, 0, err
+	}
+	return append(docs, m.extra...), total + int64(len(m.extra)), nil
+}
+
+// TestListFilesS3CorpusKeepsPathProtections_684 pins what the remote gate must
+// NOT relax. A traversal or absolute rel_path can never round-trip through
+// open_file on any backend, so it stays excluded. A hidden path stays hidden
+// while include_hidden is false. An archive member stays listable, as it is on
+// a local corpus.
+func TestListFilesS3CorpusKeepsPathProtections_684(t *testing.T) {
+	c := newS3Corpus(t, map[string][]byte{"docs/a.md": []byte("alpha")})
+	seedSourceTypedDoc684(t, c.store, "docs/a.md", "filesystem")
+	seedSourceTypedDoc684(t, c.store, "bundle.zip/inner/note.md", "archive_member")
+	seedSourceTypedDoc684(t, c.store, "docs/.secret/key.txt", "filesystem")
+
+	st := &malformedStore684{SQLiteStore: c.store, extra: []model.Document{
+		{RelPath: "../escape.md", DocType: "md", SourceType: "filesystem", Status: "ok"},
+		{RelPath: "/etc/passwd", DocType: "md", SourceType: "filesystem", Status: "ok"},
+	}}
+
+	page := listFilesOn684(t, c.cfg, st, `"limit":50,"offset":0`)
+
+	assertRelPathSet694(t, "s3 corpus protections", page, []string{
+		"docs/a.md", "bundle.zip/inner/note.md",
+	})
+}
+
+// TestListFilesLocalCorpusStillDropsMissingFiles_684 is the control: the #176
+// round-trip gate must keep running for a local corpus. The fixture differs
+// from the one above by source.kind alone, so a fix that simply deleted the
+// gate would fail here.
+func TestListFilesLocalCorpusStillDropsMissingFiles_684(t *testing.T) {
+	c := newS3Corpus(t, map[string][]byte{"docs/a.md": []byte("alpha")})
+	seedDoc(t, c.store, "docs/a.md", "md", 5)
+
+	cfg := c.cfg
+	cfg.Source.Kind = "local"
+
+	page := listFilesOn684(t, cfg, c.store, `"limit":50,"offset":0`)
+
+	if len(page.Files) != 0 {
+		t.Fatalf("a local corpus must still drop a row with no file under root, got %+v", page.Files)
+	}
+}


### PR DESCRIPTION
## What the user sees

An S3-backed corpus indexes correctly and `search` answers correctly. `dir2mcp_list_files` then returns an empty file list. The `total` field still counts the rows, so the tool reports files that it refuses to show. An agent cannot browse or discover any remote document. On a partly local, partly remote deployment the listing is not empty but wrong: only the paths that happen to exist under the local root come back.

## Cause

`list_files` resolved EVERY store row against the local filesystem. The gate joined `RootDir` with `rel_path`, ran `filepath.EvalSymlinks`, and dropped the row when the path did not exist.

An object-store corpus has no local file at `RootDir/rel_path`. `S3FS.Walk` ignores `RootDir` and reports no local path. This is the same asymmetry that broke the on-demand media paths in #759. In a normal `source.kind=s3` deployment `RootDir` defaults to the process directory, so every remote object failed the existence check.

The persisted `source_type` cannot separate the two cases. The store normalizes it to `filesystem` or `archive_member` only, so a remote object is stored as `filesystem`.

## Fix

Gate the filesystem check on the live `cfg.Source.Kind`, through the existing `corpusSourceIsRemote` helper. A new `listFilesSourceGate` builds the per-page predicate one time:

- Local corpus: unchanged. The #176 round-trip gate still drops a row whose file is gone under the root.
- Object-store corpus: only the path-shape part of the check runs. A traversal or absolute `rel_path` can never round-trip through `open_file` on any backend, so it stays excluded.

Both the fast path (`dropUnresolvableSources`) and the walk fallback (`listFilesFilteredByWalk`) use the same gate, so they cannot drift.

I did NOT widen the persisted `source_type` vocabulary. That is the other option in the issue, but the canonical enum is under adjudication in dirstral-spec #63. Gating on the running configuration needs no schema change and no spec change.

## Contract

The `list_files` input and output schemas of SPEC.md 15.5 do not change. No field is added, removed or renamed. Archive-member behavior and the hidden-path policy are untouched.

## Tests

`tests/mcp/list_files_s3_684_test.go` drives the MCP tool over the network-free S3 fixture from #759 (`newS3Corpus`, a stub S3 client, no credentials). `RootDir` points at a real but EMPTY directory, so the only reason a row can disappear is the missing local file.

- `TestListFilesS3CorpusListsRemoteObjects_684`: three seeded objects must be listed.
- `TestListFilesS3CorpusKeepsPathProtections_684`: traversal, absolute and hidden paths stay out; an archive member stays in.
- `TestListFilesLocalCorpusStillDropsMissingFiles_684`: the control. The fixture differs by `source.kind` alone, so a fix that deleted the gate fails here.

Proof on main (this branch's tests, main's `internal/mcp/tools.go`):

```
--- FAIL: TestListFilesS3CorpusListsRemoteObjects_684
    s3 corpus listing: "docs/a.md" missing from the listing (got [])
--- FAIL: TestListFilesS3CorpusKeepsPathProtections_684
    s3 corpus protections: "docs/a.md" missing from the listing (got [bundle.zip/inner/note.md])
```

The empty listing is the exact user symptom. Only the archive member survived on main, because it was the one row that skipped the disk check.

`make check` passes.

Closes #684

## Review follow-up

`coderabbit review` raised one finding. Both of its parts are fixed in the second commit.

- `filepath.IsAbs` now runs on the trimmed `rel_path`. A padded value such as `" /etc/passwd"` passes the store's own `rel_path` validation, so the untrimmed test read it as relative and the listing advertised an absolute path.
- The path-shape test now runs before the archive-member exemption. An archive member skips the local existence check only. It does not skip the rule that a listed path must be able to round-trip through `open_file`. No real archive row is affected: the store builds and validates those paths as relative already.

`internal/mcp/list_files_resolve_test.go` gains cases for both, plus a table for the new remote gate.
