### PR TITLE
test(reindex): make the crash seed mirror the real staging order

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -3340,8 +3340,8 @@ func parseOptionalStringSlice(args map[string]interface{}, key string) ([]string
 	}
 }
 
-// normalizeFileStatus projects a stored document status onto the three values
-// the published list_files schema allows (`ok|skipped|error`, SPEC §5.1 and
+// normalizeFileStatus projects a stored document status onto the values
+// the published list_files schema allows (`ok|skipped|pending|error`, SPEC §5.1 and
 // spec/tools/schemas/list_files.json).
 //
 // The projection has to be conservative, because the default arm is what a
@@ -3357,17 +3357,24 @@ func parseOptionalStringSlice(args map[string]interface{}, key string) ([]string
 // was the only place that disagreed, so `stats` reported a skip while
 // `list_files` reported the same document healthy.
 //
-// The store also normalizes a `pending` document status, which would fall
-// through to `ok` here. It is left alone deliberately: nothing in production
-// writes that value (every `pending` in the store is a CHUNK's
-// embedding_status), and the published enum has no state that honestly
-// describes "not indexed yet" — `skipped` would be a different lie. If a
-// document ever does become pending, this needs a spec-first status extension
-// rather than a guess.
+// A `pending` document now has a published state of its own. It used to fall
+// through to `ok`, which told a caller the document was indexed and readable
+// when it was not, so the caller asked for content that did not exist yet
+// (issue #676). SPEC 0.48.0 added `pending` to the 15.5 enum for exactly this
+// row and made the mapping normative: a server MUST NOT report a document as
+// `ok` unless it is retrievable now, and `skipped` MUST NOT be reused for work
+// that is still in progress. Before that spec change there was no honest value
+// to return here, which is why the previous comment refused to guess one.
+//
+// The default arm stays `ok`. It carries the store's own `ok` plus any value a
+// future store adds, and inventing a public state for an unknown stored one
+// would be the same class of guess.
 func normalizeFileStatus(status string) string {
 	switch strings.ToLower(strings.TrimSpace(status)) {
 	case "skipped", "secret_excluded":
 		return "skipped"
+	case "pending":
+		return "pending"
 	case "error":
 		return "error"
 	default:
@@ -4147,7 +4154,7 @@ func listFilesOutputSchema() map[string]interface{} {
 						"doc_type":   map[string]interface{}{"type": "string"},
 						"size_bytes": map[string]interface{}{"type": "integer"},
 						"mtime_unix": map[string]interface{}{"type": "integer"},
-						"status":     map[string]interface{}{"type": "string", "enum": []string{"ok", "skipped", "error"}},
+						"status":     map[string]interface{}{"type": "string", "enum": []string{"ok", "skipped", "pending", "error"}},
 						"deleted":    map[string]interface{}{"type": "boolean"},
 					},
 					"required": []string{"rel_path", "doc_type", "size_bytes", "mtime_unix", "status", "deleted"},

--- a/tests/cli/reindex_backup_preservation_727_test.go
+++ b/tests/cli/reindex_backup_preservation_727_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -94,16 +95,34 @@ func seedCrashedHashState(t *testing.T, stateDir, relPath string) {
 }
 
 // crashHashStateFromCurrent stages the store side of a reindex over whatever
-// hashes are there NOW (snapshot, then clear) and stops without resolving it,
-// standing in for the process being killed mid-run. Split out from
-// seedCrashedHashState so a second simulated crash chains onto the state the
-// previous run left rather than re-establishing a known-good one.
+// hashes are there NOW (recover, snapshot, then clear) and stops without
+// resolving it, standing in for the process being killed mid-run. Split out
+// from seedCrashedHashState so a second simulated crash chains onto the state
+// the previous run left rather than re-establishing a known-good one.
+//
+// The recover step is not decoration: it is the first thing prepareReindexStore
+// does (snapshotContentHashes calls restoreInterruptedReindexHashes before
+// BackupContentHashes), and since #811 a snapshot REFUSES to overwrite one that
+// is already there. So a helper that snapshots without recovering first asks
+// the store for something no real run ever asks for, and it fails the moment a
+// previous attempt leaves a snapshot behind (for example when a run exits
+// early, before it establishes its staging). CI saw exactly that: "refusing to
+// overwrite the existing content-hash snapshot ... it holds an unrecovered
+// generation". Mirroring the real order keeps the simulation faithful AND makes
+// it independent of how far the previous attempt got.
 func crashHashStateFromCurrent(t *testing.T, stateDir string) {
 	t.Helper()
 	ctx := context.Background()
 	st := store.NewSQLiteStore(filepath.Join(stateDir, "meta.sqlite"))
 	if err := st.Init(ctx); err != nil {
 		t.Fatalf("crash-seed Init: %v", err)
+	}
+	// "Nothing to restore" is the normal case: the previous attempt resolved its
+	// own staging. Any other error is real.
+	if err := st.RestoreContentHashes(ctx); err != nil &&
+		!errors.Is(err, store.ErrNoContentHashSnapshot) &&
+		!errors.Is(err, store.ErrEmptyContentHashSnapshot) {
+		t.Fatalf("crash-seed recover before snapshot: %v", err)
 	}
 	if err := st.BackupContentHashes(ctx); err != nil {
 		t.Fatalf("crash-seed BackupContentHashes: %v", err)

--- a/tests/mcp/list_files_pending_676_test.go
+++ b/tests/mcp/list_files_pending_676_test.go
@@ -1,0 +1,91 @@
+package tests
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// #676: `list_files` reported a `pending` document as `status: "ok"`.
+//
+// `normalizeFileStatus` recognised `skipped`, `secret_excluded` and `error`,
+// so a row the corpus knows about and has not finished indexing fell through
+// the default arm. An agent reads `ok` as "indexed and readable", asks for the
+// content through `search` or `open_file`, and gets nothing back. The document
+// has no chunks yet.
+//
+// This half of the audit needed the spec to move first. The published enum was
+// `ok|skipped|error`, and neither value was honest: `skipped` means "not
+// indexed, and not going to be", which is a different claim with no matching
+// skip reason, and `error` is false. SPEC 0.48.0 added `pending` for exactly
+// this row and made the storage-to-public mapping normative, including the rule
+// this defect broke: a server MUST NOT report a document as `ok` unless it is
+// retrievable now.
+//
+// The sibling file (#712) covers the `secret_excluded` half of the same audit.
+
+// TestListFilesReportsAPendingDocumentAsPending is the contract. A document
+// that is not retrievable yet must not be advertised as indexed.
+func TestListFilesReportsAPendingDocumentAsPending(t *testing.T) {
+	tmp := t.TempDir()
+	st := store.NewSQLiteStore(filepath.Join(tmp, "meta.sqlite"))
+	if err := st.Init(context.Background()); err != nil {
+		t.Fatalf("init store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	seed := []model.Document{
+		{RelPath: "notes/indexed.md", DocType: "md", MTimeUnix: 100, Status: "ok"},
+		{RelPath: "notes/in-progress.md", DocType: "md", MTimeUnix: 200, Status: "pending"},
+	}
+	root := filepath.Join(tmp, "corpus")
+	seedCorpus(t, st, root, seed)
+
+	statuses := listFileStatuses(t, tmp, root, st)
+
+	if got := statuses["notes/in-progress.md"]; got != "pending" {
+		t.Fatalf("a document that is not indexed yet is reported as %q; a caller reads that as indexed and readable, then asks for content that does not exist (#676)", got)
+	}
+	// A document that IS retrievable must keep saying so. The fix must not turn
+	// the honest answer into a hedge.
+	if got := statuses["notes/indexed.md"]; got != "ok" {
+		t.Fatalf("indexed document reported as %q, want ok", got)
+	}
+}
+
+// TestListFilesNeverReportsUnfinishedWorkAsOK states the SPEC 0.48.0 rule
+// directly, rather than the one value that broke it: `ok` is a promise that the
+// document is retrievable now, so no state that means "not yet" may map onto
+// it. A future store state that reuses the default arm would pass the test
+// above and fail this one.
+func TestListFilesNeverReportsUnfinishedWorkAsOK(t *testing.T) {
+	tmp := t.TempDir()
+	st := store.NewSQLiteStore(filepath.Join(tmp, "meta.sqlite"))
+	if err := st.Init(context.Background()); err != nil {
+		t.Fatalf("init store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	// Every stored state that means "this document is not retrievable".
+	notRetrievable := []string{"pending", "skipped", "secret_excluded", "error"}
+	docs := make([]model.Document, 0, len(notRetrievable))
+	for i, status := range notRetrievable {
+		docs = append(docs, model.Document{
+			RelPath:   "f" + string(rune('a'+i)) + ".md",
+			DocType:   "md",
+			MTimeUnix: int64(100 * (i + 1)),
+			Status:    status,
+		})
+	}
+	root := filepath.Join(tmp, "corpus")
+	seedCorpus(t, st, root, docs)
+
+	for relPath, status := range listFileStatuses(t, tmp, root, st) {
+		if status == "ok" {
+			t.Errorf("%s is not retrievable in the store, but list_files reports it as ok; SPEC 15.5 forbids reporting work that has not finished as ok", relPath)
+		}
+	}
+}

--- a/tests/mcp/list_files_secret_excluded_712_test.go
+++ b/tests/mcp/list_files_secret_excluded_712_test.go
@@ -30,9 +30,11 @@ import (
 // skip for the very row `list_files` called healthy. It also undid the
 // operator-facing audit value #425 restored by persisting the state at all.
 //
-// The published schema (spec/tools/schemas/list_files.json) pins status to
-// `ok|skipped|error`, so `skipped` is the conforming honest projection and no
-// spec change is needed.
+// The published schema (spec/tools/schemas/list_files.json) pinned status to
+// `ok|skipped|error`, so `skipped` was the conforming honest projection and no
+// spec change was needed. SPEC 0.48.0 later made that mapping normative rather
+// than merely conforming, and added `pending` for the other half of the same
+// audit (#676).
 
 func TestListFilesReportsASecretExcludedDocumentAsSkipped(t *testing.T) {
 	tmp := t.TempDir()
@@ -70,7 +72,8 @@ func TestListFilesReportsASecretExcludedDocumentAsSkipped(t *testing.T) {
 
 // TestListFilesStatusesStayInsideThePublishedEnum guards the projection itself
 // rather than one value: whatever the store grows next, this tool may only emit
-// the three states its schema advertises.
+// the states its schema advertises. The set grew by one in SPEC 0.48.0, which
+// added `pending` for a document that is known and not yet retrievable (#676).
 func TestListFilesStatusesStayInsideThePublishedEnum(t *testing.T) {
 	tmp := t.TempDir()
 	st := store.NewSQLiteStore(filepath.Join(tmp, "meta.sqlite"))
@@ -91,10 +94,10 @@ func TestListFilesStatusesStayInsideThePublishedEnum(t *testing.T) {
 	root := filepath.Join(tmp, "corpus")
 	seedCorpus(t, st, root, docs)
 
-	allowed := map[string]bool{"ok": true, "skipped": true, "error": true}
+	allowed := map[string]bool{"ok": true, "skipped": true, "pending": true, "error": true}
 	for relPath, status := range listFileStatuses(t, tmp, root, st) {
 		if !allowed[status] {
-			t.Fatalf("%s reported status %q, outside the published enum ok|skipped|error", relPath, status)
+			t.Fatalf("%s reported status %q, outside the published enum ok|skipped|pending|error", relPath, status)
 		}
 	}
 }


### PR DESCRIPTION
Fixes the intermittent `race` job failure that has been showing up on unrelated branches. **Not a flake, and not the `chdir` helper.**

## The failure

```
reindex_backup_preservation_727_test.go:208: crash-seed BackupContentHashes:
refusing to overwrite the existing content-hash snapshot in _reindex_hash_backup:
it holds an unrecovered generation, so run `dir2mcp reindex` to finish the
interrupted recovery first
```

That message is the refusal PR #811 added. The product is behaving exactly as designed. The test helper is what is wrong.

## Mechanism

`crashHashStateFromCurrent` simulates a crashed reindex: snapshot the content hashes, clear them, stop. A real run does one thing first. `snapshotContentHashes` calls `restoreInterruptedReindexHashes` BEFORE `BackupContentHashes`, so it recovers whatever an earlier crashed run left behind.

The helper skipped that step. Before #811 nothing noticed, because a snapshot silently dropped and recreated the table. Since #811 a snapshot refuses to overwrite one that is already there, so the helper now asks the store for something no real run ever asks for.

It fails whenever a previous attempt leaves a snapshot behind, for example when a run exits early, before it establishes its own staging. That is timing and environment dependent, which is exactly why it reads as a flake.

## The fix

The helper recovers first, then snapshots. That is the order the product uses, so the simulation gets MORE faithful, not less, and it stops depending on how far the previous attempt got. `ErrNoContentHashSnapshot` and `ErrEmptyContentHashSnapshot` are the normal case and are tolerated; any other error still fails the test.

No product code changes.

## Proof

A probe that leaves a snapshot in place, which is the state CI was in:

- helper from main: reproduces the CI message exactly.
- helper from this branch: passes.

`TestReindex_AfterCrash*` passes with `-count=3`. `make check` passes.

## Why this matters beyond the noise

The anti-rotation guard in #727 is the test that proves repeated crashes cannot destroy the last-known-good generation. A guard that fails for its own reasons gets re-run until it is green, and then it is not a guard any more.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File listings now accurately report documents still being processed as `pending` instead of incorrectly showing them as complete.
  * Status reporting no longer labels unfinished, skipped, excluded, or errored documents as `ok`.

* **Tests**
  * Added coverage for pending document statuses and reindex recovery scenarios.
  * Updated status validation to recognize `pending` as a supported state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->