### PR TITLE
fix(diskindex): roll back a failed single append and make delete all-or-nothing (#674)

### DIFF
--- a/internal/index/diskindex/diskindex.go
+++ b/internal/index/diskindex/diskindex.go
@@ -195,12 +195,14 @@ func (d *DiskIndex) Upsert(ctx context.Context, vector []float32, payload model.
 	if err != nil {
 		return err
 	}
+
+	// d.path is read under the lock, like the batch path: Load assigns it under
+	// d.mu, so an unlocked read here races a concurrent reopen.
+	d.mu.Lock()
+	defer d.mu.Unlock()
 	if d.path == "" {
 		return errors.New("disk index requires a path")
 	}
-
-	d.mu.Lock()
-	defer d.mu.Unlock()
 	return d.appendRecords(recs)
 }
 
@@ -226,9 +228,9 @@ func (d *DiskIndex) BatchUpsert(ctx context.Context, items []model.IndexUpsert) 
 		return nil
 	}
 	// Item validation and payload encoding stay ahead of the lock so a malformed
-	// batch is rejected without touching shared state. Reading d.path must NOT:
-	// Load assigns it under d.mu, so an unlocked read here races a concurrent
-	// reopen.
+	// batch is rejected without touching shared state. Reading d.path must stay
+	// behind the lock: Load assigns it under d.mu, so an unlocked read here
+	// races a concurrent reopen.
 	recs, err := stageUpserts(items)
 	if err != nil {
 		return err

--- a/internal/index/diskindex/diskindex.go
+++ b/internal/index/diskindex/diskindex.go
@@ -297,6 +297,10 @@ func (d *DiskIndex) appendRecords(recs []pendingRecord) error {
 	if err := d.ensureAppendEnd(f); err != nil {
 		return err
 	}
+	// A failure up to here needs no rollback: neither the open, the header write
+	// nor the seek puts a record byte in the file, and d.appendEnd already names
+	// the boundary the next append starts from. The rollback below covers every
+	// step that does write a record.
 	if _, err := f.Seek(d.appendEnd, io.SeekStart); err != nil {
 		return err
 	}
@@ -872,6 +876,13 @@ func (d *DiskIndex) Load(ctx context.Context, path string) error {
 		return err
 	}
 	identity, idErr := readIdentitySidecar(identitySidecarPath(path))
+	if idErr != nil && end == 0 {
+		// The segment file is empty (#674), so it holds no vectors and a damaged
+		// sidecar has nothing to protect. The missing-segment path above reads a
+		// damaged sidecar exactly this way, and an empty file states as much as
+		// no file: nothing.
+		identity, idErr = "", nil
+	}
 	if idErr != nil {
 		// A sidecar that EXISTS and cannot be understood. This used to read as
 		// "" exactly like a missing one, so EnsureIdentity saw a mismatch and

--- a/internal/index/diskindex/diskindex.go
+++ b/internal/index/diskindex/diskindex.go
@@ -183,15 +183,17 @@ func (d *DiskIndex) SetAutosavePolicy(threshold uint64, maxInterval time.Duratio
 
 // Upsert appends the vector+payload as the newest record and points the locator
 // at it. An empty vector or zero chunk_id is an error (matching HNSWIndex).
+//
+// It shares the append path with BatchUpsert, so it shares the crash contract: a
+// write or fsync failure truncates the segment back to its pre-append length and
+// leaves the locators untouched (#674).
 func (d *DiskIndex) Upsert(ctx context.Context, vector []float32, payload model.IndexPayload) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	if len(vector) == 0 {
-		return errors.New("vector cannot be empty")
-	}
-	if payload.ChunkID == 0 {
-		return errors.New("payload chunk_id cannot be zero")
+	recs, err := stageUpserts([]model.IndexUpsert{{Vector: vector, Payload: payload}})
+	if err != nil {
+		return err
 	}
 	if d.path == "" {
 		return errors.New("disk index requires a path")
@@ -199,7 +201,7 @@ func (d *DiskIndex) Upsert(ctx context.Context, vector []float32, payload model.
 
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	return d.appendRecord(payload.ChunkID, false, vector, payload)
+	return d.appendRecords(recs)
 }
 
 // BatchUpsert appends every item to the segment through ONE file open, ONE
@@ -223,32 +225,67 @@ func (d *DiskIndex) BatchUpsert(ctx context.Context, items []model.IndexUpsert) 
 	if len(items) == 0 {
 		return nil
 	}
-	// Validate the whole batch before touching the file so a malformed item
-	// cannot leave a partially written segment behind (Upsert rejects the same
-	// two cases).
-	for i := range items {
-		if len(items[i].Vector) == 0 {
-			return errors.New("vector cannot be empty")
-		}
-		if items[i].Payload.ChunkID == 0 {
-			return errors.New("payload chunk_id cannot be zero")
-		}
+	// Item validation and payload encoding stay ahead of the lock so a malformed
+	// batch is rejected without touching shared state. Reading d.path must NOT:
+	// Load assigns it under d.mu, so an unlocked read here races a concurrent
+	// reopen.
+	recs, err := stageUpserts(items)
+	if err != nil {
+		return err
 	}
-	// Item validation stays ahead of the lock so a malformed batch is rejected
-	// without touching shared state. Reading d.path must NOT: Load assigns it
-	// under d.mu, so an unlocked read here races a concurrent reopen.
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	if d.path == "" {
 		return errors.New("disk index requires a path")
 	}
-	return d.appendBatch(items)
+	return d.appendRecords(recs)
 }
 
-// appendBatch writes every item as a record, fsyncs once, and then publishes the
-// new locators. On any failure it rolls the segment back to its pre-batch length
-// and leaves the in-memory state untouched. Caller holds the write lock.
-func (d *DiskIndex) appendBatch(items []model.IndexUpsert) error {
+// pendingRecord is one record staged for the append log: an upsert (tombstone
+// false, carrying the vector and the encoded payload) or a delete (tombstone
+// true). Every mutation is staged in full before the segment file is opened, so
+// a validation or encoding failure can never leave bytes behind.
+type pendingRecord struct {
+	chunkID      uint64
+	tombstone    bool
+	vector       []float32
+	payloadBytes []byte
+}
+
+// stageUpserts validates and encodes every item. It rejects the same two cases
+// as Upsert, and it does so for the whole batch before any record is written.
+func stageUpserts(items []model.IndexUpsert) ([]pendingRecord, error) {
+	recs := make([]pendingRecord, len(items))
+	for i := range items {
+		if len(items[i].Vector) == 0 {
+			return nil, errors.New("vector cannot be empty")
+		}
+		if items[i].Payload.ChunkID == 0 {
+			return nil, errors.New("payload chunk_id cannot be zero")
+		}
+		payloadBytes, err := encodePayload(items[i].Payload)
+		if err != nil {
+			return nil, err
+		}
+		recs[i] = pendingRecord{
+			chunkID:      items[i].Payload.ChunkID,
+			vector:       items[i].Vector,
+			payloadBytes: payloadBytes,
+		}
+	}
+	return recs, nil
+}
+
+// appendRecords writes every staged record through ONE file open, ONE buffered
+// write pass and ONE fsync, and then publishes the result in memory.
+//
+// Every mutation (Upsert, BatchUpsert, Delete) goes through here, so every
+// mutation has the same crash contract: on a write or fsync failure the segment
+// is truncated back to its pre-append length, and neither the locators nor the
+// append pointer move. The single-record path used to return on failure without
+// the truncation, which left abandoned bytes past d.appendEnd for a later append
+// to overwrite in part (#674). Caller holds the write lock.
+func (d *DiskIndex) appendRecords(recs []pendingRecord) error {
 	f, err := statefs.OpenFile(d.path, os.O_RDWR|os.O_CREATE)
 	if err != nil {
 		return err
@@ -263,65 +300,72 @@ func (d *DiskIndex) appendBatch(items []model.IndexUpsert) error {
 	}
 
 	start := d.appendEnd
-	locs, end, werr := writeBatch(f, start, items)
+	offsets, end, werr := writeRecords(f, start, recs)
 	if werr == nil {
-		// The single durability barrier for the whole batch.
+		// The single durability barrier for the whole mutation.
 		werr = syncFile(f)
 	}
 	if werr != nil {
-		return d.rollbackBatch(f, start, werr)
+		return d.rollbackAppend(f, start, werr)
 	}
 
 	// Published only now that the bytes are durable. Applying in slice order
-	// makes a repeated chunk ID within one batch resolve last-writer-wins,
-	// exactly as a sequence of Upserts would.
-	for i := range items {
-		d.locators[items[i].Payload.ChunkID] = locs[i]
-	}
+	// makes a repeated chunk ID resolve last-writer-wins, exactly as a sequence
+	// of single mutations would.
+	d.applyRecords(recs, offsets)
 	d.appendEnd = end
-	// One mutation per item keeps the autosave delta accounting identical to the
-	// per-record path.
-	d.version += uint64(len(items))
+	// One mutation per record keeps the autosave delta accounting identical to
+	// the old per-record path.
+	d.version += uint64(len(recs))
 	// The mmap view is now stale (file grew); drop it so the next read re-maps.
 	return d.invalidateReaderLocked()
 }
 
-// writeBatch encodes every item into w through a single buffered writer, with
-// the first record landing at offset start. It returns one locator per item
-// (parallel to items) and the new end offset. It does not fsync: appendBatch
-// owns the batch's single durability barrier.
-func writeBatch(w io.Writer, start int64, items []model.IndexUpsert) ([]locator, int64, error) {
+// applyRecords points the locator map at the records just made durable: an
+// upsert publishes its locator, a tombstone drops the entry. offsets is parallel
+// to recs. Caller holds the write lock.
+func (d *DiskIndex) applyRecords(recs []pendingRecord, offsets []int64) {
+	for i := range recs {
+		if recs[i].tombstone {
+			delete(d.locators, recs[i].chunkID)
+			continue
+		}
+		d.locators[recs[i].chunkID] = locator{
+			offset:     offsets[i],
+			vecLen:     uint32(len(recs[i].vector)),
+			payloadLen: uint32(len(recs[i].payloadBytes)),
+		}
+	}
+}
+
+// writeRecords writes every staged record into w through a single buffered
+// writer, with the first record landing at offset start. It returns one offset
+// per record (parallel to recs) and the new end offset. It does not fsync:
+// appendRecords owns the mutation's single durability barrier.
+func writeRecords(w io.Writer, start int64, recs []pendingRecord) ([]int64, int64, error) {
 	bw := bufio.NewWriter(w)
-	locs := make([]locator, len(items))
+	offsets := make([]int64, len(recs))
 	offset := start
-	for i := range items {
-		payloadBytes, err := encodePayload(items[i].Payload)
+	for i := range recs {
+		n, err := writeRecord(bw, recs[i].chunkID, recs[i].tombstone, recs[i].vector, recs[i].payloadBytes)
 		if err != nil {
 			return nil, 0, err
 		}
-		n, err := writeRecord(bw, items[i].Payload.ChunkID, false, items[i].Vector, payloadBytes)
-		if err != nil {
-			return nil, 0, err
-		}
-		locs[i] = locator{
-			offset:     offset,
-			vecLen:     uint32(len(items[i].Vector)),
-			payloadLen: uint32(len(payloadBytes)),
-		}
+		offsets[i] = offset
 		offset += int64(n)
 	}
 	if err := bw.Flush(); err != nil {
 		return nil, 0, err
 	}
-	return locs, offset, nil
+	return offsets, offset, nil
 }
 
-// rollbackBatch truncates the segment back to its pre-batch length after a
-// failed batch and returns cause (joined with any rollback failure). d.locators
-// and d.appendEnd are never advanced before the fsync succeeds, so after the
-// truncation the in-memory state already matches the file again; only the mmap
-// view has to be dropped. Caller holds the write lock.
-func (d *DiskIndex) rollbackBatch(f *os.File, start int64, cause error) error {
+// rollbackAppend truncates the segment back to its pre-append length after a
+// failed mutation and returns cause (joined with any rollback failure).
+// d.locators and d.appendEnd are never advanced before the fsync succeeds, so
+// after the truncation the in-memory state already matches the file again; only
+// the mmap view has to be dropped. Caller holds the write lock.
+func (d *DiskIndex) rollbackAppend(f *os.File, start int64, cause error) error {
 	if terr := f.Truncate(start); terr != nil {
 		return errors.Join(cause, fmt.Errorf("diskindex: rollback truncate to %d: %w", start, terr))
 	}
@@ -337,6 +381,11 @@ func (d *DiskIndex) rollbackBatch(f *os.File, start int64, cause error) error {
 // Delete writes a tombstone record for each id and drops the locator. Unknown
 // ids are ignored. Tombstones keep the on-disk log append-only and consistent;
 // space is reclaimed on the next Save (compaction).
+//
+// A multi-id delete is ALL or NOTHING. Every tombstone goes into one write pass
+// behind one durability barrier, so a failure removes no id at all. The old
+// per-id loop made each id durable on its own, so an error on the third id left
+// the first two deleted and reported failure for the whole call (#674).
 func (d *DiskIndex) Delete(ctx context.Context, chunkIDs []uint64) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -346,61 +395,42 @@ func (d *DiskIndex) Delete(ctx context.Context, chunkIDs []uint64) error {
 	}
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	for _, id := range chunkIDs {
-		if _, ok := d.locators[id]; !ok {
-			continue
-		}
-		if err := d.appendRecord(id, true, nil, model.IndexPayload{}); err != nil {
-			return err
-		}
-		delete(d.locators, id)
+
+	recs, err := d.stageTombstones(chunkIDs)
+	if err != nil {
+		return err
 	}
-	return nil
+	if len(recs) == 0 {
+		return nil
+	}
+	return d.appendRecords(recs)
 }
 
-// appendRecord appends one record to the segment, creating/initialising the
-// file (with header) on first write, and updates the locator map. The caller
-// must hold the write lock.
-func (d *DiskIndex) appendRecord(chunkID uint64, tombstone bool, vector []float32, payload model.IndexPayload) error {
-	f, err := statefs.OpenFile(d.path, os.O_RDWR|os.O_CREATE)
+// stageTombstones builds one tombstone record per id that the index actually
+// holds. Unknown ids are skipped, and a repeated id is staged once: the old loop
+// wrote a single tombstone for a repeat too, because the second pass found the
+// locator already dropped. A tombstone carries the encoded zero payload, exactly
+// as the per-record path always wrote it, so the segment bytes are unchanged.
+// Caller holds the write lock.
+func (d *DiskIndex) stageTombstones(chunkIDs []uint64) ([]pendingRecord, error) {
+	// Every tombstone carries the same encoded zero payload, so encode it once.
+	payloadBytes, err := encodePayload(model.IndexPayload{})
 	if err != nil {
-		return err
+		return nil, err
 	}
-	defer func() { _ = f.Close() }()
-
-	if err := d.ensureAppendEnd(f); err != nil {
-		return err
-	}
-	if _, err := f.Seek(d.appendEnd, io.SeekStart); err != nil {
-		return err
-	}
-	payloadBytes, err := encodePayload(payload)
-	if err != nil {
-		return err
-	}
-	recOffset := d.appendEnd
-	n, err := writeRecord(f, chunkID, tombstone, vector, payloadBytes)
-	if err != nil {
-		return err
-	}
-	if err := syncFile(f); err != nil {
-		return err
-	}
-	d.appendEnd += int64(n)
-
-	if !tombstone {
-		d.locators[chunkID] = locator{
-			offset:     recOffset,
-			vecLen:     uint32(len(vector)),
-			payloadLen: uint32(len(payloadBytes)),
+	recs := make([]pendingRecord, 0, len(chunkIDs))
+	staged := make(map[uint64]struct{}, len(chunkIDs))
+	for _, id := range chunkIDs {
+		if _, known := d.locators[id]; !known {
+			continue
 		}
+		if _, dup := staged[id]; dup {
+			continue
+		}
+		staged[id] = struct{}{}
+		recs = append(recs, pendingRecord{chunkID: id, tombstone: true, payloadBytes: payloadBytes})
 	}
-	// A record landed durably: mark the index dirty so the next Save compacts it.
-	// Delete only calls this for ids it knows exist, so tombstones bump version
-	// only on a real removal — matching HNSWIndex's changed-only Delete accounting.
-	d.version++
-	// The mmap view is now stale (file grew); drop it so the next read re-maps.
-	return d.invalidateReaderLocked()
+	return recs, nil
 }
 
 // ensureAppendEnd initialises d.appendEnd from the open file, writing the header
@@ -887,7 +917,7 @@ func (d *DiskIndex) ensureReader() error {
 
 // readerLocked returns the mmap reader, opening it lazily. Returns (nil, nil)
 // when no segment file exists yet (fresh index). The cached view is invalidated
-// on every mutation (appendRecord/Reset/Save), so a held view always reflects
+// on every mutation (appendRecords/Reset/Save), so a held view always reflects
 // the on-disk bytes the current locator offsets point at. Callers must hold the
 // write lock (it may assign d.reader).
 func (d *DiskIndex) readerLocked() (*mmap.ReaderAt, error) {
@@ -1010,6 +1040,19 @@ func scanSegment(path string) (map[uint64]locator, int64, bool, error) {
 	}
 	defer func() { _ = f.Close() }()
 
+	empty, err := isEmptyFile(f)
+	if err != nil {
+		return nil, 0, false, err
+	}
+	if empty {
+		// An empty segment holds no header and no records, so it is a fresh
+		// index, not damage. The append path creates the file before it writes
+		// the header, so a failure or a crash in that window leaves exactly this
+		// file. Reporting an error here refused to start over a file that says
+		// nothing (#674); returning end 0 makes the next append write the header.
+		return make(map[uint64]locator), 0, false, nil
+	}
+
 	r := bufio.NewReader(f)
 	if err := verifyHeader(r); err != nil {
 		return nil, 0, false, err
@@ -1060,6 +1103,15 @@ func scanSegment(path string) (map[uint64]locator, int64, bool, error) {
 		}
 		offset += int64(recordHdrLen) + bodyLen
 	}
+}
+
+// isEmptyFile reports whether f holds no bytes at all.
+func isEmptyFile(f *os.File) (bool, error) {
+	info, err := f.Stat()
+	if err != nil {
+		return false, err
+	}
+	return info.Size() == 0, nil
 }
 
 // verifyHeader reads and validates the segment magic + version.

--- a/tests/index/diskindex_append_rollback_674_test.go
+++ b/tests/index/diskindex_append_rollback_674_test.go
@@ -1,0 +1,235 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/index/diskindex"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// Issue #674: the batch path rolled a failed append back, the single-record path
+// did not. A write or fsync failure left the abandoned bytes in the segment while
+// the in-memory append pointer stayed at the old offset, so the next append
+// overwrote only part of them and left residue in the middle of the log. The
+// tests below drive the failures through the existing fsync seam
+// (diskindex.SetSyncHookForTest), so they are deterministic and never depend on
+// timing. They share the package state that seam holds, so none of them may run
+// in parallel.
+
+// seedPayload674 / seedVector674 build one small, fixed record. Two indexes fed
+// the same ids therefore hold byte-identical segments.
+func seedPayload674(id uint64) model.IndexPayload {
+	return model.IndexPayload{ChunkID: id, RelPath: "seed.txt", DocType: "md"}
+}
+
+func seedVector674(id uint64) []float32 {
+	return []float32{float32(id), 1, 0, 0}
+}
+
+// readSegment674 returns the raw segment bytes.
+func readSegment674(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read segment %s: %v", path, err)
+	}
+	return data
+}
+
+// loadSegment674 opens path in a fresh index, exactly as a restart does.
+func loadSegment674(t *testing.T, path string) *diskindex.DiskIndex {
+	t.Helper()
+	idx := diskindex.New(path)
+	t.Cleanup(func() { _ = idx.Close() })
+	if err := idx.Load(context.Background(), path); err != nil {
+		t.Fatalf("Load %s: %v", path, err)
+	}
+	return idx
+}
+
+// tombstoneSize674 measures one tombstone record on a scratch index built like
+// the index under test, so the fault below can be keyed on bytes written.
+func tombstoneSize674(t *testing.T) int64 {
+	t.Helper()
+	scratch, path := newTestIndex(t)
+	mustUpsertDisk(t, scratch, seedPayload674(1), seedVector674(1))
+	before := mustFileSize(t, path)
+	if err := scratch.Delete(context.Background(), []uint64{1}); err != nil {
+		t.Fatalf("scratch Delete: %v", err)
+	}
+	return mustFileSize(t, path) - before
+}
+
+// TestUpsert_FailedFsyncLeavesNoBytesInTheLog pins the core of #674 for the
+// single-record path: a failed durability barrier must leave the segment at its
+// pre-append length, and the append that follows must produce a log that is
+// byte-identical to one that never saw the failure.
+//
+// The abandoned record is much larger than the record that follows it, which is
+// the case that leaves residue: the shorter record overwrites only the head of
+// the abandoned bytes, and the tail stays in the middle of the log.
+func TestUpsert_FailedFsyncLeavesNoBytesInTheLog(t *testing.T) {
+	ctx := context.Background()
+	idx, segPath := newTestIndex(t)
+	mustUpsertDisk(t, idx, seedPayload674(1), seedVector674(1))
+	sizeBefore := mustFileSize(t, segPath)
+	liveBefore := liveRecords(t, idx, 4)
+
+	big := model.IndexPayload{ChunkID: 2, RelPath: strings.Repeat("p", 4096), DocType: "md"}
+	boom := errors.New("simulated fsync failure")
+	restore := diskindex.SetSyncHookForTest(func(*os.File) error { return boom })
+	err := idx.Upsert(ctx, seedVector674(2), big)
+	restore()
+	if !errors.Is(err, boom) {
+		t.Fatalf("Upsert error = %v, want it to surface %v", err, boom)
+	}
+
+	if got := mustFileSize(t, segPath); got != sizeBefore {
+		t.Fatalf("segment is %d bytes after a failed upsert, want the pre-append %d: the abandoned record must be truncated away", got, sizeBefore)
+	}
+	if got := liveRecords(t, idx, 4); got != liveBefore {
+		t.Fatalf("live set changed on a failed upsert: %d -> %d", liveBefore, got)
+	}
+
+	// The next append must land on a clean log.
+	mustUpsertDisk(t, idx, seedPayload674(3), seedVector674(3))
+
+	clean, cleanPath := newTestIndex(t)
+	mustUpsertDisk(t, clean, seedPayload674(1), seedVector674(1))
+	mustUpsertDisk(t, clean, seedPayload674(3), seedVector674(3))
+	got, want := readSegment674(t, segPath), readSegment674(t, cleanPath)
+	if !bytes.Equal(got, want) {
+		t.Fatalf("segment after a failed upsert is %d bytes, want the %d bytes of a log that never saw the failure: residual bytes remain",
+			len(got), len(want))
+	}
+
+	reopened := loadSegment674(t, segPath)
+	if n := liveRecords(t, reopened, 4); n != 2 {
+		t.Fatalf("reloaded live set = %d, want 2 (chunks 1 and 3)", n)
+	}
+}
+
+// TestUpsert_FailedFirstAppendLeavesNothingToLoad covers the same failure on a
+// fresh index, where the append also creates the file and writes the header. The
+// header may stay (an empty log is valid), but the record must not: an upsert
+// that reported failure must not appear after a restart.
+func TestUpsert_FailedFirstAppendLeavesNothingToLoad(t *testing.T) {
+	ctx := context.Background()
+	idx, segPath := newTestIndex(t)
+
+	boom := errors.New("simulated fsync failure")
+	restore := diskindex.SetSyncHookForTest(func(*os.File) error { return boom })
+	err := idx.Upsert(ctx, seedVector674(1), seedPayload674(1))
+	restore()
+	if !errors.Is(err, boom) {
+		t.Fatalf("Upsert error = %v, want it to surface %v", err, boom)
+	}
+
+	reopened := loadSegment674(t, segPath)
+	if n := liveRecords(t, reopened, 4); n != 0 {
+		t.Fatalf("reloaded live set = %d, want 0: an upsert that reported failure must not survive a restart", n)
+	}
+
+	// The rolled-back segment must still accept records.
+	mustUpsertDisk(t, idx, seedPayload674(1), seedVector674(1))
+	again := loadSegment674(t, segPath)
+	if n := liveRecords(t, again, 4); n != 1 {
+		t.Fatalf("live set after the retry = %d, want 1", n)
+	}
+}
+
+// TestDelete_AppliesEveryTombstoneOrNone pins the multi-id delete contract: all
+// ids or none. The old loop made each tombstone durable on its own, so a failure
+// on a later id left the earlier ids deleted and still reported failure for the
+// whole call.
+//
+// The fault is keyed on the bytes already in the file, not on a call count or a
+// timer, so it hits the same point whether the tombstones are synced one by one
+// or once for the whole call.
+func TestDelete_AppliesEveryTombstoneOrNone(t *testing.T) {
+	ctx := context.Background()
+	idx, segPath := newTestIndex(t)
+	ids := []uint64{1, 2, 3}
+	for _, id := range ids {
+		mustUpsertDisk(t, idx, seedPayload674(id), seedVector674(id))
+	}
+	base := mustFileSize(t, segPath)
+	tombstone := tombstoneSize674(t)
+
+	boom := errors.New("simulated fsync failure")
+	limit := base + tombstone
+	restore := diskindex.SetSyncHookForTest(func(f *os.File) error {
+		info, statErr := f.Stat()
+		if statErr != nil {
+			return statErr
+		}
+		if info.Size() > limit {
+			return boom
+		}
+		return f.Sync()
+	})
+	err := idx.Delete(ctx, ids)
+	restore()
+	if !errors.Is(err, boom) {
+		t.Fatalf("Delete error = %v, want it to surface %v", err, boom)
+	}
+
+	if n := liveRecords(t, idx, 4); n != len(ids) {
+		t.Fatalf("live set = %d after a failed delete, want all %d: a multi-id delete must not half-apply", n, len(ids))
+	}
+	if got := mustFileSize(t, segPath); got != base {
+		t.Fatalf("segment is %d bytes after a failed delete, want the pre-delete %d: the tombstones must be truncated away", got, base)
+	}
+
+	reopened := loadSegment674(t, segPath)
+	if n := liveRecords(t, reopened, 4); n != len(ids) {
+		t.Fatalf("reloaded live set = %d, want all %d: no tombstone of a failed delete may survive a restart", n, len(ids))
+	}
+
+	// Once the fault clears, the same delete must remove every id.
+	if err := idx.Delete(ctx, ids); err != nil {
+		t.Fatalf("retry Delete after rollback: %v", err)
+	}
+	if n := liveRecords(t, idx, 4); n != 0 {
+		t.Fatalf("live set = %d after the retry, want 0", n)
+	}
+	retried := loadSegment674(t, segPath)
+	if n := liveRecords(t, retried, 4); n != 0 {
+		t.Fatalf("reloaded live set = %d after the retry, want 0", n)
+	}
+}
+
+// TestLoad_TreatsAnEmptySegmentFileAsFresh covers the other half of a failed
+// first append: the append path creates the segment file before it writes the
+// header, so a failure or a crash in that window leaves a file with no bytes.
+// Such a file states nothing, so startup must read it as a fresh index instead
+// of refusing to open the corpus.
+func TestLoad_TreatsAnEmptySegmentFileAsFresh(t *testing.T) {
+	ctx := context.Background()
+	segPath := filepath.Join(t.TempDir(), diskindex.SegmentFileName("text"))
+	if err := os.WriteFile(segPath, nil, 0o600); err != nil {
+		t.Fatalf("create empty segment: %v", err)
+	}
+
+	idx := diskindex.New(segPath)
+	t.Cleanup(func() { _ = idx.Close() })
+	if err := idx.Load(ctx, segPath); err != nil {
+		t.Fatalf("Load of an empty segment must succeed, got: %v", err)
+	}
+	if n := liveRecords(t, idx, 4); n != 0 {
+		t.Fatalf("live set = %d on an empty segment, want 0", n)
+	}
+
+	// The header is written by the next append, so the index stays usable.
+	mustUpsertDisk(t, idx, seedPayload674(1), seedVector674(1))
+	reopened := loadSegment674(t, segPath)
+	if n := liveRecords(t, reopened, 4); n != 1 {
+		t.Fatalf("reloaded live set = %d, want 1", n)
+	}
+}

--- a/tests/index/diskindex_append_rollback_674_test.go
+++ b/tests/index/diskindex_append_rollback_674_test.go
@@ -233,3 +233,33 @@ func TestLoad_TreatsAnEmptySegmentFileAsFresh(t *testing.T) {
 		t.Fatalf("reloaded live set = %d, want 1", n)
 	}
 }
+
+// TestLoad_EmptySegmentIgnoresADamagedIdentitySidecar pairs the empty segment
+// with a sidecar that cannot be read. A damaged sidecar over a POPULATED segment
+// stays a hard error, because it decides the fate of vectors the index still
+// holds (#728). An empty segment holds none, so there is nothing to protect and
+// nothing to report: the missing-segment path already reads a damaged sidecar
+// this way.
+func TestLoad_EmptySegmentIgnoresADamagedIdentitySidecar(t *testing.T) {
+	ctx := context.Background()
+	segPath := filepath.Join(t.TempDir(), diskindex.SegmentFileName("text"))
+	if err := os.WriteFile(segPath, nil, 0o600); err != nil {
+		t.Fatalf("create empty segment: %v", err)
+	}
+	if err := os.WriteFile(segPath+diskindex.IdentitySidecarSuffix, []byte("{not json"), 0o600); err != nil {
+		t.Fatalf("create damaged sidecar: %v", err)
+	}
+
+	idx := diskindex.New(segPath)
+	t.Cleanup(func() { _ = idx.Close() })
+	if err := idx.Load(ctx, segPath); err != nil {
+		t.Fatalf("Load of an empty segment with a damaged sidecar must succeed, got: %v", err)
+	}
+	identity, err := idx.Identity(ctx)
+	if err != nil {
+		t.Fatalf("Identity: %v", err)
+	}
+	if identity != "" {
+		t.Fatalf("identity = %q, want empty: a damaged sidecar over an empty segment states nothing", identity)
+	}
+}


### PR DESCRIPTION
## What the operator sees today

The disk index keeps its vectors in an append log. `BatchUpsert` truncates that
log back after a failed write or fsync. The single-record path used by `Upsert`
and `Delete` did not. It returned the error and left the abandoned record in the
file, while the in-memory append pointer `d.appendEnd` stayed at the old offset.

The next append seeks to that old offset. If the new record is shorter than the
abandoned one, it overwrites only the head of those bytes. The tail stays in the
middle of the log.

On the next start, `scanSegment` reads the log from the front. It reaches the
residue and does one of two things:

- It reads the residue as a torn tail and stops. Every record after that point is
  dropped, and `Load` truncates the file there.
- The residue parses as a record header. Then the index adopts an entry that no
  caller ever wrote: a live locator for an arbitrary chunk id, or a tombstone
  that deletes a chunk that is still valid.

The corpus does not always recover on its own. Dropped vectors are re-embedded,
because the embed worker only marks a chunk embedded after the barrier returns,
so that half is self-correcting (at the cost of the work). An adopted garbage
entry is not: it survives every later load, it is copied forward by the next
`Save` compaction, and only `reindex` clears it.

There is a second symptom with no recovery at all. A first append that fails
leaves an empty segment file behind, because the append path creates the file
before it writes the header. `Load` read that file as damage and returned
`read segment header: EOF`, so the daemon refused to open the corpus until an
operator deleted the file by hand.

## The crash windows

The append is one open, one write pass, one fsync, then the in-memory publish.
Take each step and ask what a crash between it and the next one leaves.

| Window | On disk | In memory | Verdict |
| --- | --- | --- | --- |
| after the file is created, before the header is durable | empty segment | nothing | Load now reads an empty file as a fresh index; the next append writes the header. Self-correcting. |
| after the header, before the record bytes | header only | pointer at `headerLen` | A valid empty log. Correct. |
| after the record bytes, before the fsync | a prefix, all of, or none of the record | pointer unmoved | The record is past the last complete one, so the scan stops there and `Load` truncates it away. The chunks are still pending and get re-embedded. Correct. |
| after the fsync, before the publish | the whole record, durable | pointer unmoved | The record is complete, so a reload adopts it. Its chunk is re-embedded and upserted again, and the log folds last-writer-wins over the same id. Redundant, never wrong. |
| after the publish | the whole record | pointer and locator advanced | The committed state. Correct. |

The failure path had the same shape as a crash, but it kept running. That is what
made it different: the process went on appending from a pointer that no longer
matched the file. The fix removes that case. A failure now truncates the segment
back to the pre-append offset and syncs, so the file and the pointer agree again,
exactly as they do after any of the crash windows above.

No new on-disk state was needed, and none was added. There is no marker file and
no new field. The order of the existing steps already decides every outcome:
the bytes go down first, the barrier decides, and memory is published last. The
only thing missing was the undo on the failing side, and PR #819 (#796) is the
same discipline: close the window by ordering, not by adding state.

## What changed

Every mutation now goes through one function, `appendRecords`:

- `Upsert` and `BatchUpsert` stage their records (validate, encode the payload),
  then write and sync.
- `Delete` stages one tombstone per id it actually holds, then writes and syncs.
- On any write or fsync failure, `rollbackAppend` (the old `rollbackBatch`)
  truncates to the pre-append offset, syncs, and drops the mmap view.

`Delete` is therefore all or nothing. The old loop made each tombstone durable on
its own, so an error on the third id left the first two deleted and still
reported failure for the whole call. The caller had no way to know which half
applied.

The existing fsync pattern is reused, not duplicated: write, `syncFile`, and
`syncDir` for a newly created file inside `ensureAppendEnd`. There is still one
barrier per mutation, so `BatchUpsert` keeps its one fsync per batch (#429 F8)
and `Upsert` keeps its one fsync per record.

`Load` now reads an empty segment file as a fresh index. It also reads a damaged
identity sidecar beside such a file as absent, for the same reason the
missing-segment path does: an empty segment holds no vectors, so the sidecar
decides nothing. Over a populated segment a damaged sidecar stays a hard error
(#728).

## Behavior that did NOT change

- The on-disk format is byte for byte the same. Same magic, same version, same
  record layout. A tombstone still carries the encoded zero payload, exactly as
  the per-record path always wrote it.
- The fsync count per `Upsert` and per `BatchUpsert` is unchanged. `Delete` of N
  ids now costs one fsync instead of N.
- The `version` counter advances by one per written record, as before, so the
  autosave throttle is unaffected.
- A repeated id inside one `Delete` still writes one tombstone. The old loop did
  the same, because its second pass found the locator already dropped.

## Tests

`tests/index/diskindex_append_rollback_674_test.go`, five cases. All drive the
failure through the existing fsync seam (`diskindex.SetSyncHookForTest`), so they
are deterministic and never wait on timing.

- `TestUpsert_FailedFsyncLeavesNoBytesInTheLog`: the failed record is much larger
  than the record that follows it, which is the case that leaves residue. The
  segment must return to its pre-append length, and the log after the next append
  must be byte-identical to a log that never saw the failure.
- `TestUpsert_FailedFirstAppendLeavesNothingToLoad`: an upsert that reported
  failure must not appear after a restart.
- `TestDelete_AppliesEveryTombstoneOrNone`: the fault is keyed on the bytes
  already in the file, not on a call count or a timer, so it hits the same point
  whether the tombstones are synced one by one or once for the whole call. No id
  may be removed, in memory or after a reload.
- `TestLoad_TreatsAnEmptySegmentFileAsFresh`: startup must not refuse a corpus
  over a segment file that says nothing.
- `TestLoad_EmptySegmentIgnoresADamagedIdentitySidecar`: the same file beside a
  sidecar that cannot be read. This case is new with the empty-file handling, so
  it is stated here rather than left to be found later.

Proven against `main` by the copy-aside method (no `git stash`): a worktree at
`origin/main` with only the new test file added.

```
--- FAIL: TestUpsert_FailedFsyncLeavesNoBytesInTheLog
    segment is 5428 bytes after a failed upsert, want the pre-append 674:
    the abandoned record must be truncated away
--- FAIL: TestUpsert_FailedFirstAppendLeavesNothingToLoad
    reloaded live set = 1, want 0: an upsert that reported failure must not
    survive a restart
--- FAIL: TestDelete_AppliesEveryTombstoneOrNone
    live set = 2 after a failed delete, want all 3: a multi-id delete must not
    half-apply
--- FAIL: TestLoad_TreatsAnEmptySegmentFileAsFresh
    Load of an empty segment must succeed, got: read segment header: EOF
```

All four pass on this branch, and so does the fifth
(`TestLoad_EmptySegmentIgnoresADamagedIdentitySidecar`, which fails on `main`
for the same reason as the fourth: `main` never gets past the empty file).

`BatchUpsert` keeps its own rollback coverage in
`tests/index/batch_upsert_diskindex_test.go` (`TestBatchUpsert_RollsBackFailedBatch`,
`TestBatchUpsert_OneFsyncPerBatch`), which now exercises the shared append path.

## Spec

No spec change, and the submodule pin is unchanged. The segment log is an
implementation detail: `dirstral-spec` never names the file, the magic, the
record layout, or the tombstone encoding, and bs-008 only requires that the
SQLite `deleted=1` tombstone stays the source of truth. The df-000
`format_version` fence covers the JSON state outputs (`connection.json`, the
`stats` payload), not this binary segment. The fix keeps the bytes identical
anyway, so an older binary reads a segment written by this one and the reverse.

## Not done

- A partial segment header (a file with one to eleven bytes) still fails `Load`.
  Our own paths cannot produce it: the header is one buffered write, and the only
  file we create with no header is the empty one handled above. A short header is
  real damage, so reporting it stays honest.
- A rollback that itself fails (the truncate errors) returns both errors joined
  and leaves the extra bytes. That is a double fault on the same file, and it is
  the behavior the batch path already had.

`make check` passes. `go test -race ./tests/index` passes.

Closes #674
