### PR TITLE
fix(mcp): report a not-yet-indexed document as pending, not ok (#676)

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -3340,8 +3340,8 @@ func parseOptionalStringSlice(args map[string]interface{}, key string) ([]string
 	}
 }
 
-// normalizeFileStatus projects a stored document status onto the three values
-// the published list_files schema allows (`ok|skipped|error`, SPEC §5.1 and
+// normalizeFileStatus projects a stored document status onto the values
+// the published list_files schema allows (`ok|skipped|pending|error`, SPEC §5.1 and
 // spec/tools/schemas/list_files.json).
 //
 // The projection has to be conservative, because the default arm is what a
@@ -3357,17 +3357,24 @@ func parseOptionalStringSlice(args map[string]interface{}, key string) ([]string
 // was the only place that disagreed, so `stats` reported a skip while
 // `list_files` reported the same document healthy.
 //
-// The store also normalizes a `pending` document status, which would fall
-// through to `ok` here. It is left alone deliberately: nothing in production
-// writes that value (every `pending` in the store is a CHUNK's
-// embedding_status), and the published enum has no state that honestly
-// describes "not indexed yet" — `skipped` would be a different lie. If a
-// document ever does become pending, this needs a spec-first status extension
-// rather than a guess.
+// A `pending` document now has a published state of its own. It used to fall
+// through to `ok`, which told a caller the document was indexed and readable
+// when it was not, so the caller asked for content that did not exist yet
+// (issue #676). SPEC 0.48.0 added `pending` to the 15.5 enum for exactly this
+// row and made the mapping normative: a server MUST NOT report a document as
+// `ok` unless it is retrievable now, and `skipped` MUST NOT be reused for work
+// that is still in progress. Before that spec change there was no honest value
+// to return here, which is why the previous comment refused to guess one.
+//
+// The default arm stays `ok`. It carries the store's own `ok` plus any value a
+// future store adds, and inventing a public state for an unknown stored one
+// would be the same class of guess.
 func normalizeFileStatus(status string) string {
 	switch strings.ToLower(strings.TrimSpace(status)) {
 	case "skipped", "secret_excluded":
 		return "skipped"
+	case "pending":
+		return "pending"
 	case "error":
 		return "error"
 	default:
@@ -4147,7 +4154,7 @@ func listFilesOutputSchema() map[string]interface{} {
 						"doc_type":   map[string]interface{}{"type": "string"},
 						"size_bytes": map[string]interface{}{"type": "integer"},
 						"mtime_unix": map[string]interface{}{"type": "integer"},
-						"status":     map[string]interface{}{"type": "string", "enum": []string{"ok", "skipped", "error"}},
+						"status":     map[string]interface{}{"type": "string", "enum": []string{"ok", "skipped", "pending", "error"}},
 						"deleted":    map[string]interface{}{"type": "boolean"},
 					},
 					"required": []string{"rel_path", "doc_type", "size_bytes", "mtime_unix", "status", "deleted"},

--- a/tests/mcp/list_files_pending_676_test.go
+++ b/tests/mcp/list_files_pending_676_test.go
@@ -1,0 +1,91 @@
+package tests
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// #676: `list_files` reported a `pending` document as `status: "ok"`.
+//
+// `normalizeFileStatus` recognised `skipped`, `secret_excluded` and `error`,
+// so a row the corpus knows about and has not finished indexing fell through
+// the default arm. An agent reads `ok` as "indexed and readable", asks for the
+// content through `search` or `open_file`, and gets nothing back. The document
+// has no chunks yet.
+//
+// This half of the audit needed the spec to move first. The published enum was
+// `ok|skipped|error`, and neither value was honest: `skipped` means "not
+// indexed, and not going to be", which is a different claim with no matching
+// skip reason, and `error` is false. SPEC 0.48.0 added `pending` for exactly
+// this row and made the storage-to-public mapping normative, including the rule
+// this defect broke: a server MUST NOT report a document as `ok` unless it is
+// retrievable now.
+//
+// The sibling file (#712) covers the `secret_excluded` half of the same audit.
+
+// TestListFilesReportsAPendingDocumentAsPending is the contract. A document
+// that is not retrievable yet must not be advertised as indexed.
+func TestListFilesReportsAPendingDocumentAsPending(t *testing.T) {
+	tmp := t.TempDir()
+	st := store.NewSQLiteStore(filepath.Join(tmp, "meta.sqlite"))
+	if err := st.Init(context.Background()); err != nil {
+		t.Fatalf("init store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	seed := []model.Document{
+		{RelPath: "notes/indexed.md", DocType: "md", MTimeUnix: 100, Status: "ok"},
+		{RelPath: "notes/in-progress.md", DocType: "md", MTimeUnix: 200, Status: "pending"},
+	}
+	root := filepath.Join(tmp, "corpus")
+	seedCorpus(t, st, root, seed)
+
+	statuses := listFileStatuses(t, tmp, root, st)
+
+	if got := statuses["notes/in-progress.md"]; got != "pending" {
+		t.Fatalf("a document that is not indexed yet is reported as %q; a caller reads that as indexed and readable, then asks for content that does not exist (#676)", got)
+	}
+	// A document that IS retrievable must keep saying so. The fix must not turn
+	// the honest answer into a hedge.
+	if got := statuses["notes/indexed.md"]; got != "ok" {
+		t.Fatalf("indexed document reported as %q, want ok", got)
+	}
+}
+
+// TestListFilesNeverReportsUnfinishedWorkAsOK states the SPEC 0.48.0 rule
+// directly, rather than the one value that broke it: `ok` is a promise that the
+// document is retrievable now, so no state that means "not yet" may map onto
+// it. A future store state that reuses the default arm would pass the test
+// above and fail this one.
+func TestListFilesNeverReportsUnfinishedWorkAsOK(t *testing.T) {
+	tmp := t.TempDir()
+	st := store.NewSQLiteStore(filepath.Join(tmp, "meta.sqlite"))
+	if err := st.Init(context.Background()); err != nil {
+		t.Fatalf("init store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	// Every stored state that means "this document is not retrievable".
+	notRetrievable := []string{"pending", "skipped", "secret_excluded", "error"}
+	docs := make([]model.Document, 0, len(notRetrievable))
+	for i, status := range notRetrievable {
+		docs = append(docs, model.Document{
+			RelPath:   "f" + string(rune('a'+i)) + ".md",
+			DocType:   "md",
+			MTimeUnix: int64(100 * (i + 1)),
+			Status:    status,
+		})
+	}
+	root := filepath.Join(tmp, "corpus")
+	seedCorpus(t, st, root, docs)
+
+	for relPath, status := range listFileStatuses(t, tmp, root, st) {
+		if status == "ok" {
+			t.Errorf("%s is not retrievable in the store, but list_files reports it as ok; SPEC 15.5 forbids reporting work that has not finished as ok", relPath)
+		}
+	}
+}

--- a/tests/mcp/list_files_secret_excluded_712_test.go
+++ b/tests/mcp/list_files_secret_excluded_712_test.go
@@ -30,9 +30,11 @@ import (
 // skip for the very row `list_files` called healthy. It also undid the
 // operator-facing audit value #425 restored by persisting the state at all.
 //
-// The published schema (spec/tools/schemas/list_files.json) pins status to
-// `ok|skipped|error`, so `skipped` is the conforming honest projection and no
-// spec change is needed.
+// The published schema (spec/tools/schemas/list_files.json) pinned status to
+// `ok|skipped|error`, so `skipped` was the conforming honest projection and no
+// spec change was needed. SPEC 0.48.0 later made that mapping normative rather
+// than merely conforming, and added `pending` for the other half of the same
+// audit (#676).
 
 func TestListFilesReportsASecretExcludedDocumentAsSkipped(t *testing.T) {
 	tmp := t.TempDir()
@@ -70,7 +72,8 @@ func TestListFilesReportsASecretExcludedDocumentAsSkipped(t *testing.T) {
 
 // TestListFilesStatusesStayInsideThePublishedEnum guards the projection itself
 // rather than one value: whatever the store grows next, this tool may only emit
-// the three states its schema advertises.
+// the states its schema advertises. The set grew by one in SPEC 0.48.0, which
+// added `pending` for a document that is known and not yet retrievable (#676).
 func TestListFilesStatusesStayInsideThePublishedEnum(t *testing.T) {
 	tmp := t.TempDir()
 	st := store.NewSQLiteStore(filepath.Join(tmp, "meta.sqlite"))
@@ -91,10 +94,10 @@ func TestListFilesStatusesStayInsideThePublishedEnum(t *testing.T) {
 	root := filepath.Join(tmp, "corpus")
 	seedCorpus(t, st, root, docs)
 
-	allowed := map[string]bool{"ok": true, "skipped": true, "error": true}
+	allowed := map[string]bool{"ok": true, "skipped": true, "pending": true, "error": true}
 	for relPath, status := range listFileStatuses(t, tmp, root, st) {
 		if !allowed[status] {
-			t.Fatalf("%s reported status %q, outside the published enum ok|skipped|error", relPath, status)
+			t.Fatalf("%s reported status %q, outside the published enum ok|skipped|pending|error", relPath, status)
 		}
 	}
 }


### PR DESCRIPTION
Gated on dirstral-spec #88 (spec 0.48.0), now merged. This PR re-pins the submodule to it.

## The defect

`list_files` reported a `pending` document as `status: "ok"`. `normalizeFileStatus` recognised `skipped`, `secret_excluded` and `error`, so a row the corpus knows about and has not finished indexing fell through the default arm.

An agent reads `ok` as "indexed and readable". It then asks for the content through `search` or `open_file` and gets nothing, because the document has no chunks yet.

## Why this needed the spec first

The published enum was `ok|skipped|error`, and neither remaining value was honest:

- `skipped` means "not indexed, and not going to be". Different claim, and no skip reason covers it.
- `error` is false.

The previous comment on this function said exactly that and refused to guess. SPEC 0.48.0 added `pending` for this row and made the storage-to-public mapping normative, including the rule the defect broke: a server MUST NOT report a document as `ok` unless it is retrievable now.

## The change

- `normalizeFileStatus` gains a `pending` arm.
- The served `outputSchema` carries the same enum as `spec/tools/schemas/list_files.json`, so the wire contract and the spec agree.
- The submodule pin moves to the merged spec commit.

The default arm stays `ok`. It carries the store's own `ok` plus any value a future store adds, and inventing a public state for an unknown stored one would be the same class of guess the old comment warned about.

## Tests

`tests/mcp/list_files_pending_676_test.go`:

- `TestListFilesReportsAPendingDocumentAsPending` is the contract, and it also asserts an indexed document still says `ok`, so the fix cannot turn the honest answer into a hedge.
- `TestListFilesNeverReportsUnfinishedWorkAsOK` states the SPEC rule rather than the one value that broke it. It seeds every stored state that means "not retrievable" and fails if any maps to `ok`. A future store state that reuses the default arm passes the first test and fails this one.

Both fail on main:

```
--- FAIL: TestListFilesReportsAPendingDocumentAsPending
    a document that is not indexed yet is reported as "ok"
--- FAIL: TestListFilesNeverReportsUnfinishedWorkAsOK
    fa.md is not retrievable in the store, but list_files reports it as ok
```

## One existing test changed

`TestListFilesStatusesStayInsideThePublishedEnum` (from #712) pinned the allowed set to `ok|skipped|error` and already seeded a `pending` row. Its allowed set grows by one, because the published enum did. The assertion itself is unchanged: this tool may only emit what its schema advertises.

## Severity

`pending` is not reachable in production today. Ingest writes `ok`, `skipped` and `error` only; the store keeps `pending` because #425 made `normalizeStatus` faithful. So this closes a latent contract lie before the state becomes reachable, rather than a live break.

## Scope

dirstral-spec #63 stays open for the `source_type` half (`file` versus `filesystem`) and the canonical error and skip-reason field names.

`make check` passes.

Closes #676