### PR TITLE
fix(config): reject an mcp_path that panics the server (#653)

### DIFF
--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -451,10 +451,11 @@ func (a *App) validateUpConfig(cfg *config.Config, opts upOptions) int {
 			return code
 		}
 	}
-	if !strings.HasPrefix(cfg.MCPPath, "/") {
-		writeCLIError(a.stderr, opts.jsonOutput, exitConfigInvalid, "CONFIG_INVALID: --mcp-path must start with '/'")
-		return exitConfigInvalid
-	}
+	// The mcp_path grammar is checked by cfg.Validate() above, which every entry
+	// point runs (persisted config, this flag overlay, and `config set`). The
+	// leading-slash check that used to live here was only reachable before that
+	// gate existed; keeping it would be dead code claiming to be a safety net
+	// (issue #653).
 	strictX402 := strings.EqualFold(strings.TrimSpace(cfg.X402.Mode), "required")
 	if err := cfg.ValidateX402(strictX402); err != nil {
 		writeCLIError(a.stderr, opts.jsonOutput, exitConfigInvalid, fmt.Sprintf("x402 configuration invalid: %v", err))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/dirstral/dir2mcp/internal/corpusfs"
 	"github.com/dirstral/dir2mcp/internal/netutil"
@@ -4651,10 +4652,28 @@ func (c *Config) Validate() error {
 // Each rejected character is rejected for its own reason, named in the error, so
 // an operator can fix the value rather than guess at a grammar.
 func (c *Config) validateMCPPath() error {
-	path := strings.TrimSpace(c.MCPPath)
+	// The value is checked UNTRIMMED, because the server registers it untrimmed.
+	// An earlier version of this gate validated a trimmed copy, so "/mcp " passed
+	// and then panicked at registration: ServeMux reads a space as the separator
+	// before the path, so "/mcp " parses as the METHOD "/mcp" with no path at all
+	// (`invalid method "/mcp"`). Validating anything other than the value that is
+	// used is the same class of defect this gate exists to close.
+	path := c.MCPPath
 	if path == "" {
-		// An empty value keeps the default, which the loader supplies.
+		// An empty value keeps the default, which the loader supplies. Only an
+		// actually empty string qualifies: a whitespace-only value is a typo, and
+		// it panics registration rather than selecting the default.
 		return nil
+	}
+	// Every Unicode space, not just ' ' and '\t'. A tab panics for the same reason
+	// a space does; a newline and a non-breaking space register a route that is
+	// not the one the operator wrote, which is worse than a refusal because the
+	// daemon then runs and no client can reach it.
+	for _, r := range path {
+		if unicode.IsSpace(r) {
+			return fmt.Errorf("mcp_path %q must not contain whitespace (found %q): "+
+				"a space or tab panics route registration, and any other whitespace registers a path no client can request", path, r)
+		}
 	}
 	if !strings.HasPrefix(path, "/") {
 		return fmt.Errorf("mcp_path %q must start with '/'", path)
@@ -4670,9 +4689,6 @@ func (c *Config) validateMCPPath() error {
 	if i := strings.IndexAny(path, "?#"); i >= 0 {
 		return fmt.Errorf("mcp_path %q must not contain %q: a query or fragment is not part of the request path, so no request could ever match it",
 			path, path[i:i+1])
-	}
-	if strings.ContainsAny(path, " \t") {
-		return fmt.Errorf("mcp_path %q must not contain whitespace", path)
 	}
 	// ServeMux redirects a request with a doubled slash to the cleaned path, so a
 	// pattern holding one is registered at an address no client is served on.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4621,6 +4621,7 @@ func (c *Config) Validate() error {
 		c.validateDistributedEmbed,
 		c.validateMediaBatch,
 		c.validateCrossLingual,
+		c.validateMCPPath,
 	} {
 		if err := validate(); err != nil {
 			return err
@@ -4630,6 +4631,58 @@ func (c *Config) Validate() error {
 	if c.SessionMaxLifetime > 0 && c.SessionMaxLifetime < c.SessionInactivityTimeout {
 		return fmt.Errorf("session_max_lifetime (%v) must be >= session_inactivity_timeout (%v)",
 			c.SessionMaxLifetime, c.SessionInactivityTimeout)
+	}
+	return nil
+}
+
+// validateMCPPath fails fast (CONFIG_INVALID) when mcp_path is not a literal URL
+// path this server can register (issue #653).
+//
+// The only check used to be a leading slash, applied in the `up` command. Go
+// 1.22's http.ServeMux reads `{name}` in a pattern as a wildcard segment and
+// PANICS on a malformed one, so `--mcp-path '/{'` took the whole daemon down
+// with `panic: parsing "/{": at offset 1: bad wildcard segment` AFTER startup
+// work had already run. A typo in a persisted config crashed the process
+// instead of producing this repository's machine-parseable CONFIG_INVALID.
+//
+// The grammar is deliberately narrower than what ServeMux accepts: mcp_path
+// names ONE endpoint, so pattern syntax is never useful here and accepting it
+// would only create ways to write a path that does not mean what it looks like.
+// Each rejected character is rejected for its own reason, named in the error, so
+// an operator can fix the value rather than guess at a grammar.
+func (c *Config) validateMCPPath() error {
+	path := strings.TrimSpace(c.MCPPath)
+	if path == "" {
+		// An empty value keeps the default, which the loader supplies.
+		return nil
+	}
+	if !strings.HasPrefix(path, "/") {
+		return fmt.Errorf("mcp_path %q must start with '/'", path)
+	}
+	// `{` and `}` are the panic. ServeMux reads them as a wildcard segment.
+	if strings.ContainsAny(path, "{}") {
+		return fmt.Errorf("mcp_path %q must not contain '{' or '}': "+
+			"Go's request multiplexer reads those as a wildcard pattern, and a malformed one panics the server", path)
+	}
+	// `?` and `#` never reach a handler as part of the path: the client sends the
+	// query and the fragment separately, so a path containing them can never
+	// match and the server would silently answer nothing on it.
+	if i := strings.IndexAny(path, "?#"); i >= 0 {
+		return fmt.Errorf("mcp_path %q must not contain %q: a query or fragment is not part of the request path, so no request could ever match it",
+			path, path[i:i+1])
+	}
+	if strings.ContainsAny(path, " \t") {
+		return fmt.Errorf("mcp_path %q must not contain whitespace", path)
+	}
+	// ServeMux redirects a request with a doubled slash to the cleaned path, so a
+	// pattern holding one is registered at an address no client is served on.
+	if strings.Contains(path, "//") {
+		return fmt.Errorf("mcp_path %q must not contain '//': requests are redirected to the cleaned path, so nothing would be served on this one", path)
+	}
+	// A trailing slash makes ServeMux treat the pattern as a SUBTREE, so
+	// `/mcp/` would also claim `/mcp/anything`. mcp_path names one endpoint.
+	if path != "/" && strings.HasSuffix(path, "/") {
+		return fmt.Errorf("mcp_path %q must not end with '/': a trailing slash registers a subtree rather than the single endpoint mcp_path names", path)
 	}
 	return nil
 }

--- a/tests/config/mcp_path_validation_653_test.go
+++ b/tests/config/mcp_path_validation_653_test.go
@@ -49,6 +49,20 @@ func TestMCPPathRejectsValuesThatCannotServeARequest(t *testing.T) {
 		{"/mcp/", "a trailing slash registers a subtree, not one endpoint"},
 		{"/mcp path", "whitespace"},
 		{"mcp", "no leading slash"},
+		// Whitespace, measured rather than assumed. ServeMux reads a space as the
+		// separator before the path, so "/mcp " parses as the METHOD "/mcp" with
+		// no path and panics with `invalid method "/mcp"`. A tab does the same. A
+		// newline and a non-breaking space do NOT panic: they register a route no
+		// client can request, which is worse, because the daemon runs and nothing
+		// reaches it. An earlier version of this gate trimmed the value before
+		// checking it, so every case below passed and "/mcp " still panicked.
+		{"/mcp ", "a trailing space: ServeMux parses it as a method separator and panics"},
+		{" /mcp", "a leading space"},
+		{"/mc\tp", "an internal tab: panics like a space"},
+		{"/mc\np", "an internal newline: registers a route no client can request"},
+		{"/mcp\u00a0x", "a non-breaking space: not caught by a space-and-tab check"},
+		{"   ", "whitespace only: this is a typo, not a request for the default"},
+		{"\t", "whitespace only"},
 	} {
 		t.Run(tc.path, func(t *testing.T) {
 			cfg := config.Default()
@@ -94,6 +108,9 @@ func TestEveryAcceptedMCPPathRegistersWithoutPanic(t *testing.T) {
 	for _, path := range []string{
 		"/mcp", "/", "/deep/nested/mcp", "/mcp-v2", "/MCP", "/mcp.json",
 		"/{", "/{name}", "/mcp}",
+		// The whitespace family, which is why this property test exists: the
+		// first version of the grammar accepted "/mcp " and it panicked here.
+		"/mcp ", " /mcp", "/mc\tp", "/mc\np", "/mcp\u00a0x", "   ", "\t",
 	} {
 		cfg := config.Default()
 		cfg.MCPPath = path

--- a/tests/config/mcp_path_validation_653_test.go
+++ b/tests/config/mcp_path_validation_653_test.go
@@ -1,0 +1,122 @@
+package tests
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+)
+
+// mcp_path validation: dir2mcp #653.
+//
+// The only check was a leading slash, and it lived in the `up` command. Go
+// 1.22's http.ServeMux reads `{name}` in a pattern as a wildcard segment and
+// PANICS on a malformed one, so `--mcp-path '/{'` took the whole daemon down
+// with `panic: parsing "/{": at offset 1: bad wildcard segment (must end with
+// '}')`, after other startup work had already run. A typo in a persisted config
+// crashed the process instead of producing a CONFIG_INVALID an operator can read.
+//
+// Validate() is the gate rather than the `up` command, so every entry point is
+// covered: a persisted config, a CLI flag overlay, and `dir2mcp config set`.
+
+// TestMCPPathRejectsAPatternThatPanicsServeMux is the headline case. It is the
+// exact value from the issue.
+func TestMCPPathRejectsAPatternThatPanicsServeMux(t *testing.T) {
+	cfg := config.Default()
+	cfg.MCPPath = "/{"
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("mcp_path=\"/{\" must be rejected: registering it panics the server goroutine after startup (#653)")
+	}
+	if !strings.Contains(err.Error(), "mcp_path") {
+		t.Errorf("error must name the offending key so an operator can fix it; got %q", err)
+	}
+}
+
+// TestMCPPathRejectsValuesThatCannotServeARequest covers the values that do not
+// panic but cannot work, each for its own reason. A path that silently serves
+// nothing is worse than one that is refused, because the operator sees a running
+// daemon and a client that cannot reach it.
+func TestMCPPathRejectsValuesThatCannotServeARequest(t *testing.T) {
+	for _, tc := range []struct{ path, why string }{
+		{"/{name}", "a wildcard segment: mcp_path names one endpoint, not a pattern"},
+		{"/mcp}", "an unbalanced brace"},
+		{"/mcp?token=x", "a query string is not part of the request path"},
+		{"/mcp#frag", "a fragment is never sent to the server"},
+		{"/a//b", "a doubled slash: requests are redirected to the cleaned path"},
+		{"/mcp/", "a trailing slash registers a subtree, not one endpoint"},
+		{"/mcp path", "whitespace"},
+		{"mcp", "no leading slash"},
+	} {
+		t.Run(tc.path, func(t *testing.T) {
+			cfg := config.Default()
+			cfg.MCPPath = tc.path
+			if err := cfg.Validate(); err == nil {
+				t.Fatalf("mcp_path=%q must be rejected (%s)", tc.path, tc.why)
+			}
+		})
+	}
+}
+
+// TestMCPPathAcceptsEveryUsableValue is the other half. A validator that
+// rejected a legitimate custom path would break a working deployment, which is a
+// worse outcome than the panic it replaces.
+func TestMCPPathAcceptsEveryUsableValue(t *testing.T) {
+	for _, path := range []string{
+		"/mcp",
+		"/",
+		"/deep/nested/mcp",
+		"/mcp-v2",
+		"/mcp_v2",
+		"/MCP",
+		"/mcp.json",
+		"", // unset: the loader supplies the default
+	} {
+		t.Run(path, func(t *testing.T) {
+			cfg := config.Default()
+			cfg.MCPPath = path
+			if err := cfg.Validate(); err != nil {
+				t.Fatalf("mcp_path=%q is usable and must be accepted; got %v", path, err)
+			}
+		})
+	}
+}
+
+// TestEveryAcceptedMCPPathRegistersWithoutPanic is the test that ties the rule to
+// the failure. The validator is only correct if what it accepts can actually be
+// registered, so this asserts the property directly against http.ServeMux rather
+// than trusting the grammar to have covered every case.
+func TestEveryAcceptedMCPPathRegistersWithoutPanic(t *testing.T) {
+	// Includes the rejected values too: for those the validator must be what
+	// stops them, and this test proves the panic is real rather than assumed.
+	for _, path := range []string{
+		"/mcp", "/", "/deep/nested/mcp", "/mcp-v2", "/MCP", "/mcp.json",
+		"/{", "/{name}", "/mcp}",
+	} {
+		cfg := config.Default()
+		cfg.MCPPath = path
+		accepted := cfg.Validate() == nil
+
+		panicked := registerPanics(path)
+		if accepted && panicked {
+			t.Errorf("mcp_path=%q passed validation but panics when registered: the grammar is too permissive", path)
+		}
+		if panicked && !accepted {
+			continue // correctly refused before it could panic
+		}
+	}
+}
+
+// registerPanics reports whether http.ServeMux panics on this pattern, which is
+// the failure #653 is about.
+func registerPanics(pattern string) (panicked bool) {
+	defer func() {
+		if recover() != nil {
+			panicked = true
+		}
+	}()
+	http.NewServeMux().HandleFunc(pattern, func(http.ResponseWriter, *http.Request) {})
+	return false
+}


### PR DESCRIPTION
## The defect

```bash
dir2mcp --dir /tmp/corpus up --foreground --mcp-path '/{'
```

```
panic: parsing "/{": at offset 1: bad wildcard segment (must end with '}')
github.com/dirstral/dir2mcp/internal/mcp.(*Server).Handler
```

Go 1.22's `http.ServeMux` reads `{name}` as a wildcard segment and panics on a malformed one. The only validation was a leading slash, so the value reached `Handler()` and killed the process **after** other startup work had already run. A typo in a persisted config crashed the daemon instead of producing a `CONFIG_INVALID` an operator can read.

After this change, the same command:

```
CONFIG_INVALID: mcp_path "/{" must not contain '{' or '}': Go's request
multiplexer reads those as a wildcard pattern, and a malformed one panics the server
```

Exit code 1, before anything binds.

## Where the gate lives

`Config.Validate()`, not the `up` command. Every entry point runs it: a persisted config, the CLI flag overlay (which #405 added the re-validation for), and `dir2mcp config set`.

## The grammar, and why it is narrow

`mcp_path` names ONE endpoint. Pattern syntax is never useful here, and accepting it would only create ways to write a path that does not mean what it looks like. Each character is refused for its own reason, and the error says which:

| rejected | reason |
|---|---|
| `{` `}` | the panic |
| `?` `#` | not part of the request path, so nothing could ever match |
| `//` | requests are redirected to the cleaned path, so the pattern serves nothing |
| trailing `/` | registers a SUBTREE, so `/mcp/` would also claim `/mcp/anything` |
| whitespace | not a usable path |
| no leading `/` | pre-existing rule, moved here |

Accepted and covered by a test: `/mcp`, `/`, `/deep/nested/mcp`, `/mcp-v2`, `/mcp_v2`, `/MCP`, `/mcp.json`, and empty (the loader supplies the default). A validator that refused a legitimate custom path would break a working deployment, which is worse than the panic it replaces.

## Dead code removed

The leading-slash check in `up` is deleted. `Validate()` runs first at the top of `validateUpConfig`, so that branch became unreachable, and dead code claiming to be a safety net is worse than the duplication.

## Tests

`tests/config/mcp_path_validation_653_test.go`. The last one is the important one:

```go
func TestEveryAcceptedMCPPathRegistersWithoutPanic(t *testing.T) {
	// ... for each value: accepted := cfg.Validate() == nil
	if accepted && registerPanics(path) { t.Errorf("the grammar is too permissive") }
}
```

It asserts the PROPERTY against a real `http.ServeMux` rather than trusting my character list to be complete. A rule that is too permissive fails there even if I missed a case, and it also proves the panic is real rather than assumed.

Proven on main: the headline case plus six of the eight rejected values fail there, and the accepted-value test passes on both.

`make check` passes.

Closes #653

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCP path validation to reject malformed or unusable paths before server startup.
  * Prevented invalid paths that could cause request routing failures or startup panics.
  * Continued supporting valid custom, root, nested, and unset MCP paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->