### PR TITLE
fix(retrieval): answer the adaptive skip verdict instead of the empty-context fallback (#685)

### DIFF
--- a/internal/retrieval/adaptive.go
+++ b/internal/retrieval/adaptive.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/dirstral/dir2mcp/internal/model"
 	"github.com/dirstral/dir2mcp/internal/usage"
 )
 
@@ -178,6 +179,45 @@ func normalizeAdaptiveBounds(kMin, kMax int) (int, int) {
 		kMax = kMin
 	}
 	return kMin, kMax
+}
+
+// applyAdaptiveGate resolves the opt-in adaptive retrieval verdict for one ask
+// (config retrieval.adaptive.*). It reports whether retrieval must be skipped
+// and it writes the effective k into query when retrieval runs. With the gate
+// disabled it is a no-op, so the fixed-k path is unchanged.
+//
+// An ask carries two texts. `query.Query` is the retrieval query. `question` is
+// the text the answer must satisfy. Ask copies the question into an empty query,
+// so the two agree unless a caller overrides the query. The gate keeps its k
+// decision on the retrieval query, because k bounds that search. A SKIP verdict
+// needs more care: it removes the evidence from an answer, so the answered
+// question must carry no information need either. A caller that pairs a
+// substantive question with a trivial query override would otherwise get an
+// ungrounded answer to a real question (#685). The gate therefore re-classifies
+// the question before it skips, and it retrieves when the question asks for
+// something.
+func (s *Service) applyAdaptiveGate(question string, query *model.SearchQuery) bool {
+	s.metaMu.RLock()
+	enabled := s.adaptiveEnabled
+	kMin := s.adaptiveKMin
+	kMax := s.adaptiveKMax
+	s.metaMu.RUnlock()
+	if !enabled {
+		return false
+	}
+	decision := adaptiveGate(query.Query, query.K, kMin, kMax)
+	s.logf("adaptive gate: class=%s retrieve=%t k=%d", decision.Class, decision.Retrieve, decision.K)
+	if decision.Retrieve {
+		query.K = decision.K
+		return false
+	}
+	asked := adaptiveGate(question, query.K, kMin, kMax)
+	if !asked.Retrieve {
+		return true
+	}
+	s.logf("adaptive gate: skip on the query, class=%s on the question; retrieving with k=%d", asked.Class, asked.K)
+	query.K = asked.K
+	return false
 }
 
 // The no-retrieval answer path (issue #685).

--- a/internal/retrieval/adaptive.go
+++ b/internal/retrieval/adaptive.go
@@ -1,8 +1,11 @@
 package retrieval
 
 import (
+	"context"
 	"regexp"
 	"strings"
+
+	"github.com/dirstral/dir2mcp/internal/usage"
 )
 
 // adaptiveDecision is the verdict of the training-free retrieval gate for a
@@ -175,6 +178,91 @@ func normalizeAdaptiveBounds(kMin, kMax int) (int, int) {
 		kMax = kMin
 	}
 	return kMin, kMax
+}
+
+// The no-retrieval answer path (issue #685).
+//
+// A "skip" verdict means the gate found no information need in the message, so
+// it spends neither an embedding nor an index search on it. Skip is NOT the
+// insufficient-evidence abstention of SPEC §9.4.3: that one runs AFTER
+// retrieval, judges an eligible hit set that exists, and reports that the
+// corpus material is too weak. Here retrieval never ran, so the server knows
+// nothing about the corpus and must not report anything about it. Returning the
+// zero-hit fallback ("No relevant context found in the indexed corpus.") states
+// a corpus result the server never obtained, which is why the skip verdict gets
+// its own answer path.
+//
+// The path stays inside the grounding rules of SPEC §9.4.1: the model receives
+// no document, so the answer carries an EMPTY citations array, and Ask strips
+// every file tag and any Sources footer the model invents.
+const (
+	// noRetrievalFallbackAnswer is the deterministic reply used when no
+	// generator is configured, when generation fails, or when the model
+	// returns nothing. It reports the server state truthfully: no lookup ran.
+	noRetrievalFallbackAnswer = "No corpus lookup was needed for this message. " +
+		"Ask a question about the indexed documents to search them."
+
+	// noRetrievalSystemPrompt instructs a short, source-free reply. The model
+	// gets no document here, so every corpus claim it could make would be
+	// ungrounded by construction.
+	noRetrievalSystemPrompt = "You are the assistant of a document search server.\n" +
+		"The message below carries no information need, so no document was retrieved.\n" +
+		"Reply in one or two short sentences.\n" +
+		"State no fact about the indexed documents.\n" +
+		"Write no file name, no source and no citation.\n" +
+		"You can offer to search the indexed documents."
+
+	// noRetrievalMaxQuestionRunes bounds the message copied into the prompt.
+	// The gate only skips very short messages, but the raw string can still
+	// hold long punctuation runs, so the bound is explicit.
+	noRetrievalMaxQuestionRunes = 512
+
+	// noRetrievalMaxTokens bounds the completion. A conversational reply needs
+	// very few tokens, and the bound keeps a skip verdict cheap.
+	noRetrievalMaxTokens = 128
+)
+
+// noRetrievalPrompt builds the bounded, non-RAG prompt for a skip verdict. It
+// contains no document fence because no document is sent.
+func noRetrievalPrompt(question string) string {
+	return noRetrievalSystemPrompt +
+		"\n\nMessage: " + truncateSnippet(question, noRetrievalMaxQuestionRunes) +
+		"\nReply:"
+}
+
+// answerWithoutRetrieval produces the answer text for an adaptive skip verdict.
+// It calls the configured generator with noRetrievalPrompt and falls back to
+// noRetrievalFallbackAnswer when no generator exists, when the call fails, or
+// when the reply is blank. It never returns citations or hits: the caller keeps
+// both empty.
+func (s *Service) answerWithoutRetrieval(ctx context.Context, question string) string {
+	if s.gen == nil {
+		return noRetrievalFallbackAnswer
+	}
+	var generated string
+	genErr := usage.TimeStage(ctx, usage.StageGenerate, func() error {
+		var gErr error
+		generated, gErr = boundedGenerate(ctx, s.gen, noRetrievalPrompt(question), noRetrievalMaxTokens)
+		return gErr
+	})
+	if genErr != nil {
+		// Log the failure without the full message, which can hold sensitive
+		// text, exactly as the grounded path does.
+		s.logf("no-retrieval generator error for question %q: %v", truncateQuestion(question), genErr)
+		return noRetrievalFallbackAnswer
+	}
+	trimmed := strings.TrimSpace(generated)
+	if trimmed == "" {
+		return noRetrievalFallbackAnswer
+	}
+	// The model saw no document, so the allowed citation set is empty and every
+	// file tag it wrote is ungrounded (§9.4.1). Ask removes any Sources footer
+	// separately through ensureAnswerAttributions.
+	trimmed = strings.TrimSpace(stripHallucinatedCitations(trimmed, nil))
+	if trimmed == "" {
+		return noRetrievalFallbackAnswer
+	}
+	return trimmed
 }
 
 // clampInt clamps v into [lo, hi] (assumes lo <= hi).

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -1667,21 +1667,7 @@ func (s *Service) Ask(ctx context.Context, question string, query model.SearchQu
 	// all and what k to use; when disabled this is a no-op so the fixed-k path
 	// below is unchanged. The gate uses the question text (the effective query)
 	// and never alters the MCP tool contract.
-	skipRetrieval := false
-	s.metaMu.RLock()
-	adaptiveEnabled := s.adaptiveEnabled
-	adaptiveKMin := s.adaptiveKMin
-	adaptiveKMax := s.adaptiveKMax
-	s.metaMu.RUnlock()
-	if adaptiveEnabled {
-		decision := adaptiveGate(query.Query, query.K, adaptiveKMin, adaptiveKMax)
-		s.logf("adaptive gate: class=%s retrieve=%t k=%d", decision.Class, decision.Retrieve, decision.K)
-		if decision.Retrieve {
-			query.K = decision.K
-		} else {
-			skipRetrieval = true
-		}
-	}
+	skipRetrieval := s.applyAdaptiveGate(question, &query)
 
 	var (
 		hits []model.SearchHit

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -1711,7 +1711,13 @@ func (s *Service) Ask(ctx context.Context, question string, query model.SearchQu
 	}
 
 	answer := buildFallbackAnswer(question, hits)
-	if s.gen != nil && len(hits) > 0 {
+	switch {
+	case skipRetrieval:
+		// The adaptive gate found no information need, so no lookup ran and the
+		// zero-hit fallback would misreport a corpus result the server never
+		// obtained (#685). Answer without retrieval and keep citations empty.
+		answer = s.answerWithoutRetrieval(ctx, question)
+	case s.gen != nil && len(hits) > 0:
 		answer, citations = s.generateGroundedAnswer(ctx, question, answer, hits, citations)
 	}
 	answer = ensureAnswerAttributions(answer, citations)

--- a/tests/retrieval/adaptive_skip_answer_685_test.go
+++ b/tests/retrieval/adaptive_skip_answer_685_test.go
@@ -159,6 +159,52 @@ func TestAdaptiveSkip685_StripsFabricatedSources(t *testing.T) {
 	}
 }
 
+// TestAdaptiveSkip685_SubstantiveQuestionNeverSkips pins the guard on the
+// no-retrieval path. A caller can set the retrieval query apart from the
+// question. A trivial query override must not remove the evidence from a real
+// question: the server must still retrieve, and the generator must not answer
+// the question with no document.
+func TestAdaptiveSkip685_SubstantiveQuestionNeverSkips(t *testing.T) {
+	gen := &fakeGenerator{out: "x402 is a payment challenge protocol."}
+	svc, idx, emb := newSkipService685(t, gen)
+
+	res, err := svc.Ask(
+		context.Background(),
+		"how does the x402 payment challenge work?",
+		model.SearchQuery{Index: "text", Query: "hi"},
+	)
+	if err != nil {
+		t.Fatalf("Ask: %v", err)
+	}
+	if idx.lastK == -1 {
+		t.Fatalf("a substantive question must still query the index, even with a trivial query override")
+	}
+	if emb.calls == 0 {
+		t.Fatalf("a substantive question must still embed the query")
+	}
+	if gen.lastPrompt != "" {
+		t.Fatalf("a zero-hit retrieved ask must not call the generator")
+	}
+	if res.Answer != noContextFallback685 {
+		t.Fatalf("answer = %q, want the empty-corpus fallback for a zero-hit retrieved ask", res.Answer)
+	}
+}
+
+// TestAdaptiveSkip685_TrivialQuestionWithRichQueryRetrieves pins the other half
+// of the guard. The k decision still follows the retrieval query, so a rich
+// query override keeps its retrieval and its widened k.
+func TestAdaptiveSkip685_TrivialQuestionWithRichQueryRetrieves(t *testing.T) {
+	svc, idx, _ := newSkipService685(t, nil)
+
+	hard := "compare and contrast the performance and reliability tradeoffs between approach one and approach two in detail"
+	if _, err := svc.Ask(context.Background(), "hi", model.SearchQuery{Index: "text", Query: hard}); err != nil {
+		t.Fatalf("Ask: %v", err)
+	}
+	if idx.lastK != 30 {
+		t.Fatalf("a hard query override must still widen k to k_max=30, got %d", idx.lastK)
+	}
+}
+
 // TestAdaptiveSkip685_RetrievedAskUnchanged pins the scope of the fix. A real
 // question still retrieves, still generates from the retrieved context, and
 // still returns its citations.

--- a/tests/retrieval/adaptive_skip_answer_685_test.go
+++ b/tests/retrieval/adaptive_skip_answer_685_test.go
@@ -1,0 +1,187 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
+)
+
+// countingEmbedder685 wraps the shared retrieval embedder fake and counts the
+// Embed calls. The adaptive skip verdict must answer without any retrieval, so
+// the query embedding is a cost the skip path must not pay (#685).
+type countingEmbedder685 struct {
+	inner *fakeRetrievalEmbedder
+	calls int
+}
+
+func (e *countingEmbedder685) Embed(
+	ctx context.Context, modelName string, role model.EmbedRole, texts []string,
+) ([][]float32, error) {
+	e.calls++
+	return e.inner.Embed(ctx, modelName, role, texts)
+}
+
+// newSkipService685 builds a retrieval service with the adaptive gate enabled,
+// a counting embedder and the supplied generator. lastK stays -1 when the index
+// is never queried.
+func newSkipService685(
+	t *testing.T, gen model.Generator,
+) (*retrieval.Service, *fakeRetrievalIndex, *countingEmbedder685) {
+	t.Helper()
+	idx := &fakeRetrievalIndex{lastK: -1}
+	emb := &countingEmbedder685{
+		inner: &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{"mistral-embed": {1, 0}}},
+	}
+	svc := retrieval.NewService(nil, idx, emb, gen)
+	svc.SetOverfetchMultiplier(1)
+	svc.SetAdaptiveRetrieval(true, 4, 30)
+	return svc, idx, emb
+}
+
+// noContextFallback685 is the zero-hit fallback answer. A skip verdict must
+// never return it: retrieval did not run, so the corpus was never consulted and
+// the message misreports the server's own state.
+const noContextFallback685 = "No relevant context found in the indexed corpus."
+
+// TestAdaptiveSkip685_CallsGeneratorWithoutRetrieval pins the fix for #685. An
+// adaptive skip verdict must answer through the configured generator with a
+// non-RAG prompt. It must not query the index, must not embed the query, and
+// must not return the empty-corpus fallback.
+func TestAdaptiveSkip685_CallsGeneratorWithoutRetrieval(t *testing.T) {
+	gen := &fakeGenerator{out: "Hello. Ask me a question about the indexed documents."}
+	svc, idx, emb := newSkipService685(t, gen)
+
+	res, err := svc.Ask(context.Background(), "hello", model.SearchQuery{Index: "text"})
+	if err != nil {
+		t.Fatalf("Ask: %v", err)
+	}
+
+	if idx.lastK != -1 {
+		t.Fatalf("skip verdict must not query the index, got k=%d", idx.lastK)
+	}
+	if emb.calls != 0 {
+		t.Fatalf("skip verdict must not embed the query, got %d Embed call(s)", emb.calls)
+	}
+	if res.Answer == noContextFallback685 {
+		t.Fatalf("skip verdict returned the empty-corpus fallback instead of a generated answer")
+	}
+	if res.Answer != gen.out {
+		t.Fatalf("answer = %q, want the generator output %q", res.Answer, gen.out)
+	}
+	if len(res.Citations) != 0 {
+		t.Fatalf("a no-retrieval answer must carry no citations, got %d", len(res.Citations))
+	}
+	if len(res.Hits) != 0 {
+		t.Fatalf("a no-retrieval answer must carry no hits, got %d", len(res.Hits))
+	}
+	if gen.lastPrompt == "" {
+		t.Fatalf("the generator was never called")
+	}
+	if !strings.Contains(gen.lastPrompt, "hello") {
+		t.Fatalf("the non-RAG prompt must carry the message, got %q", gen.lastPrompt)
+	}
+	if strings.Contains(gen.lastPrompt, "UNTRUSTED DOCUMENT") {
+		t.Fatalf("the no-retrieval prompt must carry no document fence, got %q", gen.lastPrompt)
+	}
+}
+
+// TestAdaptiveSkip685_NoGeneratorFallback pins the no-generator case. Without a
+// generator the server still must not claim that it searched the corpus.
+func TestAdaptiveSkip685_NoGeneratorFallback(t *testing.T) {
+	svc, idx, emb := newSkipService685(t, nil)
+
+	res, err := svc.Ask(context.Background(), "thanks", model.SearchQuery{Index: "text"})
+	if err != nil {
+		t.Fatalf("Ask: %v", err)
+	}
+	if idx.lastK != -1 {
+		t.Fatalf("skip verdict must not query the index, got k=%d", idx.lastK)
+	}
+	if emb.calls != 0 {
+		t.Fatalf("skip verdict must not embed the query, got %d Embed call(s)", emb.calls)
+	}
+	if res.Answer == noContextFallback685 {
+		t.Fatalf("skip verdict returned the empty-corpus fallback with no generator")
+	}
+	if strings.TrimSpace(res.Answer) == "" {
+		t.Fatalf("skip verdict returned an empty answer")
+	}
+	if len(res.Citations) != 0 {
+		t.Fatalf("a no-retrieval answer must carry no citations, got %d", len(res.Citations))
+	}
+}
+
+// TestAdaptiveSkip685_GeneratorErrorFallsBack pins the failure path. A broken
+// generator must degrade to the deterministic no-retrieval reply, not to the
+// empty-corpus message, and must still emit no citations.
+func TestAdaptiveSkip685_GeneratorErrorFallsBack(t *testing.T) {
+	gen := &fakeGenerator{err: errors.New("provider down")}
+	svc, _, _ := newSkipService685(t, gen)
+
+	res, err := svc.Ask(context.Background(), "ok", model.SearchQuery{Index: "text"})
+	if err != nil {
+		t.Fatalf("Ask: %v", err)
+	}
+	if res.Answer == noContextFallback685 {
+		t.Fatalf("a failed no-retrieval generation returned the empty-corpus fallback")
+	}
+	if strings.TrimSpace(res.Answer) == "" {
+		t.Fatalf("a failed no-retrieval generation returned an empty answer")
+	}
+	if len(res.Citations) != 0 {
+		t.Fatalf("a no-retrieval answer must carry no citations, got %d", len(res.Citations))
+	}
+}
+
+// TestAdaptiveSkip685_StripsFabricatedSources pins the grounding rule of SPEC
+// §9.4.1 on the no-retrieval path. The model saw no document, so any file tag
+// or Sources footer it writes is ungrounded and must not reach the caller.
+func TestAdaptiveSkip685_StripsFabricatedSources(t *testing.T) {
+	gen := &fakeGenerator{out: "Hello, see [docs/a.md].\n\nSources: [docs/a.md]"}
+	svc, _, _ := newSkipService685(t, gen)
+
+	res, err := svc.Ask(context.Background(), "hi", model.SearchQuery{Index: "text"})
+	if err != nil {
+		t.Fatalf("Ask: %v", err)
+	}
+	if strings.Contains(res.Answer, "docs/a.md") {
+		t.Fatalf("a no-retrieval answer must cite nothing, got %q", res.Answer)
+	}
+	if strings.Contains(res.Answer, "Sources:") {
+		t.Fatalf("a no-retrieval answer must carry no Sources footer, got %q", res.Answer)
+	}
+	if len(res.Citations) != 0 {
+		t.Fatalf("a no-retrieval answer must carry no citations, got %d", len(res.Citations))
+	}
+}
+
+// TestAdaptiveSkip685_RetrievedAskUnchanged pins the scope of the fix. A real
+// question still retrieves, still generates from the retrieved context, and
+// still returns its citations.
+func TestAdaptiveSkip685_RetrievedAskUnchanged(t *testing.T) {
+	gen := &fakeGenerator{out: "The answer is in [docs/a.md]."}
+	svc, idx, emb := newSkipService685(t, gen)
+
+	res, err := svc.Ask(context.Background(), "what is x402?", model.SearchQuery{Index: "text"})
+	if err != nil {
+		t.Fatalf("Ask: %v", err)
+	}
+	if idx.lastK == -1 {
+		t.Fatalf("a real question must still query the index")
+	}
+	if emb.calls == 0 {
+		t.Fatalf("a real question must still embed the query")
+	}
+	// The fake index returns no hits, so the retrieved path keeps the
+	// empty-corpus fallback and never calls the generator.
+	if res.Answer != noContextFallback685 {
+		t.Fatalf("retrieved ask with no hits: answer = %q, want the empty-corpus fallback", res.Answer)
+	}
+	if gen.lastPrompt != "" {
+		t.Fatalf("a zero-hit retrieved ask must not call the generator")
+	}
+}


### PR DESCRIPTION
Closes #685

## What the user sees

Set `retrieval.adaptive.enabled: true`, then send `hello` to `ask`.

**Today (main):**

```
No relevant context found in the indexed corpus.
```

The server never searched the corpus for that message. The gate decided to skip
retrieval. The message therefore reports a corpus result that the server never
obtained. The user reads it as a corpus failure or an empty index.

**After this PR:**

```
Hello. I can search the indexed documents for you. Ask a question about them.
```

The text comes from the configured generator. `citations` stays empty. `hits`
stays empty. Without a generator, or after a generator error, the user gets a
deterministic reply that states the true server state:

```
No corpus lookup was needed for this message. Ask a question about the indexed
documents to search them.
```

## Mechanism

The adaptive gate returns `{Retrieve:false, K:0, Class:"skip"}` for a trivial
message. `Ask` set `skipRetrieval=true` and left `hits` empty. `Ask` called the
generator only when `s.gen != nil && len(hits) > 0`. So the skip verdict always
fell through to `buildFallbackAnswer`, whose zero-hit branch is the fixed
no-context string. The gate saved the retrieval cost and also removed the
answer.

`Ask` now selects the answer path on the verdict:

- skip verdict: `answerWithoutRetrieval` calls the generator with a bounded
  non-RAG prompt (`noRetrievalPrompt`, 128 max tokens through the existing
  `boundedGenerate` helper). The prompt carries no document and no untrusted
  document fence.
- retrieved ask: unchanged `generateGroundedAnswer` path.

New code lives in `internal/retrieval/adaptive.go`. The `service.go` edit is one
call site plus the gate block, which moves into `applyAdaptiveGate`.

## Guard: which text the gate classifies

An ask carries two texts. `query.Query` is the retrieval query. `question` is
the text the answer must satisfy. `Ask` copies the question into an empty query,
so the two agree unless a caller overrides the query.

The gate classified `query.Query` alone. That was harmless while a skip verdict
returned the no-context string. It is not harmless once a skip verdict answers:
a caller could pair a substantive question with a trivial query override, and
the generator would answer a real question with no evidence.

`applyAdaptiveGate` therefore re-classifies `question` before it skips. It skips
only when the question also carries no information need. It retrieves in every
other case. The k decision still follows the retrieval query, so no k class
moves and every pre-existing gate test keeps its expected k.

## Grounding safety

- The model receives no document, so `citations` and `hits` stay empty. The PR
  fabricates nothing (SPEC §9.4.1).
- `stripHallucinatedCitations(answer, nil)` removes any `[rel_path]` tag the
  model writes on the no-retrieval path. The allowed set is empty by
  construction.
- `ensureAnswerAttributions` already removes a model-authored `Sources:` footer
  and adds none when the citation list is empty.
- The prompt tells the model to state no fact about the indexed documents.

## SPEC check (§9.4.3)

The skip verdict is **not** the insufficient-evidence abstention. §9.4.3 judges
an **eligible** hit set that retrieval produced, and it fires when that set is
empty or does not clear the absolute evidence threshold. The skip path runs
**before** retrieval, so no eligible set exists and §9.4.3 has nothing to judge.
`abstainOnWeakEvidence` returns early on `len(hits) == 0` and is untouched, so
the real abstention keeps its exact answer text and its empty citations array.

The SPEC does not mention adaptive retrieval at all. The gate is a config-only
dir2mcp feature (`retrieval.adaptive.*`), so no spec change is needed and no
spec-pinned behavior moves. The pinned `dirstral-spec` commit is unchanged.

## Tests

`tests/retrieval/adaptive_skip_answer_685_test.go`, seven cases:

1. `CallsGeneratorWithoutRetrieval`: the skip verdict returns the generator
   output, never queries the index, never embeds the query, carries no citation
   and no hit, and sends a prompt with no document fence. **Fails on main.**
2. `NoGeneratorFallback`: without a generator the answer is not the empty-corpus
   message. **Fails on main.**
3. `GeneratorErrorFallsBack`: a failed generation degrades to the deterministic
   reply, not to the empty-corpus message. **Fails on main.**
4. `StripsFabricatedSources`: an invented file tag and an invented `Sources:`
   footer do not reach the caller.
5. `SubstantiveQuestionNeverSkips`: a real question with a trivial query
   override still retrieves and still embeds. **Fails on main.**
6. `TrivialQuestionWithRichQueryRetrieves`: a hard query override keeps its
   retrieval and its widened k.
7. `RetrievedAskUnchanged`: a real question still retrieves, still embeds, and a
   zero-hit retrieved ask still returns the empty-corpus fallback without a
   generator call.

Proof against the sources on `main`:

```
--- FAIL: TestAdaptiveSkip685_CallsGeneratorWithoutRetrieval
--- FAIL: TestAdaptiveSkip685_NoGeneratorFallback
--- FAIL: TestAdaptiveSkip685_GeneratorErrorFallsBack
--- PASS: TestAdaptiveSkip685_StripsFabricatedSources
--- FAIL: TestAdaptiveSkip685_SubstantiveQuestionNeverSkips
--- PASS: TestAdaptiveSkip685_TrivialQuestionWithRichQueryRetrieves
--- PASS: TestAdaptiveSkip685_RetrievedAskUnchanged
```

All seven pass on this branch. The six pre-existing `TestAdaptive_*` gate tests
also still pass. `make check` passes, gocyclo `-over 15` included.

## Out of scope

- The `Hits` field stays `nil` on the skip path, exactly as before. The MCP layer
  serializes it to an empty array.
- The gate's own classification rules are untouched. This PR changes the answer
  for a skip verdict, not which messages a trivial-token scan calls trivial.
- No new config key. The behavior follows `retrieval.adaptive.enabled`, which is
  off by default, so a default install sees no change.
