### PR TITLE
fix(retrieval): refill the result slots that dropped summary hits took (#686)

### DIFF
--- a/internal/retrieval/hierarchical.go
+++ b/internal/retrieval/hierarchical.go
@@ -45,9 +45,12 @@ type summaryExpander interface {
 // only stops a pathological corpus from re-querying the index for ever.
 const summaryRefillMaxRounds = 3
 
-// summaryRefillMaxPool caps the widened pool, so a corpus made almost entirely
-// of summary vectors cannot turn one search into an unbounded index scan.
-const summaryRefillMaxPool = 200
+// summaryRefillMaxMargin caps how many EXTRA candidates a refill round may ask
+// for on top of the caller's own pool, so a corpus made almost entirely of
+// summary vectors cannot turn one search into an unbounded index scan. The cap
+// is on the margin, never on the pool, so a widened round always asks for at
+// least as many candidates as the round it repairs.
+const summaryRefillMaxMargin = 200
 
 // searchWithSummaryRefill retrieves the candidate pool and applies the §9.7
 // expand step. It re-retrieves a WIDER pool when dropped `summary` hits left the
@@ -78,10 +81,7 @@ func (s *Service) searchWithSummaryRefill(ctx context.Context, query model.Searc
 		if !needSummaryRefill(len(hits), poolK, summaries, len(raw), fetchK, round) {
 			return hits, nil
 		}
-		fetchK = poolK + summaries
-		if fetchK > summaryRefillMaxPool {
-			fetchK = summaryRefillMaxPool
-		}
+		fetchK = poolK + summaryRefillMargin(summaries)
 	}
 }
 
@@ -102,7 +102,18 @@ func needSummaryRefill(got, poolK, summaries, rawLen, fetchK, round int) bool {
 	if round+1 >= summaryRefillMaxRounds {
 		return false
 	}
-	return poolK+summaries > fetchK && fetchK < summaryRefillMaxPool
+	// Only widen when the next request would really be larger than this one.
+	return poolK+summaryRefillMargin(summaries) > fetchK
+}
+
+// summaryRefillMargin is the number of extra candidates a refill round adds to
+// the caller's pool: one per summary that took a slot, bounded by
+// summaryRefillMaxMargin.
+func summaryRefillMargin(summaries int) int {
+	if summaries > summaryRefillMaxMargin {
+		return summaryRefillMaxMargin
+	}
+	return summaries
 }
 
 // countSummaryHits reports how many `summary` candidates the pool holds. Every

--- a/internal/retrieval/hierarchical.go
+++ b/internal/retrieval/hierarchical.go
@@ -38,6 +38,86 @@ type summaryExpander interface {
 	ExpandSummaryChunk(ctx context.Context, chunkID uint64) ([]model.ChunkMetadata, error)
 }
 
+// summaryRefillMaxRounds bounds how many times search re-retrieves a widened
+// candidate pool to replace dropped `summary` routing nodes (#686). Each round
+// asks for the caller's pool PLUS the summaries the previous round saw, so two
+// extra rounds already cover a pool whose summary count keeps growing. The cap
+// only stops a pathological corpus from re-querying the index for ever.
+const summaryRefillMaxRounds = 3
+
+// summaryRefillMaxPool caps the widened pool, so a corpus made almost entirely
+// of summary vectors cannot turn one search into an unbounded index scan.
+const summaryRefillMaxPool = 200
+
+// searchWithSummaryRefill retrieves the candidate pool and applies the §9.7
+// expand step. It re-retrieves a WIDER pool when dropped `summary` hits left the
+// pool short of the caller's budget (#686).
+//
+// A summary is a routing device that never reaches the caller: it is expanded to
+// its fine children, or it is dropped (feature off, store cannot expand,
+// expansion failed, every child filtered out). Retrieval asked the index for
+// exactly poolK candidates, so each dropped summary consumed a slot that a real
+// fine chunk should have taken, and nothing refilled it. Search then returned
+// fewer than k even though eligible fine chunks were indexed.
+//
+// The refill mirrors the tombstone oversampling of SPEC §6.6: ask for more,
+// remove the ineligible candidates, keep the first k. It runs ONLY when the pool
+// both holds a summary and came up short, so a corpus with no summary vectors
+// makes exactly one retrieval call and the flat path is unchanged. The repeated
+// call re-runs retrieval only: the HyDE hypothesis and the cross-lingual query
+// variants are served from the expansion cache, so no extra generation is paid.
+func (s *Service) searchWithSummaryRefill(ctx context.Context, query model.SearchQuery, poolK int) ([]model.SearchHit, error) {
+	fetchK := poolK
+	for round := 0; ; round++ {
+		raw, err := s.searchExpanded(ctx, query, fetchK)
+		if err != nil {
+			return nil, err
+		}
+		hits := s.expandHierarchical(ctx, query, raw, fetchK)
+		summaries := countSummaryHits(raw)
+		if !needSummaryRefill(len(hits), poolK, summaries, len(raw), fetchK, round) {
+			return hits, nil
+		}
+		fetchK = poolK + summaries
+		if fetchK > summaryRefillMaxPool {
+			fetchK = summaryRefillMaxPool
+		}
+	}
+}
+
+// needSummaryRefill reports whether another, wider retrieval round can still
+// recover result slots that dropped summary hits took (#686). It stops as soon
+// as the budget is met, no summary occupied a slot, the index has no more
+// candidates to give, the widened pool would not actually grow, or the round cap
+// is reached. The loop therefore always terminates.
+func needSummaryRefill(got, poolK, summaries, rawLen, fetchK, round int) bool {
+	if got >= poolK || summaries == 0 {
+		return false
+	}
+	if rawLen < fetchK {
+		// The index returned fewer candidates than it was asked for: it is
+		// exhausted, so a wider request cannot add anything.
+		return false
+	}
+	if round+1 >= summaryRefillMaxRounds {
+		return false
+	}
+	return poolK+summaries > fetchK && fetchK < summaryRefillMaxPool
+}
+
+// countSummaryHits reports how many `summary` candidates the pool holds. Every
+// one of them is a routing node that cannot reach the caller, so the count is
+// the number of result slots the widened pool must replace (#686).
+func countSummaryHits(hits []model.SearchHit) int {
+	n := 0
+	for _, hit := range hits {
+		if model.IsSummaryRepType(hit.RepType) {
+			n++
+		}
+	}
+	return n
+}
+
 // SetHierarchical toggles the opt-in coarse-to-fine expand step (SPEC §9.7).
 // Wired from config.RetrievalHierarchicalEnabled; default false keeps retrieval
 // on the flat path.

--- a/internal/retrieval/hierarchical_refill_686_test.go
+++ b/internal/retrieval/hierarchical_refill_686_test.go
@@ -26,7 +26,8 @@ func TestNeedSummaryRefill(t *testing.T) {
 		{"index exhausted", 1, 2, 1, 2, 3, 1, false},
 		{"round cap reached", 1, 2, 1, 3, 3, 2, false},
 		{"widened pool would not grow", 1, 2, 1, 3, 3, 1, false},
-		{"pool already at the cap", 1, 300, 5, summaryRefillMaxPool, summaryRefillMaxPool, 0, false},
+		{"margin already at the cap", 1, 10, summaryRefillMaxMargin + 5, 10 + summaryRefillMaxMargin, 10 + summaryRefillMaxMargin, 0, false},
+		{"a large k still refills", 1, 300, 4, 300, 300, 0, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -36,6 +37,22 @@ func TestNeedSummaryRefill(t *testing.T) {
 					tc.got, tc.poolK, tc.summaries, tc.rawLen, tc.fetchK, tc.round, got, tc.wantRefill)
 			}
 		})
+	}
+}
+
+// A refill round must never ask the index for LESS than the round it repairs,
+// so the cap sits on the extra margin and never on the caller's own pool.
+func TestSummaryRefillMarginNeverNarrowsThePool(t *testing.T) {
+	for _, poolK := range []int{1, 15, 50, 500} {
+		for _, summaries := range []int{0, 1, 7, summaryRefillMaxMargin + 100} {
+			fetchK := poolK + summaryRefillMargin(summaries)
+			if fetchK < poolK {
+				t.Fatalf("poolK=%d summaries=%d: widened pool %d is narrower than the caller's pool", poolK, summaries, fetchK)
+			}
+			if fetchK-poolK > summaryRefillMaxMargin {
+				t.Fatalf("poolK=%d summaries=%d: margin %d exceeds the cap %d", poolK, summaries, fetchK-poolK, summaryRefillMaxMargin)
+			}
+		}
 	}
 }
 

--- a/internal/retrieval/hierarchical_refill_686_test.go
+++ b/internal/retrieval/hierarchical_refill_686_test.go
@@ -1,0 +1,57 @@
+package retrieval
+
+import (
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// The refill loop of #686 re-queries the index, so its stop rule must be exact:
+// it has to keep going while dropped summary hits still cost the caller result
+// slots, and it has to stop on every other shape. This table pins each stop.
+func TestNeedSummaryRefill(t *testing.T) {
+	cases := []struct {
+		name       string
+		got        int
+		poolK      int
+		summaries  int
+		rawLen     int
+		fetchK     int
+		round      int
+		wantRefill bool
+	}{
+		{"flat pool with no summary", 5, 10, 0, 10, 10, 0, false},
+		{"budget already met", 10, 10, 2, 10, 10, 0, false},
+		{"summary took a slot", 1, 2, 1, 2, 2, 0, true},
+		{"index exhausted", 1, 2, 1, 2, 3, 1, false},
+		{"round cap reached", 1, 2, 1, 3, 3, 2, false},
+		{"widened pool would not grow", 1, 2, 1, 3, 3, 1, false},
+		{"pool already at the cap", 1, 300, 5, summaryRefillMaxPool, summaryRefillMaxPool, 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := needSummaryRefill(tc.got, tc.poolK, tc.summaries, tc.rawLen, tc.fetchK, tc.round)
+			if got != tc.wantRefill {
+				t.Fatalf("needSummaryRefill(got=%d poolK=%d summaries=%d rawLen=%d fetchK=%d round=%d) = %v, want %v",
+					tc.got, tc.poolK, tc.summaries, tc.rawLen, tc.fetchK, tc.round, got, tc.wantRefill)
+			}
+		})
+	}
+}
+
+// countSummaryHits is the number of result slots a pool loses to routing nodes,
+// so it must count every summary and only summaries.
+func TestCountSummaryHits(t *testing.T) {
+	pool := []model.SearchHit{
+		{ChunkID: 1, RepType: model.SummaryRepType},
+		{ChunkID: 2, RepType: "raw_text"},
+		{ChunkID: 3, RepType: model.SummaryRepType},
+		{ChunkID: 4, RepType: "transcript"},
+	}
+	if n := countSummaryHits(pool); n != 2 {
+		t.Fatalf("countSummaryHits = %d, want 2", n)
+	}
+	if n := countSummaryHits(nil); n != 0 {
+		t.Fatalf("countSummaryHits(nil) = %d, want 0", n)
+	}
+}

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -1254,17 +1254,20 @@ func (s *Service) search(ctx context.Context, query model.SearchQuery) ([]model.
 	// active it runs that pipeline once per query-language variant and RRF-fuses
 	// the result sets; when inactive it reduces to a single searchWithHyDE call,
 	// so the un-expanded path is unchanged.
-	hits, err := s.searchExpanded(ctx, query, poolK)
+	//
+	// Hierarchical (coarse-to-fine) retrieval (SPEC §9.7) runs inside this call:
+	// each `summary` candidate is replaced by the fine chunks its coverage names,
+	// deduped against the directly-retrieved hits, and the merged pool is
+	// reranked. It happens BEFORE decay / the floor / truncation so expanded
+	// children compete for top-k on equal terms. A `summary` that expands to
+	// nothing is dropped, so the wrapper re-retrieves a wider pool to refill the
+	// slot it took (#686). A pool with no summary candidates (every corpus with
+	// the feature off) makes exactly one retrieval call and returns unchanged, so
+	// the flat path is untouched.
+	hits, err := s.searchWithSummaryRefill(ctx, query, poolK)
 	if err != nil {
 		return nil, err
 	}
-	// Hierarchical (coarse-to-fine) retrieval (SPEC §9.7): replace each `summary`
-	// candidate with the fine chunks its coverage names, dedup against the
-	// directly-retrieved hits, and rerank the merged pool. It runs BEFORE decay /
-	// the floor / truncation so expanded children compete for top-k on equal
-	// terms. A pool with no summary candidates — every corpus with the feature
-	// off — returns unchanged, so the flat path is untouched.
-	hits = s.expandHierarchical(ctx, query, hits, poolK)
 	// Apply the opt-in recency time-decay just BEFORE the relevance floor: it
 	// re-scores each hit by its source-document age, so the floor compares the
 	// decayed score and newer content survives a tie. Config-only; default 0 ⇒

--- a/tests/retrieval/hierarchical_refill_686_test.go
+++ b/tests/retrieval/hierarchical_refill_686_test.go
@@ -1,0 +1,182 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
+)
+
+// Hierarchical result loss: dir2mcp #686, a correctness follow-up to #329.
+//
+// A `summary` is a routing device: SPEC §9.7 says it never reaches the caller.
+// The pipeline retrieved exactly the caller's `k` candidates and dropped the
+// summaries afterwards, so every dropped summary silently stole one result slot
+// from a real fine chunk. SPEC §9.7 also says that with the feature disabled
+// retrieval behaves EXACTLY as flat retrieval, which under-returning breaks.
+//
+// Every test here indexes MORE eligible fine chunks than `k`, so a correct
+// pipeline can always fill the caller's budget.
+
+// summaryPoolCorpus wires a vector-only service over four ranked candidates:
+//
+//	chunk 10 → cosine 1.00, a `summary` of report.md (the best coarse match)
+//	chunk 11 → cosine 0.80, a fine chunk of report.md
+//	chunk 12 → cosine 0.60, a fine chunk of other.md
+//	chunk 13 → cosine 0.40, a fine chunk of third.md
+//
+// With k=2 the caller must get two fine chunks: 11 and 12.
+func summaryPoolCorpus(t *testing.T, enabled bool, st *summaryExpandStore) *retrieval.Service {
+	t.Helper()
+	idx := index.NewHNSWIndex("")
+	addVecP(t, idx, 10, []float32{1, 0}, "docs/report.md", "md")
+	addVecP(t, idx, 11, []float32{0.80, 0.60}, "docs/report.md", "md")
+	addVecP(t, idx, 12, []float32{0.60, 0.80}, "docs/other.md", "md")
+	addVecP(t, idx, 13, []float32{0.40, 0.92}, "docs/third.md", "md")
+
+	svc := retrieval.NewService(st, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+		"mistral-embed": {1, 0},
+	}}, nil)
+	svc.SetHybridEnabled(false) // vector-only: deterministic ranking, no BM25 dependency
+	svc.SetChunkMetadata(10, model.SearchHit{
+		ChunkID: 10, RelPath: "docs/report.md", DocType: "md",
+		RepType: model.SummaryRepType, Snippet: "MODEL-GENERATED SUMMARY PROSE",
+	})
+	svc.SetChunkMetadata(11, model.SearchHit{
+		ChunkID: 11, RelPath: "docs/report.md", DocType: "md",
+		RepType: "raw_text", Snippet: "fine chunk one",
+	})
+	svc.SetChunkMetadata(12, model.SearchHit{
+		ChunkID: 12, RelPath: "docs/other.md", DocType: "md",
+		RepType: "raw_text", Snippet: "fine chunk two",
+	})
+	svc.SetChunkMetadata(13, model.SearchHit{
+		ChunkID: 13, RelPath: "docs/third.md", DocType: "md",
+		RepType: "raw_text", Snippet: "fine chunk three",
+	})
+	svc.SetHierarchical(enabled)
+	return svc
+}
+
+// assertFullBudget fails when the caller asked for k and the corpus holds k
+// eligible fine chunks, but fewer came back. The message reports the measured
+// loss so a regression states its size.
+func assertFullBudget(t *testing.T, hits []model.SearchHit, k int, what string) {
+	t.Helper()
+	assertNoSummaryHit(t, hits)
+	if len(hits) < k {
+		t.Fatalf("%s: asked for k=%d with %d eligible fine chunks indexed, got %d (ids %v): %d result slot(s) lost to dropped summary hits",
+			what, k, k, len(hits), hitIDs(hits), k-len(hits))
+	}
+}
+
+// TestSearch_Hierarchical_DisabledRefillsDroppedSummarySlots is the headline
+// case of #686. The feature is OFF, so SPEC §9.7 requires the result to match a
+// corpus that never had summary vectors: [11, 12]. Before the fix the summary
+// took the first of the two retrieved slots and search returned only [11].
+func TestSearch_Hierarchical_DisabledRefillsDroppedSummarySlots(t *testing.T) {
+	st := &summaryExpandStore{children: defaultChildren()}
+	svc := summaryPoolCorpus(t, false, st)
+
+	hits := searchHits(t, svc, 2)
+	assertFullBudget(t, hits, 2, "hierarchical disabled")
+	assertOrder(t, hitIDs(hits), []uint64{11, 12})
+	if st.calls != 0 {
+		t.Fatalf("expansion ran %d times with the feature disabled; it must be inert", st.calls)
+	}
+}
+
+// TestSearch_Hierarchical_DisabledMatchesCorpusWithoutSummaries states the same
+// requirement as an equivalence: the disabled result must equal the result of
+// the identical corpus with the summary vector removed.
+func TestSearch_Hierarchical_DisabledMatchesCorpusWithoutSummaries(t *testing.T) {
+	withSummary := hitIDs(searchHits(t, summaryPoolCorpus(t, false, &summaryExpandStore{children: defaultChildren()}), 2))
+
+	idx := index.NewHNSWIndex("")
+	addVecP(t, idx, 11, []float32{0.80, 0.60}, "docs/report.md", "md")
+	addVecP(t, idx, 12, []float32{0.60, 0.80}, "docs/other.md", "md")
+	addVecP(t, idx, 13, []float32{0.40, 0.92}, "docs/third.md", "md")
+	flat := retrieval.NewService(&summaryExpandStore{}, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+		"mistral-embed": {1, 0},
+	}}, nil)
+	flat.SetHybridEnabled(false)
+	flat.SetChunkMetadata(11, model.SearchHit{ChunkID: 11, RelPath: "docs/report.md", DocType: "md", RepType: "raw_text", Snippet: "fine chunk one"})
+	flat.SetChunkMetadata(12, model.SearchHit{ChunkID: 12, RelPath: "docs/other.md", DocType: "md", RepType: "raw_text", Snippet: "fine chunk two"})
+	flat.SetChunkMetadata(13, model.SearchHit{ChunkID: 13, RelPath: "docs/third.md", DocType: "md", RepType: "raw_text", Snippet: "fine chunk three"})
+
+	assertOrder(t, withSummary, hitIDs(searchHits(t, flat, 2)))
+}
+
+// TestSearch_Hierarchical_ExpansionErrorRefillsDroppedSlot pins the fail-open
+// contract of SPEC §9.7 at the budget level: an expansion that errors drops its
+// summary. The caller must still get the best available fine hits.
+func TestSearch_Hierarchical_ExpansionErrorRefillsDroppedSlot(t *testing.T) {
+	st := &summaryExpandStore{children: defaultChildren(), expandErr: errors.New("boom")}
+	svc := summaryPoolCorpus(t, true, st)
+
+	hits := searchHits(t, svc, 2)
+	assertFullBudget(t, hits, 2, "expansion error")
+	assertOrder(t, hitIDs(hits), []uint64{11, 12})
+}
+
+// TestSearch_Hierarchical_FilteredChildrenRefillDroppedSlot pins the third drop
+// path: expansion works, but the query filters remove every child, so the
+// summary contributes nothing. The freed slot must go to the next fine chunk.
+func TestSearch_Hierarchical_FilteredChildrenRefillDroppedSlot(t *testing.T) {
+	st := &summaryExpandStore{children: map[uint64][]model.ChunkMetadata{
+		// Every child sits under a path the caller excluded via path_prefix.
+		10: {
+			fineChunk(20, "archive/old.md", "out-of-scope child"),
+			fineChunk(21, "archive/older.md", "out-of-scope child"),
+		},
+	}}
+	svc := summaryPoolCorpus(t, true, st)
+
+	hits, err := svc.Search(context.Background(), model.SearchQuery{
+		Query: "quarterly results", K: 2, PathPrefix: "docs",
+	})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	assertFullBudget(t, hits, 2, "all children filtered out")
+	for _, h := range hits {
+		if h.RelPath == "archive/old.md" || h.RelPath == "archive/older.md" {
+			t.Fatalf("expanded child %d bypassed the path_prefix filter", h.ChunkID)
+		}
+	}
+	assertOrder(t, hitIDs(hits), []uint64{11, 12})
+	if st.calls == 0 {
+		t.Fatal("expansion capability was never consulted")
+	}
+}
+
+// TestSearch_Hierarchical_RefillStopsAtCorpusSize pins termination: when the
+// corpus simply holds fewer fine chunks than k, the refill must stop instead of
+// widening for ever, and it must return every fine chunk that does exist.
+func TestSearch_Hierarchical_RefillStopsAtCorpusSize(t *testing.T) {
+	idx := index.NewHNSWIndex("")
+	addVecP(t, idx, 10, []float32{1, 0}, "docs/report.md", "md")
+	addVecP(t, idx, 11, []float32{0.80, 0.60}, "docs/report.md", "md")
+
+	st := &summaryExpandStore{children: defaultChildren(), expandErr: errors.New("boom")}
+	svc := retrieval.NewService(st, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+		"mistral-embed": {1, 0},
+	}}, nil)
+	svc.SetHybridEnabled(false)
+	svc.SetChunkMetadata(10, model.SearchHit{
+		ChunkID: 10, RelPath: "docs/report.md", DocType: "md",
+		RepType: model.SummaryRepType, Snippet: "MODEL-GENERATED SUMMARY PROSE",
+	})
+	svc.SetChunkMetadata(11, model.SearchHit{
+		ChunkID: 11, RelPath: "docs/report.md", DocType: "md",
+		RepType: "raw_text", Snippet: "fine chunk one",
+	})
+	svc.SetHierarchical(true)
+
+	hits := searchHits(t, svc, 5)
+	assertNoSummaryHit(t, hits)
+	assertOrder(t, hitIDs(hits), []uint64{11})
+}


### PR DESCRIPTION
Closes #686.

## Problem

A `summary` chunk is a routing device. SPEC 9.7 says it never reaches the
caller. But `search()` asked the index for exactly the caller's pool size
(`poolK`), and only then dropped the summary candidates. Each dropped summary
took one result slot from a real fine chunk, and no code refilled it.

A summary is dropped in four cases:

1. hierarchical retrieval is off (the default),
2. the store cannot expand,
3. the expansion call fails,
4. the query filters remove every child.

This also broke the SPEC 9.7 rule that a disabled feature behaves **exactly** as
flat retrieval. A corpus that still holds summary vectors under-returned after
an operator turned the feature off.

## Measured loss

The new tests index one summary and three eligible fine chunks, then ask for
`k=2`. Each drop path was measured on `main` before any code change:

| Case | Before (main) | After | Slots lost |
|---|---|---|---|
| hierarchical disabled | 1 hit `[11]` | 2 hits `[11, 12]` | 1 of 2 |
| expansion returns an error | 1 hit `[11]` | 2 hits `[11, 12]` | 1 of 2 |
| every child filtered out | 1 hit `[11]` | 2 hits `[11, 12]` | 1 of 2 |
| disabled vs a corpus with no summary vector | not equal | equal | 1 of 2 |

The loss is **1 of the 2 requested slots, or 50 percent of the budget**, for
each dropped summary. In general the loss is one result per dropped summary in
the pool.

## Fix

`searchWithSummaryRefill` wraps retrieval plus the 9.7 expand step. When
dropped summaries left the pool short of the budget, it re-retrieves a wider
pool. The widened size is the caller's pool plus the number of summary
candidates the previous round saw. This mirrors the tombstone oversampling of
SPEC 6.6: ask for more, remove the ineligible candidates, keep the first `k`.

The refill runs **only** when the pool both holds a summary and came up short.
A corpus with no summary vectors makes exactly one retrieval call, so the flat
path is unchanged.

`needSummaryRefill` holds the stop rule, so the loop always terminates. It
stops when the budget is met, when no summary took a slot, when the index
returned fewer candidates than it was asked for, when the widened pool would
not grow, and at a round cap of 3.

## Cost

A refill round re-runs retrieval only. The HyDE hypothesis and the
cross-lingual query variants come from the expansion cache, so no extra
generation is paid. The round does re-embed the query text, so a corpus with
stale summary vectors pays up to two extra query embeddings on an affected
query. The extra margin a refill round adds is capped at 200 candidates, so a
corpus made almost entirely of summaries cannot turn one search into an index
scan. The cap sits on the margin and never on the pool, so a widened round
always asks for at least as many candidates as the round it repairs.

## SPEC

I read `dirstral-spec/docs/SPEC.md` sections 6.6, 9.1 and 9.7 before the change.
**No spec change is needed.** The SPEC does not pin the candidate pool size. It
pins the opposite of the current code:

- 9.7: "When disabled ... retrieval behaves **exactly** as flat retrieval"
- 6.6: retrieval already oversamples for tombstones, then returns "the first
  `k` remaining"

The fix restores behavior the SPEC already requires. It does not change ranking
semantics: order, dedup, rerank and the citation-faithfulness invariant are all
untouched.

## Tests

- `tests/retrieval/hierarchical_refill_686_test.go`: 5 black-box tests. Four of
  them **fail on `main`** with the loss numbers above. The fifth pins
  termination when the corpus holds fewer fine chunks than `k`.
- `internal/retrieval/hierarchical_refill_686_test.go`: a table test over every
  stop condition of `needSummaryRefill`, plus `countSummaryHits`.

`make check` passes, including `gocyclo -over 15`.

## Not done

- No refactor of the surrounding retrieval code. The change is scoped to #686.
- No per-search query-embedding cache. That would remove the extra embed call
  of a refill round, but it is a separate change to the embedding path.
- No `dir2mcp_stats` field for refill rounds. Summary coverage reporting is
  already deferred by SPEC 9.7.
