### PR TITLE
fix(reindex): finish an interrupted commit, and stop a partial rollback claiming recovery (#820, #668)

### DIFF
--- a/internal/cli/reindex.go
+++ b/internal/cli/reindex.go
@@ -105,42 +105,115 @@ func (a *App) runReindex(ctx context.Context, global globalOptions, args []strin
 	// rebuild still rolls the index files back AFTER the store is closed, so a
 	// persist-on-close cannot clobber the restored generation.
 	if reindexErr == nil {
-		// Commit the index files BEFORE dropping the hash snapshot (issue #796).
-		//
-		// The two artifacts are undo records for the two halves of one change:
-		// *.reindex-old undoes the index move, the snapshot undoes the cleared
-		// content-hash gate. A crash between them decides which half recovery
-		// sees, so the order decides which way the corpus is wrong.
-		//
-		// Dropping the snapshot first left this window: hashes already say
-		// "new", the index backup still says "roll me back". recoverInterrupted-
-		// Reindex adopts that backup, so the corpus serves the PREVIOUS index
-		// generation while its hashes assert the new content is already
-		// ingested. The gate then skips those documents on every later run, so
-		// nothing re-ingests them and nothing reports it.
-		//
-		// Committing first inverts the failure. A crash in the window leaves no
-		// index backup and a snapshot that still holds the old hashes, so
-		// recovery restores hashes that under-state the corpus. The next scan
-		// re-ingests work it did not strictly need to redo (the #764 direction)
-		// and converges on its own. Redundant work is recoverable; a gate set
-		// too far ahead is not.
-		//
-		// commit() only unlinks the moved-aside backups, so running it while the
-		// store is open is safe: a persist-on-close writes the live slot, never
-		// the backup slot.
-		staging.commit(a.stderr)
-		staging.discardContentHashBackup(ctx, a.stderr)
-		a.closeStoreWithLog(st)
+		a.commitReindex(ctx, st, staging)
 	} else {
-		staging.restoreContentHashes(ctx, a.stderr)
-		a.closeStoreWithLog(st)
-		// Any non-success — a real error, ctx cancellation from Ctrl-C, or an
-		// unimplemented pipeline — means the rebuild is not durable, so put the
-		// previous index back (issue #418).
-		staging.rollback(a.stderr)
+		a.rollbackReindex(ctx, cfg, st, staging)
 	}
 	return a.finishReindex(global, reindexErr)
+}
+
+// commitReindex keeps the rebuild: it discards both undo records and closes the
+// store.
+//
+// The index files are committed BEFORE the hash snapshot is dropped (issue #796).
+//
+// The two artifacts are undo records for the two halves of one change:
+// *.reindex-old undoes the index move, the snapshot undoes the cleared
+// content-hash gate. A crash between them decides which half recovery sees, so
+// the order decides which way the corpus is wrong.
+//
+// Dropping the snapshot first left this window: hashes already say "new", the
+// index backup still says "roll me back". recoverInterruptedReindex adopts that
+// backup, so the corpus serves the PREVIOUS index generation while its hashes
+// assert the new content is already ingested. The gate then skips those
+// documents on every later run, so nothing re-ingests them and nothing reports
+// it.
+//
+// Committing first inverts the failure. A crash in the window leaves no index
+// backup and a snapshot that still holds the old hashes, so recovery restores
+// hashes that under-state the corpus. The next scan re-ingests work it did not
+// strictly need to redo (the #764 direction) and converges on its own. Redundant
+// work is recoverable; a gate set too far ahead is not.
+//
+// commit() only unlinks the moved-aside backups, so running it while the store
+// is open is safe: a persist-on-close writes the live slot, never the backup
+// slot.
+func (a *App) commitReindex(ctx context.Context, st model.Store, staging *reindexStaging) {
+	staging.commit(a.stderr)
+	staging.discardContentHashBackup(ctx, a.stderr)
+	a.closeStoreWithLog(st)
+}
+
+// rollbackReindex unwinds what the staging owns and then reports what it does
+// not own.
+//
+// Any non-success — a real error, ctx cancellation from Ctrl-C, or an
+// unimplemented pipeline — means the rebuild is not durable, so the previous
+// index generation and the content-hash gate both go back (issue #418). The
+// hashes are restored while the store is still open; the index files are
+// restored after it closes, so a persist-on-close cannot clobber them.
+//
+// The report is the second half of the fix for issue #668 and it runs last, so
+// it is the final word on the terminal.
+func (a *App) rollbackReindex(ctx context.Context, cfg config.Config, st model.Store, staging *reindexStaging) {
+	staging.restoreContentHashes(ctx, a.stderr)
+	a.closeStoreWithLog(st)
+	staging.rollback(a.stderr)
+	a.reportPartialReindexRollback(cfg)
+}
+
+// reportPartialReindexRollback states what the rollback did NOT put back.
+//
+// The staging owns two artifacts and restores both of them. It owns nothing
+// else. The rebuild runs through the ordinary ingest pipeline, which rewrites
+// documents, representations and chunks in place, and none of that is staged.
+// So the corpus after a rollback is NOT the corpus from before the run, and the
+// command used to imply that it was (issue #668).
+//
+// The decision here is to report rather than to complete the rollback. Two
+// reasons:
+//
+//   - Completing it means snapshotting the whole sqlite graph per run and giving
+//     the networked backends a generation swap they do not expose. That is a
+//     redesign of the protocol, and a "complete" rollback that is itself partial
+//     would be the same dishonesty one level up.
+//   - Most of the drift already repairs itself, and the report says which part
+//     does not. A re-ingest keeps chunk ids stable (they are keyed by
+//     representation and ordinal) and re-queues every chunk it rewrites, and the
+//     embed worker selects on that queue and never on the content hash. So the
+//     restored index and the partly rebuilt chunk graph still address each other,
+//     and the next `dir2mcp up` re-embeds exactly the chunks the failed run
+//     rewrote.
+//
+// The part that does not repair itself is extraction. The content hash is a done
+// marker that is withheld until a document's representations commit, so a
+// document the rebuild was still extracting holds no hash of its own, and the
+// rollback puts its pre-run hash back over it. The next scan then skips a
+// document whose representations are part old and part new. Only another full
+// rebuild clears that, which is why the report names one.
+func (a *App) reportPartialReindexRollback(cfg config.Config) {
+	writef(a.stderr, "warning: this rollback is partial. It restored the previous index generation and the content-hash gate. "+
+		"It did not restore the document, representation and chunk rows that the interrupted rebuild already rewrote.\n")
+	if !localIndexRollbackSupported(cfg.IndexBackend) {
+		// The networked backends keep no local index files, so there was no
+		// generation to move aside and none to put back. The rebuild did not
+		// touch the remote store either, so the previous vectors are still
+		// there; they are simply beside a chunk graph that has moved on.
+		writef(a.stderr, "warning: index.backend=%s keeps its vectors on the server. "+
+			"This rollback did not change them and it cannot restore them. "+
+			"They stay as they were until a later run re-embeds over them.\n", strings.TrimSpace(cfg.IndexBackend))
+	}
+	writef(a.stderr, "warning: the rebuild re-queued every chunk it rewrote, so the next `dir2mcp up` re-embeds those. "+
+		"A document the rebuild was still extracting keeps its restored content hash, so the next scan skips it and it stays part rebuilt.\n")
+	writef(a.stderr, "warning: run `dir2mcp reindex` again and let it finish to bring the whole corpus to one generation.\n")
+}
+
+// localIndexRollbackSupported reports whether the backend keeps an on-disk index
+// generation that the staging can move aside and put back. It reads the answer
+// off index.StaleIndexFiles rather than repeating the backend list, so the two
+// can never disagree about which backends are covered.
+func localIndexRollbackSupported(backend string) bool {
+	return len(index.StaleIndexFiles(backend)) > 0
 }
 
 // loadReindexConfig pulls the layered config and normalises the state

--- a/internal/cli/reindex.go
+++ b/internal/cli/reindex.go
@@ -129,7 +129,7 @@ func (a *App) runReindex(ctx context.Context, global globalOptions, args []strin
 		// commit() only unlinks the moved-aside backups, so running it while the
 		// store is open is safe: a persist-on-close writes the live slot, never
 		// the backup slot.
-		staging.commit()
+		staging.commit(a.stderr)
 		staging.discardContentHashBackup(ctx, a.stderr)
 		a.closeStoreWithLog(st)
 	} else {
@@ -288,6 +288,96 @@ func (s *reindexStaging) backup(name string) error {
 	return nil
 }
 
+// reindexCommitMarkerName is the durable record that a reindex reached its
+// commit point. It lives in the state directory beside the backups it describes.
+//
+// It exists because commit() is the ONE step of this protocol that ordering
+// cannot make safe (issue #820). Every other step is a single atomic operation,
+// so a crash lands either before it or after it, and #796 closed its window by
+// ordering the steps rather than by adding state. commit() is different: it is N
+// independent unlinks over a SET of backups, and the set carries no boundary.
+// After a crash the recovery scan sees the surviving subset and cannot tell
+// "three of five were already discarded" from "a rebuild staged three files and
+// died". Adopting that subset mixes one generation's text index with another's
+// code index. No ordering of the unlinks removes the ambiguity, because every
+// prefix of the removals is a legal observation and every prefix looks exactly
+// like a smaller staged set.
+//
+// So the marker states the one fact the file names cannot: the rebuild is
+// durable, therefore every *.reindex-old beside this marker is superseded and
+// must be discarded, not adopted. It is written before the first unlink and
+// removed after the last one, which makes recovery idempotent and makes an
+// interrupted commit resumable.
+const reindexCommitMarkerName = "reindex-commit"
+
+// reindexCommitMarkerBody explains the file to an operator who finds it in a
+// state directory. Nothing reads the contents: the marker's presence carries the
+// whole meaning, and the names it would list are exactly the names recovery
+// already reads off the directory.
+const reindexCommitMarkerBody = "dir2mcp: a reindex reached its commit point.\n" +
+	"Every *" + reindexBackupSuffix + " file beside this marker is a superseded index generation.\n" +
+	"The next `dir2mcp up` or `dir2mcp reindex` discards them and removes this file.\n"
+
+// writeReindexCommitMarker records that the rebuild is durable, so the backups
+// are stale rather than a rollback target.
+//
+// The contents are fsynced and so is the directory entry, because this marker is
+// only useful if it survives the crash it describes. The rest of the staging
+// protocol needs no fsync: it is built from renames, which are atomic, so a
+// crash sees one of two orderings either way.
+func writeReindexCommitMarker(stateDir string) error {
+	path := filepath.Join(stateDir, reindexCommitMarkerName)
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", path, err)
+	}
+	if _, err := f.WriteString(reindexCommitMarkerBody); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("sync %s: %w", path, err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close %s: %w", path, err)
+	}
+	return syncStateDir(stateDir)
+}
+
+// syncStateDir fsyncs a directory so a file created in it is durable by name and
+// not only by contents. Mirrors diskindex.syncDir: a platform that cannot open a
+// directory for read reports no error rather than failing an otherwise good
+// write.
+func syncStateDir(dir string) error {
+	d, err := os.Open(dir)
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = d.Close() }()
+	if err := d.Sync(); err != nil && !errors.Is(err, os.ErrInvalid) {
+		return fmt.Errorf("sync %s: %w", dir, err)
+	}
+	return nil
+}
+
+// interruptedReindex reports what the recovery pass did, so each caller can word
+// its own warning (the two commands do different things next) and can tell
+// "nothing to do" from "acted" without re-scanning.
+type interruptedReindex struct {
+	// restored names the live basenames put back from a crashed run's backups.
+	restored []string
+	// discarded names the superseded generations an interrupted commit left
+	// behind. Restoring one of these would mix index generations (issue #820).
+	discarded []string
+	// discardErr collects the superseded copies that could not be unlinked. It
+	// is reported and never fatal: a copy nothing reads is not a reason to
+	// refuse a corpus whose live generation is already correct. The marker
+	// stays, so the next run tries again, and a `reindex` in the meantime is
+	// still refused by backup() on the occupied slot.
+	discardErr error
+}
+
 // recoverInterruptedReindex finishes the rollback that a crashed reindex never
 // got to run. `reindex` calls it before staging a new generation; `up` calls it
 // before opening the corpus to serve from it (issue #764), so the two commands
@@ -308,43 +398,113 @@ func (s *reindexStaging) backup(name string) error {
 // single rename (not remove-then-rename) so a crash inside recovery itself can
 // never leave neither copy.
 //
-// Recovery failure is fatal to both callers: for `reindex` because staging would
-// then move the partial file into the recovery slot and destroy it, and for `up`
-// because the alternative is serving the partial generation, which is the bug.
+// A commit marker inverts the policy for exactly the case it names. The marker
+// says the rebuild is durable, so the backups beside it are superseded copies
+// that commit() had started to unlink, and adopting them would put an older
+// generation back over a newer one, file by file, in whatever mixture the crash
+// happened to leave (issue #820). Recovery therefore finishes the commit instead:
+// it discards those backups and clears the marker. Both halves are unlinks, so
+// this is idempotent and a crash inside it simply resumes on the next run.
 //
-// Returns the live basenames it restored so each caller can word its own warning
-// (the two commands do different things next), and so a caller can tell "nothing
-// to do" from "recovered" without re-scanning.
-func recoverInterruptedReindex(stateDir string) ([]string, error) {
+// A failure to RESTORE is fatal to both callers: for `reindex` because staging
+// would then move the partial file into the recovery slot and destroy it, and
+// for `up` because the alternative is serving the partial generation, which is
+// the bug. A failure to DISCARD is not, and finishInterruptedReindexCommit says
+// why.
+func recoverInterruptedReindex(stateDir string) (interruptedReindex, error) {
 	entries, err := os.ReadDir(stateDir)
 	if err != nil {
-		return nil, fmt.Errorf("scan state dir %s: %w", stateDir, err)
+		return interruptedReindex{}, fmt.Errorf("scan state dir %s: %w", stateDir, err)
 	}
-	var recovered []string
+	if hasReindexCommitMarker(entries) {
+		return finishInterruptedReindexCommit(stateDir, entries), nil
+	}
+	var out interruptedReindex
 	for _, entry := range entries {
-		name := entry.Name()
-		// Scan by suffix rather than iterating index.StaleIndexFiles for the
-		// configured backend: a crash under one backend can be retried under
-		// another, and the leftovers of the backend that crashed are part of
-		// the same last-known-good set.
-		if name == reindexBackupSuffix || !strings.HasSuffix(name, reindexBackupSuffix) {
+		live, ok := reindexBackupTarget(entry)
+		if !ok {
 			continue
 		}
-		// Only regular files are ours: staging produces a backup by renaming an
-		// index file, never a directory or a symlink. Renaming something of
-		// another shape into the live slot would move an unrelated path (or
-		// point the index at an arbitrary target), so leave it alone and let
-		// backup() refuse the occupied slot with its own explicit error.
-		if !entry.Type().IsRegular() {
-			continue
+		if err := os.Rename(filepath.Join(stateDir, entry.Name()), filepath.Join(stateDir, live)); err != nil {
+			return out, fmt.Errorf("restore last-known-good index %s: %w", live, err)
 		}
-		live := strings.TrimSuffix(name, reindexBackupSuffix)
-		if err := os.Rename(filepath.Join(stateDir, name), filepath.Join(stateDir, live)); err != nil {
-			return nil, fmt.Errorf("restore last-known-good index %s: %w", live, err)
-		}
-		recovered = append(recovered, live)
+		out.restored = append(out.restored, live)
 	}
-	return recovered, nil
+	return out, nil
+}
+
+// finishInterruptedReindexCommit runs the other policy: the marker says the
+// rebuild is durable, so every backup beside it is superseded and is unlinked
+// rather than adopted.
+//
+// Nothing here is fatal. The restoring half is fatal because the generation it
+// puts back is the one the caller is about to serve or stage over; this half
+// only deletes a copy that nothing reads. Refusing to start a daemon over a
+// leftover file would turn a stale copy into an outage, which is the trade #764
+// already rejected. A copy that survives keeps the marker, so the next run tries
+// again, and a `reindex` in the meantime still refuses on the occupied slot.
+func finishInterruptedReindexCommit(stateDir string, entries []os.DirEntry) interruptedReindex {
+	var out interruptedReindex
+	var failures []error
+	for _, entry := range entries {
+		live, ok := reindexBackupTarget(entry)
+		if !ok {
+			continue
+		}
+		if err := os.Remove(filepath.Join(stateDir, entry.Name())); err != nil && !errors.Is(err, os.ErrNotExist) {
+			failures = append(failures, fmt.Errorf("discard superseded index generation %s: %w", live, err))
+			continue
+		}
+		out.discarded = append(out.discarded, live)
+	}
+	if len(failures) > 0 {
+		// Keep the marker: the commit is not finished, so the next run must
+		// still read these backups as superseded rather than adopt them.
+		out.discardErr = errors.Join(failures...)
+		return out
+	}
+	// Last, so a crash before this point leaves the marker in place and the next
+	// run finishes the same work rather than adopting what is left.
+	if err := os.Remove(filepath.Join(stateDir, reindexCommitMarkerName)); err != nil && !errors.Is(err, os.ErrNotExist) {
+		out.discardErr = fmt.Errorf("clear the reindex commit marker: %w", err)
+	}
+	return out
+}
+
+// hasReindexCommitMarker reports whether the state directory holds the marker a
+// commit writes before it unlinks the first backup. Only a regular file counts,
+// for the same reason recovery skips a non-regular backup.
+func hasReindexCommitMarker(entries []os.DirEntry) bool {
+	for _, entry := range entries {
+		if entry.Name() == reindexCommitMarkerName && entry.Type().IsRegular() {
+			return true
+		}
+	}
+	return false
+}
+
+// reindexBackupTarget reports the live basename a directory entry is the moved-
+// aside copy of, and whether the entry is one of ours at all.
+//
+// Entries are matched by suffix rather than by iterating index.StaleIndexFiles
+// for the configured backend: a crash under one backend can be retried under
+// another, and the leftovers of the backend that crashed are part of the same
+// last-known-good set.
+//
+// Only regular files are ours: staging produces a backup by renaming an index
+// file, never a directory or a symlink. Renaming something of another shape into
+// the live slot would move an unrelated path (or point the index at an arbitrary
+// target), so leave it alone and let backup() refuse the occupied slot with its
+// own explicit error.
+func reindexBackupTarget(entry os.DirEntry) (string, bool) {
+	name := entry.Name()
+	if name == reindexBackupSuffix || !strings.HasSuffix(name, reindexBackupSuffix) {
+		return "", false
+	}
+	if !entry.Type().IsRegular() {
+		return "", false
+	}
+	return strings.TrimSuffix(name, reindexBackupSuffix), true
 }
 
 // restoreInterruptedReindexHashes is the store-side half of the rollback a
@@ -380,11 +540,57 @@ func restoreInterruptedReindexHashes(ctx context.Context, st model.Store) error 
 }
 
 // commit deletes the moved-aside backups after a durable rebuild.
-func (s *reindexStaging) commit() {
+//
+// The deletions are N independent unlinks and the set of backups has no boundary
+// on disk, so a crash inside the loop used to leave a subset that recovery read
+// as a rollback target and adopted: one generation's text index beside another
+// generation's code index (issue #820). A marker written before the first unlink
+// states the fact the file names cannot carry, namely that the rebuild is
+// durable, so recovery discards the survivors instead of adopting them. It is
+// removed after the last unlink, so a crash anywhere in this function leaves a
+// commit the next run finishes.
+//
+// Two degradations are deliberate, and both keep the corpus no worse than the
+// behaviour this replaces:
+//
+//   - The marker cannot be written. The unlinks still run, because NOT deleting
+//     the backups is the worse failure: the snapshot is dropped straight after
+//     this and recovery would then adopt a stale generation over hashes that
+//     already describe the new one, which is the #796 bug. So this degrades to
+//     the old, unprotected window, and it says so.
+//   - An unlink fails. The marker STAYS, so the next `up` or `reindex` discards
+//     what is left rather than adopting it.
+func (s *reindexStaging) commit(stderr io.Writer) {
+	if len(s.backups) == 0 {
+		return
+	}
+	marked := true
+	if err := writeReindexCommitMarker(s.stateDir); err != nil {
+		marked = false
+		writef(stderr, "warning: reindex commit: could not record the commit marker (%v); "+
+			"a crash while the superseded index generations are removed may leave a mixed generation behind\n", err)
+	}
+	removed := true
 	for _, name := range s.backups {
-		_ = os.Remove(filepath.Join(s.stateDir, name) + reindexBackupSuffix)
+		if err := os.Remove(filepath.Join(s.stateDir, name) + reindexBackupSuffix); err != nil && !errors.Is(err, os.ErrNotExist) {
+			removed = false
+			writef(stderr, "warning: reindex commit: discard superseded index generation %s: %v\n", name, err)
+		}
 	}
 	s.backups = nil
+	if !removed {
+		if marked {
+			writef(stderr, "warning: reindex commit: a superseded index generation is still on disk; "+
+				"the next `dir2mcp up` or `dir2mcp reindex` discards it\n")
+		}
+		return
+	}
+	// Unconditional, so a marker that was only half written (created, then
+	// failed to sync) is cleaned up too. A missing marker is the ordinary case
+	// when the write failed outright.
+	if err := os.Remove(filepath.Join(s.stateDir, reindexCommitMarkerName)); err != nil && !errors.Is(err, os.ErrNotExist) {
+		writef(stderr, "warning: reindex commit: remove the commit marker: %v\n", err)
+	}
 }
 
 // rollback restores the moved-aside index files over any partially-written
@@ -433,9 +639,19 @@ func (a *App) prepareReindexStore(ctx context.Context, global globalOptions, cfg
 			"The previous index generation is still on disk as *"+reindexBackupSuffix+" in the state directory; fix the error above and re-run `dir2mcp reindex`.")
 		return nil, nil, exitGeneric
 	}
-	if len(recovered) > 0 {
+	if len(recovered.restored) > 0 {
 		writef(a.stderr, "warning: recovered %d index file(s) left by an interrupted reindex before rebuilding: %s\n",
-			len(recovered), strings.Join(recovered, ", "))
+			len(recovered.restored), strings.Join(recovered.restored, ", "))
+	}
+	if len(recovered.discarded) > 0 {
+		writef(a.stderr, "warning: finished an interrupted reindex commit before rebuilding; discarded %d superseded index file(s): %s\n",
+			len(recovered.discarded), strings.Join(recovered.discarded, ", "))
+	}
+	if recovered.discardErr != nil {
+		// Not fatal here either: the staging below refuses an occupied backup
+		// slot with its own explicit error, so the run still stops before it can
+		// overwrite anything.
+		writef(a.stderr, "warning: could not finish an interrupted reindex commit: %v\n", recovered.discardErr)
 	}
 	st := a.storeForConfig(cfg)
 	if err := st.Init(ctx); err != nil && !errors.Is(err, model.ErrNotImplemented) {

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -758,12 +758,25 @@ func (a *App) openStateForServing(ctx context.Context, cfg *config.Config, jsonO
 			"The last-known-good index generation is still on disk as *"+reindexBackupSuffix+" in the state directory; fix the error above, then start the server again or rebuild with `dir2mcp reindex`.")
 		return nil, builtIndex{}, builtIndex{}, exitIndexLoadFailure
 	}
-	if len(recovered) > 0 {
+	if len(recovered.restored) > 0 {
 		// Loud on purpose, and durable: teeServerLog is already installed, so this
 		// reaches <state_dir>/server.log and the support bundle, which is where an
 		// operator looks after the fact to explain a rebuild that never finished.
 		writef(a.stderr, "warning: an interrupted reindex left this corpus inconsistent; restored %d last-known-good index file(s) before serving: %s\n",
-			len(recovered), strings.Join(recovered, ", "))
+			len(recovered.restored), strings.Join(recovered.restored, ", "))
+	}
+	if len(recovered.discarded) > 0 {
+		// The other half of the same repair: the rebuild WAS durable, so these
+		// copies are superseded and serving one would mix index generations (#820).
+		writef(a.stderr, "warning: an interrupted reindex commit left superseded index file(s) behind; discarded %d before serving: %s\n",
+			len(recovered.discarded), strings.Join(recovered.discarded, ", "))
+	}
+	if recovered.discardErr != nil {
+		// Reported, not fatal. The live slots already hold the durable rebuild's
+		// generation, so a copy that could not be unlinked changes nothing the
+		// server reads. Refusing to serve over it would turn a stale file into an
+		// outage, which is the trade this startup path already rejected.
+		writef(a.stderr, "warning: could not finish an interrupted reindex commit: %v\n", recovered.discardErr)
 	}
 	st, textBuilt, codeBuilt, code := a.initStoreAndIndices(ctx, cfg, jsonOutput)
 	if code != exitSuccess {

--- a/internal/index/backend.go
+++ b/internal/index/backend.go
@@ -169,8 +169,16 @@ func kindSnapshotFileName(kind string) string {
 // selected.
 func StaleIndexFiles(backend string) []string {
 	// Networked backends keep no local index files: their durability lives
-	// server-side and a reindex clears the remote store via the index's Reset
-	// (driven by EnsureIdentity), so there is nothing on disk to remove.
+	// server-side, so there is nothing on disk to move aside or remove.
+	//
+	// This function returning nil is therefore NOT a statement that a reindex
+	// rebuilds the remote store. It does not. `dir2mcp reindex` never opens an
+	// index at all: it rewrites the sqlite rows, re-queues every chunk it
+	// rewrote, and leaves the vectors to the daemon's embed worker. Reset runs
+	// only through EnsureIdentity, which resets only a fresh or incompatible
+	// index, and only `up`/`ask` call it. So a reindex under one of these
+	// backends leaves the previous generation's vectors in place until the next
+	// `dir2mcp up` re-embeds the queued chunks over them (issue #668).
 	switch strings.ToLower(strings.TrimSpace(backend)) {
 	case BackendQdrant, BackendPgvector:
 		return nil

--- a/tests/cli/reindex_commit_atomicity_820_test.go
+++ b/tests/cli/reindex_commit_atomicity_820_test.go
@@ -1,0 +1,227 @@
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// Reindex commit atomicity: dir2mcp #820.
+//
+// commit() unlinks the moved-aside generations one by one. The set of backups
+// carries no boundary on disk, so a crash inside that loop leaves a SUBSET, and
+// the recovery scan cannot tell "two of three were already discarded" from "a
+// rebuild staged two files and died". It adopted the survivors, which put one
+// generation's code index back beside another generation's text index.
+//
+// Ordering cannot close this window. Every prefix of the removals is a legal
+// observation, and every prefix looks exactly like a smaller staged set. So the
+// commit now writes a marker before the first unlink and removes it after the
+// last one. The marker states the fact the file names cannot carry: the rebuild
+// is durable, therefore every backup beside it is superseded.
+//
+// The crash is seeded the way the #727 suite seeds one, by leaving the
+// interrupted run's artifacts in place and never calling commit or rollback,
+// which is exactly what a crash does. The seed follows the real staging order
+// step by step, because a helper that diverged from it once produced a CI
+// failure that read as a flake (#825).
+
+const (
+	// reindexCommitMarkerFile mirrors reindexCommitMarkerName in internal/cli,
+	// which is unexported. Spelled out here for the same reason
+	// crashBackupSuffix is: the on-disk name is part of what an interrupted
+	// corpus looks like to an operator, so this suite should notice if it
+	// silently changes.
+	reindexCommitMarkerFile = "reindex-commit"
+	// crashRebuiltHash is the content_hash the durable rebuild stamped before
+	// the process was killed inside commit().
+	crashRebuiltHash = "HASH-AFTER-DURABLE-REBUILD"
+)
+
+// stagedIndexGeneration names the index files this suite seeds and stages. Both
+// names come from the package that owns them, so a rename cannot leave the test
+// staging nothing and passing green.
+func stagedIndexGeneration() []string {
+	return []string{index.TextIndexFileName, index.CodeIndexFileName}
+}
+
+// supersededBytes is the content of the generation the durable rebuild replaced.
+// One value per file, so a test can say WHICH slot was rolled back.
+func supersededBytes(name string) string { return crashGoodIndex + "/" + name }
+
+// seedCrashedReindexCommit lays down the state a reindex leaves when it is
+// killed INSIDE commit(). It walks the real protocol in order:
+//
+//  1. the corpus before the run: a complete index generation and a document
+//     whose content_hash describes it;
+//  2. staging, as prepareReindexStore does it: recover, snapshot the hashes,
+//     clear them, then move each live index file aside with an atomic rename;
+//  3. the rebuild, which succeeds: the sqlite rows carry fresh content hashes.
+//     The live index slots stay EMPTY on purpose, because `reindex` rebuilds the
+//     rows and leaves the vectors to the daemon's embed worker;
+//  4. commit(), which writes the marker and then unlinks. The process dies after
+//     the FIRST unlink, so the text generation is gone and the code generation is
+//     still in its backup slot.
+//
+// The content-hash snapshot is deliberately left in place: #796 drops it only
+// after commit returns, so a partial commit always keeps it.
+func seedCrashedReindexCommit(t *testing.T, stateDir, relPath string) {
+	t.Helper()
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	for _, name := range stagedIndexGeneration() {
+		if err := os.WriteFile(filepath.Join(stateDir, name), []byte(supersededBytes(name)), 0o600); err != nil {
+			t.Fatalf("seed index generation %s: %v", name, err)
+		}
+	}
+	seedDocumentHash(t, stateDir, relPath, crashGoodHash)
+
+	crashHashStateFromCurrent(t, stateDir)
+	for _, name := range stagedIndexGeneration() {
+		live := filepath.Join(stateDir, name)
+		if err := os.Rename(live, live+crashBackupSuffix); err != nil {
+			t.Fatalf("stage %s: %v", name, err)
+		}
+	}
+
+	seedDocumentHash(t, stateDir, relPath, crashRebuiltHash)
+
+	if err := os.WriteFile(filepath.Join(stateDir, reindexCommitMarkerFile),
+		[]byte("dir2mcp: a reindex reached its commit point.\n"), 0o600); err != nil {
+		t.Fatalf("seed commit marker: %v", err)
+	}
+	first := filepath.Join(stateDir, index.TextIndexFileName+crashBackupSuffix)
+	if err := os.Remove(first); err != nil {
+		t.Fatalf("seed the first unlink of commit(): %v", err)
+	}
+}
+
+// liveIndexContent returns the bytes in a live index slot, or "" when the slot
+// is empty. An empty slot is the normal end state of a `reindex`: the rows are
+// rebuilt and the embed worker writes the vectors afterwards.
+func liveIndexContent(t *testing.T, stateDir, name string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(stateDir, name))
+	if os.IsNotExist(err) {
+		return ""
+	}
+	if err != nil {
+		t.Fatalf("read live index %s: %v", name, err)
+	}
+	return string(data)
+}
+
+// assertCommitFinished states the end condition of an interrupted commit: no
+// superseded generation is live, no backup survives, and the marker is gone.
+func assertCommitFinished(t *testing.T, stateDir, stderr string) {
+	t.Helper()
+	for _, name := range stagedIndexGeneration() {
+		if got := liveIndexContent(t, stateDir, name); got == supersededBytes(name) {
+			t.Errorf("%s holds the superseded generation %q: an interrupted commit was read as a rollback target, so this corpus now mixes index generations (#820)", name, got)
+		}
+	}
+	if left := indexBackupsIn(stateDir); len(left) != 0 {
+		t.Errorf("an interrupted commit must be finished, not adopted; %v are still on disk", left)
+	}
+	if _, err := os.Stat(filepath.Join(stateDir, reindexCommitMarkerFile)); !os.IsNotExist(err) {
+		t.Errorf("the commit marker must be cleared once the commit is finished; stat err=%v", err)
+	}
+	// "discarded" as well as the name: a warning that merely NAMES the file is
+	// also what the adopt path prints, so the wording is what separates
+	// "finished the commit" from "rolled the corpus back".
+	if !strings.Contains(stderr, "discarded") || !strings.Contains(stderr, index.CodeIndexFileName) {
+		t.Errorf("the operator must be told which superseded generation was discarded; stderr=%q", stderr)
+	}
+}
+
+// TestReindex_AfterCrashedCommit_DiscardsTheSupersededGeneration is the #820
+// regression on the `reindex` side. The next run must finish the commit the
+// crashed run started. Adopting what is left puts the previous CODE index back
+// beside the new TEXT slot, and both then describe different chunk graphs.
+//
+// The retry fails on purpose. A failing retry rolls back whatever it staged, so
+// what is live at the end is exactly what recovery decided, with nothing written
+// over it by a fresh rebuild.
+func TestReindex_AfterCrashedCommit_DiscardsTheSupersededGeneration(t *testing.T) {
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, ".dir2mcp")
+	const relPath = "docs/a.md"
+	seedCrashedReindexCommit(t, stateDir, relPath)
+
+	code, stderr := runReindexInDir(t, tmp, func(config.Config, model.Store) (model.Ingestor, error) {
+		return reindexFailingIngestor{}, nil
+	})
+	if code == 0 {
+		t.Fatalf("reindex should fail when the ingestor errors; got exit 0 stderr=%q", stderr)
+	}
+	assertCommitFinished(t, stateDir, stderr)
+	// The snapshot outlives the commit by design (#796), so recovery restores it.
+	// The gate then UNDER-states the corpus and the next scan redoes work it did
+	// not strictly need to redo, which is the recoverable direction.
+	if got := readDocumentHash(t, stateDir, relPath); got != crashGoodHash {
+		t.Errorf("the content-hash snapshot must still be restored after an interrupted commit; want %q got %q", crashGoodHash, got)
+	}
+}
+
+// TestUp_AfterCrashedCommit_DoesNotServeTheSupersededGeneration asks the
+// question the issue is really about: not which files are on disk afterwards,
+// but which generation the daemon opened to serve from. A daemon that adopts a
+// superseded backup answers from an index whose vectors key chunk rows the
+// durable rebuild already replaced.
+func TestUp_AfterCrashedCommit_DoesNotServeTheSupersededGeneration(t *testing.T) {
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, ".dir2mcp")
+	const relPath = "docs/a.md"
+	seedCrashedReindexCommit(t, stateDir, relPath)
+
+	code, stderr, indices := upStartupProbe(t, tmp)
+	if code != 0 {
+		t.Fatalf("up should start after finishing an interrupted reindex commit; got exit %d stderr=%q", code, stderr)
+	}
+	for _, kind := range []string{index.KindText, index.KindCode} {
+		ix := indices[kind]
+		if ix == nil {
+			t.Fatalf("no %s index was built; stderr=%q", kind, stderr)
+		}
+		name := indexFileNameForKind(kind)
+		if got := ix.loadedString(); got == supersededBytes(name) {
+			t.Errorf("the daemon served the superseded %s generation %q; the durable rebuild's rows no longer match it (#820)", kind, got)
+		}
+	}
+	assertCommitFinished(t, stateDir, stderr)
+}
+
+// TestReindex_SuccessfulRun_LeavesNoCommitMarker is the guard on the other side:
+// the marker is transient. A marker that outlives its commit would make the next
+// recovery discard a generation that is a genuine rollback target, which is the
+// #727 destruction with a new cause.
+func TestReindex_SuccessfulRun_LeavesNoCommitMarker(t *testing.T) {
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, ".dir2mcp")
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	const relPath = "docs/a.md"
+	const rebuilt = "HASH-AFTER-REBUILD"
+	seedDocumentHash(t, stateDir, relPath, "HASH-BEFORE-REINDEX")
+	seedIndexGeneration(t, stateDir)
+
+	code, stderr := runReindexInDir(t, tmp, func(_ config.Config, st model.Store) (model.Ingestor, error) {
+		return reindexRebuildingIngestor{st: st, relPath: relPath, newHash: rebuilt}, nil
+	})
+	if code != 0 {
+		t.Fatalf("reindex should succeed; got exit %d stderr=%q", code, stderr)
+	}
+	if _, err := os.Stat(filepath.Join(stateDir, reindexCommitMarkerFile)); !os.IsNotExist(err) {
+		t.Errorf("a committed reindex must remove its commit marker; stat err=%v", err)
+	}
+	if left := indexBackupsIn(stateDir); len(left) != 0 {
+		t.Errorf("a committed reindex must leave no backup behind; got %v", left)
+	}
+}

--- a/tests/cli/reindex_partial_rollback_668_test.go
+++ b/tests/cli/reindex_partial_rollback_668_test.go
@@ -1,0 +1,189 @@
+package tests
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// Partial reindex rollback: dir2mcp #668.
+//
+// The staging owns two artifacts and restores both of them: the on-disk index
+// generation and the content-hash gate. It owns nothing else. The rebuild runs
+// through the ordinary ingest pipeline, which rewrites documents,
+// representations and chunks IN PLACE, and none of that is staged. So the corpus
+// after a rollback is not the corpus from before the run, and the command used
+// to imply that it was.
+//
+// The fix reports rather than completes. Completing the rollback means
+// snapshotting the whole sqlite graph per run and giving the networked backends
+// a generation swap they do not expose. A rollback that restores only some of
+// what changed is worse than one that says what it could not restore.
+//
+// These tests pin the report, because the report IS the fix.
+
+// rollbackReportPhrases are the claims the report must carry on every backend:
+// that it is partial, which rows it did not restore, and what the operator does
+// next.
+var rollbackReportPhrases = []string{
+	"this rollback is partial",
+	"did not restore the document, representation and chunk rows",
+	"run `dir2mcp reindex` again",
+}
+
+// reindexUnbuildableIngestor stands in for a rebuild that never STARTS: the
+// ingestor itself fails to construct. Nothing is rewritten in that case, so the
+// rollback really is complete and must not claim otherwise.
+func reindexUnbuildableIngestor(config.Config, model.Store) (model.Ingestor, error) {
+	return nil, errors.New("forced ingestor construction failure")
+}
+
+// writeBackendConfig points the corpus at a vector-index backend. The networked
+// backends never keep a local index file, so a rollback has nothing to put back
+// for them. The endpoint is never contacted: `reindex` opens no index at all, so
+// it only has to satisfy config validation.
+func writeBackendConfig(t *testing.T, tmp, backend string) {
+	t.Helper()
+	lines := []string{"index_backend: " + backend}
+	if backend == "qdrant" {
+		lines = append(lines,
+			"index:",
+			"  qdrant:",
+			"    url: http://qdrant.invalid:6334",
+			"    collection: docs",
+		)
+	}
+	body := strings.Join(lines, "\n") + "\n"
+	if err := os.WriteFile(filepath.Join(tmp, ".dir2mcp.yaml"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}
+
+func assertRollbackReport(t *testing.T, stderr string) {
+	t.Helper()
+	for _, phrase := range rollbackReportPhrases {
+		if !strings.Contains(stderr, phrase) {
+			t.Errorf("a failed reindex must say what its rollback could not restore; stderr is missing %q\nstderr=%q", phrase, stderr)
+		}
+	}
+}
+
+// TestReindex_FailedRebuild_ReportsWhatTheRollbackDidNotRestore is the core #668
+// regression on a backend that DOES keep a local index generation. Both staged
+// artifacts go back, and the command must still say that the metadata rows did
+// not.
+func TestReindex_FailedRebuild_ReportsWhatTheRollbackDidNotRestore(t *testing.T) {
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, ".dir2mcp")
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	const relPath = "docs/a.md"
+	seedDocumentHash(t, stateDir, relPath, "HASH-BEFORE-REINDEX")
+	seedIndexGeneration(t, stateDir)
+
+	code, stderr := runReindexInDir(t, tmp, func(config.Config, model.Store) (model.Ingestor, error) {
+		return reindexFailingIngestor{}, nil
+	})
+	if code == 0 {
+		t.Fatalf("reindex should fail when the ingestor errors; got exit 0 stderr=%q", stderr)
+	}
+	assertRollbackReport(t, stderr)
+	// The rollback still does its own half, so the report is an addition to the
+	// #418 behaviour and not a replacement for it.
+	if got := readDocumentHash(t, stateDir, relPath); got != "HASH-BEFORE-REINDEX" {
+		t.Errorf("the content-hash gate must still be restored; want %q got %q", "HASH-BEFORE-REINDEX", got)
+	}
+	// The server-side sentence belongs to the networked backends only. On a
+	// local backend the index generation WAS restored, so claiming otherwise
+	// would be the opposite dishonesty.
+	if strings.Contains(stderr, "keeps its vectors on the server") {
+		t.Errorf("a local backend restored its index generation, so the report must not claim a server-side one; stderr=%q", stderr)
+	}
+}
+
+// TestReindex_FailedRebuild_NetworkedBackend_ReportsTheUnrollbackableIndex
+// covers the half of #668 the issue leads with. A networked backend keeps no
+// local index file, so `index.StaleIndexFiles` stages nothing and the rollback
+// has no generation to put back. The corpus is left with vectors from before the
+// run beside a chunk graph that has moved on, and only the report says so.
+func TestReindex_FailedRebuild_NetworkedBackend_ReportsTheUnrollbackableIndex(t *testing.T) {
+	for _, backend := range []string{"qdrant", "pgvector"} {
+		t.Run(backend, func(t *testing.T) {
+			tmp := t.TempDir()
+			stateDir := filepath.Join(tmp, ".dir2mcp")
+			if err := os.MkdirAll(stateDir, 0o700); err != nil {
+				t.Fatalf("mkdir state dir: %v", err)
+			}
+			writeBackendConfig(t, tmp, backend)
+			seedDocumentHash(t, stateDir, "docs/a.md", "HASH-BEFORE-REINDEX")
+
+			code, stderr := runReindexInDir(t, tmp, func(config.Config, model.Store) (model.Ingestor, error) {
+				return reindexFailingIngestor{}, nil
+			})
+			if code == 0 {
+				t.Fatalf("reindex should fail when the ingestor errors; got exit 0 stderr=%q", stderr)
+			}
+			assertRollbackReport(t, stderr)
+			if !strings.Contains(stderr, "keeps its vectors on the server") || !strings.Contains(stderr, backend) {
+				t.Errorf("%s keeps no local index generation, so the rollback must say it could not restore one; stderr=%q", backend, stderr)
+			}
+		})
+	}
+}
+
+// TestReindex_SuccessfulRebuild_ReportsNoPartialRollback is a guard. The report
+// is about a rollback, so a run that committed must not print it. A warning that
+// appears on a healthy run is a warning operators learn to ignore.
+func TestReindex_SuccessfulRebuild_ReportsNoPartialRollback(t *testing.T) {
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, ".dir2mcp")
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	const relPath = "docs/a.md"
+	seedDocumentHash(t, stateDir, relPath, "HASH-BEFORE-REINDEX")
+	seedIndexGeneration(t, stateDir)
+
+	code, stderr := runReindexInDir(t, tmp, func(_ config.Config, st model.Store) (model.Ingestor, error) {
+		return reindexRebuildingIngestor{st: st, relPath: relPath, newHash: "HASH-AFTER-REBUILD"}, nil
+	})
+	if code != 0 {
+		t.Fatalf("reindex should succeed; got exit %d stderr=%q", code, stderr)
+	}
+	if strings.Contains(stderr, "this rollback is partial") {
+		t.Errorf("a committed reindex rolled nothing back, so it must not report a partial rollback; stderr=%q", stderr)
+	}
+}
+
+// TestReindex_UnbuiltIngestor_ReportsNoPartialRollback draws the other boundary.
+// When the ingestor cannot even be constructed the rebuild never runs, so no row
+// was rewritten and the rollback IS complete. Reporting a partial rollback there
+// would make the message untrue in the opposite direction.
+func TestReindex_UnbuiltIngestor_ReportsNoPartialRollback(t *testing.T) {
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, ".dir2mcp")
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	const relPath = "docs/a.md"
+	const original = "HASH-BEFORE-REINDEX"
+	seedDocumentHash(t, stateDir, relPath, original)
+	seedIndexGeneration(t, stateDir)
+
+	code, stderr := runReindexInDir(t, tmp, reindexUnbuildableIngestor)
+	if code == 0 {
+		t.Fatalf("reindex should fail when the ingestor cannot be built; got exit 0 stderr=%q", stderr)
+	}
+	if strings.Contains(stderr, "this rollback is partial") {
+		t.Errorf("no rebuild ran, so nothing was left unrestored; stderr=%q", stderr)
+	}
+	if got := readDocumentHash(t, stateDir, relPath); got != original {
+		t.Errorf("the content-hash gate must be restored when the rebuild never started; want %q got %q", original, got)
+	}
+}


### PR DESCRIPTION
Two gaps in one protocol, in two commits.

- **#820** is the last crash window in the staging protocol: `commit()` is N unlinks over a set that has no boundary on disk.
- **#668** is the boundary of the protocol itself: the rollback restores everything it staged, and it staged only two of the things the run changes.

## 1. #820: the window ordering cannot close

`commit()` unlinks each moved-aside generation on its own. The set carries no
boundary, so a crash inside the loop leaves a subset. The recovery scan sees the
survivors and cannot tell "two of three were already discarded" from "a rebuild
staged two files and died". It adopted them. That put one generation's code
index back beside another generation's text index.

**#819 asked for ordering first, and I checked that first.** Ordering cannot
close this one, and the reason is structural rather than a matter of effort.
#796 ordered two steps that are each atomic, so a crash lands either before a
step or after it. `commit()` is not atomic. Every prefix of the removals is a
legal observation, and every prefix looks exactly like a smaller staged set. No
permutation of the unlinks changes that.

So this takes option 1 from the issue, with the smallest form of it. #819's
argument against a marker was that `commit()` installs nothing and only deletes
a stale copy. That argument is about what `commit()` writes, and it still holds:
the marker installs no generation. It records one fact that the file names
cannot carry, which is that the rebuild is durable, so every `*.reindex-old`
beside the marker is superseded rather than a rollback target.

- Written before the first unlink, fsynced, with the directory entry fsynced.
- Removed after the last unlink.
- Recovery, shared by `up` and `reindex` per #764, discards the backups it names
  and then clears it. Both halves are unlinks, so recovery is idempotent and a
  crash inside recovery resumes on the next run.

I did not take option 2 (fault injection after each removal). It needs a
production seam that exists only for the test, and the state a crashed commit
leaves is seedable from outside the process, exactly as the #727 suite seeds a
crashed rebuild.

## 2. Crash-point table

Every point in the protocol, what it leaves, and what the next `up` or `reindex`
does with it. `X` is an index basename. "snapshot" is `_reindex_hash_backup`.

### Success path

| # | crash point | on disk / in sqlite | next run | verdict |
|---|---|---|---|---|
| 1 | during the rebuild | full backup set, no marker, snapshot present | adopts the backups, restores the hashes | correct: the pre-run corpus |
| 2 | inside `commit()`, between two unlinks | **subset** of backups, **marker present**, snapshot present | discards the survivors, clears the marker, restores the hashes | correct generation everywhere; the gate under-states, so the next scan redoes some work (**this PR**; used to be a mixed generation) |
| 3 | after the last unlink, before the marker is removed | no backups, marker present, snapshot present | clears the marker, restores the hashes | correct, same end state as row 2 |
| 4 | after the marker is removed, before the snapshot is dropped | no backups, no marker, snapshot present | restores the hashes | self-correcting: the gate under-states (the window #796 chose on purpose) |
| 5 | after the snapshot is dropped | nothing staged | nothing to do | correct: the run is complete |

### Failure and interruption path

| # | crash point | on disk / in sqlite | next run | verdict |
|---|---|---|---|---|
| 6 | after the hashes are restored, before `rollback()` | full backup set, no marker, no snapshot | adopts the backups | correct: index and hashes both pre-run |
| 7 | inside `rollback()`, between two renames | some slots restored, the rest still in backup, no marker | adopts the rest | correct: each restore is one atomic rename |

### Degradations inside `commit()` itself

| # | condition | what happens | verdict |
|---|---|---|---|
| 8 | the marker cannot be written | the unlinks still run, and the command warns | no worse than before this PR. Skipping the unlinks is the worse failure: the snapshot is dropped straight after, so recovery would adopt a stale generation over hashes that already describe the new one, which is #796 |
| 9 | an unlink fails | the marker **stays** and the command warns | self-correcting: the next `up` or `reindex` finishes the commit, and a `reindex` before that is refused by `backup()` on the occupied slot |

A failure to discard is reported and never fatal, in `up` as well. The live slots
already hold the durable rebuild's generation, so a copy that could not be
unlinked changes nothing the server reads. Refusing to serve over it would turn a
stale file into an outage, which is the trade #764 rejected.

## 3. #668: complete the rollback, or say it cannot

The issue is right that the rollback is partial. The staging owns two artifacts
and restores both. It owns nothing else. The rebuild runs through the ordinary
ingest pipeline, which rewrites documents, representations and chunks in place.

**Decision: report, do not complete.** Two reasons, and the second one is why
this is not a cop-out.

**Completing it is a redesign.** It needs a per-run snapshot of the whole sqlite
graph plus a generation swap the networked backends do not expose. A "complete"
rollback that is itself partial would be the same dishonesty one level up.

**Most of the drift already repairs itself, and the report names the part that
does not.** I traced this rather than assumed it:

- Chunk ids are stable across a re-ingest. They are keyed by
  `UNIQUE(rep_id, ordinal)` and the row is updated in place
  (`internal/store/sqlite_store.go`), so the restored index and the partly
  rebuilt chunk graph still address each other.
- The re-ingest sets `embedding_status='pending'` on every chunk it rewrites
  (`internal/ingest/represent.go`).
- The embed worker selects on `embedding_status` and **never** on
  `documents.content_hash` (`nextPendingQuery`, `internal/store/sqlite_store.go`).

So the next `dir2mcp up` re-embeds exactly the chunks the failed run rewrote.
The exception is extraction. `content_hash` is a done marker that is withheld
until a document's representations commit (#402), so a document the rebuild was
still extracting holds no hash of its own and the rollback puts its pre-run hash
back over it. The next scan then skips a document whose representations are part
old and part new. Only another full rebuild clears that, so the report names one.

I did **not** take "refuse to run the reindex at all". `reindex` is the command
an operator runs to recover, and #727 already settled that refusing it wedges
the recovery path.

### The remote half, and a comment that was not true

`StaleIndexFiles` said a reindex clears the remote store "via the index's Reset
(driven by EnsureIdentity)". That is where the issue's "a remote backend can be
empty or half rebuilt" comes from, and it is wrong:

- `dir2mcp reindex` never opens an index. `ingest.NewService` takes no
  `model.Index`, and the whole command only renames local index files aside.
- `EnsureIdentity` resets only a fresh or incompatible index
  (`internal/index/persistence.go`), and only `up` and `ask` call it.

So a failed reindex leaves the remote vectors exactly as they were. They are not
half rebuilt; they are simply beside a chunk graph that has moved on, which is
the same position the restored local index is in. The comment is corrected, and
the rollback report says the server-side generation was not changed and cannot be
restored.

### What the operator now sees

```
warning: this rollback is partial. It restored the previous index generation and the content-hash gate. It did not restore the document, representation and chunk rows that the interrupted rebuild already rewrote.
warning: the rebuild re-queued every chunk it rewrote, so the next `dir2mcp up` re-embeds those. A document the rebuild was still extracting keeps its restored content hash, so the next scan skips it and it stays part rebuilt.
warning: run `dir2mcp reindex` again and let it finish to bring the whole corpus to one generation.
```

The report runs only after a rebuild that started. When the ingestor itself fails
to construct, no row was rewritten and the rollback really is complete, so the
report would be untrue in the other direction. A cancellation (Ctrl-C) takes the
same path as an error, so it reports the same thing.

## 4. Tests

Both suites live under `tests/cli`, so no `tests/security/cli_boundary_test.go`
allowlist entry is needed and no file was added under `internal/cli/`.

`tests/cli/reindex_commit_atomicity_820_test.go`. The crash is seeded the way the
#727 suite seeds one, by leaving the interrupted run's artifacts in place and
never calling commit or rollback. The seed walks the real staging order step by
step (recover, snapshot, clear, rename aside, rebuild, marker, first unlink),
because a helper that diverged from it once produced a CI failure that read as a
flake (#825). The live index slots stay empty on purpose: `reindex` rebuilds the
rows and leaves the vectors to the embed worker.

- `TestReindex_AfterCrashedCommit_DiscardsTheSupersededGeneration`
- `TestUp_AfterCrashedCommit_DoesNotServeTheSupersededGeneration` uses the #764
  recording index, so it asserts which generation the daemon **opened to serve
  from**, not only which files are on disk.
- `TestReindex_SuccessfulRun_LeavesNoCommitMarker` is the guard on the other
  side: a marker that outlives its commit would make the next recovery discard a
  genuine rollback target, which is the #727 destruction with a new cause.

`tests/cli/reindex_partial_rollback_668_test.go`.

- `TestReindex_FailedRebuild_ReportsWhatTheRollbackDidNotRestore`
- `TestReindex_FailedRebuild_NetworkedBackend_ReportsTheUnrollbackableIndex`
  (qdrant and pgvector)
- `TestReindex_SuccessfulRebuild_ReportsNoPartialRollback` (guard)
- `TestReindex_UnbuiltIngestor_ReportsNoPartialRollback` (guard: the rebuild
  never ran, so the rollback is complete)

**Proof they fail on main.** By the copy-aside method, never `git stash`, since
`refs/stash` is shared across worktrees here.

#820, with `internal/cli/{reindex,up}.go` from `main`:

```
--- FAIL: TestReindex_AfterCrashedCommit_DiscardsTheSupersededGeneration
    vectors_code.v2.hnsw holds the superseded generation
    "LAST-KNOWN-GOOD-INDEX/vectors_code.v2.hnsw": an interrupted commit was read
    as a rollback target, so this corpus now mixes index generations (#820)
    the commit marker must be cleared once the commit is finished; stat err=<nil>
--- FAIL: TestUp_AfterCrashedCommit_DoesNotServeTheSupersededGeneration
    the daemon served the superseded code generation
    "LAST-KNOWN-GOOD-INDEX/vectors_code.v2.hnsw"; the durable rebuild's rows no
    longer match it (#820)
```

#668, same method:

```
--- FAIL: TestReindex_FailedRebuild_ReportsWhatTheRollbackDidNotRestore
    stderr is missing "this rollback is partial"
        stderr="reindex failed: forced reindex failure\n"
    stderr is missing "did not restore the document, representation and chunk rows"
    stderr is missing "run `dir2mcp reindex` again"
--- FAIL: TestReindex_FailedRebuild_NetworkedBackend_.../qdrant
    qdrant keeps no local index generation, so the rollback must say it could not
    restore one; stderr="reindex failed: forced reindex failure\n"
```

Both guards pass on `main`, by design. All pass with the fix.

## 5. Spec

No spec change, and I re-checked rather than trusting #819. The SPEC has no
mention of the backup suffix, the hash snapshot, the staging order, or crash
recovery for reindex: `grep -i "reindex-old|reindex_hash|hash snapshot|
last-known-good|staging|rollback" dirstral-spec/docs/SPEC.md` returns nothing,
and §2.1 says only "`dir2mcp reindex` Force full rebuild". The submodule pin is
unchanged. Nothing here alters a tool, CLI or error contract; the only
user-visible additions are stderr warnings, which `teeServerLog` already mirrors
into `<state_dir>/server.log` and the support bundle.

## 6. Not fixed here

- **The extraction half of #668.** A document the failed run was still extracting
  keeps its restored pre-run hash, so the next scan skips it. Fixing it needs a
  per-representation record of what the run touched, which is the "complete the
  rollback" direction this PR argues against. It is reported instead.
- **Orphan vectors on a networked backend after a SUCCESSFUL reindex.** Nothing
  clears the remote store, so vectors of chunks that no longer exist survive a
  full rebuild. The read-time tombstone prune (#409) hides them. That is a
  separate bug from the rollback this issue is about, and it is present with or
  without a failure. Happy to file it.
- **A test for the failed-unlink degradation (row 9).** It needs an undeletable
  file, which is not portable. The behaviour is documented at the call site.

`make check` passes, including `gocyclo -over 15`: `runReindex` is 14,
`prepareReindexStore` 13, `runUp` unchanged at 15.

Closes #668
Closes #820
