### PR TITLE
test(reindex): report stderr when the crash loop loses its hashes (#807)

### DIFF
--- a/tests/cli/reindex_backup_preservation_727_test.go
+++ b/tests/cli/reindex_backup_preservation_727_test.go
@@ -233,10 +233,17 @@ func TestReindex_AfterCrash_RepeatedCrashesDoNotRotatePartialState(t *testing.T)
 			t.Fatalf("attempt %d: reindex should fail when the ingestor errors; stderr=%q", attempt, stderr)
 		}
 		if got := readFileString(t, live); got != crashGoodIndex {
-			t.Fatalf("attempt %d: live index must still be the last-known-good generation; want %q got %q", attempt, crashGoodIndex, got)
+			t.Fatalf("attempt %d: live index must still be the last-known-good generation; want %q got %q; stderr=%q",
+				attempt, crashGoodIndex, got, stderr)
 		}
+		// stderr is part of the assertion, not decoration. The rollback names
+		// which of the two #811 sentinels it hit when a restore puts nothing
+		// back, so an empty hash here reads as "the snapshot was absent" or
+		// "the snapshot held no rows" rather than an unexplained blank. Issue
+		// #807 was mis-filed as a flaky test twice for exactly that reason.
 		if got := readDocumentHash(t, stateDir, relPath); got != crashGoodHash {
-			t.Fatalf("attempt %d: content_hash must still be the pre-crash snapshot; want %q got %q", attempt, crashGoodHash, got)
+			t.Fatalf("attempt %d: content_hash must still be the pre-crash snapshot; want %q got %q; stderr=%q",
+				attempt, crashGoodHash, got, stderr)
 		}
 	}
 }


### PR DESCRIPTION
The `race` job failed on PR #834 with:

```
attempt 2: content_hash must still be the pre-crash snapshot;
want "HASH-BEFORE-CRASHED-REINDEX" got ""
```

## It is not #834's fault

#834 changes `internal/mcp` only, plus the submodule pin and a conformance test. It cannot reach the reindex content hashes. This is **#807 recurring**, and it is now showing its ORIGINAL symptom rather than the seed problem PR #825 fixed.

That is progress of a sort: the seed noise is gone, so the underlying bug is visible again.

## The problem with the report

The assertion could not say WHY the hash was empty.

PR #811 made the rollback name which of its two sentinels it hit when a restore puts nothing back:

```go
case errors.Is(err, store.ErrNoContentHashSnapshot), errors.Is(err, store.ErrEmptyContentHashSnapshot):
    writef(stderr, "warning: reindex rollback: the content-hash snapshot did not restore (%v); ...")
```

The test already held `stderr` and threw it away on this path. So the CI log showed a blank hash with no cause, which is exactly how #807 got mis-filed as a flaky test twice.

## The change

Both assertions in the loop now carry `stderr`. The next occurrence distinguishes:

- **snapshot absent** (`ErrNoContentHashSnapshot`): the seed never staged one, so the fault is upstream of the restore.
- **snapshot empty** (`ErrEmptyContentHashSnapshot`): the restore ran and found no rows.
- **no warning at all**: the restore reported success and still left a blank hash, which would point at the snapshot's CONTENTS rather than the restore.

Those three need different fixes, and today they are indistinguishable.

## What this does not do

**It does not fix #807.** I could not reproduce the failure locally: 9 runs under `-race`, alone and with the whole reindex suite, all pass. The cause is still open and #807 stays open.

I traced the paths and could not prove a mechanism, so I am not shipping a guessed fix. The candidates I ruled out are that the crash seed diverges from the real staging order (PR #825 fixed that, and the symptom has changed since), and that the restore is cancellable (PR #811's second commit fixed that on both paths).

No product code changes.

`make check` passes.