### PR TITLE
fix(ingest): scan the whole text and every derived text for secrets (#681)

### DIFF
--- a/internal/ingest/exclude.go
+++ b/internal/ingest/exclude.go
@@ -39,8 +39,14 @@ const secretScanSampleBytes int64 = 64 * 1024
 // The doc_type split is what keeps the cost proportionate: it never runs the
 // regex set over the bytes of a 10 MiB video, which no pattern could usefully
 // match anyway.
+//
+// One case sits between the two: a binary payload that classified into a
+// text-oriented doc_type, such as a .parquet reaching "data". #398 already
+// refuses to put such content on the raw-text path, so it is never chunked and
+// never indexed. It therefore takes the head sample too: a full scan of it would
+// be the whole cost of the change with none of the benefit.
 func secretScanBytes(docType string, content []byte) []byte {
-	if ShouldGenerateRawText(docType) {
+	if ShouldGenerateRawText(docType) && !looksLikeBinaryContent(content) {
 		return content
 	}
 	return contentSample(content)

--- a/internal/ingest/exclude.go
+++ b/internal/ingest/exclude.go
@@ -8,7 +8,43 @@ import (
 	"strings"
 )
 
+// secretScanSampleBytes is the head-sample budget for a source whose searchable
+// text is NOT its raw bytes: a PDF, an image, an office document, audio, video.
+// Scanning a container's compressed or encoded bytes past the head buys nothing,
+// because a credential inside such a file only becomes readable text after
+// extraction, OCR, or transcription. Those DERIVED texts are scanned in full
+// before they are persisted (see Service.screenDerivedSecrets), so the head
+// sample is a cheap early-out, not the security boundary.
+//
+// A source whose raw bytes ARE the searchable text (text, code, markdown, data,
+// html) is scanned in FULL instead; see secretScanBytes. #681: the head sample
+// used to be the only scan for every source, so a credential past 64 KiB was
+// indexed and reachable through `search`.
 const secretScanSampleBytes int64 = 64 * 1024
+
+// secretScanBytes returns the bytes of a source document that the ingest secret
+// policy scans, given the document's classified doc_type.
+//
+// The rule is "scan what becomes searchable":
+//
+//   - a raw-text doc_type (text/code/md/data/html) is chunked and embedded from
+//     these very bytes, so every byte is scanned. There is no offset past which
+//     a credential stops being indexed, so there must be none past which it
+//     stops being scanned.
+//   - every other doc_type reaches the index only through a derived text
+//     (extraction, OCR, transcription, annotation, recognition, a subtitle
+//     sidecar). Its raw bytes are a container, so only the head sample is
+//     scanned here and the derived text carries the full scan.
+//
+// The doc_type split is what keeps the cost proportionate: it never runs the
+// regex set over the bytes of a 10 MiB video, which no pattern could usefully
+// match anyway.
+func secretScanBytes(docType string, content []byte) []byte {
+	if ShouldGenerateRawText(docType) {
+		return content
+	}
+	return contentSample(content)
+}
 
 func compileSecretPatterns(patterns []string) ([]*regexp.Regexp, error) {
 	return CompileSecretPatterns(patterns)

--- a/internal/ingest/recognize.go
+++ b/internal/ingest/recognize.go
@@ -402,6 +402,15 @@ func (s *Service) generateRecognitionRepresentation(ctx context.Context, doc mod
 		return false, nil
 	}
 
+	// #681: recognition statements are text this daemon derives from the media and
+	// then indexes, so they are screened before persistence. The scan runs over the
+	// segment texts exactly as they will be chunked, not over hashInput, which
+	// interleaves length prefixes for a different purpose. On a match the document
+	// is already withheld, so this reports "nothing recognized".
+	if s.screenDerivedSecrets(ctx, doc, derivedKindRecognition, joinSegmentTexts(segments)) {
+		return false, nil
+	}
+
 	meta, err := json.Marshal(recognitionMeta{
 		Source:       recognizeSource,
 		Provider:     s.cfg.RecognizeProvider,

--- a/internal/ingest/secret_derived.go
+++ b/internal/ingest/secret_derived.go
@@ -1,0 +1,264 @@
+package ingest
+
+import (
+	"context"
+	"errors"
+	"os"
+	"regexp"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// Derived-text secret screening (dir2mcp #681).
+//
+// SPEC §7.2 applies security.secret_patterns to file CONTENTS, and §15.2 records
+// the outcome as the closed skip_reason `secret_excluded`. Ingest honored that
+// for one kind of content only: the raw bytes of the source file. A credential
+// that reaches the index through a DERIVED text was never tested against the
+// patterns at all, so it was chunked, embedded, and served by `search` and `ask`.
+//
+// Three ordinary corpora hit this:
+//
+//   - a scanned contract or a screenshot: the key is pixels in the source and
+//     plain text only after OCR;
+//   - a recorded standup or a support call: the key is audio in the source and
+//     plain text only after transcription;
+//   - a .docx or .pdf: the key is inside a compressed container in the source and
+//     plain text only after extraction.
+//
+// The same applies to a translated transcript, a recognition statement, a
+// subtitle sidecar's cues, and a stored annotation. Every one of them is text
+// this daemon creates and then makes searchable, so every one of them is scanned
+// here BEFORE it is persisted.
+//
+// The verdict is document-wide, not representation-wide. A document is a single
+// unit of disclosure: leaving its clean representations searchable next to a
+// withheld one would still let a caller pull the surrounding context of a
+// credential, and would report a partially indexed document as healthy. So the
+// first derived match withholds the whole document as `secret_excluded` and
+// retires anything this run already wrote for it.
+//
+// Nothing here logs, persists, or returns the matched text, the matching pattern,
+// or an offset. The operator learns WHICH document was withheld and that a
+// configured pattern matched; the payload never leaves the process.
+
+// Derived-text kinds, used only for the operator-facing log line and to name the
+// producer in review. They are diagnostic labels, not a persisted vocabulary:
+// SPEC §15.2 closes the skip_reasons enum, and every one of these withholds the
+// document under the SAME `secret_excluded` reason the raw-byte path uses.
+const (
+	derivedKindExtraction  = "extraction"
+	derivedKindTranscript  = "transcript"
+	derivedKindTranslation = "translation"
+	derivedKindRecognition = "recognition"
+	derivedKindSidecar     = "subtitle sidecar"
+)
+
+// ErrSecretExcluded reports that derived text was withheld because it matched a
+// configured security.secret_patterns entry. It carries no part of the text, the
+// pattern, or the offset, so it is safe to surface verbatim on a tool or
+// diagnostic surface. `dir2mcp_annotate` maps it to the canonical §14.2
+// FORBIDDEN ("path/content blocked by policy").
+var ErrSecretExcluded = errors.New("content withheld: it matched a configured security.secret_patterns entry")
+
+// beginDocumentSecretScope opens the per-document secret scope: it captures the
+// compiled pattern set the caller is using for the raw-byte scan and clears the
+// derived-match flag. Called at every document entry point so a document can
+// never inherit the previous document's verdict, and so the derived scan can
+// never run against a different pattern set than the source scan.
+func (s *Service) beginDocumentSecretScope(patterns []*regexp.Regexp) {
+	s.docSecretPatterns = patterns
+	s.secretExcludedThisDoc = false
+}
+
+// screenDerivedSecrets reports whether derived text must be withheld because it
+// matches a configured secret pattern. It returns false (the common case) when
+// no patterns are configured, the text is empty, or nothing matches, so a caller
+// reads as `if s.screenDerivedSecrets(...) { return }` and otherwise proceeds
+// exactly as before.
+//
+// A true return means the caller MUST NOT persist the representation, its chunks,
+// its title, or any other trace of the text. The document has already been
+// withheld by the time it returns.
+//
+// It is idempotent per document: several derived texts of one document (a
+// transcript plus its per-language translations) withhold it once.
+func (s *Service) screenDerivedSecrets(ctx context.Context, doc model.Document, kind, text string) bool {
+	if !s.derivedTextHasSecret(text) {
+		return false
+	}
+	s.withholdDocumentForSecret(ctx, doc, kind)
+	return true
+}
+
+// derivedTextHasSecret is the pure predicate behind screenDerivedSecrets: it
+// tests derived text against the document's active pattern set and does nothing
+// else. Use it where a match must refuse ONE output without withholding the whole
+// document; use screenDerivedSecrets everywhere the derived text belongs to the
+// document's own pipeline.
+func (s *Service) derivedTextHasSecret(text string) bool {
+	if text == "" || len(s.docSecretPatterns) == 0 {
+		return false
+	}
+	return hasSecretMatch([]byte(text), s.docSecretPatterns)
+}
+
+// withholdDocumentForSecret records the document as `secret_excluded` and takes
+// back anything this run already made searchable for it.
+//
+// Order matters. The representations are retired FIRST, so a crash between the
+// two steps leaves a document with no searchable chunks rather than a document
+// whose row says "withheld" while its chunks are still being served.
+//
+// The content_hash is taken from the caller's document value and is NOT rewritten
+// here, because the two callers need opposite things and each already holds the
+// right value:
+//
+//   - on the single-pass path the #402 done marker is still withheld (empty), so
+//     an ungraceful death before the finalize step leaves the document to be
+//     reprocessed rather than settled half-retired. processDocument stamps the
+//     marker afterwards through finalizeSecretExcluded.
+//   - on the two-phase derivation pass the marker was already stamped by the
+//     transcription pass, and it must STAY stamped: blanking it would send the
+//     next run's transcription pass through the full pipeline again, republish the
+//     clean transcript, and only withhold the document once the derivation pass
+//     caught up. The document would be searchable in between.
+//
+// The row's title and error_message are cleared deliberately. A title lifted from
+// a document that is being withheld is itself derived text from that document, and
+// error_message is a diagnostic surface (§15.6) that must carry nothing from it.
+func (s *Service) withholdDocumentForSecret(ctx context.Context, doc model.Document, kind string) {
+	if s.secretExcludedThisDoc {
+		return
+	}
+	s.secretExcludedThisDoc = true
+
+	// Content-free by construction: the document path, the producer label, and the
+	// fact that a configured pattern matched. No offset, no pattern, no payload.
+	s.getLogger().Printf(
+		"secret policy: withholding %s; its %s output matched a configured security.secret_patterns entry, so the document is recorded secret_excluded and is not searchable",
+		doc.RelPath, kind,
+	)
+
+	s.retireDocumentRepresentations(ctx, doc.RelPath)
+
+	doc.Status = "secret_excluded"
+	doc.SkipReason = model.SkipReasonSecretExcluded
+	doc.Title = ""
+	doc.ErrorMessage = ""
+	if err := s.store.UpsertDocument(ctx, doc); err != nil {
+		s.getLogger().Printf("secret policy: record secret_excluded for %s failed: %v", doc.RelPath, err)
+	}
+
+	s.creditSecretExcludedSkip(doc)
+}
+
+// creditSecretExcludedSkip accounts for a withheld document as the skip it now
+// is (issue #426). The document was built as "ok", so its indexed credit is
+// still pending and is dropped by the secretExcludedThisDoc branch in
+// processDocument; counting the skip here keeps scanned = indexed + skipped +
+// errors and emits the one file_skip event SPEC §3.2 ties to a terminal skip.
+//
+// Two cases are deliberately not counted, and both would otherwise push the
+// run's totals past its scanned count:
+//
+//   - an archive MEMBER. Members are never credited to the run's scanned/skipped
+//     counters at all; the container document accounts for the archive. This
+//     matches persistArchiveMemberSizeCapSkips, which persists a member's skip row
+//     without reporting it either.
+//   - the two-phase DERIVATION pass. scanPass counts the corpus on the first pass
+//     only, so the derivation pass already counted this asset as scanned once.
+//
+// Each case still writes its own `secret_excluded` row, so the honest-coverage
+// aggregate (§7.7 skip_reasons) reports it either way.
+func (s *Service) creditSecretExcludedSkip(doc model.Document) {
+	if doc.SourceType == "archive_member" || s.activePass == passDerivation {
+		return
+	}
+	s.addSkipped(1)
+	s.markActiveSkipped()
+	s.notifyDocumentSkip(doc)
+}
+
+// retireDocumentRepresentations tombstones every live representation of a
+// document together with its chunks, which is what removes them from retrieval
+// (§6.6: SQLite `deleted = 1` is the source of truth a vector hit is tested
+// against, so the vectors disappear from the running session and stay gone after
+// a restart).
+//
+// It reuses the #692 reconciliation store surface rather than adding a second
+// delete path. Each producer screens its own text BEFORE persisting it, so in the
+// ordinary case there is nothing to retire; this covers the document that had a
+// clean representation written earlier in the SAME run (a clean transcript
+// followed by a translation that carries the credential).
+//
+// Best-effort with a loud log, never fatal: a store that cannot retire must not
+// convert a withheld document into a failed run. The document row is still
+// recorded `secret_excluded` either way.
+func (s *Service) retireDocumentRepresentations(ctx context.Context, relPath string) {
+	lister, listOK := s.store.(activeRepresentationLister)
+	retirer, retireOK := s.store.(representationRetirer)
+	if !listOK || !retireOK {
+		s.getLogger().Printf(
+			"secret policy: store cannot retire representations for %s; verify no stale representation is left for it",
+			relPath,
+		)
+		return
+	}
+	reps, err := lister.ActiveRepresentations(ctx, relPath)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			s.getLogger().Printf("secret policy: list representations for %s failed: %v", relPath, err)
+		}
+		return
+	}
+	if len(reps) == 0 {
+		return
+	}
+	ids := make([]int64, 0, len(reps))
+	for _, rep := range reps {
+		ids = append(ids, rep.RepID)
+	}
+	if _, err := retirer.SoftDeleteRepresentations(ctx, relPath, ids); err != nil {
+		s.getLogger().Printf("secret policy: retire representations for %s failed: %v", relPath, err)
+	}
+}
+
+// carrySecretExclusion makes a DERIVED secret verdict stick across scans.
+//
+// The raw-byte verdict is reproducible: buildDocumentWithContent re-reads the
+// same bytes every run and re-reaches the same answer. A derived verdict is not.
+// It comes from OCR, STT, or extraction output that the incremental gate is
+// designed NOT to recompute for an unchanged file, so without this the next scan
+// would rebuild the document as "ok", write that status over the withheld row,
+// and then early-return on the unchanged-content gate. The document would be
+// reported as indexed while its representations stayed retired.
+//
+// The carry is conditional on the content being provably unchanged: the stored
+// row must be `secret_excluded` AND carry a settled (non-empty) content_hash that
+// equals the one just computed from the source. An edited file, or a `--force`
+// reindex (which clears the stored hash), therefore re-derives and decides again
+// from scratch, so a credential removed from a document lets it back into the
+// index. The title is cleared for the same reason it is cleared on the withhold
+// path: it is derived text from a withheld document.
+func carrySecretExclusion(doc *model.Document, existing model.Document) {
+	if doc.Status != "ok" || existing.Status != "secret_excluded" {
+		return
+	}
+	if existing.ContentHash == "" || existing.ContentHash != doc.ContentHash {
+		return
+	}
+	doc.Status = "secret_excluded"
+	doc.SkipReason = model.SkipReasonSecretExcluded
+	doc.Title = ""
+}
+
+// finalizeSecretExcluded stamps the withheld #402 done marker onto a document
+// that a derived text withheld, so an unchanged file settles instead of being
+// re-derived on every scan. It is the `secret_excluded` counterpart of
+// finalizeIfGenerated and inherits the #413 guard: the marker is stamped only if
+// the freshly re-read row is STILL `secret_excluded`, so a status another path
+// wrote out of band is never resurrected into a done state.
+func (s *Service) finalizeSecretExcluded(ctx context.Context, doc *model.Document, contentHash string) error {
+	return s.finalizeContentHashForStatus(ctx, doc, contentHash, "secret_excluded")
+}

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -357,6 +357,26 @@ type Service struct {
 	// even when a document produces several (transcript + per-language translations).
 	quarantinedThisDoc bool
 
+	// docSecretPatterns holds the compiled security.secret_patterns set for the
+	// document currently being processed. It is the SAME slice the caller passes
+	// down the raw-byte path, captured at the document entry points
+	// (processDocument / processDocumentFromContent) by beginDocumentSecretScope,
+	// so the source scan and the derived-text scan can never disagree about which
+	// patterns are active. It exists because the derived-text producers sit many
+	// frames below those entry points (OCR, pandoc, docling, STT, translation,
+	// annotation, recognition, sidecar) and threading one more argument through all
+	// of them would say nothing the existing per-document Service state does not
+	// already say: the scan loop is sequential, at most one asset is in flight.
+	docSecretPatterns []*regexp.Regexp
+
+	// secretExcludedThisDoc records that a DERIVED text of the document currently
+	// being processed matched a configured secret pattern (#681), so the document
+	// is withheld as status="secret_excluded" and must count as exactly one skip,
+	// never as indexed. Per-document state with the same lifetime and the same
+	// sequential-scan justification as quarantinedThisDoc; reset by
+	// beginDocumentSecretScope at each document entry point.
+	secretExcludedThisDoc bool
+
 	// reconcileOutputs arms the per-document output-set reconciliation (#692) for
 	// the scan currently running. It is set once per scan by
 	// beginOutputReconciliation, when the recorded pipeline output identity no
@@ -2138,6 +2158,11 @@ func (s *Service) processDocument(ctx context.Context, f DiscoveredFile, secretP
 	// sequential archive members, which run as separate processDocumentFromContent
 	// calls under a single processDocument entry.
 	s.quarantinedThisDoc = false
+	// Open the per-document secret scope (#681) at the same authoritative point,
+	// and before any branch below can produce a derived text. It captures the
+	// pattern set this call was given, so the derived-text scan always uses the
+	// same patterns as the raw-byte scan in buildDocumentWithContent.
+	s.beginDocumentSecretScope(secretPatterns)
 
 	// Two-phase derivation pass (SPEC §8.6.11): the transcription pass already did
 	// all document building, upserting, counting, and source-transcript work for
@@ -2169,6 +2194,12 @@ func (s *Service) processDocument(ctx context.Context, f DiscoveredFile, secretP
 	if isUnexpectedStoreErr(err) {
 		return fmt.Errorf("get existing document: %w", err)
 	}
+
+	// #681: a secret found in DERIVED text is not reproducible from the source
+	// bytes, so the verdict is carried on the row rather than recomputed. Applied
+	// before the gate and the upsert so an unchanged withheld document stays
+	// withheld instead of being written back as "ok".
+	carrySecretExclusion(&doc, existingDoc)
 
 	needsProcessing := s.resolveNeedsProcessing(ctx, existingDoc, doc, forceReindex)
 	finalContentHash, willGenerateReps := withholdContentHash(&doc, needsProcessing)
@@ -2225,12 +2256,37 @@ func (s *Service) processDocument(ctx context.Context, f DiscoveredFile, secretP
 		_ = s.store.UpsertDocument(ctx, doc)
 		return fmt.Errorf("generate representations: %w", err)
 	}
-	// Representations committed: derive the optional document-level `summary`
-	// representation over them (SPEC §5.2/§9.7). It runs AFTER the fine chunks are
-	// written (it summarizes them) and is fail-open by construction — it never
-	// returns an error, so an absent summary leaves the document fully indexed and
+	// #681: a derived text of this document matched a configured secret pattern, so
+	// the document was withheld as secret_excluded and its representations were
+	// retired. Return before the summary step, which would summarize the very text
+	// that is being withheld, and before the "ok" finalize, which the #413 guard
+	// would refuse anyway. The skip is already counted, so the pending indexed
+	// credit is simply never taken.
+	if s.secretExcludedThisDoc {
+		return s.finalizeSecretExcluded(ctx, &doc, finalContentHash)
+	}
+	return s.settleProcessedDocument(ctx, &doc, willGenerateReps, finalContentHash, nonFatalErrored, indexedPending)
+}
+
+// settleProcessedDocument runs the post-generation steps for a document whose
+// representations committed: the optional document-level summary, the #692 output
+// reconciliation, the #402 done-marker stamp, and the #426 indexed credit. Split
+// out of processDocument so that function stays within the cyclomatic-complexity
+// budget; the order of the steps is unchanged and is load-bearing (see the
+// comments on each step).
+func (s *Service) settleProcessedDocument(
+	ctx context.Context,
+	doc *model.Document,
+	willGenerateReps bool,
+	finalContentHash string,
+	nonFatalErrored, indexedPending bool,
+) error {
+	// Derive the optional document-level `summary` representation over the
+	// committed chunks (SPEC §5.2/§9.7). It runs AFTER the fine chunks are written
+	// (it summarizes them) and is fail-open by construction: it never returns an
+	// error, so an absent summary leaves the document fully indexed and
 	// flat-retrievable, and the next scan retries.
-	s.GenerateDocumentSummaries(ctx, doc)
+	s.GenerateDocumentSummaries(ctx, *doc)
 	// Every output this pipeline produces for the document has now committed, so
 	// it is safe to retire the ones it no longer produces (#692). Running the
 	// reconciliation AFTER the generation pass is what guarantees a representation
@@ -2243,7 +2299,7 @@ func (s *Service) processDocument(ctx context.Context, f DiscoveredFile, secretP
 	// chunks are durably written. finalizeContentHash re-reads the row, so a
 	// document a soft-error path persisted as status="error" is left unmarked and
 	// retried next run rather than recorded as fully indexed.
-	if err := s.finalizeIfGenerated(ctx, &doc, willGenerateReps, finalContentHash); err != nil {
+	if err := s.finalizeIfGenerated(ctx, doc, willGenerateReps, finalContentHash); err != nil {
 		return err
 	}
 	if s.suppressIndexedCredit(nonFatalErrored) {
@@ -2421,8 +2477,12 @@ func (s *Service) creditIndexed(indexed bool) {
 // provider failure) returned by generateRepresentations; (2) quarantinedThisDoc —
 // an output quality gate (§8.6.6) that rejected a generated OCR/transcript/
 // translation output. Either way the document counts solely as an error.
+// (3) secretExcludedThisDoc: a derived text matched a configured secret pattern
+// (#681), so the document was withheld and counted as a skip. processDocument
+// returns before this on that path, so the guard here is a belt-and-braces
+// statement of the same rule for any future caller.
 func (s *Service) suppressIndexedCredit(nonFatalErrored bool) bool {
-	return nonFatalErrored || s.quarantinedThisDoc
+	return nonFatalErrored || s.quarantinedThisDoc || s.secretExcludedThisDoc
 }
 
 // deriveDocument runs the derivation pass for a single asset under the two-phase
@@ -2919,19 +2979,25 @@ func (s *Service) retainArchiveMembers(ctx context.Context, archiveRelPath strin
 	}
 }
 
-// processDocumentFromContent ingests a document whose content is already in
-// memory (e.g. an archive member). relPath is the virtual path stored in the
-// documents table; mtimeUnix is inherited from the parent archive.
-func (s *Service) processDocumentFromContent(ctx context.Context, relPath string, content []byte, mtimeUnix int64, secretPatterns []*regexp.Regexp, forceReindex bool) error {
-	docType := ClassifyDocType(relPath)
-	// Never ingest binary or ignored artifacts from inside archives.
-	if docType == "binary_ignored" || docType == "ignore" {
-		return nil
-	}
-	// Nested archive files are persisted as skipped document rows, but are not
-	// recursively extracted.
-	skipExtraction := docType == "archive"
-
+// buildArchiveMemberDocument assembles the document row for one extracted
+// archive member and applies the two terminal statuses decided from the member's
+// own bytes: a nested archive is a `skipped` container, and a member whose
+// scanned bytes match a configured secret pattern is `secret_excluded`.
+//
+// The scan target follows the same "scan what becomes searchable" rule as the
+// top-level path (secretScanBytes): a member whose raw bytes are its indexable
+// text is scanned in full, and a member that reaches the index through a derived
+// text is head-sampled here and scanned in full when that text is produced.
+//
+// Split out of processDocumentFromContent to keep that function within the
+// cyclomatic-complexity budget.
+func buildArchiveMemberDocument(
+	relPath, docType string,
+	content []byte,
+	mtimeUnix int64,
+	skipExtraction bool,
+	secretPatterns []*regexp.Regexp,
+) model.Document {
 	doc := model.Document{
 		RelPath:     relPath,
 		DocType:     docType,
@@ -2944,17 +3010,42 @@ func (s *Service) processDocumentFromContent(ctx context.Context, relPath string
 	if skipExtraction {
 		doc.Status = "skipped"
 		doc.SkipReason = skipReasonForDocType(docType)
+		return doc
 	}
-
-	if !skipExtraction && hasSecretMatch(contentSample(content), secretPatterns) {
+	if hasSecretMatch(secretScanBytes(docType, content), secretPatterns) {
 		doc.Status = "secret_excluded"
 		doc.SkipReason = model.SkipReasonSecretExcluded
 	}
+	return doc
+}
+
+// processDocumentFromContent ingests a document whose content is already in
+// memory (e.g. an archive member). relPath is the virtual path stored in the
+// documents table; mtimeUnix is inherited from the parent archive.
+func (s *Service) processDocumentFromContent(ctx context.Context, relPath string, content []byte, mtimeUnix int64, secretPatterns []*regexp.Regexp, forceReindex bool) error {
+	// Each archive member is an independent document, so it opens its own
+	// per-document secret scope (#681) even though the members of one archive run
+	// under a single processDocument entry.
+	s.beginDocumentSecretScope(secretPatterns)
+	docType := ClassifyDocType(relPath)
+	// Never ingest binary or ignored artifacts from inside archives.
+	if docType == "binary_ignored" || docType == "ignore" {
+		return nil
+	}
+	// Nested archive files are persisted as skipped document rows, but are not
+	// recursively extracted.
+	skipExtraction := docType == "archive"
+
+	doc := buildArchiveMemberDocument(relPath, docType, content, mtimeUnix, skipExtraction, secretPatterns)
 
 	existingDoc, err := s.store.GetDocumentByPath(ctx, relPath)
 	if err != nil && !isNotFoundError(err) {
 		return fmt.Errorf("get existing document: %w", err)
 	}
+	// #681: same carry as the top-level path, for the same reason. A member
+	// withheld for a secret in its DERIVED text must not be written back as "ok"
+	// when the container is re-extracted with the member's bytes unchanged.
+	carrySecretExclusion(&doc, existingDoc)
 	needsProcessing := s.resolveNeedsProcessing(ctx, existingDoc, doc, forceReindex)
 
 	// Withhold the content_hash done marker until representations commit so an
@@ -2985,6 +3076,12 @@ func (s *Service) processDocumentFromContent(ctx context.Context, relPath string
 		doc.ErrorMessage = RedactSecretsInMessage(err.Error(), secretPatterns)
 		_ = s.store.UpsertDocument(ctx, doc)
 		return fmt.Errorf("generate representations: %w", err)
+	}
+	// #681: a derived text of this member matched a configured secret pattern, so
+	// it is withheld as secret_excluded. Settle it under that status instead of the
+	// "ok" one, which the #413 guard would refuse.
+	if s.secretExcludedThisDoc {
+		return s.finalizeSecretExcluded(ctx, &doc, finalContentHash)
 	}
 	// Stamp the withheld #402 done marker now the archive member's reps commit.
 	if err := s.finalizeIfGenerated(ctx, &doc, willGenerateReps, finalContentHash); err != nil {
@@ -3040,7 +3137,7 @@ func (s *Service) buildDocumentWithContent(ctx context.Context, f DiscoveredFile
 		return doc, content, nil
 	}
 
-	if hasSecretMatch(contentSample(content), secretPatterns) {
+	if hasSecretMatch(secretScanBytes(docType, content), secretPatterns) {
 		doc.Status = "secret_excluded"
 		doc.SkipReason = model.SkipReasonSecretExcluded
 	}
@@ -4103,6 +4200,13 @@ func (s *Service) generateOCRMarkdownRepresentation(ctx context.Context, doc mod
 		return nil
 	}
 
+	// #681: screen the extracted text BEFORE the title heuristic and before any
+	// persistence. A credential that is only pixels in the source PDF or image is
+	// plain text here, and this is the first point at which it could be indexed.
+	if s.screenDerivedSecrets(ctx, doc, derivedKindExtraction, ocrText) {
+		return nil
+	}
+
 	s.persistTitleIfFound(ctx, doc, ocrText)
 
 	decision := s.screenOutputQuality(ctx, doc, qualityKindOCR, ocrText, quality.Context{
@@ -4140,6 +4244,12 @@ func (s *Service) generateOCRMarkdownRepresentation(ctx context.Context, doc mod
 func (s *Service) persistStructuredRepresentation(ctx context.Context, doc model.Document, res StructuredExtraction) error {
 	md := strings.TrimSpace(res.Markdown)
 	if md == "" {
+		return nil
+	}
+
+	// #681: the rendered Markdown is the text this document will be searched by, so
+	// it is screened before the title and before any persistence.
+	if s.screenDerivedSecrets(ctx, doc, derivedKindExtraction, md) {
 		return nil
 	}
 
@@ -4311,6 +4421,13 @@ func (s *Service) generatePandocMarkdownRepresentation(ctx context.Context, doc 
 	}
 	md = strings.TrimSpace(md)
 	if md == "" {
+		return nil
+	}
+
+	// #681: pandoc converts a container format (docx, epub, odt) into the text this
+	// document will be searched by, so it is screened before the title and before
+	// any persistence.
+	if s.screenDerivedSecrets(ctx, doc, derivedKindExtraction, md) {
 		return nil
 	}
 
@@ -4690,6 +4807,26 @@ func (s *Service) generateSelectedTrackTranscripts(ctx context.Context, doc mode
 	return producedAny, nil
 }
 
+// shiftSegmentsForLeadingSilence applies the optional leading-silence trim
+// (dir2mcp#258) to a transcript's time spans and returns the offset it used, in
+// milliseconds. It returns 0, leaving the spans untouched, when the trim is
+// disabled, when ffmpeg is absent, or when no dead air was detected. The caller
+// reuses the returned offset for the translated transcripts of the same track so
+// source and translated time windows stay aligned. Split out of
+// transcribeAndPersistTrack to keep it within the complexity budget.
+func (s *Service) shiftSegmentsForLeadingSilence(ctx context.Context, doc model.Document, segments []chunkSegment) int {
+	if !s.cfg.MediaTrimLeadingSilence {
+		return 0
+	}
+	offset := s.detectLeadingSilence(ctx, doc)
+	if offset <= 0 {
+		return 0
+	}
+	trimOffsetMS := int(offset.Milliseconds())
+	shiftTranscriptSpans(segments, trimOffsetMS)
+	return trimOffsetMS
+}
+
 // transcribeAndPersistTrack transcribes ONE selected audio track and persists its
 // source transcript representation (plus, in single-pass mode, its translations).
 // It returns (produced, gateRejected, err): produced is true when a representation
@@ -4715,6 +4852,15 @@ func (s *Service) transcribeAndPersistTrack(ctx context.Context, doc model.Docum
 
 	transcriptText = strings.TrimSpace(transcriptText)
 	if transcriptText == "" {
+		return false, false, nil
+	}
+
+	// #681: a credential spoken on a call, or read out in a screen share, is audio
+	// in the source file and plain text only here. Screen it before the quality
+	// gate and before any persistence. The document is already withheld on return,
+	// so this reports "no transcript produced" without a soft error: the run must
+	// not also count the withheld document as an error.
+	if s.screenDerivedSecrets(ctx, doc, derivedKindTranscript, transcriptText) {
 		return false, false, nil
 	}
 
@@ -4780,13 +4926,7 @@ func (s *Service) transcribeAndPersistTrack(ctx context.Context, doc model.Docum
 	// untouched; ffmpeg absent / detection failure -> 0 offset -> no change. The
 	// offset is captured so the SAME shift is applied to any translated
 	// transcripts below, keeping source/translated time windows aligned.
-	trimOffsetMS := 0
-	if s.cfg.MediaTrimLeadingSilence {
-		if offset := s.detectLeadingSilence(ctx, doc); offset > 0 {
-			trimOffsetMS = int(offset.Milliseconds())
-			shiftTranscriptSpans(segments, trimOffsetMS)
-		}
-	}
+	trimOffsetMS := s.shiftSegmentsForLeadingSilence(ctx, doc, segments)
 	if err := s.repGen.upsertChunksForRepresentation(ctx, repID, "text", segments, decision); err != nil {
 		return false, false, fmt.Errorf("persist transcript chunks: %w", err)
 	}
@@ -5109,6 +5249,13 @@ func (s *Service) translateOneTranscript(ctx context.Context, doc model.Document
 		return nil
 	}
 
+	// #681: a translation is model output over the transcript, and a credential
+	// survives translation verbatim. Screen it before the quality gate and before
+	// any persistence.
+	if s.screenDerivedSecrets(ctx, doc, derivedKindTranslation, translated) {
+		return nil
+	}
+
 	// A translated transcript is model output, so it routes through the output
 	// quality gate exactly like an STT transcript (anti-hallucination). The
 	// expected language is the TARGET language: the gate's language detector
@@ -5200,6 +5347,51 @@ func (s *Service) GenerateTranscriptRepresentation(ctx context.Context, doc mode
 	return err
 }
 
+// annotationPreview bounds the flattened annotation text returned to the caller
+// as a preview, cutting on a rune boundary so a multi-byte character is never
+// split.
+func annotationPreview(flattened string) string {
+	const maxPreviewRunes = 240
+	if runes := []rune(flattened); len(runes) > maxPreviewRunes {
+		return string(runes[:maxPreviewRunes]) + "..."
+	}
+	return flattened
+}
+
+// screenAnnotationForSecrets refuses an annotation whose JSON or flattened text
+// matches a configured secret pattern (#681). Both forms are chunked and
+// embedded, so both are screened before the persisting transaction opens. The
+// JSON text contains the flattened text's values, but it is screened in its own
+// right because it carries the keys and structure too, and because it is indexed
+// even when indexFlattenedText is false.
+//
+// Two things differ from the ingest producers. First, this is a standalone MCP
+// entry point (`dir2mcp_annotate`), not a step in a scan, so it opens its own
+// per-document secret scope from configuration. Second, it REFUSES the annotation
+// without withholding the source document: the annotation is model output ABOUT
+// an already-scanned document, so a match here says the model wrote a credential
+// shape, not that the corpus file holds one. Retiring a healthy document's
+// representations on that evidence would be wrong.
+//
+// The refusal is an error, not an empty preview: this tool otherwise answers
+// "stored": true and echoes the annotation back to the caller. The returned
+// sentinel and its message carry no part of the matched text.
+func (s *Service) screenAnnotationForSecrets(doc model.Document, jsonText, flattened string) error {
+	patterns, err := compileSecretPatterns(s.cfg.SecretPatterns)
+	if err != nil {
+		return fmt.Errorf("compile secret patterns: %w", err)
+	}
+	s.beginDocumentSecretScope(patterns)
+	if !s.derivedTextHasSecret(jsonText) && !s.derivedTextHasSecret(flattened) {
+		return nil
+	}
+	s.getLogger().Printf(
+		"secret policy: refusing to store the annotation for %s; it matched a configured security.secret_patterns entry",
+		doc.RelPath,
+	)
+	return ErrSecretExcluded
+}
+
 // StoreAnnotationRepresentations persists a structured annotation JSON payload
 // for a document and optionally stores a flattened text representation to make
 // annotation fields retrievable through semantic search.
@@ -5222,10 +5414,11 @@ func (s *Service) StoreAnnotationRepresentations(ctx context.Context, doc model.
 
 	flattened := s.flattenJSONForIndexing(annotation)
 	trimmed := strings.TrimSpace(flattened)
-	preview := flattened
-	if runes := []rune(preview); len(runes) > 240 {
-		preview = string(runes[:240]) + "..."
+
+	if err := s.screenAnnotationForSecrets(doc, jsonText, trimmed); err != nil {
+		return "", err
 	}
+	preview := annotationPreview(flattened)
 
 	err = s.repGen.store.WithTx(ctx, func(tx model.RepresentationStore) error {
 		jsonRep := model.Representation{

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -3761,6 +3761,13 @@ func (s *Service) generateRepresentations(ctx context.Context, doc model.Documen
 	if err != nil {
 		return false, err
 	}
+	// #681: the extracted text was withheld, so the document is already terminal.
+	// Stop before the transcript and recognition steps, and report no soft error:
+	// the caller settles it as secret_excluded, and a document counted as a skip
+	// must not also be counted as an error.
+	if s.secretExcludedThisDoc {
+		return false, nil
+	}
 	if nonFatalErrored {
 		// #394/#584: the extractor degraded an unsupported format and already
 		// recorded it — as status="error" (strict) or a durable status="skipped"
@@ -3780,6 +3787,14 @@ func (s *Service) generateRepresentations(ctx context.Context, doc model.Documen
 		if err != nil {
 			return nonFatalErrored, err
 		}
+	}
+	// #681: the transcript or the sidecar was withheld. Without this the media would
+	// fall into the "#398/#495 no representation produced" verdict below and be
+	// stamped status="error", which would overwrite the secret_excluded row and
+	// count the same document as both a skip and an error. A withheld document is
+	// unsearchable by DESIGN, not by failure, so it is neither.
+	if s.secretExcludedThisDoc {
+		return false, nil
 	}
 
 	return s.recognizeAndFinalizeMedia(ctx, doc, secretPatterns, noVideoRep, nonFatalErrored)
@@ -3813,6 +3828,12 @@ func (s *Service) recognizeAndFinalizeMedia(ctx context.Context, doc model.Docum
 	recognized, err := s.generateRecognitionRepresentation(ctx, doc)
 	if err != nil {
 		return transcriptSoftFailed, err
+	}
+	// #681: recognition itself was withheld, so the document is terminal. Same
+	// reasoning as the transcript guard: a withheld document must not also be
+	// branded an unsearchable-video error.
+	if s.secretExcludedThisDoc {
+		return false, nil
 	}
 	if noVideoRep && !recognized {
 		// Only now is the verdict final: no sidecar, no derived transcript, no
@@ -3912,6 +3933,13 @@ func (s *Service) generateTranscriptOrSidecar(ctx context.Context, doc model.Doc
 			return false, false, err
 		}
 		if ingested {
+			return false, false, nil
+		}
+		// #681: the sidecar's cues matched a configured secret pattern, so nothing
+		// was ingested AND the document is now withheld. Stop here rather than fall
+		// through to STT, which would transcribe the same media and could brand the
+		// withheld document with a provider error.
+		if s.secretExcludedThisDoc {
 			return false, false, nil
 		}
 	} else if err := s.retireStaleSidecarTranscripts(ctx, doc); err != nil {

--- a/internal/ingest/sidecar.go
+++ b/internal/ingest/sidecar.go
@@ -371,22 +371,43 @@ func (s *Service) ingestSidecarTranscripts(ctx context.Context, doc model.Docume
 	// applyCueCleaningToSegments call builds a fresh collapser, so one language's
 	// trailing cue can never start a run in the next.
 	cleanOpts := s.captionCleanOptions()
-	ingested := false
+
+	// Chunk every language BEFORE persisting any of them, so the #681 secret screen
+	// below sees the whole document's sidecar text at once. Screening per language
+	// inside the persist loop would let a clean first language commit (and count a
+	// representation) before a later language withheld the document and retired it
+	// again, which would leave the run's representation counter describing a
+	// representation that no longer exists.
+	perLang := make(map[string][]chunkSegment, len(langs))
+	var allText strings.Builder
 	for _, lang := range langs {
 		segments := chunkSubtitleCuesFiltered(groups[lang], s.captionWordFilter())
 		segments = applyCueCleaningToSegments(segments, cleanOpts)
 		if len(segments) == 0 {
 			continue
 		}
+		perLang[lang] = segments
+		if allText.Len() > 0 {
+			allText.WriteByte('\n')
+		}
+		allText.WriteString(joinSegmentTexts(segments))
+	}
+	// #681: a sidecar becomes the media document's searchable transcript, so its
+	// cue text is screened exactly like an STT transcript, over the cleaned strings
+	// that are chunked and embedded. On a match the document is already withheld
+	// and nothing below runs.
+	if s.screenDerivedSecrets(ctx, doc, derivedKindSidecar, allText.String()) {
+		return false, nil
+	}
+
+	ingested := false
+	for _, lang := range langs {
+		segments, ok := perLang[lang]
+		if !ok {
+			continue
+		}
 		if err := s.persistSidecarTranscript(ctx, doc, lang, groups[lang], segments); err != nil {
 			return ingested, err
-		}
-		// #681: this language's cues matched a configured secret pattern, so nothing
-		// was persisted and the whole document is now withheld. Stop before counting
-		// a representation that does not exist, and do not read the remaining
-		// languages: the document is already terminal.
-		if s.secretExcludedThisDoc {
-			return ingested, nil
 		}
 		s.addRepresentations(1)
 		ingested = true
@@ -464,15 +485,6 @@ func (s *Service) persistSidecarTranscript(ctx context.Context, doc model.Docume
 	// the same value (no padded/non-canonical language stored alongside a trimmed
 	// provenance decision).
 	lang = strings.TrimSpace(lang)
-
-	// #681: a subtitle sidecar becomes the media document's searchable transcript,
-	// so its cue text is screened before persistence exactly like an STT
-	// transcript. The scan runs over the cleaned segment texts, which are the
-	// strings that are chunked and embedded.
-	if s.screenDerivedSecrets(ctx, doc, derivedKindSidecar, joinSegmentTexts(segments)) {
-		return nil
-	}
-
 	meta := transcriptMeta{Source: sidecarSource, Language: lang, Timestamps: true}
 	// A sidecar's language is asserted by the source itself — the filename suffix
 	// (clip.en.vtt §8.6.4) or a TTML xml:lang — so its provenance is "declared"

--- a/internal/ingest/sidecar.go
+++ b/internal/ingest/sidecar.go
@@ -381,6 +381,13 @@ func (s *Service) ingestSidecarTranscripts(ctx context.Context, doc model.Docume
 		if err := s.persistSidecarTranscript(ctx, doc, lang, groups[lang], segments); err != nil {
 			return ingested, err
 		}
+		// #681: this language's cues matched a configured secret pattern, so nothing
+		// was persisted and the whole document is now withheld. Stop before counting
+		// a representation that does not exist, and do not read the remaining
+		// languages: the document is already terminal.
+		if s.secretExcludedThisDoc {
+			return ingested, nil
+		}
 		s.addRepresentations(1)
 		ingested = true
 	}

--- a/internal/ingest/sidecar.go
+++ b/internal/ingest/sidecar.go
@@ -457,6 +457,15 @@ func (s *Service) persistSidecarTranscript(ctx context.Context, doc model.Docume
 	// the same value (no padded/non-canonical language stored alongside a trimmed
 	// provenance decision).
 	lang = strings.TrimSpace(lang)
+
+	// #681: a subtitle sidecar becomes the media document's searchable transcript,
+	// so its cue text is screened before persistence exactly like an STT
+	// transcript. The scan runs over the cleaned segment texts, which are the
+	// strings that are chunked and embedded.
+	if s.screenDerivedSecrets(ctx, doc, derivedKindSidecar, joinSegmentTexts(segments)) {
+		return nil
+	}
+
 	meta := transcriptMeta{Source: sidecarSource, Language: lang, Timestamps: true}
 	// A sidecar's language is asserted by the source itself — the filename suffix
 	// (clip.en.vtt §8.6.4) or a TTML xml:lang — so its provenance is "declared"

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1565,6 +1565,18 @@ func (s *Server) handleAnnotateTool(ctx context.Context, args map[string]interfa
 		return toolCallResult{}, &toolExecutionError{Code: "CONFIG_INVALID", Message: err.Error(), Retryable: false}
 	}
 	preview, persistErr := ing.StoreAnnotationRepresentations(ctx, doc, annotationObj, indexFlattenedText)
+	if errors.Is(persistErr, ingest.ErrSecretExcluded) {
+		// #681: the generated annotation matched a configured
+		// security.secret_patterns entry. It was not stored, and it is NOT echoed
+		// back in the result either. Answering FORBIDDEN with the sentinel's own
+		// content-free message is what §15.4's "tool-level bypass of ingestion
+		// filters is impossible" means on this surface.
+		return toolCallResult{}, &toolExecutionError{
+			Code:      protocol.ErrorCodeForbidden,
+			Message:   persistErr.Error(),
+			Retryable: false,
+		}
+	}
 	if persistErr != nil {
 		return toolCallResult{}, &toolExecutionError{Code: "STORE_CORRUPT", Message: persistErr.Error(), Retryable: false}
 	}

--- a/internal/retrieval/open_file_stream.go
+++ b/internal/retrieval/open_file_stream.go
@@ -46,11 +46,17 @@ const (
 	// and continues past its end, and it holds the scan to a fixed cost instead
 	// of the size of the source.
 	//
-	// The value matches the ingest-time secret sample (64 KiB, see
+	// The value matches the ingest-time head sample (64 KiB, see
 	// internal/ingest.secretScanSampleBytes). open_file always reads from the
 	// first byte of the source, so every request scans at least the same head
-	// bytes that ingest scans. A document that ingest withholds can therefore
-	// never be served by the tool, which is what SPEC 15.4 requires.
+	// bytes that ingest scans.
+	//
+	// Since #681 that head sample is ingest's FLOOR, not its whole policy: a text
+	// source is scanned in full at ingest time. So a document ingest withholds can
+	// still have a clean early window served here. What SPEC 15.4 requires is
+	// preserved either way, because every byte this tool returns was scanned and
+	// found clean: the credential itself is never served, and neither is anything
+	// behind it. See the note on openFileFromResolvedPath.
 	secretScanMarginBytes = 64 << 10
 )
 

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -2276,14 +2276,23 @@ func (s *Service) openFileFromMetadata(normalizedRel string, span model.Span, ma
 //     begin after an unscanned region. A caller cannot step over a secret to
 //     reach the text behind it.
 //  3. The scan always covers at least the head bytes that ingest samples
-//     (internal/ingest.secretScanSampleBytes), so a document that ingest
-//     withholds can never be served by this tool.
+//     (internal/ingest.secretScanSampleBytes).
 //
 // The buffered path scanned the whole source, so it also refused the head of a
 // document whose only secret sat far past the answer. Reproducing that would
 // mean reading the whole source on every request, which is the cost this fix
-// removes, and it would still be weaker than it looks, because ingest itself
-// decides on a 64 KiB sample.
+// removes.
+//
+// #681 narrowed what property 3 buys. Ingest now scans a text source in FULL, so
+// a credential past the head sample withholds the whole document from the index;
+// it is no longer true that "a document ingest withholds can never be served
+// here". What still holds is the property SPEC 15.4 actually asks for: the tool
+// never returns the secret. Every byte it returns was scanned and found clean, so
+// the most a caller can obtain from a withheld document is a clean early window,
+// never the credential and never the text behind it. Closing that last gap would
+// require the whole-source read this fix removed, so it is a deliberate trade.
+// The derived-text path (openFileFromOCRCache) has no such gap: it reads its
+// whole cache file and scans all of it.
 func (s *Service) openFileFromResolvedPath(ctx context.Context, corpusFS corpusfs.CorpusFS, resolvedAbs, relPath string, secretPatterns []*regexp.Regexp, kind string, span model.Span, maxChars int) (string, bool, error) {
 	rc, err := s.openSource(ctx, corpusFS, resolvedAbs, relPath)
 	if err != nil {

--- a/tests/ingest/secret_scan_coverage_681_test.go
+++ b/tests/ingest/secret_scan_coverage_681_test.go
@@ -150,6 +150,38 @@ func TestSecretScan_CleanLargeFile_StaysIndexed(t *testing.T) {
 	}
 }
 
+// TestSecretScan_BinaryPayloadInATextDocType_IsNotIndexed pins the one case that
+// sits between the two scan targets. A binary payload can classify into a
+// text-oriented doc_type (a .parquet reaches "data"), and #398 already refuses to
+// put such content on the raw-text path, so it is never chunked and never
+// indexed. It therefore keeps the cheap head sample instead of paying for a full
+// scan that could not protect anything. What matters for #681 is the outcome: no
+// searchable text either way.
+func TestSecretScan_BinaryPayloadInATextDocType_IsNotIndexed(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	stateDir := t.TempDir()
+	// A NUL byte in the head is the #398 binary signal; the credential sits far
+	// past the head sample.
+	writeFile(t, filepath.Join(root, "export.parquet"),
+		"PAR1\x00binary column data\n"+filler681(100*1024)+"\naws_key = "+secret681+"\n")
+	st := newRealStore(t)
+
+	svc := mustNewIngestService(t, secretScanConfig(root, stateDir), st)
+	if err := svc.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	reps, err := st.ActiveRepresentations(context.Background(), "export.parquet")
+	if err != nil {
+		t.Fatalf("ActiveRepresentations: %v", err)
+	}
+	if len(reps) != 0 {
+		t.Errorf("export.parquet has %d live representation(s) %+v; binary content must never be indexed as text",
+			len(reps), reps)
+	}
+}
+
 // TestSecretScan_OnlyInExtractedText_WithholdsTheDocument is the second half of
 // #681, in its most ordinary form: a scanned contract or a screenshot. The source
 // bytes hold no readable credential; only the extractor's output does, so on

--- a/tests/ingest/secret_scan_coverage_681_test.go
+++ b/tests/ingest/secret_scan_coverage_681_test.go
@@ -27,9 +27,10 @@ import (
 //     OCR, transcription, extraction, or translation was never tested against the
 //     patterns at all.
 //
-// Every test here withholds nothing but the document: the assertions look at the
-// persisted status, the skip reason, and the live representations, which is what
-// retrieval reads.
+// Every test asserts on the state retrieval actually reads: the persisted
+// document status, its skip reason, and its live representations. A withheld
+// document must carry the SPEC 15.2 `secret_excluded` reason and must have
+// nothing left that `search`, `ask`, or `open_file` can return.
 
 // secret681 is a synthetic AWS access key id. It matches the FIRST default
 // pattern (`AKIA[0-9A-Z]{16}`), which is the shape SPEC §7.2 lists first, and it

--- a/tests/ingest/secret_scan_coverage_681_test.go
+++ b/tests/ingest/secret_scan_coverage_681_test.go
@@ -309,6 +309,49 @@ func TestSecretScan_AnnotationIsRefusedWithoutTouchingTheDocument(t *testing.T) 
 	}
 }
 
+// TestSecretScan_WithheldVideoIsNotAlsoBrandedAnError guards the interaction with
+// the #398/#495 unsearchable-video verdict. A video whose only text source is its
+// transcript produces nothing once that transcript is withheld, which looks
+// exactly like "no representation produced". It must not be stamped
+// status="error" on top: that would overwrite the secret_excluded row and count
+// one document as both a skip and an error. A withheld document is unsearchable
+// by design, not by failure.
+func TestSecretScan_WithheldVideoIsNotAlsoBrandedAnError(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	stateDir := t.TempDir()
+	writeFile(t, filepath.Join(root, "briefing.mp4"), "fake-video")
+	// The sidecar is the video's only text source, and it carries the credential.
+	// It also keeps the fixture off ffmpeg, which a synthetic video cannot satisfy.
+	writeFile(t, filepath.Join(root, "briefing.vtt"),
+		"WEBVTT\n\n00:00:00.000 --> 00:00:02.000\nthe key is aws_key = "+secret681+"\n")
+	st := newRealStore(t)
+
+	svc := mustNewIngestService(t, secretScanConfig(root, stateDir), st)
+	indexState := appstate.NewIndexingState(appstate.ModeIncremental)
+	svc.SetIndexingState(indexState)
+	if err := svc.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	assertWithheld681(t, st, "briefing.mp4")
+	if doc := docFor681(t, st, "briefing.mp4"); doc.ErrorMessage != "" {
+		t.Errorf("briefing.mp4 error_message = %q, want empty on a withheld document", doc.ErrorMessage)
+	}
+	// The corpus holds two files: the withheld video and its sidecar, which is
+	// itself never indexed. So both count as skips, neither as an error, and the
+	// #426 identity still balances.
+	snap := indexState.Snapshot()
+	if snap.Errors != 0 || snap.Indexed != 0 {
+		t.Fatalf("counters = indexed:%d skipped:%d errors:%d, want indexed 0 and errors 0",
+			snap.Indexed, snap.Skipped, snap.Errors)
+	}
+	if snap.Indexed+snap.Skipped+snap.Errors != snap.Scanned {
+		t.Fatalf("indexed:%d + skipped:%d + errors:%d != scanned:%d (#426)",
+			snap.Indexed, snap.Skipped, snap.Errors, snap.Scanned)
+	}
+}
+
 // TestSecretScan_DerivedVerdictSurvivesTheNextScan guards the incremental gate. A
 // derived verdict cannot be recomputed from the source bytes, so it has to be
 // carried on the row. Without the carry the second scan rebuilds the document as

--- a/tests/ingest/secret_scan_coverage_681_test.go
+++ b/tests/ingest/secret_scan_coverage_681_test.go
@@ -1,0 +1,422 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/appstate"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// Ingest secret-scanning coverage (dir2mcp #681).
+//
+// The ingest exclusion policy had two holes, and both of them ended with a
+// credential in the index:
+//
+//  1. it scanned only the first 64 KiB of a source file, so a credential further
+//     in was chunked, embedded, and returned by `search` and `ask`;
+//  2. it scanned the SOURCE BYTES only, so a credential that becomes text through
+//     OCR, transcription, extraction, or translation was never tested against the
+//     patterns at all.
+//
+// Every test here withholds nothing but the document: the assertions look at the
+// persisted status, the skip reason, and the live representations, which is what
+// retrieval reads.
+
+// secret681 is a synthetic AWS access key id. It matches the FIRST default
+// pattern (`AKIA[0-9A-Z]{16}`), which is the shape SPEC §7.2 lists first, and it
+// is not a real credential.
+const secret681 = "AKIA2ZZZZZZZZZZZZZZQ"
+
+// secretScanConfig returns a config with the shipped default secret patterns, so
+// the tests exercise the policy an operator gets out of the box rather than one
+// invented for the test.
+func secretScanConfig(root, stateDir string) config.Config {
+	return config.Config{
+		RootDir:        root,
+		StateDir:       stateDir,
+		STTProvider:    "off",
+		SecretPatterns: config.Default().SecretPatterns,
+	}
+}
+
+// filler681 returns n bytes of ordinary prose that matches no secret pattern.
+func filler681(n int) string {
+	line := "the quarterly report covers delivery, revenue and customer risk\n"
+	var b strings.Builder
+	b.Grow(n + len(line))
+	for b.Len() < n {
+		b.WriteString(line)
+	}
+	return b.String()[:n]
+}
+
+// docFor681 reads back the persisted document row.
+func docFor681(t *testing.T, st *store.SQLiteStore, relPath string) model.Document {
+	t.Helper()
+	doc, err := st.GetDocumentByPath(context.Background(), relPath)
+	if err != nil {
+		t.Fatalf("GetDocumentByPath(%s): %v", relPath, err)
+	}
+	return doc
+}
+
+// assertWithheld681 fails unless the document is recorded as withheld under the
+// §15.2 `secret_excluded` reason AND has nothing left that retrieval can return.
+func assertWithheld681(t *testing.T, st *store.SQLiteStore, relPath string) {
+	t.Helper()
+	doc := docFor681(t, st, relPath)
+	if doc.Status != "secret_excluded" {
+		t.Errorf("%s status = %q, want secret_excluded", relPath, doc.Status)
+	}
+	if doc.SkipReason != model.SkipReasonSecretExcluded {
+		t.Errorf("%s skip_reason = %q, want %q", relPath, doc.SkipReason, model.SkipReasonSecretExcluded)
+	}
+	reps, err := st.ActiveRepresentations(context.Background(), relPath)
+	if err != nil {
+		t.Fatalf("ActiveRepresentations(%s): %v", relPath, err)
+	}
+	if len(reps) != 0 {
+		t.Errorf("%s still has %d live representation(s) %+v; its text is searchable", relPath, len(reps), reps)
+	}
+}
+
+// TestSecretScan_PastTheHeadSample_IsWithheld is the first half of #681. The
+// credential sits well past the 64 KiB head sample that ingest used to scan, so
+// on `main` the document is indexed and `search` can return the tail that holds
+// it.
+func TestSecretScan_PastTheHeadSample_IsWithheld(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	stateDir := t.TempDir()
+	// 200 KiB of prose, then the key: more than three times the old sample.
+	writeFile(t, filepath.Join(root, "runbook.md"), filler681(200*1024)+"\naws_key = "+secret681+"\n")
+	st := newRealStore(t)
+
+	svc := mustNewIngestService(t, secretScanConfig(root, stateDir), st)
+	if err := svc.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	assertWithheld681(t, st, "runbook.md")
+}
+
+// TestSecretScan_WithinTheHeadSample_StaysWithheld pins the behaviour that must
+// NOT change: a credential in the first 64 KiB was already excluded and still is.
+func TestSecretScan_WithinTheHeadSample_StaysWithheld(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	stateDir := t.TempDir()
+	writeFile(t, filepath.Join(root, "creds.txt"), "aws_key = "+secret681+"\n"+filler681(4*1024))
+	st := newRealStore(t)
+
+	svc := mustNewIngestService(t, secretScanConfig(root, stateDir), st)
+	if err := svc.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	assertWithheld681(t, st, "creds.txt")
+}
+
+// TestSecretScan_CleanLargeFile_StaysIndexed is the false-positive guard for the
+// wider scan: reading every byte of a large document must not start excluding
+// ordinary text.
+func TestSecretScan_CleanLargeFile_StaysIndexed(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	stateDir := t.TempDir()
+	writeFile(t, filepath.Join(root, "handbook.md"), filler681(300*1024))
+	st := newRealStore(t)
+
+	svc := mustNewIngestService(t, secretScanConfig(root, stateDir), st)
+	if err := svc.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	doc := docFor681(t, st, "handbook.md")
+	if doc.Status != "ok" {
+		t.Fatalf("handbook.md status = %q, want ok; the wider scan produced a false positive", doc.Status)
+	}
+	if types := activeRepTypes(t, st, "handbook.md"); !types[ingest.RepTypeRawText] {
+		t.Errorf("handbook.md has no raw_text representation (have %v)", types)
+	}
+}
+
+// TestSecretScan_OnlyInExtractedText_WithholdsTheDocument is the second half of
+// #681, in its most ordinary form: a scanned contract or a screenshot. The source
+// bytes hold no readable credential; only the extractor's output does, so on
+// `main` nothing is scanned and the extracted text is indexed.
+func TestSecretScan_OnlyInExtractedText_WithholdsTheDocument(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	stateDir := t.TempDir()
+	writeFile(t, filepath.Join(root, "contract.pdf"), "%PDF-1.7 opaque page image bytes")
+	st := newRealStore(t)
+
+	svc := mustNewIngestService(t, secretScanConfig(root, stateDir), st)
+	svc.SetOCR(&fakeOCR{text: "# Deployment\n\nUse aws_key = " + secret681 + " for the staging account.\n"})
+	if err := svc.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	assertWithheld681(t, st, "contract.pdf")
+}
+
+// TestSecretScan_OnlyInTranscript_WithholdsTheDocument is the spoken form: the
+// credential is audio in the source and text only after transcription.
+func TestSecretScan_OnlyInTranscript_WithholdsTheDocument(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	stateDir := t.TempDir()
+	writeFile(t, filepath.Join(root, "standup.mp3"), "fake-audio")
+	st := newRealStore(t)
+
+	svc := mustNewIngestService(t, secretScanConfig(root, stateDir), st)
+	svc.SetTranscriber(&fakeTranscriber{text: "[00:00] the key is\n[00:02] aws_key = " + secret681})
+	svc.SetSTTIdentity("whisper", "whisper-large-v3")
+	if err := svc.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	assertWithheld681(t, st, "standup.mp3")
+}
+
+// TestSecretScan_OnlyInTranslation_RetiresTheCleanTranscript covers the ordering
+// case: a clean transcript is persisted first, and the credential appears only in
+// a derived translation. The verdict is document-wide, so the transcript that was
+// already written must be retired too. Otherwise the surrounding context of the
+// credential stays searchable and the document reports as healthy.
+func TestSecretScan_OnlyInTranslation_RetiresTheCleanTranscript(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	stateDir := t.TempDir()
+	writeFile(t, filepath.Join(root, "briefing.mp3"), "fake-audio")
+	st := newRealStore(t)
+
+	cfg := secretScanConfig(root, stateDir)
+	cfg.MediaTranslateEnabled = true
+	cfg.MediaTranslateTargetLangs = []string{"en"}
+
+	svc := mustNewIngestService(t, cfg, st)
+	svc.SetTranscriber(&fakeTranscriber{text: "[00:00] guten morgen\n[00:02] zweiter satz"})
+	svc.SetSTTIdentity("whisper", "whisper-large-v3")
+	svc.SetTranscriptLanguage("de")
+	// The translator emits the credential the source transcript never held.
+	svc.SetTranslator(&secretTranslator681{}, "mistral", "mistral-small-2506", cfg.MediaTranslateTargetLangs)
+	if err := svc.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	assertWithheld681(t, st, "briefing.mp3")
+}
+
+// secretTranslator681 is a model.Generator that puts a credential in its
+// translated output while the source transcript stays clean. It answers the
+// windowed prompt in the numbered 1:1 shape the parser expects, so translation
+// takes its normal path rather than the malformed-response fallback.
+type secretTranslator681 struct{}
+
+func (secretTranslator681) Generate(_ context.Context, prompt string) (string, error) {
+	var out strings.Builder
+	for i := 1; i <= countNumberedSourceLines681(prompt); i++ {
+		fmt.Fprintf(&out, "%d: the key is aws_key = %s\n", i, secret681)
+	}
+	if out.Len() > 0 {
+		return out.String(), nil
+	}
+	// Per-line prompt shape: one line in, one line out.
+	return "the key is aws_key = " + secret681, nil
+}
+
+// numberedSourceLine681 matches the "N: text" lines the windowed translate
+// prompt uses to enumerate the cues it wants translated.
+var numberedSourceLine681 = regexp.MustCompile(`(?m)^\s*\d+:\s`)
+
+func countNumberedSourceLines681(prompt string) int {
+	return len(numberedSourceLine681.FindAllString(prompt, -1))
+}
+
+// TestSecretScan_OnlyInSubtitleSidecar_WithholdsTheMedia covers the authored
+// derived text: a .vtt sidecar carries no credential of its own into the index
+// (the sidecar file is classified as a never-indexed skip), but its cues become
+// the MEDIA document's searchable transcript. So the media document is the one
+// that has to be withheld.
+func TestSecretScan_OnlyInSubtitleSidecar_WithholdsTheMedia(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	stateDir := t.TempDir()
+	writeFile(t, filepath.Join(root, "talk.mp3"), "fake-audio")
+	writeFile(t, filepath.Join(root, "talk.vtt"),
+		"WEBVTT\n\n00:00:00.000 --> 00:00:02.000\nthe key is aws_key = "+secret681+"\n")
+	st := newRealStore(t)
+
+	svc := mustNewIngestService(t, secretScanConfig(root, stateDir), st)
+	if err := svc.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	assertWithheld681(t, st, "talk.mp3")
+	if doc := docFor681(t, st, "talk.vtt"); doc.Status == "ok" {
+		t.Errorf("talk.vtt status = %q; the sidecar file must never be indexed on its own", doc.Status)
+	}
+}
+
+// TestSecretScan_AnnotationIsRefusedWithoutTouchingTheDocument covers the one
+// derived-text path that must NOT withhold its document. `dir2mcp_annotate`
+// generates text ABOUT an already-scanned document, so a match says the model
+// wrote a credential shape, not that the corpus file holds one. The annotation is
+// refused with the sentinel the MCP layer maps to FORBIDDEN, and the healthy
+// document keeps its representations.
+func TestSecretScan_AnnotationIsRefusedWithoutTouchingTheDocument(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	stateDir := t.TempDir()
+	writeFile(t, filepath.Join(root, "notes.md"), "a clean note about the deployment\n")
+	st := newRealStore(t)
+	ctx := context.Background()
+
+	svc := mustNewIngestService(t, secretScanConfig(root, stateDir), st)
+	if err := svc.Run(ctx); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	doc := docFor681(t, st, "notes.md")
+
+	annotation := map[string]interface{}{"summary": "aws_key = " + secret681}
+	preview, err := svc.StoreAnnotationRepresentations(ctx, doc, annotation, true)
+	if !errors.Is(err, ingest.ErrSecretExcluded) {
+		t.Fatalf("StoreAnnotationRepresentations error = %v, want ErrSecretExcluded", err)
+	}
+	if preview != "" {
+		t.Errorf("preview = %q, want empty; a refused annotation must not be echoed back", preview)
+	}
+	if strings.Contains(err.Error(), secret681) {
+		t.Errorf("the refusal message quotes the matched payload: %q", err.Error())
+	}
+
+	if got := docFor681(t, st, "notes.md"); got.Status != "ok" {
+		t.Errorf("notes.md status = %q after a refused annotation, want ok", got.Status)
+	}
+	if types := activeRepTypes(t, st, "notes.md"); !types[ingest.RepTypeRawText] {
+		t.Errorf("a refused annotation retired the document's own representations (have %v)", types)
+	}
+}
+
+// TestSecretScan_DerivedVerdictSurvivesTheNextScan guards the incremental gate. A
+// derived verdict cannot be recomputed from the source bytes, so it has to be
+// carried on the row. Without the carry the second scan rebuilds the document as
+// "ok", writes that over the withheld row, and then early-returns on the
+// unchanged-content gate: the corpus reports an indexed document whose
+// representations are gone.
+func TestSecretScan_DerivedVerdictSurvivesTheNextScan(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	stateDir := t.TempDir()
+	writeFile(t, filepath.Join(root, "standup.mp3"), "fake-audio")
+	st := newRealStore(t)
+
+	transcript := "[00:00] the key is\n[00:02] aws_key = " + secret681
+	for _, pass := range []string{"first", "second"} {
+		svc := mustNewIngestService(t, secretScanConfig(root, stateDir), st)
+		svc.SetTranscriber(&fakeTranscriber{text: transcript})
+		svc.SetSTTIdentity("whisper", "whisper-large-v3")
+		if err := svc.Run(context.Background()); err != nil {
+			t.Fatalf("%s scan: %v", pass, err)
+		}
+		assertWithheld681(t, st, "standup.mp3")
+	}
+}
+
+// TestSecretScan_RemovingTheSecretLetsTheDocumentBackIn is the other side of the
+// carry: it is conditional on the content being unchanged, so an edited file is
+// re-derived and decided again. A withheld document must not be withheld forever.
+func TestSecretScan_RemovingTheSecretLetsTheDocumentBackIn(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	stateDir := t.TempDir()
+	path := filepath.Join(root, "runbook.md")
+	writeFile(t, path, filler681(100*1024)+"\naws_key = "+secret681+"\n")
+	st := newRealStore(t)
+
+	first := mustNewIngestService(t, secretScanConfig(root, stateDir), st)
+	if err := first.Run(context.Background()); err != nil {
+		t.Fatalf("first scan: %v", err)
+	}
+	assertWithheld681(t, st, "runbook.md")
+
+	// The operator removes the credential.
+	writeFile(t, path, filler681(100*1024)+"\nthe key now lives in the secret manager\n")
+	second := mustNewIngestService(t, secretScanConfig(root, stateDir), st)
+	if err := second.Run(context.Background()); err != nil {
+		t.Fatalf("second scan: %v", err)
+	}
+
+	doc := docFor681(t, st, "runbook.md")
+	if doc.Status != "ok" {
+		t.Fatalf("runbook.md status = %q after the credential was removed, want ok", doc.Status)
+	}
+	if types := activeRepTypes(t, st, "runbook.md"); !types[ingest.RepTypeRawText] {
+		t.Errorf("runbook.md was not re-indexed after the credential was removed (have %v)", types)
+	}
+}
+
+// TestSecretScan_DerivedExclusionCountsAsSkipNotIndexed keeps the #426 accounting
+// invariant: a withheld document counts as exactly one skip and never also as
+// indexed, so scanned = indexed + skipped + errors still holds.
+func TestSecretScan_DerivedExclusionCountsAsSkipNotIndexed(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	stateDir := t.TempDir()
+	writeFile(t, filepath.Join(root, "standup.mp3"), "fake-audio")
+	st := newRealStore(t)
+
+	svc := mustNewIngestService(t, secretScanConfig(root, stateDir), st)
+	svc.SetTranscriber(&fakeTranscriber{text: "[00:00] aws_key = " + secret681})
+	svc.SetSTTIdentity("whisper", "whisper-large-v3")
+	indexState := appstate.NewIndexingState(appstate.ModeIncremental)
+	svc.SetIndexingState(indexState)
+	if err := svc.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	snap := indexState.Snapshot()
+	if snap.Scanned != 1 || snap.Skipped != 1 || snap.Indexed != 0 || snap.Errors != 0 {
+		t.Fatalf("counters = scanned:%d indexed:%d skipped:%d errors:%d, want 1/0/1/0",
+			snap.Scanned, snap.Indexed, snap.Skipped, snap.Errors)
+	}
+}
+
+// TestSecretScan_DerivedExclusionEmitsOneFileSkip pins the SPEC §3.2 invariant
+// that a terminal skip raises exactly one file_skip event, carrying the §15.2
+// reason so the honest-coverage aggregate names the right cause.
+func TestSecretScan_DerivedExclusionEmitsOneFileSkip(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	stateDir := t.TempDir()
+	writeFile(t, filepath.Join(root, "standup.mp3"), "fake-audio")
+	st := newRealStore(t)
+
+	var reasons []string
+	svc := mustNewIngestService(t, secretScanConfig(root, stateDir), st)
+	svc.SetTranscriber(&fakeTranscriber{text: "[00:00] aws_key = " + secret681})
+	svc.SetSTTIdentity("whisper", "whisper-large-v3")
+	svc.SetOnDocumentSkip(func(relPath, _, reason string) {
+		if relPath == "standup.mp3" {
+			reasons = append(reasons, reason)
+		}
+	})
+	if err := svc.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if len(reasons) != 1 || reasons[0] != model.SkipReasonSecretExcluded {
+		t.Fatalf("file_skip reasons = %v, want exactly one %q", reasons, model.SkipReasonSecretExcluded)
+	}
+}


### PR DESCRIPTION
Closes #681.

## The exposure, plainly

Two kinds of credential are in the index today, on `main`, on a default configuration:

1. **A secret past byte 65,536 of a text file.** Ingest sampled the first 64 KiB of the source bytes and nothing else. Everything after that offset was chunked, embedded, and is returned by `search` and `ask`. A `.env` fragment pasted at the end of a long runbook, a key in the tail of a CSV export, an `AKIA...` line 300 KiB into a log: all indexed, all searchable.
2. **A secret that only exists in derived text.** Ingest scanned the SOURCE BYTES only. A credential printed on a scanned contract is pixels in the source and plain text only after OCR. A credential read out on a recorded call is audio in the source and plain text only after transcription. A credential inside a `.docx` is compressed in the source and plain text only after extraction. None of these was ever tested against `security.secret_patterns`. The same held for a translated transcript, a recognition statement, a subtitle sidecar's cues, and a stored annotation.

Configured secret exclusions were therefore a false boundary. `tests/ingest/secret_scan_coverage_681_test.go` demonstrates both cases against `main` (results below).

## The fix

**Scan what becomes searchable.** `secretScanBytes(docType, content)` splits on the classified doc_type:

* a raw-text doc_type (`text`, `code`, `md`, `data`, `html`) is chunked and embedded from these very bytes, so **every byte is scanned**. There is no offset past which a credential stops being indexed, so there must be none past which it stops being scanned.
* every other doc_type reaches the index only through a derived text. Its raw bytes are a container, so the 64 KiB head sample stays as a cheap early-out and the derived text carries the full scan.
* one case sits between the two: a binary payload that classified into a text-oriented doc_type, such as a `.parquet` reaching `data`. #398 already refuses to put such content on the raw-text path, so it is never chunked and never indexed. It takes the head sample too, because a full scan of it would be the whole cost of this change with none of the benefit. The binary check reads only the first 8000 bytes, so the decision itself is free.

**Screen every derived text before it is persisted.** `Service.screenDerivedSecrets` runs at each producer, before the title heuristic, before the quality gate, before the representation upsert:

| producer | where |
| --- | --- |
| OCR / image / PDF extraction | `generateOCRMarkdownRepresentation` |
| structured (docling) extraction, incl. the html route | `persistStructuredRepresentation` |
| pandoc extraction | `generatePandocMarkdownRepresentation` |
| STT transcript, per track | `transcribeAndPersistTrack` |
| translated transcript, per language | `translateOneTranscript` |
| recognition annotations | `recognize.go` |
| subtitle sidecar cues | `sidecar.go` |
| stored annotation | `StoreAnnotationRepresentations` |

The verdict is **document-wide**, not representation-wide. A document is one unit of disclosure: leaving its clean representations searchable next to a withheld one would still serve the text around the credential, and would report a partially indexed document as healthy. So the first derived match records the document `secret_excluded` and retires every representation this run already wrote for it, with its chunks (SPEC 6.6: the SQLite tombstone is what removes a vector from retrieval, now and after a restart).

**The verdict is sticky.** A raw-byte verdict is reproducible, because the next scan re-reads the same bytes. A derived verdict is not: the incremental gate is designed NOT to re-run OCR or STT for an unchanged file. Without a carry, the next scan would rebuild the document as `ok`, write that over the withheld row, and early-return on the unchanged-content gate, leaving a corpus that reports an indexed document whose representations are gone. `carrySecretExclusion` keeps the withheld status while the stored `content_hash` is settled and equal to the freshly computed one. An edited file, or a `--force` reindex (which clears the stored hash), re-derives and decides again, so removing the credential lets the document back in.

## SPEC: no dirstral-spec PR needed

I checked before writing code.

* SPEC 7.2 applies `security.secret_patterns` "to file **contents**". It sets no sample bound, so scanning more of the content is inside the contract.
* SPEC 15.2 closes the `skip_reasons` enum and already defines `secret_excluded`: "withheld because it matched secret-detection". A derived match is still secret-detection on the document's content, so it reuses that reason. No new reason, no new status, no schema change.
* SPEC 14.2 `FORBIDDEN` ("path/content blocked by policy") already exists for the one tool surface that needed a new answer (below).

The submodule pointer is untouched.

## The measured cost

Full scanning is a real change, so I measured it before committing to it. Benchmark: the shipped default `security.secret_patterns` (7 regexes), ordinary prose that matches none of them, Apple M4, Go 1.26.

| document size | head sample (`main`) | full scan (this PR) |
| --- | --- | --- |
| 64 KiB | 20 ms | 20 ms (identical: the file IS the sample) |
| 256 KiB | 22 ms | 89 ms |
| 1 MiB | 23 ms | 359 ms |
| 10 MiB (the default `ingest.max_file_mb` cap) | 32 ms | 3.63 s |

The scanner runs at about **2.9 MB/s**. That is not this change: it is Go's regexp engine on the default patterns, and `main` already pays 20 ms per document for its 64 KiB sample. I measured the alternatives before accepting it. Combining the 7 patterns into one alternation is not faster (2.66 MB/s: the combined automaton costs what the 7 passes cost). Per pattern, the two case-insensitive alternations (the AWS-secret heuristic and the JWT rule) account for 244 ms of the 359 ms; the patterns with a literal prefix run at 430-460 MB/s, because the engine can skip on the prefix.

**What I chose, and why it is proportionate.**

* The cost is bounded by the ingest file cap, which defaults to 10 MiB. The worst case is about 3.6 seconds for one document at the cap.
* It is paid **once per content version**, on the same path that already chunks and embeds those exact bytes. A 10 MiB text file produces roughly 2,500 chunks, each an embedding call. Minutes of provider work, seconds of scanning. An unchanged file on the next scan pays nothing: the content gate skips it.
* The doc_type split keeps it off the files where it would be pure waste. A 10 MiB video or a 10 MiB PDF never has its container bytes run through the regexes, which no pattern could usefully match anyway. Their derived text is scanned in full instead, and that text is much smaller than the media.

**What I chose NOT to do.** A literal prefilter (extract each pattern's required substrings with `regexp/syntax`, then skip the pattern when the input holds none of them) would reach about the 450 MB/s the prefixed patterns already show, a speedup of roughly 150x. I did not build it. A bug in the direction that matters there is a **silent false negative on a security control**, which is exactly the class of defect this issue is about. Correctness first. It is a good follow-up, gated on a differential fuzz test that asserts "if the pattern matches, the prefilter admits it".

## Agreement with PR #813 (`open_file`)

#813 relaxed the `open_file` secret check to "every byte the request reads is scanned: the window, everything before it, and a 64 KiB margin". Its justification named ingest's own 64 KiB sample: a document whose secret sits past 64 KiB "is already indexed, and its text is already reachable through `search`".

**That sentence is no longer true**, and I updated it rather than leave a stale argument in the code (`internal/retrieval/service.go` and `internal/retrieval/open_file_stream.go`, comments only, no behavior change). What the two halves still agree on is the property SPEC 15.4 actually requires: `open_file` never returns the secret. Every byte it returns was scanned and found clean, so the most a caller can obtain from a withheld document is a clean early window, never the credential and never the text behind it. Closing that last gap would need the whole-source read that #690 removed, so it is a deliberate trade, now stated as one.

The derived-text half of `open_file` has no gap at all: `openFileFromOCRCache` reads its whole cache file and scans all of it, so a withheld document's OCR or transcript text is already answered `FORBIDDEN`.

## `dir2mcp_annotate` is the one path that does NOT withhold

`StoreAnnotationRepresentations` screens the annotation and its flattened text, but it refuses the ANNOTATION without touching the source document. The annotation is model output ABOUT an already-scanned document, so a match says the model wrote a credential shape, not that the corpus file holds one. To retire a healthy document's representations on that evidence would be wrong.

The refusal needed an honest answer, because the tool otherwise returns `"stored": true` and echoes the annotation back to the caller. It now returns the canonical `FORBIDDEN` (SPEC 14.2) carrying `ingest.ErrSecretExcluded`, whose message contains no part of the matched text.

## No secret is ever logged

Every new log line names the document path, the producer label, and the fact that a configured pattern matched. No offset, no pattern, no payload. The withheld row clears `title` (a title lifted from a withheld document is derived text from it) and `error_message` (a 15.6 diagnostic surface).

## The withheld document must not also be an error

A media document carries a second verdict after its transcript: a video with no sidecar, no transcript, no media chunks, and no recognition is recorded `status="error"`, because it is known but unsearchable (#398/#495).

A withheld document reached that verdict by the same route, because its text was never persisted. It was then stamped `status="error"` on top, which overwrote the `secret_excluded` row and counted one document as both a skip and an error. A withheld document is unsearchable by design, not by failure, so it is neither. Every stage now stops as soon as the document is withheld: after extraction, after the sidecar, after the transcript, and after recognition. `tests/ingest/secret_scan_coverage_681_test.go:TestSecretScan_WithheldVideoIsNotAlsoBrandedAnError` pins it, and it fails on `main`.

The sidecar path was restructured for a related reason. Screening per language inside the persist loop let a clean English transcript commit, and count a representation, before a German sidecar withheld the document and retired that same transcript. The cues of every language are now chunked first and screened together, so the persist loop runs only for a document already known clean.

## Accounting

A withheld document counts as exactly one skip and never also as indexed, so `scanned = indexed + skipped + errors` still holds, and it raises exactly one `file_skip` event carrying `secret_excluded` (SPEC 3.2). Two cases are deliberately not counted, because both would push a run's totals past its scanned count: an archive member (members are never credited; the container accounts for the archive, matching `persistArchiveMemberSizeCapSkips`) and the two-phase derivation pass (`scanPass` counts the corpus on the first pass only). Both still write their own `secret_excluded` row, so the honest-coverage aggregate reports them.

## Tests

New: `tests/ingest/secret_scan_coverage_681_test.go`, 13 cases against a real SQLite store and complete scans.

Verified against `main` with the copy-aside method (`git stash` is banned in this repo, because `refs/stash` is shared across worktrees). Files were copied to a uniquely named scratch directory, reverted with `git checkout HEAD --`, the tests run, then restored. Results on `main`:

| test | on `main` |
| --- | --- |
| `PastTheHeadSample_IsWithheld` | **FAIL**: `status = "ok"`, 1 live `raw_text` representation |
| `OnlyInExtractedText_WithholdsTheDocument` | **FAIL**: `status = "ok"`, 1 live `extracted_markdown` |
| `OnlyInTranscript_WithholdsTheDocument` | **FAIL**: `status = "ok"`, 1 live `transcript` |
| `OnlyInTranslation_RetiresTheCleanTranscript` | **FAIL**: `status = "ok"`, 2 live representations |
| `OnlyInSubtitleSidecar_WithholdsTheMedia` | **FAIL**: `status = "ok"`, 1 live `transcript` |
| `DerivedVerdictSurvivesTheNextScan` | **FAIL** |
| `RemovingTheSecretLetsTheDocumentBackIn` | **FAIL** |
| `DerivedExclusionCountsAsSkipNotIndexed` | **FAIL**: counters `scanned:1 indexed:1 skipped:0`, want `1/0/1/0` |
| `DerivedExclusionEmitsOneFileSkip` | **FAIL**: no `file_skip` raised |
| `WithheldVideoIsNotAlsoBrandedAnError` | **FAIL**: `status = "ok"`, indexed 1, 1 live `transcript` |
| `WithinTheHeadSample_StaysWithheld` | **PASS** (preservation, as it must) |
| `CleanLargeFile_StaysIndexed` | **PASS** (false-positive guard on the wider scan, as it must) |
| `BinaryPayloadInATextDocType_IsNotIndexed` | **PASS** (pins the #398 outcome that the head-sample carve-out relies on) |

`AnnotationIsRefusedWithoutTouchingTheDocument` does not compile on `main`, because it names the new sentinel, so it was left out of that run.

Every test uses the shipped default patterns rather than one invented for the test, and a synthetic `AKIA...` key that is not a real credential.

## Not in scope

* **Multimodal media chunks** (`rep_type=media`). They embed source bytes with no text stage, so there is nothing to run a text regex over. A credential visible only in a video frame under `embed.multimodal=replace` is covered by no text policy.
* **Document summaries.** A summary is derived from chunks that were already screened, so it inherits a clean input. To screen it again would only catch a model that invents a credential shape.
* **The literal prefilter** described under "The measured cost".
* **The clean-early-window gap in `open_file`** described under "Agreement with PR #813".

## Checklist

- [x] `make check` passes locally, including `gocyclo -over 15`. Four functions went over the gate and were fixed by extraction, not by working around it: `settleProcessedDocument`, `buildArchiveMemberDocument`, `shiftSegmentsForLeadingSilence`, and `screenAnnotationForSecrets` plus `annotationPreview`.
- [x] new behavior has test coverage that fails against `main`
- [x] no secret, matched payload, or pattern is logged or persisted
- [x] `README.md` and `docs/` remain truthful (neither documents the scan coverage)
- [x] `coderabbit review --committed --base main`: 0 findings
- [x] no unrelated files changed, submodule pointer untouched

## CI note

The first CI run failed the `race` job on `tests/cli` `TestReindex_AfterCrash_RepeatedCrashesDoNotRotatePartialState`, with no data race reported. That test does not touch ingest or the secret policy. It passes locally on this branch under `-race`, alone and as a whole suite, and the job passed on the next run. `tests/cli` produced a second, different flake locally (`TestUpPublicAuthNoneAllowedWithForceInsecure`), which also passed alone and in a full re-run. Both look like load-sensitive flakes in that suite rather than a regression here.
