### PR TITLE
fix(reindex): commit the index before dropping the content-hash undo (#796)

### DIFF
--- a/internal/cli/reindex.go
+++ b/internal/cli/reindex.go
@@ -101,18 +101,40 @@ func (a *App) runReindex(ctx context.Context, global globalOptions, args []strin
 	}
 	// Resolve the content-hash snapshot while the store (meta.sqlite) is still
 	// open: discard it on a durable rebuild, restore it on any failure so the
-	// incremental gate survives an interrupted reindex (issue #418). The index
-	// files, by contrast, are committed/rolled back AFTER the store is closed so
-	// a persist-on-close cannot clobber a rolled-back index.
+	// incremental gate survives an interrupted reindex (issue #418). A failed
+	// rebuild still rolls the index files back AFTER the store is closed, so a
+	// persist-on-close cannot clobber the restored generation.
 	if reindexErr == nil {
+		// Commit the index files BEFORE dropping the hash snapshot (issue #796).
+		//
+		// The two artifacts are undo records for the two halves of one change:
+		// *.reindex-old undoes the index move, the snapshot undoes the cleared
+		// content-hash gate. A crash between them decides which half recovery
+		// sees, so the order decides which way the corpus is wrong.
+		//
+		// Dropping the snapshot first left this window: hashes already say
+		// "new", the index backup still says "roll me back". recoverInterrupted-
+		// Reindex adopts that backup, so the corpus serves the PREVIOUS index
+		// generation while its hashes assert the new content is already
+		// ingested. The gate then skips those documents on every later run, so
+		// nothing re-ingests them and nothing reports it.
+		//
+		// Committing first inverts the failure. A crash in the window leaves no
+		// index backup and a snapshot that still holds the old hashes, so
+		// recovery restores hashes that under-state the corpus. The next scan
+		// re-ingests work it did not strictly need to redo (the #764 direction)
+		// and converges on its own. Redundant work is recoverable; a gate set
+		// too far ahead is not.
+		//
+		// commit() only unlinks the moved-aside backups, so running it while the
+		// store is open is safe: a persist-on-close writes the live slot, never
+		// the backup slot.
+		staging.commit()
 		staging.discardContentHashBackup(ctx, a.stderr)
+		a.closeStoreWithLog(st)
 	} else {
 		staging.restoreContentHashes(ctx, a.stderr)
-	}
-	a.closeStoreWithLog(st)
-	if reindexErr == nil {
-		staging.commit()
-	} else {
+		a.closeStoreWithLog(st)
 		// Any non-success — a real error, ctx cancellation from Ctrl-C, or an
 		// unimplemented pipeline — means the rebuild is not durable, so put the
 		// previous index back (issue #418).

--- a/tests/cli/reindex_commit_order_796_test.go
+++ b/tests/cli/reindex_commit_order_796_test.go
@@ -1,0 +1,172 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/cli"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// Reindex commit order: dir2mcp #796.
+//
+// A reindex stages two undo records. `*.reindex-old` undoes the index move, and
+// the content_hash snapshot undoes the cleared incremental gate. A crash between
+// them decides which half the next run's recovery sees, so their ORDER decides
+// which way the corpus ends up wrong.
+//
+// The old order dropped the snapshot first. A crash in that window left hashes
+// that say "new" beside an index backup that says "roll me back", and
+// recoverInterruptedReindex adopts the backup. The corpus then serves the
+// PREVIOUS index generation while its own hashes assert that the new content is
+// already ingested, so the gate skips those documents on every later run.
+// Nothing re-ingests them and nothing reports it.
+//
+// Committing the index first inverts the failure: recovery restores hashes that
+// under-state the corpus, the next scan redoes work it did not need to, and the
+// corpus converges. Redundant work is recoverable. A gate set too far ahead is
+// not.
+
+// hashUndoOrderStore records the on-disk state at the moment the reindex drops
+// the content-hash snapshot. That is the observation the ordering rule is about:
+// once the snapshot is gone, an index backup still on disk is a live crash
+// window.
+type hashUndoOrderStore struct {
+	*store.SQLiteStore
+
+	stateDir string
+	// indexBackupsAtDiscard names the *.reindex-old files that still existed
+	// when DiscardContentHashBackup was called. It is nil when the discard
+	// never ran.
+	indexBackupsAtDiscard []string
+	discardCalls          int
+}
+
+func (s *hashUndoOrderStore) DiscardContentHashBackup(ctx context.Context) error {
+	s.discardCalls++
+	s.indexBackupsAtDiscard = indexBackupsIn(s.stateDir)
+	return s.SQLiteStore.DiscardContentHashBackup(ctx)
+}
+
+// seedIndexGeneration writes the index files a reindex moves aside, so the
+// staging window this file tests actually opens. The names come from the
+// package that owns them, so a rename cannot leave the test silently staging
+// nothing and passing.
+func seedIndexGeneration(t *testing.T, stateDir string) {
+	t.Helper()
+	for _, name := range []string{index.TextIndexFileName, index.CodeIndexFileName} {
+		if err := os.WriteFile(filepath.Join(stateDir, name), []byte("previous generation"), 0o600); err != nil {
+			t.Fatalf("seed index file %s: %v", name, err)
+		}
+	}
+}
+
+// indexBackupsIn lists the moved-aside index generations in a state directory.
+func indexBackupsIn(stateDir string) []string {
+	entries, err := os.ReadDir(stateDir)
+	if err != nil {
+		return nil
+	}
+	var found []string
+	for _, entry := range entries {
+		if name := entry.Name(); filepath.Ext(name) == ".reindex-old" {
+			found = append(found, name)
+		}
+	}
+	return found
+}
+
+// TestReindex_CommitsTheIndexBeforeDroppingTheHashUndo is the #796 contract. A
+// successful reindex must not drop the content-hash snapshot while an index
+// backup is still on disk, because that pair is exactly the state recovery
+// reads as "roll the index back, the hashes are already current".
+func TestReindex_CommitsTheIndexBeforeDroppingTheHashUndo(t *testing.T) {
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, ".dir2mcp")
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	const relPath = "docs/a.md"
+	seedDocumentHash(t, stateDir, relPath, "HASH-BEFORE-REINDEX")
+
+	// A previous index generation must exist, or nothing is moved aside and the
+	// window under test cannot open.
+	seedIndexGeneration(t, stateDir)
+
+	var recorder *hashUndoOrderStore
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIOAndHooks(&stdout, &stderr, cli.RuntimeHooks{
+		NewStore: func(cfg config.Config) model.Store {
+			recorder = &hashUndoOrderStore{
+				SQLiteStore: store.NewSQLiteStore(filepath.Join(cfg.StateDir, "meta.sqlite")),
+				stateDir:    cfg.StateDir,
+			}
+			return recorder
+		},
+		NewIngestor: func(_ config.Config, st model.Store) (model.Ingestor, error) {
+			return reindexRebuildingIngestor{st: st, relPath: relPath, newHash: "HASH-AFTER-REBUILD"}, nil
+		},
+	})
+
+	var code int
+	withWorkingDir(t, tmp, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		code = app.RunWithContext(ctx, []string{"reindex"})
+	})
+	if code != 0 {
+		t.Fatalf("reindex should succeed; got exit %d stderr=%q", code, stderr.String())
+	}
+	if recorder == nil || recorder.discardCalls == 0 {
+		t.Fatalf("the reindex never dropped the content-hash snapshot; the ordering window was not exercised (stderr=%q)", stderr.String())
+	}
+	if len(recorder.indexBackupsAtDiscard) != 0 {
+		t.Errorf("the content-hash snapshot was dropped while %v still existed: a crash in that window leaves recovery adopting the previous index generation over the new hashes, and the gate then skips those documents for ever (#796)",
+			recorder.indexBackupsAtDiscard)
+	}
+}
+
+// TestReindex_LeavesNoUndoRecordsAfterSuccess states the end condition the
+// ordering serves: a committed reindex owns both halves, so neither undo record
+// survives it. A leftover of either kind is a crash window that stayed open.
+func TestReindex_LeavesNoUndoRecordsAfterSuccess(t *testing.T) {
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, ".dir2mcp")
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	const relPath = "docs/a.md"
+	const rebuilt = "HASH-AFTER-REBUILD"
+	seedDocumentHash(t, stateDir, relPath, "HASH-BEFORE-REINDEX")
+	seedIndexGeneration(t, stateDir)
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIOAndHooks(&stdout, &stderr, cli.RuntimeHooks{
+		NewIngestor: func(_ config.Config, st model.Store) (model.Ingestor, error) {
+			return reindexRebuildingIngestor{st: st, relPath: relPath, newHash: rebuilt}, nil
+		},
+	})
+
+	var code int
+	withWorkingDir(t, tmp, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		code = app.RunWithContext(ctx, []string{"reindex"})
+	})
+	if code != 0 {
+		t.Fatalf("reindex should succeed; got exit %d stderr=%q", code, stderr.String())
+	}
+	if left := indexBackupsIn(stateDir); len(left) != 0 {
+		t.Errorf("a committed reindex left the index backup(s) %v behind; the next run's recovery would adopt them over the rebuilt corpus", left)
+	}
+	if got := readDocumentHash(t, stateDir, relPath); got != rebuilt {
+		t.Errorf("content_hash = %q, want the rebuild's %q", got, rebuilt)
+	}
+}


### PR DESCRIPTION
## The window

`reindex` stages two undo records:

- `*.reindex-old` undoes the index move.
- The `content_hash` snapshot undoes the cleared incremental gate.

A crash between them decides which half the next run's recovery sees. So their ORDER decides which way the corpus ends up wrong.

The old order dropped the snapshot first:

```go
staging.discardContentHashBackup(ctx, a.stderr)  // the hash undo is gone
a.closeStoreWithLog(st)
staging.commit()                                 // the index undo is still on disk
```

A crash in that window leaves hashes that say "new" beside an index backup that says "roll me back". `recoverInterruptedReindex` adopts the backup, so the corpus serves the PREVIOUS index generation while its own hashes assert that the new content is already ingested.

## Why that is the bad direction

The content hash is the gate that decides whether a document needs work. A document whose hash says "current" is skipped. So the affected documents are not re-ingested by the next `up` or the next incremental run. The corpus stays behind, and nothing reports it.

## The fix

Commit the index first, then drop the hash snapshot.

A crash in the window now leaves no index backup and a snapshot that still holds the OLD hashes. Recovery restores hashes that under-state the corpus, the next scan redoes work it did not strictly need to redo (the #764 direction), and the corpus converges on its own.

Redundant work is recoverable. A gate set too far ahead is not.

`commit()` only unlinks the moved-aside backups, so running it while the store is open is safe: a persist-on-close writes the live slot, never the backup slot. The failure path keeps its order, because `restoreContentHashes` needs the store open and the index rollback must still run after the close.

## Why no marker file

The issue suggested a durable commit marker with a three-state recovery, and it judged the third state to have no correct silent answer. Reading the code changed that conclusion. `commit()` does not install a new generation: it only deletes the old copy. `reindex` rebuilds the sqlite rows and leaves the vectors to the daemon's embed worker, so there is no half-written index generation to protect. Once the rebuild succeeds, the moved-aside files are stale by definition, and keeping them is what causes this bug. Ordering alone closes the window, so this ships without new on-disk state.

## Tests

`tests/cli/reindex_commit_order_796_test.go`, two cases:

- `TestReindex_CommitsTheIndexBeforeDroppingTheHashUndo` wraps the store and records which `*.reindex-old` files still exist at the moment the snapshot is dropped. That is the exact observation the rule is about.
- `TestReindex_LeavesNoUndoRecordsAfterSuccess` states the end condition: a committed reindex owns both halves, so neither undo record survives it.

Proven against main by the copy-aside method (no `git stash`):

```
--- FAIL: TestReindex_CommitsTheIndexBeforeDroppingTheHashUndo
    the content-hash snapshot was dropped while
    [vectors_code.v2.hnsw.reindex-old vectors_text.v2.hnsw.reindex-old]
    still existed
```

The index file names come from `internal/index`, so a rename cannot leave the test staging nothing and passing green.

## Spec

No spec change. The SPEC does not describe the reindex staging or recovery protocol: it has no mention of the backup suffix, the hash snapshot, or crash recovery for reindex. The submodule pin is unchanged.

`make check` passes.

Closes #796

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reindex recovery and cleanup to prevent stale index backups and preserve document hash data.
  * Ensured failed reindex operations restore content hashes and roll back index changes safely.
  * Corrected cleanup ordering to improve reliability when reindexing succeeds or fails.

* **Tests**
  * Added coverage for reindex recovery, backup cleanup, undo-record ordering, and persisted document hashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->