### PR TITLE
test(conformance): run the suite on the production SDK transport, and expose the video clip gap

### DIFF
--- a/tests/conformance/errors_test.go
+++ b/tests/conformance/errors_test.go
@@ -14,7 +14,7 @@ import (
 func TestErrors_JSONRPCErrorShape(t *testing.T) {
 	t.Parallel()
 	cfg := defaultConfig()
-	srv := newServer(cfg)
+	srv := newServer(t, cfg)
 	defer srv.Close()
 
 	sid := initSession(t, srv.URL+cfg.MCPPath)
@@ -58,7 +58,7 @@ func TestErrors_HTTPUnauthorized(t *testing.T) {
 	cfg.AuthMode = "token"
 	cfg.ResolvedAuthToken = "secret-token"
 
-	srv := newServer(cfg)
+	srv := newServer(t, cfg)
 	defer srv.Close()
 
 	resp := sendRPC(t, srv.URL+cfg.MCPPath, "", `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`, nil)
@@ -84,7 +84,7 @@ func TestErrors_HTTPUnauthorized(t *testing.T) {
 func TestErrors_HTTPMethodNotAllowed(t *testing.T) {
 	t.Parallel()
 	cfg := defaultConfig()
-	srv := newServer(cfg)
+	srv := newServer(t, cfg)
 	defer srv.Close()
 
 	req, err := http.NewRequest(http.MethodGet, srv.URL+cfg.MCPPath, nil)
@@ -107,7 +107,7 @@ func TestErrors_HTTPMethodNotAllowed(t *testing.T) {
 func TestErrors_ParseErrorHasStandardCode(t *testing.T) {
 	t.Parallel()
 	cfg := defaultConfig()
-	srv := newServer(cfg)
+	srv := newServer(t, cfg)
 	defer srv.Close()
 
 	resp := sendRPC(t, srv.URL+cfg.MCPPath, "", `{bad json`, nil)

--- a/tests/conformance/helpers_test.go
+++ b/tests/conformance/helpers_test.go
@@ -1,19 +1,27 @@
 // Package conformance contains conformance tests that drive the dir2mcp MCP
 // server over HTTP and assert externally-observable behaviour: tool response
-// shapes, error codes, session lifecycle, and x402 header behaviour.  Tests
-// construct the server in-process using mcp.NewServer + httptest and drive it
-// exclusively with raw JSON-RPC payloads via net/http — assertions are made
-// only against HTTP responses, not against internal state.
+// shapes, error codes, session lifecycle, and x402 header behaviour. Tests drive
+// the server exclusively with raw JSON-RPC payloads via net/http; assertions are
+// made only against HTTP responses, never against internal state.
+//
+// The suite runs the PRODUCTION transport. newServer starts mcp.SDKTransport on a
+// real listener, wired the way internal/cli/up.go wires it, so a conformance
+// assertion reads the contract a real client gets. Server.Handler() is reachable
+// through newDirectHandlerServer, but only for unit-level parity checks: it is
+// not the chain production serves for MCP-path POST and DELETE (issue #664).
 package conformance
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -94,10 +102,74 @@ func x402Config(t *testing.T, facilitatorURL string) config.Config {
 	return cfg
 }
 
-// newServer starts an httptest.Server with the given config.
-// Callers are responsible for calling srv.Close().
-func newServer(cfg config.Config, opts ...mcp.ServerOption) *httptest.Server {
-	return httptest.NewServer(mcp.NewServer(cfg, nil, opts...).Handler())
+// runningServer is a live dir2mcp MCP endpoint. It exposes the same URL/Close
+// surface as httptest.Server, so a test reads the same whichever transport
+// serves it.
+type runningServer struct {
+	// URL is the scheme+host root of the endpoint, without the MCP path.
+	URL string
+
+	cancel   context.CancelFunc
+	done     chan error
+	closeOne sync.Once
+}
+
+// Close stops the endpoint and waits for the transport to return. It is safe to
+// call more than once, so a `defer srv.Close()` in a test and the registered
+// cleanup can both run.
+func (s *runningServer) Close() {
+	s.closeOne.Do(func() {
+		s.cancel()
+		select {
+		case <-s.done:
+		case <-time.After(serverCloseTimeout):
+		}
+	})
+}
+
+// serverCloseTimeout bounds how long Close waits for the transport goroutine.
+const serverCloseTimeout = 15 * time.Second
+
+// newServer starts the PRODUCTION MCP endpoint on a real listener.
+//
+// It wires mcp.SDKTransport exactly as internal/cli/up.go does: the SDK
+// transport owns POST and DELETE on the MCP path, and Server.Handler() is
+// passed in only as the fallback for every other path and for OPTIONS.
+// Conformance assertions therefore run against the code a real client reaches.
+//
+// Before issue #664 this helper served Server.Handler() directly. Production
+// never serves that chain for MCP-path POST/DELETE, so protocol, lifecycle,
+// session, CORS and content-conversion regressions could pass as green. Use
+// newDirectHandlerServer only for the few assertions that target the direct
+// handler on purpose.
+func newServer(t *testing.T, cfg config.Config, opts ...mcp.ServerOption) *runningServer {
+	t.Helper()
+	server := mcp.NewServer(cfg, nil, opts...)
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	transport := mcp.NewSDKTransport(server, ln, "", "")
+	ctx, cancel := context.WithCancel(context.Background())
+	srv := &runningServer{
+		URL:    "http://" + ln.Addr().String(),
+		cancel: cancel,
+		done:   make(chan error, 1),
+	}
+	go func() { srv.done <- transport.Serve(ctx, server.Handler()) }()
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// newDirectHandlerServer serves Server.Handler() directly, with no SDK
+// transport in front of it. This is a UNIT-level helper, not the production
+// path (issue #664): use it only to pin behaviour of the direct handler chain
+// itself, for example a parity check against the production path.
+func newDirectHandlerServer(t *testing.T, cfg config.Config, opts ...mcp.ServerOption) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(mcp.NewServer(cfg, nil, opts...).Handler())
+	t.Cleanup(srv.Close)
+	return srv
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/conformance/lifecycle_test.go
+++ b/tests/conformance/lifecycle_test.go
@@ -17,7 +17,7 @@ import (
 func TestLifecycle_Initialize(t *testing.T) {
 	t.Parallel()
 	cfg := defaultConfig()
-	srv := newServer(cfg)
+	srv := newServer(t, cfg)
 	defer srv.Close()
 
 	resp := sendRPC(t, srv.URL+cfg.MCPPath, "", `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`, nil)
@@ -57,7 +57,7 @@ func TestLifecycle_Initialize(t *testing.T) {
 func TestLifecycle_UnknownMethod(t *testing.T) {
 	t.Parallel()
 	cfg := defaultConfig()
-	srv := newServer(cfg)
+	srv := newServer(t, cfg)
 	defer srv.Close()
 
 	sid := initSession(t, srv.URL+cfg.MCPPath)
@@ -83,7 +83,7 @@ func TestLifecycle_UnknownMethod(t *testing.T) {
 func TestLifecycle_MalformedJSON(t *testing.T) {
 	t.Parallel()
 	cfg := defaultConfig()
-	srv := newServer(cfg)
+	srv := newServer(t, cfg)
 	defer srv.Close()
 
 	resp := sendRPC(t, srv.URL+cfg.MCPPath, "", `{not valid json`, nil)
@@ -108,7 +108,7 @@ func TestLifecycle_MalformedJSON(t *testing.T) {
 func TestLifecycle_MissingSession(t *testing.T) {
 	t.Parallel()
 	cfg := defaultConfig()
-	srv := newServer(cfg)
+	srv := newServer(t, cfg)
 	defer srv.Close()
 
 	resp := sendRPC(t, srv.URL+cfg.MCPPath, "", `{"jsonrpc":"2.0","id":3,"method":"tools/list","params":{}}`, nil)
@@ -131,7 +131,7 @@ func TestLifecycle_MissingSession(t *testing.T) {
 func TestLifecycle_InitializeMissingJSONRPC(t *testing.T) {
 	t.Parallel()
 	cfg := defaultConfig()
-	srv := newServer(cfg)
+	srv := newServer(t, cfg)
 	defer srv.Close()
 
 	resp := sendRPC(t, srv.URL+cfg.MCPPath, "", `{"id":1,"method":"initialize","params":{}}`, nil)
@@ -153,7 +153,7 @@ func TestLifecycle_AuthRequired(t *testing.T) {
 	cfg.AuthMode = "token"
 	cfg.ResolvedAuthToken = "supersecret"
 
-	srv := newServer(cfg)
+	srv := newServer(t, cfg)
 	defer srv.Close()
 
 	resp := sendRPC(t, srv.URL+cfg.MCPPath, "", `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`, nil)

--- a/tests/conformance/media_content_test.go
+++ b/tests/conformance/media_content_test.go
@@ -1,0 +1,223 @@
+package conformance
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/protocol"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// clipBytes is the canned payload the stub extractor returns. It stands in for
+// real media bytes so the suite needs no ffmpeg on PATH.
+var clipBytes = []byte("FAKE_MEDIA_CLIP_BYTES")
+
+// seedMediaClipCorpus builds a one-document corpus for dir2mcp_open_media_clip:
+// a media file on disk, its store row, a transcript representation, and one chunk
+// with a time span. It returns the config, the server options that wire the store
+// and a stub extractor, and the chunk id to call the tool with.
+func seedMediaClipCorpus(t *testing.T, relPath, docType string) (config.Config, []mcp.ServerOption, int64) {
+	t.Helper()
+	ctx := context.Background()
+
+	rootDir := t.TempDir()
+	stateDir := filepath.Join(rootDir, ".dir2mcp")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rootDir, relPath), []byte("source-media"), 0o644); err != nil {
+		t.Fatalf("write media file: %v", err)
+	}
+
+	st := store.NewSQLiteStore(filepath.Join(stateDir, "meta.sqlite"))
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("init store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	if err := st.UpsertDocument(ctx, model.Document{
+		RelPath:     relPath,
+		DocType:     docType,
+		SourceType:  "filesystem",
+		SizeBytes:   int64(len("source-media")),
+		MTimeUnix:   1,
+		ContentHash: "h1",
+		Status:      "ok",
+	}); err != nil {
+		t.Fatalf("upsert document: %v", err)
+	}
+	doc, err := st.GetDocumentByPath(ctx, relPath)
+	if err != nil {
+		t.Fatalf("get document: %v", err)
+	}
+	repID, err := st.UpsertRepresentation(ctx, model.Representation{
+		DocID:       doc.DocID,
+		RepType:     "transcript",
+		RepHash:     "rep-hash",
+		CreatedUnix: time.Now().Unix(),
+	})
+	if err != nil {
+		t.Fatalf("upsert representation: %v", err)
+	}
+	chunkID, err := st.InsertChunkWithSpans(ctx, model.Chunk{
+		RepID:   repID,
+		Ordinal: 0,
+		Text:    "hello world",
+	}, []model.Span{{Kind: "time", StartMS: 1000, EndMS: 4000}})
+	if err != nil {
+		t.Fatalf("insert chunk: %v", err)
+	}
+
+	cfg := config.Default()
+	cfg.RootDir = rootDir
+	cfg.StateDir = stateDir
+	cfg.MCPPath = protocol.DefaultMCPPath
+	cfg.AuthMode = "none"
+
+	extract := func(_ context.Context, _ string, _, _ int) ([]byte, error) { return clipBytes, nil }
+	opts := []mcp.ServerOption{mcp.WithStore(st), mcp.WithExtractSegment(extract)}
+	return cfg, opts, chunkID
+}
+
+// mediaContentItem is one entry of the tool result's content array.
+type mediaContentItem struct {
+	Type     string `json:"type"`
+	Text     string `json:"text"`
+	Data     string `json:"data"`
+	MIMEType string `json:"mimeType"`
+	Resource *struct {
+		URI      string `json:"uri"`
+		MIMEType string `json:"mimeType"`
+		Blob     string `json:"blob"`
+		Text     string `json:"text"`
+	} `json:"resource"`
+}
+
+// callOpenMediaClip runs dir2mcp_open_media_clip for chunkID against a running
+// endpoint and returns the content items plus the structured output.
+func callOpenMediaClip(t *testing.T, mcpURL string, chunkID int64) ([]mediaContentItem, map[string]interface{}) {
+	t.Helper()
+	sid := initSession(t, mcpURL)
+	body := `{"jsonrpc":"2.0","id":90,"method":"tools/call","params":{"name":"dir2mcp_open_media_clip","arguments":{"chunk_id":` +
+		strconv.FormatInt(chunkID, 10) + `}}}`
+	resp := sendRPC(t, mcpURL, sid, body, nil)
+	raw := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("open_media_clip: status=%d want=200 body=%s", resp.StatusCode, raw)
+	}
+	var envelope struct {
+		Result struct {
+			IsError           bool                   `json:"isError"`
+			Content           []mediaContentItem     `json:"content"`
+			StructuredContent map[string]interface{} `json:"structuredContent"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		t.Fatalf("open_media_clip: decode: %v body=%s", err, raw)
+	}
+	if envelope.Result.IsError {
+		t.Fatalf("open_media_clip: unexpected tool error body=%s", raw)
+	}
+	return envelope.Result.Content, envelope.Result.StructuredContent
+}
+
+// assertClipContentCarriesBytes checks the canonical content[] delivery for an
+// inline clip: exactly one item, it carries the clip bytes, and it is never an
+// empty text item. SPEC §15.11 forbids media bytes in a text item and requires
+// content[] to carry the clip when return=inline.
+func assertClipContentCarriesBytes(t *testing.T, content []mediaContentItem, wantMIME string) {
+	t.Helper()
+	if len(content) != 1 {
+		t.Fatalf("content items = %d, want 1: %+v", len(content), content)
+	}
+	item := content[0]
+	wantData := base64.StdEncoding.EncodeToString(clipBytes)
+
+	if item.Type == "text" {
+		t.Fatalf("content item is a text item (text=%q): media bytes must never travel as text, and an empty text item drops the clip entirely", item.Text)
+	}
+	switch {
+	case item.Data != "":
+		if item.Data != wantData {
+			t.Fatalf("content item data = %q, want base64(%q)", item.Data, clipBytes)
+		}
+		if item.MIMEType != wantMIME {
+			t.Fatalf("content item mimeType = %q, want %q", item.MIMEType, wantMIME)
+		}
+	case item.Resource != nil && item.Resource.Blob != "":
+		if item.Resource.Blob != wantData {
+			t.Fatalf("embedded resource blob = %q, want base64(%q)", item.Resource.Blob, clipBytes)
+		}
+		if item.Resource.MIMEType != wantMIME {
+			t.Fatalf("embedded resource mimeType = %q, want %q", item.Resource.MIMEType, wantMIME)
+		}
+	default:
+		t.Fatalf("content item type=%q carries no clip bytes: %+v", item.Type, item)
+	}
+}
+
+// TestMediaContent_AudioClipReachesTheClient pins the working half of the
+// conversion: an audio clip becomes an audio content item with the clip bytes.
+func TestMediaContent_AudioClipReachesTheClient(t *testing.T) {
+	t.Parallel()
+	cfg, opts, chunkID := seedMediaClipCorpus(t, "voice.mp3", "audio")
+	srv := newServer(t, cfg, opts...)
+	defer srv.Close()
+
+	content, structured := callOpenMediaClip(t, srv.URL+cfg.MCPPath, chunkID)
+	if structured["mime_type"] != "audio/mpeg" {
+		t.Fatalf("structured mime_type = %#v, want audio/mpeg", structured["mime_type"])
+	}
+	// Check the item count and the bytes first: it reports the protocol failure
+	// instead of panicking on an empty content array.
+	assertClipContentCarriesBytes(t, content, "audio/mpeg")
+	if content[0].Type != "audio" {
+		t.Fatalf("content item type = %q, want audio", content[0].Type)
+	}
+}
+
+// TestMediaContent_VideoClipReachesTheClient is the regression test for issue
+// #663: a video clip must reach the client as playable content, not as an empty
+// text item.
+//
+// The tool builds a `video`-typed item whose bytes live in Data. The production
+// SDK conversion maps only text and audio, so a video falls through to
+// TextContent{Text: item.Text}. Text is empty for a media item, so the client sees
+// content[] = [{"type":"text","text":""}]: a successful call with nothing in it.
+//
+// The test is skipped because the fix is blocked on the SPEC, not on the code.
+// SPEC §15.11 requires "an `audio`- or `video`-typed item" for return=inline, but
+// the pinned MCP generation 2025-11-25 defines no `video` content type, and the
+// go-sdk Content interface is closed to outside implementations, so a
+// `video`-typed item cannot be produced at all. A conformant fix has to carry the
+// clip in a shape the SPEC does not yet name (an embedded resource with a blob).
+// dir2mcp is spec-first, so a dirstral-spec PR must define that shape and merge
+// before the code lands. dirstral/dirstral-spec#60 tracks that decision. Remove
+// this skip in the follow-up.
+//
+// Run it to see the failure:
+//
+//	go test ./tests/conformance -run TestMediaContent_VideoClipReachesTheClient
+func TestMediaContent_VideoClipReachesTheClient(t *testing.T) {
+	t.Parallel()
+	t.Skip("blocked on dirstral-spec#60: SPEC §15.11 mandates a video-typed content item, which MCP 2025-11-25 does not define (dir2mcp #663)")
+	cfg, opts, chunkID := seedMediaClipCorpus(t, "clip.mp4", "video")
+	srv := newServer(t, cfg, opts...)
+	defer srv.Close()
+
+	content, structured := callOpenMediaClip(t, srv.URL+cfg.MCPPath, chunkID)
+	if structured["mime_type"] != "video/mp4" {
+		t.Fatalf("structured mime_type = %#v, want video/mp4", structured["mime_type"])
+	}
+	assertClipContentCarriesBytes(t, content, "video/mp4")
+}

--- a/tests/conformance/output_schema_conformance_test.go
+++ b/tests/conformance/output_schema_conformance_test.go
@@ -11,7 +11,7 @@ import (
 func toolsListSchemas(t *testing.T) map[string]interface{} {
 	t.Helper()
 	cfg := defaultConfig()
-	srv := newServer(cfg)
+	srv := newServer(t, cfg)
 	defer srv.Close()
 
 	sid := initSession(t, srv.URL+cfg.MCPPath)

--- a/tests/conformance/production_transport_test.go
+++ b/tests/conformance/production_transport_test.go
@@ -1,0 +1,320 @@
+package conformance
+
+import (
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/protocol"
+)
+
+// This file covers the production transport surface that the suite could not see
+// while it drove Server.Handler() directly (issue #664), plus the anti-drift gate
+// between the production path and the direct handler.
+
+// toolDescriptors calls tools/list and returns the descriptors keyed by name.
+func toolDescriptors(t *testing.T, mcpURL string) map[string]map[string]interface{} {
+	t.Helper()
+	sid := initSession(t, mcpURL)
+	resp := sendRPC(t, mcpURL, sid, `{"jsonrpc":"2.0","id":20,"method":"tools/list","params":{}}`, nil)
+	raw := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("tools/list: status=%d want=200 body=%s", resp.StatusCode, raw)
+	}
+	var envelope struct {
+		Result struct {
+			Tools []map[string]interface{} `json:"tools"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		t.Fatalf("tools/list: decode: %v body=%s", err, raw)
+	}
+	if len(envelope.Result.Tools) == 0 {
+		t.Fatalf("tools/list: no tools returned body=%s", raw)
+	}
+	out := make(map[string]map[string]interface{}, len(envelope.Result.Tools))
+	for _, tool := range envelope.Result.Tools {
+		name, _ := tool["name"].(string)
+		if name == "" {
+			t.Fatalf("tools/list: descriptor without a name: %#v", tool)
+		}
+		out[name] = tool
+	}
+	return out
+}
+
+// TestParity_ToolDescriptors fails when the production transport and the direct
+// handler advertise different tools, descriptions or schemas. Both build from the
+// same registry, so any drift is a bug in one of the two adapters.
+func TestParity_ToolDescriptors(t *testing.T) {
+	t.Parallel()
+	cfg := defaultConfig()
+	production := newServer(t, cfg)
+	defer production.Close()
+	direct := newDirectHandlerServer(t, cfg)
+	defer direct.Close()
+
+	prodTools := toolDescriptors(t, production.URL+cfg.MCPPath)
+	directTools := toolDescriptors(t, direct.URL+cfg.MCPPath)
+
+	for name, want := range directTools {
+		got, ok := prodTools[name]
+		if !ok {
+			t.Errorf("tool %q is advertised by the direct handler but not by the production transport", name)
+			continue
+		}
+		for _, field := range []string{"description", "inputSchema", "outputSchema"} {
+			if !reflect.DeepEqual(got[field], want[field]) {
+				t.Errorf("tool %q field %q diverges:\n production=%#v\n direct    =%#v", name, field, got[field], want[field])
+			}
+		}
+	}
+	for name := range prodTools {
+		if _, ok := directTools[name]; !ok {
+			t.Errorf("tool %q is advertised by the production transport but not by the direct handler", name)
+		}
+	}
+}
+
+// TestParity_ToolExecutionErrorContract fails when a tool that runs and fails
+// reports a different canonical contract on the two paths. A bad argument to a
+// real tool is a tool execution failure, so both paths must return isError=true
+// with the same canonical code (SPEC §12.4, §14.4).
+func TestParity_ToolExecutionErrorContract(t *testing.T) {
+	t.Parallel()
+	cfg := defaultConfig()
+	production := newServer(t, cfg)
+	defer production.Close()
+	direct := newDirectHandlerServer(t, cfg)
+	defer direct.Close()
+
+	const call = `{"jsonrpc":"2.0","id":21,"method":"tools/call","params":{"name":"dir2mcp_open_file","arguments":{"rel_path":""}}}`
+
+	prodCode := toolErrorCode(t, production.URL+cfg.MCPPath, call)
+	directCode := toolErrorCode(t, direct.URL+cfg.MCPPath, call)
+	if prodCode == "" {
+		t.Fatal("production transport returned no canonical tool error code")
+	}
+	if prodCode != directCode {
+		t.Fatalf("canonical tool error code diverges: production=%q direct=%q", prodCode, directCode)
+	}
+}
+
+// toolErrorCode runs a tools/call that must fail and returns the canonical code
+// carried in the structured output.
+func toolErrorCode(t *testing.T, mcpURL, call string) string {
+	t.Helper()
+	sid := initSession(t, mcpURL)
+	resp := sendRPC(t, mcpURL, sid, call, nil)
+	raw := readBody(t, resp)
+	var envelope struct {
+		Result struct {
+			IsError           bool `json:"isError"`
+			StructuredContent struct {
+				Error struct {
+					Code string `json:"code"`
+				} `json:"error"`
+			} `json:"structuredContent"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		t.Fatalf("tool error: decode: %v body=%s", err, raw)
+	}
+	if !envelope.Result.IsError {
+		t.Fatalf("tool error: expected isError=true body=%s", raw)
+	}
+	return envelope.Result.StructuredContent.Error.Code
+}
+
+// TestParity_UnknownToolIsIntentionallyDifferent pins the one known divergence
+// between the two paths, so nobody has to rediscover it.
+//
+// The production transport returns a JSON-RPC -32602 error, which is what MCP
+// requires for an unknown tool name. The direct handler returns a
+// METHOD_NOT_FOUND tool result instead. The production contract is the correct
+// one; this test records the direct handler's behaviour rather than blessing it,
+// and it fails if either side changes.
+func TestParity_UnknownToolIsIntentionallyDifferent(t *testing.T) {
+	t.Parallel()
+	cfg := defaultConfig()
+	production := newServer(t, cfg)
+	defer production.Close()
+	direct := newDirectHandlerServer(t, cfg)
+	defer direct.Close()
+
+	const call = `{"jsonrpc":"2.0","id":22,"method":"tools/call","params":{"name":"dir2mcp_does_not_exist","arguments":{}}}`
+
+	// Production: a JSON-RPC protocol error.
+	prodURL := production.URL + cfg.MCPPath
+	prodResp := sendRPC(t, prodURL, initSession(t, prodURL), call, nil)
+	prodBody := readBody(t, prodResp)
+	code, _ := decodeRPCError(t, prodBody)
+	if code != -32602 {
+		t.Fatalf("production: code=%d want=-32602 body=%s", code, prodBody)
+	}
+
+	// Direct handler: a tool result carrying METHOD_NOT_FOUND.
+	directURL := direct.URL + cfg.MCPPath
+	if got := toolErrorCode(t, directURL, call); got != "METHOD_NOT_FOUND" {
+		t.Fatalf("direct handler: canonical code=%q want=METHOD_NOT_FOUND", got)
+	}
+}
+
+// TestProduction_InitializePinsProtocolVersion verifies the production transport
+// answers initialize with the pinned protocol version, not the version the client
+// asked for (SPEC §11.2).
+func TestProduction_InitializePinsProtocolVersion(t *testing.T) {
+	t.Parallel()
+	cfg := defaultConfig()
+	srv := newServer(t, cfg)
+	defer srv.Close()
+
+	resp := sendRPC(t, srv.URL+cfg.MCPPath, "",
+		`{"jsonrpc":"2.0","id":23,"method":"initialize","params":{"protocolVersion":"2025-03-26"}}`, nil)
+	raw := readBody(t, resp)
+
+	var envelope struct {
+		Result struct {
+			ProtocolVersion string `json:"protocolVersion"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		t.Fatalf("initialize: decode: %v body=%s", err, raw)
+	}
+	if envelope.Result.ProtocolVersion != protocol.ProtocolDefaultVersion {
+		t.Fatalf("protocolVersion = %q, want %q body=%s", envelope.Result.ProtocolVersion, protocol.ProtocolDefaultVersion, raw)
+	}
+}
+
+// TestProduction_NotificationsInitializedIsAccepted verifies the production
+// transport accepts the initialized notification and keeps serving the session.
+func TestProduction_NotificationsInitializedIsAccepted(t *testing.T) {
+	t.Parallel()
+	cfg := defaultConfig()
+	srv := newServer(t, cfg)
+	defer srv.Close()
+
+	sid := initSession(t, srv.URL+cfg.MCPPath)
+	resp := sendRPC(t, srv.URL+cfg.MCPPath, sid, `{"jsonrpc":"2.0","method":"notifications/initialized"}`, nil)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("notifications/initialized: status=%d want=202", resp.StatusCode)
+	}
+
+	after := sendRPC(t, srv.URL+cfg.MCPPath, sid, `{"jsonrpc":"2.0","id":24,"method":"tools/list","params":{}}`, nil)
+	body := readBody(t, after)
+	if after.StatusCode != http.StatusOK || !hasResult(body) {
+		t.Fatalf("tools/list after initialized: status=%d body=%s", after.StatusCode, body)
+	}
+}
+
+// TestProduction_NegotiatedProtocolVersionHeaderIsAccepted verifies a client that
+// echoes the negotiated version keeps working, and that an unsupported version is
+// refused with 400.
+func TestProduction_NegotiatedProtocolVersionHeaderIsAccepted(t *testing.T) {
+	t.Parallel()
+	cfg := defaultConfig()
+	srv := newServer(t, cfg)
+	defer srv.Close()
+
+	sid := initSession(t, srv.URL+cfg.MCPPath)
+
+	ok := sendRPC(t, srv.URL+cfg.MCPPath, sid, `{"jsonrpc":"2.0","id":25,"method":"tools/list","params":{}}`,
+		map[string]string{protocol.MCPProtocolVersionHeader: protocol.ProtocolDefaultVersion})
+	body := readBody(t, ok)
+	if ok.StatusCode != http.StatusOK || !hasResult(body) {
+		t.Fatalf("tools/list with the negotiated version: status=%d body=%s", ok.StatusCode, body)
+	}
+
+	bad := sendRPC(t, srv.URL+cfg.MCPPath, sid, `{"jsonrpc":"2.0","id":26,"method":"tools/list","params":{}}`,
+		map[string]string{protocol.MCPProtocolVersionHeader: "1999-01-01"})
+	defer func() { _ = bad.Body.Close() }()
+	if bad.StatusCode != http.StatusBadRequest {
+		t.Fatalf("tools/list with an unsupported version: status=%d want=400", bad.StatusCode)
+	}
+}
+
+// TestProduction_DeleteTerminatesTheSession verifies DELETE ends the session on
+// the production transport and that the id cannot be replayed.
+func TestProduction_DeleteTerminatesTheSession(t *testing.T) {
+	t.Parallel()
+	cfg := defaultConfig()
+	srv := newServer(t, cfg)
+	defer srv.Close()
+
+	sid := initSession(t, srv.URL+cfg.MCPPath)
+
+	req, err := http.NewRequest(http.MethodDelete, srv.URL+cfg.MCPPath, nil)
+	if err != nil {
+		t.Fatalf("create DELETE request: %v", err)
+	}
+	req.Header.Set(protocol.MCPSessionHeader, sid)
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		t.Fatalf("do DELETE: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("DELETE: status=%d want=204", resp.StatusCode)
+	}
+
+	after := sendRPC(t, srv.URL+cfg.MCPPath, sid, `{"jsonrpc":"2.0","id":27,"method":"tools/list","params":{}}`, nil)
+	body := readBody(t, after)
+	if after.StatusCode != http.StatusNotFound {
+		t.Fatalf("replay after DELETE: status=%d want=404 body=%s", after.StatusCode, body)
+	}
+	code, _ := decodeRPCError(t, body)
+	if code != -32001 {
+		t.Fatalf("replay after DELETE: code=%d want=-32001 body=%s", code, body)
+	}
+}
+
+// TestProduction_CORSPreflightIsServed verifies a browser preflight still gets
+// the CORS headers on the production transport. OPTIONS is the one MCP-path verb
+// the SDK transport hands back to Server.Handler(), so this pins that routing.
+func TestProduction_CORSPreflightIsServed(t *testing.T) {
+	t.Parallel()
+	cfg := defaultConfig()
+	const origin = "https://allowed.example.com"
+	cfg.AllowedOrigins = append(cfg.AllowedOrigins, origin)
+	srv := newServer(t, cfg)
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodOptions, srv.URL+cfg.MCPPath, nil)
+	if err != nil {
+		t.Fatalf("create OPTIONS request: %v", err)
+	}
+	req.Header.Set("Origin", origin)
+	req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		t.Fatalf("do OPTIONS: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("preflight: status=%d want=204", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != origin {
+		t.Fatalf("preflight Access-Control-Allow-Origin = %q, want %q", got, origin)
+	}
+}
+
+// TestProduction_DisallowedOriginIsRefused verifies the origin guard still runs
+// on the production transport.
+func TestProduction_DisallowedOriginIsRefused(t *testing.T) {
+	t.Parallel()
+	cfg := defaultConfig()
+	srv := newServer(t, cfg)
+	defer srv.Close()
+
+	sid := initSession(t, srv.URL+cfg.MCPPath)
+	resp := sendRPC(t, srv.URL+cfg.MCPPath, sid, statsCallBody(28), map[string]string{
+		"Origin": "https://evil.example.com",
+	})
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("disallowed origin: status=%d want=403", resp.StatusCode)
+	}
+}

--- a/tests/conformance/tools_test.go
+++ b/tests/conformance/tools_test.go
@@ -12,7 +12,7 @@ import (
 func TestTools_ListContainsExpectedTools(t *testing.T) {
 	t.Parallel()
 	cfg := defaultConfig()
-	srv := newServer(cfg)
+	srv := newServer(t, cfg)
 	defer srv.Close()
 
 	sid := initSession(t, srv.URL+cfg.MCPPath)
@@ -66,7 +66,7 @@ func TestTools_ListContainsExpectedTools(t *testing.T) {
 func TestTools_CallListFilesSuccess(t *testing.T) {
 	t.Parallel()
 	cfg := defaultConfig()
-	srv := newServer(cfg)
+	srv := newServer(t, cfg)
 	defer srv.Close()
 
 	corpusDir := t.TempDir()
@@ -111,13 +111,21 @@ func TestTools_CallListFilesSuccess(t *testing.T) {
 	}
 }
 
-// TestTools_CallUnknownToolReturnsError verifies that tools/call with an
-// unknown tool name returns a tool-level isError=true result (per MCP spec,
-// tools/call errors are returned as tool-level errors, not JSON-RPC errors).
+// TestTools_CallUnknownToolReturnsError verifies that tools/call with an unknown
+// tool name returns a JSON-RPC -32602 error.
+//
+// An unknown tool name is a PROTOCOL error, not a tool execution failure, so MCP
+// puts it in the JSON-RPC error envelope. isError=true is reserved for a tool
+// that ran and failed (SPEC §12.4). The production transport returns -32602.
+//
+// This assertion used to require isError=true, and it passed only because the
+// suite drove the legacy direct handler, which maps an unknown tool to a
+// METHOD_NOT_FOUND tool result. The repointed suite (#664) reads the contract a
+// client actually gets.
 func TestTools_CallUnknownToolReturnsError(t *testing.T) {
 	t.Parallel()
 	cfg := defaultConfig()
-	srv := newServer(cfg)
+	srv := newServer(t, cfg)
 	defer srv.Close()
 
 	sid := initSession(t, srv.URL+cfg.MCPPath)
@@ -131,8 +139,9 @@ func TestTools_CallUnknownToolReturnsError(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("unknown tool: status=%d body=%s", resp.StatusCode, body)
 	}
-	if !isToolError(body) {
-		t.Fatalf("unknown tool: expected tool-level isError=true result body=%s", body)
+	code, _ := decodeRPCError(t, body)
+	if code != -32602 {
+		t.Fatalf("unknown tool: code=%d want=-32602 body=%s", code, body)
 	}
 }
 
@@ -141,7 +150,7 @@ func TestTools_CallUnknownToolReturnsError(t *testing.T) {
 func TestTools_CallMissingRequiredParamReturnsError(t *testing.T) {
 	t.Parallel()
 	cfg := defaultConfig()
-	srv := newServer(cfg)
+	srv := newServer(t, cfg)
 	defer srv.Close()
 
 	sid := initSession(t, srv.URL+cfg.MCPPath)
@@ -178,7 +187,7 @@ func isToolError(body []byte) bool {
 func TestTools_StatsCallReturnsResult(t *testing.T) {
 	t.Parallel()
 	cfg := defaultConfig()
-	srv := newServer(cfg)
+	srv := newServer(t, cfg)
 	defer srv.Close()
 
 	sid := initSession(t, srv.URL+cfg.MCPPath)

--- a/tests/conformance/x402_test.go
+++ b/tests/conformance/x402_test.go
@@ -54,7 +54,7 @@ func TestX402_ModeOff_NoPaymentHeaders(t *testing.T) {
 	cfg := defaultConfig()
 	cfg.X402.Mode = x402.ModeOff
 
-	srv := newServer(cfg)
+	srv := newServer(t, cfg)
 	defer srv.Close()
 
 	sid := initSession(t, srv.URL+cfg.MCPPath)
@@ -82,7 +82,7 @@ func TestX402_ModeOff_PaymentSignatureIgnored(t *testing.T) {
 	cfg.X402.Mode = x402.ModeOff
 	cfg.X402.FacilitatorURL = facSrv.URL
 
-	srv := newServer(cfg)
+	srv := newServer(t, cfg)
 	defer srv.Close()
 
 	sid := initSession(t, srv.URL+cfg.MCPPath)
@@ -109,7 +109,7 @@ func TestX402_ModeOn_IncompleteConfigFailsOpen(t *testing.T) {
 	cfg.X402.ToolsCallEnabled = true
 
 	var warningEmitted atomic.Bool
-	srv := newServer(cfg, mcp.WithEventEmitter(func(level, event string, _ interface{}) {
+	srv := newServer(t, cfg, mcp.WithEventEmitter(func(level, event string, _ interface{}) {
 		if event == "x402_validation_failed" {
 			warningEmitted.Store(true)
 		}
@@ -142,7 +142,7 @@ func TestX402_ModeOn_NoPaymentReturns402(t *testing.T) {
 	cfg := x402Config(t, facSrv.URL)
 	cfg.X402.Mode = x402.ModeOn
 
-	srv := newServer(cfg)
+	srv := newServer(t, cfg)
 	defer srv.Close()
 
 	sid := initSession(t, srv.URL+cfg.MCPPath)
@@ -166,7 +166,7 @@ func TestX402_ModeRequired_MissingConfigReturns503(t *testing.T) {
 	cfg.X402.Mode = x402.ModeRequired
 	cfg.X402.ToolsCallEnabled = true
 
-	srv := newServer(cfg)
+	srv := newServer(t, cfg)
 	defer srv.Close()
 
 	sid := initSession(t, srv.URL+cfg.MCPPath)
@@ -192,7 +192,7 @@ func TestX402_ModeRequired_ValidPaymentAccepted(t *testing.T) {
 	cfg := x402Config(t, facSrv.URL)
 	cfg.X402.Mode = x402.ModeRequired
 
-	srv := newServer(cfg)
+	srv := newServer(t, cfg)
 	defer srv.Close()
 
 	sid := initSession(t, srv.URL+cfg.MCPPath)
@@ -224,7 +224,7 @@ func TestX402_InitializeAndToolsListNotGated(t *testing.T) {
 			cfg := x402Config(t, facSrv.URL)
 			cfg.X402.Mode = mode
 
-			srv := newServer(cfg)
+			srv := newServer(t, cfg)
 			defer srv.Close()
 
 			// initialize must always succeed.
@@ -257,7 +257,7 @@ func TestX402_ModeOn_PaymentRequiredHeaderIsValidJSON(t *testing.T) {
 	cfg := x402Config(t, facSrv.URL)
 	cfg.X402.Mode = x402.ModeOn
 
-	srv := newServer(cfg)
+	srv := newServer(t, cfg)
 	defer srv.Close()
 
 	sid := initSession(t, srv.URL+cfg.MCPPath)


### PR DESCRIPTION
## Summary

The conformance suite graded a code path that production does not serve. This PR
moves the suite onto the production transport, and then uses the repointed suite
to prove issue #663 from the outside.

Two commits, one idea each:

1. `test(conformance): run the suite on the production SDK transport` (#664)
2. `test(conformance): cover media clip content on the production transport` (#663)

Closes #664.

Refs #663. The #663 code fix is **not** in this PR. It is blocked on the SPEC by
dirstral/dirstral-spec#60. See "Why #663 stops here" below.

## 1. Mechanism of #664

The suite started the server like this:

```go
httptest.NewServer(mcp.NewServer(cfg, nil, opts...).Handler())
```

`dir2mcp up` does something different. `internal/cli/up.go` gives POST and DELETE
on the MCP path to `SDKTransport`, and passes `Server.Handler()` in only as the
fallback for other paths and for OPTIONS. So the suite asserted against a chain
no client reaches.

`newServer` now starts `SDKTransport` on a real listener with that same wiring.
`newDirectHandlerServer` keeps the direct chain reachable, labelled as a
unit-level helper for parity checks only.

The repoint found one live contract error in the suite itself. An unknown tool
name is a protocol error, so MCP puts it in the JSON-RPC envelope as `-32602`.
`isError=true` is reserved for a tool that ran and failed (SPEC §12.4). The
production transport returns `-32602`. The old assertion demanded `isError=true`
and passed only because the legacy handler maps an unknown tool to a
`METHOD_NOT_FOUND` tool result. The test now reads the production contract, and a
new parity test records the legacy behaviour so neither side can drift silently.

New production-path coverage:

* tool descriptor parity against the direct handler, so drift in a name, a
  description or a schema fails CI
* canonical tool-execution error code parity
* the one intentional divergence, unknown tool, pinned on both sides with its
  reason
* `initialize` pins `protocolVersion` `2025-11-25` instead of echoing the client
* `notifications/initialized` is accepted and the session keeps serving
* the negotiated `MCP-Protocol-Version` header is accepted, and an unsupported
  value gets 400
* DELETE ends the session, and the id cannot be replayed
* the CORS preflight still gets its headers, and a disallowed origin still gets
  403
* media clip content items for audio and for video

## 2. Proof that the repointed suite catches #663 on its own

This is the point of pairing the two issues. The proof is one assertion, run
against the two helpers, with no other change.

The assertion lives in `assertClipContentCarriesBytes`. It says: the inline clip
must arrive in exactly one content item, that item must carry the clip bytes, and
it must never be a text item.

**On the production transport it fails:**

```
$ go test ./tests/conformance -run TestMediaContent_VideoClipReachesTheClient -v
=== RUN   TestMediaContent_VideoClipReachesTheClient
    media_content_test.go:205: content item is a text item (text=""): media bytes
    must never travel as text, and an empty text item drops the clip entirely
--- FAIL: TestMediaContent_VideoClipReachesTheClient (0.03s)
FAIL
```

**On the old helper, the direct `Server.Handler()`, the same assertion passes:**

```
$ go test ./tests/conformance -run TestScratch664_VideoClipOnLegacyHandlerPasses -v
--- PASS: TestScratch664_VideoClipOnLegacyHandlerPasses (0.02s)
PASS
```

Same fixture, same tool call, same assertion. The direct handler serializes the
repository's own `video` object, so it reports green. The production transport
converts the same result through `convertToolCallResult` and drops it. The
coverage gap was real, and #663 was living inside it.

The scratch test that produced the second output was temporary and is not in the
diff. It was six lines: the video body of `TestMediaContent_VideoClipReachesTheClient`
with `newServer` swapped for `newDirectHandlerServer`.

The audio half of the same conversion passes on the production transport, so the
failure is specific to the unmapped type and not to the fixture.

## 3. What the user sees, in plain words

A client asks for a video clip citation, for example "play me the part where that
was said". The call succeeds. `content[]` comes back as:

```json
[{"type":"text","text":""}]
```

In Claude Desktop, or in any strict MCP client, the tool call is marked
successful and the result is blank. No player appears. No text appears either.
The user gets a silent no-op and has no reason to suspect the server, because
nothing reported an error. Audio clips work, so the failure looks arbitrary. The
base64 bytes are still in `structuredContent.data`, so a client that reads the
structured output can recover them, but the canonical `content[]` media delivery
is lost.

## 4. Why #663 stops here

The correct fix needs a content shape the SPEC does not define, so per this
repository's spec-first rule a `dirstral-spec` PR must merge first.

The conflict is exact:

* SPEC §15.11: "Tool result `content[]` MUST include an `audio`- or `video`-typed
  item carrying the clip (base64 `data` + `mimeType`) when `return=inline`".
* The pinned MCP generation is `2025-11-25`. It defines `text`, `image`, `audio`,
  `resource_link` and `resource`. It defines **no** `video` content type.
* `go-sdk` v1.4.1 puts an unexported method on the `Content` interface
  (`fromWire(*wireContent)`), so this repository cannot add a `video`
  implementation. A `video`-typed item is not just wrong on the wire, it is
  unreachable from the production transport.

So the SPEC currently requires an item that the pinned protocol cannot carry. The
interoperable fix that issue #663 itself suggests is an embedded resource with a
blob:

```json
{"type":"resource","resource":{"uri":"...","mimeType":"video/mp4","blob":"<base64>"}}
```

That is a shape §15.11 does not name for `return=inline`. Choosing it, or
relaxing "audio- or video-typed", is a normative decision. I did not guess it.

**What the spec PR has to settle:** how an inline clip is delivered when the
pinned MCP generation has no content type for its media kind. Either §15.11 names
the embedded-resource form for that case, or it drops the `video`-typed
requirement and states the fallback.

dirstral/dirstral-spec#60 already tracks this exact conflict, and its acceptance
criteria name the same two options. This PR adds the measurement that issue was
missing: a repeatable failing test on the production transport, and a passing
control on the legacy handler. The spec PR merges first, then a gated submodule
re-pin plus the code fix land together, per the spec-first rule.

The regression test is committed and skipped, with the blocker named in the skip
reason. The follow-up code PR removes one skip line.

## 5. Effect on CI

`conformance` job: same command, `make conformance`. What it covers changes, and
it now covers more:

* it now grades `SDKTransport`, the transport the shipped binary serves, instead
  of the legacy handler chain
* SDK-generated session ids, SDK content conversion, SDK protocol-version
  handling and the SDK session store are now inside the graded surface
* the direct handler chain keeps only the coverage it should have: two parity
  tests that compare it against production
* one previously green assertion changed meaning, the unknown-tool contract, and
  it now matches MCP

`inspector-smoke` job: unaffected. It builds the binary and drives the MCP
Inspector against a live daemon. This PR changes test files under
`tests/conformance` only, so no product behaviour moves.

Both jobs are green on this branch.

## 6. Two more production bugs the repoint made visible

I am reporting these, not fixing them. Both are named in #664 as confirmed
false-greens, and both are separate from the harness change and from #663.

1. **A cross-origin POST from an explicitly allowed origin gets 403.** The SDK's
   `StreamableHTTPHandler` applies Go's `http.CrossOriginProtection` by default.
   It runs after our own `allowOrigin` check and refuses the request whatever
   `allowed_origins` says. Measured: production 403, direct handler 200.
2. **The MCP-path POST response carries no CORS headers.** `corsMiddleware` sits
   in `Server.Handler()`, and `SDKTransport` routes MCP-path POST past it.
   Preflight still works, because OPTIONS is handed back to the handler.

Together these break browser MCP clients. `corsMiddleware` exists for exactly
that case. Issue #652 already tracks both, and this PR gives it a measurement.
I left the suite honest about this: it asserts preflight, which works, and it
does not assert the POST case, which does not. The fix belongs to #652.

## Verification

```bash
make check                          # green
go test -race -count=2 ./tests/conformance/...
make conformance
```

## Checklist

- [x] `coderabbit review` run, both findings fixed
- [x] `make check` passes locally
- [x] New behaviour has test coverage
- [x] No unrelated files changed
