### PR TITLE
fix(corpusfs): refuse an S3 range response that serves the wrong bytes (#673)

### DIFF
--- a/internal/corpusfs/s3reader.go
+++ b/internal/corpusfs/s3reader.go
@@ -6,10 +6,37 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"strconv"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 )
+
+// ErrRangeNotHonored is returned when an object store answers a ranged GET with
+// bytes that do not start at the requested offset (#673).
+//
+// The condition is not exotic. An S3-compatible proxy or gateway that drops the
+// Range header answers with the WHOLE object, so a reader that seeked to offset N
+// receives the bytes at offset 0 and cannot tell. Those bytes are then hashed,
+// chunked and cited as if they came from N, so the corpus indexes content the
+// source document does not have at that position.
+//
+// It is a distinct sentinel because it is a property of the SERVER, not of the
+// object: the same object read without a seek is fine, so a caller may report the
+// backend as unusable for range reads instead of the document as broken.
+var ErrRangeNotHonored = errors.New("corpusfs: object store did not honor the requested byte range")
+
+// ErrObjectTruncated is returned when an object body ends before the size the
+// store itself reported (#673).
+//
+// The bytes that did arrive are a PREFIX of the document. Returned as io.EOF they
+// are indistinguishable from a complete read, so the pipeline stores a short
+// document, a content hash over the wrong bytes, and citations that do not match
+// the source. That silent short read is the #487 truncation failure, and #682
+// established the rule this follows: a read that did not deliver the object fails
+// with its own error and never with io.EOF.
+var ErrObjectTruncated = errors.New("corpusfs: object body ended before the reported size")
 
 // s3RangeReader is an io.ReadSeekCloser over an S3 object that satisfies reads
 // via ranged GETs. It tracks a logical offset and lazily opens a GET body on the
@@ -29,6 +56,7 @@ type s3RangeReader struct {
 
 	offset int64
 	body   io.ReadCloser
+	closed bool
 }
 
 // Read fulfills io.Reader, opening a ranged GET from the current offset on
@@ -44,7 +72,16 @@ type s3RangeReader struct {
 // repository uses. The reader delivers one byte more than the cap and then fails,
 // because that extra byte is what separates an object of exactly the cap (which is
 // inside the policy and must read cleanly to io.EOF) from an object past it.
+//
+// A read after Close returns fs.ErrClosed. Close leaves the logical offset where
+// it was, so a reopen would issue a fresh ranged GET on a reader the caller has
+// already released: the context may be cancelled, and if the store ignores the
+// Range the reopened body serves offset 0 while the caller believes it is at
+// r.offset (#673).
 func (r *s3RangeReader) Read(p []byte) (int, error) {
+	if r.closed {
+		return 0, fs.ErrClosed
+	}
 	if r.offset > r.maxBytes {
 		return 0, fmt.Errorf("corpusfs: read s3://%s/%s: %w (cap %d bytes)", r.bucket, r.key, ErrObjectTooLarge, r.maxBytes)
 	}
@@ -64,10 +101,32 @@ func (r *s3RangeReader) Read(p []byte) (int, error) {
 	}
 	n, err := r.body.Read(p)
 	r.offset += int64(n)
+	if errors.Is(err, io.EOF) {
+		return n, r.endOfBody()
+	}
 	return n, err
 }
 
-// openFrom starts a ranged GET beginning at off through the end of the object.
+// endOfBody decides what the end of a GET body means at the current offset.
+//
+// It is io.EOF only when the reader delivered every byte the store said the
+// object has. A body that stops earlier delivered a PREFIX, and reporting that
+// prefix as io.EOF is the silent truncation #487 fixed once already, so it fails
+// with ErrObjectTruncated instead. The cap is checked first so an object past the
+// configured limit keeps the single answer #682 gave it.
+func (r *s3RangeReader) endOfBody() error {
+	if r.offset > r.maxBytes {
+		return fmt.Errorf("corpusfs: read s3://%s/%s: %w (cap %d bytes)", r.bucket, r.key, ErrObjectTooLarge, r.maxBytes)
+	}
+	if r.offset >= r.size {
+		return io.EOF
+	}
+	return fmt.Errorf("corpusfs: read s3://%s/%s: %w (got %d of %d bytes)",
+		r.bucket, r.key, ErrObjectTruncated, r.offset, r.size)
+}
+
+// openFrom starts a ranged GET beginning at off through the end of the object,
+// and refuses a response that does not start there (#673).
 func (r *s3RangeReader) openFrom(off int64) error {
 	if off >= r.size {
 		return io.EOF
@@ -81,13 +140,93 @@ func (r *s3RangeReader) openFrom(off int64) error {
 	if err != nil {
 		return fmt.Errorf("corpusfs: range get s3://%s/%s: %w", r.bucket, r.key, err)
 	}
+	if err := r.checkRangeResponse(off, out); err != nil {
+		_ = out.Body.Close()
+		return err
+	}
 	r.body = out.Body
 	return nil
 }
 
+// checkRangeResponse verifies that the body of a ranged GET really begins at off.
+//
+// The evidence is the response itself. A store that honors `bytes=N-` answers 206
+// with `Content-Range: bytes N-<end>/<total>`, so the start byte is stated and is
+// compared. A store that DROPS the header answers 200 with the whole object and
+// states no range at all, which is why an absent Content-Range at a non-zero
+// offset is refused rather than trusted: the alternative is to read offset-0 bytes
+// as if they came from N.
+//
+// Two responses without a Content-Range are still accepted, because in both the
+// body provably starts at off:
+//
+//   - off == 0, where the whole object IS the requested range;
+//   - a reported length equal to the tail from off, which only a honored range
+//     produces (an ignored range returns the full r.size).
+func (r *s3RangeReader) checkRangeResponse(off int64, out *s3.GetObjectOutput) error {
+	start, stated, err := parseContentRangeStart(aws.ToString(out.ContentRange))
+	if err != nil {
+		return fmt.Errorf("corpusfs: range get s3://%s/%s: %w (%v)",
+			r.bucket, r.key, ErrRangeNotHonored, err)
+	}
+	if stated {
+		if start != off {
+			return fmt.Errorf("corpusfs: range get s3://%s/%s: %w (asked for byte %d, got byte %d)",
+				r.bucket, r.key, ErrRangeNotHonored, off, start)
+		}
+		return nil
+	}
+	if off == 0 {
+		return nil
+	}
+	if out.ContentLength != nil && *out.ContentLength == r.size-off {
+		return nil
+	}
+	return fmt.Errorf("corpusfs: range get s3://%s/%s: %w (asked for byte %d, response states no range)",
+		r.bucket, r.key, ErrRangeNotHonored, off)
+}
+
+// parseContentRangeStart reads the first byte position out of a `Content-Range:
+// bytes <start>-<end>/<total>` value. stated=false means the response carried no
+// Content-Range at all.
+//
+// A value that is present but malformed is an error, including the
+// unsatisfied-range form that states no first byte position. Such a value is not
+// evidence that the range was honored, and treating it as absent would let a
+// broken store fall through to the off == 0 acceptance.
+func parseContentRangeStart(header string) (start int64, stated bool, err error) {
+	h := strings.TrimSpace(header)
+	if h == "" {
+		return 0, false, nil
+	}
+	const unit = "bytes "
+	if !strings.HasPrefix(h, unit) {
+		return 0, true, fmt.Errorf("unsupported range unit in %q", header)
+	}
+	spec := strings.TrimSpace(strings.TrimPrefix(h, unit))
+	slash := strings.IndexByte(spec, '/')
+	if slash >= 0 {
+		spec = spec[:slash]
+	}
+	dash := strings.IndexByte(spec, '-')
+	if dash <= 0 {
+		return 0, true, fmt.Errorf("no first byte position in %q", header)
+	}
+	start, parseErr := strconv.ParseInt(strings.TrimSpace(spec[:dash]), 10, 64)
+	if parseErr != nil || start < 0 {
+		return 0, true, fmt.Errorf("invalid first byte position in %q", header)
+	}
+	return start, true, nil
+}
+
 // Seek fulfills io.Seeker. Any pending GET body is closed so the next Read
-// reopens from the new offset.
+// reopens from the new offset. A seek after Close returns fs.ErrClosed, matching
+// Read: a closed reader is finished, and moving its offset only sets up a read
+// that must fail anyway (#673).
 func (r *s3RangeReader) Seek(offset int64, whence int) (int64, error) {
+	if r.closed {
+		return 0, fs.ErrClosed
+	}
 	var abs int64
 	switch whence {
 	case io.SeekStart:
@@ -110,8 +249,14 @@ func (r *s3RangeReader) Seek(offset int64, whence int) (int64, error) {
 	return abs, nil
 }
 
-// Close releases any open GET body.
+// Close releases any open GET body and marks the reader closed, so a later Read
+// cannot issue a new ranged GET on a reader the caller already released (#673).
+// Double-Close is a no-op, as it is for s3StreamReader.
 func (r *s3RangeReader) Close() error {
+	if r.closed {
+		return nil
+	}
+	r.closed = true
 	if r.body != nil {
 		err := r.body.Close()
 		r.body = nil

--- a/internal/corpusfs/s3reader.go
+++ b/internal/corpusfs/s3reader.go
@@ -195,7 +195,11 @@ func (r *s3RangeReader) refuseRange(detail string) error {
 // contentRange is a parsed `Content-Range: bytes <start>-<end>/<total>` value.
 type contentRange struct {
 	start int64
-	end   int64
+	// end is validated but is not compared with the object size. A store may
+	// answer an open-ended `bytes=N-` with a shorter range than the whole tail,
+	// which is legal; a body that then ends before the object does is caught by
+	// the truncation check in endOfBody.
+	end int64
 	// total is the complete length of the object, or -1 for the `*` form RFC 9110
 	// allows when the store does not know it.
 	total int64

--- a/internal/corpusfs/s3reader.go
+++ b/internal/corpusfs/s3reader.go
@@ -150,73 +150,122 @@ func (r *s3RangeReader) openFrom(off int64) error {
 
 // checkRangeResponse verifies that the body of a ranged GET really begins at off.
 //
-// The evidence is the response itself. A store that honors `bytes=N-` answers 206
-// with `Content-Range: bytes N-<end>/<total>`, so the start byte is stated and is
-// compared. A store that DROPS the header answers 200 with the whole object and
-// states no range at all, which is why an absent Content-Range at a non-zero
-// offset is refused rather than trusted: the alternative is to read offset-0 bytes
-// as if they came from N.
+// The only evidence accepted is a well-formed Content-Range that states the
+// requested first byte position. A store that honors `bytes=N-` answers 206 with
+// `Content-Range: bytes N-<end>/<total>`, which RFC 9110 §14.4 requires it to
+// send. A store that DROPS the header answers 200 with the whole object and
+// states no range at all, so an absent Content-Range at a non-zero offset is
+// refused: the alternative is to read offset-0 bytes as if they came from N.
 //
-// Two responses without a Content-Range are still accepted, because in both the
-// body provably starts at off:
+// A response length is NOT accepted as a substitute. Content-Length states how
+// many bytes arrive, never where they start, so an object replaced between the
+// HEAD and the GET can produce a full body whose length happens to equal the
+// requested tail. The one response without a Content-Range that is still
+// accepted is off == 0, where a whole-object body IS the requested range.
 //
-//   - off == 0, where the whole object IS the requested range;
-//   - a reported length equal to the tail from off, which only a honored range
-//     produces (an ignored range returns the full r.size).
+// A stated complete length must also match the size HEAD reported. A different
+// total describes a different object, and its bytes are not the ones the caller
+// asked for. The `*` form states no total and is left to the start check.
 func (r *s3RangeReader) checkRangeResponse(off int64, out *s3.GetObjectOutput) error {
-	start, stated, err := parseContentRangeStart(aws.ToString(out.ContentRange))
+	rng, stated, err := parseContentRange(aws.ToString(out.ContentRange))
 	if err != nil {
-		return fmt.Errorf("corpusfs: range get s3://%s/%s: %w (%v)",
-			r.bucket, r.key, ErrRangeNotHonored, err)
+		return r.refuseRange(err.Error())
 	}
-	if stated {
-		if start != off {
-			return fmt.Errorf("corpusfs: range get s3://%s/%s: %w (asked for byte %d, got byte %d)",
-				r.bucket, r.key, ErrRangeNotHonored, off, start)
+	if !stated {
+		if off == 0 {
+			return nil
 		}
-		return nil
+		return r.refuseRange(fmt.Sprintf("asked for byte %d, response states no range", off))
 	}
-	if off == 0 {
-		return nil
+	if rng.start != off {
+		return r.refuseRange(fmt.Sprintf("asked for byte %d, response starts at byte %d", off, rng.start))
 	}
-	if out.ContentLength != nil && *out.ContentLength == r.size-off {
-		return nil
+	if rng.total >= 0 && rng.total != r.size {
+		return r.refuseRange(fmt.Sprintf("object is %d bytes, response states %d", r.size, rng.total))
 	}
-	return fmt.Errorf("corpusfs: range get s3://%s/%s: %w (asked for byte %d, response states no range)",
-		r.bucket, r.key, ErrRangeNotHonored, off)
+	return nil
 }
 
-// parseContentRangeStart reads the first byte position out of a `Content-Range:
-// bytes <start>-<end>/<total>` value. stated=false means the response carried no
-// Content-Range at all.
+// refuseRange builds the ErrRangeNotHonored refusal. detail names offsets and
+// sizes only, never a byte of the object, so the error is safe to log.
+func (r *s3RangeReader) refuseRange(detail string) error {
+	return fmt.Errorf("corpusfs: range get s3://%s/%s: %w (%s)", r.bucket, r.key, ErrRangeNotHonored, detail)
+}
+
+// contentRange is a parsed `Content-Range: bytes <start>-<end>/<total>` value.
+type contentRange struct {
+	start int64
+	end   int64
+	// total is the complete length of the object, or -1 for the `*` form RFC 9110
+	// allows when the store does not know it.
+	total int64
+}
+
+// parseContentRange parses a Content-Range response header. stated=false means
+// the response carried no Content-Range at all.
 //
-// A value that is present but malformed is an error, including the
-// unsatisfied-range form that states no first byte position. Such a value is not
-// evidence that the range was honored, and treating it as absent would let a
-// broken store fall through to the off == 0 acceptance.
-func parseContentRangeStart(header string) (start int64, stated bool, err error) {
+// The whole value is validated, not only the part that is read. A store that
+// sends a malformed header has not stated where its bytes start, so accepting the
+// leading digits of `bytes 32-x/64` would trust exactly the response that proves
+// the store is unreliable. Every malformed form is an error, and an error is
+// never treated as an absent header (which would fall through to the off == 0
+// acceptance).
+func parseContentRange(header string) (contentRange, bool, error) {
 	h := strings.TrimSpace(header)
 	if h == "" {
-		return 0, false, nil
+		return contentRange{}, false, nil
 	}
 	const unit = "bytes "
 	if !strings.HasPrefix(h, unit) {
-		return 0, true, fmt.Errorf("unsupported range unit in %q", header)
+		return contentRange{}, true, fmt.Errorf("unsupported Content-Range unit in %q", header)
 	}
-	spec := strings.TrimSpace(strings.TrimPrefix(h, unit))
-	slash := strings.IndexByte(spec, '/')
-	if slash >= 0 {
-		spec = spec[:slash]
+	spec, totalText, ok := strings.Cut(strings.TrimSpace(strings.TrimPrefix(h, unit)), "/")
+	if !ok {
+		return contentRange{}, true, fmt.Errorf("no complete length in Content-Range %q", header)
 	}
-	dash := strings.IndexByte(spec, '-')
-	if dash <= 0 {
-		return 0, true, fmt.Errorf("no first byte position in %q", header)
+	rng, err := parseByteRangeSpec(spec)
+	if err != nil {
+		return contentRange{}, true, fmt.Errorf("%s in Content-Range %q", err, header)
 	}
-	start, parseErr := strconv.ParseInt(strings.TrimSpace(spec[:dash]), 10, 64)
-	if parseErr != nil || start < 0 {
-		return 0, true, fmt.Errorf("invalid first byte position in %q", header)
+	total, err := parseCompleteLength(totalText)
+	if err != nil {
+		return contentRange{}, true, fmt.Errorf("%s in Content-Range %q", err, header)
 	}
-	return start, true, nil
+	rng.total = total
+	return rng, true, nil
+}
+
+// parseByteRangeSpec parses the `<start>-<end>` half of a Content-Range. Both
+// positions are required: `bytes 32-/64` states a start it does not back with an
+// end, which is not a range a store served.
+func parseByteRangeSpec(spec string) (contentRange, error) {
+	first, last, ok := strings.Cut(spec, "-")
+	if !ok {
+		return contentRange{}, errors.New("no last byte position")
+	}
+	start, err := strconv.ParseInt(strings.TrimSpace(first), 10, 64)
+	if err != nil || start < 0 {
+		return contentRange{}, errors.New("invalid first byte position")
+	}
+	end, err := strconv.ParseInt(strings.TrimSpace(last), 10, 64)
+	if err != nil || end < start {
+		return contentRange{}, errors.New("invalid last byte position")
+	}
+	return contentRange{start: start, end: end}, nil
+}
+
+// parseCompleteLength parses the `/<total>` half of a Content-Range. It returns
+// -1 for the `*` form, which is legal and states nothing.
+func parseCompleteLength(text string) (int64, error) {
+	t := strings.TrimSpace(text)
+	if t == "*" {
+		return -1, nil
+	}
+	total, err := strconv.ParseInt(t, 10, 64)
+	if err != nil || total <= 0 {
+		return 0, errors.New("invalid complete length")
+	}
+	return total, nil
 }
 
 // Seek fulfills io.Seeker. Any pending GET body is closed so the next Read

--- a/tests/corpusfs/s3_range_integrity_673_test.go
+++ b/tests/corpusfs/s3_range_integrity_673_test.go
@@ -50,9 +50,13 @@ const (
 	ignoreRange673
 	// wrongOffset673 states a range it did not serve from.
 	wrongOffset673
-	// lengthOnly673 serves the correct tail but states it only through
-	// Content-Length, with no Content-Range.
+	// lengthOnly673 serves the tail but states it only through Content-Length,
+	// with no Content-Range. A length states how many bytes arrive, never where
+	// they start.
 	lengthOnly673
+	// customRange673 states the literal value in rangeHeader, so a test can pin a
+	// malformed or mismatched Content-Range.
+	customRange673
 )
 
 // rangeStubS3For673 is a network-free S3 stub whose range behaviour and body
@@ -62,6 +66,8 @@ type rangeStubS3For673 struct {
 	object   []byte
 	headSize *int64 // nil: HEAD reports len(object)
 	behavior rangeBehavior673
+	// rangeHeader is the literal Content-Range for customRange673.
+	rangeHeader string
 	// serveBytes truncates the served body to this many bytes when it is > 0. It
 	// models a connection that ends early or a store that returns a short object.
 	serveBytes int64
@@ -109,7 +115,9 @@ func (f *rangeStubS3For673) GetObject(_ context.Context, in *s3.GetObjectInput, 
 	case wrongOffset673:
 		out.ContentRange = aws.String(fmt.Sprintf("bytes 0-%d/%d", total-1, total))
 	case lengthOnly673:
-		// Content-Length only, which is still proof of the tail.
+		// Content-Length only: a byte count, and no start.
+	case customRange673:
+		out.ContentRange = aws.String(f.rangeHeader)
 	case honorRange673:
 		out.ContentRange = aws.String(fmt.Sprintf("bytes %d-%d/%d", start, total-1, total))
 	}
@@ -355,12 +363,16 @@ func TestS3RangeReader_HonestServerRoundTripsARangedRead(t *testing.T) {
 	}
 }
 
-// TestS3RangeReader_AcceptsARangeStatedOnlyByItsLength covers the store that
-// serves the right tail but states it only through Content-Length. The reported
-// length equals the tail from the requested offset, which an ignored range can
-// never produce (it returns the whole object), so the response is still proof and
-// is accepted. Without this allowance the check would refuse correct data.
-func TestS3RangeReader_AcceptsARangeStatedOnlyByItsLength(t *testing.T) {
+// TestS3RangeReader_RefusesARangeStatedOnlyByItsLength pins that a response
+// length is not evidence of a start.
+//
+// The store here serves the right tail and states only its Content-Length, and it
+// is still refused. Content-Length says how many bytes arrive, never where they
+// begin. An object replaced between the HEAD and the GET produces a WHOLE body
+// whose length can equal the requested tail, so a store that ignores the Range
+// would pass a length check while serving byte 0. RFC 9110 requires
+// Content-Range on a 206, so the strict rule costs a conforming store nothing.
+func TestS3RangeReader_RefusesARangeStatedOnlyByItsLength(t *testing.T) {
 	obj := object673(64)
 	stub := &rangeStubS3For673{key: "corpus/doc.txt", object: obj, behavior: lengthOnly673}
 	fsys := newRangeFS673(t, stub)
@@ -374,12 +386,88 @@ func TestS3RangeReader_AcceptsARangeStatedOnlyByItsLength(t *testing.T) {
 	if _, err := rc.Seek(24, io.SeekStart); err != nil {
 		t.Fatalf("Seek: %v", err)
 	}
+	if _, err := io.ReadAll(rc); !errors.Is(err, corpusfs.ErrRangeNotHonored) {
+		t.Fatalf("read error = %v, want ErrRangeNotHonored", err)
+	}
+}
+
+// TestS3RangeReader_RefusesAMalformedContentRange covers the header values a
+// store must not be trusted on.
+//
+// Reading only the leading digits would accept `bytes 32-x/64` from a store whose
+// header proves it is unreliable, and a total that disagrees with HEAD describes a
+// DIFFERENT object, whose bytes are not the ones the caller asked for. The whole
+// value is therefore validated, and every invalid form is a refusal.
+func TestS3RangeReader_RefusesAMalformedContentRange(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		header string
+	}{
+		{name: "no complete length", header: "bytes 32-63"},
+		{name: "no last byte position", header: "bytes 32-/64"},
+		{name: "non-numeric last byte position", header: "bytes 32-x/64"},
+		{name: "no positions at all", header: "bytes 32"},
+		{name: "last before first", header: "bytes 32-16/64"},
+		{name: "unsupported unit", header: "items 32-63/64"},
+		{name: "unsatisfied range", header: "bytes */64"},
+		{name: "non-numeric complete length", header: "bytes 32-63/all"},
+		{name: "complete length of another object", header: "bytes 32-63/999"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stub := &rangeStubS3For673{
+				key:         "corpus/doc.txt",
+				object:      object673(64),
+				behavior:    customRange673,
+				rangeHeader: tc.header,
+			}
+			fsys := newRangeFS673(t, stub)
+
+			rc, err := fsys.Open(context.Background(), "doc.txt")
+			if err != nil {
+				t.Fatalf("Open: %v", err)
+			}
+			defer func() { _ = rc.Close() }()
+
+			if _, err := rc.Seek(32, io.SeekStart); err != nil {
+				t.Fatalf("Seek: %v", err)
+			}
+			if _, err := io.ReadAll(rc); !errors.Is(err, corpusfs.ErrRangeNotHonored) {
+				t.Fatalf("read error = %v for Content-Range %q, want ErrRangeNotHonored", err, tc.header)
+			}
+		})
+	}
+}
+
+// TestS3RangeReader_AcceptsAnUnknownCompleteLength is the guard on the strict
+// parser. `bytes 32-63/*` is a legal Content-Range: the store states the start it
+// served and says it does not know the object's total length. The start is the
+// evidence the reader needs, so the response must be accepted rather than refused
+// for the missing total.
+func TestS3RangeReader_AcceptsAnUnknownCompleteLength(t *testing.T) {
+	obj := object673(64)
+	stub := &rangeStubS3For673{
+		key:         "corpus/doc.txt",
+		object:      obj,
+		behavior:    customRange673,
+		rangeHeader: "bytes 32-63/*",
+	}
+	fsys := newRangeFS673(t, stub)
+
+	rc, err := fsys.Open(context.Background(), "doc.txt")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = rc.Close() }()
+
+	if _, err := rc.Seek(32, io.SeekStart); err != nil {
+		t.Fatalf("Seek: %v", err)
+	}
 	got, err := io.ReadAll(rc)
 	if err != nil {
-		t.Fatalf("read: %v", err)
+		t.Fatalf("read of a legal `*` complete length failed: %v", err)
 	}
-	if !bytes.Equal(got, obj[24:]) {
-		t.Errorf("read returned %q, want the tail %q", got, obj[24:])
+	if !bytes.Equal(got, obj[32:]) {
+		t.Errorf("read returned %q, want the tail %q", got, obj[32:])
 	}
 }
 

--- a/tests/corpusfs/s3_range_integrity_673_test.go
+++ b/tests/corpusfs/s3_range_integrity_673_test.go
@@ -1,0 +1,413 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+
+	"github.com/dirstral/dir2mcp/internal/corpusfs"
+)
+
+// Range-response integrity and reader lifecycle (dir2mcp #673).
+//
+// The known-size reader satisfies a read with a ranged GET and then trusted
+// whatever came back. Two ordinary server behaviours therefore returned the WRONG
+// BYTES with no error at all:
+//
+//   - a proxy or gateway that DROPS the Range header answers with the whole
+//     object, so a reader positioned at byte N receives the bytes at byte 0;
+//   - a body that ends early is a PREFIX of the object, and it arrived as io.EOF,
+//     which every caller reads as "the file ended here".
+//
+// Both corrupt the corpus quietly: the wrong bytes are hashed, chunked, embedded
+// and cited, so `search` answers from content the document does not contain at
+// that position and a citation does not match the source. There is no error to
+// find in a log afterwards.
+//
+// A closed reader that reopens is the same defect with a lifecycle trigger: the
+// reopened GET is a fresh request, and if the store ignores its Range the caller
+// silently continues at byte 0.
+
+// rangeBehavior673 selects how the stub answers a ranged GET.
+type rangeBehavior673 int
+
+const (
+	// honorRange673 is a conforming store: it serves the requested tail and states
+	// the range it served, as a 206 must.
+	honorRange673 rangeBehavior673 = iota
+	// ignoreRange673 is the proxy that drops the header: the whole object, a 200,
+	// and no Content-Range at all.
+	ignoreRange673
+	// wrongOffset673 states a range it did not serve from.
+	wrongOffset673
+	// lengthOnly673 serves the correct tail but states it only through
+	// Content-Length, with no Content-Range.
+	lengthOnly673
+)
+
+// rangeStubS3For673 is a network-free S3 stub whose range behaviour and body
+// length are set per test. No credentials and no endpoint are involved.
+type rangeStubS3For673 struct {
+	key      string
+	object   []byte
+	headSize *int64 // nil: HEAD reports len(object)
+	behavior rangeBehavior673
+	// serveBytes truncates the served body to this many bytes when it is > 0. It
+	// models a connection that ends early or a store that returns a short object.
+	serveBytes int64
+
+	gets atomic.Int64
+}
+
+func (f *rangeStubS3For673) ListObjectsV2(_ context.Context, _ *s3.ListObjectsV2Input, _ ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
+	return &s3.ListObjectsV2Output{IsTruncated: aws.Bool(false)}, nil
+}
+
+func (f *rangeStubS3For673) HeadObject(_ context.Context, in *s3.HeadObjectInput, _ ...func(*s3.Options)) (*s3.HeadObjectOutput, error) {
+	if aws.ToString(in.Key) != f.key {
+		return nil, &s3types.NoSuchKey{}
+	}
+	size := int64(len(f.object))
+	if f.headSize != nil {
+		size = *f.headSize
+	}
+	return &s3.HeadObjectOutput{ContentLength: aws.Int64(size)}, nil
+}
+
+func (f *rangeStubS3For673) GetObject(_ context.Context, in *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	if aws.ToString(in.Key) != f.key {
+		return nil, &s3types.NoSuchKey{}
+	}
+	f.gets.Add(1)
+	start, _ := parseRangeStart(aws.ToString(in.Range))
+	total := int64(len(f.object))
+
+	served := f.object
+	if f.behavior != ignoreRange673 && start > 0 && start <= total {
+		served = f.object[start:]
+	}
+	if f.serveBytes > 0 && int64(len(served)) > f.serveBytes {
+		served = served[:f.serveBytes]
+	}
+	out := &s3.GetObjectOutput{
+		Body:          io.NopCloser(bytes.NewReader(served)),
+		ContentLength: aws.Int64(int64(len(served))),
+	}
+	switch f.behavior {
+	case ignoreRange673:
+		// A 200: the whole object, and no range stated.
+	case wrongOffset673:
+		out.ContentRange = aws.String(fmt.Sprintf("bytes 0-%d/%d", total-1, total))
+	case lengthOnly673:
+		// Content-Length only, which is still proof of the tail.
+	case honorRange673:
+		out.ContentRange = aws.String(fmt.Sprintf("bytes %d-%d/%d", start, total-1, total))
+	}
+	return out, nil
+}
+
+// object673 is a body whose every byte names its own offset, so a test can prove
+// WHICH bytes it received, not only how many.
+func object673(n int) []byte {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + i%26)
+	}
+	return b
+}
+
+func newRangeFS673(t *testing.T, stub *rangeStubS3For673) *corpusfs.S3FS {
+	t.Helper()
+	fsys, err := corpusfs.NewS3FS(stub, corpusfs.S3Config{Bucket: "bkt", Prefix: "corpus/", CacheDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("NewS3FS: %v", err)
+	}
+	return fsys
+}
+
+// TestS3RangeReader_RefusesAServerThatIgnoresTheRange is the core case. The store
+// answers a `bytes=32-` request with the whole object, so the reader is at byte 32
+// and the bytes are the ones at byte 0.
+//
+// On `main` the read succeeds and returns the head of the file as the tail of the
+// file. Nothing downstream can detect that, so the document is indexed with the
+// wrong content at the wrong offset.
+func TestS3RangeReader_RefusesAServerThatIgnoresTheRange(t *testing.T) {
+	obj := object673(64)
+	stub := &rangeStubS3For673{key: "corpus/doc.txt", object: obj, behavior: ignoreRange673}
+	fsys := newRangeFS673(t, stub)
+
+	rc, err := fsys.Open(context.Background(), "doc.txt")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = rc.Close() }()
+
+	if _, err := rc.Seek(32, io.SeekStart); err != nil {
+		t.Fatalf("Seek: %v", err)
+	}
+	got, readErr := io.ReadAll(rc)
+	if !errors.Is(readErr, corpusfs.ErrRangeNotHonored) {
+		t.Fatalf("read error = %v, want ErrRangeNotHonored (got %d bytes)", readErr, len(got))
+	}
+	if bytes.HasPrefix(obj, got) && len(got) > 0 {
+		t.Errorf("read returned the bytes at offset 0 for a request that asked for offset 32: %q", got)
+	}
+}
+
+// TestS3RangeReader_RefusesARangeServedFromTheWrongOffset covers the store that
+// DOES state a range, but not the one it was asked for. The stated start is the
+// evidence, so it must be compared rather than assumed to match.
+func TestS3RangeReader_RefusesARangeServedFromTheWrongOffset(t *testing.T) {
+	stub := &rangeStubS3For673{key: "corpus/doc.txt", object: object673(64), behavior: wrongOffset673}
+	fsys := newRangeFS673(t, stub)
+
+	rc, err := fsys.Open(context.Background(), "doc.txt")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = rc.Close() }()
+
+	if _, err := rc.Seek(16, io.SeekStart); err != nil {
+		t.Fatalf("Seek: %v", err)
+	}
+	if _, err := io.ReadAll(rc); !errors.Is(err, corpusfs.ErrRangeNotHonored) {
+		t.Fatalf("read error = %v, want ErrRangeNotHonored", err)
+	}
+}
+
+// TestS3RangeReader_ShortBodyIsNotEOF is the truncation half. HEAD reports 4096
+// bytes and the body delivers 100, so the reader holds a PREFIX of the document.
+//
+// The precedent #682 set is followed here: a short read gets its own error and
+// never io.EOF, because io.EOF tells every caller the file ended there. That is
+// the #487 truncated-document failure, and it ends as a stored document whose
+// content and content hash belong to bytes the corpus does not have.
+//
+// On `main` io.ReadAll returns the 100 bytes with a nil error, at offset 0 and
+// after a seek alike.
+func TestS3RangeReader_ShortBodyIsNotEOF(t *testing.T) {
+	const reported = 4096
+	const delivered = 100
+
+	for _, tc := range []struct {
+		name string
+		seek int64
+	}{
+		{name: "from the start", seek: 0},
+		{name: "after a seek", seek: 512},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			head := int64(reported)
+			stub := &rangeStubS3For673{
+				key:        "corpus/report.txt",
+				object:     object673(reported),
+				headSize:   &head,
+				behavior:   honorRange673,
+				serveBytes: delivered,
+			}
+			fsys := newRangeFS673(t, stub)
+
+			rc, err := fsys.Open(context.Background(), "report.txt")
+			if err != nil {
+				t.Fatalf("Open: %v", err)
+			}
+			defer func() { _ = rc.Close() }()
+
+			if tc.seek > 0 {
+				if _, err := rc.Seek(tc.seek, io.SeekStart); err != nil {
+					t.Fatalf("Seek: %v", err)
+				}
+			}
+			got, readErr := io.ReadAll(rc)
+			if !errors.Is(readErr, corpusfs.ErrObjectTruncated) {
+				t.Fatalf("read error = %v, want ErrObjectTruncated after %d of %d bytes", readErr, len(got), reported)
+			}
+			if len(got) != delivered {
+				t.Errorf("read delivered %d bytes, want the %d the body served", len(got), delivered)
+			}
+		})
+	}
+}
+
+// TestS3RangeReader_StaysClosed pins the lifecycle. A closed reader is finished:
+// Read and Seek report fs.ErrClosed, and no new GET is issued.
+//
+// On `main` Close only drops the body, so the next Read opens a SECOND ranged GET
+// on a reader the caller already released. That request can be answered by a store
+// that ignores the Range, which returns byte 0 while the caller believes it reads
+// from its saved offset.
+func TestS3RangeReader_StaysClosed(t *testing.T) {
+	stub := &rangeStubS3For673{key: "corpus/doc.txt", object: object673(64), behavior: honorRange673}
+	fsys := newRangeFS673(t, stub)
+
+	rc, err := fsys.Open(context.Background(), "doc.txt")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if _, err := io.ReadFull(rc, make([]byte, 8)); err != nil {
+		t.Fatalf("first read: %v", err)
+	}
+	if err := rc.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	getsAtClose := stub.gets.Load()
+
+	if _, err := rc.Read(make([]byte, 8)); !errors.Is(err, fs.ErrClosed) {
+		t.Errorf("Read after Close = %v, want fs.ErrClosed", err)
+	}
+	if _, err := rc.Seek(0, io.SeekStart); !errors.Is(err, fs.ErrClosed) {
+		t.Errorf("Seek after Close = %v, want fs.ErrClosed", err)
+	}
+	if err := rc.Close(); err != nil {
+		t.Errorf("second Close = %v, want nil (double-Close is a no-op)", err)
+	}
+	if gets := stub.gets.Load(); gets != getsAtClose {
+		t.Errorf("%d GetObject calls after Close, want none: a closed reader must not reopen", gets-getsAtClose)
+	}
+}
+
+// TestS3StreamReader_StaysClosed pins the same lifecycle for the unknown-length
+// reader, which is the variant Open returns when HEAD omits Content-Length. It
+// already behaved this way; the assertion is here so BOTH variants carry the rule
+// and a later change to one of them cannot quietly drop it.
+func TestS3StreamReader_StaysClosed(t *testing.T) {
+	stub := &rangeStubS3For673{key: "corpus/nolen.bin", object: object673(64), behavior: ignoreRange673}
+	stub.headSize = nil
+	fsys, err := corpusfs.NewS3FS(&noLengthHeadS3For673{rangeStubS3For673: stub}, corpusfs.S3Config{
+		Bucket: "bkt", Prefix: "corpus/", CacheDir: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("NewS3FS: %v", err)
+	}
+
+	rc, err := fsys.Open(context.Background(), "nolen.bin")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if _, err := io.ReadFull(rc, make([]byte, 8)); err != nil {
+		t.Fatalf("first read: %v", err)
+	}
+	if err := rc.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	getsAtClose := stub.gets.Load()
+
+	if _, err := rc.Read(make([]byte, 8)); !errors.Is(err, fs.ErrClosed) {
+		t.Errorf("Read after Close = %v, want fs.ErrClosed", err)
+	}
+	if _, err := rc.Seek(0, io.SeekCurrent); !errors.Is(err, fs.ErrClosed) {
+		t.Errorf("Seek after Close = %v, want fs.ErrClosed", err)
+	}
+	if gets := stub.gets.Load(); gets != getsAtClose {
+		t.Errorf("%d GetObject calls after Close, want none", gets-getsAtClose)
+	}
+}
+
+// noLengthHeadS3For673 is the stub with HEAD's Content-Length dropped, the shape
+// #487 documented on some MinIO/R2 gateways. Open then returns the streaming
+// reader instead of the ranged one.
+type noLengthHeadS3For673 struct {
+	*rangeStubS3For673
+}
+
+func (f *noLengthHeadS3For673) HeadObject(_ context.Context, in *s3.HeadObjectInput, _ ...func(*s3.Options)) (*s3.HeadObjectOutput, error) {
+	if aws.ToString(in.Key) != f.key {
+		return nil, &s3types.NoSuchKey{}
+	}
+	return &s3.HeadObjectOutput{}, nil
+}
+
+// TestS3RangeReader_HonestServerRoundTripsARangedRead is the false-positive guard.
+// A conforming store must keep working exactly as before: the seek issues one
+// ranged GET, the bytes are the tail from that offset, and the read ends at
+// io.EOF. The check refuses a wrong answer, not a slow or unusual one.
+func TestS3RangeReader_HonestServerRoundTripsARangedRead(t *testing.T) {
+	obj := object673(64)
+	stub := &rangeStubS3For673{key: "corpus/doc.txt", object: obj, behavior: honorRange673}
+	fsys := newRangeFS673(t, stub)
+
+	rc, err := fsys.Open(context.Background(), "doc.txt")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = rc.Close() }()
+
+	if _, err := rc.Seek(40, io.SeekStart); err != nil {
+		t.Fatalf("Seek: %v", err)
+	}
+	got, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("read of an honest ranged response failed: %v", err)
+	}
+	if !bytes.Equal(got, obj[40:]) {
+		t.Errorf("read returned %q, want the tail %q", got, obj[40:])
+	}
+}
+
+// TestS3RangeReader_AcceptsARangeStatedOnlyByItsLength covers the store that
+// serves the right tail but states it only through Content-Length. The reported
+// length equals the tail from the requested offset, which an ignored range can
+// never produce (it returns the whole object), so the response is still proof and
+// is accepted. Without this allowance the check would refuse correct data.
+func TestS3RangeReader_AcceptsARangeStatedOnlyByItsLength(t *testing.T) {
+	obj := object673(64)
+	stub := &rangeStubS3For673{key: "corpus/doc.txt", object: obj, behavior: lengthOnly673}
+	fsys := newRangeFS673(t, stub)
+
+	rc, err := fsys.Open(context.Background(), "doc.txt")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = rc.Close() }()
+
+	if _, err := rc.Seek(24, io.SeekStart); err != nil {
+		t.Fatalf("Seek: %v", err)
+	}
+	got, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !bytes.Equal(got, obj[24:]) {
+		t.Errorf("read returned %q, want the tail %q", got, obj[24:])
+	}
+}
+
+// TestS3RangeReader_RefusalNamesTheObjectNotItsBytes keeps the error message safe
+// to log: it names the bucket, the key and the offsets, and never a byte of the
+// object.
+func TestS3RangeReader_RefusalNamesTheObjectNotItsBytes(t *testing.T) {
+	obj := []byte(strings.Repeat("SECRET", 16))
+	stub := &rangeStubS3For673{key: "corpus/doc.txt", object: obj, behavior: ignoreRange673}
+	fsys := newRangeFS673(t, stub)
+
+	rc, err := fsys.Open(context.Background(), "doc.txt")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = rc.Close() }()
+
+	if _, err := rc.Seek(32, io.SeekStart); err != nil {
+		t.Fatalf("Seek: %v", err)
+	}
+	_, readErr := io.ReadAll(rc)
+	if readErr == nil {
+		t.Fatal("read succeeded, want a refusal")
+	}
+	if strings.Contains(readErr.Error(), "SECRET") {
+		t.Errorf("error message carries object content: %q", readErr)
+	}
+	if !strings.Contains(readErr.Error(), "corpus/doc.txt") {
+		t.Errorf("error message does not name the object: %q", readErr)
+	}
+}

--- a/tests/corpusfs/s3_range_integrity_673_test.go
+++ b/tests/corpusfs/s3_range_integrity_673_test.go
@@ -124,8 +124,9 @@ func (f *rangeStubS3For673) GetObject(_ context.Context, in *s3.GetObjectInput, 
 	return out, nil
 }
 
-// object673 is a body whose every byte names its own offset, so a test can prove
-// WHICH bytes it received, not only how many.
+// object673 builds a body from a repeating a-z pattern. The bytes at one offset
+// differ from the bytes at another, so a test proves WHICH bytes it received and
+// not only how many of them.
 func object673(n int) []byte {
 	b := make([]byte, n)
 	for i := range b {

--- a/tests/corpusfs/s3_test.go
+++ b/tests/corpusfs/s3_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -59,10 +60,20 @@ func (f *fakeS3) GetObject(_ context.Context, in *s3.GetObjectInput, _ ...func(*
 	}
 	rangeHeader := aws.ToString(in.Range)
 	f.getRanges = append(f.getRanges, rangeHeader)
-	if start, ok := parseRangeStart(rangeHeader); ok && start <= int64(len(body)) {
+	total := int64(len(body))
+	if start, ok := parseRangeStart(rangeHeader); ok && start <= total {
 		body = body[start:]
+		// State the range that was served, exactly as a real store does on a 206.
+		// Without this the response is indistinguishable from a store that DROPPED
+		// the Range header and returned the whole object, and the reader refuses
+		// that response (#673).
+		return &s3.GetObjectOutput{
+			Body:          io.NopCloser(bytes.NewReader(body)),
+			ContentRange:  aws.String(fmt.Sprintf("bytes %d-%d/%d", start, total-1, total)),
+			ContentLength: aws.Int64(int64(len(body))),
+		}, nil
 	}
-	return &s3.GetObjectOutput{Body: io.NopCloser(bytes.NewReader(body))}, nil
+	return &s3.GetObjectOutput{Body: io.NopCloser(bytes.NewReader(body)), ContentLength: aws.Int64(total)}, nil
 }
 
 // parseRangeStart extracts the start byte from a "bytes=N-" header.


### PR DESCRIPTION
Closes #673.

## What a user saw

`search` returned a passage that is not in the document at that place. A citation pointed at a file whose bytes do not contain the quoted text. `open_file` on the same document showed different content from the hit that cited it.

Nothing reported an error. The scan said `indexed`, `errors=0`, and the coverage report was clean. The document was stored with a `content_hash` over bytes the corpus does not actually have, so the next scan agreed with itself and never re-read the file.

Two ordinary object stores produce that result today.

1. **A proxy or gateway that drops the Range header.** The reader seeks to byte N, asks for `bytes=N-`, and receives the WHOLE object with a 200. The bytes at byte 0 are then read as the bytes at byte N.
2. **A body that ends early.** The bytes that arrived are a PREFIX of the document. They arrived as `io.EOF`, which every caller reads as the end of the file.

Both are silent. The wrong bytes are hashed, chunked, embedded and cited, and no log line names the file.

## The mechanism

`s3RangeReader` asked for a range and then trusted the answer. It never looked at the response, and it never compared what it received against the size `HeadObject` reported.

### 1. A ranged response must state the offset it served

`openFrom` now checks the response before it reads a byte of it, and closes the body when the check fails.

The only accepted evidence is a well formed `Content-Range` that states the requested first byte position. RFC 9110 §14.4 requires a store to send it on a 206, so the rule costs a conforming store nothing. A store that drops the Range header answers with a 200 and states no range at all, which is exactly the case that must fail.

The whole header value is validated, not only the part that is read: the `bytes` unit, a numeric first and last position, a last position not before the first, and a complete length that is numeric or `*`. A store that sends `bytes 32-x/64` has not stated where its bytes start, and reading its leading digits would trust the one response that already proves the store unreliable. A stated numeric complete length must also equal the size `HeadObject` reported, because a different total describes a different object.

**A response length is not accepted as a substitute.** `Content-Length` states how many bytes arrive, never where they start. An object replaced between the HEAD and the GET can serve a full body whose length equals the requested tail, so a length check passes while the store serves byte 0. The one response without a `Content-Range` that is still accepted is a read at offset 0, where a whole object body IS the requested range. That keeps every existing whole file read working.

### 2. A short body is not `io.EOF`

`Read` now ends through `endOfBody`. The end of a GET body is `io.EOF` only when the reader delivered every byte the store said the object has. A body that stops earlier delivered a prefix, and it fails with `ErrObjectTruncated`.

This follows the precedent #829 set for the neighbouring case rather than a new policy: over cap delivery ends with `ErrObjectTooLarge`, never with `io.EOF`, because a silent short read looks to every caller like a complete file, which is the #487 truncation bug. The cap is checked FIRST in `endOfBody`, so an object past the configured cap keeps the single answer #829 gave it and this PR does not weaken that bound.

### 3. A closed reader stays closed

`Close` now marks the reader closed. `Read` and `Seek` after `Close` return `fs.ErrClosed`, and no new GET is issued. Double `Close` is a no op.

`Close` used to only drop the body, so the next `Read` opened a SECOND ranged GET on a reader the caller had already released. That request runs on a context the caller may have cancelled, and a store that ignores its Range answers it from byte 0 while the caller believes it continues at its saved offset. `s3StreamReader` already behaved this way. Both variants now agree, and the test file pins the rule on both.

### Two sentinels, because callers need different answers

* `ErrRangeNotHonored` is a property of the SERVER. The same object read without a seek is fine, so an operator learns the backend is unusable for range reads, not that the document is broken.
* `ErrObjectTruncated` is a property of this READ. A retry may deliver the whole object.

Neither message carries a byte of the object. They name the bucket, the key, the offsets and the sizes, so they are safe to log. `TestS3RangeReader_RefusalNamesTheObjectNotItsBytes` pins that.

## SPEC: no dirstral-spec PR needed

I checked before I wrote code.

SPEC §7.10 defines the `open / range-read` capability: a CorpusFS must "support random-access range reads (read *N* bytes at offset *O*)", and "on `s3` a range read maps to a ranged `GET`". It also states that `content_hash` is computed over "the bytes returned by open, identically across backends, so document identity is backend-independent".

A range read that returns the bytes at offset 0 does not satisfy that contract, and a hash over a truncated body breaks the identity invariant §7.8 depends on. This PR enforces what the SPEC already requires. It adds no new capability, no new config surface, no new error code, and no new skip reason. A refused read surfaces through the read error path that a corrupt or unreadable object already used. The submodule pointer is untouched.

## Verified against `main`

`git stash` is banned in this repository, because `refs/stash` is shared across worktrees. The files were copied to a uniquely named scratch directory, the tracked files were reverted with `git checkout HEAD --`, the tests were run, and everything was restored afterwards.

The new sentinels do not exist on `main`, so the file cannot compile there. The proof run used the same tests with each `errors.Is(err, corpusfs.ErrX)` assertion replaced by `err == nil`. That is a WEAKER assertion, so a pass would have been possible, and `main` still fails all four.

| test | on `main` |
| --- | --- |
| `S3RangeReader_RefusesAServerThatIgnoresTheRange` | **FAIL**: `read error = <nil>`, 32 bytes delivered from offset 0 for a request that asked for offset 32 |
| `S3RangeReader_RefusesARangeServedFromTheWrongOffset` | **FAIL**: `read error = <nil>` |
| `S3RangeReader_ShortBodyIsNotEOF` (both subtests) | **FAIL**: `read error = <nil>` after 100 of 4096 bytes, at offset 0 and after a seek |
| `S3RangeReader_StaysClosed` | **FAIL**: `Read after Close = <nil>`, `Seek after Close = <nil>`, 1 GetObject after Close |
| `S3RangeReader_RefusalNamesTheObjectNotItsBytes` | **FAIL**: `read succeeded, want a refusal` |
| `S3StreamReader_StaysClosed` | **PASS** (the streaming reader was already correct, as it must be) |
| `S3RangeReader_HonestServerRoundTripsARangedRead` | **PASS** (false positive guard, as it must be) |

The `RefusesAMalformedContentRange` and `AcceptsAnUnknownCompleteLength` cases came out of the review round. They pin the strict parser, so they were written against the FIRST commit on this branch, where the length only fallback accepted the malformed forms.

## Tests

`tests/corpusfs/s3_range_integrity_673_test.go` (17 cases). The stub is network free and takes no credentials and no endpoint. Its behaviour is selectable per test: honor the range, drop it, state the wrong offset, state a literal header, or serve a short body. Every body byte names its own offset, so a test proves WHICH bytes it received, not only how many.

`tests/corpusfs/s3_test.go`: the existing `fakeS3` honored ranges but stated no response metadata, which is why an ignored range was untested (#673 names this). It now sets `Content-Range` and `Content-Length` on a ranged answer, exactly as a real store does on a 206.

## Review round

`coderabbit review --committed --base main` returned 3 findings. All 3 were valid and all 3 are fixed in the second commit: the length only acceptance is removed, the parser validates the complete syntax, and a stated complete length is compared with the size HEAD reported. Each fix has a test.

## Not in scope

* **`Localize`** issues an unranged GET and never calls HEAD, so it has no reported size to compare a short download against. A truncation check there needs a HEAD call per download, which is a separate cost decision.
* **A `Content-Range` total that disagrees with HEAD** is refused as `ErrRangeNotHonored`. The cause may be an object that changed rather than a store that ignores ranges. A distinct "object changed under the reader" sentinel would be more precise, and it belongs with the ETag re-read work in §7.8, not here.
* **`s3StreamReader`** gets no truncation check, because a HEAD that omits `Content-Length` gives it no size to compare against. That is why it exists (#487).
* **No new MCP error code.** On the ingest path a refused read becomes a `status="error"` row with the message, which is the visible and correct answer. On `open_file` it joins the class every mid-read failure already falls into (`mapReadDocumentError` default). SPEC §14.4 names no code for "the source served the wrong bytes", and this repository is spec-first, so a new code needs a dirstral-spec PR first. An honest error under a general code is still a large improvement on silently wrong content.

## Checklist

- [x] `coderabbit review --committed --base main`: 3 findings, all fixed
- [x] `make check` passes locally, including `gocyclo -over 15`
- [x] new behaviour has test coverage that fails against `main`
- [x] no object content is logged or persisted
- [x] `README.md` and `docs/` remain truthful
- [x] no unrelated files changed, submodule pointer untouched
