### PR TITLE
fix(ingest): bound every source read and the S3 download (#682)

### DIFF
--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -1573,9 +1573,12 @@ func sourceIsRemote(cfg config.Config) bool {
 // where the S3 backend caches downloads.
 func buildCorpusFS(ctx context.Context, cfg config.Config) (corpusfs.CorpusFS, error) {
 	return corpusfs.New(ctx, corpusfs.Config{
-		Kind:              cfg.Source.Kind,
-		RootDir:           cfg.RootDir,
-		StateDir:          cfg.StateDir,
+		Kind:     cfg.Source.Kind,
+		RootDir:  cfg.RootDir,
+		StateDir: cfg.StateDir,
+		// The cap discovery admits files under, so an object-store read or download
+		// can never deliver more bytes than the operator allowed (#682).
+		MaxFileBytes:      ingest.ResolvedMaxFileBytes(cfg),
 		S3Bucket:          cfg.Source.S3Bucket,
 		S3Prefix:          cfg.Source.S3Prefix,
 		S3Region:          cfg.Source.S3Region,

--- a/internal/corpusfs/factory.go
+++ b/internal/corpusfs/factory.go
@@ -31,6 +31,13 @@ type Config struct {
 	// StateDir is the always-local state directory; the S3 cache lives under it.
 	StateDir string
 
+	// MaxFileBytes is the resolved `ingest.max_file_mb` cap in bytes. It bounds
+	// every whole-object read and every Localize download an object-store backend
+	// performs (#682), so a bucket that serves more bytes than it declared cannot
+	// exhaust memory or the local cache disk. Zero or negative selects
+	// DefaultMaxFileSizeBytes; there is no unbounded setting.
+	MaxFileBytes int64
+
 	// S3* describe the object-store backend (used only when Kind=="s3").
 	S3Bucket          string
 	S3Prefix          string
@@ -152,6 +159,7 @@ func newS3FromConfig(ctx context.Context, cfg Config) (CorpusFS, error) {
 		Bucket:   cfg.S3Bucket,
 		Prefix:   cfg.S3Prefix,
 		CacheDir: cacheDir,
+		MaxBytes: cfg.MaxFileBytes,
 	}, presignerForClient(client))
 }
 

--- a/internal/corpusfs/local.go
+++ b/internal/corpusfs/local.go
@@ -19,6 +19,20 @@ import (
 // to their own fatal-error classification without string matching.
 var ErrPathEscapesRoot = errors.New("corpusfs: path escapes the corpus root")
 
+// ErrObjectTooLarge is returned by an object-store backend when the bytes it
+// actually served passed the configured per-file cap (#682).
+//
+// It is a distinct sentinel from a transport failure for one reason: the two need
+// opposite answers. A transport failure is retried, because the next attempt may
+// work. A cap trip is a policy decision about a file discovery already refused, so
+// it is permanent for as long as the object stays that size, and callers report it
+// as the `size_cap` skip it is rather than as an error.
+//
+// LocalFS never returns it. A local Localize hands back the in-root path and
+// copies nothing, so it has no read to bound; the caller's own read is the
+// boundary there.
+var ErrObjectTooLarge = errors.New("corpusfs: object exceeds the configured max file size")
+
 // LocalFS is the default CorpusFS backed by the local filesystem. An NFS mount
 // is a local path, so it is served by LocalFS as well. It is behavior-preserving
 // relative to the historical ingest discovery walker.

--- a/internal/corpusfs/s3.go
+++ b/internal/corpusfs/s3.go
@@ -53,6 +53,10 @@ type S3FS struct {
 	// test that does not exercise the URL path); MediaURL then reports ok=false so
 	// callers fall back to Localize.
 	presign presignFunc
+	// maxBytes is the per-object read/download cap (#682). It is always positive:
+	// resolveMaxBytes turns a zero or negative configured value into the 10 MiB
+	// default, so no construction path can leave the backend unbounded.
+	maxBytes int64
 }
 
 // S3Config configures an S3FS.
@@ -62,6 +66,25 @@ type S3Config struct {
 	// CacheDir is the directory under which Localize materializes temp files.
 	// When empty, the OS temp dir is used.
 	CacheDir string
+	// MaxBytes caps the bytes a single object may deliver through Open or
+	// Localize (#682). Set it to the resolved `ingest.max_file_mb` value, because
+	// discovery already refuses an object over that cap: an object that then
+	// serves more bytes than the cap is either lying about its size or changed
+	// after discovery measured it, and neither may be read without a bound.
+	//
+	// Zero or negative selects DefaultMaxFileSizeBytes. There is deliberately no
+	// "unlimited" value: an unbounded download is the defect this field closes.
+	MaxBytes int64
+}
+
+// resolveMaxBytes turns a configured per-object cap into the positive value the
+// backend enforces. A zero or negative input selects the 10 MiB default rather
+// than disabling the bound, so a caller that forgets the field still gets one.
+func resolveMaxBytes(configured int64) int64 {
+	if configured > 0 {
+		return configured
+	}
+	return defaultMaxFileSizeBytes
 }
 
 // NewS3FS constructs an S3FS over the provided client and config. The client is
@@ -88,6 +111,7 @@ func newS3FSWithPresign(client s3API, cfg S3Config, presign presignFunc) (*S3FS,
 		prefix:   normalizeS3Prefix(cfg.Prefix),
 		cacheDir: cfg.CacheDir,
 		presign:  presign,
+		maxBytes: resolveMaxBytes(cfg.MaxBytes),
 	}, nil
 }
 
@@ -401,6 +425,15 @@ func keyHasExcludedDir(rel string, excluded ExcludedDirSet) bool {
 // size so seeks (including io.SeekEnd) resolve, and reads issue a ranged GET for
 // the requested window — so a caller reading a slice does not download the whole
 // object.
+//
+// Both readers it returns are bounded by the configured cap (#682). The bound is
+// on the BYTES DELIVERED, not on a size the object reported, because the two can
+// disagree: discovery sizes an object from ListObjectsV2, Open sizes it from
+// HeadObject, and the body arrives from a third call. A caller that reads the
+// whole reader can therefore never receive more than the cap, whichever of those
+// three numbers is wrong. Over-cap delivery stops with ErrObjectTooLarge rather
+// than with io.EOF: a silent short read would look to every caller like a
+// complete file, which is the truncated-document failure #487 already fixed once.
 func (s *S3FS) Open(ctx context.Context, relPath string) (io.ReadSeekCloser, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -423,24 +456,36 @@ func (s *S3FS) Open(ctx context.Context, relPath string) (io.ReadSeekCloser, err
 	// whole-object streaming GET so the bytes are actually read (issue #487).
 	if head.ContentLength == nil {
 		return &s3StreamReader{
-			ctx:    ctx,
-			client: s.client,
-			bucket: s.bucket,
-			key:    key,
+			ctx:      ctx,
+			client:   s.client,
+			bucket:   s.bucket,
+			key:      key,
+			maxBytes: s.maxBytes,
 		}, nil
 	}
 	return &s3RangeReader{
-		ctx:    ctx,
-		client: s.client,
-		bucket: s.bucket,
-		key:    key,
-		size:   aws.ToInt64(head.ContentLength),
+		ctx:      ctx,
+		client:   s.client,
+		bucket:   s.bucket,
+		key:      key,
+		size:     aws.ToInt64(head.ContentLength),
+		maxBytes: s.maxBytes,
 	}, nil
 }
 
 // Localize downloads the object to a temp file under the cache dir (preserving
 // the object extension so ffmpeg can infer the muxer) and returns its path with
 // a cleanup that removes the file.
+//
+// The download is bounded by the configured cap (#682). It reads at most cap+1
+// bytes: the extra byte is what separates "exactly at the cap" from "past it",
+// and it is the whole cost of telling the two apart. Past the cap the partial
+// file is removed and ErrObjectTooLarge is returned, so a bucket that serves
+// more bytes than it declared cannot fill the local cache disk.
+//
+// The bound is on the copy, not on a preceding size check. GetObject is a
+// separate operation from the ListObjectsV2 that discovery sized the object with,
+// so no check made before it can constrain what the body then delivers.
 func (s *S3FS) Localize(ctx context.Context, relPath string) (string, func(), error) {
 	if err := ctx.Err(); err != nil {
 		return "", nil, err
@@ -471,10 +516,16 @@ func (s *S3FS) Localize(ctx context.Context, relPath string) (string, func(), er
 		return "", nil, fmt.Errorf("corpusfs: create temp file: %w", err)
 	}
 	cleanup := func() { _ = os.Remove(tmp.Name()) }
-	if _, err := io.Copy(tmp, out.Body); err != nil {
+	written, err := io.Copy(tmp, io.LimitReader(out.Body, s.maxBytes+1))
+	if err != nil {
 		_ = tmp.Close()
 		cleanup()
 		return "", nil, fmt.Errorf("corpusfs: download s3://%s/%s: %w", s.bucket, key, err)
+	}
+	if written > s.maxBytes {
+		_ = tmp.Close()
+		cleanup()
+		return "", nil, fmt.Errorf("corpusfs: download s3://%s/%s: %w (cap %d bytes)", s.bucket, key, ErrObjectTooLarge, s.maxBytes)
 	}
 	if err := tmp.Close(); err != nil {
 		cleanup()

--- a/internal/corpusfs/s3.go
+++ b/internal/corpusfs/s3.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path"
 	"path/filepath"
@@ -80,11 +81,21 @@ type S3Config struct {
 // resolveMaxBytes turns a configured per-object cap into the positive value the
 // backend enforces. A zero or negative input selects the 10 MiB default rather
 // than disabling the bound, so a caller that forgets the field still gets one.
+//
+// The upper clamp keeps `maxBytes+1` representable. Every bound in this file is a
+// limit+1, and math.MaxInt64 would overflow that sum to a negative number, which
+// io.LimitReader reads as "zero bytes allowed": Localize would then write an empty
+// file and report SUCCESS, and a read would return an empty document. S3Config is
+// exported, so this invariant is enforced here rather than trusted to the caller.
 func resolveMaxBytes(configured int64) int64 {
-	if configured > 0 {
+	switch {
+	case configured <= 0:
+		return defaultMaxFileSizeBytes
+	case configured > math.MaxInt64-1:
+		return math.MaxInt64 - 1
+	default:
 		return configured
 	}
-	return defaultMaxFileSizeBytes
 }
 
 // NewS3FS constructs an S3FS over the provided client and config. The client is

--- a/internal/corpusfs/s3reader.go
+++ b/internal/corpusfs/s3reader.go
@@ -23,6 +23,9 @@ type s3RangeReader struct {
 	bucket string
 	key    string
 	size   int64
+	// maxBytes caps the bytes this reader will deliver in total (#682). It is
+	// always positive (see resolveMaxBytes), so the reader is never unbounded.
+	maxBytes int64
 
 	offset int64
 	body   io.ReadCloser
@@ -30,7 +33,16 @@ type s3RangeReader struct {
 
 // Read fulfills io.Reader, opening a ranged GET from the current offset on
 // demand.
+//
+// Two bounds apply, and they answer different lies (#682). The cap check refuses
+// to deliver a byte past maxBytes, which is what stops an object HeadObject
+// under-reported and discovery therefore admitted. The per-call slice trim holds
+// the reader to the size HeadObject DID report, so a body that returns more bytes
+// than the range asked for cannot push the total past that size either.
 func (r *s3RangeReader) Read(p []byte) (int, error) {
+	if r.offset >= r.maxBytes {
+		return 0, fmt.Errorf("corpusfs: read s3://%s/%s: %w (cap %d bytes)", r.bucket, r.key, ErrObjectTooLarge, r.maxBytes)
+	}
 	if r.offset >= r.size {
 		return 0, io.EOF
 	}
@@ -38,6 +50,12 @@ func (r *s3RangeReader) Read(p []byte) (int, error) {
 		if err := r.openFrom(r.offset); err != nil {
 			return 0, err
 		}
+	}
+	// Never hand back more than the object's reported size, or more than the cap,
+	// whichever ends first.
+	limit := min(r.size, r.maxBytes) - r.offset
+	if int64(len(p)) > limit {
+		p = p[:limit]
 	}
 	n, err := r.body.Read(p)
 	r.offset += int64(n)
@@ -110,6 +128,10 @@ type s3StreamReader struct {
 	client s3API
 	bucket string
 	key    string
+	// maxBytes caps the bytes this reader will deliver in total (#682). This
+	// reader is the one that most needs the cap: it exists precisely because the
+	// object reported no length at all, so nothing else bounds it.
+	maxBytes int64
 
 	offset int64
 	body   io.ReadCloser
@@ -117,14 +139,24 @@ type s3StreamReader struct {
 }
 
 // Read fulfills io.Reader, opening the whole-object GET body on demand.
+//
+// It stops at the configured cap with ErrObjectTooLarge (#682). An unknown-length
+// object is the case where a size check cannot help at all: there is no reported
+// size to check, so only a bound on the bytes as they arrive can hold.
 func (r *s3StreamReader) Read(p []byte) (int, error) {
 	if r.closed {
 		return 0, fs.ErrClosed
+	}
+	if r.offset >= r.maxBytes {
+		return 0, fmt.Errorf("corpusfs: read s3://%s/%s: %w (cap %d bytes)", r.bucket, r.key, ErrObjectTooLarge, r.maxBytes)
 	}
 	if r.body == nil {
 		if err := r.open(); err != nil {
 			return 0, err
 		}
+	}
+	if limit := r.maxBytes - r.offset; int64(len(p)) > limit {
+		p = p[:limit]
 	}
 	n, err := r.body.Read(p)
 	r.offset += int64(n)
@@ -172,6 +204,12 @@ func (r *s3StreamReader) Seek(offset int64, whence int) (int64, error) {
 	}
 	if abs < r.offset {
 		return 0, errors.New("corpusfs: cannot seek backward in a streaming s3 object")
+	}
+	// A forward seek is serviced by DISCARDING bytes, so an unbounded target would
+	// pull an unbounded body through the socket to reach it (#682). The cap applies
+	// to bytes read, not to bytes returned, so it applies here too.
+	if abs > r.maxBytes {
+		return 0, fmt.Errorf("corpusfs: forward seek s3://%s/%s: %w (cap %d bytes)", r.bucket, r.key, ErrObjectTooLarge, r.maxBytes)
 	}
 	if r.body == nil {
 		if err := r.open(); err != nil {

--- a/internal/corpusfs/s3reader.go
+++ b/internal/corpusfs/s3reader.go
@@ -34,13 +34,18 @@ type s3RangeReader struct {
 // Read fulfills io.Reader, opening a ranged GET from the current offset on
 // demand.
 //
-// Two bounds apply, and they answer different lies (#682). The cap check refuses
-// to deliver a byte past maxBytes, which is what stops an object HeadObject
-// under-reported and discovery therefore admitted. The per-call slice trim holds
+// Two bounds apply, and they answer different problems (#682). The cap stops an
+// object DISCOVERY under-reported: ListObjectsV2 said the object fitted, HeadObject
+// says otherwise, and the cap refuses the difference. The per-call slice trim holds
 // the reader to the size HeadObject DID report, so a body that returns more bytes
 // than the range asked for cannot push the total past that size either.
+//
+// The cap is enforced as a limit+1, the same idiom every other bounded read in this
+// repository uses. The reader delivers one byte more than the cap and then fails,
+// because that extra byte is what separates an object of exactly the cap (which is
+// inside the policy and must read cleanly to io.EOF) from an object past it.
 func (r *s3RangeReader) Read(p []byte) (int, error) {
-	if r.offset >= r.maxBytes {
+	if r.offset > r.maxBytes {
 		return 0, fmt.Errorf("corpusfs: read s3://%s/%s: %w (cap %d bytes)", r.bucket, r.key, ErrObjectTooLarge, r.maxBytes)
 	}
 	if r.offset >= r.size {
@@ -51,9 +56,9 @@ func (r *s3RangeReader) Read(p []byte) (int, error) {
 			return 0, err
 		}
 	}
-	// Never hand back more than the object's reported size, or more than the cap,
+	// Never hand back more than the object's reported size, or more than cap+1,
 	// whichever ends first.
-	limit := min(r.size, r.maxBytes) - r.offset
+	limit := min(r.size, r.maxBytes+1) - r.offset
 	if int64(len(p)) > limit {
 		p = p[:limit]
 	}
@@ -143,11 +148,16 @@ type s3StreamReader struct {
 // It stops at the configured cap with ErrObjectTooLarge (#682). An unknown-length
 // object is the case where a size check cannot help at all: there is no reported
 // size to check, so only a bound on the bytes as they arrive can hold.
+//
+// The cap is enforced as a limit+1, exactly as in s3RangeReader. Here the extra
+// byte is the ONLY way to tell an object of exactly the cap from one past it: with
+// no reported length, the difference between "the body ended" and "the body
+// continues" is one byte of evidence.
 func (r *s3StreamReader) Read(p []byte) (int, error) {
 	if r.closed {
 		return 0, fs.ErrClosed
 	}
-	if r.offset >= r.maxBytes {
+	if r.offset > r.maxBytes {
 		return 0, fmt.Errorf("corpusfs: read s3://%s/%s: %w (cap %d bytes)", r.bucket, r.key, ErrObjectTooLarge, r.maxBytes)
 	}
 	if r.body == nil {
@@ -155,7 +165,7 @@ func (r *s3StreamReader) Read(p []byte) (int, error) {
 			return 0, err
 		}
 	}
-	if limit := r.maxBytes - r.offset; int64(len(p)) > limit {
+	if limit := r.maxBytes + 1 - r.offset; int64(len(p)) > limit {
 		p = p[:limit]
 	}
 	n, err := r.body.Read(p)

--- a/internal/ingest/secret_derived.go
+++ b/internal/ingest/secret_derived.go
@@ -3,6 +3,7 @@ package ingest
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"regexp"
 
@@ -195,8 +196,14 @@ func (s *Service) creditSecretExcludedSkip(doc model.Document) {
 // Best-effort with a loud log, never fatal: a store that cannot retire must not
 // convert a withheld document into a failed run. The document row is still
 // recorded `secret_excluded` either way.
+// The returned error is deliberately DROPPED here, preserving the decision above.
+// The size-cap caller (#682) does propagate it, and the two differ for a reason
+// worth stating: a size-cap verdict is reproducible, so failing the document and
+// retrying next scan costs a re-read and nothing else, while a derived secret
+// verdict is not reproducible (the incremental gate will not re-run OCR or STT for
+// an unchanged file), so refusing to settle it would risk losing the verdict.
 func (s *Service) retireDocumentRepresentations(ctx context.Context, relPath string) {
-	s.retireRepresentationsForPath(ctx, relPath, "secret policy")
+	_ = s.retireRepresentationsForPath(ctx, relPath, "secret policy")
 }
 
 // retireRepresentationsForPath is the shared retirement step: it tombstones every
@@ -209,7 +216,14 @@ func (s *Service) retireDocumentRepresentations(ctx context.Context, relPath str
 // the cap, which retires anything an earlier scan indexed from the smaller
 // version. A second delete path for the second policy would be a second place for
 // the §6.6 tombstone rule to be got wrong, so there is one.
-func (s *Service) retireRepresentationsForPath(ctx context.Context, relPath, policy string) {
+//
+// It returns an error only when a retirement that SHOULD have happened did not: a
+// list or delete the store refused. A store that does not implement the surface at
+// all is a capability gap, not a failure, so it logs and returns nil; and a
+// document with nothing live to retire is a success. The caller decides what to do
+// with a real failure, because the right answer differs by policy (see
+// retireDocumentRepresentations and settleSizeCapSkip).
+func (s *Service) retireRepresentationsForPath(ctx context.Context, relPath, policy string) error {
 	lister, listOK := s.store.(activeRepresentationLister)
 	retirer, retireOK := s.store.(representationRetirer)
 	if !listOK || !retireOK {
@@ -217,17 +231,18 @@ func (s *Service) retireRepresentationsForPath(ctx context.Context, relPath, pol
 			"%s: store cannot retire representations for %s; verify no stale representation is left for it",
 			policy, relPath,
 		)
-		return
+		return nil
 	}
 	reps, err := lister.ActiveRepresentations(ctx, relPath)
 	if err != nil {
-		if !errors.Is(err, os.ErrNotExist) {
-			s.getLogger().Printf("%s: list representations for %s failed: %v", policy, relPath, err)
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
 		}
-		return
+		s.getLogger().Printf("%s: list representations for %s failed: %v", policy, relPath, err)
+		return fmt.Errorf("%s: list representations for %s: %w", policy, relPath, err)
 	}
 	if len(reps) == 0 {
-		return
+		return nil
 	}
 	ids := make([]int64, 0, len(reps))
 	for _, rep := range reps {
@@ -235,7 +250,9 @@ func (s *Service) retireRepresentationsForPath(ctx context.Context, relPath, pol
 	}
 	if _, err := retirer.SoftDeleteRepresentations(ctx, relPath, ids); err != nil {
 		s.getLogger().Printf("%s: retire representations for %s failed: %v", policy, relPath, err)
+		return fmt.Errorf("%s: retire representations for %s: %w", policy, relPath, err)
 	}
+	return nil
 }
 
 // carrySecretExclusion makes a DERIVED secret verdict stick across scans.

--- a/internal/ingest/secret_derived.go
+++ b/internal/ingest/secret_derived.go
@@ -196,19 +196,33 @@ func (s *Service) creditSecretExcludedSkip(doc model.Document) {
 // convert a withheld document into a failed run. The document row is still
 // recorded `secret_excluded` either way.
 func (s *Service) retireDocumentRepresentations(ctx context.Context, relPath string) {
+	s.retireRepresentationsForPath(ctx, relPath, "secret policy")
+}
+
+// retireRepresentationsForPath is the shared retirement step: it tombstones every
+// live representation of relPath together with its chunks, and labels its logs
+// with the policy that asked for it.
+//
+// Two policies retire a document's representations, and both need the same
+// action. The secret policy (#681) withholds a document whose derived text
+// carries a credential. The size cap (#682) refuses a document whose bytes passed
+// the cap, which retires anything an earlier scan indexed from the smaller
+// version. A second delete path for the second policy would be a second place for
+// the §6.6 tombstone rule to be got wrong, so there is one.
+func (s *Service) retireRepresentationsForPath(ctx context.Context, relPath, policy string) {
 	lister, listOK := s.store.(activeRepresentationLister)
 	retirer, retireOK := s.store.(representationRetirer)
 	if !listOK || !retireOK {
 		s.getLogger().Printf(
-			"secret policy: store cannot retire representations for %s; verify no stale representation is left for it",
-			relPath,
+			"%s: store cannot retire representations for %s; verify no stale representation is left for it",
+			policy, relPath,
 		)
 		return
 	}
 	reps, err := lister.ActiveRepresentations(ctx, relPath)
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
-			s.getLogger().Printf("secret policy: list representations for %s failed: %v", relPath, err)
+			s.getLogger().Printf("%s: list representations for %s failed: %v", policy, relPath, err)
 		}
 		return
 	}
@@ -220,7 +234,7 @@ func (s *Service) retireDocumentRepresentations(ctx context.Context, relPath str
 		ids = append(ids, rep.RepID)
 	}
 	if _, err := retirer.SoftDeleteRepresentations(ctx, relPath, ids); err != nil {
-		s.getLogger().Printf("secret policy: retire representations for %s failed: %v", relPath, err)
+		s.getLogger().Printf("%s: retire representations for %s failed: %v", policy, relPath, err)
 	}
 }
 

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -3266,10 +3266,15 @@ func isSizeCapSkip(doc model.Document) bool {
 // dropped by the discovery stat never reaches that branch, and this one must not
 // either.
 //
-// The order is load-bearing. Representations are retired FIRST, so an ungraceful
-// death between the two writes leaves a document with nothing searchable rather
-// than one whose row reads "skipped for size_cap" while its chunks are still being
-// served. It is the same rule the #681 withhold follows.
+// The order is load-bearing, and so is the refusal to continue past a failed
+// retirement. Representations are retired FIRST, so an ungraceful death between the
+// two writes leaves a document with nothing searchable rather than one whose row
+// reads "skipped for size_cap" while its chunks are still being served. A store
+// that REFUSES the retirement would produce that same contradiction deliberately,
+// so the row is not written at all: the document keeps the consistent state it
+// already had, the run reports one error, and the next scan retries. The verdict is
+// reproducible (the file is still over the cap, or it is not), so a retry costs a
+// re-read and nothing more.
 //
 // The counters are the ones creditInitialStatus would have applied to a skipped
 // document, with one difference that is the point of doing it here: the event is
@@ -3283,7 +3288,9 @@ func isSizeCapSkip(doc model.Document) bool {
 // pendingOversize path). A plain, codeless skip would leave the manifest unable to
 // tell this asset from a cache hit.
 func (s *Service) settleSizeCapSkip(ctx context.Context, doc model.Document) error {
-	s.retireRepresentationsForPath(ctx, doc.RelPath, "size cap")
+	if err := s.retireRepresentationsForPath(ctx, doc.RelPath, "size cap"); err != nil {
+		return err
+	}
 	if err := s.store.UpsertDocument(ctx, doc); err != nil {
 		return fmt.Errorf("upsert document: %w", err)
 	}
@@ -3310,10 +3317,23 @@ func (s *Service) settleSizeCapSkip(ctx context.Context, doc model.Document) err
 // content. That is the same contradiction the read-time path avoids, so both
 // paths resolve it the same way. It is a no-op (one empty list query) for a file
 // that was never indexed, which is the common case.
+//
+// A REFUSED retirement skips the row for that path rather than writing the
+// contradiction on purpose. The path keeps the consistent state it already had,
+// and it stays in `seen`, so markMissingAsDeleted does not tombstone it either.
+// The cap is deterministic, so the next scan drops the same file again and writes
+// the row once the store accepts the retirement. Retrying until the record lands
+// is the same choice persistArchiveMemberSizeCapSkips makes for its own rows.
 func (s *Service) persistOversizeSkips(ctx context.Context, oversize map[string]int64, seen map[string]struct{}) {
 	for relPath, size := range oversize {
 		seen[relPath] = struct{}{}
-		s.retireRepresentationsForPath(ctx, relPath, "size cap")
+		if err := s.retireRepresentationsForPath(ctx, relPath, "size cap"); err != nil {
+			s.getLogger().Printf(
+				"discovery: leaving %s as it was; its representations could not be retired, and a size_cap row beside live chunks would misreport coverage: %v",
+				relPath, err,
+			)
+			continue
+		}
 		doc := model.Document{
 			RelPath:    relPath,
 			DocType:    ClassifyDocType(relPath),

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -2208,12 +2208,9 @@ func (s *Service) processDocument(ctx context.Context, f DiscoveredFile, secretP
 		return s.persistBuildError(ctx, f, secretPatterns, buildErr)
 	}
 	if isSizeCapSkip(doc) {
-		// #682: the read passed the cap, so anything an earlier scan indexed for this
-		// path came from bytes this file no longer has. Retire it BEFORE the row is
-		// written, so a crash between the two steps leaves a document with nothing
-		// searchable rather than one whose row says "skipped for size_cap" while its
-		// chunks are still being served. Same ordering rule as the #681 withhold.
-		s.retireRepresentationsForPath(ctx, doc.RelPath, "size cap")
+		// #682: the read was refused, so this document is finished here. Everything
+		// below reasons about content this run did not obtain.
+		return s.settleSizeCapSkip(ctx, doc)
 	}
 	// Stamp the resolved content_hash onto the batch manifest outcome (§8.6.11);
 	// no-op when no batch run is active.
@@ -2478,6 +2475,10 @@ func (s *Service) creditInitialStatus(doc model.Document) (indexedPending, termi
 		// An archive container is credited as skipped here but is NOT terminal: it
 		// reverts to an error (and addSkipped(-1)) if member extraction fails, so
 		// its file_skip is deferred until handleArchiveDocument succeeds.
+		//
+		// A size_cap document never reaches this function (#682): settleSizeCapSkip
+		// counts it and raises its event, precisely so an over-cap ARCHIVE is not
+		// handed to the deferred emitter that only member extraction would reach.
 		if doc.DocType != "archive" {
 			s.notifyDocumentSkip(doc)
 		}
@@ -3243,11 +3244,51 @@ func (s *Service) sizeCapSkippedDocument(doc model.Document, f DiscoveredFile) m
 }
 
 // isSizeCapSkip reports whether doc is the size_cap skip row
-// sizeCapSkippedDocument produced. It is the marker processDocument keys the
-// representation retirement off, and it is deliberately narrow: no other builder
-// pairs status="skipped" with skip_reason="size_cap".
+// sizeCapSkippedDocument produced. It is the marker processDocument routes on, and
+// it is deliberately narrow: no other builder pairs status="skipped" with
+// skip_reason="size_cap".
 func isSizeCapSkip(doc model.Document) bool {
 	return doc.Status == "skipped" && doc.SkipReason == model.SkipReasonSizeCap
+}
+
+// settleSizeCapSkip is the whole terminal handling of a document whose SOURCE READ
+// passed the cap (#682): retire, persist, count, report. It is the read-time
+// counterpart of persistOversizeSkips, which does the same four things for a file
+// the discovery stat dropped (#497), and the two must agree, because they write the
+// same skip reason.
+//
+// Terminal by design. Everything processDocument does after this point reasons
+// about content this run did not obtain: the incremental gate, the derivation
+// identity, representation generation, output reconciliation. The most important of
+// them is the archive branch, which runs for a `skipped` container: without a
+// terminal return, an over-cap ARCHIVE would be localized and expanded, and members
+// would be ingested out of a container whose own bytes were just refused. A file
+// dropped by the discovery stat never reaches that branch, and this one must not
+// either.
+//
+// The order is load-bearing. Representations are retired FIRST, so an ungraceful
+// death between the two writes leaves a document with nothing searchable rather
+// than one whose row reads "skipped for size_cap" while its chunks are still being
+// served. It is the same rule the #681 withhold follows.
+//
+// The counters are the ones creditInitialStatus would have applied to a skipped
+// document, with one difference that is the point of doing it here: the event is
+// raised unconditionally. creditInitialStatus defers an archive container's
+// file_skip until member extraction finishes, and for this document extraction
+// never runs, so the deferred event would never be raised and the run would report
+// one more skip than it raised events for (SPEC §3.2).
+func (s *Service) settleSizeCapSkip(ctx context.Context, doc model.Document) error {
+	s.retireRepresentationsForPath(ctx, doc.RelPath, "size cap")
+	if err := s.store.UpsertDocument(ctx, doc); err != nil {
+		return fmt.Errorf("upsert document: %w", err)
+	}
+	// The row carries no content_hash, so cross-file dedup must forget the path
+	// instead of grouping it on the content it held before (#691).
+	s.notifyDocumentContentHash(doc.RelPath, doc.ContentHash)
+	s.addSkipped(1)
+	s.markActiveSkipped()
+	s.notifyDocumentSkip(doc)
+	return nil
 }
 
 // persistOversizeSkips upserts a minimal skipped document row for each file

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -1097,9 +1096,9 @@ func DiscoverOptionsFromConfig(cfg config.Config) DiscoverOptions {
 	options.FollowSymlinks = cfg.IngestFollowSymlinks
 	// One resolved list for the scan, the watcher, and the S3 lister (#773).
 	options.ExcludeDirs = append([]string(nil), cfg.IngestExcludeDirs...)
-	if cfg.IngestMaxFileMB > 0 {
-		options.MaxSizeBytes = int64(cfg.IngestMaxFileMB) * 1024 * 1024
-	}
+	// One resolver for the cap as well (#682), so discovery, the source reads, the
+	// object-store backend, and the on-demand tool paths enforce one number.
+	options.MaxSizeBytes = ResolvedMaxFileBytes(cfg)
 	options.MediaVariants = MediaVariantOptionsFromConfig(cfg)
 	return options
 }
@@ -2208,6 +2207,14 @@ func (s *Service) processDocument(ctx context.Context, f DiscoveredFile, secretP
 	if buildErr != nil {
 		return s.persistBuildError(ctx, f, secretPatterns, buildErr)
 	}
+	if isSizeCapSkip(doc) {
+		// #682: the read passed the cap, so anything an earlier scan indexed for this
+		// path came from bytes this file no longer has. Retire it BEFORE the row is
+		// written, so a crash between the two steps leaves a document with nothing
+		// searchable rather than one whose row says "skipped for size_cap" while its
+		// chunks are still being served. Same ordering rule as the #681 withhold.
+		s.retireRepresentationsForPath(ctx, doc.RelPath, "size cap")
+	}
 	// Stamp the resolved content_hash onto the batch manifest outcome (§8.6.11);
 	// no-op when no batch run is active.
 	s.recordContentHash(doc.ContentHash)
@@ -2646,13 +2653,22 @@ func (s *Service) deriveOneTrackTranslations(ctx context.Context, doc model.Docu
 // localizing remote (object-store) objects as needed. Used by the two-phase
 // derivation pass, which needs the source bytes only to key the per-language
 // translation cache.
+//
+// The read is bounded by the configured cap (#682). An over-cap asset returns
+// ErrFileTooLarge rather than a truncated buffer: a short read would produce a
+// different cache key and quietly re-derive every translation for a file the
+// transcription pass keyed on the whole bytes. deriveDocument treats any read
+// failure as a skip and leaves the existing source transcript searchable, which
+// is the right outcome here too.
 func (s *Service) readDocumentContent(ctx context.Context, relPath string) ([]byte, error) {
-	rc, err := s.corpusFS().Open(ctx, relPath)
+	content, overCap, err := s.readSourceBytes(ctx, relPath)
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = rc.Close() }()
-	return io.ReadAll(rc)
+	if overCap {
+		return nil, s.sourceOverCapError(relPath)
+	}
+	return content, nil
 }
 
 // handleArchiveDocument handles an archive-type document: if the archive
@@ -3143,14 +3159,15 @@ func (s *Service) buildDocumentWithContent(ctx context.Context, f DiscoveredFile
 		Deleted: false,
 	}
 
-	rc, err := s.corpusFS().Open(ctx, f.RelPath)
+	content, overCap, err := s.readSourceBytes(ctx, f.RelPath)
 	if err != nil {
 		return doc, nil, fmt.Errorf("read %s: %w", f.RelPath, err)
 	}
-	content, err := io.ReadAll(rc)
-	_ = rc.Close()
-	if err != nil {
-		return doc, nil, fmt.Errorf("read %s: %w", f.RelPath, err)
+	if overCap {
+		// #682: the bytes passed the cap, so this file is not the file discovery
+		// admitted. Return the honest size_cap skip row and no content: nothing
+		// downstream may see a prefix of a file it cannot have in full.
+		return s.sizeCapSkippedDocument(doc, f), nil, nil
 	}
 	// Fold any subtitle sidecar fingerprint (sibling paths + mtimes) into the
 	// media document's content hash so the incremental gate (§7.6) re-processes
@@ -3183,15 +3200,74 @@ func (s *Service) buildDocumentWithContent(ctx context.Context, f DiscoveredFile
 	return doc, content, nil
 }
 
+// sizeCapSkippedDocument turns a document whose SOURCE READ passed the configured
+// cap into the honest skip row for it (#682).
+//
+// The reason is `size_cap`: SPEC §15.2 defines it as "exceeded the configured max
+// file size", which is exactly what happened. That enum is CLOSED for a spec
+// minor, and reusing the value the spec already has for this condition is what
+// keeps the honest-coverage aggregate reporting a real cause. A file caught here
+// and a file caught by the discovery stat (#497) were refused by the same policy,
+// so they must read the same in `skip_reasons`.
+//
+// SizeBytes is deliberately zeroed. All this path knows is "more than the cap":
+// it stopped reading at cap+1 by design, and to keep reading until the end just
+// to measure the file would spend the very resources the bound exists to save.
+// The size discovery recorded is worse than nothing, because it describes a
+// snapshot the read has just proved wrong: a row saying "5 KB, skipped for
+// size_cap" is a contradiction an operator cannot act on. Zero means unknown
+// here, never empty, matching persistSymlinkSkips and the archive-member
+// exclusions.
+//
+// content_hash and ETag are cleared for the same reason: both are identity claims
+// about bytes this run did not obtain. A blank content_hash also keeps the
+// incremental gate honest: the next scan re-reads and decides again, so a file
+// that shrinks back under the cap is indexed instead of staying skipped forever,
+// and the remote ETag fast path cannot skip the re-read.
+//
+// The log line names the path, the cap, and the size discovery measured, so the
+// growth or the misreport is visible. It carries no file content.
+func (s *Service) sizeCapSkippedDocument(doc model.Document, f DiscoveredFile) model.Document {
+	s.getLogger().Printf(
+		"ingest: skipping %s: its bytes passed the ingest.max_file_mb cap (%d bytes) during the read, although discovery measured %d bytes; recorded as a size_cap skip. Raise ingest.max_file_mb to include it",
+		f.RelPath, s.sourceReadCapBytes(), f.SizeBytes,
+	)
+	doc.Status = "skipped"
+	doc.SkipReason = model.SkipReasonSizeCap
+	doc.SizeBytes = 0
+	doc.ContentHash = ""
+	doc.ETag = ""
+	doc.SidecarFingerprint = ""
+	doc.Title = ""
+	return doc
+}
+
+// isSizeCapSkip reports whether doc is the size_cap skip row
+// sizeCapSkippedDocument produced. It is the marker processDocument keys the
+// representation retirement off, and it is deliberately narrow: no other builder
+// pairs status="skipped" with skip_reason="size_cap".
+func isSizeCapSkip(doc model.Document) bool {
+	return doc.Status == "skipped" && doc.SkipReason == model.SkipReasonSizeCap
+}
+
 // persistOversizeSkips upserts a minimal skipped document row for each file
 // dropped at discovery for exceeding the ingest size cap (#497), stamping
 // skip_reason=size_cap so CorpusStats.SkipSummary can report it. Each path is
 // also registered in seen so markMissingAsDeleted (which runs after the scan)
 // does not tombstone the freshly-persisted row. Best-effort per path: a failed
 // upsert is logged and skipped rather than aborting the whole scan.
+//
+// It also retires anything an earlier scan indexed for the path (#682). A file
+// that grew past the cap was indexed while it was smaller, and the row this
+// writes carries no content_hash, so without the retirement the corpus would
+// report the file as skipped for size_cap while still serving chunks of its old
+// content. That is the same contradiction the read-time path avoids, so both
+// paths resolve it the same way. It is a no-op (one empty list query) for a file
+// that was never indexed, which is the common case.
 func (s *Service) persistOversizeSkips(ctx context.Context, oversize map[string]int64, seen map[string]struct{}) {
 	for relPath, size := range oversize {
 		seen[relPath] = struct{}{}
+		s.retireRepresentationsForPath(ctx, relPath, "size cap")
 		doc := model.Document{
 			RelPath:    relPath,
 			DocType:    ClassifyDocType(relPath),

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -3277,6 +3277,11 @@ func isSizeCapSkip(doc model.Document) bool {
 // file_skip until member extraction finishes, and for this document extraction
 // never runs, so the deferred event would never be raised and the run would report
 // one more skip than it raised events for (SPEC §3.2).
+//
+// The batch manifest entry carries the canonical §14.4 FILE_TOO_LARGE code, exactly
+// as the discovery-time drop already does (runScan records it for every
+// pendingOversize path). A plain, codeless skip would leave the manifest unable to
+// tell this asset from a cache hit.
 func (s *Service) settleSizeCapSkip(ctx context.Context, doc model.Document) error {
 	s.retireRepresentationsForPath(ctx, doc.RelPath, "size cap")
 	if err := s.store.UpsertDocument(ctx, doc); err != nil {
@@ -3286,7 +3291,7 @@ func (s *Service) settleSizeCapSkip(ctx context.Context, doc model.Document) err
 	// instead of grouping it on the content it held before (#691).
 	s.notifyDocumentContentHash(doc.RelPath, doc.ContentHash)
 	s.addSkipped(1)
-	s.markActiveSkipped()
+	s.activeOutcome.markSkippedWithCode(manifestErrFileTooLarge)
 	s.notifyDocumentSkip(doc)
 	return nil
 }

--- a/internal/ingest/sidecar.go
+++ b/internal/ingest/sidecar.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"path"
 	"sort"
 	"strings"
@@ -547,15 +546,19 @@ func sidecarRepHash(lang string, cues []subtitle.Cue) string {
 
 // readSidecar reads a sidecar file's bytes through the corpus FS and normalises
 // them to valid UTF-8 with LF line endings.
+//
+// The read is bounded by the configured cap (#682). A sidecar is a corpus file
+// like any other, so it is subject to the same cap, and it reaches this read
+// through the sidecar index rather than through the document pipeline. An
+// over-cap sidecar returns ErrFileTooLarge instead of a truncated cue list: half
+// a subtitle file would be persisted as if it were the whole transcript.
 func (s *Service) readSidecar(ctx context.Context, relPath string) (string, error) {
-	rc, err := s.corpusFS().Open(ctx, relPath)
+	raw, overCap, err := s.readSourceBytes(ctx, relPath)
 	if err != nil {
 		return "", err
 	}
-	defer func() { _ = rc.Close() }()
-	raw, err := io.ReadAll(rc)
-	if err != nil {
-		return "", err
+	if overCap {
+		return "", s.sourceOverCapError(relPath)
 	}
 	return string(NormalizeUTF8(raw)), nil
 }

--- a/internal/ingest/sourceread.go
+++ b/internal/ingest/sourceread.go
@@ -50,11 +50,13 @@ func (s *Service) sourceReadCapBytes() int64 {
 // prefix is dropped rather than returned, so no path downstream can mistake part
 // of a file for the whole of it.
 //
-// Two sources of the verdict are folded together here. The first is this limit,
-// which is the only thing that catches a LOCAL file that grew. The second is
-// corpusfs.ErrObjectTooLarge, which an object-store backend raises when its own
-// transport-level bound trips first; the caller needs one answer, not two, so it
-// is normalized into the same overCap verdict.
+// This limit is what decides in practice, and it is the only thing that can catch
+// a LOCAL file that grew. The two corpusfs.ErrObjectTooLarge branches are belt and
+// braces: an object-store backend bounds its own transport as well, and although
+// its sentinel cannot surface through THIS path (the limit reader stops asking at
+// cap+1, so the backend is never pushed past its own bound), a backend that
+// refused earlier must produce the same answer rather than a second one the caller
+// would have to classify.
 func (s *Service) readSourceBytes(ctx context.Context, relPath string) (content []byte, overCap bool, err error) {
 	capBytes := s.sourceReadCapBytes()
 	rc, err := s.corpusFS().Open(ctx, relPath)

--- a/internal/ingest/sourceread.go
+++ b/internal/ingest/sourceread.go
@@ -1,0 +1,88 @@
+package ingest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/corpusfs"
+)
+
+// ResolvedMaxFileBytes returns the effective `ingest.max_file_mb` cap in bytes.
+//
+// It is the single resolver for that cap. Discovery, every source-byte read, the
+// object-store backend, and the on-demand MCP tool paths all read it here, so the
+// four cannot drift into enforcing different numbers for the same setting. A
+// zero or negative configured value selects the 10 MiB default rather than
+// disabling the cap.
+func ResolvedMaxFileBytes(cfg config.Config) int64 {
+	if cfg.IngestMaxFileMB > 0 {
+		return int64(cfg.IngestMaxFileMB) * 1024 * 1024
+	}
+	return corpusfs.DefaultMaxFileSizeBytes()
+}
+
+// sourceReadCapBytes is ResolvedMaxFileBytes for this service's configuration.
+func (s *Service) sourceReadCapBytes() int64 {
+	return ResolvedMaxFileBytes(s.cfg)
+}
+
+// readSourceBytes reads a corpus file's bytes through the corpus filesystem under
+// a hard byte bound (#682).
+//
+// The bound is on the READ. Discovery measures a file with a stat (local) or a
+// ListObjectsV2 entry (S3) and admits it when that number is under the cap, but
+// the bytes arrive from a later, separate operation. A local file can grow between
+// the two. A bucket can serve an object that no longer matches the size it was
+// listed with, or that never did. So a size check, however it is repeated, only
+// ever describes a measurement; it cannot constrain a subsequent read. Only a
+// limit applied to the read itself can, and this is that limit.
+//
+// It reads at most cap+1 bytes. The extra byte is what separates "exactly at the
+// cap" from "past it", so the caller can refuse the second case without having
+// read a second file's worth of it.
+//
+// overCap=true is returned with a nil error, and with nil content. It is not a
+// failure: the file is over the cap the operator configured, which is the
+// `size_cap` skip of SPEC §15.2, and the caller records it as one. The truncated
+// prefix is dropped rather than returned, so no path downstream can mistake part
+// of a file for the whole of it.
+//
+// Two sources of the verdict are folded together here. The first is this limit,
+// which is the only thing that catches a LOCAL file that grew. The second is
+// corpusfs.ErrObjectTooLarge, which an object-store backend raises when its own
+// transport-level bound trips first; the caller needs one answer, not two, so it
+// is normalized into the same overCap verdict.
+func (s *Service) readSourceBytes(ctx context.Context, relPath string) (content []byte, overCap bool, err error) {
+	capBytes := s.sourceReadCapBytes()
+	rc, err := s.corpusFS().Open(ctx, relPath)
+	if err != nil {
+		if errors.Is(err, corpusfs.ErrObjectTooLarge) {
+			return nil, true, nil
+		}
+		return nil, false, err
+	}
+	defer func() { _ = rc.Close() }()
+
+	buf, err := io.ReadAll(io.LimitReader(rc, capBytes+1))
+	if err != nil {
+		if errors.Is(err, corpusfs.ErrObjectTooLarge) {
+			return nil, true, nil
+		}
+		return nil, false, err
+	}
+	if int64(len(buf)) > capBytes {
+		return nil, true, nil
+	}
+	return buf, false, nil
+}
+
+// sourceOverCapError renders the over-cap verdict as an error for the read paths
+// whose caller has no document row to record a skip on (the two-phase derivation
+// pass and the sidecar read). It wraps ErrFileTooLarge so §14.4 classification
+// keeps reporting FILE_TOO_LARGE.
+func (s *Service) sourceOverCapError(relPath string) error {
+	return fmt.Errorf("%w: %s passed the ingest.max_file_mb cap (%d bytes) while being read", ErrFileTooLarge, relPath, s.sourceReadCapBytes())
+}

--- a/internal/ingest/sourceread.go
+++ b/internal/ingest/sourceread.go
@@ -5,10 +5,21 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 
 	"github.com/dirstral/dir2mcp/internal/config"
 	"github.com/dirstral/dir2mcp/internal/corpusfs"
 )
+
+// maxSafeFileCapMB is the largest `ingest.max_file_mb` that still converts to
+// bytes without overflowing int64. Config validation only requires the value to be
+// non-negative, so a nonsense setting (a pasted digit too many) is reachable, and
+// an overflowed product would come out NEGATIVE. That is the worst possible
+// direction here: every limit+1 read would then ask for one byte, every file would
+// measure as past the cap, and a whole corpus would be skipped as size_cap. A cap
+// this large is unbounded in every practical sense anyway, so clamping to it loses
+// nothing.
+const maxSafeFileCapMB = math.MaxInt64 / (1024 * 1024)
 
 // ResolvedMaxFileBytes returns the effective `ingest.max_file_mb` cap in bytes.
 //
@@ -16,12 +27,17 @@ import (
 // object-store backend, and the on-demand MCP tool paths all read it here, so the
 // four cannot drift into enforcing different numbers for the same setting. A
 // zero or negative configured value selects the 10 MiB default rather than
-// disabling the cap.
+// disabling the cap, and an absurdly large one is clamped rather than allowed to
+// overflow into a negative limit.
 func ResolvedMaxFileBytes(cfg config.Config) int64 {
-	if cfg.IngestMaxFileMB > 0 {
-		return int64(cfg.IngestMaxFileMB) * 1024 * 1024
+	mb := int64(cfg.IngestMaxFileMB)
+	if mb <= 0 {
+		return corpusfs.DefaultMaxFileSizeBytes()
 	}
-	return corpusfs.DefaultMaxFileSizeBytes()
+	if mb > maxSafeFileCapMB {
+		mb = maxSafeFileCapMB
+	}
+	return mb * 1024 * 1024
 }
 
 // sourceReadCapBytes is ResolvedMaxFileBytes for this service's configuration.

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2640,6 +2640,12 @@ func mapPathError(err error) *toolExecutionError {
 	switch {
 	case errors.Is(err, model.ErrForbidden):
 		return &toolExecutionError{Code: protocol.ErrorCodeForbidden, Message: "forbidden", Retryable: false}
+	case errors.Is(err, corpusfs.ErrObjectTooLarge):
+		// #682: the object served more bytes than the configured cap, so the
+		// localize was refused. It is the §14.4 FILE_TOO_LARGE condition, and the
+		// default branch below would report it as "permission denied", which names
+		// the wrong cause and sends the operator to the wrong setting.
+		return &toolExecutionError{Code: "FILE_TOO_LARGE", Message: "object exceeds the configured ingest.max_file_mb cap", Retryable: false}
 	case errors.Is(err, model.ErrPathOutsideRoot):
 		return &toolExecutionError{Code: "PATH_OUTSIDE_ROOT", Message: "path outside root", Retryable: false}
 	case errors.Is(err, os.ErrNotExist):
@@ -2818,12 +2824,11 @@ func (s *Server) sourceTextForAnnotation(ctx context.Context, doc model.Document
 }
 
 // ingestMaxFileBytes returns the per-file size cap used by ingestion, so the
-// on-demand tool read paths honour the same bound (issue #407).
+// on-demand tool read paths honour the same bound (issue #407). It delegates to
+// the single resolver in ingest (#682) so this bound cannot drift from the one
+// discovery, the source reads, and the object-store backend apply.
 func (s *Server) ingestMaxFileBytes() int64 {
-	if s.cfg.IngestMaxFileMB > 0 {
-		return int64(s.cfg.IngestMaxFileMB) * 1024 * 1024
-	}
-	return ingest.DefaultMaxFileSizeBytes()
+	return ingest.ResolvedMaxFileBytes(s.cfg)
 }
 
 // readBoundedFile reads at most maxBytes from path. It reports tooLarge=true

--- a/tests/corpusfs/s3_cap_wiring_682_test.go
+++ b/tests/corpusfs/s3_cap_wiring_682_test.go
@@ -1,0 +1,103 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/corpusfs"
+)
+
+// Cap wiring and the sentinel (dir2mcp #682).
+//
+// The tests in s3_localize_bound_682_test.go prove the bound exists using only the
+// API `main` already has, so they run against `main` and fail there. These name the
+// new surface (S3Config.MaxBytes, corpusfs.ErrObjectTooLarge), so they cannot
+// compile against `main`; they pin the parts a caller depends on: the operator's
+// configured cap is the one enforced, and the refusal is a sentinel a caller can
+// classify instead of a string it has to match.
+
+// TestS3FSLocalize_HonorsTheConfiguredCap pins that the enforced bound is the
+// operator's `ingest.max_file_mb`, not a hard-coded default. The cap is set well
+// below the default so a passing test cannot be explained by the default.
+func TestS3FSLocalize_HonorsTheConfiguredCap(t *testing.T) {
+	const cap682 = 64 * 1024
+	stub := &lyingS3For682{key: "corpus/clip.mp4", listSize: 512, bodySize: 4 * cap682}
+	cacheDir := t.TempDir()
+	fsys, err := corpusfs.NewS3FS(stub, corpusfs.S3Config{
+		Bucket: "bkt", Prefix: "corpus/", CacheDir: cacheDir, MaxBytes: cap682,
+	})
+	if err != nil {
+		t.Fatalf("NewS3FS: %v", err)
+	}
+
+	_, cleanup, err := fsys.Localize(context.Background(), "clip.mp4")
+	if cleanup != nil {
+		cleanup()
+	}
+	if !errors.Is(err, corpusfs.ErrObjectTooLarge) {
+		t.Fatalf("Localize error = %v, want ErrObjectTooLarge", err)
+	}
+	if served := stub.bytesServed.Load(); served > cap682+1 {
+		t.Errorf("Localize pulled %d bytes; the bound is %d (cap+1)", served, cap682+1)
+	}
+	if left := cacheDirBytes682(t, cacheDir); left != 0 {
+		t.Errorf("cache dir still holds %d bytes after the refused download", left)
+	}
+}
+
+// TestS3FSOpen_RefusalCarriesTheSentinel pins that an over-cap read fails with
+// ErrObjectTooLarge rather than with io.EOF. A silent short read is the worse
+// outcome of the two: every caller would treat the prefix as a complete file, which
+// is the truncated-document failure #487 already fixed once.
+func TestS3FSOpen_RefusalCarriesTheSentinel(t *testing.T) {
+	const cap682 = 64 * 1024
+	head := int64(4 * cap682)
+	stub := &lyingS3For682{key: "corpus/notes.txt", listSize: 512, headSize: &head, bodySize: 4 * cap682}
+	fsys, err := corpusfs.NewS3FS(stub, corpusfs.S3Config{
+		Bucket: "bkt", Prefix: "corpus/", CacheDir: t.TempDir(), MaxBytes: cap682,
+	})
+	if err != nil {
+		t.Fatalf("NewS3FS: %v", err)
+	}
+
+	rc, err := fsys.Open(context.Background(), "notes.txt")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = rc.Close() }()
+
+	got, readErr := io.ReadAll(rc)
+	if !errors.Is(readErr, corpusfs.ErrObjectTooLarge) {
+		t.Fatalf("read error = %v, want ErrObjectTooLarge", readErr)
+	}
+	if len(got) != cap682 {
+		t.Errorf("read delivered %d bytes before refusing, want exactly the %d-byte cap", len(got), cap682)
+	}
+}
+
+// TestS3FSCapDefaultsWhenUnset pins that an unset (or zero) MaxBytes resolves to
+// the 10 MiB default rather than to "unbounded". A caller that forgets the field
+// must still get a bound; there is deliberately no unlimited setting.
+func TestS3FSCapDefaultsWhenUnset(t *testing.T) {
+	stub := &lyingS3For682{key: "corpus/big.bin", listSize: listedBytes682, bodySize: bodyBytes682}
+	cacheDir := t.TempDir()
+	fsys, err := corpusfs.NewS3FS(stub, corpusfs.S3Config{
+		Bucket: "bkt", Prefix: "corpus/", CacheDir: cacheDir, MaxBytes: 0,
+	})
+	if err != nil {
+		t.Fatalf("NewS3FS: %v", err)
+	}
+
+	_, cleanup, err := fsys.Localize(context.Background(), "big.bin")
+	if cleanup != nil {
+		cleanup()
+	}
+	if !errors.Is(err, corpusfs.ErrObjectTooLarge) {
+		t.Fatalf("Localize error = %v, want ErrObjectTooLarge under the default cap", err)
+	}
+	if served := stub.bytesServed.Load(); served > corpusfs.DefaultMaxFileSizeBytes()+1 {
+		t.Errorf("Localize pulled %d bytes; the default bound is %d (cap+1)", served, corpusfs.DefaultMaxFileSizeBytes()+1)
+	}
+}

--- a/tests/corpusfs/s3_cap_wiring_682_test.go
+++ b/tests/corpusfs/s3_cap_wiring_682_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"math"
 	"os"
 	"testing"
 
@@ -40,8 +41,8 @@ func TestS3FSLocalize_HonorsTheConfiguredCap(t *testing.T) {
 	if !errors.Is(err, corpusfs.ErrObjectTooLarge) {
 		t.Fatalf("Localize error = %v, want ErrObjectTooLarge", err)
 	}
-	if served := stub.bytesServed.Load(); served > cap682+1 {
-		t.Errorf("Localize pulled %d bytes; the bound is %d (cap+1)", served, cap682+1)
+	if served := stub.bytesServed.Load(); served != cap682+1 {
+		t.Errorf("Localize pulled %d bytes; want exactly %d (cap+1)", served, cap682+1)
 	}
 	if left := cacheDirBytes682(t, cacheDir); left != 0 {
 		t.Errorf("cache dir still holds %d bytes after the refused download", left)
@@ -153,6 +154,40 @@ func TestS3FSLocalize_ObjectOfExactlyTheCapDownloadsCleanly(t *testing.T) {
 	}
 }
 
+// TestS3FSCapClampsAnAbsurdValue pins the upper clamp on the configured cap. Every
+// bound in the backend is a limit+1, so math.MaxInt64 would overflow that sum to a
+// negative number, and io.LimitReader reads a negative limit as "no bytes allowed".
+// The failure that produces is the dangerous kind: Localize writes an EMPTY file and
+// reports success, so a caller gets a valid path to a truncated object. S3Config is
+// exported, so the invariant is enforced in the backend rather than trusted to the
+// caller.
+func TestS3FSCapClampsAnAbsurdValue(t *testing.T) {
+	const size = 4096
+	head := int64(size)
+	stub := &lyingS3For682{key: "corpus/small.bin", listSize: size, headSize: &head, bodySize: size}
+	fsys, err := corpusfs.NewS3FS(stub, corpusfs.S3Config{
+		Bucket: "bkt", Prefix: "corpus/", CacheDir: t.TempDir(), MaxBytes: math.MaxInt64,
+	})
+	if err != nil {
+		t.Fatalf("NewS3FS: %v", err)
+	}
+
+	localPath, cleanup, err := fsys.Localize(context.Background(), "small.bin")
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if err != nil {
+		t.Fatalf("Localize: %v", err)
+	}
+	info, statErr := os.Stat(localPath)
+	if statErr != nil {
+		t.Fatalf("stat localized file: %v", statErr)
+	}
+	if info.Size() != size {
+		t.Errorf("localized file is %d bytes, want the whole %d-byte object", info.Size(), size)
+	}
+}
+
 // TestS3FSCapDefaultsWhenUnset pins that an unset (or zero) MaxBytes resolves to
 // the 10 MiB default rather than to "unbounded". A caller that forgets the field
 // must still get a bound; there is deliberately no unlimited setting.
@@ -173,7 +208,7 @@ func TestS3FSCapDefaultsWhenUnset(t *testing.T) {
 	if !errors.Is(err, corpusfs.ErrObjectTooLarge) {
 		t.Fatalf("Localize error = %v, want ErrObjectTooLarge under the default cap", err)
 	}
-	if served := stub.bytesServed.Load(); served > corpusfs.DefaultMaxFileSizeBytes()+1 {
-		t.Errorf("Localize pulled %d bytes; the default bound is %d (cap+1)", served, corpusfs.DefaultMaxFileSizeBytes()+1)
+	if served := stub.bytesServed.Load(); served != corpusfs.DefaultMaxFileSizeBytes()+1 {
+		t.Errorf("Localize pulled %d bytes; want exactly %d (default cap+1)", served, corpusfs.DefaultMaxFileSizeBytes()+1)
 	}
 }

--- a/tests/corpusfs/s3_cap_wiring_682_test.go
+++ b/tests/corpusfs/s3_cap_wiring_682_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"os"
 	"testing"
 
 	"github.com/dirstral/dir2mcp/internal/corpusfs"
@@ -72,8 +73,83 @@ func TestS3FSOpen_RefusalCarriesTheSentinel(t *testing.T) {
 	if !errors.Is(readErr, corpusfs.ErrObjectTooLarge) {
 		t.Fatalf("read error = %v, want ErrObjectTooLarge", readErr)
 	}
-	if len(got) != cap682 {
-		t.Errorf("read delivered %d bytes before refusing, want exactly the %d-byte cap", len(got), cap682)
+	// limit+1: the reader hands over one byte past the cap and then fails. That
+	// byte is what proves the object is past the cap rather than exactly at it.
+	if len(got) != cap682+1 {
+		t.Errorf("read delivered %d bytes before refusing, want the %d-byte cap plus the one probe byte", len(got), cap682)
+	}
+}
+
+// TestS3FSOpen_ObjectOfExactlyTheCapReadsCleanly is the off-by-one guard on the
+// limit+1 read, and it is the case a naive bound gets wrong. An object of exactly
+// `ingest.max_file_mb` is INSIDE the policy: discovery admits it, so the reader must
+// deliver all of it and end at io.EOF, not at ErrObjectTooLarge.
+//
+// It is asserted through both reader shapes, because they decide differently: the
+// ranged reader compares against the length HEAD reported, while the streaming
+// reader has no length and must read one byte past the cap to learn that the object
+// ended there.
+func TestS3FSOpen_ObjectOfExactlyTheCapReadsCleanly(t *testing.T) {
+	const cap682 = 64 * 1024
+	head := int64(cap682)
+
+	for _, tc := range []struct {
+		name     string
+		headSize *int64
+	}{
+		{name: "reported length (ranged reader)", headSize: &head},
+		{name: "no reported length (streaming reader)", headSize: nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stub := &lyingS3For682{key: "corpus/exact.bin", listSize: cap682, headSize: tc.headSize, bodySize: cap682}
+			fsys, err := corpusfs.NewS3FS(stub, corpusfs.S3Config{
+				Bucket: "bkt", Prefix: "corpus/", CacheDir: t.TempDir(), MaxBytes: cap682,
+			})
+			if err != nil {
+				t.Fatalf("NewS3FS: %v", err)
+			}
+			rc, err := fsys.Open(context.Background(), "exact.bin")
+			if err != nil {
+				t.Fatalf("Open: %v", err)
+			}
+			defer func() { _ = rc.Close() }()
+
+			got, err := io.ReadAll(rc)
+			if err != nil {
+				t.Fatalf("read of an object exactly at the cap failed: %v", err)
+			}
+			if len(got) != cap682 {
+				t.Errorf("read returned %d bytes, want the whole %d-byte object", len(got), cap682)
+			}
+		})
+	}
+}
+
+// TestS3FSLocalize_ObjectOfExactlyTheCapDownloadsCleanly is the same off-by-one
+// guard on the download path: an object exactly at the cap must localize.
+func TestS3FSLocalize_ObjectOfExactlyTheCapDownloadsCleanly(t *testing.T) {
+	const cap682 = 64 * 1024
+	stub := &lyingS3For682{key: "corpus/exact.mp4", listSize: cap682, bodySize: cap682}
+	fsys, err := corpusfs.NewS3FS(stub, corpusfs.S3Config{
+		Bucket: "bkt", Prefix: "corpus/", CacheDir: t.TempDir(), MaxBytes: cap682,
+	})
+	if err != nil {
+		t.Fatalf("NewS3FS: %v", err)
+	}
+
+	localPath, cleanup, err := fsys.Localize(context.Background(), "exact.mp4")
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if err != nil {
+		t.Fatalf("Localize of an object exactly at the cap failed: %v", err)
+	}
+	info, err := os.Stat(localPath)
+	if err != nil {
+		t.Fatalf("stat localized file: %v", err)
+	}
+	if info.Size() != cap682 {
+		t.Errorf("localized file is %d bytes, want the whole %d-byte object", info.Size(), cap682)
 	}
 }
 

--- a/tests/corpusfs/s3_localize_bound_682_test.go
+++ b/tests/corpusfs/s3_localize_bound_682_test.go
@@ -1,0 +1,257 @@
+package tests
+
+import (
+	"context"
+	"io"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+
+	"github.com/dirstral/dir2mcp/internal/corpusfs"
+)
+
+// Bounded object-store reads and downloads (dir2mcp #682).
+//
+// The size cap was time-of-check only. Discovery sized an object from
+// ListObjectsV2 and admitted it, and the bytes then arrived from a separate
+// GetObject that nothing limited. An object that reports one size and serves
+// another therefore had no bound at all: Localize streamed the whole body onto the
+// local cache disk, and a whole-object read streamed it into memory.
+//
+// Every test here uses a bucket that LIES. List reports a few hundred bytes, and
+// HEAD or the body then delivers far more. That is the case a repeated size check
+// can never catch, because every number a check can read is a number the object
+// chose to report.
+
+// capBytes682 is the default per-object cap the backend applies when none is
+// configured (10 MiB). The tests serve more than this so the bound has to act.
+const capBytes682 = 10 * 1024 * 1024
+
+// bodyBytes682 is how many bytes the lying bucket actually serves.
+const bodyBytes682 = capBytes682 + 2*1024*1024
+
+// listedBytes682 is the size the lying bucket reports to DISCOVERY, which is what
+// admits the object under the cap in the first place.
+const listedBytes682 = 512
+
+// generatedBody682 is an io.ReadCloser that serves `remaining` bytes without ever
+// holding them in memory, and records how many were pulled. Generating the body is
+// what makes the test honest about the defect: on `main` the read is unbounded, so
+// a body held in a []byte would have to be allocated in full before the test could
+// prove anything about the bound.
+type generatedBody682 struct {
+	remaining int64
+	counter   *atomic.Int64
+}
+
+func (g *generatedBody682) Read(p []byte) (int, error) {
+	if g.remaining <= 0 {
+		return 0, io.EOF
+	}
+	if int64(len(p)) > g.remaining {
+		p = p[:g.remaining]
+	}
+	for i := range p {
+		p[i] = 'x'
+	}
+	g.remaining -= int64(len(p))
+	g.counter.Add(int64(len(p)))
+	return len(p), nil
+}
+
+func (g *generatedBody682) Close() error { return nil }
+
+// lyingS3For682 is a network-free S3 stub whose reported object size disagrees
+// with the body it serves.
+//
+// The three sizes are independent on purpose, because in production they come
+// from three separate operations: ListObjectsV2 (what discovery measured),
+// HeadObject (what Open measured), and the GetObject body (what actually
+// arrived). headSize == nil drops HEAD's Content-Length entirely, the shape #487
+// documented on some MinIO/R2 gateways and the one case where no reported size
+// exists to check at all.
+type lyingS3For682 struct {
+	key         string
+	listSize    int64
+	headSize    *int64
+	bodySize    int64
+	bytesServed atomic.Int64
+}
+
+func (f *lyingS3For682) ListObjectsV2(_ context.Context, in *s3.ListObjectsV2Input, _ ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
+	if !strings.HasPrefix(f.key, aws.ToString(in.Prefix)) {
+		return &s3.ListObjectsV2Output{IsTruncated: aws.Bool(false)}, nil
+	}
+	return &s3.ListObjectsV2Output{
+		Contents: []s3types.Object{{
+			Key:          aws.String(f.key),
+			Size:         aws.Int64(f.listSize),
+			ETag:         aws.String("\"etag-682\""),
+			LastModified: aws.Time(time.Unix(1700000000, 0)),
+		}},
+		IsTruncated: aws.Bool(false),
+	}, nil
+}
+
+func (f *lyingS3For682) HeadObject(_ context.Context, in *s3.HeadObjectInput, _ ...func(*s3.Options)) (*s3.HeadObjectOutput, error) {
+	if aws.ToString(in.Key) != f.key {
+		return nil, &s3types.NoSuchKey{}
+	}
+	if f.headSize == nil {
+		return &s3.HeadObjectOutput{}, nil
+	}
+	return &s3.HeadObjectOutput{ContentLength: aws.Int64(*f.headSize)}, nil
+}
+
+func (f *lyingS3For682) GetObject(_ context.Context, in *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	if aws.ToString(in.Key) != f.key {
+		return nil, &s3types.NoSuchKey{}
+	}
+	return &s3.GetObjectOutput{Body: &generatedBody682{remaining: f.bodySize, counter: &f.bytesServed}}, nil
+}
+
+// newLyingS3FS682 builds the stub plus a backend over it, with the default cap.
+func newLyingS3FS682(t *testing.T, stub *lyingS3For682, cacheDir string) *corpusfs.S3FS {
+	t.Helper()
+	fsys, err := corpusfs.NewS3FS(stub, corpusfs.S3Config{Bucket: "bkt", Prefix: "corpus/", CacheDir: cacheDir})
+	if err != nil {
+		t.Fatalf("NewS3FS: %v", err)
+	}
+	return fsys
+}
+
+// cacheDirBytes682 sums the sizes of the files left in the Localize cache dir, so
+// a test can assert that a refused download left nothing behind.
+func cacheDirBytes682(t *testing.T, dir string) int64 {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0
+		}
+		t.Fatalf("read cache dir: %v", err)
+	}
+	var total int64
+	for _, e := range entries {
+		info, err := e.Info()
+		if err != nil {
+			t.Fatalf("stat cache entry %s: %v", e.Name(), err)
+		}
+		total += info.Size()
+	}
+	return total
+}
+
+// TestS3FSLocalize_BoundsTheDownloadWhenTheObjectLies is the disk half of #682.
+// Discovery listed the object at 512 bytes, so the cap admitted it. The body then
+// serves 12 MiB. Localize must stop at the cap, refuse the object, and leave no
+// partial file in the cache dir.
+//
+// On `main` it downloads all 12 MiB, reports success, and hands the caller a path
+// to a file larger than the operator allowed.
+func TestS3FSLocalize_BoundsTheDownloadWhenTheObjectLies(t *testing.T) {
+	stub := &lyingS3For682{key: "corpus/big.mp4", listSize: listedBytes682, bodySize: bodyBytes682}
+	cacheDir := t.TempDir()
+	fsys := newLyingS3FS682(t, stub, cacheDir)
+
+	localPath, cleanup, err := fsys.Localize(context.Background(), "big.mp4")
+	if cleanup != nil {
+		cleanup()
+	}
+	if err == nil {
+		t.Errorf("Localize succeeded for an object that served %d bytes under a %d-byte cap; want a refusal (localized to %q)", bodyBytes682, capBytes682, localPath)
+	}
+	if served := stub.bytesServed.Load(); served > capBytes682+1 {
+		t.Errorf("Localize pulled %d bytes from the body; the bound is %d (cap+1)", served, capBytes682+1)
+	}
+	if left := cacheDirBytes682(t, cacheDir); left != 0 {
+		t.Errorf("cache dir still holds %d bytes after the refused download; a partial file must be removed", left)
+	}
+}
+
+// TestS3FSOpen_BoundsAWholeObjectReadWhenHeadDisagreesWithDiscovery is the memory
+// half of #682 for an object that DOES report a length: discovery listed it at 512
+// bytes and HEAD then reports 12 MiB. The ranged reader trusted HEAD, so a
+// whole-object read delivered every one of those bytes.
+//
+// On `main` io.ReadAll returns 12 MiB with no error.
+func TestS3FSOpen_BoundsAWholeObjectReadWhenHeadDisagreesWithDiscovery(t *testing.T) {
+	head := int64(bodyBytes682)
+	stub := &lyingS3For682{key: "corpus/report.txt", listSize: listedBytes682, headSize: &head, bodySize: bodyBytes682}
+	fsys := newLyingS3FS682(t, stub, t.TempDir())
+
+	rc, err := fsys.Open(context.Background(), "report.txt")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = rc.Close() }()
+
+	got, readErr := io.ReadAll(rc)
+	if readErr == nil {
+		t.Errorf("read of a %d-byte object completed with no error under a %d-byte cap; want a refusal (got %d bytes)", bodyBytes682, capBytes682, len(got))
+	}
+	if int64(len(got)) > capBytes682 {
+		t.Errorf("read returned %d bytes under a %d-byte cap; want no more than the cap", len(got), capBytes682)
+	}
+	if served := stub.bytesServed.Load(); served > capBytes682+1 {
+		t.Errorf("read pulled %d bytes from the body; the bound is %d (cap+1)", served, capBytes682+1)
+	}
+}
+
+// TestS3FSOpen_BoundsAWholeObjectReadWithNoReportedLength is the case where no
+// size check of any kind could help: HEAD omits Content-Length, so there is no
+// reported size to compare against. The backend falls back to a whole-object
+// streaming GET (#487), and only a bound on the arriving bytes can hold it.
+//
+// On `main` the stream reader is unbounded and io.ReadAll returns all 12 MiB.
+func TestS3FSOpen_BoundsAWholeObjectReadWithNoReportedLength(t *testing.T) {
+	stub := &lyingS3For682{key: "corpus/nolen.bin", listSize: listedBytes682, bodySize: bodyBytes682}
+	fsys := newLyingS3FS682(t, stub, t.TempDir())
+
+	rc, err := fsys.Open(context.Background(), "nolen.bin")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = rc.Close() }()
+
+	got, readErr := io.ReadAll(rc)
+	if readErr == nil {
+		t.Errorf("unknown-length object read to completion with no error; a %d-byte read under a %d-byte cap must be refused (got %d bytes)", bodyBytes682, capBytes682, len(got))
+	}
+	if int64(len(got)) > capBytes682 {
+		t.Errorf("read returned %d bytes under a %d-byte cap; want no more than the cap", len(got), capBytes682)
+	}
+	if served := stub.bytesServed.Load(); served > capBytes682+1 {
+		t.Errorf("read pulled %d bytes from the body; the bound is %d (cap+1)", served, capBytes682+1)
+	}
+}
+
+// TestS3FSOpen_ReadsAnHonestObjectInFull is the false-positive guard. An object
+// whose reported size and body agree, and which fits the cap, must still read
+// completely: the bound must refuse only what passes it.
+func TestS3FSOpen_ReadsAnHonestObjectInFull(t *testing.T) {
+	const size = 3 * 1024 * 1024
+	head := int64(size)
+	stub := &lyingS3For682{key: "corpus/honest.txt", listSize: size, headSize: &head, bodySize: size}
+	fsys := newLyingS3FS682(t, stub, t.TempDir())
+
+	rc, err := fsys.Open(context.Background(), "honest.txt")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = rc.Close() }()
+
+	got, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("read of an in-cap object failed: %v", err)
+	}
+	if len(got) != size {
+		t.Errorf("read returned %d bytes, want the whole %d-byte object", len(got), size)
+	}
+}

--- a/tests/corpusfs/s3_localize_bound_682_test.go
+++ b/tests/corpusfs/s3_localize_bound_682_test.go
@@ -167,8 +167,8 @@ func TestS3FSLocalize_BoundsTheDownloadWhenTheObjectLies(t *testing.T) {
 	if err == nil {
 		t.Errorf("Localize succeeded for an object that served %d bytes under a %d-byte cap; want a refusal (localized to %q)", bodyBytes682, capBytes682, localPath)
 	}
-	if served := stub.bytesServed.Load(); served > capBytes682+1 {
-		t.Errorf("Localize pulled %d bytes from the body; the bound is %d (cap+1)", served, capBytes682+1)
+	if served := stub.bytesServed.Load(); served != capBytes682+1 {
+		t.Errorf("Localize pulled %d bytes from the body; want exactly %d (cap+1): the bound must stop there, and must not stop short either", served, capBytes682+1)
 	}
 	if left := cacheDirBytes682(t, cacheDir); left != 0 {
 		t.Errorf("cache dir still holds %d bytes after the refused download; a partial file must be removed", left)
@@ -201,8 +201,8 @@ func TestS3FSOpen_BoundsAWholeObjectReadWhenHeadDisagreesWithDiscovery(t *testin
 	if int64(len(got)) > capBytes682+1 {
 		t.Errorf("read returned %d bytes under a %d-byte cap; the bound is cap+1", len(got), capBytes682)
 	}
-	if served := stub.bytesServed.Load(); served > capBytes682+1 {
-		t.Errorf("read pulled %d bytes from the body; the bound is %d (cap+1)", served, capBytes682+1)
+	if served := stub.bytesServed.Load(); served != capBytes682+1 {
+		t.Errorf("read pulled %d bytes from the body; want exactly %d (cap+1): the bound must stop there, and must not stop short either", served, capBytes682+1)
 	}
 }
 
@@ -231,8 +231,8 @@ func TestS3FSOpen_BoundsAWholeObjectReadWithNoReportedLength(t *testing.T) {
 	if int64(len(got)) > capBytes682+1 {
 		t.Errorf("read returned %d bytes under a %d-byte cap; the bound is cap+1", len(got), capBytes682)
 	}
-	if served := stub.bytesServed.Load(); served > capBytes682+1 {
-		t.Errorf("read pulled %d bytes from the body; the bound is %d (cap+1)", served, capBytes682+1)
+	if served := stub.bytesServed.Load(); served != capBytes682+1 {
+		t.Errorf("read pulled %d bytes from the body; want exactly %d (cap+1): the bound must stop there, and must not stop short either", served, capBytes682+1)
 	}
 }
 

--- a/tests/corpusfs/s3_localize_bound_682_test.go
+++ b/tests/corpusfs/s3_localize_bound_682_test.go
@@ -196,8 +196,10 @@ func TestS3FSOpen_BoundsAWholeObjectReadWhenHeadDisagreesWithDiscovery(t *testin
 	if readErr == nil {
 		t.Errorf("read of a %d-byte object completed with no error under a %d-byte cap; want a refusal (got %d bytes)", bodyBytes682, capBytes682, len(got))
 	}
-	if int64(len(got)) > capBytes682 {
-		t.Errorf("read returned %d bytes under a %d-byte cap; want no more than the cap", len(got), capBytes682)
+	// limit+1: one byte past the cap is what proves the object is over it rather
+	// than exactly at it. That byte is the whole allowance.
+	if int64(len(got)) > capBytes682+1 {
+		t.Errorf("read returned %d bytes under a %d-byte cap; the bound is cap+1", len(got), capBytes682)
 	}
 	if served := stub.bytesServed.Load(); served > capBytes682+1 {
 		t.Errorf("read pulled %d bytes from the body; the bound is %d (cap+1)", served, capBytes682+1)
@@ -224,8 +226,10 @@ func TestS3FSOpen_BoundsAWholeObjectReadWithNoReportedLength(t *testing.T) {
 	if readErr == nil {
 		t.Errorf("unknown-length object read to completion with no error; a %d-byte read under a %d-byte cap must be refused (got %d bytes)", bodyBytes682, capBytes682, len(got))
 	}
-	if int64(len(got)) > capBytes682 {
-		t.Errorf("read returned %d bytes under a %d-byte cap; want no more than the cap", len(got), capBytes682)
+	// limit+1: one byte past the cap is what proves the object is over it rather
+	// than exactly at it. That byte is the whole allowance.
+	if int64(len(got)) > capBytes682+1 {
+		t.Errorf("read returned %d bytes under a %d-byte cap; the bound is cap+1", len(got), capBytes682)
 	}
 	if served := stub.bytesServed.Load(); served > capBytes682+1 {
 		t.Errorf("read pulled %d bytes from the body; the bound is %d (cap+1)", served, capBytes682+1)

--- a/tests/ingest/size_cap_read_bound_682_test.go
+++ b/tests/ingest/size_cap_read_bound_682_test.go
@@ -1,0 +1,402 @@
+package tests
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/appstate"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/corpusfs"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// Bounded source reads (dir2mcp #682).
+//
+// `ingest.max_file_mb` was enforced at discovery and nowhere else. Discovery
+// measured a file with a stat (local) or a ListObjectsV2 entry (S3), admitted it
+// under the cap, and the pipeline then read the bytes with an unbounded
+// io.ReadAll. Nothing tied the bytes read to the size that had been checked.
+//
+// So a file that grew after the check, or an object that never matched the size it
+// was listed with, was read in full. What an operator saw was resident memory
+// climbing during a scan and, on a large enough file, the daemon killed by the OOM
+// killer mid-scan: indexing stopped, `status` never reached pending=0, and the log
+// named no file, because the process died inside the read.
+//
+// Every test here asserts on TWO things, and both matter. The row the scan
+// persisted, which is the honest-coverage answer; and the number of bytes the
+// source was actually asked for, which is the bound. A re-check of the size could
+// produce the first without the second, and the second is the defect.
+
+// readCap682 is the cap the tests configure, in MiB and in bytes. It is the
+// smallest cap `ingest.max_file_mb` can express, which keeps the over-cap fixtures
+// small.
+const (
+	readCapMB682    = 1
+	readCapBytes682 = int64(readCapMB682) * 1024 * 1024
+)
+
+// overCapBytes682 is the size of the fixtures that must trip the bound.
+const overCapBytes682 = 4 * readCapBytes682
+
+// countingReader682 wraps a reader and records how many bytes were pulled through
+// it. It is the whole proof: with the bound in place the scan must stop asking for
+// bytes at cap+1, however many the source is willing to serve.
+type countingReader682 struct {
+	inner   io.ReadSeekCloser
+	counter *atomic.Int64
+}
+
+func (c *countingReader682) Read(p []byte) (int, error) {
+	n, err := c.inner.Read(p)
+	c.counter.Add(int64(n))
+	return n, err
+}
+
+func (c *countingReader682) Seek(offset int64, whence int) (int64, error) {
+	return c.inner.Seek(offset, whence)
+}
+
+func (c *countingReader682) Close() error { return c.inner.Close() }
+
+// generatedFile682 serves n bytes of ordinary text without holding them in
+// memory. It also satisfies io.Seeker so it can stand in for a CorpusFS reader;
+// only the position query (Seek(0, io.SeekCurrent)) is supported, which is all a
+// sequential whole-file read needs.
+type generatedFile682 struct {
+	remaining int64
+	offset    int64
+}
+
+func (g *generatedFile682) Read(p []byte) (int, error) {
+	if g.remaining <= 0 {
+		return 0, io.EOF
+	}
+	if int64(len(p)) > g.remaining {
+		p = p[:g.remaining]
+	}
+	for i := range p {
+		p[i] = 'a'
+	}
+	g.remaining -= int64(len(p))
+	g.offset += int64(len(p))
+	return len(p), nil
+}
+
+func (g *generatedFile682) Seek(offset int64, whence int) (int64, error) {
+	if whence == io.SeekCurrent && offset == 0 {
+		return g.offset, nil
+	}
+	return 0, os.ErrInvalid
+}
+
+func (g *generatedFile682) Close() error { return nil }
+
+// underReportingFS682 is a stub corpus backend that LIES about a file's size: Walk
+// reports a handful of bytes, Open serves megabytes. It stands in for the S3
+// backend without credentials or a network, and it is the case a size re-check
+// cannot catch, because the only size a re-check can read is the one the backend
+// reports.
+type underReportingFS682 struct {
+	relPath     string
+	reportedLen int64
+	bodyLen     int64
+	bytesServed atomic.Int64
+}
+
+func (f *underReportingFS682) Walk(_ context.Context, _ string, _ corpusfs.Options) ([]corpusfs.DiscoveredFile, error) {
+	return []corpusfs.DiscoveredFile{{
+		RelPath:   f.relPath,
+		SizeBytes: f.reportedLen,
+		ETag:      "etag-682",
+	}}, nil
+}
+
+func (f *underReportingFS682) Open(_ context.Context, relPath string) (io.ReadSeekCloser, error) {
+	if relPath != f.relPath {
+		return nil, os.ErrNotExist
+	}
+	return &countingReader682{inner: &generatedFile682{remaining: f.bodyLen}, counter: &f.bytesServed}, nil
+}
+
+func (f *underReportingFS682) Localize(_ context.Context, _ string) (string, func(), error) {
+	return "", func() {}, os.ErrNotExist
+}
+
+// growOnOpenFS682 is a real local corpus with a race built into it: it walks the
+// file at its original size, then appends bytes to it before the pipeline opens it.
+// That is the local growth race, reproduced deterministically at the exact point
+// between the check and the use.
+type growOnOpenFS682 struct {
+	inner       corpusfs.CorpusFS
+	root        string
+	target      string
+	extra       int64
+	grown       atomic.Bool
+	bytesServed atomic.Int64
+}
+
+func (f *growOnOpenFS682) Walk(ctx context.Context, root string, opts corpusfs.Options) ([]corpusfs.DiscoveredFile, error) {
+	return f.inner.Walk(ctx, root, opts)
+}
+
+func (f *growOnOpenFS682) Open(ctx context.Context, relPath string) (io.ReadSeekCloser, error) {
+	if relPath == f.target && f.grown.CompareAndSwap(false, true) {
+		file, err := os.OpenFile(filepath.Join(f.root, filepath.FromSlash(relPath)), os.O_WRONLY|os.O_APPEND, 0o600)
+		if err != nil {
+			return nil, err
+		}
+		if _, err := file.Write([]byte(strings.Repeat("b", int(f.extra)))); err != nil {
+			_ = file.Close()
+			return nil, err
+		}
+		if err := file.Close(); err != nil {
+			return nil, err
+		}
+	}
+	rc, err := f.inner.Open(ctx, relPath)
+	if err != nil {
+		return nil, err
+	}
+	return &countingReader682{inner: rc, counter: &f.bytesServed}, nil
+}
+
+func (f *growOnOpenFS682) Localize(ctx context.Context, relPath string) (string, func(), error) {
+	return f.inner.Localize(ctx, relPath)
+}
+
+// capConfig682 returns a config with the 1 MiB read cap and no providers wired.
+func capConfig682(root, stateDir string) config.Config {
+	cfg := config.Default()
+	cfg.RootDir = root
+	cfg.StateDir = stateDir
+	cfg.STTProvider = "off"
+	cfg.IngestMaxFileMB = readCapMB682
+	return cfg
+}
+
+// assertSizeCapSkip682 fails unless the document is recorded as the SPEC §15.2
+// `size_cap` skip and has nothing left that retrieval can return.
+func assertSizeCapSkip682(t *testing.T, st *store.SQLiteStore, relPath string) {
+	t.Helper()
+	doc, err := st.GetDocumentByPath(context.Background(), relPath)
+	if err != nil {
+		t.Fatalf("GetDocumentByPath(%s): %v", relPath, err)
+	}
+	if doc.Status != "skipped" {
+		t.Errorf("%s status = %q, want skipped", relPath, doc.Status)
+	}
+	if doc.SkipReason != model.SkipReasonSizeCap {
+		t.Errorf("%s skip_reason = %q, want %q", relPath, doc.SkipReason, model.SkipReasonSizeCap)
+	}
+	reps, err := st.ActiveRepresentations(context.Background(), relPath)
+	if err != nil {
+		t.Fatalf("ActiveRepresentations(%s): %v", relPath, err)
+	}
+	if len(reps) != 0 {
+		t.Errorf("%s still has %d live representation(s) %+v; a size_cap row must not serve chunks", relPath, len(reps), reps)
+	}
+}
+
+// liveRepTypes682 lists the rep types still searchable for a path.
+func liveRepTypes682(t *testing.T, st *store.SQLiteStore, relPath string) []string {
+	t.Helper()
+	reps, err := st.ActiveRepresentations(context.Background(), relPath)
+	if err != nil {
+		t.Fatalf("ActiveRepresentations(%s): %v", relPath, err)
+	}
+	types := make([]string, 0, len(reps))
+	for _, rep := range reps {
+		types = append(types, rep.RepType)
+	}
+	sort.Strings(types)
+	return types
+}
+
+// TestSizeCapRead_UnderReportingSourceIsBoundedAndSkipped is the case a re-check
+// cannot catch. The backend reports 512 bytes and serves 4 MiB under a 1 MiB cap,
+// so every size the pipeline could check says the file fits.
+//
+// On `main` the scan reads all 4 MiB and records the document as `ok`.
+func TestSizeCapRead_UnderReportingSourceIsBoundedAndSkipped(t *testing.T) {
+	root := t.TempDir()
+	fs := &underReportingFS682{relPath: "liar.txt", reportedLen: 512, bodyLen: overCapBytes682}
+	st := newRealStore(t)
+
+	svc := mustNewIngestService(t, capConfig682(root, t.TempDir()), st)
+	svc.SetCorpusFS(fs)
+	if err := svc.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if served := fs.bytesServed.Load(); served > readCapBytes682+1 {
+		t.Errorf("the scan pulled %d bytes from a source that reported %d; the bound is %d (cap+1)", served, fs.reportedLen, readCapBytes682+1)
+	}
+	assertSizeCapSkip682(t, st, "liar.txt")
+}
+
+// TestSizeCapRead_LocalGrowthAfterDiscoveryIsBoundedAndSkipped is the local half:
+// the file is 12 bytes when discovery stats it and 4 MiB when the pipeline opens
+// it. This is the time-of-check/time-of-use window itself, closed at the read.
+//
+// On `main` the scan reads the whole grown file and records it as `ok`.
+func TestSizeCapRead_LocalGrowthAfterDiscoveryIsBoundedAndSkipped(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "notes.txt"), "small so far")
+	fs := &growOnOpenFS682{
+		inner:  corpusfs.NewLocalFS(root),
+		root:   root,
+		target: "notes.txt",
+		extra:  overCapBytes682,
+	}
+	st := newRealStore(t)
+
+	svc := mustNewIngestService(t, capConfig682(root, t.TempDir()), st)
+	svc.SetCorpusFS(fs)
+	if err := svc.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if served := fs.bytesServed.Load(); served > readCapBytes682+1 {
+		t.Errorf("the scan pulled %d bytes from a file discovery measured at 12; the bound is %d (cap+1)", served, readCapBytes682+1)
+	}
+	assertSizeCapSkip682(t, st, "notes.txt")
+}
+
+// TestSizeCapRead_CountsAsSkipNotError pins the accounting. An over-cap file is
+// refused by policy, not by failure, so it is one skip and never an error. Mixing
+// the two would break `scanned = indexed + skipped + errors` and would put the
+// file in `recent_failures`, where an operator would look for a bug that is not
+// there.
+//
+// On `main` the file is counted as indexed.
+func TestSizeCapRead_CountsAsSkipNotError(t *testing.T) {
+	root := t.TempDir()
+	fs := &underReportingFS682{relPath: "liar.txt", reportedLen: 512, bodyLen: overCapBytes682}
+	st := newRealStore(t)
+
+	svc := mustNewIngestService(t, capConfig682(root, t.TempDir()), st)
+	svc.SetCorpusFS(fs)
+	state := appstate.NewIndexingState(appstate.ModeIncremental)
+	svc.SetIndexingState(state)
+	if err := svc.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	snap := state.Snapshot()
+	if snap.Scanned != 1 || snap.Indexed != 0 || snap.Skipped != 1 || snap.Errors != 0 {
+		t.Errorf("counters scanned=%d indexed=%d skipped=%d errors=%d, want 1/0/1/0",
+			snap.Scanned, snap.Indexed, snap.Skipped, snap.Errors)
+	}
+}
+
+// TestSizeCapRead_RetiresWhatTheSmallerFileIndexed is the honesty half. The file
+// was indexed while it fitted, then grew past the cap. The row now says
+// "skipped for size_cap", so its old chunks must not still be answering `search`:
+// a document cannot be both not-indexed in the coverage report and searchable.
+//
+// On `main` the second scan reads the grown file and reindexes it, so the
+// representation survives and the row never says size_cap at all.
+func TestSizeCapRead_RetiresWhatTheSmallerFileIndexed(t *testing.T) {
+	root := t.TempDir()
+	stateDir := t.TempDir()
+	writeFile(t, filepath.Join(root, "notes.txt"), "small so far")
+	st := newRealStore(t)
+	cfg := capConfig682(root, stateDir)
+
+	// Scan 1: an ordinary in-cap file, indexed with a raw_text representation.
+	first := mustNewIngestService(t, cfg, st)
+	first.SetCorpusFS(corpusfs.NewLocalFS(root))
+	if err := first.Run(context.Background()); err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+	if got := liveRepTypes682(t, st, "notes.txt"); len(got) == 0 {
+		t.Fatalf("first scan indexed no representation for the in-cap file; the fixture is wrong")
+	}
+
+	// Scan 2: the file grows past the cap between the stat and the read.
+	second := mustNewIngestService(t, cfg, st)
+	second.SetCorpusFS(&growOnOpenFS682{
+		inner:  corpusfs.NewLocalFS(root),
+		root:   root,
+		target: "notes.txt",
+		extra:  overCapBytes682,
+	})
+	if err := second.Run(context.Background()); err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+
+	assertSizeCapSkip682(t, st, "notes.txt")
+}
+
+// TestSizeCapDiscovery_RetiresWhatTheSmallerFileIndexed is the same honesty rule
+// for the file that grew between two scans, so the discovery stat catches it. Both
+// routes to a size_cap row must mean the same thing, or the reason tells an
+// operator nothing about what is still searchable.
+//
+// On `main` the second scan writes the size_cap row and leaves the first scan's
+// representation live.
+func TestSizeCapDiscovery_RetiresWhatTheSmallerFileIndexed(t *testing.T) {
+	root := t.TempDir()
+	stateDir := t.TempDir()
+	path := filepath.Join(root, "notes.txt")
+	writeFile(t, path, "small so far")
+	st := newRealStore(t)
+	cfg := capConfig682(root, stateDir)
+
+	first := mustNewIngestService(t, cfg, st)
+	if err := first.Run(context.Background()); err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+	if got := liveRepTypes682(t, st, "notes.txt"); len(got) == 0 {
+		t.Fatalf("first scan indexed no representation for the in-cap file; the fixture is wrong")
+	}
+
+	// Grow the file on disk, between scans, so discovery itself refuses it.
+	if err := os.WriteFile(path, []byte(strings.Repeat("b", int(overCapBytes682))), 0o600); err != nil {
+		t.Fatalf("grow file: %v", err)
+	}
+
+	second := mustNewIngestService(t, cfg, st)
+	if err := second.Run(context.Background()); err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+
+	assertSizeCapSkip682(t, st, "notes.txt")
+}
+
+// TestSizeCapRead_FileAtTheCapIsStillIndexed is the false-positive guard on the
+// limit+1 read. A file of exactly `ingest.max_file_mb` bytes is inside the cap and
+// must still be indexed: the bound must refuse only what passes it, and an
+// off-by-one here would silently drop every file at the boundary.
+func TestSizeCapRead_FileAtTheCapIsStillIndexed(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "exact.txt"), strings.Repeat("a", int(readCapBytes682)))
+	st := newRealStore(t)
+
+	svc := mustNewIngestService(t, capConfig682(root, t.TempDir()), st)
+	if err := svc.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	doc, err := st.GetDocumentByPath(context.Background(), "exact.txt")
+	if err != nil {
+		t.Fatalf("GetDocumentByPath: %v", err)
+	}
+	if doc.Status != "ok" {
+		t.Errorf("a file of exactly the cap has status = %q (skip_reason %q), want ok", doc.Status, doc.SkipReason)
+	}
+	if doc.SizeBytes != readCapBytes682 {
+		t.Errorf("size_bytes = %d, want %d", doc.SizeBytes, readCapBytes682)
+	}
+	if got := liveRepTypes682(t, st, "exact.txt"); len(got) == 0 {
+		t.Errorf("a file of exactly the cap has no live representation; it must stay searchable")
+	}
+}

--- a/tests/ingest/size_cap_read_bound_682_test.go
+++ b/tests/ingest/size_cap_read_bound_682_test.go
@@ -2,7 +2,9 @@ package tests
 
 import (
 	"context"
+	"errors"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"sort"
@@ -236,8 +238,8 @@ func TestSizeCapRead_UnderReportingSourceIsBoundedAndSkipped(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
-	if served := fs.bytesServed.Load(); served > readCapBytes682+1 {
-		t.Errorf("the scan pulled %d bytes from a source that reported %d; the bound is %d (cap+1)", served, fs.reportedLen, readCapBytes682+1)
+	if served := fs.bytesServed.Load(); served != readCapBytes682+1 {
+		t.Errorf("the scan pulled %d bytes from a source that reported %d; want exactly %d (cap+1): the bound must stop there, and must not stop short either", served, fs.reportedLen, readCapBytes682+1)
 	}
 	assertSizeCapSkip682(t, st, "liar.txt")
 }
@@ -264,8 +266,8 @@ func TestSizeCapRead_LocalGrowthAfterDiscoveryIsBoundedAndSkipped(t *testing.T) 
 		t.Fatalf("Run: %v", err)
 	}
 
-	if served := fs.bytesServed.Load(); served > readCapBytes682+1 {
-		t.Errorf("the scan pulled %d bytes from a file discovery measured at 12; the bound is %d (cap+1)", served, readCapBytes682+1)
+	if served := fs.bytesServed.Load(); served != readCapBytes682+1 {
+		t.Errorf("the scan pulled %d bytes from a file discovery measured at 12; want exactly %d (cap+1): the bound must stop there, and must not stop short either", served, readCapBytes682+1)
 	}
 	assertSizeCapSkip682(t, st, "notes.txt")
 }
@@ -391,8 +393,8 @@ func TestSizeCapRead_OverCapArchiveIsNotExpanded(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
-	if served := fs.bytesServed.Load(); served > readCapBytes682+1 {
-		t.Errorf("the scan pulled %d bytes from the container; the bound is %d (cap+1)", served, readCapBytes682+1)
+	if served := fs.bytesServed.Load(); served != readCapBytes682+1 {
+		t.Errorf("the scan pulled %d bytes from the container; want exactly %d (cap+1): the bound must stop there, and must not stop short either", served, readCapBytes682+1)
 	}
 	doc, err := st.GetDocumentByPath(context.Background(), "bundle.zip")
 	if err != nil {
@@ -478,6 +480,108 @@ func TestSizeCapRead_ManifestCarriesFileTooLarge(t *testing.T) {
 	}
 	if got := recs[0]["error_code"]; got != "FILE_TOO_LARGE" {
 		t.Errorf("manifest error_code = %v, want FILE_TOO_LARGE", got)
+	}
+}
+
+// retireFailingStore682 is a real SQLite store whose representation retirement can
+// be made to fail on demand. It is the only way to reach the branch where the
+// store HAS the retirement capability and refuses to use it, which is different
+// from a store that does not implement it at all.
+type retireFailingStore682 struct {
+	*store.SQLiteStore
+	fail atomic.Bool
+}
+
+func (s *retireFailingStore682) SoftDeleteRepresentations(ctx context.Context, relPath string, repIDs []int64) (int, error) {
+	if s.fail.Load() {
+		return 0, errors.New("store refused the retirement")
+	}
+	return s.SQLiteStore.SoftDeleteRepresentations(ctx, relPath, repIDs)
+}
+
+// TestSizeCapRead_RefusedRetirementLeavesTheDocumentAsItWas pins that the two
+// writes are not allowed to come apart. If the store cannot retire the stale
+// representations, writing the `size_cap` row anyway would create exactly the
+// contradiction this change exists to remove: a row saying "not indexed" beside
+// chunks that still answer `search`.
+//
+// So the row is not written. The document keeps the consistent state it already
+// had, the run reports one error, and the next scan retries: the cap verdict is
+// reproducible, so a retry costs a re-read and nothing more.
+func TestSizeCapRead_RefusedRetirementLeavesTheDocumentAsItWas(t *testing.T) {
+	root := t.TempDir()
+	stateDir := t.TempDir()
+	writeFile(t, filepath.Join(root, "notes.txt"), "small so far")
+	st := &retireFailingStore682{SQLiteStore: newRealStore(t)}
+	cfg := capConfig682(root, stateDir)
+
+	first := mustNewIngestService(t, cfg, st)
+	if err := first.Run(context.Background()); err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+	if got := liveRepTypes682(t, st.SQLiteStore, "notes.txt"); len(got) == 0 {
+		t.Fatalf("first scan indexed no representation; the fixture is wrong")
+	}
+
+	// The read now trips the cap, and the store refuses to retire.
+	st.fail.Store(true)
+	second := mustNewIngestService(t, cfg, st)
+	second.SetCorpusFS(&growOnOpenFS682{
+		inner:  corpusfs.NewLocalFS(root),
+		root:   root,
+		target: "notes.txt",
+		extra:  overCapBytes682,
+	})
+	state := appstate.NewIndexingState(appstate.ModeIncremental)
+	second.SetIndexingState(state)
+	if err := second.Run(context.Background()); err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+
+	doc, err := st.GetDocumentByPath(context.Background(), "notes.txt")
+	if err != nil {
+		t.Fatalf("GetDocumentByPath: %v", err)
+	}
+	if doc.SkipReason == model.SkipReasonSizeCap {
+		t.Errorf("a size_cap row was written although the retirement failed; the row and the live chunks now disagree")
+	}
+	if doc.Status != "ok" {
+		t.Errorf("status = %q, want the previous ok row preserved", doc.Status)
+	}
+	if got := liveRepTypes682(t, st.SQLiteStore, "notes.txt"); len(got) == 0 {
+		t.Errorf("representations were retired after all; the failure path must change nothing")
+	}
+	if got := state.Snapshot().Errors; got != 1 {
+		t.Errorf("errors = %d, want 1: a refused retirement must be visible, not silent", got)
+	}
+}
+
+// TestSizeCapRead_AbsurdCapIsClampedNotOverflowed pins the resolver against an
+// operator typo. `ingest.max_file_mb` is only validated as non-negative, so a
+// pasted digit too many reaches the resolver, and MB-to-bytes would overflow int64
+// into a NEGATIVE cap. That is the worst direction: a negative limit lets through
+// one byte, every file then measures as past the cap, and the whole corpus is
+// skipped as size_cap. Clamping keeps a nonsense value harmless.
+func TestSizeCapRead_AbsurdCapIsClampedNotOverflowed(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "notes.txt"), "ordinary small file")
+	st := newRealStore(t)
+
+	cfg := capConfig682(root, t.TempDir())
+	// Past the largest MB value that converts to bytes without overflowing.
+	cfg.IngestMaxFileMB = math.MaxInt/(1024*1024) + 5
+
+	svc := mustNewIngestService(t, cfg, st)
+	if err := svc.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	doc, err := st.GetDocumentByPath(context.Background(), "notes.txt")
+	if err != nil {
+		t.Fatalf("GetDocumentByPath: %v", err)
+	}
+	if doc.Status != "ok" {
+		t.Errorf("status = %q (skip_reason %q), want ok: an absurd cap must not skip an ordinary file", doc.Status, doc.SkipReason)
 	}
 }
 

--- a/tests/ingest/size_cap_read_bound_682_test.go
+++ b/tests/ingest/size_cap_read_bound_682_test.go
@@ -372,6 +372,82 @@ func TestSizeCapDiscovery_RetiresWhatTheSmallerFileIndexed(t *testing.T) {
 	assertSizeCapSkip682(t, st, "notes.txt")
 }
 
+// TestSizeCapRead_OverCapArchiveIsNotExpanded pins that an over-cap ARCHIVE is
+// refused as a whole. The archive branch runs for a `skipped` container by design,
+// so without an explicit stop the pipeline would localize a container whose own
+// bytes had just been declared over the cap and ingest its members. A file dropped
+// by the discovery stat (#497) never reaches that branch, and this one must not
+// either.
+//
+// On `main` the container reads in full and is recorded with skip_reason="archive".
+func TestSizeCapRead_OverCapArchiveIsNotExpanded(t *testing.T) {
+	root := t.TempDir()
+	fs := &underReportingFS682{relPath: "bundle.zip", reportedLen: 512, bodyLen: overCapBytes682}
+	st := newRealStore(t)
+
+	svc := mustNewIngestService(t, capConfig682(root, t.TempDir()), st)
+	svc.SetCorpusFS(fs)
+	if err := svc.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if served := fs.bytesServed.Load(); served > readCapBytes682+1 {
+		t.Errorf("the scan pulled %d bytes from the container; the bound is %d (cap+1)", served, readCapBytes682+1)
+	}
+	doc, err := st.GetDocumentByPath(context.Background(), "bundle.zip")
+	if err != nil {
+		t.Fatalf("GetDocumentByPath: %v", err)
+	}
+	if doc.SkipReason != model.SkipReasonSizeCap {
+		t.Errorf("container skip_reason = %q, want %q: an over-cap container was refused by the cap, not because it is an archive", doc.SkipReason, model.SkipReasonSizeCap)
+	}
+	docs, _, err := st.ListFiles(context.Background(), "", "", 100, 0)
+	if err != nil {
+		t.Fatalf("ListFiles: %v", err)
+	}
+	for _, d := range docs {
+		if d.RelPath != "bundle.zip" {
+			t.Errorf("member %q was ingested out of an over-cap container", d.RelPath)
+		}
+	}
+}
+
+// TestSizeCapRead_RaisesOneFileSkipEvent pins SPEC §3.2: the number of file_skip
+// events a run emits equals its terminal `indexing.skipped`. An over-cap read
+// counts one skip, so it must raise exactly one event, carrying the §15.2 reason.
+//
+// The container case is included because it takes a different route: an archive's
+// event is normally deferred until extraction finishes, and an over-cap container
+// never extracts.
+func TestSizeCapRead_RaisesOneFileSkipEvent(t *testing.T) {
+	for _, relPath := range []string{"liar.txt", "bundle.zip"} {
+		t.Run(relPath, func(t *testing.T) {
+			root := t.TempDir()
+			fs := &underReportingFS682{relPath: relPath, reportedLen: 512, bodyLen: overCapBytes682}
+			st := newRealStore(t)
+
+			svc := mustNewIngestService(t, capConfig682(root, t.TempDir()), st)
+			svc.SetCorpusFS(fs)
+			var reasons []string
+			svc.SetOnDocumentSkip(func(_, _, reason string) {
+				reasons = append(reasons, reason)
+			})
+			state := appstate.NewIndexingState(appstate.ModeIncremental)
+			svc.SetIndexingState(state)
+			if err := svc.Run(context.Background()); err != nil {
+				t.Fatalf("Run: %v", err)
+			}
+
+			if len(reasons) != 1 || reasons[0] != model.SkipReasonSizeCap {
+				t.Errorf("file_skip reasons = %v, want exactly one %q", reasons, model.SkipReasonSizeCap)
+			}
+			if got := state.Snapshot().Skipped; got != int64(len(reasons)) {
+				t.Errorf("skipped counter = %d but %d file_skip event(s) were raised; SPEC §3.2 requires equality", got, len(reasons))
+			}
+		})
+	}
+}
+
 // TestSizeCapRead_FileAtTheCapIsStillIndexed is the false-positive guard on the
 // limit+1 read. A file of exactly `ingest.max_file_mb` bytes is inside the cap and
 // must still be indexed: the bound must refuse only what passes it, and an

--- a/tests/ingest/size_cap_read_bound_682_test.go
+++ b/tests/ingest/size_cap_read_bound_682_test.go
@@ -448,6 +448,39 @@ func TestSizeCapRead_RaisesOneFileSkipEvent(t *testing.T) {
 	}
 }
 
+// TestSizeCapRead_ManifestCarriesFileTooLarge pins the §14.4 code on the batch
+// manifest record (§8.6.11). A file the discovery stat drops already records
+// FILE_TOO_LARGE, so a file the READ refuses must record it too: a codeless skip
+// leaves the manifest unable to tell this asset from an unchanged cache hit.
+//
+// On `main` the asset is recorded as "completed".
+func TestSizeCapRead_ManifestCarriesFileTooLarge(t *testing.T) {
+	root := t.TempDir()
+	stateDir := t.TempDir()
+	manifestPath := filepath.Join(stateDir, "run.jsonl")
+	fs := &underReportingFS682{relPath: "liar.txt", reportedLen: 512, bodyLen: overCapBytes682}
+	st := newRealStore(t)
+
+	cfg := capConfig682(root, stateDir)
+	cfg.MediaBatchManifest = manifestPath
+	svc := mustNewIngestService(t, cfg, st)
+	svc.SetCorpusFS(fs)
+	if err := svc.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	recs := readManifest(t, manifestPath)
+	if len(recs) != 1 {
+		t.Fatalf("want 1 manifest record, got %d: %+v", len(recs), recs)
+	}
+	if got := recs[0]["status"]; got != "skipped" {
+		t.Errorf("manifest status = %v, want skipped", got)
+	}
+	if got := recs[0]["error_code"]; got != "FILE_TOO_LARGE" {
+		t.Errorf("manifest error_code = %v, want FILE_TOO_LARGE", got)
+	}
+}
+
 // TestSizeCapRead_FileAtTheCapIsStillIndexed is the false-positive guard on the
 // limit+1 read. A file of exactly `ingest.max_file_mb` bytes is inside the cap and
 // must still be indexed: the bound must refuse only what passes it, and an


### PR DESCRIPTION
Closes #682.

## The exposure, plainly

`ingest.max_file_mb` was enforced at discovery and nowhere else.

Discovery measures a file with a stat (local corpus) or with a ListObjectsV2 entry (S3), admits it when that number is under the cap, and hands the pipeline a rel_path. The bytes then arrive from a **later, separate operation**: an `os.Open` + `io.ReadAll`, or a `GetObject` whose body was copied with an unbounded `io.Copy`. Nothing tied the bytes read to the size that had been checked.

Two ordinary things therefore had no bound at all.

1. **A local file that grows after the stat.** A log being appended to, a file still being written by another process, an rsync in flight. Discovery saw 4 KB, the read took whatever was there.
2. **An object whose reported size is not what it serves.** Discovery sizes an object from `ListObjectsV2`, `Open` sizes it from `HeadObject`, and the body comes from a third call. Any of the three can disagree with the others, and one of them (a `HEAD` with no `Content-Length`, seen on some MinIO/R2 gateways, #487) reports no size at all. That path fell back to a whole-object streaming GET with no limit.

**What an operator saw when it happened.** Resident memory climbing through a scan, and on a large enough file the daemon killed by the OOM killer part-way through. Indexing stopped, `dir2mcp status` never reached `pending=0`, and nothing in the log named the file, because the process died inside the read. There was no `size_cap` row, no `file_skip` event, and no error: the file that caused it looked, in every report, exactly like a file that had not been reached yet. On the S3 side the same read filled the local cache disk instead, because `Localize` wrote the whole body to `StateDir/corpus-cache` before anyone looked at how big it was.

The configured cap was, in short, advisory.

## The fix: bound the read, not the check

A check is a measurement. It describes the file at the instant it ran and constrains nothing that happens afterwards. Re-checking the size before the read, or after it, would not have closed this: the second check reads the same reported number the first one did, and on S3 that number is supplied by the thing being bounded. Only a limit applied to the read itself holds.

`Service.readSourceBytes` is that limit. It reads at most **cap+1** bytes. The extra byte is what separates "exactly at the cap" from "past it", and it is the whole cost of telling the two apart. Past the cap it returns `overCap=true` with **nil content**: the prefix is dropped, so no path downstream can mistake part of a file for the whole of it.

Every ingest source read now goes through it:

| read | file |
| --- | --- |
| the document build (`buildDocumentWithContent`) | `internal/ingest/service.go` |
| the two-phase derivation read (`readDocumentContent`) | `internal/ingest/service.go` |
| the subtitle sidecar read (`readSidecar`) | `internal/ingest/sidecar.go` |

### The bound holds when the source lies about its size

This is the case a re-check cannot catch, so it is worth stating exactly why the bound does.

`readSourceBytes` never consults a reported size. It wraps the reader in `io.LimitReader(rc, cap+1)` and compares the number of bytes it actually received. The source may claim 512 bytes and serve 4 MiB; the limit reader stops asking at cap+1 either way, so the byte count the source chose to report never enters the decision. `tests/ingest/size_cap_read_bound_682_test.go` counts the bytes pulled through the reader and asserts that total, so a fix that only re-checked the size would fail that assertion while passing the status one.

The object store is bounded a second time, at its own transport, so the guarantee does not depend on each caller remembering it:

* **`S3FS.Localize`** copies at most cap+1 bytes and, past the cap, closes and **removes the partial temp file** before returning `corpusfs.ErrObjectTooLarge`. Every error path in that function now cleans up.
* **Both readers `S3FS.Open` returns** stop at cap+1. `s3RangeReader` (a reported length) also trims each `Read` to the size `HEAD` did report, so an over-delivering body cannot push the total past either number. `s3StreamReader` (no reported length) is the one that most needs the bound, because there is no size to check at all; it also refuses a forward seek past the cap, since a forward seek is serviced by discarding bytes off the socket.

Over-cap delivery ends with `ErrObjectTooLarge`, **not** with `io.EOF`. A silent short read would look to every caller like a complete file, which is the truncated-document failure #487 already had to fix once.

**Why cap+1 and not cap.** The one extra byte is the only thing that separates a file of exactly `ingest.max_file_mb` (inside the policy, admitted by discovery, must read cleanly to `io.EOF`) from a file one byte past it. For the streaming reader it is the *only* available evidence, because with no reported length "the body ended here" and "the body continues" differ by exactly that byte. My first commit on this branch refused at the cap instead of past it, so an object of exactly the cap failed; the second commit fixes it and adds the off-by-one guard through both reader shapes and through `Localize`. Those guards fail against the first commit, which is why they are there.

The cap comes from one resolver, `ingest.ResolvedMaxFileBytes`, which discovery, the source reads, the S3 backend, and the on-demand MCP tool paths all read. There were three copies of that arithmetic before; a bound enforced at four boundaries must not be able to differ between them. Zero or negative resolves to the 10 MiB default: there is deliberately no unlimited setting.

## SPEC: no dirstral-spec PR needed

I checked before writing code.

SPEC §15.2 closes the `skip_reasons` enum for a spec minor and already defines the reason this condition needs: **`size_cap`**, "exceeded the configured max file size". That is precisely what an over-cap read found. A file caught by the discovery stat (#497) and a file caught by the read were refused by the same policy, so they must read the same in the honest-coverage aggregate, and they now do. No new reason, no new status, no schema change, and the submodule pointer is untouched.

`FILE_TOO_LARGE` (§14.4) already exists for the one tool surface that needed an answer: an over-cap `Localize` on the on-demand MCP paths used to fall through `mapPathError` to `permission denied`, which names the wrong cause.

## The size_cap row is honest, on both routes into it

An over-cap read records `status="skipped"`, `skip_reason="size_cap"`, and:

* **`size_bytes = 0`.** All this path knows is "more than the cap": it stopped at cap+1 by design, and reading to the end just to measure the file would spend the resources the bound exists to save. The size discovery recorded is worse than nothing, because the read has just proved it wrong; a row reading "5 KB, skipped for size_cap" is a contradiction an operator cannot act on. Zero means unknown here, never empty, matching `persistSymlinkSkips` and the archive-member exclusions.
* **no `content_hash` and no `ETag`.** Both are identity claims about bytes this run did not obtain. The blank hash also keeps the incremental gate honest: the next scan re-reads and decides again, so a file that shrinks back under the cap is indexed rather than staying skipped forever, and the remote ETag fast path cannot skip that re-read.
* **no live representations.** A file indexed while it fitted, then grown past the cap, would otherwise be reported as not-indexed in `skip_reasons` while `search` kept answering from its old chunks. The row is retired through the same #692 store surface the #681 withhold uses (SPEC §6.6: the SQLite tombstone is what removes a vector from retrieval), and **before** the row is written, so a crash between the two steps leaves nothing searchable rather than a "skipped" row still serving chunks.

That last point is applied to `persistOversizeSkips` (#497) as well, not only to the new read-time path. Both routes write the same reason, so the reason has to mean the same thing; otherwise it tells an operator nothing about what is still searchable. **Watch mode already behaved this way** (#678/#680: a file that grows past the cap is tombstoned, its chunks leave retrieval, and it is rewritten as a skipped row, which is what README:593 documents). The scan path was the one out of step. README and `docs/` are unchanged and became more accurate, not less.

An over-cap file counts as **one skip and never an error**. It was refused by policy, not by failure, so `scanned = indexed + skipped + errors` still holds, and it raises the one `file_skip` event §3.2 ties to a terminal skip. Putting it in `recent_failures` would send an operator hunting a bug that is not there.

### An over-cap read is terminal, which matters most for an archive

`settleSizeCapSkip` is the single handler: retire, persist, count, report, return. Everything `processDocument` does past that point reasons about content the run did not obtain.

The branch that made this load-bearing is the archive one. An archive container is *supposed* to carry `status="skipped"` and then be expanded, so without a terminal return an over-cap `.zip` would have been localized and its members ingested out of a container whose own bytes had just been refused. A container the discovery stat drops (#497) never reaches that branch; this one now does not either. It is covered by `SizeCapRead_OverCapArchiveIsNotExpanded`.

The same function raises the `file_skip` event unconditionally, rather than leaving it to `creditInitialStatus`, which defers an archive container's event until member extraction finishes. For this document extraction never runs, so the deferred event would never be raised and the run would report one more skip than it emitted events for. `SizeCapRead_RaisesOneFileSkipEvent` pins the equality for a plain file and for a container.

## No secret and no payload is logged

The new log line names the path, the resolved cap, and the size discovery measured, so the growth or the misreport is visible and actionable. It carries no file content and no offset. The `size_cap` row clears `title` (a title lifted from a file whose bytes were not obtained is a claim about them) and never writes `error_message`. `ErrObjectTooLarge` messages carry bucket, key, and the cap only.

## Tests

New:

* `tests/ingest/size_cap_read_bound_682_test.go` (11 cases, a real SQLite store, a stub corpus backend and a real local corpus)
* `tests/corpusfs/s3_localize_bound_682_test.go` (4 cases, a network-free S3 stub, no credentials)
* `tests/corpusfs/s3_cap_wiring_682_test.go` (7 cases pinning the new surface, the off-by-one, and the clamp)

Every test asserts on **two** things, and both matter: the row the scan persisted, which is the coverage answer, and the number of bytes the source was actually asked for, which is the bound. A re-check could produce the first without the second, and the second is the defect.

The bodies are generated, never allocated. On `main` the read is unbounded, so a fixture held in a `[]byte` would have to be materialised in full before the test could prove anything about it.

### Verified against `main`

`git stash` is banned in this repo (`refs/stash` is shared across worktrees), so the files were copied to a uniquely named scratch directory, the tracked changes reverted with `git checkout HEAD -- internal/`, the two new-API files removed, the tests run, and everything restored.

| test | on `main` |
| --- | --- |
| `SizeCapRead_UnderReportingSourceIsBoundedAndSkipped` | **FAIL**: pulled 4,194,304 bytes from a source reporting 512 (bound 1,048,577); `status="ok"`; 1 live `raw_text` |
| `SizeCapRead_LocalGrowthAfterDiscoveryIsBoundedAndSkipped` | **FAIL**: pulled 4,194,316 bytes from a file stat'd at 12; `status="ok"`; 1 live `raw_text` |
| `SizeCapRead_CountsAsSkipNotError` | **FAIL**: counters `scanned=1 indexed=1 skipped=0 errors=0`, want `1/0/1/0` |
| `SizeCapRead_RetiresWhatTheSmallerFileIndexed` | **FAIL**: `status="ok"`, 1 live `raw_text` |
| `SizeCapDiscovery_RetiresWhatTheSmallerFileIndexed` | **FAIL**: `size_cap` row written, 1 live `raw_text` left serving |
| `SizeCapRead_OverCapArchiveIsNotExpanded` | **FAIL**: read the whole 4 MiB container, `skip_reason="archive"` |
| `SizeCapRead_RaisesOneFileSkipEvent` | **FAIL**: no event for the file; `"archive"` for the container |
| `S3FSLocalize_BoundsTheDownloadWhenTheObjectLies` | **FAIL**: downloaded all 12,582,912 bytes and reported success |
| `S3FSOpen_BoundsAWholeObjectReadWhenHeadDisagreesWithDiscovery` | **FAIL**: `io.ReadAll` returned 12,582,912 bytes, no error |
| `S3FSOpen_BoundsAWholeObjectReadWithNoReportedLength` | **FAIL**: same, through the unknown-length streaming path |
| `SizeCapRead_FileAtTheCapIsStillIndexed` | **PASS** (off-by-one guard, as it must) |
| `S3FSOpen_ReadsAnHonestObjectInFull` | **PASS** (false-positive guard, as it must) |

The five cases in `s3_cap_wiring_682_test.go` name `S3Config.MaxBytes` and `corpusfs.ErrObjectTooLarge`, so they cannot compile against `main` and were left out of that run. They pin what a caller depends on: the operator's configured cap is the one enforced (set far below the default, so a pass cannot be explained by the default), the refusal is a sentinel rather than a string, an unset cap resolves to the default rather than to unbounded, and an object of exactly the cap reads and localizes cleanly. The last of those fails against the FIRST commit on this branch, which is the defect it was written for.

## Review round

`coderabbit review --committed --base main` returned 4 findings. All 4 were valid and all 4 are fixed; the re-review returns **0 findings**.

1. **A refused retirement wrote the `size_cap` row anyway** (major). `retireRepresentationsForPath` now returns an error and `settleSizeCapSkip` propagates it, so the row is not written at all: writing it after a failed retirement would create *on purpose* the exact contradiction this PR removes. The document keeps the consistent state it already had, the run reports one error, and the next scan retries. The discovery-time path does the same. The #681 caller keeps its documented best-effort behaviour, and the comment now says why the two differ: a size-cap verdict is reproducible, so a retry costs a re-read, while a derived secret verdict is not.
2. **`resolveMaxBytes` could overflow `maxBytes+1`** (major). `math.MaxInt64` turned the sum negative, `io.LimitReader` reads a negative limit as "no bytes allowed", and `Localize` therefore wrote an **empty file and reported success**. `S3Config` is exported, so the clamp belongs in the backend rather than in the caller.
3. **`ResolvedMaxFileBytes` could overflow** (minor). Config validation only requires `ingest.max_file_mb` to be non-negative, so a pasted digit too many produced a **negative** cap, and every file then measured as past it: the whole corpus would be skipped as `size_cap`.
4. **The byte-count assertions only rejected "too many"** (minor). They now require exactly cap+1, so a bound that stopped SHORT fails too.

Each fix has a test, and each test was verified to fail without it (the `S3FSCapClampsAnAbsurdValue` case localizes 0 bytes and calls it a success on the unclamped code).

## Not in scope

Three whole-object reads outside ingest are still unbounded on a lying source, and each needs a cap plumbed into a package that does not have one. They are follow-up work, not this fix:

* **`internal/index` `readWholeMedia`** (multimodal media chunks). Bounded in practice for S3 now, because the S3 readers are, but a future backend would not be.
* **`internal/retrieval` `hashSourceBytes`**. It streams into a hasher, so memory is constant; only bandwidth is unbounded.
* **`internal/mcp` `readDocumentContent`**'s `os.ReadFile` on a LOCAL corpus. Bounded for a remote corpus now, because `Localize` is.

Also deliberately untouched: `represent.go` still gates raw text against the hard-coded 10 MiB `defaultMaxFileSizeBytes` rather than the configured cap, which is why a 15 MiB text file under the default 20 MiB setting errors instead of indexing. That is a real inconsistency and a behaviour change to fix, so it belongs in its own PR.

## Checklist

- [x] `coderabbit review --committed --base main`: 4 findings, all fixed; re-review clean (0 findings)
- [x] `make check` passes locally, including `gocyclo -over 15`. The size-cap branch pushed `processDocument` to 16; folding both of its touch points into the single `settleSizeCapSkip` handler brought it back to 15 and is the better shape anyway.
- [x] new behaviour has test coverage that fails against `main`
- [x] no file content, offset, or secret is logged or persisted
- [x] `README.md` and `docs/` remain truthful
- [x] no unrelated files changed, submodule pointer untouched
