### PR TITLE
fix(mcp): deliver an inline video clip as an embedded resource (#663)

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -94,6 +94,12 @@ type toolContentItem struct {
 	Text     string `json:"text,omitempty"`
 	Data     string `json:"data,omitempty"`
 	MIMEType string `json:"mimeType,omitempty"`
+	// URI identifies the bytes when the transport has to carry them as an
+	// embedded resource rather than a natively-typed item (a video clip; see
+	// convertToolCallResult and SPEC §15.11). An embedded resource's `uri` is
+	// required by MCP, so it is set where rel_path and the span are known
+	// rather than invented at the transport.
+	URI string `json:"uri,omitempty"`
 }
 
 type toolExecutionError struct {
@@ -1825,9 +1831,31 @@ func (s *Server) handleOpenMediaClipTool(ctx context.Context, args map[string]in
 	}
 	return toolCallResult{
 		// Media bytes travel only via the typed data item, never a text item.
-		Content:           []toolContentItem{{Type: contentType, Data: encoded, MIMEType: mimeType}},
+		//
+		// `video` is an INTERNAL item type. MCP 2025-11-25 defines no video
+		// content item, so the transport maps it onto an embedded resource
+		// (SPEC §15.11); the URI below is that resource's identifier. Keeping
+		// the internal type media-shaped means the tool layer describes what it
+		// produced and the transport owns how the protocol carries it.
+		Content: []toolContentItem{{
+			Type:     contentType,
+			Data:     encoded,
+			MIMEType: mimeType,
+			URI:      mediaClipURI(req.relPath, req.startMS, req.endMS),
+		}},
 		StructuredContent: structured,
 	}, nil
+}
+
+// mediaClipURI identifies one extracted clip: its source document plus the time
+// span it covers, in the `#t=` media-fragment form the citations already use
+// (§5.4). It is a stable identifier for the bytes, NOT a fetchable location:
+// `return=inline` carries the clip in the response, and only `return=reference`
+// promises somewhere to fetch it from.
+func mediaClipURI(relPath string, startMS, endMS int) string {
+	return fmt.Sprintf("dir2mcp:///%s#t=%.3f,%.3f",
+		strings.TrimPrefix(relPath, "/"),
+		float64(startMS)/1000, float64(endMS)/1000)
 }
 
 // parseMediaClipReturnArg parses the optional "return" argument (inline|reference).

--- a/internal/mcp/transport_sdk.go
+++ b/internal/mcp/transport_sdk.go
@@ -594,7 +594,39 @@ func convertToolCallResult(res toolCallResult) *sdkmcp.CallToolResult {
 				MIMEType: item.MIMEType,
 				Data:     data,
 			})
+		case "video":
+			// MCP 2025-11-25 defines text, image, audio, resource_link and
+			// resource. It defines NO video item, so SPEC §15.11 names an
+			// embedded resource carrying the blob and a video/* mimeType as the
+			// only valid carrier for inline video bytes (spec 0.49.0).
+			//
+			// This arm used to fall through to `default`, which produced a
+			// TextContent from an item that has no Text. The call then reported
+			// success and the client rendered nothing: no player, no text, no
+			// error (#663). Audio worked, so the failure looked arbitrary.
+			data, err := base64.StdEncoding.DecodeString(item.Data)
+			if err != nil {
+				log.Printf("warning: dropping invalid base64 video content (mime=%q): %v", item.MIMEType, err)
+				continue
+			}
+			out.Content = append(out.Content, &sdkmcp.EmbeddedResource{
+				Resource: &sdkmcp.ResourceContents{
+					URI:      item.URI,
+					MIMEType: item.MIMEType,
+					Blob:     data,
+				},
+			})
 		default:
+			// An item that carries BYTES and no text must never become a text
+			// item. That is the #663 failure mode, and §15.11 forbids it: a
+			// blank text item drops the payload while reporting success. An
+			// unmapped media type is a bug in this switch, so it is reported
+			// rather than rendered as an empty item.
+			if item.Data != "" && item.Text == "" {
+				log.Printf("warning: no MCP content mapping for item type %q (mime=%q); dropping it rather than sending an empty text item",
+					item.Type, item.MIMEType)
+				continue
+			}
 			out.Content = append(out.Content, &sdkmcp.TextContent{Text: item.Text})
 		}
 	}

--- a/tests/conformance/media_content_test.go
+++ b/tests/conformance/media_content_test.go
@@ -210,7 +210,6 @@ func TestMediaContent_AudioClipReachesTheClient(t *testing.T) {
 //	go test ./tests/conformance -run TestMediaContent_VideoClipReachesTheClient
 func TestMediaContent_VideoClipReachesTheClient(t *testing.T) {
 	t.Parallel()
-	t.Skip("blocked on dirstral-spec#60: SPEC §15.11 mandates a video-typed content item, which MCP 2025-11-25 does not define (dir2mcp #663)")
 	cfg, opts, chunkID := seedMediaClipCorpus(t, "clip.mp4", "video")
 	srv := newServer(t, cfg, opts...)
 	defer srv.Close()
@@ -220,4 +219,16 @@ func TestMediaContent_VideoClipReachesTheClient(t *testing.T) {
 		t.Fatalf("structured mime_type = %#v, want video/mp4", structured["mime_type"])
 	}
 	assertClipContentCarriesBytes(t, content, "video/mp4")
+
+	// SPEC §15.11 (spec 0.49.0) names the carrier, so assert it rather than
+	// only that SOME item carried the bytes. MCP 2025-11-25 defines no `video`
+	// item, so an embedded resource is the only valid carrier; a server that
+	// invents `type: "video"` would satisfy the helper above and still be
+	// rejected by a strict client.
+	if content[0].Type != "resource" {
+		t.Fatalf("content item type = %q, want resource: MCP defines no video item, so inline video travels as an embedded resource (SPEC §15.11)", content[0].Type)
+	}
+	if content[0].Resource == nil || content[0].Resource.URI == "" {
+		t.Fatalf("embedded resource carries no uri: MCP requires one on a resource item, got %+v", content[0].Resource)
+	}
 }


### PR DESCRIPTION
Gated on dirstral-spec #89 (spec 0.49.0), now merged. This PR re-pins the submodule to it.

## The defect

`open_media_clip` on a video document reported success and returned:

```json
{"content": [{"type": "text", "text": ""}]}
```

In a real client the tool shows as succeeded and the result is blank. No player, no text, no error. Audio worked, so the failure looked arbitrary. The bytes survived only in `structuredContent.data`.

The tool layer emits an internal `video` content item. The SDK transport had no arm for it, so it fell through to `default`, which built a `TextContent` from an item that has no `Text`.

## Why this needed the spec first

There was no correct value to map it to. MCP `2025-11-25` defines `text`, `image`, `audio`, `resource_link` and `resource`. It defines no `video` item, so the old SPEC sentence ("an `audio`- or `video`-typed item") asked for something no client accepts and the SDK cannot construct: `fromWire` is unexported, so a `video` item is unreachable rather than merely wrong.

Spec 0.49.0 names an **embedded resource** carrying the blob and a `video/*` mimeType as the only valid carrier. This PR implements it.

## The change

1. **The transport maps `video` to `EmbeddedResource`** with `Blob` and `MIMEType`.
2. **The default arm is now safe.** An item that carries bytes and no text is dropped with a warning rather than rendered as an empty text item. Silently blanking a payload is the exact failure this fixes, so the next unmapped media type reports a bug instead of repeating it.
3. **`toolContentItem` gains a `URI`**, because MCP requires one on a resource item. It is set in the tool layer where `rel_path` and the span are known, in the `#t=` media-fragment form the citations already use (§5.4), rather than invented at the transport. It identifies the clip; it is not a fetchable location, since `inline` carries the bytes and only `reference` promises somewhere to fetch from.

The internal item type stays `video`. The tool layer describes what it produced; the transport owns how the protocol carries it.

## Tests

This is the test PR #827 committed **skipped** on this blocker. The skip is removed.

The assertion is also tightened beyond "some item carried the bytes":

```go
if content[0].Type != "resource" { ... }
if content[0].Resource == nil || content[0].Resource.URI == "" { ... }
```

A server that invents `type: "video"` would carry the bytes, satisfy the generic helper, and still be rejected by a strict client. The spec now names the carrier, so the test pins the carrier.

Proven against main (both source files reverted, test kept):

```
--- FAIL: TestMediaContent_VideoClipReachesTheClient
    content item is a text item (text=""): media bytes must never travel as
    text, and an empty text item drops the clip entirely
```

Audio passes on main and on this branch, unchanged.

## Scope

- Audio behavior does not change.
- `structuredContent.data` still carries the clip, per spec 0.49.0. The response therefore holds the clip twice, and `media.clip.max_bytes` bounds the CLIP rather than the response. Narrowing that is a separate client-visible decision and dirstral-spec #60 stays open for it.
- `reference` mode is unchanged.

`make check` passes.

Closes #663