### PR TITLE
fix(retrieval): keep every hit when a rerank response is partial or repeats an index (#669)

### DIFF
--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -2917,10 +2917,10 @@ func (s *Service) hybridVectorCandidateLimit(k int, idx model.Index) int {
 // of the pool, keeps the pre-rerank order. A response that scores only part of
 // the pool keeps the unscored candidates instead of dropping them, so the
 // result count never falls below the pre-rerank count for the same k
-// (issue #669). Output is
-// deterministically ordered (relevance desc, then chunk_id asc) so ties
-// don't depend on provider response ordering (SPEC 9.1.1). Extracted
-// from the search paths to keep their cyclomatic complexity in budget.
+// (issue #669). Output is deterministically ordered (relevance desc, then
+// chunk_id asc) so ties don't depend on provider response ordering
+// (SPEC 9.1.1). Extracted from the search paths to keep their cyclomatic
+// complexity in budget.
 func (s *Service) rerankPool(ctx context.Context, query string, hits []model.SearchHit, k int) []model.SearchHit {
 	s.metaMu.RLock()
 	enabled := s.rerankEnabled

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -2913,7 +2913,11 @@ func (s *Service) hybridVectorCandidateLimit(k int, idx model.Index) int {
 // rerankPool applies the optional rerank stage to a fused candidate
 // pool and returns the best k. When rerank is disabled or no reranker
 // is configured it is exactly truncateSearchHits(hits, k). It is
-// fail-open: any provider error keeps the pre-rerank order. Output is
+// fail-open: any provider error, and any response that is not a valid ranking
+// of the pool, keeps the pre-rerank order. A response that scores only part of
+// the pool keeps the unscored candidates instead of dropping them, so the
+// result count never falls below the pre-rerank count for the same k
+// (issue #669). Output is
 // deterministically ordered (relevance desc, then chunk_id asc) so ties
 // don't depend on provider response ordering (SPEC 9.1.1). Extracted
 // from the search paths to keep their cyclomatic complexity in budget.
@@ -2954,22 +2958,9 @@ func (s *Service) rerankPool(ctx context.Context, query string, hits []model.Sea
 		}
 		return s.diversifyAndTruncate(fused, k)
 	}
-	out := make([]model.SearchHit, 0, len(fused))
-	for _, r := range results {
-		if r.Index < 0 || r.Index >= len(cand) {
-			s.logf("rerank: out-of-range index %d, falling back to fused order", r.Index)
-			return s.diversifyAndTruncate(fused, k)
-		}
-		h := cand[r.Index]
-		h.Score = r.RelevanceScore
-		// The reranker scored this (query, chunk) pair directly, so its score is
-		// an absolute relevance signal on the provider's own scale and supersedes
-		// the cosine reading recorded at retrieval time (SPEC §9.4.3). The
-		// un-reranked tail appended below keeps whatever scale it already carried,
-		// which is exactly why the scale travels per hit rather than per response.
-		h.EvidenceScore = r.RelevanceScore
-		h.EvidenceScale = evidenceScaleRerank
-		out = append(out, h)
+	out, scored, ok := s.rerankedHits(cand, results)
+	if !ok {
+		return s.diversifyAndTruncate(fused, k)
 	}
 	sort.SliceStable(out, func(i, j int) bool {
 		if out[i].Score != out[j].Score {
@@ -2977,12 +2968,60 @@ func (s *Service) rerankPool(ctx context.Context, query string, hits []model.Sea
 		}
 		return out[i].ChunkID < out[j].ChunkID
 	})
-	// Preserve fused candidates beyond the reranked pool so rerank only
-	// reorders and never returns fewer than k when more were available.
+	// Preserve every candidate the provider did not score, in fused order, so
+	// rerank only reorders and never returns fewer than k when more were
+	// available (SPEC §9.1.1 "no result loss"). Two sources feed this tail:
+	// pool members the provider left out of its response (it may cap the
+	// response at top_n), then fused candidates beyond the pool.
+	for i, h := range cand {
+		if !scored[i] {
+			out = append(out, h)
+		}
+	}
 	if len(fused) > len(cand) {
 		out = append(out, fused[len(cand):]...)
 	}
 	return s.diversifyAndTruncate(out, k)
+}
+
+// rerankedHits maps a provider response onto the candidate pool that was sent
+// to it. It returns the re-scored hits plus a scored[i] mask over cand, so the
+// caller can append the candidates the provider left out.
+//
+// A response is rejected whole (ok=false) when it is not a valid ranking of the
+// pool: an index outside the pool, or an index repeated. Both would corrupt the
+// result set (a repeated index duplicates a hit), and neither can be repaired
+// without guessing what the provider meant. Rejection routes the query to the
+// same fail-open fallback as a provider error: the deterministic pre-rerank
+// fused order, truncated to k (SPEC §9.1.1). A response that merely omits
+// candidates is NOT malformed: providers legitimately return only their top_n,
+// so those candidates are kept by the caller instead.
+func (s *Service) rerankedHits(cand []model.SearchHit, results []model.Reranked) ([]model.SearchHit, []bool, bool) {
+	out := make([]model.SearchHit, 0, len(cand))
+	scored := make([]bool, len(cand))
+	for _, r := range results {
+		if r.Index < 0 || r.Index >= len(cand) {
+			s.logf("rerank: out-of-range index %d, falling back to fused order", r.Index)
+			return nil, nil, false
+		}
+		if scored[r.Index] {
+			s.logf("rerank: duplicate index %d, falling back to fused order", r.Index)
+			return nil, nil, false
+		}
+		scored[r.Index] = true
+		h := cand[r.Index]
+		h.Score = r.RelevanceScore
+		// The reranker scored this (query, chunk) pair directly, so its score is
+		// an absolute relevance signal on the provider's own scale and supersedes
+		// the cosine reading recorded at retrieval time (SPEC §9.4.3). The
+		// un-reranked tail appended by the caller keeps whatever scale it already
+		// carried, which is exactly why the scale travels per hit rather than per
+		// response.
+		h.EvidenceScore = r.RelevanceScore
+		h.EvidenceScale = evidenceScaleRerank
+		out = append(out, h)
+	}
+	return out, scored, true
 }
 
 // rerankDocs returns the text sent to the reranker for each candidate. The

--- a/tests/retrieval/rerank_partial_669_test.go
+++ b/tests/retrieval/rerank_partial_669_test.go
@@ -1,0 +1,164 @@
+package tests
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// rawReranker returns exactly the indices it is given, without the sanity
+// filtering fakeReranker applies. It models a provider that answers HTTP 200
+// with a malformed or partial result set: fewer indices than candidates, a
+// repeated index, or an index outside the pool (issue #669).
+type rawReranker struct {
+	mu       sync.Mutex
+	calls    int
+	lastDocs []string
+	indices  []int
+}
+
+func (r *rawReranker) Rerank(_ context.Context, _ string, _ string, docs []string, _ int) ([]model.Reranked, error) {
+	r.mu.Lock()
+	r.calls++
+	r.lastDocs = append([]string(nil), docs...)
+	r.mu.Unlock()
+	out := make([]model.Reranked, 0, len(r.indices))
+	for rank, idx := range r.indices {
+		out = append(out, model.Reranked{Index: idx, RelevanceScore: float64(len(r.indices) - rank)})
+	}
+	return out, nil
+}
+
+// chunkIDs collects the chunk ids of hits in result order.
+func chunkIDs(hits []model.SearchHit) []uint64 {
+	ids := make([]uint64, 0, len(hits))
+	for _, h := range hits {
+		ids = append(ids, h.ChunkID)
+	}
+	return ids
+}
+
+// assertNoLossNoDuplicate checks the two invariants of SPEC 9.1.1 "no result
+// loss": every pre-rerank hit still appears, and no hit appears twice.
+func assertNoLossNoDuplicate(t *testing.T, before, after []model.SearchHit) {
+	t.Helper()
+	if len(after) != len(before) {
+		t.Fatalf("rerank changed the result count: got %d (%v) want %d (%v)",
+			len(after), chunkIDs(after), len(before), chunkIDs(before))
+	}
+	seen := map[uint64]int{}
+	for _, h := range after {
+		seen[h.ChunkID]++
+		if seen[h.ChunkID] > 1 {
+			t.Fatalf("rerank duplicated chunk %d: got %v", h.ChunkID, chunkIDs(after))
+		}
+	}
+	for _, h := range before {
+		if seen[h.ChunkID] == 0 {
+			t.Fatalf("rerank dropped chunk %d: got %v want the set %v",
+				h.ChunkID, chunkIDs(after), chunkIDs(before))
+		}
+	}
+}
+
+// A provider that scores only part of the pool must not drop the rest. The
+// unscored candidates are appended after the reranked ones in fused order.
+func TestRerank_PartialResultSetKeepsUnscoredCandidates(t *testing.T) {
+	svc := rerankTestService(t)
+	before := search(t, svc, 3)
+	if len(before) != 3 {
+		t.Fatalf("need 3 fused hits, got %d", len(before))
+	}
+
+	rr := &rawReranker{indices: []int{1, 0}} // 3 candidates sent, only 2 scored
+	svc.SetReranker(rr, "m", 50)
+	svc.SetRerankEnabled(true)
+
+	after := search(t, svc, 3)
+	if rr.calls != 1 {
+		t.Fatalf("reranker calls=%d, want 1", rr.calls)
+	}
+	rr.mu.Lock()
+	sent := len(rr.lastDocs)
+	rr.mu.Unlock()
+	if sent != 3 {
+		t.Fatalf("reranker must see the whole pool: saw %d docs, want 3", sent)
+	}
+	assertNoLossNoDuplicate(t, before, after)
+	// The two scored candidates were inverted, so they lead in inverted order
+	// and the unscored candidate lands last.
+	if after[0].ChunkID != before[1].ChunkID {
+		t.Fatalf("scored candidates must lead in provider order: got %v", chunkIDs(after))
+	}
+	if after[2].ChunkID != before[2].ChunkID {
+		t.Fatalf("unscored candidate must be appended last in fused order: got %v", chunkIDs(after))
+	}
+}
+
+// A repeated index makes the response an invalid ranking. It must never emit
+// the same hit twice; the query falls open to the fused order.
+func TestRerank_DuplicateIndexFallsOpenWithoutDuplicatingHits(t *testing.T) {
+	svc := rerankTestService(t)
+	before := search(t, svc, 3)
+	if len(before) != 3 {
+		t.Fatalf("need 3 fused hits, got %d", len(before))
+	}
+
+	rr := &rawReranker{indices: []int{0, 0, 1}}
+	svc.SetReranker(rr, "m", 50)
+	svc.SetRerankEnabled(true)
+
+	after := search(t, svc, 3)
+	assertNoLossNoDuplicate(t, before, after)
+	for i := range before {
+		if after[i].ChunkID != before[i].ChunkID {
+			t.Fatalf("fail-open must preserve fused order at %d: got %v want %v",
+				i, chunkIDs(after), chunkIDs(before))
+		}
+	}
+}
+
+// A mixed response (valid plus out-of-range indices) is rejected whole, the
+// same policy the provider-error path uses.
+func TestRerank_MixedValidAndOutOfRangeFallsOpen(t *testing.T) {
+	svc := rerankTestService(t)
+	before := search(t, svc, 3)
+
+	rr := &rawReranker{indices: []int{0, 7, 1}}
+	svc.SetReranker(rr, "m", 50)
+	svc.SetRerankEnabled(true)
+
+	after := search(t, svc, 3)
+	assertNoLossNoDuplicate(t, before, after)
+	for i := range before {
+		if after[i].ChunkID != before[i].ChunkID {
+			t.Fatalf("fail-open must preserve fused order at %d: got %v want %v",
+				i, chunkIDs(after), chunkIDs(before))
+		}
+	}
+}
+
+// A partial response with the pool capped below k must keep both the unscored
+// pool members and the fused tail beyond the pool.
+func TestRerank_PartialResultSetWithPoolBelowKKeepsEveryHit(t *testing.T) {
+	svc := rerankTestService(t)
+	before := search(t, svc, 3)
+	if len(before) != 3 {
+		t.Fatalf("need 3 fused hits, got %d", len(before))
+	}
+
+	rr := &rawReranker{indices: []int{1}} // 2 candidates sent, only 1 scored
+	svc.SetReranker(rr, "m", 2)           // pool < k
+	svc.SetRerankEnabled(true)
+
+	after := search(t, svc, 3)
+	assertNoLossNoDuplicate(t, before, after)
+	if after[0].ChunkID != before[1].ChunkID {
+		t.Fatalf("the scored candidate must lead: got %v", chunkIDs(after))
+	}
+	if after[2].ChunkID != before[2].ChunkID {
+		t.Fatalf("the fused tail beyond the pool must stay last: got %v", chunkIDs(after))
+	}
+}


### PR DESCRIPTION
Closes #669

## Symptom

`search` (and `ask`, which retrieves through the same path) returned fewer hits
than the corpus offered, or returned the same chunk twice.

The trigger is a rerank provider that answers HTTP 200 with a result set that
does not cover the pool it was sent:

- **Partial response.** The provider scores only part of the candidate pool. A
  provider is free to cap its response at `top_n`, or to omit low-scoring
  candidates. Example from the issue: ten candidates, `k=5`, the provider
  returns indices 0 and 1. The caller saw two hits, not five. With rerank off,
  the same query returned five.
- **Repeated index.** The provider lists the same index twice. The caller saw
  the same `chunk_id`, `rel_path` and `snippet` twice, and lost a different hit
  to the truncation to `k`. A citation set then over-counted one chunk as two
  independent sources.

Both cases were silent. No error, no warning, no field to inspect. Turning
rerank off "restored" the missing results, which made the cause hard to see.

## Cause

`rerankPool` in `internal/retrieval/service.go` sent the whole capped pool
(`cand`), then rebuilt the result list from the returned indices only, then
appended `fused[len(cand):]`. That tail holds the fused candidates **beyond**
the pool, so every pool member the provider left out was dropped. Index
validation covered range only, so a repeated index copied its hit twice.

## Fix

`rerankedHits` (new helper) maps the response onto the pool and reports which
pool members the provider scored. `rerankPool` then appends the unscored pool
members after the reranked ones, in fused order, before truncation. The fused
tail beyond the pool follows, as before. The result count can no longer fall
below the pre-rerank count for the same `k`.

## The fail-open decision

The issue allows two answers for a malformed successful response: fail open to
the fused order, or repair the response. This PR splits the two cases, because
only one of them is malformed.

**A partial response is normal, so it is repaired, not rejected.** `Rerank` is
called with `k` as `top_n`. A conforming Cohere call therefore returns `k`
results out of a pool of up to 50. Treating "fewer results than candidates" as
malformed would fail open on almost every healthy rerank call and disable the
stage in practice. SPEC 9.1.1 already names the repair for the sibling case
(`candidate_pool < k`): append the un-reranked candidates after the reranked
ones in fused order. The same rule now covers candidates the provider omitted.

**A repeated index is malformed, so the whole response is rejected.** The
precedent is in the same function, and I followed it rather than inventing a
policy. The retrieval code treats a degraded rerank provider as a provider to
ignore, not a provider to partly trust:

- a provider error falls open to the fused order (`rerankPool`);
- an empty result set falls open to the fused order (`rerankPool`);
- an out-of-range index falls open to the fused order (`rerankPool`);
- a rerank provider with no credential stays off silently (SPEC 8.4).

A repeated index means the response is not a ranking of the pool. Keeping the
first occurrence and dropping the rest would guess what the provider meant,
and would ship a half-trusted ranking. Rejecting it takes the query to the
deterministic pre-rerank order, which is the outcome the other three malformed
cases already produce. Ranking quality degrades to un-reranked; correctness
does not degrade at all.

The query never fails. SPEC 9.1.1 and 8.4 both state that a query MUST NOT fail
because rerank failed, so failing the call was not an option.

## SPEC check

No SPEC change is needed. This PR makes the code match the SPEC that is already
pinned:

- 9.1.1 **No result loss**: "reranking MUST NOT reduce the result count below
  what the pre-rerank fused order would return for the same `k`".
- 9.1.1: "Reranking only reorders results ... it MUST NOT change the result
  structure".
- 9.1.1 **Fail-open**: "any provider error falls back to the pre-rerank fused
  order, truncated to `k`".

The old behavior broke the first two rules. No normative text moves, so no
`dirstral-spec` PR gates this one.

## Tests

`tests/retrieval/rerank_partial_669_test.go` adds a `rawReranker` that emits
exactly the indices it is given, so a test can model a non-conforming provider.
`fakeReranker` filters its own indices, which is why it could not reach this
bug. Every case asserts both invariants: no hit is lost, and no hit is
repeated.

| Test | Provider response | On `main` |
| --- | --- | --- |
| `PartialResultSetKeepsUnscoredCandidates` | 3 sent, indices `{1,0}` | FAIL: 2 hits, want 3 |
| `DuplicateIndexFallsOpenWithoutDuplicatingHits` | indices `{0,0,1}` | FAIL: chunk 1 twice |
| `PartialResultSetWithPoolBelowKKeepsEveryHit` | pool 2 of 3, index `{1}` | FAIL: 2 hits, want 3 |
| `MixedValidAndOutOfRangeFallsOpen` | indices `{0,7,1}` | PASS (regression guard) |

Baseline on `main`:

```
--- FAIL: TestRerank_PartialResultSetKeepsUnscoredCandidates (0.00s)
    rerank changed the result count: got 2 ([2 1]) want 3 ([1 2 3])
--- FAIL: TestRerank_DuplicateIndexFallsOpenWithoutDuplicatingHits (0.00s)
    rerank duplicated chunk 1: got [1 1 2]
--- FAIL: TestRerank_PartialResultSetWithPoolBelowKKeepsEveryHit (0.00s)
    rerank changed the result count: got 2 ([2 3]) want 3 ([1 2 3])
--- PASS: TestRerank_MixedValidAndOutOfRangeFallsOpen (0.00s)
```

All four pass with this change, together with the seven existing `TestRerank_*`
cases.

## Gates

- `make check`: pass.
- `go test -race ./tests/retrieval/...`: pass.
- `gocyclo -over 15 internal/retrieval/`: clean. `rerankPool` sits at 14 after
  the helper extraction.
- `coderabbit review --committed`: 0 findings.

## Out of scope

- The Cohere and ColBERT adapters keep their range-only validation. Every
  reranker reaches the result set through `rerankPool`, so one guard at that
  choke point covers all providers, current and future. A duplicate check in
  each adapter would repeat the rule per provider and could drift.
- No new metric or structured field reports a rejected response. The rejection
  logs a reason, like the paths beside it. A counter is a separate change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reranking reliability when providers return incomplete, duplicate, malformed, or out-of-range results.
  * Preserved unscored and lower-ranked candidates to prevent valid results from being lost.
  * Maintained relevance and supporting evidence metadata on reranked results.
  * Added deterministic fallback behavior for invalid reranker responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->