### PR TITLE
fix(annotator): revive the annotator gate, then fix the two defects behind it (#649, #651, #650)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,6 +29,13 @@ jobs:
         with:
           go-version-file: go.mod
 
+      # `make check` runs the Python annotator suite too, so this job needs the
+      # same interpreter the dedicated `annotator` job uses.
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version-file: annotator/pyproject.toml
+
       - name: Install golangci-lint
         run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1
 
@@ -94,6 +101,11 @@ jobs:
   # never reaches it. Without this job a PR touching only annotator/ collected
   # a full set of green checks that had not executed a line of the change --
   # which is how an ungated precision regression shipped (#779/#787).
+  #
+  # `make check` in the `checks` job now runs this suite as well, so a developer
+  # who runs the documented local gate sees the same result (#649). This job
+  # stays because it reports the annotator on its own, in well under a minute,
+  # instead of inside a five minute Go run.
   annotator:
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@ __pycache__/
 # `pip install -e` so the tests exercise the working tree rather than a copy;
 # that writes this alongside the package.
 *.egg-info/
+
+# The venv `make test-annotator` owns. It installs there rather than into the
+# ambient interpreter, which a PEP 668 python refuses.
+annotator/.venv-test/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,12 +23,24 @@ dir2mcp is a Go monorepo for deploying a directory as an MCP knowledge server. I
 ## Build and test
 
 - Build: `make build`
-- Full checks: `make check`
+- Full checks: `make check` (the local merge-readiness gate: Go plus the Python
+  annotator suite)
 - CI-safe checks: `make ci`
 - Focused suites:
   - `go test ./tests/mcp -run X402`
   - `go test ./tests/x402`
   - `go test ./tests/ingest`
+  - `make test-annotator` (Python annotator suite on its own)
+
+### Gate rules
+
+- `make check` and `make ci` never rewrite the tree. `fmt-check` reports
+  unformatted files and fails; `make fmt` is the separate developer target that
+  formats in place. Do not put `fmt` back in front of a gate.
+- `make test-annotator` installs into `annotator/.venv-test`, a venv it owns.
+  A PEP 668 interpreter (Homebrew, Debian) refuses a `pip install` into itself,
+  so the suite must never install into the ambient python. Rebuild the venv with
+  `rm -rf annotator/.venv-test` or `make clean-all`.
 
 ### Integration tests
 

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ build-elevenlabs-bridge:
 up: build
 	./dir2mcp up
 
-.PHONY: all clean clean-all help fmt vet lint cyclo ineffassign misspell test test-race test-annotator check ci benchmark inspector-smoke conformance
+.PHONY: all clean clean-all help fmt fmt-check vet lint cyclo ineffassign misspell test test-race test-release-tools test-annotator check ci benchmark inspector-smoke conformance
 
 all: check
 
@@ -35,7 +35,8 @@ help:
 	@echo "  all       - default target (runs check)"
 	@echo "  clean     - remove build artifacts and local test caches only"
 	@echo "  clean-all - full clean including Go build cache (use sparingly)"
-	@echo "  fmt       - format Go code"
+	@echo "  fmt       - format Go code in place (developer convenience)"
+	@echo "  fmt-check - fail when Go code is unformatted (read-only gate)"
 	@echo "  vet    - run go vet"
 	@echo "  lint   - run golangci-lint"
 	@echo "  cyclo  - run gocyclo -over 15 over the whole tree"
@@ -43,15 +44,35 @@ help:
 	@echo "  misspell    - run misspell over the whole tree"
 	@echo "  test   - run go test"
 	@echo "  test-race - run go test -race on the concurrency-sensitive packages (needs CGO)"
-	@echo "  check  - fmt + vet + lint + cyclo + ineffassign + misspell + test + build"
-	@echo "  ci     - vet + cyclo + ineffassign + misspell + test (CI-safe default)"
+	@echo "  test-annotator - run the Python annotator suite in its own venv"
+	@echo "  check  - fmt-check + vet + lint + cyclo + ineffassign + misspell + test + test-annotator + build"
+	@echo "  ci     - fmt-check + vet + cyclo + ineffassign + misspell + test + test-annotator (CI-safe default)"
 	@echo "  build-elevenlabs-bridge - build the ElevenLabs webhook bridge binary"
 	@echo "  conformance      - run black-box conformance tests (tests/conformance/)"
 	@echo "  benchmark        - run the large-corpus retrieval benchmark"
 	@echo "  inspector-smoke  - build and run MCP inspector headless smoke test"
 
+# Go trees the two formatting targets cover. `fmt` rewrites them, `fmt-check`
+# only reads them.
+GOFMT_ROOTS := cmd internal tests
+
+# Developer convenience: format in place. Never a prerequisite of a gate.
 fmt:
-	gofmt -w $$(find cmd internal tests -name '*.go')
+	gofmt -w $$(find $(GOFMT_ROOTS) -name '*.go')
+
+# The formatting gate, and the reason it is separate from `fmt`. `check` used
+# to depend on `fmt`, so unformatted code was rewritten instead of reported: on
+# CI the rewrite landed on a throwaway checkout, the job went green, and the
+# committed tree stayed unformatted until main needed a cleanup commit (#649).
+# A check that mutates the tree can never fail, so this one only reads.
+fmt-check:
+	@drift=$$(gofmt -l $$(find $(GOFMT_ROOTS) -name '*.go')) || exit 1; \
+	if [ -n "$$drift" ]; then \
+		echo "gofmt: these files are not formatted:"; \
+		printf '  %s\n' $$drift; \
+		echo "run 'make fmt' and commit the result"; \
+		exit 1; \
+	fi
 
 vet:
 	go vet ./...
@@ -95,12 +116,36 @@ conformance:
 # not reachable from `go test`, so it needs its own target. Core is stdlib-only
 # by design; the `ocr` extra is installed as well so the vision recognizers'
 # tests run rather than skip (#787).
-test-annotator:
-	cd annotator && python3 -m pip install --quiet -e '.[test,ocr]' && python3 -m pytest -q
+#
+# The install goes into a venv this target owns, not into the ambient
+# interpreter. `pip install` into a PEP 668 interpreter (Homebrew, Debian, most
+# distribution pythons) is refused outright, so the previous form could not run
+# on a normal developer machine: the target existed and was unrunnable, which is
+# half of why the suite stayed outside every gate (#649). The venv also keeps
+# the editable install off the developer's own environment.
+ANNOTATOR_VENV ?= $(CURDIR)/annotator/.venv-test
+# Absolute, because the pytest recipe runs from `annotator/`: an override given
+# as a relative path would otherwise be resolved against the wrong directory.
+ANNOTATOR_PY := $(abspath $(ANNOTATOR_VENV))/bin/python
+# Stamp file, so the install runs when the dependency set changes and not on
+# every test run. Delete the venv (or run `make clean-all`) to rebuild it from
+# scratch, which is also the fix if its interpreter is ever removed underneath.
+ANNOTATOR_STAMP := $(ANNOTATOR_VENV)/.installed
 
-check: fmt vet lint cyclo ineffassign misspell test test-release-tools build
+$(ANNOTATOR_STAMP): annotator/pyproject.toml
+	python3 -m venv "$(ANNOTATOR_VENV)"
+	"$(ANNOTATOR_PY)" -m pip install --quiet -e '$(CURDIR)/annotator[test,ocr]'
+	touch "$@"
 
-ci: vet cyclo ineffassign misspell test test-release-tools
+test-annotator: $(ANNOTATOR_STAMP)
+	cd annotator && "$(ANNOTATOR_PY)" -m pytest -q
+
+# `check` is the documented local merge-readiness gate, so it has to cover the
+# whole repository: the annotator suite is part of it, and the formatting step
+# reports rather than rewrites.
+check: fmt-check vet lint cyclo ineffassign misspell test test-release-tools test-annotator build
+
+ci: fmt-check vet cyclo ineffassign misspell test test-release-tools test-annotator
 
 benchmark:
 	# run the large-corpus retrieval benchmark only
@@ -132,3 +177,4 @@ clean:
 clean-all: clean
 	# perform a full cache wipe, use only when you really need it
 	go clean -cache -testcache >/dev/null 2>&1 || true
+	rm -rf "$(ANNOTATOR_VENV)"

--- a/annotator/README.md
+++ b/annotator/README.md
@@ -283,8 +283,21 @@ timestamps, ~2017 onward) — no manual annotation.
 
 ## Tests
 
+From the repository root, in a venv the target owns:
+
 ```bash
-pip install -e '.[test]'   # test runner + jsonschema (external test tooling)
+make test-annotator          # installs into annotator/.venv-test, then runs pytest
+```
+
+`make check` runs the same suite, so the repository's merge-readiness gate
+covers this package. To drive pytest by hand, install into a venv of your own
+(a PEP 668 interpreter refuses an install into itself):
+
+```bash
+python3 -m venv .venv && . .venv/bin/activate
+# [test] is the runner + jsonschema; [ocr] makes the vision recognizers' tests
+# run rather than skip, which is what `make test-annotator` installs (#787).
+pip install -e '.[test,ocr]'
 python3 -m pytest tests/    # tested code needs no network, models, or ffmpeg
 ```
 

--- a/annotator/dirstral_annotator/pipeline.py
+++ b/annotator/dirstral_annotator/pipeline.py
@@ -1,21 +1,33 @@
 """Recognition pipeline: media file -> fused annotations.
 
-Shared by the serve handler (per-request) and the eval CLI. Vision
-recognizers are constructed lazily per pipeline; ones whose backends are
-missing are skipped with a note, so the cascade degrades instead of
+Shared by the serve handler and the eval CLI. Vision recognizers are
+constructed lazily and then CACHED for the pipeline's life; ones whose backends
+are missing are skipped with a note, so the cascade degrades instead of
 aborting (a metadata-only deployment still recognizes via play-by-play).
+
+"Lazily" means "not at process start", not "per request". `serve` keeps one
+pipeline behind a ThreadingHTTPServer, so building inside `cues_for` reloaded
+the ONNX and YOLO models and re-embedded the whole face bank on every POST:
+measured at 46s per request for a 40 image bank on the real InsightFace backend
+(#650). Caching also removes an inconsistency, because a bank edited during a
+run was picked up at whichever request happened to re-enroll.
+
+A cached recognizer is shared by concurrent requests, and these recognizers are
+not reentrant, so one request at a time enters any one of them. See `_Shared`.
 """
 
 from __future__ import annotations
 
 import json
+import threading
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 
 from .eval import align, ground_truth
 from .fusion import fuse
 from .model import Annotation, Cue
-from .recognizers.base import RecognizerUnavailable
+from .recognizers.base import Recognizer, RecognizerUnavailable
 from .roster import Roster
 
 
@@ -44,6 +56,46 @@ class GameConfig:
         return align.estimate(self.anchors)
 
 
+@dataclass(frozen=True)
+class _Unavailable:
+    """A recognizer whose backend is missing, remembered rather than retried.
+
+    The reason is replayed on every request, so a caller reading `skipped` gets
+    the same answer each time. Only the probing is done once.
+    """
+
+    reason: str
+
+
+class _Shared:
+    """One recognizer instance, entered by one request at a time.
+
+    Caching an instance means concurrent requests share it. That is the point:
+    building per request reloaded the models, and building per thread would
+    duplicate the allocations rather than remove them.
+
+    Sharing needs serialised inference, because these recognizers are not
+    reentrant. `NewsOverlayRecognizer.recognize` clears and refills per-role
+    reader state on itself for each run, so two runs at once interleave their
+    sightings. The default jersey detector is an ultralytics model, which is not
+    documented thread safe (see `_Detectors`). insightface hangs per-call state
+    off its app object.
+
+    So the contract is one lock per recognizer: two requests queue instead of
+    corrupting each other. They still share the frame extraction cache in
+    `recognizers.base`, which is where a real request's time goes, so the second
+    request does not re-decode the media either.
+    """
+
+    def __init__(self, recognizer: Recognizer):
+        self.recognizer = recognizer
+        self._lock = threading.Lock()
+
+    def recognize(self, media_path: Path) -> list[Cue]:
+        with self._lock:
+            return self.recognizer.recognize(media_path)
+
+
 def load_games(path: str | Path) -> dict[str, GameConfig]:
     """games.json: {"<media basename>": {"game_pk"|"feed": ..., "anchors": ["EPOCH=VIDEO_S", ...]}}"""
     raw = json.loads(Path(path).read_text(encoding="utf-8"))
@@ -70,14 +122,69 @@ class Pipeline:
     faces_bank: Path | None = None
     fps: float = 0.5
     min_confidence: float = 0.0
-    skipped: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        # Not dataclass fields on purpose. This is internal state, a Lock is
+        # neither comparable nor copyable, and a loaded model has no place in a
+        # repr of the configuration.
+        self._build_lock = threading.Lock()
+        self._recognizers: dict[str, tuple[tuple, _Shared | _Unavailable]] = {}
+        # Skip notes belong to one request, and `serve` runs a request per
+        # thread. A plain attribute is shared, so a second request replaces the
+        # first request's notes before its caller has read them: no list is
+        # interleaved, and the caller still gets the wrong answer. Thread-local
+        # storage gives each request its own.
+        self._notes = threading.local()
+
+    @property
+    def skipped(self) -> list[str]:
+        """Skip notes from the most recent `cues_for` ON THIS THREAD.
+
+        Read after the call that produced them, which is what the eval CLI and a
+        request handler both do.
+        """
+        return getattr(self._notes, "skipped", [])
+
+    def _shared(
+        self, name: str, key: tuple, build: Callable[[], Recognizer]
+    ) -> _Shared | _Unavailable:
+        """The configured recognizer for `name`, built at most once.
+
+        `key` is everything about this pipeline that decides WHAT gets built.
+        One slot per name, replaced when its key changes, so an operator who
+        repoints `faces_bank` or changes `fps` gets a recognizer built from the
+        new setting instead of the one the old setting produced, and a remembered
+        unavailability belongs to one configuration rather than to the process.
+
+        Construction holds the lock, and the lock is one per pipeline rather than
+        one per name. That is deliberate: two concurrent first requests must not
+        both load the models, and neither should a face build and a jersey build
+        want their weights at the same moment. It costs a cold second request its
+        wait, which it would spend queueing on the recognizer anyway, and a warm
+        request only a dict lookup.
+        """
+        with self._build_lock:
+            slot = self._recognizers.get(name)
+            if slot is not None and slot[0] == key:
+                return slot[1]
+            built: _Shared | _Unavailable
+            try:
+                built = _Shared(build())
+            except RecognizerUnavailable as exc:
+                built = _Unavailable(str(exc))
+            self._recognizers[name] = (key, built)
+            return built
 
     def annotations_for(self, media_path: Path) -> list[Annotation]:
         return fuse(self.cues_for(media_path), min_confidence=self.min_confidence)
 
     def cues_for(self, media_path: Path) -> list[Cue]:
         cues: list[Cue] = []
-        self.skipped = []
+        # Appended to through the local name and published to this thread only,
+        # so two concurrent requests neither interleave into one list nor
+        # overwrite each other's answer. See the `skipped` property.
+        skipped: list[str] = []
+        self._notes.skipped = skipped
 
         game = self.games.get(media_path.name)
         if game is not None and game.anchors and (game.game_pk or game.feed):
@@ -88,26 +195,47 @@ class Pipeline:
                 game.events(), alignment.offset_s, self.roster
             ).recognize(media_path)
 
-        def try_recognizer(build):
+        def try_recognizer(name, key, build):
+            entry = self._shared(name, key, build)
+            if isinstance(entry, _Unavailable):
+                skipped.append(entry.reason)
+                return
             try:
-                cues.extend(build().recognize(media_path))
+                cues.extend(entry.recognize(media_path))
             except RecognizerUnavailable as exc:
-                self.skipped.append(str(exc))
+                # A backend that only fails on its first READ, as the OCR
+                # adapter does. That is not a construction failure, so it is
+                # reported per request and the instance is not written off: the
+                # engine can be installed under a long lived server.
+                skipped.append(str(exc))
 
         if self.scorebug:
             from .recognizers.scorebug import ScorebugRecognizer
 
-            try_recognizer(lambda: ScorebugRecognizer(
-                self.roster, fps=self.fps, count_pitch_cues=self.scorebug_pitch_counts,
-            ))
+            try_recognizer(
+                "scorebug",
+                (self.roster, self.fps, self.scorebug_pitch_counts),
+                lambda: ScorebugRecognizer(
+                    self.roster, fps=self.fps,
+                    count_pitch_cues=self.scorebug_pitch_counts,
+                ),
+            )
         if self.jersey:
             from .recognizers.jersey import JerseyRecognizer
 
-            try_recognizer(lambda: JerseyRecognizer(self.roster, fps=self.fps))
+            try_recognizer(
+                "jersey",
+                (self.roster, self.fps),
+                lambda: JerseyRecognizer(self.roster, fps=self.fps),
+            )
         if self.faces_bank:
             from .recognizers.faces import FaceRecognizer
 
-            try_recognizer(lambda: FaceRecognizer(self.roster, self.faces_bank, fps=self.fps))
+            try_recognizer(
+                "face",
+                (self.roster, self.faces_bank, self.fps),
+                lambda: FaceRecognizer(self.roster, self.faces_bank, fps=self.fps),
+            )
         if self.news:
             # The only recognizer here that reads no roster: overlay text is
             # the payload, not a name to resolve.
@@ -121,8 +249,11 @@ class Pipeline:
             if self.news_min_agreement is not None:
                 gate["readable_agreement"] = self.news_min_agreement
             try_recognizer(
+                "news",
+                (self.ocr_lang, self.fps, self.news_min_chars,
+                 self.news_min_agreement),
                 lambda: NewsOverlayRecognizer(
                     lang=self.ocr_lang, fps=self.fps, **gate
-                )
+                ),
             )
         return cues

--- a/annotator/dirstral_annotator/recognizers/faces.py
+++ b/annotator/dirstral_annotator/recognizers/faces.py
@@ -10,6 +10,11 @@ Honest expectations (pilot proposal): faces are small and occluded in
 broadcast footage — this signal earns its keep on close-ups, dugout shots
 and pre-overlay archival material, and is fused with, never trusted over,
 scorebug/play-by-play.
+
+The bank is an optional backend asset, so it follows the package rule for one
+of those: a bank that is missing, is not a directory, or cannot be read raises
+`RecognizerUnavailable` at construction and the pipeline skips this recognizer
+with a note. See `_bank_player_dirs`.
 """
 
 from __future__ import annotations
@@ -192,6 +197,42 @@ def centroid(embeddings: list[Embedding]) -> Embedding:
     return [sum(e[i] for e in embeddings) / len(embeddings) for i in range(dim)]
 
 
+def _bank_player_dirs(bank_dir: Path) -> list[Path]:
+    """The bank's player subdirectories, or an unavailable recognizer.
+
+    A bank that is absent, is not a directory, or cannot be read is a missing
+    optional ASSET, the same class of problem as an uninstalled insightface
+    wheel. This package has one rule for that class, stated in the pipeline
+    docstring: raise `RecognizerUnavailable` at construction, so the pipeline
+    records a skip note and the rest of the cascade still runs. Letting the raw
+    `OSError` out instead made one absent directory fail the whole annotation
+    request: the served backend answered 502 and the eval CLI exited with a
+    traceback (#651).
+
+    Only filesystem errors are converted. Anything else is a bug in this package
+    and is left to surface as one.
+    """
+    try:
+        return sorted(p for p in bank_dir.iterdir() if p.is_dir())
+    except NotADirectoryError as exc:
+        raise RecognizerUnavailable(
+            f"face bank is not a directory: {bank_dir}"
+        ) from exc
+    except FileNotFoundError as exc:
+        raise RecognizerUnavailable(
+            f"face bank not found: {bank_dir} "
+            "(expected <bank>/<player-id-with-underscores>/*.jpg)"
+        ) from exc
+    except OSError as exc:
+        # PermissionError and everything else the filesystem can answer with.
+        # `strerror` rather than `str(exc)`: the reason belongs in the message,
+        # the path is already there, and nothing else about the caller is.
+        raise RecognizerUnavailable(
+            f"face bank cannot be read: {bank_dir} "
+            f"({exc.strerror or type(exc).__name__})"
+        ) from exc
+
+
 def match(
     embedding: Embedding, gallery: dict[str, Embedding], threshold: float = SIM_THRESHOLD
 ) -> tuple[str, float] | None:
@@ -220,22 +261,40 @@ class FaceRecognizer:
         threshold: float = SIM_THRESHOLD,
     ):
         self.roster = roster
+        bank = Path(bank_dir)
+        # The bank is read BEFORE the embedder is built. Building the default
+        # embedder loads and prepares five ONNX models, and paying that only to
+        # then find the bank is not there is waste with no upside. Both failures
+        # are RecognizerUnavailable, so the cheaper one goes first.
+        player_dirs = _bank_player_dirs(bank)
         self.embedder = embedder if embedder is not None else default_embedder()
         self.fps = fps
         self.threshold = threshold
-        self.gallery = self._enroll(Path(bank_dir))
+        self.gallery = self._enroll(bank, player_dirs)
 
-    def _enroll(self, bank_dir: Path) -> dict[str, Embedding]:
+    def _enroll(self, bank_dir: Path, player_dirs: list[Path]) -> dict[str, Embedding]:
         """Bank layout: `<bank>/<player-id-with-underscores>/*.jpg` (":" is
         awkward in dirnames, so "player:webb-logan" -> "player_webb-logan").
         Every image contributes its largest detected face."""
         gallery: dict[str, Embedding] = {}
-        for player_dir in sorted(p for p in bank_dir.iterdir() if p.is_dir()):
+        for player_dir in player_dirs:
             pid = player_dir.name.replace("_", ":", 1)
             if not self.roster.get(pid):
                 continue
+            try:
+                images = sorted(player_dir.iterdir())
+            except OSError as exc:
+                # One player's images being unreadable is not the bank being
+                # unreadable. Degrade by as little as possible: enroll everyone
+                # who can be enrolled, and say who was lost. A bank where that
+                # leaves nobody still ends as unavailability below.
+                logging.getLogger(__name__).warning(
+                    "face bank: skipping %s (%s)",
+                    player_dir.name, exc.strerror or type(exc).__name__,
+                )
+                continue
             embeddings = []
-            for img in sorted(player_dir.iterdir()):
+            for img in images:
                 if img.suffix.lower() not in IMAGE_EXTS:
                     continue
                 faces = self.embedder(img)

--- a/annotator/dirstral_annotator/serve.py
+++ b/annotator/dirstral_annotator/serve.py
@@ -3,6 +3,11 @@
 dir2mcp with `recognize.provider: serve` POSTs `{"path": "<abs media path>"}`
 to `/recognize` and indexes the returned annotations. `/health` answers 200
 for probes (docling-serve parity). Stdlib-only.
+
+One pipeline serves every request, so the recognizers it caches are shared by
+every request too, and this runs on ThreadingHTTPServer. The pipeline owns that
+contract: it builds each recognizer once and lets one request at a time into it.
+See `pipeline._Shared`.
 """
 
 from __future__ import annotations

--- a/annotator/tests/test_face_bank.py
+++ b/annotator/tests/test_face_bank.py
@@ -1,0 +1,224 @@
+"""A face bank that is not there must degrade the cascade, not abort it.
+
+The annotator has one rule for an optional backend, stated in the pipeline and
+`base` module docstrings: a recognizer whose backend is missing raises
+`RecognizerUnavailable` at construction, the pipeline records a skip note, and
+the rest of the cascade still runs. A face bank is a backend asset exactly like
+a model wheel, so a missing or unreadable one follows that same rule.
+
+It did not. `_enroll` called `bank_dir.iterdir()` with nothing around it, so a
+path that was not there raised `FileNotFoundError`, which `try_recognizer` does
+not convert. One missing optional asset took down the whole annotation request:
+the served backend answered 502 and the eval CLI exited with a traceback (#651).
+
+Backend-free: the embedding callable is injected, so nothing here needs
+insightface, onnxruntime or a model file.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from dirstral_annotator.model import Cue, Player
+from dirstral_annotator.pipeline import Pipeline
+from dirstral_annotator.recognizers import faces, scorebug
+from dirstral_annotator.recognizers.base import RecognizerUnavailable
+from dirstral_annotator.recognizers.faces import FaceRecognizer
+from dirstral_annotator.roster import Roster
+
+PLAYER_ID = "player:webb-logan"
+#: The bank's directory name for that id: ":" is awkward in a dirname, so the
+#: layout uses an underscore.
+PLAYER_DIR = "player_webb-logan"
+
+#: Two 4-dimensional unit vectors, close enough to average into a usable
+#: centroid. The numbers only have to be embeddings; nothing here scores them.
+FACE_A = [1.0, 0.0, 0.0, 0.0]
+FACE_B = [0.9, 0.1, 0.0, 0.0]
+
+BBOX = (0, 0, 40, 40)
+
+
+@pytest.fixture
+def roster() -> Roster:
+    return Roster([Player(id=PLAYER_ID, name="Logan Webb", number="62")])
+
+
+def _embedder(per_image=None):
+    """An embedding callable that answers from a per-filename table."""
+    table = per_image or {}
+
+    def embed(image: Path):
+        return [(table.get(image.name, FACE_A), BBOX)]
+
+    return embed
+
+
+def _bank(tmp_path: Path, *, player_dir: str = PLAYER_DIR, images=("a.jpg", "b.jpg")):
+    bank = tmp_path / "bank"
+    (bank / player_dir).mkdir(parents=True)
+    for name in images:
+        (bank / player_dir / name).write_bytes(b"stand-in; embedding is injected")
+    return bank
+
+
+# --- the happy path, so the failures below mean something -------------------
+
+def test_a_readable_bank_still_enrolls(tmp_path, roster):
+    bank = _bank(tmp_path)
+    rec = FaceRecognizer(roster, bank, embedder=_embedder({"b.jpg": FACE_B}))
+    assert list(rec.gallery) == [PLAYER_ID]
+    assert rec.gallery[PLAYER_ID] == pytest.approx(
+        [(a + b) / 2 for a, b in zip(FACE_A, FACE_B)]
+    )
+
+
+# --- the missing asset cases ------------------------------------------------
+
+def test_a_missing_bank_is_unavailable_not_a_crash(tmp_path, roster):
+    missing = tmp_path / "no-such-bank"
+    with pytest.raises(RecognizerUnavailable) as caught:
+        FaceRecognizer(roster, missing, embedder=_embedder())
+    # The operator has to be able to act on this: it must name the asset and the
+    # path they configured.
+    assert "face bank" in str(caught.value)
+    assert str(missing) in str(caught.value)
+
+
+def test_a_bank_that_is_a_file_is_unavailable(tmp_path, roster):
+    not_a_dir = tmp_path / "bank.tar"
+    not_a_dir.write_bytes(b"an archive somebody forgot to unpack")
+    with pytest.raises(RecognizerUnavailable) as caught:
+        FaceRecognizer(roster, not_a_dir, embedder=_embedder())
+    assert "directory" in str(caught.value)
+
+
+@pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="root ignores directory permissions, so this cannot be provoked",
+)
+def test_an_unreadable_bank_is_unavailable(tmp_path, roster):
+    bank = _bank(tmp_path)
+    bank.chmod(0o000)
+    try:
+        with pytest.raises(RecognizerUnavailable) as caught:
+            FaceRecognizer(roster, bank, embedder=_embedder())
+    finally:
+        bank.chmod(0o755)  # or tmp_path cleanup fails
+    assert "face bank" in str(caught.value)
+
+
+def test_a_bank_with_nothing_enrollable_is_unavailable(tmp_path, roster):
+    """An empty bank, and a bank whose only player is not on the roster, are
+    both "nothing to recognize with" rather than a fatal error."""
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    with pytest.raises(RecognizerUnavailable):
+        FaceRecognizer(roster, empty, embedder=_embedder())
+
+    stranger = _bank(tmp_path / "other", player_dir="player_not-on-this-roster")
+    with pytest.raises(RecognizerUnavailable):
+        FaceRecognizer(roster, stranger, embedder=_embedder())
+
+
+@pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="root ignores directory permissions, so this cannot be provoked",
+)
+def test_an_unreadable_player_directory_costs_only_that_player(tmp_path):
+    """One player's images being unreadable is not the bank being unreadable.
+
+    Degrading means degrading by as little as possible: the players who can be
+    enrolled are enrolled, and the recognizer runs.
+    """
+    two_players = Roster([
+        Player(id=PLAYER_ID, name="Logan Webb", number="62"),
+        Player(id="player:daylen-lile", name="Daylen Lile", number="4"),
+    ])
+    bank = _bank(tmp_path)
+    locked = bank / "player_daylen-lile"
+    locked.mkdir()
+    (locked / "a.jpg").write_bytes(b"stand-in")
+    locked.chmod(0o000)
+    try:
+        rec = FaceRecognizer(two_players, bank, embedder=_embedder())
+    finally:
+        locked.chmod(0o755)
+    assert list(rec.gallery) == [PLAYER_ID]
+
+
+# --- what must NOT be converted --------------------------------------------
+
+def test_an_embedder_bug_still_raises(tmp_path, roster):
+    """Only expected asset and configuration failures become unavailability.
+
+    A callable that is simply wrong is a programming error, and hiding it behind
+    a skip note would turn a bug into a silently missing recognizer.
+    """
+    bank = _bank(tmp_path)
+
+    def broken(image: Path):
+        raise ZeroDivisionError("a bug inside the embedding adapter")
+
+    with pytest.raises(ZeroDivisionError):
+        FaceRecognizer(roster, bank, embedder=broken)
+
+
+# --- the cascade keeps going -----------------------------------------------
+
+def test_the_pipeline_skips_a_missing_bank_and_keeps_running(tmp_path, roster,
+                                                             monkeypatch):
+    """The end the issue is actually about: one absent optional asset must cost
+    the face cues and nothing else.
+
+    A second recognizer stands in for the rest of the cascade. Its cue has to
+    reach the caller, alongside a skip note that names what was lost, which is
+    what "partial annotations" means here.
+    """
+    monkeypatch.setattr(faces, "default_embedder", _embedder)
+
+    survivor = Cue(source="scorebug", start_s=1.0, end_s=2.0, event="at_bat",
+                   entity_ids=(PLAYER_ID,), confidence=0.9)
+
+    class _Scorebug:
+        name = "scorebug"
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def recognize(self, media_path: Path):
+            return [survivor]
+
+    monkeypatch.setattr(scorebug, "ScorebugRecognizer", _Scorebug)
+
+    media = tmp_path / "clip.mp4"
+    media.write_bytes(b"stand-in; no recognizer reaches frame extraction here")
+
+    pipeline = Pipeline(roster=roster, scorebug=True,
+                        faces_bank=tmp_path / "no-such-bank")
+    cues = pipeline.cues_for(media)
+
+    assert cues == [survivor], "the missing bank took the rest of the cascade too"
+    assert pipeline.skipped, "a missing face bank produced no skip note"
+    note = " ".join(pipeline.skipped)
+    assert "face bank" in note, f"the skip note does not name the asset: {note}"
+
+
+def test_the_bank_is_checked_before_the_embedder_is_built(tmp_path, roster,
+                                                          monkeypatch):
+    """Building the default embedder loads and prepares the ONNX models, which
+    is measured in seconds. A bank that is not there is known before any of that
+    is worth paying for."""
+    built: list[int] = []
+
+    def recording_default_embedder():
+        built.append(1)
+        return _embedder()
+
+    monkeypatch.setattr(faces, "default_embedder", recording_default_embedder)
+    with pytest.raises(RecognizerUnavailable):
+        FaceRecognizer(roster, tmp_path / "no-such-bank")
+    assert built == [], "the models were loaded for a bank that does not exist"

--- a/annotator/tests/test_recognizer_cache.py
+++ b/annotator/tests/test_recognizer_cache.py
@@ -1,0 +1,285 @@
+"""A served pipeline builds each recognizer once, not once per request.
+
+`Pipeline.cues_for` constructed every configured recognizer inside the
+per-request call, and `serve` keeps one pipeline for the life of the process. So
+every POST to /recognize reloaded the ONNX and YOLO models and re-embedded the
+whole face bank. Measured with the real InsightFace backend and a 40 image bank:
+46 seconds of construction, per request, before a single frame of the media was
+read (#650).
+
+There is a correctness edge under the performance one. Re-enrolling per request
+means the bank on disk is re-read at an arbitrary moment, so two requests in one
+run could answer from different galleries with nothing recording that they had.
+Building once fixes both: the gallery a process serves from is the one it
+enrolled, and a change is picked up when the configuration changes, not when a
+request happens to land.
+
+Caching also means concurrent requests share the instance, so these tests pin
+the thread contract too: one request at a time inside any one recognizer.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+from dirstral_annotator.model import Cue, Player
+from dirstral_annotator.pipeline import Pipeline
+from dirstral_annotator.recognizers import faces, jersey, news, scorebug
+from dirstral_annotator.recognizers.base import RecognizerUnavailable
+from dirstral_annotator.roster import Roster
+from dirstral_annotator.serve import serve
+
+PLAYER_ID = "player:webb-logan"
+
+#: Every recognizer the pipeline constructs lazily, as
+#: (module, class attribute, the Pipeline settings that switch it on).
+RECOGNIZERS = [
+    (scorebug, "ScorebugRecognizer", {"scorebug": True}),
+    (jersey, "JerseyRecognizer", {"jersey": True}),
+    (faces, "FaceRecognizer", {"faces_bank": Path("/bank-that-the-stub-never-reads")}),
+    (news, "NewsOverlayRecognizer", {"news": True}),
+]
+
+ALL_ENABLED = {k: v for _, _, settings in RECOGNIZERS for k, v in settings.items()}
+
+#: Class name -> the `source` tag its cues carry, which is also the pipeline's
+#: cache slot name.
+NAMES = {
+    "ScorebugRecognizer": "scorebug",
+    "JerseyRecognizer": "jersey",
+    "FaceRecognizer": "face",
+    "NewsOverlayRecognizer": "news",
+}
+
+
+@pytest.fixture
+def roster() -> Roster:
+    return Roster([Player(id=PLAYER_ID, name="Logan Webb", number="62")])
+
+
+class _Stub:
+    """A recognizer that emits one cue and records nothing but its own name."""
+
+    def __init__(self, name: str):
+        self.name = name
+
+    def recognize(self, media_path: Path) -> list[Cue]:
+        return [Cue(source=self.name, start_s=1.0, end_s=2.0, event="appearance",
+                    entity_ids=(PLAYER_ID,), confidence=0.9)]
+
+
+def _install(monkeypatch, *, unavailable=(), recognizer=None):
+    """Replace every recognizer class with a constructor counter.
+
+    Returns the per-name construction log. Names in `unavailable` refuse to be
+    built, which is the case the pipeline is supposed to remember.
+    """
+    built: dict[str, int] = {}
+
+    for module, attr, _settings in RECOGNIZERS:
+        def factory(*args, _name=NAMES[attr], **kwargs):
+            built[_name] = built.get(_name, 0) + 1
+            if _name in unavailable:
+                raise RecognizerUnavailable(f"{_name} backend is not installed")
+            return (recognizer or _Stub)(_name)
+
+        monkeypatch.setattr(module, attr, factory)
+    return built
+
+
+@pytest.fixture
+def media(tmp_path) -> Path:
+    path = tmp_path / "game7.mp4"
+    path.write_bytes(b"stand-in; every recognizer here is a stub")
+    return path
+
+
+# --- the headline contract --------------------------------------------------
+
+def test_two_requests_build_each_recognizer_once(monkeypatch, roster, media):
+    built = _install(monkeypatch)
+    pipeline = Pipeline(roster=roster, **ALL_ENABLED)
+
+    first = pipeline.annotations_for(media)
+    second = pipeline.annotations_for(media)
+
+    assert built == {"scorebug": 1, "jersey": 1, "face": 1, "news": 1}, built
+    assert first == second, "the cached recognizers stopped answering"
+    assert first, "the stubs must produce annotations, or this proves nothing"
+
+
+def test_two_served_requests_build_each_recognizer_once(monkeypatch, roster, media):
+    """The same contract through the surface #650 is about: a long lived
+    ThreadingHTTPServer answering two POSTs to /recognize."""
+    built = _install(monkeypatch)
+    pipeline = Pipeline(roster=roster, **ALL_ENABLED)
+    server = serve(pipeline, host="127.0.0.1", port=0)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        url = f"http://127.0.0.1:{server.server_address[1]}/recognize"
+        for _ in range(2):
+            request = urllib.request.Request(
+                url, data=json.dumps({"path": str(media)}).encode(),
+                headers={"Content-Type": "application/json"},
+            )
+            with urllib.request.urlopen(request) as response:
+                assert response.status == 200
+                assert json.load(response)["annotations"]
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert built == {"scorebug": 1, "jersey": 1, "face": 1, "news": 1}, built
+
+
+# --- unavailability is remembered, not retried ------------------------------
+
+def test_an_unavailable_recognizer_is_built_once_and_reported_every_time(
+    monkeypatch, roster, media
+):
+    built = _install(monkeypatch, unavailable={"jersey"})
+    pipeline = Pipeline(roster=roster, **ALL_ENABLED)
+
+    pipeline.annotations_for(media)
+    first_notes = list(pipeline.skipped)
+    pipeline.annotations_for(media)
+    second_notes = list(pipeline.skipped)
+
+    assert built["jersey"] == 1, "a missing backend was probed again"
+    # Remembering the failure must not stop reporting it: a caller that reads
+    # `skipped` per request has to see the same answer every request.
+    assert len(first_notes) == 1 and first_notes == second_notes
+    assert "jersey" in first_notes[0]
+
+
+def test_reconfiguration_is_not_hidden_by_the_cache(monkeypatch, roster, media):
+    """Caching may not outlive the configuration it was built for.
+
+    An operator who repoints the face bank, or turns a recognizer's parameters,
+    must get a recognizer built from the new setting: for the face bank that is
+    the correctness edge of this issue, because the gallery is the bank.
+    """
+    built = _install(monkeypatch, unavailable={"face"})
+    pipeline = Pipeline(roster=roster, faces_bank=Path("/bank-a"))
+
+    pipeline.annotations_for(media)
+    assert built["face"] == 1
+    assert pipeline.skipped
+
+    pipeline.annotations_for(media)
+    assert built["face"] == 1, "the same configuration was rebuilt"
+
+    pipeline.faces_bank = Path("/bank-b")
+    pipeline.annotations_for(media)
+    assert built["face"] == 2, "the repointed bank reused the old recognizer"
+
+    # And a parameter change counts as reconfiguration too.
+    pipeline.fps = 2.0
+    pipeline.annotations_for(media)
+    assert built["face"] == 3
+
+
+# --- the thread contract ---------------------------------------------------
+
+def test_concurrent_requests_never_enter_one_recognizer_at_once(
+    monkeypatch, roster, media
+):
+    """Sharing an instance is the point, so it has to be safe to share.
+
+    These recognizers are not reentrant: NewsOverlayRecognizer.recognize clears
+    and refills per-role reader state on itself, and the default jersey detector
+    is an ultralytics model that is not documented thread safe. One lock per
+    recognizer, so two requests queue instead of corrupting each other.
+    """
+    concurrency = {"inside": 0, "worst": 0}
+    guard = threading.Lock()
+
+    class _Reentrancy(_Stub):
+        def recognize(self, media_path: Path) -> list[Cue]:
+            with guard:
+                concurrency["inside"] += 1
+                concurrency["worst"] = max(concurrency["worst"],
+                                           concurrency["inside"])
+            time.sleep(0.05)  # long enough for a second thread to arrive
+            with guard:
+                concurrency["inside"] -= 1
+            return super().recognize(media_path)
+
+    built = _install(monkeypatch, recognizer=_Reentrancy)
+    pipeline = Pipeline(roster=roster, scorebug=True)
+
+    start = threading.Barrier(2)
+    results: list[list] = []
+
+    def request():
+        start.wait(timeout=5)
+        results.append(pipeline.annotations_for(media))
+
+    threads = [threading.Thread(target=request) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert concurrency["worst"] == 1, "two requests were inside one recognizer"
+    assert built == {"scorebug": 1}, "concurrent first requests each built a model"
+    assert len(results) == 2 and all(results)
+
+
+def test_concurrent_requests_keep_their_own_skip_notes(monkeypatch, roster, tmp_path):
+    """`skipped` belongs to one request, not to the pipeline.
+
+    A shared attribute fails two ways. Appending into one list merges the notes,
+    and rebinding it per call still lets the last request to finish replace the
+    answer a previous caller has not read yet. No list is interleaved and the
+    caller still gets somebody else's notes.
+
+    So every request here loses its recognizer for a reason that names its own
+    media, and every request has to read back its own reason. The second barrier
+    makes the replacement deterministic rather than a matter of timing: no
+    request reads until all four have finished.
+    """
+
+    class _MissingEngine(_Stub):
+        def recognize(self, media_path: Path) -> list[Cue]:
+            raise RecognizerUnavailable(f"OCR engine missing for {media_path.name}")
+
+    _install(monkeypatch, recognizer=_MissingEngine)
+    pipeline = Pipeline(roster=roster, scorebug=True)
+
+    clips = []
+    for index in range(4):
+        clip = tmp_path / f"clip-{index}.mp4"
+        clip.write_bytes(b"stand-in; the stub never reads it")
+        clips.append(clip)
+
+    start = threading.Barrier(len(clips))
+    settled = threading.Barrier(len(clips))
+    seen: dict[str, list[str]] = {}
+    guard = threading.Lock()
+
+    def request(clip: Path):
+        start.wait(timeout=5)
+        pipeline.annotations_for(clip)
+        settled.wait(timeout=5)
+        notes = list(pipeline.skipped)
+        with guard:
+            seen[clip.name] = notes
+
+    threads = [threading.Thread(target=request, args=(clip,)) for clip in clips]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert len(seen) == len(clips), f"a request never reported: {seen}"
+    for name, notes in seen.items():
+        assert notes == [f"OCR engine missing for {name}"], (name, notes)


### PR DESCRIPTION
## Summary

The annotator's gate was dead, so two defects lived behind green checks. This PR
revives the gate first, then uses the revived gate to prove one of them from the
outside.

Three commits, one idea each:

1. `ci: run the annotator suite in the gate, and stop the gate reformatting the tree` (#649)
2. `fix(annotator): skip the face recognizer when its bank is missing` (#651)
3. `perf(annotator): build each recognizer once per pipeline, not once per request` (#650)

Closes #649. Closes #651. Closes #650.

## 1. Mechanism of #649

Two independent holes.

**The formatting step rewrote the tree instead of failing.** `check` depended on
`fmt`, and `fmt` runs `gofmt -w`. Measured on this branch point, with two files
made unformatted on purpose:

```
$ make fmt
gofmt -w $(find cmd internal tests -name '*.go')
=== make fmt exit: 0 (green) ===
 internal/x402/types.go | 2 ++
=== gofmt -l now silent: the drift was rewritten, not reported ===
```

On CI the rewrite lands on a throwaway checkout. The job goes green, the
committed tree stays unformatted, and main still needed a cleanup commit for
drift this gate had "passed". A check that mutates the tree cannot fail.

**The annotator suite was outside every gate a developer runs.** The dedicated
`annotator` CI job (#790) does run it, but `make check`, the documented local
merge-readiness gate and the PR checklist item, never reached it. The one way to
run it by hand was `make test-annotator`, and that installed into the ambient
interpreter:

```
$ make test-annotator
error: externally-managed-environment
...
hint: See PEP 668 for the detailed specification.
make: *** [test-annotator] Error 1
```

Every Homebrew and Debian python refuses that install, so the target existed and
could not be run at all.

**The fix.** `fmt-check` is a read-only gate. `make fmt` keeps the in-place
rewrite as a developer target, and no gate depends on it. `test-annotator` builds
`annotator/.venv-test` and installs there, so it is hermetic and PEP 668 proof,
and both `check` and `ci` now run it. The `checks` CI job gains a Python step,
because `make check` needs one. The dedicated `annotator` job stays: it reports
the suite on its own in under a minute instead of inside a five minute Go run.

### What a developer now sees instead

Unformatted code, before this PR: nothing. The files were rewritten and the gate
said nothing at all. After:

```
$ make fmt-check
gofmt: these files are not formatted:
  internal/x402/types.go
  internal/x402/facilitator.go
run 'make fmt' and commit the result
make: *** [fmt-check] Error 1
```

The files are left exactly as they were, so the state that failed is the state on
disk. The named fix is one command.

`fmt-check` also fails when `gofmt` itself cannot parse a file, rather than
reading an empty file list as "clean":

```
$ make fmt-check
internal/x402/types.go:333:17: expected ')', found '{'
make: *** [fmt-check] Error 1
```

## 2. Proof that the revived gate catches #651 on its own

This is the point of pairing the two issues, so it is one measurement, run on the
two gate definitions, with nothing else changed. The tree in both runs is
identical: the new `tests/test_face_bank.py` present, `faces.py` untouched.

**On the pre-#649 gate it passes.** The old `Makefile` was extracted to a
throwaway file and run as it stood:

```
$ git show HEAD~1:Makefile > Makefile-649-control
$ grep '^check:' Makefile-649-control
check: fmt vet lint cyclo ineffassign misspell test test-release-tools build
$ make -f Makefile-649-control check ; echo "OLD-GATE-EXIT=$?"
OLD-GATE-EXIT=0
```

Green. The log contains no occurrence of `pytest` or `annotator`, because that
gate never invoked either.

**On the revived gate it fails:**

```
$ make check ; echo "NEW-GATE-EXIT=$?"
...
FAILED tests/test_face_bank.py::test_a_missing_bank_is_unavailable_not_a_crash
FAILED tests/test_face_bank.py::test_a_bank_that_is_a_file_is_unavailable
FAILED tests/test_face_bank.py::test_an_unreadable_bank_is_unavailable
FAILED tests/test_face_bank.py::test_an_unreadable_player_directory_costs_only_that_player
FAILED tests/test_face_bank.py::test_the_pipeline_skips_a_missing_bank_and_keeps_running
FAILED tests/test_face_bank.py::test_the_bank_is_checked_before_the_embedder_is_built
6 failed, 291 passed in 9.85s
make: *** [test-annotator] Error 1
NEW-GATE-EXIT=2
```

Same tree, same tests, two gate definitions. The bug was reachable from a test
the whole time. Nothing was asserting the gate had been dead: the gate was
measured dead.

## 3. Mechanism of #651

`FaceRecognizer._enroll` called `bank_dir.iterdir()` with nothing around it:

```python
for player_dir in sorted(p for p in bank_dir.iterdir() if p.is_dir()):
```

A bank path that is not there raises `FileNotFoundError`, and
`Pipeline.try_recognizer` converts only `RecognizerUnavailable`. So one absent
optional asset failed the whole annotation request: the served backend answered
502 and the eval CLI exited with a traceback.

This is not a new rule, it is the existing one. The `pipeline` module docstring
states it: "ones whose backends are missing are skipped with a note, so the
cascade degrades instead of aborting". `base.RecognizerUnavailable` says the same
in its own docstring. A face bank is a backend asset exactly like a model wheel,
and the missing-insightface path already took the correct route. Only the bank
did not.

`_bank_player_dirs` converts the filesystem errors and nothing else. Absent, not
a directory, and unreadable each get their own actionable message naming the
asset and the configured path. `OSError` is the only converted class; anything
else is a bug in this package and still surfaces as one, which
`test_an_embedder_bug_still_raises` pins.

Two smaller changes ride along, both in the same "degrade by as little as
possible" direction. One unreadable player directory now costs only that player,
with a warning saying who was lost; the rest of the bank still enrolls. And the
bank is read before the embedder is built, so a bank that is not there no longer
pays to load five ONNX models first.

## 4. #650, measured

Every recognizer was constructed inside the per-request call, and `serve` keeps
one `Pipeline` for the life of the process. So every POST to `/recognize` loaded
the InsightFace ONNX sessions, loaded the YOLO weights and re-embedded the whole
face bank before it read a frame of media.

Measured for real: `insightface` + `onnxruntime` + `opencv-python-headless`
installed, buffalo_l downloaded, a bank of 4 players x 10 real face images = 40
images, and `iter_frames` stubbed to yield nothing so the number is construction
only. Two `cues_for` calls, which is what two POSTs do.

| | request 1 | request 2 |
|---|---|---|
| before | 48.406 s | 46.326 s |
| after | 42.972 s | 0.000025 s |

Request 2 is the measurement that matters: it paid the full cost again, and now it
pays none of it. Request 1 does the same work in both versions and varies from run
to run, between 43 s and 48 s on this host. Composition of that cost:

```
default_embedder() load+prepare: 0.499 s
one bank image embed:            0.991 s
40-image bank enrollment:       39.645 s
```

So the bank dominates, and it grows with the bank. A 200 image bank on this host
is about four minutes of re-enrollment per request. On a GPU host the repository
already measures buffalo_l at 0.154 s/frame against 1.340 s/frame on CPU
(`faces.select_face_providers`), so the same defect costs roughly 6 s per request
there: smaller, still per request, still unbounded in the bank size.

The correctness edge is the other half. Re-enrolling per request re-read the bank
at an arbitrary moment, so a bank edited during a run reached some requests and
not others, with nothing recording which. The gallery a process serves from is
now the one it enrolled.

### Design

`Pipeline._shared` keeps one slot per recognizer name, keyed by the settings that
decide what gets built. A key change replaces the slot, so an operator who
repoints `faces_bank` or changes `fps` still gets a recognizer built from the new
setting, and a remembered unavailability belongs to one configuration rather than
to the process. An unavailable backend is probed once, and its reason is replayed
on every request, so a caller reading `skipped` sees the same answer each time.

Sharing an instance needs a stated thread contract, because these recognizers are
not reentrant:

* `NewsOverlayRecognizer.recognize` clears and refills per-role reader state on
  itself for each run, so two runs at once interleave their sightings.
* the default jersey detector is an ultralytics model, which the code already
  documents as not thread safe (`jersey._Detectors`).
* insightface hangs per-call state off its app object.

So `_Shared` gives each recognizer one lock: two requests queue instead of
corrupting each other. Queueing rather than one instance per thread is the
deliberate choice, because a per-thread instance would duplicate the model
allocations instead of removing them, which is the other half of what #650 asks
for. Requests still share the frame extraction cache in `recognizers.base`, so
the second request does not re-decode the media either. Construction holds the
build lock, so two concurrent first requests cannot both load the models.

`skipped` also becomes a read-only property over thread-local state. It was a
plain attribute, and a plain attribute fails two ways under the threaded server:
appending into one list merges the notes, and rebinding it per call still lets the
last request to finish replace an answer a previous caller has not read yet. No
list is interleaved and the caller still gets somebody else's notes. A request now
reads only its own. Found by CodeRabbit on the first version of this PR, which had
only the local list.

## 5. Tests that fail before and pass after

Both new files were run against their parent commit first.

`tests/test_face_bank.py`, 9 tests, 6 fail on the parent (output in section 2).
Missing path, non-directory path, unreadable bank, unreadable player directory,
the pipeline-level skip, and the fail-fast ordering. The pipeline-level one also
puts a second recognizer in the cascade and asserts its cue survives, which is
what "partial annotations plus a clear skip reason" means. The other three are
the happy path, the empty-bank case and the "a bug is still a bug" guard, which
pass on both sides by design.

`tests/test_recognizer_cache.py`, 6 tests, all 6 fail on the parent:

```
FAILED test_two_requests_build_each_recognizer_once
FAILED test_two_served_requests_build_each_recognizer_once
FAILED test_an_unavailable_recognizer_is_built_once_and_reported_every_time
FAILED test_reconfiguration_is_not_hidden_by_the_cache
FAILED test_concurrent_requests_never_enter_one_recognizer_at_once
FAILED test_concurrent_requests_keep_their_own_skip_notes
6 failed in 0.64s
```

`test_two_served_requests_build_each_recognizer_once` is the issue's own
acceptance criterion: two real HTTP POSTs to a live `ThreadingHTTPServer`, then
one construction per recognizer.
`test_concurrent_requests_never_enter_one_recognizer_at_once` failed with
`worst == 2`, which is the shared-model hazard the lock removes.
`test_concurrent_requests_keep_their_own_skip_notes` gives each request a reason
that names its own media and holds every request at a barrier before any of them
reads, so the replacement is deterministic rather than a matter of timing:

```
AssertionError: ('clip-3.mp4', ['OCR engine missing for clip-1.mp4'])
```

## 6. Effect on CI

* `checks`: same command, `make check`. It gains a Python step, and the command
  now covers the annotator suite and refuses unformatted Go instead of
  reformatting it.
* `annotator`: unchanged command, `make test-annotator`. It now runs in a venv
  the target owns. Green on this branch.
* every other job: untouched. No Go product code changes in this PR.

## 7. What I chose not to do

* **The play-by-play recognizer is still built per request.** #650 names the
  scorebug, jersey and face recognizers, and those are the ones that load models.
  Play-by-play is keyed per media file and its construction re-reads or re-fetches
  the GUMBO feed, so caching it correctly is a per-media cache with its own
  eviction question. That is a separate change with a separate risk, and this PR
  does not guess at it. The per-request feed read is worth its own issue.
* **No parallel inference inside one recognizer.** Concurrent requests now queue
  per recognizer. Going faster than that means making the backends reentrant or
  pooling instances, both of which trade memory for latency in a way an operator
  should choose. The contract is documented rather than tuned.
* **`make check` now duplicates the annotator suite in CI**, because the
  dedicated job keeps running it too. That is about 30 seconds, and it buys an
  isolated red check for the annotator. I did not add a skip switch, because a
  switch on a gate is how the gate died the first time.

## Verification

```bash
make check                  # green, exit 0
make test-annotator         # 303 passed
```

## 8. Review findings addressed

CodeRabbit raised two, both valid, both fixed in the commit that introduced the
code:

1. **Major, `pipeline.py`**: skip notes were still on a shared attribute, so a
   second request could replace them before the first caller read them. `skipped`
   is now a read-only property over thread-local state, and the concurrency test
   was rewritten to detect the replacement deterministically. Section 4 and
   section 5 have the detail.
2. **Minor, `annotator/README.md`**: the manual pytest instructions installed
   `[test]` only, while `make test-annotator` installs `[test,ocr]` so the vision
   recognizers' tests run rather than skip (#787). The manual path now matches.

## Checklist

- [x] `coderabbit review` run and findings addressed
- [x] `make check` passes locally
- [x] New/changed behaviour has test coverage that fails without the change
- [x] `README.md`, `CLAUDE.md` and the annotator README remain truthful
- [x] No unrelated files changed
